### PR TITLE
fix: exitcode for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,7 @@ docker-test: ##@tests Run tests in a docker container with golang.
 
 test: test-unit ##@tests Run basic, short tests during development
 
+test-unit: SHELL := /bin/bash -o pipefail
 test-unit: UNIT_TEST_PACKAGES = $(shell go list ./...  | \
 	grep -v /vendor | \
 	grep -v /t/e2e | \


### PR DESCRIPTION
#3871 broke exitcode of failing `go test`. `pipefail` will to the trick.
