### PR TITLE
🐱 Giphy and  Tenor preview data

### DIFF
--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -22,12 +22,16 @@ type GiphyOembedData struct {
 	ProviderName string `json:"provider_name"`
 	Title        string `json:"title"`
 	URL          string `json:"url"`
+	Height       int `json:"height"`
+	Width        int  `json:"width"`
 }
 
 type TenorOembedData struct {
 	ProviderName string `json:"provider_name"`
 	ThumbnailURL string `json:"thumbnail_url"`
 	AuthorName   string `json:"author_name"`
+	Height       int `json:"height"`
+	Width        int `json:"width"`
 }
 
 type LinkPreviewData struct {
@@ -35,6 +39,8 @@ type LinkPreviewData struct {
 	Title        string `json:"title" meta:"og:title"`
 	ThumbnailURL string `json:"thumbnailUrl" meta:"og:image"`
 	ContentType  string `json:"contentType"`
+	Height       int `json:"height"`
+	Width        int `json:"width"`
 }
 
 type Site struct {
@@ -172,6 +178,8 @@ func GetGiphyPreviewData(link string) (previewData LinkPreviewData, err error) {
 	previewData.Title = oembedData.Title
 	previewData.Site = oembedData.ProviderName
 	previewData.ThumbnailURL = oembedData.URL
+	previewData.Height = oembedData.Height
+	previewData.Width = oembedData.Width
 
 	return previewData, nil
 }
@@ -231,6 +239,8 @@ func GetTenorPreviewData(link string) (previewData LinkPreviewData, err error) {
 	previewData.Title = oembedData.AuthorName // Tenor Oembed service doesn't return title of the Gif
 	previewData.Site = oembedData.ProviderName
 	previewData.ThumbnailURL = oembedData.ThumbnailURL
+	previewData.Height = oembedData.Height
+	previewData.Width = oembedData.Width
 
 	return previewData, nil
 }
@@ -248,7 +258,7 @@ func GetLinkPreviewData(link string) (previewData LinkPreviewData, err error) {
 		return GetYoutubePreviewData(link)
 	case "github.com":
 		return GetGithubPreviewData(link)
-	case "giphy.com":
+	case "giphy.com", "media.giphy.com":
 		return GetGiphyPreviewData(link)
 	case "gph.is":
 		return GetGiphyShortURLPreviewData(link)

--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -179,6 +179,7 @@ func GetGiphyPreviewData(link string) (previewData LinkPreviewData, err error) {
 // Giphy has a shortener service called gph.se, the oembed service doesn't work with shortened urls,
 // so we need to fetch the long url first
 func GetGiphyLongURL(shortURL string) (longURL string, err error) {
+	// nolint: gosec
 	res, err := http.Get(shortURL)
 
 	if err != nil {
@@ -186,22 +187,22 @@ func GetGiphyLongURL(shortURL string) (longURL string, err error) {
 	}
 
 	canonicalURL := res.Request.URL.String()
-	if (canonicalURL == shortURL) {
+	if canonicalURL == shortURL {
 		// no redirect, ie. not a valid url
 		return longURL, fmt.Errorf("unable to process Giphy's short url at %s", shortURL)
-	} else {
-		return canonicalURL, err
 	}
+
+	return canonicalURL, err
 }
 
-func GetGiphyShortURLPreviewData (shortURL string) (data LinkPreviewData, err error) {
+func GetGiphyShortURLPreviewData(shortURL string) (data LinkPreviewData, err error) {
 	longURL, err := GetGiphyLongURL(shortURL)
 
 	if err != nil {
 		return data, err
-	} else {
-		return GetGiphyPreviewData(longURL)
 	}
+
+	return GetGiphyPreviewData(longURL)
 }
 
 func GetTenorOembed(url string) (data TenorOembedData, err error) {

--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -203,33 +203,17 @@ func GetLinkPreviewData(link string) (previewData LinkPreviewData, err error) {
 	}
 
 	hostname := strings.ToLower(url.Hostname())
-	youtubeHostnames := []string{"youtube.com", "www.youtube.com", "youtu.be"}
-	for _, youtubeHostname := range youtubeHostnames {
-		if youtubeHostname == hostname {
-			return GetYoutubePreviewData(link)
-		}
-	}
-	if "github.com" == hostname {
+
+	switch hostname {
+	case "youtube.com", "youtu.be", "www.youtube.com":
+		return GetYoutubePreviewData(link)
+	case "github.com":
 		return GetGithubPreviewData(link)
-	}
-	if "giphy.com" == hostname {
+	case "giphy.com":
 		return GetGiphyPreviewData(link)
-	}
-	if "tenor.com" == hostname {
+	case "tenor.com":
 		return GetTenorPreviewData(link)
+	default:
+		return previewData, fmt.Errorf("Link %s isn't whitelisted. Hostname - %s", link, url.Hostname())
 	}
-
-	for _, site := range LinkPreviewWhitelist() {
-		if strings.HasSuffix(hostname, site.Address) && site.ImageSite {
-			content, contentErr := GetURLContent(link)
-			if contentErr != nil {
-				return previewData, contentErr
-			}
-			previewData.ThumbnailURL = link
-			previewData.ContentType = http.DetectContentType(content)
-			return previewData, nil
-		}
-	}
-
-	return previewData, fmt.Errorf("Link %s isn't whitelisted. Hostname - %s", link, url.Hostname())
 }

--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -74,6 +74,11 @@ func LinkPreviewWhitelist() []Site {
 			ImageSite: true,
 		},
 		Site{
+			Title:     "GIPHY GIFs subdomain",
+			Address:   "media.giphy.com",
+			ImageSite: true,
+		},
+		Site{
 			Title:     "GitHub",
 			Address:   "github.com",
 			ImageSite: false,

--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -85,7 +85,7 @@ func GetURLContent(url string) (data []byte, err error) {
 	// nolint: gosec
 	response, err := httpClient.Get(url)
 	if err != nil {
-		return data, fmt.Errorf("Can't get content from link %s", url)
+		return data, fmt.Errorf("can't get content from link %s", url)
 	}
 	defer response.Body.Close()
 	return ioutil.ReadAll(response.Body)
@@ -96,12 +96,12 @@ func GetYoutubeOembed(url string) (data YoutubeOembedData, err error) {
 
 	jsonBytes, err := GetURLContent(oembedLink)
 	if err != nil {
-		return data, fmt.Errorf("Can't get bytes from youtube oembed response on %s link", oembedLink)
+		return data, fmt.Errorf("can't get bytes from youtube oembed response on %s link", oembedLink)
 	}
 
 	err = json.Unmarshal(jsonBytes, &data)
 	if err != nil {
-		return data, fmt.Errorf("Can't unmarshall json")
+		return data, fmt.Errorf("can't unmarshall json")
 	}
 
 	return data, nil
@@ -125,12 +125,12 @@ func GetGithubPreviewData(link string) (previewData LinkPreviewData, err error) 
 	res, err := httpClient.Get(link)
 
 	if err != nil {
-		return previewData, fmt.Errorf("Can't get content from link %s", link)
+		return previewData, fmt.Errorf("can't get content from link %s", link)
 	}
 
 	err = metabolize.Metabolize(res.Body, &previewData)
 	if err != nil {
-		return previewData, fmt.Errorf("Can't get meta info from link %s", link)
+		return previewData, fmt.Errorf("can't get meta info from link %s", link)
 	}
 
 	return previewData, nil
@@ -142,12 +142,12 @@ func GetGiphyOembed(url string) (data GiphyOembedData, err error) {
 	jsonBytes, err := GetURLContent(oembedLink)
 
 	if err != nil {
-		return data, fmt.Errorf("Can't get bytes from Giphy oembed response at %s", oembedLink)
+		return data, fmt.Errorf("can't get bytes from Giphy oembed response at %s", oembedLink)
 	}
 
 	err = json.Unmarshal(jsonBytes, &data)
 	if err != nil {
-		return data, fmt.Errorf("Can't unmarshall json")
+		return data, fmt.Errorf("can't unmarshall json")
 	}
 
 	return data, nil
@@ -172,12 +172,12 @@ func GetTenorOembed(url string) (data TenorOembedData, err error) {
 	jsonBytes, err := GetURLContent(oembedLink)
 
 	if err != nil {
-		return data, fmt.Errorf("Can't get bytes from Tenor oembed response at %s", oembedLink)
+		return data, fmt.Errorf("can't get bytes from Tenor oembed response at %s", oembedLink)
 	}
 
 	err = json.Unmarshal(jsonBytes, &data)
 	if err != nil {
-		return data, fmt.Errorf("Can't unmarshall json")
+		return data, fmt.Errorf("can't unmarshall json")
 	}
 
 	return data, nil
@@ -199,7 +199,7 @@ func GetTenorPreviewData(link string) (previewData LinkPreviewData, err error) {
 func GetLinkPreviewData(link string) (previewData LinkPreviewData, err error) {
 	url, err := url.Parse(link)
 	if err != nil {
-		return previewData, fmt.Errorf("Cant't parse link %s", link)
+		return previewData, fmt.Errorf("cant't parse link %s", link)
 	}
 
 	hostname := strings.ToLower(url.Hostname())
@@ -214,6 +214,6 @@ func GetLinkPreviewData(link string) (previewData LinkPreviewData, err error) {
 	case "tenor.com":
 		return GetTenorPreviewData(link)
 	default:
-		return previewData, fmt.Errorf("Link %s isn't whitelisted. Hostname - %s", link, url.Hostname())
+		return previewData, fmt.Errorf("link %s isn't whitelisted. Hostname - %s", link, url.Hostname())
 	}
 }

--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -22,16 +22,16 @@ type GiphyOembedData struct {
 	ProviderName string `json:"provider_name"`
 	Title        string `json:"title"`
 	URL          string `json:"url"`
-	Height       int `json:"height"`
-	Width        int  `json:"width"`
+	Height       int    `json:"height"`
+	Width        int    `json:"width"`
 }
 
 type TenorOembedData struct {
 	ProviderName string `json:"provider_name"`
 	ThumbnailURL string `json:"thumbnail_url"`
 	AuthorName   string `json:"author_name"`
-	Height       int `json:"height"`
-	Width        int `json:"width"`
+	Height       int    `json:"height"`
+	Width        int    `json:"width"`
 }
 
 type LinkPreviewData struct {
@@ -39,8 +39,8 @@ type LinkPreviewData struct {
 	Title        string `json:"title" meta:"og:title"`
 	ThumbnailURL string `json:"thumbnailUrl" meta:"og:image"`
 	ContentType  string `json:"contentType"`
-	Height       int `json:"height"`
-	Width        int `json:"width"`
+	Height       int    `json:"height"`
+	Width        int    `json:"width"`
 }
 
 type Site struct {

--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -20,8 +20,8 @@ type YoutubeOembedData struct {
 
 type GiphyOembedData struct {
 	ProviderName string `json:"provider_name"`
-	Title string `json:"title"`
-	URL   string `json:"url"`
+	Title        string `json:"title"`
+	URL          string `json:"url"`
 }
 
 type TenorOembedData struct {
@@ -29,7 +29,6 @@ type TenorOembedData struct {
 	ThumbnailURL string `json:"thumbnail_url"`
 	AuthorName   string `json:"author_name"`
 }
-
 
 type LinkPreviewData struct {
 	Site         string `json:"site" meta:"og:site_name"`
@@ -47,7 +46,6 @@ type Site struct {
 const YoutubeOembedLink = "https://www.youtube.com/oembed?format=json&url=%s"
 const GiphyOembedLink = "https://giphy.com/services/oembed?url=%s"
 const TenorOembedLink = "https://tenor.com/oembed?url=%s"
-
 
 var httpClient = http.Client{
 	Timeout: 30 * time.Second,
@@ -84,7 +82,6 @@ func LinkPreviewWhitelist() []Site {
 }
 
 func GetURLContent(url string) (data []byte, err error) {
-
 	// nolint: gosec
 	response, err := httpClient.Get(url)
 	if err != nil {

--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -69,8 +69,8 @@ func LinkPreviewWhitelist() []Site {
 			ImageSite: true,
 		},
 		Site{
-			Title:     "GIPHY GIFs Short URLS",
-			Address:   "gph.se",
+			Title:     "GIPHY GIFs shortener",
+			Address:   "gph.is",
 			ImageSite: true,
 		},
 		Site{
@@ -176,7 +176,7 @@ func GetGiphyPreviewData(link string) (previewData LinkPreviewData, err error) {
 	return previewData, nil
 }
 
-// Giphy has a shortener service called gph.se, the oembed service doesn't work with shortened urls,
+// Giphy has a shortener service called gph.is, the oembed service doesn't work with shortened urls,
 // so we need to fetch the long url first
 func GetGiphyLongURL(shortURL string) (longURL string, err error) {
 	// nolint: gosec
@@ -250,7 +250,7 @@ func GetLinkPreviewData(link string) (previewData LinkPreviewData, err error) {
 		return GetGithubPreviewData(link)
 	case "giphy.com":
 		return GetGiphyPreviewData(link)
-	case "gph.se":
+	case "gph.is":
 		return GetGiphyShortURLPreviewData(link)
 	case "tenor.com":
 		return GetTenorPreviewData(link)

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -74,7 +74,7 @@ func TestGetGiphyLongURL(t *testing.T) {
 	_, err := GetGiphyLongURL("http://this-giphy-site-doesn-not-exist.se/bogus-url")
 	require.Error(t, err)
 
-	_, err = GetGiphyLongURL("http://gph.se/bogus-url-but-correct-domain")
+	_, err = GetGiphyLongURL("http://gph.is/bogus-url-but-correct-domain")
 	require.Error(t, err)
 }
 

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -1,8 +1,8 @@
 package urls
 
 import (
-	"testing"
 	"strings"
+	"testing"
 
 	"github.com/stretchr/testify/require"
 )

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -58,14 +58,41 @@ func TestGetGiphyPreviewData(t *testing.T) {
 	require.Error(t, err)
 
 
-	// Other link shapes
-	// shortLink := "https://gph.is/g/aXLyK7P"
 	mediaLink := "https://media.giphy.com/media/lcG3qwtTKSNI2i5vst/giphy.gif"
 
-	// shortLinkData, _ := GetGiphyPreviewData(shortLink)
 	mediaLinkData, _ := GetGiphyPreviewData(mediaLink)
 
 	require.Equal(t, thumbnailUrlWithoutSubdomain(mediaLinkData.ThumbnailURL), thumbnailUrlWithoutSubdomain(previewData.ThumbnailURL))
+}
+
+func TestGetGiphyLongURL(t *testing.T) {
+	shortURL := "https://gph.is/g/aXLyK7P"
+	computedLongURL, _ := GetGiphyLongURL(shortURL)
+	actualLongURL := "https://giphy.com/gifs/FullMag-robot-boston-dynamics-dance-lcG3qwtTKSNI2i5vst"
+
+	require.Equal(t, computedLongURL, actualLongURL)
+
+	_, err := GetGiphyLongURL("http://this-giphy-site-doesn-not-exist.se/bogus-url")
+	require.Error(t, err)
+
+	_, err = GetGiphyLongURL("http://gph.se/bogus-url-but-correct-domain")
+	require.Error(t, err)
+}
+
+
+func TestGetGiphyShortURLPreviewData(t *testing.T) {
+	shortURL := "https://gph.is/g/aXLyK7P"
+	previewData, err := GetGiphyShortURLPreviewData(shortURL)
+
+	bostonDynamicsEthGifData := LinkPreviewData{
+		Site:         "GIPHY",
+		Title:        "Boston Dynamics Yes GIF by FullMag - Find & Share on GIPHY",
+		ThumbnailURL: "https://media1.giphy.com/media/lcG3qwtTKSNI2i5vst/giphy.gif",
+	}
+
+	require.NoError(t, err)
+	require.Equal(t, bostonDynamicsEthGifData.Site, previewData.Site)
+	require.Equal(t, bostonDynamicsEthGifData.Title, previewData.Title)
 }
 
 func TestGetTenorPreviewData(t *testing.T) {

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -32,6 +32,11 @@ func TestGetLinkPreviewData(t *testing.T) {
 
 }
 
+// split at "." and ignore the first item
+func thumbnailUrlWithoutSubdomain(url string) []string {
+	return strings.Split(url, ".")[1:]
+}
+
 func TestGetGiphyPreviewData(t *testing.T) {
 	validGiphyLink := "https://giphy.com/gifs/FullMag-robot-boston-dynamics-dance-lcG3qwtTKSNI2i5vst"
 	previewData, err := GetGiphyPreviewData(validGiphyLink)
@@ -46,11 +51,21 @@ func TestGetGiphyPreviewData(t *testing.T) {
 
 	// Giphy oembed returns links to different servers: https://media1.giphy.com, https://media2.giphy.com and so on
 	// We don't care about the server as long as other parts are equal, so we split at "." and ignore the first item
-	require.Equal(t, strings.Split(bostonDynamicsEthGifData.ThumbnailURL, ".")[1:], strings.Split(previewData.ThumbnailURL, ".")[1:])
+	require.Equal(t, thumbnailUrlWithoutSubdomain(bostonDynamicsEthGifData.ThumbnailURL), thumbnailUrlWithoutSubdomain(previewData.ThumbnailURL))
 
 	invalidGiphyLink := "https://giphy.com/gifs/this-gif-does-not-exist-44444"
 	_, err = GetGiphyPreviewData(invalidGiphyLink)
 	require.Error(t, err)
+
+
+	// Other link shapes
+	// shortLink := "https://gph.is/g/aXLyK7P"
+	mediaLink := "https://media.giphy.com/media/lcG3qwtTKSNI2i5vst/giphy.gif"
+
+	// shortLinkData, _ := GetGiphyPreviewData(shortLink)
+	mediaLinkData, _ := GetGiphyPreviewData(mediaLink)
+
+	require.Equal(t, thumbnailUrlWithoutSubdomain(mediaLinkData.ThumbnailURL), thumbnailUrlWithoutSubdomain(previewData.ThumbnailURL))
 }
 
 func TestGetTenorPreviewData(t *testing.T) {

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -44,8 +44,8 @@ func TestGetGiphyPreviewData(t *testing.T) {
 		Site:         "GIPHY",
 		Title:        "Boston Dynamics Yes GIF by FullMag - Find & Share on GIPHY",
 		ThumbnailURL: "https://media1.giphy.com/media/lcG3qwtTKSNI2i5vst/giphy.gif",
-		Height:        480,
-		Width:         480,
+		Height:       480,
+		Width:        480,
 	}
 	require.NoError(t, err)
 	require.Equal(t, bostonDynamicsEthGifData.Site, previewData.Site)

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -44,10 +44,14 @@ func TestGetGiphyPreviewData(t *testing.T) {
 		Site:         "GIPHY",
 		Title:        "Boston Dynamics Yes GIF by FullMag - Find & Share on GIPHY",
 		ThumbnailURL: "https://media1.giphy.com/media/lcG3qwtTKSNI2i5vst/giphy.gif",
+		Height:        480,
+		Width:         480,
 	}
 	require.NoError(t, err)
 	require.Equal(t, bostonDynamicsEthGifData.Site, previewData.Site)
 	require.Equal(t, bostonDynamicsEthGifData.Title, previewData.Title)
+	require.Equal(t, bostonDynamicsEthGifData.Height, previewData.Height)
+	require.Equal(t, bostonDynamicsEthGifData.Width, previewData.Width)
 
 	// Giphy oembed returns links to different servers: https://media1.giphy.com, https://media2.giphy.com and so on
 	// We don't care about the server as long as other parts are equal, so we split at "." and ignore the first item
@@ -101,11 +105,15 @@ func TestGetTenorPreviewData(t *testing.T) {
 		Site:         "Tenor",
 		Title:        "Annihere",
 		ThumbnailURL: "https://media.tenor.com/images/975f6b95d188c277ebba62d9b5511685/tenor.gif",
+		Height:       400,
+		Width:        600,
 	}
 	require.NoError(t, err)
 	require.Equal(t, gifData.Site, previewData.Site)
 	require.Equal(t, gifData.Title, previewData.Title)
 	require.Equal(t, gifData.ThumbnailURL, previewData.ThumbnailURL)
+	require.Equal(t, gifData.Height, previewData.Height)
+	require.Equal(t, gifData.Width, previewData.Width)
 
 	invalidTenorLink := "https://giphy.com/gifs/this-gif-does-not-exist-44444"
 	_, err = GetTenorPreviewData(invalidTenorLink)

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -2,6 +2,7 @@ package urls
 
 import (
 	"testing"
+	"strings"
 
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +43,10 @@ func TestGetGiphyPreviewData(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, bostonDynamicsEthGifData.Site, previewData.Site)
 	require.Equal(t, bostonDynamicsEthGifData.Title, previewData.Title)
-	require.Equal(t, bostonDynamicsEthGifData.ThumbnailURL, previewData.ThumbnailURL)
+
+	// Giphy oembed returns links to different servers: https://media1.giphy.com, https://media2.giphy.com and so on
+	// We don't care about the server as long as other parts are equal, so we split at "." and ignore the first item
+	require.Equal(t, strings.Split(bostonDynamicsEthGifData.ThumbnailURL, ".")[1:], strings.Split(previewData.ThumbnailURL, ".")[1:])
 
 	invalidGiphyLink := "https://giphy.com/gifs/this-gif-does-not-exist-44444"
 	_, err = GetGiphyPreviewData(invalidGiphyLink)

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -33,7 +33,7 @@ func TestGetLinkPreviewData(t *testing.T) {
 }
 
 // split at "." and ignore the first item
-func thumbnailUrlWithoutSubdomain(url string) []string {
+func thumbnailURLWithoutSubdomain(url string) []string {
 	return strings.Split(url, ".")[1:]
 }
 
@@ -51,18 +51,17 @@ func TestGetGiphyPreviewData(t *testing.T) {
 
 	// Giphy oembed returns links to different servers: https://media1.giphy.com, https://media2.giphy.com and so on
 	// We don't care about the server as long as other parts are equal, so we split at "." and ignore the first item
-	require.Equal(t, thumbnailUrlWithoutSubdomain(bostonDynamicsEthGifData.ThumbnailURL), thumbnailUrlWithoutSubdomain(previewData.ThumbnailURL))
+	require.Equal(t, thumbnailURLWithoutSubdomain(bostonDynamicsEthGifData.ThumbnailURL), thumbnailURLWithoutSubdomain(previewData.ThumbnailURL))
 
 	invalidGiphyLink := "https://giphy.com/gifs/this-gif-does-not-exist-44444"
 	_, err = GetGiphyPreviewData(invalidGiphyLink)
 	require.Error(t, err)
 
-
 	mediaLink := "https://media.giphy.com/media/lcG3qwtTKSNI2i5vst/giphy.gif"
 
 	mediaLinkData, _ := GetGiphyPreviewData(mediaLink)
 
-	require.Equal(t, thumbnailUrlWithoutSubdomain(mediaLinkData.ThumbnailURL), thumbnailUrlWithoutSubdomain(previewData.ThumbnailURL))
+	require.Equal(t, thumbnailURLWithoutSubdomain(mediaLinkData.ThumbnailURL), thumbnailURLWithoutSubdomain(previewData.ThumbnailURL))
 }
 
 func TestGetGiphyLongURL(t *testing.T) {
@@ -78,7 +77,6 @@ func TestGetGiphyLongURL(t *testing.T) {
 	_, err = GetGiphyLongURL("http://gph.se/bogus-url-but-correct-domain")
 	require.Error(t, err)
 }
-
 
 func TestGetGiphyShortURLPreviewData(t *testing.T) {
 	shortURL := "https://gph.is/g/aXLyK7P"

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -48,3 +48,22 @@ func TestGetGiphyPreviewData(t *testing.T) {
 	_, err = GetGiphyPreviewData(invalidGiphyLink)
 	require.Error(t, err)
 }
+
+func TestGetTenorPreviewData(t *testing.T) {
+	validTenorLink := "https://tenor.com/view/robot-dance-do-you-love-me-boston-boston-dynamics-dance-gif-19998728"
+	previewData, err := GetTenorPreviewData(validTenorLink)
+
+	gifData := LinkPreviewData{
+		Site:         "Tenor",
+		Title:        "Annihere",
+		ThumbnailURL: "https://media.tenor.com/images/975f6b95d188c277ebba62d9b5511685/tenor.gif",
+	}
+	require.NoError(t, err)
+	require.Equal(t, gifData.Site, previewData.Site)
+	require.Equal(t, gifData.Title, previewData.Title)
+	require.Equal(t, gifData.ThumbnailURL, previewData.ThumbnailURL)
+
+	invalidTenorLink := "https://giphy.com/gifs/this-gif-does-not-exist-44444"
+	_, err = GetTenorPreviewData(invalidTenorLink)
+	require.Error(t, err)
+}

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -30,3 +30,21 @@ func TestGetLinkPreviewData(t *testing.T) {
 	require.Error(t, err)
 
 }
+
+func TestGetGiphyPreviewData(t *testing.T) {
+	validGiphyLink := "https://giphy.com/gifs/FullMag-robot-boston-dynamics-dance-lcG3qwtTKSNI2i5vst"
+	previewData, err := GetGiphyPreviewData(validGiphyLink)
+	bostonDynamicsEthGifData := LinkPreviewData{
+		Site:         "GIPHY",
+		Title:        "Boston Dynamics Yes GIF by FullMag - Find & Share on GIPHY",
+		ThumbnailURL: "https://media1.giphy.com/media/lcG3qwtTKSNI2i5vst/giphy.gif",
+	}
+	require.NoError(t, err)
+	require.Equal(t, bostonDynamicsEthGifData.Site, previewData.Site)
+	require.Equal(t, bostonDynamicsEthGifData.Title, previewData.Title)
+	require.Equal(t, bostonDynamicsEthGifData.ThumbnailURL, previewData.ThumbnailURL)
+
+	invalidGiphyLink := "https://giphy.com/gifs/this-gif-does-not-exist-44444"
+	_, err = GetGiphyPreviewData(invalidGiphyLink)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Giphy and Tenor links are links to HTML sites not the actual gif source. This PR parses valid Giphy/Tenor links and use their oembed services to get gif sources from links to HTML. 

This will help us show the gifs in chat messages: https://github.com/status-im/status-react/issues/11580