### PR TITLE
ci: generate junit reports for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ vendor/**/vendor
 
 package.json
 package-lock.json
+
+# junit reports for Jenkins integration
+report.xml

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ setup-dev: ##@setup Install all necessary tools for development
 setup-dev: install-lint install-mock install-modvendor install-protobuf tidy install-os-deps
 
 setup-build: ##@setup Install all necessary build tools
-setup-build: install-lint install-release install-gomobile
+setup-build: install-lint install-release install-gomobile install-junit-report
 
 install-os-deps: ##@install Operating System Dependencies
 	_assets/scripts/install_deps.sh
@@ -253,6 +253,9 @@ install-gomobile: ##@install Go Mobile Build Tools
 
 install-lint: ##@install Install Linting Tools
 	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+
+install-junit-report: ##@install Install Junit Report Tool for Jenkins integration
+	GO111MODULE=on go install github.com/jstemmer/go-junit-report/v2@latest
 
 install-mock: ##@install Install Module Mocking Tools
 	GO111MODULE=on go install github.com/golang/mock/mockgen@v1.4.4
@@ -314,7 +317,9 @@ test-unit: UNIT_TEST_PACKAGES = $(shell go list ./...  | \
 test-unit: ##@tests Run unit and integration tests
 	for file in $(UNIT_TEST_PACKAGES); do \
 		set -e; \
-		go test -tags '$(BUILD_TAGS)' -timeout 20m -v -failfast $$file $(gotest_extraflags); \
+		path=$$(echo $$file | cut -d\/ -f 4-); \
+		go test -tags '$(BUILD_TAGS)' -timeout 20m -v -failfast $$file $(gotest_extraflags) | \
+		  go-junit-report -iocopy -out $${path}/report.xml; \
 	done
 
 test-unit-race: gotest_extraflags=-race

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -85,7 +85,10 @@ pipeline {
   } // stages
 
   post {
-    always  { script { env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText" } }
+    always  {
+      script { env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText" }
+      junit '**/report.xml'
+    }
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
     cleanup { dir(env.TMPDIR) { deleteDir() } }

--- a/logutils/override.go
+++ b/logutils/override.go
@@ -48,6 +48,9 @@ func OverrideRootLog(enabled bool, levelStr string, fileOpts FileOptions, termin
 		disableRootLog()
 		return nil
 	}
+	if os.Getenv("CI") == "true" {
+		terminal = false
+	}
 	var (
 		handler log.Handler
 	)

--- a/shell.nix
+++ b/shell.nix
@@ -49,7 +49,7 @@ in pkgs.mkShell {
 
   buildInputs = with pkgs; [
     git jq which
-    go_1_19 golangci-lint gopls go-bindata gomobileMod
+    go_1_19 golangci-lint go-junit-report gopls go-bindata gomobileMod
     mockgen protobuf3_20 protoc-gen-go
   ] ++ lib.optional stdenv.isDarwin xcodeWrapper;
 


### PR DESCRIPTION
We want to make failed tests more visible without reading the logs and also use Jenkins features, like for tracking test history.
We need to have an integration between `go test` and Jenkins through junit xml files. This is an industry standard for tests-ci integration.

This PR adds too instalation and junit reports generation.
