### PR TITLE
Use different pool hostnames for NTP timesource (#939)

### DIFF
--- a/timesource/timesource.go
+++ b/timesource/timesource.go
@@ -13,13 +13,6 @@ import (
 )
 
 const (
-	// DefaultServer will be internally resolved to the closest available.
-	// also it rarely queries same server more than once.
-	DefaultServer = "pool.ntp.org"
-
-	// DefaultAttempts defines how many servers we will query
-	DefaultAttempts = 5
-
 	// DefaultMaxAllowedFailures defines how many failures will be tolerated.
 	DefaultMaxAllowedFailures = 2
 
@@ -29,6 +22,15 @@ const (
 	// DefaultRPCTimeout defines write deadline for single ntp server request.
 	DefaultRPCTimeout = 2 * time.Second
 )
+
+// defaultServers will be resolved to the closest available,
+// and with high probability resolved to the different IPs
+var defaultServers = []string{
+	"0.pool.ntp.org",
+	"1.pool.ntp.org",
+	"2.pool.ntp.org",
+	"3.pool.ntp.org",
+}
 
 type ntpQuery func(string, ntp.QueryOptions) (*ntp.Response, error)
 
@@ -54,12 +56,9 @@ func (e multiRPCError) Error() string {
 	return b.String()
 }
 
-func computeOffset(timeQuery ntpQuery, server string, attempts, allowedFailures int) (time.Duration, error) {
-	if attempts == 0 {
-		return 0, nil
-	}
-	responses := make(chan queryResponse, attempts)
-	for i := 0; i < attempts; i++ {
+func computeOffset(timeQuery ntpQuery, servers []string, allowedFailures int) (time.Duration, error) {
+	responses := make(chan queryResponse, len(servers))
+	for _, server := range servers {
 		go func() {
 			response, err := timeQuery(server, ntp.QueryOptions{
 				Timeout: DefaultRPCTimeout,
@@ -83,19 +82,19 @@ func computeOffset(timeQuery ntpQuery, server string, attempts, allowedFailures 
 			offsets = append(offsets, response.Offset)
 		}
 		collected++
-		if collected == attempts {
+		if collected == len(servers) {
 			break
 		}
 	}
 	if lth := len(rpcErrors); lth > allowedFailures {
 		return 0, rpcErrors
-	} else if lth == attempts {
+	} else if lth == len(servers) {
 		return 0, rpcErrors
 	}
 	sort.SliceStable(offsets, func(i, j int) bool {
 		return offsets[i] > offsets[j]
 	})
-	mid := attempts / 2
+	mid := len(servers) / 2
 	if len(offsets)%2 == 0 {
 		return (offsets[mid-1] + offsets[mid]) / 2, nil
 	}
@@ -105,8 +104,7 @@ func computeOffset(timeQuery ntpQuery, server string, attempts, allowedFailures 
 // Default initializes time source with default config values.
 func Default() *NTPTimeSource {
 	return &NTPTimeSource{
-		server:          DefaultServer,
-		attempts:        DefaultAttempts,
+		servers:         defaultServers,
 		allowedFailures: DefaultMaxAllowedFailures,
 		updatePeriod:    DefaultUpdatePeriod,
 		timeQuery:       ntp.QueryWithOptions,
@@ -116,8 +114,7 @@ func Default() *NTPTimeSource {
 // NTPTimeSource provides source of time that tries to be resistant to time skews.
 // It does so by periodically querying time offset from ntp servers.
 type NTPTimeSource struct {
-	server          string
-	attempts        int
+	servers         []string
 	allowedFailures int
 	updatePeriod    time.Duration
 	timeQuery       ntpQuery // for ease of testing
@@ -137,7 +134,7 @@ func (s *NTPTimeSource) Now() time.Time {
 }
 
 func (s *NTPTimeSource) updateOffset() {
-	offset, err := computeOffset(s.timeQuery, s.server, s.attempts, s.allowedFailures)
+	offset, err := computeOffset(s.timeQuery, s.servers, s.allowedFailures)
 	if err != nil {
 		log.Error("failed to compute offset", "error", err)
 		return

--- a/timesource/timesource.go
+++ b/timesource/timesource.go
@@ -57,6 +57,9 @@ func (e multiRPCError) Error() string {
 }
 
 func computeOffset(timeQuery ntpQuery, servers []string, allowedFailures int) (time.Duration, error) {
+	if len(servers) == 0 {
+		return 0, nil
+	}
 	responses := make(chan queryResponse, len(servers))
 	for _, server := range servers {
 		go func(server string) {

--- a/timesource/timesource.go
+++ b/timesource/timesource.go
@@ -59,7 +59,7 @@ func (e multiRPCError) Error() string {
 func computeOffset(timeQuery ntpQuery, servers []string, allowedFailures int) (time.Duration, error) {
 	responses := make(chan queryResponse, len(servers))
 	for _, server := range servers {
-		go func() {
+		go func(server string) {
 			response, err := timeQuery(server, ntp.QueryOptions{
 				Timeout: DefaultRPCTimeout,
 			})
@@ -68,7 +68,7 @@ func computeOffset(timeQuery ntpQuery, servers []string, allowedFailures int) (t
 				return
 			}
 			responses <- queryResponse{Offset: response.ClockOffset}
-		}()
+		}(server)
 	}
 	var (
 		rpcErrors multiRPCError


### PR DESCRIPTION
This PR changes logic of NTP querying: instead of querying N(=5) times the same `pool.ntp.prg` server (which more often than not returns the same IP (see explanation here: https://github.com/status-im/status-go/issues/939#issuecomment-388951750)), we start sending 4 concurrent queries to 4 dedicated hostnames:
 - 0.pool.ntp.org
 - 1.pool.ntp.org
 - 2.pool.ntp.org
 - 3.pool.ntp.org

They still have a possibility to resolve to the same IP now and then, but the probability should be way lower.

This PR also removes the notion of `attempts` which are actually not the "attempts" per se, but the number of requests/servers involved into the time source offset update.

PS. Can't sign commits now, because my laptop is undergoing extensive 48h drying procedure after I spilled a glass of water over the keyboard :/

Closes #939 