### PR TITLE
update mailserver tests to write to a temporary directory instead of using /tmp

### DIFF
--- a/mailserver/mailserver_test.go
+++ b/mailserver/mailserver_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -46,26 +47,45 @@ type ServerTestParams struct {
 	key   *ecdsa.PrivateKey
 }
 
+const dataDirPrefix = "whisper-server-test"
+
 func TestMailserverSuite(t *testing.T) {
 	suite.Run(t, new(MailserverSuite))
 }
 
 type MailserverSuite struct {
 	suite.Suite
-	server *WMailServer
-	shh    *whisper.Whisper
-	config *params.WhisperConfig
+	server  *WMailServer
+	shh     *whisper.Whisper
+	config  *params.WhisperConfig
+	dataDir string
 }
 
 func (s *MailserverSuite) SetupTest() {
 	s.server = &WMailServer{}
 	s.shh = whisper.New(&whisper.DefaultConfig)
 	s.shh.RegisterServer(s.server)
+
+	var err error
+	s.dataDir, err = ioutil.TempDir("/tmp", dataDirPrefix)
+	if err != nil {
+		s.FailNow("failed creating tmp data dir", err)
+	}
+
 	s.config = &params.WhisperConfig{
-		DataDir:             "/tmp/",
+		DataDir:             s.dataDir,
 		Password:            "pwd",
 		MailServerRateLimit: 5,
 	}
+}
+
+func (s *MailserverSuite) TearDownTest() {
+	if s.dataDir != "" {
+		if err := os.RemoveAll(s.dataDir); err != nil {
+			fmt.Printf("couldn't remove temporary data dir %s: %v", s.dataDir, err)
+		}
+	}
+
 }
 
 func (s *MailserverSuite) TestInit() {
@@ -82,7 +102,7 @@ func (s *MailserverSuite) TestInit() {
 			info:          "Initializing a mail server with a config with empty DataDir",
 		},
 		{
-			config:        params.WhisperConfig{DataDir: "/tmp/", Password: ""},
+			config:        params.WhisperConfig{DataDir: s.dataDir, Password: ""},
 			expectedError: errPasswordNotProvided,
 			limiterActive: false,
 			info:          "Initializing a mail server with a config with an empty password",
@@ -101,7 +121,7 @@ func (s *MailserverSuite) TestInit() {
 		},
 		{
 			config: params.WhisperConfig{
-				DataDir:  "/tmp/",
+				DataDir:  s.dataDir,
 				Password: "pwd",
 			},
 			expectedError: nil,
@@ -300,17 +320,11 @@ func (s *MailserverSuite) TestBloomFromReceivedMessage() {
 
 func (s *MailserverSuite) setupServer(server *WMailServer) {
 	const password = "password_for_this_test"
-	const dbPath = "whisper-server-test"
-
-	dir, err := ioutil.TempDir("", dbPath)
-	if err != nil {
-		s.T().Fatal(err)
-	}
 
 	s.shh = whisper.New(&whisper.DefaultConfig)
 	s.shh.RegisterServer(server)
 
-	err = server.Init(s.shh, &params.WhisperConfig{DataDir: dir, Password: password, MinimumPoW: powRequirement})
+	err := server.Init(s.shh, &params.WhisperConfig{DataDir: s.dataDir, Password: password, MinimumPoW: powRequirement})
 	if err != nil {
 		s.T().Fatal(err)
 	}


### PR DESCRIPTION
`MailserverSuite/TestInit` is always using `/tmp` as `DataDir`, so `leveldb` uses the same db files everytime. 
If for some reason `/tmp/MANIFEST` is not found, but other `leveldb` files are still in `tmp`, the tests fail with:

`errors.errorString(&errors.errorString{s:"open DB: file missing [file=MANIFEST-000000]"})`

# Steps to reproduce the error

```
git checkout develop
cd mailserver
go test # should work without problems
rm /tmp/MANIFEST-000013 # the number suffix can be different
go test # should panic
```

# Changes

In this PR we create a different temporary path for each test using `ioutil.TempDir("/tmp", dataDirPrefix)`.

The temporary folder is also removed in the `TearDownTest` method.
