### PR TITLE
Added a signal to emit after the AccountPayloadManager

### DIFF
--- a/server/pairing/events.go
+++ b/server/pairing/events.go
@@ -4,16 +4,18 @@ package pairing
 type EventType string
 
 const (
+	// Both Sender and Receiver
 
-	// both client and server
 	EventConnectionError   EventType = "connection-error"
 	EventConnectionSuccess EventType = "connection-success"
 	EventTransferError     EventType = "transfer-error"
 	EventTransferSuccess   EventType = "transfer-success"
 
-	// Only receiver side
-	EventProcessSuccess EventType = "process-success"
-	EventProcessError   EventType = "process-error"
+	// Only Receiver side
+
+	EventReceivedAccount EventType = "received-account"
+	EventProcessSuccess  EventType = "process-success"
+	EventProcessError    EventType = "process-error"
 )
 
 // Event is a type for transfer events.
@@ -21,6 +23,7 @@ type Event struct {
 	Type   EventType `json:"type"`
 	Error  string    `json:"error,omitempty"`
 	Action Action    `json:"action"`
+	Data   any       `json:"data,omitempty"`
 }
 
 type Action int

--- a/server/pairing/payload_manager.go
+++ b/server/pairing/payload_manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
+	"github.com/status-im/status-go/signal"
 )
 
 var (
@@ -252,6 +253,8 @@ func (apm *AccountPayloadManager) Receive(data []byte) error {
 		zap.String("accountPayloadMarshaller.accountPayloadMarshaller.password", apm.accountPayloadMarshaller.password),
 		zap.Binary("accountPayloadMarshaller.Received()", apm.Received()),
 	)
+
+	signal.SendLocalPairingEvent(Event{Type: EventReceivedAccount, Action: ActionPairingAccount, Data: apm.accountPayload.multiaccount})
 
 	return apm.payloadRepository.StoreToSource()
 }


### PR DESCRIPTION
## What's Changed?

Added a signal to emit after the `AccountPayloadManager` has received and successfully parsed the `multiaccounts.Account`.

The new signal:

```go
EventReceivedAccount EventType = "received-account"
```

Emitted by a receiver device.

Will contain a new field `data`, which will contained the json marshalled `multiaccounts.Account` as used in other parts of the application.

```go
	signal.SendLocalPairingEvent(Event{
		Type: EventReceivedAccount, // "received-account"
		Action: ActionPairingAccount, // 2
		Data: apm.accountPayload.multiaccount, // a json marshalled multiaccounts.Account
})
```

## Why make the change?

Because during the pairing / bootstrapping process we what to know the account details as soon as we receive them, so we can show the user what is happening on the receiving side.