### PR TITLE
chore(walletconnect)_: various improvements applied

### DIFF
--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -144,7 +144,7 @@ func NewService(
 
 	activity := activity.NewService(db, tokenManager, collectiblesManager, feed)
 
-	walletconnect := walletconnect.NewService(db, rpcClient.NetworkManager, accountsDB, transactor, gethManager, feed, config)
+	walletconnect := walletconnect.NewService(db, rpcClient.NetworkManager, accountsDB, transactionManager, gethManager, feed, config)
 
 	return &Service{
 		db:                    db,

--- a/services/wallet/walletconnect/walletconnect.go
+++ b/services/wallet/walletconnect/walletconnect.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/services/wallet/walletevent"
 )
@@ -100,14 +99,6 @@ type SessionRequest struct {
 type SessionDelete struct {
 	ID    int64 `json:"id"`
 	Topic Topic `json:"topic"`
-}
-
-type SessionRequestResponse struct {
-	KeyUID        string        `json:"keyUid,omitempty"`
-	Address       types.Address `json:"address,omitempty"`
-	AddressPath   string        `json:"addressPath,omitempty"`
-	SignOnKeycard bool          `json:"signOnKeycard,omitempty"`
-	MessageToSign interface{}   `json:"messageToSign,omitempty"`
 }
 
 // Valid namespace

--- a/transactions/pendingtxtracker.go
+++ b/transactions/pendingtxtracker.go
@@ -359,6 +359,7 @@ const (
 	BurnCommunityToken        PendingTrxType = "BurnCommunityToken"
 	DeployOwnerToken          PendingTrxType = "DeployOwnerToken"
 	SetSignerPublicKey        PendingTrxType = "SetSignerPublicKey"
+	WalletConnectTransfer     PendingTrxType = "WalletConnectTransfer"
 )
 
 type PendingTransaction struct {


### PR DESCRIPTION
These changes are the second step in cleaning the wallet API and moving the things to the place where they logically belong.

- `WalletConnectTransfer` identified as a new transfer type
- Wallet-related endpoints that logically belong to the wallet moved from the wallet connect service
- Wallet connect service now receives `transfer.TransactionManager` instead of `transactions.Transactor`
- Deadlock issue when trying to send the tx with the wrong nonce fixed
