### PR TITLE
Run lint and vendor-check on the same travis stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ install:
 - make dep-install
 jobs:
   include:
-  - stage: Lint
-    script: make lint
-  - stage: Vendor Check
-    script: make vendor-check
+  - stage: Lint & Vendor Check
+    script:
+      - make lint
+      - make vendor-check
   - stage: Test unit and integration
     script: make test-unit-coverage
   - stage: Test e2e on private network


### PR DESCRIPTION
Merge lint and vendor-check build stages on travis build and reduce the build time.

Time results based on 2 different build stages:
```
3.11 + 2.50 = 6.00 min 
```

Time results based on a merged build:
```
4.33 min
```