### PR TITLE
install xgo in setup target

### DIFF
--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
     }
     stage('Setup') { steps { dir(env.STATUS_PATH) {
       sh 'make setup'
+      sh 'make xgo'
     } } }
     stage('Lint') { steps { dir(env.STATUS_PATH) {
       sh 'make ci'


### PR DESCRIPTION
The new parallel build seems to be failing randomly on the `go get github.com/status-im/xgo` step. My guess is that because this command is ran twice in parallel - for android and ios - this triggers some kind of race condition that makes one of the executions fail.

For that reason I'm adding `xgo` target to the `setup` target which is ran in the `Setup` stage before the parallel fork. This way we might avoid the race condition.

Example build: https://ci.status.im/blue/organizations/jenkins/status-go%2Fparallel/detail/parallel/99/pipeline