### PR TITLE
fix: setup owner as CommunityDescription signer after minting community owner token

### DIFF
--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2296,6 +2296,11 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 		if err != nil {
 			return err
 		}
+
+		if communityResponse == nil {
+			return nil
+		}
+
 		community := communityResponse.Community
 		receivedMessage.CommunityID = community.IDString()
 


### PR DESCRIPTION
When we mint the owner token, clients will start to verify the signature of the CommunityDescription from the contract owner, so CommunityDescription must be signed by the owner privateKey and not by generated community private key

Closes #https://github.com/status-im/status-desktop/issues/12473
