### PR TITLE
Decrease number of kdf iterations in pfs database

### DIFF
--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -129,6 +129,7 @@ func (s *Service) InitProtocol(address string, password string) error {
 	v0Path := filepath.Join(s.dataDir, fmt.Sprintf("%x.db", address))
 	v1Path := filepath.Join(s.dataDir, fmt.Sprintf("%s.db", s.installationID))
 	v2Path := filepath.Join(s.dataDir, fmt.Sprintf("%s.v2.db", s.installationID))
+	v3Path := filepath.Join(s.dataDir, fmt.Sprintf("%s.v3.db", s.installationID))
 
 	if err := chat.MigrateDBFile(v0Path, v1Path, "ON", password); err != nil {
 		return err
@@ -141,7 +142,12 @@ func (s *Service) InitProtocol(address string, password string) error {
 		os.Remove(v2Path)
 	}
 
-	persistence, err := chat.NewSQLLitePersistence(v2Path, hashedPassword)
+	if err := chat.MigrateDBKeyKdfIterations(v2Path, v3Path, hashedPassword); err != nil {
+		os.Remove(v2Path)
+		os.Remove(v3Path)
+	}
+
+	persistence, err := chat.NewSQLLitePersistence(v3Path, hashedPassword)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
PFS database key is derived via `pbkdf` which runs 64000 iterations of `sha1`. This makes `Login` call quite slow on android devices (probably on iOS too, but [it didn't work on iOS](https://github.com/status-im/status-react/issues/7226)).

This PR changes the number of iterations to 3200, and, well, makes it faster. The problem is that from security pov key becomes kind of weaker( currently, that's probably not the case as the same key is used for keystore file and it can be encrypted way faster, so no point in brut-forcing pfs database key at all).
  
Migration is done using [`sqlcipher_export`](https://www.zetetic.net/sqlcipher/sqlcipher-api/#sqlcipher_export) command. 