### PR TITLE
[#3930] Make sure eth_getLogs for outgoing transfers are not executed…

### DIFF
--- a/services/wallet/transfer/commands.go
+++ b/services/wallet/transfer/commands.go
@@ -793,7 +793,7 @@ func (c *findAndCheckBlockRangeCommand) fastIndexErc20(ctx context.Context, from
 	commands := make([]*erc20HistoricalCommand, len(c.accounts))
 	for i, address := range c.accounts {
 		erc20 := &erc20HistoricalCommand{
-			erc20:        NewERC20TransfersDownloader(c.chainClient, []common.Address{address}, types.LatestSignerForChainID(c.chainClient.ToBigInt())),
+			erc20:        NewERC20TransfersDownloader(c.chainClient, []common.Address{address}, types.LatestSignerForChainID(c.chainClient.ToBigInt()), false),
 			chainClient:  c.chainClient,
 			feed:         c.feed,
 			address:      address,

--- a/services/wallet/transfer/reactor.go
+++ b/services/wallet/transfer/reactor.go
@@ -103,7 +103,7 @@ func (s *OnDemandFetchStrategy) newControlCommand(chainClient chain.ClientInterf
 			signer:      signer,
 			db:          s.db,
 		},
-		erc20:              NewERC20TransfersDownloader(chainClient, accounts, signer),
+		erc20:              NewERC20TransfersDownloader(chainClient, accounts, signer, false),
 		feed:               s.feed,
 		errorsCount:        0,
 		transactionManager: s.transactionManager,


### PR DESCRIPTION
needed for #3930

Tiny optimisation to avoid separate `eth_getLogs` request for outgoing transfers during scanning of ERC20 tail. 
Also PR adds an option to check the number of RPC requests in tests.

status: ready