### PR TITLE
bugfix: properly handle no LES service

### DIFF
--- a/geth/api/backend.go
+++ b/geth/api/backend.go
@@ -202,6 +202,7 @@ func (m *StatusBackend) registerHandlers() error {
 	var lightEthereum *les.LightEthereum
 	if err := runningNode.Service(&lightEthereum); err != nil {
 		log.Error("Cannot get light ethereum service", "error", err)
+		return err
 	}
 
 	lightEthereum.StatusBackend.SetAccountsFilterHandler(m.accountManager.AccountsListRequestHandler())

--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestNodeStartWithUpstream(t *testing.T) {
+func TestStartNodeWithUpstreamEnabled(t *testing.T) {
 	backend := api.NewStatusBackend()
 	require.NotNil(t, backend)
 

--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -14,8 +14,26 @@ import (
 	"github.com/status-im/status-go/geth/node"
 	"github.com/status-im/status-go/geth/params"
 	. "github.com/status-im/status-go/geth/testing"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+func TestNodeStartWithUpstream(t *testing.T) {
+	backend := api.NewStatusBackend()
+	require.NotNil(t, backend)
+
+	nodeConfig, err := MakeTestNodeConfig(params.RopstenNetworkID)
+	require.NoError(t, err)
+
+	nodeConfig.UpstreamConfig.Enabled = true
+
+	nodeStarted, err := backend.StartNode(nodeConfig)
+	require.NoError(t, err)
+	defer backend.StopNode()
+
+	<-nodeStarted
+	require.True(t, backend.IsNodeRunning())
+}
 
 func TestBackendTestSuite(t *testing.T) {
 	suite.Run(t, new(BackendTestSuite))


### PR DESCRIPTION
If `lightEthereum` service is not found, `StatusBackend.registerHandlers()` should return an error.