### PR TITLE
Allow node to start a push notification server

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/protocol/pushnotificationserver"
 	"github.com/status-im/status-go/static"
 	"github.com/status-im/status-go/whisper/v6"
 )
@@ -446,6 +447,9 @@ type NodeConfig struct {
 
 	// MailServerRegistryAddress is the MailServerRegistry contract address
 	MailServerRegistryAddress string
+
+	// PushNotificationServerConfig is the config for the push notification server
+	PushNotificationServerConfig pushnotificationserver.Config `json:"PushNotificationServerConfig"`
 }
 
 // WalletConfig extra configuration for wallet.Service.

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -206,7 +206,7 @@ func NewMessenger(
 
 	// Initialize push notification server
 	var pushNotificationServer *pushnotificationserver.Server
-	if c.pushNotificationServerConfig != nil {
+	if c.pushNotificationServerConfig != nil && c.pushNotificationServerConfig.Enabled {
 		c.pushNotificationServerConfig.Identity = identity
 		pushNotificationServerPersistence := pushnotificationserver.NewSQLitePersistence(database)
 		pushNotificationServer = pushnotificationserver.New(c.pushNotificationServerConfig, pushNotificationServerPersistence, processor)
@@ -3306,6 +3306,7 @@ func (m *Messenger) StartPushNotificationsServer() error {
 	if m.pushNotificationServer == nil {
 		pushNotificationServerPersistence := pushnotificationserver.NewSQLitePersistence(m.database)
 		config := &pushnotificationserver.Config{
+			Enabled:  true,
 			Logger:   m.logger,
 			Identity: m.identity,
 		}

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -109,6 +109,7 @@ func (s *MessengerPushNotificationSuite) newPushNotificationServer(shh types.Wak
 	s.Require().NoError(err)
 
 	serverConfig := &pushnotificationserver.Config{
+		Enabled:  true,
 		Logger:   s.logger,
 		Identity: privateKey,
 	}

--- a/protocol/pushnotificationserver/server.go
+++ b/protocol/pushnotificationserver/server.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
-	"errors"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/eth-node/crypto"
@@ -21,6 +21,7 @@ const encryptedPayloadKeyLength = 16
 const defaultGorushURL = "https://gorush.status.im"
 
 type Config struct {
+	Enabled bool
 	// Identity is our identity key
 	Identity *ecdsa.PrivateKey
 	// GorushUrl is the url for the gorush service
@@ -44,6 +45,14 @@ func New(config *Config, persistence Persistence, messageProcessor *common.Messa
 }
 
 func (s *Server) Start() error {
+	if s.config.Logger == nil {
+		logger, err := zap.NewDevelopment()
+		if err != nil {
+			return errors.Wrap(err, "failed to create a logger")
+		}
+		s.config.Logger = logger
+	}
+
 	s.config.Logger.Info("starting push notification server")
 	if s.config.Identity == nil {
 		s.config.Logger.Info("Identity nil")

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -476,7 +476,8 @@ func buildMessengerOptions(
 
 	if settings.PushNotificationsServerEnabled {
 		config := &pushnotificationserver.Config{
-			Logger: logger,
+			Enabled: true,
+			Logger:  logger,
 		}
 		options = append(options, protocol.WithPushNotificationServerConfig(config))
 	}


### PR DESCRIPTION
This commit allows a node to start a push notification server.
If the config is set it will start a messenger with a corresponding pn
server.
