### PR TITLE
feat: desktop mailserver cycle

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1180,7 +1180,6 @@ func (b *GethStatusBackend) injectAccountsIntoServices() error {
 			return ErrWakuIdentityInjectionFailure
 		}
 		st := b.statusNode.WakuV2ExtService()
-
 		if err := st.InitProtocol(b.statusNode.GethNode().Config().Name, identity, b.appDB, b.multiaccountsDB, acc, logutils.ZapLogger()); err != nil {
 			return err
 		}

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -216,6 +216,7 @@ func main() {
 			identity,
 			gethbridge.NewNodeBridge(backend.StatusNode().GethNode(), backend.StatusNode().WakuService(), backend.StatusNode().WakuV2Service()),
 			installationID.String(),
+			nil,
 			options...,
 		)
 		if err != nil {

--- a/eth-node/bridge/geth/waku.go
+++ b/eth-node/bridge/geth/waku.go
@@ -79,6 +79,10 @@ func (w *gethWakuWrapper) DropPeer(peerID string) error {
 	return errors.New("not available in WakuV1")
 }
 
+func (w *gethWakuWrapper) SubscribeToConnStatusChanges() (*types.ConnStatusSubscription, error) {
+	return nil, errors.New("not available in WakuV1")
+}
+
 // Peers function only added for compatibility with waku V2
 func (w *gethWakuWrapper) Peers() map[string][]string {
 	p := make(map[string][]string)

--- a/eth-node/bridge/geth/wakuv2.go
+++ b/eth-node/bridge/geth/wakuv2.go
@@ -263,6 +263,10 @@ func (w *gethWakuV2Wrapper) MarkP2PMessageAsProcessed(hash common.Hash) {
 	w.waku.MarkP2PMessageAsProcessed(hash)
 }
 
+func (w *gethWakuV2Wrapper) SubscribeToConnStatusChanges() (*types.ConnStatusSubscription, error) {
+	return w.waku.SubscribeToConnStatusChanges(), nil
+}
+
 type wakuV2FilterWrapper struct {
 	filter *wakucommon.Filter
 	id     string

--- a/eth-node/types/waku.go
+++ b/eth-node/types/waku.go
@@ -5,8 +5,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/pborman/uuid"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type ConnStatus struct {

--- a/multiaccounts/accounts/database.go
+++ b/multiaccounts/accounts/database.go
@@ -459,7 +459,7 @@ func (db *Database) SaveSetting(setting string, value interface{}) error {
 }
 
 func (db *Database) GetNodeConfig(nodecfg interface{}) error {
-	return db.db.QueryRow("SELECT node_config FROM settings WHERE synthetic_id = 'id'").Scan(&sqlite.JSONBlob{nodecfg})
+	return db.db.QueryRow("SELECT node_config FROM settings WHERE synthetic_id = 'id'").Scan(&sqlite.JSONBlob{Data: nodecfg})
 }
 
 func (db *Database) GetSettings() (Settings, error) {
@@ -650,6 +650,14 @@ func (db *Database) GetProfilePicturesVisibility() (int, error) {
 
 func (db *Database) GetPublicKey() (rst string, err error) {
 	err = db.db.QueryRow("SELECT public_key FROM settings WHERE synthetic_id = 'id'").Scan(&rst)
+	if err == sql.ErrNoRows {
+		return rst, nil
+	}
+	return
+}
+
+func (db *Database) GetFleet() (rst string, err error) {
+	err = db.db.QueryRow("SELECT COALESCE(fleet, '') FROM settings WHERE synthetic_id = 'id'").Scan(&rst)
 	if err == sql.ErrNoRows {
 		return rst, nil
 	}

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -153,7 +153,7 @@ func (b *StatusNode) wakuExtService(config *params.NodeConfig) (*wakuext.Service
 	}
 
 	if b.wakuExtSrvc == nil {
-		b.wakuExtSrvc = wakuext.New(config.ShhextConfig, b.nodeBridge(), ext.EnvelopeSignalHandler{}, b.db)
+		b.wakuExtSrvc = wakuext.New(*config, b.nodeBridge(), ext.EnvelopeSignalHandler{}, b.db)
 	}
 
 	b.wakuExtSrvc.SetP2PServer(b.gethNode.Server())
@@ -165,7 +165,7 @@ func (b *StatusNode) wakuV2ExtService(config *params.NodeConfig) (*wakuv2ext.Ser
 		return nil, errors.New("geth node not initialized")
 	}
 	if b.wakuV2ExtSrvc == nil {
-		b.wakuV2ExtSrvc = wakuv2ext.New(config.ShhextConfig, b.nodeBridge(), ext.EnvelopeSignalHandler{}, b.db)
+		b.wakuV2ExtSrvc = wakuv2ext.New(*config, b.nodeBridge(), ext.EnvelopeSignalHandler{}, b.db)
 	}
 
 	b.wakuV2ExtSrvc.SetP2PServer(b.gethNode.Server())

--- a/params/config.go
+++ b/params/config.go
@@ -591,7 +591,8 @@ type ShhextConfig struct {
 	ConnectionTarget int
 	// RequestsDelay used to ensure that no similar requests are sent within short periods of time.
 	RequestsDelay time.Duration
-
+	// EnableMailserverCycle is used to enable the mailserver cycle to switch between trusted servers to retrieve the message history
+	EnableMailserverCycle bool
 	// MaxServerFailures defines maximum allowed expired requests before server will be swapped to another one.
 	MaxServerFailures int
 

--- a/protocol/common/feature_flags.go
+++ b/protocol/common/feature_flags.go
@@ -8,4 +8,7 @@ type FeatureFlags struct {
 
 	// PushNotification indicates whether we should be enabling the push notification feature
 	PushNotifications bool
+
+	// MailserverCycle indicates whether we should enable or not the mailserver cycle
+	MailserverCycle bool
 }

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -75,6 +75,7 @@ func (s *MessengerCommunitiesSuite) newMessengerWithOptions(shh types.Waku, priv
 		privateKey,
 		&testNode{shh: shh},
 		uuid.New().String(),
+		nil,
 		options...,
 	)
 	s.Require().NoError(err)

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -669,7 +669,12 @@ func (m *Messenger) handleConnectionChange(online bool) {
 		if m.pushNotificationClient != nil {
 			m.pushNotificationClient.Offline()
 		}
+
+		if m.config.featureFlags.MailserverCycle {
+			m.DisconnectActiveMailserver() // force mailserver cycle to run again
+		}
 	}
+
 	m.ensVerifier.SetOnline(online)
 }
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -623,6 +623,10 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 
 	}
 
+	if m.config.featureFlags.MailserverCycle {
+		m.StartMailserverCycle()
+	}
+
 	return response, nil
 }
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -624,7 +624,10 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	}
 
 	if m.config.featureFlags.MailserverCycle {
-		m.StartMailserverCycle()
+		err := m.StartMailserverCycle()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return response, nil

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -239,3 +239,10 @@ func WithClusterConfig(cc params.ClusterConfig) Option {
 		return nil
 	}
 }
+
+func WithMailserverCycle() func(c *config) error {
+	return func(c *config) error {
+		c.featureFlags.MailserverCycle = true
+		return nil
+	}
+}

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -54,6 +54,7 @@ type config struct {
 	multiAccount        *multiaccounts.Database
 	mailserversDatabase *mailservers.Database
 	account             *multiaccounts.Account
+	clusterConfig       params.ClusterConfig
 
 	verifyTransactionClient  EthClient
 	verifyENSURL             string
@@ -228,6 +229,13 @@ func WithENSVerificationConfig(onENSVerified func(*MessengerResponse), url, addr
 		c.onContactENSVerified = onENSVerified
 		c.verifyENSURL = url
 		c.verifyENSContractAddress = address
+		return nil
+	}
+}
+
+func WithClusterConfig(cc params.ClusterConfig) Option {
+	return func(c *config) error {
+		c.clusterConfig = cc
 		return nil
 	}
 }

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -1,0 +1,661 @@
+package protocol
+
+import (
+	"context"
+	"crypto/rand"
+	"math"
+	"math/big"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/status-im/go-waku/waku/v2/dnsdisc"
+	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/services/mailservers"
+	"github.com/status-im/status-go/signal"
+)
+
+const defaultBackoff = 30 * time.Second
+
+type byRTTMs []*mailservers.PingResult
+
+func (s byRTTMs) Len() int {
+	return len(s)
+}
+
+func (s byRTTMs) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byRTTMs) Less(i, j int) bool {
+	return *s[i].RTTMs < *s[j].RTTMs
+}
+
+func (m *Messenger) StartMailserverCycle() error {
+	canUseMailservers, err := m.settings.CanUseMailservers()
+	if err != nil {
+		return err
+	}
+	if !canUseMailservers {
+		return errors.New("mailserver use is not allowed")
+	}
+
+	m.logger.Debug("started mailserver cycle")
+
+	m.mailserverCycle.events = make(chan *p2p.PeerEvent, 20)
+	m.mailserverCycle.subscription = m.server.SubscribeEvents(m.mailserverCycle.events)
+
+	go m.checkMailserverConnection()
+	go m.updateWakuV1PeerStatus()
+	go m.updateWakuV2PeerStatus()
+	return nil
+}
+
+func (m *Messenger) DisconnectActiveMailserver() {
+	m.mailserverCycle.Lock()
+	defer m.mailserverCycle.Unlock()
+	m.disconnectActiveMailserver()
+}
+
+func (m *Messenger) disconnectV1Mailserver() {
+	// TODO: remove this function once WakuV1 is deprecated
+	if m.mailserverCycle.activeMailserver == nil {
+		return
+	}
+	m.logger.Info("Disconnecting active mailserver", zap.Any("nodeID", m.mailserverCycle.activeMailserver.ID()))
+	pInfo, ok := m.mailserverCycle.peers[m.mailserverCycle.activeMailserver.ID().String()]
+	if ok {
+		pInfo.status = disconnected
+		pInfo.canConnectAfter = time.Now().Add(defaultBackoff)
+		m.mailserverCycle.peers[m.mailserverCycle.activeMailserver.ID().String()] = pInfo
+	} else {
+		m.mailserverCycle.peers[m.mailserverCycle.activeMailserver.ID().String()] = peerStatus{
+			status:          disconnected,
+			canConnectAfter: time.Now().Add(defaultBackoff),
+		}
+	}
+
+	m.server.RemovePeer(m.mailserverCycle.activeMailserver)
+	m.mailserverCycle.activeMailserver = nil
+}
+
+func (m *Messenger) disconnectStoreNode() {
+	if m.mailserverCycle.activeStoreNode == nil {
+		return
+	}
+	m.logger.Info("Disconnecting active storeNode", zap.Any("nodeID", m.mailserverCycle.activeStoreNode.Pretty()))
+	pInfo, ok := m.mailserverCycle.peers[string(*m.mailserverCycle.activeStoreNode)]
+	if ok {
+		pInfo.status = disconnected
+		pInfo.canConnectAfter = time.Now().Add(defaultBackoff)
+		m.mailserverCycle.peers[string(*m.mailserverCycle.activeStoreNode)] = pInfo
+	} else {
+		m.mailserverCycle.peers[string(*m.mailserverCycle.activeStoreNode)] = peerStatus{
+			status:          disconnected,
+			canConnectAfter: time.Now().Add(defaultBackoff),
+		}
+	}
+
+	m.transport.DropPeer(string(*m.mailserverCycle.activeStoreNode))
+	m.mailserverCycle.activeStoreNode = nil
+}
+
+func (m *Messenger) disconnectActiveMailserver() {
+	switch m.transport.WakuVersion() {
+	case 1:
+		m.disconnectV1Mailserver()
+	case 2:
+		m.disconnectStoreNode()
+	}
+	signal.SendMailserverChanged("")
+}
+
+func (m *Messenger) cycleMailservers() {
+	m.mailserverCycle.Lock()
+	defer m.mailserverCycle.Unlock()
+
+	m.logger.Info("Automatically switching mailserver")
+
+	if m.mailserverCycle.activeMailserver != nil {
+		m.disconnectActiveMailserver()
+	}
+
+	err := m.findNewMailserver()
+	if err != nil {
+		m.logger.Error("Error getting new mailserver", zap.Error(err))
+	}
+}
+
+func poolSize(fleetSize int) int {
+	return int(math.Ceil(float64(fleetSize) / 4))
+}
+
+func (m *Messenger) findNewMailserver() error {
+	switch m.transport.WakuVersion() {
+	case 1:
+		return m.findNewMailserverV1()
+	case 2:
+		return m.findStoreNode()
+	default:
+		return errors.New("waku version is not supported")
+	}
+}
+
+func (m *Messenger) findStoreNode() error {
+	allMailservers := parseStoreNodeConfig(m.config.clusterConfig.StoreNodes)
+
+	// TODO: append user mailservers once that functionality is available for waku2
+
+	var mailserverList []multiaddr.Multiaddr
+	now := time.Now()
+	for _, node := range allMailservers {
+		pID, err := getPeerID(node)
+		if err != nil {
+			continue
+		}
+
+		pInfo, ok := m.mailserverCycle.peers[string(pID)]
+		if !ok || pInfo.canConnectAfter.Before(now) {
+			mailserverList = append(mailserverList, node)
+		}
+	}
+
+	m.logger.Info("Finding a new store node...")
+
+	var mailserverStr []string
+	for _, m := range mailserverList {
+		mailserverStr = append(mailserverStr, m.String())
+	}
+
+	pingResult, err := mailservers.DoPing(context.Background(), mailserverStr, 500, mailservers.MultiAddressToAddress)
+	if err != nil {
+		return err
+	}
+
+	var availableMailservers []*mailservers.PingResult
+	for _, result := range pingResult {
+		if result.Err != nil {
+			continue // The results with error are ignored
+		}
+		availableMailservers = append(availableMailservers, result)
+	}
+	sort.Sort(byRTTMs(availableMailservers))
+
+	if len(availableMailservers) == 0 {
+		m.logger.Warn("No store nodes available") // Do nothing...
+		return nil
+	}
+
+	// Picks a random mailserver amongs the ones with the lowest latency
+	// The pool size is 1/4 of the mailservers were pinged successfully
+	pSize := poolSize(len(availableMailservers) - 1)
+	if pSize <= 0 {
+		m.logger.Warn("No store nodes available") // Do nothing...
+		return nil
+	}
+
+	r, err := rand.Int(rand.Reader, big.NewInt(int64(pSize)))
+	if err != nil {
+		return err
+	}
+
+	return m.connectToStoreNode(parseMultiaddresses([]string{availableMailservers[r.Int64()].Address})[0])
+}
+
+func (m *Messenger) findNewMailserverV1() error {
+	// TODO: remove this function once WakuV1 is deprecated
+
+	allMailservers := parseNodes(m.config.clusterConfig.TrustedMailServers)
+
+	// Append user mailservers
+	var fleet string
+	dbFleet, err := m.settings.GetFleet()
+	if err != nil {
+		return err
+	}
+	if dbFleet != "" {
+		fleet = dbFleet
+	} else if m.config.clusterConfig.Fleet != "" {
+		fleet = m.config.clusterConfig.Fleet
+	} else {
+		fleet = params.FleetProd
+	}
+
+	customMailservers, err := m.mailservers.Mailservers()
+	if err != nil {
+		return err
+	}
+	for _, c := range customMailservers {
+		if c.Fleet == fleet {
+			mNode, err := enode.ParseV4(c.Address)
+			if err != nil {
+				allMailservers = append(allMailservers, mNode)
+			}
+		}
+	}
+
+	var mailserverList []*enode.Node
+	now := time.Now()
+	for _, node := range allMailservers {
+		pInfo, ok := m.mailserverCycle.peers[node.ID().String()]
+		if !ok || pInfo.canConnectAfter.Before(now) {
+			mailserverList = append(mailserverList, node)
+		}
+	}
+
+	m.logger.Info("Finding a new mailserver...")
+
+	var mailserverStr []string
+	for _, m := range mailserverList {
+		mailserverStr = append(mailserverStr, m.String())
+	}
+
+	pingResult, err := mailservers.DoPing(context.Background(), mailserverStr, 500, mailservers.EnodeStringToAddr)
+	if err != nil {
+		return err
+	}
+
+	var availableMailservers []*mailservers.PingResult
+	for _, result := range pingResult {
+		if result.Err != nil {
+			continue // The results with error are ignored
+		}
+		availableMailservers = append(availableMailservers, result)
+	}
+	sort.Sort(byRTTMs(availableMailservers))
+
+	if len(availableMailservers) == 0 {
+		m.logger.Warn("No mailservers available") // Do nothing...
+		return nil
+	}
+
+	// Picks a random mailserver amongs the ones with the lowest latency
+	// The pool size is 1/4 of the mailservers were pinged successfully
+	pSize := poolSize(len(availableMailservers) - 1)
+	r, err := rand.Int(rand.Reader, big.NewInt(int64(pSize)))
+	if err != nil {
+		return err
+	}
+
+	return m.connectToMailserver(parseNodes([]string{availableMailservers[r.Int64()].Address})[0])
+}
+
+func (m *Messenger) activeMailserverStatus() (connStatus, error) {
+	var mailserverID string
+	switch m.transport.WakuVersion() {
+	case 1:
+		if m.mailserverCycle.activeMailserver == nil {
+			return disconnected, errors.New("Active mailserver is not set")
+		}
+		mailserverID = m.mailserverCycle.activeMailserver.ID().String()
+	case 2:
+		if m.mailserverCycle.activeStoreNode == nil {
+			return disconnected, errors.New("Active storenode is not set")
+		}
+		mailserverID = string(*m.mailserverCycle.activeStoreNode)
+	default:
+		return disconnected, errors.New("waku version is not supported")
+	}
+
+	return m.mailserverCycle.peers[mailserverID].status, nil
+}
+
+func (m *Messenger) connectToMailserver(node *enode.Node) error {
+	// TODO: remove this function once WakuV1 is deprecated
+
+	if m.transport.WakuVersion() != 1 {
+		return nil // This can only be used with wakuV1
+	}
+
+	m.logger.Info("Connecting to mailserver", zap.Any("peer", node.ID()))
+	nodeConnected := false
+
+	m.mailserverCycle.activeMailserver = node
+	signal.SendMailserverChanged(m.mailserverCycle.activeMailserver.String())
+
+	// Adding a peer and marking it as connected can't be executed sync in WakuV1, because
+	// There's a delay between requesting a peer being added, and a signal being
+	// received after the peer was added. So we first set the peer status as
+	// Connecting and once a peerConnected signal is received, we mark it as
+	// Connected
+	activeMailserverStatus, err := m.activeMailserverStatus()
+	if err != nil {
+		return err
+	}
+
+	if activeMailserverStatus == connected {
+		nodeConnected = true
+	} else {
+		// Attempt to connect to mailserver by adding it as a peer
+		m.SetMailserver(node.ID().Bytes())
+		m.server.AddPeer(node)
+		if err := m.peerStore.Update([]*enode.Node{node}); err != nil {
+			return err
+		}
+
+		pInfo, ok := m.mailserverCycle.peers[node.ID().String()]
+		if ok {
+			pInfo.status = connecting
+			pInfo.lastConnectionAttempt = time.Now()
+			m.mailserverCycle.peers[node.ID().String()] = pInfo
+		} else {
+			m.mailserverCycle.peers[node.ID().String()] = peerStatus{
+				status:                connecting,
+				lastConnectionAttempt: time.Now(),
+			}
+		}
+	}
+
+	if nodeConnected {
+		m.logger.Info("Mailserver available")
+		signal.SendMailserverAvailable(m.mailserverCycle.activeMailserver.String())
+	}
+
+	return nil
+}
+
+func (m *Messenger) connectToStoreNode(node multiaddr.Multiaddr) error {
+	if m.transport.WakuVersion() != 2 {
+		return nil // This can only be used with wakuV2
+	}
+
+	m.logger.Info("Connecting to storenode", zap.Any("peer", node))
+
+	nodeConnected := false
+
+	peerID, err := getPeerID(node)
+	if err != nil {
+		return err
+	}
+
+	m.mailserverCycle.activeStoreNode = &peerID
+	signal.SendMailserverChanged(m.mailserverCycle.activeStoreNode.Pretty())
+
+	// Adding a peer and marking it as connected can't be executed sync in WakuV1, because
+	// There's a delay between requesting a peer being added, and a signal being
+	// received after the peer was added. So we first set the peer status as
+	// Connecting and once a peerConnected signal is received, we mark it as
+	// Connected
+	activeMailserverStatus, err := m.activeMailserverStatus()
+	if err != nil {
+		return err
+	}
+
+	if activeMailserverStatus == connected {
+		nodeConnected = true
+	} else {
+		// Attempt to connect to mailserver by adding it as a peer
+		m.SetMailserver([]byte(peerID.Pretty()))
+		if err := m.transport.DialPeer(node.String()); err != nil {
+			return err
+		}
+
+		pInfo, ok := m.mailserverCycle.peers[string(peerID)]
+		if ok {
+			pInfo.status = connected
+			pInfo.lastConnectionAttempt = time.Now()
+		} else {
+			m.mailserverCycle.peers[string(peerID)] = peerStatus{
+				status:                connected,
+				lastConnectionAttempt: time.Now(),
+			}
+		}
+
+		nodeConnected = true
+	}
+
+	if nodeConnected {
+		m.logger.Info("Storenode available")
+		signal.SendMailserverAvailable(m.mailserverCycle.activeStoreNode.Pretty())
+	}
+
+	return nil
+}
+
+func (m *Messenger) isActiveMailserverAvailable() bool {
+	m.mailserverCycle.RLock()
+	defer m.mailserverCycle.RUnlock()
+
+	mailserverStatus, err := m.activeMailserverStatus()
+	if err != nil {
+		return false
+	}
+
+	return mailserverStatus == connected
+}
+
+func (m *Messenger) updateWakuV2PeerStatus() {
+	if m.transport.WakuVersion() != 2 {
+		return // This can only be used with wakuV2
+	}
+
+	connSubscription, err := m.transport.SubscribeToConnStatusChanges()
+	if err != nil {
+		m.logger.Error("Could not subscribe to connection status changes", zap.Error(err))
+	}
+
+	for {
+		select {
+		case status := <-connSubscription.C:
+			m.mailserverCycle.Lock()
+
+			for pID, pInfo := range m.mailserverCycle.peers {
+				if pInfo.status == disconnected {
+					continue
+				}
+
+				// Removing disconnected
+
+				found := false
+				for connectedPeer := range status.Peers {
+					peerID, err := peer.Decode(connectedPeer)
+					if err != nil {
+						continue
+					}
+
+					if string(peerID) == pID {
+						found = true
+						break
+					}
+				}
+				if !found && pInfo.status == connected {
+					m.logger.Info("Peer disconnected", zap.String("peer", peer.ID(pID).Pretty()))
+					pInfo.status = disconnected
+					pInfo.canConnectAfter = time.Now().Add(defaultBackoff)
+				}
+
+				m.mailserverCycle.peers[pID] = pInfo
+			}
+
+			for connectedPeer := range status.Peers {
+				peerID, err := peer.Decode(connectedPeer)
+				if err != nil {
+					continue
+				}
+
+				pInfo, ok := m.mailserverCycle.peers[string(peerID)]
+				if !ok || pInfo.status != connected {
+					m.logger.Info("Peer connected", zap.String("peer", connectedPeer))
+					pInfo.status = connected
+					pInfo.canConnectAfter = time.Now().Add(defaultBackoff)
+					m.mailserverCycle.peers[string(peerID)] = pInfo
+				}
+			}
+			m.mailserverCycle.Unlock()
+
+		case <-m.quit:
+			connSubscription.Unsubscribe()
+			return
+		}
+	}
+}
+
+func (m *Messenger) updateWakuV1PeerStatus() {
+	// TODO: remove this function once WakuV1 is deprecated
+
+	if m.transport.WakuVersion() != 1 {
+		return // This can only be used with wakuV1
+	}
+
+	for {
+		select {
+		case <-m.mailserverCycle.events:
+			connectedPeers := m.server.PeersInfo()
+			m.mailserverCycle.Lock()
+
+			for pID, pInfo := range m.mailserverCycle.peers {
+				if pInfo.status == disconnected {
+					continue
+				}
+
+				// Removing disconnected
+
+				found := false
+				for _, connectedPeer := range connectedPeers {
+					if enode.HexID(connectedPeer.ID) == enode.HexID(pID) {
+						found = true
+						break
+					}
+				}
+				if !found && (pInfo.status == connected || (pInfo.status == connecting && pInfo.lastConnectionAttempt.Add(8*time.Second).Before(time.Now()))) {
+					m.logger.Info("Peer disconnected", zap.String("peer", enode.HexID(pID).String()))
+					pInfo.status = disconnected
+					pInfo.canConnectAfter = time.Now().Add(defaultBackoff)
+				}
+
+				m.mailserverCycle.peers[pID] = pInfo
+			}
+
+			for _, connectedPeer := range connectedPeers {
+				hexID := enode.HexID(connectedPeer.ID).String()
+				pInfo, ok := m.mailserverCycle.peers[hexID]
+				if !ok || pInfo.status != connected {
+					m.logger.Info("Peer connected", zap.String("peer", hexID))
+					pInfo.status = connected
+					pInfo.canConnectAfter = time.Now().Add(defaultBackoff)
+					if m.mailserverCycle.activeMailserver != nil && hexID == m.mailserverCycle.activeMailserver.ID().String() {
+						m.logger.Info("Mailserver available")
+						signal.SendMailserverAvailable(m.mailserverCycle.activeMailserver.String())
+					}
+					m.mailserverCycle.peers[hexID] = pInfo
+				}
+			}
+			m.mailserverCycle.Unlock()
+		case <-m.quit:
+			m.mailserverCycle.Lock()
+			defer m.mailserverCycle.Unlock()
+			close(m.mailserverCycle.events)
+			m.mailserverCycle.subscription.Unsubscribe()
+			return
+		}
+	}
+}
+
+func (m *Messenger) checkMailserverConnection() {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		m.logger.Info("Verifying mailserver connection state...")
+		//	m.settings.GetPinnedMailserver
+		//if pinnedMailserver != "" && self.activeMailserver != pinnedMailserver {
+		// connect to current mailserver from the settings
+		// self.mailservers = pinnedMailserver
+		// self.connect(pinnedMailserver)
+		//} else {
+		// or setup a random mailserver:
+		if !m.isActiveMailserverAvailable() {
+			m.cycleMailservers()
+		}
+		// }
+
+		select {
+		case <-m.quit:
+			return
+		case <-ticker.C:
+			continue
+		}
+	}
+}
+
+func parseNodes(enodes []string) []*enode.Node {
+	var nodes []*enode.Node
+	for _, item := range enodes {
+		parsedPeer, err := enode.ParseV4(item)
+		if err == nil {
+			nodes = append(nodes, parsedPeer)
+		}
+	}
+	return nodes
+}
+
+func parseMultiaddresses(addresses []string) []multiaddr.Multiaddr {
+	var result []multiaddr.Multiaddr
+	for _, item := range addresses {
+		ma, err := multiaddr.NewMultiaddr(item)
+		if err == nil {
+			result = append(result, ma)
+		}
+	}
+	return result
+}
+
+func parseStoreNodeConfig(addresses []string) []multiaddr.Multiaddr {
+	// TODO: once a scoring/reputation mechanism is added to waku,
+	// this function can be modified to retrieve the storenodes
+	// from waku peerstore.
+	// We don't do that now because we can't trust any random storenode
+	// So we use only those specified in the cluster config
+	var result []multiaddr.Multiaddr
+	var dnsDiscWg sync.WaitGroup
+
+	maChan := make(chan multiaddr.Multiaddr, 1000)
+
+	for _, addrString := range addresses {
+		if strings.HasPrefix(addrString, "enrtree://") {
+			// Use DNS Discovery
+			dnsDiscWg.Add(1)
+			go func(addr string) {
+				defer dnsDiscWg.Done()
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				multiaddresses, err := dnsdisc.RetrieveNodes(ctx, addr)
+				if err == nil {
+					for _, ma := range multiaddresses {
+						maChan <- ma
+					}
+				}
+			}(addrString)
+
+		} else {
+			// It's a normal multiaddress
+			ma, err := multiaddr.NewMultiaddr(addrString)
+			if err == nil {
+				maChan <- ma
+			}
+		}
+	}
+	dnsDiscWg.Wait()
+	close(maChan)
+	for ma := range maChan {
+		result = append(result, ma)
+	}
+
+	return result
+}
+
+func getPeerID(addr multiaddr.Multiaddr) (peer.ID, error) {
+	idStr, err := addr.ValueForProtocol(multiaddr.P_P2P)
+	if err != nil {
+		return "", err
+	}
+	return peer.Decode(idStr)
+}

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -15,9 +15,10 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	"github.com/status-im/go-waku/waku/v2/dnsdisc"
+
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/status-im/go-waku/waku/v2/dnsdisc"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/mailservers"
 	"github.com/status-im/status-go/signal"
@@ -104,7 +105,11 @@ func (m *Messenger) disconnectStoreNode() {
 		}
 	}
 
-	m.transport.DropPeer(string(*m.mailserverCycle.activeStoreNode))
+	err := m.transport.DropPeer(string(*m.mailserverCycle.activeStoreNode))
+	if err != nil {
+		m.logger.Warn("Could not drop peer")
+	}
+
 	m.mailserverCycle.activeStoreNode = nil
 }
 

--- a/protocol/messenger_response_test.go
+++ b/protocol/messenger_response_test.go
@@ -55,22 +55,22 @@ func TestMessengerResponseMergeNotImplemented(t *testing.T) {
 	response1 := &MessengerResponse{}
 
 	response2 := &MessengerResponse{
-		Contacts: []*Contact{&Contact{}},
+		Contacts: []*Contact{{}},
 	}
 	require.Error(t, response1.Merge(response2))
 
 	response2 = &MessengerResponse{
-		Installations: []*multidevice.Installation{&multidevice.Installation{}},
+		Installations: []*multidevice.Installation{{}},
 	}
 	require.Error(t, response1.Merge(response2))
 
 	response2 = &MessengerResponse{
-		EmojiReactions: []*EmojiReaction{&EmojiReaction{}},
+		EmojiReactions: []*EmojiReaction{{}},
 	}
 	require.Error(t, response1.Merge(response2))
 
 	response2 = &MessengerResponse{
-		Invitations: []*GroupChatInvitation{&GroupChatInvitation{}},
+		Invitations: []*GroupChatInvitation{{}},
 	}
 	require.Error(t, response1.Merge(response2))
 

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -145,6 +145,7 @@ func newMessengerWithKey(shh types.Waku, privateKey *ecdsa.PrivateKey, logger *z
 		privateKey,
 		&testNode{shh: shh},
 		uuid.New().String(),
+		nil,
 		options...,
 	)
 	if err != nil {

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -642,3 +642,7 @@ func (t *Transport) ProcessingP2PMessages() bool {
 func (t *Transport) MarkP2PMessageAsProcessed(hash common.Hash) {
 	t.waku.MarkP2PMessageAsProcessed(hash)
 }
+
+func (t *Transport) SubscribeToConnStatusChanges() (*types.ConnStatusSubscription, error) {
+	return t.waku.SubscribeToConnStatusChanges()
+}

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -909,6 +909,14 @@ func (api *PublicAPI) RequestAllHistoricMessages() (*protocol.MessengerResponse,
 	return api.service.messenger.RequestAllHistoricMessages()
 }
 
+func (api *PublicAPI) StartMailserverCycle() error {
+	return api.service.messenger.StartMailserverCycle()
+}
+
+func (api *PublicAPI) DisconnectActiveMailserver() {
+	api.service.messenger.DisconnectActiveMailserver()
+}
+
 // Echo is a method for testing purposes.
 func (api *PublicAPI) Echo(ctx context.Context, message string) (string, error) {
 	return message, nil

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -909,10 +909,6 @@ func (api *PublicAPI) RequestAllHistoricMessages() (*protocol.MessengerResponse,
 	return api.service.messenger.RequestAllHistoricMessages()
 }
 
-func (api *PublicAPI) StartMailserverCycle() error {
-	return api.service.messenger.StartMailserverCycle()
-}
-
 func (api *PublicAPI) DisconnectActiveMailserver() {
 	api.service.messenger.DisconnectActiveMailserver()
 }

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -421,6 +421,10 @@ func buildMessengerOptions(
 		options = append(options, protocol.WithDatasync())
 	}
 
+	if config.ShhextConfig.EnableMailserverCycle {
+		options = append(options, protocol.WithMailserverCycle())
+	}
+
 	settings, err := accountsDB.GetSettings()
 	if err != sql.ErrNoRows && err != nil {
 		return nil, err

--- a/services/wakuext/api_test.go
+++ b/services/wakuext/api_test.go
@@ -53,10 +53,12 @@ func TestRequestMessagesErrors(t *testing.T) {
 	defer func() { require.NoError(t, aNode.Close()) }()
 
 	handler := ext.NewHandlerMock(1)
-	config := params.ShhextConfig{
-		InstallationID:        "1",
-		BackupDisabledDataDir: os.TempDir(),
-		PFSEnabled:            true,
+	config := params.NodeConfig{
+		ShhextConfig: params.ShhextConfig{
+			InstallationID:        "1",
+			BackupDisabledDataDir: os.TempDir(),
+			PFSEnabled:            true,
+		},
 	}
 	nodeWrapper := ext.NewTestNodeWrapper(nil, waku)
 	service := New(config, nodeWrapper, handler, nil)
@@ -102,12 +104,14 @@ func TestInitProtocol(t *testing.T) {
 	directory, err := ioutil.TempDir("", "status-go-testing")
 	require.NoError(t, err)
 
-	config := params.ShhextConfig{
-		InstallationID:          "2",
-		BackupDisabledDataDir:   directory,
-		PFSEnabled:              true,
-		MailServerConfirmations: true,
-		ConnectionTarget:        10,
+	config := params.NodeConfig{
+		ShhextConfig: params.ShhextConfig{
+			InstallationID:          "2",
+			BackupDisabledDataDir:   directory,
+			PFSEnabled:              true,
+			MailServerConfirmations: true,
+			ConnectionTarget:        10,
+		},
 	}
 	db, err := leveldb.Open(storage.NewMemStorage(), nil)
 	require.NoError(t, err)
@@ -171,12 +175,14 @@ func (s *ShhExtSuite) createAndAddNode() {
 	s.NoError(err)
 
 	// set up protocol
-	config := params.ShhextConfig{
-		InstallationID:          "1",
-		BackupDisabledDataDir:   s.dir,
-		PFSEnabled:              true,
-		MailServerConfirmations: true,
-		ConnectionTarget:        10,
+	config := params.NodeConfig{
+		ShhextConfig: params.ShhextConfig{
+			InstallationID:          "1",
+			BackupDisabledDataDir:   s.dir,
+			PFSEnabled:              true,
+			MailServerConfirmations: true,
+			ConnectionTarget:        10,
+		},
 	}
 	db, err := leveldb.Open(storage.NewMemStorage(), nil)
 	s.Require().NoError(err)

--- a/services/wakuext/service.go
+++ b/services/wakuext/service.go
@@ -15,14 +15,14 @@ type Service struct {
 	w types.Waku
 }
 
-func New(config params.ShhextConfig, n types.Node, handler ext.EnvelopeEventsHandler, ldb *leveldb.DB) *Service {
+func New(config params.NodeConfig, n types.Node, handler ext.EnvelopeEventsHandler, ldb *leveldb.DB) *Service {
 	w, err := n.GetWaku(nil)
 	if err != nil {
 		panic(err)
 	}
 	delay := ext.DefaultRequestsDelay
-	if config.RequestsDelay != 0 {
-		delay = config.RequestsDelay
+	if config.ShhextConfig.RequestsDelay != 0 {
+		delay = config.ShhextConfig.RequestsDelay
 	}
 	requestsRegistry := ext.NewRequestsRegistry(delay)
 	mailMonitor := ext.NewMailRequestMonitor(w, handler, requestsRegistry)

--- a/services/wakuv2ext/service.go
+++ b/services/wakuv2ext/service.go
@@ -15,14 +15,14 @@ type Service struct {
 	w types.Waku
 }
 
-func New(config params.ShhextConfig, n types.Node, handler ext.EnvelopeEventsHandler, ldb *leveldb.DB) *Service {
+func New(config params.NodeConfig, n types.Node, handler ext.EnvelopeEventsHandler, ldb *leveldb.DB) *Service {
 	w, err := n.GetWakuV2(nil)
 	if err != nil {
 		panic(err)
 	}
 	delay := ext.DefaultRequestsDelay
-	if config.RequestsDelay != 0 {
-		delay = config.RequestsDelay
+	if config.ShhextConfig.RequestsDelay != 0 {
+		delay = config.ShhextConfig.RequestsDelay
 	}
 	requestsRegistry := ext.NewRequestsRegistry(delay)
 	mailMonitor := ext.NewMailRequestMonitor(w, handler, requestsRegistry)

--- a/signal/events_shhext.go
+++ b/signal/events_shhext.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-
 	"github.com/status-im/status-go/eth-node/types"
 )
 
@@ -49,6 +48,12 @@ const (
 
 	// EventBackupPerformed is triggered when a backup has been performed
 	EventBackupPerformed = "backup.performed"
+
+	// EventMailserverAvailable is triggered when a mailserver becomes available
+	EventMailserverAvailable = "mailserver.available"
+
+	// EventMailserverChanged is triggered when switching the active mailserver
+	EventMailserverChanged = "mailserver.changed"
 )
 
 // EnvelopeSignal includes hash of the envelope.
@@ -82,6 +87,10 @@ type DecryptMessageFailedSignal struct {
 type BundleAddedSignal struct {
 	Identity       string `json:"identity"`
 	InstallationID string `json:"installationID"`
+}
+
+type MailserverSignal struct {
+	Address string `json:"address"`
 }
 
 type Filter struct {
@@ -194,4 +203,16 @@ func SendBundleAdded(identity string, installationID string) {
 
 func SendNewMessages(obj json.Marshaler) {
 	send(EventNewMessages, obj)
+}
+
+func SendMailserverAvailable(nodeAddress string) {
+	send(EventMailserverAvailable, MailserverSignal{
+		Address: nodeAddress,
+	})
+}
+
+func SendMailserverChanged(nodeAddress string) {
+	send(EventMailserverChanged, MailserverSignal{
+		Address: nodeAddress,
+	})
 }


### PR DESCRIPTION
This PR moves the logic for the mailserver cycle from desktop to status-go. Future iterations might even include an automatic call to request the mailserver history, but in the meanwhile this should be handled on Desktop.

The following API methods are added:
- "wakuext_startMailserverCycle". Should be called on login
- "wakuext_disconnectActiveMailserver". Should be called when "wakuext_requestAllHistoricMessages" returns an error. In the future this API method will be removed, once status-go handles the history requests by itself.

Two new signals are added:
- "mailserver.available": triggered as soon as a mailserver becomes available. This signal should be used to know when to request the mailserver history.
- "mailserver.changed": triggered when the mailserver is switched (this happens when the mailserver cycle is executed, and the current mailserver is disconnected). This signal is useful to display the current mailserver.

**Note:** There is a some duplication of code because we have to handle both WakuV1 and WakuV2, but this is something that will be solved by itself in medium term once we migrate to wakuv2 and remove wakuv1 code.
In a separate PR the code for handling pinned mailservers will be added.