### PR TITLE
Feature: remote logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ statusgo-ios-simulator-mainnet: xgo
 	@echo "iOS framework cross compilation done (mainnet)."
 
 ci:
+	build/env.sh go test -v -tags test ./cmd/statusd
 	build/env.sh go test -v ./geth/api
 	build/env.sh go test -v ./geth/common
 	build/env.sh go test -v ./geth/jail
@@ -110,7 +111,7 @@ lint:
 	@echo "Linter: gosimple\n--------------------"
 	@gometalinter --disable-all --deadline 45s --enable=gosimple extkeys cmd/... geth/... | grep -v -f ./static/config/linter_exclude_list.txt || echo "OK!"
 
-test:
+test: lint
 	@build/env.sh echo "mode: set" > coverage-all.out
 	build/env.sh go test -coverprofile=coverage.out -covermode=set ./geth/api
 	@build/env.sh tail -n +2 coverage.out >> coverage-all.out
@@ -124,7 +125,7 @@ test:
 	@build/env.sh tail -n +2 coverage.out >> coverage-all.out
 	build/env.sh go test -coverprofile=coverage.out -covermode=set ./extkeys
 	@build/env.sh tail -n +2 coverage.out >> coverage-all.out
-	build/env.sh go test -coverprofile=coverage.out -covermode=set ./cmd/statusd
+	build/env.sh go test -tags test -coverprofile=coverage.out -covermode=set ./cmd/statusd
 	@build/env.sh tail -n +2 coverage.out >> coverage-all.out
 	@build/env.sh go tool cover -html=coverage-all.out -o coverage.html
 	@build/env.sh go tool cover -func=coverage-all.out
@@ -160,7 +161,7 @@ test-extkeys:
 	@build/env.sh go tool cover -func=coverage.out
 
 test-cmd:
-	build/env.sh go test -v -coverprofile=coverage.out ./cmd/statusd
+	build/env.sh go test -v -tags test -coverprofile=coverage.out ./cmd/statusd
 	@build/env.sh go tool cover -html=coverage.out -o coverage.html
 	@build/env.sh go tool cover -func=coverage.out
 

--- a/cmd/statusd/faucetcmd.go
+++ b/cmd/statusd/faucetcmd.go
@@ -1,8 +1,10 @@
 package main
 
+import "C"
 import (
 	"fmt"
 
+	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/params"
 	"gopkg.in/urfave/cli.v1"
 )
@@ -20,6 +22,9 @@ var (
 
 // faucetCommandHandler handles `statusd faucet` command
 func faucetCommandHandler(ctx *cli.Context) error {
+	defer common.HaltOnPanic()
+	StartAPI(C.CString(params.ClientIdentifier), C.CString("INFO"))
+
 	config, err := parseFaucetCommandConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("can not parse config: %v", err)

--- a/cmd/statusd/lescmd.go
+++ b/cmd/statusd/lescmd.go
@@ -1,8 +1,10 @@
 package main
 
+import "C"
 import (
 	"fmt"
 
+	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/params"
 	"gopkg.in/urfave/cli.v1"
 )
@@ -24,6 +26,9 @@ var (
 
 // lesCommandHandler handles `statusd les` command
 func lesCommandHandler(ctx *cli.Context) error {
+	defer common.HaltOnPanic()
+	StartAPI(C.CString(params.ClientIdentifier), C.CString("INFO"))
+
 	config, err := parseLESCommandConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("can not parse config: %v", err)

--- a/cmd/statusd/library.go
+++ b/cmd/statusd/library.go
@@ -6,12 +6,30 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/status-im/status-go/geth/api"
 	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/params"
 )
 
+var statusAPI *api.StatusAPI
+
+//export StartAPI
+func StartAPI(host, logLevel *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	var err error
+	statusAPI, err = api.NewStatusAPI(C.GoString(host), C.GoString(logLevel))
+	log.Info("StatusAPI.StartAPI()", "host", C.GoString(host), "logLevel", C.GoString(logLevel))
+	return makeJSONResponse(err)
+}
+
 //export GenerateConfig
 func GenerateConfig(datadir *C.char, networkID C.int, devMode C.int) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.GenerateConfig()", "dataDir", C.GoString(datadir), "networkID", networkID, "devMode", devMode)
+
 	config, err := params.NewNodeConfig(C.GoString(datadir), uint64(networkID), devMode == 1)
 	if err != nil {
 		return makeJSONResponse(err)
@@ -27,6 +45,10 @@ func GenerateConfig(datadir *C.char, networkID C.int, devMode C.int) *C.char {
 
 //export StartNode
 func StartNode(configJSON *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.StartNode()", "config", C.GoString(configJSON))
+
 	config, err := params.LoadNodeConfig(C.GoString(configJSON))
 	if err != nil {
 		return makeJSONResponse(err)
@@ -38,54 +60,90 @@ func StartNode(configJSON *C.char) *C.char {
 
 //export StopNode
 func StopNode() *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.StopNode()")
+
 	_, err := statusAPI.StopNodeAsync()
 	return makeJSONResponse(err)
 }
 
 //export ResetChainData
 func ResetChainData() *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.ResetChainData()")
+
 	_, err := statusAPI.ResetChainDataAsync()
 	return makeJSONResponse(err)
 }
 
 //export CallRPC
 func CallRPC(inputJSON *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.CallRPC()", "input", C.GoString(inputJSON))
+
 	outputJSON := statusAPI.CallRPC(C.GoString(inputJSON))
 	return C.CString(outputJSON)
 }
 
 //export ResumeNode
 func ResumeNode() *C.char {
+	defer common.HaltOnPanic()
+
+	log.Warn("StatusAPI.ResumeNode()")
+
 	err := fmt.Errorf("%v: %v", common.ErrDeprecatedMethod.Error(), "ResumeNode")
 	return makeJSONResponse(err)
 }
 
 //export StopNodeRPCServer
 func StopNodeRPCServer() *C.char {
+	defer common.HaltOnPanic()
+
+	log.Warn("StatusAPI.StopNodeRPCServer()")
+
 	err := fmt.Errorf("%v: %v", common.ErrDeprecatedMethod.Error(), "StopNodeRPCServer")
 	return makeJSONResponse(err)
 }
 
 //export StartNodeRPCServer
 func StartNodeRPCServer() *C.char {
+	defer common.HaltOnPanic()
+
+	log.Warn("StatusAPI.StartNodeRPCServer()")
+
 	err := fmt.Errorf("%v: %v", common.ErrDeprecatedMethod.Error(), "StartNodeRPCServer")
 	return makeJSONResponse(err)
 }
 
 //export PopulateStaticPeers
 func PopulateStaticPeers() *C.char {
+	defer common.HaltOnPanic()
+
+	log.Warn("StatusAPI.PopulateStaticPeers()")
+
 	err := fmt.Errorf("%v: %v", common.ErrDeprecatedMethod.Error(), "PopulateStaticPeers")
 	return makeJSONResponse(err)
 }
 
 //export AddPeer
 func AddPeer(url *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Warn("StatusAPI.AddPeer()")
+
 	err := fmt.Errorf("%v: %v", common.ErrDeprecatedMethod.Error(), "AddPeer")
 	return makeJSONResponse(err)
 }
 
 //export CreateAccount
 func CreateAccount(password *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.CreateAccount()")
+
 	// This is equivalent to creating an account from the command line,
 	// just modified to handle the function arg passing
 	address, pubKey, mnemonic, err := statusAPI.CreateAccount(C.GoString(password))
@@ -108,6 +166,10 @@ func CreateAccount(password *C.char) *C.char {
 
 //export CreateChildAccount
 func CreateChildAccount(parentAddress, password *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.CreateChildAccount()", "parent", C.GoString(parentAddress))
+
 	address, pubKey, err := statusAPI.CreateChildAccount(C.GoString(parentAddress), C.GoString(password))
 
 	errString := ""
@@ -127,6 +189,10 @@ func CreateChildAccount(parentAddress, password *C.char) *C.char {
 
 //export RecoverAccount
 func RecoverAccount(password, mnemonic *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.RecoverAccount()")
+
 	address, pubKey, err := statusAPI.RecoverAccount(C.GoString(password), C.GoString(mnemonic))
 
 	errString := ""
@@ -147,12 +213,20 @@ func RecoverAccount(password, mnemonic *C.char) *C.char {
 
 //export VerifyAccountPassword
 func VerifyAccountPassword(keyStoreDir, address, password *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.VerifyAccountPassword()", "keyStoreDir", C.GoString(keyStoreDir), "address", C.GoString(address))
+
 	_, err := statusAPI.VerifyAccountPassword(C.GoString(keyStoreDir), C.GoString(address), C.GoString(password))
 	return makeJSONResponse(err)
 }
 
 //export Login
 func Login(address, password *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.Login()", "address", C.GoString(address))
+
 	// loads a key file (for a given address), tries to decrypt it using the password, to verify ownership
 	// if verified, purges all the previous identities from Whisper, and injects verified key as shh identity
 	err := statusAPI.SelectAccount(C.GoString(address), C.GoString(password))
@@ -161,6 +235,10 @@ func Login(address, password *C.char) *C.char {
 
 //export Logout
 func Logout() *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.Logout()")
+
 	// This is equivalent to clearing whisper identities
 	err := statusAPI.Logout()
 	return makeJSONResponse(err)
@@ -168,6 +246,10 @@ func Logout() *C.char {
 
 //export CompleteTransaction
 func CompleteTransaction(id, password *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.CompleteTransaction()", "id", C.GoString(id))
+
 	txHash, err := statusAPI.CompleteTransaction(C.GoString(id), C.GoString(password))
 
 	errString := ""
@@ -188,6 +270,10 @@ func CompleteTransaction(id, password *C.char) *C.char {
 
 //export CompleteTransactions
 func CompleteTransactions(ids, password *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.CompleteTransactions()", "ids", C.GoString(ids))
+
 	out := common.CompleteTransactionsResult{}
 	out.Results = make(map[string]common.CompleteTransactionResult)
 
@@ -209,6 +295,10 @@ func CompleteTransactions(ids, password *C.char) *C.char {
 
 //export DiscardTransaction
 func DiscardTransaction(id *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.DiscardTransaction()", "id", C.GoString(id))
+
 	err := statusAPI.DiscardTransaction(C.GoString(id))
 
 	errString := ""
@@ -228,6 +318,10 @@ func DiscardTransaction(id *C.char) *C.char {
 
 //export DiscardTransactions
 func DiscardTransactions(ids *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.DiscardTransactions()", "ids", C.GoString(ids))
+
 	out := common.DiscardTransactionsResult{}
 	out.Results = make(map[string]common.DiscardTransactionResult)
 
@@ -248,17 +342,29 @@ func DiscardTransactions(ids *C.char) *C.char {
 
 //export InitJail
 func InitJail(js *C.char) {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.InitJail()")
+
 	statusAPI.JailBaseJS(C.GoString(js))
 }
 
 //export Parse
 func Parse(chatID *C.char, js *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.Parse()")
+
 	res := statusAPI.JailParse(C.GoString(chatID), C.GoString(js))
 	return C.CString(res)
 }
 
 //export Call
 func Call(chatID *C.char, path *C.char, params *C.char) *C.char {
+	defer common.HaltOnPanic()
+
+	log.Info("StatusAPI.Call()", "chatID", C.GoString(chatID), "path", C.GoString(path), "params", C.GoString(params))
+
 	res := statusAPI.JailCall(C.GoString(chatID), C.GoString(path), C.GoString(params))
 	return C.CString(res)
 }

--- a/cmd/statusd/library_test.go
+++ b/cmd/statusd/library_test.go
@@ -1,3 +1,5 @@
+// +build test
+
 package main
 
 import (

--- a/cmd/statusd/library_utils.go
+++ b/cmd/statusd/library_utils.go
@@ -1,3 +1,5 @@
+// +build test
+
 package main
 
 import "C"

--- a/cmd/statusd/library_utils.go
+++ b/cmd/statusd/library_utils.go
@@ -1362,7 +1362,8 @@ func testJailFunctionCall(t *testing.T) bool {
 }
 
 func startTestNode(t *testing.T) <-chan struct{} {
-	StartAPI(C.CString("library_test.go"), C.CString("INFO"))
+	StartAPI(C.CString("UnitTest:Library"), C.CString("INFO"))
+	AttachLogger("UnitTest:Library", "INFO")
 
 	syncRequired := false
 	if _, err := os.Stat(TestDataDir); os.IsNotExist(err) {

--- a/cmd/statusd/library_utils.go
+++ b/cmd/statusd/library_utils.go
@@ -1362,6 +1362,8 @@ func testJailFunctionCall(t *testing.T) bool {
 }
 
 func startTestNode(t *testing.T) <-chan struct{} {
+	StartAPI(C.CString("library_test.go"), C.CString("INFO"))
+
 	syncRequired := false
 	if _, err := os.Stat(TestDataDir); os.IsNotExist(err) {
 		syncRequired = true

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/status-im/status-go/geth/api"
 	"github.com/status-im/status-go/geth/params"
 	"gopkg.in/urfave/cli.v1"
 )
@@ -15,7 +14,6 @@ var (
 	gitCommit  = "rely on linker: -ldflags -X main.GitCommit"
 	buildStamp = "rely on linker: -ldflags -X main.buildStamp"
 	app        = makeApp(gitCommit)
-	statusAPI  = api.NewStatusAPI()
 )
 
 var (
@@ -151,8 +149,8 @@ func makeNodeConfig(ctx *cli.Context) (*params.NodeConfig, error) {
 	nodeConfig.NodeKeyFile = ctx.GlobalString(NodeKeyFileFlag.Name)
 
 	if logLevel := ctx.GlobalString(LogLevelFlag.Name); len(logLevel) > 0 {
-		nodeConfig.LogEnabled = true
-		nodeConfig.LogLevel = logLevel
+		nodeConfig.LoggerConfig.Enabled = true
+		nodeConfig.LoggerConfig.Level = logLevel
 	}
 
 	return nodeConfig, nil

--- a/cmd/statusd/wnodecmd.go
+++ b/cmd/statusd/wnodecmd.go
@@ -1,5 +1,6 @@
 package main
 
+import "C"
 import (
 	"errors"
 	"fmt"
@@ -117,6 +118,9 @@ var (
 
 // version displays app version
 func wnode(ctx *cli.Context) error {
+	defer common.HaltOnPanic()
+	StartAPI(C.CString(params.ClientIdentifier), C.CString("INFO"))
+
 	config, err := makeWhisperNodeConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("can not parse config: %v", err)

--- a/geth/api/api.go
+++ b/geth/api/api.go
@@ -13,10 +13,29 @@ type StatusAPI struct {
 }
 
 // NewStatusAPI create a new StatusAPI instance
-func NewStatusAPI() *StatusAPI {
+func NewStatusAPI(hostName, logLevel string) (*StatusAPI, error) {
+	// setup logger
+	loggerConfig := &params.LoggerConfig{
+		Enabled:             true,
+		RemoteHostName:      hostName,
+		Level:               logLevel,
+		RemoteAPIKey:        params.LoggerRemoteAPIKey,
+		RemoteFlushInterval: 1,
+		RemoteBufferSize:    25,
+		LogToRemote:         true,
+		LogToStderr:         true,
+		LogToFile:           false,
+	}
+
+	nodeLogger, err := common.NewLogger(loggerConfig)
+	if err != nil {
+		return nil, err
+	}
+	nodeLogger.Attach()
+
 	return &StatusAPI{
 		b: NewStatusBackend(),
-	}
+	}, nil
 }
 
 // NodeManager returns reference to node manager

--- a/geth/api/api_test.go
+++ b/geth/api/api_test.go
@@ -26,7 +26,8 @@ type APITestSuite struct {
 
 func (s *APITestSuite) SetupTest() {
 	require := s.Require()
-	statusAPI := api.NewStatusAPI()
+	statusAPI, err := api.NewStatusAPI("UnitTest:API", "INFO")
+	require.NoError(err)
 	require.NotNil(statusAPI)
 	require.IsType(&api.StatusAPI{}, statusAPI)
 	s.api = statusAPI

--- a/geth/api/backend.go
+++ b/geth/api/backend.go
@@ -80,6 +80,7 @@ func (m *StatusBackend) StartNode(config *params.NodeConfig) (<-chan struct{}, e
 
 // onNodeStart does everything required to prepare backend
 func (m *StatusBackend) onNodeStart(nodeStarted <-chan struct{}, backendReady chan struct{}) {
+	defer common.HaltOnPanic()
 	<-nodeStarted
 
 	if err := m.registerHandlers(); err != nil {
@@ -113,6 +114,7 @@ func (m *StatusBackend) StopNode() (<-chan struct{}, error) {
 
 	backendStopped := make(chan struct{}, 1)
 	go func() {
+		defer common.HaltOnPanic()
 		<-nodeStopped
 		m.Lock()
 		m.nodeReady = nil

--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -16,14 +16,13 @@ import (
 	. "github.com/status-im/status-go/geth/testing"
 	"github.com/stretchr/testify/suite"
 )
-
-func TestBackendTestSuite(t *testing.T) {
-	suite.Run(t, new(BackendTestSuite))
-}
-
 type BackendTestSuite struct {
 	suite.Suite
 	backend *api.StatusBackend
+}
+
+func TestAPIBackend(t *testing.T) {
+	suite.Run(t, new(BackendTestSuite))
 }
 
 func (s *BackendTestSuite) SetupTest() {

--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/status-im/status-go/geth/testing"
 	"github.com/stretchr/testify/suite"
 )
+
 type BackendTestSuite struct {
 	suite.Suite
 	backend *api.StatusBackend

--- a/geth/common/logdna/logdna.go
+++ b/geth/common/logdna/logdna.go
@@ -1,0 +1,158 @@
+package logdna
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// IngestBaseURL is the base URL for the LogDNA ingest API.
+const IngestBaseURL = "https://logs.logdna.com/logs/ingest"
+
+// FlushInterval is the default interval at which logs are being flushed
+const FlushInterval = 15 * time.Second
+
+// BufferSize is the default size of buffer before logs are flushed
+const BufferSize = 50
+
+// Config is used to configure logging clients
+type Config struct {
+	APIKey        string        // LogDNA API access key
+	HostName      string        // unique ID describing the source of the incoming logs
+	AppName       string        // application name that generates logs (consider including app version)
+	FlushInterval time.Duration // how often to flush logs
+	BufferSize    int           // how many items to aggregate before flushing
+}
+
+// Client is a client to the LogDNA logging service.
+type Client struct {
+	sync.Mutex
+	config  *Config
+	payload payload
+	apiURL  *url.URL
+	stopped chan struct{} // channel to wait for termination
+}
+
+// logLine a single log line in the LogDNA ingest API JSON payload.
+type logLine struct {
+	Timestamp int64  `json:"timestamp"`
+	AppName   string `json:"app"`
+	Level     string `json:"level"`
+	Line      string `json:"line"`
+}
+
+// payload is the JSON payload that will be sent to the LogDNA ingest API.
+// it serves as buffer, and accumulates log lines (up until buffer size is
+// reached or flush interval is triggered)
+type payload struct {
+	Lines []logLine `json:"lines"`
+}
+
+// NewClient creates new client
+func NewClient(config *Config) (*Client, error) {
+	if config.BufferSize == 0 {
+		config.BufferSize = BufferSize
+	}
+
+	if config.FlushInterval == 0 {
+		config.FlushInterval = FlushInterval
+	}
+
+	apiURL, err := makeIngestURL(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		config:  config,
+		apiURL:  apiURL,
+		stopped: make(chan struct{}),
+	}, nil
+}
+
+// Log adds a single line to remote logger queue (actual delivery happens asynchronously)
+func (c *Client) Log(t time.Time, level string, line string) error {
+	logLine := logLine{
+		Timestamp: t.UnixNano() / 1000000,
+		AppName:   c.config.AppName,
+		Level:     level,
+		Line:      line,
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.payload.Lines = append(c.payload.Lines, logLine)
+	if len(c.payload.Lines) >= c.config.BufferSize {
+		go c.Flush()
+	}
+
+	return nil
+}
+
+// Flush dumps pending logs to remote service
+func (c *Client) Flush() error {
+	c.Lock()
+	defer c.Unlock()
+
+	if len(c.payload.Lines) == 0 { // nothing to flush
+		return nil
+	}
+
+	payloadJSON, err := json.Marshal(c.payload)
+	if err != nil {
+		return err
+	}
+	c.payload.Lines = nil
+
+	go func() {
+		resp, err := http.Post(c.apiURL.String(), "application/json", bytes.NewReader(payloadJSON))
+		if err != nil {
+			return
+		}
+		resp.Body.Close()
+	}()
+
+	return nil
+}
+
+// Start begins log flushing loop
+func (c *Client) Start() {
+	go func() {
+		for {
+			select {
+			case <-time.After(c.config.FlushInterval):
+				c.Flush()
+			case <-c.stopped:
+				c.stopped = make(chan struct{})
+				return
+			}
+		}
+	}()
+}
+
+// Stop terminates log flushing loop
+func (c *Client) Stop() {
+	close(c.stopped)
+}
+
+// makeIngestURL creates a new URL to LogDNA ingest API endpoint.
+// The URL is populated with API key and other required parameters.
+func makeIngestURL(config *Config) (*url.URL, error) {
+	u, err := url.Parse(IngestBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	u.User = url.User(config.APIKey)
+	values := url.Values{}
+	values.Set("hostname", config.HostName)
+	values.Set("now", strconv.FormatInt(time.Time{}.UnixNano(), 10))
+	u.RawQuery = values.Encode()
+
+	return u, nil
+}

--- a/geth/common/logger_test.go
+++ b/geth/common/logger_test.go
@@ -3,59 +3,57 @@ package common_test
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/params"
+	"github.com/stretchr/testify/suite"
 )
 
+type LoggerTestSuite struct {
+	suite.Suite
+}
+
 func TestLogger(t *testing.T) {
+	suite.Run(t, new(LoggerTestSuite))
+}
+
+func (s *LoggerTestSuite) TestLocalLogger() {
+	require := s.Require()
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "geth-logger-tests")
-	if err != nil {
-		t.Fatal(err)
-	}
-	//defer os.RemoveAll(tmpDir)
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
 
 	nodeConfig, err := params.NewNodeConfig(tmpDir, params.RopstenNetworkID, true)
-	if err != nil {
-		t.Fatal("cannot create config object")
-	}
-	nodeLogger, err := common.SetupLogger(nodeConfig)
-	if err != nil {
-		t.Fatal("cannot create logger object")
-	}
-	if nodeLogger != nil {
-		t.Fatalf("logger is not empty (while logs are disabled): %v", nodeLogger)
-	}
+	require.NoError(err, "cannot create config object")
 
-	nodeConfig.LogEnabled = true
-	nodeConfig.LogToStderr = false // just capture logs to file
-	nodeLogger, err = common.SetupLogger(nodeConfig)
-	if err != nil {
-		t.Fatal("cannot create logger object")
-	}
-	if nodeLogger == nil {
-		t.Fatal("logger is empty (while logs are enabled)")
-	}
+	loggerConfig := nodeConfig.LoggerConfig
+	nodeLogger, err := common.NewLogger(loggerConfig)
+	require.EqualError(err, common.ErrLoggerDisabled.Error())
+	require.Nil(nodeLogger, "logger is not empty (while logs are disabled)")
+
+	loggerConfig.Enabled = true
+	loggerConfig.LogToStderr = false // just capture logs to file
+	loggerConfig.LogToFile = true
+	nodeLogger, err = common.NewLogger(loggerConfig)
+	require.NoError(err, "cannot create logger object")
+	require.NotNil(nodeLogger, "logger is empty (while logs are enabled)")
+
+	require.NoError(nodeLogger.Attach()) // start capturing logs using our logger
 
 	validateLogText := func(expectedLogText string) {
-		logFilePath := filepath.Join(nodeConfig.DataDir, nodeConfig.LogFile)
-		logBytes, err := ioutil.ReadFile(logFilePath)
-		if err != nil {
-			panic(err)
-		}
+		logBytes, err := ioutil.ReadFile(loggerConfig.LogFile)
+		require.NoError(err)
+
 		logText := string(logBytes)
 		logText = strings.Trim(logText, "\n")
 		logText = logText[len(logText)-len(expectedLogText):] // as logs can be prepended with log info
 
-		if expectedLogText != logText {
-			t.Fatalf("invalid log, expected: [%s], got: [%s]", expectedLogText, string(logText))
-		} else {
-			t.Logf("log match found, expected: [%s], got: [%s]", expectedLogText, string(logText))
-		}
+		require.Equal(expectedLogText, logText)
+		s.T().Logf("log match found, expected: [%s], got: [%s]", expectedLogText, string(logText))
 	}
 
 	// sample log message
@@ -63,21 +61,58 @@ func TestLogger(t *testing.T) {
 	validateLogText(`msg="use log package"`)
 
 	// log using DEBUG log level (with appropriate level set)
-	nodeLogger.SetV("DEBUG")
+	nodeLogger.SetV(log.LvlDebug)
 	log.Info("logged DEBUG log level message")
 	validateLogText(`msg="logged DEBUG log level message"`)
 
 	// log using DEBUG log level (with appropriate level set)
-	nodeLogger.SetV("INFO")
+	nodeLogger.SetV(log.LvlInfo)
 	log.Info("logged INFO log level message")
 	validateLogText(`msg="logged INFO log level message"`)
 	log.Debug("logged DEBUG log level message")
 	validateLogText(`msg="logged INFO log level message"`) // debug level message is NOT logged
 
 	// stop logger and see if os.Stderr and gethlog continue functioning
-	if err = nodeLogger.Stop(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(nodeLogger.Detach())
 
 	log.Info("logging message: this message happens after custom logger has been stopped")
+}
+
+func (s *LoggerTestSuite) TestRemoteLogger() {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Dragons!!", "recovered", r)
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	require := s.Require()
+
+	loggerConfig := &params.LoggerConfig{
+		Enabled:             true,
+		RemoteHostName:      "LoggerTest",
+		Level:               "TRACE",
+		RemoteAPIKey:        params.LoggerRemoteAPIKey,
+		RemoteFlushInterval: 1,
+		RemoteBufferSize:    100,
+		LogToRemote:         true,
+		LogToStderr:         false,
+		LogToFile:           false,
+	}
+
+	nodeLogger, err := common.NewLogger(loggerConfig)
+	require.NoError(err)
+	require.NotNil(nodeLogger)
+	require.NoError(nodeLogger.Attach())
+
+	log.Trace("tracing the local object", "logger", nodeLogger)
+	log.Debug("debug message should provide some insite", "config", loggerConfig)
+	log.Info("test log")
+	log.Warn("I warn you it, the last time..")
+	log.Error("something strange here")
+
+	var nilLogger common.Logger
+	nilLogger.Attach() // dragons!!!
+
+	require.NoError(nodeLogger.Detach())
 }

--- a/geth/common/utils.go
+++ b/geth/common/utils.go
@@ -131,6 +131,15 @@ func ParseJSONArray(items string) ([]string, error) {
 	return parsedItems, nil
 }
 
+// HaltOnPanic recovers from panic, logs issue, and exits
+func HaltOnPanic() {
+	if r := recover(); r != nil {
+		log.Error("Runtime PANIC!!!", "error", r, "stack", string(debug.Stack()))
+		time.Sleep(5 * time.Second) // allow logger to flush logs
+		Fatalf(r)                   // os.exit(1) is called internally
+	}
+}
+
 // Fatalf is used to halt the execution.
 // When called the function prints stack end exits.
 // Failure is logged into both StdErr and StdOut.

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -207,6 +207,7 @@ func (jail *Jail) Send(chatID string, call otto.FunctionCall) (response otto.Val
 		errc := make(chan error, 1)
 		errc2 := make(chan error)
 		go func() {
+			defer common.HaltOnPanic()
 			errc2 <- <-errc
 		}()
 		errc <- client.Call(&result, req.Method, req.Params...)

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -26,6 +26,7 @@ type JailTestSuite struct {
 }
 
 func TestJail(t *testing.T) {
+	AttachLogger("UnitTest:Jail", "INFO")
 	suite.Run(t, new(JailTestSuite))
 }
 

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -20,13 +20,13 @@ const (
 
 var baseStatusJSCode = string(static.MustAsset("testdata/jail/status.js"))
 
-func TestJailTestSuite(t *testing.T) {
-	suite.Run(t, new(JailTestSuite))
-}
-
 type JailTestSuite struct {
 	BaseTestSuite
 	jail *jail.Jail
+}
+
+func TestJail(t *testing.T) {
+	suite.Run(t, new(JailTestSuite))
 }
 
 func (s *JailTestSuite) SetupTest() {

--- a/geth/node/accounts_test.go
+++ b/geth/node/accounts_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestAccountsTestSuite(t *testing.T) {
+func TestNodeAccounts(t *testing.T) {
 	suite.Run(t, new(AccountsTestSuite))
 }
 

--- a/geth/node/accounts_test.go
+++ b/geth/node/accounts_test.go
@@ -25,6 +25,7 @@ type AccountsTestSuite struct {
 }
 
 func (s *AccountsTestSuite) SetupTest() {
+	AttachLogger("UnitTest:Accounts", "INFO")
 	require := s.Require()
 	s.NodeManager = node.NewNodeManager()
 	require.NotNil(s.NodeManager)

--- a/geth/node/manager.go
+++ b/geth/node/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/rpc"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
+	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/params"
 )
 
@@ -76,7 +77,7 @@ func (m *NodeManager) startNode(config *params.NodeConfig) (<-chan struct{}, err
 	}
 	m.nodeStarted = make(chan struct{}, 1)
 	go func() {
-		defer HaltOnPanic()
+		defer common.HaltOnPanic()
 
 		// start underlying node
 		if err := ethNode.Start(); err != nil {
@@ -101,6 +102,7 @@ func (m *NodeManager) startNode(config *params.NodeConfig) (<-chan struct{}, err
 
 		// underlying node is started, every method can use it, we use it immediately
 		go func() {
+			defer common.HaltOnPanic()
 			if err := m.PopulateStaticPeers(); err != nil {
 				log.Error("Static peers population", "error", err)
 			}
@@ -150,6 +152,7 @@ func (m *NodeManager) stopNode() (<-chan struct{}, error) {
 
 	nodeStopped := make(chan struct{}, 1)
 	go func() {
+		defer common.HaltOnPanic()
 		<-m.nodeStopped // Status node is stopped (code after Wait() is executed)
 		log.Info("Ready to reset node")
 

--- a/geth/node/manager_test.go
+++ b/geth/node/manager_test.go
@@ -25,6 +25,7 @@ type ManagerTestSuite struct {
 }
 
 func TestNodeManager(t *testing.T) {
+	AttachLogger("UnitTest:Library", "INFO")
 	suite.Run(t, new(ManagerTestSuite))
 }
 

--- a/geth/node/manager_test.go
+++ b/geth/node/manager_test.go
@@ -20,12 +20,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestManagerTestSuite(t *testing.T) {
-	suite.Run(t, new(ManagerTestSuite))
-}
-
 type ManagerTestSuite struct {
 	BaseTestSuite
+}
+
+func TestNodeManager(t *testing.T) {
+	suite.Run(t, new(ManagerTestSuite))
 }
 
 func (s *ManagerTestSuite) SetupTest() {

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/whisper/mailserver"
 	"github.com/ethereum/go-ethereum/whisper/notifications"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
-	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/params"
 )
 
@@ -52,11 +51,6 @@ func MakeNode(config *params.NodeConfig) (*node.Node, error) {
 
 	// make sure keys directory exists
 	if err := os.MkdirAll(filepath.Join(config.KeyStoreDir), os.ModePerm); err != nil {
-		return nil, err
-	}
-
-	// setup logging
-	if _, err := common.SetupLogger(config); err != nil {
 		return nil, err
 	}
 

--- a/geth/node/rpc.go
+++ b/geth/node/rpc.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	jsonrpcVersion         = "2.0"
+	jsonrpcVersion = "2.0"
 )
 
 type jsonRequest struct {
@@ -68,6 +68,7 @@ func (c *RPCManager) Call(inputJSON string) string {
 	// allow HTTP requests to block w/o
 	outputJSON := make(chan string, 1)
 	go func() {
+		defer common.HaltOnPanic()
 		httpReq := httptest.NewRequest("POST", "/", strings.NewReader(inputJSON))
 		rr := httptest.NewRecorder()
 		server.ServeHTTP(rr, httpReq)

--- a/geth/node/whisper_test.go
+++ b/geth/node/whisper_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestWhisperTestSuite(t *testing.T) {
-	suite.Run(t, new(WhisperTestSuite))
-}
-
 type WhisperTestSuite struct {
 	BaseTestSuite
+}
+
+func TestWhisper(t *testing.T) {
+	suite.Run(t, new(WhisperTestSuite))
 }
 
 func (s *WhisperTestSuite) SetupTest() {

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -128,6 +128,41 @@ type BootClusterConfig struct {
 	ConfigFile string
 }
 
+// LoggerConfig logging options
+type LoggerConfig struct {
+	// Enabled flag specifies whether logging service is enabled at all
+	Enabled bool
+
+	// Level defines minimum log level. Valid names are "ERROR", "WARN", "INFO", "DEBUG", and "TRACE".
+	Level string
+
+	// LogFile is *absolute* path where logs get written to
+	LogFile string
+
+	// RemoteAPIKey access token/key to send logs to remote server
+	RemoteAPIKey string
+
+	// RemoteHostName uniquely identifies host that sends logs (useful for searching through aggregated logs)
+	RemoteHostName string
+
+	// RemoteFlushInterval specifies how many seconds to aggregate logs for,
+	// before they are flushed to the remote server
+	RemoteFlushInterval int
+
+	// RemoteBufferSize specifies how many log rows to aggregate, before they
+	// are flushed to the remote server
+	RemoteBufferSize int
+
+	// LogToFile defines whether logs should be sent to file specified by LogFile
+	LogToFile bool
+
+	// LogToRemote defines whether logs are allowed to be sent to remote server
+	LogToRemote bool
+
+	// LogToStderr defines whether logged info should also be output to os.Stderr
+	LogToStderr bool
+}
+
 // NodeConfig stores configuration options for a node
 type NodeConfig struct {
 	// DevMode is true when given configuration is to be used during development.
@@ -193,17 +228,8 @@ type NodeConfig struct {
 	// handshake phase, counted separately for inbound and outbound connections.
 	MaxPendingPeers int
 
-	// LogToFile specified whether logs should be saved into file
-	LogEnabled bool
-
-	// LogFile is filename where exposed logs get written to
-	LogFile string
-
-	// LogLevel defines minimum log level. Valid names are "ERROR", "WARNING", "INFO", "DEBUG", and "TRACE".
-	LogLevel string
-
-	// LogToStderr defines whether logged info should also be output to os.Stderr
-	LogToStderr bool
+	// LoggerConfig logging configuration
+	LoggerConfig *LoggerConfig `json:"LoggerConfig,"`
 
 	// BootClusterConfig extra configuration for supporting cluster
 	BootClusterConfig *BootClusterConfig `json:"BootClusterConfig,"`
@@ -233,9 +259,15 @@ func NewNodeConfig(dataDir string, networkID uint64, devMode bool) (*NodeConfig,
 		MaxPeers:        MaxPeers,
 		MaxPendingPeers: MaxPendingPeers,
 		IPCFile:         IPCFile,
-		LogFile:         LogFile,
-		LogLevel:        LogLevel,
-		LogToStderr:     LogToStderr,
+		LoggerConfig: &LoggerConfig{
+			RemoteHostName:      ClientIdentifier,
+			Level:               LoggerLogLevel,
+			LogFile:             filepath.Join(dataDir, LoggerLogFile),
+			LogToStderr:         true,
+			RemoteAPIKey:        LoggerRemoteAPIKey,
+			RemoteFlushInterval: LoggerRemoteFlushInterval,
+			RemoteBufferSize:    LoggerRemoteBufferSize,
+		},
 		LightEthConfig: &LightEthConfig{
 			Enabled:          true,
 			DatabaseCache:    DatabaseCache,

--- a/geth/params/defaults.go
+++ b/geth/params/defaults.go
@@ -55,18 +55,22 @@ const (
 	// TODO remove this hack, once CHT sync is implemented on LES side
 	CHTRootConfigURL = "https://gist.githubusercontent.com/farazdagi/a8d36e2818b3b2b6074d691da63a0c36/raw/"
 
-	// LogFile defines where to write logs to
-	LogFile = "geth.log"
+	// LoggerLogFile defines where to write logs to (wrt DataDir)
+	LoggerLogFile = "geth.log"
 
-	// LogLevel defines the minimum log level to report
-	LogLevel = "INFO"
+	// LoggerLogLevel defines the minimum log level to report
+	LoggerLogLevel = "INFO"
 
-	// LogLevelSuccinct defines the log level when only errors are reported.
-	// Useful when the default INFO level becomes too verbose.
-	LogLevelSuccinct = "ERROR"
+	// LoggerRemoteAPIKey remote API key to use, when sending logs to remote server
+	LoggerRemoteAPIKey = "d7dd521223bbd5d7d63a30b4d431bfbc"
 
-	// LogToStderr defines whether logged info should also be output to os.Stderr
-	LogToStderr = true
+	// LoggerRemoteFlushInterval specifies how many seconds to aggregate logs for,
+	// before they are flushed to the remote server
+	LoggerRemoteFlushInterval = 5
+
+	// LoggerRemoteBufferSize specifies how many log rows to aggregate, before they
+	// are flushed to the remote server
+	LoggerRemoteBufferSize = 25
 
 	// WhisperDataDir is directory where Whisper data is stored, relative to DataDir
 	WhisperDataDir = "wnode"

--- a/geth/params/testdata/config.mainnet.json
+++ b/geth/params/testdata/config.mainnet.json
@@ -17,10 +17,18 @@
     "TLSEnabled": false,
     "MaxPeers": 25,
     "MaxPendingPeers": 0,
-    "LogEnabled": false,
-    "LogFile": "geth.log",
-    "LogLevel": "INFO",
-    "LogToStderr": true,
+    "LoggerConfig": {
+        "Enabled": false,
+        "Level": "INFO",
+        "LogFile": "$TMPDIR/geth.log",
+        "RemoteAPIKey": "d7dd521223bbd5d7d63a30b4d431bfbc",
+        "RemoteHostName": "StatusIM",
+        "RemoteFlushInterval": 5,
+        "RemoteBufferSize": 25,
+        "LogToFile": false,
+        "LogToRemote": false,
+        "LogToStderr": true
+    },
     "BootClusterConfig": {
         "Enabled": true,
         "ConfigFile": "homestead.dev.json"

--- a/geth/params/testdata/config.rinkeby.json
+++ b/geth/params/testdata/config.rinkeby.json
@@ -17,10 +17,18 @@
     "TLSEnabled": false,
     "MaxPeers": 25,
     "MaxPendingPeers": 0,
-    "LogEnabled": false,
-    "LogFile": "geth.log",
-    "LogLevel": "INFO",
-    "LogToStderr": true,
+    "LoggerConfig": {
+        "Enabled": false,
+        "Level": "INFO",
+        "LogFile": "$TMPDIR/geth.log",
+        "RemoteAPIKey": "d7dd521223bbd5d7d63a30b4d431bfbc",
+        "RemoteHostName": "StatusIM",
+        "RemoteFlushInterval": 5,
+        "RemoteBufferSize": 25,
+        "LogToFile": false,
+        "LogToRemote": false,
+        "LogToStderr": true
+    },
     "BootClusterConfig": {
         "Enabled": true,
         "ConfigFile": "rinkeby.dev.json"

--- a/geth/params/testdata/config.ropsten.json
+++ b/geth/params/testdata/config.ropsten.json
@@ -17,10 +17,18 @@
     "TLSEnabled": false,
     "MaxPeers": 25,
     "MaxPendingPeers": 0,
-    "LogEnabled": false,
-    "LogFile": "geth.log",
-    "LogLevel": "INFO",
-    "LogToStderr": true,
+    "LoggerConfig": {
+        "Enabled": false,
+        "Level": "INFO",
+        "LogFile": "$TMPDIR/geth.log",
+        "RemoteAPIKey": "d7dd521223bbd5d7d63a30b4d431bfbc",
+        "RemoteHostName": "StatusIM",
+        "RemoteFlushInterval": 5,
+        "RemoteBufferSize": 25,
+        "LogToFile": false,
+        "LogToRemote": false,
+        "LogToStderr": true
+    },
     "BootClusterConfig": {
         "Enabled": true,
         "ConfigFile": "ropsten.dev.json"

--- a/geth/testing/testing.go
+++ b/geth/testing/testing.go
@@ -131,6 +131,29 @@ func MakeTestNodeConfig(networkID int) (*params.NodeConfig, error) {
 	return nodeConfig, nil
 }
 
+// AttachLogger creates and attaches test logger
+func AttachLogger(hostName, logLevel string) error {
+	loggerConfig := &params.LoggerConfig{
+		Enabled:             true,
+		RemoteHostName:      hostName,
+		Level:               logLevel,
+		RemoteAPIKey:        params.LoggerRemoteAPIKey,
+		RemoteFlushInterval: 1,
+		RemoteBufferSize:    25,
+		LogToRemote:         false,
+		LogToStderr:         true,
+		LogToFile:           false,
+	}
+
+	nodeLogger, err := common.NewLogger(loggerConfig)
+	if err != nil {
+		return err
+	}
+	nodeLogger.Attach()
+
+	return nil
+}
+
 // LoadFromFile is useful for loading test data, from testdata/filename into a variable
 // nolint: errcheck
 func LoadFromFile(filename string) string {

--- a/geth/testing/testing.go
+++ b/geth/testing/testing.go
@@ -116,8 +116,13 @@ func MakeTestNodeConfig(networkID int) (*params.NodeConfig, error) {
 		"DataDir": "` + filepath.Join(TestDataDir, TestNetworkNames[networkID]) + `",
 		"HTTPPort": ` + strconv.Itoa(TestConfig.Node.HTTPPort) + `,
 		"WSPort": ` + strconv.Itoa(TestConfig.Node.WSPort) + `,
-		"LogEnabled": true,
-		"LogLevel": "ERROR"
+		"LoggerConfig": {
+			"Enabled": true,
+			"LogLevel": "ERROR",
+			"LogToFile": false,
+			"LogToRemote": true,
+			"RemoteAPIKey": "` + params.LoggerRemoteAPIKey + `"
+		}
 	}`
 	nodeConfig, err := params.LoadNodeConfig(configJSON)
 	if err != nil {

--- a/vendor/github.com/ctrlrsf/logdna/README.md
+++ b/vendor/github.com/ctrlrsf/logdna/README.md
@@ -1,0 +1,43 @@
+# logdna
+
+A go library for sending logs to LogDNA via their ingest API.
+
+It works but is still under development and subject to change.
+
+## Installing
+
+```
+go get github.com/ctrlrsf/logdna/...
+```
+
+## Using library
+
+Godoc available at [https://godoc.org/github.com/ctrlrsf/logdna]()
+
+See source code of `logdna-stdin` command in this repo for an example.
+
+## Using logdna-stdin command
+
+`logdna-stdin` needs to read your LogDNA API key from environment variable `LOGDNA_API_KEY` so make sure its set:
+
+```
+export LOGDNA_API_KEY=xyz
+```
+
+Usage:
+
+```
+Usage of logdna-stdin:
+  -hostname string
+        hostname you want logs to appear from in LogDNA viewer
+  -log-file-name string
+        log file or app name you want logs to appear as in LogDNA viewer
+```
+
+To send logs to LogDNA just pipe anything that writes to stdout to the logdna-stdin command.
+
+```
+$ some_command | logdna-stdin --hostname test.host --log-file-name test.log
+```
+
+From LogDNA viewer you'll now see output from `some_command` in log file `test.log` and can filter by host `test.host`.

--- a/vendor/github.com/ctrlrsf/logdna/cmd/logdna-stdin/main.go
+++ b/vendor/github.com/ctrlrsf/logdna/cmd/logdna-stdin/main.go
@@ -1,0 +1,54 @@
+package main
+
+import "bufio"
+import "flag"
+import "fmt"
+import "os"
+import "time"
+import "github.com/ctrlrsf/logdna"
+
+func main() {
+	apiKey := os.Getenv("LOGDNA_API_KEY")
+
+	if apiKey == "" {
+		fmt.Println("Set LOGDNA_API_KEY env var")
+		os.Exit(1)
+	}
+
+	hostname := flag.String("hostname", "", "hostname you want logs to appear from in LogDNA viewer")
+	logFileName := flag.String("log-file-name", "", "log file or app name you want logs to appear as in LogDNA viewer")
+
+	flag.Parse()
+
+	if *hostname == "" {
+		fmt.Println("Error: hostname flag is required")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if *logFileName == "" {
+		fmt.Println("Error: log-file-name flag is required")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	cfg := logdna.Config{}
+	cfg.APIKey = apiKey
+	cfg.Hostname = *hostname
+	cfg.LogFile = *logFileName
+
+	client := logdna.NewClient(cfg)
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		client.Log(time.Time{}, scanner.Text())
+	}
+
+	if scanner.Err() != nil {
+		fmt.Fprintln(os.Stderr, "Error reading from stdin: %v", scanner.Err())
+		client.Flush()
+		os.Exit(1)
+	}
+
+	client.Flush()
+}

--- a/vendor/github.com/ctrlrsf/logdna/logdna.go
+++ b/vendor/github.com/ctrlrsf/logdna/logdna.go
@@ -1,0 +1,127 @@
+package logdna
+
+import "bytes"
+import "encoding/json"
+import "net/http"
+import "net/url"
+import "strconv"
+import "time"
+
+// IngestBaseURL is the base URL for the LogDNA ingest API.
+const IngestBaseURL = "https://logs.logdna.com/logs/ingest"
+
+// DefaultFlushLimit is the number of log lines before we flush to LogDNA
+const DefaultFlushLimit = 5000
+
+// Config is used by NewClient to configure new clients.
+type Config struct {
+	APIKey     string
+	LogFile    string
+	Hostname   string
+	FlushLimit int
+}
+
+// Client is a client to the LogDNA logging service.
+type Client struct {
+	config  Config
+	payload payloadJSON
+	apiURL  url.URL
+}
+
+// logLineJSON represents a log line in the LogDNA ingest API JSON payload.
+type logLineJSON struct {
+	Timestamp int64  `json:"timestamp"`
+	Line      string `json:"line"`
+	File      string `json:"file"`
+}
+
+// payloadJSON is the complete JSON payload that will be sent to the LogDNA
+// ingest API.
+type payloadJSON struct {
+	Lines []logLineJSON `json:"lines"`
+}
+
+// makeIngestURL creats a new URL to the a full LogDNA ingest API endpoint with
+// API key and requierd parameters.
+func makeIngestURL(cfg Config) url.URL {
+	u, _ := url.Parse(IngestBaseURL)
+
+	u.User = url.User(cfg.APIKey)
+	values := url.Values{}
+	values.Set("hostname", cfg.Hostname)
+	values.Set("now", strconv.FormatInt(time.Time{}.UnixNano(), 10))
+	u.RawQuery = values.Encode()
+
+	return *u
+}
+
+// NewClient returns a Client configured to send logs to the LogDNA ingest API.
+func NewClient(cfg Config) *Client {
+	if cfg.FlushLimit == 0 {
+		cfg.FlushLimit = DefaultFlushLimit
+	}
+
+	var client Client
+	client.apiURL = makeIngestURL(cfg)
+
+	client.config = cfg
+
+	return &client
+}
+
+// Log adds a new log line to Client's payload.
+//
+// To actually send the logs, Flush() needs to be called.
+//
+// Flush is called automatically if we reach the client's flush limit.
+func (c *Client) Log(t time.Time, msg string) {
+	if c.Size() == c.config.FlushLimit {
+		c.Flush()
+	}
+
+	// Ingest API wants timestamp in milliseconds so we need to round timestamp
+	// down from nanoseconds.
+	logLine := logLineJSON{
+		Timestamp: t.UnixNano() / 1000000,
+		Line:      msg,
+		File:      c.config.LogFile,
+	}
+	c.payload.Lines = append(c.payload.Lines, logLine)
+}
+
+// Size returns the number of lines waiting to be sent.
+func (c *Client) Size() int {
+	return len(c.payload.Lines)
+}
+
+// Flush sends any buffered logs to LogDNA and clears the buffered logs.
+func (c *Client) Flush() error {
+	// Return immediately if no logs to send
+	if c.Size() == 0 {
+		return nil
+	}
+
+	jsonPayload, err := json.Marshal(c.payload)
+	if err != nil {
+		return err
+	}
+
+	jsonReader := bytes.NewReader(jsonPayload)
+
+	resp, err := http.Post(c.apiURL.String(), "application/json", jsonReader)
+
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	c.payload = payloadJSON{}
+
+	return err
+}
+
+// Close closes the client. It also sends any buffered logs.
+func (c *Client) Close() error {
+	return c.Flush()
+}


### PR DESCRIPTION
- logger config has been aggregated under `LoggerConfig`:
```golang
// LoggerConfig logging options
type LoggerConfig struct {
	// Enabled flag specifies whether logging service is enabled at all
	Enabled bool

	// Level defines minimum log level. Valid names are "ERROR", "WARNING", "INFO", "DEBUG", and "TRACE".
	Level string

	// LogFile is *absolute* path where logs get written to
	LogFile string

	// RemoteAPIKey access token/key to send logs to remote server
	RemoteAPIKey string

	// LogToFile defines whether logs should be sent to file specified by LogFile
	LogToFile bool

	// LogToRemote defines whether logs are allowed to be sent to remote server
	LogToRemote bool

	// LogToStderr defines whether logged info should also be output to os.Stderr
	LogToStderr bool
}
```
- however, all this config is **IGNORED** for time being, as we need to set logging to start *before* `StartNode()` is called
- new method has been exposed: `StartAPI(hostname, logLevel)`. It is absolutely **crucial** that this is the first method called, before any other exposed methods are touched, as it sets up API + remote logger. Now, regarding `hostname` parameter: it should be unique session identifier, preferably short (like first 16 chars of hash of random user name we use). It will be extremely useful, as we will be able to filter logs by session, share sessions, analyze sessions:
![image](https://cloud.githubusercontent.com/assets/188194/26623777/7aea58bc-45f7-11e7-804b-2b219dbd365f.png)
- finally about `logLevel`, it is on of "ERROR", "WARNING", "INFO", "DEBUG", and "TRACE" (with "INFO" being default we should start from)