### PR TITLE
fix: stop sending channels members over the wire

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -3,7 +3,6 @@ package communities
 import (
 	"bytes"
 	"crypto/ecdsa"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1232,23 +1231,7 @@ func (o *Community) Description() *protobuf.CommunityDescription {
 }
 
 func (o *Community) marshaledDescription() ([]byte, error) {
-	// Clear members list for channels that don't have permissions
-	// TMP: should be fixed in https://github.com/status-im/status-desktop/issues/12188
-	clonedDescritpion := proto.Clone(o.config.CommunityDescription).(*protobuf.CommunityDescription)
-	for chatID, chat := range clonedDescritpion.Chats {
-		if !CheckIfChannelHasAnyPermissions(chatID, clonedDescritpion) {
-			chat.Members = map[string]*protobuf.CommunityMember{}
-		}
-	}
-
-	rawDescritpionData, err := proto.Marshal(clonedDescritpion)
-	if err != nil {
-		return []byte{}, nil
-	}
-
-	fmt.Println("-------------------> Raw CommunityDescritpion size: ", binary.Size(rawDescritpionData))
-
-	return rawDescritpionData, nil
+	return proto.Marshal(o.config.CommunityDescription)
 }
 
 func (o *Community) MarshaledDescription() ([]byte, error) {

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1265,7 +1265,46 @@ func (o *Community) toProtocolMessageBytes() ([]byte, error) {
 func (o *Community) ToProtocolMessageBytes() ([]byte, error) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
+
+	// This is only workaround to lower the size of the message that goes over the wire,
+	// see https://github.com/status-im/status-desktop/issues/12188
+	if o.IsControlNode() {
+		clone := o.CreateDeepCopy()
+		clone.DehydrateChannelsMembers()
+		return clone.toProtocolMessageBytes()
+	}
+
 	return o.toProtocolMessageBytes()
+}
+
+func (o *Community) DehydrateChannelsMembers() {
+	// To save space, we don't attach members for channels without permissions,
+	// otherwise the message will hit waku msg size limit.
+	for channelID, channel := range o.chats() {
+		if !o.ChannelHasTokenPermissions(o.IDString() + channelID) {
+			channel.Members = map[string]*protobuf.CommunityMember{} // clean members
+		}
+	}
+}
+
+func HydrateChannelsMembers(communityID string, description *protobuf.CommunityDescription) {
+	channelHasTokenPermissions := func(channelID string) bool {
+		for _, tokenPermission := range description.TokenPermissions {
+			if includes(tokenPermission.ChatIds, communityID+channelID) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for channelID, channel := range description.Chats {
+		if !channelHasTokenPermissions(channelID) {
+			channel.Members = make(map[string]*protobuf.CommunityMember)
+			for pubKey, member := range description.Members {
+				channel.Members[pubKey] = member
+			}
+		}
+	}
 }
 
 func (o *Community) Chats() map[string]*protobuf.CommunityChat {

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1272,14 +1272,6 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 }
 
 func (m *Manager) handleCommunityDescriptionMessageCommon(community *Community, description *protobuf.CommunityDescription, payload []byte) (*CommunityResponse, error) {
-	// For each channel that doesn't have permissions, we use community members list instead
-	// TMP: should be fixed in https://github.com/status-im/status-desktop/issues/12188
-	for chatID, chat := range description.Chats {
-		if !CheckIfChannelHasAnyPermissions(chatID, description) {
-			chat.Members = description.Members
-		}
-	}
-
 	changes, err := community.UpdateCommunityDescription(description, payload)
 	if err != nil {
 		return nil, err

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -262,11 +262,6 @@ func NewManager(identity *ecdsa.PrivateKey, db *sql.DB, encryptor *encryption.Pr
 		manager.ensVerifier = verifier
 	}
 
-	err = manager.fixupChannelMembers()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to fixup channel members")
-	}
-
 	return manager, nil
 }
 
@@ -4604,38 +4599,6 @@ func (m *Manager) saveAndPublish(community *Community) error {
 
 		m.publish(&Subscription{CommunityEventsMessage: community.ToCommunityEventsMessage()})
 		return nil
-	}
-
-	return nil
-}
-
-// This populates the member list of channels with all community members, if required.
-// Motivation: The member lists of channels were not populated for communities that had already been created.
-//
-// Ideally, this should be executed through a migration, but it's technically unfeasible
-// because `CommunityDescription“ is stored as a signed message blob in the database.
-//
-// However, it's safe to run this migration/fixup multiple times.
-func (m *Manager) fixupChannelMembers() error {
-	controlledCommunities, err := m.ControlledCommunities()
-	if err != nil {
-		return err
-	}
-
-	for _, c := range controlledCommunities {
-		fmt.Println("------> fixupChannelMembers for community: ", c.Identity().DisplayName)
-		for channelID := range c.Chats() {
-			if !c.ChannelHasTokenPermissions(c.IDString() + channelID) {
-				_, err := c.PopulateChatWithAllMembers(channelID)
-				if err != nil {
-					return err
-				}
-				err = m.persistence.SaveCommunity(c)
-				if err != nil {
-					return err
-				}
-			}
-		}
 	}
 
 	return nil

--- a/protocol/communities/utils.go
+++ b/protocol/communities/utils.go
@@ -7,7 +7,6 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/protobuf"
-	"golang.org/x/exp/slices"
 )
 
 func CalculateRequestID(publicKey string, communityID types.HexBytes) types.HexBytes {
@@ -57,13 +56,4 @@ func ExtractTokenCriteria(permissions []*CommunityTokenPermission) (erc20TokenCr
 		}
 	}
 	return
-}
-
-func CheckIfChannelHasAnyPermissions(chatID string, description *protobuf.CommunityDescription) bool {
-	for _, permission := range description.TokenPermissions {
-		if slices.Contains(permission.ChatIds, chatID) {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
Sending members for all channels causes the `CommunityDescription` to reach the Waku message limit. To address this, the following workaround has been implemented:

- Do not transmit members for channels that lack permissions
- Rehydrate members for channels without permissions locally


fixes: https://github.com/status-im/status-desktop/issues/12114