### PR TITLE
chore: Moved link preview unfurlers to a separate package

### DIFF
--- a/protocol/linkpreview/linkpreview.go
+++ b/protocol/linkpreview/linkpreview.go
@@ -3,13 +3,14 @@ package linkpreview
 import (
 	"errors"
 	"fmt"
-	"github.com/status-im/markdown"
-	"go.uber.org/zap"
-	"golang.org/x/net/publicsuffix"
 	"net/http"
 	neturl "net/url"
 	"regexp"
 	"strings"
+
+	"github.com/status-im/markdown"
+	"go.uber.org/zap"
+	"golang.org/x/net/publicsuffix"
 
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/linkpreview/unfurlers"

--- a/protocol/linkpreview/linkpreview.go
+++ b/protocol/linkpreview/linkpreview.go
@@ -1,317 +1,22 @@
 package linkpreview
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"github.com/status-im/markdown"
+	"go.uber.org/zap"
+	"golang.org/x/net/publicsuffix"
 	"net/http"
 	neturl "net/url"
 	"regexp"
 	"strings"
-	"time"
 
-	"github.com/keighl/metabolize"
-	"go.uber.org/zap"
-	"golang.org/x/net/publicsuffix"
-
-	"github.com/status-im/markdown"
-
-	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/protobuf"
+	"github.com/status-im/status-go/protocol/linkpreview/unfurlers"
 )
 
 type LinkPreview struct {
 	common.LinkPreview
-}
-
-type Unfurler interface {
-	unfurl() (common.LinkPreview, error)
-}
-
-type Headers map[string]string
-
-const (
-	defaultRequestTimeout = 15000 * time.Millisecond
-	maxImageSize          = 1024 * 350
-
-	headerAcceptJSON = "application/json; charset=utf-8"
-	headerAcceptText = "text/html; charset=utf-8"
-
-	// Without a particular user agent, many providers treat status-go as a
-	// gluttony bot, and either respond more frequently with a 429 (Too Many
-	// Requests), or simply refuse to return valid data. Note that using a known
-	// browser UA doesn't work well with some providers, such as Spotify,
-	// apparently they still flag status-go as a bad actor.
-	headerUserAgent = "status-go/v0.151.15"
-
-	// Currently set to English, but we could make this setting dynamic according
-	// to the user's language of choice.
-	headerAcceptLanguage = "en-US,en;q=0.5"
-)
-
-var imageURLRegexp = regexp.MustCompile(`(?i)^.+(png|jpg|jpeg|webp)$`)
-
-func fetchBody(logger *zap.Logger, httpClient http.Client, url string, headers Headers) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultRequestTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to perform HTTP request: %w", err)
-	}
-
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-
-	res, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := res.Body.Close(); err != nil {
-			logger.Error("failed to close response body", zap.Error(err))
-		}
-	}()
-
-	if res.StatusCode >= http.StatusBadRequest {
-		return nil, fmt.Errorf("http request failed, statusCode='%d'", res.StatusCode)
-	}
-
-	bodyBytes, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read body bytes: %w", err)
-	}
-
-	return bodyBytes, nil
-}
-
-func newDefaultLinkPreview(url *neturl.URL) common.LinkPreview {
-	return common.LinkPreview{
-		URL:      url.String(),
-		Hostname: url.Hostname(),
-	}
-}
-
-func fetchThumbnail(logger *zap.Logger, httpClient http.Client, url string) (common.LinkPreviewThumbnail, error) {
-	var thumbnail common.LinkPreviewThumbnail
-
-	imgBytes, err := fetchBody(logger, httpClient, url, nil)
-	if err != nil {
-		return thumbnail, fmt.Errorf("could not fetch thumbnail url='%s': %w", url, err)
-	}
-
-	width, height, err := images.GetImageDimensions(imgBytes)
-	if err != nil {
-		return thumbnail, fmt.Errorf("could not get image dimensions url='%s': %w", url, err)
-	}
-	thumbnail.Width = width
-	thumbnail.Height = height
-
-	dataURI, err := images.GetPayloadDataURI(imgBytes)
-	if err != nil {
-		return thumbnail, fmt.Errorf("could not build data URI url='%s': %w", url, err)
-	}
-	thumbnail.DataURI = dataURI
-
-	return thumbnail, nil
-}
-
-type OEmbedUnfurler struct {
-	logger     *zap.Logger
-	httpClient http.Client
-	// oembedEndpoint describes where the consumer may request representations for
-	// the supported URL scheme. For example, for YouTube, it is
-	// https://www.youtube.com/oembed.
-	oembedEndpoint string
-	// url is the actual URL to be unfurled.
-	url *neturl.URL
-}
-
-type OEmbedResponse struct {
-	Title        string `json:"title"`
-	ThumbnailURL string `json:"thumbnail_url"`
-}
-
-func (u OEmbedUnfurler) newOEmbedURL() (*neturl.URL, error) {
-	oembedURL, err := neturl.Parse(u.oembedEndpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	// When format is specified, the provider MUST return data in the requested
-	// format, else return an error.
-	oembedURL.RawQuery = neturl.Values{
-		"url":    {u.url.String()},
-		"format": {"json"},
-	}.Encode()
-
-	return oembedURL, nil
-}
-
-func (u OEmbedUnfurler) unfurl() (common.LinkPreview, error) {
-	preview := newDefaultLinkPreview(u.url)
-	preview.Type = protobuf.UnfurledLink_LINK
-
-	oembedURL, err := u.newOEmbedURL()
-	if err != nil {
-		return preview, err
-	}
-
-	headers := map[string]string{
-		"accept":          headerAcceptJSON,
-		"accept-language": headerAcceptLanguage,
-		"user-agent":      headerUserAgent,
-	}
-	oembedBytes, err := fetchBody(u.logger, u.httpClient, oembedURL.String(), headers)
-	if err != nil {
-		return preview, err
-	}
-
-	var oembedResponse OEmbedResponse
-	if err != nil {
-		return preview, err
-	}
-	err = json.Unmarshal(oembedBytes, &oembedResponse)
-	if err != nil {
-		return preview, err
-	}
-
-	if oembedResponse.Title == "" {
-		return preview, fmt.Errorf("missing required title in oEmbed response")
-	}
-
-	preview.Title = oembedResponse.Title
-	return preview, nil
-}
-
-type OpenGraphMetadata struct {
-	Title        string `json:"title" meta:"og:title"`
-	Description  string `json:"description" meta:"og:description"`
-	ThumbnailURL string `json:"thumbnailUrl" meta:"og:image"`
-}
-
-// OpenGraphUnfurler should be preferred over OEmbedUnfurler because oEmbed
-// gives back a JSON response with a "html" field that's supposed to be embedded
-// in an iframe (hardly useful for existing Status' clients).
-type OpenGraphUnfurler struct {
-	url        *neturl.URL
-	logger     *zap.Logger
-	httpClient http.Client
-}
-
-func (u OpenGraphUnfurler) unfurl() (common.LinkPreview, error) {
-	preview := newDefaultLinkPreview(u.url)
-	preview.Type = protobuf.UnfurledLink_LINK
-
-	headers := map[string]string{
-		"accept":          headerAcceptText,
-		"accept-language": headerAcceptLanguage,
-		"user-agent":      headerUserAgent,
-	}
-	bodyBytes, err := fetchBody(u.logger, u.httpClient, u.url.String(), headers)
-	if err != nil {
-		return preview, err
-	}
-
-	var ogMetadata OpenGraphMetadata
-	err = metabolize.Metabolize(ioutil.NopCloser(bytes.NewBuffer(bodyBytes)), &ogMetadata)
-	if err != nil {
-		return preview, fmt.Errorf("failed to parse OpenGraph data")
-	}
-
-	// There are URLs like https://wikipedia.org/ that don't have an OpenGraph
-	// title tag, but article pages do. In the future, we can fallback to the
-	// website's title by using the <title> tag.
-	if ogMetadata.Title == "" {
-		return preview, fmt.Errorf("missing required title in OpenGraph response")
-	}
-
-	if ogMetadata.ThumbnailURL != "" {
-		t, err := fetchThumbnail(u.logger, u.httpClient, ogMetadata.ThumbnailURL)
-		if err != nil {
-			// Given we want to fetch thumbnails on a best-effort basis, if an error
-			// happens we simply log it.
-			u.logger.Info("failed to fetch thumbnail", zap.String("url", u.url.String()), zap.Error(err))
-		} else {
-			preview.Thumbnail = t
-		}
-	}
-
-	preview.Title = ogMetadata.Title
-	preview.Description = ogMetadata.Description
-	return preview, nil
-}
-
-type ImageUnfurler struct {
-	url        *neturl.URL
-	logger     *zap.Logger
-	httpClient http.Client
-}
-
-func compressImage(imgBytes []byte) ([]byte, error) {
-	smallest := imgBytes
-
-	img, err := images.DecodeImageData(imgBytes, bytes.NewReader(imgBytes))
-	if err != nil {
-		return nil, err
-	}
-
-	compressed := bytes.NewBuffer([]byte{})
-	err = images.CompressToFileLimits(compressed, img, images.DefaultBounds)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(compressed.Bytes()) < len(smallest) {
-		smallest = compressed.Bytes()
-	}
-
-	if len(smallest) > maxImageSize {
-		return nil, errors.New("image too large")
-	}
-
-	return smallest, nil
-}
-
-func (u ImageUnfurler) unfurl() (common.LinkPreview, error) {
-	preview := newDefaultLinkPreview(u.url)
-	preview.Type = protobuf.UnfurledLink_IMAGE
-
-	headers := map[string]string{"user-agent": headerUserAgent}
-	imgBytes, err := fetchBody(u.logger, u.httpClient, u.url.String(), headers)
-	if err != nil {
-		return preview, err
-	}
-
-	if !isSupportedImage(imgBytes) {
-		return preview, fmt.Errorf("unsupported image type url='%s'", u.url.String())
-	}
-
-	compressedBytes, err := compressImage(imgBytes)
-	if err != nil {
-		return preview, fmt.Errorf("failed to compress image url='%s': %w", u.url.String(), err)
-	}
-
-	width, height, err := images.GetImageDimensions(compressedBytes)
-	if err != nil {
-		return preview, fmt.Errorf("could not get image dimensions url='%s': %w", u.url.String(), err)
-	}
-
-	dataURI, err := images.GetPayloadDataURI(compressedBytes)
-	if err != nil {
-		return preview, fmt.Errorf("could not build data URI url='%s': %w", u.url.String(), err)
-	}
-
-	preview.Thumbnail.Width = width
-	preview.Thumbnail.Height = height
-	preview.Thumbnail.DataURI = dataURI
-
-	return preview, nil
 }
 
 func normalizeHostname(hostname string) string {
@@ -320,45 +25,26 @@ func normalizeHostname(hostname string) string {
 	return re.ReplaceAllString(hostname, "$1")
 }
 
-// isSupportedImageURL detects whether a URL ends with one of the
-// supported image extensions. It provides a quick way to identify whether URLs
-// should be unfurled as images without needing to retrieve the full response
-// body first.
-func isSupportedImageURL(url *neturl.URL) bool {
-	return imageURLRegexp.MatchString(url.Path)
-}
-
-// isSupportedImage returns true when payload is one of the supported image
-// types. In the future, we should differentiate between animated and
-// non-animated WebP because, currently, only static WebP can be processed by
-// functions in the status-go/images package.
-func isSupportedImage(payload []byte) bool {
-	return images.IsJpeg(payload) || images.IsPng(payload) || images.IsWebp(payload)
-}
-
-func newUnfurler(logger *zap.Logger, httpClient http.Client, url *neturl.URL) Unfurler {
-	if isSupportedImageURL(url) {
-		return ImageUnfurler{
-			url:        url,
-			logger:     logger,
-			httpClient: httpClient,
-		}
+func newUnfurler(logger *zap.Logger, httpClient http.Client, url *neturl.URL) unfurlers.Unfurler {
+	if unfurlers.IsSupportedImageURL(url) {
+		return unfurlers.NewImageUnfurler(
+			url,
+			logger,
+			httpClient)
 	}
 
 	switch normalizeHostname(url.Hostname()) {
 	case "reddit.com":
-		return OEmbedUnfurler{
-			oembedEndpoint: "https://www.reddit.com/oembed",
-			url:            url,
-			logger:         logger,
-			httpClient:     httpClient,
-		}
+		return unfurlers.NewOEmbedUnfurler(
+			"https://www.reddit.com/oembed",
+			url,
+			logger,
+			httpClient)
 	default:
-		return OpenGraphUnfurler{
-			url:        url,
-			logger:     logger,
-			httpClient: httpClient,
-		}
+		return unfurlers.NewOpenGraphUnfurler(
+			url,
+			logger,
+			httpClient)
 	}
 }
 
@@ -371,7 +57,7 @@ func unfurl(logger *zap.Logger, httpClient http.Client, url string) (common.Link
 	}
 
 	unfurler := newUnfurler(logger, httpClient, parsedURL)
-	preview, err = unfurler.unfurl()
+	preview, err = unfurler.Unfurl()
 	if err != nil {
 		return preview, err
 	}
@@ -439,7 +125,7 @@ func GetURLs(text string) []string {
 }
 
 func NewDefaultHTTPClient() http.Client {
-	return http.Client{Timeout: defaultRequestTimeout}
+	return http.Client{Timeout: unfurlers.DefaultRequestTimeout}
 }
 
 // UnfurlURLs assumes clients pass URLs verbatim that were validated and

--- a/protocol/linkpreview/linkpreview_test.go
+++ b/protocol/linkpreview/linkpreview_test.go
@@ -3,6 +3,7 @@ package linkpreview
 import (
 	"bytes"
 	"fmt"
+	"github.com/status-im/status-go/protocol/linkpreview/unfurlers"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -316,7 +317,7 @@ func Test_isSupportedImageURL(t *testing.T) {
 	for _, e := range examples {
 		parsedURL, err := url.Parse(e.url)
 		require.NoError(t, err, e)
-		require.Equal(t, e.expected, isSupportedImageURL(parsedURL), e.url)
+		require.Equal(t, e.expected, unfurlers.IsSupportedImageURL(parsedURL), e.url)
 	}
 }
 

--- a/protocol/linkpreview/linkpreview_test.go
+++ b/protocol/linkpreview/linkpreview_test.go
@@ -3,7 +3,6 @@ package linkpreview
 import (
 	"bytes"
 	"fmt"
-	"github.com/status-im/status-go/protocol/linkpreview/unfurlers"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -15,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/linkpreview/unfurlers"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 

--- a/protocol/linkpreview/unfurlers/image_unfurler.go
+++ b/protocol/linkpreview/unfurlers/image_unfurler.go
@@ -24,10 +24,10 @@ var imageURLRegexp = regexp.MustCompile(`(?i)^.+(png|jpg|jpeg|webp)$`)
 type ImageUnfurler struct {
 	url        *neturl.URL
 	logger     *zap.Logger
-	httpClient http.Client
+	httpClient *http.Client
 }
 
-func NewImageUnfurler(URL *neturl.URL, logger *zap.Logger, httpClient http.Client) *ImageUnfurler {
+func NewImageUnfurler(URL *neturl.URL, logger *zap.Logger, httpClient *http.Client) *ImageUnfurler {
 	return &ImageUnfurler{
 		url:        URL,
 		logger:     logger,

--- a/protocol/linkpreview/unfurlers/image_unfurler.go
+++ b/protocol/linkpreview/unfurlers/image_unfurler.go
@@ -1,0 +1,113 @@
+package unfurlers
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	neturl "net/url"
+	"regexp"
+
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/images"
+	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/protobuf"
+)
+
+const (
+	maxImageSize = 1024 * 350
+)
+
+var imageURLRegexp = regexp.MustCompile(`(?i)^.+(png|jpg|jpeg|webp)$`)
+
+type ImageUnfurler struct {
+	url        *neturl.URL
+	logger     *zap.Logger
+	httpClient http.Client
+}
+
+func NewImageUnfurler(URL *neturl.URL, logger *zap.Logger, httpClient http.Client) *ImageUnfurler {
+	return &ImageUnfurler{
+		url:        URL,
+		logger:     logger,
+		httpClient: httpClient,
+	}
+}
+
+func compressImage(imgBytes []byte) ([]byte, error) {
+	smallest := imgBytes
+
+	img, err := images.DecodeImageData(imgBytes, bytes.NewReader(imgBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	compressed := bytes.NewBuffer([]byte{})
+	err = images.CompressToFileLimits(compressed, img, images.DefaultBounds)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(compressed.Bytes()) < len(smallest) {
+		smallest = compressed.Bytes()
+	}
+
+	if len(smallest) > maxImageSize {
+		return nil, errors.New("image too large")
+	}
+
+	return smallest, nil
+}
+
+// isSupportedImageURL detects whether a URL ends with one of the
+// supported image extensions. It provides a quick way to identify whether URLs
+// should be unfurled as images without needing to retrieve the full response
+// body first.
+func IsSupportedImageURL(url *neturl.URL) bool {
+	return imageURLRegexp.MatchString(url.Path)
+}
+
+// isSupportedImage returns true when payload is one of the supported image
+// types. In the future, we should differentiate between animated and
+// non-animated WebP because, currently, only static WebP can be processed by
+// functions in the status-go/images package.
+func isSupportedImage(payload []byte) bool {
+	return images.IsJpeg(payload) || images.IsPng(payload) || images.IsWebp(payload)
+}
+
+func (u ImageUnfurler) Unfurl() (common.LinkPreview, error) {
+	preview := newDefaultLinkPreview(u.url)
+	preview.Type = protobuf.UnfurledLink_IMAGE
+
+	headers := map[string]string{"user-agent": headerUserAgent}
+	imgBytes, err := fetchBody(u.logger, u.httpClient, u.url.String(), headers)
+	if err != nil {
+		return preview, err
+	}
+
+	if !isSupportedImage(imgBytes) {
+		return preview, fmt.Errorf("unsupported image type url='%s'", u.url.String())
+	}
+
+	compressedBytes, err := compressImage(imgBytes)
+	if err != nil {
+		return preview, fmt.Errorf("failed to compress image url='%s': %w", u.url.String(), err)
+	}
+
+	width, height, err := images.GetImageDimensions(compressedBytes)
+	if err != nil {
+		return preview, fmt.Errorf("could not get image dimensions url='%s': %w", u.url.String(), err)
+	}
+
+	dataURI, err := images.GetPayloadDataURI(compressedBytes)
+	if err != nil {
+		return preview, fmt.Errorf("could not build data URI url='%s': %w", u.url.String(), err)
+	}
+
+	preview.Thumbnail.Width = width
+	preview.Thumbnail.Height = height
+	preview.Thumbnail.DataURI = dataURI
+
+	return preview, nil
+}

--- a/protocol/linkpreview/unfurlers/image_unfurler.go
+++ b/protocol/linkpreview/unfurlers/image_unfurler.go
@@ -60,7 +60,7 @@ func compressImage(imgBytes []byte) ([]byte, error) {
 	return smallest, nil
 }
 
-// isSupportedImageURL detects whether a URL ends with one of the
+// IsSupportedImageURL detects whether a URL ends with one of the
 // supported image extensions. It provides a quick way to identify whether URLs
 // should be unfurled as images without needing to retrieve the full response
 // body first.
@@ -76,7 +76,7 @@ func isSupportedImage(payload []byte) bool {
 	return images.IsJpeg(payload) || images.IsPng(payload) || images.IsWebp(payload)
 }
 
-func (u ImageUnfurler) Unfurl() (common.LinkPreview, error) {
+func (u *ImageUnfurler) Unfurl() (common.LinkPreview, error) {
 	preview := newDefaultLinkPreview(u.url)
 	preview.Type = protobuf.UnfurledLink_IMAGE
 

--- a/protocol/linkpreview/unfurlers/oembed_unfurler.go
+++ b/protocol/linkpreview/unfurlers/oembed_unfurler.go
@@ -40,7 +40,7 @@ type OEmbedResponse struct {
 	ThumbnailURL string `json:"thumbnail_url"`
 }
 
-func (u OEmbedUnfurler) newOEmbedURL() (*neturl.URL, error) {
+func (u *OEmbedUnfurler) newOEmbedURL() (*neturl.URL, error) {
 	oembedURL, err := neturl.Parse(u.oembedEndpoint)
 	if err != nil {
 		return nil, err

--- a/protocol/linkpreview/unfurlers/oembed_unfurler.go
+++ b/protocol/linkpreview/unfurlers/oembed_unfurler.go
@@ -14,7 +14,7 @@ import (
 
 type OEmbedUnfurler struct {
 	logger     *zap.Logger
-	httpClient http.Client
+	httpClient *http.Client
 	// oembedEndpoint describes where the consumer may request representations for
 	// the supported URL scheme. For example, for YouTube, it is
 	// https://www.youtube.com/oembed.
@@ -26,7 +26,7 @@ type OEmbedUnfurler struct {
 func NewOEmbedUnfurler(oembedEndpoint string,
 	url *neturl.URL,
 	logger *zap.Logger,
-	httpClient http.Client) *OEmbedUnfurler {
+	httpClient *http.Client) *OEmbedUnfurler {
 	return &OEmbedUnfurler{
 		oembedEndpoint: oembedEndpoint,
 		url:            url,

--- a/protocol/linkpreview/unfurlers/oembed_unfurler.go
+++ b/protocol/linkpreview/unfurlers/oembed_unfurler.go
@@ -1,0 +1,91 @@
+package unfurlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/protobuf"
+	"go.uber.org/zap"
+	"net/http"
+	neturl "net/url"
+)
+
+type OEmbedUnfurler struct {
+	logger     *zap.Logger
+	httpClient http.Client
+	// oembedEndpoint describes where the consumer may request representations for
+	// the supported URL scheme. For example, for YouTube, it is
+	// https://www.youtube.com/oembed.
+	oembedEndpoint string
+	// url is the actual URL to be unfurled.
+	url *neturl.URL
+}
+
+func NewOEmbedUnfurler(oembedEndpoint string,
+	url *neturl.URL,
+	logger *zap.Logger,
+	httpClient http.Client) *OEmbedUnfurler {
+	return &OEmbedUnfurler{
+		oembedEndpoint: oembedEndpoint,
+		url:            url,
+		logger:         logger,
+		httpClient:     httpClient,
+	}
+}
+
+type OEmbedResponse struct {
+	Title        string `json:"title"`
+	ThumbnailURL string `json:"thumbnail_url"`
+}
+
+func (u OEmbedUnfurler) newOEmbedURL() (*neturl.URL, error) {
+	oembedURL, err := neturl.Parse(u.oembedEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// When format is specified, the provider MUST return data in the requested
+	// format, else return an error.
+	oembedURL.RawQuery = neturl.Values{
+		"url":    {u.url.String()},
+		"format": {"json"},
+	}.Encode()
+
+	return oembedURL, nil
+}
+
+func (u OEmbedUnfurler) Unfurl() (common.LinkPreview, error) {
+	preview := newDefaultLinkPreview(u.url)
+	preview.Type = protobuf.UnfurledLink_LINK
+
+	oembedURL, err := u.newOEmbedURL()
+	if err != nil {
+		return preview, err
+	}
+
+	headers := map[string]string{
+		"accept":          headerAcceptJSON,
+		"accept-language": headerAcceptLanguage,
+		"user-agent":      headerUserAgent,
+	}
+	oembedBytes, err := fetchBody(u.logger, u.httpClient, oembedURL.String(), headers)
+	if err != nil {
+		return preview, err
+	}
+
+	var oembedResponse OEmbedResponse
+	if err != nil {
+		return preview, err
+	}
+	err = json.Unmarshal(oembedBytes, &oembedResponse)
+	if err != nil {
+		return preview, err
+	}
+
+	if oembedResponse.Title == "" {
+		return preview, fmt.Errorf("missing required title in oEmbed response")
+	}
+
+	preview.Title = oembedResponse.Title
+	return preview, nil
+}

--- a/protocol/linkpreview/unfurlers/oembed_unfurler.go
+++ b/protocol/linkpreview/unfurlers/oembed_unfurler.go
@@ -3,11 +3,13 @@ package unfurlers
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/protobuf"
-	"go.uber.org/zap"
 	"net/http"
 	neturl "net/url"
+
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/protobuf"
 )
 
 type OEmbedUnfurler struct {

--- a/protocol/linkpreview/unfurlers/opengraph_unfurler.go
+++ b/protocol/linkpreview/unfurlers/opengraph_unfurler.go
@@ -1,0 +1,104 @@
+package unfurlers
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/keighl/metabolize"
+	"github.com/status-im/status-go/images"
+	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/protobuf"
+	"go.uber.org/zap"
+	"io/ioutil"
+	"net/http"
+	neturl "net/url"
+)
+
+type OpenGraphMetadata struct {
+	Title        string `json:"title" meta:"og:title"`
+	Description  string `json:"description" meta:"og:description"`
+	ThumbnailURL string `json:"thumbnailUrl" meta:"og:image"`
+}
+
+// OpenGraphUnfurler should be preferred over OEmbedUnfurler because oEmbed
+// gives back a JSON response with a "html" field that's supposed to be embedded
+// in an iframe (hardly useful for existing Status' clients).
+type OpenGraphUnfurler struct {
+	url        *neturl.URL
+	logger     *zap.Logger
+	httpClient http.Client
+}
+
+func NewOpenGraphUnfurler(URL *neturl.URL, logger *zap.Logger, httpClient http.Client) *OpenGraphUnfurler {
+	return &OpenGraphUnfurler{
+		url:        URL,
+		logger:     logger,
+		httpClient: httpClient,
+	}
+}
+
+func (u OpenGraphUnfurler) Unfurl() (common.LinkPreview, error) {
+	preview := newDefaultLinkPreview(u.url)
+	preview.Type = protobuf.UnfurledLink_LINK
+
+	headers := map[string]string{
+		"accept":          headerAcceptText,
+		"accept-language": headerAcceptLanguage,
+		"user-agent":      headerUserAgent,
+	}
+	bodyBytes, err := fetchBody(u.logger, u.httpClient, u.url.String(), headers)
+	if err != nil {
+		return preview, err
+	}
+
+	var ogMetadata OpenGraphMetadata
+	err = metabolize.Metabolize(ioutil.NopCloser(bytes.NewBuffer(bodyBytes)), &ogMetadata)
+	if err != nil {
+		return preview, fmt.Errorf("failed to parse OpenGraph data")
+	}
+
+	// There are URLs like https://wikipedia.org/ that don't have an OpenGraph
+	// title tag, but article pages do. In the future, we can fallback to the
+	// website's title by using the <title> tag.
+	if ogMetadata.Title == "" {
+		return preview, fmt.Errorf("missing required title in OpenGraph response")
+	}
+
+	if ogMetadata.ThumbnailURL != "" {
+		t, err := fetchThumbnail(u.logger, u.httpClient, ogMetadata.ThumbnailURL)
+		if err != nil {
+			// Given we want to fetch thumbnails on a best-effort basis, if an error
+			// happens we simply log it.
+			u.logger.Info("failed to fetch thumbnail", zap.String("url", u.url.String()), zap.Error(err))
+		} else {
+			preview.Thumbnail = t
+		}
+	}
+
+	preview.Title = ogMetadata.Title
+	preview.Description = ogMetadata.Description
+	return preview, nil
+}
+
+func fetchThumbnail(logger *zap.Logger, httpClient http.Client, url string) (common.LinkPreviewThumbnail, error) {
+	var thumbnail common.LinkPreviewThumbnail
+
+	imgBytes, err := fetchBody(logger, httpClient, url, nil)
+	if err != nil {
+		return thumbnail, fmt.Errorf("could not fetch thumbnail url='%s': %w", url, err)
+	}
+
+	width, height, err := images.GetImageDimensions(imgBytes)
+	if err != nil {
+		return thumbnail, fmt.Errorf("could not get image dimensions url='%s': %w", url, err)
+	}
+	thumbnail.Width = width
+	thumbnail.Height = height
+
+	dataURI, err := images.GetPayloadDataURI(imgBytes)
+	if err != nil {
+		return thumbnail, fmt.Errorf("could not build data URI url='%s': %w", url, err)
+	}
+	thumbnail.DataURI = dataURI
+
+	return thumbnail, nil
+}

--- a/protocol/linkpreview/unfurlers/opengraph_unfurler.go
+++ b/protocol/linkpreview/unfurlers/opengraph_unfurler.go
@@ -3,14 +3,16 @@ package unfurlers
 import (
 	"bytes"
 	"fmt"
-	"github.com/keighl/metabolize"
-	"github.com/status-im/status-go/images"
-	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/protobuf"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
 	neturl "net/url"
+
+	"github.com/keighl/metabolize"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/images"
+	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/protobuf"
 )
 
 type OpenGraphMetadata struct {

--- a/protocol/linkpreview/unfurlers/opengraph_unfurler.go
+++ b/protocol/linkpreview/unfurlers/opengraph_unfurler.go
@@ -38,7 +38,7 @@ func NewOpenGraphUnfurler(URL *neturl.URL, logger *zap.Logger, httpClient http.C
 	}
 }
 
-func (u OpenGraphUnfurler) Unfurl() (common.LinkPreview, error) {
+func (u *OpenGraphUnfurler) Unfurl() (common.LinkPreview, error) {
 	preview := newDefaultLinkPreview(u.url)
 	preview.Type = protobuf.UnfurledLink_LINK
 

--- a/protocol/linkpreview/unfurlers/opengraph_unfurler.go
+++ b/protocol/linkpreview/unfurlers/opengraph_unfurler.go
@@ -27,10 +27,10 @@ type OpenGraphMetadata struct {
 type OpenGraphUnfurler struct {
 	url        *neturl.URL
 	logger     *zap.Logger
-	httpClient http.Client
+	httpClient *http.Client
 }
 
-func NewOpenGraphUnfurler(URL *neturl.URL, logger *zap.Logger, httpClient http.Client) *OpenGraphUnfurler {
+func NewOpenGraphUnfurler(URL *neturl.URL, logger *zap.Logger, httpClient *http.Client) *OpenGraphUnfurler {
 	return &OpenGraphUnfurler{
 		url:        URL,
 		logger:     logger,
@@ -81,7 +81,7 @@ func (u *OpenGraphUnfurler) Unfurl() (common.LinkPreview, error) {
 	return preview, nil
 }
 
-func fetchThumbnail(logger *zap.Logger, httpClient http.Client, url string) (common.LinkPreviewThumbnail, error) {
+func fetchThumbnail(logger *zap.Logger, httpClient *http.Client, url string) (common.LinkPreviewThumbnail, error) {
 	var thumbnail common.LinkPreviewThumbnail
 
 	imgBytes, err := fetchBody(logger, httpClient, url, nil)

--- a/protocol/linkpreview/unfurlers/unfurler.go
+++ b/protocol/linkpreview/unfurlers/unfurler.go
@@ -44,7 +44,7 @@ func newDefaultLinkPreview(url *neturl.URL) common.LinkPreview {
 	}
 }
 
-func fetchBody(logger *zap.Logger, httpClient http.Client, url string, headers Headers) ([]byte, error) {
+func fetchBody(logger *zap.Logger, httpClient *http.Client, url string, headers Headers) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultRequestTimeout)
 	defer cancel()
 

--- a/protocol/linkpreview/unfurlers/unfurler.go
+++ b/protocol/linkpreview/unfurlers/unfurler.go
@@ -3,12 +3,14 @@ package unfurlers
 import (
 	"context"
 	"fmt"
-	"github.com/status-im/status-go/protocol/common"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
 	neturl "net/url"
 	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/protocol/common"
 )
 
 const (

--- a/protocol/linkpreview/unfurlers/unfurler.go
+++ b/protocol/linkpreview/unfurlers/unfurler.go
@@ -1,0 +1,78 @@
+package unfurlers
+
+import (
+	"context"
+	"fmt"
+	"github.com/status-im/status-go/protocol/common"
+	"go.uber.org/zap"
+	"io/ioutil"
+	"net/http"
+	neturl "net/url"
+	"time"
+)
+
+const (
+	DefaultRequestTimeout = 15000 * time.Millisecond
+
+	headerAcceptJSON = "application/json; charset=utf-8"
+	headerAcceptText = "text/html; charset=utf-8"
+
+	// Without a particular user agent, many providers treat status-go as a
+	// gluttony bot, and either respond more frequently with a 429 (Too Many
+	// Requests), or simply refuse to return valid data. Note that using a known
+	// browser UA doesn't work well with some providers, such as Spotify,
+	// apparently they still flag status-go as a bad actor.
+	headerUserAgent = "status-go/v0.151.15"
+
+	// Currently set to English, but we could make this setting dynamic according
+	// to the user's language of choice.
+	headerAcceptLanguage = "en-US,en;q=0.5"
+)
+
+type Headers map[string]string
+
+type Unfurler interface {
+	Unfurl() (common.LinkPreview, error)
+}
+
+func newDefaultLinkPreview(url *neturl.URL) common.LinkPreview {
+	return common.LinkPreview{
+		URL:      url.String(),
+		Hostname: url.Hostname(),
+	}
+}
+
+func fetchBody(logger *zap.Logger, httpClient http.Client, url string, headers Headers) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to perform HTTP request: %w", err)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			logger.Error("failed to close response body", zap.Error(err))
+		}
+	}()
+
+	if res.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("http request failed, statusCode='%d'", res.StatusCode)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read body bytes: %w", err)
+	}
+
+	return bodyBytes, nil
+}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -49,7 +49,6 @@ import (
 	"github.com/status-im/status-go/protocol/identity"
 	"github.com/status-im/status-go/protocol/identity/alias"
 	"github.com/status-im/status-go/protocol/identity/identicon"
-	"github.com/status-im/status-go/protocol/linkpreview"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/pushnotificationclient"
 	"github.com/status-im/status-go/protocol/pushnotificationserver"
@@ -6137,10 +6136,6 @@ func generateAliasAndIdenticon(pk string) (string, string, error) {
 	}
 	return name, identicon, nil
 
-}
-
-func (m *Messenger) UnfurlURLs(urls []string) ([]common.LinkPreview, error) {
-	return linkpreview.UnfurlURLs(m.logger, linkpreview.NewDefaultHTTPClient(), urls)
 }
 
 func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID string, emojiID protobuf.EmojiReaction_Type) (*MessengerResponse, error) {

--- a/protocol/messenger_linkpreview.go
+++ b/protocol/messenger_linkpreview.go
@@ -26,7 +26,7 @@ func normalizeHostname(hostname string) string {
 	return re.ReplaceAllString(hostname, "$1")
 }
 
-func (m *Messenger) newUrlUnfurler(httpClient *http.Client, url *neturl.URL) unfurlers.Unfurler {
+func (m *Messenger) newURLUnfurler(httpClient *http.Client, url *neturl.URL) unfurlers.Unfurler {
 	if unfurlers.IsSupportedImageURL(url) {
 		return unfurlers.NewImageUnfurler(
 			url,
@@ -49,7 +49,7 @@ func (m *Messenger) newUrlUnfurler(httpClient *http.Client, url *neturl.URL) unf
 	}
 }
 
-func (m *Messenger) unfurlUrl(httpClient *http.Client, url string) (common.LinkPreview, error) {
+func (m *Messenger) unfurlURL(httpClient *http.Client, url string) (common.LinkPreview, error) {
 	var preview common.LinkPreview
 
 	parsedURL, err := neturl.Parse(url)
@@ -57,7 +57,7 @@ func (m *Messenger) unfurlUrl(httpClient *http.Client, url string) (common.LinkP
 		return preview, err
 	}
 
-	unfurler := m.newUrlUnfurler(httpClient, parsedURL)
+	unfurler := m.newURLUnfurler(httpClient, parsedURL)
 	preview, err = unfurler.Unfurl()
 	if err != nil {
 		return preview, err
@@ -140,7 +140,7 @@ func (m *Messenger) UnfurlURLs(httpClient *http.Client, urls []string) ([]common
 
 	for _, url := range urls {
 		m.logger.Debug("unfurling", zap.String("url", url))
-		p, err := m.unfurlUrl(httpClient, url)
+		p, err := m.unfurlURL(httpClient, url)
 		if err != nil {
 			m.logger.Info("failed to unfurl", zap.String("url", url), zap.Error(err))
 			continue

--- a/protocol/messenger_linkpreview.go
+++ b/protocol/messenger_linkpreview.go
@@ -26,7 +26,7 @@ func normalizeHostname(hostname string) string {
 	return re.ReplaceAllString(hostname, "$1")
 }
 
-func (m *Messenger) newUrlUnfurler(httpClient http.Client, url *neturl.URL) unfurlers.Unfurler {
+func (m *Messenger) newUrlUnfurler(httpClient *http.Client, url *neturl.URL) unfurlers.Unfurler {
 	if unfurlers.IsSupportedImageURL(url) {
 		return unfurlers.NewImageUnfurler(
 			url,
@@ -49,7 +49,7 @@ func (m *Messenger) newUrlUnfurler(httpClient http.Client, url *neturl.URL) unfu
 	}
 }
 
-func (m *Messenger) unfurlUrl(httpClient http.Client, url string) (common.LinkPreview, error) {
+func (m *Messenger) unfurlUrl(httpClient *http.Client, url string) (common.LinkPreview, error) {
 	var preview common.LinkPreview
 
 	parsedURL, err := neturl.Parse(url)
@@ -125,14 +125,17 @@ func GetURLs(text string) []string {
 	return urls
 }
 
-func NewDefaultHTTPClient() http.Client {
-	return http.Client{Timeout: unfurlers.DefaultRequestTimeout}
+func NewDefaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: unfurlers.DefaultRequestTimeout}
 }
 
 // UnfurlURLs assumes clients pass URLs verbatim that were validated and
 // processed by GetURLs.
-func (m *Messenger) UnfurlURLs(urls []string) ([]common.LinkPreview, error) {
-	httpClient := NewDefaultHTTPClient()
+func (m *Messenger) UnfurlURLs(httpClient *http.Client, urls []string) ([]common.LinkPreview, error) {
+	if httpClient == nil {
+		httpClient = NewDefaultHTTPClient()
+	}
+
 	previews := make([]common.LinkPreview, 0, len(urls))
 
 	for _, url := range urls {

--- a/protocol/messenger_linkpreview_test.go
+++ b/protocol/messenger_linkpreview_test.go
@@ -1,4 +1,4 @@
-package linkpreview
+package protocol
 
 import (
 	"bytes"
@@ -207,7 +207,7 @@ func Test_UnfurlURLs_YouTube(t *testing.T) {
 	transport.AddURLMatcher(thumbnailURL, readAsset(t, "1.jpg"), nil)
 	stubbedClient := http.Client{Transport: &transport}
 
-	previews, err := UnfurlURLs(nil, stubbedClient, []string{url})
+	previews, err := m.UnfurlURLs(nil, stubbedClient, []string{url})
 	require.NoError(t, err)
 	require.Len(t, previews, 1)
 	preview := previews[0]

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1157,7 +1157,7 @@ func (api *PublicAPI) GetTextURLs(text string) []string {
 //
 // This endpoint expects the client to send URLs normalized by GetTextURLs.
 func (api *PublicAPI) UnfurlURLs(urls []string) ([]common.LinkPreview, error) {
-	return api.service.messenger.UnfurlURLs(urls)
+	return api.service.messenger.UnfurlURLs(nil, urls)
 }
 
 func (api *PublicAPI) EnsVerified(pk, ensName string) error {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -28,7 +28,6 @@ import (
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/discord"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
-	"github.com/status-im/status-go/protocol/linkpreview"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/pushnotificationclient"
 	"github.com/status-im/status-go/protocol/requests"
@@ -1150,7 +1149,7 @@ func (api *PublicAPI) GetLinkPreviewData(link string) (previewData urls.LinkPrev
 // GetTextURLs parses text and returns a deduplicated and (somewhat) normalized
 // slice of URLs. The returned URLs can be used as cache keys by clients.
 func (api *PublicAPI) GetTextURLs(text string) []string {
-	return linkpreview.GetURLs(text)
+	return protocol.GetURLs(text)
 }
 
 // UnfurlURLs uses a best-effort approach to unfurl each URL. Failed URLs will


### PR DESCRIPTION
Requires https://github.com/status-im/status-go/pull/3901
Note that it uses `feat/link-previews-for-image-urls` as target branch. I will change the base when https://github.com/status-im/status-go/pull/3901 is merged.

_____

1. Moved `linkpreviews` to `Messenger`
- This is required for unfurling Status SharedURL. That functionality is implemented in `Messenger`
- Because of this, I also reworked tests to a TestSuite, because we need a `Messenger` there

2. Clean up
- Added a separate `unfurlers` "sub"-package
- Moved each unfurler to a separate file