### PR TITLE
Update CHT root automatically using GetHeaderProofs (Fixes #320)

### DIFF
--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -144,8 +144,8 @@ func activateEthService(stack *node.Node, config *params.NodeConfig) error {
 	if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 		lightEth, err := les.New(ctx, &ethConf)
 
-        les.LightEth = lightEth
-        les.NodeConfig = config
+		les.LightEth = lightEth
+		les.NodeConfig = config
 		return lightEth, err
 	}); err != nil {
 		return fmt.Errorf("%v: %v", ErrLightEthRegistrationFailure, err)

--- a/vendor/github.com/ethereum/go-ethereum/les/backend.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/backend.go
@@ -75,6 +75,10 @@ type LightEthereum struct {
 	StatusBackend *ethapi.StatusBackend
 }
 
+func (f LightEthereum) LesOdr() *LesOdr  {
+    return f.odr
+}
+
 func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	chainDb, err := eth.CreateDB(ctx, config, "lightchaindata")
 	if err != nil {

--- a/vendor/github.com/ethereum/go-ethereum/les/backend.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/backend.go
@@ -75,8 +75,8 @@ type LightEthereum struct {
 	StatusBackend *ethapi.StatusBackend
 }
 
-func (f LightEthereum) LesOdr() *LesOdr  {
-    return f.odr
+func (f LightEthereum) LesOdr() *LesOdr {
+	return f.odr
 }
 
 func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {

--- a/vendor/github.com/ethereum/go-ethereum/les/odr_requests.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/odr_requests.go
@@ -336,17 +336,17 @@ func (r *ChtRequest) Validate(db ethdb.Database, msg *Msg) error {
 	var encNumber [8]byte
 	binary.BigEndian.PutUint64(encNumber[:], r.BlockNum)
 
-    // Issue 320: If no ChtRoot was supplied, extract ChtRoot from the proof and use that
-    if (common.Hash{} == r.ChtRoot) {
-        chtRoot := trie.ExtractChtRoot(encNumber[:], proof.Proof)
-        log.Debug("Setting r.ChtRoot to: ","chtRoot from proof: ", common.ToHex(chtRoot))
-        r.ChtRoot = common.BytesToHash(chtRoot)
-    }
+	// Issue 320: If no ChtRoot was supplied, extract ChtRoot from the proof and use that
+	if (common.Hash{} == r.ChtRoot) {
+		chtRoot := trie.ExtractChtRoot(encNumber[:], proof.Proof)
+		log.Debug("Setting r.ChtRoot to: ", "chtRoot from proof: ", common.ToHex(chtRoot))
+		r.ChtRoot = common.BytesToHash(chtRoot)
+	}
 
-    value, err := trie.VerifyProof(r.ChtRoot, encNumber[:], proof.Proof)
-    if err != nil {
-	    return err
-    }
+	value, err := trie.VerifyProof(r.ChtRoot, encNumber[:], proof.Proof)
+	if err != nil {
+		return err
+	}
 
 	var node light.ChtNode
 	if err := rlp.DecodeBytes(value, &node); err != nil {

--- a/vendor/github.com/ethereum/go-ethereum/les/sync.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/sync.go
@@ -106,7 +106,7 @@ func updateChtFromPeer(pm *ProtocolManager, peer *peer, ctx context.Context) {
     log.Debug("CHT block values: ", "chtnum",chtnum,"blocknum",blocknum)
 
     req := &light.ChtRequest{ChtNum: uint64(chtnum), BlockNum: uint64(blocknum)}
-    LightEth.LesOdr().Retrieve(context.Background(), req)
+    LightEth.LesOdr().Retrieve(ctx, req)
     log.Info("Retrieved latest CHT root from peer, got", "ChtRoot",common.ToHex(req.ChtRoot.Bytes()))
 
 	LightEth.WriteTrustedCht(light.TrustedCht{

--- a/vendor/github.com/ethereum/go-ethereum/les/sync.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/sync.go
@@ -86,39 +86,38 @@ func (pm *ProtocolManager) synchronise(peer *peer) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-    updateChtFromPeer(pm, peer, ctx)
+	updateChtFromPeer(pm, peer, ctx)
 	pm.blockchain.(*light.LightChain).SyncCht(ctx)
 	pm.downloader.Synchronise(peer.id, peer.Head(), peer.Td(), downloader.LightSync)
 }
 
 // Status.im issue 320: Use GetHeaderProofs to download the latest CHT from a peer.
 func updateChtFromPeer(pm *ProtocolManager, peer *peer, ctx context.Context) {
-    log.Info("Downloading latest CHT root from peer", "peer.headBlockInfo", peer.headBlockInfo())
+	log.Info("Downloading latest CHT root from peer", "peer.headBlockInfo", peer.headBlockInfo())
 
-    // Formula from lightchain.go:SyncCht: num := cht.Number*ChtFrequency – 1
+	// Formula from lightchain.go:SyncCht: num := cht.Number*ChtFrequency – 1
 	var hbl = peer.headBlockInfo()
-    var peerHeadBlockNum = hbl.Number
-    log.Debug("UpdateChtFromPeer","peerHeadBlockNum", peerHeadBlockNum)
+	var peerHeadBlockNum = hbl.Number
+	log.Debug("UpdateChtFromPeer", "peerHeadBlockNum", peerHeadBlockNum)
 
-    var chtnum uint64 = ((peerHeadBlockNum + 1) / light.ChtFrequency) -1
-    var blocknum uint64 = chtnum*light.ChtFrequency -1
-    log.Debug("CHT block values: ", "chtnum",chtnum,"blocknum",blocknum)
+	var chtnum uint64 = ((peerHeadBlockNum + 1) / light.ChtFrequency) - 1
+	var blocknum uint64 = chtnum*light.ChtFrequency - 1
+	log.Debug("CHT block values: ", "chtnum", chtnum, "blocknum", blocknum)
 
-    req := &light.ChtRequest{ChtNum: uint64(chtnum), BlockNum: uint64(blocknum)}
-    LightEth.LesOdr().Retrieve(ctx, req)
-    log.Info("Retrieved latest CHT root from peer, got", "ChtRoot",common.ToHex(req.ChtRoot.Bytes()))
+	req := &light.ChtRequest{ChtNum: uint64(chtnum), BlockNum: uint64(blocknum)}
+	LightEth.LesOdr().Retrieve(ctx, req)
+	log.Info("Retrieved latest CHT root from peer, got", "ChtRoot", common.ToHex(req.ChtRoot.Bytes()))
 
 	LightEth.WriteTrustedCht(light.TrustedCht{
-		Number: chtnum, 
-		Root: req.ChtRoot, 
+		Number: chtnum,
+		Root:   req.ChtRoot,
 	})
 	log.Info("Added trusted CHT",
-		"develop", NodeConfig.DevMode, 
-        "number", chtnum, "hash", common.ToHex(req.ChtRoot.Bytes()))
+		"develop", NodeConfig.DevMode,
+		"number", chtnum, "hash", common.ToHex(req.ChtRoot.Bytes()))
 
-    log.Info("Sanity check: can download some very old header?")
-    var sanityBlock uint64 = blocknum/100
-	sanityHeader,err := light.GetHeaderByNumber(ctx, LightEth.LesOdr(), sanityBlock)
-    log.Info("Sanity check result:", "sanityHeader.Number", sanityHeader.Number, "err", err)
+	log.Info("Sanity check: can download some very old header?")
+	var sanityBlock uint64 = blocknum / 100
+	sanityHeader, err := light.GetHeaderByNumber(ctx, LightEth.LesOdr(), sanityBlock)
+	log.Info("Sanity check result:", "sanityHeader.Number", sanityHeader.Number, "err", err)
 }
-

--- a/vendor/github.com/ethereum/go-ethereum/les/sync.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/sync.go
@@ -100,8 +100,7 @@ func updateChtFromPeer(pm *ProtocolManager, peer *peer, ctx context.Context) {
     var peerHeadBlockNum = hbl.Number
     log.Debug("UpdateChtFromPeer","peerHeadBlockNum", peerHeadBlockNum)
 
-    var chtnum uint64 = (peerHeadBlockNum + 1) / light.ChtFrequency
-    chtnum -= 1
+    var chtnum uint64 = ((peerHeadBlockNum + 1) / light.ChtFrequency) -1
     var blocknum uint64 = chtnum*light.ChtFrequency -1
     log.Debug("CHT block values: ", "chtnum",chtnum,"blocknum",blocknum)
 
@@ -117,7 +116,7 @@ func updateChtFromPeer(pm *ProtocolManager, peer *peer, ctx context.Context) {
 		"develop", NodeConfig.DevMode, 
         "number", chtnum, "hash", common.ToHex(req.ChtRoot.Bytes()))
 
-    log.Info("Sanity check: can download some very old block?")
+    log.Info("Sanity check: can download some very old header?")
     var sanityBlock uint64 = blocknum/100
 	sanityHeader,err := light.GetHeaderByNumber(ctx, LightEth.LesOdr(), sanityBlock)
     log.Info("Sanity check result:", "sanityHeader.Number", sanityHeader.Number, "err", err)

--- a/vendor/github.com/ethereum/go-ethereum/trie/proof.go
+++ b/vendor/github.com/ethereum/go-ethereum/trie/proof.go
@@ -155,6 +155,5 @@ func ExtractChtRoot(key []byte, proof []rlp.RawValue) []byte {
 	buf := proof[0]
 	sha.Reset()
 	sha.Write(buf)
-    return sha.Sum(nil)
+	return sha.Sum(nil)
 }
-

--- a/vendor/github.com/ethereum/go-ethereum/trie/proof.go
+++ b/vendor/github.com/ethereum/go-ethereum/trie/proof.go
@@ -147,3 +147,14 @@ func get(tn node, key []byte) ([]byte, node) {
 		}
 	}
 }
+
+// Status.im issue 320: Same code as first part of VerifyProof
+func ExtractChtRoot(key []byte, proof []rlp.RawValue) []byte {
+	key = keybytesToHex(key)
+	sha := sha3.NewKeccak256()
+	buf := proof[0]
+	sha.Reset()
+	sha.Write(buf)
+    return sha.Sum(nil)
+}
+


### PR DESCRIPTION
Fixes #320 : "Devise how to update CHT automatically"

**Superseded by https://github.com/ethereum/go-ethereum/pull/15673**

Retrieve the most recent CHT root from a peer by sending a single GetHeaderProofs message at startup.
A change has been made to ChtRequest.Validate so that in this case where no ChtRoot is supplied in the ChtRequest, it's pulled out of the proof.
Tested and appears to work fine. As a sanity check, after the CHT root has been set, an old header is retrieved and verified.

Sample output:
> INFO [11-24|23:58:47] Account reselected                       geth=StatusIM
INFO [11-24|23:58:47] Notification received                    geth=StatusIM event="{\"type\":\"node.ready\",\"event\":{}}"
INFO [11-25|00:00:15] Downloading latest CHT root from peer    geth=StatusIM peer.headBlockInfo="{Hash:[57 74 249 81 125 100 65 239 95 224 122 175 139 200 91 160 15 58 67 41 189 239 204 28 247 182 91 222 9 25 177 16] Number:2135303 Td:+6841184590931614}"
INFO [11-25|00:00:15] Retrieved latest CHT root from peer, got geth=StatusIM ChtRoot=0x8bdfeae99b0b4747ce04f2251aa37b957d41d237781f8889be7c521ab651602a
INFO [11-25|00:00:15] Added trusted CHT                        geth=StatusIM develop=true number=520 hash=0x8bdfeae99b0b4747ce04f2251aa37b957d41d237781f8889be7c521ab651602a
INFO [11-25|00:00:15] Sanity check: can download some very old header? geth=StatusIM
INFO [11-25|00:00:15] Sanity check result:                     geth=StatusIM sanityHeader.Number=21299 err=nil
INFO [11-25|00:00:15] Block synchronisation started 
INFO [11-25|00:00:18] Imported new block headers               count=576 elapsed=1.887s number=2130495 hash=180198…0ec15e                                                      ignored=0
INFO [11-25|00:00:18] Imported new block headers               count=576 elapsed=90.973ms number=2131071 hash=c19d90…82d5ff                                                      ignored=0
