### PR TITLE
Fix dependency version to build xgo-ios-simulator image

### DIFF
--- a/xgo/ios-simulator/Dockerfile
+++ b/xgo/ios-simulator/Dockerfile
@@ -1,8 +1,11 @@
 FROM statusteam/xgo:1.9.2
 
+ADD update_ios.sh /update_ios.sh
+ENV UPDATE_IOS /update_ios.sh
+RUN chmod +x $UPDATE_IOS
+
 RUN \
   IOS_SDK_PATH=https://s3.amazonaws.com/farazdagi/status-im/iPhoneSimulator9.3.sdk.tar.gz && \
   $FETCH $IOS_SDK_PATH 460423bf776e651a84c6e1bc035dbce23f93e685 && \
   $UPDATE_IOS /iPhoneSimulator9.3.sdk.tar.gz && \
   rm -rf /iPhoneSimulator9.3.sdk.tar.gz
-

--- a/xgo/ios-simulator/update_ios.sh
+++ b/xgo/ios-simulator/update_ios.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Contains a simple tool that updates some of the iOS toolchains with the SDKs
+# explicitly provided. The goal is to allow using your own up to date SDKs or
+# the simulator one not supported out of the box.
+#
+# Usage: update_ios.sh <path to>/<iSomething><Version>.sdk.tar.<type>
+set -e
+
+# Figure out the base name of the SDK
+sdk=`basename $1`
+sdk=${sdk%.*}
+sdk=${sdk%.*}
+
+# Define a small extraction utility to
+function extract {
+  case $1 in
+    *.tar.xz)
+      xz -dc $1 | tar xf -
+      ;;
+    *.tar.gz)
+      gunzip -dc $1 | tar xf -
+      ;;
+    *.tar.bz2)
+      bzip2 -dc $1 | tar xf -
+      ;;
+  esac
+}
+
+# Extract the SDK, patch it, clean it up and prep for bootstrapping
+extract $1
+
+if [[ "`basename $1`" =~ ^iPhoneSimulator ]]; then
+  echo "Patching iOS simulator SDK with missing libraries..."
+  ln -s $OSX_NDK_X86/SDK/$OSX_SDK/usr/lib/system/libsystem_kernel.dylib   $sdk/usr/lib/system/libsystem_kernel.dylib
+  ln -s $OSX_NDK_X86/SDK/$OSX_SDK/usr/lib/system/libsystem_platform.dylib $sdk/usr/lib/system/libsystem_platform.dylib
+  ln -s $OSX_NDK_X86/SDK/$OSX_SDK/usr/lib/system/libsystem_pthread.dylib  $sdk/usr/lib/system/libsystem_pthread.dylib
+  ln -s $OSX_NDK_X86/SDK/$OSX_SDK/usr/lib/system/libsystem_kernel.tbd     $sdk/usr/lib/system/libsystem_kernel.tbd
+  ln -s $OSX_NDK_X86/SDK/$OSX_SDK/usr/lib/system/libsystem_platform.tbd   $sdk/usr/lib/system/libsystem_platform.tbd
+  ln -s $OSX_NDK_X86/SDK/$OSX_SDK/usr/lib/system/libsystem_pthread.tbd    $sdk/usr/lib/system/libsystem_pthread.tbd
+fi
+
+tar -czf /tmp/$sdk.tar.gz $sdk
+rm -rf $sdk
+
+# Pull the iOS cross compiler tool and build the toolchain
+git clone https://github.com/tpoechtrager/cctools-port.git
+cd cctools-port
+git reset --hard adf616eee9d41f4961c3a83ba275249ffcb32d33
+cd ..
+
+if [[ "`basename $1`" =~ ^iPhoneSimulator ]]; then
+  rm -rf $IOS_SIM_NDK_AMD64
+  /cctools-port/usage_examples/ios_toolchain/build.sh /tmp/$sdk.tar.gz x86_64
+  mv /cctools-port/usage_examples/ios_toolchain/target $IOS_SIM_NDK_AMD64
+else
+  rm -rf $IOS_NDK_ARM_7 $IOS_NDK_ARM64
+  /cctools-port/usage_examples/ios_toolchain/build.sh /tmp/$sdk.tar.gz armv7
+  mv /cctools-port/usage_examples/ios_toolchain/target $IOS_NDK_ARM_7
+  /cctools-port/usage_examples/ios_toolchain/build.sh /tmp/$sdk.tar.gz arm64
+  mv /cctools-port/usage_examples/ios_toolchain/target $IOS_NDK_ARM64
+fi
+
+rm -rf /cctools-port

--- a/xgo/ios-simulator/update_ios.sh
+++ b/xgo/ios-simulator/update_ios.sh
@@ -44,7 +44,7 @@ tar -czf /tmp/$sdk.tar.gz $sdk
 rm -rf $sdk
 
 # Pull the iOS cross compiler tool and build the toolchain
-git clone https://github.com/tpoechtrager/cctools-port.git
+git clone -n https://github.com/tpoechtrager/cctools-port.git
 cd cctools-port
 git reset --hard adf616eee9d41f4961c3a83ba275249ffcb32d33
 cd ..


### PR DESCRIPTION
This PR fixes building `statusteam/xgo:1.9.2` Docker image to cross-compile status-go.

The image was pushed to the Docker public registry: https://hub.docker.com/u/statusteam

`update_ios.sh` was taken from https://github.com/karalabe/xgo/blob/fbd182a909a30b07ee071aee80c654b3aefd5cf0/docker/base/update_ios.sh

