### PR TITLE
Extensions for otto.Otto VM

### DIFF
--- a/cmd/statusd/library.go
+++ b/cmd/statusd/library.go
@@ -9,6 +9,8 @@ import (
 	"github.com/status-im/status-go/geth"
 	"github.com/status-im/status-go/geth/jail"
 	"github.com/status-im/status-go/geth/params"
+
+	_ "github.com/status-im/status-go/geth/jail/extensions/console" // Register console.log
 )
 
 //export CreateAccount

--- a/geth/jail/extensions/console/console.go
+++ b/geth/jail/extensions/console/console.go
@@ -1,0 +1,141 @@
+package console
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/robertkrimen/otto"
+	"github.com/status-im/status-go/geth"
+	"github.com/status-im/status-go/geth/jail/extensions"
+)
+
+var (
+	// Stdout defines the default writer for the console.log
+	// delivery call.
+	Stdout io.Writer = os.Stdout
+
+	// EventConsoleLog defines the event type for the console.log call.
+	EventConsoleLog = "vm.console.log"
+
+	// EventConsoleWarn defines the event type for the console.debug call.
+	EventConsoleWarn = "vm.console.warn"
+
+	// EventConsoleDebug defines the event type for the console.debug call.
+	EventConsoleDebug = "vm.console.debug"
+
+	// EventConsoleError defines the event type for the console.error call.
+	EventConsoleError = "vm.console.error"
+
+	_ = extensions.Register(func(vm *otto.Otto) error {
+		return vm.Set("console", map[string]interface{}{
+			"log":   consoleLog,
+			"error": consoleError,
+			"debug": consoleDebug,
+			"warn":  consoleWarn,
+		})
+	})
+)
+
+// consoleLog provides the function caller for handling console.log
+// calls as replacement for the default console.log function within a
+// otto.Otto VM instance.
+func consoleLog(fn otto.FunctionCall) otto.Value {
+
+	// Record provided values into store for delviery.
+	geth.SendSignal(geth.SignalEnvelope{
+		Type:  EventConsoleLog,
+		Event: convertArgs(fn.ArgumentList),
+	})
+
+	// Next print out the giving values.
+	handleConsole("console.log: %s", Stdout, fn.ArgumentList)
+
+	return otto.UndefinedValue()
+}
+
+// consoleWarn provides the function caller for handling console.warn
+// calls as replacement for the default console.log function within a
+// otto.Otto VM instance.
+func consoleWarn(fn otto.FunctionCall) otto.Value {
+
+	// Record provided values into store for delviery.
+	geth.SendSignal(geth.SignalEnvelope{
+		Type:  EventConsoleWarn,
+		Event: convertArgs(fn.ArgumentList),
+	})
+
+	// Next print out the giving values.
+	handleConsole("console.warn: %s", Stdout, fn.ArgumentList)
+
+	return otto.UndefinedValue()
+}
+
+// consoleDebug provides the function caller for handling console.debug
+// calls as replacement for the default console.Error function within a
+// otto.Otto VM instance.
+func consoleDebug(fn otto.FunctionCall) otto.Value {
+
+	// Record provided values into store for delviery.
+	geth.SendSignal(geth.SignalEnvelope{
+		Type:  EventConsoleDebug,
+		Event: convertArgs(fn.ArgumentList),
+	})
+
+	// Next print out the giving values.
+	handleConsole("console.debug: %s", Stdout, fn.ArgumentList)
+
+	return otto.UndefinedValue()
+}
+
+// consoleError provides the function caller for handling console.error
+// calls as replacement for the default console.Error function within a
+// otto.Otto VM instance.
+func consoleError(fn otto.FunctionCall) otto.Value {
+
+	// Record provided values into store for delviery.
+	geth.SendSignal(geth.SignalEnvelope{
+		Type:  EventConsoleLog,
+		Event: convertArgs(fn.ArgumentList),
+	})
+
+	// Next print out the giving values.
+	handleConsole("console.error: %s", Stdout, fn.ArgumentList)
+
+	return otto.UndefinedValue()
+}
+
+// convertArgs attempts to convert otto.Values into proper go types else
+// uses original.
+func convertArgs(argumentList []otto.Value) []interface{} {
+	var items []interface{}
+
+	for _, arg := range argumentList {
+		realArg, err := arg.Export()
+		if err != nil {
+			items = append(items, arg)
+			continue
+		}
+
+		items = append(items, realArg)
+	}
+
+	return items
+}
+
+// handleConsole takes the giving otto.Values and transform as
+// needed into the appropriate writer.
+func handleConsole(tag string, writer io.Writer, args []otto.Value) {
+	fmt.Fprintf(writer, tag, formatForConsole(args))
+}
+
+// formatForConsole handles conversion of giving otto.Values into
+// string counter part.
+func formatForConsole(argumentList []otto.Value) string {
+	output := []string{}
+	for _, argument := range argumentList {
+		output = append(output, fmt.Sprintf("%v", argument))
+	}
+	return strings.Join(output, " ")
+}

--- a/geth/jail/extensions/console/console.go
+++ b/geth/jail/extensions/console/console.go
@@ -30,10 +30,7 @@ var (
 
 	_ = extensions.Register(func(vm *otto.Otto) error {
 		return vm.Set("console", map[string]interface{}{
-			"log":   consoleLog,
-			"error": consoleError,
-			"debug": consoleDebug,
-			"warn":  consoleWarn,
+			"log": consoleLog,
 		})
 	})
 )

--- a/geth/jail/extensions/extensions.go
+++ b/geth/jail/extensions/extensions.go
@@ -1,0 +1,38 @@
+package extensions
+
+import (
+	"github.com/robertkrimen/otto"
+)
+
+// ExtensionFunction types a function type which is used to define
+// given extensions to be registered.
+type ExtensionFunction func(*otto.Otto) error
+
+// exts defines a package level variable to hold registered otto extensions.
+var exts = struct {
+	extensions []ExtensionFunction
+}{
+	extensions: make([]ExtensionFunction, 0),
+}
+
+// Register adds the giving extension into the appropriate extension store.
+// Overrides previous key if available.
+// Panics if the giving extension is not a valid convertible
+// type for otto.ToValue.
+func Register(extension ExtensionFunction) bool {
+	exts.extensions = append(exts.extensions, extension)
+	return true
+}
+
+// ActivateExtensions adds all the registered extensions to the Otto instance.
+// It will immediately return an error if any of the extensions fails to
+// register.
+func ActivateExtensions(vm *otto.Otto) error {
+	for _, extension := range exts.extensions {
+		if err := extension(vm); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/geth/jail/extensions/extensions_test.go
+++ b/geth/jail/extensions/extensions_test.go
@@ -24,66 +24,6 @@ type ExtensionsTestSuite struct {
 	vm *otto.Otto
 }
 
-// TestConsoleError will validate the operations of the console.error extension
-// for the otto vm.
-func (s *ExtensionsTestSuite) TestConsoleError() {
-	require := s.Require()
-	written := "Bob Marley"
-
-	var customWriter bytes.Buffer
-
-	console.Stdout = &customWriter
-
-	_, err := s.vm.Run(fmt.Sprintf(`
-		console.error(%q);
-	`, written))
-
-	require.NoError(err)
-
-	require.NotEmpty(&customWriter)
-	require.Equal(written, strings.TrimPrefix(customWriter.String(), "console.error: "))
-}
-
-// TestConsoleDebug will validate the operations of the console.debug extension
-// for the otto vm.
-func (s *ExtensionsTestSuite) TestConsoleDebug() {
-	require := s.Require()
-	written := "Bob Marley"
-
-	var customWriter bytes.Buffer
-
-	console.Stdout = &customWriter
-
-	_, err := s.vm.Run(fmt.Sprintf(`
-		console.debug(%q);
-	`, written))
-
-	require.NoError(err)
-
-	require.NotEmpty(&customWriter)
-	require.Equal(written, strings.TrimPrefix(customWriter.String(), "console.debug: "))
-}
-
-// TestConsoleWarn will validate the operations of the console.warn extension
-// for the otto vm.
-func (s *ExtensionsTestSuite) TestConsoleWarn() {
-	require := s.Require()
-	written := "Bob Marley"
-
-	var customWriter bytes.Buffer
-
-	console.Stdout = &customWriter
-
-	_, err := s.vm.Run(fmt.Sprintf(`
-		console.warn(%q);
-	`, written))
-
-	require.NoError(err)
-
-	require.NotEmpty(&customWriter)
-	require.Equal(written, strings.TrimPrefix(customWriter.String(), "console.warn: "))
-}
-
 // TestConsoleLog will validate the operations of the console.log extension
 // for the otto vm.
 func (s *ExtensionsTestSuite) TestConsoleLog() {

--- a/geth/jail/extensions/extensions_test.go
+++ b/geth/jail/extensions/extensions_test.go
@@ -1,0 +1,157 @@
+package extensions_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/robertkrimen/otto"
+	"github.com/status-im/status-go/geth"
+	"github.com/status-im/status-go/geth/jail/extensions"
+	"github.com/status-im/status-go/geth/jail/extensions/console"
+	"github.com/stretchr/testify/suite"
+)
+
+// TestExtensions validates the behaviour of giving conole extensions.
+func TestExtensions(t *testing.T) {
+	suite.Run(t, new(ExtensionsTestSuite))
+}
+
+type ExtensionsTestSuite struct {
+	suite.Suite
+	vm *otto.Otto
+}
+
+// TestConsoleError will validate the operations of the console.error extension
+// for the otto vm.
+func (s *ExtensionsTestSuite) TestConsoleError() {
+	require := s.Require()
+	written := "Bob Marley"
+
+	var customWriter bytes.Buffer
+
+	console.Stdout = &customWriter
+
+	_, err := s.vm.Run(fmt.Sprintf(`
+		console.error(%q);
+	`, written))
+
+	require.NoError(err)
+
+	require.NotEmpty(&customWriter)
+	require.Equal(written, strings.TrimPrefix(customWriter.String(), "console.error: "))
+}
+
+// TestConsoleDebug will validate the operations of the console.debug extension
+// for the otto vm.
+func (s *ExtensionsTestSuite) TestConsoleDebug() {
+	require := s.Require()
+	written := "Bob Marley"
+
+	var customWriter bytes.Buffer
+
+	console.Stdout = &customWriter
+
+	_, err := s.vm.Run(fmt.Sprintf(`
+		console.debug(%q);
+	`, written))
+
+	require.NoError(err)
+
+	require.NotEmpty(&customWriter)
+	require.Equal(written, strings.TrimPrefix(customWriter.String(), "console.debug: "))
+}
+
+// TestConsoleWarn will validate the operations of the console.warn extension
+// for the otto vm.
+func (s *ExtensionsTestSuite) TestConsoleWarn() {
+	require := s.Require()
+	written := "Bob Marley"
+
+	var customWriter bytes.Buffer
+
+	console.Stdout = &customWriter
+
+	_, err := s.vm.Run(fmt.Sprintf(`
+		console.warn(%q);
+	`, written))
+
+	require.NoError(err)
+
+	require.NotEmpty(&customWriter)
+	require.Equal(written, strings.TrimPrefix(customWriter.String(), "console.warn: "))
+}
+
+// TestConsoleLog will validate the operations of the console.log extension
+// for the otto vm.
+func (s *ExtensionsTestSuite) TestConsoleLog() {
+	require := s.Require()
+	written := "Bob Marley"
+
+	var customWriter bytes.Buffer
+
+	console.Stdout = &customWriter
+
+	_, err := s.vm.Run(fmt.Sprintf(`
+		console.log(%q);
+	`, written))
+
+	require.NoError(err)
+
+	require.NotEmpty(&customWriter)
+	require.Equal(written, strings.TrimPrefix(customWriter.String(), "console.log: "))
+}
+
+// TestObjectLogging will validate the operations of the console.log extension
+// when capturing objects declared from javascript.
+func (s *ExtensionsTestSuite) TestObjectLogging() {
+	require := s.Require()
+	var customWriter bytes.Buffer
+
+	geth.SetDefaultNodeNotificationHandler(func(event string) {
+
+		var eventReceived struct {
+			Type  string `json:"type"`
+			Event []struct {
+				Age  int    `json:"age"`
+				Name string `json:"name"`
+			} `json:"event"`
+		}
+
+		err := json.Unmarshal([]byte(event), &eventReceived)
+		require.NoError(err)
+
+		require.Equal(eventReceived.Type, "vm.console.log")
+		require.NotEmpty(eventReceived.Event)
+
+		objectReceived := eventReceived.Event[0]
+		require.Equal(objectReceived.Age, 24)
+		require.Equal(objectReceived.Name, "bob")
+	})
+
+	console.Stdout = &customWriter
+
+	_, err := s.vm.Run(`
+		var person = {name:"bob", age:24}
+		console.log(person);
+	`)
+
+	require.NoError(err)
+	require.NotEmpty(&customWriter)
+
+}
+
+func (s *ExtensionsTestSuite) SetupTest() {
+	vm := otto.New()
+	require := s.Require()
+
+	require.NotNil(vm)
+	require.IsType(&otto.Otto{}, vm)
+
+	err := extensions.ActivateExtensions(vm)
+	require.NoError(err)
+
+	s.vm = vm
+}


### PR DESCRIPTION
Commit contains the necessary structures to provide define custom
extensions that allows us hook into specific functions with the JS
VM for otto. This capability will allow us capture data logs and more.

Commit also adds testify to vendor.

Commit related to issue #179