### PR TITLE
Fix release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,13 @@ prepare-release: clean-release
 clean-release:
 	rm -rf $(RELEASE_DIR)
 
-release:
+check-existing-release:
+	@git ls-remote --exit-code origin "v$(RELEASE_TAG)" >/dev/null && \
+		echo "$(YELLOW)Release tag already exists: v$(RELEASE_TAG)$(RESET)"; \
+		echo "Remove the tag/release if you want to re-create it."; \
+		exit 1
+
+release: check-existing-release
 	@read -p "Are you sure you want to create a new GitHub $(RELEASE_TYPE) against $(RELEASE_BRANCH) branch? (y/n): " REPLY; \
 	if [ $$REPLY = "y" ]; then \
 		latest_tag=$$(git describe --tags `git rev-list --tags --max-count=1`); \

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -108,9 +108,11 @@ pipeline {
         }
       } }
     } // stage(Release)
-    
-    stage('Cleanup') { steps { dir(env.STATUS_PATH) {
-      sh 'make clean-release'
-    } } } // stage(Cleanup)
   } // stages
+
+  post {
+    always { dir(env.STATUS_PATH) {
+      sh 'make clean-release'
+    } }
+  }
 }

--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -69,14 +69,13 @@ pipeline {
     stage('Upload') { steps { script {
       env.PKG_URL = lib.uploadArtifact("pkg/${artifact}")
     } } }
-
-    stage('Cleanup') { steps { dir(env.STATUS_PATH) {
-      sh 'make clean'
-      sh "rm -fr ${dest}"
-    } } }
   } // stages
   post {
     success { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(true) } }
     failure { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(false) } }
+    always { dir(env.STATUS_PATH) {
+      sh 'make clean'
+      sh "rm -fr ${dest}"
+    } }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.docker
+++ b/_assets/ci/Jenkinsfile.docker
@@ -68,8 +68,10 @@ pipeline {
     } } } }
   } // stages
   post {
-    always  { dir(env.STATUS_PATH) { sh 'make clean-docker-images' } }
     success { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(true) } }
     failure { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(false) } }
+    always  { dir(env.STATUS_PATH) {
+      sh 'make clean-docker-images'
+    } }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -67,14 +67,13 @@ pipeline {
     stage('Upload') { steps { script {
       env.PKG_URL = lib.uploadArtifact("pkg/${artifact}")
     } } }
-
-    stage('Cleanup') { steps { dir(env.STATUS_PATH) {
-      sh 'make clean'
-      sh "rm -fr ${dest}"
-    } } }
   } // stages
   post {
     success { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(true) } }
     failure { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(false) } }
+    always { dir(env.STATUS_PATH) {
+      sh 'make clean'
+      sh "rm -fr ${dest}"
+    } }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -67,5 +67,9 @@ pipeline {
   post {
     success { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(true) } }
     failure { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(false) } }
+    always { dir(env.STATUS_PATH) {
+      sh 'make clean'
+      sh "rm -fr ${dest}"
+    } }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.xgo
+++ b/_assets/ci/Jenkinsfile.xgo
@@ -74,5 +74,9 @@ pipeline {
   post {
     success { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(true) } }
     failure { script { load("${CI_DIR}/ghcmgr.groovy").postBuild(false) } }
+    always { dir(env.STATUS_PATH) {
+      sh 'make clean'
+      sh "rm -fr ${dest}"
+    } }
   } // post
 }


### PR DESCRIPTION
This commit fixes a bug @cammellos found out when trying to use a new `status-go` branch he created.

Mistakenly - not knowing that current Nix builds `status-go` from commit SHA1 - he ran a [manual build of `status-go`](https://ci.status.im/job/status-go/job/manual/) which was not necessary. Which - he though - created the `v0.30.1-beta.2` tag from his `release/0.30.1-beta.2` branch. But it did not:
```
+ make release
Github returned an error:
 Code: 422 Unprocessable Entity. 
 Body: {"message":"Validation Failed","errors":[{"resource":"Release","code":"already_exists","field":"tag_name"}],"documentation_url":"https://developer.github.com/v3/repos/releases/#create-a-release"}
Trying again assuming release already exists.
Done
```
It silently failed due to tag already existing and pointing at an older commit.
I've added an `check-existing-release` target to the Makefile to check for this and fail clearly if it does.

I also moved cleanup steps in CI to `post { always {} }` block.