### PR TITLE
fix(unviewed): fix edge case where unviewed count would be -1

### DIFF
--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -1726,14 +1726,8 @@ func (db sqlitePersistence) MarkAllRead(chatID string, clock uint64) (int64, int
 
 	_, err = tx.Exec(
 		`UPDATE chats
-		   SET unviewed_message_count =
-		   (SELECT COUNT(1)
-		   FROM user_messages
-		   WHERE local_chat_id = ? AND seen = 0),
-		   unviewed_mentions_count =
-		   (SELECT COUNT(1)
-		   FROM user_messages
-		   WHERE local_chat_id = ? AND seen = 0 AND (mentioned or replied)),
+		   SET unviewed_message_count = 0,
+		   unviewed_mentions_count = 0,
                    highlight = 0
 		WHERE id = ?`, chatID, chatID, chatID)
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4859,7 +4859,7 @@ func (m *Messenger) markAllRead(chatID string, clock uint64, shouldBeSynced bool
 		return errors.New("chat not found")
 	}
 
-	seen, mentioned, err := m.persistence.MarkAllRead(chatID, clock)
+	_, _, err := m.persistence.MarkAllRead(chatID, clock)
 	if err != nil {
 		return err
 	}
@@ -4874,17 +4874,8 @@ func (m *Messenger) markAllRead(chatID string, clock uint64, shouldBeSynced bool
 	chat.ReadMessagesAtClockValue = clock
 	chat.Highlight = false
 
-	if chat.UnviewedMessagesCount >= uint(seen) {
-		chat.UnviewedMessagesCount -= uint(seen)
-	} else {
-		chat.UnviewedMessagesCount = 0
-	}
-
-	if chat.UnviewedMentionsCount >= uint(mentioned) {
-		chat.UnviewedMentionsCount -= uint(mentioned)
-	} else {
-		chat.UnviewedMentionsCount = 0
-	}
+	chat.UnviewedMessagesCount = 0
+	chat.UnviewedMentionsCount = 0
 
 	// TODO(samyoul) remove storing of an updated reference pointer?
 	m.allChats.Store(chat.ID, chat)

--- a/protocol/messenger_chats.go
+++ b/protocol/messenger_chats.go
@@ -460,6 +460,7 @@ func (m *Messenger) saveChat(chat *Chat) error {
 		chat.Alias = name
 		chat.Identicon = identicon
 	}
+
 	// Sync chat if it's a new active public chat, but not a timeline chat
 	if !ok && chat.Active && chat.Public() && !chat.ProfileUpdates() && !chat.Timeline() {
 

--- a/protocol/messenger_delete_message_test.go
+++ b/protocol/messenger_delete_message_test.go
@@ -448,6 +448,68 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageWithAMention() {
 	s.Require().Len(response.Chats(), 1)
 	s.Require().Len(response.Messages(), 1)
 	// Receiver (us) is  no longer mentioned
-	s.Require().Equal(int(response.Chats()[0].UnviewedMessagesCount), 0)
-	s.Require().Equal(int(response.Chats()[0].UnviewedMentionsCount), 0)
+	s.Require().Equal(int(state.Response.Chats()[0].UnviewedMessagesCount), 0)
+	s.Require().Equal(int(state.Response.Chats()[0].UnviewedMentionsCount), 0)
+}
+
+// This test makes sure the UnviewMessageCount doesn't go below 0 in a very rare case where the Chat could be marked
+// as read but the message still unseen (Seen == false)
+func (s *MessengerDeleteMessageSuite) TestDeleteMessageAndChatIsAlreadyRead() {
+	theirMessenger := s.newMessenger()
+	_, err := theirMessenger.Start()
+	s.Require().NoError(err)
+
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	err = theirMessenger.SaveChat(theirChat)
+	s.Require().NoError(err)
+
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	err = s.m.SaveChat(ourChat)
+	s.Require().NoError(err)
+
+	inputMessage := buildTestMessage(*theirChat)
+	sendResponse, err := theirMessenger.SendChatMessage(context.Background(), inputMessage)
+	s.NoError(err)
+	s.Require().Len(sendResponse.Messages(), 1)
+
+	response, err := WaitOnMessengerResponse(
+		s.m,
+		func(r *MessengerResponse) bool { return len(r.messages) == 1 },
+		"no messages",
+	)
+	s.Require().NoError(err)
+	s.Require().Len(response.Chats(), 1)
+	s.Require().Equal(response.Chats()[0].UnviewedMessagesCount, uint(1))
+	s.Require().Len(response.Messages(), 1)
+
+	// Force UnviewedMessagesCount to 0 to test if the uint validation is done correctly
+	ourChat.UnviewedMessagesCount = 0
+	err = s.m.saveChat(ourChat)
+
+	s.Require().NoError(err)
+
+	ogMessage := sendResponse.Messages()[0]
+
+	deleteMessage := DeleteMessage{
+		DeleteMessage: protobuf.DeleteMessage{
+			Clock:       2,
+			MessageType: protobuf.MessageType_ONE_TO_ONE,
+			MessageId:   ogMessage.ID,
+			ChatId:      theirChat.ID,
+		},
+		From: common.PubkeyToHex(&theirMessenger.identity.PublicKey),
+	}
+
+	state := &ReceivedMessageState{
+		Response: &MessengerResponse{},
+	}
+
+	// Handle Delete first
+	err = s.m.HandleDeleteMessage(state, deleteMessage)
+
+	s.Require().NoError(err)
+	s.Require().Len(response.Chats(), 1)
+	s.Require().Len(response.Messages(), 1)
+	// Receiver (us) no longer has unread messages and it's not negative
+	s.Require().Equal(0, int(state.Response.Chats()[0].UnviewedMessagesCount))
 }

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1632,8 +1632,10 @@ func (m *Messenger) HandleDeleteMessage(state *ReceivedMessageState, deleteMessa
 		// Reduce chat mention count and unread count if unread
 		if !messageToDelete.Seen && !unreadCountDecreased {
 			unreadCountDecreased = true
-			chat.UnviewedMessagesCount--
-			if messageToDelete.Mentioned || messageToDelete.Replied {
+			if chat.UnviewedMessagesCount > 0 {
+				chat.UnviewedMessagesCount--
+			}
+			if chat.UnviewedMentionsCount > 0 && (messageToDelete.Mentioned || messageToDelete.Replied) {
 				chat.UnviewedMentionsCount--
 			}
 			err := m.saveChat(chat)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10649

I'm not sure exactly how it's possible, but somehow, some people got -1 as `UnviewedMessagesCount` in the DB. It's supposed to be a uint, so I don't get how it's possible, but I added guards to make sure it doesn't happen again.
