### PR TITLE
Manage discovery from flags and refactor handling interrupt signals

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/status-im/status-go/cmd/statusd/debug"
 	"github.com/status-im/status-go/geth/api"
+	"github.com/status-im/status-go/geth/common"
 	"github.com/status-im/status-go/geth/params"
 )
 
@@ -33,10 +36,11 @@ var (
 	logLevel       = flag.String("log", "INFO", `Log level, one of: "ERROR", "WARN", "INFO", "DEBUG", and "TRACE"`)
 	logFile        = flag.String("logfile", "", "Path to the log file")
 	version        = flag.Bool("version", false, "Print version")
-	lesEnabled     = flag.Bool("les", true, "LES protocol enabled")
+	lesEnabled     = flag.Bool("les", false, "LES protocol enabled")
 
 	listenAddr = flag.String("listenaddr", ":30303", "IP address and port of this node (e.g. 127.0.0.1:30303)")
 	standalone = flag.Bool("standalone", true, "Don't actively connect to peers, wait for incoming connections")
+	bootnodes  = flag.String("bootnodes", "", "A list of bootnodes separated by comma")
 
 	// shh stuff
 	identityFile = flag.String("shh.identityfile", "", "Protocol identity file (private key used for asymmetric encryption)")
@@ -73,6 +77,9 @@ func main() {
 		log.Fatalf("Node start failed: %v", err)
 		return
 	}
+
+	// handle interrupt signals
+	haltOnInterruptSignal(backend.NodeManager())
 
 	// wait till node is started
 	<-started
@@ -132,6 +139,20 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	nodeConfig.LightEthConfig.Enabled = *lesEnabled
 	nodeConfig.SwarmConfig.Enabled = *swarmEnabled
 
+	if *standalone {
+		nodeConfig.BootClusterConfig.Enabled = false
+		nodeConfig.BootClusterConfig.BootNodes = nil
+	} else {
+		nodeConfig.Discovery = true
+	}
+
+	// Even if standalone is true and discovery is disabled,
+	// it's possible to use bootnodes in NodeManager.PopulateStaticPeers().
+	// TODO(adam): research if we need NodeManager.PopulateStaticPeers() at all.
+	if *bootnodes != "" {
+		nodeConfig.BootClusterConfig.BootNodes = strings.Split(*bootnodes, ",")
+	}
+
 	if *whisperEnabled {
 		return whisperConfig(nodeConfig)
 	}
@@ -183,4 +204,34 @@ Options:
 `
 	fmt.Fprintf(os.Stderr, usage) // nolint: gas
 	flag.PrintDefaults()
+}
+
+func haltOnInterruptSignal(nodeManager common.NodeManager) <-chan struct{} {
+	interruptCh := make(chan struct{})
+
+	go func() {
+		signalCh := make(chan os.Signal, 1)
+		signal.Notify(signalCh, os.Interrupt)
+		defer signal.Stop(signalCh)
+		<-signalCh
+
+		log.Println("Got interrupt, shutting down...")
+
+		close(interruptCh)
+
+		nodeStopped, err := nodeManager.StopNode()
+		if err != nil {
+			log.Printf("Failed to stop node: %v", err.Error())
+			os.Exit(1)
+		}
+
+		select {
+		case <-nodeStopped:
+		case <-time.After(time.Second * 5):
+			log.Printf("Stopping node timed out")
+			os.Exit(1)
+		}
+	}()
+
+	return interruptCh
 }

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -26,7 +26,8 @@ var (
 	nodeKeyFile    = flag.String("nodekey", "", "P2P node key file (private key)")
 	dataDir        = flag.String("datadir", params.DataDir, "Data directory for the databases and keystore")
 	networkID      = flag.Int("networkid", params.RopstenNetworkID, "Network identifier (integer, 1=Homestead, 3=Ropsten, 4=Rinkeby, 777=StatusChain)")
-	whisperEnabled = flag.Bool("shh", false, "SHH protocol enabled")
+	lesEnabled     = flag.Bool("les", false, "LES protocol enabled (default is disabled)")
+	whisperEnabled = flag.Bool("shh", false, "Whisper protocol enabled (default is disabled)")
 	swarmEnabled   = flag.Bool("swarm", false, "Swarm protocol enabled")
 	httpEnabled    = flag.Bool("http", false, "HTTP RPC endpoint enabled (default: false)")
 	httpPort       = flag.Int("httpport", params.HTTPPort, "HTTP RPC server's listening port")
@@ -36,7 +37,6 @@ var (
 	logLevel       = flag.String("log", "INFO", `Log level, one of: "ERROR", "WARN", "INFO", "DEBUG", and "TRACE"`)
 	logFile        = flag.String("logfile", "", "Path to the log file")
 	version        = flag.Bool("version", false, "Print version")
-	lesEnabled     = flag.Bool("les", false, "LES protocol enabled")
 
 	listenAddr = flag.String("listenaddr", ":30303", "IP address and port of this node (e.g. 127.0.0.1:30303)")
 	standalone = flag.Bool("standalone", true, "Don't actively connect to peers, wait for incoming connections")
@@ -206,6 +206,9 @@ Options:
 	flag.PrintDefaults()
 }
 
+// haltOnInterruptSignal catches interrupt signal (SIGINT) and
+// stops the node. It times out after 5 seconds
+// if the node can not be stopped.
 func haltOnInterruptSignal(nodeManager common.NodeManager) {
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt)

--- a/cmd/statusd/whispercfg.go
+++ b/cmd/statusd/whispercfg.go
@@ -64,11 +64,6 @@ func whisperConfig(nodeConfig *params.NodeConfig) (*params.NodeConfig, error) {
 	}
 	nodeConfig.HTTPHost = "0.0.0.0"
 
-	if *standalone {
-		nodeConfig.BootClusterConfig.Enabled = false
-		nodeConfig.BootClusterConfig.BootNodes = nil
-	}
-
 	return nodeConfig, nil
 }
 

--- a/geth/node/manager.go
+++ b/geth/node/manager.go
@@ -48,10 +48,7 @@ type NodeManager struct {
 
 // NewNodeManager makes new instance of node manager
 func NewNodeManager() *NodeManager {
-	m := &NodeManager{}
-	go HaltOnInterruptSignal(m) // allow interrupting running nodes
-
-	return m
+	return &NodeManager{}
 }
 
 // StartNode start Status node, fails if node is already started

--- a/geth/node/utils.go
+++ b/geth/node/utils.go
@@ -2,11 +2,8 @@ package node
 
 import (
 	"fmt"
-	"os"
-	osSignal "os/signal"
 
 	"github.com/status-im/status-go/geth/common"
-	"github.com/status-im/status-go/geth/log"
 	"github.com/status-im/status-go/geth/signal"
 )
 
@@ -25,24 +22,4 @@ func HaltOnPanic() {
 
 		common.Fatalf(err) // os.exit(1) is called internally
 	}
-}
-
-// HaltOnInterruptSignal stops node and panics if you press Ctrl-C enough times
-func HaltOnInterruptSignal(nodeManager *NodeManager) {
-	sigc := make(chan os.Signal, 1)
-	osSignal.Notify(sigc, os.Interrupt)
-	defer osSignal.Stop(sigc)
-	<-sigc
-	if nodeManager.node == nil {
-		return
-	}
-	log.Info("Got interrupt, shutting down...")
-	go nodeManager.node.Stop() // nolint: errcheck
-	for i := 3; i > 0; i-- {
-		<-sigc
-		if i > 1 {
-			log.Info(fmt.Sprintf("Already shutting down, interrupt %d more times for panic.", i-1))
-		}
-	}
-	panic("interrupted!")
 }

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -230,6 +230,9 @@ type NodeConfig struct {
 	// remote peer identification as well as network traffic encryption.
 	NodeKeyFile string
 
+	// Discovery set to true will enabled discovery protocol.
+	Discovery bool
+
 	// ListenAddr is an IP address and port of this node (e.g. 127.0.0.1:30303).
 	ListenAddr string
 


### PR DESCRIPTION
It's possible to control p2p discovery protocol from flags. Additionally, handling interrupt signals were removed from `geth/node` package.

This is required for Whisper test cluster which uses a bootnode and requires discovery protocol to be working.

## Important changes
- [x] `-les` is set to `false` by default.