### PR TITLE
ci: drop go-1.19 label, Nix provides correct Go

### DIFF
--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.7.0'
 
 pipeline {
-  agent { label 'macos && aarch64 && go-1.19 && nix-2.11' }
+  agent { label 'macos && aarch64 && nix-2.11' }
 
   parameters {
     string(


### PR DESCRIPTION
![1663002304955904](https://user-images.githubusercontent.com/2212681/233165202-0fbc0100-bb7e-4c46-aeed-bad18a8a1e6b.jpg)