### PR TITLE
add missing jq checks, make formatting vars the same

### DIFF
--- a/_assets/compose/bootnode/Makefile
+++ b/_assets/compose/bootnode/Makefile
@@ -1,14 +1,13 @@
 GIT_ROOT = $(shell git rev-parse --show-toplevel)
 
-RED    := $(shell tput -Txterm setaf 1)
-GREEN  := $(shell tput -Txterm setaf 2)
-YELLOW := $(shell tput -Txterm setaf 3)
-RESET  := $(shell tput -Txterm sgr0)
-BOLD   := $(shell tput bold)
+RED := $(shell tput -Txterm setaf 1)
+GRN := $(shell tput -Txterm setaf 2)
+YLW := $(shell tput -Txterm setaf 3)
+RST := $(shell tput -Txterm sgr0)
+BLD := $(shell tput bold)
 
 UID = $(shell id -u)
 GID = $(shell id -g)
-
 
 # Settings
 export LOG_LEVEL       ?= 3
@@ -23,22 +22,22 @@ all: checks start show info enode
 
 checks:
 ifeq (, $(shell which docker))
-	$(error No $(BOLD)docker$(RESET) in your $$PATH. Please install it)
+	$(error $(RED)No 'docker' in your $$PATH. Please install it$(RST))
 endif
 ifeq (, $(shell docker version | grep Server))
-	$(error No permissions to run $(BOLD)docker$(RESET). Add yourself to docker group)
+	$(error $(RED)No permissions to run 'docker'. Add yourself to docker group$(RST))
 endif
 ifeq (, $(shell which docker-compose))
-	$(error No $(BOLD)docker-compose$(RESET) in your $$PATH. Please install it)
+	$(error $(RED)No 'docker-compose' in your $$PATH. Please install it$(RST))
 endif
 ifeq (, $(shell which jq))
-	$(error No $(BOLD)jq$(RESET) in your $$PATH. Please install it)
+	$(error $(RED)No 'jq' in your $$PATH. Please install it$(RST))
 endif
 ifndef PUBLIC_IP
-	$(error PUBLIC_IP not set! Export it as environment variable)
+	$(error $(RED)$$PUBLIC_IP not set! Export it as environment variable$(RST))
 endif
 ifndef CONTAINER_NAME
-	$(error CONTAINER_NAME not set! Export it as environment variable)
+	$(error $(RED)$$CONTAINER_NAME not set! Export it as environment variable$(RST))
 endif
 
 start: keys/nodekey keys/nodeaddr
@@ -54,9 +53,9 @@ enode: keys/nodeaddr
 	@echo "enode://$(shell cat keys/nodeaddr)@$(PUBLIC_IP):$(LISTEN_PORT)"
 
 info:
-	@echo "$(GREEN)Your bootnode is listening on:$(RESET) $(BOLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RESET)"
-	@echo "$(YELLOW)Make sure that address and UDP port are available from the internet!$(RESET)"
-	@echo "$(GREEN)Your enode address is:$(RESET)"
+	@echo "$(GRN)Your bootnode is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)"
+	@echo "$(YLW)Make sure that address and UDP port are available from the internet!$(RST)"
+	@echo "$(GRN)Your enode address is:$(RST)"
 
 keys:
 	@mkdir -p keys
@@ -68,7 +67,7 @@ keys/nodekey: keys ##@ Generate a node key
 		-v $(PWD)/keys:/keys:rw \
 		$(CONTAINER_IMAGE) \
 		-genkey=/keys/nodekey
-	@echo "$(GREEN)Created key for Bootnode: keys/nodekey"
+	@echo "$(GRN)Created key for Bootnode: keys/nodekey$(RST)"
 
 keys/nodeaddr: keys ##@ Save node address for given key
 	@docker run --rm \

--- a/_assets/compose/mailserver/Makefile
+++ b/_assets/compose/mailserver/Makefile
@@ -1,10 +1,10 @@
 export GIT_ROOT = $(shell git rev-parse --show-toplevel)
 
-RED    := $(shell tput -Txterm setaf 1)
-GREEN  := $(shell tput -Txterm setaf 2)
-YELLOW := $(shell tput -Txterm setaf 3)
-RESET  := $(shell tput -Txterm sgr0)
-BOLD   := $(shell tput bold)
+RED := $(shell tput -Txterm setaf 1)
+GRN := $(shell tput -Txterm setaf 2)
+YLW := $(shell tput -Txterm setaf 3)
+RST := $(shell tput -Txterm sgr0)
+BLD := $(shell tput bold)
 
 # Settings
 export LOG_LEVEL      ?= INFO
@@ -23,22 +23,22 @@ all: checks start show info enode
 
 checks:
 ifeq (, $(shell which docker))
-	$(error No $(BOLD)docker$(RESET) in your $$PATH. Please install it)
+	$(error $(RED)No 'docker' in your $$PATH. Please install it$(RST))
 endif
 ifeq (, $(shell docker version | grep Server))
-	$(error No permissions to run $(BOLD)docker$(RESET). Add yourself to docker group)
+	$(error $(RED)No permissions to run 'docker'. Add yourself to docker group$(RST))
 endif
 ifeq (, $(shell which docker-compose))
-	$(error No $(BOLD)docker-compose$(RESET) in your $$PATH. Please install it)
+	$(error $(RED)No 'docker-compose' in your $$PATH. Please install it$(RST))
 endif
 ifeq (, $(shell which jq))
-	$(error No $(BOLD)jq$(RESET) in your $$PATH. Please install it)
+	$(error $(RED)No 'jq' in your $$PATH. Please install it$(RST))
 endif
 ifndef PUBLIC_IP
-	$(error PUBLIC_IP not set! Export it as environment variable)
+	$(error $(RED)$$PUBLIC_IP not set! Export it as environment variable$(RST))
 endif
 ifndef CONTAINER_NAME
-	$(error CONTAINER_NAME not set! Export it as environment variable)
+	$(error $(RED)$$CONTAINER_NAME not set! Export it as environment variable$(RST))
 endif
 
 start: config
@@ -57,9 +57,9 @@ config:
 	@$(GIT_ROOT)/_assets/scripts/gen_config.sh
 
 info:
-	@echo "$(GREEN)Your mailserver is listening on:$(RESET) $(BOLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RESET)"
-	@echo "$(YELLOW)Make sure that address and TCP port are available from the internet!$(RESET)"
-	@echo "$(GREEN)Your enode address is:$(RESET)"
+	@echo "$(GRN)Your mailserver is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)"
+	@echo "$(YLW)Make sure that address and TCP port are available from the internet!$(RST)"
+	@echo "$(GRN)Your enode address is:$(RST)"
 
 show:
 	@docker ps \

--- a/_assets/scripts/gen_config.sh
+++ b/_assets/scripts/gen_config.sh
@@ -11,6 +11,11 @@ MAIL_PASSWORD="${MAIL_PASSWORD:-status-offline-inbox}"
 DATA_PATH="${DATA_PATH:-/var/tmp/status-go-mail}"
 CONFIG_PATH="${CONFIG_PATH:-${DATA_PATH}/config.json}"
 
+if ! [[ -x $(command -v jq) ]]; then
+  echo "Cannot generate config. jq utility is not installed."
+  exit 1
+fi
+
 if [[ -e "${CONFIG_PATH}" ]]; then
   echo "Config already exits. Remove it to generate a new one."
   exit 0

--- a/_assets/systemd/mailserver/Makefile
+++ b/_assets/systemd/mailserver/Makefile
@@ -32,6 +32,9 @@ all: checks build config service enable restart info
 clean: stop disable rm-service forget 
 
 checks:
+ifeq (, $(shell which jq))
+	$(error $(RED)No 'jq' in your $$PATH. please install it$(RST))
+endif
 # this setup wont work without an os with systemd
 ifeq (, $(shell which systemctl))
 	$(error $(RED)Your system does not have systemd$(RST))

--- a/_assets/systemd/mailserver/service.template
+++ b/_assets/systemd/mailserver/service.template
@@ -10,7 +10,7 @@ ExecStart=${GIT_ROOT}/build/bin/statusd \
     -log-without-color \
     -log "${LOG_LEVEL}" \
     -dir "${DATA_PATH}" \
-    -c "./config.json" \
+    -c "${DATA_PATH}/config.json" \
     -metrics
 
 [Install]


### PR DESCRIPTION
Changes:
* Added checks for `jq` in `gen_config.sh` and `Makefile`s.
* Used absolute path to `config.json` in `service.template`
* Also streamlined naming of formatting variables.