### PR TITLE
Mark envelope as confirmed when it was received from a mail server

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -823,11 +823,11 @@
 
 [[projects]]
   branch = "env-received-event"
-  digest = "1:f5c403c710c6afc54214e8d58c203573c4b982a9f7b7f1b3ec458b2fa7a12793"
+  digest = "1:a90c426c6ea51783f383128eb66570f39df327b947cd305d8360a58328ef2089"
   name = "github.com/status-im/whisper"
   packages = ["whisperv6"]
   pruneopts = "NUT"
-  revision = "135b098b5e2cb95e70ecefbaddb7b17313583b85"
+  revision = "ce8adebb4984a8a9a9d438aaf5159b10fc2cfe7c"
 
 [[projects]]
   digest = "1:572c783a763db6383aca3179976eb80e4c900f52eba56cba8bb2e3cea7ce720e"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -660,7 +660,6 @@
   revision = "ad98a36ba0da87206e3378c556abbfeaeaa98668"
 
 [[projects]]
-  branch = "master"
   digest = "1:b9b9f43a8a410d633e6547f89e830926741070941f2243d4d3a0bb154f565c9e"
   name = "github.com/mr-tron/base58"
   packages = ["base58"]
@@ -823,12 +822,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:2c5092efed72e4c33a9d5f2ca6970609ed959a07b08a6b85fe6e7b70df3ed210"
+  branch = "env-received-event"
+  digest = "1:f5c403c710c6afc54214e8d58c203573c4b982a9f7b7f1b3ec458b2fa7a12793"
   name = "github.com/status-im/whisper"
   packages = ["whisperv6"]
   pruneopts = "NUT"
-  revision = "9cdf6385f8a9d8a1cc5ab90dcbbc8cd7efca1e86"
-  version = "v1.4.6"
+  revision = "135b098b5e2cb95e70ecefbaddb7b17313583b85"
 
 [[projects]]
   digest = "1:572c783a763db6383aca3179976eb80e4c900f52eba56cba8bb2e3cea7ce720e"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -822,12 +822,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  branch = "env-received-event"
-  digest = "1:a90c426c6ea51783f383128eb66570f39df327b947cd305d8360a58328ef2089"
+  digest = "1:684e59281a3fd4a35437992b008f43f98a0cf5b25cde717397325b10f94ea69c"
   name = "github.com/status-im/whisper"
   packages = ["whisperv6"]
   pruneopts = "NUT"
-  revision = "ce8adebb4984a8a9a9d438aaf5159b10fc2cfe7c"
+  revision = "88b3fdf3bd4b497ee3312b4c7b471cce167f40aa"
+  version = "v1.4.8"
 
 [[projects]]
   digest = "1:572c783a763db6383aca3179976eb80e4c900f52eba56cba8bb2e3cea7ce720e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,7 +46,7 @@
 
 [[constraint]]
   name = "github.com/status-im/whisper"
-  version = "=v1.4.6"
+  branch = "env-received-event"
 
 [[constraint]]
   name = "golang.org/x/text"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,7 +46,7 @@
 
 [[constraint]]
   name = "github.com/status-im/whisper"
-  branch = "env-received-event"
+  version = "=v1.4.8"
 
 [[constraint]]
   name = "golang.org/x/text"

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/t/helpers"
+	"github.com/status-im/status-go/t/utils"
 	whisper "github.com/status-im/whisper/whisperv6"
 	"github.com/stretchr/testify/suite"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -28,6 +29,7 @@ import (
 const (
 	// internal whisper protocol codes
 	statusCode             = 0
+	messagesCode           = 1
 	p2pRequestCompleteCode = 125
 )
 
@@ -468,19 +470,19 @@ func waitForHashInTracker(track *tracker, hash common.Hash, state EnvelopeState,
 	}
 }
 
-func TestRequestMessagesSync(t *testing.T) {
-	suite.Run(t, new(RequestMessagesSyncSuite))
-}
-
-type RequestMessagesSyncSuite struct {
+type WhisperNodeMockSuite struct {
 	suite.Suite
 
-	localAPI  *PublicAPI
-	localNode *enode.Node
-	remoteRW  *p2p.MsgPipeRW
+	localWhisperAPI *whisper.PublicWhisperAPI
+	localAPI        *PublicAPI
+	localNode       *enode.Node
+	remoteRW        *p2p.MsgPipeRW
+
+	localService *Service
+	localTracker *tracker
 }
 
-func (s *RequestMessagesSyncSuite) SetupTest() {
+func (s *WhisperNodeMockSuite) SetupTest() {
 	db, err := leveldb.Open(storage.NewMemStorage(), nil)
 	s.Require().NoError(err)
 	conf := &whisper.Config{
@@ -501,11 +503,23 @@ func (s *RequestMessagesSyncSuite) SetupTest() {
 	s.Require().NoError(p2p.ExpectMsg(rw1, statusCode, []interface{}{whisper.ProtocolVersion, math.Float64bits(w.MinPow()), w.BloomFilter(), false, true}))
 	s.Require().NoError(p2p.SendItems(rw1, statusCode, whisper.ProtocolVersion, whisper.ProtocolVersion, math.Float64bits(w.MinPow()), w.BloomFilter(), true, true))
 
-	service := New(w, nil, db, params.ShhextConfig{})
+	s.localService = New(w, nil, db, params.ShhextConfig{MailServerConfirmations: true})
+	s.Require().NoError(s.localService.UpdateMailservers([]*enode.Node{node}))
+	s.localTracker = s.localService.tracker
+	s.localTracker.Start()
 
-	s.localAPI = NewPublicAPI(service)
+	s.localWhisperAPI = whisper.NewPublicWhisperAPI(w)
+	s.localAPI = NewPublicAPI(s.localService)
 	s.localNode = node
 	s.remoteRW = rw1
+}
+
+func TestRequestMessagesSync(t *testing.T) {
+	suite.Run(t, new(RequestMessagesSyncSuite))
+}
+
+type RequestMessagesSyncSuite struct {
+	WhisperNodeMockSuite
 }
 
 func (s *RequestMessagesSyncSuite) TestExpired() {
@@ -553,4 +567,54 @@ func (s *RequestMessagesSyncSuite) TestCompletedFromFirstAttempt() {
 
 func (s *RequestMessagesSyncSuite) TestCompletedFromSecondAttempt() {
 	s.testCompletedFromAttempt(2)
+}
+
+func TestWhisperConfirmations(t *testing.T) {
+	suite.Run(t, new(WhisperConfirmationSuite))
+}
+
+type WhisperConfirmationSuite struct {
+	WhisperNodeMockSuite
+}
+
+func (s *WhisperConfirmationSuite) TestEnvelopeReceived() {
+	symID, err := s.localWhisperAPI.GenerateSymKeyFromPassword(context.TODO(), "test")
+	s.Require().NoError(err)
+	envBytes, err := s.localAPI.Post(context.TODO(), whisper.NewMessage{
+		SymKeyID: symID,
+		TTL:      1000,
+		Topic:    whisper.TopicType{0x01},
+	})
+	envHash := common.BytesToHash(envBytes)
+	s.Require().NoError(err)
+	s.Require().NoError(utils.Eventually(func() error {
+		if state := s.localTracker.GetState(envHash); state != EnvelopePosted {
+			return fmt.Errorf("envelope with hash %s wasn't posted", envHash.String())
+		}
+		return nil
+	}, 2*time.Second, 100*time.Millisecond))
+
+	// enable auto-replies once message got registered internally
+	go func() {
+		for {
+			msg, err := s.remoteRW.ReadMsg()
+			s.Require().NoError(err)
+			if msg.Code != messagesCode {
+				s.Require().NoError(msg.Discard())
+				continue
+			}
+			// reply with same envelopes. we could probably just write same data to remoteRW, but this works too.
+			var envs []*whisper.Envelope
+			s.Require().NoError(msg.Decode(&envs))
+			s.Require().NoError(p2p.Send(s.remoteRW, messagesCode, envs))
+		}
+	}()
+
+	// wait for message to be removed because it was delivered by remoteRW
+	s.Require().NoError(utils.Eventually(func() error {
+		if state := s.localTracker.GetState(envHash); state != NotRegistered {
+			return fmt.Errorf("envelope with hash %s wasn't removed from tracker", envHash.String())
+		}
+		return nil
+	}, 2*time.Second, 100*time.Millisecond))
 }

--- a/services/shhext/tracker.go
+++ b/services/shhext/tracker.go
@@ -1,7 +1,6 @@
 package shhext
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -106,7 +105,6 @@ func (t *tracker) handleEvent(event whisper.EnvelopeEvent) {
 	}
 
 	if handler, ok := handlers[event.Event]; ok {
-		fmt.Println("received event")
 		handler(event)
 	}
 }

--- a/services/shhext/tracker.go
+++ b/services/shhext/tracker.go
@@ -1,6 +1,7 @@
 package shhext
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -105,6 +106,7 @@ func (t *tracker) handleEvent(event whisper.EnvelopeEvent) {
 	}
 
 	if handler, ok := handlers[event.Event]; ok {
+		fmt.Println("received event")
 		handler(event)
 	}
 }

--- a/services/shhext/tracker_test.go
+++ b/services/shhext/tracker_test.go
@@ -94,6 +94,15 @@ func (s *TrackerSuite) TestRemoved() {
 	s.NotContains(s.tracker.cache, testHash)
 }
 
+func (s *TrackerSuite) TestReceived() {
+	s.tracker.Add(testHash)
+	s.Contains(s.tracker.cache, testHash)
+	s.tracker.handleEvent(whisper.EnvelopeEvent{
+		Event: whisper.EventEnvelopeReceived,
+		Hash:  testHash})
+	s.NotContains(s.tracker.cache, testHash)
+}
+
 func (s *TrackerSuite) TestRequestCompleted() {
 	mock := newHandlerMock(1)
 	s.tracker.handler = mock

--- a/vendor/github.com/status-im/whisper/whisperv6/events.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/events.go
@@ -13,6 +13,8 @@ const (
 	EventEnvelopeSent EventType = "envelope.sent"
 	// EventEnvelopeExpired fires when envelop expired
 	EventEnvelopeExpired EventType = "envelope.expired"
+	// EventEnvelopeReceived is sent once envelope was received from a peer.
+	EventEnvelopeReceived EventType = "envelope.received"
 	// EventBatchAcknowledged is sent when batch of envelopes was acknowleged by a peer.
 	EventBatchAcknowledged EventType = "batch.acknowleged"
 	// EventEnvelopeAvailable fires when envelop is available for filters

--- a/vendor/github.com/status-im/whisper/whisperv6/events.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/events.go
@@ -14,6 +14,8 @@ const (
 	// EventEnvelopeExpired fires when envelop expired
 	EventEnvelopeExpired EventType = "envelope.expired"
 	// EventEnvelopeReceived is sent once envelope was received from a peer.
+	// EventEnvelopeReceived must be sent to the feed even if envelope was previously in the cache.
+	// And event, ideally, should contain information about peer that sent envelope to us.
 	EventEnvelopeReceived EventType = "envelope.received"
 	// EventBatchAcknowledged is sent when batch of envelopes was acknowleged by a peer.
 	EventBatchAcknowledged EventType = "batch.acknowleged"

--- a/vendor/github.com/status-im/whisper/whisperv6/message.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/message.go
@@ -75,7 +75,6 @@ type ReceivedMessage struct {
 
 	SymKeyHash   common.Hash // The Keccak256Hash of the key
 	EnvelopeHash common.Hash // Message envelope hash to act as a unique id
-	History      bool
 }
 
 func isMessageSigned(flags byte) bool {

--- a/vendor/github.com/status-im/whisper/whisperv6/peer.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/peer.go
@@ -205,10 +205,6 @@ func (peer *Peer) expire() {
 // broadcast iterates over the collection of envelopes and transmits yet unknown
 // ones over the network.
 func (peer *Peer) broadcast() error {
-	if peer.peer.IsFlaky() {
-		log.Trace("Waiting for a peer to restore communication", "ID", peer.peer.ID())
-		return nil
-	}
 	envelopes := peer.host.Envelopes()
 	bundle := make([]*Envelope, 0, len(envelopes))
 	for _, envelope := range envelopes {

--- a/vendor/github.com/status-im/whisper/whisperv6/whisper.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/whisper.go
@@ -876,7 +876,6 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 				log.Warn("failed to decode envelopes, peer will be disconnected", "peer", p.peer.ID(), "err", err)
 				return errors.New("invalid envelopes")
 			}
-
 			trouble := false
 			for _, env := range envelopes {
 				cached, err := whisper.add(env, whisper.LightClientMode())
@@ -884,12 +883,12 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 					trouble = true
 					log.Error("bad envelope received, peer will be disconnected", "peer", p.peer.ID(), "err", err)
 				}
+				whisper.envelopeFeed.Send(EnvelopeEvent{
+					Event: EventEnvelopeReceived,
+					Hash:  env.Hash(),
+					Peer:  p.peer.ID(),
+				})
 				if cached {
-					whisper.envelopeFeed.Send(EnvelopeEvent{
-						Event: EventEnvelopeReceived,
-						Hash:  env.Hash(),
-						Peer:  p.peer.ID(),
-					})
 					p.mark(env)
 				}
 			}

--- a/vendor/github.com/status-im/whisper/whisperv6/whisper.go
+++ b/vendor/github.com/status-im/whisper/whisperv6/whisper.go
@@ -885,6 +885,11 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw p2p.MsgReadWriter) error {
 					log.Error("bad envelope received, peer will be disconnected", "peer", p.peer.ID(), "err", err)
 				}
 				if cached {
+					whisper.envelopeFeed.Send(EnvelopeEvent{
+						Event: EventEnvelopeReceived,
+						Hash:  env.Hash(),
+						Peer:  p.peer.ID(),
+					})
 					p.mark(env)
 				}
 			}


### PR DESCRIPTION
Previously i didn't take into account that envelope might get delivered from a mail server faster then it is sent to it. For example, if we are connected with 2 peers, A and B. A is a mail server. B also connected with a mail server. In rare circumstances A will receive envelope from B and deliver it to us. Whisper will mark such envelope as "known" and will never try to re-deliver it to A.

This change is linked to a custom branch in our whisper repository. I will make a new whisper release once corresponding change is merged.
