### PR TITLE
mvp ssdp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,8 @@ require (
 
 require github.com/fogleman/gg v1.3.0
 
+require github.com/koron/go-ssdp v0.0.4
+
 require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/andybalholm/brotli v1.0.5
@@ -174,7 +176,6 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
-	github.com/koron/go-ssdp v0.0.4 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
 	github.com/libp2p/go-cidranger v1.1.0 // indirect

--- a/server/pairing/ssdp_consumer.go
+++ b/server/pairing/ssdp_consumer.go
@@ -1,0 +1,86 @@
+package pairing
+
+import (
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/koron/go-ssdp"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/logutils"
+)
+
+var ssdpConsumerOnce sync.Once
+
+func StartSsdpConsumer(quit <-chan struct{}) <-chan ssdp.Service {
+	result := make(chan ssdp.Service, 1)
+	ssdpConsumerOnce.Do(func() {
+		go startSsdpConsumer(quit, result)
+	})
+	return result
+}
+
+func startSsdpConsumer(quit <-chan struct{}, result chan<- ssdp.Service) {
+	logger := logutils.ZapLogger().Named("ssdp consumer")
+	logger.Info("Starting ssdp consumer")
+
+	var services []ssdp.Service
+	var err error
+	i := 1
+	for {
+		select {
+		case <-quit:
+			logger.Info("[ssdp consumer] quit")
+			return
+		default:
+			logger.Info("[ssdp consumer] searching for services", zap.Int("searching times", i))
+			services, err = ssdp.Search(st, 1, "")
+			if err != nil {
+				logger.Error("[ssdp consumer] error when search", zap.Error(err))
+			}
+			if len(services) > 0 {
+				logger.Info("[ssdp consumer] found services", zap.Any("services", services))
+
+				serviceMap := map[string]ssdp.Service{}
+				for _, service := range services {
+					serviceMap[service.USN] = service
+				}
+
+				c := http.Client{Timeout: time.Second}
+
+				successCh := make(chan ssdp.Service, 1)
+				for _, service := range serviceMap {
+					go func(service ssdp.Service) {
+						resp, err := c.Get(service.Location)
+						if err != nil {
+							logger.Error("[ssdp consumer] error when request server", zap.String("location", service.Location), zap.Error(err))
+							return
+						}
+						defer resp.Body.Close()
+						content, err := io.ReadAll(resp.Body)
+						if err != nil {
+							logger.Error("[ssdp consumer] error when read response body", zap.String("location", service.Location), zap.Error(err))
+							return
+						}
+						logger.Info("[ssdp consumer] request server success", zap.String("location", service.Location), zap.String("content", string(content)))
+						successCh <- service
+					}(service)
+				}
+
+				timeout := time.After(maxAge * time.Second)
+				select {
+				case service := <-successCh:
+					logger.Info("[ssdp consumer] found available service", zap.String("usn", service.USN), zap.String("location", service.Location))
+					result <- service
+					return
+				case <-timeout:
+					logger.Info("[ssdp consumer] timeout when searching available service")
+				}
+			}
+		}
+
+	}
+
+}

--- a/server/pairing/ssdp_provider.go
+++ b/server/pairing/ssdp_provider.go
@@ -1,0 +1,125 @@
+package pairing
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/koron/go-ssdp"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/logutils"
+	"github.com/status-im/status-go/server"
+)
+
+const st = "urn:service:localPairProvider"
+
+var ssdpProviderOnce sync.Once
+var sendAlivePeriod = time.Duration(3)
+var maxAge = time.Duration(600)
+
+// StartSsdpProvider starts SSDP server
+// for the MVP, this should only be called on mobile since mobile network has less restriction
+// to be simple, we start SSDP provider only once
+func StartSsdpProvider(quit <-chan struct{}) {
+	go startSsdpProvider(quit)
+}
+
+func startSsdpProvider(quit <-chan struct{}) {
+	ssdpProviderOnce.Do(func() {
+		logger := logutils.ZapLogger().Named("ssdp provider")
+		logger.Info("Starting ssdp provider")
+
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			_, err := w.Write([]byte("Hello World!"))
+			if err != nil {
+				logger.Error("[ssdp provider] http server error when write", zap.Error(err))
+			}
+		})
+		//TODO we can add a handler for /startTime to return the time when the server started
+		// so client can know when the service expires
+
+		// Create a listener on a random port.
+		listener, err := net.Listen("tcp", "0.0.0.0:0")
+		if err != nil {
+			logger.Error("[ssdp provider] http server error when listen", zap.Error(err))
+		}
+
+		// Get the actual port used by the listener.
+		tcpAddr := listener.Addr().(*net.TCPAddr)
+		logger.Info("[ssdp provider] http server is listening", zap.Int("port", tcpAddr.Port))
+
+		// Use the listener with http.Serve.
+		go func() {
+			if err := http.Serve(listener, nil); err != nil {
+				logger.Error("[ssdp provider] http server error when serve", zap.Error(err))
+			}
+		}()
+
+		ips, err := server.GetLocalAddressesForPairingServer()
+		if err != nil {
+			logger.Error("[ssdp provider] error when get local addresses", zap.Error(err))
+		}
+		logger.Info("[ssdp provider] local addresses", zap.Any("ips", ips))
+
+		deviceName, err := server.GetDeviceName()
+		if err != nil {
+			logger.Error("[ssdp provider] error when get device name", zap.Error(err))
+		}
+		for _, ip := range ips {
+			go func(ip net.IP) { // Make sure to capture the loop variable
+				usn := uuid.New().String()
+				location := fmt.Sprintf("http://%s:%d/", ip.String(), tcpAddr.Port)
+				ad, err := ssdp.Advertise(
+					st,
+					usn,
+					location,
+					deviceName,
+					int(maxAge))
+				if err != nil {
+					logger.Error("[ssdp provider] error when advertise", zap.Error(err))
+					return
+				}
+				logger.Info("[ssdp provider] advertise success", zap.String("usn", usn), zap.String("location", location))
+
+				// Start the timer for sending the Alive() signal periodically
+				ticker := time.NewTicker(sendAlivePeriod * time.Second)
+				// Set a timeout for when to send the Bye() signal and close the advertiser
+				timeout := time.After(maxAge * time.Second)
+				handleShutdown := func() {
+					logger.Info("[ssdp provider] shutdown")
+					ticker.Stop()
+					if err := listener.Close(); err != nil {
+						logger.Error("msg: [ssdp provider] error when close http server listener", zap.Error(err))
+					}
+					if err := ad.Bye(); err != nil {
+						logger.Error("msg: [ssdp provider] error when send bye", zap.Error(err))
+					}
+					if err := ad.Close(); err != nil {
+						logger.Error("msg: [ssdp provider] error when close", zap.Error(err))
+					}
+				}
+				for {
+					select {
+					case <-ticker.C:
+						// Send alive signal to refresh advertisement
+						err = ad.Alive()
+						if err != nil {
+							logger.Error("[ssdp provider] error when send alive", zap.Error(err))
+						}
+					case <-timeout:
+						handleShutdown()
+						return
+					case <-quit:
+						handleShutdown()
+						return
+					}
+				}
+			}(ip)
+		}
+
+	})
+}

--- a/server/pairing/ssdp_test.go
+++ b/server/pairing/ssdp_test.go
@@ -1,0 +1,46 @@
+package pairing
+
+import (
+	"testing"
+	"time"
+)
+
+// run this test assumes provider/consumer are running on the same device
+func TestSsdp(t *testing.T) {
+	quitProvider := make(chan struct{}, 1)
+	StartSsdpProvider(quitProvider)
+	quitConsumer := make(chan struct{}, 1)
+	result := StartSsdpConsumer(quitConsumer)
+	timeout := time.After(30 * time.Second)
+	select {
+	case service := <-result:
+		t.Log("found available service with ssdp", service)
+	case <-timeout:
+		quitProvider <- struct{}{}
+		quitConsumer <- struct{}{}
+		t.Fatal("timeout when searching available service with ssdp")
+	}
+}
+
+// run this test on device A before running TestStartSsdpConsumer
+// device A and B should be on the same LAN
+func TestStartSsdpProvider(t *testing.T) {
+	quitProvider := make(chan struct{}, 1)
+	StartSsdpProvider(quitProvider)
+	// 1 minute should be enough to wait for TestStartSsdpConsumer to run, no? increase if needed
+	time.Sleep(60 * time.Second)
+}
+
+// run this test on device B
+func TestStartSsdpConsumer(t *testing.T) {
+	quitConsumer := make(chan struct{}, 1)
+	result := StartSsdpConsumer(quitConsumer)
+	timeout := time.After(10 * time.Second)
+	select {
+	case service := <-result:
+		t.Log("found available service with ssdp", service)
+	case <-timeout:
+		quitConsumer <- struct{}{}
+		t.Fatal("timeout when searching available service with ssdp")
+	}
+}


### PR DESCRIPTION
This PR is created solely for testing collaboration purposes and is not intended for merging. Its primary goal is to determine if discovery is more reliable than plain UDP multicast.

### General test steps:
- Ensure two devices(let's say A and B) are connected within the same LAN.
- On Device A, execute [TestStartSsdpProvider](https://github.com/status-im/status-go/blob/7dd413a21b486297fba53509fcfe01dc9dcadd3c/server/pairing/ssdp_test.go#L27) 
- Once `TestStartSsdpProvider` is running, run [TestStartSsdpConsumer](https://github.com/status-im/status-go/blob/7dd413a21b486297fba53509fcfe01dc9dcadd3c/server/pairing/ssdp_test.go#L35) on device B
- Check the logs related to `TestStartSsdpConsumer` , ideally you should see something like
```
content="Hello World!"
``` 
which means ssdp works as expected.

### Functions Overview
- **TestStartSsdpProvider** : Initializes an HTTP server on a random port. It then employs SSDP to announce the services offered by Device A, and the location at which the HTTP server on Device A can be accessed.
- **TestStartSsdpConsumer** : Uses SSDP to identify the services rendered by Device A and attempts to connect to the HTTP server.

### Firewall test case
- Run `TestStartSsdpProvider` on device that don't use firewall kind software to simulate mobile device
- Run `TestStartSsdpConsumer` on device that use firewall to simulate desktop device
- Check the logs related to `TestStartSsdpConsumer` if ssdp works in this case

Looking forward to your feedbacks! ❤️🙏  cc @ilmotta 