### PR TITLE
Fix wrong field being logged in  EnvelopesMonitor

### DIFF
--- a/cmd/node-canary/main.go
+++ b/cmd/node-canary/main.go
@@ -151,7 +151,6 @@ func verifyMailserverBehavior(mailserverNode *enode.Node) {
 
 	clientRPCClient := clientNode.RPCClient()
 
-	// TODO: Replace chat implementation with github.com/status-im/status-go-sdk
 	_, topic, _, err := joinPublicChat(clientWhisperService, clientRPCClient, *publicChannel)
 	if err != nil {
 		logger.Error("Failed to join public chat", "error", err)

--- a/protocol/transport/waku/envelopes.go
+++ b/protocol/transport/waku/envelopes.go
@@ -203,7 +203,7 @@ func (m *EnvelopesMonitor) handleAcknowledgedBatch(event types.EnvelopeEvent) {
 	m.logger.Debug("received a confirmation", zap.String("batch", event.Batch.String()), zap.String("peer", event.Peer.String()))
 	envelopeErrors, ok := event.Data.([]types.EnvelopeError)
 	if event.Data != nil && !ok {
-		m.logger.Error("received unexpected data in the the confirmation event", zap.String("batch", event.Batch.String()))
+		m.logger.Error("received unexpected data in the the confirmation event", zap.Any("data", event.Data))
 	}
 	failedEnvelopes := map[types.Hash]struct{}{}
 	for i := range envelopeErrors {

--- a/protocol/transport/whisper/envelopes.go
+++ b/protocol/transport/whisper/envelopes.go
@@ -204,7 +204,7 @@ func (m *EnvelopesMonitor) handleAcknowledgedBatch(event types.EnvelopeEvent) {
 	m.logger.Debug("received a confirmation", zap.String("batch", event.Batch.String()), zap.String("peer", event.Peer.String()))
 	envelopeErrors, ok := event.Data.([]types.EnvelopeError)
 	if event.Data != nil && !ok {
-		m.logger.Error("received unexpected data in the the confirmation event", zap.String("batch", event.Batch.String()))
+		m.logger.Error("received unexpected data in the the confirmation event", zap.Any("data", event.Data))
 	}
 	failedEnvelopes := map[types.Hash]struct{}{}
 	for i := range envelopeErrors {

--- a/vendor/github.com/status-im/status-go/protocol/transport/waku/envelopes.go
+++ b/vendor/github.com/status-im/status-go/protocol/transport/waku/envelopes.go
@@ -203,7 +203,7 @@ func (m *EnvelopesMonitor) handleAcknowledgedBatch(event types.EnvelopeEvent) {
 	m.logger.Debug("received a confirmation", zap.String("batch", event.Batch.String()), zap.String("peer", event.Peer.String()))
 	envelopeErrors, ok := event.Data.([]types.EnvelopeError)
 	if event.Data != nil && !ok {
-		m.logger.Error("received unexpected data in the the confirmation event", zap.String("batch", event.Batch.String()))
+		m.logger.Error("received unexpected data in the the confirmation event", zap.Any("data", event.Data))
 	}
 	failedEnvelopes := map[types.Hash]struct{}{}
 	for i := range envelopeErrors {

--- a/vendor/github.com/status-im/status-go/protocol/transport/whisper/envelopes.go
+++ b/vendor/github.com/status-im/status-go/protocol/transport/whisper/envelopes.go
@@ -204,7 +204,7 @@ func (m *EnvelopesMonitor) handleAcknowledgedBatch(event types.EnvelopeEvent) {
 	m.logger.Debug("received a confirmation", zap.String("batch", event.Batch.String()), zap.String("peer", event.Peer.String()))
 	envelopeErrors, ok := event.Data.([]types.EnvelopeError)
 	if event.Data != nil && !ok {
-		m.logger.Error("received unexpected data in the the confirmation event", zap.String("batch", event.Batch.String()))
+		m.logger.Error("received unexpected data in the the confirmation event", zap.Any("data", event.Data))
 	}
 	failedEnvelopes := map[types.Hash]struct{}{}
 	for i := range envelopeErrors {


### PR DESCRIPTION
Jakub mentioned the following error showed up in a `develop` build:

```
E GoLog   : ERROR[01-23|14:45:57.832] received unexpected data in the the confirmation event namespace=EnvelopesMonitor batch=
```

The `Data` field is not of an expected type and unfortunately we're logging the wrong field there (`Batch`). This PR fixes the logging code.