### PR TITLE
External RPC request whitelist

### DIFF
--- a/geth/api/backend.go
+++ b/geth/api/backend.go
@@ -221,14 +221,16 @@ func (b *StatusBackend) ResetChainData() error {
 
 // CallRPC executes public RPC requests on node's in-proc RPC server.
 func (b *StatusBackend) CallRPC(inputJSON string) string {
+	isExternal := true
 	client := b.statusNode.RPCClient()
-	return client.CallRaw(inputJSON)
+	return client.CallRaw(inputJSON, isExternal)
 }
 
 // CallPrivateRPC executes public and private RPC requests on node's in-proc RPC server.
 func (b *StatusBackend) CallPrivateRPC(inputJSON string) string {
+	isExternal := false
 	client := b.statusNode.RPCPrivateClient()
-	return client.CallRaw(inputJSON)
+	return client.CallRaw(inputJSON, isExternal)
 }
 
 // SendTransaction creates a new transaction and waits until it's complete.

--- a/geth/jail/jail.go
+++ b/geth/jail/jail.go
@@ -268,7 +268,8 @@ func (j *Jail) sendRPCCall(request string) (interface{}, error) {
 		return nil, ErrNoRPCClient
 	}
 
-	rawResponse := client.CallRaw(request)
+	isExternal := true
+	rawResponse := client.CallRaw(request, isExternal)
 
 	var response interface{}
 	if err := json.Unmarshal([]byte(rawResponse), &response); err != nil {

--- a/geth/rpc/call_raw.go
+++ b/geth/rpc/call_raw.go
@@ -22,7 +22,7 @@ var defaultMsgID = json.RawMessage(`0`)
 
 // CallRaw performs a JSON-RPC call with already crafted JSON-RPC body. It
 // returns string in JSON format with response (successul or error).
-func (c *Client) CallRaw(body string) string {
+func (c *Client) CallRaw(body string, external bool) string {
 	ctx := context.Background()
 	return c.callRawContext(ctx, json.RawMessage(body))
 }

--- a/t/e2e/accounts/accounts_rpc_test.go
+++ b/t/e2e/accounts/accounts_rpc_test.go
@@ -35,7 +35,7 @@ func (s *AccountsTestSuite) TestRPCEthAccounts() {
 		"id": 1,
 		"method": "eth_accounts",
 		"params": []
-    }`)
+    }`, false)
 	s.Equal(expectedResponse, resp)
 }
 
@@ -62,6 +62,6 @@ func (s *AccountsTestSuite) TestRPCEthAccountsWithUpstream() {
     	"id": 1,
     	"method": "eth_accounts",
     	"params": []
-    }`)
+    }`, false)
 	s.Equal(expectedResponse, resp)
 }

--- a/t/e2e/jail/jail_rpc_test.go
+++ b/t/e2e/jail/jail_rpc_test.go
@@ -104,7 +104,7 @@ func (s *JailRPCTestSuite) TestRegressionGetTransactionReceipt() {
 	s.NotNil(rpcClient)
 
 	// note: transaction hash is assumed to be invalid
-	got := rpcClient.CallRaw(`{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xbbebf28d0a3a3cbb38e6053a5b21f08f82c62b0c145a17b1c4313cac3f68ae7c"],"id":7}`)
+	got := rpcClient.CallRaw(`{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0xbbebf28d0a3a3cbb38e6053a5b21f08f82c62b0c145a17b1c4313cac3f68ae7c"],"id":7}`, false)
 	expected := `{"jsonrpc":"2.0","id":7,"result":null}`
 	s.Equal(expected, got)
 }

--- a/t/e2e/rpc/rpc_test.go
+++ b/t/e2e/rpc/rpc_test.go
@@ -102,7 +102,7 @@ func (s *RPCTestSuite) TestCallRPC() {
 			wg.Add(1)
 			go func(r rpcCall) {
 				defer wg.Done()
-				resultJSON := rpcClient.CallRaw(r.inputJSON)
+				resultJSON := rpcClient.CallRaw(r.inputJSON, false)
 				r.validator(resultJSON)
 			}(r)
 		}
@@ -133,7 +133,7 @@ func (s *RPCTestSuite) TestCallRawResult() {
 	client := s.StatusNode.RPCClient()
 	s.NotNil(client)
 
-	jsonResult := client.CallRaw(`{"jsonrpc":"2.0","method":"shh_version","params":[],"id":67}`)
+	jsonResult := client.CallRaw(`{"jsonrpc":"2.0","method":"shh_version","params":[],"id":67}`, false)
 	s.Equal(`{"jsonrpc":"2.0","id":67,"result":"6.0"}`, jsonResult)
 
 	s.NoError(s.StatusNode.Stop())
@@ -151,7 +151,7 @@ func (s *RPCTestSuite) TestCallRawResultGetTransactionReceipt() {
 	client := s.StatusNode.RPCClient()
 	s.NotNil(client)
 
-	jsonResult := client.CallRaw(`{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x0ca0d8f2422f62bea77e24ed17db5711a77fa72064cccbb8e53c53b699cd3b34"],"id":5}`)
+	jsonResult := client.CallRaw(`{"jsonrpc":"2.0","method":"eth_getTransactionReceipt","params":["0x0ca0d8f2422f62bea77e24ed17db5711a77fa72064cccbb8e53c53b699cd3b34"],"id":5}`, false)
 	s.Equal(`{"jsonrpc":"2.0","id":5,"result":null}`, jsonResult)
 
 	s.NoError(s.StatusNode.Stop())

--- a/t/e2e/whisper/whisper_mailbox_test.go
+++ b/t/e2e/whisper/whisper_mailbox_test.go
@@ -108,7 +108,7 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 					"to":` + strconv.FormatInt(senderWhisperService.GetCurrentTime().Unix(), 10) + `
 		}]
 	}`
-	resp := rpcClient.CallRaw(reqMessagesBody)
+	resp := rpcClient.CallRaw(reqMessagesBody, false)
 	reqMessagesResp := baseRPCResponse{}
 	err = json.Unmarshal([]byte(resp), &reqMessagesResp)
 	s.Require().NoError(err)
@@ -380,10 +380,10 @@ func (s *WhisperMailboxSuite) createPrivateChatMessageFilter(rpcCli *rpc.Client,
 	resp := rpcCli.CallRaw(`{
 			"jsonrpc": "2.0",
 			"method": "shh_newMessageFilter", "params": [
-				{"privateKeyID": "` + privateKeyID + `", "topics": [ "` + topic + `"], "allowP2P":true}
+				{"privateKeyID": "`+privateKeyID+`", "topics": [ "`+topic+`"], "allowP2P":true}
 			],
 			"id": 1
-		}`)
+		}`, false)
 
 	msgFilterResp := returnedIDResponse{}
 	err := json.Unmarshal([]byte(resp), &msgFilterResp)
@@ -399,10 +399,10 @@ func (s *WhisperMailboxSuite) createGroupChatMessageFilter(rpcCli *rpc.Client, s
 	resp := rpcCli.CallRaw(`{
 			"jsonrpc": "2.0",
 			"method": "shh_newMessageFilter", "params": [
-				{"symKeyID": "` + symkeyID + `", "topics": [ "` + topic + `"], "allowP2P":true}
+				{"symKeyID": "`+symkeyID+`", "topics": [ "`+topic+`"], "allowP2P":true}
 			],
 			"id": 1
-		}`)
+		}`, false)
 
 	msgFilterResp := returnedIDResponse{}
 	err := json.Unmarshal([]byte(resp), &msgFilterResp)
@@ -419,14 +419,14 @@ func (s *WhisperMailboxSuite) postMessageToPrivate(rpcCli *rpc.Client, bobPubkey
 		"method": "shh_post",
 		"params": [
 			{
-			"pubKey": "` + bobPubkey + `",
-			"topic": "` + topic + `",
-			"payload": "` + payload + `",
+			"pubKey": "`+bobPubkey+`",
+			"topic": "`+topic+`",
+			"payload": "`+payload+`",
 			"powTarget": 0.001,
 			"powTime": 2
 			}
 		],
-		"id": 1}`)
+		"id": 1}`, false)
 	postResp := baseRPCResponse{}
 	err := json.Unmarshal([]byte(resp), &postResp)
 	s.Require().NoError(err)
@@ -439,14 +439,14 @@ func (s *WhisperMailboxSuite) postMessageToGroup(rpcCli *rpc.Client, groupChatKe
 		"method": "shh_post",
 		"params": [
 			{
-			"symKeyID": "` + groupChatKeyID + `",
-			"topic": "` + topic + `",
-			"payload": "` + payload + `",
+			"symKeyID": "`+groupChatKeyID+`",
+			"topic": "`+topic+`",
+			"payload": "`+payload+`",
 			"powTarget": 0.001,
 			"powTime": 2
 			}
 		],
-		"id": 1}`)
+		"id": 1}`, false)
 	postResp := baseRPCResponse{}
 	err := json.Unmarshal([]byte(resp), &postResp)
 	s.Require().NoError(err)
@@ -458,8 +458,8 @@ func (s *WhisperMailboxSuite) getMessagesByMessageFilterID(rpcCli *rpc.Client, m
 	resp := rpcCli.CallRaw(`{
 		"jsonrpc": "2.0",
 		"method": "shh_getFilterMessages",
-		"params": ["` + messageFilterID + `"],
-		"id": 1}`)
+		"params": ["`+messageFilterID+`"],
+		"id": 1}`, false)
 	messages := getFilterMessagesResponse{}
 	err := json.Unmarshal([]byte(resp), &messages)
 	s.Require().NoError(err)
@@ -470,8 +470,8 @@ func (s *WhisperMailboxSuite) getMessagesByMessageFilterID(rpcCli *rpc.Client, m
 // addSymKey added symkey to node and return symkeyID.
 func (s *WhisperMailboxSuite) addSymKey(rpcCli *rpc.Client, symkey string) string {
 	resp := rpcCli.CallRaw(`{"jsonrpc":"2.0","method":"shh_addSymKey",
-			"params":["` + symkey + `"],
-			"id":1}`)
+			"params":["`+symkey+`"],
+			"id":1}`, false)
 	symkeyAddResp := returnedIDResponse{}
 	err := json.Unmarshal([]byte(resp), &symkeyAddResp)
 	s.Require().NoError(err)
@@ -489,13 +489,13 @@ func (s *WhisperMailboxSuite) requestHistoricMessages(w *whisper.Whisper, rpcCli
 		"id": 2,
 		"method": "shhext_requestMessages",
 		"params": [{
-					"mailServerPeer":"` + mailboxEnode + `",
-					"topic":"` + topic + `",
-					"symKeyID":"` + mailServerKeyID + `",
-					"from":` + strconv.FormatInt(from.Unix(), 10) + `,
-					"to":` + strconv.FormatInt(w.GetCurrentTime().Unix(), 10) + `
+					"mailServerPeer":"`+mailboxEnode+`",
+					"topic":"`+topic+`",
+					"symKeyID":"`+mailServerKeyID+`",
+					"from":`+strconv.FormatInt(from.Unix(), 10)+`,
+					"to":`+strconv.FormatInt(w.GetCurrentTime().Unix(), 10)+`
 		}]
-	}`)
+	}`, false)
 	reqMessagesResp := baseRPCResponse{}
 	err := json.Unmarshal([]byte(resp), &reqMessagesResp)
 	s.Require().NoError(err)


### PR DESCRIPTION

    Addresses #912

    Create a whitelist that prevents external RPC requests (from dapps) from using methods like shh.setMinPoW. The approach here was to pass down an 'external' flag into the context.Context of call raw, since its a request-scoped variable.

Done
 - backend.rpc:CallRPC calls CallRaw using an external flag
 - All other CallRaw calls are updated to use external=false. Don't think that any of them are external, but correct me if I'm wrong.
 - external flag gets passed into the context.Context of CallRaw
 - When calling each method, the whitelist is applied to external requests, returning an error