### PR TITLE
Remove PendingSignRequests queue from personalSign

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -34,6 +34,8 @@ var (
 	ErrWhisperClearIdentitiesFailure = errors.New("failed to clear whisper identities")
 	// ErrWhisperIdentityInjectionFailure injecting whisper identities has failed.
 	ErrWhisperIdentityInjectionFailure = errors.New("failed to inject identity into Whisper")
+	// ErrUnsupportedRPCMethod is for methods not supported by the RPC interface
+	ErrUnsupportedRPCMethod = errors.New("method is unsupported by RPC interface")
 )
 
 // StatusBackend implements Status.im service
@@ -58,7 +60,7 @@ func NewStatusBackend() *StatusBackend {
 	pendingSignRequests := sign.NewPendingRequests()
 	accountManager := account.NewManager(statusNode)
 	transactor := transactions.NewTransactor(pendingSignRequests)
-	personalAPI := personal.NewAPI(pendingSignRequests)
+	personalAPI := personal.NewAPI()
 	notificationManager := fcm.NewNotification(fcmServerKey)
 
 	return &StatusBackend{
@@ -226,6 +228,22 @@ func (b *StatusBackend) SendTransaction(ctx context.Context, args transactions.S
 	return b.transactor.SendTransaction(ctx, args)
 }
 
+// SignMessage checks the pwd vs the selected account and passes on the signParams
+// to personalAPI for message signature
+func (b *StatusBackend) SignMessage(rpcParams personal.SignParams, password string) sign.Result {
+	verifiedAccount, err := b.getVerifiedAccount(password)
+	if err != nil {
+		return sign.NewErrResult(err)
+	}
+	return b.personalAPI.Sign(rpcParams, verifiedAccount)
+}
+
+// Recover calls the personalAPI to return address associated with the private
+// key that was used to calculate the signature in the message
+func (b *StatusBackend) Recover(rpcParams personal.RecoverParams) sign.Result {
+	return b.personalAPI.Recover(rpcParams)
+}
+
 func (b *StatusBackend) getVerifiedAccount(password string) (*account.SelectedExtKey, error) {
 	selectedAccount, err := b.accountManager.SelectedAccount()
 	if err != nil {
@@ -306,10 +324,14 @@ func (b *StatusBackend) registerHandlers() error {
 		return hash.Hex(), err
 	})
 
-	rpcClient.RegisterHandler(params.PersonalSignMethodName, b.personalAPI.Sign)
-	rpcClient.RegisterHandler(params.PersonalRecoverMethodName, b.personalAPI.Recover)
+	rpcClient.RegisterHandler(params.PersonalSignMethodName, unsupportedMethodHandler)
+	rpcClient.RegisterHandler(params.PersonalRecoverMethodName, unsupportedMethodHandler)
 
 	return nil
+}
+
+func unsupportedMethodHandler(ctx context.Context, rpcParams ...interface{}) (interface{}, error) {
+	return nil, ErrUnsupportedRPCMethod
 }
 
 // ConnectionChange handles network state changes logic.

--- a/services/personal/api.go
+++ b/services/personal/api.go
@@ -2,6 +2,7 @@ package personal
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -22,37 +23,44 @@ var (
 	ErrSignInvalidNumberOfParameters = errors.New("invalid number of parameters for personal_sign (2 or 3 expected)")
 )
 
-type metadata struct {
-	Data    interface{} `json:"data"`
-	Address string      `json:"account"`
+// SignParams required to sign messages
+type SignParams struct {
+	Data     interface{} `json:"data"`
+	Address  string      `json:"account"`
+	Password string      `json:"password"`
 }
 
-func newMetadata(rpcParams []interface{}) (*metadata, error) {
-	// personal_sign can be called with the following parameters
-	// 1) data to sign
-	// 2) account
-	// 3) (optional) password
-	// here, we always ignore (3) because we send a confirmation for the password to UI
-	if len(rpcParams) < 2 || len(rpcParams) > 3 {
-		return nil, ErrSignInvalidNumberOfParameters
-	}
-	data := rpcParams[0]
-	address := rpcParams[1].(string)
+// RecoverParams are for calling `personal_ecRecover`
+type RecoverParams struct {
+	Message   string
+	Signature string
+}
 
-	return &metadata{data, address}, nil
+// UnmarshalSignRPCParams puts the RPC params for `personal_sign` or `web3.personal.sign`
+// into SignParams
+func UnmarshalSignRPCParams(rpcParamsJSON string) (SignParams, error) {
+	var params SignParams
+	err := json.Unmarshal([]byte(rpcParamsJSON), &params)
+	return params, err
+}
+
+// UnmarshalRecoverRPCParams
+func UnmarshalRecoverRPCParams(rpcParamsJSON string) (RecoverParams, error) {
+	var params RecoverParams
+	err := json.Unmarshal([]byte(rpcParamsJSON), &params)
+	return params, err
 }
 
 // PublicAPI represents a set of APIs from the `web3.personal` namespace.
 type PublicAPI struct {
-	pendingSignRequests *sign.PendingRequests
-	rpcClient           *rpc.Client
-	rpcTimeout          time.Duration
+	rpcClient  *rpc.Client
+	rpcTimeout time.Duration
 }
 
 // NewAPI creates an instance of the personal API.
-func NewAPI(pendingSignRequests *sign.PendingRequests) *PublicAPI {
+func NewAPI() *PublicAPI {
 	return &PublicAPI{
-		pendingSignRequests: pendingSignRequests,
+		rpcTimeout: 300 * time.Second,
 	}
 }
 
@@ -63,59 +71,41 @@ func (api *PublicAPI) SetRPC(rpcClient *rpc.Client, timeout time.Duration) {
 }
 
 // Recover is an implementation of `personal_ecRecover` or `web3.personal.ecRecover` API
-func (api *PublicAPI) Recover(context context.Context, rpcParams ...interface{}) (interface{}, error) {
-	var response interface{}
-
+func (api *PublicAPI) Recover(rpcParams RecoverParams) sign.Result {
+	var response sign.Response
+	ctx, cancel := context.WithTimeout(context.Background(), api.rpcTimeout)
+	defer cancel()
 	err := api.rpcClient.CallContextIgnoringLocalHandlers(
-		context, &response, params.PersonalRecoverMethodName, rpcParams...)
+		ctx,
+		&response,
+		params.PersonalRecoverMethodName,
+		rpcParams.Message, rpcParams.Signature)
 
-	return response, err
+	result := sign.Result{Error: err}
+	if err == nil {
+		result.Response = response
+	}
+	return result
 }
 
 // Sign is an implementation of `personal_sign` or `web3.personal.sign` API
-func (api *PublicAPI) Sign(context context.Context, rpcParams ...interface{}) (interface{}, error) {
-	metadata, err := newMetadata(rpcParams)
-	if err != nil {
-		return nil, err
+func (api *PublicAPI) Sign(rpcParams SignParams, verifiedAccount *account.SelectedExtKey) sign.Result {
+	if !strings.EqualFold(rpcParams.Address, verifiedAccount.Address.Hex()) {
+		return sign.NewErrResult(ErrInvalidPersonalSignAccount)
 	}
-	req, err := api.pendingSignRequests.Add(context, params.PersonalSignMethodName, metadata, api.completeFunc(context, *metadata))
-	if err != nil {
-		return nil, err
-	}
+	response := sign.EmptyResponse
+	ctx, cancel := context.WithTimeout(context.Background(), api.rpcTimeout)
+	defer cancel()
+	err := api.rpcClient.CallContextIgnoringLocalHandlers(
+		ctx,
+		&response,
+		params.PersonalSignMethodName,
+		rpcParams.Data, rpcParams.Address, rpcParams.Password)
 
-	result := api.pendingSignRequests.Wait(req.ID, api.rpcTimeout)
-	return result.Response, result.Error
-}
-
-func (api *PublicAPI) completeFunc(context context.Context, metadata metadata) sign.CompleteFunc {
-	return func(acc *account.SelectedExtKey, password string, signArgs *sign.TxArgs) (response sign.Response, err error) {
-		response = sign.EmptyResponse
-
-		err = api.validateAccount(metadata, acc)
-		if err != nil {
-			return
-		}
-
-		err = api.rpcClient.CallContextIgnoringLocalHandlers(
-			context,
-			&response,
-			params.PersonalSignMethodName,
-			metadata.Data, metadata.Address, password)
-
-		return
-	}
-}
-
-// make sure that only account which created the tx can complete it
-func (api *PublicAPI) validateAccount(metadata metadata, selectedAccount *account.SelectedExtKey) error {
-	if selectedAccount == nil {
-		return account.ErrNoAccountSelected
+	result := sign.Result{Error: err}
+	if err == nil {
+		result.Response = response
 	}
 
-	// case-insensitive string comparison
-	if !strings.EqualFold(metadata.Address, selectedAccount.Address.Hex()) {
-		return ErrInvalidPersonalSignAccount
-	}
-
-	return nil
+	return result
 }

--- a/sign/pending_requests.go
+++ b/sign/pending_requests.go
@@ -72,13 +72,13 @@ func (rs *PendingRequests) Approve(id string, password string, args *TxArgs, ver
 	request, err := rs.tryLock(id)
 	if err != nil {
 		rs.log.Warn("can't process transaction", "err", err)
-		return newErrResult(err)
+		return NewErrResult(err)
 	}
 
 	selectedAccount, err := verify(password)
 	if err != nil {
 		rs.complete(request, EmptyResponse, err)
-		return newErrResult(err)
+		return NewErrResult(err)
 	}
 
 	response, err := request.completeFunc(selectedAccount, password, args)
@@ -107,7 +107,7 @@ func (rs *PendingRequests) Discard(id string) error {
 func (rs *PendingRequests) Wait(id string, timeout time.Duration) Result {
 	request, err := rs.Get(id)
 	if err != nil {
-		return newErrResult(err)
+		return NewErrResult(err)
 	}
 	for {
 		select {

--- a/sign/result.go
+++ b/sign/result.go
@@ -32,8 +32,8 @@ type Result struct {
 	Error    error
 }
 
-// newErrResult creates a result based on an empty response and an error
-func newErrResult(err error) Result {
+// NewErrResult creates a result based on an empty response and an error
+func NewErrResult(err error) Result {
 	return Result{
 		Response: EmptyResponse,
 		Error:    err,

--- a/t/e2e/services/base_api_test.go
+++ b/t/e2e/services/base_api_test.go
@@ -12,6 +12,15 @@ import (
 	. "github.com/status-im/status-go/t/utils"
 )
 
+const (
+	// see vendor/github.com/ethereum/go-ethereum/rpc/errors.go:L27
+	methodNotFoundErrorCode = -32601
+)
+
+type rpcError struct {
+	Code int `json:"code"`
+}
+
 type BaseJSONRPCSuite struct {
 	e2e.BackendTestSuite
 }
@@ -106,5 +115,19 @@ func (s *BaseJSONRPCSuite) notificationHandler(account string, pass string, expe
 				s.EqualError(e, expectedError.Error())
 			}
 		}
+	}
+}
+
+func unmarshalEnvelope(jsonEvent string) signal.Envelope {
+	var envelope signal.Envelope
+	if e := json.Unmarshal([]byte(jsonEvent), &envelope); e != nil {
+		panic(e)
+	}
+	return envelope
+}
+
+func (s *BaseJSONRPCSuite) notificationHandlerSuccess(account string, pass string) func(string) {
+	return func(jsonEvent string) {
+		s.notificationHandler(account, pass, nil)(jsonEvent)
 	}
 }

--- a/t/e2e/services/personal_api_test.go
+++ b/t/e2e/services/personal_api_test.go
@@ -1,47 +1,22 @@
 package services
 
 import (
-	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
-	acc "github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/services/personal"
-	"github.com/status-im/status-go/signal"
 	"github.com/stretchr/testify/suite"
 
 	. "github.com/status-im/status-go/t/utils"
 )
 
 const (
-	signDataString   = "0xBAADBEEF"
-	accountNotExists = "0x00164ca341326a03b547c05B343b2E21eFAe2400"
-
-	// see vendor/github.com/ethereum/go-ethereum/rpc/errors.go:L27
-	methodNotFoundErrorCode = -32601
+	signDataString = "0xBAADBEEF"
 )
 
-type rpcError struct {
-	Code int `json:"code"`
-}
-
-type testParams struct {
-	Title             string
-	EnableUpstream    bool
-	Account           string
-	Password          string
-	HandlerFactory    func(string, string) func(string)
-	ExpectedError     error
-	DontSelectAccount bool // to take advantage of the fact, that the default is `false`
-}
-
-func TestPersonalSignSuite(t *testing.T) {
-	s := new(PersonalSignSuite)
-	s.upstream = false
-	suite.Run(t, s)
+type PersonalSignSuite struct {
+	upstream bool
+	BaseJSONRPCSuite
 }
 
 func TestPersonalSignSuiteUpstream(t *testing.T) {
@@ -50,18 +25,13 @@ func TestPersonalSignSuiteUpstream(t *testing.T) {
 	suite.Run(t, s)
 }
 
-type PersonalSignSuite struct {
-	BaseJSONRPCSuite
-	upstream bool
-}
-
 func (s *PersonalSignSuite) TestRestrictedPersonalAPIs() {
 	if s.upstream && GetNetworkID() == params.StatusChainNetworkID {
 		s.T().Skip()
 		return
 	}
 
-	err := s.SetupTest(s.upstream, false, false)
+	err := s.SetupTest(true, false, false)
 	s.NoError(err)
 	defer func() {
 		err := s.Backend.StopNode()
@@ -79,172 +49,30 @@ func (s *PersonalSignSuite) TestRestrictedPersonalAPIs() {
 	s.AssertAPIMethodUnexported("personal_importRawKey")
 }
 
-func (s *PersonalSignSuite) TestPersonalSignSuccess() {
-	s.testPersonalSign(testParams{
-		Account:  TestConfig.Account1.Address,
-		Password: TestConfig.Account1.Password,
-	})
-}
-
-func (s *PersonalSignSuite) TestPersonalSignWrongPassword() {
-	s.testPersonalSign(testParams{
-		Account:        TestConfig.Account1.Address,
-		Password:       TestConfig.Account1.Password,
-		HandlerFactory: s.notificationHandlerWrongPassword,
-	})
-}
-
-func (s *PersonalSignSuite) TestPersonalSignNoSuchAccount() {
-	s.testPersonalSign(testParams{
-		Account:        accountNotExists,
-		Password:       TestConfig.Account1.Password,
-		ExpectedError:  personal.ErrInvalidPersonalSignAccount,
-		HandlerFactory: s.notificationHandlerNoAccount,
-	})
-}
-
-func (s *PersonalSignSuite) TestPersonalSignWrongAccount() {
-	s.testPersonalSign(testParams{
-		Account:        TestConfig.Account2.Address,
-		Password:       TestConfig.Account2.Password,
-		ExpectedError:  personal.ErrInvalidPersonalSignAccount,
-		HandlerFactory: s.notificationHandlerInvalidAccount,
-	})
-}
-
-func (s *PersonalSignSuite) TestPersonalSignNoAccountSelected() {
-	s.testPersonalSign(testParams{
-		Account:           TestConfig.Account1.Address,
-		Password:          TestConfig.Account1.Password,
-		HandlerFactory:    s.notificationHandlerNoAccountSelected,
-		DontSelectAccount: true,
-	})
-}
-
-// Utility methods
-func (s *PersonalSignSuite) notificationHandlerWrongPassword(account string, pass string) func(string) {
-	return func(jsonEvent string) {
-		s.notificationHandler(account, pass+"wrong", keystore.ErrDecrypt)(jsonEvent)
-		s.notificationHandlerSuccess(account, pass)(jsonEvent)
-	}
-}
-
-func (s *PersonalSignSuite) notificationHandlerNoAccount(account string, pass string) func(string) {
-	return func(jsonEvent string) {
-		s.notificationHandler(account, pass, personal.ErrInvalidPersonalSignAccount)(jsonEvent)
-	}
-}
-
-func (s *PersonalSignSuite) notificationHandlerInvalidAccount(account string, pass string) func(string) {
-	return func(jsonEvent string) {
-		s.notificationHandler(account, pass, personal.ErrInvalidPersonalSignAccount)(jsonEvent)
-	}
-}
-
-func (s *PersonalSignSuite) notificationHandlerNoAccountSelected(account string, pass string) func(string) {
-	return func(jsonEvent string) {
-		s.notificationHandler(account, pass, acc.ErrNoAccountSelected)(jsonEvent)
-		envelope := unmarshalEnvelope(jsonEvent)
-		if envelope.Type == signal.EventSignRequestAdded {
-			err := s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password)
-			s.NoError(err)
-		}
-		s.notificationHandlerSuccess(account, pass)(jsonEvent)
-	}
-}
-
-func (s *PersonalSignSuite) notificationHandler(account string, pass string, expectedError error) func(string) {
-	return func(jsonEvent string) {
-		envelope := unmarshalEnvelope(jsonEvent)
-		if envelope.Type == signal.EventSignRequestAdded {
-			event := envelope.Event.(map[string]interface{})
-			id := event["id"].(string)
-			s.T().Logf("Sign request added (will be completed shortly): {id: %s}\n", id)
-
-			//check for the correct method name
-			method := event["method"].(string)
-			s.Equal(params.PersonalSignMethodName, method)
-			//check the event data
-			args := event["args"].(map[string]interface{})
-			s.Equal(signDataString, args["data"].(string))
-			s.Equal(account, args["account"].(string))
-
-			e := s.Backend.ApproveSignRequest(id, pass).Error
-			s.T().Logf("Sign request approved. {id: %s, acc: %s, err: %v}", id, account, e)
-			if expectedError == nil {
-				s.NoError(e, "cannot complete sign reauest[%v]: %v", id, e)
-			} else {
-				s.EqualError(e, expectedError.Error())
-			}
-		}
-	}
-}
-
-func (s *PersonalSignSuite) testPersonalSign(testParams testParams) string {
+func (s *PersonalSignSuite) TestPersonalSignUnsupportedMethod() {
 	// Test upstream if that's not StatusChain
 	if s.upstream && GetNetworkID() == params.StatusChainNetworkID {
 		s.T().Skip()
-		return ""
 	}
 
-	if testParams.HandlerFactory == nil {
-		testParams.HandlerFactory = s.notificationHandlerSuccess
-	}
-
-	err := s.SetupTest(s.upstream, false, false)
+	err := s.SetupTest(true, false, false)
 	s.NoError(err)
 	defer func() {
 		err := s.Backend.StopNode()
 		s.NoError(err)
 	}()
 
-	signal.SetDefaultNodeNotificationHandler(testParams.HandlerFactory(testParams.Account, testParams.Password))
-
-	if testParams.DontSelectAccount {
-		s.NoError(s.Backend.Logout())
-	} else {
-		s.NoError(s.Backend.SelectAccount(TestConfig.Account1.Address, TestConfig.Account1.Password))
-	}
-
 	basicCall := fmt.Sprintf(
 		`{"jsonrpc":"2.0","method":"personal_sign","params":["%s", "%s"],"id":67}`,
 		signDataString,
-		testParams.Account)
+		TestConfig.Account1.Address)
 
-	result := s.Backend.CallRPC(basicCall)
-	if testParams.ExpectedError == nil {
-		s.NotContains(result, "error")
-		return s.extractResultFromRPCResponse(result)
-	}
+	rawResult := s.Backend.CallRPC(basicCall)
 
-	s.Contains(result, testParams.ExpectedError.Error())
-	return ""
+	s.Contains(rawResult, `"error":{"code":-32700,"message":"method is unsupported by RPC interface"}`)
 }
 
-func (s *PersonalSignSuite) extractResultFromRPCResponse(response string) string {
-	var r struct {
-		Result string `json:"result"`
-	}
-	s.NoError(json.Unmarshal([]byte(response), &r))
-
-	return r.Result
-}
-
-func unmarshalEnvelope(jsonEvent string) signal.Envelope {
-	var envelope signal.Envelope
-	if e := json.Unmarshal([]byte(jsonEvent), &envelope); e != nil {
-		panic(e)
-	}
-	return envelope
-}
-
-func (s *PersonalSignSuite) TestPersonalRecoverSuccess() {
-
-	// 1. Sign
-	signedData := s.testPersonalSign(testParams{
-		Account:  TestConfig.Account1.Address,
-		Password: TestConfig.Account1.Password,
-	})
+func (s *PersonalSignSuite) TestPersonalRecoverUnsupportedMethod() {
 
 	// Test upstream if that's not StatusChain
 	if s.upstream && GetNetworkID() == params.StatusChainNetworkID {
@@ -252,7 +80,7 @@ func (s *PersonalSignSuite) TestPersonalRecoverSuccess() {
 		return
 	}
 
-	err := s.SetupTest(s.upstream, false, false)
+	err := s.SetupTest(true, false, false)
 	s.NoError(err)
 	defer func() {
 		err := s.Backend.StopNode()
@@ -263,17 +91,9 @@ func (s *PersonalSignSuite) TestPersonalRecoverSuccess() {
 	basicCall := fmt.Sprintf(
 		`{"jsonrpc":"2.0","method":"personal_ecRecover","params":["%s", "%s"],"id":67}`,
 		signDataString,
-		signedData)
+		"")
 
-	response := s.Backend.CallRPC(basicCall)
+	rawResult := s.Backend.CallRPC(basicCall)
 
-	result := s.extractResultFromRPCResponse(response)
-
-	s.True(strings.EqualFold(result, TestConfig.Account1.Address))
-}
-
-func (s *BaseJSONRPCSuite) notificationHandlerSuccess(account string, pass string) func(string) {
-	return func(jsonEvent string) {
-		s.notificationHandler(account, pass, nil)(jsonEvent)
-	}
+	s.Contains(rawResult, `"error":{"code":-32700,"message":"method is unsupported by RPC interface"}`)
 }


### PR DESCRIPTION
Addresses #1027

This PR removes the PendingSignRequests queue from SignMessage.

It will be merged into feature/remove-transactions-queue-1027 along with PRs to:

- remove PendingSignRequests from Transactor
 - remove PendingSignRequests from PersonalRecover
 - remove PendingSignRequests
