### PR TITLE
Expose expvar values for peers count and peers info

### DIFF
--- a/cmd/wnode-status/config.go
+++ b/cmd/wnode-status/config.go
@@ -22,6 +22,10 @@ var (
 	logLevel    = flag.String("log", "INFO", `Log level, one of: "ERROR", "WARN", "INFO", "DEBUG", and "TRACE"`)
 	logFile     = flag.String("logfile", "", "Path to the log file")
 
+	// stats
+	statsEnabled = flag.Bool("stats", false, "True if stats should be collected")
+	statsAddr    = flag.String("statsaddr", "0.0.0.0:8080", "HTTP address with /metrics endpoint")
+
 	// Whisper
 	identity     = flag.String("identity", "", "Protocol identity file (private key used for asymmetric encryption)")
 	passwordFile = flag.String("passwordfile", "", "Password file (password is used for symmetric encryption)")

--- a/cmd/wnode-status/config.go
+++ b/cmd/wnode-status/config.go
@@ -23,7 +23,7 @@ var (
 	logFile     = flag.String("logfile", "", "Path to the log file")
 
 	// stats
-	statsEnabled = flag.Bool("stats", false, "True if stats should be collected")
+	statsEnabled = flag.Bool("stats", false, "Expose node stats via /debug/vars expvar endpoint")
 	statsAddr    = flag.String("statsaddr", "0.0.0.0:8080", "HTTP address with /debug/vars endpoint")
 
 	// Whisper

--- a/cmd/wnode-status/config.go
+++ b/cmd/wnode-status/config.go
@@ -24,7 +24,7 @@ var (
 
 	// stats
 	statsEnabled = flag.Bool("stats", false, "True if stats should be collected")
-	statsAddr    = flag.String("statsaddr", "0.0.0.0:8080", "HTTP address with /metrics endpoint")
+	statsAddr    = flag.String("statsaddr", "0.0.0.0:8080", "HTTP address with /debug/vars endpoint")
 
 	// Whisper
 	identity     = flag.String("identity", "", "Protocol identity file (private key used for asymmetric encryption)")

--- a/cmd/wnode-status/debug.go
+++ b/cmd/wnode-status/debug.go
@@ -19,7 +19,7 @@ func newMetrics(b *api.StatusBackend) *metrics {
 func (m *metrics) peersInfo() interface{} {
 	node, err := m.backend.NodeManager().Node()
 	if err != nil {
-		log.Warn("Failed to get node", "err", err.Error())
+		log.Warn("Failed to get a node", "err", err.Error())
 		return nil
 	}
 

--- a/cmd/wnode-status/debug.go
+++ b/cmd/wnode-status/debug.go
@@ -4,6 +4,8 @@ import (
 	"expvar"
 	"net/http"
 
+	"github.com/ethereum/go-ethereum/p2p"
+
 	"github.com/status-im/status-go/geth/api"
 	"github.com/status-im/status-go/geth/log"
 )
@@ -16,7 +18,7 @@ func newMetrics(b *api.StatusBackend) *metrics {
 	return &metrics{b}
 }
 
-func (m *metrics) peersInfo() interface{} {
+func (m *metrics) server() *p2p.Server {
 	node, err := m.backend.NodeManager().Node()
 	if err != nil {
 		log.Warn("Failed to get a node", "err", err.Error())
@@ -29,10 +31,27 @@ func (m *metrics) peersInfo() interface{} {
 		return nil
 	}
 
-	return server.PeersInfo()
+	return server
+}
+
+func (m *metrics) nodeInfo() interface{} {
+	if server := m.server(); server != nil {
+		return server.NodeInfo()
+	}
+
+	return nil
+}
+
+func (m *metrics) peersInfo() interface{} {
+	if server := m.server(); server != nil {
+		return server.PeersInfo()
+	}
+
+	return nil
 }
 
 func startDebugServer(addr string, m *metrics) error {
+	expvar.Publish("node_info", expvar.Func(m.nodeInfo))
 	expvar.Publish("peers_info", expvar.Func(m.peersInfo))
 
 	return http.ListenAndServe(addr, nil)

--- a/cmd/wnode-status/debug.go
+++ b/cmd/wnode-status/debug.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"expvar"
+	"net/http"
+
+	"github.com/status-im/status-go/geth/api"
+	"github.com/status-im/status-go/geth/log"
+)
+
+type metrics struct {
+	backend *api.StatusBackend
+}
+
+func newMetrics(b *api.StatusBackend) *metrics {
+	return &metrics{b}
+}
+
+func (m *metrics) peersInfo() interface{} {
+	node, err := m.backend.NodeManager().Node()
+	if err != nil {
+		log.Warn("Failed to get node", "err", err.Error())
+		return nil
+	}
+
+	server := node.Server()
+	if server == nil {
+		log.Warn("Failed to get a server")
+		return nil
+	}
+
+	return server.PeersInfo()
+}
+
+func startDebugServer(addr string, m *metrics) error {
+	expvar.Publish("peers_info", expvar.Func(m.peersInfo))
+
+	return http.ListenAndServe(addr, nil)
+}

--- a/cmd/wnode-status/main.go
+++ b/cmd/wnode-status/main.go
@@ -1,37 +1,17 @@
 package main
 
 import (
-	"encoding/json"
-	"expvar"
 	"flag"
 	"fmt"
-	"net/http"
 	"os"
 
-	"github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/status-im/status-go/geth/api"
 	"github.com/status-im/status-go/geth/log"
 	"github.com/status-im/status-go/geth/params"
 )
 
-var (
-	peersCount = expvar.NewInt("peers_count")
-	peersInfo  = expvar.NewString("peers_info")
-)
-
 func main() {
 	flag.Parse()
-
-	if *statsEnabled {
-		log.Info("Stats enabled", "addr", *statsAddr)
-
-		go func() {
-			if err := http.ListenAndServe(*statsAddr, nil); err != nil {
-				log.Error("Failed to start metrics server", "err", err.Error())
-			}
-		}()
-	}
 
 	config, err := makeNodeConfig()
 	if err != nil {
@@ -65,17 +45,22 @@ func main() {
 		}
 	}
 
+	// start debug server and collecting metrics
+	if *statsEnabled {
+		log.Info("Stats enabled", "addr", *statsAddr)
+
+		go func() {
+			metrics := newMetrics(backend)
+			if err := startDebugServer(*statsAddr, metrics); err != nil {
+				log.Error("Failed to start metrics server", "err", err.Error())
+			}
+		}()
+	}
+
 	ethNode, err := backend.NodeManager().Node()
 	if err != nil {
 		log.Crit("Getting node failed", "err", err.Error())
 		os.Exit(1)
-	}
-
-	if *statsEnabled {
-		if err := monitorPeers(ethNode); err != nil {
-			log.Crit("Failed to monitor peers", "err", err.Error())
-			os.Exit(1)
-		}
 	}
 
 	// wait till node has been stopped
@@ -86,40 +71,4 @@ func main() {
 func printHeader(config *params.NodeConfig) {
 	fmt.Println("Starting Whisper V5 node...")
 	fmt.Printf("Config: %s\n", config.WhisperConfig)
-}
-
-func monitorPeers(n *node.Node) error {
-	server := n.Server()
-	if server == nil {
-		return fmt.Errorf("failed to get server")
-	}
-
-	peerEvents := make(chan *p2p.PeerEvent)
-	subscription := server.SubscribeEvents(peerEvents)
-	go func() {
-		for {
-			select {
-			case ev := <-peerEvents:
-				log.Info("Received an event", "type", ev.Type, "peerID", ev.Peer.String())
-
-				// Update expvar only if a peer is added or dropped.
-				// Other events are: message sent and message received.
-				if ev.Type == p2p.PeerEventTypeAdd || ev.Type == p2p.PeerEventTypeDrop {
-					peersCount.Set(int64(server.PeerCount()))
-
-					data, err := json.Marshal(server.PeersInfo())
-					if err != nil {
-						log.Warn("Failed to marshal peers info", "err", err.Error())
-					}
-					peersInfo.Set(string(data))
-				}
-			case err := <-subscription.Err():
-				log.Error("Subscription failed", "err", err.Error())
-				subscription.Unsubscribe()
-				return
-			}
-		}
-	}()
-
-	return nil
 }

--- a/cmd/wnode-status/main.go
+++ b/cmd/wnode-status/main.go
@@ -1,35 +1,58 @@
 package main
 
 import (
+	"encoding/json"
+	"expvar"
 	"flag"
 	"fmt"
-	"log"
+	"net/http"
+	"os"
 
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/status-im/status-go/geth/api"
+	"github.com/status-im/status-go/geth/log"
 	"github.com/status-im/status-go/geth/params"
+)
+
+var (
+	peersCount = expvar.NewInt("peers_count")
+	peersInfo  = expvar.NewString("peers_info")
 )
 
 func main() {
 	flag.Parse()
 
+	if *statsEnabled {
+		log.Info("Stats enabled", "addr", *statsAddr)
+
+		go func() {
+			if err := http.ListenAndServe(*statsAddr, nil); err != nil {
+				log.Error("Failed to start metrics server", "err", err.Error())
+			}
+		}()
+	}
+
 	config, err := makeNodeConfig()
 	if err != nil {
-		log.Fatalf("Making config failed: %v", err)
+		log.Error("Making config failed", "err", err.Error())
+		os.Exit(1)
 	}
 
 	printHeader(config)
 
 	if *injectAccounts {
 		if err := LoadTestAccounts(config.DataDir); err != nil {
-			log.Fatalf("Failed to load test accounts: %v", err)
+			log.Crit("Failed to load test accounts", "err", err.Error())
+			os.Exit(1)
 		}
 	}
 
 	backend := api.NewStatusBackend()
 	started, err := backend.StartNode(config)
 	if err != nil {
-		log.Fatalf("Node start failed: %v", err)
-		return
+		log.Crit("Node start failed", "err", err.Error())
+		os.Exit(1)
 	}
 
 	// wait till node is started
@@ -37,22 +60,66 @@ func main() {
 
 	if *injectAccounts {
 		if err := InjectTestAccounts(backend.NodeManager()); err != nil {
-			log.Fatalf("Failed to inject accounts: %v", err)
+			log.Crit("Failed to inject accounts", "err", err.Error())
+			os.Exit(1)
+		}
+	}
+
+	ethNode, err := backend.NodeManager().Node()
+	if err != nil {
+		log.Crit("Getting node failed", "err", err.Error())
+		os.Exit(1)
+	}
+
+	if *statsEnabled {
+		if err := monitorPeers(ethNode); err != nil {
+			log.Crit("Failed to monitor peers", "err", err.Error())
+			os.Exit(1)
 		}
 	}
 
 	// wait till node has been stopped
-	node, err := backend.NodeManager().Node()
-	if err != nil {
-		log.Fatalf("Getting node failed: %v", err)
-		return
-	}
-
-	node.Wait()
+	ethNode.Wait()
 }
 
 // printHeader prints command header
 func printHeader(config *params.NodeConfig) {
 	fmt.Println("Starting Whisper V5 node...")
 	fmt.Printf("Config: %s\n", config.WhisperConfig)
+}
+
+func monitorPeers(n *node.Node) error {
+	server := n.Server()
+	if server == nil {
+		return fmt.Errorf("failed to get server")
+	}
+
+	peerEvents := make(chan *p2p.PeerEvent)
+	subscription := server.SubscribeEvents(peerEvents)
+	go func() {
+		for {
+			select {
+			case ev := <-peerEvents:
+				log.Info("Received an event", "type", ev.Type, "peerID", ev.Peer.String())
+
+				// Update expvar only if a peer is added or dropped.
+				// Other events are: message sent and message received.
+				if ev.Type == p2p.PeerEventTypeAdd || ev.Type == p2p.PeerEventTypeDrop {
+					peersCount.Set(int64(server.PeerCount()))
+
+					data, err := json.Marshal(server.PeersInfo())
+					if err != nil {
+						log.Warn("Failed to marshal peers info", "err", err.Error())
+					}
+					peersInfo.Set(string(data))
+				}
+			case err := <-subscription.Err():
+				log.Error("Subscription failed", "err", err.Error())
+				subscription.Unsubscribe()
+				return
+			}
+		}
+	}()
+
+	return nil
 }


### PR DESCRIPTION
`wnode-status` can expose metrics with peers count and peers info.

We need peers info to visualize the state of the cluster. Peers info is exposed via `peers_info` `expvar` value as a JSON string. Peers info is updated whenever a peer is added or dropped.

Exposed metrics:
```
"peers_info": [{"id":"0f7c65277f916ff4379fe520b875082a56e587eb3ce1c1567d9ff94206bdb05ba167c52272f20f634cd1ebdec5d9dfeb393018bfde1595d8e64a717c8b46692f","name":"Geth/v1.7.2-stable/linux-amd64/go1.9.1","caps":["eth/62","eth/63","les/1","shh/5"],"network":{"localAddress":"192.168.1.4:50578","remoteAddress":"51.15.54.150:30303"},"protocols":{"shh":"unknown"}}]
```

Closes #522
