### PR TITLE
use random tcp port for wakuv2 instead of using fixed value 60000

### DIFF
--- a/node/geth_node.go
+++ b/node/geth_node.go
@@ -3,7 +3,6 @@ package node
 import (
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 
@@ -65,36 +64,6 @@ func MakeNode(config *params.NodeConfig, accs *accounts.Manager, db *leveldb.DB)
 	return stack, nil
 }
 
-func getUsableTCPPort() (int, error) {
-	conn, err := net.ListenTCP("tcp", &net.TCPAddr{
-		IP:   net.IPv4zero,
-		Port: 0,
-	})
-	if err != nil {
-		return 0, err
-	}
-	defer conn.Close()
-	return conn.Addr().(*net.TCPAddr).Port, nil
-}
-
-func handleListenAddr(listenAddr string) (string, error) {
-	if listenAddr == "" {
-		return "", nil
-	}
-	ip, port, err := net.SplitHostPort(listenAddr)
-	if err != nil {
-		return "", err
-	}
-	if port == "0" {
-		randomPort, err := getUsableTCPPort()
-		if err != nil {
-			return "", err
-		}
-		listenAddr = net.JoinHostPort(ip, fmt.Sprintf("%d", randomPort))
-	}
-	return listenAddr, nil
-}
-
 // newGethNodeConfig returns default stack configuration for mobile client node
 func newGethNodeConfig(config *params.NodeConfig) (*node.Config, error) {
 	// NOTE: I haven't changed anything related to this parameters, but
@@ -111,11 +80,6 @@ func newGethNodeConfig(config *params.NodeConfig) (*node.Config, error) {
 		maxPendingPeers = config.MaxPendingPeers
 	}
 
-	listenAddr, err := handleListenAddr(config.ListenAddr)
-	if err != nil {
-		return nil, err
-	}
-
 	nc := &node.Config{
 		DataDir:           config.DataDir,
 		KeyStoreDir:       config.KeyStoreDir,
@@ -125,7 +89,7 @@ func newGethNodeConfig(config *params.NodeConfig) (*node.Config, error) {
 		Version:           config.Version,
 		P2P: p2p.Config{
 			NoDiscovery:     true, // we always use only v5 server
-			ListenAddr:      listenAddr,
+			ListenAddr:      config.ListenAddr,
 			NAT:             nat.Any(),
 			MaxPeers:        maxPeers,
 			MaxPendingPeers: maxPendingPeers,

--- a/params/config.go
+++ b/params/config.go
@@ -859,7 +859,7 @@ func NewNodeConfig(dataDir string, networkID uint64) (*NodeConfig, error) {
 		},
 		WakuV2Config: WakuV2Config{
 			Host:           "0.0.0.0",
-			Port:           60000,
+			Port:           0,
 			DataDir:        wakuV2Dir,
 			MaxMessageSize: wakuv2common.DefaultMaxMessageSize,
 		},

--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -48,7 +48,7 @@ type Config struct {
 var DefaultConfig = Config{
 	MaxMessageSize:    common.DefaultMaxMessageSize,
 	Host:              "0.0.0.0",
-	Port:              60000,
+	Port:              0,
 	KeepAliveInterval: 10, // second
 	DiscoveryLimit:    40,
 	MinPeersForRelay:  1, // TODO: determine correct value with Vac team
@@ -66,10 +66,6 @@ func setDefaults(cfg *Config) *Config {
 
 	if cfg.Host == "" {
 		cfg.Host = DefaultConfig.Host
-	}
-
-	if cfg.Port == 0 {
-		cfg.Port = DefaultConfig.Port
 	}
 
 	if cfg.KeepAliveInterval == 0 {


### PR DESCRIPTION
If client pass a port value(not 0) for wakuv2 config, it will use it, otherwise it will use a random port instead. using random port can avoid port conflict issue, e.g. when you want run 2 ios simulators on local machine at the same time.

[relate PR](https://github.com/status-im/status-go/pull/3210)