### PR TITLE
Add topic prefix to a key that is used in mail server to access leveldb

### DIFF
--- a/_assets/patches/geth/0021-mailserver-db-topic-prefix.patch
+++ b/_assets/patches/geth/0021-mailserver-db-topic-prefix.patch
@@ -1,0 +1,44 @@
+diff --git i/whisper/mailserver/mailserver.go w/whisper/mailserver/mailserver.go
+index 0ec6ec570..cb84e4487 100644
+--- i/whisper/mailserver/mailserver.go
++++ w/whisper/mailserver/mailserver.go
+@@ -44,14 +44,15 @@ type DBKey struct {
+ 	raw       []byte
+ }
+ 
+-func NewDbKey(t uint32, h common.Hash) *DBKey {
+-	const sz = common.HashLength + 4
++func NewDbKey(topic whisper.TopicType, t uint32, h common.Hash) *DBKey {
++	const sz = common.HashLength + whisper.TopicLength + 4
+ 	var k DBKey
+ 	k.timestamp = t
+ 	k.hash = h
+ 	k.raw = make([]byte, sz)
+-	binary.BigEndian.PutUint32(k.raw, k.timestamp)
+-	copy(k.raw[4:], k.hash[:])
++	copy(k.raw[0:whisper.TopicLength], topic[:])
++	binary.BigEndian.PutUint32(k.raw[4:4+whisper.TopicLength], k.timestamp)
++	copy(k.raw[4+whisper.TopicLength:], k.hash[:])
+ 	return &k
+ }
+ 
+@@ -90,7 +91,7 @@ func (s *WMailServer) Close() {
+ }
+ 
+ func (s *WMailServer) Archive(env *whisper.Envelope) {
+-	key := NewDbKey(env.Expiry-env.TTL, env.Hash())
++	key := NewDbKey(env.Topic, env.Expiry-env.TTL, env.Hash())
+ 	rawEnvelope, err := rlp.EncodeToBytes(env)
+ 	if err != nil {
+ 		log.Error(fmt.Sprintf("rlp.EncodeToBytes failed: %s", err))
+@@ -119,8 +120,8 @@ func (s *WMailServer) processRequest(peer *whisper.Peer, lower, upper uint32, to
+ 	var err error
+ 	var zero common.Hash
+ 	var empty whisper.TopicType
+-	kl := NewDbKey(lower, zero)
+-	ku := NewDbKey(upper, zero)
++	kl := NewDbKey(topic, lower, zero)
++	ku := NewDbKey(topic, upper, zero)
+ 	i := s.db.NewIterator(&util.Range{Start: kl.raw, Limit: ku.raw}, nil)
+ 	defer i.Release()
+ 

--- a/_assets/patches/geth/README.md
+++ b/_assets/patches/geth/README.md
@@ -37,7 +37,7 @@ Instructions for creating a patch from the command line:
 - [`0014-whisperv6-notifications.patch`](./0014-whisperv6-notifications.patch) — adds Whisper v6 notifications (need to be reviewed and documented)
 - [`0015-whisperv6-envelopes-tracing.patch`](./0015-whisperv6-envelopes-tracing.patch) — adds Whisper v6 envelope tracing (need to be reviewed and documented)
 - [`0017-geth-18-downgrade-to-whisperv5.patch`](./0017-geth-18-downgrade-to-whisperv5.patch) — some files in geth 1.8 import Whisper v6, instead of v5. This patch ensures v5 is used everywhere
-
+- [`0021-mailserver-db-topic-prefix.patch`](./0021-mailserver-db-topic-prefix.patch) - add topic prefix to the key which is used by mail server to store envelopes.
 
 # Updating
 


### PR DESCRIPTION
LevelDB stores records in lexicographical order which allows making
range queries if keys are properly ordered. Originally only time queries
were allowed. By adding a topic prefix to a timestamp in big-endian order
allows us to make efficient queries using topic + timestamps.

It greatly saves the amount of resources (CPU and memory) that are used by mail servers.
The tradeoff is an inability to make queries with an empty topic. And this change is not backward compatible.
