### PR TITLE
chore: add println and logs to check what's being stored in the enr, and preemptively delete the multiaddr field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ladydascalie/currency v1.6.0
 	github.com/meirf/gopart v0.0.0-20180520194036-37e9492a85a8
-	github.com/waku-org/go-waku v0.5.2-0.20230221135630-99cb08b42f59
+	github.com/waku-org/go-waku v0.5.2-0.20230221221637-74b734c337e9
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -2105,8 +2105,8 @@ github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98 h1:xwY0kW5XZFimdqfZb9cZwT1S3VJP9j3AE6bdNd9boXM=
 github.com/waku-org/go-discover v0.0.0-20221209174356-61c833f34d98/go.mod h1:eBHgM6T4EG0RZzxpxKy+rGz/6Dw2Nd8DWxS0lm9ESDw=
-github.com/waku-org/go-waku v0.5.2-0.20230221135630-99cb08b42f59 h1:ghSb/5Ygd64RCTkro1CjrXrcE0zqneeTKMA42cdnn4o=
-github.com/waku-org/go-waku v0.5.2-0.20230221135630-99cb08b42f59/go.mod h1:hupqK7cKFAmY+r/EW7LLaPnMLsPrm0fW1OuR6KrO8a8=
+github.com/waku-org/go-waku v0.5.2-0.20230221221637-74b734c337e9 h1:9AiqlpVucwUx+Lm1gBLOwk1VUgozGYmnJ4KM9mH/Irk=
+github.com/waku-org/go-waku v0.5.2-0.20230221221637-74b734c337e9/go.mod h1:hupqK7cKFAmY+r/EW7LLaPnMLsPrm0fW1OuR6KrO8a8=
 github.com/waku-org/go-zerokit-rln v0.1.7-wakuorg h1:2vVIBCtBih2w1K9ll8YnToTDZvbxcgbsClsPlJS/kkg=
 github.com/waku-org/go-zerokit-rln v0.1.7-wakuorg/go.mod h1:GlyaVeEWNEBxVJrWC6jFTvb4LNb9d9qnjdS6EiWVUvk=
 github.com/wealdtech/go-ens/v3 v3.5.0 h1:Huc9GxBgiGweCOGTYomvsg07K2QggAqZpZ5SuiZdC8o=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -985,7 +985,7 @@ github.com/vacp2p/mvds/transport
 github.com/waku-org/go-discover/discover
 github.com/waku-org/go-discover/discover/v4wire
 github.com/waku-org/go-discover/discover/v5wire
-# github.com/waku-org/go-waku v0.5.2-0.20230221135630-99cb08b42f59
+# github.com/waku-org/go-waku v0.5.2-0.20230221221637-74b734c337e9
 ## explicit; go 1.19
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/waku/persistence


### PR DESCRIPTION
Since this https://github.com/status-im/status-desktop/issues/9589 is not easy to reproduce, I'm adding here some extra logs and also printing information in the terminal (that should be removed once the cause of the bug is found and fixed). Hopefully it will help capture the bug.

