### PR TITLE
Sync blockchain before running e2e tests on public testnet #568

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -24,5 +24,5 @@
         "vet"
     ],
     "Cyclo": 16,
-    "Deadline": "100s"
+    "Deadline": "200s"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
     # to still run, but currently does not work due to a bug
     if: type != pull_request
     script:
-      - ./build/bin/statusd -les -networkid 4 -exit-when-synced
+      - ./build/bin/statusd -les -networkid 4 -sync-and-exit
       - make test-e2e networkid=4
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ jobs:
     # using fork == false may be preferred as it would allow PRs from the origin
     # to still run, but currently does not work due to a bug
     if: type != pull_request
-    script: make test-e2e networkid=4
+    script:
+      - ./build/bin/statusd -les -networkid 4 -exit-when-synced
+      - make test-e2e networkid=4
 cache:
   directories:
   - ".ethereumtest/Mainnet"

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -109,10 +109,9 @@ func main() {
 	}
 
 	// Sync blockchain and stop.
-	if *syncAndExit > -1 {
-		if ok := syncAndStop(backend.NodeManager()); !ok {
-			return
-		}
+	if *syncAndExit >= 0 {
+		syncAndStop(backend.NodeManager())
+		return
 	}
 
 	// wait till node has been stopped

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -110,7 +110,7 @@ func main() {
 
 	// Sync blockchain and stop.
 	if *syncAndExit >= 0 {
-		syncAndStop(backend.NodeManager())
+		syncAndStopNode(backend.NodeManager())
 		return
 	}
 
@@ -166,19 +166,18 @@ func startCollectingStats(interruptCh <-chan struct{}, nodeManager common.NodeMa
 	}
 }
 
-func syncAndStop(nodeManager common.NodeManager) bool {
+func syncAndStopNode(nodeManager common.NodeManager) {
 	err := nodeManager.Sync((time.Duration)(*syncAndExit) * time.Minute)
 	if err != nil {
 		log.Fatalf("Failed while waiting for sync: %v", err)
-		return false
+		return
 	}
 	done, err := nodeManager.StopNode()
 	<-done
 	if err != nil {
 		log.Fatalf("Failed while stopping the node: %v", err)
-		return false
+		return
 	}
-	return true
 }
 
 // makeNodeConfig parses incoming CLI options and returns node configuration object

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -167,6 +167,7 @@ func startCollectingStats(interruptCh <-chan struct{}, nodeManager common.NodeMa
 }
 
 func syncAndStopNode(nodeManager common.NodeManager) {
+	log.Println("Node will synchronize and exit")
 	err := nodeManager.Sync((time.Duration)(*syncAndExit) * time.Minute)
 	if err != nil {
 		log.Fatalf("Failed while waiting for sync: %v", err)

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -188,7 +188,7 @@ func syncAndStopNode(nodeManager common.NodeManager, timeout int) (exitCode int)
 	done, err = nodeManager.StopNode()
 	if err != nil {
 		log.Printf("Stop node err: %v", err)
-		exitCode = 1
+		return 1
 	}
 	<-done
 	return

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -181,16 +181,16 @@ func syncAndStopNode(nodeManager common.NodeManager, timeout int) (exitCode int)
 		defer cancel()
 	}
 	if err != nil {
-		log.Printf("Sync and stop error: %v\n", err)
+		log.Printf("Sync error: %v", err)
 		exitCode = 1
 	}
 	var done <-chan struct{}
 	done, err = nodeManager.StopNode()
-	<-done
 	if err != nil {
-		log.Printf("Sync and stop err: %v\n", err)
+		log.Printf("Stop node err: %v", err)
 		exitCode = 1
 	}
+	<-done
 	return
 }
 

--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -53,8 +53,8 @@ type NodeManager interface {
 	// Stopped node cannot be resumed, one starts a new node instead.
 	StopNode() (<-chan struct{}, error)
 
-	// SyncAndStop node synchronizes the blockchain and stops the node.
-	SyncAndStopNode(timeout time.Duration) (errChan <-chan error)
+	// Sync waits until blockchain is synchronized.
+	Sync(timeout time.Duration) error
 
 	// RestartNode restart running Status node, fails if node is not running
 	RestartNode() (<-chan struct{}, error)

--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -53,6 +53,9 @@ type NodeManager interface {
 	// Stopped node cannot be resumed, one starts a new node instead.
 	StopNode() (<-chan struct{}, error)
 
+	// SyncAndStop node synchronizes the blockchain and stops the node.
+	SyncAndStopNode(timeout time.Duration) (errChan <-chan error)
+
 	// RestartNode restart running Status node, fails if node is not running
 	RestartNode() (<-chan struct{}, error)
 

--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -53,8 +53,8 @@ type NodeManager interface {
 	// Stopped node cannot be resumed, one starts a new node instead.
 	StopNode() (<-chan struct{}, error)
 
-	// Sync waits until blockchain is synchronized.
-	Sync(timeout time.Duration) error
+	// EnsureSync waits until blockchain is synchronized.
+	EnsureSync(ctx context.Context) error
 
 	// RestartNode restart running Status node, fails if node is not running
 	RestartNode() (<-chan struct{}, error)

--- a/geth/common/types_mock.go
+++ b/geth/common/types_mock.go
@@ -5,6 +5,7 @@
 package common
 
 import (
+	context "context"
 	accounts "github.com/ethereum/go-ethereum/accounts"
 	keystore "github.com/ethereum/go-ethereum/accounts/keystore"
 	common "github.com/ethereum/go-ethereum/common"
@@ -16,7 +17,6 @@ import (
 	params "github.com/status-im/status-go/geth/params"
 	rpc "github.com/status-im/status-go/geth/rpc"
 	reflect "reflect"
-	time "time"
 )
 
 // MockNodeManager is a mock of NodeManager interface
@@ -68,16 +68,16 @@ func (mr *MockNodeManagerMockRecorder) StopNode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopNode", reflect.TypeOf((*MockNodeManager)(nil).StopNode))
 }
 
-// Sync mocks base method
-func (m *MockNodeManager) Sync(timeout time.Duration) error {
-	ret := m.ctrl.Call(m, "Sync", timeout)
+// EnsureSync mocks base method
+func (m *MockNodeManager) EnsureSync(ctx context.Context) error {
+	ret := m.ctrl.Call(m, "EnsureSync", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Sync indicates an expected call of Sync
-func (mr *MockNodeManagerMockRecorder) Sync(timeout interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockNodeManager)(nil).Sync), timeout)
+// EnsureSync indicates an expected call of EnsureSync
+func (mr *MockNodeManagerMockRecorder) EnsureSync(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureSync", reflect.TypeOf((*MockNodeManager)(nil).EnsureSync), ctx)
 }
 
 // RestartNode mocks base method

--- a/geth/common/types_mock.go
+++ b/geth/common/types_mock.go
@@ -68,16 +68,16 @@ func (mr *MockNodeManagerMockRecorder) StopNode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopNode", reflect.TypeOf((*MockNodeManager)(nil).StopNode))
 }
 
-// SyncAndStopNode mocks base method
-func (m *MockNodeManager) SyncAndStopNode(timeout time.Duration) <-chan error {
-	ret := m.ctrl.Call(m, "SyncAndStopNode", timeout)
-	ret0, _ := ret[0].(<-chan error)
+// Sync mocks base method
+func (m *MockNodeManager) Sync(timeout time.Duration) error {
+	ret := m.ctrl.Call(m, "Sync", timeout)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SyncAndStopNode indicates an expected call of SyncAndStopNode
-func (mr *MockNodeManagerMockRecorder) SyncAndStopNode(timeout interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncAndStopNode", reflect.TypeOf((*MockNodeManager)(nil).SyncAndStopNode), timeout)
+// Sync indicates an expected call of Sync
+func (mr *MockNodeManagerMockRecorder) Sync(timeout interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockNodeManager)(nil).Sync), timeout)
 }
 
 // RestartNode mocks base method

--- a/geth/common/types_mock.go
+++ b/geth/common/types_mock.go
@@ -16,6 +16,7 @@ import (
 	params "github.com/status-im/status-go/geth/params"
 	rpc "github.com/status-im/status-go/geth/rpc"
 	reflect "reflect"
+	time "time"
 )
 
 // MockNodeManager is a mock of NodeManager interface
@@ -65,6 +66,18 @@ func (m *MockNodeManager) StopNode() (<-chan struct{}, error) {
 // StopNode indicates an expected call of StopNode
 func (mr *MockNodeManagerMockRecorder) StopNode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopNode", reflect.TypeOf((*MockNodeManager)(nil).StopNode))
+}
+
+// SyncAndStopNode mocks base method
+func (m *MockNodeManager) SyncAndStopNode(timeout time.Duration) <-chan error {
+	ret := m.ctrl.Call(m, "SyncAndStopNode", timeout)
+	ret0, _ := ret[0].(<-chan error)
+	return ret0
+}
+
+// SyncAndStopNode indicates an expected call of SyncAndStopNode
+func (mr *MockNodeManagerMockRecorder) SyncAndStopNode(timeout interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncAndStopNode", reflect.TypeOf((*MockNodeManager)(nil).SyncAndStopNode), timeout)
 }
 
 // RestartNode mocks base method

--- a/geth/node/manager.go
+++ b/geth/node/manager.go
@@ -520,11 +520,16 @@ func (m *NodeManager) isNodeAvailable() error {
 	return nil
 }
 
+// tickerResolution is the delta to check blockchain sync progress.
+const tickerResolution = time.Second
+
 // Sync waits until blockchain synchronization and returns.
+// Timeout must be at least two seconds and zero timeout
+// means waiting infinitely.
 func (m *NodeManager) Sync(timeout time.Duration) error {
 	// We need to have a larger timeout than ticker delta here
 	// unless we use zero which means infinite timeout.
-	if timeout < time.Second*2 && timeout != 0 {
+	if timeout < tickerResolution*2 && timeout != 0 {
 		return errors.New("Sync timeout can only be zero (infinite) or at least two seconds")
 	}
 	// Don't wait for any blockchain sync for the
@@ -544,7 +549,7 @@ func (m *NodeManager) sync(timeout time.Duration) error {
 		timeout = time.Hour * 8765
 	}
 
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(tickerResolution)
 	defer ticker.Stop()
 	for {
 		select {

--- a/geth/node/manager.go
+++ b/geth/node/manager.go
@@ -520,7 +520,7 @@ func (m *NodeManager) isNodeAvailable() error {
 	return nil
 }
 
-// SyncAndStop waits until node synchronization and exits.
+// SyncAndStopNode waits until node synchronization and exits.
 // Reports errors to returned channel.
 func (m *NodeManager) SyncAndStopNode(timeout time.Duration) (errChan <-chan error) {
 	ch := make(chan error, 2)


### PR DESCRIPTION
Option to sync blockchain and exit in `statusd`, for synchronizing before e2e tests.

Changes:
- `-exit-when-synced` flag is added to `statusd`.
- `NodeManager` is extended with `Sync`.
- `Sync` reuses the code in "testing/testing.go", `EnsureNodeSync`.
- `.travis.yml` is modified to sync before e2e tests on public network.

Closes #568
