### PR TITLE
test: request community from storenode

### DIFF
--- a/protocol/common/shard/shard.go
+++ b/protocol/common/shard/shard.go
@@ -1,8 +1,9 @@
 package shard
 
 import (
-	"github.com/status-im/status-go/protocol/protobuf"
 	wakuproto "github.com/waku-org/go-waku/waku/v2/protocol"
+
+	"github.com/status-im/status-go/protocol/protobuf"
 )
 
 type Shard struct {

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -26,7 +26,6 @@ import (
 
 const testChainID1 = 1
 
-const testENRBootstrap = "enrtree://AL65EKLJAUXKKPG43HVTML5EFFWEZ7L4LOKTLZCLJASG4DSESQZEC@prod.status.nodes.status.im"
 const ownerPassword = "123456"
 const alicePassword = "qwerty"
 const bobPassword = "bob123"
@@ -130,7 +129,7 @@ type MessengerCommunitiesTokenPermissionsSuite struct {
 func (s *MessengerCommunitiesTokenPermissionsSuite) SetupTest() {
 	s.logger = tt.MustCreateTestLogger()
 
-	wakuNodes := createWakuNetwork(&s.Suite, s.logger, []string{"owner", "bob", "alice"})
+	wakuNodes := CreateWakuV2Network(&s.Suite, s.logger, []string{"owner", "bob", "alice"})
 
 	ownerLogger := s.logger.With(zap.String("name", "owner"))
 	s.ownerWaku = wakuNodes[0]

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -2601,7 +2602,7 @@ func (m *Messenger) requestCommunityInfoFromMailserver(communityID string, shard
 
 	defer m.forgetCommunityRequest(communityID)
 
-	to := uint32(m.transport.GetCurrentTime() / 1000)
+	to := uint32(math.Ceil(float64(m.GetCurrentTimeInMillis()) / 1000))
 	from := to - oneMonthInSeconds
 
 	_, err := m.performMailserverRequest(func() (*MessengerResponse, error) {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2589,6 +2589,11 @@ func (m *Messenger) requestCommunityInfoFromMailserver(communityID string, shard
 		}
 		filter = filters[0]
 		m.requestedCommunities[communityID] = filter
+		m.logger.Debug("created filter for community",
+			zap.String("filterID", filter.FilterID),
+			zap.String("communityID", communityID),
+			zap.String("PubsubTopic", filter.PubsubTopic),
+		)
 	} else {
 		//we don't remember filter id associated with community because it was already installed
 		m.requestedCommunities[communityID] = nil
@@ -2623,6 +2628,9 @@ func (m *Messenger) requestCommunityInfoFromMailserver(communityID string, shard
 	if !waitForResponse {
 		return nil, nil
 	}
+
+	// TODO: We can force to process all messages then we don't have to wait?
+	//m.ProcessAllMessages()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -68,11 +68,6 @@ type MessengerSignalsHandler interface {
 }
 
 type config struct {
-	// This needs to be exposed until we move here mailserver logic
-	// as otherwise the client is not notified of a new filter and
-	// won't be pulling messages from mailservers until it reloads the chats/filters
-	onContactENSVerified func(*MessengerResponse)
-
 	// systemMessagesTranslations holds translations for system-messages
 	systemMessagesTranslations *systemMessageTranslationsMap
 	// Config for the envelopes monitor
@@ -283,9 +278,8 @@ func WithSignalsHandler(h MessengerSignalsHandler) Option {
 	}
 }
 
-func WithENSVerificationConfig(onENSVerified func(*MessengerResponse), url, address string) Option {
+func WithENSVerificationConfig(url, address string) Option {
 	return func(c *config) error {
-		c.onContactENSVerified = onENSVerified
 		c.verifyENSURL = url
 		c.verifyENSContractAddress = address
 		return nil

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1333,8 +1333,8 @@ func (m *Messenger) HandleHistoryArchiveMagnetlinkMessage(state *ReceivedMessage
 				defer task.Waiter.Done()
 
 				// this wait groups tracks all ongoing tasks across communities
-				m.downloadHistoryArchiveTasksWaitGroup.Add(1)
-				defer m.downloadHistoryArchiveTasksWaitGroup.Done()
+				m.shutdownWaitGroup.Add(1)
+				defer m.shutdownWaitGroup.Done()
 				m.downloadAndImportHistoryArchives(communityID, magnetlink, task.CancelChan)
 			}(currentTask, id)
 
@@ -1646,8 +1646,8 @@ func (m *Messenger) HandleCommunityRequestToJoinResponse(state *ReceivedMessageS
 					task.Waiter.Add(1)
 					defer task.Waiter.Done()
 
-					m.downloadHistoryArchiveTasksWaitGroup.Add(1)
-					defer m.downloadHistoryArchiveTasksWaitGroup.Done()
+					m.shutdownWaitGroup.Add(1)
+					defer m.shutdownWaitGroup.Done()
 
 					m.downloadAndImportHistoryArchives(community.ID(), magnetlink, task.CancelChan)
 				}(currentTask)

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"context"
 	"crypto/rand"
+	"fmt"
 	"math"
 	"math/big"
 	"sort"
@@ -59,20 +60,34 @@ func (m *Messenger) activeMailserverID() ([]byte, error) {
 	return m.mailserverCycle.activeMailserver.IDBytes()
 }
 
-func (m *Messenger) StartMailserverCycle() error {
+func (m *Messenger) StartMailserverCycle(mailservers []mailservers.Mailserver) error {
+	m.mailserverCycle.allMailservers = mailservers
 
-	if m.server == nil {
-		m.logger.Warn("not starting mailserver cycle")
-		return nil
+	version := m.transport.WakuVersion()
+
+	switch version {
+	case 1:
+		if m.server == nil {
+			m.logger.Warn("not starting mailserver cycle")
+			return nil
+		}
+
+		m.mailserverCycle.events = make(chan *p2p.PeerEvent, 20)
+		m.mailserverCycle.subscription = m.server.SubscribeEvents(m.mailserverCycle.events)
+		go m.updateWakuV1PeerStatus()
+
+	case 2:
+		go m.updateWakuV2PeerStatus()
+
+	default:
+		return fmt.Errorf("unsupported waku version: %d", version)
 	}
 
-	m.logger.Debug("started mailserver cycle")
+	m.logger.Debug("starting mailserver cycle",
+		zap.Uint("WakuVersion", m.transport.WakuVersion()),
+		zap.Any("mailservers", mailservers),
+	)
 
-	m.mailserverCycle.events = make(chan *p2p.PeerEvent, 20)
-	m.mailserverCycle.subscription = m.server.SubscribeEvents(m.mailserverCycle.events)
-
-	go m.updateWakuV1PeerStatus()
-	go m.updateWakuV2PeerStatus()
 	return nil
 }
 
@@ -169,15 +184,17 @@ func (m *Messenger) getFleet() (string, error) {
 }
 
 func (m *Messenger) allMailservers() ([]mailservers.Mailserver, error) {
-	// Append user mailservers
+	// Get configured fleet
 	fleet, err := m.getFleet()
 	if err != nil {
 		return nil, err
 	}
 
+	// Get default mailservers for given fleet
 	allMailservers := m.mailserversByFleet(fleet)
 
-	customMailservers, err := m.mailservers.Mailservers()
+	// Add custom configured mailservers
+	customMailservers, err := m.mailserversDatabase.Mailservers()
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +206,17 @@ func (m *Messenger) allMailservers() ([]mailservers.Mailserver, error) {
 		}
 	}
 
-	return allMailservers, nil
+	// Filter mailservers by configured waku version
+	wakuVersion := m.transport.WakuVersion()
+	matchingMailservers := make([]mailservers.Mailserver, 0, len(allMailservers))
+
+	for _, ms := range allMailservers {
+		if ms.Version == wakuVersion {
+			matchingMailservers = append(matchingMailservers, ms)
+		}
+	}
+
+	return matchingMailservers, nil
 }
 
 type SortedMailserver struct {
@@ -208,24 +235,7 @@ func (m *Messenger) findNewMailserver() error {
 		return m.connectToMailserver(*pinnedMailserver)
 	}
 
-	// Append user mailservers
-	fleet, err := m.getFleet()
-	if err != nil {
-		return err
-	}
-
-	allMailservers := m.mailserversByFleet(fleet)
-
-	customMailservers, err := m.mailservers.Mailservers()
-	if err != nil {
-		return err
-	}
-
-	for _, c := range customMailservers {
-		if c.Fleet == fleet {
-			allMailservers = append(allMailservers, c)
-		}
-	}
+	allMailservers := m.mailserverCycle.allMailservers
 
 	m.logger.Info("Finding a new mailserver...")
 
@@ -340,6 +350,10 @@ func (m *Messenger) connectToMailserver(ms mailservers.Mailserver) error {
 		return err
 	}
 
+	if ms.Version != m.transport.WakuVersion() {
+		return errors.New("mailserver waku version doesn't match")
+	}
+
 	if activeMailserverStatus != connected {
 		// Attempt to connect to mailserver by adding it as a peer
 
@@ -442,15 +456,11 @@ func (m *Messenger) penalizeMailserver(id string) {
 }
 
 func (m *Messenger) handleMailserverCycleEvent(connectedPeers []ConnectedPeer) error {
-	m.logger.Debug("connected peers", zap.Any("connected", connectedPeers))
-	m.logger.Debug("peers info", zap.Any("peer-info", m.mailserverCycle.peers))
+	m.logger.Debug("mailserver cycle event",
+		zap.Any("connected", connectedPeers),
+		zap.Any("peer-info", m.mailserverCycle.peers))
 
 	m.mailPeersMutex.Lock()
-
-	allMailservers, err := m.allMailservers()
-	if err != nil {
-		return err
-	}
 
 	for pID, pInfo := range m.mailserverCycle.peers {
 		if pInfo.status == disconnected {
@@ -461,7 +471,7 @@ func (m *Messenger) handleMailserverCycleEvent(connectedPeers []ConnectedPeer) e
 
 		found := false
 		for _, connectedPeer := range connectedPeers {
-			id, err := m.mailserverAddressToID(connectedPeer.UniqueID, allMailservers)
+			id, err := m.mailserverAddressToID(connectedPeer.UniqueID, m.mailserverCycle.allMailservers)
 			if err != nil {
 				m.logger.Error("failed to convert id to hex", zap.Error(err))
 				return err
@@ -487,7 +497,7 @@ func (m *Messenger) handleMailserverCycleEvent(connectedPeers []ConnectedPeer) e
 	// not available error
 	if m.mailserverCycle.activeMailserver != nil {
 		for _, connectedPeer := range connectedPeers {
-			id, err := m.mailserverAddressToID(connectedPeer.UniqueID, allMailservers)
+			id, err := m.mailserverAddressToID(connectedPeer.UniqueID, m.mailserverCycle.allMailservers)
 			if err != nil {
 				m.logger.Error("failed to convert id to hex", zap.Error(err))
 				return err
@@ -562,12 +572,6 @@ func (m *Messenger) handleMailserverCycleEvent(connectedPeers []ConnectedPeer) e
 }
 
 func (m *Messenger) updateWakuV1PeerStatus() {
-
-	if m.transport.WakuVersion() != 1 {
-		m.logger.Debug("waku version not 1, returning")
-		return
-	}
-
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 
@@ -609,11 +613,6 @@ func (m *Messenger) updateWakuV1PeerStatus() {
 }
 
 func (m *Messenger) updateWakuV2PeerStatus() {
-	if m.transport.WakuVersion() != 2 {
-		m.logger.Debug("waku version not 2, returning")
-		return
-	}
-
 	connSubscription, err := m.transport.SubscribeToConnStatusChanges()
 	if err != nil {
 		m.logger.Error("Could not subscribe to connection status changes", zap.Error(err))
@@ -667,7 +666,7 @@ func (m *Messenger) getPinnedMailserver() (*mailservers.Mailserver, error) {
 		return nil, nil
 	}
 
-	customMailservers, err := m.mailservers.Mailservers()
+	customMailservers, err := m.mailserversDatabase.Mailservers()
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_messages_tracking_test.go
+++ b/protocol/messenger_messages_tracking_test.go
@@ -91,7 +91,7 @@ type MessengerMessagesTrackingSuite struct {
 func (s *MessengerMessagesTrackingSuite) SetupTest() {
 	s.logger = tt.MustCreateTestLogger()
 
-	wakuNodes := createWakuNetwork(&s.Suite, s.logger, []string{"bob", "alice"})
+	wakuNodes := CreateWakuV2Network(&s.Suite, s.logger, []string{"bob", "alice"})
 
 	s.bobWaku = wakuNodes[0]
 	s.bob, s.bobInterceptor = s.newMessenger(s.bobWaku, s.logger.With(zap.String("name", "bob")))

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -1,6 +1,12 @@
 package protocol
 
 import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/status-im/status-go/appdatabase"
 	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
@@ -10,10 +16,6 @@ import (
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/protocol/tt"
 	"github.com/status-im/status-go/t/helpers"
-	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
-	"testing"
-	"time"
 
 	mailserversDB "github.com/status-im/status-go/services/mailservers"
 	waku2 "github.com/status-im/status-go/wakuv2"
@@ -45,10 +47,10 @@ func (s *MessengerStoreNodeRequestSuite) newMessenger(shh types.Waku, logger *za
 	privateKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 
-	mailserversSqlDb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
+	mailserversSQLDb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
 	s.Require().NoError(err)
 
-	mailserversDatabase := mailserversDB.NewDB(mailserversSqlDb)
+	mailserversDatabase := mailserversDB.NewDB(mailserversSQLDb)
 	err = mailserversDatabase.Add(mailserversDB.Mailserver{
 		ID:      localMailserverID,
 		Name:    localMailserverID,

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -80,9 +80,6 @@ func (s *MessengerStoreNodeRequestSuite) SetupTest() {
 	storeNodeLogger := s.logger.With(zap.String("name", "store-node-waku"))
 	s.wakuStoreNode = NewWakuV2(&s.Suite, storeNodeLogger, true, true)
 
-	//protocols := s.wakuStoreNode.Protocols()
-	//s.Require().Contains(protocols, store.StoreID_v20beta4)
-
 	storeNodeListenAddresses := s.wakuStoreNode.ListenAddresses()
 	s.Require().LessOrEqual(1, len(storeNodeListenAddresses))
 

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -1,0 +1,141 @@
+package protocol
+
+import (
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/status-im/status-go/appdatabase"
+	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/protocol/protobuf"
+	"github.com/status-im/status-go/protocol/requests"
+	"github.com/status-im/status-go/protocol/tt"
+	"github.com/status-im/status-go/t/helpers"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+	"testing"
+	"time"
+
+	mailserversDB "github.com/status-im/status-go/services/mailservers"
+	waku2 "github.com/status-im/status-go/wakuv2"
+)
+
+const (
+	localFleet        = "local-test-fleet-1"
+	localMailserverID = "local-test-mailserver"
+)
+
+func TestMessengerStoreNodeRequestSuite(t *testing.T) {
+	suite.Run(t, new(MessengerStoreNodeRequestSuite))
+}
+
+type MessengerStoreNodeRequestSuite struct {
+	suite.Suite
+
+	owner *Messenger
+	bob   *Messenger
+
+	wakuStoreNode *waku2.Waku
+	ownerWaku     types.Waku
+	bobWaku       types.Waku
+
+	logger *zap.Logger
+}
+
+func (s *MessengerStoreNodeRequestSuite) newMessenger(shh types.Waku, logger *zap.Logger, mailserverAddress string) *Messenger {
+	privateKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	mailserversSqlDb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
+	s.Require().NoError(err)
+
+	mailserversDatabase := mailserversDB.NewDB(mailserversSqlDb)
+	err = mailserversDatabase.Add(mailserversDB.Mailserver{
+		ID:      localMailserverID,
+		Name:    localMailserverID,
+		Address: mailserverAddress,
+		Fleet:   localFleet,
+	})
+	s.Require().NoError(err)
+
+	options := []Option{
+		WithMailserversDatabase(mailserversDatabase),
+		WithClusterConfig(params.ClusterConfig{
+			Fleet: localFleet,
+		}),
+	}
+
+	messenger, err := newMessengerWithKey(shh, privateKey, logger, options)
+
+	s.Require().NoError(err)
+	return messenger
+}
+
+func (s *MessengerStoreNodeRequestSuite) SetupTest() {
+	s.logger = tt.MustCreateTestLogger()
+
+	// Create store node
+
+	storeNodeLogger := s.logger.With(zap.String("name", "store-node-waku"))
+	s.wakuStoreNode = NewWakuV2(&s.Suite, storeNodeLogger, true, true)
+
+	//protocols := s.wakuStoreNode.Protocols()
+	//s.Require().Contains(protocols, store.StoreID_v20beta4)
+
+	storeNodeListenAddresses := s.wakuStoreNode.ListenAddresses()
+	s.Require().LessOrEqual(1, len(storeNodeListenAddresses))
+
+	storeNodeAddress := storeNodeListenAddresses[0]
+	s.logger.Info("store node ready", zap.String("address", storeNodeAddress))
+
+	// Create community owner
+
+	ownerWakuLogger := s.logger.With(zap.String("name", "owner-waku"))
+	s.ownerWaku = gethbridge.NewGethWakuV2Wrapper(NewWakuV2(&s.Suite, ownerWakuLogger, true, false))
+
+	ownerLogger := s.logger.With(zap.String("name", "owner"))
+	s.owner = s.newMessenger(s.ownerWaku, ownerLogger, storeNodeAddress)
+
+	// Create an independent user
+
+	bobWakuLogger := s.logger.With(zap.String("name", "owner-waku"))
+	s.bobWaku = gethbridge.NewGethWakuV2Wrapper(NewWakuV2(&s.Suite, bobWakuLogger, true, false))
+
+	bobLogger := s.logger.With(zap.String("name", "bob"))
+	s.bob = s.newMessenger(s.bobWaku, bobLogger, storeNodeAddress)
+	s.bob.StartRetrieveMessagesLoop(time.Second, nil)
+}
+
+func (s *MessengerStoreNodeRequestSuite) TestRequestCommunityInfo() {
+
+	WaitForAvailableStoreNode(&s.Suite, s.owner, time.Second)
+
+	createCommunityRequest := &requests.CreateCommunity{
+		Name:        "panda-lovers",
+		Description: "we love pandas",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+		Color:       "#ff0000",
+		Tags:        []string{"Web3"},
+	}
+
+	response, err := s.owner.CreateCommunity(createCommunityRequest, true)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+	s.Require().Len(response.Communities(), 1)
+
+	community := response.Communities()[0]
+	communityID := community.IDString()
+
+	WaitForAvailableStoreNode(&s.Suite, s.bob, time.Second)
+
+	request := FetchCommunityRequest{
+		CommunityKey:    communityID,
+		Shard:           nil,
+		TryDatabase:     false,
+		WaitForResponse: true,
+	}
+
+	fetchedCommunity, err := s.bob.FetchCommunity(&request)
+	s.Require().NoError(err)
+	s.Require().NotNil(fetchedCommunity)
+	s.Require().Equal(communityID, fetchedCommunity.IDString())
+}

--- a/protocol/messenger_sync_raw_messages.go
+++ b/protocol/messenger_sync_raw_messages.go
@@ -10,8 +10,6 @@ import (
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/protobuf"
-	localnotifications "github.com/status-im/status-go/services/local-notifications"
-	"github.com/status-im/status-go/signal"
 )
 
 type RawMessageHandler func(ctx context.Context, rawMessage common.RawMessage) (common.RawMessage, error)
@@ -313,17 +311,6 @@ func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) er
 	if err != nil {
 		return err
 	}
-	publishMessengerResponse(response)
+	m.PublishMessengerResponse(response)
 	return nil
-}
-
-// this is a copy implementation of the one in ext/service.go, we should refactor this?
-func publishMessengerResponse(response *MessengerResponse) {
-	if !response.IsEmpty() {
-		notifications := response.Notifications()
-		// Clear notifications as not used for now
-		response.ClearNotifications()
-		signal.SendNewMessages(response)
-		localnotifications.PushMessages(notifications)
-	}
 }

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"go.uber.org/zap"
 	"os"
 	"sync"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/suite"
 

--- a/protocol/transport/filters_manager.go
+++ b/protocol/transport/filters_manager.go
@@ -562,7 +562,12 @@ func (f *FiltersManager) LoadPublic(chatID string, pubsubTopic string) (*Filter,
 
 	f.filters[chatID] = chat
 
-	f.logger.Debug("registering filter for", zap.String("chatID", chatID), zap.String("type", "public"), zap.String("topic", filterAndTopic.Topic.String()))
+	f.logger.Debug("registering filter for",
+		zap.String("chatID", chatID),
+		zap.String("type", "public"),
+		zap.String("ContentTopic", filterAndTopic.Topic.String()),
+		zap.String("PubsubTopic", pubsubTopic),
+	)
 
 	return chat, nil
 }

--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -19,8 +19,9 @@
 package wakuv2
 
 import (
-	"github.com/status-im/status-go/wakuv2/common"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
+
+	"github.com/status-im/status-go/wakuv2/common"
 )
 
 // Config represents the configuration state of a waku node.

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1324,7 +1324,12 @@ func (w *Waku) OnNewEnvelopes(envelope *protocol.Envelope, msgType common.Messag
 		w.statusTelemetryClient.PushReceivedEnvelope(envelope)
 	}
 
-	logger := w.logger.With(zap.String("hash", recvMessage.Hash().Hex()), zap.String("envelopeHash", hexutil.Encode(envelope.Hash())), zap.String("contentTopic", envelope.Message().ContentTopic), zap.Int64("timestamp", envelope.Message().Timestamp))
+	logger := w.logger.With(
+		zap.String("envelopeHash", hexutil.Encode(envelope.Hash())),
+		zap.String("contentTopic", envelope.Message().ContentTopic),
+		zap.Int64("timestamp", envelope.Message().Timestamp),
+	)
+
 	logger.Debug("received new envelope")
 	trouble := false
 
@@ -1396,7 +1401,12 @@ func (w *Waku) processQueue() {
 		case <-w.ctx.Done():
 			return
 		case e := <-w.msgQueue:
-			logger := w.logger.With(zap.String("hash", e.Hash().String()), zap.String("contentTopic", e.ContentTopic.ContentTopic()), zap.Int64("timestamp", e.Envelope.Message().Timestamp))
+			logger := w.logger.With(
+				zap.String("envelopeHash", hexutil.Encode(e.Envelope.Hash())),
+				zap.String("pubsubTopic", e.PubsubTopic),
+				zap.String("contentTopic", e.ContentTopic.ContentTopic()),
+				zap.Int64("timestamp", e.Envelope.Message().Timestamp),
+			)
 			if e.MsgType == common.StoreMessageType {
 				// We need to insert it first, and then remove it if not matched,
 				// as messages are processed asynchronously


### PR DESCRIPTION
Required for https://github.com/status-im/status-go/issues/4192

## Implemented `TestRequestCommunityInfo`

Here's the logic of the test:
- Create a waku store node (
- Create a non-store waku node and a messenger using it ("owner")
- Create a non-store waku node and a messenger using it ("bob")
- Connect both waku nodes to the created store node
- owner: create a community
- bob: fetch the community by id
- 🎉 

Tested that this works without internet connection.

## Other bugfixes and improvements

This wouldn't be possible without this:

1. Move `StartRetrieveMessagesLoop` and `PublishMessengerResponse` to Messenger.
This was needed to be able to start the retrieve loop in tests, where we don't have ext service.
Also there was a duplication of `PublishMessengerResponse` in `protocol/messenger_sync_raw_messages.go`.
Also with this I removed `onContactENSVerified`, which improved readability.

2. Added `mailservers` argument to `StartMailserverCycle`.
Previously we were gathering it on every mailserver cycle iteration

3. Added filter by waku version in `Messenger.allMailservers()`
I guess this makes sense no to connect to nodes of different version? cc @richard-ramos 

4. Move `newWakuV2` and `createWakuNetwork` functions to `messenger_testing_utils.go`

5. Remove `Messenger.mailservers`, as it was a duplication of `mailserversDatabase`

6. Refactored `StartMailserverCycle` to check waku version.

7. Removed code duplication in `findNewMailserver`

8. Reformatted and improved some logging.
