### PR TITLE
fix(wallet) extra requests due to failing to detect not found block

### DIFF
--- a/services/wallet/history/balance.go
+++ b/services/wallet/history/balance.go
@@ -172,7 +172,8 @@ func (b *Balance) fetchAndCache(ctx context.Context, source DataSource, address 
 	return &dataPoint, blockNo, nil
 }
 
-// update fetches the balance history for a given asset from DB first and missing information from the blockchain to minimize the RPC calls
+// update retrieves the balance history for a specified asset from the database initially
+// and supplements any missing information from the blockchain to minimize the number of RPC calls.
 // if context is cancelled it will return with error
 func (b *Balance) update(ctx context.Context, source DataSource, address common.Address, timeInterval TimeInterval) error {
 	startTimestamp := int64(0)

--- a/services/wallet/history/service.go
+++ b/services/wallet/history/service.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -171,6 +172,7 @@ func (src *chainClientSource) TimeNow() int64 {
 	return time.Now().UTC().Unix()
 }
 
+// ERC20 token implementation of DataSource interface
 type tokenChainClientSource struct {
 	chainClientSource
 	TokenManager   *token.Manager
@@ -193,7 +195,7 @@ func (src *tokenChainClientSource) BalanceAt(ctx context.Context, account common
 	}
 	balance, err := src.TokenManager.GetTokenBalanceAt(ctx, src.chainClient, account, token.Address, blockNumber)
 	if err != nil {
-		if err.Error() == "no contract code at given address" {
+		if err == bind.ErrNoCode {
 			// Ignore requests before contract deployment and mark this state for future requests
 			src.firstUnavailableBlockNo = new(big.Int).Set(blockNumber)
 			return big.NewInt(0), nil


### PR DESCRIPTION
Add the state errors used by balance history to the ignore list of `ClientWithFallback`

The `not found` and "no contract deployed" expected errors are caught and wrapped into another error specific to `ClientWithFallback`. The fetching of the next blocks is aborted and retried in the next fetch, which is not desired.