### PR TITLE
Assert that no error is returned in `TestConcurrentComplete()`

### DIFF
--- a/sign/pending_requests_test.go
+++ b/sign/pending_requests_test.go
@@ -174,7 +174,8 @@ func (s PendingRequestsSuite) TestConcurrentComplete() {
 		}()
 	}
 
-	s.pendingRequests.Wait(req.ID, 10*time.Second)
+	rst := s.pendingRequests.Wait(req.ID, 10*time.Second)
+	s.Require().NoError(rst.Error)
 
 	s.False(s.pendingRequests.Has(req.ID), "sign request should exist")
 


### PR DESCRIPTION
This PR adds an assert so that an error returned by `pendingRequests.Wait` is visible in the test results, and we get more info when the build fails like this: https://jenkins.status.im/job/status-go/job/race-check/91/consoleFull

<blockquote></blockquote>