### PR TITLE
use EncodeToString to print []byte variables

### DIFF
--- a/mailserver/mailserver.go
+++ b/mailserver/mailserver.go
@@ -138,7 +138,7 @@ func (s *WhisperMailServer) DeliverMail(peerID []byte, req *whisper.Envelope) {
 		log.Debug(
 			"[mailserver:DeliverMail] failed to decode request",
 			"err", err,
-			"peerID", peerID,
+			"peerID", types.BytesToHash(peerID),
 			"requestID", req.Hash().String(),
 		)
 		payload, err = s.decompositeRequest(peerID, req)
@@ -147,7 +147,7 @@ func (s *WhisperMailServer) DeliverMail(peerID []byte, req *whisper.Envelope) {
 		deliveryFailuresCounter.WithLabelValues("validation").Inc()
 		log.Error(
 			"[mailserver:DeliverMail] request failed validaton",
-			"peerID", peerID,
+			"peerID", types.BytesToHash(peerID),
 			"requestID", req.Hash().String(),
 			"err", err,
 		)
@@ -394,7 +394,7 @@ func (s *WakuMailServer) DeliverMail(peerID []byte, req *wakucommon.Envelope) {
 		deliveryFailuresCounter.WithLabelValues("validation").Inc()
 		log.Error(
 			"[mailserver:DeliverMail] request failed validaton",
-			"peerID", peerID,
+			"peerID", types.BytesToHash(peerID),
 			"requestID", req.Hash().String(),
 			"err", err,
 		)


### PR DESCRIPTION
If we don't use it we get shit like:
```
[mailserver:DeliverMail] request failed validaton
  peerID="[113 189 115 37 242 24 204 13 148 190 2 73 121 249 83 175 21 18 22 254 138 157 128 45 142 254 46 252 132 209 109 135]"
  requestID=0x1b2574d73c33c6c68aadfd81746f195d629edeed403403b8e55fcd6e0e1bfde7
  err="query range is invalid: from > to (4165960798 > 3600145796)"
```
In logs, which not conducive to searching logs by peer ID.