### PR TITLE
include mail password when getting enode with get_enode.sh

### DIFF
--- a/_assets/compose/mailserver/Makefile
+++ b/_assets/compose/mailserver/Makefile
@@ -18,7 +18,7 @@ export MAIL_PASSWORD  ?= status-offline-inbox
 # Necessary to make mailserver available publicly
 export PUBLIC_IP      ?= $(shell curl -s https://ipecho.net/plain)
 
-all: checks start show info enode
+all: checks start show info enode enode-qr
 
 checks:
 ifeq (, $(shell which docker))
@@ -51,6 +51,9 @@ logs:
 
 enode:
 	@$(GIT_ROOT)/_assets/scripts/get_enode.sh
+
+enode-qr:
+	@$(GIT_ROOT)/_assets/scripts/get_enode.sh --qr
 
 config:
 	@$(GIT_ROOT)/_assets/scripts/gen_config.sh

--- a/_assets/compose/mailserver/README.md
+++ b/_assets/compose/mailserver/README.md
@@ -20,6 +20,7 @@ To simply start a container run `make`, other commands include:
 * `make logs` - Shows you logs of the container.
 * `make config` - Creates `${DATA_PATH}/config.json` with your Public IP.
 * `make enode` - Shows `enode://` address of the container.
+* `make enode-qr` - Shows `enode://` address using a QR code.
 
 # Settings
 

--- a/_assets/scripts/get_enode.sh
+++ b/_assets/scripts/get_enode.sh
@@ -6,6 +6,8 @@ RPC_PORT="${RPC_PORT:-8545}"
 if [[ -z "${PUBLIC_IP}" ]]; then
     PUBLIC_IP=$(curl -s https://ipecho.net/plain)
 fi
+# Necessary for enode address for Status app
+MAIL_PASSWORD="${MAIL_PASSWORD:-status-offline-inbox}"
 
 # query local 
 RESP_JSON=$(
@@ -23,5 +25,7 @@ ENODE_RAW=$(echo "${RESP_JSON}" | jq -r '.result.enode')
 # drop arguments at the end of enode address
 ENODE_CLEAN=$(echo "${ENODE_RAW}" | grep -oP '\Kenode://[^?]+')
 
-# replace localhost with public IP
-echo "${ENODE_CLEAN}" | sed s/127.0.0.1/${PUBLIC_IP}/
+# replace localhost with public IP and add mail password
+echo "${ENODE_CLEAN}" | sed \
+    -e "s/127.0.0.1/${PUBLIC_IP}/" \
+    -e "s/@/:${MAIL_PASSWORD}@/"

--- a/_assets/scripts/get_enode.sh
+++ b/_assets/scripts/get_enode.sh
@@ -26,6 +26,16 @@ ENODE_RAW=$(echo "${RESP_JSON}" | jq -r '.result.enode')
 ENODE_CLEAN=$(echo "${ENODE_RAW}" | grep -oP '\Kenode://[^?]+')
 
 # replace localhost with public IP and add mail password
-echo "${ENODE_CLEAN}" | sed \
+ENODE=$(echo "${ENODE_CLEAN}" | sed \
     -e "s/127.0.0.1/${PUBLIC_IP}/" \
-    -e "s/@/:${MAIL_PASSWORD}@/"
+    -e "s/@/:${MAIL_PASSWORD}@/")
+
+if [[ "$1" == "--qr" ]]; then
+    if ! [ -x "$(command -v qrencode)" ]; then
+      echo 'Install 'qrencode' for enode QR code.' >&2
+      exit 0
+    fi
+    qrencode -t UTF8 "${ENODE}"
+else
+    echo "${ENODE}"
+fi

--- a/_assets/systemd/mailserver/Makefile
+++ b/_assets/systemd/mailserver/Makefile
@@ -38,7 +38,7 @@ $(shell $(GIT_ROOT)/_assets/scripts/get_enode.sh 2>/dev/null)
 endef
 export INFO_MSG
 
-all: checks build config service enable restart info
+all: checks build config service enable restart info enode-qr
 
 clean: stop disable rm-service forget 
 
@@ -61,6 +61,9 @@ info:
 
 enode:
 	@$(GIT_ROOT)/_assets/scripts/get_enode.sh
+
+enode-qr:
+	@$(GIT_ROOT)/_assets/scripts/get_enode.sh --qr
 
 status:
 	systemctl $(SCTL_OPTS) status --no-pager $(SERVICE_NAME)

--- a/_assets/systemd/mailserver/README.md
+++ b/_assets/systemd/mailserver/README.md
@@ -18,6 +18,7 @@ In order to manage the new `statusd` service you use other `Makefile` targets:
 
 * `make info` - Info about service
 * `make enode` - Get enode address
+* `make enode-qr` - Get enode address as QR code
 * `make start` - Start the service
 * `make stop` - Stop the service
 * `make status` - Check service status


### PR DESCRIPTION
This should simplify setup for people by adding the mail password that is required by App when inputting a mailserver enode address by hand.
```bash
 $ _assets/scripts/get_enode.sh
enode://123qweASD:status-offline-inbox@12.34.56.78:30303
```
Also added option to show as QR code if `qrencode` is available:
```
 $ _assets/scripts/get_enode.sh --qr
```