### PR TITLE
README.md: Add instructions to install gometalinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use following Makefile commands:
 # Testing
 To setup accounts passphrase you need to setup an environment variable: `export ACCOUNT_PASSWORD="secret_pass_phrase"`.
 
-To test statusgo, use: `make ci`. Make sure the `gometalinter` package is installed: `go get -u github.com/alecthomas/gometalinter && go install github.com/alecthomas/gometalinter && export PATH=$PATH:$GOPATH/bin`
+To test statusgo, use: `make ci`. Make sure the `gometalinter` package is installed first by running `make lint-install`
 To test statusgo using a giving network by name, use: `make ci networkid=rinkeby`.
 To test statusgo using a giving network by id number, use: `make ci networkid=3`.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use following Makefile commands:
 # Testing
 To setup accounts passphrase you need to setup an environment variable: `export ACCOUNT_PASSWORD="secret_pass_phrase"`.
 
-To test statusgo, use: `make ci`.
+To test statusgo, use: `make ci`. Make sure the `gometalinter` package is installed: `go get -u github.com/alecthomas/gometalinter && go install github.com/alecthomas/gometalinter && export PATH=$PATH:$GOPATH/bin`
 To test statusgo using a giving network by name, use: `make ci networkid=rinkeby`.
 To test statusgo using a giving network by id number, use: `make ci networkid=3`.
 


### PR DESCRIPTION
README.md: Add instructions to install gometalinter

Starting from a clean Linux system, `make ci` doesn't work without further setup:
```
~/go/src/github.com/status-im/status-go$ make ci
lint-vet
make: gometalinter: Command not found
static/tools/mk/lint.mk:12: recipe for target 'lint-vet' failed
make: *** [lint-vet] Error 127
```

The README.md file should include installation instructions for the `gometalinter` package. Not sure if the PR commit is the best way to go about it, but it seems to do the trick.