### PR TITLE
get messenger from account service when local pairing

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1353,9 +1353,9 @@ func (b *GethStatusBackend) SignGroupMembership(content string) (string, error) 
 func (b *GethStatusBackend) Messenger() *protocol.Messenger {
 	node := b.StatusNode()
 	if node != nil {
-		wakuExtService := node.WakuExtService()
-		if wakuExtService != nil {
-			return wakuExtService.Messenger()
+		accountService := node.AccountService()
+		if accountService != nil {
+			return accountService.GetMessenger()
 		}
 	}
 	return nil

--- a/server/pairing/raw_message_handler.go
+++ b/server/pairing/raw_message_handler.go
@@ -30,7 +30,7 @@ func NewSyncRawMessageHandler(backend *api.GethStatusBackend) *SyncRawMessageHan
 func (s *SyncRawMessageHandler) PrepareRawMessage(keyUID string) ([]byte, error) {
 	messenger := s.backend.Messenger()
 	if messenger == nil {
-		return nil, fmt.Errorf("messenger is nil when handlePairingSyncDeviceSend")
+		return nil, fmt.Errorf("messenger is nil when PrepareRawMessage")
 	}
 
 	currentAccount, err := s.backend.GetActiveAccount()
@@ -112,6 +112,9 @@ func (s *SyncRawMessageHandler) HandleRawMessage(account *multiaccounts.Account,
 	}
 
 	messenger := s.backend.Messenger()
+	if messenger == nil {
+		return fmt.Errorf("messenger is nil when HandleRawMessage")
+	}
 	return messenger.HandleSyncRawMessages(rawMessages)
 }
 

--- a/services/accounts/service.go
+++ b/services/accounts/service.go
@@ -78,3 +78,7 @@ func (s *Service) GetAccountsByKeyUID(keyUID string) ([]*accounts.Account, error
 func (s *Service) GetSettings() (settings.Settings, error) {
 	return s.db.GetSettings()
 }
+
+func (s *Service) GetMessenger() *protocol.Messenger {
+	return s.messenger
+}


### PR DESCRIPTION
waku and wakuv2 maybe disabled in some cases when doing local pairing which result in [Messenger()](https://github.com/qfrank/status-go/blob/0135ad942784cd66940d96cd2a3e53920bdb14e6/api/geth_backend.go#L1353
) return nil, so we'd better get messenger from AccountService rather than from WakuExtService
