### PR TITLE
Add goroutines count to geth metrics

### DIFF
--- a/_assets/patches/geth/0035-add_goroutines_metrics.patch
+++ b/_assets/patches/geth/0035-add_goroutines_metrics.patch
@@ -1,0 +1,23 @@
+diff --git a/metrics/metrics.go b/metrics/metrics.go
+index 2356f2b1..802f1363 100644
+--- a/metrics/metrics.go
++++ b/metrics/metrics.go
+@@ -56,6 +56,7 @@ func CollectProcessMetrics(refresh time.Duration) {
+ 	memFrees := GetOrRegisterMeter("system/memory/frees", DefaultRegistry)
+ 	memInuse := GetOrRegisterMeter("system/memory/inuse", DefaultRegistry)
+ 	memPauses := GetOrRegisterMeter("system/memory/pauses", DefaultRegistry)
++	goroutines := GetOrRegisterGauge("system/goroutines", DefaultRegistry)
+ 
+ 	var diskReads, diskReadBytes, diskWrites, diskWriteBytes Meter
+ 	if err := ReadDiskStats(diskstats[0]); err == nil {
+@@ -83,6 +84,10 @@ func CollectProcessMetrics(refresh time.Duration) {
+ 			diskWrites.Mark(diskstats[location1].WriteCount - diskstats[location2].WriteCount)
+ 			diskWriteBytes.Mark(diskstats[location1].WriteBytes - diskstats[location2].WriteBytes)
+ 		}
++
++		goroutines.Update(int64(runtime.NumGoroutine()))
++
+ 		time.Sleep(refresh)
+ 	}
++
+ }

--- a/vendor/github.com/ethereum/go-ethereum/metrics/metrics.go
+++ b/vendor/github.com/ethereum/go-ethereum/metrics/metrics.go
@@ -56,6 +56,7 @@ func CollectProcessMetrics(refresh time.Duration) {
 	memFrees := GetOrRegisterMeter("system/memory/frees", DefaultRegistry)
 	memInuse := GetOrRegisterMeter("system/memory/inuse", DefaultRegistry)
 	memPauses := GetOrRegisterMeter("system/memory/pauses", DefaultRegistry)
+	goroutines := GetOrRegisterGauge("system/goroutines", DefaultRegistry)
 
 	var diskReads, diskReadBytes, diskWrites, diskWriteBytes Meter
 	if err := ReadDiskStats(diskstats[0]); err == nil {
@@ -83,6 +84,10 @@ func CollectProcessMetrics(refresh time.Duration) {
 			diskWrites.Mark(diskstats[location1].WriteCount - diskstats[location2].WriteCount)
 			diskWriteBytes.Mark(diskstats[location1].WriteBytes - diskstats[location2].WriteBytes)
 		}
+
+		goroutines.Update(int64(runtime.NumGoroutine()))
+
 		time.Sleep(refresh)
 	}
+
 }


### PR DESCRIPTION
This PR adds goroutines to the metrics exported by geth. It will be available as "system/goroutines" and updated at the same interval as memstats metrics.

Prometherus exporter(`geth_exporter`) will pick up this automatically and metrics will be available as `geth_system_goroutines_value`.