### PR TITLE
Add 'g' prefix before artifact SHA

### DIFF
--- a/Jenkins-manual
+++ b/Jenkins-manual
@@ -5,7 +5,7 @@ def getVersion(branch, sha, buildNumber) {
     version = branch.replaceAll(/\//, '-')
 
     if (sha?.trim()) {
-        version = version + '-' + sha
+        version = version + '-g' + sha
     }
 
     if (buildNumber?.trim()) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ def getVersion(branch, sha, buildNumber) {
     version = branch.replaceAll(/\//, '-')
 
     if (sha?.trim()) {
-        version = version + '-' + sha
+        version = version + '-g' + sha
     }
 
     if (buildNumber?.trim()) {


### PR DESCRIPTION
This is to align with the artifact name pattern: `branchName-gSHA` (for branch builds it's `branchName-gSHA-buildNumber` as discussed earlier).