### PR TITLE
Prevent from completing tx multiple times

### DIFF
--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -150,13 +150,14 @@ type QueuedTxID string
 
 // QueuedTx holds enough information to complete the queued transaction.
 type QueuedTx struct {
-	ID      QueuedTxID
-	Hash    common.Hash
-	Context context.Context
-	Args    SendTxArgs
-	Done    chan struct{}
-	Discard chan struct{}
-	Err     error
+	ID         QueuedTxID
+	Hash       common.Hash
+	Context    context.Context
+	Args       SendTxArgs
+	InProgress bool // true if transaction is being sent
+	Done       chan struct{}
+	Discard    chan struct{}
+	Err        error
 }
 
 // SendTxArgs represents the arguments to submit a new transaction into the transaction pool.

--- a/geth/node/txqueue.go
+++ b/geth/node/txqueue.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/log"
 )
@@ -21,10 +22,12 @@ const (
 )
 
 var (
-	ErrQueuedTxIDNotFound      = errors.New("transaction hash not found")
-	ErrQueuedTxTimedOut        = errors.New("transaction sending timed out")
-	ErrQueuedTxDiscarded       = errors.New("transaction has been discarded")
-	ErrInvalidCompleteTxSender = errors.New("transaction can only be completed by the same account which created it")
+	ErrQueuedTxIDNotFound       = errors.New("transaction hash not found")
+	ErrQueuedTxTimedOut         = errors.New("transaction sending timed out")
+	ErrQueuedTxDiscarded        = errors.New("transaction has been discarded")
+	ErrQueuedTxInProgress       = errors.New("transaction has started being processed already")
+	ErrQueuedTxAlreadyProcessed = errors.New("transaction has been already processed")
+	ErrInvalidCompleteTxSender  = errors.New("transaction can only be completed by the same account which created it")
 )
 
 // TxQueue is capped container that holds pending transactions
@@ -189,6 +192,33 @@ func (q *TxQueue) Remove(id common.QueuedTxID) {
 	defer q.mu.Unlock()
 
 	delete(q.transactions, id)
+}
+
+// StartProcessing marks a transaction as in progress. It's thread-safe and
+// prevents from processing the same transaction multiple times.
+func (q *TxQueue) StartProcessing(tx *common.QueuedTx) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if tx.Hash != (gethcommon.Hash{}) || tx.Err != nil {
+		return ErrQueuedTxAlreadyProcessed
+	}
+
+	if tx.InProgress {
+		return ErrQueuedTxInProgress
+	}
+
+	tx.InProgress = true
+
+	return nil
+}
+
+// StopProcessing removes the "InProgress" flag from the transaction.
+func (q *TxQueue) StopProcessing(tx *common.QueuedTx) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	tx.InProgress = false
 }
 
 // Count returns number of currently queued transactions

--- a/geth/node/txqueue.go
+++ b/geth/node/txqueue.go
@@ -25,7 +25,7 @@ var (
 	ErrQueuedTxIDNotFound       = errors.New("transaction hash not found")
 	ErrQueuedTxTimedOut         = errors.New("transaction sending timed out")
 	ErrQueuedTxDiscarded        = errors.New("transaction has been discarded")
-	ErrQueuedTxInProgress       = errors.New("transaction has started being processed already")
+	ErrQueuedTxInProgress       = errors.New("transaction is in progress")
 	ErrQueuedTxAlreadyProcessed = errors.New("transaction has been already processed")
 	ErrInvalidCompleteTxSender  = errors.New("transaction can only be completed by the same account which created it")
 )

--- a/geth/node/txqueue_manager.go
+++ b/geth/node/txqueue_manager.go
@@ -138,6 +138,11 @@ func (m *TxQueueManager) CompleteTransaction(id common.QueuedTxID, password stri
 		return gethcommon.Hash{}, err
 	}
 
+	if err := m.txQueue.StartProcessing(queuedTx); err != nil {
+		return gethcommon.Hash{}, err
+	}
+	defer m.txQueue.StopProcessing(queuedTx)
+
 	selectedAccount, err := m.accountManager.SelectedAccount()
 	if err != nil {
 		log.Warn("failed to get a selected account", "err", err)
@@ -179,7 +184,7 @@ func (m *TxQueueManager) CompleteTransaction(id common.QueuedTxID, password stri
 
 	queuedTx.Hash = hash
 	queuedTx.Err = txErr
-	queuedTx.Done <- struct{}{} // sendTransaction() waits on this, notify so that it can return
+	queuedTx.Done <- struct{}{}
 
 	return hash, txErr
 }
@@ -188,6 +193,7 @@ func (m *TxQueueManager) completeLocalTransaction(queuedTx *common.QueuedTx, pas
 	log.Info("complete transaction using local node", "id", queuedTx.ID)
 
 	les, err := m.nodeManager.LightEthereumService()
+	log.Info("retrival les service", "err", err)
 	if err != nil {
 		return gethcommon.Hash{}, err
 	}

--- a/geth/node/txqueue_manager.go
+++ b/geth/node/txqueue_manager.go
@@ -193,7 +193,6 @@ func (m *TxQueueManager) completeLocalTransaction(queuedTx *common.QueuedTx, pas
 	log.Info("complete transaction using local node", "id", queuedTx.ID)
 
 	les, err := m.nodeManager.LightEthereumService()
-	log.Info("retrival les service", "err", err)
 	if err != nil {
 		return gethcommon.Hash{}, err
 	}

--- a/geth/node/txqueue_manager_test.go
+++ b/geth/node/txqueue_manager_test.go
@@ -136,12 +136,11 @@ func (s *TxQueueTestSuite) TestCompleteTransactionMultipleTimes() {
 	for i := 0; i < 3; i++ {
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			_, err := txQueueManager.CompleteTransaction(tx.ID, TestConfig.Account1.Password)
 			mu.Lock()
 			completeTxErrors[err]++
 			mu.Unlock()
-
-			wg.Done()
 		}()
 	}
 


### PR DESCRIPTION
This PR prevents from completing (i.e. sending) the same transaction multiple times.

I successfully reproduced the bug described in #263 with a unit test. The problem was a missing guard which could prevent from using the same transaction in multiple `CompleteTransaction` calls.  

This is a quick solution but a well-though refactoring of `TxQueueManager` and `TxQueue` is required. I will follow up with a separate issue regarding that.