### PR TITLE
expose the mailserver metrics port by default

### DIFF
--- a/MAILSERVER.md
+++ b/MAILSERVER.md
@@ -6,8 +6,9 @@ A Status app user can run their own Mailserver for faster message retrieval or a
 
 # Service Ports
 
-* `30303` TCP - [DevP2P](https://github.com/ethereum/devp2p) wire protocol port. Should __ALWAYS__ be public.
-* `8545` TCP - [JSON RPC](https://github.com/ethereum/wiki/wiki/json-rpc) management port. Should __NEVER__ be public.
+* `30303` TCP/UDP - [DevP2P](https://github.com/ethereum/devp2p) wire protocol port. Must __ALWAYS__ be public.
+* `8545` TCP - [JSON RPC](https://github.com/ethereum/wiki/wiki/json-rpc) management port. Must __NEVER__ be public.
+* `9090` TCP - [Prometheus](https://prometheus.io/docs/concepts/data_model/) metrics port. Should not be public.
 
 # Setup methods
 
@@ -36,3 +37,28 @@ This will generate the necessary config, define and then start a user service.
 Use `sudo` if you want it to be a system service.
 
 For more details read the [README](_assets/systemd/mailserver/README.md).
+
+# Service Healthcheck
+
+There's two simple ways to verify your Mailserver is up and running.
+
+## Query Metrics
+
+By making an HTTP request to the metrics port(`9090` by default) you can check if you Mailserver is receiving envelopes:
+```sh
+ $ curl -s localhost:9090/metrics | grep '^whisper_envelopes_received_total'
+whisper_envelopes_received_total 123
+```
+
+## JSON RPC Calls
+
+The JSON RPC port (`8545` by default) allows you to manage your node.
+You can list connected peers by doing:
+```sh
+ $ export DATA='{"jsonrpc":"2.0","method":"admin_peers", "params": [], "id":1}'
+ $ curl -s -H 'content-type: application/json' -d $DATA localhost:8545 \
+     | jq -r '.result[].network.remoteAddress'
+34.68.132.118:30305
+134.209.136.123:30305
+178.128.141.249:443
+```

--- a/_assets/compose/mailserver/Makefile
+++ b/_assets/compose/mailserver/Makefile
@@ -9,6 +9,7 @@ BLD := $(shell tput bold)
 # Settings
 export LOG_LEVEL      ?= INFO
 export LISTEN_PORT    ?= 30303
+export METRICS_PORT   ?= 9090
 export RPC_PORT       ?= 8545
 export API_MODULES    ?= eth,net,web3,admin,mailserver
 export CONTAINER_NAME ?= status-go-mailserver

--- a/_assets/compose/mailserver/README.md
+++ b/_assets/compose/mailserver/README.md
@@ -28,6 +28,7 @@ All settings are passed through environment variables:
 
 * `PUBLIC_IP` - Your IP visible from the internet and advertised by the Mailserver.
 * `LISTEN_PORT` - Mailserver TCP & UDP port, by default it's `30303` but you might want to use `443`.
+* `METRICS_PORT` - Port exposing metrics in [Prometheus](https://prometheus.io/docs/concepts/data_model/) format
 * `RPC_PORT` - Control port making it possible to use the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC).
 * `API_MODULES` - API modules to be made available via the `RPC_PORT`.
 * `DATA_PATH` - Location of Mailserver storage and keys. (Default: `/var/tmp/status-go-mail`)

--- a/_assets/compose/mailserver/docker-compose.yml
+++ b/_assets/compose/mailserver/docker-compose.yml
@@ -5,11 +5,18 @@ services:
     image: statusteam/status-go:latest
     entrypoint: statusd
     restart: always
-    command: -log=${LOG_LEVEL} -log-without-color -c=/config.json -dir=/data
+    command: |
+        -log=${LOG_LEVEL}
+        -log-without-color
+        -metrics
+        -metrics-port=${METRICS_PORT}
+        -c=/config.json
+        -dir=/data
     ports:
       - '127.0.0.1:${RPC_PORT}:${RPC_PORT}'
-      - '0.0.0.0:${LISTEN_PORT}:30303/tcp'
-      - '0.0.0.0:${LISTEN_PORT}:30303/udp'
+      - '127.0.0.1:${METRICS_PORT}:${METRICS_PORT}'
+      - '0.0.0.0:${LISTEN_PORT}:${LISTEN_PORT}/tcp'
+      - '0.0.0.0:${LISTEN_PORT}:${LISTEN_PORT}/udp'
     volumes:
       - '${DATA_PATH}/config.json:/config.json'
       - '${DATA_PATH}:/data'

--- a/_assets/scripts/gen_config.sh
+++ b/_assets/scripts/gen_config.sh
@@ -4,6 +4,7 @@ GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
 
 # Settings & defaults
 RPC_PORT="${RPC_PORT:-8545}"
+LISTEN_PORT="${LSTEN_PORT:-30303}"
 API_MODULES="${API_MODULES:-eth,net,web3,admin,mailserver}"
 FLEET_NAME="${FLEET_NAME:-eth.prod}"
 REGISTER_TOPIC="${REGISTER_TOPIC:-whispermail}"
@@ -27,6 +28,7 @@ export PUBLIC_IP=$(curl -s https://ipecho.net/plain)
 # Assemble the filter for changing the config JSON
 JQ_FILTER_ARRAY=(
   ".AdvertiseAddr = \"${PUBLIC_IP}\""
+  ".ListenAddr = \"0.0.0.0:${LISTEN_PORT}\""
   ".HTTPEnabled = true"
   ".HTTPHost = \"0.0.0.0\""
   ".HTTPPort= ${RPC_PORT}"

--- a/_assets/scripts/gen_config.sh
+++ b/_assets/scripts/gen_config.sh
@@ -36,6 +36,11 @@ JQ_FILTER_ARRAY=(
   ".WhisperConfig.EnableMailServer = true"
   ".WhisperConfig.LightClient = false"
   ".WhisperConfig.MailServerPassword = \"${MAIL_PASSWORD}\""
+  ".WakuConfig.Enabled = true"
+  ".WakuConfig.EnableMailServer = true"
+  ".WakuConfig.DataDir = \"${DATA_PATH}/waku\""
+  ".WakuConfig.MailServerPassword = \"${MAIL_PASSWORD}\""
+
 )
 
 JQ_FILTER=$(printf " | %s" "${JQ_FILTER_ARRAY[@]}")

--- a/_assets/systemd/mailserver/Makefile
+++ b/_assets/systemd/mailserver/Makefile
@@ -24,6 +24,8 @@ export SERVICE_PATH ?= $(SERVICE_DIR)/$(SERVICE_NAME).service
 export DATA_PATH    ?= /var/tmp/$(SERVICE_NAME)
 export LOG_LEVEL    ?= INFO
 export LISTEN_PORT  ?= 30303
+export METRICS_PORT ?= 9090
+export RPC_PORT     ?= 8545
 # Necessary to make mailserver available publicly
 export PUBLIC_IP    ?= $(shell curl -s https://ipecho.net/plain)
 

--- a/_assets/systemd/mailserver/README.md
+++ b/_assets/systemd/mailserver/README.md
@@ -36,6 +36,7 @@ All settings are passed through environment variables:
 * `SERVICE_NAME` - Name of the `systemd` service to be created. (Default: `statusd`)
 * `PUBLIC_IP` - Your IP visible from the internet and advertised by the Mailserver.
 * `LISTEN_PORT` - Mailserver TCP & UDP port, by default it's `30303` but you might want to use `443`.
+* `METRICS_PORT` - Port exposing metrics in [Prometheus](https://prometheus.io/docs/concepts/data_model/) format
 * `RPC_PORT` - Control port making it possible to use the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC).
 * `API_MODULES` - API modules to be made available via the `RPC_PORT`.
 * `DATA_PATH` - Location of Mailserver storage and keys. (Default: `/var/tmp/status-go-mail`)

--- a/_assets/systemd/mailserver/service.template
+++ b/_assets/systemd/mailserver/service.template
@@ -8,10 +8,11 @@ WatchdogSec=60s
 WorkingDirectory=${DATA_PATH}
 ExecStart=${GIT_ROOT}/build/bin/statusd \
     -log-without-color \
-    -log "${LOG_LEVEL}" \
-    -dir "${DATA_PATH}" \
-    -c "${DATA_PATH}/config.json" \
-    -metrics
+    -log="${LOG_LEVEL}" \
+    -metrics \
+    -metrics-port=${METRICS_PORT} \
+    -c="${DATA_PATH}/config.json" \
+    -dir="${DATA_PATH}"
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Changes:
* Enables Waku protocol by default in `_assets/scripts/gen_config.sh`
* Opens the `9090` port by default to expose Prometheus metrics.
* Expands the `MAILSERVER.md` file to include ways to check if your node is up.