### PR TITLE
fix: Return statement after sendToL2 was missing

### DIFF
--- a/services/wallet/bridge/hop.go
+++ b/services/wallet/bridge/hop.go
@@ -192,6 +192,7 @@ func (h *HopBridge) Send(sendArgs *TransactionBridge, verifiedAccount *account.S
 	token := h.tokenManager.FindToken(fromNetwork, sendArgs.HopTx.Symbol)
 	if fromNetwork.Layer == 1 {
 		hash, err = h.sendToL2(sendArgs.ChainID, sendArgs.HopTx, verifiedAccount, token)
+		return hash, err
 	}
 	hash, err = h.swapAndSend(sendArgs.ChainID, sendArgs.HopTx, verifiedAccount, token)
 	return hash, err


### PR DESCRIPTION
Added return statement after sendToL2 which was missing and because of which bridge tx was failing

Important changes:
- [x] Something worth noting for reviewers.

Closes #
