### PR TITLE
Convert a keycard account to a regular account

### DIFF
--- a/account/accounts.go
+++ b/account/accounts.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -606,7 +607,7 @@ func (m *Manager) ReEncryptKeyStoreDir(keyDirPath, oldPass, newPass string) erro
 	return nil
 }
 
-func (m *Manager) DeleteAccount(keyDirPath string, address types.Address) error {
+func (m *Manager) DeleteAccount(keyDirPath string, address types.Address, ignoreCase bool) error {
 	var err error
 	var foundKeyFile string
 	err = filepath.Walk(keyDirPath, func(path string, fileInfo os.FileInfo, err error) error {
@@ -629,8 +630,14 @@ func (m *Manager) DeleteAccount(keyDirPath string, address types.Address) error 
 			return fmt.Errorf("failed to read key file: %s", e)
 		}
 
-		if types.HexToAddress("0x"+accountKey.Address).Hex() == address.Hex() {
-			foundKeyFile = path
+		if ignoreCase {
+			if strings.EqualFold("0x"+accountKey.Address, address.String()) {
+				foundKeyFile = path
+			}
+		} else {
+			if types.HexToAddress("0x"+accountKey.Address).Hex() == address.Hex() {
+				foundKeyFile = path
+			}
 		}
 
 		return nil

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -564,7 +564,7 @@ func (b *GethStatusBackend) ChangeDatabasePassword(keyUID string, password strin
 	return nil
 }
 
-func (b *GethStatusBackend) ConvertToKeycardAccount(keyStoreDir string, account multiaccounts.Account, s settings.Settings, password string, newPassword string) error {
+func (b *GethStatusBackend) ConvertToKeycardAccount(account multiaccounts.Account, s settings.Settings, password string, newPassword string) error {
 	err := b.multiaccountsDB.UpdateAccountKeycardPairing(account.KeyUID, account.KeycardPairing)
 	if err != nil {
 		return err
@@ -639,13 +639,13 @@ func (b *GethStatusBackend) ConvertToKeycardAccount(keyStoreDir string, account 
 	// whichever reason the account is still successfully migrated
 	for _, acc := range knownAccounts {
 		if account.KeyUID == acc.KeyUID {
-			_ = b.accountManager.DeleteAccount(keyStoreDir, acc.Address, true)
+			_ = b.accountManager.DeleteAccount(acc.Address, newPassword)
 		}
 	}
-	_ = b.accountManager.DeleteAccount(keyStoreDir, masterAddress, true)
-	_ = b.accountManager.DeleteAccount(keyStoreDir, dappsAddress, true)
-	_ = b.accountManager.DeleteAccount(keyStoreDir, eip1581Address, true)
-	_ = b.accountManager.DeleteAccount(keyStoreDir, walletRootAddress, true)
+	_ = b.accountManager.DeleteAccount(masterAddress, newPassword)
+	_ = b.accountManager.DeleteAccount(dappsAddress, newPassword)
+	_ = b.accountManager.DeleteAccount(eip1581Address, newPassword)
+	_ = b.accountManager.DeleteAccount(walletRootAddress, newPassword)
 
 	return nil
 }

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -604,6 +604,26 @@ func (b *GethStatusBackend) ConvertToKeycardAccount(keyStoreDir string, account 
 		return err
 	}
 
+	masterAddress, err := accountDB.GetMasterAddress()
+	if err != nil {
+		return err
+	}
+
+	dappsAddress, err := accountDB.GetDappsAddress()
+	if err != nil {
+		return err
+	}
+
+	eip1581Address, err := accountDB.GetEIP1581Address()
+	if err != nil {
+		return err
+	}
+
+	walletRootAddress, err := accountDB.GetWalletRootAddress()
+	if err != nil {
+		return err
+	}
+
 	err = b.closeAppDB()
 	if err != nil {
 		return err
@@ -614,13 +634,18 @@ func (b *GethStatusBackend) ConvertToKeycardAccount(keyStoreDir string, account 
 		return err
 	}
 
+	// We need to delete all accounts for the keypair which is being migrated
+	// no need to check for the error below cause if this action fails from
+	// whichever reason the account is still successfully migrated
 	for _, acc := range knownAccounts {
 		if account.KeyUID == acc.KeyUID {
-			// This action deletes an account from the keystore, no need to check for error in this context here, cause if this
-			// action fails from whichever reason the account is still successfully migrated since keystore won't be used any more.
-			_ = b.accountManager.DeleteAccount(keyStoreDir, acc.Address)
+			_ = b.accountManager.DeleteAccount(keyStoreDir, acc.Address, true)
 		}
 	}
+	_ = b.accountManager.DeleteAccount(keyStoreDir, masterAddress, true)
+	_ = b.accountManager.DeleteAccount(keyStoreDir, dappsAddress, true)
+	_ = b.accountManager.DeleteAccount(keyStoreDir, eip1581Address, true)
+	_ = b.accountManager.DeleteAccount(keyStoreDir, walletRootAddress, true)
 
 	return nil
 }

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -828,7 +828,7 @@ func ChangeDatabasePassword(KeyUID, password, newPassword string) string {
 	return makeJSONResponse(nil)
 }
 
-func ConvertToKeycardAccount(keyStoreDir, accountData, settingsJSON, password, newPassword string) string {
+func ConvertToKeycardAccount(accountData, settingsJSON, password, newPassword string) string {
 	var account multiaccounts.Account
 	err := json.Unmarshal([]byte(accountData), &account)
 	if err != nil {
@@ -840,7 +840,7 @@ func ConvertToKeycardAccount(keyStoreDir, accountData, settingsJSON, password, n
 		return makeJSONResponse(err)
 	}
 
-	err = statusBackend.ConvertToKeycardAccount(keyStoreDir, account, settings, password, newPassword)
+	err = statusBackend.ConvertToKeycardAccount(account, settings, password, newPassword)
 	if err != nil {
 		return makeJSONResponse(err)
 	}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -847,6 +847,14 @@ func ConvertToKeycardAccount(keyStoreDir, accountData, settingsJSON, password, n
 	return makeJSONResponse(nil)
 }
 
+func ConvertToRegularAccount(mnemonic, currPassword, newPassword string) string {
+	err := statusBackend.ConvertToRegularAccount(mnemonic, currPassword, newPassword)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	return makeJSONResponse(nil)
+}
+
 func ImageServerTLSCert() string {
 	cert, err := server.PublicTLSCert()
 

--- a/multiaccounts/accounts/database_test.go
+++ b/multiaccounts/accounts/database_test.go
@@ -324,7 +324,7 @@ func TestKeypairs(t *testing.T) {
 	require.NoError(t, err)
 	locked = true
 	for _, kp := range rows {
-		if kp.KeyUID == keyPair1.KeyUID {
+		if kp.KeycardUID == keycardUID {
 			locked = kp.KeycardLocked
 		}
 	}
@@ -337,11 +337,25 @@ func TestKeypairs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rows))
 	// Test if correct keycard is deleted
-	deletedKeyPair1 := true
+	deletedKeyCard := true
 	for _, kp := range rows {
-		if kp.KeyUID == keyPair1.KeyUID {
-			deletedKeyPair1 = false
+		if kp.KeycardUID == keycardUID {
+			deletedKeyCard = false
 		}
 	}
-	require.Equal(t, true, deletedKeyPair1)
+	require.Equal(t, true, deletedKeyCard)
+
+	// Test detleting a keypair
+	err = db.DeleteKeypair(keyPair2.KeyUID)
+	require.NoError(t, err)
+	rows, err = db.GetAllMigratedKeyPairs()
+	require.NoError(t, err)
+	// Test if correct keycard is deleted
+	deletedKeyPair2And3 := true
+	for _, kp := range rows {
+		if kp.KeyUID == keyPair2.KeyUID {
+			deletedKeyPair2And3 = false
+		}
+	}
+	require.Equal(t, true, deletedKeyPair2And3)
 }

--- a/multiaccounts/database.go
+++ b/multiaccounts/database.go
@@ -317,8 +317,8 @@ func (db *Database) UpdateAccount(account Account) error {
 	return err
 }
 
-func (db *Database) UpdateAccountKeycardPairing(account Account) error {
-	_, err := db.db.Exec("UPDATE accounts SET keycardPairing = ? WHERE keyUid = ?", account.KeycardPairing, account.KeyUID)
+func (db *Database) UpdateAccountKeycardPairing(keyUID string, keycardPairing string) error {
+	_, err := db.db.Exec("UPDATE accounts SET keycardPairing = ? WHERE keyUid = ?", keycardPairing, keyUID)
 	return err
 }
 

--- a/multiaccounts/keypairs/database.go
+++ b/multiaccounts/keypairs/database.go
@@ -263,3 +263,21 @@ func (kp *KeyPairs) DeleteKeycard(kcUID string) (err error) {
 
 	return err
 }
+
+func (kp *KeyPairs) DeleteKeypair(keyUID string) (err error) {
+	delete, err := kp.db.Prepare(`
+		DELETE
+		FROM
+			keypairs
+		WHERE
+			key_uid = ?
+	`)
+	if err != nil {
+		return err
+	}
+	defer delete.Close()
+
+	_, err = delete.Exec(keyUID)
+
+	return err
+}

--- a/multiaccounts/settings/columns.go
+++ b/multiaccounts/settings/columns.go
@@ -402,6 +402,11 @@ var (
 		dBColumnName:   "wallet_root_address",
 		valueHandler:   AddressHandler,
 	}
+	MasterAddress = SettingField{
+		reactFieldName: "address",
+		dBColumnName:   "address",
+		valueHandler:   AddressHandler,
+	}
 
 	SettingFieldRegister = []SettingField{
 		AnonMetricsShouldSend,

--- a/multiaccounts/settings/database.go
+++ b/multiaccounts/settings/database.go
@@ -587,6 +587,22 @@ func (db *Database) GetWalletRootAddress() (rst types.Address, err error) {
 	return
 }
 
+func (db *Database) GetEIP1581Address() (rst types.Address, err error) {
+	err = db.makeSelectRow(EIP1581Address).Scan(&rst)
+	if err == sql.ErrNoRows {
+		return rst, nil
+	}
+	return
+}
+
+func (db *Database) GetMasterAddress() (rst types.Address, err error) {
+	err = db.makeSelectRow(MasterAddress).Scan(&rst)
+	if err == sql.ErrNoRows {
+		return rst, nil
+	}
+	return
+}
+
 func (db *Database) TestNetworksEnabled() (rst bool, err error) {
 	err = db.makeSelectRow(TestNetworksEnabled).Scan(&rst)
 	if err == sql.ErrNoRows {

--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -78,7 +78,7 @@ func (api *API) DeleteAccount(ctx context.Context, address types.Address) error 
 		return err
 	}
 	if acc.Type != accounts.AccountTypeWatch {
-		err = api.manager.DeleteAccount(api.config.KeyStoreDir, address)
+		err = api.manager.DeleteAccount(api.config.KeyStoreDir, address, true)
 		var e *account.ErrCannotLocateKeyFile
 		if err != nil && !errors.As(err, &e) {
 			return err
@@ -444,7 +444,7 @@ func (api *API) AddMigratedKeyPair(ctx context.Context, kcUID string, kpName str
 	for _, addr := range addresses {
 		// This action deletes an account from the keystore, no need to check for error in this context here, cause if this
 		// action fails from whichever reason the account is still successfully migrated since keystore won't be used any more.
-		_ = api.manager.DeleteAccount(keyStoreDir, addr)
+		_ = api.manager.DeleteAccount(keyStoreDir, addr, true)
 	}
 	return nil
 }

--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -78,7 +78,7 @@ func (api *API) DeleteAccount(ctx context.Context, address types.Address) error 
 		return err
 	}
 	if acc.Type != accounts.AccountTypeWatch {
-		err = api.manager.DeleteAccount(api.config.KeyStoreDir, address, true)
+		err = api.manager.DeleteAccount(address, "")
 		var e *account.ErrCannotLocateKeyFile
 		if err != nil && !errors.As(err, &e) {
 			return err
@@ -444,7 +444,7 @@ func (api *API) AddMigratedKeyPair(ctx context.Context, kcUID string, kpName str
 	for _, addr := range addresses {
 		// This action deletes an account from the keystore, no need to check for error in this context here, cause if this
 		// action fails from whichever reason the account is still successfully migrated since keystore won't be used any more.
-		_ = api.manager.DeleteAccount(keyStoreDir, addr, true)
+		_ = api.manager.DeleteAccount(addr, "")
 	}
 	return nil
 }

--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -486,6 +486,10 @@ func (api *API) DeleteKeycard(ctx context.Context, kcUID string) error {
 	return api.db.DeleteKeycard(kcUID)
 }
 
+func (api *API) DeleteKeypair(ctx context.Context, keyUID string) error {
+	return api.db.DeleteKeypair(keyUID)
+}
+
 func (api *API) UpdateKeycardUID(ctx context.Context, oldKcUID string, newKcUID string) error {
 	return api.db.UpdateKeycardUID(oldKcUID, newKcUID)
 }


### PR DESCRIPTION
This PR is created to support a conversion of a keycard account to a regular account.

What's done:
- `DeleteKeypair` endpoint added
- convert a regular to a keycard account process updated in a way that previous implementation was not deleting all keystore files for the keypir being migrated
- `ConvertToRegularAccount` endpoint added
- `TestConvertAccount` tests the entire process of converting a regular account to a keycard account and then converting that keycard account back to a regular account