### PR TITLE
Updated dependabot config to assign Samyoul

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,11 +7,11 @@ update_configs:
     directory: "/"
     update_schedule: "weekly"
     default_assignees:
-    - "adambabik"
     - "cammellos"
+    - "Samyoul"
   - package_manager: "go:modules"
     directory: "/protocol"
     update_schedule: "weekly"
     default_assignees:
-    - "adambabik"
     - "cammellos"
+    - "Samyoul"


### PR DESCRIPTION
Removes Adam and adds Samuel as the default dependabot assignees