### PR TITLE
Prometheus Exporter for statusd

### DIFF
--- a/statusd_node_exporter/.gitignore
+++ b/statusd_node_exporter/.gitignore
@@ -1,0 +1,1 @@
+statusd_node_exporter

--- a/statusd_node_exporter/README.md
+++ b/statusd_node_exporter/README.md
@@ -1,0 +1,2 @@
+
+go build && ./statusd_node_exporter -ipc ../wnode-status-data/geth.ipc -filter="whisper_*" -filter="les_*"

--- a/statusd_node_exporter/README.md
+++ b/statusd_node_exporter/README.md
@@ -1,2 +1,9 @@
+# statusd_node_exporter
 
-go build && ./statusd_node_exporter -ipc ../wnode-status-data/geth.ipc -filter="whisper_*" -filter="les_*"
+## Usage
+
+```
+cd $STATUS_GO_HOME/statusd_node_exporter && \
+go build && \
+./statusd_node_exporter -ipc ../wnode-status-data/geth.ipc -filter="whisper_*" -filter="les_*"
+```

--- a/statusd_node_exporter/README.md
+++ b/statusd_node_exporter/README.md
@@ -1,5 +1,7 @@
 # statusd_node_exporter
 
+The `statusd_node_exporter` can be use to expose metrics consumed by [Prometheus](https://github.com/prometheus/prometheus).
+
 ## Usage
 
 ```

--- a/statusd_node_exporter/client.go
+++ b/statusd_node_exporter/client.go
@@ -19,10 +19,5 @@ func newClient(ipcPath string) (*client, error) {
 
 func (c *client) metrics() (metrics, error) {
 	var res metrics
-	err := c.rpcClient.Call(&res, "debug_metrics", true)
-	if err != nil {
-		return res, err
-	}
-
-	return res, nil
+	return res, c.rpcClient.Call(&res, "debug_metrics", true)
 }

--- a/statusd_node_exporter/client.go
+++ b/statusd_node_exporter/client.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+type client struct {
+	rpcClient *rpc.Client
+}
+
+func newClient(ipcPath string) (*client, error) {
+	rpcClient, err := rpc.Dial(ipcPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{rpcClient}, nil
+}
+
+func (c *client) metrics() (metrics, error) {
+	var res metrics
+	err := c.rpcClient.Call(&res, "debug_metrics", true)
+	if err != nil {
+		return res, err
+	}
+
+	return res, nil
+}

--- a/statusd_node_exporter/collector.go
+++ b/statusd_node_exporter/collector.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type collector struct {
+	c       *client
+	filters []*regexp.Regexp
+}
+
+func compileFilters(rawFilters []string) []*regexp.Regexp {
+	var filters []*regexp.Regexp
+	for _, raw := range rawFilters {
+		s := fmt.Sprintf("^%s", raw)
+		filters = append(filters, regexp.MustCompile(s))
+	}
+
+	return filters
+}
+
+func newCollector(ipcPath string, rawFilters []string) (*collector, error) {
+	c, err := newClient(ipcPath)
+	if err != nil {
+		return nil, err
+	}
+
+	filters := compileFilters(rawFilters)
+	collector := &collector{
+		c:       c,
+		filters: filters,
+	}
+
+	return collector, nil
+}
+
+func (c *collector) collect() (string, error) {
+	m, err := c.c.metrics()
+	if err != nil {
+		return "", err
+	}
+
+	all := transformMetrics(m)
+
+	for k, _ := range all {
+		if !c.match(k) {
+			delete(all, k)
+		}
+	}
+
+	return all.String(), nil
+}
+
+func (c *collector) match(key string) bool {
+	if len(c.filters) == 0 {
+		return true
+	}
+
+	for _, filter := range c.filters {
+		if filter.MatchString(key) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/statusd_node_exporter/collector.go
+++ b/statusd_node_exporter/collector.go
@@ -44,7 +44,7 @@ func (c *collector) collect() (string, error) {
 
 	all := transformMetrics(m)
 
-	for k, _ := range all {
+	for k := range all {
 		if !c.match(k) {
 			delete(all, k)
 		}

--- a/statusd_node_exporter/handlers.go
+++ b/statusd_node_exporter/handlers.go
@@ -1,0 +1,26 @@
+package main
+
+import "net/http"
+
+func rootHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(`<html>
+			<head><title>Status Node Exporter</title></head>
+			<body>
+			<h1>Status Node Exporter</h1>
+			<p><a href="` + metricsPath + `">Metrics</a></p>
+			</body>
+			</html>`))
+}
+
+func metricsHandler(c *collector) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, err := c.collect()
+		if err != nil {
+			w.WriteHeader(http.StatusBadGateway)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		w.Write([]byte(body))
+	}
+}

--- a/statusd_node_exporter/main.go
+++ b/statusd_node_exporter/main.go
@@ -41,7 +41,7 @@ func requiredFlag(f string) {
 	usage()
 }
 
-func init() {
+func parseFlags() {
 	flag.Var(&filters, "filter", "regular expression, can be used multiple times")
 	flag.Parse()
 
@@ -56,6 +56,7 @@ func init() {
 }
 
 func main() {
+	parseFlags()
 	c, err := newCollector(*ipcPath, filters)
 	if err != nil {
 		log.Fatal(err)

--- a/statusd_node_exporter/main.go
+++ b/statusd_node_exporter/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	metricsPath = "/metrics"
+)
+
+type filtersFlag []string
+
+func (f *filtersFlag) String() string {
+	return strings.Join(*f, ", ")
+}
+
+func (f *filtersFlag) Set(v string) error {
+	*f = append(*f, v)
+	return nil
+}
+
+var (
+	filters filtersFlag
+	ipcPath = flag.String("ipc", "", "path to ipc file")
+	host    = flag.String("host", "", "http server host")
+	port    = flag.Int("port", 9200, "http server port")
+)
+
+func usage() {
+	flag.Usage()
+	os.Exit(1)
+}
+
+func requiredFlag(f string) {
+	log.Printf("flag -%s is required\n", f)
+	usage()
+}
+
+func init() {
+	flag.Var(&filters, "filter", "regular expression, can be used multiple times")
+	flag.Parse()
+
+	if *ipcPath == "" {
+		requiredFlag("ipc")
+	}
+
+	if flag.NArg() > 0 {
+		log.Printf("Extra args in command line: %v", flag.Args())
+		usage()
+	}
+}
+
+func main() {
+	c, err := newCollector(*ipcPath, filters)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	http.HandleFunc(metricsPath, metricsHandler(c))
+	http.HandleFunc("/", rootHandler)
+
+	listenAddress := fmt.Sprintf("%s:%d", *host, *port)
+
+	log.Println("Listening on", listenAddress)
+	err = http.ListenAndServe(listenAddress, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/statusd_node_exporter/metrics.go
+++ b/statusd_node_exporter/metrics.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"unicode"
+	"unicode/utf8"
+)
+
+type metrics map[string]interface{}
+
+type flatMetrics map[string]string
+
+func (fm flatMetrics) String() string {
+	var s string
+	keys := make([]string, 0)
+
+	for k, _ := range fm {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		s += fmt.Sprintf("%s %s\n", k, fm[k])
+	}
+
+	return s
+}
+
+func transformMetrics(data map[string]interface{}) flatMetrics {
+	return flattenMetrics(data, make(flatMetrics), "")
+}
+
+func flattenMetrics(data metrics, memo flatMetrics, prefix string) flatMetrics {
+	for k, v := range data {
+		key := prefix + normalizeKey(k)
+
+		switch value := v.(type) {
+		case map[string]interface{}:
+			memo = flattenMetrics(value, memo, key+"_")
+		case string:
+			memo[key] = value
+		default:
+			stringValue := fmt.Sprintf("%+v", value)
+			memo[key] = stringValue
+		}
+	}
+
+	return memo
+}
+
+func normalizeKey(s string) string {
+	r, n := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError {
+		return ""
+	}
+
+	return string(unicode.ToLower(r)) + s[n:]
+}

--- a/statusd_node_exporter/metrics.go
+++ b/statusd_node_exporter/metrics.go
@@ -15,7 +15,7 @@ func (fm flatMetrics) String() string {
 	var s string
 	keys := make([]string, 0)
 
-	for k, _ := range fm {
+	for k := range fm {
 		keys = append(keys, k)
 	}
 

--- a/statusd_node_exporter/metrics_test.go
+++ b/statusd_node_exporter/metrics_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransformMetrics(t *testing.T) {
+	rawdata := `{
+		"discv5": {
+			"InboundTraffic": {
+				"AvgRate01Min": 2.0795560694463914e-25,
+				"AvgRate05Min": 0.008658276307800729,
+				"AvgRate15Min": 55.54020873026976,
+				"MeanRate": 58.25590232351501,
+				"Overall": 233315
+			},
+			"OutboundTraffic": {
+				"AvgRate01Min": 3.5387721621595252e-25,
+				"AvgRate05Min": 0.00811869219645128,
+				"AvgRate15Min": 46.94673320076724,
+				"MeanRate": 85.21793726030589,
+				"Overall": 341298
+			}
+		},
+		"chain": {
+			"inserts": {
+				"AvgRate01Min": 0,
+				"AvgRate05Min": 0,
+				"AvgRate15Min": 0,
+				"MeanRate": 0,
+				"Overall": 0,
+				"Percentiles": {
+					"5": 0,
+					"20": 0,
+					"50": 0,
+					"80": 0,
+					"95": 0
+				}
+			}
+    }
+	}`
+
+	expected := flatMetrics{
+		"discv5_inboundTraffic_avgRate01Min":  "2.0795560694463914e-25",
+		"discv5_inboundTraffic_avgRate05Min":  "0.008658276307800729",
+		"discv5_inboundTraffic_avgRate15Min":  "55.54020873026976",
+		"discv5_inboundTraffic_meanRate":      "58.25590232351501",
+		"discv5_inboundTraffic_overall":       "233315",
+		"discv5_outboundTraffic_avgRate01Min": "3.5387721621595252e-25",
+		"discv5_outboundTraffic_avgRate05Min": "0.00811869219645128",
+		"discv5_outboundTraffic_avgRate15Min": "46.94673320076724",
+		"discv5_outboundTraffic_meanRate":     "85.21793726030589",
+		"discv5_outboundTraffic_overall":      "341298",
+		"chain_inserts_avgRate01Min":          "0",
+		"chain_inserts_avgRate05Min":          "0",
+		"chain_inserts_avgRate15Min":          "0",
+		"chain_inserts_meanRate":              "0",
+		"chain_inserts_overall":               "0",
+		"chain_inserts_percentiles_5":         "0",
+		"chain_inserts_percentiles_20":        "0",
+		"chain_inserts_percentiles_50":        "0",
+		"chain_inserts_percentiles_80":        "0",
+		"chain_inserts_percentiles_95":        "0",
+	}
+
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(rawdata), &data)
+	require.Nil(t, err)
+
+	m := transformMetrics(data)
+	require.Equal(t, expected, m)
+}
+
+func TestNormalizeKey(t *testing.T) {
+	scenarios := [][2]string{
+		{"", ""},
+		{"foo", "foo"},
+		{"Foo", "foo"},
+		{"FooBar", "fooBar"},
+	}
+
+	for i, s := range scenarios {
+		t.Run(fmt.Sprintf("Scenario %d", i+1), func(t *testing.T) {
+			require.Equal(t, s[1], normalizeKey(s[0]))
+		})
+	}
+}


### PR DESCRIPTION
**CODE MOVED TO A NEW REPO:** https://github.com/status-im/geth_exporter

With PR #963 we change the way we collect metrics switching from the Prometheus client to the `go-ethereum/metrics` package.

This PR adds a self-contained  executable that collects metrics from `statusd` via `IPC` and exposes them via `HTTP` with a format recognised by Prometheus.

Closes #956 
