### PR TITLE
fix: empty wakuv2 host

### DIFF
--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -240,6 +240,10 @@ func (b *StatusNode) wakuV2Service(nodeKey string, wakuCfg *params.WakuV2Config,
 			StoreNodes:             clusterCfg.WakuStoreNodes,
 		}
 
+		if cfg.Host == "" {
+			cfg.Host = wakuv2.DefaultConfig.Host
+		}
+
 		if wakuCfg.MaxMessageSize > 0 {
 			cfg.MaxMessageSize = wakuCfg.MaxMessageSize
 		}


### PR DESCRIPTION
Fixes "Incorrect network addr conversion" error that happens when using a nodeconfig that does not have a Host defined for WakuV2