### PR TITLE
Fixed jail hanging

### DIFF
--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -274,7 +274,7 @@ type JailManager interface {
 	Parse(chatID, js string) string
 
 	// Call executes given JavaScript function w/i a jail cell context identified by the chatID.
-	Call(chatID, this, args string) string
+	Call(chatID, path, args string) string
 
 	// NewCell initializes and returns a new jail cell.
 	NewCell(chatID string) (JailCell, error)

--- a/geth/common/utils.go
+++ b/geth/common/utils.go
@@ -90,7 +90,6 @@ func PanicAfter(waitSeconds time.Duration, abort chan struct{}, desc string) {
 	go func() {
 		select {
 		case <-abort:
-			return
 		case <-time.After(waitSeconds):
 			panic("whatever you were doing takes toooo long: " + desc)
 		}

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -136,13 +136,13 @@ func (jail *Jail) Parse(chatID, js string) string {
 }
 
 // Call executes the `call` function w/i a jail cell context identified by the chatID.
-func (jail *Jail) Call(chatID, this, args string) string {
+func (jail *Jail) Call(chatID, path, args string) string {
 	cell, err := jail.Cell(chatID)
 	if err != nil {
 		return makeError(err.Error())
 	}
 
-	res, err := cell.Call("call", nil, this, args)
+	res, err := cell.Call("call", nil, path, args)
 
 	return makeResult(res.String(), err)
 }


### PR DESCRIPTION
Fixed that if you send `sendTransaction` to jail and don't confirm it, the jail is inaccessible for the following 5 minutes until the transaction automatically discarded.
Now `sendTransaction` is executed synchronously but if callback is provided, it returns immediately and executes callback later.