### PR TITLE
collect process metrics

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -10,10 +10,12 @@ import (
 	"os/signal"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/status-im/status-go/logutils"
 
 	"github.com/ethereum/go-ethereum/log"
+	gethmetrics "github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/status-im/status-go/api"
 	"github.com/status-im/status-go/cmd/statusd/debug"
@@ -149,6 +151,7 @@ func main() {
 	// Run stats server.
 	if *metrics {
 		go startCollectingNodeMetrics(interruptCh, backend.StatusNode())
+		gethmetrics.CollectProcessMetrics(3 * time.Second)
 	}
 
 	// Sync blockchain and stop.

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -151,7 +151,7 @@ func main() {
 	// Run stats server.
 	if *metrics {
 		go startCollectingNodeMetrics(interruptCh, backend.StatusNode())
-		gethmetrics.CollectProcessMetrics(3 * time.Second)
+		go gethmetrics.CollectProcessMetrics(3 * time.Second)
 	}
 
 	// Sync blockchain and stop.


### PR DESCRIPTION
Adds a call to `metrics.CollectProcessMetrics(3 * time.Second) ` to collect process metrics as described in #1042 
It doesn't  [tune the garbage collector like in go-ethereum](https://sourcegraph.com/github.com/ethereum/go-ethereum@9608ccf106584c73e91258518eb9d09ad39cc8ae/-/blob/cmd/geth/main.go#L196:3) but it can be done if needed.

in `develope` no process metrics are exported:

```
> Object.keys(debug.metrics(false)).sort()
["chain", "db", "discv5", "eth", "les", "mailserver", "p2p", "trie", "txpool", "whisper"]
```

with this PR process metrics are automatically added to the metrics exported with `debug_metrics`.
`system` is added to the main object:

```
> Object.keys(debug.metrics(false)).sort()
["chain", "db", "discv5", "eth", "les", "mailserver", "p2p", "system", "trie", "txpool", "whisper"]
```

the full output is:

```
> debug.metrics(true).system
{
  memory: {
    allocs: {
      AvgRate01Min: 247.58276660017222,
      AvgRate05Min: 453.571853943344,
      AvgRate15Min: 8160.930095676375,
      MeanRate: 414.1937535221898,
      Overall: 680883
    },
    frees: {
      AvgRate01Min: 158.19372279326478,
      AvgRate05Min: 422.55750948265575,
      AvgRate15Min: 7653.250735951939,
      MeanRate: 394.11741828802144,
      Overall: 647880
    },
    inuse: {
      AvgRate01Min: 12610.921288801805,
      AvgRate05Min: 13153.580141918983,
      AvgRate15Min: 409347.4522665585,
      MeanRate: 6687.1484346453435,
      Overall: 10992840
    },
    pauses: {
      AvgRate01Min: 472.5761634627217,
      AvgRate05Min: 1021.503457592032,
      AvgRate15Min: 13649.52342777638,
      MeanRate: 938.8873604627187,
      Overall: 1543414
    }
  }
}
```

`geth_exporter` already collects all metrics exporter calling `debug_metrics`.
Running `geth_exporter` with `statusd` from this branch:

```
curl http://localhost:9200/metrics | grep system | grep -v ^#


geth_system_memory_allocs_avgRate01Min 247.58276660017222
geth_system_memory_allocs_avgRate05Min 453.571853943344
geth_system_memory_allocs_avgRate15Min 8160.930095676375
geth_system_memory_allocs_meanRate 415.828151269051
geth_system_memory_allocs_overall 684819
geth_system_memory_frees_avgRate01Min 158.19372279326478
geth_system_memory_frees_avgRate05Min 422.55750948265575
geth_system_memory_frees_avgRate15Min 7653.250735951939
geth_system_memory_frees_meanRate 393.4604007485845
geth_system_memory_frees_overall 647982
geth_system_memory_inuse_avgRate01Min 12610.921288801805
geth_system_memory_inuse_avgRate05Min 13153.580141918983
geth_system_memory_inuse_avgRate15Min 409347.4522665585
geth_system_memory_inuse_meanRate 6883.542911958232
geth_system_memory_inuse_overall 1.1336368e+07
geth_system_memory_pauses_avgRate01Min 472.5761634627217
geth_system_memory_pauses_avgRate05Min 1021.503457592032
geth_system_memory_pauses_avgRate15Min 13649.52342777638
geth_system_memory_pauses_meanRate 937.1746327537041
geth_system_memory_pauses_overall 1.543414e+06
```

Closes #1042 
