### PR TITLE
chore: install deps script error made more user friendly for a system without package manager

### DIFF
--- a/_assets/scripts/install_deps.sh
+++ b/_assets/scripts/install_deps.sh
@@ -10,5 +10,12 @@ elif [[ -x $(command -v nix-env) ]]; then
   nix-env -iA nixos.protobuf3_17
 else
   echo "ERROR: No known package manager found!" >&2
+  case "$OSTYPE" in
+  darwin*)  echo "OSX detected: Install either brew or nix package manager and rerun the script" ;; 
+  linux*)   echo "LINUX detected: install either pacman or nix and rerun the script" ;;
+  bsd*)     echo "BSD detected: Install either pacman or nix package manager and rerun the script" ;;
+  *)        echo "unknown: $OSTYPE" ;;
+esac
+
   exit 1
 fi


### PR DESCRIPTION
I was trying to build status-go on my new macbook and realized that error message for package manager not being installed is little ambiguous. I had to dig through code to find out which package managers are required to proceed. Hence, enhanced error message based on OS to make it more user-friendle. 

Changes made to the install_deps script. 

Important changes:
- [x] OS specific error message for missing package manager scenario.

Updated message for macOS would be as below:

```
_assets/scripts/install_deps.sh
ERROR: No known package manager found!
OSX detected: Install either brew or nix package manager and rerun the script
make: *** [install-os-deps] Error 1

```
