### PR TITLE
Bug fix status-mobile 16352 - Only send PNs to chats that are unmuted

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -5839,6 +5839,7 @@ func (m *Messenger) pushNotificationOptions() *pushnotificationclient.Registrati
 	m.allChats.Range(func(chatID string, chat *Chat) (shouldContinue bool) {
 		if chat.Muted {
 			mutedChatIDs = append(mutedChatIDs, chat.ID)
+			return true
 		}
 		if chat.Active && (chat.Public() || chat.CommunityChat()) {
 			publicChatIDs = append(publicChatIDs, chat.ID)


### PR DESCRIPTION
Fixes a conditional bug/error that allowed muted chats to be added to the PublicChats key of the PushNotificationOptions.
If a chat is muted then we only care to add it to the MutedChatLIst so that we block PNs from it and not allow it to be added to the PublicChatList
Closes https://github.com/status-im/status-mobile/issues/16352
