### PR TITLE
fix(discord): always emit import error if it's of type error

### DIFF
--- a/protocol/discord/types.go
+++ b/protocol/discord/types.go
@@ -189,7 +189,7 @@ func (progress *ImportProgress) AddTaskError(task ImportTask, err *ImportError) 
 	for i, t := range progress.Tasks {
 		if t.Type == task.String() {
 			errorsAndWarningsCount := progress.Tasks[i].ErrorsCount + progress.Tasks[i].WarningsCount
-			if errorsAndWarningsCount < MaxTaskErrorItemsCount {
+			if (errorsAndWarningsCount < MaxTaskErrorItemsCount) || err.Code > WarningType {
 				errors := progress.Tasks[i].Errors
 				progress.Tasks[i].Errors = append(errors, err)
 			}


### PR DESCRIPTION
We've been limiting the amount of errors being emitted to clients to reduce payload pressure and also due to the fact that we won't be rendering more than 3 error items in the UI.

We want to let actual errors through (as opposed to warnings), even if the limit was reached.

