### PR TITLE
fix: SetSignerPublicKey return address with 0x prefix

### DIFF
--- a/eth-node/types/bytes.go
+++ b/eth-node/types/bytes.go
@@ -39,3 +39,8 @@ func Hex2Bytes(str string) []byte {
 	h, _ := hex.DecodeString(str)
 	return h
 }
+
+// ToHex returns the hex string representation of bytes with 0x prefix.
+func ToHex(bytes []byte) string {
+	return "0x" + Bytes2Hex(bytes)
+}

--- a/services/communitytokens/service.go
+++ b/services/communitytokens/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/contracts/community-tokens/ownertoken"
 	communityownertokenregistry "github.com/status-im/status-go/contracts/community-tokens/registry"
+	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/services/utils"
@@ -104,7 +105,8 @@ func (s *Service) GetSignerPubKey(ctx context.Context, chainID uint64, contractA
 	if err != nil {
 		return "", err
 	}
-	return common.Bytes2Hex(signerPubKey), nil
+
+	return types.ToHex(signerPubKey), nil
 }
 
 func (s *Service) SafeGetSignerPubKey(ctx context.Context, chainID uint64, communityID string) (string, error) {


### PR DESCRIPTION
SetSignerPublicKey returned PubKey as a string without `0x` prefix before
This lead to converting string -> PubKey error
