### PR TITLE
allow multiple topics in mailserver requests

### DIFF
--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -64,6 +64,7 @@ type MessagesRequest struct {
 	Cursor string `json:"cursor"`
 
 	// Topic is a regular Whisper topic.
+	// DEPRECATED
 	Topic whisper.TopicType `json:"topic"`
 
 	// Topics is a list of Whisper topics.

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -455,20 +455,15 @@ func createBloomFilter(r MessagesRequest) []byte {
 }
 
 func topicsToBloom(topics ...whisper.TopicType) []byte {
-	combined := make([]byte, whisper.BloomFilterSize)
-
-	for _, t := range topics {
-		bloom := whisper.TopicToBloom(t)
-
-		i := new(big.Int).SetBytes(combined)
+	i := new(big.Int)
+	for _, topic := range topics {
+		bloom := whisper.TopicToBloom(topic)
 		i.Or(i, new(big.Int).SetBytes(bloom[:]))
-
-		data := i.Bytes()
-		newCombined := make([]byte, whisper.BloomFilterSize)
-		copy(newCombined[whisper.BloomFilterSize-len(data):], data[:])
-
-		combined = newCombined
 	}
+
+	combined := make([]byte, whisper.BloomFilterSize)
+	data := i.Bytes()
+	copy(combined[whisper.BloomFilterSize-len(data):], data[:])
 
 	return combined
 }

--- a/services/shhext/api_test.go
+++ b/services/shhext/api_test.go
@@ -2,11 +2,9 @@ package shhext
 
 import (
 	"fmt"
-	"log"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/crypto/sha3"
 	whisper "github.com/status-im/whisper/whisperv6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,13 +93,5 @@ func TestCreateBloomFilter(t *testing.T) {
 }
 
 func stringToTopic(s string) whisper.TopicType {
-	h := sha3.NewKeccak256()
-	_, err := h.Write([]byte(s))
-	if err != nil {
-		log.Fatal(err)
-	}
-	fullTopic := h.Sum(nil)
-	topic := whisper.BytesToTopic(fullTopic)
-
-	return topic
+	return whisper.BytesToTopic([]byte(s))
 }


### PR DESCRIPTION
With this PR, I added the field `Topics` to the `MessagesRequest` struct.
For compatibility with older version of `status-react`, the `Topic`  field is still there.

In case `Topics` contains one or more topics, the bloom filter sent to the mail server combines all the bloom filters derived from each topic.

Closes #1234 
