### PR TITLE
vendor: Upgrade go-stack

### DIFF
--- a/vendor/github.com/go-stack/stack/LICENSE.md
+++ b/vendor/github.com/go-stack/stack/LICENSE.md
@@ -1,13 +1,21 @@
-Copyright 2014 Chris Hines
+The MIT License (MIT)
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Copyright (c) 2014 Chris Hines
 
-   http://www.apache.org/licenses/LICENSE-2.0
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Upgrade go-stack dependency to 1.54. This addresses https://github.com/status-im/status-go/issues/273

This is a very small update in `go-stack` that works around environments that don't handle sigpanic well. Relevant release notes: https://github.com/go-stack/stack/releases/tag/v1.5.4

Old go-stack:
```
(lldb) error: libarclite_iphoneos.a(arclite.o) failed to load objfile for /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_iphoneos.a
Process 370 stopped
* thread #5, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x00000001007e8660 StatusIm`github.com/status-im/status-go/vendor/github.com/go-stack/stack.findSigpanic.func1 + 104
StatusIm`github.com/status-im/status-go/vendor/github.com/go-stack/stack.findSigpanic.func1:
->  0x1007e8660 <+104>: ldr    x1, [x0]
    0x1007e8664 <+108>: str    x1, [sp, #0x38]
    0x1007e8668 <+112>: nop
    0x1007e866c <+116>: bl     0x1002145c8               ; runtime.deferreturn
(lldb)
```

New go-stack:

```
(lldb) error: libarclite_iphoneos.a(arclite.o) failed to load objfile for /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_iphoneos.a
2017-09-02 20:07:06.474 [info][tid:main][RCTBatchedBridge.m:75] Initializing <RCTBatchedBridge: 0x1741a1c00> (parent: <RCTBridge: 0x1740c6660>, executor: RCTJSCExecutor)
2017-09-02 20:07:06.527 [warn][tid:com.facebook.react.JavaScript][RCTModuleData.mm:220] RCTBridge required dispatch_sync to load RCTDevSettings. This may lead to deadlocks
2017-09-02 20:07:06.542 StatusIm[472] <Error> [Firebase/Core][I-COR000003] The default Firebase app has not yet been configured. Add [FIRApp configure] to your application initialization. Read more: https://goo.gl/ctyzm8.
(lldb)

...app continues to run...
```