### PR TITLE
fix flaky test `TestSyncCommunityRequestDecisionAccept`

### DIFF
--- a/protocol/messenger_sync_activity_center_test.go
+++ b/protocol/messenger_sync_activity_center_test.go
@@ -170,7 +170,13 @@ func (s *MessengerSyncActivityCenterSuite) addContactAndShareCommunity(userB *Me
 	response, err := userB.AddContact(context.Background(), request)
 	s.Require().NoError(err)
 	s.Require().Len(response.Messages(), 2)
-	s.Require().Equal(protobuf.ChatMessage_CONTACT_REQUEST, response.Messages()[1].ContentType)
+	existContactRequestMessage := false
+	for _, m := range response.Messages() {
+		if m.ContentType == protobuf.ChatMessage_CONTACT_REQUEST {
+			existContactRequestMessage = true
+		}
+	}
+	s.Require().True(existContactRequestMessage)
 	var contactRequestMessageID types.HexBytes
 	_, err = WaitOnMessengerResponse(s.m, func(r *MessengerResponse) bool {
 		if len(r.ActivityCenterNotifications()) > 0 {


### PR DESCRIPTION
this PR should fix flaky test `TestSyncCommunityRequestDecisionAccept`

relate test error:

```
Error Trace:  /home/jenkins/workspace/status-go_prs_tests_PR-4244/protocol/messenger_sync_activity_center_test.go:173
                    /home/jenkins/workspace/status-go_prs_tests_PR-4244/protocol/messenger_sync_activity_center_test.go:126
                    /home/jenkins/workspace/status-go_prs_tests_PR-4244/protocol/messenger_sync_activity_center_test.go:111
Error:        Not equal: 
              expected: 11
              actual  : 15
Test:         TestMessengerSyncActivityCenter/TestSyncCommunityRequestDecisionAccept
```

status: ready.