### PR TITLE
Wakuv2 peer stats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/russolsen/same v0.0.0-20160222130632-f089df61f51d // indirect
 	github.com/russolsen/transit v0.0.0-20180705123435-0794b4c4505a
 	github.com/status-im/doubleratchet v3.0.0+incompatible
-	github.com/status-im/go-waku v0.0.0-20210729163508-c9d3334f2d0e
+	github.com/status-im/go-waku v0.0.0-20210918141919-49f216d40c4a
 	github.com/status-im/go-wakurelay-pubsub v0.4.3-0.20210729162817-adc68830282a
 	github.com/status-im/markdown v0.0.0-20201022101546-c0cbdd5763bf
 	github.com/status-im/migrate/v4 v4.6.2-status.2

--- a/go.sum
+++ b/go.sum
@@ -1102,8 +1102,8 @@ github.com/status-im/go-ethereum v1.10.4-status.2 h1:uvcD2U7skYqPQviARFb4w3wZyFS
 github.com/status-im/go-ethereum v1.10.4-status.2/go.mod h1:GvIhpdCOgMHI6i5xVPEZOrv/qSMeOFHbZh77AoyZUoE=
 github.com/status-im/go-multiaddr-ethv4 v1.2.0 h1:OT84UsUzTCwguqCpJqkrCMiL4VZ1SvUtH9a5MsZupBk=
 github.com/status-im/go-multiaddr-ethv4 v1.2.0/go.mod h1:2VQ3C+9zEurcceasz12gPAtmEzCeyLUGPeKLSXYQKHo=
-github.com/status-im/go-waku v0.0.0-20210729163508-c9d3334f2d0e h1:WlCBk7mwXa8tVIOQedx0whIXk9xT4lIKv3UWWABGWpI=
-github.com/status-im/go-waku v0.0.0-20210729163508-c9d3334f2d0e/go.mod h1:plJBn9iDLcklnq2KKf/bBeuRNsKck8QMdr3yoJnh3hM=
+github.com/status-im/go-waku v0.0.0-20210918141919-49f216d40c4a h1:PQ/S9OaV3I+peTU0YC7q8/AImudIKfuLNDfMzf+w8DY=
+github.com/status-im/go-waku v0.0.0-20210918141919-49f216d40c4a/go.mod h1:XK6wGIMnxhpx9SQLDV9Qw0zfXTjd8jjw6DXGC0mKvA8=
 github.com/status-im/go-wakurelay-pubsub v0.4.3-0.20210729162817-adc68830282a h1:eCna/q/PuZVqtmOMBqytw9yzZwMNKpao4au0OJDvesI=
 github.com/status-im/go-wakurelay-pubsub v0.4.3-0.20210729162817-adc68830282a/go.mod h1:LSCVYR7mnBBsxVJghrGpQ3yJAAATEe6XeQQqGCZhwrE=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=

--- a/params/config.go
+++ b/params/config.go
@@ -222,6 +222,9 @@ type WakuV2Config struct {
 
 	// EnableConfirmations when true, instructs that confirmation should be sent for received messages
 	EnableConfirmations bool
+
+	// A name->libp2p_addr map for Wakuv2 custom nodes
+	CustomNodes map[string]string
 }
 
 // ----------

--- a/signal/events_messenger.go
+++ b/signal/events_messenger.go
@@ -1,7 +1,5 @@
 package signal
 
-import "github.com/status-im/status-go/protocol/communities"
-
 const (
 
 	// EventMesssageDelivered triggered when we got acknowledge from datasync level, that means peer got message
@@ -32,6 +30,6 @@ func SendMessageDelivered(chatID string, messageID string) {
 }
 
 // SendMessageDelivered notifies about delivered message
-func SendCommunityInfoFound(community *communities.Community) {
+func SendCommunityInfoFound(community interface{}) {
 	send(EventCommunityInfoFound, community)
 }

--- a/signal/events_wakuv2.go
+++ b/signal/events_wakuv2.go
@@ -1,0 +1,12 @@
+package signal
+
+const (
+	// EventPeerStats is sent when peer is added or removed.
+	// it will be a map with capability=peer count k/v's.
+	EventPeerStats = "wakuv2.peerstats"
+)
+
+// SendPeerStats sends discovery.summary signal.
+func SendPeerStats(peerStats interface{}) {
+	send(EventPeerStats, peerStats)
+}

--- a/vendor/github.com/status-im/go-waku/waku/v2/node/wakuoptions.go
+++ b/vendor/github.com/status-im/go-waku/waku/v2/node/wakuoptions.go
@@ -26,9 +26,10 @@ type WakuNodeParameters struct {
 	enableFilter bool
 	wOpts        []wakurelay.Option
 
-	enableStore bool
-	storeMsgs   bool
-	store       *store.WakuStore
+	enableStore  bool
+	shouldResume bool
+	storeMsgs    bool
+	store        *store.WakuStore
 	// filter      *filter.WakuFilter
 
 	keepAliveInterval time.Duration
@@ -107,11 +108,12 @@ func WithWakuFilter(opts ...wakurelay.Option) WakuNodeOption {
 
 // WithWakuStore enables the Waku V2 Store protocol and if the messages should
 // be stored or not in a message provider
-func WithWakuStore(shouldStoreMessages bool) WakuNodeOption {
+func WithWakuStore(shouldStoreMessages bool, shouldResume bool) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.enableStore = true
 		params.storeMsgs = shouldStoreMessages
 		params.store = store.NewWakuStore(shouldStoreMessages, nil)
+		params.shouldResume = shouldResume
 		return nil
 	}
 }

--- a/vendor/github.com/status-im/go-waku/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/vendor/github.com/status-im/go-waku/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -177,7 +177,12 @@ func (wakuLP *WakuLightPush) Request(ctx context.Context, req *pb.PushRequest, o
 	}
 
 	defer connOpt.Close()
-	defer connOpt.Reset()
+	defer func() {
+		err := connOpt.Reset()
+		if err != nil {
+			log.Error("failed to reset connection", err)
+		}
+	}()
 
 	pushRequestRPC := &pb.PushRPC{RequestId: hex.EncodeToString(params.requestId), Query: req}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -426,7 +426,7 @@ github.com/spacemonkeygo/spacelog
 github.com/status-im/doubleratchet
 # github.com/status-im/go-multiaddr-ethv4 v1.2.0
 github.com/status-im/go-multiaddr-ethv4
-# github.com/status-im/go-waku v0.0.0-20210729163508-c9d3334f2d0e
+# github.com/status-im/go-waku v0.0.0-20210918141919-49f216d40c4a
 github.com/status-im/go-waku/waku/v2/metrics
 github.com/status-im/go-waku/waku/v2/node
 github.com/status-im/go-waku/waku/v2/protocol


### PR DESCRIPTION
Adds support for go-waku's connection status channel receiving connectivity status updates for wakuv2 peers.

Fixes #2280 