### PR TITLE
Add ConnectionChange API call to backend

### DIFF
--- a/geth/api/api.go
+++ b/geth/api/api.go
@@ -221,3 +221,15 @@ func (api *StatusAPI) NotifyUsers(message string, payload fcm.NotificationPayloa
 
 	return err
 }
+
+// ConnectionChange handles network state changes logic.
+func (api *StatusAPI) ConnectionChange(typ string, expensive bool) {
+	state := ConnectionState{
+		Type:      NewConnectionType(typ),
+		Expensive: expensive,
+	}
+	if typ == "none" {
+		state.Offline = true
+	}
+	api.b.ConnectionChange(state)
+}

--- a/geth/api/backend.go
+++ b/geth/api/backend.go
@@ -30,6 +30,7 @@ type StatusBackend struct {
 	txQueueManager  *transactions.Manager
 	jailManager     common.JailManager
 	newNotification common.NotificationConstructor
+	connectionState ConnectionState
 }
 
 // NewStatusBackend create a new NewStatusBackend instance
@@ -223,4 +224,13 @@ func (m *StatusBackend) registerHandlers() error {
 	rpcClient.RegisterHandler("eth_accounts", m.accountManager.AccountsRPCHandler())
 	rpcClient.RegisterHandler("eth_sendTransaction", m.txQueueManager.SendTransactionRPCHandler)
 	return nil
+}
+
+// ConnectionChange handles network state changes logic.
+func (m *StatusBackend) ConnectionChange(state ConnectionState) {
+	log.Info("Network state change", "old", m.connectionState, "new", state)
+	m.connectionState = state
+
+	// logic of handling state changes here
+	// restart node? force peers reconnect? etc
 }

--- a/geth/api/connection.go
+++ b/geth/api/connection.go
@@ -34,9 +34,10 @@ func NewConnectionType(s string) ConnectionType {
 	return ConnectionUnknown
 }
 
+// ConnectionType constants
 const (
-	ConnectionCellular = iota // default value, LTE, 4G, 3G, EDGE, etc.
-	ConnectionWifi            // WIFI or iOS simulator
+	ConnectionCellular ConnectionType = iota // default value, LTE, 4G, 3G, EDGE, etc.
+	ConnectionWifi                           // WIFI or iOS simulator
 	ConnectionUnknown
 )
 

--- a/geth/api/connection.go
+++ b/geth/api/connection.go
@@ -7,8 +7,7 @@ import (
 // ConnectionState represents device connection state and type,
 // as reported by mobile framework.
 //
-// Zero value represents default assumption about network
-// connection until first update — online, on cellular and not expensive.
+// Zero value represents default assumption about network (online and unknown type).
 type ConnectionState struct {
 	Offline   bool           `json:"offline"`
 	Type      ConnectionType `json:"type"`

--- a/geth/api/connection.go
+++ b/geth/api/connection.go
@@ -36,9 +36,9 @@ func NewConnectionType(s string) ConnectionType {
 
 // ConnectionType constants
 const (
-	ConnectionCellular ConnectionType = iota // default value, LTE, 4G, 3G, EDGE, etc.
-	ConnectionWifi                           // WIFI or iOS simulator
-	ConnectionUnknown
+	ConnectionUnknown  ConnectionType = iota
+	ConnectionCellular                // cellular, LTE, 4G, 3G, EDGE, etc.
+	ConnectionWifi                    // WIFI or iOS simulator
 )
 
 // String formats ConnectionState for logs. Implements Stringer.

--- a/geth/api/connection.go
+++ b/geth/api/connection.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"fmt"
+)
+
+// ConnectionState represents device connection state and type,
+// as reported by mobile framework.
+//
+// Zero value represents default assumption about network
+// connection until first update — online, on cellular and not expensive.
+type ConnectionState struct {
+	Offline   bool           `json:"offline"`
+	Type      ConnectionType `json:"type"`
+	Expensive bool           `json:"expensive"`
+}
+
+// ConnectionType represents description of available
+// connection types as reported by React Native (see
+// https://facebook.github.io/react-native/docs/netinfo.html)
+// We're interested mainly in 'wifi' and 'cellular', but
+// other types are also may be used.
+type ConnectionType byte
+
+// NewConnectionType creates new ConnectionType from string.
+func NewConnectionType(s string) ConnectionType {
+	switch s {
+	case "cellular":
+		return ConnectionCellular
+	case "wifi":
+		return ConnectionWifi
+	}
+
+	return ConnectionUnknown
+}
+
+const (
+	ConnectionCellular = iota // default value, LTE, 4G, 3G, EDGE, etc.
+	ConnectionWifi            // WIFI or iOS simulator
+	ConnectionUnknown
+)
+
+// String formats ConnectionState for logs. Implements Stringer.
+func (c ConnectionState) String() string {
+	if c.Offline {
+		return "offline"
+	}
+
+	var typ string
+	switch c.Type {
+	case ConnectionWifi:
+		typ = "wifi"
+	case ConnectionCellular:
+		typ = "cellular"
+	default:
+		typ = "unknown"
+	}
+
+	if c.Expensive {
+		return fmt.Sprintf("%s (expensive)", typ)
+	}
+
+	return typ
+}

--- a/geth/api/connection_test.go
+++ b/geth/api/connection_test.go
@@ -26,7 +26,7 @@ func TestConnectionState(t *testing.T) {
 		{
 			"zero value",
 			ConnectionState{},
-			"cellular",
+			"unknown",
 		},
 		{
 			"offline",

--- a/geth/api/connection_test.go
+++ b/geth/api/connection_test.go
@@ -1,0 +1,59 @@
+package api
+
+import "testing"
+
+func TestConnectionType(t *testing.T) {
+	c := NewConnectionType("wifi")
+	if c != ConnectionWifi {
+		t.Fatalf("Wrong connection type: %s", c)
+	}
+	c = NewConnectionType("cellular")
+	if c != ConnectionCellular {
+		t.Fatalf("Wrong connection type: %s", c)
+	}
+	c = NewConnectionType("bluetooth")
+	if c != ConnectionUnknown {
+		t.Fatalf("Wrong connection type: %s", c)
+	}
+}
+
+func TestConnectionState(t *testing.T) {
+	tests := []struct {
+		name     string
+		state    ConnectionState
+		expected string
+	}{
+		{
+			"zero value",
+			ConnectionState{},
+			"cellular",
+		},
+		{
+			"offline",
+			ConnectionState{Offline: true},
+			"offline",
+		},
+		{
+			"wifi",
+			ConnectionState{Type: ConnectionWifi},
+			"wifi",
+		},
+		{
+			"wifi tethered",
+			ConnectionState{Type: ConnectionWifi, Expensive: true},
+			"wifi (expensive)",
+		},
+		{
+			"unknown",
+			ConnectionState{Type: ConnectionUnknown},
+			"unknown",
+		},
+	}
+
+	for _, test := range tests {
+		str := test.state.String()
+		if str != test.expected {
+			t.Fatalf("Expected String() to return '%s', got '%s'", test.expected, str)
+		}
+	}
+}

--- a/geth/api/connection_test.go
+++ b/geth/api/connection_test.go
@@ -5,15 +5,15 @@ import "testing"
 func TestConnectionType(t *testing.T) {
 	c := NewConnectionType("wifi")
 	if c != ConnectionWifi {
-		t.Fatalf("Wrong connection type: %s", c)
+		t.Fatalf("Wrong connection type: %v", c)
 	}
 	c = NewConnectionType("cellular")
 	if c != ConnectionCellular {
-		t.Fatalf("Wrong connection type: %s", c)
+		t.Fatalf("Wrong connection type: %v", c)
 	}
 	c = NewConnectionType("bluetooth")
 	if c != ConnectionUnknown {
-		t.Fatalf("Wrong connection type: %s", c)
+		t.Fatalf("Wrong connection type: %v", c)
 	}
 }
 

--- a/lib/library.go
+++ b/lib/library.go
@@ -449,3 +449,9 @@ func AddPeer(enode *C.char) *C.char {
 	err := statusAPI.NodeManager().AddPeer(C.GoString(enode))
 	return makeJSONResponse(err)
 }
+
+// ConnectionChange handles network state changes as reported
+// by ReactNative (see https://facebook.github.io/react-native/docs/netinfo.html)
+func ConnectionChange(typ *C.char, expensive C.int) {
+	statusAPI.ConnectionChange(C.GoString(typ), expensive == 1)
+}


### PR DESCRIPTION
This PR adds a new backend API method `ConnectionChange` for handling network state changes, as reported by React-Native (or whoever is using library). The main objective is to have an information about network reachability/state in a status-go layer, and be able to handle those changes appropriately (i.e. restart node, reconnect to peers, limit connections for connections over hotspot, etc).

API is simple: `ConnectionChange(type string, expensive bool)`, where type is mirroring values from RN docs: https://facebook.github.io/react-native/docs/netinfo.html

Currently, there is no logic implemented, just updating connection state internally. Investigating best choices for each network change case shall be done in follow-up issues.

`status-react` support is needed to make it work.

Related: https://github.com/status-im/status-go/issues/639