### PR TITLE
fix deadlock on starting discovery with custom AdvertiseAddr

### DIFF
--- a/node/status_node.go
+++ b/node/status_node.go
@@ -215,7 +215,8 @@ func (n *StatusNode) discoverNode() (*enode.Node, error) {
 		return nil, nil
 	}
 
-	discNode := n.gethNode.Server().Self()
+	server := n.gethNode.Server()
+	discNode := server.Self()
 
 	if n.config.AdvertiseAddr == "" {
 		return discNode, nil
@@ -225,7 +226,7 @@ func (n *StatusNode) discoverNode() (*enode.Node, error) {
 
 	r := discNode.Record()
 	r.Set(enr.IP(net.ParseIP(n.config.AdvertiseAddr)))
-	if err := enode.SignV4(r, n.Server().PrivateKey); err != nil {
+	if err := enode.SignV4(r, server.PrivateKey); err != nil {
 		return nil, err
 	}
 	return enode.New(enode.ValidSchemes[r.IdentityScheme()], r)

--- a/node/status_node_test.go
+++ b/node/status_node_test.go
@@ -277,9 +277,33 @@ func TestStatusNodeRendezvousDiscovery(t *testing.T) {
 			// not necessarily with id, just valid multiaddr
 			RendezvousNodes: []string{"/ip4/127.0.0.1/tcp/34012", "/ip4/127.0.0.1/tcp/34011"},
 		},
+		// use custom address to test the all possibilities
+		AdvertiseAddr: "127.0.0.1",
 	}
 	n := New()
 	require.NoError(t, n.Start(&config))
+	require.NotNil(t, n.discovery)
+	require.True(t, n.discovery.Running())
+	require.IsType(t, &discovery.Rendezvous{}, n.discovery)
+}
+
+func TestStatusNodeStartDiscoveryManual(t *testing.T) {
+	config := params.NodeConfig{
+		Rendezvous:  true,
+		NoDiscovery: true,
+		ClusterConfig: params.ClusterConfig{
+			Enabled: true,
+			// not necessarily with id, just valid multiaddr
+			RendezvousNodes: []string{"/ip4/127.0.0.1/tcp/34012", "/ip4/127.0.0.1/tcp/34011"},
+		},
+		// use custom address to test the all possibilities
+		AdvertiseAddr: "127.0.0.1",
+	}
+	n := New()
+	require.NoError(t, n.StartWithOptions(&config, StartOptions{}))
+	require.Nil(t, n.discovery)
+	// start discovery manually
+	require.NoError(t, n.StartDiscovery())
 	require.NotNil(t, n.discovery)
 	require.True(t, n.discovery.Running())
 	require.IsType(t, &discovery.Rendezvous{}, n.discovery)


### PR DESCRIPTION
In `discoverNode()` method was called a public `Server()` method which acquires a lock. `discoverNode()` is also called from a method that acquires the same lock resulting in a deadlock.

After we merge this PR we need to apply it to `release/0.19` and `release/0.20` and deploy on servers.

This bug does not affect status-go on mobile and desktop.

cc @jakubgs 