### PR TITLE
send message with build version in slack (parametrized build)

### DIFF
--- a/Jenkinsfile-manual
+++ b/Jenkinsfile-manual
@@ -100,6 +100,8 @@ node('linux') {
             buildInfo.name = 'status-go (' + gitBranch + '-' + gitShortSHA + ')'
             server.upload(uploadSpec, buildInfo)
             server.publishBuildInfo(buildInfo)
+
+            slackSend color: 'good', message: 'status-go `' + version + '` was built successfully. ' + env.BUILD_URL
         }
     }
 }


### PR DESCRIPTION
Send message with build version in slack (parametrized build).

Currently we don't use script from VCS but still better to add this line to repo so that it will survive if any problems with Jenkins server appear. 
