### PR TITLE
Add LogEnabled attribute to NodeConfig to, used in the call from status-react

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -102,7 +102,7 @@ func main() {
 		return
 	}
 
-	if err := logutils.OverrideRootLog(config.LogLevel, config.LogFile, true); err != nil {
+	if err := logutils.OverrideRootLog(config.LogEnabled, config.LogLevel, config.LogFile, true); err != nil {
 		stdlog.Fatalf("Error initializing logger: %s", err)
 	}
 
@@ -230,8 +230,13 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	if *logLevel != "" {
 		nodeConfig.LogLevel = *logLevel
 	}
+
 	if *logFile != "" {
 		nodeConfig.LogFile = *logFile
+	}
+
+	if *logLevel != "" || *logFile != "" {
+		nodeConfig.LogEnabled = true
 	}
 
 	nodeConfig.RPCEnabled = *httpEnabled

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -282,6 +282,9 @@ type NodeConfig struct {
 	// LogFile is filename where exposed logs get written to
 	LogFile string
 
+	// LogEnabled enables the logger
+	LogEnabled bool `json:"LogEnabled"`
+
 	// LogLevel defines minimum log level. Valid names are "ERROR", "WARN", "INFO", "DEBUG", and "TRACE".
 	LogLevel string `validate:"eq=ERROR|eq=WARN|eq=INFO|eq=DEBUG|eq=TRACE"`
 

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -279,11 +279,11 @@ type NodeConfig struct {
 
 	log log.Logger
 
-	// LogFile is filename where exposed logs get written to
-	LogFile string
-
 	// LogEnabled enables the logger
 	LogEnabled bool `json:"LogEnabled"`
+
+	// LogFile is filename where exposed logs get written to
+	LogFile string
 
 	// LogLevel defines minimum log level. Valid names are "ERROR", "WARN", "INFO", "DEBUG", and "TRACE".
 	LogLevel string `validate:"eq=ERROR|eq=WARN|eq=INFO|eq=DEBUG|eq=TRACE"`

--- a/lib/library.go
+++ b/lib/library.go
@@ -41,7 +41,7 @@ func StartNode(configJSON *C.char) *C.char {
 		return makeJSONResponse(err)
 	}
 
-	if err := logutils.OverrideRootLog(config.LogLevel, config.LogFile, false); err != nil {
+	if err := logutils.OverrideRootLog(config.LogEnabled, config.LogLevel, config.LogFile, false); err != nil {
 		return makeJSONResponse(err)
 	}
 

--- a/logutils/override.go
+++ b/logutils/override.go
@@ -9,7 +9,20 @@ import (
 
 // OverrideRootLog overrides root logger with file handler, if defined,
 // and log level (defaults to INFO).
-func OverrideRootLog(levelStr, logFile string, terminal bool) error {
+func OverrideRootLog(enabled bool, levelStr string, logFile string, terminal bool) error {
+	if !enabled {
+		disableRootLog()
+		return nil
+	}
+
+	return enableRootLog(levelStr, logFile, terminal)
+}
+
+func disableRootLog() {
+	log.Root().SetHandler(log.DiscardHandler())
+}
+
+func enableRootLog(levelStr string, logFile string, terminal bool) error {
 	var (
 		handler log.Handler
 		err     error

--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -70,7 +70,7 @@ func init() {
 	flag.Parse()
 
 	// set up logger
-	if err := logutils.OverrideRootLog(*logLevel, "", true); err != nil {
+	if err := logutils.OverrideRootLog(true, *logLevel, "", true); err != nil {
 		panic(err)
 	}
 

--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -70,7 +70,8 @@ func init() {
 	flag.Parse()
 
 	// set up logger
-	if err := logutils.OverrideRootLog(true, *logLevel, "", true); err != nil {
+	loggerEnabled := *logLevel != ""
+	if err := logutils.OverrideRootLog(loggerEnabled, *logLevel, "", true); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
Add `LogEnabled` attribute to `NodeConfig`, used in the call from `status-react`.

`status-react` set a `LogEnabled` config attribute to enable/disable logging.

This PR adds this attribute in the `NodeConfig` struct and uses it to disable logging even if `LogLevel` or `LogFile` are set. 