### PR TITLE
Set BINARY variable for golangci-lint.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ RELEASE_BRANCH := develop
 RELEASE_DIR := /tmp/release-$(RELEASE_TAG)
 PRE_RELEASE := "1"
 RELEASE_TYPE := $(shell if [ $(PRE_RELEASE) = "0" ] ; then echo release; else echo pre-release ; fi)
+GOLANGCI_BINARY=golangci-lint
 
 help: ##@other Show this help
 	@perl -e '$(HELP_FUN)' $(MAKEFILE_LIST)
@@ -269,7 +270,7 @@ canary-test: node-canary
 
 lint-install:
 	@# The following installs a specific version of golangci-lint, which is appropriate for a CI server to avoid different results from build to build
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $(GOPATH)/bin v1.17.1
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINARY=$(GOLANGCI_BINARY) bash -s -- -d -b $(GOPATH)/bin v1.17.1
 
 lint:
 	@echo "lint"

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ lint-install:
 
 lint:
 	@echo "lint"
-	@golangci-lint run ./...
+	@golangci-lint run ./... --deadline=5m
 
 ci: lint canary-test test-unit test-e2e ##@tests Run all linters and tests at once
 


### PR DESCRIPTION
If lint.sh is run with debug verbosity this error will be printed:

```
golangci/golangci-lint info checking GitHub for tag 'v1.17.1'
golangci/golangci-lint debug http_download https://github.com/golangci/golangci-lint/releases/v1.17.1
golangci/golangci-lint info found version: 1.17.1 for v1.17.1/linux/amd64
golangci/golangci-lint debug downloading files into /tmp/tmp.ExHlAPc8PO
golangci/golangci-lint debug http_download https://github.com/golangci/golangci-lint/releases/download/v1.17.1/-1.17.1-linux-amd64.tar.gz
golangci/golangci-lint debug http_download_curl received HTTP status 404
Makefile:273: recipe for target 'lint-install' failed
make: *** [lint-install] Error 1
```

BINARY variable is missing in the file from goreleaser but present in lint.sh from golangci-lint repo. Feels like it was stripped by goreleaser for some reason
