### PR TITLE
Validate Whisper DataDir to be relative to the main DataDir

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -539,8 +539,8 @@ func (c *NodeConfig) Validate() error {
 	// Whisper's data directory must be relative to the main data directory
 	// if EnableMailServer is true.
 	if c.WhisperConfig.Enabled && c.WhisperConfig.EnableMailServer {
-		if !strings.Contains(c.WhisperConfig.DataDir, c.DataDir) {
-			return fmt.Errorf("WhisperConfig.DataDir must be relative to DataDir")
+		if !strings.HasPrefix(c.WhisperConfig.DataDir, c.DataDir) {
+			return fmt.Errorf("WhisperConfig.DataDir must start with DataDir fragment")
 		}
 	}
 

--- a/params/config.go
+++ b/params/config.go
@@ -514,6 +514,7 @@ func loadConfigFromAsset(name string, config *NodeConfig) error {
 //
 //   Key: 'TestStruct.TestField' Error:Field validation for 'TestField' failed on the 'required' tag
 //
+// nolint: gocyclo
 func (c *NodeConfig) Validate() error {
 	validate := NewValidator()
 

--- a/params/config.go
+++ b/params/config.go
@@ -531,15 +531,16 @@ func (c *NodeConfig) Validate() error {
 		return fmt.Errorf("both UpstreamConfig and LightEthConfig are enabled, but they are mutually exclusive")
 	}
 
-	// Whisper's data directory must be relative to the main data directory.
-	if c.WhisperConfig.Enabled {
-		if !strings.Contains(c.WhisperConfig.DataDir, c.DataDir) {
-			return fmt.Errorf("Whisper's DataDir must be relative to DataDir")
-		}
-	}
-
 	if err := c.validateChildStructs(validate); err != nil {
 		return err
+	}
+
+	// Whisper's data directory must be relative to the main data directory
+	// if EnableMailServer is true.
+	if c.WhisperConfig.Enabled && c.WhisperConfig.EnableMailServer {
+		if !strings.Contains(c.WhisperConfig.DataDir, c.DataDir) {
+			return fmt.Errorf("WhisperConfig.DataDir must be relative to DataDir")
+		}
 	}
 
 	if !c.NoDiscovery && len(c.ClusterConfig.BootNodes) == 0 {
@@ -641,10 +642,10 @@ func (c *WhisperConfig) Validate(validate *validator.Validate) error {
 		if c.DataDir == "" {
 			return fmt.Errorf("WhisperConfig.DataDir must be specified when WhisperConfig.EnableMailServer is true")
 		}
+
 		if c.MailServerPassword == "" && c.MailServerAsymKey == "" {
 			return fmt.Errorf("WhisperConfig.MailServerPassword or WhisperConfig.MailServerAsymKey must be specified when WhisperConfig.EnableMailServer is true")
 		}
-
 		if c.MailServerAsymKey != "" {
 			if _, err := crypto.HexToECDSA(c.MailServerAsymKey); err != nil {
 				return fmt.Errorf("WhisperConfig.MailServerAsymKey is invalid: %s", c.MailServerAsymKey)

--- a/params/config.go
+++ b/params/config.go
@@ -409,7 +409,8 @@ func (c *NodeConfig) updatePeerLimits() {
 	}
 }
 
-// NewNodeConfig creates new node configuration object with bare-minimum defaults
+// NewNodeConfig creates new node configuration object with bare-minimum defaults.
+// Important: the returned config is not validated.
 func NewNodeConfig(dataDir string, networkID uint64) (*NodeConfig, error) {
 	var keyStoreDir, wnodeDir string
 
@@ -528,6 +529,13 @@ func (c *NodeConfig) Validate() error {
 
 	if c.UpstreamConfig.Enabled && c.LightEthConfig.Enabled {
 		return fmt.Errorf("both UpstreamConfig and LightEthConfig are enabled, but they are mutually exclusive")
+	}
+
+	// Whisper's data directory must be relative to the main data directory.
+	if c.WhisperConfig.Enabled {
+		if !strings.Contains(c.WhisperConfig.DataDir, c.DataDir) {
+			return fmt.Errorf("Whisper's DataDir must be relative to DataDir")
+		}
 	}
 
 	if err := c.validateChildStructs(validate); err != nil {

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -251,6 +251,23 @@ func TestNodeConfigValidate(t *testing.T) {
 			Error: "WhisperConfig.DataDir must be specified when WhisperConfig.EnableMailServer is true",
 		},
 		{
+			Name: "Validate that WhisperConfig.DataDir is checked to not be empty if mailserver is enabled",
+			Config: `{
+				"NetworkId": 1,
+				"DataDir": "/some/dir",
+				"BackupDisabledDataDir": "/some/dir",
+				"KeyStoreDir": "/some/dir",
+				"NoDiscovery": true,
+				"WhisperConfig": {
+					"Enabled": true,
+					"EnableMailServer": true,
+					"MailserverPassword": "foo",
+					"DataDir": "/other/dir"
+				}
+			}`,
+			Error: "WhisperConfig.DataDir must start with DataDir fragment",
+		},
+		{
 			Name: "Validate that check for WhisperConfig.DataDir passes if it is not empty and mailserver is enabled",
 			Config: `{
 				"NetworkId": 1,


### PR DESCRIPTION
Enforces `WhisperConfig.DataDir` to be a subpath of `DataDir`.

This is a bit stronger condition than described in #1287 but there is no valid reason to make Whisper data directory outside of the main data directory.

Closes #1287
