### PR TITLE
Fix container setup and enode querying

### DIFF
--- a/_assets/compose/bootnode/Makefile
+++ b/_assets/compose/bootnode/Makefile
@@ -19,16 +19,20 @@ export LOG_LEVEL      ?= 3
 export LISTEN_PORT    ?= 30301
 export API_MODULES    ?= eth,web3,admin
 
+NODE_ADDR  = $(shell cat keys/nodeaddr)
+ENODE_ADDR = enode://$(NODE_ADDR)@$(PUBLIC_IP):$(LISTEN_PORT)
+
 define INFO_MSG
  * $(GRN)Your bootnode is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
+ * $(GRN)Your enode address is:$(RST)
+$(ENODE_ADDR)
 
 $(YLW)Make sure that address and UDP port are available from the internet!$(RST)
 
-$(GRN)Your enode address is:$(RST)
 endef
 export INFO_MSG
 
-all: checks start show info enode
+all: checks start show info enode-qr
 
 checks:
 ifeq (, $(shell which docker))
@@ -51,10 +55,14 @@ ifndef CONTAINER_NAME
 endif
 
 enode: keys/nodeaddr
-	@echo "enode://$(shell cat keys/nodeaddr)@$(PUBLIC_IP):$(LISTEN_PORT)"
+	@echo $(ENODE_ADDR)
 
+enode-qr: keys/nodeaddr
+	@qrencode -t UTF8 $(ENODE_ADDR)
+
+logs: LOG_LINES ?= 100
 logs:
-	docker-compose logs -f -t --tail=100
+	docker-compose logs -f -t --tail=$(LOG_LINES)
 
 info:
 	@echo "$$INFO_MSG"

--- a/_assets/compose/mailserver/Makefile
+++ b/_assets/compose/mailserver/Makefile
@@ -9,15 +9,16 @@ RST := $(shell tput -Txterm sgr0)
 BLD := $(shell tput bold)
 
 # Settings
-export CONTAINER_TAG  ?= v0.83.9
+export CONTAINER_TAG  ?= v0.84.0
 export CONTAINER_IMG  ?= statusteam/status-go
 export CONTAINER_NAME ?= status-go-mailserver
 export LOG_LEVEL      ?= INFO
 export LISTEN_PORT    ?= 30303
 export METRICS_PORT   ?= 9090
+export RPC_HOST       ?= 0.0.0.0
 export RPC_PORT       ?= 8545
-export API_MODULES    ?= eth,web3,admin,mailserver
-export DATA_PATH      ?= /var/tmp/status-go-mail
+export API_MODULES    ?= eth,web3,admin,waku,wakuext
+export DATA_PATH      ?= /var/tmp/$(CONTAINER_NAME)
 export REGISTER_TOPIC ?= whispermail
 export MAIL_PASSWORD  ?= status-offline-inbox
 

--- a/_assets/compose/mailserver/Makefile
+++ b/_assets/compose/mailserver/Makefile
@@ -24,8 +24,7 @@ export MAIL_PASSWORD  ?= status-offline-inbox
 
 define INFO_MSG
  * $(GRN)Your mailserver is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
-
-$(GRN)Your enode address is:$(RST)
+ * $(GRN)Your enode address is:$(RST)
 $(shell $(GIT_ROOT)/_assets/scripts/get_enode.sh 2>/dev/null)
 
 $(YLW)Make sure that IP and TCP port are available from the internet!$(RST)
@@ -66,8 +65,9 @@ enode:
 enode-qr:
 	@$(GIT_ROOT)/_assets/scripts/get_enode.sh --qr
 
+logs: LOG_LINES ?= 100
 logs:
-	docker-compose logs -f -t --tail=100
+	docker-compose logs -f -t --tail=$(LOG_LINES)
 
 start: config
 	@echo " * $(GRN)Starting '$(CONTAINER_NAME)' container...$(RST)"

--- a/_assets/scripts/get_enode.sh
+++ b/_assets/scripts/get_enode.sh
@@ -11,7 +11,8 @@ MAIL_PASSWORD="${MAIL_PASSWORD:-status-offline-inbox}"
 
 # query local 
 RESP_JSON=$(
-    curl -s -XPOST http://${RPC_ADDR}:${RPC_PORT}/ \
+    curl -sS --retry 3 --retry-all-errors \
+        -X POST http://${RPC_ADDR}:${RPC_PORT}/ \
         -H 'Content-type: application/json' \
         -d '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}'
 )

--- a/_assets/systemd/bootnode/Makefile
+++ b/_assets/systemd/bootnode/Makefile
@@ -29,16 +29,16 @@ export LOG_LEVEL    ?= 3
 export LISTEN_PORT  ?= 30301
 
 # Info
-STATUS    = $(shell systemctl $(SCTL_OPTS) is-active $(SERVICE_NAME))
-NODE_ADDR = $(shell cat $(ADDR_PATH))
-ENODE     = enode://$(NODE_ADDR)@$(PUBLIC_IP):$(LISTEN_PORT)
+STATUS     = $(shell systemctl $(SCTL_OPTS) is-active $(SERVICE_NAME))
+NODE_ADDR  = $(shell cat $(ADDR_PATH))
+ENODE_ADDR = enode://$(NODE_ADDR)@$(PUBLIC_IP):$(LISTEN_PORT)
 
 define INFO_MSG
  * $(GRN)Your bootnode is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
+ * $(GRN)Your enode address is:$(RST)
+$(ENODE_ADDR)
 
 $(YLW)Make sure that IP and TCP port are available from the internet!$(RST)
-$(GRN)Your enode address is:$(RST)
-$(ENODE)
 endef
 export INFO_MSG
 

--- a/_assets/systemd/mailserver/Makefile
+++ b/_assets/systemd/mailserver/Makefile
@@ -34,8 +34,7 @@ STATUS = $(shell systemctl $(SCTL_OPTS) is-active $(SERVICE_NAME))
 
 define INFO_MSG
  * $(GRN)Your mailserver is listening on:$(RST) $(BLD)$(PUBLIC_IP):$(LISTEN_PORT)$(RST)
-
-$(GRN)Your enode address is:$(RST)
+ * $(GRN)Your enode address is:$(RST)
 $(shell $(GIT_ROOT)/_assets/scripts/get_enode.sh 2>/dev/null)
 
 $(YLW)Make sure that IP and TCP port are available from the internet!$(RST)


### PR DESCRIPTION
Changes:

* Upgraded Docker image to `v0.83.19`
* Updated list of API modules to enable for Containers
* Changed RPC listening port to `0.0.0.0` for Docker containers
* Move data dir to folder named after container, same as systemd service
* Added `curl` retries to querying for enode address, containers can be slow to start
* Updated info message formatting to fix `make` target completion in shells
* Added `LOG_LINES` variable to limit number of lines the `logs` targets return