### PR TITLE
Update version format of artifacts in Jenkins

### DIFF
--- a/_assets/ci/Jenkinsfile-manual
+++ b/_assets/ci/Jenkinsfile-manual
@@ -73,7 +73,7 @@ node('linux') {
         dir(cloneDir) {
             // For branch builds, replace the old artifact. For develop keep all of them.
             def version = sh(
-                script: "git describe --exact-match --tag 2>/dev/null || git rev-parse --short HEAD",
+                script: "git describe --exact-match --tag 2>/dev/null || git describe --always",
                 returnStdout: true
             ).trim()
             def server = Artifactory.server 'artifacts'

--- a/_assets/ci/Jenkinsfile-manual
+++ b/_assets/ci/Jenkinsfile-manual
@@ -75,7 +75,7 @@ node('linux') {
             def version = sh(
                 script: "git describe --exact-match --tag 2>/dev/null || git rev-parse --short HEAD",
                 returnStdout: true
-            )
+            ).trim()
             def server = Artifactory.server 'artifacts'
             def uploadSpec = """{
                 "files": [

--- a/_assets/ci/Jenkinsfile-manual
+++ b/_assets/ci/Jenkinsfile-manual
@@ -72,9 +72,10 @@ node('linux') {
     stage('Deploy') {
         dir(cloneDir) {
             // For branch builds, replace the old artifact. For develop keep all of them.
-            def version = sh("""
-                git describe --exact-match --tag 2>/dev/null || git rev-parse --short HEAD
-            """, returnStdout: true)
+            def version = sh(
+                script: "git describe --exact-match --tag 2>/dev/null || git rev-parse --short HEAD",
+                returnStdout: true
+            )
             def server = Artifactory.server 'artifacts'
             def uploadSpec = """{
                 "files": [

--- a/_assets/ci/Jenkinsfile-manual
+++ b/_assets/ci/Jenkinsfile-manual
@@ -1,20 +1,5 @@
 #!/usr/bin/env groovy
 
-@NonCPS
-def getVersion(branch, sha, buildNumber) {
-    version = branch.replaceAll(/\//, '-')
-
-    if (sha?.trim()) {
-        version = version + '-g' + sha
-    }
-
-    if (buildNumber?.trim()) {
-        version = version + '-' + buildNumber
-    }
-
-    return version
-}
-
 node('linux') {
     env.GOPATH = "${env.WORKSPACE}"
     env.PATH = "${env.PATH}:${env.GOPATH}/bin"
@@ -87,7 +72,9 @@ node('linux') {
     stage('Deploy') {
         dir(cloneDir) {
             // For branch builds, replace the old artifact. For develop keep all of them.
-            def version = gitBranch == 'develop' ? getVersion(gitBranch, gitShortSHA, '') : getVersion(gitBranch, gitShortSHA, env.BUILD_ID)
+            def version = sh("""
+                git describe --exact-match --tag 2>/dev/null || git rev-parse --short HEAD
+            """, returnStdout: true)
             def server = Artifactory.server 'artifacts'
             def uploadSpec = """{
                 "files": [


### PR DESCRIPTION
From now on, versions generated by Jenkins and `make statusgo` are the same.