### PR TITLE
feat(wallet): Improved performance of fetching transfers for Sequential fetch strategy

### DIFF
--- a/services/wallet/transfer/sequential_fetch_strategy.go
+++ b/services/wallet/transfer/sequential_fetch_strategy.go
@@ -44,9 +44,9 @@ type SequentialFetchStrategy struct {
 }
 
 func (s *SequentialFetchStrategy) newCommand(chainClient *chain.ClientWithFallback,
-	accounts []common.Address) async.Commander {
+	account common.Address) async.Commander {
 
-	return newLoadBlocksAndTransfersCommand(accounts, s.db, s.blockDAO, chainClient, s.feed,
+	return newLoadBlocksAndTransfersCommand(account, s.db, s.blockDAO, chainClient, s.feed,
 		s.transactionManager, s.tokenManager)
 }
 
@@ -67,8 +67,10 @@ func (s *SequentialFetchStrategy) start() error {
 	}
 
 	for _, chainClient := range s.chainClients {
-		ctl := s.newCommand(chainClient, s.accounts)
-		s.group.Add(ctl.Command())
+		for _, address := range s.accounts {
+			ctl := s.newCommand(chainClient, address)
+			s.group.Add(ctl.Command())
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Before:
 - block fetching commands for different accounts were in the same wait group, making them dependent on each iteration.
 - transfers loading command was checking database for new unloaded blocks on timeout and was in the same wait group with block fetching, so it was often blocked until all block fetching commands finish for iteration.
 
Now:
 - block fetching commands run independently for each account
 - transfers fetching command is run once on startup for unloaded blocks from DB
 - fetch history blocks commands are launched once on startup for accounts with no full history loaded
 - transfers are loaded on each iteration of block range check without waiting for all ranges to be checked

`loadAllTransfersCommand` removed as being redundant now - replaced with updated `loadTransfersCommand`
Logs improvement

Updates [#10246](https://github.com/status-im/status-desktop/issues/10246)