### PR TITLE
Fix channel subscriber that was blocking sending new requests

### DIFF
--- a/services/shhext/api_test.go
+++ b/services/shhext/api_test.go
@@ -220,3 +220,20 @@ func TestSyncMessagesErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestExpiredOrCompleted(t *testing.T) {
+	timeout := time.Millisecond
+	events := make(chan whisper.EnvelopeEvent)
+	errors := make(chan error, 1)
+	hash := common.Hash{1}
+	go func() {
+		_, err := waitForExpiredOrCompleted(hash, events, timeout)
+		errors <- err
+	}()
+	select {
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for waitForExpiredOrCompleted to complete")
+	case err := <-errors:
+		require.EqualError(t, err, fmt.Sprintf("request %x expired", hash))
+	}
+}


### PR DESCRIPTION
In RequestMessagesSync subscriber is listening to a feed where all whisper
events are posted. After we received event with a request hash - subscriber will
stop actively consuming messages from a feed, as a subscription channel will
get overflow and whole feed will get blocked.

Some events are posted to a feed before request is sent, so because of this issue client won't be able to send some requests.

Found this issue while testing status-console-client.