### PR TITLE
chore(waku2): bump go-waku to notice disconnection from peers faster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/gorilla/sessions v1.2.1
 	github.com/meirf/gopart v0.0.0-20180520194036-37e9492a85a8
 	github.com/rmg/iso4217 v1.0.0
-	github.com/waku-org/go-waku v0.3.2-0.20230117214048-e0ccdbe9665d
+	github.com/waku-org/go-waku v0.4.1-0.20230127175953-d4473e9c46e4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2067,8 +2067,8 @@ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98 h1:xwY0kW5XZFimdqfZb9cZwT1S3VJP9j3AE6bdNd9boXM=
 github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98/go.mod h1:eBHgM6T4EG0RZzxpxKy+rGz/6Dw2Nd8DWxS0lm9ESDw=
-github.com/waku-org/go-waku v0.3.2-0.20230117214048-e0ccdbe9665d h1:W+I90Y9avF506cmqr4jZX+HeKf5+MY8SMQRZhMR/k9g=
-github.com/waku-org/go-waku v0.3.2-0.20230117214048-e0ccdbe9665d/go.mod h1:sI14mN/sM8inIb2x2b462wydSEFyOyuDKI1cjiVIIpM=
+github.com/waku-org/go-waku v0.4.1-0.20230127175953-d4473e9c46e4 h1:6WS5u6VRNc1SC5ORC5IdepUeo71JgaLoDcvMlDK7Jx8=
+github.com/waku-org/go-waku v0.4.1-0.20230127175953-d4473e9c46e4/go.mod h1:sI14mN/sM8inIb2x2b462wydSEFyOyuDKI1cjiVIIpM=
 github.com/waku-org/go-zerokit-rln v0.1.7-wakuorg h1:2vVIBCtBih2w1K9ll8YnToTDZvbxcgbsClsPlJS/kkg=
 github.com/waku-org/go-zerokit-rln v0.1.7-wakuorg/go.mod h1:GlyaVeEWNEBxVJrWC6jFTvb4LNb9d9qnjdS6EiWVUvk=
 github.com/wealdtech/go-ens/v3 v3.5.0 h1:Huc9GxBgiGweCOGTYomvsg07K2QggAqZpZ5SuiZdC8o=

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/wakuoptions.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/wakuoptions.go
@@ -57,11 +57,12 @@ type WakuNodeParameters struct {
 
 	logger *zap.Logger
 
-	enableRelay      bool
-	enableFilter     bool
-	isFilterFullNode bool
-	filterOpts       []filter.Option
-	wOpts            []pubsub.Option
+	noDefaultWakuTopic bool
+	enableRelay        bool
+	enableFilter       bool
+	isFilterFullNode   bool
+	filterOpts         []filter.Option
+	wOpts              []pubsub.Option
 
 	minRelayPeersToPublish int
 
@@ -262,6 +263,15 @@ func (w *WakuNodeParameters) GetPrivKey() *crypto.PrivKey {
 func WithLibP2POptions(opts ...libp2p.Option) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.libP2POpts = opts
+		return nil
+	}
+}
+
+// NoDefaultWakuTopic will stop the node from subscribing to the default
+// pubsub topic automatically
+func NoDefaultWakuTopic() WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.noDefaultWakuTopic = true
 		return nil
 	}
 }

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/waku_store_client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/waku_store_client.go
@@ -206,9 +206,10 @@ func (store *WakuStore) queryFrom(ctx context.Context, q *pb.HistoryQuery, selec
 	}
 
 	if historyResponseRPC.Response == nil {
-		logger.Error("empty response")
-		metrics.RecordStoreError(store.ctx, "emptyRpcResponseFailure")
-		return nil, ErrEmptyResponse
+		// Empty response
+		return &pb.HistoryResponse{
+			PagingInfo: &pb.PagingInfo{},
+		}, nil
 	}
 
 	metrics.RecordMessage(ctx, "retrieved", len(historyResponseRPC.Response.Messages))

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/waku_store_common.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/waku_store_common.go
@@ -41,8 +41,6 @@ var (
 	ErrFailedQuery = errors.New("failed to resolve the query")
 
 	ErrFutureMessage = errors.New("message timestamp in the future")
-
-	ErrEmptyResponse = errors.New("empty store response")
 )
 
 type WakuSwap interface {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -985,7 +985,7 @@ github.com/vacp2p/mvds/transport
 github.com/waku-org/go-discover/discover
 github.com/waku-org/go-discover/discover/v4wire
 github.com/waku-org/go-discover/discover/v5wire
-# github.com/waku-org/go-waku v0.3.2-0.20230117214048-e0ccdbe9665d
+# github.com/waku-org/go-waku v0.4.1-0.20230127175953-d4473e9c46e4
 ## explicit; go 1.18
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/waku/persistence

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1137,10 +1137,7 @@ func (w *Waku) Query(ctx context.Context, peerID peer.ID, topics []common.TopicT
 	}
 
 	result, err := w.node.Store().Query(ctx, query, opts...)
-	if err != nil && errors.Is(err, store.ErrEmptyResponse) {
-		// No messages
-		return nil, nil
-	} else if err != nil {
+	if err != nil {
 		w.logger.Error("error querying storenode", zap.String("requestID", hexutil.Encode(requestID)), zap.String("peerID", peerID.String()), zap.Error(err))
 		signal.SendHistoricMessagesRequestFailed(requestID, peerID, err)
 		return nil, err


### PR DESCRIPTION
Also removes an err check which is not necessary anymore as go-waku does not generate an err anymore when the response contains no messages