### PR TITLE
Introduce `CommunitySettings`

### DIFF
--- a/appdatabase/migrations/bindata.go
+++ b/appdatabase/migrations/bindata.go
@@ -8,6 +8,7 @@
 // 1646841105_add_emoji_account.up.sql (96B)
 // 1647278782_display_name.up.sql (110B)
 // 1647860168_add_torrent_config.up.sql (211B)
+// 1647862837_add_communities_settings_table.up.sql (206B)
 // doc.go (74B)
 
 package migrations
@@ -232,8 +233,28 @@ func _1647860168_add_torrent_configUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1647860168_add_torrent_config.up.sql", size: 211, mode: os.FileMode(0664), modTime: time.Unix(1647860188, 0)}
+	info := bindataFileInfo{name: "1647860168_add_torrent_config.up.sql", size: 211, mode: os.FileMode(0664), modTime: time.Unix(1647862710, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1, 0x92, 0x22, 0x37, 0x96, 0xf3, 0xb5, 0x5b, 0x27, 0xd0, 0x7d, 0x43, 0x5, 0x4e, 0x9d, 0xe2, 0x49, 0xbe, 0x86, 0x31, 0xa1, 0x89, 0xff, 0xd6, 0x51, 0xe0, 0x9c, 0xb, 0xda, 0xfc, 0xf2, 0x93}}
+	return a, nil
+}
+
+var __1647862837_add_communities_settings_tableUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x84\xcb\xb1\xaa\xc2\x30\x14\x06\xe0\x3d\x4f\xf1\x8f\xf7\x82\x2f\x71\x1a\x4f\xa1\x18\x9b\x12\x23\xd8\x29\xd4\xf6\xd8\x06\x6c\x04\x13\x05\xdf\xde\xcd\x49\x70\xfe\xf8\xb4\x63\xf2\x0c\x4f\x95\x61\x8c\xb7\x75\x7d\xa4\x58\xa2\xe4\x90\xa5\x94\x98\xe6\x8c\x3f\x85\x0f\xbc\x42\x9c\xe0\xf9\xe4\xd1\xb9\x66\x4f\xae\xc7\x8e\x7b\xd8\x16\xda\xb6\xb5\x69\xb4\x87\xe3\xce\x90\xe6\x8d\x02\x56\xc9\x79\x98\x25\x0c\xf7\x71\x89\x4f\x09\x59\x64\x8a\x69\x0e\x92\x86\xf3\x55\x26\x54\xd6\x1a\xa6\x16\x5b\xae\xe9\x68\x3c\x6a\x32\x87\xaf\xf1\x22\x65\x5c\x7e\x4e\xf5\xaf\xd4\x3b\x00\x00\xff\xff\x01\x6b\xfa\x19\xce\x00\x00\x00")
+
+func _1647862837_add_communities_settings_tableUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1647862837_add_communities_settings_tableUpSql,
+		"1647862837_add_communities_settings_table.up.sql",
+	)
+}
+
+func _1647862837_add_communities_settings_tableUpSql() (*asset, error) {
+	bytes, err := _1647862837_add_communities_settings_tableUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1647862837_add_communities_settings_table.up.sql", size: 206, mode: os.FileMode(0664), modTime: time.Unix(1647862858, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xbd, 0x87, 0x78, 0x99, 0xd9, 0x5d, 0xbd, 0xf7, 0x57, 0x9c, 0xca, 0x97, 0xbd, 0xb3, 0xe9, 0xb5, 0x89, 0x31, 0x3f, 0xf6, 0x5c, 0x13, 0xb, 0xc3, 0x54, 0x93, 0x18, 0x40, 0x7, 0x82, 0xfe, 0x7e}}
 	return a, nil
 }
 
@@ -364,6 +385,8 @@ var _bindata = map[string]func() (*asset, error){
 
 	"1647860168_add_torrent_config.up.sql": _1647860168_add_torrent_configUpSql,
 
+	"1647862837_add_communities_settings_table.up.sql": _1647862837_add_communities_settings_tableUpSql,
+
 	"doc.go": docGo,
 }
 
@@ -416,7 +439,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1646841105_add_emoji_account.up.sql":               &bintree{_1646841105_add_emoji_accountUpSql, map[string]*bintree{}},
 	"1647278782_display_name.up.sql":                    &bintree{_1647278782_display_nameUpSql, map[string]*bintree{}},
 	"1647860168_add_torrent_config.up.sql":              &bintree{_1647860168_add_torrent_configUpSql, map[string]*bintree{}},
-	"doc.go":                                            &bintree{docGo, map[string]*bintree{}},
+	"1647862837_add_communities_settings_table.up.sql":  &bintree{_1647862837_add_communities_settings_tableUpSql, map[string]*bintree{}},
+	"doc.go": &bintree{docGo, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/appdatabase/migrations/sql/1647862837_add_communities_settings_table.up.sql
+++ b/appdatabase/migrations/sql/1647862837_add_communities_settings_table.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE communities_settings (
+  community_id TEXT PRIMARY KEY ON CONFLICT REPLACE,
+  message_archive_seeding_enabled BOOLEAN DEFAULT FALSE,
+  message_archive_fetching_enabled BOOLEAN DEFAULT FALSE
+)
+

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -269,6 +269,11 @@ func (o *Community) initialize() {
 	}
 }
 
+type CommunitySettings struct {
+	CommunityID                  string `json:"communityId"`
+	HistoryArchiveSupportEnabled bool   `json:"historyArchiveSupportEnabled"`
+}
+
 type CommunityChatChanges struct {
 	ChatModified     *protobuf.CommunityChat
 	MembersAdded     map[string]*protobuf.CommunityMember

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -916,3 +916,27 @@ func (m *Manager) SetPrivateKey(id []byte, privKey *ecdsa.PrivateKey) error {
 func (m *Manager) GetSyncedRawCommunity(id []byte) (*rawCommunityRow, error) {
 	return m.persistence.getSyncedRawCommunity(id)
 }
+
+func (m *Manager) GetCommunitySettingsByID(id types.HexBytes) (*CommunitySettings, error) {
+	return m.persistence.GetCommunitySettingsByID(id)
+}
+
+func (m *Manager) GetCommunitiesSettings() ([]CommunitySettings, error) {
+	return m.persistence.GetCommunitiesSettings()
+}
+
+func (m *Manager) SaveCommunitySettings(settings CommunitySettings) error {
+	return m.persistence.SaveCommunitySettings(settings)
+}
+
+func (m *Manager) CommunitySettingsExist(id types.HexBytes) (bool, error) {
+	return m.persistence.CommunitySettingsExist(id)
+}
+
+func (m *Manager) DeleteCommunitySettings(id types.HexBytes) error {
+	return m.persistence.DeleteCommunitySettings(id)
+}
+
+func (m *Manager) UpdateCommunitySettings(settings CommunitySettings) error {
+	return m.persistence.UpdateCommunitySettings(settings)
+}

--- a/protocol/communities/persistence_test.go
+++ b/protocol/communities/persistence_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
@@ -32,8 +33,11 @@ func (s *PersistenceSuite) SetupTest() {
 	dbPath, err := ioutil.TempFile("", "")
 	s.NoError(err, "creating temp file for db")
 
-	db, err := sqlite.Open(dbPath.Name(), "")
+	db, err := appdatabase.InitializeDB(dbPath.Name(), "")
 	s.NoError(err, "creating sqlite db instance")
+
+	err = sqlite.Migrate(db)
+	s.NoError(err, "protocol migrate")
 
 	s.db = &Persistence{db: db}
 }
@@ -254,4 +258,66 @@ func (s *PersistenceSuite) TestGetSyncedRawCommunity() {
 	s.NoError(err)
 	s.NotNil(src)
 	s.Equal(clock, src.SyncedAt)
+}
+
+func (s *PersistenceSuite) TestGetCommunitiesSettings() {
+	settings := []CommunitySettings{
+		{CommunityID: "0x01", HistoryArchiveSupportEnabled: false},
+		{CommunityID: "0x02", HistoryArchiveSupportEnabled: true},
+		{CommunityID: "0x03", HistoryArchiveSupportEnabled: false},
+	}
+
+	for i := range settings {
+		stg := settings[i]
+		err := s.db.SaveCommunitySettings(stg)
+		s.NoError(err)
+	}
+
+	rst, err := s.db.GetCommunitiesSettings()
+	s.NoError(err)
+	s.Equal(settings, rst)
+}
+
+func (s *PersistenceSuite) TestSaveCommunitySettings() {
+	settings := CommunitySettings{CommunityID: "0x01", HistoryArchiveSupportEnabled: false}
+	err := s.db.SaveCommunitySettings(settings)
+	s.NoError(err)
+	rst, err := s.db.GetCommunitiesSettings()
+	s.NoError(err)
+	s.Equal(1, len(rst))
+}
+
+func (s *PersistenceSuite) TestDeleteCommunitySettings() {
+	settings := CommunitySettings{CommunityID: "0x01", HistoryArchiveSupportEnabled: false}
+
+	err := s.db.SaveCommunitySettings(settings)
+	s.NoError(err)
+
+	rst, err := s.db.GetCommunitiesSettings()
+	s.NoError(err)
+	s.Equal(1, len(rst))
+	s.NoError(s.db.DeleteCommunitySettings(types.HexBytes{0x01}))
+	rst2, err := s.db.GetCommunitiesSettings()
+	s.NoError(err)
+	s.Equal(0, len(rst2))
+}
+
+func (s *PersistenceSuite) TestUpdateCommunitySettings() {
+	settings := []CommunitySettings{
+		{CommunityID: "0x01", HistoryArchiveSupportEnabled: true},
+		{CommunityID: "0x02", HistoryArchiveSupportEnabled: false},
+	}
+
+	s.NoError(s.db.SaveCommunitySettings(settings[0]))
+	s.NoError(s.db.SaveCommunitySettings(settings[1]))
+
+	settings[0].HistoryArchiveSupportEnabled = true
+	settings[1].HistoryArchiveSupportEnabled = false
+
+	s.NoError(s.db.UpdateCommunitySettings(settings[0]))
+	s.NoError(s.db.UpdateCommunitySettings(settings[1]))
+
+	rst, err := s.db.GetCommunitiesSettings()
+	s.NoError(err)
+	s.Equal(settings, rst)
 }

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -146,7 +146,13 @@ func (s *MessengerCommunitiesSuite) TestRetrieveCommunity() {
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Communities(), 1)
+	s.Require().Len(response.CommunitiesSettings(), 1)
+
 	community := response.Communities()[0]
+	communitySettings := response.CommunitiesSettings()[0]
+
+	s.Require().Equal(communitySettings.CommunityID, community.IDString())
+	s.Require().Equal(communitySettings.HistoryArchiveSupportEnabled, false)
 
 	// Send an community message
 	chat := CreateOneToOneChat(common.PubkeyToHex(&alice.identity.PublicKey), &alice.identity.PublicKey, s.alice.transport)
@@ -197,8 +203,13 @@ func (s *MessengerCommunitiesSuite) TestJoinCommunity() {
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Communities(), 1)
+	s.Require().Len(response.CommunitiesSettings(), 1)
 
+	communitySettings := response.CommunitiesSettings()[0]
 	community := response.Communities()[0]
+
+	s.Require().Equal(communitySettings.CommunityID, community.IDString())
+	s.Require().Equal(communitySettings.HistoryArchiveSupportEnabled, false)
 
 	orgChat := &protobuf.CommunityChat{
 		Permissions: &protobuf.CommunityPermissions{
@@ -541,8 +552,13 @@ func (s *MessengerCommunitiesSuite) TestImportCommunity() {
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Communities(), 1)
+	s.Require().Len(response.CommunitiesSettings(), 1)
 
 	community := response.Communities()[0]
+	communitySettings := response.CommunitiesSettings()[0]
+
+	s.Require().Equal(communitySettings.CommunityID, community.IDString())
+	s.Require().Equal(communitySettings.HistoryArchiveSupportEnabled, false)
 
 	category := &requests.CreateCommunityCategory{
 		CommunityID:  community.ID(),

--- a/protocol/messenger_response.go
+++ b/protocol/messenger_response.go
@@ -41,6 +41,7 @@ type MessengerResponse struct {
 	removedChats                map[string]bool
 	removedMessages             map[string]*RemovedMessage
 	communities                 map[string]*communities.Community
+	communitiesSettings         map[string]*communities.CommunitySettings
 	activityCenterNotifications map[string]*ActivityCenterNotification
 	messages                    map[string]*common.Message
 	pinMessages                 map[string]*common.PinMessage
@@ -69,6 +70,7 @@ func (r *MessengerResponse) MarshalJSON() ([]byte, error) {
 		// that are useful to notify the user about
 		Notifications               []*localnotifications.Notification `json:"notifications"`
 		Communities                 []*communities.Community           `json:"communities,omitempty"`
+		CommunitiesSettings         []*communities.CommunitySettings   `json:"communitiesSettings,omitempty"`
 		ActivityCenterNotifications []*ActivityCenterNotification      `json:"activityCenterNotifications,omitempty"`
 		CurrentStatus               *UserStatus                        `json:"currentStatus,omitempty"`
 		StatusUpdates               []UserStatus                       `json:"statusUpdates,omitempty"`
@@ -88,6 +90,7 @@ func (r *MessengerResponse) MarshalJSON() ([]byte, error) {
 	responseItem.Notifications = r.Notifications()
 	responseItem.Chats = r.Chats()
 	responseItem.Communities = r.Communities()
+	responseItem.CommunitiesSettings = r.CommunitiesSettings()
 	responseItem.RemovedChats = r.RemovedChats()
 	responseItem.RemovedMessages = r.RemovedMessages()
 	responseItem.ClearedHistories = r.ClearedHistories()
@@ -136,6 +139,14 @@ func (r *MessengerResponse) Communities() []*communities.Community {
 		communities = append(communities, c)
 	}
 	return communities
+}
+
+func (r *MessengerResponse) CommunitiesSettings() []*communities.CommunitySettings {
+	var settings []*communities.CommunitySettings
+	for _, s := range r.communitiesSettings {
+		settings = append(settings, s)
+	}
+	return settings
 }
 
 func (r *MessengerResponse) Notifications() []*localnotifications.Notification {
@@ -225,6 +236,14 @@ func (r *MessengerResponse) AddCommunity(c *communities.Community) {
 	}
 
 	r.communities[c.IDString()] = c
+}
+
+func (r *MessengerResponse) AddCommunitySettings(c *communities.CommunitySettings) {
+	if r.communitiesSettings == nil {
+		r.communitiesSettings = make(map[string]*communities.CommunitySettings)
+	}
+
+	r.communitiesSettings[c.CommunityID] = c
 }
 
 func (r *MessengerResponse) AddBookmark(bookmark *browsers.Bookmark) {

--- a/protocol/requests/create_community_request.go
+++ b/protocol/requests/create_community_request.go
@@ -17,17 +17,18 @@ var (
 )
 
 type CreateCommunity struct {
-	Name        string                               `json:"name"`
-	Description string                               `json:"description"`
-	Color       string                               `json:"color"`
-	Emoji       string                               `json:"emoji"`
-	Membership  protobuf.CommunityPermissions_Access `json:"membership"`
-	EnsOnly     bool                                 `json:"ensOnly"`
-	Image       string                               `json:"image"`
-	ImageAx     int                                  `json:"imageAx"`
-	ImageAy     int                                  `json:"imageAy"`
-	ImageBx     int                                  `json:"imageBx"`
-	ImageBy     int                                  `json:"imageBy"`
+	Name                         string                               `json:"name"`
+	Description                  string                               `json:"description"`
+	Color                        string                               `json:"color"`
+	Emoji                        string                               `json:"emoji"`
+	Membership                   protobuf.CommunityPermissions_Access `json:"membership"`
+	EnsOnly                      bool                                 `json:"ensOnly"`
+	Image                        string                               `json:"image"`
+	ImageAx                      int                                  `json:"imageAx"`
+	ImageAy                      int                                  `json:"imageAy"`
+	ImageBx                      int                                  `json:"imageBx"`
+	ImageBy                      int                                  `json:"imageBy"`
+	HistoryArchiveSupportEnabled bool                                 `json:"historyArchiveSupportEnabled,omitempty"`
 }
 
 func adaptIdentityImageToProtobuf(img *userimages.IdentityImage) *protobuf.IdentityImage {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -924,6 +924,10 @@ func (api *PublicAPI) StopDiscV5() error {
 	return api.service.messenger.StopDiscV5()
 }
 
+func (api *PublicAPI) GetCommunitiesSettings() ([]communities.CommunitySettings, error) {
+	return api.service.messenger.GetCommunitiesSettings()
+}
+
 func (api *PublicAPI) AddStorePeer(address string) (string, error) {
 	return api.service.messenger.AddStorePeer(address)
 }


### PR DESCRIPTION
These are used to store settings for individual communities a
user is part of, either as member or as owner.
This included whether or not the community history archive protocol
is enabled.

This adds a new `CommunitySettings` type and adds
a migration script that introduces a new `communities_settings`
table.

It also extends the `MessengerResponse` type to include
`CommunitySettings` which are honored when communities are being
added, edited, joined or left.

Lastly, this adds a new RPC API to retreive the settings.

Closes #2564