### PR TITLE
chore: don't expose `RevealedAccount`s on community description

### DIFF
--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -576,6 +576,11 @@ func (p *Persistence) GetPermissionTokenCriteriaResult(permissionID string, comm
 	return &PermissionTokenCriteriaResult{Criteria: criteria}, nil
 }
 
+func (p *Persistence) RemoveRequestToJoinRevealedAddresses(requestID []byte) error {
+	_, err := p.db.Exec(`DELETE FROM communities_requests_to_join_revealed_addresses WHERE request_id = ?`, requestID)
+	return err
+}
+
 func (p *Persistence) GetRequestToJoinRevealedAddresses(requestID []byte) ([]*protobuf.RevealedAccount, error) {
 	revealedAccounts := make([]*protobuf.RevealedAccount, 0)
 	rows, err := p.db.Query(`SELECT address, chain_ids, is_airdrop_address FROM communities_requests_to_join_revealed_addresses WHERE request_id = ?`, requestID)

--- a/protocol/protobuf/communities.proto
+++ b/protocol/protobuf/communities.proto
@@ -23,6 +23,7 @@ message CommunityMember {
     ROLE_TOKEN_MASTER = 5;
   }
   repeated Roles roles = 1;
+  // deprecated, do not put accounts here
   repeated RevealedAccount revealed_accounts = 2;
   uint64 last_update_clock = 3;
 }


### PR DESCRIPTION
Prior to this commit a control node would add the revealed addresses to the member struct on the community description, which exposes all those addresses to the public.

We don't want that. Revealed addresses are exclusively shared with control nodes and should stay there (although, they might be privately shared among token masters, see
https://github.com/status-im/status-desktop/issues/11610).

In this commit, we no longer add the revealed addresses to the community description. The addresses are already stored in the requestToJoin database table so we can take them from there if we need them.

Closes: https://github.com/status-im/status-desktop/issues/11573

