### PR TITLE
Go cover is not longer maintained since go 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ go:
 sudo: false
 dist: trusty
 install:
-- go get golang.org/x/tools/cmd/cover
 - make mock-install
 - make lint-install
 - make dep-install


### PR DESCRIPTION
Remove travis dependency on go cover

Many builds have been broken because of a timeout trying to pull `golang.org/x/tools/cmd/cover`. As go cover [is not being maintained anymore](https://github.com/golang/tools/tree/master/cmd/cover) remove this dependency

Important changes:
- [x] Removed go cover import from .travis.yml

Closes #781
