### PR TITLE
fix: adjust error codes for discord import

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1798,7 +1798,7 @@ func (m *Messenger) ExtractDiscordDataFromImportFiles(filesToImport []string) (*
 		bytes, err := os.ReadFile(filePath)
 		if err != nil {
 			errors[fileToImport] = &discord.ImportError{
-				Code:    201,
+				Code:    2,
 				Message: err.Error(),
 			}
 			continue
@@ -1809,7 +1809,7 @@ func (m *Messenger) ExtractDiscordDataFromImportFiles(filesToImport []string) (*
 		err = json.Unmarshal(bytes, &discordExportedData)
 		if err != nil {
 			errors[fileToImport] = &discord.ImportError{
-				Code:    202,
+				Code:    2,
 				Message: err.Error(),
 			}
 			continue
@@ -1817,7 +1817,7 @@ func (m *Messenger) ExtractDiscordDataFromImportFiles(filesToImport []string) (*
 
 		if len(discordExportedData.Messages) == 0 {
 			errors[fileToImport] = &discord.ImportError{
-				Code:    203,
+				Code:    2,
 				Message: "No messages to import",
 			}
 			continue


### PR DESCRIPTION
There are two types of errors "non-critical" (or "warning") and "critical".
These map to error codes `1` and `2` respectively.

The current error codes are a left-over of initial experimenting.

