### PR TITLE
[#901] : Always run make mock on travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 - make mock-install
 - make lint-install
 - make dep-install
+- make mock 
 jobs:
   include:
   - stage: Lint & Vendor Check


### PR DESCRIPTION
Running `make mock` before running any test

Closes #901
