### PR TITLE
fix: DismissLatestContactRequestForContact - set default request id

### DIFF
--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -857,6 +857,10 @@ func (m *Messenger) DismissLatestContactRequestForContact(ctx context.Context, r
 		return nil, err
 	}
 
+	if contactRequestID == "" {
+		contactRequestID = defaultContactRequestID(request.ID.String())
+	}
+
 	return m.DismissContactRequest(ctx, &requests.DismissContactRequest{ID: types.Hex2Bytes(contactRequestID)})
 }
 


### PR DESCRIPTION
Required by Issue #6395

Request Id was empty during dismissing.
This was observed when sending request from mobile version 1.19 to a new desktop application.

Setting default request id was added, like in accepting function.
