### PR TITLE
Check for callback in makeAsyncHandler

### DIFF
--- a/geth/jail/handlers.go
+++ b/geth/jail/handlers.go
@@ -75,10 +75,12 @@ func makeAsyncSendHandler(jail *Jail, cellInt common.JailCell) func(call otto.Fu
 		go func() {
 			response := jail.Send(call)
 
-			// run callback asyncronously with args (error, response)
 			callback := call.Argument(1)
-			err := otto.NullValue()
-			cell.CallAsync(callback, err, response)
+			if callback.Class() == "Function" {
+				// run callback asyncronously with args (error, response)
+				err := otto.NullValue()
+				cell.CallAsync(callback, err, response)
+			}
 		}()
 		return otto.UndefinedValue()
 	}


### PR DESCRIPTION
This PR fixes regression from 3540972f0e6249b32f97f3e0889c27edb68c8f4f and adds check for callback validity before putting it into event loop for sendAsync calls.