### PR TITLE
fix(archives): Skip importing the archives for community when user not a member

### DIFF
--- a/protocol/errors.go
+++ b/protocol/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrNotImplemented   = errors.New("not implemented")
 	ErrContactNotFound  = errors.New("contact not found")
 	ErrCommunityIDEmpty = errors.New("community ID is empty")
+	ErrUserNotMember    = errors.New("user not a member")
 )

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1306,6 +1306,11 @@ func (m *Messenger) downloadAndImportHistoryArchives(id types.HexBytes, magnetli
 		m.communitiesManager.LogStdout("couldn't update last seen magnetlink", zap.Error(err))
 	}
 
+	err = m.checkIfIMemberOfCommunity(id)
+	if err != nil {
+		return
+	}
+
 	err = m.importHistoryArchives(id, cancel)
 	if err != nil {
 		m.communitiesManager.LogStdout("failed to import history archives", zap.Error(err))


### PR DESCRIPTION
This PR should skip side effect when the app firing log messages that the archives can't be decrypted.
In short, if user not a member of community he doesn't have decryption key.
[desktop issue](https://github.com/status-im/status-desktop/issues/12005) 

Important changes:
- [x] Something worth noting for reviewers.

Closes #
