### PR TITLE
Fixed concurrent write to blockchain status map

### DIFF
--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"database/sql"
 	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -59,7 +60,11 @@ func NewService(
 		Publisher: walletFeed,
 	}
 	blockchainStatus := make(map[uint64]string)
+	mutex := sync.Mutex{}
 	rpcClient.SetWalletNotifier(func(chainID uint64, message string) {
+		mutex.Lock()
+		defer mutex.Unlock()
+
 		if len(blockchainStatus) == 0 {
 			networks, err := rpcClient.NetworkManager.Get(false)
 			if err != nil {


### PR DESCRIPTION
Fix for:

```
fatal error: concurrent map writes
fatal error: concurrent map writes

goroutine 62964 [running]:
github.com/status-im/status-go/services/wallet.NewService.func1(0x66eed, {0x7f21469ad372, 0x2})
        /home/blade/work/projects/Status/status-desktop/vendor/status-go/services/wallet/service.go:76 +0x127
github.com/status-im/status-go/rpc/chain.(*ClientWithFallback).SetIsConnected(0x1c00185a900, 0x1)
        /home/blade/work/projects/Status/status-desktop/vendor/status-go/rpc/chain/client.go:147 +0xed
github.com/status-im/status-go/rpc/chain.(*ClientWithFallback).makeCallSingleReturn.func1()
        /home/blade/work/projects/Status/status-desktop/vendor/status-go/rpc/chain/client.go:210 +0x67
github.com/afex/hystrix-go/hystrix.Go.func1({0x1c001e35e90?, 0x7f21458ada86?})
        /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:57 +0x1b
github.com/afex/hystrix-go/hystrix.GoC.func3()
        /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:160 +0x1b5
created by github.com/afex/hystrix-go/hystrix.GoC
        /home/blade/work/projects/Status/status-desktop/vendor/status-go/vendor/github.com/afex/hystrix-go/hystrix/hystrix.go:116 +0x3ea

```
