### PR TITLE
Generalize targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,11 +180,13 @@ endif
 	@echo "Shared library built:"
 	@ls -la build/bin/libstatus.*
 
+docker-image: BUILD_TARGET ?= statusd
 docker-image: ##@docker Build docker image (use DOCKER_IMAGE_NAME to set the image name)
 	@echo "Building docker image..."
 	docker build --file _assets/build/Dockerfile . \
 		--build-arg "build_tags=$(BUILD_TAGS)" \
 		--build-arg "build_flags=$(BUILD_FLAGS)" \
+		--build-arg "build_target=$(BUILD_TARGET)" \
 		--label "commit=$(GIT_COMMIT)" \
 		--label "author=$(AUTHOR)" \
 		-t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_CUSTOM_TAG) \

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -5,14 +5,17 @@ RUN apk add --no-cache make gcc g++ musl-dev linux-headers
 
 ARG build_tags
 ARG build_flags
+ARG build_target=statusgo
 
 RUN mkdir -p /go/src/github.com/status-im/status-go
 WORKDIR /go/src/github.com/status-im/status-go
 ADD . .
-RUN make statusgo BUILD_TAGS="$build_tags" BUILD_FLAGS="$build_flags"
+RUN make $build_target BUILD_TAGS="$build_tags" BUILD_FLAGS="$build_flags"
 
 # Copy the binary to the second image
 FROM alpine:latest
+
+ARG build_target=statusgo
 
 LABEL maintainer="support@status.im"
 LABEL source="https://github.com/status-im/status-go"
@@ -21,11 +24,13 @@ LABEL description="status-go is an underlying part of Status - a browser, messen
 RUN apk add --no-cache ca-certificates bash libgcc libstdc++
 RUN mkdir -p /static/keys
 
-COPY --from=builder /go/src/github.com/status-im/status-go/build/bin/statusd /usr/local/bin/
+COPY --from=builder /go/src/github.com/status-im/status-go/build/bin/$build_target /usr/local/bin/
 COPY --from=builder /go/src/github.com/status-im/status-go/static/keys/* /static/keys/
+
+RUN ln -s /usr/local/bin/$build_target /usr/local/bin/entrypoint
 
 # 30304 is used for Discovery v5
 EXPOSE 8080 8545 30303 30303/udp 30304/udp
 
-ENTRYPOINT ["/usr/local/bin/statusd"]
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
 CMD ["--help"]

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build status-go in a Go builder container
-FROM golang:1.18-alpine as builder
+FROM golang:1.19-alpine as builder
 
 RUN apk add --no-cache make gcc g++ musl-dev linux-headers
 


### PR DESCRIPTION
#### Generalize targets for projects in cmd folder
This way we keep just one simple target and can keep separate help messages for shorthand target names. Also adds one for `spiff-workflow`.

Now both of these result in the same thing being built:
```
make build/bin/node-canary
make node-canary
```
Also removed `GOBIN` variable since it seemed entirely pointless.

#### Generalize building of Docker image
This way we can easily build an image for `spiff-workflow` for example:
```
make docker-image BUILD_TARGET=spiff-workflow DOCKER_IMAGE_NAME=statusteam/spiff-workflow
```

#### Upgrade Go to `1.19` in main `Dockerfile`
As it says.