### PR TITLE
Ensure that discovery producer is stopped

### DIFF
--- a/peers/peerpool.go
+++ b/peers/peerpool.go
@@ -201,11 +201,11 @@ func (p *PeerPool) stopDiscovery(server *p2p.Server) {
 		return
 	}
 
+	if err := p.discovery.Stop(); err != nil {
+		log.Error("discovery errored when stopping", "err", err)
+	}
 	for _, t := range p.topics {
 		t.StopSearch(server)
-	}
-	if err := p.discovery.Stop(); err != nil {
-		log.Error("discovery errored when was closed", "err", err)
 	}
 
 	p.mu.Lock()


### PR DESCRIPTION
@PombeirP observed that test `TestPeerPoolSimulationSuite/TestSingleTopicDiscoveryWithFailoverRendezvous` fails with race flags. With a locked goroutine on sending to `found` channel, per:

```
goroutine 414 [chan send, 9 minutes]:
github.com/status-im/status-go/discovery.(*Rendezvous).Discover(0xc421c8e2c0, 0xf8abef, 0x8, 0xc425c500e0, 0xc42527f380, 0xc425c50150, 0x0, 0x0)
	/home/jenkins/workspace/status-go/race-check/src/github.com/status-im/status-go/discovery/rendezvous.go:166 +0x4c3
github.com/status-im/status-go/peers.(*TopicPool).StartSearch.func1(0xc420f6a690, 0xc42527f380, 0xc425c50150)
	/home/jenkins/workspace/status-go/race-check/src/github.com/status-im/status-go/peers/topicpool.go:402 +0xd4
created by github.com/status-im/status-go/peers.(*TopicPool).StartSearch
	/home/jenkins/workspace/status-go/race-check/src/github.com/status-im/status-go/peers/topicpool.go:401 +0x466
```

Current PR does two things to prevent this situation:
1. Producer must be stopped before consumer. In our case both rendezvous and/or discovery v5 will be stopped before stopping each topic pool.
2. Producer will be signaled that consumer exited. Current interface might be not perfect for it. But it is enforced by one used in discovery v5.