### PR TITLE
Heap queue stores only peers that were not added to p2p server

### DIFF
--- a/geth/peers/topicpool_test.go
+++ b/geth/peers/topicpool_test.go
@@ -131,21 +131,22 @@ func (s *TopicPoolSuite) TestNewPeerSelectedOnDrop() {
 	s.topicPool.processFoundNode(s.peer, peer2)
 	s.topicPool.processFoundNode(s.peer, peer3)
 	s.Len(s.topicPool.peerPool, 3)
-	s.Len(s.topicPool.peerPoolQueue, 3)
+	s.Len(s.topicPool.peerPoolQueue, 0)
 	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer1.ID))
 	s.Contains(s.topicPool.connectedPeers, peer1.ID)
 	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer2.ID))
 	s.Contains(s.topicPool.connectedPeers, peer2.ID)
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer3.ID))
+	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer3.ID))
+	s.Contains(s.topicPool.peerPool, peer3.ID)
 	s.Len(s.topicPool.peerPool, 1)
 	s.Len(s.topicPool.peerPoolQueue, 1)
-
 	// drop peer1
 	s.True(s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer1.ID)))
 	s.NotContains(s.topicPool.connectedPeers, peer1.ID)
-
 	// add peer from the pool
 	s.Equal(peer3.ID, s.topicPool.AddPeerFromTable(s.peer).ID)
-	s.Len(s.topicPool.peerPool, 0)
+	s.Len(s.topicPool.peerPool, 1)
 	s.Len(s.topicPool.peerPoolQueue, 0)
 }
 
@@ -160,7 +161,7 @@ func (s *TopicPoolSuite) TestRequestedDoesntRemove() {
 	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer1.ID))
 	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer2.ID))
 	s.False(s.topicPool.connectedPeers[peer1.ID].dismissed)
-	s.True(s.topicPool.peerPool[peer2.ID].dismissed)
+	s.True(s.topicPool.connectedPeers[peer2.ID].dismissed)
 	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer2.ID))
 	s.Contains(s.topicPool.peerPool, peer2.ID)
 	s.NotContains(s.topicPool.connectedPeers, peer2.ID)
@@ -182,10 +183,63 @@ func (s *TopicPoolSuite) TestTheMostRecentPeerIsSelected() {
 	s.topicPool.processFoundNode(s.peer, peer2)
 	s.topicPool.processFoundNode(s.peer, peer3)
 	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer1.ID))
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer2.ID))
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer3.ID))
 
+	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer2.ID))
+	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer3.ID))
 	// peer1 has dropped
 	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer1.ID))
 	// and peer3 is take from the pool as the most recent
 	s.True(s.topicPool.peerPool[peer2.ID].discoveredTime < s.topicPool.peerPool[peer3.ID].discoveredTime)
 	s.Equal(peer3.ID, s.topicPool.AddPeerFromTable(s.peer).ID)
+}
+
+func (s *TopicPoolSuite) TestSelectPeerAfterMaxLimit() {
+	s.topicPool.limits = params.NewLimits(1, 1)
+
+	peer1 := discv5.NewNode(discv5.NodeID{1}, s.peer.Self().IP, 32311, 32311)
+	peer2 := discv5.NewNode(discv5.NodeID{2}, s.peer.Self().IP, 32311, 32311)
+	peer3 := discv5.NewNode(discv5.NodeID{3}, s.peer.Self().IP, 32311, 32311)
+
+	s.topicPool.processFoundNode(s.peer, peer1)
+	s.topicPool.processFoundNode(s.peer, peer2)
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer1.ID))
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer2.ID))
+	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer2.ID))
+	s.Len(s.topicPool.peerPool, 1)
+	s.Contains(s.topicPool.peerPool, peer2.ID)
+	s.topicPool.processFoundNode(s.peer, peer3)
+	s.Len(s.topicPool.peerPool, 2)
+	s.Contains(s.topicPool.peerPool, peer3.ID)
+	s.Equal(peer3, s.topicPool.AddPeerFromTable(s.peer))
+}
+
+func (s *TopicPoolSuite) TestReplacementPeerIsCounted() {
+	s.topicPool.limits = params.NewLimits(1, 1)
+
+	peer1 := discv5.NewNode(discv5.NodeID{1}, s.peer.Self().IP, 32311, 32311)
+	peer2 := discv5.NewNode(discv5.NodeID{2}, s.peer.Self().IP, 32311, 32311)
+	s.topicPool.processFoundNode(s.peer, peer1)
+	s.topicPool.processFoundNode(s.peer, peer2)
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer1.ID))
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer2.ID))
+	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer2.ID))
+	s.topicPool.ConfirmDropped(s.peer, discover.NodeID(peer1.ID))
+
+	s.Contains(s.topicPool.peerPool, peer2.ID)
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer2.ID))
+	s.True(s.topicPool.MaxReached())
+}
+
+func (s *TopicPoolSuite) TestPeerDontAddTwice() {
+	s.topicPool.limits = params.NewLimits(1, 1)
+
+	peer1 := discv5.NewNode(discv5.NodeID{1}, s.peer.Self().IP, 32311, 32311)
+	peer2 := discv5.NewNode(discv5.NodeID{2}, s.peer.Self().IP, 32311, 32311)
+	s.topicPool.processFoundNode(s.peer, peer1)
+	s.topicPool.processFoundNode(s.peer, peer2)
+	s.topicPool.ConfirmAdded(s.peer, discover.NodeID(peer1.ID))
+	// peer2 already added to p2p server no reason to add it again
+	s.Nil(s.topicPool.AddPeerFromTable(s.peer))
 }


### PR DESCRIPTION
The primary goal of this change is to keep a whitelist of peers
that are managed by the topic pool while also preventing the same peer
from being selected from heap queue multiple times.

Closes: https://github.com/status-im/status-go/issues/973