### PR TITLE
fix: use community controlNode pubkey instead of community ID for verifying the received community data signer

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1758,7 +1758,7 @@ func (o *Community) VerifyGrantSignature(data []byte) (*protobuf.Grant, error) {
 		return nil, err
 	}
 
-	if !common.IsPubKeyEqual(o.config.ID, extractedPublicKey) {
+	if !common.IsPubKeyEqual(o.ControlNode(), extractedPublicKey) {
 		return nil, ErrInvalidGrant
 	}
 
@@ -1778,7 +1778,7 @@ func (o *Community) CanPost(pk *ecdsa.PublicKey, chatID string, grantBytes []byt
 	}
 
 	// community creator can always post, return immediately
-	if common.IsPubKeyEqual(pk, o.config.ID) {
+	if common.IsPubKeyEqual(pk, o.ControlNode()) {
 		return true, nil
 	}
 

--- a/protocol/communities/community_event.go
+++ b/protocol/communities/community_event.go
@@ -187,7 +187,7 @@ func (o *Community) UpdateCommunityByEvents(communityEventMessage *CommunityEven
 	defer o.mutex.Unlock()
 
 	// Validate that EventsBaseCommunityDescription was signed by the control node
-	description, err := validateAndGetEventsMessageCommunityDescription(communityEventMessage.EventsBaseCommunityDescription, o.config.ID)
+	description, err := validateAndGetEventsMessageCommunityDescription(communityEventMessage.EventsBaseCommunityDescription, o.ControlNode())
 	if err != nil {
 		return err
 	}
@@ -342,7 +342,7 @@ func (o *Community) addNewCommunityEvent(event *CommunityEvent) error {
 	// If there were no events before, extract CommunityDescription from CommunityDescriptionProtocolMessage
 	// and check the signature
 	if o.config.EventsData == nil || len(o.config.EventsData.EventsBaseCommunityDescription) == 0 {
-		_, err := validateAndGetEventsMessageCommunityDescription(o.config.CommunityDescriptionProtocolMessage, o.config.ID)
+		_, err := validateAndGetEventsMessageCommunityDescription(o.config.CommunityDescriptionProtocolMessage, o.ControlNode())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If the community has an owner token, we must verify the signature using ControlNode pubkey.
If the community does not have an owner token, calling ControlNode() will return community ID

Closes #https://github.com/status-im/status-desktop/issues/12902
