### PR TITLE
add shhext_requestMessagesNew

### DIFF
--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -114,7 +114,7 @@ type MessagesResponse struct {
 
 	// Error indicates that something wrong happened when sending messages
 	// to the requester.
-	Error string `json:"error"`
+	Error error `json:"error"`
 }
 
 // SyncMessagesRequest is a SyncMessages() request payload.
@@ -225,9 +225,7 @@ func (api *PublicAPI) RequestMessagesSync(conf RetryConfig, r MessagesRequest) (
 		mailServerResp, err := waitForExpiredOrCompleted(common.BytesToHash(requestID), events)
 		if err == nil {
 			resp.Cursor = hex.EncodeToString(mailServerResp.Cursor)
-			if mailServerResp.Error != nil {
-				resp.Error = mailServerResp.Error.Error()
-			}
+			resp.Error = mailServerResp.Error
 			return resp, nil
 		}
 		retries++

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -343,7 +343,7 @@ func (api *PublicAPI) RequestMessagesNew(ctx context.Context, r MessagesRequest)
 			}
 			return response, fmt.Errorf("invalid event data type")
 		case <-ctx.Done():
-			return response, ctx.Err()
+			return response, fmt.Errorf("receiving an event took too long")
 		}
 	}
 }


### PR DESCRIPTION
I want to have a method to request historic messages and be it synchronous so that I don't need to listen to signals on my own.

This change adds `shhext_requestMessagesNew` which waits for a proper Whisper events regarding the current request and returns a cursor or an error. This is a new method any none of the existing ones has been been affected.
