### PR TITLE
[Chaos Unicorn] Implement ChaosModeSetUpstreamURL to dynamically change the upstream URL

### DIFF
--- a/lib/library.go
+++ b/lib/library.go
@@ -612,8 +612,7 @@ func ExportNodeLogs() *C.char {
 	return C.CString(string(data))
 }
 
-// ChaosModeSetUpstreamURL changes the upstream RPC client URL, if enabled.
-// Additionally, if the custom URL is infura, it changes it to https://httpstat.us/500.
+// ChaosModeSetUpstreamURL changes the URL of the upstream RPC client.
 //export ChaosModeSetUpstreamURL
 func ChaosModeSetUpstreamURL(url *C.char) *C.char {
 	node := statusBackend.StatusNode()

--- a/lib/library.go
+++ b/lib/library.go
@@ -611,3 +611,16 @@ func ExportNodeLogs() *C.char {
 	}
 	return C.CString(string(data))
 }
+
+// ChaosModeSetUpstreamURL changes the upstream RPC client URL, if enabled.
+// Additionally, if the custom URL is infura, it changes it to https://httpstat.us/500.
+//export ChaosModeSetUpstreamURL
+func ChaosModeSetUpstreamURL(url *C.char) *C.char {
+	node := statusBackend.StatusNode()
+	if node == nil {
+		return makeJSONResponse(errors.New("node is not running"))
+	}
+
+	err := node.ChaosModeChangeRPCClientsUpstreamURL(C.GoString(url))
+	return makeJSONResponse(err)
+}

--- a/lib/library.go
+++ b/lib/library.go
@@ -612,14 +612,14 @@ func ExportNodeLogs() *C.char {
 	return C.CString(string(data))
 }
 
-// ChaosModeSetUpstreamURL changes the URL of the upstream RPC client.
-//export ChaosModeSetUpstreamURL
-func ChaosModeSetUpstreamURL(url *C.char) *C.char {
+// ChaosModeUpdate changes the URL of the upstream RPC client.
+//export ChaosModeUpdate
+func ChaosModeUpdate(on C.int) *C.char {
 	node := statusBackend.StatusNode()
 	if node == nil {
 		return makeJSONResponse(errors.New("node is not running"))
 	}
 
-	err := node.ChaosModeChangeRPCClientsUpstreamURL(C.GoString(url))
+	err := node.ChaosModeCheckRPCClientsUpstreamURL(on == 1)
 	return makeJSONResponse(err)
 }

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"unsafe"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -603,4 +604,20 @@ func ExportNodeLogs() string {
 		return makeJSONResponse(fmt.Errorf("error marshalling to json: %v", err))
 	}
 	return string(data)
+}
+
+// ChaosModeSetUpstreamURL changes the upstream RPC client URL, if enabled.
+// Additionally, if the custom URL is infura, it changes it to https://httpstat.us/500.
+func ChaosModeSetUpstreamURL(url string) string {
+	if strings.Contains(url, "infura.io") {
+		url = "https://httpstat.us/500"
+	}
+
+	node := statusBackend.StatusNode()
+	if node == nil {
+		return makeJSONResponse(errors.New("node is not running"))
+	}
+
+	err := node.ChangeRPCClientsUpstreamURL(url)
+	return makeJSONResponse(err)
 }

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -605,8 +605,7 @@ func ExportNodeLogs() string {
 	return string(data)
 }
 
-// ChaosModeSetUpstreamURL changes the upstream RPC client URL, if enabled.
-// Additionally, if the custom URL is infura, it changes it to https://httpstat.us/500.
+// ChaosModeSetUpstreamURL changes the URL of the upstream RPC client.
 func ChaosModeSetUpstreamURL(url string) string {
 	node := statusBackend.StatusNode()
 	if node == nil {

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"unsafe"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -609,15 +608,11 @@ func ExportNodeLogs() string {
 // ChaosModeSetUpstreamURL changes the upstream RPC client URL, if enabled.
 // Additionally, if the custom URL is infura, it changes it to https://httpstat.us/500.
 func ChaosModeSetUpstreamURL(url string) string {
-	if strings.Contains(url, "infura.io") {
-		url = "https://httpstat.us/500"
-	}
-
 	node := statusBackend.StatusNode()
 	if node == nil {
 		return makeJSONResponse(errors.New("node is not running"))
 	}
 
-	err := node.ChangeRPCClientsUpstreamURL(url)
+	err := node.ChaosModeChangeRPCClientsUpstreamURL(url)
 	return makeJSONResponse(err)
 }

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -605,13 +605,13 @@ func ExportNodeLogs() string {
 	return string(data)
 }
 
-// ChaosModeSetUpstreamURL changes the URL of the upstream RPC client.
-func ChaosModeSetUpstreamURL(url string) string {
+// ChaosModeUpdate sets the Chaos Mode on or off.
+func ChaosModeUpdate(on bool) string {
 	node := statusBackend.StatusNode()
 	if node == nil {
 		return makeJSONResponse(errors.New("node is not running"))
 	}
 
-	err := node.ChaosModeChangeRPCClientsUpstreamURL(url)
+	err := node.ChaosModeCheckRPCClientsUpstreamURL(on)
 	return makeJSONResponse(err)
 }

--- a/node/status_node.go
+++ b/node/status_node.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -639,10 +640,14 @@ func (n *StatusNode) RPCPrivateClient() *rpc.Client {
 	return n.rpcPrivateClient
 }
 
-// ChangeRPCClientsUpstreamURL updates RPCClient and RPCPrivateClient upstream URLs,
-// if defined, without restarting the node.
-// This is required for the Chaos Unicorn Day
-func (n *StatusNode) ChangeRPCClientsUpstreamURL(url string) error {
+// ChaosModeChangeRPCClientsUpstreamURL updates RPCClient and RPCPrivateClient upstream URLs,
+// if defined, without restarting the node. This is required for the Chaos Unicorn Day.
+// Additionally, if the passed URL is Infura, it changes it to httpstat.us/500.
+func (n *StatusNode) ChaosModeChangeRPCClientsUpstreamURL(url string) error {
+	if strings.Contains(url, "infura.io") {
+		url = "https://httpstat.us/500"
+	}
+
 	publicClient := n.RPCClient()
 	if publicClient != nil {
 		if err := publicClient.UpdateUpstreamURL(url); err != nil {

--- a/node/status_node.go
+++ b/node/status_node.go
@@ -639,6 +639,27 @@ func (n *StatusNode) RPCPrivateClient() *rpc.Client {
 	return n.rpcPrivateClient
 }
 
+// ChangeRPCClientsUpstreamURL updates RPCClient and RPCPrivateClient upstream URLs,
+// if defined, without restarting the node.
+// This is required for the Chaos Unicorn Day
+func (n *StatusNode) ChangeRPCClientsUpstreamURL(url string) error {
+	publicClient := n.RPCClient()
+	if publicClient != nil {
+		if err := publicClient.UpdateUpstreamURL(url); err != nil {
+			return err
+		}
+	}
+
+	privateClient := n.RPCPrivateClient()
+	if privateClient != nil {
+		if err := privateClient.UpdateUpstreamURL(url); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // EnsureSync waits until blockchain synchronization
 // is complete and returns.
 func (n *StatusNode) EnsureSync(ctx context.Context) error {

--- a/node/status_node.go
+++ b/node/status_node.go
@@ -640,12 +640,16 @@ func (n *StatusNode) RPCPrivateClient() *rpc.Client {
 	return n.rpcPrivateClient
 }
 
-// ChaosModeChangeRPCClientsUpstreamURL updates RPCClient and RPCPrivateClient upstream URLs,
+// ChaosModeCheckRPCClientsUpstreamURL updates RPCClient and RPCPrivateClient upstream URLs,
 // if defined, without restarting the node. This is required for the Chaos Unicorn Day.
 // Additionally, if the passed URL is Infura, it changes it to httpstat.us/500.
-func (n *StatusNode) ChaosModeChangeRPCClientsUpstreamURL(url string) error {
-	if strings.Contains(url, "infura.io") {
-		url = "https://httpstat.us/500"
+func (n *StatusNode) ChaosModeCheckRPCClientsUpstreamURL(on bool) error {
+	url := n.config.UpstreamConfig.URL
+
+	if on {
+		if strings.Contains(url, "infura.io") {
+			url = "https://httpstat.us/500"
+		}
 	}
 
 	publicClient := n.RPCClient()

--- a/node/status_node_test.go
+++ b/node/status_node_test.go
@@ -368,9 +368,11 @@ func TestChaosModeChangeRPCClientsUpstreamURL(t *testing.T) {
 	err = client.Call(nil, "net_version")
 	require.NoError(t, err)
 
+	// act
 	err = n.ChaosModeChangeRPCClientsUpstreamURL(params.MainnetEthereumNetworkURL)
 	require.NoError(t, err)
-	// not it should errored as 500 is always returned
+
+	// assert
 	err = client.Call(nil, "net_version")
 	require.EqualError(t, err, `500 Internal Server Error "500 Internal Server Error"`)
 }

--- a/node/status_node_test.go
+++ b/node/status_node_test.go
@@ -363,9 +363,7 @@ func TestChaosModeChangeRPCClientsUpstreamURL(t *testing.T) {
 	client := n.RPCClient()
 	require.NotNil(t, client)
 
-	var err error
-
-	err = client.Call(nil, "net_version")
+	err := client.Call(nil, "net_version")
 	require.NoError(t, err)
 
 	// act


### PR DESCRIPTION
The upstream URL of the RPC client can be changed dynamically without restarting the node. This is needed to properly simulate Infura being down during Chaos Unicorn Day.
