### PR TITLE
metrics: fix p2p_peers_count metrics labels

### DIFF
--- a/metrics/node/metrics.go
+++ b/metrics/node/metrics.go
@@ -69,7 +69,7 @@ func calculatePeerCounts(server *p2p.Server) {
 	nodePeersGauge.Reset()
 
 	for _, p := range peers {
-		labels, err := labelsFromNodeName(p.Name())
+		labels, err := labelsFromNodeName(p.Fullname())
 		if err != nil {
 			logger.Warn("failed parsing peer name", "error", err, "name", p.Name())
 			continue


### PR DESCRIPTION
Because [`p2p.Server.Name()`](https://github.com/status-im/status-go/blob/0e54d04e67fee94276b69a9b20338cf4e7624cc5/vendor/github.com/ethereum/go-ethereum/p2p/peer.go#L151-L158) function started returning an abbreviated name of the node this broke the parsing of the name in order to fill in the labels for `p2p_peers_count` metric, resulting in metrics like this:
```sh
 > curl -sS localhost:9090/metrics | grep '^p2p_peers_count'
p2p_peers_count{platform="v0.79.0",type="Statusd",version="unknown"} 3
```
Caused by value returned from [`Name()`](https://github.com/status-im/status-go/blob/0e54d04e67fee94276b69a9b20338cf4e7624cc5/vendor/github.com/ethereum/go-ethereum/p2p/peer.go#L151-L158) to look like this:
```
Statusd/v0.79.0/linu...
```
By using [`Fullname()`](https://github.com/status-im/status-go/blob/0e54d04e67fee94276b69a9b20338cf4e7624cc5/vendor/github.com/ethereum/go-ethereum/p2p/peer.go#L160-L163) we are sure we are pasing all the segments.