### PR TITLE
chore: add soname to libstatus.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ else ifeq ($(detected_OS),Windows)
  GOBIN_SHARED_LIB_EXT := dll
 else
  GOBIN_SHARED_LIB_EXT := so
+ GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS="-Wl,-soname,libstatus.so.0"
 endif
 
 help: ##@other Show this help
@@ -156,6 +157,12 @@ statusgo-shared-library: ##@cross-compile Build status-go as shared library for 
 		-buildmode=c-shared \
 		-o $(GOBIN)/libstatus.$(GOBIN_SHARED_LIB_EXT) \
 		$(GOBIN)/statusgo-lib
+ifeq ($(detected_OS),Linux)
+	cd $(GOBIN) && \
+	ls -lah . && \
+	mv ./libstatus.$(GOBIN_SHARED_LIB_EXT) ./libstatus.$(GOBIN_SHARED_LIB_EXT).0 && \
+	ln -s ./libstatus.$(GOBIN_SHARED_LIB_EXT).0 ./libstatus.$(GOBIN_SHARED_LIB_EXT)
+endif
 	@echo "Shared library built:"
 	@ls -la $(GOBIN)/libstatus.*
 


### PR DESCRIPTION
Required by https://github.com/status-im/status-desktop/pull/3512. Do not merge until that PR is merged too.

This is required for creating a valid .deb file, otherwise `lintian` will complain with the following error:
`E: status-desktop: sharedobject-in-library-directory-missing-soname usr/lib/libstatus.so`
 
Also, it's a good practice for shared libraries to include the soname.