### PR TITLE
fix(chat-api): fix unread count on channelGroup condition

### DIFF
--- a/services/chat/api.go
+++ b/services/chat/api.go
@@ -146,10 +146,9 @@ func (api *API) GetChannelGroups(ctx context.Context) (map[string]ChannelGroup, 
 	totalUnviewedMentionsCount := 0
 
 	for _, chat := range channels {
-		if !chat.IsActivePersonalChat() {
+		if !chat.Active {
 			continue
 		}
-
 		totalUnviewedMessageCount += int(chat.UnviewedMessagesCount)
 		totalUnviewedMentionsCount += int(chat.UnviewedMentionsCount)
 	}


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10264

Bad condition from my part. We just need to check if it is an active channel, not a personal one