### PR TITLE
fix: owner without community private key and token master was not able to send some admin events

### DIFF
--- a/protocol/communities/community_event.go
+++ b/protocol/communities/community_event.go
@@ -341,8 +341,8 @@ func (o *Community) updateCommunityDescriptionByCommunityEvent(communityEvent Co
 			return err
 		}
 
-		if o.IsMemberOwnerOrAdmin(pk) {
-			return errors.New("attempt to kick an owner or admin of the community from the admin side")
+		if !o.IsControlNode() && o.IsPrivilegedMember(pk) {
+			return errors.New("attempt to kick an control node or privileged user from non-control node side")
 		}
 
 		o.removeMemberFromOrg(pk)
@@ -353,8 +353,8 @@ func (o *Community) updateCommunityDescriptionByCommunityEvent(communityEvent Co
 			return err
 		}
 
-		if o.IsMemberOwnerOrAdmin(pk) {
-			return errors.New("attempt to ban an owner or admin of the community from the admin side")
+		if !o.IsControlNode() && o.IsPrivilegedMember(pk) {
+			return errors.New("attempt to ban an control node or privileged user from non-control node side")
 		}
 		o.banUserFromCommunity(pk)
 
@@ -427,6 +427,10 @@ func validateAndGetEventsMessageCommunityDescription(signedDescription []byte, s
 	signer, err := metadata.RecoverKey()
 	if err != nil {
 		return nil, err
+	}
+
+	if signer == nil {
+		return nil, errors.New("CommunityDescription does not contain the control node signature")
 	}
 
 	if !signer.Equal(signerPubkey) {

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1327,8 +1327,8 @@ func (m *Manager) HandleCommunityEventsMessage(signer *ecdsa.PublicKey, message 
 		return nil, ErrOrgNotFound
 	}
 
-	if !community.IsMemberAdmin(signer) {
-		return nil, errors.New("user is not an admin")
+	if !community.IsPrivilegedMember(signer) {
+		return nil, errors.New("user has not permissions to send events")
 	}
 
 	changes, err := community.UpdateCommunityByEvents(adminMessage)
@@ -2411,13 +2411,13 @@ func (m *Manager) HandleCommunityRequestToJoinResponse(signer *ecdsa.PublicKey, 
 		return nil, err
 	}
 
-	isOwnerOrAdminSigner := community.IsMemberOwnerOrAdmin(signer)
+	isPrivilegedUserSigner := community.IsPrivilegedMember(signer)
 	isControlNodeSigner := common.IsPubKeyEqual(community.PublicKey(), signer)
-	if !isControlNodeSigner && !isOwnerOrAdminSigner {
+	if !isControlNodeSigner && !isPrivilegedUserSigner {
 		return nil, ErrNotAuthorized
 	}
 
-	_, err = community.UpdateCommunityDescription(request.Community, appMetadataMsg, isOwnerOrAdminSigner && !isControlNodeSigner)
+	_, err = community.UpdateCommunityDescription(request.Community, appMetadataMsg, isPrivilegedUserSigner && !isControlNodeSigner)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/communities_events_owner_without_community_key_test.go
+++ b/protocol/communities_events_owner_without_community_key_test.go
@@ -244,7 +244,7 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerBanOwnerWithoutC
 	testOwnerBanTheSameRole(s, community)
 }
 
-func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestAdminBanControlNode() {
+func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerBanControlNode() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER)
 	testOwnerBanControlNode(s, community)
 }

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -91,8 +91,8 @@ func setUpCommunityAndRoles(base CommunityEventsTestsInterface, role protobuf.Co
 
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
 	joinCommunity(suite, community, base.GetControlNode(), base.GetEventSender(), request)
+	refreshMessengerResponses(base)
 	joinCommunity(suite, community, base.GetControlNode(), base.GetMember(), request)
-
 	refreshMessengerResponses(base)
 
 	// grant permissions to the event sender
@@ -344,14 +344,14 @@ func setUpOnRequestCommunityAndRoles(base CommunityEventsTestsInterface, role pr
 
 	// control node creates a community and chat
 	community := createTestCommunity(base, protobuf.CommunityPermissions_ON_REQUEST)
+	refreshMessengerResponses(base)
+
 	advertiseCommunityTo(s, community, base.GetControlNode(), base.GetEventSender())
 	advertiseCommunityTo(s, community, base.GetControlNode(), base.GetMember())
 
-	refreshMessengerResponses(base)
-
 	joinOnRequestCommunity(s, community, base.GetControlNode(), base.GetEventSender())
+	refreshMessengerResponses(base)
 	joinOnRequestCommunity(s, community, base.GetControlNode(), base.GetMember())
-
 	refreshMessengerResponses(base)
 
 	// grant permissions to event sender

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -924,12 +924,14 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 		return nil, err
 	}
 
-	// send request to join also to community admins
-	communityAdmins := community.GetMemberAdmins()
-	for _, communityAdmin := range communityAdmins {
-		_, err := m.sender.SendPrivate(context.Background(), communityAdmin, &rawMessage)
-		if err != nil {
-			return nil, err
+	if !community.AcceptRequestToJoinAutomatically() {
+		// send request to join also to community privileged members
+		privilegedMembers := community.GetPrivilegedMembers()
+		for _, privilegedMember := range privilegedMembers {
+			_, err := m.sender.SendPrivate(context.Background(), privilegedMember, &rawMessage)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -1057,10 +1059,10 @@ func (m *Messenger) EditSharedAddressesForCommunity(request *requests.EditShared
 		return nil, err
 	}
 
-	// send edit message also to community admins
-	communityAdmins := community.GetMemberAdmins()
-	for _, communityAdmin := range communityAdmins {
-		_, err := m.sender.SendPrivate(context.Background(), communityAdmin, &rawMessage)
+	// send edit message also to privileged members
+	privilegedMembers := community.GetPrivilegedMembers()
+	for _, privilegedMember := range privilegedMembers {
+		_, err := m.sender.SendPrivate(context.Background(), privilegedMember, &rawMessage)
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2589,10 +2589,10 @@ func (m *Messenger) matchChatEntity(chatEntity common.ChatEntity) (*Chat, error)
 			return nil, err
 		}
 
-		isMemberOwnerOrAdmin := community.IsMemberOwnerOrAdmin(chatEntity.GetSigPubKey())
+		hasPermission := community.IsPrivilegedMember(chatEntity.GetSigPubKey())
 		pinMessageAllowed := community.AllowsAllMembersToPinMessage()
 
-		if (pinMessage && !isMemberOwnerOrAdmin && !pinMessageAllowed) || (!emojiReaction && !canPost) {
+		if (pinMessage && !hasPermission && !pinMessageAllowed) || (!emojiReaction && !canPost) {
 			return nil, errors.New("user can't post")
 		}
 

--- a/protocol/messenger_pin_messages.go
+++ b/protocol/messenger_pin_messages.go
@@ -36,10 +36,10 @@ func (m *Messenger) sendPinMessage(ctx context.Context, message *common.PinMessa
 		if err != nil {
 			return nil, err
 		}
-		isMemberOwnerOrAdmin := community.IsMemberOwnerOrAdmin(&m.identity.PublicKey)
+		hasPermission := community.IsPrivilegedMember(&m.identity.PublicKey)
 		pinMessageAllowed := community.AllowsAllMembersToPinMessage()
 
-		if !pinMessageAllowed && !isMemberOwnerOrAdmin {
+		if !pinMessageAllowed && !hasPermission {
 			return nil, errors.New("member can't pin message")
 		}
 	}


### PR DESCRIPTION
Unit tests for the owner without a community private key and for TokenMaster were configured incorrectly, so the tests were false positives
Fixed tests and failed logic
