### PR TITLE
Enable proxying and discovery of rinkeby nodes

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -720,13 +720,15 @@ func GetStatusHome() string {
 }
 
 // LesTopic returns discovery v5 topic derived from genesis of the provided network.
-// 1 - mainnet, 4 - ropsten
+// 1 - mainnet, 3 - ropsten, 4 - rinkeby
 func LesTopic(netid int) string {
 	switch netid {
 	case 1:
-		return "LES2@" + common.Bytes2Hex(params.MainnetGenesisHash.Bytes()[:8])
+		return LESDiscoveryIdentifier + common.Bytes2Hex(params.MainnetGenesisHash.Bytes()[:8])
 	case 3:
-		return "LES2@" + common.Bytes2Hex(params.TestnetGenesisHash.Bytes()[:8])
+		return LESDiscoveryIdentifier + common.Bytes2Hex(params.TestnetGenesisHash.Bytes()[:8])
+	case 4:
+		return LESDiscoveryIdentifier + common.Bytes2Hex(params.RinkebyGenesisHash.Bytes()[:8])
 	default:
 		return ""
 	}

--- a/params/defaults.go
+++ b/params/defaults.go
@@ -114,6 +114,9 @@ const (
 
 	// WhisperDiscv5Topic used to register and search for whisper peers using discovery v5.
 	WhisperDiscv5Topic = discv5.Topic("whisper")
+
+	// LESDiscoveryIdentifier is a prefix for topic used for LES peers discovery.
+	LESDiscoveryIdentifier = "LES2@"
 )
 
 var (


### PR DESCRIPTION
Proxy will be able to discover nodes from rinkeby network (by providing `-les=4` flag to binary.
And client will be able to discover nodes from rendezvous or discovery with topic generated from rinkeby genesis.