### PR TITLE
feat: use Alchemy API key for Ethereum main/goerli

### DIFF
--- a/api/defaults.go
+++ b/api/defaults.go
@@ -138,6 +138,12 @@ func defaultNodeConfig(installationID string, request *requests.CreateAccount) (
 		nodeConfig.WalletConfig.InfuraAPIKeySecret = request.InfuraSecret
 	}
 
+	if request.AlchemyEthereumMainnetToken != "" {
+		nodeConfig.WalletConfig.AlchemyAPIKeys[mainnetChainID] = request.AlchemyEthereumMainnetToken
+	}
+	if request.AlchemyEthereumGoerliToken != "" {
+		nodeConfig.WalletConfig.AlchemyAPIKeys[goerliChainID] = request.AlchemyEthereumGoerliToken
+	}
 	if request.AlchemyArbitrumMainnetToken != "" {
 		nodeConfig.WalletConfig.AlchemyAPIKeys[arbitrumChainID] = request.AlchemyArbitrumMainnetToken
 	}

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -50,6 +50,8 @@ type WalletSecretsConfig struct {
 
 	// Testing
 	GanacheURL                  string `json:"ganacheURL"`
+	AlchemyEthereumMainnetToken string `json:"alchemyEthereumMainnetToken"`
+	AlchemyEthereumGoerliToken  string `json:"alchemyEthereumGoerliToken"`
 	AlchemyArbitrumMainnetToken string `json:"alchemyArbitrumMainnetToken"`
 	AlchemyArbitrumGoerliToken  string `json:"alchemyArbitrumGoerliToken"`
 	AlchemyOptimismMainnetToken string `json:"alchemyOptimismMainnetToken"`

--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -543,7 +543,10 @@ func (o *Manager) processFullCollectibleData(assets []thirdparty.FullCollectible
 			if canProvide {
 				metadata, err := o.metadataProvider.FetchCollectibleMetadata(id, tokenURI)
 				if err != nil {
-					return err
+					// Metadata is available but fetching failed.
+					// Ideally we would retry, but for now we just skip it.
+					log.Error("Failed to fetch collectible metadata", "err", err)
+					continue
 				}
 
 				if metadata != nil {

--- a/services/wallet/thirdparty/alchemy/client.go
+++ b/services/wallet/thirdparty/alchemy/client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
@@ -77,6 +78,12 @@ type Client struct {
 }
 
 func NewClient(apiKeys map[uint64]string) *Client {
+	for _, chainID := range walletCommon.AllChainIDs() {
+		if apiKeys[uint64(chainID)] == "" {
+			log.Warn("Alchemy API key not available for", "chainID", chainID)
+		}
+	}
+
 	return &Client{
 		client:           &http.Client{Timeout: time.Minute},
 		apiKeys:          apiKeys,

--- a/services/wallet/thirdparty/infura/client.go
+++ b/services/wallet/thirdparty/infura/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
@@ -25,6 +26,13 @@ type Client struct {
 }
 
 func NewClient(apiKey string, apiKeySecret string) *Client {
+	if apiKey == "" {
+		log.Warn("Infura API key not available")
+	}
+	if apiKeySecret == "" {
+		log.Warn("Infura API key secret not available")
+	}
+
 	return &Client{
 		client:           &http.Client{Timeout: time.Minute},
 		apiKey:           apiKey,

--- a/services/wallet/thirdparty/opensea/client.go
+++ b/services/wallet/thirdparty/opensea/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
@@ -62,6 +63,10 @@ type Client struct {
 
 // new opensea v1 client.
 func NewClient(apiKey string, httpClient *HTTPClient) *Client {
+	if apiKey == "" {
+		log.Warn("OpenseaV1 API key not available")
+	}
+
 	return &Client{
 		client:           httpClient,
 		apiKey:           apiKey,

--- a/services/wallet/thirdparty/opensea/client_v2.go
+++ b/services/wallet/thirdparty/opensea/client_v2.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
@@ -58,6 +59,10 @@ type ClientV2 struct {
 
 // new opensea v2 client.
 func NewClientV2(apiKey string, httpClient *HTTPClient) *ClientV2 {
+	if apiKey == "" {
+		log.Warn("OpenseaV2 API key not available")
+	}
+
 	return &ClientV2{
 		client:           httpClient,
 		apiKey:           apiKey,


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/12312

Use the new Alchemy API keys for Ethereum Mainnet and Goerli

Also implemented some small fixes:
- Failure to fetch community metadata is considered a "soft failure" (owner node could be down, shouldn't prevent user from loading remaining collecitbles)
- Properly parse Alchemy struct field with non-strict type