### PR TITLE
Change to support status-react #8136 [Onboarding] Recovery

### DIFF
--- a/account/accounts.go
+++ b/account/accounts.go
@@ -327,6 +327,13 @@ func (m *Manager) importExtendedKey(keyPurpose extkeys.KeyPurpose, extKey *extke
 	}
 	pubKey = hexutil.Encode(crypto.FromECDSAPub(&key.PrivateKey.PublicKey))
 
+	if password == "" {
+		err := keyStore.Delete(account, password)
+		if err != nil {
+			return address, "", err
+		}
+	}
+
 	return
 }
 


### PR DESCRIPTION
Change to support https://github.com/status-im/status-react/issues/8136 

If RecoverAccount called with empty password, delete recovered key from keystore immediately.
This enables testing recoverability of an account before user supplies a password, per the new UX flow in https://github.com/status-im/status-react/issues/8136
