### PR TITLE
fix: add discord message data to quoted messages

### DIFF
--- a/protocol/common/message.go
+++ b/protocol/common/message.go
@@ -39,6 +39,8 @@ type QuotedMessage struct {
 	CommunityID string `json:"communityId,omitempty"`
 
 	Deleted bool `json:"deleted,omitempty"`
+
+	DiscordMessage *protobuf.DiscordMessage `json:"discordMessage,omitempty"`
 }
 
 type CommandState int

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4483,6 +4483,18 @@ func (m *Messenger) prepareMessage(msg *common.Message, s *server.MediaServer) {
 	if msg.QuotedMessage != nil && msg.QuotedMessage.ContentType == int64(protobuf.ChatMessage_STICKER) {
 		msg.QuotedMessage.HasSticker = true
 	}
+	if msg.QuotedMessage != nil && msg.QuotedMessage.ContentType == int64(protobuf.ChatMessage_DISCORD_MESSAGE) {
+		dm := msg.QuotedMessage.DiscordMessage
+		exists, err := m.persistence.HasDiscordMessageAuthorImagePayload(dm.Author.Id)
+		if err != nil {
+			return
+		}
+
+		if exists {
+			msg.QuotedMessage.DiscordMessage.Author.LocalUrl = s.MakeDiscordAuthorAvatarURL(dm.Author.Id)
+		}
+	}
+
 	if msg.ContentType == protobuf.ChatMessage_IMAGE {
 		msg.ImageLocalURL = s.MakeImageURL(msg.ID)
 	}


### PR DESCRIPTION
Because `QuotedMessage` doesn't include imported message data, some of the author information in imported messages is lost in frontends.

This commit adds a `discordMessage` (soon replaced by `importedMessage`) to `Quotedmessage`, although only hydrated with a subset of data, namely author display name and avatar URL, as those are the only ones needed by front-end atm.
