### PR TITLE
feat: add signal to inform clients when all archives have been downloaded and handled

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -108,14 +108,15 @@ func (md archiveMDSlice) Less(i, j int) bool {
 }
 
 type Subscription struct {
-	Community                      *Community
-	Invitations                    []*protobuf.CommunityInvitation
-	CreatingHistoryArchivesSignal  *signal.CreatingHistoryArchivesSignal
-	HistoryArchivesCreatedSignal   *signal.HistoryArchivesCreatedSignal
-	NoHistoryArchivesCreatedSignal *signal.NoHistoryArchivesCreatedSignal
-	HistoryArchivesSeedingSignal   *signal.HistoryArchivesSeedingSignal
-	HistoryArchivesUnseededSignal  *signal.HistoryArchivesUnseededSignal
-	HistoryArchiveDownloadedSignal *signal.HistoryArchiveDownloadedSignal
+	Community                                *Community
+	Invitations                              []*protobuf.CommunityInvitation
+	CreatingHistoryArchivesSignal            *signal.CreatingHistoryArchivesSignal
+	HistoryArchivesCreatedSignal             *signal.HistoryArchivesCreatedSignal
+	NoHistoryArchivesCreatedSignal           *signal.NoHistoryArchivesCreatedSignal
+	HistoryArchivesSeedingSignal             *signal.HistoryArchivesSeedingSignal
+	HistoryArchivesUnseededSignal            *signal.HistoryArchivesUnseededSignal
+	HistoryArchiveDownloadedSignal           *signal.HistoryArchiveDownloadedSignal
+	DownloadingHistoryArchivesFinishedSignal *signal.DownloadingHistoryArchivesFinishedSignal
 }
 
 type CommunityResponse struct {

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -45,6 +45,7 @@ type MessengerSignalsHandler interface {
 	HistoryArchivesSeeding(communityID string)
 	HistoryArchivesUnseeded(communityID string)
 	HistoryArchiveDownloaded(communityID string, from int, to int)
+	DownloadingHistoryArchivesFinished(communityID string)
 	StatusUpdatesTimedOut(statusUpdates *[]UserStatus)
 	DiscordCategoriesAndChannelsExtracted(categories []*discord.Category, channels []*discord.Channel, oldestMessageTimestamp int64, errors map[string]*discord.ImportError)
 }

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -949,6 +949,7 @@ func (m *Messenger) HandleHistoryArchiveMagnetlinkMessage(state *ReceivedMessage
 					signal.SendNewMessages(response)
 					localnotifications.PushMessages(notifications)
 				}
+				m.config.messengerSignalsHandler.DownloadingHistoryArchivesFinished(types.EncodeHex(id))
 			}()
 
 			return m.communitiesManager.UpdateMagnetlinkMessageClock(id, clock)

--- a/services/ext/signal.go
+++ b/services/ext/signal.go
@@ -120,6 +120,10 @@ func (m *MessengerSignalsHandler) HistoryArchiveDownloaded(communityID string, f
 	signal.SendHistoryArchiveDownloaded(communityID, from, to)
 }
 
+func (m *MessengerSignalsHandler) DownloadingHistoryArchivesFinished(communityID string) {
+	signal.SendDownloadingHistoryArchivesFinished(communityID)
+}
+
 func (m *MessengerSignalsHandler) StatusUpdatesTimedOut(statusUpdates *[]protocol.UserStatus) {
 	signal.SendStatusUpdatesTimedOut(statusUpdates)
 }

--- a/signal/events_community_archives.go
+++ b/signal/events_community_archives.go
@@ -27,6 +27,9 @@ const (
 	// EventHistoryArchiveDownloaded is triggered when the community member node
 	// has downloaded an individual community archive
 	EventHistoryArchiveDownloaded = "community.historyArchiveDownloaded"
+	// EventDownloadingHistoryArchivesFinished is triggered when the community member node
+	// has downloaded all archives
+	EventDownloadingHistoryArchivesFinished = "community.downloadingHistoryArchivesFinished"
 )
 
 type CreatingHistoryArchivesSignal struct {
@@ -57,6 +60,10 @@ type HistoryArchiveDownloadedSignal struct {
 	CommunityID string `json:"communityId"`
 	From        int    `json:"from"`
 	To          int    `json:"to"`
+}
+
+type DownloadingHistoryArchivesFinishedSignal struct {
+	CommunityID string `json:"communityId"`
 }
 
 func SendHistoryArchivesProtocolEnabled() {
@@ -100,5 +107,11 @@ func SendHistoryArchiveDownloaded(communityID string, from int, to int) {
 		CommunityID: communityID,
 		From:        from,
 		To:          to,
+	})
+}
+
+func SendDownloadingHistoryArchivesFinished(communityID string) {
+	send(EventDownloadingHistoryArchivesFinished, DownloadingHistoryArchivesFinishedSignal{
+		CommunityID: communityID,
 	})
 }


### PR DESCRIPTION
This adds a new `DownloadingHistoryArchivesFinished` signal to the family of community archive signals. It's emitted when all to be downloaded archives have been downloaded and handled.

