### PR TITLE
Remove DefaultMinimumPow patches in favor of using Whisper config #671

### DIFF
--- a/_assets/patches/geth/0004-whisper-notifications.patch
+++ b/_assets/patches/geth/0004-whisper-notifications.patch
@@ -961,15 +961,6 @@ index 7a57488bd..a6c9e610d 100644
  )
  
  const (
-@@ -57,7 +59,7 @@ const (
- 
- 	MaxMessageSize        = uint32(10 * 1024 * 1024) // maximum accepted size of a message.
- 	DefaultMaxMessageSize = uint32(1024 * 1024)
--	DefaultMinimumPoW     = 0.2
-+	DefaultMinimumPoW     = 0.001
- 
- 	padSizeLimit      = 256 // just an arbitrary number, could be changed without breaking the protocol (must not exceed 2^24)
- 	messageQueueLimit = 1024
 @@ -85,3 +87,15 @@ type MailServer interface {
  	Archive(env *Envelope)
  	DeliverMail(whisperPeer *Peer, request *Envelope)

--- a/_assets/patches/geth/0014-whisperv6-notifications.patch
+++ b/_assets/patches/geth/0014-whisperv6-notifications.patch
@@ -32,15 +32,6 @@ index d5d7fed60..5ad660616 100644
  )
  
  // Whisper protocol parameters
-@@ -67,7 +69,7 @@ const (
- 
- 	MaxMessageSize        = uint32(10 * 1024 * 1024) // maximum accepted size of a message.
- 	DefaultMaxMessageSize = uint32(1024 * 1024)
--	DefaultMinimumPoW     = 0.2
-+	DefaultMinimumPoW     = 0.001
- 
- 	padSizeLimit      = 256 // just an arbitrary number, could be changed without breaking the protocol
- 	messageQueueLimit = 1024
 @@ -95,3 +97,15 @@ type MailServer interface {
  	Archive(env *Envelope)
  	DeliverMail(whisperPeer *Peer, request *Envelope)

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -161,9 +161,13 @@ func activateShhService(stack *node.Node, config *params.NodeConfig) error {
 	}
 
 	serviceConstructor := func(*node.ServiceContext) (node.Service, error) {
-		whisperConfig := config.WhisperConfig
-		whisperService := whisper.New(nil)
+		whisperServiceConfig := &whisper.Config{
+			MaxMessageSize:     whisper.DefaultMaxMessageSize,
+			MinimumAcceptedPOW: 0.001,
+		}
+		whisperService := whisper.New(whisperServiceConfig)
 
+		whisperConfig := config.WhisperConfig
 		// enable metrics
 		whisperService.RegisterEnvelopeTracer(&shhmetrics.EnvelopeTracer{})
 

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv5/doc.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv5/doc.go
@@ -59,7 +59,7 @@ const (
 
 	MaxMessageSize        = uint32(10 * 1024 * 1024) // maximum accepted size of a message.
 	DefaultMaxMessageSize = uint32(1024 * 1024)
-	DefaultMinimumPoW     = 0.001
+	DefaultMinimumPoW     = 0.2
 
 	padSizeLimit      = 256 // just an arbitrary number, could be changed without breaking the protocol (must not exceed 2^24)
 	messageQueueLimit = 1024

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/doc.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/doc.go
@@ -69,7 +69,7 @@ const (
 
 	MaxMessageSize        = uint32(10 * 1024 * 1024) // maximum accepted size of a message.
 	DefaultMaxMessageSize = uint32(1024 * 1024)
-	DefaultMinimumPoW     = 0.001
+	DefaultMinimumPoW     = 0.2
 
 	padSizeLimit      = 256 // just an arbitrary number, could be changed without breaking the protocol
 	messageQueueLimit = 1024


### PR DESCRIPTION
Summary
-
Remove DefaultMinimumPow patches in favor of using Whisper config.

We had an unnecessary hunk changing the DefaultMinimumPoW constant. In favor of this, we should just pass in a config with MinimumAcceptedPOW set to our desired value.

Important changes:
-
- Please note I also changed the whisperv6 patch. The original issue did not call this out. 

Closes #671
