### PR TITLE
fix(build): avoid removing untracked git changes by `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,9 +349,11 @@ ci-race: lint canary-test test-unit test-e2e-race ##@tests Run all linters and t
 
 clean: ##@other Cleanup
 	rm -fr build/bin/* mailserver-config.json
+
+git-clean:
 	git clean -xf
 
-deep-clean: clean
+deep-clean: clean git-clean
 	rm -Rdf .ethereumtest/StatusChain
 
 tidy:

--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -68,6 +68,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { sh 'make clean' }
+    cleanup { sh 'make deep-clean' }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -73,6 +73,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { sh 'make clean' }
+    cleanup { sh 'make deep-clean' }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -75,6 +75,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { sh 'make clean' }
+    cleanup { sh 'make deep-clean' }
   } // post
 } // pipeline


### PR DESCRIPTION
Use `make deep-clean` for deep cleaning

Me and some other devs occasionally fall in trouble by using `make clean` command which imo unexpectedly removes untracked files, including not yet commited fresh sources. Better use `deep-clean` command for that.
