### PR TITLE
reorder pair action by the order of occurrence

### DIFF
--- a/server/pairing/events.go
+++ b/server/pairing/events.go
@@ -27,7 +27,7 @@ type Event struct {
 type Action int
 
 const (
-	ActionPairingAccount = iota + 1
+	ActionConnect = iota + 1
+	ActionPairingAccount
 	ActionSyncDevice
-	ActionConnect
 )


### PR DESCRIPTION
when i was testing local paring, i saw the log output from [code](https://github.com/status-im/status-react/blob/3692ad38dd12dbe864dc7e7da12593be4fbc2638/src/status_im/signals/core.cljs#L56) , i feel not comfortable, the log ouput example: 
```
[Tue Jan 31 2023 15:49:23.908]  INFO     INFO [status-im.signals.core:59] - local pairing signal received {:event {:type "connection-success", :action 3}}
[Tue Jan 31 2023 15:49:23.961]  INFO     INFO [status-im.signals.core:59] - local pairing signal received {:event {:type "transfer-success", :action 1}}
[Tue Jan 31 2023 15:49:24.491]  INFO     INFO [status-im.signals.core:59] - local pairing signal received {:event {:type "process-success", :action 1}}
[Tue Jan 31 2023 15:49:24.521]  INFO     INFO [status-im.signals.core:59] - local pairing signal received {:event {:type "transfer-success", :action 2}}
```
u can c the value of action(3-1-1-2) does not appear in the log in order, this PR will make it appear in order like (1-2-2-3)