### PR TITLE
Add IPC path command line flag

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -36,6 +36,8 @@ var (
 	configFiles      configFlags
 	logLevel         = flag.String("log", "", `Log level, one of: "ERROR", "WARN", "INFO", "DEBUG", and "TRACE"`)
 	logWithoutColors = flag.Bool("log-without-color", false, "Disables log colors")
+	ipcEnabled       = flag.Bool("ipc", false, "Enable IPC RPC endpoint")
+	ipcFile          = flag.String("ipcfile", "", "Set IPC file path")
 	pprofEnabled     = flag.Bool("pprof", false, "Enable runtime profiling via pprof")
 	pprofPort        = flag.Int("pprof-port", 52525, "Port for runtime profiling via pprof")
 	version          = flag.Bool("version", false, "Print version and dump configuration")
@@ -103,6 +105,12 @@ func main() {
 		config.RegisterTopics = append(config.RegisterTopics, params.MailServerDiscv5Topic)
 	} else if *register {
 		config.RegisterTopics = append(config.RegisterTopics, params.WhisperDiscv5Topic)
+	}
+
+	// enable IPC RPC
+	if *ipcEnabled {
+		config.IPCEnabled = true
+		config.IPCFile = *ipcFile
 	}
 
 	// set up logging options

--- a/node/node.go
+++ b/node/node.go
@@ -127,15 +127,18 @@ func newGethNodeConfig(config *params.NodeConfig) (*node.Config, error) {
 			MaxPeers:        config.MaxPeers,
 			MaxPendingPeers: config.MaxPendingPeers,
 		},
-		IPCPath:          config.IPCFile,
 		HTTPCors:         nil,
 		HTTPModules:      config.FormatAPIModules(),
 		HTTPVirtualHosts: []string{"localhost"},
 	}
 
 	if config.IPCEnabled {
-		// resolve relative/absolute path for IPC endpoint
-		nc.IPCPath = nc.IPCEndpoint()
+		// use well-known defaults
+		if config.IPCFile == "" {
+			config.IPCFile = "geth.ipc"
+		}
+
+		nc.IPCPath = config.IPCFile
 	}
 
 	if config.HTTPEnabled {

--- a/node/node.go
+++ b/node/node.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"time"
 
@@ -128,10 +127,15 @@ func newGethNodeConfig(config *params.NodeConfig) (*node.Config, error) {
 			MaxPeers:        config.MaxPeers,
 			MaxPendingPeers: config.MaxPendingPeers,
 		},
-		IPCPath:          makeIPCPath(config),
+		IPCPath:          config.IPCFile,
 		HTTPCors:         nil,
 		HTTPModules:      config.FormatAPIModules(),
 		HTTPVirtualHosts: []string{"localhost"},
+	}
+
+	if config.IPCEnabled {
+		// resolve relative/absolute path for IPC endpoint
+		nc.IPCPath = nc.IPCEndpoint()
 	}
 
 	if config.HTTPEnabled {
@@ -320,15 +324,6 @@ func activateShhService(stack *node.Node, config *params.NodeConfig, db *leveldb
 		svc := shhext.New(whisper, shhext.EnvelopeSignalHandler{}, db, config)
 		return svc, nil
 	})
-}
-
-// makeIPCPath returns IPC-RPC filename
-func makeIPCPath(config *params.NodeConfig) string {
-	if !config.IPCEnabled {
-		return ""
-	}
-
-	return path.Join(config.DataDir, config.IPCFile)
 }
 
 // parseNodes creates list of discover.Node out of enode strings.


### PR DESCRIPTION
This PR re-enables IPC configuration in statusd, and makes it work with absolute paths.

The use case is to be able to do `./statusd -ipc -ipcfile /tmp/geth.ipc` and be able to attach to it via `geth attach /tmp/geth.ipc`

Currently, it's impossible for two reasons:
 - need to use a config file and not clear where to get this config file from
 - IPC path was always using DataDir, even if an absolute path is specified

This PR addresses both.
