### PR TITLE
Make sure that messages are confirmed when sent

### DIFF
--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -261,6 +261,11 @@ func (s *MessageSender) sendCommunity(
 	rawMessage.ID = types.EncodeHex(messageID)
 	messageIDs := [][]byte{messageID}
 
+	if rawMessage.BeforeDispatch != nil {
+		if err := rawMessage.BeforeDispatch(rawMessage); err != nil {
+			return nil, err
+		}
+	}
 	// Notify before dispatching, otherwise the dispatch subscription might happen
 	// earlier than the scheduled
 	s.notifyOnScheduledMessage(nil, rawMessage)
@@ -350,6 +355,12 @@ func (s *MessageSender) sendPrivate(
 
 	messageID := v1protocol.MessageID(&rawMessage.Sender.PublicKey, wrappedMessage)
 	rawMessage.ID = types.EncodeHex(messageID)
+
+	if rawMessage.BeforeDispatch != nil {
+		if err := rawMessage.BeforeDispatch(rawMessage); err != nil {
+			return nil, err
+		}
+	}
 
 	// Notify before dispatching, otherwise the dispatch subscription might happen
 	// earlier than the scheduled
@@ -510,6 +521,12 @@ func (s *MessageSender) dispatchCommunityChatMessage(ctx context.Context, rawMes
 		PowTime:   whisperPoWTime,
 	}
 
+	if rawMessage.BeforeDispatch != nil {
+		if err := rawMessage.BeforeDispatch(rawMessage); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	// notify before dispatching
 	s.notifyOnScheduledMessage(nil, rawMessage)
 
@@ -563,6 +580,12 @@ func (s *MessageSender) SendPublic(
 
 	messageID := v1protocol.MessageID(&rawMessage.Sender.PublicKey, wrappedMessage)
 	rawMessage.ID = types.EncodeHex(messageID)
+
+	if rawMessage.BeforeDispatch != nil {
+		if err := rawMessage.BeforeDispatch(&rawMessage); err != nil {
+			return nil, err
+		}
+	}
 
 	// notify before dispatching
 	s.notifyOnScheduledMessage(nil, &rawMessage)

--- a/protocol/common/raw_message.go
+++ b/protocol/common/raw_message.go
@@ -34,4 +34,5 @@ type RawMessage struct {
 	CommunityID           []byte
 	CommunityKeyExMsgType CommKeyExMsgType
 	Ephemeral             bool
+	BeforeDispatch        func(*RawMessage) error
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -574,7 +574,14 @@ func (m *Messenger) processSentMessages(ids []string) error {
 
 	for _, id := range ids {
 		rawMessage, err := m.persistence.RawMessageByID(id)
-		if err != nil {
+		// If we have no raw message, we create a temporary one, so that
+		// the sent status is preserved
+		if err == sql.ErrNoRows || rawMessage == nil {
+			rawMessage = &common.RawMessage{
+				ID:          id,
+				MessageType: protobuf.ApplicationMetadataMessage_CHAT_MESSAGE,
+			}
+		} else if err != nil {
 			return errors.Wrapf(err, "Can't get raw message with id %v", id)
 		}
 

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -2354,6 +2354,12 @@ func (s *MessengerSuite) TestMessageSent() {
 	s.True(rawMessage.Sent)
 }
 
+func (s *MessengerSuite) TestProcessSentMessages() {
+	ids := []string{"a"}
+	err := s.m.processSentMessages(ids)
+	s.Require().NoError(err)
+}
+
 func (s *MessengerSuite) TestResendExpiredEmojis() {
 	//send message
 	chat := CreatePublicChat("test-chat", s.m.transport)

--- a/protocol/persistence_test.go
+++ b/protocol/persistence_test.go
@@ -766,6 +766,29 @@ func TestExpiredMessagesIDs(t *testing.T) {
 	require.Equal(t, 1, len(ids))
 }
 
+func TestDontOverwriteSentStatus(t *testing.T) {
+	db, err := openTestDB()
+	require.NoError(t, err)
+	p := newSQLitePersistence(db)
+
+	//save rawMessage
+	rawMessage := minimalRawMessage("chat-message-id", protobuf.ApplicationMetadataMessage_CHAT_MESSAGE)
+	rawMessage.Sent = true
+	err = p.SaveRawMessage(rawMessage)
+	require.NoError(t, err)
+
+	rawMessage.Sent = false
+	rawMessage.ResendAutomatically = true
+	err = p.SaveRawMessage(rawMessage)
+	require.NoError(t, err)
+
+	m, err := p.RawMessageByID(rawMessage.ID)
+	require.NoError(t, err)
+
+	require.True(t, m.Sent)
+	require.True(t, m.ResendAutomatically)
+}
+
 func TestPersistenceEmojiReactions(t *testing.T) {
 	db, err := openTestDB()
 	require.NoError(t, err)


### PR DESCRIPTION
In some instances, we receive a confirmation before the RawMessage and Message are saved in the database. This commit addresses that issue.

This commit has two changes:

1) Makes handling raw messages asynchronous, so that the if the confirmation arrives first, is preserved in the database and not overwritten when adding the raw message.
2) It adds a `BeforeDispatch` function on raw messages to save the message before it's actually dispatched, in order to avoid a race condition where you would get the confirmation before the message has been dispatched, and it would fail to update the message. This is not the cleanest solution, it would be better to have a separate table for message outgoing status and join at runtime, but that's a much larger change and it's an expensive migration for clients, so I would defer doing that unless necessary.


