### PR TITLE
Add error to login signal

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -237,7 +237,7 @@ func (b *StatusBackend) StartNodeWithKey(acc multiaccounts.Account, password str
 	return b.injectAccountIntoServices()
 }
 
-func (b *StatusBackend) StartNodeWithAccount(acc multiaccounts.Account, password string) error {
+func (b *StatusBackend) startNodeWithAccount(acc multiaccounts.Account, password string) error {
 	err := b.ensureAppDBOpened(acc, password)
 	if err != nil {
 		return err
@@ -280,8 +280,17 @@ func (b *StatusBackend) StartNodeWithAccount(acc multiaccounts.Account, password
 	if err != nil {
 		return err
 	}
-	signal.SendLoggedIn()
 	return nil
+}
+
+func (b *StatusBackend) StartNodeWithAccount(acc multiaccounts.Account, password string) error {
+	err := b.startNodeWithAccount(acc, password)
+	signal.SendLoggedIn(err)
+	if err != nil {
+		// Stop node for clean up
+		_ = b.StopNode()
+	}
+	return err
 }
 
 // StartNodeWithAccountAndConfig is used after account and config was generated.

--- a/signal/events_node.go
+++ b/signal/events_node.go
@@ -26,6 +26,11 @@ type NodeCrashEvent struct {
 	Error string `json:"error"`
 }
 
+// NodeLoginEvent returns the result of the login event
+type NodeLoginEvent struct {
+	Error string `json:"error,omitempty"`
+}
+
 // SendNodeCrashed emits a signal when status node has crashed, and
 // provides error description.
 func SendNodeCrashed(err error) {
@@ -57,6 +62,10 @@ func SendChainDataRemoved() {
 	send(EventChainDataRemoved, nil)
 }
 
-func SendLoggedIn() {
-	send(EventLoggedIn, nil)
+func SendLoggedIn(err error) {
+	event := NodeLoginEvent{}
+	if err != nil {
+		event.Error = err.Error()
+	}
+	send(EventLoggedIn, event)
 }


### PR DESCRIPTION
Fixes: #1583 
We add an error to login signal so that the caller can tell whether
login was successful or not