### PR TITLE
Deactivating sticker pack sync

### DIFF
--- a/multiaccounts/settings/columns.go
+++ b/multiaccounts/settings/columns.go
@@ -312,6 +312,7 @@ var (
 		dBColumnName:   "stickers_packs_installed",
 		valueHandler:   JSONBlobHandler,
 		syncProtobufFactory: &SyncProtobufFactory{
+			inactive:          true, // TODO current version of stickers introduces a regression on deleting sticker packs
 			fromInterface:     stickersPacksInstalledProtobufFactory,
 			fromStruct:        stickersPacksInstalledProtobufFactoryStruct,
 			valueFromProtobuf: BytesFromSyncProtobuf,
@@ -323,6 +324,7 @@ var (
 		dBColumnName:   "stickers_packs_pending",
 		valueHandler:   JSONBlobHandler,
 		syncProtobufFactory: &SyncProtobufFactory{
+			inactive:          true, // TODO current version of stickers introduces a regression on deleting sticker packs
 			fromInterface:     stickersPacksPendingProtobufFactory,
 			fromStruct:        stickersPacksPendingProtobufFactoryStruct,
 			valueFromProtobuf: BytesFromSyncProtobuf,
@@ -334,6 +336,7 @@ var (
 		dBColumnName:   "stickers_recent_stickers",
 		valueHandler:   JSONBlobHandler,
 		syncProtobufFactory: &SyncProtobufFactory{
+			inactive:          true, // TODO current version of stickers introduces a regression on deleting sticker packs
 			fromInterface:     stickersRecentStickersProtobufFactory,
 			fromStruct:        stickersRecentStickersProtobufFactoryStruct,
 			valueFromProtobuf: BytesFromSyncProtobuf,


### PR DESCRIPTION
## What's Changed?

I've deactivated syncing of sticker packs because the current implementation introduces a regression on deletion of sticker packs.

#### Steps to reproduce

- Pair `device 1` and `device 2`
- Add `sticker pack 1` to `device 1`
- `device 2` received `sticker pack 1`
- `device 1` deletes `sticker pack 1`
-  `device 2` adds `sticker pack 2`
-  `device 2` receives late setting state of `device 1` and does not remove `sticker pack 1` because clock is older than when `sticker pack 2` was added
- `device 1` receives update including `sticker pack 1` and `2`
- `device 1` has `sticker pack 1` again and `sticker pack 2`

This issue can be fixed but requires more work to be done on #2717 Currently functionality in 2717 has merge only functionality and doesn't handle deletion either. Deletion is a bit trickier than merge only, can be fixed with a `deletedAt` field in the `StickerPack` struct, but will require coordination with desktop UI and mobile UI.

cc @churik and @audriu 

## Notes For QA:

This functionality removes syncing of sticker packs, so no sticker packs should be synced in testing