### PR TITLE
fix: create acc from mnemonic endpoint extended

### DIFF
--- a/account/generator/account.go
+++ b/account/generator/account.go
@@ -28,12 +28,14 @@ func NewAccount(privateKey *ecdsa.PrivateKey, extKey *extkeys.ExtendedKey) Accou
 }
 
 func (a *Account) ToAccountInfo() AccountInfo {
+	privateKeyHex := types.EncodeHex(crypto.FromECDSA(a.privateKey))
 	publicKeyHex := types.EncodeHex(crypto.FromECDSAPub(&a.privateKey.PublicKey))
 	addressHex := crypto.PubkeyToAddress(a.privateKey.PublicKey).Hex()
 
 	return AccountInfo{
-		PublicKey: publicKeyHex,
-		Address:   addressHex,
+		PrivateKey: privateKeyHex,
+		PublicKey:  publicKeyHex,
+		Address:    addressHex,
 	}
 }
 
@@ -58,8 +60,9 @@ func (a *Account) ToGeneratedAccountInfo(id string, mnemonic string) GeneratedAc
 
 // AccountInfo contains a PublicKey and an Address of an account.
 type AccountInfo struct {
-	PublicKey string `json:"publicKey"`
-	Address   string `json:"address"`
+	PrivateKey string `json:"privateKey"`
+	PublicKey  string `json:"publicKey"`
+	Address    string `json:"address"`
 }
 
 // IdentifiedAccountInfo contains AccountInfo and the ID of an account.

--- a/account/generator/generator_test.go
+++ b/account/generator/generator_test.go
@@ -70,11 +70,11 @@ func TestGenerator_ImportPrivateKey(t *testing.T) {
 	assert.Equal(t, testAccount.bip44Address0, info.Address)
 }
 
-func TestGenerator_CreateAccountFromMnemonic(t *testing.T) {
+func TestGenerator_CreateAccountFromMnemonicAndDeriveAccountsForPaths(t *testing.T) {
 	g := New(nil)
 	assert.Equal(t, 0, len(g.accounts))
 
-	info, err := g.CreateAccountFromMnemonic(testAccount.mnemonic, testAccount.bip39Passphrase)
+	info, err := g.CreateAccountFromMnemonicAndDeriveAccountsForPaths(testAccount.mnemonic, testAccount.bip39Passphrase, []string{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(g.accounts))

--- a/mobile/multiaccount.go
+++ b/mobile/multiaccount.go
@@ -49,8 +49,9 @@ type MultiAccountLoadAccountParams struct {
 
 // MultiAccountImportMnemonicParams are the params sent to MultiAccountImportMnemonic.
 type MultiAccountImportMnemonicParams struct {
-	MnemonicPhrase  string `json:"mnemonicPhrase"`
-	Bip39Passphrase string `json:"Bip39Passphrase"`
+	MnemonicPhrase  string   `json:"mnemonicPhrase"`
+	Bip39Passphrase string   `json:"Bip39Passphrase"`
+	Paths           []string `json:"paths"`
 }
 
 // MultiAccountGenerate generates account in memory without storing them.
@@ -158,8 +159,9 @@ func MultiAccountImportPrivateKey(paramsJSON string) string {
 	return string(out)
 }
 
-// CreateAccountFromMnemonic returns an account derived from the mnemonic phrase and the Bip39Passphrase without storing it.
-func CreateAccountFromMnemonic(paramsJSON string) string {
+// CreateAccountFromMnemonicAndDeriveAccountsForPaths returns an account derived from the mnemonic phrase and the Bip39Passphrase
+// and generate derived accounts for the list of paths without storing it
+func CreateAccountFromMnemonicAndDeriveAccountsForPaths(paramsJSON string) string {
 	var p MultiAccountImportMnemonicParams
 
 	if err := json.Unmarshal([]byte(paramsJSON), &p); err != nil {
@@ -169,7 +171,7 @@ func CreateAccountFromMnemonic(paramsJSON string) string {
 	// remove any duplicate whitespaces
 	mnemonicPhraseNoExtraSpaces := strings.Join(strings.Fields(p.MnemonicPhrase), " ")
 
-	resp, err := statusBackend.AccountManager().AccountsGenerator().CreateAccountFromMnemonic(mnemonicPhraseNoExtraSpaces, p.Bip39Passphrase)
+	resp, err := statusBackend.AccountManager().AccountsGenerator().CreateAccountFromMnemonicAndDeriveAccountsForPaths(mnemonicPhraseNoExtraSpaces, p.Bip39Passphrase, p.Paths)
 	if err != nil {
 		return makeJSONResponse(err)
 	}


### PR DESCRIPTION
`CreateAccountFromMnemonic` function renamed to `createAccountFromMnemonicAndDeriveAccountsForPaths` and extended in a way that it is able to derive accounts from passed mnemonic for the given paths, if paths is empty only an account from the given mnemonic will be generated. This endpoint doesn't store anything anywhere.