### PR TITLE
Local Pairing: Reconcile A Tiny Number of Duplicate Funcs

### DIFF
--- a/server/certs.go
+++ b/server/certs.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -21,17 +20,6 @@ func makeRandomSerialNumber() (*big.Int, error) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	return rand.Int(rand.Reader, serialNumberLimit)
 }
-
-// TODO duped in pairing
-
-func makeSerialNumberFromKey(pk *ecdsa.PrivateKey) *big.Int {
-	h := sha256.New()
-	h.Write(append(pk.D.Bytes(), append(pk.Y.Bytes(), pk.X.Bytes()...)...))
-
-	return new(big.Int).SetBytes(h.Sum(nil))
-}
-
-// TODO duped in pairing
 
 func GenerateX509Cert(sn *big.Int, from, to time.Time, hostname string) *x509.Certificate {
 	c := &x509.Certificate{
@@ -54,8 +42,6 @@ func GenerateX509Cert(sn *big.Int, from, to time.Time, hostname string) *x509.Ce
 
 	return c
 }
-
-// TODO duped in pairing
 
 func GenerateX509PEMs(cert *x509.Certificate, key *ecdsa.PrivateKey) (certPem, keyPem []byte, err error) {
 	derBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, &key.PublicKey, key)

--- a/server/certs.go
+++ b/server/certs.go
@@ -22,12 +22,16 @@ func makeRandomSerialNumber() (*big.Int, error) {
 	return rand.Int(rand.Reader, serialNumberLimit)
 }
 
+// TODO duped in pairing
+
 func makeSerialNumberFromKey(pk *ecdsa.PrivateKey) *big.Int {
 	h := sha256.New()
 	h.Write(append(pk.D.Bytes(), append(pk.Y.Bytes(), pk.X.Bytes()...)...))
 
 	return new(big.Int).SetBytes(h.Sum(nil))
 }
+
+// TODO duped in pairing
 
 func GenerateX509Cert(sn *big.Int, from, to time.Time, hostname string) *x509.Certificate {
 	c := &x509.Certificate{
@@ -50,6 +54,8 @@ func GenerateX509Cert(sn *big.Int, from, to time.Time, hostname string) *x509.Ce
 
 	return c
 }
+
+// TODO duped in pairing
 
 func GenerateX509PEMs(cert *x509.Certificate, key *ecdsa.PrivateKey) (certPem, keyPem []byte, err error) {
 	derBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, &key.PublicKey, key)

--- a/server/certs_test.go
+++ b/server/certs_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/status-im/status-go/server/servertest"
 )
 
 func TestCerts(t *testing.T) {
@@ -14,8 +16,8 @@ func TestCerts(t *testing.T) {
 
 type CertsSuite struct {
 	suite.Suite
-	TestKeyComponents
-	TestCertComponents
+	servertest.TestKeyComponents
+	servertest.TestCertComponents
 }
 
 func (s *CertsSuite) SetupSuite() {
@@ -28,7 +30,7 @@ func (s *CertsSuite) Test_makeSerialNumberFromKey() {
 }
 
 func (s *CertsSuite) TestToECDSA() {
-	k := ToECDSA(base58.Decode(DB58))
+	k := ToECDSA(base58.Decode(servertest.DB58))
 	s.Require().NotNil(k.PublicKey.X)
 	s.Require().NotNil(k.PublicKey.Y)
 
@@ -37,7 +39,7 @@ func (s *CertsSuite) TestToECDSA() {
 	s.Require().Zero(k.D.Cmp(s.D))
 
 	b58 := base58.Encode(s.D.Bytes())
-	s.Require().Equal(DB58, b58)
+	s.Require().Equal(servertest.DB58, b58)
 }
 
 func (s *CertsSuite) TestGenerateX509Cert() {

--- a/server/certs_test.go
+++ b/server/certs_test.go
@@ -25,10 +25,6 @@ func (s *CertsSuite) SetupSuite() {
 	s.SetupCertComponents(s.T())
 }
 
-func (s *CertsSuite) Test_makeSerialNumberFromKey() {
-	s.Require().Zero(makeSerialNumberFromKey(s.PK).Cmp(s.SN))
-}
-
 func (s *CertsSuite) TestToECDSA() {
 	k := ToECDSA(base58.Decode(servertest.DB58))
 	s.Require().NotNil(k.PublicKey.X)

--- a/server/pairing/certs.go
+++ b/server/pairing/certs.go
@@ -21,12 +21,16 @@ import (
 // TODO Reconcile duplicate function here and in server/certs.go
 //  https://github.com/status-im/status-go/issues/3300
 
+// TODO duped, but only used here
+
 func makeSerialNumberFromKey(pk *ecdsa.PrivateKey) *big.Int {
 	h := sha256.New()
 	h.Write(append(pk.D.Bytes(), append(pk.Y.Bytes(), pk.X.Bytes()...)...))
 
 	return new(big.Int).SetBytes(h.Sum(nil))
 }
+
+// todo duped
 
 func GenerateX509Cert(sn *big.Int, from, to time.Time, hostname string) *x509.Certificate {
 	c := &x509.Certificate{
@@ -49,6 +53,8 @@ func GenerateX509Cert(sn *big.Int, from, to time.Time, hostname string) *x509.Ce
 
 	return c
 }
+
+// todo duped
 
 func GenerateX509PEMs(cert *x509.Certificate, key *ecdsa.PrivateKey) (certPem, keyPem []byte, err error) {
 	derBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, &key.PublicKey, key)

--- a/server/pairing/certs_test.go
+++ b/server/pairing/certs_test.go
@@ -1,0 +1,28 @@
+package pairing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/status-im/status-go/server/servertest"
+)
+
+func TestCerts(t *testing.T) {
+	suite.Run(t, new(CertsSuite))
+}
+
+type CertsSuite struct {
+	suite.Suite
+	servertest.TestKeyComponents
+	servertest.TestCertComponents
+}
+
+func (s *CertsSuite) SetupSuite() {
+	s.SetupKeyComponents(s.T())
+	s.SetupCertComponents(s.T())
+}
+
+func (s *CertsSuite) Test_makeSerialNumberFromKey() {
+	s.Require().Zero(makeSerialNumberFromKey(s.PK).Cmp(s.SN))
+}

--- a/server/pairing/components_test.go
+++ b/server/pairing/components_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/server"
-	"github.com/stretchr/testify/require"
 )
 
 type TestPairingServerComponents struct {

--- a/server/pairing/components_test.go
+++ b/server/pairing/components_test.go
@@ -5,84 +5,14 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/tls"
-	"encoding/asn1"
-	"math/big"
 	"net"
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcutil/base58"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-
-	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/server"
+	"github.com/stretchr/testify/require"
 )
-
-const (
-	X        = "7744735542292224619198421067303535767629647588258222392379329927711683109548"
-	Y        = "6855516769916529066379811647277920115118980625614889267697023742462401590771"
-	D        = "38564357061962143106230288374146033267100509055924181407058066820384455255240"
-	AES      = "BbnZ7Gc66t54a9kEFCf7FW8SGQuYypwHVeNkRYeNoqV6"
-	DB58     = "6jpbvo2ucrtrnpXXF4DQYuysh697isH9ppd2aT8uSRDh"
-	SN       = "91849736469742262272885892667727604096707836853856473239722372976236128900962"
-	CertTime = "eQUriVtGtkWhPJFeLZjF"
-)
-
-type TestKeyComponents struct {
-	X      *big.Int
-	Y      *big.Int
-	D      *big.Int
-	AES    []byte
-	DBytes []byte
-	PK     *ecdsa.PrivateKey
-}
-
-func (tk *TestKeyComponents) SetupKeyComponents(t *testing.T) {
-	var ok bool
-
-	tk.X, ok = new(big.Int).SetString(X, 10)
-	require.True(t, ok)
-
-	tk.Y, ok = new(big.Int).SetString(Y, 10)
-	require.True(t, ok)
-
-	tk.D, ok = new(big.Int).SetString(D, 10)
-	require.True(t, ok)
-
-	tk.AES = base58.Decode(AES)
-	require.Len(t, tk.AES, 32)
-
-	tk.DBytes = base58.Decode(DB58)
-	require.Exactly(t, tk.D.Bytes(), tk.DBytes)
-
-	tk.PK = &ecdsa.PrivateKey{
-		PublicKey: ecdsa.PublicKey{
-			Curve: elliptic.P256(),
-			X:     tk.X,
-			Y:     tk.Y,
-		},
-		D: tk.D,
-	}
-}
-
-type TestCertComponents struct {
-	NotBefore, NotAfter time.Time
-	SN                  *big.Int
-}
-
-func (tcc *TestCertComponents) SetupCertComponents(t *testing.T) {
-	var ok bool
-
-	tcc.SN, ok = new(big.Int).SetString(SN, 10)
-	require.True(t, ok)
-
-	_, err := asn1.Unmarshal(base58.Decode(CertTime), &tcc.NotBefore)
-	require.NoError(t, err)
-
-	tcc.NotAfter = tcc.NotBefore.Add(time.Hour)
-}
 
 type TestPairingServerComponents struct {
 	EphemeralPK  *ecdsa.PrivateKey
@@ -124,14 +54,6 @@ func (tpsc *TestPairingServerComponents) SetupPairingServerComponents(t *testing
 	require.NoError(t, err)
 	tpsc.RS, err = NewReceiverServer(nil, &ReceiverServerConfig{ServerConfig: sc, ReceiverConfig: &ReceiverConfig{}})
 	require.NoError(t, err)
-}
-
-type TestLoggerComponents struct {
-	Logger *zap.Logger
-}
-
-func (tlc *TestLoggerComponents) SetupLoggerComponents() {
-	tlc.Logger = logutils.ZapLogger()
 }
 
 type MockPayloadReceiver struct {

--- a/server/pairing/connection_test.go
+++ b/server/pairing/connection_test.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	internalServer "github.com/status-im/status-go/server"
+	"github.com/status-im/status-go/server"
+	"github.com/status-im/status-go/server/servertest"
 )
 
 var (
@@ -18,9 +19,9 @@ func TestConnectionParamsSuite(t *testing.T) {
 
 type ConnectionParamsSuite struct {
 	suite.Suite
-	TestKeyComponents
-	TestCertComponents
-	TestLoggerComponents
+	servertest.TestKeyComponents
+	servertest.TestCertComponents
+	servertest.TestLoggerComponents
 
 	server *BaseServer
 }
@@ -30,10 +31,10 @@ func (s *ConnectionParamsSuite) SetupSuite() {
 	s.SetupCertComponents(s.T())
 	s.SetupLoggerComponents()
 
-	cert, _, err := GenerateCertFromKey(s.PK, s.NotBefore, internalServer.DefaultIP.String())
+	cert, _, err := GenerateCertFromKey(s.PK, s.NotBefore, server.DefaultIP.String())
 	s.Require().NoError(err)
 
-	bs := internalServer.NewServer(&cert, internalServer.DefaultIP.String(), nil, s.Logger)
+	bs := server.NewServer(&cert, server.DefaultIP.String(), nil, s.Logger)
 	err = bs.SetPort(1337)
 	s.Require().NoError(err)
 
@@ -64,7 +65,7 @@ func (s *ConnectionParamsSuite) TestConnectionParams_Generate() {
 	s.Require().NoError(err)
 
 	s.Require().Equal("https://127.0.0.1:1337", u.String())
-	s.Require().Equal(internalServer.DefaultIP.String(), u.Hostname())
+	s.Require().Equal(server.DefaultIP.String(), u.Hostname())
 	s.Require().Equal("1337", u.Port())
 
 	s.Require().True(cp.publicKey.Equal(&s.PK.PublicKey))

--- a/server/pairing/payload_management_test.go
+++ b/server/pairing/payload_management_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/protocol/sqlite"
+	"github.com/status-im/status-go/server/servertest"
 	"github.com/status-im/status-go/t/utils"
 )
 
@@ -40,7 +41,7 @@ func TestPayloadMarshallerSuite(t *testing.T) {
 
 type PayloadMarshallerSuite struct {
 	suite.Suite
-	TestLoggerComponents
+	servertest.TestLoggerComponents
 
 	teardown func()
 

--- a/server/qrops_test.go
+++ b/server/qrops_test.go
@@ -13,12 +13,13 @@ import (
 
 	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/multiaccounts"
+	"github.com/status-im/status-go/server/servertest"
 )
 
 type QROpsTestSuite struct {
 	suite.Suite
-	TestKeyComponents
-	TestLoggerComponents
+	servertest.TestKeyComponents
+	servertest.TestLoggerComponents
 
 	server          *MediaServer
 	serverNoPort    *MediaServer

--- a/server/server.go
+++ b/server/server.go
@@ -79,7 +79,7 @@ func (s *Server) listenAndServe() {
 	s.StartTimeout(func() {
 		err := s.Stop()
 		if err != nil {
-			s.logger.Error("PairingServer termination fail", zap.Error(err))
+			s.logger.Error("server termination fail", zap.Error(err))
 		}
 	})
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/images"
+	"github.com/status-im/status-go/server/servertest"
 )
 
 const (
@@ -36,8 +37,8 @@ func TestServerURLSuite(t *testing.T) {
 
 type ServerURLSuite struct {
 	suite.Suite
-	TestKeyComponents
-	TestLoggerComponents
+	servertest.TestKeyComponents
+	servertest.TestLoggerComponents
 
 	server       *MediaServer
 	serverForQR  *MediaServer

--- a/server/servertest/servertest.go
+++ b/server/servertest/servertest.go
@@ -1,4 +1,5 @@
-package server
+// Package servertest provides utilities for server testing.
+package servertest
 
 import (
 	"crypto/ecdsa"


### PR DESCRIPTION
## What's Changed?

Removed a few duplicate functions, really minor stuff actually. When I first spotted this I thought it was going to be a lot more work, but it wasn't any work at all.

## Why Change?

Because duplicate functions lead to divergence of implementation but convergence of functionality, which make finding bugs harder.

If you are curious about the `servertest` package see https://pkg.go.dev/net/http/httptest as an example for how the stn lib handles test util packages

Closes https://github.com/status-im/status-go/issues/3300