### PR TITLE
fix(wallet): quick fix for eating RPC requests. Proper fix TBD

### DIFF
--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -196,7 +196,7 @@ func (c *findNewBlocksCommand) findBlocksWithEthTransfers(parent context.Context
 
 		var newFromBlock *Block
 		var ethHeaders []*DBHeader
-		newFromBlock, ethHeaders, startBlockNum, err = c.fastIndex(parent, c.balanceCacher, fromBlock, to)
+		newFromBlock, ethHeaders, startBlockNum, err = c.fastIndex(parent, account, c.balanceCacher, fromBlock, to)
 		if err != nil {
 			log.Error("findNewBlocksCommand checkRange fastIndex", "err", err, "account", account,
 				"chain", c.chainClient.NetworkID())
@@ -517,7 +517,7 @@ func (c *findBlocksCommand) checkRange(parent context.Context, from *big.Int, to
 	account := c.accounts[0]
 	fromBlock := &Block{Number: from}
 
-	newFromBlock, ethHeaders, startBlock, err := c.fastIndex(parent, c.balanceCacher, fromBlock, to)
+	newFromBlock, ethHeaders, startBlock, err := c.fastIndex(parent, account, c.balanceCacher, fromBlock, to)
 	if err != nil {
 		log.Error("findBlocksCommand checkRange fastIndex", "err", err, "account", account,
 			"chain", c.chainClient.NetworkID())
@@ -592,11 +592,10 @@ func areAllHistoryBlocksLoadedForAddress(blockRangeDAO *BlockRangeSequentialDAO,
 
 // run fast indexing for every accont up to canonical chain head minus safety depth.
 // every account will run it from last synced header.
-func (c *findBlocksCommand) fastIndex(ctx context.Context, bCacher balance.Cacher,
+func (c *findBlocksCommand) fastIndex(ctx context.Context, account common.Address, bCacher balance.Cacher,
 	fromBlock *Block, toBlockNumber *big.Int) (resultingFrom *Block, headers []*DBHeader,
 	startBlock *big.Int, err error) {
 
-	account := c.accounts[0]
 	log.Debug("fast index started", "chainID", c.chainClient.NetworkID(), "account", account,
 		"from", fromBlock.Number, "to", toBlockNumber)
 

--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -743,8 +743,14 @@ func (c *loadBlocksAndTransfersCommand) Run(parent context.Context) error {
 	// by canceling the context which does not happen here, as we don't call group.Stop().
 	group := async.NewGroup(ctx)
 
+	fromNum := big.NewInt(0)
+	headNum, err := getHeadBlockNumber(ctx, c.chainClient)
+	if err != nil {
+		return err
+	}
+
 	// It will start loadTransfersCommand which will run until success when all transfers from DB are loaded
-	err := c.fetchTransfersForLoadedBlocks(group)
+	err = c.fetchTransfersForLoadedBlocks(group)
 	for err != nil {
 		return err
 	}
@@ -752,11 +758,6 @@ func (c *loadBlocksAndTransfersCommand) Run(parent context.Context) error {
 	// Start transfers loop to load transfers for new blocks
 	c.startTransfersLoop(ctx)
 
-	fromNum := big.NewInt(0)
-	headNum, err := getHeadBlockNumber(ctx, c.chainClient)
-	if err != nil {
-		return err
-	}
 	// This will start findBlocksCommand which will run until success when all blocks are loaded
 	// Iterate over all accounts and load blocks for each account
 	for _, account := range c.accounts {


### PR DESCRIPTION
1. An error in getting head block causes early return of the `Run` function but transfers loop is already started, which will be started once again after command will call Run again on timeout.
Avoid starting transfers loop for now before getting head block.

TBD: Proper fix is WIP

2. Fixed a bug that new ETH blocks in idle state were searched only for the first account on the list. Thanx @rasom for discovering it and pointing to the actual problem.