### PR TITLE
Fix Unstructured Error Logging in LoginAccount Function

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -305,7 +305,7 @@ func LoginAccount(requestJSON string) string {
 	api.RunAsync(func() error {
 		err := statusBackend.LoginAccount(&request)
 		if err != nil {
-			log.Error("loginAccount error", err)
+			log.Error("loginAccount failed", "error", err)
 			return err
 		}
 		log.Debug("loginAccount started node")


### PR DESCRIPTION
## Problem:
Prior to this change, an error in the LoginAccount function resulted in unstructured and incomplete log entries, which made debugging more difficult. The logs showed a generic error message, and occasionally a LOG15_ERROR with an odd number of arguments, resulting in a nil placeholder. e.g.:
```
ERROR[12-11|03:53:12.756|github.com/status-im/status-go/mobile/status.go:308]                                                                loginAccount error                       LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"
```

## Solution:
This PR addresses the issue by refining the error logging within the LoginAccount function. We now explicitly include the function name in the log message, providing a clear and direct indication of where the error originated.

**PR status:** ready.