### PR TITLE
[Fix] Admin should remove the user from community upon user's request to leave

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1233,7 +1233,6 @@ func (m *Manager) CancelRequestToJoin(request *requests.CancelRequestToJoinCommu
 		return nil, nil, err
 	}
 
-	community.RemoveOurselvesFromOrg(pk)
 	err = m.persistence.SaveCommunity(community)
 	if err != nil {
 		return nil, nil, err

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1233,6 +1233,7 @@ func (m *Manager) CancelRequestToJoin(request *requests.CancelRequestToJoinCommu
 		return nil, nil, err
 	}
 
+	community.RemoveOurselvesFromOrg(pk)
 	err = m.persistence.SaveCommunity(community)
 	if err != nil {
 		return nil, nil, err

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -2237,8 +2237,6 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 	community = response.Communities()[0]
 	s.Require().False(community.HasMember(&s.alice.identity.PublicKey))
 
-	s.logger.Info("->ALICE------")
-
 	// Alice should then be removed
 	err = tt.RetryWithBackOff(func() error {
 		response, err = s.alice.RetrieveAll()
@@ -2256,10 +2254,6 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 		}
 		return nil
 	})
-
-	aComm := response.Communities()[0]
-	s.logger.Info("->aComm", zap.Any("aComm", aComm))
-	s.Require().False(aComm.HasMember(&s.alice.identity.PublicKey))
 
 	// Check we got AC notification for Alice
 	aliceNotifications, err := s.alice.ActivityCenterNotifications(ActivityCenterNotificationsRequest{

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -2621,8 +2621,6 @@ func (s *MessengerCommunitiesSuite) TestLeaveAndRejoinCommunity() {
 		}
 	}
 	s.Require().Equal(1, numberInactiveChats)
-
-	//	J
 }
 
 func (s *MessengerCommunitiesSuite) TestShareCommunity() {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -409,6 +409,11 @@ func (api *PublicAPI) LeaveCommunity(parent context.Context, communityID types.H
 	return api.service.messenger.LeaveCommunity(communityID)
 }
 
+// RequestToLeaveCommunity requests admin to remove us from the community
+func (api *PublicAPI) RequestToLeaveCommunity(parent context.Context, communityID types.HexBytes) error {
+	return api.service.messenger.RequestToLeaveCommunity(communityID)
+}
+
 // CreateCommunity creates a new community with the provided description
 func (api *PublicAPI) CreateCommunity(request *requests.CreateCommunity) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.CreateCommunity(request, true)


### PR DESCRIPTION
Needed for https://github.com/status-im/status-mobile/issues/15705

### Problem (described in the bug)

An existing member of a community leaves the community and requests again. Then, cancels the request.  
Makes a request again. Now the requester joins the community without the approval of the admin.

### Actual Problem

When a user leaves the community. The user is not removed from the member's list (as the admin has the right to do it) but marked as **not** joined the community. Until the `RequestToLeave` message is received by the admin, the user is not removed from the community.

If the admin node is offline, the user would be under the false impression that they have left the community.

### Solution

Introducing the `RequestToLeaveCommunity` method (to be called by the client), where the user will send just the request to leave without modifying any community data/description.

In the existing handling of the request to leave, the admin will automatically remove the user from the community when the admin is online. This will remove the user in a **clean state**. 

We need to inform the user that they will be removed from the community when the admin node is online.





