### PR TITLE
Fetch erc20 history tail

### DIFF
--- a/contracts/ethscan/address.go
+++ b/contracts/ethscan/address.go
@@ -8,20 +8,34 @@ import (
 
 var errorNotAvailableOnChainID = errors.New("not available for chainID")
 
-var contractAddressByChainID = map[uint64]common.Address{
-	1:        common.HexToAddress("0x08A8fDBddc160A7d5b957256b903dCAb1aE512C5"), // mainnet
-	5:        common.HexToAddress("0x08A8fDBddc160A7d5b957256b903dCAb1aE512C5"), // goerli
-	10:       common.HexToAddress("0x9e5076df494fc949abc4461f4e57592b81517d81"), // optimism
-	420:      common.HexToAddress("0xf532c75239fa61b66d31e73f44300c46da41aadd"), // goerli optimism
-	42161:    common.HexToAddress("0xbb85398092b83a016935a17fc857507b7851a071"), // arbitrum
-	421613:   common.HexToAddress("0xec21ebe1918e8975fc0cd0c7747d318c00c0acd5"), // goerli arbitrum
-	11155111: common.HexToAddress("0xec21ebe1918e8975fc0cd0c7747d318c00c0acd5"), // sepolia
+type ContractData struct {
+	Address        common.Address
+	CreatedAtBlock uint
+}
+
+var contractDataByChainID = map[uint64]ContractData{
+	1:        {common.HexToAddress("0x08A8fDBddc160A7d5b957256b903dCAb1aE512C5"), 12_194_222}, // mainnet
+	5:        {common.HexToAddress("0x08A8fDBddc160A7d5b957256b903dCAb1aE512C5"), 4_578_854},  // goerli
+	10:       {common.HexToAddress("0x9e5076df494fc949abc4461f4e57592b81517d81"), 34_421_097}, // optimism
+	420:      {common.HexToAddress("0xf532c75239fa61b66d31e73f44300c46da41aadd"), 2_236_534},  // goerli optimism
+	42161:    {common.HexToAddress("0xbb85398092b83a016935a17fc857507b7851a071"), 70_031_945}, // arbitrum
+	421613:   {common.HexToAddress("0xec21ebe1918e8975fc0cd0c7747d318c00c0acd5"), 818_155},    // goerli arbitrum
+	777333:   {common.HexToAddress("0x0000000000000000000000000000000000777333"), 50},         // unit tests
+	11155111: {common.HexToAddress("0xec21ebe1918e8975fc0cd0c7747d318c00c0acd5"), 4_366_506},  // sepolia
 }
 
 func ContractAddress(chainID uint64) (common.Address, error) {
-	addr, exists := contractAddressByChainID[chainID]
+	contract, exists := contractDataByChainID[chainID]
 	if !exists {
 		return *new(common.Address), errorNotAvailableOnChainID
 	}
-	return addr, nil
+	return contract.Address, nil
+}
+
+func ContractCreatedAt(chainID uint64) (uint, error) {
+	contract, exists := contractDataByChainID[chainID]
+	if !exists {
+		return 0, errorNotAvailableOnChainID
+	}
+	return contract.CreatedAtBlock, nil
 }

--- a/services/wallet/history/service.go
+++ b/services/wallet/history/service.go
@@ -150,7 +150,7 @@ func (s *Service) isTokenVisible(tokenSymbol string) bool {
 
 // Native token implementation of DataSource interface
 type chainClientSource struct {
-	chainClient *chain.ClientWithFallback
+	chainClient chain.ClientInterface
 	currency    string
 }
 
@@ -163,7 +163,7 @@ func (src *chainClientSource) BalanceAt(ctx context.Context, account common.Addr
 }
 
 func (src *chainClientSource) ChainID() uint64 {
-	return src.chainClient.ChainID
+	return src.chainClient.NetworkID()
 }
 
 func (src *chainClientSource) Currency() string {
@@ -184,7 +184,7 @@ type tokenChainClientSource struct {
 }
 
 func (src *tokenChainClientSource) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
-	network := src.NetworkManager.Find(src.chainClient.ChainID)
+	network := src.NetworkManager.Find(src.chainClient.NetworkID())
 	if network == nil {
 		return nil, errors.New("network not found")
 	}

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -237,7 +237,7 @@ func (r *Reader) GetWalletToken(ctx context.Context, addresses []common.Address)
 					}
 					hasError := false
 					if client, ok := clients[token.ChainID]; ok {
-						hasError = err != nil || !client.IsConnected
+						hasError = err != nil || !client.GetIsConnected()
 					}
 					if !anyPositiveBalance {
 						anyPositiveBalance = balance.Cmp(big.NewFloat(0.0)) > 0

--- a/services/wallet/transfer/bridge_identifier.go
+++ b/services/wallet/transfer/bridge_identifier.go
@@ -131,7 +131,7 @@ func upsertHopBridgeDestinationTx(ctx context.Context, transactionManager *Trans
 	return multiTx, nil
 }
 
-func buildHopBridgeMultitransaction(ctx context.Context, client *chain.ClientWithFallback, transactionManager *TransactionManager, tokenManager *token.Manager, subTx *Transfer) (*MultiTransaction, error) {
+func buildHopBridgeMultitransaction(ctx context.Context, client chain.ClientInterface, transactionManager *TransactionManager, tokenManager *token.Manager, subTx *Transfer) (*MultiTransaction, error) {
 	// Identify if it's from/to transaction
 	switch w_common.GetEventType(subTx.Log) {
 	case w_common.HopBridgeTransferSentToL2EventType:

--- a/services/wallet/transfer/controller.go
+++ b/services/wallet/transfer/controller.go
@@ -114,7 +114,7 @@ func (c *Controller) CheckRecentHistory(chainIDs []uint64, accounts []common.Add
 // watchAccountsChanges subscribes to a feed and watches for changes in accounts list. If there are new or removed accounts
 // reactor will be restarted.
 func watchAccountsChanges(ctx context.Context, accountFeed *event.Feed, reactor *Reactor,
-	chainClients map[uint64]*chain.ClientWithFallback, initial []common.Address, loadAllTransfers bool) error {
+	chainClients map[uint64]chain.ClientInterface, initial []common.Address, loadAllTransfers bool) error {
 
 	ch := make(chan accountsevent.Event, 1) // it may block if the rate of updates will be significantly higher
 	sub := accountFeed.Subscribe(ch)

--- a/services/wallet/transfer/iterative.go
+++ b/services/wallet/transfer/iterative.go
@@ -18,7 +18,7 @@ func SetupIterativeDownloader(
 		return nil, errors.New("to or from cannot be nil")
 	}
 
-	log.Info("iterative downloader", "address", address, "from", from, "to", to, "size", size)
+	log.Debug("iterative downloader", "address", address, "from", from, "to", to, "size", size)
 	d := &IterativeDownloader{
 		client:     client,
 		batchSize:  size,
@@ -65,7 +65,7 @@ func (d *IterativeDownloader) Next(parent context.Context) ([]*DBHeader, *big.In
 		from = d.from
 	}
 	headers, err := d.downloader.GetHeadersInRange(parent, from, to)
-	log.Info("load erc20 transfers in range", "from", from, "to", to, "batchSize", d.batchSize)
+	log.Debug("load erc20 transfers in range", "from", from, "to", to, "batchSize", d.batchSize)
 	if err != nil {
 		log.Error("failed to get transfer in between two blocks", "from", from, "to", to, "error", err)
 		return nil, nil, nil, err

--- a/services/wallet/transfer/sequential_fetch_strategy.go
+++ b/services/wallet/transfer/sequential_fetch_strategy.go
@@ -19,7 +19,7 @@ import (
 func NewSequentialFetchStrategy(db *Database, blockDAO *BlockDAO, feed *event.Feed,
 	transactionManager *TransactionManager, pendingTxManager *transactions.PendingTxTracker,
 	tokenManager *token.Manager,
-	chainClients map[uint64]*chain.ClientWithFallback,
+	chainClients map[uint64]chain.ClientInterface,
 	accounts []common.Address,
 	balanceCacher balance.Cacher,
 ) *SequentialFetchStrategy {
@@ -46,12 +46,12 @@ type SequentialFetchStrategy struct {
 	transactionManager *TransactionManager
 	pendingTxManager   *transactions.PendingTxTracker
 	tokenManager       *token.Manager
-	chainClients       map[uint64]*chain.ClientWithFallback
+	chainClients       map[uint64]chain.ClientInterface
 	accounts           []common.Address
 	balanceCacher      balance.Cacher
 }
 
-func (s *SequentialFetchStrategy) newCommand(chainClient *chain.ClientWithFallback,
+func (s *SequentialFetchStrategy) newCommand(chainClient chain.ClientInterface,
 	account common.Address) async.Commander {
 
 	return newLoadBlocksAndTransfersCommand(account, s.db, s.blockDAO, chainClient, s.feed,


### PR DESCRIPTION
fix (initially) #3930 

Problem: we do not check incoming ERC20 transfers in case If we already reached the first ETH transfer while checking history.

The result is that some account will be missing ERC20 transfers in history (for instance I found one by randomly checking ERC20 transfers in 2 mins. Either I was lucky or that's not such a rare case. https://etherscan.io/address/0x1f01d365c17112f9574683e4318d2625231a9a13#tokentxns) 

The reason for not checking ERC20 tail via `eth_getLogs` right away is that those requests are slow, heavy for RPC API providers (as a result for some networks we are limited to a range like 10K blocks per request) and also we have to make quite a lot of requests to check empty or almost empty account (with only relatively recent transaction). With 18M blocks and 100K blocks per range (that's how it works in older version of the algorithm) it would cost 18M/10K*2=360 requests.
**In most cases though that ERC20 tail is going to be absent and we will likely confirm this with via single RPC request.** But when the tail exist we have to do some extra work.

Algorithm:
1. When the first ETH transfer is found we check ERC20 balances for known tokens (we have a list, at the moment it is limited to that list) before this block.
2. if there are non zero balances we do binary search of the range which is less or equal than the range limit for `eth_getLogs` call (currently 500K on [mainnet](https://github.com/status-im/status-go/blob/feature%2F%233930-erc20-history-tail/services/wallet/transfer/commands.go#L48) ).
3. Then we make two `etc_getLogs` in order to find transfers

18M blocks to check and a single ERC20 transfers somewhere in history:
1. old implementation would make **18M/100K*2=360  `etc_getLogs` requests** and find that transfer
2. new implementation would make **2 `etc_getLogs`** request and find that transfer only if it happened in that latest 100K range
3. this PRs implementation would make **2+1+(1+log2(18M/500K))+2=~12 request (for of them `eth_getLogs`), rest contract calls** (2 `eth_getLogs` on initial scan, single contact call to get balance for all known tokens, 1+log2(18M/500K)=~6 contract calls to narrow the range, 2 `eth_getLogs` calls to find blocks)

TODO in separate PRs:
1. Make sure we merge ranges for different tokens when those intersect, to avoid fetching transactions twice
4. Figure out whether we still need to check outgoing ERC20 in those ranges
5. In case if there are many tokens in the tail it might be cheaper to execute eth_getLogs, depends on network (range limits) and number of tokens. 

status: ready

