### PR TITLE
chore: fetch contact with `StoreNodeRequestManager`

### DIFF
--- a/protocol/linkpreview_unfurler_status.go
+++ b/protocol/linkpreview_unfurler_status.go
@@ -59,7 +59,7 @@ func (u *StatusUnfurler) buildContactData(publicKey string) (*common.StatusConta
 
 	// If no contact found locally, fetch it from waku
 	if contact == nil {
-		if contact, err = u.m.RequestContactInfoFromMailserver(contactID, true); err != nil {
+		if contact, err = u.m.FetchContact(contactID, true); err != nil {
 			return nil, fmt.Errorf("failed to request contact info from mailserver for public key '%s': %w", publicKey, err)
 		}
 	}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -154,9 +154,6 @@ type Messenger struct {
 		once sync.Once
 	}
 
-	requestedContactsLock sync.RWMutex
-	requestedContacts     map[string]*transport.Filter
-
 	connectionState       connection.State
 	telemetryClient       *telemetry.Client
 	contractMaker         *contracts.ContractMaker
@@ -531,16 +528,14 @@ func NewMessenger(
 			peers:                     make(map[string]peerStatus),
 			availabilitySubscriptions: make([]chan struct{}, 0),
 		},
-		mailserversDatabase:   c.mailserversDatabase,
-		account:               c.account,
-		quit:                  make(chan struct{}),
-		ctx:                   ctx,
-		cancel:                cancel,
-		requestedContactsLock: sync.RWMutex{},
-		requestedContacts:     make(map[string]*transport.Filter),
-		importingCommunities:  make(map[string]bool),
-		importingChannels:     make(map[string]bool),
-		importRateLimiter:     rate.NewLimiter(rate.Every(importSlowRate), 1),
+		mailserversDatabase:  c.mailserversDatabase,
+		account:              c.account,
+		quit:                 make(chan struct{}),
+		ctx:                  ctx,
+		cancel:               cancel,
+		importingCommunities: make(map[string]bool),
+		importingChannels:    make(map[string]bool),
+		importRateLimiter:    rate.NewLimiter(rate.Every(importSlowRate), 1),
 		importDelayer: struct {
 			wait chan struct{}
 			once sync.Once
@@ -3745,11 +3740,9 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 
 				contact, contactFound := messageState.AllContacts.Load(senderID)
 
-				if _, ok := m.requestedContacts[senderID]; !ok {
-					// Check for messages from blocked users
-					if contactFound && contact.Blocked {
-						continue
-					}
+				// Check for messages from blocked users
+				if contactFound && contact.Blocked {
+					continue
 				}
 
 				// Don't process duplicates
@@ -3773,7 +3766,6 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 					contact = c
 					if msg.ApplicationLayer.Type != protobuf.ApplicationMetadataMessage_PUSH_NOTIFICATION_QUERY {
 						messageState.AllContacts.Store(senderID, contact)
-						m.forgetContactInfoRequest(senderID)
 					}
 				}
 				messageState.CurrentMessageState = &CurrentMessageState{

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -578,7 +578,7 @@ func NewMessenger(
 	}
 
 	messenger.mentionsManager = NewMentionManager(messenger)
-	messenger.storeNodeRequestsManager = NewCommunityRequestsManager(messenger)
+	messenger.storeNodeRequestsManager = NewStoreNodeRequestManager(messenger)
 
 	if c.walletService != nil {
 		messenger.walletAPI = walletAPI

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
 

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -1218,6 +1218,11 @@ func (m *Messenger) scheduleSyncFiltersForContact(publicKey *ecdsa.PublicKey) (*
 	return filter, nil
 }
 
+func (m *Messenger) FetchContact(contactID string, waitForResponse bool) (*Contact, error) {
+	contact, _, err := m.storeNodeRequestsManager.FetchContact(contactID, waitForResponse)
+	return contact, err
+}
+
 func (m *Messenger) RequestContactInfoFromMailserver(pubkey string, waitForResponse bool) (*Contact, error) {
 
 	err := m.requestContactInfoFromMailserver(pubkey)

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -461,7 +461,7 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestWithoutWaitingResponse() {
 func (s *MessengerStoreNodeRequestSuite) TestRequestProfileInfo() {
 	s.createOwner()
 
-	// Set keypair
+	// Set keypair (to be able to set displayName)
 	ownerProfileKp := accounts.GetProfileKeypairForTest(true, false, false)
 	ownerProfileKp.KeyUID = s.owner.account.KeyUID
 	ownerProfileKp.Accounts[0].KeyUID = s.owner.account.KeyUID
@@ -473,17 +473,6 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestProfileInfo() {
 	err = s.owner.SetDisplayName("super-owner")
 	s.Require().NoError(err)
 
-	//s.waitForAvailableStoreNode(s.owner)
-	//err = s.owner.publishContactCode()
-	//s.Require().NoError(err)
-
 	s.createBob()
-	//s.waitForAvailableStoreNode(s.bob)
-	//
-	//cancel := make(chan struct{}, 1)
-	//s.bob.StartRetrieveMessagesLoop(1*time.Second, cancel)
-
 	s.fetchProfile(s.bob, s.owner.selfContact.ID, s.owner.selfContact)
-
-	//close(cancel)
 }

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -65,7 +65,7 @@ func (s *MessengerStoreNodeRequestSuite) SetupTest() {
 
 	s.cancel = make(chan struct{}, 10)
 
-	storeNodeLogger := s.logger.With(zap.String("name", "store-node-waku"))
+	storeNodeLogger := s.logger.Named("store-node-waku")
 	s.wakuStoreNode = NewWakuV2(&s.Suite, storeNodeLogger, true, true)
 
 	storeNodeListenAddresses := s.wakuStoreNode.ListenAddresses()
@@ -164,7 +164,7 @@ func (s *MessengerStoreNodeRequestSuite) requireContactsEqual(c *Contact, expect
 	s.Require().Equal(expected.SocialLinks, c.SocialLinks)
 }
 
-func (s *MessengerStoreNodeRequestSuite) fetchCommunity(m *Messenger, communityShard communities.CommunityShard, expectedCommunityInfo *communities.Community) FetchStats {
+func (s *MessengerStoreNodeRequestSuite) fetchCommunity(m *Messenger, communityShard communities.CommunityShard, expectedCommunityInfo *communities.Community) StoreNodeRequestStats {
 	fetchedCommunity, stats, err := m.storeNodeRequestsManager.FetchCommunity(communityShard, true)
 
 	s.Require().NoError(err)

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -353,7 +353,7 @@ func (api *PublicAPI) GetContactByID(parent context.Context, id string) *protoco
 }
 
 func (api *PublicAPI) RequestContactInfoFromMailserver(pubkey string) (*protocol.Contact, error) {
-	return api.service.messenger.RequestContactInfoFromMailserver(pubkey, true)
+	return api.service.messenger.FetchContact(pubkey, true)
 }
 
 func (api *PublicAPI) RemoveFilters(parent context.Context, chats []*transport.Filter) error {

--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -19,8 +19,9 @@
 package wakuv2
 
 import (
-	ethdisc "github.com/ethereum/go-ethereum/p2p/dnsdisc"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
+
+	ethdisc "github.com/ethereum/go-ethereum/p2p/dnsdisc"
 
 	"github.com/status-im/status-go/wakuv2/common"
 )

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -54,13 +54,14 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/metrics"
 
-	ethdisc "github.com/ethereum/go-ethereum/p2p/dnsdisc"
 	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/lightpush"
 	"github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
+
+	ethdisc "github.com/ethereum/go-ethereum/p2p/dnsdisc"
 
 	"github.com/status-im/status-go/connection"
 	"github.com/status-im/status-go/eth-node/types"


### PR DESCRIPTION
## Description

I introduced a better way to fetch communities from store nodes here: https://github.com/status-im/status-go/pull/4446

This PR makes the `StoreNodeRequestManager` more universal for other needs, e.g. now we fetch contacts with the same approach and code.

## QA notes

I refactored the implementation of `RequestContactInfoFromMailserver` endpoint. The API remains the same, it just should work better now.

In status-desktop this endpoint is used to:
- when typed/pasted a valid public key to ad-hoc chat input
- when received a message with a contact link and contact is not found in local database

This feature is also implicitly used by status-go when generating a link preview for a contact that is not found in local database.