### PR TITLE
fix default range value for shhext_requestMessages

### DIFF
--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -54,9 +54,12 @@ type MessagesRequest struct {
 
 func (r *MessagesRequest) setDefaults(now time.Time) {
 	// set From and To defaults
-	if r.From == 0 && r.To == 0 {
-		r.From = uint32(now.UTC().Add(-24 * time.Hour).Unix())
+	if r.To == 0 {
 		r.To = uint32(now.UTC().Unix())
+	}
+
+	if r.From == 0 {
+		r.From = r.To - 86400 // -24 hours
 	}
 }
 

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -59,7 +59,12 @@ func (r *MessagesRequest) setDefaults(now time.Time) {
 	}
 
 	if r.From == 0 {
-		r.From = r.To - 86400 // -24 hours
+		oneDay := uint32(86400) // -24 hours
+		if r.To < oneDay {
+			r.From = 0
+		} else {
+			r.From = r.To - oneDay
+		}
 	}
 }
 

--- a/services/shhext/api_test.go
+++ b/services/shhext/api_test.go
@@ -33,11 +33,15 @@ func TestMessagesRequest_setDefaults(t *testing.T) {
 			&MessagesRequest{From: 0, To: yesterday},
 			&MessagesRequest{From: daysAgo(tnow, 2), To: yesterday},
 		},
+		// 100 - 1 day would be invalid, so we set From to 0
+		{
+			&MessagesRequest{From: 0, To: 100},
+			&MessagesRequest{From: 0, To: 100},
+		},
 	}
 
 	for i, s := range scenarios {
 		t.Run(fmt.Sprintf("Scenario %d", i), func(t *testing.T) {
-			require.NotEqual(t, s.expected, s.given)
 			s.given.setDefaults(tnow)
 			require.Equal(t, s.expected, s.given)
 		})

--- a/services/shhext/api_test.go
+++ b/services/shhext/api_test.go
@@ -1,6 +1,7 @@
 package shhext
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -34,9 +35,11 @@ func TestMessagesRequest_setDefaults(t *testing.T) {
 		},
 	}
 
-	for _, s := range scenarios {
-		require.NotEqual(t, s.expected, s.given)
-		s.given.setDefaults(tnow)
-		require.Equal(t, s.expected, s.given)
+	for i, s := range scenarios {
+		t.Run(fmt.Sprintf("Scenario %d", i), func(t *testing.T) {
+			require.NotEqual(t, s.expected, s.given)
+			s.given.setDefaults(tnow)
+			require.Equal(t, s.expected, s.given)
+		})
 	}
 }

--- a/services/shhext/api_test.go
+++ b/services/shhext/api_test.go
@@ -1,0 +1,42 @@
+package shhext
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessagesRequest_setDefaults(t *testing.T) {
+	daysAgo := func(now time.Time, days int) uint32 {
+		return uint32(now.UTC().Add(-24 * time.Hour * time.Duration(days)).Unix())
+	}
+
+	tnow := time.Now()
+	now := uint32(tnow.UTC().Unix())
+	yesterday := daysAgo(tnow, 1)
+
+	scenarios := []struct {
+		given    *MessagesRequest
+		expected *MessagesRequest
+	}{
+		{
+			&MessagesRequest{From: 0, To: 0},
+			&MessagesRequest{From: yesterday, To: now},
+		},
+		{
+			&MessagesRequest{From: 1, To: 0},
+			&MessagesRequest{From: uint32(1), To: now},
+		},
+		{
+			&MessagesRequest{From: 0, To: yesterday},
+			&MessagesRequest{From: daysAgo(tnow, 2), To: yesterday},
+		},
+	}
+
+	for _, s := range scenarios {
+		require.NotEqual(t, s.expected, s.given)
+		s.given.setDefaults(tnow)
+		require.Equal(t, s.expected, s.given)
+	}
+}

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -128,13 +128,6 @@ func (s *ShhExtSuite) TestWaitMessageExpired() {
 	}
 }
 
-func (s *ShhExtSuite) TestRequestMessagesDefaults() {
-	r := MessagesRequest{}
-	r.setDefaults(time.Now())
-	s.NotZero(r.From)
-	s.InEpsilon(uint32(time.Now().UTC().Unix()), r.To, 1.0)
-}
-
 func (s *ShhExtSuite) TestRequestMessages() {
 	var err error
 


### PR DESCRIPTION
This PR set the default value of `From` and `To` in the  `shhext_requestMessages` call in case only one of the 2 is set.

Closes #933 

