### PR TITLE
Remove PendingSignRequests queue from Transactor

### DIFF
--- a/lib/library.go
+++ b/lib/library.go
@@ -16,6 +16,7 @@ import (
 	"github.com/status-im/status-go/services/personal"
 	"github.com/status-im/status-go/sign"
 	"github.com/status-im/status-go/signal"
+	"github.com/status-im/status-go/transactions"
 	"gopkg.in/go-playground/validator.v9"
 )
 
@@ -255,12 +256,23 @@ func Recover(rpcParams *C.char) *C.char {
 	return prepareSignResponse(result)
 }
 
+// SendTransaction converts RPC args and calls backend.SendTransaction
+// nolint: deadcode
+func SendTransaction(txArgsJSON, password *C.char) *C.char {
+	txArgs, err := transactions.UnmarshalSendTxRPCParams(C.GoString(txArgsJSON))
+	if err != nil {
+		return prepareSignResponse(sign.NewErrResult(err))
+	}
+	result := statusBackend.SendTransaction(txArgs, C.GoString(password))
+	return prepareSignResponse(result)
+}
+
 // prepareSignResponse based on a sign.Result prepares the binding
 // response.
 func prepareSignResponse(result sign.Result) *C.char {
 	errString := ""
 	if result.Error != nil {
-		fmt.Fprintln(os.Stderr, result.Error)
+		logger.Error("Sign result contains error", "error", result.Error)
 		errString = result.Error.Error()
 	}
 

--- a/lib/library_test_utils.go
+++ b/lib/library_test_utils.go
@@ -11,7 +11,6 @@ package main
 
 import "C"
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -21,7 +20,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -127,20 +125,12 @@ func testExportedAPI(t *testing.T, done chan struct{}) {
 			testAccountLogout,
 		},
 		{
-			"complete single queued transaction",
+			"complete single transaction",
 			testCompleteTransaction,
 		},
 		{
-			"test complete multiple queued transactions",
-			testCompleteMultipleQueuedTransactions,
-		},
-		{
-			"discard single queued transaction",
-			testDiscardTransaction,
-		},
-		{
-			"test discard multiple queued transactions",
-			testDiscardMultipleQueuedTransactions,
+			"failed single transaction",
+			testFailedTransaction,
 		},
 	}
 
@@ -777,7 +767,6 @@ func testAccountLogout(t *testing.T) bool {
 }
 
 func testCompleteTransaction(t *testing.T) bool {
-	signRequests := statusBackend.PendingSignRequests()
 
 	EnsureNodeSync(statusBackend.StatusNode().EnsureSync)
 
@@ -787,487 +776,53 @@ func testCompleteTransaction(t *testing.T) bool {
 		return false
 	}
 
-	// make sure you panic if transaction complete doesn't return
-	queuedTxCompleted := make(chan struct{}, 1)
-	abortPanic := make(chan struct{}, 1)
-	PanicAfter(10*time.Second, abortPanic, "testCompleteTransaction")
-
-	// replace transaction notification handler
-	var txHash = ""
-	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
-		var envelope signal.Envelope
-		if err := json.Unmarshal([]byte(jsonEvent), &envelope); err != nil {
-			t.Errorf("cannot unmarshal event's JSON: %s. Error %q", jsonEvent, err)
-			return
-		}
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			t.Logf("transaction queued (will be completed shortly): {id: %s}\n", event["id"].(string))
-
-			completeTxResponse := SignRequestResult{}
-			rawResponse := ApproveSignRequest(C.CString(event["id"].(string)), C.CString(TestConfig.Account1.Password))
-
-			if err := json.Unmarshal([]byte(C.GoString(rawResponse)), &completeTxResponse); err != nil {
-				t.Errorf("cannot decode RecoverAccount response (%s): %v", C.GoString(rawResponse), err)
-			}
-
-			if completeTxResponse.Error != "" {
-				t.Errorf("cannot complete queued transaction[%v]: %v", event["id"], completeTxResponse.Error)
-			}
-
-			txHash = completeTxResponse.Hash
-
-			t.Logf("transaction complete: https://testnet.etherscan.io/tx/%s", txHash)
-			abortPanic <- struct{}{} // so that timeout is aborted
-			queuedTxCompleted <- struct{}{}
-		}
-	})
-
 	// this call blocks, up until Complete Transaction is called
-	txCheckHash, err := statusBackend.SendTransaction(context.TODO(), transactions.SendTxArgs{
+	result := statusBackend.SendTransaction(transactions.SendTxArgs{
 		From:  account.FromAddress(TestConfig.Account1.Address),
 		To:    account.ToAddress(TestConfig.Account2.Address),
 		Value: (*hexutil.Big)(big.NewInt(1000000000000)),
-	})
-	if err != nil {
-		t.Errorf("Failed to SendTransaction: %s", err)
+	}, TestConfig.Account1.Password)
+	if result.Error != nil {
+		t.Errorf("Failed to SendTransaction: %s", result.Error)
 		return false
 	}
 
-	<-queuedTxCompleted // make sure that complete transaction handler completes its magic, before we proceed
-
-	if txHash != txCheckHash.Hex() {
-		t.Errorf("Transaction hash returned from SendTransaction is invalid: expected %s, got %s",
-			txCheckHash.Hex(), txHash)
-		return false
-	}
-
-	if reflect.DeepEqual(txCheckHash, gethcommon.Hash{}) {
+	if reflect.DeepEqual(result.Response.Hash(), gethcommon.Hash{}) {
 		t.Error("Test failed: transaction was never queued or completed")
 		return false
 	}
 
-	if signRequests.Count() != 0 {
-		t.Error("tx queue must be empty at this point")
-		return false
-	}
-
 	return true
 }
 
-func testCompleteMultipleQueuedTransactions(t *testing.T) bool { //nolint: gocyclo
-	signRequests := statusBackend.PendingSignRequests()
+func testFailedTransaction(t *testing.T) bool {
+	EnsureNodeSync(statusBackend.StatusNode().EnsureSync)
 
-	// log into account from which transactions will be sent
-	if err := statusBackend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password); err != nil {
-		t.Errorf("cannot select account: %v", TestConfig.Account1.Address)
+	// log into wrong account in order to get selectedAccount error
+	if err := statusBackend.SelectAccount(TestConfig.Account2.Address, TestConfig.Account2.Password); err != nil {
+		t.Errorf("cannot select account: %v. Error %q", TestConfig.Account1.Address, err)
 		return false
 	}
 
-	// make sure you panic if transaction complete doesn't return
-	testTxCount := 3
-	txIDs := make(chan string, testTxCount)
-	allTestTxCompleted := make(chan struct{}, 1)
-
-	// replace transaction notification handler
-	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
-		var txID string
-		var envelope signal.Envelope
-		if err := json.Unmarshal([]byte(jsonEvent), &envelope); err != nil {
-			t.Errorf("cannot unmarshal event's JSON: %s", jsonEvent)
-			return
-		}
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			txID = event["id"].(string)
-			t.Logf("transaction queued (will be completed in a single call, once aggregated): {id: %s}\n", txID)
-
-			txIDs <- txID
-		}
-	})
-
-	//  this call blocks, and should return when DiscardQueuedTransaction() for a given tx id is called
-	sendTx := func() {
-		txHashCheck, err := statusBackend.SendTransaction(context.TODO(), transactions.SendTxArgs{
-			From:  account.FromAddress(TestConfig.Account1.Address),
-			To:    account.ToAddress(TestConfig.Account2.Address),
-			Value: (*hexutil.Big)(big.NewInt(1000000000000)),
-		})
-		if err != nil {
-			t.Errorf("unexpected error thrown: %v", err)
-			return
-		}
-
-		if reflect.DeepEqual(txHashCheck, gethcommon.Hash{}) {
-			t.Error("transaction returned empty hash")
-			return
-		}
-	}
-
-	// wait for transactions, and complete them in a single call
-	completeTxs := func(txIDStrings string) {
-		var parsedIDs []string
-		if err := json.Unmarshal([]byte(txIDStrings), &parsedIDs); err != nil {
-			t.Error(err)
-			return
-		}
-
-		parsedIDs = append(parsedIDs, "invalid-tx-id")
-		updatedTxIDStrings, _ := json.Marshal(parsedIDs)
-
-		// complete
-		resultsString := ApproveSignRequests(C.CString(string(updatedTxIDStrings)), C.CString(TestConfig.Account1.Password))
-		resultsStruct := SignRequestsResult{}
-		if err := json.Unmarshal([]byte(C.GoString(resultsString)), &resultsStruct); err != nil {
-			t.Error(err)
-			return
-		}
-		results := resultsStruct.Results
-
-		if len(results) != (testTxCount+1) || results["invalid-tx-id"].Error != sign.ErrSignReqNotFound.Error() {
-			t.Errorf("cannot complete txs: %v", results)
-			return
-		}
-		for txID, txResult := range results {
-			if txID != txResult.ID {
-				t.Errorf("tx id not set in result: expected id is %s", txID)
-				return
-			}
-			if txResult.Error != "" && txID != "invalid-tx-id" {
-				t.Errorf("invalid error for %s", txID)
-				return
-			}
-			if txResult.Hash == zeroHash && txID != "invalid-tx-id" {
-				t.Errorf("invalid hash (expected non empty hash): %s", txID)
-				return
-			}
-
-			if txResult.Hash != zeroHash {
-				t.Logf("transaction complete: https://testnet.etherscan.io/tx/%s", txResult.Hash)
-			}
-		}
-
-		time.Sleep(1 * time.Second) // make sure that tx complete signal propagates
-		for _, txID := range parsedIDs {
-			if signRequests.Has(string(txID)) {
-				t.Errorf("txqueue should not have test tx at this point (it should be completed): %s", txID)
-				return
-			}
-		}
-	}
-	go func() {
-		var txIDStrings []string
-		for i := 0; i < testTxCount; i++ {
-			txIDStrings = append(txIDStrings, <-txIDs)
-		}
-
-		txIDJSON, _ := json.Marshal(txIDStrings)
-		completeTxs(string(txIDJSON))
-		allTestTxCompleted <- struct{}{}
-	}()
-
-	// send multiple transactions
-	for i := 0; i < testTxCount; i++ {
-		go sendTx()
-	}
-
-	select {
-	case <-allTestTxCompleted:
-		// pass
-	case <-time.After(20 * time.Second):
-		t.Error("test timed out")
-		return false
-	}
-
-	if signRequests.Count() != 0 {
-		t.Error("tx queue must be empty at this point")
-		return false
-	}
-
-	return true
-}
-
-func testDiscardTransaction(t *testing.T) bool { //nolint: gocyclo
-	signRequests := statusBackend.PendingSignRequests()
-
-	// log into account from which transactions will be sent
-	if err := statusBackend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password); err != nil {
-		t.Errorf("cannot select account: %v", TestConfig.Account1.Address)
-		return false
-	}
-
-	// make sure you panic if transaction complete doesn't return
-	completeQueuedTransaction := make(chan struct{}, 1)
-	PanicAfter(20*time.Second, completeQueuedTransaction, "testDiscardTransaction")
-
-	// replace transaction notification handler
-	var txID string
-	txFailedEventCalled := make(chan struct{})
-	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
-		var envelope signal.Envelope
-		if err := json.Unmarshal([]byte(jsonEvent), &envelope); err != nil {
-			t.Errorf("cannot unmarshal event's JSON: %s", jsonEvent)
-			return
-		}
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			txID = event["id"].(string)
-			t.Logf("transaction queued (will be discarded soon): {id: %s}\n", txID)
-
-			if !signRequests.Has(string(txID)) {
-				t.Errorf("txqueue should still have test tx: %s", txID)
-				return
-			}
-
-			// discard
-			discardResponse := DiscardSignRequestResult{}
-			rawResponse := DiscardSignRequest(C.CString(txID))
-
-			if err := json.Unmarshal([]byte(C.GoString(rawResponse)), &discardResponse); err != nil {
-				t.Errorf("cannot decode RecoverAccount response (%s): %v", C.GoString(rawResponse), err)
-			}
-
-			if discardResponse.Error != "" {
-				t.Errorf("cannot discard tx: %v", discardResponse.Error)
-				return
-			}
-
-			// try completing discarded transaction
-			err := statusBackend.ApproveSignRequest(string(txID), TestConfig.Account1.Password).Error
-			if err != sign.ErrSignReqNotFound {
-				t.Error("expects tx not found, but call to CompleteTransaction succeeded")
-				return
-			}
-
-			if signRequests.Has(string(txID)) {
-				t.Errorf("txqueue should not have test tx at this point (it should be discarded): %s", txID)
-				return
-			}
-
-			completeQueuedTransaction <- struct{}{} // so that timeout is aborted
-		}
-
-		if envelope.Type == signal.EventSignRequestFailed {
-			event := envelope.Event.(map[string]interface{})
-			t.Logf("transaction return event received: %+v\n", event)
-
-			receivedErrMessage := event["error_message"].(string)
-			expectedErrMessage := sign.ErrSignReqDiscarded.Error()
-			if receivedErrMessage != expectedErrMessage {
-				t.Errorf("unexpected error message received: got %v", receivedErrMessage)
-				return
-			}
-
-			receivedErrCode := event["error_code"].(string)
-			if receivedErrCode != strconv.Itoa(sign.SignRequestDiscardedErrorCode) {
-				t.Errorf("unexpected error code received: got %v", receivedErrCode)
-				return
-			}
-
-			close(txFailedEventCalled)
-		}
-	})
-
-	// this call blocks, and should return when DiscardQueuedTransaction() is called
-	txHashCheck, err := statusBackend.SendTransaction(context.TODO(), transactions.SendTxArgs{
+	// this call blocks, up until Complete Transaction is called
+	result := statusBackend.SendTransaction(transactions.SendTxArgs{
 		From:  account.FromAddress(TestConfig.Account1.Address),
 		To:    account.ToAddress(TestConfig.Account2.Address),
 		Value: (*hexutil.Big)(big.NewInt(1000000000000)),
-	})
+	}, TestConfig.Account1.Password)
 
-	select {
-	case <-txFailedEventCalled:
-	case <-time.After(time.Second * 10):
-		t.Error("expected tx failure signal is not received")
+	if result.Error == nil || result.Error.Error() != transactions.ErrInvalidCompleteTxSender.Error() {
+		t.Errorf("Test failed: expected result.Error == ErrInvalidCompleteTxSender, got result.Error=%s", result.Error)
 		return false
 	}
 
-	if err != sign.ErrSignReqDiscarded {
-		t.Errorf("expected error not thrown: %v", err)
-		return false
-	}
-
-	if !reflect.DeepEqual(txHashCheck, gethcommon.Hash{}) {
-		t.Error("transaction returned hash, while it shouldn't")
-		return false
-	}
-
-	if signRequests.Count() != 0 {
-		t.Error("tx queue must be empty at this point")
+	if result.Response != nil {
+		t.Errorf("Test failed: expected result.Response == nil")
 		return false
 	}
 
 	return true
-}
 
-func testDiscardMultipleQueuedTransactions(t *testing.T) bool { //nolint: gocyclo
-	signRequests := statusBackend.PendingSignRequests()
-
-	// log into account from which transactions will be sent
-	if err := statusBackend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password); err != nil {
-		t.Errorf("cannot select account: %v", TestConfig.Account1.Address)
-		return false
-	}
-
-	// make sure you panic if transaction complete doesn't return
-	testTxCount := 3
-	txIDs := make(chan string, testTxCount)
-
-	var testTxDiscarded sync.WaitGroup
-	testTxDiscarded.Add(testTxCount)
-
-	// replace transaction notification handler
-	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
-		var txID string
-		var envelope signal.Envelope
-		if err := json.Unmarshal([]byte(jsonEvent), &envelope); err != nil {
-			t.Errorf("cannot unmarshal event's JSON: %s", jsonEvent)
-			return
-		}
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			txID = event["id"].(string)
-			t.Logf("transaction queued (will be discarded soon): {id: %s}\n", txID)
-
-			if !signRequests.Has(string(txID)) {
-				t.Errorf("txqueue should still have test tx: %s", txID)
-				return
-			}
-
-			txIDs <- txID
-		}
-
-		if envelope.Type == signal.EventSignRequestFailed {
-			event := envelope.Event.(map[string]interface{})
-			t.Logf("transaction return event received: {id: %s}\n", event["id"].(string))
-
-			receivedErrMessage := event["error_message"].(string)
-			expectedErrMessage := sign.ErrSignReqDiscarded.Error()
-			if receivedErrMessage != expectedErrMessage {
-				t.Errorf("unexpected error message received: got %v", receivedErrMessage)
-				return
-			}
-
-			receivedErrCode := event["error_code"].(string)
-			if receivedErrCode != strconv.Itoa(sign.SignRequestDiscardedErrorCode) {
-				t.Errorf("unexpected error code received: got %v", receivedErrCode)
-				return
-			}
-
-			testTxDiscarded.Done()
-		}
-	})
-
-	// this call blocks, and should return when DiscardQueuedTransaction() for a given tx id is called
-	sendTx := func() {
-		txHashCheck, err := statusBackend.SendTransaction(context.TODO(), transactions.SendTxArgs{
-			From:  account.FromAddress(TestConfig.Account1.Address),
-			To:    account.ToAddress(TestConfig.Account2.Address),
-			Value: (*hexutil.Big)(big.NewInt(1000000000000)),
-		})
-		if err != sign.ErrSignReqDiscarded {
-			t.Errorf("expected error not thrown: %v", err)
-			return
-		}
-
-		if !reflect.DeepEqual(txHashCheck, gethcommon.Hash{}) {
-			t.Error("transaction returned hash, while it shouldn't")
-			return
-		}
-	}
-
-	// wait for transactions, and discard immediately
-	discardTxs := func(txIDStrings string) {
-		var parsedIDs []string
-		if err := json.Unmarshal([]byte(txIDStrings), &parsedIDs); err != nil {
-			t.Error(err)
-			return
-		}
-
-		parsedIDs = append(parsedIDs, "invalid-tx-id")
-		updatedTxIDStrings, _ := json.Marshal(parsedIDs)
-
-		// discard
-		discardResultsString := DiscardSignRequests(C.CString(string(updatedTxIDStrings)))
-		discardResultsStruct := DiscardSignRequestsResult{}
-		if err := json.Unmarshal([]byte(C.GoString(discardResultsString)), &discardResultsStruct); err != nil {
-			t.Error(err)
-			return
-		}
-		discardResults := discardResultsStruct.Results
-
-		if len(discardResults) != 1 || discardResults["invalid-tx-id"].Error != sign.ErrSignReqNotFound.Error() {
-			t.Errorf("cannot discard txs: %v", discardResults)
-			return
-		}
-
-		// try completing discarded transaction
-		completeResultsString := ApproveSignRequests(C.CString(string(updatedTxIDStrings)), C.CString(TestConfig.Account1.Password))
-		completeResultsStruct := SignRequestsResult{}
-		if err := json.Unmarshal([]byte(C.GoString(completeResultsString)), &completeResultsStruct); err != nil {
-			t.Error(err)
-			return
-		}
-		completeResults := completeResultsStruct.Results
-
-		if len(completeResults) != (testTxCount + 1) {
-			t.Error("unexpected number of errors (call to ApproveSignRequest should not succeed)")
-		}
-		for txID, txResult := range completeResults {
-			if txID != txResult.ID {
-				t.Errorf("tx id not set in result: expected id is %s", txID)
-				return
-			}
-			if txResult.Error != sign.ErrSignReqNotFound.Error() {
-				t.Errorf("invalid error for %s", txResult.Hash)
-				return
-			}
-			if txResult.Hash != zeroHash {
-				t.Errorf("invalid hash (expected zero): '%s'", txResult.Hash)
-				return
-			}
-		}
-
-		time.Sleep(1 * time.Second) // make sure that tx complete signal propagates
-		for _, txID := range parsedIDs {
-			if signRequests.Has(string(txID)) {
-				t.Errorf("txqueue should not have test tx at this point (it should be discarded): %s", txID)
-				return
-			}
-		}
-	}
-	go func() {
-		var txIDStrings []string
-		for i := 0; i < testTxCount; i++ {
-			txIDStrings = append(txIDStrings, <-txIDs)
-		}
-
-		txIDJSON, _ := json.Marshal(txIDStrings)
-		discardTxs(string(txIDJSON))
-	}()
-
-	// send multiple transactions
-	for i := 0; i < testTxCount; i++ {
-		go sendTx()
-	}
-
-	done := make(chan struct{})
-	go func() { testTxDiscarded.Wait(); close(done) }()
-
-	select {
-	case <-done:
-		// pass
-	case <-time.After(20 * time.Second):
-		t.Error("test timed out")
-		return false
-	}
-
-	if signRequests.Count() != 0 {
-		t.Error("tx queue must be empty at this point")
-		return false
-	}
-
-	return true
 }
 
 func startTestNode(t *testing.T) <-chan struct{} {

--- a/t/e2e/transactions/transactions_test.go
+++ b/t/e2e/transactions/transactions_test.go
@@ -1,36 +1,21 @@
 package transactions
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
 	"math/big"
 	"reflect"
-	"sync/atomic"
 	"testing"
-	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/sign"
-	"github.com/status-im/status-go/signal"
 	e2e "github.com/status-im/status-go/t/e2e"
 	. "github.com/status-im/status-go/t/utils"
 	"github.com/status-im/status-go/transactions"
 	"github.com/stretchr/testify/suite"
 )
 
-const invalidTxID = "invalid-tx-id"
-
 type initFunc func([]byte, *transactions.SendTxArgs)
-
-func txURLString(result sign.Result) string {
-	return fmt.Sprintf("https://ropsten.etherscan.io/tx/%s", result.Response.Hash().Hex())
-}
 
 func TestTransactionsTestSuite(t *testing.T) {
 	suite.Run(t, new(TransactionsTestSuite))
@@ -51,29 +36,8 @@ func (s *TransactionsTestSuite) TestCallRPCSendTransaction() {
 	err := s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
 	s.NoError(err)
 
-	transactionCompleted := make(chan struct{})
-
-	var signResult sign.Result
-	signal.SetDefaultNodeNotificationHandler(func(rawSignal string) {
-		var sg signal.Envelope
-		err := json.Unmarshal([]byte(rawSignal), &sg)
-		s.NoError(err)
-
-		if sg.Type == signal.EventSignRequestAdded {
-			event := sg.Event.(map[string]interface{})
-			//check for the correct method name
-			method := event["method"].(string)
-			s.Equal(params.SendTransactionMethodName, method)
-
-			txID := event["id"].(string)
-			signResult = s.Backend.ApproveSignRequest(txID, TestConfig.Account1.Password)
-			s.NoError(signResult.Error, "cannot complete queued transaction %s", txID)
-			close(transactionCompleted)
-		}
-	})
-
 	result := s.Backend.CallRPC(`{
-		"jsonrpc": "2.0",
+				"jsonrpc": "2.0",
 		"id": 1,
 		"method": "eth_sendTransaction",
 		"params": [{
@@ -82,15 +46,7 @@ func (s *TransactionsTestSuite) TestCallRPCSendTransaction() {
 			"value": "0x9184e72a"
 		}]
 	}`)
-	s.NotContains(result, "error")
-
-	select {
-	case <-transactionCompleted:
-	case <-time.After(time.Minute):
-		s.FailNow("sending transaction timed out")
-	}
-
-	s.Equal(`{"jsonrpc":"2.0","id":1,"result":"`+signResult.Response.Hash().Hex()+`"}`, result)
+	s.Contains(result, `"error":{"code":-32700,"message":"method is unsupported by RPC interface"}`)
 }
 
 func (s *TransactionsTestSuite) TestCallRPCSendTransactionUpstream() {
@@ -104,30 +60,6 @@ func (s *TransactionsTestSuite) TestCallRPCSendTransactionUpstream() {
 	err = s.Backend.SelectAccount(TestConfig.Account2.Address, TestConfig.Account2.Password)
 	s.NoError(err)
 
-	transactionCompleted := make(chan struct{})
-
-	var signResult sign.Result
-	signal.SetDefaultNodeNotificationHandler(func(rawSignal string) {
-		var signalEnvelope signal.Envelope
-		err := json.Unmarshal([]byte(rawSignal), &signalEnvelope)
-		s.NoError(err)
-
-		if signalEnvelope.Type == signal.EventSignRequestAdded {
-			event := signalEnvelope.Event.(map[string]interface{})
-			txID := event["id"].(string)
-
-			// Complete with a wrong passphrase.
-			signResult = s.Backend.ApproveSignRequest(txID, "some-invalid-passphrase")
-			s.EqualError(signResult.Error, keystore.ErrDecrypt.Error(), "should return an error as the passphrase was invalid")
-
-			// Complete with a correct passphrase.
-			signResult = s.Backend.ApproveSignRequest(txID, TestConfig.Account2.Password)
-			s.NoError(signResult.Error, "cannot complete queued transaction %s", txID)
-
-			close(transactionCompleted)
-		}
-	})
-
 	result := s.Backend.CallRPC(`{
 		"jsonrpc": "2.0",
 		"id": 1,
@@ -138,15 +70,7 @@ func (s *TransactionsTestSuite) TestCallRPCSendTransactionUpstream() {
 			"value": "0x9184e72a"
 		}]
 	}`)
-	s.NotContains(result, "error")
-
-	select {
-	case <-transactionCompleted:
-	case <-time.After(time.Minute):
-		s.FailNow("sending transaction timed out")
-	}
-
-	s.Equal(`{"jsonrpc":"2.0","id":1,"result":"`+signResult.Response.Hash().Hex()+`"}`, result)
+	s.Contains(result, `"error":{"code":-32700,"message":"method is unsupported by RPC interface"}`)
 }
 
 func (s *TransactionsTestSuite) TestEmptyToFieldPreserved() {
@@ -159,41 +83,14 @@ func (s *TransactionsTestSuite) TestEmptyToFieldPreserved() {
 	err := s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
 	s.NoError(err)
 
-	transactionCompleted := make(chan struct{})
-	signal.SetDefaultNodeNotificationHandler(func(rawSignal string) {
-		var sg struct {
-			Type  string
-			Event json.RawMessage
-		}
-		err := json.Unmarshal([]byte(rawSignal), &sg)
-		s.NoError(err)
-		if sg.Type == signal.EventSignRequestAdded {
-			var event signal.PendingRequestEvent
-			s.NoError(json.Unmarshal(sg.Event, &event))
-			args := event.Args.(map[string]interface{})
-			s.NotNil(args["from"])
-			s.Nil(args["to"])
-			signResult := s.Backend.ApproveSignRequest(event.ID, TestConfig.Account1.Password)
-			s.NoError(signResult.Error)
-			close(transactionCompleted)
-		}
-	})
-
-	result := s.Backend.CallRPC(`{
-		"jsonrpc": "2.0",
-		"id": 1,
-		"method": "eth_sendTransaction",
-		"params": [{
-			"from": "` + TestConfig.Account1.Address + `"
-		}]
-	}`)
-	s.NotContains(result, "error")
-
-	select {
-	case <-transactionCompleted:
-	case <-time.After(10 * time.Second):
-		s.FailNow("sending transaction timed out")
+	args := transactions.SendTxArgs{
+		From: account.FromAddress(TestConfig.Account1.Address),
 	}
+
+	result := s.Backend.SendTransaction(args, TestConfig.Account1.Password)
+
+	s.NoError(result.Error)
+	s.NotNil(result.Response)
 }
 
 // TestSendContractCompat tries to send transaction using the legacy "Data"
@@ -246,78 +143,14 @@ func (s *TransactionsTestSuite) TestSendContractTx() {
 	s.testSendContractTx(initFunc, nil, "")
 }
 
-func (s *TransactionsTestSuite) setDefaultNodeNotificationHandler(signRequestResult *[]byte, sampleAddress string, done chan struct{}, expectedError error) {
-	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) { // nolint :dupl
-		var envelope signal.Envelope
-		err := json.Unmarshal([]byte(jsonEvent), &envelope)
-		s.NoError(err, fmt.Sprintf("cannot unmarshal JSON: %s", jsonEvent))
-
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			log.Info("transaction queued (will be completed shortly)", "id", event["id"].(string))
-
-			// the first call will fail (we are not logged in, but trying to complete tx)
-			log.Info("trying to complete with no user logged in")
-			err = s.Backend.ApproveSignRequest(
-				event["id"].(string),
-				TestConfig.Account1.Password,
-			).Error
-			s.EqualError(
-				err,
-				account.ErrNoAccountSelected.Error(),
-				fmt.Sprintf("expected error on queued transaction[%v] not thrown", event["id"]),
-			)
-
-			// the second call will also fail (we are logged in as different user)
-			log.Info("trying to complete with invalid user")
-			err = s.Backend.SelectAccount(sampleAddress, TestConfig.Account1.Password)
-			s.NoError(err)
-			err = s.Backend.ApproveSignRequest(
-				event["id"].(string),
-				TestConfig.Account1.Password,
-			).Error
-			s.EqualError(
-				err,
-				transactions.ErrInvalidCompleteTxSender.Error(),
-				fmt.Sprintf("expected error on queued transaction[%v] not thrown", event["id"]),
-			)
-
-			// the third call will work as expected (as we are logged in with correct credentials)
-			log.Info("trying to complete with correct user, this should succeed")
-			s.NoError(s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password))
-			result := s.Backend.ApproveSignRequest(
-				event["id"].(string),
-				TestConfig.Account1.Password,
-			)
-			if expectedError != nil {
-				s.Equal(expectedError, result.Error)
-			} else {
-				s.NoError(result.Error, fmt.Sprintf("cannot complete queued transaction[%v]", event["id"]))
-			}
-
-			*signRequestResult = result.Response.Bytes()[:]
-
-			log.Info("contract transaction complete", "URL", txURLString(result))
-			close(done)
-			return
-		}
-	})
-}
-
 func (s *TransactionsTestSuite) testSendContractTx(setInputAndDataValue initFunc, expectedError error, expectedErrorDescription string) {
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 
 	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
-	sampleAddress, _, _, err := s.Backend.AccountManager().CreateAccount(TestConfig.Account1.Password)
+	err := s.Backend.AccountManager().SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
 	s.NoError(err)
-
-	completeQueuedTransaction := make(chan struct{})
-
-	// replace transaction notification handler
-	var signRequestResult []byte
-	s.setDefaultNodeNotificationHandler(&signRequestResult, sampleAddress, completeQueuedTransaction, expectedError)
 
 	// this call blocks, up until Complete Transaction is called
 	byteCode, err := hexutil.Decode(`0x6060604052341561000c57fe5b5b60a58061001b6000396000f30060606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680636ffa1caa14603a575bfe5b3415604157fe5b60556004808035906020019091905050606b565b6040518082815260200191505060405180910390f35b60008160020290505b9190505600a165627a7a72305820ccdadd737e4ac7039963b54cee5e5afb25fa859a275252bdcf06f653155228210029`)
@@ -332,24 +165,14 @@ func (s *TransactionsTestSuite) testSendContractTx(setInputAndDataValue initFunc
 	}
 
 	setInputAndDataValue(byteCode, &args)
-	txHashCheck, err := s.Backend.SendTransaction(context.TODO(), args)
+	result := s.Backend.SendTransaction(args, TestConfig.Account1.Password)
 
 	if expectedError != nil {
-		s.Equal(expectedError, err, expectedErrorDescription)
+		s.Equal(expectedError, result.Error, expectedErrorDescription)
 		return
 	}
-	s.NoError(err, "cannot send transaction")
-
-	select {
-	case <-completeQueuedTransaction:
-	case <-time.After(2 * time.Minute):
-		s.FailNow("completing transaction timed out")
-	}
-
-	s.Equal(txHashCheck.Bytes(), signRequestResult, "transaction hash returned from SendTransaction is invalid")
-	s.False(reflect.DeepEqual(txHashCheck, gethcommon.Hash{}), "transaction was never queued or completed")
-	s.Zero(s.PendingSignRequests().Count(), "tx queue must be empty at this point")
-
+	s.NoError(result.Error, "cannot send transaction")
+	s.False(reflect.DeepEqual(result.Response.Hash(), gethcommon.Hash{}))
 	s.NoError(s.Backend.Logout())
 }
 
@@ -361,33 +184,18 @@ func (s *TransactionsTestSuite) TestSendEther() {
 
 	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
-	// create an account
-	sampleAddress, _, _, err := s.Backend.AccountManager().CreateAccount(TestConfig.Account1.Password)
+	err := s.Backend.AccountManager().SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
 	s.NoError(err)
 
-	completeQueuedTransaction := make(chan struct{})
-
-	// replace transaction notification handler
-	var signRequestResult []byte
-	s.setDefaultNodeNotificationHandler(&signRequestResult, sampleAddress, completeQueuedTransaction, nil)
-
-	// this call blocks, up until Complete Transaction is called
-	txHashCheck, err := s.Backend.SendTransaction(context.TODO(), transactions.SendTxArgs{
+	result := s.Backend.SendTransaction(transactions.SendTxArgs{
 		From:  account.FromAddress(TestConfig.Account1.Address),
 		To:    account.ToAddress(TestConfig.Account2.Address),
 		Value: (*hexutil.Big)(big.NewInt(1000000000000)),
-	})
-	s.NoError(err, "cannot send transaction")
+	}, TestConfig.Account1.Password)
 
-	select {
-	case <-completeQueuedTransaction:
-	case <-time.After(2 * time.Minute):
-		s.FailNow("completing transaction timed out")
-	}
+	s.NoError(result.Error, "cannot send transaction")
 
-	s.Equal(txHashCheck.Bytes(), signRequestResult, "transaction hash returned from SendTransaction is invalid")
-	s.False(reflect.DeepEqual(txHashCheck, gethcommon.Hash{}), "transaction was never queued or completed")
-	s.Zero(s.Backend.PendingSignRequests().Count(), "tx queue must be empty at this point")
+	s.False(reflect.DeepEqual(result.Response.Hash(), gethcommon.Hash{}))
 }
 
 func (s *TransactionsTestSuite) TestSendEtherTxUpstream() {
@@ -401,460 +209,14 @@ func (s *TransactionsTestSuite) TestSendEtherTxUpstream() {
 	err = s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
 	s.NoError(err)
 
-	completeQueuedTransaction := make(chan struct{})
-
-	// replace transaction notification handler
-	var txHash = gethcommon.Hash{}
-	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) { // nolint: dupl
-		var envelope signal.Envelope
-		err = json.Unmarshal([]byte(jsonEvent), &envelope)
-		s.NoError(err, "cannot unmarshal JSON: %s", jsonEvent)
-
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			log.Info("transaction queued (will be completed shortly)", "id", event["id"].(string))
-
-			signResult := s.Backend.ApproveSignRequest(
-				event["id"].(string),
-				TestConfig.Account1.Password,
-			)
-			s.NoError(signResult.Error, "cannot complete queued transaction[%v]", event["id"])
-
-			txHash = signResult.Response.Hash()
-			log.Info("contract transaction complete", "URL", txURLString(signResult))
-			close(completeQueuedTransaction)
-		}
-	})
-
-	// This call blocks, up until Complete Transaction is called.
-	// Explicitly not setting Gas to get it estimated.
-	txHashCheck, err := s.Backend.SendTransaction(context.TODO(), transactions.SendTxArgs{
+	result := s.Backend.SendTransaction(transactions.SendTxArgs{
 		From:     account.FromAddress(TestConfig.Account1.Address),
 		To:       account.ToAddress(TestConfig.Account2.Address),
 		GasPrice: (*hexutil.Big)(big.NewInt(28000000000)),
 		Value:    (*hexutil.Big)(big.NewInt(1000000000000)),
-	})
-	s.NoError(err, "cannot send transaction")
+	}, TestConfig.Account1.Password)
 
-	select {
-	case <-completeQueuedTransaction:
-	case <-time.After(1 * time.Minute):
-		s.FailNow("completing transaction timed out")
-	}
+	s.NoError(result.Error, "cannot send transaction")
 
-	s.Equal(txHash.Hex(), txHashCheck.Hex(), "transaction hash returned from SendTransaction is invalid")
-	s.Zero(s.Backend.PendingSignRequests().Count(), "tx queue must be empty at this point")
-}
-
-func (s *TransactionsTestSuite) TestDoubleCompleteQueuedTransactions() {
-	CheckTestSkipForNetworks(s.T(), params.MainNetworkID)
-
-	s.StartTestBackend()
-	defer s.StopTestBackend()
-
-	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
-
-	// log into account from which transactions will be sent
-	s.NoError(s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password))
-
-	completeQueuedTransaction := make(chan struct{})
-
-	// replace transaction notification handler
-	var isTxFailedEventCalled int32 // using int32 as bool to avoid data race: 0 is `false`, 1 is `true`
-	signHash := gethcommon.Hash{}
-	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
-		var envelope signal.Envelope
-		err := json.Unmarshal([]byte(jsonEvent), &envelope)
-		s.NoError(err, fmt.Sprintf("cannot unmarshal JSON: %s", jsonEvent))
-
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			txID := event["id"].(string)
-			log.Info("transaction queued (will be failed and completed on the second call)", "id", txID)
-
-			// try with wrong password
-			// make sure that tx is NOT removed from the queue (by re-trying with the correct password)
-			err = s.Backend.ApproveSignRequest(txID, TestConfig.Account1.Password+"wrong").Error
-			s.EqualError(err, keystore.ErrDecrypt.Error())
-
-			s.Equal(1, s.PendingSignRequests().Count(), "txqueue cannot be empty, as tx has failed")
-
-			// now try to complete transaction, but with the correct password
-			signResult := s.Backend.ApproveSignRequest(txID, TestConfig.Account1.Password)
-			s.NoError(signResult.Error)
-
-			log.Info("transaction complete", "URL", txURLString(signResult))
-
-			signHash = signResult.Response.Hash()
-
-			close(completeQueuedTransaction)
-		}
-
-		if envelope.Type == signal.EventSignRequestFailed {
-			event := envelope.Event.(map[string]interface{})
-			log.Info("transaction return event received", "id", event["id"].(string))
-
-			receivedErrMessage := event["error_message"].(string)
-			expectedErrMessage := "could not decrypt key with given passphrase"
-			s.Equal(expectedErrMessage, receivedErrMessage)
-
-			receivedErrCode := event["error_code"].(string)
-			s.Equal("2", receivedErrCode)
-
-			atomic.AddInt32(&isTxFailedEventCalled, 1)
-		}
-	})
-
-	// this call blocks, and should return on *second* attempt to ApproveSignRequest (w/ the correct password)
-	sendTxHash, err := s.Backend.SendTransaction(context.TODO(), transactions.SendTxArgs{
-		From:  account.FromAddress(TestConfig.Account1.Address),
-		To:    account.ToAddress(TestConfig.Account2.Address),
-		Value: (*hexutil.Big)(big.NewInt(1000000000000)),
-	})
-	s.NoError(err, "cannot send transaction")
-
-	select {
-	case <-completeQueuedTransaction:
-	case <-time.After(time.Minute):
-		s.FailNow("test timed out")
-	}
-
-	s.Equal(sendTxHash, signHash, "transaction hash returned from SendTransaction is invalid")
-	s.False(reflect.DeepEqual(sendTxHash, gethcommon.Hash{}), "transaction was never queued or completed")
-	s.Zero(s.Backend.PendingSignRequests().Count(), "tx queue must be empty at this point")
-	s.True(atomic.LoadInt32(&isTxFailedEventCalled) > 0, "expected tx failure signal is not received")
-}
-
-func (s *TransactionsTestSuite) TestDiscardQueuedTransaction() {
-	CheckTestSkipForNetworks(s.T(), params.MainNetworkID)
-
-	s.StartTestBackend()
-	defer s.StopTestBackend()
-
-	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
-
-	// log into account from which transactions will be sent
-	s.NoError(s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password))
-
-	completeQueuedTransaction := make(chan struct{})
-
-	// replace transaction notification handler
-	var isTxFailedEventCalled int32 // using int32 as bool to avoid data race: 0 = `false`, 1 = `true`
-	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
-		var envelope signal.Envelope
-		err := json.Unmarshal([]byte(jsonEvent), &envelope)
-		s.NoError(err, fmt.Sprintf("cannot unmarshal JSON: %s", jsonEvent))
-
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			txID := event["id"].(string)
-			log.Info("transaction queued (will be discarded soon)", "id", txID)
-
-			s.True(s.Backend.PendingSignRequests().Has(txID), "txqueue should still have test tx")
-
-			// discard
-			err := s.Backend.DiscardSignRequest(txID)
-			s.NoError(err, "cannot discard tx")
-
-			// try completing discarded transaction
-			err = s.Backend.ApproveSignRequest(txID, TestConfig.Account1.Password).Error
-			s.EqualError(err, sign.ErrSignReqNotFound.Error(), "expects tx not found, but call to ApproveSignRequest succeeded")
-
-			time.Sleep(1 * time.Second) // make sure that tx complete signal propagates
-			s.False(s.Backend.PendingSignRequests().Has(txID),
-				fmt.Sprintf("txqueue should not have test tx at this point (it should be discarded): %s", txID))
-
-			close(completeQueuedTransaction)
-		}
-
-		if envelope.Type == signal.EventSignRequestFailed {
-			event := envelope.Event.(map[string]interface{})
-			log.Info("transaction return event received", "id", event["id"].(string))
-
-			receivedErrMessage := event["error_message"].(string)
-			expectedErrMessage := sign.ErrSignReqDiscarded.Error()
-			s.Equal(receivedErrMessage, expectedErrMessage)
-
-			receivedErrCode := event["error_code"].(string)
-			s.Equal("4", receivedErrCode)
-
-			atomic.AddInt32(&isTxFailedEventCalled, 1)
-		}
-	})
-
-	// this call blocks, and should return when DiscardQueuedTransaction() is called
-	txHashCheck, err := s.Backend.SendTransaction(context.TODO(), transactions.SendTxArgs{
-		From:  account.FromAddress(TestConfig.Account1.Address),
-		To:    account.ToAddress(TestConfig.Account2.Address),
-		Value: (*hexutil.Big)(big.NewInt(1000000000000)),
-	})
-	s.EqualError(err, sign.ErrSignReqDiscarded.Error(), "transaction is expected to be discarded")
-
-	select {
-	case <-completeQueuedTransaction:
-	case <-time.After(10 * time.Second):
-		s.FailNow("test timed out")
-	}
-
-	s.True(reflect.DeepEqual(txHashCheck, gethcommon.Hash{}), "transaction returned hash, while it shouldn't")
-	s.Zero(s.Backend.PendingSignRequests().Count(), "tx queue must be empty at this point")
-	s.True(atomic.LoadInt32(&isTxFailedEventCalled) > 0, "expected tx failure signal is not received")
-}
-
-func (s *TransactionsTestSuite) TestCompleteMultipleQueuedTransactions() {
-	CheckTestSkipForNetworks(s.T(), params.MainNetworkID)
-
-	s.setupLocalNode()
-	defer s.StopTestBackend()
-
-	// log into account from which transactions will be sent
-	err := s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
-	s.NoError(err)
-
-	s.sendConcurrentTransactions(3)
-}
-
-func (s *TransactionsTestSuite) TestDiscardMultipleQueuedTransactions() {
-	CheckTestSkipForNetworks(s.T(), params.MainNetworkID)
-
-	s.StartTestBackend()
-	defer s.StopTestBackend()
-
-	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
-
-	// log into account from which transactions will be sent
-	s.NoError(s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password))
-
-	testTxCount := 3
-	txIDs := make(chan string, testTxCount)
-	allTestTxDiscarded := make(chan struct{})
-
-	// replace transaction notification handler
-	var txFailedEventCallCount int32
-	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
-		var envelope signal.Envelope
-		err := json.Unmarshal([]byte(jsonEvent), &envelope)
-		s.NoError(err)
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			txID := event["id"].(string)
-			log.Info("transaction queued (will be discarded soon)", "id", txID)
-
-			s.True(s.Backend.PendingSignRequests().Has(txID),
-				"txqueue should still have test tx")
-			txIDs <- txID
-		}
-
-		if envelope.Type == signal.EventSignRequestFailed {
-			event := envelope.Event.(map[string]interface{})
-			log.Info("transaction return event received", "id", event["id"].(string))
-
-			receivedErrMessage := event["error_message"].(string)
-			expectedErrMessage := sign.ErrSignReqDiscarded.Error()
-			s.Equal(receivedErrMessage, expectedErrMessage)
-
-			receivedErrCode := event["error_code"].(string)
-			s.Equal("4", receivedErrCode)
-
-			newCount := atomic.AddInt32(&txFailedEventCallCount, 1)
-			if newCount == int32(testTxCount) {
-				close(allTestTxDiscarded)
-			}
-		}
-	})
-
-	require := s.Require()
-
-	//  this call blocks, and should return when DiscardQueuedTransaction() for a given tx id is called
-	sendTx := func() {
-		txHashCheck, err := s.Backend.SendTransaction(context.TODO(), transactions.SendTxArgs{
-			From:  account.FromAddress(TestConfig.Account1.Address),
-			To:    account.ToAddress(TestConfig.Account2.Address),
-			Value: (*hexutil.Big)(big.NewInt(1000000000000)),
-		})
-		require.EqualError(err, sign.ErrSignReqDiscarded.Error())
-		require.Equal(gethcommon.Hash{}, txHashCheck, "transaction returned hash, while it shouldn't")
-	}
-
-	signRequests := s.Backend.PendingSignRequests()
-
-	// wait for transactions, and discard immediately
-	discardTxs := func(txIDs []string) {
-		txIDs = append(txIDs, invalidTxID)
-
-		// discard
-		discardResults := s.Backend.DiscardSignRequests(txIDs)
-		require.Len(discardResults, 1, "cannot discard txs: %v", discardResults)
-		require.Error(discardResults[invalidTxID], sign.ErrSignReqNotFound, "cannot discard txs: %v", discardResults)
-
-		// try completing discarded transaction
-		completeResults := s.Backend.ApproveSignRequests(txIDs, TestConfig.Account1.Password)
-		require.Len(completeResults, testTxCount+1, "unexpected number of errors (call to ApproveSignRequest should not succeed)")
-
-		for _, txResult := range completeResults {
-			require.Error(txResult.Error, sign.ErrSignReqNotFound, "invalid error for %s", txResult.Response.Hex())
-			require.Equal(sign.EmptyResponse, txResult.Response, "invalid hash (expected zero): %s", txResult.Response.Hex())
-		}
-
-		time.Sleep(1 * time.Second) // make sure that tx complete signal propagates
-
-		for _, txID := range txIDs {
-			require.False(
-				signRequests.Has(txID),
-				"txqueue should not have test tx at this point (it should be discarded): %s",
-				txID,
-			)
-		}
-	}
-	go func() {
-		ids := make([]string, testTxCount)
-		for i := 0; i < testTxCount; i++ {
-			ids[i] = <-txIDs
-		}
-
-		discardTxs(ids)
-	}()
-
-	// send multiple transactions
-	for i := 0; i < testTxCount; i++ {
-		go sendTx()
-	}
-
-	select {
-	case <-allTestTxDiscarded:
-	case <-time.After(1 * time.Minute):
-		s.FailNow("test timed out")
-	}
-	time.Sleep(5 * time.Second)
-
-	s.Zero(s.Backend.PendingSignRequests().Count(), "tx queue must be empty at this point")
-}
-
-func (s *TransactionsTestSuite) TestNonExistentQueuedTransactions() {
-	s.StartTestBackend()
-	defer s.StopTestBackend()
-
-	// log into account from which transactions will be sent
-	s.NoError(s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password))
-
-	// replace transaction notification handler
-	signal.SetDefaultNodeNotificationHandler(func(string) {})
-
-	// try completing non-existing transaction
-	err := s.Backend.ApproveSignRequest("some-bad-transaction-id", TestConfig.Account1.Password).Error
-	s.Error(err, "error expected and not received")
-	s.EqualError(err, sign.ErrSignReqNotFound.Error())
-}
-
-func (s *TransactionsTestSuite) TestCompleteMultipleQueuedTransactionsUpstream() {
-	CheckTestSkipForNetworks(s.T(), params.MainNetworkID)
-
-	s.setupUpstreamNode()
-	defer s.StopTestBackend()
-
-	// log into account from which transactions will be sent
-	err := s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
-	s.NoError(err)
-
-	s.sendConcurrentTransactions(30)
-}
-
-func (s *TransactionsTestSuite) setupLocalNode() {
-	s.StartTestBackend()
-
-	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
-}
-
-func (s *TransactionsTestSuite) setupUpstreamNode() {
-	if GetNetworkID() == params.StatusChainNetworkID {
-		s.T().Skip()
-	}
-
-	addr, err := GetRemoteURL()
-	s.NoError(err)
-	s.StartTestBackend(e2e.WithUpstream(addr))
-}
-
-func (s *TransactionsTestSuite) sendConcurrentTransactions(testTxCount int) {
-	txIDs := make(chan string, testTxCount)
-	allTestTxCompleted := make(chan struct{})
-
-	require := s.Require()
-
-	// replace transaction notification handler
-	signal.SetDefaultNodeNotificationHandler(func(jsonEvent string) {
-		var envelope signal.Envelope
-		err := json.Unmarshal([]byte(jsonEvent), &envelope)
-		require.NoError(err, fmt.Sprintf("cannot unmarshal JSON: %s", jsonEvent))
-
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			txID := event["id"].(string)
-			log.Info("transaction queued (will be completed in a single call, once aggregated)", "id", txID)
-
-			txIDs <- txID
-		}
-	})
-
-	//  this call blocks, and should return when DiscardQueuedTransaction() for a given tx id is called
-	sendTx := func() {
-		txHashCheck, err := s.Backend.SendTransaction(context.TODO(), transactions.SendTxArgs{
-			From:  account.FromAddress(TestConfig.Account1.Address),
-			To:    account.ToAddress(TestConfig.Account2.Address),
-			Value: (*hexutil.Big)(big.NewInt(1000000000000)),
-		})
-		require.NoError(err, "cannot send transaction")
-		require.NotEqual(gethcommon.Hash{}, txHashCheck, "transaction returned empty hash")
-	}
-
-	// wait for transactions, and complete them in a single call
-	completeTxs := func(txIDs []string) {
-		txIDs = append(txIDs, invalidTxID)
-		results := s.Backend.ApproveSignRequests(txIDs, TestConfig.Account1.Password)
-		s.Len(results, testTxCount+1)
-		s.EqualError(results[invalidTxID].Error, sign.ErrSignReqNotFound.Error())
-
-		for txID, txResult := range results {
-			s.False(
-				txResult.Error != nil && txID != invalidTxID,
-				"invalid error for %s", txID,
-			)
-			s.False(
-				len(txResult.Response.Bytes()) < 1 && txID != invalidTxID,
-				"invalid hash (expected non empty hash): %s", txID,
-			)
-			log.Info("transaction complete", "URL", txURLString(txResult))
-		}
-
-		time.Sleep(1 * time.Second) // make sure that tx complete signal propagates
-
-		for _, txID := range txIDs {
-			s.False(
-				s.Backend.PendingSignRequests().Has(txID),
-				"txqueue should not have test tx at this point (it should be completed)",
-			)
-		}
-	}
-	go func() {
-		ids := make([]string, testTxCount)
-		for i := 0; i < testTxCount; i++ {
-			ids[i] = <-txIDs
-		}
-
-		completeTxs(ids)
-		close(allTestTxCompleted)
-	}()
-
-	// send multiple transactions
-	for i := 0; i < testTxCount; i++ {
-		go sendTx()
-	}
-
-	select {
-	case <-allTestTxCompleted:
-	case <-time.After(60 * time.Second):
-		s.FailNow("test timed out")
-	}
-
-	s.Zero(s.PendingSignRequests().Count(), "queue should be empty")
+	s.False(reflect.DeepEqual(result.Response.Hash(), gethcommon.Hash{}), "transaction was never queued or completed")
 }

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"reflect"
 	"testing"
 	"time"
 
@@ -29,12 +30,6 @@ import (
 
 	. "github.com/status-im/status-go/t/utils"
 )
-
-func simpleVerifyFunc(acc *account.SelectedExtKey) func(string) (*account.SelectedExtKey, error) {
-	return func(string) (*account.SelectedExtKey, error) {
-		return acc, nil
-	}
-}
 
 func TestTxQueueTestSuite(t *testing.T) {
 	suite.Run(t, new(TxQueueTestSuite))
@@ -63,7 +58,7 @@ func (s *TxQueueTestSuite) SetupTest() {
 	s.Require().NoError(err)
 	s.nodeConfig = nodeConfig
 
-	s.manager = NewTransactor(sign.NewPendingRequests())
+	s.manager = NewTransactor()
 	s.manager.sendTxTimeout = time.Second
 	s.manager.SetNetworkID(chainID)
 	s.manager.SetRPC(rpcClient, time.Second)
@@ -76,11 +71,9 @@ func (s *TxQueueTestSuite) TearDownTest() {
 }
 
 var (
-	testGas               = hexutil.Uint64(defaultGas + 1)
-	testGasPrice          = (*hexutil.Big)(big.NewInt(10))
-	testOverridenGas      = hexutil.Uint64(defaultGas + 2)
-	testOverridenGasPrice = (*hexutil.Big)(big.NewInt(20))
-	testNonce             = hexutil.Uint64(10)
+	testGas      = hexutil.Uint64(defaultGas + 1)
+	testGasPrice = (*hexutil.Big)(big.NewInt(10))
+	testNonce    = hexutil.Uint64(10)
 )
 
 func (s *TxQueueTestSuite) setupTransactionPoolAPI(args SendTxArgs, returnNonce, resultNonce hexutil.Uint64, account *account.SelectedExtKey, txErr error, signArgs *sign.TxArgs) {
@@ -135,80 +128,29 @@ func (s *TxQueueTestSuite) TestCompleteTransaction() {
 		AccountKey: &keystore.Key{PrivateKey: key},
 	}
 	testCases := []struct {
-		name       string
-		gas        *hexutil.Uint64
-		gasPrice   *hexutil.Big
-		signTxArgs *sign.TxArgs
+		name     string
+		gas      *hexutil.Uint64
+		gasPrice *hexutil.Big
 	}{
 		{
 			"noGasDef",
 			nil,
 			nil,
-			s.defaultSignTxArgs(),
 		},
 		{
 			"gasDefined",
 			&testGas,
 			nil,
-			s.defaultSignTxArgs(),
 		},
 		{
 			"gasPriceDefined",
 			nil,
 			testGasPrice,
-			s.defaultSignTxArgs(),
-		},
-		{
-			"inputPassedInLegacyDataField",
-			nil,
-			testGasPrice,
-			s.defaultSignTxArgs(),
-		},
-		{
-			"overrideGas",
-			nil,
-			nil,
-			&sign.TxArgs{
-				Gas: &testGas,
-			},
-		},
-		{
-			"overridePreExistingGas",
-			&testGas,
-			nil,
-			&sign.TxArgs{
-				Gas: &testOverridenGas,
-			},
-		},
-		{
-			"overridePreExistingGasPrice",
-			nil,
-			testGasPrice,
-			&sign.TxArgs{
-				GasPrice: testOverridenGasPrice,
-			},
 		},
 		{
 			"nilSignTransactionSpecificArgs",
 			nil,
 			nil,
-			nil,
-		},
-		{
-			"overridePreExistingGasWithNil",
-			&testGas,
-			nil,
-			&sign.TxArgs{
-				Gas: nil,
-			},
-		},
-		{
-			"overridePreExistingGasPriceWithNil",
-			nil,
-			testGasPrice,
-			&sign.TxArgs{
-				GasPrice: nil,
-			},
 		},
 	}
 
@@ -221,39 +163,13 @@ func (s *TxQueueTestSuite) TestCompleteTransaction() {
 				Gas:      testCase.gas,
 				GasPrice: testCase.gasPrice,
 			}
-			s.setupTransactionPoolAPI(args, testNonce, testNonce, selectedAccount, nil, testCase.signTxArgs)
+			s.setupTransactionPoolAPI(args, testNonce, testNonce, selectedAccount, nil, &sign.TxArgs{})
 
-			w := make(chan struct{})
-			var sendHash gethcommon.Hash
-			go func() {
-				var sendErr error
-				sendHash, sendErr = s.manager.SendTransaction(context.Background(), args)
-				s.NoError(sendErr)
-				close(w)
-			}()
-
-			for i := 10; i > 0; i-- {
-				if s.manager.pendingSignRequests.Count() > 0 {
-					break
-				}
-				time.Sleep(time.Millisecond)
-			}
-
-			req := s.manager.pendingSignRequests.First()
-			s.NotNil(req)
-			approveResult := s.manager.pendingSignRequests.Approve(req.ID, "", testCase.signTxArgs, simpleVerifyFunc(selectedAccount))
-			s.NoError(approveResult.Error)
-			s.NoError(WaitClosed(w, time.Second))
-
-			// Transaction should be already removed from the queue.
-			s.False(s.manager.pendingSignRequests.Has(req.ID))
-			s.Equal(sendHash.Bytes(), approveResult.Response.Bytes())
+			result := s.manager.SendTransaction(args, selectedAccount)
+			s.NoError(result.Error)
+			s.False(reflect.DeepEqual(result.Response.Hash(), gethcommon.Hash{}), "transaction was never queued or completed")
 		})
 	}
-}
-
-func (s *TxQueueTestSuite) defaultSignTxArgs() *sign.TxArgs {
-	return &sign.TxArgs{}
 }
 
 func (s *TxQueueTestSuite) TestAccountMismatch() {
@@ -266,51 +182,8 @@ func (s *TxQueueTestSuite) TestAccountMismatch() {
 		To:   account.ToAddress(TestConfig.Account2.Address),
 	}
 
-	go func() {
-		s.manager.SendTransaction(context.Background(), args) // nolint: errcheck
-	}()
-
-	for i := 10; i > 0; i-- {
-		if s.manager.pendingSignRequests.Count() > 0 {
-			break
-		}
-		time.Sleep(time.Millisecond)
-	}
-
-	req := s.manager.pendingSignRequests.First()
-	s.NotNil(req)
-	result := s.manager.pendingSignRequests.Approve(req.ID, "", s.defaultSignTxArgs(), simpleVerifyFunc(selectedAccount))
+	result := s.manager.SendTransaction(args, selectedAccount) // nolint: errcheck
 	s.EqualError(result.Error, ErrInvalidCompleteTxSender.Error())
-
-	// Transaction should stay in the queue as mismatched accounts
-	// is a recoverable error.
-	s.True(s.manager.pendingSignRequests.Has(req.ID))
-}
-
-func (s *TxQueueTestSuite) TestDiscardTransaction() {
-	args := SendTxArgs{
-		From: account.FromAddress(TestConfig.Account1.Address),
-		To:   account.ToAddress(TestConfig.Account2.Address),
-	}
-	w := make(chan struct{})
-	go func() {
-		_, err := s.manager.SendTransaction(context.Background(), args)
-		s.Equal(sign.ErrSignReqDiscarded, err)
-		close(w)
-	}()
-
-	for i := 10; i > 0; i-- {
-		if s.manager.pendingSignRequests.Count() > 0 {
-			break
-		}
-		time.Sleep(time.Millisecond)
-	}
-
-	req := s.manager.pendingSignRequests.First()
-	s.NotNil(req)
-	err := s.manager.pendingSignRequests.Discard(req.ID)
-	s.NoError(err)
-	s.NoError(WaitClosed(w, time.Second))
 }
 
 // TestLocalNonce verifies that local nonce will be used unless
@@ -329,22 +202,6 @@ func (s *TxQueueTestSuite) TestLocalNonce() {
 	}
 	nonce := hexutil.Uint64(0)
 
-	go func() {
-		approved := 0
-		for {
-			// 3 in a cycle, then 2
-			if approved >= txCount+2 {
-				return
-			}
-			req := s.manager.pendingSignRequests.First()
-			if req == nil {
-				time.Sleep(time.Millisecond)
-			} else {
-				s.manager.pendingSignRequests.Approve(req.ID, "", s.defaultSignTxArgs(), simpleVerifyFunc(selectedAccount)) // nolint: errcheck
-			}
-		}
-	}()
-
 	for i := 0; i < txCount; i++ {
 		args := SendTxArgs{
 			From: account.FromAddress(TestConfig.Account1.Address),
@@ -352,8 +209,8 @@ func (s *TxQueueTestSuite) TestLocalNonce() {
 		}
 		s.setupTransactionPoolAPI(args, nonce, hexutil.Uint64(i), selectedAccount, nil, nil)
 
-		_, err := s.manager.SendTransaction(context.Background(), args)
-		s.NoError(err)
+		result := s.manager.SendTransaction(args, selectedAccount)
+		s.NoError(result.Error)
 		resultNonce, _ := s.manager.localNonce.Load(args.From)
 		s.Equal(uint64(i)+1, resultNonce.(uint64))
 	}
@@ -366,8 +223,8 @@ func (s *TxQueueTestSuite) TestLocalNonce() {
 
 	s.setupTransactionPoolAPI(args, nonce, nonce, selectedAccount, nil, nil)
 
-	_, err := s.manager.SendTransaction(context.Background(), args)
-	s.NoError(err)
+	result := s.manager.SendTransaction(args, selectedAccount)
+	s.NoError(result.Error)
 
 	resultNonce, _ := s.manager.localNonce.Load(args.From)
 	s.Equal(uint64(nonce)+1, resultNonce.(uint64))
@@ -379,8 +236,8 @@ func (s *TxQueueTestSuite) TestLocalNonce() {
 		To:   account.ToAddress(TestConfig.Account2.Address),
 	}
 
-	_, err = s.manager.SendTransaction(context.Background(), args)
-	s.EqualError(testErr, err.Error())
+	result = s.manager.SendTransaction(args, selectedAccount)
+	s.EqualError(testErr, result.Error.Error())
 	resultNonce, _ = s.manager.localNonce.Load(args.From)
 	s.Equal(uint64(nonce)+1, resultNonce.(uint64))
 }
@@ -404,21 +261,10 @@ func (s *TxQueueTestSuite) TestContractCreation() {
 		Input: hexutil.Bytes(gethcommon.FromHex(contract.ENSBin)),
 	}
 
-	go func() {
-		for i := 1000; i > 0; i-- {
-			req := s.manager.pendingSignRequests.First()
-			if req == nil {
-				time.Sleep(time.Millisecond)
-			} else {
-				s.manager.pendingSignRequests.Approve(req.ID, "", s.defaultSignTxArgs(), simpleVerifyFunc(selectedAccount)) // nolint: errcheck
-				break
-			}
-		}
-	}()
-
-	hash, err := s.manager.SendTransaction(context.Background(), tx)
-	s.NoError(err)
+	result := s.manager.SendTransaction(tx, selectedAccount)
+	s.NoError(result.Error)
 	backend.Commit()
+	hash := result.Response.Hash()
 	receipt, err := backend.TransactionReceipt(context.TODO(), hash)
 	s.NoError(err)
 	s.Equal(crypto.CreateAddress(testaddr, 0), receipt.ContractAddress)

--- a/transactions/types.go
+++ b/transactions/types.go
@@ -89,3 +89,10 @@ func RPCCalltoSendTxArgs(args ...interface{}) (SendTxArgs, error) {
 
 	return txArgs, nil
 }
+
+// UnmarshalSendTxRPCParams creates SendTxArgs based on RPC JSON
+func UnmarshalSendTxRPCParams(rpcParamsJSON string) (SendTxArgs, error) {
+	var params SendTxArgs
+	err := json.Unmarshal([]byte(rpcParamsJSON), &params)
+	return params, err
+}


### PR DESCRIPTION
Addresses #1027 

This PR removes the PendingSignRequests queue from the transactor.

It will be merged into feature/remove-transactions-queue-1027 along with PRs to:
 - remove PendingSignRequests from PersonalSign
 - remove PendingSignRequests from PersonalRecover
 - remove PendingSignRequests

Done:
 - Remove PendingSignRequests queue from transactor
 - Update SendTransaction method to sign the transactions itself and backend.SendTransaction to verify the account
 - Expose SendTransaction method in library.go
 - Add an unsupportedMethod handler for RPC requests in backend.go
 - Update corresponding tests in:
    - t/e2e/jail/jail_rpc_test.go
    - t/e2e/transactions/transactions_test.go
    - transactions/transactor_test.go