### PR TITLE
Fix signals package to compile for ios

### DIFF
--- a/geth/signal/ios.go
+++ b/geth/signal/ios.go
@@ -1,6 +1,6 @@
 // +build darwin,cgo
 
-package node
+package signal
 
 /*
 #cgo CFLAGS: -x objective-c


### PR DESCRIPTION
File `geth/signal/ios.go` also must belong to the signal package.

Without this change, there was an error when compiling for iOS:
```
[statusgo-ios-simulator] ../../geth/signal/signals.c:18:31: warning: incompatible pointer types assigning to 'id' (aka 'struct objc_object *') from 'Class' (aka 'struct objc_class *') [-Wincompatible-pointer-types]
[statusgo-ios-simulator] # github.com/status-im/status-go/geth/signal
[statusgo-ios-simulator] Undefined symbols for architecture armv7:
[statusgo-ios-simulator]   "_objc_getClass", referenced from:
[statusgo-ios-simulator]       _initLibrary in signals.o
[statusgo-ios-simulator]   "_objc_msgSend", referenced from:
[statusgo-ios-simulator]       _StatusServiceSignalEvent in signals.o
[statusgo-ios-simulator]   "_sel_getUid", referenced from:
[statusgo-ios-simulator]       _initLibrary in signals.o
[statusgo-ios-simulator] ld: symbol(s) not found for architecture armv7
[statusgo-ios-simulator] clang: error: linker command failed with exit code 1 (use -v to see invocation)
```