### PR TITLE
Limit number of proxied records and proxy only recently observed nodes

### DIFF
--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -22,7 +23,9 @@ var (
 	bootnodes       = StringSlice{}
 	topics          = StringSlice{}
 	les             = IntSlice{}
-	useEthereum     = flag.Bool("use-ethereum-boot", false, "If true ethereum bootnodes will be used")
+	useEthereum     = flag.Bool("use-ethereum-boot", false, "If true ethereum bootnodes will be used.")
+	limit           = flag.Int("limit", 100, "Limit the number of proxied nodes.")
+	livenessWindow  = flag.Duration("liveness-window", 10*time.Minute, "Stop proxying record if it wasn't foudn again during specified window.")
 )
 
 func main() {
@@ -65,7 +68,7 @@ func main() {
 		t := t
 		wg.Add(1)
 		go func() {
-			if err := discovery.ProxyToRendezvous(v5, rendezvousServers, t, stop); err != nil {
+			if err := discovery.ProxyToRendezvous(v5, rendezvousServers, t, stop, *limit, *livenessWindow); err != nil {
 				log.Error("proxying to rendezvous servers failed", "servers", rendezvousNodes, "topic", t, "error", err)
 			}
 			wg.Done()

--- a/discovery/proxy.go
+++ b/discovery/proxy.go
@@ -6,30 +6,50 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
+const (
+	proxyStart = "start"
+	proxyStop  = "stop"
+)
+
+type proxyEvent struct {
+	ID   discv5.NodeID
+	Type string
+	Time time.Time
+}
+
+type ProxyOptions struct {
+	Topic          string
+	Servers        []ma.Multiaddr
+	Limit          int
+	LivenessWindow time.Duration
+}
+
 // ProxyToRendezvous proxies records discovered using original to rendezvous servers for specified topic.
-func ProxyToRendezvous(original Discovery, servers []ma.Multiaddr, topic string, stop chan struct{}, limit int, timeWindow time.Duration) error {
+func ProxyToRendezvous(original Discovery, stop chan struct{}, feed *event.Feed, opts ProxyOptions) error {
 	var (
-		identities   = map[discv5.NodeID]*Rendezvous{}
-		lastSeen     = map[discv5.NodeID]time.Time{}
-		closers      = map[discv5.NodeID]chan struct{}{}
-		period       = make(chan time.Duration, 1)
-		found        = make(chan *discv5.Node, 10)
-		closeRequest = make(chan discv5.NodeID, 10)
-		lookup       = make(chan bool)
-		total        = 0
-		wg           sync.WaitGroup
+		identities      = map[discv5.NodeID]*Rendezvous{}
+		lastSeen        = map[discv5.NodeID]time.Time{}
+		closers         = map[discv5.NodeID]chan struct{}{}
+		period          = make(chan time.Duration, 1)
+		found           = make(chan *discv5.Node, 10)
+		lookup          = make(chan bool)
+		total           = 0
+		livenessWatcher = time.NewTicker(opts.LivenessWindow / 10)
+		wg              sync.WaitGroup
 	)
+	defer livenessWatcher.Stop()
 	period <- 1 * time.Second
 	wg.Add(1)
 	go func() {
-		if err := original.Discover(topic, period, found, lookup); err != nil {
-			log.Error("discover request failed", "topic", topic, "error", err)
+		if err := original.Discover(opts.Topic, period, found, lookup); err != nil {
+			log.Error("discover request failed", "topic", opts.Topic, "error", err)
 		}
 		wg.Done()
 	}()
@@ -40,51 +60,52 @@ func ProxyToRendezvous(original Discovery, servers []ma.Multiaddr, topic string,
 			wg.Wait()
 			return nil
 		case <-lookup:
-		case n := <-closeRequest:
-			if _, exist := lastSeen[n]; !exist {
-				continue
-			}
-			// closeRequest is sent every time window after record was seen.
-			// record must be discovered again during same time window otherwise it will be removed.
-			if time.Since(lastSeen[n]) >= timeWindow {
-				close(closers[n])
-				_ = identities[n].Stop()
-				delete(identities, n)
-				delete(lastSeen, n)
-				delete(closers, n)
-				total--
-				log.Info("proxy for a record was removed", "identity", n.String(), "total", total)
+		case <-livenessWatcher.C:
+			for n := range identities {
+				if _, exist := lastSeen[n]; !exist {
+					continue
+				}
+				// closeRequest is sent every time window after record was seen.
+				// record must be discovered again during same time window otherwise it will be removed.
+				if time.Since(lastSeen[n]) >= opts.LivenessWindow {
+					close(closers[n])
+					_ = identities[n].Stop()
+					delete(identities, n)
+					delete(lastSeen, n)
+					delete(closers, n)
+					total--
+					log.Info("proxy for a record was removed", "identity", n.String(), "total", total)
+					feed.Send(proxyEvent{n, proxyStop, time.Now()})
+				}
 			}
 		case n := <-found:
 			_, exist := identities[n.ID]
 			// skip new record if we reached a limit.
-			if !exist && total == limit {
+			if !exist && total == opts.Limit {
 				continue
 			}
 			lastSeen[n.ID] = time.Now()
-			go time.AfterFunc(timeWindow, func() {
-				closeRequest <- n.ID
-			})
 			if exist {
 				log.Debug("received an update for existing identity", "identity", n.String())
 				continue
 			}
+			feed.Send(proxyEvent{n.ID, proxyStart, lastSeen[n.ID]})
 			total++
-			log.Info("proxying new record", "topic", topic, "identity", n.String(), "total", total)
+			log.Info("proxying new record", "topic", opts.Topic, "identity", n.String(), "total", total)
 			record, err := makeProxiedENR(n)
 			if err != nil {
 				log.Error("error converting discovered node to ENR", "node", n.String(), "error", err)
 			}
-			r := NewRendezvousWithENR(servers, record)
+			r := NewRendezvousWithENR(opts.Servers, record)
 			identities[n.ID] = r
 			closers[n.ID] = make(chan struct{})
 			if err := r.Start(); err != nil {
-				log.Error("unable to start rendezvous proxying", "servers", servers, "error", err)
+				log.Error("unable to start rendezvous proxying", "servers", opts.Servers, "error", err)
 			}
 			wg.Add(1)
 			go func() {
-				if err := r.Register(topic, closers[n.ID]); err != nil {
-					log.Error("register error", "topic", topic, "error", err)
+				if err := r.Register(opts.Topic, closers[n.ID]); err != nil {
+					log.Error("register error", "topic", opts.Topic, "error", err)
 				}
 				wg.Done()
 			}()


### PR DESCRIPTION
Amount of proxies was only growing. This PR adds to methods to clean used memory and limit potential amount of used memory.

By default only 100 nodes will be proxied. This can be changed with `-limit` flag on proxy binary.
If there was no update from a node during liveness window (10 minutes by default) node will be removed from a list of proxied nodes. Liveness window starts when node was discovered. So effectively node must be discovered again in the provided window. Default can be changed with `-liveness-window`.

Closes: https://github.com/status-im/status-go/issues/1170