### PR TITLE
feat: collectibles cache

### DIFF
--- a/services/wallet/thirdparty/types.go
+++ b/services/wallet/thirdparty/types.go
@@ -46,6 +46,10 @@ type NFTUniqueID struct {
 	TokenID         *bigint.BigInt `json:"tokenID"`
 }
 
+func (k *NFTUniqueID) HashKey() string {
+	return k.ContractAddress.String() + "+" + k.TokenID.String()
+}
+
 type NFTMetadata struct {
 	Name               string `json:"name"`
 	Description        string `json:"description"`


### PR DESCRIPTION
NFT metadata should not normally change, so we can save us several Opensea requests by caching it.

When requesting NFTs by their unique ID, we'll first look in the cache. If not found, we'll fetch them.
The cache gets updated when the assets are retrieved through the ownership-related methods.