### PR TITLE
feat(wallet) add filter api to retrieve recipients of a wallet

### DIFF
--- a/services/wallet/activity/filter_test.go
+++ b/services/wallet/activity/filter_test.go
@@ -1,0 +1,63 @@
+package activity
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/services/wallet/transfer"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestFilterDB(t *testing.T) (db *sql.DB, close func()) {
+	db, err := appdatabase.SetupTestMemorySQLDB("wallet-activity-tests-filter")
+	require.NoError(t, err)
+
+	return db, func() {
+		require.NoError(t, db.Close())
+	}
+}
+
+func TestGetRecipientsEmptyDB(t *testing.T) {
+	db, close := setupTestFilterDB(t)
+	defer close()
+
+	entries, hasMore, err := GetRecipients(context.Background(), db, 0, 15)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(entries))
+	require.False(t, hasMore)
+}
+
+func TestGetRecipients(t *testing.T) {
+	db, close := setupTestFilterDB(t)
+	defer close()
+
+	// Add 6 extractable transactions
+	trs, _, toTrs := transfer.GenerateTestTransactions(t, db, 0, 6)
+	for i := range trs {
+		transfer.InsertTestTransfer(t, db, &trs[i])
+	}
+
+	entries, hasMore, err := GetRecipients(context.Background(), db, 0, 15)
+	require.NoError(t, err)
+	require.False(t, hasMore)
+	require.Equal(t, 6, len(entries))
+	for i := range entries {
+		found := false
+		for j := range toTrs {
+			if entries[i] == toTrs[j] {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, fmt.Sprintf("recipient %s not found in toTrs", entries[i].Hex()))
+	}
+
+	entries, hasMore, err = GetRecipients(context.Background(), db, 0, 4)
+	require.NoError(t, err)
+	require.Equal(t, 4, len(entries))
+	require.True(t, hasMore)
+}

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -532,3 +532,14 @@ func (api *API) FilterActivityAsync(ctx context.Context, addresses []common.Addr
 	log.Debug("[WalletAPI:: FilterActivityAsync] addr.count", len(addresses), "chainIDs.count", len(chainIDs), "filter", filter, "offset", offset, "limit", limit)
 	return api.s.activity.FilterActivityAsync(ctx, addresses, chainIDs, filter, offset, limit)
 }
+
+type GetAllRecipientsResponse struct {
+	Addresses []common.Address `json:"addresses"`
+	HasMore   bool             `json:"hasMore"`
+}
+
+func (api *API) GetAllRecipients(ctx context.Context, offset int, limit int) (result *GetAllRecipientsResponse, err error) {
+	result = &GetAllRecipientsResponse{}
+	result.Addresses, result.HasMore, err = activity.GetRecipients(ctx, api.s.db, offset, limit)
+	return result, err
+}


### PR DESCRIPTION
### Updates status-desktop [#10025](https://github.com/status-im/status-desktop/issues/10025)

The new API returns all known wallet recipients by sourcing transfers, pending_transactions and multi_transactions tables. The API is synchronous. Future work will be to make it async. In some corner cases, when watching a famous wallet, there can be too many recipients to be returned in one go. Offset and limit can be used to paginate through the results.