### PR TITLE
Make `GetNodeConfig` retrieve config from DB

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -718,10 +718,7 @@ func (b *GethStatusBackend) saveNodeConfig(n *params.NodeConfig) error {
 }
 
 func (b *GethStatusBackend) GetNodeConfig() (*params.NodeConfig, error) {
-	if b.config == nil {
-		return nil, ErrConfigNotAvailable
-	}
-	return b.config, nil
+	return nodecfg.GetNodeConfigFromDB(b.appDB)
 }
 
 func (b *GethStatusBackend) startNode(config *params.NodeConfig) (err error) {


### PR DESCRIPTION
Prior to this commit, this API returns the in memory `NodeConfig` which
might not be the latest state.
This is the case when for example clients update any `NodeConfig` and
retrieve it right afterwards via `GetNodeConfig`.
To get the latest state of `NodeConfig` it has to be fetched from DB
instead.
