### PR TITLE
feat: add API endpoint to fetch token balance history for graph plotting purpose

### DIFF
--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -64,8 +64,8 @@ func (r *Reader) buildReaderAccount(
 	prices map[string]float64,
 	balances map[common.Address]*hexutil.Big,
 ) (ReaderAccount, error) {
-	limit := (*hexutil.Big)(big.NewInt(20))
-	toBlock := (*hexutil.Big)(big.NewInt(0))
+	limit := int64(20)
+	toBlock := big.NewInt(0)
 
 	collections := make(map[uint64][]OpenseaCollection)
 	tokens := make(map[uint64][]ReaderToken)

--- a/services/wallet/transfer/balance_cache.go
+++ b/services/wallet/transfer/balance_cache.go
@@ -15,6 +15,12 @@ type nonceRange struct {
 	min   *big.Int
 }
 
+// balanceHistoryCache is used temporary until we cache balance history in DB
+type balanceHistoryCache struct {
+	lastBlockNo        *big.Int
+	lastBlockTimestamp int64
+}
+
 type balanceCache struct {
 	// balances maps an address to a map of a block number and the balance of this particular address
 	balances     map[common.Address]map[*big.Int]*big.Int
@@ -22,6 +28,7 @@ type balanceCache struct {
 	nonceRanges  map[common.Address]map[int64]nonceRange
 	sortedRanges map[common.Address][]nonceRange
 	rw           sync.RWMutex
+	history      *balanceHistoryCache
 }
 
 type BalanceCache interface {


### PR DESCRIPTION
Add API endpoint to fetch account balance history

Add functionality to sample and retrieve balance history and cache it in memory for the current transfer controller.

The end of the balance history is snapped at twice per day to avoid having to query the blockchain again for each fetching within 12 hours interval
  
The functionality will be extended with DB caching, API call batching, "smarter" cache hitting and syncing between devices

Updates [#7662](https://github.com/status-im/status-desktop/issues/7662)