### PR TITLE
fix(wallet): start transfer controller to activate leftovers cleanup

### DIFF
--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -101,6 +101,7 @@ func NewService(
 	transactionManager := transfer.NewTransactionManager(db, gethManager, transactor, config, accountsDB, pendingTxManager, feed)
 	transferController := transfer.NewTransferController(db, accountsDB, rpcClient, accountFeed, feed, transactionManager, pendingTxManager,
 		tokenManager, balanceCacher)
+	transferController.Start()
 	cryptoCompare := cryptocompare.NewClient()
 	coingecko := coingecko.NewClient()
 	marketManager := market.NewManager(cryptoCompare, coingecko, feed)


### PR DESCRIPTION
Add a missing `transferController::Start()` call to start cleanup on wallet startup

Updates #4394
