### PR TITLE
Console Jail Mod #179

### DIFF
--- a/geth/jail/console/console.go
+++ b/geth/jail/console/console.go
@@ -1,0 +1,130 @@
+package console
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/robertkrimen/otto"
+	"github.com/status-im/status-go/geth/node"
+)
+
+const (
+	// EventConsoleLog defines the event type for the console.log call.
+	EventConsoleLog = "vm.console.log"
+
+	// EventConsoleWarn defines the event type for the console.debug call.
+	EventConsoleWarn = "vm.console.warn"
+
+	// EventConsoleDebug defines the event type for the console.debug call.
+	EventConsoleDebug = "vm.console.debug"
+
+	// EventConsoleError defines the event type for the console.error call.
+	EventConsoleError = "vm.console.error"
+)
+
+// Extension takes a giving extension function and writer and returns a standard otto.Function
+// callable by a otto vm.
+func Extension(w io.Writer, ext func(otto.FunctionCall, io.Writer) otto.Value) func(otto.FunctionCall) otto.Value {
+	return func(fn otto.FunctionCall) otto.Value {
+		return ext(fn, w)
+	}
+}
+
+// Log provides the function caller for handling console.log
+// calls as replacement for the default console.log function within a
+// otto.Otto VM instance.
+func Log(fn otto.FunctionCall, w io.Writer) otto.Value {
+	// Record provided values into store for delviery.
+	node.SendSignal(node.SignalEnvelope{
+		Type:  EventConsoleLog,
+		Event: convertArgs(fn.ArgumentList),
+	})
+
+	// Next print out the giving values.
+	handleConsole(w, "console.log: %s", fn.ArgumentList)
+
+	return otto.UndefinedValue()
+}
+
+// Warn provides the function caller for handling console.warn
+// calls as replacement for the default console.log function within a
+// otto.Otto VM instance.
+func Warn(fn otto.FunctionCall, w io.Writer) otto.Value {
+	// Record provided values into store for delviery.
+	node.SendSignal(node.SignalEnvelope{
+		Type:  EventConsoleWarn,
+		Event: convertArgs(fn.ArgumentList),
+	})
+
+	// Next print out the giving values.
+	handleConsole(w, "console.warn: %s", fn.ArgumentList)
+
+	return otto.UndefinedValue()
+}
+
+// Debug provides the function caller for handling console.debug
+// calls as replacement for the default console.Error function within a
+// otto.Otto VM instance.
+func Debug(fn otto.FunctionCall, w io.Writer) otto.Value {
+	// Record provided values into store for delviery.
+	node.SendSignal(node.SignalEnvelope{
+		Type:  EventConsoleDebug,
+		Event: convertArgs(fn.ArgumentList),
+	})
+
+	// Next print out the giving values.
+	handleConsole(w, "console.debug: %s", fn.ArgumentList)
+
+	return otto.UndefinedValue()
+}
+
+// Error provides the function caller for handling console.error
+// calls as replacement for the default console.Error function within a
+// otto.Otto VM instance.
+func Error(fn otto.FunctionCall, w io.Writer) otto.Value {
+	// Record provided values into store for delviery.
+	node.SendSignal(node.SignalEnvelope{
+		Type:  EventConsoleError,
+		Event: convertArgs(fn.ArgumentList),
+	})
+
+	// Next print out the giving values.
+	handleConsole(w, "console.error: %s", fn.ArgumentList)
+
+	return otto.UndefinedValue()
+}
+
+// convertArgs attempts to convert otto.Values into proper go types else
+// uses original.
+func convertArgs(argumentList []otto.Value) []interface{} {
+	var items []interface{}
+
+	for _, arg := range argumentList {
+		realArg, err := arg.Export()
+		if err != nil {
+			items = append(items, arg)
+			continue
+		}
+
+		items = append(items, realArg)
+	}
+
+	return items
+}
+
+// handleConsole takes the giving otto.Values and transform as
+// needed into the appropriate writer.
+func handleConsole(writer io.Writer, format string, args []otto.Value) {
+	fmt.Fprintf(writer, format, formatForConsole(args))
+}
+
+// formatForConsole handles conversion of giving otto.Values into
+// string counter part.
+func formatForConsole(argumentList []otto.Value) string {
+	output := []string{}
+	for _, argument := range argumentList {
+		output = append(output, fmt.Sprintf("%v", argument))
+	}
+	return strings.Join(output, " ")
+}

--- a/geth/jail/console/console.go
+++ b/geth/jail/console/console.go
@@ -9,90 +9,34 @@ import (
 	"github.com/status-im/status-go/geth/node"
 )
 
-const (
-	// EventConsoleLog defines the event type for the console.log call.
-	EventConsoleLog = "vm.console.log"
+// Write provides the baselevel function to writes data to the underline writer
+// for the underline otto vm.
+func Write(fn otto.FunctionCall, w io.Writer, ntype string) otto.Value {
+	node.SendSignal(node.SignalEnvelope{
+		Type:  ntype,
+		Event: convertArgs(fn.ArgumentList),
+	})
 
-	// EventConsoleWarn defines the event type for the console.debug call.
-	EventConsoleWarn = "vm.console.warn"
+	// Next print out the giving values.
+	writeConsole(w, "%s: %s", ntype, fn.ArgumentList)
 
-	// EventConsoleDebug defines the event type for the console.debug call.
-	EventConsoleDebug = "vm.console.debug"
+	return otto.UndefinedValue()
+}
 
-	// EventConsoleError defines the event type for the console.error call.
-	EventConsoleError = "vm.console.error"
-)
+// writeArgument takes the giving otto.Values and transform as
+// needed into the appropriate writer.
+func writeConsole(writer io.Writer, format string, ntype string, args []otto.Value) {
+	fmt.Fprintf(writer, format, ntype, formatForConsole(args))
+}
 
-// Extension takes a giving extension function and writer and returns a standard otto.Function
-// callable by a otto vm.
-func Extension(w io.Writer, ext func(otto.FunctionCall, io.Writer) otto.Value) func(otto.FunctionCall) otto.Value {
-	return func(fn otto.FunctionCall) otto.Value {
-		return ext(fn, w)
+// formatForConsole handles conversion of giving otto.Values into
+// string counter part.
+func formatForConsole(argumentList []otto.Value) string {
+	output := []string{}
+	for _, argument := range argumentList {
+		output = append(output, fmt.Sprintf("%v", argument))
 	}
-}
-
-// Log provides the function caller for handling console.log
-// calls as replacement for the default console.log function within a
-// otto.Otto VM instance.
-func Log(fn otto.FunctionCall, w io.Writer) otto.Value {
-	// Record provided values into store for delviery.
-	node.SendSignal(node.SignalEnvelope{
-		Type:  EventConsoleLog,
-		Event: convertArgs(fn.ArgumentList),
-	})
-
-	// Next print out the giving values.
-	handleConsole(w, "console.log: %s", fn.ArgumentList)
-
-	return otto.UndefinedValue()
-}
-
-// Warn provides the function caller for handling console.warn
-// calls as replacement for the default console.log function within a
-// otto.Otto VM instance.
-func Warn(fn otto.FunctionCall, w io.Writer) otto.Value {
-	// Record provided values into store for delviery.
-	node.SendSignal(node.SignalEnvelope{
-		Type:  EventConsoleWarn,
-		Event: convertArgs(fn.ArgumentList),
-	})
-
-	// Next print out the giving values.
-	handleConsole(w, "console.warn: %s", fn.ArgumentList)
-
-	return otto.UndefinedValue()
-}
-
-// Debug provides the function caller for handling console.debug
-// calls as replacement for the default console.Error function within a
-// otto.Otto VM instance.
-func Debug(fn otto.FunctionCall, w io.Writer) otto.Value {
-	// Record provided values into store for delviery.
-	node.SendSignal(node.SignalEnvelope{
-		Type:  EventConsoleDebug,
-		Event: convertArgs(fn.ArgumentList),
-	})
-
-	// Next print out the giving values.
-	handleConsole(w, "console.debug: %s", fn.ArgumentList)
-
-	return otto.UndefinedValue()
-}
-
-// Error provides the function caller for handling console.error
-// calls as replacement for the default console.Error function within a
-// otto.Otto VM instance.
-func Error(fn otto.FunctionCall, w io.Writer) otto.Value {
-	// Record provided values into store for delviery.
-	node.SendSignal(node.SignalEnvelope{
-		Type:  EventConsoleError,
-		Event: convertArgs(fn.ArgumentList),
-	})
-
-	// Next print out the giving values.
-	handleConsole(w, "console.error: %s", fn.ArgumentList)
-
-	return otto.UndefinedValue()
+	return strings.Join(output, " ")
 }
 
 // convertArgs attempts to convert otto.Values into proper go types else
@@ -111,20 +55,4 @@ func convertArgs(argumentList []otto.Value) []interface{} {
 	}
 
 	return items
-}
-
-// handleConsole takes the giving otto.Values and transform as
-// needed into the appropriate writer.
-func handleConsole(writer io.Writer, format string, args []otto.Value) {
-	fmt.Fprintf(writer, format, formatForConsole(args))
-}
-
-// formatForConsole handles conversion of giving otto.Values into
-// string counter part.
-func formatForConsole(argumentList []otto.Value) string {
-	output := []string{}
-	for _, argument := range argumentList {
-		output = append(output, fmt.Sprintf("%v", argument))
-	}
-	return strings.Join(output, " ")
 }

--- a/geth/jail/console/console.go
+++ b/geth/jail/console/console.go
@@ -9,24 +9,18 @@ import (
 	"github.com/status-im/status-go/geth/node"
 )
 
-// Write provides the baselevel function to writes data to the underline writer
+// Write provides the base function to write data to the underline writer
 // for the underline otto vm.
-func Write(fn otto.FunctionCall, w io.Writer, ntype string) otto.Value {
+func Write(fn otto.FunctionCall, w io.Writer, consoleEventName string) otto.Value {
 	node.SendSignal(node.SignalEnvelope{
-		Type:  ntype,
+		Type:  consoleEventName,
 		Event: convertArgs(fn.ArgumentList),
 	})
 
 	// Next print out the giving values.
-	writeConsole(w, "%s: %s", ntype, fn.ArgumentList)
+	fmt.Fprintf(w, "%s: %s", consoleEventName, formatForConsole(fn.ArgumentList))
 
 	return otto.UndefinedValue()
-}
-
-// writeArgument takes the giving otto.Values and transform as
-// needed into the appropriate writer.
-func writeConsole(writer io.Writer, format string, ntype string, args []otto.Value) {
-	fmt.Fprintf(writer, format, ntype, formatForConsole(args))
 }
 
 // formatForConsole handles conversion of giving otto.Values into

--- a/geth/jail/console/console_test.go
+++ b/geth/jail/console/console_test.go
@@ -1,0 +1,97 @@
+package console_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/robertkrimen/otto"
+	"github.com/status-im/status-go/geth/jail/console"
+	"github.com/status-im/status-go/geth/node"
+	"github.com/stretchr/testify/suite"
+)
+
+// TestConsole validates the behaviour of giving conole extensions.
+func TestConsole(t *testing.T) {
+	suite.Run(t, new(ConsoleTestSuite))
+}
+
+type ConsoleTestSuite struct {
+	suite.Suite
+	vm *otto.Otto
+}
+
+func (s *ConsoleTestSuite) SetupTest() {
+	vm := otto.New()
+	require := s.Require()
+
+	require.NotNil(vm)
+	require.IsType(&otto.Otto{}, vm)
+
+	s.vm = vm
+}
+
+// TestConsoleLog will validate the operations of the console.log extension
+// for the otto vm.
+func (s *ConsoleTestSuite) TestConsoleLog() {
+	require := s.Require()
+	written := "Bob Marley"
+
+	var customWriter bytes.Buffer
+
+	// register console handler.
+	err := s.vm.Set("console", map[string]interface{}{
+		"log": console.Extension(&customWriter, console.Log),
+	})
+	require.NoError(err)
+
+	_, err = s.vm.Run(fmt.Sprintf(`console.log(%q);`, written))
+	require.NoError(err)
+
+	require.NotEmpty(&customWriter)
+	require.Equal(written, strings.TrimPrefix(customWriter.String(), "console.log: "))
+}
+
+// TestObjectLogging will validate the operations of the console.log extension
+// when capturing objects declared from javascript.
+func (s *ConsoleTestSuite) TestObjectLogging() {
+	require := s.Require()
+
+	node.SetDefaultNodeNotificationHandler(func(event string) {
+
+		var eventReceived struct {
+			Type  string `json:"type"`
+			Event []struct {
+				Age  int    `json:"age"`
+				Name string `json:"name"`
+			} `json:"event"`
+		}
+
+		err := json.Unmarshal([]byte(event), &eventReceived)
+		require.NoError(err)
+
+		require.Equal(eventReceived.Type, "vm.console.log")
+		require.NotEmpty(eventReceived.Event)
+
+		objectReceived := eventReceived.Event[0]
+		require.Equal(objectReceived.Age, 24)
+		require.Equal(objectReceived.Name, "bob")
+	})
+
+	var customWriter bytes.Buffer
+
+	// register console handler.
+	err := s.vm.Set("console", map[string]interface{}{
+		"log": console.Extension(&customWriter, console.Log),
+	})
+	require.NoError(err)
+
+	_, err = s.vm.Run(`
+		var person = {name:"bob", age:24}
+		console.log(person);
+	`)
+	require.NoError(err)
+	require.NotEmpty(&customWriter)
+}

--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -1,7 +1,10 @@
 package jail
 
 import (
+	"os"
+
 	"github.com/robertkrimen/otto"
+	"github.com/status-im/status-go/geth/jail/console"
 	"github.com/status-im/status-go/geth/node"
 )
 
@@ -20,6 +23,12 @@ func registerHandlers(jail *Jail, vm *otto.Otto, chatID string) error {
 		return err
 	}
 	registerHandler := jeth.Object().Set
+
+	if err = registerHandler("console", map[string]interface{}{
+		"log": console.Extension(os.Stdout, console.Log),
+	}); err != nil {
+		return err
+	}
 
 	// register send handler
 	if err = registerHandler("send", makeSendHandler(jail)); err != nil {

--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -13,6 +13,9 @@ const (
 	EventLocalStorageSet = "local_storage.set"
 	EventSendMessage     = "jail.send_message"
 	EventShowSuggestions = "jail.show_suggestions"
+
+	// EventConsoleLog defines the event type for the console.log call.
+	eventConsoleLog = "vm.console.log"
 )
 
 // registerHandlers augments and transforms a given jail cell's underlying VM,
@@ -25,7 +28,9 @@ func registerHandlers(jail *Jail, vm *otto.Otto, chatID string) error {
 	registerHandler := jeth.Object().Set
 
 	if err = registerHandler("console", map[string]interface{}{
-		"log": console.Extension(os.Stdout, console.Log),
+		"log": func(fn otto.FunctionCall) otto.Value {
+			return console.Write(fn, os.Stdout, eventConsoleLog)
+		},
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
#PR adds new handlers to plug into `console.log` to allow us publish usage and calls to methods as status updates.

## Feature

- Registers new `console.log` using custom functions
- Registers new `console` object directly in `jail.registeHandlers`

Related to issue #179 