### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/account/accounts_test.go
+++ b/account/accounts_test.go
@@ -23,13 +23,8 @@ const newTestPassword = "new-test-password"
 
 func TestVerifyAccountPassword(t *testing.T) {
 	accManager := NewGethManager()
-	keyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts")
-	require.NoError(t, err)
-	defer os.RemoveAll(keyStoreDir) //nolint: errcheck
-
-	emptyKeyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts_empty")
-	require.NoError(t, err)
-	defer os.RemoveAll(emptyKeyStoreDir) //nolint: errcheck
+	keyStoreDir := t.TempDir()
+	emptyKeyStoreDir := t.TempDir()
 
 	// import account keys
 	utils.Init()
@@ -102,13 +97,11 @@ func TestVerifyAccountPassword(t *testing.T) {
 // TestVerifyAccountPasswordWithAccountBeforeEIP55 verifies if VerifyAccountPassword
 // can handle accounts before introduction of EIP55.
 func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {
-	keyStoreDir, err := os.MkdirTemp("", "status-accounts-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(keyStoreDir) //nolint: errcheck
+	keyStoreDir := t.TempDir()
 
 	// Import keys and make sure one was created before EIP55 introduction.
 	utils.Init()
-	err = utils.ImportTestAccount(keyStoreDir, "test-account3-before-eip55.pk")
+	err := utils.ImportTestAccount(keyStoreDir, "test-account3-before-eip55.pk")
 	require.NoError(t, err)
 
 	accManager := NewGethManager()
@@ -143,8 +136,7 @@ type testAccount struct {
 func (s *ManagerTestSuite) SetupTest() {
 	s.accManager = NewGethManager()
 
-	keyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts")
-	s.Require().NoError(err)
+	keyStoreDir := s.T().TempDir()
 	s.Require().NoError(s.accManager.InitKeystore(keyStoreDir))
 	s.keydir = keyStoreDir
 
@@ -169,10 +161,6 @@ func (s *ManagerTestSuite) SetupTest() {
 		accountInfo.ChatPubKey,
 		mnemonic,
 	}
-}
-
-func (s *ManagerTestSuite) TearDownTest() {
-	s.Require().NoError(os.RemoveAll(s.keydir))
 }
 
 func (s *ManagerTestSuite) TestRecoverAccount() {

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -625,9 +625,7 @@ func TestLoginWithKey(t *testing.T) {
 	main := multiaccounts.Account{
 		KeyUID: keyUID,
 	}
-	tmpdir, err := os.MkdirTemp("", "login-with-key-test-")
-	require.NoError(t, err)
-	defer os.Remove(tmpdir)
+	tmpdir := t.TempDir()
 	conf, err := params.NewNodeConfig(tmpdir, 1777)
 	require.NoError(t, err)
 	keyhex := hex.EncodeToString(gethcrypto.FromECDSA(chatKey))
@@ -668,9 +666,7 @@ func TestVerifyDatabasePassword(t *testing.T) {
 	main := multiaccounts.Account{
 		KeyUID: keyUID,
 	}
-	tmpdir, err := os.MkdirTemp("", "verify-database-password-")
-	require.NoError(t, err)
-	defer os.Remove(tmpdir)
+	tmpdir := t.TempDir()
 	conf, err := params.NewNodeConfig(tmpdir, 1777)
 	require.NoError(t, err)
 	keyhex := hex.EncodeToString(gethcrypto.FromECDSA(chatKey))
@@ -691,15 +687,13 @@ func TestVerifyDatabasePassword(t *testing.T) {
 func TestDeleteMultiaccount(t *testing.T) {
 	backend := NewGethStatusBackend()
 
-	rootDataDir, err := os.MkdirTemp("", "test-keystore-dir")
-	require.NoError(t, err)
-	defer os.Remove(rootDataDir)
+	rootDataDir := t.TempDir()
 
 	keyStoreDir := filepath.Join(rootDataDir, "keystore")
 
 	backend.rootDataDir = rootDataDir
 
-	err = backend.AccountManager().InitKeystore(keyStoreDir)
+	err := backend.AccountManager().InitKeystore(keyStoreDir)
 	require.NoError(t, err)
 
 	backend.AccountManager()
@@ -794,9 +788,7 @@ func TestConvertAccount(t *testing.T) {
 		return found
 	}
 
-	rootDataDir, err := os.MkdirTemp("", "test-keystore-dir")
-	require.NoError(t, err)
-	defer os.Remove(rootDataDir)
+	rootDataDir := t.TempDir()
 
 	keyStoreDir := filepath.Join(rootDataDir, "keystore")
 
@@ -1060,9 +1052,7 @@ func TestLoginAndMigrationsStillWorkWithExistingUsers(t *testing.T) {
 
 	srcFolder := "../static/test-0.97.3-account/"
 
-	tmpdir, err := os.MkdirTemp("", "login-and-migrations-with-existing-users")
-	require.NoError(t, err)
-	defer os.Remove(tmpdir)
+	tmpdir := t.TempDir()
 
 	copyDir(srcFolder, tmpdir, t)
 

--- a/api/test_helpers.go
+++ b/api/test_helpers.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,7 +14,7 @@ import (
 )
 
 func setupWalletTest(t *testing.T, password string) (backend *GethStatusBackend, defersFunc func(), err error) {
-	tmpdir, err := os.MkdirTemp("", "verified-account-test-")
+	tmpdir := t.TempDir()
 
 	defers := make([]func(), 0)
 	defersFunc = func() {
@@ -27,10 +26,6 @@ func setupWalletTest(t *testing.T, password string) (backend *GethStatusBackend,
 		return
 	}
 
-	defers = append(defers, func() {
-		os.Remove(tmpdir)
-	})
-	//defer os.Remove(tmpdir)
 	backend = NewGethStatusBackend()
 	backend.UpdateRootDataDir(tmpdir)
 

--- a/mailserver/mailserver_db_leveldb_test.go
+++ b/mailserver/mailserver_db_leveldb_test.go
@@ -1,7 +1,6 @@
 package mailserver
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -15,15 +14,7 @@ import (
 func TestLevelDB_BuildIteratorWithTopic(t *testing.T) {
 	topic := []byte{0x01, 0x02, 0x03, 0x04}
 
-	dir, err := os.MkdirTemp("/tmp", "status-go-test-level-db")
-	require.NoError(t, err)
-
-	db, err := NewLevelDB(dir)
-
-	defer func() {
-		_ = os.Remove(dir)
-	}()
-
+	db, err := NewLevelDB(t.TempDir())
 	require.NoError(t, err)
 
 	envelope, err := newTestEnvelope(topic)

--- a/mailserver/mailserver_test.go
+++ b/mailserver/mailserver_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -69,18 +68,13 @@ func (s *MailserverSuite) SetupTest() {
 	s.shh = waku.New(&waku.DefaultConfig, nil)
 	s.shh.RegisterMailServer(s.server)
 
-	tmpDir, err := os.MkdirTemp("", "mailserver-test")
-	s.Require().NoError(err)
+	tmpDir := s.T().TempDir()
 	s.dataDir = tmpDir
 
 	s.config = &params.WakuConfig{
 		DataDir:            tmpDir,
 		MailServerPassword: "testpassword",
 	}
-}
-
-func (s *MailserverSuite) TearDownTest() {
-	s.Require().NoError(os.RemoveAll(s.config.DataDir))
 }
 
 func (s *MailserverSuite) TestInit() {

--- a/node/geth_status_node_test.go
+++ b/node/geth_status_node_test.go
@@ -68,17 +68,11 @@ func TestStatusNodeStart(t *testing.T) {
 }
 
 func TestStatusNodeWithDataDir(t *testing.T) {
-	var err error
-
-	dir, err := os.MkdirTemp("", "status-node-test")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(dir))
-	}()
+	dir := t.TempDir()
 
 	// keystore directory
 	keyStoreDir := path.Join(dir, "keystore")
-	err = os.MkdirAll(keyStoreDir, os.ModePerm)
+	err := os.MkdirAll(keyStoreDir, os.ModePerm)
 	require.NoError(t, err)
 
 	config := params.NodeConfig{

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -3,7 +3,6 @@ package params_test
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -55,11 +54,7 @@ func TestNewNodeConfigWithDefaults(t *testing.T) {
 }
 
 func TestNewConfigFromJSON(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "geth-config-tests")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir) // nolint: errcheck
+	tmpDir := t.TempDir()
 	json := `{
 		"NetworkId": 3,
 		"DataDir": "` + tmpDir + `",
@@ -84,9 +79,7 @@ func TestNewConfigFromJSON(t *testing.T) {
 }
 
 func TestConfigWriteRead(t *testing.T) {
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "geth-config-tests")
-	require.Nil(t, err)
-	defer os.RemoveAll(tmpDir) // nolint: errcheck
+	tmpDir := t.TempDir()
 
 	nodeConfig, err := utils.MakeTestNodeConfigWithDataDir("", tmpDir, params.GoerliNetworkID)
 	require.Nil(t, err, "cannot create new config object")

--- a/profiling/profiling_test.go
+++ b/profiling/profiling_test.go
@@ -10,10 +10,9 @@ import (
 )
 
 func TestProfilingCPU(t *testing.T) {
-	dir, err := os.MkdirTemp("", "profiling")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
-	err = StartCPUProfile(dir)
+	err := StartCPUProfile(dir)
 	require.NoError(t, err)
 
 	// Block for a bit to collect some metrics.
@@ -38,10 +37,9 @@ func TestProfilingCPU(t *testing.T) {
 }
 
 func TestProfilingMem(t *testing.T) {
-	dir, err := os.MkdirTemp("", "profiling")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
-	err = WriteHeapFile(dir)
+	err := WriteHeapFile(dir)
 	require.NoError(t, err)
 
 	// Verify that the file has some content.

--- a/protocol/common/message_sender_test.go
+++ b/protocol/common/message_sender_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -53,8 +52,7 @@ func (s *MessageSenderSuite) SetupTest() {
 	s.logger, err = zap.NewDevelopment()
 	s.Require().NoError(err)
 
-	s.tmpDir, err = os.MkdirTemp("", "")
-	s.Require().NoError(err)
+	s.tmpDir = s.T().TempDir()
 
 	identity, err := crypto.GenerateKey()
 	s.Require().NoError(err)
@@ -96,7 +94,6 @@ func (s *MessageSenderSuite) SetupTest() {
 }
 
 func (s *MessageSenderSuite) TearDownTest() {
-	os.Remove(s.tmpDir)
 	_ = s.logger.Sync()
 }
 

--- a/protocol/encryption/persistence_keys_storage_test.go
+++ b/protocol/encryption/persistence_keys_storage_test.go
@@ -1,7 +1,6 @@
 package encryption
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -31,9 +30,7 @@ type SQLLitePersistenceKeysStorageTestSuite struct {
 }
 
 func (s *SQLLitePersistenceKeysStorageTestSuite) SetupTest() {
-	dir, err := os.MkdirTemp("", "keys-storage-persistence")
-	s.Require().NoError(err)
-
+	dir := s.T().TempDir()
 	key := "blahblahblah"
 
 	db, err := sqlite.Open(filepath.Join(dir, "db.sql"), key, sqlite.ReducedKDFIterationsNumber)

--- a/protocol/encryption/persistence_test.go
+++ b/protocol/encryption/persistence_test.go
@@ -2,7 +2,6 @@ package encryption
 
 import (
 	"database/sql"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,8 +25,7 @@ type SQLLitePersistenceTestSuite struct {
 }
 
 func (s *SQLLitePersistenceTestSuite) SetupTest() {
-	dir, err := os.MkdirTemp("", "sqlite-persistence")
-	s.Require().NoError(err)
+	dir := s.T().TempDir()
 
 	db, err := sqlite.Open(filepath.Join(dir, "db.sql"), "test-key", sqlite.ReducedKDFIterationsNumber)
 	s.Require().NoError(err)

--- a/protocol/sqlite/db_test.go
+++ b/protocol/sqlite/db_test.go
@@ -1,7 +1,6 @@
 package sqlite
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -9,9 +8,7 @@ import (
 )
 
 func TestOpen(t *testing.T) {
-	dir, err := os.MkdirTemp("", "test-open")
-	require.NoError(t, err)
-	defer os.Remove(dir)
+	dir := t.TempDir()
 
 	dbPath := filepath.Join(dir, "db.sql")
 

--- a/server/pairing/payload_management_test.go
+++ b/server/pairing/payload_management_test.go
@@ -62,27 +62,21 @@ func setupTestDB(t *testing.T) (*multiaccounts.Database, func()) {
 	}
 }
 
-func makeKeystores(t *testing.T) (string, string, func()) {
-	keyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts")
-	require.NoError(t, err)
-
-	emptyKeyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts_empty")
-	require.NoError(t, err)
+func makeKeystores(t *testing.T) (string, string) {
+	keyStoreDir := t.TempDir()
+	emptyKeyStoreDir := t.TempDir()
 
 	keyStoreDir = filepath.Join(keyStoreDir, keystoreDir, keyUID)
 	// TODO test case where the keystore dir does not yet exist because the device is new
 	emptyKeyStoreDir = filepath.Join(emptyKeyStoreDir, keystoreDir)
 
-	err = os.MkdirAll(keyStoreDir, 0777)
+	err := os.MkdirAll(keyStoreDir, 0777)
 	require.NoError(t, err)
 
 	err = os.MkdirAll(emptyKeyStoreDir, 0777)
 	require.NoError(t, err)
 
-	return keyStoreDir, emptyKeyStoreDir, func() {
-		os.RemoveAll(keyStoreDir)
-		os.RemoveAll(emptyKeyStoreDir)
-	}
+	return keyStoreDir, emptyKeyStoreDir
 }
 
 func initKeys(t *testing.T, keyStoreDir string) {
@@ -122,11 +116,10 @@ func (pms *PayloadMarshallerSuite) SetupTest() {
 
 	db1, db1td := setupTestDB(pms.T())
 	db2, db2td := setupTestDB(pms.T())
-	keystore1, keystore2, kstd := makeKeystores(pms.T())
+	keystore1, keystore2 := makeKeystores(pms.T())
 	pms.teardown = func() {
 		db1td()
 		db2td()
-		kstd()
 	}
 
 	initKeys(pms.T(), keystore1)

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -3,7 +3,6 @@ package pairing
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -49,19 +48,8 @@ type SyncDeviceSuite struct {
 
 func (s *SyncDeviceSuite) SetupTest() {
 	s.password = "password"
-
-	clientAsSenderTmpdir, err := os.MkdirTemp("", "TestPairingSyncDeviceClientAsSender")
-	require.NoError(s.T(), err)
-	s.clientAsSenderTmpdir = clientAsSenderTmpdir
-
-	clientAsReceiverTmpdir, err := os.MkdirTemp("", "TestPairingSyncDeviceClientAsReceiver")
-	require.NoError(s.T(), err)
-	s.clientAsReceiverTmpdir = clientAsReceiverTmpdir
-}
-
-func (s *SyncDeviceSuite) TearDownTest() {
-	os.RemoveAll(s.clientAsSenderTmpdir)
-	os.RemoveAll(s.clientAsReceiverTmpdir)
+	s.clientAsSenderTmpdir = s.T().TempDir()
+	s.clientAsReceiverTmpdir = s.T().TempDir()
 }
 
 func (s *SyncDeviceSuite) prepareBackendWithAccount(tmpdir string) *api.GethStatusBackend {

--- a/services/ens/api_test.go
+++ b/services/ens/api_test.go
@@ -34,9 +34,6 @@ func createDB(t *testing.T) (*sql.DB, func()) {
 func setupTestAPI(t *testing.T) (*API, func()) {
 	db, cancel := createDB(t)
 
-	keyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts")
-	require.NoError(t, err)
-
 	// Creating a dummy status node to simulate what it's done in get_status_node.go
 	upstreamConfig := params.UpstreamRPCConfig{
 		URL:     "https://mainnet.infura.io/v3/800c641949d64d768a5070a1b0511938",
@@ -54,7 +51,7 @@ func setupTestAPI(t *testing.T) (*API, func()) {
 
 	// import account keys
 	utils.Init()
-	require.NoError(t, utils.ImportTestAccount(keyStoreDir, utils.GetAccount1PKFile()))
+	require.NoError(t, utils.ImportTestAccount(t.TempDir(), utils.GetAccount1PKFile()))
 
 	return NewAPI(rpcClient, nil, nil, nil, db), cancel
 }

--- a/services/wakuext/api_test.go
+++ b/services/wakuext/api_test.go
@@ -102,13 +102,10 @@ func TestRequestMessagesErrors(t *testing.T) {
 }
 
 func TestInitProtocol(t *testing.T) {
-	directory, err := os.MkdirTemp("", "status-go-testing")
-	require.NoError(t, err)
-
 	config := params.NodeConfig{
 		ShhextConfig: params.ShhextConfig{
 			InstallationID:          "2",
-			BackupDisabledDataDir:   directory,
+			BackupDisabledDataDir:   t.TempDir(),
 			PFSEnabled:              true,
 			MailServerConfirmations: true,
 			ConnectionTarget:        10,
@@ -124,8 +121,7 @@ func TestInitProtocol(t *testing.T) {
 	nodeWrapper := ext.NewTestNodeWrapper(nil, waku)
 	service := New(config, nodeWrapper, nil, nil, db)
 
-	tmpdir, err := os.MkdirTemp("", "test-shhext-service-init-protocol")
-	require.NoError(t, err)
+	tmpdir := t.TempDir()
 
 	sqlDB, err := appdatabase.InitializeDB(fmt.Sprintf("%s/db.sql", tmpdir), "password", sqlite.ReducedKDFIterationsNumber)
 	require.NoError(t, err)
@@ -222,9 +218,7 @@ func (s *ShhExtSuite) createAndAddNode() {
 }
 
 func (s *ShhExtSuite) SetupTest() {
-	var err error
-	s.dir, err = os.MkdirTemp("", "status-go-testing")
-	s.Require().NoError(err)
+	s.dir = s.T().TempDir()
 }
 
 func (s *ShhExtSuite) TearDownTest() {

--- a/services/web3provider/api_test.go
+++ b/services/web3provider/api_test.go
@@ -39,8 +39,7 @@ func createDB(t *testing.T) (*sql.DB, func()) {
 func setupTestAPI(t *testing.T) (*API, func()) {
 	db, cancel := createDB(t)
 
-	keyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts")
-	require.NoError(t, err)
+	keyStoreDir := t.TempDir()
 
 	// Creating a dummy status node to simulate what it's done in get_status_node.go
 	upstreamConfig := params.UpstreamRPCConfig{


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```
