### PR TITLE
fix(api): ensure getRecentGifs doesn't error when response is empty

### DIFF
--- a/services/gif/gif.go
+++ b/services/gif/gif.go
@@ -149,11 +149,14 @@ func (api *API) GetFavoriteGifs() (favoriteGifs []Gif, err error) {
 	if err != nil {
 		return nil, err
 	}
+	favoriteGifs = make([]Gif, 0)
 	savedFavGifs := []Gif{}
-	err = json.Unmarshal(gifs, &savedFavGifs)
-	if err != nil {
-		return nil, err
+	if len(gifs) > 0 {
+		err = json.Unmarshal(gifs, &savedFavGifs)
+		if err != nil {
+			return nil, err
+		}
+		favoriteGifs = savedFavGifs
 	}
-	favoriteGifs = savedFavGifs
 	return favoriteGifs, nil
 }

--- a/services/gif/gif.go
+++ b/services/gif/gif.go
@@ -131,12 +131,15 @@ func (api *API) GetRecentGifs() (recentGifs []Gif, err error) {
 	if err != nil {
 		return nil, err
 	}
+	recentGifs = make([]Gif, 0)
 	savedRecentGifs := []Gif{}
-	err = json.Unmarshal(gifs, &savedRecentGifs)
-	if err != nil {
-		return nil, err
+	if len(gifs) > 0 {
+		err = json.Unmarshal(gifs, &savedRecentGifs)
+		if err != nil {
+			return nil, err
+		}
+		recentGifs = savedRecentGifs
 	}
-	recentGifs = savedRecentGifs
 	return recentGifs, nil
 }
 


### PR DESCRIPTION
Because the BLOB retrieved from the database can be empty, umarshalling the data into JSON causes an error.

The API should simply return an empty list of there are no recent gifs.

