### PR TITLE
❌ Disable Medium.com unfurling

### DIFF
--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -99,11 +99,13 @@ func LinkPreviewWhitelist() []Site {
 			Address:   "github.com",
 			ImageSite: false,
 		},
-		Site{
-			Title:     "Medium",
-			Address:   "medium.com",
-			ImageSite: false,
-		},
+		// Medium unfurling is failing - https://github.com/status-im/status-go/issues/2192
+		//
+		// Site{
+		// 	Title:     "Medium",
+		// 	Address:   "medium.com",
+		// 	ImageSite: false,
+		// },
 	}
 }
 
@@ -266,7 +268,7 @@ func GetLinkPreviewData(link string) (previewData LinkPreviewData, err error) {
 	switch hostname {
 	case "youtube.com", "youtu.be", "www.youtube.com":
 		return GetYoutubePreviewData(link)
-	case "github.com", "our.status.im", "medium.com":
+	case "github.com", "our.status.im":
 		return GetGenericLinkPreviewData(link)
 	case "giphy.com", "media.giphy.com":
 		return GetGiphyPreviewData(link)

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -135,17 +135,19 @@ func TestStatusLinkPreviewData(t *testing.T) {
 	require.Equal(t, statusSecurityAudit.ThumbnailURL, previewData.ThumbnailURL)
 }
 
-func TestMediumLinkPreviewData(t *testing.T) {
+// Medium unfurling is failing - https://github.com/status-im/status-go/issues/2192
+//
+// func TestMediumLinkPreviewData(t *testing.T) {
 
-	statusSecurityAudit := LinkPreviewData{
-		Site:         "Medium",
-		Title:        "A Look at the Status.im ICO Token Distribution",
-		ThumbnailURL: "https://miro.medium.com/max/700/1*Smc0y_TOL1XsofS1wxa3rg.jpeg",
-	}
+// 	statusSecurityAudit := LinkPreviewData{
+// 		Site:         "Medium",
+// 		Title:        "A Look at the Status.im ICO Token Distribution",
+// 		ThumbnailURL: "https://miro.medium.com/max/700/1*Smc0y_TOL1XsofS1wxa3rg.jpeg",
+// 	}
 
-	previewData, err := GetLinkPreviewData("https://medium.com/the-bitcoin-podcast-blog/a-look-at-the-status-im-ico-token-distribution-f5bcf7f00907")
-	require.NoError(t, err)
-	require.Equal(t, statusSecurityAudit.Site, previewData.Site)
-	require.Equal(t, statusSecurityAudit.Title, previewData.Title)
-	require.Equal(t, statusSecurityAudit.ThumbnailURL, previewData.ThumbnailURL)
-}
+// 	previewData, err := GetLinkPreviewData("https://medium.com/the-bitcoin-podcast-blog/a-look-at-the-status-im-ico-token-distribution-f5bcf7f00907")
+// 	require.NoError(t, err)
+// 	require.Equal(t, statusSecurityAudit.Site, previewData.Site)
+// 	require.Equal(t, statusSecurityAudit.Title, previewData.Title)
+// 	require.Equal(t, statusSecurityAudit.ThumbnailURL, previewData.ThumbnailURL)
+// }


### PR DESCRIPTION
Temporary measure to disable Medium.com link unfurling, because something has changed on Medium's end, and my tests were failing because of that.

* Medium Issue: https://github.com/status-im/status-go/issues/2192
* Companion React PR: https://github.com/status-im/status-react/pull/11980
