### PR TITLE
refactor: reuse nodeconfig instead of loading it from DB

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -718,6 +718,9 @@ func (b *GethStatusBackend) startNode(config *params.NodeConfig) (err error) {
 		return err
 	}
 
+	// Updating node config
+	b.config = config
+
 	b.log.Debug("updated config with defaults", "config", config)
 
 	// Start by validating configuration

--- a/appdatabase/node_config_test.go
+++ b/appdatabase/node_config_test.go
@@ -41,7 +41,7 @@ func TestGetNodeConfig(t *testing.T) {
 	nodeConfig := randomNodeConfig()
 	require.NoError(t, nodecfg.SaveNodeConfig(db, nodeConfig))
 
-	dbNodeConfig, err := nodecfg.GetNodeConfig(db)
+	dbNodeConfig, err := nodecfg.GetNodeConfigFromDB(db)
 	require.NoError(t, err)
 	require.Equal(t, nodeConfig, dbNodeConfig)
 }
@@ -55,7 +55,7 @@ func TestSaveNodeConfig(t *testing.T) {
 	newNodeConfig := randomNodeConfig()
 	require.NoError(t, nodecfg.SaveNodeConfig(db, newNodeConfig))
 
-	dbNodeConfig, err := nodecfg.GetNodeConfig(db)
+	dbNodeConfig, err := nodecfg.GetNodeConfigFromDB(db)
 	require.NoError(t, err)
 	require.Equal(t, *newNodeConfig, *dbNodeConfig)
 }
@@ -92,7 +92,7 @@ func TestMigrateNodeConfig(t *testing.T) {
 	err = nodecfg.MigrateNodeConfig(db)
 	require.NoError(t, err)
 
-	dbNodeConfig, err := nodecfg.GetNodeConfig(db)
+	dbNodeConfig, err := nodecfg.GetNodeConfigFromDB(db)
 	require.NoError(t, err)
 	require.Equal(t, nodeConfig, dbNodeConfig)
 

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -238,7 +238,7 @@ func Login(accountData, password string) string {
 
 // Login loads a key file (for a given address), tries to decrypt it using the password,
 // to verify ownership if verified, purges all the previous identities from Whisper,
-// and injects verified key as shh identity. It then updates the accounts node configuration
+// and injects verified key as shh identity. It then updates the accounts node db configuration
 // mergin the values received in the configJSON parameter
 func LoginWithConfig(accountData, password, configJSON string) string {
 	err := login(accountData, password, configJSON)

--- a/nodecfg/node_config.go
+++ b/nodecfg/node_config.go
@@ -711,7 +711,7 @@ func MigrateNodeConfig(db *sql.DB) error {
 	return nil
 }
 
-func GetNodeConfig(db *sql.DB) (*params.NodeConfig, error) {
+func GetNodeConfigFromDB(db *sql.DB) (*params.NodeConfig, error) {
 	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		return nil, err

--- a/services/accounts/service.go
+++ b/services/accounts/service.go
@@ -41,7 +41,7 @@ func (s *Service) APIs() []rpc.API {
 		{
 			Namespace: "settings",
 			Version:   "0.1.0",
-			Service:   NewSettingsAPI(s.db),
+			Service:   NewSettingsAPI(s.db, s.config),
 		},
 		{
 			Namespace: "accounts",

--- a/services/accounts/settings.go
+++ b/services/accounts/settings.go
@@ -8,13 +8,14 @@ import (
 	"github.com/status-im/status-go/params"
 )
 
-func NewSettingsAPI(db *accounts.Database) *SettingsAPI {
-	return &SettingsAPI{db}
+func NewSettingsAPI(db *accounts.Database, config *params.NodeConfig) *SettingsAPI {
+	return &SettingsAPI{db, config}
 }
 
 // SettingsAPI is class with methods available over RPC.
 type SettingsAPI struct {
-	db *accounts.Database
+	db     *accounts.Database
+	config *params.NodeConfig
 }
 
 func (api *SettingsAPI) SaveSetting(ctx context.Context, typ string, val interface{}) error {
@@ -30,10 +31,12 @@ func (api *SettingsAPI) GetSettings(ctx context.Context) (accounts.Settings, err
 	return api.db.GetSettings()
 }
 
+// NodeConfig returns the currently used node configuration
 func (api *SettingsAPI) NodeConfig(ctx context.Context) (*params.NodeConfig, error) {
-	return nodecfg.GetNodeConfig(api.db.DB())
+	return api.config, nil
 }
 
+// Saves the nodeconfig in the database. The node must be restarted for the changes to be applied
 func (api *SettingsAPI) SaveNodeConfig(ctx context.Context, n *params.NodeConfig) error {
 	return nodecfg.SaveNodeConfig(api.db.DB(), n)
 }


### PR DESCRIPTION
Avoids having to reload the nodeconfig from the DB if it's already available in GethStatusBackend