### PR TITLE
Make stop node part of the logout blocking

### DIFF
--- a/lib/library.go
+++ b/lib/library.go
@@ -404,8 +404,7 @@ func Logout() *C.char {
 	if err != nil {
 		makeJSONResponse(err)
 	}
-	api.RunAsync(statusBackend.StopNode)
-	return makeJSONResponse(nil)
+	return makeJSONResponse(statusBackend.StopNode())
 }
 
 // SignMessage unmarshals rpc params {data, address, password} and passes

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -389,8 +389,7 @@ func Logout() string {
 	if err != nil {
 		makeJSONResponse(err)
 	}
-	api.RunAsync(statusBackend.StopNode)
-	return makeJSONResponse(nil)
+	return makeJSONResponse(statusBackend.StopNode())
 }
 
 // SignMessage unmarshals rpc params {data, address, password} and


### PR DESCRIPTION
Caller needs to be sure that previous node is stopped and all previous state is cleared before next login. 

As alternative we can add a signal that node is stopped and the caller will have to wait for that signal.
