### PR TITLE
refactor: EventSenders forward RequestToJoin decision to control node

### DIFF
--- a/protocol/activity_center.go
+++ b/protocol/activity_center.go
@@ -37,6 +37,8 @@ const (
 	ActivityCenterMembershipStatusPending
 	ActivityCenterMembershipStatusAccepted
 	ActivityCenterMembershipStatusDeclined
+	ActivityCenterMembershipStatusAcceptedPending
+	ActivityCenterMembershipStatusDeclinedPending
 )
 
 type ActivityCenterQueryParamsRead uint

--- a/protocol/communities/community_event.go
+++ b/protocol/communities/community_event.go
@@ -160,7 +160,6 @@ func (o *Community) ToCommunityRequestToJoinAcceptCommunityEvent(changes *Commun
 	return &CommunityEvent{
 		CommunityEventClock:    o.NewCommunityEventClock(),
 		Type:                   protobuf.CommunityEvent_COMMUNITY_REQUEST_TO_JOIN_ACCEPT,
-		MembersAdded:           changes.MembersAdded,
 		AcceptedRequestsToJoin: changes.AcceptedRequestsToJoin,
 	}
 }
@@ -321,26 +320,6 @@ func (o *Community) updateCommunityDescriptionByCommunityEvent(communityEvent Co
 		_, err := o.reorderCategories(communityEvent.CategoryData.CategoryId, int(communityEvent.CategoryData.Position))
 		if err != nil {
 			return err
-		}
-
-	case protobuf.CommunityEvent_COMMUNITY_REQUEST_TO_JOIN_ACCEPT:
-		for pkString, addedMember := range communityEvent.MembersAdded {
-			pk, err := common.HexToPubkey(pkString)
-			if err != nil {
-				return err
-			}
-			if !o.HasMember(pk) {
-				o.addCommunityMember(pk, addedMember)
-			}
-		}
-
-	case protobuf.CommunityEvent_COMMUNITY_REQUEST_TO_JOIN_REJECT:
-		for pkString := range communityEvent.RejectedRequestsToJoin {
-			pk, err := common.HexToPubkey(pkString)
-			if err != nil {
-				return err
-			}
-			o.removeMemberFromOrg(pk)
 		}
 
 	case protobuf.CommunityEvent_COMMUNITY_MEMBER_KICK:

--- a/protocol/communities/community_event_message.go
+++ b/protocol/communities/community_event_message.go
@@ -192,7 +192,7 @@ func validateCommunityEvent(communityEvent *CommunityEvent) error {
 		}
 
 	case protobuf.CommunityEvent_COMMUNITY_REQUEST_TO_JOIN_ACCEPT:
-		if len(communityEvent.MembersAdded) == 0 {
+		if communityEvent.AcceptedRequestsToJoin == nil {
 			return errors.New("invalid community request to join accepted event")
 		}
 

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -749,6 +749,14 @@ func (p *Persistence) AcceptedRequestsToJoinForCommunity(id []byte) ([]*RequestT
 	return p.RequestsToJoinForCommunityWithState(id, RequestToJoinStateAccepted)
 }
 
+func (p *Persistence) AcceptedPendingRequestsToJoinForCommunity(id []byte) ([]*RequestToJoin, error) {
+	return p.RequestsToJoinForCommunityWithState(id, RequestToJoinStateAcceptedPending)
+}
+
+func (p *Persistence) DeclinedPendingRequestsToJoinForCommunity(id []byte) ([]*RequestToJoin, error) {
+	return p.RequestsToJoinForCommunityWithState(id, RequestToJoinStateDeclinedPending)
+}
+
 func (p *Persistence) SetRequestToJoinState(pk string, communityID []byte, state RequestToJoinState) error {
 	_, err := p.db.Exec(`UPDATE communities_requests_to_join SET state = ? WHERE community_id = ? AND public_key = ?`, state, communityID, pk)
 	return err

--- a/protocol/communities/request_to_join.go
+++ b/protocol/communities/request_to_join.go
@@ -16,6 +16,8 @@ const (
 	RequestToJoinStateDeclined
 	RequestToJoinStateAccepted
 	RequestToJoinStateCanceled
+	RequestToJoinStateAcceptedPending
+	RequestToJoinStateDeclinedPending
 )
 
 type RequestToJoin struct {
@@ -70,6 +72,10 @@ func (r *RequestToJoin) InitFromSyncProtobuf(proto *protobuf.SyncCommunityReques
 
 func (r *RequestToJoin) Empty() bool {
 	return len(r.ID)+len(r.PublicKey)+int(r.Clock)+len(r.ENSName)+len(r.ChatID)+len(r.CommunityID)+int(r.State) == 0
+}
+
+func (r *RequestToJoin) MarkedAsPendingByPrivilegedAccount() bool {
+	return r.State == RequestToJoinStateAcceptedPending || r.State == RequestToJoinStateDeclinedPending
 }
 
 func AddTimeoutToRequestToJoinClock(clock uint64) (uint64, error) {

--- a/protocol/communities_events_owner_without_community_key_test.go
+++ b/protocol/communities_events_owner_without_community_key_test.go
@@ -198,20 +198,68 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerCannotDeleteBeco
 	s.Require().Nil(response)
 }
 
+func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders() {
+	additionalOwner := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER, []*Messenger{additionalOwner})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalOwner)
+}
+
+func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerAcceptMemberRequestToJoinNotConfirmedByControlNode() {
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER, []*Messenger{})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testAcceptMemberRequestToJoinNotConfirmedByControlNode(s, community, user)
+}
+
 func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerAcceptMemberRequestToJoin() {
-	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER)
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER, []*Messenger{})
 
 	// set up additional user that will send request to join
 	user := s.newMessenger()
 	testAcceptMemberRequestToJoin(s, community, user)
 }
 
+func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerRejectMemberRequestToJoinResponseSharedWithOtherEventSenders() {
+	additionalOwner := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER, []*Messenger{additionalOwner})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalOwner)
+}
+
+func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerRejectMemberRequestToJoinNotConfirmedByControlNode() {
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER, []*Messenger{})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testRejectMemberRequestToJoinNotConfirmedByControlNode(s, community, user)
+}
+
 func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerRejectMemberRequestToJoin() {
-	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER)
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER, []*Messenger{})
 
 	// set up additional user that will send request to join
 	user := s.newMessenger()
 	testRejectMemberRequestToJoin(s, community, user)
+}
+
+func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerRequestToJoinStateCannotBeOverridden() {
+	additionalOwner := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER, []*Messenger{additionalOwner})
+
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testEventSenderCannotOverrideRequestToJoinState(s, community, user, additionalOwner)
+}
+
+func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerControlNodeHandlesMultipleEventSenderRequestToJoinDecisions() {
+	additionalOwner := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER, []*Messenger{additionalOwner})
+
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(s, community, user, additionalOwner)
 }
 
 func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerCreateEditDeleteCategories() {

--- a/protocol/communities_events_token_master_test.go
+++ b/protocol/communities_events_token_master_test.go
@@ -124,18 +124,66 @@ func (s *TokenMasterCommunityEventsSuite) TestTokenMasterCannotDeleteBecomeAdmin
 	testEventSenderCannotDeleteBecomeAdminPermission(s, community)
 }
 
+func (s *TokenMasterCommunityEventsSuite) TestTokenMasterAcceptMemberRequestToJoinNotConfirmedByControlNode() {
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testAcceptMemberRequestToJoinNotConfirmedByControlNode(s, community, user)
+}
+
 func (s *TokenMasterCommunityEventsSuite) TestTokenMasterAcceptMemberRequestToJoin() {
-	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER)
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{})
 	// set up additional user that will send request to join
 	user := s.newMessenger()
 	testAcceptMemberRequestToJoin(s, community, user)
 }
 
+func (s *TokenMasterCommunityEventsSuite) TestTokenMasterAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders() {
+	additionalTokenMaster := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{additionalTokenMaster})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalTokenMaster)
+}
+
+func (s *TokenMasterCommunityEventsSuite) TestTokenMasterRejectMemberRequestToJoinResponseSharedWithOtherEventSenders() {
+	additionalTokenMaster := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{additionalTokenMaster})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testRejectMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalTokenMaster)
+}
+
+func (s *TokenMasterCommunityEventsSuite) TestTokenMasterRejectMemberRequestToJoinNotConfirmedByControlNode() {
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testRejectMemberRequestToJoinNotConfirmedByControlNode(s, community, user)
+}
+
 func (s *TokenMasterCommunityEventsSuite) TestTokenMasterRejectMemberRequestToJoin() {
-	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER)
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{})
 	// set up additional user that will send request to join
 	user := s.newMessenger()
 	testRejectMemberRequestToJoin(s, community, user)
+}
+
+func (s *TokenMasterCommunityEventsSuite) TestTokenMasterRequestToJoinStateCannotBeOverridden() {
+	additionalTokenMaster := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{additionalTokenMaster})
+
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testEventSenderCannotOverrideRequestToJoinState(s, community, user, additionalTokenMaster)
+}
+
+func (s *TokenMasterCommunityEventsSuite) TestTokenMasterControlNodeHandlesMultipleEventSenderRequestToJoinDecisions() {
+	additionalTokenMaster := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{additionalTokenMaster})
+
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(s, community, user, additionalTokenMaster)
 }
 
 func (s *TokenMasterCommunityEventsSuite) TestTokenMasterCreateEditDeleteCategories() {

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -128,20 +128,69 @@ func (s *AdminCommunityEventsSuite) TestAdminCannotDeleteBecomeAdminPermission()
 	testEventSenderCannotDeleteBecomeAdminPermission(s, community)
 }
 
+func (s *AdminCommunityEventsSuite) TestAdminAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders() {
+	additionalAdmin := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{additionalAdmin})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalAdmin)
+}
+
+func (s *AdminCommunityEventsSuite) TestAdminAcceptMemberRequestToJoinNotConfirmedByControlNode() {
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testAcceptMemberRequestToJoinNotConfirmedByControlNode(s, community, user)
+}
+
 func (s *AdminCommunityEventsSuite) TestAdminAcceptMemberRequestToJoin() {
-	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN)
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{})
 
 	// set up additional user that will send request to join
 	user := s.newMessenger()
 	testAcceptMemberRequestToJoin(s, community, user)
 }
 
+func (s *AdminCommunityEventsSuite) TestAdminRejectMemberRequestToJoinResponseSharedWithOtherEventSenders() {
+	additionalAdmin := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{additionalAdmin})
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testRejectMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalAdmin)
+}
+
+func (s *AdminCommunityEventsSuite) TestAdminRejectMemberRequestToJoinNotConfirmedByControlNode() {
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{})
+
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testRejectMemberRequestToJoinNotConfirmedByControlNode(s, community, user)
+}
+
 func (s *AdminCommunityEventsSuite) TestAdminRejectMemberRequestToJoin() {
-	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN)
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{})
 
 	// set up additional user that will send request to join
 	user := s.newMessenger()
 	testRejectMemberRequestToJoin(s, community, user)
+}
+
+func (s *AdminCommunityEventsSuite) TestAdminRequestToJoinStateCannotBeOverridden() {
+	additionalAdmin := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{additionalAdmin})
+
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testEventSenderCannotOverrideRequestToJoinState(s, community, user, additionalAdmin)
+}
+
+func (s *AdminCommunityEventsSuite) TestAdminControlNodeHandlesMultipleEventSenderRequestToJoinDecisions() {
+	additionalAdmin := s.newMessenger()
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{additionalAdmin})
+
+	// set up additional user that will send request to join
+	user := s.newMessenger()
+	testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(s, community, user, additionalAdmin)
 }
 
 func (s *AdminCommunityEventsSuite) TestAdminCreateEditDeleteCategories() {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -254,6 +254,33 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 					}
 				}
 
+				if sub.AcceptedRequestsToJoin != nil {
+					for _, requestID := range sub.AcceptedRequestsToJoin {
+						accept := &requests.AcceptRequestToJoinCommunity{
+							ID: requestID,
+						}
+						_, err := m.AcceptRequestToJoinCommunity(accept)
+						if err != nil {
+							m.logger.Warn("failed to accept request to join ", zap.Error(err))
+						}
+						// TODO INFORM ADMINS
+					}
+				}
+
+				if sub.RejectedRequestsToJoin != nil {
+					for _, requestID := range sub.RejectedRequestsToJoin {
+						reject := &requests.DeclineRequestToJoinCommunity{
+							ID: requestID,
+						}
+						_, err := m.DeclineRequestToJoinCommunity(reject)
+						if err != nil {
+							m.logger.Warn("failed to decline request to join ", zap.Error(err))
+						}
+
+						// TODO INFORM ADMINS
+					}
+				}
+
 			case <-ticker.C:
 				// If we are not online, we don't even try
 				if !m.online() {
@@ -906,7 +933,15 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 	}
 
 	if !community.AcceptRequestToJoinAutomatically() {
-		// send request to join also to community privileged members
+		// send request to join also to community admins but without revealed addresses
+		requestToJoinProto.RevealedAccounts = make([]*protobuf.RevealedAccount, 0)
+		payload, err = proto.Marshal(requestToJoinProto)
+		if err != nil {
+			return nil, err
+		}
+
+		rawMessage.Payload = payload
+
 		privilegedMembers := community.GetPrivilegedMembers()
 		for _, privilegedMember := range privilegedMembers {
 			_, err := m.sender.SendPrivate(context.Background(), privilegedMember, &rawMessage)
@@ -1275,6 +1310,9 @@ func (m *Messenger) AcceptRequestToJoinCommunity(request *requests.AcceptRequest
 
 	if notification != nil {
 		notification.MembershipStatus = ActivityCenterMembershipStatusAccepted
+		if community.HasPermissionToSendCommunityEvents() {
+			notification.MembershipStatus = ActivityCenterMembershipStatusAcceptedPending
+		}
 		notification.Read = true
 		notification.Accepted = true
 		notification.UpdatedAt = m.getCurrentTimeInMillis()
@@ -1308,7 +1346,19 @@ func (m *Messenger) DeclineRequestToJoinCommunity(request *requests.DeclineReque
 	response := &MessengerResponse{}
 
 	if notification != nil {
+		dbRequest, err := m.communitiesManager.GetRequestToJoin(request.ID)
+		if err != nil {
+			return nil, err
+		}
+		community, err := m.communitiesManager.GetByID(dbRequest.CommunityID)
+		if err != nil {
+			return nil, err
+		}
+
 		notification.MembershipStatus = ActivityCenterMembershipStatusDeclined
+		if community.HasPermissionToSendCommunityEvents() {
+			notification.MembershipStatus = ActivityCenterMembershipStatusDeclinedPending
+		}
 		notification.Read = true
 		notification.Dismissed = true
 		notification.UpdatedAt = m.getCurrentTimeInMillis()
@@ -1925,6 +1975,14 @@ func (m *Messenger) CanceledRequestsToJoinForCommunity(id types.HexBytes) ([]*co
 
 func (m *Messenger) AcceptedRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.AcceptedRequestsToJoinForCommunity(id)
+}
+
+func (m *Messenger) AcceptedPendingRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+	return m.communitiesManager.AcceptedPendingRequestsToJoinForCommunity(id)
+}
+
+func (m *Messenger) DeclinedPendingRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
+	return m.communitiesManager.DeclinedPendingRequestsToJoinForCommunity(id)
 }
 
 func (m *Messenger) RemoveUserFromCommunity(id types.HexBytes, pkString string) (*MessengerResponse, error) {

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1384,13 +1384,15 @@ func (m *Messenger) HandleCommunityRequestToJoin(state *ReceivedMessageState, si
 		return err
 	}
 
-	if requestToJoin.State == communities.RequestToJoinStateAccepted {
+	if requestToJoin.State == communities.RequestToJoinStateAccepted || requestToJoin.State == communities.RequestToJoinStateAcceptedPending {
 		accept := &requests.AcceptRequestToJoinCommunity{
 			ID: requestToJoin.ID,
 		}
 		_, err = m.AcceptRequestToJoinCommunity(accept)
 		if err != nil {
 			if err == communities.ErrNoPermissionToJoin {
+				// only control node will end up here as it's the only one that
+				// performed token permission checks
 				requestToJoin.State = communities.RequestToJoinStateDeclined
 			} else {
 				return err
@@ -1398,7 +1400,9 @@ func (m *Messenger) HandleCommunityRequestToJoin(state *ReceivedMessageState, si
 		}
 	}
 
-	if requestToJoin.State == communities.RequestToJoinStateDeclined {
+	declinedOrDeclinedPending := requestToJoin.State == communities.RequestToJoinStateDeclined || requestToJoin.State == communities.RequestToJoinStateDeclinedPending
+
+	if declinedOrDeclinedPending {
 		cancel := &requests.DeclineRequestToJoinCommunity{
 			ID: requestToJoin.ID,
 		}


### PR DESCRIPTION
This is a bigger change in how community membership requests are handled among admins, token masters, owners, and control nodes.

Prior to this commit, all privileged users, also known as `EventSenders`, were able to accept and reject community membership requests and those changes would be applied by all users.

This commit changes this behaviour such that:

1. EventSenders can make a decision (accept, reject), but merely forward their decision to the control node, which ultimately has to confirm it
2. EventSenders are no longer removing or adding members to and from communities
3. When an eventsender signaled a decision, the membership request will enter a pending state (acceptedPending or rejectedPending)
4. Once a decision was made by one eventsender, no other eventsender can override that decision

This implementation is covered with a bunch of tests:

- Ensure that decision made by event sender is shared with other event senders
  - `testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders()`
  - `testRejectMemberRequestToJoinResponseSharedWithOtherEventSenders()`
- Ensure memebrship request stays pending, until control node has confirmed decision by event senders
  - `testAcceptMemberRequestToJoinNotConfirmedByControlNode()`
  - `testRejectMemberRequestToJoinNotConfirmedByControlNode()`
- Ensure that decision made by event sender cannot be overriden by other event senders
  - `testEventSenderCannotOverrideRequestToJoinState()`

These test cases live in three test suites for different event sender types respectively

- `OwnerWithoutCommunityKeyCommunityEventsSuite`
- `TokenMasterCommunityEventsSuite`
- `AdminCommunityEventsSuite`

In addition to the changes mentioned above, there's also a smaller changes that ensures membership requests to *not* attached revealed wallet addresses when the requests are sent to event senders (in addition to control nodes).

Requests send to a control node will still include revealed addresses as the control node needs them to verify token permissions.

This commit does not yet handle the case of event senders attempting to kick and ban members.

Similar to accepting and rejecting membership requests, kicking and banning need a new pending state. However, we don't track such state in local databases yet so those two cases will be handled in future commit to not have this commit grow larger.
