### PR TITLE
[WIP] add mailserver-tools command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,11 @@ node-canary: ##@build Build P2P node canary using status-go deps
 	go build -i -o $(GOBIN)/node-canary -v -tags '$(BUILD_TAGS)' $(BUILD_FLAGS) ./cmd/node-canary/
 	@echo "Compilation done."
 
+mailserver-tools: ##@build Build mailserver-tools
+	go build -i -o $(GOBIN)/mailserver-tools -v -tags '$(BUILD_TAGS)' $(BUILD_FLAGS) ./cmd/mailserver-tools/
+	@echo "Compilation done."
+
+
 statusgo-cross: statusgo-android statusgo-ios
 	@echo "Full cross compilation done."
 	@ls -ld $(GOBIN)/statusgo-*

--- a/cmd/mailserver-tools/README.md
+++ b/cmd/mailserver-tools/README.md
@@ -1,0 +1,8 @@
+MailServer Tools
+================
+
+A collection of mail server related tools.
+
+| Command | Description | Usage |
+|---------|-------------|-------|
+| count | Counts a number of envelopes in a topic | `$ mailserver-tools -dir=./mail-data count -topic-name=contact-discovery` |

--- a/cmd/mailserver-tools/count.go
+++ b/cmd/mailserver-tools/count.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/go-ethereum/rlp"
+	"github.com/status-im/status-go/mailserver"
+	whisper "github.com/status-im/whisper/whisperv6"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+var (
+	emptyHash common.Hash
+)
+
+func countInTopic(db *leveldb.DB, topic whisper.TopicType, start, end time.Time) (int, error) {
+	startKey := mailserver.NewDBKey(uint32(start.Unix()), emptyHash)
+	endKey := mailserver.NewDBKey(uint32(end.Unix()), emptyHash)
+
+	iter := db.NewIterator(&util.Range{Start: startKey.Bytes(), Limit: endKey.Bytes()}, nil)
+	defer iter.Release()
+
+	counter := 0
+
+	for iter.Next() {
+		var envelope whisper.Envelope
+
+		if err := rlp.DecodeBytes(iter.Value(), &envelope); err != nil {
+			return 0, err
+		}
+
+		if topic == envelope.Topic {
+			counter++
+		}
+	}
+
+	return counter, nil
+}
+
+func countLast24HoursInTopic(db *leveldb.DB, topic whisper.TopicType) (int, error) {
+	end := time.Now()
+	start := end.Add(-time.Hour * 24)
+
+	return countInTopic(db, topic, start, end)
+}

--- a/cmd/mailserver-tools/main.go
+++ b/cmd/mailserver-tools/main.go
@@ -59,7 +59,7 @@ func main() {
 		exitErr(err)
 	}
 
-	fmt.Printf("For topic '%s' there are %d envelopes\n", *topicName, counter)
+	fmt.Printf("%d", counter)
 }
 
 func exitErr(err error) {

--- a/cmd/mailserver-tools/main.go
+++ b/cmd/mailserver-tools/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	database "github.com/status-im/status-go/db"
+)
+
+var (
+	global = flag.NewFlagSet("", flag.ExitOnError)
+	dir    = global.String("dir", "", "dir with the mailserver data")
+
+	countCmd  = flag.NewFlagSet("count", flag.ExitOnError)
+	topicName = countCmd.String("topic-name", "", "topic name to count envelopes in ('contact-discovery' for private chats)")
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Println("Usage:")
+		fmt.Println("  mailserver-tools COMMAND")
+		fmt.Println("")
+		fmt.Println("Commands:")
+		fmt.Println("  count: returns a number of envelopes")
+		os.Exit(1)
+	}
+
+	if err := global.Parse(os.Args[1:2]); err != nil {
+		exitErr(err)
+	}
+
+	if *dir == "" {
+		global.PrintDefaults()
+		exitErr(fmt.Errorf("invalid value for -dir: %s", *dir))
+	}
+
+	switch os.Args[2] {
+	case "count":
+		if err := countCmd.Parse(os.Args[3:]); err != nil {
+			exitErr(err)
+		}
+	default:
+		exitErr(fmt.Errorf("invalid command: %s", os.Args[1]))
+	}
+
+	topic, err := nameToTopic(*topicName)
+	if err != nil {
+		exitErr(err)
+	}
+
+	db, err := database.Open(*dir, nil)
+	if err != nil {
+		exitErr(err)
+	}
+
+	counter, err := countLast24HoursInTopic(db, topic)
+	if err != nil {
+		exitErr(err)
+	}
+
+	fmt.Printf("For topic '%s' there are %d envelopes\n", *topicName, counter)
+}
+
+func exitErr(err error) {
+	fmt.Println(err)
+	os.Exit(1)
+}

--- a/cmd/mailserver-tools/topic.go
+++ b/cmd/mailserver-tools/topic.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	whisper "github.com/status-im/whisper/whisperv6"
+	"golang.org/x/crypto/sha3"
+)
+
+func nameToTopic(name string) (whisper.TopicType, error) {
+	hash := sha3.NewLegacyKeccak256()
+	if _, err := hash.Write([]byte(name)); err != nil {
+		return whisper.TopicType{}, err
+	}
+
+	return whisper.BytesToTopic(hash.Sum(nil)), nil
+}


### PR DESCRIPTION
`mailserver-tools` has a command `count` which returns a number of envelopes for a given topic.

We want to have a capability of verifying how new private chats topic splitting works.