### PR TITLE
add metrics to mailserver

### DIFF
--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rlp"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/status-im/status-go/geth/params"
@@ -40,6 +41,13 @@ const (
 var (
 	errDirectoryNotProvided = errors.New("data directory not provided")
 	errPasswordNotProvided  = errors.New("password is not specified")
+	// By default go-ethereum/metrics creates dummy metrics that don't register anything.
+	// Real metrics are collected only if -metrics flag is set
+	requestProcessTimer    = metrics.NewRegisteredTimer("mailserver/processTime", nil)
+	requestsCounter        = metrics.NewRegisteredCounter("mailserver/requests", nil)
+	requestErrorsCounter   = metrics.NewRegisteredCounter("mailserver/requestErrors", nil)
+	sentEnvelopesMeter     = metrics.NewRegisteredMeter("mailserver/envelopes", nil)
+	sentEnvelopesSizeMeter = metrics.NewRegisteredMeter("mailserver/envelopesSize", nil)
 )
 
 // WMailServer whisper mailserver.
@@ -160,11 +168,14 @@ func (s *WMailServer) Archive(env *whisper.Envelope) {
 
 // DeliverMail sends mail to specified whisper peer.
 func (s *WMailServer) DeliverMail(peer *whisper.Peer, request *whisper.Envelope) {
+	requestsCounter.Inc(1)
 	if peer == nil {
+		requestErrorsCounter.Inc(1)
 		log.Error("Whisper peer is nil")
 		return
 	}
 	if s.exceedsPeerRequests(peer.ID()) {
+		requestErrorsCounter.Inc(1)
 		return
 	}
 
@@ -198,6 +209,13 @@ func (s *WMailServer) processRequest(peer *whisper.Peer, lower, upper uint32, bl
 	i := s.db.NewIterator(&util.Range{Start: kl.raw, Limit: ku.raw}, nil)
 	defer i.Release()
 
+	var (
+		sentEnvelopes     int64
+		sentEnvelopesSize int64
+	)
+
+	start := time.Now()
+
 	for i.Next() {
 		var envelope whisper.Envelope
 		err = rlp.DecodeBytes(i.Value(), &envelope)
@@ -216,8 +234,14 @@ func (s *WMailServer) processRequest(peer *whisper.Peer, lower, upper uint32, bl
 					return nil
 				}
 			}
+			sentEnvelopes++
+			sentEnvelopesSize = whisper.EnvelopeHeaderLength + int64(len(envelope.Data))
 		}
 	}
+
+	requestProcessTimer.UpdateSince(start)
+	sentEnvelopesMeter.Mark(sentEnvelopes)
+	sentEnvelopesSizeMeter.Mark(sentEnvelopesSize)
 
 	err = i.Error()
 	if err != nil {

--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -235,7 +235,7 @@ func (s *WMailServer) processRequest(peer *whisper.Peer, lower, upper uint32, bl
 				}
 			}
 			sentEnvelopes++
-			sentEnvelopesSize = whisper.EnvelopeHeaderLength + int64(len(envelope.Data))
+			sentEnvelopesSize += whisper.EnvelopeHeaderLength + int64(len(envelope.Data))
 		}
 	}
 


### PR DESCRIPTION
This PR adds some metrics to mailserver.

```
requestProcessTimer    = metrics.NewRegisteredTimer("mailserver/processTime", nil)
requestsCounter        = metrics.NewRegisteredCounter("mailserver/requests", nil)
requestErrorsCounter   = metrics.NewRegisteredCounter("mailserver/requestErrors", nil)
sentEnvelopesMeter     = metrics.NewRegisteredMeter("mailserver/envelopes", nil)
sentEnvelopesSizeMeter = metrics.NewRegisteredMeter("mailserver/envelopesSize", nil)
```

Metrics from geth console:
```
> debug.metrics(true).mailserver
{
  envelopes: {
    AvgRate01Min: 0.11208505049570809,
    AvgRate05Min: 0.02830039104437328,
    AvgRate15Min: 0.009807446406630506,
    MeanRate: 0.1386104032923209,
    Overall: 9
  },
  envelopesSize: {
    AvgRate01Min: 34.073855350695254,
    AvgRate05Min: 8.60331887748948,
    AvgRate15Min: 2.981463707615674,
    MeanRate: 42.1376458336656,
    Overall: 2736
  },
  processTime: {
    AvgRate01Min: 0.012453894499523116,
    AvgRate05Min: 0.003144487893819254,
    AvgRate15Min: 0.0010897162674033895,
    MeanRate: 0.015401155576486589,
    Overall: 1,
    Percentiles: {
      20: 2266616,
      5: 2266616,
      50: 2266616,
      80: 2266616,
      95: 2266616
    }
  },
  requestErrors: {
    Overall: 0
  },
  requests: {
    Overall: 2
  }
}
```

Closes #998 
