### PR TITLE
Refactor moved message functionality from filter to message

### DIFF
--- a/waku/filter.go
+++ b/waku/filter.go
@@ -28,47 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// MessageStore defines interface for temporary message store.
-type MessageStore interface {
-	Add(*ReceivedMessage) error
-	Pop() ([]*ReceivedMessage, error)
-}
-
-// NewMemoryMessageStore returns pointer to an instance of the MemoryMessageStore.
-func NewMemoryMessageStore() *MemoryMessageStore {
-	return &MemoryMessageStore{
-		messages: map[common.Hash]*ReceivedMessage{},
-	}
-}
-
-// MemoryMessageStore stores massages in memory hash table.
-type MemoryMessageStore struct {
-	mu       sync.Mutex
-	messages map[common.Hash]*ReceivedMessage
-}
-
-// Add adds message to store.
-func (store *MemoryMessageStore) Add(msg *ReceivedMessage) error {
-	store.mu.Lock()
-	defer store.mu.Unlock()
-	if _, exist := store.messages[msg.EnvelopeHash]; !exist {
-		store.messages[msg.EnvelopeHash] = msg
-	}
-	return nil
-}
-
-// Pop returns all available messages and cleans the store.
-func (store *MemoryMessageStore) Pop() ([]*ReceivedMessage, error) {
-	store.mu.Lock()
-	defer store.mu.Unlock()
-	all := make([]*ReceivedMessage, 0, len(store.messages))
-	for hash, msg := range store.messages {
-		delete(store.messages, hash)
-		all = append(all, msg)
-	}
-	return all, nil
-}
-
 // Filter represents a Waku message filter
 type Filter struct {
 	Src        *ecdsa.PublicKey  // Sender of the message


### PR DESCRIPTION
When documenting the `filter.go` file I found that there was a lot of functionality that belongs in the `message.go` file, so I've moved it.