### PR TITLE
geth/params: status -> StatusIM

### DIFF
--- a/geth/params/defaults.go
+++ b/geth/params/defaults.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// DefaultClientIdentifier is client identifier to advertise over the network
-	DefaultClientIdentifier = "status"
+	DefaultClientIdentifier = "StatusIM"
 
 	// DefaultIPCFile is filename of exposed IPC RPC Server
 	DefaultIPCFile = "geth.ipc"


### PR DESCRIPTION
- restores application name, so that you can use previous accounts