### PR TITLE
fix: parse collectible ownership response from v3 alchemy endpoint pr…

### DIFF
--- a/services/wallet/thirdparty/alchemy/types.go
+++ b/services/wallet/thirdparty/alchemy/types.go
@@ -16,8 +16,8 @@ import (
 )
 
 type TokenBalance struct {
-	TokenID *bigint.HexBigInt `json:"tokenId"`
-	Balance *bigint.BigInt    `json:"balance"`
+	TokenID *bigint.BigInt `json:"tokenId"`
+	Balance *bigint.BigInt `json:"balance"`
 }
 
 type CollectibleOwner struct {
@@ -26,7 +26,7 @@ type CollectibleOwner struct {
 }
 
 type CollectibleContractOwnership struct {
-	Owners  []CollectibleOwner `json:"ownerAddresses"`
+	Owners  []CollectibleOwner `json:"owners"`
 	PageKey string             `json:"pageKey"`
 }
 


### PR DESCRIPTION
…operly

Fixes [#11832](https://github.com/status-im/status-desktop/issues/11832)

We changed the Alchemy client from using API V2 to V3. Endpoint [getOwnersForContract](https://docs.alchemy.com/reference/getownersforcontract-v3) returns data with some small changes I forgot to implement, so we're now always getting an empty ownership list. This fixes that.