### PR TITLE
fix: remove ourselves from members when leaving community

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -702,16 +702,11 @@ func (o *Community) RemoveUserFromChat(pk *ecdsa.PublicKey, chatID string) (*pro
 	return o.config.CommunityDescription, nil
 }
 
-func (o *Community) RemoveUserFromOrg(pk *ecdsa.PublicKey) (*protobuf.CommunityDescription, error) {
-	o.mutex.Lock()
-	defer o.mutex.Unlock()
-
-	if o.config.PrivateKey == nil {
-		return nil, ErrNotAdmin
-	}
+func (o *Community) removeMemberFromOrg(pk *ecdsa.PublicKey) {
 	if !o.hasMember(pk) {
-		return o.config.CommunityDescription, nil
+		return
 	}
+
 	key := common.PubkeyToHex(pk)
 
 	// Remove from org
@@ -723,7 +718,23 @@ func (o *Community) RemoveUserFromOrg(pk *ecdsa.PublicKey) (*protobuf.CommunityD
 	}
 
 	o.increaseClock()
+}
 
+func (o *Community) RemoveOurselvesFromOrg(pk *ecdsa.PublicKey) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	o.removeMemberFromOrg(pk)
+}
+
+func (o *Community) RemoveUserFromOrg(pk *ecdsa.PublicKey) (*protobuf.CommunityDescription, error) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	if o.config.PrivateKey == nil {
+		return nil, ErrNotAdmin
+	}
+
+	o.removeMemberFromOrg(pk)
 	return o.config.CommunityDescription, nil
 }
 

--- a/protocol/communities/community_test.go
+++ b/protocol/communities/community_test.go
@@ -327,6 +327,22 @@ func (s *CommunitySuite) TestRemoveUserFormOrg() {
 	s.Require().False(ok)
 }
 
+func (s *CommunitySuite) TestRemoveOurselvesFormOrg() {
+	org := s.buildCommunity(&s.identity.PublicKey)
+
+	// We don't need to be an admin to remove ourselves from community
+	org.config.PrivateKey = nil
+
+	org.RemoveOurselvesFromOrg(&s.member1.PublicKey)
+
+	// Check member has been removed from org
+	s.Require().False(org.HasMember(&s.member1.PublicKey))
+
+	// Check member has been removed from chat
+	_, ok := org.config.CommunityDescription.Chats[testChatID1].Members[common.PubkeyToHex(&s.member1.PublicKey)]
+	s.Require().False(ok)
+}
+
 func (s *CommunitySuite) TestAcceptRequestToJoin() {
 	// WHAT TO DO WITH ENS
 	// TEST CASE 1: Not an admin

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1047,18 +1047,14 @@ func (m *Manager) LeaveCommunity(id types.HexBytes) (*Community, error) {
 	if community == nil {
 		return nil, ErrOrgNotFound
 	}
-	if community.IsAdmin() {
-		_, err = community.RemoveUserFromOrg(m.identity)
-		if err != nil {
-			return nil, err
-		}
-	}
-	community.Leave()
-	err = m.persistence.SaveCommunity(community)
 
-	if err != nil {
+	community.RemoveOurselvesFromOrg(m.identity)
+	community.Leave()
+
+	if err = m.persistence.SaveCommunity(community); err != nil {
 		return nil, err
 	}
+
 	return community, nil
 }
 


### PR DESCRIPTION
Otherwise clients see invalid members count in invitation bubbles.
