### PR TITLE
Ensure sent event is received from a mailserver

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -329,10 +329,11 @@ func activateShhService(stack *node.Node, config *params.NodeConfig, db *leveldb
 		}
 
 		config := &shhext.ServiceConfig{
-			DataDir:        config.BackupDisabledDataDir,
-			InstallationID: config.InstallationID,
-			Debug:          config.DebugAPIEnabled,
-			PFSEnabled:     config.PFSEnabled,
+			DataDir:                 config.BackupDisabledDataDir,
+			InstallationID:          config.InstallationID,
+			Debug:                   config.DebugAPIEnabled,
+			PFSEnabled:              config.PFSEnabled,
+			MailServerConfirmations: config.MailServerConfirmations,
 		}
 
 		svc := shhext.New(whisper, shhext.EnvelopeSignalHandler{}, db, config)

--- a/params/config.go
+++ b/params/config.go
@@ -303,6 +303,9 @@ type NodeConfig struct {
 
 	// MailServerRegistryAddress is the MailServerRegistry contract address
 	MailServerRegistryAddress string
+
+	// MailServerConfirmations should be true if client wants to receive confirmatons only from a selected mail servers.
+	MailServerConfirmations bool
 }
 
 // Option is an additional setting when creating a NodeConfig

--- a/services/shhext/tracker.go
+++ b/services/shhext/tracker.go
@@ -107,6 +107,12 @@ func (t *tracker) handleEvent(event whisper.EnvelopeEvent) {
 }
 
 func (t *tracker) handleEventEnvelopeSent(event whisper.EnvelopeEvent) {
+	if t.mailServerConfirmation {
+		if !t.isMailserver(event.Peer) {
+			return
+		}
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 


### PR DESCRIPTION
In previous change i used same filtering for a handler that processes confirmations.
But if we are connected with peers that do not support confirmations on whisper level,
whisper may send "Sent" event when envelope is written to a socket. This is our old behaviour.

So, this PR allows to use confirmations from a mail servers and ensure that transition between
multiple version of peers will be smooth.
