### PR TITLE
fix(communities): improve error message about duplicated chat names

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
+	_errors "errors"
 	"fmt"
 	"os"
 	"strings"
@@ -2300,7 +2301,11 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 			communityWithChats, changes, err := m.communitiesManager.CreateChat(discordCommunity.ID(), communityChat, false)
 			if err != nil {
 				m.cleanUpImport(communityID)
-				importProgress.AddTaskError(discord.ChannelsCreationTask, discord.Error(err.Error()))
+				errmsg := err.Error()
+				if _errors.Is(err, communities.ErrInvalidCommunityDescriptionDuplicatedName) {
+					errmsg = fmt.Sprintf("Couldn't create channel '%s': %s", communityChat.Identity.DisplayName, err.Error())
+				}
+				importProgress.AddTaskError(discord.ChannelsCreationTask, discord.Error(errmsg))
 				importProgress.StopTask(discord.ChannelsCreationTask)
 				progressUpdates <- importProgress
 				return


### PR DESCRIPTION
We don't allow multiple channels with the same name in communities. Discord allows for multiple channels with the same name (living in different categories), so this is an error case in our import tool.

This commit improves the user facing error message of this scenario.

