### PR TITLE
MaxPeers barrier is not applied for static peers

### DIFF
--- a/_assets/patches/geth/0016-whisperv5-max-peers.patch
+++ b/_assets/patches/geth/0016-whisperv5-max-peers.patch
@@ -1,0 +1,166 @@
+diff --git c/whisper/whisperv5/config.go w/whisper/whisperv5/config.go
+index fcc230704..a28c01c86 100644
+--- c/whisper/whisperv5/config.go
++++ w/whisper/whisperv5/config.go
+@@ -19,9 +19,11 @@ package whisperv5
+ type Config struct {
+ 	MaxMessageSize     uint32  `toml:",omitempty"`
+ 	MinimumAcceptedPOW float64 `toml:",omitempty"`
++	MaxPeers           int     `toml:"omitempty"`
+ }
+ 
+ var DefaultConfig = Config{
+ 	MaxMessageSize:     DefaultMaxMessageSize,
+ 	MinimumAcceptedPOW: DefaultMinimumPoW,
++	MaxPeers:           25,
+ }
+diff --git c/whisper/whisperv5/peer.go w/whisper/whisperv5/peer.go
+index 179c93179..0486af2f1 100644
+--- c/whisper/whisperv5/peer.go
++++ w/whisper/whisperv5/peer.go
+@@ -18,6 +18,7 @@ package whisperv5
+ 
+ import (
+ 	"fmt"
++	"sync/atomic"
+ 	"time"
+ 
+ 	"github.com/ethereum/go-ethereum/common"
+@@ -32,7 +33,7 @@ type Peer struct {
+ 	host    *Whisper
+ 	peer    *p2p.Peer
+ 	ws      p2p.MsgReadWriter
+-	trusted bool
++	trusted int32
+ 
+ 	known *set.Set // Messages already known by the peer to avoid wasting bandwidth
+ 
+@@ -45,7 +46,7 @@ func newPeer(host *Whisper, remote *p2p.Peer, rw p2p.MsgReadWriter) *Peer {
+ 		host:    host,
+ 		peer:    remote,
+ 		ws:      rw,
+-		trusted: false,
++		trusted: 0,
+ 		known:   set.New(),
+ 		quit:    make(chan struct{}),
+ 	}
+@@ -172,3 +173,11 @@ func (p *Peer) ID() []byte {
+ 	id := p.peer.ID()
+ 	return id[:]
+ }
++
++func (p *Peer) Trusted() bool {
++	return atomic.LoadInt32(&p.trusted) == 1
++}
++
++func (p *Peer) SetTrusted() {
++	atomic.StoreInt32(&p.trusted, 1)
++}
+diff --git c/whisper/whisperv5/whisper.go w/whisper/whisperv5/whisper.go
+index 6b040befb..73c1d483c 100644
+--- c/whisper/whisperv5/whisper.go
++++ w/whisper/whisperv5/whisper.go
+@@ -77,8 +77,9 @@ type Whisper struct {
+ 	statsMu sync.Mutex // guard stats
+ 	stats   Statistics // Statistics of whisper node
+ 
+-	mailServer         MailServer // MailServer interface
+-	envelopeTracer     EnvelopeTracer // Service collecting envelopes metadata
++	mailServer     MailServer     // MailServer interface
++	envelopeTracer EnvelopeTracer // Service collecting envelopes metadata
++	maxPeers       int
+ }
+ 
+ // New creates a Whisper client ready to communicate through the Ethereum P2P network.
+@@ -96,6 +97,7 @@ func New(cfg *Config) *Whisper {
+ 		messageQueue: make(chan *Envelope, messageQueueLimit),
+ 		p2pMsgQueue:  make(chan *Envelope, messageQueueLimit),
+ 		quit:         make(chan struct{}),
++		maxPeers:     cfg.MaxPeers,
+ 	}
+ 
+ 	whisper.filters = NewFilters(whisper)
+@@ -211,7 +213,7 @@ func (w *Whisper) AllowP2PMessagesFromPeer(peerID []byte) error {
+ 	if err != nil {
+ 		return err
+ 	}
+-	p.trusted = true
++	p.SetTrusted()
+ 	return nil
+ }
+ 
+@@ -225,7 +227,7 @@ func (w *Whisper) RequestHistoricMessages(peerID []byte, envelope *Envelope) err
+ 	if err != nil {
+ 		return err
+ 	}
+-	p.trusted = true
++	p.SetTrusted()
+ 	return p2p.Send(p.ws, p2pRequestCode, envelope)
+ }
+ 
+@@ -540,9 +542,40 @@ func (w *Whisper) Stop() error {
+ 	return nil
+ }
+ 
++// waitForSlot waits until peer is marked as trusted or we have a slot for
++// another peer.
++func (w *Whisper) waitForSlot(peer *Peer) error {
++	timeout := time.After(time.Minute)
++	ticker := time.NewTicker(2 * time.Second)
++	defer ticker.Stop()
++	for {
++		select {
++		case <-timeout:
++			return p2p.DiscTooManyPeers
++		case <-ticker.C:
++			if peer.Trusted() {
++				return nil
++			}
++			w.peerMu.Lock()
++			if len(w.peers) == w.maxPeers {
++				w.peerMu.Unlock()
++				return nil
++			}
++			w.peerMu.Unlock()
++		}
++	}
++}
++
+ // HandlePeer is called by the underlying P2P layer when the whisper sub-protocol
+ // connection is negotiated.
+ func (wh *Whisper) HandlePeer(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
++	peersOverflow := false
++	wh.peerMu.RLock()
++	if len(wh.peers) > wh.maxPeers {
++		peersOverflow = true
++	}
++	wh.peerMu.RUnlock()
++
+ 	// Create the new peer and start tracking it
+ 	whisperPeer := newPeer(wh, peer, rw)
+ 
+@@ -556,6 +589,15 @@ func (wh *Whisper) HandlePeer(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
+ 		wh.peerMu.Unlock()
+ 	}()
+ 
++	// we need to leave a window for a peer to become trusted
++	// otherwise we won't be able to connect with mailserver when max peers
++	// barier already reached
++	if peersOverflow {
++		if err := wh.waitForSlot(whisperPeer); err != nil {
++			return err
++		}
++	}
++
+ 	// Run the peer handshake and state updates
+ 	if err := whisperPeer.handshake(); err != nil {
+ 		return err
+@@ -605,7 +647,7 @@ func (wh *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
+ 			// this message is not supposed to be forwarded to other peers, and
+ 			// therefore might not satisfy the PoW, expiry and other requirements.
+ 			// these messages are only accepted from the trusted peer.
+-			if p.trusted {
++			if p.Trusted() {
+ 				var envelope Envelope
+ 				if err := packet.Decode(&envelope); err != nil {
+ 					log.Warn("failed to decode direct message, peer will be disconnected", "peer", p.peer.ID(), "err", err)

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -55,9 +55,10 @@ var (
 	// don't change the name of this flag, https://github.com/ethereum/go-ethereum/blob/master/metrics/metrics.go#L41
 	_ = flag.Bool("metrics", false, "Expose ethereum metrics with debug_metrics jsonrpc call.")
 	// shh stuff
-	passwordFile = flag.String("shh.passwordfile", "", "Password file (password is used for symmetric encryption)")
-	minPow       = flag.Float64("shh.pow", params.WhisperMinimumPoW, "PoW for messages to be added to queue, in float format")
-	ttl          = flag.Int("shh.ttl", params.WhisperTTL, "Time to live for messages, in seconds")
+	passwordFile    = flag.String("shh.passwordfile", "", "Password file (password is used for symmetric encryption)")
+	minPow          = flag.Float64("shh.pow", params.WhisperMinimumPoW, "PoW for messages to be added to queue, in float format")
+	ttl             = flag.Int("shh.ttl", params.WhisperTTL, "Time to live for messages, in seconds")
+	whisperMaxPeers = flag.Int("shh.maxpeers", -1, "Maximum amount of whisper peers.")
 
 	// MailServer
 	enableMailServer = flag.Bool("shh.mailserver", false, "Delivers expired messages on demand")
@@ -204,6 +205,11 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 
 	nodeConfig.RPCEnabled = *httpEnabled
 	nodeConfig.WhisperConfig.Enabled = *whisperEnabled
+	if *whisperMaxPeers > 0 {
+		nodeConfig.WhisperConfig.MaxPeers = *whisperMaxPeers
+	} else {
+		nodeConfig.WhisperConfig.MaxPeers = *maxPeers
+	}
 	nodeConfig.MaxPeers = *maxPeers
 
 	nodeConfig.HTTPHost = *httpHost

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -163,6 +163,7 @@ func activateShhService(stack *node.Node, config *params.NodeConfig) error {
 		whisperServiceConfig := &whisper.Config{
 			MaxMessageSize:     whisper.DefaultMaxMessageSize,
 			MinimumAcceptedPOW: 0.001,
+			MaxPeers:           config.WhisperConfig.MaxPeers,
 		}
 		whisperService := whisper.New(whisperServiceConfig)
 

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -106,6 +106,9 @@ type WhisperConfig struct {
 
 	// FirebaseConfig extra configuration for Firebase Cloud Messaging
 	FirebaseConfig *FirebaseConfig `json:"FirebaseConfig,"`
+
+	// MaxPeers maximum amount of whisper peers.
+	MaxPeers int32
 }
 
 // ReadPasswordFile reads and returns content of the password file
@@ -248,6 +251,9 @@ type NodeConfig struct {
 	// MaxPeers is the maximum number of (global) peers that can be connected.
 	// Set to zero, if only static or trusted peers are allowed to connect.
 	MaxPeers int
+
+	// MaxWhisperPeers maximum amount of whisper peers
+	MaxWhisperPeers int
 
 	// MaxPendingPeers is the maximum number of peers that can be pending in the
 	// handshake phase, counted separately for inbound and outbound connections.

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -314,6 +314,7 @@ func NewNodeConfig(dataDir string, networkID uint64, devMode bool) (*NodeConfig,
 			DatabaseCache: DatabaseCache,
 		},
 		WhisperConfig: &WhisperConfig{
+			MaxPeers:   MaxWhisperPeers,
 			Enabled:    true,
 			MinimumPoW: WhisperMinimumPoW,
 			TTL:        WhisperTTL,

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -108,7 +108,7 @@ type WhisperConfig struct {
 	FirebaseConfig *FirebaseConfig `json:"FirebaseConfig,"`
 
 	// MaxPeers maximum amount of whisper peers.
-	MaxPeers int32
+	MaxPeers int
 }
 
 // ReadPasswordFile reads and returns content of the password file

--- a/geth/params/defaults.go
+++ b/geth/params/defaults.go
@@ -41,6 +41,9 @@ const (
 	// MaxPeers is the maximum number of global peers
 	MaxPeers = 25
 
+	// MaxWhisperPeers is the maximum number of whisper peers
+	MaxWhisperPeers = 25
+
 	// MaxPendingPeers is the maximum number of peers that can be pending in the
 	// handshake phase, counted separately for inbound and outbound connections.
 	MaxPendingPeers = 0

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv5/config.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv5/config.go
@@ -19,9 +19,11 @@ package whisperv5
 type Config struct {
 	MaxMessageSize     uint32  `toml:",omitempty"`
 	MinimumAcceptedPOW float64 `toml:",omitempty"`
+	MaxPeers           int     `toml:"omitempty"`
 }
 
 var DefaultConfig = Config{
 	MaxMessageSize:     DefaultMaxMessageSize,
 	MinimumAcceptedPOW: DefaultMinimumPoW,
+	MaxPeers:           25,
 }


### PR DESCRIPTION
This PR adds an option to limit whisper peers on a protocol level.
I had the following flow in my mind: static peers are added with admin.addPeer or configuration file, fastest peers will be used by whisper, all other peers will be kept in p2p.Server and used if any of initially connected peers will disconnect for any reason.

But also, we need to preserve connections with trusted peers in some way. Otherwise current flow with mailserver will be broken. I decided to leave 1m window for a peer to become trusted. This will be used for every peer that will be connected after maximum amount of peers is reached.
I understand that this is a bit hacky, but I don't see better way to make it work.

Additionally, operations on the trusted field were not thread safe and could even cause a bug with some messages from mailserver being discarded. This part of the change I will send upstream.

profiling is here https://github.com/status-im/status-scale/pull/3