### PR TITLE
fix(MessengerResponse): ensure `savedAddresses` response as `omitempty`

### DIFF
--- a/protocol/messenger_response.go
+++ b/protocol/messenger_response.go
@@ -97,7 +97,7 @@ func (r *MessengerResponse) MarshalJSON() ([]byte, error) {
 		DiscordCategories             []*discord.Category                `json:"discordCategories,omitempty"`
 		DiscordChannels               []*discord.Channel                 `json:"discordChannels,omitempty"`
 		DiscordOldestMessageTimestamp int                                `json:"discordOldestMessageTimestamp"`
-		SavedAddresses                []*wallet.SavedAddress             `json:"savedAddresses"`
+		SavedAddresses                []*wallet.SavedAddress             `json:"savedAddresses,omitempty"`
 	}{
 		Contacts:                r.Contacts,
 		Installations:           r.Installations,


### PR DESCRIPTION
Otherwise the json response will be `null` instead of an empty array
(which broke desktop): https://github.com/status-im/status-desktop/pull/7888

