### PR TITLE
Reduce number of days required to consider a PR stale to 14

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -10,6 +10,7 @@ prchecklist:
 
 stale:
   daysUntilStale: 90
+  daysUntilPullRequestStale: 14
   daysUntilClose: 7
   exemptLabels:
     - 'wall of shame'


### PR DESCRIPTION
This PR configures the new parameter I introduced in Probot and brings down the number of days required to consider a PR stale from 90 to 14. After those 14 days it will comment on the PR and count another 7 days before closing it.