### PR TITLE
fix(wallet): Fixed nil pointer dereferencing for multiTransaction.ToAmount

### DIFF
--- a/services/wallet/transfer/transaction.go
+++ b/services/wallet/transfer/transaction.go
@@ -308,6 +308,7 @@ func (tm *TransactionManager) CreateMultiTransactionFromCommand(ctx context.Cont
 		FromAsset:   command.FromAsset,
 		ToAsset:     command.ToAsset,
 		FromAmount:  command.FromAmount,
+		ToAmount:    new(hexutil.Big),
 		Type:        command.Type,
 	}
 


### PR DESCRIPTION
Closes [#11010](https://github.com/status-im/status-desktop/issues/11010)
