### PR TITLE
Enable contact request settings

### DIFF
--- a/appdatabase/migrations/bindata.go
+++ b/appdatabase/migrations/bindata.go
@@ -19,6 +19,7 @@
 // 1650616788_add_communities_archives_info_table.up.sql (208B)
 // 1652715604_add_clock_accounts.up.sql (62B)
 // 1653037334_add_notifications_settings_table.up.sql (1.276kB)
+// 1654702119_add_mutual_contact_settings.up.sql (78B)
 // doc.go (74B)
 
 package migrations
@@ -463,8 +464,28 @@ func _1653037334_add_notifications_settings_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1653037334_add_notifications_settings_table.up.sql", size: 1276, mode: os.FileMode(0644), modTime: time.Unix(1653980143, 0)}
+	info := bindataFileInfo{name: "1653037334_add_notifications_settings_table.up.sql", size: 1276, mode: os.FileMode(0644), modTime: time.Unix(1654616593, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x4b, 0xc4, 0x65, 0xac, 0xa, 0xf2, 0xef, 0xb6, 0x39, 0x3c, 0xc5, 0xb1, 0xb2, 0x9c, 0x86, 0x58, 0xe0, 0x38, 0xcb, 0x57, 0x3c, 0x76, 0x73, 0x87, 0x79, 0x4e, 0xf6, 0xed, 0xb0, 0x8e, 0x9e, 0xa}}
+	return a, nil
+}
+
+var __1654702119_add_mutual_contact_settingsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x04\xc0\x31\x0e\xc3\x20\x0c\x05\xd0\xbd\xa7\xf8\xf7\xe8\x64\x8a\x99\x5c\x90\x5a\x98\x11\x21\x28\x8a\x44\xc8\x80\xb9\x7f\x1e\x49\xe4\x1f\x22\x19\x61\xcc\xa6\x7a\x8e\x63\x82\xac\xc5\x27\x48\xfa\x7a\x5c\x4b\x57\xe9\xb9\xde\x43\x4b\xd5\xdc\x46\xd9\x7a\xdb\x61\x42\x10\x26\x0f\xcb\x8e\x92\x44\x38\x92\x3f\xbf\x5f\x4f\x00\x00\x00\xff\xff\xb0\x94\xdd\xaf\x4e\x00\x00\x00")
+
+func _1654702119_add_mutual_contact_settingsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1654702119_add_mutual_contact_settingsUpSql,
+		"1654702119_add_mutual_contact_settings.up.sql",
+	)
+}
+
+func _1654702119_add_mutual_contact_settingsUpSql() (*asset, error) {
+	bytes, err := _1654702119_add_mutual_contact_settingsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1654702119_add_mutual_contact_settings.up.sql", size: 78, mode: os.FileMode(0644), modTime: time.Unix(1654702142, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x26, 0x66, 0x67, 0x50, 0xfe, 0xd7, 0xe3, 0x29, 0x8b, 0xff, 0x9d, 0x5a, 0x87, 0xa7, 0x99, 0x6e, 0xd6, 0xcd, 0x2e, 0xbb, 0x17, 0xdf, 0x7f, 0xf7, 0xa3, 0xfa, 0x32, 0x7c, 0x2d, 0x92, 0xc8, 0x74}}
 	return a, nil
 }
 
@@ -617,6 +638,8 @@ var _bindata = map[string]func() (*asset, error){
 
 	"1653037334_add_notifications_settings_table.up.sql": _1653037334_add_notifications_settings_tableUpSql,
 
+	"1654702119_add_mutual_contact_settings.up.sql": _1654702119_add_mutual_contact_settingsUpSql,
+
 	"doc.go": docGo,
 }
 
@@ -680,6 +703,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1650616788_add_communities_archives_info_table.up.sql":        &bintree{_1650616788_add_communities_archives_info_tableUpSql, map[string]*bintree{}},
 	"1652715604_add_clock_accounts.up.sql":                         &bintree{_1652715604_add_clock_accountsUpSql, map[string]*bintree{}},
 	"1653037334_add_notifications_settings_table.up.sql":           &bintree{_1653037334_add_notifications_settings_tableUpSql, map[string]*bintree{}},
+	"1654702119_add_mutual_contact_settings.up.sql":                &bintree{_1654702119_add_mutual_contact_settingsUpSql, map[string]*bintree{}},
 	"doc.go": &bintree{docGo, map[string]*bintree{}},
 }}
 

--- a/appdatabase/migrations/sql/1654702119_add_mutual_contact_settings.up.sql
+++ b/appdatabase/migrations/sql/1654702119_add_mutual_contact_settings.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings ADD COLUMN mutual_contact_enabled BOOLEAN DEFAULT FALSE;

--- a/multiaccounts/settings/columns.go
+++ b/multiaccounts/settings/columns.go
@@ -172,6 +172,11 @@ var (
 		reactFieldName: "mnemonic",
 		dBColumnName:   "mnemonic",
 	}
+	MutualContactEnabled = SettingField{
+		reactFieldName: "mutual-contact-enabled?",
+		dBColumnName:   "mutual_contact_enabled",
+		valueHandler:   BoolHandler,
+	}
 	Name = SettingField{
 		reactFieldName: "name",
 		dBColumnName:   "name",
@@ -420,6 +425,7 @@ var (
 		LogLevel,
 		MessagesFromContactsOnly,
 		Mnemonic,
+		MutualContactEnabled,
 		Name,
 		NetworksCurrentNetwork,
 		NetworksNetworks,

--- a/multiaccounts/settings/database.go
+++ b/multiaccounts/settings/database.go
@@ -265,7 +265,7 @@ func (db *Database) SetSettingLastSynced(setting SettingField, clock uint64) err
 
 func (db *Database) GetSettings() (Settings, error) {
 	var s Settings
-	err := db.db.QueryRow("SELECT address, anon_metrics_should_send, chaos_mode, currency, current_network, custom_bootnodes, custom_bootnodes_enabled, dapps_address, display_name, eip1581_address, fleet, hide_home_tooltip, installation_id, key_uid, keycard_instance_uid, keycard_paired_on, keycard_pairing, last_updated, latest_derived_path, link_preview_request_enabled, link_previews_enabled_sites, log_level, mnemonic, name, networks, notifications_enabled, push_notifications_server_enabled, push_notifications_from_contacts_only, remote_push_notifications_enabled, send_push_notifications, push_notifications_block_mentions, photo_path, pinned_mailservers, preferred_name, preview_privacy, public_key, remember_syncing_choice, signing_phrase, stickers_packs_installed, stickers_packs_pending, stickers_recent_stickers, syncing_on_mobile_network, default_sync_period, use_mailservers, messages_from_contacts_only, usernames, appearance, profile_pictures_show_to, profile_pictures_visibility, wallet_root_address, wallet_set_up_passed, wallet_visible_tokens, waku_bloom_filter_mode, webview_allow_permission_requests, current_user_status, send_status_updates, gif_recents, gif_favorites, opensea_enabled, last_backup, backup_enabled, telemetry_server_url, auto_message_enabled, gif_api_key, test_networks_enabled FROM settings WHERE synthetic_id = 'id'").Scan(
+	err := db.db.QueryRow("SELECT address, anon_metrics_should_send, chaos_mode, currency, current_network, custom_bootnodes, custom_bootnodes_enabled, dapps_address, display_name, eip1581_address, fleet, hide_home_tooltip, installation_id, key_uid, keycard_instance_uid, keycard_paired_on, keycard_pairing, last_updated, latest_derived_path, link_preview_request_enabled, link_previews_enabled_sites, log_level, mnemonic, name, networks, notifications_enabled, push_notifications_server_enabled, push_notifications_from_contacts_only, remote_push_notifications_enabled, send_push_notifications, push_notifications_block_mentions, photo_path, pinned_mailservers, preferred_name, preview_privacy, public_key, remember_syncing_choice, signing_phrase, stickers_packs_installed, stickers_packs_pending, stickers_recent_stickers, syncing_on_mobile_network, default_sync_period, use_mailservers, messages_from_contacts_only, usernames, appearance, profile_pictures_show_to, profile_pictures_visibility, wallet_root_address, wallet_set_up_passed, wallet_visible_tokens, waku_bloom_filter_mode, webview_allow_permission_requests, current_user_status, send_status_updates, gif_recents, gif_favorites, opensea_enabled, last_backup, backup_enabled, telemetry_server_url, auto_message_enabled, gif_api_key, test_networks_enabled, mutual_contact_enabled FROM settings WHERE synthetic_id = 'id'").Scan(
 		&s.Address,
 		&s.AnonMetricsShouldSend,
 		&s.ChaosMode,
@@ -331,6 +331,7 @@ func (db *Database) GetSettings() (Settings, error) {
 		&s.AutoMessageEnabled,
 		&s.GifAPIKey,
 		&s.TestNetworksEnabled,
+		&s.MutualContactEnabled,
 	)
 
 	return s, err
@@ -489,6 +490,11 @@ func (db *Database) DisplayName() (string, error) {
 
 func (db *Database) GifAPIKey() (string, error) {
 	return db.makeSelectString(GifAPIKey)
+}
+
+func (db *Database) MutualContactEnabled() (result bool, err error) {
+	err = db.makeSelectRow(MutualContactEnabled).Scan(&result)
+	return result, err
 }
 
 func (db *Database) GifRecents() (recents json.RawMessage, err error) {

--- a/multiaccounts/settings/structs.go
+++ b/multiaccounts/settings/structs.go
@@ -134,6 +134,7 @@ type Settings struct {
 	LogLevel                  *string          `json:"log-level,omitempty"`
 	MessagesFromContactsOnly  bool             `json:"messages-from-contacts-only"`
 	Mnemonic                  *string          `json:"mnemonic,omitempty"`
+	MutualContactEnabled      bool             `json:"mutual-contact-enabled?"`
 	Name                      string           `json:"name,omitempty"`
 	Networks                  *json.RawMessage `json:"networks/networks"`
 	// NotificationsEnabled indicates whether local notifications should be enabled (android only)

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -11,6 +11,7 @@ import (
 	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
@@ -271,6 +272,8 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+
+	s.Require().NoError(theirMessenger.settings.SaveSettingField(settings.MutualContactEnabled, true))
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -679,7 +679,15 @@ func (m *Messenger) HandleRetractContactRequest(state *ReceivedMessageState, mes
 		return nil
 	}
 
-	contact.Added = false
+	mutualContactEnabled, err := m.settings.MutualContactEnabled()
+	if err != nil {
+		m.logger.Error("FAILED", zap.Error(err))
+		return err
+	}
+	// We remove from our old contacts only if mutual contacts are enabled
+	if mutualContactEnabled {
+		contact.Added = false
+	}
 	contact.HasAddedUs = false
 	contact.ContactRequestClock = message.Clock
 	contact.ContactRequestRetracted()

--- a/protocol/migrations/migrations.go
+++ b/protocol/migrations/migrations.go
@@ -1137,7 +1137,7 @@ func _1645034602_add_mutual_contact_requestUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1645034602_add_mutual_contact_request.up.sql", size: 454, mode: os.FileMode(0644), modTime: time.Unix(1653980143, 0)}
+	info := bindataFileInfo{name: "1645034602_add_mutual_contact_request.up.sql", size: 454, mode: os.FileMode(0644), modTime: time.Unix(1654616593, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1a, 0xe0, 0x5d, 0x68, 0xb8, 0x50, 0xa4, 0xbb, 0x3e, 0x4f, 0x2, 0x87, 0xad, 0x87, 0x6e, 0x38, 0xdf, 0xc8, 0x4c, 0xe2, 0x5f, 0xd1, 0x6, 0xdc, 0xe7, 0xbd, 0x4a, 0x9c, 0xf3, 0x91, 0xa1, 0x51}}
 	return a, nil
 }
@@ -1157,7 +1157,7 @@ func _1650373957_add_contact_request_stateUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1650373957_add_contact_request_state.up.sql", size: 59, mode: os.FileMode(0644), modTime: time.Unix(1653980143, 0)}
+	info := bindataFileInfo{name: "1650373957_add_contact_request_state.up.sql", size: 59, mode: os.FileMode(0644), modTime: time.Unix(1654616593, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x5e, 0xc1, 0x3f, 0x29, 0xe, 0x19, 0x86, 0x1a, 0x4c, 0x6c, 0x2a, 0x90, 0x9d, 0xdf, 0xb1, 0xb, 0x72, 0x25, 0xcd, 0x6c, 0x5f, 0xd, 0x51, 0x9e, 0x85, 0xc0, 0x9, 0xb7, 0xbc, 0x87, 0x23, 0xec}}
 	return a, nil
 }


### PR DESCRIPTION
Adds settings to status-go for mutual contact request.
This will want to be enabled by default on desktop. 
