### PR TITLE
Add docker-image-tag target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,11 @@ statusgo-library: ##@cross-compile Build status-go as static library for current
 
 docker-image: ##@docker Build docker image (use DOCKER_IMAGE_NAME to set the image name)
 	@echo "Building docker image..."
-	docker build --file _assets/build/Dockerfile --build-arg "build_tags=$(BUILD_TAGS)" . -t $(DOCKER_IMAGE_NAME)
+	docker build --file _assets/build/Dockerfile --build-arg "build_tags=$(BUILD_TAGS)" . -t $(DOCKER_IMAGE_NAME):latest
+
+docker-image-tag: ##@docker Tag DOCKER_IMAGE_NAME:latest with a tag following pattern $GIT_SHA[:8]-$BUILD_TAGS
+	@echo "Tagging docker image..."
+	docker tag $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME):$(shell BUILD_TAGS="$(BUILD_TAGS)" ./_assets/ci/get-docker-image-tag.sh)
 
 xgo-docker-images: ##@docker Build xgo docker images
 	@echo "Building xgo docker images..."

--- a/_assets/ci/get-docker-image-tag.sh
+++ b/_assets/ci/get-docker-image-tag.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 #
-# Description
+# Creates a string in a format: $GIT_SHA[:8][-$BUILD_TAGS]
+# where $BUILD_TAGS is optional and if present all spaces
+# are replaced by a hyphen (-).
+#
+# For example: BUILD_TAGS="tag1 tag2" ./_assets/ci/get-docker-image-tag.sh
+# will produce "12345678-tag1-tag2".
 
 set -e -o pipefail
 

--- a/_assets/ci/get-docker-image-tag.sh
+++ b/_assets/ci/get-docker-image-tag.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Description
+
+set -e -o pipefail
+
+tag="$(git rev-parse HEAD | cut -c 1-8)"
+
+if [ ! -z "$BUILD_TAGS" ]; then
+    tag="$tag-$(echo $BUILD_TAGS | sed -e "s/[[:space:]]/-/g")"
+fi
+
+echo $tag


### PR DESCRIPTION
docker-image-tag target in Makefile is used to tag docker images in a unified and consistent manner.