### PR TITLE
feat: Fetch community data for tokens

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -455,7 +455,7 @@ func NewMessenger(
 	if c.tokenManager != nil {
 		managerOptions = append(managerOptions, communities.WithTokenManager(c.tokenManager))
 	} else if c.rpcClient != nil {
-		tokenManager := token.NewTokenManager(c.walletDb, c.rpcClient, community.NewManager(database, c.httpServer), c.rpcClient.NetworkManager, database, c.httpServer)
+		tokenManager := token.NewTokenManager(c.walletDb, c.rpcClient, community.NewManager(database, c.httpServer, nil), c.rpcClient.NetworkManager, database, c.httpServer)
 		managerOptions = append(managerOptions, communities.WithTokenManager(communities.NewDefaultTokenManager(tokenManager)))
 	}
 

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -99,7 +99,7 @@ func NewService(
 		})
 	})
 
-	communityManager := community.NewManager(db, mediaServer)
+	communityManager := community.NewManager(db, mediaServer, feed)
 	balanceCacher := balance.NewCacherWithTTL(5 * time.Minute)
 	tokenManager := token.NewTokenManager(db, rpcClient, communityManager, rpcClient.NetworkManager, appDB, mediaServer)
 	savedAddressesManager := &SavedAddressesManager{db: db}
@@ -110,7 +110,7 @@ func NewService(
 	cryptoCompare := cryptocompare.NewClient()
 	coingecko := coingecko.NewClient()
 	marketManager := market.NewManager(cryptoCompare, coingecko, feed)
-	reader := NewReader(rpcClient, tokenManager, marketManager, accountsDB, NewPersistence(db), feed)
+	reader := NewReader(rpcClient, tokenManager, marketManager, communityManager, accountsDB, NewPersistence(db), feed)
 	history := history.NewService(db, accountsDB, feed, rpcClient, tokenManager, marketManager, balanceCacher.Cache())
 	currency := currency.NewService(db, feed, tokenManager, marketManager)
 	blockChainState := NewBlockChainState(rpcClient, accountsDB)

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -49,16 +49,9 @@ type Token struct {
 	PegSymbol string `json:"pegSymbol"`
 	Image     string `json:"image,omitempty"`
 
-	CommunityData *CommunityData `json:"community_data,omitempty"`
-	Verified      bool           `json:"verified"`
-	TokenListID   string         `json:"tokenListId"`
-}
-
-type CommunityData struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	Color string `json:"color"`
-	Image string `json:"image,omitempty"`
+	CommunityData *community.Data `json:"community_data,omitempty"`
+	Verified      bool            `json:"verified"`
+	TokenListID   string          `json:"tokenListId"`
 }
 
 func (t *Token) IsNative() bool {
@@ -551,7 +544,7 @@ func (tm *Manager) getTokensFromDB(query string, args ...any) ([]*Token, error) 
 				break
 			}
 
-			token.CommunityData = &CommunityData{
+			token.CommunityData = &community.Data{
 				ID: communityID,
 			}
 		}

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/services/wallet/community"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/walletdatabase"
 )
@@ -97,7 +98,7 @@ func TestCommunityTokens(t *testing.T) {
 		Symbol:   "COM",
 		Decimals: 12,
 		ChainID:  777,
-		CommunityData: &CommunityData{
+		CommunityData: &community.Data{
 			ID: "random_community_id",
 		},
 	}

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -937,7 +937,8 @@ func TestFindBlocksCommand(t *testing.T) {
 		}
 		client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db)
 		client.SetClient(tc.NetworkID(), tc)
-		tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil), network.NewManager(appdb), appdb, mediaServer)
+		tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer)
+
 		tokenManager.SetTokens([]*token.Token{
 			{
 				Address:  tokenTXXAddress,
@@ -1062,7 +1063,7 @@ func TestFetchTransfersForLoadedBlocks(t *testing.T) {
 
 	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db)
 	client.SetClient(tc.NetworkID(), tc)
-	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil), network.NewManager(appdb), appdb, mediaServer)
+	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer)
 
 	tokenManager.SetTokens([]*token.Token{
 		{
@@ -1182,7 +1183,7 @@ func TestFetchNewBlocksCommand_findBlocksWithEthTransfers(t *testing.T) {
 
 		client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db)
 		client.SetClient(tc.NetworkID(), tc)
-		tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil), network.NewManager(appdb), appdb, mediaServer)
+		tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer)
 
 		tokenManager.SetTokens([]*token.Token{
 			{
@@ -1259,8 +1260,7 @@ func TestFetchNewBlocksCommand(t *testing.T) {
 
 	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db)
 	client.SetClient(tc.NetworkID(), tc)
-
-	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil), network.NewManager(appdb), appdb, mediaServer)
+	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer)
 
 	tokenManager.SetTokens([]*token.Token{
 		{


### PR DESCRIPTION
Task https://github.com/status-im/status-desktop/issues/12985

Added call to fetch metadata and send event.
It affects wallet view.

Similarly to collectibles community data it is done async.
In next task event will be handled on status-desktop side to refresh it immediately. Right now it will be refreshed after next wallet tokens update (around 10 minutes or when user changes account). 

Image
![image](https://github.com/status-im/status-go/assets/11396062/7cc33542-5d17-40ca-915e-7f654d667c35)
