### PR TITLE
Update to golangci-lint 1.8.1. Get rid of standalong misspell linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,16 +56,16 @@ linters:
     - ineffassign
     - interfacer
     - megacheck
-    #- misspell
+    - misspell
     - structcheck
     - typecheck
     - unconvert
     - varcheck
   fast: false
 
-# issues:
-#   exclude:
-#     - abcdef
+issues:
+  exclude:
+    - "composite literal uses unkeyed fields" # govet
 #   exclude-use-default: true
 #   max-per-linter: 0
 #   max-same: 0

--- a/Makefile
+++ b/Makefile
@@ -195,14 +195,12 @@ test-e2e-race: gotest_extraflags=-race
 test-e2e-race: test-e2e ##@tests Run e2e tests with -race flag
 
 lint-install:
-	go get -u github.com/client9/misspell/cmd/misspell
 	@# The following installs a specific version of golangci-lint, which is appropriate for a CI server to avoid different results from build to build
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $(GOPATH)/bin v1.6.1
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $(GOPATH)/bin v1.9.1
 
 lint:
 	@echo "lint"
 	@golangci-lint run ./...
-	@find . -type f -not -path "./.ethereumtest/*" -not -path "./vendor/*" -not -path "./extkeys/mnemonic.go" -not -path "./extkeys/mnemonic_vectors.json" -print0 | xargs -0 misspell
 
 ci: lint mock dep-ensure test-unit test-e2e ##@tests Run all linters and tests at once
 


### PR DESCRIPTION
For some reason `govet` is complaining about missing `lib/C` and `signal/C` folders. The workaround here was to ignore any subfolders of those 2 folders, but alternatively we could run the linter once for govet (without those folders) and a second time for the rest (although we'd lose some performance gains by doing that). 