### PR TITLE
Shorten loop on waiting for community

### DIFF
--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -846,7 +846,7 @@ func (api *PublicAPI) EnsVerified(pk, ensName string) error {
 	return api.service.messenger.ENSVerified(pk, ensName)
 }
 
-func (api *PublicAPI) RequestCommunityInfoFromMailserver(communityID string) error {
+func (api *PublicAPI) RequestCommunityInfoFromMailserver(communityID string) (*communities.Community, error) {
 	return api.service.messenger.RequestCommunityInfoFromMailserver(communityID)
 }
 

--- a/static/mailserver_db_migrations/1557732988_initialize_db.up.sql
+++ b/static/mailserver_db_migrations/1557732988_initialize_db.up.sql
@@ -2,3 +2,4 @@ CREATE TABLE envelopes (id BYTEA NOT NULL UNIQUE, data BYTEA NOT NULL, topic BYT
 
 CREATE INDEX id_bloom_idx ON envelopes (id DESC, bloom);
 CREATE INDEX id_topic_idx ON envelopes (id DESC, topic);
+CREATE INDEX topic_idx ON envelopes(topic);


### PR DESCRIPTION
Before we would arbitrarily wait 15 seconds to fetch a community.
Now we just poll using select/timeout so we can shorten the time. 
Also adds an index to the mailserver migration which has already been added to production.