### PR TITLE
feat: fetch collection metadata when missing

### DIFF
--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -121,7 +121,13 @@ func NewService(
 		alchemyClient,
 	}
 
-	collectiblesManager := collectibles.NewManager(rpcClient, contractOwnershipProviders, accountOwnershipProviders, openseaClient)
+	collectibleDataProviders := []thirdparty.CollectibleDataProvider{
+		openseaClient,
+		infuraClient,
+		alchemyClient,
+	}
+
+	collectiblesManager := collectibles.NewManager(rpcClient, contractOwnershipProviders, accountOwnershipProviders, collectibleDataProviders, openseaClient)
 	collectibles := collectibles.NewService(db, walletFeed, accountsDB, accountFeed, rpcClient.NetworkManager, collectiblesManager)
 	return &Service{
 		db:                    db,

--- a/services/wallet/thirdparty/collectible_types.go
+++ b/services/wallet/thirdparty/collectible_types.go
@@ -52,6 +52,19 @@ func GroupCollectibleUIDsByChainID(uids []CollectibleUniqueID) map[w_common.Chai
 	return ret
 }
 
+func GroupContractIDsByChainID(ids []ContractID) map[w_common.ChainID][]ContractID {
+	ret := make(map[w_common.ChainID][]ContractID)
+
+	for _, id := range ids {
+		if _, ok := ret[id.ChainID]; !ok {
+			ret[id.ChainID] = make([]ContractID, 0, len(ids))
+		}
+		ret[id.ChainID] = append(ret[id.ChainID], id)
+	}
+
+	return ret
+}
+
 type CollectionTrait struct {
 	Min float64 `json:"min"`
 	Max float64 `json:"max"`
@@ -153,4 +166,10 @@ type CollectibleAccountOwnershipProvider interface {
 	CollectibleProvider
 	FetchAllAssetsByOwner(chainID w_common.ChainID, owner common.Address, cursor string, limit int) (*FullCollectibleDataContainer, error)
 	FetchAllAssetsByOwnerAndContractAddress(chainID w_common.ChainID, owner common.Address, contractAddresses []common.Address, cursor string, limit int) (*FullCollectibleDataContainer, error)
+}
+
+type CollectibleDataProvider interface {
+	CollectibleProvider
+	FetchAssetsByCollectibleUniqueID(uniqueIDs []CollectibleUniqueID) ([]FullCollectibleData, error)
+	FetchCollectionsDataByContractID(ids []ContractID) ([]CollectionData, error)
 }

--- a/services/wallet/thirdparty/infura/client.go
+++ b/services/wallet/thirdparty/infura/client.go
@@ -217,7 +217,7 @@ func (o *Client) FetchAssetsByCollectibleUniqueID(uniqueIDs []thirdparty.Collect
 	return ret, nil
 }
 
-func (o *Client) FetchCollectionDataByContractID(contractIDs []thirdparty.ContractID) ([]thirdparty.CollectionData, error) {
+func (o *Client) FetchCollectionsDataByContractID(contractIDs []thirdparty.ContractID) ([]thirdparty.CollectionData, error) {
 	ret := make([]thirdparty.CollectionData, 0, len(contractIDs))
 
 	for _, id := range contractIDs {

--- a/services/wallet/thirdparty/opensea/types.go
+++ b/services/wallet/thirdparty/opensea/types.go
@@ -126,6 +126,10 @@ type OwnedCollection struct {
 	OwnedAssetCount *bigint.BigInt `json:"owned_asset_count"`
 }
 
+type AssetContract struct {
+	Collection Collection `json:"collection"`
+}
+
 func (c *Asset) id() thirdparty.CollectibleUniqueID {
 	return thirdparty.CollectibleUniqueID{
 		ContractID: thirdparty.ContractID{
@@ -152,15 +156,15 @@ func openseaToCollectibleTraits(traits []Trait) []thirdparty.CollectibleTrait {
 	return ret
 }
 
-func (c *Asset) toCollectionData() thirdparty.CollectionData {
+func (c *Collection) toCollectionData(id thirdparty.ContractID) thirdparty.CollectionData {
 	ret := thirdparty.CollectionData{
-		ID:       c.id().ContractID,
-		Name:     c.Collection.Name,
-		Slug:     c.Collection.Slug,
-		ImageURL: c.Collection.ImageURL,
+		ID:       id,
+		Name:     c.Name,
+		Slug:     c.Slug,
+		ImageURL: c.ImageURL,
 		Traits:   make(map[string]thirdparty.CollectionTrait),
 	}
-	for traitType, trait := range c.Collection.Traits {
+	for traitType, trait := range c.Traits {
 		ret.Traits[traitType] = thirdparty.CollectionTrait{
 			Min: trait.Min,
 			Max: trait.Max,
@@ -184,7 +188,7 @@ func (c *Asset) toCollectiblesData() thirdparty.CollectibleData {
 }
 
 func (c *Asset) toCommon() thirdparty.FullCollectibleData {
-	collection := c.toCollectionData()
+	collection := c.Collection.toCollectionData(c.id().ContractID)
 	return thirdparty.FullCollectibleData{
 		CollectibleData: c.toCollectiblesData(),
 		CollectionData:  &collection,


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/11782

Collection data is now fetched separately when missing from the FullCollectibleData struct.

This is now mainly used for Infura (which, in turn, is used to fetch collectibles from Arbitrum Mainnet), which doesn't provide Collection metadata when fetching owned NFTs.

![image](https://github.com/status-im/status-go/assets/11161531/75f33a0c-db35-4481-b0f6-6f45c86d3c91)

Collection names being shown means we now have collection metadata.