### PR TITLE
Ensure that all discovery compoenents are set to nil on stop

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -320,3 +320,19 @@ func TestCallRPCWithStoppedNode(t *testing.T) {
 }
 
 // TODO(adam): add concurrent tests for: SendTransaction
+
+func TestStartStopMultipleTimes(t *testing.T) {
+	backend := NewStatusBackend()
+	config, err := utils.MakeTestNodeConfig(params.StatusChainNetworkID)
+	require.NoError(t, err)
+	config.NoDiscovery = false
+	// doesn't have to be running. just any valid enode to bypass validation.
+	config.ClusterConfig.BootNodes = []string{
+		"enode://e8a7c03b58911e98bbd66accb2a55d57683f35b23bf9dfca89e5e244eb5cc3f25018b4112db507faca34fb69ffb44b362f79eda97a669a8df29c72e654416784@0.0.0.0:30404",
+	}
+	require.NoError(t, err)
+	require.NoError(t, backend.StartNode(config))
+	require.NoError(t, backend.StopNode())
+	require.NoError(t, backend.StartNode(config))
+	require.NoError(t, backend.StopNode())
+}

--- a/node/status_node.go
+++ b/node/status_node.go
@@ -335,12 +335,13 @@ func (n *StatusNode) Stop() error {
 
 // stop will stop current StatusNode. A stopped node cannot be resumed.
 func (n *StatusNode) stop() error {
-	if n.discoveryEnabled() {
+	if n.isDiscoveryRunning() {
 		if err := n.stopDiscovery(); err != nil {
-			n.log.Error("Error stopping the PeerPool", "error", err)
+			n.log.Error("Error stopping the discovery components", "error", err)
 		}
 		n.register = nil
 		n.peerPool = nil
+		n.discovery = nil
 	}
 
 	if err := n.gethNode.Stop(); err != nil {


### PR DESCRIPTION
Previously we always tried to stop discovery if it was enabled according to configuration. Now we check if it was started, because it can be started separately from a node.
