### PR TITLE
[wallet] Avoid some unnecessary RPC requests

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -50,7 +50,8 @@ func (api *API) GetTransfersByAddress(ctx context.Context, address common.Addres
 			return nil, err
 		}
 
-		if block == nil {
+		// if zero block was already checked there is nothing to find more
+		if block == nil || big.NewInt(0).Cmp(block) == 0 {
 			return castToTransferViews(rst), nil
 		}
 

--- a/services/wallet/balance.go
+++ b/services/wallet/balance.go
@@ -24,13 +24,6 @@ func GetTokensBalances(parent context.Context, client *ethclient.Client, account
 		mu       sync.Mutex
 		response = map[common.Address]map[common.Address]*hexutil.Big{}
 	)
-	// requested current head to request balance on the same block number
-	ctx, cancel := context.WithTimeout(parent, requestTimeout)
-	header, err := client.HeaderByNumber(ctx, nil)
-	cancel()
-	if err != nil {
-		return nil, err
-	}
 	for _, token := range tokens {
 		caller, err := ierc20.NewIERC20Caller(token, client)
 		token := token
@@ -43,8 +36,7 @@ func GetTokensBalances(parent context.Context, client *ethclient.Client, account
 			group.Add(func(parent context.Context) error {
 				ctx, cancel := context.WithTimeout(parent, requestTimeout)
 				balance, err := caller.BalanceOf(&bind.CallOpts{
-					BlockNumber: header.Number,
-					Context:     ctx,
+					Context: ctx,
 				}, account)
 				cancel()
 				// We don't want to return an error here and prevent

--- a/services/wallet/commands.go
+++ b/services/wallet/commands.go
@@ -41,7 +41,7 @@ func (c *ethHistoricalCommand) Command() Command {
 func (c *ethHistoricalCommand) Run(ctx context.Context) (err error) {
 	start := time.Now()
 	totalRequests, cacheHits := c.balanceCache.getStats(c.address)
-	log.Info("balance cache before checking range", "total", totalRequests, "cached", totalRequests-cacheHits)
+	log.Info("balance cache before checking range", "total", totalRequests, "cached", totalRequests-cacheHits, "from", c.from, "to", c.to)
 	from, headers, err := findBlocksWithEthTransfers(ctx, c.client, c.balanceCache, c.eth, c.address, c.from, c.to, c.noLimit)
 
 	if err != nil {
@@ -647,6 +647,10 @@ func findFirstRange(c context.Context, account common.Address, initialTo *big.In
 	from := big.NewInt(0)
 	to := initialTo
 	goal := uint64(20)
+
+	if from.Cmp(to) == 0 {
+		return to, nil
+	}
 
 	firstNonce, err := client.NonceAt(c, account, to)
 	log.Info("find range with 20 <= len(tx) <= 25", "account", account, "firstNonce", firstNonce, "from", from, "to", to)

--- a/services/wallet/concurrent.go
+++ b/services/wallet/concurrent.go
@@ -111,11 +111,17 @@ func checkRanges(parent context.Context, client reactorClient, cache BalanceCach
 			if lb.Cmp(hb) == 0 {
 				log.Debug("balances are equal", "from", from, "to", to)
 
-				ln, err := client.NonceAt(ctx, account, from)
+				hn, err := client.NonceAt(ctx, account, to)
 				if err != nil {
 					return err
 				}
-				hn, err := client.NonceAt(ctx, account, to)
+				// if nonce is zero in a newer block then there is no need to check an older one
+				if hn == 0 {
+					log.Debug("zero nonce", "to", to)
+					return nil
+				}
+
+				ln, err := client.NonceAt(ctx, account, from)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Three optimisations useful for an account with no history.
- avoid making RPC request for `zero - zero` range
- avoid checking of nonce for a lower block in the range if it is zero in a higher block 
- on `wallet_getTransfersByAddress` scanning of history is skipped if zero block is already reached
- no need to fetch block num before fetching token balances

status: ready