### PR TITLE
Add mockgen dependency on the Readme to run make ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,25 @@ Use following Makefile commands:
 # Testing
 To setup accounts passphrase you need to setup an environment variable: `export ACCOUNT_PASSWORD="secret_pass_phrase"`.
 
-To test statusgo, use: `make ci`. Make sure the `gometalinter` package is installed first by running `make lint-install`
-To test statusgo using a giving network by name, use: `make ci networkid=rinkeby`.
-To test statusgo using a giving network by id number, use: `make ci networkid=3`.
+Make sure the dependencies are installed first by running:
+```
+make lint-install
+make mock-install
+```
+To test fully statusgo, use:
+```
+make ci
+```
+
+To test statusgo using a given network by name, use:
+```
+make ci networkid=rinkeby
+```
+
+To test statusgo using a given network by number ID, use:
+```
+make ci networkid=3
+```
 
 If you want to launch specific test, for instance `RPCSendTransactions`, use the following command:
 ```


### PR DESCRIPTION
README is missing the mockgen dependency for running `make ci`, it becomes on an error like:

Important changes:
- [x] README update

Closes https://github.com/status-im/status-go/issues/532

  
  