### PR TITLE
chore(wallet): split multitransaction command from full struct

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -508,9 +508,9 @@ func (api *API) GetAddressDetails(ctx context.Context, chainID uint64, address s
 	}, nil
 }
 
-func (api *API) CreateMultiTransaction(ctx context.Context, multiTransaction *transfer.MultiTransaction, data []*bridge.TransactionBridge, password string) (*transfer.MultiTransactionResult, error) {
+func (api *API) CreateMultiTransaction(ctx context.Context, multiTransactionCommand *transfer.MultiTransactionCommand, data []*bridge.TransactionBridge, password string) (*transfer.MultiTransactionCommandResult, error) {
 	log.Debug("[WalletAPI:: CreateMultiTransaction] create multi transaction")
-	return api.s.transactionManager.CreateBridgeMultiTransaction(ctx, multiTransaction, data, api.router.bridges, password)
+	return api.s.transactionManager.CreateMultiTransactionFromCommand(ctx, multiTransactionCommand, data, api.router.bridges, password)
 }
 
 func (api *API) GetMultiTransactions(ctx context.Context, transactionIDs []transfer.MultiTransactionIDType) ([]*transfer.MultiTransaction, error) {

--- a/services/wallet/transfer/transaction.go
+++ b/services/wallet/transfer/transaction.go
@@ -64,7 +64,16 @@ type MultiTransaction struct {
 	Type        MultiTransactionType `json:"type"`
 }
 
-type MultiTransactionResult struct {
+type MultiTransactionCommand struct {
+	FromAddress common.Address       `json:"fromAddress"`
+	ToAddress   common.Address       `json:"toAddress"`
+	FromAsset   string               `json:"fromAsset"`
+	ToAsset     string               `json:"toAsset"`
+	FromAmount  *hexutil.Big         `json:"fromAmount"`
+	Type        MultiTransactionType `json:"type"`
+}
+
+type MultiTransactionCommandResult struct {
 	ID     int64                   `json:"id"`
 	Hashes map[uint64][]types.Hash `json:"hashes"`
 }
@@ -292,7 +301,16 @@ func (tm *TransactionManager) InsertMultiTransaction(multiTransaction *MultiTran
 	return insertMultiTransaction(tm.db, multiTransaction)
 }
 
-func (tm *TransactionManager) CreateBridgeMultiTransaction(ctx context.Context, multiTransaction *MultiTransaction, data []*bridge.TransactionBridge, bridges map[string]bridge.Bridge, password string) (*MultiTransactionResult, error) {
+func (tm *TransactionManager) CreateMultiTransactionFromCommand(ctx context.Context, command *MultiTransactionCommand, data []*bridge.TransactionBridge, bridges map[string]bridge.Bridge, password string) (*MultiTransactionCommandResult, error) {
+	multiTransaction := &MultiTransaction{
+		FromAddress: command.FromAddress,
+		ToAddress:   command.ToAddress,
+		FromAsset:   command.FromAsset,
+		ToAsset:     command.ToAsset,
+		FromAmount:  command.FromAmount,
+		Type:        command.Type,
+	}
+
 	selectedAccount, err := tm.getVerifiedWalletAccount(multiTransaction.FromAddress.Hex(), password)
 	if err != nil {
 		return nil, err
@@ -328,7 +346,7 @@ func (tm *TransactionManager) CreateBridgeMultiTransaction(ctx context.Context, 
 		hashes[tx.ChainID] = append(hashes[tx.ChainID], hash)
 	}
 
-	return &MultiTransactionResult{
+	return &MultiTransactionCommandResult{
 		ID:     int64(multiTransactionID),
 		Hashes: hashes,
 	}, nil


### PR DESCRIPTION
Part of #10791

This is a more "proper" and future-proof fix for the issue fixed here https://github.com/status-im/status-desktop/pull/11020

Since MultiTransaction will become more complex as more transaction types are supported, to avoid having the same issue in the future we simply split the "MultiTransactionCommand" (used to trigger some operation) from the full "MultiTransaction" struct.