### PR TITLE
keycard api extension

### DIFF
--- a/multiaccounts/accounts/database_test.go
+++ b/multiaccounts/accounts/database_test.go
@@ -201,7 +201,7 @@ func TestKeypairs(t *testing.T) {
 		KeycardUID:        "00000000000000000000000000000001",
 		KeycardName:       "Card01",
 		KeycardLocked:     false,
-		AccountsAddresses: []types.Address{{0x01}, {0x02}, {0x03}},
+		AccountsAddresses: []types.Address{{0x01}, {0x02}, {0x03}, {0x04}},
 		KeyUID:            "0000000000000000000000000000000000000000000000000000000000000001",
 	}
 	keyPair2 := keypairs.KeyPair{
@@ -301,6 +301,17 @@ func TestKeypairs(t *testing.T) {
 		}
 	}
 	require.Equal(t, true, locked)
+
+	// Test detleting accounts (addresses) for a certain keycard
+	const numOfAccountsToRemove = 2
+	require.Greater(t, len(keyPair1.AccountsAddresses), numOfAccountsToRemove)
+	accountsToRemove := keyPair1.AccountsAddresses[:numOfAccountsToRemove]
+	err = db.RemoveMigratedAccountsForKeycard(keyPair1.KeycardUID, accountsToRemove)
+	require.NoError(t, err)
+	rows, err = db.GetMigratedKeyPairByKeyUID(keyPair1.KeyUID)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, len(keyPair1.AccountsAddresses)-numOfAccountsToRemove, len(rows[0].AccountsAddresses))
 
 	// Test update keycard uid
 	err = db.UpdateKeycardUID(keyPair1.KeycardUID, keycardUID)

--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -445,6 +445,15 @@ func (api *API) AddMigratedKeyPair(ctx context.Context, kcUID string, kpName str
 	return nil
 }
 
+func (api *API) RemoveMigratedAccountsForKeycard(ctx context.Context, kcUID string, accountAddresses []string) error {
+	var addresses []types.Address
+	for _, addr := range accountAddresses {
+		addresses = append(addresses, types.Address(common.HexToAddress(addr)))
+	}
+
+	return api.db.RemoveMigratedAccountsForKeycard(kcUID, addresses)
+}
+
 func (api *API) GetAllKnownKeycards(ctx context.Context) ([]*keypairs.KeyPair, error) {
 	return api.db.GetAllKnownKeycards()
 }

--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -88,6 +88,10 @@ func (api *API) DeleteAccount(ctx context.Context, address types.Address) error 
 	return (*api.messenger).DeleteAccount(address)
 }
 
+func (api *API) DeleteAccountForMigratedKeypair(ctx context.Context, address types.Address) error {
+	return (*api.messenger).DeleteAccount(address)
+}
+
 func (api *API) AddAccountWatch(ctx context.Context, address string, name string, color string, emoji string) error {
 	account := &accounts.Account{
 		Address: types.Address(common.HexToAddress(address)),


### PR DESCRIPTION
status-go api extended with the following endpoints:
- `RemoveMigratedAccountsForKeycard` - removes an account by address for a keycard with uid from `keypairs` table
- `DeleteAccountForMigratedKeypair` - deletes an account by address from `accounts` table