### PR TITLE
Forward net_* rpc commands to the upstream

### DIFF
--- a/geth/rpc/client_test.go
+++ b/geth/rpc/client_test.go
@@ -212,9 +212,9 @@ func (s *RPCTestSuite) TestCallRPC() {
 			},
 		},
 		{
-			`[{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}]`,
+			`[{"jsonrpc":"2.0","method":"net_listening","params":[],"id":67}]`,
 			func(resultJSON string) {
-				expected := `[{"jsonrpc":"2.0","id":67,"result":"4"}]`
+				expected := `[{"jsonrpc":"2.0","id":67,"result":true}]`
 				s.Equal(expected, resultJSON)
 				progress <- struct{}{}
 			},

--- a/geth/rpc/route.go
+++ b/geth/rpc/route.go
@@ -35,6 +35,7 @@ func (r *router) routeRemote(method string) bool {
 // remoteMethods contains methods that should be routed to
 // the upstream node; the rest is considered to be routed to
 // the local node.
+// A list of supported methods: https://infura.io/docs/#supported-json-rpc-methods
 // TODO(tiabc): Write a test on each of these methods to ensure they're all routed to the proper node and ensure they really work
 // TODO(tiabc: as we already caught https://github.com/status-im/status-go/issues/350 as the result of missing such test.
 // Although it's tempting to only list methods coming to the local node as there're fewer of them
@@ -85,4 +86,7 @@ var remoteMethods = [...]string{
 	"eth_getWork",
 	"eth_submitWork",
 	"eth_submitHashrate",
+	"net_version",
+	"net_peerCount",
+	"net_listening",
 }

--- a/geth/rpc/route_test.go
+++ b/geth/rpc/route_test.go
@@ -1,12 +1,13 @@
 package rpc
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-// some of the upstream examples
-var localMethods = []string{"some_weirdo_method", "shh_newMessageFilter", "net_version"}
+// localMethods are methods that should be executed locally.
+var localTestMethods = []string{"some_weirdo_method", "shh_newMessageFilter", "eth_accounts"}
 
 func TestRouteWithUpstream(t *testing.T) {
 	router := newRouter(true)
@@ -15,7 +16,7 @@ func TestRouteWithUpstream(t *testing.T) {
 		require.True(t, router.routeRemote(method), "method "+method+" should routed to remote")
 	}
 
-	for _, method := range localMethods {
+	for _, method := range localTestMethods {
 		t.Run(method, func(t *testing.T) {
 			require.False(t, router.routeRemote(method), "method "+method+" should routed to local")
 		})
@@ -29,7 +30,7 @@ func TestRouteWithoutUpstream(t *testing.T) {
 		require.False(t, router.routeRemote(method), "method "+method+" should routed to locally without UpstreamEnabled")
 	}
 
-	for _, method := range localMethods {
+	for _, method := range localTestMethods {
 		require.False(t, router.routeRemote(method), "method "+method+" should routed to local")
 	}
 }


### PR DESCRIPTION
`net_*` commands are supported by infura and should be routed there.

Otherwise, as we don't run `les` service anymore when using the upstream node, calling `net_listening` will result in an error and Dapps will think that our node is offline.