### PR TITLE
Make sure image URL are preserved when deleting a message for me

### DIFF
--- a/protocol/messenger_messages.go
+++ b/protocol/messenger_messages.go
@@ -288,7 +288,10 @@ func (m *Messenger) DeleteMessageForMeAndSync(ctx context.Context, chatID string
 		if err != nil {
 			return nil, err
 		}
+
 		response.AddMessages(updatedMessages)
+
+		m.prepareMessages(response.messages)
 
 	}
 	response.AddChat(chat)


### PR DESCRIPTION
When deleting a message for me, the image url wasn't preserved, resulting in the image disappearing on the client side. This commit adds the processing of returned messages so that the image is preserved.

