### PR TITLE
Introduce new blocking requestMessagesSync api request

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -318,6 +318,9 @@ type ShhextConfig struct {
 	ConnectionTarget int
 	// RequestsDelay used to ensure that no similar requests are sent within short periods of time.
 	RequestsDelay time.Duration
+
+	// MaxServerFailures defines maximum allowed expired requests before server will be swapped to another one.
+	MaxServerFailures int
 }
 
 // Validate validates the ShhextConfig struct and returns an error if inconsistent values are found

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -180,6 +180,58 @@ func (api *PublicAPI) getPeer(rawurl string) (*enode.Node, error) {
 	return enode.ParseV4(rawurl)
 }
 
+// RetryConfig specifies configuration for retries with timeout and max amount of retries.
+type RetryConfig struct {
+	BaseTimeout time.Duration
+	// StepTimeout defines duration increase per each retry.
+	StepTimeout time.Duration
+	MaxRetries  int
+}
+
+// RequestMessagesSync repeats MessagesRequest using configuration in retry conf.
+func (api *PublicAPI) RequestMessagesSync(conf RetryConfig, r MessagesRequest) error {
+	shh := api.service.w
+	events := make(chan whisper.EnvelopeEvent, 10)
+	sub := shh.SubscribeEnvelopeEvents(events)
+	defer sub.Unsubscribe()
+	var (
+		requestID hexutil.Bytes
+		err       error
+		retries   int
+	)
+	for retries <= conf.MaxRetries {
+		r.Timeout = conf.BaseTimeout + conf.StepTimeout*time.Duration(retries)
+		// FIXME this weird conversion is required because MessagesRequest expects seconds but defines time.Duration
+		r.Timeout = time.Duration(int(r.Timeout.Seconds()))
+		requestID, err = api.RequestMessages(context.Background(), r)
+		if err != nil {
+			return err
+		}
+		err = waitForExpiredOrCompleted(common.BytesToHash(requestID), events)
+		if err == nil {
+			return nil
+		}
+		retries++
+		api.log.Error("History request failed with %s. Making retry #%d", retries)
+	}
+	return fmt.Errorf("failed to request messages after %d retries", retries)
+}
+
+func waitForExpiredOrCompleted(requestID common.Hash, events chan whisper.EnvelopeEvent) error {
+	for {
+		ev := <-events
+		if ev.Hash != requestID {
+			continue
+		}
+		switch ev.Event {
+		case whisper.EventMailServerRequestCompleted:
+			return nil
+		case whisper.EventMailServerRequestExpired:
+			return errors.New("request expired")
+		}
+	}
+}
+
 // RequestMessages sends a request for historic messages to a MailServer.
 func (api *PublicAPI) RequestMessages(_ context.Context, r MessagesRequest) (hexutil.Bytes, error) {
 	api.log.Info("RequestMessages", "request", r)

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -234,7 +234,12 @@ func (s *Service) Start(server *p2p.Server) error {
 		if connectionsTarget == 0 {
 			connectionsTarget = defaultConnectionsTarget
 		}
-		s.connManager = mailservers.NewConnectionManager(server, s.w, connectionsTarget, defaultTimeoutWaitAdded)
+		maxFailures := s.config.MaxServerFailures
+		// if not defined change server on first expired event
+		if maxFailures == 0 {
+			maxFailures = 1
+		}
+		s.connManager = mailservers.NewConnectionManager(server, s.w, connectionsTarget, maxFailures, defaultTimeoutWaitAdded)
 		s.connManager.Start()
 		if err := mailservers.EnsureUsedRecordsAddedFirst(s.peerStore, s.connManager); err != nil {
 			return err


### PR DESCRIPTION
New api request block until expired or completed event is received from whisper backend. It accept configuration for retries, that has three options: max retries, base timeout and step timeout. Step timeout increases base timeout on every retry. 

Additionally connection manager now accept configuration option to wait for more then 1 expired event before changing a server.

I want to extend requestMessagesSync with an option to wait for switching a mail server, e.g. max server switches. That will ensure that server was switched that time before returning an error to a caller. I am not exactly sure how to wait for those switches, so that change will come as a separate PR.
