### PR TITLE
Updated dependabot config to security only

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,9 +9,15 @@ update_configs:
     default_assignees:
     - "cammellos"
     - "Samyoul"
+    allowed_updates:
+      - match:
+        update_type: "security"
   - package_manager: "go:modules"
     directory: "/protocol"
     update_schedule: "weekly"
     default_assignees:
     - "cammellos"
     - "Samyoul"
+    allowed_updates:
+      - match:
+        update_type: "security"


### PR DESCRIPTION
## Why make the change?

@dependabot makes PRs for upgrading dependencies, but it doesn't automatically call `make vendor`, which is a problem because that means any merge for a @dependabot PR will require manual intervention.

I've looked through the @dependabot PR history and there has never been a successfully merged PR. [See here](https://github.com/status-im/status-go/pulls?q=is%3Apr+author%3Aapp%2Fdependabot-preview+is%3Aclosed)

If we are going to use this service we should only be warned of security updates, until we can implement a `make-vendor-bot` to automatically update the vendored files.

## What has changed?

Changed @dependabot settings to only make a PR for security updates.