### PR TITLE
feat: add api to get list of owners from a given nft contract

### DIFF
--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -56,8 +56,6 @@ var (
 	// ErrRPCClientUnavailable is returned if an RPC client can't be retrieved.
 	// This is a normal situation when a node is stopped.
 	ErrRPCClientUnavailable = errors.New("JSON-RPC client is unavailable")
-	// OpenseaKeyFromEnv passed from on env var during build time
-	OpenseaKeyFromEnv string
 )
 
 func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *server.MediaServer) error {
@@ -132,11 +130,7 @@ func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *server
 	}
 
 	if config.WalletConfig.Enabled {
-		openseaKey := config.WalletConfig.OpenseaAPIKey
-		if len(openseaKey) == 0 {
-			openseaKey = OpenseaKeyFromEnv
-		}
-		walletService := b.walletService(accDB, accountsFeed, openseaKey, config.WalletConfig.AlchemyAPIKeys, config.WalletConfig.InfuraAPIKey, config.WalletConfig.InfuraAPIKeySecret)
+		walletService := b.walletService(accDB, accountsFeed)
 		services = append(services, walletService)
 	}
 
@@ -471,7 +465,7 @@ func (b *StatusNode) appmetricsService() common.StatusService {
 	return b.appMetricsSrvc
 }
 
-func (b *StatusNode) walletService(accountsDB *accounts.Database, accountsFeed *event.Feed, openseaAPIKey string, alchemyAPIKeys map[uint64]string, infuraAPIKey string, infuraAPIKeySecret string) common.StatusService {
+func (b *StatusNode) walletService(accountsDB *accounts.Database, accountsFeed *event.Feed) common.StatusService {
 	if b.walletSrvc == nil {
 		var extService *ext.Service
 		if b.WakuV2ExtService() != nil {
@@ -480,7 +474,7 @@ func (b *StatusNode) walletService(accountsDB *accounts.Database, accountsFeed *
 			extService = b.WakuExtService().Service
 		}
 		b.walletSrvc = wallet.NewService(
-			b.appDB, accountsDB, b.rpcClient, accountsFeed, openseaAPIKey, alchemyAPIKeys, infuraAPIKey, infuraAPIKeySecret, b.gethAccountManager, b.transactor, b.config,
+			b.appDB, accountsDB, b.rpcClient, accountsFeed, b.gethAccountManager, b.transactor, b.config,
 			b.ensService(),
 			b.stickersService(accountsDB),
 			extService,

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -136,7 +136,7 @@ func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *server
 		if len(openseaKey) == 0 {
 			openseaKey = OpenseaKeyFromEnv
 		}
-		walletService := b.walletService(accDB, accountsFeed, openseaKey)
+		walletService := b.walletService(accDB, accountsFeed, openseaKey, config.WalletConfig.AlchemyAPIKeys, config.WalletConfig.InfuraAPIKey, config.WalletConfig.InfuraAPIKeySecret)
 		services = append(services, walletService)
 	}
 
@@ -471,7 +471,7 @@ func (b *StatusNode) appmetricsService() common.StatusService {
 	return b.appMetricsSrvc
 }
 
-func (b *StatusNode) walletService(accountsDB *accounts.Database, accountsFeed *event.Feed, openseaAPIKey string) common.StatusService {
+func (b *StatusNode) walletService(accountsDB *accounts.Database, accountsFeed *event.Feed, openseaAPIKey string, alchemyAPIKeys map[uint64]string, infuraAPIKey string, infuraAPIKeySecret string) common.StatusService {
 	if b.walletSrvc == nil {
 		var extService *ext.Service
 		if b.WakuV2ExtService() != nil {
@@ -480,7 +480,7 @@ func (b *StatusNode) walletService(accountsDB *accounts.Database, accountsFeed *
 			extService = b.WakuExtService().Service
 		}
 		b.walletSrvc = wallet.NewService(
-			b.appDB, accountsDB, b.rpcClient, accountsFeed, openseaAPIKey, b.gethAccountManager, b.transactor, b.config,
+			b.appDB, accountsDB, b.rpcClient, accountsFeed, openseaAPIKey, alchemyAPIKeys, infuraAPIKey, infuraAPIKeySecret, b.gethAccountManager, b.transactor, b.config,
 			b.ensService(),
 			b.stickersService(accountsDB),
 			extService,

--- a/params/config.go
+++ b/params/config.go
@@ -515,8 +515,11 @@ type Network struct {
 
 // WalletConfig extra configuration for wallet.Service.
 type WalletConfig struct {
-	Enabled       bool
-	OpenseaAPIKey string `json:"OpenseaAPIKey"`
+	Enabled            bool
+	OpenseaAPIKey      string            `json:"OpenseaAPIKey"`
+	AlchemyAPIKeys     map[uint64]string `json:"AlchemyAPIKeys"`
+	InfuraAPIKey       string            `json:"InfuraAPIKey"`
+	InfuraAPIKeySecret string            `json:"InfuraAPIKeySecret"`
 }
 
 // LocalNotificationsConfig extra configuration for localnotifications.Service.

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -320,6 +320,11 @@ func (api *API) GetOpenseaAssetsByNFTUniqueID(ctx context.Context, chainID uint6
 	return api.s.collectiblesManager.FetchAssetsByNFTUniqueID(chainID, uniqueIDs, limit)
 }
 
+func (api *API) GetCollectibleOwnersByContractAddress(chainID uint64, contractAddress common.Address) (*thirdparty.NFTContractOwnership, error) {
+	log.Debug("call to GetCollectibleOwnersByContractAddress")
+	return api.s.collectiblesManager.FetchNFTOwnersByContractAddress(chainID, contractAddress)
+}
+
 func (api *API) AddEthereumChain(ctx context.Context, network params.Network) error {
 	log.Debug("call to AddEthereumChain")
 	return api.s.rpcClient.NetworkManager.Upsert(&network)

--- a/services/wallet/bigint/hex_big_int.go
+++ b/services/wallet/bigint/hex_big_int.go
@@ -1,0 +1,33 @@
+package bigint
+
+import (
+	"math/big"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// Unmarshals a u256 as a fixed-length hex string with 0x prefix and leading zeros
+type HexBigInt struct {
+	*big.Int
+}
+
+const FixedLength = 32 // u256 -> 32 bytes
+
+var (
+	hexBigIntT = reflect.TypeOf(HexBigInt{})
+)
+
+func (b *HexBigInt) UnmarshalJSON(input []byte) error {
+	var buf [FixedLength]byte
+	err := hexutil.UnmarshalFixedJSON(hexBigIntT, input, buf[:])
+
+	if err != nil {
+		return err
+	}
+
+	z := new(big.Int)
+	z.SetBytes(buf[:])
+	b.Int = z
+	return nil
+}

--- a/services/wallet/bigint/hex_big_int_test.go
+++ b/services/wallet/bigint/hex_big_int_test.go
@@ -1,0 +1,25 @@
+package bigint
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalUnmarshal(t *testing.T) {
+	inputString := "0x09abc5177d51c36ef4c6a36197d023b60d8fec0100000000000001000000000a"
+	inputInt := new(big.Int)
+	inputInt.SetString(inputString[2:], 16)
+
+	inputBytes, err := json.Marshal(inputString)
+
+	require.NoError(t, err)
+
+	u := new(HexBigInt)
+	err = u.UnmarshalJSON(inputBytes)
+
+	require.NoError(t, err)
+	require.Equal(t, inputInt, u.Int)
+}

--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -1,0 +1,13 @@
+package common
+
+type ChainID uint64
+
+const (
+	EthereumMainnet uint64 = 1
+	EthereumGoerli  uint64 = 5
+	EthereumSepolia uint64 = 11155111
+	OptimismMainnet uint64 = 10
+	OptimismGoerli  uint64 = 420
+	ArbitrumMainnet uint64 = 42161
+	ArbitrumGoerli  uint64 = 421613
+)

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -42,10 +42,6 @@ func NewService(
 	accountsDB *accounts.Database,
 	rpcClient *rpc.Client,
 	accountFeed *event.Feed,
-	openseaAPIKey string,
-	alchemyAPIKeys map[uint64]string,
-	infuraAPIKey string,
-	infuraAPIKeySecret string,
 	gethManager *account.GethManager,
 	transactor *transactions.Transactor,
 	config *params.NodeConfig,
@@ -98,9 +94,9 @@ func NewService(
 	history := history.NewService(db, walletFeed, rpcClient, tokenManager, marketManager)
 	currency := currency.NewService(db, walletFeed, tokenManager, marketManager)
 
-	alchemyClient := alchemy.NewClient(alchemyAPIKeys)
-	infuraClient := infura.NewClient(infuraAPIKey, infuraAPIKeySecret)
-	collectiblesManager := collectibles.NewManager(rpcClient, alchemyClient, infuraClient, nftMetadataProvider, openseaAPIKey, walletFeed)
+	alchemyClient := alchemy.NewClient(config.WalletConfig.AlchemyAPIKeys)
+	infuraClient := infura.NewClient(config.WalletConfig.InfuraAPIKey, config.WalletConfig.InfuraAPIKeySecret)
+	collectiblesManager := collectibles.NewManager(rpcClient, alchemyClient, infuraClient, nftMetadataProvider, config.WalletConfig.OpenseaAPIKey, walletFeed)
 	return &Service{
 		db:                    db,
 		accountsDB:            accountsDB,

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -22,8 +22,10 @@ import (
 	"github.com/status-im/status-go/services/wallet/history"
 	"github.com/status-im/status-go/services/wallet/market"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
+	"github.com/status-im/status-go/services/wallet/thirdparty/alchemy"
 	"github.com/status-im/status-go/services/wallet/thirdparty/coingecko"
 	"github.com/status-im/status-go/services/wallet/thirdparty/cryptocompare"
+	"github.com/status-im/status-go/services/wallet/thirdparty/infura"
 	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/services/wallet/transfer"
 	"github.com/status-im/status-go/services/wallet/walletevent"
@@ -41,6 +43,9 @@ func NewService(
 	rpcClient *rpc.Client,
 	accountFeed *event.Feed,
 	openseaAPIKey string,
+	alchemyAPIKeys map[uint64]string,
+	infuraAPIKey string,
+	infuraAPIKeySecret string,
 	gethManager *account.GethManager,
 	transactor *transactions.Transactor,
 	config *params.NodeConfig,
@@ -92,7 +97,10 @@ func NewService(
 	reader := NewReader(rpcClient, tokenManager, marketManager, accountsDB, walletFeed)
 	history := history.NewService(db, walletFeed, rpcClient, tokenManager, marketManager)
 	currency := currency.NewService(db, walletFeed, tokenManager, marketManager)
-	collectiblesManager := collectibles.NewManager(rpcClient, nftMetadataProvider, openseaAPIKey, walletFeed)
+
+	alchemyClient := alchemy.NewClient(alchemyAPIKeys)
+	infuraClient := infura.NewClient(infuraAPIKey, infuraAPIKeySecret)
+	collectiblesManager := collectibles.NewManager(rpcClient, alchemyClient, infuraClient, nftMetadataProvider, openseaAPIKey, walletFeed)
 	return &Service{
 		db:                    db,
 		accountsDB:            accountsDB,

--- a/services/wallet/thirdparty/alchemy/client.go
+++ b/services/wallet/thirdparty/alchemy/client.go
@@ -1,0 +1,161 @@
+package alchemy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/bigint"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+func getBaseURL(chainID uint64) (string, error) {
+	switch chainID {
+	case 1:
+		return "https://eth-mainnet.g.alchemy.com", nil
+	case 5:
+		return "https://eth-goerli.g.alchemy.com", nil
+	case 11155111:
+		return "https://eth-sepolia.g.alchemy.com", nil
+	case 10:
+		return "https://opt-mainnet.g.alchemy.com", nil
+	case 420:
+		return "https://opt-goerli.g.alchemy.com", nil
+	case 42161:
+		return "https://arb-mainnet.g.alchemy.com", nil
+	case 421613:
+		return "https://arb-goerli.g.alchemy.com", nil
+	}
+
+	return "", fmt.Errorf("chainID not supported: %d", chainID)
+}
+
+func getAPIKeySubpath(apiKey string) string {
+	if apiKey == "" {
+		return "demo"
+	}
+	return apiKey
+}
+
+func getNFTBaseURL(chainID uint64, apiKey string) (string, error) {
+	baseURL, err := getBaseURL(chainID)
+
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s/nft/v2/%s", baseURL, getAPIKeySubpath(apiKey)), nil
+}
+
+type TokenBalance struct {
+	TokenID *bigint.HexBigInt `json:"tokenId"`
+	Balance *bigint.BigInt    `json:"balance"`
+}
+
+type NFTOwner struct {
+	OwnerAddress  common.Address `json:"ownerAddress"`
+	TokenBalances []TokenBalance `json:"tokenBalances"`
+}
+
+type NFTContractOwnership struct {
+	Owners  []NFTOwner `json:"ownerAddresses"`
+	PageKey string     `json:"pageKey"`
+}
+
+type Client struct {
+	thirdparty.NFTContractOwnershipProvider
+	client          *http.Client
+	apiKeys         map[uint64]string
+	IsConnected     bool
+	IsConnectedLock sync.RWMutex
+}
+
+func NewClient(apiKeys map[uint64]string) *Client {
+	return &Client{
+		client:  &http.Client{Timeout: time.Minute},
+		apiKeys: apiKeys,
+	}
+}
+
+func (o *Client) doQuery(url string) (*http.Response, error) {
+	resp, err := o.client.Get(url)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (o *Client) IsChainSupported(chainID uint64) bool {
+	_, err := getBaseURL(chainID)
+	return err == nil
+}
+
+func alchemyOwnershipToCommon(contractAddress common.Address, alchemyOwnership NFTContractOwnership) (*thirdparty.NFTContractOwnership, error) {
+	owners := make([]thirdparty.NFTOwner, 0, len(alchemyOwnership.Owners))
+	for _, alchemyOwner := range alchemyOwnership.Owners {
+		balances := make([]thirdparty.TokenBalance, 0, len(alchemyOwner.TokenBalances))
+
+		for _, alchemyBalance := range alchemyOwner.TokenBalances {
+			balances = append(balances, thirdparty.TokenBalance{
+				TokenID: &bigint.BigInt{Int: alchemyBalance.TokenID.Int},
+				Balance: alchemyBalance.Balance,
+			})
+		}
+		owner := thirdparty.NFTOwner{
+			OwnerAddress:  alchemyOwner.OwnerAddress,
+			TokenBalances: balances,
+		}
+
+		owners = append(owners, owner)
+	}
+
+	ownership := thirdparty.NFTContractOwnership{
+		ContractAddress: contractAddress,
+		Owners:          owners,
+	}
+
+	return &ownership, nil
+}
+
+func (o *Client) FetchNFTOwnersByContractAddress(chainID uint64, contractAddress common.Address) (*thirdparty.NFTContractOwnership, error) {
+	queryParams := url.Values{
+		"contractAddress":   {contractAddress.String()},
+		"withTokenBalances": {"true"},
+	}
+
+	url, err := getNFTBaseURL(chainID, o.apiKeys[chainID])
+
+	if err != nil {
+		return nil, err
+	}
+
+	url = url + "/getOwnersForCollection?" + queryParams.Encode()
+
+	resp, err := o.doQuery(url)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var alchemyOwnership NFTContractOwnership
+	err = json.Unmarshal(body, &alchemyOwnership)
+	if err != nil {
+		return nil, err
+	}
+
+	return alchemyOwnershipToCommon(contractAddress, alchemyOwnership)
+}

--- a/services/wallet/thirdparty/alchemy/client.go
+++ b/services/wallet/thirdparty/alchemy/client.go
@@ -11,24 +11,25 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/services/wallet/bigint"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 )
 
 func getBaseURL(chainID uint64) (string, error) {
 	switch chainID {
-	case 1:
+	case walletCommon.EthereumMainnet:
 		return "https://eth-mainnet.g.alchemy.com", nil
-	case 5:
+	case walletCommon.EthereumGoerli:
 		return "https://eth-goerli.g.alchemy.com", nil
-	case 11155111:
+	case walletCommon.EthereumSepolia:
 		return "https://eth-sepolia.g.alchemy.com", nil
-	case 10:
+	case walletCommon.OptimismMainnet:
 		return "https://opt-mainnet.g.alchemy.com", nil
-	case 420:
+	case walletCommon.OptimismGoerli:
 		return "https://opt-goerli.g.alchemy.com", nil
-	case 42161:
+	case walletCommon.ArbitrumMainnet:
 		return "https://arb-mainnet.g.alchemy.com", nil
-	case 421613:
+	case walletCommon.ArbitrumGoerli:
 		return "https://arb-goerli.g.alchemy.com", nil
 	}
 

--- a/services/wallet/thirdparty/infura/client.go
+++ b/services/wallet/thirdparty/infura/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/services/wallet/bigint"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 )
 
@@ -64,7 +65,7 @@ func (o *Client) doQuery(url string) (*http.Response, error) {
 
 func (o *Client) IsChainSupported(chainID uint64) bool {
 	switch chainID {
-	case 1, 5, 42161, 11155111:
+	case walletCommon.EthereumMainnet, walletCommon.EthereumGoerli, walletCommon.EthereumSepolia, walletCommon.ArbitrumMainnet:
 		return true
 	}
 	return false

--- a/services/wallet/thirdparty/infura/client.go
+++ b/services/wallet/thirdparty/infura/client.go
@@ -1,0 +1,141 @@
+package infura
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/bigint"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+const baseURL = "https://nft.api.infura.io"
+
+type NFTOwner struct {
+	ContractAddress common.Address `json:"tokenAddress"`
+	TokenID         *bigint.BigInt `json:"tokenId"`
+	Amount          *bigint.BigInt `json:"amount"`
+	OwnerAddress    common.Address `json:"ownerOf"`
+}
+
+type NFTContractOwnership struct {
+	Owners  []NFTOwner `json:"owners"`
+	Network string     `json:"network"`
+	Cursor  string     `json:"cursor"`
+}
+
+type Client struct {
+	thirdparty.NFTContractOwnershipProvider
+	client          *http.Client
+	apiKey          string
+	apiKeySecret    string
+	IsConnected     bool
+	IsConnectedLock sync.RWMutex
+}
+
+func NewClient(apiKey string, apiKeySecret string) *Client {
+	return &Client{
+		client: &http.Client{Timeout: time.Minute},
+		apiKey: apiKey,
+	}
+}
+
+func (o *Client) doQuery(url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(o.apiKey, o.apiKeySecret)
+
+	resp, err := o.client.Do(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func (o *Client) IsChainSupported(chainID uint64) bool {
+	switch chainID {
+	case 1, 5, 42161, 11155111:
+		return true
+	}
+	return false
+}
+
+func infuraOwnershipToCommon(contractAddress common.Address, ownersMap map[common.Address][]NFTOwner) (*thirdparty.NFTContractOwnership, error) {
+	owners := make([]thirdparty.NFTOwner, 0, len(ownersMap))
+
+	for ownerAddress, ownerTokens := range ownersMap {
+		tokenBalances := make([]thirdparty.TokenBalance, 0, len(ownerTokens))
+
+		for _, token := range ownerTokens {
+			tokenBalances = append(tokenBalances, thirdparty.TokenBalance{
+				TokenID: token.TokenID,
+				Balance: token.Amount,
+			})
+		}
+
+		owners = append(owners, thirdparty.NFTOwner{
+			OwnerAddress:  ownerAddress,
+			TokenBalances: tokenBalances,
+		})
+	}
+
+	ownership := thirdparty.NFTContractOwnership{
+		ContractAddress: contractAddress,
+		Owners:          owners,
+	}
+
+	return &ownership, nil
+}
+
+func (o *Client) FetchNFTOwnersByContractAddress(chainID uint64, contractAddress common.Address) (*thirdparty.NFTContractOwnership, error) {
+	cursor := ""
+	ownersMap := make(map[common.Address][]NFTOwner)
+
+	for {
+		url := fmt.Sprintf("%s/networks/%d/nfts/%s/owners", baseURL, chainID, contractAddress.String())
+
+		if cursor != "" {
+			url = url + "?cursor=" + cursor
+		}
+
+		resp, err := o.doQuery(url)
+		if err != nil {
+			return nil, err
+		}
+
+		defer resp.Body.Close()
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		var infuraOwnership NFTContractOwnership
+		err = json.Unmarshal(body, &infuraOwnership)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, infuraOwner := range infuraOwnership.Owners {
+			ownersMap[infuraOwner.OwnerAddress] = append(ownersMap[infuraOwner.OwnerAddress], infuraOwner)
+		}
+
+		cursor = infuraOwnership.Cursor
+
+		if cursor == "" {
+			break
+		}
+	}
+
+	return infuraOwnershipToCommon(contractAddress, ownersMap)
+}

--- a/services/wallet/thirdparty/opensea/client.go
+++ b/services/wallet/thirdparty/opensea/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/status-im/status-go/services/wallet/bigint"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/services/wallet/walletevent"
 )
@@ -35,11 +36,9 @@ const ChainIDRequiringAPIKey = 1
 
 func getbaseURL(chainID uint64) (string, error) {
 	switch chainID {
-	case 1, 10, 42161:
+	case walletCommon.EthereumMainnet, walletCommon.OptimismMainnet, walletCommon.ArbitrumMainnet:
 		return "https://api.opensea.io/api/v1", nil
-	case 4:
-		return "https://rinkeby-api.opensea.io/api/v1", nil
-	case 5, 420, 421613:
+	case walletCommon.EthereumGoerli, walletCommon.OptimismGoerli, walletCommon.ArbitrumGoerli:
 		return "https://testnets-api.opensea.io/api/v1", nil
 	}
 

--- a/services/wallet/thirdparty/types.go
+++ b/services/wallet/thirdparty/types.go
@@ -61,3 +61,23 @@ type NFTMetadataProvider interface {
 	CanProvideNFTMetadata(chainID uint64, id NFTUniqueID, tokenURI string) (bool, error)
 	FetchNFTMetadata(chainID uint64, id NFTUniqueID, tokenURI string) (*NFTMetadata, error)
 }
+
+type TokenBalance struct {
+	TokenID *bigint.BigInt `json:"tokenId"`
+	Balance *bigint.BigInt `json:"balance"`
+}
+
+type NFTOwner struct {
+	OwnerAddress  common.Address `json:"ownerAddress"`
+	TokenBalances []TokenBalance `json:"tokenBalances"`
+}
+
+type NFTContractOwnership struct {
+	ContractAddress common.Address `json:"contractAddress"`
+	Owners          []NFTOwner     `json:"owners"`
+}
+
+type NFTContractOwnershipProvider interface {
+	FetchNFTOwnersByContractAddress(chainID uint64, contractAddress common.Address) (*NFTContractOwnership, error)
+	IsChainSupported(chainID uint64) bool
+}


### PR DESCRIPTION
Fixes #10290

Adds an API to retrieve the list of addresses and balances of NFT owners from a certain contract address. This is going to be used by community owners for NFT-gated communities.

Alchemy provides this endpoint but their free plan does not allow access to more than 5 chains per account. Since a different API key is used for each chain, a map of keys-per-chain is required.
Infura has currently support for Eth (Mainnet and Goerli) and Arbitrum (Mainnet). Not only the token is required for this endpoint, the token secret is needed as well.
