### PR TITLE
Estimate gas if missing in sending tx using upstream

### DIFF
--- a/geth/node/txqueue_manager.go
+++ b/geth/node/txqueue_manager.go
@@ -227,12 +227,16 @@ func (m *TxQueueManager) completeRemoteTransaction(queuedTx *common.QueuedTx, pa
 
 	chainID := big.NewInt(int64(config.NetworkID))
 	nonce := uint64(txCount)
-	gas := (*big.Int)(queuedTx.Args.Gas)
 	gasPrice := (*big.Int)(queuedTx.Args.GasPrice)
 	dataVal := []byte(queuedTx.Args.Data)
 	priceVal := (*big.Int)(queuedTx.Args.Value)
 
-	tx := types.NewTransaction(nonce, *queuedTx.Args.To, priceVal, gas, gasPrice, dataVal)
+	gas, err := m.estimateGas(queuedTx.Args)
+	if err != nil {
+		return emptyHash, err
+	}
+
+	tx := types.NewTransaction(nonce, *queuedTx.Args.To, priceVal, (*big.Int)(gas), gasPrice, dataVal)
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), selectedAcct.AccountKey.PrivateKey)
 	if err != nil {
 		return emptyHash, err
@@ -251,6 +255,54 @@ func (m *TxQueueManager) completeRemoteTransaction(queuedTx *common.QueuedTx, pa
 	}
 
 	return signedTx.Hash(), nil
+}
+
+func (m *TxQueueManager) estimateGas(args common.SendTxArgs) (*hexutil.Big, error) {
+	if args.Gas != nil {
+		return args.Gas, nil
+	}
+
+	client := m.nodeManager.RPCClient()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	var gasPrice hexutil.Big
+	if args.GasPrice != nil {
+		gasPrice = (hexutil.Big)(*args.GasPrice)
+	}
+
+	var value hexutil.Big
+	if args.Value != nil {
+		value = (hexutil.Big)(*args.Value)
+	}
+
+	params := struct {
+		From     gethcommon.Address  `json:"from"`
+		To       *gethcommon.Address `json:"to"`
+		Gas      hexutil.Big         `json:"gas"`
+		GasPrice hexutil.Big         `json:"gasPrice"`
+		Value    hexutil.Big         `json:"value"`
+		Data     hexutil.Bytes       `json:"data"`
+	}{
+		From:     args.From,
+		To:       args.To,
+		GasPrice: gasPrice,
+		Value:    value,
+		Data:     []byte(args.Data),
+	}
+
+	var estimatedGas hexutil.Big
+	if err := client.CallContext(
+		ctx,
+		&estimatedGas,
+		"eth_estimateGas",
+		params,
+	); err != nil {
+		log.Warn("failed to estimate gas", "err", err)
+		return nil, err
+	}
+
+	return &estimatedGas, nil
 }
 
 // CompleteTransactions instructs backend to complete sending of multiple transactions


### PR DESCRIPTION
## Problem

When sending a transaction using the upstream network, gas was not estimated if missing. As status-react does not provide this value, status-go must estimate it.

When sending a transaction using local not, estimation is done in go-ethereum.

## Fix

I added a call to `eth_estimateGas` in case gas param is missing when using the upstream. This is a little bit ugly because I create an anonymous struct to match `eth_call` params. I spotted this struct in go-ethereum but I don't see it's exported...