### PR TITLE
feat(wallet): move balance cache to a common place

### DIFF
--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/status-im/status-go/services/ens"
 	"github.com/status-im/status-go/services/stickers"
 	"github.com/status-im/status-go/services/wallet/activity"
+	"github.com/status-im/status-go/services/wallet/balance"
 	"github.com/status-im/status-go/services/wallet/collectibles"
 	"github.com/status-im/status-go/services/wallet/currency"
 	"github.com/status-im/status-go/services/wallet/history"
@@ -91,11 +92,14 @@ func NewService(
 			ChainID:  chainID,
 		})
 	})
+
+	balanceCache := balance.NewCache()
+
 	tokenManager := token.NewTokenManager(db, rpcClient, rpcClient.NetworkManager)
 	savedAddressesManager := &SavedAddressesManager{db: db}
 	transactionManager := transfer.NewTransactionManager(db, gethManager, transactor, config, accountsDB, pendingTxManager, feed)
 	transferController := transfer.NewTransferController(db, rpcClient, accountFeed, feed, transactionManager, pendingTxManager,
-		tokenManager, config.WalletConfig.LoadAllTransfers)
+		tokenManager, balanceCache, config.WalletConfig.LoadAllTransfers)
 	cryptoCompare := cryptocompare.NewClient()
 	coingecko := coingecko.NewClient()
 	marketManager := market.NewManager(cryptoCompare, coingecko, feed)

--- a/services/wallet/transfer/concurrent.go
+++ b/services/wallet/transfer/concurrent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/status-im/status-go/services/wallet/async"
+	"github.com/status-im/status-go/services/wallet/balance"
 )
 
 const (
@@ -93,7 +94,7 @@ type Downloader interface {
 
 // Returns new block ranges that contain transfers and found block headers that contain transfers, and a block where
 // beginning of trasfers history detected
-func checkRangesWithStartBlock(parent context.Context, client BalanceReader, cache BalanceCache,
+func checkRangesWithStartBlock(parent context.Context, client balance.Reader, cache balance.Cacher,
 	account common.Address, ranges [][]*big.Int, threadLimit uint32, startBlock *big.Int) (
 	resRanges [][]*big.Int, headers []*DBHeader, newStartBlock *big.Int, err error) {
 
@@ -214,7 +215,7 @@ func checkRangesWithStartBlock(parent context.Context, client BalanceReader, cac
 	return c.GetRanges(), c.GetHeaders(), newStartBlock, nil
 }
 
-func findBlocksWithEthTransfers(parent context.Context, client BalanceReader, cache BalanceCache,
+func findBlocksWithEthTransfers(parent context.Context, client balance.Reader, cache balance.Cacher,
 	account common.Address, low, high *big.Int, noLimit bool, threadLimit uint32) (
 	from *big.Int, headers []*DBHeader, resStartBlock *big.Int, err error) {
 

--- a/services/wallet/transfer/concurrent_test.go
+++ b/services/wallet/transfer/concurrent_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/status-im/status-go/rpc/chain"
+	"github.com/status-im/status-go/services/wallet/balance"
 
 	"github.com/stretchr/testify/require"
 
@@ -142,7 +143,7 @@ func TestConcurrentEthDownloader(t *testing.T) {
 			defer cancel()
 			concurrent := NewConcurrentDownloader(ctx, 0)
 			_, headers, _, _ := findBlocksWithEthTransfers(
-				ctx, tc.options.balances, newBalanceCache(),
+				ctx, tc.options.balances, balance.NewCache(),
 				common.Address{}, zero, tc.options.last, false, NoThreadLimit)
 			concurrent.Wait()
 			require.NoError(t, concurrent.Error())


### PR DESCRIPTION
And make it a parameter to share between transfers and balance history in an upcoming commit.
Had to refactor its interface for that reason.

- `BalanceCache` interface is renamed to `BalanceCacher` which requires `BalanceReader` to fetch balance data from chain. Added an additional `Cache()` method to retrieve `CacheIface` interface. It is used whenever we should get data  whether it is already cached or needs fetching from chain.
- `CacheIface` interface is used to get and add balance and nonce to/from cache (forced by linter to remove `Balance` prefix for the interface name, since the type is in `balance` package) . This is for operations on cache itself without fetching anything from chain.
- `Cache` type implements both above interfaces (forced by linter to remove `Balance` prefix for the type name)

Updates [#3835](https://github.com/status-im/status-go/issues/3835)
