### PR TITLE
feat: Add activity filtering by contract deploy and minting

### DIFF
--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -380,6 +380,9 @@ func isMetadataEmpty(asset thirdparty.CollectibleData) bool {
 }
 
 func (o *Manager) fetchTokenURI(id thirdparty.CollectibleUniqueID) (string, error) {
+	if id.TokenID == nil {
+		return "", errors.New("empty token ID")
+	}
 	backend, err := o.rpcClient.EthClient(uint64(id.ContractID.ChainID))
 	if err != nil {
 		return "", err

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -242,7 +242,7 @@ func InsertTestTransferWithOptions(tb testing.TB, db *sql.DB, address eth_common
 
 	block := blockDBFields{
 		chainID:     uint64(tr.ChainID),
-		account:     tr.To,
+		account:     address,
 		blockNumber: big.NewInt(tr.BlkNumber),
 		blockHash:   blkHash,
 	}


### PR DESCRIPTION
task: https://github.com/status-im/status-desktop/issues/12093
Corresponding status-desktop change with video:  https://github.com/status-im/status-desktop/pull/12109


* Added filtering by `Contract Deployment` and `Mint` type
ContractDeployment is subtype of Send and Mint is subtype of Receive, that required hiding those specific transfers when filtering by Send or Receive.
* Fixed missing `chainID` for `Contract Deployment`
* Fixed issue with transfer unit tests utils using wrong value for block table
* Fixed crash in rare cases when `TokenID` could be `nil`

