### PR TITLE
fix: close messenger's databases in tests

### DIFF
--- a/protocol/communities_events_owner_without_community_key_test.go
+++ b/protocol/communities_events_owner_without_community_key_test.go
@@ -79,9 +79,9 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) SetupTest() {
 }
 
 func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TearDownTest() {
-	s.Require().NoError(s.controlNode.Shutdown())
-	s.Require().NoError(s.ownerWithoutCommunityKey.Shutdown())
-	s.Require().NoError(s.alice.Shutdown())
+	TearDownMessenger(&s.Suite, s.controlNode)
+	TearDownMessenger(&s.Suite, s.ownerWithoutCommunityKey)
+	TearDownMessenger(&s.Suite, s.alice)
 	_ = s.logger.Sync()
 }
 

--- a/protocol/communities_events_token_master_test.go
+++ b/protocol/communities_events_token_master_test.go
@@ -79,9 +79,9 @@ func (s *TokenMasterCommunityEventsSuite) SetupTest() {
 }
 
 func (s *TokenMasterCommunityEventsSuite) TearDownTest() {
-	s.Require().NoError(s.controlNode.Shutdown())
-	s.Require().NoError(s.tokenMaster.Shutdown())
-	s.Require().NoError(s.alice.Shutdown())
+	TearDownMessenger(&s.Suite, s.controlNode)
+	TearDownMessenger(&s.Suite, s.tokenMaster)
+	TearDownMessenger(&s.Suite, s.alice)
 	_ = s.logger.Sync()
 }
 

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1026,7 +1026,7 @@ func testAcceptMemberRequestToJoin(base CommunityEventsTestsInterface, community
 	s := base.GetSuite()
 
 	s.Require().NoError(err)
-	defer user.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(s, user)
 
 	advertiseCommunityTo(s, community, base.GetControlNode(), user)
 
@@ -1156,7 +1156,7 @@ func testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(base Commu
 	s := base.GetSuite()
 
 	s.Require().NoError(err)
-	defer user.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(s, user)
 
 	advertiseCommunityTo(s, community, base.GetControlNode(), user)
 
@@ -1234,7 +1234,7 @@ func testRejectMemberRequestToJoinResponseSharedWithOtherEventSenders(base Commu
 	s := base.GetSuite()
 
 	s.Require().NoError(err)
-	defer user.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(s, user)
 
 	advertiseCommunityTo(s, community, base.GetControlNode(), user)
 
@@ -1311,7 +1311,7 @@ func testRejectMemberRequestToJoin(base CommunityEventsTestsInterface, community
 
 	s := base.GetSuite()
 	s.Require().NoError(err)
-	defer user.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(s, user)
 
 	advertiseCommunityTo(s, community, base.GetControlNode(), user)
 
@@ -1409,7 +1409,7 @@ func testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(base Commun
 
 	s := base.GetSuite()
 	s.Require().NoError(err)
-	defer user.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(s, user)
 
 	advertiseCommunityTo(s, community, base.GetControlNode(), user)
 

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -83,9 +83,9 @@ func (s *AdminCommunityEventsSuite) SetupTest() {
 }
 
 func (s *AdminCommunityEventsSuite) TearDownTest() {
-	s.Require().NoError(s.owner.Shutdown())
-	s.Require().NoError(s.admin.Shutdown())
-	s.Require().NoError(s.alice.Shutdown())
+	TearDownMessenger(&s.Suite, s.owner)
+	TearDownMessenger(&s.Suite, s.admin)
+	TearDownMessenger(&s.Suite, s.alice)
 	_ = s.logger.Sync()
 }
 

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"sync"
 	"time"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/account/generator"
 	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/common/dbsetup"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts"
@@ -186,11 +186,7 @@ func newMessenger(s *suite.Suite, shh types.Waku, logger *zap.Logger, password s
 
 func newCommunitiesTestMessenger(shh types.Waku, privateKey *ecdsa.PrivateKey, logger *zap.Logger, accountsManager account.Manager,
 	tokenManager communities.TokenManager, collectiblesService communitytokens.ServiceInterface) (*Messenger, error) {
-	tmpfile, err := ioutil.TempFile("", "accounts-tests-")
-	if err != nil {
-		return nil, err
-	}
-	madb, err := multiaccounts.InitializeDB(tmpfile.Name())
+	madb, err := multiaccounts.InitializeDB(dbsetup.InMemoryPath)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/communities_messenger_signers_test.go
+++ b/protocol/communities_messenger_signers_test.go
@@ -79,9 +79,9 @@ func (s *MessengerCommunitiesSignersSuite) SetupTest() {
 }
 
 func (s *MessengerCommunitiesSignersSuite) TearDownTest() {
-	s.Require().NoError(s.john.Shutdown())
-	s.Require().NoError(s.bob.Shutdown())
-	s.Require().NoError(s.alice.Shutdown())
+	TearDownMessenger(&s.Suite, s.john)
+	TearDownMessenger(&s.Suite, s.bob)
+	TearDownMessenger(&s.Suite, s.alice)
 	_ = s.logger.Sync()
 }
 

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -74,9 +74,9 @@ func (s *MessengerCommunitiesSuite) SetupTest() {
 }
 
 func (s *MessengerCommunitiesSuite) TearDownTest() {
-	s.Require().NoError(s.owner.Shutdown())
-	s.Require().NoError(s.bob.Shutdown())
-	s.Require().NoError(s.alice.Shutdown())
+	TearDownMessenger(&s.Suite, s.owner)
+	TearDownMessenger(&s.Suite, s.bob)
+	TearDownMessenger(&s.Suite, s.alice)
 	_ = s.logger.Sync()
 }
 

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -160,20 +160,20 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) SetupTest() {
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) TearDownTest() {
 	if s.owner != nil {
-		s.Require().NoError(s.owner.Shutdown())
+		TearDownMessenger(&s.Suite, s.owner)
 	}
 	if s.ownerWaku != nil {
 		s.Require().NoError(gethbridge.GetGethWakuV2From(s.ownerWaku).Stop())
 	}
 
 	if s.bob != nil {
-		s.Require().NoError(s.bob.Shutdown())
+		TearDownMessenger(&s.Suite, s.bob)
 	}
 	if s.bobWaku != nil {
 		s.Require().NoError(gethbridge.GetGethWakuV2From(s.bobWaku).Stop())
 	}
 	if s.alice != nil {
-		s.Require().NoError(s.alice.Shutdown())
+		TearDownMessenger(&s.Suite, s.alice)
 	}
 	if s.aliceWaku != nil {
 		s.Require().NoError(gethbridge.GetGethWakuV2From(s.aliceWaku).Stop())

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -2,23 +2,16 @@ package protocol
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
 
-	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
-	"github.com/status-im/status-go/eth-node/crypto"
-	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
-	"github.com/status-im/status-go/protocol/tt"
 	"github.com/status-im/status-go/server"
-	"github.com/status-im/status-go/waku"
 )
 
 func TestMessengerActivityCenterMessageSuite(t *testing.T) {
@@ -39,48 +32,14 @@ func (s *MessengerActivityCenterMessageSuite) joinCommunity(community *communiti
 }
 
 type MessengerActivityCenterMessageSuite struct {
-	suite.Suite
-	m          *Messenger        // main instance of Messenger
-	privateKey *ecdsa.PrivateKey // private key for the main instance of Messenger
-	// If one wants to send messages between different instances of Messenger,
-	// a single waku service should be shared.
-	shh    types.Waku
-	logger *zap.Logger
-}
-
-func (s *MessengerActivityCenterMessageSuite) SetupTest() {
-	s.logger = tt.MustCreateTestLogger()
-
-	config := waku.DefaultConfig
-	config.MinimumAcceptedPoW = 0
-	shh := waku.New(&config, s.logger)
-	s.shh = gethbridge.NewGethWakuWrapper(shh)
-	s.Require().NoError(shh.Start())
-
-	s.m = s.newMessenger()
-	s.privateKey = s.m.identity
-	_, err := s.m.Start()
-	s.Require().NoError(err)
-}
-
-func (s *MessengerActivityCenterMessageSuite) TearDownTest() {
-	s.Require().NoError(s.m.Shutdown())
-}
-
-func (s *MessengerActivityCenterMessageSuite) newMessenger() *Messenger {
-	privateKey, err := crypto.GenerateKey()
-	s.Require().NoError(err)
-
-	messenger, err := newMessengerWithKey(s.shh, privateKey, s.logger, nil)
-	s.Require().NoError(err)
-	return messenger
+	MessengerBaseTestSuite
 }
 
 func (s *MessengerActivityCenterMessageSuite) TestDeleteOneToOneChat() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -136,7 +95,7 @@ func (s *MessengerActivityCenterMessageSuite) TestEveryoneMentionTag() {
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)
@@ -178,7 +137,7 @@ func (s *MessengerActivityCenterMessageSuite) TestReplyWithImage() {
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	// create an http server
 	mediaServer, err := server.NewMediaServer(nil, nil, nil)
@@ -313,7 +272,7 @@ func (s *MessengerActivityCenterMessageSuite) prepareCommunityChannelWithMention
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"crypto/ecdsa"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/status-im/status-go/account/generator"
 	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/common/dbsetup"
 	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
@@ -44,7 +44,7 @@ func (s *MessengerBaseTestSuite) SetupTest() {
 }
 
 func (s *MessengerBaseTestSuite) TearDownTest() {
-	s.Require().NoError(s.m.Shutdown())
+	TearDownMessenger(&s.Suite, s.m)
 	_ = s.logger.Sync()
 }
 
@@ -68,11 +68,7 @@ type MessengerBaseTestSuite struct {
 }
 
 func newMessengerWithKey(shh types.Waku, privateKey *ecdsa.PrivateKey, logger *zap.Logger, extraOptions []Option) (*Messenger, error) {
-	tmpfile, err := ioutil.TempFile("", "accounts-tests-")
-	if err != nil {
-		return nil, err
-	}
-	madb, err := multiaccounts.InitializeDB(tmpfile.Name())
+	madb, err := multiaccounts.InitializeDB(dbsetup.InMemoryPath)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_browsers_test.go
+++ b/protocol/messenger_browsers_test.go
@@ -7,10 +7,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
-	"github.com/status-im/status-go/protocol/tt"
 	"github.com/status-im/status-go/services/browsers"
-	"github.com/status-im/status-go/waku"
 )
 
 func TestBrowserSuite(t *testing.T) {
@@ -22,22 +19,9 @@ type BrowserSuite struct {
 }
 
 func (s *BrowserSuite) SetupTest() {
-	s.logger = tt.MustCreateTestLogger()
-
-	config := waku.DefaultConfig
-	config.MinimumAcceptedPoW = 0
-	shh := waku.New(&config, s.logger)
-	s.shh = gethbridge.NewGethWakuWrapper(shh)
-	s.Require().NoError(shh.Start())
-
-	s.m = s.newMessenger()
-	s.privateKey = s.m.identity
+	s.MessengerBaseTestSuite.SetupTest()
 	_, err := s.m.Start()
 	s.Require().NoError(err)
-}
-
-func (s *BrowserSuite) TearDownTest() {
-	s.Require().NoError(s.m.Shutdown())
 }
 
 func (s *MessengerBackupSuite) TestBrowsersOrderedNewestFirst() {

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -435,7 +435,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequest() { //
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -453,7 +453,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndDismissContactRequest() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -471,7 +471,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	s.Require().NoError(theirMessenger.settings.SaveSettingField(settings.MutualContactEnabled, true))
 
@@ -497,7 +497,7 @@ func (s *MessengerContactRequestSuite) TestAliceTriesToSpamBobWithContactRequest
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -548,7 +548,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequestTwice()
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -592,7 +592,7 @@ func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContact(
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -687,7 +687,7 @@ func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContact
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -723,7 +723,7 @@ func (s *MessengerContactRequestSuite) TestPairedDevicesRemoveContact() {
 
 	_, err = alice2.Start()
 	s.Require().NoError(err)
-	defer alice2.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice2)
 
 	prepAliceMessengersForPairing(&s.Suite, alice1, alice2)
 
@@ -733,7 +733,7 @@ func (s *MessengerContactRequestSuite) TestPairedDevicesRemoveContact() {
 	bob := s.newMessenger()
 	_, err = bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	// Alice sends a contact request to bob
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
@@ -797,7 +797,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateSendContactRequest()
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -820,7 +820,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateSendContactRequest()
 
 	_, err = alice2.Start()
 	s.Require().NoError(err)
-	defer alice2.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice2)
 
 	// adds bob again to her device
 	s.sendContactRequest(request, alice2)
@@ -869,7 +869,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateReceiveContactReques
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -892,7 +892,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateReceiveContactReques
 
 	_, err = alice2.Start()
 	s.Require().NoError(err)
-	defer alice2.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice2)
 
 	// We want to facilitate the discovery of the x3dh bundl here, since bob does not know about alice device
 
@@ -950,7 +950,7 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsCorrectOrd
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1000,7 +1000,7 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsWrongOrder
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1052,7 +1052,7 @@ func (s *MessengerContactRequestSuite) TestAliceResendsContactRequestAfterRemovi
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
@@ -1108,7 +1108,7 @@ func (s *MessengerContactRequestSuite) TestBobSendsContactRequestAfterDecliningO
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1240,7 +1240,7 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 	bob1 := s.newMessenger()
 	_, err := bob1.Start()
 	s.Require().NoError(err)
-	defer bob1.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob1)
 
 	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob1.identity.PublicKey))
@@ -1262,7 +1262,7 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 
 	_, err = bob2.Start()
 	s.Require().NoError(err)
-	defer bob2.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob2)
 
 	// Get bob perspective of alice for backup
 	aliceFromBob := bob1.Contacts()[0]
@@ -1320,7 +1320,7 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice1.identity.PublicKey))
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
@@ -1342,7 +1342,7 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 
 	_, err = alice2.Start()
 	s.Require().NoError(err)
-	defer alice2.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice2)
 
 	// Get bob perspective of alice for backup
 	bobFromAlice := alice1.Contacts()[0]
@@ -1511,7 +1511,7 @@ func (s *MessengerContactRequestSuite) TestBlockedContactSyncing() {
 	bob := s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 	_ = bob.SetDisplayName("bob-1")
 	s.logger.Info("Bob account set up", zap.String("publicKey", bob.IdentityPublicKeyString()))
 
@@ -1524,7 +1524,7 @@ func (s *MessengerContactRequestSuite) TestBlockedContactSyncing() {
 	s.Require().NoError(err)
 	_, err = alice2.Start()
 	s.Require().NoError(err)
-	defer alice2.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice2)
 
 	// Pair alice-1 <-> alice-2
 	// NOTE: This doesn't include initial data sync. Local pairing could be used.

--- a/protocol/messenger_contact_update_test.go
+++ b/protocol/messenger_contact_update_test.go
@@ -7,13 +7,10 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/deprecation"
-	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/requests"
-	"github.com/status-im/status-go/protocol/tt"
-	"github.com/status-im/status-go/waku"
 )
 
 func TestMessengerContactUpdateSuite(t *testing.T) {
@@ -25,16 +22,7 @@ type MessengerContactUpdateSuite struct {
 }
 
 func (s *MessengerContactUpdateSuite) SetupTest() {
-	s.logger = tt.MustCreateTestLogger()
-
-	config := waku.DefaultConfig
-	config.MinimumAcceptedPoW = 0
-	shh := waku.New(&config, s.logger)
-	s.shh = gethbridge.NewGethWakuWrapper(shh)
-	s.Require().NoError(shh.Start())
-
-	s.m = s.newMessenger()
-	s.privateKey = s.m.identity
+	s.MessengerBaseTestSuite.SetupTest()
 	_, err := s.m.Start()
 	s.Require().NoError(err)
 }
@@ -47,7 +35,7 @@ func (s *MessengerContactUpdateSuite) TestReceiveContactUpdate() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	// Set ENS name
 	err = theirMessenger.settings.SaveSettingField(settings.PreferredName, theirName)
@@ -125,7 +113,7 @@ func (s *MessengerContactUpdateSuite) TestAddContact() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	response, err := theirMessenger.AddContact(context.Background(), &requests.AddContact{ID: contactID})
 	s.Require().NoError(err)
@@ -164,7 +152,7 @@ func (s *MessengerContactUpdateSuite) TestAddContactWithENS() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	s.Require().NoError(theirMessenger.ENSVerified(contactID, ensName))
 

--- a/protocol/messenger_delete_message_for_everyone_test.go
+++ b/protocol/messenger_delete_message_for_everyone_test.go
@@ -52,9 +52,9 @@ func (s *MessengerDeleteMessageForEveryoneSuite) SetupTest() {
 }
 
 func (s *MessengerDeleteMessageForEveryoneSuite) TearDownTest() {
-	s.Require().NoError(s.admin.Shutdown())
-	s.Require().NoError(s.bob.Shutdown())
-	s.Require().NoError(s.moderator.Shutdown())
+	TearDownMessenger(&s.Suite, s.admin)
+	TearDownMessenger(&s.Suite, s.bob)
+	TearDownMessenger(&s.Suite, s.moderator)
 	_ = s.logger.Sync()
 }
 

--- a/protocol/messenger_delete_message_for_me_test.go
+++ b/protocol/messenger_delete_message_for_me_test.go
@@ -74,8 +74,8 @@ func (s *MessengerDeleteMessageForMeSuite) SetupTest() {
 }
 
 func (s *MessengerDeleteMessageForMeSuite) TearDownTest() {
-	s.Require().NoError(s.alice1.Shutdown())
-	s.Require().NoError(s.alice2.Shutdown())
+	TearDownMessenger(&s.Suite, s.alice1)
+	TearDownMessenger(&s.Suite, s.alice2)
 	_ = s.logger.Sync()
 }
 
@@ -217,12 +217,12 @@ func (s *MessengerDeleteMessageForMeSuite) TestDeleteImageMessageFromReceiverSid
 	alice := s.otherNewMessenger()
 	_, err := alice.Start()
 	s.Require().NoError(err)
-	defer alice.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice)
 
 	bob := s.otherNewMessenger()
 	_, err = bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, alice.transport)
 	err = alice.SaveChat(theirChat)

--- a/protocol/messenger_delete_message_test.go
+++ b/protocol/messenger_delete_message_test.go
@@ -23,7 +23,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -74,7 +74,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessagePreviousLastMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -125,7 +125,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteWrongMessageType() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -154,7 +154,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageFirstThenMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -209,7 +209,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteImageMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -285,7 +285,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteImageMessageFirstThenMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -365,7 +365,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageWithAMention() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -427,7 +427,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageAndChatIsAlreadyRead() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -488,7 +488,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageReplyToImage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -543,7 +543,7 @@ func (s *MessengerDeleteMessageSuite) TestDeleteMessageForMeReplyToImage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_edit_message_test.go
+++ b/protocol/messenger_edit_message_test.go
@@ -25,7 +25,7 @@ func (s *MessengerEditMessageSuite) TestEditMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -96,7 +96,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageEdgeCases() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -199,7 +199,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageFirstEditsThenMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -258,7 +258,7 @@ func (s *MessengerEditMessageSuite) TestEditGroupChatMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	response, err := s.m.CreateGroupChatWithMembers(context.Background(), "id", []string{})
 	s.NoError(err)
@@ -343,7 +343,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -450,7 +450,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithLinkPreviews() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_emoji_test.go
+++ b/protocol/messenger_emoji_test.go
@@ -31,7 +31,7 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 
 	bob, err := newMessengerWithKey(s.shh, key, s.logger, nil)
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	chatID := statusChatID
 
@@ -112,7 +112,7 @@ func (s *MessengerEmojiSuite) TestEmojiPrivateGroup() {
 	alice := s.newMessenger()
 	_, err := alice.Start()
 	s.Require().NoError(err)
-	defer alice.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice)
 	response, err := bob.CreateGroupChatWithMembers(context.Background(), "test", []string{})
 	s.NoError(err)
 

--- a/protocol/messenger_handler_test.go
+++ b/protocol/messenger_handler_test.go
@@ -2,20 +2,15 @@ package protocol
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
 
-	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/protobuf"
-	"github.com/status-im/status-go/protocol/tt"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 	localnotifications "github.com/status-im/status-go/services/local-notifications"
-	"github.com/status-im/status-go/waku"
 )
 
 func TestEventToSystemMessageSuite(t *testing.T) {
@@ -23,38 +18,7 @@ func TestEventToSystemMessageSuite(t *testing.T) {
 }
 
 type EventToSystemMessageSuite struct {
-	suite.Suite
-	m          *Messenger        // main instance of Messenger
-	privateKey *ecdsa.PrivateKey // private key for the main instance of Messenger
-	// If one wants to send messages between different instances of Messenger,
-	// a single waku service should be shared.
-	shh    types.Waku
-	logger *zap.Logger
-}
-
-func (s *EventToSystemMessageSuite) newMessenger() *Messenger {
-	privateKey, err := crypto.GenerateKey()
-	s.Require().NoError(err)
-
-	messenger, err := newMessengerWithKey(s.shh, privateKey, s.logger, nil)
-	s.Require().NoError(err)
-	return messenger
-}
-
-func (s *EventToSystemMessageSuite) SetupTest() {
-	s.logger = tt.MustCreateTestLogger()
-
-	config := waku.DefaultConfig
-	config.MinimumAcceptedPoW = 0
-	shh := waku.New(&config, s.logger)
-	s.shh = gethbridge.NewGethWakuWrapper(shh)
-	s.Require().NoError(shh.Start())
-
-	s.m = s.newMessenger()
-	s.privateKey = s.m.identity
-
-	_, err := s.m.Start()
-	s.Require().NoError(err)
+	MessengerBaseTestSuite
 }
 
 func (s *EventToSystemMessageSuite) TestRun() {

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -45,7 +45,7 @@ func (s *MessengerProfilePictureHandlerSuite) SetupSuite() {
 	s.logger = tt.MustCreateTestLogger()
 }
 
-func (s *MessengerProfilePictureHandlerSuite) setup() {
+func (s *MessengerProfilePictureHandlerSuite) SetupTest() {
 	var err error
 
 	// Setup Waku things
@@ -80,38 +80,13 @@ func (s *MessengerProfilePictureHandlerSuite) setup() {
 	s.logger.Debug("alice setupMultiAccount after")
 }
 
-func (s *MessengerProfilePictureHandlerSuite) setupTest() {
-	s.logger.Debug("setupTest fired")
-	s.setup()
-	s.logger.Debug("setupTest completed")
-}
-
-func (s *MessengerProfilePictureHandlerSuite) SetupTest() {
-	s.logger.Debug("SetupTest fired")
-	s.setup()
-	s.logger.Debug("SetupTest completed")
-}
-
-func (s *MessengerProfilePictureHandlerSuite) tearDown() {
+func (s *MessengerProfilePictureHandlerSuite) TearDownTest() {
 	// Shutdown messengers
-	s.NoError(s.alice.Shutdown())
+	TearDownMessenger(&s.Suite, s.alice)
 	s.alice = nil
-	s.NoError(s.bob.Shutdown())
+	TearDownMessenger(&s.Suite, s.bob)
 	s.bob = nil
 	_ = s.logger.Sync()
-	//time.Sleep(2 * time.Second)
-}
-
-func (s *MessengerProfilePictureHandlerSuite) tearDownTest() {
-	s.logger.Debug("tearDownTest fired")
-	s.tearDown()
-	s.logger.Debug("tearDownTest completed")
-}
-
-func (s *MessengerProfilePictureHandlerSuite) TearDownTest() {
-	s.logger.Debug("TearDownTest fired")
-	s.tearDown()
-	s.logger.Debug("TearDownTest completed")
 }
 
 func (s *MessengerProfilePictureHandlerSuite) generateKeyUID(publicKey *ecdsa.PublicKey) string {
@@ -221,7 +196,6 @@ func (s *MessengerProfilePictureHandlerSuite) TestEncryptDecryptIdentityImagesWi
 }
 
 func (s *MessengerProfilePictureHandlerSuite) TestPictureInPrivateChatOneSided() {
-	s.setupTest()
 	err := s.bob.settings.SaveSettingField(settings.ProfilePicturesVisibility, settings.ProfilePicturesShowToEveryone)
 	s.Require().NoError(err)
 
@@ -295,7 +269,7 @@ func (s *MessengerProfilePictureHandlerSuite) TestE2eSendingReceivingProfilePict
 				for _, ac := range isContactFor["alice"] {
 					for _, bc := range isContactFor["bob"] {
 						s.logger.Debug("top of the loop")
-						s.setupTest()
+						s.SetupTest()
 						s.logger.Info("testing with criteria:",
 							zap.String("chat context type", string(cc)),
 							zap.String("profile picture Show Settings", sn),
@@ -465,7 +439,7 @@ func (s *MessengerProfilePictureHandlerSuite) TestE2eSendingReceivingProfilePict
 								zap.Bool("bob in Alice's Contacts", ac),
 								zap.Bool("alice in Bob's Contacts", bc),
 							)
-							s.tearDownTest()
+							s.TearDownTest()
 							continue
 						}
 
@@ -526,14 +500,14 @@ func (s *MessengerProfilePictureHandlerSuite) TestE2eSendingReceivingProfilePict
 							zap.Bool("bob in Alice's Contacts", ac),
 							zap.Bool("alice in Bob's Contacts", bc),
 						)
-						s.tearDownTest()
+						s.TearDownTest()
 					}
 				}
 			}
 		}
 	}
 
-	s.setupTest()
+	s.SetupTest()
 }
 
 func resultExpected(ss settings.ProfilePicturesShowToType, vs settings.ProfilePicturesVisibilityType, ac, bc bool) (bool, error) {

--- a/protocol/messenger_identity_social_links_test.go
+++ b/protocol/messenger_identity_social_links_test.go
@@ -2,21 +2,14 @@ package protocol
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"errors"
 	"testing"
 
-	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
-	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/identity"
 	"github.com/status-im/status-go/protocol/tt"
-	"github.com/status-im/status-go/waku"
 
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
-
-	"github.com/status-im/status-go/eth-node/types"
 )
 
 func TestMessengerSocialLinksHandlerSuite(t *testing.T) {
@@ -24,45 +17,7 @@ func TestMessengerSocialLinksHandlerSuite(t *testing.T) {
 }
 
 type MessengerSocialLinksHandlerSuite struct {
-	suite.Suite
-	m          *Messenger        // main instance of Messenger
-	privateKey *ecdsa.PrivateKey // private key for the main instance of Messenger
-
-	// If one wants to send messages between different instances of Messenger,
-	// a single Waku service should be shared.
-	shh types.Waku
-
-	logger *zap.Logger
-}
-
-func (s *MessengerSocialLinksHandlerSuite) SetupTest() {
-	s.logger = tt.MustCreateTestLogger()
-
-	config := waku.DefaultConfig
-	config.MinimumAcceptedPoW = 0
-	shh := waku.New(&config, s.logger)
-	s.shh = gethbridge.NewGethWakuWrapper(shh)
-	s.Require().NoError(shh.Start())
-
-	s.m = s.newMessenger(s.shh)
-	s.privateKey = s.m.identity
-	// We start the messenger in order to receive installations
-	_, err := s.m.Start()
-	s.Require().NoError(err)
-}
-
-func (s *MessengerSocialLinksHandlerSuite) TearDownTest() {
-	s.Require().NoError(s.m.Shutdown())
-}
-
-func (s *MessengerSocialLinksHandlerSuite) newMessenger(shh types.Waku) *Messenger {
-	privateKey, err := crypto.GenerateKey()
-	s.Require().NoError(err)
-
-	messenger, err := newMessengerWithKey(s.shh, privateKey, s.logger, nil)
-	s.Require().NoError(err)
-
-	return messenger
+	MessengerBaseTestSuite
 }
 
 func profileSocialLinks() identity.SocialLinks {

--- a/protocol/messenger_installations_test.go
+++ b/protocol/messenger_installations_test.go
@@ -213,7 +213,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 	alice := s.newMessenger()
 	_, err = alice.Start()
 	s.Require().NoError(err)
-	defer alice.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice)
 
 	// Create 1-1 chat
 	ourOneOneChat := CreateOneToOneChat("Our 1TO1", &alice.identity.PublicKey, alice.transport)

--- a/protocol/messenger_messages_tracking_test.go
+++ b/protocol/messenger_messages_tracking_test.go
@@ -107,14 +107,15 @@ func (s *MessengerMessagesTrackingSuite) SetupTest() {
 
 func (s *MessengerMessagesTrackingSuite) TearDownTest() {
 	if s.bob != nil {
-		s.Require().NoError(s.bob.Shutdown())
+		TearDownMessenger(&s.Suite, s.bob)
+
 	}
 	if s.bobWaku != nil {
 		s.Require().NoError(gethbridge.GetGethWakuV2From(s.bobWaku).Stop())
 	}
 
 	if s.alice != nil {
-		s.Require().NoError(s.alice.Shutdown())
+		TearDownMessenger(&s.Suite, s.alice)
 	}
 	if s.aliceWaku != nil {
 		s.Require().NoError(gethbridge.GetGethWakuV2From(s.aliceWaku).Stop())

--- a/protocol/messenger_pin_message_test.go
+++ b/protocol/messenger_pin_message_test.go
@@ -22,7 +22,7 @@ func (s *MessengerPinMessageSuite) TestPinMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -93,7 +93,7 @@ func (s *MessengerPinMessageSuite) TestPinMessageOutOfOrder() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_send_images_album_test.go
+++ b/protocol/messenger_send_images_album_test.go
@@ -2,22 +2,15 @@ package protocol
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
 
-	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
-	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
-
-	"github.com/status-im/status-go/protocol/tt"
-	"github.com/status-im/status-go/waku"
 )
 
 func TestMessengerSendImagesAlbumSuite(t *testing.T) {
@@ -25,42 +18,7 @@ func TestMessengerSendImagesAlbumSuite(t *testing.T) {
 }
 
 type MessengerSendImagesAlbumSuite struct {
-	suite.Suite
-	m          *Messenger
-	privateKey *ecdsa.PrivateKey // private key for the main instance of Messenger
-	// If one wants to send messages between different instances of Messenger,
-	// a single waku service should be shared.
-	shh    types.Waku
-	logger *zap.Logger
-}
-
-func (s *MessengerSendImagesAlbumSuite) SetupTest() {
-	s.logger = tt.MustCreateTestLogger()
-
-	config := waku.DefaultConfig
-	config.MinimumAcceptedPoW = 0
-	shh := waku.New(&config, s.logger)
-	s.shh = gethbridge.NewGethWakuWrapper(shh)
-	s.Require().NoError(shh.Start())
-
-	s.m = s.newMessenger()
-	s.privateKey = s.m.identity
-	_, err := s.m.Start()
-	s.Require().NoError(err)
-
-}
-
-func (s *MessengerSendImagesAlbumSuite) TearDownTest() {
-	s.Require().NoError(s.m.Shutdown())
-}
-
-func (s *MessengerSendImagesAlbumSuite) newMessenger() *Messenger {
-	privateKey, err := crypto.GenerateKey()
-	s.Require().NoError(err)
-
-	messenger, err := newMessengerWithKey(s.shh, privateKey, s.logger, nil)
-	s.Require().NoError(err)
-	return messenger
+	MessengerBaseTestSuite
 }
 
 func (s *MessengerSendImagesAlbumSuite) advertiseCommunityTo(community *communities.Community, user *Messenger) {
@@ -76,7 +34,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesSend() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -137,7 +95,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesWithMentionSend() 
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -190,7 +148,7 @@ func (s *MessengerSendImagesAlbumSuite) TestSingleImageMessageWithMentionInCommu
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	community, chat := createCommunity(&s.Suite, s.m)
 
@@ -324,7 +282,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImagesMessageWithMentionInCommu
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	community, chat := createCommunity(&s.Suite, s.m)
 

--- a/protocol/messenger_share_image_test.go
+++ b/protocol/messenger_share_image_test.go
@@ -2,24 +2,17 @@ package protocol
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
 
-	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
-	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
-
 	// "github.com/status-im/status-go/protocol/requests"
-	"github.com/status-im/status-go/protocol/tt"
-	"github.com/status-im/status-go/waku"
 )
 
 func TestMessengerShareMessageSuite(t *testing.T) {
@@ -27,42 +20,7 @@ func TestMessengerShareMessageSuite(t *testing.T) {
 }
 
 type MessengerShareMessageSuite struct {
-	suite.Suite
-	m          *Messenger
-	privateKey *ecdsa.PrivateKey // private key for the main instance of Messenger
-	// If one wants to send messages between different instances of Messenger,
-	// a single waku service should be shared.
-	shh    types.Waku
-	logger *zap.Logger
-}
-
-func (s *MessengerShareMessageSuite) SetupTest() {
-	s.logger = tt.MustCreateTestLogger()
-
-	config := waku.DefaultConfig
-	config.MinimumAcceptedPoW = 0
-	shh := waku.New(&config, s.logger)
-	s.shh = gethbridge.NewGethWakuWrapper(shh)
-	s.Require().NoError(shh.Start())
-
-	s.m = s.newMessenger()
-	s.privateKey = s.m.identity
-	_, err := s.m.Start()
-	s.Require().NoError(err)
-
-}
-
-func (s *MessengerShareMessageSuite) TearDownTest() {
-	s.Require().NoError(s.m.Shutdown())
-}
-
-func (s *MessengerShareMessageSuite) newMessenger() *Messenger {
-	privateKey, err := crypto.GenerateKey()
-	s.Require().NoError(err)
-
-	messenger, err := newMessengerWithKey(s.shh, privateKey, s.logger, nil)
-	s.Require().NoError(err)
-	return messenger
+	MessengerBaseTestSuite
 }
 
 func buildImageMessage(s *MessengerShareMessageSuite, chat Chat) *common.Message {
@@ -99,7 +57,7 @@ func (s *MessengerShareMessageSuite) TestImageMessageSharing() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_status_updates_test.go
+++ b/protocol/messenger_status_updates_test.go
@@ -1,19 +1,11 @@
 package protocol
 
 import (
-	"crypto/ecdsa"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
 
-	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
-	"github.com/status-im/status-go/eth-node/crypto"
-	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/protobuf"
-
-	"github.com/status-im/status-go/protocol/tt"
-	"github.com/status-im/status-go/waku"
 )
 
 func TestMessengerStatusUpdatesSuite(t *testing.T) {
@@ -21,42 +13,7 @@ func TestMessengerStatusUpdatesSuite(t *testing.T) {
 }
 
 type MessengerStatusUpdatesSuite struct {
-	suite.Suite
-	m          *Messenger
-	privateKey *ecdsa.PrivateKey // private key for the main instance of Messenger
-	// If one wants to send messages between different instances of Messenger,
-	// a single waku service should be shared.
-	shh    types.Waku
-	logger *zap.Logger
-}
-
-func (s *MessengerStatusUpdatesSuite) SetupTest() {
-	s.logger = tt.MustCreateTestLogger()
-
-	config := waku.DefaultConfig
-	config.MinimumAcceptedPoW = 0
-	shh := waku.New(&config, s.logger)
-	s.shh = gethbridge.NewGethWakuWrapper(shh)
-	s.Require().NoError(shh.Start())
-
-	s.m = s.newMessenger()
-	s.privateKey = s.m.identity
-	_, err := s.m.Start()
-	s.Require().NoError(err)
-
-}
-
-func (s *MessengerStatusUpdatesSuite) TearDownTest() {
-	s.Require().NoError(s.m.Shutdown())
-}
-
-func (s *MessengerStatusUpdatesSuite) newMessenger() *Messenger {
-	privateKey, err := crypto.GenerateKey()
-	s.Require().NoError(err)
-
-	messenger, err := newMessengerWithKey(s.shh, privateKey, s.logger, nil)
-	s.Require().NoError(err)
-	return messenger
+	MessengerBaseTestSuite
 }
 
 func (s *MessengerStatusUpdatesSuite) TestNextHigherClockValueOfAutomaticStatusUpdates() {

--- a/protocol/messenger_sync_activity_center_test.go
+++ b/protocol/messenger_sync_activity_center_test.go
@@ -43,7 +43,7 @@ func (s *MessengerSyncActivityCenterSuite) SetupTest() {
 }
 
 func (s *MessengerSyncActivityCenterSuite) TearDownTest() {
-	s.Require().NoError(s.m2.Shutdown())
+	TearDownMessenger(&s.Suite, s.m2)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/messenger_sync_bookmark_test.go
+++ b/protocol/messenger_sync_bookmark_test.go
@@ -2,22 +2,15 @@ package protocol
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"errors"
 	"testing"
 	"time"
 
-	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
-	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/tt"
 	"github.com/status-im/status-go/services/browsers"
-	"github.com/status-im/status-go/waku"
 
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/zap"
-
-	"github.com/status-im/status-go/eth-node/types"
 )
 
 func TestMessengerSyncBookmarkSuite(t *testing.T) {
@@ -25,45 +18,7 @@ func TestMessengerSyncBookmarkSuite(t *testing.T) {
 }
 
 type MessengerSyncBookmarkSuite struct {
-	suite.Suite
-	m          *Messenger        // main instance of Messenger
-	privateKey *ecdsa.PrivateKey // private key for the main instance of Messenger
-
-	// If one wants to send messages between different instances of Messenger,
-	// a single Waku service should be shared.
-	shh types.Waku
-
-	logger *zap.Logger
-}
-
-func (s *MessengerSyncBookmarkSuite) SetupTest() {
-	s.logger = tt.MustCreateTestLogger()
-
-	config := waku.DefaultConfig
-	config.MinimumAcceptedPoW = 0
-	shh := waku.New(&config, s.logger)
-	s.shh = gethbridge.NewGethWakuWrapper(shh)
-	s.Require().NoError(shh.Start())
-
-	s.m = s.newMessenger(s.shh)
-	s.privateKey = s.m.identity
-	// We start the messenger in order to receive installations
-	_, err := s.m.Start()
-	s.Require().NoError(err)
-}
-
-func (s *MessengerSyncBookmarkSuite) TearDownTest() {
-	s.Require().NoError(s.m.Shutdown())
-}
-
-func (s *MessengerSyncBookmarkSuite) newMessenger(shh types.Waku) *Messenger {
-	privateKey, err := crypto.GenerateKey()
-	s.Require().NoError(err)
-
-	messenger, err := newMessengerWithKey(s.shh, privateKey, s.logger, nil)
-	s.Require().NoError(err)
-
-	return messenger
+	MessengerBaseTestSuite
 }
 
 func (s *MessengerSyncBookmarkSuite) TestSyncBookmark() {

--- a/protocol/messenger_sync_chat_test.go
+++ b/protocol/messenger_sync_chat_test.go
@@ -75,8 +75,8 @@ func (s *MessengerSyncChatSuite) SetupTest() {
 }
 
 func (s *MessengerSyncChatSuite) TearDownTest() {
-	s.Require().NoError(s.alice1.Shutdown())
-	s.Require().NoError(s.alice2.Shutdown())
+	TearDownMessenger(&s.Suite, s.alice1)
+	TearDownMessenger(&s.Suite, s.alice2)
 	_ = s.logger.Sync()
 }
 

--- a/protocol/messenger_sync_customization_color_test.go
+++ b/protocol/messenger_sync_customization_color_test.go
@@ -52,8 +52,8 @@ func (s *MessengerSyncAccountCustomizationColorSuite) SetupTest() {
 }
 
 func (s *MessengerSyncAccountCustomizationColorSuite) TearDownTest() {
-	s.Require().NoError(s.alice.Shutdown())
-	s.Require().NoError(s.alice2.Shutdown())
+	TearDownMessenger(&s.Suite, s.alice)
+	TearDownMessenger(&s.Suite, s.alice2)
 	_ = s.logger.Sync()
 }
 

--- a/protocol/messenger_sync_keycard_change_test.go
+++ b/protocol/messenger_sync_keycard_change_test.go
@@ -109,8 +109,8 @@ func (s *MessengerSyncKeycardChangeSuite) SetupTest() {
 }
 
 func (s *MessengerSyncKeycardChangeSuite) TearDownTest() {
-	s.Require().NoError(s.other.Shutdown())
-	s.Require().NoError(s.main.Shutdown())
+	TearDownMessenger(&s.Suite, s.other)
+	TearDownMessenger(&s.Suite, s.main)
 }
 
 func (s *MessengerSyncKeycardChangeSuite) newMessenger(shh types.Waku) *Messenger {

--- a/protocol/messenger_sync_keycards_state_test.go
+++ b/protocol/messenger_sync_keycards_state_test.go
@@ -109,8 +109,8 @@ func (s *MessengerSyncKeycardsStateSuite) SetupTest() {
 }
 
 func (s *MessengerSyncKeycardsStateSuite) TearDownTest() {
-	s.Require().NoError(s.other.Shutdown())
-	s.Require().NoError(s.main.Shutdown())
+	TearDownMessenger(&s.Suite, s.other)
+	TearDownMessenger(&s.Suite, s.main)
 }
 
 func (s *MessengerSyncKeycardsStateSuite) newMessenger(shh types.Waku) *Messenger {

--- a/protocol/messenger_sync_saved_addresses_test.go
+++ b/protocol/messenger_sync_saved_addresses_test.go
@@ -79,7 +79,7 @@ func (s *MessengerSyncSavedAddressesSuite) SetupTest() {
 }
 
 func (s *MessengerSyncSavedAddressesSuite) TearDownTest() {
-	s.Require().NoError(s.main.Shutdown())
+	TearDownMessenger(&s.Suite, s.main)
 }
 
 func (s *MessengerSyncSavedAddressesSuite) newMessenger(shh types.Waku) *Messenger {

--- a/protocol/messenger_sync_settings_test.go
+++ b/protocol/messenger_sync_settings_test.go
@@ -102,7 +102,7 @@ func (s *MessengerSyncSettingsSuite) SetupTest() {
 }
 
 func (s *MessengerSyncSettingsSuite) TearDownTest() {
-	s.Require().NoError(s.alice.Shutdown())
+	TearDownMessenger(&s.Suite, s.alice)
 	_ = s.logger.Sync()
 }
 

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -508,7 +508,7 @@ func (s *MessengerSuite) TestRetrieveTheirPublic() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -552,7 +552,7 @@ func (s *MessengerSuite) TestDropAudioMessageInPublicGroup() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -579,7 +579,7 @@ func (s *MessengerSuite) TestDeletedAtClockValue() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -611,7 +611,7 @@ func (s *MessengerSuite) TestRetrieveBlockedContact() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 
 	theirChat := CreatePublicChat("status", s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
@@ -691,7 +691,7 @@ func (s *MessengerSuite) TestResendPublicMessage() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -747,7 +747,7 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateChatExisting() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirChat := CreateOneToOneChat("XXX", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -790,7 +790,7 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateChatNonExisting() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	chat := CreateOneToOneChat("XXX", &s.privateKey.PublicKey, s.m.transport)
 	err = theirMessenger.SaveChat(chat)
 	s.NoError(err)
@@ -829,7 +829,7 @@ func (s *MessengerSuite) TestRetrieveTheirPublicChatNonExisting() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	chat := CreatePublicChat("test-chat", s.m.transport)
 	err = theirMessenger.SaveChat(chat)
 	s.NoError(err)
@@ -855,7 +855,7 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateGroupChat() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	response, err = s.m.CreateGroupChatWithMembers(context.Background(), "id", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -924,7 +924,7 @@ func (s *MessengerSuite) TestChangeNameGroupChat() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	response, err = s.m.CreateGroupChatWithMembers(context.Background(), "old-name", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -981,7 +981,7 @@ func (s *MessengerSuite) TestReInvitedToGroupChat() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	response, err = s.m.CreateGroupChatWithMembers(context.Background(), "old-name", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -1514,7 +1514,7 @@ func (s *MessengerSuite) TestDeclineRequestAddressForTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	myPkString := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 
@@ -1609,7 +1609,7 @@ func (s *MessengerSuite) TestSendEthTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	receiverAddress := crypto.PubkeyToAddress(theirMessenger.identity.PublicKey)
@@ -1713,7 +1713,7 @@ func (s *MessengerSuite) TestSendTokenTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	receiverAddress := crypto.PubkeyToAddress(theirMessenger.identity.PublicKey)
@@ -1816,7 +1816,7 @@ func (s *MessengerSuite) TestAcceptRequestAddressForTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	myPkString := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 
@@ -1914,7 +1914,7 @@ func (s *MessengerSuite) TestDeclineRequestTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	chat := CreateOneToOneChat(theirPkString, &theirMessenger.identity.PublicKey, s.m.transport)
@@ -2004,7 +2004,7 @@ func (s *MessengerSuite) TestRequestTransaction() {
 	theirMessenger := s.newMessenger()
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer theirMessenger.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, theirMessenger)
 	theirPkString := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
 	chat := CreateOneToOneChat(theirPkString, &theirMessenger.identity.PublicKey, s.m.transport)
@@ -2514,7 +2514,7 @@ func (s *MessengerSuite) TestSendMessageMention() {
 	alice, bob := s.m, s.newMessenger()
 	_, err := bob.Start()
 	s.Require().NoError(err)
-	defer bob.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob)
 
 	// Set display names for Bob and Alice
 	s.Require().NoError(bob.settings.SaveSettingField(settings.DisplayName, "bobby"))

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -323,3 +323,13 @@ func CreateWakuV2Network(s *suite.Suite, parentLogger *zap.Logger, nodeNames []s
 	}
 	return wrappers
 }
+
+func TearDownMessenger(s *suite.Suite, m *Messenger) {
+	s.Require().NoError(m.Shutdown())
+	if m.database != nil {
+		s.Require().NoError(m.database.Close())
+	}
+	if m.multiAccounts != nil {
+		s.Require().NoError(m.multiAccounts.Close())
+	}
+}

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -59,7 +59,7 @@ func (s *MessengerPushNotificationSuite) SetupTest() {
 }
 
 func (s *MessengerPushNotificationSuite) TearDownTest() {
-	s.Require().NoError(s.m.Shutdown())
+	TearDownMessenger(&s.Suite, s.m)
 	_ = s.logger.Sync()
 }
 
@@ -93,18 +93,18 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotification() {
 	bob1 := s.m
 	bob2, err := newMessengerWithKey(s.shh, s.m.identity, s.logger, []Option{WithPushNotifications()})
 	s.Require().NoError(err)
-	defer bob2.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob2)
 
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
-	defer server.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, server)
 
 	alice := s.newMessenger(s.shh)
 	// start alice and enable sending push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
-	defer alice.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice)
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob1.installationID, bob2.installationID}
 
@@ -281,13 +281,13 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationFromContactO
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
-	defer server.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, server)
 
 	alice := s.newMessenger(s.shh)
 	// start alice and enable push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
-	defer alice.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice)
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
 
@@ -423,18 +423,19 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
-	defer server.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, server)
 
 	alice := s.newMessenger(s.shh)
 	// another contact to invalidate the token
 	frank := s.newMessenger(s.shh)
 	_, err = frank.Start()
 	s.Require().NoError(err)
-	defer frank.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, frank)
+
 	// start alice and enable push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
-	defer alice.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice)
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
 
@@ -651,13 +652,13 @@ func (s *MessengerPushNotificationSuite) TestContactCode() {
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
-	defer server.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, server)
 
 	alice := s.newMessenger(s.shh)
 	// start alice and enable sending push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
-	defer alice.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice)
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 
 	// Register bob1
@@ -712,13 +713,13 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
-	defer server.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, server)
 
 	alice := s.newMessenger(s.shh)
 	// start alice and enable sending push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
-	defer alice.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice)
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
 
@@ -853,13 +854,13 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
-	defer server.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, server)
 
 	alice := s.newMessenger(s.shh)
 	// start alice and enable sending push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
-	defer alice.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice)
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 
 	// Register bob
@@ -984,18 +985,18 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevice
 	bob1 := s.m
 	bob2, err := newMessengerWithKey(s.shh, s.m.identity, s.logger, []Option{WithPushNotifications()})
 	s.Require().NoError(err)
-	defer bob2.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, bob2)
 
 	serverKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 	server := s.newPushNotificationServer(s.shh, serverKey)
-	defer server.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, server)
 
 	alice := s.newMessenger(s.shh)
 	// start alice and enable sending push notifications
 	_, err = alice.Start()
 	s.Require().NoError(err)
-	defer alice.Shutdown() // nolint: errcheck
+	defer TearDownMessenger(&s.Suite, alice)
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob1.installationID, bob2.installationID}
 

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -267,13 +267,15 @@ func OpenUnecryptedDB(path string) (*sql.DB, error) {
 	// readers do not block writers and faster i/o operations
 	// https://www.sqlite.org/draft/wal.html
 	// must be set after db is encrypted
-	var mode string
-	err = db.QueryRow("PRAGMA journal_mode=WAL").Scan(&mode)
-	if err != nil {
-		return nil, err
-	}
-	if mode != WALMode {
-		return nil, fmt.Errorf("unable to set journal_mode to WAL. actual mode %s", mode)
+	if path != InMemoryPath {
+		var mode string
+		err = db.QueryRow("PRAGMA journal_mode=WAL").Scan(&mode)
+		if err != nil {
+			return nil, err
+		}
+		if mode != WALMode {
+			return nil, fmt.Errorf("unable to set journal_mode to WAL. actual mode %s", mode)
+		}
 	}
 
 	return db, nil


### PR DESCRIPTION
- ensure proper teardown of the messenger in tests
- use in-memory database

The issue of  `failed to create sqlcipher driver: disk I/O error: cannot allocate memory` in the nightly tests was most likely caused by databases not being closed.