### PR TITLE
performance(sqlcipher): Fix burn_stack performance issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ replace github.com/nfnt/resize => github.com/status-im/resize v0.0.0-20201215164
 
 replace github.com/forPelevin/gomoji => github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4
 
+replace github.com/mutecomm/go-sqlcipher v0.0.0-20190227152316-55dbde17881f => github.com/status-im/go-sqlcipher v0.1.0-status.1
+
 require (
 	github.com/anacrolix/torrent v1.41.0
 	github.com/beevik/ntp v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1551,8 +1551,6 @@ github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/n
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/mutecomm/go-sqlcipher v0.0.0-20190227152316-55dbde17881f h1:hd3r+uv9DNLScbOrnlj82rBldHQf3XWmCeXAWbw8euQ=
-github.com/mutecomm/go-sqlcipher v0.0.0-20190227152316-55dbde17881f/go.mod h1:MyUWrZlB1aI5bs7j9/pJ8ckLLZ4QcCYcNiSbsAW32D4=
 github.com/mutecomm/go-sqlcipher/v4 v4.4.0/go.mod h1:PyN04SaWalavxRGH9E8ZftG6Ju7rsPrGmQRjrEaVpiY=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -1993,6 +1991,8 @@ github.com/status-im/go-ethereum v1.10.25-status.6 h1:5YC8k1inTBqA6LpON0uX6y86ni
 github.com/status-im/go-ethereum v1.10.25-status.6/go.mod h1:Dt4K5JYMhJRdtXJwBEyGZLZn9iz/chSOZyjVmt5ZhwQ=
 github.com/status-im/go-multiaddr-ethv4 v1.2.4 h1:7fw0Y48TJXEqx4fOHlDOUiM/uBq9zG5w4x975Mjh4E0=
 github.com/status-im/go-multiaddr-ethv4 v1.2.4/go.mod h1:PDh4D7h5CvecPIy0ji0rLNwTnzzEcyz9uTPHD42VyH4=
+github.com/status-im/go-sqlcipher v0.1.0-status.1 h1:5fkuM4FG3G5o754zFO9xErATxeig9pww+Nr6sVTUN4o=
+github.com/status-im/go-sqlcipher v0.1.0-status.1/go.mod h1:MyUWrZlB1aI5bs7j9/pJ8ckLLZ4QcCYcNiSbsAW32D4=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4 h1:CtobZoiNdHpx+xurFxnuJ1xsGm3oKMfcZkB3vmomJmA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4/go.mod h1:hmpnZzkzSZJbFYWAUkrPV8I36x7mdYiPhPqnALP4fKA=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=

--- a/vendor/github.com/mutecomm/go-sqlcipher/burn_stack.c
+++ b/vendor/github.com/mutecomm/go-sqlcipher/burn_stack.c
@@ -21,10 +21,8 @@
 */
 void burn_stack(unsigned long len)
 {
-   unsigned char buf[32];
+   unsigned char buf[len];
    zeromem(buf, sizeof(buf));
-   if (len > (unsigned long)sizeof(buf))
-      burn_stack(len - sizeof(buf));
 }
 
 

--- a/vendor/github.com/mutecomm/go-sqlcipher/zeromem.c
+++ b/vendor/github.com/mutecomm/go-sqlcipher/zeromem.c
@@ -9,11 +9,21 @@
  * Tom St Denis, tomstdenis@gmail.com, http://libtom.org
  */
 #include "tomcrypt.h"
+#include <string.h>
 
 /**
    @file zeromem.c
    Zero a block of memory, Tom St Denis
 */
+
+/*
+ * Pointer to memset is volatile so that compiler must de-reference
+ * the pointer and can't assume that it points to any function in
+ * particular (such as memset, which it then might further "optimize")
+ */
+typedef void *(*memset_t)(void *, int, size_t);
+
+static volatile memset_t memset_func = memset;
 
 /**
    Zero a block of memory
@@ -22,11 +32,8 @@
 */
 void zeromem(void *out, size_t outlen)
 {
-   unsigned char *mem = out;
    LTC_ARGCHKVD(out != NULL);
-   while (outlen-- > 0) {
-      *mem++ = 0;
-   }
+   memset_func((void *)out, 0, outlen);
 }
 
 /* $Source$ */

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -652,7 +652,7 @@ github.com/multiformats/go-multistream
 # github.com/multiformats/go-varint v0.0.7
 ## explicit; go 1.18
 github.com/multiformats/go-varint
-# github.com/mutecomm/go-sqlcipher v0.0.0-20190227152316-55dbde17881f
+# github.com/mutecomm/go-sqlcipher v0.0.0-20190227152316-55dbde17881f => github.com/status-im/go-sqlcipher v0.1.0-status.1
 ## explicit; go 1.12
 github.com/mutecomm/go-sqlcipher
 # github.com/nfnt/resize v0.0.0-00010101000000-000000000000 => github.com/status-im/resize v0.0.0-20201215164250-7c6d9f0d3088


### PR DESCRIPTION
### Second iteration of https://github.com/status-im/status-go/pull/3464

1. Added changes in the newly forked go-sqlcipher repo
2. Update go.mod to use new go-sqlcipher version

### Fixing https://github.com/status-im/status-desktop/issues/10572

Implements a cross-platform version of https://github.com/OP-TEE/optee_os/pull/3102

1. Remove recursion
2. Use memset instead of while loop

A description to understand introduced changes without reading the code.

`zeromem` weights about 50% of the total CPU time on M1 Macs and seems to be major performance offender.
It is used to clear the stack when using variables with sensitive information.

Perf improvement on Status desktop (M1 arch):
`develop` on lower left; This branch on upper right

https://user-images.githubusercontent.com/47811206/236820277-95ae410c-975f-4c6f-8895-f5c1f472a376.mov

Profiling data with app in idle:
Before
<img width="1840" alt="Screenshot 2023-05-08 at 14 52 31" src="https://user-images.githubusercontent.com/47811206/236820455-4c9542b8-8228-4350-8ce2-754f8f47baf1.png">

After
<img width="1840" alt="Screenshot 2023-05-08 at 14 49 07" src="https://user-images.githubusercontent.com/47811206/236820535-a719b0d5-2b7d-4421-9854-0d53daf32c65.png">
