### PR TITLE
fix: tokenMaster does not have members revealed addresses

### DIFF
--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -1669,3 +1669,12 @@ func (p *Persistence) AllNonApprovedCommunitiesRequestsToJoin() ([]*RequestToJoi
 	}
 	return nonApprovedRequestsToJoin, nil
 }
+
+func (p *Persistence) RemoveAllCommunityRequestsToJoinWithRevealedAddressesExceptPublicKey(pk string, communityID []byte) error {
+	_, err := p.db.Exec(`
+	DELETE FROM communities_requests_to_join_revealed_addresses
+		WHERE request_id IN (SELECT id FROM communities_requests_to_join WHERE community_id = ? AND public_key != ?);
+	DELETE FROM communities_requests_to_join
+		WHERE community_id = ? AND public_key != ?;`, communityID, pk, communityID, pk)
+	return err
+}

--- a/protocol/communities/persistence_test.go
+++ b/protocol/communities/persistence_test.go
@@ -757,3 +757,108 @@ func (s *PersistenceSuite) TestAllNonApprovedCommunitiesRequestsToJoin() {
 	s.Require().NoError(err)
 	s.Require().Len(result, 6) // all except RequestToJoinStateAccepted
 }
+
+func (s *PersistenceSuite) TestRemoveAllCommunityRequestsToJoinWithRevealedAddressesExceptPublicKey() {
+	myIdentity, err := crypto.GenerateKey()
+	s.Require().NoError(err, "crypto.GenerateKey shouldn't give any error")
+
+	myPk := common.PubkeyToHex(&myIdentity.PublicKey)
+
+	clock := uint64(time.Now().Unix())
+
+	// add a new community
+	community := s.makeNewCommunity(myIdentity)
+	err = s.db.SaveCommunity(community)
+	s.Require().NoError(err)
+
+	// check on empty db
+	err = s.db.RemoveAllCommunityRequestsToJoinWithRevealedAddressesExceptPublicKey(myPk, community.ID())
+	s.Require().NoError(err)
+
+	// add requests to join to the community
+	allStates := []RequestToJoinState{
+		RequestToJoinStatePending,
+		RequestToJoinStateDeclined,
+		RequestToJoinStateAccepted,
+		RequestToJoinStateCanceled,
+		RequestToJoinStateAcceptedPending,
+		RequestToJoinStateDeclinedPending,
+		RequestToJoinStateAwaitingAddresses,
+	}
+
+	allRequestsToJoinIDs := [][]byte{}
+
+	for i := range allStates {
+		identity, err := crypto.GenerateKey()
+		s.Require().NoError(err)
+
+		revealedAccounts := []*protobuf.RevealedAccount{}
+		for j := 0; j < i; j++ {
+			acc := &protobuf.RevealedAccount{
+				Address:          "testAddr",
+				ChainIds:         []uint64{123},
+				IsAirdropAddress: true,
+				Signature:        []byte{},
+			}
+			revealedAccounts = append(revealedAccounts, acc)
+		}
+
+		rtj := &RequestToJoin{
+			ID:               types.HexBytes{1, 2, 3, 4, 5, 6, 7, byte(i)},
+			PublicKey:        common.PubkeyToHex(&identity.PublicKey),
+			Clock:            clock,
+			CommunityID:      community.ID(),
+			State:            allStates[i],
+			RevealedAccounts: revealedAccounts,
+		}
+
+		allRequestsToJoinIDs = append(allRequestsToJoinIDs, rtj.ID)
+
+		err = s.db.SaveRequestToJoin(rtj)
+		s.Require().NoError(err, "SaveRequestToJoin shouldn't give any error")
+		err = s.db.SaveRequestToJoinRevealedAddresses(rtj.ID, rtj.RevealedAccounts)
+		s.Require().NoError(err)
+	}
+
+	err = s.db.RemoveAllCommunityRequestsToJoinWithRevealedAddressesExceptPublicKey(myPk, community.ID())
+	s.Require().NoError(err)
+
+	requests, err := s.db.GetCommunityRequestsToJoinWithRevealedAddresses(community.ID())
+	s.Require().NoError(err)
+	s.Require().Len(requests, 0)
+
+	for _, rtjID := range allRequestsToJoinIDs {
+		accounts, err := s.db.GetRequestToJoinRevealedAddresses(rtjID)
+		s.Require().NoError(err)
+		s.Require().Len(accounts, 0)
+	}
+
+	myRtj := &RequestToJoin{
+		ID:          types.HexBytes{1, 2, 3, 4, 5, 6, 7, 8},
+		PublicKey:   myPk,
+		Clock:       clock,
+		CommunityID: community.ID(),
+		State:       RequestToJoinStateAccepted,
+		RevealedAccounts: []*protobuf.RevealedAccount{
+			{
+				Address:          "testAddr",
+				ChainIds:         []uint64{123},
+				IsAirdropAddress: true,
+				Signature:        []byte{},
+			},
+		},
+	}
+
+	err = s.db.SaveRequestToJoin(myRtj)
+	s.Require().NoError(err, "SaveRequestToJoin shouldn't give any error")
+	err = s.db.SaveRequestToJoinRevealedAddresses(myRtj.ID, myRtj.RevealedAccounts)
+	s.Require().NoError(err)
+
+	err = s.db.RemoveAllCommunityRequestsToJoinWithRevealedAddressesExceptPublicKey(myPk, community.ID())
+	s.Require().NoError(err)
+
+	requests, err = s.db.GetCommunityRequestsToJoinWithRevealedAddresses(community.ID())
+	s.Require().NoError(err)
+	s.Require().Len(requests, 1)
+	s.Require().Len(requests[0].RevealedAccounts, 1)
+}

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3026,16 +3026,16 @@ func (m *Messenger) handleCommunityPrivilegedUserSyncMessage(state *ReceivedMess
 		return err
 	}
 
+	if community == nil {
+		return communities.ErrOrgNotFound
+	}
+
 	// Currently this type of msg coming from the control node.
 	// If it will change in the future, check that events types starting from
 	// CONTROL_NODE were sent by a control node
-	isControlNodeMsg := common.IsPubKeyEqual(community.PublicKey(), signer)
+	isControlNodeMsg := common.IsPubKeyEqual(community.ControlNode(), signer)
 	if !isControlNodeMsg {
 		return errors.New("accepted/requested to join sync messages can be send only by the control node")
-	}
-
-	if community == nil {
-		return errors.New("community not found")
 	}
 
 	err = m.communitiesManager.ValidateCommunityPrivilegedUserSyncMessage(message)
@@ -3054,11 +3054,11 @@ func (m *Messenger) handleCommunityPrivilegedUserSyncMessage(state *ReceivedMess
 		state.Response.AddRequestsToJoinCommunity(requestsToJoin)
 
 	case protobuf.CommunityPrivilegedUserSyncMessage_CONTROL_NODE_ALL_SYNC_REQUESTS_TO_JOIN:
-		requestsToJoin, err := m.communitiesManager.HandleSyncAllRequestToJoinForNewPrivilegedMember(message, community.ID())
+		nonAcceptedRequestsToJoin, err := m.communitiesManager.HandleSyncAllRequestToJoinForNewPrivilegedMember(message, community.ID())
 		if err != nil {
 			return nil
 		}
-		state.Response.AddRequestsToJoinCommunity(requestsToJoin)
+		state.Response.AddRequestsToJoinCommunity(nonAcceptedRequestsToJoin)
 	}
 
 	return nil


### PR DESCRIPTION
fixed:
- control node sent to TokenMaster request to join with revealed addresses
- token master saves revealed addresses from control node msg during `handleCommunityPrivilegedUserSyncMessage`
- signer msg validation in `handleCommunityPrivilegedUserSyncMessage`
- drop all requests to join data on membership role change
- if we became a privileged member and received all requests to join, send to the backend only non-approved requests to join

Closes # https://github.com/status-im/status-desktop/issues/12903
