### PR TITLE
fix: only broadcast status once we are connected

### DIFF
--- a/protocol/messenger_status_updates.go
+++ b/protocol/messenger_status_updates.go
@@ -181,7 +181,12 @@ func (m *Messenger) sendCurrentUserStatusToCommunity(ctx context.Context, commun
 func (m *Messenger) broadcastLatestUserStatus() {
 	m.logger.Debug("broadcasting user status")
 	ctx := context.Background()
-	m.sendCurrentUserStatus(ctx)
+	go func() {
+		// Ensure that we are connected before sending a message
+		time.Sleep(5 * time.Second)
+		m.sendCurrentUserStatus(ctx)
+	}()
+
 	go func() {
 		for {
 			select {


### PR DESCRIPTION
We broadcast messages while we are not connected
Not totally confident this is the right way to fix that one, let me know if you prefer another alternative
prevent:
![image](https://user-images.githubusercontent.com/491074/144581290-a8b9f021-36e0-46f4-b4d9-da27438776af.png)
