### PR TITLE
fix: decompress any public keys in link previews

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4031,6 +4031,7 @@ func (m *Messenger) prepareMessage(msg *common.Message, s *server.MediaServer) {
 
 	msg.LinkPreviews = msg.ConvertFromProtoToLinkPreviews(s.MakeLinkPreviewThumbnailURL)
 	msg.StatusLinkPreviews = msg.ConvertFromProtoToStatusLinkPreviews(s.MakeStatusLinkPreviewThumbnailURL)
+	msg.DecompressPublicKeys()
 }
 
 func (m *Messenger) AllMessageByChatIDWhichMatchTerm(chatID string, searchTerm string, caseSensitive bool) ([]*common.Message, error) {


### PR DESCRIPTION
Required for https://github.com/status-im/status-desktop/pull/12613.

it's good to transfer the keys compressed, but the app mainly uses the keys uncompressed.
At first I decompressed them on the client side, but that required a status-go call per each decompression, which is bad.