### PR TITLE
feat: Collecting community messages count metrics

### DIFF
--- a/protocol/messenger_community_metrics.go
+++ b/protocol/messenger_community_metrics.go
@@ -55,6 +55,7 @@ func (m *Messenger) collectCommunityMessagesTimestamps(request *requests.Communi
 			StartTimestamp: sourceInterval.StartTimestamp,
 			EndTimestamp:   sourceInterval.EndTimestamp,
 			Timestamps:     timestamps,
+			Count:          len(timestamps),
 		}
 	}
 

--- a/protocol/messenger_community_metrics.go
+++ b/protocol/messenger_community_metrics.go
@@ -1,0 +1,76 @@
+package protocol
+
+import (
+	"errors"
+
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/protocol/requests"
+)
+
+type CommunityMetricsResponse struct {
+	Type        requests.CommunityMetricsRequestType `json:"type"`
+	CommunityID types.HexBytes                       `json:"communityId"`
+	Entries     map[uint64]int32                     `json:"entries"`
+}
+
+func initRangesMap(start uint64, end uint64, step uint64) map[uint64]int32 {
+	result := map[uint64]int32{}
+	for timestamp := start; timestamp <= end; timestamp += step {
+		result[timestamp] = 0
+	}
+	return result
+}
+
+func floorToRange(value uint64, start uint64, end uint64, step uint64) uint64 {
+	for timestamp := start; timestamp <= end; timestamp += step {
+		if value <= timestamp {
+			return timestamp
+		}
+	}
+	return 0
+}
+
+func (m *Messenger) collectCommunityMessagesMetrics(request *requests.CommunityMetricsRequest) (*CommunityMetricsResponse, error) {
+	community, err := m.GetCommunityByID(request.CommunityID)
+	if err != nil {
+		return nil, err
+	}
+
+	if community == nil {
+		return nil, errors.New("no community found")
+	}
+
+	// TODO: timestamp summary should be stored in special table, not calculated here
+	timestamps, err := m.persistence.FetchMessageTimestampsForChatsByPeriod(community.ChatIDs(), request.StartTimestamp, request.EndTimestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	timestampStep := (request.EndTimestamp - request.StartTimestamp) / uint64(request.MaxCount)
+	entries := initRangesMap(request.StartTimestamp, request.EndTimestamp, timestampStep)
+
+	for _, timestamp := range timestamps {
+		entries[floorToRange(timestamp, request.StartTimestamp, request.EndTimestamp, timestampStep)] += 1
+	}
+
+	response := &CommunityMetricsResponse{
+		Type:        request.Type,
+		CommunityID: request.CommunityID,
+		Entries:     entries,
+	}
+
+	return response, nil
+}
+
+func (m *Messenger) CollectCommunityMetrics(request *requests.CommunityMetricsRequest) (*CommunityMetricsResponse, error) {
+	if err := request.Validate(); err != nil {
+		return nil, err
+	}
+
+	switch request.Type {
+	case requests.CommunityMetricsRequestMessages:
+		return m.collectCommunityMessagesMetrics(request)
+	default:
+		return nil, errors.New("metrics is not implemented yet")
+	}
+}

--- a/protocol/messenger_community_metrics_test.go
+++ b/protocol/messenger_community_metrics_test.go
@@ -1,0 +1,30 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/status-im/status-go/protocol/requests"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestMessengerCommunityMetricsSuite(t *testing.T) {
+	suite.Run(t, new(MessengerCommunityMetricsSuite))
+}
+
+type MessengerCommunityMetricsSuite struct {
+	MessengerBaseTestSuite
+}
+
+func (s *MessengerCommunityMetricsSuite) TestCollectCommunityMessageMetrics() {
+	request := &requests.CommunityMetricsRequest{
+		CommunityID:    []byte("0x654321"),
+		Type:           requests.CommunityMetricsRequestMessages,
+		StartTimestamp: 1690279200,
+		EndTimestamp:   1690282800, // one hour
+		MaxCount:       10,
+	}
+	// Send contact request
+	resp, err := s.m.CollectCommunityMetrics(request)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+}

--- a/protocol/messenger_community_metrics_test.go
+++ b/protocol/messenger_community_metrics_test.go
@@ -117,6 +117,30 @@ func (s *MessengerCommunityMetricsSuite) generateMessages(chatID string, communi
 	s.Require().NoError(err)
 }
 
+func (s *MessengerCommunityMetricsSuite) TestCollectCommunityMetricsInvalidRequest() {
+	community, _ := s.prepareCommunityAndChatIDs()
+
+	request := &requests.CommunityMetricsRequest{
+		CommunityID: community.ID(),
+		Type:        requests.CommunityMetricsRequestMessagesTimestamps,
+		Intervals: []requests.MetricsIntervalRequest{
+			requests.MetricsIntervalRequest{
+				StartTimestamp: 1690372400,
+				EndTimestamp:   1690371800,
+			},
+			requests.MetricsIntervalRequest{
+				StartTimestamp: 1690371900,
+				EndTimestamp:   1690373000,
+			},
+		},
+	}
+
+	// Expect error
+	_, err := s.m.CollectCommunityMetrics(request)
+	s.Require().Error(err)
+	s.Require().Equal(err, requests.ErrInvalidTimestampIntervals)
+}
+
 func (s *MessengerCommunityMetricsSuite) TestCollectCommunityMetricsEmptyInterval() {
 	community, _ := s.prepareCommunityAndChatIDs()
 

--- a/protocol/messenger_community_metrics_test.go
+++ b/protocol/messenger_community_metrics_test.go
@@ -189,6 +189,10 @@ func (s *MessengerCommunityMetricsSuite) TestCollectCommunityMessagesTimestamps(
 
 	s.Require().Len(resp.Intervals, 3)
 
+	s.Require().Equal(resp.Intervals[0].Count, 3)
+	s.Require().Equal(resp.Intervals[1].Count, 2)
+	s.Require().Equal(resp.Intervals[2].Count, 1)
+
 	s.Require().Equal(resp.Intervals[0].Timestamps, []uint64{1690372000, 1690372100, 1690372200})
 	s.Require().Equal(resp.Intervals[1].Timestamps, []uint64{1690372700, 1690372800})
 	s.Require().Equal(resp.Intervals[2].Timestamps, []uint64{1690373000})

--- a/protocol/messenger_community_metrics_test.go
+++ b/protocol/messenger_community_metrics_test.go
@@ -1,8 +1,14 @@
 package protocol
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/stretchr/testify/suite"
 )
@@ -15,16 +21,186 @@ type MessengerCommunityMetricsSuite struct {
 	MessengerBaseTestSuite
 }
 
-func (s *MessengerCommunityMetricsSuite) TestCollectCommunityMessageMetrics() {
+func (s *MessengerCommunityMetricsSuite) prepareCommunity() *communities.Community {
+	description := &requests.CreateCommunity{
+		Membership:  protobuf.CommunityPermissions_NO_MEMBERSHIP,
+		Name:        "status",
+		Color:       "#ffffff",
+		Description: "status community description",
+	}
+	response, err := s.m.CreateCommunity(description, true)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+	s.Require().Len(response.Communities(), 1)
+
+	return response.Communities()[0]
+}
+
+func (s *MessengerCommunityMetricsSuite) generateMessages(chatID string, communityID string, timestamps []uint64) {
+	var messages []*common.Message
+	for i, timestamp := range timestamps {
+		message := &common.Message{
+			ChatMessage: protobuf.ChatMessage{
+				ChatId:      chatID,
+				Text:        fmt.Sprintf("Test message %d", i),
+				MessageType: protobuf.MessageType_ONE_TO_ONE,
+				// NOTE: should we filter content types for messages metrics
+				Clock:     timestamp,
+				Timestamp: timestamp,
+			},
+			WhisperTimestamp: timestamp,
+			From:             common.PubkeyToHex(&s.m.identity.PublicKey),
+			LocalChatID:      chatID,
+			CommunityID:      communityID,
+			ID:               types.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s%s%d", chatID, communityID, timestamp)))),
+		}
+
+		err := message.PrepareContent(common.PubkeyToHex(&s.m.identity.PublicKey))
+		s.Require().NoError(err)
+
+		messages = append(messages, message)
+	}
+	err := s.m.persistence.SaveMessages(messages)
+	s.Require().NoError(err)
+}
+
+func (s *MessengerCommunityMetricsSuite) TestCollectCommunityMessagesMetricsEmpty() {
+	community := s.prepareCommunity()
+
 	request := &requests.CommunityMetricsRequest{
-		CommunityID:    []byte("0x654321"),
+		CommunityID:    community.ID(),
 		Type:           requests.CommunityMetricsRequestMessages,
 		StartTimestamp: 1690279200,
 		EndTimestamp:   1690282800, // one hour
-		MaxCount:       10,
+		StepTimestamp:  100,
 	}
-	// Send contact request
+
+	// Expect empty metrics
 	resp, err := s.m.CollectCommunityMetrics(request)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
+
+	// Entries count should be empty
+	s.Require().Len(resp.Entries, 0)
+}
+
+func (s *MessengerCommunityMetricsSuite) TestCollectCommunityMessagesMetricsOneChat() {
+	community := s.prepareCommunity()
+
+	s.Require().Len(community.ChatIDs(), 1)
+	chatId := community.ChatIDs()[0]
+
+	s.generateMessages(chatId, string(community.ID()), []uint64{
+		// out ouf range messages in the begining
+		1690162000,
+		1690371999,
+		// 1st column, 3 message
+		1690372000,
+		1690372100,
+		1690372200,
+		// 2nd column, 2 messages
+		1690372700,
+		1690372800,
+		// 3rd column, 1 message
+		1690373000,
+		// out ouf range messages in the end
+		1690373100,
+		1690374000,
+		1690383000,
+	})
+
+	// Request metrics
+	request := &requests.CommunityMetricsRequest{
+		CommunityID:    community.ID(),
+		Type:           requests.CommunityMetricsRequestMessages,
+		StartTimestamp: 1690372000,
+		EndTimestamp:   1690373000, // one hour
+		StepTimestamp:  300,
+	}
+
+	resp, err := s.m.CollectCommunityMetrics(request)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	// floor(1000 / 300) == 3
+	s.Require().Len(resp.Entries, 3)
+
+	s.Require().Equal(resp.Entries[1690372300], uint(3))
+	// No entries for 1690372600
+	s.Require().Equal(resp.Entries[1690372900], uint(2))
+	s.Require().Equal(resp.Entries[1690373000], uint(1))
+}
+
+func (s *MessengerCommunityMetricsSuite) TestCollectCommunityMessagesMetricsMultipleChats() {
+	community := s.prepareCommunity()
+
+	s.Require().Len(community.ChatIDs(), 1)
+	chatIds := community.ChatIDs()
+
+	// Create another chat
+	chat := &protobuf.CommunityChat{
+		Permissions: &protobuf.CommunityPermissions{
+			Access: protobuf.CommunityPermissions_NO_MEMBERSHIP,
+		},
+		Identity: &protobuf.ChatIdentity{
+			DisplayName: "status",
+			Emoji:       "👍",
+			Description: "status community chat",
+		},
+	}
+	response, err := s.m.CreateCommunityChat(community.ID(), chat)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+	s.Require().Len(response.Communities(), 1)
+	s.Require().Len(response.Chats(), 1)
+
+	chatIds = append(chatIds, response.Chats()[0].ID)
+
+	s.generateMessages(chatIds[0], string(community.ID()), []uint64{
+		// out ouf range messages in the begining
+		1690162000,
+		// 1st column, 1 message
+		1690372200,
+		// 2nd column, 1 message
+		1690372800,
+		// 3rd column, 1 message
+		1690373000,
+		// out ouf range messages in the end
+		1690373100,
+	})
+
+	s.generateMessages(chatIds[1], string(community.ID()), []uint64{
+		// out ouf range messages in the begining
+		1690152000,
+		// 1st column, 2 messages
+		1690372000,
+		1690372100,
+		// 2nd column, 1 message
+		1690372700,
+		// 3rd column empty
+		// out ouf range messages in the end
+		1690373100,
+	})
+
+	// Request metrics
+	request := &requests.CommunityMetricsRequest{
+		CommunityID:    community.ID(),
+		Type:           requests.CommunityMetricsRequestMessages,
+		StartTimestamp: 1690372000,
+		EndTimestamp:   1690373000, // one hour
+		StepTimestamp:  300,
+	}
+
+	resp, err := s.m.CollectCommunityMetrics(request)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	// floor(1000 / 300) == 3
+	s.Require().Len(resp.Entries, 3)
+
+	s.Require().Equal(resp.Entries[1690372300], uint(3))
+	// No entries for 1690372600
+	s.Require().Equal(resp.Entries[1690372900], uint(2))
+	s.Require().Equal(resp.Entries[1690373000], uint(1))
 }

--- a/protocol/persistence_metrics.go
+++ b/protocol/persistence_metrics.go
@@ -1,0 +1,75 @@
+package protocol
+
+import (
+	"context"
+	"database/sql"
+)
+
+func (db sqlitePersistence) fetchMessagesTimestampsForPeriod(tx *sql.Tx, chatID string, startTimestamp uint64, endTimestamp uint64) ([]uint64, error) {
+	rows, err := tx.Query(`
+		SELECT timestamp FROM user_messages 
+		WHERE local_chat_id = ? AND 
+		timestamp >= ? AND 
+		timestamp <= ?`,
+		chatID,
+		startTimestamp,
+		endTimestamp)
+	if err != nil {
+		return []uint64{}, err
+	}
+	defer rows.Close()
+
+	var timestamps []uint64
+	for rows.Next() {
+		var timestamp uint64
+		err := rows.Scan(&timestamp)
+		if err != nil {
+			return nil, err
+		}
+		timestamps = append(timestamps, timestamp)
+	}
+
+	return timestamps, nil
+}
+
+func (db sqlitePersistence) FetchMessageTimestampsForChatByPeriod(chatID string, startTimestamp uint64, endTimestamp uint64) ([]uint64, error) {
+	tx, err := db.db.BeginTx(context.Background(), &sql.TxOptions{})
+	if err != nil {
+		return []uint64{}, err
+	}
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+		// don't shadow original error
+		_ = tx.Rollback()
+	}()
+
+	return db.fetchMessagesTimestampsForPeriod(tx, chatID, startTimestamp, endTimestamp)
+}
+
+func (db sqlitePersistence) FetchMessageTimestampsForChatsByPeriod(chatIDs []string, startTimestamp uint64, endTimestamp uint64) ([]uint64, error) {
+	tx, err := db.db.BeginTx(context.Background(), &sql.TxOptions{})
+	if err != nil {
+		return []uint64{}, err
+	}
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+		// don't shadow original error
+		_ = tx.Rollback()
+	}()
+
+	var timestamps []uint64
+	for _, chatID := range chatIDs {
+		chatTimestamps, err := db.fetchMessagesTimestampsForPeriod(tx, chatID, startTimestamp, endTimestamp)
+		if err != nil {
+			return []uint64{}, err
+		}
+		timestamps = append(timestamps, chatTimestamps...)
+	}
+	return timestamps, nil
+}

--- a/protocol/persistence_metrics.go
+++ b/protocol/persistence_metrics.go
@@ -7,13 +7,14 @@ import (
 
 func (db sqlitePersistence) fetchMessagesTimestampsForPeriod(tx *sql.Tx, chatID string, startTimestamp uint64, endTimestamp uint64) ([]uint64, error) {
 	rows, err := tx.Query(`
-		SELECT timestamp FROM user_messages 
+		SELECT whisper_timestamp FROM user_messages 
 		WHERE local_chat_id = ? AND 
-		timestamp >= ? AND 
-		timestamp <= ?`,
+		whisper_timestamp >= ? AND 
+		whisper_timestamp <= ?`,
 		chatID,
 		startTimestamp,
-		endTimestamp)
+		endTimestamp,
+	)
 	if err != nil {
 		return []uint64{}, err
 	}

--- a/protocol/persistence_metrics.go
+++ b/protocol/persistence_metrics.go
@@ -40,6 +40,11 @@ func (db sqlitePersistence) SelectMessagesTimestampsForChatsByPeriod(chatIDs []s
 		timestamps = append(timestamps, timestamp)
 	}
 
+	err = rows.Err()
+	if err != nil {
+		return []uint64{}, err
+	}
+
 	return timestamps, nil
 }
 

--- a/protocol/persistence_metrics_test.go
+++ b/protocol/persistence_metrics_test.go
@@ -1,1 +1,0 @@
-package protocol

--- a/protocol/persistence_metrics_test.go
+++ b/protocol/persistence_metrics_test.go
@@ -1,0 +1,1 @@
+package protocol

--- a/protocol/requests/community_metrics_request.go
+++ b/protocol/requests/community_metrics_request.go
@@ -1,0 +1,42 @@
+package requests
+
+import (
+	"errors"
+
+	"github.com/status-im/status-go/eth-node/types"
+)
+
+var ErrNoCommunityId = errors.New("community metrics request has no community id")
+var ErrInvalidTimeInterval = errors.New("community metrics request invalid time interval")
+var ErrInvalidMaxCount = errors.New("community metrics request max count should be gratear than zero")
+
+type CommunityMetricsRequestType uint
+
+const (
+	CommunityMetricsRequestMessages CommunityMetricsRequestType = iota + 1
+	CommunityMetricsRequestMembers
+	CommunityMetricsRequestControlNodeUptime
+)
+
+type CommunityMetricsRequest struct {
+	CommunityID    types.HexBytes              `json:"communityId"`
+	Type           CommunityMetricsRequestType `json:"type"`
+	StartTimestamp uint64                      `json:"startTimestamp"`
+	EndTimestamp   uint64                      `json:"endTimestamp"`
+	MaxCount       uint                        `json:"maxCount"`
+}
+
+func (r *CommunityMetricsRequest) Validate() error {
+	if len(r.CommunityID) == 0 {
+		return ErrNoCommunityId
+	}
+
+	if r.StartTimestamp == 0 || r.EndTimestamp == 0 || r.StartTimestamp >= r.EndTimestamp {
+		return ErrInvalidTimeInterval
+	}
+
+	if r.MaxCount < 1 {
+		return ErrInvalidMaxCount
+	}
+	return nil
+}

--- a/protocol/requests/community_metrics_request.go
+++ b/protocol/requests/community_metrics_request.go
@@ -12,8 +12,8 @@ var ErrInvalidTimestampIntervals = errors.New("community metrics request invalid
 type CommunityMetricsRequestType uint
 
 const (
-	CommunityMetricsRequestMessagesTimestamps CommunityMetricsRequestType = iota + 1
-	CommunityMetricsRequestMessagesCount      CommunityMetricsRequestType = iota + 1
+	CommunityMetricsRequestMessagesTimestamps CommunityMetricsRequestType = iota
+	CommunityMetricsRequestMessagesCount
 	CommunityMetricsRequestMembers
 	CommunityMetricsRequestControlNodeUptime
 )

--- a/protocol/requests/community_metrics_request.go
+++ b/protocol/requests/community_metrics_request.go
@@ -6,37 +6,39 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 )
 
-var ErrNoCommunityId = errors.New("community metrics request has no community id")
-var ErrInvalidTimestampInterval = errors.New("community metrics request invalid time interval")
-var ErrInvalidTimestampStep = errors.New("community metrics request invalid time step")
+var ErrNoCommunityID = errors.New("community metrics request has no community id")
+var ErrInvalidTimestampIntervals = errors.New("community metrics request invalid time intervals")
 
 type CommunityMetricsRequestType uint
 
 const (
-	CommunityMetricsRequestMessages CommunityMetricsRequestType = iota + 1
+	CommunityMetricsRequestMessagesTimestamps CommunityMetricsRequestType = iota + 1
+	CommunityMetricsRequestMessagesCount      CommunityMetricsRequestType = iota + 1
 	CommunityMetricsRequestMembers
 	CommunityMetricsRequestControlNodeUptime
 )
 
+type MetricsIntervalRequest struct {
+	StartTimestamp uint64 `json:"startTimestamp"`
+	EndTimestamp   uint64 `json:"endTimestamp"`
+}
+
 type CommunityMetricsRequest struct {
-	CommunityID    types.HexBytes              `json:"communityId"`
-	Type           CommunityMetricsRequestType `json:"type"`
-	StartTimestamp uint64                      `json:"startTimestamp"`
-	EndTimestamp   uint64                      `json:"endTimestamp"`
-	StepTimestamp  uint64                      `json:"stepTimestamp"`
+	CommunityID types.HexBytes              `json:"communityId"`
+	Type        CommunityMetricsRequestType `json:"type"`
+	Intervals   []MetricsIntervalRequest    `json:"intervals"`
 }
 
 func (r *CommunityMetricsRequest) Validate() error {
 	if len(r.CommunityID) == 0 {
-		return ErrNoCommunityId
+		return ErrNoCommunityID
 	}
 
-	if r.StartTimestamp == 0 || r.EndTimestamp == 0 || r.StartTimestamp >= r.EndTimestamp {
-		return ErrInvalidTimestampInterval
+	for _, interval := range r.Intervals {
+		if interval.StartTimestamp == 0 || interval.EndTimestamp == 0 || interval.StartTimestamp >= interval.EndTimestamp {
+			return ErrInvalidTimestampIntervals
+		}
 	}
 
-	if r.StepTimestamp < 1 || r.StepTimestamp > (r.EndTimestamp-r.StartTimestamp) {
-		return ErrInvalidTimestampStep
-	}
 	return nil
 }

--- a/protocol/requests/community_metrics_request.go
+++ b/protocol/requests/community_metrics_request.go
@@ -7,8 +7,8 @@ import (
 )
 
 var ErrNoCommunityId = errors.New("community metrics request has no community id")
-var ErrInvalidTimeInterval = errors.New("community metrics request invalid time interval")
-var ErrInvalidMaxCount = errors.New("community metrics request max count should be gratear than zero")
+var ErrInvalidTimestampInterval = errors.New("community metrics request invalid time interval")
+var ErrInvalidTimestampStep = errors.New("community metrics request invalid time step")
 
 type CommunityMetricsRequestType uint
 
@@ -23,7 +23,7 @@ type CommunityMetricsRequest struct {
 	Type           CommunityMetricsRequestType `json:"type"`
 	StartTimestamp uint64                      `json:"startTimestamp"`
 	EndTimestamp   uint64                      `json:"endTimestamp"`
-	MaxCount       uint                        `json:"maxCount"`
+	StepTimestamp  uint64                      `json:"stepTimestamp"`
 }
 
 func (r *CommunityMetricsRequest) Validate() error {
@@ -32,11 +32,11 @@ func (r *CommunityMetricsRequest) Validate() error {
 	}
 
 	if r.StartTimestamp == 0 || r.EndTimestamp == 0 || r.StartTimestamp >= r.EndTimestamp {
-		return ErrInvalidTimeInterval
+		return ErrInvalidTimestampInterval
 	}
 
-	if r.MaxCount < 1 {
-		return ErrInvalidMaxCount
+	if r.StepTimestamp < 1 || r.StepTimestamp > (r.EndTimestamp-r.StartTimestamp) {
+		return ErrInvalidTimestampStep
 	}
 	return nil
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1368,6 +1368,10 @@ func (api *PublicAPI) CheckAllCommunityChannelsPermissions(request *requests.Che
 	return api.service.messenger.CheckAllCommunityChannelsPermissions(request)
 }
 
+func (api *PublicAPI) CollectCommunityMetrics(request *requests.CommunityMetricsRequest) (*protocol.CommunityMetricsResponse, error) {
+	return api.service.messenger.CollectCommunityMetrics(request)
+}
+
 func (api *PublicAPI) ShareCommunityURLWithChatKey(communityID types.HexBytes) (string, error) {
 	return api.service.messenger.ShareCommunityURLWithChatKey(communityID)
 }


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/11152

Implement both strategies for fetching community messaging metrics:

- [x] `CommunityMetricsRequestMessagesTimestamps` to collect messages timestamps by intervals for all community chats
- [x] `CommunityMetricsRequestMessagesCount` to collect messages count by intervals for all community chats