### PR TITLE
chore: build library using vendor folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ statusgo-library: ##@cross-compile Build status-go as static library for current
 	go run cmd/library/*.go > $(GOBIN)/statusgo-lib/main.go
 	@echo "Building static library..."
 	go build \
+		-mod vendor \
 		-tags '$(BUILD_TAGS)' \
 		$(BUILD_FLAGS) \
 		-buildmode=c-archive \
@@ -165,6 +166,7 @@ statusgo-shared-library: ##@cross-compile Build status-go as shared library for 
 	go run cmd/library/*.go > $(GOBIN)/statusgo-lib/main.go
 	@echo "Building shared library..."
 	$(GOBIN_SHARED_LIB_CFLAGS) $(GOBIN_SHARED_LIB_CGO_LDFLAGS) go build \
+		-mod vendor \
 		-tags '$(BUILD_TAGS)' \
 		$(BUILD_FLAGS) \
 		-buildmode=c-shared \


### PR DESCRIPTION
I noticed that when we execute `make statusgo-library` or `make statusgo-shared-library` go would build status-go using the source code from $GOHOME instead the source from vendor/ folder