### PR TITLE
Wait till the node is stopped is start was executd before stop

### DIFF
--- a/geth/api/api.go
+++ b/geth/api/api.go
@@ -58,7 +58,17 @@ func (api *StatusAPI) StartNode(config *params.NodeConfig) error {
 // StartNodeAsync start Status node, fails if node is already started
 // Returns immediately w/o waiting for node to start (see node.ready)
 func (api *StatusAPI) StartNodeAsync(config *params.NodeConfig) <-chan error {
-	return runAsync(func() error { return api.StartNode(config) })
+	if !api.b.IsNodeRunning() {
+		return runAsync(func() error { return api.StartNode(config) })
+	}
+	return runAsync(func() error {
+		node, err := api.b.NodeManager().Node()
+		if err != nil {
+			return err
+		}
+		node.Wait()
+		return api.StartNode(config)
+	})
 }
 
 // StopNode stop Status node. Stopped node cannot be resumed.

--- a/t/e2e/api/api_test.go
+++ b/t/e2e/api/api_test.go
@@ -242,3 +242,15 @@ func (s *APITestSuite) TestNodeStartCrash() {
 	// cleanup
 	s.NoError(s.api.StopNode())
 }
+
+func (s *APITestSuite) TestConcurrentStopAndStartNodeAsyncWhenNodeIsRunning() {
+	nodeConfig, err := e2e.MakeTestNodeConfig(GetNetworkID())
+	s.NoError(err)
+	s.NoError(<-s.api.StartNodeAsync(nodeConfig))
+	s.True(s.api.NodeManager().IsNodeRunning())
+	startChan := s.api.StartNodeAsync(nodeConfig)
+	s.NoError(<-s.api.StopNodeAsync())
+	s.NoError(<-startChan)
+	s.True(s.api.NodeManager().IsNodeRunning())
+	s.NoError(s.api.StopNode())
+}


### PR DESCRIPTION
I am not 100% sure but from logs it looks like that code that stopped a node was executed after node was started. I will add this workaround, and make tests, but we should add API like EnsureNodeRunning(config) and do all the logic internally.