### PR TITLE
stop adding 'v' before the contents of VERSION file

### DIFF
--- a/_assets/ci/lib.groovy
+++ b/_assets/ci/lib.groovy
@@ -9,7 +9,7 @@ def timestamp() {
 
 def suffix() {
   if (params.RELEASE == true) {
-    return 'v' + readFile("${env.WORKSPACE}/${env.STATUS_PATH}/VERSION").trim()
+    return readFile("${env.WORKSPACE}/${env.STATUS_PATH}/VERSION").trim()
   } else {
     return "${timestamp()}-${gitCommit()}"
   }


### PR DESCRIPTION
This is messing with uploading of releases. Some tags we use have a `v` before them and some don't. So I'm just going to depend entirely on what is in `VERSION` and try not to add anything.