### PR TITLE
Upgrade to waku/1

### DIFF
--- a/waku/api.go
+++ b/waku/api.go
@@ -63,7 +63,7 @@ func NewPublicWakuAPI(w *Waku) *PublicWakuAPI {
 
 // Version returns the Waku sub-protocol version.
 func (api *PublicWakuAPI) Version(ctx context.Context) string {
-	return ProtocolVersionStr
+	return ProtocolVersion1Str
 }
 
 // Info contains diagnostic information.

--- a/waku/doc.go
+++ b/waku/doc.go
@@ -30,9 +30,11 @@ import (
 
 // Waku protocol parameters
 const (
-	ProtocolVersion    = uint64(0) // Protocol version number
-	ProtocolVersionStr = "0"       // The same, as a string
-	ProtocolName       = "waku"    // Nickname of the protocol
+	ProtocolVersion1    = uint64(1) // Protocol version number
+	ProtocolVersion1Str = "1"       // The same, as a string
+	ProtocolVersion0    = uint64(0) // Protocol version number for legacy version
+	ProtocolVersion0Str = "0"       // The same, as a string
+	ProtocolName        = "waku"    // Nickname of the protocol
 
 	// Waku protocol message codes, according to https://github.com/vacp2p/specs/blob/master/waku.md
 	statusCode             = 0   // used in the handshake
@@ -74,10 +76,11 @@ const (
 
 	MaxLimitInSyncMailRequest = 1000
 
+	MaxLimitInMessagesRequest = 1000
+)
+const (
 	EnvelopeTimeNotSynced uint = iota + 1
 	EnvelopeOtherError
-
-	MaxLimitInMessagesRequest = 1000
 )
 
 // MailServer represents a mail server, capable of

--- a/waku/handshake.go
+++ b/waku/handshake.go
@@ -2,11 +2,8 @@ package waku
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"math"
-	"reflect"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/rlp"
 )
@@ -20,12 +17,12 @@ var defaultMinPoW = math.Float64bits(0.001)
 // In the case of RLP, options should be serialized to an array of tuples
 // where the first item is a field name and the second is a RLP-serialized value.
 type statusOptions struct {
-	PoWRequirement       *uint64     `rlp:"key=0"` // RLP does not support float64 natively
-	BloomFilter          []byte      `rlp:"key=1"`
-	LightNodeEnabled     *bool       `rlp:"key=2"`
-	ConfirmationsEnabled *bool       `rlp:"key=3"`
-	RateLimits           *RateLimits `rlp:"key=4"`
-	TopicInterest        []TopicType `rlp:"key=5"`
+	PoWRequirement       *uint64
+	BloomFilter          []byte
+	LightNodeEnabled     *bool
+	ConfirmationsEnabled *bool
+	RateLimits           *RateLimits
+	TopicInterest        []TopicType
 }
 
 // WithDefaults adds the default values for a given peer.
@@ -57,27 +54,13 @@ func (o statusOptions) WithDefaults() statusOptions {
 	return o
 }
 
-var idxFieldKey = make(map[int]string)
-var keyFieldIdx = func() map[string]int {
-	result := make(map[string]int)
-	opts := statusOptions{}
-	v := reflect.ValueOf(opts)
-	for i := 0; i < v.NumField(); i++ {
-		// skip unexported fields
-		if !v.Field(i).CanInterface() {
-			continue
-		}
-		rlpTag := v.Type().Field(i).Tag.Get("rlp")
-		// skip fields without rlp field tag
-		if rlpTag == "" {
-			continue
-		}
-		key := strings.Split(rlpTag, "=")[1]
-		result[key] = i
-		idxFieldKey[i] = key
-	}
-	return result
-}()
+func (o statusOptions) EncodeRLP(w io.Writer) error {
+	return errors.New("not implemented")
+}
+
+func (o *statusOptions) DecodeRLP(s *rlp.Stream) error {
+	return errors.New("not implemented")
+}
 
 func (o statusOptions) PoWRequirementF() *float64 {
 	if o.PoWRequirement == nil {
@@ -87,80 +70,9 @@ func (o statusOptions) PoWRequirementF() *float64 {
 	return &result
 }
 
-func (o *statusOptions) SetPoWRequirementFromF(val float64) {
-	requirement := math.Float64bits(val)
-	o.PoWRequirement = &requirement
-}
-
-func (o statusOptions) EncodeRLP(w io.Writer) error {
-	v := reflect.ValueOf(o)
-	var optionsList []interface{}
-	for i := 0; i < v.NumField(); i++ {
-		field := v.Field(i)
-		if !field.IsNil() {
-			value := field.Interface()
-			key, ok := idxFieldKey[i]
-			if !ok {
-				continue
-			}
-			if value != nil {
-				optionsList = append(optionsList, []interface{}{key, value})
-			}
-		}
-	}
-	return rlp.Encode(w, optionsList)
-}
-
-func (o *statusOptions) DecodeRLP(s *rlp.Stream) error {
-	_, err := s.List()
-	if err != nil {
-		return fmt.Errorf("expected an outer list: %v", err)
-	}
-
-	v := reflect.ValueOf(o)
-
-loop:
-	for {
-		_, err := s.List()
-		switch err {
-		case nil:
-			// continue to decode a key
-		case rlp.EOL:
-			break loop
-		default:
-			return fmt.Errorf("expected an inner list: %v", err)
-		}
-		var key string
-		if err := s.Decode(&key); err != nil {
-			return fmt.Errorf("invalid key: %v", err)
-		}
-		// Skip processing if a key does not exist.
-		// It might happen when there is a new peer
-		// which supports a new option with
-		// a higher index.
-		idx, ok := keyFieldIdx[key]
-		if !ok {
-			// Read the rest of the list items and dump them.
-			_, err := s.Raw()
-			if err != nil {
-				return fmt.Errorf("failed to read the value of key %s: %v", key, err)
-			}
-			continue
-		}
-		if err := s.Decode(v.Elem().Field(idx).Addr().Interface()); err != nil {
-			return fmt.Errorf("failed to decode an option %s: %v", key, err)
-		}
-		if err := s.ListEnd(); err != nil {
-			return err
-		}
-	}
-
-	return s.ListEnd()
-}
-
 func (o statusOptions) Validate() error {
-	if len(o.TopicInterest) > 1000 {
-		return errors.New("topic interest is limited by 1000 items")
+	if len(o.TopicInterest) > 10000 {
+		return errors.New("topic interest is limited by 10000 items")
 	}
 	return nil
 }

--- a/waku/handshake_test.go
+++ b/waku/handshake_test.go
@@ -14,7 +14,7 @@ func TestEncodeDecodeRLP(t *testing.T) {
 	lightNodeEnabled := true
 	confirmationsEnabled := true
 
-	opts := statusOptions{
+	opts := statusOptionsV1{
 		PoWRequirement:       &pow,
 		BloomFilter:          TopicToBloom(TopicType{0xaa, 0xbb, 0xcc, 0xdd}),
 		LightNodeEnabled:     &lightNodeEnabled,
@@ -29,7 +29,7 @@ func TestEncodeDecodeRLP(t *testing.T) {
 	data, err := rlp.EncodeToBytes(opts)
 	require.NoError(t, err)
 
-	var optsDecoded statusOptions
+	var optsDecoded statusOptionsV1
 	err = rlp.DecodeBytes(data, &optsDecoded)
 	require.NoError(t, err)
 	require.EqualValues(t, opts, optsDecoded)
@@ -42,11 +42,11 @@ func TestBackwardCompatibility(t *testing.T) {
 	data, err := rlp.EncodeToBytes(alist)
 	require.NoError(t, err)
 
-	var optsDecoded statusOptions
+	var optsDecoded statusOptionsV1
 	err = rlp.DecodeBytes(data, &optsDecoded)
 	require.NoError(t, err)
 	pow := math.Float64bits(2.05)
-	require.EqualValues(t, statusOptions{PoWRequirement: &pow}, optsDecoded)
+	require.EqualValues(t, statusOptionsV1{PoWRequirement: &pow}, optsDecoded)
 }
 
 func TestForwardCompatibility(t *testing.T) {
@@ -58,8 +58,8 @@ func TestForwardCompatibility(t *testing.T) {
 	data, err := rlp.EncodeToBytes(alist)
 	require.NoError(t, err)
 
-	var optsDecoded statusOptions
+	var optsDecoded statusOptionsV1
 	err = rlp.DecodeBytes(data, &optsDecoded)
 	require.NoError(t, err)
-	require.EqualValues(t, statusOptions{PoWRequirement: &pow}, optsDecoded)
+	require.EqualValues(t, statusOptionsV1{PoWRequirement: &pow}, optsDecoded)
 }

--- a/waku/statusoptionsv0.go
+++ b/waku/statusoptionsv0.go
@@ -1,0 +1,135 @@
+package waku
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// DEPRECATED: This is now deprecated. It incorrectly uses ascii keys for
+// RLP serialization
+
+type statusOptionsV0 struct {
+	PoWRequirement       *uint64     `rlp:"key=0"` // RLP does not support float64 natively
+	BloomFilter          []byte      `rlp:"key=1"`
+	LightNodeEnabled     *bool       `rlp:"key=2"`
+	ConfirmationsEnabled *bool       `rlp:"key=3"`
+	RateLimits           *RateLimits `rlp:"key=4"`
+	TopicInterest        []TopicType `rlp:"key=5"`
+}
+
+func (o statusOptionsV0) ToStatusOptions() statusOptions {
+	return statusOptions{
+		PoWRequirement:       o.PoWRequirement,
+		BloomFilter:          o.BloomFilter,
+		LightNodeEnabled:     o.LightNodeEnabled,
+		ConfirmationsEnabled: o.ConfirmationsEnabled,
+		RateLimits:           o.RateLimits,
+		TopicInterest:        o.TopicInterest,
+	}
+}
+
+var idxFieldKeyV0 = make(map[int]string)
+var keyFieldIdxV0 = func() map[string]int {
+	result := make(map[string]int)
+	opts := statusOptionsV0{}
+	v := reflect.ValueOf(opts)
+	for i := 0; i < v.NumField(); i++ {
+		// skip unexported fields
+		if !v.Field(i).CanInterface() {
+			continue
+		}
+		rlpTag := v.Type().Field(i).Tag.Get("rlp")
+		// skip fields without rlp field tag
+		if rlpTag == "" {
+			continue
+		}
+		key := strings.Split(rlpTag, "=")[1]
+		result[key] = i
+		idxFieldKeyV0[i] = key
+	}
+	return result
+}()
+
+func (o *statusOptionsV0) SetPoWRequirementFromF(val float64) {
+	requirement := math.Float64bits(val)
+	o.PoWRequirement = &requirement
+}
+
+func (o statusOptionsV0) EncodeRLP(w io.Writer) error {
+	v := reflect.ValueOf(o)
+	var optionsList []interface{}
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if !field.IsNil() {
+			value := field.Interface()
+			key, ok := idxFieldKeyV0[i]
+			if !ok {
+				continue
+			}
+			if value != nil {
+				optionsList = append(optionsList, []interface{}{key, value})
+			}
+		}
+	}
+	return rlp.Encode(w, optionsList)
+}
+
+func (o *statusOptionsV0) DecodeRLP(s *rlp.Stream) error {
+	_, err := s.List()
+	if err != nil {
+		return fmt.Errorf("expected an outer list: %v", err)
+	}
+
+	v := reflect.ValueOf(o)
+
+loop:
+	for {
+		_, err := s.List()
+		switch err {
+		case nil:
+			// continue to decode a key
+		case rlp.EOL:
+			break loop
+		default:
+			return fmt.Errorf("expected an inner list: %v", err)
+		}
+		var key string
+		if err := s.Decode(&key); err != nil {
+			return fmt.Errorf("invalid key: %v", err)
+		}
+		// Skip processing if a key does not exist.
+		// It might happen when there is a new peer
+		// which supports a new option with
+		// a higher index.
+		idx, ok := keyFieldIdxV0[key]
+		if !ok {
+			// Read the rest of the list items and dump them.
+			_, err := s.Raw()
+			if err != nil {
+				return fmt.Errorf("failed to read the value of key %s: %v", key, err)
+			}
+			continue
+		}
+		if err := s.Decode(v.Elem().Field(idx).Addr().Interface()); err != nil {
+			return fmt.Errorf("failed to decode an option %s: %v", key, err)
+		}
+		if err := s.ListEnd(); err != nil {
+			return err
+		}
+	}
+
+	return s.ListEnd()
+}
+
+func (o statusOptionsV0) Validate() error {
+	if len(o.TopicInterest) > 10000 {
+		return errors.New("topic interest is limited by 10000 items")
+	}
+	return nil
+}

--- a/waku/statusoptionsv1.go
+++ b/waku/statusoptionsv1.go
@@ -1,0 +1,152 @@
+package waku
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// statusOptions defines additional information shared between peers
+// during the handshake.
+// There might be more options provided then fields in statusOptions
+// and they should be ignored during deserialization to stay forward compatible.
+// In the case of RLP, options should be serialized to an array of tuples
+// where the first item is a field name and the second is a RLP-serialized value.
+type statusOptionsV1 struct {
+	PoWRequirement       *uint64     `rlp:"key=0"` // RLP does not support float64 natively
+	BloomFilter          []byte      `rlp:"key=1"`
+	LightNodeEnabled     *bool       `rlp:"key=2"`
+	ConfirmationsEnabled *bool       `rlp:"key=3"`
+	RateLimits           *RateLimits `rlp:"key=4"`
+	TopicInterest        []TopicType `rlp:"key=5"`
+}
+
+func (o statusOptionsV1) ToStatusOptions() statusOptions {
+	return statusOptions{
+		PoWRequirement:       o.PoWRequirement,
+		BloomFilter:          o.BloomFilter,
+		LightNodeEnabled:     o.LightNodeEnabled,
+		ConfirmationsEnabled: o.ConfirmationsEnabled,
+		RateLimits:           o.RateLimits,
+		TopicInterest:        o.TopicInterest,
+	}
+}
+
+var idxFieldKeyV1 = make(map[int]uint64)
+var keyFieldIdxV1 = func() map[uint64]int {
+	result := make(map[uint64]int)
+	opts := statusOptionsV1{}
+	v := reflect.ValueOf(opts)
+	for i := 0; i < v.NumField(); i++ {
+		// skip unexported fields
+		if !v.Field(i).CanInterface() {
+			continue
+		}
+		rlpTag := v.Type().Field(i).Tag.Get("rlp")
+		// skip fields without rlp field tag
+		if rlpTag == "" {
+			continue
+		}
+		keyString := strings.Split(rlpTag, "=")[1]
+		key, err := strconv.ParseUint(keyString, 10, 64)
+		if err != nil {
+			panic("cannot parse uint in rlp annotation")
+		}
+
+		result[key] = i
+		idxFieldKeyV1[i] = key
+	}
+	return result
+}()
+
+func (o statusOptionsV1) PoWRequirementF() *float64 {
+	if o.PoWRequirement == nil {
+		return nil
+	}
+	result := math.Float64frombits(*o.PoWRequirement)
+	return &result
+}
+
+func (o *statusOptionsV1) SetPoWRequirementFromF(val float64) {
+	requirement := math.Float64bits(val)
+	o.PoWRequirement = &requirement
+}
+
+func (o statusOptionsV1) EncodeRLP(w io.Writer) error {
+	v := reflect.ValueOf(o)
+	var optionsList []interface{}
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		if !field.IsNil() {
+			value := field.Interface()
+			key, ok := idxFieldKeyV1[i]
+			if !ok {
+				continue
+			}
+			if value != nil {
+				optionsList = append(optionsList, []interface{}{key, value})
+			}
+		}
+	}
+	return rlp.Encode(w, optionsList)
+}
+
+func (o *statusOptionsV1) DecodeRLP(s *rlp.Stream) error {
+	_, err := s.List()
+	if err != nil {
+		return fmt.Errorf("expected an outer list: %v", err)
+	}
+
+	v := reflect.ValueOf(o)
+
+loop:
+	for {
+		_, err := s.List()
+		switch err {
+		case nil:
+			// continue to decode a key
+		case rlp.EOL:
+			break loop
+		default:
+			return fmt.Errorf("expected an inner list: %v", err)
+		}
+		var key uint64
+		if err := s.Decode(&key); err != nil {
+			return fmt.Errorf("invalid key: %v", err)
+		}
+		// Skip processing if a key does not exist.
+		// It might happen when there is a new peer
+		// which supports a new option with
+		// a higher index.
+		idx, ok := keyFieldIdxV1[key]
+		if !ok {
+			// Read the rest of the list items and dump them.
+			_, err := s.Raw()
+			if err != nil {
+				return fmt.Errorf("failed to read the value of key %d: %v", key, err)
+			}
+			continue
+		}
+		if err := s.Decode(v.Elem().Field(idx).Addr().Interface()); err != nil {
+			return fmt.Errorf("failed to decode an option %d: %v", key, err)
+		}
+		if err := s.ListEnd(); err != nil {
+			return err
+		}
+	}
+
+	return s.ListEnd()
+}
+
+func (o statusOptionsV1) Validate() error {
+	if len(o.TopicInterest) > 10000 {
+		return errors.New("topic interest is limited by 10000 items")
+	}
+	return nil
+}


### PR DESCRIPTION
This commit upgrades to waku-1.

Now the nodes will advertise both `waku/0` and `waku/1` protocol
version, so compatibility is kept.
The old behavior of `waku/0` is maintained.