### PR TITLE
Accept status service config directly from json input

### DIFF
--- a/cmd/statusd/flags_test.go
+++ b/cmd/statusd/flags_test.go
@@ -83,7 +83,7 @@ func TestStatusFlag(t *testing.T) {
 		}
 
 		require.Nil(t, err, msg)
-		require.Equal(t, s.enabled, c.StatusServiceEnabled, msg)
+		require.Equal(t, s.enabled, c.EnableStatusService, msg)
 
 		modules := c.FormatAPIModules()
 		if s.public {

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -236,15 +236,15 @@ func configureStatusService(flagValue string, nodeConfig *params.NodeConfig) (*p
 		if !nodeConfig.IPCEnabled {
 			return nil, errStatusServiceRequiresIPC
 		}
-		nodeConfig.StatusServiceEnabled = true
+		nodeConfig.EnableStatusService = true
 	case "http":
 		if !nodeConfig.HTTPEnabled {
 			return nil, errStatusServiceRequiresHTTP
 		}
-		nodeConfig.StatusServiceEnabled = true
+		nodeConfig.EnableStatusService = true
 		nodeConfig.AddAPIModule("status")
 	case "":
-		nodeConfig.StatusServiceEnabled = false
+		nodeConfig.EnableStatusService = false
 	default:
 		return nil, errStatusServiceInvalidFlag
 	}

--- a/lib/library_test.go
+++ b/lib/library_test.go
@@ -23,7 +23,7 @@ func TestExportedAPI(t *testing.T) {
 }
 
 func TestValidateNodeConfig(t *testing.T) {
-	noErrorsCallback := func(resp APIDetailedResponse) {
+	noErrorsCallback := func(t *testing.T, resp APIDetailedResponse) {
 		assert.Empty(t, resp.FieldErrors)
 		assert.Empty(t, resp.Message)
 		require.True(t, resp.Status, "expected status equal true")
@@ -32,14 +32,13 @@ func TestValidateNodeConfig(t *testing.T) {
 	testCases := []struct {
 		Name     string
 		Config   string
-		Callback func(APIDetailedResponse)
+		Callback func(*testing.T, APIDetailedResponse)
 	}{
 		{
 			Name: "response for valid config",
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/tmp",
-				"BackupDisabledDataDir": "/tmp",
 				"KeyStoreDir": "/tmp",
 				"NoDiscovery": true,
 				"WhisperConfig": {
@@ -47,6 +46,9 @@ func TestValidateNodeConfig(t *testing.T) {
 					"EnableMailServer": true,
 					"DataDir": "/tmp",
 					"MailServerPassword": "status-offline-inbox"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 			Callback: noErrorsCallback,
@@ -54,7 +56,7 @@ func TestValidateNodeConfig(t *testing.T) {
 		{
 			Name:   "response for invalid JSON string",
 			Config: `{"Network": }`,
-			Callback: func(resp APIDetailedResponse) {
+			Callback: func(t *testing.T, resp APIDetailedResponse) {
 				require.False(t, resp.Status)
 				require.Contains(t, resp.Message, "validation: invalid character '}'")
 			},
@@ -63,14 +65,16 @@ func TestValidateNodeConfig(t *testing.T) {
 			Name: "response for config missing DataDir",
 			Config: `{
 				"NetworkId": 3,
-				"BackupDisabledDataDir": "/tmp",
 				"KeyStoreDir": "/tmp",
 				"NoDiscovery": true,
 				"WhisperConfig": {
 					"Enabled": false
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
-			Callback: func(resp APIDetailedResponse) {
+			Callback: func(t *testing.T, resp APIDetailedResponse) {
 				require.False(t, resp.Status)
 				require.Equal(t, 1, len(resp.FieldErrors))
 				require.Equal(t, resp.FieldErrors[0].Parameter, "NodeConfig.DataDir")
@@ -86,12 +90,15 @@ func TestValidateNodeConfig(t *testing.T) {
 				"NoDiscovery": true,
 				"WhisperConfig": {
 					"Enabled": false
+				},
+				"ShhextConfig": {
+					"PFSEnabled": true
 				}
 			}`,
-			Callback: func(resp APIDetailedResponse) {
+			Callback: func(t *testing.T, resp APIDetailedResponse) {
 				require.False(t, resp.Status)
 				require.Equal(t, 1, len(resp.FieldErrors))
-				require.Equal(t, resp.FieldErrors[0].Parameter, "NodeConfig.BackupDisabledDataDir")
+				require.Equal(t, "NodeConfig.ShhextConfig.BackupDisabledDataDir", resp.FieldErrors[0].Parameter)
 				require.Contains(t, resp.Message, "validation: validation failed")
 			},
 		},
@@ -100,13 +107,15 @@ func TestValidateNodeConfig(t *testing.T) {
 			Config: `{
 				"NetworkId": 3,
 				"DataDir": "/tmp",
-				"BackupDisabledDataDir": "/tmp",
 				"NoDiscovery": true,
 				"WhisperConfig": {
 					"Enabled": false
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
-			Callback: func(resp APIDetailedResponse) {
+			Callback: func(t *testing.T, resp APIDetailedResponse) {
 				require.False(t, resp.Status)
 				require.Equal(t, 1, len(resp.FieldErrors))
 				require.Equal(t, resp.FieldErrors[0].Parameter, "NodeConfig.KeyStoreDir")
@@ -118,15 +127,17 @@ func TestValidateNodeConfig(t *testing.T) {
 			Config: `{
 				"NetworkId": 3,
 				"DataDir": "/tmp",
-				"BackupDisabledDataDir": "/tmp",
 				"KeyStoreDir": "/tmp",
 				"NoDiscovery": true,
 				"WhisperConfig": {
 					"Enabled": true,
 					"EnableMailServer": true
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
-			Callback: func(resp APIDetailedResponse) {
+			Callback: func(t *testing.T, resp APIDetailedResponse) {
 				require.False(t, resp.Status)
 				require.Empty(t, resp.FieldErrors)
 				require.Contains(t, resp.Message, "WhisperConfig.DataDir must be specified when WhisperConfig.EnableMailServer is true")
@@ -137,12 +148,14 @@ func TestValidateNodeConfig(t *testing.T) {
 			Config: `{
 				"NetworkId": 3,
 				"DataDir": "/tmp",
-				"BackupDisabledDataDir": "/tmp",
 				"KeyStoreDir": "/tmp",
 				"NoDiscovery": true,
 				"WhisperConfig": {
 					"Enabled": true,
 					"EnableMailServer": false
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 			Callback: noErrorsCallback,
@@ -150,20 +163,20 @@ func TestValidateNodeConfig(t *testing.T) {
 		{
 			Name:   "response for config with multiple errors",
 			Config: `{}`,
-			Callback: func(resp APIDetailedResponse) {
+			Callback: func(t *testing.T, resp APIDetailedResponse) {
 				required := map[string]string{
-					"NodeConfig.NetworkID":             "required",
-					"NodeConfig.DataDir":               "required",
-					"NodeConfig.BackupDisabledDataDir": "required",
-					"NodeConfig.KeyStoreDir":           "required",
+					"NodeConfig.NetworkID":                          "required",
+					"NodeConfig.DataDir":                            "required",
+					"NodeConfig.ShhextConfig.BackupDisabledDataDir": "required",
+					"NodeConfig.KeyStoreDir":                        "required",
 				}
 
 				require.False(t, resp.Status)
 				require.Contains(t, resp.Message, "validation: validation failed")
-				require.Equal(t, 4, len(resp.FieldErrors), resp.FieldErrors)
+				require.Equal(t, 4, len(resp.FieldErrors))
 
 				for _, err := range resp.FieldErrors {
-					require.Contains(t, required, err.Parameter)
+					require.Contains(t, required, err.Parameter, err.Error())
 					require.Contains(t, err.Error(), required[err.Parameter])
 				}
 			},
@@ -171,7 +184,8 @@ func TestValidateNodeConfig(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Logf("TestValidateNodeConfig: %s", tc.Name)
-		testValidateNodeConfig(t, tc.Config, tc.Callback)
+		t.Run(tc.Name, func(t *testing.T) {
+			testValidateNodeConfig(t, tc.Config, tc.Callback)
+		})
 	}
 }

--- a/lib/library_test_utils.go
+++ b/lib/library_test_utils.go
@@ -52,7 +52,6 @@ func init() {
 	nodeConfigJSON = `{
 	"NetworkId": ` + strconv.Itoa(GetNetworkID()) + `,
 	"DataDir": "` + testChainDir + `",
-	"BackupDisabledDataDir": "` + testChainDir + `",
 	"KeyStoreDir": "` + filepath.Join(testChainDir, "keystore") + `",
 	"HTTPPort": ` + strconv.Itoa(TestConfig.Node.HTTPPort) + `,
 	"LogLevel": "INFO",
@@ -64,6 +63,9 @@ func init() {
 		"Enabled": true,
 		"DataDir": "` + path.Join(testChainDir, "wnode") + `",
 		"EnableNTPSync": false
+	},
+	"ShhextConfig": {
+	    "BackupDisabledDataDir": "` + testChainDir + `"
 	}
 }`
 }
@@ -925,7 +927,7 @@ func startTestNode(t *testing.T) <-chan struct{} {
 }
 
 //nolint: deadcode
-func testValidateNodeConfig(t *testing.T, config string, fn func(APIDetailedResponse)) {
+func testValidateNodeConfig(t *testing.T, config string, fn func(*testing.T, APIDetailedResponse)) {
 	result := ValidateNodeConfig(C.CString(config))
 
 	var resp APIDetailedResponse
@@ -933,7 +935,7 @@ func testValidateNodeConfig(t *testing.T, config string, fn func(APIDetailedResp
 	err := json.Unmarshal([]byte(C.GoString(result)), &resp)
 	require.NoError(t, err)
 
-	fn(resp)
+	fn(t, resp)
 }
 
 // PanicAfter throws panic() after waitSeconds, unless abort channel receives

--- a/node/node.go
+++ b/node/node.go
@@ -235,7 +235,7 @@ func activatePersonalService(stack *node.Node, config *params.NodeConfig) error 
 }
 
 func activateStatusService(stack *node.Node, config *params.NodeConfig) error {
-	if !config.StatusServiceEnabled {
+	if !config.EnableStatusService {
 		logger.Info("Status service api is disabled")
 		return nil
 	}
@@ -327,17 +327,7 @@ func activateShhService(stack *node.Node, config *params.NodeConfig, db *leveldb
 		if err := ctx.Service(&whisper); err != nil {
 			return nil, err
 		}
-
-		config := &shhext.ServiceConfig{
-			DataDir:                 config.BackupDisabledDataDir,
-			InstallationID:          config.InstallationID,
-			Debug:                   config.DebugAPIEnabled,
-			PFSEnabled:              config.PFSEnabled,
-			MailServerConfirmations: config.MailServerConfirmations,
-		}
-
-		svc := shhext.New(whisper, shhext.EnvelopeSignalHandler{}, db, config)
-		return svc, nil
+		return shhext.New(whisper, shhext.EnvelopeSignalHandler{}, db, config.ShhextConfig), nil
 	})
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -180,9 +180,6 @@ type NodeConfig struct {
 
 	// DataDir is the file system folder the node should use for any data storage needs.
 	DataDir string `validate:"required"`
-	// BackupDisabledDataDir is the file system folder the node should use for any data storage needs that it doesn't want backed up.
-	BackupDisabledDataDir string `validate:"required"`
-	PFSEnabled            bool
 
 	// KeyStoreDir is the file system folder that contains private keys.
 	KeyStoreDir string `validate:"required"`
@@ -269,6 +266,9 @@ type NodeConfig struct {
 	// LogToStderr defines whether logged info should also be output to os.Stderr
 	LogToStderr bool
 
+	// EnableStatusService should be true to enable methods under status namespace.
+	EnableStatusService bool
+
 	// UpstreamConfig extra config for providing upstream infura server.
 	UpstreamConfig UpstreamRPCConfig `json:"UpstreamConfig"`
 
@@ -281,6 +281,9 @@ type NodeConfig struct {
 	// WhisperConfig extra configuration for SHH
 	WhisperConfig WhisperConfig `json:"WhisperConfig," validate:"structonly"`
 
+	// ShhextConfig keeps configuration for service running under shhext namespace.
+	ShhextConfig ShhextConfig `json:"ShhextConfig," validate:"required"`
+
 	// SwarmConfig extra configuration for Swarm and ENS
 	SwarmConfig SwarmConfig `json:"SwarmConfig," validate:"structonly"`
 
@@ -292,20 +295,31 @@ type NodeConfig struct {
 	// discoverable peers with the discovery limits.
 	RequireTopics map[discv5.Topic]Limits `json:"RequireTopics"`
 
-	// StatusServiceEnabled enables status service api
-	StatusServiceEnabled bool
-
-	// InstallationId id of the current installation
-	InstallationID string
-
-	// DebugAPIEnabled enables debug api
-	DebugAPIEnabled bool
-
 	// MailServerRegistryAddress is the MailServerRegistry contract address
 	MailServerRegistryAddress string
+}
 
+// ShhextConfig defines options used by shhext service.
+type ShhextConfig struct {
+	// BackupDisabledDataDir is the file system folder the node should use for any data storage needs that it doesn't want backed up.
+	BackupDisabledDataDir string `validate:"required"`
+	// InstallationId id of the current installation
+	InstallationID  string
+	DebugAPIEnabled bool
+	PFSEnabled      bool
 	// MailServerConfirmations should be true if client wants to receive confirmatons only from a selected mail servers.
 	MailServerConfirmations bool
+	// EnableConnectionManager turns on management of the mail server connections if true.
+	EnableConnectionManager bool
+	// EnableLastUsedMonitor guarantees that last used mail server will be tracked and persisted into the storage.
+	EnableLastUsedMonitor bool
+	// ConnectionTarget will be used by connection manager. It will ensure that we connected with configured number of servers.
+	ConnectionTarget int
+}
+
+// Validate validates the ShhextConfig struct and returns an error if inconsistent values are found
+func (c *ShhextConfig) Validate(validate *validator.Validate) error {
+	return validate.Struct(c)
 }
 
 // Option is an additional setting when creating a NodeConfig
@@ -422,23 +436,22 @@ func NewNodeConfig(dataDir string, networkID uint64) (*NodeConfig, error) {
 	}
 
 	config := &NodeConfig{
-		NetworkID:             networkID,
-		DataDir:               dataDir,
-		KeyStoreDir:           keyStoreDir,
-		BackupDisabledDataDir: dataDir,
-		Version:               Version,
-		HTTPHost:              "localhost",
-		HTTPPort:              8545,
-		HTTPVirtualHosts:      []string{"localhost"},
-		ListenAddr:            ":0",
-		APIModules:            "eth,net,web3,peer",
-		MaxPeers:              25,
-		MaxPendingPeers:       0,
-		IPCFile:               "geth.ipc",
-		log:                   log.New("package", "status-go/params.NodeConfig"),
-		LogFile:               "",
-		LogLevel:              "ERROR",
-		NoDiscovery:           true,
+		NetworkID:        networkID,
+		DataDir:          dataDir,
+		KeyStoreDir:      keyStoreDir,
+		Version:          Version,
+		HTTPHost:         "localhost",
+		HTTPPort:         8545,
+		HTTPVirtualHosts: []string{"localhost"},
+		ListenAddr:       ":0",
+		APIModules:       "eth,net,web3,peer",
+		MaxPeers:         25,
+		MaxPendingPeers:  0,
+		IPCFile:          "geth.ipc",
+		log:              log.New("package", "status-go/params.NodeConfig"),
+		LogFile:          "",
+		LogLevel:         "ERROR",
+		NoDiscovery:      true,
 		UpstreamConfig: UpstreamRPCConfig{
 			URL: getUpstreamURL(networkID),
 		},
@@ -450,6 +463,9 @@ func NewNodeConfig(dataDir string, networkID uint64) (*NodeConfig, error) {
 			MinimumPoW:     WhisperMinimumPoW,
 			TTL:            WhisperTTL,
 			MaxMessageSize: whisper.DefaultMaxMessageSize,
+		},
+		ShhextConfig: ShhextConfig{
+			BackupDisabledDataDir: dataDir,
 		},
 		SwarmConfig:    SwarmConfig{},
 		RegisterTopics: []discv5.Topic{},
@@ -550,7 +566,7 @@ func (c *NodeConfig) Validate() error {
 		return fmt.Errorf("NoDiscovery is false, but ClusterConfig.BootNodes is empty")
 	}
 
-	if c.PFSEnabled && len(c.InstallationID) == 0 {
+	if c.ShhextConfig.PFSEnabled && len(c.ShhextConfig.InstallationID) == 0 {
 		return fmt.Errorf("PFSEnabled is true, but InstallationID is empty")
 	}
 
@@ -582,7 +598,9 @@ func (c *NodeConfig) validateChildStructs(validate *validator.Validate) error {
 	if err := c.SwarmConfig.Validate(validate); err != nil {
 		return err
 	}
-
+	if err := c.ShhextConfig.Validate(validate); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -56,14 +56,16 @@ func TestNewConfigFromJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir) // nolint: errcheck
-
-	c, err := params.NewConfigFromJSON(`{
+	json := `{
 		"NetworkId": 3,
 		"DataDir": "` + tmpDir + `",
-		"BackupDisabledDataDir": "` + tmpDir + `",
 		"KeyStoreDir": "` + tmpDir + `",
-		"NoDiscovery": true
-	}`)
+		"NoDiscovery": true,
+		"ShhextConfig": {
+			"BackupDisabledDataDir": "` + tmpDir + `"
+		}
+	}`
+	c, err := params.NewConfigFromJSON(json)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), c.NetworkID)
 	require.Equal(t, tmpDir, c.DataDir)
@@ -105,7 +107,10 @@ func TestNodeConfigValidate(t *testing.T) {
 				"DataDir": "/tmp/data",
 				"BackupDisabledDataDir": "/tmp/data",
 				"KeyStoreDir": "/tmp/data",
-				"NoDiscovery": true
+				"NoDiscovery": true,
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
+				}
 			}`,
 		},
 		{
@@ -135,7 +140,10 @@ func TestNodeConfigValidate(t *testing.T) {
 				"DataDir": "/some/dir",
 				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
-				"Name": "invalid/name"
+				"Name": "invalid/name",
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
+				}
 			}`,
 			FieldErrors: map[string]string{
 				"Name": "excludes",
@@ -149,7 +157,10 @@ func TestNodeConfigValidate(t *testing.T) {
 				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
 				"NoDiscovery": true,
-				"NodeKey": "foo"
+				"NodeKey": "foo",
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
+				}
 			}`,
 			Error: "NodeKey is invalid",
 		},
@@ -164,6 +175,9 @@ func TestNodeConfigValidate(t *testing.T) {
 				"UpstreamConfig": {
 					"Enabled": true,
 					"URL": "[bad.url]"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 			Error: "'[bad.url]' is invalid",
@@ -179,6 +193,9 @@ func TestNodeConfigValidate(t *testing.T) {
 				"UpstreamConfig": {
 					"Enabled": false,
 					"URL": "[bad.url]"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 		},
@@ -193,6 +210,9 @@ func TestNodeConfigValidate(t *testing.T) {
 				"UpstreamConfig": {
 					"Enabled": true,
 					"URL": "` + params.MainnetEthereumNetworkURL + `"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 		},
@@ -203,7 +223,10 @@ func TestNodeConfigValidate(t *testing.T) {
 				"DataDir": "/some/dir",
 				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
-				"NoDiscovery": false
+				"NoDiscovery": false,
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
+				}
 			}`,
 			Error: "NoDiscovery is false, but ClusterConfig.BootNodes is empty",
 		},
@@ -215,7 +238,10 @@ func TestNodeConfigValidate(t *testing.T) {
 				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
 				"NoDiscovery": true,
-				"Rendezvous": true
+				"Rendezvous": true,
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
+				}
 			}`,
 			Error: "Rendezvous is enabled, but ClusterConfig.RendezvousNodes is empty",
 		},
@@ -224,12 +250,14 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
 				"NoDiscovery": true,
 				"Rendezvous": false,
 				"ClusterConfig": {
 					"RendezvousNodes": ["a"]
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 			Error: "Rendezvous is disabled, but ClusterConfig.RendezvousNodes is not empty",
@@ -239,13 +267,15 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
 				"NoDiscovery": true,
 				"WhisperConfig": {
 					"Enabled": true,
 					"EnableMailServer": true,
 					"MailserverPassword": "foo"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 			Error: "WhisperConfig.DataDir must be specified when WhisperConfig.EnableMailServer is true",
@@ -255,14 +285,16 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
 				"NoDiscovery": true,
 				"WhisperConfig": {
 					"Enabled": true,
 					"EnableMailServer": true,
-					"MailserverPassword": "foo",
-					"DataDir": "/other/dir"
+					"DataDir": "/other/dir",
+					"MailserverPassword": "foo"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 			Error: "WhisperConfig.DataDir must start with DataDir fragment",
@@ -272,7 +304,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
 				"NoDiscovery": true,
 				"WhisperConfig": {
@@ -280,6 +311,9 @@ func TestNodeConfigValidate(t *testing.T) {
 					"EnableMailServer": true,
 					"DataDir": "/some/dir",
 					"MailserverPassword": "foo"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 			CheckFunc: func(t *testing.T, config *params.NodeConfig) {
@@ -291,13 +325,15 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
 				"NoDiscovery": true,
 				"WhisperConfig": {
 					"Enabled": true,
 					"EnableMailServer": true,
 					"DataDir": "/some/dir"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 			Error: "WhisperConfig.MailServerPassword or WhisperConfig.MailServerAsymKey must be specified when WhisperConfig.EnableMailServer is true",
@@ -307,7 +343,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
 				"NoDiscovery": true,
 				"WhisperConfig": {
@@ -315,6 +350,9 @@ func TestNodeConfigValidate(t *testing.T) {
 					"EnableMailServer": true,
 					"DataDir": "/some/dir",
 					"MailServerAsymKey": "06c365919f1fc8e13ff79a84f1dd14b7e45b869aa5fc0e34940481ee20d32f90"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 			CheckFunc: func(t *testing.T, config *params.NodeConfig) {
@@ -326,7 +364,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
 				"NoDiscovery": true,
 				"WhisperConfig": {
@@ -334,6 +371,9 @@ func TestNodeConfigValidate(t *testing.T) {
 					"EnableMailServer": true,
 					"DataDir": "/foo",
 					"MailServerAsymKey": "bar"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
 				}
 			}`,
 			Error: "WhisperConfig.MailServerAsymKey is invalid",
@@ -343,13 +383,15 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"PFSEnabled": true,
-				"BackupDisabledDataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
 				"NoDiscovery": true,
 				"WhisperConfig": {
 					"Enabled": true,
 					"DataDir": "/foo"
+				},
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/some/dir",
+					"PFSEnabled": true
 				}
 			}`,
 			Error: "PFSEnabled is true, but InstallationID is empty",
@@ -360,7 +402,9 @@ func TestNodeConfigValidate(t *testing.T) {
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
-				"BackupDisabledDataDir": "/some/dir"
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
+				}
 			}`,
 			CheckFunc: func(t *testing.T, config *params.NodeConfig) {
 				require.Equal(t, []string{"localhost"}, config.HTTPVirtualHosts)
@@ -373,9 +417,11 @@ func TestNodeConfigValidate(t *testing.T) {
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
 				"KeyStoreDir": "/some/dir",
-				"BackupDisabledDataDir": "/some/dir",
 				"HTTPVirtualHosts": ["my.domain.com"],
-				"HTTPCors": ["http://my.domain.com:8080"]
+				"HTTPCors": ["http://my.domain.com:8080"],
+				"ShhextConfig": {
+					"BackupDisabledDataDir": "/tmp"
+				}
 			}`,
 			CheckFunc: func(t *testing.T, config *params.NodeConfig) {
 				require.Equal(t, []string{"my.domain.com"}, config.HTTPVirtualHosts)
@@ -387,7 +433,6 @@ func TestNodeConfigValidate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			config, err := params.NewConfigFromJSON(tc.Config)
-
 			switch err := err.(type) {
 			case validator.ValidationErrors:
 				for _, ve := range err {

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/shhext/chat"
 	"github.com/status-im/status-go/services/shhext/dedup"
 	"github.com/status-im/status-go/services/shhext/mailservers"
@@ -41,7 +42,7 @@ type EnvelopeEventsHandler interface {
 // Service is a service that provides some additional Whisper API.
 type Service struct {
 	w              *whisper.Whisper
-	config         *ServiceConfig
+	config         params.ShhextConfig
 	tracker        *tracker
 	server         *p2p.Server
 	nodeID         *ecdsa.PrivateKey
@@ -58,22 +59,11 @@ type Service struct {
 	lastUsedMonitor *mailservers.LastUsedConnectionMonitor
 }
 
-type ServiceConfig struct {
-	DataDir                 string
-	InstallationID          string
-	Debug                   bool
-	PFSEnabled              bool
-	MailServerConfirmations bool
-	EnableConnectionManager bool
-	EnableLastUsedMonitor   bool
-	ConnectionTarget        int
-}
-
 // Make sure that Service implements node.Service interface.
 var _ node.Service = (*Service)(nil)
 
 // New returns a new Service. dataDir is a folder path to a network-independent location
-func New(w *whisper.Whisper, handler EnvelopeEventsHandler, db *leveldb.DB, config *ServiceConfig) *Service {
+func New(w *whisper.Whisper, handler EnvelopeEventsHandler, db *leveldb.DB, config params.ShhextConfig) *Service {
 	cache := mailservers.NewCache(db)
 	ps := mailservers.NewPeerStore(cache)
 	track := &tracker{
@@ -89,8 +79,8 @@ func New(w *whisper.Whisper, handler EnvelopeEventsHandler, db *leveldb.DB, conf
 		config:         config,
 		tracker:        track,
 		deduplicator:   dedup.NewDeduplicator(w, db),
-		debug:          config.Debug,
-		dataDir:        config.DataDir,
+		debug:          config.DebugAPIEnabled,
+		dataDir:        config.BackupDisabledDataDir,
 		installationID: config.InstallationID,
 		pfsEnabled:     config.PFSEnabled,
 		peerStore:      ps,

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/t/helpers"
 	whisper "github.com/status-im/whisper/whisperv6"
 	"github.com/stretchr/testify/suite"
@@ -96,10 +97,10 @@ func (s *ShhExtSuite) SetupTest() {
 			return s.whisper[i], nil
 		}))
 
-		config := &ServiceConfig{
+		config := params.ShhextConfig{
 			InstallationID:          "1",
-			DataDir:                 directory,
-			Debug:                   true,
+			BackupDisabledDataDir:   directory,
+			DebugAPIEnabled:         true,
 			PFSEnabled:              true,
 			MailServerConfirmations: true,
 			ConnectionTarget:        10,
@@ -195,11 +196,10 @@ func (s *ShhExtSuite) TestRequestMessagesErrors() {
 	defer func() { s.NoError(aNode.Stop()) }()
 
 	mock := newHandlerMock(1)
-	config := &ServiceConfig{
-		InstallationID: "1",
-		DataDir:        os.TempDir(),
-		Debug:          false,
-		PFSEnabled:     true,
+	config := params.ShhextConfig{
+		InstallationID:        "1",
+		BackupDisabledDataDir: os.TempDir(),
+		PFSEnabled:            true,
 	}
 	service := New(shh, mock, nil, config)
 	api := NewPublicAPI(service)
@@ -261,11 +261,10 @@ func (s *ShhExtSuite) TestRequestMessagesSuccess() {
 	defer func() { err := aNode.Stop(); s.NoError(err) }()
 
 	mock := newHandlerMock(1)
-	config := &ServiceConfig{
-		InstallationID: "1",
-		DataDir:        os.TempDir(),
-		Debug:          false,
-		PFSEnabled:     true,
+	config := params.ShhextConfig{
+		InstallationID:        "1",
+		BackupDisabledDataDir: os.TempDir(),
+		PFSEnabled:            true,
 	}
 	service := New(shh, mock, nil, config)
 	s.Require().NoError(service.Start(aNode.Server()))

--- a/t/benchmarks/mailserver_test.go
+++ b/t/benchmarks/mailserver_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/node"
+	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/shhext"
 	whisper "github.com/status-im/whisper/whisperv6"
 	"github.com/stretchr/testify/require"
@@ -36,11 +37,9 @@ func testMailserverPeer(t *testing.T) {
 
 	shhService := createWhisperService()
 	shhAPI := whisper.NewPublicWhisperAPI(shhService)
-	config := &shhext.ServiceConfig{
-		DataDir:        os.TempDir(),
-		InstallationID: "1",
-		Debug:          false,
-		PFSEnabled:     false,
+	config := params.ShhextConfig{
+		BackupDisabledDataDir: os.TempDir(),
+		InstallationID:        "1",
 	}
 	mailService := shhext.New(shhService, nil, nil, config)
 	shhextAPI := shhext.NewPublicAPI(mailService)

--- a/t/e2e/services/base_api_test.go
+++ b/t/e2e/services/base_api_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/status-im/status-go/api"
 	"github.com/status-im/status-go/t/e2e"
 
-	. "github.com/status-im/status-go/t/utils"
+	"github.com/status-im/status-go/t/utils"
 )
 
 const (
@@ -71,19 +71,19 @@ func (s *BaseJSONRPCSuite) SetupTest(upstreamEnabled, statusServiceEnabled, debu
 	s.Backend = api.NewStatusBackend()
 	s.NotNil(s.Backend)
 
-	nodeConfig, err := MakeTestNodeConfig(GetNetworkID())
+	nodeConfig, err := utils.MakeTestNodeConfig(utils.GetNetworkID())
 	s.NoError(err)
 
 	nodeConfig.IPCEnabled = false
-	nodeConfig.StatusServiceEnabled = statusServiceEnabled
-	nodeConfig.DebugAPIEnabled = debugAPIEnabled
-	if nodeConfig.DebugAPIEnabled {
+	nodeConfig.EnableStatusService = statusServiceEnabled
+	nodeConfig.ShhextConfig.DebugAPIEnabled = debugAPIEnabled
+	if debugAPIEnabled {
 		nodeConfig.AddAPIModule("debug")
 	}
 	nodeConfig.HTTPHost = "" // to make sure that no HTTP interface is started
 
 	if upstreamEnabled {
-		networkURL, err := GetRemoteURL()
+		networkURL, err := utils.GetRemoteURL()
 		s.NoError(err)
 
 		nodeConfig.UpstreamConfig.Enabled = true

--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -248,7 +248,6 @@ func MakeTestNodeConfig(networkID int) (*params.NodeConfig, error) {
 		"Name": "test",
 		"NetworkId": ` + strconv.Itoa(networkID) + `,
 		"DataDir": "` + testDir + `",
-		"BackupDisabledDataDir": "` + testDir + `",
 		"KeyStoreDir": "` + path.Join(testDir, "keystore") + `",
 		"HTTPPort": ` + strconv.Itoa(TestConfig.Node.HTTPPort) + `,
 		"WSPort": ` + strconv.Itoa(TestConfig.Node.WSPort) + `,
@@ -261,6 +260,9 @@ func MakeTestNodeConfig(networkID int) (*params.NodeConfig, error) {
 			"Enabled": true,
 			"DataDir": "` + path.Join(testDir, "wnode") + `",
 			"EnableNTPSync": false
+		},
+		"ShhextConfig": {
+			"BackupDisabledDataDir": "` + testDir + `"
 		}
 	}`
 


### PR DESCRIPTION
Recently i extended status service config with more options and it seems impractical to duplicate all those options. So this change allows to provide status config directly.

I will also submit PR for status-react.
