### PR TITLE
feat: add support for Opt Sepolia in the Alchemy client

### DIFF
--- a/services/wallet/thirdparty/alchemy/client.go
+++ b/services/wallet/thirdparty/alchemy/client.go
@@ -35,6 +35,8 @@ func getBaseURL(chainID walletCommon.ChainID) (string, error) {
 		return "https://opt-mainnet.g.alchemy.com", nil
 	case walletCommon.OptimismGoerli:
 		return "https://opt-goerli.g.alchemy.com", nil
+	case walletCommon.OptimismSepolia:
+		return "https://opt-sepolia.g.alchemy.com", nil
 	case walletCommon.ArbitrumMainnet:
 		return "https://arb-mainnet.g.alchemy.com", nil
 	case walletCommon.ArbitrumGoerli:


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/12937

Add base URL for Opt Sepolia in the Alchemy client.
![image](https://github.com/status-im/status-go/assets/11161531/9504138b-7e16-4297-ad30-d2af76ae43b3)

API key management had already been included beforehand.
