### PR TITLE
node_manager: start/stop RPC server methods added

### DIFF
--- a/cmd/status/library.go
+++ b/cmd/status/library.go
@@ -216,6 +216,20 @@ func StartNode(datadir *C.char) *C.char {
 	return C.CString(string(outBytes))
 }
 
+//export StopNodeRPCServer
+func StopNodeRPCServer() *C.char {
+	_, err := geth.NodeManagerInstance().StopNodeRPCServer()
+
+	return makeJSONErrorResponse(err)
+}
+
+//export StartNodeRPCServer
+func StartNodeRPCServer() *C.char {
+	_, err := geth.NodeManagerInstance().StartNodeRPCServer()
+
+	return makeJSONErrorResponse(err)
+}
+
 //export InitJail
 func InitJail(js *C.char) {
 	jail.Init(C.GoString(js))
@@ -286,4 +300,19 @@ func RemoveWhisperFilter(idFilter int) {
 //export ClearWhisperFilters
 func ClearWhisperFilters() {
 	geth.ClearWhisperFilters()
+}
+
+func makeJSONErrorResponse(err error) *C.char {
+	errString := ""
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		errString = err.Error()
+	}
+
+	out := geth.JSONError{
+		Error: errString,
+	}
+	outBytes, _ := json.Marshal(&out)
+
+	return C.CString(string(outBytes))
 }

--- a/geth/node.go
+++ b/geth/node.go
@@ -79,6 +79,7 @@ var (
 type Node struct {
 	geth    *node.Node    // reference to the running Geth node
 	started chan struct{} // channel to wait for node to start
+	config  *node.Config
 }
 
 // Inited checks whether status node has been properly initialized
@@ -135,6 +136,7 @@ func MakeNode(dataDir string, rpcPort int) *Node {
 	return &Node{
 		geth:    stack,
 		started: make(chan struct{}),
+		config:  config,
 	}
 }
 

--- a/geth/node_manager.go
+++ b/geth/node_manager.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -21,6 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/les"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/rpc"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv2"
@@ -35,9 +37,10 @@ type SelectedExtKey struct {
 
 // NodeManager manages Status node (which abstracts contained geth node)
 type NodeManager struct {
-	node            *Node             // reference to Status node
-	services        *NodeServiceStack // default stack of services running on geth node
-	SelectedAccount *SelectedExtKey   // account that was processed during the last call to SelectAccount()
+	node            *Node                 // reference to Status node
+	services        *NodeServiceStack     // default stack of services running on geth node
+	api             *node.PrivateAdminAPI // exposes collection of administrative API methods
+	SelectedAccount *SelectedExtKey       // account that was processed during the last call to SelectAccount()
 }
 
 // NodeServiceStack contains "standard" node services (which are always available)
@@ -58,6 +61,7 @@ var (
 	ErrInvalidJailedRequestQueue   = errors.New("jailed request queue is not properly initialized")
 	ErrNodeMakeFailure             = errors.New("error creating p2p node")
 	ErrNodeStartFailure            = errors.New("error starting p2p node")
+	ErrInvalidNodeAPI              = errors.New("no node API connected")
 )
 
 var (
@@ -128,7 +132,9 @@ func (m *NodeManager) RunNode() {
 			glog.V(logger.Warn).Infoln("cannot get RPC client service:", ErrInvalidClient)
 		}
 
-		// @TODO Remove after LES supports discover out of box
+		// expose API
+		m.api = node.NewPrivateAdminAPI(m.node.geth)
+
 		m.populateStaticPeers()
 
 		m.onNodeStarted() // node started, notify listeners
@@ -162,6 +168,42 @@ func (m *NodeManager) StartNode() {
 		}
 		panic("interrupted!")
 	}()
+}
+
+func (m *NodeManager) RestartNode() error {
+	if m == nil || !m.NodeInited() {
+		return ErrInvalidGethNode
+	}
+
+	return m.node.geth.Restart()
+}
+
+func (m *NodeManager) StartNodeRPCServer() (bool, error) {
+	if m == nil || !m.NodeInited() {
+		return false, ErrInvalidGethNode
+	}
+
+	if m.api == nil {
+		return false, ErrInvalidNodeAPI
+	}
+
+	config := m.node.config
+	modules := strings.Join(config.HTTPModules, ",")
+
+	return m.api.StartRPC(&config.HTTPHost, rpc.NewHexNumber(config.HTTPPort), &config.HTTPCors, &modules)
+}
+
+// StopNodeRPCServer stops HTTP RPC service attached to node
+func (m *NodeManager) StopNodeRPCServer() (bool, error) {
+	if m == nil || !m.NodeInited() {
+		return false, ErrInvalidGethNode
+	}
+
+	if m.api == nil {
+		return false, ErrInvalidNodeAPI
+	}
+
+	return m.api.StopRPC()
 }
 
 // HasNode checks whether manager has initialized node attached

--- a/jail/jail_test.go
+++ b/jail/jail_test.go
@@ -193,7 +193,7 @@ func TestJailRPCSend(t *testing.T) {
 		return
 	}
 
-	if balance < 90 || balance > 100 {
+	if balance < 100 {
 		t.Error("wrong balance (there should be lots of test Ether on that account)")
 		return
 	}


### PR DESCRIPTION
New methods introduced:
- `StopNodeRPCServer` stops running node RPC server
- `StartNodeRPCServer` starts (if not already running i.e. no problem calling this method multiple times) RPC server on Geth node