### PR TITLE
fix: apt -> apt-get in install_deps.sh

### DIFF
--- a/_assets/scripts/install_deps.sh
+++ b/_assets/scripts/install_deps.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-if [[ -x $(command -v apt) ]]; then
-  apt install -y protobuf-compiler jq
+if [[ -x $(command -v apt-get) ]]; then
+  apt-get install -y protobuf-compiler jq
 elif [[ -x $(command -v pacman) ]]; then
   pacman -Sy protobuf jq --noconfirm
 elif [[ -x $(command -v brew) ]]; then


### PR DESCRIPTION
there's a default /usr/bin/apt cli in macos

https://discussions.apple.com/thread/252845493