### PR TITLE
[#797] Unify EnsureSync on t/utils/utils.go and StatusManager

### DIFF
--- a/lib/library_test_utils.go
+++ b/lib/library_test_utils.go
@@ -255,7 +255,7 @@ func testResetChainData(t *testing.T) bool {
 		return false
 	}
 
-	EnsureNodeSync(statusAPI.StatusNode())
+	EnsureNodeSync(statusAPI.StatusNode().EnsureSync)
 	testCompleteTransaction(t)
 
 	return true
@@ -771,7 +771,7 @@ func testCompleteTransaction(t *testing.T) bool {
 	txQueue := txQueueManager.TransactionQueue()
 
 	txQueue.Reset()
-	EnsureNodeSync(statusAPI.StatusNode())
+	EnsureNodeSync(statusAPI.StatusNode().EnsureSync)
 
 	// log into account from which transactions will be sent
 	if err := statusAPI.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password); err != nil {
@@ -1439,7 +1439,7 @@ func startTestNode(t *testing.T) <-chan struct{} {
 			// sync
 			if syncRequired {
 				t.Logf("Sync is required")
-				EnsureNodeSync(statusAPI.StatusNode())
+				EnsureNodeSync(statusAPI.StatusNode().EnsureSync)
 			} else {
 				time.Sleep(5 * time.Second)
 			}

--- a/t/e2e/api/backend_test.go
+++ b/t/e2e/api/backend_test.go
@@ -234,7 +234,7 @@ func (s *APIBackendTestSuite) TestResetChainData() {
 	s.StartTestBackend(e2e.WithDataDir(path))
 	defer s.StopTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
 	require.NoError(s.Backend.ResetChainData())
 

--- a/t/e2e/jail/jail_rpc_test.go
+++ b/t/e2e/jail/jail_rpc_test.go
@@ -39,7 +39,7 @@ func (s *JailRPCTestSuite) TestJailRPCSend() {
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
 	// load Status JS and add test command to it
 	s.jail.SetBaseJS(baseStatusJSCode)
@@ -110,7 +110,7 @@ func (s *JailRPCTestSuite) TestContractDeployment() {
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
 	// obtain VM for a given chat (to send custom JS to jailed version of Send())
 	s.jail.CreateAndInitCell(testChatID)
@@ -193,7 +193,7 @@ func (s *JailRPCTestSuite) TestJailVMPersistence() {
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
 	// log into account from which transactions will be sent
 	err := s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)

--- a/t/e2e/rpc/rpc_test.go
+++ b/t/e2e/rpc/rpc_test.go
@@ -164,7 +164,7 @@ func (s *RPCTestSuite) TestCallContextResult() {
 	s.StartTestNode()
 	defer s.StopTestNode()
 
-	EnsureNodeSync(s.StatusNode)
+	EnsureNodeSync(s.StatusNode.EnsureSync)
 
 	client := s.StatusNode.RPCClient()
 	s.NotNil(client)

--- a/t/e2e/suites.go
+++ b/t/e2e/suites.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/ethereum/go-ethereum/les"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/status-im/status-go/geth/api"
 
@@ -122,15 +121,6 @@ func (s *BackendTestSuite) WhisperService() *whisper.Whisper {
 	s.NotNil(whisperService)
 
 	return whisperService
-}
-
-// LightEthereumService returns a reference to the LES service.
-func (s *BackendTestSuite) LightEthereumService() *les.LightEthereum {
-	lightEthereum, err := s.Backend.StatusNode().LightEthereumService()
-	s.NoError(err)
-	s.NotNil(lightEthereum)
-
-	return lightEthereum
 }
 
 // TxQueueManager returns a reference to the TxQueueManager.

--- a/t/e2e/transactions/transactions_test.go
+++ b/t/e2e/transactions/transactions_test.go
@@ -37,7 +37,7 @@ func (s *TransactionsTestSuite) TestCallRPCSendTransaction() {
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
 	err := s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
 	s.NoError(err)
@@ -187,7 +187,7 @@ func (s *TransactionsTestSuite) testSendContractTx(setInputAndDataValue initFunc
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
 	sampleAddress, _, _, err := s.Backend.AccountManager().CreateAccount(TestConfig.Account1.Password)
 	s.NoError(err)
@@ -282,7 +282,7 @@ func (s *TransactionsTestSuite) TestSendEther() {
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
 	// create an account
 	sampleAddress, _, _, err := s.Backend.AccountManager().CreateAccount(TestConfig.Account1.Password)
@@ -419,7 +419,7 @@ func (s *TransactionsTestSuite) TestDoubleCompleteQueuedTransactions() {
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
 	// log into account from which transactions will be sent
 	s.NoError(s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password))
@@ -493,7 +493,7 @@ func (s *TransactionsTestSuite) TestDiscardQueuedTransaction() {
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
 	// reset queue
 	s.Backend.TxQueueManager().TransactionQueue().Reset()
@@ -583,7 +583,7 @@ func (s *TransactionsTestSuite) TestDiscardMultipleQueuedTransactions() {
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
 	// reset queue
 	s.Backend.TxQueueManager().TransactionQueue().Reset()
@@ -780,7 +780,7 @@ func (s *TransactionsTestSuite) TestCompleteMultipleQueuedTransactionsUpstream()
 func (s *TransactionsTestSuite) setupLocalNode() {
 	s.StartTestBackend()
 
-	EnsureNodeSync(s.Backend.StatusNode())
+	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 }
 
 func (s *TransactionsTestSuite) setupUpstreamNode() {


### PR DESCRIPTION
This pull request is part of [statusNode simplification](https://github.com/status-im/status-go/issues/797)

Important changes:
- [x] Unify EnsureSync on t/utils/utils.go and StatusManager
- [x] Rename insternal StatusNode.node to StatusNode.gethNode
- [x] Use geth internal cached services (les and whisper) and locks on its getters

Notes:
I'm not sure it still makes sense extracting methods like `LightEthereumService` or `WhisperService` from StatusNode, otherwise, these services will need to be accessed like `statusNode.GethNode().Service()`. 
*Any input/opinion on this topic will be appreciated*

