### PR TITLE
fix: edit message even if converting link previews to proto

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2309,9 +2309,10 @@ func (m *Messenger) sendChatMessage(ctx context.Context, message *common.Message
 		}
 	}
 
-	unfurledLinks, err := message.ConvertLinkPreviewsToProto()
 	// We consider link previews non-critical data, so we do not want to block
 	// messages from being sent.
+
+	unfurledLinks, err := message.ConvertLinkPreviewsToProto()
 	if err != nil {
 		m.logger.Error("failed to convert link previews", zap.Error(err))
 	} else {

--- a/protocol/messenger_messages.go
+++ b/protocol/messenger_messages.go
@@ -69,17 +69,22 @@ func (m *Messenger) EditMessage(ctx context.Context, request *requests.EditMessa
 		editMessage.MessageId = message.ID
 		editMessage.Clock = clock
 
+		// We consider link previews non-critical data, so we do not want to block
+		// messages from being sent.
+
 		unfurledLinks, err := message.ConvertLinkPreviewsToProto()
 		if err != nil {
-			return nil, err
+			m.logger.Error("failed to convert link previews", zap.Error(err))
+		} else {
+			editMessage.UnfurledLinks = unfurledLinks
 		}
-		editMessage.UnfurledLinks = unfurledLinks
 
 		unfurledStatusLinks, err := message.ConvertStatusLinkPreviewsToProto()
 		if err != nil {
-			return nil, err
+			m.logger.Error("failed to convert status link previews", zap.Error(err))
+		} else {
+			editMessage.UnfurledStatusLinks = unfurledStatusLinks
 		}
-		editMessage.UnfurledStatusLinks = unfurledStatusLinks
 
 		err = m.applyEditMessage(editMessage.EditMessage, message)
 		if err != nil {


### PR DESCRIPTION
We should keep editing the message, even if link previews conversion to proto failed.

We do the same when sending the message:

https://github.com/status-im/status-go/blob/7009a7d18a748097f3554a88dc8257f6087ae55a/protocol/messenger.go#L2312-L2327