### PR TITLE
Revert unviewed message count changes

### DIFF
--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -27,13 +27,6 @@ var chatColors = []string{
 	"#d37ef4", // purple
 }
 
-const (
-	// IncreaseUnviewedMessagesCountTimeoutMs
-	// this timeout indicates how long the time between received messages should be
-	// for a new message to increase the unviewed messages counter
-	IncreaseUnviewedMessagesCountTimeoutMs = 1000 * 60 * 2
-)
-
 type ChatType int
 
 const (
@@ -396,14 +389,6 @@ func (c *Chat) UpdateFromMessage(message *common.Message, timesource common.Time
 		c.LastClockValue = message.Clock
 	}
 	return nil
-}
-
-func (c *Chat) ShouldIncreaseMessageCount(message *common.Message) bool {
-	return c.LastMessage == nil ||
-		c.LastMessage.IsSystemMessage() ||
-		!c.LastMessage.New ||
-		c.LastMessage.Seen ||
-		message.Timestamp > c.LastMessage.Timestamp+IncreaseUnviewedMessagesCountTimeoutMs
 }
 
 func (c *Chat) UpdateFirstMessageTimestamp(timestamp uint32) bool {

--- a/protocol/common/message.go
+++ b/protocol/common/message.go
@@ -632,15 +632,6 @@ func (m *Message) PrepareContent(identity string) error {
 	return m.parseAudio()
 }
 
-func (m *Message) IsSystemMessage() bool {
-	return m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP ||
-		m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_GAP ||
-		m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_PINNED_MESSAGE ||
-		m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_MUTUAL_EVENT_SENT ||
-		m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_MUTUAL_EVENT_ACCEPTED ||
-		m.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_MUTUAL_EVENT_REMOVED
-}
-
 // GetSimplifiedText returns a the text stripped of all the markdown and with mentions
 // replaced by canonical names
 func (m *Message) GetSimplifiedText(identity string, canonicalNames map[string]string) (string, error) {

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -3084,11 +3084,9 @@ func (m *Messenger) isMessageAllowedFrom(publicKey string, chat *Chat) (bool, er
 }
 
 func (m *Messenger) updateUnviewedCounts(chat *Chat, message *common.Message) {
-	if chat.ShouldIncreaseMessageCount(message) {
-		chat.UnviewedMessagesCount++
-		if message.Mentioned || message.Replied || chat.OneToOne() {
-			chat.UnviewedMentionsCount++
-		}
+	chat.UnviewedMessagesCount++
+	if message.Mentioned || message.Replied || chat.OneToOne() {
+		chat.UnviewedMentionsCount++
 	}
 }
 


### PR DESCRIPTION
It was decided by @John-44 that the idea of increasing message counter only once per 2 minutes was not really good. This PR gets rid of these changes.
