### PR TITLE
feat: add batch information and request ID in history requests

### DIFF
--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -26,9 +26,10 @@ type MessengerSignalsHandler interface {
 	MessageDelivered(chatID string, messageID string)
 	CommunityInfoFound(community *communities.Community)
 	MessengerResponse(response *MessengerResponse)
-	HistoryRequestStarted()
-	HistoryRequestCompleted()
-	HistoryRequestFailed(err error)
+	HistoryRequestStarted(requestID string, numBatches int)
+	HistoryRequestBatchProcessed(requestID string, batchIndex int, batchNum int)
+	HistoryRequestCompleted(requestID string)
+	HistoryRequestFailed(requestID string, err error)
 }
 
 type config struct {

--- a/services/ext/signal.go
+++ b/services/ext/signal.go
@@ -66,14 +66,18 @@ func (m *MessengerSignalsHandler) MessengerResponse(response *protocol.Messenger
 	PublisherSignalHandler{}.NewMessages(response)
 }
 
-func (m *MessengerSignalsHandler) HistoryRequestStarted() {
-	signal.SendHistoricMessagesRequestStarted()
+func (m *MessengerSignalsHandler) HistoryRequestStarted(requestID string, numBatches int) {
+	signal.SendHistoricMessagesRequestStarted(requestID, numBatches)
 }
 
-func (m *MessengerSignalsHandler) HistoryRequestFailed(err error) {
-	signal.SendHistoricMessagesRequestFailed(err)
+func (m *MessengerSignalsHandler) HistoryRequestBatchProcessed(requestID string, batchIndex int, numBatches int) {
+	signal.SendHistoricMessagesRequestBatchProcessed(requestID, batchIndex, numBatches)
 }
 
-func (m *MessengerSignalsHandler) HistoryRequestCompleted() {
-	signal.SendHistoricMessagesRequestCompleted()
+func (m *MessengerSignalsHandler) HistoryRequestFailed(requestID string, err error) {
+	signal.SendHistoricMessagesRequestFailed(requestID, err)
+}
+
+func (m *MessengerSignalsHandler) HistoryRequestCompleted(requestID string) {
+	signal.SendHistoricMessagesRequestCompleted(requestID)
 }

--- a/signal/events_shhext.go
+++ b/signal/events_shhext.go
@@ -38,7 +38,10 @@ const (
 	// EventHistoryRequestStarted is triggered before processing a mailserver batch
 	EventHistoryRequestStarted = "history.request.started"
 
-	// EventHistoryRequestCompleted is triggered after processing a mailserver batch
+	// EventHistoryBatchProcessed is triggered after processing a mailserver batch
+	EventHistoryBatchProcessed = "history.request.batch.processed"
+
+	// EventHistoryRequestCompleted is triggered after processing all mailserver batches
 	EventHistoryRequestCompleted = "history.request.completed"
 
 	// EventHistoryRequestFailed is triggered when requesting history messages fails
@@ -61,7 +64,10 @@ type MailServerResponseSignal struct {
 }
 
 type HistoryMessagesSignal struct {
-	ErrorMsg string `json:"errorMessage,omitempty"`
+	RequestID  string `json:"requestId"`
+	BatchIndex int    `json:"batchIndex"`
+	NumBatches int    `json:"numBatches,omitempty"`
+	ErrorMsg   string `json:"errorMessage,omitempty"`
 }
 
 // DecryptMessageFailedSignal holds the sender of the message that could not be decrypted
@@ -116,16 +122,20 @@ func SendEnvelopeExpired(identifiers [][]byte, err error) {
 	send(EventEnvelopeExpired, EnvelopeSignal{IDs: hexIdentifiers, Message: message})
 }
 
-func SendHistoricMessagesRequestStarted() {
-	send(EventHistoryRequestStarted, HistoryMessagesSignal{})
+func SendHistoricMessagesRequestStarted(requestID string, numBatches int) {
+	send(EventHistoryRequestStarted, HistoryMessagesSignal{RequestID: requestID, NumBatches: numBatches})
 }
 
-func SendHistoricMessagesRequestFailed(err error) {
-	send(EventHistoryRequestFailed, HistoryMessagesSignal{ErrorMsg: err.Error()})
+func SendHistoricMessagesRequestBatchProcessed(requestID string, batchIndex int, numBatches int) {
+	send(EventHistoryBatchProcessed, HistoryMessagesSignal{RequestID: requestID, BatchIndex: batchIndex, NumBatches: numBatches})
 }
 
-func SendHistoricMessagesRequestCompleted() {
-	send(EventHistoryRequestCompleted, HistoryMessagesSignal{})
+func SendHistoricMessagesRequestFailed(requestID string, err error) {
+	send(EventHistoryRequestFailed, HistoryMessagesSignal{RequestID: requestID, ErrorMsg: err.Error()})
+}
+
+func SendHistoricMessagesRequestCompleted(requestID string) {
+	send(EventHistoryRequestCompleted, HistoryMessagesSignal{RequestID: requestID})
 }
 
 // SendMailServerRequestCompleted triggered when mail server response has been received


### PR DESCRIPTION
With the idea of adding a progress bar in desktop, I added a request id and emit a signal each time a mailserver request batch is processed, as well as some attributes that could be used to guesstimate the progress