### PR TITLE
chore(community): community itself has admin rights

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -648,6 +648,10 @@ func (o *Community) hasMemberPermission(member *protobuf.CommunityMember, permis
 }
 
 func (o *Community) hasPermission(pk *ecdsa.PublicKey, roles map[protobuf.CommunityMember_Roles]bool) bool {
+	if common.IsPubKeyEqual(pk, o.config.ID) {
+		return true
+	}
+
 	member := o.getMember(pk)
 	if member == nil {
 		return false


### PR DESCRIPTION
This might look like a weird requirement at a fist glance. The reason this is needed, is because some message signals require admin rights to take effect (e.g. PinMessage).

When messages are imported from third-party services, translated to status messages, signed by the community, and eventually distributed via the archive protocol, we need to ensure that messages signed by the community itself are considered as admin privileges as well, so they can be correctly replayed into the database.

