### PR TITLE
feature(messenger): RequestContactInfoFromMailserver

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -144,6 +144,9 @@ type Messenger struct {
 	requestedCommunitiesLock sync.RWMutex
 	requestedCommunities     map[string]*transport.Filter
 
+	requestedContactsLock sync.RWMutex
+	requestedContacts     map[string]*transport.Filter
+
 	connectionState                      connection.State
 	telemetryClient                      *telemetry.Client
 	contractMaker                        *contracts.ContractMaker
@@ -478,6 +481,8 @@ func NewMessenger(
 		cancel:                   cancel,
 		requestedCommunitiesLock: sync.RWMutex{},
 		requestedCommunities:     make(map[string]*transport.Filter),
+		requestedContactsLock:    sync.RWMutex{},
+		requestedContacts:        make(map[string]*transport.Filter),
 		importingCommunities:     make(map[string]bool),
 		browserDatabase:          c.browserDatabase,
 		httpServer:               c.httpServer,
@@ -3352,9 +3357,11 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 
 				senderID := contactIDFromPublicKey(publicKey)
 
-				// Check for messages from blocked users
-				if contact, ok := messageState.AllContacts.Load(senderID); ok && contact.Blocked {
-					continue
+				if _, ok := m.requestedContacts[senderID]; !ok {
+					// Check for messages from blocked users
+					if contact, ok := messageState.AllContacts.Load(senderID); ok && contact.Blocked {
+						continue
+					}
 				}
 
 				// Don't process duplicates
@@ -3380,6 +3387,7 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 					}
 					contact = c
 					messageState.AllContacts.Store(senderID, contact)
+					m.forgetContactInfoRequest(senderID)
 				}
 				messageState.CurrentMessageState = &CurrentMessageState{
 					MessageID:        messageID,
@@ -3847,6 +3855,8 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 						}
 
 					case protobuf.ContactUpdate:
+						logger.Info("<<< ContactUpdate", zap.String("publicKey", senderID))
+
 						if common.IsPubKeyEqual(messageState.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
 							logger.Warn("coming from us, ignoring")
 							continue
@@ -3860,6 +3870,8 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 							allMessagesProcessed = false
 							continue
 						}
+						m.forgetContactInfoRequest(senderID)
+
 					case protobuf.AcceptContactRequest:
 						logger.Debug("Handling AcceptContactRequest")
 						message := msg.ParsedMessage.Interface().(protobuf.AcceptContactRequest)

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -334,6 +334,10 @@ func (api *PublicAPI) GetContactByID(parent context.Context, id string) *protoco
 	return api.service.messenger.GetContactByID(id)
 }
 
+func (api *PublicAPI) RequestContactInfoFromMailserver(pubkey string) (*protocol.Contact, error) {
+	return api.service.messenger.RequestContactInfoFromMailserver(pubkey, true)
+}
+
 func (api *PublicAPI) RemoveFilters(parent context.Context, chats []*transport.Filter) error {
 	return api.service.messenger.RemoveFilters(chats)
 }


### PR DESCRIPTION
Required and tested in https://github.com/status-im/status-desktop/pull/10177

Implemented `RequestContactInfoFromMailserver` function.
This is needed to show profile info of unknown contact, e.g. during sending contact request. 
The desired behavior is implemented by creating a temporal mailserver subscription for given public key.

The implementation is based in `RequestCommunityInfoFromMailserver`.