### PR TITLE
Feat/wait on signaled messenger response

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -363,8 +363,9 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 						m.logger.Error("failed to save data and prepare response")
 					}
 
-					signal.SendNewMessages(response)
-
+					if m.config.messengerSignalsHandler != nil {
+						m.config.messengerSignalsHandler.MessengerResponse(response)
+					}
 				}
 
 			case <-ticker.C:


### PR DESCRIPTION
- chore: add `WaitOnSignaledMessengerResponse` test utility
- fix: use `messengerSignalsHandler` instead of global object