### PR TITLE
feat(wallet): better lifecycle handling of blocks and transfers search commands

### DIFF
--- a/services/wallet/async/async.go
+++ b/services/wallet/async/async.go
@@ -9,7 +9,7 @@ import (
 type Command func(context.Context) error
 
 type Commander interface {
-	Command() Command
+	Command(inteval ...time.Duration) Command
 }
 
 // SingleShotCommand runs once.

--- a/services/wallet/transfer/block_ranges_sequential_dao.go
+++ b/services/wallet/transfer/block_ranges_sequential_dao.go
@@ -9,6 +9,13 @@ import (
 	"github.com/status-im/status-go/services/wallet/bigint"
 )
 
+type BlockRangeDAOer interface {
+	getBlockRange(chainID uint64, address common.Address) (blockRange *ethTokensBlockRanges, err error)
+	upsertRange(chainID uint64, account common.Address, newBlockRange *ethTokensBlockRanges) (err error)
+	updateTokenRange(chainID uint64, account common.Address, newBlockRange *BlockRange) (err error)
+	upsertEthRange(chainID uint64, account common.Address, newBlockRange *BlockRange) (err error)
+}
+
 type BlockRangeSequentialDAO struct {
 	db *sql.DB
 }

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -1100,12 +1100,12 @@ func TestFetchTransfersForLoadedBlocks(t *testing.T) {
 	tc.traceAPICalls = true
 
 	ctx := context.Background()
-	group := async.NewGroup(ctx)
+	group := async.NewAtomicGroup(ctx)
 
 	fromNum := big.NewInt(0)
 	toNum, err := getHeadBlockNumber(ctx, cmd.chainClient)
 	require.NoError(t, err)
-	err = cmd.fetchHistoryBlocks(ctx, group, address, fromNum, toNum, blockChannel)
+	err = cmd.fetchHistoryBlocksForAccount(group, address, fromNum, toNum, blockChannel)
 	require.NoError(t, err)
 
 	select {


### PR DESCRIPTION
- Infinite commands started only once and never restarted, stopped on context cancellation
- Finite commands are joined into AtomicGroup to stop the rest in the group in case one command fails. Otherwise other commands in the group will continue running and the failed command is not retried to restart until other commands finish.
- Fixed goroutines leakage in case of failure of some commands

TBD: error handling in findBlocksCommand

Updates [#11074](https://github.com/status-im/status-desktop/issues/11074)
