### PR TITLE
local pairing fix: correct selection of server url, remove ip duplicates

### DIFF
--- a/server/ips.go
+++ b/server/ips.go
@@ -42,7 +42,7 @@ func addrToIPNet(addr net.Addr) *net.IPNet {
 // ips is a 2-dimensional array, where each sub-array is a list of IP
 // addresses for a single network interface.
 func filterAddressesForPairingServer(ips [][]net.IP) []net.IP {
-	var result []net.IP
+	var result = map[string]net.IP{}
 
 	for _, niIps := range ips {
 		var ipv4, ipv6 []net.IP
@@ -63,13 +63,22 @@ func filterAddressesForPairingServer(ips [][]net.IP) []net.IP {
 
 		// Prefer IPv4 over IPv6 for shorter connection string
 		if len(ipv4) == 0 {
-			result = append(result, ipv6...)
+			for _, ip := range ipv6 {
+				result[ip.String()] = ip
+			}
 		} else {
-			result = append(result, ipv4...)
+			for _, ip := range ipv4 {
+				result[ip.String()] = ip
+			}
 		}
 	}
 
-	return result
+	var out []net.IP
+	for _, v := range result {
+		out = append(out, v)
+	}
+
+	return out
 }
 
 // getAndroidLocalIP uses the net dial default ip as the standard Android IP address

--- a/server/pairing/client.go
+++ b/server/pairing/client.go
@@ -46,11 +46,8 @@ func findServerCert(c *ConnectionParams) (*url.URL, *x509.Certificate, error) {
 	var baseAddress *url.URL
 	var serverCert *x509.Certificate
 	var certErrs error
-	for i := range netIps {
-		u, err := c.URL(i)
-		if err != nil {
-			return nil, nil, err
-		}
+	for _, ip := range netIps {
+		u := c.BuildURL(ip)
 
 		serverCert, err = getServerCert(u)
 		if err != nil {

--- a/server/pairing/connection.go
+++ b/server/pairing/connection.go
@@ -236,11 +236,14 @@ func (cp *ConnectionParams) URL(IPIndex int) (*url.URL, error) {
 		return nil, err
 	}
 
-	u := &url.URL{
+	return cp.BuildURL(cp.netIPs[IPIndex]), nil
+}
+
+func (cp *ConnectionParams) BuildURL(ip net.IP) *url.URL {
+	return &url.URL{
 		Scheme: "https",
-		Host:   fmt.Sprintf("%s:%d", cp.netIPs[IPIndex], cp.port),
+		Host:   fmt.Sprintf("%s:%d", ip, cp.port),
 	}
-	return u, nil
 }
 
 func ValidateConnectionString(cs string) error {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12126

- correct selection of server url `findServerCert`
- remove ip duplicates in `filterAddressesForPairingServer`