### PR TITLE
silence error when calculating GIT_REMOTE without develop branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GOBIN=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_LOCAL  := $(shell git rev-parse @)
-GIT_REMOTE := $(shell git fetch -q && git rev-parse remotes/origin/develop || echo 'NOT_ON_DEVELOP')
+GIT_REMOTE := $(shell git fetch -q && git rev-parse remotes/origin/develop || echo 'NO_DEVELOP')
 
 BUILD_FLAGS ?= $(shell echo "-ldflags '-X main.buildStamp=`date -u '+%Y-%m-%d.%H:%M:%S'` -X github.com/status-im/status-go/params.VersionMeta=$(GIT_COMMIT)'")
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GOBIN=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GIT_LOCAL  := $(shell git rev-parse @)
-GIT_REMOTE := $(shell git fetch -q && git rev-parse remotes/origin/develop)
+GIT_REMOTE := $(shell git fetch -q && git rev-parse remotes/origin/develop || echo 'NOT_ON_DEVELOP')
 
 BUILD_FLAGS ?= $(shell echo "-ldflags '-X main.buildStamp=`date -u '+%Y-%m-%d.%H:%M:%S'` -X github.com/status-im/status-go/params.VersionMeta=$(GIT_COMMIT)'")
 


### PR DESCRIPTION
Fix calculating `GIT_REMOTE` that is required to prevent the accidental pushing of docker images with `latest` tag.
