### PR TITLE
ci: parametrize DB port for unit tests

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -25,7 +25,8 @@ pipeline {
 
   environment {
     TARGET   = 'tests'
-    DB_CONT  = 'status-go-test-db'
+    DB_CONT  = "status-go-test-db-${env.EXECUTOR_NUMBER.toInteger() + 1}"
+    DB_PORT  = "${5432 + env.EXECUTOR_NUMBER.toInteger()}"
     TMPDIR   = "${WORKSPACE_TMP}"
     GOPATH   = "${WORKSPACE_TMP}/go"
     GOCACHE  = "${WORKSPACE_TMP}/gocache"
@@ -69,12 +70,15 @@ pipeline {
     }
 
     stage('Unit Tests') {
+      environment {
+        TEST_POSTGRES_PORT = "${env.DB_PORT}"
+      }
       steps { script {
         db = docker.image('postgres:9.6-alpine').withRun([
           "--name=${DB_CONT}",
-          '--env=POSTGRES_HOST_AUTH_METHOD=trust',
-          '--publish=5432:5432',
-        ].join(' ')) { c ->
+          "--env=POSTGRES_HOST_AUTH_METHOD=trust",
+          "--publish=${DB_PORT}:${DB_PORT}",
+        ].join(' '), "-p ${DB_PORT}") { c ->
           nix.shell('make generate-handlers', pure: true)
           nix.shell('make test-unit V=1', pure: false)
         }

--- a/postgres/helpers.go
+++ b/postgres/helpers.go
@@ -2,14 +2,27 @@ package postgres
 
 import (
 	"database/sql"
+	"fmt"
+	"os"
+
 	// Import postgres driver
 	_ "github.com/lib/pq"
 )
 
-const (
-	DefaultTestURI = "postgres://postgres@127.0.0.1:5432/postgres?sslmode=disable"
-	DropTableURI   = "postgres://postgres@127.0.0.1:5432/template1?sslmode=disable"
+var (
+	DefaultTestDBHost = GetEnvDefault("TEST_POSTGRES_HOST", "localhost")
+	DefaultTestDBPort = GetEnvDefault("TEST_POSTGRES_PORT", "5432")
+	DefaultTestURI    = fmt.Sprintf("postgres://postgres@%s:%s/postgres?sslmode=disable", DefaultTestDBHost, DefaultTestDBPort)
+	DropTableURI      = fmt.Sprintf("postgres://postgres@%s:%s/template1?sslmode=disable", DefaultTestDBHost, DefaultTestDBPort)
 )
+
+func GetEnvDefault(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}
 
 func ResetDefaultTestPostgresDB() error {
 	db, err := sql.Open("postgres", DropTableURI)


### PR DESCRIPTION
Otherwise we can't run tests in parallel on the same host. Also the container name has to be different depending on executor.

Resolves errors like:
```
docker: Error response from daemon: Conflict.
    The container name "/status-go-test-db" is already in use by container "123...".
    You have to remove (or rename) that container to be able to reuse that name.
```

Resolves: https://github.com/status-im/status-go/issues/4040