### PR TITLE
Fix make ci running on Jenkins

### DIFF
--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -63,7 +63,7 @@ func init() {
 	const pathSeparator = string(os.PathSeparator)
 	RootDir = filepath.Dir(pwd)
 	pathDirs := strings.Split(RootDir, pathSeparator)
-	for i := range pathDirs {
+	for i := len(pathDirs) - 1; i >= 0; i-- {
 		if pathDirs[i] == "status-go" {
 			RootDir = filepath.Join(pathDirs[:i+1]...)
 			RootDir = filepath.Join(pathSeparator, RootDir)


### PR DESCRIPTION
Take into consideration that path may contain multiple `status-go` directories, take the last

- Happens in Jenkins

Jenkins folder from where executable runs can contain `status-go` as a parent folder, we should take the last directory in the path to make sure we're picking the right one.

https://jenkins.status.im/job/status-go/job/status-go-manual/106/console is failing because of this (I'm trying to re-enable `make ci` on that build definition):

![image](https://user-images.githubusercontent.com/138074/37972156-f101af06-31d7-11e8-909a-baabffee0545.png)
