### PR TITLE
feat(communities): retry downloading archive data

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -36,6 +36,8 @@ var defaultAnnounceList = [][]string{
 }
 var pieceLength = 100 * 1024
 
+var ErrTorrentTimedout = errors.New("torrent has timed out")
+
 type Manager struct {
 	persistence                  *Persistence
 	ensSubscription              chan []*ens.VerificationRecord
@@ -1929,7 +1931,7 @@ func (m *Manager) DownloadHistoryArchivesByMagnetlink(communityID types.HexBytes
 	m.LogStdout("fetching torrent info", zap.String("magnetlink", magnetlink))
 	select {
 	case <-timeout:
-		return nil, errors.New("torrent has timed out")
+		return nil, ErrTorrentTimedout
 	case <-torrent.GotInfo():
 		files := torrent.Files()
 


### PR DESCRIPTION
When fetching torrent info after receiving a magnet link, it can happen that the request times out.

We want to retry downloading the data again at least once more before giving up

