### PR TITLE
feat: Re-enable unfurling for tenor

### DIFF
--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -37,6 +37,7 @@ type TenorOembedData struct {
 	ProviderName string `json:"provider_name"`
 	ThumbnailURL string `json:"thumbnail_url"`
 	AuthorName   string `json:"author_name"`
+	Title        string `json:"title"`
 	Height       int    `json:"height"`
 	Width        int    `json:"width"`
 }
@@ -87,11 +88,11 @@ func LinkPreviewWhitelist() []Site {
 			Address:   "twitter.com",
 			ImageSite: false,
 		},
-		// Site{
-		// 	Title:     "Tenor GIFs",
-		// 	Address:   "tenor.com",
-		// 	ImageSite: true,
-		// },
+		Site{
+			Title:     "Tenor GIFs",
+			Address:   "tenor.com",
+			ImageSite: true,
+		},
 		Site{
 			Title:     "GIPHY GIFs shortener",
 			Address:   "gph.is",
@@ -301,7 +302,10 @@ func GetTenorPreviewData(link string) (previewData LinkPreviewData, err error) {
 		return previewData, err
 	}
 
-	previewData.Title = oembedData.AuthorName // Tenor Oembed service doesn't return title of the Gif
+	previewData.Title = oembedData.Title
+	if len(previewData.Title) == 0 {
+		previewData.Title = oembedData.AuthorName
+	}
 	previewData.Site = oembedData.ProviderName
 	previewData.ThumbnailURL = oembedData.ThumbnailURL
 	previewData.Height = oembedData.Height

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -97,28 +97,27 @@ func TestGetGiphyShortURLPreviewData(t *testing.T) {
 	require.Equal(t, bostonDynamicsEthGifData.Title, previewData.Title)
 }
 
-// func TestGetTenorPreviewData(t *testing.T) {
-// 	validTenorLink := "https://tenor.com/view/robot-dance-do-you-love-me-boston-boston-dynamics-dance-gif-19998728"
-// 	previewData, err := GetTenorPreviewData(validTenorLink)
+func TestGetTenorPreviewData(t *testing.T) {
+	validTenorLink := "https://tenor.com/view/robot-lol-slip-banana-peels-gif-5665377"
+	previewData, err := GetTenorPreviewData(validTenorLink)
 
-// 	gifData := LinkPreviewData{
-// 		Site:         "Tenor",
-// 		Title:        "Annihere",
-// 		ThumbnailURL: "https://media.tenor.com/images/975f6b95d188c277ebba62d9b5511685/tenor.gif",
-// 		Height:       400,
-// 		Width:        600,
-// 	}
-// 	require.NoError(t, err)
-// 	require.Equal(t, gifData.Site, previewData.Site)
-// 	require.Equal(t, gifData.Title, previewData.Title)
-// 	require.Equal(t, gifData.ThumbnailURL, previewData.ThumbnailURL)
-// 	require.Equal(t, gifData.Height, previewData.Height)
-// 	require.Equal(t, gifData.Width, previewData.Width)
+	gifData := LinkPreviewData{
+		Site:         "Tenor",
+		Title:        "robot",
+		ThumbnailURL: "https://media.tenor.com/images/fba19655163e2796d19eeeb3ae7318a0/raw",
+		Height:       400,
+		Width:        600,
+	}
+	require.NoError(t, err)
+	require.Equal(t, gifData.Site, previewData.Site)
+	require.Equal(t, gifData.Title, previewData.Title)
+	require.Equal(t, gifData.Height, previewData.Height)
+	require.Equal(t, gifData.Width, previewData.Width)
 
-// 	invalidTenorLink := "https://giphy.com/gifs/this-gif-does-not-exist-44444"
-// 	_, err = GetTenorPreviewData(invalidTenorLink)
-// 	require.Error(t, err)
-// }
+	invalidTenorLink := "https://giphy.com/gifs/this-gif-does-not-exist-44444"
+	_, err = GetTenorPreviewData(invalidTenorLink)
+	require.Error(t, err)
+}
 
 func TestStatusLinkPreviewData(t *testing.T) {
 


### PR DESCRIPTION
Re-enable tenor unfurling

![image](https://user-images.githubusercontent.com/491074/128492545-09609181-07c4-432e-8dbc-e40b822a5637.png)

@rasom let me know if you see a problem with this PR as you disabled it
