### PR TITLE
Add a test with network connection problem while syncing a chain

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,6 +427,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a3526e2e159fe3c55522853ca1fb9f7d8d528cad2a70bb7582cfd8879b7adf71"
+  inputs-digest = "b25a49d4ae3f629b1b507cc70b42c2211c062b9144bed2358abf9cd7d594f9ab"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/t/destructive/peers_test.go
+++ b/t/destructive/peers_test.go
@@ -19,7 +19,7 @@ const (
 	defaultTimeout = 40 * time.Second
 )
 
-func TestPeersSuiteLinkUpDown(t *testing.T) {
+func TestPeersSuiteNetworkConnection(t *testing.T) {
 	suite.Run(t, &PeersTestSuite{controller: new(NetworkConnectionController)})
 }
 

--- a/t/destructive/sync_test.go
+++ b/t/destructive/sync_test.go
@@ -1,0 +1,93 @@
+package destructive
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/status-im/status-go/geth/api"
+	"github.com/status-im/status-go/geth/log"
+	"github.com/status-im/status-go/t/e2e"
+	. "github.com/status-im/status-go/t/utils"
+)
+
+func TestSyncSuiteNetworkConnection(t *testing.T) {
+	suite.Run(t, &SyncTestSuite{controller: new(NetworkConnectionController)})
+}
+
+type SyncTestSuite struct {
+	suite.Suite
+
+	backend    *api.StatusBackend
+	controller *NetworkConnectionController
+
+	tempDir string
+}
+
+func (s *SyncTestSuite) SetupTest() {
+	s.backend = api.NewStatusBackend()
+	config, err := e2e.MakeTestNodeConfig(GetNetworkID())
+	s.Require().NoError(err)
+	s.tempDir, err = ioutil.TempDir("/tmp", "status-sync-chain")
+	s.Require().NoError(err)
+	config.LightEthConfig.Enabled = true
+	config.WhisperConfig.Enabled = false
+	s.Require().NoError(s.backend.StartNode(config))
+}
+
+func (s *SyncTestSuite) TearDown() {
+	err := s.backend.StopNode()
+	if len(s.tempDir) != 0 {
+		err = os.RemoveAll(s.tempDir)
+	}
+	s.Require().NoError(err)
+}
+
+func (s *SyncTestSuite) waitForProgress(d *downloader.Downloader) {
+	initialBlock := d.Progress().CurrentBlock
+	ticker := time.NewTicker(100 * time.Millisecond)
+	for {
+		select {
+		case <-time.After(30 * time.Second):
+			s.Require().Fail("timed out waiting for fetching new headers")
+		case <-ticker.C:
+			log.Info("sync progress", "current", d.Progress().CurrentBlock, "initial", initialBlock)
+			if d.Progress().CurrentBlock > initialBlock {
+				return
+			}
+		}
+	}
+}
+
+func (s *SyncTestSuite) consumeExpectedEvent(subscription *event.TypeMuxSubscription, expectedEvent interface{}) {
+	select {
+	case ev := <-subscription.Chan():
+		if reflect.TypeOf(expectedEvent) != reflect.TypeOf(ev.Data) {
+			s.Require().Fail("received unexpected event")
+		}
+	case <-time.After(60 * time.Second):
+		s.Require().Fail(("timeout waiting for an event"))
+	}
+}
+
+func (s *SyncTestSuite) TestSyncChain() {
+	les, err := s.backend.NodeManager().LightEthereumService()
+	s.Require().NoError(err)
+	subscription := les.EventMux().Subscribe(
+		downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
+	defer subscription.Unsubscribe()
+	s.consumeExpectedEvent(subscription, downloader.StartEvent{})
+	// wait for downloader to start festching new headers
+	s.waitForProgress(les.Downloader())
+	s.Require().NoError(s.controller.Enable())
+	s.consumeExpectedEvent(subscription, downloader.FailedEvent{})
+	s.Require().NoError(s.controller.Disable())
+	s.consumeExpectedEvent(subscription, downloader.StartEvent{})
+	s.waitForProgress(les.Downloader())
+}


### PR DESCRIPTION
Test waits till synchronization is started, then interrupts network connection, wait for a failure event and restore network connection, confirming that after the connection is restored synchronization will proceed.