### PR TITLE
Add tests for multi-device and refactor encryption service config

### DIFF
--- a/services/shhext/chat/encryption_multi_device_test.go
+++ b/services/shhext/chat/encryption_multi_device_test.go
@@ -1,6 +1,8 @@
 package chat
 
 import (
+	"crypto/ecdsa"
+	"fmt"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/suite"
 	"os"
@@ -8,114 +10,106 @@ import (
 	"testing"
 )
 
+const (
+	aliceUser = "alice"
+	bobUser   = "bob"
+)
+
 func TestEncryptionServiceMultiDeviceSuite(t *testing.T) {
 	suite.Run(t, new(EncryptionServiceMultiDeviceSuite))
 }
 
+type serviceAndKey struct {
+	encryptionServices []*EncryptionService
+	key                *ecdsa.PrivateKey
+}
+
 type EncryptionServiceMultiDeviceSuite struct {
 	suite.Suite
-	alice1 *EncryptionService
-	bob1   *EncryptionService
-	alice2 *EncryptionService
-	bob2   *EncryptionService
-	alice3 *EncryptionService
+	services map[string]*serviceAndKey
+}
+
+func setupUser(user string, s *EncryptionServiceMultiDeviceSuite, n int) error {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		return err
+	}
+
+	s.services[user] = &serviceAndKey{
+		key:                key,
+		encryptionServices: make([]*EncryptionService, n),
+	}
+
+	for i := 0; i < n; i++ {
+		installationID := fmt.Sprintf("%s%d", user, i+1)
+		dbPath := fmt.Sprintf("/tmp/%s.db", installationID)
+
+		os.Remove(dbPath)
+
+		persistence, err := NewSQLLitePersistence(dbPath, "key")
+		if err != nil {
+			return err
+		}
+
+		config := DefaultEncryptionServiceConfig(installationID)
+		config.MaxInstallations = n - 1
+
+		s.services[user].encryptionServices[i] = NewEncryptionService(persistence, config)
+
+	}
+
+	return nil
 }
 
 func (s *EncryptionServiceMultiDeviceSuite) SetupTest() {
-	const (
-		aliceDBPath1 = "/tmp/alice1.db"
-		aliceDBKey1  = "alice1"
-		aliceDBPath2 = "/tmp/alice2.db"
-		aliceDBKey2  = "alice2"
-		aliceDBPath3 = "/tmp/alice3.db"
-		aliceDBKey3  = "alice3"
-		bobDBPath1   = "/tmp/bob1.db"
-		bobDBKey1    = "bob1"
-		bobDBPath2   = "/tmp/bob2.db"
-		bobDBKey2    = "bob2"
-	)
+	s.services = make(map[string]*serviceAndKey)
+	err := setupUser(aliceUser, s, 4)
+	s.Require().NoError(err)
 
-	os.Remove(aliceDBPath1)
-	os.Remove(bobDBPath1)
-	os.Remove(aliceDBPath2)
-	os.Remove(bobDBPath2)
-	os.Remove(aliceDBPath3)
-
-	alicePersistence1, err := NewSQLLitePersistence(aliceDBPath1, aliceDBKey1)
-	if err != nil {
-		panic(err)
-	}
-
-	alicePersistence2, err := NewSQLLitePersistence(aliceDBPath2, aliceDBKey2)
-	if err != nil {
-		panic(err)
-	}
-
-	alicePersistence3, err := NewSQLLitePersistence(aliceDBPath3, aliceDBKey3)
-	if err != nil {
-		panic(err)
-	}
-
-	bobPersistence1, err := NewSQLLitePersistence(bobDBPath1, bobDBKey1)
-	if err != nil {
-		panic(err)
-	}
-
-	bobPersistence2, err := NewSQLLitePersistence(bobDBPath2, bobDBKey2)
-	if err != nil {
-		panic(err)
-	}
-
-	s.alice1 = NewEncryptionService(alicePersistence1, "alice1")
-	s.bob1 = NewEncryptionService(bobPersistence1, "bob1")
-
-	s.alice2 = NewEncryptionService(alicePersistence2, "alice2")
-	s.bob2 = NewEncryptionService(bobPersistence2, "bob2")
-
-	s.alice3 = NewEncryptionService(alicePersistence3, "alice3")
+	err = setupUser(bobUser, s, 4)
+	s.Require().NoError(err)
 }
 
 func (s *EncryptionServiceMultiDeviceSuite) TestProcessPublicBundle() {
-	aliceKey, err := crypto.GenerateKey()
-	s.Require().NoError(err)
+	aliceKey := s.services[aliceUser].key
 
-	alice2Bundle, err := s.alice2.CreateBundle(aliceKey)
+	alice2Bundle, err := s.services[aliceUser].encryptionServices[1].CreateBundle(aliceKey)
 	s.Require().NoError(err)
 
 	alice2Identity, err := ExtractIdentity(alice2Bundle)
 	s.Require().NoError(err)
 
-	alice3Bundle, err := s.alice3.CreateBundle(aliceKey)
+	alice3Bundle, err := s.services[aliceUser].encryptionServices[2].CreateBundle(aliceKey)
 	s.Require().NoError(err)
 
 	alice3Identity, err := ExtractIdentity(alice2Bundle)
 	s.Require().NoError(err)
 
 	// Add alice2 bundle
-	response, err := s.alice1.ProcessPublicBundle(aliceKey, alice2Bundle)
+	response, err := s.services[aliceUser].encryptionServices[0].ProcessPublicBundle(aliceKey, alice2Bundle)
 	s.Require().NoError(err)
 	s.Require().Equal(IdentityAndIDPair{alice2Identity, "alice2"}, response[0])
 
 	// Add alice3 bundle
-	response, err = s.alice1.ProcessPublicBundle(aliceKey, alice3Bundle)
+	response, err = s.services[aliceUser].encryptionServices[0].ProcessPublicBundle(aliceKey, alice3Bundle)
 	s.Require().NoError(err)
 	s.Require().Equal(IdentityAndIDPair{alice3Identity, "alice3"}, response[0])
 
 	// No installation is enabled
-	alice1MergedBundle1, err := s.alice1.CreateBundle(aliceKey)
+	alice1MergedBundle1, err := s.services[aliceUser].encryptionServices[0].CreateBundle(aliceKey)
 	s.Require().NoError(err)
 
 	s.Require().Equal(1, len(alice1MergedBundle1.GetSignedPreKeys()))
 	s.Require().NotNil(alice1MergedBundle1.GetSignedPreKeys()["alice1"])
 
 	// We enable the installations
-	err = s.alice1.EnableInstallation(&aliceKey.PublicKey, "alice2")
+	err = s.services[aliceUser].encryptionServices[0].EnableInstallation(&aliceKey.PublicKey, "alice2")
 	s.Require().NoError(err)
 
-	err = s.alice1.EnableInstallation(&aliceKey.PublicKey, "alice3")
+	err = s.services[aliceUser].encryptionServices[0].EnableInstallation(&aliceKey.PublicKey, "alice3")
 	s.Require().NoError(err)
 
-	alice1MergedBundle2, err := s.alice1.CreateBundle(aliceKey)
+	alice1MergedBundle2, err := s.services[aliceUser].encryptionServices[0].CreateBundle(aliceKey)
 	s.Require().NoError(err)
 
 	// We get back a bundle with all the installations
@@ -124,7 +118,7 @@ func (s *EncryptionServiceMultiDeviceSuite) TestProcessPublicBundle() {
 	s.Require().NotNil(alice1MergedBundle2.GetSignedPreKeys()["alice2"])
 	s.Require().NotNil(alice1MergedBundle2.GetSignedPreKeys()["alice3"])
 
-	response, err = s.alice1.ProcessPublicBundle(aliceKey, alice1MergedBundle2)
+	response, err = s.services[aliceUser].encryptionServices[0].ProcessPublicBundle(aliceKey, alice1MergedBundle2)
 	s.Require().NoError(err)
 	sort.Slice(response, func(i, j int) bool {
 		return response[i][1] < response[j][1]
@@ -135,10 +129,10 @@ func (s *EncryptionServiceMultiDeviceSuite) TestProcessPublicBundle() {
 	s.Require().Equal(IdentityAndIDPair{alice2Identity, "alice3"}, response[1])
 
 	// We disable the installations
-	err = s.alice1.DisableInstallation(&aliceKey.PublicKey, "alice2")
+	err = s.services[aliceUser].encryptionServices[0].DisableInstallation(&aliceKey.PublicKey, "alice2")
 	s.Require().NoError(err)
 
-	alice1MergedBundle3, err := s.alice1.CreateBundle(aliceKey)
+	alice1MergedBundle3, err := s.services[aliceUser].encryptionServices[0].CreateBundle(aliceKey)
 	s.Require().NoError(err)
 
 	// We get back a bundle with all the installations
@@ -152,25 +146,111 @@ func (s *EncryptionServiceMultiDeviceSuite) TestProcessPublicBundleOutOfOrder() 
 	s.Require().NoError(err)
 
 	// Alice1 creates a bundle
-	alice1Bundle, err := s.alice1.CreateBundle(aliceKey)
+	alice1Bundle, err := s.services[aliceUser].encryptionServices[0].CreateBundle(aliceKey)
 	s.Require().NoError(err)
 
 	// Alice2 Receives the bundle
-	_, err = s.alice2.ProcessPublicBundle(aliceKey, alice1Bundle)
+	_, err = s.services[aliceUser].encryptionServices[1].ProcessPublicBundle(aliceKey, alice1Bundle)
 	s.Require().NoError(err)
 
 	// Alice2 Creates a Bundle
-	_, err = s.alice2.CreateBundle(aliceKey)
+	_, err = s.services[aliceUser].encryptionServices[1].CreateBundle(aliceKey)
 	s.Require().NoError(err)
 
 	// We enable the installation
-	err = s.alice2.EnableInstallation(&aliceKey.PublicKey, "alice1")
+	err = s.services[aliceUser].encryptionServices[1].EnableInstallation(&aliceKey.PublicKey, "alice1")
 	s.Require().NoError(err)
 
 	// It should contain both bundles
-	alice2MergedBundle1, err := s.alice2.CreateBundle(aliceKey)
+	alice2MergedBundle1, err := s.services[aliceUser].encryptionServices[1].CreateBundle(aliceKey)
 	s.Require().NoError(err)
 
 	s.Require().NotNil(alice2MergedBundle1.GetSignedPreKeys()["alice1"])
 	s.Require().NotNil(alice2MergedBundle1.GetSignedPreKeys()["alice2"])
+}
+
+func pairDevices(s *serviceAndKey, target int) error {
+	device := s.encryptionServices[target]
+	for i := 0; i < len(s.encryptionServices); i++ {
+		b, err := s.encryptionServices[i].CreateBundle(s.key)
+
+		if err != nil {
+			return err
+		}
+
+		_, err = device.ProcessPublicBundle(s.key, b)
+		if err != nil {
+			return err
+		}
+
+		err = device.EnableInstallation(&s.key.PublicKey, s.encryptionServices[i].config.InstallationID)
+		if err != nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (s *EncryptionServiceMultiDeviceSuite) TestMaxDevices() {
+	err := pairDevices(s.services[aliceUser], 0)
+	s.Require().NoError(err)
+	alice1 := s.services[aliceUser].encryptionServices[0]
+	bob1 := s.services[bobUser].encryptionServices[0]
+	aliceKey := s.services[aliceUser].key
+	bobKey := s.services[bobUser].key
+
+	// Check bundle is ok
+	// No installation is enabled
+	aliceBundle, err := alice1.CreateBundle(aliceKey)
+	s.Require().NoError(err)
+
+	// Check all installations are correctly working, and that the oldest device is not there
+	preKeys := aliceBundle.GetSignedPreKeys()
+	s.Require().Equal(3, len(preKeys))
+	s.Require().NotNil(preKeys["alice1"])
+	// alice2 being the oldest device is rotated out, as we reached the maximum
+	s.Require().Nil(preKeys["alice2"])
+	s.Require().NotNil(preKeys["alice3"])
+	s.Require().NotNil(preKeys["alice4"])
+
+	// We propagate this to bob
+	_, err = bob1.ProcessPublicBundle(bobKey, aliceBundle)
+	s.Require().NoError(err)
+
+	// Bob sends a message to alice
+	payload, err := bob1.EncryptPayload(&aliceKey.PublicKey, bobKey, []byte("test"))
+	s.Require().NoError(err)
+	s.Require().Equal(3, len(payload))
+	s.Require().NotNil(payload["alice1"])
+	s.Require().NotNil(payload["alice3"])
+	s.Require().NotNil(payload["alice4"])
+
+	// We disable the last installation
+	err = s.services[aliceUser].encryptionServices[0].DisableInstallation(&aliceKey.PublicKey, "alice4")
+	s.Require().NoError(err)
+
+	// We check the bundle is updated
+	aliceBundle, err = alice1.CreateBundle(aliceKey)
+	s.Require().NoError(err)
+
+	// Check all installations are there
+	preKeys = aliceBundle.GetSignedPreKeys()
+	s.Require().Equal(3, len(preKeys))
+	s.Require().NotNil(preKeys["alice1"])
+	s.Require().NotNil(preKeys["alice2"])
+	s.Require().NotNil(preKeys["alice3"])
+	// alice4 is disabled at this point, alice2 is back in
+	s.Require().Nil(preKeys["alice4"])
+
+	// We propagate this to bob
+	_, err = bob1.ProcessPublicBundle(bobKey, aliceBundle)
+	s.Require().NoError(err)
+
+	// Bob sends a message to alice
+	payload, err = bob1.EncryptPayload(&aliceKey.PublicKey, bobKey, []byte("test"))
+	s.Require().NoError(err)
+	s.Require().Equal(3, len(payload))
+	s.Require().NotNil(payload["alice1"])
+	s.Require().NotNil(payload["alice2"])
+	s.Require().NotNil(payload["alice3"])
 }

--- a/services/shhext/chat/persistence.go
+++ b/services/shhext/chat/persistence.go
@@ -50,7 +50,7 @@ type PersistenceService interface {
 	RatchetInfoConfirmed([]byte, []byte, string) error
 
 	// GetActiveInstallations returns the active installations for a given identity.
-	GetActiveInstallations(maxInstallations uint, identity []byte) ([]string, error)
+	GetActiveInstallations(maxInstallations int, identity []byte) ([]string, error)
 	// AddInstallations adds the installations for a given identity.
 	AddInstallations(identity []byte, timestamp int64, installationIDs []string, enabled bool) error
 	// EnableInstallation enables the installation.

--- a/services/shhext/chat/protocol.go
+++ b/services/shhext/chat/protocol.go
@@ -51,7 +51,7 @@ func (p *ProtocolService) addBundleAndMarshal(myIdentityKey *ecdsa.PrivateKey, m
 func (p *ProtocolService) BuildPublicMessage(myIdentityKey *ecdsa.PrivateKey, payload []byte) ([]byte, error) {
 	// Build message not encrypted
 	protocolMessage := &ProtocolMessage{
-		InstallationId: p.encryption.installationID,
+		InstallationId: p.encryption.config.InstallationID,
 		PublicMessage:  payload,
 	}
 
@@ -71,7 +71,7 @@ func (p *ProtocolService) BuildDirectMessage(myIdentityKey *ecdsa.PrivateKey, pa
 
 		// Build message
 		protocolMessage := &ProtocolMessage{
-			InstallationId: p.encryption.installationID,
+			InstallationId: p.encryption.config.InstallationID,
 			DirectMessage:  encryptionResponse,
 		}
 
@@ -98,7 +98,7 @@ func (p *ProtocolService) BuildPairingMessage(myIdentityKey *ecdsa.PrivateKey, p
 
 	// Build message
 	protocolMessage := &ProtocolMessage{
-		InstallationId: p.encryption.installationID,
+		InstallationId: p.encryption.config.InstallationID,
 		DirectMessage:  encryptionResponse,
 	}
 

--- a/services/shhext/chat/protocol_test.go
+++ b/services/shhext/chat/protocol_test.go
@@ -38,8 +38,8 @@ func (s *ProtocolServiceTestSuite) SetupTest() {
 		panic(err)
 	}
 
-	s.alice = NewProtocolService(NewEncryptionService(alicePersistence, "1"))
-	s.bob = NewProtocolService(NewEncryptionService(bobPersistence, "2"))
+	s.alice = NewProtocolService(NewEncryptionService(alicePersistence, DefaultEncryptionServiceConfig("1")))
+	s.bob = NewProtocolService(NewEncryptionService(bobPersistence, DefaultEncryptionServiceConfig("2")))
 }
 
 func (s *ProtocolServiceTestSuite) TestBuildDirectMessage() {

--- a/services/shhext/chat/sql_lite_persistence.go
+++ b/services/shhext/chat/sql_lite_persistence.go
@@ -709,7 +709,7 @@ func (s *SQLLiteSessionStorage) Load(id []byte) (*dr.State, error) {
 }
 
 // GetActiveInstallations returns the active installations for a given identity
-func (s *SQLLitePersistence) GetActiveInstallations(maxInstallations uint, identity []byte) ([]string, error) {
+func (s *SQLLitePersistence) GetActiveInstallations(maxInstallations int, identity []byte) ([]string, error) {
 	stmt, err := s.db.Prepare("SELECT installation_id FROM installations WHERE enabled = 1 AND identity = ? ORDER BY timestamp DESC LIMIT ?")
 	if err != nil {
 		return nil, err

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -101,7 +101,7 @@ func (s *Service) InitProtocol(address string, password string) error {
 	if err != nil {
 		return err
 	}
-	s.protocol = chat.NewProtocolService(chat.NewEncryptionService(persistence, s.installationID))
+	s.protocol = chat.NewProtocolService(chat.NewEncryptionService(persistence, chat.DefaultEncryptionServiceConfig(s.installationID)))
 
 	return nil
 }


### PR DESCRIPTION
No functional changes,
refactor config so that it can be passed on as an argument and add a test for multi-device.

