### PR TITLE
Adding update-geth target #668

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@ ignored = ["github.com/ethereum/go-ethereum/whisper/notifications"]
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"
-  branch = "swog"
+  branch = "release/1.7"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@ ignored = ["github.com/ethereum/go-ethereum/whisper/notifications"]
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"
-  branch = "release/1.7"
+  branch = "swog"
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"

--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,8 @@ ifdef GETH_BRANCH
 	@# Update go-ethereum contraint branch
 	@sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
 endif
-	@#dep ensure -v -update github.com/ethereum/go-ethereum
-	@#$(MAKE) dep-ensure
+	@dep ensure -v -update github.com/ethereum/go-ethereum
+	@$(MAKE) dep-ensure
 	git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
 ifeq ($(git diff --cached --quiet), 0)
 		echo "No changes to commit" && exit 1

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,9 @@ dep-install: ##@dependencies Install vendoring tool
 update-geth: ##@dependencies Update geth (use BRANCH to set the branch name)
 	#TODO add line to dynamically change branch parameter here
 	dep ensure -v -update github.com/ethereum/go-ethereum
-	$(MAKE) -f $(THIS_FILE) dep-ensure
+	$(MAKE) dep-ensure
+	#Commit patches.
+	#Commit Gopkg.lock, Gopkg.toml and vendor directories.
 
 patch: ##@patching Revert and apply all patches
 	./_assets/patches/patcher

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ ifdef GETH_BRANCH
 	@# escape slashes
 	GETH_BRANCH=$(echo $GETH_BRANCH | sed 's@\/@\\\/@g')
 	@# Update go-ethereum contraint branch
-	sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
+	@sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
 endif
 	dep ensure -v -update github.com/ethereum/go-ethereum
 	$(MAKE) dep-ensure

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ dep-ensure: ##@dependencies Dep ensure and apply all patches
 dep-install: ##@dependencies Install vendoring tool
 	go get -u github.com/golang/dep/cmd/dep
 
-update-geth: ##@dependencies Update geth (use GETH_BRANCH to set the branch name)
+update-geth: ##@dependencies Update geth (use GETH_BRANCH to optionally set the geth branch name)
 ifdef GETH_BRANCH
 	@# escape slashes
 	@GETH_BRANCH=$(echo $GETH_BRANCH | sed 's@\/@\\\/@g')

--- a/Makefile
+++ b/Makefile
@@ -168,13 +168,18 @@ dep-ensure: ##@dependencies Dep ensure and apply all patches
 dep-install: ##@dependencies Install vendoring tool
 	go get -u github.com/golang/dep/cmd/dep
 
-update-geth: ##@dependencies Update geth (use BRANCH to set the branch name)
-	# Update go-ethereum contraint branch
-	sed -i 'N;N;s/\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)/\1 '"\"${BRANCH}\""'/g' Gopkg.toml
+update-geth: ##@dependencies Update geth (use GETH_BRANCH to set the branch name)
+	# Update go-ethereum contraint branch if branch is provided
+ifdef GETH_BRANCH
+		# escape slashes
+		GETH_BRANCH=$(echo $GETH_BRANCH | sed 's@\/@\\\/@g')
+		@echo ${GETH_BRANCH}
+		sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
+endif
 	dep ensure -v -update github.com/ethereum/go-ethereum
 	$(MAKE) dep-ensure
-	git add Gopkg.lock Gopkg.toml vendor/
-	git add _assets/patches
+	git add Gopkg.lock Gopkg.toml vendor/ _assets/patches
+	git commit -m "Updating Geth"
 
 patch: ##@patching Revert and apply all patches
 	./_assets/patches/patcher

--- a/Makefile
+++ b/Makefile
@@ -170,11 +170,10 @@ dep-install: ##@dependencies Install vendoring tool
 	go get -u github.com/golang/dep/cmd/dep
 
 update-geth: ##@dependencies Update geth (use BRANCH to set the branch name)
-	#TODO add line to dynamically change branch parameter here
+	# Update go-ethereum contraint branch
+	sed 'N;N;s/\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)/\1 '"\"${BRANCH}\""'/g' Gopkg.toml
 	dep ensure -v -update github.com/ethereum/go-ethereum
 	$(MAKE) dep-ensure
-	#Commit patches.
-	#Commit Gopkg.lock, Gopkg.toml and vendor directories.
 	git add Gopkg.lock Gopkg.toml vendor/
 	git add _assets/patches
 

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ ifdef GETH_BRANCH
 	@sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
 endif
 	@dep ensure -v -update github.com/ethereum/go-ethereum
-	@$(MAKE) dep-ensure
+	$(MAKE) dep-ensure
 	git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
 ifeq ($(git diff --cached --quiet), 0)
 	@echo "No changes to commit" && exit 1

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ endif
 	$(MAKE) dep-ensure
 	git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
 ifeq ($(git diff --cached --quiet), 0)
-	@echo "No changes to commit" && exit 1
+	@echo "No changes to commit. Geth up to date." && exit 1
 endif
 	@git commit --quiet -m "Updating Geth"
 	@echo "Geth updated."

--- a/Makefile
+++ b/Makefile
@@ -169,17 +169,17 @@ dep-install: ##@dependencies Install vendoring tool
 	go get -u github.com/golang/dep/cmd/dep
 
 update-geth: ##@dependencies Update geth (use GETH_BRANCH to set the branch name)
-	# Update go-ethereum contraint branch if branch is provided
 ifdef GETH_BRANCH
-		# escape slashes
-		GETH_BRANCH=$(echo $GETH_BRANCH | sed 's@\/@\\\/@g')
-		@echo ${GETH_BRANCH}
-		sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
+	@# escape slashes
+	GETH_BRANCH=$(echo $GETH_BRANCH | sed 's@\/@\\\/@g')
+	@# Update go-ethereum contraint branch
+	sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
 endif
 	dep ensure -v -update github.com/ethereum/go-ethereum
 	$(MAKE) dep-ensure
-	git add Gopkg.lock Gopkg.toml vendor/ _assets/patches
-	git commit -m "Updating Geth"
+	@git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
+	@git commit --quiet -m "Updating Geth"
+	@echo "Geth updated."
 
 patch: ##@patching Revert and apply all patches
 	./_assets/patches/patcher

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ endif
 	@$(MAKE) dep-ensure
 	git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
 ifeq ($(git diff --cached --quiet), 0)
-		echo "No changes to commit" && exit 1
+	@echo "No changes to commit" && exit 1
 endif
 	@git commit --quiet -m "Updating Geth"
 	@echo "Geth updated."

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ statusgo-ios-simulator-mainnet: xgo
 	$(GOPATH)/bin/xgo --image $(XGOIMAGEIOSSIM) --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell _assets/build/mainnet-flags.sh) ./lib
 	@echo "iOS framework cross compilation done (mainnet)."
 
+
 generate: ##@other Regenerate assets and other auto-generated stuff
 	cp ./node_modules/web3/dist/web3.js ./static/scripts/web3.js
 	go generate ./static
@@ -167,6 +168,11 @@ dep-ensure: ##@dependencies Dep ensure and apply all patches
 
 dep-install: ##@dependencies Install vendoring tool
 	go get -u github.com/golang/dep/cmd/dep
+
+update-geth: ##@dependencies Update geth (use BRANCH to set the branch name)
+	#TODO add line to dynamically change branch parameter here
+	dep ensure -v -update github.com/ethereum/go-ethereum
+	$(MAKE) -f $(THIS_FILE) dep-ensure
 
 patch: ##@patching Revert and apply all patches
 	./_assets/patches/patcher

--- a/Makefile
+++ b/Makefile
@@ -169,20 +169,7 @@ dep-install: ##@dependencies Install vendoring tool
 	go get -u github.com/golang/dep/cmd/dep
 
 update-geth: ##@dependencies Update geth (use GETH_BRANCH to optionally set the geth branch name)
-ifdef GETH_BRANCH
-	@# escape slashes
-	@GETH_BRANCH=$(echo $GETH_BRANCH | sed 's@\/@\\\/@g')
-	@# Update go-ethereum contraint branch
-	@sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
-endif
-	@dep ensure -v -update github.com/ethereum/go-ethereum
-	$(MAKE) dep-ensure
-	git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
-ifeq ($(git diff --cached --quiet), 0)
-	@echo "No changes to commit. Geth up to date." && exit 1
-endif
-	@git commit --quiet -m "Updating Geth"
-	@echo "Geth updated."
+	./_assets/ci/update-geth.sh $(GETH_BRANCH)
 
 patch: ##@patching Revert and apply all patches
 	./_assets/patches/patcher

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,8 @@ update-geth: ##@dependencies Update geth (use BRANCH to set the branch name)
 	$(MAKE) dep-ensure
 	#Commit patches.
 	#Commit Gopkg.lock, Gopkg.toml and vendor directories.
+	git add Gopkg.lock Gopkg.toml vendor/
+	git add _assets/patches
 
 patch: ##@patching Revert and apply all patches
 	./_assets/patches/patcher

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ dep-install: ##@dependencies Install vendoring tool
 
 update-geth: ##@dependencies Update geth (use BRANCH to set the branch name)
 	# Update go-ethereum contraint branch
-	sed 'N;N;s/\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)/\1 '"\"${BRANCH}\""'/g' Gopkg.toml
+	sed -i 'N;N;s/\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)/\1 '"\"${BRANCH}\""'/g' Gopkg.toml
 	dep ensure -v -update github.com/ethereum/go-ethereum
 	$(MAKE) dep-ensure
 	git add Gopkg.lock Gopkg.toml vendor/

--- a/Makefile
+++ b/Makefile
@@ -171,13 +171,16 @@ dep-install: ##@dependencies Install vendoring tool
 update-geth: ##@dependencies Update geth (use GETH_BRANCH to set the branch name)
 ifdef GETH_BRANCH
 	@# escape slashes
-	GETH_BRANCH=$(echo $GETH_BRANCH | sed 's@\/@\\\/@g')
+	@GETH_BRANCH=$(echo $GETH_BRANCH | sed 's@\/@\\\/@g')
 	@# Update go-ethereum contraint branch
 	@sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
 endif
-	dep ensure -v -update github.com/ethereum/go-ethereum
-	$(MAKE) dep-ensure
-	@git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
+	@#dep ensure -v -update github.com/ethereum/go-ethereum
+	@#$(MAKE) dep-ensure
+	git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
+ifeq ($(git diff --cached --quiet), 0)
+		echo "No changes to commit" && exit 1
+endif
 	@git commit --quiet -m "Updating Geth"
 	@echo "Geth updated."
 

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,6 @@ statusgo-ios-simulator-mainnet: xgo
 	$(GOPATH)/bin/xgo --image $(XGOIMAGEIOSSIM) --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=ios-9.3/framework -v $(shell _assets/build/mainnet-flags.sh) ./lib
 	@echo "iOS framework cross compilation done (mainnet)."
 
-
 generate: ##@other Regenerate assets and other auto-generated stuff
 	cp ./node_modules/web3/dist/web3.js ./static/scripts/web3.js
 	go generate ./static

--- a/_assets/ci/update-geth.sh
+++ b/_assets/ci/update-geth.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# This script updates the go-ethereum dependency, optionally updating the branch if GETH_BRANCH is provided.
+# If any changes were made, they will be committed.
+
+# Exit early if any errors are encountered
+set -e
+if [ ! -z "$GETH_BRANCH" ]; then
+	# escape slashes
+	GETH_BRANCH=$(echo $GETH_BRANCH | sed 's@\/@\\\/@g')
+	# Update go-ethereum contraint branch
+	sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
+fi
+dep ensure -v -update github.com/ethereum/go-ethereum
+make dep-ensure
+git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
+if $(git diff --cached --quiet); then 
+	echo "No changes to commit. Geth up to date."
+    exit 0
+fi	
+git commit --quiet -m "Updating Geth"
+echo "Geth updated."

--- a/_assets/ci/update-geth.sh
+++ b/_assets/ci/update-geth.sh
@@ -13,7 +13,7 @@ if [ ! -z "$GETH_BRANCH" ]; then
 fi
 dep ensure -v -update github.com/ethereum/go-ethereum
 make dep-ensure
-git add Gopkg.lock Gopkg.toml vendor/
+git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
 if $(git diff --cached --quiet); then
 	echo "No changes to commit. Geth up to date."
     exit 0

--- a/_assets/ci/update-geth.sh
+++ b/_assets/ci/update-geth.sh
@@ -12,7 +12,11 @@ if [ ! -z "$GETH_BRANCH" ]; then
 	sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
 fi
 dep ensure -v -update github.com/ethereum/go-ethereum
-make dep-ensure || (echo "Please fix patches and rerun. (dep-ensure failed)" && exit 1)
+if ! make dep-ensure; then
+    echo "Please fix patches and rerun. (dep-ensure failed)"
+    exit 1
+fi
+
 
 git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
 if $(git diff --cached --quiet); then

--- a/_assets/ci/update-geth.sh
+++ b/_assets/ci/update-geth.sh
@@ -12,7 +12,7 @@ if [ ! -z "$GETH_BRANCH" ]; then
 	sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
 fi
 dep ensure -v -update github.com/ethereum/go-ethereum
-make dep-ensure || (echo "Please fix patches. (dep-ensure failed)" && exit 1)
+make dep-ensure || (echo "Please fix patches and rerun. (dep-ensure failed)" && exit 1)
 
 git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
 if $(git diff --cached --quiet); then

--- a/_assets/ci/update-geth.sh
+++ b/_assets/ci/update-geth.sh
@@ -14,9 +14,9 @@ fi
 dep ensure -v -update github.com/ethereum/go-ethereum
 make dep-ensure
 git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
-if $(git diff --cached --quiet); then 
+if $(git diff --cached --quiet); then
 	echo "No changes to commit. Geth up to date."
     exit 0
-fi	
+fi
 git commit --quiet -m "Updating Geth"
 echo "Geth updated."

--- a/_assets/ci/update-geth.sh
+++ b/_assets/ci/update-geth.sh
@@ -12,7 +12,8 @@ if [ ! -z "$GETH_BRANCH" ]; then
 	sed -i 'N;N;s@\(\[\[constraint]]\n  name = "github.com\/ethereum\/go-ethereum"\n  branch =\)\(.*\)@\1 '"\"${GETH_BRANCH}\""'@g' Gopkg.toml
 fi
 dep ensure -v -update github.com/ethereum/go-ethereum
-make dep-ensure
+make dep-ensure || (echo "Please fix patches. (dep-ensure failed)" && exit 1)
+
 git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
 if $(git diff --cached --quiet); then
 	echo "No changes to commit. Geth up to date."

--- a/_assets/ci/update-geth.sh
+++ b/_assets/ci/update-geth.sh
@@ -13,7 +13,7 @@ if [ ! -z "$GETH_BRANCH" ]; then
 fi
 dep ensure -v -update github.com/ethereum/go-ethereum
 make dep-ensure
-git add Gopkg.lock Gopkg.toml vendor/ _assets/patches/
+git add Gopkg.lock Gopkg.toml vendor/
 if $(git diff --cached --quiet); then
 	echo "No changes to commit. Geth up to date."
     exit 0

--- a/_assets/docs/DEPENDENCIES.md
+++ b/_assets/docs/DEPENDENCIES.md
@@ -49,12 +49,7 @@ file is changed, `dep ensure` will re-generate `Gopkg.lock` as well.
 
 ## Updating `Geth`
 
-1. (for major releases) Update the branch name in `Gopkg.toml`.
-2. Update the `go-ethereum` dependency: `dep ensure -v -update github.com/ethereum/go-ethereum`.
-3. Update vendor files in `status-go`, and apply patches by running `make dep-ensure`.
-4. Commit patches.
-5. Commit `Gopkg.lock`, `Gopkg.toml` and `vendor` directories.
-
+Use the `update-geth` make target. For major releases, provide the GETH_BRANCH parameter. (e.g. `make update-geth GETH_BRANCH=release/1.9`). If there were any changes made, they will be committed while running this target.
 
 ## Commiting changes
 


### PR DESCRIPTION
Summary:
-
Adding Makefile target to update geth, with an optional `GETH_BRANCH` parameter. I was unsure how I could actually test this with a real branch - would appreciate any suggestions! I was also unsure if we'd want this pulled out into a separate script - I left it in the Makefile for now. This requires being on a clean branch. 

Important changes:
-
- Scripting out steps called out in https://github.com/status-im/status-go/blob/develop/_assets/docs/DEPENDENCIES.md.
-  This target will update Gopkg.toml if the `GETH_BRANCH` parameter is provided.
- This will exit out early if there is nothing to update, otherwise, it will commit the changes.


Closes #668 
