### PR TITLE
fix: changes lost while rebasing

### DIFF
--- a/server/pairing/common.go
+++ b/server/pairing/common.go
@@ -177,10 +177,6 @@ func emptyDir(dir string) error {
 }
 
 func validateReceivedKeystoreFiles(expectedKeys []string, keys map[string][]byte, password string) error {
-	if len(expectedKeys) != len(keys) {
-		return fmt.Errorf("one or more keystore files were not sent")
-	}
-
 	for _, searchKey := range expectedKeys {
 		found := false
 		for key := range keys {


### PR DESCRIPTION
The following somehow disappeared when I was rebasing changes in this PR https://github.com/status-im/status-go/pull/3911, now I'm just bringing them back:
- send transferred keyuids instead of number of transferred files
- updating keypair's operability for transferred keypairs
- unnecessary check of the number of transferred keystore files