### PR TITLE
fix(wallet): respect limits for collectibles fetching

### DIFF
--- a/services/wallet/thirdparty/opensea/client.go
+++ b/services/wallet/thirdparty/opensea/client.go
@@ -392,7 +392,7 @@ func (o *Client) fetchAssets(queryParams url.Values, limit int) (*AssetContainer
 
 	tmpLimit := AssetLimit
 	if limit > 0 && limit < tmpLimit {
-		tmpLimit = AssetLimit
+		tmpLimit = limit
 	}
 
 	queryParams["limit"] = []string{strconv.Itoa(tmpLimit)}


### PR DESCRIPTION
Due to a bug, collectibles were always fetched in chunks of 200. This caused some crashes during deserialization status-desktop side.

This PR fixes the bug. Now, the limit of 100 collectibles per call should be respected.
