### PR TITLE
add missing ENTRYPOINT for status-go image

### DIFF
--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -16,6 +16,10 @@ RUN cd /go/src/github.com/status-im/status-go && \
 # Copy the binary to the second image
 FROM alpine:latest
 
+LABEL source="https://github.com/status-im/status-go"
+LABEL description="status-go is an underlying part of Status - a browser, messenger, and gateway to a decentralized world."
+LABEL maintainer="support@status.im"
+
 RUN apk add --no-cache ca-certificates bash
 
 COPY --from=builder /go/src/github.com/status-im/status-go/build/bin/statusd /usr/local/bin/
@@ -25,3 +29,5 @@ COPY --from=builder /go/src/github.com/status-im/status-go/static/keys/* /static
 
 # 30304 is used for Discovery v5
 EXPOSE 8080 8545 30303 30303/udp 30304/udp
+
+ENTRYPOINT /usr/local/bin/statusd


### PR DESCRIPTION
Small fix for our status-go image. Adding an `ENTRYPOINT` of `/usr/local/bin/statusd` and some labels for clarity.