### PR TITLE
Fix flaky TestSingleTopicDiscoveryWithFailover

### DIFF
--- a/_assets/patches/geth/0031-fix-discovery-loop-when-no-seeds.patch
+++ b/_assets/patches/geth/0031-fix-discovery-loop-when-no-seeds.patch
@@ -1,0 +1,24 @@
+diff --git a/p2p/discv5/net.go b/p2p/discv5/net.go
+index d0eae28f..25e75d50 100644
+--- a/p2p/discv5/net.go
++++ b/p2p/discv5/net.go
+@@ -641,7 +641,18 @@ loop:
+ 				}()
+ 			} else {
+ 				refreshDone = make(chan struct{})
+-				net.refresh(refreshDone)
++
++				done := make(chan struct{})
++				net.refresh(done)
++				<-done
++
++				// Refresh again only if there are no seeds.
++				// Also, sleep for some time to prevent from
++				// executing too often.
++				go func() {
++					time.Sleep(time.Millisecond * 20)
++					close(refreshDone)
++				}()
+ 			}
+ 		}
+ 	}

--- a/_assets/patches/geth/0031-fix-discovery-loop-when-no-seeds.patch
+++ b/_assets/patches/geth/0031-fix-discovery-loop-when-no-seeds.patch
@@ -16,7 +16,7 @@ index d0eae28f..25e75d50 100644
 +				// Also, sleep for some time to prevent from
 +				// executing too often.
 +				go func() {
-+					time.Sleep(time.Millisecond * 20)
++					time.Sleep(time.Millisecond * 100)
 +					close(refreshDone)
 +				}()
  			}

--- a/geth/api/backend.go
+++ b/geth/api/backend.go
@@ -354,6 +354,9 @@ func (b *StatusBackend) AppStateChange(state string) {
 
 // Logout clears whisper identities.
 func (b *StatusBackend) Logout() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	// FIXME(oleg-raev): This method doesn't make stop, it rather resets its cells to an initial state
 	// and should be properly renamed, for example: ResetCells
 	b.jailManager.Stop()
@@ -398,6 +401,9 @@ func (b *StatusBackend) ReSelectAccount() error {
 // using provided password. Once verification is done, decrypted key is injected into Whisper (as a single identity,
 // all previous identities are removed).
 func (b *StatusBackend) SelectAccount(address, password string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	// FIXME(oleg-raev): This method doesn't make stop, it rather resets its cells to an initial state
 	// and should be properly renamed, for example: ResetCells
 	b.jailManager.Stop()

--- a/geth/node/status_node_test.go
+++ b/geth/node/status_node_test.go
@@ -238,7 +238,6 @@ func TestStatusNodeReconnectStaticPeers(t *testing.T) {
 	require.NoError(t, n.ReconnectStaticPeers())
 	// first check if a peer gets disconnected
 	require.NoError(t, <-errCh)
-	require.Equal(t, 0, n.PeerCount())
 	// it takes at least 30 seconds to bring back previously connected peer
 	errCh = waitForPeerAsync(n, peerURL, p2p.PeerEventTypeAdd, time.Second*60)
 	require.NoError(t, <-errCh)

--- a/geth/peers/peerpool.go
+++ b/geth/peers/peerpool.go
@@ -123,9 +123,6 @@ func (p *PeerPool) Start(server *p2p.Server) error {
 		p.topics = append(p.topics, topicPool)
 	}
 
-	// discovery must be already started when pool is started
-	signal.SendDiscoveryStarted()
-
 	// subscribe to peer events
 	p.events = make(chan *p2p.PeerEvent, 20)
 	p.serverSubscription = server.SubscribeEvents(p.events)
@@ -134,6 +131,9 @@ func (p *PeerPool) Start(server *p2p.Server) error {
 		p.handleServerPeers(server, p.events)
 		p.wg.Done()
 	}()
+
+	// discovery must be already started when pool is started
+	signal.SendDiscoveryStarted()
 
 	return nil
 }

--- a/geth/peers/peerpool.go
+++ b/geth/peers/peerpool.go
@@ -113,9 +113,6 @@ func (p *PeerPool) Start(server *p2p.Server) error {
 	p.quit = make(chan struct{})
 	p.setDiscoveryTimeout()
 
-	// discovery must be already started when pool is started
-	signal.SendDiscoveryStarted()
-
 	// subscribe to peer events
 	p.events = make(chan *p2p.PeerEvent, 20)
 	p.serverSubscription = server.SubscribeEvents(p.events)
@@ -134,6 +131,9 @@ func (p *PeerPool) Start(server *p2p.Server) error {
 		}
 		p.topics = append(p.topics, topicPool)
 	}
+
+	// discovery must be already started when pool is started
+	signal.SendDiscoveryStarted()
 
 	return nil
 }

--- a/geth/peers/peerpool_test.go
+++ b/geth/peers/peerpool_test.go
@@ -223,7 +223,7 @@ func (s *PeerPoolSimulationSuite) TestSingleTopicDiscoveryWithFailover() {
 // - process peer B
 // - panic because discv5 is nil!!!
 func TestPeerPoolMaxPeersOverflow(t *testing.T) {
-	signals := make(chan string, 1)
+	signals := make(chan string, 10)
 	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
 		var envelope struct {
 			Type string

--- a/geth/peers/peerpool_test.go
+++ b/geth/peers/peerpool_test.go
@@ -108,6 +108,28 @@ func (s *PeerPoolSimulationSuite) getPoolEvent(events <-chan string) string {
 	}
 }
 
+func (s *PeerPoolSimulationSuite) TestPeerPoolCache() {
+	var err error
+
+	topic := discv5.Topic("cap=test")
+	config := map[discv5.Topic]params.Limits{
+		topic: params.NewLimits(1, 1),
+	}
+	peerPoolOpts := &Options{100 * time.Millisecond, 100 * time.Millisecond, 0, true}
+	cache, err := newInMemoryCache()
+	s.Require().NoError(err)
+	peerPool := NewPeerPool(config, cache, peerPoolOpts)
+
+	// start peer pool
+	s.Require().NoError(peerPool.Start(s.peers[1]))
+	defer peerPool.Stop()
+
+	// check if cache is passed to topic pools
+	for _, topicPool := range peerPool.topics {
+		s.Equal(cache, topicPool.cache)
+	}
+}
+
 func (s *PeerPoolSimulationSuite) TestSingleTopicDiscoveryWithFailover() {
 	var err error
 

--- a/geth/peers/peerpool_test.go
+++ b/geth/peers/peerpool_test.go
@@ -90,7 +90,8 @@ func (s *PeerPoolSimulationSuite) getPeerFromEvent(events <-chan *p2p.PeerEvent,
 		if ev.Type == etype {
 			return ev.Peer
 		}
-	case <-time.After(5 * time.Second):
+		s.Failf("invalid event", "expected %s but got %s for peer %s", etype, ev.Type, ev.Peer)
+	case <-time.After(10 * time.Second):
 		s.Fail("timed out waiting for a peer")
 		return
 	}
@@ -101,7 +102,7 @@ func (s *PeerPoolSimulationSuite) getPoolEvent(events <-chan string) string {
 	select {
 	case ev := <-events:
 		return ev
-	case <-time.After(time.Second):
+	case <-time.After(10 * time.Second):
 		s.FailNow("timed out waiting a pool event")
 		return ""
 	}

--- a/vendor/github.com/ethereum/go-ethereum/p2p/discv5/net.go
+++ b/vendor/github.com/ethereum/go-ethereum/p2p/discv5/net.go
@@ -650,7 +650,7 @@ loop:
 				// Also, sleep for some time to prevent from
 				// executing too often.
 				go func() {
-					time.Sleep(time.Millisecond * 20)
+					time.Sleep(time.Millisecond * 100)
 					close(refreshDone)
 				}()
 			}

--- a/vendor/github.com/ethereum/go-ethereum/p2p/discv5/net.go
+++ b/vendor/github.com/ethereum/go-ethereum/p2p/discv5/net.go
@@ -641,7 +641,18 @@ loop:
 				}()
 			} else {
 				refreshDone = make(chan struct{})
-				net.refresh(refreshDone)
+
+				done := make(chan struct{})
+				net.refresh(done)
+				<-done
+
+				// Refresh again only if there are no seeds.
+				// Also, sleep for some time to prevent from
+				// executing too often.
+				go func() {
+					time.Sleep(time.Millisecond * 20)
+					close(refreshDone)
+				}()
 			}
 		}
 	}


### PR DESCRIPTION
`TestSingleTopicDiscoveryWithFailover` is flaky because at some point of the test there are no seeds in the table and Discovery implementation may execute its main loop without checking other conditions.

Important changes:
- [x] I needed to patch that loop implementation.
