### PR TITLE
refactor: it's not necessary for storenodes to be connected peers

### DIFF
--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -102,10 +102,13 @@ func (s *MessengerStoreNodeRequestSuite) SetupTest() {
 	bobLogger := s.logger.With(zap.String("name", "bob"))
 	s.bob = s.newMessenger(s.bobWaku, bobLogger, storeNodeAddress)
 	s.bob.StartRetrieveMessagesLoop(time.Second, nil)
+
+	// Connect owner to storenode so message is stored
+	err := s.ownerWaku.DialPeer(storeNodeAddress)
+	s.Require().NoError(err)
 }
 
 func (s *MessengerStoreNodeRequestSuite) TestRequestCommunityInfo() {
-
 	WaitForAvailableStoreNode(&s.Suite, s.owner, time.Second)
 
 	createCommunityRequest := &requests.CreateCommunity{


### PR DESCRIPTION
While looking at the mailserver cycle code, I realized that for wakuv2, it is not necessary for the storenode to be an active peer, since this is a request/response protocol. In this PR I remove code that deals with connecting to the storenode.
Once WakuV1 is removed in the future, we can go even further by removing completely the connectivity state and just keep track of the last used mailserver.