### PR TITLE
Fix a couple race conditions in tests

### DIFF
--- a/geth/common/types.go
+++ b/geth/common/types.go
@@ -177,6 +177,8 @@ type JailCell interface {
 	Set(string, interface{}) error
 	// Get a value from VM.
 	Get(string) (otto.Value, error)
+	// GetObjectValue returns the given name's otto.Value from the given otto.Value v. Should only be needed in tests.
+	GetObjectValue(otto.Value, string) (otto.Value, error)
 	// Run an arbitrary JS code. Input maybe string or otto.Script.
 	Run(interface{}) (otto.Value, error)
 	// Call an arbitrary JS function by name and args.

--- a/geth/common/types_mock.go
+++ b/geth/common/types_mock.go
@@ -431,6 +431,19 @@ func (mr *MockJailCellMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockJailCell)(nil).Get), arg0)
 }
 
+// GetObjectValue mocks base method
+func (m *MockJailCell) GetObjectValue(arg0 otto.Value, arg1 string) (otto.Value, error) {
+	ret := m.ctrl.Call(m, "GetObjectValue", arg0, arg1)
+	ret0, _ := ret[0].(otto.Value)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetObjectValue indicates an expected call of GetObjectValue
+func (mr *MockJailCellMockRecorder) GetObjectValue(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectValue", reflect.TypeOf((*MockJailCell)(nil).GetObjectValue), arg0, arg1)
+}
+
 // Run mocks base method
 func (m *MockJailCell) Run(arg0 interface{}) (otto.Value, error) {
 	ret := m.ctrl.Call(m, "Run", arg0)

--- a/geth/jail/cell_test.go
+++ b/geth/jail/cell_test.go
@@ -170,10 +170,10 @@ func (s *CellTestSuite) TestCellFetchErrorRace() {
 	case <-dataCh:
 		s.Fail("fetch didn't return error for nonexistent url")
 	case e := <-errCh:
-		name, err := e.Object().Get("name")
+		name, err := cell.GetObjectValue(e, "name")
 		s.NoError(err)
 		s.Equal("Error", name.String())
-		_, err = e.Object().Get("message")
+		_, err = cell.GetObjectValue(e, "message")
 		s.NoError(err)
 	case <-time.After(5 * time.Second):
 		s.Fail("test timed out")

--- a/geth/jail/handlers_test.go
+++ b/geth/jail/handlers_test.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/robertkrimen/otto"
 
+	"sync/atomic"
+
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/geth/rpc"
 	"github.com/status-im/status-go/geth/signal"
 	"github.com/stretchr/testify/suite"
-	"sync/atomic"
 )
 
 func TestHandlersTestSuite(t *testing.T) {
@@ -179,7 +180,7 @@ func (s *HandlersTestSuite) TestSendSignalHandler() {
 
 	value, err := cell.Run(`statusSignals.sendSignal("test signal message")`)
 	s.NoError(err)
-	result, err := value.Object().Get("result")
+	result, err := cell.GetObjectValue(value, "result")
 	s.NoError(err)
 	resultBool, err := result.ToBoolean()
 	s.NoError(err)

--- a/geth/jail/internal/loop/loop_test.go
+++ b/geth/jail/internal/loop/loop_test.go
@@ -54,8 +54,9 @@ func (s *LoopSuite) SetupTest() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
 	go func() {
+		a := s.Assertions // Cache assertions reference as otherwise we'd incur in a race condition
 		err := s.loop.Run(ctx)
-		s.Equal(context.Canceled, err)
+		a.Equal(context.Canceled, err)
 	}()
 }
 

--- a/geth/jail/internal/vm/vm.go
+++ b/geth/jail/internal/vm/vm.go
@@ -34,12 +34,20 @@ func (vm *VM) Set(key string, val interface{}) error {
 	return vm.vm.Set(key, val)
 }
 
-// Get returns the giving key's otto.Value from the underline otto vm.
+// Get returns the given key's otto.Value from the underlying otto vm.
 func (vm *VM) Get(key string) (otto.Value, error) {
 	vm.Lock()
 	defer vm.Unlock()
 
 	return vm.vm.Get(key)
+}
+
+// GetObjectValue returns the given name's otto.Value from the given otto.Value v. Should only be needed in tests.
+func (vm *VM) GetObjectValue(v otto.Value, name string) (otto.Value, error) {
+	vm.Lock()
+	defer vm.Unlock()
+
+	return v.Object().Get(name)
 }
 
 // Call attempts to call the internal call function for the giving response associated with the

--- a/geth/jail/jail_test.go
+++ b/geth/jail/jail_test.go
@@ -194,3 +194,26 @@ func (s *JailTestSuite) TestExecute() {
 	`)
 	s.Equal(`{"test":true}`, response)
 }
+
+func (s *JailTestSuite) TestGetObjectValue() {
+	cell, result, err := s.Jail.createAndInitCell(
+		"cell1",
+		`var testCreateAndInitCell1 = {obj: 'objValue'}`,
+		`var testCreateAndInitCell2 = true`,
+		`testCreateAndInitCell2`,
+	)
+	s.NoError(err)
+	s.NotNil(cell)
+	s.Equal(`{"result":true}`, result)
+
+	testCreateAndInitCell1, err := cell.Get("testCreateAndInitCell1")
+	s.NoError(err)
+	s.True(testCreateAndInitCell1.IsObject())
+	value, err := cell.GetObjectValue(testCreateAndInitCell1, "obj")
+	s.NoError(err)
+	s.Equal("objValue", value.String())
+
+	value, err = cell.Get("testCreateAndInitCell2")
+	s.NoError(err)
+	s.Equal(`true`, value.String())
+}

--- a/t/e2e/whisper/whisper_jail_test.go
+++ b/t/e2e/whisper/whisper_jail_test.go
@@ -323,7 +323,7 @@ func (s *WhisperJailTestSuite) TestJailWhisper() {
 		for {
 			filter, err := cell.Get("filter")
 			r.NoError(err, "cannot get filter")
-			filterID, err := filter.Object().Get("filterId")
+			filterID, err := cell.GetObjectValue(filter, "filterId")
 			r.NoError(err, "cannot get filterId")
 
 			select {

--- a/t/e2e/whisper/whisper_mailbox_test.go
+++ b/t/e2e/whisper/whisper_mailbox_test.go
@@ -343,6 +343,7 @@ func (s *WhisperMailboxSuite) startMailboxBackend() (*api.StatusBackend, func())
 	mailboxConfig.WhisperConfig.DataDir = filepath.Join(datadir, "data")
 	mailboxConfig.DataDir = datadir
 
+	s.Require().False(mailboxBackend.IsNodeRunning())
 	s.Require().NoError(mailboxBackend.StartNode(mailboxConfig))
 	s.Require().True(mailboxBackend.IsNodeRunning())
 	return mailboxBackend, func() {


### PR DESCRIPTION
Fix race condition on `LoopSuite` and in the access to a Otto.Value in tests.

`LoopSuite` is making an asserting using a pointer which might have been replaced by the time it is used. Changed the code so that we save the value for future use.
`Otto.Value.Object().Get()` was being used in tests without using the `JailCell` lock. Made a `GetObjectValue()` method in `JailCell` so that we have a way to perform that operation safely in multithreaded environments.

Both of these issues were uncovered with the `-race` flag, and are a prerequisite for the Whisper v6 work.

```
=== RUN   TestLoopSuite
=== RUN   TestLoopSuite/TestAddAndReady
=== RUN   TestLoopSuite/TestImmediateExecution
==================
WARNING: DATA RACE
Read at 0x00c420011f50 by goroutine 17:
  github.com/status-im/status-go/geth/jail/internal/loop.(*LoopSuite).SetupTest.func1()
      /home/pedro/go/src/github.com/status-im/status-go/geth/jail/internal/loop/loop_test.go:58 +0xda

Previous write at 0x00c420011f50 by goroutine 16:
  github.com/status-im/status-go/geth/jail/internal/loop.(*LoopSuite).SetT()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:34 +0xdb
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite.Run.func2.1()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:100 +0xbd
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite.Run.func2()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:103 +0x310
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c

Goroutine 17 (running) created at:
  github.com/status-im/status-go/geth/jail/internal/loop.(*LoopSuite).SetupTest()
      /home/pedro/go/src/github.com/status-im/status-go/geth/jail/internal/loop/loop_test.go:56 +0x375
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite.Run.func2()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:88 +0x430
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c

Goroutine 16 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:789 +0x568
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite.runTests()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:121 +0xce
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite.Run()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:108 +0x6c6
  github.com/status-im/status-go/geth/jail/internal/loop.TestLoopSuite()
      /home/pedro/go/src/github.com/status-im/status-go/geth/jail/internal/loop/loop_test.go:36 +0x5e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c
==================
==================
WARNING: DATA RACE
Read at 0x00c420050000 by goroutine 17:
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/assert.(*Assertions).Equal()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/assert/assertion_forward.go:78 +0x3f
  github.com/status-im/status-go/geth/jail/internal/loop.(*LoopSuite).SetupTest.func1()
      /home/pedro/go/src/github.com/status-im/status-go/geth/jail/internal/loop/loop_test.go:58 +0x131

Previous write at 0x00c420050000 by goroutine 16:
  github.com/status-im/status-go/geth/jail/internal/loop.(*LoopSuite).SetT()
      /home/pedro/go/src/github.com/status-im/status-go/geth/jail/internal/loop/loop_test.go:10 +0xa0
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite.Run.func2.1()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:100 +0xbd
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite.Run.func2()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:103 +0x310
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c

Goroutine 17 (running) created at:
  github.com/status-im/status-go/geth/jail/internal/loop.(*LoopSuite).SetupTest()
      /home/pedro/go/src/github.com/status-im/status-go/geth/jail/internal/loop/loop_test.go:56 +0x375
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite.Run.func2()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:88 +0x430
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c

Goroutine 16 (finished) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:789 +0x568
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite.runTests()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:121 +0xce
  github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite.Run()
      /home/pedro/go/src/github.com/status-im/status-go/vendor/github.com/stretchr/testify/suite/suite.go:108 +0x6c6
  github.com/status-im/status-go/geth/jail/internal/loop.TestLoopSuite()
      /home/pedro/go/src/github.com/status-im/status-go/geth/jail/internal/loop/loop_test.go:36 +0x5e
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c
==================
=== RUN   TestLoopSuite/TestImmediateExecutionErrorWhenClosed
=== RUN   TestLoopSuite/TestLoopErrorWhenClosed
--- FAIL: TestLoopSuite (0.43s)
    --- PASS: TestLoopSuite/TestAddAndReady (0.10s)
    --- PASS: TestLoopSuite/TestImmediateExecution (0.10s)
    --- PASS: TestLoopSuite/TestImmediateExecutionErrorWhenClosed (0.10s)
    --- PASS: TestLoopSuite/TestLoopErrorWhenClosed (0.10s)
        testing.go:699: race detected during execution of test
FAIL
FAIL    github.com/status-im/status-go/geth/jail/internal/loop  0.462s
?       github.com/status-im/status-go/geth/jail/internal/loop/looptask [no test files]
?       github.com/status-im/status-go/geth/jail/internal/process       [no test files]
```

# Future Steps

Improve approach in https://github.com/status-im/status-go/issues/691