### PR TITLE
whisper standalone mode

### DIFF
--- a/cmd/wnode-status/config.go
+++ b/cmd/wnode-status/config.go
@@ -23,6 +23,7 @@ var (
 	// Whisper
 	identity     = flag.String("identity", "", "Protocol identity file (private key used for asymmetric encryption)")
 	passwordFile = flag.String("passwordfile", "", "Password file (password is used for symmetric encryption)")
+	standalone   = flag.Bool("standalone", true, "Don't actively connect to peers, wait for incoming connections")
 	minPow       = flag.Float64("pow", params.WhisperMinimumPoW, "PoW for messages to be added to queue, in float format")
 	ttl          = flag.Int("ttl", params.WhisperTTL, "Time to live for messages, in seconds")
 
@@ -63,6 +64,7 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	whisperConfig.Enabled = true
 	whisperConfig.IdentityFile = *identity
 	whisperConfig.PasswordFile = *passwordFile
+	whisperConfig.Standalone = *standalone
 	whisperConfig.EnablePushNotification = *enablePN
 	whisperConfig.EnableMailServer = *enableMailServer
 	whisperConfig.MinimumPoW = *minPow
@@ -105,6 +107,11 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	nodeConfig.HTTPPort = *httpPort
 	nodeConfig.IPCEnabled = *ipcEnabled
 	nodeConfig.RPCEnabled = *httpEnabled
+
+	if whisperConfig.Standalone {
+		nodeConfig.BootClusterConfig.Enabled = false
+		nodeConfig.BootClusterConfig.BootNodes = nil
+	}
 
 	return nodeConfig, nil
 }

--- a/cmd/wnode-status/config.go
+++ b/cmd/wnode-status/config.go
@@ -64,7 +64,6 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	whisperConfig.Enabled = true
 	whisperConfig.IdentityFile = *identity
 	whisperConfig.PasswordFile = *passwordFile
-	whisperConfig.Standalone = *standalone
 	whisperConfig.EnablePushNotification = *enablePN
 	whisperConfig.EnableMailServer = *enableMailServer
 	whisperConfig.MinimumPoW = *minPow
@@ -108,7 +107,7 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	nodeConfig.IPCEnabled = *ipcEnabled
 	nodeConfig.RPCEnabled = *httpEnabled
 
-	if whisperConfig.Standalone {
+	if *standalone {
 		nodeConfig.BootClusterConfig.Enabled = false
 		nodeConfig.BootClusterConfig.BootNodes = nil
 	}

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -119,6 +119,11 @@ func defaultEmbeddedNodeConfig(config *params.NodeConfig) *node.Config {
 		nc.HTTPPort = config.HTTPPort
 	}
 
+	if config.WhisperConfig.Standalone {
+		nc.P2P.BootstrapNodes = nil
+		nc.P2P.BootstrapNodesV5 = nil
+	}
+
 	return nc
 }
 

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -119,7 +119,7 @@ func defaultEmbeddedNodeConfig(config *params.NodeConfig) *node.Config {
 		nc.HTTPPort = config.HTTPPort
 	}
 
-	if config.WhisperConfig.Standalone {
+	if !config.BootClusterConfig.Enabled {
 		nc.P2P.BootstrapNodes = nil
 		nc.P2P.BootstrapNodesV5 = nil
 	}

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -102,9 +102,6 @@ type WhisperConfig struct {
 	// EnablePushNotification is mode when node is capable of sending Push (and probably other kinds) Notifications
 	EnablePushNotification bool
 
-	// Standalone whether node doesn't actively connect to peers, and waits for incoming connections
-	Standalone bool
-
 	// DataDir is the file system folder Whisper should use for any data storage needs.
 	// For instance, MailServer will use this directory to store its data.
 	DataDir string

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -102,6 +102,9 @@ type WhisperConfig struct {
 	// EnablePushNotification is mode when node is capable of sending Push (and probably other kinds) Notifications
 	EnablePushNotification bool
 
+	// Standalone whether node doesn't actively connect to peers, and waits for incoming connections
+	Standalone bool
+
 	// DataDir is the file system folder Whisper should use for any data storage needs.
 	// For instance, MailServer will use this directory to store its data.
 	DataDir string


### PR DESCRIPTION
A new flag for a whisper mail server: `-standalone` to run wnode as standalone connected only with incoming connections and without adding peers at the start or discovery.

Closes #486 