### PR TITLE
add shhext.InitProtocolWithEncryptionKey

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -456,7 +456,7 @@ func (b *StatusBackend) SelectAccount(walletAddress, chatAddress, password strin
 			return err
 		}
 
-		if err := st.InitProtocol(chatAddress, password); err != nil {
+		if err := st.InitProtocolWithPassword(chatAddress, password); err != nil {
 			return err
 		}
 	}
@@ -521,7 +521,7 @@ func (b *StatusBackend) InjectChatAccount(chatKeyHex, encryptionKeyHex string) e
 			return err
 		}
 
-		if err := st.InitProtocol(chatAccount.Address.Hex(), encryptionKeyHex); err != nil {
+		if err := st.InitProtocolWithEncyptionKey(chatAccount.Address.Hex(), encryptionKeyHex); err != nil {
 			return err
 		}
 	}

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/storage"
+	"golang.org/x/crypto/sha3"
 )
 
 const (
@@ -126,7 +127,14 @@ func (s *ShhExtSuite) SetupTest() {
 }
 
 func (s *ShhExtSuite) TestInitProtocol() {
-	err := s.services[0].InitProtocol("example-address", "`090///\nhtaa\rhta9x8923)$$'23")
+	pass := "`090///\nhtaa\rhta9x8923)$$'23"
+
+	err := s.services[0].InitProtocolWithPassword("example-address", pass)
+	s.NoError(err)
+
+	digest := sha3.Sum256([]byte(pass))
+	encKey := fmt.Sprintf("%x", digest)
+	err = s.services[0].InitProtocolWithEncyptionKey("example-address", encKey)
 	s.NoError(err)
 }
 

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -127,12 +127,10 @@ func (s *ShhExtSuite) SetupTest() {
 }
 
 func (s *ShhExtSuite) TestInitProtocol() {
-	pass := "`090///\nhtaa\rhta9x8923)$$'23"
-
-	err := s.services[0].InitProtocolWithPassword("example-address", pass)
+	err := s.services[0].InitProtocolWithPassword("example-address", "`090///\nhtaa\rhta9x8923)$$'23")
 	s.NoError(err)
 
-	digest := sha3.Sum256([]byte(pass))
+	digest := sha3.Sum256([]byte("`090///\nhtaa\rhta9x8923)$$'23"))
 	encKey := fmt.Sprintf("%x", digest)
 	err = s.services[0].InitProtocolWithEncyptionKey("example-address", encKey)
 	s.NoError(err)


### PR DESCRIPTION
This PR splits the `shhext.InitProtocol` function in 2 different functions (`InitProtocolWithPassword `, `InitProtocolWithEncyptionKey `) to be able to use a password or an encryption key. 

When we log in with a Keycard, instead of using a password we use a specific encryption key generated by the card using the path defined in [EIP1581](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1581.md)
 