### PR TITLE
Add separate API for deduplicator to confirm received messages.

### DIFF
--- a/services/shhext/README.md
+++ b/services/shhext/README.md
@@ -4,9 +4,34 @@ Whisper API Extension
 API
 ---
 
+
+#### shhext_getNewFilterMessages
+
+Accepts the same input as [`shh_getFilterMessages`](https://github.com/ethereum/wiki/wiki/JSON-RPC#shh_getFilterChanges).
+
+##### Returns
+
+Returns a list of whisper messages matching the specified filter. Filters out
+the messages already confirmed received by [`shhext_confirmMessagesProcessed`](#shhextconfirmmessagesprocessed)
+
+Deduplication is made using the whisper envelope content and topic only, so the
+same content received in different whisper envelopes will be deduplicated.
+
+
+#### shhext_confirmMessagesProcessed
+
+Confirms whisper messages received and processed on the client side. These
+messages won't appear anymore when [`shhext_getNewFilterMessages`](#shhextgetnewfiltermessages) 
+is called.
+
+##### Parameters
+
+Gets a list of whisper envelopes.
+
+
 #### shhext_post
 
-Accepts same input as shh_post (see https://github.com/ethereum/wiki/wiki/JSON-RPC#shh_post)
+Accepts same input as [`shh_post`](https://github.com/ethereum/wiki/wiki/JSON-RPC#shh_post).
 
 ##### Returns
 

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -124,7 +124,13 @@ func (api *PublicAPI) GetNewFilterMessages(filterID string) ([]*whisper.Message,
 	if err != nil {
 		return nil, err
 	}
-	return api.service.Deduplicator.Deduplicate(msgs), err
+	return api.service.deduplicator.Deduplicate(msgs), err
+}
+
+// ConfirmMessagesProcessed is a method to confirm that messages was consumed by
+// the client side.
+func (api *PublicAPI) ConfirmMessagesProcessed(messages []*whisper.Message) error {
+	return api.service.deduplicator.AddMessages(messages)
 }
 
 // -----

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/status-im/status-go/services/shhext/dedup"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // EnvelopeState in local tracker
@@ -34,14 +35,14 @@ type Service struct {
 	w            *whisper.Whisper
 	tracker      *tracker
 	nodeID       *ecdsa.PrivateKey
-	Deduplicator *dedup.Deduplicator
+	deduplicator *dedup.Deduplicator
 }
 
 // Make sure that Service implements node.Service interface.
 var _ node.Service = (*Service)(nil)
 
 // New returns a new Service.
-func New(w *whisper.Whisper, handler EnvelopeEventsHandler) *Service {
+func New(w *whisper.Whisper, handler EnvelopeEventsHandler, db *leveldb.DB) *Service {
 	track := &tracker{
 		w:       w,
 		handler: handler,
@@ -50,7 +51,7 @@ func New(w *whisper.Whisper, handler EnvelopeEventsHandler) *Service {
 	return &Service{
 		w:            w,
 		tracker:      track,
-		Deduplicator: dedup.NewDeduplicator(w),
+		deduplicator: dedup.NewDeduplicator(w, db),
 	}
 }
 

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -66,7 +66,7 @@ func (s *ShhExtSuite) SetupTest() {
 		s.NoError(stack.Register(func(n *node.ServiceContext) (node.Service, error) {
 			return s.whisper[i], nil
 		}))
-		s.services[i] = New(s.whisper[i], nil)
+		s.services[i] = New(s.whisper[i], nil, nil)
 		s.NoError(stack.Register(func(n *node.ServiceContext) (node.Service, error) {
 			return s.services[i], nil
 		}))
@@ -159,7 +159,7 @@ func (s *ShhExtSuite) TestRequestMessages() {
 	}()
 
 	mock := newHandlerMock(1)
-	service := New(shh, mock)
+	service := New(shh, mock, nil)
 	api := NewPublicAPI(service)
 
 	const (

--- a/t/e2e/api/api_test.go
+++ b/t/e2e/api/api_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/status-im/status-go/signal"
 	. "github.com/status-im/status-go/t/utils"
 	"github.com/stretchr/testify/suite"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
 )
 
 const (
@@ -253,8 +255,12 @@ func (s *APITestSuite) TestNodeStartCrash() {
 	nodeConfig, err := MakeTestNodeConfig(GetNetworkID())
 	s.NoError(err)
 
+	db, err := leveldb.Open(storage.NewMemStorage(), nil)
+	s.NoError(err)
+	defer func() { s.NoError(db.Close()) }()
+
 	// start node outside the manager (on the same port), so that manager node.Start() method fails
-	outsideNode, err := node.MakeNode(nodeConfig)
+	outsideNode, err := node.MakeNode(nodeConfig, db)
 	s.NoError(err)
 	err = outsideNode.Start()
 	s.NoError(err)


### PR DESCRIPTION
A small update to the deduplicator, that require a client to actually confirm that the message was received. That helps to avoid situations if the client-side crashed and never had a chance to cache the message locally.

And some docs.