### PR TITLE
feat: support signing of a join/edit community request from within the app or keycard

### DIFF
--- a/account/accounts.go
+++ b/account/accounts.go
@@ -54,7 +54,23 @@ var zeroAddress = types.Address{}
 type SignParams struct {
 	Data     interface{} `json:"data"`
 	Address  string      `json:"account"`
-	Password string      `json:"password"`
+	Password string      `json:"password,omitempty"`
+}
+
+func (sp *SignParams) Validate(checkPassword bool) error {
+	if len(sp.Address) != 2*types.AddressLength+2 {
+		return errors.New("address has to be provided")
+	}
+
+	if sp.Data == "" {
+		return errors.New("data has to be provided")
+	}
+
+	if checkPassword && sp.Password == "" {
+		return errors.New("password has to be provided")
+	}
+
+	return nil
 }
 
 type RecoverParams struct {

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -122,19 +122,17 @@ func setUpCommunityAndRoles(base CommunityEventsTestsInterface, role protobuf.Co
 	request := &requests.RequestToJoinCommunity{
 		CommunityID:       community.ID(),
 		AddressesToReveal: []string{eventsSenderAccountAddress},
-		Password:          accountPassword,
 		AirdropAddress:    eventsSenderAccountAddress,
 	}
-	joinCommunity(suite, community, base.GetControlNode(), base.GetEventSender(), request)
+	joinCommunity(suite, community, base.GetControlNode(), base.GetEventSender(), request, accountPassword)
 	refreshMessengerResponses(base)
 
 	request = &requests.RequestToJoinCommunity{
 		CommunityID:       community.ID(),
 		AddressesToReveal: []string{aliceAccountAddress},
-		Password:          accountPassword,
 		AirdropAddress:    aliceAccountAddress,
 	}
-	joinCommunity(suite, community, base.GetControlNode(), base.GetMember(), request)
+	joinCommunity(suite, community, base.GetControlNode(), base.GetMember(), request, accountPassword)
 	refreshMessengerResponses(base)
 
 	// grant permissions to the event sender
@@ -426,7 +424,6 @@ func setUpOnRequestCommunityAndRoles(base CommunityEventsTestsInterface, role pr
 		CommunityID:       community.ID(),
 		AddressesToReveal: []string{eventsSenderAccountAddress},
 		ENSName:           "eventSender",
-		Password:          accountPassword,
 		AirdropAddress:    eventsSenderAccountAddress,
 	}
 
@@ -436,7 +433,6 @@ func setUpOnRequestCommunityAndRoles(base CommunityEventsTestsInterface, role pr
 		CommunityID:       community.ID(),
 		AddressesToReveal: []string{aliceAccountAddress},
 		ENSName:           "alice",
-		Password:          accountPassword,
 		AirdropAddress:    aliceAccountAddress,
 	}
 	joinOnRequestCommunity(s, community, base.GetControlNode(), base.GetMember(), requestMember)
@@ -2040,7 +2036,6 @@ func testJoinedPrivilegedMemberReceiveRequestsToJoin(base CommunityEventsTestsIn
 		CommunityID:       community.ID(),
 		AddressesToReveal: []string{bobAccountAddress},
 		ENSName:           "bob",
-		Password:          accountPassword,
 		AirdropAddress:    bobAccountAddress,
 	}
 
@@ -2050,7 +2045,6 @@ func testJoinedPrivilegedMemberReceiveRequestsToJoin(base CommunityEventsTestsIn
 		CommunityID:       community.ID(),
 		AddressesToReveal: []string{eventsSenderAccountAddress},
 		ENSName:           "newPrivilegedUser",
-		Password:          accountPassword,
 		AirdropAddress:    eventsSenderAccountAddress,
 	}
 
@@ -2118,7 +2112,6 @@ func testMemberReceiveRequestsToJoinAfterGettingNewRole(base CommunityEventsTest
 		CommunityID:       community.ID(),
 		AddressesToReveal: []string{aliceAccountAddress},
 		ENSName:           "alice",
-		Password:          accountPassword,
 		AirdropAddress:    aliceAccountAddress,
 	}
 
@@ -2128,7 +2121,6 @@ func testMemberReceiveRequestsToJoinAfterGettingNewRole(base CommunityEventsTest
 		CommunityID:       community.ID(),
 		AddressesToReveal: []string{bobAccountAddress},
 		ENSName:           "bob",
-		Password:          accountPassword,
 		AirdropAddress:    bobAccountAddress,
 	}
 
@@ -2138,7 +2130,6 @@ func testMemberReceiveRequestsToJoinAfterGettingNewRole(base CommunityEventsTest
 		CommunityID:       community.ID(),
 		AddressesToReveal: []string{eventsSenderAccountAddress},
 		ENSName:           "eventSender",
-		Password:          accountPassword,
 		AirdropAddress:    eventsSenderAccountAddress,
 	}
 

--- a/protocol/communities_messenger_signers_test.go
+++ b/protocol/communities_messenger_signers_test.go
@@ -95,7 +95,7 @@ func (s *MessengerCommunitiesSignersSuite) advertiseCommunityTo(controlNode *Mes
 
 func (s *MessengerCommunitiesSignersSuite) joinCommunity(controlNode *Messenger, community *communities.Community, user *Messenger) {
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
-	joinCommunity(&s.Suite, community, controlNode, user, request)
+	joinCommunity(&s.Suite, community, controlNode, user, request, "")
 }
 
 func (s *MessengerCommunitiesSignersSuite) joinOnRequestCommunity(controlNode *Messenger, community *communities.Community, user *Messenger) {

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -392,7 +392,7 @@ func (s *MessengerCommunitiesSuite) advertiseCommunityTo(community *communities.
 
 func (s *MessengerCommunitiesSuite) joinCommunity(community *communities.Community, owner *Messenger, user *Messenger) {
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
-	joinCommunity(&s.Suite, community, owner, user, request)
+	joinCommunity(&s.Suite, community, owner, user, request, "")
 }
 
 func (s *MessengerCommunitiesSuite) TestCommunityContactCodeAdvertisement() {
@@ -3246,7 +3246,7 @@ func (s *MessengerCommunitiesSuite) TestCommunityBanUserRequestToJoin() {
 
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
 	// We try to join the org
-	_, rtj, err := s.alice.communitiesManager.CreateRequestToJoin(&s.alice.identity.PublicKey, request)
+	rtj := s.alice.communitiesManager.CreateRequestToJoin(request)
 
 	s.Require().NoError(err)
 

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -34,7 +34,7 @@ func (s *MessengerActivityCenterMessageSuite) advertiseCommunityTo(community *co
 
 func (s *MessengerActivityCenterMessageSuite) joinCommunity(community *communities.Community, owner *Messenger, user *Messenger) {
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
-	joinCommunity(&s.Suite, community, owner, user, request)
+	joinCommunity(&s.Suite, community, owner, user, request, "")
 }
 
 type MessengerActivityCenterMessageSuite struct {

--- a/protocol/messenger_delete_message_for_everyone_test.go
+++ b/protocol/messenger_delete_message_for_everyone_test.go
@@ -74,10 +74,10 @@ func (s *MessengerDeleteMessageForEveryoneSuite) TestDeleteMessageForEveryone() 
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
 
 	advertiseCommunityTo(&s.Suite, community, s.admin, s.moderator)
-	joinCommunity(&s.Suite, community, s.admin, s.moderator, request)
+	joinCommunity(&s.Suite, community, s.admin, s.moderator, request, "")
 
 	advertiseCommunityTo(&s.Suite, community, s.admin, s.bob)
-	joinCommunity(&s.Suite, community, s.admin, s.bob, request)
+	joinCommunity(&s.Suite, community, s.admin, s.bob, request, "")
 
 	response, err := s.admin.AddRoleToMember(&requests.AddRoleToMember{
 		CommunityID: community.ID(),

--- a/protocol/messenger_send_images_album_test.go
+++ b/protocol/messenger_send_images_album_test.go
@@ -69,7 +69,7 @@ func (s *MessengerSendImagesAlbumSuite) advertiseCommunityTo(community *communit
 
 func (s *MessengerSendImagesAlbumSuite) joinCommunity(community *communities.Community, user *Messenger) {
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
-	joinCommunity(&s.Suite, community, s.m, user, request)
+	joinCommunity(&s.Suite, community, s.m, user, request, "")
 }
 
 func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesSend() {

--- a/protocol/requests/edit_shared_addresses.go
+++ b/protocol/requests/edit_shared_addresses.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"errors"
 
+	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 )
 
@@ -10,26 +11,45 @@ var ErrInvalidCommunityID = errors.New("invalid community id")
 var ErrMissingPassword = errors.New("password is necessary when sending a list of addresses")
 var ErrMissingSharedAddresses = errors.New("list of shared addresses is needed")
 var ErrMissingAirdropAddress = errors.New("airdropAddress is needed")
+var ErrNoAirdropAddressAmongAddressesToReveal = errors.New("airdropAddress must be in the set of addresses to reveal")
+var ErrInvalidSignature = errors.New("invalid signature")
 
 type EditSharedAddresses struct {
-	CommunityID       types.HexBytes `json:"communityId"`
-	Password          string         `json:"password"`
-	AddressesToReveal []string       `json:"addressesToReveal"`
-	AirdropAddress    string         `json:"airdropAddress"`
+	CommunityID       types.HexBytes   `json:"communityId"`
+	AddressesToReveal []string         `json:"addressesToReveal"`
+	Signatures        []types.HexBytes `json:"signatures"` // the order of signatures should match the order of addresses
+	AirdropAddress    string           `json:"airdropAddress"`
 }
 
 func (j *EditSharedAddresses) Validate() error {
 	if len(j.CommunityID) == 0 {
 		return ErrInvalidCommunityID
 	}
-	if j.Password == "" {
-		return ErrMissingPassword
-	}
+
 	if len(j.AddressesToReveal) == 0 {
 		return ErrMissingSharedAddresses
 	}
+
 	if j.AirdropAddress == "" {
 		return ErrMissingAirdropAddress
+	}
+
+	found := false
+	for _, address := range j.AddressesToReveal {
+		if address == j.AirdropAddress {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return ErrNoAirdropAddressAmongAddressesToReveal
+	}
+
+	for _, signature := range j.Signatures {
+		if len(signature) > 0 && len(signature) != crypto.SignatureLength {
+			return ErrInvalidSignature
+		}
 	}
 
 	return nil

--- a/protocol/requests/request_to_join_community.go
+++ b/protocol/requests/request_to_join_community.go
@@ -3,30 +3,62 @@ package requests
 import (
 	"errors"
 
+	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 )
 
 var ErrRequestToJoinCommunityInvalidCommunityID = errors.New("request-to-join-community: invalid community id")
+var ErrRequestToJoinCommunityNoAddressesToReveal = errors.New("request-to-join-community: no addresses to reveal")
 var ErrRequestToJoinCommunityMissingPassword = errors.New("request-to-join-community: password is necessary when sending a list of addresses")
 var ErrRequestToJoinNoAirdropAddress = errors.New("request-to-join-community: airdropAddress is necessary when sending a list of addresses")
+var ErrRequestToJoinNoAirdropAddressAmongAddressesToReveal = errors.New("request-to-join-community: airdropAddress must be in the set of addresses to reveal")
+var ErrRequestToJoinCommunityInvalidSignature = errors.New("request-to-join-community: invalid signature")
 
 type RequestToJoinCommunity struct {
-	CommunityID       types.HexBytes `json:"communityId"`
-	ENSName           string         `json:"ensName"`
-	Password          string         `json:"password"`
-	AddressesToReveal []string       `json:"addressesToReveal"`
-	AirdropAddress    string         `json:"airdropAddress"`
+	CommunityID       types.HexBytes   `json:"communityId"`
+	ENSName           string           `json:"ensName"`
+	AddressesToReveal []string         `json:"addressesToReveal"`
+	Signatures        []types.HexBytes `json:"signatures"` // the order of signatures should match the order of addresses
+	AirdropAddress    string           `json:"airdropAddress"`
 }
 
-func (j *RequestToJoinCommunity) Validate() error {
+func (j *RequestToJoinCommunity) Validate(full bool) error {
+	// TODO: A parital validation, in case `full` is set to `false` should check `AddressesToReveal` as well. But because of changes
+	//       that need to be done in tests we cannot do that now.
+	//       Also in the line 61, we should remove `len(signature) > 0` from the condition, but from the same reason we cannot do that now.
+
 	if len(j.CommunityID) == 0 {
 		return ErrRequestToJoinCommunityInvalidCommunityID
 	}
-	if len(j.AddressesToReveal) > 0 && j.Password == "" {
-		return ErrRequestToJoinCommunityMissingPassword
+
+	if !full {
+		return nil
 	}
-	if len(j.AddressesToReveal) > 0 && j.AirdropAddress == "" {
+
+	if len(j.AddressesToReveal) == 0 {
+		return ErrRequestToJoinCommunityNoAddressesToReveal
+	}
+
+	if j.AirdropAddress == "" {
 		return ErrRequestToJoinNoAirdropAddress
+	}
+
+	found := false
+	for _, address := range j.AddressesToReveal {
+		if address == j.AirdropAddress {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return ErrRequestToJoinNoAirdropAddressAmongAddressesToReveal
+	}
+
+	for _, signature := range j.Signatures {
+		if len(signature) > 0 && len(signature) != crypto.SignatureLength {
+			return ErrRequestToJoinCommunityInvalidSignature
+		}
 	}
 
 	return nil

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/services/browsers"
 	"github.com/status-im/status-go/services/wallet"
 	"github.com/status-im/status-go/services/wallet/bigint"
@@ -584,6 +585,27 @@ func (api *PublicAPI) DeclinedRequestsToJoinForCommunity(id types.HexBytes) ([]*
 // CanceledRequestsToJoinForCommunity returns the declined requests to join for a given community
 func (api *PublicAPI) CanceledRequestsToJoinForCommunity(id types.HexBytes) ([]*communities.RequestToJoin, error) {
 	return api.service.messenger.CanceledRequestsToJoinForCommunity(id)
+}
+
+// Generates a single hash for each address that needs to be revealed to a community.
+// Each hash needs to be signed.
+// The order of retuned hashes corresponds to the order of addresses in addressesToReveal.
+func (api *PublicAPI) GenerateJoiningCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]account.SignParams, error) {
+	return api.service.messenger.GenerateJoiningCommunityRequestsForSigning(memberPubKey, communityID, addressesToReveal)
+}
+
+// Generates a single hash for each address that needs to be revealed to a community.
+// Each hash needs to be signed.
+// The order of retuned hashes corresponds to the order of addresses in addressesToReveal.
+func (api *PublicAPI) GenerateEditCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]account.SignParams, error) {
+	return api.service.messenger.GenerateEditCommunityRequestsForSigning(memberPubKey, communityID, addressesToReveal)
+}
+
+// Signs the provided messages with the provided accounts and password.
+// Provided accounts must not belong to a keypair that is migrated to a keycard.
+// Otherwise, the signing will fail, cause such accounts should be signed with a keycard.
+func (api *PublicAPI) SignData(signParams []account.SignParams) ([]string, error) {
+	return api.service.messenger.SignData(signParams)
 }
 
 // CancelRequestToJoinCommunity accepts a pending request to join a community


### PR DESCRIPTION
These changes introduce support for signing a join/edit community request independently from submitting that request. That lets the client decide where wants to sign the request and once it's signed he's able to submit it.

What is basically done here is splitting the code into 3 parts:
1. preparing request (data that need to be signed)
2. signing data (that can be done either on the status-go side or any other side)
3. submitting request