### PR TITLE
[#1022] Make ntp synchronization configurable

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -116,6 +116,9 @@ type WhisperConfig struct {
 
 	// FirebaseConfig extra configuration for Firebase Cloud Messaging
 	FirebaseConfig *FirebaseConfig `json:"FirebaseConfig,"`
+
+	// EnableNTPSync enables NTP synchronizations
+	EnableNTPSync bool
 }
 
 // ReadPasswordFile reads and returns content of the password file
@@ -353,6 +356,7 @@ func NewNodeConfig(dataDir string, clstrCfgFile string, networkID uint64) (*Node
 			FirebaseConfig: &FirebaseConfig{
 				NotificationTriggerURL: FirebaseNotificationTriggerURL,
 			},
+			EnableNTPSync: true,
 		},
 		SwarmConfig:    &SwarmConfig{},
 		RegisterTopics: []discv5.Topic{},

--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -255,6 +255,8 @@ func MakeTestNodeConfig(networkID int) (*params.NodeConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	nodeConfig.WhisperConfig.EnableNTPSync = false
+
 	return nodeConfig, nil
 }
 


### PR DESCRIPTION
While we define the final scope of https://github.com/status-im/status-go/issues/1022 this pull request provides a way to disable NTP synchronization through the config check `config.WhisperConfig.EnableNTPSync`.

Important changes:
- [x] New `EnableNTPSync` entry on `config.WhisperConfig`
- [x] Default value for `EnableNTPSync` is enabled
- [x] Default e2e tests `EnableNTPSync` value is disabled


