### PR TITLE
ci: fix release process broken by missing suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,30 +267,6 @@ lint-fix:
 		-w {} \;
 	$(MAKE) vendor
 
-check-existing-release:
-	@git ls-remote --exit-code origin "$(RELEASE_TAG)" >/dev/null || exit 0; \
-	echo "$(YELLOW)Release tag already exists: $(RELEASE_TAG)$(RESET)"; \
-	echo "Remove the tag/release if you want to re-create it."; \
-	exit 1;
-
-release: check-existing-release
-	@read -p "Are you sure you want to create a new GitHub $(RELEASE_TYPE) against $(RELEASE_BRANCH) branch? (y/n): " REPLY; \
-	if [ $$REPLY = "y" ]; then \
-		latest_tag=$$(git describe --tags `git rev-list --tags --max-count=1`); \
-		comparison="$$latest_tag..HEAD"; \
-		if [ -z "$$latest_tag" ]; then comparison=""; fi; \
-		changelog=$$(git log $$comparison --oneline --no-merges --format="* %h %s"); \
-		github-release \
-			$(shell if [ $(PRE_RELEASE) != "0" ] ; then echo "-prerelease" ; fi) \
-			"status-im/status-go" \
-			"$(RELEASE_TAG)" \
-			"$(RELEASE_BRANCH)" \
-			"$(changelog)" \
-			"$(RELEASE_DIR)/*" ; \
-	else \
-	    echo "Aborting." && exit 1; \
-	fi
-
 mock: ##@other Regenerate mocks
 	mockgen -package=fake         -destination=transactions/fake/mock.go             -source=transactions/fake/txservice.go
 	mockgen -package=status       -destination=services/status/account_mock.go       -source=services/status/service.go

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.16'
+library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
   agent { label 'linux' }
@@ -28,9 +28,9 @@ pipeline {
   }
 
   environment {
-    STATUS_PATH = "${env.WORKSPACE}/src/github.com/status-im/status-go"
-    GOPATH      = "${env.WORKSPACE}"
-    PATH        = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    REPO   = "${env.WORKSPACE}/src/github.com/status-im/status-go"
+    GOPATH = "${env.WORKSPACE}"
+    PATH   = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
     /* This will override the var in Makefile */
     RELEASE_DIR = "${env.WORKSPACE}/pkg"
   }
@@ -71,32 +71,18 @@ pipeline {
     stage('Release') {
       when { expression { params.RELEASE == true } }
       steps { script {
-        def suffix = "-"+utils.suffix()
-        /* rename build files to not include versions */
-        dir(env.RELEASE_DIR) {
-          findFiles(glob: 'status-go-*').each { pkg ->
-            sh "mv ${pkg.path} ${pkg.path.replace(suffix, "")}"
-          }
-        }
-        /* perform the release */
-        dir(env.STATUS_PATH) {
-          withCredentials([[
-            $class: 'UsernamePasswordMultiBinding',
-            credentialsId: 'status-im-auto',
-            usernameVariable: 'GITHUB_USER',
-            passwordVariable: 'GITHUB_TOKEN'
-          ]]) {
-            env.RELEASE_BRANCH = utils.branchName()
-            env.RELEASE_DIR = env.RELEASE_DIR
-            sh 'yes | make release'
-          }
-        }
+        dir (env.REPO) { version = utils.getVersion() }
+        github.publishReleaseFiles(
+          repo: 'status-go',
+          version: version,
+          desc: ':warning: Fill me in!',
+       )
       } }
     } // stage(Release)
   } // stages
 
   post {
-    always { dir(env.STATUS_PATH) {
+    always { dir(env.REPO) {
       sh 'make clean-release'
     } }
   }

--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.17'
+library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
   agent { label 'linux' }
@@ -32,11 +32,10 @@ pipeline {
     /* fix for gomobile complaining about missing packages */
     CGO_ENABLED = "1"
     /* Other stuff */
-    TARGET      = 'android'
-    GOPATH      = "${env.WORKSPACE}"
-    STATUS_PATH = "${env.WORKSPACE}/src/github.com/status-im/status-go"
-    ARTIFACT    = "${env.WORKSPACE}/status-go-android-${utils.timestamp()}-${utils.gitCommit()}.aar"
-    PATH        = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    TARGET = 'android'
+    REPO   = "${env.WORKSPACE}/src/github.com/status-im/status-go"
+    GOPATH = "${env.WORKSPACE}"
+    PATH   = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
     /* Android SDK */
     ANDROID_HOME     = '/usr/lib/android-sdk'
     ANDROID_SDK_ROOT = '/usr/lib/android-sdk'
@@ -46,23 +45,26 @@ pipeline {
   }
 
   stages {
-    stage('Prep') { steps { dir(env.STATUS_PATH) { script {
-      println("Version:    ${utils.getVersion()}")
-      println("Git Branch: ${utils.branchName()}")
-      println("Git Commit: ${utils.gitCommit()}")
+    stage('Prep') { steps { dir(env.REPO) { script {
+      env.ARTIFACT = "${env.WORKSPACE}/" + utils.pkgFilename(
+        name: "status-go",
+        type: "android",
+        ext: "aar"
+      )
+      println("Output: ${env.ARTIFACT}")
     } } } }
 
-    stage('Setup') { steps { dir(env.STATUS_PATH) {
+    stage('Setup') { steps { dir(env.REPO) {
       sh 'make setup-build install-modvendor'
     } } }
 
-    stage('Vendoring check') { steps { dir(env.STATUS_PATH) {
+    stage('Vendoring check') { steps { dir(env.REPO) {
       /* fail build if vendoring hasn't been done */
       sh 'make vendor'
       sh 'git diff --exit-code --no-color --stat vendor/'
     } } }
 
-    stage('Compile') { steps { dir(env.STATUS_PATH) {
+    stage('Compile') { steps { dir(env.REPO) {
       sh 'make statusgo-android'
       sh "cp build/bin/statusgo.aar ${env.ARTIFACT}"
     } } }
@@ -78,6 +80,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { dir(env.STATUS_PATH) { sh 'make clean' } }
+    always { dir(env.REPO) { sh 'make clean' } }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.docker
+++ b/_assets/ci/Jenkinsfile.docker
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.17'
+library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
   agent { label 'linux' }
@@ -29,28 +29,26 @@ pipeline {
   }
 
   environment {
-    TARGET      = "docker"
-    GOPATH      = "${env.WORKSPACE}"
-    STATUS_PATH = "${env.WORKSPACE}/src/github.com/status-im/status-go"
-    PATH        = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    TARGET = "docker"
+    REPO   = "${env.WORKSPACE}/src/github.com/status-im/status-go"
+    GOPATH = "${env.WORKSPACE}"
+    PATH   = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
     /* docker image settings */
     IMAGE_NAME  = "statusteam/status-go"
     IMAGE_TAG   = "deploy-test"
   }
 
   stages {
-    stage('Prep') { steps { dir(env.STATUS_PATH) { script {
-      println("Version:    ${utils.getVersion()}")
-      println("Git Branch: ${utils.branchName()}")
-      println("Git Commit: ${utils.gitCommit()}")
+    stage('Prep') { steps { dir(env.REPO) { script {
+      println("Output: ${env.IMAGE_NAME}:${env.IMAGE_TAG}")
     } } } }
 
-    stage('Build') { steps { dir(env.STATUS_PATH) { script {
+    stage('Build') { steps { dir(env.REPO) { script {
       sh 'make docker-image'
       image = docker.image("${env.IMAGE_NAME}:v${utils.getVersion()}")
     } } } }
 
-    stage('Push') { steps { dir(env.STATUS_PATH) { script {
+    stage('Push') { steps { dir(env.REPO) { script {
       withDockerRegistry([credentialsId: "dockerhub-statusteam-auto", url: ""]) {
         image.push()
       }
@@ -58,7 +56,7 @@ pipeline {
 
     stage('Deploy') {
       when { expression { params.RELEASE == true } }
-      steps { dir(env.STATUS_PATH) { script {
+      steps { dir(env.REPO) { script {
         withDockerRegistry([credentialsId: "dockerhub-statusteam-auto", url: ""]) {
           image.push(env.IMAGE_TAG)
         }
@@ -67,7 +65,7 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always  { dir(env.STATUS_PATH) {
+    always  { dir(env.REPO) {
       sh 'make clean-docker-images'
     } }
   } // post

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.17'
+library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
   agent { label 'macos' }
@@ -32,25 +32,27 @@ pipeline {
     /* fix for gomobile complaining about missing packages */
     CGO_ENABLED = "1"
     /* Other stuff */
-    TARGET      = 'ios'
-    GOPATH      = "${env.WORKSPACE}"
-    STATUS_PATH = "${env.WORKSPACE}/src/github.com/status-im/status-go"
-    ARTIFACT    = "${env.WORKSPACE}/status-go-ios-${utils.timestamp()}-${utils.gitCommit()}.zip"
-    PATH        = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    TARGET = 'ios'
+    GOPATH = "${env.WORKSPACE}"
+    REPO   = "${env.WORKSPACE}/src/github.com/status-im/status-go"
+    PATH   = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
   }
 
   stages {
-    stage('Prep') { steps { dir(env.STATUS_PATH) { script {
-      println("Version:    ${utils.getVersion()}")
-      println("Git Branch: ${utils.branchName()}")
-      println("Git Commit: ${utils.gitCommit()}")
+    stage('Prep') { steps { dir(env.REPO) { script {
+      env.ARTIFACT = "${env.WORKSPACE}/" + utils.pkgFilename(
+        name: "status-go",
+        type: "ios",
+        ext: "zip"
+      )
+      println("Output: ${env.ARTIFACT}")
     } } } }
 
-    stage('Setup') { steps { dir(env.STATUS_PATH) {
+    stage('Setup') { steps { dir(env.REPO) {
       sh 'unset TMPDIR && make setup-build'
     } } }
 
-    stage('Compile') { steps { dir(env.STATUS_PATH) {
+    stage('Compile') { steps { dir(env.REPO) {
       sh 'make statusgo-ios'
       sh 'go get golang.org/x/tools/go/packages'
       dir('build/bin') {
@@ -70,6 +72,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { dir(env.STATUS_PATH) { sh 'make clean' } }
+    always { dir(env.REPO) { sh 'make clean' } }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.17'
+library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
   agent { label 'linux' }
@@ -29,30 +29,32 @@ pipeline {
   }
 
   environment {
-    TARGET      = 'linux'
-    STATUS_PATH = "${env.WORKSPACE}/src/github.com/status-im/status-go"
-    GOPATH      = "${env.WORKSPACE}"
-    ARTIFACT    = "${env.WORKSPACE}/status-go-desktop-${utils.timestamp()}-${utils.gitCommit()}.zip"
-    PATH        = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    TARGET = 'linux'
+    REPO   = "${env.WORKSPACE}/src/github.com/status-im/status-go"
+    GOPATH = "${env.WORKSPACE}"
+    PATH   = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
   }
 
   stages {
-    stage('Prep') { steps { dir(env.STATUS_PATH) { script {
-      println("Version:    ${utils.getVersion()}")
-      println("Git Branch: ${utils.branchName()}")
-      println("Git Commit: ${utils.gitCommit()}")
+    stage('Prep') { steps { dir(env.REPO) { script {
+      env.ARTIFACT = "${env.WORKSPACE}/" + utils.pkgFilename(
+        name: "status-go",
+        type: "desktop",
+        ext: "zip"
+      )
+      println("Output: ${env.ARTIFACT}")
     } } } }
 
-    stage('Setup') { steps { dir(env.STATUS_PATH) {
+    stage('Setup') { steps { dir(env.REPO) {
       sh 'make setup-build'
     } } }
 
     /* Sanity-check C bindings */
-    stage('Sanity check bindings') { steps { dir(env.STATUS_PATH) {
+    stage('Sanity check bindings') { steps { dir(env.REPO) {
       sh 'make statusgo-library'
     } } }
 
-    stage('Compress') { steps { dir(env.STATUS_PATH) {
+    stage('Compress') { steps { dir(env.REPO) {
       sh "zip -q -r ${env.ARTIFACT} . -x *.git"
     } } }
 
@@ -67,6 +69,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { dir(env.STATUS_PATH) { sh 'make clean' } }
+    always { dir(env.REPO) { sh 'make clean' } }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.17'
+library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
   agent { label 'linux' }
@@ -24,38 +24,38 @@ pipeline {
   }
 
   environment {
-    TARGET      = 'linux'
-    STATUS_PATH = 'src/github.com/status-im/status-go'
-    GOPATH      = "${env.WORKSPACE}"
-    PATH        = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    TARGET = 'linux'
+    GOPATH = "${env.WORKSPACE}"
+    PATH   = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    REPO   = 'src/github.com/status-im/status-go'
   }
 
   stages {
-    stage('Prep') { steps { dir(env.STATUS_PATH) { script {
+    stage('Prep') { steps { dir(env.REPO) { script {
       println("Version:    ${utils.getVersion()}")
       println("Git Branch: ${utils.branchName()}")
       println("Git Commit: ${utils.gitCommit()}")
     } } } }
 
-    stage('Setup') { steps { dir(env.STATUS_PATH) {
+    stage('Setup') { steps { dir(env.REPO) {
       sh 'make setup-build install-modvendor'
     } } }
 
-    stage('Vendoring check') { steps { dir(env.STATUS_PATH) {
+    stage('Vendoring check') { steps { dir(env.REPO) {
       /* fail build if vendoring hasn't been done */
       sh 'make vendor'
       sh 'git diff --exit-code --no-color --stat vendor/'
     } } }
 
-    stage('Lint') { steps { dir(env.STATUS_PATH) {
+    stage('Lint') { steps { dir(env.REPO) {
       sh 'make lint'
     } } }
 
-    stage('Canary') { steps { dir(env.STATUS_PATH) {
+    stage('Canary') { steps { dir(env.REPO) {
       sh 'make canary-test'
     } } }
 
-    stage('Unit Tests') { steps { script { dir(env.STATUS_PATH) {
+    stage('Unit Tests') { steps { script { dir(env.REPO) {
       docker.image('postgres:9.6-alpine').withRun(
         '-e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432'
       ) { c ->


### PR DESCRIPTION
This fixes a type of [CI failure](https://ci.status.im/job/status-go/job/manual/1010/console) which results in:
```
java.lang.NoSuchMethodError: No such DSL method 'suffix' found among steps ...
```
Also use release functions provided by `status-jenkins-lib`.

Depends on: https://github.com/status-im/status-jenkins-lib/pull/36