### PR TITLE
Update Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -489,6 +489,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c3c6facfce434b6e6c2c5b676526dcfb0c6bde11fffb616b18c90d16fbfb2e73"
+  inputs-digest = "a21695ec5b17d68c9524831c9cc9321753525f1e404f17c41f5dbc6b20e0b1db"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
It turned out that `Gopkg.lock` is outdated.

Todo:
- [ ] create a follow-up issue to avoid such situations in the future