### PR TITLE
Implement cache for recording removed logs due to reorg

### DIFF
--- a/services/rpcfilters/api.go
+++ b/services/rpcfilters/api.go
@@ -48,7 +48,9 @@ func NewPublicAPI(s *Service) *PublicAPI {
 		filters:                        make(map[rpc.ID]filter),
 		latestBlockChangedEvent:        s.latestBlockChangedEvent,
 		transactionSentToUpstreamEvent: s.transactionSentToUpstreamEvent,
-		client:               func() ContextCaller { return s.rpc.RPCClient() },
+
+		client: func() ContextCaller { return s.rpc.RPCClient() },
+
 		filterLivenessLoop:   defaultFilterLivenessPeriod,
 		filterLivenessPeriod: defaultFilterLivenessPeriod + 10*time.Second,
 	}
@@ -85,12 +87,13 @@ func (api *PublicAPI) NewFilter(crit filters.FilterCriteria) (rpc.ID, error) {
 	id := rpc.ID(uuid.New())
 	ctx, cancel := context.WithCancel(context.Background())
 	f := &logsFilter{
-		id:     id,
-		crit:   ethereum.FilterQuery(crit),
-		done:   make(chan struct{}),
-		timer:  time.NewTimer(api.filterLivenessPeriod),
-		ctx:    ctx,
-		cancel: cancel,
+		id:        id,
+		crit:      ethereum.FilterQuery(crit),
+		done:      make(chan struct{}),
+		timer:     time.NewTimer(api.filterLivenessPeriod),
+		ctx:       ctx,
+		cancel:    cancel,
+		logsCache: newCache(defaultCacheSize),
 	}
 	api.filtersMu.Lock()
 	api.filters[id] = f

--- a/services/rpcfilters/latest_logs.go
+++ b/services/rpcfilters/latest_logs.go
@@ -18,19 +18,16 @@ type ContextCaller interface {
 }
 
 func pollLogs(client ContextCaller, f *logsFilter, timeout, period time.Duration) {
-	adjusted := false
 	query := func() {
 		ctx, cancel := context.WithTimeout(f.ctx, timeout)
-		logs, err := getLogs(ctx, client, f.crit)
-		cancel()
+		defer cancel()
+		logs, err := getLogs(ctx, client, f.criteria())
 		if err != nil {
-			log.Error("failed to get logs", "criteria", f.crit, "error", err)
-		} else if !adjusted {
-			adjustFromBlock(&f.crit)
-			adjusted = true
+			log.Error("Error fetch logs", "criteria", f.crit, "error", err)
+			return
 		}
 		if err := f.add(logs); err != nil {
-			log.Error("error adding logs", "logs", logs, "error", err)
+			log.Error("Error adding logs", "logs", logs, "error", err)
 		}
 	}
 	query()
@@ -41,26 +38,11 @@ func pollLogs(client ContextCaller, f *logsFilter, timeout, period time.Duration
 		case <-latest.C:
 			query()
 		case <-f.done:
-			log.Debug("filter was stopped", "ID", f.id, "crit", f.crit)
+			log.Debug("Filter was stopped", "ID", f.id, "crit", f.crit)
 			return
 		}
 	}
 }
-
-// adjustFromBlock adjusts crit.FromBlock to the latest to avoid querying same logs multiple times.
-func adjustFromBlock(crit *ethereum.FilterQuery) {
-	latest := big.NewInt(rpc.LatestBlockNumber.Int64())
-	// don't adjust if filter is not interested in newer blocks
-	if crit.ToBlock != nil && crit.ToBlock.Cmp(latest) == 1 {
-		return
-	}
-	// don't adjust if from block is already pending
-	if crit.FromBlock != nil && crit.FromBlock.Cmp(latest) == -1 {
-		return
-	}
-	crit.FromBlock = latest
-}
-
 func getLogs(ctx context.Context, client ContextCaller, crit ethereum.FilterQuery) (rst []types.Log, err error) {
 	return rst, client.CallContext(ctx, &rst, "eth_getLogs", toFilterArg(crit))
 }

--- a/services/rpcfilters/logs_cache.go
+++ b/services/rpcfilters/logs_cache.go
@@ -1,0 +1,146 @@
+package rpcfilters
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const (
+	defaultCacheSize = 20
+)
+
+type cacheRecord struct {
+	block uint64
+	hash  common.Hash
+	logs  []types.Log
+}
+
+func newCache(size int) *cache {
+	return &cache{
+		records: make([]cacheRecord, 0, size),
+		size:    size,
+	}
+}
+
+type cache struct {
+	mu      sync.RWMutex
+	size    int // length of the records
+	records []cacheRecord
+}
+
+// add inserts logs into cache and returns added and replaced logs.
+// replaced logs with will be returned with Removed=true.
+func (c *cache) add(logs []types.Log) (added, replaced []types.Log, err error) {
+	if len(logs) == 0 {
+		return nil, nil, nil
+	}
+	aggregated := aggregateLogs(logs, c.size) // size doesn't change
+	if len(aggregated) == 0 {
+		return nil, nil, nil
+	}
+	if err := checkLogsAreInOrder(aggregated); err != nil {
+		return nil, nil, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// find common block. e.g. [3,4] and [1,2,3,4] = 3
+	last := 0
+	if len(c.records) > 0 {
+		last = len(c.records) - 1
+		for aggregated[0].block < c.records[last].block && last > 0 {
+			last--
+		}
+	}
+	c.records, added, replaced = merge(last, c.records, aggregated)
+	if lth := len(c.records); lth > c.size {
+		copy(c.records, c.records[lth-c.size:])
+	}
+	return added, replaced, nil
+}
+
+func (c *cache) earliestBlockNum() uint64 {
+	if len(c.records) == 0 {
+		return 0
+	}
+	return c.records[0].block
+}
+
+func checkLogsAreInOrder(records []cacheRecord) error {
+	for prev, i := 0, 1; i < len(records); i++ {
+		if records[prev].block == records[i].block-1 {
+			prev = i
+		} else {
+			return fmt.Errorf(
+				"logs must be delivered straight in order. gaps between blocks '%d' and '%d'",
+				records[prev].block, records[i].block,
+			)
+		}
+	}
+	return nil
+}
+
+// merge merges received records into old slice starting at provided position, example:
+// [1, 2, 3]
+//    [2, 3, 4]
+// [1, 2, 3, 4]
+// if hash doesn't match previously received hash - such block was removed due to reorg
+// logs that were a part of that block will be returned with Removed set to true
+func merge(last int, old, received []cacheRecord) ([]cacheRecord, []types.Log, []types.Log) {
+	var (
+		added, replaced []types.Log
+		block           uint64
+		hash            common.Hash
+	)
+	for i := range received {
+		record := received[i]
+		if last < len(old) {
+			block = old[last].block
+			hash = old[last].hash
+		}
+		if record.block > block {
+			// simply add new records
+			added = append(added, record.logs...)
+			old = append(old, record)
+		} else if record.hash != hash && record.block == block {
+			// record hash is not equal to previous record hash at the same height
+			// replace record in hash and add logs as replaced
+			replaced = append(replaced, old[last].logs...)
+			added = append(added, record.logs...)
+			old[last] = record
+		}
+		last++
+	}
+	return old, added, replaced
+}
+
+// aggregateLogs creates at most requested amount of cacheRecords from provided logs.
+// cacheRecords will be sorted in ascending order, starting from lowest block to highest.
+func aggregateLogs(logs []types.Log, limit int) []cacheRecord {
+	// sort in reverse order, so that iteration will start from latest blocks
+	sort.Slice(logs, func(i, j int) bool {
+		return logs[i].BlockNumber > logs[j].BlockNumber
+	})
+	rst := make([]cacheRecord, limit)
+	pos, start := len(rst)-1, 0
+	var hash common.Hash
+	for i := range logs {
+		log := logs[i]
+		if (hash != common.Hash{}) && hash != log.BlockHash {
+			rst[pos].logs = logs[start:i]
+			start = i
+			if pos-1 < 0 {
+				break
+			}
+			pos--
+		}
+		rst[pos].logs = logs[start:]
+		rst[pos].block = log.BlockNumber
+		rst[pos].hash = log.BlockHash
+		hash = log.BlockHash
+	}
+	return rst[pos:]
+}

--- a/services/rpcfilters/logs_cache_test.go
+++ b/services/rpcfilters/logs_cache_test.go
@@ -1,0 +1,120 @@
+package rpcfilters
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateLogs(t *testing.T) {
+	logs := []types.Log{}
+	for i := 1; i <= 15; i++ {
+		logs = append(logs,
+			types.Log{BlockNumber: uint64(i), BlockHash: common.Hash{byte(i)}},
+			types.Log{BlockNumber: uint64(i), BlockHash: common.Hash{byte(i)}})
+	}
+	aggregated := aggregateLogs(logs, 10)
+	start := 15 - len(aggregated) + 1
+	for _, record := range aggregated {
+		assert.Equal(t, start, int(record.block)) // numbers are small
+		assert.Len(t, record.logs, 2)
+		start++
+	}
+}
+
+func TestAggregateLessThenFull(t *testing.T) {
+	logs := []types.Log{}
+	for i := 1; i <= 3; i++ {
+		logs = append(logs,
+			types.Log{BlockNumber: uint64(i), BlockHash: common.Hash{byte(i)}})
+	}
+	aggregated := aggregateLogs(logs, 10)
+	start := 1
+	for _, record := range aggregated {
+		assert.Equal(t, start, int(record.block)) // numbers are small
+		assert.Len(t, record.logs, 1)
+		start++
+	}
+}
+
+func TestMerge(t *testing.T) {
+	step1Logs := []types.Log{
+		{BlockNumber: 1, BlockHash: common.Hash{1}},
+		{BlockNumber: 2, BlockHash: common.Hash{2}},
+		{BlockNumber: 3, BlockHash: common.Hash{3}},
+	}
+	step2Logs := []types.Log{
+		{BlockNumber: 2, BlockHash: common.Hash{2}},
+		{BlockNumber: 3, BlockHash: common.Hash{3}},
+		{BlockNumber: 4, BlockHash: common.Hash{4}},
+	}
+	reorg := []types.Log{
+		{BlockNumber: 2, BlockHash: common.Hash{2, 2}},
+		{BlockNumber: 3, BlockHash: common.Hash{3, 3}},
+		{BlockNumber: 4, BlockHash: common.Hash{4, 4}},
+		{BlockNumber: 5, BlockHash: common.Hash{5, 4}},
+	}
+
+	limit := 7
+	cache := make([]cacheRecord, 0, limit)
+	cache, added, replaced := merge(0, cache, aggregateLogs(step1Logs, limit))
+	require.Len(t, added, 3)
+	require.Empty(t, replaced)
+	require.Equal(t, 3, int(cache[2].block))
+	cache, added, replaced = merge(1, cache, aggregateLogs(step2Logs, limit))
+	require.Len(t, added, 1)
+	require.Empty(t, replaced)
+	require.Equal(t, 4, int(cache[3].block))
+	_, added, replaced = merge(1, cache, aggregateLogs(reorg, limit))
+	require.Len(t, added, 4)
+	require.Len(t, replaced, 3)
+}
+
+func TestMergeFull(t *testing.T) {
+	old := []cacheRecord{
+		{block: 1, hash: common.Hash{1}},
+		{block: 2, hash: common.Hash{2}},
+		{block: 3, hash: common.Hash{3}},
+	}
+	new := []cacheRecord{
+		{block: 4, hash: common.Hash{4}},
+		{block: 5, hash: common.Hash{5}},
+	}
+	old, _, _ = merge(0, old, new)
+	require.Len(t, old, 5)
+	require.Equal(t, int(old[2].block), 3)
+	require.Equal(t, int(old[3].block), 4)
+	require.Equal(t, int(old[4].block), 5)
+}
+
+func TestAddLogs(t *testing.T) {
+	c := newCache(7)
+	step1Logs := []types.Log{
+		{BlockNumber: 1, BlockHash: common.Hash{1}},
+		{BlockNumber: 2, BlockHash: common.Hash{2}},
+		{BlockNumber: 3, BlockHash: common.Hash{3}},
+	}
+	step2Logs := []types.Log{
+		{BlockNumber: 2, BlockHash: common.Hash{2}},
+		{BlockNumber: 3, BlockHash: common.Hash{3}},
+		{BlockNumber: 4, BlockHash: common.Hash{4}},
+	}
+	added, replaced, err := c.add(step1Logs)
+	require.NoError(t, err)
+	require.Len(t, added, 3)
+	require.Empty(t, replaced)
+	added, replaced, err = c.add(step2Logs)
+	require.NoError(t, err)
+	require.Len(t, added, 1)
+	require.Empty(t, replaced)
+}
+
+func TestAddLogsNotInOrder(t *testing.T) {
+	c := newCache(7)
+	logs := []types.Log{{BlockNumber: 1, BlockHash: common.Hash{1}}, {BlockNumber: 3, BlockHash: common.Hash{3}}}
+	_, _, err := c.add(logs)
+	require.EqualError(t, err, "logs must be delivered straight in order. gaps between blocks '1' and '3'")
+}

--- a/services/rpcfilters/service.go
+++ b/services/rpcfilters/service.go
@@ -27,6 +27,7 @@ func New(rpc rpcProvider) *Service {
 	return &Service{
 		latestBlockChangedEvent:        latestBlockChangedEvent,
 		transactionSentToUpstreamEvent: transactionSentToUpstreamEvent,
+
 		rpc: rpc,
 	}
 }


### PR DESCRIPTION
Original geth implementation of the newFilter will return logs with Removed flag set to true whenever reorg occurs. 

This change provides the same feature using a cache with logs for last 20 blocks. Example how it operates:
1. we queried logs from block 10 to latest, which is 11 at the moment of query. Cache will be populated with logs: Log{Block: 10, BlockHash: x10}, Log{Block: 11, BlockHash: x11}
2. we adjusted getLogs criteria to query only for latest blogs, and the next query returned logs for block 12:
Log{Block: 12, BlockHash: x12}
3. we poll again but this time for same height client received different block: Log{Block: 12, **BlockHash: x12222**}
4. we detect that reorg occurred and we need to verify if any of the previous logs are affected
5. we adjust criteria to include earliest known block that we have in our cache. in this case it is 10th block. we query from 10th block to latest, receive - Log{Block; 10, BlockHash: 0x10}, Log{Block: 11, **BlockHash: x111111**}, Log{Block: 12, BlockHash: x12222}.
6. basically this history means that block 11 is different from what we knew earlier and we notify a client that previous log was removed and new added
7. after this we make same query again, and if no-reorg detected we switch to polling only latest blocks

closes: https://github.com/status-im/status-go/issues/1110
