### PR TITLE
[#3833] Increase intreval of new blocks detection command

### DIFF
--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -23,7 +23,10 @@ type findNewBlocksCommand struct {
 
 func (c *findNewBlocksCommand) Command() async.Command {
 	return async.InfiniteCommand{
-		Interval: 13 * time.Second, // TODO - make it configurable based on chain block mining time
+		// TODO - make it configurable based on chain block mining time
+		// NOTE(rasom): ^ it is unclear why each block has to be checked,
+		// that is rather undesirable, as it causes a lot of RPC requests
+		Interval: 2 * time.Minute,
 		Runable:  c.Run,
 	}.Run
 }


### PR DESCRIPTION
related to #3833

currently an idle RPC load on a newly created multipack with a single wallet acc and single network looks like this
```Clojure
;; => {:total 1883,
;;     :methods
;;     ([:eth_FilterLogs 556]
;;      [:eth_CallContract 453]
;;      [:eth_HeaderByNumber 282]
;;      [:eth_BalanceAt 278]
;;      [:eth_NonceAt 278]
;;      [:eth_CodeAt 18]
;;      [:eth_BlockNumber 18])}
```
of which all calls except `eth_CallContract` are idle load of the routine which looks for new blocks with transfers, 1430 requests per hour, ~34k requests per day. By increasing routine's interval to 2m from 13s we reduce the number of requests around 8-10 times, depends on network

```Clojure
;; => {:total 635,
;;     :methods
;;     ([:eth_CallContract 442]
;;      [:eth_FilterLogs 60]
;;      [:eth_HeaderByNumber 36]
;;      [:eth_BalanceAt 31]
;;      [:eth_NonceAt 30]
;;      [:eth_CodeAt 18]
;;      [:eth_BlockNumber 18])}
```
of which 193 calls are related to the routine, projects to ~4.6k requests per day.

That is still a lot, but there are other ways to improve this number without changing the interval.

The cons is that in the worst case a new transfer will be detected with 2 minutes delay (comparing to 13s at the moment), but in most cases it is acceptable and if necessary can be adjusted in some specific situations (like sending of tx initiated by the user or additional scan initiated by opening wallet tab, etc).

status: ready