### PR TITLE
Run tests separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,8 +312,9 @@ test-unit: UNIT_TEST_PACKAGES = $(shell go list ./...  | \
 	grep -v /t/benchmarks | \
 	grep -v /transactions/fake )
 test-unit: ##@tests Run unit and integration tests
-	go test -tags '$(BUILD_TAGS)' -timeout 20m -v -failfast $(UNIT_TEST_PACKAGES) $(gotest_extraflags)
-	cd ./waku && go test -tags '$(BUILD_TAGS)' -timeout 20m -v -failfast ./... $(gotest_extraflags)
+	for file in $(UNIT_TEST_PACKAGES); do \
+		go test -tags '$(BUILD_TAGS)' -timeout 20m -v -failfast $$file $(gotest_extraflags); \
+	done
 
 test-unit-race: gotest_extraflags=-race
 test-unit-race: test-unit ##@tests Run unit and integration tests with -race flag

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.7.0
 	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb
-	google.golang.org/protobuf v1.30.1-0.20230508203708-b8fc77060104
+	google.golang.org/protobuf v1.30.1-0.20230508203708-b8fc77060104 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1397,7 +1397,7 @@ func buildTorrentConfig() params.TorrentConfig {
 		Enabled:    true,
 		DataDir:    os.TempDir() + "/archivedata",
 		TorrentDir: os.TempDir() + "/torrents",
-		Port:       9999,
+		Port:       0,
 	}
 	return torrentConfig
 }

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -431,6 +431,7 @@ func (s *AdminMessengerCommunitiesSuite) TestAdminAcceptMemberRequestToJoin() {
 	user := s.newMessenger()
 	_, err := user.Start()
 	s.Require().NoError(err)
+	defer user.Shutdown() // nolint: errcheck
 
 	s.advertiseCommunityTo(community, user)
 
@@ -508,6 +509,7 @@ func (s *AdminMessengerCommunitiesSuite) TestAdminRejectMemberRequestToJoin() {
 	user := s.newMessenger()
 	_, err := user.Start()
 	s.Require().NoError(err)
+	defer user.Shutdown() // nolint: errcheck
 
 	s.advertiseCommunityTo(community, user)
 

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -64,6 +64,7 @@ func (s *MessengerActivityCenterMessageSuite) TestDeleteOneToOneChat() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -127,6 +128,7 @@ func (s *MessengerActivityCenterMessageSuite) TestEveryoneMentionTag() {
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
+	defer bob.Shutdown() // nolint: errcheck
 
 	// Create an community chat
 	response, err := bob.CreateCommunity(description, true)

--- a/protocol/messenger_backup_test.go
+++ b/protocol/messenger_backup_test.go
@@ -73,6 +73,7 @@ func (s *MessengerBackupSuite) TestBackupContacts() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Create 2 contacts
 
@@ -194,6 +195,7 @@ func (s *MessengerBackupSuite) TestBackupProfile() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Check bob1
 	storedBob1DisplayName, err := bob1.settings.DisplayName()
@@ -324,6 +326,7 @@ func (s *MessengerBackupSuite) TestBackupSettings() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Check bob1
 	storedBob1DisplayName, err := bob1.settings.DisplayName()
@@ -433,6 +436,7 @@ func (s *MessengerBackupSuite) TestBackupContactsGreaterThanBatch() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Create contacts
 
@@ -475,6 +479,7 @@ func (s *MessengerBackupSuite) TestBackupRemovedContact() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Create 2 contacts on bob 1
 
@@ -549,6 +554,7 @@ func (s *MessengerBackupSuite) TestBackupLocalNickname() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Set contact nickname
 
@@ -599,6 +605,7 @@ func (s *MessengerBackupSuite) TestBackupBlockedContacts() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Create contact
 	contact1Key, err := crypto.GenerateKey()
@@ -655,6 +662,7 @@ func (s *MessengerBackupSuite) TestBackupCommunities() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Create a communitie
 
@@ -726,6 +734,7 @@ func (s *MessengerBackupSuite) TestBackupKeypairs() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Backup
 	_, err = bob1.BackupData(context.Background())
@@ -810,6 +819,7 @@ func (s *MessengerBackupSuite) TestBackupKeycards() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Backup
 	_, err = bob1.BackupData(context.Background())
@@ -851,6 +861,7 @@ func (s *MessengerBackupSuite) TestBackupWatchOnlyAccounts() {
 	s.Require().NoError(err)
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Backup
 	_, err = bob1.BackupData(context.Background())

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -62,6 +62,10 @@ const (
 )
 
 func (m *Messenger) publishOrg(org *communities.Community) error {
+	if org == nil {
+		return nil
+	}
+
 	m.logger.Debug("publishing org", zap.String("org-id", org.IDString()), zap.Any("org", org))
 	payload, err := org.MarshaledDescription()
 	if err != nil {

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -400,6 +400,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequest() { //
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -417,6 +418,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndDismissContactRequest() {
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -434,6 +436,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	s.Require().NoError(theirMessenger.settings.SaveSettingField(settings.MutualContactEnabled, true))
 
@@ -454,6 +457,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequestTwice()
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -515,6 +519,7 @@ func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContact(
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -609,6 +614,7 @@ func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContact
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -644,6 +650,7 @@ func (s *MessengerContactRequestSuite) TestPairedDevicesRemoveContact() {
 
 	_, err = alice2.Start()
 	s.Require().NoError(err)
+	defer alice2.Shutdown() // nolint: errcheck
 
 	prepAliceMessengersForPairing(&s.Suite, alice1, alice2)
 
@@ -653,6 +660,7 @@ func (s *MessengerContactRequestSuite) TestPairedDevicesRemoveContact() {
 	bob := s.newMessenger(s.shh)
 	_, err = bob.Start()
 	s.Require().NoError(err)
+	defer bob.Shutdown() // nolint: errcheck
 
 	// Alice sends a contact request to bob
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
@@ -716,6 +724,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateSendContactRequest()
 	bob := s.newMessenger(s.shh)
 	_, err := bob.Start()
 	s.Require().NoError(err)
+	defer bob.Shutdown() // nolint: errcheck
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -738,6 +747,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateSendContactRequest()
 
 	_, err = alice2.Start()
 	s.Require().NoError(err)
+	defer alice2.Shutdown() // nolint: errcheck
 
 	// adds bob again to her device
 	s.sendContactRequest(request, alice2)
@@ -786,6 +796,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateReceiveContactReques
 	bob := s.newMessenger(s.shh)
 	_, err := bob.Start()
 	s.Require().NoError(err)
+	defer bob.Shutdown() // nolint: errcheck
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -808,6 +819,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateReceiveContactReques
 
 	_, err = alice2.Start()
 	s.Require().NoError(err)
+	defer alice2.Shutdown() // nolint: errcheck
 
 	// We want to facilitate the discovery of the x3dh bundl here, since bob does not know about alice device
 
@@ -865,6 +877,7 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsCorrectOrd
 	bob := s.newMessenger(s.shh)
 	_, err := bob.Start()
 	s.Require().NoError(err)
+	defer bob.Shutdown() // nolint: errcheck
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -914,6 +927,7 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsWrongOrder
 	bob := s.newMessenger(s.shh)
 	_, err := bob.Start()
 	s.Require().NoError(err)
+	defer bob.Shutdown() // nolint: errcheck
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -965,6 +979,7 @@ func (s *MessengerContactRequestSuite) TestAliceResendsContactRequestAfterRemovi
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
@@ -1020,6 +1035,7 @@ func (s *MessengerContactRequestSuite) TestBobSendsContactRequestAfterDecliningO
 	bob := s.newMessenger(s.shh)
 	_, err := bob.Start()
 	s.Require().NoError(err)
+	defer bob.Shutdown() // nolint: errcheck
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1205,6 +1221,7 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 	bob1 := s.newMessenger(s.shh)
 	_, err := bob1.Start()
 	s.Require().NoError(err)
+	defer bob1.Shutdown() // nolint: errcheck
 
 	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob1.identity.PublicKey))
@@ -1226,6 +1243,7 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 
 	_, err = bob2.Start()
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	// Get bob perspective of alice for backup
 	aliceFromBob := bob1.Contacts()[0]
@@ -1283,6 +1301,7 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 	bob := s.newMessenger(s.shh)
 	_, err := bob.Start()
 	s.Require().NoError(err)
+	defer bob.Shutdown() // nolint: errcheck
 
 	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice1.identity.PublicKey))
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
@@ -1304,6 +1323,7 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 
 	_, err = alice2.Start()
 	s.Require().NoError(err)
+	defer alice2.Shutdown() // nolint: errcheck
 
 	// Get bob perspective of alice for backup
 	bobFromAlice := alice1.Contacts()[0]

--- a/protocol/messenger_contact_update_test.go
+++ b/protocol/messenger_contact_update_test.go
@@ -67,6 +67,7 @@ func (s *MessengerContactUpdateSuite) TestReceiveContactUpdate() {
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	// Set ENS name
 	err = theirMessenger.settings.SaveSettingField(settings.PreferredName, theirName)
@@ -126,7 +127,6 @@ func (s *MessengerContactUpdateSuite) TestReceiveContactUpdate() {
 	s.Require().Equal(newEnsName, receivedContact.EnsName)
 	s.Require().False(receivedContact.ENSVerified)
 	s.Require().NotEmpty(receivedContact.LastUpdated)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 func (s *MessengerContactUpdateSuite) TestAddContact() {
@@ -135,6 +135,7 @@ func (s *MessengerContactUpdateSuite) TestAddContact() {
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	response, err := theirMessenger.AddContact(context.Background(), &requests.AddContact{ID: contactID})
 	s.Require().NoError(err)
@@ -168,6 +169,7 @@ func (s *MessengerContactUpdateSuite) TestAddContactWithENS() {
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	s.Require().NoError(theirMessenger.ENSVerified(contactID, ensName))
 

--- a/protocol/messenger_contact_verification_test.go
+++ b/protocol/messenger_contact_verification_test.go
@@ -160,6 +160,7 @@ func (s *MessengerVerificationRequests) TestAcceptVerificationRequests() {
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	s.mutualContact(theirMessenger)
 
@@ -285,6 +286,7 @@ func (s *MessengerVerificationRequests) TestTrustedVerificationRequests() {
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	s.mutualContact(theirMessenger)
 
@@ -398,6 +400,7 @@ func (s *MessengerVerificationRequests) TestUnthrustworthyVerificationRequests()
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	s.mutualContact(theirMessenger)
 
@@ -525,6 +528,7 @@ func (s *MessengerVerificationRequests) TestDeclineVerificationRequests() {
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	s.mutualContact(theirMessenger)
 
@@ -636,6 +640,7 @@ func (s *MessengerVerificationRequests) TestCancelVerificationRequest() {
 	theirMessenger := s.newMessenger(s.shh)
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	s.mutualContact(theirMessenger)
 

--- a/protocol/messenger_delete_message_for_everyone_test.go
+++ b/protocol/messenger_delete_message_for_everyone_test.go
@@ -54,6 +54,7 @@ func (s *MessengerDeleteMessageForEveryoneSuite) SetupTest() {
 func (s *MessengerDeleteMessageForEveryoneSuite) TearDownTest() {
 	s.Require().NoError(s.admin.Shutdown())
 	s.Require().NoError(s.bob.Shutdown())
+	s.Require().NoError(s.moderator.Shutdown())
 	_ = s.logger.Sync()
 }
 

--- a/protocol/messenger_delete_message_test.go
+++ b/protocol/messenger_delete_message_test.go
@@ -23,6 +23,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -73,6 +74,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessagePreviousLastMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -123,6 +125,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteWrongMessageType() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -151,6 +154,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageFirstThenMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -206,6 +210,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteImageMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -281,6 +286,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteImageMessageFirstThenMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -362,6 +368,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageWithAMention() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -423,6 +430,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageAndChatIsAlreadyRead() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -483,6 +491,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageReplyToImage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -531,5 +540,4 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageReplyToImage() {
 	s.Require().NoError(err)
 	s.Require().Len(sendResponse.Messages(), 1)
 	s.Require().NotEmpty(sendResponse.Messages()[0].ImageLocalURL)
-	s.Require().NoError(theirMessenger.Shutdown())
 }

--- a/protocol/messenger_edit_message_test.go
+++ b/protocol/messenger_edit_message_test.go
@@ -64,6 +64,7 @@ func (s *MessengerEditMessageSuite) TestEditMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -134,6 +135,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageEdgeCases() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -236,6 +238,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageFirstEditsThenMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -295,6 +298,7 @@ func (s *MessengerEditMessageSuite) TestEditGroupChatMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	response, err := s.m.CreateGroupChatWithMembers(context.Background(), "id", []string{})
 	s.NoError(err)
@@ -379,6 +383,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_emoji_test.go
+++ b/protocol/messenger_emoji_test.go
@@ -72,6 +72,7 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 
 	bob, err := newMessengerWithKey(s.shh, key, s.logger, nil)
 	s.Require().NoError(err)
+	defer bob.Shutdown() // nolint: errcheck
 
 	chatID := statusChatID
 
@@ -145,7 +146,6 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 	s.Require().Equal(response.EmojiReactions()[0].ID(), emojiID)
 	s.Require().Equal(response.EmojiReactions()[0].Type, protobuf.EmojiReaction_SAD)
 	s.Require().True(response.EmojiReactions()[0].Retracted)
-	s.Require().NoError(bob.Shutdown())
 }
 
 func (s *MessengerEmojiSuite) TestEmojiPrivateGroup() {
@@ -153,6 +153,7 @@ func (s *MessengerEmojiSuite) TestEmojiPrivateGroup() {
 	alice := s.newMessenger(s.shh)
 	_, err := alice.Start()
 	s.Require().NoError(err)
+	defer alice.Shutdown() // nolint: errcheck
 	response, err := bob.CreateGroupChatWithMembers(context.Background(), "test", []string{})
 	s.NoError(err)
 
@@ -205,8 +206,6 @@ func (s *MessengerEmojiSuite) TestEmojiPrivateGroup() {
 		"no emoji reaction received",
 	)
 	s.Require().NoError(err)
-	s.Require().NoError(alice.Shutdown())
-
 }
 
 func (s *MessengerEmojiSuite) TestCompressedKeyReturnedWithEmoji() {

--- a/protocol/messenger_pin_message_test.go
+++ b/protocol/messenger_pin_message_test.go
@@ -22,6 +22,7 @@ func (s *MessengerPinMessageSuite) TestPinMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -93,6 +94,7 @@ func (s *MessengerPinMessageSuite) TestPinMessageOutOfOrder() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_send_images_album_test.go
+++ b/protocol/messenger_send_images_album_test.go
@@ -66,6 +66,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesSend() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -126,6 +127,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesWithMentionSend() 
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_share_image_test.go
+++ b/protocol/messenger_share_image_test.go
@@ -99,6 +99,7 @@ func (s *MessengerShareMessageSuite) TestImageMessageSharing() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -498,6 +498,7 @@ func (s *MessengerSuite) TestRetrieveTheirPublic() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirChat := CreatePublicChat("status", s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -534,7 +535,6 @@ func (s *MessengerSuite) TestRetrieveTheirPublic() {
 	s.Require().Equal(sentMessage.Clock, actualChat.LastClockValue)
 	// It sets the last message
 	s.Require().NotNil(actualChat.LastMessage)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 // Drop audio message in public group
@@ -542,6 +542,7 @@ func (s *MessengerSuite) TestDropAudioMessageInPublicGroup() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirChat := CreatePublicChat("status", s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -562,13 +563,13 @@ func (s *MessengerSuite) TestDropAudioMessageInPublicGroup() {
 	response, err := s.m.RetrieveAll()
 	s.Require().NoError(err)
 	s.Require().Len(response.Messages(), 0)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 func (s *MessengerSuite) TestDeletedAtClockValue() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirChat := CreatePublicChat("status", s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -594,13 +595,13 @@ func (s *MessengerSuite) TestDeletedAtClockValue() {
 	response, err := s.m.RetrieveAll()
 	s.Require().NoError(err)
 	s.Require().Len(response.Messages(), 0)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 func (s *MessengerSuite) TestRetrieveBlockedContact() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 
 	theirChat := CreatePublicChat("status", s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -680,6 +681,7 @@ func (s *MessengerSuite) TestResendPublicMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirChat := CreatePublicChat("status", s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -735,6 +737,7 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateChatExisting() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirChat := CreateOneToOneChat("XXX", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -770,7 +773,6 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateChatExisting() {
 	// It sets the last message
 	s.Require().NotNil(actualChat.LastMessage)
 	s.Require().False(actualChat.Active)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 // Test receiving a message on an non-existing private chat
@@ -778,6 +780,7 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateChatNonExisting() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	chat := CreateOneToOneChat("XXX", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(chat)
 	s.NoError(err)
@@ -816,6 +819,7 @@ func (s *MessengerSuite) TestRetrieveTheirPublicChatNonExisting() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	chat := CreatePublicChat("test-chat", s.m.transport)
 	err = theirMessenger.SaveChat(chat)
 	s.NoError(err)
@@ -833,7 +837,6 @@ func (s *MessengerSuite) TestRetrieveTheirPublicChatNonExisting() {
 
 	s.Require().Equal(len(response.Messages()), 0)
 	s.Require().Equal(len(response.Chats()), 0)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 // Test receiving a message on an existing private group chat
@@ -842,6 +845,7 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateGroupChat() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	response, err = s.m.CreateGroupChatWithMembers(context.Background(), "id", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -910,6 +914,7 @@ func (s *MessengerSuite) TestChangeNameGroupChat() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	response, err = s.m.CreateGroupChatWithMembers(context.Background(), "old-name", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -958,7 +963,6 @@ func (s *MessengerSuite) TestChangeNameGroupChat() {
 	s.Require().Len(response.Chats(), 1)
 	actualChat := response.Chats()[0]
 	s.Require().Equal(newEnsName, actualChat.Name)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 // Test being re-invited to a group chat
@@ -967,6 +971,7 @@ func (s *MessengerSuite) TestReInvitedToGroupChat() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	response, err = s.m.CreateGroupChatWithMembers(context.Background(), "old-name", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -1033,7 +1038,6 @@ func (s *MessengerSuite) TestReInvitedToGroupChat() {
 
 	s.Require().Len(response.Chats(), 1)
 	s.Require().False(response.Chats()[0].Active)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 func (s *MessengerSuite) TestChatPersistencePublic() {
@@ -1500,6 +1504,7 @@ func (s *MessengerSuite) TestDeclineRequestAddressForTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	myPkString := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 
@@ -1585,7 +1590,6 @@ func (s *MessengerSuite) TestDeclineRequestAddressForTransaction() {
 	s.Require().Equal(initialCommandID, receiverMessage.CommandParameters.ID)
 	s.Require().Equal(myPkString, receiverMessage.ChatId)
 	s.Require().Equal(initialCommandID, receiverMessage.Replace)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 func (s *MessengerSuite) TestSendEthTransaction() {
@@ -1595,6 +1599,7 @@ func (s *MessengerSuite) TestSendEthTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	receiverAddress := crypto.PubkeyToAddress(theirMessenger.identity.PublicKey)
@@ -1689,7 +1694,6 @@ func (s *MessengerSuite) TestSendEthTransaction() {
 	s.Require().Equal(common.CommandStateTransactionSent, receiverMessage.CommandParameters.CommandState)
 	s.Require().Equal(senderMessage.ID, receiverMessage.ID)
 	s.Require().Equal("", receiverMessage.Replace)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 func (s *MessengerSuite) TestSendTokenTransaction() {
@@ -1699,6 +1703,7 @@ func (s *MessengerSuite) TestSendTokenTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	receiverAddress := crypto.PubkeyToAddress(theirMessenger.identity.PublicKey)
@@ -1793,7 +1798,6 @@ func (s *MessengerSuite) TestSendTokenTransaction() {
 	s.Require().Equal(common.CommandStateTransactionSent, receiverMessage.CommandParameters.CommandState)
 	s.Require().Equal(senderMessage.ID, receiverMessage.ID)
 	s.Require().Equal(senderMessage.Replace, senderMessage.Replace)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 func (s *MessengerSuite) TestAcceptRequestAddressForTransaction() {
@@ -1802,6 +1806,7 @@ func (s *MessengerSuite) TestAcceptRequestAddressForTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	myPkString := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 
@@ -1889,7 +1894,6 @@ func (s *MessengerSuite) TestAcceptRequestAddressForTransaction() {
 	s.Require().Equal("some-address", receiverMessage.CommandParameters.Address)
 	s.Require().Equal(initialCommandID, receiverMessage.Replace)
 	s.Require().Equal(myPkString, receiverMessage.ChatId)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 func (s *MessengerSuite) TestDeclineRequestTransaction() {
@@ -1900,6 +1904,7 @@ func (s *MessengerSuite) TestDeclineRequestTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	chat := CreateOneToOneChat(theirPkString, &theirMessenger.identity.PublicKey, s.m.transport)
@@ -1979,7 +1984,6 @@ func (s *MessengerSuite) TestDeclineRequestTransaction() {
 	s.Require().Equal(initialCommandID, receiverMessage.CommandParameters.ID)
 	s.Require().Equal(initialCommandID, receiverMessage.Replace)
 	s.Require().Equal(common.CommandStateRequestTransactionDeclined, receiverMessage.CommandParameters.CommandState)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 func (s *MessengerSuite) TestRequestTransaction() {
@@ -1990,6 +1994,7 @@ func (s *MessengerSuite) TestRequestTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
+	defer theirMessenger.Shutdown() // nolint: errcheck
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	chat := CreateOneToOneChat(theirPkString, &theirMessenger.identity.PublicKey, s.m.transport)
@@ -2126,7 +2131,6 @@ func (s *MessengerSuite) TestRequestTransaction() {
 	s.Require().Equal(common.CommandStateTransactionSent, receiverMessage.CommandParameters.CommandState)
 	s.Require().Equal(senderMessage.ID, receiverMessage.ID)
 	s.Require().Equal(senderMessage.Replace, senderMessage.Replace)
-	s.Require().NoError(theirMessenger.Shutdown())
 }
 
 type MockTransaction struct {

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -102,6 +102,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotification() {
 	// start alice and enable sending push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
+	defer alice.Shutdown() // nolint: errcheck
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob1.installationID, bob2.installationID}
 
@@ -286,6 +287,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationFromContactO
 	// start alice and enable push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
+	defer alice.Shutdown() // nolint: errcheck
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
 
@@ -429,9 +431,11 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
 	frank := s.newMessenger(s.shh)
 	_, err = frank.Start()
 	s.Require().NoError(err)
+	defer frank.Shutdown() // nolint: errcheck
 	// start alice and enable push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
+	defer alice.Shutdown() // nolint: errcheck
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
 
@@ -650,11 +654,13 @@ func (s *MessengerPushNotificationSuite) TestContactCode() {
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
+	defer server.Shutdown() // nolint: errcheck
 
 	alice := s.newMessenger(s.shh)
 	// start alice and enable sending push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
+	defer alice.Shutdown() // nolint: errcheck
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 
 	// Register bob1
@@ -700,8 +706,6 @@ func (s *MessengerPushNotificationSuite) TestContactCode() {
 
 	s.Require().NoError(alice.pushNotificationClient.HandleContactCodeAdvertisement(&bob1.identity.PublicKey, *contactCodeAdvertisement))
 
-	s.Require().NoError(alice.Shutdown())
-	s.Require().NoError(server.Shutdown())
 }
 
 func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
@@ -711,11 +715,13 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
+	defer server.Shutdown() // nolint: errcheck
 
 	alice := s.newMessenger(s.shh)
 	// start alice and enable sending push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
+	defer alice.Shutdown() // nolint: errcheck
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
 
@@ -841,8 +847,6 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
 		return nil
 	})
 	s.Require().NoError(err)
-	s.Require().NoError(alice.Shutdown())
-	s.Require().NoError(server.Shutdown())
 }
 
 func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityRequest() {
@@ -852,11 +856,13 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
+	defer server.Shutdown() // nolint: errcheck
 
 	alice := s.newMessenger(s.shh)
 	// start alice and enable sending push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
+	defer alice.Shutdown() // nolint: errcheck
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 
 	// Register bob
@@ -974,8 +980,6 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 
 	s.Require().NoError(err)
 
-	s.Require().NoError(alice.Shutdown())
-	s.Require().NoError(server.Shutdown())
 }
 
 func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevices() {
@@ -983,15 +987,18 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevice
 	bob1 := s.m
 	bob2, err := newMessengerWithKey(s.shh, s.m.identity, s.logger, []Option{WithPushNotifications()})
 	s.Require().NoError(err)
+	defer bob2.Shutdown() // nolint: errcheck
 
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
+	defer server.Shutdown() // nolint: errcheck
 
 	alice := s.newMessenger(s.shh)
 	// start alice and enable sending push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
+	defer alice.Shutdown() // nolint: errcheck
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob1.installationID, bob2.installationID}
 
@@ -1159,7 +1166,4 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevice
 		return nil
 	})
 	s.Require().NoError(err)
-	s.Require().NoError(bob2.Shutdown())
-	s.Require().NoError(alice.Shutdown())
-	s.Require().NoError(server.Shutdown())
 }


### PR DESCRIPTION
This commit adds:

- run tests separately to avoid the 20m timeout
- Call shutdown after creating a messenger, with defer, not checking for errors. This is not ideal, but it's much easier to spot issues and messengers not closed, as there were many instances where that was the case.
- Fix torrent test, since it could not run concurrently

I tried to figure out the root cause of the slow tests. From what I could gather, it looks like a problem of resources.

The heaviest tests are the encryption tests, they take up to 6/7 minutes. On my machine though, it takes 20s to run a suite, while on CI it takes up to 4/5 minutes for the same suite. Though that's not consistent, some runs are very fast on ci (4s), while others are really slow. 
This seems to indicate that the system is under stress. One of the reasons was that messengers were not shutdown, so you could see a bunch of messengers running while the encryption tests were running (which don't use messenger at all). 
I have changed the code so that we call `defer m.Shutdown()` after creating a messenger, is less error prone, this skip error checking as it runs outside the test suite. Probably it would be best to have something a bit more elegant, but for now I think that's acceptable.
Even with this change, tests run slow, so there's something else going on. 
Each file now is run in a different `go test`, so the 20m timeout applies for test file, rather for the whole test suite.
