### PR TITLE
Ensure that Travis CI fails the build if the patches are incorrect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
   include:
   - stage: Lint & Vendor Check
     sudo: required
+    before_script: make dep-ensure
     script:
       - make lint
       - make vendor-check

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ lint:
 	@echo "lint"
 	@gometalinter ./...
 
-ci: lint mock test-unit test-e2e ##@tests Run all linters and tests at once
+ci: lint mock dep-ensure test-unit test-e2e ##@tests Run all linters and tests at once
 
 clean: ##@other Cleanup
 	rm -fr build/bin/*

--- a/_assets/patches/patcher
+++ b/_assets/patches/patcher
@@ -182,7 +182,7 @@ for ((i=0; i<${#patches[@]}; i++)); do
 		echo "Failed and reverting: $f"
 		gitApplyReverse "$f" "$basepath"
 		echo -en "\\n"
-		exit
+		exit 1
 	fi
 done
 


### PR DESCRIPTION
- Change `patcher` script so that it returns an error in the appropriate case
- Make Travis CI run `make dep-ensure` before the build script
- Make `make ci` run `make dep-ensure` so that Jenkins builds also fail appropriately

Build for this commit failed as expected in https://travis-ci.org/status-im/status-go/jobs/373839616