### PR TITLE
Added statusBackend.StopNode() when local pairing in Receiver mode

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1011,6 +1011,12 @@ func GetConnectionStringForBeingBootstrapped(configJSON string) string {
 	if err != nil {
 		return makeJSONResponse(err)
 	}
+
+	err = statusBackend.StopNode()
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
 	return cs
 }
 
@@ -1045,6 +1051,11 @@ func InputConnectionStringForBootstrapping(cs, configJSON string) string {
 	}
 
 	err := pairing.StartUpReceivingClient(statusBackend, cs, configJSON)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = statusBackend.StopNode()
 	return makeJSONResponse(err)
 }
 


### PR DESCRIPTION
## What's Changed?

Not much, after refactoring my original implementation of this functionality basically I've added a single function call to `statusBackend.StopNode()` in the case where a local pairing instance is receiving data the application should log the user out after using the `Messenger`.

## Why Change?

More detail is in the issue, but the summary is:

> the responsibility of Local Pairing should not be to log the application in for the user. Instead to maintain segregation of responsibility the Local Pairing process flow should clean up the logged in state of the application and log out once all Local Pairing functionality has completed.

Closes https://github.com/status-im/status-go/issues/3399