### PR TITLE
fix: fix special messages not being received because not encrypted

### DIFF
--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -232,6 +232,14 @@ func (s *MessageSender) getMessageID(rawMessage *RawMessage) (types.HexBytes, er
 	return messageID, nil
 }
 
+func ShouldCommunityMessageBeEncrypted(msgType protobuf.ApplicationMetadataMessage_Type) bool {
+	return msgType == protobuf.ApplicationMetadataMessage_CHAT_MESSAGE ||
+		msgType == protobuf.ApplicationMetadataMessage_EDIT_MESSAGE ||
+		msgType == protobuf.ApplicationMetadataMessage_DELETE_MESSAGE ||
+		msgType == protobuf.ApplicationMetadataMessage_PIN_MESSAGE ||
+		msgType == protobuf.ApplicationMetadataMessage_EMOJI_REACTION
+}
+
 // sendCommunity sends a message that's to be sent in a community
 // If it's a chat message, it will go to the respective topic derived by the
 // chat id, if it's not a chat message, it will go to the community topic.
@@ -284,7 +292,7 @@ func (s *MessageSender) sendCommunity(
 	}
 
 	// If it's a chat message, we send it on the community chat topic
-	if rawMessage.MessageType == protobuf.ApplicationMetadataMessage_CHAT_MESSAGE {
+	if ShouldCommunityMessageBeEncrypted(rawMessage.MessageType) {
 		messageSpec, err := s.protocol.BuildHashRatchetMessage(rawMessage.CommunityID, wrappedMessage)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes this desktop issue https://github.com/status-im/status-desktop/issues/8689

The special messages like: delete, edit, pin and reaction were **all** not being received, because they were not encrypted, so they were not using the right topic.
Debugging this was a pain in the ass, but @richard-ramos and I finally figured it out.

Let me know if more message types need to be encrypted.

Also, is there any change that the pending community requests might be caused by something similar, let me know, I'll check it out.