### PR TITLE
[#930] : False positive e2e test fix

### DIFF
--- a/t/e2e/services/status_api_test.go
+++ b/t/e2e/services/status_api_test.go
@@ -134,11 +134,12 @@ func (s *StatusAPISuite) testStatusLogin(testParams statusTestParams) *status.Lo
 
 	result := s.Backend.CallPrivateRPC(basicCall)
 	if testParams.ExpectedError == nil {
-		s.NotContains(result, "error")
 		var r struct {
+			Error  string                `json:"error"`
 			Result *status.LoginResponse `json:"result"`
 		}
 		s.NoError(json.Unmarshal([]byte(result), &r))
+		s.Empty(r.Error)
 
 		return r.Result
 	}
@@ -179,11 +180,12 @@ func (s *StatusAPISuite) testStatusSignup(testParams statusTestParams) *status.S
 	result := s.Backend.CallPrivateRPC(basicCall)
 
 	if testParams.ExpectedError == nil {
-		s.NotContains(result, "error")
 		var r struct {
+			Error  string                 `json:"error"`
 			Result *status.SignupResponse `json:"result"`
 		}
 		s.NoError(json.Unmarshal([]byte(result), &r))
+		s.Empty(r.Error)
 
 		return r.Result
 	}


### PR DESCRIPTION
NotContains assertion is used to check if `error` is part of the response expecting it will only appear on responses like `{"error":"whatever"}`, but, in fact, error is sometimes part of mnemonic, so it causes a false positive on our test suite

Closes #930
