### PR TITLE
fix: corresponding keystore files are deleted when account is migrated to a keycard

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -598,12 +598,30 @@ func (b *GethStatusBackend) ConvertToKeycardAccount(keyStoreDir string, account 
 		return err
 	}
 
+	knownAccounts, err := accountDB.GetAccounts()
+	if err != nil {
+		return err
+	}
+
 	err = b.closeAppDB()
 	if err != nil {
 		return err
 	}
 
-	return b.ChangeDatabasePassword(account.KeyUID, password, newPassword)
+	err = b.ChangeDatabasePassword(account.KeyUID, password, newPassword)
+	if err != nil {
+		return err
+	}
+
+	for _, acc := range knownAccounts {
+		if account.KeyUID == acc.KeyUID {
+			// This action deletes an account from the keystore, no need to check for error in this context here, cause if this
+			// action fails from whichever reason the account is still successfully migrated since keystore won't be used any more.
+			_ = b.accountManager.DeleteAccount(keyStoreDir, acc.Address)
+		}
+	}
+
+	return nil
 }
 
 func (b *GethStatusBackend) VerifyDatabasePassword(keyUID string, password string) error {

--- a/multiaccounts/accounts/database.go
+++ b/multiaccounts/accounts/database.go
@@ -251,11 +251,6 @@ func (db *Database) DeleteAccount(address types.Address) error {
 	return err
 }
 
-func (db *Database) DeleteSeedAndKeyAccounts() error {
-	_, err := db.db.Exec("DELETE FROM accounts WHERE type = ? OR type = ?", AccountTypeSeed, AccountTypeKey)
-	return err
-}
-
 func (db *Database) GetWalletAddress() (rst types.Address, err error) {
 	err = db.db.QueryRow("SELECT address FROM accounts WHERE wallet = 1").Scan(&rst)
 	return


### PR DESCRIPTION
When we're migrating profile or any other keypair to a Keycard we should remove corresponding locally stored keystore files, what changes applied into this PR do.