### PR TITLE
make lint-fix ignore for messenger_handlers.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,7 @@ lint-fix:
 		-and -not -name '*.pb.go' \
 		-and -not -name 'bindata*' \
 		-and -not -name 'migrations.go' \
+		-and -not -name 'messenger_handlers.go' \
 		-and -not -wholename '*/vendor/*' \
 		-exec goimports \
 		-local 'github.com/ethereum/go-ethereum,github.com/status-im/status-go,github.com/status-im/markdown' \

--- a/protocol/messenger_linkpreview.go
+++ b/protocol/messenger_linkpreview.go
@@ -8,9 +8,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/status-im/markdown"
 	"go.uber.org/zap"
 	"golang.org/x/net/publicsuffix"
+
+	"github.com/status-im/markdown"
 
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/common"


### PR DESCRIPTION
we should make `lint-fix` ignore file `messenger_handlers.go` since it's generated automatically, i don't want see it shows on my git `changelist` after `make lint-fix` 