### PR TITLE
refactor(messenger): emit discord import updates via interval

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -135,6 +135,8 @@ type Messenger struct {
 	httpServer                 *server.MediaServer
 	quit                       chan struct{}
 
+	cancelImportChannels map[string]bool
+
 	requestedCommunitiesLock sync.RWMutex
 	requestedCommunities     map[string]*transport.Filter
 
@@ -446,6 +448,7 @@ func NewMessenger(
 		quit:                     make(chan struct{}),
 		requestedCommunitiesLock: sync.RWMutex{},
 		requestedCommunities:     make(map[string]*transport.Filter),
+		cancelImportChannels:     make(map[string]bool),
 		browserDatabase:          c.browserDatabase,
 		httpServer:               c.httpServer,
 		contractMaker: &contracts.ContractMaker{

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -49,6 +49,7 @@ type MessengerSignalsHandler interface {
 	DiscordCategoriesAndChannelsExtracted(categories []*discord.Category, channels []*discord.Channel, oldestMessageTimestamp int64, errors map[string]*discord.ImportError)
 	DiscordCommunityImportProgress(importProgress *discord.ImportProgress)
 	DiscordCommunityImportFinished(communityID string)
+	DiscordCommunityImportCancelled(communityID string)
 }
 
 type config struct {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1144,6 +1144,10 @@ func (api *PublicAPI) RequestImportDiscordCommunity(request *requests.ImportDisc
 	api.service.messenger.RequestImportDiscordCommunity(request)
 }
 
+func (api *PublicAPI) RequestCancelDiscordCommunityImport(id string) {
+	api.service.messenger.MarkDiscordCommunityImportAsCancelled(id)
+}
+
 // -----
 // HELPER
 // -----

--- a/services/ext/signal.go
+++ b/services/ext/signal.go
@@ -135,3 +135,7 @@ func (m *MessengerSignalsHandler) DiscordCommunityImportProgress(importProgress 
 func (m *MessengerSignalsHandler) DiscordCommunityImportFinished(id string) {
 	signal.SendDiscordCommunityImportFinished(id)
 }
+
+func (m *MessengerSignalsHandler) DiscordCommunityImportCancelled(id string) {
+	signal.SendDiscordCommunityImportCancelled(id)
+}

--- a/signal/events_discord_import.go
+++ b/signal/events_discord_import.go
@@ -17,6 +17,10 @@ const (
 	// EventDiscordCommunityImportFinished triggered when importing
 	// the discord community into status was successful
 	EventDiscordCommunityImportFinished = "community.discordCommunityImportFinished"
+
+	// EventDiscordCommunityImportCancelled triggered when importing
+	// the discord community was cancelled
+	EventDiscordCommunityImportCancelled = "community.discordCommunityImportCancelled"
 )
 
 type DiscordCategoriesAndChannelsExtractedSignal struct {
@@ -31,6 +35,10 @@ type DiscordCommunityImportProgressSignal struct {
 }
 
 type DiscordCommunityImportFinishedSignal struct {
+	CommunityID string `json:"communityId"`
+}
+
+type DiscordCommunityImportCancelledSignal struct {
 	CommunityID string `json:"communityId"`
 }
 
@@ -51,6 +59,12 @@ func SendDiscordCommunityImportProgress(importProgress *discord.ImportProgress) 
 
 func SendDiscordCommunityImportFinished(communityID string) {
 	send(EventDiscordCommunityImportFinished, DiscordCommunityImportFinishedSignal{
+		CommunityID: communityID,
+	})
+}
+
+func SendDiscordCommunityImportCancelled(communityID string) {
+	send(EventDiscordCommunityImportCancelled, DiscordCommunityImportCancelledSignal{
 		CommunityID: communityID,
 	})
 }


### PR DESCRIPTION
This changes publishing progress updates of the discord import tool to
happen in an interval instead of synchronously whenever an emission was
done.

The benefit of this is that we reduce the amount of signals being sent
which also improves signal handling in clients as they have to handle
less load.

