### PR TITLE
feat(wallet): enable sequential transfers fetching by default.

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -520,6 +520,8 @@ type WalletConfig struct {
 	AlchemyAPIKeys     map[uint64]string `json:"AlchemyAPIKeys"`
 	InfuraAPIKey       string            `json:"InfuraAPIKey"`
 	InfuraAPIKeySecret string            `json:"InfuraAPIKeySecret"`
+	// LoadAllTransfers should be false to reduce network traffic and harddrive space consumption when loading tranfers
+	LoadAllTransfers bool `json:"LoadAllTransfers"`
 }
 
 // LocalNotificationsConfig extra configuration for localnotifications.Service.

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -86,7 +86,7 @@ func NewService(
 	tokenManager := token.NewTokenManager(db, rpcClient, rpcClient.NetworkManager)
 	savedAddressesManager := &SavedAddressesManager{db: db}
 	transactionManager := transfer.NewTransactionManager(db, gethManager, transactor, config, accountsDB)
-	transferController := transfer.NewTransferController(db, rpcClient, accountFeed, walletFeed, transactionManager, tokenManager, transfer.OnDemandFetchStrategyType)
+	transferController := transfer.NewTransferController(db, rpcClient, accountFeed, walletFeed, transactionManager, tokenManager, config.WalletConfig.LoadAllTransfers)
 	cryptoCompare := cryptocompare.NewClient()
 	coingecko := coingecko.NewClient()
 	marketManager := market.NewManager(cryptoCompare, coingecko, walletFeed)

--- a/services/wallet/transfer/reactor.go
+++ b/services/wallet/transfer/reactor.go
@@ -251,9 +251,9 @@ func NewReactor(db *Database, blockDAO *BlockDAO, feed *event.Feed, tm *Transact
 
 // Start runs reactor loop in background.
 func (r *Reactor) start(chainClients map[uint64]*chain.ClientWithFallback, accounts []common.Address,
-	fetchStrategyType FetchStrategyType) error {
+	loadAllTransfers bool) error {
 
-	r.strategy = r.createFetchStrategy(chainClients, accounts, fetchStrategyType)
+	r.strategy = r.createFetchStrategy(chainClients, accounts, loadAllTransfers)
 	return r.strategy.start()
 }
 
@@ -265,16 +265,16 @@ func (r *Reactor) stop() {
 }
 
 func (r *Reactor) restart(chainClients map[uint64]*chain.ClientWithFallback, accounts []common.Address,
-	fetchStrategyType FetchStrategyType) error {
+	loadAllTransfers bool) error {
 
 	r.stop()
-	return r.start(chainClients, accounts, fetchStrategyType)
+	return r.start(chainClients, accounts, loadAllTransfers)
 }
 
 func (r *Reactor) createFetchStrategy(chainClients map[uint64]*chain.ClientWithFallback,
-	accounts []common.Address, fetchType FetchStrategyType) HistoryFetcher {
+	accounts []common.Address, loadAllTransfers bool) HistoryFetcher {
 
-	if fetchType == SequentialFetchStrategyType {
+	if loadAllTransfers {
 		return NewSequentialFetchStrategy(
 			r.db,
 			r.blockDAO,


### PR DESCRIPTION
Enable sequential fetch strategy by default for desktop .
"EventNewTransfers' event is sent on each block processed, otherwise it could take minutes or longer before first 'EventNewTransfers' is sent.

Set `LoadAllTransfers=true` in node config to enable sequential transfers fetch strategy

Updates [#10246](https://github.com/status-im/status-desktop/issues/10246)
