### PR TITLE
ci: pin builds to hosts with specific Go version

### DIFF
--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
-  agent { label 'linux' }
+  agent { label 'linux && x86_64 && go-1.17' }
 
   parameters {
     string(

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
-  agent { label 'macos && x86_64' }
+  agent { label 'macos && x86_64 && go-1.17' }
 
   parameters {
     string(

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
-  agent { label 'linux' }
+  agent { label 'linux && x86_64 && go-1.17' }
 
   parameters {
     string(

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
-  agent { label 'linux' }
+  agent { label 'linux && x86_64 && go-1.17' }
 
   parameters {
     string(


### PR DESCRIPTION
Otherwise Go version upgrades are a pain due to randomly hitting a host with newer version of Go compiler.