### PR TITLE
Add GetContactCode, JoinPublicChats, LeavePublicChats calls

### DIFF
--- a/lib/library.go
+++ b/lib/library.go
@@ -60,6 +60,19 @@ func CreateContactCode() *C.char {
 	return cstr
 }
 
+// Get an X3DH bundle
+//export GetContactCode
+func GetContactCode(identityString *C.char) *C.char {
+	bundle, err := statusBackend.GetContactCode(C.GoString(identityString))
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	cstr := C.CString(bundle)
+
+	return cstr
+}
+
 //export ProcessContactCode
 func ProcessContactCode(bundleString *C.char) *C.char {
 	err := statusBackend.ProcessContactCode(C.GoString(bundleString))

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -313,12 +313,12 @@ func (api *PublicAPI) SendPublicMessage(ctx context.Context, msg chat.SendPublic
 }
 
 // JoinPublicChats join a set of public chats deriving the key from the chat name
-func (api *PublicAPI) JoinPublicChats(ctx context.Context, msg chat.JoinPublicChatRPC) ([]string, error) {
+func (api *PublicAPI) JoinPublicChats(ctx context.Context, msg chat.JoinPublicChatsRPC) ([]string, error) {
 	return api.service.JoinPublicChats(msg.Chats)
 }
 
 // JoinPublicChats join a set of public chats deriving the key from the chat name
-func (api *PublicAPI) LeavePublicChats(ctx context.Context, msg chat.JoinPublicChatRPC) error {
+func (api *PublicAPI) LeavePublicChats(ctx context.Context, msg chat.JoinPublicChatsRPC) error {
 	return api.service.LeavePublicChats(msg.Chats)
 }
 

--- a/services/shhext/chat/protocol.go
+++ b/services/shhext/chat/protocol.go
@@ -112,6 +112,11 @@ func (p *ProtocolService) GetBundle(myIdentityKey *ecdsa.PrivateKey) (*Bundle, e
 	return p.encryption.CreateBundle(myIdentityKey)
 }
 
+// GetPublicBundle retrieves a public bundle given an identity
+func (p *ProtocolService) GetPublicBundle(theirIdentityKey *ecdsa.PublicKey) (*Bundle, error) {
+	return p.encryption.GetPublicBundle(theirIdentityKey)
+}
+
 // EnableInstallation enables an installation for multi-device sync.
 func (p *ProtocolService) EnableInstallation(myIdentityKey *ecdsa.PublicKey, installationID string) error {
 	return p.encryption.EnableInstallation(myIdentityKey, installationID)

--- a/services/shhext/chat/rpc.go
+++ b/services/shhext/chat/rpc.go
@@ -11,6 +11,7 @@ import (
 type SendPublicMessageRPC struct {
 	Sig     string
 	Chat    string
+	PFS     bool
 	Payload hexutil.Bytes
 }
 
@@ -27,4 +28,9 @@ type SendGroupMessageRPC struct {
 	Sig     string
 	Payload hexutil.Bytes
 	PubKeys []hexutil.Bytes
+}
+
+// JoinPublicChatRPC represents the RPC payload for the JoinPublicChat RPC method
+type JoinPublicChatRPC struct {
+	Chats []string
 }

--- a/services/shhext/chat/rpc.go
+++ b/services/shhext/chat/rpc.go
@@ -30,7 +30,7 @@ type SendGroupMessageRPC struct {
 	PubKeys []hexutil.Bytes
 }
 
-// JoinPublicChatRPC represents the RPC payload for the JoinPublicChat RPC method
-type JoinPublicChatRPC struct {
+// JoinPublicChatsRPC represents the RPC payload for the JoinPublicChat RPC method
+type JoinPublicChatsRPC struct {
 	Chats []string
 }

--- a/services/shhext/chat/whisper.go
+++ b/services/shhext/chat/whisper.go
@@ -6,9 +6,9 @@ import (
 )
 
 var discoveryTopic = "contact-discovery"
-var discoveryTopicBytes = toTopic(discoveryTopic)
+var discoveryTopicBytes = ToWhisperTopic(discoveryTopic)
 
-func toTopic(s string) whisper.TopicType {
+func ToWhisperTopic(s string) whisper.TopicType {
 	return whisper.BytesToTopic(crypto.Keccak256([]byte(s)))
 }
 
@@ -25,7 +25,7 @@ func defaultWhisperMessage() whisper.NewMessage {
 func PublicMessageToWhisper(rpcMsg SendPublicMessageRPC, payload []byte) whisper.NewMessage {
 	msg := defaultWhisperMessage()
 
-	msg.Topic = toTopic(rpcMsg.Chat)
+	msg.Topic = ToWhisperTopic(rpcMsg.Chat)
 
 	msg.Payload = payload
 	msg.Sig = rpcMsg.Sig
@@ -39,7 +39,7 @@ func DirectMessageToWhisper(rpcMsg SendDirectMessageRPC, payload []byte) whisper
 	if rpcMsg.Chat == "" {
 		topicBytes = discoveryTopicBytes
 	} else {
-		topicBytes = toTopic(rpcMsg.Chat)
+		topicBytes = ToWhisperTopic(rpcMsg.Chat)
 	}
 
 	msg := defaultWhisperMessage()

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -1,6 +1,7 @@
 package shhext
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
@@ -9,7 +10,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -38,9 +42,16 @@ type EnvelopeEventsHandler interface {
 	MailServerRequestExpired(common.Hash)
 }
 
+// LoadedFilter is a record containing data about an added filter on whisper
+type LoadedFilter struct {
+	SymKeyID string
+	FilterID string
+}
+
 // Service is a service that provides some additional Whisper API.
 type Service struct {
 	w              *whisper.Whisper
+	publicAPI      *whisper.PublicWhisperAPI
 	config         *ServiceConfig
 	tracker        *tracker
 	server         *p2p.Server
@@ -56,6 +67,10 @@ type Service struct {
 	cache           *mailservers.Cache
 	connManager     *mailservers.ConnectionManager
 	lastUsedMonitor *mailservers.LastUsedConnectionMonitor
+
+	loadedFilters map[string]LoadedFilter
+
+	log log.Logger
 }
 
 type ServiceConfig struct {
@@ -86,6 +101,7 @@ func New(w *whisper.Whisper, handler EnvelopeEventsHandler, db *leveldb.DB, conf
 	}
 	return &Service{
 		w:              w,
+		publicAPI:      whisper.NewPublicWhisperAPI(w),
 		config:         config,
 		tracker:        track,
 		deduplicator:   dedup.NewDeduplicator(w, db),
@@ -95,6 +111,7 @@ func New(w *whisper.Whisper, handler EnvelopeEventsHandler, db *leveldb.DB, conf
 		pfsEnabled:     config.PFSEnabled,
 		peerStore:      ps,
 		cache:          cache,
+		log:            log.New("package", "status-go/services/sshext.Service"),
 	}
 }
 
@@ -174,6 +191,14 @@ func (s *Service) GetBundle(myIdentityKey *ecdsa.PrivateKey) (*chat.Bundle, erro
 	return s.protocol.GetBundle(myIdentityKey)
 }
 
+func (s *Service) GetPublicBundle(identityKey *ecdsa.PublicKey) (*chat.Bundle, error) {
+	if s.protocol == nil {
+		return nil, errProtocolNotInitialized
+	}
+
+	return s.protocol.GetPublicBundle(identityKey)
+}
+
 // EnableInstallation enables an installation for multi-device sync.
 func (s *Service) EnableInstallation(myIdentityKey *ecdsa.PublicKey, installationID string) error {
 	if s.protocol == nil {
@@ -250,4 +275,324 @@ func (s *Service) Stop() error {
 	}
 	s.tracker.Stop()
 	return nil
+}
+
+// JoinPublicChats join a set of public chats deriving the key from the chat name
+func (s *Service) JoinPublicChats(chats []string) ([]string, error) {
+
+	var response []string
+	if s.loadedFilters == nil {
+		s.loadedFilters = make(map[string]LoadedFilter)
+	}
+
+	for _, chatID := range chats {
+		symKeyID, err := s.w.AddSymKeyFromPassword(chatID)
+		if err != nil {
+			return nil, err
+		}
+
+		symKey, err := s.w.GetSymKey(symKeyID)
+		if err != nil {
+			return nil, err
+		}
+
+		topic := chat.ToWhisperTopic(chatID)
+		topics := [][]byte{topic[:]}
+
+		filterOpts := &whisper.Filter{
+			KeySym:   symKey,
+			Topics:   topics,
+			AllowP2P: true,
+			Messages: make(map[common.Hash]*whisper.ReceivedMessage),
+		}
+		filter, err := s.w.Subscribe(filterOpts)
+		if err != nil {
+			return nil, err
+		}
+
+		loadedFilter := LoadedFilter{
+			SymKeyID: symKeyID,
+			FilterID: filter,
+		}
+
+		s.loadedFilters[chatID] = loadedFilter
+		response = append(response, filter)
+	}
+	return response, nil
+}
+
+// LeavePublicChats leaves set of public chats
+func (s *Service) LeavePublicChats(chats []string) error {
+	for _, chatID := range chats {
+		loadedFilter, present := s.loadedFilters[chatID]
+		if !present {
+			continue
+		}
+
+		s.w.DeleteSymKey(loadedFilter.SymKeyID)
+
+		err := s.w.Unsubscribe(loadedFilter.FilterID)
+		if err != nil {
+			return err
+		}
+
+		delete(s.loadedFilters, chatID)
+
+	}
+	return nil
+}
+
+// Post shamelessly copied from whisper codebase with slight modifications.
+func (s *Service) Post(ctx context.Context, req whisper.NewMessage) (hash hexutil.Bytes, err error) {
+	hash, err = s.publicAPI.Post(ctx, req)
+	if err == nil {
+		var envHash common.Hash
+		copy(envHash[:], hash[:]) // slice can't be used as key
+		s.tracker.Add(envHash)
+	}
+	return hash, err
+}
+
+// SendPairingMessage sends a 1:1 chat message to our own devices to initiate a pairing session
+func (s *Service) SendPairingMessage(ctx context.Context, msg chat.SendDirectMessageRPC) ([]hexutil.Bytes, error) {
+	if !s.pfsEnabled {
+		return nil, ErrPFSNotEnabled
+	}
+	// To be completely agnostic from whisper we should not be using whisper to store the key
+	privateKey, err := s.w.GetPrivateKey(msg.Sig)
+	if err != nil {
+		return nil, err
+	}
+
+	msg.PubKey = crypto.FromECDSAPub(&privateKey.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	protocolMessage, err := s.protocol.BuildPairingMessage(privateKey, msg.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var response []hexutil.Bytes
+
+	// Enrich with transport layer info
+	whisperMessage := chat.DirectMessageToWhisper(msg, protocolMessage)
+
+	// And dispatch
+	hash, err := s.Post(ctx, whisperMessage)
+	if err != nil {
+		return nil, err
+	}
+	response = append(response, hash)
+
+	return response, nil
+}
+
+// SendPublicMessage sends a public chat message to the underlying transport
+func (s *Service) SendPublicMessage(ctx context.Context, msg chat.SendPublicMessageRPC) (hexutil.Bytes, error) {
+
+	if msg.PFS {
+		privateKey, err := s.w.GetPrivateKey(msg.Sig)
+		if err != nil {
+			return nil, err
+		}
+
+		// This is transport layer agnostic
+		protocolMessage, err := s.protocol.BuildPublicMessage(privateKey, msg.Payload)
+		if err != nil {
+			return nil, err
+		}
+
+		msg.Payload = protocolMessage
+	}
+
+	// Enrich with transport layer info
+	whisperMessage, err := s.buildPublicMessage(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	// And dispatch
+	return s.Post(ctx, *whisperMessage)
+}
+
+// SendDirectMessage sends a 1:1 chat message to the underlying transport
+func (s *Service) SendDirectMessage(ctx context.Context, msg chat.SendDirectMessageRPC) ([]hexutil.Bytes, error) {
+	if !s.pfsEnabled {
+		return nil, ErrPFSNotEnabled
+	}
+	// To be completely agnostic from whisper we should not be using whisper to store the key
+	privateKey, err := s.w.GetPrivateKey(msg.Sig)
+	if err != nil {
+		return nil, err
+	}
+
+	publicKey, err := crypto.UnmarshalPubkey(msg.PubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// This is transport layer-agnostic
+	protocolMessages, err := s.protocol.BuildDirectMessage(privateKey, msg.Payload, publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var response []hexutil.Bytes
+
+	for key, message := range protocolMessages {
+		msg.PubKey = crypto.FromECDSAPub(key)
+		// Enrich with transport layer info
+		whisperMessage := chat.DirectMessageToWhisper(msg, message)
+
+		// And dispatch
+		hash, err := s.Post(ctx, whisperMessage)
+		if err != nil {
+			return nil, err
+		}
+		response = append(response, hash)
+
+	}
+	return response, nil
+}
+
+// SendGroupMessage sends a group messag chat message to the underlying transport
+func (s *Service) SendGroupMessage(ctx context.Context, msg chat.SendGroupMessageRPC) ([]hexutil.Bytes, error) {
+	if !s.pfsEnabled {
+		return nil, ErrPFSNotEnabled
+	}
+
+	// To be completely agnostic from whisper we should not be using whisper to store the key
+	privateKey, err := s.w.GetPrivateKey(msg.Sig)
+	if err != nil {
+		return nil, err
+	}
+
+	var keys []*ecdsa.PublicKey
+
+	for _, k := range msg.PubKeys {
+		publicKey, err := crypto.UnmarshalPubkey(k)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, publicKey)
+	}
+
+	// This is transport layer-agnostic
+	protocolMessages, err := s.protocol.BuildDirectMessage(privateKey, msg.Payload, keys...)
+	if err != nil {
+		return nil, err
+	}
+
+	var response []hexutil.Bytes
+
+	for key, message := range protocolMessages {
+		directMessage := chat.SendDirectMessageRPC{
+			PubKey:  crypto.FromECDSAPub(key),
+			Payload: msg.Payload,
+			Sig:     msg.Sig,
+		}
+
+		// Enrich with transport layer info
+		whisperMessage := chat.DirectMessageToWhisper(directMessage, message)
+
+		// And dispatch
+		hash, err := s.Post(ctx, whisperMessage)
+		if err != nil {
+			return nil, err
+		}
+		response = append(response, hash)
+
+	}
+	return response, nil
+}
+
+// GetNewFilterMessages is a prototype method with deduplication
+func (s *Service) GetNewFilterMessages(filterID string) ([]*whisper.Message, error) {
+	msgs, err := s.publicAPI.GetFilterMessages(filterID)
+	if err != nil {
+		return nil, err
+	}
+
+	dedupMessages := s.deduplicator.Deduplicate(msgs)
+
+	if s.pfsEnabled {
+		// Attempt to decrypt message, otherwise leave unchanged
+		for _, msg := range dedupMessages {
+
+			if err := s.processPFSMessage(msg); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return dedupMessages, nil
+}
+
+// Login initialize the protocol and join the chat for advertising the bundle
+func (s *Service) Login(address string, password string) error {
+	return s.InitProtocol(address, password)
+}
+
+// Logout cleans up any filter
+func (s *Service) Logout() error {
+	var chats []string
+	for chat := range s.loadedFilters {
+		chats = append(chats, chat)
+
+	}
+
+	return s.LeavePublicChats(chats)
+}
+
+func (s *Service) processPFSMessage(msg *whisper.Message) error {
+
+	privateKeyID := s.w.SelectedKeyPairID()
+	if privateKeyID == "" {
+		return errors.New("no key selected")
+	}
+
+	privateKey, err := s.w.GetPrivateKey(privateKeyID)
+	if err != nil {
+		return err
+	}
+
+	publicKey, err := crypto.UnmarshalPubkey(msg.Sig)
+	if err != nil {
+		return err
+	}
+
+	response, err := s.protocol.HandleMessage(privateKey, publicKey, msg.Payload)
+
+	// Notify that someone tried to contact us using an invalid bundle
+	if err == chat.ErrDeviceNotFound && privateKey.PublicKey != *publicKey {
+		s.log.Warn("Device not found, sending signal", "err", err)
+		keyString := fmt.Sprintf("0x%x", crypto.FromECDSAPub(publicKey))
+		handler := EnvelopeSignalHandler{}
+		handler.DecryptMessageFailed(keyString)
+		return nil
+	} else if err != nil {
+		// Ignore errors for now as those might be non-pfs messages
+		s.log.Error("Failed handling message with error", "err", err)
+		return nil
+	}
+
+	// Add unencrypted payload
+	msg.Payload = response
+
+	return nil
+}
+
+// buildPublicMessage sends a public chat message to the underlying transport
+func (s *Service) buildPublicMessage(msg chat.SendPublicMessageRPC) (*whisper.NewMessage, error) {
+
+	filter := s.loadedFilters[msg.Chat]
+	symKeyID := filter.SymKeyID
+
+	// Enrich with transport layer info
+	whisperMessage := chat.PublicMessageToWhisper(msg, msg.Payload)
+	whisperMessage.SymKeyID = symKeyID
+
+	return &whisperMessage, nil
 }

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
-	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -73,8 +72,6 @@ type ShhExtSuite struct {
 }
 
 func (s *ShhExtSuite) SetupTest() {
-	rand.Seed(time.Now().UnixNano())
-
 	s.nodes = make([]*node.Node, 2)
 	s.services = make([]*Service, 2)
 	s.whisper = make([]*whisper.Whisper, 2)
@@ -129,14 +126,13 @@ func (s *ShhExtSuite) TestLoginLogout() {
 	s.NotNil(service.protocol)
 
 	err = service.Logout()
-
 	s.Require().NoError(err)
 }
 
 func (s *ShhExtSuite) TestGetNewFilterMessages() {
 	service := s.services[0]
 	address := "address-2"
-	publicChat := fmt.Sprintf("%g", rand.Float64())
+	publicChat := "status-go-test-public-chat"
 
 	err := service.Login(address, "`090///\nhtaa\rhta9x8923)$$'23")
 	s.Require().NoError(err)
@@ -152,7 +148,6 @@ func (s *ShhExtSuite) TestGetNewFilterMessages() {
 	s.Require().NoError(err)
 
 	err = service.Logout()
-
 	s.Require().NoError(err)
 }
 
@@ -165,14 +160,13 @@ func (s *ShhExtSuite) TestJoinLeavePublicChats() {
 	publicChats := []string{"test-1", "test-2"}
 	filters, err := service.JoinPublicChats(publicChats)
 	s.Require().NoError(err)
+	s.Require().NotNil(filters)
 
 	// Check filters are saved
 	_, found := service.loadedFilters["test-1"]
 	s.True(found)
 	_, found = service.loadedFilters["test-2"]
 	s.True(found)
-
-	s.Require().NotNil(filters)
 
 	err = service.LeavePublicChats(publicChats)
 	s.Require().NoError(err)


### PR DESCRIPTION
This commit adds a JoinPublishChats & LeavePublicChats
endpoints.
It also moves the logic from api.go to service.go, so that logic is kept
in a single place and we can offer the same endpoints through bindings &
rpc in an easier way.
