### PR TITLE
performance(sqlcipher): Fix burn_stack performance issue

### DIFF
--- a/vendor/github.com/mutecomm/go-sqlcipher/burn_stack.c
+++ b/vendor/github.com/mutecomm/go-sqlcipher/burn_stack.c
@@ -21,10 +21,8 @@
 */
 void burn_stack(unsigned long len)
 {
-   unsigned char buf[32];
+   unsigned char buf[len];
    zeromem(buf, sizeof(buf));
-   if (len > (unsigned long)sizeof(buf))
-      burn_stack(len - sizeof(buf));
 }
 
 

--- a/vendor/github.com/mutecomm/go-sqlcipher/zeromem.c
+++ b/vendor/github.com/mutecomm/go-sqlcipher/zeromem.c
@@ -9,11 +9,21 @@
  * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
  */
 #include "tomcrypt.h"
+#include <string.h>
 
 /**
    @file zeromem.c
    Zero a block of memory, Tom St Denis
 */
+
+/*
+ * Pointer to memset is volatile so that compiler must de-reference
+ * the pointer and can't assume that it points to any function in
+ * particular (such as memset, which it then might further "optimize")
+ */
+typedef void *(*memset_t)(void *, int, size_t);
+
+static volatile memset_t memset_func = memset;
 
 /**
    Zero a block of memory
@@ -22,11 +32,8 @@
 */
 void zeromem(void *out, size_t outlen)
 {
-   unsigned char *mem = out;
    LTC_ARGCHKVD(out != NULL);
-   while (outlen-- > 0) {
-      *mem++ = 0;
-   }
+   memset_func((void *)out, 0, outlen);
 }
 
 /* $Source$ */


### PR DESCRIPTION
### Fixing https://github.com/status-im/status-desktop/issues/10572

Implements a cross-platform version of https://github.com/OP-TEE/optee_os/pull/3102

1. Remove recursion
2. Use memset instead of while loop

A description to understand introduced changes without reading the code.

`zeromem` weights about 50% of the total CPU time on M1 Macs and seems to be major performance offender.
It is used to clear the stack when using variables with sensitive information.

Perf improvement on Status desktop (M1 arch):
`develop` on lower left; This branch on upper right

https://user-images.githubusercontent.com/47811206/236820277-95ae410c-975f-4c6f-8895-f5c1f472a376.mov

Profiling data with app in idle:
Before
<img width="1840" alt="Screenshot 2023-05-08 at 14 52 31" src="https://user-images.githubusercontent.com/47811206/236820455-4c9542b8-8228-4350-8ce2-754f8f47baf1.png">

After
<img width="1840" alt="Screenshot 2023-05-08 at 14 49 07" src="https://user-images.githubusercontent.com/47811206/236820535-a719b0d5-2b7d-4421-9854-0d53daf32c65.png">
