### PR TITLE
Update Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
-*
+.git
+.ethereumtest
+.github
+build/bin
+statusd-data
+wnode-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
-FROM alpine:3.5
+# Build wnode-status in a Go builder container
+FROM golang:1.9-alpine as builder
 
-RUN \
-  apk add --update go git make gcc musl-dev linux-headers ca-certificates && \
-  git clone --depth 1 --branch feature/statusd-replaces-geth-on-cluster https://github.com/farazdagi/status-go && \
-  (cd status-go && make) && \
-  cp status-go/build/bin/statusd /statusd && \
-  apk del go git make gcc musl-dev linux-headers && \
-  rm -rf /status-go && rm -rf /var/cache/apk/*
+RUN apk add --no-cache make gcc musl-dev linux-headers
 
-EXPOSE 8545
-EXPOSE 30303
-EXPOSE 3001
+RUN mkdir -p /go/src/github.com/status-im/status-go
+ADD . /go/src/github.com/status-im/status-go
+RUN cd /go/src/github.com/status-im/status-go && make statusgo && make wnode-status
 
-ENTRYPOINT ["/statusd"]
+# Copy the binary to the second image
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates bash
+COPY --from=builder /go/src/github.com/status-im/status-go/build/bin/* /usr/local/bin/
+
+RUN mkdir -p /static/keys
+COPY --from=builder /go/src/github.com/status-im/status-go/static/keys/* /static/keys/
+
+EXPOSE 8545 30303 30303/udp
+# Discovery v5
+EXPOSE 30304/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,5 @@ COPY --from=builder /go/src/github.com/status-im/status-go/build/bin/* /usr/loca
 RUN mkdir -p /static/keys
 COPY --from=builder /go/src/github.com/status-im/status-go/static/keys/* /static/keys/
 
-EXPOSE 8545 30303 30303/udp
-# Discovery v5
-EXPOSE 30304/udp
+# 30304 is used for Discovery v5
+EXPOSE 8080 8545 30303 30303/udp 30304/udp

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,17 @@ help: ##@other Show this help
 include ./static/tools/mk/lint.mk
 
 ifndef GOPATH
-$(error GOPATH not set. Please set GOPATH and make sure status-go is located at $$GOPATH/src/github.com/status-im/status-go. For more information about the GOPATH environment variable, see https://golang.org/doc/code.html#GOPATH)
+	$(error GOPATH not set. Please set GOPATH and make sure status-go is located at $$GOPATH/src/github.com/status-im/status-go. \
+	For more information about the GOPATH environment variable, see https://golang.org/doc/code.html#GOPATH)
 endif
 
 CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN = build/bin
 GO ?= latest
+
+DCKR_IMAGE_NAME ?= status-go
+
+UNIT_TEST_PACKAGES := $(shell go list ./...  | grep -v /vendor | grep -v /e2e | grep -v /cmd | grep -v /lib)
 
 # This is a code for automatic help generator.
 # It supports ANSI colors and categories.
@@ -34,10 +39,6 @@ HELP_FUN = \
 			   }; \
 			   print "\n"; \
 		   }
-
-# Main targets
-
-UNIT_TEST_PACKAGES := $(shell go list ./...  | grep -v /vendor | grep -v /e2e | grep -v /cmd | grep -v /lib)
 
 statusgo: ##@build Build status-go as statusd server
 	go build -i -o $(GOBIN)/statusd -v $(shell build/testnet-flags.sh) ./cmd/statusd
@@ -68,6 +69,10 @@ statusgo-library: ##@cross-compile Build status-go as static library for current
 	go build -buildmode=c-archive -o $(GOBIN)/libstatus.a ./lib
 	@echo "Static library built:"
 	@ls -la $(GOBIN)/libstatus.*
+
+docker-image: ##@docker Build docker image (use DCKR_IMAGE_NAME to set the image name)
+	@echo "Building docker image..."
+	docker build . -t $(DCKR_IMAGE_NAME)
 
 xgo:
 	docker pull farazdagi/xgo

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN = build/bin
 GO ?= latest
 
-DCKR_IMAGE_NAME ?= status-go
+DOCKER_IMAGE_NAME ?= status-go
 
 UNIT_TEST_PACKAGES := $(shell go list ./...  | grep -v /vendor | grep -v /e2e | grep -v /cmd | grep -v /lib)
 
@@ -70,9 +70,9 @@ statusgo-library: ##@cross-compile Build status-go as static library for current
 	@echo "Static library built:"
 	@ls -la $(GOBIN)/libstatus.*
 
-docker-image: ##@docker Build docker image (use DCKR_IMAGE_NAME to set the image name)
+docker-image: ##@docker Build docker image (use DOCKER_IMAGE_NAME to set the image name)
 	@echo "Building docker image..."
-	docker build . -t $(DCKR_IMAGE_NAME)
+	docker build . -t $(DOCKER_IMAGE_NAME)
 
 xgo:
 	docker pull farazdagi/xgo

--- a/cmd/wnode-status/config.go
+++ b/cmd/wnode-status/config.go
@@ -15,7 +15,7 @@ var (
 	prodMode    = flag.Bool("production", false, "Whether production settings should be loaded")
 	dataDir     = flag.String("datadir", "wnode-data", "Data directory for the databases and keystore")
 	networkID   = flag.Int("networkid", params.RopstenNetworkID, "Network identifier (integer, 1=Homestead, 3=Ropsten, 4=Rinkeby)")
-	listenAddr  = flag.String("listenaddr", params.ListenAddr, "IP address and port of this node (e.g. 127.0.0.1:30303)")
+	listenAddr  = flag.String("listenaddr", ":30303", "IP address and port of this node (e.g. 127.0.0.1:30303)")
 	httpEnabled = flag.Bool("http", false, "HTTP RPC enpoint enabled (default: false)")
 	httpPort    = flag.Int("httpport", params.HTTPPort, "HTTP RPC server's listening port")
 	ipcEnabled  = flag.Bool("ipc", false, "IPC RPC endpoint enabled")
@@ -107,6 +107,7 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	if !*httpEnabled {
 		nodeConfig.HTTPHost = "" // HTTP RPC is disabled
 	}
+	nodeConfig.HTTPHost = "0.0.0.0"
 	nodeConfig.HTTPPort = *httpPort
 	nodeConfig.IPCEnabled = *ipcEnabled
 	nodeConfig.RPCEnabled = *httpEnabled


### PR DESCRIPTION
Update Dockerfile to contain `statusd` and `wnode-status` binaries.

We need a docker image with `wnode-status` to run a local Whisper cluster. This `Dockerfile` consist of two images: the first is a builder and the second one contains the binaries (it's small, only about 30-40 MB).

How to build:
```
docker build . -t status-go
```

How to run:
```
docker run status-go statusd -h
```

Relates to #519 