### PR TITLE
fix: merge chat response with response to joining a community

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4033,6 +4033,7 @@ func (m *Messenger) MessageByChatID(chatID, cursor string, limit int) ([]*common
 		}
 
 	}
+
 	if m.httpServer != nil {
 		for idx := range msgs {
 			m.prepareMessage(msgs[idx], m.httpServer)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1620,11 +1620,16 @@ func (m *Messenger) HandleCommunityRequestToJoinResponse(state *ReceivedMessageS
 		if err != nil {
 			return err
 		}
+
+		// we merge to include chats in response signal to joining a community
+		err = state.Response.Merge(response)
+		if err != nil {
+			return err
+		}
+
 		if len(response.Communities()) > 0 {
 			communitySettings := response.CommunitiesSettings()[0]
 			community := response.Communities()[0]
-			state.Response.AddCommunity(community)
-			state.Response.AddCommunitySettings(communitySettings)
 
 			magnetlink := requestToJoinResponseProto.MagnetUri
 			if m.torrentClientReady() && communitySettings != nil && communitySettings.HistoryArchiveSupportEnabled && magnetlink != "" {

--- a/protocol/messenger_response.go
+++ b/protocol/messenger_response.go
@@ -316,6 +316,7 @@ func (r *MessengerResponse) Merge(response *MessengerResponse) error {
 	r.AddMessages(response.Messages())
 	r.AddContacts(response.Contacts)
 	r.AddCommunities(response.Communities())
+	r.UpdateCommunitySettings(response.CommunitiesSettings())
 	r.AddPinMessages(response.PinMessages())
 	r.AddVerificationRequests(response.VerificationRequests())
 	r.AddTrustStatuses(response.trustStatus)
@@ -360,6 +361,12 @@ func (r *MessengerResponse) AddCommunitySettings(c *communities.CommunitySetting
 	}
 
 	r.communitiesSettings[c.CommunityID] = c
+}
+
+func (r *MessengerResponse) UpdateCommunitySettings(communitySettings []*communities.CommunitySettings) {
+	for _, communitySetting := range communitySettings {
+		r.AddCommunitySettings(communitySetting)
+	}
 }
 
 func (r *MessengerResponse) AddRequestsToJoinCommunity(requestsToJoin []*communities.RequestToJoin) {


### PR DESCRIPTION
### Summary: 

When an open community was created by Device A and shared with Device B and when Device B would request to join such a community, the general channel would be forever in loading state.

This happened because as part of messenger response the chatId of general channel was not sent and mobile client would not fetch that chat data.

This PR fixes that issue by sending chatId as part of messenger response right after the request to join community succeeds.

fixes https://github.com/status-im/status-mobile/issues/17801
