### PR TITLE
Prevent sending messages to flaky peers

### DIFF
--- a/_assets/patches/geth/0028-p2p-watchdog.patch
+++ b/_assets/patches/geth/0028-p2p-watchdog.patch
@@ -1,5 +1,5 @@
 diff --git c/p2p/peer.go w/p2p/peer.go
-index 73e33418e..d08371135 100644
+index 73e33418e..322268b28 100644
 --- c/p2p/peer.go
 +++ w/p2p/peer.go
 @@ -22,6 +22,7 @@ import (
@@ -10,16 +10,19 @@ index 73e33418e..d08371135 100644
  	"time"
  
  	"github.com/ethereum/go-ethereum/common/mclock"
-@@ -38,7 +39,7 @@ const (
+@@ -38,7 +39,10 @@ const (
  
  	snappyProtocolVersion = 5
  
 -	pingInterval = 15 * time.Second
-+	pingInterval = 100 * time.Millisecond
++	pingInterval = 1 * time.Second
++	// watchdogInterval intentionally lower than ping interval.
++	// this way we reduce potential flaky window size.
++	watchdogInterval = 200 * time.Millisecond
  )
  
  const (
-@@ -100,6 +101,7 @@ type Peer struct {
+@@ -100,6 +104,7 @@ type Peer struct {
  	log     log.Logger
  	created mclock.AbsTime
  
@@ -27,7 +30,7 @@ index 73e33418e..d08371135 100644
  	wg       sync.WaitGroup
  	protoErr chan error
  	closed   chan struct{}
-@@ -118,6 +120,11 @@ func NewPeer(id discover.NodeID, name string, caps []Cap) *Peer {
+@@ -118,6 +123,11 @@ func NewPeer(id discover.NodeID, name string, caps []Cap) *Peer {
  	return peer
  }
  
@@ -39,7 +42,7 @@ index 73e33418e..d08371135 100644
  // ID returns the node's public key.
  func (p *Peer) ID() discover.NodeID {
  	return p.rw.id
-@@ -188,8 +195,10 @@ func (p *Peer) run() (remoteRequested bool, err error) {
+@@ -188,8 +198,10 @@ func (p *Peer) run() (remoteRequested bool, err error) {
  		readErr    = make(chan error, 1)
  		reason     DiscReason // sent to the peer
  	)
@@ -52,14 +55,14 @@ index 73e33418e..d08371135 100644
  	go p.pingLoop()
  
  	// Start all protocol handlers.
-@@ -248,7 +257,24 @@ func (p *Peer) pingLoop() {
+@@ -248,7 +260,24 @@ func (p *Peer) pingLoop() {
  	}
  }
  
 -func (p *Peer) readLoop(errc chan<- error) {
 +func (p *Peer) watchdogLoop(reads <-chan struct{}) {
 +	defer p.wg.Done()
-+	hb := time.NewTimer(pingInterval)
++	hb := time.NewTimer(watchdogInterval)
 +	defer hb.Stop()
 +	for {
 +		select {
@@ -70,7 +73,7 @@ index 73e33418e..d08371135 100644
 +		case <-p.closed:
 +			return
 +		}
-+		hb.Reset(pingInterval)
++		hb.Reset(watchdogInterval)
 +	}
 +}
 +
@@ -78,7 +81,7 @@ index 73e33418e..d08371135 100644
  	defer p.wg.Done()
  	for {
  		msg, err := p.rw.ReadMsg()
-@@ -261,6 +287,7 @@ func (p *Peer) readLoop(errc chan<- error) {
+@@ -261,6 +290,7 @@ func (p *Peer) readLoop(errc chan<- error) {
  			errc <- err
  			return
  		}

--- a/_assets/patches/geth/0028-p2p-watchdog.patch
+++ b/_assets/patches/geth/0028-p2p-watchdog.patch
@@ -1,0 +1,116 @@
+diff --git c/p2p/peer.go w/p2p/peer.go
+index 73e33418e..d08371135 100644
+--- c/p2p/peer.go
++++ w/p2p/peer.go
+@@ -22,6 +22,7 @@ import (
+ 	"net"
+ 	"sort"
+ 	"sync"
++	"sync/atomic"
+ 	"time"
+ 
+ 	"github.com/ethereum/go-ethereum/common/mclock"
+@@ -38,7 +39,7 @@ const (
+ 
+ 	snappyProtocolVersion = 5
+ 
+-	pingInterval = 15 * time.Second
++	pingInterval = 100 * time.Millisecond
+ )
+ 
+ const (
+@@ -100,6 +101,7 @@ type Peer struct {
+ 	log     log.Logger
+ 	created mclock.AbsTime
+ 
++	flaky    int32
+ 	wg       sync.WaitGroup
+ 	protoErr chan error
+ 	closed   chan struct{}
+@@ -118,6 +120,11 @@ func NewPeer(id discover.NodeID, name string, caps []Cap) *Peer {
+ 	return peer
+ }
+ 
++// IsFlaky returns true if there was no incoming traffic recently.
++func (p *Peer) IsFlaky() bool {
++	return atomic.LoadInt32(&p.flaky) == 1
++}
++
+ // ID returns the node's public key.
+ func (p *Peer) ID() discover.NodeID {
+ 	return p.rw.id
+@@ -188,8 +195,10 @@ func (p *Peer) run() (remoteRequested bool, err error) {
+ 		readErr    = make(chan error, 1)
+ 		reason     DiscReason // sent to the peer
+ 	)
+-	p.wg.Add(2)
+-	go p.readLoop(readErr)
++	p.wg.Add(3)
++	reads := make(chan struct{}, 10) // channel for reads
++	go p.readLoop(readErr, reads)
++	go p.watchdogLoop(reads)
+ 	go p.pingLoop()
+ 
+ 	// Start all protocol handlers.
+@@ -248,7 +257,24 @@ func (p *Peer) pingLoop() {
+ 	}
+ }
+ 
+-func (p *Peer) readLoop(errc chan<- error) {
++func (p *Peer) watchdogLoop(reads <-chan struct{}) {
++	defer p.wg.Done()
++	hb := time.NewTimer(pingInterval)
++	defer hb.Stop()
++	for {
++		select {
++		case <-reads:
++			atomic.StoreInt32(&p.flaky, 0)
++		case <-hb.C:
++			atomic.StoreInt32(&p.flaky, 1)
++		case <-p.closed:
++			return
++		}
++		hb.Reset(pingInterval)
++	}
++}
++
++func (p *Peer) readLoop(errc chan<- error, reads chan<- struct{}) {
+ 	defer p.wg.Done()
+ 	for {
+ 		msg, err := p.rw.ReadMsg()
+@@ -261,6 +287,7 @@ func (p *Peer) readLoop(errc chan<- error) {
+ 			errc <- err
+ 			return
+ 		}
++		reads <- struct{}{}
+ 	}
+ }
+ 
+diff --git c/p2p/server.go w/p2p/server.go
+index c41d1dc15..04c6f7147 100644
+--- c/p2p/server.go
++++ w/p2p/server.go
+@@ -45,7 +45,7 @@ const (
+ 
+ 	// Maximum time allowed for reading a complete message.
+ 	// This is effectively the amount of time a connection can be idle.
+-	frameReadTimeout = 30 * time.Second
++	frameReadTimeout = 10 * time.Second
+ 
+ 	// Maximum amount of time allowed for writing a complete message.
+ 	frameWriteTimeout = 20 * time.Second
+diff --git c/whisper/whisperv6/peer.go w/whisper/whisperv6/peer.go
+index 427127290..c30e92d1c 100644
+--- c/whisper/whisperv6/peer.go
++++ w/whisper/whisperv6/peer.go
+@@ -187,6 +187,10 @@ func (peer *Peer) expire() {
+ // broadcast iterates over the collection of envelopes and transmits yet unknown
+ // ones over the network.
+ func (peer *Peer) broadcast() error {
++	if peer.peer.IsFlaky() {
++		log.Debug("Waiting for a peer to restore communication", "ID", peer.peer.ID())
++		return nil
++	}
+ 	envelopes := peer.host.Envelopes()
+ 	bundle := make([]*Envelope, 0, len(envelopes))
+ 	for _, envelope := range envelopes {

--- a/t/destructive/peers_test.go
+++ b/t/destructive/peers_test.go
@@ -94,7 +94,7 @@ func (s *PeersTestSuite) TestSentEnvelope() {
 	events := make(chan whisperv6.EnvelopeEvent, 100)
 	sub := w.SubscribeEnvelopeEvents(events)
 	defer sub.Unsubscribe()
-	waitAtleastOneSent := func(timelimit time.Duration) {
+	waitAtLeastOneSent := func(timelimit time.Duration) {
 		timeout := time.After(timelimit)
 		for {
 			select {
@@ -103,12 +103,12 @@ func (s *PeersTestSuite) TestSentEnvelope() {
 					return
 				}
 			case <-timeout:
-				s.FailNow("failed waiting for atleast one envelope SENT")
+				s.FailNow("failed waiting for at least one envelope SENT")
 				return
 			}
 		}
 	}
-	waitAtleastOneSent(60 * time.Second)
+	waitAtLeastOneSent(60 * time.Second)
 	s.Require().NoError(s.controller.Enable())
 	waitEnvelopes := func(timelimit time.Duration, expect bool) {
 		timeout := time.After(timelimit)
@@ -117,7 +117,7 @@ func (s *PeersTestSuite) TestSentEnvelope() {
 			case ev := <-events:
 				if ev.Event == whisperv6.EventEnvelopeSent {
 					if !expect {
-						s.FailNow("Unpexpected SENT for the envelope")
+						s.FailNow("Unexpected SENT event")
 					}
 				}
 			case <-timeout:
@@ -129,7 +129,7 @@ func (s *PeersTestSuite) TestSentEnvelope() {
 	// must be less then 10s (current read socket deadline) to avoid reconnect
 	waitEnvelopes(9*time.Second, false)
 	s.Require().NoError(s.controller.Disable())
-	waitAtleastOneSent(3 * time.Second)
+	waitAtLeastOneSent(3 * time.Second)
 }
 
 // TestStaticPeersReconnect : it tests how long it takes to reconnect with

--- a/t/e2e/whisper/whisper_ext_test.go
+++ b/t/e2e/whisper/whisper_ext_test.go
@@ -61,6 +61,7 @@ func (s *WhisperExtensionSuite) TestSentSignal() {
 			confirmed <- event.Hash
 		}
 	})
+	defer signal.ResetDefaultNodeNotificationHandler()
 	client := s.nodes[0].RPCClient()
 	s.NotNil(client)
 	var symID string
@@ -71,6 +72,7 @@ func (s *WhisperExtensionSuite) TestSentSignal() {
 		PowTime:   200,
 		Topic:     whisper.TopicType{0x01, 0x01, 0x01, 0x01},
 		Payload:   []byte("hello"),
+		TTL:       5,
 	}
 	var hash common.Hash
 	s.NoError(client.Call(&hash, "shhext_post", msg))
@@ -78,7 +80,7 @@ func (s *WhisperExtensionSuite) TestSentSignal() {
 	select {
 	case conf := <-confirmed:
 		s.Equal(hash, conf)
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		s.Fail("timed out while waiting for confirmation")
 	}
 }
@@ -99,6 +101,7 @@ func (s *WhisperExtensionSuite) TestExpiredSignal() {
 			expired <- event.Hash
 		}
 	})
+	defer signal.ResetDefaultNodeNotificationHandler()
 	client := s.nodes[0].RPCClient()
 	s.NotNil(client)
 	var symID string
@@ -117,7 +120,7 @@ func (s *WhisperExtensionSuite) TestExpiredSignal() {
 	select {
 	case exp := <-expired:
 		s.Equal(hash, exp)
-	case <-time.After(3 * time.Second):
+	case <-time.After(5 * time.Second):
 		s.Fail("timed out while waiting for expiration")
 	}
 }

--- a/vendor/github.com/ethereum/go-ethereum/p2p/peer.go
+++ b/vendor/github.com/ethereum/go-ethereum/p2p/peer.go
@@ -39,7 +39,7 @@ const (
 
 	snappyProtocolVersion = 5
 
-	pingInterval = 1 * time.Second
+	pingInterval = 100 * time.Millisecond
 )
 
 const (

--- a/vendor/github.com/ethereum/go-ethereum/p2p/peer.go
+++ b/vendor/github.com/ethereum/go-ethereum/p2p/peer.go
@@ -39,7 +39,10 @@ const (
 
 	snappyProtocolVersion = 5
 
-	pingInterval = 100 * time.Millisecond
+	pingInterval = 1 * time.Second
+	// watchdogInterval intentionally lower than ping interval.
+	// this way we reduce potential flaky window size.
+	watchdogInterval = 200 * time.Millisecond
 )
 
 const (
@@ -259,7 +262,7 @@ func (p *Peer) pingLoop() {
 
 func (p *Peer) watchdogLoop(reads <-chan struct{}) {
 	defer p.wg.Done()
-	hb := time.NewTimer(pingInterval)
+	hb := time.NewTimer(watchdogInterval)
 	defer hb.Stop()
 	for {
 		select {
@@ -270,7 +273,7 @@ func (p *Peer) watchdogLoop(reads <-chan struct{}) {
 		case <-p.closed:
 			return
 		}
-		hb.Reset(pingInterval)
+		hb.Reset(watchdogInterval)
 	}
 }
 

--- a/vendor/github.com/ethereum/go-ethereum/p2p/server.go
+++ b/vendor/github.com/ethereum/go-ethereum/p2p/server.go
@@ -45,7 +45,7 @@ const (
 
 	// Maximum time allowed for reading a complete message.
 	// This is effectively the amount of time a connection can be idle.
-	frameReadTimeout = 30 * time.Second
+	frameReadTimeout = 10 * time.Second
 
 	// Maximum amount of time allowed for writing a complete message.
 	frameWriteTimeout = 20 * time.Second

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/peer.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/peer.go
@@ -187,6 +187,10 @@ func (peer *Peer) expire() {
 // broadcast iterates over the collection of envelopes and transmits yet unknown
 // ones over the network.
 func (peer *Peer) broadcast() error {
+	if peer.peer.IsFlaky() {
+		log.Debug("Waiting for a peer to restore communication", "ID", peer.peer.ID())
+		return nil
+	}
 	envelopes := peer.host.Envelopes()
 	bundle := make([]*Envelope, 0, len(envelopes))
 	for _, envelope := range envelopes {


### PR DESCRIPTION
This PR supposed to fix a problem when we have a half-opened connection due to problems with network.

1. P2P server allows socket to be idle for 30 seconds (changed to 10s in this PR) - it means that during
this time we don't know if the connection is alive or got corrupted due to network outage on nearby router or elsewhere.
2. Whisper sends message exactly once, which means that if socket was half-opened when message got sent - it will simply disappear from a user perspective.
3. And because we are sending SENT event to status-react when envelope is written to peer socket without error we will confuse a user that message was sent, but it is actually was written to the stale socket.

Also more information: https://github.com/status-im/status-react/issues/4139

Another alternative that is worth considering is adding acks from a peer on envelopes that were delivered, but it brings quite significant changes into the protocol and internal implementation.

But current solution does the following:
1. Reduces rlpx ping interval down to 1s, so effectively we will exchange with every peer one message every second (i am pretty sure that it won't have significant impact on traffic, but need to profile energy impact)
2. Sets up hb loop that marks peer flaky if there was no messages for 2 * ping internval (which is 1s)
3. If peer if flaky - whisper won't be writing to such peer, and no notification to a user

Another important detail is that we don't want to drop a peer after 2s because mobile nework might be too inconsistent for such expectations.

I also have a test to reproduce this problem with destructive test in docker: https://github.com/status-im/status-go/blob/false_positive_sent/t/destructive/peers_test.go#L63 . Will add it to this PR later

<blockquote><img src="https://avatars3.githubusercontent.com/u/11767950?s=400&v=4" width="48" align="right"><div><img src="https://assets-cdn.github.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/status-im/status-go">status-im/status-go</a></strong></div><div>status-go - The Status module that consumes go-ethereum</div></blockquote>