### PR TITLE
fix(accounts): fix windows path on re-encryption

### DIFF
--- a/account/accounts.go
+++ b/account/accounts.go
@@ -579,6 +579,7 @@ func (m *Manager) ReEncryptKeyStoreDir(keyDirPath, oldPass, newPass string) erro
 	}
 
 	keyDirPath = strings.TrimSuffix(keyDirPath, "/")
+	keyDirPath = strings.TrimSuffix(keyDirPath, "\\")
 	keyParent, keyDirName := filepath.Split(keyDirPath)
 
 	// backupKeyDirName used to store existing keys before final write


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/10352

Fixes a bug where Windows re-encryption wouldn't work with error 
```
ReEncryptKeyStoreDir error: unable to rename keyDirPath to backupKeyDirPath: rename C:\Users\sur_e\AppData\Local\Status\data\keystore\0x438551f7a44bcd9e3d32bf8c734fabb19d56dc8cd798a52b0e6d11b52e\ C:\Users\sur_e\AppData\Local\Status\data\keystore\0x438551f7a44bcd9e3d32bf8c734fabb19d56dc8c860435d798a52b0e6d11b52e\-backup: The process cannot access the ecause it is being used by another process
```

Merges in a release branch for desktop, since this will be needed for a 0.11 patch
I will cherry-pick and create a PR for develop afterwards