### PR TITLE
Whisper traffic rate limiting

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -347,6 +347,14 @@
   revision = "b497e2f366b8624394fb2e89c10ab607bebdde0b"
 
 [[projects]]
+  digest = "1:8b3234b10eacd5edea45bf0c13a585b608749da23f94aaf29b46d9ef8a8babf4"
+  name = "github.com/juju/ratelimit"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "59fac5042749a5afb9af70e813da1dd5474f0167"
+  version = "1.0.1"
+
+[[projects]]
   digest = "1:cdf2acbea0cf5514bc9a548836d007e379a42b4224813649ed9d98757c527172"
   name = "github.com/karalabe/hid"
   packages = ["."]
@@ -1056,6 +1064,7 @@
     "github.com/ethereum/go-ethereum/rpc",
     "github.com/ethereum/go-ethereum/whisper/whisperv6",
     "github.com/golang/mock/gomock",
+    "github.com/juju/ratelimit",
     "github.com/libp2p/go-libp2p-crypto",
     "github.com/multiformats/go-multiaddr",
     "github.com/pborman/uuid",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -155,3 +155,7 @@ ignored = [ "github.com/ethereum/go-ethereum/ethapi" ]
 [[override]]
   name = "github.com/deckarep/golang-set"
   revision = "504e848d77ea4752b3057b8fb46da0e7f746ccf3"
+
+[[constraint]]
+  name = "github.com/juju/ratelimit"
+  version = "1.0.1"

--- a/services/shhext/whisper_test.go
+++ b/services/shhext/whisper_test.go
@@ -5,19 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPeerDropsConnection(t *testing.T) {
-	conf := &whisper.Config{
-		MinimumAcceptedPOW: 0,
-		MaxMessageSize:     100 << 10,
-		IngressRateLimit:   whisper.RateLimitConfig{uint64(time.Hour), 10 << 10, 1 << 10},
-		EgressRateLimit:    whisper.RateLimitConfig{uint64(time.Hour), 10 << 10, 1 << 10},
-	}
+func setupTestWithOnePeer(t *testing.T, conf *whisper.Config) (*whisper.Whisper, *p2p.MsgPipeRW, chan error) {
 	w := whisper.New(conf)
 	idx, _ := discover.BytesID([]byte{0x01})
 	p := p2p.NewPeer(idx, "1", []p2p.Cap{{"shh", 6}})
@@ -30,14 +25,77 @@ func TestPeerDropsConnection(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), msg.Code)
 	require.NoError(t, msg.Discard())
-	require.NoError(t, p2p.SendItems(rw1, 0, whisper.ProtocolVersion, math.Float64bits(w.MinPow()), w.BloomFilter()))
+	require.NoError(t, p2p.SendItems(rw1, 0, whisper.ProtocolVersion, math.Float64bits(w.MinPow()), w.BloomFilter(), true))
 	require.NoError(t, p2p.ExpectMsg(rw1, 8, conf.IngressRateLimit), "peer must send ingress rate limit after handshake")
+	return w, rw1, errorc
+}
 
-	require.NoError(t, p2p.Send(rw1, 42, make([]byte, 11<<10)))
+func TestPeerDropsConnection(t *testing.T) {
+	conf := &whisper.Config{
+		MinimumAcceptedPOW: 0,
+		MaxMessageSize:     100 << 10,
+		IngressRateLimit:   whisper.RateLimitConfig{uint64(time.Hour), 10 << 10, 1 << 10},
+		EgressRateLimit:    whisper.RateLimitConfig{uint64(time.Hour), 10 << 10, 1 << 10},
+	}
+	_, rw1, errorc := setupTestWithOnePeer(t, conf)
+
+	require.NoError(t, p2p.Send(rw1, 42, make([]byte, 11<<10))) // limit is 1024
 	select {
 	case err := <-errorc:
 		require.Error(t, err, "error must be related to reaching rate limit")
 	case <-time.After(time.Second):
 		require.FailNow(t, "failed waiting for HandlePeer to exit")
+	}
+}
+
+func TestRateLimitedDelivery(t *testing.T) {
+	conf := &whisper.Config{
+		MinimumAcceptedPOW: 0,
+		MaxMessageSize:     100 << 10,
+		IngressRateLimit:   whisper.RateLimitConfig{uint64(time.Hour), 10 << 10, 1 << 10},
+		EgressRateLimit:    whisper.RateLimitConfig{uint64(time.Hour), 10 << 10, 1 << 10},
+		TimeSource:         time.Now,
+	}
+	w, rw1, _ := setupTestWithOnePeer(t, conf)
+	small1 := whisper.Envelope{
+		Expiry: uint32(time.Now().Add(10 * time.Second).Unix()),
+		TTL:    10,
+		Topic:  whisper.TopicType{1},
+		Data:   make([]byte, 1<<10),
+		Nonce:  1,
+	}
+	small2 := small1
+	small2.Nonce = 2
+	big := small1
+	big.Nonce = 3
+	big.Data = make([]byte, 11<<10)
+
+	require.NoError(t, w.Send(&small1))
+	require.NoError(t, w.Send(&big))
+	require.NoError(t, w.Send(&small2))
+
+	received := map[common.Hash]struct{}{}
+	// we can not guarantee that all expected envelopes will be delivered in a one batch
+	// so allow whisper to write multiple times and read every message
+	go func() {
+		time.Sleep(2 * time.Second)
+		rw1.Close()
+	}()
+	for {
+		msg, err := rw1.ReadMsg()
+		if err == p2p.ErrPipeClosed {
+			require.Contains(t, received, small1.Hash())
+			require.Contains(t, received, small2.Hash())
+			require.NotContains(t, received, big.Hash())
+			break
+		}
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), msg.Code)
+		var rst []*whisper.Envelope
+		require.NoError(t, msg.Decode(&rst))
+		for _, e := range rst {
+			received[e.Hash()] = struct{}{}
+		}
+
 	}
 }

--- a/services/shhext/whisper_test.go
+++ b/services/shhext/whisper_test.go
@@ -1,0 +1,43 @@
+package shhext
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/discover"
+	whisper "github.com/ethereum/go-ethereum/whisper/whisperv6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerDropsConnection(t *testing.T) {
+	conf := &whisper.Config{
+		MinimumAcceptedPOW: 0,
+		MaxMessageSize:     100 << 10,
+		IngressRateLimit:   whisper.RateLimitConfig{uint64(time.Hour), 10 << 10, 1 << 10},
+		EgressRateLimit:    whisper.RateLimitConfig{uint64(time.Hour), 10 << 10, 1 << 10},
+	}
+	w := whisper.New(conf)
+	idx, _ := discover.BytesID([]byte{0x01})
+	p := p2p.NewPeer(idx, "1", []p2p.Cap{{"shh", 6}})
+	rw1, rw2 := p2p.MsgPipe()
+	errorc := make(chan error, 1)
+	go func() {
+		errorc <- w.HandlePeer(p, rw2)
+	}()
+	msg, err := rw1.ReadMsg()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), msg.Code)
+	require.NoError(t, msg.Discard())
+	require.NoError(t, p2p.SendItems(rw1, 0, whisper.ProtocolVersion, math.Float64bits(w.MinPow()), w.BloomFilter()))
+	require.NoError(t, p2p.ExpectMsg(rw1, 8, conf.IngressRateLimit), "peer must send ingress rate limit after handshake")
+
+	require.NoError(t, p2p.Send(rw1, 42, make([]byte, 11<<10)))
+	select {
+	case err := <-errorc:
+		require.Error(t, err, "error must be related to reaching rate limit")
+	case <-time.After(time.Second):
+		require.FailNow(t, "failed waiting for HandlePeer to exit")
+	}
+}

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/config.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/config.go
@@ -18,11 +18,20 @@ package whisperv6
 
 import "time"
 
+// RateLimitConfig defines configuration for actual rate limiter.
+type RateLimitConfig struct {
+	Interval time.Duration
+	Capacity int64
+	Quantum  int64
+}
+
 // Config represents the configuration state of a whisper node.
 type Config struct {
 	MaxMessageSize     uint32  `toml:",omitempty"`
 	MinimumAcceptedPOW float64 `toml:",omitempty"`
 	TimeSource         func() time.Time
+	IngressRateLimit   RateLimitConfig
+	EgressRateLimit    RateLimitConfig
 }
 
 // DefaultConfig represents (shocker!) the default configuration.
@@ -30,4 +39,6 @@ var DefaultConfig = Config{
 	MaxMessageSize:     DefaultMaxMessageSize,
 	MinimumAcceptedPOW: DefaultMinimumPoW,
 	TimeSource:         time.Now,
+	IngressRateLimit:   RateLimitConfig{1 * time.Minute, 1 << (10 * 3), 10 << (10 * 2)},
+	EgressRateLimit:    RateLimitConfig{500 * time.Millisecond, 1 << (10 * 3), 10 << (10 * 2)},
 }

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/config.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/config.go
@@ -20,9 +20,13 @@ import "time"
 
 // RateLimitConfig defines configuration for actual rate limiter.
 type RateLimitConfig struct {
-	Interval time.Duration
-	Capacity int64
-	Quantum  int64
+	Interval uint64
+	Capacity uint64
+	Quantum  uint64
+}
+
+func (conf RateLimitConfig) IntervalDuration() time.Duration {
+	return time.Duration(conf.Interval)
 }
 
 // Config represents the configuration state of a whisper node.
@@ -39,6 +43,6 @@ var DefaultConfig = Config{
 	MaxMessageSize:     DefaultMaxMessageSize,
 	MinimumAcceptedPOW: DefaultMinimumPoW,
 	TimeSource:         time.Now,
-	IngressRateLimit:   RateLimitConfig{1 * time.Minute, 1 << (10 * 3), 10 << (10 * 2)},
-	EgressRateLimit:    RateLimitConfig{500 * time.Millisecond, 1 << (10 * 3), 10 << (10 * 2)},
+	IngressRateLimit:   RateLimitConfig{uint64(1 * time.Minute), 1 << (10 * 3), 10 << (10 * 2)},
+	EgressRateLimit:    RateLimitConfig{uint64(500 * time.Millisecond), 1 << (10 * 3), 10 << (10 * 2)},
 }

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/doc.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/doc.go
@@ -47,6 +47,7 @@ const (
 	messagesCode           = 1   // normal whisper message
 	powRequirementCode     = 2   // PoW requirement
 	bloomFilterExCode      = 3   // bloom filter exchange
+	peerRateLimitCode      = 8   // update of the peer rate limit
 	p2pRequestCompleteCode = 125 // peer-to-peer message, used by Dapp protocol
 	p2pRequestCode         = 126 // peer-to-peer message, used by Dapp protocol
 	p2pMessageCode         = 127 // peer-to-peer message (to be consumed by the peer, but not forwarded any further)

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/peer.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/peer.go
@@ -192,7 +192,7 @@ func (peer *Peer) expire() {
 func (peer *Peer) updateEgressRateLimit(conf RateLimitConfig) {
 	peer.egressMu.Lock()
 	defer peer.egressMu.Unlock()
-	peer.egressRateLimit = ratelimit.NewBucketWithQuantum(conf.Interval, conf.Capacity, conf.Quantum)
+	peer.egressRateLimit = ratelimit.NewBucketWithQuantum(conf.IntervalDuration(), int64(conf.Capacity), int64(conf.Quantum))
 }
 
 // broadcast iterates over the collection of envelopes and transmits yet unknown

--- a/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go
+++ b/vendor/github.com/ethereum/go-ethereum/whisper/whisperv6/whisper.go
@@ -844,6 +844,8 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 					return errors.New("invalid direct message")
 				}
 				whisper.postEvent(&envelope, true)
+			} else {
+				return fmt.Errorf("peer %x sent us %d, while connection is not marked as trusted.", p.ID(), p2pMessageCode)
 			}
 		case p2pRequestCode:
 			// Must be processed if mail server is implemented. Otherwise ignore.

--- a/vendor/github.com/juju/ratelimit/LICENSE
+++ b/vendor/github.com/juju/ratelimit/LICENSE
@@ -1,0 +1,191 @@
+All files in this repository are licensed as follows. If you contribute
+to this repository, it is assumed that you license your contribution
+under the same license unless you state otherwise.
+
+All files Copyright (C) 2015 Canonical Ltd. unless otherwise specified in the file.
+
+This software is licensed under the LGPLv3, included below.
+
+As a special exception to the GNU Lesser General Public License version 3
+("LGPL3"), the copyright holders of this Library give you permission to
+convey to a third party a Combined Work that links statically or dynamically
+to this Library without providing any Minimal Corresponding Source or
+Minimal Application Code as set out in 4d or providing the installation
+information set out in section 4e, provided that you comply with the other
+provisions of LGPL3 and provided that you meet, for the Application the
+terms and conditions of the license(s) which apply to the Application.
+
+Except as stated in this special exception, the provisions of LGPL3 will
+continue to comply in full to this Library. If you modify this Library, you
+may apply this exception to your version of this Library, but you are not
+obliged to do so. If you do not wish to do so, delete this exception
+statement from your version. This exception does not (and cannot) modify any
+license terms which apply to the Application, with which you must still
+comply.
+
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/vendor/github.com/juju/ratelimit/ratelimit.go
+++ b/vendor/github.com/juju/ratelimit/ratelimit.go
@@ -1,0 +1,344 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3 with static-linking exception.
+// See LICENCE file for details.
+
+// Package ratelimit provides an efficient token bucket implementation
+// that can be used to limit the rate of arbitrary things.
+// See http://en.wikipedia.org/wiki/Token_bucket.
+package ratelimit
+
+import (
+	"math"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// The algorithm that this implementation uses does computational work
+// only when tokens are removed from the bucket, and that work completes
+// in short, bounded-constant time (Bucket.Wait benchmarks at 175ns on
+// my laptop).
+//
+// Time is measured in equal measured ticks, a given interval
+// (fillInterval) apart. On each tick a number of tokens (quantum) are
+// added to the bucket.
+//
+// When any of the methods are called the bucket updates the number of
+// tokens that are in the bucket, and it records the current tick
+// number too. Note that it doesn't record the current time - by
+// keeping things in units of whole ticks, it's easy to dish out tokens
+// at exactly the right intervals as measured from the start time.
+//
+// This allows us to calculate the number of tokens that will be
+// available at some time in the future with a few simple arithmetic
+// operations.
+//
+// The main reason for being able to transfer multiple tokens on each tick
+// is so that we can represent rates greater than 1e9 (the resolution of the Go
+// time package) tokens per second, but it's also useful because
+// it means we can easily represent situations like "a person gets
+// five tokens an hour, replenished on the hour".
+
+// Bucket represents a token bucket that fills at a predetermined rate.
+// Methods on Bucket may be called concurrently.
+type Bucket struct {
+	clock Clock
+
+	// startTime holds the moment when the bucket was
+	// first created and ticks began.
+	startTime time.Time
+
+	// capacity holds the overall capacity of the bucket.
+	capacity int64
+
+	// quantum holds how many tokens are added on
+	// each tick.
+	quantum int64
+
+	// fillInterval holds the interval between each tick.
+	fillInterval time.Duration
+
+	// mu guards the fields below it.
+	mu sync.Mutex
+
+	// availableTokens holds the number of available
+	// tokens as of the associated latestTick.
+	// It will be negative when there are consumers
+	// waiting for tokens.
+	availableTokens int64
+
+	// latestTick holds the latest tick for which
+	// we know the number of tokens in the bucket.
+	latestTick int64
+}
+
+// NewBucket returns a new token bucket that fills at the
+// rate of one token every fillInterval, up to the given
+// maximum capacity. Both arguments must be
+// positive. The bucket is initially full.
+func NewBucket(fillInterval time.Duration, capacity int64) *Bucket {
+	return NewBucketWithClock(fillInterval, capacity, nil)
+}
+
+// NewBucketWithClock is identical to NewBucket but injects a testable clock
+// interface.
+func NewBucketWithClock(fillInterval time.Duration, capacity int64, clock Clock) *Bucket {
+	return NewBucketWithQuantumAndClock(fillInterval, capacity, 1, clock)
+}
+
+// rateMargin specifes the allowed variance of actual
+// rate from specified rate. 1% seems reasonable.
+const rateMargin = 0.01
+
+// NewBucketWithRate returns a token bucket that fills the bucket
+// at the rate of rate tokens per second up to the given
+// maximum capacity. Because of limited clock resolution,
+// at high rates, the actual rate may be up to 1% different from the
+// specified rate.
+func NewBucketWithRate(rate float64, capacity int64) *Bucket {
+	return NewBucketWithRateAndClock(rate, capacity, nil)
+}
+
+// NewBucketWithRateAndClock is identical to NewBucketWithRate but injects a
+// testable clock interface.
+func NewBucketWithRateAndClock(rate float64, capacity int64, clock Clock) *Bucket {
+	// Use the same bucket each time through the loop
+	// to save allocations.
+	tb := NewBucketWithQuantumAndClock(1, capacity, 1, clock)
+	for quantum := int64(1); quantum < 1<<50; quantum = nextQuantum(quantum) {
+		fillInterval := time.Duration(1e9 * float64(quantum) / rate)
+		if fillInterval <= 0 {
+			continue
+		}
+		tb.fillInterval = fillInterval
+		tb.quantum = quantum
+		if diff := math.Abs(tb.Rate() - rate); diff/rate <= rateMargin {
+			return tb
+		}
+	}
+	panic("cannot find suitable quantum for " + strconv.FormatFloat(rate, 'g', -1, 64))
+}
+
+// nextQuantum returns the next quantum to try after q.
+// We grow the quantum exponentially, but slowly, so we
+// get a good fit in the lower numbers.
+func nextQuantum(q int64) int64 {
+	q1 := q * 11 / 10
+	if q1 == q {
+		q1++
+	}
+	return q1
+}
+
+// NewBucketWithQuantum is similar to NewBucket, but allows
+// the specification of the quantum size - quantum tokens
+// are added every fillInterval.
+func NewBucketWithQuantum(fillInterval time.Duration, capacity, quantum int64) *Bucket {
+	return NewBucketWithQuantumAndClock(fillInterval, capacity, quantum, nil)
+}
+
+// NewBucketWithQuantumAndClock is like NewBucketWithQuantum, but
+// also has a clock argument that allows clients to fake the passing
+// of time. If clock is nil, the system clock will be used.
+func NewBucketWithQuantumAndClock(fillInterval time.Duration, capacity, quantum int64, clock Clock) *Bucket {
+	if clock == nil {
+		clock = realClock{}
+	}
+	if fillInterval <= 0 {
+		panic("token bucket fill interval is not > 0")
+	}
+	if capacity <= 0 {
+		panic("token bucket capacity is not > 0")
+	}
+	if quantum <= 0 {
+		panic("token bucket quantum is not > 0")
+	}
+	return &Bucket{
+		clock:           clock,
+		startTime:       clock.Now(),
+		latestTick:      0,
+		fillInterval:    fillInterval,
+		capacity:        capacity,
+		quantum:         quantum,
+		availableTokens: capacity,
+	}
+}
+
+// Wait takes count tokens from the bucket, waiting until they are
+// available.
+func (tb *Bucket) Wait(count int64) {
+	if d := tb.Take(count); d > 0 {
+		tb.clock.Sleep(d)
+	}
+}
+
+// WaitMaxDuration is like Wait except that it will
+// only take tokens from the bucket if it needs to wait
+// for no greater than maxWait. It reports whether
+// any tokens have been removed from the bucket
+// If no tokens have been removed, it returns immediately.
+func (tb *Bucket) WaitMaxDuration(count int64, maxWait time.Duration) bool {
+	d, ok := tb.TakeMaxDuration(count, maxWait)
+	if d > 0 {
+		tb.clock.Sleep(d)
+	}
+	return ok
+}
+
+const infinityDuration time.Duration = 0x7fffffffffffffff
+
+// Take takes count tokens from the bucket without blocking. It returns
+// the time that the caller should wait until the tokens are actually
+// available.
+//
+// Note that if the request is irrevocable - there is no way to return
+// tokens to the bucket once this method commits us to taking them.
+func (tb *Bucket) Take(count int64) time.Duration {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	d, _ := tb.take(tb.clock.Now(), count, infinityDuration)
+	return d
+}
+
+// TakeMaxDuration is like Take, except that
+// it will only take tokens from the bucket if the wait
+// time for the tokens is no greater than maxWait.
+//
+// If it would take longer than maxWait for the tokens
+// to become available, it does nothing and reports false,
+// otherwise it returns the time that the caller should
+// wait until the tokens are actually available, and reports
+// true.
+func (tb *Bucket) TakeMaxDuration(count int64, maxWait time.Duration) (time.Duration, bool) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	return tb.take(tb.clock.Now(), count, maxWait)
+}
+
+// TakeAvailable takes up to count immediately available tokens from the
+// bucket. It returns the number of tokens removed, or zero if there are
+// no available tokens. It does not block.
+func (tb *Bucket) TakeAvailable(count int64) int64 {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	return tb.takeAvailable(tb.clock.Now(), count)
+}
+
+// takeAvailable is the internal version of TakeAvailable - it takes the
+// current time as an argument to enable easy testing.
+func (tb *Bucket) takeAvailable(now time.Time, count int64) int64 {
+	if count <= 0 {
+		return 0
+	}
+	tb.adjustavailableTokens(tb.currentTick(now))
+	if tb.availableTokens <= 0 {
+		return 0
+	}
+	if count > tb.availableTokens {
+		count = tb.availableTokens
+	}
+	tb.availableTokens -= count
+	return count
+}
+
+// Available returns the number of available tokens. It will be negative
+// when there are consumers waiting for tokens. Note that if this
+// returns greater than zero, it does not guarantee that calls that take
+// tokens from the buffer will succeed, as the number of available
+// tokens could have changed in the meantime. This method is intended
+// primarily for metrics reporting and debugging.
+func (tb *Bucket) Available() int64 {
+	return tb.available(tb.clock.Now())
+}
+
+// available is the internal version of available - it takes the current time as
+// an argument to enable easy testing.
+func (tb *Bucket) available(now time.Time) int64 {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.adjustavailableTokens(tb.currentTick(now))
+	return tb.availableTokens
+}
+
+// Capacity returns the capacity that the bucket was created with.
+func (tb *Bucket) Capacity() int64 {
+	return tb.capacity
+}
+
+// Rate returns the fill rate of the bucket, in tokens per second.
+func (tb *Bucket) Rate() float64 {
+	return 1e9 * float64(tb.quantum) / float64(tb.fillInterval)
+}
+
+// take is the internal version of Take - it takes the current time as
+// an argument to enable easy testing.
+func (tb *Bucket) take(now time.Time, count int64, maxWait time.Duration) (time.Duration, bool) {
+	if count <= 0 {
+		return 0, true
+	}
+
+	tick := tb.currentTick(now)
+	tb.adjustavailableTokens(tick)
+	avail := tb.availableTokens - count
+	if avail >= 0 {
+		tb.availableTokens = avail
+		return 0, true
+	}
+	// Round up the missing tokens to the nearest multiple
+	// of quantum - the tokens won't be available until
+	// that tick.
+
+	// endTick holds the tick when all the requested tokens will
+	// become available.
+	endTick := tick + (-avail+tb.quantum-1)/tb.quantum
+	endTime := tb.startTime.Add(time.Duration(endTick) * tb.fillInterval)
+	waitTime := endTime.Sub(now)
+	if waitTime > maxWait {
+		return 0, false
+	}
+	tb.availableTokens = avail
+	return waitTime, true
+}
+
+// currentTick returns the current time tick, measured
+// from tb.startTime.
+func (tb *Bucket) currentTick(now time.Time) int64 {
+	return int64(now.Sub(tb.startTime) / tb.fillInterval)
+}
+
+// adjustavailableTokens adjusts the current number of tokens
+// available in the bucket at the given time, which must
+// be in the future (positive) with respect to tb.latestTick.
+func (tb *Bucket) adjustavailableTokens(tick int64) {
+	if tb.availableTokens >= tb.capacity {
+		return
+	}
+	tb.availableTokens += (tick - tb.latestTick) * tb.quantum
+	if tb.availableTokens > tb.capacity {
+		tb.availableTokens = tb.capacity
+	}
+	tb.latestTick = tick
+	return
+}
+
+// Clock represents the passage of time in a way that
+// can be faked out for tests.
+type Clock interface {
+	// Now returns the current time.
+	Now() time.Time
+	// Sleep sleeps for at least the given duration.
+	Sleep(d time.Duration)
+}
+
+// realClock implements Clock in terms of standard time functions.
+type realClock struct{}
+
+// Now implements Clock.Now by calling time.Now.
+func (realClock) Now() time.Time {
+	return time.Now()
+}
+
+// Now implements Clock.Sleep by calling time.Sleep.
+func (realClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}

--- a/vendor/github.com/juju/ratelimit/reader.go
+++ b/vendor/github.com/juju/ratelimit/reader.go
@@ -1,0 +1,51 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3 with static-linking exception.
+// See LICENCE file for details.
+
+package ratelimit
+
+import "io"
+
+type reader struct {
+	r      io.Reader
+	bucket *Bucket
+}
+
+// Reader returns a reader that is rate limited by
+// the given token bucket. Each token in the bucket
+// represents one byte.
+func Reader(r io.Reader, bucket *Bucket) io.Reader {
+	return &reader{
+		r:      r,
+		bucket: bucket,
+	}
+}
+
+func (r *reader) Read(buf []byte) (int, error) {
+	n, err := r.r.Read(buf)
+	if n <= 0 {
+		return n, err
+	}
+	r.bucket.Wait(int64(n))
+	return n, err
+}
+
+type writer struct {
+	w      io.Writer
+	bucket *Bucket
+}
+
+// Writer returns a reader that is rate limited by
+// the given token bucket. Each token in the bucket
+// represents one byte.
+func Writer(w io.Writer, bucket *Bucket) io.Writer {
+	return &writer{
+		w:      w,
+		bucket: bucket,
+	}
+}
+
+func (w *writer) Write(buf []byte) (int, error) {
+	w.bucket.Wait(int64(len(buf)))
+	return w.w.Write(buf)
+}


### PR DESCRIPTION
Current change allow to define ingress and egress limits, assuming that limiter will use token based approach for traffic limiting.

Peer will be dropped if it sends more traffic than user defined in the ingress rate limit. If cumulative ingress traffic is higher than egress limit peer will have to sacrifice certain traffic to preserve target peer rate limit. This is done by randomly selecting envelopes that fit under allocated limit. Envelopes are selected randomly because of the assumption that it will allow to preserve as much traffic as possible.

Locally configured rate limit will be advertised to a peer using separate p2p call. Ideally we would advertise this limit as a part of handshake, but as long as it is not in upstream we cannot do it. However I will submit proposal once all details will be sorted out and implementation will prove itself useful and not too naive.