### PR TITLE
Fix return type of RequestMessages (hash instead of bool)

### DIFF
--- a/t/benchmarks/mailserver_test.go
+++ b/t/benchmarks/mailserver_test.go
@@ -79,13 +79,13 @@ func testMailserverPeer(t *testing.T) {
 	ok, err := shhAPI.MarkTrustedPeer(context.TODO(), *peerURL)
 	require.NoError(t, err)
 	require.True(t, ok)
-	ok, err = shhextAPI.RequestMessages(context.TODO(), shhext.MessagesRequest{
+	hash, err := shhextAPI.RequestMessages(context.TODO(), shhext.MessagesRequest{
 		MailServerPeer: *peerURL,
 		SymKeyID:       symKeyID,
 		Topic:          topic,
 	})
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.NotNil(t, hash)
 	// wait for all messages
 	require.NoError(t, waitForMessages(t, *msgCount, shhAPI, filterID))
 }


### PR DESCRIPTION
The return value of RequestMessages was changed from a bool to a hash but the test was not adapted: https://github.com/status-im/status-go/blob/develop/t/benchmarks/mailserver_test.go#L82

Lint warning appears in https://travis-ci.org/status-im/status-go/jobs/393987750#L544