### PR TITLE
update account name if necessary

### DIFF
--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1750,11 +1750,17 @@ func (m *Messenger) handleSyncSetting(messageState *ReceivedMessageState, messag
 	if err != nil {
 		return err
 	}
-	if message.GetType() == protobuf.SyncSetting_DISPLAY_NAME {
-		m.account.Name = message.GetValueString()
-		err = m.multiAccounts.SaveAccount(*m.account)
+	if message.GetType() == protobuf.SyncSetting_DISPLAY_NAME && settingField != nil {
+		oldDisplayName, err := m.settings.DisplayName()
 		if err != nil {
 			return err
+		}
+		if oldDisplayName != message.GetValueString() {
+			m.account.Name = message.GetValueString()
+			err = m.multiAccounts.SaveAccount(*m.account)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	messageState.Response.AddSetting(settingField)


### PR DESCRIPTION
when doing local pairing, the account name would be replaced to empty string rather than keep the original 3 words name on the receiver side, this should not happen, this PR fixed this issue.