### PR TITLE
fix(messenger): fix handling reply with only one image

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3296,7 +3296,8 @@ func (r *ReceivedMessageState) addNewActivityCenterNotification(publicKey ecdsa.
 	// for same message with multiple images
 	var idToUse string
 
-	if message.GetImage() != nil {
+	image := message.GetImage()
+	if image != nil && image.GetAlbumId() != "" {
 		idToUse = message.GetImage().GetAlbumId()
 	} else {
 		idToUse = message.ID


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/11695 and https://github.com/status-im/status-mobile/issues/16800

If a message is sent with only 1 image, the album is not generated (no albumID), so then, in the notification handling code, it didn't use the right ID, because it thought it had to use the AlbumID for the message ID
