### PR TITLE
Push notifications: ability to trigger notifications via public API

### DIFF
--- a/cmd/statusd/library.go
+++ b/cmd/statusd/library.go
@@ -383,3 +383,9 @@ func makeJSONResponse(err error) *C.char {
 
 	return C.CString(string(outBytes))
 }
+
+//export Notify
+func Notify(token *C.char) *C.char {
+	res := statusAPI.Notify(C.GoString(token))
+	return C.CString(res)
+}

--- a/geth/api/api.go
+++ b/geth/api/api.go
@@ -3,10 +3,16 @@ package api
 import (
 	"context"
 
+	"github.com/NaySoftware/go-fcm"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/geth/common"
+	"github.com/status-im/status-go/geth/log"
 	"github.com/status-im/status-go/geth/params"
+)
+
+const (
+	serverKey = "AAAAxwa-r08:APA91bFtMIToDVKGAmVCm76iEXtA4dn9MPvLdYKIZqAlNpLJbd12EgdBI9DSDSXKdqvIAgLodepmRhGVaWvhxnXJzVpE6MoIRuKedDV3kfHSVBhWFqsyoLTwXY4xeufL9Sdzb581U-lx"
 )
 
 // StatusAPI provides API to access Status related functionality.
@@ -187,4 +193,34 @@ func (api *StatusAPI) JailCall(chatID, this, args string) string {
 // JailBaseJS allows to setup initial JavaScript to be loaded on each jail.Parse()
 func (api *StatusAPI) JailBaseJS(js string) {
 	api.b.jailManager.BaseJS(js)
+}
+
+// TODO(oskarth): API package this stuff
+func (api *StatusAPI) Notify(token string) string {
+	log.Debug("Notify", "token", token)
+
+	var NP fcm.NotificationPayload
+	NP.Title = "Status - new message"
+	NP.Body = "ping"
+
+	// TODO(oskarth): Experiment with this
+	data := map[string]string{
+		"msg": "Hello World1",
+		"sum": "Happy Day",
+	}
+
+	ids := []string{
+		token,
+	}
+
+	c := fcm.NewFcmClient(serverKey)
+	c.NewFcmRegIdsMsg(ids, data)
+	c.SetNotificationPayload(&NP)
+
+	_, err := c.Send()
+	if err != nil {
+		log.Error("Notify failed:", err)
+	}
+
+	return token
 }

--- a/geth/api/backend.go
+++ b/geth/api/backend.go
@@ -21,6 +21,7 @@ type StatusBackend struct {
 	accountManager common.AccountManager
 	txQueueManager common.TxQueueManager
 	jailManager    common.JailManager
+	// TODO(oskarth): notifer here
 }
 
 // NewStatusBackend create a new NewStatusBackend instance

--- a/vendor/github.com/NaySoftware/go-fcm/LICENSE
+++ b/vendor/github.com/NaySoftware/go-fcm/LICENSE
@@ -1,0 +1,339 @@
+GNU GENERAL PUBLIC LICENSE
+   Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+        Preamble
+
+The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and
+modification follow.
+
+GNU GENERAL PUBLIC LICENSE
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+a) You must cause the modified files to carry prominent notices
+stating that you changed the files and the date of any change.
+
+b) You must cause any work that you distribute or publish, that in
+whole or in part contains or is derived from the Program or any
+part thereof, to be licensed as a whole at no charge to all third
+parties under the terms of this License.
+
+c) If the modified program normally reads commands interactively
+when run, you must cause it, when started running for such
+interactive use in the most ordinary way, to print or display an
+announcement including an appropriate copyright notice and a
+notice that there is no warranty (or else, saying that you provide
+a warranty) and that users may redistribute the program under
+these conditions, and telling the user how to view a copy of this
+License.  (Exception: if the Program itself is interactive but
+does not normally print such an announcement, your work based on
+the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+a) Accompany it with the complete corresponding machine-readable
+source code, which must be distributed under the terms of Sections
+1 and 2 above on a medium customarily used for software interchange; or,
+
+b) Accompany it with a written offer, valid for at least three
+years, to give any third party, for a charge no more than your
+cost of physically performing source distribution, a complete
+machine-readable copy of the corresponding source code, to be
+distributed under the terms of Sections 1 and 2 above on a medium
+customarily used for software interchange; or,
+
+c) Accompany it with the information you received as to the offer
+to distribute corresponding source code.  (This alternative is
+allowed only for noncommercial distribution and only if you
+received the program in object code or executable form with such
+an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+        NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+ END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+{description}
+Copyright (C) {year}  {fullname}
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+Gnomovision version 69, Copyright (C) year name of author
+Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+This is free software, and you are welcome to redistribute it
+under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+`Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+{signature of Ty Coon}, 1 April 1989
+Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/vendor/github.com/NaySoftware/go-fcm/README.md
+++ b/vendor/github.com/NaySoftware/go-fcm/README.md
@@ -1,0 +1,193 @@
+# go-fcm : FCM Library for Go
+
+[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg?style=flat-square)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=MYW4MY786JXFN&lc=GB&item_name=go%2dfcm%20development&item_number=go%2dfcm&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted)
+[![AUR](https://img.shields.io/aur/license/yaourt.svg?style=flat-square)](https://github.com/NaySoftware/go-fcm/blob/master/LICENSE)
+
+Firebase Cloud Messaging ( FCM ) Library using golang ( Go )
+
+This library uses HTTP/JSON Firebase Cloud Messaging connection server protocol
+
+
+###### Features
+
+* Send messages to a topic
+* Send messages to a device list
+* Message can be a notification or data payload
+* Supports condition attribute (fcm only)
+* Instace Id Features
+	- Get info about app Instance
+	- Subscribe app Instance to a topic
+	- Batch Subscribe/Unsubscribe to/from a topic
+	- Create registration tokens for APNs tokens
+
+
+
+## Usage
+
+```
+go get github.com/NaySoftware/go-fcm
+```
+
+## Docs - go-fcm API
+```
+https://godoc.org/github.com/NaySoftware/go-fcm
+```
+
+####  Firebase Cloud Messaging HTTP Protocol Specs
+```
+https://firebase.google.com/docs/cloud-messaging/http-server-ref
+```
+
+#### Firebase Cloud Messaging Developer docs
+```
+https://firebase.google.com/docs/cloud-messaging/
+```
+
+#### (Google) Instance Id Server Reference
+```
+https://developers.google.com/instance-id/reference/server
+```
+### Notes
+
+
+
+
+> a note from firebase console
+
+```
+Firebase Cloud Messaging tokens have replaced server keys for
+sending messages. While you may continue to use them, support
+is being deprecated for server keys.
+```
+
+
+###### Firebase Cloud Messaging token ( new token )
+
+serverKey variable will also hold the new FCM token by Firebase Cloud Messaging
+
+Firebase Cloud Messaging token can be found in:
+
+1. Firebase project settings
+2. Cloud Messaging
+3. then copy the Firebase Cloud Messaging token
+
+
+###### Server Key
+
+serverKey is the server key by Firebase Cloud Messaging
+
+Server Key can be found in:
+
+1. Firebase project settings
+2. Cloud Messaging
+3. then copy the server key
+
+[will be deprecated by firabase as mentioned above!]
+
+###### Retry mechanism
+
+Retry should be implemented based on the requirements.
+Sending a request will result with a "FcmResponseStatus" struct, which holds
+a detailed information based on the Firebase Response, with RetryAfter
+(response header) if available - with a failed request.
+its recommended to use a backoff time to retry the request - (if RetryAfter
+	header is not available).
+
+
+
+
+# Examples
+
+### Send to A topic
+
+```go
+
+package main
+
+import (
+	"fmt"
+    "github.com/NaySoftware/go-fcm"
+)
+
+const (
+	 serverKey = "YOUR-KEY"
+     topic = "/topics/someTopic"
+)
+
+func main() {
+
+	data := map[string]string{
+		"msg": "Hello World1",
+		"sum": "Happy Day",
+	}
+
+	c := fcm.NewFcmClient(serverKey)
+	c.NewFcmMsgTo(topic, data)
+
+
+	status, err := c.Send()
+
+
+	if err == nil {
+    status.PrintResults()
+	} else {
+		fmt.Println(err)
+	}
+
+}
+
+
+```
+
+
+### Send to a list of Devices (tokens)
+
+```go
+
+package main
+
+import (
+	"fmt"
+    "github.com/NaySoftware/go-fcm"
+)
+
+const (
+	 serverKey = "YOUR-KEY"
+)
+
+func main() {
+
+	data := map[string]string{
+		"msg": "Hello World1",
+		"sum": "Happy Day",
+	}
+
+  ids := []string{
+      "token1",
+  }
+
+
+  xds := []string{
+      "token5",
+      "token6",
+      "token7",
+  }
+
+	c := fcm.NewFcmClient(serverKey)
+    c.NewFcmRegIdsMsg(ids, data)
+    c.AppendDevices(xds)
+
+	status, err := c.Send()
+
+
+	if err == nil {
+    status.PrintResults()
+	} else {
+		fmt.Println(err)
+	}
+
+}
+
+
+
+```

--- a/vendor/github.com/NaySoftware/go-fcm/fcm.go
+++ b/vendor/github.com/NaySoftware/go-fcm/fcm.go
@@ -1,0 +1,360 @@
+package fcm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+const (
+	// fcm_server_url fcm server url
+	fcm_server_url = "https://fcm.googleapis.com/fcm/send"
+	// MAX_TTL the default ttl for a notification
+	MAX_TTL = 2419200
+	// Priority_HIGH notification priority
+	Priority_HIGH = "high"
+	// Priority_NORMAL notification priority
+	Priority_NORMAL = "normal"
+	// retry_after_header header name
+	retry_after_header = "Retry-After"
+	// error_key readable error caching !
+	error_key = "error"
+)
+
+var (
+	// retreyableErrors whether the error is a retryable
+	retreyableErrors = map[string]bool{
+		"Unavailable":         true,
+		"InternalServerError": true,
+	}
+
+	// fcmServerUrl for testing purposes
+	fcmServerUrl = fcm_server_url
+)
+
+// FcmClient stores the key and the Message (FcmMsg)
+type FcmClient struct {
+	ApiKey  string
+	Message FcmMsg
+}
+
+// FcmMsg represents fcm request message
+type FcmMsg struct {
+	Data                  interface{}         `json:"data,omitempty"`
+	To                    string              `json:"to,omitempty"`
+	RegistrationIds       []string            `json:"registration_ids,omitempty"`
+	CollapseKey           string              `json:"collapse_key,omitempty"`
+	Priority              string              `json:"priority,omitempty"`
+	Notification          NotificationPayload `json:"notification,omitempty"`
+	ContentAvailable      bool                `json:"content_available,omitempty"`
+	DelayWhileIdle        bool                `json:"delay_while_idle,omitempty"`
+	TimeToLive            int                 `json:"time_to_live,omitempty"`
+	RestrictedPackageName string              `json:"restricted_package_name,omitempty"`
+	DryRun                bool                `json:"dry_run,omitempty"`
+	Condition             string              `json:"condition,omitempty"`
+}
+
+// FcmMsg represents fcm response message - (tokens and topics)
+type FcmResponseStatus struct {
+	Ok            bool
+	StatusCode    int
+	MulticastId   int64               `json:"multicast_id"`
+	Success       int                 `json:"success"`
+	Fail          int                 `json:"failure"`
+	Canonical_ids int                 `json:"canonical_ids"`
+	Results       []map[string]string `json:"results,omitempty"`
+	MsgId         int64               `json:"message_id,omitempty"`
+	Err           string              `json:"error,omitempty"`
+	RetryAfter    string
+}
+
+// NotificationPayload notification message payload
+type NotificationPayload struct {
+	Title        string `json:"title,omitempty"`
+	Body         string `json:"body,omitempty"`
+	Icon         string `json:"icon,omitempty"`
+	Sound        string `json:"sound,omitempty"`
+	Badge        string `json:"badge,omitempty"`
+	Tag          string `json:"tag,omitempty"`
+	Color        string `json:"color,omitempty"`
+	ClickAction  string `json:"click_action,omitempty"`
+	BodyLocKey   string `json:"body_loc_key,omitempty"`
+	BodyLocArgs  string `json:"body_loc_args,omitempty"`
+	TitleLocKey  string `json:"title_loc_key,omitempty"`
+	TitleLocArgs string `json:"title_loc_args,omitempty"`
+}
+
+// NewFcmClient init and create fcm client
+func NewFcmClient(apiKey string) *FcmClient {
+	fcmc := new(FcmClient)
+	fcmc.ApiKey = apiKey
+
+	return fcmc
+}
+
+// NewFcmTopicMsg sets the targeted token/topic and the data payload
+func (this *FcmClient) NewFcmTopicMsg(to string, body map[string]string) *FcmClient {
+
+	this.NewFcmMsgTo(to, body)
+
+	return this
+}
+
+// NewFcmMsgTo sets the targeted token/topic and the data payload
+func (this *FcmClient) NewFcmMsgTo(to string, body interface{}) *FcmClient {
+	this.Message.To = to
+	this.Message.Data = body
+
+	return this
+}
+
+// SetMsgData sets data payload
+func (this *FcmClient) SetMsgData(body interface{}) *FcmClient {
+
+	this.Message.Data = body
+
+	return this
+
+}
+
+// NewFcmRegIdsMsg gets a list of devices with data payload
+func (this *FcmClient) NewFcmRegIdsMsg(list []string, body interface{}) *FcmClient {
+	this.newDevicesList(list)
+	this.Message.Data = body
+
+	return this
+
+}
+
+// newDevicesList init the devices list
+func (this *FcmClient) newDevicesList(list []string) *FcmClient {
+	this.Message.RegistrationIds = make([]string, len(list))
+	copy(this.Message.RegistrationIds, list)
+
+	return this
+
+}
+
+// AppendDevices adds more devices/tokens to the Fcm request
+func (this *FcmClient) AppendDevices(list []string) *FcmClient {
+
+	this.Message.RegistrationIds = append(this.Message.RegistrationIds, list...)
+
+	return this
+}
+
+// apiKeyHeader generates the value of the Authorization key
+func (this *FcmClient) apiKeyHeader() string {
+	return fmt.Sprintf("key=%v", this.ApiKey)
+}
+
+// sendOnce send a single request to fcm
+func (this *FcmClient) sendOnce() (*FcmResponseStatus, error) {
+
+	fcmRespStatus := new(FcmResponseStatus)
+
+	jsonByte, err := this.Message.toJsonByte()
+	if err != nil {
+		return fcmRespStatus, err
+	}
+
+	request, err := http.NewRequest("POST", fcmServerUrl, bytes.NewBuffer(jsonByte))
+	request.Header.Set("Authorization", this.apiKeyHeader())
+	request.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+
+	if err != nil {
+		return fcmRespStatus, err
+	}
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return fcmRespStatus, err
+	}
+
+	fcmRespStatus.StatusCode = response.StatusCode
+
+	fcmRespStatus.RetryAfter = response.Header.Get(retry_after_header)
+
+	if response.StatusCode != 200 {
+		return fcmRespStatus, nil
+	}
+
+	err = fcmRespStatus.parseStatusBody(body)
+	if err != nil {
+		return fcmRespStatus, err
+	}
+	fcmRespStatus.Ok = true
+
+	return fcmRespStatus, nil
+}
+
+// Send to fcm
+func (this *FcmClient) Send() (*FcmResponseStatus, error) {
+	return this.sendOnce()
+
+}
+
+// toJsonByte converts FcmMsg to a json byte
+func (this *FcmMsg) toJsonByte() ([]byte, error) {
+
+	return json.Marshal(this)
+
+}
+
+// parseStatusBody parse FCM response body
+func (this *FcmResponseStatus) parseStatusBody(body []byte) error {
+
+	if err := json.Unmarshal([]byte(body), &this); err != nil {
+		return err
+	}
+	return nil
+
+}
+
+// SetPriority Sets the priority of the message.
+// Priority_HIGH or Priority_NORMAL
+func (this *FcmClient) SetPriority(p string) *FcmClient {
+
+	if p == Priority_HIGH {
+		this.Message.Priority = Priority_HIGH
+	} else {
+		this.Message.Priority = Priority_NORMAL
+	}
+
+	return this
+}
+
+// SetCollapseKey This parameter identifies a group of messages
+// (e.g., with collapse_key: "Updates Available") that can be collapsed,
+// so that only the last message gets sent when delivery can be resumed.
+// This is intended to avoid sending too many of the same messages when the
+// device comes back online or becomes active (see delay_while_idle).
+func (this *FcmClient) SetCollapseKey(val string) *FcmClient {
+
+	this.Message.CollapseKey = val
+
+	return this
+}
+
+// SetNotificationPayload sets the notification payload based on the specs
+// https://firebase.google.com/docs/cloud-messaging/http-server-ref
+func (this *FcmClient) SetNotificationPayload(payload *NotificationPayload) *FcmClient {
+
+	this.Message.Notification = *payload
+
+	return this
+}
+
+// SetContentAvailable On iOS, use this field to represent content-available
+// in the APNS payload. When a notification or message is sent and this is set
+// to true, an inactive client app is awoken. On Android, data messages wake
+// the app by default. On Chrome, currently not supported.
+func (this *FcmClient) SetContentAvailable(isContentAvailable bool) *FcmClient {
+
+	this.Message.ContentAvailable = isContentAvailable
+
+	return this
+}
+
+// SetDelayWhileIdle When this parameter is set to true, it indicates that
+// the message should not be sent until the device becomes active.
+// The default value is false.
+func (this *FcmClient) SetDelayWhileIdle(isDelayWhileIdle bool) *FcmClient {
+
+	this.Message.DelayWhileIdle = isDelayWhileIdle
+
+	return this
+}
+
+// SetTimeToLive This parameter specifies how long (in seconds) the message
+// should be kept in FCM storage if the device is offline. The maximum time
+// to live supported is 4 weeks, and the default value is 4 weeks.
+// For more information, see
+// https://firebase.google.com/docs/cloud-messaging/concept-options#ttl
+func (this *FcmClient) SetTimeToLive(ttl int) *FcmClient {
+
+	if ttl > MAX_TTL {
+
+		this.Message.TimeToLive = MAX_TTL
+
+	} else {
+
+		this.Message.TimeToLive = ttl
+
+	}
+	return this
+}
+
+// SetRestrictedPackageName This parameter specifies the package name of the
+// application where the registration tokens must match in order to
+// receive the message.
+func (this *FcmClient) SetRestrictedPackageName(pkg string) *FcmClient {
+
+	this.Message.RestrictedPackageName = pkg
+
+	return this
+}
+
+// SetDryRun This parameter, when set to true, allows developers to test
+// a request without actually sending a message.
+// The default value is false
+func (this *FcmClient) SetDryRun(drun bool) *FcmClient {
+
+	this.Message.DryRun = drun
+
+	return this
+}
+
+// PrintResults prints the FcmResponseStatus results for fast using and debugging
+func (this *FcmResponseStatus) PrintResults() {
+	fmt.Println("Status Code   :", this.StatusCode)
+	fmt.Println("Success       :", this.Success)
+	fmt.Println("Fail          :", this.Fail)
+	fmt.Println("Canonical_ids :", this.Canonical_ids)
+	fmt.Println("Topic MsgId   :", this.MsgId)
+	fmt.Println("Topic Err     :", this.Err)
+	for i, val := range this.Results {
+		fmt.Printf("Result(%d)> \n", i)
+		for k, v := range val {
+			fmt.Println("\t", k, " : ", v)
+		}
+	}
+}
+
+// IsTimeout check whether the response timeout based on http response status
+// code and if any error is retryable
+func (this *FcmResponseStatus) IsTimeout() bool {
+	if this.StatusCode >= 500 {
+		return true
+	} else if this.StatusCode == 200 {
+		for _, val := range this.Results {
+			for k, v := range val {
+				if k == error_key && retreyableErrors[v] == true {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// GetRetryAfterTime converts the retrey after response header
+// to a time.Duration
+func (this *FcmResponseStatus) GetRetryAfterTime() (t time.Duration, e error) {
+	t, e = time.ParseDuration(this.RetryAfter)
+	return
+}
+
+// SetCondition to set a logical expression of conditions that determine the message target
+func (this *FcmClient) SetCondition(condition string) *FcmClient {
+	this.Message.Condition = condition
+	return this
+}

--- a/vendor/github.com/NaySoftware/go-fcm/instanceid.go
+++ b/vendor/github.com/NaySoftware/go-fcm/instanceid.go
@@ -1,0 +1,455 @@
+package fcm
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const (
+	// instance_id_info_with_details_srv_url
+	instance_id_info_with_details_srv_url = "https://iid.googleapis.com/iid/info/%s?details=true"
+
+	// instance_id_info_no_details_srv_url
+	instance_id_info_no_details_srv_url = "https://iid.googleapis.com/iid/info/%s"
+
+	// subscribe_instanceid_to_topic_srv_url
+	subscribe_instanceid_to_topic_srv_url = "https://iid.googleapis.com/iid/v1/%s/rel/topics/%s"
+
+	// batch_add_srv_url
+	batch_add_srv_url = "https://iid.googleapis.com/iid/v1:batchAdd"
+
+	// batch_rem_srv_url
+	batch_rem_srv_url = "https://iid.googleapis.com/iid/v1:batchRemove"
+
+	// apns_batch_import_srv_url
+	apns_batch_import_srv_url = "https://iid.googleapis.com/iid/v1:batchImport"
+
+	// apns_token_key
+	apns_token_key = "apns_token"
+	// status_key
+	status_key = "status"
+	// reg_token_key
+	reg_token_key = "registration_token"
+
+	// topics
+	topics = "/topics/"
+)
+
+var (
+	// batchErrors response errors
+	batchErrors = map[string]bool{
+		"NOT_FOUND":        true,
+		"INVALID_ARGUMENT": true,
+		"INTERNAL":         true,
+		"TOO_MANY_TOPICS":  true,
+	}
+)
+
+// InstanceIdInfoResponse response for instance id info request
+type InstanceIdInfoResponse struct {
+	Application        string                                  `json:"application,omitempty"`
+	AuthorizedEntity   string                                  `json:"authorizedEntity,omitempty"`
+	ApplicationVersion string                                  `json:"applicationVersion,omitempty"`
+	AppSigner          string                                  `json:"appSigner,omitempty"`
+	AttestStatus       string                                  `json:"attestStatus,omitempty"`
+	Platform           string                                  `json:"platform,omitempty"`
+	ConnectionType     string                                  `json:"connectionType,omitempty"`
+	ConnectDate        string                                  `json:"connectDate,omitempty"`
+	Error              string                                  `json:"error,omitempty"`
+	Rel                map[string]map[string]map[string]string `json:"rel,omitempty"`
+}
+
+// SubscribeResponse response for single topic subscribtion
+type SubscribeResponse struct {
+	Error      string `json:"error,omitempty"`
+	Status     string
+	StatusCode int
+}
+
+// BatchRequest add/remove request
+type BatchRequest struct {
+	To        string   `json:"to,omitempty"`
+	RegTokens []string `json:"registration_tokens,omitempty"`
+}
+
+// BatchResponse add/remove response
+type BatchResponse struct {
+	Error      string              `json:"error,omitempty"`
+	Results    []map[string]string `json:"results,omitempty"`
+	Status     string
+	StatusCode int
+}
+
+// ApnsBatchRequest apns import request
+type ApnsBatchRequest struct {
+	App        string   `json:"application,omitempty"`
+	Sandbox    bool     `json:"sandbox,omitempty"`
+	ApnsTokens []string `json:"apns_tokens,omitempty"`
+}
+
+// ApnsBatchResponse apns import response
+type ApnsBatchResponse struct {
+	Results    []map[string]string `json:"results,omitempty"`
+	Error      string              `json:"error,omitempty"`
+	Status     string
+	StatusCode int
+}
+
+// GetInfo gets the instance id info
+func (this *FcmClient) GetInfo(withDetails bool, instanceIdToken string) (*InstanceIdInfoResponse, error) {
+
+	var request_url string = generateGetInfoUrl(instance_id_info_no_details_srv_url, instanceIdToken)
+
+	if withDetails == true {
+		request_url = generateGetInfoUrl(instance_id_info_with_details_srv_url, instanceIdToken)
+	}
+
+	request, err := http.NewRequest("GET", request_url, nil)
+	request.Header.Set("Authorization", this.apiKeyHeader())
+	request.Header.Set("Content-Type", "application/json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	infoResponse, err := parseGetInfo(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return infoResponse, nil
+}
+
+// parseGetInfo parses response to InstanceIdInfoResponse
+func parseGetInfo(body []byte) (*InstanceIdInfoResponse, error) {
+
+	info := new(InstanceIdInfoResponse)
+
+	if err := json.Unmarshal([]byte(body), &info); err != nil {
+		return nil, err
+	}
+
+	return info, nil
+
+}
+
+// PrintResults prints InstanceIdInfoResponse, for faster debugging
+func (this *InstanceIdInfoResponse) PrintResults() {
+	fmt.Println("Error     : ", this.Error)
+	fmt.Println("App       : ", this.Application)
+	fmt.Println("Auth      : ", this.AuthorizedEntity)
+	fmt.Println("Ver       : ", this.ApplicationVersion)
+	fmt.Println("Sig       : ", this.AppSigner)
+	fmt.Println("Att       : ", this.AttestStatus)
+	fmt.Println("Platform  : ", this.Platform)
+	fmt.Println("Connection: ", this.ConnectionType)
+	fmt.Println("ConnDate  : ", this.ConnectDate)
+	fmt.Println("Rel       : ")
+	for k, v := range this.Rel {
+		fmt.Println(k, " --> ")
+		for k2, v2 := range v {
+			fmt.Println("\t", k2, "\t|")
+			fmt.Println("\t\t", "addDate", " : ", v2["addDate"])
+		}
+	}
+}
+
+// generateGetInfoUrl generate based on with details and the instance token
+func generateGetInfoUrl(srv string, instanceIdToken string) string {
+	return fmt.Sprintf(srv, instanceIdToken)
+}
+
+// SubscribeToTopic subscribes a single device/token to a topic
+func (this *FcmClient) SubscribeToTopic(instanceIdToken string, topic string) (*SubscribeResponse, error) {
+
+	request, err := http.NewRequest("POST", generateSubToTopicUrl(instanceIdToken, topic), nil)
+	request.Header.Set("Authorization", this.apiKeyHeader())
+	request.Header.Set("Content-Type", "application/json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	subResponse, err := parseSubscribeResponse(body, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return subResponse, nil
+}
+
+// parseSubscribeResponse converts a byte response to a SubscribeResponse
+func parseSubscribeResponse(body []byte, resp *http.Response) (*SubscribeResponse, error) {
+
+	subResp := new(SubscribeResponse)
+
+	subResp.Status = resp.Status
+	subResp.StatusCode = resp.StatusCode
+
+	if err := json.Unmarshal(body, &subResp); err != nil {
+		return nil, err
+	}
+	return subResp, nil
+}
+
+// PrintResults prints SubscribeResponse, for faster debugging
+func (this *SubscribeResponse) PrintResults() {
+
+	fmt.Println("Response Status: ", this.Status)
+	fmt.Println("Response Code  : ", this.StatusCode)
+	if this.StatusCode != 200 {
+		fmt.Println("Error          : ", this.Error)
+	}
+
+}
+
+// generateSubToTopicUrl generates a url based on the instnace id and topic name
+func generateSubToTopicUrl(instaceId string, topic string) string {
+	Tmptopic := strings.ToLower(topic)
+	if strings.Contains(Tmptopic, "/topics/") {
+		tmp := strings.Split(topic, "/")
+		topic = tmp[len(tmp)-1]
+	}
+	return fmt.Sprintf(subscribe_instanceid_to_topic_srv_url, instaceId, topic)
+}
+
+// BatchSubscribeToTopic subscribes (many) devices/tokens to a given topic
+func (this *FcmClient) BatchSubscribeToTopic(tokens []string, topic string) (*BatchResponse, error) {
+
+	jsonByte, err := generateBatchRequest(tokens, topic)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequest("POST", batch_add_srv_url, bytes.NewBuffer(jsonByte))
+	request.Header.Set("Authorization", this.apiKeyHeader())
+	request.Header.Set("Content-Type", "application/json")
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	result, err := generateBatchResponse(body)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, errors.New("Parsing response error")
+	}
+	result.Status = response.Status
+	result.StatusCode = response.StatusCode
+
+	return result, nil
+}
+
+// BatchUnsubscribeFromTopic unsubscribes (many) devices/tokens from a given topic
+func (this *FcmClient) BatchUnsubscribeFromTopic(tokens []string, topic string) (*BatchResponse, error) {
+
+	jsonByte, err := generateBatchRequest(tokens, topic)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+
+	request, err := http.NewRequest("POST", batch_rem_srv_url, bytes.NewBuffer(jsonByte))
+	request.Header.Set("Authorization", this.apiKeyHeader())
+	request.Header.Set("Content-Type", "application/json")
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	result, err := generateBatchResponse(body)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, errors.New("Parsing response error")
+	}
+	result.Status = response.Status
+	result.StatusCode = response.StatusCode
+
+	return result, nil
+}
+
+// PrintResults prints BatchResponse, for faster debugging
+func (this *BatchResponse) PrintResults() {
+	fmt.Println("Error       : ", this.Error)
+	fmt.Println("Status      : ", this.Status)
+	fmt.Println("Status Code : ", this.StatusCode)
+	for i, val := range this.Results {
+		if batchErrors[val["error"]] == true {
+			fmt.Println("ID: ", i, " | ", val["error"])
+		}
+	}
+}
+
+// generateBatchRequest based on tokens and topic
+func generateBatchRequest(tokens []string, topic string) ([]byte, error) {
+	envelope := new(BatchRequest)
+	envelope.To = topics + extractTopicName(topic)
+	envelope.RegTokens = make([]string, len(tokens))
+	copy(envelope.RegTokens, tokens)
+
+	return json.Marshal(envelope)
+
+}
+
+// extractTopicName extract topic name for valid topic name input
+func extractTopicName(inTopic string) (result string) {
+	Tmptopic := strings.ToLower(inTopic)
+	if strings.Contains(Tmptopic, "/topics/") {
+		tmp := strings.Split(inTopic, "/")
+		result = tmp[len(tmp)-1]
+		return
+	}
+
+	result = inTopic
+	return
+}
+
+// generateBatchResponse converts a byte response to BatchResponse
+func generateBatchResponse(resp []byte) (*BatchResponse, error) {
+	result := new(BatchResponse)
+
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+
+}
+
+// ApnsBatchImportRequest apns import requst
+func (this *FcmClient) ApnsBatchImportRequest(apnsReq *ApnsBatchRequest) (*ApnsBatchResponse, error) {
+
+	jsonByte, err := apnsReq.ToByte()
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequest("POST", apns_batch_import_srv_url, bytes.NewBuffer(jsonByte))
+	request.Header.Set("Authorization", this.apiKeyHeader())
+	request.Header.Set("Content-Type", "application/json")
+
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := parseApnsBatchResponse(body)
+	if err != nil {
+		return nil, err
+	}
+
+	if result == nil {
+		return nil, errors.New("Parsing Request error")
+	}
+
+	result.Status = response.Status
+	result.StatusCode = response.StatusCode
+
+	return result, nil
+}
+
+// ToByte converts ApnsBatchRequest to a byte
+func (this *ApnsBatchRequest) ToByte() ([]byte, error) {
+	data, err := json.Marshal(this)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// parseApnsBatchResponse converts apns byte response to ApnsBatchResponse
+func parseApnsBatchResponse(resp []byte) (*ApnsBatchResponse, error) {
+
+	result := new(ApnsBatchResponse)
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+
+}
+
+// PrintResults prints ApnsBatchResponse, for faster debugging
+func (this *ApnsBatchResponse) PrintResults() {
+	fmt.Println("Status     : ", this.Status)
+	fmt.Println("StatusCode : ", this.StatusCode)
+	fmt.Println("Error      : ", this.Error)
+	for i, val := range this.Results {
+		fmt.Println(i, ":")
+		fmt.Println("\tAPNS Token", val[apns_token_key])
+		fmt.Println("\tStatus    ", val[status_key])
+		fmt.Println("\tReg Token  ", val[reg_token_key])
+	}
+}


### PR DESCRIPTION
This PR provides a way for status-react to trigger push notifications to contacts whose `FCMToken` they possess. It thus solves the basic user story as outlined in https://github.com/status-im/status-go/issues/326

It introduces the following public API call: `func (api *StatusAPI) Notify(token string) string`. This function signature is subject to change. For example, an additional argument for payload is likely to be introduced, and the return type might look different.

The specific functionality is currently a work in progress, and the currently plan of attack is to introduce a `common.Notifier` package to avoid polluting the `api.go` file.

It is likely that this will be superseded by the more sophisticated notification server, which is still in progress and review. I'm also happy to split the `go-fcm` import and basic skeleton into a separate PR to get it into `develop` as soon as possible, since (a) it is needed for the notification server as well (b) you might be wary of introducing WIP public API calls.