### PR TITLE
Community encryption should automatically be enabled/disabled depending on community permissions (closed/open)

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -969,8 +969,8 @@ func (o *Community) Encrypted() bool {
 	return o.config.CommunityDescription.Encrypted
 }
 
-func (o *Community) Encrypt() {
-	o.config.CommunityDescription.Encrypted = true
+func (o *Community) SetEncrypted(encrypted bool) {
+	o.config.CommunityDescription.Encrypted = encrypted
 }
 
 func (o *Community) Joined() bool {
@@ -1468,6 +1468,7 @@ func (o *Community) AddTokenPermission(permission *protobuf.CommunityTokenPermis
 	}
 
 	o.config.CommunityDescription.TokenPermissions[permission.Id] = permission
+
 	o.increaseClock()
 	changes := o.emptyCommunityChanges()
 

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -3334,3 +3334,17 @@ func (m *Manager) SetCommunityActiveMembersCount(communityID string, activeMembe
 
 	return nil
 }
+
+// UpdateCommunity takes a Community persists it and republishes it.
+// The clock is incremented meaning even a no change update will be republished by the admin, and parsed by the member.
+func (m *Manager) UpdateCommunity(c *Community) error {
+	c.increaseClock()
+
+	err := m.persistence.SaveCommunity(c)
+	if err != nil {
+		return err
+	}
+
+	m.publish(&Subscription{Community: c})
+	return nil
+}

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
@@ -28,7 +27,6 @@ import (
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/discord"
-	"github.com/status-im/status-go/protocol/encryption"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
@@ -640,7 +638,6 @@ func (s *MessengerCommunitiesSuite) TestPostToCommunityChat() {
 		Name:        "status",
 		Color:       "#ffffff",
 		Description: "status community description",
-		Encrypted:   true,
 	}
 
 	// Create an community chat
@@ -2578,7 +2575,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity() {
 	createCommunityReq := &requests.CreateCommunity{
 		Membership:  protobuf.CommunityPermissions_ON_REQUEST,
 		Name:        "new community",
-		Encrypted:   true,
 		Color:       "#000000",
 		Description: "new community description",
 	}
@@ -2592,15 +2588,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity() {
 		}
 	}
 	s.Require().NotNil(newCommunity)
-
-	// Check HR keys are created
-	encodedKeys, err := s.alice.encryptor.GetAllHREncodedKeys(newCommunity.ID())
-	s.Require().NoError(err)
-	s.Require().NotNil(encodedKeys)
-
-	keys := &encryption.HRKeys{}
-	s.Require().NoError(proto.Unmarshal(encodedKeys, keys))
-	s.Require().Len(keys.Keys, 1)
 
 	// Check that Alice has 2 communities
 	cs, err := s.alice.communitiesManager.All()
@@ -2628,15 +2615,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity() {
 	tcs, err = alicesOtherDevice.communitiesManager.All()
 	s.Require().NoError(err)
 	s.Len(tcs, 2, "There must be 2 communities")
-
-	// Check HR keys are synced
-	encodedKeys, err = alicesOtherDevice.encryptor.GetAllHREncodedKeys(newCommunity.ID())
-	s.Require().NoError(err)
-	s.Require().NotNil(encodedKeys)
-
-	keys = &encryption.HRKeys{}
-	s.Require().NoError(proto.Unmarshal(encodedKeys, keys))
-	s.Require().Len(keys.Keys, 1)
 
 	s.logger.Debug("", zap.Any("tcs", tcs))
 

--- a/protocol/encryption/encryptor.go
+++ b/protocol/encryption/encryptor.go
@@ -623,7 +623,7 @@ func (s *encryptor) getNextHashRatchetKeyID(groupID []byte) (uint32, error) {
 	return latestKeyID + 1, nil
 }
 
-// Generates and stores a hash ratchet key given a group ID
+// GenerateHashRatchetKey Generates and stores a hash ratchet key given a group ID
 func (s *encryptor) GenerateHashRatchetKey(groupID []byte) (uint32, error) {
 
 	// Randomly generate a hash ratchet key

--- a/protocol/encryption/persistence.go
+++ b/protocol/encryption/persistence.go
@@ -790,7 +790,7 @@ func (s *sqlitePersistence) GetHashRatchetKeyByID(groupID []byte, keyID uint32, 
 	}
 }
 
-// GetCurrentKeyIDForGroup retrieves a key ID for given group ID
+// GetCurrentKeyForGroup retrieves a key ID for given group ID
 // (with an assumption that key ids are shared in the group, and
 // at any given time there is a single key used)
 func (s *sqlitePersistence) GetCurrentKeyForGroup(groupID []byte) (uint32, error) {
@@ -845,7 +845,7 @@ func (s *sqlitePersistence) GetKeyIDsForGroup(groupID []byte) ([]uint32, error) 
 	return keyIDs, nil
 }
 
-// SaveHashRachetKeyHash saves a hash ratchet key cache data
+// SaveHashRatchetKeyHash saves a hash ratchet key cache data
 func (s *sqlitePersistence) SaveHashRatchetKeyHash(
 	groupID []byte,
 	keyID uint32,

--- a/protocol/requests/create_community_request.go
+++ b/protocol/requests/create_community_request.go
@@ -42,7 +42,6 @@ type CreateCommunity struct {
 	Banner                       images.CroppedImage                  `json:"banner"`
 	HistoryArchiveSupportEnabled bool                                 `json:"historyArchiveSupportEnabled,omitempty"`
 	PinMessageAllMembersEnabled  bool                                 `json:"pinMessageAllMembersEnabled,omitempty"`
-	Encrypted                    bool                                 `json:"encrypted,omitempty"`
 	Tags                         []string                             `json:"tags,omitempty"`
 }
 
@@ -129,7 +128,7 @@ func (c *CreateCommunity) ToCommunityDescription() (*protobuf.CommunityDescripti
 		},
 		IntroMessage: c.IntroMessage,
 		OutroMessage: c.OutroMessage,
-		Encrypted:    c.Encrypted,
+		Encrypted:    false,
 		Tags:         c.Tags,
 	}
 	return description, nil


### PR DESCRIPTION
This is a refactored version of https://github.com/status-im/status-go/pull/3417 PR as we do not need a separate UI for encryption and decryption, we always can know about it on a stage of creation/edition/removing TokenPermission

**Description:**
I've added a new function to Messenger UpdateCommunityEncryption(communityID [byte]).

UpdateCommunityEncryption takes a communityID and an encryption state, then finds the community and encrypts / decrypts the community based on TokenPermission. Community is republished along with any keys if needed.

I've added a new function to communities.Manager UpdateCommunity(c *Community).

UpdateCommunity takes a Community persists it and republishes it. The clock is incremented meaning even a no change update will be republished by the admin, and parsed by the member.

⚠️ Note:
This function cannot decrypt previously encrypted messages, and it cannot encrypt previous unencrypted messages.
This functionality has some known race conditions:
community description is processed by members before the receiving the key exchange messages
members maybe sending encrypted messages after the community description is updated and a new member joins

**Why Change?**
Community must be automatically encrypted/decrypted based on TokenPermission

Closes #
[#9942](https://github.com/status-im/status-desktop/issues/9942)