### PR TITLE
chore(wallet): hardcode specific average block duration for L2

### DIFF
--- a/services/wallet/history/service.go
+++ b/services/wallet/history/service.go
@@ -225,7 +225,7 @@ func (s *Service) GetBalanceHistory(ctx context.Context, chainIDs []uint64, addr
 		}
 	}
 
-	data, err := mergeDataPoints(allData, strideDuration(timeInterval))
+	data, err := mergeDataPoints(allData, timeIntervalToStrideDuration[timeInterval])
 	if err != nil {
 		return nil, err
 	} else if len(data) == 0 {


### PR DESCRIPTION
### Closes [#9582](https://github.com/status-im/status-desktop/issues/9582)

The L2 networks have their block number and average block duration, so we need to hardcode to keep the logic simplified.