### PR TITLE
chore: fix vscode test run

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-  "go.formatFlags": [ "-local", "github.com/ethereum/go-ethereum,github.com/status-im/status-go", "-w"],
+  "go.formatFlags": [
+    "-local",
+    "github.com/ethereum/go-ethereum,github.com/status-im/status-go",
+    "-w"
+  ],
+  "go.testTags": "gowaku_skip_migrations",
 }


### PR DESCRIPTION
To run tests locally `-tags "gowaku_skip_migrations"` is needed, otherwise, there is a circular dependency resulting in multiple definitions error.