### PR TITLE
feat: log raw messages to csv for debugging

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -498,6 +498,8 @@ type NodeConfig struct {
 
 	// PushNotificationServerConfig is the config for the push notification server
 	PushNotificationServerConfig pushnotificationserver.Config `json:"PushNotificationServerConfig"`
+
+	OutputMessageCSVEnabled bool
 }
 
 type Network struct {

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -88,6 +88,8 @@ type config struct {
 
 	logger *zap.Logger
 
+	outputMessagesCSV bool
+
 	messengerSignalsHandler MessengerSignalsHandler
 
 	telemetryServerURL string
@@ -293,6 +295,13 @@ func WithHTTPServer(s *server.MediaServer) Option {
 func WithRPCClient(r *rpc.Client) Option {
 	return func(c *config) error {
 		c.rpcClient = r
+		return nil
+	}
+}
+
+func WithMessageCSV(enabled bool) Option {
+	return func(c *config) error {
+		c.outputMessagesCSV = enabled
 		return nil
 	}
 }

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -416,6 +416,7 @@ func buildMessengerOptions(
 		protocol.WithTorrentConfig(&config.TorrentConfig),
 		protocol.WithHTTPServer(httpServer),
 		protocol.WithRPCClient(rpcClient),
+		protocol.WithMessageCSV(config.OutputMessageCSVEnabled),
 	}
 
 	if config.ShhextConfig.DataSyncEnabled {


### PR DESCRIPTION
Adds a `outputMessagesCSV` attribute to the node config that can be used to output the messages to a .csv file.
This is going to be used on desktop to debug message loss and have a way to quickly filter the message types that were received