### PR TITLE
fix: self-contact related flaky tests

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -126,6 +126,7 @@ type Messenger struct {
 	systemMessagesTranslations *systemMessageTranslationsMap
 	allChats                   *chatMap
 	selfContact                *Contact
+	selfContactSubscriptions   []chan *SelfContactChangeEvent
 	allContacts                *contactMap
 	allInstallations           *installationMap
 	modifiedInstallations      *stringBoolMap
@@ -1592,6 +1593,7 @@ func (m *Messenger) watchIdentityImageChanges() {
 					identityImagesMap[img.Name] = *img
 				}
 				m.selfContact.Images = identityImagesMap
+				m.publishSelfContactSubscriptions(&SelfContactChangeEvent{ImagesChanged: true})
 
 				if change.PublishExpected {
 					err = m.syncProfilePictures(m.dispatchMessage, identityImages)
@@ -5717,8 +5719,4 @@ func (m *Messenger) handleSyncSocialLinks(message *protobuf.SyncSocialLinks, cal
 	callback(links)
 
 	return nil
-}
-
-func (m *Messenger) GetDeleteForMeMessages() ([]*protobuf.SyncDeleteForMeMessage, error) {
-	return m.persistence.GetDeleteForMeMessages()
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -5720,3 +5720,7 @@ func (m *Messenger) handleSyncSocialLinks(message *protobuf.SyncSocialLinks, cal
 
 	return nil
 }
+
+func (m *Messenger) GetDeleteForMeMessages() ([]*protobuf.SyncDeleteForMeMessage, error) {
+	return m.persistence.GetDeleteForMeMessages()
+}

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
 
@@ -25,6 +26,14 @@ const outgoingMutualStateEventRemovedDefaultText = "You removed @%s as a contact
 const incomingMutualStateEventSentDefaultText = "@%s sent you a contact request"
 const incomingMutualStateEventAcceptedDefaultText = "@%s accepted your contact request"
 const incomingMutualStateEventRemovedDefaultText = "@%s removed you as a contact"
+
+type SelfContactChangeEvent struct {
+	DisplayNameChanged   bool
+	PreferredNameChanged bool
+	BioChanged           bool
+	SocialLinksChanged   bool
+	ImagesChanged        bool
+}
 
 func (m *Messenger) prepareMutualStateUpdateMessage(contactID string, updateType MutualStateUpdateType, clock uint64, timestamp uint64, outgoing bool) (*common.Message, error) {
 	var text string
@@ -766,6 +775,10 @@ func (m *Messenger) GetContactByID(pubKey string) *Contact {
 	return contact
 }
 
+func (m *Messenger) GetSelfContact() *Contact {
+	return m.selfContact
+}
+
 func (m *Messenger) SetContactLocalNickname(request *requests.SetContactLocalNickname) (*MessengerResponse, error) {
 
 	if err := request.Validate(); err != nil {
@@ -1290,4 +1303,24 @@ func (m *Messenger) forgetContactInfoRequest(publicKey string) {
 	}
 
 	delete(m.requestedContacts, publicKey)
+}
+
+func (m *Messenger) GetDeleteForMeMessages() ([]*protobuf.SyncDeleteForMeMessage, error) {
+	return m.persistence.GetDeleteForMeMessages()
+}
+
+func (m *Messenger) SubscribeToSelfContactChanges() chan *SelfContactChangeEvent {
+	s := make(chan *SelfContactChangeEvent, 10)
+	m.selfContactSubscriptions = append(m.selfContactSubscriptions, s)
+	return s
+}
+
+func (m *Messenger) publishSelfContactSubscriptions(event *SelfContactChangeEvent) {
+	for _, s := range m.selfContactSubscriptions {
+		select {
+		case s <- event:
+		default:
+			log.Warn("self contact subscription channel full, dropping message")
+		}
+	}
 }

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -1305,10 +1305,6 @@ func (m *Messenger) forgetContactInfoRequest(publicKey string) {
 	delete(m.requestedContacts, publicKey)
 }
 
-func (m *Messenger) GetDeleteForMeMessages() ([]*protobuf.SyncDeleteForMeMessage, error) {
-	return m.persistence.GetDeleteForMeMessages()
-}
-
 func (m *Messenger) SubscribeToSelfContactChanges() chan *SelfContactChangeEvent {
 	s := make(chan *SelfContactChangeEvent, 10)
 	m.selfContactSubscriptions = append(m.selfContactSubscriptions, s)

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
+
+	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/status-im/status-go/deprecation"
 	"github.com/status-im/status-go/eth-node/crypto"

--- a/protocol/messenger_identity.go
+++ b/protocol/messenger_identity.go
@@ -181,6 +181,9 @@ func (m *Messenger) AddOrReplaceSocialLinks(socialLinks identity.SocialLinks) er
 			return err
 		}
 		m.selfContact.SocialLinks = socialLinks
+		m.publishSelfContactSubscriptions(&SelfContactChangeEvent{
+			SocialLinksChanged: true,
+		})
 
 		err = m.syncSocialLinks(context.Background(), m.dispatchMessage)
 		return err

--- a/protocol/messenger_sync_settings.go
+++ b/protocol/messenger_sync_settings.go
@@ -169,10 +169,13 @@ func (m *Messenger) startSettingsChangesLoop() {
 				switch s.GetReactName() {
 				case settings.DisplayName.GetReactName():
 					m.selfContact.DisplayName = s.Value.(string)
+					m.publishSelfContactSubscriptions(&SelfContactChangeEvent{DisplayNameChanged: true})
 				case settings.PreferredName.GetReactName():
 					m.selfContact.EnsName = s.Value.(string)
+					m.publishSelfContactSubscriptions(&SelfContactChangeEvent{PreferredNameChanged: true})
 				case settings.Bio.GetReactName():
 					m.selfContact.Bio = s.Value.(string)
+					m.publishSelfContactSubscriptions(&SelfContactChangeEvent{BioChanged: true})
 				}
 			case <-m.quit:
 				return

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/tt"
@@ -135,43 +134,35 @@ func PairDevices(s *suite.Suite, device1, device2 *Messenger) {
 	s.Require().NoError(err)
 }
 
-func SetSettingsAndWaitForChange(s *suite.Suite, messenger *Messenger, settingsReactNames []string, timeout time.Duration, actionCallback func()) {
-	changedSettings := map[string]struct{}{}
-	wg := sync.WaitGroup{}
+func SetSettingsAndWaitForChange(s *suite.Suite, messenger *Messenger, timeout time.Duration,
+	actionCallback func(), eventCallback func(*SelfContactChangeEvent) bool) {
 
-	for _, reactName := range settingsReactNames {
-		wg.Add(1)
-		settingReactName := reactName // Loop variables captured by 'func' literals in 'go' statements might have unexpected values
-		channel := messenger.settings.SubscribeToChanges()
-		go func() {
-			defer wg.Done()
-			for {
-				select {
-				case setting := <-channel:
-					if setting.GetReactName() == settingReactName {
-						changedSettings[settingReactName] = struct{}{}
-						return
-					}
-				case <-time.After(timeout):
-					return
-				}
+	allEventsReceived := false
+	channel := messenger.SubscribeToSelfContactChanges()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		for !allEventsReceived {
+			select {
+			case event := <-channel:
+				allEventsReceived = eventCallback(event)
+			case <-time.After(timeout):
+				return
 			}
-		}()
-	}
+		}
+	}()
 
 	actionCallback()
 
 	wg.Wait()
-	s.Require().Len(changedSettings, len(settingsReactNames))
 
-	for _, reactName := range settingsReactNames {
-		_, ok := changedSettings[reactName]
-		s.Require().True(ok)
-	}
+	s.Require().True(allEventsReceived)
 }
 
-func SetIdentityImagesAndWaitForChange(s *suite.Suite, multiAccounts *multiaccounts.Database, timeout time.Duration, actionCallback func()) {
-	channel := multiAccounts.SubscribeToIdentityImageChanges()
+func SetIdentityImagesAndWaitForChange(s *suite.Suite, messenger *Messenger, timeout time.Duration, actionCallback func()) {
+	channel := messenger.SubscribeToSelfContactChanges()
 	ok := false
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -179,8 +170,10 @@ func SetIdentityImagesAndWaitForChange(s *suite.Suite, multiAccounts *multiaccou
 	go func() {
 		defer wg.Done()
 		select {
-		case <-channel:
-			ok = true
+		case event := <-channel:
+			if event.ImagesChanged {
+				ok = true
+			}
 		case <-time.After(timeout):
 			return
 		}
@@ -189,5 +182,6 @@ func SetIdentityImagesAndWaitForChange(s *suite.Suite, multiAccounts *multiaccou
 	actionCallback()
 
 	wg.Wait()
+
 	s.Require().True(ok)
 }


### PR DESCRIPTION
`Test_UnfurlURLs_SelfLink` and `Test_SelfContact` are now based on direct self-contact change events.

Previously they were tracking the `selfContact` change by origin events like `ultiAccounts.SubscribeToIdentityImageChanges` and `messenger.settings.SubscribeToChanges`. But because those events are processed by `messenger` in concurrently, it was leading to flaky tests.