### PR TITLE
Fix android/ios compilation

### DIFF
--- a/signal/signals.c
+++ b/signal/signals.c
@@ -45,6 +45,9 @@ bool StatusServiceSignalEvent(const char *jsonEvent) {
     return true;
 }
 
+void SetEventCallback(void *cb) {
+}
+
 #elif defined(ANDROID_DEPLOYMENT)
 // ======================================================================================
 // Android archive compilation using xgo
@@ -194,6 +197,9 @@ bool StatusServiceSignalEvent(const char *jsonEvent) {
 	}
 
 	return true;
+}
+
+void SetEventCallback(void *cb) {
 }
 
 #else


### PR DESCRIPTION
Compiling `status-go` for android throws an error:

`make statusgo-android` and it fails with `_cgo_4354e057a1a7_Cfunc_SetEventCallback: error: undefined reference to 'SetEventCallback'`

This was introduced when adding desktop support.
The PR adds two dummy implementations for `IOS` and `android`.
