### PR TITLE
geth: better error notification

### DIFF
--- a/cmd/status/utils.go
+++ b/cmd/status/utils.go
@@ -1123,6 +1123,11 @@ func startTestNode(t *testing.T, tlsEnabled bool) <-chan struct{} {
 			t.Errorf("cannot unmarshal event's JSON: %s", jsonEvent)
 			return
 		}
+		if envelope.Type == geth.EventNodeCrashed {
+			geth.TriggerDefaultNodeNotificationHandler(jsonEvent)
+			return
+		}
+
 		if envelope.Type == geth.EventTransactionQueued {
 		}
 		if envelope.Type == geth.EventNodeStarted {

--- a/geth/node_manager.go
+++ b/geth/node_manager.go
@@ -65,6 +65,8 @@ var (
 
 // CreateAndRunNode creates and starts running Geth node locally (exposing given RPC port along the way)
 func CreateAndRunNode(dataDir string, rpcPort int, tlsEnabled bool) error {
+	defer HaltOnPanic()
+
 	nodeManager := NewNodeManager(dataDir, rpcPort, tlsEnabled)
 
 	if nodeManager.NodeInited() {
@@ -99,6 +101,8 @@ func NodeManagerInstance() *NodeManager {
 // RunNode starts Geth node
 func (m *NodeManager) RunNode() {
 	go func() {
+		defer HaltOnPanic()
+
 		m.StartNode()
 
 		if _, err := m.AccountManager(); err != nil {

--- a/geth/node_manager_test.go
+++ b/geth/node_manager_test.go
@@ -1,6 +1,8 @@
 package geth_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,6 +39,15 @@ func TestMain(m *testing.M) {
 	}
 
 	geth.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
+		var envelope geth.SignalEnvelope
+		if err := json.Unmarshal([]byte(jsonEvent), &envelope); err != nil {
+			panic(fmt.Errorf("cannot unmarshal event's JSON: %s", jsonEvent))
+		}
+		if envelope.Type == geth.EventNodeCrashed {
+			geth.TriggerDefaultNodeNotificationHandler(jsonEvent)
+			return
+		}
+
 		if jsonEvent == `{"type":"node.started","event":{}}` {
 			signalRecieved <- struct{}{}
 		}

--- a/geth/types.go
+++ b/geth/types.go
@@ -21,6 +21,10 @@ type JSONError struct {
 	Error string `json:"error"`
 }
 
+type NodeCrashEvent struct {
+	Error string `json:"error"`
+}
+
 type AddPeerResult struct {
 	Success bool   `json:"success"`
 	Error   string `json:"error"`

--- a/geth/utils.go
+++ b/geth/utils.go
@@ -32,15 +32,19 @@ const (
 
 type NodeNotificationHandler func(jsonEvent string)
 
-var notificationHandler NodeNotificationHandler = func(jsonEvent string) { // internal signal handler (used in tests)
-	glog.V(logger.Info).Infof("notification received (default notification handler): %s\n", jsonEvent)
-}
+var notificationHandler NodeNotificationHandler = TriggerDefaultNodeNotificationHandler
 
+// SetDefaultNodeNotificationHandler sets notification handler to invoke on SendSignal
 func SetDefaultNodeNotificationHandler(fn NodeNotificationHandler) {
 	notificationHandler = fn
 }
 
-// SendSignal sends application signal (JSON, normally) upwards
+// TriggerDefaultNodeNotificationHandler triggers default notification handler (helpful in tests)
+func TriggerDefaultNodeNotificationHandler(jsonEvent string) {
+	glog.V(logger.Info).Infof("notification received (default notification handler): %s\n", jsonEvent)
+}
+
+// SendSignal sends application signal (JSON, normally) upwards to application (via default notification handler)
 func SendSignal(signal SignalEnvelope) {
 	data, _ := json.Marshal(&signal)
 	C.StatusServiceSignalEvent(C.CString(string(data)))
@@ -99,6 +103,8 @@ func PrepareTestNode() (err error) {
 		return nil
 	}
 
+	defer HaltOnPanic()
+
 	syncRequired := false
 	if _, err := os.Stat(filepath.Join(TestDataDir, "testnet")); os.IsNotExist(err) {
 		syncRequired = true
@@ -123,7 +129,10 @@ func PrepareTestNode() (err error) {
 
 	// start geth node and wait for it to initialize
 	// internally once.Do() is used, so call below is thread-safe
-	CreateAndRunNode(dataDir, 8546, false) // to avoid conflicts with running react-native app, run on different port
+	err = CreateAndRunNode(dataDir, 8546, false) // to avoid conflicts with running react-native app, run on different port
+	if err != nil {
+		panic(err)
+	}
 
 	manager = NodeManagerInstance()
 	if !manager.NodeInited() {


### PR DESCRIPTION
- fixes #77 
- better error handling
- on error (whenever node starts and whenever node runs), upward notification will be sent