### PR TITLE
feat(shared_addresses): save own shared addresses in DB

### DIFF
--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -378,7 +378,7 @@ func (p *Persistence) SaveRequestToJoin(request *RequestToJoin) (err error) {
 	return err
 }
 
-func (p *Persistence) SaveRequestToJoinRevealedAddresses(request *RequestToJoin) (err error) {
+func (p *Persistence) SaveRequestToJoinRevealedAddresses(requestID types.HexBytes, revealedAccounts []*protobuf.RevealedAccount) (err error) {
 	tx, err := p.db.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		return
@@ -398,7 +398,7 @@ func (p *Persistence) SaveRequestToJoinRevealedAddresses(request *RequestToJoin)
 		return
 	}
 	defer stmt.Close()
-	for _, account := range request.RevealedAccounts {
+	for _, account := range revealedAccounts {
 
 		var chainIDs []string
 		for _, ID := range account.ChainIds {
@@ -406,7 +406,7 @@ func (p *Persistence) SaveRequestToJoinRevealedAddresses(request *RequestToJoin)
 		}
 
 		_, err = stmt.Exec(
-			request.ID,
+			requestID,
 			account.Address,
 			strings.Join(chainIDs, ","),
 			account.IsAirdropAddress,

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1162,6 +1162,16 @@ func (m *Messenger) EditSharedAddressesForCommunity(request *requests.EditShared
 		requestToEditRevealedAccountsProto.RevealedAccounts = append(requestToEditRevealedAccountsProto.RevealedAccounts, revealedAccount)
 	}
 
+	requestID := communities.CalculateRequestID(common.PubkeyToHex(&m.identity.PublicKey), request.CommunityID)
+	err = m.communitiesManager.RemoveRequestToJoinRevealedAddresses(requestID)
+	if err != nil {
+		return nil, err
+	}
+	err = m.communitiesManager.SaveRequestToJoinRevealedAddresses(requestID, requestToEditRevealedAccountsProto.RevealedAccounts)
+	if err != nil {
+		return nil, err
+	}
+
 	payload, err := proto.Marshal(requestToEditRevealedAccountsProto)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/11972

Adds the user's shared accounts in their own DB when they request to join a community or edits those accounts.