### PR TITLE
perf(sqlCipher): Increase cipher page size to 8192

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -289,6 +289,39 @@ func (b *GethStatusBackend) DeleteImportedKey(address, password, keyStoreDir str
 	return err
 }
 
+func (b *GethStatusBackend) runDBFileMigrations(account multiaccounts.Account, password string) (string, error) {
+	// Migrate file path to fix issue https://github.com/status-im/status-go/issues/2027
+	unsupportedPath := filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql", account.KeyUID))
+	v3Path := filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db", account.KeyUID))
+	v4Path := filepath.Join(b.rootDataDir, fmt.Sprintf("%s-v4.db", account.KeyUID))
+
+	_, err := os.Stat(unsupportedPath)
+	if err == nil {
+		err := os.Rename(unsupportedPath, v3Path)
+		if err != nil {
+			return "", err
+		}
+
+		// rename journals as well, but ignore errors
+		_ = os.Rename(unsupportedPath+"-shm", v3Path+"-shm")
+		_ = os.Rename(unsupportedPath+"-wal", v3Path+"-wal")
+	}
+
+	if _, err = os.Stat(v3Path); err == nil {
+		if err := appdatabase.MigrateV3ToV4(v3Path, v4Path, password, account.KDFIterations); err != nil {
+			_ = os.Remove(v4Path)
+			_ = os.Remove(v4Path + "-shm")
+			_ = os.Remove(v4Path + "-wal")
+			return "", errors.New("Failed to migrate v3 db to v4: " + err.Error())
+		}
+		_ = os.Remove(v3Path)
+		_ = os.Remove(v3Path + "-shm")
+		_ = os.Remove(v3Path + "-wal")
+	}
+
+	return v4Path, nil
+}
+
 func (b *GethStatusBackend) ensureAppDBOpened(account multiaccounts.Account, password string) (err error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -299,23 +332,12 @@ func (b *GethStatusBackend) ensureAppDBOpened(account multiaccounts.Account, pas
 		return errors.New("root datadir wasn't provided")
 	}
 
-	// Migrate file path to fix issue https://github.com/status-im/status-go/issues/2027
-	oldPath := filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql", account.KeyUID))
-	newPath := filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db", account.KeyUID))
-
-	_, err = os.Stat(oldPath)
-	if err == nil {
-		err := os.Rename(oldPath, newPath)
-		if err != nil {
-			return err
-		}
-
-		// rename journals as well, but ignore errors
-		_ = os.Rename(oldPath+"-shm", newPath+"-shm")
-		_ = os.Rename(oldPath+"-wal", newPath+"-wal")
+	dbFilePath, err := b.runDBFileMigrations(account, password)
+	if err != nil {
+		return errors.New("Failed to migrate db file: " + err.Error())
 	}
 
-	b.appDB, err = appdatabase.InitializeDB(newPath, password, account.KDFIterations)
+	b.appDB, err = appdatabase.InitializeDB(dbFilePath, password, account.KDFIterations)
 	if err != nil {
 		b.log.Error("failed to initialize db", "err", err)
 		return err
@@ -1126,15 +1148,6 @@ func (b *GethStatusBackend) VerifyDatabasePassword(keyUID string, password strin
 	}
 
 	err = b.ensureAppDBOpened(multiaccounts.Account{KeyUID: keyUID, KDFIterations: kdfIterations}, password)
-	if err != nil {
-		return err
-	}
-
-	accountsDB, err := accounts.NewDB(b.appDB)
-	if err != nil {
-		return err
-	}
-	_, err = accountsDB.GetWalletAddress()
 	if err != nil {
 		return err
 	}

--- a/appdatabase/database.go
+++ b/appdatabase/database.go
@@ -200,6 +200,10 @@ func migrateEnsUsernames(sqlTx *sql.Tx) error {
 	return nil
 }
 
+func MigrateV3ToV4(v3Path string, v4Path string, password string, kdfIterationsNumber int) error {
+	return sqlite.MigrateV3ToV4(v3Path, v4Path, password, kdfIterationsNumber)
+}
+
 const (
 	batchSize = 1000
 )

--- a/signal/events_db.go
+++ b/signal/events_db.go
@@ -1,0 +1,18 @@
+package signal
+
+const (
+	// ReEncryptionStarted is sent when db reencryption was started.
+	ReEncryptionStarted = "db.reEncryption.started"
+	// ReEncryptionFinished is sent when db reencryption was finished.
+	ReEncryptionFinished = "db.reEncryption.finished"
+)
+
+// Send db.reencryption.started signal.
+func SendReEncryptionStarted() {
+	send(ReEncryptionStarted, nil)
+}
+
+// Send db.reencryption.finished signal.
+func SendReEncryptionFinished() {
+	send(ReEncryptionFinished, nil)
+}

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -13,6 +13,7 @@ import (
 	sqlcipher "github.com/mutecomm/go-sqlcipher/v4" // We require go sqlcipher that overrides default implementation
 
 	"github.com/status-im/status-go/protocol/sqlite"
+	"github.com/status-im/status-go/signal"
 )
 
 const (
@@ -51,6 +52,9 @@ func DecryptDB(oldPath string, newPath string, key string, kdfIterationsNumber i
 }
 
 func encryptDB(db *sql.DB, encryptedPath string, key string, kdfIterationsNumber int) error {
+	signal.SendReEncryptionStarted()
+	defer signal.SendReEncryptionFinished()
+
 	_, err := db.Exec(`ATTACH DATABASE '` + encryptedPath + `' AS encrypted KEY '` + key + `'`)
 	if err != nil {
 		return err
@@ -240,6 +244,9 @@ func OpenUnecryptedDB(path string) (*sql.DB, error) {
 }
 
 func ChangeEncryptionKey(path string, key string, kdfIterationsNumber int, newKey string) error {
+	signal.SendReEncryptionStarted()
+	defer signal.SendReEncryptionFinished()
+
 	if kdfIterationsNumber <= 0 {
 		kdfIterationsNumber = sqlite.ReducedKDFIterationsNumber
 	}


### PR DESCRIPTION
Increasing the cipher page size to 8192 requires DB re-encryption. The process is as follows: 
```
//Login to v3 DB
PRAGMA key = 'key';
PRAGMA cipher_page_size = 1024"; // old Page size
PRAGMA cipher_hmac_algorithm = HMAC_SHA1";
PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1";
PRAGMA kdf_iter = kdfIterationsNumber";

//Create V4 DB with increased page size
ATTACH DATABASE 'newdb.db' AS newdb KEY 'key';
PRAGMA newdb.cipher_page_size = 8192; // new Page size PRAGMA newdb.cipher_hmac_algorithm = HMAC_SHA1"; // same as in v3 PRAGMA newdb.cipher_kdf_algorithm = PBKDF2_HMAC_SHA1"; // same as in v3 PRAGMA newdb.kdf_iter = kdfIterationsNumber"; // same as in v3 SELECT sqlcipher_export('newdb');
DETACH DATABASE newdb;

//Login to V4 DB
...
```

Worth noting:

- The DB migration will happen on the first successful login. 
- The new DB version will have a different name to be able to distinguish between different DB versions.Versions naming mirrors sqlcipher major version (naming conventions used by sqlcipher), meaning that we're migrating from V3 to V4 DB (even if we're not fully aligned with V4 standards). The DB is not migrated to the v4 standard `SHA512` due to performance reasons. Our custom `SHA1` implementation is fully optimised for performance.
- If the migration is successful a new DB file will be created and the old DB file will be deleted

Closes https://github.com/status-im/status-desktop/issues/10753