### PR TITLE
Bump encryption too high number

### DIFF
--- a/protocol/encryption/encryptor.go
+++ b/protocol/encryption/encryptor.go
@@ -33,7 +33,7 @@ var (
 // If we have no bundles, we use a constant so that the message can reach any device.
 const (
 	noInstallationID         = "none"
-	maxHashRatchetSeqNoDelta = 1000
+	maxHashRatchetSeqNoDelta = 100000
 )
 
 type confirmationData struct {


### PR DESCRIPTION
Bump too high number for hash ratchet, currently we don't re-key often enough, so best to keep this to a high number, once rekeying happens more frequently, we can lower it, but before is best to optimize the re-keying message.