### PR TITLE
Add Makefile target for compilation into library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,7 @@ statusgo-ios-simulator: xgo	##@cross-compile Build status-go for iOS Simulator
 
 statusgo-library: ##@cross-compile Build status-go as static library for current platform
 	@echo "Building static library..."
-	@go build -buildmode=c-archive -o $(GOBIN)/libstatus ./lib
-	@ranlib $(GOBIN)/libstatus.a
+	go build -buildmode=c-archive -o $(GOBIN)/libstatus.a ./lib
 	@echo "Static library built:"
 	@ls -la $(GOBIN)/libstatus.*
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ statusgo-library: ##@cross-compile Build status-go as static library for current
 	@echo "Building static library..."
 	@go build -buildmode=c-archive -o $(GOBIN)/libstatus ./lib
 	@ranlib $(GOBIN)/libstatus.a
-	@echo "Static lib cross compilation done:"
+	@echo "Static library built:"
 	@ls -la $(GOBIN)/libstatus.*
 
 xgo:

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,13 @@ statusgo-ios-simulator: xgo	##@cross-compile Build status-go for iOS Simulator
 	$(GOPATH)/bin/xgo --image farazdagi/xgo-ios-simulator --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell build/testnet-flags.sh) ./lib
 	@echo "iOS framework cross compilation done."
 
+statusgo-library: ##@cross-compile Build status-go as static library for current platform
+	@echo "Building static library..."
+	@go build -buildmode=c-archive -o $(GOBIN)/libstatus ./lib
+	@ranlib $(GOBIN)/libstatus.a
+	@echo "Static lib cross compilation done:"
+	@ls -la $(GOBIN)/libstatus.*
+
 xgo:
 	docker pull farazdagi/xgo
 	go get github.com/karalabe/xgo


### PR DESCRIPTION
This PR adds new target to Makefile to build static library (libstatus.a). Currently, it builds library for the host platform without cross-compilation and required for https://github.com/status-im/status-nodejs

TODO: update README in https://github.com/status-im/status-nodejs once this PR is merged.