### PR TITLE
fix(desktop/wallet): fix bug in balance_cache - balances and nonces

### DIFF
--- a/services/wallet/transfer/concurrent.go
+++ b/services/wallet/transfer/concurrent.go
@@ -139,7 +139,7 @@ func checkRangesWithStartBlock(parent context.Context, client BalanceReader, cac
 				return err
 			}
 			if lb.Cmp(hb) == 0 {
-				log.Debug("balances are equal", "from", from, "to", to)
+				log.Debug("balances are equal", "from", from, "to", to, "lb", lb, "hb", hb)
 
 				hn, err := cache.NonceAt(ctx, client, account, to)
 				if err != nil {
@@ -166,7 +166,7 @@ func checkRangesWithStartBlock(parent context.Context, client BalanceReader, cac
 					return err
 				}
 				if *ln == *hn {
-					log.Debug("transaction count is also equal", "from", from, "to", to)
+					log.Debug("transaction count is also equal", "from", from, "to", to, "ln", *ln, "hn", *hn)
 					return nil
 				}
 			}

--- a/services/wallet/transfer/reactor.go
+++ b/services/wallet/transfer/reactor.go
@@ -20,7 +20,7 @@ const (
 	ReactorNotStarted string = "reactor not started"
 
 	NonArchivalNodeBlockChunkSize = 100
-	DefaultNodeBlockChunkSize     = 10000
+	DefaultNodeBlockChunkSize     = 100000
 )
 
 var errAlreadyRunning = errors.New("already running")

--- a/services/wallet/transfer/sequential_fetch_strategy.go
+++ b/services/wallet/transfer/sequential_fetch_strategy.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/status-im/status-go/rpc/chain"
@@ -42,14 +41,12 @@ type SequentialFetchStrategy struct {
 func (s *SequentialFetchStrategy) newCommand(chainClient *chain.ClientWithFallback,
 	accounts []common.Address) async.Commander {
 
-	signer := types.NewLondonSigner(chainClient.ToBigInt())
 	ctl := &loadBlocksAndTransfersCommand{
 		db:                 s.db,
 		chainClient:        chainClient,
 		accounts:           accounts,
 		blockRangeDAO:      &BlockRangeSequentialDAO{s.db.client},
 		blockDAO:           s.blockDAO,
-		erc20:              NewERC20TransfersDownloader(chainClient, accounts, signer),
 		feed:               s.feed,
 		errorsCount:        0,
 		transactionManager: s.transactionManager,


### PR DESCRIPTION
were stored in cache by pointers, which caused falsy cache hits in loop because pointers with same address were created for different block numbers. Now cache uses block numbers of uint64 as key, which can overflow but it is not a problem since we use this cache for values comparison, not as user data.
Fix crash on nil pointer in log.
Remove some unused code.
Protect nonceRanges with mutex while reading.

Updates [#10246](https://github.com/status-im/status-desktop/issues/10246)
