### PR TITLE
Add `canary-test` make target to test beta fleet mailservers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ jobs:
     before_script: make dep-ensure
     script:
       - make lint
+  - stage: Test with deployed mailservers
+    script:
+      - make canary-test
   - stage: Test unit and integration
     script:
       - make test-unit

--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,9 @@ test-e2e: ##@tests Run e2e tests
 test-e2e-race: gotest_extraflags=-race
 test-e2e-race: test-e2e ##@tests Run e2e tests with -race flag
 
+canary-test: node-canary
+	_assets/scripts/canary_test_mailservers.sh ./config/cli/fleet-eth.beta.json
+
 lint-install:
 	@# The following installs a specific version of golangci-lint, which is appropriate for a CI server to avoid different results from build to build
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $(GOPATH)/bin v1.10.2
@@ -287,7 +290,7 @@ lint:
 	@echo "lint"
 	@golangci-lint run ./...
 
-ci: lint mock dep-ensure test-unit test-e2e ##@tests Run all linters and tests at once
+ci: lint mock dep-ensure canary-test test-unit test-e2e ##@tests Run all linters and tests at once
 
 clean: ##@other Cleanup
 	rm -fr build/bin/*

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -30,10 +30,11 @@ node('linux') {
         println(gitSHA)
     }
 
-    // TODO(adam): enable when unit tests start passing
-    // stage('Test') {
-    //     sh 'make ci'
-    // }
+    stage('Test') {
+        // TODO(adam): enable when unit tests start passing
+        //sh 'make ci'
+        sh 'make canary-test'
+    }
 
     stage('Build') {
         sh 'go get github.com/status-im/xgo'

--- a/_assets/scripts/canary_test_mailservers.sh
+++ b/_assets/scripts/canary_test_mailservers.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+json_path='.ClusterConfig.TrustedMailServers'
+mailservers=$(jq -r "${json_path} | .[]" $1)
+count=$(jq -r "${json_path} | length" $1)
+
+echo "Will test ${count} mailservers..."
+failed_count=0
+
+while read -r mailserver; do
+  echo "Testing $mailserver ..."
+  ./build/bin/node-canary -log=ERROR -log-without-color=true -mailserver $mailserver || failed_count=$((failed_count + 1))
+done <<< "$mailservers"
+
+if [ $failed_count -gt 0 ]; then
+  echo "${failed_count}/${count} mailservers failed the test"
+  exit 1
+else
+  echo "All mailservers replied correctly"
+fi

--- a/_assets/scripts/install_deps.sh
+++ b/_assets/scripts/install_deps.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if [ -x "$(command -v apt)" ]; then
-  apt install -y protobuf-compiler
+  apt install -y protobuf-compiler jq
 fi
 
 if [ -x "$(command -v pacman)" ]; then
-  pacman -Sy protobuf --noconfirm
+  pacman -Sy protobuf jq --noconfirm
 fi
 
 if [ -x "$(command -v brew)" ]; then
-  brew install protobuf
+  brew install protobuf jq
 fi


### PR DESCRIPTION
This PR adds a `canary-test` make target that will test all mailservers listed in `./config/cli/fleet-eth.beta.json`. It also ensures that this test will be run on CI builds so that a PR fails in cases it breaks compatibility with the currently deployed beta fleet.

Typical output for success case:
```
pedro@pedros-thinkpad-x1:~/go/src/github.com/status-im/status-go$ make canary-test
go build -i -o /home/pedro/go/src/github.com/status-im/status-go/build/bin/node-canary -v -tags '' -ldflags '-X main.buildStamp=2018-11-19.17:09:21 -X github.com/status-im/status-go/params.Version=5b2d7dc2' ./cmd/node-canary/
Compilation done.
_assets/scripts/canary_test_mailservers.sh ./config/cli/fleet-eth.beta.json
Will test 9 mailservers...
Testing enode://da61e9eff86a56633b635f887d8b91e0ff5236bbc05b8169834292e92afb92929dcf6efdbf373a37903da8fe0384d5a0a8247e83f1ce211aa429200b6d28c548@47.91.156.93:30504 ...
Testing enode://c42f368a23fa98ee546fd247220759062323249ef657d26d357a777443aec04db1b29a3a22ef3e7c548e18493ddaf51a31b0aed6079bd6ebe5ae838fcfaf3a49@206.189.243.162:30504 ...
Testing enode://7de99e4cb1b3523bd26ca212369540646607c721ad4f3e5c821ed9148150ce6ce2e72631723002210fac1fd52dfa8bbdf3555e05379af79515e1179da37cc3db@35.188.19.210:30504 ...
Testing enode://744098ab6d3308af5cd03920aea60c46d16b2cd3d33bf367cbaf1d01c2fcd066ff8878576d0967897cd7dbb0e63f873cc0b4f7e4b0f1d7222e6b3451a78d9bda@47.89.20.15:30504 ...
Testing enode://7aa648d6e855950b2e3d3bf220c496e0cae4adfddef3e1e6062e6b177aec93bc6cdcf1282cb40d1656932ebfdd565729da440368d7c4da7dbd4d004b1ac02bf8@206.189.243.169:30504 ...
Testing enode://015e22f6cd2b44c8a51bd7a23555e271e0759c7d7f52432719665a74966f2da456d28e154e836bee6092b4d686fe67e331655586c57b718be3997c1629d24167@35.226.21.19:30504 ...
Testing enode://74957e361ab290e6af45a124536bc9adee39fbd2f995a77ace6ed7d05d9a1c7c98b78b2df5f8071c439b9c0afe4a69893ede4ad633473f96bc195ddf33f6ce00@47.52.255.195:30504 ...
Testing enode://8a64b3c349a2e0ef4a32ea49609ed6eb3364be1110253c20adc17a3cebbc39a219e5d3e13b151c0eee5d8e0f9a8ba2cd026014e67b41a4ab7d1d5dd67ca27427@206.189.243.168:30504 ...
Testing enode://531e252ec966b7e83f5538c19bf1cde7381cc7949026a6e499b6e998e695751aadf26d4c98d5a4eabfb7cefd31c3c88d600a775f14ed5781520a88ecd25da3c6@35.225.227.79:30504 ...
All mailservers replied correctly
```

Sample output for latest develop, which is currently failing:
```
pedro@pedros-thinkpad-x1:~/go/src/github.com/status-im/status-go$ make canary-test
go build -i -o /home/pedro/go/src/github.com/status-im/status-go/build/bin/node-canary -v -tags '' -ldflags ' -X main.buildStamp=2018-11-19.17:06:07 -X github.com/status-im/status-go/params.Version=860da591 -X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=false' ./cmd/node-canary/
Compilation done.
_assets/scripts/canary_test_mailservers.sh ./config/cli/fleet-eth.beta.json
Will test 9 mailservers
Testing enode://da61e9eff86a56633b635f887d8b91e0ff5236bbc05b8169834292e92afb92929dcf6efdbf373a37903da8fe0384d5a0a8247e83f1ce211aa429200b6d28c548@47.91.156.93:30504 ...
ERROR[11-19|18:06:13.420] Failed to allow P2P messages from peer   package=status-go/cmd/node-canary error="Could not find peer with ID: da61e9eff86a56633b635f887d8b91e0ff5236bbc05b8169834292e92afb92929dcf6efdbf373a37903da8fe0384d5a0a8247e83f1ce211aa429200b6d28c548"
Testing enode://c42f368a23fa98ee546fd247220759062323249ef657d26d357a777443aec04db1b29a3a22ef3e7c548e18493ddaf51a31b0aed6079bd6ebe5ae838fcfaf3a49@206.189.243.162:30504 ...
ERROR[11-19|18:06:13.793] Failed to allow P2P messages from peer   package=status-go/cmd/node-canary error="Could not find peer with ID: c42f368a23fa98ee546fd247220759062323249ef657d26d357a777443aec04db1b29a3a22ef3e7c548e18493ddaf51a31b0aed6079bd6ebe5ae838fcfaf3a49"
Testing enode://7de99e4cb1b3523bd26ca212369540646607c721ad4f3e5c821ed9148150ce6ce2e72631723002210fac1fd52dfa8bbdf3555e05379af79515e1179da37cc3db@35.188.19.210:30504 ...
ERROR[11-19|18:06:14.304] Failed to allow P2P messages from peer   package=status-go/cmd/node-canary error="Could not find peer with ID: 7de99e4cb1b3523bd26ca212369540646607c721ad4f3e5c821ed9148150ce6ce2e72631723002210fac1fd52dfa8bbdf3555e05379af79515e1179da37cc3db"
Testing enode://744098ab6d3308af5cd03920aea60c46d16b2cd3d33bf367cbaf1d01c2fcd066ff8878576d0967897cd7dbb0e63f873cc0b4f7e4b0f1d7222e6b3451a78d9bda@47.89.20.15:30504 ...
ERROR[11-19|18:06:15.075] Failed to allow P2P messages from peer   package=status-go/cmd/node-canary error="Could not find peer with ID: 744098ab6d3308af5cd03920aea60c46d16b2cd3d33bf367cbaf1d01c2fcd066ff8878576d0967897cd7dbb0e63f873cc0b4f7e4b0f1d7222e6b3451a78d9bda"
Testing enode://7aa648d6e855950b2e3d3bf220c496e0cae4adfddef3e1e6062e6b177aec93bc6cdcf1282cb40d1656932ebfdd565729da440368d7c4da7dbd4d004b1ac02bf8@206.189.243.169:30504 ...
ERROR[11-19|18:06:15.403] Failed to allow P2P messages from peer   package=status-go/cmd/node-canary error="Could not find peer with ID: 7aa648d6e855950b2e3d3bf220c496e0cae4adfddef3e1e6062e6b177aec93bc6cdcf1282cb40d1656932ebfdd565729da440368d7c4da7dbd4d004b1ac02bf8"
Testing enode://015e22f6cd2b44c8a51bd7a23555e271e0759c7d7f52432719665a74966f2da456d28e154e836bee6092b4d686fe67e331655586c57b718be3997c1629d24167@35.226.21.19:30504 ...
ERROR[11-19|18:06:15.891] Failed to allow P2P messages from peer   package=status-go/cmd/node-canary error="Could not find peer with ID: 015e22f6cd2b44c8a51bd7a23555e271e0759c7d7f52432719665a74966f2da456d28e154e836bee6092b4d686fe67e331655586c57b718be3997c1629d24167"
Testing enode://74957e361ab290e6af45a124536bc9adee39fbd2f995a77ace6ed7d05d9a1c7c98b78b2df5f8071c439b9c0afe4a69893ede4ad633473f96bc195ddf33f6ce00@47.52.255.195:30504 ...
ERROR[11-19|18:06:16.620] Failed to allow P2P messages from peer   package=status-go/cmd/node-canary error="Could not find peer with ID: 74957e361ab290e6af45a124536bc9adee39fbd2f995a77ace6ed7d05d9a1c7c98b78b2df5f8071c439b9c0afe4a69893ede4ad633473f96bc195ddf33f6ce00"
Testing enode://8a64b3c349a2e0ef4a32ea49609ed6eb3364be1110253c20adc17a3cebbc39a219e5d3e13b151c0eee5d8e0f9a8ba2cd026014e67b41a4ab7d1d5dd67ca27427@206.189.243.168:30504 ...
ERROR[11-19|18:06:16.907] Failed to allow P2P messages from peer   package=status-go/cmd/node-canary error="Could not find peer with ID: 8a64b3c349a2e0ef4a32ea49609ed6eb3364be1110253c20adc17a3cebbc39a219e5d3e13b151c0eee5d8e0f9a8ba2cd026014e67b41a4ab7d1d5dd67ca27427"
Testing enode://531e252ec966b7e83f5538c19bf1cde7381cc7949026a6e499b6e998e695751aadf26d4c98d5a4eabfb7cefd31c3c88d600a775f14ed5781520a88ecd25da3c6@35.225.227.79:30504 ...
ERROR[11-19|18:06:17.418] Failed to allow P2P messages from peer   package=status-go/cmd/node-canary error="Could not find peer with ID: 531e252ec966b7e83f5538c19bf1cde7381cc7949026a6e499b6e998e695751aadf26d4c98d5a4eabfb7cefd31c3c88d600a775f14ed5781520a88ecd25da3c6"
9/9 mailservers failed the test
```

Closes #1274