### PR TITLE
Speedup Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
   - stage: Test unit and integration
     script:
       - make test-unit-race
-      - make test-unit-coverage
+      - make test-unit
   - stage: Test e2e on private network
     script:
       - make test-e2e-race

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ mock: ##@other Regenerate mocks
 docker-test: ##@tests Run tests in a docker container with golang.
 	docker run --privileged --rm -it -v "$(shell pwd):$(DOCKER_TEST_WORKDIR)" -w "$(DOCKER_TEST_WORKDIR)" $(DOCKER_TEST_IMAGE) go test ${ARGS}
 
-test: test-unit-coverage ##@tests Run basic, short tests during development
+test: test-unit ##@tests Run basic, short tests during development
 
 test-unit: UNIT_TEST_PACKAGES = $(shell go list ./...  | \
 	grep -v /vendor | \
@@ -194,9 +194,6 @@ test-unit: UNIT_TEST_PACKAGES = $(shell go list ./...  | \
 	grep -v /lib)
 test-unit: ##@tests Run unit and integration tests
 	go test -v $(UNIT_TEST_PACKAGES) $(gotest_extraflags)
-
-test-unit-coverage: ##@tests Run unit and integration tests with coverage
-	go test -coverpkg= $(UNIT_TEST_PACKAGES) $(gotest_extraflags)
 
 test-unit-race: gotest_extraflags=-race
 test-unit-race: test-unit ##@tests Run unit and integration tests with -race flag
@@ -229,7 +226,6 @@ ci: lint mock dep-ensure test-unit test-e2e ##@tests Run all linters and tests a
 
 clean: ##@other Cleanup
 	rm -fr build/bin/*
-	rm -f coverage.out coverage-all.out coverage.html
 
 deep-clean: clean
 	rm -Rdf .ethereumtest/StatusChain

--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,6 @@ DOCKER_IMAGE_CUSTOM_TAG ?= $(shell BUILD_TAGS="$(BUILD_TAGS)" ./_assets/ci/get-d
 DOCKER_TEST_WORKDIR = /go/src/github.com/status-im/status-go/
 DOCKER_TEST_IMAGE = golang:1.10
 
-UNIT_TEST_PACKAGES := $(shell go list ./...  | \
-	grep -v /vendor | \
-	grep -v /t/e2e | \
-	grep -v /t/benchmarks | \
-	grep -v /lib)
-
 # This is a code for automatic help generator.
 # It supports ANSI colors and categories.
 # To add new item into help output, simply add comments
@@ -193,6 +187,11 @@ docker-test: ##@tests Run tests in a docker container with golang.
 
 test: test-unit-coverage ##@tests Run basic, short tests during development
 
+test-unit: UNIT_TEST_PACKAGES = $(shell go list ./...  | \
+	grep -v /vendor | \
+	grep -v /t/e2e | \
+	grep -v /t/benchmarks | \
+	grep -v /lib)
 test-unit: ##@tests Run unit and integration tests
 	go test -v $(UNIT_TEST_PACKAGES) $(gotest_extraflags)
 

--- a/Makefile
+++ b/Makefile
@@ -146,16 +146,19 @@ push-docker-images: docker-image bootnode-image
 	docker push $(BOOTNODE_IMAGE_NAME):$(DOCKER_IMAGE_CUSTOM_TAG)
 	docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_CUSTOM_TAG)
 
-push-docker-images-latest: docker-image bootnode-image
-	GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-	GIT_LOCAL  := $(shell git rev-parse @)
-	GIT_REMOTE := $(shell git fetch -q && git rev-parse remotes/origin/develop || echo 'NO_DEVELOP')
+# See https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html to understand this magic.
+push-docker-images-latest: GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+push-docker-images-latest: GIT_LOCAL  = $(shell git rev-parse @)
+push-docker-images-latest: GIT_REMOTE = $(shell git fetch -q && git rev-parse remotes/origin/develop || echo 'NO_DEVELOP')
+push-docker-images-latest:
+	@echo "Pushing latest docker images..."
+	@echo "Checking git branch..."
 ifneq ("$(GIT_BRANCH)", "develop")
-	echo "You should only use develop branch to push the latest tag!"
+	$(error You should only use develop branch to push the latest tag!)
 	exit 1
 endif
 ifneq ("$(GIT_LOCAL)", "$(GIT_REMOTE)")
-	echo "The local git commit does not match the remote origin!"
+	$(error The local git commit does not match the remote origin!)
 	exit 1
 endif
 	docker push $(BOOTNODE_IMAGE_NAME):latest

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,6 @@ endif
 CGO_CFLAGS=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-GIT_LOCAL  := $(shell git rev-parse @)
-GIT_REMOTE := $(shell git fetch -q && git rev-parse remotes/origin/develop || echo 'NO_DEVELOP')
 
 BUILD_FLAGS ?= $(shell echo "-ldflags '-X main.buildStamp=`date -u '+%Y-%m-%d.%H:%M:%S'` -X github.com/status-im/status-go/params.VersionMeta=$(GIT_COMMIT)'")
 
@@ -150,6 +147,9 @@ push-docker-images: docker-image bootnode-image
 	docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_CUSTOM_TAG)
 
 push-docker-images-latest: docker-image bootnode-image
+	GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+	GIT_LOCAL  := $(shell git rev-parse @)
+	GIT_REMOTE := $(shell git fetch -q && git rev-parse remotes/origin/develop || echo 'NO_DEVELOP')
 ifneq ("$(GIT_BRANCH)", "develop")
 	echo "You should only use develop branch to push the latest tag!"
 	exit 1

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ push-docker-images: docker-image bootnode-image
 push-docker-images-latest: GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 push-docker-images-latest: GIT_LOCAL  = $(shell git rev-parse @)
 push-docker-images-latest: GIT_REMOTE = $(shell git fetch -q && git rev-parse remotes/origin/develop || echo 'NO_DEVELOP')
-push-docker-images-latest:
+push-docker-images-latest: docker-image bootnode-image
 	@echo "Pushing latest docker images..."
 	@echo "Checking git branch..."
 ifneq ("$(GIT_BRANCH)", "develop")


### PR DESCRIPTION
This PR fixes Makefile slowdown, caused by evaluating several variables on each run. Each evaluation was quite expensive, due to I/O and network access. Even `make help` command was evaluating these variables without reason.

The solution is to move this evaluation to be target specific, and it does require using not very obvious way to define target-specific variables. More info here: https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html


Before:
```bash
$ time make help > /dev/null

real	0m4.719s
user	0m0.546s
sys	0m0.716s
```

After:
```bash
$ time make help > /dev/null

real	0m0.200s
user	0m0.037s
sys	0m0.090s
```

Important changes:
- [x] Move `git` calls into `push-docker-images-latest` target, where they are used
- [x] Move `go list` calls into `test-unit` target, where they are used
- [x] Removed `test-unit-coverage` because nobody was using it
- [x] Slightly improved errors in `push-docker-images-latest` target

<blockquote><div><strong><a href="https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html">GNU make: Target-specific</a></strong></div><div>GNU make: Target-specific</div></blockquote>