### PR TITLE
Remove implicit marking messages as seen based on clock

### DIFF
--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1610,10 +1610,6 @@ func (m *Messenger) HandleChatMessage(state *ReceivedMessageState) error {
 		return err // matchChatEntity returns a descriptive error message
 	}
 
-	if chat.ReadMessagesAtClockValue >= receivedMessage.Clock {
-		receivedMessage.Seen = true
-	}
-
 	allowed, err := m.isMessageAllowedFrom(state.CurrentMessageState.Contact.ID, chat)
 	if err != nil {
 		return err


### PR DESCRIPTION
Need for https://github.com/status-im/status-desktop/pull/9432

This code forced unseen messages coming out of order (by clock) become seen

<img width="1262" alt="Screenshot 2023-02-06 at 17 22 30" src="https://user-images.githubusercontent.com/2522130/217004150-3b827813-87d9-4230-9640-fedba7e76400.png">
