### PR TITLE
add HashTransaction

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -274,6 +274,11 @@ func (b *StatusBackend) SendTransactionWithSignature(sendArgs transactions.SendT
 	return
 }
 
+// HashTransaction validate the transaction and returns new sendArgs and the transaction hash.
+func (b *StatusBackend) HashTransaction(sendArgs transactions.SendTxArgs) (transactions.SendTxArgs, gethcommon.Hash, error) {
+	return b.transactor.HashTransaction(sendArgs)
+}
+
 // SignMessage checks the pwd vs the selected account and passes on the signParams
 // to personalAPI for message signature
 func (b *StatusBackend) SignMessage(rpcParams personal.SignParams) (hexutil.Bytes, error) {

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"unsafe"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/status-im/status-go/api"
 	"github.com/status-im/status-go/logutils"
@@ -395,6 +396,31 @@ func SendTransactionWithSignature(txArgsJSON, sigString string) string {
 		code = c
 	}
 	return prepareJSONResponseWithCode(hash.String(), err, code)
+}
+
+// HashTransaction validate the transaction and returns new txArgs and the transaction hash.
+func HashTransaction(txArgsJSON string) string {
+	var params transactions.SendTxArgs
+	err := json.Unmarshal([]byte(txArgsJSON), &params)
+	if err != nil {
+		return prepareJSONResponseWithCode(nil, err, codeFailedParseParams)
+	}
+
+	newTxArgs, hash, err := statusBackend.HashTransaction(params)
+	code := codeUnknown
+	if c, ok := errToCodeMap[err]; ok {
+		code = c
+	}
+
+	result := struct {
+		Transaction transactions.SendTxArgs `json:"transaction"`
+		Hash        common.Hash             `json:"hash"`
+	}{
+		Transaction: newTxArgs,
+		Hash:        hash,
+	}
+
+	return prepareJSONResponseWithCode(result, err, code)
 }
 
 // StartCPUProfile runs pprof for CPU.

--- a/transactions/transactor.go
+++ b/transactions/transactor.go
@@ -274,25 +274,13 @@ func (t *Transactor) validateAndPropagate(selectedAccount *account.SelectedExtKe
 
 	var tx *types.Transaction
 	if args.To != nil {
-		t.log.Info("New transaction",
-			"From", args.From,
-			"To", *args.To,
-			"Gas", gas,
-			"GasPrice", gasPrice,
-			"Value", value,
-		)
 		tx = types.NewTransaction(nonce, *args.To, value, gas, gasPrice, args.GetInput())
+		t.logNewTx(args, gas, gasPrice, value)
 	} else {
-		// contract creation is rare enough to log an expected address
-		t.log.Info("New contract",
-			"From", args.From,
-			"Gas", gas,
-			"GasPrice", gasPrice,
-			"Value", value,
-			"Contract address", crypto.CreateAddress(args.From, nonce),
-		)
 		tx = types.NewContractCreation(nonce, value, gas, gasPrice, args.GetInput())
+		t.logNewContract(args, gas, gasPrice, value, nonce)
 	}
+
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), selectedAccount.AccountKey.PrivateKey)
 	if err != nil {
 		return hash, err
@@ -315,24 +303,11 @@ func (t *Transactor) buildTransaction(args SendTxArgs) *types.Transaction {
 	var tx *types.Transaction
 
 	if args.To != nil {
-		t.log.Info("New transaction",
-			"From", args.From,
-			"To", *args.To,
-			"Gas", gas,
-			"GasPrice", gasPrice,
-			"Value", value,
-		)
 		tx = types.NewTransaction(nonce, *args.To, value, gas, gasPrice, args.GetInput())
+		t.logNewTx(args, gas, gasPrice, value)
 	} else {
-		// contract creation is rare enough to log an expected address
-		t.log.Info("New contract",
-			"From", args.From,
-			"Gas", gas,
-			"GasPrice", gasPrice,
-			"Value", value,
-			"Contract address", crypto.CreateAddress(args.From, nonce),
-		)
 		tx = types.NewContractCreation(nonce, value, gas, gasPrice, args.GetInput())
+		t.logNewContract(args, gas, gasPrice, value, nonce)
 	}
 
 	return tx
@@ -366,4 +341,24 @@ func (t *Transactor) getTransactionNonce(args SendTxArgs) (newNonce uint64, err 
 	}
 
 	return newNonce, nil
+}
+
+func (t *Transactor) logNewTx(args SendTxArgs, gas uint64, gasPrice *big.Int, value *big.Int) {
+	t.log.Info("New transaction",
+		"From", args.From,
+		"To", *args.To,
+		"Gas", gas,
+		"GasPrice", gasPrice,
+		"Value", value,
+	)
+}
+
+func (t *Transactor) logNewContract(args SendTxArgs, gas uint64, gasPrice *big.Int, value *big.Int, nonce uint64) {
+	t.log.Info("New contract",
+		"From", args.From,
+		"Gas", gas,
+		"GasPrice", gasPrice,
+		"Value", value,
+		"Contract address", crypto.CreateAddress(args.From, nonce),
+	)
 }


### PR DESCRIPTION
This PR adds a method `HashTransaction` use to validate a transaction and geneeate its hash. 
The hash will be sent to the keycard to be signed, and the signature will be sent to `SendTransactionWithSignature`.