### PR TITLE
Run tests with race flag on develop by Travis cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ install:
 - make mock-install
 - make lint-install
 - make dep-install
-before_script:
-
 jobs:
   include:
   - stage: Lint & Vendor Check
@@ -20,7 +18,7 @@ jobs:
   - stage: Test unit and integration
     env:
       # When develop is run by cron, test with `-race` flag.
-      - EXTRA_FLAGS=$([[ "${TRAVIS_EVENT_TYPE}" == "cron" && "${TRAVIS_BRANCH}" == "develop" ]] && echo '-race' || echo '')
+      - EXTRA_FLAGS=$([[ "${TRAVIS_EVENT_TYPE}" == "push" && "${TRAVIS_BRANCH}" == "chore/run-test-with-race" ]] && echo '-race' || echo '')
     script: make test-unit-coverage gotest_extraflags="$EXTRA_FLAGS"
   - stage: Test e2e on private network
     script: make test-e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
   - stage: Test unit and integration
     env:
       # When develop is run by cron, test with `-race` flag.
-      - EXTRA_FLAGS=$([[ "${TRAVIS_EVENT_TYPE}" == "push" && "${TRAVIS_BRANCH}" == "chore/run-test-with-race" ]] && echo '-race' || echo '')
+      - EXTRA_FLAGS=$([[ "${TRAVIS_EVENT_TYPE}" == "cron" && "${TRAVIS_BRANCH}" == "develop" ]] && echo '-race' || echo '')
     script: make test-unit-coverage gotest_extraflags="$EXTRA_FLAGS"
   - stage: Test e2e on private network
     script: make test-e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ install:
 - make mock-install
 - make lint-install
 - make dep-install
+before_script:
+
 jobs:
   include:
   - stage: Lint & Vendor Check
@@ -16,7 +18,10 @@ jobs:
       - make lint
       - make vendor-check
   - stage: Test unit and integration
-    script: make test-unit-coverage
+    env:
+      # When develop is run by cron, test with `-race` flag.
+      - EXTRA_FLAGS=$([[ "${TRAVIS_EVENT_TYPE}" == "cron" && "${TRAVIS_BRANCH}" == "develop" ]] && echo '-race' || echo '')
+    script: make test-unit-coverage gotest_extraflags="$EXTRA_FLAGS"
   - stage: Test e2e on private network
     script: make test-e2e
   - stage: Test e2e on public network


### PR DESCRIPTION
Run tests with `-race` flag by Travis' cron if being on the develop branch so that we have an automated way of detecting race condition issues.