### PR TITLE
Add history requests that allow to skip already received data

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -33,21 +33,22 @@ func NewMemoryDB() (*leveldb.DB, error) {
 	return leveldb.Open(storage.NewMemStorage(), nil)
 }
 
-// NewIsolatedDB returns instance that ensures isolated operations.
-func NewIsolatedDB(db *leveldb.DB, prefix storagePrefix) PrefixedLevelDB {
-	return PrefixedLevelDB{
+// NewDBNamespace returns instance that ensures isolated operations.
+func NewDBNamespace(db *leveldb.DB, prefix storagePrefix) LevelDBNamespace {
+	return LevelDBNamespace{
 		db:     db,
 		prefix: prefix,
 	}
 }
 
-// NewIsolatedMemoryDB wraps in memory leveldb with provided bucket.
-func NewIsolatedMemoryDB(prefix storagePrefix) (pdb PrefixedLevelDB, err error) {
+// NewMemoryDBNamespace wraps in memory leveldb with provided bucket.
+// Mostly used for tests. Including tests in other packages.
+func NewMemoryDBNamespace(prefix storagePrefix) (pdb LevelDBNamespace, err error) {
 	db, err := NewMemoryDB()
 	if err != nil {
 		return pdb, err
 	}
-	return NewIsolatedDB(db, prefix), nil
+	return NewDBNamespace(db, prefix), nil
 }
 
 // Key creates a DB key for a specified service with specified data
@@ -88,30 +89,30 @@ func Open(path string, opts *opt.Options) (db *leveldb.DB, err error) {
 	return
 }
 
-// PrefixedLevelDB database where all operations will be prefixed with a certain bucket.
-type PrefixedLevelDB struct {
+// LevelDBNamespace database where all operations will be prefixed with a certain bucket.
+type LevelDBNamespace struct {
 	db     *leveldb.DB
 	prefix storagePrefix
 }
 
-func (db PrefixedLevelDB) prefixedKey(key []byte) []byte {
+func (db LevelDBNamespace) prefixedKey(key []byte) []byte {
 	endkey := make([]byte, len(key)+1)
 	endkey[0] = byte(db.prefix)
 	copy(endkey[1:], key)
 	return endkey
 }
 
-func (db PrefixedLevelDB) Put(key, value []byte) error {
+func (db LevelDBNamespace) Put(key, value []byte) error {
 	return db.db.Put(db.prefixedKey(key), value, nil)
 }
 
-func (db PrefixedLevelDB) Get(key []byte) ([]byte, error) {
+func (db LevelDBNamespace) Get(key []byte) ([]byte, error) {
 	return db.db.Get(db.prefixedKey(key), nil)
 }
 
 // Range returns leveldb util.Range prefixed with a single byte.
 // If prefix is nil range will iterate over all records in a given bucket.
-func (db PrefixedLevelDB) Range(prefix, limit []byte) *util.Range {
+func (db LevelDBNamespace) Range(prefix, limit []byte) *util.Range {
 	if limit == nil {
 		return util.BytesPrefix(db.prefixedKey(prefix))
 	}
@@ -119,42 +120,42 @@ func (db PrefixedLevelDB) Range(prefix, limit []byte) *util.Range {
 }
 
 // Delete removes key from database.
-func (db PrefixedLevelDB) Delete(key []byte) error {
+func (db LevelDBNamespace) Delete(key []byte) error {
 	return db.db.Delete(db.prefixedKey(key), nil)
 }
 
 // NewIterator returns iterator for a given slice.
-func (db PrefixedLevelDB) NewIterator(slice *util.Range) PrefixedIterator {
-	return PrefixedIterator{db.db.NewIterator(slice, nil)}
+func (db LevelDBNamespace) NewIterator(slice *util.Range) NamespaceIterator {
+	return NamespaceIterator{db.db.NewIterator(slice, nil)}
 }
 
-// PrefixedIterator wraps leveldb iterator, works mostly the same way.
+// NamespaceIterator wraps leveldb iterator, works mostly the same way.
 // The only difference is that first byte of the key is dropped.
-type PrefixedIterator struct {
+type NamespaceIterator struct {
 	iter iterator.Iterator
 }
 
 // Key returns key of the current item.
-func (iter PrefixedIterator) Key() []byte {
+func (iter NamespaceIterator) Key() []byte {
 	return iter.iter.Key()[1:]
 }
 
 // Value returns actual value of the current item.
-func (iter PrefixedIterator) Value() []byte {
+func (iter NamespaceIterator) Value() []byte {
 	return iter.iter.Value()
 }
 
 // Error returns accumulated error.
-func (iter PrefixedIterator) Error() error {
+func (iter NamespaceIterator) Error() error {
 	return iter.iter.Error()
 }
 
 // Prev moves cursor backward.
-func (iter PrefixedIterator) Prev() bool {
+func (iter NamespaceIterator) Prev() bool {
 	return iter.iter.Prev()
 }
 
 // Next moves cursor forward.
-func (iter PrefixedIterator) Next() bool {
+func (iter NamespaceIterator) Next() bool {
 	return iter.iter.Next()
 }

--- a/db/db.go
+++ b/db/db.go
@@ -6,8 +6,10 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 type storagePrefix byte
@@ -20,7 +22,33 @@ const (
 	DeduplicatorCache
 	// MailserversCache is a list of mail servers provided by users.
 	MailserversCache
+	// TopicHistoryBucket isolated bucket for storing history metadata.
+	TopicHistoryBucket
+	// HistoryRequestBucket isolated bucket for storing list of pending requests.
+	HistoryRequestBucket
 )
+
+// NewMemoryDB returns leveldb with memory backend prefixed with a bucket.
+func NewMemoryDB() (*leveldb.DB, error) {
+	return leveldb.Open(storage.NewMemStorage(), nil)
+}
+
+// NewIsolatedDB returns instance that ensures isolated operations.
+func NewIsolatedDB(db *leveldb.DB, prefix storagePrefix) PrefixedLevelDB {
+	return PrefixedLevelDB{
+		db:     db,
+		prefix: prefix,
+	}
+}
+
+// NewIsolatedMemoryDB wraps in memory leveldb with provided bucket.
+func NewIsolatedMemoryDB(prefix storagePrefix) (pdb PrefixedLevelDB, err error) {
+	db, err := NewMemoryDB()
+	if err != nil {
+		return pdb, err
+	}
+	return NewIsolatedDB(db, prefix), nil
+}
 
 // Key creates a DB key for a specified service with specified data
 func Key(prefix storagePrefix, data ...[]byte) []byte {
@@ -58,4 +86,75 @@ func Open(path string, opts *opt.Options) (db *leveldb.DB, err error) {
 		db, err = leveldb.RecoverFile(path, nil)
 	}
 	return
+}
+
+// PrefixedLevelDB database where all operations will be prefixed with a certain bucket.
+type PrefixedLevelDB struct {
+	db     *leveldb.DB
+	prefix storagePrefix
+}
+
+func (db PrefixedLevelDB) prefixedKey(key []byte) []byte {
+	endkey := make([]byte, len(key)+1)
+	endkey[0] = byte(db.prefix)
+	copy(endkey[1:], key)
+	return endkey
+}
+
+func (db PrefixedLevelDB) Put(key, value []byte) error {
+	return db.db.Put(db.prefixedKey(key), value, nil)
+}
+
+func (db PrefixedLevelDB) Get(key []byte) ([]byte, error) {
+	return db.db.Get(db.prefixedKey(key), nil)
+}
+
+// Range returns leveldb util.Range prefixed with a single byte.
+// If prefix is nil range will iterate over all records in a given bucket.
+func (db PrefixedLevelDB) Range(prefix, limit []byte) *util.Range {
+	if limit == nil {
+		return util.BytesPrefix(db.prefixedKey(prefix))
+	}
+	return &util.Range{Start: db.prefixedKey(prefix), Limit: db.prefixedKey(limit)}
+}
+
+// Delete removes key from database.
+func (db PrefixedLevelDB) Delete(key []byte) error {
+	return db.db.Delete(db.prefixedKey(key), nil)
+}
+
+// NewIterator returns iterator for a given slice.
+func (db PrefixedLevelDB) NewIterator(slice *util.Range) PrefixedIterator {
+	return PrefixedIterator{db.db.NewIterator(slice, nil)}
+}
+
+// PrefixedIterator wraps leveldb iterator, works mostly the same way.
+// The only difference is that first byte of the key is dropped.
+type PrefixedIterator struct {
+	iter iterator.Iterator
+}
+
+// Key returns key of the current item.
+func (iter PrefixedIterator) Key() []byte {
+	return iter.iter.Key()[1:]
+}
+
+// Value returns actual value of the current item.
+func (iter PrefixedIterator) Value() []byte {
+	return iter.iter.Value()
+}
+
+// Error returns accumulated error.
+func (iter PrefixedIterator) Error() error {
+	return iter.iter.Error()
+}
+
+// Prev moves cursor backward.
+func (iter PrefixedIterator) Prev() bool {
+	return iter.iter.Prev()
+}
+
+// Next moves cursor forward.
+func (iter PrefixedIterator) Next() bool {
+	return iter.iter.Next()
 }

--- a/db/history.go
+++ b/db/history.go
@@ -1,0 +1,218 @@
+package db
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	whisper "github.com/status-im/whisper/whisperv6"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+var (
+	// ErrEmptyKey returned if key is not expected to be empty.
+	ErrEmptyKey = errors.New("TopicHistoryKey is empty")
+)
+
+// Interface is a common interface for DB operations.
+type Interface interface {
+	Get([]byte) ([]byte, error)
+	Put([]byte, []byte) error
+	Delete([]byte) error
+	Range([]byte, []byte) *util.Range
+	NewIterator(*util.Range) PrefixedIterator
+}
+
+// TopicHistoryKey defines bytes that are used as unique key for TopicHistory.
+// first 4 bytes are whisper.TopicType bytes
+// next 8 bytes are time.Duration encoded in big endian notation.
+type TopicHistoryKey [12]byte
+
+// LoadTopicHistoryFromKey unmarshalls key into topic and duration and loads value of topic history
+// from given database.
+func LoadTopicHistoryFromKey(db Interface, key TopicHistoryKey) (th TopicHistory, err error) {
+	if (key == TopicHistoryKey{}) {
+		return th, ErrEmptyKey
+	}
+	topic := whisper.TopicType{}
+	copy(topic[:], key[:4])
+	duration := binary.BigEndian.Uint64(key[4:])
+	th = TopicHistory{db: db, Topic: topic, Duration: time.Duration(duration)}
+	return th, th.Load()
+}
+
+// TopicHistory stores necessary information.
+type TopicHistory struct {
+	db Interface
+
+	// whisper topic
+	Topic whisper.TopicType
+
+	LastEnvelopeHash common.Hash
+
+	Duration time.Duration
+	// Timestamp that was used for the first request with this topic.
+	// Used to identify overlapping ranges.
+	First time.Time
+	// Timestamp of the last synced envelope.
+	Current time.Time
+	End     time.Time
+
+	RequestID common.Hash
+}
+
+// Key returns unique identifier for this TopicHistory.
+func (t TopicHistory) Key() TopicHistoryKey {
+	key := TopicHistoryKey{}
+	copy(key[:], t.Topic[:])
+	binary.BigEndian.PutUint64(key[4:], uint64(t.Duration))
+	return key
+}
+
+// Value marshalls TopicHistory into bytes.
+func (t TopicHistory) Value() ([]byte, error) {
+	return json.Marshal(t)
+}
+
+// Load TopicHistory from db using key and unmarshalls it.
+func (t *TopicHistory) Load() error {
+	key := t.Key()
+	if (key == TopicHistoryKey{}) {
+		return errors.New("key is empty")
+	}
+	value, err := t.db.Get(key[:])
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(value, t)
+}
+
+// Save persists TopicHistory on disk.
+func (t TopicHistory) Save() error {
+	key := t.Key()
+	val, err := t.Value()
+	if err != nil {
+		return err
+	}
+	return t.db.Put(key[:], val)
+}
+
+// SameRange returns true if topic has same range, which means:
+// true if Current is zero and Duration is the same
+// and true if Current is the same
+func (t TopicHistory) SameRange(other TopicHistory) bool {
+	zero := time.Time{}
+	if t.Current == zero && other.Current == zero {
+		return t.Duration == other.Duration
+	}
+	return t.Current == other.Current
+}
+
+// HistoryRequest is kept in the database while request is in the progress.
+// Stores necessary information to identify topics with associated ranges included in the request.
+type HistoryRequest struct {
+	db      Interface
+	topicDB Interface
+
+	histories []TopicHistory
+
+	// Generated ID
+	ID common.Hash
+	// List of the topics
+	TopicHistoryKeys []TopicHistoryKey
+	LastEnvelopeHash common.Hash
+}
+
+// AddHistory adds instance to internal list of instance and add instance key to the list
+// which will be persisted on disk.
+func (req *HistoryRequest) AddHistory(history TopicHistory) {
+	req.histories = append(req.histories, history)
+	req.TopicHistoryKeys = append(req.TopicHistoryKeys, history.Key())
+}
+
+// Histories returns internal lsit of topic histories.
+func (req *HistoryRequest) Histories() []TopicHistory {
+	// TODO Lazy load from database on first access
+	return req.histories
+}
+
+// Value returns content of HistoryRequest as bytes.
+func (req HistoryRequest) Value() ([]byte, error) {
+	return json.Marshal(req)
+}
+
+// Save persists all attached histories and request itself on the disk.
+func (req HistoryRequest) Save() error {
+	for i := range req.histories {
+		th := &req.histories[i]
+		th.RequestID = req.ID
+		if err := th.Save(); err != nil {
+			return err
+		}
+	}
+	val, err := req.Value()
+	if err != nil {
+		return err
+	}
+	return req.db.Put(req.ID.Bytes(), val)
+}
+
+// Delete HistoryRequest from store and update every topic.
+func (req HistoryRequest) Delete() error {
+	for i := range req.histories {
+		th := &req.histories[i]
+		th.RequestID = common.Hash{}
+		th.Current = th.End
+		if err := th.Save(); err != nil {
+			return err
+		}
+	}
+	return req.db.Delete(req.ID.Bytes())
+}
+
+// Load reads request and topic histories content from disk and unmarshalls them.
+func (req *HistoryRequest) Load() error {
+	val, err := req.db.Get(req.ID.Bytes())
+	if err != nil {
+		return err
+	}
+	err = req.RawUnmarshall(val)
+	if err != nil {
+		return err
+	}
+	return req.loadHistories()
+}
+
+func (req *HistoryRequest) loadHistories() error {
+	for _, hk := range req.TopicHistoryKeys {
+		th, err := LoadTopicHistoryFromKey(req.topicDB, hk)
+		if err != nil {
+			return err
+		}
+		req.histories = append(req.histories, th)
+	}
+	return nil
+}
+
+// RawUnmarshall unmarshall given bytes into the structure.
+// Used in range queries to unmarshall content of the iter.Value directly into request struct.
+func (req *HistoryRequest) RawUnmarshall(val []byte) error {
+	err := json.Unmarshal(val, req)
+	if err != nil {
+		return err
+	}
+	return req.loadHistories()
+}
+
+// Includes checks if TopicHistory is included into the request.
+func (req *HistoryRequest) Includes(history TopicHistory) bool {
+	key := history.Key()
+	for i := range req.TopicHistoryKeys {
+		if key == req.TopicHistoryKeys[i] {
+			return true
+		}
+	}
+	return false
+}

--- a/db/history.go
+++ b/db/history.go
@@ -175,11 +175,7 @@ func (req *HistoryRequest) Load() error {
 	if err != nil {
 		return err
 	}
-	err = req.RawUnmarshall(val)
-	if err != nil {
-		return err
-	}
-	return req.loadHistories()
+	return req.RawUnmarshall(val)
 }
 
 func (req *HistoryRequest) loadHistories() error {

--- a/db/history.go
+++ b/db/history.go
@@ -50,8 +50,6 @@ type TopicHistory struct {
 	// whisper topic
 	Topic whisper.TopicType
 
-	LastEnvelopeHash common.Hash
-
 	Duration time.Duration
 	// Timestamp that was used for the first request with this topic.
 	// Used to identify overlapping ranges.
@@ -122,7 +120,6 @@ type HistoryRequest struct {
 	ID common.Hash
 	// List of the topics
 	TopicHistoryKeys []TopicHistoryKey
-	LastEnvelopeHash common.Hash
 }
 
 // AddHistory adds instance to internal list of instance and add instance key to the list

--- a/db/history_store.go
+++ b/db/history_store.go
@@ -1,0 +1,91 @@
+package db
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	whisper "github.com/status-im/whisper/whisperv6"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/errors"
+)
+
+// NewHistoryStore returns HistoryStore instance.
+func NewHistoryStore(db *leveldb.DB) HistoryStore {
+	return HistoryStore{
+		topicDB:   NewIsolatedDB(db, TopicHistoryBucket),
+		requestDB: NewIsolatedDB(db, HistoryRequestBucket),
+	}
+}
+
+// HistoryStore provides utility methods for quering history and requests store.
+type HistoryStore struct {
+	topicDB   Interface
+	requestDB Interface
+}
+
+// GetHistory creates history instance and loads history from database.
+// Returns instance populated with topic and duration if history is not found in database.
+func (h HistoryStore) GetHistory(topic whisper.TopicType, duration time.Duration) (TopicHistory, error) {
+	thist := h.NewHistory(topic, duration)
+	err := thist.Load()
+	if err != nil && err != errors.ErrNotFound {
+		return TopicHistory{}, err
+	}
+	return thist, nil
+}
+
+// NewRequest returns instance of the HistoryRequest.
+func (h HistoryStore) NewRequest() HistoryRequest {
+	return HistoryRequest{db: h.requestDB, topicDB: h.topicDB}
+}
+
+// NewHistory creates TopicHistory object with required values.
+func (h HistoryStore) NewHistory(topic whisper.TopicType, duration time.Duration) TopicHistory {
+	return TopicHistory{db: h.topicDB, Duration: duration, Topic: topic}
+}
+
+// GetRequest loads HistoryRequest from database.
+func (h HistoryStore) GetRequest(id common.Hash) (HistoryRequest, error) {
+	req := HistoryRequest{db: h.requestDB, topicDB: h.topicDB, ID: id}
+	err := req.Load()
+	if err != nil {
+		return HistoryRequest{}, err
+	}
+	return req, nil
+}
+
+// GetAllRequests loads all not-finished history requests from database.
+func (h HistoryStore) GetAllRequests() ([]HistoryRequest, error) {
+	rst := []HistoryRequest{}
+	iter := h.requestDB.NewIterator(h.requestDB.Range(nil, nil))
+	for iter.Next() {
+		req := HistoryRequest{
+			db:      h.requestDB,
+			topicDB: h.topicDB,
+		}
+		err := req.RawUnmarshall(iter.Value())
+		if err != nil {
+			return nil, err
+		}
+		rst = append(rst, req)
+	}
+	return rst, nil
+}
+
+// GetHistoriesByTopic returns all histories with a given topic.
+// This is needed when we will have multiple range per single topic.
+// TODO explain
+func (h HistoryStore) GetHistoriesByTopic(topic whisper.TopicType) ([]TopicHistory, error) {
+	rst := []TopicHistory{}
+	iter := h.topicDB.NewIterator(h.topicDB.Range(topic[:], nil))
+	for iter.Next() {
+		key := TopicHistoryKey{}
+		copy(key[:], iter.Key())
+		th, err := LoadTopicHistoryFromKey(h.topicDB, key)
+		if err != nil {
+			return nil, err
+		}
+		rst = append(rst, th)
+	}
+	return rst, nil
+}

--- a/db/history_store_test.go
+++ b/db/history_store_test.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	whisper "github.com/status-im/whisper/whisperv6"
+	"github.com/stretchr/testify/require"
+)
+
+func createInMemStore(t *testing.T) HistoryStore {
+	db, err := NewMemoryDB()
+	require.NoError(t, err)
+	return NewHistoryStore(db)
+}
+
+func TestGetNewHistory(t *testing.T) {
+	topic := whisper.TopicType{1}
+	duration := time.Hour
+	store := createInMemStore(t)
+	th, err := store.GetHistory(topic, duration)
+	require.NoError(t, err)
+	require.Equal(t, duration, th.Duration)
+	require.Equal(t, topic, th.Topic)
+}
+
+func TestGetExistingHistory(t *testing.T) {
+	topic := whisper.TopicType{1}
+	duration := time.Hour
+	store := createInMemStore(t)
+	th, err := store.GetHistory(topic, duration)
+	require.NoError(t, err)
+
+	now := time.Now()
+	th.Current = now
+	require.NoError(t, th.Save())
+
+	th, err = store.GetHistory(topic, duration)
+	require.NoError(t, err)
+	require.Equal(t, now.Unix(), th.Current.Unix())
+}
+
+func TestNewHistoryRequest(t *testing.T) {
+	store := createInMemStore(t)
+	id := common.Hash{1}
+	req, err := store.GetRequest(id)
+	require.Error(t, err)
+	req = store.NewRequest()
+	req.ID = id
+	th, err := store.GetHistory(whisper.TopicType{1}, time.Hour)
+	require.NoError(t, err)
+	req.AddHistory(th)
+	require.NoError(t, req.Save())
+
+	req, err = store.GetRequest(id)
+	require.NoError(t, err)
+	require.Len(t, req.Histories(), 1)
+}
+
+func TestGetAllRequests(t *testing.T) {
+	store := createInMemStore(t)
+	idOne := common.Hash{1}
+	idTwo := common.Hash{2}
+
+	req := store.NewRequest()
+	req.ID = idOne
+	require.NoError(t, req.Save())
+
+	all, err := store.GetAllRequests()
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+
+	req = store.NewRequest()
+	req.ID = idTwo
+	require.NoError(t, req.Save())
+
+	all, err = store.GetAllRequests()
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+}

--- a/db/history_store_test.go
+++ b/db/history_store_test.go
@@ -48,6 +48,7 @@ func TestNewHistoryRequest(t *testing.T) {
 	require.Error(t, err)
 	req = store.NewRequest()
 	req.ID = id
+
 	th, err := store.GetHistory(whisper.TopicType{1}, time.Hour)
 	require.NoError(t, err)
 	req.AddHistory(th)

--- a/db/history_test.go
+++ b/db/history_test.go
@@ -1,0 +1,133 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	whisper "github.com/status-im/whisper/whisperv6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicHistoryStoreLoadFromKey(t *testing.T) {
+	db, err := NewIsolatedMemoryDB(TopicHistoryBucket)
+	require.NoError(t, err)
+	th := TopicHistory{
+		db:       db,
+		Topic:    whisper.TopicType{1, 1, 1},
+		Duration: 10 * time.Hour,
+	}
+	require.NoError(t, th.Save())
+	now := time.Now()
+	th.Current = now
+	require.NoError(t, th.Save())
+
+	th, err = LoadTopicHistoryFromKey(db, th.Key())
+	require.NoError(t, err)
+	require.Equal(t, now.Unix(), th.Current.Unix())
+}
+
+func TestTopicHistorySameRange(t *testing.T) {
+	now := time.Now()
+	testCases := []struct {
+		description string
+		result      bool
+		histories   [2]TopicHistory
+	}{
+		{
+			description: "SameDurationCurrentNotSet",
+			result:      true,
+			histories: [2]TopicHistory{
+				{Duration: time.Minute}, {Duration: time.Minute},
+			},
+		},
+		{
+			description: "DifferentDurationCurrentNotset",
+			result:      false,
+			histories: [2]TopicHistory{
+				{Duration: time.Minute}, {Duration: time.Hour},
+			},
+		},
+		{
+			description: "SameCurrent",
+			result:      true,
+			histories: [2]TopicHistory{
+				{Current: now}, {Current: now},
+			},
+		},
+		{
+			description: "DifferentCurrent",
+			result:      false,
+			histories: [2]TopicHistory{
+				{Current: now}, {Current: now.Add(time.Hour)},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			require.Equal(t, tc.result, tc.histories[0].SameRange(tc.histories[1]))
+		})
+	}
+}
+
+func TestAddHistory(t *testing.T) {
+	topic := whisper.TopicType{1, 1, 1}
+	now := time.Now()
+
+	topicdb, err := NewIsolatedMemoryDB(TopicHistoryBucket)
+	require.NoError(t, err)
+	requestdb, err := NewIsolatedMemoryDB(HistoryRequestBucket)
+	require.NoError(t, err)
+
+	th := TopicHistory{db: topicdb, Topic: topic, Current: now}
+	id := common.Hash{1}
+
+	req := HistoryRequest{db: requestdb, topicDB: topicdb, ID: id}
+	req.AddHistory(th)
+	require.NoError(t, req.Save())
+
+	req = HistoryRequest{db: requestdb, topicDB: topicdb, ID: id}
+	require.NoError(t, req.Load())
+
+	require.Len(t, req.Histories(), 1)
+	require.Equal(t, th.Topic, req.Histories()[0].Topic)
+}
+
+func TestRequestIncludesMethod(t *testing.T) {
+	topicOne := whisper.TopicType{1}
+	topicTwo := whisper.TopicType{2}
+	testCases := []struct {
+		description string
+		result      bool
+		topics      []TopicHistory
+		input       TopicHistory
+	}{
+		{
+			description: "EmptyTopic",
+			result:      false,
+			input:       TopicHistory{Topic: topicOne},
+		},
+		{
+			description: "MatchesTopic",
+			result:      true,
+			topics:      []TopicHistory{{Topic: topicOne}},
+			input:       TopicHistory{Topic: topicOne},
+		},
+		{
+			description: "NotMatchesTopic",
+			result:      false,
+			topics:      []TopicHistory{{Topic: topicOne}},
+			input:       TopicHistory{Topic: topicTwo},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			req := HistoryRequest{}
+			for _, t := range tc.topics {
+				req.AddHistory(t)
+			}
+			require.Equal(t, tc.result, req.Includes(tc.input))
+		})
+	}
+}

--- a/db/history_test.go
+++ b/db/history_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestTopicHistoryStoreLoadFromKey(t *testing.T) {
-	db, err := NewIsolatedMemoryDB(TopicHistoryBucket)
+	db, err := NewMemoryDBNamespace(TopicHistoryBucket)
 	require.NoError(t, err)
 	th := TopicHistory{
 		db:       db,
@@ -74,9 +74,9 @@ func TestAddHistory(t *testing.T) {
 	topic := whisper.TopicType{1, 1, 1}
 	now := time.Now()
 
-	topicdb, err := NewIsolatedMemoryDB(TopicHistoryBucket)
+	topicdb, err := NewMemoryDBNamespace(TopicHistoryBucket)
 	require.NoError(t, err)
-	requestdb, err := NewIsolatedMemoryDB(HistoryRequestBucket)
+	requestdb, err := NewMemoryDBNamespace(HistoryRequestBucket)
 	require.NoError(t, err)
 
 	th := TopicHistory{db: topicdb, Topic: topic, Current: now}

--- a/params/config.go
+++ b/params/config.go
@@ -336,6 +336,10 @@ type ShhextConfig struct {
 
 	// MaxMessageDeliveryAttempts defines how many times we will try to deliver not-acknowledged envelopes.
 	MaxMessageDeliveryAttempts int
+
+	// WhisperCacheDir is a folder where whisper filters may persist messages before delivering them
+	// to a client.
+	WhisperCacheDir string
 }
 
 // Validate validates the ShhextConfig struct and returns an error if inconsistent values are found

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -420,7 +420,7 @@ func (api *PublicAPI) GetNewFilterMessages(filterID string) ([]dedup.Deduplicate
 // the client side.
 func (api *PublicAPI) ConfirmMessagesProcessed(messages []*whisper.Message) error {
 	for _, msg := range messages {
-		err := api.service.historyUpdates.UpdateTopicHistory(msg.Topic, time.Unix(int64(msg.Timestamp), 0), common.BytesToHash(msg.Hash))
+		err := api.service.historyUpdates.UpdateTopicHistory(msg.Topic, time.Unix(int64(msg.Timestamp), 0))
 		if err != nil {
 			return err
 		}

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -596,11 +596,14 @@ func (api *PublicAPI) InitiateHistoryRequests(request InitiateHistoryRequest) ([
 		if err != nil {
 			return rst, err
 		}
-		hex := hexutil.Bytes{}
-		copy(hex, hash[:])
-		rst = append(rst, hex)
+		rst = append(rst, hash[:])
 	}
 	return rst, nil
+}
+
+// CompleteRequest client must mark request completed when all envelopes were processed.
+func (api *PublicAPI) CompleteRequest(ctx context.Context, hex string) error {
+	return api.service.historyUpdates.UpdateFinishedRequest(common.HexToHash(hex))
 }
 
 // DEPRECATED: use SendDirectMessage with DH flag

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/status-im/status-go/db"
 	"github.com/status-im/status-go/mailserver"
 	"github.com/status-im/status-go/services/shhext/chat"
 	"github.com/status-im/status-go/services/shhext/dedup"
@@ -418,6 +419,12 @@ func (api *PublicAPI) GetNewFilterMessages(filterID string) ([]dedup.Deduplicate
 // ConfirmMessagesProcessed is a method to confirm that messages was consumed by
 // the client side.
 func (api *PublicAPI) ConfirmMessagesProcessed(messages []*whisper.Message) error {
+	for _, msg := range messages {
+		err := api.service.historyUpdates.UpdateTopicHistory(msg.Topic, time.Unix(int64(msg.Timestamp), 0), common.BytesToHash(msg.Hash))
+		if err != nil {
+			return err
+		}
+	}
 	return api.service.deduplicator.AddMessages(messages)
 }
 
@@ -491,6 +498,109 @@ func (api *PublicAPI) SendDirectMessage(ctx context.Context, msg chat.SendDirect
 
 	// And dispatch
 	return api.Post(ctx, whisperMessage)
+}
+
+// InitiateHistoryRequest type for initiating history requests from a peer.
+type InitiateHistoryRequest struct {
+	Peer     string
+	SymKeyID string
+	Requests []TopicRequest
+	Force    bool
+	Timeout  time.Duration
+}
+
+func (api *PublicAPI) requestMessagesUsingPayload(request db.HistoryRequest, peer, symkeyID string, payload []byte, force bool, timeout time.Duration, topics []whisper.TopicType) (hash common.Hash, err error) {
+	shh := api.service.w
+	now := api.service.w.GetCurrentTime()
+
+	mailServerNode, err := api.getPeer(peer)
+	if err != nil {
+		return hash, fmt.Errorf("%v: %v", ErrInvalidMailServerPeer, err)
+	}
+
+	var (
+		symKey    []byte
+		publicKey *ecdsa.PublicKey
+	)
+
+	if symkeyID != "" {
+		symKey, err = shh.GetSymKey(symkeyID)
+		if err != nil {
+			return hash, fmt.Errorf("%v: %v", ErrInvalidSymKeyID, err)
+		}
+	} else {
+		publicKey = mailServerNode.Pubkey()
+	}
+
+	envelope, err := makeEnvelop(
+		payload,
+		symKey,
+		publicKey,
+		api.service.nodeID,
+		shh.MinPow(),
+		now,
+	)
+	if err != nil {
+		return hash, err
+	}
+	hash = envelope.Hash()
+
+	request.ID = hash
+	err = request.Save()
+	if err != nil {
+		return hash, err
+	}
+
+	if !force {
+		err = api.service.requestsRegistry.Register(hash, topics)
+		if err != nil {
+			return hash, err
+		}
+	}
+
+	if err := shh.RequestHistoricMessagesWithTimeout(mailServerNode.ID().Bytes(), envelope, timeout); err != nil {
+		err = request.Delete()
+		if err != nil {
+			return hash, err
+		}
+		if !force {
+			api.service.requestsRegistry.Unregister(hash)
+		}
+		return hash, err
+	}
+
+	return hash, nil
+
+}
+
+// InitiateHistoryRequests is a stateful API for initiating history request for each topic.
+// Caller of this method needs to define only two parameters per each TopicRequest:
+// - Topic
+// - Duration before Now
+// After that status-go will guarantee that request for this topic and date will be performed.
+func (api *PublicAPI) InitiateHistoryRequests(request InitiateHistoryRequest) ([]hexutil.Bytes, error) {
+	rst := []hexutil.Bytes{}
+	requests, err := api.service.historyUpdates.CreateRequests(request.Requests)
+	if err != nil {
+		return nil, err
+	}
+	for i := range requests {
+		req := requests[i]
+		options := CreateTopicOptionsFromRequest(req)
+		bloom := options.ToBloomFilterOption()
+		payload, err := bloom.ToMessagesRequestPayload()
+		if err != nil {
+			return rst, err
+		}
+		hash, err := api.requestMessagesUsingPayload(req, request.Peer, request.SymKeyID, payload, request.Force, request.Timeout, options.Topics())
+		if err != nil {
+			return rst, err
+		}
+		hex := hexutil.Bytes{}
+		copy(hex, hash[:])
+		rst = append(rst, hex)
+	}
+	return rst, nil
 }
 
 // DEPRECATED: use SendDirectMessage with DH flag

--- a/services/shhext/envelopes.go
+++ b/services/shhext/envelopes.go
@@ -196,7 +196,7 @@ func (m *EnvelopesMonitor) handleAcknowledgedBatch(event whisper.EnvelopeEvent) 
 	log.Debug("received a confirmation", "batch", event.Batch, "peer", event.Peer)
 	envelopeErrors, ok := event.Data.([]whisper.EnvelopeError)
 	if event.Data != nil && !ok {
-		log.Warn("received unexpected data for the confirmation event", "batch", event.Batch)
+		log.Error("received unexpected data in the the confirmation event", "batch", event.Batch)
 	}
 	failedEnvelopes := map[common.Hash]struct{}{}
 	for i := range envelopeErrors {

--- a/services/shhext/history.go
+++ b/services/shhext/history.go
@@ -55,7 +55,7 @@ func (reactor *HistoryUpdateReactor) UpdateFinishedRequest(id common.Hash) error
 }
 
 // UpdateTopicHistory updates Current timestamp for the TopicHistory with a given timestamp.
-func (reactor *HistoryUpdateReactor) UpdateTopicHistory(topic whisper.TopicType, timestamp time.Time, envelopeHash common.Hash) error {
+func (reactor *HistoryUpdateReactor) UpdateTopicHistory(topic whisper.TopicType, timestamp time.Time) error {
 	reactor.mu.Lock()
 	defer reactor.mu.Unlock()
 	histories, err := reactor.store.GetHistoriesByTopic(topic)
@@ -75,7 +75,6 @@ func (reactor *HistoryUpdateReactor) UpdateTopicHistory(topic whisper.TopicType,
 	}
 	if timestamp.After(th.Current) {
 		th.Current = timestamp
-		th.LastEnvelopeHash = envelopeHash
 	}
 	return th.Save()
 }

--- a/services/shhext/history.go
+++ b/services/shhext/history.go
@@ -1,0 +1,353 @@
+package shhext
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/status-im/status-go/db"
+	"github.com/status-im/status-go/mailserver"
+	whisper "github.com/status-im/whisper/whisperv6"
+)
+
+const (
+	// WhisperTimeAllowance is needed to ensure that we won't miss envelopes that were
+	// delivered to mail server after we made a request.
+	WhisperTimeAllowance = 20 * time.Second
+)
+
+// TimeSource is a function that returns current time.
+type TimeSource func() time.Time
+
+// NewHistoryUpdateReactor creates HistoryUpdateReactor instance.
+func NewHistoryUpdateReactor(store db.HistoryStore, registry *RequestsRegistry, timeSource TimeSource) *HistoryUpdateReactor {
+	return &HistoryUpdateReactor{
+		store:      store,
+		registry:   registry,
+		timeSource: timeSource,
+	}
+}
+
+// HistoryUpdateReactor responsible for tracking progress for all history requests.
+// It listens for 2 events:
+//    - when envelope from mail server is received we will update appropriate topic on disk
+//    - when confirmation for request completion is received - we will set last envelope timestamp as the last timestamp
+//      for all TopicLists in current request.
+type HistoryUpdateReactor struct {
+	mu         sync.Mutex
+	store      db.HistoryStore
+	registry   *RequestsRegistry
+	timeSource TimeSource
+}
+
+// UpdateFinishedRequest removes succesfully finished request and updates every topic
+// attached to the request.
+func (reactor *HistoryUpdateReactor) UpdateFinishedRequest(id common.Hash, hash common.Hash) error {
+	reactor.mu.Lock()
+	defer reactor.mu.Unlock()
+	req, err := reactor.store.GetRequest(id)
+	if err != nil {
+		return err
+	}
+	// event was received once we processed all envelopes related to this event
+	histories := req.Histories()
+	for i := range histories {
+		th := &histories[i]
+		if th.LastEnvelopeHash == hash {
+			return req.Delete()
+		}
+	}
+	// if any of the topics already received LastEnvelopeHash we know that request is finished
+	// and we can safely remove request. If it is not finished then we need to wait for that LastTimestamp.
+	// and we do that in UpdateTopicHistory method
+	req.LastEnvelopeHash = hash
+	return req.Save()
+}
+
+// UpdateTopicHistory updates Current timestamp for the TopicHistory with a given timestamp.
+func (reactor *HistoryUpdateReactor) UpdateTopicHistory(topic whisper.TopicType, timestamp time.Time, envelopeHash common.Hash) error {
+	reactor.mu.Lock()
+	defer reactor.mu.Unlock()
+	histories, err := reactor.store.GetHistoriesByTopic(topic)
+	if err != nil {
+		return err
+	}
+	if len(histories) == 0 {
+		return fmt.Errorf("no histories for topic 0x%x", topic)
+	}
+	// TODO support multiple history ranges per topic
+	th := histories[0]
+	// this case could happen only iff envelopes were delivered out of order
+	// last envelope received, request completed, then others envelopes received
+	// request completed, last envelope received, and then all others envelopes received
+	if (th.RequestID == common.Hash{}) {
+		return nil
+	}
+	if timestamp.After(th.Current) {
+		th.Current = timestamp
+		th.LastEnvelopeHash = envelopeHash
+	}
+	err = th.Save()
+	if err != nil {
+		return err
+	}
+	req, err := reactor.store.GetRequest(th.RequestID)
+	if err != nil {
+		return err
+	}
+	// we didn't receive event that request got finished yet
+	if (req.LastEnvelopeHash == common.Hash{}) {
+		return nil
+	}
+	// in this case we already processed event that request was finished
+	if req.LastEnvelopeHash == envelopeHash {
+		return req.Delete()
+	}
+	return nil
+}
+
+// TopicRequest defines what user has to provide.
+type TopicRequest struct {
+	Topic    whisper.TopicType
+	Duration time.Duration
+}
+
+// CreateRequests receives list of topic with desired timestamps and initiates both pending requests and requests
+// that cover new topics.
+func (reactor *HistoryUpdateReactor) CreateRequests(topicRequests []TopicRequest) ([]db.HistoryRequest, error) {
+	reactor.mu.Lock()
+	defer reactor.mu.Unlock()
+	topics := map[whisper.TopicType]db.TopicHistory{}
+	for i := range topicRequests {
+		topic, err := reactor.store.GetHistory(topicRequests[i].Topic, topicRequests[i].Duration)
+		if err != nil {
+			return nil, err
+		}
+		topics[topicRequests[i].Topic] = topic
+	}
+	requests, err := reactor.store.GetAllRequests()
+	if err != nil {
+		return nil, err
+	}
+	filtered := []db.HistoryRequest{}
+	for i := range requests {
+		req := requests[i]
+		for _, t := range topics {
+			if req.Includes(t) {
+				delete(topics, t.Topic)
+			}
+		}
+		if !reactor.registry.Has(req.ID) {
+			filtered = append(filtered, req)
+		}
+	}
+	filtered = append(filtered, GroupHistoriesByRequestTimespan(reactor.store, mapToList(topics))...)
+	return RenewRequests(filtered, reactor.timeSource()), nil
+}
+
+// RenewRequests re-sets current, first and end timestamps.
+// Changes should not be persisted on disk in this method.
+func RenewRequests(requests []db.HistoryRequest, now time.Time) []db.HistoryRequest {
+	zero := time.Time{}
+	for i := range requests {
+		req := requests[i]
+		histories := req.Histories()
+		for j := range histories {
+			history := &histories[j]
+			if history.Current == zero {
+				history.Current = now.Add(-(history.Duration))
+			}
+			if history.First == zero {
+				history.First = history.Current
+			}
+			history.End = now
+		}
+	}
+	return requests
+}
+
+// CreateTopicOptionsFromRequest transforms histories attached to a single request to a simpler format - TopicOptions.
+func CreateTopicOptionsFromRequest(req db.HistoryRequest) TopicOptions {
+	histories := req.Histories()
+	rst := make(TopicOptions, len(histories))
+	for i := range histories {
+		history := histories[i]
+		rst[i] = TopicOption{
+			Topic: history.Topic,
+			Range: Range{
+				Start: uint64(history.Current.Add(-(WhisperTimeAllowance)).Unix()),
+				End:   uint64(history.End.Unix()),
+			},
+		}
+	}
+	return rst
+}
+
+func mapToList(topics map[whisper.TopicType]db.TopicHistory) []db.TopicHistory {
+	rst := make([]db.TopicHistory, 0, len(topics))
+	for key := range topics {
+		rst = append(rst, topics[key])
+	}
+	return rst
+}
+
+// GroupHistoriesByRequestTimespan creates requests from provided histories.
+// Multiple histories will be included into the same request only if they share timespan.
+func GroupHistoriesByRequestTimespan(store db.HistoryStore, histories []db.TopicHistory) []db.HistoryRequest {
+	requests := []db.HistoryRequest{}
+	for _, th := range histories {
+		var added bool
+		for i := range requests {
+			req := &requests[i]
+			histories := req.Histories()
+			if histories[0].SameRange(th) {
+				req.AddHistory(th)
+				added = true
+			}
+		}
+		if !added {
+			req := store.NewRequest()
+			req.AddHistory(th)
+			requests = append(requests, req)
+		}
+	}
+	return requests
+}
+
+// Range of the request.
+type Range struct {
+	Start uint64
+	End   uint64
+}
+
+// TopicOption request for a single topic.
+type TopicOption struct {
+	Topic whisper.TopicType
+	Range Range
+}
+
+// TopicOptions is a list of topic-based requsts.
+type TopicOptions []TopicOption
+
+// ToBloomFilterOption creates bloom filter request from a list of topics.
+func (options TopicOptions) ToBloomFilterOption() BloomFilterOption {
+	topics := make([]whisper.TopicType, len(options))
+	var start, end uint64
+	for i := range options {
+		opt := options[i]
+		topics[i] = opt.Topic
+		if opt.Range.Start > start {
+			start = opt.Range.Start
+		}
+		if opt.Range.End > end {
+			end = opt.Range.End
+		}
+	}
+
+	return BloomFilterOption{
+		Range:  Range{Start: start, End: end},
+		Filter: topicsToBloom(topics...),
+	}
+}
+
+// Topics returns list of whisper TopicType attached to each TopicOption.
+func (options TopicOptions) Topics() []whisper.TopicType {
+	rst := make([]whisper.TopicType, len(options))
+	for i := range options {
+		rst[i] = options[i].Topic
+	}
+	return rst
+}
+
+// BloomFilterOption is a request based on bloom filter.
+type BloomFilterOption struct {
+	Range  Range
+	Filter []byte
+}
+
+// ToMessagesRequestPayload creates mailserver.MessagesRequestPayload and encodes it to bytes using rlp.
+func (filter BloomFilterOption) ToMessagesRequestPayload() ([]byte, error) {
+	// TODO fix this conversion.
+	// we start from time.Duration which is int64, then convert to uint64 for rlp-serilizability
+	// why uint32 here? max uint32 is smaller than max int64
+	payload := mailserver.MessagesRequestPayload{
+		Lower: uint32(filter.Range.Start),
+		Upper: uint32(filter.Range.End),
+		Bloom: filter.Filter,
+		// Client must tell the MailServer if it supports batch responses.
+		// This can be removed in the future.
+		Batch: true,
+		Limit: 10000,
+	}
+	return rlp.EncodeToBytes(payload)
+}
+
+// NewHistoryListener returns instance of the HistoryEventListener.
+func NewHistoryListener(reactor *HistoryUpdateReactor, requestsUpdates RequestEventsProducer) *HistoryEventListener {
+	return &HistoryEventListener{
+		reactor:        reactor,
+		requestUpdates: requestsUpdates,
+	}
+}
+
+// RequestEventsProducer produces events that track flow of history requests.
+type RequestEventsProducer interface {
+	SubscribeEnvelopeEvents(chan<- whisper.EnvelopeEvent) event.Subscription
+}
+
+// HistoryEventListener is an object that keeps open subscriptions for event producers and feeds necessary
+// information to HistoryUpdateReactor.
+type HistoryEventListener struct {
+	wg   sync.WaitGroup
+	quit chan struct{}
+
+	reactor *HistoryUpdateReactor
+
+	requestUpdates RequestEventsProducer
+}
+
+// Start creates subscriptions and spawns a goroutine to consume events from them.
+// Must be called in the same thread as Stop.
+func (listener *HistoryEventListener) Start() error {
+	if listener.quit != nil {
+		return errors.New("already running")
+	}
+	listener.wg.Add(1)
+	listener.quit = make(chan struct{})
+	requests := make(chan whisper.EnvelopeEvent, 10)
+	requestsSub := listener.requestUpdates.SubscribeEnvelopeEvents(requests)
+	go func() {
+		for {
+			select {
+			case <-listener.quit:
+				requestsSub.Unsubscribe()
+				listener.wg.Done()
+				return
+			case ev := <-requests:
+				if ev.Event != whisper.EventMailServerRequestCompleted {
+					continue
+				}
+				data := ev.Data.(*whisper.MailServerResponse)
+				err := listener.reactor.UpdateFinishedRequest(ev.Hash, data.LastEnvelopeHash)
+				if err != nil {
+					log.Error("failed to update request when it was finished", "id", ev.Hash, "error", err)
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+// Stop consuming goroutine and wait until it exits.
+func (listener *HistoryEventListener) Stop() {
+	if listener.quit == nil {
+		return
+	}
+	close(listener.quit)
+	listener.wg.Wait()
+}

--- a/services/shhext/history.go
+++ b/services/shhext/history.go
@@ -45,7 +45,7 @@ type HistoryUpdateReactor struct {
 	timeSource TimeSource
 }
 
-// UpdateFinishedRequest removes succesfully finished request and updates every topic
+// UpdateFinishedRequest removes successfully finished request and updates every topic
 // attached to the request.
 func (reactor *HistoryUpdateReactor) UpdateFinishedRequest(id common.Hash, hash common.Hash) error {
 	reactor.mu.Lock()
@@ -122,13 +122,13 @@ type TopicRequest struct {
 func (reactor *HistoryUpdateReactor) CreateRequests(topicRequests []TopicRequest) ([]db.HistoryRequest, error) {
 	reactor.mu.Lock()
 	defer reactor.mu.Unlock()
-	topics := map[whisper.TopicType]db.TopicHistory{}
+	histories := map[whisper.TopicType]db.TopicHistory{}
 	for i := range topicRequests {
-		topic, err := reactor.store.GetHistory(topicRequests[i].Topic, topicRequests[i].Duration)
+		history, err := reactor.store.GetHistory(topicRequests[i].Topic, topicRequests[i].Duration)
 		if err != nil {
 			return nil, err
 		}
-		topics[topicRequests[i].Topic] = topic
+		histories[topicRequests[i].Topic] = history
 	}
 	requests, err := reactor.store.GetAllRequests()
 	if err != nil {
@@ -137,16 +137,16 @@ func (reactor *HistoryUpdateReactor) CreateRequests(topicRequests []TopicRequest
 	filtered := []db.HistoryRequest{}
 	for i := range requests {
 		req := requests[i]
-		for _, t := range topics {
-			if req.Includes(t) {
-				delete(topics, t.Topic)
+		for _, th := range histories {
+			if req.Includes(th) {
+				delete(histories, th.Topic)
 			}
 		}
 		if !reactor.registry.Has(req.ID) {
 			filtered = append(filtered, req)
 		}
 	}
-	filtered = append(filtered, GroupHistoriesByRequestTimespan(reactor.store, mapToList(topics))...)
+	filtered = append(filtered, GroupHistoriesByRequestTimespan(reactor.store, mapToList(histories))...)
 	return RenewRequests(filtered, reactor.timeSource()), nil
 }
 

--- a/services/shhext/history_test.go
+++ b/services/shhext/history_test.go
@@ -53,7 +53,7 @@ func TestCreateTopicOptionsFromRequest(t *testing.T) {
 	require.Equal(t, topic, options[0].Topic)
 	require.Equal(t, uint64(now.Add(-WhisperTimeAllowance).Unix()), options[0].Range.Start,
 		"start of the range must be adjusted by the whisper time allowance")
-	require.Equal(t, uint64(now.UnixNano()), options[0].Range.End)
+	require.Equal(t, uint64(now.Unix()), options[0].Range.End)
 }
 
 func TestTopicOptionsToBloom(t *testing.T) {
@@ -174,8 +174,13 @@ func TestRequestFinishedUpdate(t *testing.T) {
 }
 
 func TestTopicHistoryUpdate(t *testing.T) {
+	reqID := common.Hash{1}
 	store := createInMemStore(t)
+	request := store.NewRequest()
+	request.ID = reqID
+	require.NoError(t, request.Save())
 	th := store.NewHistory(whisper.TopicType{1}, time.Hour)
+	th.RequestID = request.ID
 	require.NoError(t, th.Save())
 	reactor := NewHistoryUpdateReactor(store, NewRequestsRegistry(0), time.Now)
 	now := time.Now()

--- a/services/shhext/history_test.go
+++ b/services/shhext/history_test.go
@@ -161,9 +161,8 @@ func TestRequestFinishedUpdate(t *testing.T) {
 	require.NoError(t, req.Save())
 
 	reactor := NewHistoryUpdateReactor(store, NewRequestsRegistry(0), time.Now)
-	last := common.Hash{255}
 	require.NoError(t, reactor.UpdateFinishedRequest(req.ID))
-	require.NoError(t, reactor.UpdateTopicHistory(thOne.Topic, now, last))
+	require.NoError(t, reactor.UpdateTopicHistory(thOne.Topic, now))
 	_, err := store.GetRequest(req.ID)
 	require.EqualError(t, err, "leveldb: not found")
 
@@ -186,11 +185,11 @@ func TestTopicHistoryUpdate(t *testing.T) {
 	now := time.Now()
 	hour := now.Add(time.Hour)
 
-	require.NoError(t, reactor.UpdateTopicHistory(th.Topic, hour, common.Hash{3}))
+	require.NoError(t, reactor.UpdateTopicHistory(th.Topic, hour))
 	require.NoError(t, th.Load())
 	require.Equal(t, hour.Unix(), th.Current.Unix())
 
-	require.NoError(t, reactor.UpdateTopicHistory(th.Topic, now, common.Hash{4}))
+	require.NoError(t, reactor.UpdateTopicHistory(th.Topic, now))
 	require.NoError(t, th.Load())
 	require.Equal(t, hour.Unix(), th.Current.Unix())
 }

--- a/services/shhext/history_test.go
+++ b/services/shhext/history_test.go
@@ -162,7 +162,7 @@ func TestRequestFinishedUpdate(t *testing.T) {
 
 	reactor := NewHistoryUpdateReactor(store, NewRequestsRegistry(0), time.Now)
 	last := common.Hash{255}
-	require.NoError(t, reactor.UpdateFinishedRequest(req.ID, last))
+	require.NoError(t, reactor.UpdateFinishedRequest(req.ID))
 	require.NoError(t, reactor.UpdateTopicHistory(thOne.Topic, now, last))
 	_, err := store.GetRequest(req.ID)
 	require.EqualError(t, err, "leveldb: not found")

--- a/services/shhext/history_test.go
+++ b/services/shhext/history_test.go
@@ -1,0 +1,206 @@
+package shhext
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/status-im/status-go/db"
+	"github.com/status-im/status-go/mailserver"
+	whisper "github.com/status-im/whisper/whisperv6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createInMemStore(t *testing.T) db.HistoryStore {
+	mdb, err := db.NewMemoryDB()
+	require.NoError(t, err)
+	return db.NewHistoryStore(mdb)
+}
+
+func TestRenewRequest(t *testing.T) {
+	req := db.HistoryRequest{}
+	duration := time.Hour
+	req.AddHistory(db.TopicHistory{Duration: duration})
+
+	firstNow := time.Now()
+	RenewRequests([]db.HistoryRequest{req}, firstNow)
+
+	initial := firstNow.Add(-duration).Unix()
+
+	th := req.Histories()[0]
+	require.Equal(t, initial, th.Current.Unix())
+	require.Equal(t, initial, th.First.Unix())
+	require.Equal(t, firstNow.Unix(), th.End.Unix())
+
+	secondNow := time.Now()
+	RenewRequests([]db.HistoryRequest{req}, secondNow)
+
+	require.Equal(t, initial, th.Current.Unix())
+	require.Equal(t, initial, th.First.Unix())
+	require.Equal(t, secondNow.Unix(), th.End.Unix())
+}
+
+func TestCreateTopicOptionsFromRequest(t *testing.T) {
+	req := db.HistoryRequest{}
+	topic := whisper.TopicType{1}
+	now := time.Now()
+	req.AddHistory(db.TopicHistory{Topic: topic, Current: now, End: now})
+	options := CreateTopicOptionsFromRequest(req)
+	require.Len(t, options, len(req.Histories()),
+		"length must be equal to the number of topic histories attached to request")
+	require.Equal(t, topic, options[0].Topic)
+	require.Equal(t, uint64(now.Add(-WhisperTimeAllowance).Unix()), options[0].Range.Start,
+		"start of the range must be adjusted by the whisper time allowance")
+	require.Equal(t, uint64(now.UnixNano()), options[0].Range.End)
+}
+
+func TestTopicOptionsToBloom(t *testing.T) {
+	options := TopicOptions{
+		{Topic: whisper.TopicType{1}, Range: Range{Start: 1, End: 10}},
+		{Topic: whisper.TopicType{2}, Range: Range{Start: 3, End: 12}},
+	}
+	bloom := options.ToBloomFilterOption()
+	require.Equal(t, uint64(3), bloom.Range.Start, "Start must be the latest Start across all options")
+	require.Equal(t, uint64(12), bloom.Range.End, "End must be the latest End across all options")
+	require.Equal(t, topicsToBloom(options[0].Topic, options[1].Topic), bloom.Filter)
+}
+
+func TestBloomFilterToMessageRequestPayload(t *testing.T) {
+	var (
+		start   uint32 = 10
+		end     uint32 = 20
+		filter         = []byte{1, 1, 1, 1}
+		message        = mailserver.MessagesRequestPayload{
+			Lower: start,
+			Upper: end,
+			Bloom: filter,
+			Batch: true,
+			Limit: 10000,
+		}
+		bloomOption = BloomFilterOption{
+			Filter: filter,
+			Range: Range{
+				Start: uint64(start),
+				End:   uint64(end),
+			},
+		}
+	)
+	expected, err := rlp.EncodeToBytes(message)
+	require.NoError(t, err)
+	payload, err := bloomOption.ToMessagesRequestPayload()
+	require.NoError(t, err)
+	require.Equal(t, expected, payload)
+}
+
+func TestCreateRequestsEmptyState(t *testing.T) {
+	now := time.Now()
+	reactor := NewHistoryUpdateReactor(
+		createInMemStore(t), NewRequestsRegistry(0),
+		func() time.Time { return now })
+	requests, err := reactor.CreateRequests([]TopicRequest{
+		{Topic: whisper.TopicType{1}, Duration: time.Hour},
+		{Topic: whisper.TopicType{2}, Duration: time.Hour},
+		{Topic: whisper.TopicType{3}, Duration: 10 * time.Hour},
+	})
+	require.NoError(t, err)
+	require.Len(t, requests, 2)
+	var (
+		oneTopic, twoTopic db.HistoryRequest
+	)
+	if len(requests[0].Histories()) == 1 {
+		oneTopic, twoTopic = requests[0], requests[1]
+	} else {
+		oneTopic, twoTopic = requests[1], requests[0]
+	}
+	require.Len(t, oneTopic.Histories(), 1)
+	require.Len(t, twoTopic.Histories(), 2)
+
+}
+
+func TestCreateRequestsWithExistingRequest(t *testing.T) {
+	store := createInMemStore(t)
+	req := store.NewRequest()
+	req.ID = common.Hash{1}
+	th := store.NewHistory(whisper.TopicType{1}, time.Hour)
+	req.AddHistory(th)
+	require.NoError(t, req.Save())
+	reactor := NewHistoryUpdateReactor(store, NewRequestsRegistry(0), time.Now)
+	requests, err := reactor.CreateRequests([]TopicRequest{
+		{Topic: whisper.TopicType{1}, Duration: time.Hour},
+		{Topic: whisper.TopicType{2}, Duration: time.Hour},
+		{Topic: whisper.TopicType{3}, Duration: time.Hour},
+	})
+	require.NoError(t, err)
+	require.Len(t, requests, 2)
+
+	var (
+		oneTopic, twoTopic db.HistoryRequest
+	)
+	if len(requests[0].Histories()) == 1 {
+		oneTopic, twoTopic = requests[0], requests[1]
+	} else {
+		oneTopic, twoTopic = requests[1], requests[0]
+	}
+	assert.Len(t, oneTopic.Histories(), 1)
+	assert.Len(t, twoTopic.Histories(), 2)
+}
+
+func TestRequestFinishedUpdate(t *testing.T) {
+	store := createInMemStore(t)
+	req := store.NewRequest()
+	req.ID = common.Hash{1}
+	now := time.Now()
+	thOne := store.NewHistory(whisper.TopicType{1}, time.Hour)
+	thOne.End = now
+	thTwo := store.NewHistory(whisper.TopicType{2}, time.Hour)
+	thTwo.End = now
+	req.AddHistory(thOne)
+	req.AddHistory(thTwo)
+	require.NoError(t, req.Save())
+
+	reactor := NewHistoryUpdateReactor(store, NewRequestsRegistry(0), time.Now)
+	last := common.Hash{255}
+	require.NoError(t, reactor.UpdateFinishedRequest(req.ID, last))
+	require.NoError(t, reactor.UpdateTopicHistory(thOne.Topic, now, last))
+	_, err := store.GetRequest(req.ID)
+	require.EqualError(t, err, "leveldb: not found")
+
+	require.NoError(t, thOne.Load())
+	require.NoError(t, thTwo.Load())
+	require.Equal(t, thOne.End, thOne.Current)
+	require.Equal(t, thTwo.End, thTwo.Current)
+}
+
+func TestTopicHistoryUpdate(t *testing.T) {
+	store := createInMemStore(t)
+	th := store.NewHistory(whisper.TopicType{1}, time.Hour)
+	require.NoError(t, th.Save())
+	reactor := NewHistoryUpdateReactor(store, NewRequestsRegistry(0), time.Now)
+	now := time.Now()
+	hour := now.Add(time.Hour)
+
+	require.NoError(t, reactor.UpdateTopicHistory(th.Topic, hour, common.Hash{3}))
+	require.NoError(t, th.Load())
+	require.Equal(t, hour.Unix(), th.Current.Unix())
+
+	require.NoError(t, reactor.UpdateTopicHistory(th.Topic, now, common.Hash{4}))
+	require.NoError(t, th.Load())
+	require.Equal(t, hour.Unix(), th.Current.Unix())
+}
+
+func TestGroupHistoriesByRequestTimestamp(t *testing.T) {
+	requests := GroupHistoriesByRequestTimespan(createInMemStore(t), []db.TopicHistory{
+		{Topic: whisper.TopicType{1}, Duration: time.Hour},
+		{Topic: whisper.TopicType{2}, Duration: time.Hour},
+		{Topic: whisper.TopicType{3}, Duration: 2 * time.Hour},
+		{Topic: whisper.TopicType{4}, Duration: 2 * time.Hour},
+		{Topic: whisper.TopicType{5}, Duration: 3 * time.Hour},
+		{Topic: whisper.TopicType{6}, Duration: 3 * time.Hour},
+	})
+	require.Len(t, requests, 3)
+	for _, req := range requests {
+		require.Len(t, req.Histories(), 2)
+	}
+}

--- a/services/shhext/requests.go
+++ b/services/shhext/requests.go
@@ -57,6 +57,14 @@ func (r *RequestsRegistry) Register(uid common.Hash, topics []whisper.TopicType)
 	return nil
 }
 
+// Has returns true if given uid is stored in registry.
+func (r *RequestsRegistry) Has(uid common.Hash) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, exist := r.uidToTopics[uid]
+	return exist
+}
+
 // Unregister removes request with given UID from registry.
 func (r *RequestsRegistry) Unregister(uid common.Hash) {
 	r.mu.Lock()

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -800,7 +800,7 @@ func (s *RequestWithTrackingHistorySuite) createEmptyFilter(topics ...whisper.To
 }
 
 func (s *RequestWithTrackingHistorySuite) initiateHistoryRequest(topics ...TopicRequest) []hexutil.Bytes {
-	requests, err := s.localAPI.InitiateHistoryRequests(InitiateHistoryRequest{
+	requests, err := s.localAPI.InitiateHistoryRequests(InitiateHistoryRequestParams{
 		Peer:     s.remoteNode.String(),
 		SymKeyID: s.mailSymKey,
 		Timeout:  10 * time.Second,

--- a/services/shhext/service_test.go
+++ b/services/shhext/service_test.go
@@ -857,9 +857,9 @@ func (s *RequestWithTrackingHistorySuite) TestMultipleMergeIntoOne() {
 	s.Require().Len(requests, 2)
 	s.waitMessagesDelivered(filterid, hexes...)
 
-	s.Require().NoError(s.localService.historyUpdates.UpdateTopicHistory(topic1, time.Now(), common.BytesToHash(hexes[0])))
-	s.Require().NoError(s.localService.historyUpdates.UpdateTopicHistory(topic2, time.Now(), common.BytesToHash(hexes[1])))
-	s.Require().NoError(s.localService.historyUpdates.UpdateTopicHistory(topic3, time.Now(), common.BytesToHash(hexes[2])))
+	s.Require().NoError(s.localService.historyUpdates.UpdateTopicHistory(topic1, time.Now()))
+	s.Require().NoError(s.localService.historyUpdates.UpdateTopicHistory(topic2, time.Now()))
+	s.Require().NoError(s.localService.historyUpdates.UpdateTopicHistory(topic3, time.Now()))
 	for _, r := range requests {
 		s.Require().NoError(s.localAPI.CompleteRequest(context.TODO(), r.String()))
 	}

--- a/signal/events_shhext.go
+++ b/signal/events_shhext.go
@@ -14,6 +14,9 @@ const (
 	// to any peer
 	EventEnvelopeExpired = "envelope.expired"
 
+	// EventEnvelopeDiscarded is triggerd when envelope was discarded by a peer for some reason.
+	EventEnvelopeDiscarded = "envelope.discarded"
+
 	// EventMailServerRequestCompleted is triggered when whisper receives a message ack from the mailserver
 	EventMailServerRequestCompleted = "mailserver.request.completed"
 


### PR DESCRIPTION
After this API fully implemented it will allow to skip envelopes that client already received. The new API requires user to set which topics expected to be synced with a duration for each topic. For example, topic1=24 hours and topic2=7 days. After that application will generate and send requests for specified topics.

Concurrently we will be waiting for new envelopes from mail server. They will be arriving in the forward order, and we will be persisting every new timestamp on disk. In the case, if initially created request failed we will re-try it, but time range for the new request will be updated and request will progress. So, even if a connection is extremely flaky and slow we have a guarantee that history synchronization will progress.

Request between mail client and mail server will be performed with bloom filter. There will be no major changes in that client-server flow. The difference will be how that request is generated. At first when topics are received they will be grouped by the duration. So if we will have 2 different topics with same duration - we will make only one request with a bloom filter created from those topics. In case when duration is different, like 24 hours and 7 days - we will have to create different requests. I believe we do the same thing on status-react right now, but the implementation is somewhat different.

Also we will have to ensure that every request is finished before adding more topics to that request. This is required to ensure that all data will be downloaded for new topics without receiving duplicate data for old one. So every time we will receive request with new API - we will check if there are any pending requests that were terminated, exclude topics that are covered by such requests, and only then form new requests from all other topics. 

Example for a such condition: at first we requested messages starting from 0 to 10 and defined by bloom filter 1100. We know that the last message in this bloom filter was timestamped by 5, so if connection will be terminated/or app closed - we can safely restart request with same bloom filter and range from 5 to 10. At the same time new topic was added (doesn't matter if it is covered by existing bloom filter or not). We want to receive all data for this topic as well, from 0 to 10. As you see we cannot include this topic in the previous request, it will start from 5.