### PR TITLE
chore: change address of community portal testnet contract

### DIFF
--- a/contracts/directory/address.go
+++ b/contracts/directory/address.go
@@ -9,7 +9,7 @@ import (
 var errorNotAvailableOnChainID = errors.New("not available for chainID")
 
 var contractAddressByChainID = map[uint64]common.Address{
-	69: common.HexToAddress("0x33534cc18D50ab082324A98eE69A7cCe47b75C49"), // optimism kovan testnet
+	69: common.HexToAddress("0x4BbCCa869E9931280Cb46AE0DfF18881Be581a4d"), // optimism kovan testnet
 }
 
 func ContractAddress(chainID uint64) (common.Address, error) {


### PR DESCRIPTION
I redeployed the contract and verified it in https://kovan-optimistic.etherscan.io/address/0x4BbCCa869E9931280Cb46AE0DfF18881Be581a4d so anyone can add / remove communities for testing