### PR TITLE
EnsureNodeSync() now throws a panic in case of error or timeout

### DIFF
--- a/cmd/statusd/utils.go
+++ b/cmd/statusd/utils.go
@@ -215,11 +215,7 @@ func testResetChainData(t *testing.T) bool {
 		return false
 	}
 
-	if err := EnsureNodeSync(statusAPI.NodeManager()); err != nil {
-		t.Errorf("cannot ensure node synchronization: %v", err)
-		return false
-	}
-
+	EnsureNodeSync(statusAPI.NodeManager())
 	testCompleteTransaction(t)
 
 	return true
@@ -735,11 +731,7 @@ func testCompleteTransaction(t *testing.T) bool {
 	txQueue := txQueueManager.TransactionQueue()
 
 	txQueue.Reset()
-
-	if err := EnsureNodeSync(statusAPI.NodeManager()); err != nil {
-		t.Errorf("cannot ensure node synchronization: %v", err)
-		return false
-	}
+	EnsureNodeSync(statusAPI.NodeManager())
 
 	// log into account from which transactions will be sent
 	if err := statusAPI.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password); err != nil {
@@ -1373,10 +1365,7 @@ func startTestNode(t *testing.T) <-chan struct{} {
 			// sync
 			if syncRequired {
 				t.Logf("Sync is required")
-				if err := EnsureNodeSync(statusAPI.NodeManager()); err != nil {
-					t.Errorf("cannot ensure node synchronization: %v", err)
-					return
-				}
+				EnsureNodeSync(statusAPI.NodeManager())
 			} else {
 				time.Sleep(5 * time.Second)
 			}

--- a/e2e/api/backend_test.go
+++ b/e2e/api/backend_test.go
@@ -242,7 +242,7 @@ func (s *APIBackendTestSuite) TestResetChainData() {
 	s.StartTestBackend(params.RinkebyNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()), "cannot ensure node synchronization")
+	EnsureNodeSync(s.Backend.NodeManager())
 
 	s.True(s.Backend.IsNodeRunning())
 	nodeReady, err := s.Backend.ResetChainData()

--- a/e2e/jail/jail_rpc_test.go
+++ b/e2e/jail/jail_rpc_test.go
@@ -39,7 +39,7 @@ func (s *JailRPCTestSuite) TestJailRPCSend() {
 	s.StartTestBackend(params.StatusChainNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()), "cannot ensure node synchronization")
+	EnsureNodeSync(s.Backend.NodeManager())
 
 	// load Status JS and add test command to it
 	s.jail.BaseJS(baseStatusJSCode)
@@ -112,7 +112,7 @@ func (s *JailRPCTestSuite) TestContractDeployment() {
 	s.StartTestBackend(params.StatusChainNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()), "cannot ensure node synchronization")
+	EnsureNodeSync(s.Backend.NodeManager())
 
 	// obtain VM for a given chat (to send custom JS to jailed version of Send())
 	s.jail.Parse(testChatID, "")
@@ -198,7 +198,7 @@ func (s *JailRPCTestSuite) TestJailVMPersistence() {
 	s.StartTestBackend(params.StatusChainNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()), "cannot ensure node synchronization")
+	EnsureNodeSync(s.Backend.NodeManager())
 
 	// log into account from which transactions will be sent
 	err := s.Backend.AccountManager().SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)

--- a/e2e/node/manager_test.go
+++ b/e2e/node/manager_test.go
@@ -296,7 +296,7 @@ func (s *ManagerTestSuite) TestResetChainData() {
 	s.StartTestNode(params.RinkebyNetworkID)
 	defer s.StopTestNode()
 
-	s.NoError(EnsureNodeSync(s.NodeManager), "cannot ensure node synchronization")
+	EnsureNodeSync(s.NodeManager)
 
 	// reset chain data
 	nodeReady, err := s.NodeManager.ResetChainData()

--- a/e2e/rpc/rpc_test.go
+++ b/e2e/rpc/rpc_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/status-im/status-go/e2e"
 	"github.com/status-im/status-go/geth/node"
 	"github.com/status-im/status-go/geth/params"
 	. "github.com/status-im/status-go/testing"
 	"github.com/stretchr/testify/suite"
-	"math/big"
 )
 
 func TestRPCTestSuite(t *testing.T) {
@@ -143,7 +144,7 @@ func (s *RPCTestSuite) TestCallContextResult() {
 	s.StartTestNode(params.StatusChainNetworkID)
 	defer s.StopTestNode()
 
-	s.Require().NoError(EnsureNodeSync(s.NodeManager))
+	EnsureNodeSync(s.NodeManager)
 
 	client := s.NodeManager.RPCClient()
 	s.NotNil(client)

--- a/e2e/transactions/transactions_test.go
+++ b/e2e/transactions/transactions_test.go
@@ -35,7 +35,7 @@ func (s *TransactionsTestSuite) TestCallRPCSendTransaction() {
 	s.StartTestBackend(params.StatusChainNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()), "cannot ensure node synchronization")
+	EnsureNodeSync(s.Backend.NodeManager())
 
 	err := s.Backend.AccountManager().SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
 	s.NoError(err)
@@ -142,7 +142,7 @@ func (s *TransactionsTestSuite) TestSendContractTx() {
 	s.StartTestBackend(params.StatusChainNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()), "cannot ensure node synchronization")
+	EnsureNodeSync(s.Backend.NodeManager())
 
 	sampleAddress, _, _, err := s.Backend.AccountManager().CreateAccount(TestConfig.Account1.Password)
 	s.NoError(err)
@@ -229,7 +229,7 @@ func (s *TransactionsTestSuite) TestSendEther() {
 	s.StartTestBackend(params.StatusChainNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()))
+	EnsureNodeSync(s.Backend.NodeManager())
 
 	backend := s.LightEthereumService().StatusBackend
 	s.NotNil(backend)
@@ -369,7 +369,7 @@ func (s *TransactionsTestSuite) TestDoubleCompleteQueuedTransactions() {
 	s.StartTestBackend(params.StatusChainNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()), "cannot ensure node synchronization")
+	EnsureNodeSync(s.Backend.NodeManager())
 
 	backend := s.LightEthereumService().StatusBackend
 	s.NotNil(backend)
@@ -446,7 +446,7 @@ func (s *TransactionsTestSuite) TestDiscardQueuedTransaction() {
 	s.StartTestBackend(params.StatusChainNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()), "cannot ensure node synchronization")
+	EnsureNodeSync(s.Backend.NodeManager())
 
 	backend := s.LightEthereumService().StatusBackend
 	s.NotNil(backend)
@@ -526,8 +526,7 @@ func (s *TransactionsTestSuite) TestCompleteMultipleQueuedTransactions() {
 	s.StartTestBackend(params.StatusChainNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()), "cannot ensure node synchronization")
-
+	EnsureNodeSync(s.Backend.NodeManager())
 	s.TxQueueManager().TransactionQueue().Reset()
 
 	// log into account from which transactions will be sent
@@ -620,7 +619,7 @@ func (s *TransactionsTestSuite) TestDiscardMultipleQueuedTransactions() {
 	s.StartTestBackend(params.StatusChainNetworkID)
 	defer s.StopTestBackend()
 
-	s.NoError(EnsureNodeSync(s.Backend.NodeManager()), "cannot ensure node synchronization")
+	EnsureNodeSync(s.Backend.NodeManager())
 
 	backend := s.LightEthereumService().StatusBackend
 	s.NotNil(backend)

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -69,23 +68,23 @@ func LoadFromFile(filename string) string {
 }
 
 // EnsureNodeSync waits until node synchronzation is done to continue
-// with tests afterwards. Returns an error in case of a timeout.
-func EnsureNodeSync(nodeManager common.NodeManager) error {
+// with tests afterwards. Panics in case of an error or a timeout.
+func EnsureNodeSync(nodeManager common.NodeManager) {
 	nc, err := nodeManager.NodeConfig()
 	if err != nil {
-		return errors.New("can't retrieve NodeConfig")
+		panic("can't retrieve NodeConfig")
 	}
 	// Don't wait for any blockchain sync for the local private chain as blocks are never mined.
 	if nc.NetworkID == params.StatusChainNetworkID {
-		return nil
+		return
 	}
 
 	les, err := nodeManager.LightEthereumService()
 	if err != nil {
-		return err
+		panic(err)
 	}
 	if les == nil {
-		return errors.New("LightEthereumService is nil")
+		panic("LightEthereumService is nil")
 	}
 
 	timeouter := time.NewTimer(20 * time.Minute)
@@ -96,7 +95,7 @@ func EnsureNodeSync(nodeManager common.NodeManager) error {
 	for {
 		select {
 		case <-timeouter.C:
-			return errors.New("timout during node synchronization")
+			panic("timout during node synchronization")
 		case <-ticker.C:
 			downloader := les.Downloader()
 
@@ -105,10 +104,9 @@ func EnsureNodeSync(nodeManager common.NodeManager) error {
 				progress := downloader.Progress()
 
 				if !isSyncing && progress.HighestBlock > 0 && progress.CurrentBlock >= progress.HighestBlock {
-					return nil
+					return
 				}
 			}
-
 		}
 	}
 }


### PR DESCRIPTION
Based on a discussion with @tiabc about the pure test intention of the function `EnsureNodeSync()` it has been changed to return no error anymore, Instead in case of an internal error or a timeout a panic is thrown.

- [X] Changed `EnsureNodeSync()` to throw panic
- [X] Removed assertions for non-existing error at `EnsureNodeSync()` calls
- [X] Tested pass on CI

Solves no concrete issue, is more an optimisation of #344.