### PR TITLE
Remove tput usage from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ UNIT_TEST_PACKAGES := $(shell go list ./...  | grep -v /vendor | grep -v /e2e | 
 # It supports ANSI colors and categories.
 # To add new item into help output, simply add comments
 # starting with '##'. To add category, use @category.
-GREEN  := $(shell tput -Txterm setaf 2)
-WHITE  := $(shell tput -Txterm setaf 7)
-YELLOW := $(shell tput -Txterm setaf 3)
-RESET  := $(shell tput -Txterm sgr0)
+GREEN  := $(shell echo "\e[32m")
+WHITE  := $(shell echo "\e[37m")
+YELLOW := $(shell echo "\e[33m")
+RESET  := $(shell echo "\e[0m")
 HELP_FUN = \
 		   %help; \
 		   while(<>) { push @{$$help{$$2 // 'options'}}, [$$1, $$3] if /^([a-zA-Z\-]+)\s*:.*\#\#(?:@([a-zA-Z\-]+))?\s(.*)$$/ }; \


### PR DESCRIPTION
After updating Dockerfile in https://github.com/status-im/status-go/pull/521, `make` commands executed during docker build were printing error messages `tput: command not found`.

`tput` command was used in Makefile to change text color for the help screen. This command comes with `ncurses` package, found in most distributionі. In the minimal Docker image ’tput` is absent.

Instead of installing `ncurses` into docker image, I propose to get rid of `tput` usage and replace with `echo` which exists in pretty much every shell.
  