### PR TITLE
ci: drop unnecessary go get command

### DIFF
--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -54,7 +54,6 @@ pipeline {
 
     stage('Compile') { steps { dir(env.REPO) {
       sh 'make statusgo-ios'
-      sh 'go get golang.org/x/tools/go/packages'
       dir('build/bin') {
         sh 'zip -r status-go-ios.zip Statusgo.framework'
         sh "cp status-go-ios.zip ${env.ARTIFACT}"

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	go.uber.org/zap v1.22.0
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb
-	google.golang.org/protobuf v1.28.0
+	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0


### PR DESCRIPTION
Not sure why that was added at some point, but it doesn't seem necessary, and even if it was `go install` should be used.