### PR TITLE
Statefull login with keycard

### DIFF
--- a/account/accounts.go
+++ b/account/accounts.go
@@ -222,12 +222,16 @@ func (m *Manager) SelectAccount(loginParams LoginParams) error {
 	if err != nil {
 		return err
 	}
-
 	m.watchAddresses = loginParams.WatchAddresses
 	m.mainAccountAddress = loginParams.MainAccount
 	m.selectedChatAccount = selectedChatAccount
-
 	return nil
+}
+
+func (m *Manager) SetAccountAddresses(main common.Address, secondary ...common.Address) {
+	m.watchAddresses = []common.Address{main}
+	m.watchAddresses = append(m.watchAddresses, secondary...)
+	m.mainAccountAddress = main
 }
 
 // SetChatAccount initializes selectedChatAccount with privKey

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -537,3 +537,36 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 		require.Equal(t, address, key.Address)
 	})
 }
+
+func TestLoginWithKey(t *testing.T) {
+	b := NewStatusBackend()
+	pkey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	main := multiaccounts.Account{
+		Address: crypto.PubkeyToAddress(pkey.PublicKey),
+	}
+	tmpdir, err := ioutil.TempDir("", "login-with-key-test-")
+	require.NoError(t, err)
+	defer os.Remove(tmpdir)
+	conf, err := params.NewNodeConfig(tmpdir, 1777)
+	require.NoError(t, err)
+	password := "test"
+	keyhex := hex.EncodeToString(crypto.FromECDSA(pkey))
+
+	require.NoError(t, b.accountManager.InitKeystore(conf.KeyStoreDir))
+	b.UpdateRootDataDir(conf.DataDir)
+	require.NoError(t, b.OpenAccounts())
+
+	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, conf, password, keyhex))
+	require.NoError(t, b.Logout())
+	require.NoError(t, b.StopNode())
+
+	require.NoError(t, b.StartNodeWithKey(main, password, keyhex))
+	defer func() {
+		assert.NoError(t, b.Logout())
+		assert.NoError(t, b.StopNode())
+	}()
+	extkey, err := b.accountManager.SelectedChatAccount()
+	require.NoError(t, err)
+	require.Equal(t, crypto.PubkeyToAddress(pkey.PublicKey), extkey.Address)
+}

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -550,18 +550,17 @@ func TestLoginWithKey(t *testing.T) {
 	defer os.Remove(tmpdir)
 	conf, err := params.NewNodeConfig(tmpdir, 1777)
 	require.NoError(t, err)
-	password := "test"
 	keyhex := hex.EncodeToString(crypto.FromECDSA(pkey))
 
 	require.NoError(t, b.accountManager.InitKeystore(conf.KeyStoreDir))
 	b.UpdateRootDataDir(conf.DataDir)
 	require.NoError(t, b.OpenAccounts())
 
-	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, conf, password, keyhex))
+	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, conf, "test-pass", keyhex))
 	require.NoError(t, b.Logout())
 	require.NoError(t, b.StopNode())
 
-	require.NoError(t, b.StartNodeWithKey(main, password, keyhex))
+	require.NoError(t, b.StartNodeWithKey(main, "test-pass", keyhex))
 	defer func() {
 		assert.NoError(t, b.Logout())
 		assert.NoError(t, b.StopNode())


### PR DESCRIPTION
closes: https://github.com/status-im/status-go/issues/1576

@gravityblast please a take a look if this change make sense. i plan to be mainly unavailable starting from next week, so it would be good if we can resolve this issue before that)

The proposal is to call `SaveAccountAndLoginWithKey(accountData, password, configJSON, keyHex string)` on first login (when user created account),

And then use `LoginWithKeycard(accountData, password, keyHex string)` for regular login.

accountData is a multiaccount struct, the same that is used for login flow without keycard.
configJSON is node configuration json generated from default by status-react.
password is anything that can be used for secure database encryption (i don't know if accounts with keycard are using passwords)
keyHex is a chat key.

@dmitryn does it work for you?