### PR TITLE
Add versioning & tests, migrate db files

### DIFF
--- a/services/shhext/chat/sql_lite_persistence_test.go
+++ b/services/shhext/chat/sql_lite_persistence_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -74,7 +73,7 @@ func (s *SQLLitePersistenceTestSuite) TestPrivateBundle() {
 	anyPrivateBundle, err = s.service.GetAnyPrivateBundle(identity, []string{installationID})
 	s.Require().NoError(err)
 	s.NotNil(anyPrivateBundle)
-	s.True(proto.Equal(bundle.GetBundle(), anyPrivateBundle.GetBundle()), "It returns the same bundle")
+	s.Equal(bundle.GetBundle().GetSignedPreKeys()[installationID].SignedPreKey, anyPrivateBundle.GetBundle().GetSignedPreKeys()[installationID].SignedPreKey, "It returns the same bundle")
 }
 
 func (s *SQLLitePersistenceTestSuite) TestPublicBundle() {

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -98,7 +98,14 @@ func (s *Service) InitProtocol(address string, password string) error {
 	if err := os.MkdirAll(filepath.Clean(s.dataDir), os.ModePerm); err != nil {
 		return err
 	}
-	persistence, err := chat.NewSQLLitePersistence(filepath.Join(s.dataDir, fmt.Sprintf("%x.db", address)), password)
+	oldPath := filepath.Join(s.dataDir, fmt.Sprintf("%x.db", address))
+	newPath := filepath.Join(s.dataDir, fmt.Sprintf("%s.db", s.installationID))
+
+	if err := chat.MigrateDBFile(oldPath, newPath, password); err != nil {
+		return err
+	}
+
+	persistence, err := chat.NewSQLLitePersistence(newPath, password)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We are preparing for the release of this to general public, so a few
things have been added:

1) Add versioning for bundles, and make refresh interval configurable
2) Move files to installationID so no metadata is leaked (previously using the user pk)
3) Re-key using user password db
