### PR TITLE
unify format of logs with peerID

### DIFF
--- a/waku/v0/peer.go
+++ b/waku/v0/peer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/status-im/status-go/eth-node/types"
 
 	"github.com/status-im/status-go/waku/common"
 )
@@ -80,13 +81,13 @@ func (p *Peer) Start() error {
 		return err
 	}
 	go p.update()
-	p.logger.Debug("starting peer", zap.Binary("peerID", p.ID()))
+	p.logger.Debug("starting peer", zap.String("peerID", types.EncodeHex(p.ID())))
 	return nil
 }
 
 func (p *Peer) Stop() {
 	close(p.quit)
-	p.logger.Debug("stopping peer", zap.Binary("peerID", p.ID()))
+	p.logger.Debug("stopping peer", zap.String("peerID", types.EncodeHex(p.ID())))
 }
 
 func (p *Peer) NotifyAboutPowRequirementChange(pow float64) error {
@@ -184,17 +185,17 @@ func (p *Peer) Run() error {
 		// fetch the next packet
 		packet, err := p.rw.ReadMsg()
 		if err != nil {
-			logger.Info("failed to read a message", zap.Binary("peer", p.ID()), zap.Error(err))
+			logger.Info("failed to read a message", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 			return err
 		}
 
 		if packet.Size > p.host.MaxMessageSize() {
-			logger.Warn("oversize message received", zap.Binary("peer", p.ID()), zap.Uint32("size", packet.Size))
+			logger.Warn("oversize message received", zap.String("peerID", types.EncodeHex(p.ID())), zap.Uint32("size", packet.Size))
 			return errors.New("oversize message received")
 		}
 
 		if err := p.handlePacket(packet); err != nil {
-			logger.Warn("failed to handle packet message, peer will be disconnected", zap.Binary("peer", p.ID()), zap.Error(err))
+			logger.Warn("failed to handle packet message, peer will be disconnected", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 		}
 		_ = packet.Discard()
 	}
@@ -204,37 +205,37 @@ func (p *Peer) handlePacket(packet p2p.Msg) error {
 	switch packet.Code {
 	case messagesCode:
 		if err := p.handleMessagesCode(packet); err != nil {
-			p.logger.Warn("failed to handle messagesCode message, peer will be disconnected", zap.Binary("peer", p.ID()), zap.Error(err))
+			p.logger.Warn("failed to handle messagesCode message, peer will be disconnected", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 			return err
 		}
 	case messageResponseCode:
 		if err := p.handleMessageResponseCode(packet); err != nil {
-			p.logger.Warn("failed to handle messageResponseCode message, peer will be disconnected", zap.Binary("peer", p.ID()), zap.Error(err))
+			p.logger.Warn("failed to handle messageResponseCode message, peer will be disconnected", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 			return err
 		}
 	case batchAcknowledgedCode:
 		if err := p.handleBatchAcknowledgeCode(packet); err != nil {
-			p.logger.Warn("failed to handle batchAcknowledgedCode message, peer will be disconnected", zap.Binary("peer", p.ID()), zap.Error(err))
+			p.logger.Warn("failed to handle batchAcknowledgedCode message, peer will be disconnected", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 			return err
 		}
 	case statusUpdateCode:
 		if err := p.handleStatusUpdateCode(packet); err != nil {
-			p.logger.Warn("failed to decode status update message, peer will be disconnected", zap.Binary("peer", p.ID()), zap.Error(err))
+			p.logger.Warn("failed to decode status update message, peer will be disconnected", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 			return err
 		}
 	case p2pMessageCode:
 		if err := p.handleP2PMessageCode(packet); err != nil {
-			p.logger.Warn("failed to decode direct message, peer will be disconnected", zap.Binary("peer", p.ID()), zap.Error(err))
+			p.logger.Warn("failed to decode direct message, peer will be disconnected", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 			return err
 		}
 	case p2pRequestCode:
 		if err := p.handleP2PRequestCode(packet); err != nil {
-			p.logger.Warn("failed to decode p2p request message, peer will be disconnected", zap.Binary("peer", p.ID()), zap.Error(err))
+			p.logger.Warn("failed to decode p2p request message, peer will be disconnected", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 			return err
 		}
 	case p2pRequestCompleteCode:
 		if err := p.handleP2PRequestCompleteCode(packet); err != nil {
-			p.logger.Warn("failed to decode p2p request complete message, peer will be disconnected", zap.Binary("peer", p.ID()), zap.Error(err))
+			p.logger.Warn("failed to decode p2p request complete message, peer will be disconnected", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 			return err
 		}
 	default:
@@ -308,7 +309,7 @@ func (p *Peer) handleP2PRequestCode(packet p2p.Msg) error {
 	if errDepReq == nil {
 		return p.host.OnDeprecatedMessagesRequest(&requestDeprecated, p)
 	}
-	p.logger.Info("failed to decode p2p request message (deprecated)", zap.Binary("peer", p.ID()), zap.Error(errDepReq))
+	p.logger.Info("failed to decode p2p request message (deprecated)", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(errDepReq))
 
 	// As we failed to decode the request, let's set the offset
 	// to the beginning and try decode it again.
@@ -321,7 +322,7 @@ func (p *Peer) handleP2PRequestCode(packet p2p.Msg) error {
 	if errReq == nil {
 		return p.host.OnMessagesRequest(request, p)
 	}
-	p.logger.Info("failed to decode p2p request message", zap.Binary("peer", p.ID()), zap.Error(errReq))
+	p.logger.Info("failed to decode p2p request message", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(errReq))
 
 	return errors.New("invalid p2p request message")
 }
@@ -456,7 +457,7 @@ func (p *Peer) update() {
 
 		case <-transmit.C:
 			if err := p.broadcast(); err != nil {
-				p.logger.Debug("broadcasting failed", zap.Binary("peer", p.ID()), zap.Error(err))
+				p.logger.Debug("broadcasting failed", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 				return
 			}
 
@@ -468,7 +469,7 @@ func (p *Peer) update() {
 
 func (p *Peer) setOptions(peerOptions StatusOptions) error {
 
-	p.logger.Debug("settings options", zap.Binary("peerID", p.ID()), zap.Any("Options", peerOptions))
+	p.logger.Debug("settings options", zap.String("peerID", types.EncodeHex(p.ID())), zap.Any("Options", peerOptions))
 
 	if err := peerOptions.Validate(); err != nil {
 		return fmt.Errorf("p [%x]: sent invalid options: %v", p.ID(), err)
@@ -543,7 +544,7 @@ func (p *Peer) broadcast() error {
 
 	batchHash, err := sendBundle(p.rw, bundle)
 	if err != nil {
-		p.logger.Debug("failed to deliver envelopes", zap.Binary("peer", p.ID()), zap.Error(err))
+		p.logger.Debug("failed to deliver envelopes", zap.String("peerID", types.EncodeHex(p.ID())), zap.Error(err))
 		return err
 	}
 
@@ -560,7 +561,7 @@ func (p *Peer) broadcast() error {
 		}
 		p.host.SendEnvelopeEvent(event)
 	}
-	p.logger.Debug("broadcasted bundles successfully", zap.Binary("peer", p.ID()), zap.Int("count", len(bundle)))
+	p.logger.Debug("broadcasted bundles successfully", zap.String("peerID", types.EncodeHex(p.ID())), zap.Int("count", len(bundle)))
 	return nil
 }
 


### PR DESCRIPTION
I've gotten tired of logs showing peer IDs like this:
```
failed to read a message     peer="[170 24 26 97 2 120 107 86 157 253 226 23 79 197 57 9 243 144 6 157 118 206 29 124 220 117 73 122 251 61 197 31]" error="p2p: read or write on closed message pipe"
```
Now it should look like this:
```
failed to read a message     peerID=0x34f766b58ca7f8ea197bfd2ffb377c474acb4b254cff4ad693a5b403e82001df error=EOF
```
Also the inconsistency in naming between `peer` and `peerID` is annoying.