### PR TITLE
get_enode.sh: --retry-connrefused instead --retry-all-errors

### DIFF
--- a/_assets/scripts/get_enode.sh
+++ b/_assets/scripts/get_enode.sh
@@ -11,7 +11,7 @@ MAIL_PASSWORD="${MAIL_PASSWORD:-status-offline-inbox}"
 
 # query local 
 RESP_JSON=$(
-    curl -sS --retry 3 --retry-all-errors \
+    curl -sS --retry 3 --retry-connrefused \
         -X POST http://${RPC_ADDR}:${RPC_PORT}/ \
         -H 'Content-type: application/json' \
         -d '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}'


### PR DESCRIPTION
The `--retry-all-errors` flag was added only in `7.71.0` version of Curl: https://github.com/curl/curl/commit/b995bb58

So it fails on older distrubutions with:
```
curl: option --retry-all-errors: is unknown
curl: try 'curl --help' or 'curl --manual' for more information
```