### PR TITLE
fix(wallet/coingecko): Fix coingecko crash on race writing to tokens map

### DIFF
--- a/services/wallet/thirdparty/coingecko/client_test.go
+++ b/services/wallet/thirdparty/coingecko/client_test.go
@@ -1,0 +1,82 @@
+package coingecko
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setupTest(t *testing.T, response []byte) (*httptest.Server, func()) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, err := w.Write(response)
+		if err != nil {
+			return
+		}
+	}))
+
+	return srv, func() {
+		srv.Close()
+	}
+}
+
+func TestGetTokensSuccess(t *testing.T) {
+	expected := []GeckoToken{
+		{
+			ID:     "ethereum",
+			Symbol: "eth",
+			Name:   "Ethereum",
+		},
+		{
+			ID:     "status",
+			Symbol: "snt",
+			Name:   "Status",
+		},
+	}
+
+	expectedMap := map[string]GeckoToken{
+		"ETH": {
+			ID:     "ethereum",
+			Symbol: "eth",
+			Name:   "Ethereum",
+		},
+		"SNT": {
+			ID:     "status",
+			Symbol: "snt",
+			Name:   "Status",
+		},
+	}
+	response, _ := json.Marshal(expected)
+
+	srv, stop := setupTest(t, response)
+	defer stop()
+
+	geckoClient := &Client{
+		client:    srv.Client(),
+		tokens:    make(map[string]GeckoToken),
+		tokensURL: srv.URL,
+	}
+
+	tokenMap, err := geckoClient.getTokens()
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(expectedMap, tokenMap))
+}
+
+func TestGetTokensFailure(t *testing.T) {
+	resp := []byte{}
+	srv, stop := setupTest(t, resp)
+	defer stop()
+
+	geckoClient := &Client{
+		client:    srv.Client(),
+		tokens:    make(map[string]GeckoToken),
+		tokensURL: srv.URL,
+	}
+
+	_, err := geckoClient.getTokens()
+	require.Error(t, err)
+}


### PR DESCRIPTION
Fix crash in coingecko client on concurrent writes to token map

Crash happened in `getTokens()` method which is called from multiple places via coroutines.

```
fatal error: concurrent map writes

goroutine 1391 [running]:
github.com/status-im/status-go/services/wallet/thirdparty/coingecko.(*Client).getTokens(0x1c002727470)
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/services/wallet/thirdparty/coingecko/client.go:128 +0x3e5
github.com/status-im/status-go/services/wallet/thirdparty/coingecko.(*Client).mapSymbolsToIds(0x7ffa911fe0a0?, {0x1c006d4f800, 0x172, 0x1c005079f50?})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/services/wallet/thirdparty/coingecko/client.go:135 +0x3e
github.com/status-im/status-go/services/wallet/thirdparty/coingecko.(*Client).FetchPrices(0x1c002727470, {0x1c006d4f800?, 0x172, 0x172?}, {0x1c006cef6a0?, 0x1, 0x1})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/services/wallet/thirdparty/coingecko/client.go:158 +0x94
github.com/status-im/status-go/services/wallet/market.(*Manager).FetchPrices.func2()
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/services/wallet/market/market.go:162 +0x3e
github.com/status-im/status-go/services/wallet/market.(*Manager).makeCall.func2({0x7ffa912f9860?, 0x1c00064ea60?})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/services/wallet/market/market.go:61 +0x4d
github.com/afex/hystrix-go/hystrix.Go.func2({0x7ffa8fb03696?, 0x7ffa90eee720?}, {0x7ffa912f9860?, 0x1c00064ea60?})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:62 +0x2d
github.com/afex/hystrix-go/hystrix.(*command).tryFallback(0x1c006d567e0, {0x7ffa91308c78?, 0x1c0000da038?}, {0x7ffa912f9860?, 0x1c00064ea60?})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:290 +0x6a
github.com/afex/hystrix-go/hystrix.(*command).errorWithFallback(0x1c006d567e0, {0x7ffa91308c78, 0x1c0000da038}, {0x7ffa912f9860?, 0x1c00064ea60})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:278 +0x305
github.com/afex/hystrix-go/hystrix.GoC.func4.2()
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:190 +0x85
sync.(*Once).doSlow(0x1c000732f98?, 0x1c000732ee4?)
    /usr/local/go/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
    /usr/local/go/src/sync/once.go:65
github.com/afex/hystrix-go/hystrix.GoC.func4()
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:188 +0x1d8
created by github.com/afex/hystrix-go/hystrix.GoC
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:173 +0x4d8

```

```
goroutine 1930 [runnable]:
strings.ToUpper({0x1c0016bc870, 0x3})
    /usr/local/go/src/strings/strings.go:559 +0x25a
github.com/status-im/status-go/services/wallet/thirdparty/coingecko.(*Client).getTokens(0x1c002727470)
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/services/wallet/thirdparty/coingecko/client.go:123 +0x35b
github.com/status-im/status-go/services/wallet/thirdparty/coingecko.(*Client).FetchTokenDetails(0x1c002727470?, {0x1c007288000, 0x172, 0x200?})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/services/wallet/thirdparty/coingecko/client.go:196 +0x3e
github.com/status-im/status-go/services/wallet/market.(*Manager).FetchTokenDetails.func2()
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/services/wallet/market/market.go:133 +0x32
github.com/status-im/status-go/services/wallet/market.(*Manager).makeCall.func2({0x7ffa912f9860?, 0x1c004e1ba70?})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/services/wallet/market/market.go:61 +0x4d
github.com/afex/hystrix-go/hystrix.Go.func2({0x7ffa8fb03696?, 0x7ffa90eee720?}, {0x7ffa912f9860?, 0x1c004e1ba70?})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:62 +0x2d
github.com/afex/hystrix-go/hystrix.(*command).tryFallback(0x1c0066b1f80, {0x7ffa91308c78?, 0x1c0000da038?}, {0x7ffa912f9860?, 0x1c004e1ba70?})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:290 +0x6a
github.com/afex/hystrix-go/hystrix.(*command).errorWithFallback(0x1c0066b1f80, {0x7ffa91308c78, 0x1c0000da038}, {0x7ffa912f9860?, 0x1c004e1ba70})
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:278 +0x305
github.com/afex/hystrix-go/hystrix.GoC.func4.2()
    /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:190 +0x85
sync.(*Once).doSlow(0x1c0007b4f98?, 0x1c0007b4ee4?)
    /usr/local/go/src/sync/once.go:74 +0xc2

```

Refactored coingecko client to make it testable.
Implemented a test to reproduce the crash, crash fix is confirmed with test.
