### PR TITLE
feat: Add logic to re caculate route for sending a transaction based on networks disabled by the user

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -323,9 +323,9 @@ func (api *API) GetTransactionEstimatedTime(ctx context.Context, chainID uint64,
 	return api.s.feesManager.transactionEstimatedTime(ctx, chainID, maxFeePerGas), nil
 }
 
-func (api *API) GetSuggestedRoutes(ctx context.Context, account common.Address, amount float64, tokenSymbol string) (*SuggestedRoutes, error) {
+func (api *API) GetSuggestedRoutes(ctx context.Context, account common.Address, amount float64, tokenSymbol string, disabledChainIDs []uint64) (*SuggestedRoutes, error) {
 	log.Debug("call to GetSuggestedRoutes")
-	return api.router.suggestedRoutes(ctx, account, amount, tokenSymbol)
+	return api.router.suggestedRoutes(ctx, account, amount, tokenSymbol, disabledChainIDs)
 }
 
 func (api *API) GetDerivedAddressesForPath(ctx context.Context, password string, derivedFrom string, path string, pageSize int, pageNumber int) ([]*DerivedAddress, error) {

--- a/services/wallet/router.go
+++ b/services/wallet/router.go
@@ -49,7 +49,7 @@ func (r *Router) suitableTokenExists(ctx context.Context, network *params.Networ
 	return false, nil
 }
 
-func (r *Router) suggestedRoutes(ctx context.Context, account common.Address, amount float64, tokenSymbol string) (*SuggestedRoutes, error) {
+func (r *Router) suggestedRoutes(ctx context.Context, account common.Address, amount float64, tokenSymbol string, disabledChainIDs []uint64) (*SuggestedRoutes, error) {
 	areTestNetworksEnabled, err := r.s.accountsDB.GetTestNetworksEnabled()
 	if err != nil {
 		return nil, err
@@ -68,6 +68,19 @@ func (r *Router) suggestedRoutes(ctx context.Context, account common.Address, am
 	for networkIdx := range networks {
 		network := networks[networkIdx]
 		if network.IsTest != areTestNetworksEnabled {
+			continue
+		}
+
+		networkFound := false
+		for _, chainID := range disabledChainIDs {
+			networkFound = false
+			if chainID == network.ChainID {
+				networkFound = true
+				break
+			}
+		}
+		// This is network cannot be used as a suggestedRoute as the user has disabled it
+		if networkFound {
 			continue
 		}
 


### PR DESCRIPTION
Add logic to re calculate route for sending a transaction based on networks disabled by the user