### PR TITLE
fix documentation url in the checklist

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -6,7 +6,7 @@ github-team:
 prchecklist:
   title: Pull Request Checklist
   checklist:
-    - 'Have you updated the documentation, if impacted (e.g. [docs.status.im](https://docs.status.im/docs/build_status_go.html))?'
+    - 'Have you updated the documentation, if impacted (e.g. [docs.status.im](https://status.im/docs/))?'
     - 'Have you tested changes with mobile?'
     - 'Have you tested changes with desktop?'
 


### PR DESCRIPTION
on click of the link the redirected url was : https://status.im/docs/docs/build_status_go.html which was a 404.
updated that to the correct url https://status.im/docs/

