### PR TITLE
chore: Common `createOtherDevice` for community_messenger_test

### DIFF
--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -915,7 +915,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	s.Require().Len(response.Communities(), 1)
 	community := response.Communities()[0]
 
-	// Send an community message
+	// Send a community message
 	chat := CreateOneToOneChat(common.PubkeyToHex(&alice.identity.PublicKey), &alice.identity.PublicKey, alice.transport)
 
 	inputMessage := &common.Message{}


### PR DESCRIPTION
Just a minor test refactoring:
- created a common `createOtherDevice` function not to copy the code
- fixed a type `send an community message`