### PR TITLE
chore: Use proper Gwei decimals

### DIFF
--- a/services/wallet/currency/service.go
+++ b/services/wallet/currency/service.go
@@ -109,5 +109,12 @@ func (s *Service) fetchAllTokenCurrencyFormats() (FormatPerSymbol, error) {
 		}
 	}
 
-	return s.currency.FetchTokenCurrencyFormats(tokenSymbols)
+	tokenFormats, err := s.currency.FetchTokenCurrencyFormats(tokenSymbols)
+	gweiSymbol := "Gwei"
+	tokenFormats[gweiSymbol] = Format{
+		Symbol:              gweiSymbol,
+		DisplayDecimals:     9,
+		StripTrailingZeroes: true,
+	}
+	return tokenFormats, err
 }


### PR DESCRIPTION
Use proper decimal points for Gwei, so that Gwei and Gwei converted to ETH is displayed correctly.

![image](https://github.com/status-im/status-go/assets/11396062/a98c65d4-aa2e-46fc-abf6-61463200144b)

https://goerli.etherscan.io/tx/0xb3b9675a8ff138feb0654dcb3fcc52daac8e94731381244e1540038b9d904f0c