### PR TITLE
fix(Communities): correct query params order when updating community

### DIFF
--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -686,8 +686,8 @@ func (p *Persistence) UpdateCommunitySettings(communitySettings CommunitySetting
     WHERE community_id = ?`,
 		communitySettings.HistoryArchiveSupportEnabled,
 		communitySettings.HistoryArchiveSupportEnabled,
-		communitySettings.CommunityID,
 		communitySettings.Clock,
+		communitySettings.CommunityID,
 	)
 	return err
 }


### PR DESCRIPTION
settings

Turns out `UpdateCommunitySettings()` has never worked. Two parameters where in the wrong order, cause the SQL statement to never find the row it has to update.