### PR TITLE
fix broken Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -427,6 +427,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "74c0b717b81bb33bc09218c02f1077d366c5aa4b8294607695d36dc1cf94adc9"
+  inputs-digest = "a3526e2e159fe3c55522853ca1fb9f7d8d528cad2a70bb7582cfd8879b7adf71"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
our `Gopkg.lock` is out-of-sync, so vendor-check always fails
