### PR TITLE
feat: check member permission funds periodically

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1227,14 +1227,6 @@ func (m *Manager) AcceptRequestToJoin(request *requests.AcceptRequestToJoinCommu
 		}
 
 		if !hasPermission {
-			pk, err := common.HexToPubkey(dbRequest.PublicKey)
-			if err != nil {
-				return nil, err
-			}
-			err = m.markRequestToJoinAsCanceled(pk, community)
-			if err != nil {
-				return nil, err
-			}
 			return community, ErrNoPermissionToJoin
 		}
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -729,6 +729,12 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 				<-available
 				m.InitHistoryArchiveTasks(adminCommunities)
 			}()
+
+			for _, c := range adminCommunities {
+				if c.Joined() {
+					go m.communitiesManager.CheckMemberPermissionsPeriodically(c.ID())
+				}
+			}
 		}
 	}
 

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -732,20 +732,8 @@ func (m *Messenger) AcceptRequestToJoinCommunity(request *requests.AcceptRequest
 	}
 
 	community, err := m.communitiesManager.AcceptRequestToJoin(request)
-	if err != nil && err != communities.ErrNoPermissionToJoin {
+	if err != nil {
 		return nil, err
-	}
-
-	if err == communities.ErrNoPermissionToJoin {
-		cancel := &requests.DeclineRequestToJoinCommunity{
-			ID: requestToJoin.ID,
-		}
-		response, err := m.DeclineRequestToJoinCommunity(cancel)
-		if err != nil {
-			return nil, err
-		}
-		response.AddCommunity(community)
-		return response, nil
 	}
 
 	pk, err := common.HexToPubkey(requestToJoin.PublicKey)


### PR DESCRIPTION
This adds a periodic member permission check for every admin community such that member funds are checked every hour.
