### PR TITLE
fix: keep original case for collectible trait types

### DIFF
--- a/services/wallet/opensea.go
+++ b/services/wallet/opensea.go
@@ -169,7 +169,7 @@ func (o *OpenseaClient) fetchAllAssetsByOwnerAndCollection(owner common.Address,
 
 		for _, asset := range container.Assets {
 			for i := range asset.Traits {
-				asset.Traits[i].TraitType = strings.Replace(strings.ToUpper(asset.Traits[i].TraitType), "_", " ", 1)
+				asset.Traits[i].TraitType = strings.Replace(asset.Traits[i].TraitType, "_", " ", 1)
 				asset.Traits[i].Value = TraitValue(strings.Title(string(asset.Traits[i].Value)))
 			}
 			assets = append(assets, asset)


### PR DESCRIPTION
Currently, when fetching assets for a specific owner+collection the trait types are converted to all uppercase, which doesn't match the design requirements (https://www.figma.com/file/FkFClTCYKf83RJWoifWgoX/Wallet-v2?node-id=6455%3A126329&t=DzOhPxmqYwusTvqw-0) . This PR keeps the original case, for it to be converted as needed closer to the frontend.

