### PR TITLE
fix: Mutual state update messages are always seen

### DIFF
--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -78,7 +78,7 @@ func (m *Messenger) prepareMutualStateUpdateMessage(contactID string, updateType
 		From:             from,
 		WhisperTimestamp: timestamp,
 		LocalChatID:      contactID,
-		Seen:             outgoing,
+		Seen:             true,
 		ID:               types.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s%s%d%d", from, to, updateType, clock)))),
 	}
 


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/11580

Important changes:
- [x] Mutual state update messages are always seen

