### PR TITLE
Perform initial filter subscribe asynchronously

### DIFF
--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -214,7 +214,7 @@ func TestWakuV2Filter(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Ensure there is 1 active filter subscription
 	require.Len(t, w.filterSubscriptions, 1)


### PR DESCRIPTION
Also adds `Unsubscribe` invocation for cases when filter peer is not alive. And fixes an exception occurring in in cases when re-subscription fails for some reason.

Related to #3606 and https://github.com/status-im/status-desktop/pull/11042