### PR TITLE
[FIX #450] Remove creating global catalog variable from status-go.

### DIFF
--- a/e2e/jail/jail_rpc_test.go
+++ b/e2e/jail/jail_rpc_test.go
@@ -272,6 +272,8 @@ func (s *JailRPCTestSuite) TestJailVMPersistence() {
 			 }
 		  });
 		}
+
+		_status_catalog;
 	`)
 	s.NotContains(parseResult, "error", "further will fail if initial parsing failed")
 

--- a/e2e/jail/jail_test.go
+++ b/e2e/jail/jail_test.go
@@ -56,9 +56,9 @@ func (s *JailTestSuite) TestInitWithoutBaseJS() {
 	s.EqualError(err, "cell '"+testChatID+"' not found")
 	s.Nil(cell)
 
-	// create VM (w/o properly initializing base JS script)
-	err = errors.New("ReferenceError: '_status_catalog' is not defined")
-	s.Equal(errorWrapper(err), s.Jail.CreateAndInitCell(testChatID, ``))
+	response := s.Jail.CreateAndInitCell(testChatID)
+	s.Equal(jail.EmptyResponse, response)
+
 	err = errors.New("ReferenceError: 'call' is not defined")
 	s.Equal(errorWrapper(err), s.Jail.Call(testChatID, `["commands", "testCommand"]`, `{"val": 12}`))
 
@@ -77,40 +77,34 @@ func (s *JailTestSuite) TestInitWithBaseJS() {
 
 	// now no error should occur
 	response := s.Jail.CreateAndInitCell(testChatID)
-	expectedResponse := `{"result": {"commands":{},"responses":{}}}`
-	s.Equal(expectedResponse, response)
+	s.Equal(jail.EmptyResponse, response)
 
 	// make sure that Call succeeds even w/o running node
 	response = s.Jail.Call(testChatID, `["commands", "testCommand"]`, `{"val": 12}`)
-	expectedResponse = `{"result": 144}`
+	expectedResponse := `{"result": 144}`
 	s.Equal(expectedResponse, response)
 }
 
-// @TODO(adam): finally, this test should pass as checking existence of `_status_catalog`
-// should be done in status-react.
-func (s *JailTestSuite) TestCreateAndInitCellWithoutStatusCatalog() {
-	response := s.Jail.CreateAndInitCell(testChatID)
-	s.Equal(`{"error":"ReferenceError: '_status_catalog' is not defined"}`, response)
-}
+func (s *JailTestSuite) TestCreateAndInitCell() {
+	// If no custom JS provided -- the default response is returned
+	response := s.Jail.CreateAndInitCell("newChat1")
+	expectedResponse := jail.EmptyResponse
+	s.Equal(expectedResponse, response)
 
-// @TODO(adam): remove extra JS when checking `_status_catalog` is move to status-react.
-func (s *JailTestSuite) TestMultipleInitError() {
-	response := s.Jail.CreateAndInitCell(testChatID, `var _status_catalog = {}`)
-	s.Equal(`{"result": {}}`, response)
+	// If any custom JS provided -- the result of the last op is returned
+	response = s.Jail.CreateAndInitCell("newChat2", "var a = 2", "a")
+	expectedResponse = `{"result": 2}`
+	s.Equal(expectedResponse, response)
 
-	// Shouldn't cause an error and reinitialize existing
-	response = s.Jail.CreateAndInitCell(testChatID)
-	s.Equal(`{"result": {}}`, response)
-}
+	// Reinitialization preserves the JS environment, so the 'test' variable exists
+	// even though we didn't initialize it here (in the second room).
+	response = s.Jail.CreateAndInitCell("newChat2", "a")
+	expectedResponse = `{"result": 2}`
+	s.Equal(expectedResponse, response)
 
-// @TODO(adam): remove extra JS when checking `_status_catalog` is moved to status-react.
-func (s *JailTestSuite) TestCreateAndInitCellResponse() {
-	extraCode := `
-	var _status_catalog = {
-		foo: 'bar'
-	};`
-	response := s.Jail.CreateAndInitCell("newChat", extraCode)
-	expectedResponse := `{"result": {"foo":"bar"}}`
+	// But this variable doesn't leak into other rooms.
+	response = s.Jail.CreateAndInitCell("newChat1", "a")
+	expectedResponse = `{"error":"ReferenceError: 'a' is not defined"}`
 	s.Equal(expectedResponse, response)
 }
 

--- a/geth/jail/handlers_test.go
+++ b/geth/jail/handlers_test.go
@@ -52,7 +52,7 @@ func (s *HandlersTestSuite) TestWeb3SendHandlerSuccess() {
 
 	jail := New(&testRPCClientProvider{client})
 
-	cell, err := jail.createAndInitCell("cell1")
+	cell, _, err := jail.createAndInitCell("cell1")
 	s.NoError(err)
 
 	// web3.eth.syncing is an arbitrary web3 sync RPC call.
@@ -66,7 +66,7 @@ func (s *HandlersTestSuite) TestWeb3SendHandlerSuccess() {
 func (s *HandlersTestSuite) TestWeb3SendHandlerFailure() {
 	jail := New(nil)
 
-	cell, err := jail.createAndInitCell("cell1")
+	cell, _, err := jail.createAndInitCell("cell1")
 	s.NoError(err)
 
 	_, err = cell.Run("web3.eth.syncing")
@@ -79,7 +79,7 @@ func (s *HandlersTestSuite) TestWeb3SendAsyncHandlerSuccess() {
 
 	jail := New(&testRPCClientProvider{client})
 
-	cell, err := jail.createAndInitCell("cell1")
+	cell, _, err := jail.createAndInitCell("cell1")
 	s.NoError(err)
 
 	errc := make(chan string)
@@ -104,7 +104,7 @@ func (s *HandlersTestSuite) TestWeb3SendAsyncHandlerWithoutCallbackSuccess() {
 
 	jail := New(&testRPCClientProvider{client})
 
-	cell, err := jail.createAndInitCell("cell1")
+	cell, _, err := jail.createAndInitCell("cell1")
 	s.NoError(err)
 
 	_, err = cell.Run(`web3.eth.getSyncing()`)
@@ -119,7 +119,7 @@ func (s *HandlersTestSuite) TestWeb3SendAsyncHandlerWithoutCallbackSuccess() {
 func (s *HandlersTestSuite) TestWeb3SendAsyncHandlerFailure() {
 	jail := New(nil)
 
-	cell, err := jail.createAndInitCell("cell1")
+	cell, _, err := jail.createAndInitCell("cell1")
 	s.NoError(err)
 
 	errc := make(chan otto.Value)
@@ -148,7 +148,7 @@ func (s *HandlersTestSuite) TestWeb3IsConnectedHandler() {
 
 	jail := New(&testRPCClientProvider{client})
 
-	cell, err := jail.createAndInitCell("cell1")
+	cell, _, err := jail.createAndInitCell("cell1")
 	s.NoError(err)
 
 	// When result is true.
@@ -170,7 +170,7 @@ func (s *HandlersTestSuite) TestWeb3IsConnectedHandler() {
 func (s *HandlersTestSuite) TestSendSignalHandler() {
 	jail := New(nil)
 
-	cell, err := jail.createAndInitCell("cell1")
+	cell, _, err := jail.createAndInitCell("cell1")
 	s.NoError(err)
 
 	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {


### PR DESCRIPTION
I tried to make on both sides: status-react and status-go.
This change is trivial (thanks to @divan for pre-refactoring).

I'll keep this one as `WIP` until [status-react#2587](https://github.com/status-im/status-react/pull/2587) is merged.

Closes #450 