### PR TITLE
Make parameters ordering of `personal_sign` MetaMask-compatible.

### DIFF
--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -79,15 +79,15 @@ func MakeNode(config *params.NodeConfig) (*node.Node, error) {
 		if err := activateLightEthService(stack, config); err != nil {
 			return nil, fmt.Errorf("%v: %v", ErrLightEthRegistrationFailure, err)
 		}
-	} else {
-		// `personal_sign` and `personal_ecRecover` methods are important to
-		// keep DApps working.
-		// Usually, they are provided by an ETH or a LES service, but when using
-		// upstream, we don't start any of these, so we need to start our own
-		// implementation.
-		if err := activatePersonalService(stack, config); err != nil {
-			return nil, fmt.Errorf("%v: %v", ErrPersonalServiceRegistrationFailure, err)
-		}
+	}
+
+	// `personal_sign` and `personal_ecRecover` methods are important to
+	// keep DApps working.
+	// Usually, they are provided by an ETH or a LES service.
+	// Unfortunately, the parameters of `personal_sign` used in DApps
+	// are different from what LES provides, so we start this service always.
+	if err := activatePersonalService(stack, config); err != nil {
+		return nil, fmt.Errorf("%v: %v", ErrPersonalServiceRegistrationFailure, err)
 	}
 
 	// start Whisper service.

--- a/t/e2e/services/personal_api_test.go
+++ b/t/e2e/services/personal_api_test.go
@@ -206,10 +206,12 @@ func (s *PersonalSignSuite) testPersonalSign(testParams testParams) string {
 		s.NoError(s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password))
 	}
 
+	// Parameters ordering here is MetaMask-compatible, not geth-compatible.
+	// account *PRECEDES* data
 	basicCall := fmt.Sprintf(
 		`{"jsonrpc":"2.0","method":"personal_sign","params":["%s", "%s"],"id":67}`,
-		signDataString,
-		testParams.Account)
+		testParams.Account,
+		signDataString)
 
 	result := s.Backend.CallRPC(basicCall)
 	if testParams.ExpectedError == nil {


### PR DESCRIPTION
MetaMask's `personal_sign` has the different argument order than geth's one.

Here we make our version MetaMask (and DApps)-compatible.

Closes #894