### PR TITLE
Hotfix: Don't send members for unpermitted channels

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1231,7 +1231,7 @@ func (o *Community) Description() *protobuf.CommunityDescription {
 }
 
 func (o *Community) marshaledDescription() ([]byte, error) {
-	// Clear members list for each channel what don't have permissions
+	// Clear members list for channels that don't have permissions
 	// TMP: should be fixed in https://github.com/status-im/status-desktop/issues/12188
 	clonedDescritpion := proto.Clone(o.config.CommunityDescription).(*protobuf.CommunityDescription)
 	for chatID, chat := range clonedDescritpion.Chats {

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -3,6 +3,7 @@ package communities
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1240,7 +1241,14 @@ func (o *Community) marshaledDescription() ([]byte, error) {
 		}
 	}
 
-	return proto.Marshal(clonedDescritpion)
+	rawDescritpionData, err := proto.Marshal(clonedDescritpion)
+	if err != nil {
+		return []byte{}, nil
+	}
+
+	fmt.Println("-------------------> Raw CommunityDescritpion size: ", binary.Size(rawDescritpionData))
+
+	return rawDescritpionData, nil
 }
 
 func (o *Community) MarshaledDescription() ([]byte, error) {

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1231,7 +1231,16 @@ func (o *Community) Description() *protobuf.CommunityDescription {
 }
 
 func (o *Community) marshaledDescription() ([]byte, error) {
-	return proto.Marshal(o.config.CommunityDescription)
+	// Clear members list for each channel what don't have permissions
+	// TMP: should be fixed in https://github.com/status-im/status-desktop/issues/12188
+	clonedDescritpion := proto.Clone(o.config.CommunityDescription).(*protobuf.CommunityDescription)
+	for chatID, chat := range clonedDescritpion.Chats {
+		if !CheckIfChannelHasAnyPermissions(chatID, clonedDescritpion) {
+			chat.Members = map[string]*protobuf.CommunityMember{}
+		}
+	}
+
+	return proto.Marshal(clonedDescritpion)
 }
 
 func (o *Community) MarshaledDescription() ([]byte, error) {

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1272,7 +1272,7 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 }
 
 func (m *Manager) handleCommunityDescriptionMessageCommon(community *Community, description *protobuf.CommunityDescription, payload []byte) (*CommunityResponse, error) {
-	// For each channel what don't have permissions, we use community members list instead
+	// For each channel that doesn't have permissions, we use community members list instead
 	// TMP: should be fixed in https://github.com/status-im/status-desktop/issues/12188
 	for chatID, chat := range description.Chats {
 		if !CheckIfChannelHasAnyPermissions(chatID, description) {

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1272,6 +1272,14 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 }
 
 func (m *Manager) handleCommunityDescriptionMessageCommon(community *Community, description *protobuf.CommunityDescription, payload []byte) (*CommunityResponse, error) {
+	// For each channel what don't have permissions, we use community members list instead
+	// TMP: should be fixed in https://github.com/status-im/status-desktop/issues/12188
+	for chatID, chat := range description.Chats {
+		if !CheckIfChannelHasAnyPermissions(chatID, description) {
+			chat.Members = description.Members
+		}
+	}
+
 	changes, err := community.UpdateCommunityDescription(description, payload)
 	if err != nil {
 		return nil, err

--- a/protocol/communities/utils.go
+++ b/protocol/communities/utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/protobuf"
+	"golang.org/x/exp/slices"
 )
 
 func CalculateRequestID(publicKey string, communityID types.HexBytes) types.HexBytes {
@@ -56,4 +57,13 @@ func ExtractTokenCriteria(permissions []*CommunityTokenPermission) (erc20TokenCr
 		}
 	}
 	return
+}
+
+func CheckIfChannelHasAnyPermissions(chatID string, description *protobuf.CommunityDescription) bool {
+	for _, permission := range description.TokenPermissions {
+		if slices.Contains(permission.ChatIds, chatID) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Hot fix for [this](https://github.com/status-im/status-desktop/issues/12114#issuecomment-1721426909) problem.

Important changes:
- [x] Empty community channels member list, if there is no permissions settled up for that channels when sending a community description message
- [x] Restore community channels member list from community member list if there is no permissions settled up

Actual fix should be implemented here: https://github.com/status-im/status-desktop/issues/12188