### PR TITLE
Peer pool to manage v5 peers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -489,6 +489,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a21695ec5b17d68c9524831c9cc9321753525f1e404f17c41f5dbc6b20e0b1db"
+  inputs-digest = "2bdb7a811f635e7d86992a28dfa158f917167dd443bd5766945492c52bbd6534"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -489,6 +489,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2bdb7a811f635e7d86992a28dfa158f917167dd443bd5766945492c52bbd6534"
+  inputs-digest = "eff125b3ad51a2875bc0ee5f9d190ce65ee9fb774e79d8df0de7a7e4bf4e32f8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/statusd/topics.go
+++ b/cmd/statusd/topics.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/status-im/status-go/geth/params"
+)
+
+type topicsFlag []discv5.Topic
+
+func (f *topicsFlag) String() string {
+	return "discv5 topics"
+}
+
+func (f *topicsFlag) Set(value string) error {
+	*f = append(*f, discv5.Topic(strings.TrimSpace(value)))
+	return nil
+}
+
+type topicLimitsFlag map[discv5.Topic]params.Limits
+
+func (f *topicLimitsFlag) String() string {
+	return "disv5 topics to limits map"
+}
+
+func (f *topicLimitsFlag) Set(value string) error {
+	parts := strings.Split(strings.TrimSpace(value), "=")
+	if len(parts) != 2 {
+		return errors.New("topic must be separated by '=' from limits, e.g. 'topic1=1,1'")
+	}
+	limits := strings.Split(parts[1], ",")
+	if len(limits) != 2 {
+		return errors.New("min and max limit must be set, e.g. 'topic1=1,1'")
+	}
+	minL, err := strconv.Atoi(limits[0])
+	if err != nil {
+		return err
+	}
+	maxL, err := strconv.Atoi(limits[1])
+	if err != nil {
+		return err
+	}
+	(*f)[discv5.Topic(parts[0])] = params.Limits{minL, maxL}
+	return nil
+}

--- a/geth/db/db.go
+++ b/geth/db/db.go
@@ -1,16 +1,18 @@
 package db
 
 import (
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
-// CreateDatabase returns status pointer to leveldb.DB.
-func CreateDatabase(path string) (*leveldb.DB, error) {
+// Create returns status pointer to leveldb.DB.
+func Create(path string) (*leveldb.DB, error) {
 	opts := &opt.Options{OpenFilesCacheCapacity: 5}
 	db, err := leveldb.OpenFile(path, opts)
 	if _, iscorrupted := err.(*errors.ErrCorrupted); iscorrupted {
+		log.Info("database is corrupted trying to recover", "path", path)
 		db, err = leveldb.RecoverFile(path, nil)
 	}
 	if err != nil {

--- a/geth/db/db.go
+++ b/geth/db/db.go
@@ -1,0 +1,20 @@
+package db
+
+import (
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+)
+
+// CreateDatabase returns status pointer to leveldb.DB.
+func CreateDatabase(path string) (*leveldb.DB, error) {
+	opts := &opt.Options{OpenFilesCacheCapacity: 5}
+	db, err := leveldb.OpenFile(path, opts)
+	if _, iscorrupted := err.(*errors.ErrCorrupted); iscorrupted {
+		db, err = leveldb.RecoverFile(path, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return db, err
+}

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/whisper/mailserver"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
@@ -94,14 +95,12 @@ func defaultEmbeddedNodeConfig(config *params.NodeConfig) *node.Config {
 		Name:              config.Name,
 		Version:           config.Version,
 		P2P: p2p.Config{
-			NoDiscovery:      !config.Discovery,
-			DiscoveryV5:      config.Discovery,
-			BootstrapNodes:   nil,
-			BootstrapNodesV5: nil,
-			ListenAddr:       config.ListenAddr,
-			NAT:              nat.Any(),
-			MaxPeers:         config.MaxPeers,
-			MaxPendingPeers:  config.MaxPendingPeers,
+			NoDiscovery:     true,
+			DiscoveryV5:     config.Discovery,
+			ListenAddr:      config.ListenAddr,
+			NAT:             nat.Any(),
+			MaxPeers:        config.MaxPeers,
+			MaxPendingPeers: config.MaxPendingPeers,
 		},
 		IPCPath:          makeIPCPath(config),
 		HTTPCors:         []string{"*"},
@@ -120,7 +119,7 @@ func defaultEmbeddedNodeConfig(config *params.NodeConfig) *node.Config {
 
 	if config.ClusterConfig.Enabled {
 		nc.P2P.StaticNodes = parseNodes(config.ClusterConfig.StaticNodes)
-		nc.P2P.BootstrapNodes = parseNodes(config.ClusterConfig.BootNodes)
+		nc.P2P.BootstrapNodesV5 = parseNodesV5(config.ClusterConfig.BootNodes)
 	}
 
 	return nc
@@ -226,6 +225,15 @@ func parseNodes(enodes []string) []*discover.Node {
 	nodes := make([]*discover.Node, len(enodes))
 	for i, enode := range enodes {
 		nodes[i] = discover.MustParseNode(enode)
+	}
+	return nodes
+}
+
+// parseNodesV5 creates list of discv5.Node out of enode strings.
+func parseNodesV5(enodes []string) []*discv5.Node {
+	nodes := make([]*discv5.Node, len(enodes))
+	for i, enode := range enodes {
+		nodes[i] = discv5.MustParseNode(enode)
 	}
 	return nodes
 }

--- a/geth/node/status_node.go
+++ b/geth/node/status_node.go
@@ -53,10 +53,8 @@ type StatusNode struct {
 	peerPool *peers.PeerPool
 	db       *leveldb.DB
 
-	whisperService *whisper.Whisper   // reference to Whisper service
-	lesService     *les.LightEthereum // reference to LES service
-	rpcClient      *rpc.Client        // reference to RPC client
-	log            log.Logger
+	rpcClient *rpc.Client // reference to RPC client
+	log       log.Logger
 }
 
 // New makes new instance of StatusNode.

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/status-im/status-go/static"
 )
 
@@ -179,6 +180,9 @@ func (c *ClusterConfig) String() string {
 	return string(data)
 }
 
+// Limits represent min and max amount of peers
+type Limits [2]int
+
 // ----------
 // UpstreamRPCConfig
 // ----------
@@ -300,6 +304,9 @@ type NodeConfig struct {
 
 	// SwarmConfig extra configuration for Swarm and ENS
 	SwarmConfig *SwarmConfig `json:"SwarmConfig," validate:"structonly"`
+
+	RegisterTopics []discv5.Topic          `json:"RegisterTopics"`
+	RequireTopics  map[discv5.Topic]Limits `json:"RequireTopics"`
 }
 
 // NewNodeConfig creates new node configuration object

--- a/geth/params/defaults.go
+++ b/geth/params/defaults.go
@@ -7,6 +7,9 @@ const (
 	// DataDir is default data directory used by statusd executable
 	DataDir = "statusd-data"
 
+	// StatusDatabase path relative to DataDir.
+	StatusDatabase = "status-db"
+
 	// KeyStoreDir is default directory where private keys are stored, relative to DataDir
 	KeyStoreDir = "keystore"
 

--- a/geth/peers/cache.go
+++ b/geth/peers/cache.go
@@ -48,7 +48,7 @@ func (d *Cache) GetPeersRange(topic discv5.Topic, limit int) (nodes []*discv5.No
 	iterator := d.db.NewIterator(&util.Range{Start: key}, nil)
 	defer iterator.Release()
 	count := 0
-	for iterator.Next() {
+	for iterator.Next() && count < limit {
 		node := discv5.Node{}
 		value := iterator.Value()
 		if err := node.UnmarshalText(value); err != nil {
@@ -57,9 +57,6 @@ func (d *Cache) GetPeersRange(topic discv5.Topic, limit int) (nodes []*discv5.No
 		}
 		nodes = append(nodes, &node)
 		count++
-		if count == limit {
-			return nodes
-		}
 	}
 	return nodes
 }

--- a/geth/peers/cache.go
+++ b/geth/peers/cache.go
@@ -1,0 +1,65 @@
+package peers
+
+import (
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+// NewCache returns instance of PeersDatabase
+func NewCache(db *leveldb.DB) *Cache {
+	return &Cache{db: db}
+}
+
+// Cache maintains list of peers that were discovered.
+type Cache struct {
+	db *leveldb.DB
+}
+
+func makePeerKey(peerID discv5.NodeID, topic discv5.Topic) []byte {
+	topicLen := len([]byte(topic))
+	lth := topicLen + len(peerID)
+	key := make([]byte, lth)
+	copy(key[:], topic[:])
+	copy(key[topicLen:], peerID[:])
+	return key
+}
+
+// AddPeer stores peer with a following key: <topic><peer ID>
+func (d *Cache) AddPeer(peer *discv5.Node, topic discv5.Topic) error {
+	data, err := peer.MarshalText()
+	if err != nil {
+		return err
+	}
+	return d.db.Put(makePeerKey(peer.ID, topic), data, nil)
+}
+
+// RemovePeer deletes a peer from database.
+func (d *Cache) RemovePeer(peerID discv5.NodeID, topic discv5.Topic) error {
+	return d.db.Delete(makePeerKey(peerID, topic), nil)
+}
+
+// GetPeersRange returns peers for a given topic with a limit.
+func (d *Cache) GetPeersRange(topic discv5.Topic, limit int) (nodes []*discv5.Node) {
+	topicLen := len([]byte(topic))
+	key := make([]byte, topicLen)
+	copy(key[:], []byte(topic))
+	iterator := d.db.NewIterator(&util.Range{Start: key}, nil)
+	defer iterator.Release()
+	count := 0
+	for iterator.Next() {
+		node := discv5.Node{}
+		value := iterator.Value()
+		if err := node.UnmarshalText(value); err != nil {
+			log.Error("can't unmarshal node", "value", value, "error", err)
+			continue
+		}
+		nodes = append(nodes, &node)
+		count++
+		if count == limit {
+			return nodes
+		}
+	}
+	return nodes
+}

--- a/geth/peers/cache_test.go
+++ b/geth/peers/cache_test.go
@@ -1,0 +1,48 @@
+package peers
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/status-im/status-go/geth/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeersRange(t *testing.T) {
+	path, err := ioutil.TempDir("/tmp", "status-peers-test-")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(path))
+	}()
+	rootDB, err := db.CreateDatabase(path)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, rootDB.Close())
+	}()
+
+	peersDB := Cache{db: rootDB}
+	topic := discv5.Topic("test")
+	peers := [3]*discv5.Node{
+		discv5.NewNode(discv5.NodeID{3}, net.IPv4(100, 100, 0, 3), 32311, 32311),
+		discv5.NewNode(discv5.NodeID{4}, net.IPv4(100, 100, 0, 4), 32311, 32311),
+		discv5.NewNode(discv5.NodeID{2}, net.IPv4(100, 100, 0, 2), 32311, 32311),
+	}
+	for _, peer := range peers {
+		assert.NoError(t, peersDB.AddPeer(peer, topic))
+	}
+	nodes := peersDB.GetPeersRange(topic, 3)
+	require.Len(t, nodes, 3)
+	// object will be ordered by memcpy order of bytes 2,3,4 in our case
+	// order of tests is intentionally mixed to make it obvious that range is
+	// not ordered by the insertion time
+	assert.Equal(t, peers[2].String(), nodes[0].String())
+	assert.Equal(t, peers[0].String(), nodes[1].String())
+	assert.Equal(t, peers[1].String(), nodes[2].String())
+
+	assert.NoError(t, peersDB.RemovePeer(peers[1].ID, topic))
+	require.Len(t, peersDB.GetPeersRange(topic, 3), 2)
+}

--- a/geth/peers/cache_test.go
+++ b/geth/peers/cache_test.go
@@ -18,7 +18,7 @@ func TestPeersRange(t *testing.T) {
 	defer func() {
 		require.NoError(t, os.RemoveAll(path))
 	}()
-	rootDB, err := db.CreateDatabase(path)
+	rootDB, err := db.Create(path)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, rootDB.Close())

--- a/geth/peers/peerpool.go
+++ b/geth/peers/peerpool.go
@@ -1,0 +1,150 @@
+package peers
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+
+	"github.com/status-im/status-go/geth/params"
+)
+
+var (
+	// ErrDiscv5NotRunning returned when pool is started but discover v5 is not running or not enabled.
+	ErrDiscv5NotRunning = errors.New("Discovery v5 is not running")
+)
+
+const (
+	// expirationPeriod is an amount of time while peer is considered as a connectable
+	expirationPeriod = 60 * time.Minute
+	// DefaultFastSync is a recommended value for aggressive peers search.
+	DefaultFastSync = 3 * time.Second
+	// DefaultSlowSync is a recommended value for slow (background) peers search.
+	DefaultSlowSync = 30 * time.Minute
+)
+
+// NewPeerPool creates instance of PeerPool
+func NewPeerPool(config map[discv5.Topic]params.Limits, fastSync, slowSync time.Duration, cache *Cache, stopOnMax bool) *PeerPool {
+	return &PeerPool{
+		config:    config,
+		fastSync:  fastSync,
+		slowSync:  slowSync,
+		cache:     cache,
+		stopOnMax: stopOnMax,
+	}
+}
+
+type peerInfo struct {
+	// discoveredTime last time when node was found by v5
+	discoveredTime mclock.AbsTime
+	// connected is true if node is added as a static peer
+	connected bool
+
+	node *discv5.Node
+}
+
+// PeerPool manages discovered peers and connects them to p2p server
+type PeerPool struct {
+	// config can be set only once per pool life cycle
+	config    map[discv5.Topic]params.Limits
+	fastSync  time.Duration
+	slowSync  time.Duration
+	cache     *Cache
+	stopOnMax bool
+
+	mu                 sync.RWMutex
+	topics             []*TopicPool
+	serverSubscription event.Subscription
+	quit               chan struct{}
+
+	wg sync.WaitGroup
+}
+
+// Start creates topic pool for each topic in config and subscribes to server events.
+func (p *PeerPool) Start(server *p2p.Server) error {
+	if server.DiscV5 == nil {
+		return ErrDiscv5NotRunning
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.quit = make(chan struct{})
+	p.topics = make([]*TopicPool, 0, len(p.config))
+	for topic, limits := range p.config {
+		topicPool := NewTopicPool(topic, limits, p.slowSync, p.fastSync)
+		if err := topicPool.StartSearch(server); err != nil {
+			return err
+		}
+		p.topics = append(p.topics, topicPool)
+	}
+
+	events := make(chan *p2p.PeerEvent, 20)
+	p.serverSubscription = server.SubscribeEvents(events)
+	p.wg.Add(1)
+	go func() {
+		p.handleServerPeers(server, events)
+		p.wg.Done()
+	}()
+	return nil
+}
+
+// handleServerPeers watches server peer events, notifies topic pools about changes
+// in the peer set and stops the discv5 if all topic pools collected enough peers.
+func (p *PeerPool) handleServerPeers(server *p2p.Server, events <-chan *p2p.PeerEvent) {
+	for {
+		select {
+		case <-p.quit:
+			return
+		case event := <-events:
+			switch event.Type {
+			case p2p.PeerEventTypeDrop:
+				p.mu.Lock()
+				for _, t := range p.topics {
+					t.ConfirmDropped(server, event.Peer, event.Error)
+					// TODO(dshulyak) restart discv5 if peers number dropped too low
+				}
+				p.mu.Unlock()
+			case p2p.PeerEventTypeAdd:
+				p.mu.Lock()
+				total := 0
+				for _, t := range p.topics {
+					t.ConfirmAdded(server, event.Peer)
+					if p.stopOnMax && t.MaxReached() {
+						total++
+						t.StopSearch()
+					}
+				}
+				if p.stopOnMax && total == len(p.config) {
+					log.Debug("closing discv5 connection")
+					server.DiscV5.Close()
+				}
+				p.mu.Unlock()
+			}
+		}
+	}
+}
+
+// Stop closes pool quit channel and all channels that are watched by search queries
+// and waits till all goroutines will exit.
+func (p *PeerPool) Stop() {
+	// pool wasn't started
+	if p.quit == nil {
+		return
+	}
+	select {
+	case <-p.quit:
+		return
+	default:
+		log.Debug("started closing peer pool")
+		close(p.quit)
+	}
+	p.serverSubscription.Unsubscribe()
+	for _, t := range p.topics {
+		t.StopSearch()
+	}
+	p.wg.Wait()
+}

--- a/geth/peers/peerpool_test.go
+++ b/geth/peers/peerpool_test.go
@@ -1,0 +1,116 @@
+package peers
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/status-im/status-go/geth/params"
+)
+
+type PeerPoolSimulationSuite struct {
+	suite.Suite
+
+	bootnode *p2p.Server
+	peers    []*p2p.Server
+}
+
+func TestPeerPoolSimulationSuite(t *testing.T) {
+	suite.Run(t, new(PeerPoolSimulationSuite))
+}
+
+func (s *PeerPoolSimulationSuite) freePort() int {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	s.Require().NoError(err)
+	l, err := net.ListenTCP("tcp", addr)
+	s.Require().NoError(err)
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func (s *PeerPoolSimulationSuite) SetupTest() {
+	// :0 can't be passed to p2p config, cause it will be used for Self()
+	// which breaks things
+	port := s.freePort()
+	key, _ := crypto.GenerateKey()
+	name := common.MakeName("bootnode", "1.0")
+	// 127.0.0.1 is invalidated by discovery v5
+	s.bootnode = &p2p.Server{
+		Config: p2p.Config{
+			MaxPeers:    10,
+			Name:        name,
+			ListenAddr:  fmt.Sprintf("0.0.0.0:%d", port),
+			PrivateKey:  key,
+			DiscoveryV5: true,
+			NoDiscovery: true,
+		},
+	}
+	s.Require().NoError(s.bootnode.Start())
+	bootnodeV5 := discv5.NewNode(s.bootnode.DiscV5.Self().ID, net.ParseIP("127.0.0.1"), uint16(port), uint16(port))
+
+	s.peers = make([]*p2p.Server, 2)
+	for i := range s.peers {
+		key, _ := crypto.GenerateKey()
+		peer := &p2p.Server{
+			Config: p2p.Config{
+				MaxPeers:         10,
+				Name:             common.MakeName("peer-"+strconv.Itoa(i), "1.0"),
+				ListenAddr:       fmt.Sprintf("0.0.0.0:%d", s.freePort()),
+				PrivateKey:       key,
+				DiscoveryV5:      true,
+				NoDiscovery:      true,
+				BootstrapNodesV5: []*discv5.Node{bootnodeV5},
+			},
+		}
+		s.NoError(peer.Start())
+		s.peers[i] = peer
+	}
+}
+
+func (s *PeerPoolSimulationSuite) TestSingleTopicDiscovery() {
+	topic := discv5.Topic("cap=test")
+	expectedConnections := 1
+	// simulation should only rely on fast sync
+	config := map[discv5.Topic]params.Limits{
+		topic: {expectedConnections, expectedConnections},
+	}
+	peerPool := NewPeerPool(config, 100*time.Millisecond, 100*time.Millisecond, nil, false)
+	register := NewRegister(topic)
+	s.Require().NoError(register.Start(s.peers[0]))
+	defer register.Stop()
+	// need to wait for topic to get registered, discv5 can query same node
+	// for a topic only once a minute
+	events := make(chan *p2p.PeerEvent, 20)
+	subscription := s.peers[1].SubscribeEvents(events)
+	defer subscription.Unsubscribe()
+	s.NoError(peerPool.Start(s.peers[1]))
+	defer peerPool.Stop()
+	connected := 0
+	for {
+		select {
+		case ev := <-events:
+			if ev.Type == p2p.PeerEventTypeAdd {
+				connected++
+			}
+		case <-time.After(5 * time.Second):
+			s.Require().FailNowf("waiting for peers timed out", strconv.Itoa(connected))
+		}
+		if connected == expectedConnections {
+			break
+		}
+	}
+}
+
+func (s *PeerPoolSimulationSuite) TearDown() {
+	s.bootnode.Stop()
+	for _, p := range s.peers {
+		p.Stop()
+	}
+}

--- a/geth/peers/topic_register.go
+++ b/geth/peers/topic_register.go
@@ -1,0 +1,54 @@
+package peers
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+)
+
+// Register manages register topic queries
+type Register struct {
+	topics []discv5.Topic
+
+	wg   sync.WaitGroup
+	quit chan struct{}
+}
+
+// NewRegister creates instance of topic register
+func NewRegister(topics ...discv5.Topic) *Register {
+	return &Register{topics: topics}
+}
+
+// Start topic register query for every topic
+func (r *Register) Start(server *p2p.Server) error {
+	if server.DiscV5 == nil {
+		return ErrDiscv5NotRunning
+	}
+	r.quit = make(chan struct{})
+	for _, topic := range r.topics {
+		r.wg.Add(1)
+		go func(t discv5.Topic) {
+			log.Debug("v5 register topic", "topic", t)
+			server.DiscV5.RegisterTopic(t, r.quit)
+			r.wg.Done()
+		}(topic)
+	}
+	return nil
+}
+
+// Stop all register topic queries and waits for them to exit
+func (r *Register) Stop() {
+	if r.quit == nil {
+		return
+	}
+	select {
+	case <-r.quit:
+		return
+	default:
+		close(r.quit)
+	}
+	log.Debug("waiting for register queries to exit")
+	r.wg.Wait()
+}

--- a/geth/peers/topicpool.go
+++ b/geth/peers/topicpool.go
@@ -35,7 +35,7 @@ type TopicPool struct {
 	running int32
 
 	mu         sync.RWMutex
-	discvWG    sync.WaitGroup
+	discWG     sync.WaitGroup
 	consumerWG sync.WaitGroup
 	connected  int
 	peers      map[discv5.NodeID]*peerInfo
@@ -155,10 +155,10 @@ func (t *TopicPool) StartSearch(server *p2p.Server) error {
 			found <- peer
 		}
 	}
-	t.discvWG.Add(1)
+	t.discWG.Add(1)
 	go func() {
 		server.DiscV5.SearchTopic(t.topic, t.period, found, lookup)
-		t.discvWG.Done()
+		t.discWG.Done()
 	}()
 	t.consumerWG.Add(1)
 	go func() {
@@ -239,5 +239,5 @@ func (t *TopicPool) StopSearch() {
 	t.consumerWG.Wait()
 	atomic.StoreInt32(&t.running, 0)
 	close(t.period)
-	t.discvWG.Wait()
+	t.discWG.Wait()
 }

--- a/geth/peers/topicpool.go
+++ b/geth/peers/topicpool.go
@@ -1,0 +1,243 @@
+package peers
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/status-im/status-go/geth/params"
+)
+
+// NewTopicPool returns instance of TopicPool
+func NewTopicPool(topic discv5.Topic, limits params.Limits, slowSync, fastSync time.Duration) *TopicPool {
+	return &TopicPool{
+		topic:    topic,
+		limits:   limits,
+		slowSync: slowSync,
+		fastSync: fastSync,
+		peers:    map[discv5.NodeID]*peerInfo{},
+	}
+}
+
+// TopicPool manages peers for topic.
+type TopicPool struct {
+	topic    discv5.Topic
+	limits   params.Limits
+	slowSync time.Duration
+	fastSync time.Duration
+
+	quit    chan struct{}
+	running int32
+
+	mu         sync.RWMutex
+	discvWG    sync.WaitGroup
+	consumerWG sync.WaitGroup
+	connected  int
+	peers      map[discv5.NodeID]*peerInfo
+	period     chan time.Duration
+
+	cache *Cache
+}
+
+// SearchRunning returns true if search is running
+func (t *TopicPool) SearchRunning() bool {
+	return atomic.LoadInt32(&t.running) == 1
+}
+
+// MaxReached returns true if we connected with max number of peers.
+func (t *TopicPool) MaxReached() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.connected == t.limits[1]
+}
+
+// ConfirmAdded called when peer was added by p2p Server.
+// 1. Skip a peer if it not in our peer table
+// 2. Add a peer to a cache.
+// 3. Disconnect a peer if it was connected after we reached max limit of peers.
+//    (we can't know in advance if peer will be connected, thats why we allow
+//     to overflow for short duration)
+// 4. Switch search to slow mode if it is running.
+func (t *TopicPool) ConfirmAdded(server *p2p.Server, nodeID discover.NodeID) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	// inbound connection
+	peer, exist := t.peers[discv5.NodeID(nodeID)]
+	if !exist {
+		return
+	}
+	// established connection means that the node is a viable candidate for a connection and can be cached
+	if t.cache != nil {
+		if err := t.cache.AddPeer(peer.node, t.topic); err != nil {
+			log.Error("failed to persist a peer", "error", err)
+		}
+	}
+	// when max limit is reached drop every peer after
+	if t.connected == t.limits[1] {
+		log.Debug("max limit is reached drop the peer", "ID", nodeID, "topic", t.topic)
+		t.removePeer(server, peer)
+		return
+	}
+	// don't count same peer twice
+	if !peer.connected {
+		log.Debug("marking as connected", "ID", nodeID)
+		peer.connected = true
+		t.connected++
+	}
+	if t.SearchRunning() && t.connected == t.limits[0] {
+		t.period <- t.slowSync
+	}
+}
+
+// ConfirmDropped called when server receives drop event.
+// 1. Skip peer if it is not in our peer table.
+// 2. If disconnect request - we could drop that peer ourselves.
+// 3. If connected number will drop below min limit - switch to fast mode.
+// 4. Delete a peer from cache and peer table.
+// 5. Connect with another valid peer, if such is available.
+func (t *TopicPool) ConfirmDropped(server *p2p.Server, nodeID discover.NodeID, reason string) (new bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	// either inbound or connected from another topic
+	peer, exist := t.peers[discv5.NodeID(nodeID)]
+	if !exist {
+		return false
+	}
+	log.Debug("disconnect reason", "peer", nodeID, "reason", reason)
+	// if requested - we don't need to remove peer from cache and look for a replacement
+	if reason == p2p.DiscRequested.Error() {
+		return false
+	}
+	if t.SearchRunning() && t.connected == t.limits[0] {
+		t.period <- t.fastSync
+	}
+	t.connected--
+	t.removePeer(server, peer)
+	delete(t.peers, discv5.NodeID(nodeID))
+	if t.cache != nil {
+		if err := t.cache.RemovePeer(discv5.NodeID(nodeID), t.topic); err != nil {
+			log.Error("failed to remove peer from cache", "error", err)
+		}
+	}
+	// TODO use a heap queue and always get a peer that was discovered recently
+	for _, peer := range t.peers {
+		if !peer.connected && mclock.Now() < peer.discoveredTime+mclock.AbsTime(expirationPeriod) {
+			t.addPeer(server, peer)
+			return true
+		}
+	}
+	return false
+}
+
+// StartSearch creates discv5 queries and runs a loop to consume found peers.
+func (t *TopicPool) StartSearch(server *p2p.Server) error {
+	if atomic.LoadInt32(&t.running) == 1 {
+		return nil
+	}
+	if server.DiscV5 == nil {
+		return ErrDiscv5NotRunning
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	atomic.StoreInt32(&t.running, 1)
+	t.quit = make(chan struct{})
+	t.period = make(chan time.Duration, 2) // 2 allows to send slow and then fast without blocking a producer
+	found := make(chan *discv5.Node, 5)    // 5 reasonable number for concurrently found nodes
+	lookup := make(chan bool, 10)          // sufficiently buffered channel, just prevents blocking because of lookup
+	if t.cache != nil {
+		for _, peer := range t.cache.GetPeersRange(t.topic, 5) {
+			log.Debug("adding a peer from cache", "peer", peer)
+			found <- peer
+		}
+	}
+	t.discvWG.Add(1)
+	go func() {
+		server.DiscV5.SearchTopic(t.topic, t.period, found, lookup)
+		t.discvWG.Done()
+	}()
+	t.consumerWG.Add(1)
+	go func() {
+		t.handleFoundPeers(server, found, lookup)
+		t.consumerWG.Done()
+	}()
+	return nil
+}
+
+func (t *TopicPool) handleFoundPeers(server *p2p.Server, found <-chan *discv5.Node, lookup <-chan bool) {
+	t.period <- t.fastSync
+	selfID := discv5.NodeID(server.Self().ID)
+	for {
+		select {
+		case <-t.quit:
+			return
+		case <-lookup:
+		case node := <-found:
+			if node.ID != selfID {
+				t.processFoundNode(server, node)
+			}
+		}
+	}
+}
+
+// processFoundNode called when node is discovered by kademlia search query
+// 2 important conditions
+// 1. every time when node is processed we need to update discoveredTime.
+//    peer will be considered as valid later only if it was discovered < 60m ago
+// 2. if peer is connected or if max limit is reached we are not a adding peer to p2p server
+func (t *TopicPool) processFoundNode(server *p2p.Server, node *discv5.Node) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if info, exist := t.peers[node.ID]; exist {
+		info.discoveredTime = mclock.Now()
+	} else {
+		t.peers[node.ID] = &peerInfo{
+			discoveredTime: mclock.Now(),
+			node:           node,
+		}
+	}
+	if t.connected < t.limits[1] && !t.peers[node.ID].connected {
+		log.Debug("peer found", "ID", node.ID, "topic", t.topic)
+		t.addPeer(server, t.peers[node.ID])
+	}
+}
+
+func (t *TopicPool) addPeer(server *p2p.Server, info *peerInfo) {
+	server.AddPeer(discover.NewNode(
+		discover.NodeID(info.node.ID),
+		info.node.IP,
+		info.node.UDP,
+		info.node.TCP,
+	))
+}
+
+func (t *TopicPool) removePeer(server *p2p.Server, info *peerInfo) {
+	server.RemovePeer(discover.NewNode(
+		discover.NodeID(info.node.ID),
+		info.node.IP,
+		info.node.UDP,
+		info.node.TCP,
+	))
+}
+
+// StopSearch stops the closes stop
+func (t *TopicPool) StopSearch() {
+	if t.quit == nil {
+		return
+	}
+	select {
+	case <-t.quit:
+		return
+	default:
+		log.Debug("stoping search", "topic", t.topic)
+		close(t.quit)
+	}
+	t.consumerWG.Wait()
+	atomic.StoreInt32(&t.running, 0)
+	close(t.period)
+	t.discvWG.Wait()
+}

--- a/geth/peers/topicpool_test.go
+++ b/geth/peers/topicpool_test.go
@@ -1,0 +1,96 @@
+package peers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/status-im/status-go/geth/params"
+	"github.com/stretchr/testify/suite"
+)
+
+type TopicPoolSuite struct {
+	suite.Suite
+
+	peer      *p2p.Server
+	topicPool *TopicPool
+}
+
+func TestTopicPoolSuite(t *testing.T) {
+	suite.Run(t, new(TopicPoolSuite))
+}
+
+func (s *TopicPoolSuite) SetupTest() {
+	key, _ := crypto.GenerateKey()
+	name := common.MakeName("peer", "1.0")
+	s.peer = &p2p.Server{
+		Config: p2p.Config{
+			MaxPeers:    10,
+			Name:        name,
+			ListenAddr:  "0.0.0.0:0",
+			PrivateKey:  key,
+			NoDiscovery: true,
+		},
+	}
+	s.Require().NoError(s.peer.Start())
+	topic := discv5.Topic("cap=cap1")
+	limits := params.Limits{1, 2}
+	s.topicPool = NewTopicPool(topic, limits, 100*time.Millisecond, 200*time.Millisecond)
+	s.topicPool.period = make(chan time.Duration, 2)
+	s.topicPool.running = 1
+}
+
+func (s *TopicPoolSuite) TearDown() {
+	s.peer.Stop()
+}
+
+func (s *TopicPoolSuite) AssertConsumed(channel chan time.Duration, expected time.Duration, timeout time.Duration) {
+	select {
+	case received := <-channel:
+		s.Equal(expected, received)
+	case <-time.After(timeout):
+		s.FailNow("timed out waiting")
+	}
+}
+
+func (s *TopicPoolSuite) TestSyncSwitches() {
+	testPeer := discv5.NewNode(discv5.NodeID{1}, s.peer.Self().IP, 32311, 32311)
+	s.topicPool.processFoundNode(s.peer, testPeer)
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(testPeer.ID))
+	s.AssertConsumed(s.topicPool.period, s.topicPool.slowSync, time.Second)
+	s.True(s.topicPool.peers[testPeer.ID].connected)
+	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(testPeer.ID), p2p.DiscProtocolError.Error())
+	s.AssertConsumed(s.topicPool.period, s.topicPool.fastSync, time.Second)
+}
+
+func (s *TopicPoolSuite) TestNewPeerSelectedOnDrop() {
+	peer1 := discv5.NewNode(discv5.NodeID{1}, s.peer.Self().IP, 32311, 32311)
+	peer2 := discv5.NewNode(discv5.NodeID{2}, s.peer.Self().IP, 32311, 32311)
+	peer3 := discv5.NewNode(discv5.NodeID{3}, s.peer.Self().IP, 32311, 32311)
+	// add 3 nodes and confirm connection for 1 and 2
+	s.topicPool.processFoundNode(s.peer, peer1)
+	s.topicPool.processFoundNode(s.peer, peer2)
+	s.topicPool.processFoundNode(s.peer, peer3)
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer1.ID))
+	s.True(s.topicPool.peers[peer1.ID].connected)
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer2.ID))
+	s.True(s.topicPool.peers[peer2.ID].connected)
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer3.ID))
+	s.False(s.topicPool.peers[peer3.ID].connected)
+
+	s.True(s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer1.ID), p2p.DiscNetworkError.Error()))
+}
+
+func (s *TopicPoolSuite) TestRequestedDoesntRemove() {
+	peer1 := discv5.NewNode(discv5.NodeID{1}, s.peer.Self().IP, 32311, 32311)
+	s.topicPool.processFoundNode(s.peer, peer1)
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer1.ID))
+	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer1.ID), p2p.DiscRequested.Error())
+	s.Contains(s.topicPool.peers, peer1.ID)
+	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer1.ID), p2p.DiscProtocolError.Error())
+	s.NotContains(s.topicPool.peers, peer1.ID)
+}


### PR DESCRIPTION
Peer pool works in a following way:
1. For each configured topic it will create discovery v5 search query.
Search query will periodically do regular kademlia lookups with bucket size 16
and send a topic query to every node that is returned from kademlia lookup.
Eventually nodes with required topics will be found and we will pass them to p2p server.
2. Additional loop will be created for every topic that will synchronize
found nodes with p2p server. This loop will follow next logic:
- if node is found and max limit of peers is not reached we will add this node to
  server and assume that it is connected
- if max limit is reached we will add peer to our peer topic table for later use
- if min limit is reached - frequency will be changed to a keepalive timer, this is required cause we need
  frequent lookups only when we are looking for a peer
3. when peer is disconnected we do 3 things:
  - select new peer from peers table that was updated no longer than foundTimeout (90s) and not
    connected at the moment
  - set a peer as not connected
  - check how many peers do we have and in case if we went below min limit - set period to fastSync

More details on how this is tested: https://github.com/status-im/status-scale/pull/4
Depends on https://github.com/status-im/status-go/pull/749

In general it is quite expensive to use discovery (including v5) on mobile devices, without any tuning it generates 1-2 mb of traffic a minute if there new participants in the network, and because mobile connections are usually transient, we will be able to see this pattern.
One thing that we may explore is to persist found nodes for different topics, so that discovery can be started in slow mode every time after initial peers are discovered.