### PR TITLE
Fail tests if ACCOUNT_PASSWORD env var is not defined

### DIFF
--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -297,7 +297,12 @@ func loadTestConfig() (*testConfig, error) {
 			return nil, err
 		}
 
-		pass := os.Getenv(passphraseEnvName)
+		pass, ok := os.LookupEnv(passphraseEnvName)
+		if !ok {
+			err := fmt.Errorf("Missing %s environment variable", passphraseEnvName)
+			return nil, err
+		}
+
 		config.Account1.Password = pass
 		config.Account2.Password = pass
 	}


### PR DESCRIPTION
When tests that require `ACCOUNT_PASSWORD` are run (e.g. tests on Ropsten network), no check was being executed at startup, so the dev only found that something was wrong after a long execution time. With this change, the user is immediately notified about the problem:

```
go test -timeout 50m ./t/e2e/jail/... -network=4
panic: Missing ACCOUNT_PASSWORD environment variable

goroutine 1 [running]:
github.com/status-im/status-go/t/utils.init.0()
        /home/pedro/go/src/github.com/status-im/status-go/t/utils/utils.go:95 +0x377
FAIL    github.com/status-im/status-go/t/e2e/jail       0.120s
```
