### PR TITLE
Support simple metrics with expvars

### DIFF
--- a/cmd/statusd/library.go
+++ b/cmd/statusd/library.go
@@ -12,6 +12,8 @@ import (
 	"github.com/status-im/status-go/geth/log"
 	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/helpers/profiling"
+
+	_ "github.com/status-im/status-go/helpers/expvars"
 )
 
 //export GenerateConfig

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -9,6 +9,7 @@ import (
 	"github.com/robertkrimen/otto"
 	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/log"
+	"github.com/status-im/status-go/helpers/expvars"
 	"github.com/status-im/status-go/static"
 )
 
@@ -68,6 +69,8 @@ func (jail *Jail) NewCell(chatID string) (common.JailCell, error) {
 	jail.Lock()
 	jail.cells[chatID] = cell
 	jail.Unlock()
+
+	expvars.Cells.Add(1)
 
 	return cell, nil
 }

--- a/geth/node/manager.go
+++ b/geth/node/manager.go
@@ -16,6 +16,7 @@ import (
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
 	"github.com/status-im/status-go/geth/log"
 	"github.com/status-im/status-go/geth/params"
+	"github.com/status-im/status-go/helpers/expvars"
 )
 
 // errors
@@ -286,6 +287,8 @@ func (m *NodeManager) addPeer(url string) error {
 		return err
 	}
 	server.AddPeer(parsedNode)
+
+	expvars.Peers.Add(1)
 
 	return nil
 }

--- a/helpers/expvars/README.md
+++ b/helpers/expvars/README.md
@@ -47,7 +47,7 @@ Note: you may define new vars in any package, but it would be nice to keep all e
 # Monitoring
 Setting up the monitoring/metrics stack is too expensive for debug sessions or even impossible for mobile environment.
 
-There is a tool for easy zero-cost expvar monitoring, [expvarmon](https://github.com/divan/expvarmon). Here is an example output for `statusd`:
+There is a tool for easy zero-conf expvar monitoring, [expvarmon](https://github.com/divan/expvarmon). Here is an example output for `statusd`:
 
 ![](https://i.imgur.com/oz11bmT.png)
 

--- a/helpers/expvars/README.md
+++ b/helpers/expvars/README.md
@@ -1,0 +1,58 @@
+# expvars
+--
+
+Expvars package is a helper package to use "exported vars" metrics in `status-go`.
+
+Expvar is a wrapper around stdlib [expvar](https://golang.org/pkg/expvar/) package, which exposes http endpoint `/debug/vars` with JSON containing exported vars.
+
+This JSON can be later polled by any metrics/monitoring tool for further analysis/display.
+
+## Usage
+
+First, define variable of function in `expvars.go` for easy usage from other packages:
+
+## Creating new var
+### Simple variables:
+
+```go
+var Peers = expvar.NewInt("Peers")
+```
+
+### Functions:
+You may also define more complex metrics using functions:
+
+```go
+func goroutines() interface{} {
+	return runtime.NumGoroutine()
+}
+...
+expvar.Publish("Goroutines", expvar.Func(goroutines))
+```
+## Using new var
+Second, import package:
+
+```go
+import "github.com/status-im/status-go/helpers/expvars"
+```
+
+then, use exported variable and change its value:
+
+```go
+expvars.Peers.Add(1)
+```
+And that's it. Exported field `"Peers"` with actualized value will appear in JSON returned by `/debug/vars` endpoint.
+
+Note: you may define new vars in any package, but it would be nice to keep all exported vars in one placce.
+
+# Monitoring
+Setting up the monitoring/metrics stack is too expensive for debug sessions or even impossible for mobile environment.
+
+There is a tool for easy zero-cost expvar monitoring, [expvarmon](https://github.com/divan/expvarmon). Here is an example output for `statusd`:
+
+![](https://i.imgur.com/oz11bmT.png)
+
+Command to use:
+
+```bash
+expvarmon -ports 10000 -vars Goroutines,duration:Uptime,Cells,Peers,mem:memstats.Alloc,mem:memstats.Sys,mem:memstats.HeapAlloc,mem:memstats.HeapInuse,duration:memstats.PauseNs,duration:memstats.PauseTotalNs -i 500ms
+```

--- a/helpers/expvars/README.md
+++ b/helpers/expvars/README.md
@@ -56,3 +56,9 @@ Command to use:
 ```bash
 expvarmon -ports 10000 -vars Goroutines,duration:Uptime,Cells,Peers,mem:memstats.Alloc,mem:memstats.Sys,mem:memstats.HeapAlloc,mem:memstats.HeapInuse,duration:memstats.PauseNs,duration:memstats.PauseTotalNs -i 500ms
 ```
+
+# Further read
+If you want to learn better `expvar` package, a few links:
+
+ - [http://blog.ralch.com/tutorial/golang-metrics-with-expvar/](http://blog.ralch.com/tutorial/golang-metrics-with-expvar/)
+ - [https://golang.org/pkg/expvar/](https://golang.org/pkg/expvar/)

--- a/helpers/expvars/expvars.go
+++ b/helpers/expvars/expvars.go
@@ -8,7 +8,13 @@ import (
 	"time"
 )
 
-var startTime = time.Now().UTC()
+var (
+	// Example exported vars
+	Cells = expvar.NewInt("Cells")
+	Peers = expvar.NewInt("Peers")
+
+	startTime = time.Now().UTC()
+)
 
 // goroutines is an expvar.Func compliant
 // wrapper for active goroutines counter

--- a/helpers/expvars/expvars.go
+++ b/helpers/expvars/expvars.go
@@ -1,0 +1,36 @@
+package expvars
+
+import (
+	"expvar"
+	"fmt"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+var startTime = time.Now().UTC()
+
+// goroutines is an expvar.Func compliant
+// wrapper for active goroutines counter
+func goroutines() interface{} {
+	return runtime.NumGoroutine()
+}
+
+// uptime is an expvar.Func compliant
+// wrapper for uptime info
+func uptime() interface{} {
+	uptime := time.Since(startTime)
+	return int64(uptime)
+}
+
+func init() {
+	expvar.Publish("Goroutines", expvar.Func(goroutines))
+	expvar.Publish("Uptime", expvar.Func(uptime))
+
+	fmt.Println("Starting expvars")
+	expvarsPort := ":10000" //os.Getenv("STATUS_EXPVARS")
+	if expvarsPort != "" {
+		go http.ListenAndServe(expvarsPort, nil)
+	}
+
+}


### PR DESCRIPTION
This PR adds support for `expvar` metrics for Go code. It's stdlib metrics easy-to-use mechanism, which can be nicely used together with zero-conf [expvarmon](https://github.com/divan/expvarmon) to monitor app in a development/debugging sessions. 

Note, this is work in progress and few questions need to be solved:
 - start http server for expvar only in debug mode
 - agree on port or provide configuration options
 - add more relevant metrics for developers

Currently server starts on tcp port 10000. To use it with android emulator, run:
```adb forward tcp:10000 tcp:10000```

Please see [README.md](https://github.com/status-im/status-go/blob/7c8ba78cc219f04fb8aa3666dc6fd3c4752e1314/helpers/expvars/README.md) for more details.

Example `expvarmon` screen, updating each 500ms:
![](https://i.imgur.com/oz11bmT.png)

More links on using expvars:
 - [http://blog.ralch.com/tutorial/golang-metrics-with-expvar/](http://blog.ralch.com/tutorial/golang-metrics-with-expvar/)
 - [https://golang.org/pkg/expvar/](https://golang.org/pkg/expvar/)