### PR TITLE
fix: remove notification from debug log

### DIFF
--- a/services/local-notifications/core.go
+++ b/services/local-notifications/core.go
@@ -153,7 +153,7 @@ func PushMessages(ns []*Notification) {
 }
 
 func pushMessage(notification *Notification) {
-	log.Debug("Pushing a new push notification", "notification", notification)
+	log.Debug("Pushing a new push notification")
 	signal.SendLocalNotifications(notification)
 }
 


### PR DESCRIPTION
Looks like the logger does not know how to log notifications

¯\\\_(ツ)_/¯