### PR TITLE
feat: new configurable endpoint RequestCommunityInfoFromMailserverV2

### DIFF
--- a/cmd/ping-community/main.go
+++ b/cmd/ping-community/main.go
@@ -156,7 +156,7 @@ func main() {
 	}
 
 	community, err := messenger.FetchCommunity(&protocol.FetchCommunityRequest{
-		CommunityID:     *communityID,
+		CommunityKey:    *communityID,
 		Shard:           shard,
 		TryDatabase:     true,
 		WaitForResponse: true,

--- a/cmd/ping-community/main.go
+++ b/cmd/ping-community/main.go
@@ -155,7 +155,12 @@ func main() {
 		}
 	}
 
-	community, err := messenger.RequestCommunityInfoFromMailserver(*communityID, shard, true)
+	community, err := messenger.RequestCommunityInfoFromMailserver(&protocol.CommunityInfoRequest{
+		CommunityID:     *communityID,
+		Shard:           shard,
+		UseDatabase:     true,
+		WaitForResponse: true,
+	})
 	if err != nil {
 
 		logger.Error("community error", "error", err)

--- a/cmd/ping-community/main.go
+++ b/cmd/ping-community/main.go
@@ -155,10 +155,10 @@ func main() {
 		}
 	}
 
-	community, err := messenger.RequestCommunityInfoFromMailserver(&protocol.CommunityInfoRequest{
+	community, err := messenger.FetchCommunity(&protocol.FetchCommunityRequest{
 		CommunityID:     *communityID,
 		Shard:           shard,
-		UseDatabase:     true,
+		TryDatabase:     true,
 		WaitForResponse: true,
 	})
 	if err != nil {

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -3331,11 +3331,11 @@ func (s *MessengerCommunitiesSuite) TestGetCommunityIdFromKey() {
 	privateKey := "0x3f932031cb5f94ba7eb8ab4c824c3677973ab01fde65d1b89e0b3f470003a2cd"
 
 	// Public key returns the same
-	communityID := s.bob.GetCommunityIDFromKey(publicKey)
+	communityID := GetCommunityIDFromKey(publicKey)
 	s.Require().Equal(communityID, publicKey)
 
 	// Private key returns the public key
-	communityID = s.bob.GetCommunityIDFromKey(privateKey)
+	communityID = GetCommunityIDFromKey(privateKey)
 	s.Require().Equal(communityID, publicKey)
 }
 

--- a/protocol/linkpreview_unfurler_status.go
+++ b/protocol/linkpreview_unfurler_status.go
@@ -92,9 +92,14 @@ func (u *StatusUnfurler) fillCommunityImages(community *communities.Community, i
 	return nil
 }
 
-func (u *StatusUnfurler) buildCommunityData(communityID string) (*communities.Community, *common.StatusCommunityLinkPreview, error) {
+func (u *StatusUnfurler) buildCommunityData(communityID string, shard *common.Shard) (*communities.Community, *common.StatusCommunityLinkPreview, error) {
 	// This automatically checks the database
-	community, err := u.m.RequestCommunityInfoFromMailserver(communityID, nil, true)
+	community, err := u.m.RequestCommunityInfoFromMailserver(&CommunityInfoRequest{
+		CommunityID:     communityID,
+		Shard:           shard,
+		UseDatabase:     true,
+		WaitForResponse: true,
+	})
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get community info for communityID '%s': %w", communityID, err)
@@ -120,8 +125,8 @@ func (u *StatusUnfurler) buildCommunityData(communityID string) (*communities.Co
 	return community, c, nil
 }
 
-func (u *StatusUnfurler) buildChannelData(channelUUID string, communityID string) (*common.StatusCommunityChannelLinkPreview, error) {
-	community, communityData, err := u.buildCommunityData(communityID)
+func (u *StatusUnfurler) buildChannelData(channelUUID string, communityID string, communityShard *common.Shard) (*common.StatusCommunityChannelLinkPreview, error) {
+	community, communityData, err := u.buildCommunityData(communityID, communityShard)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build channel community data: %w", err)
 	}
@@ -169,7 +174,7 @@ func (u *StatusUnfurler) Unfurl() (*common.StatusLinkPreview, error) {
 		if resp.Community == nil {
 			return preview, fmt.Errorf("channel community can't be empty")
 		}
-		preview.Channel, err = u.buildChannelData(resp.Channel.ChannelUUID, resp.Community.CommunityID)
+		preview.Channel, err = u.buildChannelData(resp.Channel.ChannelUUID, resp.Community.CommunityID, resp.Shard)
 		if err != nil {
 			return nil, fmt.Errorf("error when building channel data: %w", err)
 		}
@@ -177,7 +182,7 @@ func (u *StatusUnfurler) Unfurl() (*common.StatusLinkPreview, error) {
 	}
 
 	if resp.Community != nil {
-		_, preview.Community, err = u.buildCommunityData(resp.Community.CommunityID)
+		_, preview.Community, err = u.buildCommunityData(resp.Community.CommunityID, resp.Shard)
 		if err != nil {
 			return nil, fmt.Errorf("error when building community data: %w", err)
 		}

--- a/protocol/linkpreview_unfurler_status.go
+++ b/protocol/linkpreview_unfurler_status.go
@@ -95,7 +95,7 @@ func (u *StatusUnfurler) fillCommunityImages(community *communities.Community, i
 func (u *StatusUnfurler) buildCommunityData(communityID string, shard *common.Shard) (*communities.Community, *common.StatusCommunityLinkPreview, error) {
 	// This automatically checks the database
 	community, err := u.m.FetchCommunity(&FetchCommunityRequest{
-		CommunityID:     communityID,
+		CommunityKey:    communityID,
 		Shard:           shard,
 		TryDatabase:     true,
 		WaitForResponse: true,

--- a/protocol/linkpreview_unfurler_status.go
+++ b/protocol/linkpreview_unfurler_status.go
@@ -94,10 +94,10 @@ func (u *StatusUnfurler) fillCommunityImages(community *communities.Community, i
 
 func (u *StatusUnfurler) buildCommunityData(communityID string, shard *common.Shard) (*communities.Community, *common.StatusCommunityLinkPreview, error) {
 	// This automatically checks the database
-	community, err := u.m.RequestCommunityInfoFromMailserver(&CommunityInfoRequest{
+	community, err := u.m.FetchCommunity(&FetchCommunityRequest{
 		CommunityID:     communityID,
 		Shard:           shard,
-		UseDatabase:     true,
+		TryDatabase:     true,
 		WaitForResponse: true,
 	})
 

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2705,6 +2705,11 @@ func (m *Messenger) requestCommunityInfoFromMailserver(communityID string, shard
 		return nil, err
 	}
 
+	m.logger.Info("mailserver request performed",
+		zap.String("communityID", communityID),
+		zap.Bool("waitForResponse", waitForResponse),
+	)
+
 	if !waitForResponse {
 		return nil, nil
 	}
@@ -2721,6 +2726,9 @@ func (m *Messenger) requestCommunityInfoFromMailserver(communityID string, shard
 				return nil, err
 			}
 			if community != nil && community.Name() != "" && community.DescriptionText() != "" {
+				m.logger.Debug("community info found",
+					zap.String("communityID", communityID),
+					zap.String("displayName", community.Name()))
 				return community, nil
 			}
 

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2335,7 +2335,12 @@ func (m *Messenger) ImportCommunity(ctx context.Context, key *ecdsa.PrivateKey) 
 		return nil, err
 	}
 
-	_, err = m.RequestCommunityInfoFromMailserver(community.IDString(), community.Shard(), false)
+	_, err = m.RequestCommunityInfoFromMailserver(&CommunityInfoRequest{
+		CommunityID:     community.IDString(),
+		Shard:           community.Shard(),
+		UseDatabase:     false,
+		WaitForResponse: true,
+	})
 	if err != nil {
 		// TODO In the future we should add a mechanism to re-apply next steps (adding owner, joining)
 		// if there is no connection with mailserver. Otherwise changes will be overwritten.

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -462,7 +462,7 @@ func (api *PublicAPI) ImportCommunity(ctx context.Context, hexPrivateKey string)
 
 // GetCommunityPublicKeyFromPrivateKey gets the community's public key from its private key
 func (api *PublicAPI) GetCommunityPublicKeyFromPrivateKey(ctx context.Context, hexPrivateKey string) string {
-	publicKey := api.service.messenger.GetCommunityIDFromKey(hexPrivateKey)
+	publicKey := protocol.GetCommunityIDFromKey(hexPrivateKey)
 	return publicKey
 }
 
@@ -1187,7 +1187,7 @@ func (api *PublicAPI) EnsVerified(pk, ensName string) error {
 // configurable FetchCommunity.
 func (api *PublicAPI) RequestCommunityInfoFromMailserver(communityID string) (*communities.Community, error) {
 	request := &protocol.FetchCommunityRequest{
-		CommunityID:     communityID,
+		CommunityKey:    communityID,
 		Shard:           nil,
 		TryDatabase:     true,
 		WaitForResponse: true,
@@ -1199,7 +1199,7 @@ func (api *PublicAPI) RequestCommunityInfoFromMailserver(communityID string) (*c
 // configurable FetchCommunity.
 func (api *PublicAPI) RequestCommunityInfoFromMailserverWithShard(communityID string, shard *common.Shard) (*communities.Community, error) {
 	request := &protocol.FetchCommunityRequest{
-		CommunityID:     communityID,
+		CommunityKey:    communityID,
 		Shard:           shard,
 		TryDatabase:     true,
 		WaitForResponse: true,
@@ -1211,7 +1211,7 @@ func (api *PublicAPI) RequestCommunityInfoFromMailserverWithShard(communityID st
 // configurable FetchCommunity.
 func (api *PublicAPI) RequestCommunityInfoFromMailserverAsync(communityID string) error {
 	request := &protocol.FetchCommunityRequest{
-		CommunityID:     communityID,
+		CommunityKey:    communityID,
 		Shard:           nil,
 		TryDatabase:     true,
 		WaitForResponse: false,
@@ -1224,7 +1224,7 @@ func (api *PublicAPI) RequestCommunityInfoFromMailserverAsync(communityID string
 // configurable FetchCommunity.
 func (api *PublicAPI) RequestCommunityInfoFromMailserverAsyncWithShard(communityID string, shard *common.Shard) error {
 	request := &protocol.FetchCommunityRequest{
-		CommunityID:     communityID,
+		CommunityKey:    communityID,
 		Shard:           shard,
 		TryDatabase:     true,
 		WaitForResponse: false,

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1184,57 +1184,57 @@ func (api *PublicAPI) EnsVerified(pk, ensName string) error {
 }
 
 // Deprecated: RequestCommunityInfoFromMailserver is deprecated in favor of
-// configurable RequestCommunityInfoFromMailserverV2.
+// configurable FetchCommunity.
 func (api *PublicAPI) RequestCommunityInfoFromMailserver(communityID string) (*communities.Community, error) {
-	request := &protocol.CommunityInfoRequest{
+	request := &protocol.FetchCommunityRequest{
 		CommunityID:     communityID,
 		Shard:           nil,
-		UseDatabase:     true,
+		TryDatabase:     true,
 		WaitForResponse: true,
 	}
-	return api.RequestCommunityInfoFromMailserverV2(request)
+	return api.FetchCommunity(request)
 }
 
 // Deprecated: RequestCommunityInfoFromMailserverWithShard is deprecated in favor of
-// configurable RequestCommunityInfoFromMailserverV2.
+// configurable FetchCommunity.
 func (api *PublicAPI) RequestCommunityInfoFromMailserverWithShard(communityID string, shard *common.Shard) (*communities.Community, error) {
-	request := &protocol.CommunityInfoRequest{
+	request := &protocol.FetchCommunityRequest{
 		CommunityID:     communityID,
 		Shard:           shard,
-		UseDatabase:     true,
+		TryDatabase:     true,
 		WaitForResponse: true,
 	}
-	return api.RequestCommunityInfoFromMailserverV2(request)
+	return api.FetchCommunity(request)
 }
 
 // Deprecated: RequestCommunityInfoFromMailserverAsync is deprecated in favor of
-// configurable RequestCommunityInfoFromMailserverV2.
+// configurable FetchCommunity.
 func (api *PublicAPI) RequestCommunityInfoFromMailserverAsync(communityID string) error {
-	request := &protocol.CommunityInfoRequest{
+	request := &protocol.FetchCommunityRequest{
 		CommunityID:     communityID,
 		Shard:           nil,
-		UseDatabase:     true,
+		TryDatabase:     true,
 		WaitForResponse: false,
 	}
-	_, err := api.RequestCommunityInfoFromMailserverV2(request)
+	_, err := api.FetchCommunity(request)
 	return err
 }
 
 // Deprecated: RequestCommunityInfoFromMailserverAsyncWithShard is deprecated in favor of
-// configurable RequestCommunityInfoFromMailserverV2.
+// configurable FetchCommunity.
 func (api *PublicAPI) RequestCommunityInfoFromMailserverAsyncWithShard(communityID string, shard *common.Shard) error {
-	request := &protocol.CommunityInfoRequest{
+	request := &protocol.FetchCommunityRequest{
 		CommunityID:     communityID,
 		Shard:           shard,
-		UseDatabase:     true,
+		TryDatabase:     true,
 		WaitForResponse: false,
 	}
-	_, err := api.RequestCommunityInfoFromMailserverV2(request)
+	_, err := api.FetchCommunity(request)
 	return err
 }
 
-func (api *PublicAPI) RequestCommunityInfoFromMailserverV2(request *protocol.CommunityInfoRequest) (*communities.Community, error) {
-	return api.service.messenger.RequestCommunityInfoFromMailserver(request)
+func (api *PublicAPI) FetchCommunity(request *protocol.FetchCommunityRequest) (*communities.Community, error) {
+	return api.service.messenger.FetchCommunity(request)
 }
 
 func (api *PublicAPI) ActivityCenterNotifications(request protocol.ActivityCenterNotificationsRequest) (*protocol.ActivityCenterPaginationResponse, error) {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1183,22 +1183,58 @@ func (api *PublicAPI) EnsVerified(pk, ensName string) error {
 	return api.service.messenger.ENSVerified(pk, ensName)
 }
 
-// DEPRECATED
+// Deprecated: RequestCommunityInfoFromMailserver is deprecated in favor of
+// configurable RequestCommunityInfoFromMailserverV2.
 func (api *PublicAPI) RequestCommunityInfoFromMailserver(communityID string) (*communities.Community, error) {
-	return api.service.messenger.RequestCommunityInfoFromMailserver(communityID, nil, true)
+	request := &protocol.CommunityInfoRequest{
+		CommunityID:     communityID,
+		Shard:           nil,
+		UseDatabase:     true,
+		WaitForResponse: true,
+	}
+	return api.RequestCommunityInfoFromMailserverV2(request)
 }
 
+// Deprecated: RequestCommunityInfoFromMailserverWithShard is deprecated in favor of
+// configurable RequestCommunityInfoFromMailserverV2.
 func (api *PublicAPI) RequestCommunityInfoFromMailserverWithShard(communityID string, shard *common.Shard) (*communities.Community, error) {
-	return api.service.messenger.RequestCommunityInfoFromMailserver(communityID, shard, true)
+	request := &protocol.CommunityInfoRequest{
+		CommunityID:     communityID,
+		Shard:           shard,
+		UseDatabase:     true,
+		WaitForResponse: true,
+	}
+	return api.RequestCommunityInfoFromMailserverV2(request)
 }
 
-// DEPRECATED
+// Deprecated: RequestCommunityInfoFromMailserverAsync is deprecated in favor of
+// configurable RequestCommunityInfoFromMailserverV2.
 func (api *PublicAPI) RequestCommunityInfoFromMailserverAsync(communityID string) error {
-	return api.service.messenger.RequestCommunityInfoFromMailserverAsync(communityID, nil)
+	request := &protocol.CommunityInfoRequest{
+		CommunityID:     communityID,
+		Shard:           nil,
+		UseDatabase:     true,
+		WaitForResponse: false,
+	}
+	_, err := api.RequestCommunityInfoFromMailserverV2(request)
+	return err
 }
 
+// Deprecated: RequestCommunityInfoFromMailserverAsyncWithShard is deprecated in favor of
+// configurable RequestCommunityInfoFromMailserverV2.
 func (api *PublicAPI) RequestCommunityInfoFromMailserverAsyncWithShard(communityID string, shard *common.Shard) error {
-	return api.service.messenger.RequestCommunityInfoFromMailserverAsync(communityID, shard)
+	request := &protocol.CommunityInfoRequest{
+		CommunityID:     communityID,
+		Shard:           shard,
+		UseDatabase:     true,
+		WaitForResponse: false,
+	}
+	_, err := api.RequestCommunityInfoFromMailserverV2(request)
+	return err
+}
+
+func (api *PublicAPI) RequestCommunityInfoFromMailserverV2(request *protocol.CommunityInfoRequest) (*communities.Community, error) {
+	return api.service.messenger.RequestCommunityInfoFromMailserver(request)
 }
 
 func (api *PublicAPI) ActivityCenterNotifications(request protocol.ActivityCenterNotificationsRequest) (*protocol.ActivityCenterPaginationResponse, error) {

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -671,10 +671,10 @@ func (s *Service) fetchCommunity(communityID string) (*communities.Community, er
 	// communities that have specific shards
 
 	var shard *common.Shard = nil // TODO: build this with info from token
-	community, err := s.messenger.RequestCommunityInfoFromMailserver(&protocol.CommunityInfoRequest{
+	community, err := s.messenger.FetchCommunity(&protocol.FetchCommunityRequest{
 		CommunityID:     communityID,
 		Shard:           shard,
-		UseDatabase:     true,
+		TryDatabase:     true,
 		WaitForResponse: true,
 	})
 

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -672,7 +672,7 @@ func (s *Service) fetchCommunity(communityID string) (*communities.Community, er
 
 	var shard *common.Shard = nil // TODO: build this with info from token
 	community, err := s.messenger.FetchCommunity(&protocol.FetchCommunityRequest{
-		CommunityID:     communityID,
+		CommunityKey:    communityID,
 		Shard:           shard,
 		TryDatabase:     true,
 		WaitForResponse: true,

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -671,7 +671,12 @@ func (s *Service) fetchCommunity(communityID string) (*communities.Community, er
 	// communities that have specific shards
 
 	var shard *common.Shard = nil // TODO: build this with info from token
-	community, err := s.messenger.RequestCommunityInfoFromMailserver(communityID, shard, true)
+	community, err := s.messenger.RequestCommunityInfoFromMailserver(&protocol.CommunityInfoRequest{
+		CommunityID:     communityID,
+		Shard:           shard,
+		UseDatabase:     true,
+		WaitForResponse: true,
+	})
 
 	if err != nil {
 		return nil, err

--- a/services/status/service.go
+++ b/services/status/service.go
@@ -75,10 +75,10 @@ func (p *PublicAPI) CommunityInfo(communityID types.HexBytes, shard *common.Shar
 		return nil, ErrNotInitialized
 	}
 
-	community, err := p.service.messenger.RequestCommunityInfoFromMailserver(&protocol.CommunityInfoRequest{
+	community, err := p.service.messenger.FetchCommunity(&protocol.FetchCommunityRequest{
 		CommunityID:     communityID.String(),
 		Shard:           shard,
-		UseDatabase:     true,
+		TryDatabase:     true,
 		WaitForResponse: true,
 	})
 	if err != nil {

--- a/services/status/service.go
+++ b/services/status/service.go
@@ -75,7 +75,12 @@ func (p *PublicAPI) CommunityInfo(communityID types.HexBytes, shard *common.Shar
 		return nil, ErrNotInitialized
 	}
 
-	community, err := p.service.messenger.RequestCommunityInfoFromMailserver(communityID.String(), shard, true)
+	community, err := p.service.messenger.RequestCommunityInfoFromMailserver(&protocol.CommunityInfoRequest{
+		CommunityID:     communityID.String(),
+		Shard:           shard,
+		UseDatabase:     true,
+		WaitForResponse: true,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/services/status/service.go
+++ b/services/status/service.go
@@ -76,7 +76,7 @@ func (p *PublicAPI) CommunityInfo(communityID types.HexBytes, shard *common.Shar
 	}
 
 	community, err := p.service.messenger.FetchCommunity(&protocol.FetchCommunityRequest{
-		CommunityID:     communityID.String(),
+		CommunityKey:    communityID.String(),
 		Shard:           shard,
 		TryDatabase:     true,
 		WaitForResponse: true,


### PR DESCRIPTION
1. Add new API endpoint `RequestCommunityInfoFromMailserverV2`
It does nothing new, but has a single general `CommunityInfoRequest` argument, which:
  - adds ability to request community info with `useDatabase = false`
  - makes it simpler to extend request with more parameters if needed

2. Deprecate old `RequestCommunityInfo...` endpoints.
Currently they wrap the new `RequestCommunityInfoFromMailserverV2`.

3. Fixed `StatusUnfurler` to use `shard` property from URL data

4. Some logs added