### PR TITLE
feat(communities): introduce `publish` flag in community manager APIs

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -286,7 +286,7 @@ func (m *Manager) Created() ([]*Community, error) {
 }
 
 // CreateCommunity takes a description, generates an ID for it, saves it and return it
-func (m *Manager) CreateCommunity(request *requests.CreateCommunity) (*Community, error) {
+func (m *Manager) CreateCommunity(request *requests.CreateCommunity, publish bool) (*Community, error) {
 
 	description, err := request.ToCommunityDescription()
 	if err != nil {
@@ -329,7 +329,9 @@ func (m *Manager) CreateCommunity(request *requests.CreateCommunity) (*Community
 		return nil, err
 	}
 
-	m.publish(&Subscription{Community: community})
+	if publish {
+		m.publish(&Subscription{Community: community})
+	}
 
 	return community, nil
 }
@@ -444,7 +446,7 @@ func (m *Manager) ImportCommunity(key *ecdsa.PrivateKey) (*Community, error) {
 	return community, nil
 }
 
-func (m *Manager) CreateChat(communityID types.HexBytes, chat *protobuf.CommunityChat) (*Community, *CommunityChanges, error) {
+func (m *Manager) CreateChat(communityID types.HexBytes, chat *protobuf.CommunityChat, publish bool) (*Community, *CommunityChanges, error) {
 	community, err := m.GetByID(communityID)
 	if err != nil {
 		return nil, nil, err
@@ -464,7 +466,9 @@ func (m *Manager) CreateChat(communityID types.HexBytes, chat *protobuf.Communit
 	}
 
 	// Advertise changes
-	m.publish(&Subscription{Community: community})
+	if publish {
+		m.publish(&Subscription{Community: community})
+	}
 
 	return community, changes, nil
 }
@@ -528,7 +532,7 @@ func (m *Manager) DeleteChat(communityID types.HexBytes, chatID string) (*Commun
 	return community, description, nil
 }
 
-func (m *Manager) CreateCategory(request *requests.CreateCommunityCategory) (*Community, *CommunityChanges, error) {
+func (m *Manager) CreateCategory(request *requests.CreateCommunityCategory, publish bool) (*Community, *CommunityChanges, error) {
 	community, err := m.GetByID(request.CommunityID)
 	if err != nil {
 		return nil, nil, err
@@ -556,7 +560,9 @@ func (m *Manager) CreateCategory(request *requests.CreateCommunityCategory) (*Co
 	}
 
 	// Advertise changes
-	m.publish(&Subscription{Community: community})
+	if publish {
+		m.publish(&Subscription{Community: community})
+	}
 
 	return community, changes, nil
 }

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -60,7 +60,7 @@ func (s *ManagerSuite) TestCreateCommunity() {
 		Membership:  protobuf.CommunityPermissions_NO_MEMBERSHIP,
 	}
 
-	community, err := s.manager.CreateCommunity(request)
+	community, err := s.manager.CreateCommunity(request, true)
 	s.Require().NoError(err)
 	s.Require().NotNil(community)
 
@@ -104,7 +104,7 @@ func (s *ManagerSuite) TestCreateCommunity_WithBanner() {
 		},
 	}
 
-	community, err := s.manager.CreateCommunity(request)
+	community, err := s.manager.CreateCommunity(request, true)
 	s.Require().NoError(err)
 	s.Require().NotNil(community)
 
@@ -126,7 +126,7 @@ func (s *ManagerSuite) TestEditCommunity() {
 		Membership:  protobuf.CommunityPermissions_NO_MEMBERSHIP,
 	}
 
-	community, err := s.manager.CreateCommunity(createRequest)
+	community, err := s.manager.CreateCommunity(createRequest, true)
 	s.Require().NoError(err)
 	s.Require().NotNil(community)
 
@@ -551,7 +551,7 @@ func (s *ManagerSuite) buildCommunityWithChat() (*Community, string, error) {
 		Description: "status community description",
 		Membership:  protobuf.CommunityPermissions_NO_MEMBERSHIP,
 	}
-	community, err := s.manager.CreateCommunity(createRequest)
+	community, err := s.manager.CreateCommunity(createRequest, true)
 	if err != nil {
 		return nil, "", err
 	}
@@ -565,7 +565,7 @@ func (s *ManagerSuite) buildCommunityWithChat() (*Community, string, error) {
 		},
 		Members: make(map[string]*protobuf.CommunityMember),
 	}
-	_, changes, err := s.manager.CreateChat(community.ID(), chat)
+	_, changes, err := s.manager.CreateChat(community.ID(), chat, true)
 	if err != nil {
 		return nil, "", err
 	}

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -453,7 +453,7 @@ func (m *Messenger) CreateCommunityCategory(request *requests.CreateCommunityCat
 	}
 
 	var response MessengerResponse
-	community, changes, err := m.communitiesManager.CreateCategory(request)
+	community, changes, err := m.communitiesManager.CreateCategory(request, true)
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +651,7 @@ func (m *Messenger) leaveCommunity(communityID types.HexBytes) (*MessengerRespon
 
 func (m *Messenger) CreateCommunityChat(communityID types.HexBytes, c *protobuf.CommunityChat) (*MessengerResponse, error) {
 	var response MessengerResponse
-	community, changes, err := m.communitiesManager.CreateChat(communityID, c)
+	community, changes, err := m.communitiesManager.CreateChat(communityID, c, true)
 	if err != nil {
 		return nil, err
 	}
@@ -750,7 +750,7 @@ func (m *Messenger) CreateCommunity(request *requests.CreateCommunity, createDef
 
 	response := &MessengerResponse{}
 
-	community, err := m.communitiesManager.CreateCommunity(request)
+	community, err := m.communitiesManager.CreateCommunity(request, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is so that we can control whether we want to publish the community
when it, or it's categories and channels, are created.

This is needed for the discord import so that we can create communities,
channels and categories without publishing the community and have it
show up in UIs too early.
