### PR TITLE
chore: `forceFetchingBackup` param added to `RequestAllHistoricMessages` and `RequestAllHistoricMessagesWithRetries` functions

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -834,7 +834,7 @@ func (m *Messenger) handleConnectionChange(online bool) {
 			m.shouldPublishContactCode = false
 		}
 		go func() {
-			_, err := m.RequestAllHistoricMessagesWithRetries()
+			_, err := m.RequestAllHistoricMessagesWithRetries(false)
 			if err != nil {
 				m.logger.Warn("failed to fetch historic messages", zap.Error(err))
 			}

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -294,12 +294,12 @@ func (m *Messenger) resetFiltersPriority(filters []*transport.Filter) {
 	}
 }
 
-func (m *Messenger) RequestAllHistoricMessagesWithRetries() (*MessengerResponse, error) {
-	return m.performMailserverRequest(m.RequestAllHistoricMessages)
+func (m *Messenger) RequestAllHistoricMessagesWithRetries(forceFetchingBackup bool) (*MessengerResponse, error) {
+	return m.performMailserverRequest(func() (*MessengerResponse, error) { return m.RequestAllHistoricMessages(forceFetchingBackup) })
 }
 
 // RequestAllHistoricMessages requests all the historic messages for any topic
-func (m *Messenger) RequestAllHistoricMessages() (*MessengerResponse, error) {
+func (m *Messenger) RequestAllHistoricMessages(forceFetchingBackup bool) (*MessengerResponse, error) {
 	shouldSync, err := m.shouldSync()
 	if err != nil {
 		return nil, err
@@ -314,7 +314,7 @@ func (m *Messenger) RequestAllHistoricMessages() (*MessengerResponse, error) {
 		return nil, err
 	}
 
-	if !backupFetched {
+	if forceFetchingBackup || !backupFetched {
 		m.logger.Info("fetching backup")
 		err := m.syncBackup()
 		if err != nil {

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -515,7 +515,7 @@ func (m *Messenger) handleMailserverCycleEvent(connectedPeers []ConnectedPeer) e
 				}
 				// Query mailserver
 				go func() {
-					_, err := m.performMailserverRequest(m.RequestAllHistoricMessages)
+					_, err := m.performMailserverRequest(func() (*MessengerResponse, error) { return m.RequestAllHistoricMessages(false) })
 					if err != nil {
 						m.logger.Error("could not perform mailserver request", zap.Error(err))
 					}

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1172,12 +1172,12 @@ func (api *PublicAPI) DeleteActivityCenterNotifications(ctx context.Context, ids
 	return api.service.messenger.DeleteActivityCenterNotifications(ctx, ids, false)
 }
 
-func (api *PublicAPI) RequestAllHistoricMessages() (*protocol.MessengerResponse, error) {
-	return api.service.messenger.RequestAllHistoricMessages()
+func (api *PublicAPI) RequestAllHistoricMessages(forceFetchingBackup bool) (*protocol.MessengerResponse, error) {
+	return api.service.messenger.RequestAllHistoricMessages(forceFetchingBackup)
 }
 
-func (api *PublicAPI) RequestAllHistoricMessagesWithRetries() (*protocol.MessengerResponse, error) {
-	return api.service.messenger.RequestAllHistoricMessagesWithRetries()
+func (api *PublicAPI) RequestAllHistoricMessagesWithRetries(forceFetchingBackup bool) (*protocol.MessengerResponse, error) {
+	return api.service.messenger.RequestAllHistoricMessagesWithRetries(forceFetchingBackup)
 }
 
 func (api *PublicAPI) DisconnectActiveMailserver() {


### PR DESCRIPTION
If `forceFetchingBackup` is set to `true` it will force `syncBackup` function call. 