### PR TITLE
Fix race condition in `0016-fix-leveldb-issue.patch`

### DIFF
--- a/_assets/patches/geth/0016-fix-leveldb-issue.patch
+++ b/_assets/patches/geth/0016-fix-leveldb-issue.patch
@@ -2,16 +2,24 @@ diff --git a/eth/downloader/downloader.go b/eth/downloader/downloader.go
 index 7ede530a9..60ff8dbc6 100644
 --- a/eth/downloader/downloader.go
 +++ b/eth/downloader/downloader.go
-@@ -141,6 +141,8 @@ type Downloader struct {
+@@ -143,6 +143,8 @@
  	quitCh   chan struct{} // Quit channel to signal termination
  	quitLock sync.RWMutex  // Lock to prevent double closes
-
+ 
 +	downloads sync.WaitGroup // Keeps track of the currently active downloads
 +
  	// Testing hooks
  	syncInitHook     func(uint64, uint64)  // Method to call upon initiating a new sync run
  	bodyFetchHook    func([]*types.Header) // Method to call upon starting a block body fetch
-@@ -398,7 +400,9 @@ func (d *Downloader) synchronise(id string, hash common.Hash, td *big.Int, mode
+@@ -228,6 +230,7 @@
+ 		},
+ 		trackStateReq: make(chan *stateReq),
+ 	}
++	dl.downloads.Add(1) // Add a sentinel value to avoid waiting with zero count and getting a race condition signaled when terminating Downloader before starting sync
+ 	go dl.qosTuner()
+ 	go dl.stateFetcher()
+ 	return dl
+@@ -403,7 +406,9 @@
  // specified peer and head hash.
  func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.Int) (err error) {
  	d.mux.Post(StartEvent{})
@@ -21,16 +29,19 @@ index 7ede530a9..60ff8dbc6 100644
  		// reset on error
  		if err != nil {
  			d.mux.Post(FailedEvent{err})
-@@ -528,6 +532,10 @@ func (d *Downloader) Terminate() {
-
+@@ -539,6 +544,13 @@
+ 
  	// Cancel any pending download requests
  	d.Cancel()
++
++	// Remove sentinel value from WaitGroup before calling Wait()
++	go func() { d.downloads.Done() }()
 +
 +	// Wait, so external dependencies aren't destroyed
 +	// until the download processing is done.
 +	d.downloads.Wait()
  }
-
+ 
  // fetchHeight retrieves the head header of the remote peer to aid in estimating
 diff --git a/eth/handler.go b/eth/handler.go
 index c2426544f..08818a507 100644


### PR DESCRIPTION
Update `0016-fix-leveldb-issue.patch` so that it passes in `make test-e2e-race` (failed in https://jenkins.status.im/job/status-go/job/race-check/45/)

This patch change adds a workaround so that Terminate doesn't call `WaitGroup.Wait()` when it has zero count (which gets signaled as a race condition by WaitGroup).

<blockquote></blockquote>