### PR TITLE
don't overwrite linux build variable with docker build

### DIFF
--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
           linux = lib.buildBranch('status-go/platforms/linux')
         } } }
         stage('Docker') { steps { script {
-          linux = lib.buildBranch('status-go/platforms/docker')
+          dock = lib.buildBranch('status-go/platforms/docker')
         } } }
       } // parallel
     } // stage(Build)


### PR DESCRIPTION
Forgot to rename variable and Docker build overwrote Linux build variable in effect braking `Archive` stage.