### PR TITLE
Pairing Server Payload Locking to prevent multiple requests

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -119,6 +119,8 @@ func (c *PairingClient) sendAccountData() error {
 	}
 
 	signal.SendLocalPairingEvent(Event{Type: EventTransferSuccess})
+
+	c.PayloadManager.LockPayload()
 	return nil
 }
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -424,7 +424,6 @@ func handlePairingReceive(ps *PairingServer) http.HandlerFunc {
 func handlePairingSend(ps *PairingServer) http.HandlerFunc {
 	signal.SendLocalPairingEvent(Event{Type: EventConnectionSuccess})
 
-	// TODO lock sending after one successful transfer, perhaps perform the lock on the PayloadManager level
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, err := w.Write(ps.PayloadManager.ToSend())
@@ -434,6 +433,8 @@ func handlePairingSend(ps *PairingServer) http.HandlerFunc {
 			return
 		}
 		signal.SendLocalPairingEvent(Event{Type: EventTransferSuccess})
+
+		ps.PayloadManager.LockPayload()
 	}
 }
 


### PR DESCRIPTION
## What's Changed?

I've added a lock for the `PairingServer` `EncryptionPayload`.

## Why Change?

This lock prevents the application from sending the pairing payload again, after lock the `PayloadEncryptionManager` only returns a nil value.