### PR TITLE
Fix deadlock in mailserver DeliverMail method

### DIFF
--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -295,6 +295,7 @@ func (s *WMailServer) DeliverMail(peer *whisper.Peer, request *whisper.Envelope)
 		iter,
 		bloom,
 		int(limit),
+		time.Minute,
 		bundles,
 		cancelProcessing,
 	)
@@ -369,6 +370,7 @@ func (s *WMailServer) SyncMail(peer *whisper.Peer, request whisper.SyncMailReque
 		iter,
 		request.Bloom,
 		int(request.Limit),
+		time.Minute,
 		bundles,
 		cancelProcessing,
 	)
@@ -450,6 +452,7 @@ func (s *WMailServer) processRequestInBundles(
 	iter iterator.Iterator,
 	bloom []byte,
 	limit int,
+	timeout time.Duration,
 	output chan<- []*whisper.Envelope,
 	cancel <-chan struct{},
 ) ([]byte, common.Hash) {
@@ -551,7 +554,7 @@ func (s *WMailServer) processRequestInBundles(
 			log.Error("[mailserver:processRequestInBundles] failed to push all batches",
 				"requestID", requestID)
 			break
-		case <-time.After(time.Minute):
+		case <-time.After(timeout):
 			log.Error("[mailserver:processRequestInBundles] timed out pushing a batch",
 				"requestID", requestID)
 			break

--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -51,6 +51,7 @@ const (
 	timestampLength        = 4
 	requestLimitLength     = 4
 	requestTimeRangeLength = timestampLength * 2
+	processRequestTimeout  = time.Minute
 )
 
 // dbImpl is an interface introduced to be able to test some unexpected
@@ -295,7 +296,7 @@ func (s *WMailServer) DeliverMail(peer *whisper.Peer, request *whisper.Envelope)
 		iter,
 		bloom,
 		int(limit),
-		time.Minute,
+		processRequestTimeout,
 		bundles,
 		cancelProcessing,
 	)
@@ -370,7 +371,7 @@ func (s *WMailServer) SyncMail(peer *whisper.Peer, request whisper.SyncMailReque
 		iter,
 		request.Bloom,
 		int(request.Limit),
-		time.Minute,
+		processRequestTimeout,
 		bundles,
 		cancelProcessing,
 	)
@@ -551,7 +552,7 @@ func (s *WMailServer) processRequestInBundles(
 		// the consumer of `output` channel exits prematurely.
 		// In such a case, we should stop pushing batches and exit.
 		case <-cancel:
-			log.Error("[mailserver:processRequestInBundles] failed to push all batches",
+			log.Info("[mailserver:processRequestInBundles] failed to push all batches",
 				"requestID", requestID)
 			break
 		case <-time.After(timeout):

--- a/mailserver/mailserver_test.go
+++ b/mailserver/mailserver_test.go
@@ -651,7 +651,7 @@ func processRequestAndCollectHashes(
 		close(done)
 	}()
 
-	cursor, lastHash := server.processRequestInBundles(iter, bloom, limit, bundles)
+	cursor, lastHash := server.processRequestInBundles(iter, bloom, limit, bundles, done)
 
 	<-done
 


### PR DESCRIPTION
Fix an issue where `DeliverMail()` method could get into a deadlock when the connection with a peer was dropped but there was more bundles to deliver than buffered channel could store. In such a case, `WMailServer.processRequestInBundles()` would never return.