### PR TITLE
Bring back Parse binding

### DIFF
--- a/geth/api/api.go
+++ b/geth/api/api.go
@@ -179,6 +179,13 @@ func (api *StatusAPI) DiscardTransactions(ids []common.QueuedTxID) map[common.Qu
 	return api.b.txQueueManager.DiscardTransactions(ids)
 }
 
+// JailParse creates a new jail cell context, with the given chatID as identifier.
+// New context executes provided JavaScript code, right after the initialization.
+// DEPRECATED in favour of CreateAndInitCell.
+func (api *StatusAPI) JailParse(chatID string, js string) string {
+	return api.b.jailManager.Parse(chatID, js)
+}
+
 // CreateAndInitCell creates a new jail cell context, with the given chatID as identifier.
 // New context executes provided JavaScript code, right after the initialization.
 func (api *StatusAPI) CreateAndInitCell(chatID, js string) string {

--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -297,6 +297,11 @@ type JailManager interface {
 	// CreateCell creates a new jail cell.
 	CreateCell(chatID string) (JailCell, error)
 
+	// Parse creates a new jail cell context, with the given chatID as identifier.
+	// New context executes provided JavaScript code, right after the initialization.
+	// DEPRECATED
+	Parse(chatID, js string) string
+
 	// CreateAndInitCell creates a new jail cell and initialize it
 	// with web3 and other handlers.
 	CreateAndInitCell(chatID string, code ...string) string

--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -299,7 +299,7 @@ type JailManager interface {
 
 	// Parse creates a new jail cell context, with the given chatID as identifier.
 	// New context executes provided JavaScript code, right after the initialization.
-	// DEPRECATED
+	// DEPRECATED in favour of CreateAndInitCell.
 	Parse(chatID, js string) string
 
 	// CreateAndInitCell creates a new jail cell and initialize it

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -161,6 +161,26 @@ func (j *Jail) CreateAndInitCell(chatID string, code ...string) string {
 	return j.makeCatalogVariable(cell)
 }
 
+// Parse creates a new jail cell context, with the given chatID as identifier.
+// New context executes provided JavaScript code, right after the initialization.
+// DEPRECATED
+func (j *Jail) Parse(chatID, code string) string {
+	cell, err := j.cell(chatID)
+	if err != nil {
+		// cell does not exist
+		cell, err = j.createAndInitCell(chatID, code)
+	} else {
+		// cell already exist, so just execute the code
+		_, err = cell.Run(code)
+	}
+
+	if err != nil {
+		return newJailErrorResponse(err)
+	}
+
+	return j.makeCatalogVariable(cell)
+}
+
 // makeCatalogVariable provides `catalog` as a global variable.
 // TODO(divan): this can and should be implemented outside of jail,
 // on a clojure side. Moving this into separate method to nuke it later

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -163,7 +163,7 @@ func (j *Jail) CreateAndInitCell(chatID string, code ...string) string {
 
 // Parse creates a new jail cell context, with the given chatID as identifier.
 // New context executes provided JavaScript code, right after the initialization.
-// DEPRECATED
+// DEPRECATED in favour of CreateAndInitCell.
 func (j *Jail) Parse(chatID, code string) string {
 	cell, err := j.cell(chatID)
 	if err != nil {

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -167,14 +167,18 @@ func (j *Jail) CreateAndInitCell(chatID string, code ...string) string {
 func (j *Jail) Parse(chatID, code string) string {
 	cell, err := j.cell(chatID)
 	if err != nil {
-		// cell does not exist
+		// cell does not exist, so create and init it
 		cell, err = j.createAndInitCell(chatID, code)
 	} else {
-		// cell already exist, so just execute the code
-		_, err = cell.Run(code)
+		// cell already exists, so just reinit it
+		err = j.initCell(cell)
 	}
 
 	if err != nil {
+		return newJailErrorResponse(err)
+	}
+
+	if _, err = cell.Run(code); err != nil {
 		return newJailErrorResponse(err)
 	}
 

--- a/lib/library.go
+++ b/lib/library.go
@@ -323,6 +323,14 @@ func InitJail(js *C.char) {
 	statusAPI.SetJailBaseJS(C.GoString(js))
 }
 
+//Parse creates a new jail cell context and executes provided JavaScript code.
+//DEPRECATED in favour of CreateAndInitCell and ExecuteJS.
+//export Parse
+func Parse(chatID *C.char, js *C.char) *C.char {
+	res := statusAPI.JailParse(C.GoString(chatID), C.GoString(js))
+	return C.CString(res)
+}
+
 //CreateAndInitCell creates a new jail cell context and executes provided JavaScript code.
 //export CreateAndInitCell
 func CreateAndInitCell(chatID *C.char, js *C.char) *C.char {

--- a/lib/library.go
+++ b/lib/library.go
@@ -324,7 +324,7 @@ func InitJail(js *C.char) {
 }
 
 //Parse creates a new jail cell context and executes provided JavaScript code.
-//DEPRECATED in favour of CreateAndInitCell and ExecuteJS.
+//DEPRECATED in favour of CreateAndInitCell.
 //export Parse
 func Parse(chatID *C.char, js *C.char) *C.char {
 	res := statusAPI.JailParse(C.GoString(chatID), C.GoString(js))


### PR DESCRIPTION
It brings back `Parse()` binding as it's not possible for status-react to get rid of just yet.

In PR https://github.com/status-im/status-go/pull/401, we introduced new bindings: `CreateAndInitCell` and `ExecuteJS` to improve performance and prevent from constant reparsing huge chunks of JS code. However, it turned out that status-react is not ready to implement required changes on their side, thus we need to bring back `Parse()` binding for now.

Important changes:
- [x] `Parse()` binding with tests is back.