### PR TITLE
[#639] Disable filter removal in `go-ethereum`.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -109,7 +109,7 @@
     "whisper/notifications",
     "whisper/whisperv5"
   ]
-  revision = "6b396471b29c6fdf9f05eb85dd0eaf8544ede3d9"
+  revision = "6bba5c70ba424f5efb448536ae3d000f96e7cc9e"
   source = "https://github.com/status-im/go-ethereum.git"
 
 [[projects]]

--- a/_assets/patches/geth/0012-disable-filter-timeout.patch
+++ b/_assets/patches/geth/0012-disable-filter-timeout.patch
@@ -1,0 +1,16 @@
+diff --git a/whisper/whisperv5/api.go b/whisper/whisperv5/api.go
+index e3c2f4a97..96d895fdc 100644
+--- a/whisper/whisperv5/api.go
++++ b/whisper/whisperv5/api.go
+@@ -33,7 +33,10 @@ import (
+ )
+ 
+ const (
+-	filterTimeout = 300 // filters are considered timeout out after filterTimeout seconds
++	// HACK: make the filter essentially never timeout (1 year of timeout time)
++	// It's a hack, but that simplifies rebasing process, because the patch consists
++	// only of 1 LoC change (excluding this comment).
++	filterTimeout = 525600 * 60 // filters are considered timeout out after filterTimeout seconds
+ )
+ 
+ var (

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv5/api.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv5/api.go
@@ -33,7 +33,10 @@ import (
 )
 
 const (
-	filterTimeout = 300 // filters are considered timeout out after filterTimeout seconds
+	// HACK: make the filter essentially never timeout (1 year of timeout time)
+	// It's a hack, but that simplifies rebasing process, because the patch consists
+	// only of 1 LoC change (excluding this comment).
+	filterTimeout = 525600 * 60 // filters are considered timeout out after filterTimeout seconds
 )
 
 var (


### PR DESCRIPTION
Quickfix for #639 and https://github.com/status-im/status-react/issues/3116