### PR TITLE
Add check that PR was tested with mobile\desktop

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -7,6 +7,7 @@ prchecklist:
   title: Pull Request Checklist
   checklist:
     - 'Have you updated the documentation, if impacted (e.g. [docs.status.im](https://docs.status.im/docs/build_status_go.html))?'
+    - 'Have you tested changes with mobile or desktop version?'
 
 stale:
   daysUntilStale: 90


### PR DESCRIPTION
Add one more item to PR check list to make clear that `status-go` prs should be tested with mobile or desktop before merging. 