### PR TITLE
Report correct number of pruned rows in Postgres mailserver

### DIFF
--- a/mailserver/mailserver_db_postgres.go
+++ b/mailserver/mailserver_db_postgres.go
@@ -171,11 +171,15 @@ func (i *PostgresDB) Prune(t time.Time, batch int) (int, error) {
 	}
 	defer stmt.Close()
 
-	if _, err = stmt.Exec(kl.Bytes(), ku.Bytes()); err != nil {
+	result, err := stmt.Exec(kl.Bytes(), ku.Bytes())
+	if err != nil {
 		return 0, err
 	}
-
-	return 0, nil
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(rows), nil
 }
 
 func (i *PostgresDB) SaveEnvelope(env types.Envelope) error {


### PR DESCRIPTION
When using Postgres mailsever, the reported pruned number of rows is always 0. This change uses `RowsAffected` to provide the correct number.

## Note

Before merging, the query `DELETE FROM envelopes WHERE id BETWEEN $1 AND $2` should be verified.

cc @cammellos @jakubgs