### PR TITLE
fix: only save/send request to join when the permissions are satisfied

### DIFF
--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -3123,7 +3123,7 @@ func (s *MessengerCommunitiesSuite) TestCommunityBanUserRequesToJoin() {
 
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
 	// We try to join the org
-	_, rtj, err := s.alice.communitiesManager.RequestToJoin(&s.alice.identity.PublicKey, request)
+	_, rtj, err := s.alice.communitiesManager.CreateRequestToJoin(&s.alice.identity.PublicKey, request)
 
 	s.Require().NoError(err)
 


### PR DESCRIPTION
There were two problems. 

1. We were saving the request to join to the user's DB before the permissions were checked, so if those errored or were not satisfied, we still saved it, creating a weird scenario where the user would think the request was sent, but it wasn't.
2. We still sent the request to join even if the user didn't satisfy the permission to join. In theory, the UI blocks that behaviour, but the backend should enforce it. 

I upgraded the "join with permission" test to validate those behaviours above. 
