### PR TITLE
feat(wallet): SequentialFetchStrategy improvements

### DIFF
--- a/services/wallet/transfer/block_dao.go
+++ b/services/wallet/transfer/block_dao.go
@@ -249,6 +249,30 @@ func (b *BlockDAO) GetLastSavedBlock(chainID uint64) (rst *DBHeader, err error) 
 	return nil, nil
 }
 
+func (b *BlockDAO) GetFirstSavedBlock(chainID uint64, address common.Address) (rst *DBHeader, err error) {
+	query := `SELECT blk_number, blk_hash, loaded
+	FROM blocks
+	WHERE network_id = ? AND address = ?
+	ORDER BY blk_number LIMIT 1`
+	rows, err := b.db.Query(query, chainID, address)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		header := &DBHeader{Hash: common.Hash{}, Number: new(big.Int)}
+		err = rows.Scan((*bigint.SQLBigInt)(header.Number), &header.Hash, &header.Loaded)
+		if err != nil {
+			return nil, err
+		}
+
+		return header, nil
+	}
+
+	return nil, nil
+}
+
 // TODO remove as not used
 func (b *BlockDAO) GetBlocks(chainID uint64) (rst []*DBHeader, err error) {
 	query := `SELECT blk_number, blk_hash, address FROM blocks`

--- a/services/wallet/transfer/block_ranges_sequential_dao.go
+++ b/services/wallet/transfer/block_ranges_sequential_dao.go
@@ -81,8 +81,7 @@ func (b *BlockRangeSequentialDAO) upsertRange(chainID uint64, account common.Add
 		// to a greater value, because no history can be before some block that is considered
 		// as a start of history, but due to concurrent block range checks, a newer greater block
 		// can be found that matches criteria of a start block (nonce is zero, balances are equal)
-		if newBlockRange.Start != nil || (blockRange.Start != nil && newBlockRange.Start != nil &&
-			blockRange.Start.Cmp(newBlockRange.Start) < 0) {
+		if newBlockRange.Start != nil && (blockRange.Start == nil || blockRange.Start.Cmp(newBlockRange.Start) < 0) {
 			blockRange.Start = newBlockRange.Start
 		}
 

--- a/services/wallet/transfer/concurrent.go
+++ b/services/wallet/transfer/concurrent.go
@@ -93,9 +93,9 @@ type Downloader interface {
 
 // Returns new block ranges that contain transfers and found block headers that contain transfers, and a block where
 // beginning of trasfers history detected
-func checkRangesWithStartBlock(parent context.Context, client BalanceReader, cache BalanceCache, downloader Downloader,
-	account common.Address, ranges [][]*big.Int, threadLimit uint32, startBlock *big.Int) (resRanges [][]*big.Int,
-	headers []*DBHeader, newStartBlock *big.Int, err error) {
+func checkRangesWithStartBlock(parent context.Context, client BalanceReader, cache BalanceCache,
+	account common.Address, ranges [][]*big.Int, threadLimit uint32, startBlock *big.Int) (
+	resRanges [][]*big.Int, headers []*DBHeader, newStartBlock *big.Int, err error) {
 
 	log.Debug("start checkRanges", "account", account.Hex(), "ranges len", len(ranges))
 
@@ -208,8 +208,9 @@ func checkRangesWithStartBlock(parent context.Context, client BalanceReader, cac
 	return c.GetRanges(), c.GetHeaders(), newStartBlock, nil
 }
 
-func findBlocksWithEthTransfers(parent context.Context, client BalanceReader, cache BalanceCache, downloader Downloader,
-	account common.Address, low, high *big.Int, noLimit bool, threadLimit uint32) (from *big.Int, headers []*DBHeader, resStartBlock *big.Int, err error) {
+func findBlocksWithEthTransfers(parent context.Context, client BalanceReader, cache BalanceCache,
+	account common.Address, low, high *big.Int, noLimit bool, threadLimit uint32) (
+	from *big.Int, headers []*DBHeader, resStartBlock *big.Int, err error) {
 
 	ranges := [][]*big.Int{{low, high}}
 	from = big.NewInt(low.Int64())
@@ -222,7 +223,7 @@ func findBlocksWithEthTransfers(parent context.Context, client BalanceReader, ca
 		// Check if there are transfers in blocks in ranges. To do that, nonce and balance is checked
 		// the block ranges that have transfers are returned
 		newRanges, newHeaders, strtBlock, err := checkRangesWithStartBlock(parent, client, cache,
-			downloader, account, ranges, threadLimit, resStartBlock)
+			account, ranges, threadLimit, resStartBlock)
 		resStartBlock = strtBlock
 		if err != nil {
 			return nil, nil, nil, err

--- a/services/wallet/transfer/concurrent_test.go
+++ b/services/wallet/transfer/concurrent_test.go
@@ -128,7 +128,7 @@ func TestConcurrentEthDownloader(t *testing.T) {
 			defer cancel()
 			concurrent := NewConcurrentDownloader(ctx, 0)
 			_, headers, _, _ := findBlocksWithEthTransfers(
-				ctx, tc.options.balances, newBalanceCache(), tc.options.batches,
+				ctx, tc.options.balances, newBalanceCache(),
 				common.Address{}, zero, tc.options.last, false, NoThreadLimit)
 			concurrent.Wait()
 			require.NoError(t, concurrent.Error())


### PR DESCRIPTION
- reverted a change that stopped looking for ERC20 transfers if no nonce and balance change found within a block range for ETH
- implemented sending EventRecentHistoryReady event at a proper time
- moved EventFetchingRecentHistory event to Strategy type as it does not make sense to send this event in loop
- moved iterating through blocks logic to inside of `loadTransfers` command, which now accepts a block range. It allows to handle each accounts transfer commands completion separately and fire event on finished per account basis
- reused `uniqueHeaders` function in commands.go
- cleaned up

Updates [#10246](https://github.com/status-im/status-desktop/issues/10246)
