### PR TITLE
Add flag setup for RPCEnabled and add comment

### DIFF
--- a/cmd/statusd/faucetcmd.go
+++ b/cmd/statusd/faucetcmd.go
@@ -56,6 +56,7 @@ func parseFaucetCommandConfig(ctx *cli.Context) (*params.NodeConfig, error) {
 	nodeConfig.APIModules = "eth"
 	nodeConfig.HTTPHost = "0.0.0.0" // allow to connect from anywhere
 	nodeConfig.HTTPPort = ctx.Int(HTTPPortFlag.Name)
+	nodeConfig.RPCEnabled = ctx.Bool(HTTPEnabledFlag.Name)
 
 	// extra options
 	nodeConfig.BootClusterConfig.Enabled = true

--- a/cmd/statusd/lescmd.go
+++ b/cmd/statusd/lescmd.go
@@ -53,6 +53,7 @@ func parseLESCommandConfig(ctx *cli.Context) (*params.NodeConfig, error) {
 
 	// Enabled sub-protocols
 	nodeConfig.LightEthConfig.Enabled = true
+	nodeConfig.RPCEnabled = ctx.Bool(HTTPEnabledFlag.Name)
 	nodeConfig.WhisperConfig.Enabled = ctx.Bool(WhisperEnabledFlag.Name)
 	nodeConfig.SwarmConfig.Enabled = ctx.Bool(SwarmEnabledFlag.Name)
 

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -66,7 +66,7 @@ var (
 	// HTTPEnabledFlag defines whether HTTP RPC endpoint should be opened or not
 	HTTPEnabledFlag = cli.BoolFlag{
 		Name:  "http",
-		Usage: "HTTP RPC enpoint enabled",
+		Usage: "HTTP RPC enpoint enabled (default: false)",
 	}
 
 	// HTTPPortFlag defines HTTP RPC port to use (if HTTP RPC is enabled)


### PR DESCRIPTION
PR adds flag initializations for the `params.NodeConfig.RPCEnabled` flag which dictates whether the CLI connects to the internal ethereum rpc server or the provided upstream server in `params.NodeConfig.HTTPHost` and `params.NodeConfig.HTTPPort`.


### Adds

- Sets the `params.NodeConfig.RPCEnabled` to the provided value of the `HTTPEnabled.Flag`
- Add static comment to dictate the default value of flag.

Related to issue #224.