### PR TITLE
fix: fix returning correctly when the password is incorrect

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -721,13 +721,12 @@ func (b *GethStatusBackend) StartNodeWithAccount(acc multiaccounts.Account, pass
 	if err != nil {
 		// Stop node for clean up
 		_ = b.StopNode()
-		return err
 	}
 	// get logged in
 	if !b.localPairing {
 		return b.LoggedIn(acc.KeyUID, err)
 	}
-	return nil
+	return err
 }
 
 func (b *GethStatusBackend) LoggedIn(keyUID string, err error) error {


### PR DESCRIPTION
This PR (https://github.com/status-im/status-go/pull/3722) introduced a small bug where entering an incorrect password would make the login process just spin forever (not returning).

I don't know the logic super well @cammellos so please check it out (it's pretty small)