### PR TITLE
Added timeout functionality to Servers

### DIFF
--- a/server/pairing/payload_manager.go
+++ b/server/pairing/payload_manager.go
@@ -61,6 +61,9 @@ type PayloadSourceConfig struct {
 	// they are required in other cases
 	KeyUID   string `json:"keyUID"`
 	Password string `json:"password"`
+
+	// Timeout the number of milliseconds after which the pairing server will automatically terminate
+	Timeout uint `json:"timeout"`
 }
 
 // AccountPayloadManagerConfig represents the initialisation parameters required for a AccountPayloadManager

--- a/server/pairing/server.go
+++ b/server/pairing/server.go
@@ -76,7 +76,7 @@ func NewPairingServer(backend *api.GethStatusBackend, config *Config) (*Server, 
 		return nil, err
 	}
 
-	return &Server{Server: server.NewServer(
+	s := &Server{Server: server.NewServer(
 		config.Cert,
 		config.Hostname,
 		nil,
@@ -88,7 +88,10 @@ func NewPairingServer(backend *api.GethStatusBackend, config *Config) (*Server, 
 		PayloadManager:           pm,
 		cookieStore:              cs,
 		rawMessagePayloadManager: rmpm,
-	}, nil
+	}
+	s.SetTimeout(config.Timeout)
+
+	return s, nil
 }
 
 // MakeConnectionParams generates a *ConnectionParams based on the Server's current state

--- a/server/pairing/server_pairing_test.go
+++ b/server/pairing/server_pairing_test.go
@@ -41,6 +41,39 @@ func (s *PairingServerSuite) TestMultiBackgroundForeground() {
 	s.Require().Regexp(regexp.MustCompile("(https://\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d{1,5})"), s.PS.MakeBaseURL().String()) // nolint: gosimple
 }
 
+func (s *PairingServerSuite) TestMultiTimeout() {
+	s.PS.SetTimeout(20)
+
+	err := s.PS.Start()
+	s.Require().NoError(err)
+
+	s.PS.ToBackground()
+	s.PS.ToForeground()
+	s.PS.ToBackground()
+	s.PS.ToBackground()
+	s.PS.ToForeground()
+	s.PS.ToForeground()
+
+	s.Require().Regexp(regexp.MustCompile("(https://\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:\\d{1,5})"), s.PS.MakeBaseURL().String()) // nolint: gosimple
+
+	time.Sleep(7 * time.Millisecond)
+	s.PS.ToBackground()
+	time.Sleep(7 * time.Millisecond)
+	s.PS.ToForeground()
+	time.Sleep(7 * time.Millisecond)
+	s.PS.ToBackground()
+	time.Sleep(7 * time.Millisecond)
+	s.PS.ToBackground()
+	time.Sleep(7 * time.Millisecond)
+	s.PS.ToForeground()
+	time.Sleep(7 * time.Millisecond)
+	s.PS.ToForeground()
+
+	// Wait for timeout to expire
+	time.Sleep(40 * time.Millisecond)
+	s.Require().False(s.PS.IsRunning())
+}
+
 func (s *PairingServerSuite) TestPairingServer_StartPairing() {
 	// Replace PairingServer.PayloadManager with a MockEncryptOnlyPayloadManager
 	pm, err := NewMockEncryptOnlyPayloadManager(s.EphemeralAES)

--- a/server/server.go
+++ b/server/server.go
@@ -75,9 +75,13 @@ func (s *Server) listenAndServe() {
 	}
 
 	s.isRunning = true
-	defer func() { s.isRunning = false }()
 
-	s.StartTimeout(func() { s.Stop() })
+	s.StartTimeout(func() {
+		err := s.Stop()
+		if err != nil {
+			s.logger.Error("PairingServer termination fail", zap.Error(err))
+		}
+	})
 
 	err = s.server.Serve(listener)
 	if err != http.ErrServerClosed {
@@ -88,6 +92,7 @@ func (s *Server) listenAndServe() {
 		}
 		return
 	}
+	s.isRunning = false
 }
 
 func (s *Server) resetServer() {

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,7 @@ func NewServer(cert *tls.Certificate, hostname string, afterPortChanged func(int
 		cert:           cert,
 		hostname:       hostname,
 		portManger:     newPortManager(logger.Named("Server"), afterPortChanged),
-		timeoutManager: newTimeoutManager(logger),
+		timeoutManager: newTimeoutManager(),
 	}
 }
 

--- a/server/timeout.go
+++ b/server/timeout.go
@@ -3,8 +3,6 @@ package server
 import (
 	"sync"
 	"time"
-
-	"go.uber.org/zap"
 )
 
 // timeoutManager represents a discrete encapsulation of timeout functionality.
@@ -20,15 +18,12 @@ type timeoutManager struct {
 	// exitQueue handles the cancel signal channels that circumvent timeout operations and prevent the
 	// execution of any `terminate` func()
 	exitQueue *exitQueueManager
-
-	logger *zap.Logger
 }
 
 // newTimeoutManager returns a fully qualified and initialised timeoutManager
-func newTimeoutManager(logger *zap.Logger) *timeoutManager {
+func newTimeoutManager() *timeoutManager {
 	return &timeoutManager{
-		exitQueue: &exitQueueManager{queue: []chan struct{}{}, logger: logger},
-		logger:    logger,
+		exitQueue: &exitQueueManager{queue: []chan struct{}{}},
 	}
 }
 
@@ -40,85 +35,58 @@ func (t *timeoutManager) SetTimeout(milliseconds uint) {
 // StartTimeout starts a timeout operation based on the set timeoutManager.timeout value
 // the given terminate func() will be executed once the timeout duration has passed
 func (t *timeoutManager) StartTimeout(terminate func()) {
-	t.logger.Debug("fired")
 	if t.timeout == 0 {
-		t.logger.Debug("t.timeout == 0")
 		return
 	}
-
-	t.logger.Debug("pre StopTimeout()")
 	t.StopTimeout()
-	t.logger.Debug("post StopTimeout()")
 
-	t.logger.Debug("pre t.run(terminate, exit)")
 	exit := make(chan struct{}, 1)
 	t.exitQueue.add(exit)
 	go t.run(terminate, exit)
-	t.logger.Debug("post t.run(terminate, exit)")
-
-	t.logger.Debug("end")
 }
 
 // StopTimeout terminates a timeout operation and exits gracefully
 func (t *timeoutManager) StopTimeout() {
-	t.logger.Debug("fired")
 	if t.timeout == 0 {
-		t.logger.Debug("t.timeout == 0")
 		return
 	}
-
-	t.logger.Debug("pre t.exitQueue.empty()")
 	t.exitQueue.empty()
-	t.logger.Debug("post t.exitQueue.empty()")
-
-	t.logger.Debug("end")
 }
 
 // run inits the main timeout run function that awaits for the exit command to be triggered or for the
 // timeout duration to elapse and trigger the parameter terminate function.
 func (t *timeoutManager) run(terminate func(), exit chan struct{}) {
-	t.logger.Debug("run fired", zap.Uint("t.timeout", t.timeout))
-
 	select {
 	case <-exit:
-		t.logger.Debug("<-exit sig")
 		return
 	case <-time.After(time.Duration(t.timeout) * time.Millisecond):
 		terminate()
-		t.logger.Debug("post terminate()")
 		return
 	}
 }
 
 // exitQueueManager
 type exitQueueManager struct {
-	logger    *zap.Logger
 	queue     []chan struct{}
 	queueLock sync.Mutex
 }
 
 // add handles new exit channels adding them to the exit queue
 func (e *exitQueueManager) add(exit chan struct{}) {
-	e.logger.Debug("fired")
 	e.queueLock.Lock()
 	defer e.queueLock.Unlock()
-	e.logger.Debug("", zap.Int("e.queue.len()", len(e.queue)))
 
 	e.queue = append(e.queue, exit)
-	e.logger.Debug("end", zap.Int("e.queue.len()", len(e.queue)))
 }
 
 // empty sends a signal to evert exit channel in the queue and then resets the queue
 func (e *exitQueueManager) empty() {
-	e.logger.Debug("fired")
 	e.queueLock.Lock()
 	defer e.queueLock.Unlock()
-	e.logger.Debug("", zap.Int("e.queue.len()", len(e.queue)))
 
 	for i := range e.queue {
 		e.queue[i] <- struct{}{}
 	}
 
 	e.queue = []chan struct{}{}
-	e.logger.Debug("end", zap.Int("e.queue.len()", len(e.queue)))
 }

--- a/server/timeout.go
+++ b/server/timeout.go
@@ -79,7 +79,7 @@ func (e *exitQueueManager) add(exit chan struct{}) {
 	e.queue = append(e.queue, exit)
 }
 
-// empty sends a signal to evert exit channel in the queue and then resets the queue
+// empty sends a signal to every exit channel in the queue and then resets the queue
 func (e *exitQueueManager) empty() {
 	e.queueLock.Lock()
 	defer e.queueLock.Unlock()

--- a/server/timeout.go
+++ b/server/timeout.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// timeoutManager represents a discrete encapsulation of timeout functionality.
+// this struct expose 3 functions:
+//  - SetTimeout
+//  - StartTimeout
+//  - StopTimeout
+type timeoutManager struct {
+	// timeout number of milliseconds the timeout operation will run before executing the `terminate` func()
+	// 0 represents an inactive timeout
+	timeout uint
+
+	// exitQueue handles the cancel signal channels that circumvent timeout operations and prevent the
+	// execution of any `terminate` func()
+	exitQueue *exitQueueManager
+
+	logger *zap.Logger
+}
+
+// newTimeoutManager returns a fully qualified and initialised timeoutManager
+func newTimeoutManager(logger *zap.Logger) *timeoutManager {
+	return &timeoutManager{
+		exitQueue: &exitQueueManager{queue: []chan struct{}{}, logger: logger},
+		logger:    logger,
+	}
+}
+
+// SetTimeout sets the value of the timeoutManager.timeout
+func (t *timeoutManager) SetTimeout(milliseconds uint) {
+	t.timeout = milliseconds
+}
+
+// StartTimeout starts a timeout operation based on the set timeoutManager.timeout value
+// the given terminate func() will be executed once the timeout duration has passed
+func (t *timeoutManager) StartTimeout(terminate func()) {
+	t.logger.Debug("fired")
+	if t.timeout == 0 {
+		t.logger.Debug("t.timeout == 0")
+		return
+	}
+
+	t.logger.Debug("pre StopTimeout()")
+	t.StopTimeout()
+	t.logger.Debug("post StopTimeout()")
+
+	t.logger.Debug("pre t.run(terminate, exit)")
+	exit := make(chan struct{}, 1)
+	t.exitQueue.add(exit)
+	go t.run(terminate, exit)
+	t.logger.Debug("post t.run(terminate, exit)")
+
+	t.logger.Debug("end")
+}
+
+// StopTimeout terminates a timeout operation and exits gracefully
+func (t *timeoutManager) StopTimeout() {
+	t.logger.Debug("fired")
+	if t.timeout == 0 {
+		t.logger.Debug("t.timeout == 0")
+		return
+	}
+
+	t.logger.Debug("pre t.exitQueue.empty()")
+	t.exitQueue.empty()
+	t.logger.Debug("post t.exitQueue.empty()")
+
+	t.logger.Debug("end")
+}
+
+// run inits the main timeout run function that awaits for the exit command to be triggered or for the
+// timeout duration to elapse and trigger the parameter terminate function.
+func (t *timeoutManager) run(terminate func(), exit chan struct{}) {
+	t.logger.Debug("run fired", zap.Uint("t.timeout", t.timeout))
+
+	select {
+	case <-exit:
+		t.logger.Debug("<-exit sig")
+		return
+	case <-time.After(time.Duration(t.timeout) * time.Millisecond):
+		terminate()
+		t.logger.Debug("post terminate()")
+		return
+	}
+}
+
+// exitQueueManager
+type exitQueueManager struct {
+	logger    *zap.Logger
+	queue     []chan struct{}
+	queueLock sync.Mutex
+}
+
+// add handles new exit channels adding them to the exit queue
+func (e *exitQueueManager) add(exit chan struct{}) {
+	e.logger.Debug("fired")
+	e.queueLock.Lock()
+	defer e.queueLock.Unlock()
+	e.logger.Debug("", zap.Int("e.queue.len()", len(e.queue)))
+
+	e.queue = append(e.queue, exit)
+	e.logger.Debug("end", zap.Int("e.queue.len()", len(e.queue)))
+}
+
+// empty sends a signal to evert exit channel in the queue and then resets the queue
+func (e *exitQueueManager) empty() {
+	e.logger.Debug("fired")
+	e.queueLock.Lock()
+	defer e.queueLock.Unlock()
+	e.logger.Debug("", zap.Int("e.queue.len()", len(e.queue)))
+
+	for i := range e.queue {
+		e.queue[i] <- struct{}{}
+	}
+
+	e.queue = []chan struct{}{}
+	e.logger.Debug("end", zap.Int("e.queue.len()", len(e.queue)))
+}

--- a/server/timeout_test.go
+++ b/server/timeout_test.go
@@ -5,19 +5,10 @@ import (
 	"math/big"
 	"testing"
 	"time"
-
-	"go.uber.org/zap"
 )
 
 func TestTimeoutManager(t *testing.T) {
-	config := zap.NewDevelopmentConfig()
-	config.EncoderConfig.FunctionKey = "X"
-	logger, err := config.Build()
-	if err != nil {
-		t.Error(err)
-	}
-
-	tm := newTimeoutManager(logger)
+	tm := newTimeoutManager()
 
 	// test 0 timeout means timeout does not occur
 	tm.SetTimeout(0)

--- a/server/timeout_test.go
+++ b/server/timeout_test.go
@@ -38,13 +38,14 @@ func TestTimeoutManager(t *testing.T) {
 			t.Error(err)
 		}
 
-		tm.SetTimeout(uint(to.Int64() * 10))
+		tm.SetTimeout(uint(to.Int64() * 20))
 
 		if b.Int64() == 1 {
 			tm.StartTimeout(t.FailNow)
 		} else {
 			tm.StopTimeout()
 		}
+		tm.StopTimeout()
 	}
 
 	// test StopTimeout() prevents termination func

--- a/server/timeout_test.go
+++ b/server/timeout_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestTimeoutManager(t *testing.T) {
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.FunctionKey = "X"
+	logger, err := config.Build()
+	if err != nil {
+		t.Error(err)
+	}
+
+	tm := newTimeoutManager(logger)
+
+	// test 0 timeout means timeout does not occur
+	tm.SetTimeout(0)
+
+	// test fuzzing - 0 timeout - multiple sequential calls to random init and stop funcs
+	for i := 0; i < 30; i++ {
+		b, err := rand.Int(rand.Reader, big.NewInt(2))
+		if err != nil {
+			t.Error(err)
+		}
+
+		if b.Int64() == 1 {
+			tm.StartTimeout(t.FailNow)
+		} else {
+			tm.StopTimeout()
+		}
+	}
+
+	// test fuzzing - random timeout - multiple sequential calls to random init and stop funcs
+	for i := 0; i < 30; i++ {
+		b, err := rand.Int(rand.Reader, big.NewInt(2))
+		if err != nil {
+			t.Error(err)
+		}
+		to, err := rand.Int(rand.Reader, big.NewInt(11))
+		if err != nil {
+			t.Error(err)
+		}
+
+		tm.SetTimeout(uint(to.Int64() * 10))
+
+		if b.Int64() == 1 {
+			tm.StartTimeout(t.FailNow)
+		} else {
+			tm.StopTimeout()
+		}
+	}
+
+	// test StopTimeout() prevents termination func
+	tm.SetTimeout(20)
+	tm.StartTimeout(t.FailNow)
+	time.Sleep(10 * time.Millisecond)
+	tm.StopTimeout()
+
+	// test StartTimeout() executes termination func on timeout
+	ok := false
+	tm.SetTimeout(10)
+	tm.StartTimeout(func() {
+		ok = true
+	})
+	time.Sleep(20 * time.Millisecond)
+	if !ok {
+		t.FailNow()
+	}
+
+}


### PR DESCRIPTION
## What's Changed?

I've added timeout functionality to the Server types. Currently it is only possible to timeout a `PairingServer`.

This is configurable only via:

```go
type PayloadSourceConfig struct {
	// required
	KeystorePath string `json:"keystorePath"`
	// following 2 fields r optional.
	// optional cases:
	// 1. server mode is Receiving and server side doesn't contain this info
	// 2. server mode is Sending and client side doesn't contain this info
	// they are required in other cases
	KeyUID   string `json:"keyUID"`
	Password string `json:"password"`

	// Timeout the number of milliseconds after which the pairing server will automatically terminate
	Timeout uint `json:"timeout"`
}
```

With the new Pairing config field `timeout`, consuming code can set a pairing server to terminate after n milliseconds.

## Why Make the Change?

Sometimes we want the Servers to only live for a specific amount of time. Setting a timeout will allow consuming code to startup a server and not need to manage termination calls.

---

## Follow Up

Add functionality that ensure the TLS cert expires in sync with the timeout.