### PR TITLE
Added new make migration command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,3 +367,10 @@ clean-mailserver-systemd: ##@Easy Clean your systemd service for running a mails
 
 clean-mailserver-docker: ##@Easy Clean your Docker container running a mailserver
 	@cd _assets/compose/mailserver && $(MAKE) clean
+
+DEFAULT_MIGRATION_PATH := appdatabase/migrations/sql/
+UNIX_TIMESTAMP := $(shell date +%s)
+migration:
+	@echo >> $(DEFAULT_MIGRATION_PATH)$(UNIX_TIMESTAMP)_$(DESC).up.sql
+	@echo created $(DEFAULT_MIGRATION_PATH)$(UNIX_TIMESTAMP)_$(DESC).up.sql
+	## TODO(samyoul) option to set and/or overwrite migration path

--- a/Makefile
+++ b/Makefile
@@ -368,9 +368,8 @@ clean-mailserver-systemd: ##@Easy Clean your systemd service for running a mails
 clean-mailserver-docker: ##@Easy Clean your Docker container running a mailserver
 	@cd _assets/compose/mailserver && $(MAKE) clean
 
-DEFAULT_MIGRATION_PATH := appdatabase/migrations/sql/
-UNIX_TIMESTAMP := $(shell date +%s)
+## TODO(samyoul) option to set and/or overwrite migration path
+migration: DEFAULT_MIGRATION_PATH := appdatabase/migrations/sql/
+migration: UNIX_TIMESTAMP := $(shell date +%s)
 migration:
-	@echo >> $(DEFAULT_MIGRATION_PATH)$(UNIX_TIMESTAMP)_$(DESC).up.sql
-	@echo created $(DEFAULT_MIGRATION_PATH)$(UNIX_TIMESTAMP)_$(DESC).up.sql
-	## TODO(samyoul) option to set and/or overwrite migration path
+	touch $(DEFAULT_MIGRATION_PATH)$(UNIX_TIMESTAMP)_$(DESC).up.sql


### PR DESCRIPTION
## What's changed

A new `make` command

```sh
$ make migration DESC=add_new_columns_to_table
created appdatabase/migrations/sql/1618416974_add_new_columns_to_table.up.sql
```

## Why make the change

It is annoying to manually make a new migration file every time I want to make a new unique migration. This is better 😄 