### PR TITLE
Disable geth.log if no log level is specified. Part of status-im/status-react#4782

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -216,14 +216,11 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 
 	if *logLevel != "" {
 		nodeConfig.LogLevel = *logLevel
+		nodeConfig.LogEnabled = true
 	}
 
 	if *logFile != "" {
 		nodeConfig.LogFile = *logFile
-	}
-
-	if *logLevel != "" || *logFile != "" {
-		nodeConfig.LogEnabled = true
 	}
 
 	nodeConfig.RPCEnabled = *httpEnabled


### PR DESCRIPTION
This PR disables logging if there is no log level specified (needed for https://github.com/status-im/status-react/issues/4782). Confirmed that it still logs to command line when running `statusd`.