### PR TITLE
make sure Version is always set in loadNodeConfig()

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -349,6 +349,10 @@ func (b *StatusBackend) loadNodeConfig() (*params.NodeConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	// NodeConfig.Version should be taken from params.Version
+	// which is set at the compile time.
+	// What's cached is usually outdated so we overwrite it here.
+	conf.Version = params.Version
 	return &conf, nil
 }
 

--- a/params/version.go
+++ b/params/version.go
@@ -1,6 +1,7 @@
 package params
 
 // Version is defined in VERSION file.
+// We set it in loadNodeConfig() in api/backend.go.
 var Version string
 
 // GitCommit is a commit hash.

--- a/params/version_test.go
+++ b/params/version_test.go
@@ -1,0 +1,19 @@
+package params_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestVersionFormat(t *testing.T) {
+	data, err := ioutil.ReadFile(filepath.Join("..", "VERSION"))
+	if err != nil {
+		t.Error("unable to open VERSION file")
+	}
+	matched, _ := regexp.Match(`^\d+\.\d+\.\d+(-[.\w]+)?\n?$`, data)
+	if !matched {
+		t.Error("version in incorrect format")
+	}
+}


### PR DESCRIPTION
This should resolve the issue with missing `status-go` version in the App:
https://github.com/status-im/status-react/issues/9270