### PR TITLE
Flaky test TestPeerPoolSimulationSuite/TestSingleTopicDiscoveryWithFailover

### DIFF
--- a/geth/peers/peerpool_test.go
+++ b/geth/peers/peerpool_test.go
@@ -166,13 +166,13 @@ func (s *PeerPoolSimulationSuite) TestSingleTopicDiscoveryWithFailover() {
 
 	s.Equal(signal.EventDiscoveryStarted, s.getPoolEvent(poolEvents))
 	s.Require().NotNil(s.peers[1].DiscV5)
-	register = NewRegister(topic)
 	s.Require().NoError(register.Start(s.peers[2]))
 	defer register.Stop()
 	s.Equal(s.peers[2].Self().ID, s.getPeerFromEvent(events, p2p.PeerEventTypeAdd))
 
 	s.Equal(signal.EventDiscoveryStopped, s.getPoolEvent(poolEvents))
 	s.Require().Equal(signal.EventDiscoverySummary, s.getPoolEvent(poolEvents))
+
 	summary = <-summaries
 	s.Len(summary, 1)
 


### PR DESCRIPTION
A recurrent error on travis builds is breaking builds since last week, its output looks like:

```
--- FAIL: TestPeerPoolSimulationSuite (6.15s)
    --- FAIL: TestPeerPoolSimulationSuite/TestSingleTopicDiscoveryWithFailover (6.14s)
    Error Trace:    peerpool_test.go:91
            peerpool_test.go:172
    Error:          timed out waiting for a peer
    Error Trace:    peerpool_test.go:172
    Error:          Not equal: 
                    expected: discover.HexID("c5b900c95400f00da70dfddb0f780d97fed82abb7a736151c7c07eb130c9affd47c98e9a9f85f5734bc6bc592371f91af9577230f8b9d421e0094247190a67fe")
                    actual: discover.HexID("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
                    
                    Diff:
                    --- Expected
                    +++ Actual
                    @@ -1,2 +1,2 @@
                    -(discover.NodeID) (len=64) c5b900c95400f00da70dfddb0f780d97fed82abb7a736151c7c07eb130c9affd47c98e9a9f85f5734bc6bc592371f91af9577230f8b9d421e0094247190a67fe
                    +(discover.NodeID) (len=64) 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
                     
    Error Trace:    peerpool_test.go:102
            peerpool_test.go:174
    Error:          timed out waiting for a peer
```

Closes #983
