### PR TITLE
feat: introduce `CheckAllCommunityChannelsPermissions()` API

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3875,6 +3875,25 @@ func (m *Messenger) CheckCommunityChannelPermissions(request *requests.CheckComm
 	return m.communitiesManager.CheckChannelPermissions(request.CommunityID, request.ChatID, addresses)
 }
 
+func (m *Messenger) CheckAllCommunityChannelsPermissions(request *requests.CheckAllCommunityChannelsPermissions) (*communities.CheckAllChannelsPermissionsResponse, error) {
+	if err := request.Validate(); err != nil {
+		return nil, err
+	}
+
+	accounts, err := m.settings.GetAccounts()
+	if err != nil {
+		return nil, err
+	}
+
+	var addresses []gethcommon.Address
+
+	for _, a := range accounts {
+		addresses = append(addresses, gethcommon.HexToAddress(a.Address.Hex()))
+	}
+
+	return m.communitiesManager.CheckAllChannelsPermissions(request.CommunityID, addresses)
+}
+
 func chunkSlice[T comparable](slice []T, chunkSize int) [][]T {
 	var chunks [][]T
 	for i := 0; i < len(slice); i += chunkSize {

--- a/protocol/requests/check_all_community_channels_permissions.go
+++ b/protocol/requests/check_all_community_channels_permissions.go
@@ -1,0 +1,23 @@
+package requests
+
+import (
+	"errors"
+
+	"github.com/status-im/status-go/eth-node/types"
+)
+
+var (
+	ErrCheckAllCommunityChannelsPermissionsInvalidID = errors.New("check-community-channel-permissions: invalid id")
+)
+
+type CheckAllCommunityChannelsPermissions struct {
+	CommunityID types.HexBytes
+}
+
+func (u *CheckAllCommunityChannelsPermissions) Validate() error {
+	if len(u.CommunityID) == 0 {
+		return ErrCheckAllCommunityChannelsPermissionsInvalidID
+	}
+
+	return nil
+}

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1333,6 +1333,10 @@ func (api *PublicAPI) CheckCommunityChannelPermissions(request *requests.CheckCo
 	return api.service.messenger.CheckCommunityChannelPermissions(request)
 }
 
+func (api *PublicAPI) CheckAllCommunityChannelsPermissions(request *requests.CheckAllCommunityChannelsPermissions) (*communities.CheckAllChannelsPermissionsResponse, error) {
+	return api.service.messenger.CheckAllCommunityChannelsPermissions(request)
+}
+
 func (api *PublicAPI) Messenger() *protocol.Messenger {
 	return api.service.messenger
 }


### PR DESCRIPTION
This API is used to get a permission status of all channels of a given community.

Clients can use this API to get the provided information for all community channels with a single RPC call instead of doing one call for each channel separately.

