### PR TITLE
chore: use lamport timestamp for communities

### DIFF
--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -53,7 +53,7 @@ func (s *ManagerSuite) SetupTest() {
 	key, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	s.Require().NoError(err)
-	m, err := NewManager(key, db, nil, nil, nil, nil, nil)
+	m, err := NewManager(key, db, nil, nil, nil, nil, &TimeSourceStub{}, nil)
 	s.Require().NoError(err)
 	s.Require().NoError(m.Start())
 	s.manager = m
@@ -161,7 +161,7 @@ func (s *ManagerSuite) setupManagerForTokenPermissions() (*Manager, *testCollect
 		WithTokenManager(tm),
 	}
 
-	m, err := NewManager(key, db, nil, nil, nil, nil, nil, options...)
+	m, err := NewManager(key, db, nil, nil, nil, nil, &TimeSourceStub{}, nil, options...)
 	s.Require().NoError(err)
 	s.Require().NoError(m.Start())
 

--- a/protocol/communities/persistence_test.go
+++ b/protocol/communities/persistence_test.go
@@ -39,7 +39,7 @@ func (s *PersistenceSuite) SetupTest() {
 	err = sqlite.Migrate(db)
 	s.NoError(err, "protocol migrate")
 
-	s.db = &Persistence{db: db}
+	s.db = &Persistence{db: db, timesource: &TimeSourceStub{}}
 }
 
 func (s *PersistenceSuite) TestSaveCommunity() {
@@ -259,7 +259,7 @@ func (s *PersistenceSuite) makeNewCommunity(identity *ecdsa.PrivateKey) *Communi
 		MemberIdentity: &identity.PublicKey,
 		PrivateKey:     comPrivKey,
 		ID:             &comPrivKey.PublicKey,
-	})
+	}, &TimeSourceStub{})
 	s.NoError(err, "New shouldn't give any error")
 
 	md, err := com.MarshaledDescription()

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -2635,7 +2635,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_Leave() {
 
 	// Check that the joined community has the correct values
 	s.Equal(community.ID(), aCom.ID())
-	s.Equal(uint64(0x2), aCom.Clock())
+	s.Equal(community.Clock(), aCom.Clock())
 	s.Equal(community.PublicKey(), aCom.PublicKey())
 
 	// Check alicesOtherDevice receives the sync join message

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -461,7 +461,7 @@ func NewMessenger(
 		managerOptions = append(managerOptions, communities.WithCommunityTokensService(c.communityTokensService))
 	}
 
-	communitiesManager, err := communities.NewManager(identity, database, encryptionProtocol, logger, ensVerifier, transp, c.torrentConfig, managerOptions...)
+	communitiesManager, err := communities.NewManager(identity, database, encryptionProtocol, logger, ensVerifier, transp, transp, c.torrentConfig, managerOptions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
closes: status-im/status-desktop#11961
