### PR TITLE
fix: don't unsubscribe from community when kicked

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4359,9 +4359,13 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 					}
 
 				} else if changes.ShouldMemberLeave {
-					response, err := m.leaveCommunity(changes.Community.ID())
+					// this means we've been kicked by the community owner/admin,
+					// in this case we don't want to unsubscribe from community updates
+					// so we still get notified accordingly when something changes,
+					// hence, we're setting `unsubscribeFromCommunity` to `false` here
+					response, err := m.leaveCommunity(changes.Community.ID(), false)
 					if err != nil {
-						logger.Error("cannot join community", zap.Error(err))
+						logger.Error("cannot leave community", zap.Error(err))
 						continue
 					}
 

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -980,7 +980,7 @@ func (m *Messenger) LeaveCommunity(communityID types.HexBytes) (*MessengerRespon
 		return nil, err
 	}
 
-	mr, err := m.leaveCommunity(communityID)
+	mr, err := m.leaveCommunity(communityID, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1036,7 +1036,7 @@ func (m *Messenger) LeaveCommunity(communityID types.HexBytes) (*MessengerRespon
 	return mr, nil
 }
 
-func (m *Messenger) leaveCommunity(communityID types.HexBytes) (*MessengerResponse, error) {
+func (m *Messenger) leaveCommunity(communityID types.HexBytes, unsubsribeFromCommunity bool) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
 
 	community, err := m.communitiesManager.LeaveCommunity(communityID)
@@ -1059,9 +1059,11 @@ func (m *Messenger) leaveCommunity(communityID types.HexBytes) (*MessengerRespon
 		}
 	}
 
-	_, err = m.transport.RemoveFilterByChatID(communityID.String())
-	if err != nil {
-		return nil, err
+	if unsubsribeFromCommunity {
+		_, err = m.transport.RemoveFilterByChatID(communityID.String())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	response.AddCommunity(community)
@@ -2143,7 +2145,7 @@ func (m *Messenger) handleSyncCommunity(messageState *ReceivedMessageState, sync
 				return err
 			}
 		} else {
-			mr, err = m.leaveCommunity(syncCommunity.Id)
+			mr, err = m.leaveCommunity(syncCommunity.Id, true)
 			if err != nil {
 				logger.Debug("m.leaveCommunity error", zap.Error(err))
 				return err


### PR DESCRIPTION
There's two scenarios in which we're leaving a community: We either get kicked or we leave ourselves.

In case of leaving ourselves it's fine to unsubscribe from further community updates be cause we deliberately chose to leave.

In case of being kicked however, this is different. Say I'm kicked from a community because its token permissions have changed, in this case we don't want clients to manually re-subscribe to the community to get informed when there were further changes. status-go should rather not unsubscribe if we know for sure we've been kicked by someone else.

