### PR TITLE
Add methods to sign and recover messages/signatures to AccountManager

### DIFF
--- a/account/accounts_geth.go
+++ b/account/accounts_geth.go
@@ -1,9 +1,12 @@
 package account
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/accounts"
 
 	"github.com/status-im/status-go/account/generator"
+	"github.com/status-im/status-go/rpc"
 )
 
 // GethManager represents account manager interface.
@@ -18,6 +21,11 @@ func NewGethManager() *GethManager {
 	m := &GethManager{}
 	m.Manager = &Manager{accountsGenerator: generator.New(m)}
 	return m
+}
+
+func (m *GethManager) SetRPCClient(rpcClient *rpc.Client, rpcTimeout time.Duration) {
+	m.Manager.rpcClient = rpcClient
+	m.Manager.rpcTimeout = rpcTimeout
 }
 
 // InitKeystore sets key manager and key store.

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -960,7 +960,7 @@ func (b *GethStatusBackend) startNode(config *params.NodeConfig) (err error) {
 	}); err != nil {
 		return
 	}
-
+	b.accountManager.SetRPCClient(b.statusNode.RPCClient(), rpc.DefaultCallTimeout)
 	signal.SendNodeStarted()
 
 	b.transactor.SetNetworkID(config.NetworkID)
@@ -1456,7 +1456,7 @@ func (b *GethStatusBackend) injectAccountsIntoWakuService(w types.WakuKeyManager
 	}
 
 	if st != nil {
-		if err := st.InitProtocol(b.statusNode.GethNode().Config().Name, identity, b.appDB, b.statusNode.HTTPServer(), b.multiaccountsDB, acc, logutils.ZapLogger()); err != nil {
+		if err := st.InitProtocol(b.statusNode.GethNode().Config().Name, identity, b.appDB, b.statusNode.HTTPServer(), b.multiaccountsDB, acc, b.accountManager, logutils.ZapLogger()); err != nil {
 			return err
 		}
 		// Set initial connection state

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -226,6 +226,7 @@ func main() {
 			gethbridge.NewNodeBridge(backend.StatusNode().GethNode(), backend.StatusNode().WakuService(), backend.StatusNode().WakuV2Service()),
 			installationID.String(),
 			nil,
+			backend.AccountManager(),
 			options...,
 		)
 		if err != nil {

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -86,6 +86,7 @@ func (s *MessengerCommunitiesSuite) newMessengerWithOptions(shh types.Waku, priv
 		&testNode{shh: shh},
 		uuid.New().String(),
 		nil,
+		nil,
 		options...,
 	)
 	s.Require().NoError(err)

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/appmetrics"
 	"github.com/status-im/status-go/connection"
@@ -106,6 +107,7 @@ type Messenger struct {
 	pushNotificationClient *pushnotificationclient.Client
 	pushNotificationServer *pushnotificationserver.Server
 	communitiesManager     *communities.Manager
+	accountsManager        *account.GethManager
 	logger                 *zap.Logger
 
 	outputCSV bool
@@ -238,6 +240,7 @@ func NewMessenger(
 	node types.Node,
 	installationID string,
 	peerStore *mailservers.PeerStore,
+	accountsManager *account.GethManager,
 	opts ...Option,
 ) (*Messenger, error) {
 	var messenger *Messenger
@@ -434,6 +437,7 @@ func NewMessenger(
 		pushNotificationClient:     pushNotificationClient,
 		pushNotificationServer:     pushNotificationServer,
 		communitiesManager:         communitiesManager,
+		accountsManager:            accountsManager,
 		ensVerifier:                ensVerifier,
 		featureFlags:               c.featureFlags,
 		systemMessagesTranslations: c.systemMessagesTranslations,

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -100,6 +100,7 @@ func newMessengerWithKey(shh types.Waku, privateKey *ecdsa.PrivateKey, logger *z
 		&testNode{shh: shh},
 		uuid.New().String(),
 		nil,
+		nil,
 		options...,
 	)
 	if err != nil {

--- a/protocol/messenger_sync_settings_test.go
+++ b/protocol/messenger_sync_settings_test.go
@@ -113,6 +113,7 @@ func (s *MessengerSyncSettingsSuite) newMessengerWithOptions(shh types.Waku, pri
 		&testNode{shh: shh},
 		uuid.New().String(),
 		nil,
+		nil,
 		options...,
 	)
 	s.Require().NoError(err)

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 
+	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/connection"
 	"github.com/status-im/status-go/db"
 	coretypes "github.com/status-im/status-go/eth-node/core/types"
@@ -107,7 +108,7 @@ func (s *Service) GetPeer(rawURL string) (*enode.Node, error) {
 	return enode.ParseV4(rawURL)
 }
 
-func (s *Service) InitProtocol(nodeName string, identity *ecdsa.PrivateKey, db *sql.DB, httpServer *server.MediaServer, multiAccountDb *multiaccounts.Database, acc *multiaccounts.Account, logger *zap.Logger) error {
+func (s *Service) InitProtocol(nodeName string, identity *ecdsa.PrivateKey, db *sql.DB, httpServer *server.MediaServer, multiAccountDb *multiaccounts.Database, acc *multiaccounts.Account, accountManager *account.GethManager, logger *zap.Logger) error {
 	var err error
 	if !s.config.ShhextConfig.PFSEnabled {
 		return nil
@@ -157,6 +158,7 @@ func (s *Service) InitProtocol(nodeName string, identity *ecdsa.PrivateKey, db *
 		s.n,
 		s.config.ShhextConfig.InstallationID,
 		s.peerStore,
+		accountManager,
 		options...,
 	)
 	if err != nil {

--- a/services/wakuext/api_test.go
+++ b/services/wakuext/api_test.go
@@ -137,7 +137,7 @@ func TestInitProtocol(t *testing.T) {
 
 	acc := &multiaccounts.Account{KeyUID: "0xdeadbeef"}
 
-	err = service.InitProtocol("Test", privateKey, sqlDB, nil, multiAccounts, acc, zap.NewNop())
+	err = service.InitProtocol("Test", privateKey, sqlDB, nil, multiAccounts, acc, nil, zap.NewNop())
 	require.NoError(t, err)
 }
 
@@ -202,7 +202,7 @@ func (s *ShhExtSuite) createAndAddNode() {
 
 	acc := &multiaccounts.Account{KeyUID: "0xdeadbeef"}
 
-	err = service.InitProtocol("Test", privateKey, sqlDB, nil, multiAccounts, acc, zap.NewNop())
+	err = service.InitProtocol("Test", privateKey, sqlDB, nil, multiAccounts, acc, nil, zap.NewNop())
 	s.NoError(err)
 
 	stack.RegisterLifecycle(service)


### PR DESCRIPTION
Also, make AccountManager a dependency of `Messenger`. This is needed for community token permissions as we'll need a way to access wallet accounts and sign messages when sending requests to join a community.

The APIs have been mostly taken from `GethStatusBackend` and `personal` service.

