### PR TITLE
Ignore confirmations not from a mail server based on a config value

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	gethnode "github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 
 	fcmlib "github.com/NaySoftware/go-fcm"
 
@@ -569,5 +570,23 @@ func (b *StatusBackend) DisableInstallation(installationID string) error {
 		return err
 	}
 
+	return nil
+}
+
+// UpdateMailservers on ShhExtService.
+func (b *StatusBackend) UpdateMailservers(enodes []string) error {
+	st, err := b.statusNode.ShhExtService()
+	if err != nil {
+		return err
+	}
+	nodes := make([]*enode.Node, len(enodes))
+	for i, rawurl := range enodes {
+		node, err := enode.ParseV4(rawurl)
+		if err != nil {
+			return err
+		}
+		nodes[i] = node
+	}
+	st.UpdateMailservers(nodes)
 	return nil
 }

--- a/lib/library.go
+++ b/lib/library.go
@@ -462,6 +462,18 @@ func NotifyUsers(message, payloadJSON, tokensArray *C.char) (outCBytes *C.char) 
 	return
 }
 
+// UpdateMailservers updates mail servers in status backend.
+//export UpdateMailservers
+func UpdateMailservers(data *C.char) *C.char {
+	var enodes []string
+	err := json.Unmarshal([]byte(C.GoString(data)), &enodes)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	err = statusBackend.UpdateMailservers(enodes)
+	return makeJSONResponse(err)
+}
+
 // AddPeer adds an enode as a peer.
 //export AddPeer
 func AddPeer(enode *C.char) *C.char {

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/status-im/status-go/services/shhext/chat"
 	"github.com/status-im/status-go/services/shhext/dedup"
@@ -56,10 +57,11 @@ type Service struct {
 }
 
 type ServiceConfig struct {
-	DataDir        string
-	InstallationID string
-	Debug          bool
-	PFSEnabled     bool
+	DataDir                 string
+	InstallationID          string
+	Debug                   bool
+	PFSEnabled              bool
+	MailServerConfirmations bool
 }
 
 // Make sure that Service implements node.Service interface.
@@ -68,10 +70,12 @@ var _ node.Service = (*Service)(nil)
 // New returns a new Service. dataDir is a folder path to a network-independent location
 func New(w *whisper.Whisper, handler EnvelopeEventsHandler, db *leveldb.DB, config *ServiceConfig) *Service {
 	track := &tracker{
-		w:       w,
-		handler: handler,
-		cache:   map[common.Hash]EnvelopeState{},
-		batches: map[common.Hash]map[common.Hash]struct{}{},
+		w:                      w,
+		handler:                handler,
+		cache:                  map[common.Hash]EnvelopeState{},
+		batches:                map[common.Hash]map[common.Hash]struct{}{},
+		mailservers:            map[enode.ID]struct{}{},
+		mailServerConfirmation: config.MailServerConfirmations,
 	}
 	return &Service{
 		w:              w,
@@ -82,6 +86,11 @@ func New(w *whisper.Whisper, handler EnvelopeEventsHandler, db *leveldb.DB, conf
 		installationID: config.InstallationID,
 		pfsEnabled:     config.PFSEnabled,
 	}
+}
+
+// UpdateMailservers updates information about selected mail servers.
+func (s *Service) UpdateMailservers(nodes []*enode.Node) {
+	s.tracker.UpdateMailservers(nodes)
 }
 
 // Protocols returns a new protocols list. In this case, there are none.
@@ -182,12 +191,16 @@ func (s *Service) Stop() error {
 // tracker responsible for processing events for envelopes that we are interested in
 // and calling specified handler.
 type tracker struct {
-	w       *whisper.Whisper
-	handler EnvelopeEventsHandler
+	w                      *whisper.Whisper
+	handler                EnvelopeEventsHandler
+	mailServerConfirmation bool
 
 	mu      sync.Mutex
 	cache   map[common.Hash]EnvelopeState
 	batches map[common.Hash]map[common.Hash]struct{}
+
+	mailMu      sync.Mutex
+	mailservers map[enode.ID]struct{}
 
 	wg   sync.WaitGroup
 	quit chan struct{}
@@ -214,6 +227,15 @@ func (t *tracker) Add(hash common.Hash) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.cache[hash] = EnvelopePosted
+}
+
+func (t *tracker) UpdateMailservers(nodes []*enode.Node) {
+	t.mailMu.Lock()
+	defer t.mailMu.Unlock()
+	t.mailservers = map[enode.ID]struct{}{}
+	for _, n := range nodes {
+		t.mailservers[n.ID()] = struct{}{}
+	}
 }
 
 // Add request hash to a tracker.
@@ -268,6 +290,12 @@ func (t *tracker) handleEvent(event whisper.EnvelopeEvent) {
 }
 
 func (t *tracker) handleEventEnvelopeSent(event whisper.EnvelopeEvent) {
+	if t.mailServerConfirmation {
+		if !t.isMailserver(event.Peer) {
+			return
+		}
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -292,7 +320,28 @@ func (t *tracker) handleEventEnvelopeSent(event whisper.EnvelopeEvent) {
 	}
 }
 
+func (t *tracker) isMailserver(peer enode.ID) bool {
+	t.mailMu.Lock()
+	defer t.mailMu.Unlock()
+	if len(t.mailservers) == 0 {
+		log.Error("mail servers are empty")
+		return false
+	}
+	_, exist := t.mailservers[peer]
+	if !exist {
+		log.Debug("confirmation received not from a mail server is skipped", "peer", peer)
+		return false
+	}
+	return true
+}
+
 func (t *tracker) handleAcknowledgedBatch(event whisper.EnvelopeEvent) {
+	if t.mailServerConfirmation {
+		if !t.isMailserver(event.Peer) {
+			return
+		}
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 


### PR DESCRIPTION
status-react will have to explicitly specify mail servers that are used with a separate biding. this configuration will be used in shhext envelope tracker to filter received confirmations.

to guarantee a smooth transition. there will be `MailServerConfirmations` boolean in ShhextConfig. this option will have to be set to true when the application will start to provide information about selected mail servers.

this part doesn't change the way we guarantee connection with selected mail servers. i will do a separate PR for that thing after i get some feedback in https://github.com/status-im/status-go/issues/1285

closes: https://github.com/status-im/status-go/issues/1278
includes: https://github.com/status-im/status-go/pull/1284
