### PR TITLE
fix: properly initialize NFTMetadataProvider in wallet service

### DIFF
--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -105,11 +105,6 @@ func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *server
 		services = append(services, wakuext)
 	}
 
-	if config.WalletConfig.Enabled {
-		walletService := b.walletService(accDB, accountsFeed)
-		services = append(services, walletService)
-	}
-
 	if config.WakuV2Config.Enabled {
 		telemetryServerURL := ""
 		if accDB.DB() != nil {
@@ -133,6 +128,13 @@ func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *server
 		b.wakuV2ExtSrvc = wakuext
 
 		services = append(services, wakuext)
+	}
+
+	// Wallet Service makes use of wakuExtSrvc/wakuV2ExtSrvc
+	// Keep this initialization below the other two
+	if config.WalletConfig.Enabled {
+		walletService := b.walletService(accDB, accountsFeed)
+		services = append(services, walletService)
 	}
 
 	// We ignore for now local notifications flag as users who are upgrading have no mean to enable it

--- a/services/wallet/collectibles/collectibles.go
+++ b/services/wallet/collectibles/collectibles.go
@@ -2,6 +2,7 @@ package collectibles
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -254,6 +255,9 @@ func (o *Manager) processAssets(chainID uint64, assets []opensea.Asset) error {
 		}
 
 		if isMetadataEmpty(asset) {
+			if o.metadataProvider == nil {
+				return fmt.Errorf("NFTMetadataProvider not available")
+			}
 			tokenURI, err := o.fetchTokenURI(chainID, id)
 
 			if err != nil {


### PR DESCRIPTION
Wallet Service initialization was moved above WakuV2 Service initialization in https://github.com/status-im/status-go/pull/3443/files#diff-fa95f2b61a88804406e520993c3df20fb3fd543dbff521b5c2b01d0873b2135dR108

Since the Wallet uses Waku to fetch Community NFT metadata, this caused a crash when an account in the wallet held such an NFT. 

This PR moves the Wallet Service initialization back to where it was, and a check was added to make sure the provider is available before attempting to use it.

With this, issue https://github.com/status-im/status-desktop/issues/11244 is fixed.
![image](https://github.com/status-im/status-go/assets/11161531/e0707502-fe32-4ac0-a9df-229cc6835ba1)
