### PR TITLE
feat: Return seen/unseen messages count in MessengerResponse

### DIFF
--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -417,12 +417,12 @@ func (s *MessengerActivityCenterMessageSuite) confirmMentionAndReplyNotification
 func (s *MessengerActivityCenterMessageSuite) TestMarkMessagesSeenMarksNotificationsRead() {
 	alice, _, mentionMessage, replyMessage, _ := s.prepareCommunityChannelWithMentionAndReply()
 
-	_, _, notifications, err := alice.MarkMessagesSeen(replyMessage.ChatId, []string{mentionMessage.ID, replyMessage.ID})
+	response, err := alice.MarkMessagesRead(replyMessage.ChatId, []string{mentionMessage.ID, replyMessage.ID})
 
 	s.Require().NoError(err)
-	s.Require().Len(notifications, 2)
-	s.Require().True(notifications[0].Read)
-	s.Require().True(notifications[1].Read)
+	s.Require().Len(response.ActivityCenterNotifications(), 2)
+	s.Require().True(response.ActivityCenterNotifications()[0].Read)
+	s.Require().True(response.ActivityCenterNotifications()[1].Read)
 
 	s.confirmMentionAndReplyNotificationsRead(alice, mentionMessage, replyMessage, true)
 }

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -268,18 +268,25 @@ func (s *MessengerSuite) TestMarkMessagesSeen() {
 	err = s.m.SaveMessages([]*common.Message{inputMessage1, inputMessage2})
 	s.Require().NoError(err)
 
-	count, countWithMentions, notifications, err := s.m.MarkMessagesSeen(chat.ID, []string{inputMessage1.ID})
+	response, err := s.m.MarkMessagesRead(chat.ID, []string{inputMessage1.ID})
 	s.Require().NoError(err)
-	s.Require().Equal(uint64(1), count)
-	s.Require().Equal(uint64(1), countWithMentions)
-	s.Require().Len(notifications, 0)
+
+	s.Require().Len(response.GetSeenAndUnseenMessages(), 1)
+	s.Require().Equal(chat.ID, response.GetSeenAndUnseenMessages()[0].ChatID)
+	s.Require().Equal(uint64(1), response.GetSeenAndUnseenMessages()[0].Count)
+	s.Require().Equal(uint64(1), response.GetSeenAndUnseenMessages()[0].CountWithMentions)
+	s.Require().Equal(true, response.GetSeenAndUnseenMessages()[0].Seen)
+	s.Require().Len(response.ActivityCenterNotifications(), 0)
 
 	// Make sure that if it's not seen, it does not return a count of 1
-	count, countWithMentions, notifications, err = s.m.MarkMessagesSeen(chat.ID, []string{inputMessage1.ID})
+	response, err = s.m.MarkMessagesRead(chat.ID, []string{inputMessage1.ID})
 	s.Require().NoError(err)
-	s.Require().Equal(uint64(0), count)
-	s.Require().Equal(uint64(0), countWithMentions)
-	s.Require().Len(notifications, 0)
+	s.Require().Len(response.GetSeenAndUnseenMessages(), 1)
+	s.Require().Equal(chat.ID, response.GetSeenAndUnseenMessages()[0].ChatID)
+	s.Require().Equal(uint64(0), response.GetSeenAndUnseenMessages()[0].Count)
+	s.Require().Equal(uint64(0), response.GetSeenAndUnseenMessages()[0].CountWithMentions)
+	s.Require().Equal(true, response.GetSeenAndUnseenMessages()[0].Seen)
+	s.Require().Len(response.ActivityCenterNotifications(), 0)
 
 	chats := s.m.Chats()
 	for _, c := range chats {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -797,6 +797,7 @@ func (api *PublicAPI) DeleteMessagesByChatID(id string) error {
 	return api.service.messenger.DeleteMessagesByChatID(id)
 }
 
+// Deprecated: Use MarkMessagesRead instead
 func (api *PublicAPI) MarkMessagesSeen(chatID string, ids []string) (*MarkMessageSeenResponse, error) {
 	count, withMentions, notifications, err := api.service.messenger.MarkMessagesSeen(chatID, ids)
 	if err != nil {
@@ -811,18 +812,12 @@ func (api *PublicAPI) MarkMessagesSeen(chatID string, ids []string) (*MarkMessag
 	return response, nil
 }
 
-func (api *PublicAPI) MarkMessageAsUnread(chatID string, messageID string) (*MarkMessageSeenResponse, error) {
-	count, withMentions, notifications, err := api.service.messenger.MarkMessageAsUnread(chatID, messageID)
-	if err != nil {
-		return nil, err
-	}
+func (api *PublicAPI) MarkMessagesRead(chatID string, ids []string) (*protocol.MessengerResponse, error) {
+	return api.service.messenger.MarkMessagesRead(chatID, ids)
+}
 
-	response := &MarkMessageSeenResponse{
-		Count:                       count,
-		CountWithMentions:           withMentions,
-		ActivityCenterNotifications: notifications,
-	}
-	return response, nil
+func (api *PublicAPI) MarkMessageAsUnread(chatID string, messageID string) (*protocol.MessengerResponse, error) {
+	return api.service.messenger.MarkMessageAsUnread(chatID, messageID)
 }
 
 func (api *PublicAPI) MarkAllRead(ctx context.Context, chatID string) (*protocol.MessengerResponse, error) {


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/12857

Add unread count and unread count with mentions to the messenger response

Important changes:
- [x] Change `MarkActivityCenterNotificationsRead`: add count and count with mentions for each affected chat in the response
- [x] Deprecate `MarkMessagesSeen`
- [x] Introduce `MarkMessagesRead` with MessengerResponse
- [x] Change `MarkMessageAsUnread` with MessengerResponse return type (not used on mobile currently)

