### PR TITLE
Fix race conditions in tests

### DIFF
--- a/geth/node/status_node.go
+++ b/geth/node/status_node.go
@@ -357,6 +357,9 @@ func (n *StatusNode) gethService(serviceInstance interface{}) error {
 
 // LightEthereumService exposes reference to LES service running on top of the node
 func (n *StatusNode) LightEthereumService() (l *les.LightEthereum, err error) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
 	err = n.gethService(&l)
 	if err == node.ErrServiceUnknown {
 		err = ErrServiceUnknown
@@ -367,6 +370,9 @@ func (n *StatusNode) LightEthereumService() (l *les.LightEthereum, err error) {
 
 // WhisperService exposes reference to Whisper service running on top of the node
 func (n *StatusNode) WhisperService() (w *whisper.Whisper, err error) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
 	err = n.gethService(&w)
 	if err == node.ErrServiceUnknown {
 		err = ErrServiceUnknown

--- a/lib/library_test_utils.go
+++ b/lib/library_test_utils.go
@@ -1117,12 +1117,11 @@ func testDiscardTransaction(t *testing.T) bool { //nolint: gocyclo
 
 	select {
 	case <-txFailedEventCalled:
+		return true
 	default:
 		t.Error("expected tx failure signal is not received")
 		return false
 	}
-
-	return true
 }
 
 func testDiscardMultipleQueuedTransactions(t *testing.T) bool { //nolint: gocyclo


### PR DESCRIPTION
```
$ make test-unit-race
go test github.com/status-im/status-go/cmd/statusd github.com/status-im/status-go/cmd/statusd/debug github.com/status-im/status-go/cmd/statusd/topics github.com/status-im/status-go/cmd/statusd-cli github.com/status-im/status-go/extkeys github.com/status-im/status-go/geth/account github.com/status-im/status-go/geth/api github.com/status-im/status-go/geth/db github.com/status-im/status-go/geth/jail github.com/status-im/status-go/geth/jail/console github.com/status-im/status-go/geth/jail/internal github.com/status-im/status-go/geth/jail/internal/fetch github.com/status-im/status-go/geth/jail/internal/loop github.com/status-im/status-go/geth/jail/internal/loop/looptask github.com/status-im/status-go/geth/jail/internal/process github.com/status-im/status-go/geth/jail/internal/promise github.com/status-im/status-go/geth/jail/internal/timers github.com/status-im/status-go/geth/jail/internal/vm github.com/status-im/status-go/geth/mailservice github.com/status-im/status-go/geth/node github.com/status-im/status-go/geth/notifications/push github.com/status-im/status-go/geth/notifications/push/fcm github.com/status-im/status-go/geth/params github.com/status-im/status-go/geth/peers github.com/status-im/status-go/geth/rpc github.com/status-im/status-go/geth/signal github.com/status-im/status-go/geth/transactions github.com/status-im/status-go/geth/transactions/fake github.com/status-im/status-go/logutils github.com/status-im/status-go/metrics github.com/status-im/status-go/metrics/node github.com/status-im/status-go/metrics/whisper github.com/status-im/status-go/profiling github.com/status-im/status-go/services/personal github.com/status-im/status-go/services/shhext github.com/status-im/status-go/sign github.com/status-im/status-go/static github.com/status-im/status-go/t github.com/status-im/status-go/t/utils -race
?   	github.com/status-im/status-go/cmd/statusd	[no test files]
ok  	github.com/status-im/status-go/cmd/statusd/debug	21.679s
ok  	github.com/status-im/status-go/cmd/statusd/topics	1.131s
?   	github.com/status-im/status-go/cmd/statusd-cli	[no test files]
ok  	github.com/status-im/status-go/extkeys	10.342s
ok  	github.com/status-im/status-go/geth/account	41.940s
ok  	github.com/status-im/status-go/geth/api	20.534s
?   	github.com/status-im/status-go/geth/db	[no test files]
ok  	github.com/status-im/status-go/geth/jail	17.359s
ok  	github.com/status-im/status-go/geth/jail/console	1.094s
?   	github.com/status-im/status-go/geth/jail/internal	[no test files]
ok  	github.com/status-im/status-go/geth/jail/internal/fetch	1.410s
ok  	github.com/status-im/status-go/geth/jail/internal/loop	1.501s
?   	github.com/status-im/status-go/geth/jail/internal/loop/looptask	[no test files]
?   	github.com/status-im/status-go/geth/jail/internal/process	[no test files]
ok  	github.com/status-im/status-go/geth/jail/internal/promise	1.120s
ok  	github.com/status-im/status-go/geth/jail/internal/timers	1.460s
?   	github.com/status-im/status-go/geth/jail/internal/vm	[no test files]
ok  	github.com/status-im/status-go/geth/mailservice	5.085s
ok  	github.com/status-im/status-go/geth/node	41.298s
?   	github.com/status-im/status-go/geth/notifications/push	[no test files]
ok  	github.com/status-im/status-go/geth/notifications/push/fcm	1.078s
ok  	github.com/status-im/status-go/geth/params	5.249s
ok  	github.com/status-im/status-go/geth/peers	3.515s
ok  	github.com/status-im/status-go/geth/rpc	1.100s
ok  	github.com/status-im/status-go/geth/signal	1.039s
ok  	github.com/status-im/status-go/geth/transactions	2.086s
?   	github.com/status-im/status-go/geth/transactions/fake	[no test files]
?   	github.com/status-im/status-go/logutils	[no test files]
?   	github.com/status-im/status-go/metrics	[no test files]
ok  	github.com/status-im/status-go/metrics/node	2.136s
?   	github.com/status-im/status-go/metrics/whisper	[no test files]
ok  	github.com/status-im/status-go/profiling	2.067s
?   	github.com/status-im/status-go/services/personal	[no test files]
ok  	github.com/status-im/status-go/services/shhext	4.137s
ok  	github.com/status-im/status-go/sign	1.724s
?   	github.com/status-im/status-go/static	[no test files]
?   	github.com/status-im/status-go/t	[no test files]
?   	github.com/status-im/status-go/t/utils	[no test files]
```

```
$ make test-e2e-race
# order: reliability then alphabetical
# TODO(tiabc): make a single command out of them adding `-p 1` flag.
go test -timeout 5m ./t/e2e/accounts/... -network=StatusChain -race
ok  	github.com/status-im/status-go/t/e2e/accounts	104.338s
go test -timeout 5m ./t/e2e/api/... -network=StatusChain -race
ok  	github.com/status-im/status-go/t/e2e/api	59.169s
go test -timeout 5m ./t/e2e/node/... -network=StatusChain -race
ok  	github.com/status-im/status-go/t/e2e/node	14.333s
go test -timeout 50m ./t/e2e/jail/... -network=StatusChain -race
ok  	github.com/status-im/status-go/t/e2e/jail	29.146s
go test -timeout 20m ./t/e2e/rpc/... -network=StatusChain -race
ok  	github.com/status-im/status-go/t/e2e/rpc	8.898s
go test -timeout 20m ./t/e2e/whisper/... -network=StatusChain -race
ok  	github.com/status-im/status-go/t/e2e/whisper	81.181s
go test -timeout 10m ./t/e2e/transactions/... -network=StatusChain -race
ok  	github.com/status-im/status-go/t/e2e/transactions	65.080s
go test -timeout 10m ./t/e2e/services/... -network=StatusChain -race
ok  	github.com/status-im/status-go/t/e2e/services	20.445s
# e2e_test tag is required to include some files from ./lib without _test suffix
go test -timeout 40m -tags e2e_test ./lib -network=StatusChain -race
ok  	github.com/status-im/status-go/lib	110.719s
```

Closes #777 