### PR TITLE
feat: dynamic social links

### DIFF
--- a/multiaccounts/settings_social_links/database.go
+++ b/multiaccounts/settings_social_links/database.go
@@ -47,7 +47,7 @@ func (s *SocialLinksSettings) GetSocialLinks() (identity.SocialLinks, error) {
 	return links, nil
 }
 
-// Be careful, it removes every row except static links (__twitter, etc.) before insertion
+// Be careful, it removes every row before insertion
 func (s *SocialLinksSettings) SetSocialLinks(links *identity.SocialLinks) (err error) {
 	if links == nil {
 		return errors.New("can't set social links, nil object provided")
@@ -66,9 +66,8 @@ func (s *SocialLinksSettings) SetSocialLinks(links *identity.SocialLinks) (err e
 		_ = tx.Rollback()
 	}()
 
-	// remove everything except static links
-	_, err = tx.Exec(`DELETE from social_links_settings WHERE link_text != ? AND link_text != ? AND link_text != ? AND link_text != ? AND link_text != ? AND link_text != ?`,
-		identity.TwitterID, identity.PersonalSiteID, identity.GithubID, identity.YoutubeID, identity.DiscordID, identity.TelegramID)
+	// remove everything
+	_, err = tx.Exec(`DELETE from social_links_settings`)
 
 	stmt, err := tx.Prepare("INSERT INTO social_links_settings (link_text, link_url) VALUES (?, ?)")
 	if err != nil {

--- a/multiaccounts/settings_social_links/database_test.go
+++ b/multiaccounts/settings_social_links/database_test.go
@@ -71,7 +71,7 @@ func TestDatabase(t *testing.T) {
 	require.NoError(t, err)
 	links, err = socialLinkSettings.GetSocialLinks()
 	require.NoError(t, err)
-	require.True(t, links.Equals(socialLinksWithDefaults("", "", "", "", "", "")))
+	require.True(t, links.Equals(identity.SocialLinks{}))
 
 	// custom links
 	links = identity.SocialLinks{
@@ -80,18 +80,27 @@ func TestDatabase(t *testing.T) {
 			URL:  "Status_ico",
 		},
 		{
+			Text: identity.TelegramID,
+			URL:  "dummy.telegram",
+		},
+		{
 			Text: "customLink",
 			URL:  "customLink.com",
+		},
+	}
+	err = socialLinkSettings.SetSocialLinks(&links)
+	require.NoError(t, err)
+
+	expected := identity.SocialLinks{
+		{
+			Text: identity.TwitterID,
+			URL:  "Status_ico",
 		},
 		{
 			Text: identity.TelegramID,
 			URL:  "dummy.telegram",
 		},
 	}
-	err = socialLinkSettings.SetSocialLinks(&links)
-	require.NoError(t, err)
-
-	expected := socialLinksWithDefaults("Status_ico", "", "", "", "", "dummy.telegram")
 	expected = append(expected, identity.SocialLink{Text: "customLink", URL: "customLink.com"})
 
 	links, err = socialLinkSettings.GetSocialLinks()

--- a/protocol/identity/social_links.go
+++ b/protocol/identity/social_links.go
@@ -2,7 +2,7 @@ package identity
 
 import (
 	"encoding/json"
-	"sort"
+	"reflect"
 
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -41,18 +41,7 @@ func (s *SocialLinks) ToProtobuf() []*protobuf.SocialLink {
 }
 
 func (s SocialLinks) Equals(rhs SocialLinks) bool {
-	if len(s) != len(rhs) {
-		return false
-	}
-	sort.Slice(s, func(i, j int) bool { return s[i].Text < s[j].Text })
-	sort.Slice(rhs, func(i, j int) bool { return rhs[i].Text < rhs[j].Text })
-	for i := range s {
-		if s[i] != rhs[i] {
-			return false
-		}
-	}
-
-	return true
+	return reflect.DeepEqual(s, rhs)
 }
 
 func (s *SocialLinks) Serialize() ([]byte, error) {

--- a/protocol/identity/social_links_test.go
+++ b/protocol/identity/social_links_test.go
@@ -28,11 +28,4 @@ func TestEquals(t *testing.T) {
 	protobufLinks = append(protobufLinks, &protobuf.SocialLink{Text: "X", Url: "Y"})
 	transformedLinks = NewSocialLinks(protobufLinks)
 	require.True(t, socialLinks.Equals(*transformedLinks))
-
-	// order does not matter
-	protobufLinks = []*protobuf.SocialLink{}
-	protobufLinks = append(protobufLinks, &protobuf.SocialLink{Text: "X", Url: "Y"})
-	protobufLinks = append(protobufLinks, &protobuf.SocialLink{Text: "A", Url: "B"})
-	transformedLinks = NewSocialLinks(protobufLinks)
-	require.True(t, socialLinks.Equals(*transformedLinks))
 }


### PR DESCRIPTION
- completely replace social links on save
- respect the order of items and also the URL when comparing

Needed for https://github.com/status-im/status-desktop/issues/9777

Rationale: for MVP, we'll want the user to be able to add several links of the same type, and adjust/preserve their order by drag'n'drop
