### PR TITLE
feat: add signal indicating that history messages are being imported

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -137,6 +137,7 @@ type Subscription struct {
 	HistoryArchiveDownloadedSignal           *signal.HistoryArchiveDownloadedSignal
 	DownloadingHistoryArchivesStartedSignal  *signal.DownloadingHistoryArchivesStartedSignal
 	DownloadingHistoryArchivesFinishedSignal *signal.DownloadingHistoryArchivesFinishedSignal
+	ImportingHistoryArchiveMessagesSignal    *signal.ImportingHistoryArchiveMessagesSignal
 }
 
 type CommunityResponse struct {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -146,6 +146,10 @@ func (m *Messenger) handleCommunitiesHistoryArchivesSubscription(c chan *communi
 				if sub.DownloadingHistoryArchivesStartedSignal != nil {
 					m.config.messengerSignalsHandler.DownloadingHistoryArchivesStarted(sub.DownloadingHistoryArchivesStartedSignal.CommunityID)
 				}
+
+				if sub.ImportingHistoryArchiveMessagesSignal != nil {
+					m.config.messengerSignalsHandler.ImportingHistoryArchiveMessages(sub.ImportingHistoryArchiveMessagesSignal.CommunityID)
+				}
 			case <-m.quit:
 				return
 			}

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -46,6 +46,7 @@ type MessengerSignalsHandler interface {
 	HistoryArchiveDownloaded(communityID string, from int, to int)
 	DownloadingHistoryArchivesStarted(communityID string)
 	DownloadingHistoryArchivesFinished(communityID string)
+	ImportingHistoryArchiveMessages(communityID string)
 	StatusUpdatesTimedOut(statusUpdates *[]UserStatus)
 	DiscordCategoriesAndChannelsExtracted(categories []*discord.Category, channels []*discord.Channel, oldestMessageTimestamp int64, errors map[string]*discord.ImportError)
 	DiscordCommunityImportProgress(importProgress *discord.ImportProgress)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -963,6 +963,8 @@ func (m *Messenger) HandleHistoryArchiveMagnetlinkMessage(state *ReceivedMessage
 					}
 				}
 
+				m.config.messengerSignalsHandler.ImportingHistoryArchiveMessages(types.EncodeHex(id))
+
 				err = m.handleImportedMessages(importedMessages)
 				if err != nil {
 					log.Println("failed to handle imported messages", err)

--- a/services/ext/signal.go
+++ b/services/ext/signal.go
@@ -116,6 +116,10 @@ func (m *MessengerSignalsHandler) DownloadingHistoryArchivesStarted(communityID 
 	signal.SendDownloadingHistoryArchivesStarted(communityID)
 }
 
+func (m *MessengerSignalsHandler) ImportingHistoryArchiveMessages(communityID string) {
+	signal.SendImportingHistoryArchiveMessages(communityID)
+}
+
 func (m *MessengerSignalsHandler) DownloadingHistoryArchivesFinished(communityID string) {
 	signal.SendDownloadingHistoryArchivesFinished(communityID)
 }

--- a/signal/events_community_archives.go
+++ b/signal/events_community_archives.go
@@ -30,6 +30,9 @@ const (
 	// EventHistoryArchiveDownloaded is triggered when the community member node
 	// has downloaded an individual community archive
 	EventHistoryArchiveDownloaded = "community.historyArchiveDownloaded"
+	// EventImportingHistoryArchiveMessages is triggered when the community member node
+	// has starts importing downloaded archive messages into the database
+	EventImportingHistoryArchiveMessages = "community.importingHistoryArchiveMessages"
 	// EventDownloadingHistoryArchivesFinished is triggered when the community member node
 	// has downloaded all archives
 	EventDownloadingHistoryArchivesFinished = "community.downloadingHistoryArchivesFinished"
@@ -66,6 +69,10 @@ type HistoryArchiveDownloadedSignal struct {
 }
 
 type DownloadingHistoryArchivesStartedSignal struct {
+	CommunityID string `json:"communityId"`
+}
+
+type ImportingHistoryArchiveMessagesSignal struct {
 	CommunityID string `json:"communityId"`
 }
 
@@ -119,6 +126,12 @@ func SendHistoryArchiveDownloaded(communityID string, from int, to int) {
 
 func SendDownloadingHistoryArchivesStarted(communityID string) {
 	send(EventDownloadingHistoryArchivesStarted, DownloadingHistoryArchivesStartedSignal{
+		CommunityID: communityID,
+	})
+}
+
+func SendImportingHistoryArchiveMessages(communityID string) {
+	send(EventImportingHistoryArchiveMessages, ImportingHistoryArchiveMessagesSignal{
 		CommunityID: communityID,
 	})
 }


### PR DESCRIPTION
In order to give clients more insights about archive messages being processed, we're adding this additional signal that informs clients when the import of downloaded history archive messages has started.

