### PR TITLE
Make Limits type a struct

### DIFF
--- a/cmd/statusd/topics/topics.go
+++ b/cmd/statusd/topics/topics.go
@@ -47,6 +47,6 @@ func (f *TopicLimitsFlag) Set(value string) error {
 	if err != nil {
 		return err
 	}
-	(*f)[discv5.Topic(parts[0])] = params.Limits{minL, maxL}
+	(*f)[discv5.Topic(parts[0])] = params.NewLimits(minL, maxL)
 	return nil
 }

--- a/cmd/statusd/topics/topics_test.go
+++ b/cmd/statusd/topics/topics_test.go
@@ -52,17 +52,17 @@ func TestTopicLimitsFlag(t *testing.T) {
 		{
 			shortcut: "single",
 			flags:    []string{"whisper=1,1"},
-			expected: TopicLimitsFlag{"whisper": params.Limits{1, 1}},
+			expected: TopicLimitsFlag{"whisper": params.NewLimits(1, 1)},
 		},
 		{
 			shortcut: "multiple",
 			flags:    []string{"whisper=1,1", "les=2,3"},
-			expected: TopicLimitsFlag{"whisper": params.Limits{1, 1}, "les": params.Limits{2, 3}},
+			expected: TopicLimitsFlag{"whisper": params.NewLimits(1, 1), "les": params.NewLimits(2, 3)},
 		},
 		{
 			shortcut: "corrupted",
 			flags:    []string{" whisper=1,1 ", " les=2,3"},
-			expected: TopicLimitsFlag{"whisper": params.Limits{1, 1}, "les": params.Limits{2, 3}},
+			expected: TopicLimitsFlag{"whisper": params.NewLimits(1, 1), "les": params.NewLimits(2, 3)},
 		},
 		{
 			shortcut:  "badseparator",

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -181,7 +181,17 @@ func (c *ClusterConfig) String() string {
 }
 
 // Limits represent min and max amount of peers
-type Limits [2]int
+type Limits struct {
+	Min, Max int
+}
+
+// NewLimits creates new Limits config with given min and max values.
+func NewLimits(min, max int) Limits {
+	return Limits{
+		Min: min,
+		Max: max,
+	}
+}
 
 // ----------
 // UpstreamRPCConfig

--- a/geth/peers/peerpool_test.go
+++ b/geth/peers/peerpool_test.go
@@ -96,7 +96,7 @@ func (s *PeerPoolSimulationSuite) TestSingleTopicDiscoveryWithFailover() {
 	topic := discv5.Topic("cap=test")
 	// simulation should only rely on fast sync
 	config := map[discv5.Topic]params.Limits{
-		topic: {1, 1}, // limits a chosen for simplicity of the simulation
+		topic: params.NewLimits(1, 1), // limits a chosen for simplicity of the simulation
 	}
 	peerPool := NewPeerPool(config, 100*time.Millisecond, 100*time.Millisecond, nil, true)
 	register := NewRegister(topic)

--- a/geth/peers/topicpool_test.go
+++ b/geth/peers/topicpool_test.go
@@ -38,7 +38,7 @@ func (s *TopicPoolSuite) SetupTest() {
 	}
 	s.Require().NoError(s.peer.Start())
 	topic := discv5.Topic("cap=cap1")
-	limits := params.Limits{1, 2}
+	limits := params.NewLimits(1, 2)
 	s.topicPool = NewTopicPool(topic, limits, 100*time.Millisecond, 200*time.Millisecond)
 	s.topicPool.period = make(chan time.Duration, 2)
 	s.topicPool.running = 1
@@ -97,7 +97,7 @@ func (s *TopicPoolSuite) TestNewPeerSelectedOnDrop() {
 func (s *TopicPoolSuite) TestRequestedDoesntRemove() {
 	// max limit is 1 because we test that 2nd peer will stay in local table
 	// when we request to drop it
-	s.topicPool.limits = params.Limits{1, 1}
+	s.topicPool.limits = params.NewLimits(1, 1)
 	peer1 := discv5.NewNode(discv5.NodeID{1}, s.peer.Self().IP, 32311, 32311)
 	peer2 := discv5.NewNode(discv5.NodeID{2}, s.peer.Self().IP, 32311, 32311)
 	s.topicPool.processFoundNode(s.peer, peer1)
@@ -115,7 +115,7 @@ func (s *TopicPoolSuite) TestRequestedDoesntRemove() {
 }
 
 func (s *TopicPoolSuite) TestTheMostRecentPeerIsSelected() {
-	s.topicPool.limits = params.Limits{1, 1}
+	s.topicPool.limits = params.NewLimits(1, 1)
 
 	peer1 := discv5.NewNode(discv5.NodeID{1}, s.peer.Self().IP, 32311, 32311)
 	peer2 := discv5.NewNode(discv5.NodeID{2}, s.peer.Self().IP, 32311, 32311)


### PR DESCRIPTION
This PR changes type `Limits` from 2-elements array to struct with `Min` and `Max` fields. This makes its usage much clearer and expressive, so instead of:
```
x < limits[1]
```
one can write
```
x < limits.Max
```
