### PR TITLE
Change API of BuildDirectMessage function to use variadic arguments

### DIFF
--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -260,9 +260,8 @@ func (api *PublicAPI) SendDirectMessage(ctx context.Context, msg chat.SendDirect
 		return nil, err
 	}
 
-	keys := []*ecdsa.PublicKey{publicKey}
 	// This is transport layer-agnostic
-	protocolMessages, err := api.service.protocol.BuildDirectMessage(privateKey, keys, msg.Payload)
+	protocolMessages, err := api.service.protocol.BuildDirectMessage(privateKey, msg.Payload, publicKey)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +343,7 @@ func (api *PublicAPI) SendGroupMessage(ctx context.Context, msg chat.SendGroupMe
 	}
 
 	// This is transport layer-agnostic
-	protocolMessages, err := api.service.protocol.BuildDirectMessage(privateKey, keys, msg.Payload)
+	protocolMessages, err := api.service.protocol.BuildDirectMessage(privateKey, msg.Payload, keys...)
 	if err != nil {
 		return nil, err
 	}

--- a/services/shhext/chat/protocol.go
+++ b/services/shhext/chat/protocol.go
@@ -59,9 +59,10 @@ func (p *ProtocolService) BuildPublicMessage(myIdentityKey *ecdsa.PrivateKey, pa
 }
 
 // BuildDirectMessage marshals a 1:1 chat message given the user identity private key, the recipient's public key, and a payload
-func (p *ProtocolService) BuildDirectMessage(myIdentityKey *ecdsa.PrivateKey, theirPublicKeys []*ecdsa.PublicKey, payload []byte) (map[*ecdsa.PublicKey][]byte, error) {
+func (p *ProtocolService) BuildDirectMessage(myIdentityKey *ecdsa.PrivateKey, payload []byte, theirPublicKeys ...*ecdsa.PublicKey) (map[*ecdsa.PublicKey][]byte, error) {
 	response := make(map[*ecdsa.PublicKey][]byte)
-	for _, publicKey := range append(theirPublicKeys, &myIdentityKey.PublicKey) {
+	publicKeys := append(theirPublicKeys, &myIdentityKey.PublicKey)
+	for _, publicKey := range publicKeys {
 		// Encrypt payload
 		encryptionResponse, err := p.encryption.EncryptPayload(publicKey, myIdentityKey, payload)
 		if err != nil {

--- a/services/shhext/chat/protocol_test.go
+++ b/services/shhext/chat/protocol_test.go
@@ -57,8 +57,7 @@ func (s *ProtocolServiceTestSuite) TestBuildDirectMessage() {
 	})
 	s.NoError(err)
 
-	keys := []*ecdsa.PublicKey{&bobKey.PublicKey}
-	marshaledMsg, err := s.alice.BuildDirectMessage(aliceKey, keys, payload)
+	marshaledMsg, err := s.alice.BuildDirectMessage(aliceKey, payload, &bobKey.PublicKey)
 
 	s.NoError(err)
 	s.NotNil(marshaledMsg, "It creates a message")
@@ -98,10 +97,8 @@ func (s *ProtocolServiceTestSuite) TestBuildAndReadDirectMessage() {
 	marshaledPayload, err := proto.Marshal(&payload)
 	s.NoError(err)
 
-	keys := []*ecdsa.PublicKey{&bobKey.PublicKey}
-
 	// Message is sent with DH
-	marshaledMsg, err := s.alice.BuildDirectMessage(aliceKey, keys, marshaledPayload)
+	marshaledMsg, err := s.alice.BuildDirectMessage(aliceKey, marshaledPayload, &bobKey.PublicKey)
 
 	s.NoError(err)
 

--- a/services/shhext/chat/protocol_test.go
+++ b/services/shhext/chat/protocol_test.go
@@ -1,7 +1,6 @@
 package chat
 
 import (
-	"crypto/ecdsa"
 	"os"
 	"testing"
 


### PR DESCRIPTION
I was late to the party of reviewing https://github.com/status-im/status-go/pull/1237, so will be addressing some of my unpublished comments in separate small PRs.

This one slightly improves API of `BuildDirectMessage` function by using [variadic arguments](https://golang.org/ref/spec#Passing_arguments_to_..._parameters). Seems like it simplifies the usage a bit, removing the need of wrapping single key into the slice of keys.