### PR TITLE
fix: share shard info independently on waku version, only control node can publish shard info

### DIFF
--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -2361,7 +2361,7 @@ func testPrivilegedMemberAcceptsRequestToJoinAfterMemberLeave(base CommunityEven
 
 	// check event sender received member leave update from ControlNode
 	_, err = WaitOnMessengerResponse(
-		base.GetControlNode(),
+		base.GetEventSender(),
 		checkMemberLeave,
 		"event sender did not receive member leave update",
 	)

--- a/protocol/messenger_community_shard.go
+++ b/protocol/messenger_community_shard.go
@@ -19,12 +19,8 @@ import (
 )
 
 func (m *Messenger) sendPublicCommunityShardInfo(community *communities.Community) error {
-	if m.transport.WakuVersion() != 2 {
-		return nil
-	}
-
 	if !community.IsControlNode() {
-		return nil
+		return communities.ErrNotControlNode
 	}
 
 	publicShardInfo := &protobuf.PublicShardInfo{


### PR DESCRIPTION
1. waku version must not be a blocker for sharing shards info
2. Only control node can publish shard info
3. fix TestAdminAcceptsRequestToJoinAfterMemberLeave


