### PR TITLE
set archived_envelopes_total on start based on DB count

### DIFF
--- a/mailserver/cleaner_test.go
+++ b/mailserver/cleaner_test.go
@@ -93,7 +93,10 @@ func setupTestServer(t *testing.T) *WhisperMailServer {
 	db, _ := leveldb.Open(storage.NewMemStorage(), nil)
 
 	s.ms = &mailServer{
-		db:      &LevelDB{ldb: db},
+		db: &LevelDB{
+			ldb:  db,
+			done: make(chan struct{}),
+		},
 		adapter: &whisperAdapter{},
 	}
 	s.minRequestPoW = powRequirement

--- a/mailserver/mailserver_db.go
+++ b/mailserver/mailserver_db.go
@@ -6,6 +6,9 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 )
 
+// every this many seconds check real envelopes count
+const envelopeCountCheckInterval = 60
+
 // DB is an interface to abstract interactions with the db so that the mailserver
 // is agnostic to the underlying technology used
 type DB interface {

--- a/mailserver/metrics.go
+++ b/mailserver/metrics.go
@@ -43,23 +43,23 @@ var (
 		Help:    "Size of processed Whisper envelopes in bytes.",
 		Buckets: prom.ExponentialBuckets(1024, 4, 10),
 	})
-	archivedErrorsCounter = prom.NewCounter(prom.CounterOpts{
-		Name: "mailserver_archived_envelopes_falures_total",
-		Help: "Number of failures storing a Whisper envelope.",
-	})
-	archivedEnvelopesCounter = prom.NewCounter(prom.CounterOpts{
-		Name: "mailserver_archived_envelopes_total",
-		Help: "Number of envelopes saved.",
-	})
-	archivedEnvelopeSizeMeter = prom.NewHistogram(prom.HistogramOpts{
-		Name:    "mailserver_archived_envelope_size_bytes",
-		Help:    "Size of envelopes saved.",
-		Buckets: prom.ExponentialBuckets(1024, 2, 11),
-	})
 	mailDeliveryDuration = prom.NewHistogram(prom.HistogramOpts{
 		Name: "mailserver_delivery_duration_seconds",
 		Help: "Time it takes to deliver messages to a Whisper peer.",
 	})
+	archivedErrorsCounter = prom.NewCounterVec(prom.CounterOpts{
+		Name: "mailserver_archived_envelopes_falures_total",
+		Help: "Number of failures storing a Whisper envelope.",
+	}, []string{"db"})
+	archivedEnvelopesGauge = prom.NewGaugeVec(prom.GaugeOpts{
+		Name: "mailserver_archived_envelopes_total",
+		Help: "Number of envelopes saved in the DB.",
+	}, []string{"db"})
+	archivedEnvelopeSizeMeter = prom.NewHistogramVec(prom.HistogramOpts{
+		Name:    "mailserver_archived_envelope_size_bytes",
+		Help:    "Size of envelopes saved.",
+		Buckets: prom.ExponentialBuckets(1024, 2, 11),
+	}, []string{"db"})
 )
 
 func init() {
@@ -72,8 +72,8 @@ func init() {
 	prom.MustRegister(syncAttemptsCounter)
 	prom.MustRegister(sendRawEnvelopeDuration)
 	prom.MustRegister(sentEnvelopeBatchSizeMeter)
-	prom.MustRegister(archivedErrorsCounter)
-	prom.MustRegister(archivedEnvelopesCounter)
-	prom.MustRegister(archivedEnvelopeSizeMeter)
 	prom.MustRegister(mailDeliveryDuration)
+	prom.MustRegister(archivedErrorsCounter)
+	prom.MustRegister(archivedEnvelopesGauge)
+	prom.MustRegister(archivedEnvelopeSizeMeter)
 }


### PR DESCRIPTION
This change adds an `envelopesCount()` method that will be called in constructors for both DBs in order to set the initial value of `archivedEnvelopesGauge` to that of the count. Those are `NewLevelDB()` and `NewPostgresDB()` respectively.

It also changes the archive metrics to be labeled with `db` set to either DB name(Postgres) or the path(LevelDB). This way we can distinguish between `waku` and `whisper` metrics.

Resolves: #1923