### PR TITLE
Accept RequestToJoinCommunity only with revealed accounts

### DIFF
--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -204,6 +204,10 @@ func joinCommunity(s *suite.Suite, community *communities.Community, owner *Mess
 	s.Require().NoError(err)
 }
 
+func createRequestToJoinCommunity(community *communities.Community) *requests.RequestToJoinCommunity {
+	return &requests.RequestToJoinCommunity{CommunityID: community.ID(), Password: dummyPassword, AddressesToReveal: []string{dummyAddress}}
+}
+
 func sendChatMessage(s *suite.Suite, sender *Messenger, chatID string, text string) *common.Message {
 	msg := &common.Message{
 		ChatMessage: protobuf.ChatMessage{

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 	"time"
 
-	gethcommon "github.com/ethereum/go-ethereum/common"
-	hexutil "github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	hexutil "github.com/ethereum/go-ethereum/common/hexutil"
 	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
@@ -401,10 +401,6 @@ func (s *MessengerCommunitiesSuite) createCommunity() *communities.Community {
 
 func (s *MessengerCommunitiesSuite) advertiseCommunityTo(community *communities.Community, user *Messenger) {
 	advertiseCommunityTo(&s.Suite, community, s.admin, user)
-}
-
-func createRequestToJoinCommunity(community *communities.Community) *requests.RequestToJoinCommunity {
-	return &requests.RequestToJoinCommunity{CommunityID: community.ID(), Password: dummyPassword, AddressesToReveal: []string{dummyAddress}}
 }
 
 func (s *MessengerCommunitiesSuite) joinCommunity(community *communities.Community, user *Messenger) {

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -403,9 +403,12 @@ func (s *MessengerCommunitiesSuite) advertiseCommunityTo(community *communities.
 	advertiseCommunityTo(&s.Suite, community, s.admin, user)
 }
 
+func createRequestToJoinCommunity(community *communities.Community) *requests.RequestToJoinCommunity {
+	return &requests.RequestToJoinCommunity{CommunityID: community.ID(), Password: dummyPassword, AddressesToReveal: []string{dummyAddress}}
+}
+
 func (s *MessengerCommunitiesSuite) joinCommunity(community *communities.Community, user *Messenger) {
-	request := &requests.RequestToJoinCommunity{CommunityID: community.ID(), Password: dummyPassword, AddressesToReveal: []string{dummyAddress}}
-	joinCommunity(&s.Suite, community, s.admin, user, request)
+	joinCommunity(&s.Suite, community, s.admin, user, createRequestToJoinCommunity(community))
 }
 
 func (s *MessengerCommunitiesSuite) TestCommunityContactCodeAdvertisement() {
@@ -784,7 +787,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccess() {
 
 	s.Require().NoError(err)
 
-	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request := createRequestToJoinCommunity(community)
 	// We try to join the org
 	response, err = s.alice.RequestToJoinCommunity(request)
 	s.Require().NoError(err)
@@ -992,7 +995,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccess() {
 	s.Require().NoError(err)
 
 	// Alice request to join community
-	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request := createRequestToJoinCommunity(community)
 	response, err = s.alice.RequestToJoinCommunity(request)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
@@ -1099,7 +1102,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccess() {
 	s.Require().True(notification.Deleted)
 
 	// Alice request to join community
-	request = &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request = createRequestToJoinCommunity(community)
 	response, err = s.alice.RequestToJoinCommunity(request)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
@@ -1182,7 +1185,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccessWithDeclinedSt
 	s.Require().NoError(err)
 
 	// Alice request to join community
-	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request := createRequestToJoinCommunity(community)
 	response, err = s.alice.RequestToJoinCommunity(request)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
@@ -1348,7 +1351,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccessWithDeclinedSt
 	s.Require().False(notificationState.HasSeen)
 
 	// Alice request to join community
-	request = &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request = createRequestToJoinCommunity(community)
 	response, err = s.alice.RequestToJoinCommunity(request)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
@@ -1431,7 +1434,7 @@ func (s *MessengerCommunitiesSuite) TestCancelRequestAccess() {
 
 	s.Require().NoError(err)
 
-	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request := createRequestToJoinCommunity(community)
 	// We try to join the org
 	response, err = s.alice.RequestToJoinCommunity(request)
 	s.Require().NoError(err)
@@ -1606,7 +1609,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 
 	s.Require().NoError(err)
 
-	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request := createRequestToJoinCommunity(community)
 	// We try to join the org
 	response, err = s.alice.RequestToJoinCommunity(request)
 	s.Require().NoError(err)
@@ -1752,7 +1755,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 	s.Require().Len(requestsToJoin, 0)
 
 	// We request again
-	request2 := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request2 := createRequestToJoinCommunity(community)
 	// We try to join the org, it should error as we are already a member
 	response, err = s.alice.RequestToJoinCommunity(request2)
 	s.Require().Error(err)
@@ -1810,7 +1813,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 	s.Require().False(aliceCommunity.HasMember(&s.alice.identity.PublicKey))
 
 	// Alice can request access again
-	request3 := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request3 := createRequestToJoinCommunity(community)
 	response, err = s.alice.RequestToJoinCommunity(request3)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
@@ -1906,7 +1909,7 @@ func (s *MessengerCommunitiesSuite) TestDeclineAccess() {
 
 	s.Require().NoError(err)
 
-	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request := createRequestToJoinCommunity(community)
 	// We try to join the org
 	response, err = s.alice.RequestToJoinCommunity(request)
 	s.Require().NoError(err)
@@ -2597,7 +2600,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_RequestToJoin() {
 	}
 
 	// Alice requests to join the new community
-	response, err = s.alice.RequestToJoinCommunity(&requests.RequestToJoinCommunity{CommunityID: community.ID()})
+	response, err = s.alice.RequestToJoinCommunity(createRequestToJoinCommunity(community))
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.RequestsToJoinCommunity, 1)
@@ -3138,7 +3141,7 @@ func (s *MessengerCommunitiesSuite) TestCommunityBanUserRequesToJoin() {
 	s.Require().NoError(err)
 	s.Require().Len(response.Communities(), 1)
 
-	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	request := createRequestToJoinCommunity(community)
 	// We try to join the org
 	_, rtj, err := s.alice.communitiesManager.RequestToJoin(&s.alice.identity.PublicKey, request)
 

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -357,7 +357,10 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestRequestAccessWithENSToke
 
 	s.advertiseCommunityTo(community, s.alice)
 
-	requestToJoin := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
+	requestToJoin := &requests.RequestToJoinCommunity{
+		CommunityID: community.ID(),
+		Password:    types.EncodeHex(crypto.Keccak256([]byte(alicePassword))),
+	}
 	// We try to join the org
 	response, err = s.alice.RequestToJoinCommunity(requestToJoin)
 	s.Require().NoError(err)


### PR DESCRIPTION
Important changes:
- [x]  Don't send `RequestToJoinCommunity` without revealed accounts. Client should provide password hash to reveal them.
- [x]  Don't accept `RequestToJoinCommunity` without revealed accounts.
- [x] All tests in `communities_messneger_test.go` provide password to `RequestToJoinCommunity`