### PR TITLE
fix(community): getting kicked out of a community should still spectate

### DIFF
--- a/protocol/communities/community_changes.go
+++ b/protocol/communities/community_changes.go
@@ -42,9 +42,8 @@ type CommunityChanges struct {
 	// automatically
 	ShouldMemberJoin bool `json:"memberAdded"`
 
-	// ShouldMemberJoin indicates whether the user should leave this community
-	// automatically
-	ShouldMemberLeave bool `json:"memberRemoved"`
+	// MemberKicked indicates whether the user has been kicked out
+	MemberKicked bool `json:"memberRemoved"`
 }
 
 func EmptyCommunityChanges() *CommunityChanges {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1699,7 +1699,7 @@ func (m *Messenger) LeaveCommunity(communityID types.HexBytes) (*MessengerRespon
 		return nil, err
 	}
 
-	mr, err := m.leaveCommunity(communityID, true)
+	mr, err := m.leaveCommunity(communityID)
 	if err != nil {
 		return nil, err
 	}
@@ -1753,7 +1753,7 @@ func (m *Messenger) LeaveCommunity(communityID types.HexBytes) (*MessengerRespon
 	return mr, nil
 }
 
-func (m *Messenger) leaveCommunity(communityID types.HexBytes, unsubsribeFromCommunity bool) (*MessengerResponse, error) {
+func (m *Messenger) leaveCommunity(communityID types.HexBytes) (*MessengerResponse, error) {
 	response := &MessengerResponse{}
 
 	community, err := m.communitiesManager.LeaveCommunity(communityID)
@@ -1776,11 +1776,21 @@ func (m *Messenger) leaveCommunity(communityID types.HexBytes, unsubsribeFromCom
 		}
 	}
 
-	if unsubsribeFromCommunity {
-		_, err = m.transport.RemoveFilterByChatID(communityID.String())
-		if err != nil {
-			return nil, err
-		}
+	_, err = m.transport.RemoveFilterByChatID(communityID.String())
+	if err != nil {
+		return nil, err
+	}
+
+	response.AddCommunity(community)
+	return response, nil
+}
+
+func (m *Messenger) kickedOutOfCommunity(communityID types.HexBytes) (*MessengerResponse, error) {
+	response := &MessengerResponse{}
+
+	community, err := m.communitiesManager.KickedOutOfCommunity(communityID)
+	if err != nil {
+		return nil, err
 	}
 
 	response.AddCommunity(community)
@@ -3230,7 +3240,7 @@ func (m *Messenger) handleSyncInstallationCommunity(messageState *ReceivedMessag
 				return err
 			}
 		} else {
-			mr, err = m.leaveCommunity(syncCommunity.Id, true)
+			mr, err = m.leaveCommunity(syncCommunity.Id)
 			if err != nil {
 				logger.Debug("m.leaveCommunity error", zap.Error(err))
 				return err
@@ -5877,12 +5887,8 @@ func (m *Messenger) processCommunityChanges(messageState *ReceivedMessageState) 
 				continue
 			}
 
-		} else if changes.ShouldMemberLeave {
-			// this means we've been kicked by the community owner/admin,
-			// in this case we don't want to unsubscribe from community updates
-			// so we still get notified accordingly when something changes,
-			// hence, we're setting `unsubscribeFromCommunity` to `false` here
-			response, err := m.leaveCommunity(changes.Community.ID(), false)
+		} else if changes.MemberKicked {
+			response, err := m.kickedOutOfCommunity(changes.Community.ID())
 			if err != nil {
 				m.logger.Error("cannot leave community", zap.Error(err))
 				continue


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12558

When getting kicked out of  a community, before we used to leave the community completely, but just keep the filters on. That created a problem when reopening the app, because the community disappeared and could even create a problem in desktop where it tried to open the last opened community but it's no longer there.

The fix now is that when getting kicked out, we instead just remove ourselves from the community and set Joined to false, but we keep the community spectated.
