### PR TITLE
Make 1-1 messages appear as mentions each 2 minutes

### DIFF
--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -27,6 +27,13 @@ var chatColors = []string{
 	"#d37ef4", // purple
 }
 
+const (
+	// IncreaseUnviewedMessagesCountTimeoutMs
+	// this timeout indicates how long the time between received messages should be
+	// for a new message to increase the unviewed messages counter
+	IncreaseUnviewedMessagesCountTimeoutMs = 1000 * 60 * 2
+)
+
 type ChatType int
 
 const (
@@ -389,6 +396,14 @@ func (c *Chat) UpdateFromMessage(message *common.Message, timesource common.Time
 		c.LastClockValue = message.Clock
 	}
 	return nil
+}
+
+func (c *Chat) ShouldIncreaseMessageCount(message *common.Message) bool {
+	return c.LastMessage == nil ||
+		c.LastMessage.IsSystemMessage() ||
+		!c.LastMessage.New ||
+		c.LastMessage.Seen ||
+		message.Timestamp > c.LastMessage.Timestamp+IncreaseUnviewedMessagesCountTimeoutMs
 }
 
 func (c *Chat) UpdateFirstMessageTimestamp(timestamp uint32) bool {

--- a/protocol/common/message.go
+++ b/protocol/common/message.go
@@ -635,8 +635,6 @@ func (m *Message) PrepareContent(identity string) error {
 func (m *Message) IsSystemMessage() bool {
 	return m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP ||
 		m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_GAP ||
-		m.ContentType == protobuf.ChatMessage_CONTACT_REQUEST ||
-		m.ContentType == protobuf.ChatMessage_IDENTITY_VERIFICATION ||
 		m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_PINNED_MESSAGE ||
 		m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_MUTUAL_EVENT_SENT ||
 		m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_MUTUAL_EVENT_ACCEPTED ||

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4108,6 +4108,10 @@ func (m *Messenger) markAllRead(chatID string, clock uint64, shouldBeSynced bool
 	chat.UnviewedMessagesCount = 0
 	chat.UnviewedMentionsCount = 0
 
+	if chat.LastMessage != nil {
+		chat.LastMessage.Seen = true
+	}
+
 	// TODO(samyoul) remove storing of an updated reference pointer?
 	m.allChats.Store(chat.ID, chat)
 	return m.persistence.SaveChats([]*Chat{chat})

--- a/protocol/messenger_edit_message_test.go
+++ b/protocol/messenger_edit_message_test.go
@@ -367,10 +367,10 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 	s.Require().NoError(err)
 	s.Require().Len(response.Chats(), 1)
 	s.Require().Len(response.Messages(), 1)
-	// Make sure there is no mention at first
-	s.Require().Equal(int(response.Chats()[0].UnviewedMessagesCount), 1)
-	s.Require().Equal(int(response.Chats()[0].UnviewedMentionsCount), 0)
+	// Make sure the message is not marked as Mentioned (chat still counts it because it's 1-1)
 	s.Require().False(response.Messages()[0].Mentioned)
+	s.Require().Equal(int(response.Chats()[0].UnviewedMessagesCount), 1)
+	s.Require().Equal(int(response.Chats()[0].UnviewedMentionsCount), 1)
 
 	ogMessage := sendResponse.Messages()[0]
 
@@ -407,9 +407,9 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 	s.Require().NotEmpty(response.Messages()[0].EditedAt)
 	s.Require().False(response.Messages()[0].New)
 	// Receiver (us) is now mentioned
+	s.Require().True(response.Messages()[0].Mentioned)
 	s.Require().Equal(int(response.Chats()[0].UnviewedMessagesCount), 1)
 	s.Require().Equal(int(response.Chats()[0].UnviewedMentionsCount), 1)
-	s.Require().True(response.Messages()[0].Mentioned)
 
 	// Edit the message again but remove the mention
 	editedText = "edited text no mention"
@@ -441,9 +441,9 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 	s.Require().NotEmpty(response.Messages()[0].EditedAt)
 	s.Require().False(response.Messages()[0].New)
 	// Receiver (us) is no longer mentioned
-	s.Require().Equal(int(response.Chats()[0].UnviewedMessagesCount), 1) // We still have an unread message though
-	s.Require().Equal(int(response.Chats()[0].UnviewedMentionsCount), 0)
 	s.Require().False(response.Messages()[0].Mentioned)
+	s.Require().Equal(int(response.Chats()[0].UnviewedMessagesCount), 1) // We still have an unread message though
+	s.Require().Equal(int(response.Chats()[0].UnviewedMentionsCount), 1)
 }
 
 func (s *MessengerEditMessageSuite) TestEditMessageWithLinkPreviews() {


### PR DESCRIPTION
Iterates over https://github.com/status-im/status-go/pull/3889

Needed for https://github.com/status-im/status-desktop/issues/10195

Fixes and improves the work done by @alwx 

Makes it so that 1-1 messages count as a mention every 2 minutes.

I didn't add the activity center portion of the issue, because the chat is saved before the AC notification can be created, so we lose the last message timestamp.
It can be done later.