### PR TITLE
Use in-memory DB for test

### DIFF
--- a/node/status_node_test.go
+++ b/node/status_node_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestStatusNodeStart(t *testing.T) {
-	config, err := utils.MakeTestNodeConfig(params.StatusChainNetworkID)
+	config, err := utils.MakeTestNodeConfigWithDataDir("", "", params.FleetUndefined, params.StatusChainNetworkID)
 	require.NoError(t, err)
 	n := New()
 


### PR DESCRIPTION
This PR fixes a test that got broken in 3d00af7fa3b0a263b306f994dbeafdf94eefc766. The original branch contained this fix, but somehow it got lost in the squash.