### PR TITLE
refactor: simplify community requests logic

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1020,12 +1020,19 @@ func (o *Community) ValidateRequestToJoin(signer *ecdsa.PublicKey, request *prot
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 
-	// If we are not admin, fuggetaboutit
-	if !o.IsControlNode() && !o.HasPermissionToSendCommunityEvents() {
+	if o.IsControlNode() {
+		// TODO: Enable this once mobile supports revealed addresses.
+		// if len(request.RevealedAccounts) == 0 {
+		// 	return errors.New("no addresses revealed")
+		// }
+	} else if o.HasPermissionToSendCommunityEvents() {
+		if o.AcceptRequestToJoinAutomatically() {
+			return errors.New("auto-accept community requests can only be processed by the control node")
+		}
+	} else {
 		return ErrNotAdmin
 	}
 
-	// If the org is ens name only, then reject if not present
 	if o.config.CommunityDescription.Permissions.EnsOnly && len(request.EnsName) == 0 {
 		return ErrCantRequestAccess
 	}
@@ -1037,6 +1044,19 @@ func (o *Community) ValidateRequestToJoin(signer *ecdsa.PublicKey, request *prot
 	err := o.validateRequestToJoinWithoutChatID(request)
 	if err != nil {
 		return err
+	}
+
+	if o.isBanned(signer) {
+		return ErrCantRequestAccess
+	}
+
+	timeNow := uint64(time.Now().Unix())
+	requestTimeOutClock, err := AddTimeoutToRequestToJoinClock(request.Clock)
+	if err != nil {
+		return err
+	}
+	if timeNow >= requestTimeOutClock {
+		return errors.New("request is expired")
 	}
 
 	return nil

--- a/protocol/communities/community_test.go
+++ b/protocol/communities/community_test.go
@@ -338,21 +338,25 @@ func (s *CommunitySuite) TestValidateRequestToJoin() {
 	request := &protobuf.CommunityRequestToJoin{
 		EnsName:     "donvanvliet.stateofus.eth",
 		CommunityId: s.communityID,
+		Clock:       uint64(time.Now().Unix()),
 	}
 
 	requestWithChatID := &protobuf.CommunityRequestToJoin{
 		EnsName:     "donvanvliet.stateofus.eth",
 		CommunityId: s.communityID,
 		ChatId:      testChatID1,
+		Clock:       uint64(time.Now().Unix()),
 	}
 
 	requestWithoutENS := &protobuf.CommunityRequestToJoin{
 		CommunityId: s.communityID,
+		Clock:       uint64(time.Now().Unix()),
 	}
 
 	requestWithChatWithoutENS := &protobuf.CommunityRequestToJoin{
 		CommunityId: s.communityID,
 		ChatId:      testChatID1,
+		Clock:       uint64(time.Now().Unix()),
 	}
 
 	// MATRIX

--- a/protocol/communities/request_to_join.go
+++ b/protocol/communities/request_to_join.go
@@ -74,6 +74,19 @@ func (r *RequestToJoin) Empty() bool {
 	return len(r.ID)+len(r.PublicKey)+int(r.Clock)+len(r.ENSName)+len(r.ChatID)+len(r.CommunityID)+int(r.State) == 0
 }
 
+func (r *RequestToJoin) ShouldRetainDeclined(clock uint64) (bool, error) {
+	if r.State != RequestToJoinStateDeclined {
+		return false, nil
+	}
+
+	declineExpiryClock, err := AddTimeoutToRequestToJoinClock(r.Clock)
+	if err != nil {
+		return false, err
+	}
+
+	return clock < declineExpiryClock, nil
+}
+
 func AddTimeoutToRequestToJoinClock(clock uint64) (uint64, error) {
 	requestToJoinClock, err := strconv.ParseInt(fmt.Sprint(clock), 10, 64)
 	if err != nil {

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1990,7 +1990,6 @@ func addCommunityTokenToCommunityTokensService(base CommunityEventsTestsInterfac
 
 func testJoinedPrivilegedMemberReceiveRequestsToJoin(base CommunityEventsTestsInterface, community *communities.Community,
 	bob *Messenger, newPrivilegedUser *Messenger, tokenPermissionType protobuf.CommunityTokenPermission_Type) {
-
 	// create community permission
 	rolePermission := createTestPermissionRequest(community, tokenPermissionType)
 	controlNodeCreatesCommunityPermission(base, community, rolePermission)
@@ -2030,44 +2029,38 @@ func testJoinedPrivilegedMemberReceiveRequestsToJoin(base CommunityEventsTestsIn
 	s.Require().NotNil(updatedCommunity)
 	s.Require().True(updatedCommunity.HasMember(&newPrivilegedUser.identity.PublicKey))
 
-	// receive request to join msg
+	// privileged user should receive request to join from user and its shared addresses from control node
 	_, err = WaitOnMessengerResponse(
 		newPrivilegedUser,
 		func(r *MessengerResponse) bool {
-			return len(r.RequestsToJoinCommunity) > 3
+			requestsToJoin, err := newPrivilegedUser.communitiesManager.GetCommunityRequestsToJoinWithRevealedAddresses(community.ID())
+			if err != nil {
+				return false
+			}
+			if len(requestsToJoin) != 4 {
+				s.T().Log("invalid requests to join count:", len(requestsToJoin))
+				return false
+			}
+
+			for _, request := range requestsToJoin {
+				if tokenPermissionType == protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER {
+					if len(request.RevealedAccounts) != 1 {
+						s.T().Log("no accounts revealed")
+						return false
+					}
+				} else {
+					if len(request.RevealedAccounts) != 0 {
+						s.T().Log("unexpected accounts revealed")
+						return false
+					}
+				}
+			}
+
+			return true
 		},
 		"newPrivilegedUser did not receive all requests to join from the control node",
 	)
 	s.Require().NoError(err)
-
-	checkRevealedAddresses := func(user *Messenger) {
-		requestsToJoin, err := newPrivilegedUser.communitiesManager.GetCommunityRequestsToJoinWithRevealedAddresses(community.ID())
-		s.Require().NoError(err)
-		// event sender, member, bob and newPrivilegedUser requests
-		s.Require().Len(requestsToJoin, 4)
-
-		// check if revealed addresses are present based on the role
-		for _, request := range requestsToJoin {
-			if tokenPermissionType == protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER {
-				s.Require().Len(request.RevealedAccounts, 1)
-			} else {
-				s.Require().Len(request.RevealedAccounts, 0)
-			}
-		}
-	}
-
-	checkRevealedAddresses(bob)
-
-	_, err = WaitOnMessengerResponse(
-		base.GetEventSender(),
-		func(r *MessengerResponse) bool {
-			return len(r.RequestsToJoinCommunity) > 1
-		},
-		"EventSender did not receive new requests to join from the control node",
-	)
-	s.Require().NoError(err)
-
-	checkRevealedAddresses(base.GetEventSender())
 }
 
 func testMemberReceiveRequestsToJoinAfterGettingNewRole(base CommunityEventsTestsInterface, bob *Messenger, tokenPermissionType protobuf.CommunityTokenPermission_Type) {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1103,19 +1103,33 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 		return nil, err
 	}
 
+	// send request to join to privileged members
 	if !community.AcceptRequestToJoinAutomatically() {
-		// send request to join also to community admins but without revealed addresses
+		privilegedMembers := community.GetFilteredPrivilegedMembers(map[string]struct{}{})
+
+		for _, member := range privilegedMembers[protobuf.CommunityMember_ROLE_OWNER] {
+			_, err := m.sender.SendPrivate(context.Background(), member, &rawMessage)
+			if err != nil {
+				return nil, err
+			}
+		}
+		for _, member := range privilegedMembers[protobuf.CommunityMember_ROLE_TOKEN_MASTER] {
+			_, err := m.sender.SendPrivate(context.Background(), member, &rawMessage)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// don't send revealed addresses to admins
 		requestToJoinProto.RevealedAccounts = make([]*protobuf.RevealedAccount, 0)
 		payload, err = proto.Marshal(requestToJoinProto)
 		if err != nil {
 			return nil, err
 		}
-
 		rawMessage.Payload = payload
 
-		privilegedMembers := community.GetPrivilegedMembers()
-		for _, privilegedMember := range privilegedMembers {
-			_, err := m.sender.SendPrivate(context.Background(), privilegedMember, &rawMessage)
+		for _, member := range privilegedMembers[protobuf.CommunityMember_ROLE_ADMIN] {
+			_, err := m.sender.SendPrivate(context.Background(), member, &rawMessage)
 			if err != nil {
 				return nil, err
 			}

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1466,76 +1466,22 @@ func (m *Messenger) HandleCommunityCancelRequestToJoin(state *ReceivedMessageSta
 
 // HandleCommunityRequestToJoin handles an community request to join
 func (m *Messenger) HandleCommunityRequestToJoin(state *ReceivedMessageState, requestToJoinProto *protobuf.CommunityRequestToJoin, statusMessage *v1protocol.StatusMessage) error {
-	if requestToJoinProto.CommunityId == nil {
-		return ErrInvalidCommunityID
-	}
-
-	timeNow := uint64(time.Now().Unix())
-
-	requestTimeOutClock, err := communities.AddTimeoutToRequestToJoinClock(requestToJoinProto.Clock)
-	if err != nil {
-		return err
-	}
-
-	if timeNow >= requestTimeOutClock {
-		return errors.New("request is expired")
-	}
-
 	signer := state.CurrentMessageState.PublicKey
-	receiver := statusMessage.Dst
-	requestToJoin, err := m.communitiesManager.HandleCommunityRequestToJoin(signer, receiver, requestToJoinProto)
-	if err != nil {
-		return err
-	}
-	// not interested, stop further processing
-	if requestToJoin == nil {
-		return nil
-	}
-
-	if requestToJoin.State == communities.RequestToJoinStateAccepted {
-		accept := &requests.AcceptRequestToJoinCommunity{
-			ID: requestToJoin.ID,
-		}
-		_, err = m.AcceptRequestToJoinCommunity(accept)
-		if err != nil {
-			if err == communities.ErrNoPermissionToJoin {
-				// only control node will end up here as it's the only one that
-				// performed token permission checks
-				requestToJoin.State = communities.RequestToJoinStateDeclined
-			} else {
-				return err
-			}
-		}
-	}
-
-	if requestToJoin.State == communities.RequestToJoinStateDeclined {
-		cancel := &requests.DeclineRequestToJoinCommunity{
-			ID: requestToJoin.ID,
-		}
-		_, err = m.DeclineRequestToJoinCommunity(cancel)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	community, err := m.communitiesManager.GetByID(requestToJoinProto.CommunityId)
+	community, requestToJoin, err := m.communitiesManager.HandleCommunityRequestToJoin(signer, statusMessage.Dst, requestToJoinProto)
 	if err != nil {
 		return err
 	}
 
-	contactID := contactIDFromPublicKey(signer)
+	switch requestToJoin.State {
+	case communities.RequestToJoinStatePending:
+		contact, _ := state.AllContacts.Load(contactIDFromPublicKey(signer))
+		if len(requestToJoinProto.DisplayName) != 0 {
+			contact.DisplayName = requestToJoinProto.DisplayName
+			state.ModifiedContacts.Store(contact.ID, true)
+			state.AllContacts.Store(contact.ID, contact)
+			state.ModifiedContacts.Store(contact.ID, true)
+		}
 
-	contact, _ := state.AllContacts.Load(contactID)
-
-	if len(requestToJoinProto.DisplayName) != 0 {
-		contact.DisplayName = requestToJoinProto.DisplayName
-		state.ModifiedContacts.Store(contact.ID, true)
-		state.AllContacts.Store(contact.ID, contact)
-		state.ModifiedContacts.Store(contact.ID, true)
-	}
-
-	if requestToJoin.State == communities.RequestToJoinStatePending {
 		if state.Response.RequestsToJoinCommunity == nil {
 			state.Response.RequestsToJoinCommunity = make([]*communities.RequestToJoin, 0)
 		}
@@ -1554,32 +1500,52 @@ func (m *Messenger) HandleCommunityRequestToJoin(state *ReceivedMessageState, re
 			Deleted:          false,
 			UpdatedAt:        m.getCurrentTimeInMillis(),
 		}
-
 		err = m.addActivityCenterNotification(state.Response, notification)
 		if err != nil {
 			m.logger.Error("failed to save notification", zap.Error(err))
 			return err
 		}
-	} else {
-		// Activity Center notification, updating existing for accepted/declined
-		notification, err := m.persistence.GetActivityCenterNotificationByID(requestToJoin.ID)
-		if err != nil {
+
+	case communities.RequestToJoinStateDeclined:
+		response, err := m.declineRequestToJoinCommunity(requestToJoin)
+		if err == nil {
+			err := state.Response.Merge(response)
+			if err != nil {
+				return err
+			}
+		} else {
 			return err
 		}
 
-		if notification != nil {
-			if requestToJoin.State == communities.RequestToJoinStateAccepted {
-				notification.MembershipStatus = ActivityCenterMembershipStatusAccepted
-			} else {
-				notification.MembershipStatus = ActivityCenterMembershipStatusDeclined
-			}
-			notification.UpdatedAt = m.getCurrentTimeInMillis()
-			err = m.addActivityCenterNotification(state.Response, notification)
+	case communities.RequestToJoinStateAccepted:
+		response, err := m.acceptRequestToJoinCommunity(requestToJoin)
+		if err == nil {
+			err := state.Response.Merge(response) // new member has been added
 			if err != nil {
-				m.logger.Error("failed to save notification", zap.Error(err))
 				return err
 			}
+		} else if err == communities.ErrNoPermissionToJoin {
+			// only control node will end up here as it's the only one that
+			// performed token permission checks
+			response, err = m.declineRequestToJoinCommunity(requestToJoin)
+			if err == nil {
+				err := state.Response.Merge(response)
+				if err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
+		} else {
+			return err
 		}
+
+	case communities.RequestToJoinStateCanceled:
+		// cancellation is handled by separate message
+		fallthrough
+	case communities.RequestToJoinStateAcceptedPending, communities.RequestToJoinStateDeclinedPending:
+		// request can be marked as pending only manually
+		return errors.New("invalid request state")
 	}
 
 	return nil


### PR DESCRIPTION
With the recent introduction of pending states, the community requests logic became more complex. This commit simplifies the flow and appropriately delegates logic to its corresponding abstraction levels: messenger, manager and community. Additionally, it eliminates redundancies in notifications and request-saving mechanism.