### PR TITLE
fix: MultiAccountImportMnemonic: Remove extra spaces in the entered mnemonic

### DIFF
--- a/mobile/multiaccount.go
+++ b/mobile/multiaccount.go
@@ -2,6 +2,7 @@ package statusgo
 
 import (
 	"encoding/json"
+	"strings"
 )
 
 // MultiAccountGenerateParams are the params sent to MultiAccountGenerate.
@@ -165,7 +166,10 @@ func MultiAccountImportMnemonic(paramsJSON string) string {
 		return makeJSONResponse(err)
 	}
 
-	resp, err := statusBackend.AccountManager().AccountsGenerator().ImportMnemonic(p.MnemonicPhrase, p.Bip39Passphrase)
+	// remove any duplicate whitespaces
+	mnemonicPhraseNoExtraSpaces := strings.Join(strings.Fields(p.MnemonicPhrase), " ")
+
+	resp, err := statusBackend.AccountManager().AccountsGenerator().ImportMnemonic(mnemonicPhraseNoExtraSpaces, p.Bip39Passphrase)
 	if err != nil {
 		return makeJSONResponse(err)
 	}


### PR DESCRIPTION
fix: MultiAccountImportMnemonic: Remove extra spaces in the entered mnemonic

This commit removes any extra white spaces in between the mnemonic.

An extra whitespace at the end or between leads to an incorrect account being retrieved.
The changes here first removes all the spaces and then joins the string with a single space in between. 

Closes # 4353
