### PR TITLE
Updates eth.accounts and personal.listAccounts to rely on HD keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 # used by the Makefile
 /build/_workspace/
 /build/bin/
+/vendor/github.com/karalabe/xgo
 
 # travis
 profile.tmp

--- a/geth/accounts.go
+++ b/geth/accounts.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -21,7 +22,7 @@ var (
 	ErrInvalidMasterKeyCreated         = errors.New("can not create master extended key")
 )
 
-// createAccount creates an internal geth account
+// CreateAccount creates an internal geth account
 // BIP44-compatible keys are generated: CKD#1 is stored as account key, CKD#2 stored as sub-account root
 // Public key of CKD#1 is returned, with CKD#2 securely encoded into account key file (to be used for
 // sub-account derivations)
@@ -48,7 +49,7 @@ func CreateAccount(password string) (address, pubKey, mnemonic string, err error
 	return address, pubKey, mnemonic, nil
 }
 
-// createChildAccount creates sub-account for an account identified by parent address.
+// CreateChildAccount creates sub-account for an account identified by parent address.
 // CKD#2 is used as root for master accounts (when parentAddress is "").
 // Otherwise (when parentAddress != ""), child is derived directly from parent.
 func CreateChildAccount(parentAddress, password string) (address, pubKey string, err error) {
@@ -58,20 +59,20 @@ func CreateChildAccount(parentAddress, password string) (address, pubKey string,
 		return "", "", err
 	}
 
-	if parentAddress == "" { // by default derive from currently selected account
-		parentAddress = nodeManager.SelectedAddress
+	if parentAddress == "" && nodeManager.SelectedAccount != nil { // derive from selected account by default
+		parentAddress = string(nodeManager.SelectedAccount.Address.Hex())
 	}
 
 	if parentAddress == "" {
 		return "", "", ErrNoAccountSelected
 	}
 
-	// make sure that given password can decrypt key associated with a given parent address
 	account, err := utils.MakeAddress(accountManager, parentAddress)
 	if err != nil {
 		return "", "", ErrAddressToAccountMappingFailure
 	}
 
+	// make sure that given password can decrypt key associated with a given parent address
 	account, accountKey, err := accountManager.AccountDecryptedKey(account, password)
 	if err != nil {
 		return "", "", fmt.Errorf("%s: %v", ErrAccountToKeyMappingFailure.Error(), err)
@@ -88,6 +89,7 @@ func CreateChildAccount(parentAddress, password string) (address, pubKey string,
 		return "", "", err
 	}
 	accountManager.IncSubAccountIndex(account, password)
+	accountKey.SubAccountIndex++
 
 	// import derived key into account keystore
 	address, pubKey, err = importExtendedKey(childKey, password)
@@ -95,10 +97,15 @@ func CreateChildAccount(parentAddress, password string) (address, pubKey string,
 		return
 	}
 
+	// update in-memory selected account
+	if nodeManager.SelectedAccount != nil {
+		nodeManager.SelectedAccount.AccountKey = accountKey
+	}
+
 	return address, pubKey, nil
 }
 
-// recoverAccount re-creates master key using given details.
+// RecoverAccount re-creates master key using given details.
 // Once master key is re-generated, it is inserted into keystore (if not already there).
 func RecoverAccount(password, mnemonic string) (address, pubKey string, err error) {
 	// re-create extended key (see BIP32)
@@ -117,7 +124,7 @@ func RecoverAccount(password, mnemonic string) (address, pubKey string, err erro
 	return address, pubKey, nil
 }
 
-// selectAccount selects current account, by verifying that address has corresponding account which can be decrypted
+// SelectAccount selects current account, by verifying that address has corresponding account which can be decrypted
 // using provided password. Once verification is done, decrypted key is injected into Whisper (as a single identity,
 // all previous identities are removed).
 func SelectAccount(address, password string) error {
@@ -146,13 +153,21 @@ func SelectAccount(address, password string) error {
 		return ErrWhisperIdentityInjectionFailure
 	}
 
-	// persist address for easier recovery of currently selected key (from Whisper)
-	nodeManager.SelectedAddress = address
+	// persist account key for easier recovery of currently selected key
+	subAccounts, err := findSubAccounts(accountKey.ExtendedKey, accountKey.SubAccountIndex)
+	if err != nil {
+		return err
+	}
+	nodeManager.SelectedAccount = &SelectedExtKey{
+		Address:     account.Address,
+		AccountKey:  accountKey,
+		SubAccounts: subAccounts,
+	}
 
 	return nil
 }
 
-// logout clears whisper identities
+// Logout clears whisper identities
 func Logout() error {
 	nodeManager := GetNodeManager()
 	whisperService, err := nodeManager.WhisperService()
@@ -165,12 +180,12 @@ func Logout() error {
 		return fmt.Errorf("%s: %v", ErrWhisperClearIdentitiesFailure, err)
 	}
 
-	nodeManager.SelectedAddress = ""
+	nodeManager.SelectedAccount = nil
 
 	return nil
 }
 
-// unlockAccount unlocks an existing account for a certain duration and
+// UnlockAccount unlocks an existing account for a certain duration and
 // inject the account as a whisper identity if the account was created as
 // a whisper enabled account
 func UnlockAccount(address, password string, seconds int) error {
@@ -200,4 +215,91 @@ func importExtendedKey(extKey *extkeys.ExtendedKey, password string) (address, p
 	pubKey = common.ToHex(crypto.FromECDSAPub(&key.PrivateKey.PublicKey))
 
 	return
+}
+
+func onAccountsListRequest(entities []accounts.Account) []accounts.Account {
+	nodeManager := GetNodeManager()
+
+	if nodeManager.SelectedAccount == nil {
+		return []accounts.Account{}
+	}
+
+	refreshSelectedAccount()
+
+	filtered := make([]accounts.Account, 0)
+	for _, account := range entities {
+		// main account
+		if nodeManager.SelectedAccount.Address.Hex() == account.Address.Hex() {
+			filtered = append(filtered, account)
+		} else {
+			// sub accounts
+			for _, subAccount := range nodeManager.SelectedAccount.SubAccounts {
+				if subAccount.Address.Hex() == account.Address.Hex() {
+					filtered = append(filtered, account)
+				}
+			}
+		}
+	}
+
+	return filtered
+}
+
+// refreshSelectedAccount re-populates list of sub-accounts of the currently selected account (if any)
+func refreshSelectedAccount() {
+	nodeManager := GetNodeManager()
+
+	if nodeManager.SelectedAccount == nil {
+		return
+	}
+
+	accountKey := nodeManager.SelectedAccount.AccountKey
+	if accountKey == nil {
+		return
+	}
+
+	// re-populate list of sub-accounts
+	subAccounts, err := findSubAccounts(accountKey.ExtendedKey, accountKey.SubAccountIndex)
+	if err != nil {
+		return
+	}
+	nodeManager.SelectedAccount = &SelectedExtKey{
+		Address:     nodeManager.SelectedAccount.Address,
+		AccountKey:  nodeManager.SelectedAccount.AccountKey,
+		SubAccounts: subAccounts,
+	}
+}
+
+// findSubAccounts traverses cached accounts and adds as a sub-accounts any
+// that belong to the currently selected account.
+// The extKey is CKD#2 := root of sub-accounts of the main account
+func findSubAccounts(extKey *extkeys.ExtendedKey, subAccountIndex uint32) ([]accounts.Account, error) {
+	nodeManager := GetNodeManager()
+	accountManager, err := nodeManager.AccountManager()
+	if err != nil {
+		return []accounts.Account{}, err
+	}
+
+	subAccounts := make([]accounts.Account, 0)
+	if extKey.Depth == 5 { // CKD#2 level
+		// gather possible sub-account addresses
+		subAccountAddresses := make([]common.Address, 0)
+		for i := uint32(0); i < subAccountIndex; i++ {
+			childKey, err := extKey.Child(i)
+			if err != nil {
+				return []accounts.Account{}, err
+			}
+			subAccountAddresses = append(subAccountAddresses, crypto.PubkeyToAddress(childKey.ToECDSA().PublicKey))
+		}
+
+		// see if any of the gathered addresses actually exist in cached accounts list
+		for _, cachedAccount := range accountManager.Accounts() {
+			for _, possibleAddress := range subAccountAddresses {
+				if possibleAddress.Hex() == cachedAccount.Address.Hex() {
+					subAccounts = append(subAccounts, cachedAccount)
+				}
+			}
+		}
+	}
+
+	return subAccounts, nil
 }

--- a/geth/node_test.go
+++ b/geth/node_test.go
@@ -21,10 +21,18 @@ const (
 )
 
 func TestMain(m *testing.M) {
+	syncRequired := false
+	if _, err := os.Stat(geth.TestDataDir); os.IsNotExist(err) {
+		syncRequired = true
+	}
 	// make sure you panic if node start signal is not received
 	signalRecieved := make(chan struct{}, 1)
 	abortPanic := make(chan bool, 1)
-	geth.PanicAfter(10*time.Second, abortPanic, "TestNodeSetup")
+	if syncRequired {
+		geth.PanicAfter(geth.TestNodeSyncSeconds*time.Second, abortPanic, "TestNodeSetup")
+	} else {
+		geth.PanicAfter(10*time.Second, abortPanic, "TestNodeSetup")
+	}
 
 	geth.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
 		if jsonEvent == `{"type":"node.started","event":{}}` {

--- a/geth/utils.go
+++ b/geth/utils.go
@@ -22,8 +22,8 @@ import (
 var muPrepareTestNode sync.Mutex
 
 const (
-	testDataDir         = "../.ethereumtest"
-	testNodeSyncSeconds = 300
+	TestDataDir         = "../.ethereumtest"
+	TestNodeSyncSeconds = 300
 )
 
 type NodeNotificationHandler func(jsonEvent string)
@@ -90,19 +90,19 @@ func PrepareTestNode() (err error) {
 	}
 
 	syncRequired := false
-	if _, err := os.Stat(testDataDir); os.IsNotExist(err) {
+	if _, err := os.Stat(TestDataDir); os.IsNotExist(err) {
 		syncRequired = true
 	}
 
 	// prepare node directory
-	dataDir, err := PreprocessDataDir(testDataDir)
+	dataDir, err := PreprocessDataDir(TestDataDir)
 	if err != nil {
 		glog.V(logger.Warn).Infoln("make node failed:", err)
 		return err
 	}
 
 	// import test account (with test ether on it)
-	dst := filepath.Join(testDataDir, "testnet", "keystore", "test-account.pk")
+	dst := filepath.Join(TestDataDir, "testnet", "keystore", "test-account.pk")
 	if _, err := os.Stat(dst); os.IsNotExist(err) {
 		err = CopyFile(dst, filepath.Join("../data", "test-account.pk"))
 		if err != nil {
@@ -132,8 +132,8 @@ func PrepareTestNode() (err error) {
 	manager.AddPeer("enode://409772c7dea96fa59a912186ad5bcdb5e51b80556b3fe447d940f99d9eaadb51d4f0ffedb68efad232b52475dd7bd59b51cee99968b3cc79e2d5684b33c4090c@139.162.166.59:30303")
 
 	if syncRequired {
-		glog.V(logger.Warn).Infof("Sync is required, it will take %d seconds", testNodeSyncSeconds)
-		time.Sleep(testNodeSyncSeconds * time.Second) // LES syncs headers, so that we are up do date when it is done
+		glog.V(logger.Warn).Infof("Sync is required, it will take %d seconds", TestNodeSyncSeconds)
+		time.Sleep(TestNodeSyncSeconds * time.Second) // LES syncs headers, so that we are up do date when it is done
 	} else {
 		time.Sleep(5 * time.Second)
 	}
@@ -142,7 +142,7 @@ func PrepareTestNode() (err error) {
 }
 
 func RemoveTestNode() {
-	err := os.RemoveAll(testDataDir)
+	err := os.RemoveAll(TestDataDir)
 	if err != nil {
 		glog.V(logger.Warn).Infof("could not clean up temporary datadir")
 	}

--- a/vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go
+++ b/vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go
@@ -199,6 +199,11 @@ func NewPublicAccountAPI(am *accounts.Manager) *PublicAccountAPI {
 
 // Accounts returns the collection of accounts this node manages
 func (s *PublicAccountAPI) Accounts() []accounts.Account {
+	backend := GetStatusBackend()
+	if backend != nil {
+		return statusBackend.am.Accounts()
+	}
+
 	return s.am.Accounts()
 }
 
@@ -220,7 +225,14 @@ func NewPrivateAccountAPI(b Backend) *PrivateAccountAPI {
 
 // ListAccounts will return a list of addresses for accounts this node manages.
 func (s *PrivateAccountAPI) ListAccounts() []common.Address {
-	accounts := s.am.Accounts()
+	var accounts []accounts.Account
+	backend := GetStatusBackend()
+	if backend != nil {
+		accounts = statusBackend.am.Accounts()
+	} else {
+		accounts = s.am.Accounts()
+	}
+
 	addresses := make([]common.Address, len(accounts))
 	for i, acc := range accounts {
 		addresses[i] = acc.Address

--- a/vendor/github.com/ethereum/go-ethereum/les/status/accounts.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/status/accounts.go
@@ -1,0 +1,35 @@
+package status
+
+import (
+	"github.com/ethereum/go-ethereum/accounts"
+)
+
+type AccountManager struct {
+	am                    *accounts.Manager
+	accountsFilterHandler AccountsFilterHandler
+}
+
+// NewAccountManager creates a new AccountManager
+func NewAccountManager(am *accounts.Manager) *AccountManager {
+	return &AccountManager{
+		am: am,
+	}
+}
+
+type AccountsFilterHandler func([]accounts.Account) []accounts.Account
+
+// Accounts returns accounts of currently logged in user.
+// Since status supports HD keys, the following list is returned:
+// [addressCDK#1, addressCKD#2->Child1, addressCKD#2->Child2, .. addressCKD#2->ChildN]
+func (d *AccountManager) Accounts() []accounts.Account {
+	accounts := d.am.Accounts()
+	if d.accountsFilterHandler != nil {
+		accounts = d.accountsFilterHandler(accounts)
+	}
+
+	return accounts
+}
+
+func (d *AccountManager) SetAccountsFilterHandler(fn AccountsFilterHandler) {
+	d.accountsFilterHandler = fn
+}


### PR DESCRIPTION
- closes https://github.com/status-im/go-ethereum/issues/24
- `eth.accounts` and `personal.listAccounts` take into account our extended keys now i.e. returned accounts are [`main_account`, `sub-account1`, `sub-account2`, .. , `sub-accountN`]
- you need to be logged into some account for `eth.accounts` to return anything. This is a breaking change - as in original implementation they return all accounts that node is aware of, while we, on the other hand, return only accounts of currently logged in user.
- I've introduced functionality in a way that allows `go-ethereum` to fall back to default implementation i.e. when built w/i status-go bindings, respective method are decorated with custom functionality (here ability to emit extended keys), however the very same code can be build in our fork of `go-ethereum` and will still work using default behaviour. This is crucial for easier rebasing (we are extending + we make so in pluggable way) and this way we can build LES server and be sure that it behaves exactly as non-modified go-ethereum code.