### PR TITLE
fix(ImageUnfurler): set title for image links

### DIFF
--- a/protocol/linkpreview_unfurler_image.go
+++ b/protocol/linkpreview_unfurler_image.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	neturl "net/url"
+	"path"
 	"regexp"
 
 	"go.uber.org/zap"
@@ -105,6 +106,7 @@ func (u *ImageUnfurler) Unfurl() (*common.LinkPreview, error) {
 		return preview, fmt.Errorf("could not build data URI url='%s': %w", u.url.String(), err)
 	}
 
+	preview.Title = path.Base(u.url.Path)
 	preview.Thumbnail.Width = width
 	preview.Thumbnail.Height = height
 	preview.Thumbnail.DataURI = dataURI

--- a/protocol/messenger_linkpreview_test.go
+++ b/protocol/messenger_linkpreview_test.go
@@ -356,7 +356,7 @@ func (s *MessengerLinkPreviewsTestSuite) Test_UnfurlURLs_Image() {
 		Type:        protobuf.UnfurledLink_IMAGE,
 		URL:         u,
 		Hostname:    "placehold.co",
-		Title:       "",
+		Title:       "600x400@3x.png",
 		Description: "",
 		Thumbnail: common.LinkPreviewThumbnail{
 			Width:   1293,


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12479

`ImageUnfurler` is now setting the `Title` field of the previews as the last part of the link.

Design: https://www.figma.com/file/Mr3rqxxgKJ2zMQ06UAKiWL/%F0%9F%92%AC-Chat%E2%8E%9CDesktop?type=design&node-id=22347-218121&mode=design&t=CE68IwnhoZ2StTc0-4

![image](https://github.com/status-im/status-go/assets/25482501/fab1d3f9-aaab-49c0-abd0-69440f9282ec)
