### PR TITLE
Centralize leveldb.OpenFile calls under `db` package

### DIFF
--- a/cmd/statusd-prune/main.go
+++ b/cmd/statusd-prune/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/status-im/status-go/db"
 	"github.com/status-im/status-go/mailserver"
-	"github.com/syndtr/goleveldb/leveldb"
 )
 
 var (
@@ -47,7 +47,7 @@ func init() {
 }
 
 func main() {
-	db, err := leveldb.OpenFile(*dbPath, nil)
+	db, err := db.Open(*dbPath, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -45,14 +45,15 @@ func Create(path, dbName string) (*leveldb.DB, error) {
 	}
 
 	path = filepath.Join(path, dbName)
-	opts := &opt.Options{OpenFilesCacheCapacity: 5}
-	db, err := leveldb.OpenFile(path, opts)
+	return Open(path, &opt.Options{OpenFilesCacheCapacity: 5})
+}
+
+// Open opens an existing leveldb database
+func Open(path string, opts *opt.Options) (db *leveldb.DB, err error) {
+	db, err = leveldb.OpenFile(path, opts)
 	if _, iscorrupted := err.(*errors.ErrCorrupted); iscorrupted {
 		log.Info("database is corrupted trying to recover", "path", path)
 		db, err = leveldb.RecoverFile(path, nil)
 	}
-	if err != nil {
-		return nil, err
-	}
-	return db, err
+	return
 }

--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rlp"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
+	"github.com/status-im/status-go/db"
 	"github.com/status-im/status-go/params"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
@@ -110,7 +111,7 @@ func (s *WMailServer) Init(shh *whisper.Whisper, config *params.WhisperConfig) e
 		return errPasswordNotProvided
 	}
 
-	db, err := leveldb.OpenFile(config.DataDir, nil)
+	db, err := db.Open(config.DataDir, nil)
 	if err != nil {
 		return fmt.Errorf("open DB: %s", err)
 	}


### PR DESCRIPTION
Even we have some shared functions to manage leveldb connections under `db` package, we're using `leveldb.Openfile` every time.
Using the functions provided by db package we will be able to manage possible corrupted files, and still be able to open it, or at least leave a log.

Important changes:
- [x] Split `db.Create` method on `db.Create` and `db.Open`
- [x] Changed calls to `leveldb.OpenFile` by `db.Open`
