### PR TITLE
feat(communities): enable RequestCommunityInfo to use a privateKey

### DIFF
--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -3273,3 +3273,16 @@ func (s *MessengerCommunitiesSuite) TestHandleImport() {
 	s.Require().NotNil(chat)
 	s.Require().Equal(0, int(chat.UnviewedMessagesCount))
 }
+
+func (s *MessengerCommunitiesSuite) TestGetCommunityIdFromKey() {
+	publicKey := "0x029e4777ce55f20373db33546c8681a082bd181d665c87e18d4306766de9302b53"
+	privateKey := "0x3f932031cb5f94ba7eb8ab4c824c3677973ab01fde65d1b89e0b3f470003a2cd"
+
+	// Public key returns the same
+	communityID := s.bob.GetCommunityIDFromKey(publicKey)
+	s.Require().Equal(communityID, publicKey)
+
+	// Private key returns the public key
+	communityID = s.bob.GetCommunityIDFromKey(privateKey)
+	s.Require().Equal(communityID, publicKey)
+}

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1854,10 +1854,25 @@ func (m *Messenger) findCommunityInfoFromDB(communityID string) (*communities.Co
 	return community, nil
 }
 
+func (m *Messenger) GetCommunityIDFromKey(communityKey string) string {
+	// Check if the key is a private key
+	privateKey, err := crypto.HexToECDSA(communityKey[2:])
+	communityID := ""
+	if err != nil {
+		// Not a private key, use the public key
+		communityID = communityKey
+	} else {
+		// It is a privateKey
+		communityID = types.HexBytes(crypto.CompressPubkey(&privateKey.PublicKey)).String()
+	}
+	return communityID
+}
+
 // RequestCommunityInfoFromMailserver installs filter for community and requests its details
 // from mailserver. It waits until it has the community before returning it.
 // If useDatabase is true, it searches for community in database and does not request mailserver.
-func (m *Messenger) RequestCommunityInfoFromMailserver(communityID string, useDatabase bool) (*communities.Community, error) {
+func (m *Messenger) RequestCommunityInfoFromMailserver(privateOrPublicKey string, useDatabase bool) (*communities.Community, error) {
+	communityID := m.GetCommunityIDFromKey(privateOrPublicKey)
 	if useDatabase {
 		community, err := m.findCommunityInfoFromDB(communityID)
 		if err != nil {
@@ -1873,7 +1888,9 @@ func (m *Messenger) RequestCommunityInfoFromMailserver(communityID string, useDa
 
 // RequestCommunityInfoFromMailserverAsync installs filter for community and requests its details
 // from mailserver. When response received it will be passed through signals handler
-func (m *Messenger) RequestCommunityInfoFromMailserverAsync(communityID string) error {
+func (m *Messenger) RequestCommunityInfoFromMailserverAsync(privateOrPublicKey string) error {
+	communityID := m.GetCommunityIDFromKey(privateOrPublicKey)
+
 	community, err := m.findCommunityInfoFromDB(communityID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Needed for  https://github.com/status-im/status-desktop/issues/11273

Enables `RequestCommunityInfoFromMailserver` to be called with a community private key as well as a public key like before.