### PR TITLE
Unregister request if whisper failed to send it

### DIFF
--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -279,6 +279,7 @@ func (api *PublicAPI) RequestMessages(_ context.Context, r MessagesRequest) (hex
 		return nil, err
 	}
 	hash := envelope.Hash()
+
 	if !r.Force {
 		err = api.service.requestsRegistry.Register(hash, r.Topics)
 		if err != nil {
@@ -287,8 +288,12 @@ func (api *PublicAPI) RequestMessages(_ context.Context, r MessagesRequest) (hex
 	}
 
 	if err := shh.RequestHistoricMessagesWithTimeout(mailServerNode.ID().Bytes(), envelope, r.Timeout*time.Second); err != nil {
+		if !r.Force {
+			api.service.requestsRegistry.Unregister(hash)
+		}
 		return nil, err
 	}
+
 	return hash[:], nil
 }
 

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -278,6 +278,23 @@ func (s *ShhExtSuite) TestMultipleRequestMessagesWithoutForce() {
 	}))
 }
 
+func (s *ShhExtSuite) TestFailedRequestUnregistered() {
+	waitErr := helpers.WaitForPeerAsync(s.nodes[0].Server(), s.nodes[1].Server().Self().String(), p2p.PeerEventTypeAdd, time.Second)
+	s.nodes[0].Server().AddPeer(s.nodes[1].Server().Self())
+	s.Require().NoError(<-waitErr)
+	client, err := s.nodes[0].Attach()
+	topics := []whisper.TopicType{{1}}
+	s.NoError(err)
+	s.EqualError(client.Call(nil, "shhext_requestMessages", MessagesRequest{
+		MailServerPeer: "enode://19872f94b1e776da3a13e25afa71b47dfa99e658afd6427ea8d6e03c22a99f13590205a8826443e95a37eee1d815fc433af7a8ca9a8d0df7943d1f55684045b7@0.0.0.0:30305",
+		Topics:         topics,
+	}), "Could not find peer with ID: 10841e6db5c02fc331bf36a8d2a9137a1696d9d3b6b1f872f780e02aa8ec5bba")
+	s.NoError(client.Call(nil, "shhext_requestMessages", MessagesRequest{
+		MailServerPeer: s.nodes[1].Server().Self().String(),
+		Topics:         topics,
+	}))
+}
+
 func (s *ShhExtSuite) TestRequestMessagesSuccess() {
 	var err error
 


### PR DESCRIPTION
This fixes an issue when 2nd request is made right after first one returned error.

It doesn't prevent an issue when two concurrent requests are made, and the first request has an invalid mail server. In case of the concurrent requests it may happen that first one will fail with whisper error and second will be rate limited.
