### PR TITLE
feat: delete message for new design

### DIFF
--- a/protocol/messenger_delete_message_for_me_test.go
+++ b/protocol/messenger_delete_message_for_me_test.go
@@ -162,6 +162,7 @@ func (s *MessengerDeleteMessageForMeSuite) TestDeleteMessageForMe() {
 	response, err = s.alice1.DeleteMessageForMeAndSync(context.Background(), chatID, messageID)
 	s.Require().NoError(err)
 	s.Require().True(response.Messages()[0].DeletedForMe)
+	s.Require().Nil(response.Chats()[0].LastMessage)
 
 	err = tt.RetryWithBackOff(func() error {
 		var err error

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1270,11 +1270,6 @@ func (m *Messenger) HandleDeleteMessage(state *ReceivedMessageState, deleteMessa
 		return err
 	}
 
-	err = m.persistence.SetHideOnMessage(deleteMessage.MessageId)
-	if err != nil {
-		return err
-	}
-
 	m.logger.Debug("deleting activity center notification for message", zap.String("chatID", chat.ID), zap.String("messageID", deleteMessage.MessageId))
 	err = m.persistence.DeleteActivityCenterNotificationForMessage(chat.ID, deleteMessage.MessageId)
 

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1352,7 +1352,7 @@ func (m *Messenger) HandleDeleteForMeMessage(state *ReceivedMessageState, delete
 
 func (m *Messenger) updateLastMessage(chat *Chat) error {
 	// Get last message that is not hidden
-	messages, _, err := m.persistence.MessageByChatID(chat.ID, "", 1)
+	messages, err := m.persistence.LatestMessageByChatID(chat.ID)
 	if err != nil {
 		return err
 	}
@@ -1503,7 +1503,7 @@ func (m *Messenger) HandleChatMessage(state *ReceivedMessageState) error {
 
 	if (receivedMessage.Deleted || receivedMessage.DeletedForMe) && (chat.LastMessage == nil || chat.LastMessage.ID == receivedMessage.ID) {
 		// Get last message that is not hidden
-		messages, _, err := m.persistence.MessageByChatID(receivedMessage.LocalChatID, "", 1)
+		messages, err := m.persistence.LatestMessageByChatID(receivedMessage.LocalChatID)
 		if err != nil {
 			return err
 		}

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1338,6 +1338,12 @@ func (m *Messenger) HandleDeleteForMeMessage(state *ReceivedMessageState, delete
 		return err
 	}
 
+	if chat.LastMessage != nil && chat.LastMessage.ID == originalMessage.ID {
+		if err := m.updateLastMessage(chat); err != nil {
+			return err
+		}
+	}
+
 	state.Response.AddMessage(originalMessage)
 	state.Response.AddChat(chat)
 
@@ -1495,7 +1501,7 @@ func (m *Messenger) HandleChatMessage(state *ReceivedMessageState) error {
 		return err
 	}
 
-	if receivedMessage.Deleted && (chat.LastMessage == nil || chat.LastMessage.ID == receivedMessage.ID) {
+	if (receivedMessage.Deleted || receivedMessage.DeletedForMe) && (chat.LastMessage == nil || chat.LastMessage.ID == receivedMessage.ID) {
 		// Get last message that is not hidden
 		messages, _, err := m.persistence.MessageByChatID(receivedMessage.LocalChatID, "", 1)
 		if err != nil {

--- a/protocol/messenger_messages.go
+++ b/protocol/messenger_messages.go
@@ -184,6 +184,12 @@ func (m *Messenger) DeleteMessageForMeAndSync(ctx context.Context, chatID string
 		return nil, err
 	}
 
+	if chat.LastMessage != nil && chat.LastMessage.ID == message.ID {
+		if err := m.updateLastMessage(chat); err != nil {
+			return nil, err
+		}
+	}
+
 	response := &MessengerResponse{}
 	response.AddMessage(message)
 	response.AddChat(chat)

--- a/protocol/messenger_messages.go
+++ b/protocol/messenger_messages.go
@@ -143,11 +143,6 @@ func (m *Messenger) DeleteMessageAndSend(ctx context.Context, messageID string) 
 		return nil, err
 	}
 
-	err = m.persistence.HideMessage(messageID)
-	if err != nil {
-		return nil, err
-	}
-
 	if chat.LastMessage != nil && chat.LastMessage.ID == message.ID {
 		if err := m.updateLastMessage(chat); err != nil {
 			return nil, err
@@ -273,7 +268,7 @@ func (m *Messenger) applyDeleteMessage(messageDeletes []*DeleteMessage, message 
 		return err
 	}
 
-	return m.persistence.HideMessage(message.ID)
+	return nil
 }
 
 func (m *Messenger) applyDeleteForMeMessage(messageDeletes []*DeleteForMeMessage, message *common.Message) error {


### PR DESCRIPTION
**BREAKING CHANGE**
`wakuext_chatMessages` will return `deleted` messages since we don't mark them as `hide` anymore



Changes in new design: need to display deleted messages in chat

Important changes:
- not `Hide` messages when they `Deleted`
- won't count deleted/deleted_for_me message as last message

Somewhat related to https://github.com/status-im/status-mobile/issues/14188