### PR TITLE
fix(keycard_pairings): don't write the pairing file if content is empty

### DIFF
--- a/services/wallet/keycard_pairings.go
+++ b/services/wallet/keycard_pairings.go
@@ -28,6 +28,10 @@ func (kp *KeycardPairings) GetPairingsJSONFileContent() ([]byte, error) {
 }
 
 func (kp *KeycardPairings) SetPairingsJSONFileContent(content []byte) error {
+	if len(content) == 0 {
+		// Nothing to write
+		return nil
+	}
 	_, err := os.Stat(kp.pairingsFile)
 	if os.IsNotExist(err) {
 		dir, _ := filepath.Split(kp.pairingsFile)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12342

When pairing for the first time, the pairing sender doesn't have a file, so it sends an empty message, the receiver then tries to save that empty message, but it then becomes non-valid JSON.

Another solution would be to write `{}` instead. Let me know what you prefer.
