### PR TITLE
chore(messenger_communities): up unknown curated communities timeout

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -499,7 +499,9 @@ func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
 
 	const errorTimeout = 10 * time.Second
 	const successTimeout = 120 * time.Second
-	const unknownCommunitiesFoundTimeout = 3 * time.Second
+	// TODO lower this back again once the real curated community contract is up
+	// The current contract contains communities that are no longer accessible on waku
+	const unknownCommunitiesFoundTimeout = 60 * time.Second
 
 	go func() {
 		for {


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/12207

The issue is that the curation Dapp is not up yet, so we hard coded the contract with communities.
However, one of the curated communities is very old and not used anymore, so it is no longer broadcasted on Waku.

That means that we enter the "unknown community timeout" loop of 3 seconds. It ends up spamming a little bit.

I upped the timer to 1 minute for now. We can lower it back down when we deploy the real Dapp and contract.