### PR TITLE
Remove mention of DevMode

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -214,8 +214,7 @@ func startCollectingStats(interruptCh <-chan struct{}, statusNode *node.StatusNo
 
 // makeNodeConfig parses incoming CLI options and returns node configuration object
 func makeNodeConfig() (*params.NodeConfig, error) {
-	devMode := !*prodMode
-	nodeConfig, err := params.NewNodeConfig(*dataDir, *clusterConfigFile, uint64(*networkID), devMode)
+	nodeConfig, err := params.NewNodeConfig(*dataDir, *clusterConfigFile, uint64(*networkID))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -32,7 +32,6 @@ var (
 
 var (
 	clusterConfigFile = flag.String("clusterconfig", "", "Cluster configuration file")
-	prodMode          = flag.Bool("production", false, "Whether production settings should be loaded")
 	nodeKeyFile       = flag.String("nodekey", "", "P2P node key file (private key)")
 	dataDir           = flag.String("datadir", params.DataDir, "Data directory for the databases and keystore")
 	networkID         = flag.Int("networkid", params.RopstenNetworkID, "Network identifier (integer, 1=Homestead, 3=Ropsten, 4=Rinkeby, 777=StatusChain)")

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -213,12 +213,6 @@ type UpstreamRPCConfig struct {
 
 // NodeConfig stores configuration options for a node
 type NodeConfig struct {
-	// DevMode is true when given configuration is to be used during development.
-	// For production, this flag should be turned off, so that more strict requirements
-	// are applied to node's configuration
-	// DEPRECATED.
-	DevMode bool
-
 	// NetworkID sets network to use for selecting peers to connect to
 	NetworkID uint64 `json:"NetworkId" validate:"required"`
 
@@ -312,9 +306,8 @@ type NodeConfig struct {
 }
 
 // NewNodeConfig creates new node configuration object
-func NewNodeConfig(dataDir string, clstrCfgFile string, networkID uint64, devMode bool) (*NodeConfig, error) {
+func NewNodeConfig(dataDir string, clstrCfgFile string, networkID uint64) (*NodeConfig, error) {
 	nodeConfig := &NodeConfig{
-		DevMode:           devMode,
 		NetworkID:         networkID,
 		DataDir:           dataDir,
 		Name:              ClientIdentifier,
@@ -377,7 +370,7 @@ func LoadNodeConfig(configJSON string) (*NodeConfig, error) {
 }
 
 func loadNodeConfig(configJSON string) (*NodeConfig, error) {
-	nodeConfig, err := NewNodeConfig("", "", 0, true)
+	nodeConfig, err := NewNodeConfig("", "", 0)
 	if err != nil {
 		return nil, err
 	}

--- a/geth/params/config_test.go
+++ b/geth/params/config_test.go
@@ -269,8 +269,7 @@ var loadConfigTestCases = []struct {
 		`default cluster configuration (Ropsten Prod)`,
 		`{
 			"NetworkId": 3,
-			"DataDir": "$TMPDIR",
-			"DevMode": false
+			"DataDir": "$TMPDIR"
 		}`,
 		func(t *testing.T, dataDir string, nodeConfig *params.NodeConfig, err error) {
 			require.NoError(t, err)
@@ -319,31 +318,6 @@ var loadConfigTestCases = []struct {
 
 			enodes := nodeConfig.ClusterConfig.StaticNodes
 			require.True(t, len(enodes) >= 2)
-		},
-	},
-	{
-		`default DevMode (true)`,
-		`{
-			"NetworkId": 311,
-			"DataDir": "$TMPDIR"
-		}`,
-		func(t *testing.T, dataDir string, nodeConfig *params.NodeConfig, err error) {
-			require.NoError(t, err)
-			require.True(t, nodeConfig.DevMode)
-			require.True(t, nodeConfig.ClusterConfig.Enabled)
-		},
-	},
-	{
-		`explicit DevMode = false`,
-		`{
-			"NetworkId": 3,
-			"DataDir": "$TMPDIR",
-			"DevMode": false
-		}`,
-		func(t *testing.T, dataDir string, nodeConfig *params.NodeConfig, err error) {
-			require.NoError(t, err)
-			require.False(t, nodeConfig.DevMode)
-			require.True(t, nodeConfig.ClusterConfig.Enabled)
 		},
 	},
 	{
@@ -403,7 +377,7 @@ func TestConfigWriteRead(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(tmpDir) // nolint: errcheck
 
-	nodeConfig, err := params.NewNodeConfig(tmpDir, "", params.RopstenNetworkID, true)
+	nodeConfig, err := params.NewNodeConfig(tmpDir, "", params.RopstenNetworkID)
 	require.Nil(t, err, "cannot create new config object")
 
 	err = nodeConfig.Save()
@@ -411,7 +385,6 @@ func TestConfigWriteRead(t *testing.T) {
 
 	loadedConfigData, err := ioutil.ReadFile(filepath.Join(nodeConfig.DataDir, "config.json"))
 	require.Nil(t, err, "cannot read configuration from disk")
-	require.Contains(t, string(loadedConfigData), fmt.Sprintf(`"DevMode": %t`, true))
 	require.Contains(t, string(loadedConfigData), fmt.Sprintf(`"NetworkId": %d`, params.RopstenNetworkID))
 	require.Contains(t, string(loadedConfigData), fmt.Sprintf(`"DataDir": "%s"`, tmpDir))
 }

--- a/geth/transactions/transactor_test.go
+++ b/geth/transactions/transactor_test.go
@@ -59,7 +59,7 @@ func (s *TxQueueTestSuite) SetupTest() {
 	rpcClient, _ := rpc.NewClient(s.client, params.UpstreamRPCConfig{})
 	// expected by simulated backend
 	chainID := gethparams.AllEthashProtocolChanges.ChainId.Uint64()
-	nodeConfig, err := params.NewNodeConfig("/tmp", "", chainID, true)
+	nodeConfig, err := params.NewNodeConfig("/tmp", "", chainID)
 	s.Require().NoError(err)
 	s.nodeConfig = nodeConfig
 

--- a/lib/library.go
+++ b/lib/library.go
@@ -19,8 +19,8 @@ var logger = log.New("package", "status-go/lib")
 
 //GenerateConfig for status node
 //export GenerateConfig
-func GenerateConfig(datadir *C.char, networkID C.int, devMode C.int) *C.char {
-	config, err := params.NewNodeConfig(C.GoString(datadir), "", uint64(networkID), devMode == 1)
+func GenerateConfig(datadir *C.char, networkID C.int) *C.char {
+	config, err := params.NewNodeConfig(C.GoString(datadir), "", uint64(networkID))
 	if err != nil {
 		return makeJSONResponse(err)
 	}

--- a/lib/library_test_utils.go
+++ b/lib/library_test_utils.go
@@ -233,7 +233,7 @@ func testGetDefaultConfig(t *testing.T) bool {
 		t.Run(fmt.Sprintf("networkID=%d", network.chainID), func(t *testing.T) {
 			var (
 				nodeConfig  = params.NodeConfig{}
-				rawResponse = GenerateConfig(C.CString("/tmp/data-folder"), C.int(network.chainID), 1)
+				rawResponse = GenerateConfig(C.CString("/tmp/data-folder"), C.int(network.chainID))
 			)
 			if err := json.Unmarshal([]byte(C.GoString(rawResponse)), &nodeConfig); err != nil {
 				t.Errorf("cannot decode response (%s): %v", C.GoString(rawResponse), err)

--- a/t/e2e/whisper/whisper_ext_test.go
+++ b/t/e2e/whisper/whisper_ext_test.go
@@ -33,7 +33,7 @@ func (s *WhisperExtensionSuite) SetupTest() {
 		dir, err := ioutil.TempDir("", "test-shhext-")
 		s.NoError(err)
 		// network id is irrelevant
-		cfg, err := params.NewNodeConfig(dir, "", 777, true)
+		cfg, err := params.NewNodeConfig(dir, "", 777)
 		cfg.LightEthConfig.Enabled = false
 		cfg.Name = fmt.Sprintf("test-shhext-%d", i)
 		s.Require().NoError(err)


### PR DESCRIPTION
Removes any mention of DevMode in `status-go` codebase, has been marked as deprecated with merge of #830.

Closes #842
