### PR TITLE
hotfix: Fallback member list for old communities

### DIFF
--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -1304,6 +1304,14 @@ func decodeWrappedCommunityDescription(wrappedDescriptionBytes []byte) (*protobu
 		return nil, err
 	}
 
+	// TODO: Since there has been a change in compatibility between old and new communities,
+	// we need a more reliable way to determine if a community is old or not.
+	for _, chat := range description.Chats {
+		if len(chat.Members) == 0 {
+			chat.Members = description.Members
+		}
+	}
+
 	return description, nil
 }
 


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/12046 
and https://github.com/status-im/status-desktop/issues/12047

This is a ~~workaround~~ dirty hack to display the list of members of _old_ communities. See comment [here](https://github.com/status-im/status-desktop/issues/12046#issuecomment-1708147543)

