### PR TITLE
Add a workaround for waiting till node is synced with network

### DIFF
--- a/e2e/rpc/rpc_test.go
+++ b/e2e/rpc/rpc_test.go
@@ -181,7 +181,7 @@ func (s *RPCTestSuite) TestCallContextResult() {
 	defer cancel()
 
 	var balance hexutil.Big
-	err := client.CallContext(ctx, &balance, "eth_getBalance", "0xbF164ca341326a03b547c05B343b2E21eFAe24b9", "latest")
+	err := client.CallContext(ctx, &balance, "eth_getBalance", TestConfig.Account1.Address, "latest")
 	s.NoError(err)
 	s.True(balance.ToInt().Cmp(big.NewInt(0)) > 0, "balance should be higher than 0")
 }

--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -75,6 +75,9 @@ type NodeManager interface {
 	// AddPeer adds URL of static peer
 	AddPeer(url string) error
 
+	// PeerCount returns number of connected peers
+	PeerCount() int
+
 	// LightEthereumService exposes reference to LES service running on top of the node
 	LightEthereumService() (*les.LightEthereum, error)
 

--- a/geth/common/types_mock.go
+++ b/geth/common/types_mock.go
@@ -156,6 +156,18 @@ func (mr *MockNodeManagerMockRecorder) AddPeer(url interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPeer", reflect.TypeOf((*MockNodeManager)(nil).AddPeer), url)
 }
 
+// PeerCount mocks base method
+func (m *MockNodeManager) PeerCount() int {
+	ret := m.ctrl.Call(m, "PeerCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// PeerCount indicates an expected call of PeerCount
+func (mr *MockNodeManagerMockRecorder) PeerCount() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PeerCount", reflect.TypeOf((*MockNodeManager)(nil).PeerCount))
+}
+
 // LightEthereumService mocks base method
 func (m *MockNodeManager) LightEthereumService() (*les.LightEthereum, error) {
 	ret := m.ctrl.Call(m, "LightEthereumService")

--- a/geth/node/manager.go
+++ b/geth/node/manager.go
@@ -299,6 +299,9 @@ func (m *NodeManager) addPeer(url string) error {
 }
 
 func (m *NodeManager) PeerCount() int {
+	if m.node == nil || m.node.Server() == nil {
+		return 0
+	}
 	return m.node.Server().PeerCount()
 }
 

--- a/geth/node/manager.go
+++ b/geth/node/manager.go
@@ -298,6 +298,10 @@ func (m *NodeManager) addPeer(url string) error {
 	return nil
 }
 
+func (m *NodeManager) PeerCount() int {
+	return m.node.Server().PeerCount()
+}
+
 // ResetChainData remove chain data from data directory.
 // Node is stopped, and new node is started, with clean data directory.
 func (m *NodeManager) ResetChainData() (<-chan struct{}, error) {


### PR DESCRIPTION
Fixes: https://github.com/status-im/status-go/issues/563

At the moment every second test will halt because of EnsureNodeSync.
It happens because first test usually downloads all the new state from the
network and for all following tests progress.HighestBlock will be 0.

It will be 0 because highest block is updated only if syncing with peer was started.