### PR TITLE
feat(wallet) lazy load activity info optimization

### DIFF
--- a/services/wallet/activity/filter.go
+++ b/services/wallet/activity/filter.go
@@ -55,15 +55,13 @@ const (
 	Erc1155
 )
 
-type TokenID *hexutil.Big
-
 // Token supports all tokens. Some fields might be optional, depending on the TokenType
 type Token struct {
 	TokenType TokenType `json:"tokenType"`
 	// ChainID is used for TokenType.Native only to lookup the symbol, all chains will be included in the token filter
 	ChainID common.ChainID `json:"chainId"`
 	Address eth.Address    `json:"address,omitempty"`
-	TokenID TokenID        `json:"tokenId,omitempty"`
+	TokenID *hexutil.Big   `json:"tokenId,omitempty"`
 }
 
 func allTokensFilter() []Token {

--- a/services/wallet/activity/service_test.go
+++ b/services/wallet/activity/service_test.go
@@ -1,0 +1,236 @@
+package activity
+
+import (
+	"database/sql"
+	"encoding/json"
+	"math/big"
+	"testing"
+	"time"
+
+	eth "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
+
+	"github.com/status-im/status-go/services/wallet/bigint"
+	"github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+	"github.com/status-im/status-go/services/wallet/token"
+	"github.com/status-im/status-go/services/wallet/transfer"
+	"github.com/status-im/status-go/services/wallet/walletevent"
+	"github.com/status-im/status-go/t/helpers"
+	"github.com/status-im/status-go/walletdatabase"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// mockCollectiblesManager implements the collectibles.ManagerInterface
+type mockCollectiblesManager struct {
+	mock.Mock
+}
+
+func (m *mockCollectiblesManager) FetchAssetsByCollectibleUniqueID(uniqueIDs []thirdparty.CollectibleUniqueID) ([]thirdparty.FullCollectibleData, error) {
+	args := m.Called(uniqueIDs)
+	res := args.Get(0)
+	if res == nil {
+		return nil, args.Error(1)
+	}
+	return res.([]thirdparty.FullCollectibleData), args.Error(1)
+}
+
+// mockTokenManager implements the token.ManagerInterface
+type mockTokenManager struct {
+	mock.Mock
+}
+
+func (m *mockTokenManager) LookupTokenIdentity(chainID uint64, address eth.Address, native bool) *token.Token {
+	args := m.Called(chainID, address, native)
+	res := args.Get(0)
+	if res == nil {
+		return nil
+	}
+	return res.(*token.Token)
+}
+
+func (m *mockTokenManager) LookupToken(chainID *uint64, tokenSymbol string) (tkn *token.Token, isNative bool) {
+	args := m.Called(chainID, tokenSymbol)
+	return args.Get(0).(*token.Token), args.Bool(1)
+}
+
+func setupTestService(tb testing.TB) (service *Service, eventFeed *event.Feed, tokenMock *mockTokenManager, collectiblesMock *mockCollectiblesManager, close func()) {
+	db, err := helpers.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(tb, err)
+
+	eventFeed = new(event.Feed)
+	tokenMock = &mockTokenManager{}
+	collectiblesMock = &mockCollectiblesManager{}
+	service = NewService(db, tokenMock, collectiblesMock, eventFeed, nil)
+
+	return service, eventFeed, tokenMock, collectiblesMock, func() {
+		require.NoError(tb, db.Close())
+	}
+}
+
+type arg struct {
+	chainID         common.ChainID
+	tokenAddressStr string
+	tokenIDStr      string
+	tokenID         *big.Int
+	tokenAddress    *eth.Address
+}
+
+// insertStubTransfersWithCollectibles will insert nil if tokenIDStr is empty
+func insertStubTransfersWithCollectibles(t *testing.T, db *sql.DB, args []arg) {
+	trs, _, _ := transfer.GenerateTestTransfers(t, db, 0, len(args))
+	for i := range args {
+		trs[i].ChainID = args[i].chainID
+		if args[i].tokenIDStr == "" {
+			args[i].tokenID = nil
+		} else {
+			args[i].tokenID = new(big.Int)
+			args[i].tokenID.SetString(args[i].tokenIDStr, 0)
+		}
+		args[i].tokenAddress = new(eth.Address)
+		*args[i].tokenAddress = eth.HexToAddress(args[i].tokenAddressStr)
+		transfer.InsertTestTransferWithOptions(t, db, trs[i].To, &trs[i], &transfer.TestTransferOptions{
+			TokenAddress: *args[i].tokenAddress,
+			TokenID:      args[i].tokenID,
+		})
+	}
+}
+
+func TestService_UpdateCollectibleInfo(t *testing.T) {
+	s, e, tM, c, close := setupTestService(t)
+	defer close()
+
+	args := []arg{
+		{5, "0xA2838FDA19EB6EED3F8B9EFF411D4CD7D2DE0313", "0x0D", nil, nil},
+		{5, "0xA2838FDA19EB6EED3F8B9EFF411D4CD7D2DE0313", "0x762AD3E4934E687F8701F24C7274E5209213FD6208FF952ACEB325D028866949", nil, nil},
+		{5, "0x3d6afaa395c31fcd391fe3d562e75fe9e8ec7e6a", "", nil, nil},
+		{5, "0xA2838FDA19EB6EED3F8B9EFF411D4CD7D2DE0313", "0x0F", nil, nil},
+	}
+	insertStubTransfersWithCollectibles(t, s.db, args)
+
+	ch := make(chan walletevent.Event)
+	sub := e.Subscribe(ch)
+
+	// Expect one call for the fungible token
+	tM.On("LookupTokenIdentity", uint64(5), eth.HexToAddress("0x3d6afaa395c31fcd391fe3d562e75fe9e8ec7e6a"), false).Return(
+		&token.Token{
+			ChainID: 5,
+			Address: eth.HexToAddress("0x3d6afaa395c31fcd391fe3d562e75fe9e8ec7e6a"),
+			Symbol:  "STT",
+		}, false,
+	).Once()
+	c.On("FetchAssetsByCollectibleUniqueID", []thirdparty.CollectibleUniqueID{
+		{
+			ContractID: thirdparty.ContractID{
+				ChainID: args[3].chainID,
+				Address: *args[3].tokenAddress},
+			TokenID: &bigint.BigInt{Int: args[3].tokenID},
+		}, {
+			ContractID: thirdparty.ContractID{
+				ChainID: args[1].chainID,
+				Address: *args[1].tokenAddress},
+			TokenID: &bigint.BigInt{Int: args[1].tokenID},
+		},
+	}).Return([]thirdparty.FullCollectibleData{
+		{
+			CollectibleData: thirdparty.CollectibleData{
+				Name:     "Test 2",
+				ImageURL: "test://url/2"},
+			CollectionData: nil,
+		}, {
+			CollectibleData: thirdparty.CollectibleData{
+				Name:     "Test 1",
+				ImageURL: "test://url/1"},
+			CollectionData: nil,
+		},
+	}, nil).Once()
+
+	s.FilterActivityAsync(0, allAddressesFilter(), allNetworksFilter(), Filter{}, 0, 3)
+
+	filterResponseCount := 0
+	var updates []EntryData
+
+	for i := 0; i < 2; i++ {
+		select {
+		case res := <-ch:
+			switch res.Type {
+			case EventActivityFilteringDone:
+				var payload FilterResponse
+				err := json.Unmarshal([]byte(res.Message), &payload)
+				require.NoError(t, err)
+				require.Equal(t, ErrorCodeSuccess, payload.ErrorCode)
+				require.Equal(t, 3, len(payload.Activities))
+				filterResponseCount++
+			case EventActivityFilteringUpdate:
+				err := json.Unmarshal([]byte(res.Message), &updates)
+				require.NoError(t, err)
+			}
+		case <-time.NewTimer(1 * time.Second).C:
+			require.Fail(t, "timeout while waiting for event")
+		}
+	}
+
+	require.Equal(t, 1, filterResponseCount)
+	require.Equal(t, 2, len(updates))
+	require.Equal(t, "Test 2", *updates[0].NftName)
+	require.Equal(t, "test://url/2", *updates[0].NftURL)
+	require.Equal(t, "Test 1", *updates[1].NftName)
+	require.Equal(t, "test://url/1", *updates[1].NftURL)
+
+	sub.Unsubscribe()
+}
+
+func TestService_UpdateCollectibleInfo_Error(t *testing.T) {
+	s, e, _, c, close := setupTestService(t)
+	defer close()
+
+	args := []arg{
+		{5, "0xA2838FDA19EB6EED3F8B9EFF411D4CD7D2DE0313", "0x762AD3E4934E687F8701F24C7274E5209213FD6208FF952ACEB325D028866949", nil, nil},
+		{5, "0xA2838FDA19EB6EED3F8B9EFF411D4CD7D2DE0313", "0x0D", nil, nil},
+	}
+	insertStubTransfersWithCollectibles(t, s.db, args)
+
+	ch := make(chan walletevent.Event)
+	sub := e.Subscribe(ch)
+
+	c.On("FetchAssetsByCollectibleUniqueID", mock.Anything).Return(nil, thirdparty.ErrChainIDNotSupported).Once()
+
+	s.FilterActivityAsync(0, allAddressesFilter(), allNetworksFilter(), Filter{}, 0, 5)
+
+	filterResponseCount := 0
+	updatesCount := 0
+
+	select {
+	case res := <-ch:
+		switch res.Type {
+		case EventActivityFilteringDone:
+			var payload FilterResponse
+			err := json.Unmarshal([]byte(res.Message), &payload)
+			require.NoError(t, err)
+			require.Equal(t, ErrorCodeSuccess, payload.ErrorCode)
+			require.Equal(t, 2, len(payload.Activities))
+			filterResponseCount++
+		case EventActivityFilteringUpdate:
+			updatesCount++
+		}
+	case <-time.NewTimer(100 * time.Millisecond).C:
+	}
+
+	select {
+	case res := <-ch:
+		switch res.Type {
+		case EventActivityFilteringDone:
+			filterResponseCount++
+		case EventActivityFilteringUpdate:
+			updatesCount++
+		}
+	case <-time.NewTimer(100 * time.Microsecond).C:
+	}
+
+	require.Equal(t, 1, filterResponseCount)
+	require.Equal(t, 0, updatesCount)
+
+	sub.Unsubscribe()
+}

--- a/services/wallet/async/scheduler.go
+++ b/services/wallet/async/scheduler.go
@@ -150,8 +150,8 @@ func (s *Scheduler) runTask(tc *taskContext, taskFn taskFunction, resFn func(int
 }
 
 // finishedTask is the only one that can remove a task from the queue
-// if the current running task is
-func (s *Scheduler) finishedTask(finishedRes interface{}, finishedTask *taskContext, finishedResFn resultFunction, finishedErr error) {
+// if the current running task completed (doNotDeleteCurrentTask is true)
+func (s *Scheduler) finishedTask(finishedRes interface{}, doneTask *taskContext, finishedResFn resultFunction, finishedErr error) {
 	s.queueMutex.Lock()
 
 	// We always have a running task
@@ -175,7 +175,7 @@ func (s *Scheduler) finishedTask(finishedRes interface{}, finishedTask *taskCont
 	s.queueMutex.Unlock()
 
 	// Report result
-	finishedResFn(finishedRes, finishedTask.taskType, finishedErr)
+	finishedResFn(finishedRes, doneTask.taskType, finishedErr)
 }
 
 func (s *Scheduler) Stop() {

--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -38,6 +38,10 @@ var (
 	ErrNoProvidersAvailableForChainID = errors.New("no providers available for chainID")
 )
 
+type ManagerInterface interface {
+	FetchAssetsByCollectibleUniqueID(uniqueIDs []thirdparty.CollectibleUniqueID) ([]thirdparty.FullCollectibleData, error)
+}
+
 type Manager struct {
 	rpcClient                  *rpc.Client
 	contractOwnershipProviders []thirdparty.CollectibleContractOwnershipProvider

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -102,7 +102,6 @@ func NewService(
 	reader := NewReader(rpcClient, tokenManager, marketManager, accountsDB, NewPersistence(db), feed)
 	history := history.NewService(db, accountsDB, feed, rpcClient, tokenManager, marketManager)
 	currency := currency.NewService(db, feed, tokenManager, marketManager)
-	activity := activity.NewService(db, tokenManager, feed, accountsDB)
 
 	openseaHTTPClient := opensea.NewHTTPClient()
 	openseaClient := opensea.NewClient(config.WalletConfig.OpenseaAPIKey, openseaHTTPClient, feed)
@@ -138,6 +137,9 @@ func NewService(
 
 	collectiblesManager := collectibles.NewManager(db, rpcClient, contractOwnershipProviders, accountOwnershipProviders, collectibleDataProviders, collectionDataProviders, openseaClient)
 	collectibles := collectibles.NewService(db, feed, accountsDB, accountFeed, rpcClient.NetworkManager, collectiblesManager)
+
+	activity := activity.NewService(db, tokenManager, collectiblesManager, feed, accountsDB)
+
 	return &Service{
 		db:                    db,
 		accountsDB:            accountsDB,

--- a/services/wallet/thirdparty/collectible_types.go
+++ b/services/wallet/thirdparty/collectible_types.go
@@ -39,6 +39,10 @@ func (k *CollectibleUniqueID) HashKey() string {
 	return fmt.Sprintf("%s+%s", k.ContractID.HashKey(), k.TokenID.String())
 }
 
+func (k *CollectibleUniqueID) Same(other *CollectibleUniqueID) bool {
+	return k.ContractID.ChainID == other.ContractID.ChainID && k.ContractID.Address == other.ContractID.Address && k.TokenID.Cmp(other.TokenID.Int) == 0
+}
+
 func GroupCollectibleUIDsByChainID(uids []CollectibleUniqueID) map[w_common.ChainID][]CollectibleUniqueID {
 	ret := make(map[w_common.ChainID][]CollectibleUniqueID)
 

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -45,6 +45,11 @@ func (t *Token) IsNative() bool {
 	return t.Address == nativeChainAddress
 }
 
+type ManagerInterface interface {
+	LookupTokenIdentity(chainID uint64, address common.Address, native bool) *Token
+	LookupToken(chainID *uint64, tokenSymbol string) (token *Token, isNative bool)
+}
+
 // Manager is used for accessing token store. It changes the token store based on overridden tokens
 type Manager struct {
 	db               *sql.DB

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -218,6 +218,7 @@ func InsertTestTransfer(tb testing.TB, db *sql.DB, address eth_common.Address, t
 
 type TestTransferOptions struct {
 	TokenAddress     eth_common.Address
+	TokenID          *big.Int
 	NullifyAddresses []eth_common.Address
 }
 
@@ -255,7 +256,11 @@ func InsertTestTransferWithOptions(tb testing.TB, db *sql.DB, address eth_common
 
 	tokenType := "eth"
 	if (opt.TokenAddress != eth_common.Address{}) {
-		tokenType = "erc20"
+		if opt.TokenID == nil {
+			tokenType = "erc20"
+		} else {
+			tokenType = "erc721"
+		}
 	}
 
 	// Workaround to simulate writing of NULL values for addresses
@@ -288,6 +293,7 @@ func InsertTestTransferWithOptions(tb testing.TB, db *sql.DB, address eth_common
 		txNonce:            &tr.Nonce,
 		tokenAddress:       &opt.TokenAddress,
 		contractAddress:    &tr.Contract,
+		tokenID:            opt.TokenID,
 	}
 	err = updateOrInsertTransfersDBFields(tx, []transferDBFields{transfer})
 	require.NoError(tb, err)


### PR DESCRIPTION
## Updates status-desktop [#11597](https://github.com/status-im/status-desktop/issues/11597)

Trigger async fetching of extra information on each activity filtering request. Only emit the update event for incomplete entries.

Other changes:

- Make DataEntry light as an event payload by making all the fields optional
- Add new required fields to the activity DataEntry