### PR TITLE
fix: default to attaching all support chainIDs in membership requests

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1550,6 +1550,17 @@ func (m *Manager) CheckPermissionToJoin(id []byte, addresses []gethcommon.Addres
 	}
 
 	accountsAndChainIDs := combineAddressesAndChainIDs(addresses, allChainIDs)
+
+	if len(permissionsToJoin) == 0 {
+		// There are no permissions to join on this community at the moment,
+		// so we reveal all accounts + all chain IDs
+		response := &CheckPermissionsResponse{
+			Satisfied:         true,
+			Permissions:       make(map[string]*PermissionTokenCriteriaResult),
+			ValidCombinations: accountsAndChainIDs,
+		}
+		return response, nil
+	}
 	return m.checkPermissionToJoin(permissionsToJoin, accountsAndChainIDs, false)
 }
 


### PR DESCRIPTION
There's only one scenario in which a `RevealedAccount` will have an empty `ChainIDs` list attached to it:

When the community in question requires users to satisfy certain criteria to join, and the user's wallet does not own the necessary funds on any of the supported chains.

If there are **no** permissions to join on the community, then we want to reveal all (selected) accounts with all supported chainIDs.

This is necessary so that, once the community *does* become permissioned, it'll have address + chain information from all joined members.

Closes: https://github.com/status-im/status-desktop/issues/11255

