### PR TITLE
[#1040] Patch go-ethereum reducing from Warn to Info on "message loop" logs

### DIFF
--- a/_assets/patches/geth/0033-message-loop-warning-to-info.patch
+++ b/_assets/patches/geth/0033-message-loop-warning-to-info.patch
@@ -1,0 +1,26 @@
+diff --git a/whisper/whisperv5/whisper.go b/whisper/whisperv5/whisper.go
+index 85849ccc..3b75e53a 100644
+--- a/whisper/whisperv5/whisper.go
++++ b/whisper/whisperv5/whisper.go
+@@ -499,7 +499,7 @@ func (wh *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
+ 		// fetch the next packet
+ 		packet, err := rw.ReadMsg()
+ 		if err != nil {
+-			log.Warn("message loop", "peer", p.peer.ID(), "err", err)
++			log.Info("message loop", "peer", p.peer.ID(), "err", err)
+ 			return err
+ 		}
+ 		if packet.Size > wh.MaxMessageSize() {
+diff --git a/whisper/whisperv6/whisper.go b/whisper/whisperv6/whisper.go
+index 4a7b0065..91d44821 100644
+--- a/whisper/whisperv6/whisper.go
++++ b/whisper/whisperv6/whisper.go
+@@ -747,7 +747,7 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
+ 		// fetch the next packet
+ 		packet, err := rw.ReadMsg()
+ 		if err != nil {
+-			log.Warn("message loop", "peer", p.peer.ID(), "err", err)
++			log.Info("message loop", "peer", p.peer.ID(), "err", err)
+ 			return err
+ 		}
+ 		if packet.Size > whisper.MaxMessageSize() {

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv5/whisper.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv5/whisper.go
@@ -499,7 +499,7 @@ func (wh *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 		// fetch the next packet
 		packet, err := rw.ReadMsg()
 		if err != nil {
-			log.Warn("message loop", "peer", p.peer.ID(), "err", err)
+			log.Info("message loop", "peer", p.peer.ID(), "err", err)
 			return err
 		}
 		if packet.Size > wh.MaxMessageSize() {

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go
@@ -747,7 +747,7 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 		// fetch the next packet
 		packet, err := rw.ReadMsg()
 		if err != nil {
-			log.Warn("message loop", "peer", p.peer.ID(), "err", err)
+			log.Info("message loop", "peer", p.peer.ID(), "err", err)
 			return err
 		}
 		if packet.Size > whisper.MaxMessageSize() {


### PR DESCRIPTION
Patched go-ethereum to reduce from Warn to Info the log level for "message loop" logs

Closes #1040 
