### PR TITLE
Use cache in topic pool

### DIFF
--- a/geth/peers/cache.go
+++ b/geth/peers/cache.go
@@ -15,9 +15,12 @@ func NewCache(db *leveldb.DB) *Cache {
 }
 
 // newInMemoryCache creates a cache for tests
-func newInMemoryCache() *Cache {
-	memdb, _ := leveldb.Open(storage.NewMemStorage(), nil)
-	return NewCache(memdb)
+func newInMemoryCache() (*Cache, error) {
+	memdb, err := leveldb.Open(storage.NewMemStorage(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return NewCache(memdb), nil
 }
 
 // Cache maintains list of peers that were discovered.

--- a/geth/peers/cache.go
+++ b/geth/peers/cache.go
@@ -5,12 +5,19 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/status-im/status-go/geth/db"
 	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 // NewCache returns instance of PeersDatabase
 func NewCache(db *leveldb.DB) *Cache {
 	return &Cache{db: db}
+}
+
+// newInMemoryCache creates a cache for tests
+func newInMemoryCache() *Cache {
+	memdb, _ := leveldb.Open(storage.NewMemStorage(), nil)
+	return NewCache(memdb)
 }
 
 // Cache maintains list of peers that were discovered.

--- a/geth/peers/cache.go
+++ b/geth/peers/cache.go
@@ -5,22 +5,12 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/status-im/status-go/geth/db"
 	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/storage"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 // NewCache returns instance of PeersDatabase
 func NewCache(db *leveldb.DB) *Cache {
 	return &Cache{db: db}
-}
-
-// newInMemoryCache creates a cache for tests
-func newInMemoryCache() (*Cache, error) {
-	memdb, err := leveldb.Open(storage.NewMemStorage(), nil)
-	if err != nil {
-		return nil, err
-	}
-	return NewCache(memdb), nil
 }
 
 // Cache maintains list of peers that were discovered.

--- a/geth/peers/cache_test.go
+++ b/geth/peers/cache_test.go
@@ -5,19 +5,24 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/p2p/discv5"
-	"github.com/status-im/status-go/geth/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
 )
 
-func TestPeersRange(t *testing.T) {
-	rootDB, err := db.Create("", "status-peers-test")
-	require.NoError(t, err)
-	defer func() {
-		assert.NoError(t, rootDB.Close())
-	}()
+// newInMemoryCache creates a cache for tests
+func newInMemoryCache() (*Cache, error) {
+	memdb, err := leveldb.Open(storage.NewMemStorage(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return NewCache(memdb), nil
+}
 
-	peersDB := Cache{db: rootDB}
+func TestPeersRange(t *testing.T) {
+	peersDB, err := newInMemoryCache()
+	require.NoError(t, err)
 	topic := discv5.Topic("test")
 	peers := [3]*discv5.Node{
 		discv5.NewNode(discv5.NodeID{3}, net.IPv4(100, 100, 0, 3), 32311, 32311),

--- a/geth/peers/peerpool.go
+++ b/geth/peers/peerpool.go
@@ -116,7 +116,7 @@ func (p *PeerPool) Start(server *p2p.Server) error {
 	// collect topics and start searching for nodes
 	p.topics = make([]*TopicPool, 0, len(p.config))
 	for topic, limits := range p.config {
-		topicPool := NewTopicPool(topic, limits, p.opts.SlowSync, p.opts.FastSync)
+		topicPool := NewTopicPool(topic, limits, p.opts.SlowSync, p.opts.FastSync, p.cache)
 		if err := topicPool.StartSearch(server); err != nil {
 			return err
 		}

--- a/geth/peers/peerpool_test.go
+++ b/geth/peers/peerpool_test.go
@@ -133,7 +133,9 @@ func (s *PeerPoolSimulationSuite) TestSingleTopicDiscoveryWithFailover() {
 		topic: params.NewLimits(1, 1), // limits are chosen for simplicity of the simulation
 	}
 	peerPoolOpts := &Options{100 * time.Millisecond, 100 * time.Millisecond, 0, true}
-	peerPool := NewPeerPool(config, newInMemoryCache(), peerPoolOpts)
+	cache, err := newInMemoryCache()
+	s.Require().NoError(err)
+	peerPool := NewPeerPool(config, cache, peerPoolOpts)
 	register := NewRegister(topic)
 	s.Require().NoError(register.Start(s.peers[0]))
 	// need to wait for topic to get registered, discv5 can query same node

--- a/geth/peers/topicpool_test.go
+++ b/geth/peers/topicpool_test.go
@@ -39,7 +39,7 @@ func (s *TopicPoolSuite) SetupTest() {
 	s.Require().NoError(s.peer.Start())
 	topic := discv5.Topic("cap=cap1")
 	limits := params.NewLimits(1, 2)
-	s.topicPool = NewTopicPool(topic, limits, 100*time.Millisecond, 200*time.Millisecond)
+	s.topicPool = NewTopicPool(topic, limits, 100*time.Millisecond, 200*time.Millisecond, newInMemoryCache())
 	s.topicPool.running = 1
 	// This is a buffered channel to simplify testing.
 	// If your test generates more than 10 mode changes,

--- a/geth/peers/topicpool_test.go
+++ b/geth/peers/topicpool_test.go
@@ -39,7 +39,9 @@ func (s *TopicPoolSuite) SetupTest() {
 	s.Require().NoError(s.peer.Start())
 	topic := discv5.Topic("cap=cap1")
 	limits := params.NewLimits(1, 2)
-	s.topicPool = NewTopicPool(topic, limits, 100*time.Millisecond, 200*time.Millisecond, newInMemoryCache())
+	cache, err := newInMemoryCache()
+	s.Require().NoError(err)
+	s.topicPool = NewTopicPool(topic, limits, 100*time.Millisecond, 200*time.Millisecond, cache)
 	s.topicPool.running = 1
 	// This is a buffered channel to simplify testing.
 	// If your test generates more than 10 mode changes,


### PR DESCRIPTION
It must have slipped when i moved a significant chunk of logic
from peer pool to topic pool and because of the != nil protection
this bug was missed

Related: https://github.com/status-im/status-go/issues/941