### PR TITLE
Use linux node in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ def getVersion(branch, sha) {
     return branch.replaceAll(/\//, '-')
 }
 
-node {
+node('linux') {
     checkout scm
 
     def remoteOriginRegex = ~/^remotes\/origin\//

--- a/build/env.sh
+++ b/build/env.sh
@@ -13,7 +13,7 @@ WS1="$ROOT/build/_workspace/deps"
 WS2="$ROOT/build/_workspace/project"
 
 # expose all vendored packages
-if [ ! -d "$WS1/src" ]; then
+if [ ! -L "$WS1/src" ]; then
     mkdir -p "$WS1"
     cd "$WS1"
     ln -s "$ROOT/vendor" src


### PR DESCRIPTION
In order to move some load from Jenkins master, let's build status-go on `linux` node.