### PR TITLE
add fleet param to GenerateConfig binding

### DIFF
--- a/lib/library.go
+++ b/lib/library.go
@@ -24,8 +24,8 @@ var logger = log.New("package", "status-go/lib")
 
 //GenerateConfig for status node
 //export GenerateConfig
-func GenerateConfig(datadir *C.char, networkID C.int) *C.char {
-	config, err := params.NewNodeConfig(C.GoString(datadir), "", params.FleetBeta, uint64(networkID))
+func GenerateConfig(datadir *C.char, fleet *C.char, networkID C.int) *C.char {
+	config, err := params.NewNodeConfig(C.GoString(datadir), "", C.GoString(fleet), uint64(networkID))
 	if err != nil {
 		return makeJSONResponse(err)
 	}

--- a/lib/library_test_utils.go
+++ b/lib/library_test_utils.go
@@ -203,7 +203,7 @@ func testGetDefaultConfig(t *testing.T) bool {
 		t.Run(fmt.Sprintf("networkID=%d", network.chainID), func(t *testing.T) {
 			var (
 				nodeConfig  = params.NodeConfig{}
-				rawResponse = GenerateConfig(C.CString("/tmp/data-folder"), C.int(network.chainID))
+				rawResponse = GenerateConfig(C.CString("/tmp/data-folder"), C.CString("eth.staging"), C.int(network.chainID))
 			)
 			if err := json.Unmarshal([]byte(C.GoString(rawResponse)), &nodeConfig); err != nil {
 				t.Errorf("cannot decode response (%s): %v", C.GoString(rawResponse), err)

--- a/params/cluster.go
+++ b/params/cluster.go
@@ -9,7 +9,8 @@ const (
 	FleetStaging   = "eth.staging"
 )
 
-type cluster struct {
+// Cluster defines a list of Ethereum nodes.
+type Cluster struct {
 	NetworkID       int      `json:"networkID"`
 	StaticNodes     []string `json:"staticnodes"`
 	BootNodes       []string `json:"bootnodes"`
@@ -17,7 +18,7 @@ type cluster struct {
 	RendezvousNodes []string `json:"rendezvousnodes"`
 }
 
-var ropstenCluster = cluster{
+var ropstenCluster = Cluster{
 	NetworkID: RopstenNetworkID,
 	BootNodes: []string{
 		"enode://436cc6f674928fdc9a9f7990f2944002b685d1c37f025c1be425185b5b1f0900feaf1ccc2a6130268f9901be4a7d252f37302c8335a2c1a62736e9232691cc3a@174.138.105.243:30404", // boot-01.do-ams3.eth.beta
@@ -39,7 +40,7 @@ var ropstenCluster = cluster{
 	},
 }
 
-var rinkebyCluster = cluster{
+var rinkebyCluster = Cluster{
 	NetworkID: RinkebyNetworkID,
 	BootNodes: []string{
 		"enode://436cc6f674928fdc9a9f7990f2944002b685d1c37f025c1be425185b5b1f0900feaf1ccc2a6130268f9901be4a7d252f37302c8335a2c1a62736e9232691cc3a@174.138.105.243:30404", // boot-01.do-ams3.eth.beta
@@ -48,16 +49,20 @@ var rinkebyCluster = cluster{
 		"enode://ebefab39b69bbbe64d8cd86be765b3be356d8c4b24660f65d493143a0c44f38c85a257300178f7845592a1b0332811542e9a58281c835babdd7535babb64efc1@35.202.99.224:30404",   // boot-02.gc-us-central1-a.eth.beta
 	},
 	StaticNodes: []string{
-		"enode://a6a2a9b3a7cbb0a15da74301537ebba549c990e3325ae78e1272a19a3ace150d03c184b8ac86cc33f1f2f63691e467d49308f02d613277754c4dccd6773b95e8@206.189.108.68:30304",
-		"enode://207e53d9bf66be7441e3daba36f53bfbda0b6099dba9a865afc6260a2d253fb8a56a72a48598a4f7ba271792c2e4a8e1a43aaef7f34857f520c8c820f63b44c8@35.224.15.65:30304",
+		"enode://a6a2a9b3a7cbb0a15da74301537ebba549c990e3325ae78e1272a19a3ace150d03c184b8ac86cc33f1f2f63691e467d49308f02d613277754c4dccd6773b95e8@206.189.243.176:30304", // node-01.do-ams3.eth.beta
+		"enode://207e53d9bf66be7441e3daba36f53bfbda0b6099dba9a865afc6260a2d253fb8a56a72a48598a4f7ba271792c2e4a8e1a43aaef7f34857f520c8c820f63b44c8@35.224.15.65:30304",    // node-01.gc-us-central1-a.eth.beta
 	},
 	MailServers: []string{
-		"enode://43829580446ad138386dadb7fa50b6bd4d99f7c28659a0bc08115f8c0380005922a340962496f6af756a42b94a1522baa38a694fa27de59c3a73d4e08d5dbb31@206.189.6.48:30504",
-		"enode://70a2004e78399075f566033c42e9a0b1d43c683d4742755bb5457d03191be66a1b48c2b4fb259696839f28646a5828a1958b900860e27897f984ad0fc8482404@206.189.56.154:30504",
+		"enode://c42f368a23fa98ee546fd247220759062323249ef657d26d357a777443aec04db1b29a3a22ef3e7c548e18493ddaf51a31b0aed6079bd6ebe5ae838fcfaf3a49@206.189.243.162:30504", // mail-01.do-ams3.eth.beta
+		"enode://7aa648d6e855950b2e3d3bf220c496e0cae4adfddef3e1e6062e6b177aec93bc6cdcf1282cb40d1656932ebfdd565729da440368d7c4da7dbd4d004b1ac02bf8@206.189.243.169:30504", // mail-02.do-ams3.eth.beta
+		"enode://8a64b3c349a2e0ef4a32ea49609ed6eb3364be1110253c20adc17a3cebbc39a219e5d3e13b151c0eee5d8e0f9a8ba2cd026014e67b41a4ab7d1d5dd67ca27427@206.189.243.168:30504", // mail-03.do-ams3.eth.beta
+		"enode://7de99e4cb1b3523bd26ca212369540646607c721ad4f3e5c821ed9148150ce6ce2e72631723002210fac1fd52dfa8bbdf3555e05379af79515e1179da37cc3db@35.188.19.210:30504",   // mail-01.gc-us-central1-a.eth.beta
+		"enode://015e22f6cd2b44c8a51bd7a23555e271e0759c7d7f52432719665a74966f2da456d28e154e836bee6092b4d686fe67e331655586c57b718be3997c1629d24167@35.226.21.19:30504",    // mail-02.gc-us-central1-a.eth.beta
+		"enode://531e252ec966b7e83f5538c19bf1cde7381cc7949026a6e499b6e998e695751aadf26d4c98d5a4eabfb7cefd31c3c88d600a775f14ed5781520a88ecd25da3c6@35.225.227.79:30504",   // mail-03.gc-us-central1-a.eth.beta
 	},
 }
 
-var mainnetCluster = cluster{
+var mainnetCluster = Cluster{
 	NetworkID: MainNetworkID,
 	BootNodes: []string{
 		"enode://436cc6f674928fdc9a9f7990f2944002b685d1c37f025c1be425185b5b1f0900feaf1ccc2a6130268f9901be4a7d252f37302c8335a2c1a62736e9232691cc3a@174.138.105.243:30404", // boot-01.do-ams3.eth.beta
@@ -79,9 +84,9 @@ var mainnetCluster = cluster{
 	},
 }
 
-var betaCluster = []cluster{ropstenCluster, rinkebyCluster, mainnetCluster}
+var betaCluster = []Cluster{ropstenCluster, rinkebyCluster, mainnetCluster}
 
-var stagingCluster = []cluster{
+var stagingCluster = []Cluster{
 	{
 		NetworkID: MainNetworkID,
 		BootNodes: []string{
@@ -98,8 +103,8 @@ var stagingCluster = []cluster{
 	},
 }
 
-// clusterForFleet returns a cluster for a given fleet.
-func clusterForFleet(fleet string) ([]cluster, error) {
+// ClusterForFleet returns a cluster for a given fleet.
+func ClusterForFleet(fleet string) ([]Cluster, error) {
 	switch fleet {
 	case FleetStaging:
 		return stagingCluster, nil
@@ -108,4 +113,14 @@ func clusterForFleet(fleet string) ([]cluster, error) {
 	default:
 		return nil, errors.New("fleet could not be found")
 	}
+}
+
+// ClusterForNetwork selects a cluster for a given network ID.
+func ClusterForNetwork(clusters []Cluster, networkID int) (Cluster, bool) {
+	for _, c := range clusters {
+		if c.NetworkID == networkID {
+			return c, true
+		}
+	}
+	return Cluster{}, false
 }

--- a/params/config.go
+++ b/params/config.go
@@ -612,13 +612,10 @@ func (c *NodeConfig) updateClusterConfig() error {
 		return nil
 	}
 
-	c.log.Debug(
-		"update cluster config",
-		"configFile", c.ClusterConfigFile,
-		"fleet", c.ClusterConfig.Fleet)
+	c.log.Info("update cluster config", "configFile", c.ClusterConfigFile, "fleet", c.ClusterConfig.Fleet)
 
 	var (
-		clusters []cluster
+		clusters []Cluster
 		err      error
 	)
 
@@ -633,7 +630,7 @@ func (c *NodeConfig) updateClusterConfig() error {
 			return fmt.Errorf("failed to unmarshal cluster configuration file: %s", err)
 		}
 	} else {
-		clusters, err = clusterForFleet(c.ClusterConfig.Fleet)
+		clusters, err = ClusterForFleet(c.ClusterConfig.Fleet)
 		if err != nil {
 			return fmt.Errorf("getting fleet '%s' failed: %v", c.ClusterConfig.Fleet, err)
 		}

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -389,7 +389,7 @@ var loadConfigTestCases = []struct {
 				"Fleet": "eth.staging"
 			}
 		}`,
-		func(t *testing.T, _ string, nodeConfig *params.NodeConfig, err error) {
+		func(t *testing.T, _ string, nodeConfig *params.NodeConfig, loadConfErr error) {
 			stagingClusters, err := params.ClusterForFleet("eth.staging")
 			require.NoError(t, err)
 			staging, ok := params.ClusterForNetwork(stagingClusters, params.RopstenNetworkID)
@@ -403,7 +403,7 @@ var loadConfigTestCases = []struct {
 			require.NotEqual(t, staging, beta)
 
 			// assert
-			require.NoError(t, err)
+			require.NoError(t, loadConfErr)
 			require.Equal(t, "eth.staging", nodeConfig.ClusterConfig.Fleet)
 			require.Equal(t, staging.BootNodes, nodeConfig.ClusterConfig.BootNodes)
 		},


### PR DESCRIPTION
Other changes:
- added a unit test to make sure that `ClusterConfig` is properly populated based on a selected fleet,
- added mail servers for Rinkeby and `eth.beta` cluster (they are not used by status-react yet).