### PR TITLE
Put int64 as the first word in Loop

### DIFF
--- a/geth/jail/internal/loop/loop.go
+++ b/geth/jail/internal/loop/loop.go
@@ -39,6 +39,10 @@ type Task interface {
 // aren't ready yet, keyed by their ID, and a channel of tasks that are ready
 // to finalise on the VM. The channel holding the tasks pending finalising can
 // be buffered or unbuffered.
+//
+// Warning: id must be the first field in this struct as it's accessed atomically.
+// Otherwise, on ARM and x86-32 it will panic.
+// More information: https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
 type Loop struct {
 	id    int64
 	vm    *vm.VM

--- a/geth/jail/internal/loop/loop.go
+++ b/geth/jail/internal/loop/loop.go
@@ -40,8 +40,8 @@ type Task interface {
 // to finalise on the VM. The channel holding the tasks pending finalising can
 // be buffered or unbuffered.
 type Loop struct {
-	vm    *vm.VM
 	id    int64
+	vm    *vm.VM
 	lock  sync.RWMutex
 	tasks map[int64]Task
 	ready chan Task


### PR DESCRIPTION
This should fix a bug with both ARM and x86-32 and use of atomic operations on 64bit values.

Bug: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
Siilar issue: https://github.com/golang/go/issues/17207

