### PR TITLE
simplify NodeManager

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -3,17 +3,10 @@ package node
 import (
 	"errors"
 	"fmt"
-	"path"
-	"strings"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/node"
-	"github.com/ethereum/go-ethereum/p2p"
-	"github.com/ethereum/go-ethereum/p2p/discover"
-	"github.com/ethereum/go-ethereum/p2p/discv5"
-	"github.com/ethereum/go-ethereum/p2p/nat"
-	gethparams "github.com/ethereum/go-ethereum/params"
+	ethNode "github.com/ethereum/go-ethereum/node"
 	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/geth/signal"
 )
@@ -28,31 +21,45 @@ var (
 	ErrNodeStartFailure                  = errors.New("error starting p2p node")
 )
 
-type StatusNode struct {
-	sync.RWMutex
-	Config  *params.NodeConfig
-	Node    *node.Node
-	Started chan struct{}
-	Stopped chan struct{}
+type Node interface {
+	Config() *params.NodeConfig
+	Node() *ethNode.Node
+	Start() (chan struct{}, error)
 }
 
-func New(config *params.NodeConfig) (*StatusNode, error) {
+type statusNode struct {
+	sync.Mutex
+	config  *params.NodeConfig
+	node    *ethNode.Node
+	started chan struct{}
+	stopped chan struct{}
+}
+
+func New(config *params.NodeConfig) (Node, error) {
 	stackConfig := defaultEmbeddedNodeConfig(config)
-	n, err := node.New(stackConfig)
+	n, err := ethNode.New(stackConfig)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return &StatusNode{
-		Config:  config,
-		Node:    n,
-		Started: make(chan struct{}),
-		Stopped: make(chan struct{}),
+	return &statusNode{
+		config: config,
+		node:   n,
 	}, nil
 }
 
-func (sn *StatusNode) Start() error {
+func (sn *statusNode) Start() (chan struct{}, error) {
+	sn.Lock()
+	if sn.started != nil {
+		sn.Unlock()
+		return sn.started, nil
+	}
+
+	sn.started = make(chan struct{})
+	sn.stopped = make(chan struct{})
+	sn.Unlock()
+
 	// TODO: make sure data directory exists
 	// TODO: make sure keys directory exists
 	// TODO: configure required node (should you need to update node's config, e.g. add bootstrap nodes, see node.Config)
@@ -62,134 +69,52 @@ func (sn *StatusNode) Start() error {
 	// TODO: initialise logging
 	// TODO: activate MailService required for Offline Inboxing
 
-	sn.start()
+	go sn.start()
 
-	return nil
+	return sn.started, nil
 }
 
-func (sn *StatusNode) start() {
-	go func() {
-		defer HaltOnPanic()
-		// start underlying node
-		if startErr := sn.Node.Start(); startErr != nil {
-			close(sn.Started)
-			sn.Lock()
-			sn.Started = nil
-			sn.Unlock()
-			signal.Send(signal.Envelope{
-				Type: signal.EventNodeCrashed,
-				Event: signal.NodeCrashEvent{
-					Error: fmt.Errorf("%v: %v", ErrNodeStartFailure, startErr).Error(),
-				},
-			})
+func (sn *statusNode) start() {
+	defer HaltOnPanic()
 
-			return
-		}
-
+	// start underlying node
+	if startErr := sn.node.Start(); startErr != nil {
+		close(sn.started)
 		sn.Lock()
-		// TODO: init RPC client for this node
+		sn.started = nil
 		sn.Unlock()
-
-		// underlying node is started, every method can use it, we use it immediately
-		// TODO: PopulateStaticPeers
-
-		// notify all subscribers that Status node is started
-		close(sn.Started)
 		signal.Send(signal.Envelope{
-			Type:  signal.EventNodeStarted,
-			Event: struct{}{},
+			Type: signal.EventNodeCrashed,
+			Event: signal.NodeCrashEvent{
+				Error: fmt.Errorf("%v: %v", ErrNodeStartFailure, startErr).Error(),
+			},
 		})
 
-		// wait up until underlying node is stopped
-		sn.Node.Wait()
+		return
+	}
 
-		// notify sn.Stop() that node has been stopped
-		close(sn.Stopped)
-		log.Info("Node is stopped")
-	}()
+	// TODO: init RPC client for this node
+	// TODO: PopulateStaticPeers
+
+	// notify all subscribers that Status node is started
+	close(sn.started)
+	signal.Send(signal.Envelope{
+		Type:  signal.EventNodeStarted,
+		Event: struct{}{},
+	})
+
+	// wait up until underlying node is stopped
+	sn.node.Wait()
+
+	// notify sn.Stop() that node has been stopped
+	close(sn.stopped)
+	log.Info("Node is stopped")
 }
 
-func defaultEmbeddedNodeConfig(config *params.NodeConfig) *node.Config {
-	nc := &node.Config{
-		DataDir:           config.DataDir,
-		KeyStoreDir:       config.KeyStoreDir,
-		UseLightweightKDF: true,
-		NoUSB:             true,
-		Name:              config.Name,
-		Version:           config.Version,
-		P2P: p2p.Config{
-			NoDiscovery:      true,
-			DiscoveryV5:      true,
-			DiscoveryV5Addr:  ":0",
-			BootstrapNodes:   makeBootstrapNodes(),
-			BootstrapNodesV5: makeBootstrapNodesV5(),
-			ListenAddr:       config.ListenAddr,
-			NAT:              nat.Any(),
-			MaxPeers:         config.MaxPeers,
-			MaxPendingPeers:  config.MaxPendingPeers,
-		},
-		IPCPath:     makeIPCPath(config),
-		HTTPCors:    []string{"*"},
-		HTTPModules: strings.Split(config.APIModules, ","),
-		WSHost:      makeWSHost(config),
-		WSPort:      config.WSPort,
-		WSOrigins:   []string{"*"},
-		WSModules:   strings.Split(config.APIModules, ","),
-	}
-
-	if config.RPCEnabled {
-		nc.HTTPHost = config.HTTPHost
-		nc.HTTPPort = config.HTTPPort
-	}
-
-	if config.BootClusterConfig == nil || !config.BootClusterConfig.Enabled {
-		nc.P2P.BootstrapNodes = nil
-		nc.P2P.BootstrapNodesV5 = nil
-	}
-
-	return nc
+func (sn *statusNode) Node() *ethNode.Node {
+	return sn.node
 }
 
-// makeIPCPath returns IPC-RPC filename
-func makeIPCPath(config *params.NodeConfig) string {
-	if !config.IPCEnabled {
-		return ""
-	}
-
-	return path.Join(config.DataDir, config.IPCFile)
-}
-
-// makeWSHost returns WS-RPC Server host, given enabled/disabled flag
-func makeWSHost(config *params.NodeConfig) string {
-	if !config.WSEnabled {
-		return ""
-	}
-
-	return config.WSHost
-}
-
-// makeBootstrapNodes returns default (hence bootstrap) list of peers
-func makeBootstrapNodes() []*discover.Node {
-	// on desktops params.TestnetBootnodes and params.MainBootnodes,
-	// on mobile client we deliberately keep this list empty
-	enodes := []string{}
-
-	var bootstrapNodes []*discover.Node
-	for _, enode := range enodes {
-		bootstrapNodes = append(bootstrapNodes, discover.MustParseNode(enode))
-	}
-
-	return bootstrapNodes
-}
-
-// makeBootstrapNodesV5 returns default (hence bootstrap) list of peers
-func makeBootstrapNodesV5() []*discv5.Node {
-	enodes := gethparams.DiscoveryV5Bootnodes
-
-	var bootstrapNodes []*discv5.Node
-	for _, enode := range enodes {
-		bootstrapNodes = append(bootstrapNodes, discv5.MustParseNode(enode))
-	}
-
-	return bootstrapNodes
+func (sn *statusNode) Config() *params.NodeConfig {
+	return sn.config
 }

--- a/node/node.go
+++ b/node/node.go
@@ -1,0 +1,195 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/ethereum/go-ethereum/p2p/nat"
+	gethparams "github.com/ethereum/go-ethereum/params"
+	"github.com/status-im/status-go/geth/params"
+	"github.com/status-im/status-go/geth/signal"
+)
+
+// node-related errors
+var (
+	ErrEthServiceRegistrationFailure     = errors.New("failed to register the Ethereum service")
+	ErrWhisperServiceRegistrationFailure = errors.New("failed to register the Whisper service")
+	ErrLightEthRegistrationFailure       = errors.New("failed to register the LES service")
+	ErrNodeMakeFailure                   = errors.New("error creating p2p node")
+	ErrNodeRunFailure                    = errors.New("error running p2p node")
+	ErrNodeStartFailure                  = errors.New("error starting p2p node")
+)
+
+type StatusNode struct {
+	sync.RWMutex
+	Config  *params.NodeConfig
+	Node    *node.Node
+	Started chan struct{}
+	Stopped chan struct{}
+}
+
+func New(config *params.NodeConfig) (*StatusNode, error) {
+	stackConfig := defaultEmbeddedNodeConfig(config)
+	n, err := node.New(stackConfig)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &StatusNode{
+		Config:  config,
+		Node:    n,
+		Started: make(chan struct{}),
+		Stopped: make(chan struct{}),
+	}, nil
+}
+
+func (sn *StatusNode) Start() error {
+	// TODO: make sure data directory exists
+	// TODO: make sure keys directory exists
+	// TODO: configure required node (should you need to update node's config, e.g. add bootstrap nodes, see node.Config)
+	// TODO: Start Ethereum service if we are not expected to use an upstream server.
+	// TODO: start Whisper service
+	// TODO: return error if node already started
+	// TODO: initialise logging
+	// TODO: activate MailService required for Offline Inboxing
+
+	sn.start()
+
+	return nil
+}
+
+func (sn *StatusNode) start() {
+	go func() {
+		defer HaltOnPanic()
+		// start underlying node
+		if startErr := sn.Node.Start(); startErr != nil {
+			close(sn.Started)
+			sn.Lock()
+			sn.Started = nil
+			sn.Unlock()
+			signal.Send(signal.Envelope{
+				Type: signal.EventNodeCrashed,
+				Event: signal.NodeCrashEvent{
+					Error: fmt.Errorf("%v: %v", ErrNodeStartFailure, startErr).Error(),
+				},
+			})
+
+			return
+		}
+
+		sn.Lock()
+		// TODO: init RPC client for this node
+		sn.Unlock()
+
+		// underlying node is started, every method can use it, we use it immediately
+		// TODO: PopulateStaticPeers
+
+		// notify all subscribers that Status node is started
+		close(sn.Started)
+		signal.Send(signal.Envelope{
+			Type:  signal.EventNodeStarted,
+			Event: struct{}{},
+		})
+
+		// wait up until underlying node is stopped
+		sn.Node.Wait()
+
+		// notify sn.Stop() that node has been stopped
+		close(sn.Stopped)
+		log.Info("Node is stopped")
+	}()
+}
+
+func defaultEmbeddedNodeConfig(config *params.NodeConfig) *node.Config {
+	nc := &node.Config{
+		DataDir:           config.DataDir,
+		KeyStoreDir:       config.KeyStoreDir,
+		UseLightweightKDF: true,
+		NoUSB:             true,
+		Name:              config.Name,
+		Version:           config.Version,
+		P2P: p2p.Config{
+			NoDiscovery:      true,
+			DiscoveryV5:      true,
+			DiscoveryV5Addr:  ":0",
+			BootstrapNodes:   makeBootstrapNodes(),
+			BootstrapNodesV5: makeBootstrapNodesV5(),
+			ListenAddr:       config.ListenAddr,
+			NAT:              nat.Any(),
+			MaxPeers:         config.MaxPeers,
+			MaxPendingPeers:  config.MaxPendingPeers,
+		},
+		IPCPath:     makeIPCPath(config),
+		HTTPCors:    []string{"*"},
+		HTTPModules: strings.Split(config.APIModules, ","),
+		WSHost:      makeWSHost(config),
+		WSPort:      config.WSPort,
+		WSOrigins:   []string{"*"},
+		WSModules:   strings.Split(config.APIModules, ","),
+	}
+
+	if config.RPCEnabled {
+		nc.HTTPHost = config.HTTPHost
+		nc.HTTPPort = config.HTTPPort
+	}
+
+	if config.BootClusterConfig == nil || !config.BootClusterConfig.Enabled {
+		nc.P2P.BootstrapNodes = nil
+		nc.P2P.BootstrapNodesV5 = nil
+	}
+
+	return nc
+}
+
+// makeIPCPath returns IPC-RPC filename
+func makeIPCPath(config *params.NodeConfig) string {
+	if !config.IPCEnabled {
+		return ""
+	}
+
+	return path.Join(config.DataDir, config.IPCFile)
+}
+
+// makeWSHost returns WS-RPC Server host, given enabled/disabled flag
+func makeWSHost(config *params.NodeConfig) string {
+	if !config.WSEnabled {
+		return ""
+	}
+
+	return config.WSHost
+}
+
+// makeBootstrapNodes returns default (hence bootstrap) list of peers
+func makeBootstrapNodes() []*discover.Node {
+	// on desktops params.TestnetBootnodes and params.MainBootnodes,
+	// on mobile client we deliberately keep this list empty
+	enodes := []string{}
+
+	var bootstrapNodes []*discover.Node
+	for _, enode := range enodes {
+		bootstrapNodes = append(bootstrapNodes, discover.MustParseNode(enode))
+	}
+
+	return bootstrapNodes
+}
+
+// makeBootstrapNodesV5 returns default (hence bootstrap) list of peers
+func makeBootstrapNodesV5() []*discv5.Node {
+	enodes := gethparams.DiscoveryV5Bootnodes
+
+	var bootstrapNodes []*discv5.Node
+	for _, enode := range enodes {
+		bootstrapNodes = append(bootstrapNodes, discv5.MustParseNode(enode))
+	}
+
+	return bootstrapNodes
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -9,46 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func nodeConfigTest() *params.NodeConfig {
-	return &params.NodeConfig{
-		DevMode:         true,
-		NetworkID:       params.RopstenNetworkID,
-		DataDir:         "./test-data",
-		Name:            params.ClientIdentifier,
-		Version:         "0.0.0.0",
-		RPCEnabled:      params.RPCEnabledDefault,
-		HTTPHost:        params.HTTPHost,
-		HTTPPort:        params.HTTPPort,
-		ListenAddr:      params.ListenAddr,
-		APIModules:      params.APIModules,
-		WSHost:          params.WSHost,
-		WSPort:          params.WSPort,
-		MaxPeers:        params.MaxPeers,
-		MaxPendingPeers: params.MaxPendingPeers,
-		IPCFile:         params.IPCFile,
-		LogFile:         params.LogFile,
-		LogLevel:        params.LogLevel,
-		LogToStderr:     params.LogToStderr,
-		BootClusterConfig: &params.BootClusterConfig{
-			Enabled:   true,
-			BootNodes: []string{},
-		},
-		LightEthConfig: &params.LightEthConfig{
-			Enabled:       true,
-			DatabaseCache: params.DatabaseCache,
-		},
-		WhisperConfig: &params.WhisperConfig{
-			Enabled:    true,
-			MinimumPoW: params.WhisperMinimumPoW,
-			TTL:        params.WhisperTTL,
-			FirebaseConfig: &params.FirebaseConfig{
-				NotificationTriggerURL: params.FirebaseNotificationTriggerURL,
-			},
-		},
-		SwarmConfig: &params.SwarmConfig{},
-	}
-}
-
 func newTestNode(t *testing.T) Node {
 	config, err := e2e.MakeTestNodeConfig(params.RopstenNetworkID)
 	require.Nil(t, err)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -49,7 +49,7 @@ func nodeConfigTest() *params.NodeConfig {
 	}
 }
 
-func newTestNode(t *testing.T) *StatusNode {
+func newTestNode(t *testing.T) Node {
 	config, err := e2e.MakeTestNodeConfig(params.RopstenNetworkID)
 	require.Nil(t, err)
 	sn, err := New(config)
@@ -59,26 +59,15 @@ func newTestNode(t *testing.T) *StatusNode {
 	return sn
 }
 
-func TestNew(t *testing.T) {
+func TestNode_Start(t *testing.T) {
 	sn := newTestNode(t)
-
-	defer func() {
-		if r := recover(); r != nil {
-			t.Fatalf("error closing `Started` channel: %+v", r)
-		}
-	}()
-
-	close(sn.Started)
-}
-
-func TestNode_Start_Stop(t *testing.T) {
-	sn := newTestNode(t)
-	sn.Start()
+	started, err := sn.Start()
+	require.Nil(t, err)
 
 	waitFor := time.Duration(200)
 
 	select {
-	case <-sn.Started:
+	case <-started:
 		t.Log("node started")
 	case <-time.After(time.Millisecond * waitFor):
 		t.Fatalf("node hasn't started after %d milliseconds", waitFor)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,0 +1,86 @@
+package node
+
+import (
+	"testing"
+	"time"
+
+	"github.com/status-im/status-go/e2e"
+	"github.com/status-im/status-go/geth/params"
+	"github.com/stretchr/testify/require"
+)
+
+func nodeConfigTest() *params.NodeConfig {
+	return &params.NodeConfig{
+		DevMode:         true,
+		NetworkID:       params.RopstenNetworkID,
+		DataDir:         "./test-data",
+		Name:            params.ClientIdentifier,
+		Version:         "0.0.0.0",
+		RPCEnabled:      params.RPCEnabledDefault,
+		HTTPHost:        params.HTTPHost,
+		HTTPPort:        params.HTTPPort,
+		ListenAddr:      params.ListenAddr,
+		APIModules:      params.APIModules,
+		WSHost:          params.WSHost,
+		WSPort:          params.WSPort,
+		MaxPeers:        params.MaxPeers,
+		MaxPendingPeers: params.MaxPendingPeers,
+		IPCFile:         params.IPCFile,
+		LogFile:         params.LogFile,
+		LogLevel:        params.LogLevel,
+		LogToStderr:     params.LogToStderr,
+		BootClusterConfig: &params.BootClusterConfig{
+			Enabled:   true,
+			BootNodes: []string{},
+		},
+		LightEthConfig: &params.LightEthConfig{
+			Enabled:       true,
+			DatabaseCache: params.DatabaseCache,
+		},
+		WhisperConfig: &params.WhisperConfig{
+			Enabled:    true,
+			MinimumPoW: params.WhisperMinimumPoW,
+			TTL:        params.WhisperTTL,
+			FirebaseConfig: &params.FirebaseConfig{
+				NotificationTriggerURL: params.FirebaseNotificationTriggerURL,
+			},
+		},
+		SwarmConfig: &params.SwarmConfig{},
+	}
+}
+
+func newTestNode(t *testing.T) *StatusNode {
+	config, err := e2e.MakeTestNodeConfig(params.RopstenNetworkID)
+	require.Nil(t, err)
+	sn, err := New(config)
+	require.Nil(t, err)
+	require.NotNil(t, sn)
+
+	return sn
+}
+
+func TestNew(t *testing.T) {
+	sn := newTestNode(t)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("error closing `Started` channel: %+v", r)
+		}
+	}()
+
+	close(sn.Started)
+}
+
+func TestNode_Start_Stop(t *testing.T) {
+	sn := newTestNode(t)
+	sn.Start()
+
+	waitFor := time.Duration(200)
+
+	select {
+	case <-sn.Started:
+		t.Log("node started")
+	case <-time.After(time.Millisecond * waitFor):
+		t.Fatalf("node hasn't started after %d milliseconds", waitFor)
+	}
+}

--- a/node/taskmanager/task.go
+++ b/node/taskmanager/task.go
@@ -1,0 +1,23 @@
+package taskmanager
+
+type task struct {
+	name      string
+	stopCh    chan struct{}
+	stoppedCh chan struct{}
+}
+
+func newTask(name string) *task {
+	return &task{
+		name:      name,
+		stopCh:    make(chan struct{}),
+		stoppedCh: make(chan struct{}),
+	}
+}
+
+func (t *task) stop() {
+	close(t.stopCh)
+}
+
+func (t *task) wait() {
+	<-t.stoppedCh
+}

--- a/node/taskmanager/task_manager.go
+++ b/node/taskmanager/task_manager.go
@@ -1,0 +1,61 @@
+package taskmanager
+
+import (
+	"sync"
+)
+
+type initFunc func(stop <-chan struct{}, stopped chan<- struct{})
+
+type TaskManager interface {
+	Add(name string, f initFunc)
+	StopTasks() <-chan struct{}
+}
+
+type taskManager struct {
+	sync.Mutex
+	tasks    []*task
+	stopping chan struct{}
+}
+
+func New() TaskManager {
+	return &taskManager{
+		tasks: make([]*task, 0),
+	}
+}
+
+func (tm *taskManager) Add(name string, f initFunc) {
+	t := newTask(name)
+	tm.Lock()
+	tm.tasks = append(tm.tasks, t)
+	tm.Unlock()
+	f(t.stopCh, t.stoppedCh)
+}
+
+func (tm *taskManager) StopTasks() <-chan struct{} {
+	tm.Lock()
+	if tm.stopping != nil {
+		tm.Unlock()
+		return tm.stopping
+	}
+
+	tm.stopping = make(chan struct{})
+	tm.Unlock()
+
+	go func() {
+		var wg sync.WaitGroup
+
+		for _, t := range tm.tasks {
+			wg.Add(1)
+			go func(t *task) {
+				t.stop()
+				t.wait()
+				wg.Done()
+			}(t)
+		}
+
+		wg.Wait()
+		close(tm.stopping)
+	}()
+
+	return tm.stopping
+}

--- a/node/taskmanager/task_manager_test.go
+++ b/node/taskmanager/task_manager_test.go
@@ -1,0 +1,40 @@
+package taskmanager
+
+import (
+	"fmt"
+	"testing"
+)
+
+func newTestTask(t *testing.T, name string, notifyTest chan struct{}) initFunc {
+	return func(stop <-chan struct{}, stopped chan<- struct{}) {
+		go func() {
+			<-stop
+			notifyTest <- struct{}{}
+			t.Logf("%s received stop signal", name)
+			stopped <- struct{}{}
+			t.Logf("%s ended", name)
+		}()
+	}
+}
+
+func TestTaskManager(t *testing.T) {
+	tasksCount := 3
+	notifyTest := make(chan struct{}, tasksCount)
+	notificationsReceived := make(chan struct{})
+
+	tm := New()
+	for i := 0; i < tasksCount; i++ {
+		name := fmt.Sprintf("task-%d", i)
+		tm.Add(name, newTestTask(t, name, notifyTest))
+	}
+
+	go func() {
+		for i := 0; i < tasksCount; i++ {
+			<-notifyTest
+		}
+		notificationsReceived <- struct{}{}
+	}()
+
+	<-tm.StopTasks()
+	<-notificationsReceived
+}

--- a/node/utils.go
+++ b/node/utils.go
@@ -2,8 +2,17 @@ package node
 
 import (
 	"fmt"
+	"path"
+	"strings"
 
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/ethereum/go-ethereum/p2p/nat"
+	gethparams "github.com/ethereum/go-ethereum/params"
 	"github.com/status-im/status-go/geth/common"
+	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/geth/signal"
 )
 
@@ -22,4 +31,89 @@ func HaltOnPanic() {
 
 		common.Fatalf(err) // os.exit(1) is called internally
 	}
+}
+
+func defaultEmbeddedNodeConfig(config *params.NodeConfig) *node.Config {
+	nc := &node.Config{
+		DataDir:           config.DataDir,
+		KeyStoreDir:       config.KeyStoreDir,
+		UseLightweightKDF: true,
+		NoUSB:             true,
+		Name:              config.Name,
+		Version:           config.Version,
+		P2P: p2p.Config{
+			NoDiscovery:      true,
+			DiscoveryV5:      true,
+			DiscoveryV5Addr:  ":0",
+			BootstrapNodes:   makeBootstrapNodes(),
+			BootstrapNodesV5: makeBootstrapNodesV5(),
+			ListenAddr:       config.ListenAddr,
+			NAT:              nat.Any(),
+			MaxPeers:         config.MaxPeers,
+			MaxPendingPeers:  config.MaxPendingPeers,
+		},
+		IPCPath:     makeIPCPath(config),
+		HTTPCors:    []string{"*"},
+		HTTPModules: strings.Split(config.APIModules, ","),
+		WSHost:      makeWSHost(config),
+		WSPort:      config.WSPort,
+		WSOrigins:   []string{"*"},
+		WSModules:   strings.Split(config.APIModules, ","),
+	}
+
+	if config.RPCEnabled {
+		nc.HTTPHost = config.HTTPHost
+		nc.HTTPPort = config.HTTPPort
+	}
+
+	if config.BootClusterConfig == nil || !config.BootClusterConfig.Enabled {
+		nc.P2P.BootstrapNodes = nil
+		nc.P2P.BootstrapNodesV5 = nil
+	}
+
+	return nc
+}
+
+// makeIPCPath returns IPC-RPC filename
+func makeIPCPath(config *params.NodeConfig) string {
+	if !config.IPCEnabled {
+		return ""
+	}
+
+	return path.Join(config.DataDir, config.IPCFile)
+}
+
+// makeWSHost returns WS-RPC Server host, given enabled/disabled flag
+func makeWSHost(config *params.NodeConfig) string {
+	if !config.WSEnabled {
+		return ""
+	}
+
+	return config.WSHost
+}
+
+// makeBootstrapNodes returns default (hence bootstrap) list of peers
+func makeBootstrapNodes() []*discover.Node {
+	// on desktops params.TestnetBootnodes and params.MainBootnodes,
+	// on mobile client we deliberately keep this list empty
+	enodes := []string{}
+
+	var bootstrapNodes []*discover.Node
+	for _, enode := range enodes {
+		bootstrapNodes = append(bootstrapNodes, discover.MustParseNode(enode))
+	}
+
+	return bootstrapNodes
+}
+
+// makeBootstrapNodesV5 returns default (hence bootstrap) list of peers
+func makeBootstrapNodesV5() []*discv5.Node {
+	enodes := gethparams.DiscoveryV5Bootnodes
+
+	var bootstrapNodes []*discv5.Node
+	for _, enode := range enodes {
+		bootstrapNodes = append(bootstrapNodes, discv5.MustParseNode(enode))
+	}
+
+	return bootstrapNodes
 }

--- a/node/utils.go
+++ b/node/utils.go
@@ -1,0 +1,25 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/status-im/status-go/geth/common"
+	"github.com/status-im/status-go/geth/signal"
+)
+
+// HaltOnPanic recovers from panic, logs issue, sends upward notification, and exits
+func HaltOnPanic() {
+	if r := recover(); r != nil {
+		err := fmt.Errorf("%v: %v", ErrNodeRunFailure, r)
+
+		// send signal up to native app
+		signal.Send(signal.Envelope{
+			Type: signal.EventNodeCrashed,
+			Event: signal.NodeCrashEvent{
+				Error: err.Error(),
+			},
+		})
+
+		common.Fatalf(err) // os.exit(1) is called internally
+	}
+}


### PR DESCRIPTION
Simplify NodeManager creating `github.com/status-im/status-go/node` and add TaskManager.

This is an initial POC to start simplifying NodeManager and moving it to a `node` package following #403. 
It also adds the package `taskmanager` that can be use in `node` to be able to stop all the background tasks before stopping the node.