### PR TITLE
Add `Content-Type` to the whisper tests as required in geth 1.7.3.

### DIFF
--- a/e2e/whisper/mailservice_test.go
+++ b/e2e/whisper/mailservice_test.go
@@ -49,6 +49,7 @@ func (s *MailServiceSuite) TestShhRequestMessagesRPCMethodAvailability() {
 		"method": "shh_requestMessages",
 		"params": [{}]
 	}`)))
+	req.Header.Set("Content-Type", "application/json")
 	r.NoError(err)
 	resp, err := http.DefaultClient.Do(req)
 	r.NoError(err)


### PR DESCRIPTION
Closes #552 