### PR TITLE
feat: convert history balance tokens to fiat

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/bridge"
 	"github.com/status-im/status-go/services/wallet/chain"
 	"github.com/status-im/status-go/services/wallet/history"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/services/wallet/transfer"
 )
@@ -129,27 +130,15 @@ func (api *API) GetTokensBalancesForChainIDs(ctx context.Context, chainIDs []uin
 	return api.s.tokenManager.GetBalances(ctx, clients, accounts, addresses)
 }
 
-func (api *API) StartBalanceHistory(ctx context.Context) error {
-	api.s.history.StartBalanceHistory()
-	return nil
-}
-
-func (api *API) StopBalanceHistory(ctx context.Context) error {
-	api.s.history.Stop()
-	return nil
-}
-
 func (api *API) UpdateVisibleTokens(ctx context.Context, symbols []string) error {
 	api.s.history.UpdateVisibleTokens(symbols)
 	return nil
 }
 
 // GetBalanceHistory retrieves token balance history for token identity on multiple chains
-// TODO: pass parameters by GetBalanceHistoryParameters struct
-// TODO: expose endTimestamp parameter
-func (api *API) GetBalanceHistory(ctx context.Context, chainIDs []uint64, address common.Address, currency string, timeInterval history.TimeInterval) ([]*history.DataPoint, error) {
+func (api *API) GetBalanceHistory(ctx context.Context, chainIDs []uint64, address common.Address, tokenSymbol string, currencySymbol string, timeInterval history.TimeInterval) ([]*history.ValuePoint, error) {
 	endTimestamp := time.Now().UTC().Unix()
-	return api.s.history.GetBalanceHistory(ctx, chainIDs, address, currency, endTimestamp, timeInterval)
+	return api.s.history.GetBalanceHistory(ctx, chainIDs, address, tokenSymbol, currencySymbol, endTimestamp, timeInterval)
 }
 
 func (api *API) GetTokens(ctx context.Context, chainID uint64) ([]*token.Token, error) {
@@ -353,24 +342,24 @@ func (api *API) GetCachedPrices(ctx context.Context) (map[string]map[string]floa
 	return api.s.priceManager.GetCachedPrices()
 }
 
-func (api *API) FetchMarketValues(ctx context.Context, symbols []string, currencies []string) (map[string]map[string]MarketCoinValues, error) {
+func (api *API) FetchMarketValues(ctx context.Context, symbols []string, currencies []string) (map[string]map[string]thirdparty.MarketCoinValues, error) {
 	log.Debug("call to FetchMarketValues")
-	return api.s.cryptoCompare.fetchTokenMarketValues(symbols, currencies)
+	return api.s.cryptoCompare.FetchTokenMarketValues(symbols, currencies)
 }
 
-func (api *API) GetHourlyMarketValues(ctx context.Context, symbol string, currency string, limit int, aggregate int) ([]TokenHistoricalPairs, error) {
+func (api *API) GetHourlyMarketValues(ctx context.Context, symbol string, currency string, limit int, aggregate int) ([]thirdparty.TokenHistoricalPairs, error) {
 	log.Debug("call to GetHourlyMarketValues")
-	return api.s.cryptoCompare.fetchHourlyMarketValues(symbol, currency, limit, aggregate)
+	return api.s.cryptoCompare.FetchHourlyMarketValues(symbol, currency, limit, aggregate)
 }
 
-func (api *API) GetDailyMarketValues(ctx context.Context, symbol string, currency string, limit int, allData bool, aggregate int) ([]TokenHistoricalPairs, error) {
+func (api *API) GetDailyMarketValues(ctx context.Context, symbol string, currency string, limit int, allData bool, aggregate int) ([]thirdparty.TokenHistoricalPairs, error) {
 	log.Debug("call to GetDailyMarketValues")
-	return api.s.cryptoCompare.fetchDailyMarketValues(symbol, currency, limit, allData, aggregate)
+	return api.s.cryptoCompare.FetchDailyMarketValues(symbol, currency, limit, allData, aggregate)
 }
 
-func (api *API) FetchTokenDetails(ctx context.Context, symbols []string) (map[string]Coin, error) {
+func (api *API) FetchTokenDetails(ctx context.Context, symbols []string) (map[string]thirdparty.Coin, error) {
 	log.Debug("call to FetchTokenDetails")
-	return api.s.cryptoCompare.fetchTokenDetails(symbols)
+	return api.s.cryptoCompare.FetchTokenDetails(symbols)
 }
 
 func (api *API) GetSuggestedFees(ctx context.Context, chainID uint64) (*SuggestedFees, error) {

--- a/services/wallet/history/balance.go
+++ b/services/wallet/history/balance.go
@@ -87,9 +87,9 @@ type DataSource interface {
 }
 
 type DataPoint struct {
-	Value       *hexutil.Big `json:"value"`
-	Timestamp   uint64       `json:"time"`
-	BlockNumber *hexutil.Big `json:"blockNumber"`
+	Balance     *hexutil.Big
+	Timestamp   uint64
+	BlockNumber *hexutil.Big
 }
 
 func strideDuration(timeInterval TimeInterval) time.Duration {
@@ -113,7 +113,7 @@ func (b *Balance) fetchAndCache(ctx context.Context, source DataSource, address 
 				return nil, nil, err
 			}
 			return &DataPoint{
-				Value:       (*hexutil.Big)(cached[0].balance),
+				Balance:     (*hexutil.Big)(cached[0].balance),
 				Timestamp:   uint64(cached[0].timestamp),
 				BlockNumber: (*hexutil.Big)(cached[0].block),
 			}, blockNo, nil
@@ -156,7 +156,7 @@ func (b *Balance) fetchAndCache(ctx context.Context, source DataSource, address 
 	}
 
 	var dataPoint DataPoint
-	dataPoint.Value = (*hexutil.Big)(currentBalance)
+	dataPoint.Balance = (*hexutil.Big)(currentBalance)
 	dataPoint.Timestamp = uint64(timestamp)
 	return &dataPoint, blockNo, nil
 }
@@ -241,7 +241,7 @@ func (b *Balance) get(ctx context.Context, chainID uint64, currency string, addr
 	points := make([]*DataPoint, 0, len(cached)+1)
 	for _, entry := range cached {
 		dataPoint := DataPoint{
-			Value:       (*hexutil.Big)(entry.balance),
+			Balance:     (*hexutil.Big)(entry.balance),
 			Timestamp:   uint64(entry.timestamp),
 			BlockNumber: (*hexutil.Big)(entry.block),
 		}
@@ -254,7 +254,7 @@ func (b *Balance) get(ctx context.Context, chainID uint64, currency string, addr
 	}
 	if len(lastCached) > 0 && len(cached) > 0 && lastCached[0].block.Cmp(cached[len(cached)-1].block) > 0 {
 		points = append(points, &DataPoint{
-			Value:       (*hexutil.Big)(lastCached[0].balance),
+			Balance:     (*hexutil.Big)(lastCached[0].balance),
 			Timestamp:   uint64(lastCached[0].timestamp),
 			BlockNumber: (*hexutil.Big)(lastCached[0].block),
 		})

--- a/services/wallet/history/balance_test.go
+++ b/services/wallet/history/balance_test.go
@@ -497,7 +497,7 @@ func TestBalanceHistoryValidateBalanceValuesAndCacheHit(t *testing.T) {
 				n := reqBlkNos[i]
 
 				if value, contains := requestedBalance[n]; contains {
-					require.Equal(t, value.Cmp(balanceData[resIdx].Value.ToInt()), 0)
+					require.Equal(t, value.Cmp(balanceData[resIdx].Balance.ToInt()), 0)
 					resIdx++
 				}
 				blockHeaderRequestCount := dataSource.requestedBlocks[n].headerInfoRequests
@@ -508,7 +508,7 @@ func TestBalanceHistoryValidateBalanceValuesAndCacheHit(t *testing.T) {
 
 			// Check that balance values are in order
 			for i := 1; i < len(balanceData); i++ {
-				require.Greater(t, balanceData[i].Value.ToInt().Cmp(balanceData[i-1].Value.ToInt()), 0, "expected balanceData[%d] > balanceData[%d] for interval %d", i, i-1, testInput.interval)
+				require.Greater(t, balanceData[i].Balance.ToInt().Cmp(balanceData[i-1].Balance.ToInt()), 0, "expected balanceData[%d] > balanceData[%d] for interval %d", i, i-1, testInput.interval)
 			}
 			requestedBalance = make(map[int64]*big.Int)
 		})

--- a/services/wallet/history/exchange.go
+++ b/services/wallet/history/exchange.go
@@ -1,0 +1,176 @@
+package history
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+type tokenType = string
+type currencyType = string
+type yearType = int
+
+type allTimeEntry struct {
+	value          float32
+	startTimestamp int64
+	endTimestamp   int64
+}
+
+// Exchange caches conversion rates in memory on a daily basis
+type Exchange struct {
+	// year map keeps a list of values with days as index in the slice for the corresponding year (key) starting from the first to the last available
+	cache map[tokenType]map[currencyType]map[yearType][]float32
+	// special case for all time information
+	allTimeCache map[tokenType]map[currencyType][]allTimeEntry
+	fetchMutex   sync.Mutex
+
+	cryptoCompare *thirdparty.CryptoCompare
+}
+
+func NewExchange(cryptoCompare *thirdparty.CryptoCompare) *Exchange {
+	return &Exchange{
+		cache:         make(map[tokenType]map[currencyType]map[yearType][]float32),
+		cryptoCompare: cryptoCompare,
+	}
+}
+
+// GetExchangeRate returns the exchange rate from token to currency in the day of the given date
+// if none exists returns "missing <element>" error
+func (e *Exchange) GetExchangeRateForDay(token tokenType, currency currencyType, date time.Time) (float32, error) {
+	e.fetchMutex.Lock()
+	defer e.fetchMutex.Unlock()
+
+	currencyMap, found := e.cache[token]
+	if !found {
+		return 0, errors.New("missing token")
+	}
+
+	yearsMap, found := currencyMap[currency]
+	if !found {
+		return 0, errors.New("missing currency")
+	}
+
+	year := date.Year()
+	valueForDays, found := yearsMap[year]
+	if !found {
+		// Search closest in all time
+		allCurrencyMap, found := e.allTimeCache[token]
+		if !found {
+			return 0, errors.New("missing token in all time data")
+		}
+
+		allYearsMap, found := allCurrencyMap[currency]
+		if !found {
+			return 0, errors.New("missing currency in all time data")
+		}
+		for _, entry := range allYearsMap {
+			if entry.startTimestamp <= date.Unix() && entry.endTimestamp > date.Unix() {
+				return entry.value, nil
+			}
+		}
+		return 0, errors.New("missing entry")
+	}
+
+	day := date.YearDay()
+	if day >= len(valueForDays) {
+		return 0, errors.New("missing day")
+	}
+	return valueForDays[day], nil
+}
+
+// fetchAndCacheRates fetches and in memory cache exchange rates for this and last year
+func (e *Exchange) FetchAndCacheMissingRates(token tokenType, currency currencyType) error {
+	// Protect REST calls also to prevent fetching the same token/currency twice
+	e.fetchMutex.Lock()
+	defer e.fetchMutex.Unlock()
+
+	// Allocate missing values
+	currencyMap, found := e.cache[token]
+	if !found {
+		currencyMap = make(map[currencyType]map[yearType][]float32)
+		e.cache[token] = currencyMap
+	}
+
+	yearsMap, found := currencyMap[currency]
+	if !found {
+		yearsMap = make(map[yearType][]float32)
+		currencyMap[currency] = yearsMap
+	}
+
+	currentTime := time.Now().UTC()
+	endOfPrevYearTime := time.Date(currentTime.Year()-1, 12, 31, 23, 0, 0, 0, time.UTC)
+
+	daysToFetch := extendDaysSliceForYear(yearsMap, endOfPrevYearTime)
+
+	curYearTime := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, time.UTC)
+	daysToFetch += extendDaysSliceForYear(yearsMap, curYearTime)
+	if daysToFetch == 0 {
+		return nil
+	}
+
+	res, err := e.cryptoCompare.FetchDailyMarketValues(token, currency, daysToFetch, false, 1)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(res); i++ {
+		t := time.Unix(res[i].Timestamp, 0).UTC()
+		yearDayIndex := t.YearDay() - 1
+		yearValues, found := yearsMap[t.Year()]
+		if found && yearDayIndex < len(yearValues) {
+			yearValues[yearDayIndex] = float32(res[i].Value)
+		}
+	}
+
+	// Fetch all time
+	allTime, err := e.cryptoCompare.FetchDailyMarketValues(token, currency, 1, true, 30)
+	if err != nil {
+		return err
+	}
+
+	if e.allTimeCache == nil {
+		e.allTimeCache = make(map[tokenType]map[currencyType][]allTimeEntry)
+	}
+	_, found = e.allTimeCache[token]
+	if !found {
+		e.allTimeCache[token] = make(map[currencyType][]allTimeEntry)
+	}
+
+	// No benefit to fetch intermendiate values, overwrite historical
+	e.allTimeCache[token][currency] = make([]allTimeEntry, 0)
+
+	for i := 0; i < len(allTime) && allTime[i].Timestamp < res[0].Timestamp; i++ {
+		if allTime[i].Value > 0 {
+			var endTimestamp int64
+			if i+1 < len(allTime) {
+				endTimestamp = allTime[i+1].Timestamp
+			} else {
+				endTimestamp = res[0].Timestamp
+			}
+			e.allTimeCache[token][currency] = append(e.allTimeCache[token][currency],
+				allTimeEntry{
+					value:          float32(allTime[i].Value),
+					startTimestamp: allTime[i].Timestamp,
+					endTimestamp:   endTimestamp,
+				})
+		}
+	}
+
+	return nil
+}
+
+func extendDaysSliceForYear(yearsMap map[yearType][]float32, untilTime time.Time) (daysToFetch int) {
+	year := untilTime.Year()
+	_, found := yearsMap[year]
+	if !found {
+		yearsMap[year] = make([]float32, untilTime.YearDay())
+		return untilTime.YearDay()
+	}
+
+	// Just extend the slice if needed
+	missingDays := untilTime.YearDay() - len(yearsMap[year])
+	yearsMap[year] = append(yearsMap[year], make([]float32, missingDays)...)
+	return missingDays
+}

--- a/services/wallet/price.go
+++ b/services/wallet/price.go
@@ -4,21 +4,23 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	"github.com/status-im/status-go/services/wallet/thirdparty"
 )
 
 type PricesPerTokenAndCurrency = map[string]map[string]float64
 
 type PriceManager struct {
 	db            *sql.DB
-	cryptoCompare *CryptoCompare
+	cryptoCompare *thirdparty.CryptoCompare
 }
 
-func NewPriceManager(db *sql.DB, cryptoCompare *CryptoCompare) *PriceManager {
+func NewPriceManager(db *sql.DB, cryptoCompare *thirdparty.CryptoCompare) *PriceManager {
 	return &PriceManager{db: db, cryptoCompare: cryptoCompare}
 }
 
 func (pm *PriceManager) FetchPrices(symbols []string, currencies []string) (PricesPerTokenAndCurrency, error) {
-	result, err := pm.cryptoCompare.fetchPrices(symbols, currencies)
+	result, err := pm.cryptoCompare.FetchPrices(symbols, currencies)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/price_test.go
+++ b/services/wallet/price_test.go
@@ -6,12 +6,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
 )
 
 func setupTestPriceDB(t *testing.T) (*PriceManager, func()) {
 	db, err := appdatabase.InitializeDB(":memory:", "wallet-price-tests-", 1)
 	require.NoError(t, err)
-	return NewPriceManager(db, NewCryptoCompare()), func() {
+	return NewPriceManager(db, thirdparty.NewCryptoCompare()), func() {
 		require.NoError(t, db.Close())
 	}
 }

--- a/services/wallet/thirdparty/cryptocompare.go
+++ b/services/wallet/thirdparty/cryptocompare.go
@@ -1,4 +1,4 @@
-package wallet
+package thirdparty
 
 import (
 	"encoding/json"
@@ -119,7 +119,7 @@ func (c *CryptoCompare) DoQuery(url string) (*http.Response, error) {
 	return resp, nil
 }
 
-func (c *CryptoCompare) fetchPrices(symbols []string, currencies []string) (map[string]map[string]float64, error) {
+func (c *CryptoCompare) FetchPrices(symbols []string, currencies []string) (map[string]map[string]float64, error) {
 	chunks := chunkSymbols(symbols)
 	result := make(map[string]map[string]float64)
 	realCurrencies := renameSymbols(currencies)
@@ -153,7 +153,7 @@ func (c *CryptoCompare) fetchPrices(symbols []string, currencies []string) (map[
 	return result, nil
 }
 
-func (c *CryptoCompare) fetchTokenDetails(symbols []string) (map[string]Coin, error) {
+func (c *CryptoCompare) FetchTokenDetails(symbols []string) (map[string]Coin, error) {
 	url := fmt.Sprintf("%s/data/all/coinlist", cryptocompareURL)
 	resp, err := c.DoQuery(url)
 	if err != nil {
@@ -181,7 +181,7 @@ func (c *CryptoCompare) fetchTokenDetails(symbols []string) (map[string]Coin, er
 	return coins, nil
 }
 
-func (c *CryptoCompare) fetchTokenMarketValues(symbols []string, currencies []string) (map[string]map[string]MarketCoinValues, error) {
+func (c *CryptoCompare) FetchTokenMarketValues(symbols []string, currencies []string) (map[string]map[string]MarketCoinValues, error) {
 	realCurrencies := renameSymbols(currencies)
 	realSymbols := renameSymbols(symbols)
 	item := map[string]map[string]MarketCoinValues{}
@@ -214,7 +214,7 @@ func (c *CryptoCompare) fetchTokenMarketValues(symbols []string, currencies []st
 	return item, nil
 }
 
-func (c *CryptoCompare) fetchHourlyMarketValues(symbol string, currency string, limit int, aggregate int) ([]TokenHistoricalPairs, error) {
+func (c *CryptoCompare) FetchHourlyMarketValues(symbol string, currency string, limit int, aggregate int) ([]TokenHistoricalPairs, error) {
 	item := []TokenHistoricalPairs{}
 
 	url := fmt.Sprintf("%s/data/v2/histohour?fsym=%s&tsym=%s&aggregate=%d&limit=%d&extraParams=Status.im", cryptocompareURL, getRealSymbol(symbol), currency, aggregate, limit)
@@ -240,7 +240,7 @@ func (c *CryptoCompare) fetchHourlyMarketValues(symbol string, currency string, 
 	return item, nil
 }
 
-func (c *CryptoCompare) fetchDailyMarketValues(symbol string, currency string, limit int, allData bool, aggregate int) ([]TokenHistoricalPairs, error) {
+func (c *CryptoCompare) FetchDailyMarketValues(symbol string, currency string, limit int, allData bool, aggregate int) ([]TokenHistoricalPairs, error) {
 	item := []TokenHistoricalPairs{}
 
 	url := fmt.Sprintf("%s/data/v2/histoday?fsym=%s&tsym=%s&aggregate=%d&limit=%d&allData=%v&extraParams=Status.im", cryptocompareURL, getRealSymbol(symbol), currency, aggregate, limit, allData)


### PR DESCRIPTION
Add `history.exchange` sub-package with the following responsibilities.

- Fetch and cache daily exchange rates for tokens - partial update if missing data starting from yesterday (going backward)
- Fetches the price of the token after merging entries for the selected chains
- Implements all-time fetching particular case

`history. service` package changes

- Return `ValuePoint` instead of `DataPoint` - contains the value in fiat as float64 instead
- Convert merged values from tokens balance (wei) to fiat

Other changes

- Move Cryptocompare implementation from `wallet` to `thirdparty` package to avoid recursive import
- Rename `DataPoint.Value` to `DataPoint.Balance`
- Move start/stop balance history to startWallet/stopWallet
- Don't merge entries for one chain and preserve original data

Closes [#9279](https://github.com/status-im/status-desktop/issues/9279)
