### PR TITLE
feat(wallet): complete filter api

### DIFF
--- a/multiaccounts/accounts/testutils.go
+++ b/multiaccounts/accounts/testutils.go
@@ -1,0 +1,19 @@
+package accounts
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func AddTestAccounts(t *testing.T, db *sql.DB, accounts []*Account) {
+	d, err := NewDB(db)
+	require.NoError(t, err)
+
+	err = d.SaveAccounts(accounts)
+	require.NoError(t, err)
+	res, err := d.GetAccounts()
+	require.NoError(t, err)
+	require.Equal(t, accounts, res)
+}

--- a/services/wallet/activity/activity.go
+++ b/services/wallet/activity/activity.go
@@ -9,12 +9,19 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
+	eth "github.com/ethereum/go-ethereum/common"
+
+	"github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/transfer"
+
+	"golang.org/x/exp/constraints"
 )
 
 type PayloadType = int
 
+// Beware if adding/removing please check if affected and update the functions below
+// - NewActivityEntryWithTransaction
+// - multiTransactionTypeToActivityType
 const (
 	MultiTransactionPT PayloadType = iota + 1
 	SimpleTransactionPT
@@ -22,29 +29,34 @@ const (
 )
 
 type Entry struct {
-	// TODO: rename in payloadType
-	transactionType PayloadType
-	transaction     *transfer.TransactionIdentity
-	id              transfer.MultiTransactionIDType
-	timestamp       int64
-	activityType    Type
+	payloadType    PayloadType
+	transaction    *transfer.TransactionIdentity
+	id             transfer.MultiTransactionIDType
+	timestamp      int64
+	activityType   Type
+	activityStatus Status
+	tokenType      TokenType
 }
 
 type jsonSerializationTemplate struct {
-	TransactionType PayloadType                     `json:"transactionType"`
-	Transaction     *transfer.TransactionIdentity   `json:"transaction"`
-	ID              transfer.MultiTransactionIDType `json:"id"`
-	Timestamp       int64                           `json:"timestamp"`
-	ActivityType    Type                            `json:"activityType"`
+	PayloadType    PayloadType                     `json:"payloadType"`
+	Transaction    *transfer.TransactionIdentity   `json:"transaction"`
+	ID             transfer.MultiTransactionIDType `json:"id"`
+	Timestamp      int64                           `json:"timestamp"`
+	ActivityType   Type                            `json:"activityType"`
+	ActivityStatus Status                          `json:"activityStatus"`
+	TokenType      TokenType                       `json:"tokenType"`
 }
 
 func (e *Entry) MarshalJSON() ([]byte, error) {
 	return json.Marshal(jsonSerializationTemplate{
-		TransactionType: e.transactionType,
-		Transaction:     e.transaction,
-		ID:              e.id,
-		Timestamp:       e.timestamp,
-		ActivityType:    e.activityType,
+		PayloadType:    e.payloadType,
+		Transaction:    e.transaction,
+		ID:             e.id,
+		Timestamp:      e.timestamp,
+		ActivityType:   e.activityType,
+		ActivityStatus: e.activityStatus,
+		TokenType:      e.tokenType,
 	})
 }
 
@@ -55,7 +67,7 @@ func (e *Entry) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	e.transactionType = aux.TransactionType
+	e.payloadType = aux.PayloadType
 	e.transaction = aux.Transaction
 	e.id = aux.ID
 	e.timestamp = aux.Timestamp
@@ -63,31 +75,35 @@ func (e *Entry) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func NewActivityEntryWithTransaction(transactionType PayloadType, transaction *transfer.TransactionIdentity, timestamp int64, activityType Type) Entry {
-	if transactionType != SimpleTransactionPT && transactionType != PendingTransactionPT {
+func NewActivityEntryWithTransaction(payloadType PayloadType, transaction *transfer.TransactionIdentity, timestamp int64, activityType Type, activityStatus Status) Entry {
+	if payloadType != SimpleTransactionPT && payloadType != PendingTransactionPT {
 		panic("invalid transaction type")
 	}
 
 	return Entry{
-		transactionType: transactionType,
-		transaction:     transaction,
-		id:              0,
-		timestamp:       timestamp,
-		activityType:    activityType,
+		payloadType:    payloadType,
+		transaction:    transaction,
+		id:             0,
+		timestamp:      timestamp,
+		activityType:   activityType,
+		activityStatus: activityStatus,
+		tokenType:      AssetTT,
 	}
 }
 
-func NewActivityEntryWithMultiTransaction(id transfer.MultiTransactionIDType, timestamp int64, activityType Type) Entry {
+func NewActivityEntryWithMultiTransaction(id transfer.MultiTransactionIDType, timestamp int64, activityType Type, activityStatus Status) Entry {
 	return Entry{
-		transactionType: MultiTransactionPT,
-		id:              id,
-		timestamp:       timestamp,
-		activityType:    activityType,
+		payloadType:    MultiTransactionPT,
+		id:             id,
+		timestamp:      timestamp,
+		activityType:   activityType,
+		activityStatus: activityStatus,
+		tokenType:      AssetTT,
 	}
 }
 
-func (e *Entry) TransactionType() PayloadType {
-	return e.transactionType
+func (e *Entry) PayloadType() PayloadType {
+	return e.payloadType
 }
 
 func multiTransactionTypeToActivityType(mtType transfer.MultiTransactionType) Type {
@@ -101,7 +117,7 @@ func multiTransactionTypeToActivityType(mtType transfer.MultiTransactionType) Ty
 	panic("unknown multi transaction type")
 }
 
-func typesContain(slice []Type, item Type) bool {
+func sliceContains[T constraints.Ordered](slice []T, item T) bool {
 	for _, a := range slice {
 		if a == item {
 			return true
@@ -110,31 +126,33 @@ func typesContain(slice []Type, item Type) bool {
 	return false
 }
 
-func joinMTTypes(types []transfer.MultiTransactionType) string {
-	var sb strings.Builder
-	for i, val := range types {
-		if i > 0 {
-			sb.WriteString(",")
-		}
-		sb.WriteString(strconv.Itoa(int(val)))
+func joinItems[T interface{}](items []T, itemConversion func(T) string) string {
+	if len(items) == 0 {
+		return ""
 	}
+	var sb strings.Builder
+	if itemConversion == nil {
+		itemConversion = func(item T) string {
+			return fmt.Sprintf("%v", item)
+		}
+	}
+	for i, item := range items {
+		if i == 0 {
+			sb.WriteString("(")
+		} else {
+			sb.WriteString("),(")
+		}
+		sb.WriteString(itemConversion(item))
+	}
+	sb.WriteString(")")
 
 	return sb.String()
 }
 
-func joinAddresses(addresses []common.Address) string {
-	var sb strings.Builder
-	for i, address := range addresses {
-		if i == 0 {
-			sb.WriteString("('")
-		} else {
-			sb.WriteString("'),('")
-		}
-		sb.WriteString(strings.ToUpper(hex.EncodeToString(address[:])))
-	}
-	sb.WriteString("')")
-
-	return sb.String()
+func joinAddresses(addresses []eth.Address) string {
+	return joinItems(addresses, func(a eth.Address) string {
+		return fmt.Sprintf("'%s'", strings.ToUpper(hex.EncodeToString(a[:])))
+	})
 }
 
 func activityTypesToMultiTransactionTypes(trTypes []Type) []transfer.MultiTransactionType {
@@ -155,11 +173,25 @@ func activityTypesToMultiTransactionTypes(trTypes []Type) []transfer.MultiTransa
 	return mtTypes
 }
 
-// TODO: extend with SEND/RECEIVE for transfers and pending_transactions
-// TODO: clarify if we include sender and receiver in pending_transactions as we do for transfers
-// TODO optimization: consider implementing nullable []byte instead of using strings for addresses
-// Query includes duplicates, will return multiple rows for the same transaction
-const queryFormatString = `
+const (
+	fromTrType = byte(1)
+	//toTrType   = byte(2)
+
+	// TODO: Multi-transaction network information is missing in filtering
+	// TODO: extract token code for non transfer type eth
+	// TODO optimization: consider implementing nullable []byte instead of using strings for addresses
+	//
+	// Query includes duplicates, will return multiple rows for the same transaction if both to and from addresses
+	// are in the address list.
+	//
+	// The addresses list will have priority in deciding the source of the duplicate transaction. However, if the
+	// if the addresses list is empty, and all addresses should be included, the accounts table will be used
+	// see filter_addresses temp table is used
+	// The switch for tr_type is used to de-conflict the source for the two entries for the same transaction
+	//
+	// UNION ALL is used to avoid the overhead of DISTINCT given that we don't expect to have duplicate entries outside
+	// the sender and receiver addresses being in the list which is handled separately
+	queryFormatString = `
 	WITH filter_conditions AS (
 		SELECT
 			? AS startFilterDisabled,
@@ -171,9 +203,26 @@ const queryFormatString = `
 			? AS filterActivityTypeSend,
 			? AS filterActivityTypeReceive,
 
-			? AS filterAllAddresses
+			? AS filterAllAddresses,
+			? AS filterAllToAddresses,
+			? AS filterAllActivityStatus,
+			? AS includeAllTokenTypeAssets,
+			? AS statusIsPending,
+
+			? AS includeAllNetworks
 		),
 		filter_addresses(address) AS (
+			SELECT HEX(address) FROM accounts WHERE (SELECT filterAllAddresses FROM filter_conditions) != 0
+			UNION ALL
+			SELECT * FROM (VALUES %s) WHERE (SELECT filterAllAddresses FROM filter_conditions) = 0
+		),
+		filter_to_addresses(address) AS (
+			VALUES %s
+		),
+		filter_assets(token_code) AS (
+			VALUES %s
+		),
+		filter_networks(network_id) AS (
 			VALUES %s
 		)
 	SELECT
@@ -183,12 +232,48 @@ const queryFormatString = `
 		0 AS multi_tx_id,
 		transfers.timestamp AS timestamp,
 		NULL AS mt_type,
-		HEX(transfers.address) AS owner_address
+
+		CASE
+	        WHEN from_join.address IS NOT NULL AND to_join.address IS NULL THEN 1
+			WHEN to_join.address IS NOT NULL AND from_join.address IS NULL THEN 2
+	        WHEN from_join.address IS NOT NULL AND to_join.address IS NOT NULL THEN
+				CASE
+					WHEN from_join.address < to_join.address THEN 1
+					ELSE 2
+				END
+        	ELSE NULL
+	    END as tr_type,
+
+		transfers.sender AS from_address,
+		transfers.address AS to_address
 	FROM transfers, filter_conditions
+	LEFT JOIN
+		filter_addresses from_join ON HEX(transfers.sender) = from_join.address
+	LEFT JOIN
+		filter_addresses to_join ON HEX(transfers.address) = to_join.address
 	WHERE transfers.multi_transaction_id = 0
-		AND ((startFilterDisabled OR timestamp >= startTimestamp) AND (endFilterDisabled OR timestamp <= endTimestamp))
-		AND (filterActivityTypeAll OR (filterActivityTypeSend AND (filterAllAddresses OR (HEX(transfers.sender) IN filter_addresses))) OR (filterActivityTypeReceive AND (filterAllAddresses OR (HEX(transfers.address) IN filter_addresses))))
-		AND (filterAllAddresses OR (HEX(transfers.sender) IN filter_addresses) OR (HEX(transfers.address) IN filter_addresses))
+		AND ((startFilterDisabled OR timestamp >= startTimestamp)
+		    AND (endFilterDisabled OR timestamp <= endTimestamp)
+		)
+		AND (filterActivityTypeAll
+			OR (filterActivityTypeSend
+				AND (filterAllAddresses
+					OR (HEX(transfers.sender) IN filter_addresses)
+				)
+			)
+			OR (filterActivityTypeReceive
+				AND (filterAllAddresses OR (HEX(transfers.address) IN filter_addresses))
+			)
+		)
+		AND (filterAllAddresses
+			OR (HEX(transfers.sender) IN filter_addresses)
+			OR (HEX(transfers.address) IN filter_addresses)
+		)
+		AND (filterAllToAddresses
+			OR (HEX(transfers.address) IN filter_to_addresses)
+		)
+		AND (includeAllTokenTypeAssets OR (transfers.type = "eth" AND ("ETH" IN filter_assets)))
+		AND (includeAllNetworks OR (transfers.network_id IN filter_networks))
 
 	UNION ALL
 
@@ -199,12 +284,40 @@ const queryFormatString = `
 		0 AS multi_tx_id,
 		pending_transactions.timestamp AS timestamp,
 		NULL AS mt_type,
-		NULL AS owner_address
+
+		CASE
+	        WHEN from_join.address IS NOT NULL AND to_join.address IS NULL THEN 1
+			WHEN to_join.address IS NOT NULL AND from_join.address IS NULL THEN 2
+	        WHEN from_join.address IS NOT NULL AND to_join.address IS NOT NULL THEN
+				CASE
+					WHEN from_join.address < to_join.address THEN 1
+					ELSE 2
+				END
+        	ELSE NULL
+	    END as tr_type,
+
+		pending_transactions.from_address AS from_address,
+		pending_transactions.to_address AS to_address
 	FROM pending_transactions, filter_conditions
+	LEFT JOIN
+		filter_addresses from_join ON HEX(pending_transactions.from_address) = from_join.address
+	LEFT JOIN
+		filter_addresses to_join ON HEX(pending_transactions.to_address) = to_join.address
 	WHERE pending_transactions.multi_transaction_id = 0
-		AND ((startFilterDisabled OR timestamp >= startTimestamp) AND (endFilterDisabled OR timestamp <= endTimestamp))
+		AND (filterAllActivityStatus OR statusIsPending)
+		AND ((startFilterDisabled OR timestamp >= startTimestamp)
+			AND (endFilterDisabled OR timestamp <= endTimestamp)
+		)
 		AND (filterActivityTypeAll OR filterActivityTypeSend)
-		AND (filterAllAddresses OR (HEX(pending_transactions.from_address) IN filter_addresses) OR (HEX(pending_transactions.to_address) IN filter_addresses))
+		AND (filterAllAddresses
+			OR (HEX(pending_transactions.from_address) IN filter_addresses)
+			OR (HEX(pending_transactions.to_address) IN filter_addresses)
+		)
+		AND (filterAllToAddresses
+			OR (HEX(pending_transactions.to_address) IN filter_to_addresses)
+		)
+		AND (includeAllTokenTypeAssets OR (UPPER(pending_transactions.symbol) IN filter_assets))
+		AND (includeAllNetworks OR (pending_transactions.network_id IN filter_networks))
 
 	UNION ALL
 
@@ -215,41 +328,89 @@ const queryFormatString = `
 		multi_transactions.ROWID AS multi_tx_id,
 		multi_transactions.timestamp AS timestamp,
 		multi_transactions.type AS mt_type,
-		NULL AS owner_address
+		NULL as tr_type,
+		multi_transactions.from_address AS from_address,
+		multi_transactions.to_address AS to_address
 	FROM multi_transactions, filter_conditions
-	WHERE ((startFilterDisabled OR timestamp >= startTimestamp) AND (endFilterDisabled OR timestamp <= endTimestamp))
+	WHERE ((startFilterDisabled OR timestamp >= startTimestamp)
+			AND (endFilterDisabled OR timestamp <= endTimestamp)
+		)
 		AND (filterActivityTypeAll OR (multi_transactions.type IN (%s)))
-		AND (filterAllAddresses OR (HEX(multi_transactions.from_address) IN filter_addresses) OR (HEX(multi_transactions.to_address) IN filter_addresses))
+		AND (filterAllAddresses
+			OR (HEX(multi_transactions.from_address) IN filter_addresses)
+			OR (HEX(multi_transactions.to_address) IN filter_addresses)
+		)
+		AND (filterAllToAddresses
+			OR (HEX(multi_transactions.to_address) IN filter_to_addresses)
+		)
+		AND (includeAllTokenTypeAssets OR (UPPER(multi_transactions.from_asset) IN filter_assets) OR (UPPER(multi_transactions.to_asset) IN filter_assets))
 
 	ORDER BY timestamp DESC
 	LIMIT ? OFFSET ?`
 
-func GetActivityEntries(db *sql.DB, addresses []common.Address, chainIDs []uint64, filter Filter, offset int, limit int) ([]Entry, error) {
-	// Query the transfers, pending_transactions, and multi_transactions tables ordered by timestamp column
+	noEntriesInTmpTableSQLValues = "(NULL)"
+)
 
-	// TODO: finish filter: chainIDs, statuses, tokenTypes, counterpartyAddresses
-	// TODO: use all accounts list for detecting SEND/RECEIVE instead of the current addresses list; also change activityType detection in transfer part
+// GetActivityEntries returns query the transfers, pending_transactions, and multi_transactions tables
+// based on filter parameters and arguments
+// it returns metadata for all entries ordered by timestamp column
+//
+// Adding a no-limit option was never considered or required.
+func GetActivityEntries(db *sql.DB, addresses []eth.Address, chainIDs []common.ChainID, filter Filter, offset int, limit int) ([]Entry, error) {
+	// TODO: filter collectibles after  they are added to multi_transactions table
+	if len(filter.Tokens.EnabledTypes) > 0 && !sliceContains(filter.Tokens.EnabledTypes, AssetTT) {
+		// For now we deal only with assets so return empty result
+		return []Entry{}, nil
+	}
+
+	includeAllTokenTypeAssets := (len(filter.Tokens.EnabledTypes) == 0 ||
+		sliceContains(filter.Tokens.EnabledTypes, AssetTT)) && len(filter.Tokens.Assets) == 0
+
+	assets := noEntriesInTmpTableSQLValues
+	if !includeAllTokenTypeAssets {
+		assets = joinItems(filter.Tokens.Assets, func(item TokenCode) string { return fmt.Sprintf("'%v'", item) })
+	}
+
+	includeAllNetworks := len(chainIDs) == 0
+	networks := noEntriesInTmpTableSQLValues
+	if !includeAllNetworks {
+		networks = joinItems(chainIDs, nil)
+	}
+
 	startFilterDisabled := !(filter.Period.StartTimestamp > 0)
 	endFilterDisabled := !(filter.Period.EndTimestamp > 0)
-	filterActivityTypeAll := typesContain(filter.Types, AllAT) || len(filter.Types) == 0
+	filterActivityTypeAll := len(filter.Types) == 0
 	filterAllAddresses := len(addresses) == 0
+	filterAllToAddresses := len(filter.CounterpartyAddresses) == 0
+	includeAllStatuses := len(filter.Statuses) == 0
 
-	//fmt.Println("@dd filter: timeEnabled", filter.Period.StartTimestamp, filter.Period.EndTimestamp, "; type", filter.Types, "offset", offset, "limit", limit)
+	statusIsPending := false
+	if !includeAllStatuses {
+		statusIsPending = sliceContains(filter.Statuses, PendingAS)
+	}
 
-	joinedAddresses := "(NULL)"
+	involvedAddresses := noEntriesInTmpTableSQLValues
 	if !filterAllAddresses {
-		joinedAddresses = joinAddresses(addresses)
+		involvedAddresses = joinAddresses(addresses)
+	}
+	toAddresses := noEntriesInTmpTableSQLValues
+	if !filterAllToAddresses {
+		toAddresses = joinAddresses(filter.CounterpartyAddresses)
 	}
 
 	mtTypes := activityTypesToMultiTransactionTypes(filter.Types)
-	joinedMTTypes := joinMTTypes(mtTypes)
+	joinedMTTypes := joinItems(mtTypes, func(t transfer.MultiTransactionType) string {
+		return strconv.Itoa(int(t))
+	})
 
-	queryString := fmt.Sprintf(queryFormatString, joinedAddresses, joinedMTTypes)
+	queryString := fmt.Sprintf(queryFormatString, involvedAddresses, toAddresses, assets, networks,
+		joinedMTTypes)
 
 	rows, err := db.Query(queryString,
 		startFilterDisabled, filter.Period.StartTimestamp, endFilterDisabled, filter.Period.EndTimestamp,
-		filterActivityTypeAll, typesContain(filter.Types, SendAT), typesContain(filter.Types, ReceiveAT),
-		filterAllAddresses,
+		filterActivityTypeAll, sliceContains(filter.Types, SendAT), sliceContains(filter.Types, ReceiveAT),
+		filterAllAddresses, filterAllToAddresses, includeAllStatuses, includeAllTokenTypeAssets, statusIsPending,
+		includeAllNetworks,
 		limit, offset)
 	if err != nil {
 		return nil, err
@@ -261,30 +422,41 @@ func GetActivityEntries(db *sql.DB, addresses []common.Address, chainIDs []uint6
 		var transferHash, pendingHash []byte
 		var chainID, multiTxID sql.NullInt64
 		var timestamp int64
-		var dbActivityType sql.NullByte
-		var dbAddress sql.NullString
-		err := rows.Scan(&transferHash, &pendingHash, &chainID, &multiTxID, &timestamp, &dbActivityType, &dbAddress)
+		var dbMtType, dbTrType sql.NullByte
+		var toAddress, fromAddress eth.Address
+		err := rows.Scan(&transferHash, &pendingHash, &chainID, &multiTxID, &timestamp, &dbMtType, &dbTrType, &fromAddress, &toAddress)
 		if err != nil {
 			return nil, err
 		}
 
+		getActivityType := func(trType sql.NullByte) (activityType Type, filteredAddress eth.Address) {
+			if trType.Valid && trType.Byte == fromTrType {
+				return SendAT, fromAddress
+			}
+			// Don't expect this to happen due to trType = NULL outside of tests
+			return ReceiveAT, toAddress
+		}
+
 		var entry Entry
 		if transferHash != nil && chainID.Valid {
-			var activityType Type = SendAT
-			thisAddress := common.HexToAddress(dbAddress.String)
-			for _, address := range addresses {
-				if address == thisAddress {
-					activityType = ReceiveAT
-				}
-			}
-			entry = NewActivityEntryWithTransaction(SimpleTransactionPT, &transfer.TransactionIdentity{ChainID: uint64(chainID.Int64), Hash: common.BytesToHash(transferHash), Address: thisAddress}, timestamp, activityType)
+			// TODO: extend DB with status in order to filter by status. The status has to be extracted from the receipt upon downloading
+			activityStatus := FinalizedAS
+			activityType, filteredAddress := getActivityType(dbTrType)
+			entry = NewActivityEntryWithTransaction(SimpleTransactionPT,
+				&transfer.TransactionIdentity{ChainID: common.ChainID(chainID.Int64), Hash: eth.BytesToHash(transferHash), Address: filteredAddress},
+				timestamp, activityType, activityStatus)
 		} else if pendingHash != nil && chainID.Valid {
-			var activityType Type = SendAT
-			entry = NewActivityEntryWithTransaction(PendingTransactionPT, &transfer.TransactionIdentity{ChainID: uint64(chainID.Int64), Hash: common.BytesToHash(pendingHash)}, timestamp, activityType)
+			activityStatus := PendingAS
+			activityType, _ := getActivityType(dbTrType)
+			entry = NewActivityEntryWithTransaction(PendingTransactionPT,
+				&transfer.TransactionIdentity{ChainID: common.ChainID(chainID.Int64), Hash: eth.BytesToHash(pendingHash)},
+				timestamp, activityType, activityStatus)
 		} else if multiTxID.Valid {
-			activityType := multiTransactionTypeToActivityType(transfer.MultiTransactionType(dbActivityType.Byte))
+			activityType := multiTransactionTypeToActivityType(transfer.MultiTransactionType(dbMtType.Byte))
+			// TODO: aggregate status from all sub-transactions
+			activityStatus := FinalizedAS
 			entry = NewActivityEntryWithMultiTransaction(transfer.MultiTransactionIDType(multiTxID.Int64),
-				timestamp, activityType)
+				timestamp, activityType, activityStatus)
 		} else {
 			return nil, errors.New("invalid row data")
 		}

--- a/services/wallet/activity/filter.go
+++ b/services/wallet/activity/filter.go
@@ -1,9 +1,13 @@
 package activity
 
-import "github.com/ethereum/go-ethereum/common"
+import (
+	eth_common "github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/common"
+)
+
+const NoLimitTimestampForPeriod = 0
 
 type Period struct {
-	// 0 means no limit
 	StartTimestamp int64 `json:"startTimestamp"`
 	EndTimestamp   int64 `json:"endTimestamp"`
 }
@@ -11,36 +15,69 @@ type Period struct {
 type Type int
 
 const (
-	AllAT Type = iota
-	SendAT
+	SendAT Type = iota
 	ReceiveAT
 	BuyAT
 	SwapAT
 	BridgeAT
 )
 
+func allActivityTypesFilter() []Type {
+	return []Type{}
+}
+
 type Status int
 
 const (
-	AllAS Status = iota
-	FailedAS
+	FailedAS Status = iota
 	PendingAS
 	CompleteAS
 	FinalizedAS
 )
 
+func allActivityStatusesFilter() []Status {
+	return []Status{}
+}
+
 type TokenType int
 
 const (
-	AllTT TokenType = iota
-	AssetTT
+	AssetTT TokenType = iota
 	CollectiblesTT
 )
 
+type TokenCode string
+
+// Tokens the following rules apply for its members:
+// empty member: none is selected
+// nil means all
+// see allTokensFilter and noTokensFilter
+type Tokens struct {
+	Assets       []TokenCode          `json:"assets"`
+	Collectibles []eth_common.Address `json:"collectibles"`
+	EnabledTypes []TokenType          `json:"enabledTypes"`
+}
+
+func noAssetsFilter() Tokens {
+	return Tokens{[]TokenCode{}, []eth_common.Address{}, []TokenType{CollectiblesTT}}
+}
+
+func allTokensFilter() Tokens {
+	return Tokens{}
+}
+
+func allAddressesFilter() []eth_common.Address {
+	return []eth_common.Address{}
+}
+
+func allNetworksFilter() []common.ChainID {
+	return []common.ChainID{}
+}
+
 type Filter struct {
-	Period                Period           `json:"period"`
-	Types                 []Type           `json:"types"`
-	Statuses              []Status         `json:"statuses"`
-	TokenTypes            []TokenType      `json:"tokenTypes"`
-	CounterpartyAddresses []common.Address `json:"counterpartyAddresses"`
+	Period                Period               `json:"period"`
+	Types                 []Type               `json:"types"`
+	Statuses              []Status             `json:"statuses"`
+	Tokens                Tokens               `json:"tokens"`
+	CounterpartyAddresses []eth_common.Address `json:"counterpartyAddresses"`
 }

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -19,6 +19,8 @@ import (
 	"github.com/status-im/status-go/services/wallet/thirdparty/opensea"
 	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/services/wallet/transfer"
+
+	wallet_common "github.com/status-im/status-go/services/wallet/common"
 )
 
 func NewAPI(s *Service) *API {
@@ -247,7 +249,7 @@ func (api *API) GetPendingTransactionsForIdentities(ctx context.Context, identit
 	result = make([]*transfer.PendingTransaction, 0, len(identities))
 	var pt *transfer.PendingTransaction
 	for _, identity := range identities {
-		pt, err = api.s.transactionManager.GetPendingEntry(identity.ChainID, identity.Hash)
+		pt, err = api.s.transactionManager.GetPendingEntry(uint64(identity.ChainID), identity.Hash)
 		result = append(result, pt)
 	}
 
@@ -525,7 +527,7 @@ func (api *API) FetchAllCurrencyFormats() (currency.FormatPerSymbol, error) {
 	return api.s.currency.FetchAllCurrencyFormats()
 }
 
-func (api *API) GetActivityEntries(addresses []common.Address, chainIDs []uint64, filter activity.Filter, offset int, limit int) ([]activity.Entry, error) {
+func (api *API) GetActivityEntries(addresses []common.Address, chainIDs []wallet_common.ChainID, filter activity.Filter, offset int, limit int) ([]activity.Entry, error) {
 	log.Debug("call to GetActivityEntries")
 	return activity.GetActivityEntries(api.s.db, addresses, chainIDs, filter, offset, limit)
 }

--- a/services/wallet/testutils/helpers.go
+++ b/services/wallet/testutils/helpers.go
@@ -2,6 +2,10 @@ package testutils
 
 import "reflect"
 
+const EthSymbol = "ETH"
+const SntSymbol = "SNT"
+const DaiSymbol = "DAI"
+
 func StructExistsInSlice[T any](target T, slice []T) bool {
 	for _, item := range slice {
 		if reflect.DeepEqual(target, item) {

--- a/services/wallet/transfer/database.go
+++ b/services/wallet/transfer/database.go
@@ -279,7 +279,7 @@ func (db *Database) GetTransfersForIdentities(ctx context.Context, identities []
 	for _, identity := range identities {
 		subQuery := newSubQuery()
 		// TODO optimization: consider using tuples in sqlite and IN operator
-		subQuery = subQuery.FilterNetwork(identity.ChainID).FilterTransactionHash(identity.Hash).FilterAddress(identity.Address)
+		subQuery = subQuery.FilterNetwork(uint64(identity.ChainID)).FilterTransactionHash(identity.Hash).FilterAddress(identity.Address)
 		query.addSubQuery(subQuery, OrSeparator)
 	}
 	rows, err := db.client.QueryContext(ctx, query.String(), query.Args()...)

--- a/services/wallet/transfer/database_test.go
+++ b/services/wallet/transfer/database_test.go
@@ -223,8 +223,8 @@ func TestGetTransfersForIdentities(t *testing.T) {
 	require.Equal(t, big.NewInt(trs[3].BlkNumber), entries[1].BlockNumber)
 	require.Equal(t, uint64(trs[1].Timestamp), entries[0].Timestamp)
 	require.Equal(t, uint64(trs[3].Timestamp), entries[1].Timestamp)
-	require.Equal(t, trs[1].ChainID, entries[0].NetworkID)
-	require.Equal(t, trs[3].ChainID, entries[1].NetworkID)
+	require.Equal(t, uint64(trs[1].ChainID), entries[0].NetworkID)
+	require.Equal(t, uint64(trs[3].ChainID), entries[1].NetworkID)
 	require.Equal(t, MultiTransactionIDType(0), entries[0].MultiTransactionID)
 	require.Equal(t, MultiTransactionIDType(0), entries[1].MultiTransactionID)
 }

--- a/services/wallet/transfer/query.go
+++ b/services/wallet/transfer/query.go
@@ -53,6 +53,7 @@ func (q *transfersQuery) addWhereSeparator(separator SeparatorType) {
 
 type SeparatorType int
 
+// Beware if changing this enum please update addWhereSeparator as well
 const (
 	NoSeparator SeparatorType = iota + 1
 	OrSeparator

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -3,18 +3,23 @@ package transfer
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
+	eth_common "github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/testutils"
 
 	"github.com/stretchr/testify/require"
 )
 
 type TestTransaction struct {
-	Hash                 common.Hash
-	ChainID              uint64
-	From                 common.Address // [sender]
-	To                   common.Address // [address]
+	Hash                 eth_common.Hash
+	ChainID              common.ChainID
+	From                 eth_common.Address // [sender]
+	To                   eth_common.Address // [address]
+	FromToken            string             // used to detect type in transfers table
+	ToToken              string             // only used in multi_transactions table
 	Timestamp            int64
 	Value                int64
 	BlkNumber            int64
@@ -25,10 +30,10 @@ type TestTransaction struct {
 func GenerateTestTransactions(t *testing.T, db *sql.DB, firstStartIndex int, count int) (result []TestTransaction) {
 	for i := firstStartIndex; i < (firstStartIndex + count); i++ {
 		tr := TestTransaction{
-			Hash:                 common.HexToHash(fmt.Sprintf("0x1%d", i)),
-			ChainID:              uint64(i),
-			From:                 common.HexToAddress(fmt.Sprintf("0x2%d", i)),
-			To:                   common.HexToAddress(fmt.Sprintf("0x3%d", i)),
+			Hash:                 eth_common.HexToHash(fmt.Sprintf("0x1%d", i)),
+			ChainID:              common.ChainID(i),
+			From:                 eth_common.HexToAddress(fmt.Sprintf("0x2%d", i)),
+			To:                   eth_common.HexToAddress(fmt.Sprintf("0x3%d", i)),
 			Timestamp:            int64(i),
 			Value:                int64(i),
 			BlkNumber:            int64(i),
@@ -42,7 +47,11 @@ func GenerateTestTransactions(t *testing.T, db *sql.DB, firstStartIndex int, cou
 
 func InsertTestTransfer(t *testing.T, db *sql.DB, tr *TestTransaction) {
 	// Respect `FOREIGN KEY(network_id,address,blk_hash)` of `transfers` table
-	blkHash := common.HexToHash("4")
+	tokenType := "eth"
+	if tr.FromToken != "" && strings.ToUpper(tr.FromToken) != testutils.EthSymbol {
+		tokenType = "erc20"
+	}
+	blkHash := eth_common.HexToHash("4")
 	_, err := db.Exec(`
 		INSERT OR IGNORE INTO blocks(
 			network_id, address, blk_number, blk_hash
@@ -50,17 +59,34 @@ func InsertTestTransfer(t *testing.T, db *sql.DB, tr *TestTransaction) {
 		INSERT INTO transfers (network_id, hash, address, blk_hash, tx,
 			sender, receipt, log, type, blk_number, timestamp, loaded,
 			multi_transaction_id, base_gas_fee
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, "test", ?, ?, 0, ?, 0)`,
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 0)`,
 		tr.ChainID, tr.To, tr.BlkNumber, blkHash,
-		tr.ChainID, tr.Hash, tr.To, blkHash, &JSONBlob{}, tr.From, &JSONBlob{}, &JSONBlob{}, tr.BlkNumber, tr.Timestamp, tr.MultiTransactionID)
+		tr.ChainID, tr.Hash, tr.To, blkHash, &JSONBlob{}, tr.From, &JSONBlob{}, &JSONBlob{}, tokenType, tr.BlkNumber, tr.Timestamp, tr.MultiTransactionID)
+	require.NoError(t, err)
+}
+
+func InsertTestPendingTransaction(t *testing.T, db *sql.DB, tr *TestTransaction) {
+	_, err := db.Exec(`
+		INSERT INTO pending_transactions (network_id, hash, timestamp, from_address, to_address,
+			symbol, gas_price, gas_limit, value, data, type, additional_data, multi_transaction_id
+		) VALUES (?, ?, ?, ?, ?, 'ETH', 0, 0, ?, '', 'test', '', ?)`,
+		tr.ChainID, tr.Hash, tr.Timestamp, tr.From, tr.To, tr.Value, tr.MultiTransactionID)
 	require.NoError(t, err)
 }
 
 func InsertTestMultiTransaction(t *testing.T, db *sql.DB, tr *TestTransaction) MultiTransactionIDType {
+	fromTokenType := tr.FromToken
+	if tr.FromToken == "" {
+		fromTokenType = testutils.EthSymbol
+	}
+	toTokenType := tr.ToToken
+	if tr.ToToken == "" {
+		toTokenType = testutils.EthSymbol
+	}
 	result, err := db.Exec(`
 		INSERT INTO multi_transactions (from_address, from_asset, from_amount, to_address, to_asset, type, timestamp
-		) VALUES (?, 'ETH', 0, ?, 'SNT', ?, ?)`,
-		tr.From, tr.To, tr.MultiTransactionType, tr.Timestamp)
+		) VALUES (?, ?, 0, ?, ?, ?, ?)`,
+		tr.From, fromTokenType, tr.To, toTokenType, tr.MultiTransactionType, tr.Timestamp)
 	require.NoError(t, err)
 	rowID, err := result.LastInsertId()
 	require.NoError(t, err)

--- a/services/wallet/transfer/transaction.go
+++ b/services/wallet/transfer/transaction.go
@@ -20,6 +20,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/async"
 	"github.com/status-im/status-go/services/wallet/bigint"
 	"github.com/status-im/status-go/services/wallet/bridge"
+	wallet_common "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/transactions"
 )
 
@@ -96,9 +97,9 @@ type PendingTransaction struct {
 }
 
 type TransactionIdentity struct {
-	ChainID uint64         `json:"chainId"`
-	Hash    common.Hash    `json:"hash"`
-	Address common.Address `json:"address"`
+	ChainID wallet_common.ChainID `json:"chainId"`
+	Hash    common.Hash           `json:"hash"`
+	Address common.Address        `json:"address"`
 }
 
 const selectFromPending = `SELECT hash, timestamp, value, from_address, to_address, data,


### PR DESCRIPTION
### Closes status-desktop [#10634](https://github.com/status-im/status-desktop/issues/10634)

It uses the current data only and doesn't extend with new types or
include new features in activity sources DBs.

Major changes:
- Partially filter by chain IDs
- Partially filter by Status if it is the case
- Partially filter by token types
- Filter by counterparty addresses
- Use accounts to detect transaction origin and type (TO/FROM). Use accounts table when all accounts filter is requested
