### PR TITLE
Bugfix/eth accounts workaround #294

### DIFF
--- a/geth/api/backend_accounts_test.go
+++ b/geth/api/backend_accounts_test.go
@@ -335,3 +335,47 @@ func (s *BackendTestSuite) TestSelectedAccountOnRestart() {
 	require.EqualError(node.ErrNoAccountSelected, err.Error())
 	require.Nil(selectedAccount)
 }
+
+func (s *BackendTestSuite) TestRPCEthAccounts() {
+	require := s.Require()
+
+	s.StartTestBackend(params.RopstenNetworkID)
+	defer s.StopTestBackend()
+
+	// log into test account
+	err := s.backend.AccountManager().SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
+	require.NoError(err)
+
+	rpcClient := s.backend.NodeManager().RPCClient()
+
+	expectedResponse := `{"jsonrpc":"2.0","id":1,"result":["0xadaf150b905cf5e6a778e553e15a139b6618bbb7"]}`
+	resp := rpcClient.CallRaw(`{
+              "jsonrpc": "2.0",
+              "id":1,
+              "method": "eth_accounts",
+              "params": []
+      }`)
+	require.Equal(expectedResponse, resp)
+}
+
+func (s *BackendTestSuite) TestRPCEthAccountsWithUpstream() {
+	require := s.Require()
+
+	s.StartTestBackend(params.RopstenNetworkID, WithUpstream("https://ropsten.infura.io/z6GCTmjdP3FETEJmMBI4"))
+	defer s.StopTestBackend()
+
+	// log into test account
+	err := s.backend.AccountManager().SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
+	require.NoError(err)
+
+	rpcClient := s.backend.NodeManager().RPCClient()
+
+	expectedResponse := `{"jsonrpc":"2.0","id":1,"result":["0xadaf150b905cf5e6a778e553e15a139b6618bbb7"]}`
+	resp := rpcClient.CallRaw(`{
+              "jsonrpc": "2.0",
+              "id":1,
+              "method": "eth_accounts",
+              "params": []
+      }`)
+	require.Equal(expectedResponse, resp)
+}

--- a/geth/api/backend_accounts_test.go
+++ b/geth/api/backend_accounts_test.go
@@ -348,10 +348,10 @@ func (s *BackendTestSuite) TestRPCEthAccounts() {
 
 	rpcClient := s.backend.NodeManager().RPCClient()
 
-	expectedResponse := `{"jsonrpc":"2.0","id":1,"result":["0xadaf150b905cf5e6a778e553e15a139b6618bbb7"]}`
+	expectedResponse := `{"jsonrpc":"2.0","id":1,"result":["` + TestConfig.Account1.Address + `"]}`
 	resp := rpcClient.CallRaw(`{
               "jsonrpc": "2.0",
-              "id":1,
+              "id": 1,
               "method": "eth_accounts",
               "params": []
       }`)
@@ -370,10 +370,10 @@ func (s *BackendTestSuite) TestRPCEthAccountsWithUpstream() {
 
 	rpcClient := s.backend.NodeManager().RPCClient()
 
-	expectedResponse := `{"jsonrpc":"2.0","id":1,"result":["0xadaf150b905cf5e6a778e553e15a139b6618bbb7"]}`
+	expectedResponse := `{"jsonrpc":"2.0","id":1,"result":["` + TestConfig.Account1.Address + `"]}`
 	resp := rpcClient.CallRaw(`{
               "jsonrpc": "2.0",
-              "id":1,
+              "id": 1,
               "method": "eth_accounts",
               "params": []
       }`)

--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -34,12 +34,17 @@ func (s *BackendTestSuite) SetupTest() {
 	s.backend = backend
 }
 
-func (s *BackendTestSuite) StartTestBackend(networkID int) {
+func (s *BackendTestSuite) StartTestBackend(networkID int, opts ...TestNodeOption) {
 	require := s.Require()
 	require.NotNil(s.backend)
 
 	nodeConfig, err := MakeTestNodeConfig(networkID)
 	require.NoError(err)
+
+	// Apply any options altering node config.
+	for i := range opts {
+		opts[i](nodeConfig)
+	}
 
 	// import account keys
 	require.NoError(common.ImportTestAccount(nodeConfig.KeyStoreDir, "test-account1.pk"))

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -76,6 +76,13 @@ func MakeNode(config *params.NodeConfig) (*node.Node, error) {
 			return nil, fmt.Errorf("%v: %v", ErrEthServiceRegistrationFailure, err)
 		}
 	} else {
+		// TODO(divan): FIXME: this is rude workaround for #294 issue
+		// we start activate LES service to have RPC handler for `eth_accounts` call
+		// should be removed once proper own RPC and refactoring is completed
+		config.MaxPeers = 0
+		if err := activateEthService(stack, config); err != nil {
+			return nil, fmt.Errorf("%v: %v", ErrEthServiceRegistrationFailure, err)
+		}
 		log.Info("Blockchain synchronization is switched off, RPC requests will be proxied to " + config.UpstreamConfig.URL)
 	}
 


### PR DESCRIPTION
This PR is ~dirty hack~ workaround for #294 issue. It starts LES service with sync disabled (by `MaxPeers` option set to 0), even if Upstream is enabled. This ensures that all RPC calls are registered in local node (they are registered during LES service initialization and do not exist if LES service is not activated).