### PR TITLE
feat: transferring keystore files for selected keypair via local network

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1140,6 +1140,36 @@ func InputConnectionStringForBootstrappingAnotherDevice(cs, configJSON string) s
 	return makeJSONResponse(err)
 }
 
+// GetConnectionStringForExportingKeypairsKeystores starts a pairing.SenderServer
+// then generates a pairing.ConnectionParams. Used when the device is Logged in and therefore has Account keys
+// and the device might not have a camera, to transfer kestore files of provided key uids.
+func GetConnectionStringForExportingKeypairsKeystores(configJSON string) string {
+	if configJSON == "" {
+		return makeJSONResponse(fmt.Errorf("no config given, SendingServerConfig is expected"))
+	}
+
+	cs, err := pairing.StartUpKeystoreFilesSenderServer(statusBackend, configJSON)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	return cs
+}
+
+// InputConnectionStringForImportingKeypairsKeystores starts a pairing.ReceiverClient
+// The given server.ConnectionParams string will determine the server.Mode
+// Used when the device is Logged in and has Account keys and has a camera to read a QR code
+//
+// Example: A mobile device (device with a camera) receiving account data from
+// a device with a screen (mobile or desktop devices)
+func InputConnectionStringForImportingKeypairsKeystores(cs, configJSON string) string {
+	if configJSON == "" {
+		return makeJSONResponse(fmt.Errorf("no config given, ReceiverClientConfig is expected"))
+	}
+
+	err := pairing.StartUpKeystoreFilesReceivingClient(statusBackend, cs, configJSON)
+	return makeJSONResponse(err)
+}
+
 func ValidateConnectionString(cs string) string {
 	err := pairing.ValidateConnectionString(cs)
 	if err == nil {

--- a/server/pairing/config.go
+++ b/server/pairing/config.go
@@ -41,6 +41,22 @@ type ReceiverConfig struct {
 	LoggedInKeyUID string                  `json:"-"`
 }
 
+type KeystoreFilesConfig struct {
+	KeystorePath   string `json:"keystorePath" validate:"required,keystorepath"`
+	LoggedInKeyUID string `json:"loggedInKeyUid" validate:"required,keyuid"`
+	Password       string `json:"password" validate:"required"`
+}
+
+type KeystoreFilesSenderConfig struct {
+	KeystoreFilesConfig
+	KeypairsToExport []string `json:"keypairsToExport" validate:"required"`
+}
+
+type KeystoreFilesReceiverConfig struct {
+	KeystoreFilesConfig
+	KeypairsToImport []string `json:"keypairsToImport" validate:"required"`
+}
+
 type ServerConfig struct {
 	// Timeout the number of milliseconds after which the pairing server will automatically terminate
 	Timeout uint `json:"timeout" validate:"omitempty,gte=0"`
@@ -61,6 +77,11 @@ type SenderServerConfig struct {
 	ServerConfig *ServerConfig `json:"serverConfig" validate:"omitempty,dive"`
 }
 
+type KeystoreFilesSenderServerConfig struct {
+	SenderConfig *KeystoreFilesSenderConfig `json:"senderConfig" validate:"required"`
+	ServerConfig *ServerConfig              `json:"serverConfig" validate:"omitempty,dive"`
+}
+
 type SenderClientConfig struct {
 	SenderConfig *SenderConfig `json:"senderConfig" validate:"required"`
 	ClientConfig *ClientConfig `json:"clientConfig"`
@@ -69,6 +90,11 @@ type SenderClientConfig struct {
 type ReceiverClientConfig struct {
 	ReceiverConfig *ReceiverConfig `json:"receiverConfig" validate:"required"`
 	ClientConfig   *ClientConfig   `json:"clientConfig"`
+}
+
+type KeystoreFilesReceiverClientConfig struct {
+	ReceiverConfig *KeystoreFilesReceiverConfig `json:"receiverConfig" validate:"required"`
+	ClientConfig   *ClientConfig                `json:"clientConfig"`
 }
 
 type ReceiverServerConfig struct {
@@ -83,6 +109,13 @@ func NewSenderServerConfig() *SenderServerConfig {
 	}
 }
 
+func NewKeystoreFilesSenderServerConfig() *KeystoreFilesSenderServerConfig {
+	return &KeystoreFilesSenderServerConfig{
+		SenderConfig: new(KeystoreFilesSenderConfig),
+		ServerConfig: new(ServerConfig),
+	}
+}
+
 func NewSenderClientConfig() *SenderClientConfig {
 	return &SenderClientConfig{
 		SenderConfig: new(SenderConfig),
@@ -93,6 +126,13 @@ func NewSenderClientConfig() *SenderClientConfig {
 func NewReceiverClientConfig() *ReceiverClientConfig {
 	return &ReceiverClientConfig{
 		ReceiverConfig: new(ReceiverConfig),
+		ClientConfig:   new(ClientConfig),
+	}
+}
+
+func NewKeystoreFilesReceiverClientConfig() *KeystoreFilesReceiverClientConfig {
+	return &KeystoreFilesReceiverClientConfig{
+		ReceiverConfig: new(KeystoreFilesReceiverConfig),
 		ClientConfig:   new(ClientConfig),
 	}
 }

--- a/server/pairing/events.go
+++ b/server/pairing/events.go
@@ -17,9 +17,10 @@ const (
 
 	// Only Receiver side
 
-	EventReceivedAccount EventType = "received-account"
-	EventProcessSuccess  EventType = "process-success"
-	EventProcessError    EventType = "process-error"
+	EventReceivedAccount       EventType = "received-account"
+	EventProcessSuccess        EventType = "process-success"
+	EventProcessError          EventType = "process-error"
+	EventReceivedKeystoreFiles EventType = "received-keystore-files"
 )
 
 // Event is a type for transfer events.
@@ -38,6 +39,7 @@ const (
 	ActionSyncDevice
 	ActionPairingInstallation
 	ActionPeerDiscovery
+	ActionKeystoreFilesTransfer
 )
 
 type AccountData struct {

--- a/server/pairing/payload_management.go
+++ b/server/pairing/payload_management.go
@@ -45,13 +45,16 @@ func NewPairingPayloadMarshaller(ap *AccountPayload, logger *zap.Logger) *Accoun
 }
 
 func (ppm *AccountPayloadMarshaller) MarshalProtobuf() ([]byte, error) {
-	return proto.Marshal(&protobuf.LocalPairingPayload{
+	lpp := &protobuf.LocalPairingPayload{
 		Keys:            ppm.accountKeysToProtobuf(),
-		Multiaccount:    ppm.multiaccount.ToProtobuf(),
 		Password:        ppm.password,
 		ChatKey:         ppm.chatKey,
 		KeycardPairings: ppm.keycardPairings,
-	})
+	}
+	if ppm.multiaccount != nil {
+		lpp.Multiaccount = ppm.multiaccount.ToProtobuf()
+	}
+	return proto.Marshal(lpp)
 }
 
 func (ppm *AccountPayloadMarshaller) accountKeysToProtobuf() []*protobuf.LocalPairingPayload_Key {
@@ -79,7 +82,9 @@ func (ppm *AccountPayloadMarshaller) UnmarshalProtobuf(data []byte) error {
 	}
 
 	ppm.accountKeysFromProtobuf(pb.Keys)
-	ppm.multiaccountFromProtobuf(pb.Multiaccount)
+	if pb.Multiaccount != nil {
+		ppm.multiaccountFromProtobuf(pb.Multiaccount)
+	}
 	ppm.password = pb.Password
 	ppm.chatKey = pb.ChatKey
 	ppm.keycardPairings = pb.KeycardPairings

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -3,7 +3,10 @@ package pairing
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,20 +32,25 @@ import (
 	"github.com/status-im/status-go/protocol/identity/alias"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
+	accservice "github.com/status-im/status-go/services/accounts"
 	"github.com/status-im/status-go/services/browsers"
 	"github.com/status-im/status-go/sqlite"
 )
 
 const (
-	pathWalletRoot    = "m/44'/60'/0'/0"
-	pathEIP1581       = "m/43'/60'/1581'"
-	pathDefaultChat   = pathEIP1581 + "/0'/0"
-	pathDefaultWallet = pathWalletRoot + "/0"
-	currentNetwork    = "mainnet_rpc"
-	socialLinkURL     = "https://github.com/status-im"
-	ensUsername       = "bob.stateofus.eth"
-	ensChainID        = 1
-	publicChatID      = "localpairtest"
+	pathWalletRoot     = "m/44'/60'/0'/0"
+	pathEIP1581        = "m/43'/60'/1581'"
+	pathDefaultChat    = pathEIP1581 + "/0'/0"
+	pathDefaultWallet  = pathWalletRoot + "/0"
+	currentNetwork     = "mainnet_rpc"
+	socialLinkURL      = "https://github.com/status-im"
+	ensUsername        = "bob.stateofus.eth"
+	ensChainID         = 1
+	publicChatID       = "localpairtest"
+	profileMnemonic    = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon"
+	seedPhraseMnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+	path0              = "m/44'/60'/0'/0/0"
+	path1              = "m/44'/60'/0'/0/1"
 )
 
 var paths = []string{pathWalletRoot, pathEIP1581, pathDefaultChat, pathDefaultWallet}
@@ -68,13 +76,25 @@ func (s *SyncDeviceSuite) SetupTest() {
 	s.pairThreeDevicesTmpdir = s.T().TempDir()
 }
 
-func (s *SyncDeviceSuite) prepareBackendWithAccount(tmpdir string) *api.GethStatusBackend {
+func (s *SyncDeviceSuite) prepareBackendWithAccount(mnemonic, tmpdir string) *api.GethStatusBackend {
 	backend := s.prepareBackendWithoutAccount(tmpdir)
 	accountManager := backend.AccountManager()
-	generator := accountManager.AccountsGenerator()
-	generatedAccountInfos, err := generator.GenerateAndDeriveAddresses(12, 1, "", paths)
-	require.NoError(s.T(), err)
-	generatedAccountInfo := generatedAccountInfos[0]
+	accGenerator := accountManager.AccountsGenerator()
+
+	var (
+		generatedAccountInfo generator.GeneratedAndDerivedAccountInfo
+		err                  error
+	)
+	if len(mnemonic) > 0 {
+		generatedAccountInfo.GeneratedAccountInfo, err = accGenerator.ImportMnemonic(mnemonic, "")
+		require.NoError(s.T(), err)
+		generatedAccountInfo.Derived, err = accGenerator.DeriveAddresses(generatedAccountInfo.ID, paths)
+		require.NoError(s.T(), err)
+	} else {
+		generatedAccountInfos, err := accGenerator.GenerateAndDeriveAddresses(12, 1, "", paths)
+		require.NoError(s.T(), err)
+		generatedAccountInfo = generatedAccountInfos[0]
+	}
 	account := multiaccounts.Account{
 		KeyUID:        generatedAccountInfo.KeyUID,
 		KDFIterations: sqlite.ReducedKDFIterationsNumber,
@@ -84,7 +104,7 @@ func (s *SyncDeviceSuite) prepareBackendWithAccount(tmpdir string) *api.GethStat
 	err = backend.OpenAccounts()
 	require.NoError(s.T(), err)
 	derivedAddresses := generatedAccountInfo.Derived
-	_, err = generator.StoreDerivedAccounts(generatedAccountInfo.ID, s.password, paths)
+	_, err = accGenerator.StoreDerivedAccounts(generatedAccountInfo.ID, s.password, paths)
 	require.NoError(s.T(), err)
 
 	settings, err := defaultSettings(generatedAccountInfo.GeneratedAccountInfo, derivedAddresses, nil)
@@ -256,7 +276,7 @@ func (s *SyncDeviceSuite) checkMutualContact(backend *api.GethStatusBackend, con
 
 func (s *SyncDeviceSuite) TestPairingSyncDeviceClientAsSender() {
 	clientTmpDir := filepath.Join(s.clientAsSenderTmpdir, "client")
-	clientBackend := s.prepareBackendWithAccount(clientTmpDir)
+	clientBackend := s.prepareBackendWithAccount("", clientTmpDir)
 	serverTmpDir := filepath.Join(s.clientAsSenderTmpdir, "server")
 	serverBackend := s.prepareBackendWithoutAccount(serverTmpDir)
 	defer func() {
@@ -380,7 +400,7 @@ func (s *SyncDeviceSuite) TestPairingSyncDeviceClientAsReceiver() {
 	ctx := context.TODO()
 
 	serverTmpDir := filepath.Join(s.clientAsReceiverTmpdir, "server")
-	serverBackend := s.prepareBackendWithAccount(serverTmpDir)
+	serverBackend := s.prepareBackendWithAccount("", serverTmpDir)
 	defer func() {
 		require.NoError(s.T(), clientBackend.Logout())
 		require.NoError(s.T(), serverBackend.Logout())
@@ -512,13 +532,13 @@ func (s *SyncDeviceSuite) TestPairingSyncDeviceClientAsReceiver() {
 
 func (s *SyncDeviceSuite) TestPairingThreeDevices() {
 	bobTmpDir := filepath.Join(s.pairThreeDevicesTmpdir, "bob")
-	bobBackend := s.prepareBackendWithAccount(bobTmpDir)
+	bobBackend := s.prepareBackendWithAccount("", bobTmpDir)
 	bobMessenger := bobBackend.Messenger()
 	_, err := bobMessenger.Start()
 	s.Require().NoError(err)
 
 	alice1TmpDir := filepath.Join(s.pairThreeDevicesTmpdir, "alice1")
-	alice1Backend := s.prepareBackendWithAccount(alice1TmpDir)
+	alice1Backend := s.prepareBackendWithAccount("", alice1TmpDir)
 	alice1Messenger := alice1Backend.Messenger()
 	_, err = alice1Messenger.Start()
 	s.Require().NoError(err)
@@ -527,7 +547,7 @@ func (s *SyncDeviceSuite) TestPairingThreeDevices() {
 	alice2Backend := s.prepareBackendWithoutAccount(alice2TmpDir)
 
 	alice3TmpDir := filepath.Join(s.pairThreeDevicesTmpdir, "alice3")
-	alice3Backend := s.prepareBackendWithAccount(alice3TmpDir)
+	alice3Backend := s.prepareBackendWithAccount("", alice3TmpDir)
 
 	defer func() {
 		require.NoError(s.T(), bobBackend.Logout())
@@ -687,4 +707,161 @@ func buildTestMessage(chat *protocol.Chat) *common.Message {
 	}
 
 	return message
+}
+
+func (s *SyncDeviceSuite) getSeedPhraseKeypairForTest(backend *api.GethStatusBackend, server bool) *accounts.Keypair {
+	generatedAccount, err := backend.AccountManager().AccountsGenerator().ImportMnemonic(seedPhraseMnemonic, "")
+	require.NoError(s.T(), err)
+	generatedDerivedAccs, err := backend.AccountManager().AccountsGenerator().DeriveAddresses(generatedAccount.ID, []string{path0, path1})
+	require.NoError(s.T(), err)
+
+	seedPhraseKp := &accounts.Keypair{
+		KeyUID:      generatedAccount.KeyUID,
+		Name:        "SeedPhraseImported",
+		Type:        accounts.KeypairTypeSeed,
+		DerivedFrom: generatedAccount.Address,
+	}
+	i := 0
+	for path, ga := range generatedDerivedAccs {
+		acc := &accounts.Account{
+			Address:   types.HexToAddress(ga.Address),
+			KeyUID:    generatedAccount.KeyUID,
+			Wallet:    false,
+			Chat:      false,
+			Type:      accounts.AccountTypeSeed,
+			Path:      path,
+			PublicKey: types.HexBytes(ga.PublicKey),
+			Name:      fmt.Sprintf("Acc_%d", i),
+			Operable:  accounts.AccountFullyOperable,
+			Emoji:     fmt.Sprintf("Emoji_%d", i),
+			ColorID:   "blue",
+		}
+		if !server {
+			acc.Operable = accounts.AccountNonOperable
+		}
+		seedPhraseKp.Accounts = append(seedPhraseKp.Accounts, acc)
+		i++
+	}
+
+	return seedPhraseKp
+}
+
+func (s *SyncDeviceSuite) TestTransferringKeystoreFiles() {
+	ctx := context.TODO()
+
+	serverTmpDir := filepath.Join(s.clientAsReceiverTmpdir, "server")
+	serverBackend := s.prepareBackendWithAccount(profileMnemonic, serverTmpDir)
+
+	clientTmpDir := filepath.Join(s.clientAsReceiverTmpdir, "client")
+	clientBackend := s.prepareBackendWithAccount(profileMnemonic, clientTmpDir)
+	defer func() {
+		require.NoError(s.T(), clientBackend.Logout())
+		require.NoError(s.T(), serverBackend.Logout())
+	}()
+
+	serverBackend.Messenger().SetLocalPairing(true)
+	clientBackend.Messenger().SetLocalPairing(true)
+
+	serverActiveAccount, err := serverBackend.GetActiveAccount()
+	require.NoError(s.T(), err)
+
+	clientActiveAccount, err := clientBackend.GetActiveAccount()
+	require.NoError(s.T(), err)
+
+	require.True(s.T(), serverActiveAccount.KeyUID == clientActiveAccount.KeyUID)
+
+	serverSeedPhraseKp := s.getSeedPhraseKeypairForTest(serverBackend, true)
+	serverAccountsAPI := serverBackend.StatusNode().AccountService().APIs()[1].Service.(*accservice.API)
+	err = serverAccountsAPI.ImportMnemonic(ctx, seedPhraseMnemonic, s.password)
+	require.NoError(s.T(), err, "importing mnemonic for new keypair on server")
+	err = serverAccountsAPI.AddKeypair(ctx, s.password, serverSeedPhraseKp)
+	require.NoError(s.T(), err, "saving seed phrase keypair on server with keystore files created")
+
+	clientSeedPhraseKp := s.getSeedPhraseKeypairForTest(serverBackend, true)
+	clientAccountsAPI := clientBackend.StatusNode().AccountService().APIs()[1].Service.(*accservice.API)
+	err = clientAccountsAPI.SaveKeypair(ctx, clientSeedPhraseKp)
+	require.NoError(s.T(), err, "saving seed phrase keypair on client without keystore files")
+
+	containsKeystoreFile := func(directory, key string) bool {
+		files, err := os.ReadDir(directory)
+		if err != nil {
+			return false
+		}
+
+		for _, file := range files {
+			if strings.Contains(file.Name(), strings.ToLower(key)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// check server - server should contain keystore files for imported seed phrase
+	serverKeystorePath := filepath.Join(serverTmpDir, keystoreDir, serverActiveAccount.KeyUID)
+	require.True(s.T(), containsKeystoreFile(serverKeystorePath, serverSeedPhraseKp.DerivedFrom[2:]))
+	for _, acc := range serverSeedPhraseKp.Accounts {
+		require.True(s.T(), containsKeystoreFile(serverKeystorePath, acc.Address.String()[2:]))
+	}
+
+	// check client - client should not contain keystore files for imported seed phrase
+	clientKeystorePath := filepath.Join(clientTmpDir, keystoreDir, clientActiveAccount.KeyUID)
+	require.False(s.T(), containsKeystoreFile(clientKeystorePath, clientSeedPhraseKp.DerivedFrom[2:]))
+	for _, acc := range clientSeedPhraseKp.Accounts {
+		require.False(s.T(), containsKeystoreFile(clientKeystorePath, acc.Address.String()[2:]))
+	}
+
+	// prepare sender
+	var config = KeystoreFilesSenderServerConfig{
+		SenderConfig: &KeystoreFilesSenderConfig{
+			KeystoreFilesConfig: KeystoreFilesConfig{
+				KeystorePath:   serverKeystorePath,
+				LoggedInKeyUID: serverActiveAccount.KeyUID,
+				Password:       s.password,
+			},
+			KeypairsToExport: []string{serverSeedPhraseKp.KeyUID},
+		},
+		ServerConfig: new(ServerConfig),
+	}
+	configBytes, err := json.Marshal(config)
+	require.NoError(s.T(), err)
+	cs, err := StartUpKeystoreFilesSenderServer(serverBackend, string(configBytes))
+	require.NoError(s.T(), err)
+
+	// prepare receiver
+	clientPayloadSourceConfig := KeystoreFilesReceiverClientConfig{
+		ReceiverConfig: &KeystoreFilesReceiverConfig{
+			KeystoreFilesConfig: KeystoreFilesConfig{
+				KeystorePath:   clientKeystorePath,
+				LoggedInKeyUID: clientActiveAccount.KeyUID,
+				Password:       s.password,
+			},
+			KeypairsToImport: []string{serverSeedPhraseKp.KeyUID},
+		},
+		ClientConfig: new(ClientConfig),
+	}
+	clientConfigBytes, err := json.Marshal(clientPayloadSourceConfig)
+	require.NoError(s.T(), err)
+	err = StartUpKeystoreFilesReceivingClient(clientBackend, cs, string(clientConfigBytes))
+	require.NoError(s.T(), err)
+
+	// check client - client should contain keystore files for imported seed phrase
+	accountManager := clientBackend.AccountManager()
+	accGenerator := accountManager.AccountsGenerator()
+	require.True(s.T(), containsKeystoreFile(clientKeystorePath, clientSeedPhraseKp.DerivedFrom[2:]))
+	for _, acc := range clientSeedPhraseKp.Accounts {
+		require.True(s.T(), containsKeystoreFile(clientKeystorePath, acc.Address.String()[2:]))
+	}
+
+	// reinit keystore on client
+	require.NoError(s.T(), accountManager.InitKeystore(clientKeystorePath))
+
+	// check keystore on client
+	genAccInfo, err := accGenerator.LoadAccount(clientSeedPhraseKp.DerivedFrom, s.password)
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), clientSeedPhraseKp.KeyUID, genAccInfo.KeyUID)
+	for _, acc := range clientSeedPhraseKp.Accounts {
+		genAccInfo, err := accGenerator.LoadAccount(acc.Address.String(), s.password)
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), acc.Address.String(), genAccInfo.Address)
+	}
 }

--- a/services/accounts/service.go
+++ b/services/accounts/service.go
@@ -82,3 +82,12 @@ func (s *Service) GetSettings() (settings.Settings, error) {
 func (s *Service) GetMessenger() *protocol.Messenger {
 	return s.messenger
 }
+
+func (s *Service) VerifyPassword(password string) bool {
+	address, err := s.db.GetChatAddress()
+	if err != nil {
+		return false
+	}
+	_, err = s.manager.VerifyAccountPassword(s.config.KeyStoreDir, address.Hex(), password)
+	return err == nil
+}


### PR DESCRIPTION
This PR is a replacement for the work done here https://github.com/status-im/status-go/pull/3887, in an improved way.

There is a desktop app feature where we need to transfer keystore files for selected keypair/s only (of course, which are not migrated to a keycard, otherwise we wouldn't need to do that) via a local network using a QR code.