### PR TITLE
take care of kdf when local pairing

### DIFF
--- a/multiaccounts/database.go
+++ b/multiaccounts/database.go
@@ -208,7 +208,7 @@ func (db *Database) GetAccounts() (rst []Account, err error) {
 }
 
 func (db *Database) GetAccount(keyUID string) (*Account, error) {
-	rows, err := db.db.Query("SELECT  a.name, a.loginTimestamp, a.identicon, a.colorHash, a.colorId, a.keycardPairing, a.keyUid, ii.key_uid, ii.name, ii.image_payload, ii.width, ii.height, ii.file_size, ii.resize_target, ii.clock FROM accounts AS a LEFT JOIN identity_images AS ii ON ii.key_uid = a.keyUid WHERE a.keyUid = ? ORDER BY loginTimestamp DESC", keyUID)
+	rows, err := db.db.Query("SELECT  a.name, a.loginTimestamp, a.identicon, a.colorHash, a.colorId, a.keycardPairing, a.keyUid, a.kdfIterations, ii.key_uid, ii.name, ii.image_payload, ii.width, ii.height, ii.file_size, ii.resize_target, ii.clock FROM accounts AS a LEFT JOIN identity_images AS ii ON ii.key_uid = a.keyUid WHERE a.keyUid = ? ORDER BY loginTimestamp DESC", keyUID)
 	if err != nil {
 		return nil, err
 	}
@@ -241,6 +241,7 @@ func (db *Database) GetAccount(keyUID string) (*Account, error) {
 			&accColorID,
 			&acc.KeycardPairing,
 			&acc.KeyUID,
+			&acc.KDFIterations,
 			&iiKeyUID,
 			&iiName,
 			&ii.Payload,
@@ -281,7 +282,8 @@ func (db *Database) GetAccount(keyUID string) (*Account, error) {
 	return acc, nil
 }
 
-func (db *Database) SaveAccount(account Account) error {
+// SaveAccount we use pointer to account to be able to get updated KDFIterations
+func (db *Database) SaveAccount(account *Account) error {
 	colorHash, err := json.Marshal(account.ColorHash)
 	if err != nil {
 		return err

--- a/multiaccounts/database_test.go
+++ b/multiaccounts/database_test.go
@@ -27,7 +27,7 @@ func TestAccounts(t *testing.T) {
 	db, stop := setupTestDB(t)
 	defer stop()
 	expected := Account{Name: "string", KeyUID: "string", ColorHash: ColourHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10, KDFIterations: sqlite.ReducedKDFIterationsNumber}
-	require.NoError(t, db.SaveAccount(expected))
+	require.NoError(t, db.SaveAccount(&expected))
 	accounts, err := db.GetAccounts()
 	require.NoError(t, err)
 	require.Len(t, accounts, 1)
@@ -38,7 +38,7 @@ func TestAccountsUpdate(t *testing.T) {
 	db, stop := setupTestDB(t)
 	defer stop()
 	expected := Account{KeyUID: "string", ColorHash: ColourHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10, KDFIterations: sqlite.ReducedKDFIterationsNumber}
-	require.NoError(t, db.SaveAccount(expected))
+	require.NoError(t, db.SaveAccount(&expected))
 	expected.Name = "chars"
 	require.NoError(t, db.UpdateAccount(expected))
 	rst, err := db.GetAccounts()
@@ -53,7 +53,8 @@ func TestLoginUpdate(t *testing.T) {
 
 	accounts := []Account{{Name: "first", KeyUID: "0x1", KDFIterations: sqlite.ReducedKDFIterationsNumber}, {Name: "second", KeyUID: "0x2", KDFIterations: sqlite.ReducedKDFIterationsNumber}}
 	for _, acc := range accounts {
-		require.NoError(t, db.SaveAccount(acc))
+		toSave := acc
+		require.NoError(t, db.SaveAccount(&toSave))
 	}
 	require.NoError(t, db.UpdateAccountTimestamp(accounts[0].KeyUID, 100))
 	require.NoError(t, db.UpdateAccountTimestamp(accounts[1].KeyUID, 10))
@@ -158,7 +159,8 @@ func TestDatabase_GetAccountsWithIdentityImages(t *testing.T) {
 	expected := `[{"name":"string","timestamp":100,"identicon":"data","colorHash":null,"colorId":0,"keycard-pairing":"","key-uid":"0xdeadbeef","images":[{"keyUid":"0xdeadbeef","type":"large","uri":"data:image/png;base64,iVBORw0KGgoAAAANSUg=","width":240,"height":300,"fileSize":1024,"resizeTarget":240,"clock":0},{"keyUid":"0xdeadbeef","type":"thumbnail","uri":"data:image/jpeg;base64,/9j/2wCEAFA3PEY8MlA=","width":80,"height":80,"fileSize":256,"resizeTarget":80,"clock":0}],"kdfIterations":3200},{"name":"string","timestamp":10,"identicon":"","colorHash":null,"colorId":0,"keycard-pairing":"","key-uid":"0x1337beef","images":null,"kdfIterations":3200},{"name":"string","timestamp":0,"identicon":"","colorHash":null,"colorId":0,"keycard-pairing":"","key-uid":"0x1337beef2","images":null,"kdfIterations":3200},{"name":"string","timestamp":0,"identicon":"","colorHash":null,"colorId":0,"keycard-pairing":"","key-uid":"0x1337beef3","images":[{"keyUid":"0x1337beef3","type":"large","uri":"data:image/png;base64,iVBORw0KGgoAAAANSUg=","width":240,"height":300,"fileSize":1024,"resizeTarget":240,"clock":0},{"keyUid":"0x1337beef3","type":"thumbnail","uri":"data:image/jpeg;base64,/9j/2wCEAFA3PEY8MlA=","width":80,"height":80,"fileSize":256,"resizeTarget":80,"clock":0}],"kdfIterations":3200}]`
 
 	for _, a := range testAccs {
-		require.NoError(t, db.SaveAccount(a))
+		toSave := a
+		require.NoError(t, db.SaveAccount(&toSave))
 	}
 
 	seedTestDBWithIdentityImages(t, db, keyUID)
@@ -182,8 +184,8 @@ func TestDatabase_GetAccount(t *testing.T) {
 	db, stop := setupTestDB(t)
 	defer stop()
 
-	expected := Account{Name: "string", KeyUID: keyUID, ColorHash: ColourHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10}
-	require.NoError(t, db.SaveAccount(expected))
+	expected := Account{Name: "string", KeyUID: keyUID, ColorHash: ColourHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10, KDFIterations: sqlite.ReducedKDFIterationsNumber}
+	require.NoError(t, db.SaveAccount(&expected))
 
 	account, err := db.GetAccount(expected.KeyUID)
 	require.NoError(t, err)
@@ -201,7 +203,7 @@ func TestDatabase_SaveAccountWithIdentityImages(t *testing.T) {
 		ColorID:   10,
 		Images:    images.SampleIdentityImages(),
 	}
-	require.NoError(t, db.SaveAccount(expected))
+	require.NoError(t, db.SaveAccount(&expected))
 
 	account, err := db.GetAccount(expected.KeyUID)
 	require.NoError(t, err)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1896,7 +1896,7 @@ func (m *Messenger) handleSyncSetting(messageState *ReceivedMessageState, messag
 		}
 		if oldDisplayName != message.GetValueString() {
 			m.account.Name = message.GetValueString()
-			err = m.multiAccounts.SaveAccount(*m.account)
+			err = m.multiAccounts.SaveAccount(m.account)
 			if err != nil {
 				return err
 			}

--- a/protocol/messenger_identity.go
+++ b/protocol/messenger_identity.go
@@ -64,7 +64,7 @@ func (m *Messenger) SetDisplayName(displayName string, publishChange bool) error
 	}
 
 	m.account.Name = displayName // We might need to do the same when syncing settings?
-	err = m.multiAccounts.SaveAccount(*m.account)
+	err = m.multiAccounts.SaveAccount(m.account)
 	if err != nil {
 		return err
 	}

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -122,7 +122,7 @@ func (s *MessengerProfilePictureHandlerSuite) setupMultiAccount(m *Messenger) {
 	keyUID := s.generateKeyUID(&m.identity.PublicKey)
 	m.account = &multiaccounts.Account{KeyUID: keyUID}
 
-	err := m.multiAccounts.SaveAccount(multiaccounts.Account{Name: "string", KeyUID: keyUID})
+	err := m.multiAccounts.SaveAccount(&multiaccounts.Account{Name: "string", KeyUID: keyUID})
 	s.NoError(err)
 }
 

--- a/server/pairing/payload_manager.go
+++ b/server/pairing/payload_manager.go
@@ -512,7 +512,7 @@ func (apr *AccountPayloadRepository) storeKeys(keyStorePath string) error {
 }
 
 func (apr *AccountPayloadRepository) storeMultiAccount() error {
-	return apr.multiaccountsDB.SaveAccount(*apr.multiaccount)
+	return apr.multiaccountsDB.SaveAccount(apr.multiaccount)
 }
 
 type RawMessagePayloadManager struct {

--- a/server/pairing/payload_manager_test.go
+++ b/server/pairing/payload_manager_test.go
@@ -129,7 +129,7 @@ func (pms *PayloadMarshallerSuite) SetupTest() {
 	}
 
 	initKeys(pms.T(), keystore1)
-	err := db1.SaveAccount(expected)
+	err := db1.SaveAccount(&expected)
 	pms.Require().NoError(err)
 
 	pms.config1 = &AccountPayloadManagerConfig{


### PR DESCRIPTION
when doing local pairing, use status-desktop as sender and mobile as receiver, use mobile to scan sync code, after done local pairing, it will create app-db file with KDFIterations 0, but `KDFIterations` in db on mobile is 3200, so it's inconsistent which shouldn't be, and when we login again, status-mobile won't pass KDFIterations stored in DB(3200) to status-go, we should use 3200(get from db) if status-mobile didn't pass this parameter when login
