### PR TITLE
fix release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: statusgo-android statusgo-ios
 
 RELEASE_TAG := $(shell cat VERSION)
-RELEASE_BRANCH := "develop"
+RELEASE_BRANCH := develop
 RELEASE_DIR := /tmp/release-$(RELEASE_TAG)
 PRE_RELEASE := "1"
 RELEASE_TYPE := $(shell if [ $(PRE_RELEASE) = "0" ] ; then echo release; else echo pre-release ; fi)
@@ -219,7 +219,7 @@ clean-release:
 	rm -rf $(RELEASE_DIR)
 
 release:
-	@read -p "Are you sure you want to create a new GitHub $(RELEASE_TYPE} against $(RELEASE_BRANCH) branch? (y/n): " REPLY; \
+	@read -p "Are you sure you want to create a new GitHub $(RELEASE_TYPE) against $(RELEASE_BRANCH) branch? (y/n): " REPLY; \
 	if [ $$REPLY = "y" ]; then \
 		latest_tag=$$(git describe --tags `git rev-list --tags --max-count=1`); \
 		comparison="$$latest_tag..HEAD"; \

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
   }
 
   environment {
-    STATUS_PATH = 'src/github.com/status-im/status-go'
+    STATUS_PATH = "${env.WORKSPACE}/src/github.com/status-im/status-go"
     CI_DIR      = "${env.STATUS_PATH}/_assets/ci"
     GOPATH      = "${env.WORKSPACE}"
     PATH        = "${env.PATH}:${env.GOPATH}/bin"
@@ -38,7 +38,7 @@ pipeline {
     stage('Prep') {
       steps { script {
         lib = load("${env.STATUS_PATH}/_assets/ci/lib.groovy")
-        version = readFile("${STATUS_PATH}/VERSION").trim()
+        version = lib.getVersion()
         println("Version: ${version}")
         println("Git Branch: ${lib.gitBranch()}")
         println("Git Commit: ${lib.gitCommit()}")
@@ -86,11 +86,11 @@ pipeline {
 
     stage('Release') { when { expression { params.RELEASE == true } }
       steps { script {
+        def suffix = "-"+lib.suffix()
         /* rename build files to not include versions */
         dir(env.RELEASE_DIR) {
-          def pkgs = findFiles(glob: 'status-go-*')
-          pkgs.each { pkg ->
-            sh "mv ${pkg.path} ${pkg.path.replace("-"+lib.suffix(), "")}"
+          findFiles(glob: 'status-go-*').each { pkg ->
+            sh "mv ${pkg.path} ${pkg.path.replace(suffix, "")}"
           }
         }
         /* perform the release */

--- a/_assets/ci/lib.groovy
+++ b/_assets/ci/lib.groovy
@@ -33,10 +33,6 @@ def getFilename(path) {
   return path.tokenize('/')[-1]
 }
 
-def getReleaseDir() {
-  return '/tmp/release-' + new File(env.WORKSPACE + '/VERSION').text.trim()
-}
-
 def uploadArtifact(path) {
   /* defaults for upload */
   def domain = 'ams3.digitaloceanspaces.com'


### PR DESCRIPTION
Fix for release builds for bug from #1439. `STATUS_PATH` needs to be an absolute path so `dir()` doesn't change it's effect. Also removes `getReleaseDir()` because it does nothing.

Error:

```
java.nio.file.NoSuchFileException: /home/jenkins/workspace/status-go/manual/pkg/src/github.com/status-im/status-go/VERSION
```

https://ci.status.im/job/status-go/job/manual/400/console

Successful manual build on this branch:
https://ci.status.im/job/status-go/job/manual/404/console
Failed to create release since it already exists.

