### PR TITLE
xgo: Use statusim/xgo Docker image, based on Go 1.9.2 instead of 1.8.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ endif
 CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN = build/bin
 GO ?= latest
+XGOVERSION ?= 1.9.2
+XGOIMAGE = statusteam/xgo:$(XGOVERSION)
+XGOIMAGEIOSSIM = statusteam/xgo-ios-simulator:$(XGOVERSION)
 
 DOCKER_IMAGE_NAME ?= status-go
 
@@ -52,16 +55,16 @@ statusgo-cross: statusgo-android statusgo-ios
 	@ls -ld $(GOBIN)/statusgo-*
 
 statusgo-android: xgo ##@cross-compile Build status-go for Android
-	$(GOPATH)/bin/xgo --image farazdagi/xgo --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=android-16/aar -v $(shell build/testnet-flags.sh) ./lib
+	$(GOPATH)/bin/xgo --image $(XGOIMAGE) --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=android-16/aar -v $(shell build/testnet-flags.sh) ./lib
 	@echo "Android cross compilation done."
 
 statusgo-ios: xgo	##@cross-compile Build status-go for iOS
-	$(GOPATH)/bin/xgo --image farazdagi/xgo --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell build/testnet-flags.sh) ./lib
+	$(GOPATH)/bin/xgo --image $(XGOIMAGE) --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell build/testnet-flags.sh) ./lib
 	@echo "iOS framework cross compilation done."
 
 statusgo-ios-simulator: xgo	##@cross-compile Build status-go for iOS Simulator
-	@docker pull farazdagi/xgo-ios-simulator
-	$(GOPATH)/bin/xgo --image farazdagi/xgo-ios-simulator --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell build/testnet-flags.sh) ./lib
+	@docker pull $(XGOIMAGEIOSSIM)
+	$(GOPATH)/bin/xgo --image $(XGOIMAGEIOSSIM) --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell build/testnet-flags.sh) ./lib
 	@echo "iOS framework cross compilation done."
 
 statusgo-library: ##@cross-compile Build status-go as static library for current platform
@@ -74,8 +77,13 @@ docker-image: ##@docker Build docker image (use DOCKER_IMAGE_NAME to set the ima
 	@echo "Building docker image..."
 	docker build . -t $(DOCKER_IMAGE_NAME)
 
+xgo-docker-images: ##@docker Build xgo docker images
+	@echo "Building xgo docker images..."
+	docker build xgo/base -t $(XGOIMAGE)
+	docker build xgo/ios-simulator -t $(XGOIMAGEIOSSIM)
+
 xgo:
-	docker pull farazdagi/xgo
+	docker pull $(XGOIMAGE)
 	go get github.com/karalabe/xgo
 
 statusgo-mainnet:
@@ -84,15 +92,15 @@ statusgo-mainnet:
 	@echo "Run \"build/bin/statusgo\" to view available commands"
 
 statusgo-android-mainnet: xgo
-	$(GOPATH)/bin/xgo --image farazdagi/xgo --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=android-16/aar -v $(shell build/mainnet-flags.sh) ./lib
+	$(GOPATH)/bin/xgo --image $(XGOIMAGE) --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=android-16/aar -v $(shell build/mainnet-flags.sh) ./lib
 	@echo "Android cross compilation done (mainnet)."
 
 statusgo-ios-mainnet: xgo
-	$(GOPATH)/bin/xgo --image farazdagi/xgo --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell build/mainnet-flags.sh) ./lib
+	$(GOPATH)/bin/xgo --image $(XGOIMAGE) --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell build/mainnet-flags.sh) ./lib
 	@echo "iOS framework cross compilation done (mainnet)."
 
 statusgo-ios-simulator-mainnet: xgo
-	$(GOPATH)/bin/xgo --image farazdagi/xgo-ios-simulator --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell build/mainnet-flags.sh) ./lib
+	$(GOPATH)/bin/xgo --image $(XGOIMAGEIOSSIM) --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell build/mainnet-flags.sh) ./lib
 	@echo "iOS framework cross compilation done (mainnet)."
 
 generate: ##@other Regenerate assets and other auto-generated stuff

--- a/xgo/base/Dockerfile
+++ b/xgo/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM karalabe/xgo-1.7.1
+FROM karalabe/xgo-1.9.2
 
 # Inject the container entry point, the build script (patched for Status bindings conditional builds of C code)
 ADD build.sh /build.sh

--- a/xgo/ios-simulator/Dockerfile
+++ b/xgo/ios-simulator/Dockerfile
@@ -1,4 +1,4 @@
-FROM farazdagi/xgo
+FROM statusteam/xgo:1.9.2
 
 RUN \
   IOS_SDK_PATH=https://s3.amazonaws.com/farazdagi/status-im/iPhoneSimulator9.3.sdk.tar.gz && \


### PR DESCRIPTION
This PR replaces the `farazdagi/xgo` Docker image based on xgo 1.8.3 with a status-im image based on xgo 1.9.2. It changes the xgo Dockerfiles and the Makefile. I've decided to reuse the versioning system from the base xgo Docker image, which allows us to reference older images in the future in case something is broken (or we want to build a branch which uses an older xgo version).

One question, the GH issue suggests using `statusim/xgo` as the image name. Should it instead be `status-im/xgo`, in keeping with the GitHub organization name?

Remaining work from Ops:
- [ ] Update version reference at the bottom of https://github.com/status-im/status-go/wiki/Building to 1.9.*
- [ ] Optional: Set up an automated build in Docker Hub as described in https://github.com/status-im/status-go/issues/391#issuecomment-353801680.
- [ ] Optional: Upload `iPhoneSimulator9.3.sdk.tar.gz` to a CDN address controlled by Status (https://github.com/status-im/status-go/issues/391#issuecomment-353740549).

Once these bullet points have been addressed, the PR can be tested.

Closes #391 
