### PR TITLE
Deliver envelopes in forward order

### DIFF
--- a/mailserver/db_key.go
+++ b/mailserver/db_key.go
@@ -53,13 +53,3 @@ func NewDBKeyFromBytes(b []byte) (*DBKey, error) {
 		hash:      common.BytesToHash(b[4:]),
 	}, nil
 }
-
-// mustNewDBKeyFromBytes panics if creating a key from a byte slice fails.
-// Check if a byte slice has DBKeyLength length before using it.
-func mustNewDBKeyFromBytes(b []byte) *DBKey {
-	k, err := NewDBKeyFromBytes(b)
-	if err != nil {
-		panic(err)
-	}
-	return k
-}

--- a/mailserver/mailserver_test.go
+++ b/mailserver/mailserver_test.go
@@ -299,10 +299,10 @@ func (s *MailserverSuite) TestRequestPaginationLimit() {
 	defer s.server.Close()
 
 	var (
-		sentEnvelopes     []*whisper.Envelope
-		reverseSentHashes []common.Hash
-		receivedHashes    []common.Hash
-		archiveKeys       []string
+		sentEnvelopes  []*whisper.Envelope
+		sentHashes     []common.Hash
+		receivedHashes []common.Hash
+		archiveKeys    []string
 	)
 
 	now := time.Now()
@@ -316,7 +316,7 @@ func (s *MailserverSuite) TestRequestPaginationLimit() {
 		key := NewDBKey(env.Expiry-env.TTL, env.Hash())
 		archiveKeys = append(archiveKeys, fmt.Sprintf("%x", key.Bytes()))
 		sentEnvelopes = append(sentEnvelopes, env)
-		reverseSentHashes = append([]common.Hash{env.Hash()}, reverseSentHashes...)
+		sentHashes = append(sentHashes, env.Hash())
 	}
 
 	reqLimit := uint32(6)
@@ -334,11 +334,11 @@ func (s *MailserverSuite) TestRequestPaginationLimit() {
 	// 10 envelopes sent
 	s.Equal(count, uint32(len(sentEnvelopes)))
 	// 6 envelopes received
-	s.Equal(int(limit), len(receivedHashes))
-	// the 6 envelopes received should be in descending order
-	s.Equal(reverseSentHashes[:limit], receivedHashes)
+	s.Len(receivedHashes, int(limit))
+	// the 6 envelopes received should be in forward order
+	s.Equal(sentHashes[:limit], receivedHashes)
 	// cursor should be the key of the last envelope of the last page
-	s.Equal(archiveKeys[count-limit], fmt.Sprintf("%x", cursor))
+	s.Equal(archiveKeys[limit-1], fmt.Sprintf("%x", cursor))
 
 	// second page
 	receivedHashes, cursor, _ = processRequestAndCollectHashes(


### PR DESCRIPTION
This is a requirement for https://github.com/status-im/status-go/pull/1433

Envelopes are delivered in order, from latest to newest. Returned cursor is a timestamp+envelope hash of the last delivered envelope. The difference is that we always iterate from lower to upper, and if cursor provided we will seek cursor and iterate from it till the end (upper bound). 

As i understand new flow will be incompatible with requests that will be in-flight at the moment of new mailserver deployment. Not sure how big is the issue, i would prefer not to add another query type for backward compatibility and just take the risk that some query will fail. What are people thoughts about that issue?