### PR TITLE
feat: add cmakelist to status-go for c/c++ projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.0)
+project(status-go)
+
+SET(LIB_FILE ${CMAKE_CURRENT_SOURCE_DIR}/build/bin/libstatus.a)
+SET(LIB_SHARED_FILE ${CMAKE_CURRENT_SOURCE_DIR}/build/bin/libstatus.so)
+SET(LIB_HEADER_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/build/bin/libstatus.h)
+
+add_custom_command(OUTPUT  ${LIB_SHARED_FILE}
+                   COMMAND make statusgo-shared-library
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_custom_target(statusgo_shared_target DEPENDS ${LIB_SHARED_FILE})
+
+add_library(statusgo_shared SHARED IMPORTED GLOBAL)
+
+add_dependencies(statusgo_shared statusgo_shared_target)
+
+set_target_properties(statusgo_shared
+    PROPERTIES
+    IMPORTED_LOCATION ${LIB_SHARED_FILE}
+    INTERFACE_INCLUDE_DIRECTORIES ${LIB_HEADER_FOLDER})
+
+
+add_custom_command(OUTPUT  ${LIB_FILE}
+                   COMMAND make statusgo-library
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_custom_target(statusgo_target DEPENDS ${LIB_FILE})
+
+add_library(statusgo STATIC IMPORTED GLOBAL)
+
+add_dependencies(statusgo statusgo_target)
+
+set_target_properties(statusgo
+    PROPERTIES
+    IMPORTED_LOCATION ${LIB_FILE}
+    INTERFACE_INCLUDE_DIRECTORIES ${LIB_HEADER_FOLDER})


### PR DESCRIPTION
This is to avoid having to use ExternalProject_Add when building a  cmake project that uses status-go
```cmake
add_subdirectory(path/to/status-go bin/status-go)
add_executable(app main.cpp )
# To add status-go as shared library (we use this on desktop)
target_link_libraries(app statusgo_shared)
# To add as static library
target_link_libraries(app statusgo)
```