### PR TITLE
Remove mentions of our fork of `go-ethereum` from docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It's written in Go and requires Go 1.8 or above.
 
 It uses Makefile to do most common actions. See `make help` output for available commands.
 
-status-go uses [ethereum-go](https://github.com/status-im/go-ethereum) with [some patches applied](./_assets/patches/geth) in it, located under [`vendor/`](./vendor/github.com/ethereum/go-ethereum) directory. See [geth patches README](./_assets/patches/geth/README.md) for more info.
+status-go uses [go-ethereum](https://github.com/ethereum/go-ethereum) with [some patches applied](./_assets/patches/geth) in it, located under [`vendor/`](./vendor/github.com/ethereum/go-ethereum) directory. See [geth patches README](./_assets/patches/geth/README.md) for more info.
 
 # Build
 There are two main modes status-go can be built:

--- a/_assets/docs/DEPENDENCIES.md
+++ b/_assets/docs/DEPENDENCIES.md
@@ -49,10 +49,10 @@ file is changed, `dep ensure` will re-generate `Gopkg.lock` as well.
 
 ## Updating `Geth`
 
-1. Update `develop` branch in [`status-im/go-ethereum`](https://github.com/status-im/go-ethereum/tree/develop).
+1. (for major releases) Update the branch name in `Gopkg.toml`.
 2. Update the `go-ethereum` dependency: `dep ensure -v -update github.com/ethereum/go-ethereum`.
-3. Make sure that `[[constraint]]` statements in `status-go/Gopkg.toml` contains the same SHAs as `go-ethereum/vendor/vendor.json`.
-4. Update vendor files in `status-go`, running `dep ensure`.
+3. Update vendor files in `status-go`, and apply patches by running `make dep-ensure`.
+4. Commit patches.
 5. Commit `Gopkg.lock`, `Gopkg.toml` and `vendor` directories.
 
 


### PR DESCRIPTION
Cleaning-up leftovers.