### PR TITLE
Fixed all typos on bootstrap spelling in node.go

### DIFF
--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -323,22 +323,22 @@ func makeBootstrapNodes() []*discover.Node {
 	// on mobile client we deliberately keep this list empty
 	enodes := []string{}
 
-	var bootstapNodes []*discover.Node
+	var bootstrapNodes []*discover.Node
 	for _, enode := range enodes {
-		bootstapNodes = append(bootstapNodes, discover.MustParseNode(enode))
+		bootstrapNodes = append(bootstrapNodes, discover.MustParseNode(enode))
 	}
 
-	return bootstapNodes
+	return bootstrapNodes
 }
 
 // makeBootstrapNodesV5 returns default (hence bootstrap) list of peers
 func makeBootstrapNodesV5() []*discv5.Node {
 	enodes := gethparams.DiscoveryV5Bootnodes
 
-	var bootstapNodes []*discv5.Node
+	var bootstrapNodes []*discv5.Node
 	for _, enode := range enodes {
-		bootstapNodes = append(bootstapNodes, discv5.MustParseNode(enode))
+		bootstrapNodes = append(bootstrapNodes, discv5.MustParseNode(enode))
 	}
 
-	return bootstapNodes
+	return bootstrapNodes
 }


### PR DESCRIPTION
Changed all typos on bootstrap spelling from "bootstap" to "bootstrap".
For example in function makeBootstrapNodes(), line 326 now reads:
var bootstrapNodes []*discover.Node