### PR TITLE
Add patch 0036-fix-whisper-expire-loop

### DIFF
--- a/_assets/patches/geth/0036-fix-whisper-expire-loop.patch
+++ b/_assets/patches/geth/0036-fix-whisper-expire-loop.patch
@@ -1,0 +1,13 @@
+diff --git a/whisper/whisperv6/whisper.go b/whisper/whisperv6/whisper.go
+index 48bbca3c..482457cb 100644
+--- a/whisper/whisperv6/whisper.go
++++ b/whisper/whisperv6/whisper.go
+@@ -1060,7 +1060,7 @@ func (whisper *Whisper) expire() {
+ 				whisper.stats.messagesCleared++
+ 				whisper.stats.memoryCleared += sz
+ 				whisper.stats.memoryUsed -= sz
+-				return true
++				return false
+ 			})
+ 			whisper.expirations[expiry].Clear()
+ 			delete(whisper.expirations, expiry)

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go
@@ -1085,7 +1085,7 @@ func (whisper *Whisper) expire() {
 				whisper.stats.messagesCleared++
 				whisper.stats.memoryCleared += sz
 				whisper.stats.memoryUsed -= sz
-				return true
+				return false
 			})
 			whisper.expirations[expiry].Clear()
 			delete(whisper.expirations, expiry)


### PR DESCRIPTION
This bug was caused when go-ethereum changed a library implementing `Set`. Due to different implementation of `Each()`, a loop in `expire()` was removing only the first matching item instead all of them. This led to leaking expired envelopes.