### PR TITLE
compose: parametrize docker image, bind to v0.64.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ docker-image: ##@docker Build docker image (use DOCKER_IMAGE_NAME to set the ima
 		--build-arg "build_flags=$(BUILD_FLAGS)" \
 		--label "commit=$(GIT_COMMIT)" \
 		--label "author=$(AUTHOR)" \
-		-t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_CUSTOM_TAG) \
+		-t $(DOCKER_IMAGE_NAME):v$(DOCKER_IMAGE_CUSTOM_TAG) \
 		-t $(DOCKER_IMAGE_NAME):latest
 
 bootnode-image:
@@ -161,7 +161,7 @@ bootnode-image:
 		--build-arg "build_flags=$(BUILD_FLAGS)" \
 		--label "commit=$(GIT_COMMIT)" \
 		--label "author=$(AUTHOR)" \
-		-t $(BOOTNODE_IMAGE_NAME):$(DOCKER_IMAGE_CUSTOM_TAG) \
+		-t $(BOOTNODE_IMAGE_NAME):v$(DOCKER_IMAGE_CUSTOM_TAG) \
 		-t $(BOOTNODE_IMAGE_NAME):latest
 
 push-docker-images: docker-image bootnode-image
@@ -186,8 +186,8 @@ ifneq ("$(GIT_LOCAL)", "$(GIT_REMOTE)")
 	$(error The local git commit does not match the remote origin!)
 	exit 1
 endif
-	docker push $(BOOTNODE_IMAGE_NAME):latest
-	docker push $(DOCKER_IMAGE_NAME):latest
+	docker push $(BOOTNODE_IMAGE_NAME):v$(DOCKER_IMAGE_CUSTOM_TAG)
+	docker push $(DOCKER_IMAGE_NAME):v$(DOCKER_IMAGE_CUSTOM_TAG)
 
 install-os-dependencies:
 	_assets/scripts/install_deps.sh

--- a/_assets/compose/bootnode/Makefile
+++ b/_assets/compose/bootnode/Makefile
@@ -10,13 +10,14 @@ UID = $(shell id -u)
 GID = $(shell id -g)
 
 # Settings
-export LOG_LEVEL       ?= 3
-export LISTEN_PORT     ?= 30301
-export API_MODULES     ?= eth,net,web3,admin
-export CONTAINER_NAME  ?= status-go-bootnode
-export CONTAINER_IMAGE ?= statusteam/bootnode:latest
+export CONTAINER_TAG  ?= v0.64.3
+export CONTAINER_IMG  ?= statusteam/bootnode
+export CONTAINER_NAME ?= status-go-bootnode
+export LOG_LEVEL      ?= 3
+export LISTEN_PORT    ?= 30301
+export API_MODULES    ?= eth,net,web3,admin
 # Necessary to make bootnode available publicly
-export PUBLIC_IP       ?= $(shell curl -s https://ipecho.net/plain)
+export PUBLIC_IP      ?= $(shell curl -s https://ipecho.net/plain)
 
 all: checks start show info enode
 
@@ -65,7 +66,7 @@ keys/nodekey: keys ##@ Generate a node key
 		-u $(UID):$(GID) \
 		--entrypoint=bootnode \
 		-v $(PWD)/keys:/keys:rw \
-		$(CONTAINER_IMAGE) \
+		$(CONTAINER_IMG) \
 		-genkey=/keys/nodekey
 	@echo "$(GRN)Created key for Bootnode: keys/nodekey$(RST)"
 
@@ -74,7 +75,7 @@ keys/nodeaddr: keys ##@ Save node address for given key
 		-u $(UID):$(GID) \
 		--entrypoint=sh \
 		-v $(PWD)/keys:/keys:rw \
-		$(CONTAINER_IMAGE) \
+		$(CONTAINER_IMG) \
 		-c 'bootnode -writeaddress -nodekey=/keys/nodekey > /keys/nodeaddr'
 
 show:

--- a/_assets/compose/bootnode/README.md
+++ b/_assets/compose/bootnode/README.md
@@ -29,8 +29,10 @@ All settings are passed through environment variables:
 * `LISTEN_PORT` - Bootnode UDP port, by default it's `30301` but you might want to use `443`.
 * `RPC_PORT` - Control port making it possible to use the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC).
 * `API_MODULES` - API modules to be made available via the `RPC_PORT`.
-* `CONTAINER_NAME` - Name of the container that will be created.
-* `LOG_LEVEL` - Set level of log messages to show. (__default:__ `1=ERROR`, `2=WARN`, `3=INFO`, `4=DEBUG`, `5=TRACE`)
+* `CONTAINER_IMG` - Name of the container image. (default: `statusteam/status-go`)
+* `CONTAINER_TAG` - Tag of container image to use. (default: `v0.64.3`)
+* `CONTAINER_NAME` - Name of the container that will be created. (default: `status-go-bootnode`)
+* `LOG_LEVEL` - Set level of log messages to show. (valid: `1=ERROR`, `2=WARN`, `3=INFO`, `4=DEBUG`, `5=TRACE`)
 
 # Known Issues
 

--- a/_assets/compose/bootnode/docker-compose.yml
+++ b/_assets/compose/bootnode/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   mailserver:
     container_name: '${CONTAINER_NAME}'
-    image: ${CONTAINER_IMAGE}
+    image: '${CONTAINER_IMG}:${CONTAINER_TAG}'
     entrypoint: bootnode
     restart: always
     command: |

--- a/_assets/compose/mailserver/Makefile
+++ b/_assets/compose/mailserver/Makefile
@@ -7,12 +7,14 @@ RST := $(shell tput -Txterm sgr0)
 BLD := $(shell tput bold)
 
 # Settings
+export CONTAINER_TAG  ?= v0.64.3
+export CONTAINER_IMG  ?= statusteam/status-go
+export CONTAINER_NAME ?= status-go-mailserver
 export LOG_LEVEL      ?= INFO
 export LISTEN_PORT    ?= 30303
 export METRICS_PORT   ?= 9090
 export RPC_PORT       ?= 8545
 export API_MODULES    ?= eth,net,web3,admin,mailserver
-export CONTAINER_NAME ?= status-go-mailserver
 export DATA_PATH      ?= /var/tmp/status-go-mail
 export REGISTER_TOPIC ?= whispermail
 export MAIL_PASSWORD  ?= status-offline-inbox

--- a/_assets/compose/mailserver/README.md
+++ b/_assets/compose/mailserver/README.md
@@ -31,11 +31,13 @@ All settings are passed through environment variables:
 * `METRICS_PORT` - Port exposing metrics in [Prometheus](https://prometheus.io/docs/concepts/data_model/) format
 * `RPC_PORT` - Control port making it possible to use the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC).
 * `API_MODULES` - API modules to be made available via the `RPC_PORT`.
-* `DATA_PATH` - Location of Mailserver storage and keys. (Default: `/var/tmp/status-go-mail`)
-* `CONTAINER_NAME` - Name of the container that will be created.
-* `REGISTER_TOPIC` - Mynamic mailserver discovery topic. (Default: `whispermail`)
-* `MAIL_PASSWORD` - Basic HTTP auth password for mailserver. (Default: `status-offline-inbox`)
-* `LOG_LEVEL` - Set level of log messages to show. (`ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`)
+* `DATA_PATH` - Location of Mailserver storage and keys. (default: `/var/tmp/status-go-mail`)
+* `CONTAINER_IMG` - Name of the container image. (default: `statusteam/status-go`)
+* `CONTAINER_TAG` - Tag of container image to use. (default: `v0.64.3`) 
+* `CONTAINER_NAME` - Name of the container that will be created. (default: `status-go-mailserver`)
+* `REGISTER_TOPIC` - Mynamic mailserver discovery topic. (default: `whispermail`)
+* `MAIL_PASSWORD` - Basic HTTP auth password for mailserver. (default: `status-offline-inbox`)
+* `LOG_LEVEL` - Set level of log messages to show. (valid: `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`)
 
 The generated configuration file end up under `${DATA_PATH}/config.json`.
 

--- a/_assets/compose/mailserver/docker-compose.yml
+++ b/_assets/compose/mailserver/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   mailserver:
     container_name: '${CONTAINER_NAME}'
-    image: statusteam/status-go:latest
+    image: '${CONTAINER_IMG}:${CONTAINER_TAG}'
     entrypoint: statusd
     restart: always
     command: |


### PR DESCRIPTION
While working with @jinhojang6 on better node running instructions we found out that `latest` tag was borked.

Using `latest` tag is dangerous for non-technical users.
And updating `latest` tag willy-nilly is also bad.