### PR TITLE
fix workdir path in case it has code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,11 +316,11 @@ test-unit: UNIT_TEST_PACKAGES = $(shell go list ./...  | \
 	grep -v /t/benchmarks | \
 	grep -v /transactions/fake )
 test-unit: ##@tests Run unit and integration tests
-	for file in $(UNIT_TEST_PACKAGES); do \
+	for package in $(UNIT_TEST_PACKAGES); do \
 		set -e; \
-		path=$$(echo $$file | cut -d\/ -f 4-); \
-		go test -tags '$(BUILD_TAGS)' -timeout 30m -v -failfast $$file $(gotest_extraflags) | \
-		  go-junit-report -iocopy -out $${path}/report.xml; \
+		package_dir=$$(go list -f {{.Dir}} $${package}); \
+		go test -tags '$(BUILD_TAGS)' -timeout 30m -v -failfast $${package} $(gotest_extraflags) | \
+		  go-junit-report -iocopy -out $${package_dir}/report.xml; \
 	done
 
 test-unit-race: gotest_extraflags=-race


### PR DESCRIPTION
`make test` was failing (see https://github.com/status-im/status-go/pull/3914) in case of code in `github.com/status-im/status-go` (from `go list ./...` output`)

~~This PR adds `./` in front of subfolder.~~
Found a better solution to find a dir of package: `go list -f {{.Dir}} ${package}`
Also fixed variable names.