### PR TITLE
Patch/dependabot protocol

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -11,7 +11,7 @@ update_configs:
     - "Samyoul"
     allowed_updates:
       - match:
-        update_type: "security"
+          update_type: "security"
   - package_manager: "go:modules"
     directory: "/protocol"
     update_schedule: "weekly"
@@ -20,4 +20,4 @@ update_configs:
     - "Samyoul"
     allowed_updates:
       - match:
-        update_type: "security"
+          update_type: "security"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,12 +12,3 @@ update_configs:
     allowed_updates:
       - match:
           update_type: "security"
-  - package_manager: "go:modules"
-    directory: "/protocol"
-    update_schedule: "weekly"
-    default_assignees:
-    - "cammellos"
-    - "Samyoul"
-    allowed_updates:
-      - match:
-          update_type: "security"


### PR DESCRIPTION
## Why make the change?

There is only one `vendor` for this repo, the protocol vendoring was removed, but the dependabot config wasn't updated.

- [Introduces dependabot config with new protocol package which includes a protocol/vendor](https://github.com/status-im/status-go/commit/ed5a5c154daf5362cdf0c35fd1bc204e6a6d49ae#diff-b44e3cec799fb1f7871015e85dba6eb3)
- [Removal of protocol/go.mod](https://github.com/status-im/status-go/pull/1835/files#diff-326517a0e19e23c71d9175a14b06437e)

## What's changed?

Remove the following from the @dependabot config

```yml
  - package_manager: "go:modules"
    directory: "/protocol"
    update_schedule: "weekly"
    default_assignees:
    - "cammellos"
    - "Samyoul"
    allowed_updates:
      - match:
          update_type: "security"
```