### PR TITLE
ResetChainData() exposed

### DIFF
--- a/cmd/status/library.go
+++ b/cmd/status/library.go
@@ -205,6 +205,12 @@ func StartNode(datadir *C.char) *C.char {
 	return makeJSONErrorResponse(err)
 }
 
+//export ResetChainData
+func ResetChainData() *C.char {
+	err := geth.NodeManagerInstance().ResetChainData()
+	return makeJSONErrorResponse(err)
+}
+
 //export StartTLSNode
 func StartTLSNode(datadir *C.char) *C.char {
 	// This starts a geth node with the given datadir

--- a/geth/node_manager.go
+++ b/geth/node_manager.go
@@ -29,8 +29,16 @@ type SelectedExtKey struct {
 	SubAccounts []accounts.Account
 }
 
+// NodeManagerConfig stores configuration options passed to constructor
+type NodeManagerConfig struct {
+	DataDir    string
+	RPCPort    int
+	TLSEnabled bool
+}
+
 // NodeManager manages Status node (which abstracts contained geth node)
 type NodeManager struct {
+	config          *NodeManagerConfig    // reference to passed configuration variables
 	node            *Node                 // reference to Status node
 	services        *NodeServiceStack     // default stack of services running on geth node
 	api             *node.PrivateAdminAPI // exposes collection of administrative API methods
@@ -71,8 +79,7 @@ func CreateAndRunNode(dataDir string, rpcPort int, tlsEnabled bool) error {
 
 	if nodeManager.NodeInited() {
 		nodeManager.RunNode()
-
-		<-nodeManager.node.started // block until node is ready
+		nodeManager.WaitNodeStarted()
 		return nil
 	}
 
@@ -83,6 +90,11 @@ func CreateAndRunNode(dataDir string, rpcPort int, tlsEnabled bool) error {
 func NewNodeManager(dataDir string, rpcPort int, tlsEnabled bool) *NodeManager {
 	createOnce.Do(func() {
 		nodeManagerInstance = &NodeManager{
+			config: &NodeManagerConfig{
+				DataDir:    dataDir,
+				RPCPort:    rpcPort,
+				TLSEnabled: tlsEnabled,
+			},
 			services: &NodeServiceStack{
 				jailedRequestQueue: NewJailedRequestsQueue(),
 			},
@@ -137,6 +149,8 @@ func (m *NodeManager) RunNode() {
 
 		m.onNodeStarted() // node started, notify listeners
 		m.node.geth.Wait()
+
+		glog.V(logger.Info).Infoln("node stopped")
 	}()
 }
 
@@ -168,12 +182,53 @@ func (m *NodeManager) StartNode() {
 	}()
 }
 
+// StopNode stops running P2P node
+func (m *NodeManager) StopNode() error {
+	if m == nil || !m.NodeInited() {
+		return ErrInvalidGethNode
+	}
+
+	m.node.geth.Stop()
+	m.node.started = make(chan struct{})
+	return nil
+}
+
+// RestartNode restarts P2P node
 func (m *NodeManager) RestartNode() error {
 	if m == nil || !m.NodeInited() {
 		return ErrInvalidGethNode
 	}
 
-	return m.node.geth.Restart()
+	m.StopNode()
+	m.RunNode()
+	m.WaitNodeStarted()
+
+	return nil
+}
+
+// ResetChainData purges chain data (by removing data directory). Safe to apply on running P2P node.
+func (m *NodeManager) ResetChainData() error {
+	if m == nil || !m.NodeInited() {
+		return ErrInvalidGethNode
+	}
+
+	if err := m.StopNode(); err != nil {
+		return err
+	}
+
+	chainDataDir := filepath.Join(m.node.config.DataDir, m.node.config.Name, "lightchaindata")
+	if _, err := os.Stat(chainDataDir); os.IsNotExist(err) {
+		return err
+	}
+
+	if err := os.RemoveAll(chainDataDir); err != nil {
+		return err
+	}
+
+	m.RunNode()
+	m.WaitNodeStarted()
+
+	return nil
 }
 
 func (m *NodeManager) StartNodeRPCServer() (bool, error) {
@@ -293,6 +348,11 @@ func (m *NodeManager) AddPeer(url string) (bool, error) {
 	server.AddPeer(parsedNode)
 
 	return true, nil
+}
+
+// WaitNodeStarted blocks until node is started (start channel gets notified)
+func (m *NodeManager) WaitNodeStarted() {
+	<-m.node.started // block until node is started
 }
 
 // onNodeStarted sends upward notification letting the app know that Geth node is ready to be used

--- a/geth/node_manager_test.go
+++ b/geth/node_manager_test.go
@@ -63,3 +63,22 @@ func TestMain(m *testing.M) {
 
 	os.Exit(m.Run())
 }
+
+func TestResetChainData(t *testing.T) {
+	err := geth.PrepareTestNode()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := geth.NodeManagerInstance().ResetChainData(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	// allow some time to re-sync
+	time.Sleep(15 * time.Second)
+
+	// now make sure that everything is intact
+	TestQueuedTransactions(t)
+}

--- a/geth/txqueue_test.go
+++ b/geth/txqueue_test.go
@@ -36,9 +36,11 @@ func TestQueuedTransactions(t *testing.T) {
 		return
 	}
 
+	geth.Logout()
+
 	// make sure you panic if transaction complete doesn't return
 	completeQueuedTransaction := make(chan struct{}, 1)
-	geth.PanicAfter(20*time.Second, completeQueuedTransaction, "TestQueuedTransactions")
+	geth.PanicAfter(60*time.Second, completeQueuedTransaction, "TestQueuedTransactions")
 
 	// replace transaction notification handler
 	var txHash = common.Hash{}

--- a/geth/utils.go
+++ b/geth/utils.go
@@ -27,7 +27,7 @@ var muPrepareTestNode sync.Mutex
 
 const (
 	TestDataDir         = "../.ethereumtest"
-	TestNodeSyncSeconds = 120
+	TestNodeSyncSeconds = 30
 )
 
 type NodeNotificationHandler func(jsonEvent string)

--- a/vendor/github.com/ethereum/go-ethereum/eth/api_backend.go
+++ b/vendor/github.com/ethereum/go-ethereum/eth/api_backend.go
@@ -37,8 +37,13 @@ import (
 
 // EthApiBackend implements ethapi.Backend for full nodes
 type EthApiBackend struct {
-	eth *Ethereum
-	gpo *gasprice.GasPriceOracle
+	eth           *Ethereum
+	gpo           *gasprice.GasPriceOracle
+	statusBackend *ethapi.StatusBackend
+}
+
+func (b *EthApiBackend) GetStatusBackend() *ethapi.StatusBackend {
+	return b.statusBackend
 }
 
 func (b *EthApiBackend) ChainConfig() *params.ChainConfig {

--- a/vendor/github.com/ethereum/go-ethereum/eth/backend.go
+++ b/vendor/github.com/ethereum/go-ethereum/eth/backend.go
@@ -255,7 +255,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		GpobaseCorrectionFactor: config.GpobaseCorrectionFactor,
 	}
 	gpo := gasprice.NewGasPriceOracle(eth.blockchain, chainDb, eth.eventMux, gpoParams)
-	eth.ApiBackend = &EthApiBackend{eth, gpo}
+	eth.ApiBackend = &EthApiBackend{eth, gpo, nil}
 
 	return eth, nil
 }

--- a/vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go
+++ b/vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/ethereum/ethash"
@@ -40,14 +39,12 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/pborman/uuid"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
 	"golang.org/x/net/context"
 )
 
 const defaultGas = 90000
-const defaultTxQueueCap = int(5)
 
 // PublicEthereumAPI provides an API to access Ethereum related information.
 // It offers only methods that operate on public data that is freely available to anyone.
@@ -179,18 +176,22 @@ func (s *PublicTxPoolAPI) Inspect() map[string]map[string]map[string]string {
 // It offers only methods that can retrieve accounts.
 type PublicAccountAPI struct {
 	am *accounts.Manager
+	b  Backend
 }
 
 // NewPublicAccountAPI creates a new PublicAccountAPI.
-func NewPublicAccountAPI(am *accounts.Manager) *PublicAccountAPI {
-	return &PublicAccountAPI{am: am}
+func NewPublicAccountAPI(b Backend) *PublicAccountAPI {
+	return &PublicAccountAPI{
+		am: b.AccountManager(),
+		b:  b,
+	}
 }
 
 // Accounts returns the collection of accounts this node manages
 func (s *PublicAccountAPI) Accounts() []accounts.Account {
-	backend := GetStatusBackend()
+	backend := s.b.GetStatusBackend()
 	if backend != nil {
-		return statusBackend.am.Accounts()
+		return backend.am.Accounts()
 	}
 
 	return s.am.Accounts()
@@ -215,9 +216,9 @@ func NewPrivateAccountAPI(b Backend) *PrivateAccountAPI {
 // ListAccounts will return a list of addresses for accounts this node manages.
 func (s *PrivateAccountAPI) ListAccounts() []common.Address {
 	var accounts []accounts.Account
-	backend := GetStatusBackend()
+	backend := s.b.GetStatusBackend()
 	if backend != nil {
-		accounts = statusBackend.am.Accounts()
+		accounts = backend.am.Accounts()
 	} else {
 		accounts = s.am.Accounts()
 	}
@@ -782,25 +783,13 @@ func newRPCTransaction(b *types.Block, txHash common.Hash) (*RPCTransaction, err
 
 // PublicTransactionPoolAPI exposes methods for the RPC interface
 type PublicTransactionPoolAPI struct {
-	b       Backend
-	txQueue chan *status.QueuedTx
+	b Backend
 }
-
-var txSingletonQueue chan *status.QueuedTx
 
 // NewPublicTransactionPoolAPI creates a new RPC service with methods specific for the transaction pool.
 func NewPublicTransactionPoolAPI(b Backend) *PublicTransactionPoolAPI {
-	var once sync.Once
-	once.Do(func() {
-		if txSingletonQueue == nil {
-			glog.V(logger.Info).Infof("Transaction queue inited (Public Transaction Pool API)")
-			txSingletonQueue = make(chan *status.QueuedTx, status.DefaultTxSendQueueCap)
-		}
-	})
-
 	return &PublicTransactionPoolAPI{
-		b:       b,
-		txQueue: txSingletonQueue,
+		b: b,
 	}
 }
 
@@ -1080,42 +1069,14 @@ func submitTransaction(ctx context.Context, b Backend, tx *types.Transaction, si
 	return signedTx.Hash(), nil
 }
 
-func (s *PublicTransactionPoolAPI) GetTransactionQueue() (chan *status.QueuedTx, error) {
-	return s.txQueue, nil
-}
-
 // SendTransaction queues transactions, to be fulfilled by CompleteQueuedTransaction()
 func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args SendTxArgs) (common.Hash, error) {
-	queuedTx := &status.QueuedTx{
-		Id:      status.QueuedTxId(uuid.New()),
-		Hash:    common.Hash{},
-		Context: ctx,
-		Args:    status.SendTxArgs(args),
-		Done:    make(chan struct{}, 1),
-		Discard: make(chan struct{}, 1),
+	backend := s.b.GetStatusBackend()
+	if backend != nil {
+		return backend.SendTransaction(ctx, status.SendTxArgs(args))
 	}
 
-	// send transaction to pending pool
-	s.txQueue <- queuedTx
-
-	// now wait up until transaction is:
-	// - completed (via CompleteQueuedTransaction),
-	// - discarded (via DiscardQueuedTransaction)
-	// - or times out
-	backend := GetStatusBackend()
-	select {
-	case <-queuedTx.Done:
-		backend.NotifyOnQueuedTxReturn(queuedTx, queuedTx.Err)
-		return queuedTx.Hash, queuedTx.Err
-	case <-queuedTx.Discard:
-		backend.NotifyOnQueuedTxReturn(queuedTx, status.ErrQueuedTxDiscarded)
-		return queuedTx.Hash, queuedTx.Err
-	case <-time.After(status.DefaultTxSendCompletionTimeout * time.Second):
-		backend.NotifyOnQueuedTxReturn(queuedTx, status.ErrQueuedTxTimedOut)
-		return common.Hash{}, status.ErrQueuedTxTimedOut
-	}
-
-	return queuedTx.Hash, nil
+	return common.Hash{}, ErrStatusBackendNotInited
 }
 
 // CompleteQueuedTransaction creates a transaction by unpacking queued transaction, signs it and submits to the

--- a/vendor/github.com/ethereum/go-ethereum/internal/ethapi/backend.go
+++ b/vendor/github.com/ethereum/go-ethereum/internal/ethapi/backend.go
@@ -63,6 +63,8 @@ type Backend interface {
 
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block
+
+	GetStatusBackend() *StatusBackend
 }
 
 type State interface {
@@ -107,7 +109,7 @@ func GetAPIs(apiBackend Backend, solcPath string) []rpc.API {
 		}, {
 			Namespace: "eth",
 			Version:   "1.0",
-			Service:   NewPublicAccountAPI(apiBackend.AccountManager()),
+			Service:   NewPublicAccountAPI(apiBackend),
 			Public:    true,
 		}, {
 			Namespace: "personal",

--- a/vendor/github.com/ethereum/go-ethereum/internal/ethapi/status_backend.go
+++ b/vendor/github.com/ethereum/go-ethereum/internal/ethapi/status_backend.go
@@ -1,13 +1,15 @@
 package ethapi
 
 import (
-	"sync"
+	"errors"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/les/status"
 	"github.com/ethereum/go-ethereum/logger"
 	"github.com/ethereum/go-ethereum/logger/glog"
+	"github.com/pborman/uuid"
 	"golang.org/x/net/context"
 )
 
@@ -21,30 +23,30 @@ type StatusBackend struct {
 	am      *status.AccountManager
 }
 
-var statusBackend *StatusBackend
-var once sync.Once
+var (
+	ErrStatusBackendNotInited = errors.New("StatusIM backend is not properly inited")
+)
 
 // NewStatusBackend creates a new backend using an existing Ethereum object.
 func NewStatusBackend(apiBackend Backend) *StatusBackend {
-	glog.V(logger.Info).Infof("Status backend service started")
-	once.Do(func() {
-		statusBackend = &StatusBackend{
-			eapi:    NewPublicEthereumAPI(apiBackend),
-			bcapi:   NewPublicBlockChainAPI(apiBackend),
-			txapi:   NewPublicTransactionPoolAPI(apiBackend),
-			txQueue: status.NewTransactionQueue(),
-			am:      status.NewAccountManager(apiBackend.AccountManager()),
-		}
-	})
-
-	go statusBackend.transactionQueueForwardingLoop()
-
-	return statusBackend
+	glog.V(logger.Info).Infof("StatusIM: backend service inited")
+	return &StatusBackend{
+		eapi:    NewPublicEthereumAPI(apiBackend),
+		bcapi:   NewPublicBlockChainAPI(apiBackend),
+		txapi:   NewPublicTransactionPoolAPI(apiBackend),
+		txQueue: status.NewTransactionQueue(),
+		am:      status.NewAccountManager(apiBackend.AccountManager()),
+	}
 }
 
-// GetStatusBackend exposes backend singleton instance
-func GetStatusBackend() *StatusBackend {
-	return statusBackend
+func (b *StatusBackend) Start() {
+	glog.V(logger.Info).Infof("StatusIM: started as LES sub-protocol")
+	b.txQueue.Start()
+}
+
+func (b *StatusBackend) Stop() {
+	glog.V(logger.Info).Infof("StatusIM: stopped as LES sub-protocol")
+	b.txQueue.Stop()
 }
 
 func (b *StatusBackend) NotifyOnQueuedTxReturn(queuedTx *status.QueuedTx, err error) {
@@ -81,7 +83,35 @@ func (b *StatusBackend) SendTransaction(ctx context.Context, args status.SendTxA
 		ctx = context.Background()
 	}
 
-	return b.txapi.SendTransaction(ctx, SendTxArgs(args))
+	queuedTx := &status.QueuedTx{
+		Id:      status.QueuedTxId(uuid.New()),
+		Hash:    common.Hash{},
+		Context: ctx,
+		Args:    status.SendTxArgs(args),
+		Done:    make(chan struct{}, 1),
+		Discard: make(chan struct{}, 1),
+	}
+
+	// send transaction to pending pool, w/o blocking
+	b.txQueue.EnqueueAsync(queuedTx)
+
+	// now wait up until transaction is:
+	// - completed (via CompleteQueuedTransaction),
+	// - discarded (via DiscardQueuedTransaction)
+	// - or times out
+	select {
+	case <-queuedTx.Done:
+		b.NotifyOnQueuedTxReturn(queuedTx, queuedTx.Err)
+		return queuedTx.Hash, queuedTx.Err
+	case <-queuedTx.Discard:
+		b.NotifyOnQueuedTxReturn(queuedTx, status.ErrQueuedTxDiscarded)
+		return queuedTx.Hash, queuedTx.Err
+	case <-time.After(status.DefaultTxSendCompletionTimeout * time.Second):
+		b.NotifyOnQueuedTxReturn(queuedTx, status.ErrQueuedTxTimedOut)
+		return common.Hash{}, status.ErrQueuedTxTimedOut
+	}
+
+	return queuedTx.Hash, nil
 }
 
 // CompleteQueuedTransaction wraps call to PublicTransactionPoolAPI.CompleteQueuedTransaction
@@ -128,17 +158,4 @@ func (b *StatusBackend) DiscardQueuedTransaction(id status.QueuedTxId) error {
 	queuedTx.Discard <- struct{}{} // sendTransaction() waits on this, notify so that it can return
 
 	return nil
-}
-
-func (b *StatusBackend) transactionQueueForwardingLoop() {
-	txQueue, err := b.txapi.GetTransactionQueue()
-	if err != nil {
-		glog.V(logger.Error).Infof("cannot read from transaction queue")
-		return
-	}
-
-	// forward internal ethapi transactions to status backend
-	for queuedTx := range txQueue {
-		b.txQueue.Enqueue(queuedTx)
-	}
 }

--- a/vendor/github.com/ethereum/go-ethereum/les/api_backend.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/api_backend.go
@@ -36,8 +36,13 @@ import (
 )
 
 type LesApiBackend struct {
-	eth *LightEthereum
-	gpo *gasprice.LightPriceOracle
+	eth           *LightEthereum
+	gpo           *gasprice.LightPriceOracle
+	statusBackend *ethapi.StatusBackend
+}
+
+func (b *LesApiBackend) GetStatusBackend() *ethapi.StatusBackend {
+	return b.statusBackend
 }
 
 func (b *LesApiBackend) ChainConfig() *params.ChainConfig {

--- a/vendor/github.com/ethereum/go-ethereum/les/backend.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/backend.go
@@ -118,11 +118,12 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		return nil, err
 	}
 
-	eth.ApiBackend = &LesApiBackend{eth, nil}
+	eth.ApiBackend = &LesApiBackend{eth, nil, nil}
 	eth.ApiBackend.gpo = gasprice.NewLightPriceOracle(eth.ApiBackend)
 
 	// inject status-im backend
-	eth.StatusBackend = ethapi.NewStatusBackend(eth.ApiBackend)
+	eth.ApiBackend.statusBackend = ethapi.NewStatusBackend(eth.ApiBackend)
+	eth.StatusBackend = eth.ApiBackend.statusBackend // alias
 
 	return eth, nil
 }
@@ -199,6 +200,7 @@ func (s *LightEthereum) Start(srvr *p2p.Server) error {
 	glog.V(logger.Info).Infof("WARNING: light client mode is an experimental feature")
 	s.netRPCService = ethapi.NewPublicNetAPI(srvr, s.netVersionId)
 	s.protocolManager.Start(srvr)
+	s.StatusBackend.Start()
 	return nil
 }
 
@@ -215,6 +217,8 @@ func (s *LightEthereum) Stop() error {
 	time.Sleep(time.Millisecond * 200)
 	s.chainDb.Close()
 	close(s.shutdownChan)
+
+	s.StatusBackend.Stop()
 
 	return nil
 }

--- a/vendor/github.com/ethereum/go-ethereum/les/status/txqueue.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/status/txqueue.go
@@ -122,7 +122,7 @@ func (q *TxQueue) enqueueLoop() {
 	for {
 		select {
 		case queuedTx := <-q.incomingPool:
-			glog.V(logger.Info).Infof("StatusIM: transaction enqueued")
+			glog.V(logger.Info).Infof("StatusIM: transaction enqueued %v", queuedTx.Id)
 			q.Enqueue(queuedTx)
 		case <-q.stopped:
 			glog.V(logger.Info).Infof("StatusIM: transaction queue's enqueue loop stopped")

--- a/vendor/github.com/ethereum/go-ethereum/les/status/txqueue.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/status/txqueue.go
@@ -7,6 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/logger"
+	"github.com/ethereum/go-ethereum/logger/glog"
 	"golang.org/x/net/context"
 )
 
@@ -27,9 +29,14 @@ var (
 // TxQueue is capped container that holds pending transactions
 type TxQueue struct {
 	transactions  map[QueuedTxId]*QueuedTx
-	mu            sync.RWMutex // to guard trasactions map
+	mu            sync.RWMutex // to guard transactions map
 	evictableIds  chan QueuedTxId
 	enqueueTicker chan struct{}
+	incomingPool  chan *QueuedTx
+
+	// when this channel is closed, all queue channels processing must cease (incoming queue, processing queued items etc)
+	stopped      chan struct{}
+	stoppedGroup sync.WaitGroup // to make sure that all routines are stopped
 
 	// when items are enqueued notify subscriber
 	txEnqueueHandler EnqueuedTxHandler
@@ -57,7 +64,7 @@ type EnqueuedTxHandler func(QueuedTx)
 // EnqueuedTxReturnHandler is a function that receives response when tx is complete (both on success and error)
 type EnqueuedTxReturnHandler func(queuedTx *QueuedTx, err error)
 
-// SendTxArgs represents the arguments to submbit a new transaction into the transaction pool.
+// SendTxArgs represents the arguments to submit a new transaction into the transaction pool.
 type SendTxArgs struct {
 	From     common.Address  `json:"from"`
 	To       *common.Address `json:"to"`
@@ -69,22 +76,58 @@ type SendTxArgs struct {
 }
 
 func NewTransactionQueue() *TxQueue {
-	txQueue := &TxQueue{
+	glog.V(logger.Info).Infof("StatusIM: initializing transaction queue")
+	return &TxQueue{
 		transactions:  make(map[QueuedTxId]*QueuedTx),
 		evictableIds:  make(chan QueuedTxId, DefaultTxQueueCap), // will be used to evict in FIFO
 		enqueueTicker: make(chan struct{}),
+		incomingPool:  make(chan *QueuedTx, DefaultTxSendQueueCap),
 	}
+}
 
-	go txQueue.evictionLoop()
+func (q *TxQueue) Start() {
+	glog.V(logger.Info).Infof("StatusIM: starting transaction queue")
 
-	return txQueue
+	q.stopped = make(chan struct{})
+	q.stoppedGroup.Add(2)
+
+	go q.evictionLoop()
+	go q.enqueueLoop()
+}
+
+func (q *TxQueue) Stop() {
+	glog.V(logger.Info).Infof("StatusIM: stopping transaction queue")
+	close(q.stopped) // stops all processing loops (enqueue, eviction etc)
+	q.stoppedGroup.Wait()
 }
 
 func (q *TxQueue) evictionLoop() {
-	for range q.enqueueTicker {
-		if len(q.transactions) >= (DefaultTxQueueCap - 1) { // eviction is required to accommodate another/last item
-			q.Remove(<-q.evictableIds)
-			q.enqueueTicker <- struct{}{} // in case we pulled already removed item
+	for {
+		select {
+		case <-q.enqueueTicker:
+			if len(q.transactions) >= (DefaultTxQueueCap - 1) { // eviction is required to accommodate another/last item
+				q.Remove(<-q.evictableIds)
+				q.enqueueTicker <- struct{}{} // in case we pulled already removed item
+			}
+		case <-q.stopped:
+			glog.V(logger.Info).Infof("StatusIM: transaction queue's eviction loop stopped")
+			q.stoppedGroup.Done()
+			return
+		}
+	}
+}
+
+func (q *TxQueue) enqueueLoop() {
+	// enqueue incoming transactions
+	for {
+		select {
+		case queuedTx := <-q.incomingPool:
+			glog.V(logger.Info).Infof("StatusIM: transaction enqueued")
+			q.Enqueue(queuedTx)
+		case <-q.stopped:
+			glog.V(logger.Info).Infof("StatusIM: transaction queue's enqueue loop stopped")
+			q.stoppedGroup.Done()
+			return
 		}
 	}
 }
@@ -96,6 +139,12 @@ func (q *TxQueue) Reset() {
 
 	q.transactions = make(map[QueuedTxId]*QueuedTx)
 	q.evictableIds = make(chan QueuedTxId, DefaultTxQueueCap)
+}
+
+func (q *TxQueue) EnqueueAsync(tx *QueuedTx) error {
+	q.incomingPool <- tx
+
+	return nil
 }
 
 func (q *TxQueue) Enqueue(tx *QueuedTx) error {

--- a/vendor/github.com/ethereum/go-ethereum/light/lightchain.go
+++ b/vendor/github.com/ethereum/go-ethereum/light/lightchain.go
@@ -119,11 +119,11 @@ func NewLightChain(odr OdrBackend, config *params.ChainConfig, pow pow.PoW, mux 
 		}
 		glog.V(logger.Info).Infoln("Added trusted CHT for mainnet")
 	} else {
-		if bc.genesisBlock.Hash() == (common.Hash{12, 215, 134, 162, 66, 93, 22, 241, 82, 198, 88, 49, 108, 66, 62, 108, 225, 24, 30, 21, 195, 41, 88, 38, 215, 201, 144, 76, 186, 156, 227, 3}) {
+		if bc.genesisBlock.Hash() == (common.Hash{65, 148, 16, 35, 104, 9, 35, 224, 254, 77, 116, 163, 75, 218, 200, 20, 31, 37, 64, 227, 174, 144, 98, 55, 24, 228, 125, 102, 209, 202, 74, 45}) {
 			// add trusted CHT for testnet
 			WriteTrustedCht(bc.chainDb, TrustedCht{
-				Number: 452,
-				Root:   common.HexToHash("511da2c88e32b14cf4a4e62f7fcbb297139faebc260a4ab5eb43cce6edcba324"),
+				Number: 95,
+				Root:   common.HexToHash("2a7416d1febea2a2f2b66f8171bea4e77dbad476b00a8d9d250037958a6472d8"),
 			})
 			glog.V(logger.Info).Infoln("Added trusted CHT for testnet")
 		} else {


### PR DESCRIPTION
- fixes #63 
- tx queueing and processing has been refactored (got rid of ugly singleton, improved to the point that I finally like how we patching geth's behavior)
- makes #93 possible (as we now have **tested** way to set CHT, which works - so now the only task remaining is to make this CHT update dynamic)
- `ResetChainData()` command introduced, it:
  - stops running node (and all sub-protocols i.e. LES, Status)
  - wipes out `lightchaindata` directore
  - starts the same node again