### PR TITLE
Fix log levels and enable ethereum-go logger

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/status-im/status-go/geth/api"
+	"github.com/status-im/status-go/geth/log"
 	"github.com/status-im/status-go/geth/params"
 	"gopkg.in/urfave/cli.v1"
 )
@@ -85,7 +86,7 @@ var (
 	// LogLevelFlag defines a log reporting level
 	LogLevelFlag = cli.StringFlag{
 		Name:  "log",
-		Usage: `Log level, one of: ""ERROR", "WARNING", "INFO", "DEBUG", and "TRACE"`,
+		Usage: `Log level, one of: "ERROR", "WARNING", "INFO", "DEBUG", and "TRACE"`,
 		Value: "INFO",
 	}
 )
@@ -153,6 +154,7 @@ func makeNodeConfig(ctx *cli.Context) (*params.NodeConfig, error) {
 	if logLevel := ctx.GlobalString(LogLevelFlag.Name); len(logLevel) > 0 {
 		nodeConfig.LogEnabled = true
 		nodeConfig.LogLevel = logLevel
+		log.Init(logLevel)
 	}
 
 	return nodeConfig, nil

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -86,7 +86,7 @@ var (
 	// LogLevelFlag defines a log reporting level
 	LogLevelFlag = cli.StringFlag{
 		Name:  "log",
-		Usage: `Log level, one of: "ERROR", "WARNING", "INFO", "DEBUG", and "TRACE"`,
+		Usage: `Log level, one of: "ERROR", "WARN", "INFO", "DEBUG", and "TRACE"`,
 		Value: "INFO",
 	}
 )

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -154,7 +154,7 @@ func makeNodeConfig(ctx *cli.Context) (*params.NodeConfig, error) {
 	if logLevel := ctx.GlobalString(LogLevelFlag.Name); len(logLevel) > 0 {
 		nodeConfig.LogEnabled = true
 		nodeConfig.LogLevel = logLevel
-		log.Init(logLevel)
+		log.SetLevel(logLevel)
 	}
 
 	return nodeConfig, nil

--- a/geth/api/backend_jail_test.go
+++ b/geth/api/backend_jail_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
 	"github.com/status-im/status-go/geth/common"
-	"github.com/status-im/status-go/geth/jail"
 	"github.com/status-im/status-go/geth/log"
 	"github.com/status-im/status-go/geth/node"
 	"github.com/status-im/status-go/geth/params"

--- a/geth/log/log.go
+++ b/geth/log/log.go
@@ -1,75 +1,64 @@
 package log
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// Logger is wrapper for go-ethereum log
-type Logger struct {
-	output log.Logger
+// logger is package scope instance of log.Logger
+var logger = log.New("geth", "StatusIM")
+
+// Init inits status and ethereum-go logging packages,
+// enabling logging and setting up proper log level.
+//
+// Our log levels are in form "DEBUG|ERROR|WARN|etc", while
+// ethereum-go expects names in lower case: "debug|error|warn|etc".
+func Init(level string) {
+	lvl, err := log.LvlFromString(strings.ToLower(level))
+	if err != nil {
+		fmt.Printf("Incorrect log level: %s, using defaults", level)
+		lvl = log.LvlInfo
+	}
+
+	initWithHandler(lvl, log.StdoutHandler)
 }
 
-// Instance to a logger struct
-var logger *Logger
+// initWithHandler is a init helper that allows (re)initialization
+// with different handler. Useful for testing.
+func initWithHandler(lvl log.Lvl, handler log.Handler) {
+	h := log.LvlFilterHandler(lvl, handler)
+	logger.SetHandler(h)
+	log.Root().SetHandler(h) // ethereum-go logger
+}
 
-// Trace is a convenient alias for Root().Trace
+// Trace is a package scope alias for logger.Trace
 func Trace(msg string, ctx ...interface{}) {
-	printLog(log.LvlTrace, msg, ctx...)
+	logger.Trace(msg, ctx...)
 }
 
-// Debug is a convenient alias for Root().Debug
+// Debug is a package scope for logger.Debug
 func Debug(msg string, ctx ...interface{}) {
-	printLog(log.LvlDebug, msg, ctx...)
+	logger.Debug(msg, ctx...)
 }
 
-// Info is a convenient alias for Root().Info
+// Info is a package scope for logger.Info
 func Info(msg string, ctx ...interface{}) {
-	printLog(log.LvlInfo, msg, ctx...)
+	logger.Info(msg, ctx...)
 }
 
-// Warn is a convenient alias for Root().Warn
+// Warn is a package scope for logger.Warn
 func Warn(msg string, ctx ...interface{}) {
-	printLog(log.LvlWarn, msg, ctx...)
+	logger.Warn(msg, ctx...)
 }
 
-// Error is a convenient alias for Root().Error
+// Error is a package scope for logger.Error
 func Error(msg string, ctx ...interface{}) {
-	printLog(log.LvlError, msg, ctx...)
+	logger.Error(msg, ctx...)
 }
 
-// Crit is a convenient alias for Root().Crit
+// Crit is a package scope for logger.Crit
 func Crit(msg string, ctx ...interface{}) {
-	printLog(log.LvlCrit, msg, ctx...)
-}
-
-// outputs the log to a given log config level
-func printLog(lvl log.Lvl, msg string, ctx ...interface{}) {
-	if logger == nil {
-		logger = &Logger{
-			output: log.New("geth", "StatusIM"),
-		}
-		logger.output.SetHandler(log.StdoutHandler)
-	}
-
-	switch lvl {
-
-	case log.LvlError:
-		logger.output.Error(msg, ctx...)
-
-	case log.LvlWarn:
-		logger.output.Warn(msg, ctx...)
-
-	case log.LvlInfo:
-		logger.output.Info(msg, ctx...)
-
-	case log.LvlDebug:
-		logger.output.Debug(msg, ctx...)
-
-	case log.LvlTrace:
-		logger.output.Trace(msg, ctx...)
-
-	default:
-		logger.output.Info(msg, ctx...)
-
-	}
+	logger.Crit(msg, ctx...)
 }

--- a/geth/log/log.go
+++ b/geth/log/log.go
@@ -10,12 +10,16 @@ import (
 // logger is package scope instance of log.Logger
 var logger = log.New("geth", "StatusIM")
 
+func init() {
+	SetLevel("INFO")
+}
+
 // Init inits status and ethereum-go logging packages,
 // enabling logging and setting up proper log level.
 //
 // Our log levels are in form "DEBUG|ERROR|WARN|etc", while
 // ethereum-go expects names in lower case: "debug|error|warn|etc".
-func Init(level string) {
+func SetLevel(level string) {
 	lvl, err := log.LvlFromString(strings.ToLower(level))
 	if err != nil {
 		fmt.Printf("Incorrect log level: %s, using defaults", level)

--- a/geth/log/log.go
+++ b/geth/log/log.go
@@ -14,7 +14,7 @@ func init() {
 	SetLevel("INFO")
 }
 
-// Init inits status and ethereum-go logging packages,
+// SetLevel inits status and ethereum-go logging packages,
 // enabling logging and setting up proper log level.
 //
 // Our log levels are in form "DEBUG|ERROR|WARN|etc", while

--- a/geth/log/log.go
+++ b/geth/log/log.go
@@ -26,12 +26,12 @@ func SetLevel(level string) {
 		lvl = log.LvlInfo
 	}
 
-	initWithHandler(lvl, log.StdoutHandler)
+	setHandler(lvl, log.StdoutHandler)
 }
 
-// initWithHandler is a init helper that allows (re)initialization
+// setHandler is a init helper that allows (re)initialization
 // with different handler. Useful for testing.
-func initWithHandler(lvl log.Lvl, handler log.Handler) {
+func setHandler(lvl log.Lvl, handler log.Handler) {
 	h := log.LvlFilterHandler(lvl, handler)
 	logger.SetHandler(h)
 	log.Root().SetHandler(h) // ethereum-go logger

--- a/geth/log/log.go
+++ b/geth/log/log.go
@@ -22,7 +22,7 @@ func init() {
 func SetLevel(level string) {
 	lvl, err := log.LvlFromString(strings.ToLower(level))
 	if err != nil {
-		fmt.Printf("Incorrect log level: %s, using defaults", level)
+		fmt.Printf("Incorrect log level: %s, using defaults\n", level)
 		lvl = log.LvlInfo
 	}
 

--- a/geth/log/log_test.go
+++ b/geth/log/log_test.go
@@ -1,18 +1,51 @@
-// log_test
 package log
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
-func TestLogger(t *testing.T) {
+const (
+	trace = "trace log message\n"
+	debug = "debug log message\n"
+	info  = "info log message\n"
+	warn  = "warning log message\n"
+	err   = "error log message\n"
+)
 
-	t.Log("Testing log package..")
+func TestLogLevels(t *testing.T) {
+	var tests = []struct {
+		lvl log.Lvl
+		out string
+	}{
+		{log.LvlTrace, trace + debug + info + warn + err},
+		{log.LvlDebug, debug + info + warn + err},
+		{log.LvlInfo, info + warn + err},
+		{log.LvlWarn, warn + err},
+		{log.LvlError, err},
+	}
 
-	Trace("Trace Message")
-	Debug("Debug Message")
-	Info("Info Message")
-	Warn("Warn Message")
-	Error("Error Message")
-	Crit("Crit Message")
+	var buf bytes.Buffer
+	// log-comaptible handler that writes log in the buffer
+	handler := log.FuncHandler(func(r *log.Record) error {
+		_, err := buf.Write([]byte(r.Msg))
+		return err
+	})
+	for _, test := range tests {
+		buf.Reset()
+
+		initWithHandler(test.lvl, handler)
+
+		Trace(trace)
+		Debug(debug)
+		Info(info)
+		Warn(warn)
+		Error(err)
+
+		if buf.String() != test.out {
+			t.Errorf("Expecting log output to be '%s', got '%s'", test.out, buf.String())
+		}
+	}
 }

--- a/geth/log/log_test.go
+++ b/geth/log/log_test.go
@@ -36,7 +36,7 @@ func TestLogLevels(t *testing.T) {
 	for _, test := range tests {
 		buf.Reset()
 
-		initWithHandler(test.lvl, handler)
+		setHandler(test.lvl, handler)
 
 		Trace(trace)
 		Debug(debug)

--- a/geth/testing/testing.go
+++ b/geth/testing/testing.go
@@ -11,6 +11,7 @@ import (
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/geth/common"
+	"github.com/status-im/status-go/geth/log"
 	"github.com/status-im/status-go/geth/params"
 	assertions "github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -53,6 +54,8 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	log.SetLevel("ERROR")
 }
 
 // BaseTestSuite defines a base tests suit which others suites can embedded to


### PR DESCRIPTION
This PR addresses https://github.com/status-im/status-go/issues/255 (turn on `ethereum-go` log) and fixes log levelling.

In current version of `develop` branch, command line flag `--log` doesn't affect log output - it outputs always at INFO level. Part of this PR fixes this moment.

A few notes:
 - status-go uses two logger variables (own and `ethereum-go`), both are instances of `github.com/ethereum/go-ethereum/log.(Logger)` types, which is, in fact, a fork of [log15 log package](https://github.com/inconshreveable/log15)
 - now both loggers initialized in `geth/log.go` with given log level
 - `status-go` and `github.com/ethereum/go-ethereum/log` use different different definitions for log levels ("ERROR"/"DEBUG"/etc vs "error"/"debug"/etc), so some conversion is being made during log initialization.
 - as `statusd` is both command line app and server, it makes sense to initialize logging only for server mode. It is true for now, but not explicitly, because `log.Init()` is called in `makeNodeConfig()` function. Probably makes sense to make this moment more visible.