### PR TITLE
Use `make setup` on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ go:
 - 1.9.x
 sudo: false
 dist: trusty
-install:
-- make mock-install
-- make lint-install
-- make dep-install
+install: make setup
 jobs:
   include:
   - stage: Lint & Vendor Check


### PR DESCRIPTION
`make setup` already performs all the steps required, so no need to repeat them in this config.