### PR TITLE
fix: ensure queries coalesce `album_id` value when scanning

### DIFF
--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -115,7 +115,7 @@ func (db sqlitePersistence) tableUserMessagesAllFieldsJoin() string {
 		m1.sticker_hash,
 		m1.image_payload,
 		m1.image_type,
-		m1.album_id,
+		COALESCE(m1.album_id, ""),
 		COALESCE(m1.audio_duration_ms,0),
 		m1.community_id,
 		m1.mentions,


### PR DESCRIPTION
Otherwise databases with existing messages that don't have an `album_id` will run into and `converting NULL to string is unsupported` error.

See: https://github.com/status-im/status-go/pull/3021#issuecomment-1351623814

