### PR TITLE
chore(waku2): revert disable light client on status.prod

### DIFF
--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -219,11 +219,6 @@ func New(nodeKey string, fleet string, cfg *Config, logger *zap.Logger, appDB *s
 		return waku.node.FilterLightnode().IsSubscriptionAlive(context.Background(), sub)
 	}
 
-	// Disabling light client mode if using status.prod or undefined
-	if fleet == "status.prod" || fleet == "" {
-		cfg.LightClient = false
-	}
-
 	waku.settings = settings{
 		MaxMsgSize:        cfg.MaxMessageSize,
 		LightClient:       cfg.LightClient,


### PR DESCRIPTION
Reverts changes made in:
- https://github.com/status-im/status-go/pull/2987

i.e. re-enable light mode on status.prod.

_____

Requires:
- https://github.com/status-im/status-go/pull/3608

Required for:
- https://github.com/status-im/status-desktop/issues/10957

Corresponding desktop PR: 
- https://github.com/status-im/status-desktop/pull/11042
