### PR TITLE
[#ISSUE-947/ISSUE-946] Rate limit and query range limit on mail server

### DIFF
--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -227,12 +227,7 @@ func activateShhService(stack *node.Node, config *params.NodeConfig, db *leveldb
 
 			var mailServer mailserver.WMailServer
 			whisperService.RegisterServer(&mailServer)
-			err := mailServer.Init(
-				whisperService,
-				config.WhisperConfig.DataDir,
-				config.WhisperConfig.Password,
-				config.WhisperConfig.MinimumPoW,
-			)
+			err := mailServer.Init(whisperService, config.WhisperConfig)
 			if err != nil {
 				return nil, err
 			}

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -105,6 +105,12 @@ type WhisperConfig struct {
 	// MinimumPoW minimum PoW for Whisper messages
 	MinimumPoW float64
 
+	// RateLimit minimum time between queries to mail server per peer
+	MailServerRateLimit int
+
+	// MailServerCleanupPeriod time in seconds to wait to run mail server cleanup
+	MailServerCleanupPeriod int
+
 	// TTL time to live for messages, in seconds
 	TTL int
 

--- a/mailserver/mailserver_test.go
+++ b/mailserver/mailserver_test.go
@@ -21,16 +21,17 @@ import (
 	"crypto/ecdsa"
 	"encoding/binary"
 	"io/ioutil"
-	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
+	"github.com/status-im/status-go/geth/params"
 )
 
 const powRequirement = 0.00001
+const peerID = "peerID"
 
 var keyID string
 var shh *whisper.Whisper
@@ -38,6 +39,7 @@ var seed = time.Now().Unix()
 
 type ServerTestParams struct {
 	topic whisper.TopicType
+	birth uint32
 	low   uint32
 	upp   uint32
 	key   *ecdsa.PrivateKey
@@ -56,6 +58,39 @@ func TestDBKey(t *testing.T) {
 	assert(len(k.raw) == common.HashLength+4, "wrong DB key length", t)
 	assert(byte(i%0x100) == k.raw[3], "raw representation should be big endian", t)
 	assert(byte(i/0x1000000) == k.raw[0], "big endian expected", t)
+}
+
+func TestMailServer(t *testing.T) {
+	var server WMailServer
+
+	setupServer(t, &server)
+	defer server.Close()
+
+	env := generateEnvelope(t)
+	server.Archive(env)
+	deliverTest(t, &server, env)
+}
+
+func TestRateLimits(t *testing.T) {
+	l := newLimiter(time.Duration(5 * time.Millisecond))
+	assert(l.isAllowed(peerID), "Expected limiter not to allow with empty db", t)
+
+	l.db[peerID] = time.Now().Add(time.Duration(-10 * time.Millisecond))
+	assert(l.isAllowed(peerID), "Expected limiter to allow with peer on its db", t)
+
+	l.db[peerID] = time.Now().Add(time.Duration(-1 * time.Millisecond))
+	assert(!l.isAllowed(peerID), "Expected limiter to not allow with peer on its db", t)
+}
+
+func TestRemoveExpiredRateLimits(t *testing.T) {
+	l := newLimiter(time.Duration(10) * time.Second)
+	l.db[peerID] = time.Now().Add(time.Duration(-10) * time.Second)
+	l.db[peerID+"A"] = time.Now().Add(time.Duration(10) * time.Second)
+	l.deleteExpired()
+	_, ok := l.db[peerID]
+	assert(!ok, "Expired peer should not exist, but it does ", t)
+	_, ok = l.db[peerID+"A"]
+	assert(ok, "Non expired peer should exist, but it doesn't", t)
 }
 
 func generateEnvelope(t *testing.T) *whisper.Envelope {
@@ -79,37 +114,7 @@ func generateEnvelope(t *testing.T) *whisper.Envelope {
 	return env
 }
 
-func TestMailServer(t *testing.T) {
-	const password = "password_for_this_test"
-	const dbPath = "whisper-server-test"
-
-	dir, err := ioutil.TempDir("", dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var server WMailServer
-	shh = whisper.New(&whisper.DefaultConfig)
-	shh.RegisterServer(&server)
-
-	err = server.Init(shh, dir, password, powRequirement)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer server.Close()
-
-	keyID, err = shh.AddSymKeyFromPassword(password)
-	if err != nil {
-		t.Fatalf("Failed to create symmetric key for mail request: %s", err)
-	}
-
-	rand.Seed(seed)
-	env := generateEnvelope(t)
-	server.Archive(env)
-	deliverTest(t, &server, env)
-}
-
-func deliverTest(t *testing.T, server *WMailServer, env *whisper.Envelope) {
+func serverParams(t *testing.T, env *whisper.Envelope) *ServerTestParams {
 	id, err := shh.NewKeyPair()
 	if err != nil {
 		t.Fatalf("failed to generate new key pair with seed %d: %s.", seed, err)
@@ -119,25 +124,44 @@ func deliverTest(t *testing.T, server *WMailServer, env *whisper.Envelope) {
 		t.Fatalf("failed to retrieve new key pair with seed %d: %s.", seed, err)
 	}
 	birth := env.Expiry - env.TTL
-	p := &ServerTestParams{
+
+	return &ServerTestParams{
 		topic: env.Topic,
+		birth: birth,
 		low:   birth - 1,
 		upp:   birth + 1,
 		key:   testPeerID,
 	}
-
+}
+func deliverTest(t *testing.T, server *WMailServer, env *whisper.Envelope) {
+	p := serverParams(t, env)
 	singleRequest(t, server, env, p, true)
 
-	p.low, p.upp = birth+1, 0xffffffff
+	p.low = p.birth + 1
+	p.upp = p.birth + 1
 	singleRequest(t, server, env, p, false)
 
-	p.low, p.upp = 0, birth-1
-	singleRequest(t, server, env, p, false)
-
-	p.low = birth - 1
-	p.upp = birth + 1
+	p.low = p.birth
+	p.upp = p.birth + 1
 	p.topic[0] = 0xFF
 	singleRequest(t, server, env, p, false)
+
+	p.low = 0
+	p.upp = p.birth - 1
+	failRequest(t, server, p, "validation should fail due to negative query time range")
+
+	p.low = 0
+	p.upp = p.birth + 24
+	failRequest(t, server, p, "validation should fail due to query big time range")
+}
+
+func failRequest(t *testing.T, server *WMailServer, p *ServerTestParams, err string) {
+	request := createRequest(t, p)
+	src := crypto.FromECDSAPub(&p.key.PublicKey)
+	ok, _, _, _ := server.validateRequest(src, request)
+	if ok {
+		t.Fatalf(err)
+	}
 }
 
 func singleRequest(t *testing.T, server *WMailServer, env *whisper.Envelope, p *ServerTestParams, expect bool) {
@@ -209,4 +233,27 @@ func createRequest(t *testing.T, p *ServerTestParams) *whisper.Envelope {
 		t.Fatalf("failed to wrap with seed %d: %s.", seed, err)
 	}
 	return env
+}
+
+func setupServer(t *testing.T, server *WMailServer) {
+	const password = "password_for_this_test"
+	const dbPath = "whisper-server-test"
+
+	dir, err := ioutil.TempDir("", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shh = whisper.New(&whisper.DefaultConfig)
+	shh.RegisterServer(server)
+
+	err = server.Init(shh, &params.WhisperConfig{DataDir: dir, Password: password, MinimumPoW: powRequirement})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyID, err = shh.AddSymKeyFromPassword(password)
+	if err != nil {
+		t.Fatalf("Failed to create symmetric key for mail request: %s", err)
+	}
 }

--- a/mailserver/ticker.go
+++ b/mailserver/ticker.go
@@ -1,0 +1,24 @@
+package mailserver
+
+import "time"
+
+type ticker struct {
+	timeTicker *time.Ticker
+}
+
+func (t *ticker) run(period time.Duration, fn func()) {
+	if t.timeTicker != nil {
+		return
+	}
+
+	t.timeTicker = time.NewTicker(period)
+	go func() {
+		for range t.timeTicker.C {
+			fn()
+		}
+	}()
+}
+
+func (t *ticker) stop() {
+	t.timeTicker.Stop()
+}

--- a/t/e2e/whisper/whisper_mailbox_test.go
+++ b/t/e2e/whisper/whisper_mailbox_test.go
@@ -95,6 +95,7 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 	// Act.
 
 	// Request messages (including the previous one, expired) from mailbox.
+	from := senderWhisperService.GetCurrentTime().Add(-12 * time.Hour)
 	reqMessagesBody := `{
 		"jsonrpc": "2.0",
 		"id": 1,
@@ -103,7 +104,7 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 					"mailServerPeer":"` + mailboxPeerStr + `",
 					"topic":"` + topic.String() + `",
 					"symKeyID":"` + MailServerKeyID + `",
-					"from":0,
+					"from":` + strconv.FormatInt(from.Unix(), 10) + `,
 					"to":` + strconv.FormatInt(senderWhisperService.GetCurrentTime().Unix(), 10) + `
 		}]
 	}`
@@ -482,6 +483,7 @@ func (s *WhisperMailboxSuite) addSymKey(rpcCli *rpc.Client, symkey string) strin
 
 // requestHistoricMessages asks a mailnode to resend messages.
 func (s *WhisperMailboxSuite) requestHistoricMessages(w *whisper.Whisper, rpcCli *rpc.Client, mailboxEnode, mailServerKeyID, topic string) {
+	from := w.GetCurrentTime().Add(-12 * time.Hour)
 	resp := rpcCli.CallRaw(`{
 		"jsonrpc": "2.0",
 		"id": 2,
@@ -490,7 +492,7 @@ func (s *WhisperMailboxSuite) requestHistoricMessages(w *whisper.Whisper, rpcCli
 					"mailServerPeer":"` + mailboxEnode + `",
 					"topic":"` + topic + `",
 					"symKeyID":"` + mailServerKeyID + `",
-					"from":0,
+					"from":` + strconv.FormatInt(from.Unix(), 10) + `,
 					"to":` + strconv.FormatInt(w.GetCurrentTime().Unix(), 10) + `
 		}]
 	}`)


### PR DESCRIPTION
This PR introduces a new ability for the mail server to rate limits and limit query ranges to 24 hours as part of [improving security on mail server](https://github.com/status-im/status-go/issues/937)

Important changes:
- [x] [Introduced query range limited to 24hours](https://github.com/status-im/status-go/issues/946)
- [x] [Introduced rate limits](https://github.com/status-im/status-go/issues/947)
- [x] Added a "garbage collector" to get rid of expired rate limits
- [x] Mailserver input is now an instance of params.WhisperConfig

Notes:
- As rate limits are used to avoid possible server DDoS, I've avoided touch any extra logic like LevelDB to store them. They will be stored in memory by now, we can change this if you feel they should be on LevelDB

Closes #947 #946
