### PR TITLE
Allow specify topic in rpc endpoint

### DIFF
--- a/services/shhext/chat/rpc.go
+++ b/services/shhext/chat/rpc.go
@@ -17,6 +17,7 @@ type SendPublicMessageRPC struct {
 // SendDirectMessageRPC represents the RPC payload for the SendDirectMessage RPC method
 type SendDirectMessageRPC struct {
 	Sig     string
+	Chat    string
 	Payload hexutil.Bytes
 	PubKey  hexutil.Bytes
 }

--- a/services/shhext/chat/whisper.go
+++ b/services/shhext/chat/whisper.go
@@ -34,10 +34,17 @@ func PublicMessageToWhisper(rpcMsg SendPublicMessageRPC, payload []byte) whisper
 }
 
 func DirectMessageToWhisper(rpcMsg SendDirectMessageRPC, payload []byte) whisper.NewMessage {
+	var topicBytes whisper.TopicType
+
+	if rpcMsg.Chat == "" {
+		topicBytes = discoveryTopicBytes
+	} else {
+		topicBytes = toTopic(rpcMsg.Chat)
+	}
 
 	msg := defaultWhisperMessage()
 
-	msg.Topic = discoveryTopicBytes
+	msg.Topic = topicBytes
 
 	msg.Payload = payload
 	msg.Sig = rpcMsg.Sig


### PR DESCRIPTION
Allow to specify the topic for direct messages, fallback to discovery so is not a breaking change.

status: ready