### PR TITLE
fix: mark community as no longer spectated when joined

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -928,6 +928,7 @@ func (o *Community) Edit(description *protobuf.CommunityDescription) {
 
 func (o *Community) Join() {
 	o.config.Joined = true
+	o.config.Spectated = false
 }
 
 func (o *Community) Leave() {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/11334


