### PR TITLE
Fix two race conditions in peerpool tests

### DIFF
--- a/geth/peers/topicpool.go
+++ b/geth/peers/topicpool.go
@@ -245,7 +245,7 @@ func (t *TopicPool) removePeer(server *p2p.Server, info *peerInfo) {
 
 // StopSearch stops the closes stop
 func (t *TopicPool) StopSearch() {
-	if !t.SearchRunning() {
+	if !atomic.CompareAndSwapInt32(&t.running, 1, 0) {
 		return
 	}
 	if t.quit == nil {
@@ -259,7 +259,6 @@ func (t *TopicPool) StopSearch() {
 		close(t.quit)
 	}
 	t.consumerWG.Wait()
-	atomic.StoreInt32(&t.running, 0)
 	close(t.period)
 	t.discWG.Wait()
 }


### PR DESCRIPTION
Multiple concurrent topic pool stops could result in the close of the closed
quit channel. Fixed by using atomic compare and swap and closing only if swap
happened.

Added events feed to peer pool for tests purpose. Otherwise, it is impossible to run a simulation with -race flag enabled. In the essence, it happens because we are managing the global
object, which is server.Discv5, but unfortunately there is no way around it.
