### PR TITLE
fix: set pubsubTopic in request community info from mailserver

### DIFF
--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -112,8 +112,8 @@ func (m *Messenger) connectToNewMailserverAndWait() error {
 
 func (m *Messenger) performMailserverRequest(fn func() (*MessengerResponse, error)) (*MessengerResponse, error) {
 
-	m.mailserverCycle.Lock()
-	defer m.mailserverCycle.Unlock()
+	m.mailserverCycle.RLock()
+	defer m.mailserverCycle.RUnlock()
 	var tries uint = 0
 	for tries < mailserverMaxTries {
 		if !m.isActiveMailserverAvailable() {
@@ -134,6 +134,12 @@ func (m *Messenger) performMailserverRequest(fn func() (*MessengerResponse, erro
 			activeMailserver.FailedRequests = 0
 			return response, nil
 		}
+
+		m.logger.Error("failed to perform mailserver request",
+			zap.String("mailserverID", activeMailserver.ID),
+			zap.Uint("tries", tries),
+			zap.Error(err),
+		)
 
 		tries++
 		// Increment failed requests


### PR DESCRIPTION
Partially fixes https://github.com/status-im/status-desktop/issues/12465
A more proper and general should be done later: https://github.com/status-im/status-go/issues/4192

1. Set `PubsubTopic` in the created `MailserverBatch`
2. In `requestCommunitiesFromMailserver` make several requests, one for each `PubsubTopic`
3. Lock `mailserverCycle` for reading only during `performMailserverRequest`
4. defer call `forgetCommunityRequest` in `requestCommunitiesFromMailserver`