### PR TITLE
fix: merge balance history using block time

### DIFF
--- a/services/wallet/history/service_test.go
+++ b/services/wallet/history/service_test.go
@@ -3,6 +3,7 @@ package history
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
@@ -13,12 +14,12 @@ type TestDataPoint struct {
 	value       int64
 	timestamp   uint64
 	blockNumber int64
-	chainID     uint64
+	chainID     chainIdentity
 }
 
 // generateTestDataForElementCount generates dummy consecutive blocks of data for the same chain_id, address and currency
-func prepareTestData(data []TestDataPoint) map[uint64][]*DataPoint {
-	res := make(map[uint64][]*DataPoint)
+func prepareTestData(data []TestDataPoint) map[chainIdentity][]*DataPoint {
+	res := make(map[chainIdentity][]*DataPoint)
 	for i := 0; i < len(data); i++ {
 		entry := data[i]
 		_, found := res[entry.chainID]
@@ -34,10 +35,15 @@ func prepareTestData(data []TestDataPoint) map[uint64][]*DataPoint {
 	return res
 }
 
+// getBlockNumbers returns -1 if block number is nil
 func getBlockNumbers(data []*DataPoint) []int64 {
 	res := make([]int64, 0)
 	for _, entry := range data {
-		res = append(res, entry.BlockNumber.ToInt().Int64())
+		if entry.BlockNumber == nil {
+			res = append(res, -1)
+		} else {
+			res = append(res, entry.BlockNumber.ToInt().Int64())
+		}
 	}
 	return res
 }
@@ -58,7 +64,8 @@ func getTimestamps(data []*DataPoint) []int64 {
 	return res
 }
 
-func TestServiceGetBalanceHistory(t *testing.T) {
+func TestServiceMergeDataPoints(t *testing.T) {
+	strideDuration := 5 * time.Second
 	testData := prepareTestData([]TestDataPoint{
 		// Drop 100
 		{value: 1, timestamp: 100, blockNumber: 100, chainID: 1},
@@ -88,15 +95,16 @@ func TestServiceGetBalanceHistory(t *testing.T) {
 		{value: 1, timestamp: 135, blockNumber: 135, chainID: 1},
 	})
 
-	res, err := mergeDataPoints(testData)
+	res, err := mergeDataPoints(testData, strideDuration)
 	require.NoError(t, err)
 	require.Equal(t, 4, len(res))
 	require.Equal(t, []int64{105, 115, 125, 130}, getBlockNumbers(res))
 	require.Equal(t, []int64{3, 3 * 2, 3 * 3, 3 * 4}, getValues(res))
-	require.Equal(t, []int64{105, 115, 125, 130}, getTimestamps(res))
+	require.Equal(t, []int64{110, 120, 130, 135}, getTimestamps(res))
 }
 
-func TestServiceGetBalanceHistoryAllMatch(t *testing.T) {
+func TestServiceMergeDataPointsAllMatch(t *testing.T) {
+	strideDuration := 10 * time.Second
 	testData := prepareTestData([]TestDataPoint{
 		// Keep 105
 		{value: 1, timestamp: 105, blockNumber: 105, chainID: 1},
@@ -116,15 +124,16 @@ func TestServiceGetBalanceHistoryAllMatch(t *testing.T) {
 		{value: 4, timestamp: 135, blockNumber: 135, chainID: 3},
 	})
 
-	res, err := mergeDataPoints(testData)
+	res, err := mergeDataPoints(testData, strideDuration)
 	require.NoError(t, err)
 	require.Equal(t, 4, len(res))
 	require.Equal(t, []int64{105, 115, 125, 135}, getBlockNumbers(res))
 	require.Equal(t, []int64{3, 3 * 2, 3 * 3, 3 * 4}, getValues(res))
-	require.Equal(t, []int64{105, 115, 125, 135}, getTimestamps(res))
+	require.Equal(t, []int64{115, 125, 135, 145}, getTimestamps(res))
 }
 
-func TestServiceGetBalanceHistoryOneChain(t *testing.T) {
+func TestServiceMergeDataPointsOneChain(t *testing.T) {
+	strideDuration := 10 * time.Second
 	testData := prepareTestData([]TestDataPoint{
 		// Keep 105
 		{value: 1, timestamp: 105, blockNumber: 105, chainID: 1},
@@ -134,31 +143,74 @@ func TestServiceGetBalanceHistoryOneChain(t *testing.T) {
 		{value: 3, timestamp: 125, blockNumber: 125, chainID: 1},
 	})
 
-	res, err := mergeDataPoints(testData)
+	res, err := mergeDataPoints(testData, strideDuration)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(res))
 	require.Equal(t, []int64{105, 115, 125}, getBlockNumbers(res))
 	require.Equal(t, []int64{1, 2, 3}, getValues(res))
-	require.Equal(t, []int64{105, 115, 125}, getTimestamps(res))
+	require.Equal(t, []int64{115, 125, 135}, getTimestamps(res))
 }
 
-func TestServiceGetBalanceHistoryDropAll(t *testing.T) {
+func TestServiceMergeDataPointsDropAll(t *testing.T) {
+	strideDuration := 10 * time.Second
 	testData := prepareTestData([]TestDataPoint{
 		{value: 1, timestamp: 100, blockNumber: 100, chainID: 1},
-		{value: 1, timestamp: 100, blockNumber: 101, chainID: 2},
-		{value: 1, timestamp: 100, blockNumber: 102, chainID: 3},
-		{value: 1, timestamp: 100, blockNumber: 103, chainID: 4},
+		{value: 1, timestamp: 110, blockNumber: 110, chainID: 2},
+		{value: 1, timestamp: 120, blockNumber: 120, chainID: 3},
+		{value: 1, timestamp: 130, blockNumber: 130, chainID: 4},
 	})
 
-	res, err := mergeDataPoints(testData)
+	res, err := mergeDataPoints(testData, strideDuration)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(res))
 }
 
-func TestServiceGetBalanceHistoryEmptyDB(t *testing.T) {
+func TestServiceMergeDataPointsEmptyDB(t *testing.T) {
 	testData := prepareTestData([]TestDataPoint{})
 
-	res, err := mergeDataPoints(testData)
+	strideDuration := 10 * time.Second
+
+	res, err := mergeDataPoints(testData, strideDuration)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(res))
+}
+
+func TestServiceFindFirstStrideWindowFirstForAllChainInOneStride(t *testing.T) {
+	strideDuration := 10 * time.Second
+	testData := prepareTestData([]TestDataPoint{
+		{value: 1, timestamp: 103, blockNumber: 101, chainID: 2},
+		{value: 1, timestamp: 106, blockNumber: 102, chainID: 3},
+		{value: 1, timestamp: 100, blockNumber: 100, chainID: 1},
+		{value: 1, timestamp: 110, blockNumber: 103, chainID: 1},
+		{value: 1, timestamp: 110, blockNumber: 103, chainID: 2},
+	})
+
+	startTimestamp := findFirstStrideWindow(testData, strideDuration)
+	require.Equal(t, testData[1][0].Timestamp, uint64(startTimestamp))
+}
+
+func TestServiceSortTimeAsc(t *testing.T) {
+	testData := prepareTestData([]TestDataPoint{
+		{value: 3, timestamp: 103, blockNumber: 103, chainID: 3},
+		{value: 4, timestamp: 104, blockNumber: 104, chainID: 4},
+		{value: 2, timestamp: 102, blockNumber: 102, chainID: 2},
+		{value: 1, timestamp: 101, blockNumber: 101, chainID: 1},
+	})
+
+	sorted := sortTimeAsc(testData, map[chainIdentity]int{4: 0, 3: 0, 2: 0, 1: 0})
+	require.Equal(t, []timeIdentity{{1, 0}, {2, 0}, {3, 0}, {4, 0}}, sorted)
+}
+
+func TestServiceAtEnd(t *testing.T) {
+	testData := prepareTestData([]TestDataPoint{
+		{value: 1, timestamp: 101, blockNumber: 101, chainID: 1},
+		{value: 1, timestamp: 101, blockNumber: 101, chainID: 2},
+		{value: 1, timestamp: 102, blockNumber: 102, chainID: 1},
+	})
+
+	sorted := sortTimeAsc(testData, map[chainIdentity]int{1: 0, 2: 0})
+	require.False(t, sorted[0].atEnd(testData))
+	require.True(t, sorted[1].atEnd(testData))
+	sorted = sortTimeAsc(testData, map[chainIdentity]int{1: 1, 2: 0})
+	require.True(t, sorted[1].atEnd(testData))
 }


### PR DESCRIPTION
### Implements [9205](https://github.com/status-im/status-desktop/issues/9205)
    
This change improves on the [previous implementation](https://github.com/status-im/status-go/pull/3071), which used the block number, that doesn't work (that means merging incompatible blockchains, regarding block pacing, e.g. L1 vs L2)

#### Problem description

Users can visualize the balance history graph for all the selected chains for a specific address and token currency; see [`wallet.history.Service.GetBalanceHistory`](https://github.com/status-im/status-go/blob/a2ff03c79ec4b874c53eabb768e1a4908d522a5d/services/wallet/history/service.go#L200)

That means we fetch from the DB [balance entries](https://github.com/status-im/status-go/blob/a2ff03c79ec4b874c53eabb768e1a4908d522a5d/services/wallet/history/balance.go#L89) for multiple chains. Some tokens (chain native, `ERC20`) have the same blocks hence the same timestamp for each entry and could be merged by block number (the previous implementation).

However, the same tokens on incompatible chains (L1 vs L2) have different block numbers; hence the entries will be on different block numbers having different states).

#### Solution

We merge the entries for each chain that fit in the same [time slice](https://github.com/status-im/status-go/blob/a2ff03c79ec4b874c53eabb768e1a4908d522a5d/services/wallet/history/balance.go#L66) and output one entry with the slice's last timestamp.

Closes: [#9205](https://github.com/status-im/status-desktop/issues/9205)