### PR TITLE
Reduce cryptographic operations when rendezvous disccovery is started

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -767,7 +767,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b9b4aaa95bb880c345f400d7de8d5023731f71a9dfd4ff62ec77a74acfda529e"
+  digest = "1:b88d64c27ed467659fa0ee1806bc790b88c37bcbff0b8fcd1b97d6a3ee7f9703"
   name = "github.com/status-im/rendezvous"
   packages = [
     ".",
@@ -775,7 +775,7 @@
     "server",
   ]
   pruneopts = "NUT"
-  revision = "7fe5bc0fd1c58bb7f7bec64656d8b821bec8338f"
+  revision = "55370cdfd9f288059b03c04e23784bb8829a894c"
 
 [[projects]]
   digest = "1:572c783a763db6383aca3179976eb80e4c900f52eba56cba8bb2e3cea7ce720e"

--- a/discovery/proxy_test.go
+++ b/discovery/proxy_test.go
@@ -21,7 +21,7 @@ func TestProxyToRendezvous(t *testing.T) {
 		stop     = make(chan struct{})
 		wg       sync.WaitGroup
 	)
-	client, err := rendezvous.NewTemporary()
+	client, err := rendezvous.NewEphemeral()
 	require.NoError(t, err)
 	reg.Add(topic, id)
 	wg.Add(1)

--- a/discovery/rendezvous.go
+++ b/discovery/rendezvous.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"math/rand"
 	"net"
 	"sync"
@@ -22,20 +23,18 @@ const (
 	bucketSize         = 10
 )
 
+var (
+	errNodeIsNil     = errors.New("node cannot be nil")
+	errIdentityIsNil = errors.New("identity cannot be nil")
+)
+
 func NewRendezvous(servers []ma.Multiaddr, identity *ecdsa.PrivateKey, node *discover.Node) (*Rendezvous, error) {
 	r := new(Rendezvous)
+	r.node = node
+	r.identity = identity
 	r.servers = servers
 	r.registrationPeriod = registrationPeriod
 	r.bucketSize = bucketSize
-
-	r.record = enr.Record{}
-	r.record.Set(enr.IP(node.IP))
-	r.record.Set(enr.TCP(node.TCP))
-	r.record.Set(enr.UDP(node.UDP))
-	// public key is added to ENR when ENR is signed
-	if err := enr.SignV4(&r.record, identity); err != nil {
-		return nil, err
-	}
 	return r, nil
 }
 
@@ -44,7 +43,7 @@ func NewRendezvousWithENR(servers []ma.Multiaddr, record enr.Record) *Rendezvous
 	r.servers = servers
 	r.registrationPeriod = registrationPeriod
 	r.bucketSize = bucketSize
-	r.record = record
+	r.record = &record
 	return r
 }
 
@@ -62,7 +61,11 @@ type Rendezvous struct {
 	servers            []ma.Multiaddr
 	registrationPeriod time.Duration
 	bucketSize         int
-	record             enr.Record
+	node               *discover.Node
+	identity           *ecdsa.PrivateKey
+
+	recordMu sync.Mutex
+	record   *enr.Record // record is set directly if rendezvous is used in proxy mode
 }
 
 func (r *Rendezvous) Running() bool {
@@ -93,7 +96,30 @@ func (r *Rendezvous) Stop() error {
 	return nil
 }
 
-func (r *Rendezvous) register(topic string) error {
+func (r *Rendezvous) MakeRecord() (record enr.Record, err error) {
+	r.recordMu.Lock()
+	defer r.recordMu.Unlock()
+	if r.record != nil {
+		return *r.record, nil
+	}
+	if r.node == nil {
+		return record, errNodeIsNil
+	}
+	if r.identity == nil {
+		return record, errIdentityIsNil
+	}
+	record.Set(enr.IP(r.node.IP))
+	record.Set(enr.TCP(r.node.TCP))
+	record.Set(enr.UDP(r.node.UDP))
+	// public key is added to ENR when ENR is signed
+	if err := enr.SignV4(&record, r.identity); err != nil {
+		return record, err
+	}
+	r.record = &record
+	return record, nil
+}
+
+func (r *Rendezvous) register(topic string, record enr.Record) error {
 	srv := r.servers[rand.Intn(len(r.servers))]
 	ctx, cancel := context.WithTimeout(r.rootCtx, requestTimeout)
 	defer cancel()
@@ -101,7 +127,7 @@ func (r *Rendezvous) register(topic string) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	err := r.client.Register(ctx, srv, topic, r.record, r.registrationPeriod)
+	err := r.client.Register(ctx, srv, topic, record, r.registrationPeriod)
 	if err != nil {
 		log.Error("error registering", "topic", topic, "rendezvous server", srv, "err", err)
 	}
@@ -110,12 +136,16 @@ func (r *Rendezvous) register(topic string) error {
 
 // Register renews registration in the specified server.
 func (r *Rendezvous) Register(topic string, stop chan struct{}) error {
+	record, err := r.MakeRecord()
+	if err != nil {
+		return err
+	}
 	// sending registration more often than the whole registraton period
 	// will ensure that it won't be accidentally removed
 	ticker := time.NewTicker(r.registrationPeriod / 2)
 	defer ticker.Stop()
 
-	if err := r.register(topic); err == context.Canceled {
+	if err := r.register(topic, record); err == context.Canceled {
 		return err
 	}
 
@@ -124,7 +154,7 @@ func (r *Rendezvous) Register(topic string, stop chan struct{}) error {
 		case <-stop:
 			return nil
 		case <-ticker.C:
-			if err := r.register(topic); err == context.Canceled {
+			if err := r.register(topic, record); err == context.Canceled {
 				return err
 			}
 		}

--- a/discovery/rendezvous.go
+++ b/discovery/rendezvous.go
@@ -75,7 +75,7 @@ func (r *Rendezvous) Running() bool {
 func (r *Rendezvous) Start() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	client, err := rendezvous.NewTemporary()
+	client, err := rendezvous.NewEphemeral()
 	if err != nil {
 		return err
 	}

--- a/discovery/rendezvous_test.go
+++ b/discovery/rendezvous_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	lcrypto "github.com/libp2p/go-libp2p-crypto"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/status-im/rendezvous/server"
@@ -58,6 +59,18 @@ func TestRendezvousDiscovery(t *testing.T) {
 	}
 	close(stop)
 	close(period)
+}
+
+func TestMakeRecordReturnsCachedRecord(t *testing.T) {
+	identity, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	record := enr.Record{}
+	require.NoError(t, enr.SignV4(&record, identity))
+	c := NewRendezvousWithENR(nil, record)
+	rst, err := c.MakeRecord()
+	require.NoError(t, err)
+	require.NotNil(t, rst.NodeAddr())
+	require.Equal(t, record.NodeAddr(), rst.NodeAddr())
 }
 
 func BenchmarkRendezvousStart(b *testing.B) {

--- a/discovery/rendezvous_test.go
+++ b/discovery/rendezvous_test.go
@@ -59,3 +59,18 @@ func TestRendezvousDiscovery(t *testing.T) {
 	close(stop)
 	close(period)
 }
+
+func BenchmarkRendezvousStart(b *testing.B) {
+	identity, err := crypto.GenerateKey()
+	require.NoError(b, err)
+	addr, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/7777")
+	require.NoError(b, err)
+	node := discover.NewNode(discover.PubkeyID(&identity.PublicKey), net.IP{10, 10, 10, 10}, 10, 20)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		c, err := NewRendezvous([]ma.Multiaddr{addr}, identity, node)
+		require.NoError(b, err)
+		require.NoError(b, c.Start())
+	}
+}

--- a/vendor/github.com/status-im/rendezvous/client.go
+++ b/vendor/github.com/status-im/rendezvous/client.go
@@ -21,8 +21,8 @@ import (
 
 var logger = log.New("package", "rendezvous/client")
 
-func NewTemporary() (c Client, err error) {
-	priv, _, err := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, rand.Reader)
+func NewEphemeral() (c Client, err error) {
+	priv, _, err := crypto.GenerateKeyPairWithReader(crypto.Secp256k1, 0, rand.Reader) // bits are ignored with edwards or secp251k1
 	if err != nil {
 		return Client{}, err
 	}


### PR DESCRIPTION
Performance issues that were observed recently on mobile device are caused by generating ephemeral key that is used for libp2p secure connection. And to the lesser extent because of signing enr record.

This is the benchmark result for creating rendezvous client with RSA key:
```
BenchmarkRendezvousStart-8   	       5	 303744970 ns/op

      flat  flat%   sum%        cum   cum%
         0     0%     0%      2.31s 99.57%  crypto/rsa.GenerateKey
         0     0%     0%      2.31s 99.57%  crypto/rsa.GenerateMultiPrimeKey
         0     0%     0%      2.31s 99.57%  github.com/status-im/status-go/discovery.(*Rendezvous).Start
         0     0%     0%      2.31s 99.57%  github.com/status-im/status-go/discovery.BenchmarkRendezvousStart
         0     0%     0%      2.31s 99.57%  github.com/status-im/status-go/vendor/github.com/libp2p/go-libp2p-crypto.GenerateKeyPairWithReader
         0     0%     0%      2.31s 99.57%  github.com/status-im/status-go/vendor/github.com/status-im/rendezvous.NewTemporary
         0     0%     0%      2.31s 99.57%  testing.(*B).runN
         0     0%     0%      2.30s 99.14%  crypto/rand.Prime
         0     0%     0%      2.30s 99.14%  math/big.(*Int).ProbablyPrime
         0     0%     0%      2.24s 96.55%  math/big.nat.probablyPrimeMillerRabin
```

If we simply swap that with seckp256k1 for generated ephemeral key then situation is already heavily improved:

```
BenchmarkRendezvousStart-8   	    2000	    728445 ns/op

      flat  flat%   sum%        cum   cum%
         0     0%     0%      1.54s 99.35%  github.com/status-im/status-go/discovery.BenchmarkRendezvousStart
         0     0%     0%      1.54s 99.35%  testing.(*B).launch
         0     0%     0%      1.54s 99.35%  testing.(*B).runN
     0.01s  0.65%  0.65%      1.34s 86.45%  github.com/status-im/status-go/discovery.NewRendezvous
         0     0%  0.65%      1.33s 85.81%  github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/p2p/enr.SignV4
     1.27s 81.94% 82.58%      1.27s 81.94%  runtime.cgocall
         0     0% 82.58%      0.91s 58.71%  github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/p2p/enr.(*Record).SetSig
         0     0% 82.58%      0.90s 58.06%  github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/p2p/enr.(*v4ID).Verify
         0     0% 82.58%      0.90s 58.06%  github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/p2p/enr.v4ID.Verify
         0     0% 82.58%      0.88s 56.77%  github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/crypto.VerifySignature
```

And additionally I moved signing of ENR closer to a place where it is used.

```BenchmarkRendezvousStart-8   	   10000	    136658 ns/op```

I am not sure that it is worth to leave this naive benchmark. So I can remove if it will be better.