### PR TITLE
create a /metrics endpoint for Prometheus

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,32 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/metrics/prometheus"
+)
+
+// Server runs and controls a HTTP pprof interface.
+type Server struct {
+	server *http.Server
+}
+
+func NewMetricsServer(port int, r metrics.Registry) *Server {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", prometheus.Handler(r))
+	p := Server{
+		server: &http.Server{
+			Addr:    fmt.Sprintf(":%d", port),
+			Handler: mux,
+		},
+	}
+	return &p
+}
+
+// Listen starts the HTTP server in the background.
+func (p *Server) Listen() {
+	log.Info("metrics server stopped", "err", p.server.ListenAndServe())
+}


### PR DESCRIPTION
Since Geth `1.9` [introduced a Prometheus metrics endpoint](https://blog.ethereum.org/2019/07/10/geth-v1-9-0/#metrics-collection) and @adambabik has upgraded `status-go` to use Geth `1.9` in 26880b83d7cf4e950ac11eb8b14464adf10f3cb8 it would make sense to start using that endpoint.

This is done for two reasons:

* Allows us to drop the [geth_exporter](https://github.com/status-im/geth_exporter) service for exporting metrics
* Implement a new `whiper_mobile_peers_total` metrics for https://github.com/status-im/infra-misc/issues/26

I got the default `9305` port from [Prometheus default port allocations](https://github.com/prometheus/prometheus/wiki/Default-port-allocations).