### PR TITLE
Feat/alchemy sepolia support

### DIFF
--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -9,14 +9,17 @@ import (
 )
 
 const (
-	mainnetChainID        uint64 = 1
-	goerliChainID         uint64 = 5
-	optimismChainID       uint64 = 10
-	optimismGoerliChainID uint64 = 420
-	arbitrumChainID       uint64 = 42161
-	arbitrumGoerliChainID uint64 = 421613
-	sntSymbol                    = "SNT"
-	sttSymbol                    = "STT"
+	mainnetChainID         uint64 = 1
+	goerliChainID          uint64 = 5
+	sepoliaChainID         uint64 = 11155111
+	optimismChainID        uint64 = 10
+	optimismGoerliChainID  uint64 = 420
+	optimismSepoliaChainID uint64 = 11155420
+	arbitrumChainID        uint64 = 42161
+	arbitrumGoerliChainID  uint64 = 421613
+	arbitrumSepoliaChainID uint64 = 421614
+	sntSymbol                     = "SNT"
+	sttSymbol                     = "STT"
 )
 
 var ganacheTokenAddress = common.HexToAddress("0x8571Ddc46b10d31EF963aF49b6C7799Ea7eff818")

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -173,17 +173,26 @@ func defaultNodeConfig(installationID string, request *requests.CreateAccount) (
 	if request.AlchemyEthereumGoerliToken != "" {
 		nodeConfig.WalletConfig.AlchemyAPIKeys[goerliChainID] = request.AlchemyEthereumGoerliToken
 	}
+	if request.AlchemyEthereumSepoliaToken != "" {
+		nodeConfig.WalletConfig.AlchemyAPIKeys[sepoliaChainID] = request.AlchemyEthereumSepoliaToken
+	}
 	if request.AlchemyArbitrumMainnetToken != "" {
 		nodeConfig.WalletConfig.AlchemyAPIKeys[arbitrumChainID] = request.AlchemyArbitrumMainnetToken
 	}
 	if request.AlchemyArbitrumGoerliToken != "" {
 		nodeConfig.WalletConfig.AlchemyAPIKeys[arbitrumGoerliChainID] = request.AlchemyArbitrumGoerliToken
 	}
+	if request.AlchemyArbitrumSepoliaToken != "" {
+		nodeConfig.WalletConfig.AlchemyAPIKeys[arbitrumSepoliaChainID] = request.AlchemyArbitrumSepoliaToken
+	}
 	if request.AlchemyOptimismMainnetToken != "" {
 		nodeConfig.WalletConfig.AlchemyAPIKeys[optimismChainID] = request.AlchemyOptimismMainnetToken
 	}
 	if request.AlchemyOptimismGoerliToken != "" {
 		nodeConfig.WalletConfig.AlchemyAPIKeys[optimismGoerliChainID] = request.AlchemyOptimismGoerliToken
+	}
+	if request.AlchemyOptimismSepoliaToken != "" {
+		nodeConfig.WalletConfig.AlchemyAPIKeys[optimismSepoliaChainID] = request.AlchemyOptimismSepoliaToken
 	}
 
 	nodeConfig.LocalNotificationsConfig = params.LocalNotificationsConfig{Enabled: true}

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -52,10 +52,13 @@ type WalletSecretsConfig struct {
 	GanacheURL                  string `json:"ganacheURL"`
 	AlchemyEthereumMainnetToken string `json:"alchemyEthereumMainnetToken"`
 	AlchemyEthereumGoerliToken  string `json:"alchemyEthereumGoerliToken"`
+	AlchemyEthereumSepoliaToken string `json:"alchemyEthereumSepoliaToken"`
 	AlchemyArbitrumMainnetToken string `json:"alchemyArbitrumMainnetToken"`
 	AlchemyArbitrumGoerliToken  string `json:"alchemyArbitrumGoerliToken"`
+	AlchemyArbitrumSepoliaToken string `json:"alchemyArbitrumSepoliaToken"`
 	AlchemyOptimismMainnetToken string `json:"alchemyOptimismMainnetToken"`
 	AlchemyOptimismGoerliToken  string `json:"alchemyOptimismGoerliToken"`
+	AlchemyOptimismSepoliaToken string `json:"alchemyOptimismSepoliaToken"`
 }
 
 func (c *CreateAccount) Validate() error {

--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -14,6 +14,7 @@ const (
 	EthereumSepolia uint64 = 11155111
 	OptimismMainnet uint64 = 10
 	OptimismGoerli  uint64 = 420
+	OptimismSepolia uint64 = 11155420
 	ArbitrumMainnet uint64 = 42161
 	ArbitrumGoerli  uint64 = 421613
 	ArbitrumSepolia uint64 = 421614
@@ -30,6 +31,7 @@ func AllChainIDs() []ChainID {
 		ChainID(EthereumSepolia),
 		ChainID(OptimismMainnet),
 		ChainID(OptimismGoerli),
+		ChainID(OptimismSepolia),
 		ChainID(ArbitrumMainnet),
 		ChainID(ArbitrumGoerli),
 		ChainID(ArbitrumSepolia),

--- a/services/wallet/thirdparty/alchemy/client.go
+++ b/services/wallet/thirdparty/alchemy/client.go
@@ -39,6 +39,8 @@ func getBaseURL(chainID walletCommon.ChainID) (string, error) {
 		return "https://arb-mainnet.g.alchemy.com", nil
 	case walletCommon.ArbitrumGoerli:
 		return "https://arb-goerli.g.alchemy.com", nil
+	case walletCommon.ArbitrumSepolia:
+		return "https://arb-sepolia.g.alchemy.com", nil
 	}
 
 	return "", thirdparty.ErrChainIDNotSupported

--- a/services/wallet/thirdparty/opensea/client_v2.go
+++ b/services/wallet/thirdparty/opensea/client_v2.go
@@ -22,7 +22,7 @@ func getV2BaseURL(chainID walletCommon.ChainID) (string, error) {
 	switch uint64(chainID) {
 	case walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet, walletCommon.OptimismMainnet:
 		return "https://api.opensea.io/v2", nil
-	case walletCommon.EthereumGoerli, walletCommon.EthereumSepolia, walletCommon.ArbitrumGoerli, walletCommon.OptimismGoerli:
+	case walletCommon.EthereumGoerli, walletCommon.EthereumSepolia, walletCommon.ArbitrumGoerli, walletCommon.ArbitrumSepolia, walletCommon.OptimismGoerli:
 		return "https://testnets-api.opensea.io/v2", nil
 	}
 

--- a/services/wallet/thirdparty/opensea/types_v2.go
+++ b/services/wallet/thirdparty/opensea/types_v2.go
@@ -23,6 +23,7 @@ const (
 	ethereumGoerliString  = "goerli"
 	ethereumSepoliaString = "sepolia"
 	arbitrumGoerliString  = "arbitrum_goerli"
+	arbitrumSepoliaString = "arbitrum_sepolia"
 	optimismGoerliString  = "optimism_goerli"
 )
 
@@ -43,6 +44,8 @@ func chainIDToChainString(chainID walletCommon.ChainID) string {
 		chainString = ethereumSepoliaString
 	case walletCommon.ArbitrumGoerli:
 		chainString = arbitrumGoerliString
+	case walletCommon.ArbitrumSepolia:
+		chainString = arbitrumSepoliaString
 	case walletCommon.OptimismGoerli:
 		chainString = optimismGoerliString
 	}


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/12771

Enable support for Sepolia in the Alchemy client

Picking up keys for all chains, but only Eth and Arb are supported by Alchemy at the moment. Opt coming soon.