### PR TITLE
 Result of tx processing returned as QueuedTxResult

### DIFF
--- a/e2e/transactions/transactions_test.go
+++ b/e2e/transactions/transactions_test.go
@@ -495,7 +495,7 @@ func (s *TransactionsTestSuite) TestDiscardQueuedTransaction() {
 			log.Info("transaction return event received", "id", event["id"].(string))
 
 			receivedErrMessage := event["error_message"].(string)
-			expectedErrMessage := queue.ErrQueuedTxDiscarded.Error()
+			expectedErrMessage := transactions.ErrQueuedTxDiscarded.Error()
 			s.Equal(receivedErrMessage, expectedErrMessage)
 
 			receivedErrCode := event["error_code"].(string)
@@ -511,7 +511,7 @@ func (s *TransactionsTestSuite) TestDiscardQueuedTransaction() {
 		To:    common.ToAddress(TestConfig.Account2.Address),
 		Value: (*hexutil.Big)(big.NewInt(1000000000000)),
 	})
-	s.EqualError(err, queue.ErrQueuedTxDiscarded.Error(), "transaction is expected to be discarded")
+	s.EqualError(err, transactions.ErrQueuedTxDiscarded.Error(), "transaction is expected to be discarded")
 
 	select {
 	case <-completeQueuedTransaction:
@@ -659,7 +659,7 @@ func (s *TransactionsTestSuite) TestDiscardMultipleQueuedTransactions() {
 			log.Info("transaction return event received", "id", event["id"].(string))
 
 			receivedErrMessage := event["error_message"].(string)
-			expectedErrMessage := queue.ErrQueuedTxDiscarded.Error()
+			expectedErrMessage := transactions.ErrQueuedTxDiscarded.Error()
 			s.Equal(receivedErrMessage, expectedErrMessage)
 
 			receivedErrCode := event["error_code"].(string)
@@ -681,7 +681,7 @@ func (s *TransactionsTestSuite) TestDiscardMultipleQueuedTransactions() {
 			To:    common.ToAddress(TestConfig.Account2.Address),
 			Value: (*hexutil.Big)(big.NewInt(1000000000000)),
 		})
-		require.EqualError(err, queue.ErrQueuedTxDiscarded.Error())
+		require.EqualError(err, transactions.ErrQueuedTxDiscarded.Error())
 		require.Equal(gethcommon.Hash{}, txHashCheck, "transaction returned hash, while it shouldn't")
 	}
 

--- a/geth/api/api.go
+++ b/geth/api/api.go
@@ -172,7 +172,7 @@ func (api *StatusAPI) CompleteTransaction(id common.QueuedTxID, password string)
 }
 
 // CompleteTransactions instructs backend to complete sending of multiple transactions
-func (api *StatusAPI) CompleteTransactions(ids []common.QueuedTxID, password string) map[common.QueuedTxID]common.RawCompleteTransactionResult {
+func (api *StatusAPI) CompleteTransactions(ids []common.QueuedTxID, password string) map[common.QueuedTxID]common.TransactionResult {
 	return api.b.txQueueManager.CompleteTransactions(ids, password)
 }
 

--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -141,8 +141,8 @@ type AccountManager interface {
 	AddressToDecryptedAccount(address, password string) (accounts.Account, *keystore.Key, error)
 }
 
-// RawCompleteTransactionResult is a JSON returned from transaction complete function (used internally)
-type RawCompleteTransactionResult struct {
+// TransactionResult is a JSON returned from transaction complete function (used internally)
+type TransactionResult struct {
 	Hash  common.Hash
 	Error error
 }
@@ -158,11 +158,9 @@ type QueuedTxID string
 // QueuedTx holds enough information to complete the queued transaction.
 type QueuedTx struct {
 	ID      QueuedTxID
-	Hash    common.Hash
 	Context context.Context
 	Args    SendTxArgs
-	Done    chan struct{}
-	Err     error
+	Result  chan TransactionResult
 }
 
 // SendTxArgs represents the arguments to submit a new transaction into the transaction pool.

--- a/geth/common/utils.go
+++ b/geth/common/utils.go
@@ -157,9 +157,8 @@ func Fatalf(reason interface{}, args ...interface{}) {
 func CreateTransaction(ctx context.Context, args SendTxArgs) *QueuedTx {
 	return &QueuedTx{
 		ID:      QueuedTxID(uuid.New()),
-		Hash:    common.Hash{},
 		Context: ctx,
 		Args:    args,
-		Done:    make(chan struct{}),
+		Result:  make(chan TransactionResult, 1),
 	}
 }

--- a/geth/transactions/errors.go
+++ b/geth/transactions/errors.go
@@ -1,0 +1,10 @@
+package transactions
+
+import "errors"
+
+var (
+	//ErrQueuedTxTimedOut - error transaction sending timed out
+	ErrQueuedTxTimedOut = errors.New("transaction sending timed out")
+	//ErrQueuedTxDiscarded - error transaction discarded
+	ErrQueuedTxDiscarded = errors.New("transaction has been discarded")
+)

--- a/geth/transactions/fake/mock.go
+++ b/geth/transactions/fake/mock.go
@@ -14,31 +14,31 @@ import (
 	reflect "reflect"
 )
 
-// MockFakePublicTransactionPoolAPI is a mock of FakePublicTransactionPoolAPI interface
-type MockFakePublicTransactionPoolAPI struct {
+// MockPublicTransactionPoolAPI is a mock of PublicTransactionPoolAPI interface
+type MockPublicTransactionPoolAPI struct {
 	ctrl     *gomock.Controller
-	recorder *MockFakePublicTransactionPoolAPIMockRecorder
+	recorder *MockPublicTransactionPoolAPIMockRecorder
 }
 
-// MockFakePublicTransactionPoolAPIMockRecorder is the mock recorder for MockFakePublicTransactionPoolAPI
-type MockFakePublicTransactionPoolAPIMockRecorder struct {
-	mock *MockFakePublicTransactionPoolAPI
+// MockPublicTransactionPoolAPIMockRecorder is the mock recorder for MockPublicTransactionPoolAPI
+type MockPublicTransactionPoolAPIMockRecorder struct {
+	mock *MockPublicTransactionPoolAPI
 }
 
-// NewMockFakePublicTransactionPoolAPI creates a new mock instance
-func NewMockFakePublicTransactionPoolAPI(ctrl *gomock.Controller) *MockFakePublicTransactionPoolAPI {
-	mock := &MockFakePublicTransactionPoolAPI{ctrl: ctrl}
-	mock.recorder = &MockFakePublicTransactionPoolAPIMockRecorder{mock}
+// NewMockPublicTransactionPoolAPI creates a new mock instance
+func NewMockPublicTransactionPoolAPI(ctrl *gomock.Controller) *MockPublicTransactionPoolAPI {
+	mock := &MockPublicTransactionPoolAPI{ctrl: ctrl}
+	mock.recorder = &MockPublicTransactionPoolAPIMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockFakePublicTransactionPoolAPI) EXPECT() *MockFakePublicTransactionPoolAPIMockRecorder {
+func (m *MockPublicTransactionPoolAPI) EXPECT() *MockPublicTransactionPoolAPIMockRecorder {
 	return m.recorder
 }
 
 // GasPrice mocks base method
-func (m *MockFakePublicTransactionPoolAPI) GasPrice(ctx context.Context) (*big.Int, error) {
+func (m *MockPublicTransactionPoolAPI) GasPrice(ctx context.Context) (*big.Int, error) {
 	ret := m.ctrl.Call(m, "GasPrice", ctx)
 	ret0, _ := ret[0].(*big.Int)
 	ret1, _ := ret[1].(error)
@@ -46,12 +46,12 @@ func (m *MockFakePublicTransactionPoolAPI) GasPrice(ctx context.Context) (*big.I
 }
 
 // GasPrice indicates an expected call of GasPrice
-func (mr *MockFakePublicTransactionPoolAPIMockRecorder) GasPrice(ctx interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GasPrice", reflect.TypeOf((*MockFakePublicTransactionPoolAPI)(nil).GasPrice), ctx)
+func (mr *MockPublicTransactionPoolAPIMockRecorder) GasPrice(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GasPrice", reflect.TypeOf((*MockPublicTransactionPoolAPI)(nil).GasPrice), ctx)
 }
 
 // EstimateGas mocks base method
-func (m *MockFakePublicTransactionPoolAPI) EstimateGas(ctx context.Context, args CallArgs) (*hexutil.Big, error) {
+func (m *MockPublicTransactionPoolAPI) EstimateGas(ctx context.Context, args CallArgs) (*hexutil.Big, error) {
 	ret := m.ctrl.Call(m, "EstimateGas", ctx, args)
 	ret0, _ := ret[0].(*hexutil.Big)
 	ret1, _ := ret[1].(error)
@@ -59,12 +59,12 @@ func (m *MockFakePublicTransactionPoolAPI) EstimateGas(ctx context.Context, args
 }
 
 // EstimateGas indicates an expected call of EstimateGas
-func (mr *MockFakePublicTransactionPoolAPIMockRecorder) EstimateGas(ctx, args interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateGas", reflect.TypeOf((*MockFakePublicTransactionPoolAPI)(nil).EstimateGas), ctx, args)
+func (mr *MockPublicTransactionPoolAPIMockRecorder) EstimateGas(ctx, args interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateGas", reflect.TypeOf((*MockPublicTransactionPoolAPI)(nil).EstimateGas), ctx, args)
 }
 
 // GetTransactionCount mocks base method
-func (m *MockFakePublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*hexutil.Uint64, error) {
+func (m *MockPublicTransactionPoolAPI) GetTransactionCount(ctx context.Context, address common.Address, blockNr rpc.BlockNumber) (*hexutil.Uint64, error) {
 	ret := m.ctrl.Call(m, "GetTransactionCount", ctx, address, blockNr)
 	ret0, _ := ret[0].(*hexutil.Uint64)
 	ret1, _ := ret[1].(error)
@@ -72,12 +72,12 @@ func (m *MockFakePublicTransactionPoolAPI) GetTransactionCount(ctx context.Conte
 }
 
 // GetTransactionCount indicates an expected call of GetTransactionCount
-func (mr *MockFakePublicTransactionPoolAPIMockRecorder) GetTransactionCount(ctx, address, blockNr interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactionCount", reflect.TypeOf((*MockFakePublicTransactionPoolAPI)(nil).GetTransactionCount), ctx, address, blockNr)
+func (mr *MockPublicTransactionPoolAPIMockRecorder) GetTransactionCount(ctx, address, blockNr interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactionCount", reflect.TypeOf((*MockPublicTransactionPoolAPI)(nil).GetTransactionCount), ctx, address, blockNr)
 }
 
 // SendRawTransaction mocks base method
-func (m *MockFakePublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error) {
+func (m *MockPublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error) {
 	ret := m.ctrl.Call(m, "SendRawTransaction", ctx, encodedTx)
 	ret0, _ := ret[0].(common.Hash)
 	ret1, _ := ret[1].(error)
@@ -85,6 +85,6 @@ func (m *MockFakePublicTransactionPoolAPI) SendRawTransaction(ctx context.Contex
 }
 
 // SendRawTransaction indicates an expected call of SendRawTransaction
-func (mr *MockFakePublicTransactionPoolAPIMockRecorder) SendRawTransaction(ctx, encodedTx interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendRawTransaction", reflect.TypeOf((*MockFakePublicTransactionPoolAPI)(nil).SendRawTransaction), ctx, encodedTx)
+func (mr *MockPublicTransactionPoolAPIMockRecorder) SendRawTransaction(ctx, encodedTx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendRawTransaction", reflect.TypeOf((*MockPublicTransactionPoolAPI)(nil).SendRawTransaction), ctx, encodedTx)
 }

--- a/geth/transactions/fake/txservice.go
+++ b/geth/transactions/fake/txservice.go
@@ -11,9 +11,9 @@ import (
 )
 
 // NewTestServer returns a mocked test server
-func NewTestServer(ctrl *gomock.Controller) (*rpc.Server, *MockFakePublicTransactionPoolAPI) {
+func NewTestServer(ctrl *gomock.Controller) (*rpc.Server, *MockPublicTransactionPoolAPI) {
 	srv := rpc.NewServer()
-	svc := NewMockFakePublicTransactionPoolAPI(ctrl)
+	svc := NewMockPublicTransactionPoolAPI(ctrl)
 	if err := srv.RegisterName("eth", svc); err != nil {
 		panic(err)
 	}

--- a/geth/transactions/queue/queue_test.go
+++ b/geth/transactions/queue/queue_test.go
@@ -52,15 +52,13 @@ func (s *QueueTestSuite) TestGetTransaction() {
 	}
 }
 
-func (s *QueueTestSuite) TestEnqueueProcessedTransaction() {
-	// enqueue will fail if transaction with hash will be enqueued
+func (s *QueueTestSuite) TestAlreadyEnqueued() {
 	tx := common.CreateTransaction(context.Background(), common.SendTxArgs{})
-	tx.Hash = gethcommon.Hash{1}
-	s.Equal(ErrQueuedTxAlreadyProcessed, s.queue.Enqueue(tx))
-
+	s.NoError(s.queue.Enqueue(tx))
+	s.Equal(ErrQueuedTxExist, s.queue.Enqueue(tx))
+	// try to enqueue another tx to double check locking
 	tx = common.CreateTransaction(context.Background(), common.SendTxArgs{})
-	tx.Err = errors.New("error")
-	s.Equal(ErrQueuedTxAlreadyProcessed, s.queue.Enqueue(tx))
+	s.NoError(s.queue.Enqueue(tx))
 }
 
 func (s *QueueTestSuite) testDone(hash gethcommon.Hash, err error) *common.QueuedTx {
@@ -73,12 +71,12 @@ func (s *QueueTestSuite) testDone(hash gethcommon.Hash, err error) *common.Queue
 func (s *QueueTestSuite) TestDoneSuccess() {
 	hash := gethcommon.Hash{1}
 	tx := s.testDone(hash, nil)
-	s.NoError(tx.Err)
-	s.Equal(hash, tx.Hash)
-	s.False(s.queue.Has(tx.ID))
 	// event is sent only if transaction was removed from a queue
 	select {
-	case <-tx.Done:
+	case rst := <-tx.Result:
+		s.NoError(rst.Error)
+		s.Equal(hash, rst.Hash)
+		s.False(s.queue.Has(tx.ID))
 	default:
 		s.Fail("No event was sent to Done channel")
 	}
@@ -88,22 +86,22 @@ func (s *QueueTestSuite) TestDoneTransientError() {
 	hash := gethcommon.Hash{1}
 	err := keystore.ErrDecrypt
 	tx := s.testDone(hash, err)
-	s.Equal(keystore.ErrDecrypt, tx.Err)
-	s.Equal(gethcommon.Hash{}, tx.Hash)
 	s.True(s.queue.Has(tx.ID))
+	_, inp := s.queue.inprogress[tx.ID]
+	s.False(inp)
 }
 
 func (s *QueueTestSuite) TestDoneError() {
 	hash := gethcommon.Hash{1}
 	err := errors.New("test")
 	tx := s.testDone(hash, err)
-	s.Equal(err, tx.Err)
-	s.NotEqual(hash, tx.Hash)
-	s.Equal(gethcommon.Hash{}, tx.Hash)
-	s.False(s.queue.Has(tx.ID))
 	// event is sent only if transaction was removed from a queue
 	select {
-	case <-tx.Done:
+	case rst := <-tx.Result:
+		s.Equal(err, rst.Error)
+		s.NotEqual(hash, rst.Hash)
+		s.Equal(gethcommon.Hash{}, rst.Hash)
+		s.False(s.queue.Has(tx.ID))
 	default:
 		s.Fail("No event was sent to Done channel")
 	}

--- a/geth/transactions/txqueue_manager_test.go
+++ b/geth/transactions/txqueue_manager_test.go
@@ -36,7 +36,7 @@ type TxQueueTestSuite struct {
 	server                 *gethrpc.Server
 	client                 *gethrpc.Client
 	txServiceMockCtrl      *gomock.Controller
-	txServiceMock          *fake.MockFakePublicTransactionPoolAPI
+	txServiceMock          *fake.MockPublicTransactionPoolAPI
 }
 
 func (s *TxQueueTestSuite) SetupTest() {
@@ -98,24 +98,26 @@ func (s *TxQueueTestSuite) TestCompleteTransaction() {
 		From: common.FromAddress(TestConfig.Account1.Address),
 		To:   common.ToAddress(TestConfig.Account2.Address),
 	})
-	err := txQueueManager.QueueTransaction(tx)
-	s.NoError(err)
 
+	s.NoError(txQueueManager.QueueTransaction(tx))
 	w := make(chan struct{})
+	var (
+		hash gethcommon.Hash
+		err  error
+	)
 	go func() {
-		hash, err := txQueueManager.CompleteTransaction(tx.ID, password)
+		hash, err = txQueueManager.CompleteTransaction(tx.ID, password)
 		s.NoError(err)
-		s.Equal(tx.Hash, hash)
 		close(w)
 	}()
 
-	err = txQueueManager.WaitForTransaction(tx)
-	s.NoError(err)
+	rst := txQueueManager.WaitForTransaction(tx)
 	// Check that error is assigned to the transaction.
-	s.NoError(tx.Err)
+	s.NoError(rst.Error)
 	// Transaction should be already removed from the queue.
 	s.False(txQueueManager.TransactionQueue().Has(tx.ID))
 	s.NoError(WaitClosed(w, time.Second))
+	s.Equal(hash, rst.Hash)
 }
 
 func (s *TxQueueTestSuite) TestCompleteTransactionMultipleTimes() {
@@ -141,8 +143,7 @@ func (s *TxQueueTestSuite) TestCompleteTransactionMultipleTimes() {
 		To:   common.ToAddress(TestConfig.Account2.Address),
 	})
 
-	err := txQueueManager.QueueTransaction(tx)
-	s.NoError(err)
+	s.NoError(txQueueManager.QueueTransaction(tx))
 
 	var (
 		wg           sync.WaitGroup
@@ -168,10 +169,9 @@ func (s *TxQueueTestSuite) TestCompleteTransactionMultipleTimes() {
 		}()
 	}
 
-	err = txQueueManager.WaitForTransaction(tx)
-	s.NoError(err)
+	rst := txQueueManager.WaitForTransaction(tx)
 	// Check that error is assigned to the transaction.
-	s.NoError(tx.Err)
+	s.NoError(rst.Error)
 	// Transaction should be already removed from the queue.
 	s.False(txQueueManager.TransactionQueue().Has(tx.ID))
 
@@ -197,10 +197,9 @@ func (s *TxQueueTestSuite) TestAccountMismatch() {
 		To:   common.ToAddress(TestConfig.Account2.Address),
 	})
 
-	err := txQueueManager.QueueTransaction(tx)
-	s.NoError(err)
+	s.NoError(txQueueManager.QueueTransaction(tx))
 
-	_, err = txQueueManager.CompleteTransaction(tx.ID, TestConfig.Account1.Password)
+	_, err := txQueueManager.CompleteTransaction(tx.ID, TestConfig.Account1.Password)
 	s.Equal(err, queue.ErrInvalidCompleteTxSender)
 
 	// Transaction should stay in the queue as mismatched accounts
@@ -227,10 +226,9 @@ func (s *TxQueueTestSuite) TestInvalidPassword() {
 		To:   common.ToAddress(TestConfig.Account2.Address),
 	})
 
-	err := txQueueManager.QueueTransaction(tx)
-	s.NoError(err)
+	s.NoError(txQueueManager.QueueTransaction(tx))
 
-	_, err = txQueueManager.CompleteTransaction(tx.ID, password)
+	_, err := txQueueManager.CompleteTransaction(tx.ID, password)
 	s.Equal(err.Error(), keystore.ErrDecrypt.Error())
 
 	// Transaction should stay in the queue as mismatched accounts
@@ -250,20 +248,34 @@ func (s *TxQueueTestSuite) TestDiscardTransaction() {
 		To:   common.ToAddress(TestConfig.Account2.Address),
 	})
 
-	err := txQueueManager.QueueTransaction(tx)
-	s.NoError(err)
-
+	s.NoError(txQueueManager.QueueTransaction(tx))
 	w := make(chan struct{})
 	go func() {
 		s.NoError(txQueueManager.DiscardTransaction(tx.ID))
 		close(w)
 	}()
 
-	err = txQueueManager.WaitForTransaction(tx)
-	s.Equal(queue.ErrQueuedTxDiscarded, err)
-	// Check that error is assigned to the transaction.
-	s.Equal(queue.ErrQueuedTxDiscarded, tx.Err)
+	rst := txQueueManager.WaitForTransaction(tx)
+	s.Equal(ErrQueuedTxDiscarded, rst.Error)
 	// Transaction should be already removed from the queue.
 	s.False(txQueueManager.TransactionQueue().Has(tx.ID))
 	s.NoError(WaitClosed(w, time.Second))
+}
+
+func (s *TxQueueTestSuite) TestCompletionTimedOut() {
+	txQueueManager := NewManager(s.nodeManagerMock, s.accountManagerMock)
+	txQueueManager.DisableNotificactions()
+	txQueueManager.completionTimeout = time.Nanosecond
+
+	txQueueManager.Start()
+	defer txQueueManager.Stop()
+
+	tx := common.CreateTransaction(context.Background(), common.SendTxArgs{
+		From: common.FromAddress(TestConfig.Account1.Address),
+		To:   common.ToAddress(TestConfig.Account2.Address),
+	})
+
+	s.NoError(txQueueManager.QueueTransaction(tx))
+	rst := txQueueManager.WaitForTransaction(tx)
+	s.Equal(ErrQueuedTxTimedOut, rst.Error)
 }

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -1049,7 +1049,7 @@ func testDiscardTransaction(t *testing.T) bool { //nolint: gocyclo
 			t.Logf("transaction return event received: {id: %s}\n", event["id"].(string))
 
 			receivedErrMessage := event["error_message"].(string)
-			expectedErrMessage := queue.ErrQueuedTxDiscarded.Error()
+			expectedErrMessage := transactions.ErrQueuedTxDiscarded.Error()
 			if receivedErrMessage != expectedErrMessage {
 				t.Errorf("unexpected error message received: got %v", receivedErrMessage)
 				return
@@ -1071,7 +1071,7 @@ func testDiscardTransaction(t *testing.T) bool { //nolint: gocyclo
 		To:    common.ToAddress(TestConfig.Account2.Address),
 		Value: (*hexutil.Big)(big.NewInt(1000000000000)),
 	})
-	if err != queue.ErrQueuedTxDiscarded {
+	if err != transactions.ErrQueuedTxDiscarded {
 		t.Errorf("expected error not thrown: %v", err)
 		return false
 	}
@@ -1136,7 +1136,7 @@ func testDiscardMultipleQueuedTransactions(t *testing.T) bool { //nolint: gocycl
 			t.Logf("transaction return event received: {id: %s}\n", event["id"].(string))
 
 			receivedErrMessage := event["error_message"].(string)
-			expectedErrMessage := queue.ErrQueuedTxDiscarded.Error()
+			expectedErrMessage := transactions.ErrQueuedTxDiscarded.Error()
 			if receivedErrMessage != expectedErrMessage {
 				t.Errorf("unexpected error message received: got %v", receivedErrMessage)
 				return
@@ -1162,7 +1162,7 @@ func testDiscardMultipleQueuedTransactions(t *testing.T) bool { //nolint: gocycl
 			To:    common.ToAddress(TestConfig.Account2.Address),
 			Value: (*hexutil.Big)(big.NewInt(1000000000000)),
 		})
-		if err != queue.ErrQueuedTxDiscarded {
+		if err != transactions.ErrQueuedTxDiscarded {
 			t.Errorf("expected error not thrown: %v", err)
 			return
 		}


### PR DESCRIPTION
Currently, it is quite easy to introduce concurrency issues while working
with transaction object. For example, race issue will exist every time
while a transaction is processed in a separate goroutine and caller will
try to check for an error before an event to the Done channel is sent.

Current change removes all the data that is updated on transaction and leaves
it with ID, Args, and Context (which is not used at the moment).

Blocked by: https://github.com/status-im/status-go/pull/530