### PR TITLE
WIP/Fixing Deps for Raspberry Pi install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,19 +16,6 @@ endif
 
 
 EXPECTED_PATH=$(shell go env GOPATH)/src/github.com/status-im/status-go
-ifneq ($(CURDIR),$(EXPECTED_PATH))
-define NOT_IN_GOPATH_ERROR
-
-Current dir is $(CURDIR), which seems to be different from your GOPATH.
-Please, build status-go from GOPATH for proper build.
-  GOPATH       = $(shell go env GOPATH)
-  Current dir  = $(CURDIR)
-  Expected dir = $(EXPECTED_PATH))
-See https://golang.org/doc/code.html#GOPATH for more info
-
-endef
-$(error $(NOT_IN_GOPATH_ERROR))
-endif
 
 CGO_CFLAGS = -I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 GOBIN = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))build/bin
@@ -192,7 +179,7 @@ install-os-dependencies:
 
 setup-dev: setup-build mock-install install-os-dependencies gen-install ##@other Prepare project for development
 
-setup-build: dep-install lint-install release-install gomobile-install ##@other Prepare project for build
+setup-build: dep-install release-install gomobile-install ##@other Prepare project for build
 
 setup: setup-build setup-dev ##@other Prepare project for development and building
 
@@ -236,7 +223,6 @@ gen-install:
 
 mock-install: ##@other Install mocking tools
 	go get -u github.com/golang/mock/mockgen
-	dep ensure -update github.com/golang/mock
 
 mock: ##@other Regenerate mocks
 	mockgen -package=fcm          -destination=notifications/push/fcm/client_mock.go -source=notifications/push/fcm/client.go
@@ -286,8 +272,7 @@ lint-install:
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $(GOPATH)/bin v1.10.2
 
 lint:
-	@echo "lint"
-	@golangci-lint run ./...
+	@echo "No linter available"
 
 ci: lint dep-ensure canary-test test-unit test-e2e ##@tests Run all linters and tests at once
 

--- a/_assets/scripts/install_deps.sh
+++ b/_assets/scripts/install_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -x "$(command -v apt)" ]; then
-  apt install -y protobuf-compiler jq
+  echo "apt install -y protobuf-compiler jq"
 fi
 
 if [ -x "$(command -v pacman)" ]; then


### PR DESCRIPTION
This PR is a WIP for setting up status-go on a Raspberry Pi. Not meant to be directly added, but probably could serve as a starting point for getting a working solution for Raspberry Pis.

To set up on a Raspberry Pi, a few of the Makefile commands must be altered as well as some of the deps that aren't necessary to run.

Important changes:
- [ ] Removes go `dep` library ensure checks for mocks.
- [ ] Removes `install-os-dependencies and assumes user manually installs using `apt-get`.
- [ ] Removes go `golangci-lint` library since it does not allow builds on ARM architectures.
- [ ] Removes gopath check. The user has to install from source and make adjustments and must manually add the library to the gopath src directory.

Closes #1441