### PR TITLE
feat(communities): add community images to import progress signal

### DIFF
--- a/protocol/discord/types.go
+++ b/protocol/discord/types.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -149,14 +150,15 @@ type ImportTaskProgress struct {
 type ImportTasks map[ImportTask]*ImportTaskProgress
 
 type ImportProgress struct {
-	CommunityID   string                `json:"communityId,omitempty"`
-	CommunityName string                `json:"communityName"`
-	Tasks         []*ImportTaskProgress `json:"tasks"`
-	Progress      float32               `json:"progress"`
-	ErrorsCount   uint                  `json:"errorsCount"`
-	WarningsCount uint                  `json:"warningsCount"`
-	Stopped       bool                  `json:"stopped"`
-	m             sync.Mutex
+	CommunityID     string                          `json:"communityId,omitempty"`
+	CommunityName   string                          `json:"communityName"`
+	CommunityImages map[string]images.IdentityImage `json:"communityImages"`
+	Tasks           []*ImportTaskProgress           `json:"tasks"`
+	Progress        float32                         `json:"progress"`
+	ErrorsCount     uint                            `json:"errorsCount"`
+	WarningsCount   uint                            `json:"warningsCount"`
+	Stopped         bool                            `json:"stopped"`
+	m               sync.Mutex
 }
 
 func (progress *ImportProgress) Init(tasks []ImportTask) {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
@@ -2221,6 +2222,13 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 		// marking import as not cancelled
 		m.importingCommunities[communityID] = false
 		importProgress.CommunityID = communityID
+		importProgress.CommunityImages = make(map[string]images.IdentityImage)
+
+		imgs := discordCommunity.Images()
+		for t, i := range imgs {
+			importProgress.CommunityImages[t] = images.IdentityImage{Name: t, Payload: i.Payload}
+		}
+
 		importProgress.UpdateTaskProgress(discord.CommunityCreationTask, 0.75)
 		progressUpdates <- importProgress
 


### PR DESCRIPTION
This is needed so clients can render the selected community image while the import is running.

