### PR TITLE
Add function that posts a message to the end of javascript runtime queue

### DIFF
--- a/t/e2e/whisper/whisper_jail_test.go
+++ b/t/e2e/whisper/whisper_jail_test.go
@@ -1,7 +1,6 @@
 package whisper
 
 import (
-	"runtime"
 	"testing"
 	"time"
 
@@ -66,11 +65,6 @@ func (s *WhisperJailTestSuite) TestJailWhisper() {
 
 	r := s.Require()
 
-	// Increase number of OS threads that can run go code simultaneously.
-	// Some test cases (namely test 3) require a higher number of parallel
-	// go routines to successfully complete without hanging.
-	runtime.GOMAXPROCS(3)
-
 	keyPairID1, err := s.AddKeyPair(TestConfig.Account1.Address, TestConfig.Account1.Password)
 	r.NoError(err)
 
@@ -123,7 +117,7 @@ func (s *WhisperJailTestSuite) TestJailWhisper() {
 					topic: topic,
 					sig: shh.getPublicKey(identity1),
 					pubKey: shh.getPublicKey(identity2),
-			  		payload: web3.toHex(payload),
+					payload: web3.toHex(payload),
 				};
 
 				var sent = shh.post(message)
@@ -165,7 +159,7 @@ func (s *WhisperJailTestSuite) TestJailWhisper() {
 					topic: topic,
 					sig: shh.getPublicKey(identity),
 					symKeyID: keyid,
-			  		payload: web3.toHex(payload),
+					payload: web3.toHex(payload),
 				};
 
 				var sent = shh.post(message)
@@ -192,21 +186,23 @@ func (s *WhisperJailTestSuite) TestJailWhisper() {
 					topics: [topic],
 					symKeyID: keyid
 				});
-
-				// post message
-				var message = {
+				// creating a filter is an async operation
+				setTimeout(function() {
+				  // post message
+				  var message = {
 					ttl: 10,
 					powTarget: 0.001,
 					powTime: 2,
 					topic: topic,
 					symKeyID: keyid,
-			  		payload: web3.toHex(payload),
-				};
+					payload: web3.toHex(payload),
+				  };
 
-				var sent = shh.post(message)
-				if (!sent) {
+				  var sent = shh.post(message)
+				  if (!sent) {
 					throw 'message not sent: ' + JSON.stringify(message);
-				}
+				  }
+				}, 0)
 			`,
 			true,
 		},
@@ -234,7 +230,7 @@ func (s *WhisperJailTestSuite) TestJailWhisper() {
 					powTime: 20,
 					topic: topic,
 					pubKey: shh.getPublicKey(identity),
-			  		payload: web3.toHex(payload),
+					payload: web3.toHex(payload),
 				};
 
 				var sent = shh.post(message)
@@ -269,10 +265,10 @@ func (s *WhisperJailTestSuite) TestJailWhisper() {
 					ttl: 10,
 					powTarget: 0.001,
 					powTime: 2,
-				  	sig: shh.getPublicKey(identity2),
-				  	pubKey: shh.getPublicKey(identity1),
-				  	topic: topic,
-				  	payload: web3.toHex(payload)
+					sig: shh.getPublicKey(identity2),
+					pubKey: shh.getPublicKey(identity1),
+					topic: topic,
+					payload: web3.toHex(payload)
 				};
 
 				var sent = shh.post(message)


### PR DESCRIPTION
I am not 100% percent sure what is happening but it seems that
newMessageFilter is async operation, result of this operation is assumed
to be used in callbacks. All other tests are doing at least 1 io operation
in between creating a filter and posting a message, and it must be enough
for newMessageFilter to complete.

Setting higher GOMAXPROCS allows Otto VM to execute received io requests
faster. While lower number of processes may result in events re-ordering. Could it be a bug in otto vm? I need someone who knows javascript runtime...

https://github.com/ethereum/web3.js/blob/develop/lib/web3/methods/shh.js#L39-L41

I tested this change with GOMAXPROCS=1 and it passes consistently.
