### PR TITLE
ci: use WORKSPACE_TMP for TMPDIR to not abuse /run

### DIFF
--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -28,6 +28,7 @@ pipeline {
 
   environment {
     TARGET   = 'android'
+    TMPDIR   = "${WORKSPACE_TMP}"
     GOPATH   = "${WORKSPACE_TMP}/go"
     PATH     = "${PATH}:${GOPATH}/bin"
     REPO_SRC = "${GOPATH}/src/github.com/status-im/status-go"

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -28,6 +28,7 @@ pipeline {
 
   environment {
     TARGET   = 'ios'
+    TMPDIR   = "${WORKSPACE_TMP}"
     GOPATH   = "${WORKSPACE_TMP}/go"
     PATH     = "${PATH}:${GOPATH}/bin"
     REPO_SRC = "${GOPATH}/src/github.com/status-im/status-go"

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -28,6 +28,7 @@ pipeline {
 
   environment {
     TARGET   = 'linux'
+    TMPDIR   = "${WORKSPACE_TMP}"
     GOPATH   = "${WORKSPACE_TMP}/go"
     PATH     = "${PATH}:${GOPATH}/bin"
     REPO_SRC = "${GOPATH}/src/github.com/status-im/status-go"

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -22,7 +22,8 @@ pipeline {
   }
 
   environment {
-    TARGET   = 'linux'
+    TARGET   = 'tests'
+    TMPDIR   = "${WORKSPACE_TMP}"
     GOPATH   = "${WORKSPACE_TMP}/go"
     PATH     = "${PATH}:${GOPATH}/bin"
     REPO_SRC = "${GOPATH}/src/github.com/status-im/status-go"
@@ -69,4 +70,11 @@ pipeline {
       } }
     }
   } // stages
+
+  post {
+    always  { script { env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText" } }
+    success { script { github.notifyPR(true) } }
+    failure { script { github.notifyPR(false) } }
+    cleanup { dir(env.TMPDIR) { deleteDir() } }
+  } // post
 } // pipeline

--- a/account/accounts_test.go
+++ b/account/accounts_test.go
@@ -23,11 +23,11 @@ const newTestPassword = "new-test-password"
 
 func TestVerifyAccountPassword(t *testing.T) {
 	accManager := NewGethManager()
-	keyStoreDir, err := ioutil.TempDir(os.TempDir(), "accounts")
+	keyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts")
 	require.NoError(t, err)
 	defer os.RemoveAll(keyStoreDir) //nolint: errcheck
 
-	emptyKeyStoreDir, err := ioutil.TempDir(os.TempDir(), "accounts_empty")
+	emptyKeyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts_empty")
 	require.NoError(t, err)
 	defer os.RemoveAll(emptyKeyStoreDir) //nolint: errcheck
 
@@ -102,7 +102,7 @@ func TestVerifyAccountPassword(t *testing.T) {
 // TestVerifyAccountPasswordWithAccountBeforeEIP55 verifies if VerifyAccountPassword
 // can handle accounts before introduction of EIP55.
 func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {
-	keyStoreDir, err := ioutil.TempDir("", "status-accounts-test")
+	keyStoreDir, err := os.MkdirTemp("", "status-accounts-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(keyStoreDir) //nolint: errcheck
 
@@ -143,7 +143,7 @@ type testAccount struct {
 func (s *ManagerTestSuite) SetupTest() {
 	s.accManager = NewGethManager()
 
-	keyStoreDir, err := ioutil.TempDir(os.TempDir(), "accounts")
+	keyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts")
 	s.Require().NoError(err)
 	s.Require().NoError(s.accManager.InitKeystore(keyStoreDir))
 	s.keydir = keyStoreDir

--- a/account/keystore_geth.go
+++ b/account/keystore_geth.go
@@ -1,7 +1,6 @@
 package account
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -16,7 +15,7 @@ import (
 func makeAccountManager(keydir string) (manager *accounts.Manager, err error) {
 	if keydir == "" {
 		// There is no datadir.
-		keydir, err = ioutil.TempDir("", "go-ethereum-keystore")
+		keydir, err = os.MkdirTemp("", "go-ethereum-keystore")
 	}
 	if err != nil {
 		return nil, err

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -474,7 +474,7 @@ func TestLoginWithKey(t *testing.T) {
 	main := multiaccounts.Account{
 		KeyUID: keyUID,
 	}
-	tmpdir, err := ioutil.TempDir("", "login-with-key-test-")
+	tmpdir, err := os.MkdirTemp("", "login-with-key-test-")
 	require.NoError(t, err)
 	defer os.Remove(tmpdir)
 	conf, err := params.NewNodeConfig(tmpdir, 1777)
@@ -517,7 +517,7 @@ func TestVerifyDatabasePassword(t *testing.T) {
 	main := multiaccounts.Account{
 		KeyUID: keyUID,
 	}
-	tmpdir, err := ioutil.TempDir("", "verify-database-password-")
+	tmpdir, err := os.MkdirTemp("", "verify-database-password-")
 	require.NoError(t, err)
 	defer os.Remove(tmpdir)
 	conf, err := params.NewNodeConfig(tmpdir, 1777)
@@ -540,7 +540,7 @@ func TestVerifyDatabasePassword(t *testing.T) {
 func TestDeleteMultiaccount(t *testing.T) {
 	backend := NewGethStatusBackend()
 
-	rootDataDir, err := ioutil.TempDir("", "test-keystore-dir")
+	rootDataDir, err := os.MkdirTemp("", "test-keystore-dir")
 	require.NoError(t, err)
 	defer os.Remove(rootDataDir)
 
@@ -616,7 +616,7 @@ func TestDeleteMultiaccount(t *testing.T) {
 func TestConvertAccount(t *testing.T) {
 	backend := NewGethStatusBackend()
 	password := "123123"
-	rootDataDir, err := ioutil.TempDir("", "test-keystore-dir")
+	rootDataDir, err := os.MkdirTemp("", "test-keystore-dir")
 	require.NoError(t, err)
 	defer os.Remove(rootDataDir)
 
@@ -812,7 +812,7 @@ func TestLoginAndMigrationsStillWorkWithExistingUsers(t *testing.T) {
 
 	srcFolder := "../static/test-0.97.3-account/"
 
-	tmpdir, err := ioutil.TempDir("", "login-and-migrations-with-existing-users")
+	tmpdir, err := os.MkdirTemp("", "login-and-migrations-with-existing-users")
 	require.NoError(t, err)
 	defer os.Remove(tmpdir)
 

--- a/api/test_helpers.go
+++ b/api/test_helpers.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ import (
 )
 
 func setupWalletTest(t *testing.T, password string) (backend *GethStatusBackend, defersFunc func(), err error) {
-	tmpdir, err := ioutil.TempDir("", "verified-account-test-")
+	tmpdir, err := os.MkdirTemp("", "verified-account-test-")
 
 	defers := make([]func(), 0)
 	defersFunc = func() {

--- a/mailserver/mailserver_db_leveldb_test.go
+++ b/mailserver/mailserver_db_leveldb_test.go
@@ -1,7 +1,6 @@
 package mailserver
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -16,7 +15,7 @@ import (
 func TestLevelDB_BuildIteratorWithTopic(t *testing.T) {
 	topic := []byte{0x01, 0x02, 0x03, 0x04}
 
-	dir, err := ioutil.TempDir("/tmp", "status-go-test-level-db")
+	dir, err := os.MkdirTemp("/tmp", "status-go-test-level-db")
 	require.NoError(t, err)
 
 	db, err := NewLevelDB(dir)

--- a/mailserver/mailserver_test.go
+++ b/mailserver/mailserver_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -70,7 +69,7 @@ func (s *MailserverSuite) SetupTest() {
 	s.shh = waku.New(&waku.DefaultConfig, nil)
 	s.shh.RegisterMailServer(s.server)
 
-	tmpDir, err := ioutil.TempDir("", "mailserver-test")
+	tmpDir, err := os.MkdirTemp("", "mailserver-test")
 	s.Require().NoError(err)
 	s.dataDir = tmpDir
 

--- a/node/geth_status_node_test.go
+++ b/node/geth_status_node_test.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"io/ioutil"
 	"math"
 	"net"
 	"os"
@@ -59,7 +58,7 @@ func TestStatusNodeStart(t *testing.T) {
 func TestStatusNodeWithDataDir(t *testing.T) {
 	var err error
 
-	dir, err := ioutil.TempDir("", "status-node-test")
+	dir, err := os.MkdirTemp("", "status-node-test")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, os.RemoveAll(dir))

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -55,7 +55,7 @@ func TestNewNodeConfigWithDefaults(t *testing.T) {
 }
 
 func TestNewConfigFromJSON(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "geth-config-tests")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "geth-config-tests")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestNewConfigFromJSON(t *testing.T) {
 }
 
 func TestConfigWriteRead(t *testing.T) {
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "geth-config-tests")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "geth-config-tests")
 	require.Nil(t, err)
 	defer os.RemoveAll(tmpDir) // nolint: errcheck
 

--- a/profiling/profiling_test.go
+++ b/profiling/profiling_test.go
@@ -1,7 +1,6 @@
 package profiling
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestProfilingCPU(t *testing.T) {
-	dir, err := ioutil.TempDir("", "profiling")
+	dir, err := os.MkdirTemp("", "profiling")
 	require.NoError(t, err)
 
 	err = StartCPUProfile(dir)
@@ -39,7 +38,7 @@ func TestProfilingCPU(t *testing.T) {
 }
 
 func TestProfilingMem(t *testing.T) {
-	dir, err := ioutil.TempDir("", "profiling")
+	dir, err := os.MkdirTemp("", "profiling")
 	require.NoError(t, err)
 
 	err = WriteHeapFile(dir)

--- a/protocol/common/message_sender_test.go
+++ b/protocol/common/message_sender_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -54,7 +53,7 @@ func (s *MessageSenderSuite) SetupTest() {
 	s.logger, err = zap.NewDevelopment()
 	s.Require().NoError(err)
 
-	s.tmpDir, err = ioutil.TempDir("", "")
+	s.tmpDir, err = os.MkdirTemp("", "")
 	s.Require().NoError(err)
 
 	identity, err := crypto.GenerateKey()

--- a/protocol/encryption/persistence_keys_storage_test.go
+++ b/protocol/encryption/persistence_keys_storage_test.go
@@ -1,7 +1,7 @@
 package encryption
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -31,7 +31,7 @@ type SQLLitePersistenceKeysStorageTestSuite struct {
 }
 
 func (s *SQLLitePersistenceKeysStorageTestSuite) SetupTest() {
-	dir, err := ioutil.TempDir("", "keys-storage-persistence")
+	dir, err := os.MkdirTemp("", "keys-storage-persistence")
 	s.Require().NoError(err)
 
 	key := "blahblahblah"

--- a/protocol/encryption/persistence_test.go
+++ b/protocol/encryption/persistence_test.go
@@ -2,7 +2,7 @@ package encryption
 
 import (
 	"database/sql"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,7 +26,7 @@ type SQLLitePersistenceTestSuite struct {
 }
 
 func (s *SQLLitePersistenceTestSuite) SetupTest() {
-	dir, err := ioutil.TempDir("", "sqlite-persistence")
+	dir, err := os.MkdirTemp("", "sqlite-persistence")
 	s.Require().NoError(err)
 
 	db, err := sqlite.Open(filepath.Join(dir, "db.sql"), "test-key", sqlite.ReducedKDFIterationsNumber)

--- a/protocol/sqlite/db_test.go
+++ b/protocol/sqlite/db_test.go
@@ -1,7 +1,6 @@
 package sqlite
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,7 +9,7 @@ import (
 )
 
 func TestOpen(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-open")
+	dir, err := os.MkdirTemp("", "test-open")
 	require.NoError(t, err)
 	defer os.Remove(dir)
 

--- a/server/payload_manager_test.go
+++ b/server/payload_manager_test.go
@@ -62,10 +62,10 @@ func setupTestDB(t *testing.T) (*multiaccounts.Database, func()) {
 }
 
 func makeKeystores(t *testing.T) (string, string, func()) {
-	keyStoreDir, err := ioutil.TempDir(os.TempDir(), "accounts")
+	keyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts")
 	require.NoError(t, err)
 
-	emptyKeyStoreDir, err := ioutil.TempDir(os.TempDir(), "accounts_empty")
+	emptyKeyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts_empty")
 	require.NoError(t, err)
 
 	keyStoreDir = filepath.Join(keyStoreDir, "keystore", keyUID)

--- a/services/ens/api_test.go
+++ b/services/ens/api_test.go
@@ -34,7 +34,7 @@ func createDB(t *testing.T) (*sql.DB, func()) {
 func setupTestAPI(t *testing.T) (*API, func()) {
 	db, cancel := createDB(t)
 
-	keyStoreDir, err := ioutil.TempDir(os.TempDir(), "accounts")
+	keyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts")
 	require.NoError(t, err)
 
 	// Creating a dummy status node to simulate what it's done in get_status_node.go

--- a/services/wakuext/api_test.go
+++ b/services/wakuext/api_test.go
@@ -102,7 +102,7 @@ func TestRequestMessagesErrors(t *testing.T) {
 }
 
 func TestInitProtocol(t *testing.T) {
-	directory, err := ioutil.TempDir("", "status-go-testing")
+	directory, err := os.MkdirTemp("", "status-go-testing")
 	require.NoError(t, err)
 
 	config := params.NodeConfig{
@@ -124,7 +124,7 @@ func TestInitProtocol(t *testing.T) {
 	nodeWrapper := ext.NewTestNodeWrapper(nil, waku)
 	service := New(config, nodeWrapper, nil, nil, db)
 
-	tmpdir, err := ioutil.TempDir("", "test-shhext-service-init-protocol")
+	tmpdir, err := os.MkdirTemp("", "test-shhext-service-init-protocol")
 	require.NoError(t, err)
 
 	sqlDB, err := appdatabase.InitializeDB(fmt.Sprintf("%s/db.sql", tmpdir), "password", sqlite.ReducedKDFIterationsNumber)
@@ -223,7 +223,7 @@ func (s *ShhExtSuite) createAndAddNode() {
 
 func (s *ShhExtSuite) SetupTest() {
 	var err error
-	s.dir, err = ioutil.TempDir("", "status-go-testing")
+	s.dir, err = os.MkdirTemp("", "status-go-testing")
 	s.Require().NoError(err)
 }
 

--- a/services/web3provider/api_test.go
+++ b/services/web3provider/api_test.go
@@ -39,7 +39,7 @@ func createDB(t *testing.T) (*sql.DB, func()) {
 func setupTestAPI(t *testing.T) (*API, func()) {
 	db, cancel := createDB(t)
 
-	keyStoreDir, err := ioutil.TempDir(os.TempDir(), "accounts")
+	keyStoreDir, err := os.MkdirTemp(os.TempDir(), "accounts")
 	require.NoError(t, err)
 
 	// Creating a dummy status node to simulate what it's done in get_status_node.go

--- a/shell.nix
+++ b/shell.nix
@@ -49,4 +49,8 @@ pkgs.mkShell {
     ANDROID_NDK=${androidSdk}/libexec/android-sdk/ndk-bundle
     ANDROID_NDK_HOME=$ANDROID_NDK
   '';
+
+  # Sandbox causes Xcode issues on MacOS. Requires sandbox=relaxed.
+  # https://github.com/status-im/status-mobile/pull/13912
+  __noChroot = pkgs.stdenv.isDarwin;
 }


### PR DESCRIPTION
Changes:

- Set `TMPDIR` to `WORKSPACE_TMP` to avoid filling up `/run/user/*` due to use of `MkdirTemp`.
- Replaced use of deprecated `ioutil.TempDir()` with `os.MkdirTemp()`.
- Set `__noChroot = true` on Darwin to avoid Xcode errors: `xcodebuild: Operation not permitted`