### PR TITLE
[#12783] Improve order of mailserver requests

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3736,7 +3736,7 @@ func (m *Messenger) markAllRead(chatID string, clock uint64, shouldBeSynced bool
 
 	// TODO(samyoul) remove storing of an updated reference pointer?
 	m.allChats.Store(chat.ID, chat)
-	return nil
+	return m.persistence.SaveChats([]*Chat{chat})
 }
 
 func (m *Messenger) MarkAllRead(chatID string) error {

--- a/protocol/transport/filter.go
+++ b/protocol/transport/filter.go
@@ -25,6 +25,8 @@ type Filter struct {
 	Listen bool `json:"listen"`
 	// Ephemeral indicates that this is an ephemeral filter
 	Ephemeral bool `json:"ephemeral"`
+	// Priority
+	Priority uint64
 }
 
 func (c *Filter) IsPublic() bool {


### PR DESCRIPTION
needed for status-im/status-react#12783

Before syncing, topics are sorted by priority. In case if all topics have zero priority requests are executed as before. Otherwise, topics with higher priority are requested in first N batches (currently three batches with 1, 5, 10 topics. That's arbitrary, emphasis is on the first batch), and the rest of topics are requested as before.

`chat.ReadMessagesAtClockValue` is used to prioritise topics before historical requests as it is always updated when the user opens chat (at least in mobile version). We can add a separate field for this but I'm not sure this is necessary.
 
status: ready