### PR TITLE
feat(Wallet): add API to fetch collectibles in a paginated way

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -303,17 +303,36 @@ func (api *API) GetOpenseaCollectionsByOwner(ctx context.Context, chainID uint64
 	return client.FetchAllCollectionsByOwner(owner)
 }
 
+// Kept for compatibility with mobile app
 func (api *API) GetOpenseaAssetsByOwnerAndCollection(ctx context.Context, chainID uint64, owner common.Address, collectionSlug string, limit int) ([]opensea.Asset, error) {
+	container, err := api.GetOpenseaAssetsByOwnerAndCollectionWithCursor(ctx, chainID, owner, collectionSlug, "", limit)
+	if err != nil {
+		return nil, err
+	}
+	return container.Assets, nil
+}
+
+func (api *API) GetOpenseaAssetsByOwnerAndCollectionWithCursor(ctx context.Context, chainID uint64, owner common.Address, collectionSlug string, cursor string, limit int) (*opensea.AssetContainer, error) {
 	log.Debug("call to get opensea assets")
 	client, err := opensea.NewOpenseaClient(chainID, api.s.openseaAPIKey)
 	if err != nil {
 		return nil, err
 	}
 
-	return client.FetchAllAssetsByOwnerAndCollection(owner, collectionSlug, limit)
+	return client.FetchAllAssetsByOwnerAndCollection(owner, collectionSlug, cursor, limit)
 }
 
-func (api *API) GetOpenseaAssetsByNFTUniqueID(ctx context.Context, chainID uint64, uniqueIDs []opensea.NFTUniqueID, limit int) ([]opensea.Asset, error) {
+func (api *API) GetOpenseaAssetsByOwnerWithCursor(ctx context.Context, chainID uint64, owner common.Address, cursor string, limit int) (*opensea.AssetContainer, error) {
+	log.Debug("call to FetchAllAssetsByOwner")
+	client, err := opensea.NewOpenseaClient(chainID, api.s.openseaAPIKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.FetchAllAssetsByOwner(owner, cursor, limit)
+}
+
+func (api *API) GetOpenseaAssetsByNFTUniqueID(ctx context.Context, chainID uint64, uniqueIDs []opensea.NFTUniqueID, limit int) (*opensea.AssetContainer, error) {
 	log.Debug("call to GetOpenseaAssetsByNFTUniqueID")
 
 	client, err := opensea.NewOpenseaClient(chainID, api.s.openseaAPIKey)

--- a/services/wallet/thirdparty/opensea/client_test.go
+++ b/services/wallet/thirdparty/opensea/client_test.go
@@ -43,17 +43,21 @@ func TestFetchAllCollectionsByOwner(t *testing.T) {
 }
 
 func TestFetchAllAssetsByOwnerAndCollection(t *testing.T) {
-	expected := []Asset{{
-		ID:                1,
-		Name:              "Rocky",
-		Description:       "Rocky Balboa",
-		Permalink:         "permalink",
-		ImageThumbnailURL: "ImageThumbnailURL",
-		ImageURL:          "ImageUrl",
-		Contract:          Contract{Address: "1"},
-		Collection:        Collection{Name: "Rocky"},
-	}}
-	response, _ := json.Marshal(AssetContainer{Assets: expected})
+	expected := AssetContainer{
+		Assets: []Asset{{
+			ID:                1,
+			Name:              "Rocky",
+			Description:       "Rocky Balboa",
+			Permalink:         "permalink",
+			ImageThumbnailURL: "ImageThumbnailURL",
+			ImageURL:          "ImageUrl",
+			Contract:          Contract{Address: "1"},
+			Collection:        Collection{Name: "Rocky"},
+		}},
+		NextCursor:     "",
+		PreviousCursor: "",
+	}
+	response, _ := json.Marshal(expected)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		_, err := w.Write(response)
@@ -67,7 +71,7 @@ func TestFetchAllAssetsByOwnerAndCollection(t *testing.T) {
 		client: srv.Client(),
 		url:    srv.URL,
 	}
-	res, err := opensea.FetchAllAssetsByOwnerAndCollection(common.Address{1}, "rocky", 200)
-	assert.Equal(t, expected, res)
+	res, err := opensea.FetchAllAssetsByOwnerAndCollection(common.Address{1}, "rocky", "", 200)
 	assert.Nil(t, err)
+	assert.Equal(t, expected, *res)
 }


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/9461

A new method was added to the API to retrieve all collectibles owned by a certain address, regardless of the collection.

Support for pagination (through parameter `cursor`) was added to the new method and the pre-existing one. 
