### PR TITLE
Desktop platform jail signal callback support

### DIFF
--- a/lib/library.go
+++ b/lib/library.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"unsafe"
 
 	"github.com/NaySoftware/go-fcm"
 	"github.com/ethereum/go-ethereum/log"
@@ -14,6 +15,7 @@ import (
 	"github.com/status-im/status-go/profiling"
 	"github.com/status-im/status-go/sign"
 	"gopkg.in/go-playground/validator.v9"
+	"github.com/status-im/status-go/signal"
 )
 
 // All general log messages in this package should be routed through this logger.
@@ -483,4 +485,10 @@ func ConnectionChange(typ *C.char, expensive C.int) {
 //export AppStateChange
 func AppStateChange(state *C.char) {
 	statusBackend.AppStateChange(C.GoString(state))
+}
+
+// SetSignalEventCallback setup geth callback to notify about new jail signal
+//export SetSignalEventCallback
+func SetSignalEventCallback(cb unsafe.Pointer) {
+	signal.SetSignalEventCallback(cb)
 }

--- a/signal/signals.c
+++ b/signal/signals.c
@@ -198,7 +198,7 @@ bool StatusServiceSignalEvent(const char *jsonEvent) {
 
 #else
 // ======================================================================================
-// cgo compilation (for local tests)
+// cgo compilation (for desktop platforms and local tests)
 // ======================================================================================
 
 #include <stdio.h>
@@ -206,10 +206,21 @@ bool StatusServiceSignalEvent(const char *jsonEvent) {
 #include <stdbool.h>
 #include "_cgo_export.h"
 
+typedef void (*callback)(const char *jsonEvent);
+callback gCallback = 0;
+
 bool StatusServiceSignalEvent(const char *jsonEvent) {
-    NotifyNode((char *)jsonEvent); // re-send notification back to status node
+	if (gCallback) {
+		gCallback(jsonEvent);
+	} else {
+		NotifyNode((char *)jsonEvent); // re-send notification back to status node
+	}
 
 	return true;
+}
+
+void SetEventCallback(void *cb) {
+	gCallback = (callback)cb;
 }
 
 #endif

--- a/signal/signals.go
+++ b/signal/signals.go
@@ -4,10 +4,13 @@ package signal
 #include <stddef.h>
 #include <stdbool.h>
 extern bool StatusServiceSignalEvent(const char *jsonEvent);
+extern void SetEventCallback(void *cb);
 */
 import "C"
 import (
 	"encoding/json"
+
+	"unsafe"
 
 	"sync"
 
@@ -81,4 +84,9 @@ func NotifyNode(jsonEvent *C.char) {
 //nolint: golint
 func TriggerTestSignal() {
 	C.StatusServiceSignalEvent(C.CString(`{"answer": 42}`))
+}
+
+// SetSignalEventCallback set callback
+func SetSignalEventCallback(cb unsafe.Pointer) {
+	C.SetEventCallback(cb)
 }


### PR DESCRIPTION
Native library build adjusted to be used by StatusIm Desktop app (by react-native-desktop's native module "Status").

Introduced possibility to set specific C callback method to get new geth jail signals notifications.  

Important changes:
`SetJailSignalCallback` is called by external CPP source code. Preset callback is called from `signal/signals.c` on new jail signal propagation.

Closes https://github.com/status-im/status-react/issues/4841
