### PR TITLE
fix: do not filter out deleted messages in MessageByChatID

### DIFF
--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -592,7 +592,7 @@ func (db sqlitePersistence) MessageByChatID(chatID string, currCursor string, li
 	// This new column values can also be returned as a cursor for subsequent requests.
 	where := fmt.Sprintf(`
             WHERE
-                NOT(m1.hide) AND m1.local_chat_id = ? %s AND NOT(m1.deleted)
+                NOT(m1.hide) AND m1.local_chat_id = ? %s
             ORDER BY cursor DESC
             LIMIT ?`, cursorWhere)
 


### PR DESCRIPTION
New design require showing deleted messages rather than hide them.  PR https://github.com/status-im/status-go/pull/2922 stop set deleted message hide.

Important changes:
- [x] do not filter out deleted messages in `MessageByChatID`

related 
- https://github.com/status-im/status-mobile/pull/14232
