### PR TITLE
fix: ensure correct initialization order for wallet and mesenger services

### DIFF
--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -51,7 +51,6 @@ func NewService(
 	ens *ens.Service,
 	stickers *stickers.Service,
 	rpcFilterSrvc *rpcfilters.Service,
-	nftMetadataProvider thirdparty.NFTMetadataProvider,
 ) *Service {
 	cryptoOnRampManager := NewCryptoOnRampManager(&CryptoOnRampOptions{
 		dataSourceType: DataSourceStatic,
@@ -107,7 +106,7 @@ func NewService(
 
 	alchemyClient := alchemy.NewClient(config.WalletConfig.AlchemyAPIKeys)
 	infuraClient := infura.NewClient(config.WalletConfig.InfuraAPIKey, config.WalletConfig.InfuraAPIKeySecret)
-	collectiblesManager := collectibles.NewManager(rpcClient, alchemyClient, infuraClient, nftMetadataProvider, config.WalletConfig.OpenseaAPIKey, walletFeed)
+	collectiblesManager := collectibles.NewManager(rpcClient, alchemyClient, infuraClient, config.WalletConfig.OpenseaAPIKey, walletFeed)
 	return &Service{
 		db:                    db,
 		accountsDB:            accountsDB,
@@ -179,6 +178,11 @@ func (s *Service) Start() error {
 // GetFeed returns signals feed.
 func (s *Service) GetFeed() *event.Feed {
 	return s.transferController.TransferFeed
+}
+
+// Set external Collectibles metadata provider
+func (s *Service) SetNFTMetadataProvider(provider thirdparty.NFTMetadataProvider) {
+	s.collectiblesManager.SetMetadataProvider(provider)
 }
 
 // Stop reactor and close db.


### PR DESCRIPTION
We've got a circular dependency between Messenger and Wallet.

```
	// CollectiblesManager needs the WakuExt service to get metadata for
	// Community collectibles.
	// Messenger needs the CollectiblesManager to get the list of collectibles owned
	// by a certain account and check community entry permissions.
```

There's probably a more proper way of handling this, but for now we simply inject the NFTMetadataProvider (WakuExt) instance to the WalletService after both objects have been instanced.

