### PR TITLE
Use logical clock for ENS

### DIFF
--- a/eth-node/bridge/geth/ens/ens.go
+++ b/eth-node/bridge/geth/ens/ens.go
@@ -30,14 +30,13 @@ func NewVerifier(logger *zap.Logger) *ENSVerifier {
 	return &ENSVerifier{logger: logger}
 }
 
-func (m *ENSVerifier) verifyENSName(ensInfo enstypes.ENSDetails, ethclient *ethclient.Client) enstypes.ENSResponse {
+func (m *ENSVerifier) verifyENSName(ensInfo enstypes.ENSDetails, ethclient *ethclient.Client) *enstypes.ENSResponse {
 	publicKeyStr := ensInfo.PublicKeyString
 	ensName := ensInfo.Name
 	m.logger.Info("Resolving ENS name", zap.String("name", ensName), zap.String("publicKey", publicKeyStr))
-	response := enstypes.ENSResponse{
+	response := &enstypes.ENSResponse{
 		Name:            ensName,
 		PublicKeyString: publicKeyStr,
-		VerifiedAt:      time.Now().Unix(),
 	}
 
 	expectedPubKeyBytes, err := hex.DecodeString(publicKeyStr)
@@ -75,12 +74,12 @@ func (m *ENSVerifier) verifyENSName(ensInfo enstypes.ENSDetails, ethclient *ethc
 }
 
 // CheckBatch verifies that a registered ENS name matches the expected public key
-func (m *ENSVerifier) CheckBatch(ensDetails []enstypes.ENSDetails, rpcEndpoint, contractAddress string) (map[string]enstypes.ENSResponse, error) {
+func (m *ENSVerifier) CheckBatch(ensDetails []enstypes.ENSDetails, rpcEndpoint, contractAddress string) (map[string]*enstypes.ENSResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), contractQueryTimeout)
 	defer cancel()
 
-	ch := make(chan enstypes.ENSResponse)
-	response := make(map[string]enstypes.ENSResponse)
+	ch := make(chan *enstypes.ENSResponse)
+	response := make(map[string]*enstypes.ENSResponse)
 
 	ethclient, err := ethclient.DialContext(ctx, rpcEndpoint)
 	if err != nil {

--- a/eth-node/types/ens/ens.go
+++ b/eth-node/types/ens/ens.go
@@ -4,18 +4,19 @@ import "crypto/ecdsa"
 
 type ENSVerifier interface {
 	// CheckBatch verifies that a registered ENS name matches the expected public key
-	CheckBatch(ensDetails []ENSDetails, rpcEndpoint, contractAddress string) (map[string]ENSResponse, error)
+	CheckBatch(ensDetails []ENSDetails, rpcEndpoint, contractAddress string) (map[string]*ENSResponse, error)
 }
 
 type ENSDetails struct {
 	Name            string `json:"name"`
 	PublicKeyString string `json:"publicKey"`
+	Clock           uint64 `json:"clock"`
 }
 
 type ENSResponse struct {
 	Name            string           `json:"name"`
 	Verified        bool             `json:"verified"`
-	VerifiedAt      int64            `json:"verifiedAt"`
+	VerifiedAt      uint64           `json:"verifiedAt"`
 	Error           error            `json:"error"`
 	PublicKey       *ecdsa.PublicKey `json:"-"`
 	PublicKeyString string           `json:"publicKey"`

--- a/protocol/contact.go
+++ b/protocol/contact.go
@@ -38,7 +38,7 @@ type Contact struct {
 	// EnsVerified whether we verified the name of the contact
 	ENSVerified bool `json:"ensVerified"`
 	// EnsVerifiedAt the time we last verified the name
-	ENSVerifiedAt int64 `json:"ensVerifiedAt"`
+	ENSVerifiedAt uint64 `json:"ensVerifiedAt"`
 	// Generated username name of the contact
 	Alias string `json:"alias,omitempty"`
 	// Identicon generated from public key

--- a/protocol/encryption/publisher/publisher.go
+++ b/protocol/encryption/publisher/publisher.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// How often a ticker fires in seconds.
-	tickerInterval = 120
+	tickerInterval = 10
 	// How often we should publish a contact code in seconds.
 	publishInterval = 21600
 	// Cooldown period on acking messages when not targeting our device.

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -309,7 +309,7 @@ func (api *PublicAPI) SetInstallationMetadata(installationID string, data *multi
 }
 
 // VerifyENSNames takes a list of ensdetails and returns whether they match the public key specified
-func (api *PublicAPI) VerifyENSNames(details []enstypes.ENSDetails) (map[string]enstypes.ENSResponse, error) {
+func (api *PublicAPI) VerifyENSNames(details []enstypes.ENSDetails) (map[string]*enstypes.ENSResponse, error) {
 	return api.service.messenger.VerifyENSNames(params.MainnetEthereumNetworkURL, ensContractAddress, details)
 }
 

--- a/vendor/github.com/status-im/status-go/eth-node/bridge/geth/ens/ens.go
+++ b/vendor/github.com/status-im/status-go/eth-node/bridge/geth/ens/ens.go
@@ -30,14 +30,13 @@ func NewVerifier(logger *zap.Logger) *ENSVerifier {
 	return &ENSVerifier{logger: logger}
 }
 
-func (m *ENSVerifier) verifyENSName(ensInfo enstypes.ENSDetails, ethclient *ethclient.Client) enstypes.ENSResponse {
+func (m *ENSVerifier) verifyENSName(ensInfo enstypes.ENSDetails, ethclient *ethclient.Client) *enstypes.ENSResponse {
 	publicKeyStr := ensInfo.PublicKeyString
 	ensName := ensInfo.Name
 	m.logger.Info("Resolving ENS name", zap.String("name", ensName), zap.String("publicKey", publicKeyStr))
-	response := enstypes.ENSResponse{
+	response := &enstypes.ENSResponse{
 		Name:            ensName,
 		PublicKeyString: publicKeyStr,
-		VerifiedAt:      time.Now().Unix(),
 	}
 
 	expectedPubKeyBytes, err := hex.DecodeString(publicKeyStr)
@@ -75,12 +74,12 @@ func (m *ENSVerifier) verifyENSName(ensInfo enstypes.ENSDetails, ethclient *ethc
 }
 
 // CheckBatch verifies that a registered ENS name matches the expected public key
-func (m *ENSVerifier) CheckBatch(ensDetails []enstypes.ENSDetails, rpcEndpoint, contractAddress string) (map[string]enstypes.ENSResponse, error) {
+func (m *ENSVerifier) CheckBatch(ensDetails []enstypes.ENSDetails, rpcEndpoint, contractAddress string) (map[string]*enstypes.ENSResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), contractQueryTimeout)
 	defer cancel()
 
-	ch := make(chan enstypes.ENSResponse)
-	response := make(map[string]enstypes.ENSResponse)
+	ch := make(chan *enstypes.ENSResponse)
+	response := make(map[string]*enstypes.ENSResponse)
 
 	ethclient, err := ethclient.DialContext(ctx, rpcEndpoint)
 	if err != nil {

--- a/vendor/github.com/status-im/status-go/eth-node/types/ens/ens.go
+++ b/vendor/github.com/status-im/status-go/eth-node/types/ens/ens.go
@@ -4,18 +4,19 @@ import "crypto/ecdsa"
 
 type ENSVerifier interface {
 	// CheckBatch verifies that a registered ENS name matches the expected public key
-	CheckBatch(ensDetails []ENSDetails, rpcEndpoint, contractAddress string) (map[string]ENSResponse, error)
+	CheckBatch(ensDetails []ENSDetails, rpcEndpoint, contractAddress string) (map[string]*ENSResponse, error)
 }
 
 type ENSDetails struct {
 	Name            string `json:"name"`
 	PublicKeyString string `json:"publicKey"`
+	Clock           uint64 `json:"clock"`
 }
 
 type ENSResponse struct {
 	Name            string           `json:"name"`
 	Verified        bool             `json:"verified"`
-	VerifiedAt      int64            `json:"verifiedAt"`
+	VerifiedAt      uint64           `json:"verifiedAt"`
 	Error           error            `json:"error"`
 	PublicKey       *ecdsa.PublicKey `json:"-"`
 	PublicKeyString string           `json:"publicKey"`

--- a/vendor/github.com/status-im/status-go/protocol/contact.go
+++ b/vendor/github.com/status-im/status-go/protocol/contact.go
@@ -38,7 +38,7 @@ type Contact struct {
 	// EnsVerified whether we verified the name of the contact
 	ENSVerified bool `json:"ensVerified"`
 	// EnsVerifiedAt the time we last verified the name
-	ENSVerifiedAt int64 `json:"ensVerifiedAt"`
+	ENSVerifiedAt uint64 `json:"ensVerifiedAt"`
 	// Generated username name of the contact
 	Alias string `json:"alias,omitempty"`
 	// Identicon generated from public key

--- a/vendor/github.com/status-im/status-go/protocol/encryption/publisher/publisher.go
+++ b/vendor/github.com/status-im/status-go/protocol/encryption/publisher/publisher.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// How often a ticker fires in seconds.
-	tickerInterval = 120
+	tickerInterval = 10
 	// How often we should publish a contact code in seconds.
 	publishInterval = 21600
 	// Cooldown period on acking messages when not targeting our device.


### PR DESCRIPTION
Because ENS is pulled from messages, we use a logical clock
(clock-value) for ENSVerifiedAt, so that old messages can be handled
appropiately.

status: ready