### PR TITLE
enable stale github bot for closing issues

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -7,3 +7,18 @@ prchecklist:
   title: Pull Request Checklist
   checklist:
     - 'Have you updated the documentation, if impacted (e.g. [docs.status.im](https://docs.status.im/docs/build_status_go.html))?'
+
+stale:
+  daysUntilStale: 90
+  daysUntilClose: 7
+  exemptLabels:
+    - 'wall of shame'
+    - security
+  staleLabel: stale
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+  closeComment: >
+    This issue has been automatically closed. Please re-open if this issue
+    is important to you.


### PR DESCRIPTION
This enables and configures the [Stale](https://probot.github.io/apps/stale/) GitHub bot that was added to our [`status-github-bot`](https://github.com/status-im/status-github-bot) bot.