### PR TITLE
Recognize `@everyone` as mention in messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/russolsen/transit v0.0.0-20180705123435-0794b4c4505a
 	github.com/status-im/doubleratchet v3.0.0+incompatible
-	github.com/status-im/markdown v0.0.0-20220622180305-7ee4aa8bbc3f
+	github.com/status-im/markdown v0.0.0-20221220095528-8f1babe09d1e
 	github.com/status-im/migrate/v4 v4.6.2-status.2
 	github.com/status-im/rendezvous v1.3.6
 	github.com/status-im/status-go/extkeys v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1965,8 +1965,8 @@ github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4/go.mod h1:hmpnZ
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969 h1:Oo2KZNP70KE0+IUJSidPj/BFS/RXNHmKIJOdckzml2E=
 github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
-github.com/status-im/markdown v0.0.0-20220622180305-7ee4aa8bbc3f h1:uLIn523HVfEAMSL/Y2HXixdg8KjYthDQDjrauwMESEc=
-github.com/status-im/markdown v0.0.0-20220622180305-7ee4aa8bbc3f/go.mod h1:5rjPyv3KffPNVbFjnsVy0NGj9+JeW40WvXLdxH1VKuE=
+github.com/status-im/markdown v0.0.0-20221220095528-8f1babe09d1e h1:XYd/yywsmvYsRh6p8I+sRmpq9/MJAiFXsPwUe0ZPxGA=
+github.com/status-im/markdown v0.0.0-20221220095528-8f1babe09d1e/go.mod h1:5rjPyv3KffPNVbFjnsVy0NGj9+JeW40WvXLdxH1VKuE=
 github.com/status-im/migrate/v4 v4.6.2-status.2 h1:SdC+sMDl/aI7vUlwD2qj2p7KsK4T60IS9z4/rYCCbI8=
 github.com/status-im/migrate/v4 v4.6.2-status.2/go.mod h1:c/kc90n47GZu/58nnz1OMLTf7uE4Da4gZP5qmU+A/v8=
 github.com/status-im/noise v1.0.1-handshakeMessages h1:mj1btE58Qk2pS0qz+BHE22HYIOhZoEFNTnRpQeMfHYk=

--- a/protocol/common/message.go
+++ b/protocol/common/message.go
@@ -70,6 +70,8 @@ const (
 	ContactVerificationStateCanceled
 )
 
+const everyoneMentionTag = "0x00001"
+
 type CommandParameters struct {
 	// ID is the ID of the initial message
 	ID string `json:"id"`
@@ -470,7 +472,7 @@ func (v *MentionsAndLinksVisitor) Visit(node ast.Node, entering bool) ast.WalkSt
 	switch n := node.(type) {
 	case *ast.Mention:
 		mention := string(n.Literal)
-		if mention == v.identity {
+		if mention == v.identity || mention == everyoneMentionTag {
 			v.mentioned = true
 		}
 		v.mentions = append(v.mentions, mention)

--- a/vendor/github.com/status-im/markdown/parser/parser.go
+++ b/vendor/github.com/status-im/markdown/parser/parser.go
@@ -712,6 +712,11 @@ func isValidCompressedPublicKeyChar(c byte) bool {
 		c == 'R' || c == 'S' || c == 'T' || c == 'U' || c == 'V' || c == 'W' || c == 'X' || c == 'Y' || c == 'Z'
 }
 
+func isValidSystemTagChar(c byte) bool {
+  return c == '0' || c == '1' || c == '2' || c == '3' || c == '4' || c == '5' || c == '6' || c == '7' || c == '8' || c == '9'
+}
+
+
 // TODO: this is not used
 // Replace tab characters with spaces, aligning to the next TAB_SIZE column.
 // always ends output with a newline

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -903,7 +903,7 @@ github.com/status-im/go-multiaddr-ethv4
 # github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969
 ## explicit
 github.com/status-im/keycard-go/derivationpath
-# github.com/status-im/markdown v0.0.0-20220622180305-7ee4aa8bbc3f
+# github.com/status-im/markdown v0.0.0-20221220095528-8f1babe09d1e
 ## explicit; go 1.12
 github.com/status-im/markdown
 github.com/status-im/markdown/ast


### PR DESCRIPTION
This "id" or "tag" will be interpeted/interpolated as `@everyone` by
clients.

For this change to work

https://github.com/status-im/markdown/pull/5

is needed.