### PR TITLE
ci: upgrade Xcode version required to 14.3

### DIFF
--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -1,7 +1,7 @@
 library 'status-jenkins-lib@v1.7.0'
 
 pipeline {
-  agent { label 'macos && aarch64 && nix-2.11' }
+  agent { label 'macos && aarch64 && xcode-14.3 && nix-2.11' }
 
   parameters {
     string(
@@ -47,7 +47,7 @@ pipeline {
 
     stage('Compile') {
       steps { script {
-        nix.shell('make statusgo-ios', pure: false)
+        nix.shell('make statusgo-ios', pure: false, sandbox: false)
       } }
     }
 

--- a/shell.nix
+++ b/shell.nix
@@ -35,7 +35,7 @@ let
   /* No Android SDK for Darwin aarch64. */
   isMacM1 = stdenv.isDarwin && stdenv.isAarch64;
   /* Lock requires Xcode verison. */
-  xcodeWrapper = pkgs.xcodeenv.composeXcodeWrapper { version = "14.2"; };
+  xcodeWrapper = pkgs.xcodeenv.composeXcodeWrapper { version = "14.3"; };
   /* Gomobile also needs the Xcode wrapper. */
   gomobileMod = pkgs.gomobile.override {
     inherit xcodeWrapper;


### PR DESCRIPTION
Using `sandbox: false` for `nix.shell()` call to avoid failures in
Xcode wrapper derivation due to missing permissions:
```
error: builder for '/nix/store/xxx-xcode-wrapper-14.3.drv' failed with exit code 1;
       last 2 log lines:
       > /nix/store/yyy-stdenv-darwin/setup: line 1391: /nix/store/yyy-xcode-wrapper-14.3/bin/xcodebuild: Operation not permitted
       > We require xcodebuild version: 14.3
```

We can make the Xcode version requirement less strict once this is merged and `nixpkgs` get updated:

* https://github.com/NixOS/nixpkgs/pull/204278