### PR TITLE
Makefile: pin gomobile version to 5d9a3325

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,9 @@ HELP_FUN = \
 		   }
 
 statusgo: ##@build Build status-go as statusd server
-	go build -mod=vendor -i -o $(GOBIN)/statusd -v -tags '$(BUILD_TAGS)' $(BUILD_FLAGS) ./cmd/statusd
+	go build -mod=vendor -i -v \
+		-tags '$(BUILD_TAGS)' $(BUILD_FLAGS) \
+		-o $(GOBIN)/statusd ./cmd/statusd
 	@echo "Compilation done."
 	@echo "Run \"build/bin/statusd -h\" to view available commands."
 
@@ -94,11 +96,15 @@ statusd-prune-docker-image: ##@statusd-prune Build statusd-prune docker image
 		-t $(STATUSD_PRUNE_IMAGE_NAME):latest
 
 bootnode: ##@build Build discovery v5 bootnode using status-go deps
-	go build -i -o $(GOBIN)/bootnode -v -tags '$(BUILD_TAGS)' $(BUILD_FLAGS) ./cmd/bootnode/
+	go build -i -v \
+		-tags '$(BUILD_TAGS)' $(BUILD_FLAGS) \
+		-o $(GOBIN)/bootnode ./cmd/bootnode/
 	@echo "Compilation done."
 
 node-canary: ##@build Build P2P node canary using status-go deps
-	go build -i -o $(GOBIN)/node-canary -v -tags '$(BUILD_TAGS)' $(BUILD_FLAGS) ./cmd/node-canary/
+	go build -i -v \
+		-tags '$(BUILD_TAGS)' $(BUILD_FLAGS) \
+		-o $(GOBIN)/node-canary ./cmd/node-canary/
 	@echo "Compilation done."
 
 statusgo-cross: statusgo-android statusgo-ios
@@ -108,13 +114,21 @@ statusgo-cross: statusgo-android statusgo-ios
 statusgo-android: ##@cross-compile Build status-go for Android
 	@echo "Building status-go for Android..."
 	gomobile init
-	gomobile bind -v -target=android -ldflags="-s -w" $(BUILD_FLAGS_MOBILE) -o build/bin/statusgo.aar github.com/status-im/status-go/mobile
+	gomobile bind -v \
+		-target=android -ldflags="-s -w" \
+		$(BUILD_FLAGS_MOBILE) \
+		-o build/bin/statusgo.aar \
+		github.com/status-im/status-go/mobile
 	@echo "Android cross compilation done in build/bin/statusgo.aar"
 
 statusgo-ios: ##@cross-compile Build status-go for iOS
 	@echo "Building status-go for iOS..."
 	gomobile init
-	gomobile bind -v -target=ios -ldflags="-s -w" $(BUILD_FLAGS_MOBILE) -o build/bin/Statusgo.framework github.com/status-im/status-go/mobile
+	gomobile bind -v \
+		-target=ios -ldflags="-s -w" \
+		$(BUILD_FLAGS_MOBILE) \
+		-o build/bin/Statusgo.framework \
+		github.com/status-im/status-go/mobile
 	@echo "iOS framework cross compilation done in build/bin/Statusgo.framework"
 
 statusgo-library: ##@cross-compile Build status-go as static library for current platform
@@ -122,7 +136,11 @@ statusgo-library: ##@cross-compile Build status-go as static library for current
 	mkdir -p $(GOBIN)/statusgo-lib
 	go run cmd/library/*.go > $(GOBIN)/statusgo-lib/main.go
 	@echo "Building static library..."
-	go build -buildmode=c-archive -o $(GOBIN)/libstatus.a $(BUILD_FLAGS) $(GOBIN)/statusgo-lib
+	go build \
+		$(BUILD_FLAGS) \
+		-buildmode=c-archive \
+		-o $(GOBIN)/libstatus.a \
+		$(GOBIN)/statusgo-lib
 	@echo "Static library built:"
 	@ls -la $(GOBIN)/libstatus.*
 
@@ -131,7 +149,11 @@ statusgo-shared-library: ##@cross-compile Build status-go as shared library for 
 	mkdir -p $(GOBIN)/statusgo-lib
 	go run cmd/library/*.go > $(GOBIN)/statusgo-lib/main.go
 	@echo "Building shared library..."
-	$(GOBIN_SHARED_LIB_CGO_LDFLAGS) go build -buildmode=c-shared -o $(GOBIN)/libstatus.$(GOBIN_SHARED_LIB_EXT) $(BUILD_FLAGS) $(GOBIN)/statusgo-lib
+	$(GOBIN_SHARED_LIB_CGO_LDFLAGS) go build \
+		$(BUILD_FLAGS) \
+		-buildmode=c-shared \
+		-o $(GOBIN)/libstatus.$(GOBIN_SHARED_LIB_EXT) \
+		$(GOBIN)/statusgo-lib
 	@echo "Shared library built:"
 	@ls -la $(GOBIN)/libstatus.*
 

--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -31,7 +31,6 @@ pipeline {
   environment {
     /* fix for gomobile complaining about missing packages */
     CGO_ENABLED = "1"
-    GO111MODULE = "off"
     /* Other stuff */
     TARGET      = 'android'
     GOPATH      = "${env.WORKSPACE}"
@@ -54,12 +53,12 @@ pipeline {
     } } } }
 
     stage('Setup') { steps { dir(env.STATUS_PATH) {
-      sh 'make setup-build modvendor-install'
+      sh 'make setup-build install-modvendor'
     } } }
 
     stage('Vendoring check') { steps { dir(env.STATUS_PATH) {
       /* fail build if vendoring hasn't been done */
-      sh 'GO111MODULE=on make vendor'
+      sh 'make vendor'
       sh 'git diff --exit-code --no-color --stat vendor/'
     } } }
 

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -31,7 +31,6 @@ pipeline {
   environment {
     /* fix for gomobile complaining about missing packages */
     CGO_ENABLED = "1"
-    GO111MODULE = "off"
     /* Other stuff */
     TARGET      = 'ios'
     GOPATH      = "${env.WORKSPACE}"

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -38,12 +38,13 @@ pipeline {
     } } } }
 
     stage('Setup') { steps { dir(env.STATUS_PATH) {
-      sh 'GO111MODULE=off make setup-build modvendor-install'
+      sh 'make setup-build install-modvendor'
     } } }
 
     stage('Vendoring check') { steps { dir(env.STATUS_PATH) {
-      // fail build if vendoring hasn't been done
-      sh 'GO111MODULE=on make vendor && git diff --exit-code --no-color --stat vendor/'
+      /* fail build if vendoring hasn't been done */
+      sh 'make vendor'
+      sh 'git diff --exit-code --no-color --stat vendor/'
     } } }
 
     stage('Lint') { steps { dir(env.STATUS_PATH) {

--- a/_assets/scripts/install_deps.sh
+++ b/_assets/scripts/install_deps.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-if [ -x "$(command -v apt)" ]; then
+if [[ -x $(command -v apt) ]]; then
   apt install -y protobuf-compiler jq
-fi
-
-if [ -x "$(command -v pacman)" ]; then
+elif [[ -x $(command -v pacman) ]]; then
   pacman -Sy protobuf jq --noconfirm
-fi
-
-if [ -x "$(command -v brew)" ]; then
+elif [[ -x $(command -v brew) ]]; then
   brew install protobuf jq
+elif [[ -x $(command -v nix-env) ]]; then
+  nix-env -iA nixos.protobuf3_13
+else
+  echo "ERROR: No known package manager found!" >&2
+  exit 1
 fi

--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
 	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb
+	golang.org/x/tools v0.1.2 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -1193,6 +1193,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b/go.mod h1:T3BPAOm2cqquPa0MKWeNkmOM5RQsRhkrwMWonFMN7fE=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -1344,6 +1345,7 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -1438,8 +1440,10 @@ golang.org/x/sys v0.0.0-20210301091718-77cc2087c03b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
@@ -1518,8 +1522,9 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
+golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Using latest version every time is just asking for weird random issues.

Also this commit has made Go `1.16` required: https://github.com/golang/mobile/commit/80cb72e7af8e71b65e7d9e59fb4ec5d620134608

Also refactored the `Makefile` a bit so install targets start with `install-*` for easier tab completion:
```
 > make help | grep --color=never -E '(install|setup)'
install:
  install-os-deps                 Operating System Dependencies
  install-gomobile                Go Mobile Build Tools
  install-lint                    Install Linting Tools
  install-mock                    Install Module Mocking Tools
  install-modvendor               Install Module Vendoring Tool
  install-protobuf                Install Protobuf Generation Tools
  install-release                 Install Github Release Tools
  install-xtools                  Install Miscellaneous Go Tools
setup:
  setup                           Install all tools
  setup-dev                       Install all necessary tools for development
  setup-build                     Install all necessary build tools
```