### PR TITLE
[WIP] use envelope events instead of sleep/retry in mailserver e2e tests

### DIFF
--- a/t/e2e/whisper/whisper_mailbox_test.go
+++ b/t/e2e/whisper/whisper_mailbox_test.go
@@ -126,7 +126,7 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 
 	// wait for mail server response
 	resp := s.waitForMailServerResponse(mailServerResponseWatcher, requestID)
-	s.NotEmpty(resp.LastEnvelopeHash)
+	s.Equal(messageHash, resp.LastEnvelopeHash.String())
 	s.Empty(resp.Cursor)
 
 	// wait for last envelope sent by the mailserver to be available for filters


### PR DESCRIPTION
A short summary which serves as a squashed-commit message.

A description to understand introduced changes without reading the code.

Important changes:
- [x] Something worth noting for reviewers.

Closes #
