### PR TITLE
Disable inbound connections on mobiles

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -407,6 +407,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ae9e87f81c4bfcd1c190314d52248c8851a58936c149947a9e1bbad8b53a542c"
+  inputs-digest = "fc723df39f24964e9f751f6aaea07e592d31b2f0e53b244b4efb3f6bc4446e2a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/_assets/patches/geth/0031-limit-inbound-connections.patch
+++ b/_assets/patches/geth/0031-limit-inbound-connections.patch
@@ -1,0 +1,26 @@
+diff --git c/p2p/server.go w/p2p/server.go
+index 04c6f7147..694562c5a 100644
+--- c/p2p/server.go
++++ w/p2p/server.go
+@@ -72,6 +72,12 @@ type Config struct {
+ 	// Setting DialRatio to zero defaults it to 3.
+ 	DialRatio int `toml:",omitempty"`
+ 
++	// InboundPercent controls percent of inbound connections in group
++	// Since we don't use dialing we have to introduce another config
++	// for limiting inbound connections.
++	// inboundConns = (maxpeers * inbound percent) / 100
++	InboundPercent int
++
+ 	// NoDiscovery can be used to disable the peer discovery mechanism.
+ 	// Disabling is useful for protocol debugging (manual topology).
+ 	NoDiscovery bool
+@@ -717,7 +723,7 @@ func (srv *Server) encHandshakeChecks(peers map[discover.NodeID]*Peer, inboundCo
+ }
+ 
+ func (srv *Server) maxInboundConns() int {
+-	return srv.MaxPeers - srv.maxDialedConns()
++	return (srv.MaxPeers * srv.InboundPercent) / 100
+ }
+ 
+ func (srv *Server) maxDialedConns() int {

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -39,6 +39,7 @@ var (
 	statusService     = flag.String("status", "", `Enable StatusService, possible values: "ipc", "http"`)
 	swarmEnabled      = flag.Bool("swarm", false, "Enable Swarm protocol")
 	maxPeers          = flag.Int("maxpeers", 25, "maximum number of p2p peers (including all protocols)")
+	inboundPercent    = flag.Int("inbound", 70, "percent of inbound connections")
 	httpEnabled       = flag.Bool("http", false, "Enable HTTP RPC endpoint")
 	httpHost          = flag.String("httphost", "127.0.0.1", "HTTP RPC host of the listening socket")
 	httpPort          = flag.Int("httpport", params.HTTPPort, "HTTP RPC server's listening port")
@@ -215,6 +216,7 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	nodeConfig.RPCEnabled = *httpEnabled
 	nodeConfig.WhisperConfig.Enabled = *whisperEnabled
 	nodeConfig.MaxPeers = *maxPeers
+	nodeConfig.InboundPercent = *inboundPercent
 
 	nodeConfig.HTTPHost = *httpHost
 	nodeConfig.HTTPPort = *httpPort

--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
-	"github.com/ethereum/go-ethereum/p2p/nat"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/mailserver"
@@ -118,8 +117,8 @@ func defaultEmbeddedNodeConfig(config *params.NodeConfig) *node.Config {
 			NoDiscovery:     true, // we always use only v5 server
 			DiscoveryV5:     !config.NoDiscovery,
 			ListenAddr:      config.ListenAddr,
-			NAT:             nat.Any(),
 			MaxPeers:        config.MaxPeers,
+			InboundPercent:  config.InboundPercent,
 			MaxPendingPeers: config.MaxPendingPeers,
 		},
 		IPCPath:          makeIPCPath(config),

--- a/geth/node/node_test.go
+++ b/geth/node/node_test.go
@@ -1,0 +1,96 @@
+package node
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInboundConnections(t *testing.T) {
+	type testCase struct {
+		name    string
+		max     int
+		percent int
+	}
+
+	for _, tc := range []testCase{
+		{
+			name:    "All",
+			max:     4,
+			percent: 100,
+		},
+		{
+			name:    "Half",
+			max:     4,
+			percent: 50,
+		},
+		{
+			name:    "FloorDivision",
+			max:     4,
+			percent: 70,
+		},
+		{
+			name:    "None",
+			max:     4,
+			percent: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key, _ := crypto.GenerateKey()
+			main := p2p.Server{
+				Config: p2p.Config{
+					NoDiscovery:    true,
+					PrivateKey:     key,
+					InboundPercent: tc.percent,
+					MaxPeers:       tc.max,
+					ListenAddr:     "127.0.0.1:0",
+				},
+			}
+			require.NoError(t, main.Start())
+			defer main.Stop()
+
+			rst := make(chan *p2p.PeerEvent, main.Config.MaxPeers)
+			sub := main.SubscribeEvents(rst)
+			defer sub.Unsubscribe()
+
+			peers := make([]*p2p.Server, 0, main.Config.MaxPeers)
+			for i := 0; i < main.Config.MaxPeers; i++ {
+				key, _ := crypto.GenerateKey()
+				peer := &p2p.Server{
+					Config: p2p.Config{
+						NoDiscovery: true,
+						PrivateKey:  key,
+						MaxPeers:    1,
+						ListenAddr:  "127.0.0.1:0",
+					},
+				}
+				assert.NoError(t, peer.Start())
+				peers = append(peers, peer)
+				peer.AddPeer(main.Self())
+			}
+			defer func() {
+				for i := range peers {
+					peers[i].Stop()
+				}
+			}()
+
+			expected := (main.Config.MaxPeers * main.Config.InboundPercent) / 100
+			connections := 0
+			for {
+				select {
+				case ev := <-rst:
+					if ev.Type == p2p.PeerEventTypeAdd {
+						connections++
+					}
+				case <-time.After(500 * time.Millisecond):
+					require.Equal(t, expected, connections)
+					return
+				}
+			}
+		})
+	}
+}

--- a/geth/node/node_test.go
+++ b/geth/node/node_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +15,6 @@ func TestInboundConnections(t *testing.T) {
 		max     int
 		percent int
 	}
-
 	for _, tc := range []testCase{
 		{
 			name:    "All",
@@ -40,6 +38,7 @@ func TestInboundConnections(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			key, _ := crypto.GenerateKey()
 			main := p2p.Server{
 				Config: p2p.Config{
@@ -68,7 +67,7 @@ func TestInboundConnections(t *testing.T) {
 						ListenAddr:  "127.0.0.1:0",
 					},
 				}
-				assert.NoError(t, peer.Start())
+				require.NoError(t, peer.Start())
 				peers = append(peers, peer)
 				peer.AddPeer(main.Self())
 			}

--- a/geth/node/status_node_test.go
+++ b/geth/node/status_node_test.go
@@ -159,9 +159,10 @@ func TestStatusNodeAddPeer(t *testing.T) {
 
 	peer, err := gethnode.New(&gethnode.Config{
 		P2P: p2p.Config{
-			MaxPeers:    math.MaxInt32,
-			NoDiscovery: true,
-			ListenAddr:  ":0",
+			MaxPeers:       math.MaxInt32,
+			NoDiscovery:    true,
+			ListenAddr:     ":0",
+			InboundPercent: 50,
 		},
 	})
 	require.NoError(t, err)
@@ -194,9 +195,10 @@ func TestStatusNodeReconnectStaticPeers(t *testing.T) {
 
 	peer, err := gethnode.New(&gethnode.Config{
 		P2P: p2p.Config{
-			MaxPeers:    math.MaxInt32,
-			NoDiscovery: true,
-			ListenAddr:  ":0",
+			MaxPeers:       math.MaxInt32,
+			NoDiscovery:    true,
+			ListenAddr:     ":0",
+			InboundPercent: 50,
 		},
 	})
 	require.NoError(t, err)

--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -277,6 +277,12 @@ type NodeConfig struct {
 	// handshake phase, counted separately for inbound and outbound connections.
 	MaxPendingPeers int
 
+	// InboundPercent controls percent of inbound connections in group
+	// Since we don't use dialing we have to introduce another config
+	// for limiting inbound connections.
+	// inboundConns = (maxpeers * inbound percent) / 100
+	InboundPercent int
+
 	log log.Logger
 
 	// LogEnabled enables the logger
@@ -331,6 +337,7 @@ func NewNodeConfig(dataDir string, clstrCfgFile string, networkID uint64) (*Node
 		APIModules:        APIModules,
 		MaxPeers:          MaxPeers,
 		MaxPendingPeers:   MaxPendingPeers,
+		InboundPercent:    InboundPercent,
 		IPCFile:           IPCFile,
 		log:               log.New("package", "status-go/geth/params.NodeConfig"),
 		LogFile:           LogFile,

--- a/geth/params/defaults.go
+++ b/geth/params/defaults.go
@@ -50,6 +50,9 @@ const (
 	// MaxPeers is the maximum number of global peers
 	MaxPeers = 25
 
+	// InboundPercent of 0 will disable inbound connections.
+	InboundPercent = 0
+
 	// MaxPendingPeers is the maximum number of peers that can be pending in the
 	// handshake phase, counted separately for inbound and outbound connections.
 	MaxPendingPeers = 0

--- a/geth/peers/peerpool_test.go
+++ b/geth/peers/peerpool_test.go
@@ -69,6 +69,7 @@ func (s *PeerPoolSimulationSuite) SetupTest() {
 		peer := &p2p.Server{
 			Config: p2p.Config{
 				MaxPeers:         10,
+				InboundPercent:   50,
 				Name:             common.MakeName("peer-"+strconv.Itoa(i), "1.0"),
 				ListenAddr:       fmt.Sprintf("0.0.0.0:%d", s.nextPort()),
 				PrivateKey:       key,

--- a/vendor/github.com/ethereum/go-ethereum/p2p/server.go
+++ b/vendor/github.com/ethereum/go-ethereum/p2p/server.go
@@ -72,6 +72,12 @@ type Config struct {
 	// Setting DialRatio to zero defaults it to 3.
 	DialRatio int `toml:",omitempty"`
 
+	// InboundPercent controls percent of inbound connections in group
+	// Since we don't use dialing we have to introduce another config
+	// for limiting inbound connections.
+	// inboundConns = (maxpeers * inbound percent) / 100
+	InboundPercent int
+
 	// NoDiscovery can be used to disable the peer discovery mechanism.
 	// Disabling is useful for protocol debugging (manual topology).
 	NoDiscovery bool
@@ -717,7 +723,7 @@ func (srv *Server) encHandshakeChecks(peers map[discover.NodeID]*Peer, inboundCo
 }
 
 func (srv *Server) maxInboundConns() int {
-	return srv.MaxPeers - srv.maxDialedConns()
+	return (srv.MaxPeers * srv.InboundPercent) / 100
 }
 
 func (srv *Server) maxDialedConns() int {


### PR DESCRIPTION
Since we are not using p2p server v4 discovery and dialing i had to add another control option to p2p config

Closes: https://github.com/status-im/status-go/issues/978