### PR TITLE
test leveldb panics on mailserver

### DIFF
--- a/mailserver/cleaner.go
+++ b/mailserver/cleaner.go
@@ -11,12 +11,12 @@ const batchSize = 1000
 
 // Cleaner removes old messages from a db
 type Cleaner struct {
-	db        DB
+	db        dbImpl
 	batchSize int
 }
 
 // NewCleanerWithDB returns a new Cleaner for db
-func NewCleanerWithDB(db DB) *Cleaner {
+func NewCleanerWithDB(db dbImpl) *Cleaner {
 	return &Cleaner{
 		db:        db,
 		batchSize: batchSize,

--- a/mailserver/cleaner.go
+++ b/mailserver/cleaner.go
@@ -11,12 +11,12 @@ const batchSize = 1000
 
 // Cleaner removes old messages from a db
 type Cleaner struct {
-	db        *leveldb.DB
+	db        DB
 	batchSize int
 }
 
 // NewCleanerWithDB returns a new Cleaner for db
-func NewCleanerWithDB(db *leveldb.DB) *Cleaner {
+func NewCleanerWithDB(db DB) *Cleaner {
 	return &Cleaner{
 		db:        db,
 		batchSize: batchSize,

--- a/mailserver/cleaner_test.go
+++ b/mailserver/cleaner_test.go
@@ -95,7 +95,7 @@ func testMessagesCount(t *testing.T, expected int, s *WMailServer) {
 	require.Equal(t, expected, count, fmt.Sprintf("expected %d message, got: %d", expected, count))
 }
 
-func countMessages(t *testing.T, db *leveldb.DB) int {
+func countMessages(t *testing.T, db DB) int {
 	var (
 		count int
 		zero  common.Hash

--- a/mailserver/cleaner_test.go
+++ b/mailserver/cleaner_test.go
@@ -95,7 +95,7 @@ func testMessagesCount(t *testing.T, expected int, s *WMailServer) {
 	require.Equal(t, expected, count, fmt.Sprintf("expected %d message, got: %d", expected, count))
 }
 
-func countMessages(t *testing.T, db DB) int {
+func countMessages(t *testing.T, db dbImpl) int {
 	var (
 		count int
 		zero  common.Hash

--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -55,7 +55,13 @@ var (
 	archivedErrorsCounter  = metrics.NewRegisteredCounter("mailserver/archiveErrors", nil)
 )
 
-type DB interface {
+// dbImpl is an interface introduced to be able to test some unexpected
+// panics from leveldb that are difficult to reproduce.
+// normally the db implementation is leveldb.DB, but in TestMailServerDBPanicSuite
+// we use panicDB to test panics from the db.
+// more info about the panic errors:
+// https://github.com/syndtr/goleveldb/issues/224
+type dbImpl interface {
 	Close() error
 	Write(*leveldb.Batch, *opt.WriteOptions) error
 	Put([]byte, []byte, *opt.WriteOptions) error
@@ -65,7 +71,7 @@ type DB interface {
 
 // WMailServer whisper mailserver.
 type WMailServer struct {
-	db    DB
+	db    dbImpl
 	w     *whisper.Whisper
 	pow   float64
 	key   []byte

--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -245,9 +245,7 @@ func (s *WMailServer) processRequest(peer *whisper.Peer, lower, upper uint32, bl
 	// Recover from possible goleveldb panics
 	defer func() {
 		if r := recover(); r != nil {
-			if errString, ok := r.(string); ok {
-				err = fmt.Errorf("recovered from panic in processRequest: %s", errString)
-			}
+			err = fmt.Errorf("recovered from panic in processRequest: %v", r)
 		}
 	}()
 
@@ -269,6 +267,7 @@ func (s *WMailServer) processRequest(peer *whisper.Peer, lower, upper uint32, bl
 		decodeErr := rlp.DecodeBytes(i.Value(), &envelope)
 		if decodeErr != nil {
 			log.Error(fmt.Sprintf("RLP decoding failed: %s", decodeErr))
+			continue
 		}
 
 		if whisper.BloomFilterMatch(bloom, envelope.Bloom()) {

--- a/mailserver/mailserver_db_panic_test.go
+++ b/mailserver/mailserver_db_panic_test.go
@@ -1,0 +1,66 @@
+package mailserver
+
+import (
+	"testing"
+
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
+	"github.com/stretchr/testify/suite"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+type panicDB struct{}
+
+func (db *panicDB) Close() error {
+	panic("panicDB panic on Close")
+}
+
+func (db *panicDB) Write(b *leveldb.Batch, opts *opt.WriteOptions) error {
+	panic("panicDB panic on Write")
+}
+
+func (db *panicDB) Put(k []byte, v []byte, opts *opt.WriteOptions) error {
+	panic("panicDB panic on Put")
+}
+
+func (db *panicDB) Get(k []byte, opts *opt.ReadOptions) ([]byte, error) {
+	panic("panicDB panic on Get")
+}
+
+func (db *panicDB) NewIterator(r *util.Range, opts *opt.ReadOptions) iterator.Iterator {
+	panic("panicDB panic on Get")
+}
+
+func TestMailServerDBPanicSuite(t *testing.T) {
+	suite.Run(t, new(MailServerDBPanicSuite))
+}
+
+type MailServerDBPanicSuite struct {
+	suite.Suite
+	server *WMailServer
+}
+
+func (s *MailServerDBPanicSuite) SetupTest() {
+	s.server = &WMailServer{}
+	s.server.db = &panicDB{}
+}
+
+func (s *MailServerDBPanicSuite) TestArchive() {
+	defer s.testPanicRecover("Archive")
+	s.server.Archive(&whisper.Envelope{})
+}
+
+func (s *MailServerDBPanicSuite) TestDeliverMail() {
+	defer s.testPanicRecover("DeliverMail")
+	_, err := s.server.processRequest(nil, 10, 20, []byte{})
+	s.Error(err)
+	s.Equal("recovered from panic in processRequest: panicDB panic on Get", err.Error())
+}
+
+func (s *MailServerDBPanicSuite) testPanicRecover(method string) {
+	if r := recover(); r != nil {
+		s.Failf("error recovering panic", "expected recover to return nil, got: %+v", r)
+	}
+}

--- a/mailserver/mailserver_db_panic_test.go
+++ b/mailserver/mailserver_db_panic_test.go
@@ -30,7 +30,7 @@ func (db *panicDB) Get(k []byte, opts *opt.ReadOptions) ([]byte, error) {
 }
 
 func (db *panicDB) NewIterator(r *util.Range, opts *opt.ReadOptions) iterator.Iterator {
-	panic("panicDB panic on Get")
+	panic("panicDB panic on NewIterator")
 }
 
 func TestMailServerDBPanicSuite(t *testing.T) {
@@ -56,7 +56,7 @@ func (s *MailServerDBPanicSuite) TestDeliverMail() {
 	defer s.testPanicRecover("DeliverMail")
 	_, err := s.server.processRequest(nil, 10, 20, []byte{})
 	s.Error(err)
-	s.Equal("recovered from panic in processRequest: panicDB panic on Get", err.Error())
+	s.Equal("recovered from panic in processRequest: panicDB panic on NewIterator", err.Error())
 }
 
 func (s *MailServerDBPanicSuite) testPanicRecover(method string) {

--- a/mailserver/mailserver_test.go
+++ b/mailserver/mailserver_test.go
@@ -251,7 +251,8 @@ func (s *MailserverSuite) TestMailServer() {
 
 func (s *MailserverSuite) messageExists(envelope *whisper.Envelope, low, upp uint32, bloom []byte) bool {
 	var exist bool
-	mail := s.server.processRequest(nil, low, upp, bloom)
+	mail, err := s.server.processRequest(nil, low, upp, bloom)
+	s.NoError(err)
 	for _, msg := range mail {
 		if msg.Hash() == envelope.Hash() {
 			exist = true


### PR DESCRIPTION
In the last days we had some error that were crashing the mailserver. In a PR (#1061) already merged we added a `recover` function to recover the panics.
This PR adds some tests on those recover functions. They act also as regression tests to ensure we don't break it again in the future. 

# Changes

* `db` in Mailserver is now an interface so that we can easily test a panic. Otherwise it's very difficult to reproduce. More info on the leveldb error are here https://github.com/syndtr/goleveldb/issues/224
* added an `error` return value in `processRequest` to easily test that function without passing from `DeliverMail`, which needs a `whisper.Peer`. It also follows the other unit test that skip `DeliverMail` and test `processRequest` directly.

Closes #1063 
