### PR TITLE
Convert Keys from Desktop to Mobile format

### DIFF
--- a/mobile/response_test.go
+++ b/mobile/response_test.go
@@ -25,3 +25,10 @@ func TestPrepareJSONResponseErrorWithError(t *testing.T) {
 	data := prepareJSONResponse("0x123", errors.New("some error"))
 	require.Contains(t, data, `{"error":{"message":"some error"}}`)
 }
+
+func TestDeserializeAndCompressKeyApi(t *testing.T) {
+	desktopKey := "zQ3shTAten2v9CwyQD1Kc7VXAqNPDcHZAMsfbLHCZEx6nFqk9"
+	mobileKeyExpected := "0x025596a7ff87da36860a84b0908191ce60a504afc94aac93c1abd774f182967ce6"
+	mobileKeyConverted := DeserializeAndCompressKey(desktopKey)
+	require.Equal(t, mobileKeyConverted, mobileKeyExpected)
+}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1088,3 +1088,9 @@ func ToChecksumAddress(address string) string {
 	}
 	return address
 }
+
+func DeserializeAndCompressKey(DesktopKey string) string {
+	deserialisedKey := MultiformatDeserializePublicKey(DesktopKey, "f")
+	sanitisedKey := "0x" + deserialisedKey[5:]
+	return CompressPublicKey(sanitisedKey)
+}


### PR DESCRIPTION
In desktop when a community is created the share url looks like : 

`https://join.status.im/c/zQ3shTAten2v9CwyQD1Kc7VXAqNPDcHZAMsfbLHCZEx6nFqk9`  where 
`zQ3shTAten2v9CwyQD1Kc7VXAqNPDcHZAMsfbLHCZEx6nFqk9`
is the serialised key which desktop uses.

In mobile when a community is created the share url looks like : 
`https://join.status.im/c/0x025596a7ff87da36860a84b0908191ce60a504afc94aac93c1abd774f182967ce6` where
`0x025596a7ff87da36860a84b0908191ce60a504afc94aac93c1abd774f182967ce6`
is the non serialised key (but compressed) key which mobile uses.

The goal of this PR is to give mobile the ability to go from 
`zQ3shTAten2v9CwyQD1Kc7VXAqNPDcHZAMsfbLHCZEx6nFqk9` to `0x025596a7ff87da36860a84b0908191ce60a504afc94aac93c1abd774f182967ce6`
