### PR TITLE
fix: add missing error check in currency service

### DIFF
--- a/services/wallet/currency/service.go
+++ b/services/wallet/currency/service.go
@@ -110,6 +110,9 @@ func (s *Service) fetchAllTokenCurrencyFormats() (FormatPerSymbol, error) {
 	}
 
 	tokenFormats, err := s.currency.FetchTokenCurrencyFormats(tokenSymbols)
+	if err != nil {
+		return nil, err
+	}
 	gweiSymbol := "Gwei"
 	tokenFormats[gweiSymbol] = Format{
 		Symbol:              gweiSymbol,


### PR DESCRIPTION
Added missing error check in the currency service, that caused a crash on startup when generating the list of currency formats.
