### PR TITLE
PR for Jail sendAsync: Add method to jail sendAsync with tests

### DIFF
--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -1,8 +1,6 @@
 package jail
 
 import (
-	"fmt"
-
 	"github.com/robertkrimen/otto"
 	"github.com/status-im/status-go/geth"
 )
@@ -74,8 +72,6 @@ func registerHandlers(jail *Jail, vm *otto.Otto, chatID string) (err error) {
 // makeAsyncSendHandler returns jeth.sendAsync() handler.
 func makeAsyncSendHandler(jail *Jail, chatID string) func(call otto.FunctionCall) (response otto.Value) {
 	return func(call otto.FunctionCall) (response otto.Value) {
-		fmt.Printf("Delivering response to goroutine: %+q\n", chatID)
-
 		go func() {
 			res := jail.Send(chatID, call)
 
@@ -92,7 +88,6 @@ func makeAsyncSendHandler(jail *Jail, chatID string) func(call otto.FunctionCall
 // makeSendHandler returns jeth.send() and jeth.sendAsync() handler
 func makeSendHandler(jail *Jail, chatID string) func(call otto.FunctionCall) (response otto.Value) {
 	return func(call otto.FunctionCall) (response otto.Value) {
-		fmt.Printf("Delivering response to flat: %+q\n", chatID)
 		return jail.Send(chatID, call)
 	}
 }

--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -27,7 +27,7 @@ func registerHandlers(jail *Jail, vm *otto.Otto, chatID string) (err error) {
 	}
 
 	// register sendAsync handler
-	if err = registerHandler("sendAsync", makeSendHandler(jail, chatID)); err != nil {
+	if err = registerHandler("sendAsync", makeAsyncSendHandler(jail, chatID)); err != nil {
 		return err
 	}
 
@@ -67,6 +67,22 @@ func registerHandlers(jail *Jail, vm *otto.Otto, chatID string) (err error) {
 	}
 
 	return nil
+}
+
+// makeAsyncSendHandler returns jeth.sendAsync() handler.
+func makeAsyncSendHandler(jail *Jail, chatID string) func(call otto.FunctionCall) (response otto.Value) {
+	return func(call otto.FunctionCall) (response otto.Value) {
+		go func() {
+			res := jail.Send(chatID, call)
+
+			// Deliver response if callback is provided.
+			if call.Otto != nil {
+				newResultResponse(call, res)
+			}
+		}()
+
+		return otto.UndefinedValue()
+	}
 }
 
 // makeSendHandler returns jeth.send() and jeth.sendAsync() handler

--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -1,6 +1,8 @@
 package jail
 
 import (
+	"fmt"
+
 	"github.com/robertkrimen/otto"
 	"github.com/status-im/status-go/geth"
 )
@@ -73,11 +75,14 @@ func registerHandlers(jail *Jail, vm *otto.Otto, chatID string) (err error) {
 func makeAsyncSendHandler(jail *Jail, chatID string) func(call otto.FunctionCall) (response otto.Value) {
 	return func(call otto.FunctionCall) (response otto.Value) {
 		go func() {
+			fmt.Printf("Delivering response: %+q\n", chatID)
 			res := jail.Send(chatID, call)
 
 			// Deliver response if callback is provided.
+			fmt.Printf("Deliver response: %+q\n", res)
 			if call.Otto != nil {
-				newResultResponse(call, res)
+				newResultResponse(call.Otto, res)
+				fmt.Printf("Delivered response: %+q\n", res)
 			}
 		}()
 

--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -74,8 +74,9 @@ func registerHandlers(jail *Jail, vm *otto.Otto, chatID string) (err error) {
 // makeAsyncSendHandler returns jeth.sendAsync() handler.
 func makeAsyncSendHandler(jail *Jail, chatID string) func(call otto.FunctionCall) (response otto.Value) {
 	return func(call otto.FunctionCall) (response otto.Value) {
+		fmt.Printf("Delivering response to goroutine: %+q\n", chatID)
+
 		go func() {
-			fmt.Printf("Delivering response: %+q\n", chatID)
 			res := jail.Send(chatID, call)
 
 			// Deliver response if callback is provided.
@@ -93,6 +94,7 @@ func makeAsyncSendHandler(jail *Jail, chatID string) func(call otto.FunctionCall
 // makeSendHandler returns jeth.send() and jeth.sendAsync() handler
 func makeSendHandler(jail *Jail, chatID string) func(call otto.FunctionCall) (response otto.Value) {
 	return func(call otto.FunctionCall) (response otto.Value) {
+		fmt.Printf("Delivering response to flat: %+q\n", chatID)
 		return jail.Send(chatID, call)
 	}
 }

--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -80,10 +80,8 @@ func makeAsyncSendHandler(jail *Jail, chatID string) func(call otto.FunctionCall
 			res := jail.Send(chatID, call)
 
 			// Deliver response if callback is provided.
-			fmt.Printf("Deliver response: %+q\n", res)
 			if call.Otto != nil {
 				newResultResponse(call.Otto, res)
-				fmt.Printf("Delivered response: %+q\n", res)
 			}
 		}()
 

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -318,7 +318,10 @@ func (jail *Jail) RPCClient() (*rpc.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	jail.Lock()
 	jail.client = client
+	jail.Unlock()
 
 	return jail.client, nil
 }

--- a/geth/jail/testdata/tx-send/rx-send.js
+++ b/geth/jail/testdata/tx-send/rx-send.js
@@ -55,56 +55,46 @@ function call(pathStr, paramsStr) {
     return JSON.stringify(res);
 }
 
-function sendAsyncTransaction(params, callback) {
+var status = {
+    message_id: '42',
+};
+
+function send(params) {
+    console.log("Recieving send: ", params);
     var data = {
         from: params.from,
         to: params.to,
         value: web3.toWei(params.value, "ether")
     };
 
-    // message_id allows you to distinguish between !send invocations
-    // (when you receive transaction queued event, message_id will be
-    // attached along the queued transaction id)
-    status.message_id = 'foobar';
-
-    // Blocking call, it will return when transaction is complete.
-    // While call is executing, status-go will call up the application,
-    // allowing it to validate and complete transaction
-    var hash = web3.eth.sendTransaction(data, callback);
-
-    return { "transaction-hash": hash };
-}
-
-function sendTransaction(params) {
-    var data = {
-        from: params.from,
-        to: params.to,
-        value: web3.toWei(params.value, "ether")
-    };
-
-    // message_id allows you to distinguish between !send invocations
-    // (when you receive transaction queued event, message_id will be
-    // attached along the queued transaction id)
-    status.message_id = 'foobar';
-
-    // Blocking call, it will return when transaction is complete.
-    // While call is executing, status-go will call up the application,
-    // allowing it to validate and complete transaction
     var hash = web3.eth.sendTransaction(data);
 
     return { "transaction-hash": hash };
-}
+};
 
-_status_catalog.commands['send'] = sendTransaction;
-// _status_catalog.commands['sendAsync'] = sendAsyncTransaction;
+function sendAsync(params) {
+    console.log("Recieving sendAsync: ", params);
 
-_status_catalog.commands['getBalance'] = function(params) {
-    var balance = web3.eth.getBalance(params.address);
-    balance = web3.fromWei(balance, "ether");
-    if (balance < 90) {
-        console.log("Unexpected balance (<90): ", balance)
-    }
-    // used in tx tests, to check that non-context, non-message-is requests work too
-    // so actual balance is not important
-    return { "balance": 42 }
+    var data = {
+        from: params.from,
+        to: params.to,
+        value: web3.toWei(params.value, "ether")
+    };
+
+    var hash
+
+    web3.eth.sendTransaction(data, function(hash) {
+        hash = hash
+    });
+
+    return { "transaction-hash": hash };
+};
+
+var _status_catalog = {
+    commands: {
+        silo: 'rocker',
+        send: send,
+        sendAsync: sendAsync,
+    },
+    responses: {},
 };

--- a/geth/jail/testdata/tx-send/tx-send.js
+++ b/geth/jail/testdata/tx-send/tx-send.js
@@ -10,6 +10,7 @@ var _status_catalog = {
 };
 
 var context = {};
+
 function addContext(ns, key, value) { // this function is expected to be present, as status-go uses it to set context
     if (!(ns in context)) {
         context[ns] = {}
@@ -54,6 +55,26 @@ function call(pathStr, paramsStr) {
     return JSON.stringify(res);
 }
 
+function sendAsyncTransaction(params, callback) {
+    var data = {
+        from: params.from,
+        to: params.to,
+        value: web3.toWei(params.value, "ether")
+    };
+
+    // message_id allows you to distinguish between !send invocations
+    // (when you receive transaction queued event, message_id will be
+    // attached along the queued transaction id)
+    status.message_id = 'foobar';
+
+    // Blocking call, it will return when transaction is complete.
+    // While call is executing, status-go will call up the application,
+    // allowing it to validate and complete transaction
+    var hash = web3.eth.sendTransaction(data, callback);
+
+    return { "transaction-hash": hash };
+}
+
 function sendTransaction(params) {
     var data = {
         from: params.from,
@@ -71,11 +92,13 @@ function sendTransaction(params) {
     // allowing it to validate and complete transaction
     var hash = web3.eth.sendTransaction(data);
 
-    return {"transaction-hash": hash};
+    return { "transaction-hash": hash };
 }
 
 _status_catalog.commands['send'] = sendTransaction;
-_status_catalog.commands['getBalance'] = function (params) {
+_status_catalog.commands['sendAsync'] = sendAsyncTransaction;
+
+_status_catalog.commands['getBalance'] = function(params) {
     var balance = web3.eth.getBalance(params.address);
     balance = web3.fromWei(balance, "ether");
     if (balance < 90) {
@@ -83,5 +106,5 @@ _status_catalog.commands['getBalance'] = function (params) {
     }
     // used in tx tests, to check that non-context, non-message-is requests work too
     // so actual balance is not important
-    return {"balance": 42}
+    return { "balance": 42 }
 };

--- a/geth/txqueue.go
+++ b/geth/txqueue.go
@@ -218,7 +218,7 @@ func (q *JailedRequestQueue) ProcessSendTransactionRequest(lock sync.Locker, vm 
 
 	backend := lightEthereum.StatusBackend
 
-	// TODO(alex): Ask why this was not locked around here?
+	//TODO(farazdagi): Ask why this was not locked around here?
 	lock.Lock()
 
 	messageID, err := q.PreProcessRequest(vm, req)
@@ -236,11 +236,13 @@ func (q *JailedRequestQueue) ProcessSendTransactionRequest(lock sync.Locker, vm 
 	txHash, err := backend.SendTransaction(ctx, sendTxArgsFromRPCCall(req))
 	if err != nil {
 
-		//TODO(alex): Why do we relock this here?
+		//TODO(farazdagi): Why do we relock this here?
 		lock.Lock()
 		return common.Hash{}, err
 	}
 
+	//TODO(farazdagi): Why do we relock this here? Should we ensure only functions
+	// that need the lock, lock and unlock as needed.
 	lock.Lock() // re-lock
 
 	// invoke post processing


### PR DESCRIPTION
PR is related to issue #184 and it provides the initial handler for use of asynchronous send with callbacks from the js side with the Jail VM which has it's `send` and `sendAsync` method swapped for our custom ones.

Current method works with initial tests and will require more tests.

## Reviewer:
@farazdagi Please review specific todos that ask questions about specific areas in code that caused a few races.

## Issues
Related to #184 amd #181 