### PR TITLE
start discovery after sending "node.ready" signal

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -135,7 +135,13 @@ func (b *StatusBackend) startNode(config *params.NodeConfig) (err error) {
 	services := []gethnode.ServiceConstructor{}
 	services = appendIf(config.UpstreamConfig.Enabled, services, b.rpcFiltersService())
 
-	if err = b.statusNode.Start(config, services...); err != nil {
+	if err = b.statusNode.StartWithOptions(config, node.StartOptions{
+		Services: services,
+		// The peers discovery protocols are started manually after
+		// `node.ready` signal is sent.
+		// It was discussed in https://github.com/status-im/status-go/pull/1333.
+		StartDiscovery: false,
+	}); err != nil {
 		return
 	}
 	signal.SendNodeStarted()

--- a/api/backend.go
+++ b/api/backend.go
@@ -166,6 +166,10 @@ func (b *StatusBackend) startNode(config *params.NodeConfig) (err error) {
 
 	signal.SendNodeReady()
 
+	if err := b.statusNode.StartDiscovery(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/node/status_node.go
+++ b/node/status_node.go
@@ -112,9 +112,6 @@ func (n *StatusNode) startWithDB(config *params.NodeConfig, db *leveldb.DB, serv
 		return err
 	}
 
-	if n.discoveryEnabled() {
-		return n.startDiscovery()
-	}
 	return nil
 }
 
@@ -233,6 +230,17 @@ func (n *StatusNode) startRendezvous() (discovery.Discovery, error) {
 	}
 
 	return discovery.NewRendezvous(maddrs, n.gethNode.Server().PrivateKey, node)
+}
+
+func (n *StatusNode) StartDiscovery() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.discoveryEnabled() {
+		return n.startDiscovery()
+	}
+
+	return nil
 }
 
 func (n *StatusNode) startDiscovery() error {

--- a/node/status_node.go
+++ b/node/status_node.go
@@ -99,12 +99,6 @@ func (n *StatusNode) Server() *p2p.Server {
 	return n.gethNode.Server()
 }
 
-// StartOptions allows to control some parameters of Start() method.
-type StartOptions struct {
-	Services       []node.ServiceConstructor
-	StartDiscovery bool
-}
-
 // Start starts current StatusNode, failing if it's already started.
 // It accepts a list of services that should be added to the node.
 func (n *StatusNode) Start(config *params.NodeConfig, services ...node.ServiceConstructor) error {
@@ -112,6 +106,12 @@ func (n *StatusNode) Start(config *params.NodeConfig, services ...node.ServiceCo
 		Services:       services,
 		StartDiscovery: true,
 	})
+}
+
+// StartOptions allows to control some parameters of Start() method.
+type StartOptions struct {
+	Services       []node.ServiceConstructor
+	StartDiscovery bool
 }
 
 // StartWithOptions starts current StatusNode, failing if it's already started.

--- a/peers/peerpool_test.go
+++ b/peers/peerpool_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	lcrypto "github.com/libp2p/go-libp2p-crypto"
 	ma "github.com/multiformats/go-multiaddr"
-	"github.com/status-im/whisper/whisperv6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -26,9 +25,7 @@ import (
 	"github.com/status-im/status-go/discovery"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/signal"
-
-	// to access logs in the test with `-log` flag
-	_ "github.com/status-im/status-go/t/utils"
+	whisper "github.com/status-im/whisper/whisperv6"
 )
 
 type PeerPoolSimulationSuite struct {
@@ -75,7 +72,7 @@ func (s *PeerPoolSimulationSuite) SetupTest() {
 	s.discovery = make([]discovery.Discovery, 3)
 	for i := range s.peers {
 		key, _ := crypto.GenerateKey()
-		whisper := whisperv6.New(nil)
+		whisper := whisper.New(nil)
 		peer := &p2p.Server{
 			Config: p2p.Config{
 				MaxPeers:         10,


### PR DESCRIPTION
Currently, it takes ~2.1-2.4s on any device to receive "node.ready" signal after `Statusgo.StartNode` call. It seems that [`n.gethNode.Server().Self()`](https://github.com/status-im/status-go/blob/52a1bdfed669718a61093bbcc0aa8da917d029f9/node/status_node.go#L199) takes ~2s.

This PR is rather an attempt to emphasize what's the reason of that 2s delay, so if it totally doesn't make sense don't hesitate to close it :). Although already tested on a real android device and doesn't make any harm at first glance.   