### PR TITLE
Don't leak goroutines on decorator

### DIFF
--- a/waku/waku.go
+++ b/waku/waku.go
@@ -595,9 +595,9 @@ func (w *Waku) notifyPeersAboutTopicInterestChange(topicInterest []common.TopicT
 }
 
 func (w *Waku) getPeers() []common.Peer {
+	w.peerMu.Lock()
 	arr := make([]common.Peer, len(w.peers))
 	i := 0
-	w.peerMu.Lock()
 	for p := range w.peers {
 		arr[i] = p
 		i++

--- a/whisper/whisper.go
+++ b/whisper/whisper.go
@@ -459,9 +459,9 @@ func (whisper *Whisper) notifyPeersAboutBloomFilterChange(bloom []byte) {
 }
 
 func (whisper *Whisper) getPeers() []*Peer {
+	whisper.peerMu.Lock()
 	arr := make([]*Peer, len(whisper.peers))
 	i := 0
-	whisper.peerMu.Lock()
 	for p := range whisper.peers {
 		arr[i] = p
 		i++


### PR DESCRIPTION
When an error occours (or the peer disconnect), we return from decorator
as an error is published to the chan.
There are though still 5 or 6 goroutines that want to write on that
channel and at least 3/4 of them will be hanging, leaving them stuck
publishing on the chan.
This though is probably not the cause of
https://github.com/status-im/infra-eth-cluster/issues/39
fills up the stack trace with hung go routines.