### PR TITLE
feat: publish test_stats report

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -103,11 +103,25 @@ pipeline {
   post {
     always  {
       script { env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText" }
-      junit '**/report.xml'
+      junit testResults:          '**/report.xml',
+            skipOldReports:       true,
+            skipPublishingChecks: true
+      publishHTML target: [
+        allowMissing:           true,
+        alwaysLinkToLastBuild:  true,
+        keepAll:                true,
+        reportDir:              'reports',
+        reportFiles:            'test_stats.txt',
+        reportName:             'Reports',
+        reportTitles:           'Test Stats'
+      ]
     }
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { dir(env.TMPDIR) { deleteDir() } }
+    cleanup {
+      dir(env.TMPDIR) { deleteDir() }
+      sh "make git-clean"
+    }
   } // post
 } // pipeline
 

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -40,17 +40,22 @@ for package in ${UNIT_TEST_PACKAGES}; do
   fi
 
   if [[ "${go_test_exit}" -ne 0 ]]; then
-    echo -e "${YLW}Failed, see the log:${RST} ${BLD}${output_file}${RST}"
+    if [[ "${CI}" == 'true' ]]; then
+      echo -e "${YLW}Failed, see the log:${RST} ${BLD}${output_file}${RST}"
+    fi
+
     if [[ "$UNIT_TEST_FAILFAST" == 'true' ]]; then
       exit "${go_test_exit}"
     fi
+
     last_failing_exit_code="${go_test_exit}"
   fi
 done
 
 if [[ "${last_failing_exit_code}" -ne 0 ]]; then
   if [[ "${UNIT_TEST_COUNT}" -gt 1 ]]; then
-    "${GIT_ROOT}/_assets/scripts/test_stats.py"
+    mkdir -p "${GIT_ROOT}/reports"
+    "${GIT_ROOT}/_assets/scripts/test_stats.py" | redirect_stdout "${GIT_ROOT}/reports/test_stats.txt"
   fi
 
   exit "${last_failing_exit_code}"


### PR DESCRIPTION
Let's publish test_stats as a Jenkins report instead of printing to the build log.

You can find the report in "Reports" on a left side pane.