### PR TITLE
Local Pairing: Remove Server Mode

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1017,7 +1017,7 @@ func GetConnectionStringForBeingBootstrapped(configJSON string) string {
 	if configJSON == "" {
 		return makeJSONResponse(fmt.Errorf("no config given, PayloadSourceConfig is expected"))
 	}
-	cs, err := pairing.StartUpReceiverServer(statusBackend, pairing.Receiving, configJSON)
+	cs, err := pairing.StartUpReceiverServer(statusBackend, configJSON)
 	if err != nil {
 		return makeJSONResponse(err)
 	}
@@ -1034,7 +1034,7 @@ func GetConnectionStringForBootstrappingAnotherDevice(configJSON string) string 
 	if configJSON == "" {
 		return makeJSONResponse(fmt.Errorf("no config given, SendingServerConfig is expected"))
 	}
-	cs, err := pairing.StartUpSenderServer(statusBackend, pairing.Sending, configJSON)
+	cs, err := pairing.StartUpSenderServer(statusBackend, configJSON)
 	if err != nil {
 		return makeJSONResponse(err)
 	}

--- a/server/pairing/config.go
+++ b/server/pairing/config.go
@@ -46,7 +46,6 @@ type ServerConfig struct {
 	EK       []byte           `json:"-"`
 	Cert     *tls.Certificate `json:"-"`
 	Hostname string           `json:"-"`
-	Mode     Mode             `json:"-"`
 }
 
 type ClientConfig struct{}

--- a/server/pairing/connection_test.go
+++ b/server/pairing/connection_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	connectionString = "cs2:4FHRnp:Q4:uqnnMwVUfJc2Fkcaojet8F1ufKC3hZdGEt47joyBx9yd:BbnZ7Gc66t54a9kEFCf7FW8SGQuYypwHVeNkRYeNoqV6:3"
+	connectionString = "cs2:4FHRnp:Q4:uqnnMwVUfJc2Fkcaojet8F1ufKC3hZdGEt47joyBx9yd:BbnZ7Gc66t54a9kEFCf7FW8SGQuYypwHVeNkRYeNoqV6"
 )
 
 func TestConnectionParamsSuite(t *testing.T) {
@@ -42,7 +42,6 @@ func (s *ConnectionParamsSuite) SetupSuite() {
 		Server: bs,
 		pk:     &s.PK.PublicKey,
 		ek:     s.AES,
-		mode:   Sending,
 	}
 }
 
@@ -58,8 +57,6 @@ func (s *ConnectionParamsSuite) TestConnectionParams_Generate() {
 	cp := new(ConnectionParams)
 	err := cp.FromString(connectionString)
 	s.Require().NoError(err)
-
-	s.Require().Exactly(Sending, cp.serverMode)
 
 	u, err := cp.URL()
 	s.Require().NoError(err)

--- a/server/pairing/server.go
+++ b/server/pairing/server.go
@@ -31,9 +31,6 @@ type BaseServer struct {
 
 	pk *ecdsa.PublicKey
 	ek []byte
-	// TODO remove mode from pairing process
-	//  https://github.com/status-im/status-go/issues/3301
-	mode Mode
 }
 
 // NewBaseServer returns a *BaseServer init from the given *SenderServerConfig
@@ -53,7 +50,6 @@ func NewBaseServer(logger *zap.Logger, e *PayloadEncryptor, config *ServerConfig
 		challengeGiver: cg,
 		pk:             config.PK,
 		ek:             config.EK,
-		mode:           config.Mode,
 	}
 	bs.SetTimeout(config.Timeout)
 	return bs, nil
@@ -72,7 +68,7 @@ func (s *BaseServer) MakeConnectionParams() (*ConnectionParams, error) {
 		netIP = netIP4
 	}
 
-	return NewConnectionParams(netIP, s.MustGetPort(), s.pk, s.ek, s.mode), nil
+	return NewConnectionParams(netIP, s.MustGetPort(), s.pk, s.ek), nil
 }
 
 func MakeServerConfig(config *ServerConfig) error {
@@ -158,7 +154,7 @@ func (s *SenderServer) startSendingData() error {
 }
 
 // MakeFullSenderServer generates a fully configured and randomly seeded SenderServer
-func MakeFullSenderServer(backend *api.GethStatusBackend, mode Mode, config *SenderServerConfig) (*SenderServer, error) {
+func MakeFullSenderServer(backend *api.GethStatusBackend, config *SenderServerConfig) (*SenderServer, error) {
 	err := MakeServerConfig(config.ServerConfig)
 	if err != nil {
 		return nil, err
@@ -168,16 +164,16 @@ func MakeFullSenderServer(backend *api.GethStatusBackend, mode Mode, config *Sen
 	return NewSenderServer(backend, config)
 }
 
-// StartUpSenderServer generates a SenderServer, starts the sending server in the correct mode
+// StartUpSenderServer generates a SenderServer, starts the sending server
 // and returns the ConnectionParams string to allow a ReceiverClient to make a successful connection.
-func StartUpSenderServer(backend *api.GethStatusBackend, mode Mode, configJSON string) (string, error) {
+func StartUpSenderServer(backend *api.GethStatusBackend, configJSON string) (string, error) {
 	conf := NewSenderServerConfig()
 	err := json.Unmarshal([]byte(configJSON), conf)
 	if err != nil {
 		return "", err
 	}
 
-	ps, err := MakeFullSenderServer(backend, mode, conf)
+	ps, err := MakeFullSenderServer(backend, conf)
 	if err != nil {
 		return "", err
 	}
@@ -249,7 +245,7 @@ func (s *ReceiverServer) startReceivingData() error {
 }
 
 // MakeFullReceiverServer generates a fully configured and randomly seeded ReceiverServer
-func MakeFullReceiverServer(backend *api.GethStatusBackend, mode Mode, config *ReceiverServerConfig) (*ReceiverServer, error) {
+func MakeFullReceiverServer(backend *api.GethStatusBackend, config *ReceiverServerConfig) (*ReceiverServer, error) {
 	err := MakeServerConfig(config.ServerConfig)
 	if err != nil {
 		return nil, err
@@ -264,16 +260,16 @@ func MakeFullReceiverServer(backend *api.GethStatusBackend, mode Mode, config *R
 	return NewReceiverServer(backend, config)
 }
 
-// StartUpReceiverServer generates a ReceiverServer, starts the sending server in the correct mode
+// StartUpReceiverServer generates a ReceiverServer, starts the sending server
 // and returns the ConnectionParams string to allow a SenderClient to make a successful connection.
-func StartUpReceiverServer(backend *api.GethStatusBackend, mode Mode, configJSON string) (string, error) {
+func StartUpReceiverServer(backend *api.GethStatusBackend, configJSON string) (string, error) {
 	conf := NewReceiverServerConfig()
 	err := json.Unmarshal([]byte(configJSON), conf)
 	if err != nil {
 		return "", err
 	}
 
-	ps, err := MakeFullReceiverServer(backend, mode, conf)
+	ps, err := MakeFullReceiverServer(backend, conf)
 	if err != nil {
 		return "", err
 	}

--- a/server/pairing/server_pairing_test.go
+++ b/server/pairing/server_pairing_test.go
@@ -79,7 +79,6 @@ func (s *PairingServerSuite) TestPairingServer_StartPairingSend() {
 	// Replace PairingServer.accountMounter with a MockPayloadMounter
 	pm := NewMockPayloadMounter(s.EphemeralAES)
 	s.SS.accountMounter = pm
-	s.SS.mode = Sending
 
 	err := s.SS.startSendingData()
 	s.Require().NoError(err)
@@ -127,8 +126,6 @@ func (s *PairingServerSuite) TestPairingServer_StartPairingReceive() {
 	pm := NewMockPayloadReceiver(s.EphemeralAES)
 	s.RS.accountReceiver = pm
 
-	s.RS.mode = Receiving
-
 	err := s.RS.startReceivingData()
 	s.Require().NoError(err)
 
@@ -172,7 +169,6 @@ func (s *PairingServerSuite) sendingSetup() *ReceiverClient {
 	// Replace PairingServer.PayloadManager with a MockPayloadReceiver
 	pm := NewMockPayloadMounter(s.EphemeralAES)
 	s.SS.accountMounter = pm
-	s.SS.mode = Sending
 
 	err := s.SS.startSendingData()
 	s.Require().NoError(err)
@@ -290,7 +286,6 @@ func makeThingToSay() (string, error) {
 }
 
 func (s *PairingServerSuite) TestGetOutboundIPWithFullServerE2e() {
-	s.SS.mode = Sending
 	s.SS.SetHandlers(server.HandlerPatternMap{"/hello": testHandler(s.T())})
 
 	err := s.SS.Start()

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -153,7 +153,7 @@ func (s *SyncDeviceSuite) TestPairingSyncDeviceClientAsSender() {
 	serverNodeConfig.RootDataDir = serverTmpDir
 	serverConfigBytes, err := json.Marshal(serverPayloadSourceConfig)
 	require.NoError(s.T(), err)
-	cs, err := StartUpReceiverServer(serverBackend, Receiving, string(serverConfigBytes))
+	cs, err := StartUpReceiverServer(serverBackend, string(serverConfigBytes))
 	require.NoError(s.T(), err)
 
 	// generate some data for the client
@@ -207,7 +207,7 @@ func (s *SyncDeviceSuite) TestPairingSyncDeviceClientAsSender() {
 	require.False(s.T(), serverMessenger.HasPairedDevices())
 
 	// repeat local pairing, we should expect no error after receiver logged in
-	cs, err = StartUpReceiverServer(serverBackend, Receiving, string(serverConfigBytes))
+	cs, err = StartUpReceiverServer(serverBackend, string(serverConfigBytes))
 	require.NoError(s.T(), err)
 	err = StartUpSendingClient(clientBackend, cs, string(clientConfigBytes))
 	require.NoError(s.T(), err)
@@ -216,7 +216,7 @@ func (s *SyncDeviceSuite) TestPairingSyncDeviceClientAsSender() {
 
 	// test if it's okay when account already exist but not logged in
 	require.NoError(s.T(), serverBackend.Logout())
-	cs, err = StartUpReceiverServer(serverBackend, Receiving, string(serverConfigBytes))
+	cs, err = StartUpReceiverServer(serverBackend, string(serverConfigBytes))
 	require.NoError(s.T(), err)
 	err = StartUpSendingClient(clientBackend, cs, string(clientConfigBytes))
 	require.NoError(s.T(), err)
@@ -247,7 +247,7 @@ func (s *SyncDeviceSuite) TestPairingSyncDeviceClientAsReceiver() {
 	}
 	configBytes, err := json.Marshal(config)
 	require.NoError(s.T(), err)
-	cs, err := StartUpSenderServer(serverBackend, Sending, string(configBytes))
+	cs, err := StartUpSenderServer(serverBackend, string(configBytes))
 	require.NoError(s.T(), err)
 
 	// generate some data for the server
@@ -308,7 +308,7 @@ func (s *SyncDeviceSuite) TestPairingSyncDeviceClientAsReceiver() {
 	require.False(s.T(), clientMessenger.HasPairedDevices())
 
 	// repeat local pairing, we should expect no error after receiver logged in
-	cs, err = StartUpSenderServer(serverBackend, Sending, string(configBytes))
+	cs, err = StartUpSenderServer(serverBackend, string(configBytes))
 	require.NoError(s.T(), err)
 	err = StartUpReceivingClient(clientBackend, cs, string(clientConfigBytes))
 	require.NoError(s.T(), err)
@@ -317,7 +317,7 @@ func (s *SyncDeviceSuite) TestPairingSyncDeviceClientAsReceiver() {
 
 	// test if it's okay when account already exist but not logged in
 	require.NoError(s.T(), clientBackend.Logout())
-	cs, err = StartUpSenderServer(serverBackend, Sending, string(configBytes))
+	cs, err = StartUpSenderServer(serverBackend, string(configBytes))
 	require.NoError(s.T(), err)
 	err = StartUpReceivingClient(clientBackend, cs, string(clientConfigBytes))
 	require.NoError(s.T(), err)


### PR DESCRIPTION
## What's Changed?

I've removed all reference to `server mode` / `pairing.Mode`.

## Why Change?

Due to the refactor of https://github.com/status-im/status-go/pull/3248 the concept of a `server mode` is now redundant as server and client types are created explicitly depending on the API endpoint triggered. I feel that `server mode` may not have been a useful idea.

Closes https://github.com/status-im/status-go/issues/3301
