### PR TITLE
fix: don't save sender as contact for certain message types

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3615,8 +3615,10 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 						continue
 					}
 					contact = c
-					messageState.AllContacts.Store(senderID, contact)
-					m.forgetContactInfoRequest(senderID)
+					if msg.Type != protobuf.ApplicationMetadataMessage_PUSH_NOTIFICATION_QUERY {
+						messageState.AllContacts.Store(senderID, contact)
+						m.forgetContactInfoRequest(senderID)
+					}
 				}
 				messageState.CurrentMessageState = &CurrentMessageState{
 					MessageID:        messageID,


### PR DESCRIPTION
Because we use ephemeral keys for `PUSH_NOTIFICATION_QUERY`, there's no need to store it as contact.
In some situations it was leading to flaky tests.

Closes https://github.com/status-im/status-go/issues/4047