### PR TITLE
fix(community-edit): Save permissions when community edited

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -728,6 +728,7 @@ func (o *Community) Edit(description *protobuf.CommunityDescription) {
 	if o.config.CommunityDescription.AdminSettings == nil {
 		o.config.CommunityDescription.AdminSettings = &protobuf.CommunityAdminSettings{}
 	}
+	o.config.CommunityDescription.Permissions = description.Permissions
 	o.config.CommunityDescription.AdminSettings.PinMessageAllMembersEnabled = description.AdminSettings.PinMessageAllMembersEnabled
 	o.increaseClock()
 }


### PR DESCRIPTION
Part of: https://github.com/status-im/status-desktop/issues/6073
