### PR TITLE
Add Jenkins-manual and fix artifacts versioning

### DIFF
--- a/Jenkins-manual
+++ b/Jenkins-manual
@@ -16,7 +16,17 @@ def getVersion(branch, sha, buildNumber) {
 }
 
 node('linux') {
-    checkout scm
+    paramBranch = env.branch ? ('*/' + env.branch) : '*/develop'
+
+    checkout(
+        changelog: false,
+        poll: false,
+        scm: [$class: 'GitSCM', branches: [[name: paramBranch]],
+        doGenerateSubmoduleConfigurations: false,
+        extensions: [],
+        submoduleCfg: [],
+        userRemoteConfigs: [[url: 'https://github.com/status-im/status-go']]]
+    )
 
     def remoteOriginRegex = ~/^remotes\/origin\//
 
@@ -40,14 +50,22 @@ node('linux') {
 
         parallel (
             'statusgo-android': {
-                sh 'make statusgo-android'
+                if (env.platform == 'android') {
+                    sh 'make statusgo-android'
+                } else {
+                    print 'Skipping Android'
+                }
             },
             'statusgo-ios-simulator': {
-                sh '''
-                    make statusgo-ios-simulator
-                    cd build/bin/statusgo-ios-9.3-framework/
-                    zip -r status-go-ios.zip Statusgo.framework
-                '''
+                if (env.platform == 'ios-simulator') {
+                    sh '''
+                        make statusgo-ios-simulator
+                        cd build/bin/statusgo-ios-9.3-framework/
+                        zip -r status-go-ios.zip Statusgo.framework
+                    '''
+                } else {
+                    print 'Skipping ios-simulator'
+                }
             }
         )
     }


### PR DESCRIPTION
## Changes

1. Previous versioning required to clean cache for branch builds.
2. A new Jenkins file was introduced to support manual builds of arbitrary status-go branches.

## Todo

1. Add slack notifications.
2. Extract common parts to a separate groovy script as currently both Jenkinfiles duplicate some code.