### PR TITLE
Tolerate only one error during ntp sync

### DIFF
--- a/timesource/timesource.go
+++ b/timesource/timesource.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultMaxAllowedFailures defines how many failures will be tolerated.
-	DefaultMaxAllowedFailures = 2
+	DefaultMaxAllowedFailures = 1
 
 	// FastNTPSyncPeriod period between ntp synchronizations before the first
 	// successful connection.


### PR DESCRIPTION
Previously we were doing 5 concurrent requests, thus it was
safe to tolerate 2 errors. With 4 it doesn't make sense to use
only 2 responses, because even if 1 of them is skewed - we will set
incorrect time.