### PR TITLE
fix: Add network id for multi tx

### DIFF
--- a/services/wallet/transfer/transaction.go
+++ b/services/wallet/transfer/transaction.go
@@ -302,6 +302,9 @@ func (tm *TransactionManager) CreateMultiTransactionFromCommand(ctx context.Cont
 	for _, tx := range data {
 		chainIDs = append(chainIDs, tx.ChainID)
 	}
+	if multiTransaction.Type == MultiTransactionSend && multiTransaction.FromNetworkID == 0 && len(chainIDs) == 1 {
+		multiTransaction.FromNetworkID = chainIDs[0]
+	}
 	multiTransactionID, err := tm.insertMultiTransactionAndNotify(tm.db, multiTransaction, chainIDs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fixes https://github.com/status-im/status-desktop/issues/12495
fixes https://github.com/status-im/status-desktop/issues/12506

Send done by Status desktop is marked as multi tx and network id wasn't populated.
This won't fix previous transactions in database and only work on ones done since that fix.

Missing network id was also cause of not displaying progress bar as app didn't know which network it is.

![image](https://github.com/status-im/status-go/assets/11396062/9d4da3f4-a121-4d58-9954-b9c344b48a78)

![image](https://github.com/status-im/status-go/assets/11396062/f293f06b-a716-4ebe-9a13-267496c42cd4)

