### PR TITLE
feat: transferring keystore files for selected keypair via local network

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1140,6 +1140,36 @@ func InputConnectionStringForBootstrappingAnotherDevice(cs, configJSON string) s
 	return makeJSONResponse(err)
 }
 
+// GetConnectionStringForExportingKeypairsKeystores starts a pairing.SenderServer
+// then generates a pairing.ConnectionParams. Used when the device is Logged in and therefore has Account keys
+// and the device might not have a camera, to transfer kestore files of provided key uids.
+func GetConnectionStringForExportingKeypairsKeystores(configJSON string) string {
+	if configJSON == "" {
+		return makeJSONResponse(fmt.Errorf("no config given, SendingServerConfig is expected"))
+	}
+
+	cs, err := pairing.StartUpSenderServer(statusBackend, configJSON)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	return cs
+}
+
+// InputConnectionStringForImportingKeypairsKeystores starts a pairing.ReceiverClient
+// The given server.ConnectionParams string will determine the server.Mode
+// Used when the device is Logged in and has Account keys and has a camera to read a QR code
+//
+// Example: A mobile device (device with a camera) receiving account data from
+// a device with a screen (mobile or desktop devices)
+func InputConnectionStringForImportingKeypairsKeystores(cs, configJSON string) string {
+	if configJSON == "" {
+		return makeJSONResponse(fmt.Errorf("no config given, ReceiverClientConfig is expected"))
+	}
+
+	err := pairing.StartUpReceivingClient(statusBackend, cs, configJSON)
+	return makeJSONResponse(err)
+}
+
 func ValidateConnectionString(cs string) string {
 	err := pairing.ValidateConnectionString(cs)
 	if err == nil {

--- a/multiaccounts/accounts/test_helper.go
+++ b/multiaccounts/accounts/test_helper.go
@@ -131,7 +131,7 @@ func GetSeedImportedKeypair1ForTest() *Keypair {
 		KeyUID:      "0000000000000000000000000000000000000000000000000000000000000002",
 		Name:        "Seed Imported 1",
 		Type:        KeypairTypeSeed,
-		DerivedFrom: "0x0002",
+		DerivedFrom: types.Address{0x20}.String(),
 	}
 
 	seedGeneratedWalletAccount1 := &Account{

--- a/server/pairing/config.go
+++ b/server/pairing/config.go
@@ -14,10 +14,11 @@ type SenderConfig struct {
 	// DeviceType SendPairInstallation need this information
 	DeviceType string `json:"deviceType" validate:"required"`
 
-	KeyUID          string `json:"keyUID" validate:"required,keyuid"`
-	Password        string `json:"password" validate:"required"`
-	ChatKey         string `json:"chatKey"` // set only in case of a Keycard user, otherwise empty
-	KeycardPairings string `json:"keycardPairings"`
+	KeyUID             string   `json:"keyUID" validate:"required,keyuid"`
+	Password           string   `json:"password" validate:"required"`
+	ChatKey            string   `json:"chatKey"` // set only in case of a Keycard user, otherwise empty
+	KeycardPairings    string   `json:"keycardPairings"`
+	UnimportedKeypairs []string `json:"unimportedKeypairs"` // used to select keypairs we're transferring keystore files for
 
 	DB *multiaccounts.Database `json:"-"`
 }
@@ -39,6 +40,10 @@ type ReceiverConfig struct {
 	DeviceName     string                  `json:"deviceName"`
 	DB             *multiaccounts.Database `json:"-"`
 	LoggedInKeyUID string                  `json:"-"`
+
+	TransferringKeystoreFiles bool   `json:"transferringKeystoreFiles"` // informs receiver that only keystore files are expected
+	Password                  string `json:"password"`                  // necessary in case of transferring keystores
+	KeyUID                    string `json:"keyUID"`                    // necessary in case of transferring keystores
 }
 
 type ServerConfig struct {

--- a/server/pairing/payload_management.go
+++ b/server/pairing/payload_management.go
@@ -45,13 +45,16 @@ func NewPairingPayloadMarshaller(ap *AccountPayload, logger *zap.Logger) *Accoun
 }
 
 func (ppm *AccountPayloadMarshaller) MarshalProtobuf() ([]byte, error) {
-	return proto.Marshal(&protobuf.LocalPairingPayload{
+	lpp := &protobuf.LocalPairingPayload{
 		Keys:            ppm.accountKeysToProtobuf(),
-		Multiaccount:    ppm.multiaccount.ToProtobuf(),
 		Password:        ppm.password,
 		ChatKey:         ppm.chatKey,
 		KeycardPairings: ppm.keycardPairings,
-	})
+	}
+	if ppm.multiaccount != nil {
+		lpp.Multiaccount = ppm.multiaccount.ToProtobuf()
+	}
+	return proto.Marshal(lpp)
 }
 
 func (ppm *AccountPayloadMarshaller) accountKeysToProtobuf() []*protobuf.LocalPairingPayload_Key {

--- a/server/pairing/payload_management_test.go
+++ b/server/pairing/payload_management_test.go
@@ -148,7 +148,7 @@ func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_LoadPayloads() {
 	pp := new(AccountPayload)
 
 	// Make and Load() PairingPayloadRepository 1
-	ppr, err := NewAccountPayloadLoader(pp, pms.config1)
+	ppr, err := NewAccountPayloadLoader(nil, pp, pms.config1)
 	pms.Require().NoError(err)
 	err = ppr.Load()
 	pms.Require().NoError(err)
@@ -182,7 +182,7 @@ func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_MarshalToProtobuf() {
 	pp := new(AccountPayload)
 
 	// Make and Load() PairingPayloadRepository 1
-	ppr, err := NewAccountPayloadLoader(pp, pms.config1)
+	ppr, err := NewAccountPayloadLoader(nil, pp, pms.config1)
 	pms.Require().NoError(err)
 	err = ppr.Load()
 	pms.Require().NoError(err)
@@ -212,7 +212,7 @@ func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_UnmarshalProtobuf() {
 	pp := new(AccountPayload)
 
 	// Make and Load() PairingPayloadRepository 1
-	ppr, err := NewAccountPayloadLoader(pp, pms.config1)
+	ppr, err := NewAccountPayloadLoader(nil, pp, pms.config1)
 	pms.Require().NoError(err)
 	err = ppr.Load()
 	pms.Require().NoError(err)
@@ -266,7 +266,7 @@ func (pms *PayloadMarshallerSuite) TestPayloadMarshaller_StorePayloads() {
 	pp := new(AccountPayload)
 
 	// Make and Load() PairingPayloadRepository 1
-	ppr, err := NewAccountPayloadLoader(pp, pms.config1)
+	ppr, err := NewAccountPayloadLoader(nil, pp, pms.config1)
 	pms.Require().NoError(err)
 	err = ppr.Load()
 	pms.Require().NoError(err)

--- a/services/accounts/service.go
+++ b/services/accounts/service.go
@@ -82,3 +82,12 @@ func (s *Service) GetSettings() (settings.Settings, error) {
 func (s *Service) GetMessenger() *protocol.Messenger {
 	return s.messenger
 }
+
+func (s *Service) VerifyPassword(password string) bool {
+	address, err := s.db.GetChatAddress()
+	if err != nil {
+		return false
+	}
+	_, err = s.manager.VerifyAccountPassword(s.config.KeyStoreDir, address.Hex(), password)
+	return err == nil
+}


### PR DESCRIPTION
There is a desktop app feature where we need to transfer keystore files for selected keypair/s only (of course, which are not migrated to a keycard, otherwise we wouldn't need to do that) via local network using QR code.