### PR TITLE
Feat/11080 expose transaction entry amounts

### DIFF
--- a/services/wallet/activity/activity_test.go
+++ b/services/wallet/activity/activity_test.go
@@ -3,6 +3,7 @@ package activity
 import (
 	"context"
 	"database/sql"
+	"math/big"
 	"testing"
 
 	"github.com/status-im/status-go/appdatabase"
@@ -14,6 +15,7 @@ import (
 
 	eth "github.com/ethereum/go-ethereum/common"
 	eth_common "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/stretchr/testify/require"
 )
@@ -133,6 +135,8 @@ func TestGetActivityEntriesAll(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.tr1.Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries))
 	require.True(t, testutils.StructExistsInSlice(Entry{
 		payloadType:    PendingTransactionPT,
@@ -142,6 +146,8 @@ func TestGetActivityEntriesAll(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: PendingAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.pendingTr.Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries))
 	require.True(t, testutils.StructExistsInSlice(Entry{
 		payloadType:    MultiTransactionPT,
@@ -151,6 +157,8 @@ func TestGetActivityEntriesAll(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.multiTx1.FromAmount)),
+		amountIn:       (*hexutil.Big)(big.NewInt(td.multiTx1.ToAmount)),
 	}, entries))
 	require.True(t, testutils.StructExistsInSlice(Entry{
 		payloadType:    MultiTransactionPT,
@@ -160,6 +168,8 @@ func TestGetActivityEntriesAll(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: PendingAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.multiTx2.FromAmount)),
+		amountIn:       (*hexutil.Big)(big.NewInt(td.multiTx2.ToAmount)),
 	}, entries))
 
 	// Ensure the sub-transactions of the multi-transactions are not returned
@@ -171,6 +181,8 @@ func TestGetActivityEntriesAll(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.multiTx1Tr1.Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries))
 	require.False(t, testutils.StructExistsInSlice(Entry{
 		payloadType:    SimpleTransactionPT,
@@ -180,6 +192,8 @@ func TestGetActivityEntriesAll(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.multiTx1Tr2.Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries))
 	require.False(t, testutils.StructExistsInSlice(Entry{
 		payloadType:    SimpleTransactionPT,
@@ -189,6 +203,8 @@ func TestGetActivityEntriesAll(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.multiTx2Tr1.Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries))
 	require.False(t, testutils.StructExistsInSlice(Entry{
 		payloadType:    SimpleTransactionPT,
@@ -198,6 +214,8 @@ func TestGetActivityEntriesAll(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.multiTx2Tr2.Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries))
 	require.False(t, testutils.StructExistsInSlice(Entry{
 		payloadType:    PendingTransactionPT,
@@ -207,6 +225,8 @@ func TestGetActivityEntriesAll(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: PendingAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.multiTx2PendingTr.Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries))
 }
 
@@ -286,6 +306,8 @@ func TestGetActivityEntriesFilterByTime(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(trs[5].Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries[0])
 	require.Equal(t, Entry{
 		payloadType:    MultiTransactionPT,
@@ -295,6 +317,8 @@ func TestGetActivityEntriesFilterByTime(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.multiTx1.FromAmount)),
+		amountIn:       (*hexutil.Big)(big.NewInt(td.multiTx1.ToAmount)),
 	}, entries[7])
 
 	// Test complete interval
@@ -311,6 +335,8 @@ func TestGetActivityEntriesFilterByTime(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(trs[2].Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries[0])
 	require.Equal(t, Entry{
 		payloadType:    MultiTransactionPT,
@@ -320,6 +346,8 @@ func TestGetActivityEntriesFilterByTime(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.multiTx1.FromAmount)),
+		amountIn:       (*hexutil.Big)(big.NewInt(td.multiTx1.ToAmount)),
 	}, entries[4])
 
 	// Test end only
@@ -336,6 +364,8 @@ func TestGetActivityEntriesFilterByTime(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(trs[2].Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries[0])
 	require.Equal(t, Entry{
 		payloadType:    SimpleTransactionPT,
@@ -345,6 +375,8 @@ func TestGetActivityEntriesFilterByTime(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.tr1.Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries[6])
 }
 
@@ -381,6 +413,8 @@ func TestGetActivityEntriesCheckOffsetAndLimit(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(trs[8].Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries[0])
 	require.Equal(t, Entry{
 		payloadType:    SimpleTransactionPT,
@@ -390,6 +424,8 @@ func TestGetActivityEntriesCheckOffsetAndLimit(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(trs[6].Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries[2])
 
 	// Move window 2 entries forward
@@ -405,6 +441,8 @@ func TestGetActivityEntriesCheckOffsetAndLimit(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(trs[6].Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries[0])
 	require.Equal(t, Entry{
 		payloadType:    SimpleTransactionPT,
@@ -414,6 +452,8 @@ func TestGetActivityEntriesCheckOffsetAndLimit(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(trs[4].Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries[2])
 
 	// Move window 4 more entries to test filter cap
@@ -429,6 +469,8 @@ func TestGetActivityEntriesCheckOffsetAndLimit(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(trs[2].Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries[0])
 }
 
@@ -541,6 +583,8 @@ func TestGetActivityEntriesFilterByAddresses(t *testing.T) {
 		activityType:   ReceiveAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(0)),
+		amountIn:       (*hexutil.Big)(big.NewInt(trs[4].Value)),
 	}, entries[0])
 	require.Equal(t, Entry{
 		payloadType:    SimpleTransactionPT,
@@ -550,6 +594,8 @@ func TestGetActivityEntriesFilterByAddresses(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: CompleteAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(trs[1].Value)),
+		amountIn:       (*hexutil.Big)(big.NewInt(0)),
 	}, entries[1])
 	require.Equal(t, Entry{
 		payloadType:    MultiTransactionPT,
@@ -559,6 +605,8 @@ func TestGetActivityEntriesFilterByAddresses(t *testing.T) {
 		activityType:   SendAT,
 		activityStatus: PendingAS,
 		tokenType:      AssetTT,
+		amountOut:      (*hexutil.Big)(big.NewInt(td.multiTx2.FromAmount)),
+		amountIn:       (*hexutil.Big)(big.NewInt(td.multiTx2.ToAmount)),
 	}, entries[2])
 }
 

--- a/services/wallet/activity/filter_test.go
+++ b/services/wallet/activity/filter_test.go
@@ -36,7 +36,7 @@ func TestGetRecipients(t *testing.T) {
 	defer close()
 
 	// Add 6 extractable transactions
-	trs, _, toTrs := transfer.GenerateTestTransactions(t, db, 0, 6)
+	trs, _, toTrs := transfer.GenerateTestTransfers(t, db, 0, 6)
 	for i := range trs {
 		transfer.InsertTestTransfer(t, db, &trs[i])
 	}

--- a/services/wallet/transfer/database_test.go
+++ b/services/wallet/transfer/database_test.go
@@ -182,7 +182,7 @@ func TestGetTransfersForIdentities(t *testing.T) {
 	db, _, stop := setupTestDB(t)
 	defer stop()
 
-	trs, _, _ := GenerateTestTransactions(t, db.client, 1, 4)
+	trs, _, _ := GenerateTestTransfers(t, db.client, 1, 4)
 	for i := range trs {
 		InsertTestTransfer(t, db.client, &trs[i])
 	}

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -9,6 +9,7 @@ import (
 	eth_common "github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/testutils"
+	"github.com/status-im/status-go/sqlite"
 
 	"github.com/stretchr/testify/require"
 )
@@ -118,16 +119,18 @@ func InsertTestTransfer(t *testing.T, db *sql.DB, tr *TestTransfer) {
 		tokenType = "erc20"
 	}
 	blkHash := eth_common.HexToHash("4")
+	value := sqlite.Int64ToPadded128BitsStr(tr.Value)
+
 	_, err := db.Exec(`
 		INSERT OR IGNORE INTO blocks(
 			network_id, address, blk_number, blk_hash
 		) VALUES (?, ?, ?, ?);
 		INSERT INTO transfers (network_id, hash, address, blk_hash, tx,
 			sender, receipt, log, type, blk_number, timestamp, loaded,
-			multi_transaction_id, base_gas_fee, status
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?)`,
+			multi_transaction_id, base_gas_fee, status, amount_padded128hex
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?)`,
 		tr.ChainID, tr.To, tr.BlkNumber, blkHash,
-		tr.ChainID, tr.Hash, tr.To, blkHash, &JSONBlob{}, tr.From, &JSONBlob{}, &JSONBlob{}, tokenType, tr.BlkNumber, tr.Timestamp, tr.MultiTransactionID, tr.Success)
+		tr.ChainID, tr.Hash, tr.To, blkHash, &JSONBlob{}, tr.From, &JSONBlob{}, &JSONBlob{}, tokenType, tr.BlkNumber, tr.Timestamp, tr.MultiTransactionID, tr.Success, value)
 	require.NoError(t, err)
 }
 

--- a/sqlite/fields.go
+++ b/sqlite/fields.go
@@ -87,3 +87,8 @@ func BigIntToPadded128BitsStr(val *big.Int) *string {
 	*res = fmt.Sprintf("%032s", hexStr)
 	return res
 }
+
+func Int64ToPadded128BitsStr(val int64) *string {
+	res := fmt.Sprintf("%032x", val)
+	return &res
+}

--- a/sqlite/fields_test.go
+++ b/sqlite/fields_test.go
@@ -57,3 +57,35 @@ func TestBigIntToPadded128BitsStr(t *testing.T) {
 		})
 	}
 }
+
+func TestInt64ToPadded128BitsStr(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    int64
+		expected *string
+	}{
+		{
+			name:     "case nonzero",
+			input:    123456,
+			expected: strToPtr("0000000000000000000000000001e240"),
+		},
+		{
+			name:     "case zero",
+			input:    0,
+			expected: strToPtr("00000000000000000000000000000000"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := Int64ToPadded128BitsStr(tc.input)
+			if result != nil && tc.expected != nil {
+				if *result != *tc.expected {
+					t.Errorf("expected %s, got %s", *tc.expected, *result)
+				}
+			} else if result != nil || tc.expected != nil {
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Transaction amounts are added to the activity Entry struct, for it to be consumed on the client side.

Common `inAmount` and `outAmount` fields are used, which get filled/not filled according to activity type.

Test were reworked in preparation for future additional changes.