### PR TITLE
Import suite module before parsing flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ profile.cov
 # tests
 .ethereumtest/
 /vendor/**/*_test.go
+*.test
 
 #
 # golang

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/params"
+
+	_ "github.com/stretchr/testify/suite" // required to register testify flags
 )
 
 var (


### PR DESCRIPTION
It is required to register testify flags. Particularly testify.m that can be used to select tests of the testify suite to run. Usage example:
```
./transactions.test -network= -test.run=TransactionsTestSuite -testify.m=TestCompleteMultipleQueuedTransactions
```

  