### PR TITLE
Init keystore fix

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -929,10 +929,18 @@ func (b *GethStatusBackend) startNode(config *params.NodeConfig) (err error) {
 		return err
 	}
 
+	if b.accountManager.GetManager() == nil {
+		err = b.accountManager.InitKeystore(config.KeyStoreDir)
+		if err != nil {
+			return err
+		}
+	}
+
 	manager := b.accountManager.GetManager()
 	if manager == nil {
 		return errors.New("ethereum accounts.Manager is nil")
 	}
+
 	if err = b.statusNode.StartWithOptions(config, node.StartOptions{
 		// The peers discovery protocols are started manually after
 		// `node.ready` signal is sent.


### PR DESCRIPTION
We delegate to services to init the keystore file, but there's a race condition that can be triggered, whereby the keystore file is not initialized before login, and that results in the user not being able to login.

This commit changes the services so that the keystore is initialized before login, I have left also the code in services just to make sure nothing relies on it, but it could probably be removed. Initializing keystore twice seems like a noop if already initialized.

