### PR TITLE
fix: activity center persistence test flaky test

### DIFF
--- a/protocol/activity_center_persistence_test.go
+++ b/protocol/activity_center_persistence_test.go
@@ -18,10 +18,11 @@ func TestActivityCenterPersistence(t *testing.T) {
 
 type ActivityCenterPersistenceTestSuite struct {
 	suite.Suite
+	idCounter int
 }
 
 func (s *ActivityCenterPersistenceTestSuite) SetupTest() {
-
+	s.idCounter = 0
 }
 
 func currentMilliseconds() uint64 {
@@ -36,7 +37,8 @@ func (s *ActivityCenterPersistenceTestSuite) createNotifications(p *sqlitePersis
 			notif.Timestamp = now
 		}
 		if len(notif.ID) == 0 {
-			notif.ID = types.HexBytes(strconv.Itoa(index))
+			s.idCounter++
+			notif.ID = types.HexBytes(strconv.Itoa(s.idCounter + index))
 		}
 		if notif.UpdatedAt == 0 {
 			notif.UpdatedAt = now
@@ -635,6 +637,7 @@ func (s *ActivityCenterPersistenceTestSuite) Test_ActiveContactRequestNotificati
 
 	notif, err = p.ActiveContactRequestNotification(contactID)
 	s.Require().NoError(err)
+	s.Require().NotNil(notif)
 	s.Require().Equal(ActivityCenterNotificationTypeContactRequest, notif.Type)
 
 	// Test: In case there's more than one notification, return the most recent


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/4111

_____

Faced the test fail here: https://github.com/status-im/status-go/pull/4110

Better to review by commits.
- 1b462d2ed5a433e7f352e6ddfa7f3421053124d2: created a test suite `ActivityCenterPersistenceTestSuite` from existing tests (trust me, nothing else there)
- 5131d17970bb50ce6feed90cb99ec71e1446b962: fixed the flaky test `Test_ActiveContactRequestNotification`.

The main problem with flake tests was tha the test was the generated IDs were always starting from the same value `0`.
And then it depended on the executing speed. When it's fast, `UpdatedAt` was also the same and the notification wasn't replaced. And when it's slow, it was replaced with a valid value and then the test was passing.
https://github.com/status-im/status-go/blob/5131d17970bb50ce6feed90cb99ec71e1446b962/protocol/activity_center_persistence_test.go#L44

it was passing in ~50%.