### PR TITLE
feature(@status-go/chat): implement search on sqlcipher (status-go side)

### DIFF
--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -588,11 +588,11 @@ func (db sqlitePersistence) MessageByChatID(chatID string, currCursor string, li
 	return result, newCursor, nil
 }
 
-// AllMessageByChatIdWhichMatchPattern returns all messages which match the search
-// term, for a given chatId in descending order.
+// AllMessageByChatIDWhichMatchPattern returns all messages which match the search
+// term, for a given chatID in descending order.
 // Ordering is accomplished using two concatenated values: ClockValue and ID.
 // These two values are also used to compose a cursor which is returned to the result.
-func (db sqlitePersistence) AllMessageByChatIdWhichMatchTerm(chatId string, searchTerm string, caseSensitive bool) ([]*common.Message, error) {
+func (db sqlitePersistence) AllMessageByChatIDWhichMatchTerm(chatID string, searchTerm string, caseSensitive bool) ([]*common.Message, error) {
 	if searchTerm == "" {
 		return nil, fmt.Errorf("empty search term")
 	}
@@ -627,7 +627,7 @@ func (db sqlitePersistence) AllMessageByChatIdWhichMatchTerm(chatId string, sear
 				NOT(m1.hide) AND m1.local_chat_id = ? %s
 			ORDER BY cursor DESC
 		`, allFields, searchCond),
-		chatId, searchTerm,
+		chatID, searchTerm,
 	)
 
 	if err != nil {
@@ -636,7 +636,7 @@ func (db sqlitePersistence) AllMessageByChatIdWhichMatchTerm(chatId string, sear
 	defer rows.Close()
 
 	var (
-		result  []*common.Message
+		result []*common.Message
 	)
 	for rows.Next() {
 		var (

--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -588,6 +588,70 @@ func (db sqlitePersistence) MessageByChatID(chatID string, currCursor string, li
 	return result, newCursor, nil
 }
 
+// AllMessageByChatIdWhichMatchPattern returns all messages which match the search
+// term, for a given chatId in descending order.
+// Ordering is accomplished using two concatenated values: ClockValue and ID.
+// These two values are also used to compose a cursor which is returned to the result.
+func (db sqlitePersistence) AllMessageByChatIdWhichMatchTerm(chatId string, searchTerm string, caseSensitive bool) ([]*common.Message, error) {
+	if searchTerm == "" {
+		return nil, fmt.Errorf("empty search term")
+	}
+
+	searchCond := ""
+	if caseSensitive {
+		searchCond = "AND m1.text LIKE '%' || ? || '%'"
+	} else {
+		searchCond = "AND LOWER(m1.text) LIKE LOWER('%' || ? || '%')"
+	}
+
+	allFields := db.tableUserMessagesAllFieldsJoin()
+
+	rows, err := db.db.Query(
+		fmt.Sprintf(`
+			SELECT
+				%s,
+				substr('0000000000000000000000000000000000000000000000000000000000000000' || m1.clock_value, -64, 64) || m1.id as cursor
+			FROM
+				user_messages m1
+			LEFT JOIN
+				user_messages m2
+			ON
+			m1.response_to = m2.id
+
+			LEFT JOIN
+			      contacts c
+			ON
+
+			m1.source = c.id
+			WHERE
+				NOT(m1.hide) AND m1.local_chat_id = ? %s
+			ORDER BY cursor DESC
+		`, allFields, searchCond),
+		chatId, searchTerm,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var (
+		result  []*common.Message
+	)
+	for rows.Next() {
+		var (
+			message common.Message
+			cursor  string
+		)
+		if err := db.tableUserMessagesScanAllFields(rows, &message, &cursor); err != nil {
+			return nil, err
+		}
+		result = append(result, &message)
+	}
+
+	return result, nil
+}
+
 // PinnedMessageByChatID returns all pinned messages for a given chatID in descending order.
 // Ordering is accomplished using two concatenated values: ClockValue and ID.
 // These two values are also used to compose a cursor which is returned to the result.

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3105,13 +3105,13 @@ func (m *Messenger) MessageByChatID(chatID, cursor string, limit int) ([]*common
 	return m.persistence.MessageByChatID(chatID, cursor, limit)
 }
 
-func (m *Messenger) AllMessageByChatIdWhichMatchTerm(chatId string, searchTerm string, caseSensitive bool) ([]*common.Message, error) {
-	_, err := m.persistence.Chat(chatId)
+func (m *Messenger) AllMessageByChatIDWhichMatchTerm(chatID string, searchTerm string, caseSensitive bool) ([]*common.Message, error) {
+	_, err := m.persistence.Chat(chatID)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.persistence.AllMessageByChatIdWhichMatchTerm(chatId, searchTerm, caseSensitive)
+	return m.persistence.AllMessageByChatIDWhichMatchTerm(chatID, searchTerm, caseSensitive)
 }
 
 func (m *Messenger) SaveMessages(messages []*common.Message) error {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3105,6 +3105,15 @@ func (m *Messenger) MessageByChatID(chatID, cursor string, limit int) ([]*common
 	return m.persistence.MessageByChatID(chatID, cursor, limit)
 }
 
+func (m *Messenger) AllMessageByChatIdWhichMatchTerm(chatId string, searchTerm string, caseSensitive bool) ([]*common.Message, error) {
+	_, err := m.persistence.Chat(chatId)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.persistence.AllMessageByChatIdWhichMatchTerm(chatId, searchTerm, caseSensitive)
+}
+
 func (m *Messenger) SaveMessages(messages []*common.Message) error {
 	return m.persistence.SaveMessages(messages)
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -490,6 +490,17 @@ func (api *PublicAPI) ChatMessages(chatID, cursor string, limit int) (*Applicati
 	}, nil
 }
 
+func (api *PublicAPI) AllChatMessagesWhichMatchTerm(chatId, searchTerm string, caseSensitive bool) (*ApplicationMessagesResponse, error) {
+	messages, err := api.service.messenger.AllMessageByChatIdWhichMatchTerm(chatId, searchTerm, caseSensitive)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ApplicationMessagesResponse{
+		Messages: messages,
+	}, nil
+}
+
 func (api *PublicAPI) ChatPinnedMessages(chatID, cursor string, limit int) (*ApplicationPinnedMessagesResponse, error) {
 	pinnedMessages, cursor, err := api.service.messenger.PinnedMessageByChatID(chatID, cursor, limit)
 	if err != nil {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -490,8 +490,8 @@ func (api *PublicAPI) ChatMessages(chatID, cursor string, limit int) (*Applicati
 	}, nil
 }
 
-func (api *PublicAPI) AllChatMessagesWhichMatchTerm(chatId, searchTerm string, caseSensitive bool) (*ApplicationMessagesResponse, error) {
-	messages, err := api.service.messenger.AllMessageByChatIdWhichMatchTerm(chatId, searchTerm, caseSensitive)
+func (api *PublicAPI) AllChatMessagesWhichMatchTerm(chatID, searchTerm string, caseSensitive bool) (*ApplicationMessagesResponse, error) {
+	messages, err := api.service.messenger.AllMessageByChatIDWhichMatchTerm(chatID, searchTerm, caseSensitive)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Searching messages by some term for a specific channel is added on the side of status-go.

Added method to the public api: AllChatMessagesWhichMatchTerm, with parameters chatId, searchTerm 
and caseSensitive respectively.


Closes #2912