### PR TITLE
Ensure owner is removed from community when leaving community

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -726,8 +726,15 @@ func (m *Manager) LeaveCommunity(id types.HexBytes) (*Community, error) {
 	if community == nil {
 		return nil, ErrOrgNotFound
 	}
+	if community.IsAdmin() {
+		_, err = community.RemoveUserFromOrg(m.identity)
+		if err != nil {
+			return nil, err
+		}
+	}
 	community.Leave()
 	err = m.persistence.SaveCommunity(community)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Prior to this commit, when a community owner leaves her community,
status-go would just set the `joined` flag to `false` without updating the
members list. This results in wrong data as the number of members doesn't
match the reality.

This commit removes the owner of the community from the members list
when she's leaving the community.