### PR TITLE
Enforce type safety in `NodeCrashEvent` #602

### DIFF
--- a/geth/node/manager.go
+++ b/geth/node/manager.go
@@ -93,7 +93,7 @@ func (m *NodeManager) startNode(config *params.NodeConfig) (<-chan struct{}, err
 			signal.Send(signal.Envelope{
 				Type: signal.EventNodeCrashed,
 				Event: signal.NodeCrashEvent{
-					Error: fmt.Errorf("%v: %v", ErrNodeStartFailure, startErr).Error(),
+					Error: fmt.Errorf("%v: %v", ErrNodeStartFailure, startErr),
 				},
 			})
 			return
@@ -117,7 +117,7 @@ func (m *NodeManager) startNode(config *params.NodeConfig) (<-chan struct{}, err
 			signal.Send(signal.Envelope{
 				Type: signal.EventNodeCrashed,
 				Event: signal.NodeCrashEvent{
-					Error: ErrRPCClient.Error(),
+					Error: ErrRPCClient,
 				},
 			})
 			return

--- a/geth/node/utils.go
+++ b/geth/node/utils.go
@@ -10,13 +10,13 @@ import (
 // HaltOnPanic recovers from panic, logs issue, sends upward notification, and exits
 func HaltOnPanic() {
 	if r := recover(); r != nil {
-		strErr := fmt.Sprintf("%v: %v", ErrNodeRunFailure, r)
+		err := fmt.Errorf("%v: %v", ErrNodeRunFailure, r)
 
 		// send signal up to native app
 		signal.Send(signal.Envelope{
 			Type: signal.EventNodeCrashed,
 			Event: signal.NodeCrashEvent{
-				Error: strErr,
+				Error: err,
 			},
 		})
 

--- a/geth/signal/signals.go
+++ b/geth/signal/signals.go
@@ -9,8 +9,9 @@ import "C"
 import (
 	"encoding/json"
 
-	"github.com/status-im/status-go/geth/log"
 	"sync"
+
+	"github.com/status-im/status-go/geth/log"
 )
 
 const (
@@ -39,7 +40,16 @@ type Envelope struct {
 
 // NodeCrashEvent is special kind of error, used to report node crashes
 type NodeCrashEvent struct {
-	Error string `json:"error"`
+	Error error `json:"error"`
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (e NodeCrashEvent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Error string `json:"error"`
+	}{
+		Error: e.Error.Error(),
+	})
 }
 
 // NodeNotificationHandler defines a handler able to process incoming node events.

--- a/geth/signal/signals_test.go
+++ b/geth/signal/signals_test.go
@@ -1,0 +1,21 @@
+package signal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNodeCrashEventJSONMarshalling(t *testing.T) {
+	errorMsg := "TestNodeCrashEventJSONMarshallingError"
+	expectedJSON := fmt.Sprintf(`{"error":"%s"}`, errorMsg)
+	nodeCrashEvent := &NodeCrashEvent{
+		Error: errors.New(errorMsg),
+	}
+	marshalled, err := json.Marshal(nodeCrashEvent)
+	require.NoError(t, err)
+	require.Equal(t, expectedJSON, string(marshalled))
+}

--- a/geth/transactions/queue/utils.go
+++ b/geth/transactions/queue/utils.go
@@ -20,7 +20,7 @@ func HaltOnPanic() {
 		signal.Send(signal.Envelope{
 			Type: signal.EventNodeCrashed,
 			Event: signal.NodeCrashEvent{
-				Error: err.Error(),
+				Error: err,
 			},
 		})
 


### PR DESCRIPTION
This PR updates NodeCrashEvent to use `error` type instead of `string` type for its error field in order to enforce type safety.

Because of this change we need to update the marshaling methods for both NodeCrashEvent and Envelope, so that NodeCrashEvent converts its `error` field to a `string` and Envelope treats its `Event` field as a NodeCrashEvent type when appropriate.

Closes #602
