### PR TITLE
add metrics to mailserver for invalid reqs and processing errors

### DIFF
--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -48,14 +48,17 @@ var (
 	errDecryptionMethodNotProvided = errors.New("decryption method is not provided")
 	// By default go-ethereum/metrics creates dummy metrics that don't register anything.
 	// Real metrics are collected only if -metrics flag is set
-	requestProcessTimer    = metrics.NewRegisteredTimer("mailserver/requestProcessTime", nil)
-	requestsMeter          = metrics.NewRegisteredMeter("mailserver/requests", nil)
-	requestErrorsCounter   = metrics.NewRegisteredCounter("mailserver/requestErrors", nil)
-	sentEnvelopesMeter     = metrics.NewRegisteredMeter("mailserver/sentEnvelopes", nil)
-	sentEnvelopesSizeMeter = metrics.NewRegisteredMeter("mailserver/sentEnvelopesSize", nil)
-	archivedMeter          = metrics.NewRegisteredMeter("mailserver/archivedEnvelopes", nil)
-	archivedSizeMeter      = metrics.NewRegisteredMeter("mailserver/archivedEnvelopesSize", nil)
-	archivedErrorsCounter  = metrics.NewRegisteredCounter("mailserver/archiveErrors", nil)
+	requestProcessTimer            = metrics.NewRegisteredTimer("mailserver/requestProcessTime", nil)
+	requestsMeter                  = metrics.NewRegisteredMeter("mailserver/requests", nil)
+	requestErrorsCounter           = metrics.NewRegisteredCounter("mailserver/requestErrors", nil)
+	sentEnvelopesMeter             = metrics.NewRegisteredMeter("mailserver/sentEnvelopes", nil)
+	sentEnvelopesSizeMeter         = metrics.NewRegisteredMeter("mailserver/sentEnvelopesSize", nil)
+	archivedMeter                  = metrics.NewRegisteredMeter("mailserver/archivedEnvelopes", nil)
+	archivedSizeMeter              = metrics.NewRegisteredMeter("mailserver/archivedEnvelopesSize", nil)
+	archivedErrorsCounter          = metrics.NewRegisteredCounter("mailserver/archiveErrors", nil)
+	requestValidationErrorsCounter = metrics.NewRegisteredCounter("mailserver/requestValidationErrors", nil)
+	processRequestErrorsCounter    = metrics.NewRegisteredCounter("mailserver/processRequestErrors", nil)
+	historicResponseErrorsCounter  = metrics.NewRegisteredCounter("mailserver/historicResponseErrors", nil)
 )
 
 const (
@@ -252,13 +255,17 @@ func (s *WMailServer) DeliverMail(peer *whisper.Peer, request *whisper.Envelope)
 	if ok, lower, upper, bloom, limit, cursor := s.validateRequest(peer.ID(), request); ok {
 		_, lastEnvelopeHash, nextPageCursor, err := s.processRequest(peer, lower, upper, bloom, limit, cursor)
 		if err != nil {
+			processRequestErrorsCounter.Inc(1)
 			log.Error(fmt.Sprintf("error in DeliverMail: %s", err))
 			return
 		}
 
 		if err := s.sendHistoricMessageResponse(peer, request, lastEnvelopeHash, nextPageCursor); err != nil {
+			historicResponseErrorsCounter.Inc(1)
 			log.Error(fmt.Sprintf("SendHistoricMessageResponse error: %s", err))
 		}
+	} else {
+		requestValidationErrorsCounter.Inc(1)
 	}
 }
 


### PR DESCRIPTION
This PR add more metrics to mail server in case of:

1 - invalid request
2 - error while sending messages
3 - error sending response message