### PR TITLE
fix: use all available providers when fetching collectibles by ID

### DIFF
--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -269,7 +269,7 @@ func (o *Manager) FetchAssetsByCollectibleUniqueID(uniqueIDs []thirdparty.Collec
 				continue
 			}
 
-			fetchedAssets, err := o.opensea.FetchAssetsByCollectibleUniqueID(idsToFetch)
+			fetchedAssets, err := provider.FetchAssetsByCollectibleUniqueID(idsToFetch)
 			if err != nil {
 				return nil, err
 			}

--- a/services/wallet/thirdparty/opensea/client_v2.go
+++ b/services/wallet/thirdparty/opensea/client_v2.go
@@ -25,9 +25,9 @@ const assetLimitV2 = 50
 func getV2BaseURL(chainID walletCommon.ChainID) (string, error) {
 	switch uint64(chainID) {
 	case walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet, walletCommon.OptimismMainnet:
-		return "https://api.opensea.io/api/v2", nil
+		return "https://api.opensea.io/v2", nil
 	case walletCommon.EthereumGoerli, walletCommon.EthereumSepolia, walletCommon.ArbitrumGoerli, walletCommon.OptimismGoerli:
-		return "https://testnets-api.opensea.io/api/v2", nil
+		return "https://testnets-api.opensea.io/v2", nil
 	}
 
 	return "", thirdparty.ErrChainIDNotSupported
@@ -155,6 +155,13 @@ func (o *ClientV2) fetchAssets(chainID walletCommon.ChainID, pathParams []string
 			return nil, err
 		}
 		o.connectionStatus.SetIsConnected(true)
+
+		// If body is empty, it means the account has no collectibles for this chain.
+		// (Workaround implemented in http_client.go)
+		if body == nil {
+			assets.NextCursor = ""
+			break
+		}
 
 		// if Json is not returned there must be an error
 		if !json.Valid(body) {

--- a/services/wallet/thirdparty/opensea/http_client.go
+++ b/services/wallet/thirdparty/opensea/http_client.go
@@ -65,6 +65,10 @@ func (o *HTTPClient) doGetRequest(url string, apiKey string) ([]byte, error) {
 		case http.StatusOK:
 			body, err := ioutil.ReadAll(resp.Body)
 			return body, err
+		case http.StatusBadRequest:
+			// The OpenSea v2 API will return error 400 if the account holds no collectibles on
+			// the requested chain. This shouldn't be treated as an error, return an empty body.
+			return nil, nil
 		case http.StatusTooManyRequests:
 			if retryCount < getRequestRetryMaxCount {
 				// sleep and retry


### PR DESCRIPTION
We were only using opensea v1 for fetching collectibles by UniqueID, so only Eth Mainnet and Sepolia were supported (the rest returned an error). This PR fixes that.
On top of that, OpenSea returns error 400 (Bad Request) for some reason when querying owned assets for an empty/inactive account. This condition is handled in the client code.

