### PR TITLE
Fix xgo creating files as `root`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ tags
 # used by the Makefile
 /build/_workspace/
 /build/bin/
-/vendor/github.com/karalabe/xgo
+/vendor/github.com/status-im/xgo
 
 # travis
 profile.tmp

--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,8 @@ xgo-docker-images: ##@docker Build xgo docker images
 
 xgo:
 	docker pull $(XGOIMAGE)
-	go get github.com/karalabe/xgo
+	go get github.com/status-im/xgo
+	mkdir -p $(GOBIN)
 
 setup: dep-install lint-install mock-install update-fleet-config ##@other Prepare project for first build
 

--- a/_assets/build/xgo/base/Dockerfile
+++ b/_assets/build/xgo/base/Dockerfile
@@ -1,5 +1,7 @@
 FROM karalabe/xgo-1.10.x
 
+VOLUME [ "/build", "/deps-cache" ]
+
 # Inject the container entry point, the build script (patched for Status bindings conditional builds of C code)
 ADD build.sh /build.sh
 ENV BUILD /build.sh

--- a/_assets/build/xgo/base/build.sh
+++ b/_assets/build/xgo/base/build.sh
@@ -298,6 +298,9 @@ for TARGET in $TARGETS; do
         (cd $archive && zip -r $bundle *)
         rm -rf $jni $archive
       fi
+
+      # Fix up permissions on bundle file
+      chown $UID:$GID $bundle
     fi
     # Clean up the android builds, toolchains and runtimes
     rm -rf /build-android-aar
@@ -583,6 +586,8 @@ for TARGET in $TARGETS; do
         echo -e "framework module \"$title\" {\n  header \"$title.h\"\n  export *\n}" > $framework/Versions/A/Modules/module.modulemap
         (cd $framework && ln -nsf Versions/A/Modules Modules)
 
+        # Fix up permissions on bundle file
+        chown $UID:$GID /build/$NAME-ios-$PLATFORM-framework
         chmod 777 -R /build/$NAME-ios-$PLATFORM-framework
       fi
       rm -rf /build-ios-fw

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -36,7 +36,7 @@ node('linux') {
     // }
 
     stage('Build') {
-        sh 'go get github.com/karalabe/xgo'
+        sh 'go get github.com/status-im/xgo'
 
         parallel (
             'statusgo-android': {

--- a/_assets/ci/Jenkinsfile-manual
+++ b/_assets/ci/Jenkinsfile-manual
@@ -49,7 +49,7 @@ node('linux') {
     }
 
     stage('Build') {
-        sh 'go get github.com/karalabe/xgo'
+        sh 'go get github.com/status-im/xgo'
 
         parallel (
             'statusgo-android': {


### PR DESCRIPTION
This PR fixes a longstanding issue with xgo: since it leverages Docker to create the build artifacts, those files are by default generated as the `root` user, so if we later need to delete them, we need to that as `root` user as well. This was causing frequent problems in Jenkins as the build would fail because it could not clean the old build files.

Important changes:
- [x] Forked github.com/karalabe/xgo (needed to add UID/GID env vars to `docker run` command).
- [x] Created upstream PR: https://github.com/karalabe/xgo/pull/132.
- [x] Modified `_assets/build/xgo/base/build.sh` with `chown` calls.
- [x] Updated our own `statusteam/xgo:1.10.x` and `statusteam/xgo-ios-simulator:1.10.x` images