### PR TITLE
Create a script that auto-applies geth-patches #603

### DIFF
--- a/patcher
+++ b/patcher
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+# Default behaviour:
+# Reverts all patches in patch dir, notes down the ones
+# which were previously applied. Applies all from the beginning
+# and reports about previously unapplied patches. If there's
+# an error, reverts the last one and stops.
+#
+# Usage: ./patcher -p <base_path> -r -v
+# -p: <base_path> is where to apply to (a go-ethereum package)
+# -r: reverts all and exit if this flag is present
+# -v: verbose error reporting about failed patch
+#
+# If -p is not present, default path is as below ($basepath).
+
 patches=($(pwd)/geth-patches/*.patch)
 
 # Base path is vendor/github.com/ethereum/go-ethereum

--- a/patcher
+++ b/patcher
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
 
-patches="$(pwd)/geth-patches/*"
+patches=($(pwd)/geth-patches/*.patch)
 
 # Base path is vendor/github.com/ethereum/go-ethereum
 # unless specified.
 basepath="vendor/github.com/ethereum/go-ethereum"
-while getopts ":p:r" opt; do
+verbose=0
+while getopts :prv opt; do
 	case $opt in
 	p)
 		basepath=$OPTARG
     	;;
 	r)
-		# Reverts and exits.
-		for f in $patches; do
-			git apply "$f" --directory="$basepath" -R > /dev/null 2>&1
+		# Reverts in reverse order and exits.
+		for ((i=${#patches[@]}-1; i>=0; i--)); do
+			git apply "${patches[$i]}" --directory="$basepath" -R > /dev/null 2>&1
 		done
 		echo "Reverted all."
 		exit
+		;;
+	v)
+		verbose=1
 		;;
     \?)
     	echo "Invalid flag: -$OPTARG" >&2
@@ -30,19 +34,23 @@ applied=()
 echo -en "\\n"
 echo "Previously applied:"
 echo "==================="
-# Reverts and applies each patch to see which was previously applied.
-for f in $patches; do
-	git apply "$f" --directory="$basepath" -R --check > /dev/null 2>&1
+# Reverts every patch in reverse order to see
+# which was previously applied.
+for ((i=${#patches[@]}-1; i>=0; i--)); do
+	f=${patches[$i]}
+	git apply "$f" --directory="$basepath" -R > /dev/null 2>&1
 	if [ $? -eq 0 ]; then
 		applied+=("$f")
 		echo "$f"
 	fi
 done
 echo "==================="
-
 echo -en "\\n"
-for f in $patches; do
-	# If applied, don't apply.
+
+# Applies every patch from the beginning.
+for ((i=0; i<${#patches[@]}; i++)); do
+	f=${patches[$i]}
+	# If not applied, report it new.
 	has=0
 	for patch in "${applied[@]}"; do
 		if [ "$patch" == "$f" ]; then
@@ -50,12 +58,14 @@ for f in $patches; do
 			break
 		fi
 	done
-	if [ $has -eq 1 ]; then
-		continue
+	if [ $has -eq 0 ]; then
+		echo "Applying new: $f"
 	fi
-
-	echo "Applying: $f"
-	git apply "$f" --directory="$basepath"
+	if [ $verbose -eq 1 ]; then
+		git apply "$f" --directory="$basepath"
+	else
+		git apply "$f" --directory="$basepath" > /dev/null 2>&1
+	fi
 	if [ $? -eq 1 ]; then
 		echo -en "\\n"
 		echo "Failed and reverting: $f"

--- a/patcher
+++ b/patcher
@@ -60,6 +60,7 @@ for ((i=0; i<${#patches[@]}; i++)); do
 	done
 	if [ $has -eq 0 ]; then
 		echo "Applying new: $f"
+		echo -en "\\n"
 	fi
 	if [ $verbose -eq 1 ]; then
 		git apply "$f" --directory="$basepath"
@@ -67,13 +68,11 @@ for ((i=0; i<${#patches[@]}; i++)); do
 		git apply "$f" --directory="$basepath" > /dev/null 2>&1
 	fi
 	if [ $? -eq 1 ]; then
-		echo -en "\\n"
 		echo "Failed and reverting: $f"
 		git apply "$f" --directory="$basepath" -R > /dev/null 2>&1
 		echo -en "\\n"
 		exit
 	fi
-	echo -en "\\n"
 done
 
 echo -en "\\n"

--- a/patcher
+++ b/patcher
@@ -32,9 +32,8 @@ echo "Previously applied:"
 echo "==================="
 # Reverts and applies each patch to see which was previously applied.
 for f in $patches; do
-	git apply "$f" --directory="$basepath" -R > /dev/null 2>&1
+	git apply "$f" --directory="$basepath" -R --check > /dev/null 2>&1
 	if [ $? -eq 0 ]; then
-		git apply "$f" --directory="$basepath" > /dev/null 2>&1
 		applied+=("$f")
 		echo "$f"
 	fi

--- a/patcher
+++ b/patcher
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+patches="$(pwd)/geth-patches/*"
+
+# Base path is vendor/github.com/ethereum/go-ethereum
+# unless specified.
+basepath="vendor/github.com/ethereum/go-ethereum"
+while getopts ":p:r" opt; do
+	case $opt in
+	p)
+		basepath=$OPTARG
+    	;;
+	r)
+		# Reverts and exits.
+		for f in $patches; do
+			git apply "$f" --directory="$basepath" -R > /dev/null 2>&1
+		done
+		echo "Reverted all."
+		exit
+		;;
+    \?)
+    	echo "Invalid flag: -$OPTARG" >&2
+		exit
+    	;;
+	esac
+done
+
+applied=()
+
+echo -en "\\n"
+echo "Previously applied:"
+echo "==================="
+# Reverts and applies each patch to see which was previously applied.
+for f in $patches; do
+	git apply "$f" --directory="$basepath" -R > /dev/null 2>&1
+	if [ $? -eq 0 ]; then
+		git apply "$f" --directory="$basepath" > /dev/null 2>&1
+		applied+=("$f")
+		echo "$f"
+	fi
+done
+echo "==================="
+
+echo -en "\\n"
+for f in $patches; do
+	# If applied, don't apply.
+	has=0
+	for patch in "${applied[@]}"; do
+		if [ "$patch" == "$f" ]; then
+			has=1
+			break
+		fi
+	done
+	if [ $has -eq 1 ]; then
+		continue
+	fi
+
+	echo "Applying: $f"
+	git apply "$f" --directory="$basepath"
+	if [ $? -eq 1 ]; then
+		echo -en "\\n"
+		echo "Failed and reverting: $f"
+		git apply "$f" --directory="$basepath" -R > /dev/null 2>&1
+		echo -en "\\n"
+		exit
+	fi
+	echo -en "\\n"
+done
+
+echo -en "\\n"
+echo "Done."


### PR DESCRIPTION
Add patcher. Usage `./patcher -p <base_path> -r -v`. `-r` flag causes the script to revert all patches in reverse order and exit. `-v` is for making error reporting verbose.

Default behaviour:
- Checks each patch by reverting in reverse order. If it can, then stores each as an applied patch.
- Applies all patches starting from first one and reports the ones which haven't been applied previously. Also stops and reverts the last failing patch.

Closes #603
