### PR TITLE
fix(edit-message): Add check ContentType for request and original message

### DIFF
--- a/protocol/messenger_edit_message_test.go
+++ b/protocol/messenger_edit_message_test.go
@@ -94,8 +94,9 @@ func (s *MessengerEditMessageSuite) TestEditMessage() {
 
 	editedText := "edited text"
 	editedMessage := &requests.EditMessage{
-		ID:   messageID,
-		Text: editedText,
+		ID:          messageID,
+		Text:        editedText,
+		ContentType: protobuf.ChatMessage_TEXT_PLAIN,
 	}
 
 	sendResponse, err = theirMessenger.EditMessage(context.Background(), editedMessage)
@@ -122,8 +123,9 @@ func (s *MessengerEditMessageSuite) TestEditMessage() {
 
 	// Main instance user attempts to edit the message it received from theirMessenger
 	editedMessage = &requests.EditMessage{
-		ID:   messageID,
-		Text: "edited-again text",
+		ID:          messageID,
+		Text:        "edited-again text",
+		ContentType: protobuf.ChatMessage_TEXT_PLAIN,
 	}
 	_, err = s.m.EditMessage(context.Background(), editedMessage)
 
@@ -166,8 +168,9 @@ func (s *MessengerEditMessageSuite) TestEditMessageActivityCenter() {
 
 	editedText := "edited text"
 	editedMessage := &requests.EditMessage{
-		ID:   messageID,
-		Text: editedText,
+		ID:          messageID,
+		Text:        editedText,
+		ContentType: protobuf.ChatMessage_TEXT_PLAIN,
 	}
 
 	sendResponse, err = theirMessenger.EditMessage(context.Background(), editedMessage)
@@ -199,8 +202,9 @@ func (s *MessengerEditMessageSuite) TestEditMessageActivityCenter() {
 
 	// Main instance user attempts to edit the message it received from theirMessenger
 	editedMessage = &requests.EditMessage{
-		ID:   messageID,
-		Text: "edited-again text",
+		ID:          messageID,
+		Text:        "edited-again text",
+		ContentType: protobuf.ChatMessage_TEXT_PLAIN,
 	}
 	_, err = s.m.EditMessage(context.Background(), editedMessage)
 
@@ -244,10 +248,11 @@ func (s *MessengerEditMessageSuite) TestEditMessageEdgeCases() {
 
 	editMessage := EditMessage{
 		EditMessage: protobuf.EditMessage{
-			Clock:     editedMessage.Clock + 1,
-			Text:      "some text",
-			MessageId: editedMessage.ID,
-			ChatId:    chat.ID,
+			Clock:       editedMessage.Clock + 1,
+			Text:        "some text",
+			MessageId:   editedMessage.ID,
+			ContentType: protobuf.ChatMessage_TEXT_PLAIN,
+			ChatId:      chat.ID,
 		},
 		From: wrongContact.ID,
 	}
@@ -293,6 +298,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageEdgeCases() {
 			Text:        "some other text",
 			MessageType: protobuf.MessageType_ONE_TO_ONE,
 			MessageId:   editedMessage.ID,
+			ContentType: protobuf.ChatMessage_TEXT_PLAIN,
 			ChatId:      chat.ID,
 		},
 		From: contact.ID,
@@ -332,6 +338,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageFirstEditsThenMessage() {
 			Text:        "some text",
 			MessageType: protobuf.MessageType_ONE_TO_ONE,
 			MessageId:   messageID,
+			ContentType: protobuf.ChatMessage_TEXT_PLAIN,
 			ChatId:      theirChat.ID,
 		},
 		From: common.PubkeyToHex(&theirMessenger.identity.PublicKey),
@@ -429,8 +436,9 @@ func (s *MessengerEditMessageSuite) TestEditGroupChatMessage() {
 
 	editedText := "edited text"
 	editedMessage := &requests.EditMessage{
-		ID:   messageID,
-		Text: editedText,
+		ID:          messageID,
+		Text:        editedText,
+		ContentType: protobuf.ChatMessage_TEXT_PLAIN,
 	}
 
 	_, err = theirMessenger.EditMessage(context.Background(), editedMessage)

--- a/protocol/messenger_messages.go
+++ b/protocol/messenger_messages.go
@@ -14,6 +14,7 @@ import (
 var ErrInvalidEditOrDeleteAuthor = errors.New("sender is not the author of the message")
 var ErrInvalidDeleteTypeAuthor = errors.New("message type cannot be deleted")
 var ErrInvalidEditContentType = errors.New("only text or emoji messages can be replaced")
+var ErrInvalidEditRequestContentType = errors.New("message type can't be changed")
 
 func (m *Messenger) EditMessage(ctx context.Context, request *requests.EditMessage) (*MessengerResponse, error) {
 	err := request.Validate()
@@ -27,6 +28,10 @@ func (m *Messenger) EditMessage(ctx context.Context, request *requests.EditMessa
 
 	if message.From != common.PubkeyToHex(&m.identity.PublicKey) {
 		return nil, ErrInvalidEditOrDeleteAuthor
+	}
+
+	if message.ContentType != request.ContentType {
+		return nil, ErrInvalidEditRequestContentType
 	}
 
 	if message.ContentType != protobuf.ChatMessage_TEXT_PLAIN && message.ContentType != protobuf.ChatMessage_EMOJI {


### PR DESCRIPTION
When user edit message, status-go can replace content type of message to another. That issue was in desktop app which never send content type of edited message and content type of original message was changed to `unknown`

Add check of types in request and original message.

Important changes:
- [x] Something worth noting for reviewers.

