### PR TITLE
refactor(timeline) Removed timeline feature

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1126,14 +1126,16 @@ func (m *Messenger) Init() error {
 			continue
 		}
 
-		m.allChats.Store(chat.ID, chat)
+                if (!chat.Timeline() && chat.ChatType != ChatTypeProfile) {
+                        m.allChats.Store(chat.ID, chat)
+                }
 
-		if !chat.Active || chat.Timeline() {
-			continue
-		}
+                if !chat.Active || chat.Timeline() {
+                        continue
+                }
 
-		switch chat.ChatType {
-		case ChatTypePublic, ChatTypeProfile:
+                switch chat.ChatType {
+                case ChatTypePublic, ChatTypeProfile:
 			publicChatIDs = append(publicChatIDs, chat.ID)
 		case ChatTypeCommunityChat:
 			publicChatIDs = append(publicChatIDs, chat.ID)


### PR DESCRIPTION
Since timeline feature is depecated, added condition
in status-go to not save timeline and profile chats
in order to avoid displaying public chats of this type.

Relates to dekstop [#4177](https://github.com/status-im/status-desktop/issues/4177)
