### PR TITLE
validate query range on requestMessages API

### DIFF
--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -115,6 +115,11 @@ func (api *PublicAPI) RequestMessages(_ context.Context, r MessagesRequest) (hex
 	shh := api.service.w
 	now := api.service.w.GetCurrentTime()
 	r.setDefaults(now)
+
+	if r.From > r.To {
+		return nil, fmt.Errorf("Query range is invalid: from > to (%d > %d)", r.From, r.To)
+	}
+
 	mailServerNode, err := discover.ParseNode(r.MailServerPeer)
 	if err != nil {
 		return nil, fmt.Errorf("%v: %v", ErrInvalidMailServerPeer, err)

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -196,6 +196,14 @@ func (s *ShhExtSuite) TestRequestMessages() {
 	s.Contains(err.Error(), "Could not find peer with ID")
 	s.Nil(hash)
 
+	// from is greater than to
+	hash, err = api.RequestMessages(context.TODO(), MessagesRequest{
+		From: 10,
+		To:   5,
+	})
+	s.Contains(err.Error(), "Query range is invalid: from > to (10 > 5)")
+	s.Nil(hash)
+
 	// with a peer acting as a mailserver
 	// prepare a node first
 	mailNode, err := node.New(&node.Config{


### PR DESCRIPTION
This PR follows https://github.com/status-im/status-go/pull/1058, it adds the same validation but client-side, so that the client can receive an error and manage it or show a message to the user.