### PR TITLE
prefix git tag with v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: statusgo statusd-prune all test clean help
 .PHONY: statusgo-android statusgo-ios
 
-RELEASE_TAG := $(shell cat VERSION)
+RELEASE_TAG := "$(shell cat VERSION)"
 RELEASE_BRANCH := "develop"
 RELEASE_DIRECTORY := /tmp/release-$(RELEASE_TAG)
 PRE_RELEASE := "1"
@@ -215,7 +215,7 @@ release:
 		comparison="$$latest_tag..HEAD"; \
 		if [ -z "$$latest_tag" ]; then comparison=""; fi; \
 		changelog=$$(git log $$comparison --oneline --no-merges --format="* %h %s"); \
-	    github-release $(shell if [ $(PRE_RELEASE) != "0" ] ; then echo "-prerelease" ; fi) "status-im/status-go" "$(RELEASE_TAG)" "$(RELEASE_BRANCH)" "$(changelog)" "$(RELEASE_DIRECTORY)/*" ; \
+	    github-release $(shell if [ $(PRE_RELEASE) != "0" ] ; then echo "-prerelease" ; fi) "status-im/status-go" "v$(RELEASE_TAG)" "$(RELEASE_BRANCH)" "$(changelog)" "$(RELEASE_DIRECTORY)/*" ; \
 	else \
 	    echo "Aborting." && exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: statusgo statusd-prune all test clean help
 .PHONY: statusgo-android statusgo-ios
 
-RELEASE_TAG := "$(shell cat VERSION)"
+RELEASE_TAG := $(shell cat VERSION)
 RELEASE_BRANCH := "develop"
 RELEASE_DIRECTORY := /tmp/release-$(RELEASE_TAG)
 PRE_RELEASE := "1"


### PR DESCRIPTION
In order to use status-go with Go modules, the git tags must start with a letter `v`.
