### PR TITLE
fix(wallet) limit nft description length

### DIFF
--- a/services/wallet/collectibles/collectibles.go
+++ b/services/wallet/collectibles/collectibles.go
@@ -21,6 +21,8 @@ const requestTimeout = 5 * time.Second
 
 const hystrixContractOwnershipClientName = "contractOwnershipClient"
 
+const maxNFTDescriptionLength = 1024
+
 type Manager struct {
 	rpcClient                         *rpc.Client
 	mainContractOwnershipProvider     thirdparty.NFTContractOwnershipProvider
@@ -270,6 +272,12 @@ func (o *Manager) processAssets(chainID uint64, assets []opensea.Asset) error {
 					assets[idx].ImageURL = metadata.ImageURL
 				}
 			}
+		}
+
+		// The NFT description field could be arbitrarily large, causing memory management issues upstream.
+		// Trim it to a reasonable length here.
+		if len(assets[idx].Description) > maxNFTDescriptionLength {
+			assets[idx].Description = assets[idx].Description[:maxNFTDescriptionLength]
 		}
 
 		o.nftCache[chainID][id.HashKey()] = assets[idx]


### PR DESCRIPTION
Fixes [#10923](https://github.com/status-im/status-desktop/issues/10923)

Nim (sometimes?) crashes when trying to parse JSONs which are too large. We've observed some crashes after fetching collectibles, which seem to be tied to the length of their `description` field. Since it could be arbitrarily long, we impose a hard limit in the backend.
