### PR TITLE
fix(handleSyncKeypair): skip empty keypairs

### DIFF
--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -3085,6 +3085,11 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair) (*accounts.
 	if message == nil {
 		return nil, errors.New("handleSyncKeypair receive a nil message")
 	}
+
+	if message.KeyUid == "" {
+		return nil, errors.New("empty KeyUID")
+	}
+
 	dbKeypair, err := m.settings.GetKeypairByKeyUID(message.KeyUid)
 	if err != nil && err != accounts.ErrDbKeypairNotFound {
 		return nil, err


### PR DESCRIPTION
This is a hotfix for https://github.com/status-im/status-desktop/issues/11533.

As it turned out, after pairing mobile->desktop the latter would receive an and empty `SyncKeypair` message. 
This was leading to a status-desktop crash at some point.

I couldn't quickly find the source of such empty sync keypairs being sent. 
But I also couldn't reproduce the issue on latest status-desktop master. So I suppose it's ok to push such a hotfix with 0.13.1.
