### PR TITLE
Close both sides of the stream when client is done with reading response

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -811,7 +811,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5fb8fc6a365f62e1d771b8a33c808a111ace9ba3506089f00ec252ec1e257a83"
+  digest = "1:7eae6e73aa5dd99a7ab975fbc4a39cd98cb72c5a5272970735676e099667cf8a"
   name = "github.com/status-im/rendezvous"
   packages = [
     ".",
@@ -819,7 +819,7 @@
     "server",
   ]
   pruneopts = "NUT"
-  revision = "fbcc46a78cd43fef95a110df664aab513116a850"
+  revision = "9e20b11affd0bf0591126a518f3e7b8aa057f88f"
 
 [[projects]]
   digest = "1:7f2aeb661efc22a59fff9f7e223c59844e32433c18b3567ad24d23758ecf2f64"

--- a/discovery/rendezvous.go
+++ b/discovery/rendezvous.go
@@ -93,6 +93,9 @@ func (r *Rendezvous) Stop() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.cancelRootCtx()
+	if err := r.client.Close(); err != nil {
+		return err
+	}
 	r.client = nil
 	return nil
 }

--- a/vendor/github.com/status-im/rendezvous/stream.go
+++ b/vendor/github.com/status-im/rendezvous/stream.go
@@ -1,8 +1,11 @@
 package rendezvous
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/metrics"
 	inet "github.com/libp2p/go-libp2p-net"
+	protocol "github.com/libp2p/go-libp2p-protocol"
 )
 
 var (
@@ -10,23 +13,51 @@ var (
 	egressTrafficMeter  = metrics.NewRegisteredMeter("rendezvous/OutboundTraffic", nil)
 )
 
-// InstrumenetedStream implements read writer interface and collects metrics.
-type InstrumenetedStream struct {
+// InstrumentedStream implements read writer interface and collects metrics.
+type InstrumentedStream struct {
 	s inet.Stream
 }
 
-func (si InstrumenetedStream) Write(p []byte) (int, error) {
+func (si InstrumentedStream) Write(p []byte) (int, error) {
 	n, err := si.s.Write(p)
 	egressTrafficMeter.Mark(int64(n))
 	return n, err
 }
 
-func (si InstrumenetedStream) Read(p []byte) (int, error) {
+func (si InstrumentedStream) Read(p []byte) (int, error) {
 	n, err := si.s.Read(p)
 	ingressTrafficMeter.Mark(int64(n))
 	return n, err
 }
 
-func (si InstrumenetedStream) Close() error {
+func (si InstrumentedStream) Close() error {
 	return si.s.Close()
+}
+
+func (si InstrumentedStream) Reset() error {
+	return si.s.Reset()
+}
+
+func (si InstrumentedStream) SetDeadline(timeout time.Time) error {
+	return si.s.SetDeadline(timeout)
+}
+
+func (si InstrumentedStream) SetReadDeadline(timeout time.Time) error {
+	return si.s.SetReadDeadline(timeout)
+}
+
+func (si InstrumentedStream) SetWriteDeadline(timeout time.Time) error {
+	return si.s.SetWriteDeadline(timeout)
+}
+
+func (si InstrumentedStream) Protocol() protocol.ID {
+	return si.s.Protocol()
+}
+
+func (si InstrumentedStream) SetProtocol(pid protocol.ID) {
+	si.s.SetProtocol(pid)
+}
+
+func (si InstrumentedStream) Conn() inet.Conn {
+	return si.s.Conn()
 }


### PR DESCRIPTION
Libp2p keeps stream open if EOF wasn't seen and we called Close method.
The most important change is that reader now uses FullClose util, that will
wait for EOF character before closing the stream.
