### PR TITLE
Feat/multi chain collectible ownership provider

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -422,8 +422,17 @@ func NewMessenger(
 
 	ensVerifier := ens.New(node, logger, transp, database, c.verifyENSURL, c.verifyENSContractAddress)
 
+	var walletAPI *wallet.API
+	if c.walletService != nil {
+		walletAPI = wallet.NewAPI(c.walletService)
+	}
+
 	managerOptions := []communities.ManagerOption{
 		communities.WithAccountManager(accountsManager),
+	}
+
+	if walletAPI != nil {
+		managerOptions = append(managerOptions, communities.WithCollectiblesManager(walletAPI))
 	}
 
 	if c.tokenManager != nil {
@@ -535,7 +544,7 @@ func NewMessenger(
 	messenger.mentionsManager = NewMentionManager(messenger)
 
 	if c.walletService != nil {
-		messenger.walletAPI = wallet.NewAPI(c.walletService)
+		messenger.walletAPI = walletAPI
 	}
 
 	if c.outputMessagesCSV {

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -336,6 +336,11 @@ func (api *API) GetCollectibleOwnersByContractAddress(chainID uint64, contractAd
 	return api.s.collectiblesManager.FetchNFTOwnersByContractAddress(chainID, contractAddress)
 }
 
+func (api *API) FetchBalancesByOwnerAndContractAddress(chainID uint64, ownerAddress common.Address, contractAddresses []common.Address) (thirdparty.TokenBalancesPerContractAddress, error) {
+	log.Debug("call to FetchBalancesByOwnerAndContractAddress")
+	return api.s.collectiblesManager.FetchBalancesByOwnerAndContractAddress(chainID, ownerAddress, contractAddresses)
+}
+
 func (api *API) AddEthereumChain(ctx context.Context, network params.Network) error {
 	log.Debug("call to AddEthereumChain")
 	return api.s.rpcClient.NetworkManager.Upsert(&network)

--- a/services/wallet/thirdparty/types.go
+++ b/services/wallet/thirdparty/types.go
@@ -67,6 +67,8 @@ type TokenBalance struct {
 	Balance *bigint.BigInt `json:"balance"`
 }
 
+type TokenBalancesPerContractAddress = map[common.Address][]TokenBalance
+
 type NFTOwner struct {
 	OwnerAddress  common.Address `json:"ownerAddress"`
 	TokenBalances []TokenBalance `json:"tokenBalances"`


### PR DESCRIPTION
The OpenSea V1 API only provides info for the Ethereum Main/Test chains (no Arbitrum and Optimism). This caused membership requests for Optimism/Arbitrum NFT-gated communities not to be sent, due to the checks not passing, even when the user owned the needed collectibles on those chains.

For now, we use Infura+Alchemy endpoints we already support to supplement OpenSea in the new method `FetchBalancesByOwnerAndContractAddress`. This is a bit inefficient, since those endpoints return the full list of owners for a given contract instead of just the wallet address we're interested in. Finding and using a more proper endpoint is left for a future PR.

We also now use the Wallet Service instead of a new instance of the OpenSea client in the Community manager.