### PR TITLE
iso: fix builds by using .xcframework file extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ statusgo-android: ##@cross-compile Build status-go for Android
 statusgo-ios: ##@cross-compile Build status-go for iOS
 	@echo "Building status-go for iOS..."
 	gomobile init
-	gomobile bind -v -target=ios -ldflags="-s -w" $(BUILD_FLAGS_MOBILE) -o build/bin/Statusgo.framework github.com/status-im/status-go/mobile
-	@echo "iOS framework cross compilation done in build/bin/Statusgo.framework"
+	gomobile bind -v -target=ios -ldflags="-s -w" $(BUILD_FLAGS_MOBILE) -o build/bin/Statusgo.xcframework github.com/status-im/status-go/mobile
+	@echo "iOS framework cross compilation done in build/bin/Statusgo.xcframework"
 
 statusgo-library: ##@cross-compile Build status-go as static library for current platform
 	## cmd/library/README.md explains the magic incantation behind this
@@ -195,8 +195,8 @@ generate: ##@other Regenerate assets and other auto-generated stuff
 prepare-release: clean-release
 	mkdir -p $(RELEASE_DIR)
 	mv build/bin/statusgo.aar $(RELEASE_DIR)/status-go-android.aar
-	zip -r build/bin/Statusgo.framework.zip build/bin/Statusgo.framework
-	mv build/bin/Statusgo.framework.zip $(RELEASE_DIR)/status-go-ios.zip
+	zip -r build/bin/Statusgo.xcframework.zip build/bin/Statusgo.xcframework
+	mv build/bin/Statusgo.xcframework.zip $(RELEASE_DIR)/status-go-ios.zip
 	zip -r $(RELEASE_DIR)/status-go-desktop.zip . -x *.git*
 	${MAKE} clean
 

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -55,7 +55,7 @@ pipeline {
       sh 'make statusgo-ios'
       sh 'go get golang.org/x/tools/go/packages'
       dir('build/bin') {
-        sh 'zip -r status-go-ios.zip Statusgo.framework'
+        sh 'zip -r status-go-ios.zip Statusgo.xcframework'
         sh "cp status-go-ios.zip ${env.ARTIFACT}"
       }
     } } }


### PR DESCRIPTION
Fixes:
```
gomobile: static framework name "build/bin/Statusgo.framework" missing .xcframework suffix
```
https://ci.status.im/job/status-go/job/platforms/job/ios/425/console