### PR TITLE
CreateAndInitCell should allow reinitializing a cell #497

### DIFF
--- a/e2e/jail/jail_test.go
+++ b/e2e/jail/jail_test.go
@@ -98,8 +98,9 @@ func (s *JailTestSuite) TestMultipleInitError() {
 	response := s.Jail.CreateAndInitCell(testChatID, `var _status_catalog = {}`)
 	s.Equal(`{"result": {}}`, response)
 
+	// Shouldn't cause an error and reinitialize existing
 	response = s.Jail.CreateAndInitCell(testChatID)
-	s.Equal(`{"error":"cell with id 'testChat' already exists"}`, response)
+	s.Equal(`{"result": {}}`, response)
 }
 
 // @TODO(adam): remove extra JS when checking `_status_catalog` is moved to status-react.

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -141,11 +141,13 @@ func (s *JailTestSuite) TestPublicCreateAndInitCell() {
 
 func (s *JailTestSuite) TestPublicCreateAndInitCellConsecutive() {
 	response1 := s.Jail.CreateAndInitCell("cell1", `var _status_catalog = { test: true }`)
+	s.Contains(response1, "test")
 	cell1, err := s.Jail.Cell("cell1")
 	s.NoError(err)
 
 	// Create it again
 	response2 := s.Jail.CreateAndInitCell("cell1", `var _status_catalog = { test: true, foo: 5 }`)
+	s.Contains(response2, "test", "foo")
 	cell2, err := s.Jail.Cell("cell1")
 	s.NoError(err)
 

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -139,6 +139,23 @@ func (s *JailTestSuite) TestPublicCreateAndInitCell() {
 	s.Equal(`{"result": {"test":true}}`, response)
 }
 
+func (s *JailTestSuite) TestPublicCreateAndInitCellConsecutive() {
+	response1 := s.Jail.CreateAndInitCell("cell1", `var _status_catalog = { test: true }`)
+	cell1, err := s.Jail.Cell("cell1")
+	s.NoError(err)
+
+	// Create it again
+	response2 := s.Jail.CreateAndInitCell("cell1", `var _status_catalog = { test: true, foo: 5 }`)
+	cell2, err := s.Jail.Cell("cell1")
+	s.NoError(err)
+
+	// Second cell has to be the same object as the first one
+	s.Equal(cell1, cell2)
+
+	// Second cell must have been reinitialized
+	s.NotEqual(response1, response2)
+}
+
 func (s *JailTestSuite) TestExecute() {
 	// cell does not exist
 	response := s.Jail.Execute("cell1", "('some string')")

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -60,7 +60,7 @@ func (s *JailTestSuite) TestJailGetCell() {
 
 func (s *JailTestSuite) TestJailInitCell() {
 	// InitCell on an existing cell.
-	cell, err := s.Jail.createCell("cell1")
+	cell, err := s.Jail.obtainCell("cell1", false)
 	s.NoError(err)
 	err = s.Jail.initCell(cell)
 	s.NoError(err)
@@ -102,7 +102,7 @@ func (s *JailTestSuite) TestJailCall() {
 }
 
 func (s *JailTestSuite) TestMakeCatalogVariable() {
-	cell, err := s.Jail.createCell("cell1")
+	cell, err := s.Jail.obtainCell("cell1", false)
 	s.NoError(err)
 
 	// no `_status_catalog` variable
@@ -144,7 +144,7 @@ func (s *JailTestSuite) TestExecute() {
 	response := s.Jail.Execute("cell1", "('some string')")
 	s.Equal(`{"error":"cell 'cell1' not found"}`, response)
 
-	_, err := s.Jail.createCell("cell1")
+	_, err := s.Jail.obtainCell("cell1", false)
 	s.NoError(err)
 
 	// cell exists

--- a/lib/library.go
+++ b/lib/library.go
@@ -327,7 +327,7 @@ func InitJail(js *C.char) {
 //DEPRECATED in favour of CreateAndInitCell.
 //export Parse
 func Parse(chatID *C.char, js *C.char) *C.char {
-	res := statusAPI.JailParse(C.GoString(chatID), C.GoString(js))
+	res := statusAPI.CreateAndInitCell(C.GoString(chatID), C.GoString(js))
 	return C.CString(res)
 }
 


### PR DESCRIPTION
Changes `Jail.createCell` to `Jail.obtainCell`, which alters the error-throwing behaviour for better `Jail.CreateAndInitCell`

This PR allows cells to be reinitialized without being recreated.

Important changes:
- [x] Calling with same cell ID won't cause any errors.
- [x] Consecutive calls with same cell ID only reinitialize existing cell.
- [x] `Parse` in `library.go` uses `StatusAPI.CreateAndInitCell`.

Closes #497 
