### PR TITLE
add GetContactByID to Messenger

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1147,8 +1147,18 @@ func (m *Messenger) Contacts() []*Contact {
 	for _, contact := range m.allContacts {
 		contacts = append(contacts, contact)
 	}
-
 	return contacts
+}
+
+// GetContactByID assumes pubKey includes 0x prefix
+func (m *Messenger) GetContactByID(pubKey string) (*Contact, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	contact, ok := m.allContacts[pubKey]
+	if !ok {
+		return nil, errors.New("no contact found")
+	}
+	return contact, nil
 }
 
 // ReSendChatMessage pulls a message from the database and sends it again


### PR DESCRIPTION
This will allow me to more efficiently get ENS names for contacts in our bridge.

Otherwise I'd need to use `Contacts()` and iterate through a list, which is stupid.