### PR TITLE
Connection state changes now correctly propagates to messenger

### DIFF
--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -615,11 +615,13 @@ func (n *StatusNode) PeerCount() int {
 }
 
 func (n *StatusNode) ConnectionChanged(state connection.State) {
-	if n.wakuExtSrvc == nil {
-		return
+	if n.wakuExtSrvc != nil {
+		n.wakuExtSrvc.ConnectionChanged(state)
 	}
 
-	n.wakuExtSrvc.ConnectionChanged(state)
+	if n.wakuV2ExtSrvc != nil {
+		n.wakuV2ExtSrvc.ConnectionChanged(state)
+	}
 }
 
 // AccountManager exposes reference to node's accounts manager


### PR DESCRIPTION
status-mobile has an [issue](https://github.com/status-im/status-mobile/issues/15087) with messages marked as "sent" even when they are sent while the internet connection is off.

Turned out that `ConnectionChanged()` wasn't invoked correctly

[Related status-mobile PR](https://github.com/status-im/status-mobile/pull/15148)