### PR TITLE
feat: unified chat API pt. 2

### DIFF
--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -381,7 +381,7 @@ func (b *StatusNode) gifService() *gif.Service {
 
 func (b *StatusNode) ChatService() *chat.Service {
 	if b.chatSrvc == nil {
-		b.chatSrvc = chat.NewService(b.appDB)
+		b.chatSrvc = chat.NewService()
 	}
 	return b.chatSrvc
 }

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -682,6 +682,10 @@ func (o *Community) Muted() bool {
 	return o.config.Muted
 }
 
+func (o *Community) MemberIdentity() *ecdsa.PublicKey {
+	return o.config.MemberIdentity
+}
+
 // UpdateCommunityDescription will update the community to the new community description and return a list of changes
 func (o *Community) UpdateCommunityDescription(signer *ecdsa.PublicKey, description *protobuf.CommunityDescription, rawMessage []byte) (*CommunityChanges, error) {
 	o.mutex.Lock()

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -633,6 +633,10 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	return response, nil
 }
 
+func (m *Messenger) IdentityPublicKey() *ecdsa.PublicKey {
+	return &m.identity.PublicKey
+}
+
 // cleanTopics remove any topic that does not have a Listen flag set
 func (m *Messenger) cleanTopics() error {
 	if m.mailserversDatabase == nil {

--- a/services/chat/api_group_chats.go
+++ b/services/chat/api_group_chats.go
@@ -1,0 +1,207 @@
+package chat
+
+import (
+	"context"
+
+	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/protocol"
+	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/requests"
+)
+
+type GroupChatResponse struct {
+	Chat     *Chat             `json:"chat"`
+	Messages []*common.Message `json:"messages"`
+}
+
+type GroupChatResponseWithInvitations struct {
+	Chat        *Chat                           `json:"chat"`
+	Messages    []*common.Message               `json:"messages"`
+	Invitations []*protocol.GroupChatInvitation `json:"invitations"`
+}
+
+type CreateOneToOneChatResponse struct {
+	Chat    *Chat             `json:"chat,omitempty"`
+	Contact *protocol.Contact `json:"contact,omitempty"`
+}
+
+type StartGroupChatResponse struct {
+	Chat     *Chat               `json:"chat,omitempty"`
+	Contacts []*protocol.Contact `json:"contacts"`
+	Messages []*common.Message   `json:"messages,omitempty"`
+}
+
+func (api *API) CreateOneToOneChat(ctx context.Context, ID types.HexBytes, ensName string) (*CreateOneToOneChatResponse, error) {
+	pubKey := types.EncodeHex(crypto.FromECDSAPub(api.s.messenger.IdentityPublicKey()))
+	response, err := api.s.messenger.CreateOneToOneChat(&requests.CreateOneToOneChat{ID: ID, ENSName: ensName})
+	if err != nil {
+		return nil, err
+	}
+
+	protocolChat := response.Chats()[0]
+	pinnedMessages, cursor, err := api.s.messenger.PinnedMessageByChatID(protocolChat.ID, "", -1)
+	if err != nil {
+		return nil, err
+	}
+	chat, err := toAPIChat(protocolChat, nil, pubKey, pinnedMessages, cursor)
+	if err != nil {
+		return nil, err
+	}
+
+	var contact *protocol.Contact
+	if ensName != "" {
+		contact = response.Contacts[0]
+	}
+
+	return &CreateOneToOneChatResponse{
+		Chat:    chat,
+		Contact: contact,
+	}, nil
+}
+
+func (api *API) CreateGroupChat(ctx context.Context, name string, members []string) (*GroupChatResponse, error) {
+	return api.execAndGetGroupChatResponse(func() (*protocol.MessengerResponse, error) {
+		return api.s.messenger.CreateGroupChatWithMembers(ctx, name, members)
+	})
+}
+
+func (api *API) CreateGroupChatFromInvitation(name string, chatID string, adminPK string) (*GroupChatResponse, error) {
+	return api.execAndGetGroupChatResponse(func() (*protocol.MessengerResponse, error) {
+		return api.s.messenger.CreateGroupChatFromInvitation(name, chatID, adminPK)
+	})
+}
+
+func (api *API) LeaveGroupChat(ctx context.Context, chatID string, remove bool) (*GroupChatResponse, error) {
+	return api.execAndGetGroupChatResponse(func() (*protocol.MessengerResponse, error) {
+		return api.s.messenger.LeaveGroupChat(ctx, chatID, remove)
+	})
+}
+
+func (api *API) AddMembersToGroupChat(ctx context.Context, chatID string, members []string) (*GroupChatResponseWithInvitations, error) {
+	return api.execAndGetGroupChatResponseWithInvitations(func() (*protocol.MessengerResponse, error) {
+		return api.s.messenger.AddMembersToGroupChat(ctx, chatID, members)
+	})
+}
+
+func (api *API) RemoveMemberFromGroupChat(ctx context.Context, chatID string, member string) (*GroupChatResponse, error) {
+	return api.execAndGetGroupChatResponse(func() (*protocol.MessengerResponse, error) {
+		return api.s.messenger.RemoveMemberFromGroupChat(ctx, chatID, member)
+	})
+}
+
+func (api *API) AddAdminsToGroupChat(ctx context.Context, chatID string, members []string) (*GroupChatResponse, error) {
+	return api.execAndGetGroupChatResponse(func() (*protocol.MessengerResponse, error) {
+		return api.s.messenger.AddAdminsToGroupChat(ctx, chatID, members)
+	})
+}
+
+func (api *API) ConfirmJoiningGroup(ctx context.Context, chatID string) (*GroupChatResponse, error) {
+	return api.execAndGetGroupChatResponse(func() (*protocol.MessengerResponse, error) {
+		return api.s.messenger.ConfirmJoiningGroup(ctx, chatID)
+	})
+}
+
+func (api *API) ChangeGroupChatName(ctx context.Context, chatID string, name string) (*GroupChatResponse, error) {
+	return api.execAndGetGroupChatResponse(func() (*protocol.MessengerResponse, error) {
+		return api.s.messenger.ChangeGroupChatName(ctx, chatID, name)
+	})
+}
+
+func (api *API) SendGroupChatInvitationRequest(ctx context.Context, chatID string, adminPK string, message string) (*GroupChatResponseWithInvitations, error) {
+	return api.execAndGetGroupChatResponseWithInvitations(func() (*protocol.MessengerResponse, error) {
+		return api.s.messenger.SendGroupChatInvitationRequest(ctx, chatID, adminPK, message)
+	})
+}
+
+func (api *API) GetGroupChatInvitations() ([]*protocol.GroupChatInvitation, error) {
+	return api.s.messenger.GetGroupChatInvitations()
+}
+
+func (api *API) SendGroupChatInvitationRejection(ctx context.Context, invitationRequestID string) ([]*protocol.GroupChatInvitation, error) {
+	response, err := api.s.messenger.SendGroupChatInvitationRejection(ctx, invitationRequestID)
+	if err != nil {
+		return nil, err
+	}
+	return response.Invitations, nil
+}
+
+func (api *API) StartGroupChat(ctx context.Context, name string, members []string) (*StartGroupChatResponse, error) {
+	pubKey := types.EncodeHex(crypto.FromECDSAPub(api.s.messenger.IdentityPublicKey()))
+
+	var response *protocol.MessengerResponse
+	var err error
+	if len(members) == 1 {
+		memberPk, err := common.HexToPubkey(members[0])
+		if err != nil {
+			return nil, err
+		}
+		response, err = api.s.messenger.CreateOneToOneChat(&requests.CreateOneToOneChat{
+			ID: types.HexBytes(crypto.FromECDSAPub(memberPk)),
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		response, err = api.s.messenger.CreateGroupChatWithMembers(ctx, name, members)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	chat, err := toAPIChat(response.Chats()[0], nil, pubKey, nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return &StartGroupChatResponse{
+		Chat:     chat,
+		Contacts: response.Contacts,
+		Messages: response.Messages(),
+	}, nil
+}
+
+func toGroupChatResponse(pubKey string, response *protocol.MessengerResponse) (*GroupChatResponse, error) {
+	chat, err := toAPIChat(response.Chats()[0], nil, pubKey, nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return &GroupChatResponse{
+		Chat:     chat,
+		Messages: response.Messages(),
+	}, nil
+}
+
+func toGroupChatResponseWithInvitations(pubKey string, response *protocol.MessengerResponse) (*GroupChatResponseWithInvitations, error) {
+	g, err := toGroupChatResponse(pubKey, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GroupChatResponseWithInvitations{
+		Chat:        g.Chat,
+		Messages:    g.Messages,
+		Invitations: response.Invitations,
+	}, nil
+}
+
+func (api *API) execAndGetGroupChatResponse(fn func() (*protocol.MessengerResponse, error)) (*GroupChatResponse, error) {
+	pubKey := types.EncodeHex(crypto.FromECDSAPub(api.s.messenger.IdentityPublicKey()))
+	response, err := fn()
+	if err != nil {
+		return nil, err
+	}
+	return toGroupChatResponse(pubKey, response)
+}
+
+func (api *API) execAndGetGroupChatResponseWithInvitations(fn func() (*protocol.MessengerResponse, error)) (*GroupChatResponseWithInvitations, error) {
+	pubKey := types.EncodeHex(crypto.FromECDSAPub(api.s.messenger.IdentityPublicKey()))
+
+	response, err := fn()
+	if err != nil {
+		return nil, err
+	}
+
+	return toGroupChatResponseWithInvitations(pubKey, response)
+}

--- a/services/chat/service.go
+++ b/services/chat/service.go
@@ -1,24 +1,18 @@
 package chat
 
 import (
-	"database/sql"
-
 	"github.com/ethereum/go-ethereum/p2p"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/protocol"
 )
 
-func NewService(appDB *sql.DB) *Service {
-	return &Service{
-		accountsDB: accounts.NewDB(appDB),
-	}
+func NewService() *Service {
+	return &Service{}
 }
 
 type Service struct {
-	accountsDB *accounts.Database
-	messenger  *protocol.Messenger
+	messenger *protocol.Messenger
 }
 
 func (s *Service) Init(messenger *protocol.Messenger) {


### PR DESCRIPTION
Adds the following RPC methods to the "chat" service:
See https://notes.status.im/vciGwqsKTA6Fnid0lqnEnQ for a summary of why these changes are needed, as well as methods that will be created.


### getMembers
Returns a map with all the members of a chat (only valid for group chats, 1:1, and community channels). Will return null for a public channel.
```json
{"method":"chat_getMembers","params":[communityID, chatID]}
```

### joinChat
Joins a channel
```json
{"method":"chat_joinChat", "params":[communityID, chatID]}
```

### createOneToOneChat
Creates a one to one chat with someone. It's similar to `wakuext_createOneToOneChat`, with a different response object.
Will be deprecated once `wakuext_startGroupChat` is implemented in the UI.
```json
{"method":"chat_createOneToOneChat","params":[ID, ensName]}
```

### createGroupChat
Creates a group chat. It's similar to `wakuext_createGroupChat`, with a different response object.
Will be deprecated once `wakuext_startGroupChat` is implemented in the UI.
```json
{"method":"chat_createGroupChat","params":[groupName, [member1ID, member2ID...]]}
```

### createGroupChatFromInvitation
Similar to `wakuext_createGroupChatFromInvitation`, with a different response object.
```json
{"method":"chat_createGroupChatFromInvitation","params":[name, chatID, adminPK]}
```

### leaveGroupChat
Similar to `wakuext_leaveGroupChat`, with a different response object.
```json
{"method":"chat_leaveGroupChat","params":[chatID, remove]}
```

### confirmJoiningGroup
Similar to `wakuext_confirmJoiningGroup`, with a different response object.
```json
{"method":"chat_confirmJoiningGroup","params":[chatID]}
```

### changeGroupChatName
Similar to `wakuext_changeGroupChatName`, with a different response object.
```json
{"method":"chat_changeGroupChatName","params":[chatID, name]}
```

### sendGroupChatInvitationRequest
Similar to `wakuext_sendGroupChatInvitationRequest`, with a different response object.
```json
{"method":"chat_sendGroupChatInvitationRequest","params":[chatID, adminPK, message]}
```

### getGroupChatInvitations
Similar to `wakuext_getGroupChatInvitations`.
```json
{"method":"chat_getGroupChatInvitations","params":[]}
```

### sendGroupChatInvitationRejection
Similar to `wakuext_sendGroupChatInvitationRejection`, but only returns the Invitations
```json
{"method":"chat_sendGroupChatInvitationRejection","params":[invitationRequestID]}
```

### startGroupChat
If the member array contains a single public key, it will create a 1:1 chat, otherwise it will create a group chat
```json
{"method":"chat_startGroupChat","params":[name, [member1Id, member2Id...]]}
```

## The following methods will be modified and renamed in a separate PR
so they'll be able to receive a communityID (so the user is able to leave a community, add members and so on), for example, instead of `chat_addMembersToGroupChat(chatID, [member])`, `chat_addMembers(communityId, chatID, [member])`

### addMembersToGroupChat
Similar to `wakuext_addMembersToGroupChat`, with a different response object.
```json
{"method":"chat_addMembersToGroupChat","params":[chatID, [member1ID, member2ID...]]}
```

### removeMemberFromGroupChat
Similar to `wakuext_removeMemberFromGroupChat`, with a different response object.
```json
{"method":"chat_removeMemberFromGroupChat","params":[chatID, memberID]}
```

### addAdminsToGroupChat
Similar to `wakuext_addAdminsToGroupChat`, with a different response object.
```json
{"method":"chat_addAdminsToGroupChat","params":[chatID, [member1ID, member2ID...]]}
```





