### PR TITLE
fix(wallet) GetMultiTransactions for to_amount NULL in multi_transactions

### DIFF
--- a/services/wallet/activity/activity_test.go
+++ b/services/wallet/activity/activity_test.go
@@ -838,7 +838,7 @@ func TestGetActivityEntriesCheckToAndFrom(t *testing.T) {
 	deps, close := setupTestActivityDB(t)
 	defer close()
 
-	// Adds 6 transactions from which 4 are filered out
+	// Adds 6 transactions from which 4 are filtered out
 	td, _, _ := fillTestData(t, deps.db)
 
 	// Add extra transactions to test To address

--- a/services/wallet/transfer/transaction.go
+++ b/services/wallet/transfer/transaction.go
@@ -381,16 +381,15 @@ func (tm *TransactionManager) GetMultiTransactions(ctx context.Context, ids []Mu
 	var multiTransactions []*MultiTransaction
 	for rows.Next() {
 		multiTransaction := &MultiTransaction{}
-		var fromAmount string
-		var toAmount string
+		var fromAmountDB, toAmountDB sql.NullString
 		err := rows.Scan(
 			&multiTransaction.ID,
 			&multiTransaction.FromAddress,
 			&multiTransaction.FromAsset,
-			&fromAmount,
+			&fromAmountDB,
 			&multiTransaction.ToAddress,
 			&multiTransaction.ToAsset,
-			&toAmount,
+			&toAmountDB,
 			&multiTransaction.Type,
 			&multiTransaction.Timestamp,
 		)
@@ -398,16 +397,18 @@ func (tm *TransactionManager) GetMultiTransactions(ctx context.Context, ids []Mu
 			return nil, err
 		}
 
-		multiTransaction.FromAmount = new(hexutil.Big)
-		_, ok := (*big.Int)(multiTransaction.FromAmount).SetString(fromAmount, 0)
-		if !ok {
-			return nil, errors.New("failed to convert fromAmount to big.Int: " + fromAmount)
+		if fromAmountDB.Valid {
+			multiTransaction.FromAmount = new(hexutil.Big)
+			if _, ok := (*big.Int)(multiTransaction.FromAmount).SetString(fromAmountDB.String, 0); !ok {
+				return nil, errors.New("failed to convert fromAmountDB.String to big.Int: " + fromAmountDB.String)
+			}
 		}
 
-		multiTransaction.ToAmount = new(hexutil.Big)
-		_, ok = (*big.Int)(multiTransaction.ToAmount).SetString(toAmount, 0)
-		if !ok {
-			return nil, errors.New("failed to convert toAmount to big.Int: " + toAmount)
+		if toAmountDB.Valid {
+			multiTransaction.ToAmount = new(hexutil.Big)
+			if _, ok := (*big.Int)(multiTransaction.ToAmount).SetString(toAmountDB.String, 0); !ok {
+				return nil, errors.New("failed to convert fromAmountDB.String to big.Int: " + toAmountDB.String)
+			}
 		}
 
 		multiTransactions = append(multiTransactions, multiTransaction)


### PR DESCRIPTION
### Found while debugging [#11233](https://github.com/status-im/status-desktop/issues/11233)

After changes in https://github.com/status-im/status-go/pull/3712 we now retrieve dangling multi-transactions (a corner case). I found that some of those transactions have `to_asset` NULL, which is expected.