### PR TITLE
LevelDB error when running e2e tests on the public network #652

### DIFF
--- a/_assets/patches/geth/0016-db-closed-warn.patch
+++ b/_assets/patches/geth/0016-db-closed-warn.patch
@@ -1,0 +1,15 @@
+diff --git a/core/database_util.go b/core/database_util.go
+index c6b125da..3e0cf243 100644
+--- a/core/database_util.go
++++ b/core/database_util.go
+@@ -353,6 +353,10 @@ func WriteCanonicalHash(db ethdb.Putter, hash common.Hash, number uint64) error
+ // WriteHeadHeaderHash stores the head header's hash.
+ func WriteHeadHeaderHash(db ethdb.Putter, hash common.Hash) error {
+ 	if err := db.Put(headHeaderKey, hash.Bytes()); err != nil {
++		if err.Error() == "leveldb: closed" {
++			log.Warn("Failed to store last header's hash", "err", err)
++			return nil
++		}
+ 		log.Crit("Failed to store last header's hash", "err", err)
+ 	}
+ 	return nil

--- a/vendor/github.com/ethereum/go-ethereum/core/database_util.go
+++ b/vendor/github.com/ethereum/go-ethereum/core/database_util.go
@@ -353,6 +353,10 @@ func WriteCanonicalHash(db ethdb.Putter, hash common.Hash, number uint64) error 
 // WriteHeadHeaderHash stores the head header's hash.
 func WriteHeadHeaderHash(db ethdb.Putter, hash common.Hash) error {
 	if err := db.Put(headHeaderKey, hash.Bytes()); err != nil {
+		if err.Error() == "leveldb: closed" {
+			log.Warn("Failed to store last header's hash", "err", err)
+			return nil
+		}
 		log.Crit("Failed to store last header's hash", "err", err)
 	}
 	return nil


### PR DESCRIPTION
Adds patch to change log severity. ~~Another possible change I don't like~~ (This is the current change now):
```go
if err != nil {
    if err.Error() == "leveldb: closed" {
        // WARN
        // return nil err
    }
    // CRIT
}
```
I don't like this because use of `syndtr/goleveldb` is loosely coupled with `go-ethereum`.

Reasons:
- I was easily reproduce the error by running e2e/whisper tests locally using Rinkeby because my copy of the blockchain was always out of sync. And it happens because light chain database is getting closed while new header hashes are being put.
- "leveldb: closed" error is already not about unsafe behaviour and coming from `db.Put` (`syndtr/goleveldb`). `db.Put` checks if DB instance is closed and returns a "leveldb: closed" error without doing anything else.
- ~~We can't disable LES for e2e/whisper tests because that way we get `web3 is not defined` from `TestJailWhisper`.~~ (I'm not sure if this is relevant.)
- It's not wise to patch `syndtr/goleveldb`, the logic is correct already. If database is closed, an error should be returned stating that.
- I think using `WARN` ~~with `os.Exit(0)`~~ is a clean and reliable solution.

Closes #652
