### PR TITLE
Addition of Valid Config Test Cases

### DIFF
--- a/cmd/statusd/library.go
+++ b/cmd/statusd/library.go
@@ -25,6 +25,12 @@ func GenerateConfig(datadir *C.char, networkID C.int, devMode C.int) *C.char {
 	return C.CString(string(outBytes))
 }
 
+//export ValidateConfig
+func ValidateConfig(configJSON *C.char) *C.char {
+	_, err := params.LoadNodeConfig(C.GoString(configJSON))
+	return makeJSONResponse(err)
+}
+
 //export StartNode
 func StartNode(configJSON *C.char) *C.char {
 	config, err := params.LoadNodeConfig(C.GoString(configJSON))

--- a/cmd/statusd/utils.go
+++ b/cmd/statusd/utils.go
@@ -44,6 +44,10 @@ func testExportedAPI(t *testing.T, done chan struct{}) {
 		fn   func(t *testing.T) bool
 	}{
 		{
+			"validate default configuration",
+			testValidConfig,
+		},
+		{
 			"check default configuration",
 			testGetDefaultConfig,
 		},
@@ -148,6 +152,21 @@ func testVerifyAccountPassword(t *testing.T) bool {
 	}
 	if response.Error != "" {
 		t.Errorf("unexpected error: %s", response.Error)
+		return false
+	}
+
+	return true
+}
+
+func testValidConfig(t *testing.T) bool {
+	config, err := params.LoadNodeConfig(nodeConfigJSON)
+	if err != nil {
+		t.Errorf("invalid configuration:  does not match config standards: %+q", err)
+		return false
+	}
+
+	if config.DataDir != TestDataDir {
+		t.Errorf("Loaded config.DataDir does not expected: %q", TestDataDir)
 		return false
 	}
 

--- a/cmd/statusd/utils.go
+++ b/cmd/statusd/utils.go
@@ -159,14 +159,17 @@ func testVerifyAccountPassword(t *testing.T) bool {
 }
 
 func testValidConfig(t *testing.T) bool {
-	config, err := params.LoadNodeConfig(nodeConfigJSON)
-	if err != nil {
-		t.Errorf("invalid configuration:  does not match config standards: %+q", err)
+	response := ValidateConfig(C.CString(nodeConfigJSON))
+
+	var res common.APIResponse
+
+	if err := json.Unmarshal([]byte(C.GoString(response)), &res); err != nil {
+		t.Errorf("Invalid response: Expected common.APIResponse type: %+q", err)
 		return false
 	}
 
-	if config.DataDir != TestDataDir {
-		t.Errorf("Loaded config.DataDir does not expected: %q", TestDataDir)
+	if len(res.Error) != 0 {
+		t.Errorf("Invalid configuration: Expected no error for config: %+q", res.Error)
 		return false
 	}
 

--- a/geth/params/config_test.go
+++ b/geth/params/config_test.go
@@ -21,6 +21,25 @@ var loadConfigTestCases = []struct {
 	validator  func(t *testing.T, dataDir string, nodeConfig *params.NodeConfig, err error)
 }{
 	{
+		`valid input configuration`,
+		`{
+			"NetworkId": 3,
+			"DataDir": "$TMPDIR",
+			"Name": "TestStatusNode",
+			"WSPort": 8546,
+			"IPCEnabled": true,
+			"WSEnabled": false,
+			"LightEthConfig": {
+				"DatabaseCache": 64
+			}
+		}`,
+		func(t *testing.T, dataDir string, nodeConfig *params.NodeConfig, err error) {
+			if err != nil {
+				t.Fatalf("error is not expected, check config: %+q", err)
+			}
+		},
+	},
+	{
 		`invalid input configuration`,
 		`{
 			"NetworkId": 3


### PR DESCRIPTION
PR addes two test cases to existing tests to validate `NodeConfig` which is used for user defined configuration. The following areas are affected:

- `cmd/statusd/utils.go`

- `geth/params/config_test.go`


PR is related to issue #149.
Please review @farazdagi.