### PR TITLE
fix(messenger_communities): block messages and reactions to token gated or spectated communities

### DIFF
--- a/protocol/communities/community_test.go
+++ b/protocol/communities/community_test.go
@@ -511,7 +511,7 @@ func (s *CommunitySuite) TestCanPost() {
 			name:    "no-membership org with no-membeship chat",
 			config:  s.configNoMembershipOrgNoMembershipChat(),
 			member:  notMember,
-			canPost: true,
+			canPost: false,
 		},
 		{
 			name:    "no-membership org with invitation only chat-not-a-member",
@@ -529,7 +529,7 @@ func (s *CommunitySuite) TestCanPost() {
 			name:    "no-membership org with invitation only chat-not-a-member valid grant",
 			config:  s.configNoMembershipOrgInvitationOnlyChat(),
 			member:  notMember,
-			canPost: true,
+			canPost: false,
 			grant:   validGrant,
 		},
 		{
@@ -555,7 +555,7 @@ func (s *CommunitySuite) TestCanPost() {
 			name:    "membership org with no-membership chat  not-a-member valid grant",
 			config:  s.configOnRequestOrgNoMembershipChat(),
 			member:  notMember,
-			canPost: true,
+			canPost: false,
 			grant:   validGrant,
 		},
 		{

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2137,10 +2137,8 @@ func (m *Messenger) dispatchMessage(ctx context.Context, rawMessage common.RawMe
 			return rawMessage, err
 		}
 
-		// We allow emoji reactions by anyone
-		if rawMessage.MessageType != protobuf.ApplicationMetadataMessage_EMOJI_REACTION && !canPost {
+		if !canPost {
 			m.logger.Error("can't post on chat", zap.String("chat-id", chat.ID), zap.String("chat-name", chat.Name))
-
 			return rawMessage, errors.New("can't post on chat")
 		}
 


### PR DESCRIPTION
Right now, if the QML UI control checks are disabled, the user can send messages to spectated, non-joined and, possibly, token-gated communities with _invalid tokens_?

Right now the PR is in draft stage with possible code culprits.

---
Closes https://github.com/status-im/status-desktop/issues/11915
