### PR TITLE
Remove LES activation when using upstream

### DIFF
--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -75,15 +75,6 @@ func MakeNode(config *params.NodeConfig) (*node.Node, error) {
 		if err := activateEthService(stack, config); err != nil {
 			return nil, fmt.Errorf("%v: %v", ErrEthServiceRegistrationFailure, err)
 		}
-	} else {
-		// TODO(divan): FIXME: this is rude workaround for #294 issue
-		// we start activate LES service to have RPC handler for `eth_accounts` call
-		// should be removed once proper own RPC and refactoring is completed
-		config.MaxPeers = 0
-		if err := activateEthService(stack, config); err != nil {
-			return nil, fmt.Errorf("%v: %v", ErrEthServiceRegistrationFailure, err)
-		}
-		log.Info("Blockchain synchronization is switched off, RPC requests will be proxied to " + config.UpstreamConfig.URL)
 	}
 
 	// start Whisper service


### PR DESCRIPTION
LES service is not required anymore when using the upstream node.