### PR TITLE
feat: backup display name improvements

### DIFF
--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -557,7 +557,7 @@ func (s *MessengerCommunitiesSuite) TestCommunityContactCodeAdvertisement() {
 	s.joinCommunity(community, s.alice)
 
 	// Trigger ContactCodeAdvertisement
-	err := s.bob.SetDisplayName("bobby", true)
+	err := s.bob.SetDisplayName("bobby")
 	s.Require().NoError(err)
 	err = s.bob.SetBio("I like P2P chats")
 	s.Require().NoError(err)

--- a/protocol/messenger_backup.go
+++ b/protocol/messenger_backup.go
@@ -89,7 +89,7 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	_, settings, errors := m.prepareSyncSettingsMessages(clock)
+	_, settings, errors := m.prepareSyncSettingsMessages(clock, true)
 	if len(errors) != 0 {
 		// return just the first error, the others have been logged
 		return 0, errors[0]

--- a/protocol/messenger_backup_test.go
+++ b/protocol/messenger_backup_test.go
@@ -143,7 +143,7 @@ func (s *MessengerBackupSuite) TestBackupProfile() {
 
 	// Create bob1
 	bob1 := s.m
-	err := bob1.SetDisplayName(bob1DisplayName, true)
+	err := bob1.SetDisplayName(bob1DisplayName)
 	s.Require().NoError(err)
 	bob1KeyUID := bob1.account.KeyUID
 	imagesExpected := fmt.Sprintf(`[{"keyUid":"%s","type":"large","uri":"data:image/png;base64,iVBORw0KGgoAAAANSUg=","width":240,"height":300,"fileSize":1024,"resizeTarget":240,"clock":0},{"keyUid":"%s","type":"thumbnail","uri":"data:image/jpeg;base64,/9j/2wCEAFA3PEY8MlA=","width":80,"height":80,"fileSize":256,"resizeTarget":80,"clock":0}]`,

--- a/protocol/messenger_identity.go
+++ b/protocol/messenger_identity.go
@@ -50,7 +50,7 @@ func ValidateDisplayName(displayName *string) error {
 	return nil
 }
 
-func (m *Messenger) SetDisplayName(displayName string, publishChange bool) error {
+func (m *Messenger) SetDisplayName(displayName string) error {
 	currDisplayName, err := m.settings.DisplayName()
 	if err != nil {
 		return err
@@ -64,7 +64,7 @@ func (m *Messenger) SetDisplayName(displayName string, publishChange bool) error
 		return err
 	}
 
-	m.account.Name = displayName // We might need to do the same when syncing settings?
+	m.account.Name = displayName
 	err = m.multiAccounts.SaveAccount(*m.account)
 	if err != nil {
 		return err
@@ -75,16 +75,22 @@ func (m *Messenger) SetDisplayName(displayName string, publishChange bool) error
 		return err
 	}
 
-	if publishChange {
-		err = m.resetLastPublishedTimeForChatIdentity()
-		if err != nil {
-			return err
-		}
-
-		return m.publishContactCode()
+	err = m.resetLastPublishedTimeForChatIdentity()
+	if err != nil {
+		return err
 	}
 
-	return nil
+	return m.publishContactCode()
+}
+
+func (m *Messenger) SaveSyncDisplayName(displayName string, clock uint64) error {
+	err := m.settings.SaveSyncSetting(settings.DisplayName, displayName, clock)
+	if err != nil {
+		return err
+	}
+
+	m.account.Name = displayName
+	return m.multiAccounts.SaveAccount(*m.account)
 }
 
 func ValidateBio(bio *string) error {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -833,7 +833,7 @@ func (api *PublicAPI) SendContactUpdate(ctx context.Context, contactID, name, pi
 }
 
 func (api *PublicAPI) SetDisplayName(ctx context.Context, displayName string) error {
-	return api.service.messenger.SetDisplayName(displayName, true)
+	return api.service.messenger.SetDisplayName(displayName)
 }
 
 func (api *PublicAPI) MarkAsTrusted(ctx context.Context, contactID string) error {


### PR DESCRIPTION
- Display name is now backed up only as a part of `protobuf.BackedUpProfile` message, it is not backed up via `protobuf.SyncSetting` any more (this refers only to backing up to and fetching data from waku, regular syncing (among devices) remains unchanged)

- When saving the display name fetched from waku, before a clock was set to the current time when that operation is made, which was incorrect, now we're using the clock from backed up message (`SaveSyncDisplayName` function)