### PR TITLE
fix(wallet) filter by sub-transaction chain ID

### DIFF
--- a/services/wallet/activity/activity.go
+++ b/services/wallet/activity/activity.go
@@ -30,7 +30,7 @@ import (
 
 type PayloadType = int
 
-// Beware: pleas update multiTransactionTypeToActivityType if changing this enum
+// Beware: please update multiTransactionTypeToActivityType if changing this enum
 const (
 	MultiTransactionPT PayloadType = iota + 1
 	SimpleTransactionPT

--- a/services/wallet/activity/activity_test.go
+++ b/services/wallet/activity/activity_test.go
@@ -1039,6 +1039,9 @@ func TestGetActivityEntriesFilterByNetworksOfSubTransactions(t *testing.T) {
 
 	trs[3].ChainID = 1234
 	mt2 := transfer.GenerateTestSwapMultiTransaction(trs[3], testutils.SntSymbol, 100)
+	// insertMultiTransaction will insert 0 instead of NULL
+	mt2.FromNetworkID = common.NewAndSet(uint64(0))
+	mt2.ToNetworkID = common.NewAndSet(uint64(0))
 	trs[3].MultiTransactionID = transfer.InsertTestMultiTransaction(t, deps.db, &mt2)
 
 	for i := range trs {
@@ -1055,19 +1058,24 @@ func TestGetActivityEntriesFilterByNetworksOfSubTransactions(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, len(entries))
 
-	// Extract sub-transactions by pending
 	chainIDs = []common.ChainID{trs[0].ChainID, trs[1].ChainID}
 	entries, err = getActivityEntries(context.Background(), deps, toTrs, chainIDs, filter, 0, 15)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(entries))
 	require.Equal(t, entries[0].id, mt1.MultiTransactionID)
 
-	// Extract sub-transactions by
+	// Filter by pending_transactions sub-transacitons
 	chainIDs = []common.ChainID{trs[2].ChainID}
 	entries, err = getActivityEntries(context.Background(), deps, toTrs, chainIDs, filter, 0, 15)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(entries))
 	require.Equal(t, entries[0].id, mt1.MultiTransactionID)
+
+	chainIDs = []common.ChainID{trs[3].ChainID}
+	entries, err = getActivityEntries(context.Background(), deps, toTrs, chainIDs, filter, 0, 15)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(entries))
+	require.Equal(t, entries[0].id, mt2.MultiTransactionID)
 }
 
 func TestGetActivityEntriesCheckToAndFrom(t *testing.T) {

--- a/services/wallet/activity/filter.sql
+++ b/services/wallet/activity/filter.sql
@@ -43,7 +43,7 @@ filter_addresses(address) AS (
 	SELECT
 		HEX(address)
 	FROM
-		% s
+		%s
 	WHERE
 		(
 			SELECT
@@ -58,7 +58,7 @@ filter_addresses(address) AS (
 	FROM
 		(
 			VALUES
-				% s
+				%s
 		)
 	WHERE
 		(
@@ -70,19 +70,19 @@ filter_addresses(address) AS (
 ),
 filter_to_addresses(address) AS (
 	VALUES
-		% s
+		%s
 ),
 assets_token_codes(token_code) AS (
 	VALUES
-		% s
+		%s
 ),
 assets_erc20(chain_id, token_address) AS (
 	VALUES
-		% s
+		%s
 ),
 filter_networks(network_id) AS (
 	VALUES
-		% s
+		%s
 ),
 tr_status AS (
 	SELECT
@@ -401,7 +401,7 @@ WHERE
 	)
 	AND (
 		filterActivityTypeAll
-		OR (multi_transactions.type IN (% s))
+		OR (multi_transactions.type IN (%s))
 	)
 	AND (
 		filterAllAddresses
@@ -460,8 +460,8 @@ WHERE
 			multi_transactions.to_network_id IN filter_networks
 		)
 		OR (
-			multi_transactions.from_network_id IS NULL
-			AND multi_transactions.to_network_id IS NULL
+			COALESCE(multi_transactions.from_network_id, 0) = 0
+			AND COALESCE(multi_transactions.to_network_id, 0) = 0
 			AND (
 				EXISTS (
 					SELECT

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -45,6 +45,8 @@ type TestMultiTransaction struct {
 	FromAmount           int64
 	ToAmount             int64
 	Timestamp            int64
+	FromNetworkID        *uint64
+	ToNetworkID          *uint64
 }
 
 func SeedToToken(seed int) *token.Token {
@@ -321,9 +323,9 @@ func InsertTestMultiTransaction(tb testing.TB, db *sql.DB, tr *TestMultiTransact
 	toAmount := (*hexutil.Big)(big.NewInt(tr.ToAmount))
 
 	result, err := db.Exec(`
-		INSERT INTO multi_transactions (from_address, from_asset, from_amount, to_address, to_asset, to_amount, type, timestamp
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		tr.FromAddress, fromTokenType, fromAmount.String(), tr.ToAddress, toTokenType, toAmount.String(), tr.MultiTransactionType, tr.Timestamp)
+		INSERT INTO multi_transactions (from_address, from_asset, from_amount, to_address, to_asset, to_amount, type, timestamp, from_network_id, to_network_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		tr.FromAddress, fromTokenType, fromAmount.String(), tr.ToAddress, toTokenType, toAmount.String(), tr.MultiTransactionType, tr.Timestamp, tr.FromNetworkID, tr.ToNetworkID)
 	require.NoError(tb, err)
 	rowID, err := result.LastInsertId()
 	require.NoError(tb, err)


### PR DESCRIPTION
### Closes status-desktop [#12077](https://github.com/status-im/status-desktop/issues/12077)

The network IDs for `multi_transactions` were set to `0` when missing instead of the expected `NULL`. Fixed to support both cases. Extended tests to cover the regression.