### PR TITLE
Fix flaky TestStatusNodeReconnectStaticPeers test

### DIFF
--- a/geth/node/status_node_test.go
+++ b/geth/node/status_node_test.go
@@ -234,9 +234,9 @@ func TestStatusNodeReconnectStaticPeers(t *testing.T) {
 	require.Equal(t, 1, n.PeerCount())
 
 	// reconnect static peers
+	errCh = waitForPeerAsync(n, peerURL, p2p.PeerEventTypeDrop, time.Second*30)
 	require.NoError(t, n.ReconnectStaticPeers())
 	// first check if a peer gets disconnected
-	errCh = waitForPeerAsync(n, peerURL, p2p.PeerEventTypeDrop, time.Second*30)
 	require.NoError(t, <-errCh)
 	require.Equal(t, 0, n.PeerCount())
 	// it takes at least 30 seconds to bring back previously connected peer


### PR DESCRIPTION
This addresses a problem spotted in https://jenkins.status.im/job/status-go/job/race-check/64/consoleFull

### Problem
`TestStatusNodeReconnectStaticPeers` can fail because 
```go
errCh = waitForPeerAsync(n, peerURL, time.Second*30)
```
can be called before 
```go
require.NoError(t, n.Start(&config))
```
and the first call requires the node to be already running.

<blockquote></blockquote>