### PR TITLE
fix(images): ensure decode from URL emits error on HTTP error code

### DIFF
--- a/images/decode.go
+++ b/images/decode.go
@@ -48,6 +48,10 @@ func DecodeFromURL(path string) (image.Image, error) {
 		}
 	}()
 
+	if res.StatusCode >= 400 {
+		return nil, errors.New(http.StatusText(res.StatusCode))
+	}
+
 	bodyBytes, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err

--- a/images/decode_test.go
+++ b/images/decode_test.go
@@ -150,6 +150,14 @@ func TestDecodeFromURL(t *testing.T) {
 	}
 }
 
+func TestDecodeFromURL_WithErrors(t *testing.T) {
+	s := httptest.NewServer(http.FileServer(http.Dir(path)))
+	defer s.Close()
+
+	_, err := DecodeFromURL("https://doesnt-exist.com")
+	require.Error(t, err)
+}
+
 func TestGetType(t *testing.T) {
 	cs := []struct {
 		Buf   []byte


### PR DESCRIPTION
We should emit an error when the request to an image to be fetched returns and HTTP error code. Otherwise, we'll run into other higher level errors down the line, which are misleading

Example: I kept seeing "image content type not supported" errors, although the content type *is* supported. The actual problem was that the decode function operates on non existing image bytes.

