### PR TITLE
Ensure community owners and members subscribe to magnetlink channel

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -947,10 +947,15 @@ func (o *Community) StatusUpdatesChannelID() string {
 	return o.IDString() + "-ping"
 }
 
+func (o *Community) MagnetlinkMessageChannelID() string {
+	return o.IDString() + "-magnetlinks"
+}
+
 func (o *Community) DefaultFilters() []string {
 	cID := o.IDString()
 	updatesChannelID := o.StatusUpdatesChannelID()
-	return []string{cID, updatesChannelID}
+	mlChannelID := o.MagnetlinkMessageChannelID()
+	return []string{cID, updatesChannelID, mlChannelID}
 }
 
 func (o *Community) PrivateKey() *ecdsa.PrivateKey {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1243,7 +1243,7 @@ func (m *Messenger) Init() error {
 	}
 	for _, org := range joinedCommunities {
 		// the org advertise on the public topic derived by the pk
-		publicChatIDs = append(publicChatIDs, org.IDString(), org.StatusUpdatesChannelID())
+		publicChatIDs = append(publicChatIDs, org.IDString(), org.StatusUpdatesChannelID(), org.MagnetlinkMessageChannelID())
 	}
 
 	// Init filters for the communities we are an admin of


### PR DESCRIPTION
This commit adds the special magnetlink channel that is used to
distribute community archive magnetlinks to community members.

The channel shoudn't be visible in the UI, so instead creating an
actual channel instance, it just sets up the filters.

Closes #2565 
