### PR TITLE
remove formatting from metrics.ResettingTimer when requested in raw format

### DIFF
--- a/_assets/patches/geth/0034-resetting-timer-metrics-raw.patch
+++ b/_assets/patches/geth/0034-resetting-timer-metrics-raw.patch
@@ -1,0 +1,24 @@
+diff --git a/node/api.go b/node/api.go
+index 6d5df7d..dc7d6ae 100644
+--- a/node/api.go
++++ b/node/api.go
+@@ -348,13 +348,13 @@ func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
+ 				ps := t.Percentiles([]float64{5, 20, 50, 80, 95})
+ 				root[name] = map[string]interface{}{
+ 					"Measurements": len(t.Values()),
+-					"Mean":         time.Duration(t.Mean()).String(),
++					"Mean":         t.Mean(),
+ 					"Percentiles": map[string]interface{}{
+-						"5":  time.Duration(ps[0]).String(),
+-						"20": time.Duration(ps[1]).String(),
+-						"50": time.Duration(ps[2]).String(),
+-						"80": time.Duration(ps[3]).String(),
+-						"95": time.Duration(ps[4]).String(),
++						"5":  ps[0],
++						"20": ps[1],
++						"50": ps[2],
++						"80": ps[3],
++						"95": ps[4],
+ 					},
+ 				}
+ 

--- a/vendor/github.com/ethereum/go-ethereum/node/api.go
+++ b/vendor/github.com/ethereum/go-ethereum/node/api.go
@@ -348,13 +348,13 @@ func (api *PublicDebugAPI) Metrics(raw bool) (map[string]interface{}, error) {
 				ps := t.Percentiles([]float64{5, 20, 50, 80, 95})
 				root[name] = map[string]interface{}{
 					"Measurements": len(t.Values()),
-					"Mean":         time.Duration(t.Mean()).String(),
+					"Mean":         t.Mean(),
 					"Percentiles": map[string]interface{}{
-						"5":  time.Duration(ps[0]).String(),
-						"20": time.Duration(ps[1]).String(),
-						"50": time.Duration(ps[2]).String(),
-						"80": time.Duration(ps[3]).String(),
-						"95": time.Duration(ps[4]).String(),
+						"5":  ps[0],
+						"20": ps[1],
+						"50": ps[2],
+						"80": ps[3],
+						"95": ps[4],
 					},
 				}
 


### PR DESCRIPTION
Running `geth_exporter` I noticed a warning in the logs:

`error building metric: strconv.ParseFloat: parsing "0s": invalid syntax`

All metrics are exporter from `statusd` with `debug.metrics(true)`. `true` means raw, so they should not be formatted with `s` for seconds.
Looking at `vendor/github.com/ethereum/go-ethereum/node/api.go` it looks like if a metric is of type `metrics.ResettingTimer` it is always formatted as a string, even if `true` is passed.
I removed the formatting looking at other metrics like `metrics.Timer`, that are not using any formatting when raw metrics are requested.