### PR TITLE
fix: avoid imported wallet account deletion while converting it to keycard account

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -699,6 +699,9 @@ func TestConvertAccount(t *testing.T) {
 
 	err = backend.ensureAppDBOpened(keycardAccount, keycardPassword)
 	require.NoError(t, err)
+
+	b := NewGethStatusBackend()
+	require.NoError(t, b.OpenAccounts())
 }
 
 func copyFile(srcFolder string, dstFolder string, fileName string, t *testing.T) {

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -576,23 +576,18 @@ func (b *GethStatusBackend) ConvertToKeycardAccount(keyStoreDir string, account 
 		return err
 	}
 
-	err = accountDB.DeleteSeedAndKeyAccounts()
-	if err != nil {
-		return err
-	}
-
-	dbPath := filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db", account.KeyUID))
-	err = appdatabase.ChangeDatabasePassword(dbPath, password, newPassword)
-	if err != nil {
-		return err
-	}
-
 	err = b.closeAppDB()
 	if err != nil {
 		return err
 	}
 
-	return os.RemoveAll(keyStoreDir)
+	err = os.RemoveAll(keyStoreDir)
+	if err != nil {
+		return err
+	}
+
+	dbPath := filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db", account.KeyUID))
+	return appdatabase.ChangeDatabasePassword(dbPath, password, newPassword)
 }
 
 func (b *GethStatusBackend) VerifyDatabasePassword(keyUID string, password string) error {


### PR DESCRIPTION
- imported wallet accounts via seed phrase or private key are not deleted anymore
when migrating any of those key pairs to a keycard