### PR TITLE
statusd: use eth.prod fleet by default

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -87,7 +87,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	opts := []params.Option{params.WithFleet(params.FleetBeta)}
+	opts := []params.Option{params.WithFleet(params.FleetProd)}
 	if *mailserver {
 		opts = append(opts, params.WithMailserver())
 	}

--- a/params/cluster.go
+++ b/params/cluster.go
@@ -4,6 +4,7 @@ package params
 const (
 	FleetUndefined = ""
 	FleetBeta      = "eth.beta"
+	FleetProd      = "eth.prod"
 	FleetStaging   = "eth.staging"
 )
 


### PR DESCRIPTION
Because `eth.beta` will be phased out after v1 is out.