### PR TITLE
fix: don't return with error in permissions check when no chain IDs are found

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1977,7 +1977,7 @@ func (m *Manager) checkPermissionToJoin(permissions []*protobuf.CommunityTokenPe
 	// if there are no chain IDs that match token criteria chain IDs
 	// we aren't able to check balances on selected networks
 	if len(erc20ChainIDsMap) > 0 && len(chainIDsForERC20) == 0 {
-		return nil, errors.New("no chain IDs found to check token funds on")
+		return response, nil
 	}
 
 	ownedERC20TokenBalances := make(map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big, 0)


### PR DESCRIPTION

Turns out that, when we return with an error, instead of a non-statisfied check permissions response, we can run into cases where members that should be kicked are not kicked.

