### PR TITLE
fix(community): only checkPermissions if the community has permissions

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1433,6 +1433,10 @@ func (o *Community) TokenPermissions() map[string]*protobuf.CommunityTokenPermis
 	return o.config.CommunityDescription.TokenPermissions
 }
 
+func (o *Community) HasTokenPermissions() bool {
+	return len(o.config.CommunityDescription.TokenPermissions) > 0
+}
+
 func (o *Community) TokenPermissionsByType(permissionType protobuf.CommunityTokenPermission_Type) []*protobuf.CommunityTokenPermission {
 	permissions := make([]*protobuf.CommunityTokenPermission, 0)
 	for _, tokenPermission := range o.TokenPermissions() {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -732,7 +732,7 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 			}()
 
 			for _, c := range adminCommunities {
-				if c.Joined() {
+				if c.Joined() && c.HasTokenPermissions() {
 					go m.communitiesManager.CheckMemberPermissionsPeriodically(c.ID())
 				}
 			}


### PR DESCRIPTION
There was a crash with the following logs:

```
goroutine 1910 [running]:
github.com/status-im/status-go/protocol/communities.(*Manager).CheckMemberPermissionsPeriodically(0xc003214160, {0xc005fa5440, 0x21, 0x21})
	/Users/mprakhov/Work/status/status-desktop/vendor/status-go/protocol/communities/manager.go:609 +0x2d8
created by github.com/status-im/status-go/protocol.(*Messenger).Start
	/Users/mprakhov/Work/status/status-desktop/vendor/status-go/protocol/messenger.go:735 +0xd0d
```

I fixed by checking if a community has permissions before calling the function.

The crash is hard to reproduce, but once I applied this fix, I couldn't see if anymore.