### PR TITLE
Skip including lib/utils.go in cgo compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,8 @@ test-e2e: ##@tests Run e2e tests
 	go test -timeout 20m ./e2e/rpc/... -network=$(networkid)
 	go test -timeout 20m ./e2e/whisper/... -network=$(networkid)
 	go test -timeout 10m ./e2e/transactions/... -network=$(networkid)
-	go test -timeout 40m ./lib -network=$(networkid)
+	# e2e_test tag is required to include some files from ./lib without _test suffix
+	go test -timeout 40m -tags e2e_test ./lib -network=$(networkid)
 
 ci: lint mock-install mock test-unit test-e2e ##@tests Run all linters and tests at once
 

--- a/lib/library_test.go
+++ b/lib/library_test.go
@@ -1,3 +1,9 @@
+// +build e2e_test
+
+// Tests in `./lib` package will run only when `e2e_test` build tag is provided.
+// It's required to prevent some files from being included in the binary.
+// Check out `lib/utils.go` for more details.
+
 package main
 
 import (

--- a/lib/main.go
+++ b/lib/main.go
@@ -9,5 +9,4 @@ var statusAPI = api.NewStatusAPI()
 // without main it produces cryptic errors.
 // TODO(divan): investigate the cause of the errors
 // and change this package to be a library if possible.
-func main() {
-}
+func main() {}

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -1,5 +1,12 @@
 // +build e2e_test
 
+// This is a file with e2e tests for C bindings written in library.go.
+// As a CGO file, it can't have `_test.go` suffix as it's not allowed by Go.
+// At the same time, we don't want this file to be included in the binaries.
+// This is why `e2e_test` tag was introduced. Without it, this file is excluded
+// from the build. Providing this tag will include this file into the build
+// and that's what is done while running e2e tests for `lib/` package.
+
 package main
 
 import "C"

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -1,3 +1,5 @@
+// +build e2e_test
+
 package main
 
 import "C"


### PR DESCRIPTION
`lib/utils.go` is a file with binding tests written in CGO. It can't have `_test` suffix because Go does not allow test files to be CGO files.

I introduced a new build tag `e2e_test` which is required to include `lib/utils.go`. I added that flag in Makefile to run e2e tests in `lib/` package.

Solves #468 