### PR TITLE
send tx with signature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ statusgo-cross: statusgo-android statusgo-ios
 
 statusgo-android: ##@cross-compile Build status-go for Android
 	@echo "Building status-go for Android..."
-	env
 	@gomobile bind -target=android -ldflags="-s -w" -o build/bin/statusgo.aar github.com/status-im/status-go/mobile
 	@echo "Android cross compilation done in build/bin/statusgo.aar"
 

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ statusgo-cross: statusgo-android statusgo-ios
 
 statusgo-android: ##@cross-compile Build status-go for Android
 	@echo "Building status-go for Android..."
+	env
 	@gomobile bind -target=android -ldflags="-s -w" -o build/bin/statusgo.aar github.com/status-im/status-go/mobile
 	@echo "Android cross compilation done in build/bin/statusgo.aar"
 
@@ -220,7 +221,6 @@ release:
 
 gomobile-install:
 	go get -u golang.org/x/mobile/cmd/gomobile
-	env
 ifdef NDK_GOMOBILE
 	gomobile init -ndk $(NDK_GOMOBILE)
 else

--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,7 @@ release:
 
 gomobile-install:
 	go get -u golang.org/x/mobile/cmd/gomobile
+	env
 ifdef NDK_GOMOBILE
 	gomobile init -ndk $(NDK_GOMOBILE)
 else

--- a/api/backend.go
+++ b/api/backend.go
@@ -262,6 +262,17 @@ func (b *StatusBackend) SendTransaction(sendArgs transactions.SendTxArgs, passwo
 	return
 }
 
+func (b *StatusBackend) SendTransactionWithSignature(sendArgs transactions.SendTxArgs, sig []byte) (hash gethcommon.Hash, err error) {
+	hash, err = b.transactor.SendTransactionWithSignature(sendArgs, sig)
+	if err != nil {
+		return
+	}
+
+	go b.rpcFilters.TriggerTransactionSentToUpstreamEvent(hash)
+
+	return
+}
+
 // SignMessage checks the pwd vs the selected account and passes on the signParams
 // to personalAPI for message signature
 func (b *StatusBackend) SignMessage(rpcParams personal.SignParams) (hexutil.Bytes, error) {

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1,6 +1,7 @@
 package statusgo
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -361,6 +362,27 @@ func SendTransaction(txArgsJSON, password string) string {
 		return prepareJSONResponseWithCode(nil, err, codeFailedParseParams)
 	}
 	hash, err := statusBackend.SendTransaction(params, password)
+	code := codeUnknown
+	if c, ok := errToCodeMap[err]; ok {
+		code = c
+	}
+	return prepareJSONResponseWithCode(hash.String(), err, code)
+}
+
+// SendTransactionWithSignature converts RPC args and calls backend.SendTransactionWithSignature
+func SendTransactionWithSignature(txArgsJSON, sigString string) string {
+	var params transactions.SendTxArgs
+	err := json.Unmarshal([]byte(txArgsJSON), &params)
+	if err != nil {
+		return prepareJSONResponseWithCode(nil, err, codeFailedParseParams)
+	}
+
+	sig, err := hex.DecodeString(sigString)
+	if err != nil {
+		return prepareJSONResponseWithCode(nil, err, codeFailedParseParams)
+	}
+
+	hash, err := statusBackend.SendTransactionWithSignature(params, sig)
 	code := codeUnknown
 	if c, ok := errToCodeMap[err]; ok {
 		code = c

--- a/transactions/transactor.go
+++ b/transactions/transactor.go
@@ -69,6 +69,8 @@ func (t *Transactor) SendTransaction(sendArgs SendTxArgs, verifiedAccount *accou
 	return
 }
 
+// SendTransactionWithSignature receive a transaction and a signature, serialize them together and propage it to the network.
+// It's different from eth_sendRawTransaction because it receives a signature and not a serialized transaction with signature.
 func (t *Transactor) SendTransactionWithSignature(args SendTxArgs, sig []byte) (hash gethcommon.Hash, err error) {
 	chainID := big.NewInt(int64(t.networkID))
 	signer := types.NewEIP155Signer(chainID)
@@ -113,6 +115,7 @@ func (t *Transactor) SendTransactionWithSignature(args SendTxArgs, sig []byte) (
 	if err := t.sender.SendTransaction(ctx, signedTx); err != nil {
 		return hash, err
 	}
+
 	return signedTx.Hash(), nil
 }
 

--- a/transactions/transactor.go
+++ b/transactions/transactor.go
@@ -73,6 +73,10 @@ func (t *Transactor) SendTransaction(sendArgs SendTxArgs, verifiedAccount *accou
 // It's different from eth_sendRawTransaction because it receives a signature and not a serialized transaction with signature.
 // Since the transactions is already signed, we assume it was validated and used the right nonce.
 func (t *Transactor) SendTransactionWithSignature(args SendTxArgs, sig []byte) (hash gethcommon.Hash, err error) {
+	if !args.Valid() {
+		return hash, ErrInvalidSendTxArgs
+	}
+
 	chainID := big.NewInt(int64(t.networkID))
 	signer := types.NewEIP155Signer(chainID)
 

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -3,6 +3,7 @@ package transactions
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"reflect"
@@ -284,51 +285,90 @@ func (s *TransactorSuite) TestContractCreation() {
 	s.Equal(crypto.CreateAddress(testaddr, 0), receipt.ContractAddress)
 }
 
-func (s *TransactorSuite) TestSendTransactionWithSignature_IncrementingNonce() {
+func (s *TransactorSuite) TestSendTransactionWithSignature() {
 	privKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	address := crypto.PubkeyToAddress(privKey.PublicKey)
 
-	nonce := hexutil.Uint64(0)
-	from := address
-	to := address
-	value := (*hexutil.Big)(big.NewInt(10))
-	gas := hexutil.Uint64(21000)
-	gasPrice := (*hexutil.Big)(big.NewInt(2000000000))
-	data := []byte{}
-	chainID := big.NewInt(int64(s.nodeConfig.NetworkID))
-
-	args := SendTxArgs{
-		From:     from,
-		To:       &to,
-		Gas:      &gas,
-		GasPrice: gasPrice,
-		Value:    value,
-		Nonce:    &nonce,
-		Data:     nil,
+	scenarios := []struct {
+		localNonce  hexutil.Uint64
+		txNonce     hexutil.Uint64
+		expectError bool
+	}{
+		{
+			localNonce:  hexutil.Uint64(0),
+			txNonce:     hexutil.Uint64(0),
+			expectError: false,
+		},
+		{
+			localNonce:  hexutil.Uint64(1),
+			txNonce:     hexutil.Uint64(0),
+			expectError: true,
+		},
+		{
+			localNonce:  hexutil.Uint64(0),
+			txNonce:     hexutil.Uint64(1),
+			expectError: true,
+		},
 	}
 
-	// simulate transaction signed externally
-	signer := types.NewEIP155Signer(chainID)
-	tx := types.NewTransaction(uint64(nonce), to, (*big.Int)(value), uint64(gas), (*big.Int)(gasPrice), data)
-	hash := signer.Hash(tx)
-	sig, err := crypto.Sign(hash[:], privKey)
-	s.Require().NoError(err)
-	txWithSig, err := tx.WithSignature(signer, sig)
-	s.Require().NoError(err)
-	expectedEncodedTx, err := rlp.EncodeToBytes(txWithSig)
-	s.Require().NoError(err)
+	for _, scenario := range scenarios {
+		desc := fmt.Sprintf("local nonce: %d, tx nonce: %d, expect error: %v", scenario.localNonce, scenario.txNonce, scenario.expectError)
+		s.T().Run(desc, func(t *testing.T) {
+			s.manager.localNonce.Store(address, uint64(scenario.localNonce))
 
-	s.txServiceMock.EXPECT().
-		GetTransactionCount(gomock.Any(), address, gethrpc.PendingBlockNumber).
-		Return(&nonce, nil)
+			nonce := hexutil.Uint64(scenario.txNonce)
+			from := address
+			to := address
+			value := (*hexutil.Big)(big.NewInt(10))
+			gas := hexutil.Uint64(21000)
+			gasPrice := (*hexutil.Big)(big.NewInt(2000000000))
+			data := []byte{}
+			chainID := big.NewInt(int64(s.nodeConfig.NetworkID))
 
-	s.txServiceMock.EXPECT().
-		SendRawTransaction(gomock.Any(), hexutil.Bytes(expectedEncodedTx)).
-		Return(gethcommon.Hash{}, nil)
+			args := SendTxArgs{
+				From:     from,
+				To:       &to,
+				Gas:      &gas,
+				GasPrice: gasPrice,
+				Value:    value,
+				Nonce:    &nonce,
+				Data:     nil,
+			}
 
-	_, err = s.manager.SendTransactionWithSignature(args, sig)
-	s.NoError(err)
-	resultNonce, _ := s.manager.localNonce.Load(args.From)
-	s.Equal(uint64(nonce)+1, resultNonce.(uint64))
+			// simulate transaction signed externally
+			signer := types.NewEIP155Signer(chainID)
+			tx := types.NewTransaction(uint64(nonce), to, (*big.Int)(value), uint64(gas), (*big.Int)(gasPrice), data)
+			hash := signer.Hash(tx)
+			sig, err := crypto.Sign(hash[:], privKey)
+			s.Require().NoError(err)
+			txWithSig, err := tx.WithSignature(signer, sig)
+			s.Require().NoError(err)
+			expectedEncodedTx, err := rlp.EncodeToBytes(txWithSig)
+			s.Require().NoError(err)
+
+			s.txServiceMock.EXPECT().
+				GetTransactionCount(gomock.Any(), address, gethrpc.PendingBlockNumber).
+				Return(&scenario.localNonce, nil)
+
+			if !scenario.expectError {
+				s.txServiceMock.EXPECT().
+					SendRawTransaction(gomock.Any(), hexutil.Bytes(expectedEncodedTx)).
+					Return(gethcommon.Hash{}, nil)
+			}
+
+			_, err = s.manager.SendTransactionWithSignature(args, sig)
+			if scenario.expectError {
+				s.Error(err)
+				// local nonce should not be incremented
+				resultNonce, _ := s.manager.localNonce.Load(args.From)
+				s.Equal(uint64(scenario.localNonce), resultNonce.(uint64))
+			} else {
+				s.NoError(err)
+				// local nonce should be incremented
+				resultNonce, _ := s.manager.localNonce.Load(args.From)
+				s.Equal(uint64(nonce)+1, resultNonce.(uint64))
+			}
+		})
+	}
 }

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -317,7 +317,7 @@ func (s *TransactorSuite) TestSendTransactionWithSignature() {
 		s.T().Run(desc, func(t *testing.T) {
 			s.manager.localNonce.Store(address, uint64(scenario.localNonce))
 
-			nonce := hexutil.Uint64(scenario.txNonce)
+			nonce := scenario.txNonce
 			from := address
 			to := address
 			value := (*hexutil.Big)(big.NewInt(10))

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -286,6 +286,7 @@ func (s *TransactorSuite) TestContractCreation() {
 
 func (s *TransactorSuite) TestSendTransactionWithSignature_IncrementingNonce() {
 	privKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
 	address := crypto.PubkeyToAddress(privKey.PublicKey)
 
 	nonce := hexutil.Uint64(0)


### PR DESCRIPTION
In case of a keycard account, the transaction is signed by the card and the signature is sent to `status-go` together with the original transaction.
The original transaction is needed to serialize the final transaction with signature.

Important changes:
- [x] add `SendTransactionWithSignature` to transactor
