### PR TITLE
fix(encryptor): correctly send an error when there is no encryption key

### DIFF
--- a/protocol/encryption/encryptor.go
+++ b/protocol/encryption/encryptor.go
@@ -670,6 +670,9 @@ func (s *encryptor) encryptWithHR(groupID []byte, keyID uint32, payload []byte) 
 	if err != nil {
 		return nil, err
 	}
+	if hrCache == nil {
+		return nil, errors.New("no encryption key found for the community")
+	}
 
 	var dbHash []byte
 	if len(hrCache.Hash) == 0 {


### PR DESCRIPTION
It would crash otherwise, leaving no message
