### PR TITLE
dev: allow option to force compiling for apple silicon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ SET(LIB_SHARED_FILE ${CMAKE_CURRENT_SOURCE_DIR}/build/bin/libstatus${CMAKE_SHARE
 SET(LIB_HEADER_FOLDER ${CMAKE_CURRENT_SOURCE_DIR}/build/bin/)
 
 add_custom_command(OUTPUT  ${LIB_SHARED_FILE}
-                   COMMAND make statusgo-shared-library
+                   COMMAND make FORCE_ARCH=${STATUSGO_FORCE_ARCH} statusgo-shared-library
                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_target(statusgo_shared_target DEPENDS ${LIB_SHARED_FILE} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,10 @@ endif
 
 ifeq ($(detected_OS),Darwin)
  GOBIN_SHARED_LIB_EXT := dylib
+  # Building on M1 is still not supported, so in the meantime we crosscompile by default to amd64
   ifeq ("$(shell sysctl -nq hw.optional.arm64)","1")
-    # Building on M1 is still not supported, so in the meantime we crosscompile to amd64
-    GOBIN_SHARED_LIB_CFLAGS=CGO_ENABLED=1 GOOS=darwin GOARCH=amd64
+    FORCE_ARCH ?= amd64
+    GOBIN_SHARED_LIB_CFLAGS=CGO_ENABLED=1 GOOS=darwin GOARCH=$(FORCE_ARCH)
   endif
 else ifeq ($(detected_OS),Windows)
  GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS=""


### PR DESCRIPTION
Adding the optional switch to satisfy the following requirements

- The desktop `nim` app requires still building for `x86_64`
- Desktop C++ app requires native support with `Qt 6`

The default is still forcing `x86_64` builds on apple silicon

Follow up on [#2693](https://github.com/status-im/status-go/pull/2693)

@richard-ramos in the meantime I ran the [test](https://github.com/status-im/status-desktop/blob/9602dada11330d77be9e8a6b3be3e677efa201ac/test/libs/StatusGoQt/test_messaging.cpp#L21) that was causing problems in the past (before go 1.8) and validated that it is working and can be safely merged.

Closes #5676