### PR TITLE
unset TMPDIR, otherwise go get fails

### DIFF
--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -49,7 +49,7 @@ pipeline {
     } } }
 
     stage('Setup') { steps { dir(env.STATUS_PATH) {
-      sh 'make setup-build'
+      sh 'unset TMPDIR && make setup-build'
     } } }
 
     stage('Compile') { steps { dir(env.STATUS_PATH) {


### PR DESCRIPTION
Possible fix for new failues in iOS builds:
```logs
+ make setup-build
go get -u github.com/golang/dep/cmd/dep
curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /Users/jenkins/workspace/status-go/platforms/ios/bin v1.10.2
golangci/golangci-lint info checking GitHub for tag 'v1.10.2'
golangci/golangci-lint info found version: 1.10.2 for v1.10.2/darwin/amd64
golangci/golangci-lint info installed /Users/jenkins/workspace/status-go/platforms/ios/bin/golangci-lint
rm: /var/folders/sn/6fj1hwmd11zdtjk4f5skyj2w0000gp/T//tmp.Znf4Xqpd/.fseventsd: Permission denied
rm: /var/folders/sn/6fj1hwmd11zdtjk4f5skyj2w0000gp/T//tmp.Znf4Xqpd: Resource busy
rm: /var/folders/sn/6fj1hwmd11zdtjk4f5skyj2w0000gp/T/: Operation not permitted
make: *** [lint-install] Error 1
```
https://ci.status.im/job/status-go/job/platforms/job/ios/68/