### PR TITLE
Fixed jail.cells nil assignment

### DIFF
--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -75,7 +75,8 @@ func (jail *Jail) Stop() {
 	for _, cell := range jail.cells {
 		cell.Stop()
 	}
-	jail.cells = nil
+	// TODO(tiabc): Move this initialisation to a proper place.
+	jail.cells = make(map[string]*Cell)
 }
 
 // Cell returns the existing instance of Cell.


### PR DESCRIPTION
jail.cells is now re-created upon Jail.Stop, not assigned to nil. Assigning it to nil led to runtime panic when a node was stopped and started again.

Fixes crash on https://github.com/status-im/status-react/issues/2122