### PR TITLE
Enable history archive support for all non-admin communities

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -200,7 +200,7 @@ func (m *Messenger) JoinCommunity(ctx context.Context, communityID types.HexByte
 
 	communitySettings := communities.CommunitySettings{
 		CommunityID:                  communityID.String(),
-		HistoryArchiveSupportEnabled: false,
+		HistoryArchiveSupportEnabled: true,
 	}
 
 	err = m.communitiesManager.SaveCommunitySettings(communitySettings)


### PR DESCRIPTION

Previously, we've turned archive support off by default, this means,
community member nodes won't try to download torrent data when they
receive a magnetlink.

This commit ensures that communities joined in the future will have
this setting on, and also all existing communities that the node
isn't admin of will have this feature enabled.