### PR TITLE
[#732] Create status-go API to return a current revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ endif
 
 CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
+GIT_COMMIT := $(shell git rev-parse --short HEAD)
 
-BUILD_FLAGS := $(shell echo "-ldflags '-X main.buildStamp=`date -u '+%Y-%m-%d.%H:%M:%S'` -X main.gitCommit=$(git rev-parse HEAD)'")
+BUILD_FLAGS := $(shell echo "-ldflags '-X main.buildStamp=`date -u '+%Y-%m-%d.%H:%M:%S'` -X main.gitCommit=$(GIT_COMMIT)  -X github.com/status-im/status-go/geth/params.VersionMeta=$(GIT_COMMIT)'")
 
 GO ?= latest
 XGOVERSION ?= 1.9.2

--- a/geth/params/version.go
+++ b/geth/params/version.go
@@ -13,10 +13,10 @@ const (
 
 	// VersionPatch is a patch version component of the current release
 	VersionPatch = 9
-
-	// VersionMeta is metadata to append to the version string
-	VersionMeta = "unstable"
 )
+
+// VersionMeta is metadata to append to the version string
+var VersionMeta string // rely on linker: -ldflags -X github.com/status-im/status-go/geth/params.VersionMeta"
 
 // Version exposes string representation of program version.
 var Version = fmt.Sprintf("%d.%d.%d-%s", VersionMajor, VersionMinor, VersionPatch, VersionMeta)


### PR DESCRIPTION
Change `BUILD_FLAGS` in Makefile and update `github.com/status-im/status-go/geth/params.VersionMeta` value with the current Git SHA.

Closes #732
