### PR TITLE
Allow version string to omit meta section

### DIFF
--- a/geth/params/version.go
+++ b/geth/params/version.go
@@ -19,4 +19,17 @@ const (
 )
 
 // Version exposes string representation of program version.
-var Version = fmt.Sprintf("%d.%d.%d-%s", VersionMajor, VersionMinor, VersionPatch, VersionMeta)
+var Version = buildVersionString(VersionMajor, VersionMinor, VersionPatch, VersionMeta)
+
+// buildVersionString builds string representation of program version.
+func buildVersionString(major, minor, patch int, meta string) string {
+	var version string
+
+	if len(meta) > 0 {
+		version = fmt.Sprintf("%d.%d.%d-%s", major, minor, patch, meta)
+	} else {
+		version = fmt.Sprintf("%d.%d.%d", major, minor, patch)
+	}
+
+	return version
+}

--- a/geth/params/version_test.go
+++ b/geth/params/version_test.go
@@ -1,0 +1,18 @@
+package params
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestVersionWithMeta(t *testing.T) {
+	var version = buildVersionString(1, 1, 0, "alpha.1")
+	var expectedVersion = "1.1.0-alpha.1"
+	require.Equal(t, expectedVersion, version)
+}
+
+func TestVersionWithoutMeta(t *testing.T) {
+	var version = buildVersionString(0, 40, 100, "")
+	var expectedVersion = "0.40.100"
+	require.Equal(t, expectedVersion, version)
+}


### PR DESCRIPTION
status-go versions are composed by a major.minor.patch-meta format. #422
proposes that production releases should be versioned as
major.minor.patch, without the meta portion in the string. This commit
allows the use of the proposed release format when the VersionMeta
string is empty.

References #422