### PR TITLE
do not return private key in the result for VerifyAccountPassword

### DIFF
--- a/account/accounts_test.go
+++ b/account/accounts_test.go
@@ -78,6 +78,7 @@ func TestVerifyAccountPassword(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
+		accManager.ReadKey = true
 		accountKey, err := accManager.VerifyAccountPassword(testCase.keyPath, testCase.address, testCase.password)
 		if !reflect.DeepEqual(err, testCase.expectedError) {
 			require.FailNow(t, fmt.Sprintf("unexpected error: expected \n'%v', got \n'%v'", testCase.expectedError, err))


### PR DESCRIPTION
Add readKey parameter to manager to return key in VerifyAccountPassword iff explicitly set by the caller. Default behaviour is only verifying the passphrase.

Closes #1882
