### PR TITLE
Add LoginAccount endpoint

### DIFF
--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -141,7 +141,7 @@ var goerliGanacheTokenOverrides = params.TokenOverride{
 	Address: ganacheTokenAddress,
 }
 
-func setRPCs(networks []params.Network, request *requests.CreateAccount) []params.Network {
+func setRPCs(networks []params.Network, request *requests.WalletSecretsConfig) []params.Network {
 
 	var networksWithRPC []params.Network
 
@@ -187,5 +187,5 @@ func setRPCs(networks []params.Network, request *requests.CreateAccount) []param
 }
 
 func buildDefaultNetworks(request *requests.CreateAccount) []params.Network {
-	return setRPCs(defaultNetworks, request)
+	return setRPCs(defaultNetworks, &request.WalletSecretsConfig)
 }

--- a/api/default_networks_test.go
+++ b/api/default_networks_test.go
@@ -13,8 +13,10 @@ func TestBuildDefaultNetworks(t *testing.T) {
 	poktToken := "poket-token"
 	infuraToken := "infura-token"
 	request := &requests.CreateAccount{
-		PoktToken:   poktToken,
-		InfuraToken: infuraToken,
+		WalletSecretsConfig: requests.WalletSecretsConfig{
+			PoktToken:   poktToken,
+			InfuraToken: infuraToken,
+		},
 	}
 
 	actualNetworks := buildDefaultNetworks(request)
@@ -55,7 +57,9 @@ func TestBuildDefaultNetworks(t *testing.T) {
 func TestBuildDefaultNetworksGanache(t *testing.T) {
 	ganacheURL := "ganacheurl"
 	request := &requests.CreateAccount{
-		GanacheURL: ganacheURL,
+		WalletSecretsConfig: requests.WalletSecretsConfig{
+			GanacheURL: ganacheURL,
+		},
 	}
 
 	actualNetworks := buildDefaultNetworks(request)

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -287,6 +287,30 @@ func CreateAccountAndLogin(requestJSON string) string {
 	return makeJSONResponse(nil)
 }
 
+func LoginAccount(requestJSON string) string {
+	var request requests.Login
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = request.Validate()
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	api.RunAsync(func() error {
+		err := statusBackend.LoginAccount(&request)
+		if err != nil {
+			log.Error("loginAccount error", err)
+			return err
+		}
+		log.Debug("loginAccount started node")
+		return nil
+	})
+	return makeJSONResponse(nil)
+}
+
 func RestoreAccountAndLogin(requestJSON string) string {
 	var request requests.RestoreAccount
 	err := json.Unmarshal([]byte(requestJSON), &request)

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -36,10 +36,15 @@ type CreateAccount struct {
 
 	CurrentNetwork string `json:"currentNetwork"`
 	NetworkID      uint64 `json:"networkId"`
-	PoktToken      string `json:"poktToken"`
-	InfuraToken    string `json:"infuraToken"`
-	InfuraSecret   string `json:"infuraSecret"`
-	OpenseaAPIKey  string `json:"openseaApiKey"`
+
+	WalletSecretsConfig
+}
+
+type WalletSecretsConfig struct {
+	PoktToken     string `json:"poktToken"`
+	InfuraToken   string `json:"infuraToken"`
+	InfuraSecret  string `json:"infuraSecret"`
+	OpenseaAPIKey string `json:"openseaApiKey"`
 
 	// Testing
 	GanacheURL                  string `json:"ganacheURL"`

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -1,0 +1,20 @@
+package requests
+
+import "errors"
+
+var ErrLoginInvalidKeyUID = errors.New("login: invalid key-uid")
+
+type Login struct {
+	Password      string `json:"password"`
+	KeyUID        string `json:"keyUid"`
+	KdfIterations int    `json:"kdfIterations"`
+
+	WalletSecretsConfig
+}
+
+func (c *Login) Validate() error {
+	if c.KeyUID == "" {
+		return ErrLoginInvalidKeyUID
+	}
+	return nil
+}

--- a/rpc/verif_proxy.go
+++ b/rpc/verif_proxy.go
@@ -6,14 +6,15 @@ package rpc
 import (
 	"context"
 	"fmt"
-)
 
-import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
+
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
+
 	proxy "github.com/siphiuel/lc-proxy-wrapper"
+
 	"github.com/status-im/status-go/params"
 )
 

--- a/rpc/verif_proxy_test.go
+++ b/rpc/verif_proxy_test.go
@@ -14,16 +14,15 @@ import (
 
 	"net/http"
 	"net/http/httptest"
-)
 
-import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	gethrpc "github.com/ethereum/go-ethereum/rpc"
-	"github.com/status-im/status-go/params"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/status-im/status-go/params"
 )
 
 type ProxySuite struct {


### PR DESCRIPTION
This commit adds LoginAccount endpoint.
This makes it consistent with CreateAccount and RestoreAccount as they use similar config.

The notable difference with the previous endpoint is the API, which is the same as CreateAccount/RestoreAccount, and the fact that it will override your networks configuration, and use the credentials passed by the client.

Storing them in the config is now not needed anymore, as that's always driven from the backend, and we won't allow custom networks in the new wallet.

We can now probably start using the same 3 endpoints, CreateAccount/RestoreAccount/LoginAccount on both desktop and mobile.