### PR TITLE
tx discard

### DIFF
--- a/cmd/status/library.go
+++ b/cmd/status/library.go
@@ -158,6 +158,25 @@ func CompleteTransaction(id, password *C.char) *C.char {
 	return C.CString(string(outBytes))
 }
 
+//export DiscardTransaction
+func DiscardTransaction(id *C.char) *C.char {
+	err := geth.DiscardTransaction(C.GoString(id))
+
+	errString := ""
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		errString = err.Error()
+	}
+
+	out := geth.DiscardTransactionResult{
+		Id:    C.GoString(id),
+		Error: errString,
+	}
+	outBytes, _ := json.Marshal(&out)
+
+	return C.CString(string(outBytes))
+}
+
 //export StartNode
 func StartNode(datadir *C.char) *C.char {
 	// This starts a geth node with the given datadir

--- a/geth/types.go
+++ b/geth/types.go
@@ -53,6 +53,11 @@ type CompleteTransactionResult struct {
 	Error string `json:"error"`
 }
 
+type DiscardTransactionResult struct {
+	Id    string `json:"id"`
+	Error string `json:"error"`
+}
+
 type GethEvent struct {
 	Type  string      `json:"type"`
 	Event interface{} `json:"event"`


### PR DESCRIPTION
- related to #32
- new method exposed: `DiscardTransaction(id)` [more details](https://github.com/status-im/status-go/wiki/Notes-on-Bindings#6-sending-transactions)
- since there might be a need to capture `SendTransaction()` unblocking on discarding, binding will signal native app (similar to how signal is sent on queuing/completion/timeout). Here is a sample signal:

``` json
"type":"transaction.failed",
"event":{
  "id":"4649d826-b40a-4505-9a9d-6db8bdb20186",
  "args":{"from":"0x89b50b2b26947ccad43accaef76c21d175ad85f4","to":"0x6865538c1d0969d74ae31282167b7e14062de936","gas":null,"gasPrice":null,"value":"0xe8d4a51000","data":"","nonce":null},
  "message_id":"",
  "error_message":"transaction has been discarded",
  "error_code":"4"
}
```
