### PR TITLE
Fix SendTransaction signature in go-ethereum

### DIFF
--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -206,7 +206,7 @@ func (s *BackendTestSuite) TestCallRPC() {
 				"data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}],"id":1}`,
 			func(resultJSON string) {
 				log.Info("eth_sendTransaction")
-				s.T().Log("GOT: ", resultJSON)
+				s.NotContains(resultJSON, "error")
 				progress <- struct{}{}
 			},
 		},

--- a/vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go
+++ b/vendor/github.com/ethereum/go-ethereum/internal/ethapi/api.go
@@ -1180,9 +1180,10 @@ func submitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 	return tx.Hash(), nil
 }
 
-// SendTransaction creates a transaction by unpacking queued transaction, signs it and submits to the
+// SendTransactionWithPassphrase creates a transaction by unpacking queued transaction, signs it and submits to the
 // transaction pool.
-func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args SendTxArgs, passphrase string) (common.Hash, error) {
+// @Status
+func (s *PublicTransactionPoolAPI) SendTransactionWithPassphrase(ctx context.Context, args SendTxArgs, passphrase string) (common.Hash, error) {
 	// Set some sanity defaults and terminate on failure
 	if err := args.setDefaults(ctx, s.b); err != nil {
 		return common.Hash{}, err
@@ -1215,6 +1216,47 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 		chainID = config.ChainId
 	}
 	signed, err := wallet.SignTxWithPassphrase(account, passphrase, tx, chainID)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return submitTransaction(ctx, s.b, signed)
+}
+
+// SendTransaction creates a transaction by unpacking queued transaction, signs it and submits to the
+// transaction pool.
+func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args SendTxArgs) (common.Hash, error) {
+	// Set some sanity defaults and terminate on failure
+	if err := args.setDefaults(ctx, s.b); err != nil {
+		return common.Hash{}, err
+	}
+
+	// Look up the wallet containing the requested signer
+	account := accounts.Account{Address: args.From}
+
+	wallet, err := s.b.AccountManager().Find(account)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	if args.Nonce == nil {
+		// Hold the addresse's mutex around signing to prevent concurrent assignment of
+		// the same nonce to multiple accounts.
+		s.nonceLock.LockAddr(args.From)
+		defer s.nonceLock.UnlockAddr(args.From)
+	}
+
+	// Set some sanity defaults and terminate on failure
+	if err := args.setDefaults(ctx, s.b); err != nil {
+		return common.Hash{}, err
+	}
+	// Assemble the transaction and sign with the wallet
+	tx := args.toTransaction()
+
+	var chainID *big.Int
+	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {
+		chainID = config.ChainId
+	}
+	signed, err := wallet.SignTx(account, tx, chainID)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/vendor/github.com/ethereum/go-ethereum/internal/ethapi/status_backend.go
+++ b/vendor/github.com/ethereum/go-ethereum/internal/ethapi/status_backend.go
@@ -45,7 +45,7 @@ func (b *StatusBackend) AccountManager() *status.AccountManager {
 	return b.am
 }
 
-// SendTransaction wraps call to PublicTransactionPoolAPI.SendTransaction
+// SendTransaction wraps call to PublicTransactionPoolAPI.SendTransactionWithPassphrase
 func (b *StatusBackend) SendTransaction(ctx context.Context, args status.SendTxArgs, passphrase string) (common.Hash, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -57,7 +57,7 @@ func (b *StatusBackend) SendTransaction(ctx context.Context, args status.SendTxA
 		}
 	}
 
-	return b.txapi.SendTransaction(ctx, SendTxArgs(args), passphrase)
+	return b.txapi.SendTransactionWithPassphrase(ctx, SendTxArgs(args), passphrase)
 }
 
 // EstimateGas uses underlying blockchain API to obtain gas for a given tx arguments


### PR DESCRIPTION
## Issue

During refactoring `TxQueueManager`, I extended `SendTransaction()` signature with a passphrase argument, unaware that it's the same method that is called when `eth_sendTransaction` is called via RPC.

## Implementation

I created a separate method `SendTransactionWithPassphrase` which accepts passphrase as a second argument. It's an exact copy of `SendTransaction` except for calling `wallet.SignTxWithPassphrase`.

## Notes

Be aware that this change does not fix `eth_sendTransaction` completely as #351 does it.