### PR TITLE
WIP: dev: allow option to force compiling for apple silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,15 @@ SET(LIB_FILE ${CMAKE_CURRENT_SOURCE_DIR}/build/bin/libstatus.a)
 SET(LIB_SHARED_FILE ${CMAKE_CURRENT_SOURCE_DIR}/build/bin/libstatus${CMAKE_SHARED_LIBRARY_SUFFIX})
 SET(LIB_HEADER_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/build/bin/)
 
-add_custom_command(OUTPUT  ${LIB_SHARED_FILE}
-                   COMMAND make statusgo-shared-library
-                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+if(DEFINED STATUSGO_FORCE_ARCH)
+    add_custom_command(OUTPUT  ${LIB_SHARED_FILE}
+                    COMMAND make FORCE_ARCH=${STATUSGO_FORCE_ARCH} statusgo-shared-library
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+else()
+    add_custom_command(OUTPUT  ${LIB_SHARED_FILE}
+                    COMMAND make statusgo-shared-library
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 
 add_custom_target(statusgo_shared_target DEPENDS ${LIB_SHARED_FILE} ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,13 @@ endif
 
 ifeq ($(detected_OS),Darwin)
  GOBIN_SHARED_LIB_EXT := dylib
+  # Building on M1 is still not supported, so in the meantime we crosscompile by default to amd64
   ifeq ("$(shell sysctl -nq hw.optional.arm64)","1")
-    # Building on M1 is still not supported, so in the meantime we crosscompile to amd64
-    GOBIN_SHARED_LIB_CFLAGS=CGO_ENABLED=1 GOOS=darwin GOARCH=amd64
+    USE_ARCH := amd64
+	ifneq ($(origin FORCE_ARCH),undefined)
+		USE_ARCH := $(FORCE_ARCH)
+	endif
+    GOBIN_SHARED_LIB_CFLAGS=CGO_ENABLED=1 GOOS=darwin GOARCH=$(USE_ARCH)
   endif
 else ifeq ($(detected_OS),Windows)
  GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS=""


### PR DESCRIPTION
Adding the optional switch to satisfy the following requirements

- The desktop nim app requires to build for x86_64
- Desktop C++ app requires native support with Qt6.3+

The default is still forcing x86_64 builds on apple silicon.

Updates https://github.com/status-im/status-desktop/issues/5676