### PR TITLE
feat: Add param for change24Hour to get 24 hours change value for a token from cryptocompare

### DIFF
--- a/services/wallet/cryptocompare.go
+++ b/services/wallet/cryptocompare.go
@@ -29,6 +29,7 @@ type MarketCoinValues struct {
 	CHANGEPCTHOUR   string `json:"CHANGEPCTHOUR"`
 	CHANGEPCTDAY    string `json:"CHANGEPCTDAY"`
 	CHANGEPCT24HOUR string `json:"CHANGEPCT24HOUR"`
+	CHANGE24HOUR    string `json:"CHANGE24HOUR"`
 }
 
 type CoinsContainer struct {


### PR DESCRIPTION
feat: Add param for change24Hour to get 24 hours change value for a token from cryptocompare

A short summary which serves as a squashed-commit message.

A description to understand introduced changes without reading the code.

Important changes:
- [x] Something worth noting for reviewers.

Closes #
