### PR TITLE
Add option to disable ntp sync to statusd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     script:
       # Sync the chain first. It will time out after 30 minutes. Used network: Rinkeby.
       - make statusgo
-      - ./build/bin/statusd -datadir=.ethereumtest/Rinkeby -les -networkid=4 -sync-and-exit=45 -log=WARN -standalone=false -discovery=false
+      - ./build/bin/statusd -datadir=.ethereumtest/Rinkeby -les -networkid=4 -sync-and-exit=45 -log=WARN -standalone=false -discovery=false -ntp=false
       - make test-e2e networkid=4
 cache:
   directories:

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -79,6 +79,8 @@ var (
 
 	syncAndExit = flag.Int("sync-and-exit", -1, "Timeout in minutes for blockchain sync and exit, zero means no timeout unless sync is finished")
 
+	ntpSyncEnabled = flag.Bool("ntp", true, "Enable/disable whisper NTP synchronization")
+
 	// Topics that will be search and registered by discovery v5.
 	searchTopics   = topics.TopicLimitsFlag{}
 	registerTopics = topics.TopicFlag{}
@@ -249,6 +251,8 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 	nodeConfig.NoDiscovery = !(*discovery)
 	nodeConfig.RequireTopics = map[discv5.Topic]params.Limits(searchTopics)
 	nodeConfig.RegisterTopics = []discv5.Topic(registerTopics)
+
+	nodeConfig.WhisperConfig.EnableNTPSync = *ntpSyncEnabled
 
 	// Even if standalone is true and discovery is disabled,
 	// it's possible to use bootnodes.


### PR DESCRIPTION
When running e2e tests on public network a statusd instance is setup and running on the background, even we've disabled NTP sync on nodes setup inside tests, this instance is still reporting NTP sync timeouts.

### Important changes:

- [x] Add a new flag to statusd to avoid ntp sync
- [x]  Configure travis builds to disable ntp sync

Partially closes #1022