### PR TITLE
Enable metrics by default when building docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ endif
 CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
 
-BUILD_TAGS =
 BUILD_FLAGS := $(shell echo "-ldflags '-X main.buildStamp=`date -u '+%Y-%m-%d.%H:%M:%S'` -X main.gitCommit=$(git rev-parse HEAD)'")
 
 GO ?= latest
@@ -25,7 +24,7 @@ networkid ?= StatusChain
 DOCKER_IMAGE_NAME ?= statusteam/status-go
 
 DOCKER_TEST_WORKDIR = /go/src/github.com/status-im/status-go/
-DOCKER_TEST_IMAGE  = golang:1.9
+DOCKER_TEST_IMAGE = golang:1.9
 
 UNIT_TEST_PACKAGES := $(shell go list ./...  | grep -v /vendor | grep -v /t/e2e | grep -v /t/destructive | grep -v /cmd | grep -v /lib)
 
@@ -84,6 +83,7 @@ statusgo-library: ##@cross-compile Build status-go as static library for current
 	@echo "Static library built:"
 	@ls -la $(GOBIN)/libstatus.*
 
+docker-image: BUILD_TAGS ?= metrics prometheus
 docker-image: ##@docker Build docker image (use DOCKER_IMAGE_NAME to set the image name)
 	@echo "Building docker image..."
 	docker build --file _assets/build/Dockerfile --build-arg "build_tags=$(BUILD_TAGS)" . -t $(DOCKER_IMAGE_NAME):latest


### PR DESCRIPTION
When status-go is built as a docker image, we usually run it on a server and it is desired to have Prometheus metrics available. In all other builds, metrics are disabled.