### PR TITLE
fix 1741

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -27,7 +27,7 @@ type StatusBackend interface {
 	OpenAccounts() error
 	GetAccounts() ([]multiaccounts.Account, error)
 	// SaveAccount(account multiaccounts.Account) error
-	SaveAccountAndStartNodeWithKey(acc multiaccounts.Account, conf *params.NodeConfig, password string, keyHex string) error
+	SaveAccountAndStartNodeWithKey(acc multiaccounts.Account, password string, conf *params.NodeConfig, subaccs []accounts.Account, keyHex string) error
 	Recover(rpcParams personal.RecoverParams) (types.Address, error)
 	Logout() error
 

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -583,7 +583,8 @@ func TestLoginWithKey(t *testing.T) {
 	b.UpdateRootDataDir(conf.DataDir)
 	require.NoError(t, b.OpenAccounts())
 
-	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, conf, "test-pass", keyhex))
+	address := crypto.PubkeyToAddress(pkey.PublicKey)
+	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", conf, []accounts.Account{{Address: address}}, keyhex))
 	require.NoError(t, b.Logout())
 	require.NoError(t, b.StopNode())
 

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -565,9 +565,11 @@ func TestLoginWithKey(t *testing.T) {
 	utils.Init()
 
 	b := NewGethStatusBackend()
-	pkey, err := crypto.GenerateKey()
+	chatKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
-	keyUIDHex := sha256.Sum256(crypto.FromECDSAPub(&pkey.PublicKey))
+	walletKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	keyUIDHex := sha256.Sum256(crypto.FromECDSAPub(&chatKey.PublicKey))
 	keyUID := types.EncodeHex(keyUIDHex[:])
 	main := multiaccounts.Account{
 		KeyUID: keyUID,
@@ -577,14 +579,14 @@ func TestLoginWithKey(t *testing.T) {
 	defer os.Remove(tmpdir)
 	conf, err := params.NewNodeConfig(tmpdir, 1777)
 	require.NoError(t, err)
-	keyhex := hex.EncodeToString(crypto.FromECDSA(pkey))
+	keyhex := hex.EncodeToString(crypto.FromECDSA(chatKey))
 
 	require.NoError(t, b.AccountManager().InitKeystore(conf.KeyStoreDir))
 	b.UpdateRootDataDir(conf.DataDir)
 	require.NoError(t, b.OpenAccounts())
 
-	address := crypto.PubkeyToAddress(pkey.PublicKey)
-	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", conf, []accounts.Account{{Address: address}}, keyhex))
+	address := crypto.PubkeyToAddress(walletKey.PublicKey)
+	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", conf, []accounts.Account{{Address: address, Wallet: true}}, keyhex))
 	require.NoError(t, b.Logout())
 	require.NoError(t, b.StopNode())
 
@@ -595,5 +597,5 @@ func TestLoginWithKey(t *testing.T) {
 	}()
 	extkey, err := b.accountManager.SelectedChatAccount()
 	require.NoError(t, err)
-	require.Equal(t, crypto.PubkeyToAddress(pkey.PublicKey), extkey.Address)
+	require.Equal(t, crypto.PubkeyToAddress(chatKey.PublicKey), extkey.Address)
 }

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -186,7 +186,7 @@ func (b *GethStatusBackend) ensureAppDBOpened(account multiaccounts.Account, pas
 	return nil
 }
 
-func (b *GethStatusBackend) SaveAccountAndStartNodeWithKey(acc multiaccounts.Account, conf *params.NodeConfig, password string, keyHex string) error {
+func (b *GethStatusBackend) SaveAccountAndStartNodeWithKey(acc multiaccounts.Account, password string, conf *params.NodeConfig, subaccs []accounts.Account, keyHex string) error {
 	err := b.SaveAccount(acc)
 	if err != nil {
 		return err
@@ -196,6 +196,10 @@ func (b *GethStatusBackend) SaveAccountAndStartNodeWithKey(acc multiaccounts.Acc
 		return err
 	}
 	err = b.saveNodeConfig(conf)
+	if err != nil {
+		return err
+	}
+	err = accounts.NewDB(b.appDB).SaveAccounts(subaccs)
 	if err != nil {
 		return err
 	}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -376,7 +376,7 @@ func InitKeystore(keydir string) string {
 }
 
 // SaveAccountAndLoginWithKeycard saves account in status-go database..
-func SaveAccountAndLoginWithKeycard(accountData, password, configJSON, keyHex string) string {
+func SaveAccountAndLoginWithKeycard(accountData, password, configJSON, subaccountData string, keyHex string) string {
 	var account multiaccounts.Account
 	err := json.Unmarshal([]byte(accountData), &account)
 	if err != nil {
@@ -387,9 +387,14 @@ func SaveAccountAndLoginWithKeycard(accountData, password, configJSON, keyHex st
 	if err != nil {
 		return makeJSONResponse(err)
 	}
+	var subaccs []accounts.Account
+	err = json.Unmarshal([]byte(subaccountData), &subaccs)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
 	api.RunAsync(func() error {
 		log.Debug("starting a node, and saving account with configuration", "key-uid", account.KeyUID)
-		err := statusBackend.SaveAccountAndStartNodeWithKey(account, &conf, password, keyHex)
+		err := statusBackend.SaveAccountAndStartNodeWithKey(account, password, &conf, subaccs, keyHex)
 		if err != nil {
 			log.Error("failed to start node and save account", "key-uid", account.KeyUID, "error", err)
 			return err


### PR DESCRIPTION
save accounts with SaveAccountAndStartNodeWithKey

also fixes the login bug where keycard accounts load the chat account as main wallet account and ignore the saved accounts

Closes #1741