### PR TITLE
Fix flags in statusd

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -46,6 +46,7 @@ var (
 	listenAddr = flag.String("listenaddr", ":30303", "IP address and port of this node (e.g. 127.0.0.1:30303)")
 	standalone = flag.Bool("standalone", true, "Don't actively connect to peers, wait for incoming connections")
 	bootnodes  = flag.String("bootnodes", "", "A list of bootnodes separated by comma")
+	discovery  = flag.Bool("discovery", false, "Enable discovery protocol")
 
 	// stats
 	statsEnabled = flag.Bool("stats", false, "Expose node stats via /debug/vars expvar endpoint or Prometheus (log by default)")
@@ -169,6 +170,8 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 		return nil, err
 	}
 
+	nodeConfig.ListenAddr = *listenAddr
+
 	// TODO(divan): move this logic into params package
 	if *nodeKeyFile != "" {
 		nodeConfig.NodeKeyFile = *nodeKeyFile
@@ -194,9 +197,9 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	if *standalone {
 		nodeConfig.BootClusterConfig.Enabled = false
 		nodeConfig.BootClusterConfig.BootNodes = nil
-	} else {
-		nodeConfig.Discovery = true
 	}
+
+	nodeConfig.Discovery = *discovery
 
 	// Even if standalone is true and discovery is disabled,
 	// it's possible to use bootnodes in NodeManager.PopulateStaticPeers().

--- a/cmd/statusd/whispercfg.go
+++ b/cmd/statusd/whispercfg.go
@@ -11,12 +11,6 @@ import (
 
 // whisperConfig creates node configuration object from flags
 func whisperConfig(nodeConfig *params.NodeConfig) (*params.NodeConfig, error) {
-
-	nodeConfig.ListenAddr = *listenAddr
-
-	nodeConfig.LogLevel = *logLevel
-
-	// whisper configuration
 	whisperConfig := nodeConfig.WhisperConfig
 	whisperConfig.Enabled = true
 	whisperConfig.IdentityFile = *identityFile
@@ -56,13 +50,6 @@ func whisperConfig(nodeConfig *params.NodeConfig) (*params.NodeConfig, error) {
 			return nil, err
 		}
 	}
-
-	// RPC configuration
-	// TODO(adam): clarify all these IPC/RPC/HTTPHost
-	if !*httpEnabled {
-		nodeConfig.HTTPHost = "" // HTTP RPC is disabled
-	}
-	nodeConfig.HTTPHost = "0.0.0.0"
 
 	return nodeConfig, nil
 }


### PR DESCRIPTION
Not all flags were assigned to `nodeConfig` and some of them were in wrong places.

I discovered this when tried to deploy a MailServer without discovery enabled but with static peers from our cluster.
