### PR TITLE
declare all parameters, fix names of files on release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,6 @@ release:
 
 gomobile-install:
 	go get -u golang.org/x/mobile/cmd/gomobile
-	gomobile init
 
 release-install:
 	go get -u github.com/c4milo/github-release

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -2,10 +2,15 @@ pipeline {
   agent { label 'linux' }
 
   parameters {
+    string(
+      name: 'BRANCH',
+      defaultValue: 'develop',
+      description: 'Name of branch to build.'
+    )
     booleanParam(
       name: 'RELEASE',
-      description: 'Enable to create a new release on GitHub and DigitalOcean Space.',
       defaultValue: false,
+      description: 'Enable to create a new release on GitHub and DigitalOcean Space.',
     )
   }
 

--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -1,6 +1,19 @@
 pipeline {
   agent { label 'linux' }
 
+  parameters {
+    string(
+      name: 'BRANCH',
+      defaultValue: 'develop',
+      description: 'Name of branch to build.'
+    )
+    booleanParam(
+      name: 'RELEASE',
+      defaultValue: false,
+      description: 'Enable to create build for release.',
+    )
+  }
+
   options {
     timestamps()
     disableConcurrentBuilds()

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -1,6 +1,19 @@
 pipeline {
   agent { label 'macos' }
 
+  parameters {
+    string(
+      name: 'BRANCH',
+      defaultValue: 'develop',
+      description: 'Name of branch to build.'
+    )
+    booleanParam(
+      name: 'RELEASE',
+      defaultValue: false,
+      description: 'Enable to create build for release.',
+    )
+  }
+
   options {
     timestamps()
     disableConcurrentBuilds()

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -1,6 +1,19 @@
 pipeline {
   agent { label 'linux' }
 
+  parameters {
+    string(
+      name: 'BRANCH',
+      defaultValue: 'develop',
+      description: 'Name of branch to build.'
+    )
+    booleanParam(
+      name: 'RELEASE',
+      defaultValue: false,
+      description: 'Enable to create build for release.',
+    )
+  }
+
   options {
     timestamps()
     disableConcurrentBuilds()

--- a/_assets/ci/lib.groovy
+++ b/_assets/ci/lib.groovy
@@ -62,8 +62,10 @@ def buildBranch(name = null, buildType = null) {
     /* this allows us to analize the job even after failure */
     propagate: false,
     parameters: [
-      [name: 'BRANCH',     value: branchName,    $class: 'StringParameterValue'],
-  ])
+      [name: 'BRANCH',  value: branchName,     $class: 'StringParameterValue'],
+      [name: 'RELEASE', value: params.RELEASE, $class: 'BooleanParameterValue'],
+    ]
+  )
   /* BlueOcean seems to not show child-build links */
   println "Build: ${resp.getAbsoluteUrl()} (${resp.result})"
   if (resp.result != 'SUCCESS') {


### PR DESCRIPTION
Fixes the suffix in `status-go` releases. For example this release build:
https://ci.status.im/job/status-go/job/parallel/347/
Which triggered this build:
https://ci.status.im/job/status-go/job/platforms/job/ios/29/consoleFull
Did not have `RELEASE` parameter passed, which resulted in wrong path being taken here:
https://github.com/status-im/status-go/blob/e88e59002849a3931b78e1558a2a7c58d96d71bf/_assets/ci/lib.groovy#L15-L18
Which named the released file `status-go-ios-190222-092425-cc20f6.zip`, rather than `status-go-ios-0.23.0-beta.2.zip`.