### PR TITLE
feat: Make DB re-encryption fault proof

### DIFF
--- a/appdatabase/database.go
+++ b/appdatabase/database.go
@@ -72,6 +72,10 @@ func EncryptDatabase(oldPath, newPath, password string, kdfIterationsNumber int)
 	return sqlite.EncryptDB(oldPath, newPath, password, kdfIterationsNumber)
 }
 
+func ExportDB(path string, password string, kdfIterationsNumber int, newDbPAth string, newPassword string) error {
+	return sqlite.ExportDB(path, password, kdfIterationsNumber, newDbPAth, newPassword)
+}
+
 func ChangeDatabasePassword(path string, password string, kdfIterationsNumber int, newPassword string) error {
 	return sqlite.ChangeEncryptionKey(path, password, kdfIterationsNumber, newPassword)
 }

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -102,6 +102,16 @@ func EncryptDB(unencryptedPath string, encryptedPath string, key string, kdfIter
 	return encryptDB(db, encryptedPath, key, kdfIterationsNumber)
 }
 
+// Export takes an encrypted database and re-encrypts it in a new file, with a new key
+func ExportDB(encryptedPath string, key string, kdfIterationsNumber int, newPath string, newKey string) error {
+	db, err := openDB(encryptedPath, key, kdfIterationsNumber, V4CipherPageSize)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	return encryptDB(db, newPath, newKey, kdfIterationsNumber)
+}
+
 func buildSqlcipherDSN(path string) (string, error) {
 	if path == InMemoryPath {
 		return InMemoryPath, nil


### PR DESCRIPTION
Improve error management to avoid DB corruption in case of failure/app exit.

Changes:
Use sqlcipher_export instead of rekey to change the DB password. The advantage is that sqlcipher_export will operate on a new DB file and we don't need to modify the current account until the export is successful. Keeping the rekey requires to create a DB copy before trying to re-encrypt the DB, but the DB copy is risky in case the DB file changes while the copy is in progress. It could also lead to DB corruption.

Closes https://github.com/status-im/status-desktop/issues/10353
