### PR TITLE
Allow passing nameserver on login

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -534,6 +534,10 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 		return err
 	}
 
+	if b.config.WakuV2Config.Enabled && request.WakuV2Nameserver != "" {
+		b.config.WakuV2Config.Nameserver = request.WakuV2Nameserver
+	}
+
 	b.overrideNetworks(b.config, request)
 
 	err = b.setupLogSettings()

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -9,6 +9,8 @@ type Login struct {
 	KeyUID        string `json:"keyUid"`
 	KdfIterations int    `json:"kdfIterations"`
 
+	WakuV2Nameserver string `json:"wakuV2Nameserver"`
+
 	WalletSecretsConfig
 }
 


### PR DESCRIPTION
Nameserver is passed by the OS on creation/restore, this commit adds the ability to pass it at login time.
We don't want to store it on disk since that's bound to change, and currently there's a bug on golang that prevents getting the DNS from the system on android.

