### PR TITLE
Allow disabling fleet specification in NewNodeConfig

### DIFF
--- a/cmd/mailserver-canary/main.go
+++ b/cmd/mailserver-canary/main.go
@@ -192,7 +192,7 @@ func makeNodeConfig() (*params.NodeConfig, error) {
 		return nil, err
 	}
 
-	nodeConfig, err := params.NewNodeConfig(path.Join(workDir, ".ethereum"), "", params.FleetBeta, uint64(params.RopstenNetworkID))
+	nodeConfig, err := params.NewNodeConfig(path.Join(workDir, ".ethereum"), "", params.FleetUndefined, uint64(params.RopstenNetworkID))
 	if err != nil {
 		return nil, err
 	}

--- a/params/cluster.go
+++ b/params/cluster.go
@@ -4,8 +4,9 @@ import "errors"
 
 // Define available fleets.
 const (
-	FleetBeta    = "eth.beta"
-	FleetStaging = "eth.staging"
+	FleetUndefined = ""
+	FleetBeta      = "eth.beta"
+	FleetStaging   = "eth.staging"
 )
 
 type cluster struct {

--- a/params/config.go
+++ b/params/config.go
@@ -376,7 +376,7 @@ func NewNodeConfig(dataDir, clstrCfgFile, fleet string, networkID uint64) (*Node
 		LogToStderr:       LogToStderr,
 		ClusterConfigFile: clstrCfgFile,
 		ClusterConfig: &ClusterConfig{
-			Enabled:     true,
+			Enabled:     fleet != FleetUndefined,
 			Fleet:       fleet,
 			StaticNodes: []string{},
 			BootNodes:   []string{},


### PR DESCRIPTION
mailserver-canary is meant to work on a specific enode, so it doesn't need to worry about fleets. This PR modifies `NewNodeConfig` so that passing an empty string for the fleet paratemer disables `ClusterConfig`.
