### PR TITLE
return rttMs as null on error

### DIFF
--- a/rtt/README.md
+++ b/rtt/README.md
@@ -16,7 +16,7 @@ The call takes one struct argument which contains two attributes:
 The return value consists of a list of objects representing a result for each mailserver, each containing following attributes:
 
 * `address` - The `enode` address of given mailserver.
-* `rtt_ms` - Round Trip Time given in milliseconds. Set to `-1` in case of an error.`
+* `rttMs` - Round Trip Time given in milliseconds. Set to `null` in case of an error.`
 * `error` - A text of error that caused the ping failure.
 
 # Example
@@ -53,7 +53,7 @@ EOL
     },
     {
       "address": "enode://c42f368a23fa98ee546fd247220759062323249ef657d26d357a777443aec04db1b29a3a22ef3e7c548e18493ddaf51a31b0aed6079bd6ebe5ae838fcfaf3a49@206.189.243.162:999",
-      "rtt_ms": -1,
+      "rtt_ms": null,
       "error": "tcp check timeout: I/O timeout"
     }
   ]

--- a/services/mailservers/tcp_ping.go
+++ b/services/mailservers/tcp_ping.go
@@ -19,7 +19,7 @@ type PingQuery struct {
 
 type PingResult struct {
 	ENode string  `json:"address"`
-	RTTMs int     `json:"rtt_ms"`
+	RTTMs *int    `json:"rttMs"`
 	Err   *string `json:"error"`
 }
 
@@ -28,7 +28,11 @@ func (pr *PingResult) Update(rttMs int, err error) {
 		errStr := err.Error()
 		pr.Err = &errStr
 	}
-	pr.RTTMs = rttMs
+	if rttMs > 0 {
+		pr.RTTMs = &rttMs
+	} else {
+		pr.RTTMs = nil
+	}
 }
 
 func enodeToAddr(enodeAddr string) (string, error) {


### PR DESCRIPTION
### Changes


* Renames `rtt_ms` to `rttMs` in RPC JSON response to stick to CamelCase
* Changes returns value on error for `rttMs` from `-1` to `null`

### Result


```bash
curl -s localhost:8545 -H 'content-type: application/json' -d '{"jsonrpc":"2.0","method":"mailservers_ping","params":[{"addresses":["enode://c42f368a23fa98ee546fd247220759062323249ef657d26d357a777443aec04db1b29a3a22ef3e7c548e18493ddaf51a31b0aed6079bd6ebe5ae838fcfaf3a49@206.189.243.162:222"], "timeoutMs": 500}],"id":1}'
```

```json
{
"jsonrpc": "2.0",
"id": 1,
"result": [
{
"address": "enode://c42f368a23fa98ee546fd247220759062323249ef657d26d357a777443aec04db1b29a3a22ef3e7c548e18493ddaf51a31b0aed6079bd6ebe5ae838fcfaf3a49@206.189.243.162:222",
"rttMs": null,
"error": "tcp check timeout: I/O timeout"
}
]
}
```

