### PR TITLE
Fix patches so that they correctly indicate whether a file to be patched is new

### DIFF
--- a/_assets/patches/geth/0002-les-api-status.patch
+++ b/_assets/patches/geth/0002-les-api-status.patch
@@ -274,7 +274,7 @@ index 56f617a7d..f839f24e6 100644
  
  func (b *LesApiBackend) ChainConfig() *params.ChainConfig {
 diff --git a/les/backend.go b/les/backend.go
-index 333df920e..7d8cf3916 100644
+index 333df920e..71fbc181b 100644
 --- a/les/backend.go
 +++ b/les/backend.go
 @@ -75,6 +75,8 @@ type LightEthereum struct {

--- a/_assets/patches/geth/0003-dockerfiles-wnode-swarm.patch
+++ b/_assets/patches/geth/0003-dockerfiles-wnode-swarm.patch
@@ -1,6 +1,8 @@
 diff --git a/containers/docker/status-alpine/geth/Dockerfile b/containers/docker/status-alpine/geth/Dockerfile
---- a/containers/docker/status-alpine/geth/Dockerfile	1970-01-01 01:00:00.000000000 +0100
-+++ b/containers/docker/status-alpine/geth/Dockerfile	2017-09-19 17:03:51.000000000 +0200
+new file mode 100644
+index 000000000..2cc2177d0
+--- /dev/null
++++ b/containers/docker/status-alpine/geth/Dockerfile
 @@ -0,0 +1,20 @@
 +FROM alpine:3.5
 +
@@ -23,8 +25,10 @@ diff --git a/containers/docker/status-alpine/geth/Dockerfile b/containers/docker
 +
 +ENTRYPOINT ["/geth"]
 diff --git a/containers/docker/status-alpine/swarm/Dockerfile b/containers/docker/status-alpine/swarm/Dockerfile
---- a/containers/docker/status-alpine/swarm/Dockerfile	1970-01-01 01:00:00.000000000 +0100
-+++ b/containers/docker/status-alpine/swarm/Dockerfile	2017-09-19 17:03:51.000000000 +0200
+new file mode 100644
+index 000000000..685bf5ad9
+--- /dev/null
++++ b/containers/docker/status-alpine/swarm/Dockerfile
 @@ -0,0 +1,19 @@
 +FROM alpine:3.5
 +
@@ -46,8 +50,10 @@ diff --git a/containers/docker/status-alpine/swarm/Dockerfile b/containers/docke
 +
 +ENTRYPOINT ["/swarm"]
 diff --git a/containers/docker/status-alpine/wnode/Dockerfile b/containers/docker/status-alpine/wnode/Dockerfile
---- a/containers/docker/status-alpine/wnode/Dockerfile	1970-01-01 01:00:00.000000000 +0100
-+++ b/containers/docker/status-alpine/wnode/Dockerfile	2017-09-19 17:03:51.000000000 +0200
+new file mode 100644
+index 000000000..e160ff9d7
+--- /dev/null
++++ b/containers/docker/status-alpine/wnode/Dockerfile
 @@ -0,0 +1,19 @@
 +FROM alpine:3.5
 +

--- a/_assets/patches/geth/0004-whisper-notifications.patch
+++ b/_assets/patches/geth/0004-whisper-notifications.patch
@@ -1,6 +1,8 @@
 diff --git a/whisper/notifications/discovery.go b/whisper/notifications/discovery.go
---- a/whisper/notifications/discovery.go	1970-01-01 01:00:00.000000000 +0100
-+++ b/whisper/notifications/discovery.go	2017-09-19 17:03:51.000000000 +0200
+new file mode 100644
+index 000000000..de8ec85be
+--- /dev/null
++++ b/whisper/notifications/discovery.go
 @@ -0,0 +1,154 @@
 +package notifications
 +
@@ -157,8 +159,10 @@ diff --git a/whisper/notifications/discovery.go b/whisper/notifications/discover
 +	return nil
 +}
 diff --git a/whisper/notifications/provider.go b/whisper/notifications/provider.go
---- a/whisper/notifications/provider.go	1970-01-01 01:00:00.000000000 +0100
-+++ b/whisper/notifications/provider.go	2017-09-19 17:03:51.000000000 +0200
+new file mode 100644
+index 000000000..032463a6e
+--- /dev/null
++++ b/whisper/notifications/provider.go
 @@ -0,0 +1,59 @@
 +package notifications
 +
@@ -220,8 +224,10 @@ diff --git a/whisper/notifications/provider.go b/whisper/notifications/provider.
 +	return nil
 +}
 diff --git a/whisper/notifications/server.go b/whisper/notifications/server.go
---- a/whisper/notifications/server.go	1970-01-01 01:00:00.000000000 +0100
-+++ b/whisper/notifications/server.go	2017-09-19 17:03:51.000000000 +0200
+new file mode 100644
+index 000000000..7f27f0301
+--- /dev/null
++++ b/whisper/notifications/server.go
 @@ -0,0 +1,590 @@
 +package notifications
 +
@@ -814,8 +820,10 @@ diff --git a/whisper/notifications/server.go b/whisper/notifications/server.go
 +	return
 +}
 diff --git a/whisper/notifications/utils.go b/whisper/notifications/utils.go
---- a/whisper/notifications/utils.go	1970-01-01 01:00:00.000000000 +0100
-+++ b/whisper/notifications/utils.go	2017-09-19 17:03:51.000000000 +0200
+new file mode 100644
+index 000000000..106752186
+--- /dev/null
++++ b/whisper/notifications/utils.go
 @@ -0,0 +1,84 @@
 +package notifications
 +
@@ -902,9 +910,10 @@ diff --git a/whisper/notifications/utils.go b/whisper/notifications/utils.go
 +	return
 +}
 diff --git a/whisper/whisperv2/whisper.go b/whisper/whisperv2/whisper.go
---- a/whisper/whisperv2/whisper.go	2017-12-04 14:11:36.000000000 +0100
-+++ b/whisper/whisperv2/whisper.go	2017-12-03 19:32:31.000000000 +0100
-@@ -134,6 +134,13 @@
+index 61c36918d..908346999 100644
+--- a/whisper/whisperv2/whisper.go
++++ b/whisper/whisperv2/whisper.go
+@@ -134,6 +134,13 @@ func (self *Whisper) NewIdentity() *ecdsa.PrivateKey {
  	return key
  }
  
@@ -919,9 +928,10 @@ diff --git a/whisper/whisperv2/whisper.go b/whisper/whisperv2/whisper.go
  // of the specified public pair.
  func (self *Whisper) HasIdentity(key *ecdsa.PublicKey) bool {
 diff --git a/whisper/whisperv5/api.go b/whisper/whisperv5/api.go
---- a/whisper/whisperv5/api.go	2017-12-04 14:13:07.000000000 +0100
-+++ b/whisper/whisperv5/api.go	2017-12-04 17:40:41.000000000 +0100
-@@ -313,6 +313,16 @@
+index 96c4b0e6c..e3c2f4a97 100644
+--- a/whisper/whisperv5/api.go
++++ b/whisper/whisperv5/api.go
+@@ -313,6 +313,16 @@ func (api *PublicWhisperAPI) Post(ctx context.Context, req NewMessage) (bool, er
  	return true, api.w.Send(env)
  }
  
@@ -939,9 +949,10 @@ diff --git a/whisper/whisperv5/api.go b/whisper/whisperv5/api.go
  
  // Criteria holds various filter options for inbound messages.
 diff --git a/whisper/whisperv5/doc.go b/whisper/whisperv5/doc.go
---- a/whisper/whisperv5/doc.go	2017-12-03 18:18:01.000000000 +0100
-+++ b/whisper/whisperv5/doc.go	2017-12-04 17:40:41.000000000 +0100
-@@ -32,6 +32,8 @@
+index 7a57488bd..a6c9e610d 100644
+--- a/whisper/whisperv5/doc.go
++++ b/whisper/whisperv5/doc.go
+@@ -32,6 +32,8 @@ package whisperv5
  import (
  	"fmt"
  	"time"
@@ -950,7 +961,7 @@ diff --git a/whisper/whisperv5/doc.go b/whisper/whisperv5/doc.go
  )
  
  const (
-@@ -57,7 +59,7 @@
+@@ -57,7 +59,7 @@ const (
  
  	MaxMessageSize        = uint32(10 * 1024 * 1024) // maximum accepted size of a message.
  	DefaultMaxMessageSize = uint32(1024 * 1024)
@@ -959,7 +970,7 @@ diff --git a/whisper/whisperv5/doc.go b/whisper/whisperv5/doc.go
  
  	padSizeLimit      = 256 // just an arbitrary number, could be changed without breaking the protocol (must not exceed 2^24)
  	messageQueueLimit = 1024
-@@ -85,3 +87,15 @@
+@@ -85,3 +87,15 @@ type MailServer interface {
  	Archive(env *Envelope)
  	DeliverMail(whisperPeer *Peer, request *Envelope)
  }
@@ -976,9 +987,10 @@ diff --git a/whisper/whisperv5/doc.go b/whisper/whisperv5/doc.go
 +	Stop() error
 +}
 diff --git a/whisper/whisperv5/whisper.go b/whisper/whisperv5/whisper.go
---- a/whisper/whisperv5/whisper.go	2017-12-03 19:03:21.000000000 +0100
-+++ b/whisper/whisperv5/whisper.go	2017-12-04 17:40:41.000000000 +0100
-@@ -77,7 +77,8 @@
+index 85849ccce..c39e8b3e0 100644
+--- a/whisper/whisperv5/whisper.go
++++ b/whisper/whisperv5/whisper.go
+@@ -77,7 +77,8 @@ type Whisper struct {
  	statsMu sync.Mutex // guard stats
  	stats   Statistics // Statistics of whisper node
  
@@ -988,7 +1000,7 @@ diff --git a/whisper/whisperv5/whisper.go b/whisper/whisperv5/whisper.go
  }
  
  // New creates a Whisper client ready to communicate through the Ethereum P2P network.
-@@ -156,6 +157,11 @@
+@@ -156,6 +157,11 @@ func (w *Whisper) RegisterServer(server MailServer) {
  	w.mailServer = server
  }
  
@@ -1000,7 +1012,7 @@ diff --git a/whisper/whisperv5/whisper.go b/whisper/whisperv5/whisper.go
  // Protocols returns the whisper sub-protocols ran by this particular client.
  func (w *Whisper) Protocols() []p2p.Protocol {
  	return []p2p.Protocol{w.protocol}
-@@ -250,9 +256,9 @@
+@@ -250,9 +256,9 @@ func (w *Whisper) NewKeyPair() (string, error) {
  		return "", fmt.Errorf("failed to generate valid key")
  	}
  
@@ -1012,7 +1024,7 @@ diff --git a/whisper/whisperv5/whisper.go b/whisper/whisperv5/whisper.go
  	}
  
  	w.keyMu.Lock()
-@@ -265,45 +271,94 @@
+@@ -265,45 +271,94 @@ func (w *Whisper) NewKeyPair() (string, error) {
  	return id, nil
  }
  
@@ -1122,7 +1134,7 @@ diff --git a/whisper/whisperv5/whisper.go b/whisper/whisperv5/whisper.go
  	if key == nil {
  		return nil, fmt.Errorf("invalid id")
  	}
-@@ -336,6 +391,23 @@
+@@ -336,6 +391,23 @@ func (w *Whisper) GenerateSymKey() (string, error) {
  	return id, nil
  }
  
@@ -1146,7 +1158,7 @@ diff --git a/whisper/whisperv5/whisper.go b/whisper/whisperv5/whisper.go
  // AddSymKeyDirect stores the key, and returns its id.
  func (w *Whisper) AddSymKeyDirect(key []byte) (string, error) {
  	if len(key) != aesKeyLength {
-@@ -447,7 +519,7 @@
+@@ -447,7 +519,7 @@ func (w *Whisper) Send(envelope *Envelope) error {
  
  // Start implements node.Service, starting the background data propagation thread
  // of the Whisper protocol.
@@ -1155,7 +1167,7 @@ diff --git a/whisper/whisperv5/whisper.go b/whisper/whisperv5/whisper.go
  	log.Info("started whisper v." + ProtocolVersionStr)
  	go w.update()
  
-@@ -456,6 +528,12 @@
+@@ -456,6 +528,12 @@ func (w *Whisper) Start(*p2p.Server) error {
  		go w.processQueue()
  	}
  
@@ -1168,7 +1180,7 @@ diff --git a/whisper/whisperv5/whisper.go b/whisper/whisperv5/whisper.go
  	return nil
  }
  
-@@ -463,6 +541,13 @@
+@@ -463,6 +541,13 @@ func (w *Whisper) Start(*p2p.Server) error {
  // of the Whisper protocol.
  func (w *Whisper) Stop() error {
  	close(w.quit)
@@ -1182,7 +1194,7 @@ diff --git a/whisper/whisperv5/whisper.go b/whisper/whisperv5/whisper.go
  	log.Info("whisper stopped")
  	return nil
  }
-@@ -856,3 +941,30 @@
+@@ -856,3 +941,30 @@ func GenerateRandomID() (id string, err error) {
  	id = common.Bytes2Hex(buf)
  	return id, err
  }

--- a/_assets/patches/geth/0006-latest-cht.patch
+++ b/_assets/patches/geth/0006-latest-cht.patch
@@ -1,5 +1,5 @@
 diff --git a/light/postprocess.go b/light/postprocess.go
-index e7e51388..dc6562be 100644
+index e7e513880..dc6562be8 100644
 --- a/light/postprocess.go
 +++ b/light/postprocess.go
 @@ -66,12 +66,20 @@ var (

--- a/_assets/patches/geth/0010-geth-17-fix-npe-in-filter-system.patch
+++ b/_assets/patches/geth/0010-geth-17-fix-npe-in-filter-system.patch
@@ -1,5 +1,5 @@
 diff --git a/eth/filters/filter_system.go b/eth/filters/filter_system.go
-index e08cedb274..a234709c63 100644
+index e08cedb27..a234709c6 100644
 --- a/eth/filters/filter_system.go
 +++ b/eth/filters/filter_system.go
 @@ -109,7 +109,11 @@ func NewEventSystem(mux *event.TypeMux, backend Backend, lightMode bool) *EventS
@@ -57,4 +57,3 @@ index e08cedb274..a234709c63 100644
  
  	// Unsubscribe all events
  	defer sub.Unsubscribe()
-

--- a/_assets/patches/geth/README.md
+++ b/_assets/patches/geth/README.md
@@ -7,6 +7,15 @@ However, there are a few changes has been made to the upstream, that are specifi
 
 We try to minimize number and amount of changes in those patches as much as possible, and whereas possible, to contribute changes into the upstream.
 
+# Creating patches
+
+Instructions for creating a patch from the command line:
+
+1. Enter the command line at the status-im/go-ethereum repo root
+1. Create the patch:
+    1. If you already have a commit that represents the change, find its SHA1 (e.g. `$COMMIT_SHA1`) and do `git diff $COMMIT_SHA1 > file.patch`
+    1. If the files are staged, do `git diff --cached > file.patch`
+
 # Patches
 
  - [`0000-accounts-hd-keys.patch`](./0000-accounts-hd-keys.patch) — adds support for HD extended keys (links/docs?)
@@ -16,6 +25,7 @@ We try to minimize number and amount of changes in those patches as much as poss
  - [`0006-latest-cht.patch`](./0006-latest-cht.patch) – updates CHT root hashes, should be updated regularly to keep sync fast, until proper Trusted Checkpoint sync is not implemented as part of LES/2 protocol.
  - [`0007-README.patch`](./0007-README.patch) — update upstream README.md.
  - [`0010-geth-17-fix-npe-in-filter-system.patch`](./0010-geth-17-fix-npe-in-filter-system.patch) - Temp patch for 1.7.x to fix a NPE in the filter system.
+
 # Updating upstream version
 
 When a new stable release of `go-ethereum` comes out, we need to upgrade our fork and vendored copy.

--- a/_assets/patches/patcher
+++ b/_assets/patches/patcher
@@ -13,7 +13,7 @@
 #
 # If -p is not present, default path is as below ($basepath).
 
-patches=($(pwd)/_assets/patches/geth/*.patch)
+patches=($( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/geth/*.patch)
 
 # Base path is vendor/github.com/ethereum/go-ethereum
 # unless specified.


### PR DESCRIPTION
When working to create new patches for Whisper V6, at some point I went back to upstream 1.7.3 and started applying each patch individually. Patches 3 and 4 failed because they contain new files and the patch entries did not describe them as such (it described them as file content changes):

![image](https://user-images.githubusercontent.com/138074/36061569-47077056-0e5c-11e8-96b8-9b8d71444145.png)

This caused `git apply` to fail because it expected to patch an existing file (`a/whisper/*`) which wasn't there. This PR regenerates all of the patch files by applying the following repeatable process:

1. take the first patch file and `git apply` it;
1. do a `git add .` and `git diff --cached > 0001.patch`; *the fact that we stage the files and then use the `--cached` argument ensures that the new files are taken into account*
1. Commit and repeat process with following patch.

The PR also does a minor tweak to the `patcher` tool in which the tool uses the patch folder underneath it, even if the current directory refers to somewhere else on the drive. This makes it straightforward to go to the `go-ethereum` repo and apply the patches from there using `~/go/src/github.com/status-im/status-go/patcher -p .`