### PR TITLE
ci: drop wrongly calling make install-lint

### DIFF
--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -32,6 +32,7 @@ pipeline {
     TARGET   = 'android'
     TMPDIR   = "${WORKSPACE_TMP}"
     GOPATH   = "${WORKSPACE_TMP}/go"
+    GOCACHE  = "${WORKSPACE_TMP}/gocache"
     PATH     = "${PATH}:${GOPATH}/bin"
     REPO_SRC = "${GOPATH}/src/github.com/status-im/status-go"
     ARTIFACT = utils.pkgFilename(name: "status-go", type: "android", ext: "aar", version: null)

--- a/_assets/ci/Jenkinsfile.docker
+++ b/_assets/ci/Jenkinsfile.docker
@@ -31,10 +31,11 @@ pipeline {
   }
 
   environment {
-    TARGET = "docker"
-    REPO   = "${env.WORKSPACE}/src/github.com/status-im/status-go"
-    GOPATH = "${env.WORKSPACE}"
-    PATH   = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
+    TARGET  = "docker"
+    REPO    = "${env.WORKSPACE}/src/github.com/status-im/status-go"
+    GOPATH  = "${env.WORKSPACE}"
+    GOCACHE = "${WORKSPACE_TMP}/gocache"
+    PATH    = "/usr/local/go/bin:${env.PATH}:${env.GOPATH}/bin"
     /* Makefile parameters */
     DOCKER_IMAGE_NAME = 'statusteam/status-go'
     DOCKER_IMAGE_CUSTOM_TAG = "ci-build-${utils.gitCommit()}"

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -32,6 +32,7 @@ pipeline {
     TARGET   = 'ios'
     TMPDIR   = "${WORKSPACE_TMP}"
     GOPATH   = "${WORKSPACE_TMP}/go"
+    GOCACHE  = "${WORKSPACE_TMP}/gocache"
     PATH     = "${PATH}:${GOPATH}/bin"
     REPO_SRC = "${GOPATH}/src/github.com/status-im/status-go"
     ARTIFACT = utils.pkgFilename(name: "status-go", type: "ios", ext: "zip", version: null)

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -32,6 +32,7 @@ pipeline {
     TARGET   = 'linux'
     TMPDIR   = "${WORKSPACE_TMP}"
     GOPATH   = "${WORKSPACE_TMP}/go"
+    GOCACHE  = "${WORKSPACE_TMP}/gocache"
     PATH     = "${PATH}:${GOPATH}/bin"
     REPO_SRC = "${GOPATH}/src/github.com/status-im/status-go"
     ARTIFACT = utils.pkgFilename(name: "status-go", type: "desktop", ext: "zip", version: null)

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -28,6 +28,7 @@ pipeline {
     DB_CONT  = 'status-go-test-db'
     TMPDIR   = "${WORKSPACE_TMP}"
     GOPATH   = "${WORKSPACE_TMP}/go"
+    GOCACHE  = "${WORKSPACE_TMP}/gocache"
     PATH     = "${PATH}:${GOPATH}/bin"
     REPO_SRC = "${GOPATH}/src/github.com/status-im/status-go"
   }

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -57,14 +57,13 @@ pipeline {
 
     stage('Lint') {
       steps { script {
-        nix.shell('make install-lint', pure: false)
-        nix.shell('make lint', pure: false)
+        nix.shell('make lint', pure: true)
       } }
     }
 
     stage('Canary') {
       steps { script {
-        nix.shell('make canary-test', pure: false)
+        nix.shell('make canary-test', pure: true)
       } }
     }
 


### PR DESCRIPTION
Linting tools should already be installed by Nix, and we should use them.

Also switching most shells to pure mode to see what happens.
And set Go cache to workspace tmp folder to avoid cache poisoning.