### PR TITLE
drop AdvertiseAddr from default configuration

### DIFF
--- a/_assets/compose/bootnode/Makefile
+++ b/_assets/compose/bootnode/Makefile
@@ -1,4 +1,6 @@
-GIT_ROOT = $(shell git rev-parse --show-toplevel)
+export GIT_ROOT = $(shell git rev-parse --show-toplevel)
+# Useful for showing enode address
+PUBLIC_IP ?= $(shell curl -s https://ipecho.net/plain)
 
 RED := $(shell tput -Txterm setaf 1)
 GRN := $(shell tput -Txterm setaf 2)
@@ -15,9 +17,16 @@ export CONTAINER_IMG  ?= statusteam/bootnode
 export CONTAINER_NAME ?= status-go-bootnode
 export LOG_LEVEL      ?= 3
 export LISTEN_PORT    ?= 30301
-export API_MODULES    ?= eth,net,web3,admin
-# Necessary to make bootnode available publicly
-export PUBLIC_IP      ?= $(shell curl -s https://ipecho.net/plain)
+export API_MODULES    ?= eth,web3,admin
+
+define INFO_MSG
+ * $(GRN)Your bootnode is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
+
+$(YLW)Make sure that address and UDP port are available from the internet!$(RST)
+
+$(GRN)Your enode address is:$(RST)
+endef
+export INFO_MSG
 
 all: checks start show info enode
 
@@ -41,36 +50,38 @@ ifndef CONTAINER_NAME
 	$(error $(RED)$$CONTAINER_NAME not set! Export it as environment variable$(RST))
 endif
 
-start: keys/nodekey keys/nodeaddr
-	docker-compose up -d
-
-stop:
-	docker-compose down
+enode: keys/nodeaddr
+	@echo "enode://$(shell cat keys/nodeaddr)@$(PUBLIC_IP):$(LISTEN_PORT)"
 
 logs:
 	docker-compose logs -f -t --tail=100
 
-enode: keys/nodeaddr
-	@echo "enode://$(shell cat keys/nodeaddr)@$(PUBLIC_IP):$(LISTEN_PORT)"
-
 info:
-	@echo "$(GRN)Your bootnode is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)"
-	@echo "$(YLW)Make sure that address and UDP port are available from the internet!$(RST)"
-	@echo "$(GRN)Your enode address is:$(RST)"
+	@echo "$$INFO_MSG"
 
 keys:
 	@mkdir -p keys
 
+start: keys/nodekey keys/nodeaddr
+	@echo " * $(GRN)Starting '$(CONTAINER_NAME)' container...$(RST)"
+	docker-compose up -d
+
+stop:
+	@echo " * $(YLW)Stopping '$(CONTAINER_NAME)' container...$(RST)"
+	docker-compose down
+
 keys/nodekey: keys ##@ Generate a node key
+	@echo " * $(GRN)Generating '$(CONTAINER_NAME)' keys...$(RST)"
 	@docker run --rm \
 		-u $(UID):$(GID) \
 		--entrypoint=bootnode \
 		-v $(PWD)/keys:/keys:rw \
 		$(CONTAINER_IMG) \
 		-genkey=/keys/nodekey
-	@echo "$(GRN)Created key for Bootnode: keys/nodekey$(RST)"
+	@echo " * $(GRN)Created key for Bootnode: keys/nodekey$(RST)"
 
 keys/nodeaddr: keys ##@ Save node address for given key
+	@echo " * $(GRN)Saving '$(CONTAINER_NAME)' enode address...$(RST)"
 	@docker run --rm \
 		-u $(UID):$(GID) \
 		--entrypoint=sh \

--- a/_assets/compose/bootnode/README.md
+++ b/_assets/compose/bootnode/README.md
@@ -25,7 +25,6 @@ To simply start a container run `make`, other commands include:
 
 All settings are passed through environment variables:
 
-* `PUBLIC_IP` - Your IP visible from the internet and advertised by the Bootnode.
 * `LISTEN_PORT` - Bootnode UDP port, by default it's `30301` but you might want to use `443`.
 * `RPC_PORT` - Control port making it possible to use the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC).
 * `API_MODULES` - API modules to be made available via the `RPC_PORT`.
@@ -33,22 +32,3 @@ All settings are passed through environment variables:
 * `CONTAINER_TAG` - Tag of container image to use. (default: `v0.64.3`)
 * `CONTAINER_NAME` - Name of the container that will be created. (default: `status-go-bootnode`)
 * `LOG_LEVEL` - Set level of log messages to show. (valid: `1=ERROR`, `2=WARN`, `3=INFO`, `4=DEBUG`, `5=TRACE`)
-
-# Known Issues
-
-If the discovery of your Public IP does not work please simply export the `PUBLIC_IP` env variable.
-You can also set `LISTEN_PORT` to something else to avoid firewall issues.
-```bash
-$ export PUBLIC_IP=1.2.3.4
-$ export LISTEN_PORT=443
-$ make
-Created key for Bootnode: keys/nodekey
-docker-compose up -d
-Creating status-go-bootnode ... done
-CONTAINER ID        NAMES                STATUS                  PORTS
-036ca55423c2        status-go-bootnode   Up Less than a second   0.0.0.0:30303->30303/tcp
-Your bootnode is listening on: 1.2.3.4:30303
-Make sure that address and port are available from the internet!
-Your enode address is:
-enode://2654f0ee4f021cecbfc84d56e7749daa01250f5fd3828989e482b36f9ca13981c83d4c28ad647e4cfec26efa6b8d230075d17fc9c0eb127a7210bd35d27a67a9@1.2.3.4:30303
-```

--- a/_assets/compose/mailserver/Makefile
+++ b/_assets/compose/mailserver/Makefile
@@ -1,4 +1,6 @@
 export GIT_ROOT = $(shell git rev-parse --show-toplevel)
+# Useful for showing enode address
+PUBLIC_IP ?= $(shell curl -s https://ipecho.net/plain)
 
 RED := $(shell tput -Txterm setaf 1)
 GRN := $(shell tput -Txterm setaf 2)
@@ -7,21 +9,32 @@ RST := $(shell tput -Txterm sgr0)
 BLD := $(shell tput bold)
 
 # Settings
-export CONTAINER_TAG  ?= v0.64.3
+export CONTAINER_TAG  ?= v0.83.9
 export CONTAINER_IMG  ?= statusteam/status-go
 export CONTAINER_NAME ?= status-go-mailserver
 export LOG_LEVEL      ?= INFO
 export LISTEN_PORT    ?= 30303
 export METRICS_PORT   ?= 9090
 export RPC_PORT       ?= 8545
-export API_MODULES    ?= eth,net,web3,admin,mailserver
+export API_MODULES    ?= eth,web3,admin,mailserver
 export DATA_PATH      ?= /var/tmp/status-go-mail
 export REGISTER_TOPIC ?= whispermail
 export MAIL_PASSWORD  ?= status-offline-inbox
-# Necessary to make mailserver available publicly
-export PUBLIC_IP      ?= $(shell curl -s https://ipecho.net/plain)
 
-all: checks start show info enode enode-qr
+define INFO_MSG
+ * $(GRN)Your mailserver is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
+
+$(GRN)Your enode address is:$(RST)
+$(shell $(GIT_ROOT)/_assets/scripts/get_enode.sh 2>/dev/null)
+
+$(YLW)Make sure that IP and TCP port are available from the internet!$(RST)
+
+endef
+export INFO_MSG
+
+all: checks start show info enode-qr
+
+status: show
 
 checks:
 ifeq (, $(shell which docker))
@@ -36,21 +49,15 @@ endif
 ifeq (, $(shell which jq))
 	$(error $(RED)No 'jq' in your $$PATH. Please install it$(RST))
 endif
-ifndef PUBLIC_IP
-	$(error $(RED)$$PUBLIC_IP not set! Export it as environment variable$(RST))
-endif
 ifndef CONTAINER_NAME
 	$(error $(RED)$$CONTAINER_NAME not set! Export it as environment variable$(RST))
 endif
+ifndef PUBLIC_IP
+	$(warning $(YLW)$$PUBLIC_IP not set! Export it as environment variable$(RST))
+endif
 
-start: config
-	docker-compose up -d
-
-stop:
-	docker-compose down
-
-logs:
-	docker-compose logs -f -t --tail=100
+info:
+	@echo "$$INFO_MSG"
 
 enode:
 	@$(GIT_ROOT)/_assets/scripts/get_enode.sh
@@ -58,13 +65,20 @@ enode:
 enode-qr:
 	@$(GIT_ROOT)/_assets/scripts/get_enode.sh --qr
 
-config:
-	@$(GIT_ROOT)/_assets/scripts/gen_config.sh
+logs:
+	docker-compose logs -f -t --tail=100
 
-info:
-	@echo "$(GRN)Your mailserver is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)"
-	@echo "$(YLW)Make sure that address and TCP port are available from the internet!$(RST)"
-	@echo "$(GRN)Your enode address is:$(RST)"
+start: config
+	@echo " * $(GRN)Starting '$(CONTAINER_NAME)' container...$(RST)"
+	docker-compose up -d
+
+stop:
+	@echo " * $(YLW)Stopping '$(CONTAINER_NAME)' container...$(RST)"
+	docker-compose down
+
+config:
+	@echo " * $(GRN)Generating '$(CONTAINER_NAME)' config...$(RST)"
+	@$(GIT_ROOT)/_assets/scripts/gen_config.sh
 
 show:
 	@docker ps \
@@ -72,4 +86,5 @@ show:
 		--format="table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}"
 
 clean:
+	@echo " * $(YLW)Removing '$(CONTAINER_NAME)' container...$(RST)"
 	docker-compose rm -s -f

--- a/_assets/compose/mailserver/README.md
+++ b/_assets/compose/mailserver/README.md
@@ -26,7 +26,6 @@ To simply start a container run `make`, other commands include:
 
 All settings are passed through environment variables:
 
-* `PUBLIC_IP` - Your IP visible from the internet and advertised by the Mailserver.
 * `LISTEN_PORT` - Mailserver TCP & UDP port, by default it's `30303` but you might want to use `443`.
 * `METRICS_PORT` - Port exposing metrics in [Prometheus](https://prometheus.io/docs/concepts/data_model/) format
 * `RPC_PORT` - Control port making it possible to use the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC).
@@ -40,24 +39,6 @@ All settings are passed through environment variables:
 * `LOG_LEVEL` - Set level of log messages to show. (valid: `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`)
 
 The generated configuration file end up under `${DATA_PATH}/config.json`.
-
-# Known Issues
-
-If the discovery of your Public IP does not work please simply export the `PUBLIC_IP` env variable.
-You can also set `LISTEN_PORT` to something else to avoid firewall issues.
-```bash
-$ export PUBLIC_IP=1.2.3.4
-$ export LISTEN_PORT=443
-$ make
-docker-compose up -d
-Creating status-go-mailserver ... done
-CONTAINER ID        NAMES                  STATUS              PORTS
-bee56564926d        status-go-mailserver   Up 6 minutes        8080/tcp, 127.0.0.1:8545->8545/tcp, 30303-30304/udp, 0.0.0.0:30303->30303/tcp
-Your mailserver is listening on: 1.2.3.4:443
-Make sure that address and port are available from the internet!
-Your enode address is:
-enode://dccd2f3c1df42c23af6672df28f287893ab70a5d45668637576a759b6db10b83e83fc02598f36c80ac094fbf8621419153cfe539f56d278ab099da21800f880c@1.2.3.4:30303
-```
 
 # F.A.Q.
 

--- a/_assets/scripts/gen_config.sh
+++ b/_assets/scripts/gen_config.sh
@@ -13,21 +13,18 @@ DATA_PATH="${DATA_PATH:-/var/tmp/status-go-mail}"
 CONFIG_PATH="${CONFIG_PATH:-${DATA_PATH}/config.json}"
 
 if ! [[ -x $(command -v jq) ]]; then
-  echo "Cannot generate config. jq utility is not installed."
+  echo "Cannot generate config. jq utility is not installed." >&2
   exit 1
 fi
 
 if [[ -e "${CONFIG_PATH}" ]]; then
-  echo "Config already exits. Remove it to generate a new one."
+  echo "Config already exits: ${CONFIG_PATH}" >&2
+  echo "Remove it to generate a new one." >&2
   exit 0
 fi
 
-# Necessary to make mailserver available publicly
-export PUBLIC_IP=$(curl -s https://ipecho.net/plain)
-
 # Assemble the filter for changing the config JSON
 JQ_FILTER_ARRAY=(
-  ".AdvertiseAddr = \"${PUBLIC_IP}\""
   ".ListenAddr = \"0.0.0.0:${LISTEN_PORT}\""
   ".HTTPEnabled = true"
   ".HTTPHost = \"0.0.0.0\""
@@ -39,7 +36,6 @@ JQ_FILTER_ARRAY=(
   ".WakuConfig.EnableMailServer = true"
   ".WakuConfig.DataDir = \"${DATA_PATH}/waku\""
   ".WakuConfig.MailServerPassword = \"${MAIL_PASSWORD}\""
-
 )
 
 JQ_FILTER=$(printf " | %s" "${JQ_FILTER_ARRAY[@]}")

--- a/_assets/systemd/bootnode/Makefile
+++ b/_assets/systemd/bootnode/Makefile
@@ -1,4 +1,6 @@
-export GIT_ROOT = $(shell git rev-parse --show-toplevel)
+export GIT_ROOT := $(shell git rev-parse --show-toplevel)
+# Useful for showing enode address
+PUBLIC_IP ?= $(shell curl -s https://ipecho.net/plain)
 
 RED := $(shell tput -Txterm setaf 1)
 GRN := $(shell tput -Txterm setaf 2)
@@ -25,8 +27,6 @@ export KEY_PATH     ?= $(DATA_PATH)/nodekey
 export ADDR_PATH    ?= $(DATA_PATH)/nodeaddr
 export LOG_LEVEL    ?= 3
 export LISTEN_PORT  ?= 30301
-# Necessary to make bootnode available publicly
-export PUBLIC_IP    ?= $(shell curl -s https://ipecho.net/plain)
 
 # Info
 STATUS    = $(shell systemctl $(SCTL_OPTS) is-active $(SERVICE_NAME))
@@ -34,8 +34,9 @@ NODE_ADDR = $(shell cat $(ADDR_PATH))
 ENODE     = enode://$(NODE_ADDR)@$(PUBLIC_IP):$(LISTEN_PORT)
 
 define INFO_MSG
-* $(GRN)Your bootnode is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
-* $(YLW)Make sure that IP and TCP port are available from the internet!$(RST)
+ * $(GRN)Your bootnode is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
+
+$(YLW)Make sure that IP and TCP port are available from the internet!$(RST)
 $(GRN)Your enode address is:$(RST)
 $(ENODE)
 endef
@@ -56,12 +57,6 @@ ifeq (active, $(STATUS))
 	$(error $(YLW)Service already started$(RST))
 endif
 
-info:
-	@echo "$$INFO_MSG"
-
-enode:
-	@echo "$(ENODE)"
-
 genkey: $(DATA_PATH)
 	@$(GIT_ROOT)/build/bin/bootnode -genkey=$(KEY_PATH)
 
@@ -77,33 +72,39 @@ status:
 logs:
 	journalctl $(JRNL_OPTS) statusd
 
+info:
+	@echo "$$INFO_MSG"
+
+enode:
+	@echo "$(ENODE)"
+
 enable:
-	@echo "* $(BLD)Enabling '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(GRN)Enabling '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) enable $(SERVICE_NAME)
 
 disable:
-	@echo "* $(BLD)Disabling '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(YLW)Disabling '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) disable "${SERVICE_NAME}"
 
 start:
-	@echo "* $(BLD)Starting '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(GRN)Starting '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) start $(SERVICE_NAME)
 
 restart:
-	@echo "* $(BLD)Restarting '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(YLW)Restarting '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) restart $(SERVICE_NAME)
 
 stop:
-	@echo "* $(BLD)Stopping '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(YLW)Stopping '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) stop "${SERVICE_NAME}"
 
 forget:
-	@echo "* $(BLD)Stopping '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(YLW)Stopping '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) daemon-reload
 	systemctl $(SCTL_OPTS) reset-failed
 
 $(GIT_ROOT)/build/bin/bootnode:
-	@echo "* $(BLD)Building bootnode binary...$(RST)"
+	@echo " * $(GRN)Building bootnode binary...$(RST)"
 	@cd "$(GIT_ROOT)" && make bootnode
 
 build: $(GIT_ROOT)/build/bin/bootnode
@@ -114,7 +115,7 @@ $(SERVICE_DIR):
 	@mkdir -p $(SERVICE_DIR)
 
 service: $(SERVICE_DIR)
-	@echo "* $(BLD)Generating '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(GRN)Generating '$(SERVICE_NAME)' service...$(RST)"
 	@envsubst < ./service.template > $(SERVICE_PATH)
 
 $(DATA_PATH):

--- a/_assets/systemd/bootnode/README.md
+++ b/_assets/systemd/bootnode/README.md
@@ -33,7 +33,6 @@ All the above commands are just wrappers around the [`systemctl`](http://man7.or
 All settings are passed through environment variables:
 
 * `SERVICE_NAME` - Name of the `systemd` service to be created. (Default: `statusd`)
-* `PUBLIC_IP` - Your IP visible from the internet and advertised by the Bootnode.
 * `LISTEN_PORT` - Bootnode TCP & UDP port, by default it's `30301` but you might want to use `443`.
 * `DATA_PATH` - Location of Bootnode storage and keys. (Default: `/var/tmp/status-go-boot`)
 * `KEY_PATH` - Location of Bootnode private key file. (Default: `/var/tmp/status-go-boot/nodekey`)

--- a/_assets/systemd/mailserver/Makefile
+++ b/_assets/systemd/mailserver/Makefile
@@ -1,4 +1,6 @@
-export GIT_ROOT = $(shell git rev-parse --show-toplevel)
+export GIT_ROOT := $(shell git rev-parse --show-toplevel)
+# Useful for showing enode address
+PUBLIC_IP ?= $(shell curl -s https://ipecho.net/plain)
 
 RED := $(shell tput -Txterm setaf 1)
 GRN := $(shell tput -Txterm setaf 2)
@@ -26,17 +28,18 @@ export LOG_LEVEL    ?= INFO
 export LISTEN_PORT  ?= 30303
 export METRICS_PORT ?= 9090
 export RPC_PORT     ?= 8545
-# Necessary to make mailserver available publicly
-export PUBLIC_IP    ?= $(shell curl -s https://ipecho.net/plain)
 
 # Info
 STATUS = $(shell systemctl $(SCTL_OPTS) is-active $(SERVICE_NAME))
 
 define INFO_MSG
-* $(GRN)Your mailserver is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
-* $(YLW)Make sure that IP and TCP port are available from the internet!$(RST)
+ * $(GRN)Your mailserver is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
+
 $(GRN)Your enode address is:$(RST)
 $(shell $(GIT_ROOT)/_assets/scripts/get_enode.sh 2>/dev/null)
+
+$(YLW)Make sure that IP and TCP port are available from the internet!$(RST)
+
 endef
 export INFO_MSG
 
@@ -74,32 +77,32 @@ logs:
 	journalctl $(JRNL_OPTS) statusd
 
 enable:
-	@echo "* $(BLD)Enabling '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(GRN)Enabling '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) enable $(SERVICE_NAME)
 
 disable:
-	@echo "* $(BLD)Disabling '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(YLW)Disabling '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) disable "${SERVICE_NAME}"
 
 start:
-	@echo "* $(BLD)Starting '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(GRN)Starting '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) start $(SERVICE_NAME)
 
 restart:
-	@echo "* $(BLD)Restarting '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(GRN)Restarting '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) restart $(SERVICE_NAME)
 
 stop:
-	@echo "* $(BLD)Stopping '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(YLW)Stopping '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) stop "${SERVICE_NAME}"
 
 forget:
-	@echo "* $(BLD)Stopping '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(YLW)Stopping '$(SERVICE_NAME)' service...$(RST)"
 	systemctl $(SCTL_OPTS) daemon-reload
 	systemctl $(SCTL_OPTS) reset-failed
 
 $(GIT_ROOT)/build/bin/statusd:
-	@echo "* $(BLD)Building mailserver binary...$(RST)"
+	@echo " * $(GRN)Building mailserver binary...$(RST)"
 	@cd "$(GIT_ROOT)" && make statusgo
 
 build: $(GIT_ROOT)/build/bin/statusd
@@ -109,12 +112,12 @@ $(SERVICE_DIR):
 	@mkdir -p $(SERVICE_DIR)
 
 service: $(SERVICE_DIR)
-	@echo "* $(BLD)Generating '$(SERVICE_NAME)' service...$(RST)"
+	@echo " * $(GRN)Generating '$(SERVICE_NAME)' service...$(RST)"
 	@envsubst < ./service.template > $(SERVICE_PATH)
 
 rm-service:
 	rm -f $(SERVICE_PATH)
 
 config:
-	@echo "* $(BLD)Generating '$(SERVICE_NAME)' config...$(RST)"
+	@echo " * $(GRN)Generating '$(SERVICE_NAME)' config...$(RST)"
 	@$(GIT_ROOT)/_assets/scripts/gen_config.sh

--- a/_assets/systemd/mailserver/README.md
+++ b/_assets/systemd/mailserver/README.md
@@ -34,7 +34,6 @@ All the above commands are just wrappers around the [`systemctl`](http://man7.or
 All settings are passed through environment variables:
 
 * `SERVICE_NAME` - Name of the `systemd` service to be created. (Default: `statusd`)
-* `PUBLIC_IP` - Your IP visible from the internet and advertised by the Mailserver.
 * `LISTEN_PORT` - Mailserver TCP & UDP port, by default it's `30303` but you might want to use `443`.
 * `METRICS_PORT` - Port exposing metrics in [Prometheus](https://prometheus.io/docs/concepts/data_model/) format
 * `RPC_PORT` - Control port making it possible to use the [JSON-RPC API](https://github.com/ethereum/wiki/wiki/JSON-RPC).

--- a/config/README.md
+++ b/config/README.md
@@ -22,10 +22,9 @@ An example of most important settings would include:
     "NetworkID": 1,
     "DataDir": "/tmp/status-go-data",
     "NodeKey": "123qwe123qwe123qwe123",
-    "Rendezvous": true,
+    "Rendezvous": false,
     "NoDiscovery": false,
     "ListenAddr": "0.0.0.0:30303",
-    "AdvertiseAddr": "12.34.56.78",
     "RegisterTopics": ["whispermail"]
 }
 ```
@@ -99,13 +98,8 @@ This config manages what peers and bootstrap nodes your `status-go` instance con
     ],
     "StaticNodes": [
       "enode://123qwe123qwe@12.34.56.78:30305"
-    ],
-    "RendezvousNodes": [
-      "/ip4/87.65.43.21/tcp/30703/ethv4/16Uiu2HAm312312312312312312312312"
     ]
   }
 }
 ```
 `BootNodes` help the `status-go` instance find peers. They are more important to have than `StaticNodes` or `TrustedMailServers`, which are just statically added peers on start.
-
-`RendezvousNodes` are an alternative protocol for doing the same peer discovery as `BootNodes` do.


### PR DESCRIPTION
It appears it is being used by Rendezvous, and if that protocol is not being used there is no need to set `AdvertiseAddr` either.

I also adjusted all the `Makefile`s to not depend on `PUBLIC_IP` variable.