### PR TITLE
Local Pairing: Challenge Lifecycle Upgrade

### DIFF
--- a/server/pairing/challenge_management.go
+++ b/server/pairing/challenge_management.go
@@ -1,0 +1,144 @@
+package pairing
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/gorilla/sessions"
+	"go.uber.org/zap"
+)
+
+type ChallengeError struct {
+	Text     string
+	HttpCode int
+}
+
+func (ce *ChallengeError) Error() string {
+	return fmt.Sprintf("%s : %d", ce.Text, ce.HttpCode)
+}
+
+func makeCookieStore() (*sessions.CookieStore, error) {
+	auth := make([]byte, 64)
+	_, err := rand.Read(auth)
+	if err != nil {
+		return nil, err
+	}
+
+	enc := make([]byte, 32)
+	_, err = rand.Read(enc)
+	if err != nil {
+		return nil, err
+	}
+
+	return sessions.NewCookieStore(auth, enc), nil
+}
+
+type ChallengeGiver struct {
+	cookieStore *sessions.CookieStore
+	encryptor   *PayloadEncryptor
+	logger      *zap.Logger
+}
+
+func NewChallengeGiver(e *PayloadEncryptor, logger *zap.Logger) (*ChallengeGiver, error) {
+	cs, err := makeCookieStore()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChallengeGiver{
+		cookieStore: cs,
+		encryptor:   e,
+		logger:      logger,
+	}, nil
+}
+
+func (cg *ChallengeGiver) handleChallengeResponse(w http.ResponseWriter, r *http.Request) *ChallengeError {
+	s, err := cg.cookieStore.Get(r, sessionChallenge)
+	if err != nil {
+		cg.logger.Error("hs.GetCookieStore().Get(r, sessionChallenge)", zap.Error(err))
+		return &ChallengeError{"error", http.StatusInternalServerError}
+	}
+
+	blocked, ok := s.Values[sessionBlocked].(bool)
+	if ok && blocked {
+		return &ChallengeError{"forbidden", http.StatusForbidden}
+	}
+
+	// If the request header doesn't include a challenge don't punish the client, just throw a 403
+	pc := r.Header.Get(sessionChallenge)
+	if pc == "" {
+		return &ChallengeError{"forbidden", http.StatusForbidden}
+	}
+
+	c, err := cg.encryptor.decryptPlain(base58.Decode(pc))
+	if err != nil {
+		cg.logger.Error("c, err := hs.DecryptPlain(rc, hs.ek)", zap.Error(err))
+		return &ChallengeError{"error", http.StatusInternalServerError}
+	}
+
+	// If the challenge is not in the session store don't punish the client, just throw a 403
+	challenge, ok := s.Values[sessionChallenge].([]byte)
+	if !ok {
+		return &ChallengeError{"forbidden", http.StatusForbidden}
+	}
+
+	// Only if we have both a challenge in the session store and in the request header
+	// do we entertain blocking the client. Because then we know someone is trying to be sneaky.
+	if !bytes.Equal(c, challenge) {
+		s.Values[sessionBlocked] = true
+		err = s.Save(r, w)
+		if err != nil {
+			cg.logger.Error("err = s.Save(r, w)", zap.Error(err))
+		}
+
+		return &ChallengeError{"forbidden", http.StatusForbidden}
+	}
+	return nil
+}
+
+func (cg *ChallengeGiver) challenge(w http.ResponseWriter, r *http.Request) *ChallengeError {
+	s, err := cg.cookieStore.Get(r, sessionChallenge)
+	if err != nil {
+		cg.logger.Error("hs.GetCookieStore().Get(r, sessionChallenge)", zap.Error(err))
+		return &ChallengeError{"error", http.StatusInternalServerError}
+	}
+
+	challenge, ok := s.Values[sessionChallenge].([]byte)
+	if !ok {
+		challenge = make([]byte, 64)
+		_, err = rand.Read(challenge)
+		if err != nil {
+			cg.logger.Error("_, err = rand.Read(challenge)", zap.Error(err))
+			return &ChallengeError{"error", http.StatusInternalServerError}
+		}
+
+		s.Values[sessionChallenge] = challenge
+		err = s.Save(r, w)
+		if err != nil {
+			cg.logger.Error("err = s.Save(r, w)", zap.Error(err))
+			return &ChallengeError{"error", http.StatusInternalServerError}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	_, err = w.Write(challenge)
+	if err != nil {
+		cg.logger.Error("_, err = w.Write(challenge)", zap.Error(err))
+	}
+	return nil
+}
+
+func (s *BaseServer) GetCookieStore() *sessions.CookieStore {
+	return s.cookieStore
+}
+
+func (s *BaseServer) DecryptPlain(data []byte) ([]byte, error) {
+	return s.encryptor.decryptPlain(data)
+}
+
+type ChallengeTaker struct {
+	encryptor *PayloadEncryptor
+}

--- a/server/pairing/challenge_management.go
+++ b/server/pairing/challenge_management.go
@@ -20,11 +20,11 @@ const (
 
 type ChallengeError struct {
 	Text     string
-	HttpCode int
+	HTTPCode int
 }
 
 func (ce *ChallengeError) Error() string {
-	return fmt.Sprintf("%s : %d", ce.Text, ce.HttpCode)
+	return fmt.Sprintf("%s : %d", ce.Text, ce.HTTPCode)
 }
 
 func makeCookieStore() (*sessions.CookieStore, error) {
@@ -142,14 +142,17 @@ func (cg *ChallengeGiver) checkChallengeResponse(w http.ResponseWriter, r *http.
 }
 
 func (cg *ChallengeGiver) getChallenge(w http.ResponseWriter, r *http.Request) ([]byte, *ChallengeError) {
-	s, ce := cg.getSession(r)
-	if ce != nil {
-		return nil, ce
+	s, err := cg.getSession(r)
+	if err != nil {
+		return nil, err
 	}
 
 	challenge, ok := s.Values[sessionChallenge].([]byte)
 	if !ok {
-		challenge, ce = cg.generateNewChallenge(s, w, r)
+		challenge, err = cg.generateNewChallenge(s, w, r)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return challenge, nil
 }

--- a/server/pairing/challenge_management.go
+++ b/server/pairing/challenge_management.go
@@ -65,7 +65,7 @@ func NewChallengeGiver(e *PayloadEncryptor, logger *zap.Logger) (*ChallengeGiver
 	}, nil
 }
 
-func (cg *ChallengeGiver) getIP(r *http.Request) (net.IP, *ChallengeError) {
+func (cg *ChallengeGiver) getIP(r *http.Request) (net.IP, error) {
 	h, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		cg.logger.Error("getIP: h, _, err := net.SplitHostPort(r.RemoteAddr)", zap.Error(err), zap.String("r.RemoteAddr", r.RemoteAddr))
@@ -74,16 +74,16 @@ func (cg *ChallengeGiver) getIP(r *http.Request) (net.IP, *ChallengeError) {
 	return net.ParseIP(h), nil
 }
 
-func (cg *ChallengeGiver) registerClientIP(r *http.Request) *ChallengeError {
-	hIP, err := cg.getIP(r)
+func (cg *ChallengeGiver) registerClientIP(r *http.Request) error {
+	IP, err := cg.getIP(r)
 	if err != nil {
 		return err
 	}
-	cg.authedIP = hIP
+	cg.authedIP = IP
 	return nil
 }
 
-func (cg *ChallengeGiver) validateClientIP(r *http.Request) *ChallengeError {
+func (cg *ChallengeGiver) validateClientIP(r *http.Request) error {
 	// If we haven't registered yet register the IP
 	if cg.authedIP == nil || len(cg.authedIP) == 0 {
 		err := cg.registerClientIP(r)
@@ -93,23 +93,23 @@ func (cg *ChallengeGiver) validateClientIP(r *http.Request) *ChallengeError {
 	}
 
 	// Then compare the current req RemoteIP with the authed IP
-	hIP, err := cg.getIP(r)
+	IP, err := cg.getIP(r)
 	if err != nil {
 		return err
 	}
 
-	if !cg.authedIP.Equal(hIP) {
+	if !cg.authedIP.Equal(IP) {
 		cg.logger.Error(
 			"request RemoteAddr does not match authedIP: expected '%s', received '%s'",
 			zap.String("expected", cg.authedIP.String()),
-			zap.String("received", hIP.String()),
+			zap.String("received", IP.String()),
 		)
 		return &ChallengeError{"forbidden", http.StatusForbidden}
 	}
 	return nil
 }
 
-func (cg *ChallengeGiver) getSession(r *http.Request) (*sessions.Session, *ChallengeError) {
+func (cg *ChallengeGiver) getSession(r *http.Request) (*sessions.Session, error) {
 	s, err := cg.cookieStore.Get(r, sessionChallenge)
 	if err != nil {
 		cg.logger.Error("checkChallengeResponse: cg.cookieStore.Get(r, sessionChallenge)", zap.Error(err), zap.String("sessionChallenge", sessionChallenge))
@@ -118,7 +118,7 @@ func (cg *ChallengeGiver) getSession(r *http.Request) (*sessions.Session, *Chall
 	return s, nil
 }
 
-func (cg *ChallengeGiver) generateNewChallenge(s *sessions.Session, w http.ResponseWriter, r *http.Request) ([]byte, *ChallengeError) {
+func (cg *ChallengeGiver) generateNewChallenge(s *sessions.Session, w http.ResponseWriter, r *http.Request) ([]byte, error) {
 	challenge := make([]byte, 64)
 	_, err := rand.Read(challenge)
 	if err != nil {
@@ -136,7 +136,7 @@ func (cg *ChallengeGiver) generateNewChallenge(s *sessions.Session, w http.Respo
 	return challenge, nil
 }
 
-func (cg *ChallengeGiver) block(s *sessions.Session, w http.ResponseWriter, r *http.Request) *ChallengeError {
+func (cg *ChallengeGiver) block(s *sessions.Session, w http.ResponseWriter, r *http.Request) error {
 	s.Values[sessionBlocked] = true
 	err := s.Save(r, w)
 	if err != nil {
@@ -147,15 +147,15 @@ func (cg *ChallengeGiver) block(s *sessions.Session, w http.ResponseWriter, r *h
 	return &ChallengeError{"forbidden", http.StatusForbidden}
 }
 
-func (cg *ChallengeGiver) checkChallengeResponse(w http.ResponseWriter, r *http.Request) *ChallengeError {
-	ce := cg.validateClientIP(r)
-	if ce != nil {
-		return ce
+func (cg *ChallengeGiver) checkChallengeResponse(w http.ResponseWriter, r *http.Request) error {
+	err := cg.validateClientIP(r)
+	if err != nil {
+		return err
 	}
 
-	s, ce := cg.getSession(r)
-	if ce != nil {
-		return ce
+	s, err := cg.getSession(r)
+	if err != nil {
+		return err
 	}
 
 	blocked, ok := s.Values[sessionBlocked].(bool)
@@ -164,14 +164,14 @@ func (cg *ChallengeGiver) checkChallengeResponse(w http.ResponseWriter, r *http.
 	}
 
 	// If the request header doesn't include a challenge don't punish the client, just throw a 403
-	pc := r.Header.Get(sessionChallenge)
-	if pc == "" {
+	clientChallengeResp := r.Header.Get(sessionChallenge)
+	if clientChallengeResp == "" {
 		return &ChallengeError{"forbidden", http.StatusForbidden}
 	}
 
-	c, err := cg.encryptor.decryptPlain(base58.Decode(pc))
+	dcr, err := cg.encryptor.decryptPlain(base58.Decode(clientChallengeResp))
 	if err != nil {
-		cg.logger.Error("checkChallengeResponse: cg.encryptor.decryptPlain(base58.Decode(pc))", zap.Error(err), zap.String("pc", pc))
+		cg.logger.Error("checkChallengeResponse: cg.encryptor.decryptPlain(base58.Decode(clientChallengeResp))", zap.Error(err), zap.String("clientChallengeResp", clientChallengeResp))
 		return &ChallengeError{"error", http.StatusInternalServerError}
 	}
 
@@ -183,16 +183,16 @@ func (cg *ChallengeGiver) checkChallengeResponse(w http.ResponseWriter, r *http.
 
 	// Only if we have both a challenge in the session store and in the request header
 	// do we entertain blocking the client. Because then we know someone is trying to be sneaky.
-	if !bytes.Equal(c, challenge) {
+	if !bytes.Equal(dcr, challenge) {
 		return cg.block(s, w, r)
 	}
 
 	// If every is ok, generate a new challenge for the next req
-	_, ce = cg.generateNewChallenge(s, w, r)
-	return ce
+	_, err = cg.generateNewChallenge(s, w, r)
+	return err
 }
 
-func (cg *ChallengeGiver) getChallenge(w http.ResponseWriter, r *http.Request) ([]byte, *ChallengeError) {
+func (cg *ChallengeGiver) getChallenge(w http.ResponseWriter, r *http.Request) ([]byte, error) {
 	err := cg.validateClientIP(r)
 	if err != nil {
 		return nil, err

--- a/server/pairing/client.go
+++ b/server/pairing/client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -95,12 +94,7 @@ func (c *BaseClient) getChallenge() error {
 		return fmt.Errorf("[client] status not ok when getting challenge, received '%s'", resp.Status)
 	}
 
-	challenge, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-	c.challengeTaker.SetChallenge(challenge)
-	return nil
+	return c.challengeTaker.SetChallenge(resp)
 }
 
 /*
@@ -445,6 +439,7 @@ func StartUpReceivingClient(backend *api.GethStatusBackend, cs, configJSON strin
 	if err != nil {
 		return err
 	}
+
 	err = c.getChallenge()
 	if err != nil {
 		return err
@@ -453,7 +448,17 @@ func StartUpReceivingClient(backend *api.GethStatusBackend, cs, configJSON strin
 	if err != nil {
 		return err
 	}
+
+	err = c.getChallenge()
+	if err != nil {
+		return err
+	}
 	err = c.receiveSyncDeviceData()
+	if err != nil {
+		return err
+	}
+
+	err = c.getChallenge()
 	if err != nil {
 		return err
 	}

--- a/server/pairing/client.go
+++ b/server/pairing/client.go
@@ -192,6 +192,12 @@ func (c *SenderClient) receiveInstallationData() error {
 		return err
 	}
 
+	err = c.challengeTaker.DoChallenge(req)
+	if err != nil {
+		signal.SendLocalPairingEvent(Event{Type: EventTransferError, Error: err.Error(), Action: ActionPairingInstallation})
+		return err
+	}
+
 	resp, err := c.Do(req)
 	if err != nil {
 		signal.SendLocalPairingEvent(Event{Type: EventTransferError, Error: err.Error(), Action: ActionPairingInstallation})

--- a/server/pairing/client.go
+++ b/server/pairing/client.go
@@ -253,6 +253,10 @@ func StartUpSendingClient(backend *api.GethStatusBackend, cs, configJSON string)
 	if err != nil {
 		return err
 	}
+	err = c.getChallenge()
+	if err != nil {
+		return err
+	}
 	return c.receiveInstallationData()
 }
 

--- a/server/pairing/handlers.go
+++ b/server/pairing/handlers.go
@@ -187,7 +187,7 @@ func handleSendInstallation(hs HandlerServer, pmr PayloadMounterReceiver) http.H
 
 func middlewareChallenge(cg *ChallengeGiver, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ce := cg.handleChallengeResponse(w, r)
+		ce := cg.checkChallengeResponse(w, r)
 		if ce != nil {
 			http.Error(w, ce.Text, ce.HttpCode)
 			return

--- a/server/pairing/handlers.go
+++ b/server/pairing/handlers.go
@@ -19,10 +19,6 @@ const (
 	pairingReceiveSyncDevice   = pairingBase + "/receiveSyncDevice"
 	pairingSendInstallation    = pairingBase + "/sendInstallation"
 	pairingReceiveInstallation = pairingBase + "/receiveInstallation"
-
-	// Session names
-	sessionChallenge = "challenge"
-	sessionBlocked   = "blocked"
 )
 
 // Account handling

--- a/server/pairing/handlers.go
+++ b/server/pairing/handlers.go
@@ -185,7 +185,7 @@ func middlewareChallenge(cg *ChallengeGiver, next http.Handler) http.HandlerFunc
 	return func(w http.ResponseWriter, r *http.Request) {
 		ce := cg.checkChallengeResponse(w, r)
 		if ce != nil {
-			http.Error(w, ce.Text, ce.HttpCode)
+			http.Error(w, ce.Text, ce.HTTPCode)
 			return
 		}
 
@@ -197,7 +197,7 @@ func handlePairingChallenge(cg *ChallengeGiver) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		challenge, ce := cg.getChallenge(w, r)
 		if ce != nil {
-			http.Error(w, ce.Text, ce.HttpCode)
+			http.Error(w, ce.Text, ce.HTTPCode)
 			return
 		}
 

--- a/server/pairing/interfaces.go
+++ b/server/pairing/interfaces.go
@@ -1,7 +1,6 @@
 package pairing
 
 import (
-	"github.com/gorilla/sessions"
 	"go.uber.org/zap"
 )
 
@@ -28,8 +27,6 @@ type PayloadLocker interface {
 
 type HandlerServer interface {
 	GetLogger() *zap.Logger
-	GetCookieStore() *sessions.CookieStore
-	DecryptPlain([]byte) ([]byte, error)
 }
 
 type ProtobufMarshaler interface {

--- a/server/pairing/server.go
+++ b/server/pairing/server.go
@@ -63,22 +63,6 @@ func NewBaseServer(logger *zap.Logger, e *PayloadEncryptor, config *ServerConfig
 	return bs, nil
 }
 
-func makeCookieStore() (*sessions.CookieStore, error) {
-	auth := make([]byte, 64)
-	_, err := rand.Read(auth)
-	if err != nil {
-		return nil, err
-	}
-
-	enc := make([]byte, 32)
-	_, err = rand.Read(enc)
-	if err != nil {
-		return nil, err
-	}
-
-	return sessions.NewCookieStore(auth, enc), nil
-}
-
 // MakeConnectionParams generates a *ConnectionParams based on the Server's current state
 func (s *BaseServer) MakeConnectionParams() (*ConnectionParams, error) {
 	hostname := s.GetHostname()
@@ -93,14 +77,6 @@ func (s *BaseServer) MakeConnectionParams() (*ConnectionParams, error) {
 	}
 
 	return NewConnectionParams(netIP, s.MustGetPort(), s.pk, s.ek, s.mode), nil
-}
-
-func (s *BaseServer) GetCookieStore() *sessions.CookieStore {
-	return s.cookieStore
-}
-
-func (s *BaseServer) DecryptPlain(data []byte) ([]byte, error) {
-	return s.encryptor.decryptPlain(data)
 }
 
 func MakeServerConfig(config *ServerConfig) error {

--- a/server/pairing/server_pairing_test.go
+++ b/server/pairing/server_pairing_test.go
@@ -223,6 +223,13 @@ func (s *PairingServerSuite) TestPairingServer_handlePairingChallengeMiddleware(
 	err = c.getChallenge()
 	s.Require().NoError(err)
 	s.Require().NotEqual(challenge, c.challengeTaker.serverChallenge)
+
+	// Unlock the MockPayloadMounter to allow the test. Don't do this ordinarily
+	s.SS.accountMounter.(*MockPayloadMounter).encryptor.payload.locked = false
+
+	// receiving account data again using the new challenge
+	err = c.receiveAccountData()
+	s.Require().NoError(err)
 }
 
 func (s *PairingServerSuite) TestPairingServer_handlePairingChallengeMiddleware_block() {


### PR DESCRIPTION
## What's Changed?

- Migrated all challenge related functionality into `ChallengeGiver` and `ChallengeTaker` structs
- Integrated `ChallengeGiver` functionality into `Server` types
- Integrated `ChallengeTaker` functionality into `Client` types
- Simplified the challenge endpoint and middleware to execute `ChallengeGiver` functions
- Added back challenge functionality to sending installation data from the `ReceiverServer`
- Added IP lock to the`ChallengeGiver`, this prevents any other device on the network from acquiring the challenge session
- Updated challenge lifecycle to generate a new challenge after every successfully completed challenge
- Updated tests to confirm the new functionality

## Why Make the Change?

To improve the separation of concerns, the code now has a single type that handles all challenge giving and a single type that handles all challenge taking functionality. Improving maintainability and removing state management from structs that do not require access to specific states.

To improve connection security. Challenge changing after every success aligns the challenge system with best practices for multi call challenge protection [SASL](https://en.wikipedia.org/wiki/Simple_Authentication_and_Security_Layer).

Locking the session to the first device that requests a challenge prevents multiple clients on the LAN to attempt to access the payload data. If an attacker claims the lock first, they have a single attempt to succeed a challenge. A single failure blocks that session from any additional attempts.

## TODO

- [ ] Implement a bidirectional challenge system to prevent malicious actors from injecting their own keys in to a `ReceiverServer`. Unlikely as the attacker would also need to know the shared secret AES key

---

closes https://github.com/status-im/status-go/issues/3299