### PR TITLE
Rollback mailserver DataDir to previous leveldb data directory

### DIFF
--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -19,7 +19,6 @@ package mailserver
 import (
 	"encoding/binary"
 	"fmt"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -74,12 +73,11 @@ func (s *WMailServer) Init(shh *whisper.Whisper, config *params.WhisperConfig) e
 		return fmt.Errorf("data directory not provided")
 	}
 
-	path := filepath.Join(config.DataDir, "mailserver", "data")
 	if len(config.Password) == 0 {
 		return fmt.Errorf("password is not specified")
 	}
 
-	s.db, err = leveldb.OpenFile(path, nil)
+	s.db, err = leveldb.OpenFile(config.DataDir, nil)
 	if err != nil {
 		return fmt.Errorf("open DB: %s", err)
 	}


### PR DESCRIPTION
In order to keep compatibility with old mail servers we're recovering old `WhisperConfig.DataDir` as base folder for all leveldb storage.