### PR TITLE
docs: clarify purpose and describe ports

### DIFF
--- a/BOOTNODE.md
+++ b/BOOTNODE.md
@@ -1,5 +1,14 @@
 # Description
 
+A "Bootnode" is a match-maker for all kinds of nodes. For example our [Mailserver](/MAILSERVER.md). It helps a new node find other nodes it can communicate with. It bootstraps connections between them.
+
+A Bootstrap node is a very static thing and should not change its IP. Their addresses are either hardcoded into the node binary or provided via flags or config files on process start.
+
+# Service Ports
+
+* `30301` UDP - Ethereum [Discovery port](https://github.com/ethereum/devp2p/wiki/Discovery-Overview), should __ALWAYS__ be public.
+# Setup methods
+
 This document describes the two alternative ways to start a Status Bootnode:
 
 * [Docker Compose](https://docs.docker.com/compose/) - More self-contained and portable

--- a/MAILSERVER.md
+++ b/MAILSERVER.md
@@ -1,5 +1,16 @@
 # Description
 
+A poorly named "Mailserver" is essentially a Whisper node that stores message history in either a LevelDB or PostgreSQL database.
+
+A Status app user can run their own Mailserver for faster message retrieval or additional security.
+
+# Service Ports
+
+* `30303` TCP - [DevP2P](https://github.com/ethereum/devp2p) wire protocol port. Should __ALWAYS__ be public.
+* `8545` TCP - [JSON RPC](https://github.com/ethereum/wiki/wiki/json-rpc) management port. Should __NEVER__ be public.
+
+# Setup methods
+
 This document describes the two alternative ways to start a Status Mailserver:
 
 * [Docker Compose](https://docs.docker.com/compose/) - More self-contained and portable

--- a/_assets/compose/bootnode/Makefile
+++ b/_assets/compose/bootnode/Makefile
@@ -11,7 +11,7 @@ GID = $(shell id -g)
 
 # Settings
 export LOG_LEVEL       ?= 3
-export LISTEN_PORT     ?= 30303
+export LISTEN_PORT     ?= 30301
 export API_MODULES     ?= eth,net,web3,admin
 export CONTAINER_NAME  ?= status-go-bootnode
 export CONTAINER_IMAGE ?= statusteam/bootnode:latest

--- a/_assets/compose/bootnode/README.md
+++ b/_assets/compose/bootnode/README.md
@@ -26,7 +26,7 @@ To simply start a container run `make`, other commands include:
 All settings are passed through environment variables:
 
 * `PUBLIC_IP` - Your IP visible from the internet and advertised by the Bootnode.
-* `LISTEN_PORT` - Bootnode UDP port, by default it's `30303` but you might want to use `443`.
+* `LISTEN_PORT` - Bootnode UDP port, by default it's `30301` but you might want to use `443`.
 * `RPC_PORT` - Control port making it possible to use the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC).
 * `API_MODULES` - API modules to be made available via the `RPC_PORT`.
 * `CONTAINER_NAME` - Name of the container that will be created.

--- a/_assets/systemd/bootnode/Makefile
+++ b/_assets/systemd/bootnode/Makefile
@@ -24,7 +24,7 @@ export DATA_PATH    ?= /var/tmp/$(SERVICE_NAME)
 export KEY_PATH     ?= $(DATA_PATH)/nodekey
 export ADDR_PATH    ?= $(DATA_PATH)/nodeaddr
 export LOG_LEVEL    ?= 3
-export LISTEN_PORT  ?= 30303
+export LISTEN_PORT  ?= 30301
 # Necessary to make bootnode available publicly
 export PUBLIC_IP    ?= $(shell curl -s https://ipecho.net/plain)
 

--- a/_assets/systemd/bootnode/README.md
+++ b/_assets/systemd/bootnode/README.md
@@ -34,7 +34,7 @@ All settings are passed through environment variables:
 
 * `SERVICE_NAME` - Name of the `systemd` service to be created. (Default: `statusd`)
 * `PUBLIC_IP` - Your IP visible from the internet and advertised by the Bootnode.
-* `LISTEN_PORT` - Bootnode TCP & UDP port, by default it's `30303` but you might want to use `443`.
+* `LISTEN_PORT` - Bootnode TCP & UDP port, by default it's `30301` but you might want to use `443`.
 * `DATA_PATH` - Location of Bootnode storage and keys. (Default: `/var/tmp/status-go-boot`)
 * `KEY_PATH` - Location of Bootnode private key file. (Default: `/var/tmp/status-go-boot/nodekey`)
 * `LOG_LEVEL` - Set level of log messages to show. (Values:`0-9`, Default: `3`)`


### PR DESCRIPTION
Some people were asking about purpose of ports so I'm clarifying it in the docs.

Also make bootnode use `30301` instead of `30303` by default to avoid clash/confusion with Mailserver.