### PR TITLE
Fix sync-and-exit option logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ jobs:
     # to still run, but currently does not work due to a bug
     if: type != pull_request
     script:
-      # sync the chain first; it will time out after 20 minutes
+      # sync the chain first; it will time out after 20 minutes; Rinkeby is networkid=4
       - make statusgo
-      - ./build/bin/statusd -datadir .ethereumtest -les -networkid=4 -sync-and-exit=20 -log WARN -standalone=false -discovery=false
+      - ./build/bin/statusd -datadir .ethereumtest/Rinkeby -les -networkid=4 -sync-and-exit=20 -log WARN -standalone=false -discovery=false
       - make test-e2e networkid=4
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ jobs:
     # to still run, but currently does not work due to a bug
     if: type != pull_request
     script:
-      # sync the chain first; it will time out after 10 minutes
+      # sync the chain first; it will time out after 20 minutes
       - make statusgo
-      - ./build/bin/statusd -les -networkid=4 -sync-and-exit=10 -log WARN -standalone=false -discovery=false
+      - ./build/bin/statusd -les -networkid=4 -sync-and-exit=20 -log WARN -standalone=false -discovery=false
       - make test-e2e networkid=4
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
     script:
       # sync the chain first; it will time out after 10 minutes
       - make statusgo
-      - ./build/bin/statusd -les -networkid=4 -sync-and-exit=10 -log DEBUG -standalone=false -discovery=false
+      - ./build/bin/statusd -les -networkid=4 -sync-and-exit=10 -log WARN -standalone=false -discovery=false
       - make test-e2e networkid=4
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ jobs:
     # to still run, but currently does not work due to a bug
     if: type != pull_request
     script:
-      - ./build/bin/statusd -les -networkid 4 -sync-and-exit
+      # sync the chain first; it will time out after 10 minutes
+      - ./build/bin/statusd -les -networkid=4 -sync-and-exit=10 -log DEBUG -standalone=false -discovery=false
       - make test-e2e networkid=4
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
     if: type != pull_request
     script:
       # sync the chain first; it will time out after 10 minutes
+      - make statusgo
       - ./build/bin/statusd -les -networkid=4 -sync-and-exit=10 -log DEBUG -standalone=false -discovery=false
       - make test-e2e networkid=4
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
     script:
       # sync the chain first; it will time out after 20 minutes
       - make statusgo
-      - ./build/bin/statusd -les -networkid=4 -sync-and-exit=20 -log WARN -standalone=false -discovery=false
+      - ./build/bin/statusd -datadir .ethereumtest -les -networkid=4 -sync-and-exit=20 -log WARN -standalone=false -discovery=false
       - make test-e2e networkid=4
 cache:
   directories:

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -183,7 +183,7 @@ func startCollectingStats(interruptCh <-chan struct{}, nodeManager common.NodeMa
 // that can be used in `os.Exit` to exit immediately when the function returns.
 // The special exit code `-1` is used if execution was interrupted.
 func syncAndStopNode(interruptCh <-chan struct{}, nodeManager common.NodeManager, timeout int) (exitCode int) {
-	log.Printf("Node will synchronize the chain and exit (timeout %d mins)", timeout)
+	log.Printf("syncAndStopNode: node will synchronize the chain and exit (timeout %d mins)", timeout)
 
 	if timeout < 0 {
 		log.Println("syncAndStopNode: invalid negative timeout value")
@@ -215,19 +215,18 @@ func syncAndStopNode(interruptCh <-chan struct{}, nodeManager common.NodeManager
 
 	select {
 	case err := <-errSync:
-		fmt.Printf("Failed to sync the chain: %v", err)
+		fmt.Printf("syncAndStopNode: failed to sync the chain: %v", err)
 		exitCode = 1
+	case <-doneSync:
 	case <-interruptCh:
 		// cancel context and return immediately if interrupted
 		// `-1` is used as a special exit code to denote interruption
 		return -1
 	}
 
-	<-doneSync
-
 	done, err := nodeManager.StopNode()
 	if err != nil {
-		log.Printf("Stop node err: %v", err)
+		log.Printf("syncAndStopNode: failed to stop the node: %v", err)
 		return 1
 	}
 	<-done

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -178,57 +178,6 @@ func startCollectingStats(interruptCh <-chan struct{}, nodeManager common.NodeMa
 	}
 }
 
-// syncAndStopNode tries to sync the blockchain and stop the node.
-// It returns an exit code (`0` if successful or `1` in case of error)
-// that can be used in `os.Exit` to exit immediately when the function returns.
-// The special exit code `-1` is used if execution was interrupted.
-func syncAndStopNode(interruptCh <-chan struct{}, nodeManager common.NodeManager, timeout int) (exitCode int) {
-	log.Printf("syncAndStopNode: node will synchronize the chain and exit (timeout %d mins)", timeout)
-
-	var (
-		ctx    context.Context
-		cancel context.CancelFunc
-	)
-
-	if timeout == 0 {
-		ctx, cancel = context.WithCancel(context.Background())
-		defer cancel()
-	} else {
-		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeout)*time.Minute)
-		defer cancel()
-	}
-
-	doneSync := make(chan struct{})
-	errSync := make(chan error)
-	go func() {
-		if err := nodeManager.EnsureSync(ctx); err != nil {
-			errSync <- err
-		}
-
-		close(doneSync)
-	}()
-
-	select {
-	case err := <-errSync:
-		fmt.Printf("syncAndStopNode: failed to sync the chain: %v", err)
-		exitCode = 1
-	case <-doneSync:
-	case <-interruptCh:
-		// cancel context and return immediately if interrupted
-		// `-1` is used as a special exit code to denote interruption
-		return -1
-	}
-
-	done, err := nodeManager.StopNode()
-	if err != nil {
-		log.Printf("syncAndStopNode: failed to stop the node: %v", err)
-		return 1
-	}
-	<-done
-
-	return
-}
-
 // makeNodeConfig parses incoming CLI options and returns node configuration object
 func makeNodeConfig() (*params.NodeConfig, error) {
 	devMode := !*prodMode

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -185,11 +185,6 @@ func startCollectingStats(interruptCh <-chan struct{}, nodeManager common.NodeMa
 func syncAndStopNode(interruptCh <-chan struct{}, nodeManager common.NodeManager, timeout int) (exitCode int) {
 	log.Printf("syncAndStopNode: node will synchronize the chain and exit (timeout %d mins)", timeout)
 
-	if timeout < 0 {
-		log.Println("syncAndStopNode: invalid negative timeout value")
-		return 1
-	}
-
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc

--- a/cmd/statusd/sync.go
+++ b/cmd/statusd/sync.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
 
@@ -38,7 +37,7 @@ func syncAndStopNode(interruptCh <-chan struct{}, nodeManager common.NodeManager
 
 	select {
 	case err := <-errSync:
-		fmt.Printf("syncAndStopNode: failed to sync the chain: %v", err)
+		log.Printf("syncAndStopNode: failed to sync the chain: %v", err)
 		exitCode = 1
 	case <-doneSync:
 	case <-interruptCh:

--- a/cmd/statusd/sync.go
+++ b/cmd/statusd/sync.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/status-im/status-go/geth/common"
+)
+
+func createContextFromTimeout(timeout int) (context.Context, context.CancelFunc) {
+	if timeout == 0 {
+		return context.WithCancel(context.Background())
+	}
+
+	return context.WithTimeout(context.Background(), time.Duration(timeout)*time.Minute)
+}
+
+// syncAndStopNode tries to sync the blockchain and stop the node.
+// It returns an exit code (`0` if successful or `1` in case of error)
+// that can be used in `os.Exit` to exit immediately when the function returns.
+// The special exit code `-1` is used if execution was interrupted.
+func syncAndStopNode(interruptCh <-chan struct{}, nodeManager common.NodeManager, timeout int) (exitCode int) {
+	log.Printf("syncAndStopNode: node will synchronize the chain and exit (timeout %d mins)", timeout)
+
+	ctx, cancel := createContextFromTimeout(timeout)
+	defer cancel()
+
+	doneSync := make(chan struct{})
+	errSync := make(chan error)
+	go func() {
+		if err := nodeManager.EnsureSync(ctx); err != nil {
+			errSync <- err
+		}
+		close(doneSync)
+	}()
+
+	select {
+	case err := <-errSync:
+		fmt.Printf("syncAndStopNode: failed to sync the chain: %v", err)
+		exitCode = 1
+	case <-doneSync:
+	case <-interruptCh:
+		// cancel context and return immediately if interrupted
+		// `-1` is used as a special exit code to denote interruption
+		return -1
+	}
+
+	done, err := nodeManager.StopNode()
+	if err != nil {
+		log.Printf("syncAndStopNode: failed to stop the node: %v", err)
+		return 1
+	}
+	<-done
+
+	return
+}

--- a/geth/node/manager.go
+++ b/geth/node/manager.go
@@ -574,7 +574,7 @@ func (m *NodeManager) ensureSync(ctx context.Context) error {
 			}
 			progress = downloader.Progress()
 			if progress.CurrentBlock >= progress.HighestBlock {
-				log.Debug("Synchronization completed", "current block", progress.CurrentBlock, "highest block", progress.HighestBlock)
+				log.Info("Synchronization completed", "current block", progress.CurrentBlock, "highest block", progress.HighestBlock)
 				return nil
 			}
 			log.Debug("Synchronization is not finished", "current", progress.CurrentBlock, "highest", progress.HighestBlock)

--- a/geth/node/manager.go
+++ b/geth/node/manager.go
@@ -555,6 +555,10 @@ func (m *NodeManager) ensureSync(ctx context.Context) error {
 
 	ticker := time.NewTicker(tickerResolution)
 	defer ticker.Stop()
+
+	progressTicker := time.NewTicker(time.Minute)
+	defer progressTicker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -573,10 +577,10 @@ func (m *NodeManager) ensureSync(ctx context.Context) error {
 				log.Debug("Synchronization completed", "current block", progress.CurrentBlock, "highest block", progress.HighestBlock)
 				return nil
 			}
-			log.Debug(
-				fmt.Sprintf("Synchronization is not finished yet: current block %d < highest block %d",
-					progress.CurrentBlock, progress.HighestBlock),
-			)
+			log.Debug("Synchronization is not finished", "current", progress.CurrentBlock, "highest", progress.HighestBlock)
+		case <-progressTicker.C:
+			progress = downloader.Progress()
+			log.Warn("Synchronization is not finished", "current", progress.CurrentBlock, "highest", progress.HighestBlock)
 		}
 	}
 }


### PR DESCRIPTION
Make sure that `-sync-and-exit` handles interruption properly.

cc @canercidam 

Relates to #568 