### PR TITLE
Update go-duktape.v3 revision to include submitted patch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -387,7 +387,7 @@
   branch = "v3"
   name = "gopkg.in/olebedev/go-duktape.v3"
   packages = ["."]
-  revision = "3c4db4ad4f2db84859454dc805d6eb7d8051a8ce"
+  revision = "abf0ba0be5d5d36b1f9266463cc320b9a5ab224e"
 
 [[projects]]
   name = "gopkg.in/sourcemap.v1"

--- a/vendor/gopkg.in/olebedev/go-duktape.v3/api.go
+++ b/vendor/gopkg.in/olebedev/go-duktape.v3/api.go
@@ -1,8 +1,8 @@
 package duktape
 
 /*
-#cgo !windows CFLAGS: -std=c99 -O3 -Wall -fomit-frame-pointer -fstrict-aliasing
-#cgo windows CFLAGS: -O3 -Wall -fomit-frame-pointer -fstrict-aliasing
+#cgo !windows CFLAGS: -std=c99 -O3 -Wall -Wno-unused-value -fomit-frame-pointer -fstrict-aliasing
+#cgo windows CFLAGS: -O3 -Wall -Wno-unused-value -fomit-frame-pointer -fstrict-aliasing
 
 #include "duktape.h"
 #include "duk_logging.h"


### PR DESCRIPTION
- Gets rid of noisy build warnings