### PR TITLE
fix(messenger_base_test): remove messenger `Start` duplication

### DIFF
--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -41,8 +41,6 @@ func (s *MessengerBaseTestSuite) SetupTest() {
 
 	s.m = s.newMessenger()
 	s.privateKey = s.m.identity
-	_, err := s.m.Start()
-	s.Require().NoError(err)
 }
 
 func (s *MessengerBaseTestSuite) TearDownTest() {


### PR DESCRIPTION
The created messenger is already started here:
https://github.com/status-im/status-go/blob/b919e744a5c48b014ef5e5cd16843e529ad08a32/protocol/messenger_base_test.go#L131-L134

So we don't need to start it again.
