### PR TITLE
Increase timeout for Rinkeby sync on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ jobs:
     # ACCOUNT_PASSWORD environment variable anyway.
     if: (type != push) AND (fork = false)
     script:
-      # Sync the chain first. It will time out after 20 minutes. Used network: Rinkeby.
+      # Sync the chain first. It will time out after 30 minutes. Used network: Rinkeby.
       - make statusgo
-      - ./build/bin/statusd -datadir=.ethereumtest/Rinkeby -les -networkid=4 -sync-and-exit=20 -log=WARN -standalone=false -discovery=false
+      - ./build/bin/statusd -datadir=.ethereumtest/Rinkeby -les -networkid=4 -sync-and-exit=30 -log=WARN -standalone=false -discovery=false
       - make test-e2e networkid=4
 cache:
   directories:


### PR DESCRIPTION
- Fixes https://travis-ci.org/status-im/status-go/jobs/374296755

```
WARN [05-03|08:50:44] Synchronization is not finished          package=status-go/geth/node.StatusNode current=1641870 highest=2217745
ERROR[05-03|08:50:44] syncAndStopNode: failed to sync the chain package=status-go/cmd/statusd          error="timeout during node synchronization"
```


<blockquote><div><strong><a href="https://travis-ci.org/status-im/status-go/jobs/374296755">Travis CI - Test and Deploy Your Code with Confidence</a></strong></div></blockquote>