### PR TITLE
Change expected warning log level from `WARNING` to `WARN`

### DIFF
--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -288,8 +288,8 @@ type NodeConfig struct {
 	// LogFile is filename where exposed logs get written to
 	LogFile string
 
-	// LogLevel defines minimum log level. Valid names are "ERROR", "WARNING", "INFO", "DEBUG", and "TRACE".
-	LogLevel string `validate:"eq=ERROR|eq=WARNING|eq=INFO|eq=DEBUG|eq=TRACE"`
+	// LogLevel defines minimum log level. Valid names are "ERROR", "WARN", "INFO", "DEBUG", and "TRACE".
+	LogLevel string `validate:"eq=ERROR|eq=WARN|eq=INFO|eq=DEBUG|eq=TRACE"`
 
 	// LogToStderr defines whether logged info should also be output to os.Stderr
 	LogToStderr bool


### PR DESCRIPTION
This PR is related to https://github.com/status-im/status-react/pull/2803

`WARNING` is not a valid value, `WARN` is, so this quick PR fixes the documentation and JSON validation.