### PR TITLE
chore: remove unused `applicationLayer` parameter of `HandleMessages`

### DIFF
--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -647,7 +647,7 @@ func unwrapDatasyncMessage(m *v1protocol.StatusMessage, datasync *datasync.DataS
 // layer message, or in case of Raw methods, the processing stops at the layer
 // before.
 // It returns an error only if the processing of required steps failed.
-func (s *MessageSender) HandleMessages(shhMessage *types.Message, applicationLayer bool) ([]*v1protocol.StatusMessage, [][]byte, error) {
+func (s *MessageSender) HandleMessages(shhMessage *types.Message) ([]*v1protocol.StatusMessage, [][]byte, error) {
 	logger := s.logger.With(zap.String("site", "handleMessages"))
 	hlogger := logger.With(zap.ByteString("hash", shhMessage.Hash))
 	var statusMessage v1protocol.StatusMessage
@@ -715,11 +715,9 @@ func (s *MessageSender) HandleMessages(shhMessage *types.Message, applicationLay
 			hlogger.Error("failed to handle application metadata layer message", zap.Error(err))
 		}
 
-		if applicationLayer {
-			err = statusMessage.HandleApplication()
-			if err != nil {
-				hlogger.Error("failed to handle application layer message", zap.Error(err))
-			}
+		err = statusMessage.HandleApplication()
+		if err != nil {
+			hlogger.Error("failed to handle application layer message", zap.Error(err))
 		}
 	}
 

--- a/protocol/common/message_sender_test.go
+++ b/protocol/common/message_sender_test.go
@@ -114,7 +114,7 @@ func (s *MessageSenderSuite) TestHandleDecodedMessagesWrapped() {
 	message.Sig = crypto.FromECDSAPub(&relayerKey.PublicKey)
 	message.Payload = wrappedPayload
 
-	decodedMessages, _, err := s.sender.HandleMessages(message, true)
+	decodedMessages, _, err := s.sender.HandleMessages(message)
 	s.Require().NoError(err)
 
 	s.Require().Equal(1, len(decodedMessages))
@@ -150,7 +150,7 @@ func (s *MessageSenderSuite) TestHandleDecodedMessagesDatasync() {
 	message.Sig = crypto.FromECDSAPub(&relayerKey.PublicKey)
 	message.Payload = marshalledDataSyncMessage
 
-	decodedMessages, _, err := s.sender.HandleMessages(message, true)
+	decodedMessages, _, err := s.sender.HandleMessages(message)
 	s.Require().NoError(err)
 
 	// We send two messages, the unwrapped one will be attributed to the relayer, while the wrapped one will be attributed to the author
@@ -214,7 +214,7 @@ func (s *MessageSenderSuite) TestHandleDecodedMessagesDatasyncEncrypted() {
 	message.Sig = crypto.FromECDSAPub(&relayerKey.PublicKey)
 	message.Payload = encryptedPayload
 
-	decodedMessages, _, err := s.sender.HandleMessages(message, true)
+	decodedMessages, _, err := s.sender.HandleMessages(message)
 	s.Require().NoError(err)
 
 	// We send two messages, the unwrapped one will be attributed to the relayer,

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3248,7 +3248,7 @@ func (m *Messenger) handleImportedMessages(messagesToHandle map[transport.Filter
 	for filter, messages := range messagesToHandle {
 		for _, shhMessage := range messages {
 
-			statusMessages, _, err := m.sender.HandleMessages(shhMessage, true)
+			statusMessages, _, err := m.sender.HandleMessages(shhMessage)
 			if err != nil {
 				logger.Info("failed to decode messages", zap.Error(err))
 				continue
@@ -3397,7 +3397,7 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 				}
 			}
 
-			statusMessages, acks, err := m.sender.HandleMessages(shhMessage, true)
+			statusMessages, acks, err := m.sender.HandleMessages(shhMessage)
 			if err != nil {
 				logger.Info("failed to decode messages", zap.Error(err))
 				continue


### PR DESCRIPTION
There is no scenario where `applicationLayer` is set to false

