### PR TITLE
mailserver: add DB query metrics

### DIFF
--- a/_assets/scripts/install_deps.sh
+++ b/_assets/scripts/install_deps.sh
@@ -7,7 +7,7 @@ elif [[ -x $(command -v pacman) ]]; then
 elif [[ -x $(command -v brew) ]]; then
   brew install protobuf jq
 elif [[ -x $(command -v nix-env) ]]; then
-  nix-env -iA nixos.protobuf3_13
+  nix-env -iA nixos.protobuf3_17
 else
   echo "ERROR: No known package manager found!" >&2
   exit 1

--- a/mailserver/mailserver_db_leveldb.go
+++ b/mailserver/mailserver_db_leveldb.go
@@ -128,6 +128,8 @@ func (db *LevelDB) BuildIterator(query CursorQuery) (Iterator, error) {
 	defer recoverLevelDBPanics("BuildIterator")
 
 	i := db.ldb.NewIterator(&util.Range{Start: query.start, Limit: query.end}, nil)
+
+	envelopeQueriesCounter.WithLabelValues("unknown", "unknown").Inc()
 	// seek to the end as we want to return envelopes in a descending order
 	if len(query.cursor) == CursorLength {
 		i.Seek(query.cursor)

--- a/mailserver/metrics.go
+++ b/mailserver/metrics.go
@@ -60,6 +60,10 @@ var (
 		Help:    "Size of envelopes saved.",
 		Buckets: prom.ExponentialBuckets(1024, 2, 11),
 	}, []string{"db"})
+	envelopeQueriesCounter = prom.NewCounterVec(prom.CounterOpts{
+		Name: "mailserver_envelope_queries_total",
+		Help: "Number of queries for envelopes in the DB.",
+	}, []string{"filter", "history"})
 )
 
 func init() {
@@ -76,4 +80,5 @@ func init() {
 	prom.MustRegister(archivedErrorsCounter)
 	prom.MustRegister(archivedEnvelopesGauge)
 	prom.MustRegister(archivedEnvelopeSizeMeter)
+	prom.MustRegister(envelopeQueriesCounter)
 }


### PR DESCRIPTION
Useful for debugging spikes in I/O caused by SQL queries.
```
 > curl -s 0:9090/metrics | grep queries
# HELP mailserver_envelope_queries_total Number of queries for envelopes in the DB.
# TYPE mailserver_envelope_queries_total counter
mailserver_envelope_queries_total{filter="unknown",history="unknown"} 2
```
```
admin@mail-02.gc-us-central1-a.eth.prod:~ % curl -s 0:9305/metrics | grep queries               
# HELP mailserver_envelope_queries_total Number of queries for envelopes in the DB.
# TYPE mailserver_envelope_queries_total counter
mailserver_envelope_queries_total{filter="partial",history="full"} 7
```