### PR TITLE
Allow overriding BootNodes

### DIFF
--- a/geth/params/config.go
+++ b/geth/params/config.go
@@ -582,7 +582,9 @@ func (c *NodeConfig) updateClusterConfig() error {
 
 	for _, cluster := range clusters {
 		if cluster.NetworkID == int(c.NetworkID) {
-			c.ClusterConfig.BootNodes = cluster.BootNodes
+			if len(c.ClusterConfig.BootNodes) == 0 {
+				c.ClusterConfig.BootNodes = cluster.BootNodes
+			}
 			c.ClusterConfig.StaticNodes = cluster.StaticNodes
 			// no point in running discovery if we don't have bootnodes.
 			// but in case if we do have nodes and NoDiscovery=true we will preserve that value

--- a/geth/params/config_test.go
+++ b/geth/params/config_test.go
@@ -240,6 +240,24 @@ var loadConfigTestCases = []struct {
 		},
 	},
 	{
+		`custom boot nodes`,
+		`{
+			"NetworkId": 3,
+			"DataDir": "$TMPDIR",
+                        "ClusterConfig": {
+                          "BootNodes": ["a", "b", "c"]
+                        }
+		}`,
+		func(t *testing.T, dataDir string, nodeConfig *params.NodeConfig, err error) {
+			require.NoError(t, err)
+
+			enodes := nodeConfig.ClusterConfig.BootNodes
+			expectedEnodes := []string{"a", "b", "c"}
+
+			require.Equal(t, enodes, expectedEnodes)
+		},
+	},
+	{
 		`illegal cluster configuration file`,
 		`{
 			"NetworkId": 3,


### PR DESCRIPTION
We need to allow the user to specify custom BootNodes, to address https://github.com/status-im/status-react/issues/4264 . 

The code has been changed so that it will use the provided ones if passed through config (`CusterConfig.BootNodes`) and is not empty. 

Otherwise fallback on default ones.


Important changes:

I have made it so that it will use the default ones if the user passes an empty array, not sure if that is something we want to support.
