### PR TITLE
feat: emit event on received community collectibles

### DIFF
--- a/services/wallet/collectibles/service.go
+++ b/services/wallet/collectibles/service.go
@@ -26,6 +26,7 @@ const (
 	EventCollectiblesOwnershipUpdatePartial           walletevent.EventType = "wallet-collectibles-ownership-update-partial"
 	EventCollectiblesOwnershipUpdateFinished          walletevent.EventType = "wallet-collectibles-ownership-update-finished"
 	EventCollectiblesOwnershipUpdateFinishedWithError walletevent.EventType = "wallet-collectibles-ownership-update-finished-with-error"
+	EventCommunityCollectiblesReceived                walletevent.EventType = "wallet-collectibles-community-collectibles-received"
 
 	EventOwnedCollectiblesFilteringDone walletevent.EventType = "wallet-owned-collectibles-filtering-done"
 	EventGetCollectiblesDetailsDone     walletevent.EventType = "wallet-get-collectibles-details-done"
@@ -258,12 +259,8 @@ func (s *Service) fullCollectiblesDataToHeaders(data []thirdparty.FullCollectibl
 				return nil, err
 			}
 
-			header.CommunityHeader = &CommunityHeader{
-				CommunityID:     communityInfo.CommunityID,
-				CommunityName:   communityInfo.CommunityName,
-				CommunityColor:  communityInfo.CommunityColor,
-				PrivilegesLevel: communityInfo.PrivilegesLevel,
-			}
+			communityHeader := communityInfoToHeader(*communityInfo)
+			header.CommunityHeader = &communityHeader
 		}
 
 		res = append(res, header)

--- a/services/wallet/collectibles/types.go
+++ b/services/wallet/collectibles/types.go
@@ -42,6 +42,12 @@ type CommunityHeader struct {
 	PrivilegesLevel token.PrivilegesLevel `json:"privileges_level"`
 }
 
+type CommunityCollectibleHeader struct {
+	ID              thirdparty.CollectibleUniqueID `json:"id"`
+	Name            string                         `json:"name"`
+	CommunityHeader CommunityHeader                `json:"community_header"`
+}
+
 func fullCollectibleDataToHeader(c thirdparty.FullCollectibleData) CollectibleHeader {
 	ret := CollectibleHeader{
 		ID:                 c.CollectibleData.ID,
@@ -76,4 +82,13 @@ func fullCollectibleDataToDetails(c thirdparty.FullCollectibleData) CollectibleD
 		ret.CollectionImageURL = c.CollectionData.ImageURL
 	}
 	return ret
+}
+
+func communityInfoToHeader(c thirdparty.CollectiblesCommunityInfo) CommunityHeader {
+	return CommunityHeader{
+		CommunityID:     c.CommunityID,
+		CommunityName:   c.CommunityName,
+		CommunityColor:  c.CommunityColor,
+		PrivilegesLevel: c.PrivilegesLevel,
+	}
 }


### PR DESCRIPTION
Whenever a new community collectible is detected on an account, a wallet event will be emitted containing some collectible+community information