### PR TITLE
Feat/10728 collectibles ownership on arb and opt

### DIFF
--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -550,7 +550,7 @@ func (s *Service) CanProvideCollectibleMetadata(id thirdparty.CollectibleUniqueI
 	return ret, nil
 }
 
-func (s *Service) FetchCollectibleMetadata(id thirdparty.CollectibleUniqueID, tokenURI string) (*thirdparty.CollectibleData, error) {
+func (s *Service) FetchCollectibleMetadata(id thirdparty.CollectibleUniqueID, tokenURI string) (*thirdparty.FullCollectibleData, error) {
 	if s.messenger == nil {
 		return nil, fmt.Errorf("messenger not ready")
 	}
@@ -573,13 +573,17 @@ func (s *Service) FetchCollectibleMetadata(id thirdparty.CollectibleUniqueID, to
 
 		for _, tokenMetadata := range tokensMetadata {
 			contractAddresses := tokenMetadata.GetContractAddresses()
-			if contractAddresses[uint64(id.ChainID)] == id.ContractAddress.Hex() {
-				return &thirdparty.CollectibleData{
-					ID:          id,
-					Name:        tokenMetadata.GetName(),
-					Description: tokenMetadata.GetDescription(),
-					ImageURL:    tokenMetadata.GetImage(),
-					CollectionData: thirdparty.CollectionData{
+			if contractAddresses[uint64(id.ContractID.ChainID)] == id.ContractID.Address.Hex() {
+				return &thirdparty.FullCollectibleData{
+					CollectibleData: thirdparty.CollectibleData{
+						ID:          id,
+						Name:        tokenMetadata.GetName(),
+						Description: tokenMetadata.GetDescription(),
+						ImageURL:    tokenMetadata.GetImage(),
+						TokenURI:    tokenURI,
+					},
+					CollectionData: &thirdparty.CollectionData{
+						ID:       id.ContractID,
 						Name:     tokenMetadata.GetName(),
 						ImageURL: tokenMetadata.GetImage(),
 					},

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -316,10 +316,10 @@ func (api *API) FilterOwnedCollectiblesAsync(ctx context.Context, chainIDs []wco
 	return nil
 }
 
-func (api *API) GetCollectiblesDataAsync(ctx context.Context, uniqueIDs []thirdparty.CollectibleUniqueID) error {
+func (api *API) GetCollectiblesDetailsAsync(ctx context.Context, uniqueIDs []thirdparty.CollectibleUniqueID) error {
 	log.Debug("wallet.api.GetCollectiblesDetailsAsync")
 
-	api.s.collectibles.GetCollectiblesDataAsync(ctx, uniqueIDs)
+	api.s.collectibles.GetCollectiblesDetailsAsync(ctx, uniqueIDs)
 	return nil
 }
 
@@ -342,22 +342,22 @@ func (api *API) GetOpenseaAssetsByOwnerAndCollection(ctx context.Context, chainI
 	return container.Assets, nil
 }
 
-func (api *API) GetCollectiblesByOwnerAndCollectionWithCursor(ctx context.Context, chainID wcommon.ChainID, owner common.Address, collectionSlug string, cursor string, limit int) (*thirdparty.CollectibleDataContainer, error) {
+func (api *API) GetCollectiblesByOwnerAndCollectionWithCursor(ctx context.Context, chainID wcommon.ChainID, owner common.Address, collectionSlug string, cursor string, limit int) (*thirdparty.FullCollectibleDataContainer, error) {
 	log.Debug("call to GetCollectiblesByOwnerAndCollectionWithCursor")
 	return api.s.collectiblesManager.FetchAllAssetsByOwnerAndCollection(chainID, owner, collectionSlug, cursor, limit)
 }
 
-func (api *API) GetCollectiblesByOwnerWithCursor(ctx context.Context, chainID wcommon.ChainID, owner common.Address, cursor string, limit int) (*thirdparty.CollectibleDataContainer, error) {
+func (api *API) GetCollectiblesByOwnerWithCursor(ctx context.Context, chainID wcommon.ChainID, owner common.Address, cursor string, limit int) (*thirdparty.FullCollectibleDataContainer, error) {
 	log.Debug("call to GetCollectiblesByOwnerWithCursor")
 	return api.s.collectiblesManager.FetchAllAssetsByOwner(chainID, owner, cursor, limit)
 }
 
-func (api *API) GetCollectiblesByOwnerAndContractAddressWithCursor(ctx context.Context, chainID wcommon.ChainID, owner common.Address, contractAddresses []common.Address, cursor string, limit int) (*thirdparty.CollectibleDataContainer, error) {
+func (api *API) GetCollectiblesByOwnerAndContractAddressWithCursor(ctx context.Context, chainID wcommon.ChainID, owner common.Address, contractAddresses []common.Address, cursor string, limit int) (*thirdparty.FullCollectibleDataContainer, error) {
 	log.Debug("call to GetCollectiblesByOwnerAndContractAddressWithCursor")
 	return api.s.collectiblesManager.FetchAllAssetsByOwnerAndContractAddress(chainID, owner, contractAddresses, cursor, limit)
 }
 
-func (api *API) GetCollectiblesByUniqueID(ctx context.Context, uniqueIDs []thirdparty.CollectibleUniqueID) ([]thirdparty.CollectibleData, error) {
+func (api *API) GetCollectiblesByUniqueID(ctx context.Context, uniqueIDs []thirdparty.CollectibleUniqueID) ([]thirdparty.FullCollectibleData, error) {
 	log.Debug("call to GetCollectiblesByUniqueID")
 	return api.s.collectiblesManager.FetchAssetsByCollectibleUniqueID(uniqueIDs)
 }

--- a/services/wallet/collectibles/commands.go
+++ b/services/wallet/collectibles/commands.go
@@ -136,7 +136,7 @@ func (c *loadOwnedCollectiblesCommand) Run(parent context.Context) (err error) {
 	log.Debug("start loadOwnedCollectiblesCommand", "chain", c.chainID, "account", c.account)
 
 	pageNr := 0
-	cursor := FetchFromStartCursor
+	cursor := thirdparty.FetchFromStartCursor
 
 	c.triggerEvent(EventCollectiblesOwnershipUpdateStarted, c.chainID, c.account, "")
 	// Fetch collectibles in chunks
@@ -161,7 +161,7 @@ func (c *loadOwnedCollectiblesCommand) Run(parent context.Context) (err error) {
 		pageNr++
 		cursor = partialOwnership.NextCursor
 
-		if cursor == FetchFromStartCursor {
+		if cursor == thirdparty.FetchFromStartCursor {
 			err = c.ownershipDB.Update(c.chainID, c.account, c.partialOwnership)
 			if err != nil {
 				log.Error("failed updating ownershipDB in loadOwnedCollectiblesCommand", "chain", c.chainID, "account", c.account, "error", err)

--- a/services/wallet/collectibles/commands.go
+++ b/services/wallet/collectibles/commands.go
@@ -154,9 +154,9 @@ func (c *loadOwnedCollectiblesCommand) Run(parent context.Context) (err error) {
 			break
 		}
 
-		log.Debug("partial loadOwnedCollectiblesCommand", "chain", c.chainID, "account", c.account, "page", pageNr, "found", len(partialOwnership.Collectibles), "collectibles")
+		log.Debug("partial loadOwnedCollectiblesCommand", "chain", c.chainID, "account", c.account, "page", pageNr, "found", len(partialOwnership.Items), "collectibles")
 
-		c.partialOwnership = append(c.partialOwnership, partialOwnership.Collectibles...)
+		c.partialOwnership = append(c.partialOwnership, partialOwnership.Items...)
 
 		pageNr++
 		cursor = partialOwnership.NextCursor

--- a/services/wallet/collectibles/ownership_db.go
+++ b/services/wallet/collectibles/ownership_db.go
@@ -54,7 +54,7 @@ func insertAddressOwnership(creator statementCreator, ownerAddress common.Addres
 	}
 
 	for _, c := range collectibles {
-		_, err = insertOwnership.Exec(c.ChainID, c.ContractAddress, (*bigint.SQLBigIntBytes)(c.TokenID.Int), ownerAddress)
+		_, err = insertOwnership.Exec(c.ContractID.ChainID, c.ContractID.Address, (*bigint.SQLBigIntBytes)(c.TokenID.Int), ownerAddress)
 		if err != nil {
 			return err
 		}
@@ -101,8 +101,8 @@ func rowsToCollectibles(rows *sql.Rows) ([]thirdparty.CollectibleUniqueID, error
 			TokenID: &bigint.BigInt{Int: big.NewInt(0)},
 		}
 		err := rows.Scan(
-			&id.ChainID,
-			&id.ContractAddress,
+			&id.ContractID.ChainID,
+			&id.ContractID.Address,
 			(*bigint.SQLBigIntBytes)(id.TokenID.Int),
 		)
 		if err != nil {

--- a/services/wallet/collectibles/ownership_db_test.go
+++ b/services/wallet/collectibles/ownership_db_test.go
@@ -27,9 +27,11 @@ func generateTestCollectibles(chainID w_common.ChainID, count int) (result []thi
 	for i := 0; i < count; i++ {
 		bigI := big.NewInt(int64(i))
 		newCollectible := thirdparty.CollectibleUniqueID{
-			ChainID:         chainID,
-			ContractAddress: common.BigToAddress(bigI),
-			TokenID:         &bigint.BigInt{Int: bigI},
+			ContractID: thirdparty.ContractID{
+				ChainID: chainID,
+				Address: common.BigToAddress(bigI),
+			},
+			TokenID: &bigint.BigInt{Int: bigI},
 		}
 		result = append(result, newCollectible)
 	}
@@ -98,9 +100,11 @@ func TestLargeTokenID(t *testing.T) {
 
 	ownedListChain := []thirdparty.CollectibleUniqueID{
 		{
-			ChainID:         chainID,
-			ContractAddress: common.HexToAddress("0x1234"),
-			TokenID:         &bigint.BigInt{Int: big.NewInt(0).SetBytes([]byte("0x1234567890123456789012345678901234567890"))},
+			ContractID: thirdparty.ContractID{
+				ChainID: chainID,
+				Address: common.HexToAddress("0x1234"),
+			},
+			TokenID: &bigint.BigInt{Int: big.NewInt(0).SetBytes([]byte("0x1234567890123456789012345678901234567890"))},
 		},
 	}
 

--- a/services/wallet/collectibles/types.go
+++ b/services/wallet/collectibles/types.go
@@ -1,0 +1,83 @@
+package collectibles
+
+import "github.com/status-im/status-go/services/wallet/thirdparty"
+
+// Combined Collection+Collectible info, used to display a detailed view of a collectible
+type CollectibleDetails struct {
+	ID                 thirdparty.CollectibleUniqueID `json:"id"`
+	Name               string                         `json:"name"`
+	Description        string                         `json:"description"`
+	ImageURL           string                         `json:"image_url"`
+	AnimationURL       string                         `json:"animation_url"`
+	AnimationMediaType string                         `json:"animation_media_type"`
+	Traits             []thirdparty.CollectibleTrait  `json:"traits"`
+	BackgroundColor    string                         `json:"background_color"`
+	CollectionName     string                         `json:"collection_name"`
+	CollectionSlug     string                         `json:"collection_slug"`
+	CollectionImageURL string                         `json:"collection_image_url"`
+}
+
+// Combined Collection+Collectible info, used to display a basic view of a collectible in a list
+type CollectibleHeader struct {
+	ID                 thirdparty.CollectibleUniqueID `json:"id"`
+	Name               string                         `json:"name"`
+	ImageURL           string                         `json:"image_url"`
+	AnimationURL       string                         `json:"animation_url"`
+	AnimationMediaType string                         `json:"animation_media_type"`
+	BackgroundColor    string                         `json:"background_color"`
+	CollectionName     string                         `json:"collection_name"`
+}
+
+func fullCollectibleDataToHeader(c thirdparty.FullCollectibleData) CollectibleHeader {
+	ret := CollectibleHeader{
+		ID:                 c.CollectibleData.ID,
+		Name:               c.CollectibleData.Name,
+		ImageURL:           c.CollectibleData.ImageURL,
+		AnimationURL:       c.CollectibleData.AnimationURL,
+		AnimationMediaType: c.CollectibleData.AnimationMediaType,
+		BackgroundColor:    c.CollectibleData.BackgroundColor,
+	}
+	if c.CollectionData != nil {
+		ret.CollectionName = c.CollectionData.Name
+	}
+	return ret
+}
+
+func fullCollectiblesDataToHeaders(data []thirdparty.FullCollectibleData) []CollectibleHeader {
+	res := make([]CollectibleHeader, 0, len(data))
+
+	for _, c := range data {
+		res = append(res, fullCollectibleDataToHeader(c))
+	}
+
+	return res
+}
+
+func fullCollectibleDataToDetails(c thirdparty.FullCollectibleData) CollectibleDetails {
+	ret := CollectibleDetails{
+		ID:                 c.CollectibleData.ID,
+		Name:               c.CollectibleData.Name,
+		Description:        c.CollectibleData.Description,
+		ImageURL:           c.CollectibleData.ImageURL,
+		AnimationURL:       c.CollectibleData.AnimationURL,
+		AnimationMediaType: c.CollectibleData.AnimationMediaType,
+		BackgroundColor:    c.CollectibleData.BackgroundColor,
+		Traits:             c.CollectibleData.Traits,
+	}
+	if c.CollectionData != nil {
+		ret.CollectionName = c.CollectionData.Name
+		ret.CollectionSlug = c.CollectionData.Slug
+		ret.CollectionImageURL = c.CollectionData.ImageURL
+	}
+	return ret
+}
+
+func fullCollectiblesDataToDetails(data []thirdparty.FullCollectibleData) []CollectibleDetails {
+	res := make([]CollectibleDetails, 0, len(data))
+
+	for _, c := range data {
+		res = append(res, fullCollectibleDataToDetails(c))
+	}
+
+	return res
+}

--- a/services/wallet/thirdparty/alchemy/client.go
+++ b/services/wallet/thirdparty/alchemy/client.go
@@ -33,7 +33,16 @@ func getBaseURL(chainID walletCommon.ChainID) (string, error) {
 		return "https://arb-goerli.g.alchemy.com", nil
 	}
 
-	return "", fmt.Errorf("chainID not supported: %d", chainID)
+	return "", thirdparty.ErrChainIDNotSupported
+}
+
+func (o *Client) ID() string {
+	return "alchemy"
+}
+
+func (o *Client) IsChainSupported(chainID walletCommon.ChainID) bool {
+	_, err := getBaseURL(chainID)
+	return err == nil
 }
 
 func getAPIKeySubpath(apiKey string) string {
@@ -91,11 +100,6 @@ func (o *Client) doQuery(url string) (*http.Response, error) {
 	}
 
 	return resp, nil
-}
-
-func (o *Client) IsChainSupported(chainID walletCommon.ChainID) bool {
-	_, err := getBaseURL(chainID)
-	return err == nil
 }
 
 func alchemyOwnershipToCommon(contractAddress common.Address, alchemyOwnership CollectibleContractOwnership) (*thirdparty.CollectibleContractOwnership, error) {

--- a/services/wallet/thirdparty/alchemy/types.go
+++ b/services/wallet/thirdparty/alchemy/types.go
@@ -1,9 +1,18 @@
 package alchemy
 
 import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/status-im/status-go/services/wallet/bigint"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type TokenBalance struct {
@@ -21,9 +30,9 @@ type CollectibleContractOwnership struct {
 	PageKey string             `json:"pageKey"`
 }
 
-func alchemyOwnershipToCommon(contractAddress common.Address, alchemyOwnership CollectibleContractOwnership) (*thirdparty.CollectibleContractOwnership, error) {
-	owners := make([]thirdparty.CollectibleOwner, 0, len(alchemyOwnership.Owners))
-	for _, alchemyOwner := range alchemyOwnership.Owners {
+func alchemyCollectibleOwnersToCommon(alchemyOwners []CollectibleOwner) []thirdparty.CollectibleOwner {
+	owners := make([]thirdparty.CollectibleOwner, 0, len(alchemyOwners))
+	for _, alchemyOwner := range alchemyOwners {
 		balances := make([]thirdparty.TokenBalance, 0, len(alchemyOwner.TokenBalances))
 
 		for _, alchemyBalance := range alchemyOwner.TokenBalances {
@@ -39,11 +48,129 @@ func alchemyOwnershipToCommon(contractAddress common.Address, alchemyOwnership C
 
 		owners = append(owners, owner)
 	}
+	return owners
+}
 
-	ownership := thirdparty.CollectibleContractOwnership{
-		ContractAddress: contractAddress,
-		Owners:          owners,
+type AttributeValue string
+
+func (st *AttributeValue) UnmarshalJSON(b []byte) error {
+	var item interface{}
+	if err := json.Unmarshal(b, &item); err != nil {
+		return err
 	}
 
-	return &ownership, nil
+	switch v := item.(type) {
+	case float64:
+		*st = AttributeValue(strconv.FormatFloat(v, 'f', 2, 64))
+	case int:
+		*st = AttributeValue(strconv.Itoa(v))
+	case string:
+		*st = AttributeValue(v)
+	}
+	return nil
+}
+
+type Attribute struct {
+	TraitType string         `json:"trait_type"`
+	Value     AttributeValue `json:"value"`
+}
+
+type RawMetadata struct {
+	Attributes []Attribute `json:"attributes"`
+}
+
+type Raw struct {
+	RawMetadata RawMetadata `json:"metadata"`
+}
+
+type OpenSeaMetadata struct {
+	ImageURL string `json:"imageUrl"`
+}
+
+type Contract struct {
+	Address         common.Address  `json:"address"`
+	Name            string          `json:"name"`
+	Symbol          string          `json:"symbol"`
+	TokenType       string          `json:"tokenType"`
+	OpenSeaMetadata OpenSeaMetadata `json:"openSeaMetadata"`
+}
+
+type Image struct {
+	ImageURL             string `json:"pngUrl"`
+	CachedAnimationURL   string `json:"cachedUrl"`
+	OriginalAnimationURL string `json:"originalUrl"`
+}
+
+type Asset struct {
+	Contract    Contract       `json:"contract"`
+	TokenID     *bigint.BigInt `json:"tokenId"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Image       Image          `json:"image"`
+	Raw         Raw            `json:"raw"`
+	TokenURI    string         `json:"tokenUri"`
+}
+
+type NFTList struct {
+	OwnedNFTs  []Asset        `json:"ownedNfts"`
+	TotalCount *bigint.BigInt `json:"totalCount"`
+	PageKey    string         `json:"pageKey"`
+}
+
+func alchemyToCollectibleTraits(attributes []Attribute) []thirdparty.CollectibleTrait {
+	ret := make([]thirdparty.CollectibleTrait, 0, len(attributes))
+	caser := cases.Title(language.Und, cases.NoLower)
+	for _, orig := range attributes {
+		dest := thirdparty.CollectibleTrait{
+			TraitType: strings.Replace(orig.TraitType, "_", " ", 1),
+			Value:     caser.String(string(orig.Value)),
+		}
+
+		ret = append(ret, dest)
+	}
+	return ret
+}
+
+func (c *Asset) toCollectionData(id thirdparty.ContractID) thirdparty.CollectionData {
+	ret := thirdparty.CollectionData{
+		ID:       id,
+		Name:     c.Contract.Name,
+		ImageURL: c.Contract.OpenSeaMetadata.ImageURL,
+	}
+	return ret
+}
+
+func (c *Asset) toCollectiblesData(id thirdparty.CollectibleUniqueID) thirdparty.CollectibleData {
+	return thirdparty.CollectibleData{
+		ID:           id,
+		Name:         c.Name,
+		Description:  c.Description,
+		ImageURL:     c.Image.ImageURL,
+		AnimationURL: c.Image.OriginalAnimationURL,
+		Traits:       alchemyToCollectibleTraits(c.Raw.RawMetadata.Attributes),
+	}
+}
+
+func (c *Asset) toCommon(id thirdparty.CollectibleUniqueID) thirdparty.FullCollectibleData {
+	contractData := c.toCollectionData(id.ContractID)
+	return thirdparty.FullCollectibleData{
+		CollectibleData: c.toCollectiblesData(id),
+		CollectionData:  &contractData,
+	}
+}
+
+func (l *NFTList) toCommon(chainID walletCommon.ChainID) []thirdparty.FullCollectibleData {
+	ret := make([]thirdparty.FullCollectibleData, 0, len(l.OwnedNFTs))
+	for _, asset := range l.OwnedNFTs {
+		id := thirdparty.CollectibleUniqueID{
+			ContractID: thirdparty.ContractID{
+				ChainID: chainID,
+				Address: asset.Contract.Address,
+			},
+			TokenID: asset.TokenID,
+		}
+		item := asset.toCommon(id)
+		ret = append(ret, item)
+	}
+	return ret
 }

--- a/services/wallet/thirdparty/alchemy/types.go
+++ b/services/wallet/thirdparty/alchemy/types.go
@@ -1,0 +1,49 @@
+package alchemy
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/bigint"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+type TokenBalance struct {
+	TokenID *bigint.HexBigInt `json:"tokenId"`
+	Balance *bigint.BigInt    `json:"balance"`
+}
+
+type CollectibleOwner struct {
+	OwnerAddress  common.Address `json:"ownerAddress"`
+	TokenBalances []TokenBalance `json:"tokenBalances"`
+}
+
+type CollectibleContractOwnership struct {
+	Owners  []CollectibleOwner `json:"ownerAddresses"`
+	PageKey string             `json:"pageKey"`
+}
+
+func alchemyOwnershipToCommon(contractAddress common.Address, alchemyOwnership CollectibleContractOwnership) (*thirdparty.CollectibleContractOwnership, error) {
+	owners := make([]thirdparty.CollectibleOwner, 0, len(alchemyOwnership.Owners))
+	for _, alchemyOwner := range alchemyOwnership.Owners {
+		balances := make([]thirdparty.TokenBalance, 0, len(alchemyOwner.TokenBalances))
+
+		for _, alchemyBalance := range alchemyOwner.TokenBalances {
+			balances = append(balances, thirdparty.TokenBalance{
+				TokenID: &bigint.BigInt{Int: alchemyBalance.TokenID.Int},
+				Balance: alchemyBalance.Balance,
+			})
+		}
+		owner := thirdparty.CollectibleOwner{
+			OwnerAddress:  alchemyOwner.OwnerAddress,
+			TokenBalances: balances,
+		}
+
+		owners = append(owners, owner)
+	}
+
+	ownership := thirdparty.CollectibleContractOwnership{
+		ContractAddress: contractAddress,
+		Owners:          owners,
+	}
+
+	return &ownership, nil
+}

--- a/services/wallet/thirdparty/collectible_types.go
+++ b/services/wallet/thirdparty/collectible_types.go
@@ -13,6 +13,9 @@ var (
 	ErrChainIDNotSupported = errors.New("chainID not supported")
 )
 
+const FetchNoLimit = 0
+const FetchFromStartCursor = ""
+
 type CollectibleProvider interface {
 	ID() string
 	IsChainSupported(chainID w_common.ChainID) bool

--- a/services/wallet/thirdparty/collectible_types.go
+++ b/services/wallet/thirdparty/collectible_types.go
@@ -145,6 +145,12 @@ type CollectibleContractOwnership struct {
 }
 
 type CollectibleContractOwnershipProvider interface {
+	CollectibleProvider
 	FetchCollectibleOwnersByContractAddress(chainID w_common.ChainID, contractAddress common.Address) (*CollectibleContractOwnership, error)
-	IsChainSupported(chainID w_common.ChainID) bool
+}
+
+type CollectibleAccountOwnershipProvider interface {
+	CollectibleProvider
+	FetchAllAssetsByOwner(chainID w_common.ChainID, owner common.Address, cursor string, limit int) (*FullCollectibleDataContainer, error)
+	FetchAllAssetsByOwnerAndContractAddress(chainID w_common.ChainID, owner common.Address, contractAddresses []common.Address, cursor string, limit int) (*FullCollectibleDataContainer, error)
 }

--- a/services/wallet/thirdparty/infura/client.go
+++ b/services/wallet/thirdparty/infura/client.go
@@ -63,6 +63,10 @@ func (o *Client) doQuery(url string) (*http.Response, error) {
 	return resp, nil
 }
 
+func (o *Client) ID() string {
+	return "infura"
+}
+
 func (o *Client) IsChainSupported(chainID walletCommon.ChainID) bool {
 	switch uint64(chainID) {
 	case walletCommon.EthereumMainnet, walletCommon.EthereumGoerli, walletCommon.EthereumSepolia, walletCommon.ArbitrumMainnet:

--- a/services/wallet/thirdparty/infura/types.go
+++ b/services/wallet/thirdparty/infura/types.go
@@ -1,10 +1,34 @@
 package infura
 
 import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/status-im/status-go/services/wallet/bigint"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
+
+func chainStringToChainID(chainString string) walletCommon.ChainID {
+	chainID := walletCommon.UnknownChainID
+	switch chainString {
+	case "ETHEREUM":
+		chainID = walletCommon.EthereumMainnet
+	case "ARBITRUM":
+		chainID = walletCommon.ArbitrumMainnet
+	case "GOERLI":
+		chainID = walletCommon.EthereumGoerli
+	case "SEPOLIA":
+		chainID = walletCommon.EthereumSepolia
+	}
+	return walletCommon.ChainID(chainID)
+}
 
 type CollectibleOwner struct {
 	ContractAddress common.Address `json:"tokenAddress"`
@@ -44,4 +68,116 @@ func infuraOwnershipToCommon(contractAddress common.Address, ownersMap map[commo
 	}
 
 	return &ownership, nil
+}
+
+type AttributeValue string
+
+func (st *AttributeValue) UnmarshalJSON(b []byte) error {
+	var item interface{}
+	if err := json.Unmarshal(b, &item); err != nil {
+		return err
+	}
+
+	switch v := item.(type) {
+	case float64:
+		*st = AttributeValue(strconv.FormatFloat(v, 'f', 2, 64))
+	case int:
+		*st = AttributeValue(strconv.Itoa(v))
+	case string:
+		*st = AttributeValue(v)
+	}
+	return nil
+}
+
+type Attribute struct {
+	TraitType string         `json:"trait_type"`
+	Value     AttributeValue `json:"value"`
+}
+
+type AssetMetadata struct {
+	Name         string      `json:"name"`
+	Description  string      `json:"description"`
+	Permalink    string      `json:"permalink"`
+	ImageURL     string      `json:"image"`
+	AnimationURL string      `json:"animation_url"`
+	Attributes   []Attribute `json:"attributes"`
+}
+
+type ContractMetadata struct {
+	ContractAddress string `json:"contract"`
+	Name            string `json:"name"`
+	Symbol          string `json:"symbol"`
+	TokenType       string `json:"tokenType"`
+}
+
+type Asset struct {
+	ContractAddress common.Address `json:"contract"`
+	TokenID         *bigint.BigInt `json:"tokenId"`
+	Metadata        AssetMetadata  `json:"metadata"`
+}
+
+type NFTList struct {
+	Total      *bigint.BigInt `json:"total"`
+	PageNumber int            `json:"pageNumber"`
+	PageSize   int            `json:"pageSize"`
+	Network    string         `json:"network"`
+	Account    string         `json:"account"`
+	Cursor     string         `json:"cursor"`
+	Assets     []Asset        `json:"assets"`
+}
+
+func (c *Asset) toCollectiblesData(id thirdparty.CollectibleUniqueID) thirdparty.CollectibleData {
+	return thirdparty.CollectibleData{
+		ID:           id,
+		Name:         c.Metadata.Name,
+		Description:  c.Metadata.Description,
+		Permalink:    c.Metadata.Permalink,
+		ImageURL:     c.Metadata.ImageURL,
+		AnimationURL: c.Metadata.AnimationURL,
+		Traits:       infuraToCollectibleTraits(c.Metadata.Attributes),
+	}
+}
+
+func (c *Asset) toCommon(id thirdparty.CollectibleUniqueID) thirdparty.FullCollectibleData {
+	return thirdparty.FullCollectibleData{
+		CollectibleData: c.toCollectiblesData(id),
+		CollectionData:  nil,
+	}
+}
+
+func (l *NFTList) toCommon() []thirdparty.FullCollectibleData {
+	ret := make([]thirdparty.FullCollectibleData, 0, len(l.Assets))
+	for _, asset := range l.Assets {
+		id := thirdparty.CollectibleUniqueID{
+			ContractID: thirdparty.ContractID{
+				ChainID: chainStringToChainID(l.Network),
+				Address: asset.ContractAddress,
+			},
+			TokenID: asset.TokenID,
+		}
+		item := asset.toCommon(id)
+		ret = append(ret, item)
+	}
+	return ret
+}
+
+func infuraToCollectibleTraits(attributes []Attribute) []thirdparty.CollectibleTrait {
+	ret := make([]thirdparty.CollectibleTrait, 0, len(attributes))
+	caser := cases.Title(language.Und, cases.NoLower)
+	for _, orig := range attributes {
+		dest := thirdparty.CollectibleTrait{
+			TraitType: strings.Replace(orig.TraitType, "_", " ", 1),
+			Value:     caser.String(string(orig.Value)),
+		}
+
+		ret = append(ret, dest)
+	}
+	return ret
+}
+
+func (c *ContractMetadata) toCommon(id thirdparty.ContractID) thirdparty.CollectionData {
+	return thirdparty.CollectionData{
+		ID:   id,
+		Name: c.Name,
+	}
 }

--- a/services/wallet/thirdparty/infura/types.go
+++ b/services/wallet/thirdparty/infura/types.go
@@ -1,0 +1,47 @@
+package infura
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/bigint"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
+
+type CollectibleOwner struct {
+	ContractAddress common.Address `json:"tokenAddress"`
+	TokenID         *bigint.BigInt `json:"tokenId"`
+	Amount          *bigint.BigInt `json:"amount"`
+	OwnerAddress    common.Address `json:"ownerOf"`
+}
+
+type CollectibleContractOwnership struct {
+	Owners  []CollectibleOwner `json:"owners"`
+	Network string             `json:"network"`
+	Cursor  string             `json:"cursor"`
+}
+
+func infuraOwnershipToCommon(contractAddress common.Address, ownersMap map[common.Address][]CollectibleOwner) (*thirdparty.CollectibleContractOwnership, error) {
+	owners := make([]thirdparty.CollectibleOwner, 0, len(ownersMap))
+
+	for ownerAddress, ownerTokens := range ownersMap {
+		tokenBalances := make([]thirdparty.TokenBalance, 0, len(ownerTokens))
+
+		for _, token := range ownerTokens {
+			tokenBalances = append(tokenBalances, thirdparty.TokenBalance{
+				TokenID: token.TokenID,
+				Balance: token.Amount,
+			})
+		}
+
+		owners = append(owners, thirdparty.CollectibleOwner{
+			OwnerAddress:  ownerAddress,
+			TokenBalances: tokenBalances,
+		})
+	}
+
+	ownership := thirdparty.CollectibleContractOwnership{
+		ContractAddress: contractAddress,
+		Owners:          owners,
+	}
+
+	return &ownership, nil
+}

--- a/services/wallet/thirdparty/opensea/client_test.go
+++ b/services/wallet/thirdparty/opensea/client_test.go
@@ -106,23 +106,33 @@ func TestFetchAllAssetsByOwnerAndCollection(t *testing.T) {
 		NextCursor:     "",
 		PreviousCursor: "",
 	}
-	expectedCommon := thirdparty.CollectibleDataContainer{
-		Collectibles: []thirdparty.CollectibleData{{
-			ID: thirdparty.CollectibleUniqueID{
-				ChainID:         1,
-				ContractAddress: common.HexToAddress("0x1"),
-				TokenID:         &bigint.BigInt{Int: big.NewInt(1)},
+	expectedCommon := thirdparty.FullCollectibleDataContainer{
+		Items: []thirdparty.FullCollectibleData{
+			thirdparty.FullCollectibleData{
+				CollectibleData: thirdparty.CollectibleData{
+					ID: thirdparty.CollectibleUniqueID{
+						ContractID: thirdparty.ContractID{
+							ChainID: 1,
+							Address: common.HexToAddress("0x1"),
+						},
+						TokenID: &bigint.BigInt{Int: big.NewInt(1)},
+					},
+					Name:        "Rocky",
+					Description: "Rocky Balboa",
+					Permalink:   "permalink",
+					ImageURL:    "ImageUrl",
+					Traits:      []thirdparty.CollectibleTrait{},
+				},
+				CollectionData: &thirdparty.CollectionData{
+					ID: thirdparty.ContractID{
+						ChainID: 1,
+						Address: common.HexToAddress("0x1"),
+					},
+					Name:   "Rocky",
+					Traits: map[string]thirdparty.CollectionTrait{},
+				},
 			},
-			Name:        "Rocky",
-			Description: "Rocky Balboa",
-			Permalink:   "permalink",
-			ImageURL:    "ImageUrl",
-			Traits:      []thirdparty.CollectibleTrait{},
-			CollectionData: thirdparty.CollectionData{
-				Name:   "Rocky",
-				Traits: map[string]thirdparty.CollectionTrait{},
-			},
-		}},
+		},
 		NextCursor:     "",
 		PreviousCursor: "",
 	}

--- a/services/wallet/thirdparty/opensea/http_client.go
+++ b/services/wallet/thirdparty/opensea/http_client.go
@@ -1,0 +1,87 @@
+package opensea
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type HTTPClient struct {
+	client         *http.Client
+	getRequestLock sync.RWMutex
+}
+
+func newHTTPClient() *HTTPClient {
+	return &HTTPClient{
+		client: &http.Client{
+			Timeout: RequestTimeout,
+		},
+	}
+}
+
+func (o *HTTPClient) doGetRequest(url string, apiKey string) ([]byte, error) {
+	// Ensure only one thread makes a request at a time
+	o.getRequestLock.Lock()
+	defer o.getRequestLock.Unlock()
+
+	retryCount := 0
+	statusCode := http.StatusOK
+
+	// Try to do the request without an apiKey first
+	tmpAPIKey := ""
+
+	for {
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:96.0) Gecko/20100101 Firefox/96.0")
+		if len(tmpAPIKey) > 0 {
+			req.Header.Set("X-API-KEY", tmpAPIKey)
+		}
+
+		resp, err := o.client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				log.Error("failed to close opensea request body", "err", err)
+			}
+		}()
+
+		statusCode = resp.StatusCode
+		switch resp.StatusCode {
+		case http.StatusOK:
+			body, err := ioutil.ReadAll(resp.Body)
+			return body, err
+		case http.StatusTooManyRequests:
+			if retryCount < GetRequestRetryMaxCount {
+				// sleep and retry
+				time.Sleep(GetRequestWaitTime)
+				retryCount++
+				continue
+			}
+			// break and error
+		case http.StatusForbidden:
+			// Request requires an apiKey, set it and retry
+			if tmpAPIKey == "" && apiKey != "" {
+				tmpAPIKey = apiKey
+				// sleep and retry
+				time.Sleep(GetRequestWaitTime)
+				continue
+			}
+			// break and error
+		default:
+			// break and error
+		}
+		break
+	}
+	return nil, fmt.Errorf("unsuccessful request: %d %s", statusCode, http.StatusText(statusCode))
+}

--- a/services/wallet/thirdparty/opensea/types.go
+++ b/services/wallet/thirdparty/opensea/types.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/status-im/status-go/services/wallet/bigint"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
+
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )

--- a/services/wallet/thirdparty/opensea/types.go
+++ b/services/wallet/thirdparty/opensea/types.go
@@ -1,0 +1,190 @@
+package opensea
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/bigint"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+func chainStringToChainID(chainString string) walletCommon.ChainID {
+	chainID := walletCommon.UnknownChainID
+	switch chainString {
+	case "ethereum":
+		chainID = walletCommon.EthereumMainnet
+	case "arbitrum":
+		chainID = walletCommon.ArbitrumMainnet
+	case "optimism":
+		chainID = walletCommon.OptimismMainnet
+	case "goerli":
+		chainID = walletCommon.EthereumGoerli
+	case "arbitrum_goerli":
+		chainID = walletCommon.ArbitrumGoerli
+	case "optimism_goerli":
+		chainID = walletCommon.OptimismGoerli
+	}
+	return walletCommon.ChainID(chainID)
+}
+
+type TraitValue string
+
+func (st *TraitValue) UnmarshalJSON(b []byte) error {
+	var item interface{}
+	if err := json.Unmarshal(b, &item); err != nil {
+		return err
+	}
+
+	switch v := item.(type) {
+	case float64:
+		*st = TraitValue(strconv.FormatFloat(v, 'f', 2, 64))
+	case int:
+		*st = TraitValue(strconv.Itoa(v))
+	case string:
+		*st = TraitValue(v)
+
+	}
+	return nil
+}
+
+type AssetContainer struct {
+	Assets         []Asset `json:"assets"`
+	NextCursor     string  `json:"next"`
+	PreviousCursor string  `json:"previous"`
+}
+
+type Contract struct {
+	Address         string `json:"address"`
+	ChainIdentifier string `json:"chain_identifier"`
+}
+
+type Trait struct {
+	TraitType   string     `json:"trait_type"`
+	Value       TraitValue `json:"value"`
+	DisplayType string     `json:"display_type"`
+	MaxValue    string     `json:"max_value"`
+}
+
+type PaymentToken struct {
+	ID       int    `json:"id"`
+	Symbol   string `json:"symbol"`
+	Address  string `json:"address"`
+	ImageURL string `json:"image_url"`
+	Name     string `json:"name"`
+	Decimals int    `json:"decimals"`
+	EthPrice string `json:"eth_price"`
+	UsdPrice string `json:"usd_price"`
+}
+
+type LastSale struct {
+	PaymentToken PaymentToken `json:"payment_token"`
+}
+
+type SellOrder struct {
+	CurrentPrice string `json:"current_price"`
+}
+
+type Asset struct {
+	ID                int            `json:"id"`
+	TokenID           *bigint.BigInt `json:"token_id"`
+	Name              string         `json:"name"`
+	Description       string         `json:"description"`
+	Permalink         string         `json:"permalink"`
+	ImageThumbnailURL string         `json:"image_thumbnail_url"`
+	ImageURL          string         `json:"image_url"`
+	AnimationURL      string         `json:"animation_url"`
+	Contract          Contract       `json:"asset_contract"`
+	Collection        Collection     `json:"collection"`
+	Traits            []Trait        `json:"traits"`
+	LastSale          LastSale       `json:"last_sale"`
+	SellOrders        []SellOrder    `json:"sell_orders"`
+	BackgroundColor   string         `json:"background_color"`
+	TokenURI          string         `json:"token_metadata"`
+}
+
+type CollectionTrait struct {
+	Min float64 `json:"min"`
+	Max float64 `json:"max"`
+}
+
+type Collection struct {
+	Name     string                     `json:"name"`
+	Slug     string                     `json:"slug"`
+	ImageURL string                     `json:"image_url"`
+	Traits   map[string]CollectionTrait `json:"traits"`
+}
+
+type OwnedCollection struct {
+	Collection
+	OwnedAssetCount *bigint.BigInt `json:"owned_asset_count"`
+}
+
+func (c *Asset) id() thirdparty.CollectibleUniqueID {
+	return thirdparty.CollectibleUniqueID{
+		ContractID: thirdparty.ContractID{
+			ChainID: chainStringToChainID(c.Contract.ChainIdentifier),
+			Address: common.HexToAddress(c.Contract.Address),
+		},
+		TokenID: c.TokenID,
+	}
+}
+
+func openseaToCollectibleTraits(traits []Trait) []thirdparty.CollectibleTrait {
+	ret := make([]thirdparty.CollectibleTrait, 0, len(traits))
+	caser := cases.Title(language.Und, cases.NoLower)
+	for _, orig := range traits {
+		dest := thirdparty.CollectibleTrait{
+			TraitType:   strings.Replace(orig.TraitType, "_", " ", 1),
+			Value:       caser.String(string(orig.Value)),
+			DisplayType: orig.DisplayType,
+			MaxValue:    orig.MaxValue,
+		}
+
+		ret = append(ret, dest)
+	}
+	return ret
+}
+
+func (c *Asset) toCollectionData() thirdparty.CollectionData {
+	ret := thirdparty.CollectionData{
+		ID:       c.id().ContractID,
+		Name:     c.Collection.Name,
+		Slug:     c.Collection.Slug,
+		ImageURL: c.Collection.ImageURL,
+		Traits:   make(map[string]thirdparty.CollectionTrait),
+	}
+	for traitType, trait := range c.Collection.Traits {
+		ret.Traits[traitType] = thirdparty.CollectionTrait{
+			Min: trait.Min,
+			Max: trait.Max,
+		}
+	}
+	return ret
+}
+
+func (c *Asset) toCollectiblesData() thirdparty.CollectibleData {
+	return thirdparty.CollectibleData{
+		ID:              c.id(),
+		Name:            c.Name,
+		Description:     c.Description,
+		Permalink:       c.Permalink,
+		ImageURL:        c.ImageURL,
+		AnimationURL:    c.AnimationURL,
+		Traits:          openseaToCollectibleTraits(c.Traits),
+		BackgroundColor: c.BackgroundColor,
+		TokenURI:        c.TokenURI,
+	}
+}
+
+func (c *Asset) toCommon() thirdparty.FullCollectibleData {
+	collection := c.toCollectionData()
+	return thirdparty.FullCollectibleData{
+		CollectibleData: c.toCollectiblesData(),
+		CollectionData:  &collection,
+	}
+}


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/10728

Commits to be reviewed separately.

Use Infura and Alchemy as providers for Collectibles data.

Infura: Arb Mainnet
Alchemy: Arb Testnet, Opt Mainnet+Testnet

Notes:
- Infura doesn't provide all the Collection metadata we need (missing CollectionImageURL). Implementation of separate collection metadata fetching is left for another PR.
- We now have more than one provider for some chains, main+fallback providers mechanism for Collectibles ownership is left for another PR.

We should now be able to fetch collectibles from all chains we support:

![image](https://github.com/status-im/status-go/assets/11161531/706de096-15dc-47ca-8c02-311f04356c79)

![image](https://github.com/status-im/status-go/assets/11161531/efc05cfa-fe8b-4f2c-9bd5-51d53032df15)
