### PR TITLE
feat: limit unfurls number

### DIFF
--- a/protocol/messenger_linkpreview.go
+++ b/protocol/messenger_linkpreview.go
@@ -17,6 +17,8 @@ import (
 	"github.com/status-im/status-go/protocol/common"
 )
 
+const UnfurledLinksPerMessageLimit = 5
+
 type UnfurlURLsResponse struct {
 	LinkPreviews       []*common.LinkPreview       `json:"linkPreviews,omitempty"`
 	StatusLinkPreviews []*common.StatusLinkPreview `json:"statusLinkPreviews,omitempty"`
@@ -122,6 +124,12 @@ func GetURLs(text string) []string {
 		} else {
 			indexed[idx] = nil
 			urls = append(urls, idx)
+		}
+
+		// This is a temporary limitation solution,
+		// should be changed with https://github.com/status-im/status-go/issues/4235
+		if len(urls) == UnfurledLinksPerMessageLimit {
+			break
 		}
 	}
 

--- a/protocol/messenger_linkpreview_test.go
+++ b/protocol/messenger_linkpreview_test.go
@@ -659,5 +659,17 @@ func (s *MessengerLinkPreviewsTestSuite) Test_UnfurlURLs_Settings() {
 	s.Require().Len(linkPreviews.LinkPreviews, 0)
 	s.Require().Len(linkPreviews.StatusLinkPreviews, 1) // Status links are always unfurled
 	s.Require().Equal(requestsCount, 0)
+}
 
+func (s *MessengerLinkPreviewsTestSuite) Test_UnfurlURLs_Limit() {
+	linksToUnfurl := "https://www.youtube.com/watch?v=6dkDepLX0rk " +
+		"https://www.youtube.com/watch?v=ferZnZ0_rSM " +
+		"https://www.youtube.com/watch?v=bdneye4pzMw " +
+		"https://www.youtube.com/watch?v=pRERgcQe-fQ " +
+		"https://www.youtube.com/watch?v=j82L3pLjb_0 " +
+		"https://www.youtube.com/watch?v=hxsJvKYyVyg " +
+		"https://www.youtube.com/watch?v=jIIuzB11dsA"
+
+	urls := GetURLs(linksToUnfurl)
+	s.Require().Equal(UnfurledLinksPerMessageLimit, len(urls))
 }


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/4236
_____

Added a limit of 5 links to URL unfurling.

More proper implementation will be here: https://github.com/status-im/status-go/issues/4235
Currently it affects the syntax highlighter in desktop:

<img width="1378" alt="image" src="https://github.com/status-im/status-go/assets/25482501/fbf0904a-1cfd-4117-b9ab-ae1ce09bd29a">
