### PR TITLE
fix(wallet) fix crash if to_address is NULL in transfers

### DIFF
--- a/services/wallet/activity/activity_test.go
+++ b/services/wallet/activity/activity_test.go
@@ -696,7 +696,9 @@ func TestGetActivityEntriesFilterByTokenType(t *testing.T) {
 	for i := range trs {
 		tokenAddr := transfer.TestTokens[i].Address
 		trs[i].ChainID = common.ChainID(transfer.TestTokens[i].ChainID)
-		transfer.InsertTestTransferWithToken(t, deps.db, trs[i].To, &trs[i], tokenAddr)
+		transfer.InsertTestTransferWithOptions(t, deps.db, trs[i].To, &trs[i], &transfer.TestTransferOptions{
+			TokenAddress: tokenAddr,
+		})
 	}
 
 	mockTestAccountsWithAddresses(t, deps.db, append(append(append(fromTds, toTds...), fromTrs...), toTrs...))


### PR DESCRIPTION
Updates status-desktop [#11170](https://github.com/status-im/status-desktop/issues/11170)

Add nill tests for TestGetRecipients, GetOldestTimestamp

Also, fix returning duplicate addresses in TestGetRecipients

