### PR TITLE
Validate lower/upper limit in mailserver request

### DIFF
--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -294,6 +294,11 @@ func (s *WMailServer) validateRequest(peerID []byte, request *whisper.Envelope) 
 	lower := binary.BigEndian.Uint32(decrypted.Payload[:4])
 	upper := binary.BigEndian.Uint32(decrypted.Payload[4:8])
 
+	if upper < lower {
+		log.Error(fmt.Sprintf("Query range is invalid: from > to (%d > %d)", lower, upper))
+		return false, 0, 0, nil
+	}
+
 	lowerTime := time.Unix(int64(lower), 0)
 	upperTime := time.Unix(int64(upper), 0)
 	if upperTime.Sub(lowerTime) > maxQueryRange {

--- a/mailserver/mailserver_test.go
+++ b/mailserver/mailserver_test.go
@@ -209,7 +209,7 @@ func (s *MailserverSuite) TestMailServer() {
 		{
 			params: func() *ServerTestParams {
 				params := s.defaultServerParams(env)
-				params.low = 0
+				params.low = params.birth
 				params.upp = params.birth - 1
 
 				return params


### PR DESCRIPTION
This PR improves validation of the "RequestHistoricMessages" request, by checking that `lower` timestamp is always less or equal to `upper` (ensures `from` < `to`, in other words).

This seems like a minor change, but unfortunately passing incorrect from/to parameters may crash leveldb under certain conditions (leveldb issue will follow up).

Instead of adding a new test case, I changed an existing one that, according to the description, was aimed to test exactly this but implemented incorrectly. (I might miss something in those test cases, though).