### PR TITLE
Change publishing envelopes behaviour

### DIFF
--- a/mailserver/mailserver_test.go
+++ b/mailserver/mailserver_test.go
@@ -652,7 +652,6 @@ func processRequestAndCollectHashes(
 	}()
 
 	cursor, lastHash := server.processRequestInBundles(iter, bloom, limit, bundles)
-	close(bundles)
 
 	<-done
 


### PR DESCRIPTION
Before `processedEnvelopes` was always set to `0`, which lead to the behavior that envelopes would only be published when the size of the current bundle was too big, or when the count of the envelopes in a given bundle hit `limit`, and at the end of the loop.
 
Effectively this meant that for small `limit` it all worked ok, for large limits (i.e. 2000), we would publish all the envelopes in the range (say 0 -> 5000) in one go, and for medium size limit (`400`), the behavior was dependent on the size of the envelopes. In any case it correctly sent out all the envelopes in the original range, just not in the right pagination.

