### PR TITLE
fix: fixes issues on mobile app side after updating `ConvertToKeycardAccount`

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -771,7 +771,7 @@ func TestConvertAccount(t *testing.T) {
 	}
 
 	// Converting to a keycard account
-	err = backend.ConvertToKeycardAccount(keycardAccount, keycardSettings, password, keycardPassword)
+	err = backend.ConvertToKeycardAccountDesktop(keycardAccount, keycardSettings, password, keycardPassword)
 	require.NoError(t, err)
 
 	// Validating results of converting to a keycard account.

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -828,7 +828,10 @@ func ChangeDatabasePassword(KeyUID, password, newPassword string) string {
 	return makeJSONResponse(nil)
 }
 
-func ConvertToKeycardAccount(accountData, settingsJSON, password, newPassword string) string {
+// Adding this function to fix issues we have for mobile app after adding `ConvertToKeycardAccountDesktop`.
+// Please if you need this function consider using `ConvertToKeycardAccountDesktop` instead.
+// At the end would be good to have only a single function for converting an account to a keycard account.
+func ConvertToKeycardAccount(keyStoreDir, accountData, settingsJSON, password, newPassword string) string {
 	var account multiaccounts.Account
 	err := json.Unmarshal([]byte(accountData), &account)
 	if err != nil {
@@ -840,7 +843,26 @@ func ConvertToKeycardAccount(accountData, settingsJSON, password, newPassword st
 		return makeJSONResponse(err)
 	}
 
-	err = statusBackend.ConvertToKeycardAccount(account, settings, password, newPassword)
+	err = statusBackend.ConvertToKeycardAccount(keyStoreDir, account, settings, password, newPassword)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	return makeJSONResponse(nil)
+}
+
+func ConvertToKeycardAccountDesktop(accountData, settingsJSON, password, newPassword string) string {
+	var account multiaccounts.Account
+	err := json.Unmarshal([]byte(accountData), &account)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	var settings settings.Settings
+	err = json.Unmarshal([]byte(settingsJSON), &settings)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = statusBackend.ConvertToKeycardAccountDesktop(account, settings, password, newPassword)
 	if err != nil {
 		return makeJSONResponse(err)
 	}

--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -78,7 +78,7 @@ func (api *API) DeleteAccount(ctx context.Context, address types.Address) error 
 		return err
 	}
 	if acc.Type != accounts.AccountTypeWatch {
-		err = api.manager.DeleteAccount(address, "")
+		err = api.manager.DeleteAccount(api.config.KeyStoreDir, address, true)
 		var e *account.ErrCannotLocateKeyFile
 		if err != nil && !errors.As(err, &e) {
 			return err
@@ -444,7 +444,7 @@ func (api *API) AddMigratedKeyPair(ctx context.Context, kcUID string, kpName str
 	for _, addr := range addresses {
 		// This action deletes an account from the keystore, no need to check for error in this context here, cause if this
 		// action fails from whichever reason the account is still successfully migrated since keystore won't be used any more.
-		_ = api.manager.DeleteAccount(addr, "")
+		_ = api.manager.DeleteAccountNew(addr, "")
 	}
 	return nil
 }


### PR DESCRIPTION
An update of `ConvertToKeycardAccount` function caused some issues on the mobile app side. This commit fixes that trying to satisfy both sides, desktop and mobile:
- `ConvertToKeycardAccount` function is now the same as it was
- updated `ConvertToKeycardAccount` function (which introduced some changes for the desktop app needs) is not renamed to `ConvertToKeycardAccountDesktop`
- `DeleteAccount` function is now the same as it was
- updated `DeleteAccount` function is renamed to `DeleteAccountNew`