### PR TITLE
vendor: clean up go-ethereum

### DIFF
--- a/vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go
+++ b/vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go
@@ -1180,7 +1180,7 @@ func submitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	return tx.Hash(), nil
 }
 
-// CompleteQueuedTransaction creates a transaction by unpacking queued transaction, signs it and submits to the
+// SendTransaction creates a transaction by unpacking queued transaction, signs it and submits to the
 // transaction pool.
 func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args SendTxArgs, passphrase string) (common.Hash, error) {
 	// Set some sanity defaults and terminate on failure

--- a/vendor/github.com/ethereum/go-ethereum/les/status/accounts.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/status/accounts.go
@@ -5,8 +5,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const SelectedAccountKey = "selected_account"
-
 // AccountManager abstracts both internal account manager and extra filter status backend requires
 type AccountManager struct {
 	am                    *accounts.Manager


### PR DESCRIPTION
The goal of this PR is to remove any differences between go-ethereum in the vendor dir and our fork status-im/go-ethereum branch `status/1.6.7-stable`.