### PR TITLE
[#FIXES-714] : Makefile GOBIN to use absolute path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ endif
 
 CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 BUILD_TAGS =
-GOBIN = build/bin
+GOBIN=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
+
 GO ?= latest
 XGOVERSION ?= 1.9.2
 XGOIMAGE = statusteam/xgo:$(XGOVERSION)


### PR DESCRIPTION
Using absolute path for GOBIN instead of a relative one
```
$ make xgo
docker pull statusteam/xgo:1.9.2
1.9.2: Pulling from statusteam/xgo
Digest: sha256:d7f275998ec52a2a0c19a223115a6aaf67ed6f5fa0bf327c41af54e8def22292
Status: Image is up to date for statusteam/xgo:1.9.2
go get github.com/karalabe/xgo
```
Closes #714 
