### PR TITLE
silence `make lint-gas` warnings

### DIFF
--- a/cmd/statusd/debug/commands.go
+++ b/cmd/statusd/debug/commands.go
@@ -74,9 +74,9 @@ func exprsToArgs(exprs []ast.Expr) []interface{} {
 		case *ast.BasicLit:
 			switch expr.Kind {
 			case token.INT:
-				args[i], _ = strconv.ParseInt(expr.Value, 10, 64)
+				args[i], _ = strconv.ParseInt(expr.Value, 10, 64) // nolint: gas
 			case token.FLOAT:
-				args[i], _ = strconv.ParseFloat(expr.Value, 64)
+				args[i], _ = strconv.ParseFloat(expr.Value, 64) // nolint: gas
 			case token.CHAR:
 				args[i] = expr.Value[1]
 			case token.STRING:

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -147,8 +147,8 @@ func printVersion(config *params.NodeConfig, gitCommit, buildStamp string) {
 }
 
 func printUsage() {
-	fmt.Fprintln(os.Stderr, "Usage: statusd [options]")
-	fmt.Fprintf(os.Stderr, `
+	usage := `
+Usage: statusd [options]
 Examples:
   statusd               # run status node with defaults
   statusd -networkid 4  # run node on Rinkeby network
@@ -157,6 +157,7 @@ Examples:
   statusd -cli          # enable connection by statusd-cli on default port
 
 Options:
-`)
+`
+	fmt.Fprintf(os.Stderr, usage) // nolint: gas
 	flag.PrintDefaults()
 }

--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -336,8 +336,7 @@ func (r APIDetailedResponse) Error() string {
 	buf := bytes.NewBufferString("")
 
 	for _, err := range r.FieldErrors {
-		buf.WriteString(err.Error())
-		buf.WriteString("\n")
+		buf.WriteString(err.Error() + "\n") // nolint: gas
 	}
 
 	return strings.TrimSpace(buf.String())
@@ -358,8 +357,7 @@ func (e APIFieldError) Error() string {
 	buf := bytes.NewBufferString(fmt.Sprintf("Parameter: %s\n", e.Parameter))
 
 	for _, err := range e.Errors {
-		buf.WriteString(err.Error())
-		buf.WriteString("\n")
+		buf.WriteString(err.Error() + "\n") // nolint: gas
 	}
 
 	return strings.TrimSpace(buf.String())

--- a/geth/common/utils.go
+++ b/geth/common/utils.go
@@ -69,7 +69,7 @@ func ToAddress(accountAddress string) *common.Address {
 func ImportTestAccount(keystoreDir, accountFile string) error {
 	// make sure that keystore folder exists
 	if _, err := os.Stat(keystoreDir); os.IsNotExist(err) {
-		os.MkdirAll(keystoreDir, os.ModePerm) // nolint: errcheck
+		os.MkdirAll(keystoreDir, os.ModePerm) // nolint: errcheck, gas
 	}
 
 	dst := filepath.Join(keystoreDir, accountFile)
@@ -133,8 +133,8 @@ func ParseJSONArray(items string) ([]string, error) {
 func Fatalf(reason interface{}, args ...interface{}) {
 	// decide on output stream
 	w := io.MultiWriter(os.Stdout, os.Stderr)
-	outf, _ := os.Stdout.Stat()
-	errf, _ := os.Stderr.Stat()
+	outf, _ := os.Stdout.Stat() // nolint: gas
+	errf, _ := os.Stderr.Stat() // nolint: gas
 	if outf != nil && errf != nil && os.SameFile(outf, errf) {
 		w = os.Stderr
 	}
@@ -142,9 +142,9 @@ func Fatalf(reason interface{}, args ...interface{}) {
 	// find out whether error or string has been passed as a reason
 	r := reflect.ValueOf(reason)
 	if r.Kind() == reflect.String {
-		fmt.Fprintf(w, "Fatal Failure: "+reason.(string)+"\n", args)
+		fmt.Fprintf(w, "Fatal Failure: "+reason.(string)+"\n", args) //nolint: gas
 	} else {
-		fmt.Fprintf(w, "Fatal Failure: %v\n", reason.(error))
+		fmt.Fprintf(w, "Fatal Failure: %v\n", reason.(error)) //nolint: gas
 	}
 
 	debug.PrintStack()

--- a/geth/jail/console/console.go
+++ b/geth/jail/console/console.go
@@ -18,7 +18,7 @@ func Write(fn otto.FunctionCall, w io.Writer, consoleEventName string) otto.Valu
 	})
 
 	// Next print out the giving values.
-	fmt.Fprintf(w, "%s: %s", consoleEventName, formatForConsole(fn.ArgumentList))
+	fmt.Fprintf(w, "%s: %s", consoleEventName, formatForConsole(fn.ArgumentList)) // nolint: gas
 
 	return otto.UndefinedValue()
 }

--- a/geth/jail/internal/timers/timers.go
+++ b/geth/jail/internal/timers/timers.go
@@ -64,7 +64,7 @@ func newTimerHandler(l *loop.Loop, interval bool) func(call otto.FunctionCall) o
 		}
 
 		t.timer = time.AfterFunc(t.duration, func() {
-			l.Ready(t) // nolint: errcheck
+			l.Ready(t) // nolint: errcheck, gas
 		})
 
 		value, newTimerErr := call.Otto.ToValue(t)
@@ -90,7 +90,7 @@ func newImmediateTimerHandler(l *loop.Loop) func(call otto.FunctionCall) otto.Va
 		}
 
 		t.timer = time.AfterFunc(t.duration, func() {
-			l.Ready(t) // nolint: errcheck
+			l.Ready(t) // nolint: errcheck, gas
 		})
 
 		value, setImmediateErr := call.Otto.ToValue(t)
@@ -104,7 +104,7 @@ func newImmediateTimerHandler(l *loop.Loop) func(call otto.FunctionCall) otto.Va
 
 func newClearTimeoutHandler(l *loop.Loop) func(call otto.FunctionCall) otto.Value {
 	return func(call otto.FunctionCall) otto.Value {
-		v, _ := call.Argument(0).Export()
+		v, _ := call.Argument(0).Export() // nolint: gas
 		if t, ok := v.(*timerTask); ok {
 			t.stopped = true
 			t.timer.Stop()

--- a/geth/jail/internal/timers/timers.go
+++ b/geth/jail/internal/timers/timers.go
@@ -41,7 +41,7 @@ func getDelayWithMin(call otto.FunctionCall, interval bool) int64 {
 		false: 4,
 	}
 
-	delay, _ := call.Argument(1).ToInteger()
+	delay, _ := call.Argument(1).ToInteger() // nolint: gas
 	if delay < minDelay[interval] {
 		return minDelay[interval]
 	}

--- a/geth/log/log.go
+++ b/geth/log/log.go
@@ -91,7 +91,7 @@ func SetLogFile(filename string) error {
 func levelFromString(level string) log.Lvl {
 	lvl, err := log.LvlFromString(strings.ToLower(level))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Incorrect log level: %s, using defaults\n", level)
+		fmt.Fprintf(os.Stderr, "Incorrect log level: %s, using defaults\n", level) // nolint: gas
 		lvl = log.LvlInfo
 	}
 	return lvl

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -160,7 +160,7 @@ func (c *WhisperConfig) ReadIdentityFile() (*ecdsa.PrivateKey, error) {
 
 // String dumps config object as nicely indented JSON
 func (c *WhisperConfig) String() string {
-	data, _ := json.MarshalIndent(c, "", "    ")
+	data, _ := json.MarshalIndent(c, "", "    ") // nolint: gas
 	return string(data)
 }
 
@@ -172,7 +172,7 @@ type SwarmConfig struct {
 
 // String dumps config object as nicely indented JSON
 func (c *SwarmConfig) String() string {
-	data, _ := json.MarshalIndent(c, "", "    ")
+	data, _ := json.MarshalIndent(c, "", "    ") // nolint: gas
 	return string(data)
 }
 
@@ -196,7 +196,7 @@ type BootClusterConfig struct {
 
 // String dumps config object as nicely indented JSON
 func (c *BootClusterConfig) String() string {
-	data, _ := json.MarshalIndent(c, "", "    ")
+	data, _ := json.MarshalIndent(c, "", "    ") // nolint: gas
 	return string(data)
 }
 


### PR DESCRIPTION
Potentially fixes #543.  Current changes simply tell `lint-gas` to ignore each of these unhandled errors.  (See #543 for the specific warnings.)  Each of these changes needs scrutiny to determine whether an ignore is appropriate, or whether we really should be handling that error.