### PR TITLE
Check ownership of collectibles in community permissions

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -218,6 +218,7 @@ func main() {
 			protocol.WithPushNotificationServerConfig(&config.PushNotificationServerConfig),
 			protocol.WithDatabase(db),
 			protocol.WithTorrentConfig(&config.TorrentConfig),
+			protocol.WithWalletConfig(&config.WalletConfig),
 			protocol.WithRPCClient(backend.StatusNode().RPCClient()),
 		}
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -417,6 +417,10 @@ func NewMessenger(
 		managerOptions = append(managerOptions, communities.WithTokenManager(tokenManager))
 	}
 
+	if c.walletConfig != nil {
+		managerOptions = append(managerOptions, communities.WithWalletConfig(c.walletConfig))
+	}
+
 	communitiesManager, err := communities.NewManager(identity, database, encryptionProtocol, logger, ensVerifier, transp, c.torrentConfig, managerOptions...)
 	if err != nil {
 		return nil, err

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -83,6 +83,7 @@ type config struct {
 	clusterConfig       params.ClusterConfig
 	browserDatabase     *browsers.Database
 	torrentConfig       *params.TorrentConfig
+	walletConfig        *params.WalletConfig
 	httpServer          *server.MediaServer
 	rpcClient           *rpc.Client
 
@@ -305,6 +306,13 @@ func WithHTTPServer(s *server.MediaServer) Option {
 func WithRPCClient(r *rpc.Client) Option {
 	return func(c *config) error {
 		c.rpcClient = r
+		return nil
+	}
+}
+
+func WithWalletConfig(wc *params.WalletConfig) Option {
+	return func(c *config) error {
+		c.walletConfig = wc
 		return nil
 	}
 }

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -425,6 +425,7 @@ func buildMessengerOptions(
 		protocol.WithHTTPServer(httpServer),
 		protocol.WithRPCClient(rpcClient),
 		protocol.WithMessageCSV(config.OutputMessageCSVEnabled),
+		protocol.WithWalletConfig(&config.WalletConfig),
 	}
 
 	if config.ShhextConfig.DataSyncEnabled {

--- a/services/wallet/thirdparty/opensea/client_test.go
+++ b/services/wallet/thirdparty/opensea/client_test.go
@@ -39,8 +39,11 @@ func TestFetchAllCollectionsByOwner(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	opensea := &Client{
+	client := &HTTPClient{
 		client: srv.Client(),
+	}
+	opensea := &Client{
+		client: client,
 		url:    srv.URL,
 	}
 	res, err := opensea.FetchAllCollectionsByOwner(common.Address{1})
@@ -58,8 +61,11 @@ func TestFetchAllCollectionsByOwnerWithInValidJson(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	opensea := &Client{
+	client := &HTTPClient{
 		client: srv.Client(),
+	}
+	opensea := &Client{
+		client: client,
 		url:    srv.URL,
 	}
 	res, err := opensea.FetchAllCollectionsByOwner(common.Address{1})
@@ -92,8 +98,11 @@ func TestFetchAllAssetsByOwnerAndCollection(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	opensea := &Client{
+	client := &HTTPClient{
 		client: srv.Client(),
+	}
+	opensea := &Client{
+		client: client,
 		url:    srv.URL,
 	}
 	res, err := opensea.FetchAllAssetsByOwnerAndCollection(common.Address{1}, "rocky", "", 200)
@@ -111,8 +120,11 @@ func TestFetchAllAssetsByOwnerAndCollectionInvalidJson(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	opensea := &Client{
+	client := &HTTPClient{
 		client: srv.Client(),
+	}
+	opensea := &Client{
+		client: client,
 		url:    srv.URL,
 	}
 	res, err := opensea.FetchAllAssetsByOwnerAndCollection(common.Address{1}, "rocky", "", 200)


### PR DESCRIPTION
This adds an additional check for collectibles when community permissions are validated.

Specifically this uses opensea to request all NFTs given an owner wallet and a list of contract addresses (collectibles).

