### PR TITLE
ci: bump tests timeout to 30 minutes

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -14,7 +14,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 20, unit: 'MINUTES')
+    timeout(time: 30, unit: 'MINUTES')
     disableConcurrentBuilds()
     /* manage how many builds we keep */
     buildDiscarder(logRotator(


### PR DESCRIPTION
The test running time can be a bit unpredictable due to server load, which can result in tests that finish in 5 minutes, or over 20.