### PR TITLE
Discard installations with no metadata in tests

### DIFF
--- a/waku/waku_version_test.go
+++ b/waku/waku_version_test.go
@@ -151,6 +151,9 @@ func (s *WakuTestSuite) testConfirmationsHandshake(expectConfirmations bool) {
 	s.Require().NoError(err)
 	peers := w1.getPeers()
 	s.Require().Len(peers, 1)
+	// We need to let the loop run, not very elegant, but otherwise is
+	// flaky
+	time.Sleep(10 * time.Millisecond)
 	s.Require().Equal(expectConfirmations, peers[0].ConfirmationsEnabled())
 	timer.Stop()
 	s.Require().NoError(rw1.Close())


### PR DESCRIPTION
We need to discard installations with no metadata, as some might be sent
before, so we need to check in the loop that the one we care about is
received.

Also uses `Require()` everywhere, as we want to fail as soon as a condition is not met