### PR TITLE
chore: remove tenor from the whitelist

### DIFF
--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -33,15 +33,6 @@ type GiphyOembedData struct {
 	Width        int    `json:"width"`
 }
 
-type TenorOembedData struct {
-	ProviderName string `json:"provider_name"`
-	ThumbnailURL string `json:"thumbnail_url"`
-	AuthorName   string `json:"author_name"`
-	Title        string `json:"title"`
-	Height       int    `json:"height"`
-	Width        int    `json:"width"`
-}
-
 type LinkPreviewData struct {
 	Site         string `json:"site" meta:"og:site_name"`
 	Title        string `json:"title" meta:"og:title"`
@@ -60,7 +51,6 @@ type Site struct {
 const YoutubeOembedLink = "https://www.youtube.com/oembed?format=json&url=%s"
 const TwitterOembedLink = "https://publish.twitter.com/oembed?url=%s"
 const GiphyOembedLink = "https://giphy.com/services/oembed?url=%s"
-const TenorOembedLink = "https://tenor.com/oembed?url=%s"
 
 var httpClient = http.Client{
 	Timeout: 30 * time.Second,
@@ -87,11 +77,6 @@ func LinkPreviewWhitelist() []Site {
 			Title:     "Twitter",
 			Address:   "twitter.com",
 			ImageSite: false,
-		},
-		Site{
-			Title:     "Tenor GIFs",
-			Address:   "tenor.com",
-			ImageSite: true,
 		},
 		Site{
 			Title:     "GIPHY GIFs shortener",
@@ -279,41 +264,6 @@ func GetGiphyShortURLPreviewData(shortURL string) (data LinkPreviewData, err err
 	return GetGiphyPreviewData(longURL)
 }
 
-func GetTenorOembed(url string) (data TenorOembedData, err error) {
-	oembedLink := fmt.Sprintf(TenorOembedLink, url)
-
-	jsonBytes, err := GetURLContent(oembedLink)
-
-	if err != nil {
-		return data, fmt.Errorf("can't get bytes from Tenor oembed response at %s", oembedLink)
-	}
-
-	err = json.Unmarshal(jsonBytes, &data)
-	if err != nil {
-		return data, fmt.Errorf("can't unmarshall json %w", err)
-	}
-
-	return data, nil
-}
-
-func GetTenorPreviewData(link string) (previewData LinkPreviewData, err error) {
-	oembedData, err := GetTenorOembed(link)
-	if err != nil {
-		return previewData, err
-	}
-
-	previewData.Title = oembedData.Title
-	if len(previewData.Title) == 0 {
-		previewData.Title = oembedData.AuthorName
-	}
-	previewData.Site = oembedData.ProviderName
-	previewData.ThumbnailURL = oembedData.ThumbnailURL
-	previewData.Height = oembedData.Height
-	previewData.Width = oembedData.Width
-
-	return previewData, nil
-}
-
 func GetLinkPreviewData(link string) (previewData LinkPreviewData, err error) {
 	url, err := url.Parse(link)
 	if err != nil {
@@ -331,8 +281,6 @@ func GetLinkPreviewData(link string) (previewData LinkPreviewData, err error) {
 		return GetGiphyPreviewData(link)
 	case "gph.is":
 		return GetGiphyShortURLPreviewData(link)
-	case "tenor.com":
-		return GetTenorPreviewData(link)
 	case "twitter.com":
 		return GetTwitterPreviewData(link)
 	default:

--- a/protocol/urls/urls_test.go
+++ b/protocol/urls/urls_test.go
@@ -97,28 +97,6 @@ func TestGetGiphyShortURLPreviewData(t *testing.T) {
 	require.Equal(t, bostonDynamicsEthGifData.Title, previewData.Title)
 }
 
-func TestGetTenorPreviewData(t *testing.T) {
-	validTenorLink := "https://tenor.com/view/robot-lol-slip-banana-peels-gif-5665377"
-	previewData, err := GetTenorPreviewData(validTenorLink)
-
-	gifData := LinkPreviewData{
-		Site:         "Tenor",
-		Title:        "robot",
-		ThumbnailURL: "https://media.tenor.com/images/fba19655163e2796d19eeeb3ae7318a0/raw",
-		Height:       400,
-		Width:        600,
-	}
-	require.NoError(t, err)
-	require.Equal(t, gifData.Site, previewData.Site)
-	require.Equal(t, gifData.Title, previewData.Title)
-	require.Equal(t, gifData.Height, previewData.Height)
-	require.Equal(t, gifData.Width, previewData.Width)
-
-	invalidTenorLink := "https://giphy.com/gifs/this-gif-does-not-exist-44444"
-	_, err = GetTenorPreviewData(invalidTenorLink)
-	require.Error(t, err)
-}
-
 func TestStatusLinkPreviewData(t *testing.T) {
 
 	statusSecurityAudit := LinkPreviewData{


### PR DESCRIPTION
Removing Tenor from the whitelist since the API now doesn't return a thumbnail and just an iframe instead.

Example of what it looks like now:
```json
{
  "type": "video",
  "version": "1.0",
  "provider_name": "Tenor",
  "provider_url": "https://tenor.com/",
  "cache_age": 86400,
  "html": "<iframe src=\"https://tenor.com/embed/4986167\" width=\"600\" height=\"400\" frameborder=\"0\"></iframe>",
  "width": 600,
  "height": 400,
  "title": "thats me"
}
```

Anyway. it doesn't work anymore and using an iframe sounds very shitty