### PR TITLE
Run tests with race and coverage flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ jobs:
       - make lint
       - make vendor-check
   - stage: Test unit and integration
-    script: make test-unit-race
+    script:
+      - make test-unit-race
+      - make test-unit-coverage
   - stage: Test e2e on private network
     script: make test-e2e-race
   - stage: Test e2e on public network

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ jobs:
       - make lint
       - make vendor-check
   - stage: Test unit and integration
-    script: make test-unit-coverage
+    script: make test-unit-race
   - stage: Test e2e on private network
-    script: make test-e2e
+    script: make test-e2e-race
   - stage: Test e2e on public network
     # Disable running this stage for pushes as it's not needed to run it twice.
     # We only want to check if tests on public testnet pass in a merge build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,15 @@ jobs:
       - make lint
       - make vendor-check
   - stage: Test unit and integration
-    script:
-      - make test-unit-race
-      - make test-unit-coverage
+    script: make test-unit-coverage
   - stage: Test e2e on private network
-    script: make test-e2e-race
+    script: make test-e2e
   - stage: Test e2e on public network
     # Disable running this stage for pushes as it's not needed to run it twice.
     # We only want to check if tests on public testnet pass in a merge build.
     # Also, disable for fork builds as they do not have access to
     # ACCOUNT_PASSWORD environment variable anyway.
-    if: (type != push) AND (fork = false)
+    if: ((type != push) OR (branch = "develop")) AND (fork = false)
     script:
       # Sync the chain first. It will time out after 30 minutes. Used network: Rinkeby.
       - make statusgo

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,12 @@ jobs:
       - make lint
       - make vendor-check
   - stage: Test unit and integration
-    script: make test-unit-coverage
+    script:
+      - make test-unit-race
+      - make test-unit-coverage
   - stage: Test e2e on private network
-    script: make test-e2e
+    script:
+      - make test-e2e-race
   - stage: Test e2e on public network
     # Disable running this stage for pushes as it's not needed to run it twice.
     # We only want to check if tests on public testnet pass in a merge build.


### PR DESCRIPTION
Currently, we can benefit more from running race tests in the branch builds.