### PR TITLE
feat: add cropping support for community token assets

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3778,8 +3778,8 @@ func (m *Messenger) GetAllCommunityTokens() ([]*communities.CommunityToken, erro
 	return m.communitiesManager.GetAllCommunityTokens()
 }
 
-func (m *Messenger) AddCommunityToken(token *communities.CommunityToken) (*communities.CommunityToken, error) {
-	return m.communitiesManager.AddCommunityToken(token)
+func (m *Messenger) AddCommunityToken(token *communities.CommunityToken, croppedImage *images.CroppedImage) (*communities.CommunityToken, error) {
+	return m.communitiesManager.AddCommunityToken(token, croppedImage)
 }
 
 func (m *Messenger) UpdateCommunityTokenState(chainID int, contractAddress string, deployState communities.DeployState) error {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -18,6 +18,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/mailserver"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol"
@@ -1305,8 +1306,8 @@ func (api *PublicAPI) GetAllCommunityTokens() ([]*communities.CommunityToken, er
 	return api.service.messenger.GetAllCommunityTokens()
 }
 
-func (api *PublicAPI) AddCommunityToken(token *communities.CommunityToken) (*communities.CommunityToken, error) {
-	return api.service.messenger.AddCommunityToken(token)
+func (api *PublicAPI) AddCommunityToken(token *communities.CommunityToken, croppedImage *images.CroppedImage) (*communities.CommunityToken, error) {
+	return api.service.messenger.AddCommunityToken(token, croppedImage)
 }
 
 func (api *PublicAPI) UpdateCommunityTokenState(chainID int, contractAddress string, deployState communities.DeployState) error {


### PR DESCRIPTION
This commit extends the `AddCommunityToken` API to also expect an optional `CroppedImage`, which will be used instead of the `ImageBase64` path provided by `CommunityToken`, to calculate the actual base64 encoded image.
