### PR TITLE
feat: introduce messenger API to remove community tokens

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -3937,6 +3937,10 @@ func (m *Manager) UpdateCommunityTokenSupply(chainID int, contractAddress string
 	return m.persistence.UpdateCommunityTokenSupply(chainID, contractAddress, supply)
 }
 
+func (m *Manager) RemoveCommunityToken(chainID int, contractAddress string) error {
+	return m.persistence.RemoveCommunityToken(chainID, contractAddress)
+}
+
 func (m *Manager) SetCommunityActiveMembersCount(communityID string, activeMembersCount uint64) error {
 	community, err := m.GetByIDString(communityID)
 	if err != nil {

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -1251,6 +1251,11 @@ func (p *Persistence) UpdateCommunityTokenSupply(chainID int, contractAddress st
 	return err
 }
 
+func (p *Persistence) RemoveCommunityToken(chainID int, contractAddress string) error {
+	_, err := p.db.Exec(`DELETE FROM community_tokens WHERE chain_id = ? AND address = ?`, chainID, contractAddress)
+	return err
+}
+
 func decodeCommunityDescription(descriptionBytes []byte) (*protobuf.CommunityDescription, error) {
 	metadata := &protobuf.ApplicationMetadataMessage{}
 

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4078,6 +4078,10 @@ func (m *Messenger) UpdateCommunityTokenSupply(chainID int, contractAddress stri
 	return m.communitiesManager.UpdateCommunityTokenSupply(chainID, contractAddress, supply)
 }
 
+func (m *Messenger) RemoveCommunityToken(chainID int, contractAddress string) error {
+	return m.communitiesManager.RemoveCommunityToken(chainID, contractAddress)
+}
+
 // UpdateCommunityEncryption takes a communityID string and an encryption state, then finds the community and
 // encrypts / decrypts the community. Community is republished along with any keys if needed.
 //

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1341,6 +1341,10 @@ func (api *PublicAPI) UpdateCommunityTokenSupply(chainID int, contractAddress st
 	return api.service.messenger.UpdateCommunityTokenSupply(chainID, contractAddress, supply)
 }
 
+func (api *PublicAPI) RemoveCommunityToken(chainID int, contractAddress string) error {
+	return api.service.messenger.RemoveCommunityToken(chainID, contractAddress)
+}
+
 func (api *PublicAPI) ToggleCollapsedCommunityCategory(request *requests.ToggleCollapsedCommunityCategory) error {
 	return api.service.messenger.ToggleCollapsedCommunityCategory(request)
 }


### PR DESCRIPTION
This is to allow users to remove a community token if the deployment transaction has been rejected.

