### PR TITLE
Make DiscoveryV5 follow node config.

### DIFF
--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -92,7 +92,7 @@ func defaultEmbeddedNodeConfig(config *params.NodeConfig) *node.Config {
 		Version:           config.Version,
 		P2P: p2p.Config{
 			NoDiscovery:      !config.Discovery,
-			DiscoveryV5:      true,
+			DiscoveryV5:      config.Discovery,
 			BootstrapNodes:   nil,
 			BootstrapNodesV5: nil,
 			ListenAddr:       config.ListenAddr,


### PR DESCRIPTION
We used to keep `DiscoveryV5` enabled even when `Discovery` flag was set to `false` via a node config.

During profiling on a device, I noticed that it consumes a significant amount of CPU and energy.

This commit disables `DiscoveryV5` if we disable discovery in a node config. We don't use discovery in our app at the moment.

Closes #724 
