### PR TITLE
Remove shh and shhext from APIModules

### DIFF
--- a/geth/params/defaults.go
+++ b/geth/params/defaults.go
@@ -31,9 +31,9 @@ const (
 	// ListenAddr is an IP address and port of this node (e.g. 127.0.0.1:30303).
 	ListenAddr = ":0"
 
-	// APIModules is a list of modules to expose via any type of RPC (HTTP, IPC, in-proc)
-	// we also expose 2 limited personal APIs by overriding them in `api/backend.go`
-	APIModules = "eth,net,web3,shh,shhext"
+	// APIModules is a list of modules to expose via HTTP and `CallRPC()` binding.
+	// We also expose all handlers registered with `rpc.Client.RegisterHandler` to `CallRPC()` binding.
+	APIModules = "eth,net,web3"
 
 	// SendTransactionMethodName defines the name for a giving transaction.
 	SendTransactionMethodName = "eth_sendTransaction"

--- a/t/e2e/rpc/rpc_test.go
+++ b/t/e2e/rpc/rpc_test.go
@@ -40,7 +40,8 @@ func (s *RPCTestSuite) TestCallRPC() {
 		s.NoError(err)
 
 		nodeConfig.IPCEnabled = false
-		nodeConfig.HTTPHost = "" // to make sure that no HTTP interface is started
+		nodeConfig.HTTPHost = ""        // to make sure that no HTTP interface is started
+		nodeConfig.APIModules += ",shh" // shh_version normally wouldn't be callable with RPCClient
 
 		if upstreamEnabled {
 			networkURL, err := GetRemoteURL()
@@ -130,7 +131,7 @@ func (s *RPCTestSuite) TestCallRawResult() {
 
 	s.NoError(s.StatusNode.Start(nodeConfig))
 
-	client := s.StatusNode.RPCClient()
+	client := s.StatusNode.RPCPrivateClient()
 	s.NotNil(client)
 
 	jsonResult := client.CallRaw(`{"jsonrpc":"2.0","method":"shh_version","params":[],"id":67}`)

--- a/t/e2e/whisper/mailservice_test.go
+++ b/t/e2e/whisper/mailservice_test.go
@@ -31,6 +31,7 @@ func (s *MailServiceSuite) TestShhextRequestMessagesRPCMethodAvailability() {
 
 	s.StartTestNode(func(config *params.NodeConfig) {
 		config.RPCEnabled = true
+		config.APIModules = "shhext"
 	})
 	defer s.StopTestNode()
 

--- a/t/e2e/whisper/whisper_ext_test.go
+++ b/t/e2e/whisper/whisper_ext_test.go
@@ -62,7 +62,7 @@ func (s *WhisperExtensionSuite) TestSentSignal() {
 		}
 	})
 	defer signal.ResetDefaultNodeNotificationHandler()
-	client := s.nodes[0].RPCClient()
+	client := s.nodes[0].RPCPrivateClient()
 	s.NotNil(client)
 	var symID string
 	s.NoError(client.Call(&symID, "shh_newSymKey"))
@@ -102,7 +102,7 @@ func (s *WhisperExtensionSuite) TestExpiredSignal() {
 		}
 	})
 	defer signal.ResetDefaultNodeNotificationHandler()
-	client := s.nodes[0].RPCClient()
+	client := s.nodes[0].RPCPrivateClient()
 	s.NotNil(client)
 	var symID string
 	s.NoError(client.Call(&symID, "shh_newSymKey"))

--- a/t/e2e/whisper/whisper_jail_test.go
+++ b/t/e2e/whisper/whisper_jail_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/status-im/status-go/geth/jail"
+	"github.com/status-im/status-go/geth/params"
 	"github.com/status-im/status-go/static"
 	"github.com/status-im/status-go/t/e2e"
 	. "github.com/status-im/status-go/t/utils"
@@ -60,7 +61,9 @@ func (s *WhisperJailTestSuite) AddKeyPair(address, password string) (string, err
 }
 
 func (s *WhisperJailTestSuite) TestJailWhisper() {
-	s.StartTestBackend()
+	s.StartTestBackend(func(config *params.NodeConfig) {
+		config.APIModules = "shh"
+	})
 	defer s.StopTestBackend()
 
 	r := s.Require()

--- a/t/e2e/whisper/whisper_mailbox_test.go
+++ b/t/e2e/whisper/whisper_mailbox_test.go
@@ -64,7 +64,7 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 	MailServerKeyID, err := senderWhisperService.AddSymKeyFromPassword(password)
 	s.Require().NoError(err)
 
-	rpcClient := sender.StatusNode().RPCClient()
+	rpcClient := sender.StatusNode().RPCPrivateClient()
 	s.Require().NotNil(rpcClient)
 
 	// Create topic.
@@ -163,9 +163,9 @@ func (s *WhisperMailboxSuite) TestRequestMessagesInGroupChat() {
 	charlieWhisperService, err := charlieBackend.StatusNode().WhisperService()
 	s.Require().NoError(err)
 	// Get rpc client.
-	aliceRPCClient := aliceBackend.StatusNode().RPCClient()
-	bobRPCClient := bobBackend.StatusNode().RPCClient()
-	charlieRPCClient := charlieBackend.StatusNode().RPCClient()
+	aliceRPCClient := aliceBackend.StatusNode().RPCPrivateClient()
+	bobRPCClient := bobBackend.StatusNode().RPCPrivateClient()
+	charlieRPCClient := charlieBackend.StatusNode().RPCPrivateClient()
 
 	// Bob and charlie add the mailserver key.
 	password := "status-offline-inbox"


### PR DESCRIPTION
Addresses #912. By removing these two modules from APIModules, we disallow dapps from using dangerous methods like shh.SetMinPoW
