### PR TITLE
Soft blacklist peer ids

### DIFF
--- a/node/geth_node.go
+++ b/node/geth_node.go
@@ -447,10 +447,11 @@ func createShhService(ctx *node.ServiceContext, whisperConfig *params.WhisperCon
 
 func createWakuService(ctx *node.ServiceContext, wakuCfg *params.WakuConfig, clusterCfg *params.ClusterConfig) (*waku.Waku, error) {
 	cfg := &waku.Config{
-		MaxMessageSize:     wakucommon.DefaultMaxMessageSize,
-		BloomFilterMode:    wakuCfg.BloomFilterMode,
-		FullNode:           wakuCfg.FullNode,
-		MinimumAcceptedPoW: params.WakuMinimumPoW,
+		MaxMessageSize:         wakucommon.DefaultMaxMessageSize,
+		BloomFilterMode:        wakuCfg.BloomFilterMode,
+		FullNode:               wakuCfg.FullNode,
+		SoftBlacklistedPeerIDs: wakuCfg.SoftBlacklistedPeerIDs,
+		MinimumAcceptedPoW:     params.WakuMinimumPoW,
 	}
 
 	if wakuCfg.MaxMessageSize > 0 {

--- a/params/config.go
+++ b/params/config.go
@@ -208,6 +208,9 @@ type WakuConfig struct {
 	// BloomFilterMode tells us whether we should be sending a bloom
 	// filter rather than TopicInterest
 	BloomFilterMode bool
+
+	// SoftBlacklistedPeerIDs is a list of peer ids that should be soft-blacklisted (messages should be dropped but connection kept)
+	SoftBlacklistedPeerIDs []string
 }
 
 // ----------

--- a/waku/config.go
+++ b/waku/config.go
@@ -24,13 +24,14 @@ import (
 
 // Config represents the configuration state of a waku node.
 type Config struct {
-	MaxMessageSize           uint32  `toml:",omitempty"`
-	MinimumAcceptedPoW       float64 `toml:",omitempty"`
-	BloomFilterMode          bool    `toml:",omitempty"` // when true, we only match against bloom filter
-	LightClient              bool    `toml:",omitempty"` // when true, it does not forward messages
-	FullNode                 bool    `toml:",omitempty"` // when true, it forwards all messages
-	RestrictLightClientsConn bool    `toml:",omitempty"` // when true, do not accept light client as peers if it is a light client itself
-	EnableConfirmations      bool    `toml:",omitempty"` // when true, sends message confirmations
+	MaxMessageSize           uint32   `toml:",omitempty"`
+	MinimumAcceptedPoW       float64  `toml:",omitempty"`
+	BloomFilterMode          bool     `toml:",omitempty"` // when true, we only match against bloom filter
+	LightClient              bool     `toml:",omitempty"` // when true, it does not forward messages
+	FullNode                 bool     `toml:",omitempty"` // when true, it forwards all messages
+	RestrictLightClientsConn bool     `toml:",omitempty"` // when true, do not accept light client as peers if it is a light client itself
+	EnableConfirmations      bool     `toml:",omitempty"` // when true, sends message confirmations
+	SoftBlacklistedPeerIDs   []string `toml:",omitempty"`
 }
 
 var DefaultConfig = Config{


### PR DESCRIPTION
### Why make this change?

This change is useful so we can blacklist peer ids, without actually
disconnecting them, so that it's harder for them to tell that they are
being blacklisted. Envelopes will just be dropped.

### What has changed?

In waku we pass a config with a list of hex-encoded peer ids, and we
check that against newly received envelopes.
If so we just drop the envelope and return

