### PR TITLE
ci: specify macos host architecture in labels

### DIFF
--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
-  agent { label 'macos' }
+  agent { label 'macos && x86_64' }
 
   parameters {
     string(


### PR DESCRIPTION
Since now we have a 5th Gen Mac Mini with `arm64` M1 CPU.