### PR TITLE
!refactor: introduce `SaveCommunityToken()` and change `AddCommunityToken()`

### DIFF
--- a/protocol/communities/persistence_test.go
+++ b/protocol/communities/persistence_test.go
@@ -373,6 +373,35 @@ func (s *PersistenceSuite) TestUpdateCommunitySettings() {
 	s.Equal(settings, rst)
 }
 
+func (s *PersistenceSuite) TestGetCommunityToken() {
+	tokens, err := s.db.GetCommunityTokens("123")
+	s.Require().NoError(err)
+	s.Require().Len(tokens, 0)
+
+	tokenERC721 := CommunityToken{
+		CommunityID:        "123",
+		TokenType:          protobuf.CommunityTokenType_ERC721,
+		Address:            "0x123",
+		Name:               "StatusToken",
+		Symbol:             "STT",
+		Description:        "desc",
+		Supply:             &bigint.BigInt{Int: big.NewInt(123)},
+		InfiniteSupply:     false,
+		Transferable:       true,
+		RemoteSelfDestruct: true,
+		ChainID:            1,
+		DeployState:        InProgress,
+		Base64Image:        "ABCD",
+	}
+
+	err = s.db.AddCommunityToken(&tokenERC721)
+	s.Require().NoError(err)
+
+	token, err := s.db.GetCommunityToken("123", 1, "0x123")
+	s.Require().NoError(err)
+	s.Require().Equal(&tokenERC721, token)
+}
+
 func (s *PersistenceSuite) TestGetCommunityTokens() {
 	tokens, err := s.db.GetCommunityTokens("123")
 	s.Require().NoError(err)

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4062,8 +4062,12 @@ func (m *Messenger) GetAllCommunityTokens() ([]*communities.CommunityToken, erro
 	return m.communitiesManager.GetAllCommunityTokens()
 }
 
-func (m *Messenger) AddCommunityToken(token *communities.CommunityToken, croppedImage *images.CroppedImage) (*communities.CommunityToken, error) {
-	return m.communitiesManager.AddCommunityToken(token, croppedImage)
+func (m *Messenger) SaveCommunityToken(token *communities.CommunityToken, croppedImage *images.CroppedImage) (*communities.CommunityToken, error) {
+	return m.communitiesManager.SaveCommunityToken(token, croppedImage)
+}
+
+func (m *Messenger) AddCommunityToken(communityID string, chainID int, address string) error {
+	return m.communitiesManager.AddCommunityToken(communityID, chainID, address)
 }
 
 func (m *Messenger) UpdateCommunityTokenState(chainID int, contractAddress string, deployState communities.DeployState) error {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1325,8 +1325,12 @@ func (api *PublicAPI) GetAllCommunityTokens() ([]*communities.CommunityToken, er
 	return api.service.messenger.GetAllCommunityTokens()
 }
 
-func (api *PublicAPI) AddCommunityToken(token *communities.CommunityToken, croppedImage *images.CroppedImage) (*communities.CommunityToken, error) {
-	return api.service.messenger.AddCommunityToken(token, croppedImage)
+func (api *PublicAPI) SaveCommunityToken(token *communities.CommunityToken, croppedImage *images.CroppedImage) (*communities.CommunityToken, error) {
+	return api.service.messenger.SaveCommunityToken(token, croppedImage)
+}
+
+func (api *PublicAPI) AddCommunityToken(communityID string, chainID int, address string) error {
+	return api.service.messenger.AddCommunityToken(communityID, chainID, address)
 }
 
 func (api *PublicAPI) UpdateCommunityTokenState(chainID int, contractAddress string, deployState communities.DeployState) error {


### PR DESCRIPTION
**This is a breaking change!**

Prior to this commit we had `AddCommunityToken(token *communities, croppedImage CroppedImage)` that we used to

1. add a `CommunityToken` to the user's database and
2. to create a `CommunityTokenMetadata` from it which is then added to the community's `CommunityDescription` and published to its members

However, I've then discovered that we need to separate these two things, such that we can deploy a community token, then add it to the database only for tracking purposes, **then** add it to the community description (and propagate to members) once we know that the deploy tx indeed went through.

To implement this, this commit introduces a new API `SaveCommunityToken(token *communities.CommunityToken, croppedImage CroppedImage)` which adds the token to the database only and doesn't touch the community description.

The `AddCommunityToken` API is then changed that it's exclusively used for adding an already saved `CommunityToken` to the community description so it can be published to members. Hence, the signature is now `AddCommunityToken(communityID string, chainID int, address string)`, which makes this a breaking change.

Clients that used `AddCommunityToken()` before now need to ensure that they first call `SaveCommunityToken()` as `AddCommunityToken()` will fail otherwise.

