### PR TITLE
Added distinct ColourHash type

### DIFF
--- a/multiaccounts/database.go
+++ b/multiaccounts/database.go
@@ -12,12 +12,14 @@ import (
 	"github.com/status-im/status-go/sqlite"
 )
 
+type ColourHash [][2]int
+
 // Account stores public information about account.
 type Account struct {
 	Name           string                 `json:"name"`
 	Timestamp      int64                  `json:"timestamp"`
 	Identicon      string                 `json:"identicon"`
-	ColorHash      [][]int                `json:"colorHash"`
+	ColorHash      ColourHash             `json:"colorHash"`
 	ColorID        int64                  `json:"colorId"`
 	KeycardPairing string                 `json:"keycard-pairing"`
 	KeyUID         string                 `json:"key-uid"`
@@ -54,11 +56,11 @@ func (a *Account) ToProtobuf() *protobuf.MultiAccount {
 }
 
 func (a *Account) FromProtobuf(ma *protobuf.MultiAccount) {
-	var colourHash [][]int
+	var colourHash ColourHash
 	for _, index := range ma.ColorHash {
-		var i []int
-		for _, is := range index.Index {
-			i = append(i, int(is))
+		var i [2]int
+		for n, is := range index.Index {
+			i[n] = int(is)
 		}
 
 		colourHash = append(colourHash, i)

--- a/multiaccounts/database_test.go
+++ b/multiaccounts/database_test.go
@@ -26,7 +26,7 @@ func setupTestDB(t *testing.T) (*Database, func()) {
 func TestAccounts(t *testing.T) {
 	db, stop := setupTestDB(t)
 	defer stop()
-	expected := Account{Name: "string", KeyUID: "string", ColorHash: [][]int{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10, KDFIterations: sqlite.ReducedKDFIterationsNumber}
+	expected := Account{Name: "string", KeyUID: "string", ColorHash: ColourHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10, KDFIterations: sqlite.ReducedKDFIterationsNumber}
 	require.NoError(t, db.SaveAccount(expected))
 	accounts, err := db.GetAccounts()
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestAccounts(t *testing.T) {
 func TestAccountsUpdate(t *testing.T) {
 	db, stop := setupTestDB(t)
 	defer stop()
-	expected := Account{KeyUID: "string", ColorHash: [][]int{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10, KDFIterations: sqlite.ReducedKDFIterationsNumber}
+	expected := Account{KeyUID: "string", ColorHash: ColourHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10, KDFIterations: sqlite.ReducedKDFIterationsNumber}
 	require.NoError(t, db.SaveAccount(expected))
 	expected.Name = "chars"
 	require.NoError(t, db.UpdateAccount(expected))
@@ -182,7 +182,7 @@ func TestDatabase_GetAccount(t *testing.T) {
 	db, stop := setupTestDB(t)
 	defer stop()
 
-	expected := Account{Name: "string", KeyUID: keyUID, ColorHash: [][]int{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10}
+	expected := Account{Name: "string", KeyUID: keyUID, ColorHash: ColourHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10}
 	require.NoError(t, db.SaveAccount(expected))
 
 	account, err := db.GetAccount(expected.KeyUID)
@@ -197,7 +197,7 @@ func TestDatabase_SaveAccountWithIdentityImages(t *testing.T) {
 	expected := Account{
 		Name:      "string",
 		KeyUID:    keyUID,
-		ColorHash: [][]int{{4, 3}, {4, 0}, {4, 3}, {4, 0}},
+		ColorHash: ColourHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}},
 		ColorID:   10,
 		Images:    images.SampleIdentityImages(),
 	}

--- a/protocol/identity/colorhash/colorhash.go
+++ b/protocol/identity/colorhash/colorhash.go
@@ -3,6 +3,7 @@ package colorhash
 import (
 	"math/big"
 
+	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/protocol/identity"
 )
 
@@ -13,7 +14,7 @@ const (
 
 var colorHashAlphabet [][]int
 
-func GenerateFor(pubkey string) (hash [][]int, err error) {
+func GenerateFor(pubkey string) (hash multiaccounts.ColourHash, err error) {
 	if len(colorHashAlphabet) == 0 {
 		colorHashAlphabet = makeColorHashAlphabet(colorHashSegmentMaxLen, colorHashColorsCount)
 	}
@@ -47,12 +48,12 @@ func makeColorHashAlphabet(units, colors int) (res [][]int) {
 	return
 }
 
-func toColorHash(value *big.Int, alphabet *[][]int, colorsCount int) (hash [][]int) {
+func toColorHash(value *big.Int, alphabet *[][]int, colorsCount int) (hash multiaccounts.ColourHash) {
 	alphabetLen := len(*alphabet)
 	indexes := identity.ToBigBase(value, uint64(alphabetLen))
-	hash = make([][](int), len(indexes))
+	hash = make(multiaccounts.ColourHash, len(indexes))
 	for i, v := range indexes {
-		hash[i] = make([](int), 2)
+		hash[i] = [2]int{}
 		hash[i][0] = (*alphabet)[v][0]
 		hash[i][1] = (*alphabet)[v][1]
 	}

--- a/protocol/identity/colorhash/colorhash_test.go
+++ b/protocol/identity/colorhash/colorhash_test.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/protocol/identity"
 )
 
 func TestGenerateFor(t *testing.T) {
-	checker := func(pubkey string, expected *[][](int)) {
+	checker := func(pubkey string, expected *multiaccounts.ColourHash) {
 		colorhash, err := GenerateFor(pubkey)
 		require.NoError(t, err)
 		if !reflect.DeepEqual(colorhash, *expected) {
@@ -19,7 +20,7 @@ func TestGenerateFor(t *testing.T) {
 	}
 
 	checker("0x04e25da6994ea2dc4ac70727e07eca153ae92bf7609db7befb7ebdceaad348f4fc55bbe90abf9501176301db5aa103fc0eb3bc3750272a26c424a10887db2a7ea8",
-		&[][]int{{3, 30}, {2, 10}, {5, 5}, {3, 14}, {5, 4}, {4, 19}, {3, 16}, {4, 0}, {5, 28}, {4, 13}, {4, 15}})
+		&multiaccounts.ColourHash{{3, 30}, {2, 10}, {5, 5}, {3, 14}, {5, 4}, {4, 19}, {3, 16}, {4, 0}, {5, 28}, {4, 13}, {4, 15}})
 }
 
 func TestColorHashOfInvalidKey(t *testing.T) {
@@ -36,7 +37,7 @@ func TestColorHashOfInvalidKey(t *testing.T) {
 func TestColorHash(t *testing.T) {
 	alphabet := makeColorHashAlphabet(4, 4)
 
-	checker := func(valueStr string, expected *[][](int)) {
+	checker := func(valueStr string, expected *multiaccounts.ColourHash) {
 		value := identity.ToBigInt(t, valueStr)
 		res := toColorHash(value, &alphabet, 4)
 		if !reflect.DeepEqual(res, *expected) {
@@ -44,14 +45,14 @@ func TestColorHash(t *testing.T) {
 		}
 	}
 
-	checker("0x0", &[][]int{{1, 0}})
-	checker("0x1", &[][]int{{1, 1}})
-	checker("0x4", &[][]int{{2, 0}})
-	checker("0xF", &[][]int{{4, 3}})
+	checker("0x0", &multiaccounts.ColourHash{{1, 0}})
+	checker("0x1", &multiaccounts.ColourHash{{1, 1}})
+	checker("0x4", &multiaccounts.ColourHash{{2, 0}})
+	checker("0xF", &multiaccounts.ColourHash{{4, 3}})
 
 	// oops, collision
-	checker("0xFF", &[][]int{{4, 3}, {4, 0}})
-	checker("0xFC", &[][]int{{4, 3}, {4, 0}})
+	checker("0xFF", &multiaccounts.ColourHash{{4, 3}, {4, 0}})
+	checker("0xFC", &multiaccounts.ColourHash{{4, 3}, {4, 0}})
 
-	checker("0xFFFF", &[][]int{{4, 3}, {4, 0}, {4, 3}, {4, 0}})
+	checker("0xFFFF", &multiaccounts.ColourHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}})
 }

--- a/protocol/identity/ring/ring.go
+++ b/protocol/identity/ring/ring.go
@@ -8,6 +8,8 @@ import (
 	"math"
 
 	"github.com/fogleman/gg"
+
+	"github.com/status-im/status-go/multiaccounts"
 )
 
 type Theme int
@@ -23,11 +25,11 @@ var (
 )
 
 type DrawRingParam struct {
-	Theme      Theme   `json:"theme"`
-	ColorHash  [][]int `json:"colorHash"`
-	ImageBytes []byte  `json:"imageBytes"`
-	Height     int     `json:"height"`
-	Width      int     `json:"width"`
+	Theme      Theme                    `json:"theme"`
+	ColorHash  multiaccounts.ColourHash `json:"colorHash"`
+	ImageBytes []byte                   `json:"imageBytes"`
+	Height     int                      `json:"height"`
+	Width      int                      `json:"width"`
 }
 
 func DrawRing(param *DrawRingParam) ([]byte, error) {

--- a/server/payload_manager_test.go
+++ b/server/payload_manager_test.go
@@ -25,7 +25,7 @@ var (
 	expected = multiaccounts.Account{
 		Name:          "cool account",
 		KeyUID:        keyUID,
-		ColorHash:     [][]int{{4, 3}, {4, 0}, {4, 3}, {4, 0}},
+		ColorHash:     multiaccounts.ColourHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}},
 		ColorID:       10,
 		Images:        images.SampleIdentityImages(),
 		KDFIterations: sqlite.ReducedKDFIterationsNumber,


### PR DESCRIPTION
## What's Changed?

I've replaced references to `[][]int` that are used directly as a `ColourHash`, to use an explicit `[][2]int`

## Why Change?

This change codifies that a `ColourHash` is a slice of `[2]int`, as consuming code depends on the inner slice having exactly 2 indexes.