### PR TITLE
`FetchCommunity`: various fixes and improvements

### DIFF
--- a/multiaccounts/settings/mocks/database_settings_manager_mock.go
+++ b/multiaccounts/settings/mocks/database_settings_manager_mock.go
@@ -125,8 +125,6 @@ func (mr *MockDatabaseSettingsManagerMockRecorder) CanUseMailservers() *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanUseMailservers", reflect.TypeOf((*MockDatabaseSettingsManager)(nil).CanUseMailservers))
 }
 
-
-
 // DeviceName mocks base method.
 func (m *MockDatabaseSettingsManager) DeviceName() (string, error) {
 	m.ctrl.T.Helper()
@@ -201,7 +199,6 @@ func (mr *MockDatabaseSettingsManagerMockRecorder) GetEIP1581Address() *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEIP1581Address", reflect.TypeOf((*MockDatabaseSettingsManager)(nil).GetEIP1581Address))
 }
-
 
 // GetInstalledStickerPacks mocks base method.
 func (m *MockDatabaseSettingsManager) GetInstalledStickerPacks() (*json.RawMessage, error) {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2574,10 +2574,16 @@ func (m *Messenger) FetchCommunity(request *FetchCommunityRequest) (*communities
 		}
 	}
 
-	community, _, err := m.storeNodeRequestsManager.FetchCommunity(communities.CommunityShard{
+	communityAddress := communities.CommunityShard{
 		CommunityID: communityID,
 		Shard:       request.Shard,
-	}, request.WaitForResponse)
+	}
+
+	options := []StoreNodeRequestOption{
+		WithWaitForResponseOption(request.WaitForResponse),
+	}
+
+	community, _, err := m.storeNodeRequestsManager.FetchCommunity(communityAddress, options)
 
 	return community, err
 }
@@ -2585,7 +2591,7 @@ func (m *Messenger) FetchCommunity(request *FetchCommunityRequest) (*communities
 // fetchCommunities installs filter for community and requests its details from store node.
 // When response received it will be passed through signals handler.
 func (m *Messenger) fetchCommunities(communities []communities.CommunityShard) error {
-	return m.storeNodeRequestsManager.FetchCommunities(communities)
+	return m.storeNodeRequestsManager.FetchCommunities(communities, []StoreNodeRequestOption{})
 }
 
 // passStoredCommunityInfoToSignalHandler calls signal handler with community info

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -1218,7 +1218,10 @@ func (m *Messenger) scheduleSyncFiltersForContact(publicKey *ecdsa.PublicKey) (*
 }
 
 func (m *Messenger) FetchContact(contactID string, waitForResponse bool) (*Contact, error) {
-	contact, _, err := m.storeNodeRequestsManager.FetchContact(contactID, waitForResponse)
+	options := []StoreNodeRequestOption{
+		WithWaitForResponseOption(waitForResponse),
+	}
+	contact, _, err := m.storeNodeRequestsManager.FetchContact(contactID, options)
 	return contact, err
 }
 

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -23,17 +23,17 @@ import (
 const (
 	initialStoreNodeRequestPageSize = 4
 	defaultStoreNodeRequestPageSize = 20
+
+	// tolerance is how many seconds of potentially out-of-order messages we want to fetch
+	tolerance uint32 = 60
+
+	mailserverRequestTimeout           = 30 * time.Second
+	oneMonthInSeconds           uint32 = 31 * 24 * 60 * 60
+	mailserverMaxTries          uint   = 2
+	mailserverMaxFailedRequests uint   = 2
+
+	OneDayInSeconds = 86400
 )
-
-// tolerance is how many seconds of potentially out-of-order messages we want to fetch
-var tolerance uint32 = 60
-
-var mailserverRequestTimeout = 30 * time.Second
-var oneMonthInSeconds uint32 = 31 * 24 * 60 * 60
-var mailserverMaxTries uint = 2
-var mailserverMaxFailedRequests uint = 2
-
-const OneDayInSeconds = 86400
 
 // maxTopicsPerRequest sets the batch size to limit the number of topics per store query
 var maxTopicsPerRequest int = 10

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -28,13 +28,7 @@ const isAndroidEmulator = runtime.GOOS == "android" && runtime.GOARCH == "amd64"
 const findNearestMailServer = !isAndroidEmulator
 
 func (m *Messenger) mailserversByFleet(fleet string) []mailservers.Mailserver {
-	var items []mailservers.Mailserver
-	for _, ms := range mailservers.DefaultMailservers() {
-		if ms.Fleet == fleet {
-			items = append(items, ms)
-		}
-	}
-	return items
+	return mailservers.DefaultMailserversByFleet(fleet)
 }
 
 type byRTTMsAndCanConnectBefore []SortedMailserver

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -1,0 +1,57 @@
+package protocol
+
+type StoreNodeRequestConfig struct {
+	WaitForResponse   bool
+	StopWhenDataFound bool
+	InitialPageSize   uint32
+	FurtherPageSize   uint32
+}
+
+type StoreNodeRequestOption func(*StoreNodeRequestConfig)
+
+func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {
+	return StoreNodeRequestConfig{
+		WaitForResponse:   true,
+		StopWhenDataFound: true,
+		InitialPageSize:   initialStoreNodeRequestPageSize,
+		FurtherPageSize:   defaultStoreNodeRequestPageSize,
+	}
+}
+
+func buildStoreNodeRequestConfig(opts []StoreNodeRequestOption) StoreNodeRequestConfig {
+	cfg := defaultStoreNodeRequestConfig()
+
+	// TODO: remove these 2 when fixed: https://github.com/waku-org/nwaku/issues/2317
+	opts = append(opts, WithStopWhenDataFound(false))
+	opts = append(opts, WithInitialPageSize(defaultStoreNodeRequestPageSize))
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return cfg
+}
+
+func WithWaitForResponseOption(waitForResponse bool) StoreNodeRequestOption {
+	return func(c *StoreNodeRequestConfig) {
+		c.WaitForResponse = waitForResponse
+	}
+}
+
+func WithStopWhenDataFound(stopWhenDataFound bool) StoreNodeRequestOption {
+	return func(c *StoreNodeRequestConfig) {
+		c.StopWhenDataFound = stopWhenDataFound
+	}
+}
+
+func WithInitialPageSize(initialPageSize uint32) StoreNodeRequestOption {
+	return func(c *StoreNodeRequestConfig) {
+		c.InitialPageSize = initialPageSize
+	}
+}
+
+func WithFurtherPageSize(furtherPageSize uint32) StoreNodeRequestOption {
+	return func(c *StoreNodeRequestConfig) {
+		c.FurtherPageSize = furtherPageSize
+	}
+}

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -16,8 +16,6 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
-
 	"github.com/status-im/status-go/appdatabase"
 	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
 	"github.com/status-im/status-go/eth-node/types"
@@ -253,9 +251,10 @@ func WaitForAvailableStoreNode(s *suite.Suite, m *Messenger, timeout time.Durati
 	s.Require().True(available)
 }
 
-func NewWakuV2(s *suite.Suite, logger *zap.Logger, useLocalWaku bool, enableStore bool) *waku2.Waku {
+func NewWakuV2(s *suite.Suite, logger *zap.Logger, useLocalWaku bool, enableStore bool, useShardAsDefaultTopic bool) *waku2.Waku {
 	wakuConfig := &waku2.Config{
-		DefaultShardPubsubTopic: relay.DefaultWakuTopic, // shard.DefaultShardPubsubTopic(),
+		DefaultShardPubsubTopic: "", // TODO: Empty string should work fine, for default value if not.
+		UseShardAsDefaultTopic:  useShardAsDefaultTopic,
 	}
 
 	var onPeerStats func(connStatus types.ConnStatus)
@@ -316,7 +315,7 @@ func CreateWakuV2Network(s *suite.Suite, parentLogger *zap.Logger, nodeNames []s
 	nodes := make([]*waku2.Waku, len(nodeNames))
 	for i, name := range nodeNames {
 		logger := parentLogger.With(zap.String("name", name+"-waku"))
-		wakuNode := NewWakuV2(s, logger, true, false)
+		wakuNode := NewWakuV2(s, logger, true, false, false)
 		nodes[i] = wakuNode
 	}
 
@@ -343,6 +342,9 @@ func CreateWakuV2Network(s *suite.Suite, parentLogger *zap.Logger, nodeNames []s
 }
 
 func TearDownMessenger(s *suite.Suite, m *Messenger) {
+	if m == nil {
+		return
+	}
 	s.Require().NoError(m.Shutdown())
 	if m.database != nil {
 		s.Require().NoError(m.database.Close())

--- a/services/mailservers/fleet.go
+++ b/services/mailservers/fleet.go
@@ -2,6 +2,16 @@ package mailservers
 
 import "github.com/status-im/status-go/params"
 
+func DefaultMailserversByFleet(fleet string) []Mailserver {
+	var items []Mailserver
+	for _, ms := range DefaultMailservers() {
+		if ms.Fleet == fleet {
+			items = append(items, ms)
+		}
+	}
+	return items
+}
+
 func DefaultMailservers() []Mailserver {
 
 	return []Mailserver{

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1150,7 +1150,11 @@ func (w *Waku) Query(ctx context.Context, peerID peer.ID, pubsubTopic string, to
 		msg.RateLimitProof = nil
 
 		envelope := protocol.NewEnvelope(msg, msg.GetTimestamp(), pubsubTopic)
-		w.logger.Info("received waku2 store message", zap.Any("envelopeHash", hexutil.Encode(envelope.Hash())), zap.String("pubsubTopic", pubsubTopic))
+		w.logger.Info("received waku2 store message",
+			zap.Any("envelopeHash", hexutil.Encode(envelope.Hash())),
+			zap.String("pubsubTopic", pubsubTopic),
+			zap.Int64p("timestamp", envelope.Message().Timestamp),
+		)
 
 		err = w.OnNewEnvelopes(envelope, common.StoreMessageType, processEnvelopes)
 		if err != nil {


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/4496
Closes https://github.com/status-im/status-go/issues/4496

## Main changes

1. Temporal fix for https://github.com/waku-org/nwaku/issues/2317 bug.
I made the manager to always fetch all envelopes in the batch (no stop when community was found).
These lines should be removed/reverted when the original bug is fixed:
https://github.com/status-im/status-go/blob/fdcdec371f37fffd6c7706cb14b26e826bfbe6df/protocol/messenger_store_node_request_manager_config.go#L24-L26
https://github.com/status-im/status-go/blob/fdcdec371f37fffd6c7706cb14b26e826bfbe6df/protocol/messenger_storenode_request_test.go#L420

2. Check if a desired community already exists in the database and require the fetched community `Clock` to be higher.
If no newer information was fethed, `nil` is returned, even if the community exists in the database

3. Implement `StoreNodeRequestManager` options:
- `WaitForResponse`
- `StopWhenDataFound`
- `InitialPageSize`
- `FurtherPageSize`
This allows a better control over the request. And made it possible to implement the fix (1) tidy.

~~4. It seems to me that the `TestRequestMultipleCommunities ` is now less flaky, but still fails at about 1% cases.~~
4. UPD: Fixes `TestRequestMultipleCommunities` flaky test

5. Extracted `DefaultMailserversByFleet` function

6. Some other minor refactoring and logging

## Test improvements

1. Added a mechanism to wait for the test store node to receive the envelopes.
This was previously leading to bugs, the case is tested with `TestSequentialUpdates`

2. Implemented a test to check the fetched envelopes order: `TestRequestCommunityEnvelopesOrder`
This is to address https://github.com/waku-org/nwaku/issues/2317 bug, to ensure that our code behaves correctly (assuming that go-waku is also working correctly).

3. Implemented a `TestFetchRealCommunity`
it allows to fetch community from all store nodes in a given fleet and check community state on each store node.