### PR TITLE
docker: upgrade Golang version to 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ HELP_FUN = \
 		   }
 
 statusgo: ##@build Build status-go as statusd server
-	go build -mod=vendor -i -v \
+	go build -mod=vendor -v \
 		-tags '$(BUILD_TAGS)' $(BUILD_FLAGS) \
 		-o $(GOBIN)/statusd ./cmd/statusd
 	@echo "Compilation done."
@@ -101,13 +101,13 @@ statusd-prune-docker-image: ##@statusd-prune Build statusd-prune docker image
 		-t $(STATUSD_PRUNE_IMAGE_NAME):latest
 
 bootnode: ##@build Build discovery v5 bootnode using status-go deps
-	go build -i -v \
+	go build -v \
 		-tags '$(BUILD_TAGS)' $(BUILD_FLAGS) \
 		-o $(GOBIN)/bootnode ./cmd/bootnode/
 	@echo "Compilation done."
 
 node-canary: ##@build Build P2P node canary using status-go deps
-	go build -i -v \
+	go build -v \
 		-tags '$(BUILD_TAGS)' $(BUILD_FLAGS) \
 		-o $(GOBIN)/node-canary ./cmd/node-canary/
 	@echo "Compilation done."

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -1,7 +1,7 @@
 # Build status-go in a Go builder container
-FROM golang:1.13-alpine as builder
+FROM golang:1.18-alpine as builder
 
-RUN apk add --no-cache make gcc musl-dev linux-headers
+RUN apk add --no-cache make gcc g++ musl-dev linux-headers
 
 ARG build_tags
 ARG build_flags
@@ -18,7 +18,7 @@ LABEL maintainer="support@status.im"
 LABEL source="https://github.com/status-im/status-go"
 LABEL description="status-go is an underlying part of Status - a browser, messenger, and gateway to a decentralized world."
 
-RUN apk add --no-cache ca-certificates bash
+RUN apk add --no-cache ca-certificates bash libgcc libstdc++
 RUN mkdir -p /static/keys
 
 COPY --from=builder /go/src/github.com/status-im/status-go/build/bin/statusd /usr/local/bin/


### PR DESCRIPTION
Otherwise it fails with:
```
build github.com/status-im/status-go/cmd/statusd:
  cannot load github.com/lucas-clemente/quic-go/internal/qtls: no Go source files
```

We also add missing `g++` compiler for `go-libutp` to fix:
```
go build github.com/anacrolix/go-libutp: g++: exec: "g++": executable file not found in $PATH
```

As well as install `libgcc` and `libstdc++` to avoids failures like this:
```
Error loading shared library libstdc++.so.6: No such file or directory (needed by /usr/local/bin/statusd)
Error loading shared library libgcc_s.so.1: No such file or directory (needed by /usr/local/bin/statusd)
Error relocating /usr/local/bin/statusd: _Znwm: symbol not found
Error relocating /usr/local/bin/statusd: _ZdlPvm: symbol not found
Error relocating /usr/local/bin/statusd: _Unwind_Resume: symbol not found
Error relocating /usr/local/bin/statusd: __gxx_personality_v0: symbol not found
```