### PR TITLE
feat(communities): enable selecting addresses to pass when joining

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -704,8 +704,22 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 		revealedAccounts := make(map[gethcommon.Address]*protobuf.RevealedAccount)
 		revealedAddresses := make([]gethcommon.Address, 0)
 
+		containsAddress := func(addresses []string, targetAddress string) bool {
+			for _, address := range addresses {
+				if address == targetAddress {
+					return true
+				}
+			}
+			return false
+		}
+
 		for _, walletAccount := range walletAccounts {
 			if !walletAccount.Chat && walletAccount.Type != accounts.AccountTypeWatch {
+
+				if len(request.AddressesToReveal) > 0 && !containsAddress(request.AddressesToReveal, walletAccount.Address.Hex()) {
+					continue
+				}
+
 				verifiedAccount, err := m.accountsManager.GetVerifiedWalletAccount(m.settings, walletAccount.Address.Hex(), request.Password)
 				if err != nil {
 					return nil, err

--- a/protocol/requests/request_to_join_community.go
+++ b/protocol/requests/request_to_join_community.go
@@ -7,16 +7,21 @@ import (
 )
 
 var ErrRequestToJoinCommunityInvalidCommunityID = errors.New("request-to-join-community: invalid community id")
+var ErrRequestToJoinCommunityMissingPassword = errors.New("request-to-join-community: password is necessary when sending a list of addresses")
 
 type RequestToJoinCommunity struct {
-	CommunityID types.HexBytes `json:"communityId"`
-	ENSName     string         `json:"ensName"`
-	Password    string         `json:"password"`
+	CommunityID       types.HexBytes `json:"communityId"`
+	ENSName           string         `json:"ensName"`
+	Password          string         `json:"password"`
+	AddressesToReveal []string       `json:"addressesToReveal"`
 }
 
 func (j *RequestToJoinCommunity) Validate() error {
 	if len(j.CommunityID) == 0 {
 		return ErrRequestToJoinCommunityInvalidCommunityID
+	}
+	if len(j.AddressesToReveal) > 0 && j.Password == "" {
+		return ErrRequestToJoinCommunityMissingPassword
 	}
 
 	return nil


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/11154

Improves `RequestToJoinCommunity`  to accept `Addresses` in the request. If `Addresses` is not empty, we then only pass to the owner the selected addresses. The others are ignored. Does not validate that the addresses in the slice are part of the user's wallet. Those not part of the wallet are just ignored.
