### PR TITLE
Add node_peers Prometheus metric

### DIFF
--- a/_assets/compose/wnode-test-cluster/docker-compose.yml
+++ b/_assets/compose/wnode-test-cluster/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: ethereum/client-go:alltools-latest
     entrypoint: bootnode
     command: -addr=:30303 -nodekey /static/keys/bootnode.key
+    ports:
+      - 30303
     volumes:
       - ./../../../static/keys:/static/keys:ro
     networks:
@@ -12,10 +14,21 @@ services:
 
   wnode:
     image: status-go:latest
-    command: statusd -les=false -shh -listenaddr=:30303 -discovery=true -http -log DEBUG -stats -standalone=false -bootnodes=enode://3f04db09bedc8d85a198de94c84da73aa7782fafc61b28c525ec5cca5a6cc16be7ebbb5cd001780f71d8408d35a2f6326faa1e524d9d8875294172ebec988743@172.16.238.10:30303
+    command:
+      - statusd
+      - "-les=false"
+      - "-shh"
+      - "-listenaddr=:30303"
+      - "-discovery=true"
+      - "-standalone=false"
+      - "-bootnodes=enode://3f04db09bedc8d85a198de94c84da73aa7782fafc61b28c525ec5cca5a6cc16be7ebbb5cd001780f71d8408d35a2f6326faa1e524d9d8875294172ebec988743@172.16.238.10:30303"
+      - "-http"
+      - "-httphost=0.0.0.0"
+      - "-log DEBUG"
     ports:
       - 8080
       - 8545
+      - 30303
     networks:
       cluster:
     depends_on:

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -159,6 +159,12 @@ func startCollectingStats(interruptCh <-chan struct{}, nodeManager common.NodeMa
 
 	server := metrics.NewMetricsServer(*statsAddr)
 	go func() {
+		// server may be nil if `-stats` flag is used
+		// but the binary is compiled without metrics enabled
+		if server == nil {
+			return
+		}
+
 		err := server.ListenAndServe()
 		switch err {
 		case http.ErrServerClosed:

--- a/metrics/node/node_info_log.go
+++ b/metrics/node/node_info_log.go
@@ -1,4 +1,4 @@
-// +build !metrics metrics,prometheus
+// +build !metrics
 
 package node
 

--- a/metrics/node/node_info_prometheus.go
+++ b/metrics/node/node_info_prometheus.go
@@ -1,0 +1,36 @@
+// +build metrics,prometheus
+
+package node
+
+import (
+	"github.com/ethereum/go-ethereum/node"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/status-im/status-go/geth/log"
+)
+
+var (
+	nodePeersGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "node_peers",
+			Help: "A number of node peers",
+		},
+		[]string{},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(nodePeersGauge)
+}
+
+func updateNodeInfo(node *node.Node) {}
+
+func updateNodePeers(node *node.Node) {
+	server := node.Server()
+	if server == nil {
+		log.Warn("Failed to get a server")
+		return
+	}
+
+	peerCount := server.PeerCount()
+	nodePeersGauge.WithLabelValues().Set(float64(peerCount))
+}


### PR DESCRIPTION
`node_peers` gauge metric is added to Prometheus.
