### PR TITLE
fix ENTRYPOINT syntax and add CMD for easier use by new people

### DIFF
--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -30,4 +30,5 @@ COPY --from=builder /go/src/github.com/status-im/status-go/static/keys/* /static
 # 30304 is used for Discovery v5
 EXPOSE 8080 8545 30303 30303/udp 30304/udp
 
-ENTRYPOINT /usr/local/bin/statusd
+ENTRYPOINT ["/usr/local/bin/statusd"]
+CMD ["--help"]


### PR DESCRIPTION
Based of off comments from @adambabik in https://github.com/status-im/status-go/pull/1084#issuecomment-404107767 and some discussion in Slack.
This will make it easier to start using the image by someone new to it rather than setting some default options in `CMD`.