### PR TITLE
extkeys: extended key can derive a child only if its depth is less than 255

### DIFF
--- a/extkeys/hdkey_test.go
+++ b/extkeys/hdkey_test.go
@@ -506,6 +506,26 @@ func TestErrors(t *testing.T) {
 	}
 }
 
+func TestMaxDepth(t *testing.T) {
+	mnemonic := NewMnemonic()
+	phrase, err := mnemonic.MnemonicPhrase(128, EnglishLanguage)
+	if err != nil {
+		t.Errorf("Test failed: could not create mnemonic phrase: %v", err)
+	}
+
+	lastParentKey, err := NewMaster(mnemonic.MnemonicSeed(phrase, "test-password"))
+	if err != nil {
+		t.Errorf("couldn't create master extended key: %v", err)
+	}
+
+	lastParentKey.Depth = 255
+
+	_, err = lastParentKey.Child(0)
+	if err != ErrMaxDepthExceeded {
+		t.Errorf("Expected ErrMaxDepthExceeded, got %+v", err)
+	}
+}
+
 func TestBIP44ChildDerivation(t *testing.T) {
 	keyString := "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
 	derivedKey1String := "xprvA38t8tFW4vbuB7WJXEqMFmZqRrcZUKWqqMcGjjKjr2hbfvPhRtLLJGL4ayWG8shF1VkuUikVGodGshLiKRS7WrdsrGSVDQCY33qoPBxG2Kp"


### PR DESCRIPTION
As described in #932, we are not checking the maximum depth of child keys.

An extended key is encoded with this format:

```
version (4 bytes) || depth (1 byte) || parent fingerprint (4 bytes) || child num (4 bytes) || chain code (32 bytes) || key data (33 bytes) || checksum (4bytes)
```

Given that `depth` has only 1 byte, the derivation path can have `256` parts, so the `depth` can be a value between `0` (master key) and `255`.

Important changes:
- [x] changed `ExtendedKey.Depth` type to `uint8`
- [x] return `ErrMaxDepthExceeded` if `Child` is called on an extended key with `Depth == 255`

This PR needs an audit.

Closes #932 
