### PR TITLE
feat: balance endoint without market data

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -76,6 +76,10 @@ func (api *API) GetBalancesByChain(ctx context.Context, chainIDs []uint64, addre
 	return api.s.tokenManager.GetBalancesByChain(ctx, clients, addresses, tokens)
 }
 
+func (api *API) GetWalletTokenBalances(ctx context.Context, addresses []common.Address) (map[common.Address][]Token, error) {
+	return api.reader.GetWalletTokenBalances(ctx, addresses)
+}
+
 func (api *API) GetCachedWalletTokensWithoutMarketData(ctx context.Context) (map[common.Address][]Token, error) {
 	return api.reader.GetCachedWalletTokensWithoutMarketData()
 }


### PR DESCRIPTION
Create a new balance endpoint in order to retrieve only balances for the specified account addresses

This is a lighter version of the get wallet token use to save cost on queries made for market data