### PR TITLE
tests: make test-unit target more dynamic

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -70,7 +70,7 @@ pipeline {
           '--env=POSTGRES_HOST_AUTH_METHOD=trust',
           '--publish=5432:5432',
         ].join(' ')) { c ->
-          nix.shell('make test-unit V=1', pure: false)
+          nix.shell('make test-unit V=1 -j1', pure: false)
         }
       } }
       post { cleanup { /* Leftover DB containers. */


### PR DESCRIPTION
We are generating a list of unit tests we can run with `go list`, and then a dynamic target that can take a `test-unit_${UNIT_PATH}` as target.

This way we can run all tests using `make test-unit`, or we can run individual tests using the prefixed form:
```
 > make test-unit_github.com/status-im/status-go/appdatabase
TESTING: test-unit_github.com/status-im/status-go/appdatabase
=== RUN   Test_GetDBFilename
--- PASS: Test_GetDBFilename (0.29s)
=== RUN   TestMigrateWalletJsonBlobs
--- PASS: TestMigrateWalletJsonBlobs (0.09s)
=== RUN   TestGetNodeConfig
--- PASS: TestGetNodeConfig (0.20s)
=== RUN   TestSaveNodeConfig
--- PASS: TestSaveNodeConfig (0.20s)
=== RUN   TestMigrateNodeConfig
--- PASS: TestMigrateNodeConfig (0.20s)
PASS
ok      github.com/status-im/status-go/appdatabase    (cached)

real    0m0.281s
user    0m0.872s
sys    0m0.438s
```
It's also worth noting that if `make test-unit -j1` is used then the tests will run serially instead of in parallel.