### PR TITLE
Add unit tests for CreateAccount and RecoverAccount methods #510

### DIFF
--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -133,10 +133,17 @@ func newTestKeyStore(t *testing.T, dir string) (keyStore *keystore.KeyStore, key
 func TestCreateAndRecoverAccountSuccess(t *testing.T) {
 	accManager, nodeManager := newTestAccManager(t)
 
-	password := "some-pass"
+	var password string
 
 	keyStore, keyStoreDir := newTestKeyStore(t, "accounts")
 	defer os.RemoveAll(keyStoreDir) //nolint: errcheck
+
+	// Don't fail on empty password
+	nodeManager.EXPECT().AccountKeyStore().Return(keyStore, nil)
+	_, _, _, err := accManager.CreateAccount(password)
+	require.NoError(t, err)
+
+	password = "some-pass"
 
 	nodeManager.EXPECT().AccountKeyStore().Return(keyStore, nil)
 	addr1, pubKey1, mnemonic, err := accManager.CreateAccount(password)

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -134,9 +134,9 @@ func TestManagerTestSuite(t *testing.T) {
 	nodeManager.EXPECT().AccountKeyStore().Return(keyStore, nil)
 	addr, pubKey, mnemonic, err := accManager.CreateAccount(testPassword)
 	require.NoError(t, err)
-	require.NotNil(t, addr)
-	require.NotNil(t, pubKey)
-	require.NotNil(t, mnemonic)
+	require.NotEmpty(t, addr)
+	require.NotEmpty(t, pubKey)
+	require.NotEmpty(t, mnemonic)
 
 	s := &ManagerTestSuite{
 		testAccount: testAccount{
@@ -342,8 +342,8 @@ func (s *ManagerTestSuite) TestCreateChildAccount() {
 				s.Error(err)
 			} else {
 				s.NoError(err)
-				s.NotNil(childAddr)
-				s.NotNil(childPubKey)
+				s.NotEmpty(childAddr)
+				s.NotEmpty(childPubKey)
 			}
 		})
 	}

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -396,7 +396,7 @@ func (s *ManagerTestSuite) TestLogout() {
 	s.Equal(testErrWhisper, err)
 }
 
-// TestAccounts tests cases for (*Manager).Accounts
+// TestAccounts tests cases for (*Manager).Accounts.
 func (s *ManagerTestSuite) TestAccounts() {
 	// Select the test account
 	s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil).AnyTimes()

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -474,13 +474,15 @@ func (s *ManagerTestSuite) TestAddressToDecryptedAccount() {
 		s.T().Run(testCase.name, func(t *testing.T) {
 			s.reinitMock()
 			s.nodeManager.EXPECT().AccountKeyStore().Return(testCase.accountKeyStoreReturn...).AnyTimes()
-			acc, keyStore, err := s.accManager.AddressToDecryptedAccount(testCase.address, testCase.password)
+			acc, key, err := s.accManager.AddressToDecryptedAccount(testCase.address, testCase.password)
 			if testCase.fail {
 				s.Error(err)
 			} else {
 				s.NoError(err)
 				s.NotNil(acc)
-				s.NotNil(keyStore)
+				s.NotNil(key)
+				s.Equal(acc.Address, key.Address)
+				s.keyStore.Find(acc)
 			}
 		})
 	}

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -485,7 +485,6 @@ func (s *ManagerTestSuite) TestAddressToDecryptedAccount() {
 				s.NotNil(acc)
 				s.NotNil(key)
 				s.Equal(acc.Address, key.Address)
-				s.keyStore.Find(acc)
 			}
 		})
 	}

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -367,7 +367,7 @@ func (s *ManagerTestSuite) TestSelectedAndReSelectAccount() {
 		s.NoError(err)
 	})
 
-	s.T().Run("ReSelect_fail", func(t *testing.T) {
+	s.T().Run("ReSelect_fail_whisper", func(t *testing.T) {
 		s.reinitMock()
 		s.nodeManager.EXPECT().WhisperService().Return(nil, testErrWhisper).AnyTimes()
 		err = s.accManager.ReSelectAccount()
@@ -377,9 +377,9 @@ func (s *ManagerTestSuite) TestSelectedAndReSelectAccount() {
 	s.accManager.selectedAccount = nil
 	s.reinitMock()
 	s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil).AnyTimes()
-	s.nodeManager.EXPECT().WhisperService().Return(nil, testErrWhisper).AnyTimes()
+	s.nodeManager.EXPECT().WhisperService().Return(s.shh, nil).AnyTimes()
 
-	s.T().Run("Selected_fail", func(t *testing.T) {
+	s.T().Run("Selected_fail_noAccount", func(t *testing.T) {
 		_, err := s.accManager.SelectedAccount()
 		s.Equal(ErrNoAccountSelected, err)
 	})

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -402,6 +402,7 @@ func (s *ManagerTestSuite) TestLogout() {
 	s.Equal(testErrWhisper, err)
 }
 
+// TestAccounts tests cases for (*Manager).Accounts
 func (s *ManagerTestSuite) TestAccounts() {
 	s.reinitMock()
 

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -170,8 +170,6 @@ func TestCreateAndRecoverAccountFail_KeyStore(t *testing.T) {
 	keyStore, keyStoreDir := newTestKeyStore(t, "accounts")
 	defer os.RemoveAll(keyStoreDir) //nolint: errcheck
 
-	// Fail if account keystore can't be acquired
-
 	expectedErr := errors.New("Non-nil error string")
 	nodeManager.EXPECT().AccountKeyStore().Return(nil, expectedErr)
 	_, _, _, err := accManager.CreateAccount(password)

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -180,15 +180,19 @@ type testAccount struct {
 
 // reinitMock is for reassigning a new mock node manager to account manager.
 // Stating the amount of times for mock calls kills the flexibility for
-// development so this is a good workaround to use with EXPECT().AnyTimes()
+// development so this is a good workaround to use with EXPECT().Func().AnyTimes()
 func (s *ManagerTestSuite) reinitMock() {
 	s.nodeManager = newMockNodeManager(s.T())
 	s.accManager.nodeManager = s.nodeManager
 }
 
-func (s *ManagerTestSuite) TestCreateAccount() {
+// SetupTest is used here for reinitializing the mock before every
+// test function to avoid faulty execution.
+func (s *ManagerTestSuite) SetupTest() {
 	s.reinitMock()
+}
 
+func (s *ManagerTestSuite) TestCreateAccount() {
 	// Don't fail on empty password
 	s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil)
 	_, _, _, err := s.accManager.CreateAccount(s.password)
@@ -200,8 +204,6 @@ func (s *ManagerTestSuite) TestCreateAccount() {
 }
 
 func (s *ManagerTestSuite) TestRecoverAccount() {
-	s.reinitMock()
-
 	s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil)
 	addr, pubKey, err := s.accManager.RecoverAccount(s.password, s.mnemonic)
 	s.NoError(err)
@@ -214,8 +216,6 @@ func (s *ManagerTestSuite) TestRecoverAccount() {
 }
 
 func (s *ManagerTestSuite) TestSelectAccount() {
-	s.reinitMock()
-
 	testCases := []struct {
 		name                  string
 		accountKeyStoreReturn []interface{}
@@ -278,8 +278,6 @@ func (s *ManagerTestSuite) TestSelectAccount() {
 }
 
 func (s *ManagerTestSuite) TestCreateChildAccount() {
-	s.reinitMock()
-
 	// First, test the negative case where an account is not selected
 	// and an address is not provided.
 	s.accManager.selectedAccount = nil
@@ -350,8 +348,6 @@ func (s *ManagerTestSuite) TestCreateChildAccount() {
 }
 
 func (s *ManagerTestSuite) TestSelectedAndReSelectAccount() {
-	s.reinitMock()
-
 	// Select the test account
 	s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil).AnyTimes()
 	s.nodeManager.EXPECT().WhisperService().Return(s.shh, nil).AnyTimes()
@@ -391,8 +387,6 @@ func (s *ManagerTestSuite) TestSelectedAndReSelectAccount() {
 }
 
 func (s *ManagerTestSuite) TestLogout() {
-	s.reinitMock()
-
 	s.nodeManager.EXPECT().WhisperService().Return(s.shh, nil)
 	err := s.accManager.Logout()
 	s.NoError(err)
@@ -404,8 +398,6 @@ func (s *ManagerTestSuite) TestLogout() {
 
 // TestAccounts tests cases for (*Manager).Accounts
 func (s *ManagerTestSuite) TestAccounts() {
-	s.reinitMock()
-
 	// Select the test account
 	s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil).AnyTimes()
 	s.nodeManager.EXPECT().WhisperService().Return(s.shh, nil).AnyTimes()
@@ -432,8 +424,6 @@ func (s *ManagerTestSuite) TestAccounts() {
 }
 
 func (s *ManagerTestSuite) TestAddressToDecryptedAccount() {
-	s.reinitMock()
-
 	testCases := []struct {
 		name                  string
 		accountKeyStoreReturn []interface{}

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -112,9 +112,9 @@ func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// newTestAccManager returns the account manager and the mock node manager
+// newTestManager returns the account manager and the mock node manager
 // that's being used within it for testing purposes.
-func newTestAccManager(t *testing.T) (accManager *account.Manager, nodeManager *common.MockNodeManager) {
+func newTestManager(t *testing.T) (accManager *account.Manager, nodeManager *common.MockNodeManager) {
 	ctrl := gomock.NewController(t)
 	nodeManager = common.NewMockNodeManager(ctrl)
 	accManager = account.NewManager(nodeManager)
@@ -131,7 +131,7 @@ func newTestKeyStore(t *testing.T, dir string) (keyStore *keystore.KeyStore, key
 }
 
 func TestCreateAndRecoverAccountSuccess(t *testing.T) {
-	accManager, nodeManager := newTestAccManager(t)
+	accManager, nodeManager := newTestManager(t)
 
 	var password string
 
@@ -163,7 +163,7 @@ func TestCreateAndRecoverAccountSuccess(t *testing.T) {
 }
 
 func TestCreateAndRecoverAccountFail_KeyStore(t *testing.T) {
-	accManager, nodeManager := newTestAccManager(t)
+	accManager, nodeManager := newTestManager(t)
 
 	password := "some-pass"
 

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -342,7 +342,7 @@ func (s *ManagerTestSuite) TestCreateChildAccount() {
 	}
 }
 
-func (s *ManagerTestSuite) TestSelectedAccount() {
+func (s *ManagerTestSuite) TestSelectedAndReSelectAccount() {
 	s.reinitMock()
 
 	// Create and select an account
@@ -358,12 +358,30 @@ func (s *ManagerTestSuite) TestSelectedAccount() {
 		acc, err := s.accManager.SelectedAccount()
 		s.NoError(err)
 		s.NotNil(acc)
+
+		err = s.accManager.ReSelectAccount()
+		s.NoError(err)
+	})
+
+	s.T().Run("ReSelect_fail", func(t *testing.T) {
+		s.reinitMock()
+		s.nodeManager.EXPECT().WhisperService().Return(s.shh, errors.New("Can't return a whisper service")).AnyTimes()
+		err = s.accManager.ReSelectAccount()
+		s.Error(err)
 	})
 
 	s.accManager.selectedAccount = nil
+	s.reinitMock()
+	s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil).AnyTimes()
+	s.nodeManager.EXPECT().WhisperService().Return(s.shh, errors.New("Can't return a whisper service")).AnyTimes()
 
-	s.T().Run("fail", func(t *testing.T) {
+	s.T().Run("Selected_fail", func(t *testing.T) {
 		_, err := s.accManager.SelectedAccount()
 		s.Equal(ErrNoAccountSelected, err)
+	})
+
+	s.T().Run("ReSelect_success_noAccount", func(t *testing.T) {
+		err = s.accManager.ReSelectAccount()
+		s.NoError(err)
 	})
 }

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -115,8 +115,9 @@ func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {
 }
 
 var (
-	testErrWhisper  = errors.New("Can't return a whisper service")
-	testErrKeyStore = errors.New("Can't return a key store")
+	testErrWhisper    = errors.New("Can't return a whisper service")
+	testErrKeyStore   = errors.New("Can't return a key store")
+	testErrAccManager = errors.New("Can't return an account manager")
 )
 
 func TestManagerTestSuite(t *testing.T) {
@@ -289,7 +290,7 @@ func (s *ManagerTestSuite) TestCreateChildAccount() {
 	s.T().Run("fail_noAccount", func(t *testing.T) {
 		s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil).AnyTimes()
 		_, _, err := s.accManager.CreateChildAccount("", s.password)
-		s.Error(err)
+		s.Equal(ErrNoAccountSelected, err)
 	})
 
 	// Now, select the test account for rest of the test cases.
@@ -374,7 +375,7 @@ func (s *ManagerTestSuite) TestSelectedAndReSelectAccount() {
 		s.reinitMock()
 		s.nodeManager.EXPECT().WhisperService().Return(nil, testErrWhisper).AnyTimes()
 		err = s.accManager.ReSelectAccount()
-		s.Error(err)
+		s.Equal(testErrWhisper, err)
 	})
 
 	s.accManager.selectedAccount = nil
@@ -402,7 +403,7 @@ func (s *ManagerTestSuite) TestLogout() {
 
 	s.nodeManager.EXPECT().WhisperService().Return(nil, testErrWhisper)
 	err = s.accManager.Logout()
-	s.Error(err)
+	s.Equal(testErrWhisper, err)
 }
 
 func (s *ManagerTestSuite) TestAccounts() {
@@ -421,9 +422,9 @@ func (s *ManagerTestSuite) TestAccounts() {
 	s.NotNil(accs)
 
 	// Can't get an account manager
-	s.nodeManager.EXPECT().AccountManager().Return(nil, errors.New("Can't return an account manager"))
+	s.nodeManager.EXPECT().AccountManager().Return(nil, testErrAccManager)
 	_, err = s.accManager.Accounts()
-	s.Error(err)
+	s.Equal(testErrAccManager, err)
 
 	// Selected account is nil but doesn't fail
 	s.accManager.selectedAccount = nil

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -341,3 +341,29 @@ func (s *ManagerTestSuite) TestCreateChildAccount() {
 		})
 	}
 }
+
+func (s *ManagerTestSuite) TestSelectedAccount() {
+	s.reinitMock()
+
+	// Create and select an account
+	s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil)
+	addr, _, _, err := s.accManager.CreateAccount(s.password)
+	s.NoError(err)
+	s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil).AnyTimes()
+	s.nodeManager.EXPECT().WhisperService().Return(s.shh, nil).AnyTimes()
+	err = s.accManager.SelectAccount(addr, s.password)
+	s.NoError(err)
+
+	s.T().Run("success", func(t *testing.T) {
+		acc, err := s.accManager.SelectedAccount()
+		s.NoError(err)
+		s.NotNil(acc)
+	})
+
+	s.accManager.selectedAccount = nil
+
+	s.T().Run("fail", func(t *testing.T) {
+		_, err := s.accManager.SelectedAccount()
+		s.Equal(ErrNoAccountSelected, err)
+	})
+}

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -185,7 +185,7 @@ func (s *ManagerTestSuite) reinitMock() {
 	s.accManager.nodeManager = s.nodeManager
 }
 
-func (s *ManagerTestSuite) TestCreateAndRecoverAccount() {
+func (s *ManagerTestSuite) TestCreateAccount() {
 	s.reinitMock()
 
 	// Don't fail on empty password
@@ -193,16 +193,19 @@ func (s *ManagerTestSuite) TestCreateAndRecoverAccount() {
 	_, _, _, err := s.accManager.CreateAccount(s.password)
 	s.NoError(err)
 
-	// Recover the account using the mnemonic seed and the password
+	s.nodeManager.EXPECT().AccountKeyStore().Return(nil, testErrKeyStore)
+	_, _, _, err = s.accManager.CreateAccount(s.password)
+	s.Equal(err, testErrKeyStore)
+}
+
+func (s *ManagerTestSuite) TestRecoverAccount() {
+	s.reinitMock()
+
 	s.nodeManager.EXPECT().AccountKeyStore().Return(s.keyStore, nil)
 	addr, pubKey, err := s.accManager.RecoverAccount(s.password, s.mnemonic)
 	s.NoError(err)
 	s.Equal(s.address, addr)
 	s.Equal(s.pubKey, pubKey)
-
-	s.nodeManager.EXPECT().AccountKeyStore().Return(nil, testErrKeyStore)
-	_, _, _, err = s.accManager.CreateAccount(s.password)
-	s.Equal(err, testErrKeyStore)
 
 	s.nodeManager.EXPECT().AccountKeyStore().Return(nil, testErrKeyStore)
 	_, _, err = s.accManager.RecoverAccount(s.password, s.mnemonic)

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -196,7 +196,7 @@ func (s *ManagerTestSuite) TestCreateAccount() {
 
 	s.nodeManager.EXPECT().AccountKeyStore().Return(nil, testErrKeyStore)
 	_, _, _, err = s.accManager.CreateAccount(s.password)
-	s.Equal(err, testErrKeyStore)
+	s.Equal(testErrKeyStore, err)
 }
 
 func (s *ManagerTestSuite) TestRecoverAccount() {
@@ -210,7 +210,7 @@ func (s *ManagerTestSuite) TestRecoverAccount() {
 
 	s.nodeManager.EXPECT().AccountKeyStore().Return(nil, testErrKeyStore)
 	_, _, err = s.accManager.RecoverAccount(s.password, s.mnemonic)
-	s.Equal(err, testErrKeyStore)
+	s.Equal(testErrKeyStore, err)
 }
 
 func (s *ManagerTestSuite) TestSelectAccount() {

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -272,11 +272,7 @@ func (s *ManagerTestSuite) TestSelectAccount() {
 			s.nodeManager.EXPECT().AccountKeyStore().Return(testCase.accountKeyStoreReturn...).AnyTimes()
 			s.nodeManager.EXPECT().WhisperService().Return(testCase.whisperServiceReturn...).AnyTimes()
 			err := s.accManager.SelectAccount(testCase.address, testCase.password)
-			if testCase.expectedError != nil {
-				s.Equal(testCase.expectedError, err)
-			} else {
-				s.NoError(err)
-			}
+			s.Equal(testCase.expectedError, err)
 		})
 	}
 }

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -310,6 +310,20 @@ func (s *ManagerTestSuite) TestCreateChildAccount() {
 			[]interface{}{nil, errors.New("Can't return a key store")},
 			true,
 		},
+		{
+			"fail_wrongAddress",
+			"wrong-address",
+			s.password,
+			[]interface{}{s.keyStore, nil},
+			true,
+		},
+		{
+			"fail_wrongPassword",
+			addr,
+			"wrong-password",
+			[]interface{}{s.keyStore, nil},
+			true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/geth/account/accounts_test.go
+++ b/geth/account/accounts_test.go
@@ -149,7 +149,6 @@ func TestCreateAndRecoverAccountSuccess(t *testing.T) {
 	nodeManager.EXPECT().AccountKeyStore().Return(keyStore, nil)
 	addr1, pubKey1, mnemonic, err := accManager.CreateAccount(password)
 	require.NoError(t, err)
-
 	require.NotNil(t, addr1)
 	require.NotNil(t, pubKey1)
 	require.NotNil(t, mnemonic)
@@ -158,7 +157,6 @@ func TestCreateAndRecoverAccountSuccess(t *testing.T) {
 	nodeManager.EXPECT().AccountKeyStore().Return(keyStore, nil)
 	addr2, pubKey2, err := accManager.RecoverAccount(password, mnemonic)
 	require.NoError(t, err)
-
 	require.Equal(t, addr1, addr2)
 	require.Equal(t, pubKey1, pubKey2)
 }
@@ -198,7 +196,7 @@ func TestSelectAccount(t *testing.T) {
 	addr, _, _, err := accManager.CreateAccount(password)
 	require.NoError(t, err)
 
-	w := whisper.New(nil)
+	shh := whisper.New(nil)
 
 	testCases := []struct {
 		name                  string
@@ -211,7 +209,7 @@ func TestSelectAccount(t *testing.T) {
 		{
 			"success",
 			[]interface{}{keyStore, nil},
-			[]interface{}{w, nil},
+			[]interface{}{shh, nil},
 			addr,
 			password,
 			false,
@@ -219,7 +217,7 @@ func TestSelectAccount(t *testing.T) {
 		{
 			"fail_keyStore",
 			[]interface{}{nil, errors.New("Can't return you a key store")},
-			[]interface{}{w, nil},
+			[]interface{}{shh, nil},
 			addr,
 			password,
 			true,
@@ -235,7 +233,7 @@ func TestSelectAccount(t *testing.T) {
 		{
 			"fail_wrongAddress",
 			[]interface{}{keyStore, nil},
-			[]interface{}{w, nil},
+			[]interface{}{shh, nil},
 			"wrong-address",
 			password,
 			true,
@@ -243,7 +241,7 @@ func TestSelectAccount(t *testing.T) {
 		{
 			"fail_wrongPassword",
 			[]interface{}{keyStore, nil},
-			[]interface{}{w, nil},
+			[]interface{}{shh, nil},
 			addr,
 			"wrong-password",
 			true,


### PR DESCRIPTION
Unit tests for account creation and recovery using `common.MockNodeManager`

Important changes:
- [x] No race conditions.
- [x] Coverage for `Manager.CreateAccount` and `Manager.RecoverAccount` is over 80%.
- [x] ~~All functions which are independent from `common.NodeManager` are included. (?)~~
- [x] Overall test coverage is over 80%.

Closes #510 
