### PR TITLE
remove redundant "if" before "return" statement

### DIFF
--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -480,11 +480,7 @@ func (c *NodeConfig) updateConfig() error {
 		return err
 	}
 
-	if err := c.updateRelativeDirsConfig(); err != nil {
-		return err
-	}
-
-	return nil
+	return c.updateRelativeDirsConfig()
 }
 
 // updateGenesisConfig does necessary adjustments to config object (depending on network node will be running on)

--- a/geth/rpc/client.go
+++ b/geth/rpc/client.go
@@ -120,11 +120,7 @@ func (c *Client) callMethod(ctx context.Context, result interface{}, handler Han
 		return nil
 	}
 
-	if err := setResultFromRPCResponse(result, response); err != nil {
-		return err
-	}
-
-	return nil
+	return setResultFromRPCResponse(result, response)
 }
 
 // handler is a concurrently safe method to get registered handler by name.


### PR DESCRIPTION
Some versions of `golint`are failing when there is a reduntant `if` before returning `err/nil`.