### PR TITLE
Add migration check scripts

### DIFF
--- a/.github/github-bot.yml
+++ b/.github/github-bot.yml
@@ -3,13 +3,6 @@ _extends: probot-settings
 github-team:
   slug: 'go'
 
-prchecklist:
-  title: Pull Request Checklist
-  checklist:
-    - 'Have you updated the documentation, if impacted (e.g. [docs.status.im](https://status.im/docs/))?'
-    - 'Have you tested changes with mobile?'
-    - 'Have you tested changes with desktop?'
-
 stale:
   daysUntilStale: 90
   daysUntilPullRequestStale: 14

--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,13 @@ migration: DEFAULT_MIGRATION_PATH := appdatabase/migrations/sql
 migration:
 	touch $(DEFAULT_MIGRATION_PATH)/$(shell date +%s)_$(D).up.sql
 
+migration-check:
+	bash _assets/scripts/migration_check.sh
+
+install-git-hooks:
+	@ln -s -f $(shell pwd)/_assets/hooks/pre-rebase .git/hooks
+	@ln -s -f $(shell pwd)/_assets/hooks/pre-merge-commit .git/hooks
+
 migration-protocol: DEFAULT_PROTOCOL_PATH := protocol/migrations/sqlite
 migration-protocol:
 	touch $(DEFAULT_PROTOCOL_PATH)/$(shell date +%s)_$(D).up.sql

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -49,6 +49,11 @@ pipeline {
       } }
     }
 
+    stage('Migration') {
+      steps { script {
+        nix.shell('make migration-check')
+      } }
+    }
 
     stage('Lint') {
       steps { script {

--- a/_assets/hooks/pre-merge-commit
+++ b/_assets/hooks/pre-merge-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make migration-check

--- a/_assets/hooks/pre-rebase
+++ b/_assets/hooks/pre-rebase
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make migration-check

--- a/_assets/scripts/migration_check.sh
+++ b/_assets/scripts/migration_check.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+check_migration_order() {
+  local prev_migration=""
+  for file in "$@"; do
+    current_migration=$(echo "$file" | cut -d'-' -f1)
+
+    if [[ ! -z "$prev_migration" && "$current_migration" < "$prev_migration" ]]; then
+
+      echo "migration ${current_migration} is not in order with ${prev_migration}"
+      echo "Error: Migration files are out of order. Please ensure migrations are added in chronological order."
+      exit 1
+    fi
+
+    prev_migration="$current_migration"
+  done
+}
+
+committed_files=$(git ls-tree -r --name-only HEAD protocol/migrations/sqlite/*.sql | sort)
+staged_files=$(git diff --name-only origin/develop protocol/migrations/sqlite/*.sql | sort)
+
+all_files=$(echo -e "$committed_files\n$staged_files")
+
+check_migration_order $all_files
+
+exit 0


### PR DESCRIPTION
This commit adds a script that checks that no out of order migrations are introduced in the codebase when merging/rebasing.

This check is done on Jenkins, I have also added a way to install git hooks so that if someone merges locally it will trigger the same.

You can install the scripts locally by running
`make install-git-hooks`