### PR TITLE
String payload

### DIFF
--- a/services/shhext/dedup/deduplicator.go
+++ b/services/shhext/dedup/deduplicator.go
@@ -36,6 +36,7 @@ type Metadata struct {
 type DeduplicateMessage struct {
 	Message  *whispertypes.Message `json:"message"`
 	Metadata Metadata              `json:"metadata"`
+	Payload  string                `json:"payload"`
 }
 
 // NewDeduplicator creates a new deduplicator

--- a/services/shhext/service.go
+++ b/services/shhext/service.go
@@ -213,6 +213,7 @@ func (s *Service) retrieveMessagesLoop(tick time.Duration, cancel <-chan struct{
 							Message: message.TransportMessage,
 						}
 						dedupMessage.Message.Payload = message.DecryptedPayload
+						dedupMessage.Payload = string(message.DecryptedPayload)
 						dedupMessages = append(dedupMessages, dedupMessage)
 					}
 				}


### PR DESCRIPTION
Add a string payload, which will be used by status-react as it avoid having to convert `hex` to `utf8`, improving performance.