### PR TITLE
Remove 24h time range validation from mailserver request

### DIFF
--- a/mailserver/request.go
+++ b/mailserver/request.go
@@ -39,9 +39,6 @@ func (r MessagesRequestPayload) Validate() error {
 	if r.Upper < r.Lower {
 		return errors.New("query range is invalid: lower > upper")
 	}
-	if r.Upper-r.Lower > uint32(maxQueryRange.Seconds()) {
-		return errors.New("query range must be smaller or equal to 24 hours")
-	}
 	if len(r.Bloom) == 0 {
 		return errors.New("bloom filter is empty")
 	}


### PR DESCRIPTION
We limit number of messages using `Limit` only. The time range might be arbitrary.