### PR TITLE
Prevent starting node without APIModules

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -437,6 +437,9 @@ func (b *GethStatusBackend) startNode(config *params.NodeConfig) (err error) {
 		}
 	}()
 
+	// Update config with some defaults.
+	config.UpdateWithMobileDefaults()
+
 	// Start by validating configuration
 	if err := config.Validate(); err != nil {
 		return err

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -45,21 +45,6 @@ func OpenAccounts(datadir string) string {
 	return string(data)
 }
 
-// GenerateConfig for status node.
-func GenerateConfig(datadir string, networkID int) string {
-	config, err := params.NewNodeConfig(datadir, uint64(networkID))
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-
-	outBytes, err := json.Marshal(config)
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-
-	return string(outBytes)
-}
-
 // ExtractGroupMembershipSignatures extract public keys from tuples of content/signature.
 func ExtractGroupMembershipSignatures(signaturePairsStr string) string {
 	var signaturePairs [][2]string

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -135,11 +135,11 @@ func (n *StatusNode) StartWithOptions(config *params.NodeConfig, options StartOp
 	defer n.mu.Unlock()
 
 	if n.isRunning() {
-		n.log.Debug("cannot start, node already running")
+		n.log.Debug("node is already running")
 		return ErrNodeRunning
 	}
 
-	n.log.Debug("starting with NodeConfig", "ClusterConfig", config.ClusterConfig)
+	n.log.Debug("starting with options", "ClusterConfig", config.ClusterConfig)
 
 	db, err := db.Create(config.DataDir, params.StatusDatabase)
 	if err != nil {
@@ -172,7 +172,7 @@ func (n *StatusNode) startWithDB(config *params.NodeConfig, accs *accounts.Manag
 	}
 	n.config = config
 
-	if err := n.start(services); err != nil {
+	if err := n.startGethNode(services); err != nil {
 		return err
 	}
 
@@ -192,8 +192,8 @@ func (n *StatusNode) createNode(config *params.NodeConfig, accs *accounts.Manage
 	return err
 }
 
-// start starts current StatusNode, will fail if it's already started.
-func (n *StatusNode) start(services []node.ServiceConstructor) error {
+// startGethNode starts current StatusNode, will fail if it's already started.
+func (n *StatusNode) startGethNode(services []node.ServiceConstructor) error {
 	for _, service := range services {
 		if err := n.gethNode.Register(service); err != nil {
 			return err

--- a/node/nimbus_status_node.go
+++ b/node/nimbus_status_node.go
@@ -135,7 +135,7 @@ func (n *NimbusStatusNode) StartWithOptions(config *params.NodeConfig, options N
 	defer n.mu.Unlock()
 
 	if n.isRunning() {
-		n.log.Debug("cannot start, node already running")
+		n.log.Debug("node is already running")
 		return ErrNodeRunning
 	}
 

--- a/params/config.go
+++ b/params/config.go
@@ -338,7 +338,7 @@ type NodeConfig struct {
 	Version string
 
 	// APIModules is a comma-separated list of API modules exposed via *any* (HTTP/WS/IPC) RPC interface.
-	APIModules string
+	APIModules string `validate:"required"`
 
 	// HTTPEnabled specifies whether the http RPC server is to be enabled by default.
 	HTTPEnabled bool
@@ -620,6 +620,19 @@ func NewNodeConfigWithDefaults(dataDir string, networkID uint64, opts ...Option)
 	}
 
 	return c, nil
+}
+
+// UpdateWithMobileDefaults updates config with missing default values
+// tailored for the mobile nodes.
+func (c *NodeConfig) UpdateWithMobileDefaults() {
+	// Empty APIModules will fallback to services' APIs definition.
+	// If any API is defined as public, it will be exposed.
+	// We disallow empty APIModules to avoid confusion
+	// when some APIs suddenly become available for Dapps.
+	// More: https://github.com/status-im/status-go/issues/1870.
+	if c.APIModules == "" {
+		c.APIModules = "net,web3"
+	}
 }
 
 // NewNodeConfigWithDefaultsAndFiles creates new node configuration object

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -487,6 +487,13 @@ func TestNodeConfigValidate(t *testing.T) {
 			},
 			Error: "field Port is required if incentivisation is enabled",
 		},
+		{
+			Name:   "Missing APIModules",
+			Config: `{"NetworkId": 1, "DataDir": "/tmp/data", "KeyStoreDir": "/tmp/data", "APIModules" :""}`,
+			FieldErrors: map[string]string{
+				"APIModules": "required",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This change adds a validation which requires `APIModules` to be not empty. This is a breaking changes but a call to `NodeConfig.UpdateWithMobileDefaults` was added to mitigate it. It sets `APIModules` a safe default value if it's empty.

Closes #1870 