### PR TITLE
Fix: allow zero tx

### DIFF
--- a/services/wallet/router.go
+++ b/services/wallet/router.go
@@ -627,13 +627,15 @@ func (r *Router) suggestedRoutes(
 					if err != nil {
 						continue
 					}
-					if maxAmountIn.ToInt().Cmp(amountIn) >= 0 {
-						if bonderFees.Cmp(amountIn) >= 0 {
-							continue
-						}
-					} else {
-						if bonderFees.Cmp(maxAmountIn.ToInt()) >= 0 {
-							continue
+					if bonderFees.Cmp(zero) != 0 {
+						if maxAmountIn.ToInt().Cmp(amountIn) >= 0 {
+							if bonderFees.Cmp(amountIn) >= 0 {
+								continue
+							}
+						} else {
+							if bonderFees.Cmp(maxAmountIn.ToInt()) >= 0 {
+								continue
+							}
 						}
 					}
 					gasLimit := uint64(0)


### PR DESCRIPTION
If bonder fees are 0 there is no need to check if  bonder fees are bigger or equal to amount to prevent impossible transaction
