### PR TITLE
Notify users that envelope was discarded and retry sending it

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -830,12 +830,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  branch = "messages-response-with-errors"
   digest = "1:ff23c911716ddbe23acccecf0a88bb99e89132b221a3be8dbad6a8377fd6f3a0"
   name = "github.com/status-im/whisper"
   packages = ["whisperv6"]
   pruneopts = "NUT"
-  revision = "e24f0a42ab864746c8550d724499dcc9f0d5f6f5"
+  revision = "3a4601b568649ac152afa76551ea9c332464b867"
+  version = "v1.4.10"
 
 [[projects]]
   digest = "1:572c783a763db6383aca3179976eb80e4c900f52eba56cba8bb2e3cea7ce720e"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -830,12 +830,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:684e59281a3fd4a35437992b008f43f98a0cf5b25cde717397325b10f94ea69c"
+  branch = "messages-response-with-errors"
+  digest = "1:ff23c911716ddbe23acccecf0a88bb99e89132b221a3be8dbad6a8377fd6f3a0"
   name = "github.com/status-im/whisper"
   packages = ["whisperv6"]
   pruneopts = "NUT"
-  revision = "f60fda29e21f802bc20bc20b4924dc22fe8a0514"
-  version = "v1.4.9"
+  revision = "e24f0a42ab864746c8550d724499dcc9f0d5f6f5"
 
 [[projects]]
   digest = "1:572c783a763db6383aca3179976eb80e4c900f52eba56cba8bb2e3cea7ce720e"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,7 +46,7 @@
 
 [[constraint]]
   name = "github.com/status-im/whisper"
-  branch = "messages-response-with-errors"
+  version = "=v1.4.10"
 
 [[constraint]]
   name = "golang.org/x/text"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,7 +46,7 @@
 
 [[constraint]]
   name = "github.com/status-im/whisper"
-  version = "=v1.4.9"
+  branch = "messages-response-with-errors"
 
 [[constraint]]
   name = "golang.org/x/text"

--- a/services/shhext/envelopes.go
+++ b/services/shhext/envelopes.go
@@ -195,8 +195,8 @@ func (m *EnvelopesMonitor) handleAcknowledgedBatch(event whisper.EnvelopeEvent) 
 	}
 	log.Debug("received a confirmation", "batch", event.Batch, "peer", event.Peer)
 	envelopeErrors, ok := event.Data.([]whisper.EnvelopeError)
-	if !ok {
-		log.Error("received unexpected data in the the confirmation event", "batch", event.Batch)
+	if event.Data != nil && !ok {
+		log.Warn("received unexpected data for the confirmation event", "batch", event.Batch)
 	}
 	failedEnvelopes := map[common.Hash]struct{}{}
 	for i := range envelopeErrors {

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -34,7 +34,7 @@ var errProtocolNotInitialized = errors.New("procotol is not initialized")
 // EnvelopeEventsHandler used for two different event types.
 type EnvelopeEventsHandler interface {
 	EnvelopeSent(common.Hash)
-	EnvelopeExpired(common.Hash)
+	EnvelopeExpired(common.Hash, error)
 	MailServerRequestCompleted(common.Hash, common.Hash, []byte, error)
 	MailServerRequestExpired(common.Hash)
 }

--- a/services/shhext/signal.go
+++ b/services/shhext/signal.go
@@ -14,8 +14,8 @@ func (h EnvelopeSignalHandler) EnvelopeSent(hash common.Hash) {
 }
 
 // EnvelopeExpired triggered when envelope is expired but wasn't delivered to any peer.
-func (h EnvelopeSignalHandler) EnvelopeExpired(hash common.Hash) {
-	signal.SendEnvelopeExpired(hash)
+func (h EnvelopeSignalHandler) EnvelopeExpired(hash common.Hash, err error) {
+	signal.SendEnvelopeExpired(hash, err)
 }
 
 // MailServerRequestCompleted triggered when the mailserver sends a message to notify that the request has been completed

--- a/signal/events_shhext.go
+++ b/signal/events_shhext.go
@@ -14,9 +14,6 @@ const (
 	// to any peer
 	EventEnvelopeExpired = "envelope.expired"
 
-	// EventEnvelopeDiscarded is triggerd when envelope was discarded by a peer for some reason.
-	EventEnvelopeDiscarded = "envelope.discarded"
-
 	// EventMailServerRequestCompleted is triggered when whisper receives a message ack from the mailserver
 	EventMailServerRequestCompleted = "mailserver.request.completed"
 

--- a/signal/events_shhext.go
+++ b/signal/events_shhext.go
@@ -14,6 +14,9 @@ const (
 	// to any peer
 	EventEnvelopeExpired = "envelope.expired"
 
+	// EventEnvelopeDiscarded is triggerd when envelope was discarded by a peer for some reason.
+	EventEnvelopeDiscarded = "envelope.discarded"
+
 	// EventMailServerRequestCompleted is triggered when whisper receives a message ack from the mailserver
 	EventMailServerRequestCompleted = "mailserver.request.completed"
 
@@ -32,7 +35,8 @@ const (
 
 // EnvelopeSignal includes hash of the envelope.
 type EnvelopeSignal struct {
-	Hash common.Hash `json:"hash"`
+	Hash    common.Hash `json:"hash"`
+	Message string      `json:"message"`
 }
 
 // MailServerResponseSignal holds the data received in the response from the mailserver.
@@ -56,12 +60,16 @@ type BundleAddedSignal struct {
 
 // SendEnvelopeSent triggered when envelope delivered at least to 1 peer.
 func SendEnvelopeSent(hash common.Hash) {
-	send(EventEnvelopeSent, EnvelopeSignal{hash})
+	send(EventEnvelopeSent, EnvelopeSignal{Hash: hash})
 }
 
 // SendEnvelopeExpired triggered when envelope delivered at least to 1 peer.
-func SendEnvelopeExpired(hash common.Hash) {
-	send(EventEnvelopeExpired, EnvelopeSignal{hash})
+func SendEnvelopeExpired(hash common.Hash, err error) {
+	var message string
+	if err != nil {
+		message = err.Error()
+	}
+	send(EventEnvelopeExpired, EnvelopeSignal{Hash: hash, Message: message})
 }
 
 // SendMailServerRequestCompleted triggered when mail server response has been received
@@ -81,7 +89,7 @@ func SendMailServerRequestCompleted(requestID common.Hash, lastEnvelopeHash comm
 
 // SendMailServerRequestExpired triggered when mail server request expires
 func SendMailServerRequestExpired(hash common.Hash) {
-	send(EventMailServerRequestExpired, EnvelopeSignal{hash})
+	send(EventMailServerRequestExpired, EnvelopeSignal{Hash: hash})
 }
 
 // EnodeDiscoveredSignal includes enode address and topic


### PR DESCRIPTION
Changes in the whisper that enable this feature: https://github.com/status-im/whisper/pull/23

After some experimentation i decided to extend existing signal. This signal will be extended with a Message keyword. When we receive error from a peer that envelope was discarded because of the time sync issue - Message will be populated with appropriate error.

So, basically from the client perspective this change doesn't introduce any new steps in the flow of signals. Client still waits for an ExpiredSignal. But now we can provide more feedback why certain envelopes weren't delivered.

