### PR TITLE
Enable `typecheck` to catch syntax errors on files which are not normally compiled

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,7 @@ linters:
     - megacheck
     #- misspell
     - structcheck
+    - typecheck
     - unconvert
     - varcheck
   fast: false


### PR DESCRIPTION
Running typecheck linter ensures that the build will fail if other linters cannot run due to syntax errors, maybe in files which are not normally built (like `benchmarks` package)

https://travis-ci.org/status-im/status-go/jobs/393987750#L544


<blockquote><div><strong><a href="https://travis-ci.org/status-im/status-go/jobs/393987750#L544">Travis CI - Test and Deploy Your Code with Confidence</a></strong></div></blockquote>