### PR TITLE
Chore/community permissions integration tests

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -295,6 +295,10 @@ type Subscription struct {
 	DownloadingHistoryArchivesFinishedSignal *signal.DownloadingHistoryArchivesFinishedSignal
 	ImportingHistoryArchiveMessagesSignal    *signal.ImportingHistoryArchiveMessagesSignal
 	CommunityAdminEvent                      *protobuf.CommunityAdminEvent
+	MemberPermissionsCheckedSignal           *MemberPermissionsCheckedSignal
+}
+
+type MemberPermissionsCheckedSignal struct {
 }
 
 type CommunityResponse struct {
@@ -667,7 +671,6 @@ func (m *Manager) checkMemberPermissions(community *Community, removeAdmins bool
 	memberPermissions := len(becomeMemberPermissions) > 0
 
 	if !adminPermissions && !memberPermissions && !removeAdmins {
-		m.publish(&Subscription{Community: community})
 		return nil
 	}
 
@@ -741,7 +744,10 @@ func (m *Manager) checkMemberPermissions(community *Community, removeAdmins bool
 		}
 	}
 
-	m.publish(&Subscription{Community: community})
+	m.publish(&Subscription{
+		Community:                      community,
+		MemberPermissionsCheckedSignal: &MemberPermissionsCheckedSignal{},
+	})
 	return nil
 }
 

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -203,3 +203,18 @@ func joinCommunity(s *suite.Suite, community *communities.Community, owner *Mess
 	})
 	s.Require().NoError(err)
 }
+
+func sendChatMessage(s *suite.Suite, sender *Messenger, chatID string, text string) *common.Message {
+	msg := &common.Message{
+		ChatMessage: protobuf.ChatMessage{
+			ChatId:      chatID,
+			ContentType: protobuf.ChatMessage_TEXT_PLAIN,
+			Text:        text,
+		},
+	}
+
+	_, err := sender.SendChatMessage(context.Background(), msg)
+	s.Require().NoError(err)
+
+	return msg
+}


### PR DESCRIPTION
- cleaned up tests a bit
- added TestBecomeMemberPermissions integration test
    - if bob satisfy criteria, then bob can read channel messages
    - if bob doesn't satisfy criteria, then bob can't read channel messages
- fixed a bug, where ratchet key would be propagated to all members before doing permissions check
