### PR TITLE
fix: force verifiedOwner in `handleSyncInstallationCommunity`

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1380,6 +1380,10 @@ func (o *Community) Description() *protobuf.CommunityDescription {
 	return o.config.CommunityDescription
 }
 
+func (o *Community) DescriptionProtocolMessage() []byte {
+	return o.config.CommunityDescriptionProtocolMessage
+}
+
 func (o *Community) marshaledDescription() ([]byte, error) {
 	// This is only workaround to lower the size of the message that goes over the wire,
 	// see https://github.com/status-im/status-desktop/issues/12188

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1634,7 +1634,12 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	if hasTokenOwnership {
 		// Override verified owner
 		if verifiedOwner != nil {
-			m.logger.Info("updating verified owner", zap.String("communityID", community.IDString()), zap.String("owner", common.PubkeyToHex(verifiedOwner)))
+			m.logger.Info("updating verified owner",
+				zap.String("communityID", community.IDString()),
+				zap.String("verifiedOwner", common.PubkeyToHex(verifiedOwner)),
+				zap.String("signer", common.PubkeyToHex(signer)),
+				zap.String("controlNode", common.PubkeyToHex(community.ControlNode())),
+			)
 
 			// If we are not the verified owner anymore, drop the private key
 			if !common.IsPubKeyEqual(verifiedOwner, &m.identity.PublicKey) {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3345,7 +3345,14 @@ func (m *Messenger) handleSyncInstallationCommunity(messageState *ReceivedMessag
 
 	// This is our own message, so we can trust the set community owner
 	// This is good to do so that we don't have to queue all the actions done after the handled community description.
-	err = m.handleCommunityDescription(messageState, orgPubKey, &cd, syncCommunity.Description, orgPubKey)
+	// `signer` is `communityID` for a community with no owner token and `owner public key` otherwise
+	signer, err := amm.RecoverKey()
+	if err != nil {
+		logger.Debug("failed to recover community description signer", zap.Error(err))
+		return err
+	}
+
+	err = m.handleCommunityDescription(messageState, signer, &cd, syncCommunity.Description, signer)
 	if err != nil {
 		logger.Debug("m.handleCommunityDescription error", zap.Error(err))
 		return err
@@ -3420,10 +3427,6 @@ func (m *Messenger) HandleSyncCommunitySettings(messageState *ReceivedMessageSta
 
 	messageState.Response.AddCommunitySettings(communitySettings)
 	return nil
-}
-
-func (m *Messenger) handleCommunityTokensMetadataByPrivilegedMembers(community *communities.Community) error {
-	return m.communitiesManager.HandleCommunityTokensMetadataByPrivilegedMembers(community)
 }
 
 func (m *Messenger) InitHistoryArchiveTasks(communities []*communities.Community) {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2938,8 +2938,8 @@ func (m *Messenger) passStoredCommunityInfoToSignalHandler(communityID string) {
 }
 
 // handleCommunityDescription handles an community description
-func (m *Messenger) handleCommunityDescription(state *ReceivedMessageState, signer *ecdsa.PublicKey, description *protobuf.CommunityDescription, rawPayload []byte) error {
-	communityResponse, err := m.communitiesManager.HandleCommunityDescriptionMessage(signer, description, rawPayload, nil)
+func (m *Messenger) handleCommunityDescription(state *ReceivedMessageState, signer *ecdsa.PublicKey, description *protobuf.CommunityDescription, rawPayload []byte, verifiedOwner *ecdsa.PublicKey) error {
+	communityResponse, err := m.communitiesManager.HandleCommunityDescriptionMessage(signer, description, rawPayload, verifiedOwner)
 	if err != nil {
 		return err
 	}
@@ -3280,7 +3280,7 @@ func (m *Messenger) HandleSyncInstallationCommunity(messageState *ReceivedMessag
 }
 
 func (m *Messenger) handleSyncInstallationCommunity(messageState *ReceivedMessageState, syncCommunity *protobuf.SyncInstallationCommunity, statusMessage *v1protocol.StatusMessage) error {
-	logger := m.logger.Named("handleSyncCommunity")
+	logger := m.logger.Named("handleSyncInstallationCommunity")
 
 	// Should handle community
 	shouldHandle, err := m.communitiesManager.ShouldHandleSyncCommunity(syncCommunity)
@@ -3343,7 +3343,9 @@ func (m *Messenger) handleSyncInstallationCommunity(messageState *ReceivedMessag
 		return err
 	}
 
-	err = m.handleCommunityDescription(messageState, orgPubKey, &cd, syncCommunity.Description)
+	// This is our own message, so we can trust the set community owner
+	// This is good to do so that we don't have to queue all the actions done after the handled community description.
+	err = m.handleCommunityDescription(messageState, orgPubKey, &cd, syncCommunity.Description, orgPubKey)
 	if err != nil {
 		logger.Debug("m.handleCommunityDescription error", zap.Error(err))
 		return err
@@ -3363,16 +3365,6 @@ func (m *Messenger) handleSyncInstallationCommunity(messageState *ReceivedMessag
 			logger.Debug("m.SetSyncControlNode", zap.Error(err))
 			return err
 		}
-	}
-
-	savedCommunity, err := m.communitiesManager.GetByID(syncCommunity.Id)
-	if err != nil {
-		return err
-	}
-
-	if err := m.handleCommunityTokensMetadataByPrivilegedMembers(savedCommunity); err != nil {
-		logger.Debug("m.handleCommunityTokensMetadataByPrivilegedMembers", zap.Error(err))
-		return err
 	}
 
 	// if we are not waiting for approval, join or leave the community

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2299,7 +2299,7 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 			return err
 		}
 
-		err = m.handleCommunityDescription(state, signer, description, receivedMessage.GetCommunity())
+		err = m.handleCommunityDescription(state, signer, description, receivedMessage.GetCommunity(), nil)
 		if err != nil {
 			return err
 		}
@@ -3587,7 +3587,7 @@ func (m *Messenger) HandlePushNotificationRequest(state *ReceivedMessageState, m
 
 func (m *Messenger) HandleCommunityDescription(state *ReceivedMessageState, message *protobuf.CommunityDescription, statusMessage *v1protocol.StatusMessage) error {
 
-	err := m.handleCommunityDescription(state, state.CurrentMessageState.PublicKey, message, statusMessage.EncryptionLayer.Payload)
+	err := m.handleCommunityDescription(state, state.CurrentMessageState.PublicKey, message, statusMessage.EncryptionLayer.Payload, nil)
 	if err != nil {
 		m.logger.Warn("failed to handle CommunityDescription", zap.Error(err))
 		return err


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12872
desktop PR: https://github.com/status-im/status-desktop/pull/12925

1. When a message comes to us from the backup, we can trust communities owner as verified.
So we just pass the signed to force this behaviour:
https://github.com/status-im/status-go/blob/c25dd3cf52fcb426701f5c2afbb9eed155c755f1/protocol/messenger_communities.go#L3348

2. I removed a redundant call to `handleCommunityTokensMetadataByPrivilegedMembers` here:
https://github.com/status-im/status-go/blob/c66d28d93e93fabc1e77f16db5a67686286fe01d/protocol/messenger_communities.go#L3373-L3376
because we already do that during `handleCommunityDescription` here:
https://github.com/status-im/status-go/blob/c25dd3cf52fcb426701f5c2afbb9eed155c755f1/protocol/communities/manager.go#L1669


