### PR TITLE
fix: change cursor of opensea v2 ownership endpoint

### DIFF
--- a/services/wallet/thirdparty/opensea/client_v2.go
+++ b/services/wallet/thirdparty/opensea/client_v2.go
@@ -84,9 +84,10 @@ func (o *ClientV2) FetchAllAssetsByOwnerAndContractAddress(chainID walletCommon.
 	}
 
 	assets.PreviousCursor = cursor
+	assets.NextCursor = cursor
 
 	for {
-		assetsPage, err := o.FetchAllAssetsByOwner(chainID, owner, cursor, assetLimitV2)
+		assetsPage, err := o.FetchAllAssetsByOwner(chainID, owner, assets.NextCursor, assetLimitV2)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Was not updating the cursor on each loop. This PR fixes that.