### PR TITLE
Disable unparam linter

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -27,7 +27,6 @@
         "misspell",
         "structcheck",
         "unconvert",
-        "unparam",
         "varcheck",
         "vet"
     ],


### PR DESCRIPTION
unparam checks if a function is called always with same arguments. probably the idea is to suggest moving those arguments to consts. But in my cases, all those warnings were for timeout or ticker periods, and usually i want to keep function parametrized.

if someone feels that this linter is useful i will close PR
