### PR TITLE
Multi account login

### DIFF
--- a/account/accounts.go
+++ b/account/accounts.go
@@ -264,7 +264,7 @@ func (m *Manager) Logout() {
 
 	m.accountsGenerator.Reset()
 	m.mainAccountAddress = zeroAddress
-	m.watchAddresses = make([]common.Address, 0)
+	m.watchAddresses = nil
 	m.selectedChatAccount = nil
 }
 
@@ -335,11 +335,6 @@ func (m *Manager) importExtendedKey(keyPurpose extkeys.KeyPurpose, extKey *extke
 func (m *Manager) Accounts() ([]gethcommon.Address, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-
-	_, err := m.geth.AccountManager()
-	if err != nil {
-		return nil, err
-	}
 
 	addresses := make([]gethcommon.Address, 0)
 	if m.mainAccountAddress != zeroAddress {

--- a/account/accounts_test.go
+++ b/account/accounts_test.go
@@ -115,10 +115,7 @@ func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {
 	require.NoError(t, err)
 }
 
-var (
-	errKeyStore   = errors.New("Can't return a key store")
-	errAccManager = errors.New("Can't return an account manager")
-)
+var errKeyStore = errors.New("Can't return a key store")
 
 func TestManagerTestSuite(t *testing.T) {
 	gethServiceProvider := newMockGethServiceProvider(t)

--- a/account/accounts_test.go
+++ b/account/accounts_test.go
@@ -385,11 +385,6 @@ func (s *ManagerTestSuite) TestAccounts() {
 	s.NoError(err)
 	s.NotNil(accs)
 
-	// Can't get an account manager
-	s.gethServiceProvider.EXPECT().AccountManager().Return(nil, errAccManager)
-	_, err = s.accManager.Accounts()
-	s.Equal(errAccManager, err)
-
 	// Selected main account address is zero address but doesn't fail
 	s.accManager.mainAccountAddress = common.Address{}
 	s.gethServiceProvider.EXPECT().AccountManager().Return(s.gethAccManager, nil)

--- a/account/utils.go
+++ b/account/utils.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"encoding/json"
 	"errors"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -13,6 +14,23 @@ var (
 	ErrInvalidAccountAddressOrKey  = errors.New("cannot parse address or key to valid account address")
 	ErrInvalidMnemonicPhraseLength = errors.New("invalid mnemonic phrase length; valid lengths are 12, 15, 18, 21, and 24")
 )
+
+type LoginParams struct {
+	ChatAddress    common.Address   `json:"chatAddress"`
+	Password       string           `json:"password"`
+	MainAccount    common.Address   `json:"mainAccount"`
+	WatchAddresses []common.Address `json:"watchAddresses"`
+}
+
+// FIXME: validate all params
+func ParseLoginParams(paramsJSON string) (LoginParams, error) {
+	var params LoginParams
+	if err := json.Unmarshal([]byte(paramsJSON), &params); err != nil {
+		return params, err
+	}
+
+	return params, nil
+}
 
 // Info contains wallet and chat addresses and public keys of an account.
 type Info struct {

--- a/api/backend.go
+++ b/api/backend.go
@@ -619,7 +619,7 @@ func (b *StatusBackend) startWallet(password string) error {
 		return err
 	}
 
-	allAddresses := make([]string, len(watchAddresses)+1)
+	allAddresses := make([]common.Address, len(watchAddresses)+1)
 	allAddresses[0] = mainAccountAddress
 	copy(allAddresses[1:], watchAddresses)
 

--- a/api/backend.go
+++ b/api/backend.go
@@ -619,7 +619,9 @@ func (b *StatusBackend) startWallet(password string) error {
 		return err
 	}
 
-	allAddresses := append(watchAddresses, mainAccountAddress)
+	allAddresses := make([]string, len(watchAddresses)+1)
+	allAddresses[0] = mainAccountAddress
+	copy(allAddresses[1:], watchAddresses)
 
 	path := path.Join(b.statusNode.Config().DataDir, fmt.Sprintf("wallet-%x.sql", mainAccountAddress))
 	return wallet.StartReactor(path, password,

--- a/api/backend_subs_test.go
+++ b/api/backend_subs_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/signal"
 	"github.com/status-im/status-go/t/utils"
@@ -226,7 +228,12 @@ func initNodeAndLogin(t *testing.T, backend *StatusBackend) (string, string) {
 	info, _, err := backend.AccountManager().CreateAccount(password)
 	require.NoError(t, err)
 
-	require.NoError(t, backend.AccountManager().SelectAccount(info.WalletAddress, info.ChatAddress, password))
+	loginParams := account.LoginParams{
+		MainAccount: common.HexToAddress(info.WalletAddress),
+		ChatAddress: common.HexToAddress(info.ChatAddress),
+		Password:    password,
+	}
+	require.NoError(t, backend.AccountManager().SelectAccount(loginParams))
 
 	unlockFmt := `
 	{

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -167,7 +167,12 @@ func TestBackendAccountsConcurrently(t *testing.T) {
 	for tuple := range addressCh {
 		wg.Add(1)
 		go func(tuple [3]string) {
-			assert.NoError(t, backend.SelectAccount(tuple[0], tuple[1], tuple[2]))
+			loginParams := account.LoginParams{
+				MainAccount: common.HexToAddress(tuple[0]),
+				ChatAddress: common.HexToAddress(tuple[1]),
+				Password:    tuple[2],
+			}
+			assert.NoError(t, backend.SelectAccount(loginParams))
 			wg.Done()
 		}(tuple)
 
@@ -219,8 +224,8 @@ func TestBackendInjectChatAccount(t *testing.T) {
 	require.True(t, whisperService.HasKeyPair(chatPubKeyHex), "identity not injected into whisper")
 
 	// wallet account should not be selected
-	walletAcc, err := backend.AccountManager().SelectedWalletAccount()
-	require.Nil(t, walletAcc)
+	mainAccountAddress, err := backend.AccountManager().MainAccountAddress()
+	require.Equal(t, common.Address{}, mainAccountAddress)
 	require.Equal(t, account.ErrNoAccountSelected, err)
 
 	// selected chat account should have the key injected previously

--- a/lib/library_test_utils.go
+++ b/lib/library_test_utils.go
@@ -13,6 +13,7 @@ import "C"
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"math/big"
 	"os"

--- a/services/status/account_mock.go
+++ b/services/status/account_mock.go
@@ -91,17 +91,17 @@ func (mr *MockAccountManagerMockRecorder) AddressToDecryptedAccount(arg0, arg1 i
 }
 
 // SelectAccount mocks base method
-func (m *MockAccountManager) SelectAccount(walletAddress, chatAddress, password string) error {
+func (m *MockAccountManager) SelectAccount(arg0 account.LoginParams) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SelectAccount", walletAddress, chatAddress, password)
+	ret := m.ctrl.Call(m, "SelectAccount", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SelectAccount indicates an expected call of SelectAccount
-func (mr *MockAccountManagerMockRecorder) SelectAccount(walletAddress, chatAddress, password interface{}) *gomock.Call {
+func (mr *MockAccountManagerMockRecorder) SelectAccount(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectAccount", reflect.TypeOf((*MockAccountManager)(nil).SelectAccount), walletAddress, chatAddress, password)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectAccount", reflect.TypeOf((*MockAccountManager)(nil).SelectAccount), arg0)
 }
 
 // CreateAccount mocks base method

--- a/services/status/api.go
+++ b/services/status/api.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/account"
 )
 
@@ -40,7 +41,12 @@ func (api *PublicAPI) Login(context context.Context, req LoginRequest) (res Logi
 		return
 	}
 
-	if err = api.s.am.SelectAccount(req.Addr, req.Addr, req.Password); err != nil {
+	loginParams := account.LoginParams{
+		ChatAddress: common.HexToAddress(req.Addr),
+		Password:    req.Password,
+		MainAccount: common.HexToAddress(req.Addr),
+	}
+	if err = api.s.am.SelectAccount(loginParams); err != nil {
 		return
 	}
 

--- a/services/status/api_test.go
+++ b/services/status/api_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang/mock/gomock"
 	"github.com/status-im/status-go/account"
 	"github.com/stretchr/testify/suite"
@@ -48,9 +49,15 @@ var logintests = []struct {
 			key := keystore.Key{
 				PrivateKey: &ecdsa.PrivateKey{},
 			}
-			s.am.EXPECT().AddressToDecryptedAccount("address...", "password").Return(accounts.Account{}, &key, nil)
+			s.am.EXPECT().AddressToDecryptedAccount("0x01", "password").Return(accounts.Account{}, &key, nil)
 			s.w.EXPECT().AddKeyPair(key.PrivateKey).Return("addressKey", nil)
-			s.am.EXPECT().SelectAccount("address...", "address...", "password").Return(nil)
+
+			loginParams := account.LoginParams{
+				MainAccount: common.HexToAddress("0x01"),
+				ChatAddress: common.HexToAddress("0x01"),
+				Password:    "password",
+			}
+			s.am.EXPECT().SelectAccount(loginParams).Return(nil)
 		},
 	},
 	{
@@ -61,7 +68,7 @@ var logintests = []struct {
 			key := keystore.Key{
 				PrivateKey: &ecdsa.PrivateKey{},
 			}
-			s.am.EXPECT().AddressToDecryptedAccount("address...", "password").Return(accounts.Account{}, &key, errors.New("foo"))
+			s.am.EXPECT().AddressToDecryptedAccount("0x01", "password").Return(accounts.Account{}, &key, errors.New("foo"))
 		},
 	},
 	{
@@ -72,7 +79,7 @@ var logintests = []struct {
 			key := keystore.Key{
 				PrivateKey: &ecdsa.PrivateKey{},
 			}
-			s.am.EXPECT().AddressToDecryptedAccount("address...", "password").Return(accounts.Account{}, &key, nil)
+			s.am.EXPECT().AddressToDecryptedAccount("0x01", "password").Return(accounts.Account{}, &key, nil)
 			s.w.EXPECT().AddKeyPair(key.PrivateKey).Return("", errors.New("foo"))
 		},
 	},
@@ -84,16 +91,22 @@ var logintests = []struct {
 			key := keystore.Key{
 				PrivateKey: &ecdsa.PrivateKey{},
 			}
-			s.am.EXPECT().AddressToDecryptedAccount("address...", "password").Return(accounts.Account{}, &key, nil)
+			s.am.EXPECT().AddressToDecryptedAccount("0x01", "password").Return(accounts.Account{}, &key, nil)
 			s.w.EXPECT().AddKeyPair(key.PrivateKey).Return("", nil)
-			s.am.EXPECT().SelectAccount("address...", "address...", "password").Return(errors.New("foo"))
+
+			loginParams := account.LoginParams{
+				MainAccount: common.HexToAddress("0x01"),
+				ChatAddress: common.HexToAddress("0x01"),
+				Password:    "password",
+			}
+			s.am.EXPECT().SelectAccount(loginParams).Return(errors.New("foo"))
 		},
 	},
 }
 
 func (s *StatusSuite) TestLogin() {
 	for _, t := range logintests {
-		req := LoginRequest{Addr: "address...", Password: "password"}
+		req := LoginRequest{Addr: "0x01", Password: "password"}
 
 		t.prepareExpectations(s)
 

--- a/services/status/service.go
+++ b/services/status/service.go
@@ -22,7 +22,7 @@ type WhisperService interface {
 // AccountManager interface to manage account actions
 type AccountManager interface {
 	AddressToDecryptedAccount(string, string) (accounts.Account, *keystore.Key, error)
-	SelectAccount(walletAddress, chatAddress, password string) error
+	SelectAccount(account.LoginParams) error
 	CreateAccount(password string) (accountInfo account.Info, mnemonic string, err error)
 }
 

--- a/t/devtests/tranfers_test.go
+++ b/t/devtests/tranfers_test.go
@@ -30,8 +30,17 @@ type TransfersSuite struct {
 }
 
 func (s *TransfersSuite) SelectAccount() {
-	s.Require().NoError(s.backend.SelectAccount(s.Info.WalletAddress, s.Info.ChatAddress, s.Password))
-	_, err := s.backend.AccountManager().SelectedWalletAccount()
+	loginParams := account.LoginParams{
+		ChatAddress: common.HexToAddress(s.Info.ChatAddress),
+		Password:    s.Password,
+		MainAccount: common.HexToAddress(s.Info.WalletAddress),
+	}
+
+	s.Require().NoError(s.backend.SelectAccount(loginParams))
+	_, err := s.backend.AccountManager().MainAccountAddress()
+	s.Require().NoError(err)
+
+	_, err = s.backend.AccountManager().SelectedChatAccount()
 	s.Require().NoError(err)
 }
 

--- a/t/e2e/accounts/accounts_rpc_test.go
+++ b/t/e2e/accounts/accounts_rpc_test.go
@@ -23,7 +23,7 @@ func (s *AccountsTestSuite) TestRPCEthAccounts() {
 	defer s.StopTestBackend()
 
 	// log into test account
-	err := s.Backend.SelectAccount(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password)
+	err := s.Backend.SelectAccount(buildLoginParams(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password, nil))
 	s.NoError(err)
 
 	rpcClient := s.Backend.StatusNode().RPCClient()
@@ -51,7 +51,7 @@ func (s *AccountsTestSuite) TestRPCEthAccountsWithUpstream() {
 	defer s.StopTestBackend()
 
 	// log into test account
-	err = s.Backend.SelectAccount(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password)
+	err = s.Backend.SelectAccount(buildLoginParams(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password, nil))
 	s.NoError(err)
 
 	rpcClient := s.Backend.StatusNode().RPCClient()

--- a/t/e2e/accounts/accounts_test.go
+++ b/t/e2e/accounts/accounts_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/extkeys"
@@ -13,6 +14,15 @@ import (
 	. "github.com/status-im/status-go/t/utils"
 	"github.com/stretchr/testify/suite"
 )
+
+func buildLoginParams(mainAccountAddress, chatAddress, password string, watchAddresses []common.Address) account.LoginParams {
+	return account.LoginParams{
+		ChatAddress:    common.HexToAddress(chatAddress),
+		Password:       password,
+		MainAccount:    common.HexToAddress(mainAccountAddress),
+		WatchAddresses: watchAddresses,
+	}
+}
 
 func TestAccountsTestSuite(t *testing.T) {
 	suite.Run(t, new(AccountsTestSuite))
@@ -42,7 +52,7 @@ func (s *AccountsTestSuite) TestAccountsList() {
 	s.Zero(len(accounts), "accounts returned, while there should be none (we haven't logged in yet)")
 
 	// select account (sub-accounts will be created for this key)
-	err = s.Backend.SelectAccount(accountInfo.WalletAddress, accountInfo.ChatAddress, TestConfig.Account1.Password)
+	err = s.Backend.SelectAccount(buildLoginParams(accountInfo.WalletAddress, accountInfo.ChatAddress, TestConfig.Account1.Password, nil))
 	s.NoError(err, "account selection failed")
 
 	// at this point main account should show up
@@ -51,36 +61,6 @@ func (s *AccountsTestSuite) TestAccountsList() {
 	s.Equal(1, len(accounts), "exactly single account is expected (main account)")
 	s.Equal(accounts[0].Hex(), accountInfo.WalletAddress,
 		fmt.Sprintf("main account is not retured as the first key: got %s, expected %s", accounts[0].Hex(), "0x"+accountInfo.WalletAddress))
-
-	// create sub-account 1
-	subAccount1, subPubKey1, err := s.Backend.AccountManager().CreateChildAccount("", TestConfig.Account1.Password)
-	s.NoError(err, "cannot create sub-account")
-
-	// now we expect to see both main account and sub-account 1
-	accounts, err = s.Backend.AccountManager().Accounts()
-	s.NoError(err)
-	s.Equal(2, len(accounts), "exactly 2 accounts are expected (main + sub-account 1)")
-	s.Equal(accounts[0].Hex(), accountInfo.WalletAddress, "main account is not retured as the first key")
-	s.Equal(accounts[1].Hex(), subAccount1, "subAcount1 not returned")
-
-	// create sub-account 2, index automatically progresses
-	subAccount2, subPubKey2, err := s.Backend.AccountManager().CreateChildAccount("", TestConfig.Account1.Password)
-	s.NoError(err, "cannot create sub-account")
-	s.False(subAccount1 == subAccount2 || subPubKey1 == subPubKey2, "sub-account index auto-increament failed")
-
-	// finally, all 3 accounts should show up (main account, sub-accounts 1 and 2)
-	accounts, err = s.Backend.AccountManager().Accounts()
-	s.NoError(err)
-	s.Equal(3, len(accounts), "unexpected number of accounts")
-	s.Equal(accounts[0].Hex(), accountInfo.WalletAddress, "main account is not retured as the first key")
-
-	subAccount1MatchesKey1 := accounts[1].Hex() != "0x"+subAccount1
-	subAccount1MatchesKey2 := accounts[2].Hex() != "0x"+subAccount1
-	s.False(!subAccount1MatchesKey1 && !subAccount1MatchesKey2, "subAcount1 not returned")
-
-	subAccount2MatchesKey1 := accounts[1].Hex() != "0x"+subAccount2
-	subAccount2MatchesKey2 := accounts[2].Hex() != "0x"+subAccount2
-	s.False(!subAccount2MatchesKey1 && !subAccount2MatchesKey2, "subAcount2 not returned")
 }
 
 func (s *AccountsTestSuite) TestImportSingleExtendedKey() {
@@ -133,55 +113,6 @@ func (s *AccountsTestSuite) TestImportAccount() {
 
 	s.Equal(crypto.FromECDSA(privateKey), crypto.FromECDSA(key.PrivateKey))
 	s.True(key.ExtendedKey.IsZeroed())
-}
-
-func (s *AccountsTestSuite) TestCreateChildAccount() {
-	s.StartTestBackend()
-	defer s.StopTestBackend()
-
-	keyStore, err := s.Backend.StatusNode().AccountKeyStore()
-	s.NoError(err)
-	s.NotNil(keyStore)
-
-	// create an account
-	accountInfo, mnemonic, err := s.Backend.AccountManager().CreateAccount(TestConfig.Account1.Password)
-	s.NoError(err)
-	s.T().Logf("Account created: {walletAddress: %s, walletKey: %s, chatAddress: %s, chatKey: %s, mnemonic:%s}",
-		accountInfo.WalletAddress, accountInfo.WalletPubKey, accountInfo.ChatAddress, accountInfo.ChatPubKey, mnemonic)
-
-	acct, err := account.ParseAccountString(accountInfo.WalletAddress)
-	s.NoError(err, "can not get account from address")
-
-	// obtain decrypted key, and make sure that extended key (which will be used as root for sub-accounts) is present
-	_, key, err := keyStore.AccountDecryptedKey(acct, TestConfig.Account1.Password)
-	s.NoError(err, "can not obtain decrypted account key")
-	s.NotNil(key.ExtendedKey, "CKD#2 has not been generated for new account")
-
-	// try creating sub-account, w/o selecting main account i.e. w/o login to main account
-	_, _, err = s.Backend.AccountManager().CreateChildAccount("", TestConfig.Account1.Password)
-	s.EqualError(account.ErrNoAccountSelected, err.Error(), "expected error is not returned (tried to create sub-account w/o login)")
-
-	err = s.Backend.SelectAccount(accountInfo.WalletAddress, accountInfo.ChatAddress, TestConfig.Account1.Password)
-	s.NoError(err, "cannot select account")
-
-	// try to create sub-account with wrong password
-	_, _, err = s.Backend.AccountManager().CreateChildAccount("", "wrong password")
-	expectedErr := errors.New("cannot retrieve a valid key for a given account: could not decrypt key with given passphrase")
-	s.EqualError(expectedErr, err.Error(), "create sub-account with wrong password")
-
-	// create sub-account (from implicit parent)
-	subAccount1, subPubKey1, err := s.Backend.AccountManager().CreateChildAccount("", TestConfig.Account1.Password)
-	s.NoError(err, "cannot create sub-account")
-
-	// make sure that sub-account index automatically progresses
-	subAccount2, subPubKey2, err := s.Backend.AccountManager().CreateChildAccount("", TestConfig.Account1.Password)
-	s.NoError(err)
-	s.False(subAccount1 == subAccount2 || subPubKey1 == subPubKey2, "sub-account index auto-increament failed")
-
-	// create sub-account (from explicit parent)
-	subAccount3, subPubKey3, err := s.Backend.AccountManager().CreateChildAccount(subAccount2, TestConfig.Account1.Password)
-	s.NoError(err)
-	s.False(subAccount1 == subAccount3 || subPubKey1 == subPubKey3 || subAccount2 == subAccount3 || subPubKey2 == subPubKey3)
 }
 
 func (s *AccountsTestSuite) TestRecoverAccount() {
@@ -244,15 +175,15 @@ func (s *AccountsTestSuite) TestSelectAccount() {
 		accountInfo2.WalletAddress, accountInfo2.WalletPubKey, accountInfo2.ChatAddress, accountInfo2.ChatPubKey)
 
 	// try selecting with wrong password
-	err = s.Backend.SelectAccount(accountInfo1.WalletAddress, accountInfo1.ChatAddress, "wrongPassword")
+	err = s.Backend.SelectAccount(buildLoginParams(accountInfo1.WalletAddress, accountInfo1.ChatAddress, "wrongPassword", nil))
 	expectedErr := errors.New("cannot retrieve a valid key for a given account: could not decrypt key with given passphrase")
 	s.EqualError(expectedErr, err.Error(), "select account is expected to throw error: wrong password used")
 
-	err = s.Backend.SelectAccount(accountInfo1.WalletAddress, accountInfo1.ChatAddress, TestConfig.Account1.Password)
+	err = s.Backend.SelectAccount(buildLoginParams(accountInfo1.WalletAddress, accountInfo1.ChatAddress, TestConfig.Account1.Password, nil))
 	s.NoError(err)
 
 	// select another account, make sure that previous account is wiped out from Whisper cache
-	s.NoError(s.Backend.SelectAccount(accountInfo2.WalletAddress, accountInfo2.ChatAddress, TestConfig.Account1.Password))
+	s.NoError(s.Backend.SelectAccount(buildLoginParams(accountInfo2.WalletAddress, accountInfo2.ChatAddress, TestConfig.Account1.Password, nil)))
 }
 
 func (s *AccountsTestSuite) TestSetChatAccount() {
@@ -285,19 +216,23 @@ func (s *AccountsTestSuite) TestSelectedAccountOnRestart() {
 	s.NoError(err)
 
 	// make sure that no account is selected by default
-	selectedWalletAccount, err := s.Backend.AccountManager().SelectedWalletAccount()
+	selectedWalletAccount, err := s.Backend.AccountManager().MainAccountAddress()
 	s.EqualError(account.ErrNoAccountSelected, err.Error(), "account selected, but should not be")
-	s.Nil(selectedWalletAccount)
+	s.Equal(common.Address{}, selectedWalletAccount)
 	selectedChatAccount, err := s.Backend.AccountManager().SelectedChatAccount()
 	s.EqualError(account.ErrNoAccountSelected, err.Error(), "account selected, but should not be")
 	s.Nil(selectedChatAccount)
 
 	// select account
-	err = s.Backend.SelectAccount(accountInfo1.WalletAddress, accountInfo1.ChatAddress, "wrongPassword")
+	err = s.Backend.SelectAccount(buildLoginParams(accountInfo1.WalletAddress, accountInfo1.ChatAddress, "wrongPassword", nil))
 	expectedErr := errors.New("cannot retrieve a valid key for a given account: could not decrypt key with given passphrase")
 	s.EqualError(expectedErr, err.Error())
 
-	s.NoError(s.Backend.SelectAccount(accountInfo2.WalletAddress, accountInfo2.ChatAddress, TestConfig.Account1.Password))
+	watchAddresses := []common.Address{
+		common.HexToAddress("0x00000000000000000000000000000000000001"),
+		common.HexToAddress("0x00000000000000000000000000000000000002"),
+	}
+	s.NoError(s.Backend.SelectAccount(buildLoginParams(accountInfo2.WalletAddress, accountInfo2.ChatAddress, TestConfig.Account1.Password, watchAddresses)))
 
 	// stop node (and all of its sub-protocols)
 	nodeConfig := s.Backend.StatusNode().Config()
@@ -306,27 +241,29 @@ func (s *AccountsTestSuite) TestSelectedAccountOnRestart() {
 	s.NoError(s.Backend.StopNode())
 
 	// make sure that account is still selected
-	selectedWalletAccount, err = s.Backend.AccountManager().SelectedWalletAccount()
+	selectedWalletAccount, err = s.Backend.AccountManager().MainAccountAddress()
 	s.Require().NoError(err)
 	s.NotNil(selectedWalletAccount)
-	s.Equal(selectedWalletAccount.Address.Hex(), accountInfo2.WalletAddress, "incorrect wallet address selected")
+	s.Equal(selectedWalletAccount.String(), accountInfo2.WalletAddress, "incorrect wallet address selected")
 	selectedChatAccount, err = s.Backend.AccountManager().SelectedChatAccount()
 	s.NoError(err)
 	s.NotNil(selectedChatAccount)
 	s.Equal(selectedChatAccount.Address.Hex(), accountInfo2.ChatAddress, "incorrect chat address selected")
+	s.Equal(watchAddresses, s.Backend.AccountManager().WatchAddresses())
 
 	// resume node
 	s.Require().NoError(s.Backend.StartNode(&preservedNodeConfig))
 
 	// re-check selected account (account2 MUST be selected)
-	selectedWalletAccount, err = s.Backend.AccountManager().SelectedWalletAccount()
+	selectedWalletAccount, err = s.Backend.AccountManager().MainAccountAddress()
 	s.NoError(err)
 	s.NotNil(selectedWalletAccount)
-	s.Equal(selectedWalletAccount.Address.Hex(), accountInfo2.WalletAddress, "incorrect wallet address selected")
+	s.Equal(selectedWalletAccount.String(), accountInfo2.WalletAddress, "incorrect wallet address selected")
 	selectedChatAccount, err = s.Backend.AccountManager().SelectedChatAccount()
 	s.NoError(err)
 	s.NotNil(selectedChatAccount)
 	s.Equal(selectedChatAccount.Address.Hex(), accountInfo2.WalletAddress, "incorrect chat address selected")
+	s.Equal(watchAddresses, s.Backend.AccountManager().WatchAddresses())
 
 	// now restart node using RestartNode() method, and make sure that account is still available
 	s.RestartTestNode()
@@ -336,10 +273,11 @@ func (s *AccountsTestSuite) TestSelectedAccountOnRestart() {
 	s.NoError(s.Backend.Logout())
 	s.RestartTestNode()
 
-	selectedWalletAccount, err = s.Backend.AccountManager().SelectedWalletAccount()
+	selectedWalletAccount, err = s.Backend.AccountManager().MainAccountAddress()
 	s.EqualError(account.ErrNoAccountSelected, err.Error())
-	s.Nil(selectedWalletAccount)
+	s.Equal(common.Address{}, selectedWalletAccount)
 	selectedChatAccount, err = s.Backend.AccountManager().SelectedChatAccount()
 	s.EqualError(account.ErrNoAccountSelected, err.Error())
 	s.Nil(selectedChatAccount)
+	s.Len(s.Backend.AccountManager().WatchAddresses(), 0)
 }

--- a/t/e2e/transactions/transactions_test.go
+++ b/t/e2e/transactions/transactions_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/status-im/status-go/account"
@@ -16,6 +17,14 @@ import (
 )
 
 type initFunc func([]byte, *transactions.SendTxArgs)
+
+func buildLoginParams(mainAccountAddress, chatAddress, password string) account.LoginParams {
+	return account.LoginParams{
+		ChatAddress: common.HexToAddress(chatAddress),
+		Password:    password,
+		MainAccount: common.HexToAddress(mainAccountAddress),
+	}
+}
 
 func TestTransactionsTestSuite(t *testing.T) {
 	suite.Run(t, new(TransactionsTestSuite))
@@ -70,7 +79,7 @@ func (s *TransactionsTestSuite) TestCallUpstreamPrivateRPCSendTransaction() {
 func (s *TransactionsTestSuite) sendTransactionUsingRPCClient(
 	callRPCFn func(string) (string, error),
 ) {
-	err := s.Backend.SelectAccount(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password)
+	err := s.Backend.SelectAccount(buildLoginParams(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password))
 	s.NoError(err)
 
 	result, err := callRPCFn(`{
@@ -94,7 +103,7 @@ func (s *TransactionsTestSuite) TestEmptyToFieldPreserved() {
 	defer s.StopTestBackend()
 
 	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
-	err := s.Backend.SelectAccount(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password)
+	err := s.Backend.SelectAccount(buildLoginParams(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password))
 	s.NoError(err)
 
 	args := transactions.SendTxArgs{
@@ -162,7 +171,7 @@ func (s *TransactionsTestSuite) testSendContractTx(setInputAndDataValue initFunc
 
 	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
-	err := s.Backend.AccountManager().SelectAccount(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password)
+	err := s.Backend.AccountManager().SelectAccount(buildLoginParams(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password))
 	s.NoError(err)
 
 	// this call blocks, up until Complete Transaction is called
@@ -196,7 +205,7 @@ func (s *TransactionsTestSuite) TestSendEther() {
 
 	EnsureNodeSync(s.Backend.StatusNode().EnsureSync)
 
-	err := s.Backend.AccountManager().SelectAccount(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password)
+	err := s.Backend.AccountManager().SelectAccount(buildLoginParams(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password))
 	s.NoError(err)
 
 	hash, err := s.Backend.SendTransaction(transactions.SendTxArgs{
@@ -216,7 +225,7 @@ func (s *TransactionsTestSuite) TestSendEtherTxUpstream() {
 	s.StartTestBackend(e2e.WithUpstream(addr))
 	defer s.StopTestBackend()
 
-	err = s.Backend.SelectAccount(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password)
+	err = s.Backend.SelectAccount(buildLoginParams(TestConfig.Account1.WalletAddress, TestConfig.Account1.ChatAddress, TestConfig.Account1.Password))
 	s.NoError(err)
 
 	hash, err := s.Backend.SendTransaction(transactions.SendTxArgs{


### PR DESCRIPTION
depends on #1500 

This PR enables the use of multi-account already merged in #1500 .
The main change is removing the selectedWalletAccount from memory. 
Only the selectedChatAccount key remains in memory. 
For tx signing an account will be unlocked and used when needed.

Important changes:
- [x] remove selectedWalletAccount
- [x] add mainAccountAddress to be returned to `web3.eth.getAccounts()`
- [x] add watchAddresses, a list of addresses to watch when the wallet service starts.

Closes #1489 
Closes #1490 
Closes #1492