### PR TITLE
using zap.NewNop() ignores configured log level

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -252,7 +252,16 @@ func (b *GethStatusBackend) startNodeWithKey(acc multiaccounts.Account, password
 		return err
 	}
 
-	if err := logutils.OverrideRootLogWithConfig(conf, false); err != nil {
+	logSettings := logutils.LogSettings{
+		Enabled:         conf.LogEnabled,
+		MobileSystem:    conf.LogMobileSystem,
+		Level:           conf.LogLevel,
+		File:            conf.LogFile,
+		MaxSize:         conf.LogMaxSize,
+		MaxBackups:      conf.LogMaxBackups,
+		CompressRotated: conf.LogCompressRotated,
+	}
+	if err := logutils.OverrideRootLogWithConfig(logSettings, false); err != nil {
 		return err
 	}
 
@@ -312,7 +321,17 @@ func (b *GethStatusBackend) startNodeWithAccount(acc multiaccounts.Account, pass
 	if err != nil {
 		return err
 	}
-	if err := logutils.OverrideRootLogWithConfig(conf, false); err != nil {
+
+	logSettings := logutils.LogSettings{
+		Enabled:         conf.LogEnabled,
+		MobileSystem:    conf.LogMobileSystem,
+		Level:           conf.LogLevel,
+		File:            conf.LogFile,
+		MaxSize:         conf.LogMaxSize,
+		MaxBackups:      conf.LogMaxBackups,
+		CompressRotated: conf.LogCompressRotated,
+	}
+	if err := logutils.OverrideRootLogWithConfig(logSettings, false); err != nil {
 		return err
 	}
 	b.account = &acc

--- a/cmd/populate-db/main.go
+++ b/cmd/populate-db/main.go
@@ -262,8 +262,17 @@ func setupLogging(config *params.NodeConfig) {
 		config.LogLevel = *logLevel
 	}
 
+	logSettings := logutils.LogSettings{
+		Enabled:         config.LogEnabled,
+		MobileSystem:    config.LogMobileSystem,
+		Level:           config.LogLevel,
+		File:            config.LogFile,
+		MaxSize:         config.LogMaxSize,
+		MaxBackups:      config.LogMaxBackups,
+		CompressRotated: config.LogCompressRotated,
+	}
 	colors := !(*logWithoutColors) && terminal.IsTerminal(int(os.Stdin.Fd()))
-	if err := logutils.OverrideRootLogWithConfig(config, colors); err != nil {
+	if err := logutils.OverrideRootLogWithConfig(logSettings, colors); err != nil {
 		stdlog.Fatalf("Error initializing logger: %v", err)
 	}
 }

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -255,8 +255,17 @@ func setupLogging(config *params.NodeConfig) {
 		config.LogLevel = *logLevel
 	}
 
+	logSettings := logutils.LogSettings{
+		Enabled:         config.LogEnabled,
+		MobileSystem:    config.LogMobileSystem,
+		Level:           config.LogLevel,
+		File:            config.LogFile,
+		MaxSize:         config.LogMaxSize,
+		MaxBackups:      config.LogMaxBackups,
+		CompressRotated: config.LogCompressRotated,
+	}
 	colors := !(*logWithoutColors) && terminal.IsTerminal(int(os.Stdin.Fd()))
-	if err := logutils.OverrideRootLogWithConfig(config, colors); err != nil {
+	if err := logutils.OverrideRootLogWithConfig(logSettings, colors); err != nil {
 		stdlog.Fatalf("Error initializing logger: %v", err)
 	}
 }

--- a/logutils/logrotation.go
+++ b/logutils/logrotation.go
@@ -1,7 +1,7 @@
 package logutils
 
 import (
-	lumberjack "gopkg.in/natefinch/lumberjack.v2"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/ethereum/go-ethereum/log"
 )

--- a/logutils/override.go
+++ b/logutils/override.go
@@ -5,28 +5,36 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/log"
-
-	"github.com/status-im/status-go/params"
 )
 
+type LogSettings struct {
+	Enabled         bool
+	MobileSystem    bool
+	Level           string
+	File            string
+	MaxSize         int
+	MaxBackups      int
+	CompressRotated bool
+}
+
 // OverrideWithStdLogger overwrites ethereum's root logger with a logger from golang std lib.
-func OverrideWithStdLogger(config *params.NodeConfig) error {
-	return enableRootLog(config.LogLevel, NewStdHandler(log.LogfmtFormat()))
+func OverrideWithStdLogger(logLevel string) error {
+	return enableRootLog(logLevel, NewStdHandler(log.LogfmtFormat()))
 }
 
 // OverrideRootLogWithConfig derives all configuration from params.NodeConfig and configures logger using it.
-func OverrideRootLogWithConfig(config *params.NodeConfig, colors bool) error {
-	if !config.LogEnabled {
+func OverrideRootLogWithConfig(settings LogSettings, colors bool) error {
+	if !settings.Enabled {
 		return nil
 	}
-	if config.LogMobileSystem {
-		return OverrideWithStdLogger(config)
+	if settings.MobileSystem {
+		return OverrideWithStdLogger(settings.Level)
 	}
-	return OverrideRootLog(config.LogEnabled, config.LogLevel, FileOptions{
-		Filename:   config.LogFile,
-		MaxSize:    config.LogMaxSize,
-		MaxBackups: config.LogMaxBackups,
-		Compress:   config.LogCompressRotated,
+	return OverrideRootLog(settings.Enabled, settings.Level, FileOptions{
+		Filename:   settings.File,
+		MaxSize:    settings.MaxSize,
+		MaxBackups: settings.MaxBackups,
+		Compress:   settings.CompressRotated,
 	}, colors)
 
 }

--- a/protocol/encryption/publisher/publisher.go
+++ b/protocol/encryption/publisher/publisher.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/logutils"
 )
 
 const (
@@ -32,7 +33,7 @@ type Publisher struct {
 
 func New(logger *zap.Logger) *Publisher {
 	if logger == nil {
-		logger = zap.NewNop()
+		logger = logutils.ZapLogger()
 	}
 
 	return &Publisher{

--- a/waku/waku.go
+++ b/waku/waku.go
@@ -38,13 +38,13 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/waku/common"
 	v0 "github.com/status-im/status-go/waku/v0"
 	v1 "github.com/status-im/status-go/waku/v1"
@@ -116,7 +116,7 @@ type Waku struct {
 // New creates a Waku client ready to communicate through the Ethereum P2P network.
 func New(cfg *Config, logger *zap.Logger) *Waku {
 	if logger == nil {
-		logger = zap.NewNop()
+		logger = logutils.ZapLogger()
 	}
 
 	logger.Debug("starting waku with config", zap.Any("config", cfg))
@@ -1331,7 +1331,7 @@ func (w *Waku) addAndBridge(envelope *common.Envelope, isP2P bool, bridged bool)
 	if sent > now {
 		if sent-common.DefaultSyncAllowance > now {
 			common.EnvelopesCacheFailedCounter.WithLabelValues("in_future").Inc()
-			log.Warn("envelope created in the future", "hash", envelope.Hash())
+			w.logger.Warn("envelope created in the future", zap.ByteString("hash", envelope.Hash().Bytes()))
 			return false, common.TimeSyncError(errors.New("envelope from future"))
 		}
 		// recalculate PoW, adjusted for the time difference, plus one second for latency
@@ -1341,10 +1341,10 @@ func (w *Waku) addAndBridge(envelope *common.Envelope, isP2P bool, bridged bool)
 	if envelope.Expiry < now {
 		if envelope.Expiry+common.DefaultSyncAllowance*2 < now {
 			common.EnvelopesCacheFailedCounter.WithLabelValues("very_old").Inc()
-			log.Warn("very old envelope", "hash", envelope.Hash())
+			w.logger.Warn("very old envelope", zap.ByteString("hash", envelope.Hash().Bytes()))
 			return false, common.TimeSyncError(errors.New("very old envelope"))
 		}
-		log.Debug("expired envelope dropped", "hash", envelope.Hash().Hex())
+		w.logger.Debug("expired envelope dropped", zap.ByteString("hash", envelope.Hash().Bytes()))
 		common.EnvelopesCacheFailedCounter.WithLabelValues("expired").Inc()
 		return false, nil // drop envelope without error
 	}
@@ -1383,10 +1383,8 @@ func (w *Waku) addAndBridge(envelope *common.Envelope, isP2P bool, bridged bool)
 	}
 
 	if alreadyCached {
-		log.Trace("w envelope already cached", "hash", envelope.Hash().Hex())
 		common.EnvelopesCachedCounter.WithLabelValues("hit").Inc()
 	} else {
-		log.Trace("cached w envelope", "hash", envelope.Hash().Hex())
 		common.EnvelopesCachedCounter.WithLabelValues("miss").Inc()
 		common.EnvelopesSizeMeter.Observe(float64(envelope.Size()))
 		w.postEvent(envelope, isP2P) // notify the local node about the new message
@@ -1402,7 +1400,7 @@ func (w *Waku) addAndBridge(envelope *common.Envelope, isP2P bool, bridged bool)
 		// In particular, if a node is a lightweight node,
 		// it should not bridge any envelopes.
 		if !isP2P && !bridged && w.bridge != nil {
-			log.Debug("bridging envelope from Waku", "hash", envelope.Hash().Hex())
+			w.logger.Debug("bridging envelope from Waku", zap.ByteString("hash", envelope.Hash().Bytes()))
 			_, in := w.bridge.Pipe()
 			in <- envelope
 			common.BridgeSent.Inc()


### PR DESCRIPTION
Our hosts are flooded with `DEBUG` level logs about each and every message multiplied by N number of log messages.