### PR TITLE
Hotfix: mark `Chat` and `Pin` archive messages as seen

### DIFF
--- a/_assets/generate_handlers/generate_handlers.go
+++ b/_assets/generate_handlers/generate_handlers.go
@@ -19,11 +19,12 @@ type EnumType struct {
 
 // MethodInfo holds information about a method
 type MethodInfo struct {
-	ProtobufName string
-	MethodName   string
-	EnumValue    string
-	ProcessRaw   bool
-	SyncMessage  bool
+	ProtobufName   string
+	MethodName     string
+	EnumValue      string
+	ProcessRaw     bool
+	SyncMessage    bool
+	FromArchiveArg bool
 }
 
 func main() {
@@ -66,6 +67,8 @@ func main() {
 		if protobufName == "PushNotificationRegistration" {
 			info.ProcessRaw = true
 		}
+
+		info.FromArchiveArg = protobufName == "ChatMessage" || protobufName == "PinMessage"
 
 		methodInfos = append(methodInfos, info)
 	}

--- a/_assets/generate_handlers/generate_handlers_template.txt
+++ b/_assets/generate_handlers/generate_handlers_template.txt
@@ -16,11 +16,11 @@ import (
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 )
 
-func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter) error {
+func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter, fromArchive bool) error {
 	switch msg.Type {
 	{{ range .}}
            case protobuf.ApplicationMetadataMessage_{{.EnumValue}}:
-		return m.{{.MethodName}}(messageState, protoBytes, msg, filter)
+		return m.{{.MethodName}}(messageState, protoBytes, msg, filter{{ if .FromArchiveArg }}, fromArchive{{ end }})
         {{ end }}
 	default:
 		m.logger.Info("protobuf type not found", zap.String("type", string(msg.Type)))
@@ -30,7 +30,7 @@ func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoB
 }
 
 {{ range . }}
-func (m *Messenger) {{.MethodName}}(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter) error {
+func (m *Messenger) {{.MethodName}}(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter{{ if .FromArchiveArg }}, fromArchive bool{{ end }}) error {
 	m.logger.Info("handling {{ .ProtobufName}}")
 	{{ if .SyncMessage }}
 	if !common.IsPubKeyEqual(messageState.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
@@ -50,7 +50,7 @@ func (m *Messenger) {{.MethodName}}(messageState *ReceivedMessageState, protoByt
 
 	m.outputToCSV(msg.TransportMessage.Timestamp, msg.ID, messageState.CurrentMessageState.Contact.ID, filter.Topic, filter.ChatID, msg.Type, p)
 
-	return m.Handle{{.ProtobufName}}(messageState, p, msg)
+	return m.Handle{{.ProtobufName}}(messageState, p, msg{{ if .FromArchiveArg }}, fromArchive {{ end }})
 	{{ end }}
 }
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3136,7 +3136,7 @@ func (m *Messenger) RetrieveAll() (*MessengerResponse, error) {
 		return nil, err
 	}
 
-	return m.handleRetrievedMessages(chatWithMessages, true)
+	return m.handleRetrievedMessages(chatWithMessages, true, false)
 }
 
 func (m *Messenger) GetStats() types.StatsSummary {
@@ -3413,21 +3413,16 @@ func (m *Messenger) handleImportedMessages(messagesToHandle map[transport.Filter
 					switch msg.Type {
 
 					case protobuf.ApplicationMetadataMessage_CHAT_MESSAGE:
-						logger.Debug("Handling ChatMessage")
-
-						protoMessage := &protobuf.ChatMessage{}
-						err := proto.Unmarshal(msg.UnwrappedPayload, protoMessage)
-						if err != nil {
-							logger.Warn("failed to unmarshal ChatMessage", zap.Error(err))
-							continue
-						}
-
-						messageState.CurrentMessageState.Message = protoMessage
-						m.outputToCSV(msg.TransportMessage.Timestamp, msg.ID, senderID, filter.Topic, filter.ChatID, msg.Type, messageState.CurrentMessageState.Message)
-						err = m.HandleImportedChatMessage(messageState)
+						err = m.handleChatMessageProtobuf(messageState, msg.UnwrappedPayload, msg, filter, true)
 						if err != nil {
 							logger.Warn("failed to handle ChatMessage", zap.Error(err))
 							continue
+						}
+
+					case protobuf.ApplicationMetadataMessage_PIN_MESSAGE:
+						err = m.handlePinMessageProtobuf(messageState, msg.UnwrappedPayload, msg, filter, true)
+						if err != nil {
+							logger.Warn("failed to handle PinMessage", zap.Error(err))
 						}
 					}
 				}
@@ -3491,7 +3486,7 @@ func (m *Messenger) handleImportedMessages(messagesToHandle map[transport.Filter
 	return nil
 }
 
-func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filter][]*types.Message, storeWakuMessages bool) (*MessengerResponse, error) {
+func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filter][]*types.Message, storeWakuMessages bool, fromArchive bool) (*MessengerResponse, error) {
 
 	m.handleMessagesMutex.Lock()
 	defer m.handleMessagesMutex.Unlock()
@@ -3596,7 +3591,7 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 
 				if msg.UnwrappedPayload != nil {
 
-					err := m.dispatchToHandler(messageState, msg.UnwrappedPayload, msg, filter)
+					err := m.dispatchToHandler(messageState, msg.UnwrappedPayload, msg, filter, fromArchive)
 					if err != nil {
 						allMessagesProcessed = false
 						logger.Warn("failed to process protobuf", zap.Error(err))

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2580,8 +2580,8 @@ func (m *Messenger) handleCommunityResponse(state *ReceivedMessageState, communi
 	state.Response.CommunityChanges = append(state.Response.CommunityChanges, communityResponse.Changes)
 	state.Response.AddRequestsToJoinCommunity(communityResponse.RequestsToJoin)
 
-	// If we haven't joined the org, nothing to do
-	if !community.Joined() {
+	// If we haven't joined/spectated the org, nothing to do
+	if !community.Joined() && !community.Spectated() {
 		return nil
 	}
 

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -1208,7 +1208,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 	}
 
 	response := state.Response
-	err = s.m.HandleChatMessage(state, &message, nil)
+	err = s.m.HandleChatMessage(state, &message, nil, false)
 	s.Require().NoError(err)
 	s.Require().Len(response.ActivityCenterNotifications(), 1)
 	contacts := s.m.Contacts()

--- a/protocol/messenger_delete_message_test.go
+++ b/protocol/messenger_delete_message_test.go
@@ -198,7 +198,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageFirstThenMessage() {
 			PublicKey:        &theirMessenger.identity.PublicKey,
 		},
 	}
-	err = s.m.HandleChatMessage(state, inputMessage.ChatMessage, nil)
+	err = s.m.HandleChatMessage(state, inputMessage.ChatMessage, nil, false)
 	s.Require().NoError(err)
 	s.Require().Len(state.Response.Messages(), 0) // Message should not be added to response
 	s.Require().Len(state.Response.RemovedMessages(), 0)
@@ -338,7 +338,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteImageMessageFirstThenMessage() {
 			PublicKey:        &theirMessenger.identity.PublicKey,
 		},
 	}
-	err = s.m.HandleChatMessage(state, album[0].ChatMessage, nil)
+	err = s.m.HandleChatMessage(state, album[0].ChatMessage, nil, false)
 	s.Require().NoError(err)
 	s.Require().Len(state.Response.Messages(), 0) // Message should not be added to response
 	s.Require().Len(state.Response.RemovedMessages(), 0)
@@ -354,7 +354,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteImageMessageFirstThenMessage() {
 			PublicKey:        &theirMessenger.identity.PublicKey,
 		},
 	}
-	err = s.m.HandleChatMessage(state, album[1].ChatMessage, nil)
+	err = s.m.HandleChatMessage(state, album[1].ChatMessage, nil, false)
 	s.Require().NoError(err)
 	s.Require().Len(state.Response.Messages(), 0) // Message should not be added to response even if we didn't delete that ID
 	s.Require().Len(state.Response.RemovedMessages(), 0)

--- a/protocol/messenger_edit_message_test.go
+++ b/protocol/messenger_edit_message_test.go
@@ -244,7 +244,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageFirstEditsThenMessage() {
 			PublicKey:        &theirMessenger.identity.PublicKey,
 		},
 	}
-	err = s.m.HandleChatMessage(state, inputMessage.ChatMessage, nil)
+	err = s.m.HandleChatMessage(state, inputMessage.ChatMessage, nil, false)
 	s.Require().NoError(err)
 	s.Require().Len(response.Messages(), 1)
 

--- a/protocol/messenger_handlers.go
+++ b/protocol/messenger_handlers.go
@@ -16,11 +16,11 @@ import (
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 )
 
-func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter) error {
+func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter, fromArchive bool) error {
 	switch msg.Type {
 	
            case protobuf.ApplicationMetadataMessage_CHAT_MESSAGE:
-		return m.handleChatMessageProtobuf(messageState, protoBytes, msg, filter)
+		return m.handleChatMessageProtobuf(messageState, protoBytes, msg, filter, fromArchive)
         
            case protobuf.ApplicationMetadataMessage_CONTACT_UPDATE:
 		return m.handleContactUpdateProtobuf(messageState, protoBytes, msg, filter)
@@ -95,7 +95,7 @@ func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoB
 		return m.handleCommunityRequestToJoinProtobuf(messageState, protoBytes, msg, filter)
         
            case protobuf.ApplicationMetadataMessage_PIN_MESSAGE:
-		return m.handlePinMessageProtobuf(messageState, protoBytes, msg, filter)
+		return m.handlePinMessageProtobuf(messageState, protoBytes, msg, filter, fromArchive)
         
            case protobuf.ApplicationMetadataMessage_EDIT_MESSAGE:
 		return m.handleEditMessageProtobuf(messageState, protoBytes, msg, filter)
@@ -234,7 +234,7 @@ func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoB
 }
 
 
-func (m *Messenger) handleChatMessageProtobuf(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter) error {
+func (m *Messenger) handleChatMessageProtobuf(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter, fromArchive bool) error {
 	m.logger.Info("handling ChatMessage")
 	
 
@@ -247,7 +247,7 @@ func (m *Messenger) handleChatMessageProtobuf(messageState *ReceivedMessageState
 
 	m.outputToCSV(msg.TransportMessage.Timestamp, msg.ID, messageState.CurrentMessageState.Contact.ID, filter.Topic, filter.ChatID, msg.Type, p)
 
-	return m.HandleChatMessage(messageState, p, msg)
+	return m.HandleChatMessage(messageState, p, msg, fromArchive )
 	
 }
 
@@ -696,7 +696,7 @@ func (m *Messenger) handleCommunityRequestToJoinProtobuf(messageState *ReceivedM
 }
 
 
-func (m *Messenger) handlePinMessageProtobuf(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter) error {
+func (m *Messenger) handlePinMessageProtobuf(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter, fromArchive bool) error {
 	m.logger.Info("handling PinMessage")
 	
 
@@ -709,7 +709,7 @@ func (m *Messenger) handlePinMessageProtobuf(messageState *ReceivedMessageState,
 
 	m.outputToCSV(msg.TransportMessage.Timestamp, msg.ID, messageState.CurrentMessageState.Contact.ID, filter.Topic, filter.ChatID, msg.Type, p)
 
-	return m.HandlePinMessage(messageState, p, msg)
+	return m.HandlePinMessage(messageState, p, msg, fromArchive )
 	
 }
 

--- a/protocol/messenger_pin_message_test.go
+++ b/protocol/messenger_pin_message_test.go
@@ -133,6 +133,7 @@ func (s *MessengerPinMessageSuite) TestPinMessageOutOfOrder() {
 		1000,
 		handlePinMessageResponse,
 		&unpinMessage,
+		false,
 	)
 	s.Require().NoError(err)
 
@@ -156,6 +157,7 @@ func (s *MessengerPinMessageSuite) TestPinMessageOutOfOrder() {
 		1000,
 		handlePinMessageResponse,
 		&pinMessage,
+		false,
 	)
 	s.Require().NoError(err)
 
@@ -180,6 +182,7 @@ func (s *MessengerPinMessageSuite) TestPinMessageOutOfOrder() {
 		1000,
 		handlePinMessageResponse,
 		&pinMessage,
+		false,
 	)
 	s.Require().NoError(err)
 


### PR DESCRIPTION
Related: https://github.com/status-im/status-desktop/issues/11854.

1. Add option to force `seen` property for generated `SYTEM_MESSAGE_PIN_MESSAGE`
https://github.com/status-im/status-go/blob/7531dbeaef7d067db832a1a175af500428e40c98/protocol/messenger_handler.go#L852-L854

2. Apply workaround: Mark all `ChatMessage` and `PinMessage` from archives as `seen`.
Currently we only mark "imported" messages as seen. But this doesn't cover imported `PinMessage`s and therefore wasn't possible to mark generated `SYTEM_MESSAGE_PIN_MESSAGE` as `Seen`. 
    - We can remove this workaround when https://github.com/status-im/status-desktop/issues/10911 is implemented.
    - More details here: https://github.com/status-im/status-go/issues/3991

3. Add processing of `PinMessage` when handling imported messages.
I could introduce it together with [#3991](https://github.com/status-im/status-go/issues/3991), but it totally makes sense here anyway. And adds backward compatibility for the future.
https://github.com/status-im/status-go/blob/7531dbeaef7d067db832a1a175af500428e40c98/protocol/messenger.go#L3422-L3423

4. Subscribe to spectated communities.
Without it's easy to get into "infinite chat loading animation" in desktop app. 
https://github.com/status-im/status-go/blob/7531dbeaef7d067db832a1a175af500428e40c98/protocol/messenger_communities.go#L2584