### PR TITLE
Redirect log output to mobile system loggers

### DIFF
--- a/logutils/stdhandler.go
+++ b/logutils/stdhandler.go
@@ -1,0 +1,17 @@
+package logutils
+
+import (
+	stdlog "log"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// NewStdHandler returns handler that uses logger from golang std lib.
+func NewStdHandler(fmtr log.Format) log.Handler {
+	return log.FuncHandler(func(r *log.Record) error {
+		line := fmtr.Format(r)
+		// 8 is a number of frames that will be skipped when log is printed.
+		// this is needed to show the file (with line number) where call to a logger was made
+		return stdlog.Output(8, string(line))
+	})
+}

--- a/params/config.go
+++ b/params/config.go
@@ -259,6 +259,9 @@ type NodeConfig struct {
 	// LogEnabled enables the logger
 	LogEnabled bool `json:"LogEnabled"`
 
+	// LogMobileSystem enables log redirection to android/ios system logger.
+	LogMobileSystem bool
+
 	// LogFile is filename where exposed logs get written to
 	LogFile string
 


### PR DESCRIPTION
Gomobile redirects output of the logger from std lib to mobile system loggers. For example in android log of the go application can be viewed with `adb logcat GoLog:I *:S`. 

This change wraps logger from std lib in a log.Handler interface.
sources: https://github.com/golang/mobile/blob/master/internal/mobileinit/mobileinit_android.go