### PR TITLE
feat: new deeplink status-im->status-app

### DIFF
--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/status-im/status-go/deprecation"
@@ -16,6 +17,7 @@ import (
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
+	"github.com/status-im/status-go/services/utils"
 )
 
 var chatColors = []string{
@@ -501,18 +503,30 @@ func CreateCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, 
 
 func (c *Chat) DeepLink() string {
 	if c.OneToOne() {
-		return "status-im://p/" + c.ID
+		return "status-app://p/" + c.ID
 	}
 	if c.PrivateGroupChat() {
-		return "status-im://g/args?a2=" + c.ID
+		return "status-app://g/args?a2=" + c.ID
 	}
 
 	if c.CommunityChat() {
-		return "status-im://cc/" + c.ID
+		communityChannelID := strings.TrimPrefix(c.ID, c.CommunityID)
+		pubkey, err := types.DecodeHex(c.CommunityID)
+		if err != nil {
+			return ""
+		}
+
+		serializedCommunityID, err := utils.SerializePublicKey(pubkey)
+
+		if err != nil {
+			return ""
+		}
+
+		return "status-app://cc/" + communityChannelID + "#" + serializedCommunityID
 	}
 
 	if c.Public() {
-		return "status-im://" + c.ID
+		return "status-app://" + c.ID
 	}
 
 	return ""

--- a/protocol/chat_test.go
+++ b/protocol/chat_test.go
@@ -162,3 +162,13 @@ func (s *ChatTestSuite) TestUpdateFirstMessageTimestamp() {
 	setAndCheck(FirstMessageTimestampNoMessage, false, 200)
 	setAndCheck(100, true, 100)
 }
+
+func (s *ChatTestSuite) TestDeepLink() {
+	chat := &Chat{
+		CommunityID: "0x02b1188c997e666cd5505ffd5c4b5fdbe3084b78a486d8e709da3b32ad3708a89e",
+		ID:          "0x02b1188c997e666cd5505ffd5c4b5fdbe3084b78a486d8e709da3b32ad3708a89ec432709e-fc73-440d-bb67-cb3a0929dfda",
+		ChatType:    ChatTypeCommunityChat,
+	}
+
+	s.Require().Equal(chat.DeepLink(), "status-app://cc/c432709e-fc73-440d-bb67-cb3a0929dfda#zQ3shZL6dXiFCbDyxnXxwQa9v8QFC2q19subFtyxd7kVszMVo")
+}

--- a/protocol/local_notifications.go
+++ b/protocol/local_notifications.go
@@ -156,7 +156,7 @@ func (n NotificationBody) toCommunityRequestToJoinNotification(id string) *local
 		Message:  n.Contact.PrimaryName() + " wants to join  message " + n.Community.Name(),
 		BodyType: localnotifications.TypeMessage,
 		Category: localnotifications.CategoryCommunityRequestToJoin,
-		Deeplink: "status-im://cr/" + n.Community.IDString(),
+		Deeplink: "status-app://cr/" + n.Community.IDString(),
 		Image:    "",
 	}
 }

--- a/protocol/messenger_share_urls.go
+++ b/protocol/messenger_share_urls.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	"github.com/status-im/status-go/api/multiformat"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
@@ -52,20 +51,7 @@ const baseShareURL = "https://status.app"
 const channelUUIDRegExp = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$"
 
 func (m *Messenger) SerializePublicKey(compressedKey types.HexBytes) (string, error) {
-	rawKey, err := crypto.DecompressPubkey(compressedKey)
-	if err != nil {
-		return "", err
-	}
-	pubKey := types.EncodeHex(crypto.FromECDSAPub(rawKey))
-
-	secp256k1Code := "0xe701"
-	base58btc := "z"
-	multiCodecKey := secp256k1Code + strings.TrimPrefix(pubKey, "0x")
-	cpk, err := multiformat.SerializePublicKey(multiCodecKey, base58btc)
-	if err != nil {
-		return "", err
-	}
-	return cpk, nil
+	return utils.SerializePublicKey(compressedKey)
 }
 
 func (m *Messenger) DeserializePublicKey(compressedKey string) (types.HexBytes, error) {

--- a/services/local-notifications/transaction.go
+++ b/services/local-notifications/transaction.go
@@ -18,7 +18,7 @@ import (
 type transactionState string
 
 const (
-	walletDeeplinkPrefix = "status-im://wallet/"
+	walletDeeplinkPrefix = "status-app://wallet/"
 
 	failed   transactionState = "failed"
 	inbound  transactionState = "inbound"

--- a/services/utils/utils.go
+++ b/services/utils/utils.go
@@ -41,3 +41,20 @@ func DeserializePublicKey(compressedKey string) (types.HexBytes, error) {
 
 	return crypto.CompressPubkey(pubKey), nil
 }
+
+func SerializePublicKey(compressedKey types.HexBytes) (string, error) {
+	rawKey, err := crypto.DecompressPubkey(compressedKey)
+	if err != nil {
+		return "", err
+	}
+	pubKey := types.EncodeHex(crypto.FromECDSAPub(rawKey))
+
+	secp256k1Code := "0xe701"
+	base58btc := "z"
+	multiCodecKey := secp256k1Code + strings.TrimPrefix(pubKey, "0x")
+	cpk, err := multiformat.SerializePublicKey(multiCodecKey, base58btc)
+	if err != nil {
+		return "", err
+	}
+	return cpk, nil
+}


### PR DESCRIPTION
1. `status-im` -> `status-app`
1. `status-app://cc/` -> `status-app://ccm/`
`cc/` is for community channel in the spec https://github.com/vacp2p/rfc/pull/602/files#diff-497acddee81a09a3aa6fb5a2aa0d0585a3ac9a9628ae0e9d4855b77309a5e7cb 
but it's community chat message for mobile, so I moved old `cc/` to `ccm/`