### PR TITLE
Fix memleak in signal package

### DIFF
--- a/signal/signals.go
+++ b/signal/signals.go
@@ -3,6 +3,7 @@ package signal
 /*
 #include <stddef.h>
 #include <stdbool.h>
+#include <stdlib.h>
 extern bool StatusServiceSignalEvent(const char *jsonEvent);
 extern void SetEventCallback(void *cb);
 */
@@ -41,7 +42,10 @@ func send(typ string, event interface{}) {
 	if err != nil {
 		logger.Error("Marshalling signal envelope", "error", err)
 	}
-	C.StatusServiceSignalEvent(C.CString(string(data)))
+
+	str := C.CString(string(data))
+	C.StatusServiceSignalEvent(str)
+	C.free(unsafe.Pointer(str))
 }
 
 // NodeNotificationHandler defines a handler able to process incoming node events.
@@ -83,7 +87,9 @@ func NotifyNode(jsonEvent *C.char) {
 //export TriggerTestSignal
 //nolint: golint
 func TriggerTestSignal() {
-	C.StatusServiceSignalEvent(C.CString(`{"answer": 42}`))
+	str := C.CString(`{"answer": 42}`)
+	C.StatusServiceSignalEvent(str)
+	C.free(unsafe.Pointer(str))
 }
 
 // SetSignalEventCallback set callback

--- a/signal/signals.go
+++ b/signal/signals.go
@@ -41,6 +41,7 @@ func send(typ string, event interface{}) {
 	data, err := json.Marshal(&signal)
 	if err != nil {
 		logger.Error("Marshalling signal envelope", "error", err)
+		return
 	}
 
 	str := C.CString(string(data))


### PR DESCRIPTION
We were investigating memory leak in a server instance of statusd, and here is a brief explanation of findings: 
https://github.com/status-im/status-go/issues/1067#issuecomment-407567649

TLDR: 
 a) we call signals even when running as a server
 b) we historically never free memory allocated by `C.CString`.

I believe this fix should stop memory from growing (or at least notable decrease growth).

Closes #1067 
