### PR TITLE
Waku handshake RLP key variable initialisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ Session.vim
 /.idea/
 /.vscode/
 /cmd/*/.ethereum/
+*.iml
 
 # created for running container
 _assets/compose/bootnode/keys

--- a/waku/handshake.go
+++ b/waku/handshake.go
@@ -171,6 +171,9 @@ loop:
 		}
 
 		key, keyType, err := o.decodeKey(s)
+		if err != nil {
+			return fmt.Errorf("key decode failure: %v", err)
+		}
 		o.setKeyType(keyType)
 
 		// Skip processing if a key does not exist.

--- a/waku/handshake.go
+++ b/waku/handshake.go
@@ -11,8 +11,10 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
+// statusOptionKey is a current type used in statusOptions as a key.
 type statusOptionKey uint
 
+// statusOptionKeyType is a type of a statusOptions key used for a particular instance of statusOptions struct.
 type statusOptionKeyType uint
 
 type statusOptionKeyToType struct {
@@ -22,7 +24,7 @@ type statusOptionKeyToType struct {
 }
 
 const (
-	sOKTS statusOptionKeyType = iota // Status Option Key Type String
+	sOKTS statusOptionKeyType = iota + 1 // Status Option Key Type String
 	sOKTU                            // Status Option Key Type Uint
 )
 
@@ -220,7 +222,7 @@ func (o *statusOptions) addKeyToType(ktt *statusOptionKeyToType) {
 	o.keyTypeMapping.keyFieldIdx[ktt.Key] = ktt
 }
 
-func (k statusOptionKeyToType) decodeStream(s *rlp.Stream) error {
+func (k *statusOptionKeyToType) decodeStream(s *rlp.Stream) error {
 	var key statusOptionKey
 
 	// If uint can be decoded return it

--- a/waku/handshake.go
+++ b/waku/handshake.go
@@ -146,7 +146,10 @@ func (o *statusOptions) DecodeRLP(s *rlp.Stream) error {
 		return fmt.Errorf("expected an outer list: %v", err)
 	}
 
-	o.parseStatusOptionKeys()
+	err = o.parseStatusOptionKeys()
+	if err != nil {
+		return err
+	}
 
 	v := reflect.ValueOf(o)
 

--- a/waku/handshake_test.go
+++ b/waku/handshake_test.go
@@ -1,8 +1,6 @@
 package waku
 
 import (
-	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"math"
 	"testing"
 
@@ -27,7 +25,6 @@ func TestEncodeDecodeRLP(t *testing.T) {
 			TopicLimits:  1,
 		},
 		TopicInterest: []TopicType{{0x01}, {0x02}, {0x03}, {0x04}},
-		keyType:       sOKTU,
 	}
 	data, err := rlp.EncodeToBytes(opts)
 	require.NoError(t, err)
@@ -38,87 +35,18 @@ func TestEncodeDecodeRLP(t *testing.T) {
 	require.EqualValues(t, opts, optsDecoded)
 }
 
-// TODO remove once key type issue is resolved.
-func TestKeyTypes(t *testing.T) {
-	uKeys := []uint{
-		0, 1, 2, 49, 50, 256, 257, 1000, 6000,
-	}
-
-	for i, uKey := range uKeys {
-		fmt.Printf("test %d, for key '%d'", i+1, uKey)
-
-		encodeable := []interface{}{
-			[]interface{}{uKey, true},
-		}
-		data, err := rlp.EncodeToBytes(encodeable)
-		spew.Dump(data, err)
-
-		var optsDecoded statusOptions
-		err = rlp.DecodeBytes(data, &optsDecoded)
-		spew.Dump(optsDecoded, err)
-
-		println("\n----------------\n")
-	}
-}
-
 func TestBackwardCompatibility(t *testing.T) {
+	alist := []interface{}{
+		[]interface{}{"0", math.Float64bits(2.05)},
+	}
+	data, err := rlp.EncodeToBytes(alist)
+	require.NoError(t, err)
+
+	var optsDecoded statusOptions
+	err = rlp.DecodeBytes(data, &optsDecoded)
+	require.NoError(t, err)
 	pow := math.Float64bits(2.05)
-	lne := true
-
-	cs := []struct {
-		Input []interface{}
-		Expected statusOptions
-	}{
-		{
-			[]interface{}{
-				[]interface{}{"0", pow},
-			},
-			statusOptions{PoWRequirement: &pow, keyType: sOKTS},
-		},
-		{
-			[]interface{}{
-				[]interface{}{"2", true},
-			},
-			statusOptions{LightNodeEnabled: &lne, keyType: sOKTS},
-		},
-		{
-			[]interface{}{
-				[]interface{}{uint(2), true},
-			},
-			statusOptions{LightNodeEnabled: &lne, keyType: sOKTU},
-		},
-		{
-			[]interface{}{
-				[]interface{}{uint(0), pow},
-			},
-			statusOptions{PoWRequirement: &pow, keyType: sOKTU},
-		},
-		{
-			[]interface{}{
-				[]interface{}{"1000", true},
-			},
-			statusOptions{keyType: sOKTS},
-		},
-		{
-			[]interface{}{
-				[]interface{}{uint(1000), true},
-			},
-			statusOptions{keyType: sOKTU},
-		},
-	}
-
-	for i, c := range cs {
-		failMsg := fmt.Sprintf("test '%d'", i+1)
-
-		data, err := rlp.EncodeToBytes(c.Input)
-		require.NoError(t, err, failMsg)
-
-		var optsDecoded statusOptions
-		err = rlp.DecodeBytes(data, &optsDecoded)
-		require.NoError(t, err, failMsg)
-
-		require.EqualValues(t, c.Expected, optsDecoded, failMsg)
-	}
+	require.EqualValues(t, statusOptions{PoWRequirement: &pow}, optsDecoded)
 }
 
 func TestForwardCompatibility(t *testing.T) {
@@ -138,20 +66,20 @@ func TestForwardCompatibility(t *testing.T) {
 
 func TestInitRLPKeyFields(t *testing.T) {
 	ifk := map[int]statusOptionKey{
-		0: 0,
-		1: 1,
-		2: 2,
-		3: 3,
-		4: 4,
-		5: 5,
+		0: "0",
+		1: "1",
+		2: "2",
+		3: "3",
+		4: "4",
+		5: "5",
 	}
 	kfi := map[statusOptionKey]int{
-		0: 0,
-		1: 1,
-		2: 2,
-		3: 3,
-		4: 4,
-		5: 5,
+		"0": 0,
+		"1": 1,
+		"2": 2,
+		"3": 3,
+		"4": 4,
+		"5": 5,
 	}
 
 	// Test that the kfi length matches the inited global keyFieldIdx length

--- a/waku/handshake_test.go
+++ b/waku/handshake_test.go
@@ -2,9 +2,6 @@ package waku
 
 import (
 	"math"
-	"reflect"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -67,60 +64,47 @@ func TestForwardCompatibility(t *testing.T) {
 	require.EqualValues(t, statusOptions{PoWRequirement: &pow}, optsDecoded)
 }
 
-func TestStatusOptionKeys(t *testing.T) {
-	o := statusOptions{}
-
-	kfi := make(map[statusOptionKey]int)
-	ifk := make(map[int]statusOptionKey)
-
-	v := reflect.ValueOf(o)
-
-	for i := 0; i < v.NumField(); i++ {
-		// skip unexported fields
-		if !v.Field(i).CanInterface() {
-			continue
-		}
-		rlpTag := v.Type().Field(i).Tag.Get("rlp")
-		// skip fields without rlp field tag
-		if rlpTag == "" {
-			continue
-		}
-
-		keys := strings.Split(rlpTag, "=")
-		require.Equal(t, 2, len(keys))
-
-		// parse keys[1] as an int
-		key, err := strconv.ParseUint(keys[1], 10, 64)
-		require.NoError(t, err)
-
-		// typecast key to be of statusOptionKey type
-		kfi[statusOptionKey(key)] = i
-		ifk[i] = statusOptionKey(key)
+func TestInitRLPKeyFields(t *testing.T) {
+	ifk := map[int]statusOptionKey{
+		0: 0,
+		1: 1,
+		2: 2,
+		3: 3,
+		4: 4,
+		5: 5,
+	}
+	kfi := map[statusOptionKey]int{
+		0: 0,
+		1: 1,
+		2: 2,
+		3: 3,
+		4: 4,
+		5: 5,
 	}
 
-	// Test that the statusOptions' derived kfi length matches the global keyFieldIdx length
-	require.Equal(t, len(keyFieldIdx), len(kfi))
+	// Test that the kfi length matches the inited global keyFieldIdx length
+	require.Equal(t, len(kfi), len(keyFieldIdx))
 
-	// Test that each index of the statusOptions' derived kfi values matches the global keyFieldIdx of the same index
+	// Test that each index of the kfi values matches the inited global keyFieldIdx of the same index
 	for k, v := range kfi {
-		require.Exactly(t, keyFieldIdx[k], v)
+		require.Exactly(t, v, keyFieldIdx[k])
 	}
 
-	// Test that each index of the global keyFieldIdx values matches statusOptions' derived kfi values of the same index
+	// Test that each index of the inited global keyFieldIdx values matches kfi values of the same index
 	for k, v := range keyFieldIdx {
-		require.Exactly(t, kfi[k], v)
+		require.Exactly(t, v, kfi[k])
 	}
 
-	// Test that the statusOptions' derived ifk length matches the global idxFieldKey length
-	require.Equal(t, len(idxFieldKey), len(ifk))
+	// Test that the ifk length matches the inited global idxFieldKey length
+	require.Equal(t, len(ifk), len(idxFieldKey))
 
-	// Test that each index of the statusOptions' derived ifk values matches the global idxFieldKey of the same index
+	// Test that each index of the ifk values matches the inited global idxFieldKey of the same index
 	for k, v := range ifk {
-		require.Exactly(t, idxFieldKey[k], v)
+		require.Exactly(t, v, idxFieldKey[k])
 	}
 
-	// Test that each index of the global idxFieldKey values matches statusOptions' derived ifk values of the same index
+	// Test that each index of the inited global idxFieldKey values matches ifk values of the same index
 	for k, v := range idxFieldKey {
-		require.Exactly(t, ifk[k], v)
+		require.Exactly(t, v, ifk[k])
 	}
 }

--- a/waku/handshake_test.go
+++ b/waku/handshake_test.go
@@ -25,6 +25,7 @@ func TestEncodeDecodeRLP(t *testing.T) {
 			TopicLimits:  1,
 		},
 		TopicInterest: []TopicType{{0x01}, {0x02}, {0x03}, {0x04}},
+		keyType:       sOKTU,
 	}
 	data, err := rlp.EncodeToBytes(opts)
 	require.NoError(t, err)

--- a/waku/handshake_test.go
+++ b/waku/handshake_test.go
@@ -2,10 +2,10 @@ package waku
 
 import (
 	"math"
-	"testing"
 	"reflect"
 	"strconv"
 	"strings"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 
@@ -103,12 +103,12 @@ func TestStatusOptionKeys(t *testing.T) {
 
 	// Test that each index of the statusOptions' derived kfi values matches the global keyFieldIdx of the same index
 	for k, v := range kfi {
-		require.Equal(t, keyFieldIdx[k], v)
+		require.Exactly(t, keyFieldIdx[k], v)
 	}
 
 	// Test that each index of the global keyFieldIdx values matches statusOptions' derived kfi values of the same index
 	for k, v := range keyFieldIdx {
-		require.Equal(t, kfi[k], v)
+		require.Exactly(t, kfi[k], v)
 	}
 
 	// Test that the statusOptions' derived ifk length matches the global idxFieldKey length
@@ -116,11 +116,11 @@ func TestStatusOptionKeys(t *testing.T) {
 
 	// Test that each index of the statusOptions' derived ifk values matches the global idxFieldKey of the same index
 	for k, v := range ifk {
-		require.Equal(t, idxFieldKey[k], v)
+		require.Exactly(t, idxFieldKey[k], v)
 	}
 
 	// Test that each index of the global idxFieldKey values matches statusOptions' derived ifk values of the same index
 	for k, v := range idxFieldKey {
-		require.Equal(t, ifk[k], v)
+		require.Exactly(t, ifk[k], v)
 	}
 }

--- a/waku/waku.go
+++ b/waku/waku.go
@@ -108,6 +108,14 @@ type Waku struct {
 	logger *zap.Logger
 }
 
+// init initialises the waku package
+func init() {
+	err := initRLPKeyFields()
+	if err != nil {
+		panic(err)
+	}
+}
+
 // New creates a Waku client ready to communicate through the Ethereum P2P network.
 func New(cfg *Config, logger *zap.Logger) *Waku {
 	if cfg == nil {

--- a/waku/waku.go
+++ b/waku/waku.go
@@ -110,10 +110,7 @@ type Waku struct {
 
 // init initialises the waku package
 func init() {
-	err := initRLPKeyFields()
-	if err != nil {
-		panic(err)
-	}
+	initRLPKeyFields()
 }
 
 // New creates a Waku client ready to communicate through the Ethereum P2P network.


### PR DESCRIPTION
## Why make the change?

This PR is the first attempt at resolving the issue reported here https://github.com/status-im/status-go/issues/1929, however this PR has been superseded by https://github.com/status-im/status-go/pull/1938.

## What's changed?

This PR is now is essentially a refactor of variable initialisation and the declaration of a new type. 

### Refactor

Variable declaration

- `waku.idxFieldKey map[int]statusOptionKey{}`
- `waku.keyFieldIdx map[statusOptionKey]int{}`

### Added

Type
- `waku.statusOptionKey`

Functions
- `waku.initRLPKeyFields()`
- `waku.init()`

Tests
- `TestInitRLPKeyFields()`

This test explicitly checks that the variable initialisation matches the expected parse result of the `statusOptions` struct.