### PR TITLE
Add password validation in completeRemoteTransaction

### DIFF
--- a/geth/api/backend_test.go
+++ b/geth/api/backend_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/les"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
@@ -344,6 +345,12 @@ func (s *BackendTestSuite) TestCallRPCSendTransactionUpstream() {
 		if signal.Type == node.EventTransactionQueued {
 			event := signal.Event.(map[string]interface{})
 			txID := event["id"].(string)
+
+			// Complete with a wrong passphrase.
+			txHash, err = s.backend.CompleteTransaction(common.QueuedTxID(txID), "some-invalid-passphrase")
+			s.EqualError(err, keystore.ErrDecrypt.Error(), "should return an error as the passphrase was invalid")
+
+			// Complete with a correct passphrase.
 			txHash, err = s.backend.CompleteTransaction(common.QueuedTxID(txID), TestConfig.Account2.Password)
 			s.NoError(err, "cannot complete queued transaction %s", txID)
 

--- a/geth/node/txqueue_manager.go
+++ b/geth/node/txqueue_manager.go
@@ -216,6 +216,14 @@ func (m *TxQueueManager) completeRemoteTransaction(queuedTx *common.QueuedTx, pa
 		return emptyHash, err
 	}
 
+	if _, err := m.accountManager.VerifyAccountPassword(
+		config.KeyStoreDir,
+		selectedAcct.Address.String(),
+		password,
+	); err != nil {
+		return emptyHash, err
+	}
+
 	// We need to request a new transaction nounce from upstream node.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()


### PR DESCRIPTION
This PR adds a validation of the passphrase when completing a password using a remote node like infura.

Validation is performed using `AccountManager.VerifyAccountPassword()`.