### PR TITLE
logout binding to clear whisper identities

### DIFF
--- a/src/gethdep.go
+++ b/src/gethdep.go
@@ -79,6 +79,22 @@ func unlockAccount(address, password string, seconds int) error {
 
 }
 
+// logout clears whisper identities
+func logout() error {
+
+	if currentNode != nil {
+		whisperInstance := (*accountSync)[0].(*whisper.Whisper)
+		err := whisperInstance.ClearIdentities()
+		if err != nil {
+			return errextra.Wrap(err, "Could not call clear identities whipser func")
+		}
+		return nil
+	}
+
+	return errors.New("No running node detected for logout")
+
+}
+
 // createAndStartNode creates a node entity and starts the
 // node running locally
 func createAndStartNode(inputDir string) error {

--- a/src/library.go
+++ b/src/library.go
@@ -40,6 +40,26 @@ func Login(address, password *C.char) *C.char {
 	return out
 }
 
+//export Logout
+func Logout() *C.char {
+
+	// This is equivalent to clearing whisper identities
+	err := logout()
+
+	errString := emptyError
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		errString = err.Error()
+	}
+
+	out := JSONError{
+		Error: errString,
+	}
+	outBytes, _ := json.Marshal(&out)
+
+	return C.CString(string(outBytes))
+}
+
 //export UnlockAccount
 func UnlockAccount(address, password *C.char, seconds int) *C.char {
 

--- a/src/vendor/github.com/ethereum/go-ethereum/whisper/whisper.go
+++ b/src/vendor/github.com/ethereum/go-ethereum/whisper/whisper.go
@@ -160,6 +160,15 @@ func (self *Whisper) InjectIdentity(key *ecdsa.PrivateKey) error {
 	return nil
 }
 
+// ClearIdentities clears the current whisper identities in memory
+func (self *Whisper) ClearIdentities() error {
+	self.keys = make(map[string]*ecdsa.PrivateKey)
+	if len(self.keys) != 0 {
+		return fmt.Errorf("could not clear keys map")
+	}
+	return nil
+}
+
 // Watch installs a new message handler to run in case a matching packet arrives
 // from the whisper network.
 func (self *Whisper) Watch(options Filter) int {


### PR DESCRIPTION
This adds a binding for logout functionality.  The functionality clears whisper identities on logout.

Note, there seems to be an unrelated error on `go install` related to the jail stuff that was merged in:

```
dwhitena@dirac:src$ go install
# github.com/status-im/statusgo/src
./library.c:3:17: fatal error: jni.h: No such file or directory
compilation terminated.
```
