### PR TITLE
fix: save revealed accounts regardless of permissions granted

### DIFF
--- a/account/accounts.go
+++ b/account/accounts.go
@@ -62,7 +62,14 @@ type RecoverParams struct {
 	Signature string `json:"signature"`
 }
 
-// Manager represents account manager interface.
+// Interface represents account manager interface
+type Interface interface {
+	GetVerifiedWalletAccount(db *accounts.Database, address, password string) (*SelectedExtKey, error)
+	Sign(rpcParams SignParams, verifiedAccount *SelectedExtKey) (result types.HexBytes, err error)
+	Recover(rpcParams RecoverParams) (addr types.Address, err error)
+}
+
+// Manager represents account manager implementation
 type Manager struct {
 	mu         sync.RWMutex
 	rpcClient  *rpc.Client

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -111,7 +111,7 @@ type Messenger struct {
 	pushNotificationClient *pushnotificationclient.Client
 	pushNotificationServer *pushnotificationserver.Server
 	communitiesManager     *communities.Manager
-	accountsManager        *account.GethManager
+	accountsManager        account.Interface
 	mentionsManager        *MentionManager
 	logger                 *zap.Logger
 
@@ -254,7 +254,7 @@ func NewMessenger(
 	node types.Node,
 	installationID string,
 	peerStore *mailservers.PeerStore,
-	accountsManager *account.GethManager,
+	accountsManager account.Interface,
 	opts ...Option,
 ) (*Messenger, error) {
 	var messenger *Messenger
@@ -424,7 +424,10 @@ func NewMessenger(
 	managerOptions := []communities.ManagerOption{
 		communities.WithAccountManager(accountsManager),
 	}
-	if c.rpcClient != nil {
+
+	if c.tokenManager != nil {
+		managerOptions = append(managerOptions, communities.WithTokenManager(c.tokenManager))
+	} else if c.rpcClient != nil {
 		tokenManager := token.NewTokenManager(database, c.rpcClient, c.rpcClient.NetworkManager)
 		managerOptions = append(managerOptions, communities.WithTokenManager(communities.NewDefaultTokenManager(tokenManager)))
 	}

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -90,6 +90,7 @@ type config struct {
 	walletService       *wallet.Service
 	httpServer          *server.MediaServer
 	rpcClient           *rpc.Client
+	tokenManager        communities.TokenManager
 
 	verifyTransactionClient  EthClient
 	verifyENSURL             string
@@ -331,6 +332,13 @@ func WithMessageCSV(enabled bool) Option {
 func WithWalletService(s *wallet.Service) Option {
 	return func(c *config) error {
 		c.walletService = s
+		return nil
+	}
+}
+
+func WithTokenManager(tokenManager communities.TokenManager) Option {
+	return func(c *config) error {
+		c.tokenManager = tokenManager
 		return nil
 	}
 }


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/pull/10967

Important changes:
- [x] save revealed accounts regardless of permissions granted

This PR does not contain checks for provided addresses, this should be fixed in https://github.com/status-im/status-go/pull/3580 after release
