### PR TITLE
chore: use provided pictures visibility options when creating settings db entry

### DIFF
--- a/multiaccounts/settings/database.go
+++ b/multiaccounts/settings/database.go
@@ -109,10 +109,12 @@ INSERT INTO settings (
   signing_phrase,
   wallet_root_address,
   synthetic_id,
-  current_user_status
+  current_user_status,
+  profile_pictures_show_to,
+  profile_pictures_visibility
 ) VALUES (
 ?,?,?,?,?,?,?,?,?,?,?,?,
-?,?,?,?,?,?,?,?,?,'id',?)`,
+?,?,?,?,?,?,?,?,?,'id',?,?,?)`,
 		s.Address,
 		s.Currency,
 		s.CurrentNetwork,
@@ -135,6 +137,8 @@ INSERT INTO settings (
 		s.SigningPhrase,
 		s.WalletRootAddress,
 		s.CurrentUserStatus,
+		s.ProfilePicturesShowTo,
+		s.ProfilePicturesVisibility,
 	)
 	if err != nil {
 		return err

--- a/protocol/messenger_sync_settings_test.go
+++ b/protocol/messenger_sync_settings_test.go
@@ -141,6 +141,7 @@ func (s *MessengerSyncSettingsSuite) newMessengerWithOptions(shh types.Waku, pri
 		PublicKey:                 "0x04112233445566778899001122334455667788990011223344556677889900112233445566778899001122334455667788990011223344556677889900",
 		SigningPhrase:             "yurt joey vibe",
 		SendPushNotifications:     true,
+		ProfilePicturesShowTo:     1,
 		ProfilePicturesVisibility: 1,
 		DefaultSyncPeriod:         86400,
 		UseMailservers:            true,

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -131,7 +131,10 @@ func newMessengerWithKey(shh types.Waku, privateKey *ecdsa.PrivateKey, logger *z
 		WithAccount(iai.ToMultiAccount()),
 		WithDatasync(),
 		WithToplevelDatabaseMigrations(),
-		WithAppSettings(settings.Settings{}, params.NodeConfig{}),
+		WithAppSettings(settings.Settings{
+			ProfilePicturesShowTo:     1,
+			ProfilePicturesVisibility: 1,
+		}, params.NodeConfig{}),
 		WithBrowserDatabase(nil),
 	}
 


### PR DESCRIPTION
When initially creating settings, properties 'initialize profile_pictures_show_to' and 'profile_pictures_visibility' are set according to the provided Setting object.

Required by: https://github.com/status-im/status-desktop/issues/7310