### PR TITLE
feat: share image/username on separate topic on a community

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1110,11 +1110,16 @@ func (o *Community) MagnetlinkMessageChannelID() string {
 	return o.IDString() + "-magnetlinks"
 }
 
+func (o *Community) MemberUpdateChannelID() string {
+	return o.IDString() + "-memberUpdate"
+}
+
 func (o *Community) DefaultFilters() []string {
 	cID := o.IDString()
 	updatesChannelID := o.StatusUpdatesChannelID()
 	mlChannelID := o.MagnetlinkMessageChannelID()
-	return []string{cID, updatesChannelID, mlChannelID}
+	memberUpdateChannelID := o.MemberUpdateChannelID()
+	return []string{cID, updatesChannelID, mlChannelID, memberUpdateChannelID}
 }
 
 func (o *Community) PrivateKey() *ecdsa.PrivateKey {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -819,6 +819,18 @@ func (m *Messenger) publishContactCode() error {
 		m.logger.Warn("failed to send a contact code", zap.Error(err))
 	}
 
+	joinedCommunities, err := m.communitiesManager.Joined()
+	if err != nil {
+		return err
+	}
+	for _, community := range joinedCommunities {
+		rawMessage.LocalChatID = community.MemberUpdateChannelID()
+		_, err = m.sender.SendPublic(ctx, rawMessage.LocalChatID, rawMessage)
+		if err != nil {
+			return err
+		}
+	}
+
 	m.logger.Debug("contact code sent")
 	return err
 }
@@ -1285,7 +1297,7 @@ func (m *Messenger) Init() error {
 	}
 	for _, org := range joinedCommunities {
 		// the org advertise on the public topic derived by the pk
-		publicChatIDs = append(publicChatIDs, org.IDString(), org.StatusUpdatesChannelID(), org.MagnetlinkMessageChannelID())
+		publicChatIDs = append(publicChatIDs, org.IDString(), org.StatusUpdatesChannelID(), org.MagnetlinkMessageChannelID(), org.MemberUpdateChannelID())
 
 		// This is for status-go versions that didn't have `CommunitySettings`
 		// We need to ensure communities that existed before community settings

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -342,6 +342,11 @@ func (m *Messenger) joinCommunity(ctx context.Context, communityID types.HexByte
 		return nil, err
 	}
 
+	err = m.PublishIdentityImage()
+	if err != nil {
+		return nil, err
+	}
+
 	return response, nil
 }
 


### PR DESCRIPTION
- `publishContactCode` now also publishes on joined communities separate topic
- `publishIdentityImage` is now triggered each time user joins a new community, this is to ensure other community members got updated with user details immediately

closes: #2707