### PR TITLE
add ipcfile flag to specify IPC file path

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -45,6 +45,7 @@ var (
 	httpHost          = flag.String("httphost", "127.0.0.1", "HTTP RPC host of the listening socket")
 	httpPort          = flag.Int("httpport", params.HTTPPort, "HTTP RPC server's listening port")
 	ipcEnabled        = flag.Bool("ipc", false, "Enable IPC RPC endpoint")
+	ipcFile           = flag.String("ipcfile", "", "Set IPC file path")
 	cliEnabled        = flag.Bool("cli", false, "Enable debugging CLI server")
 	cliPort           = flag.String("cliport", debug.CLIPort, "CLI server's listening port")
 	pprofEnabled      = flag.Bool("pprof", false, "Enable runtime profiling via pprof")
@@ -246,6 +247,11 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	nodeConfig.HTTPHost = *httpHost
 	nodeConfig.HTTPPort = *httpPort
 	nodeConfig.IPCEnabled = *ipcEnabled
+
+	if *ipcFile != "" {
+		nodeConfig.IPCEnabled = true
+		nodeConfig.IPCFile = *ipcFile
+	}
 
 	nodeConfig.LightEthConfig.Enabled = *lesEnabled
 	nodeConfig.SwarmConfig.Enabled = *swarmEnabled


### PR DESCRIPTION
Add `ipcfile` flag to `statusd` to be able to specify a different path for the IPC file.

This is useful when a user creates a bot with the [status-go-sdk](https://github.com/status-im/status-go-sdk) and run `statusd` and the bot in 2 different docker containers that share a volume with the ipc file. 