### PR TITLE
feat(api): add api to get members revealed accounts

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1135,6 +1135,27 @@ func (m *Messenger) EditSharedAddressesForCommunity(request *requests.EditShared
 	return response, nil
 }
 
+func (m *Messenger) GetRevealedAccounts(communityID types.HexBytes, memberPk string) ([]*protobuf.RevealedAccount, error) {
+	return m.communitiesManager.GetRevealedAddresses(communityID, memberPk)
+}
+
+func (m *Messenger) GetRevealedAccountsForAllMembers(communityID types.HexBytes) (map[string][]*protobuf.RevealedAccount, error) {
+	community, err := m.communitiesManager.GetByID(communityID)
+	if err != nil {
+		return nil, err
+	}
+	membersRevealedAccounts := map[string][]*protobuf.RevealedAccount{}
+	for _, memberPubKey := range community.GetMemberPubkeys() {
+		memberPubKeyStr := common.PubkeyToHex(memberPubKey)
+		accounts, err := m.communitiesManager.GetRevealedAddresses(communityID, memberPubKeyStr)
+		if err != nil {
+			return nil, err
+		}
+		membersRevealedAccounts[memberPubKeyStr] = accounts
+	}
+	return membersRevealedAccounts, nil
+}
+
 func (m *Messenger) CreateCommunityCategory(request *requests.CreateCommunityCategory) (*MessengerResponse, error) {
 	if err := request.Validate(); err != nil {
 		return nil, err

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -586,6 +586,16 @@ func (api *PublicAPI) EditSharedAddressesForCommunity(request *requests.EditShar
 	return api.service.messenger.EditSharedAddressesForCommunity(request)
 }
 
+// GetRevealedAccounts gets the revealed addresses for a member in a community
+func (api *PublicAPI) GetRevealedAccounts(communityID types.HexBytes, memberPk string) ([]*protobuf.RevealedAccount, error) {
+	return api.service.messenger.GetRevealedAccounts(communityID, memberPk)
+}
+
+// GetRevealedAccountsForAllMembers gets the revealed addresses for all the members of a community
+func (api *PublicAPI) GetRevealedAccountsForAllMembers(communityID types.HexBytes) (map[string][]*protobuf.RevealedAccount, error) {
+	return api.service.messenger.GetRevealedAccountsForAllMembers(communityID)
+}
+
 // CheckAndClearPendingRequestToJoinCommunity to delete pending request to join a community which are older than 7 days
 func (api *PublicAPI) CheckAndDeletePendingRequestToJoinCommunity() (*protocol.MessengerResponse, error) {
 	return api.service.messenger.CheckAndDeletePendingRequestToJoinCommunity(true)


### PR DESCRIPTION
Adds an API to get the revealed accounts.

Based on top of https://github.com/status-im/status-go/pull/3853