### PR TITLE
add Jenkinsfile.docker for pushing new images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,9 @@ push-docker-images: docker-image bootnode-image
 	docker push $(BOOTNODE_IMAGE_NAME):$(DOCKER_IMAGE_CUSTOM_TAG)
 	docker push $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_CUSTOM_TAG)
 
+clean-docker-images:
+	docker rmi -f $(shell docker image ls --filter="reference=$(DOCKER_IMAGE_NAME)" --quiet)
+
 # See https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html to understand this magic.
 push-docker-images-latest: GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 push-docker-images-latest: GIT_LOCAL  = $(shell git rev-parse @)

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -61,6 +61,9 @@ pipeline {
         stage('Linux') { steps { script {
           linux = lib.buildBranch('status-go/platforms/linux')
         } } }
+        stage('Docker') { steps { script {
+          linux = lib.buildBranch('status-go/platforms/docker')
+        } } }
       } // parallel
     } // stage(Build)
 

--- a/_assets/ci/Jenkinsfile.docker
+++ b/_assets/ci/Jenkinsfile.docker
@@ -1,0 +1,75 @@
+pipeline {
+  agent { label 'linux' }
+
+  parameters {
+    string(
+      name: 'BRANCH',
+      defaultValue: 'develop',
+      description: 'Name of branch to build.'
+    )
+    booleanParam(
+      name: 'RELEASE',
+      defaultValue: false,
+      description: 'Enable to create build for release.',
+    )
+  }
+
+  options {
+    timestamps()
+    disableConcurrentBuilds()
+    /* Go requires a certain directory structure */
+    checkoutToSubdirectory('src/github.com/status-im/status-go')
+    /* manage how many builds we keep */
+    buildDiscarder(logRotator(
+      numToKeepStr: '30',
+      daysToKeepStr: '30',
+    ))
+  }
+
+  environment {
+    STATUS_PATH = 'src/github.com/status-im/status-go'
+    CI_DIR      = "${env.STATUS_PATH}/_assets/ci"
+    GOPATH      = "${env.WORKSPACE}"
+    PATH        = "${env.PATH}:${env.GOPATH}/bin"
+    /* docker image settings */
+    IMAGE_NAME  = "statusteam/status-go"
+    IMAGE_TAG   = "deploy-test"
+  }
+
+  stages {
+    stage('Prep') { steps { script {
+      lib = load("${env.STATUS_PATH}/_assets/ci/lib.groovy")
+      /* clarify what we're building */
+      println("Version: ${lib.getVersion()}")
+      println("Git Branch: ${lib.gitBranch()}")
+      println("Git Commit: ${lib.gitCommit()}")
+      /* save and create a dir for artifacts */
+      dest = "${env.WORKSPACE}/pkg"
+      sh "mkdir -p ${dest}"
+    } } }
+
+    stage('Build') { steps { dir(env.STATUS_PATH) { script {
+      sh 'make docker-image'
+      image = docker.image("${env.IMAGE_NAME}:${lib.getVersion()}")
+    } } } }
+
+    stage('Push') { steps { dir(env.STATUS_PATH) { script {
+      withDockerRegistry([credentialsId: "dockerhub-statusteam-auto", url: ""]) {
+        image.push()
+      }
+    } } } }
+
+    stage('Deploy') {
+      when { expression { params.RELEASE == true } }
+      steps { dir(env.STATUS_PATH) { script {
+        withDockerRegistry([credentialsId: "dockerhub-statusteam-auto", url: ""]) {
+          image.push(env.IMAGE_TAG)
+        }
+    } } } }
+  } // stages
+  post {
+    always  { dir(env.STATUS_PATH) { sh 'make clean-docker-images' } }
+    success { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(true) } }
+    failure { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(false) } }
+  } // post
+} // pipeline

--- a/_assets/ci/lib.groovy
+++ b/_assets/ci/lib.groovy
@@ -1,5 +1,5 @@
 def getVersion() {
-  return readFile("${env.STATUS_PATH}/VERSION").trim()
+  return readFile("${env.WORKSPACE}/${env.STATUS_PATH}/VERSION").trim()
 }
 
 def gitCommit() {
@@ -13,7 +13,7 @@ def timestamp() {
 
 def suffix() {
   if (params.RELEASE == true) {
-    return readFile("${env.WORKSPACE}/${env.STATUS_PATH}/VERSION").trim()
+    return getVersion()
   } else {
     return "${timestamp()}-${gitCommit()}"
   }


### PR DESCRIPTION
This provides a feature requested by  #1325 by adding `Jenkinsfile.docker` which by default builds a docker image and pushes it under a tag based of off contents of the `VERSION` file.
If the `RELEASE` checkbox is selected then it also pushes under the `deploy-test` tag to deploy the newly built image to the `eth.test` cluster.