### PR TITLE
WIP - Fix xgo creating files as `root`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ tags
 # used by the Makefile
 /build/_workspace/
 /build/bin/
-/vendor/github.com/karalabe/xgo
+/vendor/github.com/status-im/xgo
 
 # travis
 profile.tmp

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,8 @@ xgo-docker-images: ##@docker Build xgo docker images
 
 xgo:
 	docker pull $(XGOIMAGE)
-	go get github.com/karalabe/xgo
+	go get github.com/status-im/xgo
+	mkdir -p $(GOLIB)
 
 setup: dep-install lint-install mock-install update-fleet-config ##@other Prepare project for first build
 

--- a/_assets/build/xgo/base/Dockerfile
+++ b/_assets/build/xgo/base/Dockerfile
@@ -1,5 +1,14 @@
 FROM karalabe/xgo-1.10.x
 
+# Inject the old Go package downloader and tool-chain bootstrapper
+ADD bootstrap.sh /bootstrap.sh
+ENV BOOTSTRAP /bootstrap.sh
+RUN chmod +x $BOOTSTRAP
+
+# Inject the C dependency cross compiler
+ADD build_deps.sh /build_deps.sh
+RUN chmod +x $BUILD_DEPS
+
 # Inject the container entry point, the build script (patched for Status bindings conditional builds of C code)
 ADD build.sh /build.sh
 ENV BUILD /build.sh

--- a/_assets/build/xgo/base/bootstrap.sh
+++ b/_assets/build/xgo/base/bootstrap.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Contains the Go tool-chain bootstrapper, that retrieves all the configured
+# distribution packages, extracts the binaries and deletes anything not needed.
+#
+# Usage: bootstrap.sh
+#
+# Needed environment variables:
+#   FETCH - Remote file fetcher and checksum verifier (injected by image)
+#   DIST_LINUX_64,  DIST_LINUX_64_SHA  - 64 bit Linux Go binaries and checksum
+#   DIST_LINUX_32,  DIST_LINUX_32_SHA  - 32 bit Linux Go binaries and checksum
+#   DIST_LINUX_ARM, DIST_LINUX_ARM_SHA - ARM v5 Linux Go binaries and checksum
+#   DIST_OSX_64,    DIST_OSX_64_SHA    - 64 bit Mac OSX Go binaries and checksum
+#   DIST_OSX_32,    DIST_OSX_32_SHA    - 32 bit Mac OSX Go binaries and checksum
+#   DIST_WIN_64,    DIST_WIN_64_SHA    - 64 bit Windows Go binaries and checksum
+#   DIST_WIN_32,    DIST_WIN_32_SHA    - 32 bit Windows Go binaries and checksum
+set -e
+
+# Download and verify all the binary packages
+$FETCH $DIST_LINUX_64  $DIST_LINUX_64_SHA
+$FETCH $DIST_LINUX_32  $DIST_LINUX_32_SHA
+$FETCH $DIST_LINUX_ARM $DIST_LINUX_ARM_SHA
+$FETCH $DIST_OSX_64    $DIST_OSX_64_SHA
+$FETCH $DIST_OSX_32    $DIST_OSX_32_SHA
+$FETCH $DIST_WIN_64    $DIST_WIN_64_SHA
+$FETCH $DIST_WIN_32    $DIST_WIN_32_SHA
+
+# Extract the 64 bit Linux package as the primary Go SDK
+tar -C /usr/local -xzf `basename $DIST_LINUX_64`
+rm -f `basename $DIST_LINUX_64`
+
+export GOROOT=/usr/local/go
+export GOROOT_BOOTSTRAP=$GOROOT
+
+# Extract all other packages as secondary ones, keeping only the binaries
+if [ "$DIST_LINUX_32" != "" ]; then
+  tar -C /usr/local --wildcards -xzf `basename $DIST_LINUX_32` go/pkg/linux_386*
+  GOOS=linux GOARCH=386 /usr/local/go/pkg/tool/linux_amd64/dist bootstrap
+  rm -f `basename $DIST_LINUX_32`
+fi
+if [ "$DIST_LINUX_ARM" != "" ]; then
+  tar -C /usr/local --wildcards -xzf `basename $DIST_LINUX_ARM` go/pkg/linux_arm*
+  GOOS=linux GOARCH=arm /usr/local/go/pkg/tool/linux_amd64/dist bootstrap
+  rm -f `basename $DIST_LINUX_ARM`
+fi
+
+if [ "$DIST_OSX_64" != "" ]; then
+  tar -C /usr/local --wildcards -xzf `basename $DIST_OSX_64` go/pkg/darwin_amd64*
+  GOOS=darwin GOARCH=amd64 /usr/local/go/pkg/tool/linux_amd64/dist bootstrap
+  rm -f `basename $DIST_OSX_64`
+fi
+if [ "$DIST_OSX_32" != "" ]; then
+  tar -C /usr/local --wildcards -xzf `basename $DIST_OSX_32` go/pkg/darwin_386*
+  GOOS=darwin GOARCH=386 /usr/local/go/pkg/tool/linux_amd64/dist bootstrap
+  rm -f `basename $DIST_OSX_32`
+fi
+
+if [ "$DIST_WIN_64" != "" ]; then
+  unzip -d /usr/local -q `basename $DIST_WIN_64` go/pkg/windows_amd64*
+  GOOS=windows GOARCH=amd64 /usr/local/go/pkg/tool/linux_amd64/dist bootstrap
+  rm -f `basename $DIST_WIN_64`
+fi
+if [ "$DIST_WIN_32" != "" ]; then
+  unzip -d /usr/local -q `basename $DIST_WIN_32` go/pkg/windows_386*
+  GOOS=windows GOARCH=386 /usr/local/go/pkg/tool/linux_amd64/dist bootstrap
+  rm -f `basename $DIST_WIN_32`
+fi
+
+# Install xgo within the container to enable internal cross compilation
+echo "Installing xgo-in-xgo..."
+go get -u github.com/status-im/xgo

--- a/_assets/build/xgo/base/build.sh
+++ b/_assets/build/xgo/base/build.sh
@@ -115,11 +115,11 @@ else
 fi
 
 # Download all the C dependencies
-mkdir /deps
+mkdir /tmp/deps
 DEPS=($DEPS) && for dep in "${DEPS[@]}"; do
-  if [ "${dep##*.}" == "tar" ]; then cat "/deps-cache/`basename $dep`" | tar -C /deps -x; fi
-  if [ "${dep##*.}" == "gz" ];  then cat "/deps-cache/`basename $dep`" | tar -C /deps -xz; fi
-  if [ "${dep##*.}" == "bz2" ]; then cat "/deps-cache/`basename $dep`" | tar -C /deps -xj; fi
+  if [ "${dep##*.}" == "tar" ]; then cat "/deps-cache/`basename $dep`" | tar -C /tmp/deps -x; fi
+  if [ "${dep##*.}" == "gz" ];  then cat "/deps-cache/`basename $dep`" | tar -C /tmp/deps -xz; fi
+  if [ "${dep##*.}" == "bz2" ]; then cat "/deps-cache/`basename $dep`" | tar -C /tmp/deps -xj; fi
 done
 
 DEPS_ARGS=($ARGS)
@@ -167,7 +167,7 @@ for TARGET in $TARGETS; do
     else
       unset CGO_CCPIE CGO_LDPIE EXT_LDPIE
     fi
-    mkdir -p /build-android-aar
+    mkdir -p /tmp/build-android-aar
 
     # Iterate over the requested architectures, bootstrap and build
     if [ $XGOARCH == "." ] || [ $XGOARCH == "arm" ] || [ $XGOARCH == "aar" ]; then
@@ -186,7 +186,7 @@ for TARGET in $TARGETS; do
         CC=arm-linux-androideabi-gcc GOOS=android GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="$CGO_CCPIE" CGO_LDFLAGS="$CGO_LDPIE" go install std
 
         echo "Compiling for android-$PLATFORM/arm..."
-        CC=arm-linux-androideabi-gcc CXX=arm-linux-androideabi-g++ HOST=arm-linux-androideabi PREFIX=/usr/$ANDROID_CHAIN_ARM/arm-linux-androideabi $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+        CC=arm-linux-androideabi-gcc CXX=arm-linux-androideabi-g++ HOST=arm-linux-androideabi PREFIX=/usr/$ANDROID_CHAIN_ARM/arm-linux-androideabi $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
         export PKG_CONFIG_PATH=/usr/$ANDROID_CHAIN_ARM/arm-linux-androideabi/lib/pkgconfig
 
         if [ $XGOARCH == "." ] || [ $XGOARCH == "arm" ]; then
@@ -195,7 +195,7 @@ for TARGET in $TARGETS; do
         fi
         if [ $XGOARCH == "." ] || [ $XGOARCH == "aar" ]; then
           CC=arm-linux-androideabi-gcc CXX=arm-linux-androideabi-g++ GOOS=android GOARCH=arm GOARM=7 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
-          CC=arm-linux-androideabi-gcc CXX=arm-linux-androideabi-g++ GOOS=android GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${T[@]}" --ldflags="$V $EXT_LDAMD $LD" --buildmode=c-shared -o "/build-android-aar/$NAME-android-$PLATFORM-arm.so" ./$PACK
+          CC=arm-linux-androideabi-gcc CXX=arm-linux-androideabi-g++ GOOS=android GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${T[@]}" --ldflags="$V $EXT_LDAMD $LD" --buildmode=c-shared -o "/tmp/build-android-aar/$NAME-android-$PLATFORM-arm.so" ./$PACK
         fi
       fi
     fi
@@ -210,7 +210,7 @@ for TARGET in $TARGETS; do
         CC=i686-linux-android-gcc GOOS=android GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_CCPIE" CGO_LDFLAGS="$CGO_LDPIE" go install std
 
         echo "Compiling for android-$PLATFORM/386..."
-        CC=i686-linux-android-gcc CXX=i686-linux-android-g++ HOST=i686-linux-android PREFIX=/usr/$ANDROID_CHAIN_386/i686-linux-android $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+        CC=i686-linux-android-gcc CXX=i686-linux-android-g++ HOST=i686-linux-android PREFIX=/usr/$ANDROID_CHAIN_386/i686-linux-android $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
         export PKG_CONFIG_PATH=/usr/$ANDROID_CHAIN_386/i686-linux-android/lib/pkgconfig
 
         if [ $XGOARCH == "." ] || [ $XGOARCH == "386" ]; then
@@ -219,7 +219,7 @@ for TARGET in $TARGETS; do
         fi
         if [ $XGOARCH == "." ] || [ $XGOARCH == "aar" ]; then
           CC=i686-linux-android-gcc CXX=i686-linux-android-g++ GOOS=android GOARCH=386 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
-          CC=i686-linux-android-gcc CXX=i686-linux-android-g++ GOOS=android GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${T[@]}" --ldflags="$V $LD" --buildmode=c-shared -o "/build-android-aar/$NAME-android-$PLATFORM-386.so" ./$PACK
+          CC=i686-linux-android-gcc CXX=i686-linux-android-g++ GOOS=android GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${T[@]}" --ldflags="$V $LD" --buildmode=c-shared -o "/tmp/build-android-aar/$NAME-android-$PLATFORM-386.so" ./$PACK
         fi
       fi
       if [ "$PLATFORM" -ge 21 ] && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm64" ] || [ $XGOARCH == "aar" ]); then
@@ -230,7 +230,7 @@ for TARGET in $TARGETS; do
         CC=aarch64-linux-android-gcc GOOS=android GOARCH=arm64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_CCPIE" CGO_LDFLAGS="$CGO_LDPIE" go install std
 
         echo "Compiling for android-$PLATFORM/arm64..."
-        CC=aarch64-linux-android-gcc CXX=aarch64-linux-android-g++ HOST=aarch64-linux-android PREFIX=/usr/$ANDROID_CHAIN_ARM64/aarch64-linux-android $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+        CC=aarch64-linux-android-gcc CXX=aarch64-linux-android-g++ HOST=aarch64-linux-android PREFIX=/usr/$ANDROID_CHAIN_ARM64/aarch64-linux-android $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
         export PKG_CONFIG_PATH=/usr/$ANDROID_CHAIN_ARM64/aarch64-linux-android/lib/pkgconfig
 
         if [ $XGOARCH == "." ] || [ $XGOARCH == "arm64" ]; then
@@ -239,7 +239,7 @@ for TARGET in $TARGETS; do
         fi
         if [ $XGOARCH == "." ] || [ $XGOARCH == "aar" ]; then
           CC=aarch64-linux-android-gcc CXX=aarch64-linux-android-g++ GOOS=android GOARCH=arm64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
-          CC=aarch64-linux-android-gcc CXX=aarch64-linux-android-g++ GOOS=android GOARCH=arm64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${T[@]}" --ldflags="$V $LD" --buildmode=c-shared -o "/build-android-aar/$NAME-android-$PLATFORM-arm64.so" ./$PACK
+          CC=aarch64-linux-android-gcc CXX=aarch64-linux-android-g++ GOOS=android GOARCH=arm64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${T[@]}" --ldflags="$V $LD" --buildmode=c-shared -o "/tmp/build-android-aar/$NAME-android-$PLATFORM-arm64.so" ./$PACK
         fi
       fi
     fi
@@ -265,7 +265,7 @@ for TARGET in $TARGETS; do
 
       # Generate the JNI wrappers automatically with SWIG
       jni=`mktemp -d`
-      header=`find /build-android-aar | grep '\.h$' | head -n 1`
+      header=`find /tmp/build-android-aar | grep '\.h$' | head -n 1`
       if [ "$header" == "" ]; then
         echo "No API C header specified, skipping android-$PLATFORM/aar..."
       else
@@ -278,7 +278,7 @@ for TARGET in $TARGETS; do
         swig -java -package $package -outdir $jni/${package//.//} $jni/$NAME.i
 
         # Assemble the Go static libraries and the JNI interface into shared libraries
-        for lib in `find /build-android-aar | grep '\.so$'`; do
+        for lib in `find /tmp/build-android-aar | grep '\.so$'`; do
           if [[ "$lib" = *-arm.so ]];   then cc=arm-linux-androideabi-gcc; abi="armeabi-v7a"; fi
           if [[ "$lib" = *-arm64.so ]]; then cc=aarch64-linux-android-gcc; abi="arm64-v8a"; fi
           if [[ "$lib" = *-386.so ]];   then cc=i686-linux-android-gcc;    abi="x86"; fi
@@ -300,20 +300,20 @@ for TARGET in $TARGETS; do
       fi
     fi
     # Clean up the android builds, toolchains and runtimes
-    rm -rf /build-android-aar
+    rm -rf /tmp/build-android-aar
     rm -rf /usr/local/go/pkg/android_*
     rm -rf /usr/$ANDROID_CHAIN_ARM /usr/$ANDROID_CHAIN_ARM64 /usr/$ANDROID_CHAIN_386
   fi
   # Check and build for Linux targets
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
     echo "Compiling for linux/amd64..."
-    HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+    HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
     GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
     GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $V $X "${T[@]}" --ldflags="$V $LD" $R $BM -o "/build/$NAME-linux-amd64$R`extension linux`" ./$PACK
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
     echo "Compiling for linux/386..."
-    HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+    HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
     GOOS=linux GOARCH=386 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
     GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $X "${T[@]}" --ldflags="$V $LD" $BM -o "/build/$NAME-linux-386`extension linux`" ./$PACK
   fi
@@ -323,7 +323,7 @@ for TARGET in $TARGETS; do
       CC=arm-linux-gnueabi-gcc-5 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go install std
     fi
     echo "Compiling for linux/arm-5..."
-    CC=arm-linux-gnueabi-gcc-5 CXX=arm-linux-gnueabi-g++-5 HOST=arm-linux-gnueabi PREFIX=/usr/arm-linux-gnueabi CFLAGS="-march=armv5" CXXFLAGS="-march=armv5" $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+    CC=arm-linux-gnueabi-gcc-5 CXX=arm-linux-gnueabi-g++-5 HOST=arm-linux-gnueabi PREFIX=/usr/arm-linux-gnueabi CFLAGS="-march=armv5" CXXFLAGS="-march=armv5" $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
     export PKG_CONFIG_PATH=/usr/arm-linux-gnueabi/lib/pkgconfig
 
     CC=arm-linux-gnueabi-gcc-5 CXX=arm-linux-gnueabi-g++-5 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
@@ -341,7 +341,7 @@ for TARGET in $TARGETS; do
       CC=arm-linux-gnueabi-gcc-5 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go install std
 
       echo "Compiling for linux/arm-6..."
-      CC=arm-linux-gnueabi-gcc-5 CXX=arm-linux-gnueabi-g++-5 HOST=arm-linux-gnueabi PREFIX=/usr/arm-linux-gnueabi CFLAGS="-march=armv6" CXXFLAGS="-march=armv6" $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=arm-linux-gnueabi-gcc-5 CXX=arm-linux-gnueabi-g++-5 HOST=arm-linux-gnueabi PREFIX=/usr/arm-linux-gnueabi CFLAGS="-march=armv6" CXXFLAGS="-march=armv6" $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
       export PKG_CONFIG_PATH=/usr/arm-linux-gnueabi/lib/pkgconfig
 
       CC=arm-linux-gnueabi-gcc-5 CXX=arm-linux-gnueabi-g++-5 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
@@ -359,7 +359,7 @@ for TARGET in $TARGETS; do
       CC=arm-linux-gnueabihf-gcc-5 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a" CGO_CXXFLAGS="-march=armv7-a" go install std
 
       echo "Compiling for linux/arm-7..."
-      CC=arm-linux-gnueabihf-gcc-5 CXX=arm-linux-gnueabihf-g++-5 HOST=arm-linux-gnueabihf PREFIX=/usr/arm-linux-gnueabihf CFLAGS="-march=armv7-a -fPIC" CXXFLAGS="-march=armv7-a -fPIC" $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=arm-linux-gnueabihf-gcc-5 CXX=arm-linux-gnueabihf-g++-5 HOST=arm-linux-gnueabihf PREFIX=/usr/arm-linux-gnueabihf CFLAGS="-march=armv7-a -fPIC" CXXFLAGS="-march=armv7-a -fPIC" $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
       export PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig
 
       CC=arm-linux-gnueabihf-gcc-5 CXX=arm-linux-gnueabihf-g++-5 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a -fPIC" CGO_CXXFLAGS="-march=armv7-a -fPIC" go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
@@ -374,7 +374,7 @@ for TARGET in $TARGETS; do
       echo "Go version too low, skipping linux/arm64..."
     else
       echo "Compiling for linux/arm64..."
-      CC=aarch64-linux-gnu-gcc-5 CXX=aarch64-linux-gnu-g++-5 HOST=aarch64-linux-gnu PREFIX=/usr/aarch64-linux-gnu $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=aarch64-linux-gnu-gcc-5 CXX=aarch64-linux-gnu-g++-5 HOST=aarch64-linux-gnu PREFIX=/usr/aarch64-linux-gnu $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
       export PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig
 
       CC=aarch64-linux-gnu-gcc-5 CXX=aarch64-linux-gnu-g++-5 GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
@@ -386,7 +386,7 @@ for TARGET in $TARGETS; do
       echo "Go version too low, skipping linux/mips64..."
     else
       echo "Compiling for linux/mips64..."
-      CC=mips64-linux-gnuabi64-gcc-5 CXX=mips64-linux-gnuabi64-g++-5 HOST=mips64-linux-gnuabi64 PREFIX=/usr/mips64-linux-gnuabi64 $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=mips64-linux-gnuabi64-gcc-5 CXX=mips64-linux-gnuabi64-g++-5 HOST=mips64-linux-gnuabi64 PREFIX=/usr/mips64-linux-gnuabi64 $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
       export PKG_CONFIG_PATH=/usr/mips64-linux-gnuabi64/lib/pkgconfig
 
       CC=mips64-linux-gnuabi64-gcc-5 CXX=mips64-linux-gnuabi64-g++-5 GOOS=linux GOARCH=mips64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
@@ -398,7 +398,7 @@ for TARGET in $TARGETS; do
       echo "Go version too low, skipping linux/mips64le..."
     else
       echo "Compiling for linux/mips64le..."
-      CC=mips64el-linux-gnuabi64-gcc-5 CXX=mips64el-linux-gnuabi64-g++-5 HOST=mips64el-linux-gnuabi64 PREFIX=/usr/mips64el-linux-gnuabi64 $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=mips64el-linux-gnuabi64-gcc-5 CXX=mips64el-linux-gnuabi64-g++-5 HOST=mips64el-linux-gnuabi64 PREFIX=/usr/mips64el-linux-gnuabi64 $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
       export PKG_CONFIG_PATH=/usr/mips64le-linux-gnuabi64/lib/pkgconfig
 
       CC=mips64el-linux-gnuabi64-gcc-5 CXX=mips64el-linux-gnuabi64-g++-5 GOOS=linux GOARCH=mips64le CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
@@ -422,7 +422,7 @@ for TARGET in $TARGETS; do
     # Build the requested windows binaries
     if [ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]; then
       echo "Compiling for windows-$PLATFORM/amd64..."
-      CC=x86_64-w64-mingw32-gcc-posix CXX=x86_64-w64-mingw32-g++-posix HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=x86_64-w64-mingw32-gcc-posix CXX=x86_64-w64-mingw32-g++-posix HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
       export PKG_CONFIG_PATH=/usr/x86_64-w64-mingw32/lib/pkgconfig
 
       CC=x86_64-w64-mingw32-gcc-posix CXX=x86_64-w64-mingw32-g++-posix GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
@@ -430,7 +430,7 @@ for TARGET in $TARGETS; do
     fi
     if [ $XGOARCH == "." ] || [ $XGOARCH == "386" ]; then
       echo "Compiling for windows-$PLATFORM/386..."
-      CC=i686-w64-mingw32-gcc-posix CXX=i686-w64-mingw32-g++-posix HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=i686-w64-mingw32-gcc-posix CXX=i686-w64-mingw32-g++-posix HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
       export PKG_CONFIG_PATH=/usr/i686-w64-mingw32/lib/pkgconfig
 
       CC=i686-w64-mingw32-gcc-posix CXX=i686-w64-mingw32-g++-posix GOOS=windows GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go get $V $X "${T[@]}" --ldflags="$V $LD" -d ./$PACK
@@ -454,13 +454,13 @@ for TARGET in $TARGETS; do
     # Build the requested darwin binaries
     if [ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]; then
       echo "Compiling for darwin-$PLATFORM/amd64..."
-      CC=o64-clang CXX=o64-clang++ HOST=x86_64-apple-darwin15 PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=o64-clang CXX=o64-clang++ HOST=x86_64-apple-darwin15 PREFIX=/usr/local $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
       CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$LDSTRIP $V $LD" -d ./$PACK
       CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build $V $X "${T[@]}" --ldflags="$LDSTRIP $V $LD" $R $BM -o "/build/$NAME-darwin-$PLATFORM-amd64$R`extension darwin`" ./$PACK
     fi
     if [ $XGOARCH == "." ] || [ $XGOARCH == "386" ]; then
       echo "Compiling for darwin-$PLATFORM/386..."
-      CC=o32-clang CXX=o32-clang++ HOST=i386-apple-darwin15 PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=o32-clang CXX=o32-clang++ HOST=i386-apple-darwin15 PREFIX=/usr/local $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
       CC=o32-clang CXX=o32-clang++ GOOS=darwin GOARCH=386 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$LDSTRIP $V $LD" -d ./$PACK
       CC=o32-clang CXX=o32-clang++ GOOS=darwin GOARCH=386 CGO_ENABLED=1 go build $V $X "${T[@]}" --ldflags="$LDSTRIP $V $LD" $BM -o "/build/$NAME-darwin-$PLATFORM-386`extension darwin`" ./$PACK
     fi
@@ -486,7 +486,7 @@ for TARGET in $TARGETS; do
       else
         IOSTAGS=(--tags ios)
       fi
-      mkdir -p /build-ios-fw
+      mkdir -p /tmp/build-ios-fw
 
       # Strip symbol table below Go 1.6 to prevent DWARF issues
       LDSTRIP=""
@@ -501,7 +501,7 @@ for TARGET in $TARGETS; do
         GOOS=darwin GOARCH=arm GOARM=7 CGO_ENABLED=1 CC=arm-apple-darwin11-clang go install --tags ios std
 
         echo "Compiling for ios-$PLATFORM/arm-7..."
-        CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ HOST=arm-apple-darwin11 PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+        CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ HOST=arm-apple-darwin11 PREFIX=/usr/local $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
         CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ GOOS=darwin GOARCH=arm GOARM=7 CGO_ENABLED=1 go get $V $X "${IOSTAGS[@]}" --ldflags="$V $LD" -d ./$PACK
         if [ $XGOARCH == "." ] || [ $XGOARCH == "arm-7" ]; then
           CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ GOOS=darwin GOARCH=arm GOARM=7 CGO_ENABLED=1 go build $V $X "${IOSTAGS[@]}" --ldflags="$LDSTRIP $V $LD" $BM -o "/build/$NAME-ios-$PLATFORM-armv7`extension darwin`" ./$PACK
@@ -518,13 +518,13 @@ for TARGET in $TARGETS; do
         GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 CC=arm-apple-darwin11-clang go install --tags ios std
 
         echo "Compiling for ios-$PLATFORM/arm64..."
-        CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ HOST=arm-apple-darwin11 PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+        CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ HOST=arm-apple-darwin11 PREFIX=/usr/local $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
         CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go get $V $X "${IOSTAGS[@]}" --ldflags="$V $LD" -d ./$PACK
         if [ $XGOARCH == "." ] || [ $XGOARCH == "arm64" ]; then
           CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${IOSTAGS[@]}" --ldflags="$LDSTRIP $V $LD" $BM -o "/build/$NAME-ios-$PLATFORM-arm64`extension darwin`" ./$PACK
         fi
         if [ $XGOARCH == "." ] || [ $XGOARCH == "framework" ]; then
-          CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${IOSTAGS[@]}" --ldflags="$V $LD" --buildmode=c-archive -o "/build-ios-fw/$NAME-ios-$PLATFORM-arm64.a" ./$PACK
+          CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${IOSTAGS[@]}" --ldflags="$V $LD" --buildmode=c-archive -o "/tmp/build-ios-fw/$NAME-ios-$PLATFORM-arm64.a" ./$PACK
         fi
         echo "Cleaning up Go runtime for ios-$PLATFORM/arm64..."
         rm -rf /usr/local/go/pkg/darwin_arm64
@@ -536,13 +536,13 @@ for TARGET in $TARGETS; do
         GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 CC=arm-apple-darwin11-clang go install --tags ios std
 
         echo "Compiling for ios-$PLATFORM/amd64..."
-        CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ HOST=arm-apple-darwin11 PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+        CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ HOST=arm-apple-darwin11 PREFIX=/usr/local $BUILD_DEPS /tmp/deps ${DEPS_ARGS[@]}
         CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get $V $X "${IOSTAGS[@]}" --ldflags="$V $LD" -d ./$PACK
         if [ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]; then
           CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${IOSTAGS[@]}" --ldflags="$LDSTRIP $V $LD" $BM -o "/build/$NAME-ios-$PLATFORM-x86_64`extension darwin`" ./$PACK
         fi
         if [ $XGOARCH == "." ] || [ $XGOARCH == "framework" ]; then
-          CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${IOSTAGS[@]}" --ldflags="$V $LD" --buildmode=c-archive -o "/build-ios-fw/$NAME-ios-$PLATFORM-x86_64.a" ./$PACK
+          CC=arm-apple-darwin11-clang CXX=arm-apple-darwin11-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_STATUS_IM" go build $V $X "${IOSTAGS[@]}" --ldflags="$V $LD" --buildmode=c-archive -o "/tmp/build-ios-fw/$NAME-ios-$PLATFORM-x86_64.a" ./$PACK
         fi
         echo "Cleaning up Go runtime for ios-$PLATFORM/amd64..."
         rm -rf /usr/local/go/pkg/darwin_amd64
@@ -559,16 +559,16 @@ for TARGET in $TARGETS; do
         (cd $framework/Versions && ln -nsf A Current)
 
         arches=()
-        for lib in `ls /build-ios-fw | grep -e '\.a$'`; do
-          arches+=("-arch" "`echo ${lib##*-} | cut -d '.' -f 1`" "/build-ios-fw/$lib")
+        for lib in `ls /tmp/build-ios-fw | grep -e '\.a$'`; do
+          arches+=("-arch" "`echo ${lib##*-} | cut -d '.' -f 1`" "/tmp/build-ios-fw/$lib")
         done
         arm-apple-darwin11-lipo -create "${arches[@]}" -o $framework/Versions/A/$title
         arm-apple-darwin11-ranlib $framework/Versions/A/$title
         (cd $framework && ln -nsf Versions/A/$title $title)
 
         mkdir -p $framework/Versions/A/Headers
-        for header in `ls /build-ios-fw | grep -e '\.h$'`; do
-          cp -f /build-ios-fw/$header $framework/Versions/A/Headers/$title.h
+        for header in `ls /tmp/build-ios-fw | grep -e '\.h$'`; do
+          cp -f /tmp/build-ios-fw/$header $framework/Versions/A/Headers/$title.h
         done
         (cd $framework && ln -nsf Versions/A/Headers Headers)
 
@@ -585,7 +585,7 @@ for TARGET in $TARGETS; do
 
         chmod 777 -R /build/$NAME-ios-$PLATFORM-framework
       fi
-      rm -rf /build-ios-fw
+      rm -rf /tmp/build-ios-fw
     fi
     # Remove any automatically injected deployment target vars
     unset IPHONEOS_DEPLOYMENT_TARGET
@@ -594,7 +594,7 @@ done
 
 # Clean up any leftovers for subsequent build invocations
 echo "Cleaning up build environment..."
-rm -rf /deps
+rm -rf /tmp/deps
 
 for dir in `ls /usr/local`; do
   keep=0

--- a/_assets/build/xgo/base/build_deps.sh
+++ b/_assets/build/xgo/base/build_deps.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Contains the a dependency builder to iterate over all installed dependencies
+# and cross compile them to the requested target platform.
+#
+# Usage: build_deps.sh <dependency folder> <configure arguments>
+#
+# Needed environment variables:
+#   CC      - C cross compiler to use for the build
+#   HOST    - Target platform to build (used to find the needed tool-chains)
+#   PREFIX  - File-system path where to install the built binaries
+set -e
+
+# Remove any previous build leftovers, and copy a fresh working set (clean doesn't work for cross compiling)
+rm -rf /tmp/deps-build && cp -r $1 /tmp/deps-build
+
+# Build all the dependencies (no order for now)
+for dep in `ls /tmp/deps-build`; do
+	echo "Configuring dependency $dep for $HOST..."
+	(cd /tmp/deps-build/$dep && ./configure --disable-shared --host=$HOST --prefix=$PREFIX --silent ${@:2})
+
+	echo "Building dependency $dep for $HOST..."
+	(cd /tmp/deps-build/$dep && make --silent -j install)
+done
+
+# Remove any build artifacts
+rm -rf /tmp/deps-build

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -36,7 +36,7 @@ node('linux') {
     // }
 
     stage('Build') {
-        sh 'go get github.com/karalabe/xgo'
+        sh 'go get github.com/status-im/xgo'
 
         parallel (
             'statusgo-android': {

--- a/_assets/ci/Jenkinsfile-manual
+++ b/_assets/ci/Jenkinsfile-manual
@@ -49,7 +49,7 @@ node('linux') {
     }
 
     stage('Build') {
-        sh 'go get github.com/karalabe/xgo'
+        sh 'go get github.com/status-im/xgo'
 
         parallel (
             'statusgo-android': {


### PR DESCRIPTION
This PR fixes a longstanding issue with xgo: since it leverages Docker to create the build artifacts, those files are generated as the `root` user, so if we later need to delete them, we need to that as `root` as well. This was causing frequent problems in Jenkins as the build would fail because it could not clean the old build files.

Important changes:
- [x] Forked github.com/karalabe/xgo (needed to add UID/GID env vars to `docker run` command).
- [x] Created upstream PR: https://github.com/karalabe/xgo/pull/132.
- [x] Modified `_assets/build/xgo/base/build.sh` with `chown` calls.
- [x] Updated our own `statusteam/xgo:1.10.x` and `statusteam/xgo-ios-simulator:1.10.x` images