### PR TITLE
fix: don't keep Messenger from starting when torrent client fails to

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -158,7 +158,7 @@ func (m *Manager) Start() error {
 
 	if m.torrentConfig != nil && m.torrentConfig.Enabled {
 		err := m.StartTorrentClient()
-		return err
+		m.logger.Warn("couldn't start torrent client", zap.Error(err))
 	}
 
 	return nil

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -705,7 +705,7 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 		return nil, err
 	}
 
-	if m.config.torrentConfig != nil && m.config.torrentConfig.Enabled {
+	if m.config.torrentConfig != nil && m.config.torrentConfig.Enabled && m.communitiesManager.TorrentClientStarted() {
 		adminCommunities, err := m.communitiesManager.Created()
 		if err == nil && len(adminCommunities) > 0 {
 			available := m.SubscribeMailserverAvailable()

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1076,7 +1076,7 @@ func (m *Messenger) EditCommunity(request *requests.EditCommunity) (*MessengerRe
 
 	id := community.ID()
 
-	if m.config.torrentConfig != nil && m.config.torrentConfig.Enabled {
+	if m.config.torrentConfig != nil && m.config.torrentConfig.Enabled && m.communitiesManager.TorrentClientStarted() {
 		if !communitySettings.HistoryArchiveSupportEnabled {
 			m.communitiesManager.StopHistoryArchiveTasksInterval(id)
 		} else if !m.communitiesManager.IsSeedingHistoryArchiveTorrent(id) {
@@ -1135,7 +1135,7 @@ func (m *Messenger) ImportCommunity(ctx context.Context, key *ecdsa.PrivateKey) 
 		return nil, err
 	}
 
-	if m.config.torrentConfig != nil && m.config.torrentConfig.Enabled {
+	if m.config.torrentConfig != nil && m.config.torrentConfig.Enabled && m.communitiesManager.TorrentClientStarted() {
 		var communities []*communities.Community
 		communities = append(communities, community)
 		go m.InitHistoryArchiveTasks(communities)
@@ -2976,7 +2976,10 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 			}
 		}
 
-		if m.config.torrentConfig != nil && m.config.torrentConfig.Enabled && communitySettings.HistoryArchiveSupportEnabled {
+		if m.config.torrentConfig != nil &&
+			m.config.torrentConfig.Enabled &&
+			communitySettings.HistoryArchiveSupportEnabled &&
+			m.communitiesManager.TorrentClientStarted() {
 
 			err = m.communitiesManager.SeedHistoryArchiveTorrent(discordCommunity.ID())
 			if err != nil {


### PR DESCRIPTION
start

There are various cases that could make the torrent client fail to start. We don't want this to keep the entire messenger from starting.

