### PR TITLE
Wait for `Rollback` before closing the DB in the light client.

### DIFF
--- a/_assets/patches/geth/0016-fix-leveldb-issue.patch
+++ b/_assets/patches/geth/0016-fix-leveldb-issue.patch
@@ -1,0 +1,64 @@
+diff --git a/les/handler.go b/les/handler.go
+index 613fbb79..a6ae09ef 100644
+--- a/les/handler.go
++++ b/les/handler.go
+@@ -124,6 +124,10 @@ type ProtocolManager struct {
+ 	// wait group is used for graceful shutdowns during downloading
+ 	// and processing
+ 	wg *sync.WaitGroup
++
++	// wait group is used for waiting for currend download
++	// to finish (if running)
++	downloads *sync.WaitGroup
+ }
+
+ // NewProtocolManager returns a new ethereum sub protocol manager. The Ethereum sub protocol manages peers capable
+@@ -145,6 +149,7 @@ func NewProtocolManager(chainConfig *params.ChainConfig, lightSync bool, protoco
+ 		quitSync:    quitSync,
+ 		wg:          wg,
+ 		noMorePeers: make(chan struct{}),
++		downloads:   &sync.WaitGroup{},
+ 	}
+ 	if odr != nil {
+ 		manager.retriever = odr.retriever
+@@ -210,9 +215,31 @@ func NewProtocolManager(chainConfig *params.ChainConfig, lightSync bool, protoco
+ 		manager.fetcher = newLightFetcher(manager)
+ 	}
+
++	go manager.monitorDownloads()
++
+ 	return manager, nil
+ }
+
++func (pm *ProtocolManager) monitorDownloads() {
++	sub := pm.eventMux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
++
++	for {
++		select {
++		case event := <-sub.Chan():
++			if event == nil {
++				return
++			}
++
++			switch event.Data.(type) {
++			case downloader.StartEvent:
++				pm.downloads.Add(1)
++			case downloader.DoneEvent, downloader.FailedEvent:
++				pm.downloads.Done()
++			}
++		}
++	}
++}
++
+ // removePeer initiates disconnection from a peer by removing it from the peer set
+ func (pm *ProtocolManager) removePeer(id string) {
+ 	pm.peers.Unregister(id)
+@@ -240,6 +267,8 @@ func (pm *ProtocolManager) Stop() {
+
+ 	close(pm.quitSync) // quits syncer, fetcher
+
++	pm.downloads.Wait() // Wait until current downloads are finished.
++
+ 	// Disconnect existing sessions.
+ 	// This also closes the gate for any new registrations on the peer set.
+ 	// sessions which are already established but not added to pm.peers yet

--- a/_assets/patches/geth/0016-fix-leveldb-issue.patch
+++ b/_assets/patches/geth/0016-fix-leveldb-issue.patch
@@ -1,3 +1,23 @@
+diff --git a/les/backend.go b/les/backend.go
+index 333df920..450d8351 100644
+--- a/les/backend.go
++++ b/les/backend.go
+@@ -20,7 +20,6 @@ package les
+ import (
+ 	"fmt"
+ 	"sync"
+-	"time"
+ 
+ 	"github.com/ethereum/go-ethereum/accounts"
+ 	"github.com/ethereum/go-ethereum/common"
+@@ -248,7 +247,6 @@ func (s *LightEthereum) Stop() error {
+ 
+ 	s.eventMux.Stop()
+ 
+-	time.Sleep(time.Millisecond * 200)
+ 	s.chainDb.Close()
+ 	close(s.shutdownChan)
+ 
 diff --git a/les/handler.go b/les/handler.go
 index 613fbb79..a6ae09ef 100644
 --- a/les/handler.go
@@ -21,7 +41,7 @@ index 613fbb79..a6ae09ef 100644
  	}
  	if odr != nil {
  		manager.retriever = odr.retriever
-@@ -210,9 +215,31 @@ func NewProtocolManager(chainConfig *params.ChainConfig, lightSync bool, protoco
+@@ -210,9 +215,32 @@ func NewProtocolManager(chainConfig *params.ChainConfig, lightSync bool, protoco
  		manager.fetcher = newLightFetcher(manager)
  	}
 
@@ -32,6 +52,7 @@ index 613fbb79..a6ae09ef 100644
 
 +func (pm *ProtocolManager) monitorDownloads() {
 +	sub := pm.eventMux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
++	defer sub.Unsubscribe()
 +
 +	for {
 +		select {

--- a/vendor/github.com/ethereum/go-ethereum/les/backend.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/backend.go
@@ -20,7 +20,6 @@ package les
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -248,7 +247,6 @@ func (s *LightEthereum) Stop() error {
 
 	s.eventMux.Stop()
 
-	time.Sleep(time.Millisecond * 200)
 	s.chainDb.Close()
 	close(s.shutdownChan)
 

--- a/vendor/github.com/ethereum/go-ethereum/les/handler.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/handler.go
@@ -222,6 +222,7 @@ func NewProtocolManager(chainConfig *params.ChainConfig, lightSync bool, protoco
 
 func (pm *ProtocolManager) monitorDownloads() {
 	sub := pm.eventMux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
+	defer sub.Unsubscribe()
 
 	for {
 		select {

--- a/vendor/github.com/ethereum/go-ethereum/les/handler.go
+++ b/vendor/github.com/ethereum/go-ethereum/les/handler.go
@@ -124,6 +124,10 @@ type ProtocolManager struct {
 	// wait group is used for graceful shutdowns during downloading
 	// and processing
 	wg *sync.WaitGroup
+
+	// wait group is used for waiting for currend download
+	// to finish (if running)
+	downloads *sync.WaitGroup
 }
 
 // NewProtocolManager returns a new ethereum sub protocol manager. The Ethereum sub protocol manages peers capable
@@ -145,6 +149,7 @@ func NewProtocolManager(chainConfig *params.ChainConfig, lightSync bool, protoco
 		quitSync:    quitSync,
 		wg:          wg,
 		noMorePeers: make(chan struct{}),
+		downloads:   &sync.WaitGroup{},
 	}
 	if odr != nil {
 		manager.retriever = odr.retriever
@@ -210,7 +215,29 @@ func NewProtocolManager(chainConfig *params.ChainConfig, lightSync bool, protoco
 		manager.fetcher = newLightFetcher(manager)
 	}
 
+	go manager.monitorDownloads()
+
 	return manager, nil
+}
+
+func (pm *ProtocolManager) monitorDownloads() {
+	sub := pm.eventMux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
+
+	for {
+		select {
+		case event := <-sub.Chan():
+			if event == nil {
+				return
+			}
+
+			switch event.Data.(type) {
+			case downloader.StartEvent:
+				pm.downloads.Add(1)
+			case downloader.DoneEvent, downloader.FailedEvent:
+				pm.downloads.Done()
+			}
+		}
+	}
 }
 
 // removePeer initiates disconnection from a peer by removing it from the peer set
@@ -239,6 +266,8 @@ func (pm *ProtocolManager) Stop() {
 	pm.noMorePeers <- struct{}{}
 
 	close(pm.quitSync) // quits syncer, fetcher
+
+	pm.downloads.Wait() // Wait until current downloads are finished.
 
 	// Disconnect existing sessions.
 	// This also closes the gate for any new registrations on the peer set.


### PR DESCRIPTION
The `CRIT [02-12|10:57:59] Failed to store last header's hash       err="leveldb: closed"` happens when there are too many blocks to rollback when finishing processing.

See `eth/downloader/downloader.go:1146`
```go
func (d *Downloader) processHeaders(origin uint64, td *big.Int) error {
	// Calculate the pivoting point for switching from fast to slow sync
	pivot := d.queue.FastSyncPivot()

	// Keep a count of uncertain headers to roll back
	rollback := []*types.Header{}
	defer func() {
		if len(rollback) > 0 {
			//....
			d.lightchain.Rollback(hashes) // <<--- THIS!
                        //....
	}()
```

No code in the `les/*` actually waits for rollback to finish. If the computer is fast enough and if the rollback is quick enough (private network), it works, because of 
```go
// Stop implements node.Service, terminating all internal goroutines used by the
// Ethereum protocol.
func (s *LightEthereum) Stop() error {
        //...
	s.protocolManager.Stop() // Here we stop the downloader and start `Rollback` if needed
        //...

	time.Sleep(time.Millisecond * 200) // We wait for arbitrarty time span, sometimes it is enough
	s.chainDb.Close()  // ...and might close the DB even if Rollback didn't happen yet
        //...
}
```

This time is not enough on Travis and on a public network.

Closes #652 