### PR TITLE
use envelopeFeed to wait for envelopes to be available in tests

### DIFF
--- a/t/e2e/whisper/whisper_mailbox_test.go
+++ b/t/e2e/whisper/whisper_mailbox_test.go
@@ -85,15 +85,18 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 
 	// watch envelopes to be archived on mailserver
 	envelopeArchivedWatcher := make(chan whisper.EnvelopeEvent, 1024)
-	mailboxWhisperService.SubscribeEnvelopeEvents(envelopeArchivedWatcher)
+	sub := mailboxWhisperService.SubscribeEnvelopeEvents(envelopeArchivedWatcher)
+	defer sub.Unsubscribe()
 
 	// watch envelopes to be available for filters in the client
 	envelopeAvailableWatcher := make(chan whisper.EnvelopeEvent, 1024)
-	senderWhisperService.SubscribeEnvelopeEvents(envelopeAvailableWatcher)
+	sub = senderWhisperService.SubscribeEnvelopeEvents(envelopeAvailableWatcher)
+	defer sub.Unsubscribe()
 
 	// watch mailserver responses in the client
 	mailServerResponseWatcher := make(chan whisper.EnvelopeEvent, 1024)
-	senderWhisperService.SubscribeEnvelopeEvents(mailServerResponseWatcher)
+	sub = senderWhisperService.SubscribeEnvelopeEvents(mailServerResponseWatcher)
+	defer sub.Unsubscribe()
 
 	// Create topic.
 	topic := whisper.BytesToTopic([]byte("topic name"))
@@ -197,13 +200,16 @@ func (s *WhisperMailboxSuite) TestRequestMessagesInGroupChat() {
 
 	// watchers
 	envelopeArchivedWatcher := make(chan whisper.EnvelopeEvent, 1024)
-	mailboxWhisperService.SubscribeEnvelopeEvents(envelopeArchivedWatcher)
+	sub := mailboxWhisperService.SubscribeEnvelopeEvents(envelopeArchivedWatcher)
+	defer sub.Unsubscribe()
 
 	bobEnvelopeAvailableWatcher := make(chan whisper.EnvelopeEvent, 1024)
-	bobWhisperService.SubscribeEnvelopeEvents(bobEnvelopeAvailableWatcher)
+	sub = bobWhisperService.SubscribeEnvelopeEvents(bobEnvelopeAvailableWatcher)
+	defer sub.Unsubscribe()
 
 	charlieEnvelopeAvailableWatcher := make(chan whisper.EnvelopeEvent, 1024)
-	charlieWhisperService.SubscribeEnvelopeEvents(charlieEnvelopeAvailableWatcher)
+	sub = charlieWhisperService.SubscribeEnvelopeEvents(charlieEnvelopeAvailableWatcher)
+	defer sub.Unsubscribe()
 
 	// Bob and charlie add the mailserver key.
 	password := mailboxPassword
@@ -370,15 +376,18 @@ func (s *WhisperMailboxSuite) TestRequestMessagesWithPagination() {
 
 	// watch envelopes to be archived on mailserver
 	envelopeArchivedWatcher := make(chan whisper.EnvelopeEvent, 1024)
-	mailboxWhisperService.SubscribeEnvelopeEvents(envelopeArchivedWatcher)
+	sub := mailboxWhisperService.SubscribeEnvelopeEvents(envelopeArchivedWatcher)
+	defer sub.Unsubscribe()
 
 	// watch envelopes to be available for filters in the client
 	envelopeAvailableWatcher := make(chan whisper.EnvelopeEvent, 1024)
-	clientWhisperService.SubscribeEnvelopeEvents(envelopeAvailableWatcher)
+	sub = clientWhisperService.SubscribeEnvelopeEvents(envelopeAvailableWatcher)
+	defer sub.Unsubscribe()
 
 	// watch mailserver responses in the client
 	mailServerResponseWatcher := make(chan whisper.EnvelopeEvent, 1024)
-	clientWhisperService.SubscribeEnvelopeEvents(mailServerResponseWatcher)
+	sub = clientWhisperService.SubscribeEnvelopeEvents(mailServerResponseWatcher)
+	defer sub.Unsubscribe()
 
 	// send envelopes
 	for i := 0; i < envelopesCount; i++ {

--- a/t/e2e/whisper/whisper_mailbox_test.go
+++ b/t/e2e/whisper/whisper_mailbox_test.go
@@ -195,13 +195,6 @@ func (s *WhisperMailboxSuite) TestRequestMessagesInGroupChat() {
 	bobRPCClient := bobBackend.StatusNode().RPCClient()
 	charlieRPCClient := charlieBackend.StatusNode().RPCClient()
 
-	aliceTracer := newTracer()
-	aliceWhisperService.RegisterEnvelopeTracer(aliceTracer)
-	bobTracer := newTracer()
-	bobWhisperService.RegisterEnvelopeTracer(bobTracer)
-	charlieTracer := newTracer()
-	charlieWhisperService.RegisterEnvelopeTracer(charlieTracer)
-
 	// watchers
 	envelopeArchivedWatcher := make(chan whisper.EnvelopeEvent, 1024)
 	mailboxWhisperService.SubscribeEnvelopeEvents(envelopeArchivedWatcher)
@@ -801,20 +794,4 @@ type returnedIDResponse struct {
 type baseRPCResponse struct {
 	Result interface{}
 	Error  interface{}
-}
-
-// envelopeTracer traces incoming envelopes. We leverage it to know when a peer has received an envelope
-// so we rely less on timeouts for the tests
-type envelopeTracer struct {
-	envelopChan chan *whisper.EnvelopeMeta
-}
-
-func newTracer() *envelopeTracer {
-	return &envelopeTracer{make(chan *whisper.EnvelopeMeta, 1)}
-}
-
-// Trace is called for every incoming envelope.
-func (t *envelopeTracer) Trace(envelope *whisper.EnvelopeMeta) {
-	// Do not block notifier
-	go func() { t.envelopChan <- envelope }()
 }


### PR DESCRIPTION
# Problem

Even if an envelope has been received, it can be still not available for filters, for this reason `TestWhisperMailboxTestSuite/TestRequestMessagesInGroupChat` is trying multiple time to get messages calling `getMessagesByMessageFilterID`.

# Changes

Instead of retrying multiple times, I'm using a recently added event `EventEnvelopeAvailable` to be sure that the envelope is available for filters.

I also added `WaitForPeerAsync` instead of sleeping after adding a peer.