### PR TITLE
fix(wakuv2): post envelopes previously cached but not processed

### DIFF
--- a/wakuv2/common/message.go
+++ b/wakuv2/common/message.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/waku-org/go-waku/waku/v2/payload"
@@ -55,6 +56,8 @@ type ReceivedMessage struct {
 	SymKeyHash common.Hash // The Keccak256Hash of the key
 
 	hash common.Hash
+
+	Processed atomic.Bool
 }
 
 // MessagesRequest contains details of a request for historic messages.


### PR DESCRIPTION
In relay mode we cache envelopes, even if there're no filters found for them.
This affects later mailserver requests, because the envelopes that are found in cache were considered as "processed", even when there were not.

Now we actually save the `Processed` state of the envelopes in the cache.