### PR TITLE
Execute writes atomically only after request was processed without errors

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -34,7 +34,7 @@ func NewMemoryDB() (*leveldb.DB, error) {
 }
 
 // NewDBNamespace returns instance that ensures isolated operations.
-func NewDBNamespace(db *leveldb.DB, prefix storagePrefix) LevelDBNamespace {
+func NewDBNamespace(db Storage, prefix storagePrefix) LevelDBNamespace {
 	return LevelDBNamespace{
 		db:     db,
 		prefix: prefix,
@@ -48,7 +48,7 @@ func NewMemoryDBNamespace(prefix storagePrefix) (pdb LevelDBNamespace, err error
 	if err != nil {
 		return pdb, err
 	}
-	return NewDBNamespace(db, prefix), nil
+	return NewDBNamespace(LevelDBStorage{db: db}, prefix), nil
 }
 
 // Key creates a DB key for a specified service with specified data
@@ -91,7 +91,7 @@ func Open(path string, opts *opt.Options) (db *leveldb.DB, err error) {
 
 // LevelDBNamespace database where all operations will be prefixed with a certain bucket.
 type LevelDBNamespace struct {
-	db     *leveldb.DB
+	db     Storage
 	prefix storagePrefix
 }
 
@@ -103,11 +103,11 @@ func (db LevelDBNamespace) prefixedKey(key []byte) []byte {
 }
 
 func (db LevelDBNamespace) Put(key, value []byte) error {
-	return db.db.Put(db.prefixedKey(key), value, nil)
+	return db.db.Put(db.prefixedKey(key), value)
 }
 
 func (db LevelDBNamespace) Get(key []byte) ([]byte, error) {
-	return db.db.Get(db.prefixedKey(key), nil)
+	return db.db.Get(db.prefixedKey(key))
 }
 
 // Range returns leveldb util.Range prefixed with a single byte.
@@ -121,12 +121,12 @@ func (db LevelDBNamespace) Range(prefix, limit []byte) *util.Range {
 
 // Delete removes key from database.
 func (db LevelDBNamespace) Delete(key []byte) error {
-	return db.db.Delete(db.prefixedKey(key), nil)
+	return db.db.Delete(db.prefixedKey(key))
 }
 
 // NewIterator returns iterator for a given slice.
 func (db LevelDBNamespace) NewIterator(slice *util.Range) NamespaceIterator {
-	return NamespaceIterator{db.db.NewIterator(slice, nil)}
+	return NamespaceIterator{db.db.NewIterator(slice)}
 }
 
 // NamespaceIterator wraps leveldb iterator, works mostly the same way.

--- a/db/history_store.go
+++ b/db/history_store.go
@@ -5,15 +5,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	whisper "github.com/status-im/whisper/whisperv6"
-	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 )
 
 // NewHistoryStore returns HistoryStore instance.
-func NewHistoryStore(db *leveldb.DB) HistoryStore {
+func NewHistoryStore(storage Storage) HistoryStore {
 	return HistoryStore{
-		topicDB:   NewDBNamespace(db, TopicHistoryBucket),
-		requestDB: NewDBNamespace(db, HistoryRequestBucket),
+		topicDB:   NewDBNamespace(storage, TopicHistoryBucket),
+		requestDB: NewDBNamespace(storage, HistoryRequestBucket),
 	}
 }
 

--- a/db/history_store_test.go
+++ b/db/history_store_test.go
@@ -12,7 +12,7 @@ import (
 func createInMemStore(t *testing.T) HistoryStore {
 	db, err := NewMemoryDB()
 	require.NoError(t, err)
-	return NewHistoryStore(db)
+	return NewHistoryStore(LevelDBStorage{db: db})
 }
 
 func TestGetNewHistory(t *testing.T) {

--- a/db/storage.go
+++ b/db/storage.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+// Storage is an interface for common db operations.
+type Storage interface {
+	Put([]byte, []byte) error
+	Delete([]byte) error
+	Get([]byte) ([]byte, error)
+	NewIterator(*util.Range) iterator.Iterator
+}
+
+// CommitStorage allows to write all tx/batched values atomically.
+type CommitStorage interface {
+	Storage
+	Commit() error
+}
+
+// TransactionalStorage adds transaction features on top of regular storage.
+type TransactionalStorage interface {
+	Storage
+	NewTx() CommitStorage
+}
+
+// NewMemoryLevelDBStorage returns LevelDBStorage instance with in memory leveldb backend.
+func NewMemoryLevelDBStorage() (LevelDBStorage, error) {
+	mdb, err := leveldb.Open(storage.NewMemStorage(), nil)
+	if err != nil {
+		return LevelDBStorage{}, err
+	}
+	return NewLevelDBStorage(mdb), nil
+}
+
+// NewLevelDBStorage creates new LevelDBStorage instance.
+func NewLevelDBStorage(db *leveldb.DB) LevelDBStorage {
+	return LevelDBStorage{db: db}
+}
+
+// LevelDBStorage wrapper around leveldb.DB.
+type LevelDBStorage struct {
+	db *leveldb.DB
+}
+
+// Put upserts given key/value pair.
+func (db LevelDBStorage) Put(key, buf []byte) error {
+	return db.db.Put(key, buf, nil)
+}
+
+// Delete removes given key from database..
+func (db LevelDBStorage) Delete(key []byte) error {
+	return db.db.Delete(key, nil)
+}
+
+// Get returns value for a given key.
+func (db LevelDBStorage) Get(key []byte) ([]byte, error) {
+	return db.db.Get(key, nil)
+}
+
+// NewIterator returns new leveldb iterator.Iterator instance for a given range.
+func (db LevelDBStorage) NewIterator(slice *util.Range) iterator.Iterator {
+	return db.db.NewIterator(slice, nil)
+}
+
+// NewTx is a wrapper around leveldb.Batch that allows to write atomically.
+func (db LevelDBStorage) NewTx() CommitStorage {
+	return LevelDBTx{
+		batch: &leveldb.Batch{},
+		db:    db,
+	}
+}

--- a/db/tx.go
+++ b/db/tx.go
@@ -1,0 +1,40 @@
+package db
+
+import (
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+// LevelDBTx doesn't provide any read isolation. It allows to commit all writes atomically (put/delete).
+type LevelDBTx struct {
+	batch *leveldb.Batch
+	db    LevelDBStorage
+}
+
+// Put adds key/value to associated batch.
+func (tx LevelDBTx) Put(key, buf []byte) error {
+	tx.batch.Put(key, buf)
+	return nil
+}
+
+// Delete adds delete operation to associated batch.
+func (tx LevelDBTx) Delete(key []byte) error {
+	tx.batch.Delete(key)
+	return nil
+}
+
+// Get reads from currently commited state.
+func (tx LevelDBTx) Get(key []byte) ([]byte, error) {
+	return tx.db.Get(key)
+}
+
+// NewIterator returns iterator.Iterator that will read from currently commited state.
+func (tx LevelDBTx) NewIterator(slice *util.Range) iterator.Iterator {
+	return tx.db.NewIterator(slice)
+}
+
+// Commit writes batch atomically.
+func (tx LevelDBTx) Commit() error {
+	return tx.db.db.Write(tx.batch, nil)
+}

--- a/db/tx.go
+++ b/db/tx.go
@@ -6,7 +6,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
-// LevelDBTx doesn't provide any read isolation. It allows to commit all writes atomically (put/delete).
+// LevelDBTx doesn't provide any read isolation. It allows committing all writes atomically (put/delete).
 type LevelDBTx struct {
 	batch *leveldb.Batch
 	db    LevelDBStorage

--- a/db/tx.go
+++ b/db/tx.go
@@ -24,12 +24,12 @@ func (tx LevelDBTx) Delete(key []byte) error {
 	return nil
 }
 
-// Get reads from currently commited state.
+// Get reads from currently committed state.
 func (tx LevelDBTx) Get(key []byte) ([]byte, error) {
 	return tx.db.Get(key)
 }
 
-// NewIterator returns iterator.Iterator that will read from currently commited state.
+// NewIterator returns iterator.Iterator that will read from currently committed state.
 func (tx LevelDBTx) NewIterator(slice *util.Range) iterator.Iterator {
 	return tx.db.NewIterator(slice)
 }

--- a/db/tx_test.go
+++ b/db/tx_test.go
@@ -1,0 +1,23 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxWritesOnCommit(t *testing.T) {
+	storage, err := NewMemoryLevelDBStorage()
+	tx := storage.NewTx()
+	require.NoError(t, err)
+	key := []byte{1}
+	val := []byte{1, 1}
+	require.NoError(t, tx.Put(key, val))
+	result, err := storage.Get(key)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.NoError(t, tx.Commit())
+	result, err = storage.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, val, result)
+}

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -595,15 +595,19 @@ func (api *PublicAPI) InitiateHistoryRequests(parent context.Context, request In
 	if err != nil {
 		return nil, err
 	}
+	var (
+		payload []byte
+		hash    common.Hash
+	)
 	for i := range requests {
 		req := requests[i]
 		options := CreateTopicOptionsFromRequest(req)
 		bloom := options.ToBloomFilterOption()
-		payload, err := bloom.ToMessagesRequestPayload()
+		payload, err = bloom.ToMessagesRequestPayload()
 		if err != nil {
 			return rst, err
 		}
-		hash, err := api.requestMessagesUsingPayload(req, request.Peer, request.SymKeyID, payload, request.Force, request.Timeout, options.Topics())
+		hash, err = api.requestMessagesUsingPayload(req, request.Peer, request.SymKeyID, payload, request.Force, request.Timeout, options.Topics())
 		if err != nil {
 			return rst, err
 		}
@@ -613,10 +617,10 @@ func (api *PublicAPI) InitiateHistoryRequests(parent context.Context, request In
 }
 
 // CompleteRequest client must mark request completed when all envelopes were processed.
-func (api *PublicAPI) CompleteRequest(parent context.Context, hex string) error {
+func (api *PublicAPI) CompleteRequest(parent context.Context, hex string) (err error) {
 	tx := api.service.storage.NewTx()
 	ctx := NewContextFromService(parent, api.service, tx)
-	err := api.service.historyUpdates.UpdateFinishedRequest(ctx, common.HexToHash(hex))
+	err = api.service.historyUpdates.UpdateFinishedRequest(ctx, common.HexToHash(hex))
 	if err == nil {
 		return tx.Commit()
 	}

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -611,7 +611,7 @@ func (api *PublicAPI) InitiateHistoryRequests(parent context.Context, request In
 		if err != nil {
 			return rst, err
 		}
-		rst = append(rst, hash[:])
+		rst = append(rst, hash.Bytes())
 	}
 	return rst, err
 }

--- a/services/shhext/api.go
+++ b/services/shhext/api.go
@@ -427,16 +427,24 @@ func (api *PublicAPI) GetNewFilterMessages(filterID string) ([]dedup.Deduplicate
 
 // ConfirmMessagesProcessed is a method to confirm that messages was consumed by
 // the client side.
-func (api *PublicAPI) ConfirmMessagesProcessed(messages []*whisper.Message) error {
+func (api *PublicAPI) ConfirmMessagesProcessed(messages []*whisper.Message) (err error) {
+	tx := api.service.storage.NewTx()
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+		}
+	}()
+	ctx := NewContextFromService(context.Background(), api.service, tx)
 	for _, msg := range messages {
 		if msg.P2P {
-			err := api.service.historyUpdates.UpdateTopicHistory(msg.Topic, time.Unix(int64(msg.Timestamp), 0))
+			err = api.service.historyUpdates.UpdateTopicHistory(ctx, msg.Topic, time.Unix(int64(msg.Timestamp), 0))
 			if err != nil {
 				return err
 			}
 		}
 	}
-	return api.service.deduplicator.AddMessages(messages)
+	err = api.service.deduplicator.AddMessages(messages)
+	return err
 }
 
 // ConfirmMessagesProcessedByID is a method to confirm that messages was consumed by
@@ -575,9 +583,15 @@ func (api *PublicAPI) requestMessagesUsingPayload(request db.HistoryRequest, pee
 // - Topic
 // - Duration in nanoseconds. Will be used to determine starting time for history request.
 // After that status-go will guarantee that request for this topic and date will be performed.
-func (api *PublicAPI) InitiateHistoryRequests(request InitiateHistoryRequestParams) ([]hexutil.Bytes, error) {
-	rst := []hexutil.Bytes{}
-	requests, err := api.service.historyUpdates.CreateRequests(request.Requests)
+func (api *PublicAPI) InitiateHistoryRequests(parent context.Context, request InitiateHistoryRequestParams) (rst []hexutil.Bytes, err error) {
+	tx := api.service.storage.NewTx()
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+		}
+	}()
+	ctx := NewContextFromService(parent, api.service, tx)
+	requests, err := api.service.historyUpdates.CreateRequests(ctx, request.Requests)
 	if err != nil {
 		return nil, err
 	}
@@ -595,12 +609,18 @@ func (api *PublicAPI) InitiateHistoryRequests(request InitiateHistoryRequestPara
 		}
 		rst = append(rst, hash[:])
 	}
-	return rst, nil
+	return rst, err
 }
 
 // CompleteRequest client must mark request completed when all envelopes were processed.
-func (api *PublicAPI) CompleteRequest(ctx context.Context, hex string) error {
-	return api.service.historyUpdates.UpdateFinishedRequest(common.HexToHash(hex))
+func (api *PublicAPI) CompleteRequest(parent context.Context, hex string) error {
+	tx := api.service.storage.NewTx()
+	ctx := NewContextFromService(parent, api.service, tx)
+	err := api.service.historyUpdates.UpdateFinishedRequest(ctx, common.HexToHash(hex))
+	if err == nil {
+		return tx.Commit()
+	}
+	return err
 }
 
 // DEPRECATED: use SendDirectMessage with DH flag

--- a/services/shhext/context.go
+++ b/services/shhext/context.go
@@ -1,0 +1,60 @@
+package shhext
+
+import (
+	"context"
+	"time"
+
+	"github.com/status-im/status-go/db"
+)
+
+// ContextKey is a type used for keys in shhext Context.
+type ContextKey struct {
+	Name string
+}
+
+// NewContextKey returns new ContextKey instance.
+func NewContextKey(name string) ContextKey {
+	return ContextKey{Name: name}
+}
+
+var (
+	historyDBKey       = NewContextKey("history_db")
+	requestRegistryKey = NewContextKey("request_registry")
+	timeKey            = NewContextKey("time")
+)
+
+// NewContextFromService creates new context instance using Service fileds directly and Storage.
+func NewContextFromService(ctx context.Context, service *Service, storage db.Storage) Context {
+	return NewContext(ctx, service.w.GetCurrentTime, service.requestsRegistry, storage)
+}
+
+// NewContext creates Context with all required fields.
+func NewContext(ctx context.Context, source TimeSource, registry *RequestsRegistry, storage db.Storage) Context {
+	ctx = context.WithValue(ctx, historyDBKey, db.NewHistoryStore(storage))
+	ctx = context.WithValue(ctx, timeKey, source)
+	ctx = context.WithValue(ctx, requestRegistryKey, registry)
+	return Context{ctx}
+}
+
+// TimeSource is a type used for current time.
+type TimeSource func() time.Time
+
+// Context provides access to request-scoped values.
+type Context struct {
+	context.Context
+}
+
+// HistoryStore returns db.HistoryStore instance associated with this request.
+func (c Context) HistoryStore() db.HistoryStore {
+	return c.Value(historyDBKey).(db.HistoryStore)
+}
+
+// Time returns current time using time function associated with this request.
+func (c Context) Time() time.Time {
+	return c.Value(timeKey).(TimeSource)()
+}
+
+// RequestRegistry returns RequestRegistry that tracks each request life-span.
+func (c Context) RequestRegistry() *RequestsRegistry {
+	return c.Value(requestRegistryKey).(*RequestsRegistry)
+}

--- a/services/shhext/history.go
+++ b/services/shhext/history.go
@@ -353,8 +353,8 @@ func (filter BloomFilterOption) ToMessagesRequestPayload() ([]byte, error) {
 		Bloom: filter.Filter,
 		// Client must tell the MailServer if it supports batch responses.
 		// This can be removed in the future.
-		Batch: true,
-		Limit: 10000,
+		//Batch: true,
+		Limit: 100000,
 	}
 	return rlp.EncodeToBytes(payload)
 }

--- a/services/shhext/history.go
+++ b/services/shhext/history.go
@@ -353,8 +353,8 @@ func (filter BloomFilterOption) ToMessagesRequestPayload() ([]byte, error) {
 		Bloom: filter.Filter,
 		// Client must tell the MailServer if it supports batch responses.
 		// This can be removed in the future.
-		//Batch: true,
-		Limit: 100000,
+		Batch: true,
+		Limit: 10000,
 	}
 	return rlp.EncodeToBytes(payload)
 }

--- a/services/shhext/history_test.go
+++ b/services/shhext/history_test.go
@@ -76,7 +76,8 @@ func TestBloomFilterToMessageRequestPayload(t *testing.T) {
 			Lower: start,
 			Upper: end,
 			Bloom: filter,
-			Limit: 100000,
+			Batch: true,
+			Limit: 10000,
 		}
 		bloomOption = BloomFilterOption{
 			Filter: filter,

--- a/services/shhext/history_test.go
+++ b/services/shhext/history_test.go
@@ -76,8 +76,7 @@ func TestBloomFilterToMessageRequestPayload(t *testing.T) {
 			Lower: start,
 			Upper: end,
 			Bloom: filter,
-			Batch: true,
-			Limit: 10000,
+			Limit: 100000,
 		}
 		bloomOption = BloomFilterOption{
 			Filter: filter,

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -42,6 +42,7 @@ type EnvelopeEventsHandler interface {
 
 // Service is a service that provides some additional Whisper API.
 type Service struct {
+	storage          db.TransactionalStorage
 	w                *whisper.Whisper
 	config           params.ShhextConfig
 	envelopesMonitor *EnvelopesMonitor
@@ -73,7 +74,7 @@ func New(w *whisper.Whisper, handler EnvelopeEventsHandler, ldb *leveldb.DB, con
 		delay = config.RequestsDelay
 	}
 	requestsRegistry := NewRequestsRegistry(delay)
-	historyUpdates := NewHistoryUpdateReactor(db.NewHistoryStore(ldb), requestsRegistry, w.GetCurrentTime)
+	historyUpdates := NewHistoryUpdateReactor()
 	mailMonitor := &MailRequestMonitor{
 		w:                w,
 		handler:          handler,
@@ -82,6 +83,7 @@ func New(w *whisper.Whisper, handler EnvelopeEventsHandler, ldb *leveldb.DB, con
 	}
 	envelopesMonitor := NewEnvelopesMonitor(w, handler, config.MailServerConfirmations, ps, config.MaxMessageDeliveryAttempts)
 	return &Service{
+		storage:          db.NewLevelDBStorage(ldb),
 		w:                w,
 		config:           config,
 		envelopesMonitor: envelopesMonitor,


### PR DESCRIPTION
In order to avoid corrupted state due to unpredictable interrupt or storage error all writes will be performed atomically. It also makes it easier to reason about request flow.

I reused leveldb.Batch to enforce that. It doesn't provide any read isolation and doesn't allow to read its own uncommitted writes, so it shouldn't be used as a regular sql transaction.