### PR TITLE
fix: simplified tokenURI retrieval. Extended NFTMetadata struct.

### DIFF
--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -569,9 +569,10 @@ func (s *Service) FetchNFTMetadata(chainID uint64, id thirdparty.NFTUniqueID, to
 			contractAddresses := tokenMetadata.GetContractAddresses()
 			if contractAddresses[chainID] == id.ContractAddress.Hex() {
 				return &thirdparty.NFTMetadata{
-					Name:        tokenMetadata.GetName(),
-					Description: tokenMetadata.GetDescription(),
-					ImageURL:    tokenMetadata.GetImage(),
+					Name:               tokenMetadata.GetName(),
+					Description:        tokenMetadata.GetDescription(),
+					CollectionImageURL: tokenMetadata.GetImage(),
+					ImageURL:           tokenMetadata.GetImage(),
 				}, nil
 			}
 		}

--- a/services/wallet/thirdparty/types.go
+++ b/services/wallet/thirdparty/types.go
@@ -47,9 +47,10 @@ type NFTUniqueID struct {
 }
 
 type NFTMetadata struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	ImageURL    string `json:"image"`
+	Name               string `json:"name"`
+	Description        string `json:"description"`
+	CollectionImageURL string `json:"collection_image"`
+	ImageURL           string `json:"image"`
 }
 
 type NFTMetadataProvider interface {


### PR DESCRIPTION
Call to `SupportsInterface` was not really useful since we don't know if the contract supports that method to begin with. We now call `TokenURI` directly and check for reversal error.
