### PR TITLE
feat: endpoint `MakePartiallyOperableAccoutsFullyOperable` added

### DIFF
--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -3221,14 +3221,14 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 		}
 	} else if !fromLocalPairing && dbKeypair != nil {
 		for _, dbAcc := range dbKeypair.Accounts {
-			found := false
+			removeAcc := false
 			for _, acc := range kp.Accounts {
-				if dbAcc.Address == acc.Address {
-					found = true
+				if dbAcc.Address == acc.Address && acc.Removed && !dbAcc.Removed {
+					removeAcc = true
 					break
 				}
 			}
-			if !found {
+			if removeAcc {
 				err = m.deleteKeystoreFileForAddress(dbAcc.Address)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
- Endpoint `MakePartiallyOperableAccoutsFullyOperable` added.
- When we switched to marking removed accounts, the handler remained unchanged. It kept checking for the account existence in the received `protobuf.SyncKeypair` message, instead of checking a removed flag, fixed now.