### PR TITLE
feat: show activity center notification if user must reveal addressed to join/rejoin the community

### DIFF
--- a/protocol/activity_center.go
+++ b/protocol/activity_center.go
@@ -34,6 +34,7 @@ const (
 	ActivityCenterNotificationTypeOwnershipLost
 	ActivityCenterNotificationTypeSetSignerFailed
 	ActivityCenterNotificationTypeSetSignerDeclined
+	ActivityCenterNotificationTypeShareAccounts
 )
 
 type ActivityCenterMembershipStatus int

--- a/protocol/communities/errors.go
+++ b/protocol/communities/errors.go
@@ -41,3 +41,5 @@ var ErrNotEnoughPermissions = errors.New("not enough permissions for this commun
 var ErrCannotRemoveOwnerOrAdmin = errors.New("not allowed to remove admin or owner")
 var ErrCannotBanOwnerOrAdmin = errors.New("not allowed to ban admin or owner")
 var ErrInvalidManageTokensPermission = errors.New("no privileges to manage tokens")
+var ErrRevealedAccountsAbsent = errors.New("revealed accounts is absent")
+var ErrNoRevealedAccountsSignature = errors.New("revealed accounts without the signature")

--- a/protocol/communities/persistence_test.go
+++ b/protocol/communities/persistence_test.go
@@ -666,3 +666,56 @@ func (s *PersistenceSuite) TestCuratedCommunities() {
 	s.Require().NoError(err)
 	s.Require().True(reflect.DeepEqual(communities, setCommunities))
 }
+
+func (s *PersistenceSuite) TestGetCommunityRequestToJoinWithRevealedAddresses() {
+	identity, err := crypto.GenerateKey()
+	s.Require().NoError(err, "crypto.GenerateKey shouldn't give any error")
+
+	clock := uint64(time.Now().Unix())
+	communityID := types.HexBytes{7, 7, 7, 7, 7, 7, 7, 7}
+	revealedAddresses := []string{"address1", "address2", "address3"}
+	chainIds := []uint64{1, 2}
+	publicKey := common.PubkeyToHex(&identity.PublicKey)
+	signature := []byte("test")
+
+	// No data in database
+	_, err = s.db.GetCommunityRequestToJoinWithRevealedAddresses(publicKey, communityID)
+	s.Require().ErrorIs(err, sql.ErrNoRows)
+
+	// RTJ with 2 withoutRevealed Addresses
+	expectedRtj := &RequestToJoin{
+		ID:          types.HexBytes{1, 2, 3, 4, 5, 6, 7, 8},
+		PublicKey:   publicKey,
+		Clock:       clock,
+		CommunityID: communityID,
+		State:       RequestToJoinStateAccepted,
+		RevealedAccounts: []*protobuf.RevealedAccount{
+			{
+				Address:          revealedAddresses[2],
+				ChainIds:         chainIds,
+				IsAirdropAddress: true,
+				Signature:        signature,
+			},
+		},
+	}
+	err = s.db.SaveRequestToJoin(expectedRtj)
+	s.Require().NoError(err, "SaveRequestToJoin shouldn't give any error")
+
+	// check that there will be no error if revealed account is absent
+	rtjResult, err := s.db.GetCommunityRequestToJoinWithRevealedAddresses(publicKey, communityID)
+	s.Require().NoError(err, "RevealedAccounts empty, shouldn't give any error")
+
+	s.Require().Len(rtjResult.RevealedAccounts, 0)
+
+	// save revealed accounts for previous request to join
+	err = s.db.SaveRequestToJoinRevealedAddresses(expectedRtj.ID, expectedRtj.RevealedAccounts)
+	s.Require().NoError(err)
+
+	rtjResult, err = s.db.GetCommunityRequestToJoinWithRevealedAddresses(publicKey, communityID)
+	s.Require().NoError(err)
+	s.Require().Equal(expectedRtj.ID, rtjResult.ID)
+	s.Require().Equal(expectedRtj.PublicKey, rtjResult.PublicKey)
+	s.Require().Equal(expectedRtj.Clock, rtjResult.Clock)
+	s.Require().Equal(expectedRtj.CommunityID, rtjResult.CommunityID)
+	s.Require().Len(rtjResult.RevealedAccounts, 1)
+}

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"context"
 	"crypto/ecdsa"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sync"
@@ -391,8 +392,13 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 					// control node changed and we were kicked out. It now awaits our addresses
 					if communityResponse.Changes.ControlNodeChanged != nil && communityResponse.Changes.MemberKicked {
 						requestToJoin, err := m.sendSharedAddressToControlNode(communityResponse.Community.ControlNode(), communityResponse.Community)
+
 						if err != nil {
 							m.logger.Error("share address to control node failed", zap.String("id", types.EncodeHex(communityResponse.Community.ID())), zap.Error(err))
+
+							if err == communities.ErrRevealedAccountsAbsent || err == communities.ErrNoRevealedAccountsSignature {
+								m.AddActivityCenterNotificationToResponse(communityResponse.Community.IDString(), ActivityCenterNotificationTypeShareAccounts, response)
+							}
 						} else {
 							state.Response.RequestsToJoinCommunity = append(state.Response.RequestsToJoinCommunity, requestToJoin)
 						}
@@ -3096,7 +3102,28 @@ func (m *Messenger) sendSharedAddressToControlNode(receiver *ecdsa.PublicKey, co
 
 	requestToJoin, err := m.communitiesManager.GetCommunityRequestToJoinWithRevealedAddresses(pk, community.ID())
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, communities.ErrRevealedAccountsAbsent
+		}
 		return nil, err
+	}
+
+	if len(requestToJoin.RevealedAccounts) == 0 {
+		return nil, communities.ErrRevealedAccountsAbsent
+	}
+
+	// check if at least one account is signed
+	// old community users can not keep locally the signature of their revealed accounts in the DB
+	revealedAccountSigned := false
+	for _, account := range requestToJoin.RevealedAccounts {
+		revealedAccountSigned = len(account.Signature) > 0
+		if revealedAccountSigned {
+			break
+		}
+	}
+
+	if !revealedAccountSigned {
+		return nil, communities.ErrNoRevealedAccountsSignature
 	}
 
 	requestToJoin.Clock = uint64(time.Now().Unix())
@@ -4207,4 +4234,22 @@ func (m *Messenger) SendMessageToControlNode(community *communities.Community, r
 	}
 
 	return m.sender.SendCommunityMessage(context.Background(), rawMessage)
+}
+
+func (m *Messenger) AddActivityCenterNotificationToResponse(communityID string, acType ActivityCenterType, response *MessengerResponse) {
+	// Activity Center notification
+	notification := &ActivityCenterNotification{
+		ID:          types.FromHex(uuid.New().String()),
+		Type:        acType,
+		Timestamp:   m.getTimesource().GetCurrentTime(),
+		CommunityID: communityID,
+		Read:        false,
+		Deleted:     false,
+		UpdatedAt:   m.GetCurrentTimeInMillis(),
+	}
+
+	err := m.addActivityCenterNotification(response, notification, nil)
+	if err != nil {
+		m.logger.Error("failed to save notification", zap.Error(err))
+	}
 }


### PR DESCRIPTION
When the community ownership changed, all members are kicked. If this member does not have request to join with revealed addresses or revealed addresses is not signed - show the a notification in activity center to share their revealed accounts

Closes: https://github.com/status-im/status-desktop/issues/11974

status-desktop PR: https://github.com/status-im/status-desktop/pull/12856