### PR TITLE
fix: delete account sync keystore

### DIFF
--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -53,6 +53,11 @@ func (api *API) GetAccounts(ctx context.Context) ([]accounts.Account, error) {
 }
 
 func (api *API) DeleteAccount(ctx context.Context, address types.Address) error {
+	err := api.manager.DeleteAccount(api.config.KeyStoreDir, address)
+	if err != nil {
+		return err
+	}
+
 	return api.db.DeleteAccount(address)
 }
 


### PR DESCRIPTION
Since we can choose the path when generating account, we can be in a situation where we re-generate an account previously deleted

We need to also clean the keystore file