### PR TITLE
Chore/use cached control node

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1086,7 +1086,7 @@ func (o *Community) ValidateEditSharedAddresses(signer *ecdsa.PublicKey, request
 
 // We treat control node as an owner with community key
 func (o *Community) IsControlNode() bool {
-	return o.config.PrivateKey != nil && o.config.PrivateKey.PublicKey.Equal(o.config.ControlNode)
+	return o.config.PrivateKey != nil && o.config.PrivateKey.PublicKey.Equal(o.ControlNode())
 }
 
 func (o *Community) IsOwnerWithoutCommunityKey() bool {

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1308,6 +1308,9 @@ func (o *Community) setPrivateKey(pk *ecdsa.PrivateKey) {
 }
 
 func (o *Community) ControlNode() *ecdsa.PublicKey {
+	if o.config.ControlNode == nil {
+		return o.config.ID
+	}
 	return o.config.ControlNode
 }
 


### PR DESCRIPTION
- chore: omit `CommunityDescription` queuing if owner is already verified
- fix: prevent nil dereference in `IsControlNode` for existing communities