### PR TITLE
[WIP] Add user-facing explainer

### DIFF
--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -13,7 +13,7 @@ Status is an open-source platform. To verify that the app only collects and shar
 
 In detail this means the app can collect and share:
 - Navigation events
-- Screens that is navigated to
+- Screens that are navigated to
 - Action events (for example button clicks, list swipes, switch toggles, etc)
 - Time events are created
 - Operating System

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -5,7 +5,7 @@ _______
 
 _______
 
-Starting release 1.14, the Status mobile app asks to share privacy-preserving, end-to-end encrypted data about how you use Status. Data is only ever shared if you opt in to doing so, you can review all data before it is sent and it is shared over Status' peer-to-peer network (Waku), just like a 1:1 message.
+Starting release 1.14, the Status mobile app asks to share data about how you use Status. Data is only ever shared if you opt in to doing so, you can review all data before it is sent and it is shared over Status' peer-to-peer network (Waku), just like a 1:1 message.
 
 Sharing data is strictly opt-in, and can be changed at any times in Settings in the app.
 
@@ -27,7 +27,7 @@ In detail this means the app can collect and share:
 - Time since last batch sent
 
 For any data to be collected and shared, it needs to meet the rules set in the validator script. By policy of Status' Core Contributors, rules set in the validator script need to be assessed as posing a non-existent to low threat by being in:
-- local storage over time **(Specify what worst case can be and when this occurs)**
+- local storage over time
 - aggregated storage from Status over time
 
 ### What will never be shared

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -1,5 +1,5 @@
 
-# Anonymous usage data
+# Status usage data
 Starting release 1.14, the Status mobile app asks to share anonymous end-to-end encrypted data about how you use Status. Data is only ever shared if you opt in to doing so, you can review all data before it is sent and it is shared anonymously over Waku, just like a 1:1 message.
 
 Sharing data is strictly opt-in, and can be changed at any times in Settings in the app.
@@ -23,7 +23,7 @@ In detail this means the app can collect and share:
 - Time since last data message sent
 
 ### What will never be shared
-No data will be shared unless you opt-in. Furthermore, Status commits to never collect identifiable data in its broadest sense. This means that we will never collect anything that can be linked back to you. Including but not limited to:
+No data will be shared unless you opt-in. Furthermore, Status commits to never collect identifiable data in its broadest sense. This means that we will never collect anything that we believe can be linked back to you. Including but not limited to:
 - IP addresses
 - Random name
 - Chat key
@@ -39,7 +39,7 @@ No data will be shared unless you opt-in. Furthermore, Status commits to never c
 While we employ a ‘can’t be evil’ approach. We highly recommend that you employ a ‘don’t trust, but verify’ approach. In this case, the above data can technically be logged, stored and shared. In order to verify that this does not happen, view the rules defined to store metrics data in the [source code](https://github.com/status-im/status-go/blob/develop/appmetrics/validators.go).
 
 ### Purpose of the data
-Anonymous, aggregated data is used to inform product development. Given our principles, the type of data that is collected and its anonymous nature, there is no incentive for Status or other parties to use the data for any other purpose.
+Aggregated data is used to inform product development. Given our principles, the type of data that is collected and its rudimentary nature, there is no incentive for Status or other parties to use the data for any other purpose.
 
 
 ### Viewing the data

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -49,7 +49,7 @@ The above data can technically be logged, stored and shared. In order to verify 
 Moreover, while we made a best effort to make data collection as privacy-preserving as possible, we cannot guarantee that there are no ways to de-anonymous collected data. **If you find yourself at risk if your identity were to be uncovered: don't enable sharing data.**
 
 ### Purpose of the data
-Aggregated data is used to inform product development. Given our principles, the type of data that is collected and its rudimentary nature, there is no incentive for Status or other parties to use the data for any other purpose.
+Aggregated data is used to inform product development. Given our principles, the type of data that is collected and its rudimentary nature, there is no incentive for Status or other parties to use the data for any other purpose. Status will never use these data for profit.
 
 
 ### Viewing the data

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -5,7 +5,7 @@ Starting release 1.14, the Status mobile app asks to share anonymous end-to-end 
 Sharing data is strictly opt-in, and can be changed at any times in Settings in the app.
 
 ### What is shared (Opt-in)
-Status is an open-source platform. To verify that the app only collects and shares the events and metadata listed below, you can view the rules defined to store metrics data in the [source code](https://github.com/status-im/status-go/blob/develop/appmetrics/validators.go).
+Status is an open-source platform. To verify that the app only collects and shares the events and metadata listed below, you can view the rules set to store metrics data in the [source code](https://github.com/status-im/status-go/blob/develop/appmetrics/validators.go).
 
 - Your interactions with the app like clicks and screenviews
 - Background activity and internal processes
@@ -21,6 +21,10 @@ In detail this means the app can collect and share:
 - Batch ID
 - Time since last session
 - Time since last data message sent
+
+For any data to be collected and shared, it needs to meet the rules set in the validator script. By policy of Status' Core Contributors, rules set in the validator script need to be assessed as posing a non-existent to low threat by being in:
+- local storage over time **(Specify what worst case can be and when this occurs)**
+- aggregated storage from Status over time
 
 ### What will never be shared
 No data will be shared unless you opt-in. Furthermore, Status commits to never collect identifiable data in its broadest sense. This means that we will never collect anything that we believe can be linked back to you. Including but not limited to:

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -52,8 +52,6 @@ As of writing, we plan to make a Dashboard that shows the aggregated data public
 _________
 
 # How it works
-## App Metrics
-
 `appmetrics` is a way to capture and transfer app usage data, anonymously over Waku to a Status managed key.
 
 

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -9,7 +9,7 @@ Status is an open-source platform. To verify that the app only collects and shar
 
 - Your interactions with the app like clicks and screenviews
 - Background activity and internal processes
-- Settings and pre=eferences
+- Settings and preferences
 
 In detail this means the app can collect and share:
 - Navigation events
@@ -81,4 +81,3 @@ Transmission happens over Waku, and as of now, all data will be deleted locally 
 |-----------------------|--------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | navigate-to           | {:view_id: "", :params {:screen ""}} | The user navigated to one of the screens. If the `view_id` has a `_stack` suffix, it could signify a top level tab. |
 | screens/on-will-focus | {:view_id: "", :params {:screen ""}} | The user navigated to a top level tab.                                                                              |
-

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -87,3 +87,16 @@ Transmission happens over Waku, and as of now, all data is deleted locally after
 |-----------------------|--------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | navigate-to           | {:view_id: "", :params {:screen ""}} | The user navigated to one of the screens. If the `view_id` has a `_stack` suffix, it could signify a top level tab. |
 | screens/on-will-focus | {:view_id: "", :params {:screen ""}} | The user navigated to a top level tab.                                                                              |
+
+## Related PRs
+
+### `status-go`
+- [#2170 - 🎭 📊 Anonymous Metrics V0](https://github.com/status-im/status-go/pull/2170)
+- [#2195 - Added Anonymous Metrics Send Opt-In Setting](https://github.com/status-im/status-go/pull/2195)
+- [#2198 - Anon Metrics Broadcast](https://github.com/status-im/status-go/pull/2198)
+
+### `status-react`
+- [#11901 - Feature/anon metrics](https://github.com/status-im/status-react/pull/11901)
+- [#11941 - Feature/anon metrics](https://github.com/status-im/status-react/pull/11941)
+- [#11963 - 🗂️ Anon metrics batching](https://github.com/status-im/status-react/pull/11963)
+- [#12024 - 🔘 Anon metrics opt-in UI (disabled using feature flags)](https://github.com/status-im/status-react/pull/12024)

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -77,7 +77,7 @@ The interesting bit is the validation process, which serves two purposes:
 2. acts as an audit layer: anyone who wishes to check the kind of data being captured, can do so by auditing just one file: https://github.com/status-im/status-go/blob/develop/appmetrics/validators.go
 
 ### Transmission and deletion
-Transmission happens over Waku, and as of now, all data will be deleted locally after transmission, however (in future) we might want to keep a copy of the data locally.
+Transmission happens over Waku, and as of now, all data is deleted locally after transmission, however (in the future) we might want to keep a copy of the data locally. If a batch is not transmitted within 7 days, data is deleted locally.
 
 
 ## Events

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -1,6 +1,6 @@
 
 # Status usage data
-Starting release 1.14, the Status mobile app asks to share anonymous end-to-end encrypted data about how you use Status. Data is only ever shared if you opt in to doing so, you can review all data before it is sent and it is shared anonymously over Waku, just like a 1:1 message.
+Starting release 1.14, the Status mobile app asks to share privacy-preserving, end-to-end encrypted data about how you use Status. Data is only ever shared if you opt in to doing so, you can review all data before it is sent and it is shared over Status' peer-to-peer network (Waku), just like a 1:1 message.
 
 Sharing data is strictly opt-in, and can be changed at any times in Settings in the app.
 

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -1,4 +1,58 @@
-# App Metrics
+
+# Anonymous usage data
+Starting release 1.14, the Status mobile app asks to share anonymous end-to-end encrypted data about how you use Status. Data is only ever shared if you opt in to doing so, you can review all data before it is sent and it is shared anonymously over Waku, just like a 1:1 message.
+
+Sharing data is strictly opt-in, and can be changed at any times in Settings in the app.
+
+### What is shared (Opt-in)
+Status is an open-source platform. To verify that the app only collects and shares the events and metadata listed below, you can view the rules defined to store metrics data in the [source code](https://github.com/status-im/status-go/blob/develop/appmetrics/validators.go).
+
+- Your interactions with the app like clicks and screenviews
+- Background activity and internal processes
+- Settings and pre=eferences
+
+In detail this means the app can collect and share:
+- Navigation events
+- Screens that is navigated to
+- Action events (for example button clicks, list swipes, switch toggles, etc)
+- Time events are created
+- Operating System
+- App version
+- Session key
+- Time since last session
+- Time since last data message sent
+
+### What will never be shared
+No data will be shared unless you opt-in. Furthermore, Status commits to never collect identifiable data in its broadest sense. This means that we will never collect anything that can be linked back to you. Including but not limited to:
+- IP addresses
+- Random name
+- (Regular) Chat key
+- Public Ethereum addresses
+- Account balance(s)
+- Account history
+- ENS name
+- Input field entries (browser address bar, chat key/ENS entry)
+- Any content you generate (images, messages, profile picture)
+- Contacts or other (favorite) lists (wallet and browser favorites)
+- Chat, group, community memberships
+
+While we employ a ‘can’t be evil’ approach. We highly recommend that you employ a ‘don’t trust, but verify’ approach. In this case, the above data can technically be logged, stored and shared. In order to verify that this does not happen, view the rules defined to store metrics data in the [source code](https://github.com/status-im/status-go/blob/develop/appmetrics/validators.go).
+
+### Purpose of the data
+Anonymous, aggregated data is used to inform product development. Given our principles, the type of data that is collected and its anonymous nature, there is no incentive for Status or other parties to use the data for any other purpose.
+
+
+### Viewing the data
+As of writing, we plan to make a Dashboard that shows the aggregated data public; Similar to metrics.status.im. As soon as this Dashboard is available we will provide a link here. The data that is stored on your device and shared can be viewed through the interface of the app.
+
+
+
+
+
+_________
+
+# How it works
+## App Metrics
 
 `appmetrics` is a way to capture and transfer app usage data, anonymously over Waku to a Status managed key.
 

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -18,7 +18,7 @@ In detail this means the app can collect and share:
 - The time events are created
 - Operating System
 - App version
-- Session key
+- Batch ID
 - Time since last session
 - Time since last data message sent
 
@@ -26,7 +26,7 @@ In detail this means the app can collect and share:
 No data will be shared unless you opt-in. Furthermore, Status commits to never collect identifiable data in its broadest sense. This means that we will never collect anything that can be linked back to you. Including but not limited to:
 - IP addresses
 - Random name
-- (Regular) Chat key
+- Chat key
 - Public Ethereum addresses
 - Account balance(s)
 - Account history

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -1,5 +1,10 @@
 
 # Status usage data
+_______
+:warning: **We cannot guarantee that there are no ways to de-anonymous usage data you share. If you find yourself at risk if your identity were to be uncovered: don't enable sharing data!**
+
+_______
+
 Starting release 1.14, the Status mobile app asks to share privacy-preserving, end-to-end encrypted data about how you use Status. Data is only ever shared if you opt in to doing so, you can review all data before it is sent and it is shared over Status' peer-to-peer network (Waku), just like a 1:1 message.
 
 Sharing data is strictly opt-in, and can be changed at any times in Settings in the app.
@@ -19,8 +24,7 @@ In detail this means the app can collect and share:
 - Operating System
 - App version
 - Batch ID
-- Time since last session
-- Time since last data message sent
+- Time since last batch sent
 
 For any data to be collected and shared, it needs to meet the rules set in the validator script. By policy of Status' Core Contributors, rules set in the validator script need to be assessed as posing a non-existent to low threat by being in:
 - local storage over time **(Specify what worst case can be and when this occurs)**
@@ -40,7 +44,9 @@ No data will be shared unless you opt-in. Furthermore, Status commits to never c
 - Contacts or other (favorite) lists (wallet and browser favorites)
 - Chat, group, community memberships
 
-While we employ a ‘can’t be evil’ approach. We highly recommend that you employ a ‘don’t trust, but verify’ approach. In this case, the above data can technically be logged, stored and shared. In order to verify that this does not happen, view the rules defined to store metrics data in the [source code](https://github.com/status-im/status-go/blob/develop/appmetrics/validators.go).
+The above data can technically be logged, stored and shared. In order to verify that this does not happen, view the rules defined to store metrics data in the [source code](https://github.com/status-im/status-go/blob/develop/appmetrics/validators.go).
+
+Moreover, while we made a best effort to make data collection as privacy-preserving as possible, we cannot guarantee that there are no ways to de-anonymous collected data. **If you find yourself at risk if your identity were to be uncovered: don't enable sharing data.**
 
 ### Purpose of the data
 Aggregated data is used to inform product development. Given our principles, the type of data that is collected and its rudimentary nature, there is no incentive for Status or other parties to use the data for any other purpose.

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -15,7 +15,7 @@ In detail this means the app can collect and share:
 - Navigation events
 - Screens that are navigated to
 - Action events (for example button clicks, list swipes, switch toggles, etc)
-- Time events are created
+- The time events are created
 - Operating System
 - App version
 - Session key

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -58,7 +58,7 @@ As of writing, we plan to make a Dashboard that shows the aggregated data public
 _________
 
 # How it works
-`appmetrics` is a way to capture and transfer app usage data, anonymously over Waku to a Status managed key.
+`appmetrics` is a way to capture and transfer app usage data, end-to-end encrypted over Waku to a Status managed key.
 
 
 ## History

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -45,10 +45,6 @@ Anonymous, aggregated data is used to inform product development. Given our prin
 ### Viewing the data
 As of writing, we plan to make a Dashboard that shows the aggregated data public; Similar to metrics.status.im. As soon as this Dashboard is available we will provide a link here. The data that is stored on your device and shared can be viewed through the interface of the app.
 
-
-
-
-
 _________
 
 # How it works

--- a/_docs/app-metrics.md
+++ b/_docs/app-metrics.md
@@ -1,11 +1,13 @@
 
 # Status usage data
+
+_______
+ℹ️: **The release and develop (nightly) version of Status DO NOT collect in-app usage data. A service to do so has been developed and might be used in experimental builds of the app, for testing purposes and with double opt-in only. Any information in this document about data (not) collected and how the service works, only applies if you've deliberately installed an experimental build**. 
 _______
 :warning: **We cannot guarantee that there are no ways to de-anonymous usage data you share. If you find yourself at risk if your identity were to be uncovered: don't enable sharing data!**
-
 _______
 
-Starting release 1.14, the Status mobile app asks to share data about how you use Status. Data is only ever shared if you opt in to doing so, you can review all data before it is sent and it is shared over Status' peer-to-peer network (Waku), just like a 1:1 message.
+Data is only ever shared if you opt in to doing so, you can review all data before it is sent and it is shared over Status' peer-to-peer network (Waku), just like a 1:1 message.
 
 Sharing data is strictly opt-in, and can be changed at any times in Settings in the app.
 


### PR DESCRIPTION
- Added a user-facing explainer at the top of the doc as we link to this file from the UI.
- Moved all content that was already in the doc to below the divider with the heading 'How it works'