### PR TITLE
fix(wallet): balance history used a wrong db for accessing accounts.

### DIFF
--- a/services/wallet/README.md
+++ b/services/wallet/README.md
@@ -132,30 +132,6 @@ Returns avaiable transfers in a given range.
 ]
 ```
 
-### wallet_setInitialBlocksRange
-
-Sets `zero block - latest block` range as scanned for an account. It is used when a new multiaccount is generated to avoid scanning transfers history.
-
-#### Example 
-
-```json
-{"jsonrpc":"2.0","id":7,"method":"wallet_setInitialBlocksRange","params":[]}
-```
-
-### setInitialBlocksRangeForChainIDs
-
-Sets `zero block - latest block` range as scanned for an account. It is used when a new multiaccount is generated to avoid scanning transfers history.
-
-#### Parameters
-
-- `chainIDs`: `[]INT` - array of ethereum chain ID to be initialized
-
-#### Example 
-
-```json
-{"jsonrpc":"2.0","id":7,"method":"wallet_setInitialBlocksRangeForChainIDs","params":[[1, 2]]}
-```
-
 ### wallet_watchTransaction
 
 Starts watching for transaction confirmation/rejection. If transaction was not confirmed/rejected in 10 minutes the call is timed out with error.
@@ -616,7 +592,7 @@ Emitted when history scanning is started.
 
 Emitted when history scanning is ended.
 
-4. `fetching-history-error` 
+4. `fetching-history-error`
 
 Emitted when when history can't be fetched because some error. Error's decritption can be found in `message` field.
 
@@ -630,12 +606,11 @@ Emitted when the application is connected to a non-archival node.
 
 When a new multiaccount is created corresponding address will not contain any transaction. Thus no point in checking history, it will be empty.
 
-1. Call `wallet_setInitialRange` 
-2. Call `wallet_checkRecentHistory`
-3. On `recent-history-ready` request transactions via `wallet_getTransfersByAddress`
-4. Repeat `wallet_checkRecentHistory` in N minutes (currently 20 minutes in `status-mobile` for upstream RPC node. If a custom node is used interval can be arbitrary)
+1. Call `wallet_checkRecentHistory`
+2. On `recent-history-ready` request transactions via `wallet_getTransfersByAddress`
+3. Repeat `wallet_checkRecentHistory` in N minutes (currently 20 minutes in `status-mobile` for upstream RPC node. If a custom node is used interval can be arbitrary)
 
-### Logging into application 
+### Logging into application
 1. Call `wallet_checkRecentHistory`
 2. On `recent-history-ready` request transactions via `wallet_getTransfersByAddress`
 3. Repeat `wallet_checkRecentHistory` in N minutes (currently 20 minutes in `status-mobile` for upstream RPC node. If a custom node is used interval can be arbitrary)

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -66,15 +66,6 @@ type DerivedAddress struct {
 	AlreadyCreated bool           `json:"alreadyCreated"`
 }
 
-// SetInitialBlocksRange sets initial blocks range
-func (api *API) SetInitialBlocksRange(ctx context.Context) error {
-	return api.s.transferController.SetInitialBlocksRange([]uint64{api.s.rpcClient.UpstreamChainID})
-}
-
-func (api *API) SetInitialBlocksRangeForChainIDs(ctx context.Context, chainIDs []uint64) error {
-	return api.s.transferController.SetInitialBlocksRange(chainIDs)
-}
-
 func (api *API) CheckRecentHistory(ctx context.Context, addresses []common.Address) error {
 	return api.s.transferController.CheckRecentHistory([]uint64{api.s.rpcClient.UpstreamChainID}, addresses)
 }

--- a/services/wallet/history/service_test.go
+++ b/services/wallet/history/service_test.go
@@ -43,7 +43,7 @@ func setupDummyServiceNoDependencies(t *testing.T) (service *Service, closeFn fu
 	rpcClient, err := statusRPC.NewClient(client, 1, upstreamConfig, nil, db)
 	require.NoError(t, err)
 
-	return NewService(db, nil, rpcClient, nil, market.NewManager(cryptoCompare, cryptoCompare, &event.Feed{})), func() {
+	return NewService(db, nil, nil, rpcClient, nil, market.NewManager(cryptoCompare, cryptoCompare, &event.Feed{})), func() {
 		require.NoError(t, db.Close())
 	}
 }

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -100,7 +100,7 @@ func NewService(
 	coingecko := coingecko.NewClient()
 	marketManager := market.NewManager(cryptoCompare, coingecko, feed)
 	reader := NewReader(rpcClient, tokenManager, marketManager, accountsDB, NewPersistence(db), feed)
-	history := history.NewService(db, feed, rpcClient, tokenManager, marketManager)
+	history := history.NewService(db, accountsDB, feed, rpcClient, tokenManager, marketManager)
 	currency := currency.NewService(db, feed, tokenManager, marketManager)
 	activity := activity.NewService(db, tokenManager, feed, accountsDB)
 

--- a/services/wallet/transfer/block_dao.go
+++ b/services/wallet/transfer/block_dao.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/services/wallet/bigint"
 )
 
@@ -56,23 +55,6 @@ func (b *BlockDAO) mergeBlocksRanges(chainIDs []uint64, accounts []common.Addres
 				return err
 			}
 		}
-	}
-	return nil
-}
-
-func (b *BlockDAO) setInitialBlocksRange(chainID uint64, from *big.Int, to *big.Int) error {
-	accountsDB, err := accounts.NewDB(b.db)
-	if err != nil {
-		return err
-	}
-	watchAddress, err := accountsDB.GetWalletAddress()
-	if err != nil {
-		return err
-	}
-
-	err = b.insertRange(chainID, common.Address(watchAddress), from, to, big.NewInt(0), 0)
-	if err != nil {
-		return err
 	}
 	return nil
 }

--- a/services/wallet/transfer/controller.go
+++ b/services/wallet/transfer/controller.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -64,32 +63,6 @@ func (c *Controller) Stop() {
 		c.group.Wait()
 		c.group = nil
 	}
-}
-
-func (c *Controller) SetInitialBlocksRange(chainIDs []uint64) error {
-	chainClients, err := c.rpcClient.EthClients(chainIDs)
-	if err != nil {
-		return err
-	}
-
-	for chainID, chainClient := range chainClients {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-
-		toHeader, err := chainClient.HeaderByNumber(ctx, nil)
-		if err != nil {
-			return err
-		}
-
-		from := big.NewInt(0)
-
-		err = c.blockDAO.setInitialBlocksRange(chainID, from, toHeader.Number)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (c *Controller) CheckRecentHistory(chainIDs []uint64, accounts []common.Address) error {

--- a/services/wallet/transfer/reactor.go
+++ b/services/wallet/transfer/reactor.go
@@ -57,6 +57,30 @@ type HistoryFetcher interface {
 		limit int64, fetchMore bool) ([]Transfer, error)
 }
 
+func NewOnDemandFetchStrategy(
+	db *Database,
+	blockDAO *BlockDAO,
+	feed *event.Feed,
+	transactionManager *TransactionManager,
+	pendingTxManager *transactions.PendingTxTracker,
+	tokenManager *token.Manager,
+	chainClients map[uint64]*chain.ClientWithFallback,
+	accounts []common.Address,
+) *OnDemandFetchStrategy {
+	strategy := &OnDemandFetchStrategy{
+		db:                 db,
+		blockDAO:           blockDAO,
+		feed:               feed,
+		transactionManager: transactionManager,
+		pendingTxManager:   pendingTxManager,
+		tokenManager:       tokenManager,
+		chainClients:       chainClients,
+		accounts:           accounts,
+	}
+
+	return strategy
+}
+
 type OnDemandFetchStrategy struct {
 	db                 *Database
 	blockDAO           *BlockDAO
@@ -294,16 +318,7 @@ func (r *Reactor) createFetchStrategy(chainClients map[uint64]*chain.ClientWithF
 		)
 	}
 
-	return &OnDemandFetchStrategy{
-		db:                 r.db,
-		feed:               r.feed,
-		blockDAO:           r.blockDAO,
-		transactionManager: r.transactionManager,
-		pendingTxManager:   r.pendingTxManager,
-		tokenManager:       r.tokenManager,
-		chainClients:       chainClients,
-		accounts:           accounts,
-	}
+	return NewOnDemandFetchStrategy(r.db, r.blockDAO, r.feed, r.transactionManager, r.pendingTxManager, r.tokenManager, chainClients, accounts)
 }
 
 func (r *Reactor) getTransfersByAddress(ctx context.Context, chainID uint64, address common.Address, toBlock *big.Int,


### PR DESCRIPTION
Balance history was not checked for all chains if no history on some chain.
Removed `SetInitialRange` from wallet API as internal implementation. This method was called on adding a brand new Status account to initialize `blocks_range` table for `OnDemand` transfer fetching strategy.

And [issue](https://github.com/status-im/status-go/issues/3971) created as a follow up to handle a case for a brand new accounts and initial history fetching for ERC20 tokens.
