### PR TITLE
feat(wallet): make filter API async

### DIFF
--- a/services/wallet/activity/activity.go
+++ b/services/wallet/activity/activity.go
@@ -1,6 +1,7 @@
 package activity
 
 import (
+	"context"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -422,12 +423,12 @@ const (
 	noEntriesInTmpTableSQLValues = "(NULL)"
 )
 
-// GetActivityEntries returns query the transfers, pending_transactions, and multi_transactions tables
+// getActivityEntries queries the transfers, pending_transactions, and multi_transactions tables
 // based on filter parameters and arguments
 // it returns metadata for all entries ordered by timestamp column
 //
 // Adding a no-limit option was never considered or required.
-func GetActivityEntries(db *sql.DB, addresses []eth.Address, chainIDs []common.ChainID, filter Filter, offset int, limit int) ([]Entry, error) {
+func getActivityEntries(ctx context.Context, db *sql.DB, addresses []eth.Address, chainIDs []common.ChainID, filter Filter, offset int, limit int) ([]Entry, error) {
 	// TODO: filter collectibles after  they are added to multi_transactions table
 	if len(filter.Tokens.EnabledTypes) > 0 && !sliceContains(filter.Tokens.EnabledTypes, AssetTT) {
 		// For now we deal only with assets so return empty result
@@ -483,7 +484,7 @@ func GetActivityEntries(db *sql.DB, addresses []eth.Address, chainIDs []common.C
 	queryString := fmt.Sprintf(queryFormatString, involvedAddresses, toAddresses, assets, networks,
 		joinedMTTypes)
 
-	rows, err := db.Query(queryString,
+	rows, err := db.QueryContext(ctx, queryString,
 		startFilterDisabled, filter.Period.StartTimestamp, endFilterDisabled, filter.Period.EndTimestamp,
 		filterActivityTypeAll, sliceContains(filter.Types, SendAT), sliceContains(filter.Types, ReceiveAT),
 		fromTrType, toTrType,

--- a/services/wallet/activity/service.go
+++ b/services/wallet/activity/service.go
@@ -1,0 +1,123 @@
+package activity
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+
+	w_common "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/walletevent"
+)
+
+const (
+	// FilterResponse json is sent as a message in the EventActivityFilteringDone event
+	EventActivityFilteringDone walletevent.EventType = "wallet-activity-filtering-done"
+)
+
+type Service struct {
+	db        *sql.DB
+	eventFeed *event.Feed
+
+	context  context.Context
+	cancelFn context.CancelFunc
+	wg       sync.WaitGroup
+	mu       sync.Mutex
+}
+
+func NewService(db *sql.DB, eventFeed *event.Feed) *Service {
+	return &Service{
+		db:        db,
+		eventFeed: eventFeed,
+	}
+}
+
+type ErrorCode = int
+
+const (
+	ErrorCodeSuccess ErrorCode = iota + 1
+	ErrorCodeFilterCanceled
+	ErrorCodeFilterFailed
+)
+
+type FilterResponse struct {
+	Activities       []Entry   `json:"activities"`
+	ThereMightBeMore bool      `json:"thereMightBeMore"`
+	ErrorCode        ErrorCode `json:"errorCode"`
+}
+
+// FilterActivityAsync allows only one filter task to run at a time
+// and it cancels the current one if a new one is started
+// All calls will trigger an EventActivityFilteringDone event with the result of the filtering
+func (s *Service) FilterActivityAsync(ctx context.Context, addresses []common.Address, chainIDs []w_common.ChainID, filter Filter, offset int, limit int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// If a previous task is running, cancel it and wait to finish
+	if s.cancelFn != nil {
+		s.cancelFn()
+		s.wg.Wait()
+	}
+
+	if ctx.Err() != nil {
+		return fmt.Errorf("context error: %w", ctx.Err())
+	}
+
+	s.context, s.cancelFn = context.WithCancel(context.Background())
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		defer func() {
+			s.cancelFn = nil
+		}()
+
+		activities, err := getActivityEntries(s.context, s.db, addresses, chainIDs, filter, offset, limit)
+
+		res := FilterResponse{
+			ErrorCode: ErrorCodeFilterFailed,
+		}
+
+		if errors.Is(err, context.Canceled) {
+			res.ErrorCode = ErrorCodeFilterCanceled
+		} else if err == nil {
+			res.Activities = activities
+			res.ThereMightBeMore = len(activities) == limit
+			res.ErrorCode = ErrorCodeSuccess
+		}
+
+		s.sendResponseEvent(res)
+	}()
+
+	return nil
+}
+
+func (s *Service) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// If a previous task is running, cancel it and wait to finish
+	if s.cancelFn != nil {
+		s.cancelFn()
+		s.wg.Wait()
+		s.cancelFn = nil
+	}
+}
+
+func (s *Service) sendResponseEvent(response FilterResponse) {
+	payload, err := json.Marshal(response)
+	if err != nil {
+		log.Error("Error marshaling response: %v", err)
+	}
+
+	s.eventFeed.Send(walletevent.Event{
+		Type:    EventActivityFilteringDone,
+		Message: string(payload),
+	})
+}

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -20,7 +20,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/services/wallet/transfer"
 
-	wallet_common "github.com/status-im/status-go/services/wallet/common"
+	wcommon "github.com/status-im/status-go/services/wallet/common"
 )
 
 func NewAPI(s *Service) *API {
@@ -528,7 +528,7 @@ func (api *API) FetchAllCurrencyFormats() (currency.FormatPerSymbol, error) {
 	return api.s.currency.FetchAllCurrencyFormats()
 }
 
-func (api *API) GetActivityEntries(addresses []common.Address, chainIDs []wallet_common.ChainID, filter activity.Filter, offset int, limit int) ([]activity.Entry, error) {
-	log.Debug("call to GetActivityEntries")
-	return activity.GetActivityEntries(api.s.db, addresses, chainIDs, filter, offset, limit)
+func (api *API) FilterActivityAsync(ctx context.Context, addresses []common.Address, chainIDs []wcommon.ChainID, filter activity.Filter, offset int, limit int) error {
+	log.Debug("[WalletAPI:: FilterActivityAsync] addr.count", len(addresses), "chainIDs.count", len(chainIDs), "filter", filter, "offset", offset, "limit", limit)
+	return api.s.activity.FilterActivityAsync(ctx, addresses, chainIDs, filter, offset, limit)
 }

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/services/ens"
 	"github.com/status-im/status-go/services/stickers"
+	"github.com/status-im/status-go/services/wallet/activity"
 	"github.com/status-im/status-go/services/wallet/collectibles"
 	"github.com/status-im/status-go/services/wallet/currency"
 	"github.com/status-im/status-go/services/wallet/history"
@@ -93,6 +94,7 @@ func NewService(
 	reader := NewReader(rpcClient, tokenManager, marketManager, accountsDB, NewPersistence(db), walletFeed)
 	history := history.NewService(db, walletFeed, rpcClient, tokenManager, marketManager)
 	currency := currency.NewService(db, walletFeed, tokenManager, marketManager)
+	activity := activity.NewService(db, walletFeed)
 
 	alchemyClient := alchemy.NewClient(config.WalletConfig.AlchemyAPIKeys)
 	infuraClient := infura.NewClient(config.WalletConfig.InfuraAPIKey, config.WalletConfig.InfuraAPIKeySecret)
@@ -118,6 +120,7 @@ func NewService(
 		reader:                reader,
 		history:               history,
 		currency:              currency,
+		activity:              activity,
 	}
 }
 
@@ -144,6 +147,7 @@ type Service struct {
 	reader                *Reader
 	history               *history.Service
 	currency              *currency.Service
+	activity              *activity.Service
 }
 
 // Start signals transmitter.
@@ -169,6 +173,7 @@ func (s *Service) Stop() error {
 	s.currency.Stop()
 	s.reader.Stop()
 	s.history.Stop()
+	s.activity.Stop()
 	s.started = false
 	log.Info("wallet stopped")
 	return nil


### PR DESCRIPTION
### Closes status-desktop [#10994](https://github.com/status-im/status-desktop/issues/10994)

Refactor the filter interface into an async call which returns the result using a wallet event.
A call to the filter API will cancel the ongoing filter and receive an error result event.
The filter also returns if there might be more info based on the heuristic of the query returning fewer results than the requested batch
For every call to the filter API, an async response is guaranteed success or failure.
Provide error codes for error state interpretation

Closes status-desktop #10994

