### PR TITLE
fix: add supported chains to OpenSea

### DIFF
--- a/services/wallet/thirdparty/opensea/client.go
+++ b/services/wallet/thirdparty/opensea/client.go
@@ -35,15 +35,15 @@ const ChainIDRequiringAPIKey = 1
 
 func getbaseURL(chainID uint64) (string, error) {
 	switch chainID {
-	case 1:
+	case 1, 10, 42161:
 		return "https://api.opensea.io/api/v1", nil
 	case 4:
 		return "https://rinkeby-api.opensea.io/api/v1", nil
-	case 5:
+	case 5, 420, 421613:
 		return "https://testnets-api.opensea.io/api/v1", nil
 	}
 
-	return "", fmt.Errorf("chainID not supported")
+	return "", fmt.Errorf("chainID not supported: %d", chainID)
 }
 
 var OpenseaClientInstances = make(map[uint64]*Client)


### PR DESCRIPTION
Opensea supports several chains (both mainnet and testnet: https://support.opensea.io/hc/en-us/articles/4404027708051-Which-blockchains-are-compatible-with-OpenSea-). Add the ones we use in the app, since, although we normally pass the Ethereum chain when fetching owned collectibles, the specific one is used when fetching NFT metadata for transactions.