### PR TITLE
ci: hide `go test` output to the file on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ package-lock.json
 
 # junit reports for Jenkins integration
 report.xml
+
+# go test logs
+test.log

--- a/_assets/scripts/colors.sh
+++ b/_assets/scripts/colors.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Colors
+export YLW='\033[1;33m'
+export RED='\033[0;31m'
+export GRN='\033[0;32m'
+export BLU='\033[0;34m'
+export BLD='\033[1m'
+export RST='\033[0m'
+
+# Clear line
+export CLR='\033[2K'

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -o pipefail
+
+GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
+
+source "${GIT_ROOT}/_assets/scripts/colors.sh"
+
+for package in ${UNIT_TEST_PACKAGES}; do
+  echo -e "${GRN}Testing:${RST} ${package}"
+  package_dir=$(go list -f "{{.Dir}}" "${package}")
+  output_file=${package_dir}/test.log
+
+  go test -tags "${BUILD_TAGS}" -timeout 30m -v -failfast "${package}" ${GOTEST_EXTRAFLAGS} | \
+     if [ "${CI}" = "true" ]; then cat > "${output_file}"; else tee "${output_file}"; fi
+  go_test_exit=$?
+
+  if [ "${CI}" = "true" ]; then
+    go-junit-report -in "${output_file}" -out "${package_dir}"/report.xml
+  fi
+
+  if [ ${go_test_exit} -ne 0 ]; then
+    echo -e "${YLW}Failed, see the log:${RST} ${BLD}${output_file}${RST}"
+    exit "${go_test_exit}"
+  fi
+done


### PR DESCRIPTION
Let's hide stdout of go tests to the files.
In case of failed test - it should be included in junit report anyway and shown in Jenkins.

Closes #3543
