### PR TITLE
Refactoring

### DIFF
--- a/geth/api/api.go
+++ b/geth/api/api.go
@@ -168,9 +168,8 @@ func (api *StatusAPI) JailParse(chatID string, js string) string {
 }
 
 // JailCall executes given JavaScript function w/i a jail cell context identified by the chatID.
-// Jail cell is clonned before call is executed i.e. all calls execute w/i their own contexts.
-func (api *StatusAPI) JailCall(chatID string, path string, args string) string {
-	return api.b.jailManager.Call(chatID, path, args)
+func (api *StatusAPI) JailCall(chatID, this, args string) string {
+	return api.b.jailManager.Call(chatID, this, args)
 }
 
 // JailBaseJS allows to setup initial JavaScript to be loaded on each jail.Parse()

--- a/geth/api/backend_jail_test.go
+++ b/geth/api/backend_jail_test.go
@@ -208,7 +208,7 @@ func (s *BackendTestSuite) TestContractDeployment() {
 	jailInstance := s.backend.JailManager()
 	jailInstance.Parse(testChatID, "")
 
-	cell, err := jailInstance.GetJailCell(testChatID)
+	cell, err := jailInstance.Cell(testChatID)
 	require.NoError(err)
 
 	// make sure you panic if transaction complete doesn't return
@@ -615,7 +615,7 @@ func (s *BackendTestSuite) TestJailWhisper() {
 			};
 		`)
 
-		cell, err := jailInstance.GetJailCell(testCaseKey)
+		cell, err := jailInstance.Cell(testCaseKey)
 		require.NoError(err, "cannot get VM")
 
 		// post messages
@@ -796,7 +796,7 @@ func (s *BackendTestSuite) TestJailVMPersistence() {
 	wg.Wait()
 
 	// Validate total.
-	cell, err := jailInstance.GetJailCell(testChatID)
+	cell, err := jailInstance.Cell(testChatID)
 	require.NoError(err)
 
 	totalOtto, err := cell.Get("total")

--- a/geth/api/backend_jail_test.go
+++ b/geth/api/backend_jail_test.go
@@ -611,9 +611,8 @@ func (s *BackendTestSuite) TestJailWhisper() {
 		require.NoError(err, "cannot get VM")
 
 		// post messages
-		if _, err := cell.Run(testCase.testCode); err != nil {
-			require.Fail(err.Error())
-		}
+		_, err = cell.Run(testCase.testCode)
+		require.NoError(err)
 
 		if !testCase.useFilter {
 			continue
@@ -626,9 +625,8 @@ func (s *BackendTestSuite) TestJailWhisper() {
 		filterName, err := cell.Get("filterName")
 		require.NoError(err, "cannot get filterName")
 
-		if _, ok := installedFilters[filterName.String()]; !ok {
-			require.FailNow("unrecognized filter")
-		}
+		_, ok := installedFilters[filterName.String()]
+		require.True(ok, "unrecognized filter")
 
 		installedFilters[filterName.String()] = filterId.String()
 	}

--- a/geth/api/backend_txqueue_test.go
+++ b/geth/api/backend_txqueue_test.go
@@ -395,23 +395,23 @@ func (s *BackendTestSuite) TestCompleteMultipleQueuedTransactions() {
 		require.EqualError(results["invalid-tx-id"].Error, "transaction hash not found")
 
 		for txID, txResult := range results {
-			if txResult.Error != nil && txID != "invalid-tx-id" {
-				require.Fail(fmt.Sprintf("invalid error for %s", txID))
-			}
+			require.False(
+				txResult.Error != nil && txID != "invalid-tx-id",
+				"invalid error for %s", txID,
+			)
 
-			if txResult.Hash.Hex() == "0x0000000000000000000000000000000000000000000000000000000000000000" && txID != "invalid-tx-id" {
-				require.Fail(fmt.Sprintf("invalid hash (expected non empty hash): %s", txID))
-			}
-
-			if txResult.Hash.Hex() != "0x0000000000000000000000000000000000000000000000000000000000000000" {
-				log.Info("transaction complete", "URL", "https://ropsten.etherscan.io/tx/"+txResult.Hash.Hex())
-			}
+			require.False(
+				txResult.Hash.Hex() == "0x0000000000000000000000000000000000000000000000000000000000000000" && txID != "invalid-tx-id",
+				"invalid hash (expected non empty hash): %s", txID,
+			)
 		}
 
 		time.Sleep(1 * time.Second) // make sure that tx complete signal propagates
 		for _, txID := range parsedIDs {
-			require.False(backend.TransactionQueue().Has(status.QueuedTxID(txID)),
-				"txqueue should not have test tx at this point (it should be completed)")
+			require.False(
+				backend.TransactionQueue().Has(status.QueuedTxID(txID)),
+				"txqueue should not have test tx at this point (it should be completed)",
+			)
 		}
 	}
 	go func() {

--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -185,17 +185,16 @@ type JailCell interface {
 type JailManager interface {
 	// Parse creates a new jail cell context, with the given chatID as identifier.
 	// New context executes provided JavaScript code, right after the initialization.
-	Parse(chatID string, js string) string
+	Parse(chatID, js string) string
 
 	// Call executes given JavaScript function w/i a jail cell context identified by the chatID.
-	// Jail cell is clonned before call is executed i.e. all calls execute w/i their own contexts.
-	Call(chatID string, path string, args string) string
+	Call(chatID, path, args string) string
 
-	// NewJailCell initializes and returns jail cell
-	NewJailCell(id string) (JailCell, error)
+	// NewCell initializes and returns a new jail cell.
+	NewCell(chatID string) (JailCell, error)
 
-	// GetJailCell returns instance of JailCell (which is persisted w/i jail cell) by chatID
-	GetJailCell(chatID string) (JailCell, error)
+	// Cell returns an existing instance of JailCell.
+	Cell(chatID string) (JailCell, error)
 
 	// BaseJS allows to setup initial JavaScript to be loaded on each jail.Parse()
 	BaseJS(js string)

--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -179,6 +179,7 @@ type JailCell interface {
 	Set(string, interface{}) error
 	Get(string) (otto.Value, error)
 	Run(string) (otto.Value, error)
+	Call(item string, this interface{}, args ...interface{}) (otto.Value, error)
 }
 
 // JailManager defines methods for managing jailed environments
@@ -188,7 +189,7 @@ type JailManager interface {
 	Parse(chatID, js string) string
 
 	// Call executes given JavaScript function w/i a jail cell context identified by the chatID.
-	Call(chatID, path, args string) string
+	Call(chatID, this, args string) string
 
 	// NewCell initializes and returns a new jail cell.
 	NewCell(chatID string) (JailCell, error)

--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -20,7 +20,7 @@ const (
 
 // registerHandlers augments and transforms a given jail cell's underlying VM,
 // by adding and replacing method handlers.
-func registerHandlers(jail *Jail, cell *JailCell, chatID string) error {
+func registerHandlers(jail *Jail, cell *Cell, chatID string) error {
 	jeth, err := cell.Get("jeth")
 	if err != nil {
 		return err

--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/robertkrimen/otto"
+	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/jail/console"
 	"github.com/status-im/status-go/geth/node"
 )
@@ -20,7 +21,7 @@ const (
 
 // registerHandlers augments and transforms a given jail cell's underlying VM,
 // by adding and replacing method handlers.
-func registerHandlers(jail *Jail, cell *Cell, chatID string) error {
+func registerHandlers(jail *Jail, cell common.JailCell, chatID string) error {
 	jeth, err := cell.Get("jeth")
 	if err != nil {
 		return err

--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -70,18 +70,14 @@ func registerHandlers(jail *Jail, cell *Cell, chatID string) error {
 	if err = cell.Set("statusSignals", struct{}{}); err != nil {
 		return err
 	}
-
 	statusSignals, err := cell.Get("statusSignals")
 	if err != nil {
 		return err
 	}
-
 	registerHandler = statusSignals.Object().Set
-
 	if err = registerHandler("sendMessage", makeSendMessageHandler(chatID)); err != nil {
 		return err
 	}
-
 	if err = registerHandler("showSuggestions", makeShowSuggestionsHandler(chatID)); err != nil {
 		return err
 	}

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -123,12 +123,6 @@ func (jail *Jail) Parse(chatID, js string) string {
 		return makeError(err.Error())
 	}
 
-	// sendMessage/showSuggestions handlers
-	jcell.Set("statusSignals", struct{}{})
-	statusSignals, _ := jcell.Get("statusSignals")
-	statusSignals.Object().Set("sendMessage", makeSendMessageHandler(chatID))
-	statusSignals.Object().Set("showSuggestions", makeShowSuggestionsHandler(chatID))
-
 	jjs := string(web3JSCode) + `
 	var Web3 = require('web3');
 	var web3 = new Web3(jeth);

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -92,26 +92,26 @@ func (jail *Jail) Parse(chatID, js string) string {
 		return makeError(ErrInvalidJail.Error())
 	}
 
-	jailCell, err := jail.Cell(chatID)
+	cell, err := jail.Cell(chatID)
 	if err != nil {
 		if _, mkerr := jail.NewCell(chatID); mkerr != nil {
 			return makeError(mkerr.Error())
 		}
 
-		jailCell, _ = jail.Cell(chatID)
+		cell, _ = jail.Cell(chatID)
 	}
 
 	// init jeth and its handlers
-	if err = jailCell.Set("jeth", struct{}{}); err != nil {
+	if err = cell.Set("jeth", struct{}{}); err != nil {
 		return makeError(err.Error())
 	}
 
-	if err = registerHandlers(jail, jailCell, chatID); err != nil {
+	if err = registerHandlers(jail, cell, chatID); err != nil {
 		return makeError(err.Error())
 	}
 
 	initJs := jail.baseJSCode + ";"
-	if _, err = jailCell.Run(initJs); err != nil {
+	if _, err = cell.Run(initJs); err != nil {
 		return makeError(err.Error())
 	}
 
@@ -123,11 +123,11 @@ func (jail *Jail) Parse(chatID, js string) string {
             return new Bignumber(val);
         }
 	` + js + "; var catalog = JSON.stringify(_status_catalog);"
-	if _, err = jailCell.Run(jjs); err != nil {
+	if _, err = cell.Run(jjs); err != nil {
 		return makeError(err.Error())
 	}
 
-	res, err := jailCell.Get("catalog")
+	res, err := cell.Get("catalog")
 	if err != nil {
 		return makeError(err.Error())
 	}

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -32,8 +32,8 @@ type Jail struct {
 	nodeManager    common.NodeManager
 	accountManager common.AccountManager
 	policy         *ExecutionPolicy
-	cells          map[string]*JailCell // jail supports running many isolated instances of jailed runtime
-	baseJSCode     string               // JavaScript used to initialize all new cells with
+	cells          map[string]*Cell // jail supports running many isolated instances of jailed runtime
+	baseJSCode     string           // JavaScript used to initialize all new cells with
 }
 
 // New returns new Jail environment with the associated NodeManager and
@@ -42,7 +42,7 @@ func New(nodeManager common.NodeManager, accountManager common.AccountManager) *
 	return &Jail{
 		nodeManager:    nodeManager,
 		accountManager: accountManager,
-		cells:          make(map[string]*JailCell),
+		cells:          make(map[string]*Cell),
 		policy:         NewExecutionPolicy(nodeManager, accountManager),
 	}
 }
@@ -52,33 +52,34 @@ func (jail *Jail) BaseJS(js string) {
 	jail.baseJSCode = js
 }
 
-// NewJailCell initializes and returns jail cell.
-func (jail *Jail) NewJailCell(id string) (common.JailCell, error) {
+// NewCell initializes and returns a new jail cell.
+func (jail *Jail) NewCell(chatID string) (common.JailCell, error) {
 	if jail == nil {
 		return nil, ErrInvalidJail
 	}
 
 	vm := otto.New()
 
-	newJail, err := newJailCell(id, vm)
+	cell, err := newCell(chatID, vm)
 	if err != nil {
 		return nil, err
 	}
 
 	jail.Lock()
-	jail.cells[id] = newJail
+	jail.cells[chatID] = cell
 	jail.Unlock()
 
-	return newJail, nil
+	return cell, nil
 }
 
-// GetJailCell returns the associated *JailCell for the provided chatID.
-func (jail *Jail) GetJailCell(chatID string) (common.JailCell, error) {
-	return jail.GetCell(chatID)
+// Cell returns the existing instance of Cell.
+func (jail *Jail) Cell(chatID string) (common.JailCell, error) {
+	return jail.GetConcreteCell(chatID)
 }
 
-// GetCell returns the associated *JailCell for the provided chatID.
-func (jail *Jail) GetCell(chatID string) (*JailCell, error) {
+// Cell returns the associated *Cell for the provided chatID.
+// TODO(tiabc): Deal with this duplicated method.
+func (jail *Jail) GetConcreteCell(chatID string) (*Cell, error) {
 	jail.RLock()
 	defer jail.RUnlock()
 
@@ -92,20 +93,20 @@ func (jail *Jail) GetCell(chatID string) (*JailCell, error) {
 
 // Parse creates a new jail cell context, with the given chatID as identifier.
 // New context executes provided JavaScript code, right after the initialization.
-func (jail *Jail) Parse(chatID string, js string) string {
+func (jail *Jail) Parse(chatID, js string) string {
 	if jail == nil {
 		return makeError(ErrInvalidJail.Error())
 	}
 
 	var err error
-	var jcell *JailCell
+	var jcell *Cell
 
-	if jcell, err = jail.GetCell(chatID); err != nil {
-		if _, mkerr := jail.NewJailCell(chatID); mkerr != nil {
+	if jcell, err = jail.GetConcreteCell(chatID); err != nil {
+		if _, mkerr := jail.NewCell(chatID); mkerr != nil {
 			return makeError(mkerr.Error())
 		}
 
-		jcell, _ = jail.GetCell(chatID)
+		jcell, _ = jail.GetConcreteCell(chatID)
 	}
 
 	// init jeth and its handlers
@@ -149,9 +150,8 @@ func (jail *Jail) Parse(chatID string, js string) string {
 }
 
 // Call executes the `call` function w/i a jail cell context identified by the chatID.
-// Jail cell is clonned before call is executed i.e. all calls execute w/i their own contexts.
-func (jail *Jail) Call(chatID string, path string, args string) string {
-	jcell, err := jail.GetCell(chatID)
+func (jail *Jail) Call(chatID, path, args string) string {
+	jcell, err := jail.GetConcreteCell(chatID)
 	if err != nil {
 		return makeError(err.Error())
 	}

--- a/geth/jail/jail_cell.go
+++ b/geth/jail/jail_cell.go
@@ -8,11 +8,6 @@ import (
 	"github.com/status-im/ottoext/timers"
 )
 
-const (
-	// JailCellRequestTimeout seconds before jailed request times out.
-	JailCellRequestTimeout = 60
-)
-
 // Cell represents a single jail cell, which is basically a JavaScript VM.
 type Cell struct {
 	sync.Mutex

--- a/geth/jail/jail_cell.go
+++ b/geth/jail/jail_cell.go
@@ -13,18 +13,17 @@ const (
 	JailCellRequestTimeout = 60
 )
 
-// JailCell represents single jail cell, which is basically a JavaScript VM.
-// TODO(influx6): Rename JailCell to Cell in next refactoring phase.
-type JailCell struct {
+// Cell represents a single jail cell, which is basically a JavaScript VM.
+type Cell struct {
 	sync.Mutex
 
 	id string
 	vm *otto.Otto
 }
 
-// newJailCell encapsulates what we need to create a new jailCell from the
+// newCell encapsulates what we need to create a new jailCell from the
 // provided vm and eventloop instance.
-func newJailCell(id string, vm *otto.Otto) (*JailCell, error) {
+func newCell(id string, vm *otto.Otto) (*Cell, error) {
 	// create new event loop for the new cell.
 	// this loop is handling 'setTimeout/setInterval'
 	// calls and is running endlessly in a separate goroutine
@@ -37,17 +36,17 @@ func newJailCell(id string, vm *otto.Otto) (*JailCell, error) {
 	}
 
 	// finally, start loop in a goroutine
-	// JailCell is currently immortal, so the loop
+	// Cell is currently immortal, so the loop
 	go lo.Run()
 
-	return &JailCell{
+	return &Cell{
 		id: id,
 		vm: vm,
 	}, nil
 }
 
 // Set sets the value to be keyed by the provided keyname.
-func (cell *JailCell) Set(key string, val interface{}) error {
+func (cell *Cell) Set(key string, val interface{}) error {
 	cell.Lock()
 	defer cell.Unlock()
 
@@ -55,7 +54,7 @@ func (cell *JailCell) Set(key string, val interface{}) error {
 }
 
 // Get returns the giving key's otto.Value from the underline otto vm.
-func (cell *JailCell) Get(key string) (otto.Value, error) {
+func (cell *Cell) Get(key string) (otto.Value, error) {
 	cell.Lock()
 	defer cell.Unlock()
 
@@ -64,7 +63,7 @@ func (cell *JailCell) Get(key string) (otto.Value, error) {
 
 // Call attempts to call the internal call function for the giving response associated with the
 // proper values.
-func (cell *JailCell) Call(item string, this interface{}, args ...interface{}) (otto.Value, error) {
+func (cell *Cell) Call(item string, this interface{}, args ...interface{}) (otto.Value, error) {
 	cell.Lock()
 	defer cell.Unlock()
 
@@ -72,7 +71,7 @@ func (cell *JailCell) Call(item string, this interface{}, args ...interface{}) (
 }
 
 // Run evaluates the giving js string on the associated vm llop.
-func (cell *JailCell) Run(val string) (otto.Value, error) {
+func (cell *Cell) Run(val string) (otto.Value, error) {
 	cell.Lock()
 	defer cell.Unlock()
 

--- a/geth/jail/jail_cell_test.go
+++ b/geth/jail/jail_cell_test.go
@@ -70,7 +70,7 @@ func (s *JailTestSuite) TestJailTimeout() {
 func (s *JailTestSuite) TestJailLoopInCall() {
 	require := s.Require()
 
-	s.StartTestNode(params.RopstenNetworkID, true)
+	s.StartTestNode(params.RopstenNetworkID)
 	defer s.StopTestNode()
 
 	// load Status JS and add test command to it
@@ -105,8 +105,6 @@ func (s *JailTestSuite) TestJailLoopInCall() {
 	select {
 	case received := <-items:
 		require.Equal(received, "softball")
-		break
-
 	case <-time.After(5 * time.Second):
 		require.Fail("Failed to received event response")
 	}

--- a/geth/jail/jail_cell_test.go
+++ b/geth/jail/jail_cell_test.go
@@ -77,7 +77,7 @@ func (s *JailTestSuite) TestJailLoopInCall() {
 	s.jail.BaseJS(baseStatusJSCode)
 	s.jail.Parse(testChatID, ``)
 
-	cell, err := s.jail.GetConcreteCell(testChatID)
+	cell, err := s.jail.Cell(testChatID)
 	require.NoError(err)
 	require.NotNil(cell)
 

--- a/geth/jail/jail_cell_test.go
+++ b/geth/jail/jail_cell_test.go
@@ -11,11 +11,11 @@ func (s *JailTestSuite) TestJailTimeoutFailure() {
 	require := s.Require()
 	require.NotNil(s.jail)
 
-	cell, err := s.jail.NewJailCell(testChatID)
+	cell, err := s.jail.NewCell(testChatID)
 	require.NoError(err)
 	require.NotNil(cell)
 
-	// Attempt to run a timeout string against a JailCell.
+	// Attempt to run a timeout string against a Cell.
 	_, err = cell.Run(`
 		var timerCounts = 0;
  		setTimeout(function(n){		
@@ -42,11 +42,11 @@ func (s *JailTestSuite) TestJailTimeout() {
 	require := s.Require()
 	require.NotNil(s.jail)
 
-	cell, err := s.jail.NewJailCell(testChatID)
+	cell, err := s.jail.NewCell(testChatID)
 	require.NoError(err)
 	require.NotNil(cell)
 
-	// Attempt to run a timeout string against a JailCell.
+	// Attempt to run a timeout string against a Cell.
 	_, err = cell.Run(`
 		var timerCounts = 0;
  		setTimeout(function(n){		
@@ -80,7 +80,7 @@ func (s *JailTestSuite) TestJailLoopInCall() {
 	s.jail.BaseJS(baseStatusJSCode)
 	s.jail.Parse(testChatID, ``)
 
-	cell, err := s.jail.GetCell(testChatID)
+	cell, err := s.jail.GetConcreteCell(testChatID)
 	require.NoError(err)
 	require.NotNil(cell)
 

--- a/geth/jail/jail_cell_test.go
+++ b/geth/jail/jail_cell_test.go
@@ -9,7 +9,6 @@ import (
 
 func (s *JailTestSuite) TestJailTimeoutFailure() {
 	require := s.Require()
-	require.NotNil(s.jail)
 
 	cell, err := s.jail.NewCell(testChatID)
 	require.NoError(err)
@@ -40,7 +39,6 @@ func (s *JailTestSuite) TestJailTimeoutFailure() {
 
 func (s *JailTestSuite) TestJailTimeout() {
 	require := s.Require()
-	require.NotNil(s.jail)
 
 	cell, err := s.jail.NewCell(testChatID)
 	require.NoError(err)
@@ -71,7 +69,6 @@ func (s *JailTestSuite) TestJailTimeout() {
 
 func (s *JailTestSuite) TestJailLoopInCall() {
 	require := s.Require()
-	require.NotNil(s.jail)
 
 	s.StartTestNode(params.RopstenNetworkID, true)
 	defer s.StopTestNode()

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -122,7 +122,7 @@ func (s *JailTestSuite) TestFunctionCall() {
 func (s *JailTestSuite) TestJailRPCSend() {
 	require := s.Require()
 
-	s.StartTestNode(params.RopstenNetworkID, false)
+	s.StartTestNode(params.RopstenNetworkID)
 	defer s.StopTestNode()
 
 	// load Status JS and add test command to it
@@ -155,7 +155,7 @@ func (s *JailTestSuite) TestJailRPCSend() {
 func (s *JailTestSuite) TestIsConnected() {
 	require := s.Require()
 
-	s.StartTestNode(params.RopstenNetworkID, false)
+	s.StartTestNode(params.RopstenNetworkID)
 	defer s.StopTestNode()
 
 	s.jail.Parse(testChatID, "")
@@ -225,15 +225,15 @@ func (s *JailTestSuite) TestLocalStorageSet() {
 	case <-opCompletedSuccessfully:
 		// pass
 	case <-time.After(3 * time.Second):
-		s.Fail("operation timed out")
+		require.Fail("operation timed out")
 	}
 
 	responseValue, err := cell.Get("responseValue")
-	s.NoError(err, "cannot obtain result of localStorage.set()")
+	require.NoError(err, "cannot obtain result of localStorage.set()")
 
 	response, err := responseValue.ToString()
-	s.NoError(err, "cannot parse result")
+	require.NoError(err, "cannot parse result")
 
 	expectedResponse := `{"jsonrpc":"2.0","result":true}`
-	s.Equal(expectedResponse, response)
+	require.Equal(expectedResponse, response)
 }

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -54,7 +54,7 @@ func (s *JailTestSuite) TestInit() {
 	}
 
 	// get cell VM w/o defining cell first
-	cell, err := s.jail.GetCell(testChatID)
+	cell, err := s.jail.GetConcreteCell(testChatID)
 	require.EqualError(err, "cell[testChat] doesn't exist")
 	require.Nil(cell)
 
@@ -65,7 +65,7 @@ func (s *JailTestSuite) TestInit() {
 	require.Equal(errorWrapper(err), s.jail.Call(testChatID, `["commands", "testCommand"]`, `{"val": 12}`))
 
 	// get existing cell (even though we got errors, cell was still created)
-	cell, err = s.jail.GetCell(testChatID)
+	cell, err = s.jail.GetConcreteCell(testChatID)
 	require.NoError(err)
 	require.NotNil(cell)
 
@@ -134,7 +134,7 @@ func (s *JailTestSuite) TestJailRPCSend() {
 	s.jail.Parse(testChatID, ``)
 
 	// obtain VM for a given chat (to send custom JS to jailed version of Send())
-	cell, err := s.jail.GetCell(testChatID)
+	cell, err := s.jail.GetConcreteCell(testChatID)
 	require.NoError(err)
 	require.NotNil(cell)
 
@@ -168,7 +168,7 @@ func (s *JailTestSuite) TestIsConnected() {
 	s.jail.Parse(testChatID, "")
 
 	// obtain VM for a given chat (to send custom JS to jailed version of Send())
-	cell, err := s.jail.GetCell(testChatID)
+	cell, err := s.jail.GetConcreteCell(testChatID)
 	require.NoError(err)
 
 	_, err = cell.Run(`
@@ -194,7 +194,7 @@ func (s *JailTestSuite) TestLocalStorageSet() {
 	s.jail.Parse(testChatID, "")
 
 	// obtain VM for a given chat (to send custom JS to jailed version of Send())
-	cell, err := s.jail.GetCell(testChatID)
+	cell, err := s.jail.GetConcreteCell(testChatID)
 	require.NoError(err)
 
 	testData := "foobar"

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -47,7 +47,6 @@ func (s *JailTestSuite) SetupTest() {
 
 func (s *JailTestSuite) TestInit() {
 	require := s.Require()
-	require.NotNil(s.jail)
 
 	errorWrapper := func(err error) string {
 		return `{"error":"` + err.Error() + `"}`
@@ -88,7 +87,6 @@ func (s *JailTestSuite) TestInit() {
 
 func (s *JailTestSuite) TestParse() {
 	require := s.Require()
-	require.NotNil(s.jail)
 
 	extraCode := `
 	var _status_catalog = {
@@ -102,7 +100,6 @@ func (s *JailTestSuite) TestParse() {
 
 func (s *JailTestSuite) TestFunctionCall() {
 	require := s.Require()
-	require.NotNil(s.jail)
 
 	// load Status JS and add test command to it
 	statusJS := baseStatusJSCode + `;
@@ -124,7 +121,6 @@ func (s *JailTestSuite) TestFunctionCall() {
 
 func (s *JailTestSuite) TestJailRPCSend() {
 	require := s.Require()
-	require.NotNil(s.jail)
 
 	s.StartTestNode(params.RopstenNetworkID, false)
 	defer s.StopTestNode()
@@ -158,11 +154,8 @@ func (s *JailTestSuite) TestJailRPCSend() {
 
 func (s *JailTestSuite) TestIsConnected() {
 	require := s.Require()
-	require.NotNil(s.jail)
 
-	// TODO(tiabc): Is this required?
 	s.StartTestNode(params.RopstenNetworkID, false)
-
 	defer s.StopTestNode()
 
 	s.jail.Parse(testChatID, "")
@@ -189,7 +182,6 @@ func (s *JailTestSuite) TestIsConnected() {
 
 func (s *JailTestSuite) TestLocalStorageSet() {
 	require := s.Require()
-	require.NotNil(s.jail)
 
 	s.jail.Parse(testChatID, "")
 

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -53,7 +53,7 @@ func (s *JailTestSuite) TestInit() {
 	}
 
 	// get cell VM w/o defining cell first
-	cell, err := s.jail.GetConcreteCell(testChatID)
+	cell, err := s.jail.Cell(testChatID)
 	require.EqualError(err, "cell[testChat] doesn't exist")
 	require.Nil(cell)
 
@@ -64,7 +64,7 @@ func (s *JailTestSuite) TestInit() {
 	require.Equal(errorWrapper(err), s.jail.Call(testChatID, `["commands", "testCommand"]`, `{"val": 12}`))
 
 	// get existing cell (even though we got errors, cell was still created)
-	cell, err = s.jail.GetConcreteCell(testChatID)
+	cell, err = s.jail.Cell(testChatID)
 	require.NoError(err)
 	require.NotNil(cell)
 
@@ -130,7 +130,7 @@ func (s *JailTestSuite) TestJailRPCSend() {
 	s.jail.Parse(testChatID, ``)
 
 	// obtain VM for a given chat (to send custom JS to jailed version of Send())
-	cell, err := s.jail.GetConcreteCell(testChatID)
+	cell, err := s.jail.Cell(testChatID)
 	require.NoError(err)
 	require.NotNil(cell)
 
@@ -161,7 +161,7 @@ func (s *JailTestSuite) TestIsConnected() {
 	s.jail.Parse(testChatID, "")
 
 	// obtain VM for a given chat (to send custom JS to jailed version of Send())
-	cell, err := s.jail.GetConcreteCell(testChatID)
+	cell, err := s.jail.Cell(testChatID)
 	require.NoError(err)
 
 	_, err = cell.Run(`
@@ -186,7 +186,7 @@ func (s *JailTestSuite) TestLocalStorageSet() {
 	s.jail.Parse(testChatID, "")
 
 	// obtain VM for a given chat (to send custom JS to jailed version of Send())
-	cell, err := s.jail.GetConcreteCell(testChatID)
+	cell, err := s.jail.Cell(testChatID)
 	require.NoError(err)
 
 	testData := "foobar"

--- a/geth/node/manager_test.go
+++ b/geth/node/manager_test.go
@@ -248,7 +248,7 @@ func (s *ManagerTestSuite) TestReferences() {
 	}
 
 	// test with node fully started
-	s.StartTestNode(params.RinkebyNetworkID, false)
+	s.StartTestNode(params.RinkebyNetworkID)
 	defer s.StopTestNode()
 	var nodeReadyTestCases = []struct {
 		name         string
@@ -403,7 +403,7 @@ func (s *ManagerTestSuite) TestResetChainData() {
 	require := s.Require()
 	require.NotNil(s.NodeManager)
 
-	s.StartTestNode(params.RinkebyNetworkID, false)
+	s.StartTestNode(params.RinkebyNetworkID)
 	defer s.StopTestNode()
 
 	time.Sleep(2 * time.Second) // allow to sync for some time
@@ -422,7 +422,7 @@ func (s *ManagerTestSuite) TestRestartNode() {
 	require := s.Require()
 	require.NotNil(s.NodeManager)
 
-	s.StartTestNode(params.RinkebyNetworkID, false)
+	s.StartTestNode(params.RinkebyNetworkID)
 	defer s.StopTestNode()
 
 	s.True(s.NodeManager.IsNodeRunning())

--- a/geth/node/whisper_test.go
+++ b/geth/node/whisper_test.go
@@ -1,8 +1,8 @@
 package node_test
 
 import (
-	"testing"
 	"context"
+	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
@@ -30,7 +30,7 @@ func (s *WhisperTestSuite) TestWhisperFilterRace() {
 	require := s.Require()
 	require.NotNil(s.NodeManager)
 
-	s.StartTestNode(params.RinkebyNetworkID, false)
+	s.StartTestNode(params.RinkebyNetworkID)
 	defer s.StopTestNode()
 
 	whisperService, err := s.NodeManager.WhisperService()


### PR DESCRIPTION
From the original requirements:
> 1. Rename methods of the `common.JailCell` interface:
> CellVM() -> VM()
> CellLoop() -> Loop()

Not applicable as there're no such methods anymore.

> 2. Get rid of duplicated code in common.Jail struct methods: Call, JailCell, JailCellVM, GetCell.

Not applicable.

> 3. Get rid of the `Jail` prefix everywhere in the `jail` package.

Done.

> 4. Rewrite tests to use `jail.NewJailCell` instead of `jailInstance.Parse(testChatID, ``)`.

Not applicable. These 2 functions serve different functions. And the latter deserves better name which was out of scope.

> 5. In JailTestSuite initialise the internal jail with BaseJS in SetupSuite and initialise a test jail cell in SetupTest. The idea is to make those tests as meaningful as possible avoiding as much extra scaffolding as we can.

Not applicable. Some tests should be initialised otherwise. Long tests should definitely be shortened but it's out of scope.

> 6. Refactor all tests to use `testify` asserts. Tests become twice as short and twice as meaningful.

Done.

> 7. Figure out if one of `Jail.GetJailCell` and `Jail.GetCell` could be removed. This looks like rather an architecture issue.

Removed one of them. @influx6 I need your opinion on this: https://github.com/status-im/status-go/commit/6755b605486a2ace5eff9fa011a25fdfa1ed88e9

> 8. See if it's possible to invoke `jail.BaseJS` in setup methods in JailTestSuite instead of doing it in every test.

Not possible, unfortunately.

Also:
1. Fixed naming in different places.
2. Introduced a way to specify upstream url in tests with functional options.
3. Removed redundant `statusSignals` setting.
4. Removed unused `JailCellRequestTimeout`.