### PR TITLE
fix: specify clusterid as 16 when using sharding fleet 

### DIFF
--- a/api/defaults.go
+++ b/api/defaults.go
@@ -23,7 +23,6 @@ const defaultMnemonicLength = 12
 const walletAccountDefaultName = "Ethereum account"
 const keystoreRelativePath = "keystore"
 const defaultKeycardPairingDataFile = "/ethereum/mainnet_rpc/keycard/pairings.json"
-const wakuClusterID uint16 = 16 // as per https://rfc.vac.dev/spec/51/#static-sharding 16 is assigned for Status app
 
 var paths = []string{pathWalletRoot, pathEIP1581, pathDefaultChat, pathDefaultWallet}
 
@@ -116,9 +115,6 @@ func SetFleet(fleet string, nodeConfig *params.NodeConfig) error {
 		return err
 	}
 	nodeConfig.ClusterConfig = *clusterConfig
-	if fleet == shardsTest {
-		nodeConfig.ClusterConfig.ClusterID = wakuClusterID
-	}
 	nodeConfig.ClusterConfig.WakuNodes = defaultWakuNodes[fleet]
 	nodeConfig.ClusterConfig.DiscV5BootstrapNodes = defaultWakuNodes[fleet]
 

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -23,6 +23,7 @@ const defaultMnemonicLength = 12
 const walletAccountDefaultName = "Ethereum account"
 const keystoreRelativePath = "keystore"
 const defaultKeycardPairingDataFile = "/ethereum/mainnet_rpc/keycard/pairings.json"
+const wakuClusterID uint16 = 16 // as per https://rfc.vac.dev/spec/51/#static-sharding 16 is assigned for Status app
 
 var paths = []string{pathWalletRoot, pathEIP1581, pathDefaultChat, pathDefaultWallet}
 
@@ -115,7 +116,9 @@ func SetFleet(fleet string, nodeConfig *params.NodeConfig) error {
 		return err
 	}
 	nodeConfig.ClusterConfig = *clusterConfig
-
+	if fleet == shardsTest {
+		nodeConfig.ClusterConfig.ClusterID = wakuClusterID
+	}
 	nodeConfig.ClusterConfig.WakuNodes = defaultWakuNodes[fleet]
 	nodeConfig.ClusterConfig.DiscV5BootstrapNodes = defaultWakuNodes[fleet]
 

--- a/appdatabase/migrations/bindata.go
+++ b/appdatabase/migrations/bindata.go
@@ -95,6 +95,7 @@
 // 1697123233_drop_include_watch_only_account_to_settings_sync_clock.up.sql (72B)
 // 1697623289_add_omit_transfers_history_scan_to_settings.up.sql (92B)
 // 1699577175_use_shards.up.sql (84B)
+// 1700741911_clusterID.up.sql (75B)
 // doc.go (74B)
 // report.xml (266B)
 
@@ -2060,8 +2061,28 @@ func _1699577175_use_shardsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1699577175_use_shards.up.sql", size: 84, mode: os.FileMode(0664), modTime: time.Unix(1699578013, 0)}
+	info := bindataFileInfo{name: "1699577175_use_shards.up.sql", size: 84, mode: os.FileMode(0664), modTime: time.Unix(1699884737, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3c, 0xc9, 0x51, 0x6d, 0x40, 0xb9, 0x96, 0xd2, 0xe3, 0xfc, 0xd8, 0xb1, 0xdf, 0xc7, 0x55, 0xf6, 0x63, 0xb4, 0xec, 0xc1, 0xe5, 0xb9, 0xcc, 0xa, 0xaa, 0xac, 0x49, 0x20, 0x7f, 0xdd, 0xa2, 0x71}}
+	return a, nil
+}
+
+var __1700741911_clusteridUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x48\xce\x29\x2d\x2e\x49\x2d\x8a\x4f\xce\xcf\x4b\xcb\x4c\x57\x70\x74\x71\x51\x70\xf6\xf7\x09\xf5\xf5\x83\xcb\x64\xa6\x28\x78\xfa\x85\x28\xf8\xf9\x87\x28\xf8\x85\xfa\xf8\x28\xb8\xb8\xba\x39\x86\xfa\x84\x28\xa8\x1b\xa8\x5b\x73\x01\x02\x00\x00\xff\xff\xce\x90\x14\xb6\x4b\x00\x00\x00")
+
+func _1700741911_clusteridUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1700741911_clusteridUpSql,
+		"1700741911_clusterID.up.sql",
+	)
+}
+
+func _1700741911_clusteridUpSql() (*asset, error) {
+	bytes, err := _1700741911_clusteridUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1700741911_clusterID.up.sql", size: 75, mode: os.FileMode(0664), modTime: time.Unix(1700742797, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x38, 0x60, 0x13, 0x88, 0x61, 0x66, 0xe0, 0xf3, 0x38, 0x91, 0x1a, 0x91, 0xa7, 0x0, 0x7b, 0x32, 0x5e, 0x8, 0xa9, 0xb3, 0x76, 0x5, 0xeb, 0xf, 0x37, 0x85, 0xdf, 0x5c, 0xed, 0x34, 0x50, 0x9e}}
 	return a, nil
 }
 
@@ -2386,6 +2407,8 @@ var _bindata = map[string]func() (*asset, error){
 
 	"1699577175_use_shards.up.sql": _1699577175_use_shardsUpSql,
 
+	"1700741911_clusterID.up.sql": _1700741911_clusteridUpSql,
+
 	"doc.go": docGo,
 
 	"report.xml": reportXml,
@@ -2527,6 +2550,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1697123233_drop_include_watch_only_account_to_settings_sync_clock.up.sql": &bintree{_1697123233_drop_include_watch_only_account_to_settings_sync_clockUpSql, map[string]*bintree{}},
 	"1697623289_add_omit_transfers_history_scan_to_settings.up.sql":            &bintree{_1697623289_add_omit_transfers_history_scan_to_settingsUpSql, map[string]*bintree{}},
 	"1699577175_use_shards.up.sql":                                             &bintree{_1699577175_use_shardsUpSql, map[string]*bintree{}},
+	"1700741911_clusterID.up.sql":                                              &bintree{_1700741911_clusteridUpSql, map[string]*bintree{}},
 	"doc.go":                                                                   &bintree{docGo, map[string]*bintree{}},
 	"report.xml":                                                               &bintree{reportXml, map[string]*bintree{}},
 }}

--- a/appdatabase/migrations/sql/1700741911_clusterID.up.sql
+++ b/appdatabase/migrations/sql/1700741911_clusterID.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cluster_config ADD COLUMN cluster_id INT NOT NULL DEFAULT '0';

--- a/config/cli/fleet-shards.test.json
+++ b/config/cli/fleet-shards.test.json
@@ -2,6 +2,7 @@
   "Rendezvous": false,
   "NoDiscovery": true,
   "ClusterConfig": {
+    "ClusterID": 16,
     "Enabled": true,
     "Fleet": "status.prod",
     "BootNodes": [],

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1000,9 +1000,15 @@ func SwitchFleet(fleet string, configJSON string) string {
 		}
 	}
 
-	conf.ClusterConfig.Fleet = fleet
+	clusterConfig, err := params.LoadClusterConfigFromFleet(fleet)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
 
-	err := statusBackend.SwitchFleet(fleet, &conf)
+	conf.ClusterConfig.Fleet = fleet
+	conf.ClusterConfig.ClusterID = clusterConfig.ClusterID
+
+	err = statusBackend.SwitchFleet(fleet, &conf)
 
 	return makeJSONResponse(err)
 }

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -330,7 +330,7 @@ func (b *StatusNode) wakuV2Service(nodeConfig *params.NodeConfig, telemetryServe
 			DefaultShardPubsubTopic: shard.DefaultShardPubsubTopic(),
 			UseShardAsDefaultTopic:  nodeConfig.WakuV2Config.UseShardAsDefaultTopic,
 			TelemetryServerURL:      telemetryServerURL,
-			ClusterId:               nodeConfig.ClusterConfig.ClusterID,
+			ClusterID:               nodeConfig.ClusterConfig.ClusterID,
 		}
 
 		if nodeConfig.WakuV2Config.MaxMessageSize > 0 {

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -330,6 +330,7 @@ func (b *StatusNode) wakuV2Service(nodeConfig *params.NodeConfig, telemetryServe
 			DefaultShardPubsubTopic: shard.DefaultShardPubsubTopic(),
 			UseShardAsDefaultTopic:  nodeConfig.WakuV2Config.UseShardAsDefaultTopic,
 			TelemetryServerURL:      telemetryServerURL,
+			ClusterId:               nodeConfig.ClusterConfig.ClusterID,
 		}
 
 		if nodeConfig.WakuV2Config.MaxMessageSize > 0 {

--- a/nodecfg/node_config.go
+++ b/nodecfg/node_config.go
@@ -245,6 +245,16 @@ func insertWakuV2ShardConfig(tx *sql.Tx, c *params.NodeConfig) error {
 	WHERE synthetic_id = 'id'`,
 		c.WakuV2Config.UseShardAsDefaultTopic,
 	)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec(`
+	UPDATE cluster_config
+	SET cluster_id = ?
+	WHERE synthetic_id = 'id'`,
+		c.ClusterConfig.ClusterID,
+	)
 
 	return err
 }
@@ -516,7 +526,7 @@ func loadNodeConfig(tx *sql.Tx) (*params.NodeConfig, error) {
 		nodecfg.Networks = append(nodecfg.Networks, n)
 	}
 
-	err = tx.QueryRow("SELECT enabled, fleet FROM cluster_config WHERE synthetic_id = 'id'").Scan(&nodecfg.ClusterConfig.Enabled, &nodecfg.ClusterConfig.Fleet)
+	err = tx.QueryRow("SELECT enabled, fleet, cluster_id FROM cluster_config WHERE synthetic_id = 'id'").Scan(&nodecfg.ClusterConfig.Enabled, &nodecfg.ClusterConfig.Fleet, &nodecfg.ClusterConfig.ClusterID)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -271,6 +271,9 @@ type ClusterConfig struct {
 
 	// DiscV5Nodes is a list of enr to be used for ambient discovery
 	DiscV5BootstrapNodes []string
+
+	//Waku network identifier
+	ClusterID uint16
 }
 
 // String dumps config object as nicely indented JSON

--- a/static/bindata.go
+++ b/static/bindata.go
@@ -6,7 +6,7 @@
 // ../config/cli/anon-metric-node-server.json (696B)
 // ../config/cli/fleet-eth.prod.json (3.619kB)
 // ../config/cli/fleet-eth.staging.json (2.139kB)
-// ../config/cli/fleet-shards.test.json (1.954kB)
+// ../config/cli/fleet-shards.test.json (1.975kB)
 // ../config/cli/fleet-status.prod.json (2.338kB)
 // ../config/cli/fleet-status.test.json (1.457kB)
 // ../config/cli/fleet-wakuv2.prod.json (1.264kB)
@@ -104,7 +104,7 @@ func emojisTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "emojis.txt", size: 28134, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "emojis.txt", size: 28134, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf5, 0x28, 0xc, 0x22, 0x34, 0xa1, 0xeb, 0x8, 0x8d, 0xef, 0x38, 0x1b, 0xd8, 0xc2, 0x1a, 0x6d, 0xa2, 0x62, 0xad, 0x43, 0xfc, 0x1c, 0x38, 0xda, 0x8c, 0x3f, 0x34, 0xa, 0x8c, 0x6f, 0x5d, 0xd8}}
 	return a, nil
 }
@@ -124,7 +124,7 @@ func ConfigReadmeMd() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/README.md", size: 3031, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/README.md", size: 3031, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x15, 0x44, 0x2b, 0x13, 0x14, 0x34, 0xa, 0x66, 0x62, 0x1b, 0xc6, 0x4a, 0x2c, 0x7d, 0x4d, 0x89, 0xfb, 0xc9, 0x69, 0xe4, 0x18, 0x5f, 0x3, 0x98, 0x6d, 0x3c, 0x9e, 0xa8, 0xcd, 0x53, 0x5d, 0x75}}
 	return a, nil
 }
@@ -144,7 +144,7 @@ func ConfigCliAnonMetricNodeClientJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/anon-metric-node-client.json", size: 857, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/cli/anon-metric-node-client.json", size: 857, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x90, 0xdf, 0xcd, 0xc8, 0x92, 0x1d, 0x63, 0x5e, 0xe1, 0xf9, 0x7f, 0xed, 0xf2, 0x68, 0x6b, 0x20, 0xff, 0x1d, 0x3b, 0xc9, 0x7b, 0xb9, 0x6a, 0xba, 0xd3, 0xbd, 0xf7, 0x48, 0x7b, 0x5a, 0x52, 0x79}}
 	return a, nil
 }
@@ -164,7 +164,7 @@ func ConfigCliAnonMetricNodeServerJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/anon-metric-node-server.json", size: 696, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/cli/anon-metric-node-server.json", size: 696, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf0, 0x2f, 0x97, 0xab, 0x77, 0x61, 0x93, 0x9d, 0x1f, 0x33, 0x18, 0x72, 0xad, 0xce, 0xa3, 0x35, 0xa9, 0x44, 0xbf, 0x29, 0xa8, 0xea, 0x21, 0xb7, 0x22, 0x7f, 0x7d, 0x3a, 0x6b, 0x55, 0x3c, 0x66}}
 	return a, nil
 }
@@ -184,7 +184,7 @@ func ConfigCliFleetEthProdJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/fleet-eth.prod.json", size: 3619, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/cli/fleet-eth.prod.json", size: 3619, mode: os.FileMode(0664), modTime: time.Unix(1685365190, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x92, 0x4f, 0x86, 0x8b, 0x6e, 0x2, 0x27, 0xa3, 0x37, 0x27, 0x74, 0x51, 0xf0, 0x97, 0x5b, 0x64, 0x8e, 0xbd, 0x29, 0xba, 0x75, 0x2d, 0x75, 0x78, 0x46, 0xb9, 0x56, 0x6, 0xb1, 0xf9, 0x85, 0xdd}}
 	return a, nil
 }
@@ -204,12 +204,12 @@ func ConfigCliFleetEthStagingJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/fleet-eth.staging.json", size: 2139, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/cli/fleet-eth.staging.json", size: 2139, mode: os.FileMode(0664), modTime: time.Unix(1685365190, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb0, 0xac, 0xc9, 0x61, 0x97, 0x42, 0x0, 0x3a, 0xfc, 0x78, 0x11, 0xa1, 0xc7, 0x55, 0x71, 0x46, 0x72, 0x3e, 0x52, 0xb0, 0x89, 0x69, 0x7f, 0x8f, 0xf1, 0x26, 0x44, 0xc5, 0xfc, 0x20, 0x9f, 0xa1}}
 	return a, nil
 }
 
-var _ConfigCliFleetShardsTestJson = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xac\x55\x4d\x6f\x22\x39\x14\xbc\xe7\x57\xb4\x38\x2f\x89\x3f\xdb\x76\x6e\x09\x5f\x11\x21\x08\x08\x0d\x09\xab\x3d\x3c\xdb\xcf\xd0\x10\xba\x43\x7f\x10\xc2\x6a\xfe\xfb\x8a\x99\xcc\xce\xcc\x8e\xb2\xd2\x6c\xf6\xfa\x5e\xc9\x55\xae\x2a\xcb\x7f\x9e\x45\x51\x63\x82\x99\xc7\xe3\x3e\xaf\xcb\xc6\x65\x14\xe0\xa9\xc4\xdf\x4e\xe3\x61\xde\x4e\x4b\x97\xef\xb1\x78\x6d\x5c\x46\x55\x51\x7f\x19\xb7\x9e\xea\xb2\xc2\xa2\x95\x67\x21\x5d\x36\x2e\xa3\xd3\x11\x51\xd4\xe8\x64\x60\x9f\xd0\x7f\x87\x8c\xa2\x46\xf7\x09\xb1\x6a\x5c\x46\x8d\xb2\x82\xaa\x2e\xcf\x9f\x8b\xdc\x37\xde\x76\xd7\x79\x5e\x0d\x73\x8f\x27\xd2\xdf\xff\x78\x1b\x4e\x8b\xd3\xe1\xfe\x0e\xd2\xa7\x7b\x2c\xf6\x58\xfc\xb0\x1d\xd5\xe5\x6a\x98\x57\x69\x48\x1d\x54\x69\x9e\x95\xdf\x61\x3e\x23\xa2\xa8\x21\x08\xb5\x20\xd1\x83\x20\x2c\x56\xda\x3b\xa5\x81\x80\x20\xc1\x13\x65\x64\x10\x08\xda\x52\xe4\xc2\x28\xe6\x84\xa7\xd2\x05\xce\xc1\x11\xca\x0c\xe3\x82\x3a\x6d\x02\x71\xd6\xc5\x5c\x05\x30\x41\x01\x0f\x01\x89\x35\x3e\xa0\x21\x68\x9c\x07\x54\x40\x85\x61\x52\x12\x02\x96\x50\x1b\x83\xa1\x2e\x56\x16\x50\x30\x30\x0a\xde\xae\x17\x45\x0d\xaa\x29\x15\xd4\x52\x4f\x29\x35\x44\x03\x04\x22\x83\x50\x5a\x63\xac\x94\x46\x47\x14\x51\x1c\xa8\x17\x48\x1d\x0a\xee\x14\xd7\x54\x3a\x41\x10\x05\x2a\x2e\x24\x50\x67\x83\x04\x43\x40\xc8\x10\x13\x6a\x03\x57\x31\x0f\x94\x59\x8c\xb9\x25\x34\x66\xc2\x02\x0d\x3c\x46\xb4\x46\x2a\x26\xa4\x44\x45\xb8\xb0\x3a\x98\xc0\x9c\xf8\xa6\x44\x86\xe0\xb8\xf0\x32\x04\x0f\x54\x13\x6f\x84\xf3\xdc\x28\xe1\x0d\x7a\x66\x2d\xd1\x0c\x3d\xc6\x3a\x70\xc1\x2c\x58\x6f\x51\x13\xea\x30\x04\xab\x3c\x18\xc2\x88\x56\x5e\xf0\x60\x00\x4c\x4c\x9d\xb2\x5a\x12\x66\xb8\xd4\x5a\x09\x47\x34\x06\x22\xd0\x81\x37\x81\x7a\x23\x81\x06\x82\x42\x68\x67\xbd\x97\x9e\x08\x2e\x89\x53\x8d\xcf\x42\xbe\xa6\x78\x5f\x41\x95\xba\x9f\xa2\xff\xd6\xc2\x9f\x56\x73\xd8\xd4\x7f\x0f\xbf\x5e\xea\xc2\x67\xa5\xb8\xb0\x79\x5e\x35\x09\x3d\xf7\x79\x13\xb6\x25\x3f\x2f\x57\x50\xf8\xf2\xbc\xc2\xb2\x3a\xff\x52\xba\x74\x7b\x9e\x61\x75\x51\xb9\xe7\x0b\x4e\x38\xe1\x17\xcf\xec\xf9\x82\xc6\x49\x5a\xb3\x9b\xab\xed\xd5\x84\x89\x3b\x6b\xe3\x59\x7d\xcc\x5f\x93\xb4\x77\x10\x2c\xc1\xac\xbd\x29\x57\x9d\xe1\xac\xbd\x16\xbb\x6c\xbb\xb5\x60\x07\xfb\x9c\xd3\x6f\x86\xfe\xc8\xbd\x74\xcd\xba\x6c\x3a\xcc\xaa\x02\x9e\x68\x13\x7e\x59\x84\xde\x26\x0b\xaa\xab\xeb\xf9\xe8\xa1\x3d\x2e\xa1\xab\x46\xb6\x75\xfb\x78\xc5\xe5\x51\xcd\xaf\xd9\x61\xb8\xb8\x61\x9d\xd9\x8e\xee\xee\xf5\xa0\xff\x9e\x08\x70\x4d\x97\x35\x57\x79\xb6\xdc\xe4\xd9\xb2\xe9\x7e\x59\x44\xef\xc5\x75\xf4\x5e\x2d\xb7\xfd\x61\x67\xde\xad\x16\x55\xbe\x7e\x7c\x1e\xdd\x4d\x6f\x5e\xd9\xfa\x7a\x30\x88\x0f\x93\x0d\xe7\xbb\x65\xfb\xd0\x9d\x3f\xfc\x18\xe8\x29\x9e\xfb\x2a\x2f\xf0\x9d\x8c\xca\xd3\xee\x43\x21\x25\xbe\x18\xf3\xfa\xe5\x58\x77\x44\xef\x55\xb4\x65\xbc\x7a\x88\xeb\xc1\x6d\x07\xb1\xe8\x5f\x65\xab\xdb\xce\xcd\x82\xb7\x0f\x5d\xda\x09\xd3\x7f\xfa\xf3\x46\xce\xfe\x33\xb9\x81\x76\x7f\xb4\x59\xf5\x0e\x8e\xdd\x77\x5d\xe7\xaa\x35\xed\xfa\x85\xa1\x63\x39\xed\xaf\x9f\x55\xbc\x5b\x74\x56\x3b\x93\x76\xa5\x39\xa8\xc9\x3b\xe4\xff\x43\x45\xee\x3a\x83\x56\xce\xa8\x5e\x65\xae\x55\x4d\xf7\x2d\xd6\x7e\xb1\xb8\xe6\x85\x7d\xbd\x19\xbb\x89\xc6\xe2\x61\x98\xdd\xf6\x30\x55\xf3\xd1\xe2\x5d\x0b\x3e\xac\xa2\x9f\xcd\x26\x6a\x71\xec\xc2\xe3\xde\xa5\xa3\x19\x84\xe4\xa1\x7e\xec\x0d\x6e\x46\xc7\xfb\x24\x5d\xee\xae\xb6\x38\x7c\x31\x59\x3f\x99\xf5\xf0\xee\x5d\x2f\x3e\xdc\x54\x76\xa7\x0e\xa5\x72\x83\x91\xe3\x6b\xd8\xc2\xcb\xa6\xb3\xb3\x85\x72\x49\xff\x81\xd2\x7a\xff\xa8\x06\x87\x71\x3c\xef\x26\x3e\xb9\x4d\xde\xaf\xc3\x87\x55\x98\xd6\x78\x55\xd6\x2f\xa3\x89\x14\x3b\xa6\x36\xc3\xb5\x49\x61\x3c\x0b\xaf\x93\xe3\xb4\x77\x5b\xac\xba\xdb\xc2\x88\xbc\xad\xeb\x75\x12\x8f\xde\xde\xcb\x59\x14\x7d\xfa\xfc\x87\x9e\x5e\xcc\x8c\xfd\xfb\x17\x7a\x02\x9f\x7d\x3a\xfb\x2b\x00\x00\xff\xff\xfd\x07\x20\x5a\xa2\x07\x00\x00")
+var _ConfigCliFleetShardsTestJson = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xac\x55\x5d\x53\x22\x39\x14\x7d\xf7\x57\x74\xf1\x3c\x68\xbe\xba\x93\xf8\xa6\xd0\xe0\x22\x52\x80\x34\x28\x5b\xfb\x70\x93\xdc\x40\x83\x74\x4b\x7f\x20\xb2\x35\xff\x7d\x8b\xd1\x59\xc7\x99\xf2\x61\xd6\x7d\x3d\xf7\x26\xf7\xe4\x9c\x93\xba\x7f\x9f\x04\x41\x63\x8c\x99\xc3\xc3\x2e\xaf\xcb\xc6\x79\xe0\xe1\xa1\xc4\x2f\x47\x78\x90\xb7\xd3\xd2\xe6\x3b\x2c\x9e\x1b\xe7\x41\x55\xd4\x2f\x70\xeb\xa1\x2e\x2b\x2c\x5a\x79\xe6\xd3\x45\xe3\x3c\x38\x5e\xf1\x06\xff\xd1\x6e\x9c\x07\x34\xfa\xf2\x02\xc6\x19\x98\x07\x74\x3f\x1c\x0f\x82\x46\xe7\x01\xb1\x6a\x9c\x07\x8d\xb2\x82\xaa\x2e\x4f\x1f\x8b\xdc\x35\x5e\x6b\x97\x79\x5e\x0d\x72\x87\x47\x26\x7f\xfe\xf5\x0a\x4e\x8a\xe3\xd5\xee\x06\xd2\x87\x5b\x2c\x76\x58\xbc\xab\x0e\xeb\x72\x39\xc8\xab\xd4\xa7\x16\xaa\x34\xcf\xca\x1f\x7a\xbe\x75\x04\x41\x43\x10\x6a\x20\x44\x07\x82\xb0\x48\x2a\x67\xa5\x02\x02\x82\x78\x47\xa4\x0e\xbd\x40\x50\x86\x22\x17\x5a\x32\x2b\x1c\x0d\xad\xe7\x1c\x2c\xa1\x4c\x33\x2e\xa8\x55\xda\x13\x6b\x6c\xc4\xa5\x07\xed\x25\x70\xef\x91\x18\xed\x3c\x6a\x82\xda\x3a\x40\x09\x54\x68\x16\x86\x84\x80\x21\xd4\x44\xa0\xa9\x8d\xa4\x01\x14\x0c\xb4\x84\xd7\xe7\x05\x41\x83\x2a\x4a\x05\x35\xd4\x51\x4a\x35\x51\x00\x9e\x84\x5e\x48\xa5\x30\x92\x52\xa1\x25\x92\x48\x0e\xd4\x09\xa4\x16\x05\xb7\x92\x2b\x1a\x5a\x41\x10\x05\x4a\x2e\x42\xa0\xd6\xf8\x10\x34\x01\x11\xfa\x88\x50\xe3\xb9\x8c\xb8\xa7\xcc\x60\xc4\x0d\xa1\x11\x13\x06\xa8\xe7\x11\xa2\xd1\xa1\x64\x22\x0c\x51\x12\x2e\x8c\xf2\xda\x33\x2b\xde\x98\x84\xde\x5b\x2e\x5c\xe8\xbd\x03\xaa\x88\xd3\xc2\x3a\xae\xa5\x70\x1a\x1d\x33\x86\x28\x86\x0e\x23\xe5\xb9\x60\x06\x8c\x33\xa8\x08\xb5\xe8\xbd\x91\x0e\x34\x61\x44\x49\x27\xb8\xd7\x00\x3a\xa2\x56\x1a\x15\x12\xa6\x79\xa8\x94\x14\x96\x28\xf4\x44\xa0\x05\xa7\x3d\x75\x3a\x04\xea\x09\x0a\xa1\xac\x71\x2e\x74\x44\xf0\x90\x58\xd9\xf8\x46\xe4\xbb\x8b\xb7\x15\x54\xa9\xfd\xc5\xfa\xb7\x68\xfe\x52\x9a\xc1\xba\xfe\x17\xfc\xfe\xa8\x33\x97\x95\xe2\xcc\xe4\x79\xd5\x24\xf4\xd4\xe5\x4d\xd8\x94\xfc\xb4\x5c\x42\xe1\xca\xd3\x0a\xcb\xea\xf4\x25\x74\xe9\xe6\x34\xc3\xea\xac\xb2\x8f\x67\x9c\x70\xc2\xcf\x1e\xd9\xe3\x19\x8d\x92\xb4\x66\x57\x17\x9b\x8b\x31\x13\x37\xc6\x44\xd3\xfa\x90\x3f\x27\x69\x77\x2f\x58\x82\x59\x7b\x5d\x2e\xe3\xc1\xb4\xbd\x12\xdb\x6c\xb3\x31\x60\xfa\xbb\x9c\xd3\x37\x41\xdf\xcf\x5e\xd8\x66\x5d\x36\x2d\x66\x55\x01\x0f\xb4\x09\xbf\x4d\x42\x6d\x92\x39\x55\xd5\xe5\x6c\x78\xd7\x1e\x95\xd0\x91\x43\xd3\xba\xbe\xbf\xe0\xe1\x41\xce\x2e\xd9\x7e\x30\xbf\x62\xf1\x74\x4b\xb7\xb7\xaa\xdf\xfb\x88\x04\xd8\xa6\xcd\x9a\xcb\x3c\x5b\xac\xf3\x6c\xd1\xb4\xbf\x4d\xa2\xfb\x64\x63\xb5\x93\x8b\x4d\x6f\x10\xcf\x3a\xd5\xbc\xca\x57\xf7\x8f\xc3\x9b\xc9\xd5\x33\x5b\x5d\xf6\xfb\xd1\x7e\xbc\xe6\x7c\xbb\x68\xef\x3b\xb3\xbb\xf7\x86\x1e\xed\xb9\xad\xf2\x02\x3f\xf0\xa8\x3c\xd6\x3e\x65\x52\xe2\x8a\x11\xaf\x9f\x0e\x75\x2c\xba\xcf\xa2\x1d\x46\xcb\xbb\xa8\xee\x5f\xc7\x88\x45\xef\x22\x5b\x5e\xc7\x57\x73\xde\xde\x77\x68\xec\x27\x3f\xeb\xf3\x3a\x9c\xfd\xe7\xe1\x1a\xda\xbd\xe1\x7a\xd9\xdd\x5b\x76\xdb\xb1\xf1\x45\x6b\xd2\x71\x73\x4d\x47\xe1\xa4\xb7\x7a\x94\xd1\x76\x1e\x2f\xb7\x3a\xed\x84\x7a\x2f\xc7\x1f\x0c\xff\x1f\x22\x72\x13\xf7\x5b\x39\xa3\x6a\x99\xd9\x56\x35\xd9\xb5\x58\xfb\xc9\xe0\x8a\x17\xe6\xf9\x6a\x64\xc7\x0a\x8b\xbb\x41\x76\xdd\xc5\x54\xce\x86\xf3\x0f\x25\xf8\x34\x8b\x5e\x36\x1d\xcb\xf9\xa1\x03\xf7\x3b\x9b\x0e\xa7\xe0\x93\xbb\xfa\xbe\xdb\xbf\x1a\x1e\x6e\x93\x74\xb1\xbd\xd8\xe0\xe0\x49\x67\xbd\x64\xda\xc5\x9b\x0f\xb5\xf8\x74\x52\xd9\x8d\xdc\x97\xd2\xf6\x87\x96\xaf\x60\x03\x4f\xeb\x78\x6b\x0a\x69\x93\xde\x1d\xa5\xf5\xee\x5e\xf6\xf7\xa3\x68\xd6\x49\x5c\x72\x9d\x7c\x1c\x87\x4f\xb3\xd0\xad\xd1\xb2\xac\x9f\x86\xe3\x50\x6c\x99\x5c\x0f\x56\x3a\x85\xd1\xd4\x3f\x8f\x0f\x93\xee\x75\xb1\xec\x6c\x0a\x2d\xf2\xb6\xaa\x57\x49\x34\x7c\xfd\x2f\x27\x41\xf0\xf5\xdb\x62\x3d\xfe\x98\x29\xfb\x79\xaf\xbe\x5f\xa1\xc7\xe6\x93\xaf\x27\xff\x04\x00\x00\xff\xff\xb4\x17\xa3\x9b\xb7\x07\x00\x00")
 
 func ConfigCliFleetShardsTestJsonBytes() ([]byte, error) {
 	return bindataRead(
@@ -224,8 +224,8 @@ func ConfigCliFleetShardsTestJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/fleet-shards.test.json", size: 1954, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
-	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xcf, 0xeb, 0x33, 0xd4, 0x3, 0x54, 0xff, 0xda, 0x1f, 0xc4, 0xc, 0x91, 0x88, 0x1e, 0x53, 0xbf, 0x49, 0xa, 0x6c, 0x45, 0xf9, 0x19, 0x91, 0xec, 0xe, 0x1a, 0xfc, 0x14, 0x86, 0x8d, 0xa3, 0x5a}}
+	info := bindataFileInfo{name: "../config/cli/fleet-shards.test.json", size: 1975, mode: os.FileMode(0664), modTime: time.Unix(1700741336, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x27, 0x67, 0x7, 0x87, 0xe, 0x4, 0xdb, 0x1b, 0x36, 0x6b, 0x15, 0x8f, 0xd2, 0xd1, 0x57, 0x7e, 0xb3, 0x9c, 0x74, 0x5a, 0x43, 0x7a, 0x6a, 0xf1, 0x86, 0x16, 0xda, 0x3b, 0x9e, 0x30, 0x6b, 0x9e}}
 	return a, nil
 }
 
@@ -244,7 +244,7 @@ func ConfigCliFleetStatusProdJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/fleet-status.prod.json", size: 2338, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/cli/fleet-status.prod.json", size: 2338, mode: os.FileMode(0664), modTime: time.Unix(1685365190, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x59, 0xea, 0x14, 0x57, 0xed, 0x60, 0x4d, 0xb6, 0x32, 0x7e, 0xd3, 0xbe, 0x1e, 0xc7, 0xfe, 0x42, 0xee, 0xfe, 0x10, 0xe4, 0x22, 0x64, 0xc1, 0xb9, 0xce, 0x34, 0xcd, 0xdd, 0xe3, 0x38, 0x43, 0xd3}}
 	return a, nil
 }
@@ -264,7 +264,7 @@ func ConfigCliFleetStatusTestJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/fleet-status.test.json", size: 1457, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/cli/fleet-status.test.json", size: 1457, mode: os.FileMode(0664), modTime: time.Unix(1685365190, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc9, 0x9f, 0x8f, 0x25, 0x1f, 0x31, 0xbd, 0x72, 0x26, 0xb7, 0xd, 0x7e, 0xcb, 0xbb, 0x12, 0xef, 0x9f, 0x1a, 0x2e, 0xb, 0x96, 0x64, 0x7d, 0x52, 0x9e, 0x68, 0x13, 0x55, 0xd5, 0x88, 0x38, 0x7b}}
 	return a, nil
 }
@@ -284,7 +284,7 @@ func ConfigCliFleetWakuv2ProdJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/fleet-wakuv2.prod.json", size: 1264, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/cli/fleet-wakuv2.prod.json", size: 1264, mode: os.FileMode(0664), modTime: time.Unix(1685365190, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x71, 0xb9, 0x1c, 0x57, 0x50, 0xa9, 0x93, 0x70, 0xcd, 0xd7, 0x22, 0xee, 0x65, 0x72, 0x11, 0x71, 0xd3, 0x20, 0xd0, 0xf0, 0x4d, 0x53, 0x94, 0x44, 0x81, 0xbd, 0x11, 0xed, 0x5e, 0x72, 0x0, 0x12}}
 	return a, nil
 }
@@ -304,7 +304,7 @@ func ConfigCliFleetWakuv2TestJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/fleet-wakuv2.test.json", size: 1264, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/cli/fleet-wakuv2.test.json", size: 1264, mode: os.FileMode(0664), modTime: time.Unix(1685365190, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2c, 0x67, 0x1e, 0xd1, 0x98, 0x7b, 0xf3, 0x9f, 0x76, 0xa0, 0xbe, 0x67, 0x29, 0xdb, 0xd7, 0x3e, 0xb8, 0x7c, 0x65, 0x2d, 0x2, 0x84, 0xe0, 0xab, 0x8d, 0x3d, 0x4a, 0x53, 0xb4, 0xa7, 0x2e, 0xf0}}
 	return a, nil
 }
@@ -324,7 +324,7 @@ func ConfigCliLesEnabledJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/les-enabled.json", size: 58, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/cli/les-enabled.json", size: 58, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7e, 0xee, 0x27, 0xa7, 0x74, 0xa0, 0x46, 0xa1, 0x41, 0xed, 0x4d, 0x16, 0x5b, 0xf3, 0xf0, 0x7c, 0xc8, 0x2f, 0x6f, 0x47, 0xa4, 0xbb, 0x5f, 0x43, 0x33, 0xd, 0x9, 0x9d, 0xea, 0x9e, 0x15, 0xee}}
 	return a, nil
 }
@@ -344,7 +344,7 @@ func ConfigCliMailserverEnabledJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/cli/mailserver-enabled.json", size: 176, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/cli/mailserver-enabled.json", size: 176, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x34, 0xec, 0x81, 0x8b, 0x99, 0xb6, 0xdb, 0xc0, 0x8b, 0x46, 0x97, 0x96, 0xc7, 0x58, 0x30, 0x33, 0xef, 0x54, 0x25, 0x87, 0x7b, 0xb9, 0x94, 0x6b, 0x18, 0xa4, 0x5b, 0x58, 0x67, 0x7c, 0x44, 0xa6}}
 	return a, nil
 }
@@ -364,7 +364,7 @@ func ConfigStatusChainGenesisJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../config/status-chain-genesis.json", size: 612, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "../config/status-chain-genesis.json", size: 612, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb, 0xf0, 0xc, 0x1, 0x95, 0x65, 0x6, 0x55, 0x48, 0x8f, 0x83, 0xa0, 0xb4, 0x81, 0xda, 0xad, 0x30, 0x6d, 0xb2, 0x78, 0x1b, 0x26, 0x4, 0x13, 0x12, 0x9, 0x6, 0xae, 0x3a, 0x2c, 0x1, 0x71}}
 	return a, nil
 }
@@ -384,7 +384,7 @@ func keysBootnodeKey() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "keys/bootnode.key", size: 65, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "keys/bootnode.key", size: 65, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x31, 0xcf, 0x27, 0xd4, 0x96, 0x2e, 0x32, 0xcd, 0x58, 0x96, 0x2a, 0xe5, 0x8c, 0xa0, 0xf1, 0x73, 0x1f, 0xd6, 0xd6, 0x8b, 0xb, 0x73, 0xd3, 0x2c, 0x84, 0x1a, 0x56, 0xa4, 0x74, 0xb6, 0x95, 0x20}}
 	return a, nil
 }
@@ -404,7 +404,7 @@ func keysFirebaseauthkey() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "keys/firebaseauthkey", size: 153, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "keys/firebaseauthkey", size: 153, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe, 0x69, 0x23, 0x64, 0x7d, 0xf9, 0x14, 0x37, 0x6f, 0x2b, 0x1, 0xf0, 0xb0, 0xa4, 0xb2, 0xd0, 0x18, 0xcd, 0xf9, 0xeb, 0x57, 0xa3, 0xfd, 0x79, 0x25, 0xa7, 0x9c, 0x3, 0xce, 0x26, 0xec, 0xe1}}
 	return a, nil
 }
@@ -424,7 +424,7 @@ func keysTestAccount1StatusChainPk() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "keys/test-account1-status-chain.pk", size: 489, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "keys/test-account1-status-chain.pk", size: 489, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8f, 0xba, 0x35, 0x1, 0x2b, 0x9d, 0xad, 0xf0, 0x2d, 0x3c, 0x4d, 0x6, 0xb5, 0x22, 0x2, 0x47, 0xd4, 0x1c, 0xf4, 0x31, 0x2f, 0xb, 0x5b, 0x27, 0x5d, 0x43, 0x97, 0x58, 0x2d, 0xf0, 0xe1, 0xbe}}
 	return a, nil
 }
@@ -444,7 +444,7 @@ func keysTestAccount1Pk() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "keys/test-account1.pk", size: 491, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "keys/test-account1.pk", size: 491, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9, 0x43, 0xc2, 0xf4, 0x8c, 0xc6, 0x64, 0x25, 0x8c, 0x7, 0x8c, 0xa8, 0x89, 0x2b, 0x7b, 0x9b, 0x4f, 0x81, 0xcb, 0xce, 0x3d, 0xef, 0x82, 0x9c, 0x27, 0x27, 0xa9, 0xc5, 0x46, 0x70, 0x30, 0x38}}
 	return a, nil
 }
@@ -464,7 +464,7 @@ func keysTestAccount2StatusChainPk() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "keys/test-account2-status-chain.pk", size: 489, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "keys/test-account2-status-chain.pk", size: 489, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9, 0xf8, 0x5c, 0xe9, 0x92, 0x96, 0x2d, 0x88, 0x2b, 0x8e, 0x42, 0x3f, 0xa4, 0x93, 0x6c, 0xad, 0xe9, 0xc0, 0x1b, 0x8a, 0x8, 0x8c, 0x5e, 0x7a, 0x84, 0xa2, 0xf, 0x9f, 0x77, 0x58, 0x2c, 0x2c}}
 	return a, nil
 }
@@ -484,7 +484,7 @@ func keysTestAccount2Pk() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "keys/test-account2.pk", size: 491, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "keys/test-account2.pk", size: 491, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9f, 0x72, 0xd5, 0x95, 0x5c, 0x5a, 0x99, 0x9d, 0x2f, 0x21, 0x83, 0xd7, 0x10, 0x17, 0x4a, 0x3d, 0x65, 0xc9, 0x26, 0x1a, 0x2c, 0x9d, 0x65, 0x63, 0xd2, 0xa0, 0xfc, 0x7c, 0x0, 0x87, 0x38, 0x9f}}
 	return a, nil
 }
@@ -504,7 +504,7 @@ func keysTestAccount3BeforeEip55Pk() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "keys/test-account3-before-eip55.pk", size: 489, mode: os.FileMode(0644), modTime: time.Unix(1699005551, 0)}
+	info := bindataFileInfo{name: "keys/test-account3-before-eip55.pk", size: 489, mode: os.FileMode(0664), modTime: time.Unix(1663713040, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x81, 0x40, 0x56, 0xc1, 0x5e, 0x10, 0x6e, 0x28, 0x15, 0x3, 0x4e, 0xc4, 0xc4, 0x71, 0x4d, 0x16, 0x99, 0xcc, 0x1b, 0x63, 0xee, 0x10, 0x20, 0xe4, 0x59, 0x52, 0x3f, 0xc0, 0xad, 0x15, 0x13, 0x72}}
 	return a, nil
 }

--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	EnableFilterFullNode    bool     `toml:",omitempty"`
 	DefaultShardPubsubTopic string   `toml:",omitempty"`
 	UseShardAsDefaultTopic  bool     `toml:",omitempty"`
-	ClusterId               uint16   `toml:",omitempty"`
+	ClusterID               uint16   `toml:",omitempty"`
 }
 
 var DefaultConfig = Config{

--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	EnableFilterFullNode    bool     `toml:",omitempty"`
 	DefaultShardPubsubTopic string   `toml:",omitempty"`
 	UseShardAsDefaultTopic  bool     `toml:",omitempty"`
+	ClusterId               uint16   `toml:",omitempty"`
 }
 
 var DefaultConfig = Config{

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -285,7 +285,7 @@ func New(nodeKey string, fleet string, cfg *Config, logger *zap.Logger, appDB *s
 		node.WithKeepAlive(time.Duration(cfg.KeepAliveInterval) * time.Second),
 		node.WithMaxPeerConnections(cfg.DiscoveryLimit),
 		node.WithLogger(logger),
-		node.WithClusterID(cfg.ClusterId),
+		node.WithClusterID(cfg.ClusterID),
 	}
 
 	if cfg.EnableDiscV5 {

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -285,6 +285,7 @@ func New(nodeKey string, fleet string, cfg *Config, logger *zap.Logger, appDB *s
 		node.WithKeepAlive(time.Duration(cfg.KeepAliveInterval) * time.Second),
 		node.WithMaxPeerConnections(cfg.DiscoveryLimit),
 		node.WithLogger(logger),
+		node.WithClusterID(cfg.ClusterId),
 	}
 
 	if cfg.EnableDiscV5 {


### PR DESCRIPTION
While dogfooding status-desktop version https://github.com/status-im/status-desktop/pull/12765  with sharding fleet, noticed that connections to the fleet were dropped because of mismatch in clusterID.
The fleet nodes expect a clusterID of 16 whereas Waku within status-desktop is initialized without one which assumes a clusterID of 0.

This PR addresses the above issue so that metadata proto negotiation doesn't fail and connection with sharding fleet nodes would be successful.

Specify clusterid as 16 when using sharding fleet 

Important changes:
- [x] If the fleet selected in shards fleet, then use clusterID 16 as per https://rfc.vac.dev/spec/51/#static-sharding.
- [x] For any other fleet, clusterID will default to 0

Note: Could not test these changes, as i am having trouble building status-desktop on my mac-M2. 
@richard-ramos , Would be great if you could test this.
