### PR TITLE
Fix incorrect log call format

### DIFF
--- a/transactions/transactor.go
+++ b/transactions/transactor.go
@@ -2,6 +2,7 @@ package transactions
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"sync"
 	"time"
@@ -164,7 +165,7 @@ func (t *Transactor) validateAndPropagate(selectedAccount *account.SelectedExtKe
 			return hash, err
 		}
 		if gas < defaultGas {
-			t.log.Info("default gas will be used. estimated gas", gas, "is lower than", defaultGas)
+			t.log.Info(fmt.Sprintf("default gas will be used. estimated gas %v is lower than %v", gas, defaultGas))
 			gas = defaultGas
 		}
 	} else {


### PR DESCRIPTION
This tiny PR fixes an incorrect call format to the `log.Info` method, which was polluting the log with 
```
LOG15_ERROR="Normalized odd number of arguments by adding nil"
``` 