### PR TITLE
allow running systemd service as root

### DIFF
--- a/BOOTNODE.md
+++ b/BOOTNODE.md
@@ -1,6 +1,6 @@
 # Description
 
-This document describes the two easiest ways to start a Status Bootnode:
+This document describes the two alternative ways to start a Status Bootnode:
 
 * [Docker Compose](https://docs.docker.com/compose/) - More self-contained and portable
 * [Systemd Service](https://www.freedesktop.org/wiki/Software/systemd/) - More local and configurable
@@ -21,6 +21,7 @@ The other way is to run the `bootnode` under `systemd`:
 ```
 make run-bootnode-systemd
 ```
-This will generate the necessary config, define and then start the service.
+This will generate the necessary config, define and then start a user service.
+Use `sudo` if you want it to be a system service.
 
 For more details read the [README](_assets/systemd/bootnode/README.md).

--- a/MAILSERVER.md
+++ b/MAILSERVER.md
@@ -1,6 +1,6 @@
 # Description
 
-This document describes the two easiest ways to start a Status Mailserver:
+This document describes the two alternative ways to start a Status Mailserver:
 
 * [Docker Compose](https://docs.docker.com/compose/) - More self-contained and portable
 * [Systemd Service](https://www.freedesktop.org/wiki/Software/systemd/) - More local and configurable
@@ -21,6 +21,7 @@ The other way is to run the `mailserver` under `systemd`:
 ```
 make run-mailserver-systemd
 ```
-This will generate the necessary config, define and then start the service.
+This will generate the necessary config, define and then start a user service.
+Use `sudo` if you want it to be a system service.
 
 For more details read the [README](_assets/systemd/mailserver/README.md).

--- a/_assets/systemd/bootnode/Makefile
+++ b/_assets/systemd/bootnode/Makefile
@@ -6,9 +6,19 @@ YLW := $(shell tput -Txterm setaf 3)
 RST := $(shell tput -Txterm sgr0)
 BLD := $(shell tput bold)
 
+# by default we run the service as user
+SCTL_OPTS   := --user
+JRNL_OPTS   := --user-unit
+SERVICE_DIR := $(HOME)/.config/systemd/user/
+# with sudo it will run as a system service
+ifeq ($(USER), root)
+SCTL_OPTS   := 
+JRNL_OPTS   := --unit
+SERVICE_DIR := /etc/systemd/system/
+endif
+
 # Settings
 export SERVICE_NAME ?= bootnode
-export SERVICE_DIR  ?= $(HOME)/.config/systemd/user/
 export SERVICE_PATH ?= $(SERVICE_DIR)/$(SERVICE_NAME).service
 export LOG_LEVEL    ?= 3
 export LISTEN_PORT  ?= 30303
@@ -19,7 +29,7 @@ export ADDR_PATH    ?= $(DATA_PATH)/nodeaddr
 export PUBLIC_IP    ?= $(shell curl -s https://ipecho.net/plain)
 
 # Info
-STATUS    = $(shell systemctl --user is-active $(SERVICE_NAME))
+STATUS    = $(shell systemctl $(SCTL_OPTS) is-active $(SERVICE_NAME))
 NODE_ADDR = $(shell cat $(ADDR_PATH))
 ENODE     = enode://$(NODE_ADDR)@$(PUBLIC_IP):$(LISTEN_PORT)
 
@@ -62,35 +72,35 @@ save-address:
 	@$(GIT_ROOT)/build/bin/bootnode -nodekey=$(KEY_PATH) -writeaddress > $(ADDR_PATH)
 
 status:
-	systemctl --user status --no-pager $(SERVICE_NAME)
+	systemctl $(SCTL_OPTS) status --no-pager $(SERVICE_NAME)
 
 logs:
-	journalctl --user-unit statusd
+	journalctl $(JRNL_OPTS) statusd
 
 enable:
 	@echo "* $(BLD)Enabling '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user enable $(SERVICE_NAME)
+	systemctl $(SCTL_OPTS) enable $(SERVICE_NAME)
 
 disable:
 	@echo "* $(BLD)Disabling '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user disable "${SERVICE_NAME}"
+	systemctl $(SCTL_OPTS) disable "${SERVICE_NAME}"
 
 start:
 	@echo "* $(BLD)Starting '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user start $(SERVICE_NAME)
+	systemctl $(SCTL_OPTS) start $(SERVICE_NAME)
 
 restart:
 	@echo "* $(BLD)Restarting '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user restart $(SERVICE_NAME)
+	systemctl $(SCTL_OPTS) restart $(SERVICE_NAME)
 
 stop:
 	@echo "* $(BLD)Stopping '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user stop "${SERVICE_NAME}"
+	systemctl $(SCTL_OPTS) stop "${SERVICE_NAME}"
 
 forget:
 	@echo "* $(BLD)Stopping '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user daemon-reload
-	systemctl --user reset-failed
+	systemctl $(SCTL_OPTS) daemon-reload
+	systemctl $(SCTL_OPTS) reset-failed
 
 $(GIT_ROOT)/build/bin/bootnode:
 	@echo "* $(BLD)Building bootnode binary...$(RST)"

--- a/_assets/systemd/bootnode/README.md
+++ b/_assets/systemd/bootnode/README.md
@@ -39,6 +39,12 @@ All settings are passed through environment variables:
 * `KEY_PATH` - Location of Bootnode private key file. (Default: `/var/tmp/status-go-boot/nodekey`)
 * `LOG_LEVEL` - Set level of log messages to show. (Values:`0-9`, Default: `3`)`
 
+# System Service
+
+By default this `Makefile` configures the Bootnode as a [systemd user service](https://www.freedesktop.org/software/systemd/man/user@.service.html). This is done to simplify the proces and remove the need for `sudo`. The disadvantage of this solution is that the service is stopped when the user logs out.
+
+In order to make your service a system service use `sudo make`.
+
 # Known Issues
 
 * `No journal files were opened due to insufficient permissions.` from `systemctl`

--- a/_assets/systemd/mailserver/Makefile
+++ b/_assets/systemd/mailserver/Makefile
@@ -6,6 +6,17 @@ YLW := $(shell tput -Txterm setaf 3)
 RST := $(shell tput -Txterm sgr0)
 BLD := $(shell tput bold)
 
+# by default we run the service as user
+SCTL_OPTS   := --user
+JRNL_OPTS   := --user-unit
+SERVICE_DIR := $(HOME)/.config/systemd/user/
+# with sudo it will run as a system service
+ifeq ($(USER), root)
+SCTL_OPTS   := 
+JRNL_OPTS   := --unit
+SERVICE_DIR := /etc/systemd/system/
+endif
+
 # Settings
 export SERVICE_NAME ?= statusd
 export SERVICE_DIR  ?= $(HOME)/.config/systemd/user/
@@ -17,7 +28,7 @@ export DATA_PATH    ?= /var/tmp/status-go-mail
 export PUBLIC_IP    ?= $(shell curl -s https://ipecho.net/plain)
 
 # Info
-STATUS = $(shell systemctl --user is-active $(SERVICE_NAME))
+STATUS = $(shell systemctl $(SCTL_OPTS) is-active $(SERVICE_NAME))
 
 define INFO_MSG
 * $(GRN)Your mailserver is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
@@ -52,35 +63,35 @@ enode:
 	@$(GIT_ROOT)/_assets/scripts/get_enode.sh
 
 status:
-	systemctl --user status --no-pager $(SERVICE_NAME)
+	systemctl $(SCTL_OPTS) status --no-pager $(SERVICE_NAME)
 
 logs:
-	journalctl --user-unit statusd
+	journalctl $(JRNL_OPTS) statusd
 
 enable:
 	@echo "* $(BLD)Enabling '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user enable $(SERVICE_NAME)
+	systemctl $(SCTL_OPTS) enable $(SERVICE_NAME)
 
 disable:
 	@echo "* $(BLD)Disabling '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user disable "${SERVICE_NAME}"
+	systemctl $(SCTL_OPTS) disable "${SERVICE_NAME}"
 
 start:
 	@echo "* $(BLD)Starting '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user start $(SERVICE_NAME)
+	systemctl $(SCTL_OPTS) start $(SERVICE_NAME)
 
 restart:
 	@echo "* $(BLD)Restarting '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user restart $(SERVICE_NAME)
+	systemctl $(SCTL_OPTS) restart $(SERVICE_NAME)
 
 stop:
 	@echo "* $(BLD)Stopping '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user stop "${SERVICE_NAME}"
+	systemctl $(SCTL_OPTS) stop "${SERVICE_NAME}"
 
 forget:
 	@echo "* $(BLD)Stopping '$(SERVICE_NAME)' service...$(RST)"
-	systemctl --user daemon-reload
-	systemctl --user reset-failed
+	systemctl $(SCTL_OPTS) daemon-reload
+	systemctl $(SCTL_OPTS) reset-failed
 
 $(GIT_ROOT)/build/bin/statusd:
 	@echo "* $(BLD)Building mailserver binary...$(RST)"

--- a/_assets/systemd/mailserver/README.md
+++ b/_assets/systemd/mailserver/README.md
@@ -38,11 +38,17 @@ All settings are passed through environment variables:
 * `RPC_PORT` - Control port making it possible to use the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC).
 * `API_MODULES` - API modules to be made available via the `RPC_PORT`.
 * `DATA_PATH` - Location of Mailserver storage and keys. (Default: `/var/tmp/status-go-mail`)
-* `REGISTER_TOPIC` - Mynamic mailserver discovery topic. (Default: `whispermail`)
-* `MAIL_PASSWORD` - Basic HTTP auth password for mailserver. (Default: `status-offline-inbox`)
+* `REGISTER_TOPIC` - Mynamic Mailserver discovery topic. (Default: `whispermail`)
+* `MAIL_PASSWORD` - Basic HTTP auth password for Mailserver. (Default: `status-offline-inbox`)
 * `LOG_LEVEL` - Set level of log messages to show. (`ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`)
 
 The generated configuration file end up under `${DATA_PATH}/config.json`.
+
+# System Service
+
+By default this `Makefile` configures the Mailserver as a [systemd user service](https://www.freedesktop.org/software/systemd/man/user@.service.html). This is done to simplify the proces and remove the need for `sudo`. The disadvantage of this solution is that the service is stopped when the user logs out.
+
+In order to make your service a system service use `sudo make`.
 
 # Known Issues
 


### PR DESCRIPTION
Based on https://github.com/status-im/status-go/issues/1616 I've added the ability to use the `Makefile`s in `_assets/systemd/{bootnode,mailserver}` with `sudo` to create the systemd services as system rather than user services.

This fixes the issue for those that want the service to run even when they are logged out.