### PR TITLE
Fix: Prevent Unintended Clearing of Previous Community Notifications

### DIFF
--- a/protocol/activity_center_persistence.go
+++ b/protocol/activity_center_persistence.go
@@ -60,10 +60,6 @@ func (db sqlitePersistence) DeleteActivityCenterNotificationForMessage(chatID st
 	}
 
 	for _, notification := range notifications {
-		if notification.LastMessage != nil && notification.LastMessage.ID == messageID {
-			withNotification(notification)
-		}
-
 		if notification.Message != nil && notification.Message.ID == messageID {
 			withNotification(notification)
 		}


### PR DESCRIPTION
fix for https://github.com/status-im/status-mobile/issues/17052

### Summary
This pull request resolves the issue where deleting the last mention or reply for everyone in a community chat inadvertently cleared previous notifications.