### PR TITLE
Move transaction queue code into separate package

### DIFF
--- a/geth/api/backend.go
+++ b/geth/api/backend.go
@@ -12,6 +12,7 @@ import (
 	"github.com/status-im/status-go/geth/node"
 	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/geth/signal"
+	"github.com/status-im/status-go/geth/txqueue"
 )
 
 // StatusBackend implements Status.im service
@@ -31,7 +32,7 @@ func NewStatusBackend() *StatusBackend {
 
 	nodeManager := node.NewNodeManager()
 	accountManager := account.NewManager(nodeManager)
-	txQueueManager := node.NewTxQueueManager(nodeManager, accountManager)
+	txQueueManager := txqueue.NewManager(nodeManager, accountManager)
 
 	return &StatusBackend{
 		nodeManager:    nodeManager,

--- a/geth/api/backend_jail_test.go
+++ b/geth/api/backend_jail_test.go
@@ -14,10 +14,10 @@ import (
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
 	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/log"
-	"github.com/status-im/status-go/geth/node"
 	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/geth/signal"
 	. "github.com/status-im/status-go/geth/testing"
+	"github.com/status-im/status-go/geth/txqueue"
 	"github.com/status-im/status-go/static"
 )
 
@@ -61,7 +61,7 @@ func (s *BackendTestSuite) TestJailSendQueuedTransaction() {
 		err := json.Unmarshal([]byte(jsonEvent), &envelope)
 		s.NoError(err, fmt.Sprintf("cannot unmarshal JSON: %s", jsonEvent))
 
-		if envelope.Type == node.EventTransactionQueued {
+		if envelope.Type == txqueue.EventTransactionQueued {
 			event := envelope.Event.(map[string]interface{})
 			messageId, ok := event["message_id"].(string)
 			s.True(ok, "Message id is required, but not found")
@@ -221,7 +221,7 @@ func (s *BackendTestSuite) TestContractDeployment() {
 		err = json.Unmarshal([]byte(jsonEvent), &envelope)
 		require.NoError(err, fmt.Sprintf("cannot unmarshal JSON: %s", jsonEvent))
 
-		if envelope.Type == node.EventTransactionQueued {
+		if envelope.Type == txqueue.EventTransactionQueued {
 			// Use s.* for assertions - require leaves the channel unclosed.
 
 			event := envelope.Event.(map[string]interface{})
@@ -724,7 +724,7 @@ func (s *BackendTestSuite) TestJailVMPersistence() {
 			s.T().Errorf("cannot unmarshal event's JSON: %s", jsonEvent)
 			return
 		}
-		if envelope.Type == node.EventTransactionQueued {
+		if envelope.Type == txqueue.EventTransactionQueued {
 			event := envelope.Event.(map[string]interface{})
 			s.T().Logf("Transaction queued (will be completed shortly): {id: %s}\n", event["id"].(string))
 

--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/geth/signal"
 	. "github.com/status-im/status-go/geth/testing"
+	"github.com/status-im/status-go/geth/txqueue"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -285,7 +286,7 @@ func (s *BackendTestSuite) TestCallRPCSendTransaction() {
 		err := json.Unmarshal([]byte(rawSignal), &signal)
 		s.NoError(err)
 
-		if signal.Type == node.EventTransactionQueued {
+		if signal.Type == txqueue.EventTransactionQueued {
 			event := signal.Event.(map[string]interface{})
 			txID := event["id"].(string)
 			txHash, err = s.backend.CompleteTransaction(common.QueuedTxID(txID), TestConfig.Account1.Password)
@@ -343,7 +344,7 @@ func (s *BackendTestSuite) TestCallRPCSendTransactionUpstream() {
 		err := json.Unmarshal([]byte(rawSignal), &signal)
 		s.NoError(err)
 
-		if signal.Type == node.EventTransactionQueued {
+		if signal.Type == txqueue.EventTransactionQueued {
 			event := signal.Event.(map[string]interface{})
 			txID := event["id"].(string)
 

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/geth/signal"
 	. "github.com/status-im/status-go/geth/testing"
+	"github.com/status-im/status-go/geth/txqueue"
 	"github.com/status-im/status-go/static"
 	"github.com/stretchr/testify/suite"
 )
@@ -44,7 +45,7 @@ func (s *JailTestSuite) SetupTest() {
 	accountManager := account.NewManager(nodeManager)
 	require.NotNil(accountManager)
 
-	txQueueManager := node.NewTxQueueManager(nodeManager, accountManager)
+	txQueueManager := txqueue.NewManager(nodeManager, accountManager)
 
 	jail := jail.New(nodeManager, accountManager, txQueueManager)
 	require.NotNil(jail)

--- a/geth/txqueue/txqueue.go
+++ b/geth/txqueue/txqueue.go
@@ -1,4 +1,4 @@
-package node
+package txqueue
 
 import (
 	"errors"

--- a/geth/txqueue/txqueue_manager.go
+++ b/geth/txqueue/txqueue_manager.go
@@ -1,4 +1,4 @@
-package node
+package txqueue
 
 import (
 	"context"

--- a/geth/txqueue/txqueue_manager.go
+++ b/geth/txqueue/txqueue_manager.go
@@ -44,16 +44,16 @@ var txReturnCodes = map[error]string{ // deliberately strings, in case more mean
 	ErrQueuedTxDiscarded: SendTransactionDiscardedErrorCode,
 }
 
-// TxQueueManager provides means to manage internal Status Backend (injected into LES)
-type TxQueueManager struct {
+// Manager provides means to manage internal Status Backend (injected into LES)
+type Manager struct {
 	nodeManager    common.NodeManager
 	accountManager common.AccountManager
 	txQueue        *TxQueue
 }
 
-// NewTxQueueManager returns a new TxQueueManager.
-func NewTxQueueManager(nodeManager common.NodeManager, accountManager common.AccountManager) *TxQueueManager {
-	return &TxQueueManager{
+// NewManager returns a new Manager.
+func NewManager(nodeManager common.NodeManager, accountManager common.AccountManager) *Manager {
+	return &Manager{
 		nodeManager:    nodeManager,
 		accountManager: accountManager,
 		txQueue:        NewTransactionQueue(),
@@ -61,24 +61,24 @@ func NewTxQueueManager(nodeManager common.NodeManager, accountManager common.Acc
 }
 
 // Start starts accepting new transactions into the queue.
-func (m *TxQueueManager) Start() {
-	log.Info("start TxQueueManager")
+func (m *Manager) Start() {
+	log.Info("start Manager")
 	m.txQueue.Start()
 }
 
 // Stop stops accepting new transactions into the queue.
-func (m *TxQueueManager) Stop() {
-	log.Info("stop TxQueueManager")
+func (m *Manager) Stop() {
+	log.Info("stop Manager")
 	m.txQueue.Stop()
 }
 
 // TransactionQueue returns a reference to the queue.
-func (m *TxQueueManager) TransactionQueue() common.TxQueue {
+func (m *Manager) TransactionQueue() common.TxQueue {
 	return m.txQueue
 }
 
 // CreateTransaction returns a transaction object.
-func (m *TxQueueManager) CreateTransaction(ctx context.Context, args common.SendTxArgs) *common.QueuedTx {
+func (m *Manager) CreateTransaction(ctx context.Context, args common.SendTxArgs) *common.QueuedTx {
 	return &common.QueuedTx{
 		ID:      common.QueuedTxID(uuid.New()),
 		Hash:    gethcommon.Hash{},
@@ -90,7 +90,7 @@ func (m *TxQueueManager) CreateTransaction(ctx context.Context, args common.Send
 }
 
 // QueueTransaction puts a transaction into the queue.
-func (m *TxQueueManager) QueueTransaction(tx *common.QueuedTx) error {
+func (m *Manager) QueueTransaction(tx *common.QueuedTx) error {
 	to := "<nil>"
 	if tx.Args.To != nil {
 		to = tx.Args.To.Hex()
@@ -102,7 +102,7 @@ func (m *TxQueueManager) QueueTransaction(tx *common.QueuedTx) error {
 
 // WaitForTransaction adds a transaction to the queue and blocks
 // until it's completed, discarded or times out.
-func (m *TxQueueManager) WaitForTransaction(tx *common.QueuedTx) error {
+func (m *Manager) WaitForTransaction(tx *common.QueuedTx) error {
 	log.Info("wait for transaction", "id", tx.ID)
 
 	// now wait up until transaction is:
@@ -123,14 +123,14 @@ func (m *TxQueueManager) WaitForTransaction(tx *common.QueuedTx) error {
 }
 
 // NotifyOnQueuedTxReturn calls a handler when a transaction resolves.
-func (m *TxQueueManager) NotifyOnQueuedTxReturn(queuedTx *common.QueuedTx, err error) {
+func (m *Manager) NotifyOnQueuedTxReturn(queuedTx *common.QueuedTx, err error) {
 	m.txQueue.NotifyOnQueuedTxReturn(queuedTx, err)
 }
 
 // CompleteTransaction instructs backend to complete sending of a given transaction.
 // TODO(adam): investigate a possible bug that calling this method multiple times with the same Transaction ID
 // results in sending multiple transactions.
-func (m *TxQueueManager) CompleteTransaction(id common.QueuedTxID, password string) (gethcommon.Hash, error) {
+func (m *Manager) CompleteTransaction(id common.QueuedTxID, password string) (gethcommon.Hash, error) {
 	log.Info("complete transaction", "id", id)
 
 	queuedTx, err := m.txQueue.Get(id)
@@ -190,7 +190,7 @@ func (m *TxQueueManager) CompleteTransaction(id common.QueuedTxID, password stri
 	return hash, txErr
 }
 
-func (m *TxQueueManager) completeLocalTransaction(queuedTx *common.QueuedTx, password string) (gethcommon.Hash, error) {
+func (m *Manager) completeLocalTransaction(queuedTx *common.QueuedTx, password string) (gethcommon.Hash, error) {
 	log.Info("complete transaction using local node", "id", queuedTx.ID)
 
 	les, err := m.nodeManager.LightEthereumService()
@@ -201,7 +201,7 @@ func (m *TxQueueManager) completeLocalTransaction(queuedTx *common.QueuedTx, pas
 	return les.StatusBackend.SendTransaction(context.Background(), status.SendTxArgs(queuedTx.Args), password)
 }
 
-func (m *TxQueueManager) completeRemoteTransaction(queuedTx *common.QueuedTx, password string) (gethcommon.Hash, error) {
+func (m *Manager) completeRemoteTransaction(queuedTx *common.QueuedTx, password string) (gethcommon.Hash, error) {
 	log.Info("complete transaction using upstream node", "id", queuedTx.ID)
 
 	var emptyHash gethcommon.Hash
@@ -290,7 +290,7 @@ func (m *TxQueueManager) completeRemoteTransaction(queuedTx *common.QueuedTx, pa
 	return signedTx.Hash(), nil
 }
 
-func (m *TxQueueManager) estimateGas(args common.SendTxArgs) (*hexutil.Big, error) {
+func (m *Manager) estimateGas(args common.SendTxArgs) (*hexutil.Big, error) {
 	if args.Gas != nil {
 		return args.Gas, nil
 	}
@@ -338,7 +338,7 @@ func (m *TxQueueManager) estimateGas(args common.SendTxArgs) (*hexutil.Big, erro
 	return &estimatedGas, nil
 }
 
-func (m *TxQueueManager) gasPrice() (*hexutil.Big, error) {
+func (m *Manager) gasPrice() (*hexutil.Big, error) {
 	client := m.nodeManager.RPCClient()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -353,7 +353,7 @@ func (m *TxQueueManager) gasPrice() (*hexutil.Big, error) {
 }
 
 // CompleteTransactions instructs backend to complete sending of multiple transactions
-func (m *TxQueueManager) CompleteTransactions(ids []common.QueuedTxID, password string) map[common.QueuedTxID]common.RawCompleteTransactionResult {
+func (m *Manager) CompleteTransactions(ids []common.QueuedTxID, password string) map[common.QueuedTxID]common.RawCompleteTransactionResult {
 	results := make(map[common.QueuedTxID]common.RawCompleteTransactionResult)
 
 	for _, txID := range ids {
@@ -368,7 +368,7 @@ func (m *TxQueueManager) CompleteTransactions(ids []common.QueuedTxID, password 
 }
 
 // DiscardTransaction discards a given transaction from transaction queue
-func (m *TxQueueManager) DiscardTransaction(id common.QueuedTxID) error {
+func (m *Manager) DiscardTransaction(id common.QueuedTxID) error {
 	queuedTx, err := m.txQueue.Get(id)
 	if err != nil {
 		return err
@@ -385,7 +385,7 @@ func (m *TxQueueManager) DiscardTransaction(id common.QueuedTxID) error {
 }
 
 // DiscardTransactions discards given multiple transactions from transaction queue
-func (m *TxQueueManager) DiscardTransactions(ids []common.QueuedTxID) map[common.QueuedTxID]common.RawDiscardTransactionResult {
+func (m *Manager) DiscardTransactions(ids []common.QueuedTxID) map[common.QueuedTxID]common.RawDiscardTransactionResult {
 	results := make(map[common.QueuedTxID]common.RawDiscardTransactionResult)
 
 	for _, txID := range ids {
@@ -408,7 +408,7 @@ type SendTransactionEvent struct {
 }
 
 // TransactionQueueHandler returns handler that processes incoming tx queue requests
-func (m *TxQueueManager) TransactionQueueHandler() func(queuedTx *common.QueuedTx) {
+func (m *Manager) TransactionQueueHandler() func(queuedTx *common.QueuedTx) {
 	return func(queuedTx *common.QueuedTx) {
 		log.Info("calling TransactionQueueHandler")
 		signal.Send(signal.Envelope{
@@ -424,7 +424,7 @@ func (m *TxQueueManager) TransactionQueueHandler() func(queuedTx *common.QueuedT
 
 // SetTransactionQueueHandler sets a handler that will be called
 // when a new transaction is enqueued.
-func (m *TxQueueManager) SetTransactionQueueHandler(fn common.EnqueuedTxHandler) {
+func (m *Manager) SetTransactionQueueHandler(fn common.EnqueuedTxHandler) {
 	m.txQueue.SetEnqueueHandler(fn)
 }
 
@@ -438,7 +438,7 @@ type ReturnSendTransactionEvent struct {
 }
 
 // TransactionReturnHandler returns handler that processes responses from internal tx manager
-func (m *TxQueueManager) TransactionReturnHandler() func(queuedTx *common.QueuedTx, err error) {
+func (m *Manager) TransactionReturnHandler() func(queuedTx *common.QueuedTx, err error) {
 	return func(queuedTx *common.QueuedTx, err error) {
 		if err == nil {
 			return
@@ -463,7 +463,7 @@ func (m *TxQueueManager) TransactionReturnHandler() func(queuedTx *common.Queued
 	}
 }
 
-func (m *TxQueueManager) sendTransactionErrorCode(err error) string {
+func (m *Manager) sendTransactionErrorCode(err error) string {
 	if code, ok := txReturnCodes[err]; ok {
 		return code
 	}
@@ -474,13 +474,13 @@ func (m *TxQueueManager) sendTransactionErrorCode(err error) string {
 // SetTransactionReturnHandler sets a handler that will be called
 // when a transaction is about to return or when a recoverable error occured.
 // Recoverable error is, for instance, wrong password.
-func (m *TxQueueManager) SetTransactionReturnHandler(fn common.EnqueuedTxReturnHandler) {
+func (m *Manager) SetTransactionReturnHandler(fn common.EnqueuedTxReturnHandler) {
 	m.txQueue.SetTxReturnHandler(fn)
 }
 
 // SendTransactionRPCHandler is a handler for eth_sendTransaction method.
 // It accepts one param which is a slice with a map of transaction params.
-func (m *TxQueueManager) SendTransactionRPCHandler(ctx context.Context, args ...interface{}) (interface{}, error) {
+func (m *Manager) SendTransactionRPCHandler(ctx context.Context, args ...interface{}) (interface{}, error) {
 	log.Info("SendTransactionRPCHandler called")
 
 	// TODO(adam): it's a hack to parse arguments as common.RPCCall can do that.

--- a/geth/txqueue/txqueue_manager_test.go
+++ b/geth/txqueue/txqueue_manager_test.go
@@ -1,4 +1,4 @@
-package node
+package txqueue
 
 import (
 	"context"

--- a/geth/txqueue/txqueue_manager_test.go
+++ b/geth/txqueue/txqueue_manager_test.go
@@ -57,7 +57,7 @@ func (s *TxQueueTestSuite) TestCompleteTransaction() {
 	// and treat as success.
 	s.nodeManagerMock.EXPECT().LightEthereumService().Return(nil, errTxAssumedSent)
 
-	txQueueManager := NewTxQueueManager(s.nodeManagerMock, s.accountManagerMock)
+	txQueueManager := NewManager(s.nodeManagerMock, s.accountManagerMock)
 
 	txQueueManager.Start()
 	defer txQueueManager.Stop()
@@ -107,7 +107,7 @@ func (s *TxQueueTestSuite) TestCompleteTransactionMultipleTimes() {
 	// and treat as success.
 	s.nodeManagerMock.EXPECT().LightEthereumService().Return(nil, errTxAssumedSent)
 
-	txQueueManager := NewTxQueueManager(s.nodeManagerMock, s.accountManagerMock)
+	txQueueManager := NewManager(s.nodeManagerMock, s.accountManagerMock)
 
 	txQueueManager.Start()
 	defer txQueueManager.Stop()
@@ -161,7 +161,7 @@ func (s *TxQueueTestSuite) TestAccountMismatch() {
 		Address: common.FromAddress(TestConfig.Account2.Address),
 	}, nil)
 
-	txQueueManager := NewTxQueueManager(s.nodeManagerMock, s.accountManagerMock)
+	txQueueManager := NewManager(s.nodeManagerMock, s.accountManagerMock)
 
 	txQueueManager.Start()
 	defer txQueueManager.Stop()
@@ -207,7 +207,7 @@ func (s *TxQueueTestSuite) TestInvalidPassword() {
 	// Set ErrDecrypt error response as expected with a wrong password.
 	s.nodeManagerMock.EXPECT().LightEthereumService().Return(nil, keystore.ErrDecrypt)
 
-	txQueueManager := NewTxQueueManager(s.nodeManagerMock, s.accountManagerMock)
+	txQueueManager := NewManager(s.nodeManagerMock, s.accountManagerMock)
 
 	txQueueManager.Start()
 	defer txQueueManager.Stop()
@@ -242,7 +242,7 @@ func (s *TxQueueTestSuite) TestInvalidPassword() {
 }
 
 func (s *TxQueueTestSuite) TestDiscardTransaction() {
-	txQueueManager := NewTxQueueManager(s.nodeManagerMock, s.accountManagerMock)
+	txQueueManager := NewManager(s.nodeManagerMock, s.accountManagerMock)
 
 	txQueueManager.Start()
 	defer txQueueManager.Stop()

--- a/geth/txqueue/utils.go
+++ b/geth/txqueue/utils.go
@@ -1,0 +1,28 @@
+package txqueue
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/status-im/status-go/geth/common"
+	"github.com/status-im/status-go/geth/signal"
+)
+
+var ErrTxQueueRunFailure = errors.New("error running transaction queue")
+
+// HaltOnPanic recovers from panic, logs issue, sends upward notification, and exits
+func HaltOnPanic() {
+	if r := recover(); r != nil {
+		err := fmt.Errorf("%v: %v", ErrTxQueueRunFailure, r)
+
+		// send signal up to native app
+		signal.Send(signal.Envelope{
+			Type: signal.EventNodeCrashed,
+			Event: signal.NodeCrashEvent{
+				Error: err.Error(),
+			},
+		})
+
+		common.Fatalf(err) // os.exit(1) is called internally
+	}
+}


### PR DESCRIPTION
This PR is part of refactoring packages process and moves all transaction queue related code into separate package.