### PR TITLE
fix: mailserver response time

### DIFF
--- a/services/mailservers/tcp_ping.go
+++ b/services/mailservers/tcp_ping.go
@@ -31,7 +31,7 @@ func (pr *PingResult) Update(rttMs int, err error) {
 		errStr := err.Error()
 		pr.Err = &errStr
 	}
-	if rttMs > 0 {
+	if rttMs >= 0 {
 		pr.RTTMs = &rttMs
 	} else {
 		pr.RTTMs = nil


### PR DESCRIPTION
RTTMs were being set nil when the response time was less than 1ms