### PR TITLE
Return always json struct

### DIFF
--- a/lib/library.go
+++ b/lib/library.go
@@ -106,7 +106,14 @@ func VerifyGroupMembershipSignatures(signaturePairsStr *C.char) *C.char {
 		return makeJSONResponse(err)
 	}
 
-	return nil
+	data, err := json.Marshal(struct {
+		Success bool `json:"success"`
+	}{Success: true})
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	return C.CString(string(data))
 }
 
 // Sign signs a string containing group membership information


### PR DESCRIPTION
There seem to be a difference on how desktop and android/ios handles callbacks from status-go, whereby returning `nil` in desktop is cast to `""` ,making the JSON parser complain about it.
It seems sensible to always return some JSON so the type is always the same.