### PR TITLE
[WIP] Create desktop static libraries in Jenkins builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,7 @@ tags
 .settings
 
 # used by the Makefile
-/build/_workspace/
-/build/bin/
+/build/
 /vendor/github.com/status-im/xgo
 
 # travis

--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,8 @@ generate: ##@other Regenerate assets and other auto-generated stuff
 
 prepare-release: clean-release
 	mkdir -p $(RELEASE_DIRECTORY)
-	mv build/bin/statusgo-android-16.aar $(RELEASE_DIRECTORY)/status-go-android.aar
-	mv build/bin/statusgo-ios-9.3-framework/status-go-ios.zip $(RELEASE_DIRECTORY)/status-go-ios.zip
+	mv build/lib/statusgo-android-16.aar $(RELEASE_DIRECTORY)/status-go-android.aar
+	mv build/lib/statusgo-ios-9.3-framework/status-go-ios.zip $(RELEASE_DIRECTORY)/status-go-ios.zip
 	mv build/lib/linux/status-go-linux.zip $(RELEASE_DIRECTORY)/status-go-linux.zip
 	mv build/lib/darwin/status-go-darwin.zip $(RELEASE_DIRECTORY)/status-go-darwin.zip
 	mv build/lib/windows/status-go-win-x86-64.zip $(RELEASE_DIRECTORY)/status-go-win-x86-64.zip

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ xgo:
 install-os-dependencies:
 	_assets/scripts/install_deps.sh
 
-setup: install-os-dependencies dep-install lint-install mock-install deploy-install gen-install update-fleet-config ##@other Prepare project for first build
+setup: install-os-dependencies dep-install lint-install mock-install deploy-install gen-install ##@other Prepare project for first build
 
 generate: ##@other Regenerate assets and other auto-generated stuff
 	go generate ./static ./static/migrations

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -36,6 +36,10 @@ node('linux') {
         sh 'make canary-test'
     }
 
+    stage('Build and test') {
+        sh 'make ci'
+    }
+
     stage('Build packages') {
         sh 'go get github.com/status-im/xgo'
         dir(cloneDir) {

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -36,44 +36,85 @@ node('linux') {
         sh 'make canary-test'
     }
 
-    stage('Build') {
+    stage('Build packages') {
         sh 'go get github.com/status-im/xgo'
+        dir(cloneDir) {
+            // Ensure folders are created with correct owner (otherwise xgo will create files owned by root)
+            sh 'mkdir -p build/lib/'
+        }
 
         parallel (
             'statusgo-android': {
                 sh 'make statusgo-android'
             },
             'statusgo-ios-simulator': {
-                sh '''
-                    make statusgo-ios-simulator
-                    cd build/bin/statusgo-ios-9.3-framework/
-                    zip -r status-go-ios.zip Statusgo.framework
-                '''
+                dir(cloneDir) {
+                    sh """
+                        make statusgo-ios-simulator
+                        cd build/lib/
+                        zip -r status-go-ios.zip statusgo-ios-9.3-framework/Statusgo.framework
+                    """
+                }
+            }
+        )
+
+        parallel (
+            'statusgo-linux': {
+                dir(cloneDir) {
+                    sh """
+                        make statusgo-linux
+                        mkdir -p build/lib/linux
+                        cd build/lib/linux
+                        mkdir -p include lib
+                        mv ../statusgo-linux-amd64.a lib/libstatus.a
+                        mv ../statusgo-linux-amd64.h include/libstatus.h
+                        zip status-go-linux.zip lib/* include/*
+                    """
+                }
+            },
+            'statusgo-windows': {
+                dir(cloneDir) {
+                    sh """
+                        make statusgo-windows
+                        mkdir -p build/lib/windows
+                        cd build/lib/windows
+                        mkdir -p include lib
+                        mv ../statusgo-windows-4.0-amd64.lib lib/status.lib
+                        mv ../statusgo-windows-4.0-amd64.h include/status.h
+                        zip status-go-win-x86-64.zip lib/* include/*
+                    """
+                }
+            },
+            'statusgo-macos': {
+                dir(cloneDir) {
+                    sh """
+                        make statusgo-macos
+                        mkdir -p build/lib/darwin
+                        cd build/lib/darwin
+                        mkdir -p include lib
+                        mv ../statusgo-darwin-10.6-amd64.a lib/libstatus.a
+                        mv ../statusgo-darwin-10.6-amd64.h include/libstatus.h
+                        zip status-go-darwin.zip lib/* include/*
+                    """
+                }
             }
         )
     }
 
     stage('Deploy') {
-        // For branch builds, replace the old artifact. For develop keep all of them.
-        def version = gitBranch == 'develop' ? getVersion(gitBranch, gitShortSHA, '') : getVersion(gitBranch, gitShortSHA, env.BUILD_ID)
-        def server = Artifactory.server 'artifactory'
-        def uploadSpec = """{
-            "files": [
-                {
-                    "pattern": "build/bin/statusgo-android-16.aar",
-                    "target": "libs-release-local/status-im/status-go/${version}/status-go-${version}.aar"
-                },
-                {
-                    "pattern": "build/bin/statusgo-ios-9.3-framework/status-go-ios.zip",
-                    "target": "libs-release-local/status-im/status-go-ios-simulator/${version}/status-go-ios-simulator-${version}.zip"
-                }
-            ]
-        }"""
-
-        def buildInfo = Artifactory.newBuildInfo()
-        buildInfo.env.capture = false
-        buildInfo.name = 'status-go (' + gitBranch + '-' + gitShortSHA + ')'
-        server.upload(uploadSpec, buildInfo)
-        server.publishBuildInfo(buildInfo)
+        dir(cloneDir) {
+            sh "make prepare-release"
+            withCredentials([[
+                $class: 'UsernamePasswordMultiBinding',
+                credentialsId: 'status-im-auto',
+                usernameVariable: 'GITHUB_USER',
+                passwordVariable: 'GITHUB_TOKEN'
+            ]]) {
+              sh """
+                yes | make release release_branch=${gitBranch}
+              """
+            }
+            sh "make clean-release"
+        }
     }
 }

--- a/_assets/ci/Jenkinsfile-manual
+++ b/_assets/ci/Jenkinsfile-manual
@@ -41,15 +41,19 @@ node('linux') {
         println(gitSHA)
     }
 
-    stage('Test') {
+    stage('Build and test') {
         dir(cloneDir) {
             sh 'make setup'
             sh 'make ci'
         }
     }
 
-    stage('Build') {
+    stage('Build packages') {
         sh 'go get github.com/status-im/xgo'
+        dir(cloneDir) {
+            // Ensure folders are created with correct owner (otherwise xgo will create files owned by root)
+            sh 'mkdir -p build/lib/'
+        }
 
         parallel (
             'statusgo-android': {
@@ -64,6 +68,48 @@ node('linux') {
                         cd build/bin/statusgo-ios-9.3-framework/
                         zip -r status-go-ios.zip Statusgo.framework
                     '''
+                }
+            }
+        )
+
+        parallel (
+            'statusgo-linux': {
+                dir(cloneDir) {
+                    sh """
+                        make statusgo-linux
+                        mkdir -p build/lib/linux
+                        cd build/lib/linux
+                        mkdir -p include lib
+                        mv ../statusgo-linux-amd64.a lib/libstatus.a
+                        mv ../statusgo-linux-amd64.h include/libstatus.h
+                        zip status-go-linux.zip lib/* include/*
+                    """
+                }
+            },
+            'statusgo-windows': {
+                dir(cloneDir) {
+                    sh """
+                        make statusgo-windows
+                        mkdir -p build/lib/windows
+                        cd build/lib/windows
+                        mkdir -p include lib
+                        mv ../statusgo-windows-4.0-amd64.lib lib/status.lib
+                        mv ../statusgo-windows-4.0-amd64.h include/status.h
+                        zip status-go-win-x86-64.zip lib/* include/*
+                    """
+                }
+            },
+            'statusgo-macos': {
+                dir(cloneDir) {
+                    sh """
+                        make statusgo-macos
+                        mkdir -p build/lib/darwin
+                        cd build/lib/darwin
+                        mkdir -p include lib
+                        mv ../statusgo-darwin-10.6-amd64.a lib/libstatus.a
+                        mv ../statusgo-darwin-10.6-amd64.h include/libstatus.h
+                        zip status-go-darwin.zip lib/* include/*
+                    """
                 }
             }
         )

--- a/_assets/ci/common.groovy
+++ b/_assets/ci/common.groovy
@@ -1,0 +1,27 @@
+def getFilename(path) {
+  return path.tokenize('/')[-1]
+}
+
+def uploadArtifact(path) {
+  /* defaults for upload */
+  def domain = 'ams3.digitaloceanspaces.com'
+  def bucket = 'status-im'
+  withCredentials([usernamePassword(
+    credentialsId: 'digital-ocean-access-keys',
+    usernameVariable: 'DO_ACCESS_KEY',
+    passwordVariable: 'DO_SECRET_KEY'
+  )]) {
+    sh """
+      s3cmd \\
+        --acl-public \\
+        --host='${domain}' \\
+        --host-bucket='%(bucket)s.${domain}' \\
+        --access_key=${DO_ACCESS_KEY} \\
+        --secret_key=${DO_SECRET_KEY} \\
+        put ${path} s3://${bucket}/
+    """
+  }
+  return "https://${bucket}.${domain}/${getFilename(path)}"
+}
+
+return this


### PR DESCRIPTION
Currently Desktop builds status-go every single time because they don't have access to the static library for their platform. This PR adds those libraries to the build artifacts. A working build can be seen in https://ci.status.im/job/status-go/job/status-go-manual/475/console

It also moves the library output to `build/lib`, so that only executables are found in `build/bin`.

Closes #1190