### PR TITLE
Add a docker-compose.yml and Makefile for running a mailserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ Session.vim
 /.idea/
 /.vscode/
 /cmd/*/.ethereum/
+
+# created for running container
+_assets/compose/mailserver/config.json

--- a/Makefile
+++ b/Makefile
@@ -308,3 +308,6 @@ update-fleet-config: ##@other Update fleets configuration from fleets.status.im
 	@echo "Updating static assets..."
 	@go generate ./static
 	@echo "Done"
+
+run-mailserver: ##@Easy way to run a mailserver locally with Docker
+	cd _assets/compose/mailserver/ && $(MAKE)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [How To Build](https://status.im/build_status/status_go.html)
 - [How To Contribute](CONTRIBUTING.md)
 - [How To Release](RELEASING.md)
+- [How To run a Mailserver](_assets/compose/mailserver/README.md)
 
 # License
 

--- a/_assets/compose/mailserver/Makefile
+++ b/_assets/compose/mailserver/Makefile
@@ -1,0 +1,72 @@
+GIT_ROOT = $(shell git rev-parse --show-toplevel)
+
+RED    := $(shell tput -Txterm setaf 1)
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+RESET  := $(shell tput -Txterm sgr0)
+BOLD   := $(shell tput bold)
+
+# Settings
+export LOG_LEVEL = INFO
+export LISTEN_PORT ?= 30303
+export RPC_PORT ?= 8545
+export API_MODULES = eth,net,web3,admin
+export CONTAINER_NAME ?= status-go-mailserver
+export DATA_PATH ?= /var/tmp/status-go-mail
+export FLEET_NAME = eth.beta
+# Necessary to make mailserver available publicly
+export PUBLIC_IP ?= $(shell curl -s https://ipecho.net/plain)
+
+all: checks start show info enode
+
+checks:
+ifeq (, $(shell which docker-compose))
+	$(error No $(BOLD)docker-compose$(RESET) in your $$PATH. Please install it)
+endif
+ifeq (, $(shell which jq))
+	$(error No $(BOLD)jq$(RESET) in your $$PATH. Please install it)
+endif
+ifndef PUBLIC_IP
+	$(error PUBLIC_IP not set! Export it as environment variable)
+endif
+ifndef CONTAINER_NAME
+	$(error CONTAINER_NAME not set! Export it as environment variable)
+endif
+
+start: config
+	docker-compose up -d
+
+stop:
+	docker-compose down
+
+logs:
+	docker-compose logs -f -t --tail=100
+
+enode:
+	@curl -s -XPOST http://localhost:$(RPC_PORT)/ \
+		-H 'Content-type: application/json' \
+		-d '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}' \
+		| jq -r '.result.enode' \
+		| grep -oP '\Kenode://[^?]+'
+
+
+info:
+	@echo "$(GREEN)Your mailserver is listening on:$(RESET) $(BOLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RESET)"
+	@echo "$(YELLOW)Make sure that address and port are available from the internet!$(RESET)"
+	@echo "$(GREEN)Your enode address is:$(RESET)"
+
+show:
+	@docker ps --filter='name=$(CONTAINER_NAME)' --format="table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}"
+
+config: ##@ Generate config for mailserver with current public IP.
+	@cat $(GIT_ROOT)/config/cli/fleet-$(FLEET_NAME).json \
+		| jq '.AdvertiseAddr = "$(PUBLIC_IP)"' \
+		| jq '.HTTPEnabled = true' \
+		| jq '.HTTPHost = "0.0.0.0"' \
+		| jq '.HTTPPort= $(RPC_PORT)' \
+		| jq '.APIModules = "$(API_MODULES)"' \
+		> config.json
+
+clean:
+	rm -f config.json
+	docker-compose rm -s -f

--- a/_assets/compose/mailserver/README.md
+++ b/_assets/compose/mailserver/README.md
@@ -1,0 +1,51 @@
+# Status Mailserver
+
+This folder contains setup for running your own Status Mailserver.
+It uses:
+
+* [Docker Compose](https://docs.docker.com/compose/) for managing the Status Mailserver container.
+* [Makefile](https://www.gnu.org/software/make/) to simplify the process for the user.
+
+# Requirements
+
+This Makefile uses two tools: `jq` and `docker-compose`.
+
+# Usage
+
+To simply start a container run `make`, other commands include:
+
+* `make start` - Starts the `status-go-mailserver` container.
+* `make stop` - Stops the container.
+* `make show` - Shows you current status of the container.
+* `make logs` - Shows you logs of the container.
+* `make config.json` - Creates `config.json` with your Public IP.
+
+# Settings
+
+All settings are passed through environment variables:
+
+* `PUBLIC_IP` - Your IP visible from the internet and advertised by the Mailserver.
+* `LISTEN_PORT` - Mailserver port, by default it's `30303` but you might want to use `443`.
+* `RPC_PORT` - Control port making it possible to use the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC).
+* `API_MODULES` - API modules to be made available via the `RPC_PORT`.
+* `DATA_PATH` - Location of Mailserver storage and keys. (Default: `/var/tmp/status-go-mail`)
+* `CONTAINER_NAME` - Name of the container that will be created.
+* `LOG_LEVEL` - Set level of log messages to show. (`ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`)
+
+# Known Issues
+
+If the discovery of your Public IP does not work please simply export the `PUBLIC_IP` env variable.
+You can also set `LISTEN_PORT` to something else to avoid firewall issues.
+```bash
+$ export PUBLIC_IP=1.2.3.4
+$ export LISTEN_PORT=443
+$ make
+docker-compose up -d
+Creating status-go-mailserver ... done
+CONTAINER ID        NAMES                  STATUS              PORTS
+bee56564926d        status-go-mailserver   Up 6 minutes        8080/tcp, 127.0.0.1:8545->8545/tcp, 30303-30304/udp, 0.0.0.0:30303->30303/tcp
+Your mailserver is listening on: 1.2.3.4:443
+Make sure that address and port are available from the internet!
+Your enode address is:
+enode://dccd2f3c1df42c23af6672df28f287893ab70a5d45668637576a759b6db10b83e83fc02598f36c80ac094fbf8621419153cfe539f56d278ab099da21800f880c@127.0.0.1:30303
+```

--- a/_assets/compose/mailserver/docker-compose.yml
+++ b/_assets/compose/mailserver/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  mailserver:
+    container_name: '${CONTAINER_NAME}'
+    image: statusteam/status-go:latest
+    entrypoint: statusd
+    restart: always
+    command: -log=${LOG_LEVEL} -log-without-color -c=/config.json -dir=/data
+    ports:
+      - '127.0.0.1:${RPC_PORT}:${RPC_PORT}'
+      - '0.0.0.0:${LISTEN_PORT}:30303'
+    volumes:
+      - '${PWD}/config.json:/config.json'
+      - '${DATA_PATH}:/data'


### PR DESCRIPTION
This should simplify running a mailserver for a less tech-savvy user. All you need to do is run:
```
cd _assets/compose/mailserver && make
```
In the repo directory.

Also adds a [README](https://github.com/status-im/status-go/tree/add-mailserver-compose/_assets/compose/mailserver).
