### PR TITLE
fix: better `IsStatusSharedURL`

### DIFF
--- a/protocol/messenger_linkpreview.go
+++ b/protocol/messenger_linkpreview.go
@@ -154,7 +154,7 @@ func (m *Messenger) UnfurlURLs(httpClient *http.Client, urls []string) (UnfurlUR
 	for _, url := range urls {
 		m.logger.Debug("unfurling", zap.String("url", url))
 
-		if m.IsStatusSharedURL(url) {
+		if IsStatusSharedURL(url) {
 			unfurler := NewStatusUnfurler(url, m, m.logger)
 			preview, err := unfurler.Unfurl()
 			if err != nil {

--- a/protocol/messenger_share_urls.go
+++ b/protocol/messenger_share_urls.go
@@ -48,6 +48,18 @@ type URLDataResponse struct {
 }
 
 const baseShareURL = "https://status.app"
+const userPath = "u#"
+const userWithDataPath = "u/"
+const communityPath = "c#"
+const communityWithDataPath = "c/"
+const channelPath = "cc/"
+
+const sharedUrlUserPrefix = baseShareURL + "/" + userPath
+const sharedUrlUserPrefixWithData = baseShareURL + "/" + userWithDataPath
+const sharedUrlCommunityPrefix = baseShareURL + "/" + communityPath
+const sharedUrlCommunityPrefixWithData = baseShareURL + "/" + communityWithDataPath
+const sharedUrlChannelPrefixWithData = baseShareURL + "/" + channelPath
+
 const channelUUIDRegExp = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$"
 
 func (m *Messenger) SerializePublicKey(compressedKey types.HexBytes) (string, error) {
@@ -511,12 +523,16 @@ func (m *Messenger) parseUserURLWithData(data string, chatKey string) (*URLDataR
 	}, nil
 }
 
-func (m *Messenger) IsStatusSharedURL(url string) bool {
-	return strings.HasPrefix(url, baseShareURL)
+func IsStatusSharedURL(url string) bool {
+	return strings.HasPrefix(url, sharedUrlUserPrefix) ||
+		strings.HasPrefix(url, sharedUrlUserPrefixWithData) ||
+		strings.HasPrefix(url, sharedUrlCommunityPrefix) ||
+		strings.HasPrefix(url, sharedUrlCommunityPrefixWithData) ||
+		strings.HasPrefix(url, sharedUrlChannelPrefixWithData)
 }
 
 func (m *Messenger) ParseSharedURL(url string) (*URLDataResponse, error) {
-	if !m.IsStatusSharedURL(url) {
+	if !IsStatusSharedURL(url) {
 		return nil, fmt.Errorf("url should start with '%s'", baseShareURL)
 	}
 

--- a/protocol/messenger_share_urls.go
+++ b/protocol/messenger_share_urls.go
@@ -54,11 +54,11 @@ const communityPath = "c#"
 const communityWithDataPath = "c/"
 const channelPath = "cc/"
 
-const sharedUrlUserPrefix = baseShareURL + "/" + userPath
-const sharedUrlUserPrefixWithData = baseShareURL + "/" + userWithDataPath
-const sharedUrlCommunityPrefix = baseShareURL + "/" + communityPath
-const sharedUrlCommunityPrefixWithData = baseShareURL + "/" + communityWithDataPath
-const sharedUrlChannelPrefixWithData = baseShareURL + "/" + channelPath
+const sharedURLUserPrefix = baseShareURL + "/" + userPath
+const sharedURLUserPrefixWithData = baseShareURL + "/" + userWithDataPath
+const sharedURLCommunityPrefix = baseShareURL + "/" + communityPath
+const sharedURLCommunityPrefixWithData = baseShareURL + "/" + communityWithDataPath
+const sharedURLChannelPrefixWithData = baseShareURL + "/" + channelPath
 
 const channelUUIDRegExp = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$"
 
@@ -524,11 +524,11 @@ func (m *Messenger) parseUserURLWithData(data string, chatKey string) (*URLDataR
 }
 
 func IsStatusSharedURL(url string) bool {
-	return strings.HasPrefix(url, sharedUrlUserPrefix) ||
-		strings.HasPrefix(url, sharedUrlUserPrefixWithData) ||
-		strings.HasPrefix(url, sharedUrlCommunityPrefix) ||
-		strings.HasPrefix(url, sharedUrlCommunityPrefixWithData) ||
-		strings.HasPrefix(url, sharedUrlChannelPrefixWithData)
+	return strings.HasPrefix(url, sharedURLUserPrefix) ||
+		strings.HasPrefix(url, sharedURLUserPrefixWithData) ||
+		strings.HasPrefix(url, sharedURLCommunityPrefix) ||
+		strings.HasPrefix(url, sharedURLCommunityPrefixWithData) ||
+		strings.HasPrefix(url, sharedURLChannelPrefixWithData)
 }
 
 func (m *Messenger) ParseSharedURL(url string) (*URLDataResponse, error) {

--- a/protocol/messenger_share_urls.go
+++ b/protocol/messenger_share_urls.go
@@ -533,7 +533,7 @@ func IsStatusSharedURL(url string) bool {
 
 func (m *Messenger) ParseSharedURL(url string) (*URLDataResponse, error) {
 	if !IsStatusSharedURL(url) {
-		return nil, fmt.Errorf("url should start with '%s'", baseShareURL)
+		return nil, fmt.Errorf("url is not a status shared url")
 	}
 
 	urlContents := regexp.MustCompile(`\#`).Split(strings.TrimPrefix(url, baseShareURL+"/"), 2)

--- a/protocol/messenger_share_urls_test.go
+++ b/protocol/messenger_share_urls_test.go
@@ -144,11 +144,11 @@ func (s *MessengerShareUrlsSuite) TestDeserializePublicKey() {
 
 func (s *MessengerShareUrlsSuite) TestParseWrongUrls() {
 	urls := map[string]string{
-		"https://status.appc/#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11":  "unhandled shared url",
-		"https://status.app/cc#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11": "unhandled shared url",
-		"https://status.app/a#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11":  "unhandled shared url",
+		"https://status.appc/#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11":  "url is not a status shared url",
+		"https://status.app/cc#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11": "url is not a status shared url",
+		"https://status.app/a#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11":  "url is not a status shared url",
 		"https://status.app/u/": "url should contain at least one `#` separator",
-		"https://status.im/u#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11": "url should start with 'https://status.app'",
+		"https://status.im/u#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11": "url is not a status shared url",
 	}
 
 	for url, expectedError := range urls {

--- a/protocol/messenger_share_urls_test.go
+++ b/protocol/messenger_share_urls_test.go
@@ -17,6 +17,15 @@ import (
 	"github.com/status-im/status-go/protocol/urls"
 )
 
+const (
+	userURL              = "https://status.app/u#zQ3shwQPhRuDJSjVGVBnTjCdgXy5i9WQaeVPdGJD6yTarJQSj"
+	userURLWithData      = "https://status.app/u/G10A4B0JdgwyRww90WXtnP1oNH1ZLQNM0yX0Ja9YyAMjrqSZIYINOHCbFhrnKRAcPGStPxCMJDSZlGCKzmZrJcimHY8BbcXlORrElv_BbQEegnMDPx1g9C5VVNl0fE4y#zQ3shwQPhRuDJSjVGVBnTjCdgXy5i9WQaeVPdGJD6yTarJQSj"
+	communityURL         = "https://status.app/c#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11"
+	communityURLWithData = "https://status.app/c/iyKACkQKB0Rvb2RsZXMSJ0NvbG9yaW5nIHRoZSB3b3JsZCB3aXRoIGpveSDigKIg4bSXIOKAohiYohsiByMxMzFEMkYqAwEhMwM=#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11"
+	channelURL           = "https://status.app/cc/003cdcd5-e065-48f9-b166-b1a94ac75a11#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11"
+	channelURLWithData   = "https://status.app/cc/G54AAKwObLdpiGjXnckYzRcOSq0QQAS_CURGfqVU42ceGHCObstUIknTTZDOKF3E8y2MSicncpO7fTskXnoACiPKeejvjtLTGWNxUhlT7fyQS7Jrr33UVHluxv_PLjV2ePGw5GQ33innzeK34pInIgUGs5RjdQifMVmURalxxQKwiuoY5zwIjixWWRHqjHM=#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11"
+)
+
 func TestMessengerShareUrlsSuite(t *testing.T) {
 	suite.Run(t, new(MessengerShareUrlsSuite))
 }
@@ -151,6 +160,68 @@ func (s *MessengerShareUrlsSuite) TestParseWrongUrls() {
 	}
 }
 
+func (s *MessengerShareUrlsSuite) TestIsStatusSharedUrl() {
+	testCases := []struct {
+		Name   string
+		URL    string
+		Result bool
+	}{
+		{
+			Name:   "Direct website link",
+			URL:    "https://status.app",
+			Result: false,
+		},
+		{
+			Name:   "Website page link",
+			URL:    "https://status.app/features/messenger",
+			Result: false,
+		},
+		{
+			// starts with `/c`, but no `#` after
+			Name:   "Website page link",
+			URL:    "https://status.app/communities",
+			Result: false,
+		},
+		{
+			Name:   "User link",
+			URL:    userURL,
+			Result: true,
+		},
+		{
+			Name:   "User link with data",
+			URL:    userURLWithData,
+			Result: true,
+		},
+		{
+			Name:   "Community link",
+			URL:    communityURL,
+			Result: true,
+		},
+		{
+			Name:   "Community link with data",
+			URL:    communityURLWithData,
+			Result: true,
+		},
+		{
+			Name:   "Channel link",
+			URL:    channelURL,
+			Result: true,
+		},
+		{
+			Name:   "Channel link with data",
+			URL:    channelURLWithData,
+			Result: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.Name, func() {
+			result := IsStatusSharedURL(tc.URL)
+			s.Require().Equal(tc.Result, result)
+		})
+	}
+}
+
 func (s *MessengerShareUrlsSuite) TestShareCommunityURLWithChatKey() {
 	community := s.createCommunity()
 
@@ -198,9 +269,7 @@ func (s *MessengerShareUrlsSuite) TestShareCommunityURLWithData() {
 }
 
 func (s *MessengerShareUrlsSuite) TestParseCommunityURLWithData() {
-	url := "https://status.app/c/iyKACkQKB0Rvb2RsZXMSJ0NvbG9yaW5nIHRoZSB3b3JsZCB3aXRoIGpveSDigKIg4bSXIOKAohiYohsiByMxMzFEMkYqAwEhMwM=#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11"
-
-	urlData, err := s.m.ParseSharedURL(url)
+	urlData, err := s.m.ParseSharedURL(communityURLWithData)
 	s.Require().NoError(err)
 	s.Require().NotNil(urlData)
 
@@ -290,9 +359,7 @@ func (s *MessengerShareUrlsSuite) TestShareCommunityChannelURLWithData() {
 }
 
 func (s *MessengerShareUrlsSuite) TestParseCommunityChannelURLWithData() {
-	url := "https://status.app/cc/G54AAKwObLdpiGjXnckYzRcOSq0QQAS_CURGfqVU42ceGHCObstUIknTTZDOKF3E8y2MSicncpO7fTskXnoACiPKeejvjtLTGWNxUhlT7fyQS7Jrr33UVHluxv_PLjV2ePGw5GQ33innzeK34pInIgUGs5RjdQifMVmURalxxQKwiuoY5zwIjixWWRHqjHM=#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11"
-
-	urlData, err := s.m.ParseSharedURL(url)
+	urlData, err := s.m.ParseSharedURL(channelURLWithData)
 	s.Require().NoError(err)
 	s.Require().NotNil(urlData)
 
@@ -392,8 +459,7 @@ func (s *MessengerShareUrlsSuite) TestShareUserURLWithENS() {
 // }
 
 func (s *MessengerShareUrlsSuite) TestParseUserURLWithData() {
-	url := "https://status.app/u/G10A4B0JdgwyRww90WXtnP1oNH1ZLQNM0yX0Ja9YyAMjrqSZIYINOHCbFhrnKRAcPGStPxCMJDSZlGCKzmZrJcimHY8BbcXlORrElv_BbQEegnMDPx1g9C5VVNl0fE4y#zQ3shwQPhRuDJSjVGVBnTjCdgXy5i9WQaeVPdGJD6yTarJQSj"
-	urlData, err := s.m.ParseSharedURL(url)
+	urlData, err := s.m.ParseSharedURL(userURLWithData)
 	s.Require().NoError(err)
 	s.Require().NotNil(urlData)
 

--- a/protocol/messenger_share_urls_test.go
+++ b/protocol/messenger_share_urls_test.go
@@ -143,19 +143,19 @@ func (s *MessengerShareUrlsSuite) TestDeserializePublicKey() {
 }
 
 func (s *MessengerShareUrlsSuite) TestParseWrongUrls() {
-	urls := map[string]string{
-		"https://status.appc/#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11":  "url is not a status shared url",
-		"https://status.app/cc#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11": "url is not a status shared url",
-		"https://status.app/a#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11":  "url is not a status shared url",
+	const notStatusSharedURLError = "not a status shared url"
+	badURLs := map[string]string{
+		"https://status.appc/#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11":  notStatusSharedURLError,
+		"https://status.app/cc#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11": notStatusSharedURLError,
+		"https://status.app/a#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11":  notStatusSharedURLError,
+		"https://status.im/u#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11":   notStatusSharedURLError,
 		"https://status.app/u/": "url should contain at least one `#` separator",
-		"https://status.im/u#zQ3shYSHp7GoiXaauJMnDcjwU2yNjdzpXLosAWapPS4CFxc11": "url is not a status shared url",
 	}
 
-	for url, expectedError := range urls {
+	for url, expectedError := range badURLs {
 		urlData, err := s.m.ParseSharedURL(url)
 		s.Require().Error(err)
-
-		s.Require().True(strings.HasPrefix(err.Error(), expectedError))
+		s.Require().Equal(err.Error(), expectedError)
 		s.Require().Nil(urlData)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-go/issues/4275

Now `IsStatusSharedURL` method check for URL to begin with one of the options:
- `https://status.app/u#`
- `https://status.app/u/`
- `https://status.app/c#`
- `https://status.app/c/`
- `https://status.app/cc/`

So link preveiw is generated properly for https://status.app:
<img width="487" alt="image" src="https://github.com/status-im/status-go/assets/25482501/9cad3239-28ec-4c17-aa75-91cf6e4d6bfb">
