### PR TITLE
Improve JSON-RPC handling for raw requests/responses, Fixes #364

### DIFF
--- a/geth/rpc/call_raw.go
+++ b/geth/rpc/call_raw.go
@@ -168,13 +168,6 @@ func newSuccessResponse(result json.RawMessage, id json.RawMessage) string {
 		id = defaultMsgID
 	}
 
-	// original response with `null` is lost due to geth RPC client
-	// conversion (unmarshalling). We'll have nil result object in this case,
-	// so handle it specially. `result` is required field in response.
-	if result == nil {
-		result = json.RawMessage("null")
-	}
-
 	msg := &jsonrpcSuccessfulResponse{
 		jsonrpcMessage: jsonrpcMessage{
 			ID:      id,

--- a/geth/rpc/call_raw.go
+++ b/geth/rpc/call_raw.go
@@ -47,7 +47,7 @@ type jsonrpcSuccessfulResponse struct {
 
 type jsonrpcErrorResponse struct {
 	jsonrpcMessage
-	Error *jsonError `json:"error,omitempty"`
+	Error *jsonError `json:"error"`
 }
 
 // jsonError represents Error message for JSON-RPC responses.

--- a/geth/rpc/call_raw.go
+++ b/geth/rpc/call_raw.go
@@ -47,7 +47,7 @@ type jsonrpcSuccessfulResponse struct {
 
 type jsonrpcErrorResponse struct {
 	jsonrpcMessage
-	Error *jsonError `json:"error"`
+	Error jsonError `json:"error"`
 }
 
 // jsonError represents Error message for JSON-RPC responses.
@@ -189,7 +189,7 @@ func newErrorResponse(code int, err error, id json.RawMessage) string {
 			ID:      id,
 			Version: jsonrpcVersion,
 		},
-		Error: &jsonError{
+		Error: jsonError{
 			Code:    code,
 			Message: err.Error(),
 		},

--- a/geth/rpc/call_raw_test.go
+++ b/geth/rpc/call_raw_test.go
@@ -42,10 +42,10 @@ func TestUnmarshalMessage(t *testing.T) {
 	got, err := unmarshalMessage(body)
 	require.NoError(t, err)
 
-	expected := &jsonrpcMessage{
-		Version: "2.0",
-		Method:  "subtract",
-		Params:  json.RawMessage(`{"subtrahend": 23, "minuend": 42}`),
+	expected := &jsonrpcRequest{
+		jsonrpcMessage: jsonrpcMessage{Version: "2.0"},
+		Method:         "subtract",
+		Params:         json.RawMessage(`{"subtrahend": 23, "minuend": 42}`),
 	}
 	require.Equal(t, expected, got)
 }


### PR DESCRIPTION
Didn't see any progress on the issue so thought i'd give it a go. 

changes:
- [x] Split the response types with common members ID and Version
- [x] Did a review of JSON RPC spec and updates tags as necessary
- [x] Removed a previous workaround for `nil result` that will be unnecessary with these changes
- No notification message type, seems to be not required at this stage?
- Couldn't find any new use cases for unit tests, no new functions added 

How does this look 😃 ? 
ci tests fail at some point due to the fork repo not having access to `ACCOUNT_PASSWORD` secret variable. Is there a workaround for this? However the unit tests for this area of the code pass.

Fixes #364