### PR TITLE
Use `EnvelopeTracer` as an event source to avoid relying on timeouts in tests. Fixes #1021

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jobs:
     # ACCOUNT_PASSWORD environment variable anyway.
     if: ((type != push) OR (branch = "develop")) AND (fork = false)
     script:
-      # Sync the chain first. It will time out after 30 minutes. Used network: Rinkeby.
+      # Sync the chain first. It will time out after 45 minutes. Used network: Rinkeby.
       - make statusgo
       - ./build/bin/statusd -datadir=.ethereumtest/Rinkeby -les -networkid=4 -sync-and-exit=45 -log=WARN -standalone=false -discovery=false -ntp=false
       - make test-e2e networkid=4

--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -217,7 +217,7 @@ func (s *WMailServer) processRequest(peer *whisper.Peer, lower, upper uint32, bl
 	var err error
 	var zero common.Hash
 	kl := NewDbKey(lower, zero)
-	ku := NewDbKey(upper, zero)
+	ku := NewDbKey(upper+1, zero) // LevelDB is exclusive, while the Whisper API is inclusive
 	i := s.db.NewIterator(&util.Range{Start: kl.raw, Limit: ku.raw}, nil)
 	defer i.Release()
 


### PR DESCRIPTION
This PR replaces most of the time.Sleeps in the Whisper mailserver tests, and also fixes a bug in the mailserver implementation which was using upper bound `to` parameter as an exclusive, rather than inclusive parameter, as stated in the documentation: https://github.com/status-im/status-go/wiki/Additional-JSON-RPC-API. I've created a PR in geth for the bug. The fact that we weren't relying on an event to know when a message has reached a peer, in conjunction with the aforementioned bug, was causing tests to fail very often.

The tests now take 20 seconds less to execute on Travis CI and on my local machine, since we don't spend as much time waiting for the messages. There is still room for improvement in the future (as noted in the TODO), that would avoid having to wait up to 3 seconds for a message to be decoded and available, every time we want to retrieve a message.

Closes #1021 