### PR TITLE
Add help command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ statusgo-cross: statusgo-android statusgo-ios
 	@echo "Full cross compilation done."
 	@ls -ld $(GOBIN)/statusgo-*
 
-statusgo-android: xgo	##@cross-compile Build status-go for Android
+statusgo-android: xgo ##@cross-compile Build status-go for Android
 	build/env.sh $(GOBIN)/xgo --image farazdagi/xgo --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=android-16/aar -v $(shell build/testnet-flags.sh) ./cmd/statusd
 	@echo "Android cross compilation done."
 
@@ -81,7 +81,7 @@ ci: mock
 	build/env.sh go test -timeout 40m -v ./extkeys
 	build/env.sh go test -timeout 1m -v ./helpers/...
 
-generate:	##@other Regenerate assets and other auto-generated stuff
+generate: ##@other Regenerate assets and other auto-generated stuff
 	cp ./node_modules/web3/dist/web3.js ./static/scripts/web3.js
 	build/env.sh go generate ./static
 	rm ./static/scripts/web3.js


### PR DESCRIPTION
This PR adds some love to Makefile. It introduces a new `help` target, which dynamically builds usage output, with textual description of what target does. It supports ANSI colors and categories. It assumes that `perl` is installed in the system.

```bash
$ make help
Usage: make [target]

build:
  statusgo                        Build status-go as statusd server

cross-compile:
  statusgo-android                Build status-go for Android
  statusgo-ios                    Build status-go for iOS
  statusgo-ios-simulator          Build status-go for iOS Simulator

other:
  help                            Show this help
  generate                        Regenerate assets and other auto-generated stuff
  mock                            Regenerate mocks
  clean                           Cleanup

tests:
  lint                            Run meta linter on code
  test                            Run tests
```

To add new item to help, just add comment next to the target name starting with `##`:

```diff
- statusgo-android: xgo
+ statusgo-android: xgo ## Build status-go for Android
```
the rest is magic :)

If you want to add category, let's say `cross-compile`, just put `@cross-compile` right after `##`:

```diff
- statusgo-android: xgo ## Build status-go for Android
+ statusgo-android: xgo ##@cross-compile Build status-go for Android
```