### PR TITLE
feat: trigger collectibles refresh on transfer

### DIFF
--- a/services/wallet/collectibles/controller.go
+++ b/services/wallet/collectibles/controller.go
@@ -1,0 +1,352 @@
+package collectibles
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/status-im/status-go/multiaccounts/accounts"
+	"github.com/status-im/status-go/rpc/network"
+	"github.com/status-im/status-go/services/accounts/accountsevent"
+	walletAccounts "github.com/status-im/status-go/services/wallet/accounts"
+	"github.com/status-im/status-go/services/wallet/async"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/transfer"
+	"github.com/status-im/status-go/services/wallet/walletevent"
+)
+
+const (
+	activityRefetchMarginSeconds = 30 * 60 // Trigger a fetch if activity is detected this many seconds before the last fetch
+)
+
+type commandPerChainID = map[walletCommon.ChainID]*periodicRefreshOwnedCollectiblesCommand
+type commandPerAddressAndChainID = map[common.Address]commandPerChainID
+
+type timerPerChainID = map[walletCommon.ChainID]*time.Timer
+type timerPerAddressAndChainID = map[common.Address]timerPerChainID
+
+type Controller struct {
+	manager      *Manager
+	ownershipDB  *OwnershipDB
+	walletFeed   *event.Feed
+	accountsDB   *accounts.Database
+	accountsFeed *event.Feed
+
+	networkManager *network.Manager
+	cancelFn       context.CancelFunc
+
+	commands            commandPerAddressAndChainID
+	timers              timerPerAddressAndChainID
+	group               *async.Group
+	accountsWatcher     *walletAccounts.Watcher
+	walletEventsWatcher *walletevent.Watcher
+
+	commandsLock sync.RWMutex
+}
+
+func NewController(db *sql.DB, walletFeed *event.Feed, accountsDB *accounts.Database, accountsFeed *event.Feed, networkManager *network.Manager, manager *Manager) *Controller {
+	return &Controller{
+		manager:        manager,
+		ownershipDB:    NewOwnershipDB(db),
+		walletFeed:     walletFeed,
+		accountsDB:     accountsDB,
+		accountsFeed:   accountsFeed,
+		networkManager: networkManager,
+		commands:       make(commandPerAddressAndChainID),
+		timers:         make(timerPerAddressAndChainID),
+	}
+}
+
+func (c *Controller) Start() {
+	// Setup periodical collectibles refresh
+	_ = c.startPeriodicalOwnershipFetch()
+
+	// Setup collectibles fetch when a new account gets added
+	c.startAccountsWatcher()
+
+	// Setup collectibles fetch when relevant activity is detected
+	c.startWalletEventsWatcher()
+}
+
+func (c *Controller) Stop() {
+	c.stopWalletEventsWatcher()
+
+	c.stopAccountsWatcher()
+
+	c.stopPeriodicalOwnershipFetch()
+}
+
+func (c *Controller) RefetchOwnedCollectibles() {
+	c.stopPeriodicalOwnershipFetch()
+	c.manager.ResetConnectionStatus()
+	_ = c.startPeriodicalOwnershipFetch()
+}
+
+func (c *Controller) GetCommandState(chainID walletCommon.ChainID, address common.Address) OwnershipState {
+	c.commandsLock.RLock()
+	defer c.commandsLock.RUnlock()
+
+	state := OwnershipStateIdle
+	if c.commands[address] != nil && c.commands[address][chainID] != nil {
+		state = c.commands[address][chainID].GetState()
+	}
+
+	return state
+}
+
+func (c *Controller) isPeriodicalOwnershipFetchRunning() bool {
+	return c.group != nil
+}
+
+// Starts periodical fetching for the all wallet addresses and all chains
+func (c *Controller) startPeriodicalOwnershipFetch() error {
+	c.commandsLock.Lock()
+	defer c.commandsLock.Unlock()
+
+	if c.isPeriodicalOwnershipFetchRunning() {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancelFn = cancel
+
+	c.group = async.NewGroup(ctx)
+
+	addresses, err := c.accountsDB.GetWalletAddresses()
+	if err != nil {
+		return err
+	}
+
+	for _, addr := range addresses {
+		err := c.startPeriodicalOwnershipFetchForAccount(common.Address(addr))
+		if err != nil {
+			log.Error("Error starting periodical collectibles fetch for accpunt", "address", addr, "error", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) stopPeriodicalOwnershipFetch() {
+	c.commandsLock.Lock()
+	defer c.commandsLock.Unlock()
+
+	if !c.isPeriodicalOwnershipFetchRunning() {
+		return
+	}
+
+	if c.cancelFn != nil {
+		c.cancelFn()
+		c.cancelFn = nil
+	}
+	if c.group != nil {
+		c.group.Stop()
+		c.group.Wait()
+		c.group = nil
+		c.commands = make(commandPerAddressAndChainID)
+	}
+}
+
+// Starts (or restarts) periodical fetching for the given account address for all chains
+func (c *Controller) startPeriodicalOwnershipFetchForAccount(address common.Address) error {
+	log.Debug("wallet.api.collectibles.Controller", "Start periodical fetching", "address", address)
+
+	networks, err := c.networkManager.Get(false)
+	if err != nil {
+		return err
+	}
+
+	areTestNetworksEnabled, err := c.accountsDB.GetTestNetworksEnabled()
+	if err != nil {
+		return err
+	}
+
+	for _, network := range networks {
+		if network.IsTest != areTestNetworksEnabled {
+			continue
+		}
+		chainID := walletCommon.ChainID(network.ChainID)
+
+		err := c.startPeriodicalOwnershipFetchForAccountAndChainID(address, chainID, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Starts (or restarts) periodical fetching for the given account address for all chains
+func (c *Controller) startPeriodicalOwnershipFetchForAccountAndChainID(address common.Address, chainID walletCommon.ChainID, delayed bool) error {
+	log.Debug("wallet.api.collectibles.Controller", "Start periodical fetching", "address", address, "chainID", chainID, "delayed", delayed)
+
+	if !c.isPeriodicalOwnershipFetchRunning() {
+		return errors.New("periodical fetch not initialized")
+	}
+
+	err := c.stopPeriodicalOwnershipFetchForAccountAndChainID(address, chainID)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := c.commands[address]; !ok {
+		c.commands[address] = make(commandPerChainID)
+	}
+
+	command := newPeriodicRefreshOwnedCollectiblesCommand(
+		c.manager,
+		c.ownershipDB,
+		c.walletFeed,
+		chainID,
+		address,
+	)
+
+	c.commands[address][chainID] = command
+	if delayed {
+		c.group.Add(command.DelayedCommand())
+	} else {
+		c.group.Add(command.Command())
+	}
+
+	return nil
+}
+
+// Stop periodical fetching for the given account address for all chains
+func (c *Controller) stopPeriodicalOwnershipFetchForAccount(address common.Address) error {
+	log.Debug("wallet.api.collectibles.Controller", "Stop periodical fetching", "address", address)
+
+	if !c.isPeriodicalOwnershipFetchRunning() {
+		return errors.New("periodical fetch not initialized")
+	}
+
+	if _, ok := c.commands[address]; ok {
+		for chainID := range c.commands[address] {
+			err := c.stopPeriodicalOwnershipFetchForAccountAndChainID(address, chainID)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func (c *Controller) stopPeriodicalOwnershipFetchForAccountAndChainID(address common.Address, chainID walletCommon.ChainID) error {
+	log.Debug("wallet.api.collectibles.Controller", "Stop periodical fetching", "address", address, "chainID", chainID)
+
+	if !c.isPeriodicalOwnershipFetchRunning() {
+		return errors.New("periodical fetch not initialized")
+	}
+
+	if _, ok := c.commands[address]; ok {
+		if _, ok := c.commands[address][chainID]; ok {
+			c.commands[address][chainID].Stop()
+			delete(c.commands[address], chainID)
+		}
+		// If it was the last chain, delete the address as well
+		if len(c.commands[address]) == 0 {
+			delete(c.commands, address)
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) startAccountsWatcher() {
+	if c.accountsWatcher != nil {
+		return
+	}
+
+	accountChangeCb := func(changedAddresses []common.Address, eventType accountsevent.EventType, currentAddresses []common.Address) {
+		c.commandsLock.Lock()
+		defer c.commandsLock.Unlock()
+		// Whenever an account gets added, start fetching
+		if eventType == accountsevent.EventTypeAdded {
+			for _, address := range changedAddresses {
+				err := c.startPeriodicalOwnershipFetchForAccount(address)
+				if err != nil {
+					log.Error("Error starting periodical collectibles fetch", "address", address, "error", err)
+				}
+			}
+		} else if eventType == accountsevent.EventTypeRemoved {
+			for _, address := range changedAddresses {
+				err := c.stopPeriodicalOwnershipFetchForAccount(address)
+				if err != nil {
+					log.Error("Error starting periodical collectibles fetch", "address", address, "error", err)
+				}
+			}
+		}
+	}
+
+	c.accountsWatcher = walletAccounts.NewWatcher(c.accountsDB, c.accountsFeed, accountChangeCb)
+
+	c.accountsWatcher.Start()
+}
+
+func (c *Controller) stopAccountsWatcher() {
+	if c.accountsWatcher != nil {
+		c.accountsWatcher.Stop()
+		c.accountsWatcher = nil
+	}
+}
+
+func (c *Controller) startWalletEventsWatcher() {
+	if c.walletEventsWatcher != nil {
+		return
+	}
+
+	walletEventCb := func(event walletevent.Event) {
+		// EventRecentHistoryReady ?
+		if event.Type != transfer.EventInternalERC721TransferDetected {
+			return
+		}
+
+		chainID := walletCommon.ChainID(event.ChainID)
+		for _, account := range event.Accounts {
+			// Check last ownership update timestamp
+			timestamp, err := c.ownershipDB.GetOwnershipUpdateTimestamp(account, chainID)
+
+			if err != nil {
+				log.Error("Error getting ownership update timestamp", "error", err)
+				continue
+			}
+			if timestamp == InvalidTimestamp {
+				// Ownership was never fetched for this account
+				continue
+			}
+
+			timeCheck := timestamp - activityRefetchMarginSeconds
+			if timeCheck < 0 {
+				timeCheck = 0
+			}
+
+			if event.At > timeCheck {
+				// Restart fetching for account + chainID
+				c.commandsLock.Lock()
+				err := c.startPeriodicalOwnershipFetchForAccountAndChainID(account, chainID, true)
+				c.commandsLock.Unlock()
+				if err != nil {
+					log.Error("Error starting periodical collectibles fetch", "address", account, "error", err)
+				}
+			}
+		}
+	}
+
+	c.walletEventsWatcher = walletevent.NewWatcher(c.walletFeed, walletEventCb)
+
+	c.walletEventsWatcher.Start()
+}
+
+func (c *Controller) stopWalletEventsWatcher() {
+	if c.walletEventsWatcher != nil {
+		c.walletEventsWatcher.Stop()
+		c.walletEventsWatcher = nil
+	}
+}

--- a/services/wallet/walletevent/events.go
+++ b/services/wallet/walletevent/events.go
@@ -2,12 +2,22 @@ package walletevent
 
 import (
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 )
 
 // EventType type for event types.
 type EventType string
+
+// EventType prefix to be used for internal events.
+// These events are not forwarded to the client, they are only used
+// within status-go.
+const InternalEventTypePrefix = "INT-"
+
+func (t EventType) IsInternal() bool {
+	return strings.HasPrefix(string(t), InternalEventTypePrefix)
+}
 
 // Event is a type for transfer events.
 type Event struct {

--- a/services/wallet/walletevent/transmitter.go
+++ b/services/wallet/walletevent/transmitter.go
@@ -47,7 +47,9 @@ func (tmr *SignalsTransmitter) Start() error {
 				}
 				return
 			case event := <-events:
-				signal.SendWalletEvent(event)
+				if !event.Type.IsInternal() {
+					signal.SendWalletEvent(event)
+				}
 			}
 		}
 	}()

--- a/services/wallet/walletevent/watcher.go
+++ b/services/wallet/walletevent/watcher.go
@@ -1,0 +1,65 @@
+package walletevent
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/status-im/status-go/services/wallet/async"
+)
+
+type EventCb func(event Event)
+
+// Watcher executes a given callback whenever a wallet event gets sent
+type Watcher struct {
+	feed     *event.Feed
+	group    *async.Group
+	callback EventCb
+}
+
+func NewWatcher(feed *event.Feed, callback EventCb) *Watcher {
+	return &Watcher{
+		feed:     feed,
+		callback: callback,
+	}
+}
+
+func (w *Watcher) Start() {
+	if w.group != nil {
+		return
+	}
+
+	w.group = async.NewGroup(context.Background())
+	w.group.Add(func(ctx context.Context) error {
+		return watch(ctx, w.feed, w.callback)
+	})
+}
+
+func (w *Watcher) Stop() {
+	if w.group != nil {
+		w.group.Stop()
+		w.group.Wait()
+		w.group = nil
+	}
+}
+
+func watch(ctx context.Context, feed *event.Feed, callback EventCb) error {
+	ch := make(chan Event, 10)
+	sub := feed.Subscribe(ch)
+	defer sub.Unsubscribe()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-sub.Err():
+			if err != nil {
+				log.Error("wallet event watcher subscription failed", "error", err)
+			}
+		case ev := <-ch:
+			if callback != nil {
+				callback(ev)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/9823

What does the PR do
Refresh the list of owned collectibles for a given address+chainID whenever an ERC721 transfer is detected.
Periodic fetching still works as before (for any address+chainID, trigger a refetch a given time -now 30 mins- after the last fetch). With these changes, we can probably make the period longer.

The mechanism is as follows, and it is performed independently for each address+chainID:
Whenever we process a list of blocks and detect one or many ERC721 transfers, we emit an internal (not forwarded to the client) event containing the latest timestamp of the set.
The collectibles service subscribes to this event. If collectibles have not been yet successfully fetched, we do nothing. If the transfer occurred later than some time after the last successful fetch (currently 30 minutes - this is used to account for any delays in the update of the list of collectibles given by our providers), we start a timer (currently 1 minute - this is used in case multiple blocks are processed in a short time, to avoid re-fetching many times) to trigger a refetch. The timer is reset if any suitable transfer is detected within that time.

Note: Tested this on goerli and Status took ~5mins to detect the erc721 transaction, not sure if that's OK.