### PR TITLE
Add rendezvous nodes to cluster

### DIFF
--- a/params/cluster.go
+++ b/params/cluster.go
@@ -9,10 +9,11 @@ const (
 )
 
 type cluster struct {
-	NetworkID   int      `json:"networkID"`
-	StaticNodes []string `json:"staticnodes"`
-	BootNodes   []string `json:"bootnodes"`
-	MailServers []string `json:"mailservers"` // list of trusted mail servers
+	NetworkID       int      `json:"networkID"`
+	StaticNodes     []string `json:"staticnodes"`
+	BootNodes       []string `json:"bootnodes"`
+	MailServers     []string `json:"mailservers"` // list of trusted mail servers
+	RendezvousNodes []string `json:"rendezvousnodes"`
 }
 
 var ropstenCluster = cluster{

--- a/params/config.go
+++ b/params/config.go
@@ -647,6 +647,12 @@ func (c *NodeConfig) updateClusterConfig() error {
 			if len(cluster.BootNodes) == 0 {
 				c.NoDiscovery = true
 			}
+			if len(c.ClusterConfig.RendezvousNodes) == 0 {
+				c.ClusterConfig.RendezvousNodes = cluster.RendezvousNodes
+			}
+			if len(c.ClusterConfig.RendezvousNodes) != 0 {
+				c.Rendezvous = true
+			}
 			c.ClusterConfig.TrustedMailServers = cluster.MailServers
 			break
 		}


### PR DESCRIPTION
Allows to set rendezvous nodes as a part of a certain cluster, in the same way as any other node
