### PR TITLE
Add Fetch API support to jail cell

### DIFF
--- a/geth/jail/jail_cell.go
+++ b/geth/jail/jail_cell.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/robertkrimen/otto"
+	"github.com/status-im/ottoext/fetch"
 	"github.com/status-im/ottoext/loop"
 	"github.com/status-im/ottoext/timers"
 )
@@ -33,6 +34,11 @@ func newJailCell(id string, vm *otto.Otto) (*JailCell, error) {
 	// register handlers for setTimeout/setInterval
 	// functions
 	if err := timers.Define(vm, lo); err != nil {
+		return nil, err
+	}
+
+	// register handlers for FetchAPI functions
+	if err := fetch.Define(vm, lo); err != nil {
 		return nil, err
 	}
 

--- a/geth/jail/jail_cell_test.go
+++ b/geth/jail/jail_cell_test.go
@@ -1,6 +1,8 @@
 package jail_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"time"
 
 	"github.com/robertkrimen/otto"
@@ -112,5 +114,92 @@ func (s *JailTestSuite) TestJailLoopInCall() {
 
 	case <-time.After(5 * time.Second):
 		require.Fail("Failed to received event response")
+	}
+}
+
+func (s *JailTestSuite) TestJailFetchPromise() {
+	body := `{"key": "value"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	require := s.Require()
+	require.NotNil(s.jail)
+
+	cell, err := s.jail.NewJailCell(testChatID)
+	require.NoError(err)
+	require.NotNil(cell)
+
+	dataCh := make(chan otto.Value, 1)
+	errCh := make(chan otto.Value, 1)
+
+	err = cell.Set("__captureSuccess", func(res otto.Value) { dataCh <- res })
+	require.NoError(err)
+	err = cell.Set("__captureError", func(res otto.Value) { errCh <- res })
+	require.NoError(err)
+
+	// run JS code for fetching valid URL
+	_, err = cell.Run(`fetch('` + server.URL + `').then(function(r) {
+		return r.text()
+	}).then(function(data) {
+		__captureSuccess(data)
+	}).catch(function (e) {
+		__captureError(e)
+	})`)
+	require.NoError(err)
+
+	timer := time.NewTimer(500 * time.Millisecond)
+	select {
+	case data := <-dataCh:
+		require.True(data.IsString())
+		require.Equal(body, data.String())
+	case err := <-errCh:
+		require.Fail("request failed", err)
+	case <-timer.C:
+		require.Fail("test timed out")
+	}
+}
+
+func (s *JailTestSuite) TestJailFetchCatch() {
+	require := s.Require()
+	require.NotNil(s.jail)
+
+	cell, err := s.jail.NewJailCell(testChatID)
+	require.NoError(err)
+	require.NotNil(cell)
+
+	dataCh := make(chan otto.Value, 1)
+	errCh := make(chan otto.Value, 1)
+
+	err = cell.Set("__captureSuccess", func(res otto.Value) { dataCh <- res })
+	require.NoError(err)
+	err = cell.Set("__captureError", func(res otto.Value) { errCh <- res })
+	require.NoError(err)
+
+	// run JS code for fetching valid URL
+	_, err = cell.Run(`fetch('http://👽/nonexistent').then(function(r) {
+		return r.text()
+	}).then(function(data) {
+		__captureSuccess(data)
+	}).catch(function (e) {
+		__captureError(e)
+	})`)
+	require.NoError(err)
+
+	timer := time.NewTimer(500 * time.Millisecond)
+	select {
+	case data := <-dataCh:
+		require.Fail("request should have failed, but returned", data)
+	case e := <-errCh:
+		require.True(e.IsObject())
+		name, err := e.Object().Get("name")
+		require.NoError(err)
+		require.Equal("Error", name.String())
+		_, err = e.Object().Get("message")
+		require.NoError(err)
+	case <-timer.C:
+		require.Fail("test timed out")
 	}
 }


### PR DESCRIPTION
This PR adds support for Fetch API to the Jail Cell VM.

It basically just registers Go fetch implementation handlers from `ottoext` with Cell's VM.

Should resolve https://github.com/status-im/status-go/issues/231

Signed-off-by: Ivan Danyliuk <ivan.daniluk@gmail.com>