### PR TITLE
Ignore malformed enodes in ClusterConfig

### DIFF
--- a/geth/node/node.go
+++ b/geth/node/node.go
@@ -269,18 +269,30 @@ func makeIPCPath(config *params.NodeConfig) string {
 
 // parseNodes creates list of discover.Node out of enode strings.
 func parseNodes(enodes []string) []*discover.Node {
-	nodes := make([]*discover.Node, len(enodes))
-	for i, enode := range enodes {
-		nodes[i] = discover.MustParseNode(enode)
+	var nodes []*discover.Node
+	for _, enode := range enodes {
+		parsedPeer, err := discover.ParseNode(enode)
+		if err == nil {
+			nodes = append(nodes, parsedPeer)
+		} else {
+			logger.Error("Failed to parse enode", "enode", enode, "err", err)
+		}
+
 	}
 	return nodes
 }
 
 // parseNodesV5 creates list of discv5.Node out of enode strings.
 func parseNodesV5(enodes []string) []*discv5.Node {
-	nodes := make([]*discv5.Node, len(enodes))
-	for i, enode := range enodes {
-		nodes[i] = discv5.MustParseNode(enode)
+	var nodes []*discv5.Node
+	for _, enode := range enodes {
+		parsedPeer, err := discv5.ParseNode(enode)
+
+		if err == nil {
+			nodes = append(nodes, parsedPeer)
+		} else {
+			logger.Error("Failed to parse enode", "enode", enode, "err", err)
+		}
 	}
 	return nodes
 }

--- a/geth/node/node_test.go
+++ b/geth/node/node_test.go
@@ -1,0 +1,58 @@
+package node
+
+import (
+	. "github.com/status-im/status-go/t/utils"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	"testing"
+)
+
+var enode1 = "enode://f32efef2739e5135a0f9a80600b321ba4d13393a5f1d3f5f593df85919262f06c70bfa66d38507b9d79a91021f5e200ec20150592e72934c66248e87014c4317@1.1.1.1:30404"
+var enode2 = "enode://f32efef2739e5135a0f9a80600b321ba4d13393a5f1d3f5f593df85919262f06c70bfa66d38507b9d79a91021f5e200ec20150592e72934c66248e87014c4317@1.1.1.1:30404"
+
+func TestMakeNodeDefaultConfig(t *testing.T) {
+	config, err := MakeTestNodeConfig(3)
+	require.NoError(t, err)
+
+	db, err := leveldb.Open(storage.NewMemStorage(), nil)
+	require.NoError(t, err)
+
+	_, err = MakeNode(config, db)
+	require.NoError(t, err)
+}
+
+func TestMakeNodeWellFormedBootnodes(t *testing.T) {
+	config, err := MakeTestNodeConfig(3)
+	require.NoError(t, err)
+
+	bootnodes := []string{
+		enode1,
+		enode2,
+	}
+	config.ClusterConfig.BootNodes = bootnodes
+
+	db, err := leveldb.Open(storage.NewMemStorage(), nil)
+	require.NoError(t, err)
+
+	_, err = MakeNode(config, db)
+	require.NoError(t, err)
+}
+
+func TestMakeNodeMalformedBootnodes(t *testing.T) {
+	config, err := MakeTestNodeConfig(3)
+	require.NoError(t, err)
+
+	bootnodes := []string{
+		enode1,
+		enode2,
+		"enode://badkey@3.3.3.3:30303",
+	}
+	config.ClusterConfig.BootNodes = bootnodes
+
+	db, err := leveldb.Open(storage.NewMemStorage(), nil)
+	require.NoError(t, err)
+
+	_, err = MakeNode(config, db)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
We now allow the user to override bootnodes in `status-react`.

Only light validation is made in the app (no public key for example).

At the moment status-go panics if an enode is malformed, preventing the
user to login into their account.

This commit changes the behaviour to ignore malformed enodes and log with `WARN` level.

Important changes:
- [x] Malformed urls in `ClusterConfig` will be ignored.

