### PR TITLE
fix: Password change failed

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -816,7 +816,7 @@ func (b *GethStatusBackend) ChangeDatabasePassword(keyUID string, password strin
 		return err
 	}
 
-	file, err := os.CreateTemp("", "*-v4.db")
+	file, err := os.CreateTemp(filepath.Dir(b.rootDataDir), "*-v4.db")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixing a linux issue where the password cannot be changed if the temporary folder is located on another partition.

Important changes:
- [x] Something worth noting for reviewers.

The temporary db file needs to be located in the current workdir. Otherwise the db replacement could fail after encryption.

Closes  https://github.com/status-im/status-desktop/issues/11811
