### PR TITLE
fix(wallet) fix filtering failing with NULL values in to_address

### DIFF
--- a/services/wallet/activity/service.go
+++ b/services/wallet/activity/service.go
@@ -93,7 +93,7 @@ func (s *Service) FilterActivityAsync(ctx context.Context, addresses []common.Ad
 			res.ErrorCode = ErrorCodeSuccess
 		}
 
-		s.sendResponseEvent(EventActivityFilteringDone, res)
+		s.sendResponseEvent(EventActivityFilteringDone, res, err)
 	})
 }
 
@@ -126,7 +126,7 @@ func (s *Service) GetRecipientsAsync(ctx context.Context, offset int, limit int)
 			res.ErrorCode = ErrorCodeFailed
 		}
 
-		s.sendResponseEvent(EventActivityGetRecipientsDone, result)
+		s.sendResponseEvent(EventActivityGetRecipientsDone, result, err)
 	})
 }
 
@@ -151,7 +151,7 @@ func (s *Service) GetOldestTimestampAsync(ctx context.Context, addresses []commo
 			res.ErrorCode = ErrorCodeSuccess
 		}
 
-		s.sendResponseEvent(EventActivityGetOldestTimestampDone, res)
+		s.sendResponseEvent(EventActivityGetOldestTimestampDone, res, err)
 	})
 }
 
@@ -192,10 +192,12 @@ func (s *Service) getDeps() FilterDependencies {
 	}
 }
 
-func (s *Service) sendResponseEvent(eventType walletevent.EventType, payloadObj interface{}) {
+func (s *Service) sendResponseEvent(eventType walletevent.EventType, payloadObj interface{}, resErr error) {
 	payload, err := json.Marshal(payloadObj)
 	if err != nil {
-		log.Error("Error marshaling response: %v", err)
+		log.Error("Error marshaling response: %v; result error: %w", err, resErr)
+	} else {
+		err = resErr
 	}
 
 	log.Debug("wallet.api.activity.Service RESPONSE", "eventType", eventType, "error", err, "payload.len", len(payload))


### PR DESCRIPTION
### Found while working on status-desktop [#11233](https://github.com/status-im/status-desktop/issues/11233)

Added test to validate the fix

Also, change JOIN to LEFT JOIN between `multi_transactions` and `transactions` tables so that we return all entries from `multi_transactions` table even if there is no matching entry in `transactions` table, which might be the case for multi transactions that could not be detected. This will postpone the error case until we get into details of the multi-transaction.