### PR TITLE
feat(waku2): peer exchange

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -189,7 +189,7 @@ type WakuV2Config struct {
 	// A name->libp2p_addr map for Wakuv2 custom nodes
 	CustomNodes map[string]string
 
-	// PeerExchange determines whether GossipSub Peer Exchange is enabled or not
+	// PeerExchange determines whether WakuV2 Peer Exchange is enabled or not
 	PeerExchange bool
 
 	// EnableDiscV5 indicates if DiscoveryV5 is enabled or not


### PR DESCRIPTION
This adds the [34/WAKU2-PEER-EXCHANGE](https://rfc.vac.dev/spec/34/) feature to status-go.

The way it works right now is by choosing a random node as peer exchange node as long as it has these characteristics:
- It was obtained via DNS Discovery
- It supports peer exchange protocol

The reason why I only chose from DNS Discovery nodes is to use a 'curated' set of nodes to ask peers from, instead of choosing any random peer status-go might have connected to that has peer exchange support.

Then, it will take the number of connected Relay nodes, and compare it against the max number of peers that can be discovered, to get the number of peers to request from this PX node. Currently I don't know if peer exchange should be used for light clients as well (we need to define also which criteria is going to be used to select filter and lightpush nodes)



