### PR TITLE
test: ensure max message length is not excessed when send

### DIFF
--- a/wakuv2/api.go
+++ b/wakuv2/api.go
@@ -255,6 +255,14 @@ func (api *PublicWakuAPI) Post(ctx context.Context, req NewMessage) (hexutil.Byt
 		Ephemeral:    &req.Ephemeral,
 	}
 
+	encodedMsg, err := proto.Marshal(wakuMsg)
+	if err != nil {
+		return nil, err
+	}
+	if len(encodedMsg) > int(api.w.MaxMessageSize()) {
+		return nil, errors.New("message size exceeds max size allowed by waku node")
+	}
+
 	hash, err := api.w.Send(req.PubsubTopic, wakuMsg)
 
 	if err != nil {

--- a/wakuv2/api_test.go
+++ b/wakuv2/api_test.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 
 	"github.com/status-im/status-go/wakuv2/common"

--- a/wakuv2/api_test.go
+++ b/wakuv2/api_test.go
@@ -77,19 +77,16 @@ func TestExceedMaxMessageSize(t *testing.T) {
 	w, err := New("", "", nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	api := NewPublicWakuAPI(w)
-
-	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Second)
-	defer cancel()
-
 	keyID, err := w.GenerateSymKey()
 	require.NoError(t, err)
+
 	msg := NewMessage{
 		SymKeyID:     keyID,
 		Payload:      make([]byte, 1024*1024),
 		ContentTopic: common.TopicType([4]byte{0xde, 0xea, 0xbe, 0xef}),
 	}
 
-	_, err = api.Post(ctx, msg)
+	api := NewPublicWakuAPI(w)
+	_, err = api.Post(context.TODO(), msg)
 	require.EqualError(t, err, "message size exceeds max size allowed by waku node")
 }


### PR DESCRIPTION
The check both happens in api here and [waku side](https://github.com/waku-org/go-waku/pull/939). 
It seems necessary since error raised in go-waku is not propagated to api.

Relates to https://github.com/status-im/status-go/issues/4355
