### PR TITLE
Exit when extra/errorneous flags are set

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -93,6 +93,11 @@ func main() {
 
 	flag.Usage = printUsage
 	flag.Parse()
+	if flag.NArg() > 0 {
+		stdlog.Printf("Extra args in command line: %v", flag.Args())
+		printUsage()
+		os.Exit(1)
+	}
 
 	config, err := makeNodeConfig()
 	if err != nil {


### PR DESCRIPTION
I just spent 20 mins fighting the issue with "missing IPC file", which was simply an error in a command line:`./statusd  -standalone false -ipc`. I thought it's some weird error related to recent `ipcfile` flag, but it's just a `-standalone false` flag format was incorrect. `false -ipc` was "extra args" and statusd silently ignored this and continued to run without IPC enabled.

As we don't use any extra flags anyway, I propose to fail in such a case, as it's likely to be the same issue that I've ran into.