### PR TITLE
LAN pairing security

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -16,15 +16,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
-
-	"github.com/davecgh/go-spew/spew"
-	"github.com/golang/protobuf/proto"
-
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/status-im/status-go/appdatabase"

--- a/server/certs.go
+++ b/server/certs.go
@@ -207,7 +207,7 @@ func verifyCert(cert *x509.Certificate, publicKey *ecdsa.PublicKey) error {
 // the function expects there to be only 1 certificate
 func getServerCert(URL *url.URL) (*x509.Certificate, error) {
 	conf := &tls.Config{
-		InsecureSkipVerify: true, // Only skip verify to get the server's TLS cert. DO NOT skip for any other reason.
+		InsecureSkipVerify: true, // nolint: gosec // Only skip verify to get the server's TLS cert. DO NOT skip for any other reason.
 	}
 
 	conn, err := tls.Dial("tcp", URL.Host, conf)

--- a/server/certs.go
+++ b/server/certs.go
@@ -8,10 +8,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
 	"math/big"
 	"net"
+	"net/url"
 	"time"
 )
 
@@ -145,4 +147,79 @@ func ToECDSA(d []byte) *ecdsa.PrivateKey {
 
 	k.PublicKey.X, k.PublicKey.Y = k.PublicKey.Curve.ScalarBaseMult(d)
 	return k
+}
+
+// verifyCertPublicKey checks that the ecdsa.PublicKey using in a x509.Certificate matches a known ecdsa.PublicKey
+func verifyCertPublicKey(cert *x509.Certificate, publicKey *ecdsa.PublicKey) error {
+	certKey, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("unexpected public key type, expected ecdsa.PublicKey")
+	}
+
+	if !certKey.Equal(publicKey) {
+		return fmt.Errorf("server certificate MUST match the given public key")
+	}
+	return nil
+}
+
+// verifyCertSig checks that a x509.Certificate's Signature verifies against x509.Certificate's PublicKey
+// If the x509.Certificate's PublicKey is not an ecdsa.PublicKey an error will be thrown
+func verifyCertSig(cert *x509.Certificate) (bool, error) {
+	var esig struct {
+		R, S *big.Int
+	}
+	if _, err := asn1.Unmarshal(cert.Signature, &esig); err != nil {
+		return false, err
+	}
+
+	hash := sha256.New()
+	hash.Write(cert.RawTBSCertificate)
+
+	ecKey, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return false, fmt.Errorf("certificate public is not an ecdsa.PublicKey")
+	}
+
+	verified := ecdsa.Verify(ecKey, hash.Sum(nil), esig.R, esig.S)
+	return verified, nil
+}
+
+// verifyCert verifies an x509.Certificate against a known ecdsa.PublicKey
+// combining the checks of verifyCertPublicKey and verifyCertSig.
+// If an x509.Certificate fails to verify an error is also thrown
+func verifyCert(cert *x509.Certificate, publicKey *ecdsa.PublicKey) error {
+	err := verifyCertPublicKey(cert, publicKey)
+	if err != nil {
+		return err
+	}
+
+	verified, err := verifyCertSig(cert)
+	if err != nil {
+		return err
+	}
+	if !verified {
+		return fmt.Errorf("server certificate signature MUST verify")
+	}
+	return nil
+}
+
+// getServerCert pings a given tls host, extracts and returns its x509.Certificate
+// the function expects there to be only 1 certificate
+func getServerCert(URL *url.URL) (*x509.Certificate, error) {
+	conf := &tls.Config{
+		InsecureSkipVerify: true, // Only skip verify to get the server's TLS cert. DO NOT skip for any other reason.
+	}
+
+	conn, err := tls.Dial("tcp", URL.Host, conf)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) != 1 {
+		return nil, fmt.Errorf("expected 1 TLS certificate, received '%d'", len(certs))
+	}
+
+	return certs[0], nil
 }

--- a/server/components_test.go
+++ b/server/components_test.go
@@ -19,6 +19,7 @@ const (
 	X        = "7744735542292224619198421067303535767629647588258222392379329927711683109548"
 	Y        = "6855516769916529066379811647277920115118980625614889267697023742462401590771"
 	D        = "38564357061962143106230288374146033267100509055924181407058066820384455255240"
+	AES      = "BbnZ7Gc66t54a9kEFCf7FW8SGQuYypwHVeNkRYeNoqV6"
 	DB58     = "6jpbvo2ucrtrnpXXF4DQYuysh697isH9ppd2aT8uSRDh"
 	SN       = "91849736469742262272885892667727604096707836853856473239722372976236128900962"
 	CertTime = "eQUriVtGtkWhPJFeLZjF"
@@ -28,6 +29,7 @@ type TestKeyComponents struct {
 	X      *big.Int
 	Y      *big.Int
 	D      *big.Int
+	AES    []byte
 	DBytes []byte
 	PK     *ecdsa.PrivateKey
 }
@@ -43,6 +45,9 @@ func (tk *TestKeyComponents) SetupKeyComponents(t *testing.T) {
 
 	tk.D, ok = new(big.Int).SetString(D, 10)
 	require.True(t, ok)
+
+	tk.AES = base58.Decode(AES)
+	require.Len(t, tk.AES, 32)
 
 	tk.DBytes = base58.Decode(DB58)
 	require.Exactly(t, tk.D.Bytes(), tk.DBytes)
@@ -75,34 +80,36 @@ func (tcc *TestCertComponents) SetupCertComponents(t *testing.T) {
 }
 
 type TestPairingServerComponents struct {
-	EphemeralPK *ecdsa.PrivateKey
-	OutboundIP  net.IP
-	CertTime    time.Time
-	Cert        tls.Certificate
-	PS          *PairingServer
+	EphemeralPK  *ecdsa.PrivateKey
+	EphemeralAES []byte
+	OutboundIP   net.IP
+	Cert         tls.Certificate
+	PS           *PairingServer
 }
 
 func (tpsc *TestPairingServerComponents) SetupPairingServerComponents(t *testing.T) {
 	var err error
 
-	// Get 3 key components for tls.cert generation
+	// Get 4 key components for tls.cert generation
 	// 1) Ephemeral private key
 	tpsc.EphemeralPK, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 
-	// 2) Device outbound IP address
+	// 2) AES encryption key
+	tpsc.EphemeralAES, err = makeEncryptionKey(tpsc.EphemeralPK)
+	require.NoError(t, err)
+
+	// 3) Device outbound IP address
 	tpsc.OutboundIP, err = GetOutboundIP()
 	require.NoError(t, err)
 
-	// 3) NotBefore time
-	tpsc.CertTime = time.Now()
-
 	// Generate tls.Certificate and Server
-	tpsc.Cert, _, err = GenerateCertFromKey(tpsc.EphemeralPK, tpsc.CertTime, tpsc.OutboundIP.String())
+	tpsc.Cert, _, err = GenerateCertFromKey(tpsc.EphemeralPK, time.Now(), tpsc.OutboundIP.String())
 	require.NoError(t, err)
 
 	tpsc.PS, err = NewPairingServer(&Config{
-		PK:       tpsc.EphemeralPK,
+		PK:       &tpsc.EphemeralPK.PublicKey,
+		EK:       tpsc.EphemeralAES,
 		Cert:     &tpsc.Cert,
 		Hostname: tpsc.OutboundIP.String()})
 	require.NoError(t, err)
@@ -112,8 +119,8 @@ type MockEncryptOnlyPayloadManager struct {
 	pem *PayloadEncryptionManager
 }
 
-func NewMockEncryptOnlyPayloadManager(pk *ecdsa.PrivateKey) (*MockEncryptOnlyPayloadManager, error) {
-	pem, err := NewPayloadEncryptionManager(pk)
+func NewMockEncryptOnlyPayloadManager(aesKey []byte) (*MockEncryptOnlyPayloadManager, error) {
+	pem, err := NewPayloadEncryptionManager(aesKey)
 	if err != nil {
 		return nil, err
 	}

--- a/server/connection_test.go
+++ b/server/connection_test.go
@@ -1,16 +1,13 @@
 package server
 
 import (
-	"crypto/ecdsa"
-	"crypto/x509"
-	"encoding/pem"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 )
 
 var (
-	connectionString = "2:4FHRnp:Q4:6jpbvo2ucrtrnpXXF4DQYuysh697isH9ppd2aT8uSRDh:eQUriVtGtkWhPJFeLZjF:3"
+	connectionString = "2:4FHRnp:Q4:uqnnMwVUfJc2Fkcaojet8F1ufKC3hZdGEt47joyBx9yd:BbnZ7Gc66t54a9kEFCf7FW8SGQuYypwHVeNkRYeNoqV6:3"
 )
 
 func TestConnectionParamsSuite(t *testing.T) {
@@ -37,7 +34,8 @@ func (s *ConnectionParamsSuite) SetupSuite() {
 
 	s.server = &PairingServer{
 		Server: bs,
-		pk:     s.PK,
+		pk:     &s.PK.PublicKey,
+		ek:     s.AES,
 		mode:   Sending,
 	}
 }
@@ -46,9 +44,7 @@ func (s *ConnectionParamsSuite) TestConnectionParams_ToString() {
 	cp, err := s.server.MakeConnectionParams()
 	s.Require().NoError(err)
 
-	cps, err := cp.ToString()
-	s.Require().NoError(err)
-
+	cps := cp.ToString()
 	s.Require().Equal(connectionString, cps)
 }
 
@@ -59,27 +55,13 @@ func (s *ConnectionParamsSuite) TestConnectionParams_Generate() {
 
 	s.Require().Exactly(Sending, cp.serverMode)
 
-	u, c, err := cp.Generate()
+	u, err := cp.URL()
 	s.Require().NoError(err)
 
 	s.Require().Equal("https://127.0.0.1:1337", u.String())
 	s.Require().Equal(defaultIP.String(), u.Hostname())
 	s.Require().Equal("1337", u.Port())
 
-	// Parse cert PEM into x509 cert
-	block, _ := pem.Decode(c)
-	s.Require().NotNil(block)
-	cert, err := x509.ParseCertificate(block.Bytes)
-	s.Require().NoError(err)
-
-	// Compare cert values
-	cl := s.server.cert.Leaf
-	s.Require().NotEqual(cl.Signature, cert.Signature)
-	s.Require().Zero(cl.PublicKey.(*ecdsa.PublicKey).X.Cmp(cert.PublicKey.(*ecdsa.PublicKey).X))
-	s.Require().Zero(cl.PublicKey.(*ecdsa.PublicKey).Y.Cmp(cert.PublicKey.(*ecdsa.PublicKey).Y))
-	s.Require().Equal(cl.Version, cert.Version)
-	s.Require().Zero(cl.SerialNumber.Cmp(cert.SerialNumber))
-	s.Require().Exactly(cl.NotBefore, cert.NotBefore)
-	s.Require().Exactly(cl.NotAfter, cert.NotAfter)
-	s.Require().Exactly(cl.IPAddresses, cert.IPAddresses)
+	s.Require().True(cp.publicKey.Equal(&s.PK.PublicKey))
+	s.Require().Equal(s.AES, cp.aesKey)
 }

--- a/server/ips_test.go
+++ b/server/ips_test.go
@@ -63,8 +63,7 @@ func (s *GetOutboundIPSuite) TestGetOutboundIPWithFullServerE2e() {
 	cp, err := s.PS.MakeConnectionParams()
 	s.Require().NoError(err)
 
-	qr, err := cp.ToString()
-	s.Require().NoError(err)
+	qr := cp.ToString()
 
 	// Client reads QR code and parses the connection string
 	ccp := new(ConnectionParams)

--- a/server/payload_manager.go
+++ b/server/payload_manager.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -44,8 +43,8 @@ type PairingPayloadManager struct {
 }
 
 // NewPairingPayloadManager generates a new and initialised PairingPayloadManager
-func NewPairingPayloadManager(pk *ecdsa.PrivateKey, config *PairingPayloadManagerConfig) (*PairingPayloadManager, error) {
-	pem, err := NewPayloadEncryptionManager(pk)
+func NewPairingPayloadManager(aesKey []byte, config *PairingPayloadManagerConfig) (*PairingPayloadManager, error) {
+	pem, err := NewPayloadEncryptionManager(aesKey)
 	if err != nil {
 		return nil, err
 	}
@@ -120,13 +119,8 @@ type PayloadEncryptionManager struct {
 	received *EncryptionPayload
 }
 
-func NewPayloadEncryptionManager(pk *ecdsa.PrivateKey) (*PayloadEncryptionManager, error) {
-	ek, err := makeEncryptionKey(pk)
-	if err != nil {
-		return nil, err
-	}
-
-	return &PayloadEncryptionManager{ek, new(EncryptionPayload), new(EncryptionPayload)}, nil
+func NewPayloadEncryptionManager(aesKey []byte) (*PayloadEncryptionManager, error) {
+	return &PayloadEncryptionManager{aesKey, new(EncryptionPayload), new(EncryptionPayload)}, nil
 }
 
 func (pem *PayloadEncryptionManager) Encrypt(data []byte) error {

--- a/server/server.go
+++ b/server/server.go
@@ -117,6 +117,16 @@ func (s *Server) SetHandlers(handlers HandlerPatternMap) {
 	s.handlers = handlers
 }
 
+func (s *Server) AddHandlers(handlers HandlerPatternMap) {
+	if s.handlers == nil {
+		s.handlers = make(HandlerPatternMap)
+	}
+
+	for name := range handlers {
+		s.handlers[name] = handlers[name]
+	}
+}
+
 func (s *Server) MakeBaseURL() *url.URL {
 	return &url.URL{
 		Scheme: "https",

--- a/server/server_pairing_test.go
+++ b/server/server_pairing_test.go
@@ -59,6 +59,9 @@ func (s *PairingServerSuite) TestPairingServer_StartPairing() {
 		c, err := NewPairingClient(ccp, nil)
 		s.Require().NoError(err)
 
+		err = c.getServerCert()
+		s.Require().NoError(err)
+
 		// Replace PairingClient.PayloadManager with a MockEncryptOnlyPayloadManager
 		c.PayloadManager, err = NewMockEncryptOnlyPayloadManager(s.EphemeralPK)
 		s.Require().NoError(err)


### PR DESCRIPTION
## What's Changed?

After a review from @s1fr0 I've replaced passing an ECDSA private key with its public key, and replaced the `NotBefore` parameter with a symmetric key.

`PairingClient`s no longer have the potential to impersonate the `PairingServer`.

### `PairingClient` gets TLS cert from `PairingServer`

- `PairingServer` generates TLS cert
- `PairingServer` shares:
  - The public key associated with the cert
  - Its IP address and port number
- `PairingClient` makes a TLS connection to the `PairingServer`
  -  ⚠️ **Note**, this connection requires that the client config set `InsecureSkipVerify` to true, because the root certs do not yet contain the `PairingServer`'s cert. This connection is **only ever** used to find the `PairingServer`'s TLS cert.
- `PairingClient` gets the TLS cert
- `PairingClient` checks TLS cert has the expected public key
- `PairingClient` verifies TLS cert signature
- `PairingClient` adds the TLS cert to the list of root certs

## Follow Up

In a follow up PR I've implemented a fix for an issue where the `PairingClient` **or any other network client** can receive the encrypted payload of the `PairingServer` without any authentication. To fix this I've implemented a challenge on client request to send payload,

## Note for QA

This change should have no impact on e2e tests.