### PR TITLE
Send account/settings on login

### DIFF
--- a/appdatabase/database.go
+++ b/appdatabase/database.go
@@ -69,16 +69,16 @@ func DecryptDatabase(oldPath, newPath, password string, kdfIterationsNumber int)
 
 // EncryptDatabase creates an encrypted copy of the database and copies it to the
 // user path
-func EncryptDatabase(oldPath, newPath, password string, kdfIterationsNumber int) error {
-	return sqlite.EncryptDB(oldPath, newPath, password, kdfIterationsNumber)
+func EncryptDatabase(oldPath, newPath, password string, kdfIterationsNumber int, onStart func(), onEnd func()) error {
+	return sqlite.EncryptDB(oldPath, newPath, password, kdfIterationsNumber, onStart, onEnd)
 }
 
-func ExportDB(path string, password string, kdfIterationsNumber int, newDbPAth string, newPassword string) error {
-	return sqlite.ExportDB(path, password, kdfIterationsNumber, newDbPAth, newPassword)
+func ExportDB(path string, password string, kdfIterationsNumber int, newDbPAth string, newPassword string, onStart func(), onEnd func()) error {
+	return sqlite.ExportDB(path, password, kdfIterationsNumber, newDbPAth, newPassword, onStart, onEnd)
 }
 
-func ChangeDatabasePassword(path string, password string, kdfIterationsNumber int, newPassword string) error {
-	return sqlite.ChangeEncryptionKey(path, password, kdfIterationsNumber, newPassword)
+func ChangeDatabasePassword(path string, password string, kdfIterationsNumber int, newPassword string, onStart func(), onEnd func()) error {
+	return sqlite.ChangeEncryptionKey(path, password, kdfIterationsNumber, newPassword, onStart, onEnd)
 }
 
 // GetDBFilename takes an instance of sql.DB and returns the filename of the "main" database
@@ -205,8 +205,8 @@ func migrateEnsUsernames(sqlTx *sql.Tx) error {
 	return nil
 }
 
-func MigrateV3ToV4(v3Path string, v4Path string, password string, kdfIterationsNumber int) error {
-	return sqlite.MigrateV3ToV4(v3Path, v4Path, password, kdfIterationsNumber)
+func MigrateV3ToV4(v3Path string, v4Path string, password string, kdfIterationsNumber int, onStart func(), onEnd func()) error {
+	return sqlite.MigrateV3ToV4(v3Path, v4Path, password, kdfIterationsNumber, onStart, onEnd)
 }
 
 const (

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/status-im/status-go/server"
+	"github.com/status-im/status-go/signal"
 
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -314,7 +315,7 @@ func (b *StatusNode) wakuV2Service(nodeConfig *params.NodeConfig, telemetryServe
 			cfg.MaxMessageSize = nodeConfig.WakuV2Config.MaxMessageSize
 		}
 
-		w, err := wakuv2.New(nodeConfig.NodeKey, nodeConfig.ClusterConfig.Fleet, cfg, logutils.ZapLogger(), b.appDB, b.timeSource())
+		w, err := wakuv2.New(nodeConfig.NodeKey, nodeConfig.ClusterConfig.Fleet, cfg, logutils.ZapLogger(), b.appDB, b.timeSource(), signal.SendHistoricMessagesRequestFailed, signal.SendPeerStats)
 
 		if err != nil {
 			return nil, err

--- a/signal/events_node.go
+++ b/signal/events_node.go
@@ -1,5 +1,10 @@
 package signal
 
+import (
+	"github.com/status-im/status-go/multiaccounts"
+	"github.com/status-im/status-go/multiaccounts/settings"
+)
+
 const (
 	// EventNodeStarted is triggered when underlying node is started
 	EventNodeStarted = "node.started"
@@ -28,7 +33,9 @@ type NodeCrashEvent struct {
 
 // NodeLoginEvent returns the result of the login event
 type NodeLoginEvent struct {
-	Error string `json:"error,omitempty"`
+	Error    string                 `json:"error,omitempty"`
+	Settings *settings.Settings     `json:"settings,omitempty"`
+	Account  *multiaccounts.Account `json:"account,omitempty"`
 }
 
 // SendNodeCrashed emits a signal when status node has crashed, and
@@ -62,8 +69,8 @@ func SendChainDataRemoved() {
 	send(EventChainDataRemoved, nil)
 }
 
-func SendLoggedIn(err error) {
-	event := NodeLoginEvent{}
+func SendLoggedIn(account *multiaccounts.Account, settings *settings.Settings, err error) {
+	event := NodeLoginEvent{Settings: settings, Account: account}
 	if err != nil {
 		event.Error = err.Error()
 	}

--- a/signal/events_wakuv2.go
+++ b/signal/events_wakuv2.go
@@ -1,5 +1,7 @@
 package signal
 
+import "github.com/status-im/status-go/eth-node/types"
+
 const (
 	// EventPeerStats is sent when peer is added or removed.
 	// it will be a map with capability=peer count k/v's.
@@ -7,6 +9,6 @@ const (
 )
 
 // SendPeerStats sends discovery.summary signal.
-func SendPeerStats(peerStats interface{}) {
+func SendPeerStats(peerStats types.ConnStatus) {
 	send(EventPeerStats, peerStats)
 }

--- a/wakuv2/api_test.go
+++ b/wakuv2/api_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestMultipleTopicCopyInNewMessageFilter(t *testing.T) {
-	w, err := New("", "", nil, nil, nil, nil)
+	w, err := New("", "", nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Error creating WakuV2 client: %v", err)
 	}

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -28,7 +28,7 @@ func TestDiscoveryV5(t *testing.T) {
 	config.DiscV5BootstrapNodes = []string{testENRBootstrap}
 	config.DiscoveryLimit = 20
 	config.UDPPort = 9001
-	w, err := New("", "", config, nil, nil, nil)
+	w, err := New("", "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, w.Start())
@@ -53,7 +53,7 @@ func TestRestartDiscoveryV5(t *testing.T) {
 	config.DiscV5BootstrapNodes = []string{"enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@1.1.1.2"}
 	config.DiscoveryLimit = 20
 	config.UDPPort = 9002
-	w, err := New("", "", config, nil, nil, nil)
+	w, err := New("", "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, w.Start())
@@ -107,7 +107,7 @@ func TestBasicWakuV2(t *testing.T) {
 	config.DiscoveryLimit = 20
 	config.UDPPort = 9001
 	config.WakuNodes = []string{enrTreeAddress}
-	w, err := New("", "", config, nil, nil, nil)
+	w, err := New("", "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 
@@ -182,7 +182,7 @@ func TestWakuV2Filter(t *testing.T) {
 	config.UDPPort = 9001
 	config.WakuNodes = []string{enrTreeAddress}
 	fleet := "status.test" // Need a name fleet so that LightClient is not set to false
-	w, err := New("", fleet, config, nil, nil, nil)
+	w, err := New("", fleet, config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 


### PR DESCRIPTION
This PR adds sending account/settings in the login signal.

I had to change the way we signal database encryption because of a circular dependency (sqlite depended on signals, signals depends on high level stuff which in turns depends on sqlite). 
The change is to pass a couple of function onStart onEnd, which makes sense as sqlite is low level while signal is higher abstraction. 