### PR TITLE
Resume import of message history archives upon bootstrap

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -720,6 +720,20 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 		}
 	}
 
+	joinedCommunities, err := m.communitiesManager.Joined()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, joinedCommunity := range joinedCommunities {
+		// resume importing message history archives in case
+		// imports have been interrupted previously
+		err := m.resumeHistoryArchivesImport(joinedCommunity.ID())
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if m.httpServer != nil {
 		err = m.httpServer.Start()
 		if err != nil {


### PR DESCRIPTION
This adds the functionality that history archives continue to be imported in case the import has been interrupted the last time the app/client was running.

This typically happens when users don't wait for an ongoing import to finish, which sometimes can take a while. Users then close the app/kill the client which leaves the database in a state where there's downloaded archives that haven't been fully imported.

Prior to this change, the node will have to wait until it receives a new magnetlink that it hasn't seen before, until it processes imports again. This can take several days.

Now, it will check on startup if there are any archives left to be imported and resumes the import from there.

