### PR TITLE
Handle remove event out of order in private group chats

### DIFF
--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -138,12 +138,17 @@ func (m *Messenger) HandleMembershipUpdate(messageState *ReceivedMessageState, c
 			return err
 		}
 
-		// A new chat must contain us
-		if !group.IsMember(ourKey) {
+		// A new chat must have contained us at some point
+		wasEverMember, err := group.WasEverMember(ourKey)
+		if err != nil {
+			return err
+		}
+
+		if !wasEverMember {
 			return errors.New("can't create a new group chat without us being a member")
 		}
-		// A new chat always adds us
-		wasUserAdded = true
+
+		wasUserAdded = group.IsMember(ourKey)
 		newChat := CreateGroupChat(messageState.Timesource)
 		// We set group chat inactive and create a notification instead
 		// unless is coming from us or a contact or were waiting for approval.

--- a/protocol/v1/membership_update_message_test.go
+++ b/protocol/v1/membership_update_message_test.go
@@ -543,3 +543,32 @@ func TestAbridgedEventsAdmins(t *testing.T) {
 	// All the events are relevant here, so it should be the same
 	require.Len(t, g.AbridgedEvents(), 3)
 }
+
+func TestWasEverMember(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	g, err := NewGroupWithCreator("abc", "#fa6565", 20, key)
+	require.NoError(t, err)
+
+	wasMember, err := g.WasEverMember(publicKeyToString(&key.PublicKey))
+	require.NoError(t, err)
+	require.True(t, wasMember)
+
+	key2, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	wasMember, err = g.WasEverMember(publicKeyToString(&key2.PublicKey))
+	require.NoError(t, err)
+	require.False(t, wasMember)
+
+	// Add a new member
+	event := NewMembersAddedEvent([]string{publicKeyToString(&key2.PublicKey)}, 21)
+	event.From = publicKeyToString(&key.PublicKey)
+	event.ChatID = g.chatID
+	err = g.ProcessEvent(event)
+	require.NoError(t, err)
+
+	wasMember, err = g.WasEverMember(publicKeyToString(&key2.PublicKey))
+	require.NoError(t, err)
+	require.True(t, wasMember)
+}


### PR DESCRIPTION
When we received a remove event from a private group chat out of order, the chat would not be created.
This was causing some issues if later on we received the previous event. This commit changes the behavior so that a chat is created.

