### PR TITLE
fix(LinksPreview): Validate image links in the links preview request

### DIFF
--- a/protocol/urls/urls.go
+++ b/protocol/urls/urls.go
@@ -193,9 +193,23 @@ func GetGenericLinkPreviewData(link string) (previewData LinkPreviewData, err er
 }
 
 func FakeGenericImageLinkPreviewData(title string, link string) (previewData LinkPreviewData, err error) {
-	u, _ := url.Parse(link)
+	url, err := url.Parse(link)
+	if err != nil {
+		return previewData, fmt.Errorf("Failed to parse link %s", link)
+	}
+
+	res, err := httpClient.Head(link)
+	if err != nil {
+		return previewData, fmt.Errorf("Failed to get HEAD from link %s", link)
+	}
+
+	if res.StatusCode != 200 {
+		return previewData, fmt.Errorf("Image link %s is not available", link)
+	}
+
 	previewData.Title = title
-	previewData.Site = strings.ToLower(u.Hostname())
+	previewData.Site = strings.ToLower(url.Hostname())
+	previewData.ContentType = res.Header.Get("Content-type")
 	previewData.ThumbnailURL = link
 	previewData.Height = 0
 	previewData.Width = 0


### PR DESCRIPTION
Motivated by: [9084](https://github.com/status-im/status-desktop/pull/9084)

While we don't request preview data from Tenor because the url itself will contain the GIF image, we still need to validate the url in the preview request. This is done using a HEAD request where we expect the response status code to be 200 OK. At the same time we will add the content type to the preview response.

Companion PR [9428](https://github.com/status-im/status-desktop/pull/9428)
