### PR TITLE
fetch develop before checking

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -51,7 +51,7 @@ pipeline {
 
     stage('Migration') {
       steps { script {
-        nix.shell('make migration-check')
+        nix.shell('make migration-check', pure: false)
       } }
     }
 

--- a/_assets/scripts/migration_check.sh
+++ b/_assets/scripts/migration_check.sh
@@ -19,6 +19,7 @@ check_migration_order() {
   done
 }
 
+git fetch origin develop
 committed_files=$(git ls-tree -r --name-only HEAD protocol/migrations/sqlite/*.sql | sort)
 staged_files=$(git diff --name-only origin/develop protocol/migrations/sqlite/*.sql | sort)
 


### PR DESCRIPTION
fixed an issue with the check migration script where it would be checking against an outdate version of develop.
