### PR TITLE
Dump peer infos as discovery summary

### DIFF
--- a/geth/peers/README.md
+++ b/geth/peers/README.md
@@ -32,9 +32,25 @@ of peers with that capability as a value.
 ```json
 {
   "type": "discovery.summary",
-  "event": {
-    "shh/6": 1
-  }
+  "event": [
+    {
+      "id": "339c84c816b5f17a622c8d7ab9498f9998e942a274f70794af934bf5d3d02e14db8ddca2170e4edccede29ea6d409b154c141c34c01006e76c95e17672a27454",
+      "name": "peer-0/v1.0/darwin/go1.10.1",
+      "caps": [
+        "shh/6"
+      ],
+      "network": {
+        "localAddress": "127.0.0.1:61049",
+        "remoteAddress": "127.0.0.1:33732",
+        "inbound": false,
+        "trusted": false,
+        "static": true
+      },
+      "protocols": {
+        "shh": "unknown"
+      }
+    }
+  ]
 }
 ```
 
@@ -43,6 +59,6 @@ Or if we don't have any peers:
 ```json
 {
   "type": "discovery.summary",
-  "event": {}
+  "event": []
 }
 ```

--- a/geth/peers/peerpool_test.go
+++ b/geth/peers/peerpool_test.go
@@ -106,7 +106,7 @@ func (s *PeerPoolSimulationSuite) getPoolEvent(events <-chan string) string {
 
 func (s *PeerPoolSimulationSuite) TestSingleTopicDiscoveryWithFailover() {
 	poolEvents := make(chan string, 1)
-	summaries := make(chan map[string]int, 1)
+	summaries := make(chan []*p2p.PeerInfo, 1)
 	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
 		var envelope struct {
 			Type  string
@@ -120,7 +120,7 @@ func (s *PeerPoolSimulationSuite) TestSingleTopicDiscoveryWithFailover() {
 			poolEvents <- envelope.Type
 		case signal.EventDiscoverySummary:
 			poolEvents <- envelope.Type
-			var summary map[string]int
+			var summary []*p2p.PeerInfo
 			s.NoError(json.Unmarshal(envelope.Event, &summary))
 			summaries <- summary
 		}
@@ -151,8 +151,6 @@ func (s *PeerPoolSimulationSuite) TestSingleTopicDiscoveryWithFailover() {
 	s.Require().Equal(signal.EventDiscoverySummary, s.getPoolEvent(poolEvents))
 	summary := <-summaries
 	s.Len(summary, 1)
-	s.Contains(summary, "shh/6")
-	s.Equal(summary["shh/6"], 1)
 
 	register.Stop()
 	s.peers[0].Stop()
@@ -174,8 +172,6 @@ func (s *PeerPoolSimulationSuite) TestSingleTopicDiscoveryWithFailover() {
 	s.Require().Equal(signal.EventDiscoverySummary, s.getPoolEvent(poolEvents))
 	summary = <-summaries
 	s.Len(summary, 1)
-	s.Contains(summary, "shh/6")
-	s.Equal(summary["shh/6"], 1)
 }
 
 // TestPeerPoolMaxPeersOverflow verifies that following scenario will not occur:

--- a/geth/peers/signal.go
+++ b/geth/peers/signal.go
@@ -7,11 +7,5 @@ import (
 
 // SendDiscoverySummary sends discovery.summary signal.
 func SendDiscoverySummary(peers []*p2p.PeerInfo) {
-	summary := map[string]int{}
-	for i := range peers {
-		for _, cap := range peers[i].Caps {
-			summary[cap]++
-		}
-	}
-	signal.SendDiscoverySummary(summary)
+	signal.SendDiscoverySummary(peers)
 }

--- a/signal/events_discovery.go
+++ b/signal/events_discovery.go
@@ -22,6 +22,6 @@ func SendDiscoveryStopped() {
 }
 
 // SendDiscoverySummary sends discovery.summary signal.
-func SendDiscoverySummary(summary map[string]int) {
+func SendDiscoverySummary(summary interface{}) {
 	send(EventDiscoverySummary, summary)
 }


### PR DESCRIPTION
Instead of doing aggregation in status-go we will return all peer infos to the caller and let them do aggregation on their own.
The reason behind this change is that status-react needs to know enode of the connected/not-connected node. At first, i wanted to provide such list of enodes, but it just seems better to let the caller do any kind of aggregation.

Now discovery summary will have list with such info:

```json
{
  "type": "discovery.summary",
  "event": [
    {
      "id": "339c84c816b5f17a622c8d7ab9498f9998e942a274f70794af934bf5d3d02e14db8ddca2170e4edccede29ea6d409b154c141c34c01006e76c95e17672a27454",
      "name": "peer-0/v1.0/darwin/go1.10.1",
      "caps": [
        "shh/6"
      ],
      "network": {
        "localAddress": "127.0.0.1:61049",
        "remoteAddress": "127.0.0.1:33732",
        "inbound": false,
        "trusted": false,
        "static": true
      },
      "protocols": {
        "shh": "unknown"
      }
    }
  ]
}
```

cc @yenda 
