### PR TITLE
fix: add option to preserve history on chat delete

### DIFF
--- a/protocol/messenger_chats.go
+++ b/protocol/messenger_chats.go
@@ -383,7 +383,9 @@ func (m *Messenger) DeactivateChat(request *requests.DeactivateChat) (*Messenger
 		return nil, err
 	}
 
-	return m.deactivateChat(request.ID, 0, true, true)
+	doClearHistory := !request.PreserveHistory
+
+	return m.deactivateChat(request.ID, 0, true, doClearHistory)
 }
 
 func (m *Messenger) deactivateChat(chatID string, deactivationClock uint64, shouldBeSynced bool, doClearHistory bool) (*MessengerResponse, error) {

--- a/protocol/requests/deactivate_chat.go
+++ b/protocol/requests/deactivate_chat.go
@@ -7,7 +7,8 @@ import (
 var ErrDeactivateChatInvalidID = errors.New("deactivate-chat: invalid id")
 
 type DeactivateChat struct {
-	ID string `json:"id"`
+	ID              string `json:"id"`
+	PreserveHistory bool   `json:"preserveHistory"`
 }
 
 func (j *DeactivateChat) Validate() error {


### PR DESCRIPTION
The `Delete Chat` action was updated to `Close Chat` which is meant to preserve history. This PR adds the option to preserve the history when calling `DeactivateChat`.

Related mobile issue: https://github.com/status-im/status-mobile/issues/17912