### PR TITLE
ci: use M1 Macs for iOS builds

### DIFF
--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.6.4'
 
 pipeline {
-  agent { label 'macos && x86_64 && go-1.18' }
+  agent { label 'macos && aarch64 && go-1.18 && nix-2.11' }
 
   parameters {
     string(


### PR DESCRIPTION
Should be faster, and is the same a how we do it for mobile app.

![image](https://user-images.githubusercontent.com/2212681/219340505-cfade1df-5ceb-46e7-ab57-69abe7dcfa08.png)

Normally compilation takes about 1.5 minute.