### PR TITLE
Added link to specs for key compression API

### DIFF
--- a/api/multiformat/utils.go
+++ b/api/multiformat/utils.go
@@ -20,7 +20,7 @@ const (
 )
 
 // SerializePublicKey serialises a non-serialised multibase encoded multicodec identified EC public key
-// For details on usage see specs //TODO add the link to the specs
+// For details on usage see specs https://specs.status.im/spec/2#public-key-serialization
 func SerializePublicKey(key, outputBase string) (string, error) {
 	dKey, err := multibaseDecode(key)
 	if err != nil {
@@ -43,7 +43,7 @@ func SerializePublicKey(key, outputBase string) (string, error) {
 }
 
 // DeserializePublicKey deserialise a serialised multibase encoded multicodec identified EC public key
-// For details on usage see specs //TODO add the link to the specs
+// For details on usage see specs https://specs.status.im/spec/2#public-key-serialization
 func DeserializePublicKey(key, outputBase string) (string, error) {
 	cpk, err := multibaseDecode(key)
 	if err != nil {

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -671,7 +671,7 @@ func ValidateMnemonic(mnemonic string) string {
 }
 
 // SerializePublicKey compresses an uncompressed multibase encoded multicodec identified EC public key
-// For details on usage see specs //TODO add the link to the specs
+// For details on usage see specs https://specs.status.im/spec/2#public-key-serialization
 func MultiformatSerializePublicKey(key, outBase string) string {
 	cpk, err := multiformat.SerializePublicKey(key, outBase)
 	if err != nil {
@@ -682,7 +682,7 @@ func MultiformatSerializePublicKey(key, outBase string) string {
 }
 
 // DeserializePublicKey decompresses a compressed multibase encoded multicodec identified EC public key
-// For details on usage see specs //TODO add the link to the specs
+// For details on usage see specs https://specs.status.im/spec/2#public-key-serialization
 func MultiformatDeserializePublicKey(key, outBase string) string {
 	pk, err := multiformat.DeserializePublicKey(key, outBase)
 	if err != nil {


### PR DESCRIPTION
I merged https://github.com/status-im/status-go/pull/1990 a little prematurely I forgot to add a link to the specs in the docs of the de/serialisation API