### PR TITLE
Enable synchronising Sticker Pack setting fields

### DIFF
--- a/multiaccounts/settings/columns.go
+++ b/multiaccounts/settings/columns.go
@@ -317,9 +317,7 @@ var (
 		reactFieldName: "stickers/packs-pending",
 		dBColumnName:   "stickers_packs_pending",
 		valueHandler:   JSONBlobHandler,
-		// TODO resolve issue 8 https://github.com/status-im/status-react/pull/13053#issuecomment-1065179963
 		syncProtobufFactory: &SyncProtobufFactory{
-			inactive:          true, // Remove after issue is resolved
 			fromInterface:     stickersPacksPendingProtobufFactory,
 			fromStruct:        stickersPacksPendingProtobufFactoryStruct,
 			valueFromProtobuf: BytesFromSyncProtobuf,
@@ -330,9 +328,7 @@ var (
 		reactFieldName: "stickers/recent-stickers",
 		dBColumnName:   "stickers_recent_stickers",
 		valueHandler:   JSONBlobHandler,
-		// TODO resolve issue 8 https://github.com/status-im/status-react/pull/13053#issuecomment-1065179963
 		syncProtobufFactory: &SyncProtobufFactory{
-			inactive:          true, // Remove after issue is resolved
 			fromInterface:     stickersRecentStickersProtobufFactory,
 			fromStruct:        stickersRecentStickersProtobufFactoryStruct,
 			valueFromProtobuf: BytesFromSyncProtobuf,

--- a/multiaccounts/settings/sync_protobuf_factories.go
+++ b/multiaccounts/settings/sync_protobuf_factories.go
@@ -409,6 +409,10 @@ func extractJSONBlob(jb *sqlite.JSONBlob) ([]byte, error) {
 		return nil, err
 	}
 
+	if value == nil {
+		return nil, nil
+	}
+
 	return value.([]byte), nil
 }
 


### PR DESCRIPTION
Synchronise Sticker Pack setting fields.
Uncomment the disabled Sticker Pack field synchronization.

Closes https://github.com/status-im/status-react/issues/13193
