### PR TITLE
fix collecting p2p/Peers metric

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -207,6 +207,7 @@ func startCollectingNodeMetrics(interruptCh <-chan struct{}, statusNode *node.St
 			if err := nodemetrics.SubscribeServerEvents(ctx, gethNode); err != nil {
 				logger.Error("Failed to subscribe server events", "error", err)
 			} else {
+				// no error means that the subscription was terminated by purpose
 				return
 			}
 

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -202,8 +202,15 @@ func startCollectingNodeMetrics(interruptCh <-chan struct{}, statusNode *node.St
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		if err := nodemetrics.SubscribeServerEvents(ctx, gethNode); err != nil {
-			logger.Error("Failed to subscribe server events", "error", err)
+		// Try to subscribe and collect metrics. In case of an error, retry.
+		for {
+			if err := nodemetrics.SubscribeServerEvents(ctx, gethNode); err != nil {
+				logger.Error("Failed to subscribe server events", "error", err)
+			} else {
+				return
+			}
+
+			time.Sleep(time.Second)
 		}
 	}()
 

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -139,8 +139,10 @@ func main() {
 		profiling.NewProfiler(*pprofPort).Go()
 	}
 
-	// Run stats server.
-	if *metrics {
+	// Start collecting metrics. Metrics can be enabled by providing `-metrics` flag
+	// or setting `gethmetrics.Enabled` to true during compilation time:
+	// https://github.com/status-im/go-ethereum/pull/76.
+	if *metrics || gethmetrics.Enabled {
 		go startCollectingNodeMetrics(interruptCh, backend.StatusNode())
 		go gethmetrics.CollectProcessMetrics(3 * time.Second)
 	}

--- a/metrics/node/metrics.go
+++ b/metrics/node/metrics.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	nodePeersCounter  metrics.Counter
+	nodePeersGauge    metrics.Gauge
 	nodeMaxPeersGauge metrics.Gauge
 )
 
@@ -22,7 +22,7 @@ func init() {
 		metrics.Enabled = true
 	}
 
-	nodePeersCounter = metrics.NewRegisteredCounter("p2p/Peers", nil)
+	nodePeersGauge = metrics.NewRegisteredGauge("p2p/Peers", nil)
 	nodeMaxPeersGauge = metrics.NewRegisteredGauge("p2p/MaxPeers", nil)
 }
 
@@ -32,12 +32,7 @@ func updateNodeMetrics(node *node.Node, evType p2p.PeerEventType) error {
 		return errors.New("p2p server is unavailable")
 	}
 
-	if evType == p2p.PeerEventTypeAdd {
-		nodePeersCounter.Inc(1)
-	} else if evType == p2p.PeerEventTypeDrop {
-		nodePeersCounter.Dec(1)
-	}
-
+	nodePeersGauge.Update(int64(server.PeerCount()))
 	nodeMaxPeersGauge.Update(int64(server.MaxPeers))
 
 	return nil

--- a/metrics/node/metrics_test.go
+++ b/metrics/node/metrics_test.go
@@ -22,23 +22,23 @@ func TestUpdateNodeMetricsPeersCounter(t *testing.T) {
 
 	err = updateNodeMetrics(n, p2p.PeerEventTypeAdd)
 	require.NoError(t, err)
-	require.Equal(t, int64(1), nodePeersGauge.Value())
+	require.Equal(t, int64(1), nodePeersCounter.Count())
 	require.Equal(t, int64(10), nodeMaxPeersGauge.Value())
 
 	err = updateNodeMetrics(n, p2p.PeerEventTypeAdd)
 	require.NoError(t, err)
-	require.Equal(t, int64(2), nodePeersGauge.Value())
+	require.Equal(t, int64(2), nodePeersCounter.Count())
 
 	// skip other events
 	err = updateNodeMetrics(n, p2p.PeerEventTypeMsgRecv)
 	require.NoError(t, err)
 	err = updateNodeMetrics(n, p2p.PeerEventTypeMsgSend)
 	require.NoError(t, err)
-	require.Equal(t, int64(2), nodePeersGauge.Value())
+	require.Equal(t, int64(2), nodePeersCounter.Count())
 
 	err = updateNodeMetrics(n, p2p.PeerEventTypeDrop)
 	require.NoError(t, err)
-	require.Equal(t, int64(1), nodePeersGauge.Value())
+	require.Equal(t, int64(1), nodePeersCounter.Count())
 
 	n.Server().MaxPeers = 20
 	err = updateNodeMetrics(n, p2p.PeerEventTypeDrop)

--- a/metrics/node/metrics_test.go
+++ b/metrics/node/metrics_test.go
@@ -22,23 +22,23 @@ func TestUpdateNodeMetricsPeersCounter(t *testing.T) {
 
 	err = updateNodeMetrics(n, p2p.PeerEventTypeAdd)
 	require.NoError(t, err)
-	require.Equal(t, int64(1), nodePeersCounter.Count())
+	require.Equal(t, int64(1), nodePeersGauge.Value())
 	require.Equal(t, int64(10), nodeMaxPeersGauge.Value())
 
 	err = updateNodeMetrics(n, p2p.PeerEventTypeAdd)
 	require.NoError(t, err)
-	require.Equal(t, int64(2), nodePeersCounter.Count())
+	require.Equal(t, int64(2), nodePeersGauge.Value())
 
 	// skip other events
 	err = updateNodeMetrics(n, p2p.PeerEventTypeMsgRecv)
 	require.NoError(t, err)
 	err = updateNodeMetrics(n, p2p.PeerEventTypeMsgSend)
 	require.NoError(t, err)
-	require.Equal(t, int64(2), nodePeersCounter.Count())
+	require.Equal(t, int64(2), nodePeersGauge.Value())
 
 	err = updateNodeMetrics(n, p2p.PeerEventTypeDrop)
 	require.NoError(t, err)
-	require.Equal(t, int64(1), nodePeersCounter.Count())
+	require.Equal(t, int64(1), nodePeersGauge.Value())
 
 	n.Server().MaxPeers = 20
 	err = updateNodeMetrics(n, p2p.PeerEventTypeDrop)

--- a/metrics/node/subscribe.go
+++ b/metrics/node/subscribe.go
@@ -23,6 +23,7 @@ func SubscribeServerEvents(ctx context.Context, node *node.Node) error {
 
 	ch := make(chan *p2p.PeerEvent, server.MaxPeers)
 	subscription := server.SubscribeEvents(ch)
+	defer subscription.Unsubscribe()
 
 	logger.Debug("Subscribed to server events")
 
@@ -38,10 +39,8 @@ func SubscribeServerEvents(ctx context.Context, node *node.Node) error {
 			if err != nil {
 				logger.Error("Subscription failed", "err", err)
 			}
-			subscription.Unsubscribe()
 			return err
 		case <-ctx.Done():
-			subscription.Unsubscribe()
 			return nil
 		}
 	}


### PR DESCRIPTION
In case a peer event is missed, the calculation of the current number of peers might be off. Change to getting the absolute value always.

I did not figure out why some subscription events are missed...

The biggest difference I found was for `node-04.ac-cn-hongkong-c.eth.beta` container `statusd-whisper-1` where the total number of connected peers was 75 while the metrics reported 13.