### PR TITLE
Node signals + Start/stop resets config

### DIFF
--- a/geth/node.go
+++ b/geth/node.go
@@ -34,6 +34,12 @@ const (
 	// EventNodeStarted is triggered when underlying node is fully started
 	EventNodeStarted = "node.started"
 
+	// EventNodeStopped is triggered when underlying node is fully stopped
+	EventNodeStopped = "node.stopped"
+
+	// EventChainDataRemoved is triggered when node's chain data is removed
+	EventChainDataRemoved = "chaindata.removed"
+
 	// EventNodeCrashed is triggered when node crashes
 	EventNodeCrashed = "node.crashed"
 )

--- a/geth/node_manager_test.go
+++ b/geth/node_manager_test.go
@@ -1,11 +1,16 @@
 package geth_test
 
 import (
+	"context"
+	"io/ioutil"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/geth"
+	"github.com/status-im/status-go/geth/params"
 )
 
 var testConfig *geth.TestConfig
@@ -42,4 +47,96 @@ func TestResetChainData(t *testing.T) {
 
 	// now make sure that everything is intact
 	TestQueuedTransactions(t)
+}
+
+func TestNetworkChange(t *testing.T) {
+	var firstBlock struct {
+		Hash common.Hash `json:"hash"`
+	}
+
+	// Ropsten
+	dataDir1, err := ioutil.TempDir(os.TempDir(), "ropsten")
+	if err != nil {
+		t.Fatal(err)
+	}
+	configJSON1 := `{
+		"NetworkId": ` + strconv.Itoa(params.RopstenNetworkID) + `,
+		"DataDir": "` + dataDir1 + `",
+		"HTTPPort": 8845,
+		"LogEnabled": true,
+		"LogLevel": "INFO"
+	}`
+
+	// Rinkeby
+	dataDir2, err := ioutil.TempDir(os.TempDir(), "rinkeby")
+	if err != nil {
+		t.Fatal(err)
+	}
+	configJSON2 := `{
+		"NetworkId": ` + strconv.Itoa(params.RinkebyNetworkID) + `,
+		"DataDir": "` + dataDir2 + `",
+		"HTTPPort": 8845,
+		"LogEnabled": true,
+		"LogLevel": "INFO"
+	}`
+
+	// start Ropsten
+	nodeConfig, err := params.LoadNodeConfig(configJSON1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := geth.CreateAndRunNode(nodeConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	// allow some time to sync
+	time.Sleep(15 * time.Second)
+
+	// validate the hash of the first block
+	rpcClient, err := geth.NodeManagerInstance().Node().GethStack().Attach()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rpcClient.CallContext(context.Background(), &firstBlock, "eth_getBlockByNumber", "0x0", true); err != nil {
+		t.Fatal(err)
+	}
+	expectedHash := "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d"
+	if firstBlock.Hash.Hex() != expectedHash {
+		t.Errorf("unexpected genesis hash, expected: %v, got: %v", expectedHash, firstBlock.Hash.Hex())
+	}
+
+	// stop running node
+	if err := geth.NodeManagerInstance().StopNode(); err != nil {
+		t.Fatal(err)
+	}
+
+	// start Rinkeby
+	nodeConfig, err = params.LoadNodeConfig(configJSON2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := geth.CreateAndRunNode(nodeConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	// allow some time to sync
+	time.Sleep(15 * time.Second)
+
+	// validate the hash of the first block
+	rpcClient, err = geth.NodeManagerInstance().Node().GethStack().Attach()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rpcClient.CallContext(context.Background(), &firstBlock, "eth_getBlockByNumber", "0x0", true); err != nil {
+		t.Fatal(err)
+	}
+	expectedHash = "0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177"
+	if firstBlock.Hash.Hex() != expectedHash {
+		t.Errorf("unexpected genesis hash, expected: %v, got: %v", expectedHash, firstBlock.Hash.Hex())
+	}
+
+	// stop running node
+	if err := geth.NodeManagerInstance().StopNode(); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -109,7 +109,7 @@ type SwarmConfig struct {
 	Enabled bool
 }
 
-// BootCluster holds configuration for supporting boot cluster, which is a temporary
+// BootClusterConfig holds configuration for supporting boot cluster, which is a temporary
 // means for mobile devices to get connected to Ethereum network (UDP-based discovery
 // may not be available, so we need means to discover the network manually).
 type BootClusterConfig struct {
@@ -329,7 +329,7 @@ func (c *NodeConfig) LoadBootClusterNodes() ([]string, error) {
 	}
 
 	// parse JSON
-	if err := json.Unmarshal([]byte(configData), &bootnodes); err != nil {
+	if err := json.Unmarshal(configData, &bootnodes); err != nil {
 		return nil, err
 	}
 	return bootnodes, nil

--- a/geth/params/config_test.go
+++ b/geth/params/config_test.go
@@ -312,7 +312,7 @@ var loadConfigTestCases = []struct {
 					params.BootClusterConfigFile, nodeConfig.BootClusterConfig.ConfigFile)
 			}
 
-			if nodeConfig.BootClusterConfig.Enabled != true {
+			if !nodeConfig.BootClusterConfig.Enabled {
 				t.Fatal("boot cluster is expected to be enabled by default")
 			}
 
@@ -354,7 +354,7 @@ var loadConfigTestCases = []struct {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if nodeConfig.BootClusterConfig.Enabled != false {
+			if nodeConfig.BootClusterConfig.Enabled {
 				t.Fatal("boot cluster is expected to be disabled")
 			}
 		},
@@ -598,11 +598,11 @@ var loadConfigTestCases = []struct {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if nodeConfig.DevMode != true {
+			if !nodeConfig.DevMode {
 				t.Fatalf("unexpected dev mode: expected: %v, got: %v", true, nodeConfig.DevMode)
 			}
 
-			if nodeConfig.BootClusterConfig.Enabled != true {
+			if !nodeConfig.BootClusterConfig.Enabled {
 				t.Fatal("expected boot cluster to be enabled")
 			}
 
@@ -624,11 +624,11 @@ var loadConfigTestCases = []struct {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if nodeConfig.DevMode != false {
+			if nodeConfig.DevMode {
 				t.Fatalf("unexpected dev mode: expected: %v, got: %v", false, nodeConfig.DevMode)
 			}
 
-			if nodeConfig.BootClusterConfig.Enabled != true {
+			if !nodeConfig.BootClusterConfig.Enabled {
 				t.Fatal("expected boot cluster to be enabled")
 			}
 
@@ -651,11 +651,11 @@ var loadConfigTestCases = []struct {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if nodeConfig.DevMode != true {
+			if !nodeConfig.DevMode {
 				t.Fatalf("unexpected dev mode: expected: %v, got: %v", true, nodeConfig.DevMode)
 			}
 
-			if nodeConfig.BootClusterConfig.Enabled != true {
+			if !nodeConfig.BootClusterConfig.Enabled {
 				t.Fatal("expected boot cluster to be enabled")
 			}
 
@@ -678,11 +678,11 @@ var loadConfigTestCases = []struct {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if nodeConfig.DevMode != false {
+			if nodeConfig.DevMode {
 				t.Fatalf("unexpected dev mode: expected: %v, got: %v", false, nodeConfig.DevMode)
 			}
 
-			if nodeConfig.BootClusterConfig.Enabled != true {
+			if !nodeConfig.BootClusterConfig.Enabled {
 				t.Fatal("expected boot cluster to be enabled")
 			}
 
@@ -704,11 +704,11 @@ var loadConfigTestCases = []struct {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if nodeConfig.DevMode != true {
+			if !nodeConfig.DevMode {
 				t.Fatalf("unexpected dev mode: expected: %v, got: %v", true, nodeConfig.DevMode)
 			}
 
-			if nodeConfig.BootClusterConfig.Enabled != true {
+			if !nodeConfig.BootClusterConfig.Enabled {
 				t.Fatal("expected boot cluster to be enabled")
 			}
 
@@ -731,11 +731,11 @@ var loadConfigTestCases = []struct {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if nodeConfig.DevMode != false {
+			if nodeConfig.DevMode {
 				t.Fatalf("unexpected dev mode: expected: %v, got: %v", false, nodeConfig.DevMode)
 			}
 
-			if nodeConfig.BootClusterConfig.Enabled != true {
+			if !nodeConfig.BootClusterConfig.Enabled {
 				t.Fatal("expected boot cluster to be enabled")
 			}
 
@@ -757,11 +757,11 @@ var loadConfigTestCases = []struct {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if nodeConfig.DevMode != true {
+			if !nodeConfig.DevMode {
 				t.Fatalf("unexpected dev mode: expected: %v, got: %v", true, nodeConfig.DevMode)
 			}
 
-			if nodeConfig.BootClusterConfig.Enabled != true {
+			if !nodeConfig.BootClusterConfig.Enabled {
 				t.Fatal("expected boot cluster to be enabled")
 			}
 
@@ -784,11 +784,11 @@ var loadConfigTestCases = []struct {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if nodeConfig.DevMode != false {
+			if nodeConfig.DevMode {
 				t.Fatalf("unexpected dev mode: expected: %v, got: %v", false, nodeConfig.DevMode)
 			}
 
-			if nodeConfig.BootClusterConfig.Enabled != true {
+			if !nodeConfig.BootClusterConfig.Enabled {
 				t.Fatal("expected boot cluster to be enabled")
 			}
 

--- a/geth/utils.go
+++ b/geth/utils.go
@@ -65,7 +65,7 @@ func SetDefaultNodeNotificationHandler(fn NodeNotificationHandler) {
 
 // TriggerDefaultNodeNotificationHandler triggers default notification handler (helpful in tests)
 func TriggerDefaultNodeNotificationHandler(jsonEvent string) {
-	log.Info("notification received (default notification handler)", "event", jsonEvent)
+	log.Info("Notification received (default handler)", "event", jsonEvent)
 }
 
 // SendSignal sends application signal (JSON, normally) upwards to application (via default notification handler)


### PR DESCRIPTION
- closes #152 

### Overview

- signals added:
  - `node.stopped`
  - `chaindata.removed`
- updated `StartNode()` method, so that new node is forced on start

### Network Changing Walkthrough
In my [test](https://github.com/status-im/status-go/pull/165/files#diff-75be6536aeb0efacdf639585a645696fR52), I do the following:
1. Start stack with the following config: ``NetworkID = 3``
2. Attach RPC client, read the 0th block's hash (compare to what I expect)
3. Stop node (you should wait for `node.stopped` signal before staring the new node)
4. Start stack with `NetworkID = 4`
5. Check the first block's hash (which is obviously different for different nets)

### Limitations
I will do another review on this feature later on this week, as I'd also like to add some corner cases tests (like what happens if we call start node twice, w/o stopping it etc).

