### PR TITLE
Make sure all new docker images are also tagged with commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-GIT_LOCAL  := $(git rev-parse @)
-GIT_REMOTE := $(git rev-parse origin)
+GIT_LOCAL  := $(shell git rev-parse @)
+GIT_REMOTE := $(shell git fetch -q && git rev-parse origin)
 
 BUILD_FLAGS ?= $(shell echo "-ldflags '-X main.buildStamp=`date -u '+%Y-%m-%d.%H:%M:%S'` -X github.com/status-im/status-go/params.VersionMeta=$(GIT_COMMIT)'")
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+GIT_LOCAL  := $(git rev-parse @)
+GIT_REMOTE := $(git rev-parse origin)
 
 BUILD_FLAGS ?= $(shell echo "-ldflags '-X main.buildStamp=`date -u '+%Y-%m-%d.%H:%M:%S'` -X github.com/status-im/status-go/params.VersionMeta=$(GIT_COMMIT)'")
 
@@ -151,6 +153,10 @@ push-docker-images: docker-image bootnode-image
 push-docker-images-latest: docker-image bootnode-image
 ifneq ("$(GIT_BRANCH)", "develop")
 	echo "You should only use develop branch to push the latest tag!"
+	exit 1
+endif
+ifneq ("$(GIT_LOCAL)", "$(GIT_REMOTE)")
+	echo "The local git commit does not match the remote origin!"
 	exit 1
 endif
 	docker push $(BOOTNODE_IMAGE_NAME):latest 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ endif
 CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
 BUILD_FLAGS ?= $(shell echo "-ldflags '-X main.buildStamp=`date -u '+%Y-%m-%d.%H:%M:%S'` -X github.com/status-im/status-go/params.VersionMeta=$(GIT_COMMIT)'")
 
@@ -145,8 +146,14 @@ bootnode-image:
 
 push-docker-images: docker-image bootnode-image
 	docker push $(BOOTNODE_IMAGE_NAME):$(DOCKER_IMAGE_CUSTOM_TAG)
-	docker push $(BOOTNODE_IMAGE_NAME):latest 
 	docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_CUSTOM_TAG)
+
+push-docker-images-latest: docker-image bootnode-image
+ifneq ("$(GIT_BRANCH)", "develop")
+	echo "You should only use develop branch to push the latest tag!"
+	exit 1
+endif
+	docker push $(BOOTNODE_IMAGE_NAME):latest 
 	docker push $(DOCKER_IMAGE_NAME):latest
 
 xgo-docker-images: ##@docker Build xgo docker images


### PR DESCRIPTION
Since we want to pull docker images for the cluster based on commit hardcoded into Ansible configuration(for now) we need to make sure that images pushed to Docker Hub are always tagges with the commit as well.