### PR TITLE
Enforce isolation between different buckets and topics

### DIFF
--- a/peers/cache.go
+++ b/peers/cache.go
@@ -39,7 +39,9 @@ func (d *Cache) RemovePeer(peerID discv5.NodeID, topic discv5.Topic) error {
 // GetPeersRange returns peers for a given topic with a limit.
 func (d *Cache) GetPeersRange(topic discv5.Topic, limit int) (nodes []*discv5.Node) {
 	key := db.Key(db.PeersCache, []byte(topic))
-	iterator := d.db.NewIterator(&util.Range{Start: key}, nil)
+	// it is important to set Limit on the range passed to iterator, so that
+	// we limit reads only to particular topic.
+	iterator := d.db.NewIterator(util.BytesPrefix(key), nil)
 	defer iterator.Release()
 	count := 0
 	for iterator.Next() && count < limit {


### PR DESCRIPTION
Without a limit leveldb will continue looping over records from different topics and eventually from other buckets as well.

For example: we want our query to contain only topic with 0x01, but we also have records with topic 0x02 - without a range limit we will loop over all of them and break isolation. Since we will now use multiple topics it is important to fix earlier.

Also possible to break bucket isolation (at the moment we have 2, 0x00 bucket is used for enode records and 0x01 for messages records). Since we were not using a limit it was possible to read records from message bucket and try to parse them. It doesn't lead to any serious problems, but it explains those warnings reported by @cammellos 

Fix uses utility provided by leveldb library that sets a limit to prefix with incremented last byte (which is not 255).