### PR TITLE
Feat/channels encryption

### DIFF
--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -285,7 +285,7 @@ func (s *MessageSender) sendCommunity(
 	// Check if it's a key exchange message. In this case we send it
 	// to all the recipients
 	if rawMessage.CommunityKeyExMsgType != KeyExMsgNone {
-		keyExMessageSpecs, err := s.protocol.GetKeyExMessageSpecs(rawMessage.CommunityID, s.identity, rawMessage.Recipients, rawMessage.CommunityKeyExMsgType == KeyExMsgRekey)
+		keyExMessageSpecs, err := s.protocol.GetKeyExMessageSpecs(rawMessage.HashRatchetGroupID, s.identity, rawMessage.Recipients, rawMessage.CommunityKeyExMsgType == KeyExMsgRekey)
 		if err != nil {
 			return nil, err
 		}
@@ -307,7 +307,7 @@ func (s *MessageSender) sendCommunity(
 
 	// If it's a chat message, we send it on the community chat topic
 	if ShouldCommunityMessageBeEncrypted(rawMessage.MessageType) {
-		messageSpec, err := s.protocol.BuildHashRatchetMessage(rawMessage.CommunityID, wrappedMessage)
+		messageSpec, err := s.protocol.BuildHashRatchetMessage(rawMessage.HashRatchetGroupID, wrappedMessage)
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/common/raw_message.go
+++ b/protocol/common/raw_message.go
@@ -35,4 +35,5 @@ type RawMessage struct {
 	CommunityKeyExMsgType CommKeyExMsgType
 	Ephemeral             bool
 	BeforeDispatch        func(*RawMessage) error
+	HashRatchetGroupID    []byte
 }

--- a/protocol/communities/community_encryption_key_action.go
+++ b/protocol/communities/community_encryption_key_action.go
@@ -63,7 +63,9 @@ func evaluateCommunityLevelEncryptionKeyAction(origin, modified *Community, chan
 func evaluateChannelLevelEncryptionKeyActions(origin, modified *Community, changes *CommunityChanges) *map[string]EncryptionKeyAction {
 	result := make(map[string]EncryptionKeyAction)
 
-	for chatID := range modified.config.CommunityDescription.Chats {
+	for channelID := range modified.config.CommunityDescription.Chats {
+		chatID := modified.IDString() + channelID
+
 		originChannelViewOnlyPermissions := origin.ChannelTokenPermissionsByType(chatID, protobuf.CommunityTokenPermission_CAN_VIEW_CHANNEL)
 		originChannelViewAndPostPermissions := origin.ChannelTokenPermissionsByType(chatID, protobuf.CommunityTokenPermission_CAN_VIEW_AND_POST_CHANNEL)
 		originChannelPermissions := append(originChannelViewOnlyPermissions, originChannelViewAndPostPermissions...)
@@ -75,13 +77,13 @@ func evaluateChannelLevelEncryptionKeyActions(origin, modified *Community, chang
 		membersAdded := make(map[string]*protobuf.CommunityMember)
 		membersRemoved := make(map[string]*protobuf.CommunityMember)
 
-		chatChanges, ok := changes.ChatsModified[chatID]
+		chatChanges, ok := changes.ChatsModified[channelID]
 		if ok {
 			membersAdded = chatChanges.MembersAdded
 			membersRemoved = chatChanges.MembersRemoved
 		}
 
-		result[chatID] = *evaluateEncryptionKeyAction(originChannelPermissions, modifiedChannelPermissions, modified.config.CommunityDescription.Members, membersAdded, membersRemoved)
+		result[channelID] = *evaluateEncryptionKeyAction(originChannelPermissions, modifiedChannelPermissions, modified.config.CommunityDescription.Chats[channelID].Members, membersAdded, membersRemoved)
 	}
 
 	return &result

--- a/protocol/communities_key_distributor.go
+++ b/protocol/communities_key_distributor.go
@@ -29,9 +29,9 @@ func (ckd *CommunitiesKeyDistributorImpl) Distribute(community *communities.Comm
 		return err
 	}
 
-	for chatID := range keyActions.ChannelKeysActions {
-		keyAction := keyActions.ChannelKeysActions[chatID]
-		err := ckd.distributeKey(community.ID(), []byte(chatID), &keyAction)
+	for channelID := range keyActions.ChannelKeysActions {
+		keyAction := keyActions.ChannelKeysActions[channelID]
+		err := ckd.distributeKey(community.ID(), []byte(community.IDString()+channelID), &keyAction)
 		if err != nil {
 			return err
 		}
@@ -83,6 +83,7 @@ func (ckd *CommunitiesKeyDistributorImpl) sendKeyExchangeMessage(communityID, ha
 		CommunityKeyExMsgType: msgType,
 		Recipients:            pubkeys,
 		MessageType:           protobuf.ApplicationMetadataMessage_CHAT_MESSAGE,
+		HashRatchetGroupID:    hashRatchetGroupID,
 	}
 	_, err := ckd.sender.SendCommunityMessage(context.Background(), rawMessage)
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -810,7 +810,7 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 
 			for _, c := range adminCommunities {
 				if c.Joined() && c.HasTokenPermissions() {
-					go m.communitiesManager.CheckMemberPermissionsPeriodically(c.ID())
+					go m.communitiesManager.ReevaluateMembersPeriodically(c.ID())
 				}
 			}
 		}
@@ -2051,21 +2051,36 @@ func (m *Messenger) dispatchMessage(ctx context.Context, rawMessage common.RawMe
 		}
 
 		logger.Debug("sending community chat message", zap.String("chatName", chat.Name))
-		isEncrypted, err := m.communitiesManager.IsEncrypted(chat.CommunityID)
+		isCommunityEncrypted, err := m.communitiesManager.IsEncrypted(chat.CommunityID)
 		if err != nil {
 			return rawMessage, err
 		}
+		isChannelEncrypted, err := m.communitiesManager.IsChannelEncrypted(chat.CommunityID, chat.ID)
+		if err != nil {
+			return rawMessage, err
+		}
+		isEncrypted := isCommunityEncrypted || isChannelEncrypted
 		if !isEncrypted {
 			id, err = m.sender.SendPublic(ctx, chat.ID, rawMessage)
+			if err != nil {
+				return rawMessage, err
+			}
 		} else {
 			rawMessage.CommunityID, err = types.DecodeHex(chat.CommunityID)
-
-			if err == nil {
-				id, err = m.sender.SendCommunityMessage(ctx, rawMessage)
+			if err != nil {
+				return rawMessage, err
 			}
-		}
-		if err != nil {
-			return rawMessage, err
+
+			if isChannelEncrypted {
+				rawMessage.HashRatchetGroupID = []byte(chat.ID)
+			} else {
+				rawMessage.HashRatchetGroupID = rawMessage.CommunityID
+			}
+
+			id, err = m.sender.SendCommunityMessage(ctx, rawMessage)
+			if err != nil {
+				return rawMessage, err
+			}
 		}
 	case ChatTypePrivateGroupChat:
 		logger.Debug("sending group message", zap.String("chatName", chat.Name))


### PR DESCRIPTION
Introduced channel-level encryption.

- distribute ratchet keys at both community and channel levels
- use explicit `HashRatchetGroupID` in ecryption layer, instead of
  inheriting `groupID` from `CommunityID`
- populate `HashRatchetGroupID` with `CommunityID+ChannelID` for
  channels, and `CommunityID` for whole community
- hydrate channels with members; channel members are now subset of
  community members
- include channel permissions in periodic permissions check

closes: https://github.com/status-im/status-desktop/issues/10998