### PR TITLE
chore: don't send membership requests to admins of auto-accept communities

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1217,6 +1217,8 @@ func tokenMasterRolePermissions() map[protobuf.CommunityMember_Roles]bool {
 func (o *Community) MemberRole(pubKey *ecdsa.PublicKey) protobuf.CommunityMember_Roles {
 	if o.IsMemberOwner(pubKey) {
 		return protobuf.CommunityMember_ROLE_OWNER
+	} else if o.IsMemberTokenMaster(pubKey) {
+		return protobuf.CommunityMember_ROLE_TOKEN_MASTER
 	} else if o.IsMemberAdmin(pubKey) {
 		return protobuf.CommunityMember_ROLE_ADMIN
 	} else if o.CanManageUsers(pubKey) {

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1752,6 +1752,11 @@ func (m *Manager) HandleCommunityRequestToJoin(signer *ecdsa.PublicKey, request 
 		return nil, ErrOrgNotFound
 	}
 
+	// don't process request as admin if community is configured as auto-accept
+	if community.HasPermissionToSendCommunityEvents() && community.AcceptRequestToJoinAutomatically() {
+		return nil, errors.New("ignoring request to join, community is set to auto-accept")
+	}
+
 	isUserRejected, err := m.isUserRejectedFromCommunity(signer, community, request.Clock)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
No need to send requests to admins if owner will auto accept anyways.