### PR TITLE
[#429] fix npe in geth's filter system.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -109,7 +109,7 @@
     "whisper/notifications",
     "whisper/whisperv5"
   ]
-  revision = "0e836de922116088b7621b86adf630a86d944c07"
+  revision = "f392249eb323a64d188dd53648975b8a5ca25eda"
   source = "https://github.com/status-im/go-ethereum.git"
 
 [[projects]]
@@ -415,6 +415,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "68577fada4194f3b038486eb3ec5289d273f17c3df53418bc824fe8e91dc5ea7"
+  inputs-digest = "1e24f8d3adca6619451ee4406b8064268631ad03c06fdc6323abc00a974797ac"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/ethereum/go-ethereum/eth/filters/filter_system.go
+++ b/vendor/github.com/ethereum/go-ethereum/eth/filters/filter_system.go
@@ -109,7 +109,11 @@ func NewEventSystem(mux *event.TypeMux, backend Backend, lightMode bool) *EventS
 		uninstall: make(chan *subscription),
 	}
 
-	go m.eventLoop()
+	eventLoopInit := sync.WaitGroup{}
+	eventLoopInit.Add(1)
+
+	go m.eventLoop(&eventLoopInit)
+	eventLoopInit.Wait() // Wait until eventLoop is properly initialized
 
 	return m
 }
@@ -393,23 +397,33 @@ func (es *EventSystem) lightFilterLogs(header *types.Header, addresses []common.
 }
 
 // eventLoop (un)installs filters and processes mux events.
-func (es *EventSystem) eventLoop() {
+func (es *EventSystem) eventLoop(initWaitGroup *sync.WaitGroup) {
 	var (
-		index = make(filterIndex)
-		sub   = es.mux.Subscribe(core.PendingLogsEvent{})
+		sub                                   *event.TypeMuxSubscription
+		txSub, rmLogsSub, logsSub, chainEvSub event.Subscription
+
+		index     = make(filterIndex)
+		txCh      = make(chan core.TxPreEvent, txChanSize)
+		rmLogsCh  = make(chan core.RemovedLogsEvent, rmLogsChanSize)
+		logsCh    = make(chan []*types.Log, logsChanSize)
+		chainEvCh = make(chan core.ChainEvent, chainEvChanSize)
+	)
+
+	// To guarantee that `initWaitGroup.Done()` is called even if any of the subscriptions
+	// will panic. Otherwise, it will deadlock `NewEventSystem`.
+	func() {
+		defer initWaitGroup.Done()
+
+		sub = es.mux.Subscribe(core.PendingLogsEvent{})
 		// Subscribe TxPreEvent form txpool
-		txCh  = make(chan core.TxPreEvent, txChanSize)
 		txSub = es.backend.SubscribeTxPreEvent(txCh)
 		// Subscribe RemovedLogsEvent
-		rmLogsCh  = make(chan core.RemovedLogsEvent, rmLogsChanSize)
 		rmLogsSub = es.backend.SubscribeRemovedLogsEvent(rmLogsCh)
 		// Subscribe []*types.Log
-		logsCh  = make(chan []*types.Log, logsChanSize)
 		logsSub = es.backend.SubscribeLogsEvent(logsCh)
 		// Subscribe ChainEvent
-		chainEvCh  = make(chan core.ChainEvent, chainEvChanSize)
 		chainEvSub = es.backend.SubscribeChainEvent(chainEvCh)
-	)
+	}()
 
 	// Unsubscribe all events
 	defer sub.Unsubscribe()


### PR DESCRIPTION
In this PR `0010-geth-17-fix-npe-in-filter-system.patch` is applied and `go-ethereum` version is updated.

Closes #429