### PR TITLE
Fix updating peers limit if LES is enabled in CLI

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -69,10 +69,12 @@ func init() {
 }
 
 func main() {
-	config, err := params.NewNodeConfigWithDefaults("statusd-data", params.FleetBeta, params.RopstenNetworkID)
-	if err == nil {
-		err = parseConfig(configFiles, config)
-	}
+	config, err := params.NewNodeConfigWithDefaultsAndFiles(
+		"statusd-data",
+		params.FleetBeta,
+		params.RopstenNetworkID,
+		configFiles...,
+	)
 	if err != nil {
 		printUsage()
 		if err != nil {
@@ -81,8 +83,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	if *logLevel != "" {
+		config.LogLevel = *logLevel
+	}
+
 	colors := !(*logWithoutColors) && terminal.IsTerminal(int(os.Stdin.Fd()))
-	if err = logutils.OverrideRootLog(logEnabled(config), config.LogLevel, config.LogFile, colors); err != nil {
+	if err := logutils.OverrideRootLog(
+		logEnabled(config),
+		config.LogLevel,
+		config.LogFile,
+		colors,
+	); err != nil {
 		stdlog.Fatalf("Error initializing logger: %v", err)
 	}
 
@@ -202,19 +213,6 @@ func configureStatusService(flagValue string, nodeConfig *params.NodeConfig) (*p
 	}
 
 	return nodeConfig, nil
-}
-
-func parseConfig(configFiles configFlags, config *params.NodeConfig) error {
-	// Merge specified configuration files, in order
-	if err := params.LoadConfigFromFiles(configFiles, config); err != nil {
-		return err
-	}
-
-	if *logLevel != "" {
-		config.LogLevel = *logLevel
-	}
-
-	return nil
 }
 
 // printVersion prints verbose output about version and config.

--- a/params/config.go
+++ b/params/config.go
@@ -274,7 +274,8 @@ type NodeConfig struct {
 	MailServerRegistryAddress string
 }
 
-// NewNodeConfigWithDefaults creates new node configuration object with some defaults suitable for adhoc use
+// NewNodeConfigWithDefaults creates new node configuration object
+// with some defaults suitable for adhoc use.
 func NewNodeConfigWithDefaults(dataDir, fleet string, networkID uint64) (*NodeConfig, error) {
 	nodeConfig, err := NewNodeConfig(dataDir, fleet, networkID)
 	if err != nil {
@@ -307,6 +308,27 @@ func NewNodeConfigWithDefaults(dataDir, fleet string, networkID uint64) (*NodeCo
 	nodeConfig.updatePeerLimits()
 
 	return nodeConfig, nil
+}
+
+// NewNodeConfigWithDefaultsAndFiles creates new node configuration object
+// with some defaults suitable for adhoc use and applies config files on top.
+func NewNodeConfigWithDefaultsAndFiles(
+	dataDir, fleet string, networkID uint64, files ...string,
+) (*NodeConfig, error) {
+	c, err := NewNodeConfigWithDefaults(dataDir, fleet, networkID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		if err := loadConfigConfigFromFile(file, c); err != nil {
+			return nil, err
+		}
+	}
+
+	c.updatePeerLimits()
+
+	return c, nil
 }
 
 // updatePeerLimits will set default peer limits expectations based on enabled services.


### PR DESCRIPTION
When starting a status node from the CLI with LES enabled, the peers limits are properly updated to search for LES peers.

Without this fix, even though LES is enabled, LES peers are not searched for because the peers limits were not configured with proper topics.