### PR TITLE
Disable NTP sync on the remaining e2e tests

### DIFF
--- a/cmd/mailserver-canary/main.go
+++ b/cmd/mailserver-canary/main.go
@@ -192,7 +192,7 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 		return nil, err
 	}
 
-	nodeConfig, err := params.NewNodeConfig(path.Join(workDir, ".ethereum"), "", uint64(params.RopstenNetworkID))
+	nodeConfig, err := params.NewNodeConfig(path.Join(workDir, ".ethereum"), "", params.FleetBeta, uint64(params.RopstenNetworkID))
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -34,7 +34,7 @@ import (
 
 // Errors related to node and services creation.
 var (
-	ErrNodeMakeFailure                    = errors.New("error creating p2p node")
+	ErrNodeMakeFailureFormat              = "error creating p2p node: %s"
 	ErrWhisperServiceRegistrationFailure  = errors.New("failed to register the Whisper service")
 	ErrLightEthRegistrationFailure        = errors.New("failed to register the LES service")
 	ErrPersonalServiceRegistrationFailure = errors.New("failed to register the personal api service")
@@ -76,7 +76,7 @@ func MakeNode(config *params.NodeConfig, db *leveldb.DB) (*node.Node, error) {
 
 	stack, err := node.New(stackConfig)
 	if err != nil {
-		return nil, ErrNodeMakeFailure
+		return nil, fmt.Errorf(ErrNodeMakeFailureFormat, err.Error())
 	}
 
 	// start Ethereum service if we are not expected to use an upstream server

--- a/t/e2e/services/debug_api_test.go
+++ b/t/e2e/services/debug_api_test.go
@@ -143,11 +143,8 @@ func (s *DebugAPISuite) addPeerToCurrentNode(dir string) {
 // newNode creates, configures and starts a new peer.
 func (s *DebugAPISuite) newPeer(name, dir string) *node.StatusNode {
 	// network id is irrelevant
-	cfg, err := params.NewNodeConfig(dir, "", params.FleetBeta, 777)
+	cfg, err := MakeTestNodeConfigWithDataDir(name, dir, 777)
 	s.Require().NoError(err)
-	cfg.LightEthConfig.Enabled = false
-	cfg.Name = name
-	cfg.NetworkID = uint64(GetNetworkID())
 	n := node.New()
 	s.Require().NoError(n.Start(cfg))
 

--- a/t/e2e/whisper/whisper_ext_test.go
+++ b/t/e2e/whisper/whisper_ext_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/status-im/status-go/node"
-	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/signal"
+	"github.com/status-im/status-go/t/utils"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -32,10 +32,8 @@ func (s *WhisperExtensionSuite) SetupTest() {
 		dir, err := ioutil.TempDir("", "test-shhext-")
 		s.NoError(err)
 		// network id is irrelevant
-		cfg, err := params.NewNodeConfig(dir, "", params.FleetBeta, 777)
+		cfg, err := utils.MakeTestNodeConfigWithDataDir(fmt.Sprintf("test-shhext-%d", i), dir, 777)
 		s.Require().NoError(err)
-		cfg.LightEthConfig.Enabled = false
-		cfg.Name = fmt.Sprintf("test-shhext-%d", i)
 		s.nodes[i] = node.New()
 		s.Require().NoError(s.nodes[i].Start(cfg))
 	}

--- a/t/e2e/whisper/whisper_mailbox_test.go
+++ b/t/e2e/whisper/whisper_mailbox_test.go
@@ -131,8 +131,8 @@ func (s *WhisperMailboxSuite) TestRequestMessageFromMailboxAsync() {
 
 	// wait for mail server response
 	resp := s.waitForMailServerResponse(mailServerResponseWatcher, requestID)
-	s.Equal(messageHash, resp.LastEnvelopeHash.String())
-	s.Empty(resp.Cursor)
+	s.Require().Equal(messageHash, resp.LastEnvelopeHash.String())
+	s.Require().Empty(resp.Cursor)
 
 	// wait for last envelope sent by the mailserver to be available for filters
 	s.waitForEnvelopeEvents(envelopeAvailableWatcher, []string{resp.LastEnvelopeHash.String()}, whisper.EventEnvelopeAvailable)

--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -227,7 +227,7 @@ func WaitClosed(c <-chan struct{}, d time.Duration) error {
 	}
 }
 
-// MakeTestNodeConfig defines a function to return a giving params.NodeConfig
+// MakeTestNodeConfig defines a function to return a params.NodeConfig
 // where specific network addresses are assigned based on provided network id.
 func MakeTestNodeConfig(networkID int) (*params.NodeConfig, error) {
 	testDir := filepath.Join(TestDataDir, TestNetworkNames[networkID])
@@ -258,6 +258,22 @@ func MakeTestNodeConfig(networkID int) (*params.NodeConfig, error) {
 	nodeConfig.WhisperConfig.EnableNTPSync = false
 
 	return nodeConfig, nil
+}
+
+// MakeTestNodeConfigWithDataDir defines a function to return a params.NodeConfig
+// where specific network addresses are assigned based on provided network id, and assigns
+// a given name and data dir.
+func MakeTestNodeConfigWithDataDir(name, dataDir string, networkID uint64) (*params.NodeConfig, error) {
+	cfg, err := params.NewNodeConfig(dataDir, "", params.FleetBeta, networkID)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Name = name
+	cfg.NetworkID = uint64(GetNetworkID())
+	cfg.LightEthConfig.Enabled = false
+	cfg.WhisperConfig.EnableNTPSync = false
+
+	return cfg, nil
 }
 
 type account struct {


### PR DESCRIPTION
Some e2e tests still allowed NTP sync to happen. This PR disables NTP sync for all e2e tests. It also improves error reporting in `node.MakeNode` so that the inner error message is not discarded.