### PR TITLE
Login with keycard

### DIFF
--- a/account/accounts.go
+++ b/account/accounts.go
@@ -249,7 +249,7 @@ func (m *Manager) SelectAccount(walletAddress, chatAddress, password string) err
 }
 
 // SetChatAccount initializes selectedChatAccount with privKey
-func (m *Manager) SetChatAccount(privKey *ecdsa.PrivateKey) error {
+func (m *Manager) SetChatAccount(privKey *ecdsa.PrivateKey) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -265,8 +265,6 @@ func (m *Manager) SetChatAccount(privKey *ecdsa.PrivateKey) error {
 		Address:    address,
 		AccountKey: key,
 	}
-
-	return nil
 }
 
 // SelectedWalletAccount returns currently selected wallet account

--- a/account/accounts.go
+++ b/account/accounts.go
@@ -248,8 +248,8 @@ func (m *Manager) SelectAccount(walletAddress, chatAddress, password string) err
 	return nil
 }
 
-// InjectChatAccount initializes selectedChatAccount with privKey
-func (m *Manager) InjectChatAccount(privKey *ecdsa.PrivateKey) error {
+// SetChatAccount initializes selectedChatAccount with privKey
+func (m *Manager) SetChatAccount(privKey *ecdsa.PrivateKey) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/account/accounts.go
+++ b/account/accounts.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,8 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/pborman/uuid"
+
 	"github.com/status-im/status-go/extkeys"
 )
 
@@ -241,6 +244,27 @@ func (m *Manager) SelectAccount(walletAddress, chatAddress, password string) err
 
 	m.selectedWalletAccount = selectedWalletAccount
 	m.selectedChatAccount = selectedChatAccount
+
+	return nil
+}
+
+// InjectChatAccount initializes selectedChatAccount with privKey
+func (m *Manager) InjectChatAccount(privKey *ecdsa.PrivateKey) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	address := crypto.PubkeyToAddress(privKey.PublicKey)
+	id := uuid.NewRandom()
+	key := &keystore.Key{
+		Id:         id,
+		Address:    address,
+		PrivateKey: privKey,
+	}
+
+	m.selectedChatAccount = &SelectedExtKey{
+		Address:    address,
+		AccountKey: key,
+	}
 
 	return nil
 }

--- a/account/accounts_test.go
+++ b/account/accounts_test.go
@@ -301,7 +301,7 @@ func (s *ManagerTestSuite) TestSelectAccount() {
 	}
 }
 
-func (s *ManagerTestSuite) TestInjectChatAccount() {
+func (s *ManagerTestSuite) TestSetChatAccount() {
 	s.accManager.Logout()
 
 	privKey, err := crypto.GenerateKey()
@@ -309,7 +309,7 @@ func (s *ManagerTestSuite) TestInjectChatAccount() {
 
 	address := crypto.PubkeyToAddress(privKey.PublicKey)
 
-	err = s.accManager.InjectChatAccount(privKey)
+	err = s.accManager.SetChatAccount(privKey)
 	s.Require().NoError(err)
 
 	selectedChatAccount, err := s.accManager.SelectedChatAccount()

--- a/account/accounts_test.go
+++ b/account/accounts_test.go
@@ -309,9 +309,7 @@ func (s *ManagerTestSuite) TestSetChatAccount() {
 
 	address := crypto.PubkeyToAddress(privKey.PublicKey)
 
-	err = s.accManager.SetChatAccount(privKey)
-	s.Require().NoError(err)
-
+	s.accManager.SetChatAccount(privKey)
 	selectedChatAccount, err := s.accManager.SelectedChatAccount()
 	s.Require().NoError(err)
 	s.Require().NotNil(selectedChatAccount)

--- a/account/accounts_test.go
+++ b/account/accounts_test.go
@@ -302,6 +302,8 @@ func (s *ManagerTestSuite) TestSelectAccount() {
 }
 
 func (s *ManagerTestSuite) TestInjectChatAccount() {
+	s.accManager.Logout()
+
 	privKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 

--- a/account/accounts_test.go
+++ b/account/accounts_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/golang/mock/gomock"
 	. "github.com/status-im/status-go/t/utils"
 	"github.com/stretchr/testify/assert"
@@ -298,6 +299,26 @@ func (s *ManagerTestSuite) TestSelectAccount() {
 			s.accManager.Logout()
 		})
 	}
+}
+
+func (s *ManagerTestSuite) TestInjectChatAccount() {
+	privKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	address := crypto.PubkeyToAddress(privKey.PublicKey)
+
+	err = s.accManager.InjectChatAccount(privKey)
+	s.Require().NoError(err)
+
+	selectedChatAccount, err := s.accManager.SelectedChatAccount()
+	s.Require().NoError(err)
+	s.Require().NotNil(selectedChatAccount)
+	s.Equal(privKey, selectedChatAccount.AccountKey.PrivateKey)
+	s.Equal(address, selectedChatAccount.Address)
+
+	selectedWalletAccount, err := s.accManager.SelectedWalletAccount()
+	s.Error(err)
+	s.Nil(selectedWalletAccount)
 }
 
 func (s *ManagerTestSuite) TestCreateChildAccount() {

--- a/api/backend.go
+++ b/api/backend.go
@@ -490,6 +490,8 @@ func (b *StatusBackend) InjectChatAccount(chatKeyHex, encryptionKeyHex string) e
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	b.accountManager.Logout()
+
 	chatKey, err := ethcrypto.HexToECDSA(chatKeyHex)
 	if err != nil {
 		return err

--- a/api/backend.go
+++ b/api/backend.go
@@ -497,7 +497,7 @@ func (b *StatusBackend) InjectChatAccount(chatKeyHex, encryptionKeyHex string) e
 		return err
 	}
 
-	err = b.accountManager.InjectChatAccount(chatKey)
+	err = b.accountManager.SetChatAccount(chatKey)
 	if err != nil {
 		return err
 	}

--- a/api/backend.go
+++ b/api/backend.go
@@ -486,6 +486,7 @@ func (b *StatusBackend) SendDataNotification(dataPayloadJSON string, tokens ...s
 	return err
 }
 
+// InjectChatAccount selects the current chat account using chatKeyHex and injects the key into whisper.
 func (b *StatusBackend) InjectChatAccount(chatKeyHex, encryptionKeyHex string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/api/backend.go
+++ b/api/backend.go
@@ -497,11 +497,7 @@ func (b *StatusBackend) InjectChatAccount(chatKeyHex, encryptionKeyHex string) e
 		return err
 	}
 
-	err = b.accountManager.SetChatAccount(chatKey)
-	if err != nil {
-		return err
-	}
-
+	b.accountManager.SetChatAccount(chatKey)
 	chatAccount, err := b.accountManager.SelectedChatAccount()
 	if err != nil {
 		return err

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -190,6 +190,9 @@ func TestBackendInjectChatAccount(t *testing.T) {
 	require.NoError(t, err)
 	err = backend.StartNode(config)
 	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, backend.StopNode())
+	}()
 
 	chatPrivKey, err := crypto.GenerateKey()
 	require.NoError(t, err)

--- a/lib/library.go
+++ b/lib/library.go
@@ -327,6 +327,9 @@ func Login(address, password *C.char) *C.char {
 	return makeJSONResponse(err)
 }
 
+//LoginWithKeycard initializes an account with a chat key and encryption key used for PFS.
+// It purges all the previous identities from Whisper, and injects the key as shh identity.
+// export LoginWithKeycard
 func LoginWithKeycard(chatKeyData, encryptionKeyData *C.char) *C.char {
 	err := statusBackend.InjectChatAccount(C.GoString(chatKeyData), C.GoString(encryptionKeyData))
 	return makeJSONResponse(err)

--- a/lib/library.go
+++ b/lib/library.go
@@ -327,6 +327,11 @@ func Login(address, password *C.char) *C.char {
 	return makeJSONResponse(err)
 }
 
+func LoginWithKeycard(chatKeyData, encryptionKeyData *C.char) *C.char {
+	err := statusBackend.InjectChatAccount(C.GoString(chatKeyData), C.GoString(encryptionKeyData))
+	return makeJSONResponse(err)
+}
+
 //Logout is equivalent to clearing whisper identities
 //export Logout
 func Logout() *C.char {

--- a/lib/library.go
+++ b/lib/library.go
@@ -327,9 +327,9 @@ func Login(address, password *C.char) *C.char {
 	return makeJSONResponse(err)
 }
 
-//LoginWithKeycard initializes an account with a chat key and encryption key used for PFS.
+// LoginWithKeycard initializes an account with a chat key and encryption key used for PFS.
 // It purges all the previous identities from Whisper, and injects the key as shh identity.
-// export LoginWithKeycard
+//export LoginWithKeycard
 func LoginWithKeycard(chatKeyData, encryptionKeyData *C.char) *C.char {
 	err := statusBackend.InjectChatAccount(C.GoString(chatKeyData), C.GoString(encryptionKeyData))
 	return makeJSONResponse(err)

--- a/t/e2e/accounts/accounts_test.go
+++ b/t/e2e/accounts/accounts_test.go
@@ -202,7 +202,7 @@ func (s *AccountsTestSuite) TestSelectAccount() {
 	s.NoError(s.Backend.SelectAccount(accountInfo2.WalletAddress, accountInfo2.ChatAddress, TestConfig.Account1.Password))
 }
 
-func (s *AccountsTestSuite) TestInjectChatAccount() {
+func (s *AccountsTestSuite) TestSetChatAccount() {
 	s.StartTestBackend()
 	defer s.StopTestBackend()
 

--- a/t/e2e/accounts/accounts_test.go
+++ b/t/e2e/accounts/accounts_test.go
@@ -1,10 +1,12 @@
 package accounts
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/status-im/status-go/account"
 	e2e "github.com/status-im/status-go/t/e2e"
 	. "github.com/status-im/status-go/t/utils"
@@ -198,6 +200,26 @@ func (s *AccountsTestSuite) TestSelectAccount() {
 
 	// select another account, make sure that previous account is wiped out from Whisper cache
 	s.NoError(s.Backend.SelectAccount(accountInfo2.WalletAddress, accountInfo2.ChatAddress, TestConfig.Account1.Password))
+}
+
+func (s *AccountsTestSuite) TestInjectChatAccount() {
+	s.StartTestBackend()
+	defer s.StopTestBackend()
+
+	chatPrivKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	chatPrivKeyHex := hex.EncodeToString(crypto.FromECDSA(chatPrivKey))
+
+	encryptionPrivKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	encryptionPrivKeyHex := hex.EncodeToString(crypto.FromECDSA(encryptionPrivKey))
+
+	err = s.Backend.InjectChatAccount(chatPrivKeyHex, encryptionPrivKeyHex)
+	s.Require().NoError(err)
+
+	selectedChatAccount, err := s.Backend.AccountManager().SelectedChatAccount()
+	s.Require().NoError(err)
+	s.Equal(chatPrivKey, selectedChatAccount.AccountKey.PrivateKey)
 }
 
 func (s *AccountsTestSuite) TestSelectedAccountOnRestart() {


### PR DESCRIPTION
In this PR we allow logging in with keycard.
At login `status-react` creates a secure channel to communicate with the keycard and verifies the PIN.
If login with the keycard is successful, `status-react` inject the whisper key downloaded from the keycard to whisper. To do that, it calls `LoginWithKeycard` passing the whisper private key that will be injected in whisper. It also passes another key used as password for sqlite if PFS is enabled.

Important changes:
- [x] add `LoginWithKeycard` in `lib/library.go` 
- [x] add `InjectChatAccount` to `Backend` and use the received key for the whisper identity.
- [x] add `SetChatAccount` to account manager and use the received key for the `selectedChatAccount`
