### PR TITLE
fix: don't store ourselves as a contact

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3436,10 +3436,13 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 				}
 
 				senderID := contactIDFromPublicKey(publicKey)
+				m.logger.Info("processing message", zap.Any("type", msg.Type), zap.String("senderID", senderID))
+
+				contact, contactFound := messageState.AllContacts.Load(senderID)
 
 				if _, ok := m.requestedContacts[senderID]; !ok {
 					// Check for messages from blocked users
-					if contact, ok := messageState.AllContacts.Load(senderID); ok && contact.Blocked {
+					if contactFound && contact.Blocked {
 						continue
 					}
 				}
@@ -3455,10 +3458,7 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 					continue
 				}
 
-				var contact *Contact
-				if c, ok := messageState.AllContacts.Load(senderID); ok {
-					contact = c
-				} else {
+				if !contactFound {
 					c, err := buildContact(senderID, publicKey)
 					if err != nil {
 						logger.Info("failed to build contact", zap.Error(err))

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -62,12 +62,7 @@ func (s *MessengerContactRequestSuite) newMessenger(shh types.Waku) *Messenger {
 }
 
 func (s *MessengerContactRequestSuite) findFirstByContentType(messages []*common.Message, contentType protobuf.ChatMessage_ContentType) *common.Message {
-	for _, message := range messages {
-		if message.ContentType == contentType {
-			return message
-		}
-	}
-	return nil
+	return FindFirstByContentType(messages, contentType)
 }
 
 func (s *MessengerContactRequestSuite) sendContactRequest(request *requests.SendContactRequest, messenger *Messenger) {

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -267,6 +267,8 @@ func (m *Messenger) SendContactRequest(ctx context.Context, request *requests.Se
 }
 
 func (m *Messenger) updateAcceptedContactRequest(response *MessengerResponse, contactRequestID string) (*MessengerResponse, error) {
+
+	fmt.Println("<<< updateAcceptedContactRequest. contactRequestID: ", contactRequestID)
 	contactRequest, err := m.persistence.MessageByID(contactRequestID)
 	if err != nil {
 		return nil, err
@@ -274,14 +276,22 @@ func (m *Messenger) updateAcceptedContactRequest(response *MessengerResponse, co
 
 	contactRequest.ContactRequestState = common.ContactRequestStateAccepted
 
+	fmt.Println("<<< updateAcceptedContactRequest. contactRequest 1: ", contactRequest)
+	fmt.Println("<<< updateAcceptedContactRequest from ", contactRequest.From)
+
 	err = m.persistence.SetContactRequestState(contactRequest.ID, contactRequest.ContactRequestState)
 	if err != nil {
 		return nil, err
 	}
 
-	contact, _ := m.allContacts.Load(contactRequest.From)
+	fmt.Println("<<< updateAcceptedContactRequest. contactRequest 2: ", contactRequest)
+	fmt.Println("<<< updateAcceptedContactRequest from ", contactRequest.From)
+
+	contact, ok := m.allContacts.Load(contactRequest.From)
+	fmt.Println("<<< updateAcceptedContactRequest load contact: ", ok)
 
 	_, clock, err := m.getOneToOneAndNextClock(contact)
+	fmt.Println("<<< updateAcceptedContactRequest getOneToOneAndNextClock ", clock)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -286,8 +286,7 @@ func (m *Messenger) updateAcceptedContactRequest(response *MessengerResponse, co
 	contact, ok := m.allContacts.Load(contactRequest.From)
 	if !ok {
 		m.logger.Error("failed to update contact request: contact not found", zap.String("contact id", contactRequest.From))
-		// TODO: Uncomment return error when #3667 crash is fixed
-		//	return nil, errors.New("failed to update contact request: contact not found")
+		return nil, errors.New("failed to update contact request: contact not found")
 	}
 
 	_, clock, err := m.getOneToOneAndNextClock(contact)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -455,19 +455,19 @@ func (m *Messenger) handleCommandMessage(state *ReceivedMessageState, message *c
 
 func (m *Messenger) syncContactRequestForInstallationContact(contact *Contact, state *ReceivedMessageState, chat *Chat, outgoing bool) error {
 
-	fmt.Println("<<< syncContactRequestForInstallationContact")
+	m.logger.Debug("syncContactRequestForInstallationContact")
 
 	if chat == nil {
 		return fmt.Errorf("no chat restored during the contact synchronisation, contact.ID = %s", contact.ID)
 	}
 
 	contactRequestID, err := m.persistence.LatestPendingContactRequestIDForContact(contact.ID)
-	fmt.Println("<<< syncContactRequestForInstallationContact 1", contactRequestID, err)
 	if err != nil {
 		return err
 	}
 
 	if contactRequestID != "" {
+		m.logger.Warn("syncContactRequestForInstallationContact: skipping as contact request found", zap.String("contactRequestID", contactRequestID))
 		return nil
 	}
 
@@ -478,7 +478,7 @@ func (m *Messenger) syncContactRequestForInstallationContact(contact *Contact, s
 	}
 
 	contactRequest.ID = defaultContactRequestID(contact.ID)
-	fmt.Println("<<< syncContactRequestForInstallationContact 2", contactRequest)
+	m.logger.Warn("syncContactRequestForInstallationContact: generated contact request", zap.Any("contactRequest", contactRequest))
 
 	state.Response.AddMessage(contactRequest)
 	err = m.persistence.SaveMessages([]*common.Message{contactRequest})
@@ -505,9 +505,8 @@ func (m *Messenger) syncContactRequestForInstallationContact(contact *Contact, s
 func (m *Messenger) HandleSyncInstallationContact(state *ReceivedMessageState, message protobuf.SyncInstallationContactV2) error {
 	// Ignore own contact installation
 
-	fmt.Println("<<< HandleSyncInstallationContact ", message, m.myHexIdentity())
-
 	if message.Id == m.myHexIdentity() {
+		m.logger.Warn("HandleSyncInstallationContact: skipping own contact")
 		return nil
 	}
 
@@ -533,7 +532,6 @@ func (m *Messenger) HandleSyncInstallationContact(state *ReceivedMessageState, m
 
 		var err error
 		contact, err = buildContactFromPkString(message.Id)
-		fmt.Println("<<< HandleSyncInstallationContact building contact", contact)
 		if err != nil {
 			return err
 		}
@@ -542,7 +540,6 @@ func (m *Messenger) HandleSyncInstallationContact(state *ReceivedMessageState, m
 	if message.ContactRequestRemoteClock != 0 || message.ContactRequestLocalClock != 0 {
 		// Some local action about contact requests were performed,
 		// process them
-		fmt.Println("<<< HandleSyncInstallationContact 1", message.ContactRequestRemoteClock, message.ContactRequestLocalClock)
 		contact.ProcessSyncContactRequestState(
 			ContactRequestState(message.ContactRequestRemoteState),
 			uint64(message.ContactRequestRemoteClock),
@@ -558,8 +555,6 @@ func (m *Messenger) HandleSyncInstallationContact(state *ReceivedMessageState, m
 	} else if message.Added || message.HasAddedUs {
 		// NOTE(cammellos): this is for handling backward compatibility, old clients
 		// won't propagate ContactRequestRemoteClock or ContactRequestLocalClock
-
-		fmt.Println("<<< HandleSyncInstallationContact 2", message.Added, message.HasAddedUs)
 
 		if message.Added && contact.LastUpdatedLocally < message.LastUpdatedLocally {
 			contact.ContactRequestSent(message.LastUpdatedLocally)
@@ -673,7 +668,6 @@ func (m *Messenger) HandleSyncInstallationContact(state *ReceivedMessageState, m
 			state.Response.AddChat(chat)
 		}
 
-		fmt.Println("<<< HandleSyncInstallationContact storing contact", contact)
 		state.ModifiedContacts.Store(contact.ID, true)
 		state.AllContacts.Store(contact.ID, contact)
 	}
@@ -3230,8 +3224,6 @@ func (m *Messenger) HandleSyncKeypairFull(state *ReceivedMessageState, message p
 func (m *Messenger) HandleSyncContactRequestDecision(state *ReceivedMessageState, message protobuf.SyncContactRequestDecision) error {
 	var err error
 	var response *MessengerResponse
-
-	fmt.Println("<<< HandleSyncContactRequestDecision. message: ", message)
 
 	if message.DecisionStatus == protobuf.SyncContactRequestDecision_ACCEPTED {
 		response, err = m.updateAcceptedContactRequest(nil, message.RequestId)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -3218,6 +3218,8 @@ func (m *Messenger) HandleSyncContactRequestDecision(state *ReceivedMessageState
 	var err error
 	var response *MessengerResponse
 
+	fmt.Println("<<< HandleSyncContactRequestDecision. message: ", message)
+
 	if message.DecisionStatus == protobuf.SyncContactRequestDecision_ACCEPTED {
 		response, err = m.updateAcceptedContactRequest(nil, message.RequestId)
 	} else {

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -455,8 +455,6 @@ func (m *Messenger) handleCommandMessage(state *ReceivedMessageState, message *c
 
 func (m *Messenger) syncContactRequestForInstallationContact(contact *Contact, state *ReceivedMessageState, chat *Chat, outgoing bool) error {
 
-	m.logger.Debug("syncContactRequestForInstallationContact")
-
 	if chat == nil {
 		return fmt.Errorf("no chat restored during the contact synchronisation, contact.ID = %s", contact.ID)
 	}
@@ -478,7 +476,6 @@ func (m *Messenger) syncContactRequestForInstallationContact(contact *Contact, s
 	}
 
 	contactRequest.ID = defaultContactRequestID(contact.ID)
-	m.logger.Warn("syncContactRequestForInstallationContact: generated contact request", zap.Any("contactRequest", contactRequest))
 
 	state.Response.AddMessage(contactRequest)
 	err = m.persistence.SaveMessages([]*common.Message{contactRequest})

--- a/protocol/messenger_maps.go
+++ b/protocol/messenger_maps.go
@@ -1,8 +1,9 @@
 package protocol
 
 import (
-	"go.uber.org/zap"
 	"sync"
+
+	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/protobuf"

--- a/protocol/messenger_sync_raw_messages.go
+++ b/protocol/messenger_sync_raw_messages.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"context"
 	"errors"
+
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
 

--- a/protocol/messenger_sync_raw_messages.go
+++ b/protocol/messenger_sync_raw_messages.go
@@ -113,7 +113,6 @@ func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) er
 			if err != nil {
 				return err
 			}
-			fmt.Println("<<< HandleSyncInstallationContact ", message)
 			err = m.HandleSyncInstallationContact(state, message)
 			if err != nil {
 				m.logger.Error("failed to HandleSyncInstallationContact when HandleSyncRawMessages", zap.Error(err))

--- a/protocol/messenger_sync_raw_messages.go
+++ b/protocol/messenger_sync_raw_messages.go
@@ -107,7 +107,6 @@ func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) er
 		case protobuf.ApplicationMetadataMessage_SYNC_INSTALLATION_CONTACT:
 			var message protobuf.SyncInstallationContactV2
 			err := proto.Unmarshal(rawMessage.GetPayload(), &message)
-			m.logger.Debug("handling sync raw message SYNC_INSTALLATION_CONTACT", zap.Any("message", message))
 			if err != nil {
 				return err
 			}
@@ -185,7 +184,6 @@ func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) er
 		case protobuf.ApplicationMetadataMessage_SYNC_CONTACT_REQUEST_DECISION:
 			var message protobuf.SyncContactRequestDecision
 			err := proto.Unmarshal(rawMessage.GetPayload(), &message)
-			m.logger.Debug("handling sync raw message SYNC_CONTACT_REQUEST_DECISION", zap.Any("message", message))
 			if err != nil {
 				return err
 			}

--- a/protocol/messenger_sync_raw_messages.go
+++ b/protocol/messenger_sync_raw_messages.go
@@ -3,8 +3,6 @@ package protocol
 import (
 	"context"
 	"errors"
-	"fmt"
-
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
 
@@ -21,7 +19,6 @@ type RawMessageHandler func(ctx context.Context, rawMessage common.RawMessage) (
 func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) error {
 	state := m.buildMessageState()
 	for _, rawMessage := range rawMessages {
-		fmt.Println("<<< rawMessage Type -> ", rawMessage.GetMessageType())
 		switch rawMessage.GetMessageType() {
 		case protobuf.ApplicationMetadataMessage_CONTACT_UPDATE:
 			var message protobuf.ContactUpdate
@@ -110,6 +107,7 @@ func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) er
 		case protobuf.ApplicationMetadataMessage_SYNC_INSTALLATION_CONTACT:
 			var message protobuf.SyncInstallationContactV2
 			err := proto.Unmarshal(rawMessage.GetPayload(), &message)
+			m.logger.Debug("handling sync raw message SYNC_INSTALLATION_CONTACT", zap.Any("message", message))
 			if err != nil {
 				return err
 			}
@@ -187,6 +185,7 @@ func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) er
 		case protobuf.ApplicationMetadataMessage_SYNC_CONTACT_REQUEST_DECISION:
 			var message protobuf.SyncContactRequestDecision
 			err := proto.Unmarshal(rawMessage.GetPayload(), &message)
+			m.logger.Debug("handling sync raw message SYNC_CONTACT_REQUEST_DECISION", zap.Any("message", message))
 			if err != nil {
 				return err
 			}

--- a/protocol/messenger_sync_raw_messages.go
+++ b/protocol/messenger_sync_raw_messages.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
@@ -20,6 +21,7 @@ type RawMessageHandler func(ctx context.Context, rawMessage common.RawMessage) (
 func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) error {
 	state := m.buildMessageState()
 	for _, rawMessage := range rawMessages {
+		fmt.Println("<<< rawMessage Type -> ", rawMessage.GetMessageType())
 		switch rawMessage.GetMessageType() {
 		case protobuf.ApplicationMetadataMessage_CONTACT_UPDATE:
 			var message protobuf.ContactUpdate
@@ -111,6 +113,7 @@ func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) er
 			if err != nil {
 				return err
 			}
+			fmt.Println("<<< HandleSyncInstallationContact ", message)
 			err = m.HandleSyncInstallationContact(state, message)
 			if err != nil {
 				m.logger.Error("failed to HandleSyncInstallationContact when HandleSyncRawMessages", zap.Error(err))

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -2439,24 +2439,3 @@ type testTimeSource struct{}
 func (t *testTimeSource) GetCurrentTime() uint64 {
 	return uint64(time.Now().Unix())
 }
-
-// WaitOnMessengerResponse Wait until the condition is true or the timeout is reached.
-func WaitOnMessengerResponse(m *Messenger, condition func(*MessengerResponse) bool, errorMessage string) (*MessengerResponse, error) {
-	response := &MessengerResponse{}
-	err := tt.RetryWithBackOff(func() error {
-		var err error
-		r, err := m.RetrieveAll()
-		if err := response.Merge(r); err != nil {
-			panic(err)
-		}
-
-		if err == nil && !condition(response) {
-			err = errors.New(errorMessage)
-		}
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-	return response, nil
-}

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"errors"
+
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/tt"

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -1,0 +1,38 @@
+package protocol
+
+import (
+	"errors"
+	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/protobuf"
+	"github.com/status-im/status-go/protocol/tt"
+)
+
+// WaitOnMessengerResponse Wait until the condition is true or the timeout is reached.
+func WaitOnMessengerResponse(m *Messenger, condition func(*MessengerResponse) bool, errorMessage string) (*MessengerResponse, error) {
+	response := &MessengerResponse{}
+	err := tt.RetryWithBackOff(func() error {
+		var err error
+		r, err := m.RetrieveAll()
+		if err := response.Merge(r); err != nil {
+			panic(err)
+		}
+
+		if err == nil && !condition(response) {
+			err = errors.New(errorMessage)
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func FindFirstByContentType(messages []*common.Message, contentType protobuf.ChatMessage_ContentType) *common.Message {
+	for _, message := range messages {
+		if message.ContentType == contentType {
+			return message
+		}
+	}
+	return nil
+}

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -3,12 +3,14 @@ package pairing
 import (
 	"context"
 	"encoding/json"
-	"github.com/status-im/status-go/eth-node/crypto"
-	"github.com/status-im/status-go/protocol/tt"
-	"go.uber.org/zap"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/protocol/tt"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -546,19 +546,23 @@ func (s *SyncDeviceSuite) TestPairingThreeDevices() {
 	s.acceptContactRequest(contactRequest, alice1Messenger, bobMessenger)
 	s.checkMutualContact(alice1Backend, bobPublicKey)
 
+	// We shouldn't sync ourselves as a contact, so we check there's only Bob
+	// https://github.com/status-im/status-go/issues/3667
+	s.Require().Equal(1, len(alice1Backend.Messenger().Contacts()))
+
 	// Pair alice-1 <-> alice-2
 	s.logger.Info("pairing Alice-1 and Alice-2")
 	s.pairAccounts(alice1Backend, alice1TmpDir, alice2Backend, alice2TmpDir)
 
 	s.checkMutualContact(alice2Backend, bobPublicKey)
-	// TODO: Check if Alice-2 has herself as contact?
-	// TODO: Check if Alice-2 has an accepted contact request from Bob?
+	s.Require().Equal(1, len(alice2Backend.Messenger().Contacts()))
 
 	// Pair Alice-2 <-> ALice-3
 	s.logger.Info("pairing Alice-2 and Alice-3")
 	s.pairAccounts(alice2Backend, alice2TmpDir, alice3Backend, alice3TmpDir)
 
 	s.checkMutualContact(alice3Backend, bobPublicKey)
+	s.Require().Equal(1, len(alice3Backend.Messenger().Contacts()))
 }
 
 func defaultSettings(generatedAccountInfo generator.GeneratedAccountInfo, derivedAddresses map[string]generator.AccountInfo, mnemonic *string) (*settings.Settings, error) {


### PR DESCRIPTION
Fixes  #3667

1. Added a short-circuit for our public key in `contactsMap`
I've listed all places where it was happening in a separate issue: https://github.com/status-im/status-go/issues/3719
2. Added a test for pairing three devices of an account with mutual contact
3. Reused one `messageState.AllConacts.Load(senderID)` in `messenger.go`
4. Moved some common testing functions to `messenger_testing_utils.go`
5. Added a check if contact exists in `updateAcceptedContactRequest`

The bug mentioned is fixed by this:
https://github.com/status-im/status-go/blob/4618e1d3f160086cade6e55ae178bd02710b1e84/protocol/messenger_maps.go#L62-L72

Now the `Contact` object for ourselves is generated on the fly, so it's never "not found".