### PR TITLE
fix: don't expect `CommunityTokensMetadata` in `EditCommunity()`

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -933,7 +933,6 @@ func (o *Community) Edit(description *protobuf.CommunityDescription) {
 	}
 	o.config.CommunityDescription.Permissions = description.Permissions
 	o.config.CommunityDescription.AdminSettings.PinMessageAllMembersEnabled = description.AdminSettings.PinMessageAllMembersEnabled
-	o.config.CommunityDescription.CommunityTokensMetadata = description.CommunityTokensMetadata
 	o.increaseClock()
 }
 


### PR DESCRIPTION
The `Edit()` method on `Community` merely updates "primitive" values that live inside a community description. For any data that is more complex, we typically have dedicated methods.

Because `Edit()` was expecting `CommunityTokensMetadata`, it would override it with empty data every time we would edit a community. This is because we typically don't update that kind of data as part of `Edit()`.

In addition, `CommunityTokensMetadata` is append-only anyways, so there wouldn't be any other way to update that field, other than adding new items to it, which is done in a dedicated method.

