### PR TITLE
allow building shared library on M1 Macs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,10 @@ endif
 
 ifeq ($(detected_OS),Darwin)
  GOBIN_SHARED_LIB_EXT := dylib
-  # Building on M1 is still not supported, so in the meantime we crosscompile by default to amd64
-  ifeq ("$(shell sysctl -nq hw.optional.arm64)","1")
-    FORCE_ARCH ?= amd64
-    GOBIN_SHARED_LIB_CFLAGS=CGO_ENABLED=1 GOOS=darwin GOARCH=$(FORCE_ARCH)
-  endif
+ GOBIN_SHARED_LIB_CFLAGS := CGO_ENABLED=1 GOOS=darwin
 else ifeq ($(detected_OS),Windows)
- GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS=""
  GOBIN_SHARED_LIB_EXT := dll
+ GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS=""
 else
  GOBIN_SHARED_LIB_EXT := so
  GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS="-Wl,-soname,libstatus.so.0"


### PR DESCRIPTION
Seems like this wasn't supported in the past, but should work now.
```
 % make statusgo-shared-library GOBIN_SHARED_LIB_CFLAGS='GOOS=darwin GOARCH=arm64'
...
Shared library built:
-rw-r--r--  1 admin  admin  81850034 Jan 25 14:57 /Users/admin/status-go/build/bin/libstatus.dylib
-rw-r--r--  1 admin  admin      6658 Jan 25 14:57 /Users/admin/status-go/build/bin/libstatus.h
```