### PR TITLE
[Fixes: #4088] Fix pending notification test

### DIFF
--- a/protocol/activity_center.go
+++ b/protocol/activity_center.go
@@ -76,6 +76,16 @@ type ActivityCenterNotification struct {
 	AlbumMessages []*common.Message `json:"albumMessages"`
 }
 
+func (n *ActivityCenterNotification) IncrementUpdatedAt(timesource common.TimeSource) {
+	tNow := timesource.GetCurrentTime()
+	// If updatead at is greater or equal than time now, we bump it
+	if n.UpdatedAt >= tNow {
+		n.UpdatedAt++
+	} else {
+		n.UpdatedAt = tNow
+	}
+}
+
 type ActivityCenterNotificationsRequest struct {
 	Cursor        string                        `json:"cursor"`
 	Limit         uint64                        `json:"limit"`


### PR DESCRIPTION
There were 2 issues:

1) We hard delete requests, that means that on retransmission they will be recreated, the test has been changed to accommodate this behavior 


2) We always used time.now when updating timestamp in notification,
   sometimes time is the same so the notification is not updated, we
   changed to use what essentially is a clock value

