### PR TITLE
Feat/transaction history for collectibles

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -296,7 +296,7 @@ func (api *API) GetCryptoOnRamps(ctx context.Context) ([]CryptoOnRamp, error) {
 	return api.s.cryptoOnRampManager.Get()
 }
 
-func (api *API) GetOpenseaCollectionsByOwner(ctx context.Context, chainID uint64, owner common.Address) ([]opensea.Collection, error) {
+func (api *API) GetOpenseaCollectionsByOwner(ctx context.Context, chainID uint64, owner common.Address) ([]opensea.OwnedCollection, error) {
 	log.Debug("call to get opensea collections")
 	client, err := opensea.NewOpenseaClient(chainID, api.s.openseaAPIKey)
 	if err != nil {
@@ -314,6 +314,17 @@ func (api *API) GetOpenseaAssetsByOwnerAndCollection(ctx context.Context, chainI
 	}
 
 	return client.FetchAllAssetsByOwnerAndCollection(owner, collectionSlug, limit)
+}
+
+func (api *API) GetOpenseaAssetsByNFTUniqueID(ctx context.Context, chainID uint64, uniqueIDs []opensea.NFTUniqueID, limit int) ([]opensea.Asset, error) {
+	log.Debug("call to GetOpenseaAssetsByNFTUniqueID")
+
+	client, err := opensea.NewOpenseaClient(chainID, api.s.openseaAPIKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.FetchAssetsByNFTUniqueID(uniqueIDs, limit)
 }
 
 func (api *API) AddEthereumChain(ctx context.Context, network params.Network) error {

--- a/services/wallet/thirdparty/opensea/client_test.go
+++ b/services/wallet/thirdparty/opensea/client_test.go
@@ -2,9 +2,12 @@ package opensea
 
 import (
 	"encoding/json"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/status-im/status-go/services/wallet/bigint"
 
 	"github.com/stretchr/testify/assert"
 
@@ -12,7 +15,14 @@ import (
 )
 
 func TestFetchAllCollectionsByOwner(t *testing.T) {
-	expected := []Collection{Collection{Name: "Rocky", Slug: "rocky", ImageURL: "ImageUrl", OwnedAssetCount: 1}}
+	expected := []OwnedCollection{{
+		Collection: Collection{
+			Name:     "Rocky",
+			Slug:     "rocky",
+			ImageURL: "ImageUrl",
+		},
+		OwnedAssetCount: &bigint.BigInt{Int: big.NewInt(1)},
+	}}
 	response, _ := json.Marshal(expected)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
@@ -33,7 +43,7 @@ func TestFetchAllCollectionsByOwner(t *testing.T) {
 }
 
 func TestFetchAllAssetsByOwnerAndCollection(t *testing.T) {
-	expected := []Asset{Asset{
+	expected := []Asset{{
 		ID:                1,
 		Name:              "Rocky",
 		Description:       "Rocky Balboa",
@@ -41,7 +51,7 @@ func TestFetchAllAssetsByOwnerAndCollection(t *testing.T) {
 		ImageThumbnailURL: "ImageThumbnailURL",
 		ImageURL:          "ImageUrl",
 		Contract:          Contract{Address: "1"},
-		Collection:        AssetCollection{Name: "Rocky"},
+		Collection:        Collection{Name: "Rocky"},
 	}}
 	response, _ := json.Marshal(AssetContainer{Assets: expected})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/services/wallet/transfer/view.go
+++ b/services/wallet/transfer/view.go
@@ -77,7 +77,7 @@ func CastToTransferView(t Transfer) View {
 	view.NetworkID = t.NetworkID
 
 	value := new(hexutil.Big)
-	tokenId := new(hexutil.Big)
+	tokenID := new(hexutil.Big)
 
 	switch view.Type {
 	case ethTransfer:
@@ -93,13 +93,13 @@ func CastToTransferView(t Transfer) View {
 		view.From, view.To, value = from, to, (*hexutil.Big)(valueInt)
 	case erc721Transfer:
 		view.Contract = t.Log.Address
-		from, to, tokenIdInt := parseErc721Log(t.Log)
-		view.From, view.To, tokenId = from, to, (*hexutil.Big)(tokenIdInt)
+		from, to, tokenIDInt := parseErc721Log(t.Log)
+		view.From, view.To, tokenID = from, to, (*hexutil.Big)(tokenIDInt)
 	}
 
 	view.MultiTransactionID = int64(t.MultiTransactionID)
 	view.Value = value
-	view.TokenID = tokenId
+	view.TokenID = tokenID
 
 	return view
 }
@@ -146,8 +146,8 @@ func parseErc20Log(ethlog *types.Log) (from, to common.Address, amount *big.Int)
 	return
 }
 
-func parseErc721Log(ethlog *types.Log) (from, to common.Address, tokenId *big.Int) {
-	tokenId = new(big.Int)
+func parseErc721Log(ethlog *types.Log) (from, to common.Address, tokenID *big.Int) {
+	tokenID = new(big.Int)
 	if len(ethlog.Topics) < 4 {
 		log.Warn("not enough topics for erc721 transfer", "topics", ethlog.Topics)
 		return
@@ -166,7 +166,7 @@ func parseErc721Log(ethlog *types.Log) (from, to common.Address, tokenId *big.In
 	}
 	copy(from[:], ethlog.Topics[1][12:])
 	copy(to[:], ethlog.Topics[2][12:])
-	tokenId.SetBytes(ethlog.Topics[3][:])
+	tokenID.SetBytes(ethlog.Topics[3][:])
 
 	return
 }


### PR DESCRIPTION
Part of [#8811](https://github.com/status-im/status-desktop/issues/8811)

This is composed of 2 commits.
In the first one, erc20 transfers are differentiated from erc721 ones, and the tokenID is retrieved for the second ones.
In the second one, we allow fetching OpenSea assets by Contract Address + tokenID. Additionally, http error handling and a retry mechanism (with wait between retries) is introduced for OpenSea, plus some minor fixes.