### PR TITLE
feat: add banner support for communities

### DIFF
--- a/images/cropped_image.go
+++ b/images/cropped_image.go
@@ -1,0 +1,9 @@
+package images
+
+type CroppedImage struct {
+	ImagePath string `json:"imagePath"`
+	X         int    `json:"x"`
+	Y         int    `json:"y"`
+	Width     int    `json:"width"`
+	Height    int    `json:"height"`
+}

--- a/images/encode.go
+++ b/images/encode.go
@@ -25,7 +25,7 @@ func renderJpeg(w io.Writer, m image.Image, config EncodeConfig) error {
 	return jpeg.Encode(w, m, o)
 }
 
-func EncodeToBestSize(bb *bytes.Buffer, img image.Image, size ResizeDimension) error {
+func EncodeToLimits(bb *bytes.Buffer, img image.Image, bounds DimensionLimits) error {
 	q := MaxJpegQuality
 	for q > MinJpegQuality-1 {
 
@@ -34,17 +34,17 @@ func EncodeToBestSize(bb *bytes.Buffer, img image.Image, size ResizeDimension) e
 			return err
 		}
 
-		if DimensionSizeLimit[size].Ideal > bb.Len() {
+		if bounds.Ideal > bb.Len() {
 			return nil
 		}
 
 		if q == MinJpegQuality {
-			if DimensionSizeLimit[size].Max > bb.Len() {
+			if bounds.Max > bb.Len() {
 				return nil
 			}
 			return fmt.Errorf(
 				"image size after processing exceeds max, expect < '%d', received < '%d'",
-				DimensionSizeLimit[size].Max,
+				bounds.Max,
 				bb.Len(),
 			)
 		}
@@ -54,6 +54,10 @@ func EncodeToBestSize(bb *bytes.Buffer, img image.Image, size ResizeDimension) e
 	}
 
 	return nil
+}
+
+func EncodeToBestSize(bb *bytes.Buffer, img image.Image, size ResizeDimension) error {
+	return EncodeToLimits(bb, img, DimensionSizeLimit[size])
 }
 
 func GetPayloadDataURI(payload []byte) (string, error) {

--- a/images/main.go
+++ b/images/main.go
@@ -64,3 +64,41 @@ func GenerateIdentityImagesFromURL(url string) ([]*IdentityImage, error) {
 
 	return GenerateImageVariants(cImg)
 }
+
+func GenerateBannerImage(filepath string, aX, aY, bX, bY int) (*IdentityImage, error) {
+	img, err := Decode(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	cropRect := image.Rectangle{
+		Min: image.Point{X: aX, Y: aY},
+		Max: image.Point{X: bX, Y: bY},
+	}
+	croppedImg, err := Crop(img, cropRect)
+	if err != nil {
+		return nil, err
+	}
+
+	dimension := BannerDim
+	resizedImg := ShrinkOnly(dimension, croppedImg)
+
+	sizeLimits := GetBannerDimensionLimits()
+
+	bb := bytes.NewBuffer([]byte{})
+	err = EncodeToLimits(bb, resizedImg, sizeLimits)
+	if err != nil {
+		return nil, err
+	}
+
+	ii := &IdentityImage{
+		Name:         BannerIdentityName,
+		Payload:      bb.Bytes(),
+		Width:        resizedImg.Bounds().Dx(),
+		Height:       resizedImg.Bounds().Dy(),
+		FileSize:     bb.Len(),
+		ResizeTarget: int(dimension),
+	}
+
+	return ii, nil
+}

--- a/images/main_test.go
+++ b/images/main_test.go
@@ -1,0 +1,46 @@
+package images
+
+import (
+	"image"
+	"image/png"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateBannerImage_NoScaleUp(t *testing.T) {
+	// Test image 256x256
+	testImage := path + "status.png"
+	identityImage, err := GenerateBannerImage(testImage, 50, 50, 150, 100)
+
+	require.NoError(t, err)
+	require.Exactly(t, identityImage.Name, BannerIdentityName)
+	require.Positive(t, len(identityImage.Payload))
+	// Ensure we don't scale it up. That will be done inefficiently in backend instead of frontend
+	require.Exactly(t, identityImage.Width, 100)
+	require.Exactly(t, identityImage.Height, 50)
+	require.Exactly(t, identityImage.FileSize, len(identityImage.Payload))
+	require.Exactly(t, identityImage.ResizeTarget, int(BannerDim))
+}
+
+func TestGenerateBannerImage_ShrinkOnly(t *testing.T) {
+	// Generate test image bigger than BannerDim
+	testImage := image.NewRGBA(image.Rect(0, 0, int(BannerDim)+10, int(BannerDim)+20))
+
+	tmpTestFilePath := t.TempDir() + "/test.png"
+	file, err := os.Create(tmpTestFilePath)
+	require.NoError(t, err)
+	defer file.Close()
+
+	err = png.Encode(file, testImage)
+	require.NoError(t, err)
+
+	identityImage, error := GenerateBannerImage(tmpTestFilePath, 0, 0, int(BannerDim)+5, int(BannerDim)+10)
+
+	require.NoError(t, error)
+	require.Positive(t, len(identityImage.Payload))
+	// Ensure we scale it down by the small side
+	require.Exactly(t, identityImage.Width, int(BannerDim))
+	require.Exactly(t, identityImage.Height, 805)
+}

--- a/images/manipulation.go
+++ b/images/manipulation.go
@@ -3,6 +3,7 @@ package images
 import (
 	"fmt"
 	"image"
+	"math"
 
 	"github.com/nfnt/resize"
 	"github.com/oliamb/cutter"
@@ -25,6 +26,11 @@ func Resize(size ResizeDimension, img image.Image) image.Image {
 	log.Info("resizing", "size", size, "width", width, "height", height)
 
 	return resize.Resize(width, height, img, resize.Bilinear)
+}
+
+func ShrinkOnly(size ResizeDimension, img image.Image) image.Image {
+	finalSize := int(math.Min(float64(size), math.Min(float64(img.Bounds().Dx()), float64(img.Bounds().Dy()))))
+	return Resize(ResizeDimension(finalSize), img)
 }
 
 func Crop(img image.Image, rect image.Rectangle) (image.Image, error) {

--- a/images/manipulation_test.go
+++ b/images/manipulation_test.go
@@ -97,6 +97,22 @@ func TestResize(t *testing.T) {
 	}
 }
 
+// Requirement of ShrinkOnly
+func TestThatResizeResizesSmallerHeightByTheSmallestSide(t *testing.T) {
+	image := image.NewRGBA(image.Rect(0, 0, 4, 2))
+	resizedImage := Resize(ResizeDimension(1), image)
+	require.Exactly(t, 2, resizedImage.Bounds().Dx())
+	require.Exactly(t, 1, resizedImage.Bounds().Dy())
+}
+
+// Requirement of ShrinkOnly
+func TestThatResizeResizesSmallerWidthByTheSmallestSide(t *testing.T) {
+	image := image.NewRGBA(image.Rect(0, 0, 4, 8))
+	resizedImage := Resize(ResizeDimension(2), image)
+	require.Exactly(t, 2, resizedImage.Bounds().Dx())
+	require.Exactly(t, 4, resizedImage.Bounds().Dy())
+}
+
 func TestCrop(t *testing.T) {
 	type params struct {
 		Rectangle   image.Rectangle

--- a/images/meta.go
+++ b/images/meta.go
@@ -17,8 +17,12 @@ const (
 	SmallDim = ResizeDimension(80)
 	LargeDim = ResizeDimension(240)
 
+	BannerDim = ResizeDimension(800)
+
 	SmallDimName = "thumbnail"
 	LargeDimName = "large"
+
+	BannerIdentityName = "banner"
 )
 
 var (
@@ -58,3 +62,10 @@ type DimensionLimits struct {
 
 type ImageType uint
 type ResizeDimension uint
+
+func GetBannerDimensionLimits() DimensionLimits {
+	return DimensionLimits{
+		Ideal: 307200, // We want to save space and traffic but keep to maximum compression
+		Max:   460800, // Can't go bigger than 450 KB
+	}
+}


### PR DESCRIPTION
Add banner image as a special "banner" `IdentityImage` beside "thumbnail" and "large"

Changes to `images` module

- Refactor `EncodeToBestSize` as `EncodeToLimits` to accept arbitrary dimmensions to allow for custom size
- Define `DimensionLimits` for banner not to exceed 450 KB

Closes [status-desktop #5403](https://github.com/status-im/status-desktop/issues/5403)
