### PR TITLE
Refactor/community naming cleanup

### DIFF
--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -370,15 +370,14 @@ func (s *ManagerSuite) TestEditCommunity() {
 	s.Require().Equal(storedCommunity.config.CommunityDescription.Identity.Description, update.CreateCommunity.Description)
 }
 
-func (s *ManagerSuite) TestGetAdminCommuniesChatIDs() {
-
+func (s *ManagerSuite) TestGetControlledCommunitiesChatIDs() {
 	community, _, err := s.buildCommunityWithChat()
 	s.Require().NoError(err)
 	s.Require().NotNil(community)
 
-	adminChatIDs, err := s.manager.GetAdminCommunitiesChatIDs()
+	controlledChatIDs, err := s.manager.GetControlledCommunitiesChatIDs()
 	s.Require().NoError(err)
-	s.Require().Len(adminChatIDs, 1)
+	s.Require().Len(controlledChatIDs, 1)
 }
 
 func (s *ManagerSuite) TestStartAndStopTorrentClient() {

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -255,7 +255,7 @@ WHERE NOT c.Joined AND (r.community_id IS NULL or r.state != ?)`
 	return p.rowsToCommunities(memberIdentity, rows)
 }
 
-func (p *Persistence) CreatedCommunities(memberIdentity *ecdsa.PublicKey) ([]*Community, error) {
+func (p *Persistence) CommunitiesWithPrivateKey(memberIdentity *ecdsa.PublicKey) ([]*Community, error) {
 	query := communitiesBaseQuery + ` WHERE c.private_key IS NOT NULL`
 	return p.queryCommunities(memberIdentity, query)
 }


### PR DESCRIPTION
- use `IsOwner` instead of `config.privateKey != nil`
- improve community functions naming