### PR TITLE
chore: parse all non confirmed requests to join of the community during getting all communities

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -265,6 +265,7 @@ func (o *Community) MarshalJSON() ([]byte, error) {
 		PubsubTopic                 string                               `json:"pubsubTopic"`
 		PubsubTopicKey              string                               `json:"pubsubTopicKey"`
 		Shard                       *shard.Shard                         `json:"shard"`
+		RequestsToJoinCommunity     []*RequestToJoin                     `json:"requestsToJoinCommunity"`
 	}{
 		ID:                          o.ID(),
 		MemberRole:                  o.MemberRole(o.MemberIdentity()),
@@ -287,6 +288,7 @@ func (o *Community) MarshalJSON() ([]byte, error) {
 		PubsubTopic:                 o.PubsubTopic(),
 		PubsubTopicKey:              o.PubsubTopicKey(),
 		Shard:                       o.Shard(),
+		RequestsToJoinCommunity:     []*RequestToJoin{},
 	}
 	if o.config.CommunityDescription != nil {
 		for id, c := range o.config.CommunityDescription.Categories {
@@ -325,6 +327,7 @@ func (o *Community) MarshalJSON() ([]byte, error) {
 		communityItem.OutroMessage = o.config.CommunityDescription.OutroMessage
 		communityItem.CommunityTokensMetadata = o.config.CommunityDescription.CommunityTokensMetadata
 		communityItem.ActiveMembersCount = o.config.CommunityDescription.ActiveMembersCount
+		communityItem.RequestsToJoinCommunity = o.config.RequestsToJoin
 
 		if o.config.CommunityDescription.Identity != nil {
 			communityItem.Name = o.Name()

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -1894,3 +1894,64 @@ func (s *ManagerSuite) TestCommunityQueueMultipleDifferentSignersIgnoreIfNotRetu
 	s.Require().NoError(err)
 	s.Require().Equal(clock1, fetchedCommunity.config.CommunityDescription.Clock)
 }
+
+func (s *ManagerSuite) TestGetAllCommunities() {
+	// default community
+	communities, err := s.manager.All()
+	s.Require().NoError(err)
+	s.Require().Len(communities, 1)
+
+	request := &requests.CreateCommunity{
+		Name:        "status",
+		Description: "token membership description",
+		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+	}
+
+	community, err := s.manager.CreateCommunity(request, true)
+	s.Require().NoError(err)
+	s.Require().NotNil(community)
+
+	communities, err = s.manager.All()
+	s.Require().NoError(err)
+	s.Require().Len(communities, 2)
+
+	// add requests to join to the community
+	allStates := []RequestToJoinState{
+		RequestToJoinStatePending,
+		RequestToJoinStateDeclined,
+		RequestToJoinStateAccepted,
+		RequestToJoinStateCanceled,
+		RequestToJoinStateAcceptedPending,
+		RequestToJoinStateDeclinedPending,
+		RequestToJoinStateAwaitingAddresses,
+	}
+
+	clock := uint64(time.Now().Unix())
+
+	for i := range allStates {
+		identity, err := crypto.GenerateKey()
+		s.Require().NoError(err)
+
+		rtj := &RequestToJoin{
+			ID:          types.HexBytes{1, 2, 3, 4, 5, 6, 7, byte(i)},
+			PublicKey:   common.PubkeyToHex(&identity.PublicKey),
+			Clock:       clock,
+			CommunityID: community.ID(),
+			State:       allStates[i],
+		}
+		err = s.manager.SaveRequestToJoin(rtj)
+		s.Require().NoError(err)
+	}
+
+	communities, err = s.manager.All()
+	s.Require().NoError(err)
+	s.Require().Len(communities, 2)
+
+	for _, resultCommunity := range communities {
+		if resultCommunity.IDString() == community.IDString() {
+			s.Require().Len(resultCommunity.RequestsToJoin(), 6)
+		} else {
+			s.Require().Len(resultCommunity.RequestsToJoin(), 0)
+		}
+	}
+}

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -1646,3 +1646,28 @@ func (p *Persistence) SetCuratedCommunities(communities *CuratedCommunities) err
 
 	return nil
 }
+
+func (p *Persistence) AllNonApprovedCommunitiesRequestsToJoin() (map[string][]*RequestToJoin, error) {
+	nonApprovedRequestsToJoin := make(map[string][]*RequestToJoin)
+	rows, err := p.db.Query(`SELECT id,public_key,clock,ens_name,chat_id,community_id,state FROM communities_requests_to_join WHERE state != ?`, RequestToJoinStateAccepted)
+
+	if err == sql.ErrNoRows {
+		return nonApprovedRequestsToJoin, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	for rows.Next() {
+		request := &RequestToJoin{}
+		err := rows.Scan(&request.ID, &request.PublicKey, &request.Clock, &request.ENSName, &request.ChatID, &request.CommunityID, &request.State)
+		if err != nil {
+			return nil, err
+		}
+
+		communityID := types.EncodeHex(request.CommunityID)
+		nonApprovedRequestsToJoin[communityID] = append(nonApprovedRequestsToJoin[communityID], request)
+	}
+	return nonApprovedRequestsToJoin, nil
+}


### PR DESCRIPTION
- during requesting all communities, add all non-approved requests to join the Community
- send MessengerSignal after promoting self as a control node

Closes #https://github.com/status-im/status-desktop/issues/12577

status-desktop PR: https://github.com/status-im/status-desktop/pull/12928
