### PR TITLE
Add GOPATH check to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,12 @@ statusgo-cross: statusgo-android statusgo-ios
 	@echo "Full cross compilation done."
 	@ls -ld $(GOBIN)/statusgo-*
 
+statusgo-linux: xgo ##@cross-compile Build status-go for Linux
+	./_assets/patches/patcher -b . -p geth-xgo
+	$(GOPATH)/bin/xgo --image $(XGOIMAGE) --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=linux/amd64 -v -tags '$(BUILD_TAGS)' $(BUILD_FLAGS) ./cmd/statusd
+	./_assets/patches/patcher -b . -p geth-xgo -r
+	@echo "Android cross compilation done."
+
 statusgo-android: xgo ##@cross-compile Build status-go for Android
 	./_assets/patches/patcher -b . -p geth-xgo
 	$(GOPATH)/bin/xgo --image $(XGOIMAGE) --go=$(GO) -out statusgo --dest=$(GOBIN) --targets=android-16/aar -v -tags '$(BUILD_TAGS)' $(BUILD_FLAGS) ./lib

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,22 @@ ifndef GOPATH
 	For more information about the GOPATH environment variable, see https://golang.org/doc/code.html#GOPATH)
 endif
 
+
+EXPECTED_PATH=$(GOPATH)/src/github.com/status-im/status-go
+ifneq ($(CURDIR),$(EXPECTED_PATH))
+define NOT_IN_GOPATH_ERROR
+
+Current dir is $(CURDIR), which seems to be different from your GOPATH.
+Please, build status-go from GOPATH for proper build.
+  GOPATH       = $(GOPATH) 
+  Current dir  = $(CURDIR) 
+  Expected dir = $(EXPECTED_PATH))
+See see https://golang.org/doc/code.html#GOPATH for more info
+
+endef
+$(error $(NOT_IN_GOPATH_ERROR))
+endif
+
 CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
 GIT_COMMIT := $(shell git rev-parse --short HEAD)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ Please, build status-go from GOPATH for proper build.
   GOPATH       = $(GOPATH) 
   Current dir  = $(CURDIR) 
   Expected dir = $(EXPECTED_PATH))
-See see https://golang.org/doc/code.html#GOPATH for more info
+See https://golang.org/doc/code.html#GOPATH for more info
 
 endef
 $(error $(NOT_IN_GOPATH_ERROR))

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ ifndef GOPATH
 endif
 
 
-EXPECTED_PATH=$(GOPATH)/src/github.com/status-im/status-go
+EXPECTED_PATH=$(shell go env GOPATH)/src/github.com/status-im/status-go
 ifneq ($(CURDIR),$(EXPECTED_PATH))
 define NOT_IN_GOPATH_ERROR
 
 Current dir is $(CURDIR), which seems to be different from your GOPATH.
 Please, build status-go from GOPATH for proper build.
-  GOPATH       = $(GOPATH) 
+  GOPATH       = $(shell go env GOPATH) 
   Current dir  = $(CURDIR) 
   Expected dir = $(EXPECTED_PATH))
 See https://golang.org/doc/code.html#GOPATH for more info


### PR DESCRIPTION
This PR adds (ugly) Makefile check to detect cases where status-go is being built outside of GOPATH.

We've seen numerous times that non-Go developers tend to do this:
```
cd ~/SomeFolder
git clone git@github.com:status-im/status-go.git
make statusgo
```
and get not really helpful error message:

```
can't load package: package .: no Go files in /
```

This change adds a helpful message for this case:
```
/tmp $ make
Makefile:25: ***
Current dir is /private/tmp, which seems to be different from your GOPATH.
Please, build status-go from GOPATH for proper build.
  GOPATH       = /Users/divan
  Current dir  = /private/tmp
  Expected dir = /Users/divan/src/github.com/status-im/status-go)
See https://golang.org/doc/code.html#GOPATH for more info
.  Stop.
```

It also adds `statusgo-linux` target (not related to the GOPATH problem, just need it regularly on MacOS X), sorry :)