### PR TITLE
Reduce max keep in tests

### DIFF
--- a/protocol/encryption/encryption_test.go
+++ b/protocol/encryption/encryption_test.go
@@ -620,6 +620,8 @@ func (s *EncryptionServiceTestSuite) TestMaxKeep() {
 	config := defaultEncryptorConfig("none", s.logger)
 	// Set MaxMessageKeysPerSession to an high value so it does not interfere
 	config.MaxMessageKeysPerSession = 100000
+	// Set MaxKeep to a small number for testing
+	config.MaxKeep = 10
 
 	s.initDatabases(config)
 


### PR DESCRIPTION
TestMaxKeep is one of the slowest tests, this reduces the amount of messages so that it should take faster.
I am not sure it's the reason of the timeouts (I don't think so, there's probably something else), but it should speed things up.