### PR TITLE
[CHERRY-PICK] Don't panic if config is nil in community

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -698,7 +698,7 @@ func (o *Community) hasMemberPermission(member *protobuf.CommunityMember, permis
 }
 
 func (o *Community) hasPermission(pk *ecdsa.PublicKey, roles map[protobuf.CommunityMember_Roles]bool) bool {
-	if pk == nil || o.config.ID == nil {
+	if pk == nil || o.config == nil || o.config.ID == nil {
 		return false
 	}
 

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1356,6 +1356,10 @@ func (m *Manager) HandleCommunityAdminEvent(signer *ecdsa.PublicKey, adminEvent 
 		return nil, err
 	}
 
+	if community == nil {
+		return nil, ErrOrgNotFound
+	}
+
 	if !community.IsMemberAdmin(signer) {
 		return nil, errors.New("user is not an admin")
 	}


### PR DESCRIPTION
Gonna fix https://github.com/status-im/status-desktop/issues/11533

Cherry-pick of https://github.com/status-im/status-go/commit/3f5f87d1d1551b2570cb662fcd9cefc051096aa

I have encountered a crash in the app after syncing, looks like a community has been created without a Config.
This crashes the app after the user logs in.
This commit prevents the app from crashing, but does not fix the underlaying issue (that's something I will have to investigate). Added tests to validate the behavior.