### PR TITLE
Add support for adding to the environment from status-react

### DIFF
--- a/geth/api/api.go
+++ b/geth/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"os"
 
 	"github.com/NaySoftware/go-fcm"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -233,4 +234,16 @@ func (api *StatusAPI) NotifyUsers(message string, payload fcm.NotificationPayloa
 	}
 
 	return err
+}
+
+// AddEnv loads key-value pairs into ENV, such as flags.
+func (api *StatusAPI) AddEnv(key string, value string) string {
+	log.Debug("AddEnv", key, value)
+
+	err := os.Setenv(key, value)
+	if err != nil {
+		log.Error("AddEnv error:", err)
+	}
+
+	return key
 }

--- a/lib/library.go
+++ b/lib/library.go
@@ -442,3 +442,9 @@ func NotifyUsers(message, payloadJSON, tokensArray *C.char) (outCBytes *C.char) 
 
 	return
 }
+
+//export AddEnv
+func AddEnv(key *C.char, value *C.char) *C.char {
+	res := statusAPI.AddEnv(C.GoString(key), C.GoString(value))
+	return C.CString(res)
+}


### PR DESCRIPTION
Add support for adding to the environment from status-react.

Adds AddEnv public API call that enables status-react (and by extensions, Jenkins CI for QA) to set env variable values in status-go.

This is useful for feature flags, where we just want to instrument a very specific part of the code without error-prone changes to the config.

For status-go developers, these ENV variables work the same as normal ENV lookups when running in more forgiving environment than bundled as an ObjC package for a React Native app. The interface is thus string based, just like env variables set in shell.

Important changes:
- [x] AddEnv(key, value) API call.

Solves the problem of enabling:
- https://github.com/status-im/status-react/issues/2544
- https://github.com/status-im/status-react/issues/2504
- https://github.com/status-im/status-react/issues/2511
- https://github.com/status-im/status-go/pull/464
- https://github.com/status-im/status-go/issues/432

status: ready