### PR TITLE
waku2: enable message confirmations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/russolsen/same v0.0.0-20160222130632-f089df61f51d // indirect
 	github.com/russolsen/transit v0.0.0-20180705123435-0794b4c4505a
 	github.com/status-im/doubleratchet v3.0.0+incompatible
-	github.com/status-im/go-waku v0.0.0-20211018124348-4227a9d69d19
+	github.com/status-im/go-waku v0.0.0-20211101173358-268767262b60
 	github.com/status-im/go-waku-rendezvous v0.0.0-20211018070416-a93f3b70c432
 	github.com/status-im/markdown v0.0.0-20210405121740-32e5a5055fb6
 	github.com/status-im/migrate/v4 v4.6.2-status.2

--- a/go.sum
+++ b/go.sum
@@ -1206,8 +1206,8 @@ github.com/status-im/go-ethereum v1.10.4-status.3 h1:RF618iSCvqJtXu3ZSg7XNg6MJaS
 github.com/status-im/go-ethereum v1.10.4-status.3/go.mod h1:GvIhpdCOgMHI6i5xVPEZOrv/qSMeOFHbZh77AoyZUoE=
 github.com/status-im/go-multiaddr-ethv4 v1.2.1 h1:09v9n6426NAojNOvdgegqrAotgffWW/UPDwrpJ85DNE=
 github.com/status-im/go-multiaddr-ethv4 v1.2.1/go.mod h1:SlBebvQcSUM5+/R/YfpfMuu5WyraW47XFmIqLYBmlKU=
-github.com/status-im/go-waku v0.0.0-20211018124348-4227a9d69d19 h1:z5xRto9SI+VgPNA52Wf+NTYs1i75hfW5gGhJC4k53Vs=
-github.com/status-im/go-waku v0.0.0-20211018124348-4227a9d69d19/go.mod h1:A0lI3uZYLKrXiviVkwGgBdT8b9HLcW3U/xUcE/4665k=
+github.com/status-im/go-waku v0.0.0-20211101173358-268767262b60 h1:ymq5jgtepOPqNbs8yA9g2hkFn5811snImNqNbQzpcDA=
+github.com/status-im/go-waku v0.0.0-20211101173358-268767262b60/go.mod h1:A0lI3uZYLKrXiviVkwGgBdT8b9HLcW3U/xUcE/4665k=
 github.com/status-im/go-waku-rendezvous v0.0.0-20211018070416-a93f3b70c432 h1:cbNFU38iimo9fY4B7CdF/fvIF6tNPJIZjBbpfmW2EY4=
 github.com/status-im/go-waku-rendezvous v0.0.0-20211018070416-a93f3b70c432/go.mod h1:A8t3i0CUGtXCA0aiLsP7iyikmk/KaD/2XVvNJqGCU20=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=

--- a/protocol/transport/envelopes_monitor.go
+++ b/protocol/transport/envelopes_monitor.go
@@ -163,7 +163,8 @@ func (m *EnvelopesMonitor) handleEvent(event types.EnvelopeEvent) {
 }
 
 func (m *EnvelopesMonitor) handleEventEnvelopeSent(event types.EnvelopeEvent) {
-	if m.mailServerConfirmation {
+	// Mailserver confirmations for WakuV2 are disabled
+	if m.w.Version() < 2 && m.mailServerConfirmation {
 		if !m.isMailserver(event.Peer) {
 			return
 		}
@@ -173,6 +174,7 @@ func (m *EnvelopesMonitor) handleEventEnvelopeSent(event types.EnvelopeEvent) {
 	defer m.mu.Unlock()
 
 	state, ok := m.envelopes[event.Hash]
+
 	// if we didn't send a message using extension - skip it
 	// if message was already confirmed - skip it
 	if !ok || state == EnvelopeSent {

--- a/protocol/transport/envelopes_monitor.go
+++ b/protocol/transport/envelopes_monitor.go
@@ -164,7 +164,7 @@ func (m *EnvelopesMonitor) handleEvent(event types.EnvelopeEvent) {
 
 func (m *EnvelopesMonitor) handleEventEnvelopeSent(event types.EnvelopeEvent) {
 	// Mailserver confirmations for WakuV2 are disabled
-	if m.w.Version() < 2 && m.mailServerConfirmation {
+	if (m.w == nil || m.w.Version() < 2) && m.mailServerConfirmation {
 		if !m.isMailserver(event.Peer) {
 			return
 		}

--- a/vendor/github.com/status-im/go-waku/waku/persistence/rendezvous.go
+++ b/vendor/github.com/status-im/go-waku/waku/persistence/rendezvous.go
@@ -1,0 +1,34 @@
+package persistence
+
+import (
+	rendezvous "github.com/status-im/go-waku-rendezvous"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+type RendezVousLevelDB struct {
+	db *leveldb.DB
+}
+
+func NewRendezVousLevelDB(dBPath string) (*RendezVousLevelDB, error) {
+	db, err := leveldb.OpenFile(dBPath, &opt.Options{OpenFilesCacheCapacity: 3})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &RendezVousLevelDB{db}, nil
+}
+
+func (r *RendezVousLevelDB) Delete(key []byte) error {
+	return r.db.Delete(key, nil)
+}
+
+func (r *RendezVousLevelDB) Put(key []byte, value []byte) error {
+	return r.db.Put(key, value, nil)
+}
+
+func (r *RendezVousLevelDB) NewIterator(prefix []byte) rendezvous.Iterator {
+	return r.db.NewIterator(util.BytesPrefix(prefix), nil)
+}

--- a/vendor/github.com/status-im/go-waku/waku/persistence/store.go
+++ b/vendor/github.com/status-im/go-waku/waku/persistence/store.go
@@ -1,0 +1,153 @@
+package persistence
+
+import (
+	"database/sql"
+	"log"
+
+	"github.com/status-im/go-waku/waku/v2/protocol/pb"
+)
+
+type MessageProvider interface {
+	GetAll() ([]StoredMessage, error)
+	Put(cursor *pb.Index, pubsubTopic string, message *pb.WakuMessage) error
+	Stop()
+}
+
+// DBStore is a MessageProvider that has a *sql.DB connection
+type DBStore struct {
+	MessageProvider
+	db *sql.DB
+}
+
+type StoredMessage struct {
+	ID           []byte
+	PubsubTopic  string
+	ReceiverTime float64
+	Message      *pb.WakuMessage
+}
+
+// DBOption is an optional setting that can be used to configure the DBStore
+type DBOption func(*DBStore) error
+
+// WithDB is a DBOption that lets you use any custom *sql.DB with a DBStore.
+func WithDB(db *sql.DB) DBOption {
+	return func(d *DBStore) error {
+		d.db = db
+		return nil
+	}
+}
+
+// WithDriver is a DBOption that will open a *sql.DB connection
+func WithDriver(driverName string, datasourceName string) DBOption {
+	return func(d *DBStore) error {
+		db, err := sql.Open(driverName, datasourceName)
+		if err != nil {
+			return err
+		}
+		d.db = db
+		return nil
+	}
+}
+
+// Creates a new DB store using the db specified via options.
+// It will create a messages table if it does not exist
+func NewDBStore(opt DBOption) (*DBStore, error) {
+	result := new(DBStore)
+
+	err := opt(result)
+	if err != nil {
+		return nil, err
+	}
+
+	err = result.createTable()
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (d *DBStore) createTable() error {
+	sqlStmt := `CREATE TABLE IF NOT EXISTS message (
+		id BLOB PRIMARY KEY,
+		receiverTimestamp REAL NOT NULL,
+		senderTimestamp REAL NOT NULL,
+		contentTopic BLOB NOT NULL,
+		pubsubTopic BLOB NOT NULL,
+		payload BLOB,
+		version INTEGER NOT NULL DEFAULT 0
+	) WITHOUT ROWID;`
+	_, err := d.db.Exec(sqlStmt)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Closes a DB connection
+func (d *DBStore) Stop() {
+	d.db.Close()
+}
+
+// Inserts a WakuMessage into the DB
+func (d *DBStore) Put(cursor *pb.Index, pubsubTopic string, message *pb.WakuMessage) error {
+	stmt, err := d.db.Prepare("INSERT INTO message (id, receiverTimestamp, senderTimestamp, contentTopic, pubsubTopic, payload, version) VALUES (?, ?, ?, ?, ?, ?, ?)")
+	if err != nil {
+		return err
+	}
+	_, err = stmt.Exec(cursor.Digest, cursor.ReceiverTime, message.Timestamp, message.ContentTopic, pubsubTopic, message.Payload, message.Version)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Returns all the stored WakuMessages
+func (d *DBStore) GetAll() ([]StoredMessage, error) {
+	rows, err := d.db.Query("SELECT id, receiverTimestamp, senderTimestamp, contentTopic, pubsubTopic, payload, version FROM message ORDER BY senderTimestamp ASC")
+	if err != nil {
+		return nil, err
+	}
+
+	var result []StoredMessage
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var id []byte
+		var receiverTimestamp float64
+		var senderTimestamp float64
+		var contentTopic string
+		var payload []byte
+		var version uint32
+		var pubsubTopic string
+
+		err = rows.Scan(&id, &receiverTimestamp, &senderTimestamp, &contentTopic, &pubsubTopic, &payload, &version)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		msg := new(pb.WakuMessage)
+		msg.ContentTopic = contentTopic
+		msg.Payload = payload
+		msg.Timestamp = senderTimestamp
+		msg.Version = version
+
+		record := StoredMessage{
+			ID:           id,
+			PubsubTopic:  pubsubTopic,
+			ReceiverTime: receiverTimestamp,
+			Message:      msg,
+		}
+
+		result = append(result, record)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/vendor/github.com/status-im/go-waku/waku/v2/broadcast.go
+++ b/vendor/github.com/status-im/go-waku/waku/v2/broadcast.go
@@ -1,4 +1,4 @@
-package node
+package v2
 
 import (
 	"github.com/status-im/go-waku/waku/v2/protocol"
@@ -23,7 +23,7 @@ type Broadcaster interface {
 	// Unregister a channel so that it no longer receives broadcasts.
 	Unregister(chan<- *protocol.Envelope)
 	// Shut this broadcaster down.
-	Close() error
+	Close()
 	// Submit a new object to all subscribers
 	Submit(*protocol.Envelope)
 }
@@ -78,9 +78,8 @@ func (b *broadcaster) Unregister(newch chan<- *protocol.Envelope) {
 }
 
 // Closes the broadcaster. Used to stop receiving new subscribers
-func (b *broadcaster) Close() error {
+func (b *broadcaster) Close() {
 	close(b.reg)
-	return nil
 }
 
 // Submits an Envelope to be broadcasted among all registered subscriber channels

--- a/vendor/github.com/status-im/go-waku/waku/v2/node/wakuoptions.go
+++ b/vendor/github.com/status-im/go-waku/waku/v2/node/wakuoptions.go
@@ -28,14 +28,15 @@ type WakuNodeParameters struct {
 	privKey        *crypto.PrivKey
 	libP2POpts     []libp2p.Option
 
-	enableRelay  bool
-	enableFilter bool
-	wOpts        []pubsub.Option
+	enableRelay      bool
+	enableFilter     bool
+	isFilterFullNode bool
+	wOpts            []pubsub.Option
 
-	enableStore  bool
-	shouldResume bool
-	storeMsgs    bool
-	store        *store.WakuStore
+	enableStore     bool
+	shouldResume    bool
+	storeMsgs       bool
+	messageProvider store.MessageProvider
 
 	enableRendezvous       bool
 	enableRendezvousServer bool
@@ -151,9 +152,10 @@ func WithRendezvousServer(storage rendezvous.Storage) WakuNodeOption {
 
 // WithWakuFilter enables the Waku V2 Filter protocol. This WakuNodeOption
 // accepts a list of WakuFilter gossipsub options to setup the protocol
-func WithWakuFilter(opts ...pubsub.Option) WakuNodeOption {
+func WithWakuFilter(fullNode bool) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.enableFilter = true
+		params.isFilterFullNode = fullNode
 		return nil
 	}
 }
@@ -164,7 +166,6 @@ func WithWakuStore(shouldStoreMessages bool, shouldResume bool) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.enableStore = true
 		params.storeMsgs = shouldStoreMessages
-		params.store = store.NewWakuStore(shouldStoreMessages, nil)
 		params.shouldResume = shouldResume
 		return nil
 	}
@@ -174,11 +175,7 @@ func WithWakuStore(shouldStoreMessages bool, shouldResume bool) WakuNodeOption {
 // used to store and retrieve persisted messages
 func WithMessageProvider(s store.MessageProvider) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
-		if params.store != nil {
-			params.store.SetMsgProvider(s)
-		} else {
-			params.store = store.NewWakuStore(true, s)
-		}
+		params.messageProvider = s
 		return nil
 	}
 }

--- a/vendor/github.com/status-im/go-waku/waku/v2/utils/peer.go
+++ b/vendor/github.com/status-im/go-waku/waku/v2/utils/peer.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"math/rand"
 
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -10,8 +11,7 @@ import (
 
 var log = logging.Logger("utils")
 
-// SelectPeer is used to return a peer that supports a given protocol.
-// It currently selects the first peer returned by the peerstore
+// SelectPeer is used to return a random peer that supports a given protocol.
 func SelectPeer(host host.Host, protocolId string) (*peer.ID, error) {
 	// @TODO We need to be more strategic about which peers we dial. Right now we just set one on the service.
 	// Ideally depending on the query and our set  of peers we take a subset of ideal peers.
@@ -19,9 +19,6 @@ func SelectPeer(host host.Host, protocolId string) (*peer.ID, error) {
 	//  - which topics they track
 	//  - latency?
 	//  - default store peer?
-
-	// Selects the best peer for a given protocol
-
 	var peers peer.IDSlice
 	for _, peer := range host.Peerstore().Peers() {
 		protocols, err := host.Peerstore().SupportsProtocols(peer, protocolId)
@@ -36,8 +33,8 @@ func SelectPeer(host host.Host, protocolId string) (*peer.ID, error) {
 	}
 
 	if len(peers) >= 1 {
-		// TODO: proper heuristic here that compares peer scores and selects "best" one. For now the first peer for the given protocol is returned
-		return &peers[0], nil
+		// TODO: proper heuristic here that compares peer scores and selects "best" one. For now a random peer for the given protocol is returned
+		return &peers[rand.Intn(len(peers))], nil // nolint: gosec
 	}
 
 	return nil, errors.New("no suitable peers found")

--- a/vendor/github.com/status-im/go-waku/waku/v2/utils/time.go
+++ b/vendor/github.com/status-im/go-waku/waku/v2/utils/time.go
@@ -2,6 +2,10 @@ package utils
 
 import "time"
 
+func GetUnixEpochFrom(now func() time.Time) float64 {
+	return float64(now().UnixNano()) / float64(time.Second)
+}
+
 func GetUnixEpoch() float64 {
-	return float64(time.Now().UnixNano()) / float64(time.Second)
+	return GetUnixEpochFrom(time.Now)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -446,7 +446,9 @@ github.com/spacemonkeygo/spacelog
 github.com/status-im/doubleratchet
 # github.com/status-im/go-multiaddr-ethv4 v1.2.1
 github.com/status-im/go-multiaddr-ethv4
-# github.com/status-im/go-waku v0.0.0-20211018124348-4227a9d69d19
+# github.com/status-im/go-waku v0.0.0-20211101173358-268767262b60
+github.com/status-im/go-waku/waku/persistence
+github.com/status-im/go-waku/waku/v2
 github.com/status-im/go-waku/waku/v2/metrics
 github.com/status-im/go-waku/waku/v2/node
 github.com/status-im/go-waku/waku/v2/protocol

--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -45,6 +45,6 @@ var DefaultConfig = Config{
 	MaxMessageSize:    common.DefaultMaxMessageSize,
 	Host:              "0.0.0.0",
 	Port:              60000,
-	KeepAliveInterval: 1, // second
+	KeepAliveInterval: 10, // second
 	DiscoveryLimit:    40,
 }


### PR DESCRIPTION
Since in wakuv2 mailservers do not return a message confirmation, automatically mark a message as sent if the publish function executes successfully.

This PR also updates go-waku to latest version