### PR TITLE
chore(wallet) optimize activity filer query

### DIFF
--- a/services/wallet/activity/activity.go
+++ b/services/wallet/activity/activity.go
@@ -200,7 +200,6 @@ func (e *Entry) isNFT() bool {
 	return tt != nil && (*tt == TransferTypeErc721 || *tt == TransferTypeErc1155) && ((e.tokenIn != nil && e.tokenIn.TokenID != nil) || (e.tokenOut != nil && e.tokenOut.TokenID != nil))
 }
 
-// TODO - #11952: use only one of (big.Int, bigint.BigInt and hexutil.Big)
 func tokenIDToWalletBigInt(tokenID *hexutil.Big) *bigint.BigInt {
 	if tokenID == nil {
 		return nil

--- a/services/wallet/activity/benchmarks_test.go
+++ b/services/wallet/activity/benchmarks_test.go
@@ -1,0 +1,303 @@
+package activity
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	eth "github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/testutils"
+	"github.com/status-im/status-go/services/wallet/transfer"
+)
+
+func setupBenchmark(b *testing.B, accountsCount int, inMemory bool) (deps FilterDependencies, close func(), accounts []eth.Address) {
+	deps, close = setupTestActivityDBStorageChoice(b, inMemory)
+
+	const transactionCount = 100000
+	const mtSendRatio = 0.2   // 20%
+	const mtSwapRatio = 0.1   // 10%
+	const mtBridgeRatio = 0.1 // 10%
+	const pendingCount = 10
+	const mtSendCount = int(float64(transactionCount) * mtSendRatio)
+	const mtSwapCount = int(float64(transactionCount) * mtSwapRatio)
+	// Bridge requires two transactions
+	const mtBridgeCount = int(float64(transactionCount) * (mtBridgeRatio / 2))
+
+	trs, _, _ := transfer.GenerateTestTransfers(b, deps.db, 0, transactionCount)
+
+	accounts = []eth.Address{}
+	for i := 0; i < accountsCount; i++ {
+		if i%2 == 0 {
+			accounts = append(accounts, trs[i].From)
+		} else {
+			accounts = append(accounts, trs[i].To)
+		}
+	}
+
+	i := 0
+	multiTxs := make([]transfer.TestMultiTransaction, mtSendCount+mtSwapCount+mtBridgeCount)
+	for ; i < mtSendCount; i++ {
+		multiTxs[i] = transfer.GenerateTestSendMultiTransaction(trs[i])
+		trs[i].From = accounts[i%len(accounts)]
+		multiTxs[i].FromAddress = trs[i].From
+		// Currently the network ID is not filled in for send transactions
+		multiTxs[i].FromNetworkID = nil
+		multiTxs[i].ToNetworkID = nil
+
+		multiTxs[i].MultiTransactionID = transfer.InsertTestMultiTransaction(b, deps.db, &multiTxs[i])
+		trs[i].MultiTransactionID = multiTxs[i].MultiTransactionID
+	}
+
+	for j := 0; j < mtSwapCount; i, j = i+1, j+1 {
+		multiTxs[i] = transfer.GenerateTestSwapMultiTransaction(trs[i], testutils.SntSymbol, int64(i))
+		trs[i].From = accounts[i%len(accounts)]
+		multiTxs[i].FromAddress = trs[i].From
+
+		multiTxs[i].MultiTransactionID = transfer.InsertTestMultiTransaction(b, deps.db, &multiTxs[i])
+		trs[i].MultiTransactionID = multiTxs[i].MultiTransactionID
+	}
+
+	for mtIdx := 0; mtIdx < mtBridgeCount; i, mtIdx = i+2, mtIdx+1 {
+		firstTrIdx := i
+		secondTrIdx := i + 1
+		multiTxs[mtIdx] = transfer.GenerateTestBridgeMultiTransaction(trs[firstTrIdx], trs[secondTrIdx])
+		trs[firstTrIdx].From = accounts[i%len(accounts)]
+		trs[secondTrIdx].To = accounts[(i+3)%len(accounts)]
+		multiTxs[mtIdx].FromAddress = trs[firstTrIdx].From
+		multiTxs[mtIdx].ToAddress = trs[secondTrIdx].To
+		multiTxs[mtIdx].FromAddress = trs[i].From
+
+		multiTxs[mtIdx].MultiTransactionID = transfer.InsertTestMultiTransaction(b, deps.db, &multiTxs[mtIdx])
+		trs[firstTrIdx].MultiTransactionID = multiTxs[mtIdx].MultiTransactionID
+		trs[secondTrIdx].MultiTransactionID = multiTxs[mtIdx].MultiTransactionID
+	}
+
+	for i = 0; i < transactionCount-pendingCount; i++ {
+		trs[i].From = accounts[i%len(accounts)]
+		transfer.InsertTestTransfer(b, deps.db, trs[i].From, &trs[i])
+	}
+
+	for ; i < transactionCount; i++ {
+		trs[i].From = accounts[i%len(accounts)]
+		transfer.InsertTestPendingTransaction(b, deps.db, &trs[i])
+	}
+
+	return
+}
+
+var allNetEnabled = []common.ChainID(nil)
+
+func BenchmarkGetActivityEntries(bArg *testing.B) {
+	deps, closeFn, accounts := setupBenchmark(bArg, 6, true)
+	defer closeFn()
+
+	type params struct {
+		inMemory bool
+		// resultCount must be nil to expect as many requested
+		resultCount            *int
+		generateTestParameters func() (addresses []eth.Address, allAddresses bool, networks []common.ChainID, filter *Filter, startIndex int)
+	}
+	testCases := []struct {
+		name   string
+		params params
+	}{
+		{
+			"RAM_NoFilter",
+			params{
+				true,
+				nil,
+				func() ([]eth.Address, bool, []common.ChainID, *Filter, int) {
+					return accounts, true, allNetEnabled, &Filter{}, 0
+				},
+			},
+		},
+		{
+			"SSD_NoFilter",
+			params{
+				false,
+				nil,
+				func() ([]eth.Address, bool, []common.ChainID, *Filter, int) {
+					return accounts, true, allNetEnabled, &Filter{}, 0
+				},
+			},
+		},
+		{
+			"SSD_MovingWindow",
+			params{
+				false,
+				nil,
+				func() ([]eth.Address, bool, []common.ChainID, *Filter, int) {
+					return accounts, true, allNetEnabled, &Filter{}, 200
+				},
+			},
+		},
+		{
+			"SSD_AllAddr_AllTos",
+			params{
+				false,
+				nil,
+				func() ([]eth.Address, bool, []common.ChainID, *Filter, int) {
+					return accounts, true, allNetEnabled, &Filter{CounterpartyAddresses: accounts[3:]}, 0
+				},
+			},
+		},
+		{
+			"SSD_OneAddress",
+			params{
+				false,
+				nil,
+				func() ([]eth.Address, bool, []common.ChainID, *Filter, int) {
+					return accounts[0:1], false, allNetEnabled, &Filter{}, 0
+				},
+			},
+		},
+		// All memory from here
+		{
+			"FilterSend_AllAddr",
+			params{
+				true,
+				nil,
+				func() ([]eth.Address, bool, []common.ChainID, *Filter, int) {
+					return accounts, true, allNetEnabled, &Filter{
+						Types: []Type{SendAT},
+					}, 0
+				},
+			},
+		},
+		{
+			"FilterSend_6Addr",
+			params{
+				true,
+				nil,
+				func() ([]eth.Address, bool, []common.ChainID, *Filter, int) {
+					return accounts[len(accounts)-6:], false, allNetEnabled, &Filter{
+						Types: []Type{SendAT},
+					}, 0
+				},
+			},
+		},
+		{
+			"FilterThreeNetworks",
+			params{
+				true,
+				nil,
+				func() ([]eth.Address, bool, []common.ChainID, *Filter, int) {
+					return accounts, true, []common.ChainID{}, &Filter{}, 0
+				},
+			},
+		},
+	}
+
+	const resultCount = 100
+	for _, tc := range testCases {
+		addresses, allAddresses, nets, filter, startIndex := tc.params.generateTestParameters()
+		networks := allNetworksFilter()
+		if len(nets) > 0 {
+			networks = nets
+		}
+
+		bArg.Run(tc.name, func(b *testing.B) {
+			// Reset timer after setup
+			b.ResetTimer()
+
+			// Run benchmark
+			for i := 0; i < b.N; i++ {
+				res, err := getActivityEntries(context.Background(), deps, addresses, allAddresses, networks, *filter, startIndex, resultCount)
+				if err != nil {
+					b.Error(err)
+				} else if tc.params.resultCount != nil {
+					if len(res) != *tc.params.resultCount {
+						b.Error("Got less then expected")
+					}
+				} else if len(res) != resultCount {
+					b.Error("Got less than requested")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkSQLQuery(b *testing.B) {
+	type params struct {
+		query            string
+		args             []interface{}
+		expectedResCount int
+	}
+
+	deps, closeFn, accounts := setupBenchmark(b, 10000, true)
+	defer closeFn()
+
+	var addrValuesStr, insertAddrValuesStr, addrPlaceholdersStr string
+	var refAccounts []interface{}
+	for _, acc := range accounts {
+		addrValuesStr += fmt.Sprintf("X'%s',", acc.Hex()[2:])
+		insertAddrValuesStr += fmt.Sprintf("(X'%s'),", acc.Hex()[2:])
+		addrPlaceholdersStr += "?,"
+		refAccounts = append(refAccounts, acc)
+	}
+	addrValuesStr = addrValuesStr[:len(addrValuesStr)-1]
+	insertAddrValuesStr = insertAddrValuesStr[:len(insertAddrValuesStr)-1]
+	addrPlaceholdersStr = addrPlaceholdersStr[:len(addrPlaceholdersStr)-1]
+
+	if _, err := deps.db.Exec(fmt.Sprintf("CREATE TEMP TABLE filter_addresses_table (address VARCHAR PRIMARY KEY); INSERT INTO filter_addresses_table (address) VALUES %s;", insertAddrValuesStr)); err != nil {
+		b.Fatal("failed to create temporary table", err)
+	}
+
+	testCases := []struct {
+		name string
+		args params
+		res  testing.BenchmarkResult
+	}{
+		{
+			name: "JoinQuery",
+			args: params{
+				query:            "SELECT COUNT(*) FROM transfers JOIN filter_addresses_table ON transfers.tx_from_address = filter_addresses_table.address",
+				expectedResCount: 99990,
+			},
+		},
+		{
+			name: "LiteralQuery",
+			args: params{
+				query:            fmt.Sprintf("SELECT COUNT(*) FROM transfers WHERE tx_from_address IN (%s)", addrValuesStr),
+				expectedResCount: 99990,
+			},
+		},
+		{
+			name: "ParamQuery",
+			args: params{
+				query:            fmt.Sprintf("SELECT COUNT(*) FROM transfers WHERE tx_from_address IN (%s)", addrPlaceholdersStr),
+				args:             refAccounts,
+				expectedResCount: 99990,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					res, err := deps.db.Query(tc.args.query, tc.args.args...)
+					if err != nil {
+						b.Fatal("failed to query db", err)
+					}
+					res.Next()
+
+					var count int
+					if err := res.Scan(&count); err != nil {
+						b.Fatal("failed to scan db result", err)
+					}
+					if count != tc.args.expectedResCount {
+						b.Fatalf("unexpected result count: %d, expected: %d", count, tc.args.expectedResCount)
+					}
+
+					res.Close()
+				}
+			}
+		})
+	}
+}

--- a/services/wallet/activity/filter.go
+++ b/services/wallet/activity/filter.go
@@ -166,7 +166,7 @@ func GetOldestTimestamp(ctx context.Context, db *sql.DB, addresses []eth.Address
 			transfers.timestamp AS timestamp
 		FROM transfers, filter_conditions
 		WHERE transfers.multi_transaction_id = 0
-			AND (filterAllAddresses OR HEX(from_address) IN filter_addresses OR HEX(to_address) IN filter_addresses)
+			AND (filterAllAddresses OR from_address IN filter_addresses OR to_address IN filter_addresses)
 
 		UNION ALL
 
@@ -176,7 +176,7 @@ func GetOldestTimestamp(ctx context.Context, db *sql.DB, addresses []eth.Address
 			pending_transactions.timestamp AS timestamp
 		FROM pending_transactions, filter_conditions
 		WHERE pending_transactions.multi_transaction_id = 0
-			AND (filterAllAddresses OR HEX(from_address) IN filter_addresses OR HEX(to_address) IN filter_addresses)
+			AND (filterAllAddresses OR from_address IN filter_addresses OR to_address IN filter_addresses)
 
 		UNION ALL
 
@@ -185,7 +185,7 @@ func GetOldestTimestamp(ctx context.Context, db *sql.DB, addresses []eth.Address
 			multi_transactions.to_address AS to_address,
 			multi_transactions.timestamp AS timestamp
 		FROM multi_transactions, filter_conditions
-		WHERE filterAllAddresses OR HEX(from_address) IN filter_addresses OR HEX(to_address) IN filter_addresses
+		WHERE filterAllAddresses OR from_address IN filter_addresses OR to_address IN filter_addresses
 		ORDER BY timestamp ASC
 		LIMIT 1`
 

--- a/services/wallet/activity/service.go
+++ b/services/wallet/activity/service.go
@@ -236,6 +236,15 @@ func (s *Service) GetOldestTimestampAsync(requestID int32, addresses []common.Ad
 	})
 }
 
+func (s *Service) CancelFilterTask(requestID int32) {
+	s.scheduler.Enqueue(requestID, filterTask, func(ctx context.Context) (interface{}, error) {
+		// No-op
+		return nil, nil
+	}, func(result interface{}, taskType async.TaskType, err error) {
+		// Ignore result
+	})
+}
+
 func (s *Service) Stop() {
 	s.scheduler.Stop()
 }

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -577,6 +577,13 @@ func (api *API) FilterActivityAsync(requestID int32, addresses []common.Address,
 	return nil
 }
 
+func (api *API) CancelActivityFilterTask(requestID int32) error {
+	log.Debug("wallet.api.CancelActivityFilterTask", "requestID", requestID)
+
+	api.s.activity.CancelFilterTask(requestID)
+	return nil
+}
+
 func (api *API) GetMultiTxDetails(ctx context.Context, multiTxID int) (*activity.EntryDetails, error) {
 	log.Debug("wallet.api.GetMultiTxDetails", "multiTxID", multiTxID)
 

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -68,14 +68,15 @@ func TestTrToToken(t *testing.T, tt *TestTransaction) (token *token.Token, isNat
 func generateTestTransaction(seed int) TestTransaction {
 	token := SeedToToken(seed)
 	return TestTransaction{
-		Hash:               eth_common.HexToHash(fmt.Sprintf("0x1%d", seed)),
-		ChainID:            common.ChainID(token.ChainID),
-		From:               eth_common.HexToAddress(fmt.Sprintf("0x2%d", seed)),
-		Timestamp:          int64(seed),
-		BlkNumber:          int64(seed),
-		Success:            true,
-		Nonce:              uint64(seed),
-		Contract:           eth_common.HexToAddress(fmt.Sprintf("0x2%d", seed)),
+		Hash:      eth_common.HexToHash(fmt.Sprintf("0x1%d", seed)),
+		ChainID:   common.ChainID(token.ChainID),
+		From:      eth_common.HexToAddress(fmt.Sprintf("0x2%d", seed)),
+		Timestamp: int64(seed),
+		BlkNumber: int64(seed),
+		Success:   true,
+		Nonce:     uint64(seed),
+		// In practice this is last20Bytes(Keccak256(RLP(From, nonce)))
+		Contract:           eth_common.HexToAddress(fmt.Sprintf("0x4%d", seed)),
 		MultiTransactionID: NoMultiTransactionID,
 	}
 }


### PR DESCRIPTION
### Updates [#11036](https://github.com/status-im/status-desktop/issues/11036)

Activity filter optimizations

# Activity filter optimizations

| Name                   | Original   | tr_type   | join     | hex      | no-db     | db_only   |     exp |    net_j |
|:-----------------------|:-----------|:----------|:---------|:---------|:----------|:----------|---------:|---------:|
| RAM_NoFilter-10        | 49580229   | 51253242  | 51112462 | 50915133 | 121217817 | 141691008 | 50908642 | 50239712 |
| SSD_NoFilter-10        | 49963604   | 51393588  | 51213038 | 50881483 | 120785679 | 141063467 | 50462767 | 49676867 |
| SSD_MovingWindow-10    | 53695712   | 54155292  | 54161733 | 54061325 | 126966633 | 146866017 | 53479929 | 53350475 |
| SSD_AllAddr_AllTos-10  | 41382804   | 41195225  | 51684175 | 52107262 | 64348100  | 97608833  | 50523529 | 49968321 |
| SSD_OneAddress-10      | 34945275   | 35103850  | 31066429 | 31328762 | 50927300  | 54322971  | 30098529 | 30252546 |
| FilterSend_AllAddr-10  | 39546808   | 37566604  | 38389725 | 38260738 | 114820458 | 125588408 | 37127625 | 36864575 |
| FilterSend_6Addr-10    | 41221458   | 41111225  | 40848288 | 40135492 | 118629700 | 128200467 | 38942521 | 39012100 |
| FilterThreeNetworks-10 | -          | -         | -        | -        | -         | -         | 50058929 | 49854450 |

Legend

- Original: before current change
- tr_type: use tr_type instead of `IN` filter_addresses
- join: filter recipients as join. I also tried from and owner but it didn't work as expected
- hex: remove usage of HEX and insert binary. Didn't notice much improvement though
- no-db: removed using temporary DB
- db_only: only used temporary DB and join
- exp: some more experiments
- net_j: join networks instead of WHERE ... IN ...