### PR TITLE
Ignore *.test files from all folders

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 build/bin
 statusd-data
 wnode-data
+**/*.test


### PR DESCRIPTION
I've been building lots of images lately, and this patch reduces
transferred amount of data from 500mb to 30mb which is somewhat speeds
the build process. In case if you are running lots of tests, of course.

