### PR TITLE
Add downloader.Cancel to stop sync

### DIFF
--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -177,81 +177,8 @@ func (s *BackendTestSuite) TestStartNodeWithUpstreamEnabled() {
 	// Get lightEthereum service and attempt to download sync.
 	lightEth, err := backend.NodeManager().LightEthereumService()
 	require.NoError(err)
-	require.NotNil(lightEth)
 	time.Sleep(5 * time.Second)
-	require.False(lightEth.Downloader().Synchronising(), "NodeChain synchronization is not started")
-}
-
-func (s *BackendTestSuite) TestCallRPCWithUpstreamEnabled() {
-	require := s.Require()
-	require.NotNil(s.backend)
-
-	nodeConfig, err := MakeTestNodeConfig(params.RinkebyNetworkID)
-	require.NoError(err)
-
-	nodeConfig.UpstreamConfig.Enabled = true
-
-	nodeStarted, err := s.backend.StartNode(nodeConfig)
-	require.NoError(err)
-	require.NotNil(nodeStarted)
-	defer s.backend.StopNode()
-	<-nodeStarted
-
-	progress := make(chan struct{}, 25)
-	type rpcCall struct {
-		inputJSON string
-		validator func(resultJSON string)
-	}
-	var rpcCalls = []rpcCall{
-		{
-			`{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{
-				"from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
-				"to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
-				"gas": "0x76c0",
-				"gasPrice": "0x9184e72a000",
-				"value": "0x9184e72a",
-				"data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}],"id":1}`,
-			func(resultJSON string) {
-				log.Info("eth_sendTransaction")
-				s.T().Log("GOT: ", resultJSON)
-				progress <- struct{}{}
-			},
-		},
-		{
-			`{"jsonrpc":"2.0","method":"shh_version","params":[],"id":67}`,
-			func(resultJSON string) {
-				expected := `{"jsonrpc":"2.0","id":67,"result":"5.0"}`
-				s.Equal(expected, resultJSON)
-				s.T().Log("shh_version: ", resultJSON)
-				progress <- struct{}{}
-			},
-		},
-		{
-			`{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}`,
-			func(resultJSON string) {
-				expected := `{"jsonrpc":"2.0","id":67,"result":"4"}`
-				s.Equal(expected, resultJSON)
-				s.T().Log("net_version: ", resultJSON)
-				progress <- struct{}{}
-			},
-		},
-	}
-
-	cnt := len(rpcCalls) - 1 // send transaction blocks up until complete/discarded/times out
-	for _, r := range rpcCalls {
-		go func(r rpcCall) {
-			s.T().Logf("Run test: %v", r.inputJSON)
-			resultJSON := s.backend.CallRPC(r.inputJSON)
-			r.validator(resultJSON)
-		}(r)
-	}
-
-	for range progress {
-		cnt -= 1
-		if cnt <= 0 {
-			break
-		}
-	}
+	require.False(lightEth.Downloader().Synchronising(), "NodeChain synchronization should'nt have started")
 }
 
 // FIXME(tiabc): There's also a test with the same name in geth/node/rpc_test.go

--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -178,7 +178,7 @@ func (s *BackendTestSuite) TestStartNodeWithUpstreamEnabled() {
 	lightEth, err := backend.NodeManager().LightEthereumService()
 	require.NoError(err)
 	require.NotNil(lightEth)
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 	require.False(lightEth.Downloader().Synchronising(), "NodeChain synchronization is not started")
 }
 

--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -173,6 +173,85 @@ func (s *BackendTestSuite) TestStartNodeWithUpstreamEnabled() {
 
 	<-nodeStarted
 	require.True(backend.IsNodeRunning())
+
+	// Get lightEthereum service and attempt to download sync.
+	lightEth, err := backend.NodeManager().LightEthereumService()
+	require.NoError(err)
+	require.NotNil(lightEth)
+	time.Sleep(3 * time.Second)
+	require.False(lightEth.Downloader().Synchronising(), "NodeChain synchronization is not started")
+}
+
+func (s *BackendTestSuite) TestCallRPCWithUpstreamEnabled() {
+	require := s.Require()
+	require.NotNil(s.backend)
+
+	nodeConfig, err := MakeTestNodeConfig(params.RinkebyNetworkID)
+	require.NoError(err)
+
+	nodeConfig.UpstreamConfig.Enabled = true
+
+	nodeStarted, err := s.backend.StartNode(nodeConfig)
+	require.NoError(err)
+	require.NotNil(nodeStarted)
+	defer s.backend.StopNode()
+	<-nodeStarted
+
+	progress := make(chan struct{}, 25)
+	type rpcCall struct {
+		inputJSON string
+		validator func(resultJSON string)
+	}
+	var rpcCalls = []rpcCall{
+		{
+			`{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{
+				"from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
+				"to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
+				"gas": "0x76c0",
+				"gasPrice": "0x9184e72a000",
+				"value": "0x9184e72a",
+				"data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}],"id":1}`,
+			func(resultJSON string) {
+				log.Info("eth_sendTransaction")
+				s.T().Log("GOT: ", resultJSON)
+				progress <- struct{}{}
+			},
+		},
+		{
+			`{"jsonrpc":"2.0","method":"shh_version","params":[],"id":67}`,
+			func(resultJSON string) {
+				expected := `{"jsonrpc":"2.0","id":67,"result":"5.0"}`
+				s.Equal(expected, resultJSON)
+				s.T().Log("shh_version: ", resultJSON)
+				progress <- struct{}{}
+			},
+		},
+		{
+			`{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}`,
+			func(resultJSON string) {
+				expected := `{"jsonrpc":"2.0","id":67,"result":"4"}`
+				s.Equal(expected, resultJSON)
+				s.T().Log("net_version: ", resultJSON)
+				progress <- struct{}{}
+			},
+		},
+	}
+
+	cnt := len(rpcCalls) - 1 // send transaction blocks up until complete/discarded/times out
+	for _, r := range rpcCalls {
+		go func(r rpcCall) {
+			s.T().Logf("Run test: %v", r.inputJSON)
+			resultJSON := s.backend.CallRPC(r.inputJSON)
+			r.validator(resultJSON)
+		}(r)
+	}
+
+	for range progress {
+		cnt -= 1
+		if cnt <= 0 {
+			break
+		}
+	}
 }
 
 // FIXME(tiabc): There's also a test with the same name in geth/node/rpc_test.go

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -180,9 +180,11 @@ func activateEthService(stack *node.Node, config *params.NodeConfig) error {
 		if err == nil {
 			updateCHT(lightEth, config)
 
-			// Cancel downloaders operation if upstream enabled and ensure it stops sync.
 			if config.UpstreamConfig.Enabled {
 				lightEth.Downloader().Terminate()
+				if block := lightEth.BlockChain(); block != nil {
+					block.Stop()
+				}
 			}
 		}
 		return lightEth, err

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -180,6 +180,10 @@ func activateEthService(stack *node.Node, config *params.NodeConfig) error {
 		if err == nil {
 			updateCHT(lightEth, config)
 
+			// TODO(influx6): Find a more concrete solution for node sync.
+			// This is a temporary solution to provide a fix for node synchronization
+			// when upstream is enabled. We will need to find something more suitable
+			// later.
 			if config.UpstreamConfig.Enabled {
 				lightEth.Downloader().Terminate()
 				if block := lightEth.BlockChain(); block != nil {

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -179,6 +179,11 @@ func activateEthService(stack *node.Node, config *params.NodeConfig) error {
 		lightEth, err := les.New(ctx, &ethConf)
 		if err == nil {
 			updateCHT(lightEth, config)
+
+			// Cancel downloaders operation if upstream enabled and ensure it stops sync.
+			if config.UpstreamConfig.Enabled {
+				lightEth.Downloader().Cancel()
+			}
 		}
 		return lightEth, err
 	}); err != nil {

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -182,7 +182,7 @@ func activateEthService(stack *node.Node, config *params.NodeConfig) error {
 
 			// Cancel downloaders operation if upstream enabled and ensure it stops sync.
 			if config.UpstreamConfig.Enabled {
-				lightEth.Downloader().Cancel()
+				lightEth.Downloader().Terminate()
 			}
 		}
 		return lightEth, err


### PR DESCRIPTION
PR adds a fix to ensure `lightEthereum.Downloader.Cancel` stops synchronization of node.

For now i can validate the data directory has no node cache files, but will need @rasom to test this out with a `status-react` build. Am not sure, what would be an appropriate test to validate emptiness of files in `datadir` so for now, we can test this out that sync never starts.

Related to issue #348 