### PR TITLE
Watch new accounts aftter they were saved to accounts table

### DIFF
--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -3,20 +3,27 @@ package accounts
 import (
 	"context"
 
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 )
 
-func NewAccountsAPI(db *accounts.Database) *API {
-	return &API{db}
+func NewAccountsAPI(db *accounts.Database, feed *event.Feed) *API {
+	return &API{db, feed}
 }
 
 // API is class with methods available over RPC.
 type API struct {
-	db *accounts.Database
+	db   *accounts.Database
+	feed *event.Feed
 }
 
 func (api *API) SaveAccounts(ctx context.Context, accounts []accounts.Account) error {
-	return api.db.SaveAccounts(accounts)
+	err := api.db.SaveAccounts(accounts)
+	if err != nil {
+		return err
+	}
+	api.feed.Send(accounts)
+	return nil
 }
 
 func (api *API) GetAccounts(ctx context.Context) ([]accounts.Account, error) {

--- a/services/accounts/service.go
+++ b/services/accounts/service.go
@@ -1,6 +1,7 @@
 package accounts
 
 import (
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/status-im/status-go/account"
@@ -9,8 +10,8 @@ import (
 )
 
 // NewService initializes service instance.
-func NewService(db *accounts.Database, mdb *multiaccounts.Database, manager *account.Manager) *Service {
-	return &Service{db, mdb, manager}
+func NewService(db *accounts.Database, mdb *multiaccounts.Database, manager *account.Manager, feed *event.Feed) *Service {
+	return &Service{db, mdb, manager, feed}
 }
 
 // Service is a browsers service.
@@ -18,6 +19,7 @@ type Service struct {
 	db      *accounts.Database
 	mdb     *multiaccounts.Database
 	manager *account.Manager
+	feed    *event.Feed
 }
 
 // Start a service.
@@ -41,7 +43,7 @@ func (s *Service) APIs() []rpc.API {
 		{
 			Namespace: "accounts",
 			Version:   "0.1.0",
-			Service:   NewAccountsAPI(s.db),
+			Service:   NewAccountsAPI(s.db, s.feed),
 		},
 		{
 			Namespace: "multiaccounts",

--- a/services/wallet/async.go
+++ b/services/wallet/async.go
@@ -15,6 +15,10 @@ type FiniteCommand struct {
 }
 
 func (c FiniteCommand) Run(ctx context.Context) error {
+	err := c.Runable(ctx)
+	if err == nil {
+		return nil
+	}
 	ticker := time.NewTicker(c.Interval)
 	for {
 		select {
@@ -36,6 +40,7 @@ type InfiniteCommand struct {
 }
 
 func (c InfiniteCommand) Run(ctx context.Context) error {
+	_ = c.Runable(ctx)
 	ticker := time.NewTicker(c.Interval)
 	for {
 		select {

--- a/services/wallet/concurrent.go
+++ b/services/wallet/concurrent.go
@@ -47,6 +47,9 @@ type TransferDownloader interface {
 
 func downloadEthConcurrently(c *ConcurrentDownloader, client BalanceReader, downloader TransferDownloader, account common.Address, low, high *big.Int) {
 	c.Add(func(ctx context.Context) error {
+		if low.Cmp(high) >= 0 {
+			return nil
+		}
 		log.Debug("eth transfers comparing blocks", "low", low, "high", high)
 		lb, err := client.BalanceAt(ctx, account, low)
 		if err != nil {

--- a/services/wallet/reactor.go
+++ b/services/wallet/reactor.go
@@ -50,30 +50,28 @@ type reactorClient interface {
 }
 
 // NewReactor creates instance of the Reactor.
-func NewReactor(db *Database, feed *event.Feed, client *ethclient.Client, accounts []common.Address, chain *big.Int) *Reactor {
+func NewReactor(db *Database, feed *event.Feed, client *ethclient.Client, chain *big.Int) *Reactor {
 	return &Reactor{
-		db:       db,
-		client:   client,
-		feed:     feed,
-		accounts: accounts,
-		chain:    chain,
+		db:     db,
+		client: client,
+		feed:   feed,
+		chain:  chain,
 	}
 }
 
 // Reactor listens to new blocks and stores transfers into the database.
 type Reactor struct {
-	client   *ethclient.Client
-	db       *Database
-	feed     *event.Feed
-	accounts []common.Address
-	chain    *big.Int
+	client *ethclient.Client
+	db     *Database
+	feed   *event.Feed
+	chain  *big.Int
 
 	mu    sync.Mutex
 	group *Group
 }
 
 // Start runs reactor loop in background.
-func (r *Reactor) Start() error {
+func (r *Reactor) Start(accounts []common.Address) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.group != nil {
@@ -81,20 +79,17 @@ func (r *Reactor) Start() error {
 	}
 	r.group = NewGroup(context.Background())
 	signer := types.NewEIP155Signer(r.chain)
-	// TODO(dshulyak) to support adding accounts in runtime implement keyed group
-	// and export private api to start downloaders from accounts
-	// private api should have access only to reactor
 	ctl := &controlCommand{
 		db:       r.db,
 		chain:    r.chain,
 		client:   r.client,
-		accounts: r.accounts,
+		accounts: accounts,
 		eth: &ETHTransferDownloader{
 			client:   r.client,
-			accounts: r.accounts,
+			accounts: accounts,
 			signer:   signer,
 		},
-		erc20:       NewERC20TransfersDownloader(r.client, r.accounts, signer),
+		erc20:       NewERC20TransfersDownloader(r.client, accounts, signer),
 		feed:        r.feed,
 		safetyDepth: reorgSafetyDepth,
 	}

--- a/services/wallet/service_test.go
+++ b/services/wallet/service_test.go
@@ -1,0 +1,105 @@
+package wallet
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/status-im/status-go/multiaccounts/accounts"
+	"github.com/status-im/status-go/t/devtests/testchain"
+	"github.com/status-im/status-go/t/utils"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestReactorChanges(t *testing.T) {
+	suite.Run(t, new(ReactorChangesSuite))
+}
+
+type ReactorChangesSuite struct {
+	suite.Suite
+	backend *testchain.Backend
+	reactor *Reactor
+	db      *Database
+	dbStop  func()
+	feed    *event.Feed
+
+	first, second common.Address
+}
+
+func (s *ReactorChangesSuite) txToAddress(nonce uint64, address common.Address) *types.Transaction {
+	tx := types.NewTransaction(nonce, address, big.NewInt(1e17), 21000, big.NewInt(1), nil)
+	tx, err := types.SignTx(tx, s.backend.Signer, s.backend.Faucet)
+	s.Require().NoError(err)
+	return tx
+}
+
+func (s *ReactorChangesSuite) SetupTest() {
+	var err error
+	db, stop := setupTestDB(s.Suite.T())
+	s.db = db
+	s.dbStop = stop
+	s.backend, err = testchain.NewBackend()
+	s.Require().NoError(err)
+	s.feed = &event.Feed{}
+	s.reactor = NewReactor(s.db, &event.Feed{}, s.backend.Client, big.NewInt(1337))
+	account, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	s.first = crypto.PubkeyToAddress(account.PublicKey)
+	account, err = crypto.GenerateKey()
+	s.Require().NoError(err)
+	s.second = crypto.PubkeyToAddress(account.PublicKey)
+	nonce := uint64(0)
+	blocks := s.backend.GenerateBlocks(1, 0, func(n int, gen *core.BlockGen) {
+		gen.AddTx(s.txToAddress(nonce, s.first))
+		nonce++
+		gen.AddTx(s.txToAddress(nonce, s.second))
+		nonce++
+	})
+	_, err = s.backend.Ethereum.BlockChain().InsertChain(blocks)
+	s.Require().NoError(err)
+}
+
+func (s *ReactorChangesSuite) TestWatchNewAccounts() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	group := NewGroup(ctx)
+	group.Add(func(ctx context.Context) error {
+		return WatchAccountsChanges(ctx, s.feed, []common.Address{s.first}, s.reactor)
+	})
+	s.Require().NoError(s.reactor.Start([]common.Address{s.first}))
+	s.Require().NoError(utils.Eventually(func() error {
+		transfers, err := s.db.GetTransfersByAddress(s.first, big.NewInt(0), nil)
+		if err != nil {
+			return err
+		}
+		if len(transfers) != 1 {
+			return fmt.Errorf("expect to get 1 transfer for first address %x, got %d", s.first, len(transfers))
+		}
+		transfers, err = s.db.GetTransfersByAddress(s.second, big.NewInt(0), nil)
+		if err != nil {
+			return err
+		}
+		if len(transfers) != 0 {
+			return fmt.Errorf("expect not to get any transfer for second address %x", s.second)
+		}
+		return nil
+	}, 5*time.Second, 500*time.Millisecond))
+	s.feed.Send([]accounts.Account{{Address: s.first}, {Address: s.second}})
+	s.Require().NoError(utils.Eventually(func() error {
+		transfers, err := s.db.GetTransfersByAddress(s.second, big.NewInt(0), nil)
+		if err != nil {
+			return err
+		}
+		if len(transfers) == 0 {
+			return fmt.Errorf("expect 1 transfer for second address %x, got %d", s.second, len(transfers))
+		}
+		return nil
+	}, 5*time.Second, 500*time.Millisecond))
+}


### PR DESCRIPTION
After accounts_saveAccounts persisted accounts in the db successfully it will notify wallet service that it can start watching for new addresses. 
Wallet will restart whole reactor component to ensure that every address will have the same head of the chain after new accounts are synced.

closes: https://github.com/status-im/status-go/issues/1566