### PR TITLE
Enable ethereum metrics collection

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -51,6 +51,8 @@ var (
 	statsEnabled = flag.Bool("stats", false, "Expose node stats via /debug/vars expvar endpoint or Prometheus (log by default)")
 	statsAddr    = flag.String("stats.addr", "0.0.0.0:8080", "HTTP address with /debug/vars endpoint")
 
+	// don't change the name of this flag, https://github.com/ethereum/go-ethereum/blob/master/metrics/metrics.go#L41
+	ethereumMetrics = flag.Bool("metrics", false, "Expose ethereum metrics with debug_metrics jsonrpc call.")
 	// shh stuff
 	identityFile = flag.String("shh.identityfile", "", "Protocol identity file (private key used for asymmetric encryption)")
 	passwordFile = flag.String("shh.passwordfile", "", "Password file (password is used for symmetric encryption)")

--- a/geth/params/defaults.go
+++ b/geth/params/defaults.go
@@ -27,7 +27,7 @@ const (
 	ListenAddr = ":0"
 
 	// APIModules is a list of modules to expose via any type of RPC (HTTP, IPC, in-proc)
-	APIModules = "db,eth,net,web3,shh,personal,admin"
+	APIModules = "db,eth,net,web3,shh,personal,admin,debug"
 
 	// WSHost is a host interface for the websocket RPC server
 	WSHost = "localhost"


### PR DESCRIPTION
Enable debug api and add hack for ethereum metrics collection. See https://github.com/ethereum/go-ethereum/blob/master/metrics/metrics.go#L41 for details of this hack.

Allows to collect lots of metrics (db,trie,p2p,sync), I am primarily interested in this:
```
"p2p": {
      "InboundConnects": {
        "AvgRate01Min": 0,
        "AvgRate05Min": 0,
        "AvgRate15Min": 0,
        "MeanRate": 0,
        "Overall": 0
      },
      "InboundTraffic": {
        "AvgRate01Min": 0,
        "AvgRate05Min": 0,
        "AvgRate15Min": 0,
        "MeanRate": 0,
        "Overall": 0
      },
      "OutboundConnects": {
        "AvgRate01Min": 0,
        "AvgRate05Min": 0,
        "AvgRate15Min": 0,
        "MeanRate": 0,
        "Overall": 0
      },
      "OutboundTraffic": {
        "AvgRate01Min": 0,
        "AvgRate05Min": 0,
        "AvgRate15Min": 0,
        "MeanRate": 0,
        "Overall": 0
      }
```