### PR TITLE
Stops showing notifications on muted contacts

### DIFF
--- a/protocol/local_notifications.go
+++ b/protocol/local_notifications.go
@@ -27,6 +27,14 @@ func showMessageNotification(publicKey ecdsa.PublicKey, message *common.Message,
 		return true
 	}
 
+	if chat != nil && chat.Muted {
+		return false
+	}
+
+	if message.Mentioned && chat.Muted {
+		return false
+	}
+
 	if message.Mentioned {
 		return true
 	}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2893,14 +2893,12 @@ func (r *ReceivedMessageState) addNewMessageNotification(publicKey ecdsa.PublicK
 		return fmt.Errorf("contact ID '%s' not present", contactID)
 	}
 
-	if !chat.Muted {
-		if showMessageNotification(publicKey, m, chat, responseTo) {
-			notification, err := NewMessageNotification(m.ID, m, chat, contact, r.AllContacts, profilePicturesVisibility)
-			if err != nil {
-				return err
-			}
-			r.Response.AddNotification(notification)
+	if showMessageNotification(publicKey, m, chat, responseTo) {
+		notification, err := NewMessageNotification(m.ID, m, chat, contact, r.AllContacts, profilePicturesVisibility)
+		if err != nil {
+			return err
 		}
+		r.Response.AddNotification(notification)
 	}
 
 	return nil


### PR DESCRIPTION
This pr disables notifications from showing on muted chats, instances of public and group mentions for muted contacts