### PR TITLE
fix_: don't start mailserver cycle when no mailservers set

### DIFF
--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -68,7 +68,7 @@ func (m *Messenger) StartMailserverCycle(mailservers []mailservers.Mailserver) e
 	switch version {
 	case 1:
 		if m.server == nil {
-			m.logger.Warn("not starting mailserver cycle")
+			m.logger.Warn("not starting mailserver cycle: no p2p server is set")
 			return nil
 		}
 
@@ -77,6 +77,10 @@ func (m *Messenger) StartMailserverCycle(mailservers []mailservers.Mailserver) e
 		go m.updateWakuV1PeerStatus()
 
 	case 2:
+		if len(mailservers) == 0 {
+			m.logger.Warn("not starting mailserver cycle: empty mailservers list")
+			return nil
+		}
 		for _, storenode := range mailservers {
 			_, err := m.transport.AddStorePeer(storenode.Address)
 			if err != nil {


### PR DESCRIPTION
### Summary

After refactoring the mailserver cycle was started even when no mailservers are set.

It's not a big problem, but it's a bit cleaner now for the tests that use Waku v2 (e.g. `MessengerCommunitiesTokenPermissionsSuite`).