### PR TITLE
Make Messenger.TimeSource public

### DIFF
--- a/protocol/message_builder.go
+++ b/protocol/message_builder.go
@@ -9,7 +9,7 @@ import (
 	"github.com/status-im/status-go/protocol/identity/identicon"
 )
 
-func extendMessageFromChat(message *Message, chat *Chat, key *ecdsa.PublicKey, timesource ClockValueTimesource) error {
+func extendMessageFromChat(message *Message, chat *Chat, key *ecdsa.PublicKey, timesource TimeSource) error {
 	clock, timestamp := chat.NextClockAndTimestamp(timesource)
 
 	message.LocalChatID = chat.ID

--- a/protocol/message_handler.go
+++ b/protocol/message_handler.go
@@ -59,7 +59,7 @@ func (m *MessageHandler) HandleMembershipUpdate(messageState *ReceivedMessageSta
 		if !group.IsMember(contactIDFromPublicKey(&m.identity.PublicKey)) {
 			return errors.New("can't create a new group chat without us being a member")
 		}
-		newChat := createGroupChat(messageState.Timesource)
+		newChat := CreateGroupChat(messageState.Timesource)
 		chat = &newChat
 
 	} else {
@@ -550,7 +550,7 @@ func (m *MessageHandler) HandleDeclineRequestTransaction(messageState *ReceivedM
 	return m.handleCommandMessage(messageState, oldMessage)
 }
 
-func (m *MessageHandler) matchMessage(message *Message, chats map[string]*Chat, timesource ClockValueTimesource) (*Chat, error) {
+func (m *MessageHandler) matchMessage(message *Message, chats map[string]*Chat, timesource TimeSource) (*Chat, error) {
 	if message.SigPubKey == nil {
 		m.logger.Error("public key can't be empty")
 		return nil, errors.New("received a message with empty public key")

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -126,6 +126,8 @@ type config struct {
 
 type Option func(*config) error
 
+// WithSystemMessagesTranslations is required for Group Chats which are currently disabled.
+// nolint: unused
 func WithSystemMessagesTranslations(t map[protobuf.MembershipUpdateEvent_EventType]string) Option {
 	return func(c *config) error {
 		c.systemMessagesTranslations = t
@@ -629,7 +631,7 @@ func (m *Messenger) CreateGroupChatWithMembers(ctx context.Context, name string,
 	var response MessengerResponse
 	logger := m.logger.With(zap.String("site", "CreateGroupChatWithMembers"))
 	logger.Info("Creating group chat", zap.String("name", name), zap.Any("members", members))
-	chat := createGroupChat(m.getTimesource())
+	chat := CreateGroupChat(m.getTimesource())
 	group, err := v1protocol.NewGroupWithCreator(name, m.identity)
 	if err != nil {
 		return nil, err
@@ -1699,8 +1701,8 @@ type ReceivedMessageState struct {
 	ExistingMessagesMap map[string]bool
 	// Response to the client
 	Response *MessengerResponse
-	// Timesource is a timesource for clock values/timestamps
-	Timesource ClockValueTimesource
+	// Timesource is a time source for clock values/timestamps.
+	Timesource TimeSource
 }
 
 func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filter][]*types.Message) (*MessengerResponse, error) {
@@ -2806,6 +2808,10 @@ func (m *Messenger) ValidateTransactions(ctx context.Context, addresses []types.
 	return &response, nil
 }
 
-func (m *Messenger) getTimesource() ClockValueTimesource {
+func (m *Messenger) getTimesource() TimeSource {
 	return m.transport
+}
+
+func (m *Messenger) Timesource() TimeSource {
+	return m.getTimesource()
 }

--- a/protocol/timesource.go
+++ b/protocol/timesource.go
@@ -1,0 +1,12 @@
+package protocol
+
+// TimeSource provides a unified way of getting the current time.
+// The intention is to always use a synchronized time source
+// between all components of the protocol.
+//
+// This is required by Whisper and Waku protocols
+// which rely on a fact that all peers
+// have a synchronized time source.
+type TimeSource interface {
+	GetCurrentTime() uint64
+}

--- a/vendor/github.com/status-im/status-go/protocol/message_builder.go
+++ b/vendor/github.com/status-im/status-go/protocol/message_builder.go
@@ -9,7 +9,7 @@ import (
 	"github.com/status-im/status-go/protocol/identity/identicon"
 )
 
-func extendMessageFromChat(message *Message, chat *Chat, key *ecdsa.PublicKey, timesource ClockValueTimesource) error {
+func extendMessageFromChat(message *Message, chat *Chat, key *ecdsa.PublicKey, timesource TimeSource) error {
 	clock, timestamp := chat.NextClockAndTimestamp(timesource)
 
 	message.LocalChatID = chat.ID

--- a/vendor/github.com/status-im/status-go/protocol/message_handler.go
+++ b/vendor/github.com/status-im/status-go/protocol/message_handler.go
@@ -59,7 +59,7 @@ func (m *MessageHandler) HandleMembershipUpdate(messageState *ReceivedMessageSta
 		if !group.IsMember(contactIDFromPublicKey(&m.identity.PublicKey)) {
 			return errors.New("can't create a new group chat without us being a member")
 		}
-		newChat := createGroupChat(messageState.Timesource)
+		newChat := CreateGroupChat(messageState.Timesource)
 		chat = &newChat
 
 	} else {
@@ -550,7 +550,7 @@ func (m *MessageHandler) HandleDeclineRequestTransaction(messageState *ReceivedM
 	return m.handleCommandMessage(messageState, oldMessage)
 }
 
-func (m *MessageHandler) matchMessage(message *Message, chats map[string]*Chat, timesource ClockValueTimesource) (*Chat, error) {
+func (m *MessageHandler) matchMessage(message *Message, chats map[string]*Chat, timesource TimeSource) (*Chat, error) {
 	if message.SigPubKey == nil {
 		m.logger.Error("public key can't be empty")
 		return nil, errors.New("received a message with empty public key")

--- a/vendor/github.com/status-im/status-go/protocol/messenger.go
+++ b/vendor/github.com/status-im/status-go/protocol/messenger.go
@@ -126,6 +126,8 @@ type config struct {
 
 type Option func(*config) error
 
+// WithSystemMessagesTranslations is required for Group Chats which are currently disabled.
+// nolint: unused
 func WithSystemMessagesTranslations(t map[protobuf.MembershipUpdateEvent_EventType]string) Option {
 	return func(c *config) error {
 		c.systemMessagesTranslations = t
@@ -629,7 +631,7 @@ func (m *Messenger) CreateGroupChatWithMembers(ctx context.Context, name string,
 	var response MessengerResponse
 	logger := m.logger.With(zap.String("site", "CreateGroupChatWithMembers"))
 	logger.Info("Creating group chat", zap.String("name", name), zap.Any("members", members))
-	chat := createGroupChat(m.getTimesource())
+	chat := CreateGroupChat(m.getTimesource())
 	group, err := v1protocol.NewGroupWithCreator(name, m.identity)
 	if err != nil {
 		return nil, err
@@ -1699,8 +1701,8 @@ type ReceivedMessageState struct {
 	ExistingMessagesMap map[string]bool
 	// Response to the client
 	Response *MessengerResponse
-	// Timesource is a timesource for clock values/timestamps
-	Timesource ClockValueTimesource
+	// Timesource is a time source for clock values/timestamps.
+	Timesource TimeSource
 }
 
 func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filter][]*types.Message) (*MessengerResponse, error) {
@@ -2806,6 +2808,10 @@ func (m *Messenger) ValidateTransactions(ctx context.Context, addresses []types.
 	return &response, nil
 }
 
-func (m *Messenger) getTimesource() ClockValueTimesource {
+func (m *Messenger) getTimesource() TimeSource {
 	return m.transport
+}
+
+func (m *Messenger) Timesource() TimeSource {
+	return m.getTimesource()
 }

--- a/vendor/github.com/status-im/status-go/protocol/timesource.go
+++ b/vendor/github.com/status-im/status-go/protocol/timesource.go
@@ -1,0 +1,12 @@
+package protocol
+
+// TimeSource provides a unified way of getting the current time.
+// The intention is to always use a synchronized time source
+// between all components of the protocol.
+//
+// This is required by Whisper and Waku protocols
+// which rely on a fact that all peers
+// have a synchronized time source.
+type TimeSource interface {
+	GetCurrentTime() uint64
+}


### PR DESCRIPTION
`github.com/status-im/status-go/protocol` exports a few `Chat` constructors which require a `TimeSource`, however, there is no way to get `TimeSource` from `Messenger`.

This change exports `Messenger.TimeSource` which provides `TimeSource` used by `Messenger` to send messages.