### PR TITLE
Prepare messages before notifications are sent back

### DIFF
--- a/protocol/messenger_activity_center.go
+++ b/protocol/messenger_activity_center.go
@@ -41,6 +41,14 @@ func (m *Messenger) ActivityCenterNotifications(request ActivityCenterNotificati
 		return nil, err
 	}
 
+	if m.httpServer != nil {
+		for _, notification := range notifications {
+			if notification.Message != nil {
+				m.prepareMessage(notification.Message, m.httpServer)
+			}
+		}
+	}
+
 	return &ActivityCenterPaginationResponse{
 		Cursor:        cursor,
 		Notifications: notifications,

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/protocol/tt"
+	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/waku"
 )
 
@@ -195,4 +196,136 @@ func (s *MessengerActivityCenterMessageSuite) TestEveryoneMentionTag() {
 	s.Require().True(response.Messages()[0].Mentioned)
 	s.Require().Len(response.ActivityCenterNotifications(), 1)
 	s.Require().Equal(ActivityCenterNotificationTypeMention, response.ActivityCenterNotifications()[0].Type)
+}
+
+func (s *MessengerActivityCenterMessageSuite) TestReplyWithImage() {
+
+	description := &requests.CreateCommunity{
+		Membership:  protobuf.CommunityPermissions_NO_MEMBERSHIP,
+		Name:        "status",
+		Color:       "#ffffff",
+		Description: "status community description",
+	}
+
+	alice := s.m
+	bob := s.newMessenger()
+	_, err := bob.Start()
+	s.Require().NoError(err)
+	defer bob.Shutdown() // nolint: errcheck
+
+	// create an http server
+	mediaServer, err := server.NewMediaServer(nil, nil, nil)
+	s.Require().NoError(err)
+	s.Require().NotNil(mediaServer)
+	s.Require().NoError(mediaServer.Start())
+
+	alice.httpServer = mediaServer
+
+	// Create an community chat
+	response, err := bob.CreateCommunity(description, true)
+	s.Require().NoError(err)
+	s.Require().Len(response.Communities(), 1)
+
+	community := response.Communities()[0]
+	s.Require().NotNil(community)
+
+	chat := CreateOneToOneChat(common.PubkeyToHex(&alice.identity.PublicKey), &alice.identity.PublicKey, bob.transport)
+
+	// bob sends a community message
+	inputMessage := &common.Message{}
+	inputMessage.ChatId = chat.ID
+	inputMessage.Text = "some text"
+	inputMessage.CommunityID = community.IDString()
+
+	err = bob.SaveChat(chat)
+	s.Require().NoError(err)
+	_, err = bob.SendChatMessage(context.Background(), inputMessage)
+	s.Require().NoError(err)
+
+	_, err = WaitOnMessengerResponse(
+		alice,
+		func(r *MessengerResponse) bool { return len(r.Communities()) == 1 },
+		"no messages",
+	)
+
+	s.Require().NoError(err)
+
+	// Alice joins the community
+	response, err = alice.JoinCommunity(context.Background(), community.ID(), false)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+	s.Require().Len(response.Communities(), 1)
+	s.Require().True(response.Communities()[0].Joined())
+	s.Require().Len(response.Chats(), 1)
+
+	defaultCommunityChat := response.Chats()[0]
+
+	defaultCommunityChatID := defaultCommunityChat.ID
+
+	// bob sends a community message
+	inputMessage = &common.Message{}
+	inputMessage.ChatId = defaultCommunityChatID
+	inputMessage.Text = "test message"
+	inputMessage.CommunityID = community.IDString()
+
+	response, err = alice.SendChatMessage(context.Background(), inputMessage)
+	s.Require().NoError(err)
+
+	s.Require().Len(response.Messages(), 1)
+
+	response, err = WaitOnMessengerResponse(
+		bob,
+		func(r *MessengerResponse) bool { return len(r.Messages()) == 1 },
+		"no messages",
+	)
+
+	s.Require().NoError(err)
+
+	s.Require().Len(response.Messages(), 1)
+
+	// bob sends a community message
+	inputMessage, err = buildImageWithAlbumIDMessage(*defaultCommunityChat, "0x34")
+	s.Require().NoError(err)
+
+	inputMessage.Text = "test message reply"
+	inputMessage.ResponseTo = response.Messages()[0].ID
+
+	response, err = bob.SendChatMessage(context.Background(), inputMessage)
+	s.Require().NoError(err)
+
+	s.Require().Len(response.Messages(), 2)
+
+	response, err = WaitOnMessengerResponse(
+		alice,
+		func(r *MessengerResponse) bool { return len(r.Messages()) == 2 },
+		"no messages",
+	)
+
+	s.Require().NoError(err)
+	s.Require().Len(response.ActivityCenterNotifications(), 1)
+
+	var newMessage *common.Message
+	for _, m := range response.Messages() {
+		if m.Text == "test message reply" {
+			newMessage = m
+		}
+	}
+
+	s.Require().NotNil(newMessage)
+	s.Require().Equal(protobuf.ChatMessage_IMAGE, newMessage.ContentType)
+	s.Require().NotEmpty(newMessage.ImageLocalURL)
+
+	s.Require().NotNil(response.ActivityCenterNotifications()[0].Message)
+	s.Require().NotEmpty(response.ActivityCenterNotifications()[0].Message.ImageLocalURL)
+	s.Require().Equal(ActivityCenterNotificationTypeReply, response.ActivityCenterNotifications()[0].Type)
+
+	notifResponse, err := alice.ActivityCenterNotifications(ActivityCenterNotificationsRequest{
+		Limit:         8,
+		ReadType:      ActivityCenterQueryParamsReadAll,
+		ActivityTypes: []ActivityCenterType{ActivityCenterNotificationTypeReply},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(notifResponse.Notifications, 1)
+	s.Require().NotNil(notifResponse.Notifications[0].Message)
+	s.Require().NotEmpty(notifResponse.Notifications[0].Message.ImageLocalURL)
 }

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -17,6 +17,10 @@ func WaitOnMessengerResponse(m *Messenger, condition func(*MessengerResponse) bo
 	err := tt.RetryWithBackOff(func() error {
 		var err error
 		r, err := m.RetrieveAll()
+		if err != nil {
+			panic(err)
+		}
+
 		if err := response.Merge(r); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
When notifications were queried, the message wasn't prepared, resulting in an empty image url.
