### PR TITLE
fix sdk messaged ordering

### DIFF
--- a/sdk/chan.go
+++ b/sdk/chan.go
@@ -17,10 +17,7 @@ type Channel struct {
 
 // Publish : Publishes a message with the given body on the current channel
 func (c *Channel) Publish(body string) error {
-	cfg, err := c.conn.statusNode.Config()
-	if err != nil {
-		return err
-	}
+	cfg := c.conn.statusNode.Config()
 
 	message := NewMsg(c.conn.userName, body, c.channelName)
 	cmd := fmt.Sprintf(standardMessageFormat,

--- a/sdk/msg.go
+++ b/sdk/msg.go
@@ -24,7 +24,7 @@ func NewMsg(from, text, channel string) *Msg {
 		From:        from,
 		Text:        text,
 		ChannelName: channel,
-		Timestamp:   time.Now().Unix(),
+		Timestamp:   time.Now().Unix() * 1000,
 	}
 }
 


### PR DESCRIPTION
This PR merges to branch `sdk`. 
It fixes the ordering of the messages and timestamp for the new protocol using milliseconds instead of the standard unix timestamp in seconds. 