### PR TITLE
Enable logs in tests

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/status-im/status-go/logutils"
+
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/status-im/status-go/cmd/statusd/debug"
@@ -83,32 +85,6 @@ var (
 // All general log messages in this package should be routed through this logger.
 var logger = log.New("package", "status-go/cmd/statusd")
 
-func enhanceLogger(logger *log.Logger, config *params.NodeConfig) error {
-	var (
-		handler log.Handler
-		err     error
-	)
-
-	if config.LogFile != "" {
-		handler, err = log.FileHandler(config.LogFile, log.LogfmtFormat())
-		if err != nil {
-			return err
-		}
-	} else {
-		handler = log.StreamHandler(os.Stderr, log.TerminalFormat(true))
-	}
-
-	level, err := log.LvlFromString(strings.ToLower(config.LogLevel))
-	if err != nil {
-		return err
-	}
-
-	filteredHandler := log.LvlFilterHandler(level, handler)
-	log.Root().SetHandler(filteredHandler)
-
-	return nil
-}
-
 func main() {
 	flag.Var(&searchTopics, "topic.search", "Topic that will be searched in discovery v5, e.g (mailserver=1,1)")
 	flag.Var(&registerTopics, "topic.register", "Topic that will be registered using discovery v5.")
@@ -126,7 +102,7 @@ func main() {
 		return
 	}
 
-	if err := enhanceLogger(&logger, config); err != nil {
+	if err := logutils.OverrideRootLog(config.LogLevel, config.LogFile, true); err != nil {
 		stdlog.Fatalf("Error initializing logger: %s", err)
 	}
 

--- a/logutils/override.go
+++ b/logutils/override.go
@@ -1,0 +1,40 @@
+package logutils
+
+import (
+	"os"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// OverrideRootLog overrides root logger with file handler, if defined,
+// and log level (defaults to INFO).
+func OverrideRootLog(levelStr, logFile string, terminal bool) error {
+	var (
+		handler log.Handler
+		err     error
+	)
+
+	if logFile != "" {
+		handler, err = log.FileHandler(logFile, log.LogfmtFormat())
+		if err != nil {
+			return err
+		}
+	} else {
+		handler = log.StreamHandler(os.Stderr, log.TerminalFormat(terminal))
+	}
+
+	if levelStr == "" {
+		levelStr = "INFO"
+	}
+
+	level, err := log.LvlFromString(strings.ToLower(levelStr))
+	if err != nil {
+		return err
+	}
+
+	filteredHandler := log.LvlFilterHandler(level, handler)
+	log.Root().SetHandler(filteredHandler)
+
+	return nil
+}

--- a/t/e2e/jail/jail_rpc_test.go
+++ b/t/e2e/jail/jail_rpc_test.go
@@ -190,7 +190,7 @@ func (s *JailRPCTestSuite) TestContractDeployment() {
 	s.NoError(err)
 
 	expectedResponse := txHash.Hex()
-	s.NotEqual(expectedResponse, response)
+	s.Equal(expectedResponse, response)
 }
 
 func (s *JailRPCTestSuite) TestJailVMPersistence() {

--- a/t/e2e/jail/jail_rpc_test.go
+++ b/t/e2e/jail/jail_rpc_test.go
@@ -190,7 +190,7 @@ func (s *JailRPCTestSuite) TestContractDeployment() {
 	s.NoError(err)
 
 	expectedResponse := txHash.Hex()
-	s.Equal(expectedResponse, response)
+	s.NotEqual(expectedResponse, response)
 }
 
 func (s *JailRPCTestSuite) TestJailVMPersistence() {

--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/status-im/status-go/logutils"
+
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/static"
@@ -26,7 +28,10 @@ import (
 
 var (
 	networkSelected = flag.String("network", "statuschain", "-network=NETWORKID or -network=NETWORKNAME to select network used for tests")
+	logLevel        = flag.String("log", "INFO", `Log level, one of: "ERROR", "WARN", "INFO", "DEBUG", and "TRACE"`)
+)
 
+var (
 	// ErrNoRemoteURL is returned when network id has no associated url.
 	ErrNoRemoteURL = errors.New("network id requires a remote URL")
 
@@ -63,6 +68,11 @@ func init() {
 	}
 
 	flag.Parse()
+
+	// set up logger
+	if err := logutils.OverrideRootLog(*logLevel, "", true); err != nil {
+		panic(err)
+	}
 
 	// setup root directory
 	const pathSeparator = string(os.PathSeparator)


### PR DESCRIPTION
Pass `-log` option to `go test` in order to change log level. By default, it's `INFO`.

Closes #792 
