### PR TITLE
feat(wallet): keep and propagate multi-transactions relation after transaction is complete

### DIFF
--- a/services/local-notifications/core_test.go
+++ b/services/local-notifications/core_test.go
@@ -114,7 +114,7 @@ func TestTransactionNotification(t *testing.T) {
 		Nonce:   &nonce,
 	}
 	require.NoError(t, walletDb.ProcessBlocks(1777, header.Address, big.NewInt(1), lastBlock, []*transfer.DBHeader{header}))
-	require.NoError(t, walletDb.ProcessTranfers(1777, transfers, []*transfer.DBHeader{}))
+	require.NoError(t, walletDb.ProcessTransfers(1777, transfers, []*transfer.DBHeader{}))
 
 	feed.Send(walletevent.Event{
 		Type:        transfer.EventRecentHistoryReady,

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -224,54 +224,54 @@ func (api *API) DeleteSavedAddress(ctx context.Context, address common.Address) 
 	return err
 }
 
-func (api *API) GetPendingTransactions(ctx context.Context) ([]*PendingTransaction, error) {
+func (api *API) GetPendingTransactions(ctx context.Context) ([]*transfer.PendingTransaction, error) {
 	log.Debug("call to get pending transactions")
-	rst, err := api.s.transactionManager.getAllPendings([]uint64{api.s.rpcClient.UpstreamChainID})
+	rst, err := api.s.transactionManager.GetAllPending([]uint64{api.s.rpcClient.UpstreamChainID})
 	log.Debug("result from database for pending transactions", "len", len(rst))
 	return rst, err
 }
 
-func (api *API) GetPendingTransactionsByChainIDs(ctx context.Context, chainIDs []uint64) ([]*PendingTransaction, error) {
+func (api *API) GetPendingTransactionsByChainIDs(ctx context.Context, chainIDs []uint64) ([]*transfer.PendingTransaction, error) {
 	log.Debug("call to get pending transactions")
-	rst, err := api.s.transactionManager.getAllPendings(chainIDs)
+	rst, err := api.s.transactionManager.GetAllPending(chainIDs)
 	log.Debug("result from database for pending transactions", "len", len(rst))
 	return rst, err
 }
 
-func (api *API) GetPendingOutboundTransactionsByAddress(ctx context.Context, address common.Address) ([]*PendingTransaction, error) {
+func (api *API) GetPendingOutboundTransactionsByAddress(ctx context.Context, address common.Address) ([]*transfer.PendingTransaction, error) {
 	log.Debug("call to get pending outbound transactions by address")
-	rst, err := api.s.transactionManager.getPendingByAddress([]uint64{api.s.rpcClient.UpstreamChainID}, address)
+	rst, err := api.s.transactionManager.GetPendingByAddress([]uint64{api.s.rpcClient.UpstreamChainID}, address)
 	log.Debug("result from database for pending transactions by address", "len", len(rst))
 	return rst, err
 }
 
-func (api *API) GetPendingOutboundTransactionsByAddressAndChainID(ctx context.Context, chainIDs []uint64, address common.Address) ([]*PendingTransaction, error) {
+func (api *API) GetPendingOutboundTransactionsByAddressAndChainID(ctx context.Context, chainIDs []uint64, address common.Address) ([]*transfer.PendingTransaction, error) {
 	log.Debug("call to get pending outbound transactions by address")
-	rst, err := api.s.transactionManager.getPendingByAddress(chainIDs, address)
+	rst, err := api.s.transactionManager.GetPendingByAddress(chainIDs, address)
 	log.Debug("result from database for pending transactions by address", "len", len(rst))
 	return rst, err
 }
 
-func (api *API) StorePendingTransaction(ctx context.Context, trx PendingTransaction) error {
+func (api *API) StorePendingTransaction(ctx context.Context, trx transfer.PendingTransaction) error {
 	log.Debug("call to create or edit pending transaction")
 	if trx.ChainID == 0 {
 		trx.ChainID = api.s.rpcClient.UpstreamChainID
 	}
-	err := api.s.transactionManager.addPending(trx)
+	err := api.s.transactionManager.AddPending(trx)
 	log.Debug("result from database for creating or editing a pending transaction", "err", err)
 	return err
 }
 
 func (api *API) DeletePendingTransaction(ctx context.Context, transactionHash common.Hash) error {
 	log.Debug("call to remove pending transaction")
-	err := api.s.transactionManager.deletePending(api.s.rpcClient.UpstreamChainID, transactionHash)
+	err := api.s.transactionManager.DeletePending(api.s.rpcClient.UpstreamChainID, transactionHash)
 	log.Debug("result from database for remove pending transaction", "err", err)
 	return err
 }
 
 func (api *API) DeletePendingTransactionByChainID(ctx context.Context, chainID uint64, transactionHash common.Hash) error {
 	log.Debug("call to remove pending transaction")
-	err := api.s.transactionManager.deletePending(chainID, transactionHash)
+	err := api.s.transactionManager.DeletePending(chainID, transactionHash)
 	log.Debug("result from database for remove pending transaction", "err", err)
 	return err
 }
@@ -281,7 +281,7 @@ func (api *API) WatchTransaction(ctx context.Context, transactionHash common.Has
 	if err != nil {
 		return err
 	}
-	return api.s.transactionManager.watch(ctx, transactionHash, chainClient)
+	return api.s.transactionManager.Watch(ctx, transactionHash, chainClient)
 }
 
 func (api *API) WatchTransactionByChainID(ctx context.Context, chainID uint64, transactionHash common.Hash) error {
@@ -289,7 +289,7 @@ func (api *API) WatchTransactionByChainID(ctx context.Context, chainID uint64, t
 	if err != nil {
 		return err
 	}
-	return api.s.transactionManager.watch(ctx, transactionHash, chainClient)
+	return api.s.transactionManager.Watch(ctx, transactionHash, chainClient)
 }
 
 func (api *API) GetCryptoOnRamps(ctx context.Context) ([]CryptoOnRamp, error) {
@@ -545,9 +545,9 @@ func (api *API) getDerivedAddress(id string, derivedPath string) (*DerivedAddres
 	return address, nil
 }
 
-func (api *API) CreateMultiTransaction(ctx context.Context, multiTransaction *MultiTransaction, data []*bridge.TransactionBridge, password string) (*MultiTransactionResult, error) {
+func (api *API) CreateMultiTransaction(ctx context.Context, multiTransaction *transfer.MultiTransaction, data []*bridge.TransactionBridge, password string) (*transfer.MultiTransactionResult, error) {
 	log.Debug("[WalletAPI:: CreateMultiTransaction] create multi transaction")
-	return api.s.transactionManager.createMultiTransaction(ctx, multiTransaction, data, api.router.bridges, password)
+	return api.s.transactionManager.CreateMultiTransaction(ctx, multiTransaction, data, api.router.bridges, password)
 }
 
 func (api *API) GetCachedCurrencyFormats() (currency.FormatPerSymbol, error) {

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -61,8 +61,8 @@ func NewService(
 	}
 	tokenManager := token.NewTokenManager(db, rpcClient, rpcClient.NetworkManager)
 	savedAddressesManager := &SavedAddressesManager{db: db}
-	transactionManager := &TransactionManager{db: db, transactor: transactor, gethManager: gethManager, config: config, accountsDB: accountsDB}
-	transferController := transfer.NewTransferController(db, rpcClient, accountFeed, walletFeed)
+	transactionManager := transfer.NewTransactionManager(db, gethManager, transactor, config, accountsDB)
+	transferController := transfer.NewTransferController(db, rpcClient, accountFeed, walletFeed, transactionManager)
 	cryptoCompare := cryptocompare.NewClient()
 	coingecko := coingecko.NewClient()
 	marketManager := market.NewManager(cryptoCompare, coingecko)
@@ -100,7 +100,7 @@ type Service struct {
 	rpcClient             *rpc.Client
 	savedAddressesManager *SavedAddressesManager
 	tokenManager          *token.Manager
-	transactionManager    *TransactionManager
+	transactionManager    *transfer.TransactionManager
 	cryptoOnRampManager   *CryptoOnRampManager
 	transferController    *transfer.Controller
 	feesManager           *FeeManager

--- a/services/wallet/transfer/database_test.go
+++ b/services/wallet/transfer/database_test.go
@@ -83,7 +83,7 @@ func TestDBProcessBlocks(t *testing.T) {
 			From:        common.Address{1},
 		},
 	}
-	require.NoError(t, db.SaveTranfers(777, address, transfers, []*big.Int{big.NewInt(1), big.NewInt(2)}))
+	require.NoError(t, db.SaveTransfers(777, address, transfers, []*big.Int{big.NewInt(1), big.NewInt(2)}))
 }
 
 func TestDBProcessTransfer(t *testing.T) {
@@ -97,13 +97,14 @@ func TestDBProcessTransfer(t *testing.T) {
 	tx := types.NewTransaction(1, common.Address{1}, nil, 10, big.NewInt(10), nil)
 	transfers := []Transfer{
 		{
-			ID:          common.Hash{1},
-			Type:        ethTransfer,
-			BlockHash:   header.Hash,
-			BlockNumber: header.Number,
-			Transaction: tx,
-			Receipt:     types.NewReceipt(nil, false, 100),
-			Address:     common.Address{1},
+			ID:                 common.Hash{1},
+			Type:               ethTransfer,
+			BlockHash:          header.Hash,
+			BlockNumber:        header.Number,
+			Transaction:        tx,
+			Receipt:            types.NewReceipt(nil, false, 100),
+			Address:            common.Address{1},
+			MultiTransactionID: 0,
 		},
 	}
 	nonce := int64(0)
@@ -113,7 +114,7 @@ func TestDBProcessTransfer(t *testing.T) {
 		Nonce:   &nonce,
 	}
 	require.NoError(t, db.ProcessBlocks(777, common.Address{1}, big.NewInt(1), lastBlock, []*DBHeader{header}))
-	require.NoError(t, db.ProcessTranfers(777, transfers, []*DBHeader{}))
+	require.NoError(t, db.ProcessTransfers(777, transfers, []*DBHeader{}))
 }
 
 func TestDBReorgTransfers(t *testing.T) {
@@ -140,8 +141,8 @@ func TestDBReorgTransfers(t *testing.T) {
 		Nonce:   &nonce,
 	}
 	require.NoError(t, db.ProcessBlocks(777, original.Address, original.Number, lastBlock, []*DBHeader{original}))
-	require.NoError(t, db.ProcessTranfers(777, []Transfer{
-		{ethTransfer, common.Hash{1}, *originalTX.To(), original.Number, original.Hash, 100, originalTX, true, 1777, common.Address{1}, rcpt, nil, "2100"},
+	require.NoError(t, db.ProcessTransfers(777, []Transfer{
+		{ethTransfer, common.Hash{1}, *originalTX.To(), original.Number, original.Hash, 100, originalTX, true, 1777, common.Address{1}, rcpt, nil, "2100", NoMultiTransactionID},
 	}, []*DBHeader{}))
 	nonce = int64(0)
 	lastBlock = &LastKnownBlock{
@@ -150,8 +151,8 @@ func TestDBReorgTransfers(t *testing.T) {
 		Nonce:   &nonce,
 	}
 	require.NoError(t, db.ProcessBlocks(777, replaced.Address, replaced.Number, lastBlock, []*DBHeader{replaced}))
-	require.NoError(t, db.ProcessTranfers(777, []Transfer{
-		{ethTransfer, common.Hash{2}, *replacedTX.To(), replaced.Number, replaced.Hash, 100, replacedTX, true, 1777, common.Address{1}, rcpt, nil, "2100"},
+	require.NoError(t, db.ProcessTransfers(777, []Transfer{
+		{ethTransfer, common.Hash{2}, *replacedTX.To(), replaced.Number, replaced.Hash, 100, replacedTX, true, 1777, common.Address{1}, rcpt, nil, "2100", NoMultiTransactionID},
 	}, []*DBHeader{original}))
 
 	all, err := db.GetTransfers(777, big.NewInt(0), nil)
@@ -193,7 +194,7 @@ func TestDBGetTransfersFromBlock(t *testing.T) {
 		Nonce:   &nonce,
 	}
 	require.NoError(t, db.ProcessBlocks(777, headers[0].Address, headers[0].Number, lastBlock, headers))
-	require.NoError(t, db.ProcessTranfers(777, transfers, []*DBHeader{}))
+	require.NoError(t, db.ProcessTransfers(777, transfers, []*DBHeader{}))
 	rst, err := db.GetTransfers(777, big.NewInt(7), nil)
 	require.NoError(t, err)
 	require.Len(t, rst, 3)

--- a/services/wallet/transfer/downloader.go
+++ b/services/wallet/transfer/downloader.go
@@ -18,12 +18,15 @@ import (
 
 // Type type of the asset that was transferred.
 type Type string
+type MultiTransactionIDType int64
 
 const (
 	ethTransfer   Type = "eth"
 	erc20Transfer Type = "erc20"
 
 	erc20TransferEventSignature = "Transfer(address,address,uint256)"
+
+	NoMultiTransactionID = MultiTransactionIDType(0)
 )
 
 var (
@@ -49,6 +52,8 @@ type Transfer struct {
 	// Log that was used to generate erc20 transfer. Nil for eth transfer.
 	Log         *types.Log `json:"log"`
 	BaseGasFees string
+	// Internal field that is used to track multi-transaction transfers.
+	MultiTransactionID MultiTransactionIDType `json:"multi_transaction_id"`
 }
 
 // ETHDownloader downloads regular eth transfers.

--- a/services/wallet/transfer/query.go
+++ b/services/wallet/transfer/query.go
@@ -10,7 +10,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/bigint"
 )
 
-const baseTransfersQuery = "SELECT hash, type, blk_hash, blk_number, timestamp, address, tx, sender, receipt, log, network_id, base_gas_fee FROM transfers"
+const baseTransfersQuery = "SELECT hash, type, blk_hash, blk_number, timestamp, address, tx, sender, receipt, log, network_id, base_gas_fee, COALESCE(multi_transaction_id, 0) FROM transfers"
 
 func newTransfersQuery() *transfersQuery {
 	buf := bytes.NewBuffer(nil)
@@ -119,7 +119,7 @@ func (q *transfersQuery) Scan(rows *sql.Rows) (rst []Transfer, err error) {
 		err = rows.Scan(
 			&transfer.ID, &transfer.Type, &transfer.BlockHash,
 			(*bigint.SQLBigInt)(transfer.BlockNumber), &transfer.Timestamp, &transfer.Address,
-			&JSONBlob{transfer.Transaction}, &transfer.From, &JSONBlob{transfer.Receipt}, &JSONBlob{transfer.Log}, &transfer.NetworkID, &transfer.BaseGasFees)
+			&JSONBlob{transfer.Transaction}, &transfer.From, &JSONBlob{transfer.Receipt}, &JSONBlob{transfer.Log}, &transfer.NetworkID, &transfer.BaseGasFees, &transfer.MultiTransactionID)
 		if err != nil {
 			return nil, err
 		}

--- a/services/wallet/transfer/reactor.go
+++ b/services/wallet/transfer/reactor.go
@@ -30,11 +30,12 @@ type BalanceReader interface {
 
 // Reactor listens to new blocks and stores transfers into the database.
 type Reactor struct {
-	db    *Database
-	block *Block
-	feed  *event.Feed
-	mu    sync.Mutex
-	group *async.Group
+	db                 *Database
+	block              *Block
+	feed               *event.Feed
+	mu                 sync.Mutex
+	group              *async.Group
+	transactionManager *TransactionManager
 }
 
 func (r *Reactor) newControlCommand(chainClient *chain.ClientWithFallback, accounts []common.Address) *controlCommand {
@@ -50,9 +51,10 @@ func (r *Reactor) newControlCommand(chainClient *chain.ClientWithFallback, accou
 			signer:      signer,
 			db:          r.db,
 		},
-		erc20:       NewERC20TransfersDownloader(chainClient, accounts, signer),
-		feed:        r.feed,
-		errorsCount: 0,
+		erc20:              NewERC20TransfersDownloader(chainClient, accounts, signer),
+		feed:               r.feed,
+		errorsCount:        0,
+		transactionManager: r.transactionManager,
 	}
 
 	return ctl

--- a/services/wallet/transfer/transaction_test.go
+++ b/services/wallet/transfer/transaction_test.go
@@ -1,4 +1,4 @@
-package wallet
+package transfer
 
 import (
 	"io/ioutil"
@@ -42,39 +42,39 @@ func TestPendingTransactions(t *testing.T) {
 		ChainID:        777,
 	}
 
-	rst, err := manager.getAllPendings([]uint64{777})
+	rst, err := manager.GetAllPending([]uint64{777})
 	require.NoError(t, err)
 	require.Nil(t, rst)
 
-	rst, err = manager.getPendingByAddress([]uint64{777}, trx.From)
+	rst, err = manager.GetPendingByAddress([]uint64{777}, trx.From)
 	require.NoError(t, err)
 	require.Nil(t, rst)
 
-	err = manager.addPending(trx)
+	err = manager.AddPending(trx)
 	require.NoError(t, err)
 
-	rst, err = manager.getPendingByAddress([]uint64{777}, trx.From)
+	rst, err = manager.GetPendingByAddress([]uint64{777}, trx.From)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rst))
 	require.Equal(t, trx, *rst[0])
 
-	rst, err = manager.getAllPendings([]uint64{777})
+	rst, err = manager.GetAllPending([]uint64{777})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rst))
 	require.Equal(t, trx, *rst[0])
 
-	rst, err = manager.getPendingByAddress([]uint64{777}, common.Address{2})
+	rst, err = manager.GetPendingByAddress([]uint64{777}, common.Address{2})
 	require.NoError(t, err)
 	require.Nil(t, rst)
 
-	err = manager.deletePending(777, trx.Hash)
+	err = manager.DeletePending(777, trx.Hash)
 	require.NoError(t, err)
 
-	rst, err = manager.getPendingByAddress([]uint64{777}, trx.From)
+	rst, err = manager.GetPendingByAddress([]uint64{777}, trx.From)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(rst))
 
-	rst, err = manager.getAllPendings([]uint64{777})
+	rst, err = manager.GetAllPending([]uint64{777})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(rst))
 }

--- a/services/wallet/transfer/view.go
+++ b/services/wallet/transfer/view.go
@@ -34,7 +34,7 @@ type View struct {
 	To                   common.Address `json:"to"`
 	Contract             common.Address `json:"contract"`
 	NetworkID            uint64         `json:"networkId"`
-	MultiTransactionID   int64          `json:"multi_transaction_id"`
+	MultiTransactionID   int64          `json:"multiTransactionID"`
 	BaseGasFees          string         `json:"base_gas_fee"`
 }
 
@@ -87,6 +87,8 @@ func CastToTransferView(t Transfer) View {
 		from, to, amount := parseLog(t.Log)
 		view.From, view.To, view.Value = from, to, (*hexutil.Big)(amount)
 	}
+
+	view.MultiTransactionID = int64(t.MultiTransactionID)
 	return view
 }
 


### PR DESCRIPTION
## Updates [#7663](https://github.com/status-im/status-desktop/issues/7663)

Changes:
- Store multi-transaction ID into transactions DB
  - Add `TransactionManager.GetPendingEntry` API to get the ID and store it in `transfers`
- Delete pending transactions after downloading the first success status
- Add `multiTransactionID` to `transfer.View` to provide the ID to the presentation layer
- Move `TransactionManager` from `wallet` to `transfer` package