### PR TITLE
Increase max skip keys

### DIFF
--- a/services/shhext/chat/encryption.go
+++ b/services/shhext/chat/encryption.go
@@ -251,6 +251,9 @@ func (s *EncryptionService) createNewSession(drInfo *RatchetInfo, sk [32]byte, k
 			keyPair,
 			s.persistence.GetSessionStorage(),
 			dr.WithKeysStorage(s.persistence.GetKeysStorage()),
+			// TODO: Temporarily increase to a high number, until
+			// we make sure it's a sliding window rather than dropping
+			dr.WithMaxSkip(10000),
 			dr.WithCrypto(crypto.EthereumCrypto{}))
 	} else {
 		session, err = dr.NewWithRemoteKey(
@@ -259,6 +262,9 @@ func (s *EncryptionService) createNewSession(drInfo *RatchetInfo, sk [32]byte, k
 			keyPair.PubKey,
 			s.persistence.GetSessionStorage(),
 			dr.WithKeysStorage(s.persistence.GetKeysStorage()),
+			// TODO: Temporarily increase to a high number, until
+			// we make sure it's a sliding window rather than dropping
+			dr.WithMaxSkip(10000),
 			dr.WithCrypto(crypto.EthereumCrypto{}))
 	}
 
@@ -285,6 +291,9 @@ func (s *EncryptionService) encryptUsingDR(theirIdentityKey *ecdsa.PublicKey, dr
 		drInfo.ID,
 		sessionStorage,
 		dr.WithKeysStorage(s.persistence.GetKeysStorage()),
+		// TODO: Temporarily increase to a high number, until
+		// we make sure it's a sliding window rather than dropping
+		dr.WithMaxSkip(10000),
 		dr.WithCrypto(crypto.EthereumCrypto{}),
 	)
 	if err != nil {
@@ -333,6 +342,9 @@ func (s *EncryptionService) decryptUsingDR(theirIdentityKey *ecdsa.PublicKey, dr
 		drInfo.ID,
 		sessionStorage,
 		dr.WithKeysStorage(s.persistence.GetKeysStorage()),
+		// TODO: Temporarily increase to a high number, until
+		// we make sure it's a sliding window rather than dropping
+		dr.WithMaxSkip(10000),
 		dr.WithCrypto(crypto.EthereumCrypto{}),
 	)
 	if err != nil {


### PR DESCRIPTION
This is still a preliminary investigation, not sure is 100% is accurate.

It seems our implementation of the doubleratchet chose a different approach on handling skipped keys (https://signal.org/docs/specifications/doubleratchet/#deletion-of-skipped-message-keys), instead of deleting old keys it refuses to decrypt  new messages once the threshold is reached.
The specs suggests to store x amount of keys, not to stop decrypting (old keys should be removed rather, as those are the one that are more likely to be compromised).

This is problematic  as missed messages start accumulating until you reach the threshold at which point the session will not be decrypting anymore messages unless previous messages are retrieved.

In the meantime I have increase the amount of stored keys, while I will investigate further and work on a potential fix.

<blockquote></blockquote>