### PR TITLE
Regularly update the list of curated communities

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -795,6 +795,7 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	}
 	m.startSyncSettingsLoop()
 	m.startCommunityRekeyLoop()
+	m.startCuratedCommunitiesUpdateLoop()
 
 	if err := m.cleanTopics(); err != nil {
 		return nil, err

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -455,22 +455,22 @@ func (m *Messenger) CuratedCommunities() (*communities.KnownCommunitiesResponse,
 	if err != nil {
 		return nil, err
 	}
-	var backend *ethclient.Client
+	var ethClient *ethclient.Client
 	for _, n := range nodeConfig.Networks {
 		if n.ChainID == chainID {
-			b, err := ethclient.Dial(n.RPCURL)
+			e, err := ethclient.Dial(n.RPCURL)
 			if err != nil {
 				return nil, err
 			}
-			backend = b
+			ethClient = e
 		}
 	}
 
-	if backend == nil {
+	if ethClient == nil {
 		return nil, errors.New("failed to initialize backend before requesting curated communities")
 	}
 
-	directory, err := m.contractMaker.NewDirectoryWithBackend(chainID, backend)
+	directory, err := m.contractMaker.NewDirectoryWithBackend(chainID, ethClient)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -59,6 +59,7 @@ type MessengerSignalsHandler interface {
 	SendWakuBackedUpSettings(response *wakusync.WakuBackedUpDataResponse)
 	SendWakuBackedUpKeypair(response *wakusync.WakuBackedUpDataResponse)
 	SendWakuBackedUpWatchOnlyAccount(response *wakusync.WakuBackedUpDataResponse)
+	SendCuratedCommunitiesUpdate(response *communities.KnownCommunitiesResponse)
 }
 
 type config struct {

--- a/services/ext/signal.go
+++ b/services/ext/signal.go
@@ -164,3 +164,7 @@ func (m *MessengerSignalsHandler) SendWakuBackedUpKeypair(response *wakusync.Wak
 func (m *MessengerSignalsHandler) SendWakuBackedUpWatchOnlyAccount(response *wakusync.WakuBackedUpDataResponse) {
 	signal.SendWakuBackedUpWatchOnlyAccount(response)
 }
+
+func (m *MessengerSignalsHandler) SendCuratedCommunitiesUpdate(response *communities.KnownCommunitiesResponse) {
+	signal.SendCuratedCommunitiesUpdate(response)
+}

--- a/signal/events_messenger.go
+++ b/signal/events_messenger.go
@@ -13,6 +13,9 @@ const (
 
 	// EventStatusUpdatesTimedOut Event Automatic Status Updates Timed out
 	EventStatusUpdatesTimedOut = "status.updates.timedout"
+
+	// EventCuratedCommunitiesUpdate triggered when it is time to refresh the list of curated communities
+	EventCuratedCommunitiesUpdate = "curated.communities.update"
 )
 
 // MessageDeliveredSignal specifies chat and message that was delivered
@@ -51,4 +54,8 @@ func SendCommunityInfoFound(community interface{}) {
 
 func SendStatusUpdatesTimedOut(statusUpdates interface{}) {
 	send(EventStatusUpdatesTimedOut, statusUpdates)
+}
+
+func SendCuratedCommunitiesUpdate(curatedCommunitiesUpdate interface{}) {
+	send(EventCuratedCommunitiesUpdate, curatedCommunitiesUpdate)
 }


### PR DESCRIPTION
Related to [status-mobile bug](https://github.com/status-im/status-mobile/issues/16346)

Problem: when featured communities are requested by a client, some of them may be not known yet and their details should be requested from mailserver. But the client won't know this because the `CuratedCommunities()` result already returned without unknown communities.

Solution: now `status-go` every 2 minutes (random timeout, can be changed) polls the featured communities and signals the client about them. If there are unknown communities in the latest poll, the next one will happen in 15 seconds (hoping that communities info already will be fetched from mailserver).


