### PR TITLE
fix env variables pointing at android ndk for gomobile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,11 +220,7 @@ release:
 
 gomobile-install:
 	go get -u golang.org/x/mobile/cmd/gomobile
-ifdef NDK_GOMOBILE
-	gomobile init -ndk $(NDK_GOMOBILE)
-else
 	gomobile init
-endif
 
 release-install:
 	go get -u github.com/c4milo/github-release

--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -2,6 +2,8 @@ pipeline {
   agent { label 'linux' }
 
   options {
+    timestamps()
+    disableConcurrentBuilds()
     /* Go requires a certain directory structure */
     checkoutToSubdirectory('src/github.com/status-im/status-go')
     /* manage how many builds we keep */
@@ -19,8 +21,9 @@ pipeline {
     PATH             = "${env.PATH}:${env.GOPATH}/bin"
     ANDROID_HOME     = '/usr/lib/android-sdk'
     ANDROID_SDK_ROOT = '/usr/lib/android-sdk'
-    ANDROID_NDK      = '/usr/lib/android-ndk'
-    ANDROID_NDK_HOME = '/usr/lib/android-ndk'
+    /* gomobile requires a specific NDK version */
+    ANDROID_NDK      = "${env.NDK_GOMOBILE}"
+    ANDROID_NDK_HOME = "${env.NDK_GOMOBILE}"
   }
 
   stages {

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -2,6 +2,8 @@ pipeline {
   agent { label 'macos' }
 
   options {
+    timestamps()
+    disableConcurrentBuilds()
     /* Go requires a certain directory structure */
     checkoutToSubdirectory('src/github.com/status-im/status-go')
     /* manage how many builds we keep */

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -2,6 +2,8 @@ pipeline {
   agent { label 'linux' }
 
   options {
+    timestamps()
+    disableConcurrentBuilds()
     /* Go requires a certain directory structure */
     checkoutToSubdirectory('src/github.com/status-im/status-go')
     /* manage how many builds we keep */


### PR DESCRIPTION
The `NDK_GOMOBILE`  env variable is set for `jenkins` user in CI via Bash profile:
https://github.com/status-im/infra-misc/blob/ba9db5dbf543425cdc01d421dd2175330b3488fa/ansible/roles/jenkins-slave-linux/tasks/user.yml#L22-L26
Also added `disableConcurrentBuilds()` to fix clashing ports in tests run on the same host.