### PR TITLE
Build binaries for various platforms in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ node {
             sh '''
                 set +x
 
-                version="${GIT_BRANCH##origin/}-g${GIT_COMMIT:0:7}"
+                version=$(echo "${GIT_BRANCH##origin/}-g${GIT_COMMIT:0:7}" | tr / -)
                 curl -u "${USERPASS}" \
                     -X PUT "http://139.162.11.12:8081/artifactory/libs-release-local/status-im/status-go/${version}/status-go-${version}.aar" \
                     -T ./build/bin/statusgo-android-16.aar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,26 +1,29 @@
 node {
     stage('Debug') {
-        sh 'echo ${env}'
+        sh 'env'
     }
 
     stage('Build') {
-        sh 'make statusgo-android'
+        def scmVars = checkout scm
+        print scmVars
+
+        // sh 'make statusgo-android'
     }
 
-    stage('Deploy') {
-        withCredentials([usernameColonPassword(credentialsId: 'artifactory-deploy-bot', variable: 'USERPASS')]) {
-            gitSHA = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
-            gitShortSHA = gitCommit.take(7)
-            gitBranch = sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
+    // stage('Deploy') {
+    //     withCredentials([usernameColonPassword(credentialsId: 'artifactory-deploy-bot', variable: 'USERPASS')]) {
+    //         gitSHA = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+    //         gitShortSHA = gitCommit.take(7)
+    //         gitBranch = sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
 
-            sh '''
-                set +x
+    //         sh '''
+    //             set +x
 
-                version=$(echo "${gitBranch##origin/}-${gitShortSHA}" | tr / -)
-                curl -u "${USERPASS}" \
-                    -X PUT "http://139.162.11.12:8081/artifactory/libs-release-local/status-im/status-go/${version}/status-go-${version}.aar" \
-                    -T ./build/bin/statusgo-android-16.aar
-            '''
-        }
-    }
+    //             version=$(echo "${gitBranch##origin/}-${gitShortSHA}" | tr / -)
+    //             curl -u "${USERPASS}" \
+    //                 -X PUT "http://139.162.11.12:8081/artifactory/libs-release-local/status-im/status-go/${version}/status-go-${version}.aar" \
+    //                 -T ./build/bin/statusgo-android-16.aar
+    //         '''
+    //     }
+    // }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,19 @@
+def version(branch, sha) {
+    return branch.replaceAll(/\//, '-') + '-' + sha
+}
+
 node {
+    def remoteOriginRegex = ~/^remotes\/origin\//
+
     gitSHA = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
     gitShortSHA = gitSHA.take(7)
-    gitBranch = sh(returnStdout: true, script: 'git name-rev --name-only HEAD').trim()
+    String gitBranch = sh(returnStdout: true, script: 'git name-rev --name-only HEAD').trim() - remoteOriginRegex
 
     stage('Debug') {
         sh 'env'
-        print gitBranch
-        print gitSHA
+        println(gitBranch)
+        println(gitSHA)
+        println(version(gitBranch, gitShortSHA))
     }
 
     // stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,17 @@
 node {
+    gitSHA = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+    gitShortSHA = gitCommit.take(7)
+    gitBranch = sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
+
     stage('Debug') {
         sh 'env'
+        print gitBranch
+        print gitSHA
     }
 
-    stage('Build') {
-        def scmVars = checkout scm
-        print scmVars.GIT_COMMIT
-        // sh 'make statusgo-android'
-    }
+    // stage('Build') {
+    //     sh 'make statusgo-android'
+    // }
 
     // stage('Deploy') {
     //     withCredentials([usernameColonPassword(credentialsId: 'artifactory-deploy-bot', variable: 'USERPASS')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,6 @@ node {
     }
 
     stage('Deploy') {
-        let version=$(get_version ${TRAVIS_BRANCH} ${TRAVIS_COMMIT})
-
         withCredentials([usernameColonPassword(credentialsId: 'artifactory-deploy-bot', variable: 'USERPASS')]) {
             sh '''
                 set +x

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,11 @@ node {
         println(gitSHA)
     }
 
+    // TODO(adam): enable when unit tests start passing
+    // stage('Test') {
+    //     sh 'make ci'
+    // }
+
     stage('Build') {
         sh 'make statusgo-android'
     }
@@ -36,10 +41,13 @@ node {
             ]
         }"""
 
+        // TODO(adam): do we need a POM file?
+
         def buildInfo = Artifactory.newBuildInfo()
+        buildInfo.name = 'status-go'
         server.upload(uploadSpec, buildInfo)
-        // server upload iOS
-        // server upload iOS simulator
+        // TODO(adam): server upload iOS
+        // TODO(adam): server upload iOS simulator
         server.publishBuildInfo(buildInfo)
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,15 +47,6 @@ node {
     stage('Deploy') {
         // For branch builds, replace the old artifact. For develop keep all of them.
         def version = gitBranch == 'develop' ? getVersion(gitBranch, gitShortSHA) : getVersion(gitBranch, '')
-
-        // Clean up the previous artifacts.
-        withCredentials([usernameColonPassword(credentialsId: 'artifactory-deploy-bot', variable: 'USERPASS')]) {
-            sh """
-                curl -u "${USERPASS}" -X DELETE "http://artifacts.status.im:8081/artifactory/libs-release-local/status-im/status-go/${version}"
-                curl -u "${USERPASS}" -X DELETE "http://artifacts.status.im:8081/artifactory/libs-release-local/status-im/status-go-ios-simulator/${version}"
-            """
-        }
-
         def server = Artifactory.server 'artifactory'
         def uploadSpec = """{
             "files": [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 node {
     stage('Build') {
         sh 'make statusgo'
+        sh 'make statusgo-android'
     }
 
     stage('Deploy') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,9 @@
+node {
+    stage('Build') {
+        echo 'Build'
+    }
+
+    stage('Deploy') {
+        echo 'Deploy'
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,15 +25,18 @@ node {
     }
 
     stage('Deploy') {
-        env.version = getVersion(gitBranch, gitShortSHA)
+        def version = getVersion(gitBranch, gitShortSHA)
+        def server = Artifactory.server 'artifactory'
+        def uploadSpec = """{
+            "files": [
+                {
+                    "pattern": "build/bin/statusgo-android-16.aar",
+                    "target": "libs-release-local/status-im/status-go/${version}/status-go-${version}.aar"
+                }
+            ]
+        }"""
 
-        withCredentials([usernameColonPassword(credentialsId: 'artifactory-deploy-bot', variable: 'USERPASS')]) {
-            sh '''
-                set +x
-                curl -u "${USERPASS}" \
-                    -X PUT "http://139.162.11.12:8081/artifactory/libs-release-local/status-im/status-go/${version}/status-go-${version}.aar" \
-                    -T ./build/bin/statusgo-android-16.aar
-            '''
-        }
+        def buildInfo = server.upload(uploadSpec)
+        println(buildInfo)
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 node {
     gitSHA = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
     gitShortSHA = gitSHA.take(7)
-    gitBranch = sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
+    gitBranch = sh(returnStdout: true, script: 'git name-rev --name-only HEAD').trim()
 
     stage('Debug') {
         sh 'env'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,8 @@ node {
     stage('Build') {
         def scmVars = checkout scm
         print scmVars
-
+        print scmVars.BRANCH_NAME
+        print scmVars['GIT_COMMIT']
         // sh 'make statusgo-android'
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 node {
     stage('Build') {
-        echo 'Build'
+        sh 'make statusgo'
     }
 
     stage('Deploy') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,8 @@ def getVersion(branch, sha) {
 }
 
 node {
+    checkout scm
+
     def remoteOriginRegex = ~/^remotes\/origin\//
 
     gitSHA = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,24 @@
 node {
+    stage('Debug') {
+        sh 'env'
+    }
+
     stage('Build') {
-        sh 'make statusgo'
         sh 'make statusgo-android'
     }
 
     stage('Deploy') {
-        echo 'Deploy'
+        let version=$(get_version ${TRAVIS_BRANCH} ${TRAVIS_COMMIT})
+
+        withCredentials([usernameColonPassword(credentialsId: 'artifactory-deploy-bot', variable: 'USERPASS')]) {
+            sh '''
+                set +x
+
+                version="${GIT_BRANCH##origin/}-g${GIT_COMMIT:0:7}"
+                curl -u "${USERPASS}" \
+                    -X PUT "http://139.162.11.12:8081/artifactory/libs-release-local/status-im/status-go/${version}/status-go-${version}.aar" \
+                    -T ./build/bin/statusgo-android-16.aar
+            '''
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,7 @@ node {
 
     stage('Build') {
         def scmVars = checkout scm
-        print scmVars
-        print scmVars.BRANCH_NAME
-        print scmVars['GIT_COMMIT']
+        print scmVars.GIT_COMMIT
         // sh 'make statusgo-android'
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 node {
     gitSHA = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
-    gitShortSHA = gitCommit.take(7)
+    gitShortSHA = gitSHA.take(7)
     gitBranch = sh(returnStdout: true, script: 'git rev-parse --abbrev-ref HEAD').trim()
 
     stage('Debug') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,10 @@ node {
             ]
         }"""
 
-        def buildInfo = server.upload(uploadSpec)
-        println(buildInfo)
+        def buildInfo = Artifactory.newBuildInfo()
+        server.upload(uploadSpec, buildInfo)
+        // server upload iOS
+        // server upload iOS simulator
+        server.publishBuildInfo(buildInfo)
     }
 }


### PR DESCRIPTION
This PR provides a Jenkinsfile and enables automatic builds of status-go binaries for various platforms and deploys them to the artifacts manager.

**TBD: deploy strategy** 
1. Deploy artifacts for every commit for every branch (version like `feature-ci-build-024b3c5`; lots of artifacts, many can be broken),
2. Deploy artifacts just per branch (will overwrite with each commit; version like `feature-ci-build`; changing binary of once released version is confusing),
3. Deploy only after merge to `develop` (version like `0.9.8-024b3c5`).

I recommend the third option for the time being, with an additional Jenkins job which one can use to manually generate binaries for an arbitrary branch if needed.

@tiabc @rasom which strategy is the most useful for you?

**Todo:**
- [ ] ~~is `pom.xml` required? (cc @rasom)~~ (not needed)
- [x] should we enabled iOS builds or Android is enough for now? (cc @rasom) 

