### PR TITLE
Add test method TestPinMessageInCommunityChat

### DIFF
--- a/protocol/messenger_pin_messages.go
+++ b/protocol/messenger_pin_messages.go
@@ -36,11 +36,16 @@ func (m *Messenger) sendPinMessage(ctx context.Context, message *common.PinMessa
 		if err != nil {
 			return nil, err
 		}
+
 		hasPermission := community.IsPrivilegedMember(&m.identity.PublicKey)
 		pinMessageAllowed := community.AllowsAllMembersToPinMessage()
+		canPost, err := community.CanPost(&m.identity.PublicKey, chat.CommunityChatID(), nil)
+		if err != nil {
+			return nil, err
+		}
 
-		if !pinMessageAllowed && !hasPermission {
-			return nil, errors.New("member can't pin message")
+		if !canPost && !pinMessageAllowed && !hasPermission {
+			return nil, errors.New("can't pin message")
 		}
 	}
 


### PR DESCRIPTION
Add TestPinMessageInCommunityChat to test that a pin message type can be sent correctly for community\chat members or denied for non-members.

~~Need to fix `community.AdminSettings().PinMessageAllMembersEnabled` setting first, which seems to be ignored for non-owner members.~~

Closes #4138
