### PR TITLE
HD Keys: sub-accounts support added

### DIFF
--- a/src/gethdep_test.go
+++ b/src/gethdep_test.go
@@ -35,6 +35,87 @@ const (
 	whisperMessage5 = "test message 5 (K2 -> K1)"
 )
 
+func TestCreateChildAccount(t *testing.T) {
+	err := prepareTestNode()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// create an account
+	address, pubKey, mnemonic, err := createAccount(newAccountPassword)
+	if err != nil {
+		t.Errorf("could not create account: %v", err)
+		return
+	}
+	glog.V(logger.Info).Infof("Account created: {address: %s, key: %s, mnemonic:%s}", address, pubKey, mnemonic)
+
+	account, err := utils.MakeAddress(accountManager, address)
+	if err != nil {
+		t.Errorf("can not get account from address: %v", err)
+		return
+	}
+
+	// obtain decrypted key, and make sure that extended key (which will be used as root for sub-accounts) is present
+	account, key, err := accountManager.AccountDecryptedKey(account, newAccountPassword)
+	if err != nil {
+		t.Errorf("can not obtain decrypted account key: %v", err)
+		return
+	}
+
+	if key.ExtendedKey == nil {
+		t.Error("CKD#2 has not been generated for new account")
+		return
+	}
+
+	// try creating sub-account, w/o selecting main account i.e. w/o login to main account
+	_, _, err = createChildAccount("", newAccountPassword)
+	if !reflect.DeepEqual(err, ErrNoAccountSelected) {
+		t.Errorf("expected error is not returned (tried to create sub-account w/o login): %v", err)
+		return
+	}
+
+	err = selectAccount(address, newAccountPassword)
+	if err != nil {
+		t.Errorf("Test failed: could not select account: %v", err)
+		return
+	}
+
+	// try to create sub-account with wrong password
+	_, _, err = createChildAccount("", "wrong password")
+	if !reflect.DeepEqual(err, errors.New("cannot retreive a valid key for a given account: could not decrypt key with given passphrase")) {
+		t.Errorf("expected error is not returned (tried to create sub-account with wrong password): %v", err)
+		return
+	}
+
+	// create sub-account (from implicit parent)
+	subAccount1, subPubKey1, err := createChildAccount("", newAccountPassword)
+	if err != nil {
+		t.Errorf("cannot create sub-account: %v", err)
+		return
+	}
+
+	// make sure that sub-account index automatically progresses
+	subAccount2, subPubKey2, err := createChildAccount("", newAccountPassword)
+	if err != nil {
+		t.Errorf("cannot create sub-account: %v", err)
+	}
+	if subAccount1 == subAccount2 || subPubKey1 == subPubKey2 {
+		t.Error("sub-account index auto-increament failed")
+		return
+	}
+
+	// create sub-account (from explicit parent)
+	subAccount3, subPubKey3, err := createChildAccount(subAccount2, newAccountPassword)
+	if err != nil {
+		t.Errorf("cannot create sub-account: %v", err)
+	}
+	if subAccount1 == subAccount3 || subPubKey1 == subPubKey3 || subAccount2 == subAccount3 || subPubKey2 == subPubKey3 {
+		t.Error("sub-account index auto-increament failed")
+		return
+	}
+}
+
 func TestRecoverAccount(t *testing.T) {
 	err := prepareTestNode()
 	if err != nil {
@@ -57,7 +138,72 @@ func TestRecoverAccount(t *testing.T) {
 		return
 	}
 	if address != addressCheck || pubKey != pubKeyCheck {
-		t.Error("Test failed: recover account details failed to pull the correct details")
+		t.Error("recover account details failed to pull the correct details")
+	}
+
+	// now test recovering, but make sure that account/key file is removed i.e. simulate recovering on a new device
+	account, err := utils.MakeAddress(accountManager, address)
+	if err != nil {
+		t.Errorf("can not get account from address: %v", err)
+	}
+
+	account, key, err := accountManager.AccountDecryptedKey(account, newAccountPassword)
+	if err != nil {
+		t.Errorf("can not obtain decrypted account key: %v", err)
+		return
+	}
+	extChild2String := key.ExtendedKey.String()
+
+	if err := accountManager.DeleteAccount(account, newAccountPassword); err != nil {
+		t.Errorf("cannot remove account: %v", err)
+	}
+
+	addressCheck, pubKeyCheck, err = recoverAccount(newAccountPassword, mnemonic)
+	if err != nil {
+		t.Errorf("recover account failed (for non-cached account): %v", err)
+		return
+	}
+	if address != addressCheck || pubKey != pubKeyCheck {
+		t.Error("recover account details failed to pull the correct details (for non-cached account)")
+	}
+
+	// make sure that extended key exists and is imported ok too
+	account, key, err = accountManager.AccountDecryptedKey(account, newAccountPassword)
+	if err != nil {
+		t.Errorf("can not obtain decrypted account key: %v", err)
+		return
+	}
+	if extChild2String != key.ExtendedKey.String() {
+		t.Errorf("CKD#2 key mismatch, expected: %s, got: %s", extChild2String, key.ExtendedKey.String())
+	}
+
+	// make sure that calling import several times, just returns from cache (no error is expected)
+	addressCheck, pubKeyCheck, err = recoverAccount(newAccountPassword, mnemonic)
+	if err != nil {
+		t.Errorf("recover account failed (for non-cached account): %v", err)
+		return
+	}
+	if address != addressCheck || pubKey != pubKeyCheck {
+		t.Error("recover account details failed to pull the correct details (for non-cached account)")
+	}
+
+	// time to login with recovered data
+	var whisperInstance *whisper.Whisper
+	if err := currentNode.Service(&whisperInstance); err != nil {
+		t.Errorf("whisper service not running: %v", err)
+	}
+
+	// make sure that identity is not (yet injected)
+	if whisperInstance.HasIdentity(crypto.ToECDSAPub(common.FromHex(pubKeyCheck))) {
+		t.Errorf("identity already present in whisper")
+	}
+	err = selectAccount(addressCheck, newAccountPassword)
+	if err != nil {
+		t.Errorf("Test failed: could not select account: %v", err)
+		return
+	}
+	if !whisperInstance.HasIdentity(crypto.ToECDSAPub(common.FromHex(pubKeyCheck))) {
+		t.Errorf("identity not injected into whisper: %v", err)
 	}
 }
 
@@ -75,11 +221,10 @@ func TestAccountSelect(t *testing.T) {
 		t.Errorf("whisper service not running: %v", err)
 	}
 
-	// create an accounts
+	// create an account
 	address1, pubKey1, _, err := createAccount(newAccountPassword)
 	if err != nil {
-		fmt.Println(err.Error())
-		t.Error("Test failed: could not create account")
+		t.Errorf("could not create account: %v", err)
 		return
 	}
 	glog.V(logger.Info).Infof("Account created: {address: %s, key: %s}", address1, pubKey1)
@@ -92,7 +237,7 @@ func TestAccountSelect(t *testing.T) {
 	}
 	glog.V(logger.Info).Infof("Account created: {address: %s, key: %s}", address2, pubKey2)
 
-	// inject key of newly created account into Whisper, as identity
+	// make sure that identity is not (yet injected)
 	if whisperInstance.HasIdentity(crypto.ToECDSAPub(common.FromHex(pubKey1))) {
 		t.Errorf("identity already present in whisper")
 	}

--- a/src/library.go
+++ b/src/library.go
@@ -34,6 +34,27 @@ func CreateAccount(password *C.char) *C.char {
 	return C.CString(string(outBytes))
 }
 
+//export CreateChildAccount
+func CreateChildAccount(parentAddress, password *C.char) *C.char {
+
+	address, pubKey, err := createChildAccount(C.GoString(parentAddress), C.GoString(password))
+
+	errString := emptyError
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		errString = err.Error()
+	}
+
+	out := AccountInfo{
+		Address: address,
+		PubKey:  pubKey,
+		Error:   errString,
+	}
+	outBytes, _ := json.Marshal(&out)
+
+	return C.CString(string(outBytes))
+}
+
 //export RecoverAccount
 func RecoverAccount(password, mnemonic *C.char) *C.char {
 

--- a/src/main.go
+++ b/src/main.go
@@ -35,19 +35,20 @@ const (
 )
 
 var (
-	vString        string                    // Combined textual representation of the version
-	rConfig        release.Config            // Structured version information and release oracle config
-	currentNode    *node.Node                // currently running geth node
-	c              *cli.Context              // the CLI context used to start the geth node
-	accountSync    *[]node.Service           // the object used to sync accounts between geth services
-	lightEthereum  *les.LightEthereum        // LES service
-	accountManager *accounts.Manager         // the account manager attached to the currentNode
-	whisperService *whisper.Whisper          // whisper service
-	datadir        string                    // data directory for geth
-	rpcport        int                = 8545 // RPC port (replaced in unit tests)
-	client         rpc.Client
-	gitCommit      = "rely on linker: -ldflags -X main.GitCommit"
-	buildStamp     = "rely on linker: -ldflags -X main.buildStamp"
+	vString         string                    // Combined textual representation of the version
+	rConfig         release.Config            // Structured version information and release oracle config
+	currentNode     *node.Node                // currently running geth node
+	c               *cli.Context              // the CLI context used to start the geth node
+	accountSync     *[]node.Service           // the object used to sync accounts between geth services
+	lightEthereum   *les.LightEthereum        // LES service
+	accountManager  *accounts.Manager         // the account manager attached to the currentNode
+	selectedAddress string                    // address of the account that was processed during the last call to SelectAccount()
+	whisperService  *whisper.Whisper          // whisper service
+	datadir         string                    // data directory for geth
+	rpcport         int                = 8545 // RPC port (replaced in unit tests)
+	client          rpc.Client
+	gitCommit       = "rely on linker: -ldflags -X main.GitCommit"
+	buildStamp      = "rely on linker: -ldflags -X main.buildStamp"
 )
 
 var (

--- a/src/vendor/github.com/ethereum/go-ethereum/accounts/key.go
+++ b/src/vendor/github.com/ethereum/go-ethereum/accounts/key.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/pborman/uuid"
+	"github.com/status-im/status-go/src/extkeys"
 )
 
 const (
@@ -49,6 +50,10 @@ type Key struct {
 	// if whisper is enabled here, the address will be used as a whisper
 	// identity upon creation of the account or unlocking of the account
 	WhisperEnabled bool
+	// extended key is the root node for new hardened children i.e. sub-accounts
+	ExtendedKey *extkeys.ExtendedKey
+	// next index to be used for sub-account child derivation
+	SubAccountIndex uint32
 }
 
 type keyStore interface {
@@ -68,11 +73,13 @@ type plainKeyJSON struct {
 }
 
 type encryptedKeyJSONV3 struct {
-	Address        string     `json:"address"`
-	Crypto         cryptoJSON `json:"crypto"`
-	Id             string     `json:"id"`
-	Version        int        `json:"version"`
-	WhisperEnabled bool       `json:"whisperenabled"`
+	Address         string     `json:"address"`
+	Crypto          cryptoJSON `json:"crypto"`
+	Id              string     `json:"id"`
+	Version         int        `json:"version"`
+	WhisperEnabled  bool       `json:"whisperenabled"`
+	ExtendedKey     cryptoJSON `json:"extendedkey"`
+	SubAccountIndex uint32     `json:"subaccountindex"`
 }
 
 type encryptedKeyJSONV1 struct {
@@ -148,6 +155,41 @@ func newKeyFromECDSA(privateKeyECDSA *ecdsa.PrivateKey) *Key {
 		PrivateKey: privateKeyECDSA,
 	}
 	return key
+}
+
+func newKeyFromExtendedKey(extKey *extkeys.ExtendedKey) (*Key, error) {
+	var (
+		extChild1, extChild2 *extkeys.ExtendedKey
+		err                  error
+	)
+
+	if extKey.Depth == 0 { // we are dealing with master key
+		// CKD#1 - main account
+		extChild1, err = extKey.BIP44Child(extkeys.CoinTypeETH, 0)
+		if err != nil {
+			return &Key{}, err
+		}
+
+		// CKD#2 - sub-accounts root
+		extChild2, err = extKey.BIP44Child(extkeys.CoinTypeETH, 1)
+		if err != nil {
+			return &Key{}, err
+		}
+	} else { // we are dealing with non-master key, so it is safe to persist and extend from it
+		extChild1 = extKey
+		extChild2 = extKey
+	}
+
+	privateKeyECDSA := extChild1.ToECDSA()
+	id := uuid.NewRandom()
+	key := &Key{
+		Id:             id,
+		Address:        crypto.PubkeyToAddress(privateKeyECDSA.PublicKey),
+		PrivateKey:     privateKeyECDSA,
+		WhisperEnabled: true,
+		ExtendedKey:    extChild2,
+	}
+	return key, nil
 }
 
 // NewKeyForDirectICAP generates a key whose address fits into < 155 bits so it can fit

--- a/src/vendor/github.com/ethereum/go-ethereum/accounts/key_store_passphrase.go
+++ b/src/vendor/github.com/ethereum/go-ethereum/accounts/key_store_passphrase.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/randentropy"
 	"github.com/pborman/uuid"
+	"github.com/status-im/status-go/src/extkeys"
 	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/crypto/scrypt"
 )
@@ -135,14 +136,61 @@ func EncryptKey(key *Key, auth string, scryptN, scryptP int) ([]byte, error) {
 		KDFParams:    scryptParamsJSON,
 		MAC:          hex.EncodeToString(mac),
 	}
+	encryptedExtendedKey, err := EncryptExtendedKey(key.ExtendedKey, auth, scryptN, scryptP)
+	if err != nil {
+		return nil, err
+	}
 	encryptedKeyJSONV3 := encryptedKeyJSONV3{
 		hex.EncodeToString(key.Address[:]),
 		cryptoStruct,
 		key.Id.String(),
 		version,
 		key.WhisperEnabled,
+		encryptedExtendedKey,
+		key.SubAccountIndex,
 	}
 	return json.Marshal(encryptedKeyJSONV3)
+}
+
+func EncryptExtendedKey(extKey *extkeys.ExtendedKey, auth string, scryptN, scryptP int) (cryptoJSON, error) {
+	if extKey == nil {
+		return cryptoJSON{}, nil
+	}
+	authArray := []byte(auth)
+	salt := randentropy.GetEntropyCSPRNG(32)
+	derivedKey, err := scrypt.Key(authArray, salt, scryptN, scryptR, scryptP, scryptDKLen)
+	if err != nil {
+		return cryptoJSON{}, err
+	}
+	encryptKey := derivedKey[:16]
+	keyBytes := []byte(extKey.String())
+
+	iv := randentropy.GetEntropyCSPRNG(aes.BlockSize) // 16
+	cipherText, err := aesCTRXOR(encryptKey, keyBytes, iv)
+	if err != nil {
+		return cryptoJSON{}, err
+	}
+	mac := crypto.Keccak256(derivedKey[16:32], cipherText)
+
+	scryptParamsJSON := make(map[string]interface{}, 5)
+	scryptParamsJSON["n"] = scryptN
+	scryptParamsJSON["r"] = scryptR
+	scryptParamsJSON["p"] = scryptP
+	scryptParamsJSON["dklen"] = scryptDKLen
+	scryptParamsJSON["salt"] = hex.EncodeToString(salt)
+
+	cipherParamsJSON := cipherparamsJSON{
+		IV: hex.EncodeToString(iv),
+	}
+
+	return cryptoJSON{
+		Cipher:       "aes-128-ctr",
+		CipherText:   hex.EncodeToString(cipherText),
+		CipherParams: cipherParamsJSON,
+		KDF:          "scrypt",
+		KDFParams:    scryptParamsJSON,
+		MAC:          hex.EncodeToString(mac),
+	}, nil
 }
 
 // DecryptKey decrypts a key from a json blob, returning the private key itself.
@@ -156,19 +204,41 @@ func DecryptKey(keyjson []byte, auth string) (*Key, error) {
 	var (
 		keyBytes, keyId []byte
 		err             error
+		extKeyBytes     []byte
+		extKey          *extkeys.ExtendedKey
 	)
+
+	subAccountIndex, ok := m["subaccountindex"].(float64)
+	if !ok {
+		subAccountIndex = 0
+	}
+
 	if version, ok := m["version"].(string); ok && version == "1" {
 		k := new(encryptedKeyJSONV1)
 		if err := json.Unmarshal(keyjson, k); err != nil {
 			return nil, err
 		}
 		keyBytes, keyId, err = decryptKeyV1(k, auth)
+		if err != nil {
+			return nil, err
+		}
+
+		extKey, err = extkeys.NewKeyFromString(extkeys.EmptyExtendedKeyString)
 	} else {
 		k := new(encryptedKeyJSONV3)
 		if err := json.Unmarshal(keyjson, k); err != nil {
 			return nil, err
 		}
 		keyBytes, keyId, err = decryptKeyV3(k, auth)
+		if err != nil {
+			return nil, err
+		}
+
+		extKeyBytes, err = decryptExtendedKey(k, auth)
+		if err != nil {
+			return nil, err
+		}
+		extKey, err = extkeys.NewKeyFromString(string(extKeyBytes))
 	}
 	// Handle any decryption errors and return the key
 	if err != nil {
@@ -176,10 +246,12 @@ func DecryptKey(keyjson []byte, auth string) (*Key, error) {
 	}
 	key := crypto.ToECDSA(keyBytes)
 	return &Key{
-		Id:             uuid.UUID(keyId),
-		Address:        crypto.PubkeyToAddress(key.PublicKey),
-		PrivateKey:     key,
-		WhisperEnabled: m["whisperenabled"].(bool),
+		Id:              uuid.UUID(keyId),
+		Address:         crypto.PubkeyToAddress(key.PublicKey),
+		PrivateKey:      key,
+		WhisperEnabled:  m["whisperenabled"].(bool),
+		ExtendedKey:     extKey,
+		SubAccountIndex: uint32(subAccountIndex),
 	}, nil
 }
 
@@ -257,6 +329,51 @@ func decryptKeyV1(keyProtected *encryptedKeyJSONV1, auth string) (keyBytes []byt
 		return nil, nil, err
 	}
 	return plainText, keyId, err
+}
+
+func decryptExtendedKey(keyProtected *encryptedKeyJSONV3, auth string) (plainText []byte, err error) {
+	if len(keyProtected.ExtendedKey.CipherText) == 0 {
+		return []byte(extkeys.EmptyExtendedKeyString), nil
+	}
+
+	if keyProtected.Version != version {
+		return nil, fmt.Errorf("Version not supported: %v", keyProtected.Version)
+	}
+
+	if keyProtected.ExtendedKey.Cipher != "aes-128-ctr" {
+		return nil, fmt.Errorf("Cipher not supported: %v", keyProtected.ExtendedKey.Cipher)
+	}
+
+	mac, err := hex.DecodeString(keyProtected.ExtendedKey.MAC)
+	if err != nil {
+		return nil, err
+	}
+
+	iv, err := hex.DecodeString(keyProtected.ExtendedKey.CipherParams.IV)
+	if err != nil {
+		return nil, err
+	}
+
+	cipherText, err := hex.DecodeString(keyProtected.ExtendedKey.CipherText)
+	if err != nil {
+		return nil, err
+	}
+
+	derivedKey, err := getKDFKey(keyProtected.ExtendedKey, auth)
+	if err != nil {
+		return nil, err
+	}
+
+	calculatedMAC := crypto.Keccak256(derivedKey[16:32], cipherText)
+	if !bytes.Equal(calculatedMAC, mac) {
+		return nil, ErrDecrypt
+	}
+
+	plainText, err = aesCTRXOR(derivedKey[:16], cipherText, iv)
+	if err != nil {
+		return nil, err
+	}
+	return plainText, err
 }
 
 func getKDFKey(cryptoJSON cryptoJSON, auth string) ([]byte, error) {


### PR DESCRIPTION
Closes #27 
- `createAccount()` refactored (now method is much more concise, as it relies on `importExtendedKey`)
- `importExtendedKey()` has been introduced, which is a wrapper around also newly introduced [account_manager.ImportExtendedKey](https://github.com/farazdagi/status-go/blob/feature/hd-child-derivation/src/vendor/github.com/ethereum/go-ethereum/accounts/account_manager.go#L354) method (see https://github.com/status-im/go-ethereum/pull/26 for details)
- `createChildAccount(parentAddress, password)` has been added (see [Bindings doc in Wiki](https://github.com/status-im/status-go/wiki/Notes-on-Bindings#sub-account-creation) for full details):
  - if `parentAddress` is `""` (empty string), `CKD#2` of the last logged in account is used as derivation root
  - if `parentAddress` is some arbitrary extended key, then system derives child right from the given parent (this is only possible for second level children, first level children **which are sub-accounts** should be derived with empty parent address i.e. `Login(mainAccountAddress, "passphrase")` into main account and then derive sub-account using `CreateChildAccount("", "passphrase")
- `recoverAccount()` refactored (it relies on `importExtendedKey` method as well)
- see `go-ethereum` PR for details on changes introduced on that side: https://github.com/status-im/go-ethereum/pull/26
