### PR TITLE
Use confirmation that bundle is delivered for sending feedback to user

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -822,12 +822,12 @@
   revision = "fbcc46a78cd43fef95a110df664aab513116a850"
 
 [[projects]]
-  branch = "confirmations"
-  digest = "1:76b7b8cea6cbefec29c52598c01457b4c5f36a54212f6441e103fd408218cd38"
+  digest = "1:6cb252f27feb57ef0e8406556c259d903c0ecff2ab0d2200ca85773b3561777d"
   name = "github.com/status-im/whisper"
   packages = ["whisperv6"]
   pruneopts = "NUT"
-  revision = "47d06f0c5cf51f2f9757526be7bd0d17538dd55f"
+  revision = "76c24476436f0cf832021be98316a4ee62cc83cc"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:572c783a763db6383aca3179976eb80e4c900f52eba56cba8bb2e3cea7ce720e"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -822,12 +822,12 @@
   revision = "fbcc46a78cd43fef95a110df664aab513116a850"
 
 [[projects]]
-  digest = "1:fe884981c5589ade6ea86ca876be4a744ea1344c6e8cfa17e434fcf270b04598"
+  branch = "confirmations"
+  digest = "1:76b7b8cea6cbefec29c52598c01457b4c5f36a54212f6441e103fd408218cd38"
   name = "github.com/status-im/whisper"
   packages = ["whisperv6"]
   pruneopts = "NUT"
-  revision = "e25ea1d673d5982b16fd3e51ed2a0d8f91b809d9"
-  version = "v1.3.0"
+  revision = "47d06f0c5cf51f2f9757526be7bd0d17538dd55f"
 
 [[projects]]
   digest = "1:572c783a763db6383aca3179976eb80e4c900f52eba56cba8bb2e3cea7ce720e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@
 
 [[constraint]]
   name = "github.com/status-im/whisper"
-  branch = "confirmations"
+  version = "=v1.4.0"
 
 [[override]]
   name = "github.com/golang/protobuf"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,7 +29,7 @@
 
 [[constraint]]
   name = "github.com/status-im/whisper"
-  version = "=v1.3.0"
+  branch = "confirmations"
 
 [[override]]
   name = "github.com/golang/protobuf"

--- a/vendor/github.com/status-im/whisper/whisperv6/config.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	MaxMessageSize                        uint32  `toml:",omitempty"`
 	MinimumAcceptedPOW                    float64 `toml:",omitempty"`
 	RestrictConnectionBetweenLightClients bool    `toml:",omitempty"`
+	DisableConfirmations                  bool    `toml:",omitempty"`
 }
 
 // DefaultConfig represents (shocker!) the default configuration.

--- a/vendor/github.com/status-im/whisper/whisperv6/doc.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/doc.go
@@ -47,6 +47,7 @@ const (
 	messagesCode           = 1   // normal whisper message
 	powRequirementCode     = 2   // PoW requirement
 	bloomFilterExCode      = 3   // bloom filter exchange
+	confirmationCode       = 11  // confirmation that batch of envelopes was received
 	p2pRequestCompleteCode = 125 // peer-to-peer message, used by Dapp protocol
 	p2pRequestCode         = 126 // peer-to-peer message, used by Dapp protocol
 	p2pMessageCode         = 127 // peer-to-peer message (to be consumed by the peer, but not forwarded any further)

--- a/vendor/github.com/status-im/whisper/whisperv6/doc.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/doc.go
@@ -47,7 +47,7 @@ const (
 	messagesCode           = 1   // normal whisper message
 	powRequirementCode     = 2   // PoW requirement
 	bloomFilterExCode      = 3   // bloom filter exchange
-	confirmationCode       = 11  // confirmation that batch of envelopes was received
+	batchAcknowledgedCode  = 11  // confirmation that batch of envelopes was received
 	p2pRequestCompleteCode = 125 // peer-to-peer message, used by Dapp protocol
 	p2pRequestCode         = 126 // peer-to-peer message, used by Dapp protocol
 	p2pMessageCode         = 127 // peer-to-peer message (to be consumed by the peer, but not forwarded any further)

--- a/vendor/github.com/status-im/whisper/whisperv6/events.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/events.go
@@ -13,6 +13,8 @@ const (
 	EventEnvelopeSent EventType = "envelope.sent"
 	// EventEnvelopeExpired fires when envelop expired
 	EventEnvelopeExpired EventType = "envelope.expired"
+	// EventBatchAcknowledged is sent when envelope was acknowleged by a peer
+	EventBatchAcknowledged EventType = "batch.acknowleged"
 	// EventEnvelopeAvailable fires when envelop is available for filters
 	EventEnvelopeAvailable EventType = "envelope.available"
 	// EventMailServerRequestCompleted fires after mailserver sends all the requested messages
@@ -27,6 +29,7 @@ const (
 type EnvelopeEvent struct {
 	Event EventType
 	Hash  common.Hash
+	Batch common.Hash
 	Peer  enode.ID
 	Data  interface{}
 }

--- a/vendor/github.com/status-im/whisper/whisperv6/events.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/events.go
@@ -13,7 +13,7 @@ const (
 	EventEnvelopeSent EventType = "envelope.sent"
 	// EventEnvelopeExpired fires when envelop expired
 	EventEnvelopeExpired EventType = "envelope.expired"
-	// EventBatchAcknowledged is sent when envelope was acknowleged by a peer
+	// EventBatchAcknowledged is sent when batch of envelopes was acknowleged by a peer.
 	EventBatchAcknowledged EventType = "batch.acknowleged"
 	// EventEnvelopeAvailable fires when envelop is available for filters
 	EventEnvelopeAvailable EventType = "envelope.available"

--- a/vendor/github.com/status-im/whisper/whisperv6/peer.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/peer.go
@@ -88,8 +88,9 @@ func (peer *Peer) handshake() error {
 		pow := peer.host.MinPow()
 		powConverted := math.Float64bits(pow)
 		bloom := peer.host.BloomFilter()
+		confirmationsEnabled := !peer.host.disableConfirmations
 
-		errc <- p2p.SendItems(peer.ws, statusCode, ProtocolVersion, powConverted, bloom, isLightNode, true)
+		errc <- p2p.SendItems(peer.ws, statusCode, ProtocolVersion, powConverted, bloom, isLightNode, confirmationsEnabled)
 	}()
 
 	// Fetch the remote status packet and verify protocol match
@@ -220,6 +221,7 @@ func (peer *Peer) broadcast() error {
 		batchHash, err := sendBundle(peer.ws, bundle)
 		if err != nil {
 			log.Warn("failed to deliver envelopes", "peer", peer.peer.ID(), "error", err)
+			return err
 		}
 
 		// mark envelopes only if they were successfully sent

--- a/vendor/github.com/status-im/whisper/whisperv6/peer.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/peer.go
@@ -17,6 +17,7 @@
 package whisperv6
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"sync"
@@ -24,6 +25,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -35,11 +37,12 @@ type Peer struct {
 	peer *p2p.Peer
 	ws   p2p.MsgReadWriter
 
-	trusted        bool
-	powRequirement float64
-	bloomMu        sync.Mutex
-	bloomFilter    []byte
-	fullNode       bool
+	trusted              bool
+	powRequirement       float64
+	bloomMu              sync.Mutex
+	bloomFilter          []byte
+	fullNode             bool
+	confirmationsEnabled bool
 
 	known mapset.Set // Messages already known by the peer to avoid wasting bandwidth
 
@@ -86,7 +89,7 @@ func (peer *Peer) handshake() error {
 		powConverted := math.Float64bits(pow)
 		bloom := peer.host.BloomFilter()
 
-		errc <- p2p.SendItems(peer.ws, statusCode, ProtocolVersion, powConverted, bloom, isLightNode)
+		errc <- p2p.SendItems(peer.ws, statusCode, ProtocolVersion, powConverted, bloom, isLightNode, true)
 	}()
 
 	// Fetch the remote status packet and verify protocol match
@@ -133,6 +136,12 @@ func (peer *Peer) handshake() error {
 	isRemotePeerLightNode, err := s.Bool()
 	if isRemotePeerLightNode && isLightNode && isRestrictedLightNodeConnection {
 		return fmt.Errorf("peer [%x] is useless: two light client communication restricted", peer.ID())
+	}
+	confirmationsEnabled, err := s.Bool()
+	if err != nil || !confirmationsEnabled {
+		log.Warn("confirmations are disabled", "peer", peer.ID())
+	} else {
+		peer.confirmationsEnabled = confirmationsEnabled
 	}
 
 	if err := <-errc; err != nil {
@@ -208,19 +217,23 @@ func (peer *Peer) broadcast() error {
 	}
 
 	if len(bundle) > 0 {
-		// transmit the batch of envelopes
-		if err := p2p.Send(peer.ws, messagesCode, bundle); err != nil {
-			return err
+		batchHash, err := sendBundle(peer.ws, bundle)
+		if err != nil {
+			log.Warn("failed to deliver envelopes", "peer", peer.peer.ID(), "error", err)
 		}
 
 		// mark envelopes only if they were successfully sent
 		for _, e := range bundle {
 			peer.mark(e)
-			peer.host.envelopeFeed.Send(EnvelopeEvent{
+			event := EnvelopeEvent{
 				Event: EventEnvelopeSent,
 				Hash:  e.Hash(),
-				Peer:  peer.peer.ID(), // specifically discover.NodeID because it can be pretty printed
-			})
+				Peer:  peer.peer.ID(),
+			}
+			if peer.confirmationsEnabled {
+				event.Batch = batchHash
+			}
+			peer.host.envelopeFeed.Send(event)
 		}
 
 		log.Trace("broadcast", "num. messages", len(bundle))
@@ -265,4 +278,20 @@ func MakeFullNodeBloom() []byte {
 		bloom[i] = 0xFF
 	}
 	return bloom
+}
+
+func sendBundle(rw p2p.MsgWriter, bundle []*Envelope) (rst common.Hash, err error) {
+	data, err := rlp.EncodeToBytes(bundle)
+	if err != nil {
+		return
+	}
+	err = rw.WriteMsg(p2p.Msg{
+		Code:    messagesCode,
+		Size:    uint32(len(data)),
+		Payload: bytes.NewBuffer(data),
+	})
+	if err != nil {
+		return
+	}
+	return crypto.Keccak256Hash(data), nil
 }

--- a/vendor/github.com/status-im/whisper/whisperv6/whisper.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/whisper.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/syndtr/goleveldb/leveldb/errors"
@@ -92,6 +93,8 @@ type Whisper struct {
 
 	settings syncmap.Map // holds configuration settings that can be dynamically changed
 
+	disableConfirmations bool // do not reply with confirmations
+
 	syncAllowance int // maximum time in seconds allowed to process the whisper-related messages
 
 	statsMu sync.Mutex // guard stats
@@ -111,16 +114,17 @@ func New(cfg *Config) *Whisper {
 	}
 
 	whisper := &Whisper{
-		privateKeys:   make(map[string]*ecdsa.PrivateKey),
-		symKeys:       make(map[string][]byte),
-		envelopes:     make(map[common.Hash]*Envelope),
-		expirations:   make(map[uint32]mapset.Set),
-		peers:         make(map[*Peer]struct{}),
-		messageQueue:  make(chan *Envelope, messageQueueLimit),
-		p2pMsgQueue:   make(chan *Envelope, messageQueueLimit),
-		quit:          make(chan struct{}),
-		syncAllowance: DefaultSyncAllowance,
-		timeSource:    time.Now,
+		privateKeys:          make(map[string]*ecdsa.PrivateKey),
+		symKeys:              make(map[string][]byte),
+		envelopes:            make(map[common.Hash]*Envelope),
+		expirations:          make(map[uint32]mapset.Set),
+		peers:                make(map[*Peer]struct{}),
+		messageQueue:         make(chan *Envelope, messageQueueLimit),
+		p2pMsgQueue:          make(chan *Envelope, messageQueueLimit),
+		quit:                 make(chan struct{}),
+		syncAllowance:        DefaultSyncAllowance,
+		timeSource:           time.Now,
+		disableConfirmations: cfg.DisableConfirmations,
 	}
 
 	whisper.filters = NewFilters(whisper)
@@ -780,6 +784,13 @@ func (whisper *Whisper) HandlePeer(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 	return whisper.runMessageLoop(whisperPeer, rw)
 }
 
+func (whisper *Whisper) sendConfirmation(peer enode.ID, rw p2p.MsgReadWriter, data []byte) {
+	batchHash := crypto.Keccak256Hash(data)
+	if err := p2p.Send(rw, batchAcknowledgedCode, batchHash); err != nil {
+		log.Warn("failed to deliver confirmation", "hash", batchHash, "peer", peer, "error", err)
+	}
+}
+
 // runMessageLoop reads and processes inbound messages directly to merge into client-global state.
 func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 	for {
@@ -805,9 +816,8 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 				log.Warn("failed to read envelopes data", "peer", p.peer.ID(), "error", err)
 				return errors.New("invalid enveloopes")
 			}
-			batchHash := crypto.Keccak256Hash(data)
-			if err := p2p.Send(rw, confirmationCode, batchHash); err != nil {
-				log.Warn("failed to deliver confirmation", "hash", batchHash, "peer", p.peer.ID(), "error", err)
+			if !whisper.disableConfirmations {
+				go whisper.sendConfirmation(p.peer.ID(), rw, data)
 			}
 
 			var envelopes []*Envelope
@@ -831,10 +841,9 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 			if trouble {
 				return errors.New("invalid envelope")
 			}
-		case confirmationCode:
+		case batchAcknowledgedCode:
 			var batchHash common.Hash
 			if err := packet.Decode(&batchHash); err != nil {
-				fmt.Println(err.Error())
 				log.Warn("failed to decode confirmation into common.Hash", "peer", p.peer.ID(), "error", err)
 				return errors.New("invalid confirmation message")
 			}


### PR DESCRIPTION
In this PR we accept confirmations from any peer at all. Whisper generates event when confirmation is received, and based on this event we send an appropriate  signal. I will ensure that we count only confirmations from connected mail server in a follow up PR.

This change will work even if we are connected with peers that do not produce confirmations. In this case signal will be sent immediately when envelope is sent over the network.

includes https://github.com/status-im/whisper/pull/10
part of https://github.com/status-im/status-go/issues/1278
