### PR TITLE
Added custom path and default protocol path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,8 +368,11 @@ clean-mailserver-systemd: ##@Easy Clean your systemd service for running a mails
 clean-mailserver-docker: ##@Easy Clean your Docker container running a mailserver
 	@cd _assets/compose/mailserver && $(MAKE) clean
 
-## TODO(samyoul) option to set and/or overwrite migration path
-migration: DEFAULT_MIGRATION_PATH := appdatabase/migrations/sql/
-migration: UNIX_TIMESTAMP := $(shell date +%s)
+UNIX_TIMESTAMP := $(shell date +%s)
+migration: PATH := appdatabase/migrations/sql
 migration:
-	touch $(DEFAULT_MIGRATION_PATH)$(UNIX_TIMESTAMP)_$(DESC).up.sql
+	touch $(PATH)/$(UNIX_TIMESTAMP)_$(D).up.sql
+
+migration-protocol: DEFAULT_PROTOCOL_PATH := protocol/migrations/sqlite
+migration-protocol:
+	touch $(DEFAULT_PROTOCOL_PATH)/$(UNIX_TIMESTAMP)_$(D).up.sql

--- a/Makefile
+++ b/Makefile
@@ -368,11 +368,10 @@ clean-mailserver-systemd: ##@Easy Clean your systemd service for running a mails
 clean-mailserver-docker: ##@Easy Clean your Docker container running a mailserver
 	@cd _assets/compose/mailserver && $(MAKE) clean
 
-UNIX_TIMESTAMP := $(shell date +%s)
 migration: PATH := appdatabase/migrations/sql
 migration:
-	touch $(PATH)/$(UNIX_TIMESTAMP)_$(D).up.sql
+	touch $(PATH)/$(shell date +%s)_$(D).up.sql
 
 migration-protocol: DEFAULT_PROTOCOL_PATH := protocol/migrations/sqlite
 migration-protocol:
-	touch $(DEFAULT_PROTOCOL_PATH)/$(UNIX_TIMESTAMP)_$(D).up.sql
+	touch $(DEFAULT_PROTOCOL_PATH)/$(shell date +%s)_$(D).up.sql


### PR DESCRIPTION
## What has changed

Improved the `make migration` command to:

- Replace `DESC` flag with `D`
- Added an over-writable default `PATH` flag
- Added default protocol migration target `make migration-protocol`

## Why make the change

Because it is useful to generate a migration in any directory you'd like.

## Usage

```
$ make migration D="added_columm_to_table"
touch appdatabase/migrations/sql/1618502237_added_columm_to_table.up.sql

$ make migration D="added_columm_to_table" PATH="some/custom/path"
touch some/custom/path/1618502237_added_columm_to_table.up.sql

$ make migration-protocol D="add_goats_to_boats"
touch protocol/migrations/sqlite/1618502450_add_goats_to_boats.up.sql
```