### PR TITLE
feat: Switch to ConnectionString V2

### DIFF
--- a/server/certs_test.go
+++ b/server/certs_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -42,12 +43,12 @@ func (s *CertsSuite) TestGenerateX509Cert() {
 	notBefore := time.Now()
 	notAfter := notBefore.Add(time.Hour)
 
-	c1 := GenerateX509Cert(s.SN, notBefore, notAfter, Localhost)
+	c1 := GenerateX509Cert(s.SN, notBefore, notAfter, []net.IP{}, []string{Localhost})
 	s.Require().Exactly([]string{Localhost}, c1.DNSNames)
-	s.Require().Nil(c1.IPAddresses)
+	s.Require().Empty(c1.IPAddresses)
 
-	c2 := GenerateX509Cert(s.SN, notBefore, notAfter, DefaultIP.String())
+	c2 := GenerateX509Cert(s.SN, notBefore, notAfter, []net.IP{LocalHostIP}, []string{})
 	s.Require().Len(c2.IPAddresses, 1)
-	s.Require().Equal(DefaultIP.String(), c2.IPAddresses[0].String())
-	s.Require().Nil(c2.DNSNames)
+	s.Require().Equal(LocalHostIP.String(), c2.IPAddresses[0].String())
+	s.Require().Empty(c2.DNSNames)
 }

--- a/server/ips.go
+++ b/server/ips.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	DefaultIP = net.IP{127, 0, 0, 1}
-	Localhost = "Localhost"
+	LocalHostIP = net.IP{127, 0, 0, 1}
+	Localhost   = "Localhost"
 )
 
 func GetOutboundIP() (net.IP, error) {

--- a/server/pairing/client.go
+++ b/server/pairing/client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -50,7 +49,7 @@ func NewBaseClient(c *ConnectionParams) (*BaseClient, error) {
 
 		serverCert, err = getServerCert(u)
 		if err != nil {
-			certErrs = errors.Join(certErrs, err)
+			certErrs = fmt.Errorf("%wconnecting to '%s' failed: %w; ", certErrs, u, err)
 			continue
 		}
 
@@ -59,7 +58,7 @@ func NewBaseClient(c *ConnectionParams) (*BaseClient, error) {
 	}
 
 	if serverCert == nil {
-		certErrs = errors.Join(errors.New("failed to connect to any of given addresses"), certErrs)
+		certErrs = fmt.Errorf("failed to connect to any of given addresses. %w", certErrs)
 		signal.SendLocalPairingEvent(Event{Type: EventConnectionError, Error: certErrs.Error(), Action: ActionConnect})
 		return nil, certErrs
 	}

--- a/server/pairing/client.go
+++ b/server/pairing/client.go
@@ -37,7 +37,7 @@ type BaseClient struct {
 // NewBaseClient returns a fully qualified BaseClient from the given ConnectionParams
 func NewBaseClient(c *ConnectionParams) (*BaseClient, error) {
 
-	var url *url.URL
+	var baseAddress *url.URL
 	var serverCert *x509.Certificate
 	var certErrs error
 
@@ -53,7 +53,7 @@ func NewBaseClient(c *ConnectionParams) (*BaseClient, error) {
 			continue
 		}
 
-		url = u
+		baseAddress = u
 		break
 	}
 
@@ -98,7 +98,7 @@ func NewBaseClient(c *ConnectionParams) (*BaseClient, error) {
 		Client:         &http.Client{Transport: tr, Jar: cj},
 		serverCert:     serverCert,
 		challengeTaker: NewChallengeTaker(NewPayloadEncryptor(c.aesKey)),
-		baseAddress:    url,
+		baseAddress:    baseAddress,
 	}, nil
 }
 

--- a/server/pairing/config.go
+++ b/server/pairing/config.go
@@ -3,6 +3,7 @@ package pairing
 import (
 	"crypto/ecdsa"
 	"crypto/tls"
+	"net"
 
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/params"
@@ -48,10 +49,11 @@ type ServerConfig struct {
 	// Connection fields, not json (un)marshalled
 	// Required for the server, but MUST NOT come from client
 
-	PK       *ecdsa.PublicKey `json:"-"`
-	EK       []byte           `json:"-"`
-	Cert     *tls.Certificate `json:"-"`
-	Hostname string           `json:"-"`
+	PK          *ecdsa.PublicKey `json:"-"`
+	EK          []byte           `json:"-"`
+	Cert        *tls.Certificate `json:"-"`
+	ListenIP    net.IP           `json:"-"`
+	IPAddresses []net.IP         `json:"-"`
 }
 
 type ClientConfig struct{}

--- a/server/pairing/preflight/preflight.go
+++ b/server/pairing/preflight/preflight.go
@@ -36,7 +36,7 @@ func preflightHandler(w http.ResponseWriter, r *http.Request) {
 func makeCert(address net.IP) (*tls.Certificate, []byte, error) {
 	notBefore := time.Now()
 	notAfter := notBefore.Add(time.Minute)
-	return server.GenerateTLSCert(notBefore, notAfter, address.String())
+	return server.GenerateTLSCert(notBefore, notAfter, []net.IP{address}, []string{})
 }
 
 func makeAndStartServer(cert *tls.Certificate, address net.IP) (string, func() error, error) {

--- a/server/pairing/versioning/version.go
+++ b/server/pairing/versioning/version.go
@@ -14,6 +14,6 @@ const (
 )
 
 const (
-	LatestConnectionParamVer = ConnectionParamsV1
+	LatestConnectionParamVer = ConnectionParamsV2
 	LatestLocalPairingVer    = LocalPairingV1
 )

--- a/server/qrops_test.go
+++ b/server/qrops_test.go
@@ -51,7 +51,7 @@ func (s *QROpsTestSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.serverNoPort = &MediaServer{Server: Server{
-		hostname:   DefaultIP.String(),
+		hostname:   LocalHostIP.String(),
 		portManger: newPortManager(s.Logger, nil),
 	}}
 	go func() {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -59,14 +59,14 @@ func (s *ServerURLSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.server = &MediaServer{Server: Server{
-		hostname:   DefaultIP.String(),
+		hostname:   LocalHostIP.String(),
 		portManger: newPortManager(s.Logger, nil),
 	}}
 	err = s.server.SetPort(customPortForTests)
 	s.Require().NoError(err)
 
 	s.serverNoPort = &MediaServer{Server: Server{
-		hostname:   DefaultIP.String(),
+		hostname:   LocalHostIP.String(),
 		portManger: newPortManager(s.Logger, nil),
 	}}
 	go func() {


### PR DESCRIPTION
Required for https://github.com/status-im/status-go/issues/3884

This PR switches local pairing to ConnectionString version 2 🥳 
For information I already tested with:
- mac-desktop -> mac-desktop (on a single MacOS device)
- mac-desktop -> win-desktop
- win-desktop -> mac-desktop

Didn't test with mobile yet, not sure how to build status-mobile with a not-yet-merged status-go branch.

We can do more tests when merging `feat/issue-3884-lp-cs-v2` to `develop`. Code review is mostly required now.