### PR TITLE
Fix env reading for write delay

### DIFF
--- a/geth/api/api.go
+++ b/geth/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"os"
 
 	"github.com/NaySoftware/go-fcm"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -233,4 +234,16 @@ func (api *StatusAPI) NotifyUsers(message string, payload fcm.NotificationPayloa
 	}
 
 	return err
+}
+
+// AddEnv loads key-value pairs into ENV, such as flags.
+func (api *StatusAPI) AddEnv(key string, value string) string {
+	log.Debug("AddEnv", key, value)
+
+	err := os.Setenv(key, value)
+	if err != nil {
+		log.Error("AddEnv error:", err)
+	}
+
+	return key
 }

--- a/lib/library.go
+++ b/lib/library.go
@@ -442,3 +442,9 @@ func NotifyUsers(message, payloadJSON, tokensArray *C.char) (outCBytes *C.char) 
 
 	return
 }
+
+//export AddEnv
+func AddEnv(key *C.char, value *C.char) *C.char {
+	res := statusAPI.AddEnv(C.GoString(key), C.GoString(value))
+	return C.CString(res)
+}

--- a/vendor/github.com/ethereum/go-ethereum/core/headerchain.go
+++ b/vendor/github.com/ethereum/go-ethereum/core/headerchain.go
@@ -44,9 +44,15 @@ const (
 
 var writeDelay time.Duration = 0
 
-func init() {
+// NOTE(oskarth): Previously this was an n init function that was called before
+// RN was even started, which meant there was nothing in the environment yet.
+func setWriteDelay() {
 	str, ok := os.LookupEnv("FEATURE_SYNC_DELAY")
+	// XXX(oskarth): INFO not showing up in logs, easily greppable
+	fmt.Println("[FLAG] Set FEATURE_SYNC_DELAY", str)
+	log.Info("[FLAG] Set FEATURE_SYNC_DELAY info", str)
 	if !ok {
+		fmt.Println("[FLAG] Set FEATURE_SYNC_DELAY !ok", ok)
 		return
 	}
 	delay, err := strconv.ParseInt(str, 10, 0)
@@ -278,6 +284,10 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 // of the header retrieval mechanisms already need to verfy nonces, as well as
 // because nonces can be verified sparsely, not needing to check each.
 func (hc *HeaderChain) InsertHeaderChain(chain []*types.Header, writeHeader WhCallback, start time.Time) (int, error) {
+
+	// TODO(oskarth): Init this earlier in chain but after StartNode
+	setWriteDelay()
+
 	// Collect some import statistics to report on
 	stats := struct{ processed, ignored int }{}
 	// All headers passed verification, import them into the database


### PR DESCRIPTION
In https://github.com/status-im/status-go/pull/464 we introduced FEATURE_SYNC_DELAY to tune WriteDelay in InsertHeaderChain. However, this was called in `Init` before React Native was initialized, which means env variable never got a chance to show up.

This PR "fixes" it by looking up env each header insert. Note that this PR is _not_ the proper way to solve it, as it breaks the contract of introducing work even when flag is off. It illustrates the problem though.

Cherry-picked support for env variables in general as this is necessary. Separate PR: https://github.com/status-im/status-go/pull/483

status: wip