### PR TITLE
Pause/resume node implemented

### DIFF
--- a/cmd/status/library.go
+++ b/cmd/status/library.go
@@ -205,6 +205,18 @@ func StartNode(datadir *C.char) *C.char {
 	return makeJSONErrorResponse(err)
 }
 
+//export StopNode
+func StopNode() *C.char {
+	err := geth.NodeManagerInstance().StopNode()
+	return makeJSONErrorResponse(err)
+}
+
+//export ResumeNode
+func ResumeNode() *C.char {
+	err := geth.NodeManagerInstance().ResumeNode()
+	return makeJSONErrorResponse(err)
+}
+
 //export ResetChainData
 func ResetChainData() *C.char {
 	err := geth.NodeManagerInstance().ResetChainData()

--- a/cmd/status/library.go
+++ b/cmd/status/library.go
@@ -202,6 +202,7 @@ func StartNode(datadir *C.char) *C.char {
 	// This starts a geth node with the given datadir
 	err := geth.CreateAndRunNode(&geth.NodeConfig{
 		DataDir:    C.GoString(datadir),
+		IPCEnabled: true,
 		HTTPPort:   geth.HTTPPort,
 		WSEnabled:  true,
 		WSPort:     geth.WSPort,

--- a/cmd/status/library.go
+++ b/cmd/status/library.go
@@ -202,9 +202,9 @@ func StartNode(datadir *C.char) *C.char {
 	// This starts a geth node with the given datadir
 	err := geth.CreateAndRunNode(&geth.NodeConfig{
 		DataDir:    C.GoString(datadir),
-		IPCEnabled: true,
+		IPCEnabled: false,
 		HTTPPort:   geth.HTTPPort,
-		WSEnabled:  true,
+		WSEnabled:  false,
 		WSPort:     geth.WSPort,
 		TLSEnabled: false,
 	})

--- a/cmd/status/library.go
+++ b/cmd/status/library.go
@@ -200,7 +200,13 @@ func DiscardTransactions(ids *C.char) *C.char {
 //export StartNode
 func StartNode(datadir *C.char) *C.char {
 	// This starts a geth node with the given datadir
-	err := geth.CreateAndRunNode(C.GoString(datadir), geth.RPCPort)
+	err := geth.CreateAndRunNode(&geth.NodeConfig{
+		DataDir:    C.GoString(datadir),
+		HTTPPort:   geth.HTTPPort,
+		WSEnabled:  true,
+		WSPort:     geth.WSPort,
+		TLSEnabled: false,
+	})
 
 	return makeJSONErrorResponse(err)
 }
@@ -220,6 +226,19 @@ func ResumeNode() *C.char {
 //export ResetChainData
 func ResetChainData() *C.char {
 	err := geth.NodeManagerInstance().ResetChainData()
+	return makeJSONErrorResponse(err)
+}
+
+//export StartTLSNode
+func StartTLSNode(datadir *C.char) *C.char {
+	// This starts a geth node with the given datadir
+	err := geth.CreateAndRunNode(&geth.NodeConfig{
+		DataDir:    C.GoString(datadir),
+		HTTPPort:   geth.HTTPPort,
+		WSPort:     geth.WSPort,
+		TLSEnabled: true,
+	})
+
 	return makeJSONErrorResponse(err)
 }
 

--- a/geth/accounts.go
+++ b/geth/accounts.go
@@ -167,6 +167,27 @@ func SelectAccount(address, password string) error {
 	return nil
 }
 
+// ReSelectAccount selects previously selected account, often, after node restart.
+func ReSelectAccount() error {
+	nodeManager := NodeManagerInstance()
+
+	selectedAccount := nodeManager.SelectedAccount
+	if selectedAccount == nil {
+		return nil
+	}
+
+	whisperService, err := nodeManager.WhisperService()
+	if err != nil {
+		return err
+	}
+
+	if err := whisperService.InjectIdentity(selectedAccount.AccountKey.PrivateKey); err != nil {
+		return ErrWhisperIdentityInjectionFailure
+	}
+
+	return nil
+}
+
 // Logout clears whisper identities
 func Logout() error {
 	nodeManager := NodeManagerInstance()

--- a/geth/node.go
+++ b/geth/node.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math/big"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"runtime"

--- a/geth/node.go
+++ b/geth/node.go
@@ -33,13 +33,13 @@ const (
 	VersionMinor     = 2          // Minor version component of the current release
 	VersionPatch     = 0          // Patch version component of the current release
 	VersionMeta      = "unstable" // Version metadata to append to the version string
-
-	HTTPPort        = 8545 // HTTP-RPC port (replaced in unit tests)
-	WSPort          = 8546 // WS-RPC port (replaced in unit tests)
-	NetworkPort     = 30303
-	MaxPeers        = 25
-	MaxLightPeers   = 20
-	MaxPendingPeers = 0
+	IPCFile          = "geth.ipc" // Filename of exposed IPC-RPC Server
+	HTTPPort         = 8545       // HTTP-RPC port (replaced in unit tests)
+	WSPort           = 8546       // WS-RPC port (replaced in unit tests)
+	NetworkPort      = 30303
+	MaxPeers         = 25
+	MaxLightPeers    = 20
+	MaxPendingPeers  = 0
 
 	ProcessFileDescriptorLimit = uint64(2048)
 	DatabaseCacheSize          = 128 // Megabytes of memory allocated to internal caching (min 16MB / database forced)
@@ -81,6 +81,7 @@ var (
 // NodeConfig stores configuration options for a node
 type NodeConfig struct {
 	DataDir    string // base data directory
+	IPCEnabled bool   // whether IPC-RPC Server is enabled or not
 	HTTPPort   int    // HTTP-RPC Server port
 	WSPort     int    // WS-RPC Server port
 	WSEnabled  bool   // whether WS-RPC Server is enabled or not
@@ -127,6 +128,7 @@ func MakeNode(config *NodeConfig) *Node {
 		ListenAddr:        fmt.Sprintf(":%d", NetworkPort),
 		MaxPeers:          MaxPeers,
 		MaxPendingPeers:   MaxPendingPeers,
+		IPCPath:           makeIPCPath(dataDir, config.IPCEnabled),
 		HTTPHost:          node.DefaultHTTPHost,
 		HTTPPort:          config.HTTPPort,
 		HTTPCors:          "*",
@@ -209,6 +211,15 @@ func activateShhService(stack *node.Node) error {
 	}
 
 	return nil
+}
+
+// makeIPCPath returns IPC-RPC filename
+func makeIPCPath(dataDir string, ipcEnabled bool) string {
+	if !ipcEnabled {
+		return ""
+	}
+
+	return path.Join(dataDir, IPCFile)
 }
 
 // makeWSHost returns WS-RPC Server host, given enabled/disabled flag

--- a/geth/node.go
+++ b/geth/node.go
@@ -34,7 +34,8 @@ const (
 	VersionPatch     = 0          // Patch version component of the current release
 	VersionMeta      = "unstable" // Version metadata to append to the version string
 
-	RPCPort         = 8545 // RPC port (replaced in unit tests)
+	HTTPPort        = 8545 // HTTP-RPC port (replaced in unit tests)
+	WSPort          = 8546 // WS-RPC port (replaced in unit tests)
 	NetworkPort     = 30303
 	MaxPeers        = 25
 	MaxLightPeers   = 20
@@ -72,18 +73,26 @@ func init() {
 
 // node-related errors
 var (
-	ErrRLimitRaiseFailure            = errors.New("failed to register the whisper service")
-	ErrDatabaseAccessFailure         = errors.New("could not open database")
-	ErrChainConfigurationFailure     = errors.New("could not make chain configuration")
 	ErrEthServiceRegistrationFailure = errors.New("failed to register the Ethereum service")
 	ErrSshServiceRegistrationFailure = errors.New("failed to register the Whisper service")
 	ErrLightEthRegistrationFailure   = errors.New("failed to register the LES service")
 )
 
+// NodeConfig stores configuration options for a node
+type NodeConfig struct {
+	DataDir    string // base data directory
+	HTTPPort   int    // HTTP-RPC Server port
+	WSPort     int    // WS-RPC Server port
+	WSEnabled  bool   // whether WS-RPC Server is enabled or not
+	TLSEnabled bool   // whether TLS support should be enabled on node or not
+}
+
+// Node represents running node (serves as a wrapper around P2P node)
 type Node struct {
-	geth    *node.Node    // reference to the running Geth node
-	started chan struct{} // channel to wait for node to start
-	config  *node.Config
+	config     *NodeConfig   // configuration used to create Status node
+	geth       *node.Node    // reference to the running Geth node
+	gethConfig *node.Config  // configuration used to create P2P node
+	started    chan struct{} // channel to wait for node to start
 }
 
 // Inited checks whether status node has been properly initialized
@@ -92,16 +101,20 @@ func (n *Node) Inited() bool {
 }
 
 // MakeNode create a geth node entity
-func MakeNode(dataDir string, rpcPort int) *Node {
+func MakeNode(config *NodeConfig) *Node {
 	glog.CopyStandardLogTo("INFO")
 	glog.SetToStderr(true)
 
+	dataDir := config.DataDir
 	if UseTestnet {
-		dataDir = filepath.Join(dataDir, "testnet")
+		dataDir = filepath.Join(config.DataDir, "testnet")
 	}
 
+	// exposed RPC APIs
+	exposedAPIs := "db,eth,net,web3,shh,personal,admin" // TODO remove "admin" on main net
+
 	// configure required node (should you need to update node's config, e.g. add bootstrap nodes, see node.Config)
-	config := &node.Config{
+	stackConfig := &node.Config{
 		DataDir:           dataDir,
 		UseLightweightKDF: true,
 		Name:              ClientIdentifier,
@@ -115,12 +128,16 @@ func MakeNode(dataDir string, rpcPort int) *Node {
 		MaxPeers:          MaxPeers,
 		MaxPendingPeers:   MaxPendingPeers,
 		HTTPHost:          node.DefaultHTTPHost,
-		HTTPPort:          rpcPort,
+		HTTPPort:          config.HTTPPort,
 		HTTPCors:          "*",
-		HTTPModules:       strings.Split("db,eth,net,web3,shh,personal,admin", ","), // TODO remove "admin" on main net
+		HTTPModules:       strings.Split(exposedAPIs, ","),
+		WSHost:            makeWSHost(config.WSEnabled),
+		WSPort:            config.WSPort,
+		WSOrigins:         "*",
+		WSModules:         strings.Split(exposedAPIs, ","),
 	}
 
-	stack, err := node.New(config)
+	stack, err := node.New(stackConfig)
 	if err != nil {
 		Fatalf(ErrNodeMakeFailure)
 	}
@@ -136,9 +153,10 @@ func MakeNode(dataDir string, rpcPort int) *Node {
 	}
 
 	return &Node{
-		geth:    stack,
-		started: make(chan struct{}),
-		config:  config,
+		geth:       stack,
+		gethConfig: stackConfig,
+		started:    make(chan struct{}),
+		config:     config,
 	}
 }
 
@@ -191,6 +209,15 @@ func activateShhService(stack *node.Node) error {
 	}
 
 	return nil
+}
+
+// makeWSHost returns WS-RPC Server host, given enabled/disabled flag
+func makeWSHost(wsEnabled bool) string {
+	if !wsEnabled {
+		return ""
+	}
+
+	return node.DefaultWSHost
 }
 
 // makeChainConfig reads the chain configuration from the database in the datadir.

--- a/geth/node_manager.go
+++ b/geth/node_manager.go
@@ -206,6 +206,23 @@ func (m *NodeManager) RestartNode() error {
 	return nil
 }
 
+// ResumeNode resumes previously stopped P2P node
+func (m *NodeManager) ResumeNode() error {
+	if m == nil || !m.NodeInited() {
+		return ErrInvalidGethNode
+	}
+
+	m.RunNode()
+	m.WaitNodeStarted()
+
+	// re-select the previously selected account
+	if err := ReSelectAccount(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ResetChainData purges chain data (by removing data directory). Safe to apply on running P2P node.
 func (m *NodeManager) ResetChainData() error {
 	if m == nil || !m.NodeInited() {
@@ -225,8 +242,9 @@ func (m *NodeManager) ResetChainData() error {
 		return err
 	}
 
-	m.RunNode()
-	m.WaitNodeStarted()
+	if err := m.ResumeNode(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/geth/node_manager.go
+++ b/geth/node_manager.go
@@ -29,16 +29,8 @@ type SelectedExtKey struct {
 	SubAccounts []accounts.Account
 }
 
-// NodeManagerConfig stores configuration options passed to constructor
-type NodeManagerConfig struct {
-	DataDir    string
-	RPCPort    int
-	TLSEnabled bool
-}
-
 // NodeManager manages Status node (which abstracts contained geth node)
 type NodeManager struct {
-	config          *NodeManagerConfig    // reference to passed configuration variables
 	node            *Node                 // reference to Status node
 	services        *NodeServiceStack     // default stack of services running on geth node
 	api             *node.PrivateAdminAPI // exposes collection of administrative API methods
@@ -72,10 +64,10 @@ var (
 )
 
 // CreateAndRunNode creates and starts running Geth node locally (exposing given RPC port along the way)
-func CreateAndRunNode(dataDir string, rpcPort int) error {
+func CreateAndRunNode(config *NodeConfig) error {
 	defer HaltOnPanic()
 
-	nodeManager := NewNodeManager(dataDir, rpcPort)
+	nodeManager := NewNodeManager(config)
 
 	if nodeManager.NodeInited() {
 		nodeManager.RunNode()
@@ -87,19 +79,14 @@ func CreateAndRunNode(dataDir string, rpcPort int) error {
 }
 
 // NewNodeManager makes new instance of node manager
-func NewNodeManager(dataDir string, rpcPort int) *NodeManager {
+func NewNodeManager(config *NodeConfig) *NodeManager {
 	createOnce.Do(func() {
 		nodeManagerInstance = &NodeManager{
-			config: &NodeManagerConfig{
-				DataDir:    dataDir,
-				RPCPort:    rpcPort,
-				TLSEnabled: false,
-			},
 			services: &NodeServiceStack{
 				jailedRequestQueue: NewJailedRequestsQueue(),
 			},
 		}
-		nodeManagerInstance.node = MakeNode(dataDir, rpcPort)
+		nodeManagerInstance.node = MakeNode(config)
 	})
 
 	return nodeManagerInstance
@@ -233,7 +220,7 @@ func (m *NodeManager) ResetChainData() error {
 		return err
 	}
 
-	chainDataDir := filepath.Join(m.node.config.DataDir, m.node.config.Name, "lightchaindata")
+	chainDataDir := filepath.Join(m.node.gethConfig.DataDir, m.node.gethConfig.Name, "lightchaindata")
 	if _, err := os.Stat(chainDataDir); os.IsNotExist(err) {
 		return err
 	}
@@ -258,7 +245,7 @@ func (m *NodeManager) StartNodeRPCServer() (bool, error) {
 		return false, ErrInvalidNodeAPI
 	}
 
-	config := m.node.config
+	config := m.node.gethConfig
 	modules := strings.Join(config.HTTPModules, ",")
 
 	return m.api.StartRPC(&config.HTTPHost, &config.HTTPPort, &config.HTTPCors, &modules)

--- a/geth/utils.go
+++ b/geth/utils.go
@@ -132,9 +132,9 @@ func PrepareTestNode() (err error) {
 	// start geth node and wait for it to initialize
 	err = CreateAndRunNode(&NodeConfig{
 		DataDir:    dataDir,
-		IPCEnabled: true,
+		IPCEnabled: false,
 		HTTPPort:   TestNodeHTTPPort, // to avoid conflicts with running app, using different port in tests
-		WSEnabled:  true,
+		WSEnabled:  false,
 		WSPort:     TestNodeWSPort, // ditto
 		TLSEnabled: false,
 	})

--- a/geth/utils.go
+++ b/geth/utils.go
@@ -28,6 +28,8 @@ var muPrepareTestNode sync.Mutex
 const (
 	TestDataDir         = "../.ethereumtest"
 	TestNodeSyncSeconds = 30
+	TestNodeHTTPPort    = 8645
+	TestNodeWSPort      = 8646
 )
 
 type NodeNotificationHandler func(jsonEvent string)
@@ -128,8 +130,13 @@ func PrepareTestNode() (err error) {
 	}
 
 	// start geth node and wait for it to initialize
-	// internally once.Do() is used, so call below is thread-safe
-	err = CreateAndRunNode(dataDir, 8546) // to avoid conflicts with running react-native app, run on different port
+	err = CreateAndRunNode(&NodeConfig{
+		DataDir:    dataDir,
+		HTTPPort:   TestNodeHTTPPort, // to avoid conflicts with running app, using different port in tests
+		WSEnabled:  true,
+		WSPort:     TestNodeWSPort, // ditto
+		TLSEnabled: false,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/geth/utils.go
+++ b/geth/utils.go
@@ -132,6 +132,7 @@ func PrepareTestNode() (err error) {
 	// start geth node and wait for it to initialize
 	err = CreateAndRunNode(&NodeConfig{
 		DataDir:    dataDir,
+		IPCEnabled: true,
 		HTTPPort:   TestNodeHTTPPort, // to avoid conflicts with running app, using different port in tests
 		WSEnabled:  true,
 		WSPort:     TestNodeWSPort, // ditto


### PR DESCRIPTION
- fixes #96
- merge https://github.com/status-im/status-go/pull/91 and https://github.com/status-im/status-go/pull/95 first (as this implementation depends on refactored implementation of transaction queue - only that updated implementation works correctly on stop/start events)
- new methods exposed: `StopNode()` and `ResumeNode()` (additional method for resuming is introduced due to fact that you do not need to provide `datadir` on resuming, so I've decided not implement resuming as part of `StartNode()`)
- both exposed methods and internal implementation are covered with tests (I made sure I double check  Whisper identity on resume)

**Note:**
- on `StopNode()` **all** Geth protocols stop (LES, IPC, HTTP etc)
- on `ResumeNode()` Geth protocols start again, previously selected ("logged in") account is injected into Whisper as identity