### PR TITLE
ApproveSignRequestWithArgs gas and gasInfo should be long instead of int

### DIFF
--- a/lib/library.go
+++ b/lib/library.go
@@ -211,7 +211,7 @@ func Logout() *C.char {
 // gas and gasPrice will be overrided with the given values before signing the
 // transaction.
 //export ApproveSignRequestWithArgs
-func ApproveSignRequestWithArgs(id, password *C.char, gas, gasPrice C.int) *C.char {
+func ApproveSignRequestWithArgs(id, password *C.char, gas, gasPrice C.longlong) *C.char {
 	result := statusAPI.ApproveSignRequestWithArgs(C.GoString(id), C.GoString(password), int64(gas), int64(gasPrice))
 
 	return prepareApproveSignRequestResponse(result, id)


### PR DESCRIPTION
Gas and gasPrice are now being exposed through ApproveSignRequestWithArgs binding as integers but they should be of type int64.

In C long is 32 bits and longlong is 64 https://en.wikipedia.org/wiki/C_data_types.

<blockquote><img src="/static/favicon/wikipedia.ico" width="48" align="right"><div><strong><a href="https://en.wikipedia.org/wiki/C_data_types">C data types - Wikipedia</a></strong></div></blockquote>