### PR TITLE
Use 10s as TTL for rendezvous with 5s for registration renewal

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -767,7 +767,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0a0848f018c29e4db5d941c2a8dbbbcaf1ea74f294c4759b69e8664b0a242040"
+  digest = "1:b9b4aaa95bb880c345f400d7de8d5023731f71a9dfd4ff62ec77a74acfda529e"
   name = "github.com/status-im/rendezvous"
   packages = [
     ".",
@@ -775,7 +775,7 @@
     "server",
   ]
   pruneopts = "NUT"
-  revision = "444e3eda4a281ca36d61df8a2a0832265d09511d"
+  revision = "7fe5bc0fd1c58bb7f7bec64656d8b821bec8338f"
 
 [[projects]]
   digest = "1:572c783a763db6383aca3179976eb80e4c900f52eba56cba8bb2e3cea7ce720e"

--- a/discovery/rendezvous.go
+++ b/discovery/rendezvous.go
@@ -101,7 +101,7 @@ func (r *Rendezvous) register(topic string) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	err := r.client.Register(ctx, srv, topic, r.record)
+	err := r.client.Register(ctx, srv, topic, r.record, r.registrationPeriod)
 	if err != nil {
 		log.Error("error registering", "topic", topic, "rendezvous server", srv, "err", err)
 	}
@@ -110,7 +110,9 @@ func (r *Rendezvous) register(topic string) error {
 
 // Register renews registration in the specified server.
 func (r *Rendezvous) Register(topic string, stop chan struct{}) error {
-	ticker := time.NewTicker(r.registrationPeriod)
+	// sending registration more often than the whole registraton period
+	// will ensure that it won't be accidentally removed
+	ticker := time.NewTicker(r.registrationPeriod / 2)
 	defer ticker.Stop()
 
 	if err := r.register(topic); err == context.Canceled {

--- a/vendor/github.com/status-im/rendezvous/client.go
+++ b/vendor/github.com/status-im/rendezvous/client.go
@@ -50,7 +50,7 @@ type Client struct {
 	h host.Host
 }
 
-func (c Client) Register(ctx context.Context, srv ma.Multiaddr, topic string, record enr.Record) error {
+func (c Client) Register(ctx context.Context, srv ma.Multiaddr, topic string, record enr.Record, ttl time.Duration) error {
 	s, err := c.newStream(ctx, srv)
 	if err != nil {
 		return err
@@ -59,7 +59,7 @@ func (c Client) Register(ctx context.Context, srv ma.Multiaddr, topic string, re
 	if err = rlp.Encode(s, protocol.REGISTER); err != nil {
 		return err
 	}
-	if err = rlp.Encode(s, protocol.Register{Topic: topic, Record: record, TTL: uint64(5 * time.Second)}); err != nil {
+	if err = rlp.Encode(s, protocol.Register{Topic: topic, Record: record, TTL: uint64(ttl)}); err != nil {
 		return err
 	}
 	rs := rlp.NewStream(s, 0)

--- a/vendor/github.com/status-im/rendezvous/server/metrics.go
+++ b/vendor/github.com/status-im/rendezvous/server/metrics.go
@@ -1,0 +1,29 @@
+package server
+
+var (
+	metrics MetricsInterface = noopMetrics{}
+)
+
+func UseMetrics(m MetricsInterface) {
+	metrics = m
+}
+
+type MetricsInterface interface {
+	AddActiveRegistration(...string)
+	RemoveActiveRegistration(...string)
+	ObserveDiscoverSize(float64, ...string)
+	ObserveDiscoveryDuration(float64, ...string)
+	CountError(...string)
+}
+
+type noopMetrics struct{}
+
+func (n noopMetrics) AddActiveRegistration(lvs ...string) {}
+
+func (n noopMetrics) RemoveActiveRegistration(lvs ...string) {}
+
+func (n noopMetrics) ObserveDiscoverSize(o float64, lvs ...string) {}
+
+func (n noopMetrics) ObserveDiscoveryDuration(o float64, lvs ...string) {}
+
+func (n noopMetrics) CountError(lvs ...string) {}


### PR DESCRIPTION
Rendezvous client was using hardcoded TTL which could lead to a situation when identity was removed from active registrations, but new registration wasn't yet sent.

I had to update rendezvous client, and all consequentially all other parts of library cause it is used in tests. Major changes in vendor related to prometheus and protobuf updated that is compatible with prometheus.