### PR TITLE
fix(wallet) send/receive for duplicate transactions

### DIFF
--- a/services/wallet/activity/activity.go
+++ b/services/wallet/activity/activity.go
@@ -421,6 +421,7 @@ func getActivityEntries(ctx context.Context, deps FilterDependencies, addresses 
 		startFilterDisabled, filter.Period.StartTimestamp, endFilterDisabled, filter.Period.EndTimestamp,
 		filterActivityTypeAll, sliceContains(filter.Types, SendAT), sliceContains(filter.Types, ReceiveAT),
 		sliceContains(filter.Types, ContractDeploymentAT), sliceContains(filter.Types, MintAT),
+		transfer.MultiTransactionSend,
 		fromTrType, toTrType,
 		filterAllAddresses, filterAllToAddresses,
 		includeAllStatuses, filterStatusCompleted, filterStatusFailed, filterStatusFinalized, filterStatusPending,

--- a/services/wallet/activity/activity_test.go
+++ b/services/wallet/activity/activity_test.go
@@ -734,6 +734,12 @@ func TestGetActivityEntriesFilterByType(t *testing.T) {
 	require.Equal(t, 0, mintCount)
 	require.Equal(t, 0, swapCount)
 	require.Equal(t, 0, bridgeCount)
+
+	// Filter with all addresses regression
+	filter.Types = []Type{SendAT}
+	entries, err = getActivityEntries(context.Background(), deps, allAddressesFilter(), []common.ChainID{}, filter, 0, 15)
+	require.NoError(t, err)
+	require.Equal(t, 5, len(entries))
 }
 
 func TestGetActivityEntriesFilterByAddresses(t *testing.T) {

--- a/services/wallet/transfer/database.go
+++ b/services/wallet/transfer/database.go
@@ -573,3 +573,13 @@ func markBlocksAsLoaded(chainID uint64, creator statementCreator, address common
 	}
 	return nil
 }
+
+// GetOwnedMultiTransactionID returns sql.ErrNoRows if no transaction is found for the given identity
+func GetOwnedMultiTransactionID(tx *sql.Tx, chainID w_common.ChainID, id common.Hash, address common.Address) (mTID int64, err error) {
+	row := tx.QueryRow(`SELECT COALESCE(multi_transaction_id, 0) FROM transfers WHERE network_id = ? AND hash = ? AND address = ?`, chainID, id, address)
+	err = row.Scan(&mTID)
+	if err != nil {
+		return 0, err
+	}
+	return mTID, nil
+}

--- a/services/wallet/transfer/iterative.go
+++ b/services/wallet/transfer/iterative.go
@@ -67,7 +67,7 @@ func (d *IterativeDownloader) Next(parent context.Context) ([]*DBHeader, *big.In
 	headers, err := d.downloader.GetHeadersInRange(parent, from, to)
 	log.Info("load erc20 transfers in range", "from", from, "to", to, "batchSize", d.batchSize)
 	if err != nil {
-		log.Error("failed to get transfer in between two bloks", "from", from, "to", to, "error", err)
+		log.Error("failed to get transfer in between two blocks", "from", from, "to", to, "error", err)
 		return nil, nil, nil, err
 	}
 

--- a/transactions/pendingtxtracker.go
+++ b/transactions/pendingtxtracker.go
@@ -561,15 +561,16 @@ func (tm *PendingTxTracker) DeleteBySQLTx(tx *sql.Tx, chainID common.ChainID, ha
 	}, err
 }
 
-func GetTransferData(tx *sql.Tx, chainID common.ChainID, hash eth.Hash) (txType *PendingTrxType, MTID *int64, err error) {
-	row := tx.QueryRow(`SELECT type, multi_transaction_id FROM pending_transactions WHERE network_id = ? AND hash = ?`, chainID, hash, txType)
+// GetOwnedPendingStatus returns sql.ErrNoRows if no pending transaction is found for the given identity
+func GetOwnedPendingStatus(tx *sql.Tx, chainID common.ChainID, hash eth.Hash, ownerAddress eth.Address) (txType *PendingTrxType, mTID *int64, err error) {
+	row := tx.QueryRow(`SELECT type, multi_transaction_id FROM pending_transactions WHERE network_id = ? AND hash = ? AND from_address = ?`, chainID, hash, ownerAddress)
 	txType = new(PendingTrxType)
-	MTID = new(int64)
-	err = row.Scan(txType, MTID)
+	mTID = new(int64)
+	err = row.Scan(txType, mTID)
 	if err != nil {
 		return nil, nil, err
 	}
-	return txType, MTID, nil
+	return txType, mTID, nil
 }
 
 // Watch returns sql.ErrNoRows if no pending transaction is found for the given identity


### PR DESCRIPTION
### Closes [#11960](https://github.com/status-im/status-desktop/issues/11960)
    
It brings consistency when the sender and receiver are in the filter address list. This fixes the case of the sender and receiver in addresses and filters out duplicate entries.

Also

- refactor tests to provide support for owners
- adapt TestGetActivityEntriesWithSameTransactionForSenderAndReceiverInDB
  to the use of owner instead of from
