### PR TITLE
geth/params: fixes issue with double "testnet" folder generation

### DIFF
--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/geth"
-	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/geth/jail"
+	"github.com/status-im/status-go/geth/params"
 )
 
 const (

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -2,12 +2,12 @@ package params
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
-	"math/big"
-	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
@@ -195,9 +195,6 @@ func (c *NodeConfig) populateChainConfig() {
 		c.ChainConfig.EIP158Block = params.TestnetChainConfig.EIP158Block
 		c.ChainConfig.ChainId = params.TestnetChainConfig.ChainId
 
-		if len(c.DataDir) > 0 {
-			c.DataDir = filepath.Join(c.DataDir, "testnet")
-		}
 		c.Genesis = core.DefaultTestnetGenesisBlock()
 	} else {
 		// Homestead fork

--- a/geth/params/config_test.go
+++ b/geth/params/config_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	gethparams "github.com/ethereum/go-ethereum/params"
 	"github.com/status-im/status-go/geth"
 	"github.com/status-im/status-go/geth/params"
-	gethparams "github.com/ethereum/go-ethereum/params"
 )
 
 var loadConfigTestCases = []struct {
@@ -60,40 +60,18 @@ var loadConfigTestCases = []struct {
 		},
 	},
 	{
-		`testnet subdirectory not used (while we are on Network = 3)`,
+		`check static DataDir passing`,
 		`{
 			"NetworkId": 3,
-			"DataDir": "$TMPDIR"
+			"DataDir": "/storage/emulated/0/ethereum/"
 		}`,
 		func(t *testing.T, dataDir string, nodeConfig *params.NodeConfig, err error) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if nodeConfig.DataDir != filepath.Join(dataDir, "testnet") {
-				t.Fatal("'testnet' subdirectory not used")
-			}
-
-			if !strings.Contains(nodeConfig.LightEthConfig.Genesis, "\"chainId\": 3") {
-				t.Fatal("wrong genesis")
-			}
-		},
-	},
-	{
-		`testnet subdirectory used (while we are on Network != 3)`,
-		`{
-			"NetworkId": 1,
-			"DataDir": "$TMPDIR"
-		}`,
-		func(t *testing.T, dataDir string, nodeConfig *params.NodeConfig, err error) {
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if nodeConfig.DataDir != dataDir {
-				t.Fatal("'testnet' subdirectory used")
-			}
-
-			if strings.Contains(nodeConfig.LightEthConfig.Genesis, "\"chainId\": 3") {
-				t.Fatal("wrong genesis")
+			expectedDataDir := "/storage/emulated/0/ethereum/"
+			if nodeConfig.DataDir != expectedDataDir {
+				t.Fatalf("incorrect DataDir used, expected: %v, got: %v", expectedDataDir, nodeConfig.DataDir)
 			}
 		},
 	},
@@ -139,7 +117,7 @@ var loadConfigTestCases = []struct {
 				t.Fatal("wrong WSEnabled")
 			}
 
-			if nodeConfig.IPCEnabled != true{
+			if nodeConfig.IPCEnabled != true {
 				t.Fatal("wrong IPCEnabled")
 			}
 			if nodeConfig.LightEthConfig.DatabaseCache != 64 {

--- a/geth/params/testdata/config.testnet.json
+++ b/geth/params/testdata/config.testnet.json
@@ -2,7 +2,7 @@
     "TestNet": true,
     "NetworkId": 3,
     "DataDir": "$TMPDIR",
-    "Name": "status",
+    "Name": "StatusIM",
     "Version": "$VERSION",
     "APIModules": "db,eth,net,web3,shh,personal,admin",
     "HTTPHost": "localhost",

--- a/geth/utils.go
+++ b/geth/utils.go
@@ -157,18 +157,18 @@ func PrepareTestNode() (err error) {
 	}
 
 	syncRequired := false
-	if _, err := os.Stat(filepath.Join(TestDataDir, "testnet")); os.IsNotExist(err) {
+	if _, err := os.Stat(TestDataDir); os.IsNotExist(err) {
 		syncRequired = true
 	}
 
 	// prepare node directory
-	if err := os.MkdirAll(filepath.Join(TestDataDir, "testnet", "keystore"), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Join(TestDataDir, "keystore"), os.ModePerm); err != nil {
 		glog.V(logger.Warn).Infoln("make node failed:", err)
 		return err
 	}
 
 	// import test account (with test ether on it)
-	dst := filepath.Join(TestDataDir, "testnet", "keystore", "test-account.pk")
+	dst := filepath.Join(TestDataDir, "keystore", "test-account.pk")
 	if _, err := os.Stat(dst); os.IsNotExist(err) {
 		err = CopyFile(dst, filepath.Join(RootDir, "data", "test-account.pk"))
 		if err != nil {


### PR DESCRIPTION
- fixes issue when double "testnet" was used in data folder name on real devices