### PR TITLE
Add extract group membership signatures

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -501,9 +501,15 @@ func (b *StatusBackend) ExtractIdentityFromContactCode(contactCode string) (stri
 	return chat.ExtractIdentity(bundle)
 }
 
+// DEPRECATED
 // VerifyGroupMembershipSignatures verifies that the signatures are valid
 func (b *StatusBackend) VerifyGroupMembershipSignatures(signaturePairs [][3]string) error {
 	return crypto.VerifySignatures(signaturePairs)
+}
+
+// ExtractGroupMembershipSignatures extract signatures from tuples of content/signature
+func (b *StatusBackend) ExtractGroupMembershipSignatures(signaturePairs [][2]string) ([]string, error) {
+	return crypto.ExtractSignatures(signaturePairs)
 }
 
 // SignGroupMembership signs a piece of data containing membership information

--- a/lib/library.go
+++ b/lib/library.go
@@ -116,6 +116,30 @@ func VerifyGroupMembershipSignatures(signaturePairsStr *C.char) *C.char {
 	return C.CString(string(data))
 }
 
+// ExtractGroupMembershipSignatures extract public keys from tuples of content/signature
+//export ExtractGroupMembershipSignatures
+func ExtractGroupMembershipSignatures(signaturePairsStr *C.char) *C.char {
+	var signaturePairs [][2]string
+
+	if err := json.Unmarshal([]byte(C.GoString(signaturePairsStr)), &signaturePairs); err != nil {
+		return makeJSONResponse(err)
+	}
+
+	identities, err := statusBackend.ExtractGroupMembershipSignatures(signaturePairs)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	data, err := json.Marshal(struct {
+		Identities []string `json:"identities"`
+	}{Identities: identities})
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	return C.CString(string(data))
+}
+
 // Sign signs a string containing group membership information
 //export SignGroupMembership
 func SignGroupMembership(content *C.char) *C.char {

--- a/services/shhext/chat/crypto/crypto.go
+++ b/services/shhext/chat/crypto/crypto.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -58,6 +59,31 @@ func VerifySignatures(signaturePairs [][3]string) error {
 	}
 
 	return nil
+}
+
+// ExtractSignatures extract from tuples of signatures content a public key
+func ExtractSignatures(signaturePairs [][2]string) ([]string, error) {
+	response := make([]string, len(signaturePairs))
+	for i, signaturePair := range signaturePairs {
+		content := crypto.Keccak256([]byte(signaturePair[0]))
+
+		signature, err := hex.DecodeString(signaturePair[1])
+		if err != nil {
+			return nil, err
+		}
+
+		recoveredKey, err := crypto.SigToPub(
+			content,
+			signature,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		response[i] = fmt.Sprintf("%x", crypto.FromECDSAPub(recoveredKey))
+	}
+
+	return response, nil
 }
 
 func EncryptSymmetric(key, plaintext []byte) ([]byte, error) {

--- a/services/shhext/chat/crypto/crypto_test.go
+++ b/services/shhext/chat/crypto/crypto_test.go
@@ -2,11 +2,50 @@ package crypto
 
 import (
 	"encoding/hex"
-	"fmt"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
+
+func TestExtractSignatures(t *testing.T) {
+	const content1 = "045a8cae84d8d139e887bb927d2b98cee481afae3770e0ee45f2dc19c6545e45921bc6a55ea92b705e45dfbbe47182c7b1d64a080a220d2781577163923d7cbb4b045a8cae84d8d139e887bb927d2b98cee481afae3770e0ee45f2dc19c6545e45921bc6a55ea92b705e45dfbbe47182c7b1d64a080a220d2781577163923d7cbb4b04ca82dd41fa592bf46ecf7e2eddae61013fc95a565b59c49f37f06b1b591ed3bd24e143495f2d1e241e151ab3572ac108d577be349d4b88d3d5a50c481ab35441"
+	const content2 = "045a8cae84d8d139e887bb927d2b98cee481afae3770e0ee45f2dc19c6545e45921bc6a55ea92b705e45dfbbe47182c7b1d64a080a220d2781577163923d7cbb4b045a8cae84d8d139e887bb927d2b98cee481afae3770e0ee45f2dc19c6545e45921bc6a55ea92b705e45dfbbe47182c7b1d64a080a220d2781577163923d7cbb4b04ca82dd41fa592bf46ecf7e2eddae61013fc95a565b59c49f37f06b1b591ed3bd24e143495f2d1e241e151ab3572ac108d577be349d4b88d3d5a50c481ab35440"
+
+	key1, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	key2, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	signature1, err := Sign(content1, key1)
+	require.NoError(t, err)
+
+	signature2, err := Sign(content2, key2)
+	require.NoError(t, err)
+
+	key1String := hex.EncodeToString(crypto.FromECDSAPub(&key1.PublicKey))
+	key2String := hex.EncodeToString(crypto.FromECDSAPub(&key2.PublicKey))
+
+	pair1 := [2]string{content1, signature1}
+	pair2 := [2]string{content2, signature2}
+
+	signaturePairs := [][2]string{pair1, pair2}
+
+	extractedSignatures, err := ExtractSignatures(signaturePairs)
+	require.NoError(t, err)
+	require.Equal(t, []string{key1String, key2String}, extractedSignatures)
+
+	// Test wrong content
+	pair3 := [2]string{content1, signature2}
+
+	signaturePairs = [][2]string{pair1, pair2, pair3}
+
+	extractedSignatures, err = ExtractSignatures(signaturePairs)
+	require.NoError(t, err)
+	// The public key is neither the one which generated the content, nor the one generated the signature
+	require.NotEqual(t, []string{key1String, key2String, key1String}, extractedSignatures)
+	require.NotEqual(t, []string{key1String, key2String, key2String}, extractedSignatures)
+}
 
 func TestVerifySignature(t *testing.T) {
 	const content1 = "045a8cae84d8d139e887bb927d2b98cee481afae3770e0ee45f2dc19c6545e45921bc6a55ea92b705e45dfbbe47182c7b1d64a080a220d2781577163923d7cbb4b045a8cae84d8d139e887bb927d2b98cee481afae3770e0ee45f2dc19c6545e45921bc6a55ea92b705e45dfbbe47182c7b1d64a080a220d2781577163923d7cbb4b04ca82dd41fa592bf46ecf7e2eddae61013fc95a565b59c49f37f06b1b591ed3bd24e143495f2d1e241e151ab3572ac108d577be349d4b88d3d5a50c481ab35441"
@@ -20,7 +59,6 @@ func TestVerifySignature(t *testing.T) {
 
 	signature1, err := Sign(content1, key1)
 	require.NoError(t, err)
-	fmt.Println(signature1)
 
 	signature2, err := Sign(content2, key2)
 	require.NoError(t, err)


### PR DESCRIPTION
I have changed a method used in status react,  instead of `verifyGroupMembershipSignatures` we will use `extractGroupMembershipSignatures`. I have kept the old method for now so that `status-go` and `status-react` HEAD are compatible. Once this PR is merged I will remove the usage from `status-react` and remove the unused function from `status-go`.
