### PR TITLE
Add a method to mobile bindings that allows to dump content of the logs file(s)

### DIFF
--- a/exportlogs/logs.go
+++ b/exportlogs/logs.go
@@ -1,0 +1,34 @@
+package exportlogs
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/status-im/go-ethereum/common/hexutil"
+)
+
+// Log contains actual log content and filename. If content is gzipped Compressed will be set to true.
+type Log struct {
+	Filename   string
+	Content    []byte
+	Compressed bool
+}
+
+// ExportResponse contains all available logs
+type ExportResponse struct {
+	Error string
+	Logs  []Log
+}
+
+// ExportFromBaseFile reads log file and returns its content with some meta.
+// In future can be extended to dump rotated logs.
+func ExportFromBaseFile(logFile string) ExportResponse {
+	data, err := ioutil.ReadFile(logFile)
+	if err != nil {
+		return ExportResponse{Error: fmt.Errorf("error reading file %s: %v", logFile, err).Error()}
+	}
+	return ExportResponse{Logs: []Log{
+		{Filename: logFile, Compressed: false, Content: hexutil.Bytes(data)},
+	}}
+
+}

--- a/exportlogs/logs_test.go
+++ b/exportlogs/logs_test.go
@@ -1,0 +1,30 @@
+package exportlogs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExportLogs(t *testing.T) {
+	tempf, err := ioutil.TempFile("", "test-dump-logs")
+	require.NoError(t, err)
+	logs := "first line\nsecond line\n"
+	n, err := fmt.Fprintf(tempf, logs)
+	require.NoError(t, err)
+	require.Equal(t, len(logs), n)
+	response := ExportFromBaseFile(tempf.Name())
+	require.Empty(t, response.Error)
+	require.Len(t, response.Logs, 1)
+	log := response.Logs[0]
+	require.Equal(t, false, log.Compressed)
+	require.Equal(t, tempf.Name(), log.Filename)
+	require.Equal(t, logs, string(log.Content))
+}
+
+func TestExportLogsNoFileError(t *testing.T) {
+	response := ExportFromBaseFile("doesnt-exist")
+	require.Equal(t, "error reading file doesnt-exist: open doesnt-exist: no such file or directory", response.Error)
+}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -3,6 +3,7 @@ package statusgo
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"unsafe"
@@ -10,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/status-im/status-go/api"
+	"github.com/status-im/status-go/exportlogs"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/profiling"
@@ -459,13 +461,13 @@ func makeJSONResponse(err error) string {
 // SendDataNotification sends push notifications by given tokens.
 // dataPayloadJSON is a JSON string that looks like this:
 // {
-// 	"data": {
-// 		"msg-v2": {
-// 			"from": "0x2cea3bd5", // hash of sender (first 10 characters/4 bytes of sha3 hash)
-// 			"to": "0xb1f89744", // hash of recipient (first 10 characters/4 bytes of sha3 hash)
-// 			"id": "0x872653ad", // message ID hash (first 10 characters/4 bytes of sha3 hash)
-// 		}
-// 	}
+//	"data": {
+//		"msg-v2": {
+//			"from": "0x2cea3bd5", // hash of sender (first 10 characters/4 bytes of sha3 hash)
+//			"to": "0xb1f89744", // hash of recipient (first 10 characters/4 bytes of sha3 hash)
+//			"id": "0x872653ad", // message ID hash (first 10 characters/4 bytes of sha3 hash)
+//		}
+//	}
 // }
 func SendDataNotification(dataPayloadJSON, tokensArray string) (result string) {
 	var (
@@ -565,5 +567,23 @@ func GetContactCode(identity string) string {
 		return makeJSONResponse(err)
 	}
 
+	return string(data)
+}
+
+// ExportNodeLogs reads current node log and returns content to a caller.
+//export ExportNodeLogs
+func ExportNodeLogs() string {
+	node := statusBackend.StatusNode()
+	if node == nil {
+		return makeJSONResponse(errors.New("node is not running"))
+	}
+	config := node.Config()
+	if config == nil {
+		return makeJSONResponse(errors.New("config and log file are not available"))
+	}
+	data, err := json.Marshal(exportlogs.ExportFromBaseFile(config.LogFile))
+	if err != nil {
+		return makeJSONResponse(fmt.Errorf("error marshalling to json: %v", err))
+	}
 	return string(data)
 }


### PR DESCRIPTION
This method allows to read content of the file that is current used for logging and return it's content to a caller. In future this method can be extended to read content of the files that were log rotated, and return compressed content.

It allows to get logs in situation when file system is accessible only by a mobile app.
