### PR TITLE
feat: add API to mark activity center messages as unread

### DIFF
--- a/protocol/activity_center_persistence.go
+++ b/protocol/activity_center_persistence.go
@@ -382,6 +382,20 @@ func (db sqlitePersistence) MarkActivityCenterNotificationsRead(ids []types.HexB
 
 }
 
+func (db sqlitePersistence) MarkActivityCenterNotificationsUnread(ids []types.HexBytes) error {
+
+	idsArgs := make([]interface{}, 0, len(ids))
+	for _, id := range ids {
+		idsArgs = append(idsArgs, id)
+	}
+
+	inVector := strings.Repeat("?, ", len(ids)-1) + "?"
+	query := "UPDATE activity_center_notifications SET read = 0 WHERE id IN (" + inVector + ")" // nolint: gosec
+	_, err := db.db.Exec(query, idsArgs...)
+	return err
+
+}
+
 func (db sqlitePersistence) UnreadActivityCenterNotificationsCount() (uint64, error) {
 	var count uint64
 	err := db.db.QueryRow(`SELECT COUNT(1) FROM activity_center_notifications WHERE NOT read AND NOT dismissed AND NOT accepted`).Scan(&count)

--- a/protocol/messenger_activity_center.go
+++ b/protocol/messenger_activity_center.go
@@ -16,6 +16,10 @@ func (m *Messenger) MarkActivityCenterNotificationsRead(ids []types.HexBytes) er
 	return m.persistence.MarkActivityCenterNotificationsRead(ids)
 }
 
+func (m *Messenger) MarkActivityCenterNotificationsUnread(ids []types.HexBytes) error {
+	return m.persistence.MarkActivityCenterNotificationsUnread(ids)
+}
+
 func (m *Messenger) processAcceptedActivityCenterNotifications(notifications []*ActivityCenterNotification) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
 	var chats []*Chat

--- a/protocol/persistence_test.go
+++ b/protocol/persistence_test.go
@@ -1214,6 +1214,12 @@ func TestActivityCenterPersistence(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), count)
 
+	// Mark first one as unread
+	require.NoError(t, p.MarkActivityCenterNotificationsUnread([]types.HexBytes{nID1}))
+	count, err = p.UnreadActivityCenterNotificationsCount()
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), count)
+
 	// Mark all read
 	require.NoError(t, p.MarkAllActivityCenterNotificationsRead())
 	_, notifications, err = p.ActivityCenterNotifications(cursor, 2)

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -875,6 +875,10 @@ func (api *PublicAPI) MarkActivityCenterNotificationsRead(ids []types.HexBytes) 
 	return api.service.messenger.MarkActivityCenterNotificationsRead(ids)
 }
 
+func (api *PublicAPI) MarkActivityCenterNotificationsUnread(ids []types.HexBytes) error {
+	return api.service.messenger.MarkActivityCenterNotificationsUnread(ids)
+}
+
 func (api *PublicAPI) AcceptAllActivityCenterNotifications() (*protocol.MessengerResponse, error) {
 	return api.service.messenger.AcceptAllActivityCenterNotifications()
 }


### PR DESCRIPTION
As raised in https://github.com/status-im/status-desktop/issues/3665, there's no way in Status Deskop to mark activity center notifications as unread. Not only is this not implemented in Status Desktop's UI, there's also no API to mark notifications as unread.

This commit adds a new `markActivityCenterNotificationsAsUnread` to the protocol API, so marking notifications as unread can be implemented by status clients.

