### PR TITLE
fix: do not export all symbols in windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ ifeq ($(detected_OS),Darwin)
     GOBIN_SHARED_LIB_CFLAGS=CGO_ENABLED=1 GOOS=darwin GOARCH=amd64
   endif
 else ifeq ($(detected_OS),Windows)
- # on Windows need `--export-all-symbols` flag else expected symbols will not be found in libstatus.dll
- GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS="-Wl,--export-all-symbols"
+ GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS=""
  GOBIN_SHARED_LIB_EXT := dll
 else
  GOBIN_SHARED_LIB_EXT := so


### PR DESCRIPTION
Fixes:
```
C:\Program Files\Go\pkg\tool\windows_amd64\link.exe: running g++ failed: exit status 1
c:/programdata/chocolatey/lib/mingw/tools/install/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: error: export ordinal too large: 70071
```