### PR TITLE
Change getChats to getChannelGroups and add getChannelGroupByID

### DIFF
--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -228,6 +228,10 @@ func (c *Chat) PrivateGroupChat() bool {
 	return c.ChatType == ChatTypePrivateGroupChat
 }
 
+func (c *Chat) IsActivePersonalChat() bool {
+	return c.Active && (c.OneToOne() || c.PrivateGroupChat() && c.Public()) && c.CommunityID == ""
+}
+
 func (c *Chat) CommunityChatID() string {
 	if c.ChatType != ChatTypeCommunityChat {
 		return c.ID

--- a/services/chat/api_group_chats.go
+++ b/services/chat/api_group_chats.go
@@ -43,7 +43,7 @@ func (api *API) CreateOneToOneChat(ctx context.Context, communityID types.HexByt
 		return nil, err
 	}
 
-	chat, err := api.toAPIChat(response.Chats()[0], nil, pubKey)
+	chat, err := api.toAPIChat(response.Chats()[0], nil, pubKey, false)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (api *API) StartGroupChat(ctx context.Context, communityID types.HexBytes, 
 		}
 	}
 
-	chat, err := api.toAPIChat(response.Chats()[0], nil, pubKey)
+	chat, err := api.toAPIChat(response.Chats()[0], nil, pubKey, false)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (api *API) StartGroupChat(ctx context.Context, communityID types.HexBytes, 
 }
 
 func (api *API) toGroupChatResponse(pubKey string, response *protocol.MessengerResponse) (*GroupChatResponse, error) {
-	chat, err := api.toAPIChat(response.Chats()[0], nil, pubKey)
+	chat, err := api.toAPIChat(response.Chats()[0], nil, pubKey, false)
 	if err != nil {
 		return nil, err
 	}

--- a/services/chat/api_send_messages.go
+++ b/services/chat/api_send_messages.go
@@ -55,7 +55,7 @@ func (api *API) toSendMessageResponse(response *protocol.MessengerResponse) (*Se
 	}
 
 	pubKey := types.EncodeHex(crypto.FromECDSAPub(api.s.messenger.IdentityPublicKey()))
-	chat, err := api.toAPIChat(protocolChat, community, pubKey)
+	chat, err := api.toAPIChat(protocolChat, community, pubKey, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/9858

Changes `getChats` to `getChannelGroups`, since they don't just get chats, but also everything relating to channel groups.

I also simplified it so that it only gets the channel group info and not chats or categories. That way, we can create the channel group buttons (navigation).

Then, when a section is activated, we call the other new function called `getChannelGroupByID` to get all the info about that channel group (chats, categories, members).

I added a condition to `toApiChat` to only get the chat info, because we do not need the pinned chats or the chat members, and those calls take a long time.

