### PR TITLE
Persist selected mail server using separate monitor

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -587,6 +587,5 @@ func (b *StatusBackend) UpdateMailservers(enodes []string) error {
 		}
 		nodes[i] = node
 	}
-	st.UpdateMailservers(nodes)
-	return nil
+	return st.UpdateMailservers(nodes)
 }

--- a/db/db.go
+++ b/db/db.go
@@ -18,6 +18,8 @@ const (
 	// DeduplicatorCache is used for the db entries used for messages
 	// deduplication cache
 	DeduplicatorCache
+	// MailserversCache is a list of mail servers provided by users.
+	MailserversCache
 )
 
 // Key creates a DB key for a specified service with specified data

--- a/services/shhext/mailservers/cache.go
+++ b/services/shhext/mailservers/cache.go
@@ -1,0 +1,142 @@
+package mailservers
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/status-im/status-go/db"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+// NewPeerRecord returns instance of the peer record.
+func NewPeerRecord(node *enode.Node) PeerRecord {
+	return PeerRecord{node: node}
+}
+
+// PeerRecord is set data associated with each peer that is stored on disk.
+// PeerRecord stored with a enode as a key in leveldb, and body marshalled as json.
+type PeerRecord struct {
+	node *enode.Node
+
+	// last time it was used.
+	LastUsed time.Time
+}
+
+// Encode encodes PeerRecords to bytes.
+func (r PeerRecord) Encode() ([]byte, error) {
+	return json.Marshal(r)
+}
+
+// ID returns enode identity of the node.
+func (r PeerRecord) ID() enode.ID {
+	return r.node.ID()
+}
+
+// Node returs pointer to original object.
+// enode.Node doensn't allow modification on the object.
+func (r PeerRecord) Node() *enode.Node {
+	return r.node
+}
+
+// EncodeKey returns bytes that will should be used as a key in persistent storage.
+func (r PeerRecord) EncodeKey() ([]byte, error) {
+	return r.Node().MarshalText()
+}
+
+// NewCache returns pointer to a Cache instance.
+func NewCache(db *leveldb.DB) *Cache {
+	return &Cache{db: db}
+}
+
+// Cache is wrapper for operations on disk with leveldb.
+type Cache struct {
+	db *leveldb.DB
+}
+
+// Replace deletes old and adds new records in the persistent cache.
+func (c *Cache) Replace(nodes []*enode.Node) error {
+	batch := new(leveldb.Batch)
+	iter := createPeersIterator(c.db)
+	defer iter.Release()
+	newNodes := nodesToMap(nodes)
+	for iter.Next() {
+		record, err := unmarshalKeyValue(keyWithoutPrefix(iter.Key()), iter.Value())
+		if err != nil {
+			return err
+		}
+		if _, exist := newNodes[record.ID()]; exist {
+			delete(newNodes, record.ID())
+		} else {
+			batch.Delete(iter.Key())
+		}
+	}
+	for _, n := range newNodes {
+		enodeKey, err := n.MarshalText()
+		if err != nil {
+			return err
+		}
+		// we put nil as default value doesn't have any state associated with them.
+		batch.Put(db.Key(db.MailserversCache, enodeKey), nil)
+	}
+	return c.db.Write(batch, nil)
+}
+
+// LoadAll loads all records from persistent database.
+func (c *Cache) LoadAll() (rst []PeerRecord, err error) {
+	iter := createPeersIterator(c.db)
+	for iter.Next() {
+		record, err := unmarshalKeyValue(keyWithoutPrefix(iter.Key()), iter.Value())
+		if err != nil {
+			return nil, err
+		}
+		rst = append(rst, record)
+	}
+	return rst, nil
+}
+
+// UpdateRecord updates single record.
+func (c *Cache) UpdateRecord(record PeerRecord) error {
+	enodeKey, err := record.EncodeKey()
+	if err != nil {
+		return err
+	}
+	value, err := record.Encode()
+	if err != nil {
+		return err
+	}
+	return c.db.Put(db.Key(db.MailserversCache, enodeKey), value, nil)
+}
+
+func unmarshalKeyValue(key, value []byte) (record PeerRecord, err error) {
+	enodeKey := key
+	node := new(enode.Node)
+	err = node.UnmarshalText(enodeKey)
+	if err != nil {
+		return record, err
+	}
+	record = PeerRecord{node: node}
+	if len(value) != 0 {
+		err = json.Unmarshal(value, &record)
+	}
+	return record, err
+}
+
+func nodesToMap(nodes []*enode.Node) map[enode.ID]*enode.Node {
+	rst := map[enode.ID]*enode.Node{}
+	for _, n := range nodes {
+		rst[n.ID()] = n
+	}
+	return rst
+}
+
+func createPeersIterator(level *leveldb.DB) iterator.Iterator {
+	return level.NewIterator(util.BytesPrefix([]byte{byte(db.MailserversCache)}), nil)
+}
+
+// keyWithoutPrefix removes first byte from key.
+func keyWithoutPrefix(key []byte) []byte {
+	return key[1:]
+}

--- a/services/shhext/mailservers/cache_test.go
+++ b/services/shhext/mailservers/cache_test.go
@@ -23,14 +23,14 @@ func containsNode(nodes []*enode.Node, node *enode.Node) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("nodes %+s do not containt  %s", nodes, node)
+	return fmt.Errorf("nodes %+s do not contain  %s", nodes, node)
 }
 
 func TestReplaceRecords(t *testing.T) {
 	nodesNumber := 3
 	cache := newInMemCache(t)
 	nodes := make([]*enode.Node, nodesNumber)
-	// First round is a sanity check that record were written.
+	// First round is a sanity check that records were written.
 	fillWithRandomNodes(t, nodes)
 	require.NoError(t, cache.Replace(nodes))
 	records, err := cache.LoadAll()

--- a/services/shhext/mailservers/cache_test.go
+++ b/services/shhext/mailservers/cache_test.go
@@ -1,0 +1,80 @@
+package mailservers
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+)
+
+func newInMemCache(t *testing.T) *Cache {
+	db, err := leveldb.Open(storage.NewMemStorage(), nil)
+	require.NoError(t, err)
+	return NewCache(db)
+}
+
+func containsNode(nodes []*enode.Node, node *enode.Node) error {
+	for _, n := range nodes {
+		if n.ID() == node.ID() {
+			return nil
+		}
+	}
+	return fmt.Errorf("nodes %+s do not containt  %s", nodes, node)
+}
+
+func TestReplaceRecords(t *testing.T) {
+	nodesNumber := 3
+	cache := newInMemCache(t)
+	nodes := make([]*enode.Node, nodesNumber)
+	// First round is a sanity check that record were written.
+	fillWithRandomNodes(t, nodes)
+	require.NoError(t, cache.Replace(nodes))
+	records, err := cache.LoadAll()
+	require.NoError(t, err)
+	require.Len(t, records, nodesNumber)
+	for i := range records {
+		require.NoError(t, containsNode(nodes, records[i].Node()))
+	}
+	// Replace all nodes and verify that length is the same and loaded records are found.
+	fillWithRandomNodes(t, nodes)
+	require.NoError(t, cache.Replace(nodes))
+	records, err = cache.LoadAll()
+	require.NoError(t, err)
+	require.Len(t, records, nodesNumber)
+	for i := range records {
+		require.NoError(t, containsNode(nodes, records[i].Node()))
+	}
+}
+
+func TestUsedRecord(t *testing.T) {
+	cache := newInMemCache(t)
+	node, err := RandomNode()
+	require.NoError(t, err)
+	record := PeerRecord{node: node}
+	require.NoError(t, cache.UpdateRecord(record))
+	record.LastUsed = time.Now()
+	require.NoError(t, cache.UpdateRecord(record))
+	records, err := cache.LoadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.True(t, record.LastUsed.Equal(records[0].LastUsed))
+}
+
+func TestTimestampPreservedOnReplace(t *testing.T) {
+	cache := newInMemCache(t)
+	node, err := RandomNode()
+	require.NoError(t, err)
+	record := PeerRecord{node: node, LastUsed: time.Now()}
+	require.NoError(t, cache.UpdateRecord(record))
+	require.NoError(t, cache.Replace([]*enode.Node{node}))
+	records, err := cache.LoadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, node.ID(), records[0].Node().ID())
+	require.False(t, records[0].LastUsed.IsZero(), "timestamp should be preserved and not equal to zero")
+
+}

--- a/services/shhext/mailservers/connmonitor.go
+++ b/services/shhext/mailservers/connmonitor.go
@@ -1,0 +1,85 @@
+package mailservers
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/status-im/whisper/whisperv6"
+)
+
+// NewLastUsedConnectionMonitor returns pointer to the instance of LastUsedConnectionMonitor.
+func NewLastUsedConnectionMonitor(ps *PeerStore, cache *Cache, whisper EnvelopeEventSubscbriber) *LastUsedConnectionMonitor {
+	return &LastUsedConnectionMonitor{
+		ps:      ps,
+		cache:   cache,
+		whisper: whisper,
+	}
+}
+
+// LastUsedConnectionMonitor watches relevant events and reflects it in cache.
+type LastUsedConnectionMonitor struct {
+	ps    *PeerStore
+	cache *Cache
+
+	whisper EnvelopeEventSubscbriber
+
+	quit chan struct{}
+	wg   sync.WaitGroup
+}
+
+// Start spins a separate goroutine to watch connections.
+func (mon *LastUsedConnectionMonitor) Start() {
+	mon.quit = make(chan struct{})
+	mon.wg.Add(1)
+	go func() {
+		events := make(chan whisperv6.EnvelopeEvent, whisperEventsBuffer)
+		sub := mon.whisper.SubscribeEnvelopeEvents(events)
+		for {
+			select {
+			case <-mon.quit:
+				sub.Unsubscribe()
+				mon.wg.Done()
+				return
+			case err := <-sub.Err():
+				log.Error("retry after error suscribing to whisper events", "error", err)
+				sub = mon.whisper.SubscribeEnvelopeEvents(events)
+			case ev := <-events:
+				node := mon.ps.Get(ev.Peer)
+				if node == nil {
+					continue
+				}
+				if ev.Event == whisperv6.EventMailServerRequestCompleted {
+					err := mon.updateRecord(ev.Peer)
+					if err != nil {
+						log.Error("unable to store that server was used", "peer", ev.Peer, "error", err)
+					}
+				}
+			}
+		}
+	}()
+}
+
+func (mon *LastUsedConnectionMonitor) updateRecord(nodeID enode.ID) error {
+	node := mon.ps.Get(nodeID)
+	if node == nil {
+		return nil
+	}
+	return mon.cache.UpdateRecord(PeerRecord{node: node, LastUsed: time.Now()})
+}
+
+// Stop closes channel to signal a quit and waits until all goroutines are stoppped.
+func (mon *LastUsedConnectionMonitor) Stop() {
+	if mon.quit == nil {
+		return
+	}
+	select {
+	case <-mon.quit:
+		return
+	default:
+	}
+	close(mon.quit)
+	mon.wg.Wait()
+	mon.quit = nil
+}

--- a/services/shhext/mailservers/connmonitor_test.go
+++ b/services/shhext/mailservers/connmonitor_test.go
@@ -1,0 +1,79 @@
+package mailservers
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/status-im/status-go/t/utils"
+	whisper "github.com/status-im/whisper/whisperv6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsedConnectionPersisted(t *testing.T) {
+	nodes := make([]*enode.Node, 2)
+	fillWithRandomNodes(t, nodes)
+
+	cache := newInMemCache(t)
+	store := NewPeerStore(cache)
+	require.NoError(t, store.Update(nodes))
+	whisperMock := newFakeEnvelopesEvents()
+	monitor := NewLastUsedConnectionMonitor(store, cache, whisperMock)
+	monitor.Start()
+
+	// Send a confirmation that we received history from one of the peers.
+	select {
+	case whisperMock.input <- whisper.EnvelopeEvent{
+		Event: whisper.EventMailServerRequestCompleted, Peer: nodes[0].ID()}:
+	case <-time.After(time.Second):
+		require.FailNow(t, "can't send a 'completed' event")
+	}
+
+	// Wait until records will be updated in the cache.
+	require.NoError(t, utils.Eventually(func() error {
+		records, err := cache.LoadAll()
+		if err != nil {
+			return err
+		}
+		if lth := len(records); lth != 2 {
+			return fmt.Errorf("unexpected length of all records stored in the cache. expected %d got %d", 2, lth)
+		}
+		var used bool
+		for _, r := range records {
+			if r.Node().ID() == nodes[0].ID() {
+				used = !r.LastUsed.IsZero()
+			}
+		}
+		if !used {
+			return fmt.Errorf("record %s is not marked as used", nodes[0].ID())
+		}
+		return nil
+	}, time.Second, 100*time.Millisecond))
+
+	// Use different peer, first will be marked as unused.
+	select {
+	case whisperMock.input <- whisper.EnvelopeEvent{
+		Event: whisper.EventMailServerRequestCompleted, Peer: nodes[1].ID()}:
+	case <-time.After(time.Second):
+		require.FailNow(t, "can't send a 'completed' event")
+	}
+
+	require.NoError(t, utils.Eventually(func() error {
+		records, err := cache.LoadAll()
+		if err != nil {
+			return err
+		}
+		if lth := len(records); lth != 2 {
+			return fmt.Errorf("unexpected length of all records stored in the cache. expected %d got %d", 2, lth)
+		}
+		sort.Slice(records, func(i, j int) bool {
+			return records[i].LastUsed.After(records[j].LastUsed)
+		})
+		if records[0].Node().ID() != nodes[1].ID() {
+			return fmt.Errorf("record wasn't updated after previous event")
+		}
+		return nil
+	}, time.Second, 100*time.Millisecond))
+}

--- a/services/shhext/mailservers/utils.go
+++ b/services/shhext/mailservers/utils.go
@@ -1,0 +1,52 @@
+package mailservers
+
+import (
+	"sort"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// GetFirstConnected returns first connected peer that is also added to a peer store.
+// Raises ErrNoConnected if no peers are added to a peer store.
+func GetFirstConnected(provider PeersProvider, store *PeerStore) (*enode.Node, error) {
+	peers := provider.Peers()
+	for _, p := range peers {
+		if store.Exist(p.ID()) {
+			return p.Node(), nil
+		}
+	}
+	return nil, ErrNoConnected
+}
+
+// NodesNotifee interface to be notified when new nodes are received.
+type NodesNotifee interface {
+	Notify([]*enode.Node)
+}
+
+// EnsureUsedRecordsAddedFirst checks if any nodes were marked as connected before app went offline.
+func EnsureUsedRecordsAddedFirst(ps *PeerStore, conn NodesNotifee) error {
+	records, err := ps.cache.LoadAll()
+	if err != nil {
+		return err
+	}
+	if len(records) == 0 {
+		return nil
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].LastUsed.After(records[j].LastUsed)
+	})
+	all := recordsToNodes(records)
+	if !records[0].LastUsed.IsZero() {
+		conn.Notify(all[:1])
+	}
+	conn.Notify(all)
+	return nil
+}
+
+func recordsToNodes(records []PeerRecord) []*enode.Node {
+	nodes := make([]*enode.Node, len(records))
+	for i := range records {
+		nodes[i] = records[i].Node()
+	}
+	return nodes
+}

--- a/services/shhext/mailservers/utils_test.go
+++ b/services/shhext/mailservers/utils_test.go
@@ -1,0 +1,55 @@
+package mailservers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFirstConnected(t *testing.T) {
+	numPeers := 3
+	nodes := make([]*enode.Node, numPeers)
+	peers := make([]*p2p.Peer, numPeers)
+	nodesMap := getMapWithRandomNodes(t, numPeers)
+	i := 0
+	for _, node := range nodesMap {
+		nodes[i] = node
+		peers[i] = p2p.NewPeer(node.ID(), node.ID().String(), nil)
+		i++
+	}
+	store := NewPeerStore(newInMemCache(t))
+	provider := fakePeerProvider{peers}
+	_, err := GetFirstConnected(provider, store)
+	require.EqualError(t, ErrNoConnected, err.Error())
+	require.NoError(t, store.Update(nodes))
+	node, err := GetFirstConnected(provider, store)
+	require.NoError(t, err)
+	require.Contains(t, nodesMap, node.ID())
+}
+
+type trackingNodeNotifee struct {
+	calls [][]*enode.Node
+}
+
+func (t *trackingNodeNotifee) Notify(nodes []*enode.Node) {
+	t.calls = append(t.calls, nodes)
+}
+
+func TestEnsureNewRecordsAddedFirst(t *testing.T) {
+	notifee := new(trackingNodeNotifee)
+	store := NewPeerStore(newInMemCache(t))
+	nodes := make([]*enode.Node, 3)
+	fillWithRandomNodes(t, nodes)
+	require.NoError(t, store.Update(nodes))
+	record := NewPeerRecord(nodes[0])
+	record.LastUsed = time.Now()
+	require.NoError(t, store.cache.UpdateRecord(record))
+	require.NoError(t, EnsureUsedRecordsAddedFirst(store, notifee))
+	require.Len(t, notifee.calls, 2)
+	require.Len(t, notifee.calls[0], 1)
+	require.Equal(t, nodes[0].ID(), notifee.calls[0][0].ID())
+	require.Len(t, notifee.calls[1], 3)
+}

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/node"
@@ -22,6 +23,8 @@ import (
 const (
 	// defaultConnectionsTarget used in Service.Start if configured connection target is 0.
 	defaultConnectionsTarget = 1
+	// defaultTimeoutWaitAdded is a timeout to use to establish initial connections.
+	defaultTimeoutWaitAdded = 5 * time.Second
 )
 
 var errProtocolNotInitialized = errors.New("procotol is not initialized")
@@ -48,8 +51,10 @@ type Service struct {
 	installationID string
 	pfsEnabled     bool
 
-	peerStore   *mailservers.PeerStore
-	connManager *mailservers.ConnectionManager
+	peerStore       *mailservers.PeerStore
+	cache           *mailservers.Cache
+	connManager     *mailservers.ConnectionManager
+	lastUsedMonitor *mailservers.LastUsedConnectionMonitor
 }
 
 type ServiceConfig struct {
@@ -59,6 +64,7 @@ type ServiceConfig struct {
 	PFSEnabled              bool
 	MailServerConfirmations bool
 	EnableConnectionManager bool
+	EnableLastUsedMonitor   bool
 	ConnectionTarget        int
 }
 
@@ -67,7 +73,8 @@ var _ node.Service = (*Service)(nil)
 
 // New returns a new Service. dataDir is a folder path to a network-independent location
 func New(w *whisper.Whisper, handler EnvelopeEventsHandler, db *leveldb.DB, config *ServiceConfig) *Service {
-	ps := mailservers.NewPeerStore()
+	cache := mailservers.NewCache(db)
+	ps := mailservers.NewPeerStore(cache)
 	track := &tracker{
 		w:                      w,
 		handler:                handler,
@@ -86,15 +93,19 @@ func New(w *whisper.Whisper, handler EnvelopeEventsHandler, db *leveldb.DB, conf
 		installationID: config.InstallationID,
 		pfsEnabled:     config.PFSEnabled,
 		peerStore:      ps,
+		cache:          cache,
 	}
 }
 
 // UpdateMailservers updates information about selected mail servers.
-func (s *Service) UpdateMailservers(nodes []*enode.Node) {
-	s.peerStore.Update(nodes)
+func (s *Service) UpdateMailservers(nodes []*enode.Node) error {
+	if err := s.peerStore.Update(nodes); err != nil {
+		return err
+	}
 	if s.connManager != nil {
 		s.connManager.Notify(nodes)
 	}
+	return nil
 }
 
 // Protocols returns a new protocols list. In this case, there are none.
@@ -200,8 +211,15 @@ func (s *Service) Start(server *p2p.Server) error {
 		if connectionsTarget == 0 {
 			connectionsTarget = defaultConnectionsTarget
 		}
-		s.connManager = mailservers.NewConnectionManager(server, s.w, connectionsTarget)
+		s.connManager = mailservers.NewConnectionManager(server, s.w, connectionsTarget, defaultTimeoutWaitAdded)
 		s.connManager.Start()
+		if err := mailservers.EnsureUsedRecordsAddedFirst(s.peerStore, s.connManager); err != nil {
+			return err
+		}
+	}
+	if s.config.EnableLastUsedMonitor {
+		s.lastUsedMonitor = mailservers.NewLastUsedConnectionMonitor(s.peerStore, s.cache, s.w)
+		s.lastUsedMonitor.Start()
 	}
 	s.tracker.Start()
 	s.nodeID = server.PrivateKey
@@ -214,6 +232,9 @@ func (s *Service) Start(server *p2p.Server) error {
 func (s *Service) Stop() error {
 	if s.config.EnableConnectionManager {
 		s.connManager.Stop()
+	}
+	if s.config.EnableLastUsedMonitor {
+		s.lastUsedMonitor.Stop()
 	}
 	s.tracker.Stop()
 	return nil


### PR DESCRIPTION
This change allows to connect to the mail server that we were using before the app was restarted. Separate loop is listening for whisper events, and when we receive event that request was completed we will update time on a peer record.

Records are stored in leveldb. Body of the record is marshaled using json. At this point the only field is a timestamp when record was used. 

This loop doesn't control connections, it only tracks what mail server we ended up using. It works asynchronously to connection management loop. Which tracks events that are related to connection state and expiry of the requests.

When app starts we look into the database and select the most recently used record. This record is added to connection management loop first. So if this server is available we will stick to using it. If we weren't able to connect to the same server in configured timeout (5s) we will try to connect to any other server from list of active servers.

closes: https://github.com/status-im/status-go/issues/1285
