### PR TITLE
fix(activity_center): Add remove activity center notifications array to message response

### DIFF
--- a/protocol/messenger_delete_message_for_everyone_test.go
+++ b/protocol/messenger_delete_message_for_everyone_test.go
@@ -107,11 +107,15 @@ func (s *MessengerDeleteMessageForEveryoneSuite) TestDeleteMessageForEveryone() 
 	deleteMessageResponse, err := s.moderator.DeleteMessageAndSend(ctx, message.ID)
 	s.Require().NoError(err)
 
-	_, err = WaitOnMessengerResponse(s.bob, func(response *MessengerResponse) bool {
+	response, err = WaitOnMessengerResponse(s.bob, func(response *MessengerResponse) bool {
 		return len(response.RemovedMessages()) > 0
 	}, "removed messages not received")
 	s.Require().Equal(deleteMessageResponse.RemovedMessages()[0].DeletedBy, contactIDFromPublicKey(s.moderator.IdentityPublicKey()))
+
 	s.Require().NoError(err)
+	s.Require().Len(response.ActivityCenterNotifications(), 1)
+	s.Require().True(response.ActivityCenterNotifications()[0].Deleted)
+
 	message, err = s.bob.MessageByID(message.ID)
 	s.Require().NoError(err)
 	s.Require().True(message.Deleted)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1583,6 +1583,10 @@ func (m *Messenger) HandleDeleteMessage(state *ReceivedMessageState, deleteMessa
 	state.Response.AddRemovedMessage(&RemovedMessage{MessageID: messageID, ChatID: chat.ID, DeletedBy: deleteMessage.DeleteMessage.DeletedBy})
 	state.Response.AddChat(chat)
 	state.Response.AddNotification(DeletedMessageNotification(messageID, chat))
+	state.Response.AddActivityCenterNotification(&ActivityCenterNotification{
+		ID:      types.FromHex(messageID),
+		Deleted: true,
+	})
 
 	return nil
 }


### PR DESCRIPTION
in fact of this [issue](https://github.com/status-im/status-desktop/issues/9751) I add an array to provide event for deleting notifications from activity center

Important changes:
- [x] Something worth noting for reviewers.

Closes #
