### PR TITLE
fix(messenger): don't remove inactive chats when syncing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -259,6 +259,7 @@ require (
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
 	golang.org/x/tools v0.1.11 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
+	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0 // indirect

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2865,7 +2865,7 @@ func (m *Messenger) SyncDevices(ctx context.Context, ensName, photoPath string) 
 			}
 		}
 
-		if (isPublicChat || chat.OneToOne() || chat.PrivateGroupChat()) && !chat.Active {
+		if (isPublicChat || chat.OneToOne() || chat.PrivateGroupChat()) && !chat.Active && chat.DeletedAtClockValue > 0 {
 			pending, err := m.persistence.HasPendingNotificationsForChat(chat.ID)
 			if err != nil {
 				return false

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -605,6 +605,10 @@ func (m *Messenger) HandleSyncChatRemoved(state *ReceivedMessageState, message p
 		return nil
 	}
 
+	if chat.DeletedAtClockValue > message.Clock {
+		return nil
+	}
+
 	if chat.PrivateGroupChat() {
 		_, err := m.leaveGroupChat(context.Background(), state.Response, message.Id, true, false)
 		if err != nil {

--- a/protocol/messenger_installations_test.go
+++ b/protocol/messenger_installations_test.go
@@ -169,6 +169,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 
 	// add and deactivate chat
 	chat2 := CreatePublicChat(removedChatID, s.m.transport)
+	chat2.DeletedAtClockValue = 1
 	err = s.m.SaveChat(chat2)
 	s.Require().NoError(err)
 	_, err = s.m.deactivateChat(removedChatID, 0, true)


### PR DESCRIPTION
This commit ensures we're relying on `chat.DeletedAtClockValue` instead
of `chat.Active` to know whether or not we need to remove the chat from
paired devices.

Because we were relying on `Active != true`, we ended up with a serious
bug that would result in deactivating all chats on paired devices.

The reason the chats would disappear on paired devices is because, when
setting up a new device by importing a seedphrase, chances are this
device will receive `HandleBackUp` signals (which originate from other
devices with the same account that backed up contacts etc).

When backups are handled, we create chats for every contact that's part
of the backup signal. Those chats are set to `Active = false` because
the signal handling shouldn't cause those chats to show up in the UI.

However, because those are set to `Active = false`, the next time the
user tries to sync from this devices, all those chats are considered as
"removed", hence sending "chat removed" signals when syncing (which then
causes those chats to disappear on all paired devices.

We need to rely on `DeletedAtClockValue` to know whether a chat was
indeed removed and only then emit such a signal.

