### PR TITLE
e2e: wait and get message before asserting empty list

### DIFF
--- a/e2e/whisper/whisper_mailbox_test.go
+++ b/e2e/whisper/whisper_mailbox_test.go
@@ -86,13 +86,18 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 	//Post message
 	s.postMessageToPrivate(rpcClient, pubkey.String(), topic.String(), hexutil.Encode([]byte("Hello world!")))
 
-	//There are no messages, because it's a sender filter
+	//wait to receive message and retrieve it
+	time.Sleep(1 * time.Second)
+	messages = s.getMessagesByMessageFilterID(rpcClient, messageFilterID)
+	s.Require().Equal(1, len(messages))
+
+	//check that there are no messages
 	messages = s.getMessagesByMessageFilterID(rpcClient, messageFilterID)
 	s.Require().Equal(0, len(messages))
 
 	//act
 
-	//Request messages from mailbox
+	//Request messages (including the previous one, expired) from mailbox
 	reqMessagesBody := `{
 		"jsonrpc": "2.0",
 		"id": 1,

--- a/e2e/whisper/whisper_mailbox_test.go
+++ b/e2e/whisper/whisper_mailbox_test.go
@@ -92,10 +92,6 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 	s.Require().Equal(1, len(messages))
 	s.Require().NoError(err)
 
-	//check that there are no more messages
-	messages = s.getMessagesByMessageFilterID(rpcClient, messageFilterID)
-	s.Require().Equal(0, len(messages))
-
 	//act
 
 	//Request messages (including the previous one, expired) from mailbox

--- a/e2e/whisper/whisper_mailbox_test.go
+++ b/e2e/whisper/whisper_mailbox_test.go
@@ -86,7 +86,7 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 	//Post message matching with filter (key and token)
 	s.postMessageToPrivate(rpcClient, pubkey.String(), topic.String(), hexutil.Encode([]byte("Hello world!")))
 
-	//get message to make sure that it will come from the mailbox later
+	//Get message to make sure that it will come from the mailbox later
 	time.Sleep(1 * time.Second)
 	messages = s.getMessagesByMessageFilterID(rpcClient, messageFilterID)
 	s.Require().Equal(1, len(messages))

--- a/e2e/whisper/whisper_mailbox_test.go
+++ b/e2e/whisper/whisper_mailbox_test.go
@@ -90,7 +90,6 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 	time.Sleep(1 * time.Second)
 	messages = s.getMessagesByMessageFilterID(rpcClient, messageFilterID)
 	s.Require().Equal(1, len(messages))
-	s.Require().NoError(err)
 
 	//act
 

--- a/e2e/whisper/whisper_mailbox_test.go
+++ b/e2e/whisper/whisper_mailbox_test.go
@@ -83,15 +83,16 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 	messages := s.getMessagesByMessageFilterID(rpcClient, messageFilterID)
 	s.Require().Equal(0, len(messages))
 
-	//Post message
+	//Post message matching with filter (key and token)
 	s.postMessageToPrivate(rpcClient, pubkey.String(), topic.String(), hexutil.Encode([]byte("Hello world!")))
 
-	//wait to receive message and retrieve it
+	//get message to make sure that it will come from the mailbox later
 	time.Sleep(1 * time.Second)
 	messages = s.getMessagesByMessageFilterID(rpcClient, messageFilterID)
 	s.Require().Equal(1, len(messages))
+	s.Require().NoError(err)
 
-	//check that there are no messages
+	//check that there are no more messages
 	messages = s.getMessagesByMessageFilterID(rpcClient, messageFilterID)
 	s.Require().Equal(0, len(messages))
 
@@ -118,7 +119,7 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 
 	//wait to receive message
 	time.Sleep(time.Second)
-	//And we receive message
+	//And we receive message, it comes from mailbox
 	messages = s.getMessagesByMessageFilterID(rpcClient, messageFilterID)
 	s.Require().Equal(1, len(messages))
 


### PR DESCRIPTION
e2e: wait and get messages before asserting empty list.

Looks like the flakiness is coming from the test checking for an empty messages list before retrieving. This sometimes succeeds (when the message hasn't been received yet) and sometimes fails (when the message has already arrived). Adding a sleep before getting messages as suggested in #567 gives enough time for the message to arrive, and the test always fails.

The fix consists in adding a sleep and a message retrieval (by the same filter) call before getting again and asserting empty list. Also some additions to the comments aiming to clarify the actions.

I've tested successfully with `--network=4`, results are consistent with>150 executions.

Closes #567
