### PR TITLE
fix: sync clear history in real-time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -266,7 +266,6 @@ require (
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/tools v0.1.5 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0 // indirect

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -586,8 +586,8 @@ func (api *PublicAPI) DeleteMessage(id string) error {
 	return api.service.messenger.DeleteMessage(id)
 }
 
-func (api *PublicAPI) DeleteMessagesByChatID(id string) error {
-	return api.service.messenger.DeleteMessagesByChatID(id)
+func (api *PublicAPI) DeleteMessagesByChatID(ctx context.Context, id string) error {
+	return api.service.messenger.DeleteMessagesByChatID(ctx, id)
 }
 
 func (api *PublicAPI) MarkMessagesSeen(chatID string, ids []string) (*MarkMessagSeenResponse, error) {


### PR DESCRIPTION
Prior to this commit sync clear history messags were only dispatched when
devices where synced, but not when histories where actually cleared.

Closes #2714

