### PR TITLE
chore(messenger_communities): use new name for community Access

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4157,7 +4157,7 @@ func (m *Messenger) RequestImportDiscordChannel(request *requests.ImportDiscordC
 
 				communityChat := &protobuf.CommunityChat{
 					Permissions: &protobuf.CommunityPermissions{
-						Access: protobuf.CommunityPermissions_NO_MEMBERSHIP,
+						Access: protobuf.CommunityPermissions_AUTO_ACCEPT,
 					},
 					Identity: &protobuf.ChatIdentity{
 						DisplayName: request.Name,


### PR DESCRIPTION
A little oopsie from a rebase probably
