### PR TITLE
Remove mock step from ci pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,9 +187,9 @@ endif
 install-os-dependencies:
 	_assets/scripts/install_deps.sh
 
-setup-dev: setup-build install-os-dependencies gen-install ##@other Prepare project for development
+setup-dev: setup-build mock-install install-os-dependencies gen-install ##@other Prepare project for development
 
-setup-build: dep-install lint-install mock-install release-install gomobile-install ##@other Prepare project for build
+setup-build: dep-install lint-install release-install gomobile-install ##@other Prepare project for build
 
 setup: setup-build setup-dev ##@other Prepare project for development and building
 
@@ -286,9 +286,9 @@ lint:
 	@echo "lint"
 	@golangci-lint run ./...
 
-ci: lint mock dep-ensure canary-test test-unit test-e2e ##@tests Run all linters and tests at once
+ci: lint dep-ensure canary-test test-unit test-e2e ##@tests Run all linters and tests at once
 
-ci-race: lint mock dep-ensure canary-test test-unit test-e2e-race ##@tests Run all linters and tests at once + race
+ci-race: lint dep-ensure canary-test test-unit test-e2e-race ##@tests Run all linters and tests at once + race
 
 clean: ##@other Cleanup
 	rm -fr build/bin/*

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -46,10 +46,6 @@ pipeline {
       sh 'make lint'
     } } }
 
-    stage('Mock') { steps { dir(env.STATUS_PATH) {
-      sh 'make mock'
-    } } }
-
     stage('Dep-Ensure') { steps { dir(env.STATUS_PATH) {
       sh 'make dep-ensure'
     } } }


### PR DESCRIPTION
This change allows to run ci without generating mocks. Mocks should be generated during development phase, and there is no need to re-gen them during ci.
