### PR TITLE
fix: Discord import tool various fixes for pinned messages

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3543,6 +3543,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 		}
 
 		var chatsToSave []*Chat
+		createdChats := make(map[string]*Chat, 0)
 		processedChannelIds := make(map[string]string, 0)
 		processedCategoriesIds := make(map[string]string, 0)
 
@@ -3677,6 +3678,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 				// know there was only a single such change (and it's a map)
 				for chatID, chat := range changes.ChatsAdded {
 					c := CreateCommunityChat(communityID, chatID, chat, m.getTimesource())
+					createdChats[c.ID] = c
 					chatsToSave = append(chatsToSave, c)
 					processedChannelIds[channel.Channel.ID] = c.ID
 				}
@@ -3766,9 +3768,9 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 
 				// Handle message replies
 				if discordMessage.Type == string(discord.MessageTypeReply) && discordMessage.Reference != nil {
-					_, exists := messagesToSave[communityID+discordMessage.Reference.MessageId]
-					if exists {
-						chatMessage.ResponseTo = communityID + discordMessage.Reference.MessageId
+					repliedMessageId := communityID + discordMessage.Reference.MessageId
+					if _, exists := messagesToSave[repliedMessageId]; exists {
+						chatMessage.ResponseTo = repliedMessageId
 					}
 				}
 
@@ -3794,11 +3796,12 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 				// Handle pin messages
 				if discordMessage.Type == string(discord.MessageTypeChannelPinned) && discordMessage.Reference != nil {
 
-					_, exists := messagesToSave[communityID+discordMessage.Reference.MessageId]
+					pinnedMessageId := communityID + discordMessage.Reference.MessageId
+					_, exists := messagesToSave[pinnedMessageId]
 					if exists {
 						pinMessage := protobuf.PinMessage{
 							Clock:       messageToSave.WhisperTimestamp,
-							MessageId:   communityID + discordMessage.Reference.MessageId,
+							MessageId:   pinnedMessageId,
 							ChatId:      messageToSave.LocalChatID,
 							MessageType: protobuf.MessageType_COMMUNITY_CHAT,
 							Pinned:      true,
@@ -3820,10 +3823,8 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 							continue
 						}
 
-						messageID := v1protocol.MessageID(&communityPubKey, wrappedPayload)
-
 						pinMessageToSave := common.PinMessage{
-							ID:               types.EncodeHex(messageID),
+							ID:               types.EncodeHex(v1protocol.MessageID(&communityPubKey, wrappedPayload)),
 							PinMessage:       &pinMessage,
 							LocalChatID:      processedChannelIds[channel.Channel.ID],
 							From:             messageToSave.From,
@@ -3832,9 +3833,48 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 						}
 
 						pinMessagesToSave = append(pinMessagesToSave, &pinMessageToSave)
+
+						// Generate SystemMessagePinnedMessage
+
+						chat, ok := createdChats[pinMessageToSave.LocalChatID]
+						if !ok {
+							err := errors.New("failed to get chat for pin message")
+							m.logger.Warn(err.Error(),
+								zap.String("PinMessageId", pinMessageToSave.ID),
+								zap.String("ChatID", pinMessageToSave.LocalChatID))
+							importProgress.AddTaskError(discord.ImportMessagesTask, discord.Warning(err.Error()))
+							progressUpdates <- importProgress
+							continue
+						}
+
+						id, err := generatePinMessageNotificationID(&m.identity.PublicKey, &pinMessageToSave, chat)
+						if err != nil {
+							m.logger.Warn("failed to generate pin message notification ID",
+								zap.String("PinMessageId", pinMessageToSave.ID))
+							importProgress.AddTaskError(discord.ImportMessagesTask, discord.Warning(err.Error()))
+							progressUpdates <- importProgress
+							continue
+						}
+						systemMessage := &common.Message{
+							ChatMessage: &protobuf.ChatMessage{
+								Clock:       pinMessageToSave.Clock,
+								Timestamp:   clockAndTimestamp,
+								ChatId:      chat.ID,
+								MessageType: pinMessageToSave.MessageType,
+								ResponseTo:  pinMessage.MessageId,
+								ContentType: protobuf.ChatMessage_SYSTEM_MESSAGE_PINNED_MESSAGE,
+							},
+							WhisperTimestamp: clockAndTimestamp,
+							ID:               id,
+							LocalChatID:      chat.ID,
+							From:             messageToSave.From,
+							Seen:             true,
+						}
+
+						messagesToSave[systemMessage.ID] = systemMessage
 					}
 				} else {
-					messagesToSave[communityID+discordMessage.Id] = messageToSave
+					messagesToSave[messageToSave.ID] = messageToSave
 				}
 
 				progressValue := calculateProgress(i+1, totalImportChunkCount, float32(ii+1)/float32(len(channel.Messages))*0.5)
@@ -3851,10 +3891,12 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 
 			var discordMessages []*protobuf.DiscordMessage
 			for _, msg := range messagesToSave {
-				discordMessages = append(discordMessages, msg.GetDiscordMessage())
+				if msg.ChatMessage.ContentType == protobuf.ChatMessage_DISCORD_MESSAGE {
+					discordMessages = append(discordMessages, msg.GetDiscordMessage())
+				}
 			}
 
-			// We save these messages in chunks so we don't block the database
+			// We save these messages in chunks, so we don't block the database
 			// for a longer period of time
 			discordMessageChunks := chunkSlice(discordMessages, maxChunkSizeMessages)
 			chunksCount := len(discordMessageChunks)
@@ -3890,7 +3932,9 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 				}
 			}
 
-			var messages []*common.Message
+			// Get slice of all values in `messagesToSave` map
+
+			var messages = make([]*common.Message, 0, len(messagesToSave))
 			for _, msg := range messagesToSave {
 				messages = append(messages, msg)
 			}
@@ -3991,7 +4035,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 					}
 
 					assetCounter.Increase()
-					progressValue := calculateProgress(i+1, totalImportChunkCount, (float32(assetCounter.Value())/float32(totalAssetsCount))*0.25)
+					progressValue := calculateProgress(i+1, totalImportChunkCount, (float32(assetCounter.Value())/float32(totalAssetsCount))*0.5)
 					importProgress.UpdateTaskProgress(discord.DownloadAssetsTask, progressValue)
 					progressUpdates <- importProgress
 
@@ -4038,7 +4082,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 						}
 
 						assetCounter.Increase()
-						progressValue := calculateProgress(i+1, totalImportChunkCount, 0.25+(float32(assetCounter.Value())/float32(totalAssetsCount))*0.25)
+						progressValue := calculateProgress(i+1, totalImportChunkCount, (float32(assetCounter.Value())/float32(totalAssetsCount))*0.5)
 						importProgress.UpdateTaskProgress(discord.DownloadAssetsTask, progressValue)
 						progressUpdates <- importProgress
 					}
@@ -4085,6 +4129,11 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 				if currentCount < chunksCount {
 					time.Sleep(2 * time.Second)
 				}
+			}
+
+			if len(attachmentChunks) == 0 {
+				progressValue := calculateProgress(i+1, totalImportChunkCount, 1.0)
+				importProgress.UpdateTaskProgress(discord.DownloadAssetsTask, progressValue)
 			}
 
 			_, err := m.transport.JoinPublic(processedChannelIds[channel.Channel.ID])
@@ -4364,6 +4413,7 @@ func (m *Messenger) pinMessagesToWakuMessages(pinMessages []*common.PinMessage, 
 			Payload:   wrappedPayload,
 			Padding:   []byte{1},
 			Hash:      hash[:],
+			ThirdPartyID: msg.ID, // CommunityID + DiscordMessageID
 		}
 		wakuMessages = append(wakuMessages, wakuMessage)
 	}
@@ -4395,7 +4445,7 @@ func (m *Messenger) chatMessagesToWakuMessages(chatMessages []*common.Message, c
 			return nil, err
 		}
 
-		hash := crypto.Keccak256Hash([]byte(c.IDString() + msg.GetDiscordMessage().Id))
+		hash := crypto.Keccak256Hash([]byte(msg.ID))
 		wakuMessage := &types.Message{
 			Sig:          crypto.FromECDSAPub(&c.PrivateKey().PublicKey),
 			Timestamp:    uint32(msg.WhisperTimestamp / 1000),
@@ -4403,7 +4453,7 @@ func (m *Messenger) chatMessagesToWakuMessages(chatMessages []*common.Message, c
 			Payload:      wrappedPayload,
 			Padding:      []byte{1},
 			Hash:         hash[:],
-			ThirdPartyID: c.IDString() + msg.GetDiscordMessage().Id,
+			ThirdPartyID: msg.ID, // CommunityID + DiscordMessageID
 		}
 		wakuMessages = append(wakuMessages, wakuMessage)
 	}

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3768,9 +3768,9 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 
 				// Handle message replies
 				if discordMessage.Type == string(discord.MessageTypeReply) && discordMessage.Reference != nil {
-					repliedMessageId := communityID + discordMessage.Reference.MessageId
-					if _, exists := messagesToSave[repliedMessageId]; exists {
-						chatMessage.ResponseTo = repliedMessageId
+					repliedMessageID := communityID + discordMessage.Reference.MessageId
+					if _, exists := messagesToSave[repliedMessageID]; exists {
+						chatMessage.ResponseTo = repliedMessageID
 					}
 				}
 
@@ -3796,12 +3796,12 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 				// Handle pin messages
 				if discordMessage.Type == string(discord.MessageTypeChannelPinned) && discordMessage.Reference != nil {
 
-					pinnedMessageId := communityID + discordMessage.Reference.MessageId
-					_, exists := messagesToSave[pinnedMessageId]
+					pinnedMessageID := communityID + discordMessage.Reference.MessageId
+					_, exists := messagesToSave[pinnedMessageID]
 					if exists {
 						pinMessage := protobuf.PinMessage{
 							Clock:       messageToSave.WhisperTimestamp,
-							MessageId:   pinnedMessageId,
+							MessageId:   pinnedMessageID,
 							ChatId:      messageToSave.LocalChatID,
 							MessageType: protobuf.MessageType_COMMUNITY_CHAT,
 							Pinned:      true,
@@ -4407,12 +4407,12 @@ func (m *Messenger) pinMessagesToWakuMessages(pinMessages []*common.PinMessage, 
 
 		hash := crypto.Keccak256Hash(append([]byte(c.IDString()), wrappedPayload...))
 		wakuMessage := &types.Message{
-			Sig:       crypto.FromECDSAPub(&c.PrivateKey().PublicKey),
-			Timestamp: uint32(msg.WhisperTimestamp / 1000),
-			Topic:     filter.ContentTopic,
-			Payload:   wrappedPayload,
-			Padding:   []byte{1},
-			Hash:      hash[:],
+			Sig:          crypto.FromECDSAPub(&c.PrivateKey().PublicKey),
+			Timestamp:    uint32(msg.WhisperTimestamp / 1000),
+			Topic:        filter.ContentTopic,
+			Payload:      wrappedPayload,
+			Padding:      []byte{1},
+			Hash:         hash[:],
 			ThirdPartyID: msg.ID, // CommunityID + DiscordMessageID
 		}
 		wakuMessages = append(wakuMessages, wakuMessage)


### PR DESCRIPTION
1. Save`ThirdPartyID` for pinned messages
2. Explicitly bind `ThirdPartyID` to `MessageID`:
https://github.com/status-im/status-go/blob/ba050bf38a0583a44952ce896999472723798295/protocol/messenger_communities.go#L4456
4. Generate `SYSTEM_MESSAGE_PINNED_MESSAGE` during discord import.
Before it was never seen for the importer user.
5. Fix assets downloading calculation
- Correctly treat downloading assets as 50% of progress
https://github.com/status-im/status-go/blob/ba050bf38a0583a44952ce896999472723798295/protocol/messenger_communities.go#L4038
https://github.com/status-im/status-go/blob/ba050bf38a0583a44952ce896999472723798295/protocol/messenger_communities.go#L4085
- Explicit jump to 100% in case there's no attachments 
https://github.com/status-im/status-go/blob/ba050bf38a0583a44952ce896999472723798295/protocol/messenger_communities.go#L4134-L4137
6. Some minor refactoring improvements

Closes #3991
