### PR TITLE
feat: refresh balances when Eth or ERC20 transfer is detected

### DIFF
--- a/services/wallet/collectibles/controller.go
+++ b/services/wallet/collectibles/controller.go
@@ -330,7 +330,8 @@ func (c *Controller) startWalletEventsWatcher() {
 
 	walletEventCb := func(event walletevent.Event) {
 		// EventRecentHistoryReady ?
-		if event.Type != transfer.EventInternalERC721TransferDetected {
+		if event.Type != transfer.EventInternalERC721TransferDetected &&
+			event.Type != transfer.EventInternalERC1155TransferDetected {
 			return
 		}
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12138

Whenever an ETH or ERC20 transfer is detected, we trigger a waller refresh (re-fetch balances).

We trigger them if the Tx happened later than 30 seconds before the last update (account for delays in the balances calculation).

We delay the actual refresh for about 30 seconds, to prevent triggering multiple refreshes if a lot of Txs are detected at the same time.

We don't have the granularity needed in our API to update only balances for the token involved in the transfer. This can be improved in the future. 