### PR TITLE
chore: attach wrapped CommunityDescription when sharing community

### DIFF
--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1028,6 +1028,7 @@ func advertiseCommunityToUserOldWay(s *suite.Suite, community *communities.Commu
 	inputMessage.ChatId = chat.ID
 	inputMessage.Text = "some text"
 	inputMessage.CommunityID = community.IDString()
+	inputMessage.ContentType = protobuf.ChatMessage_COMMUNITY
 
 	err := owner.SaveChat(chat)
 	s.Require().NoError(err)

--- a/protocol/communities_messenger_signers_test.go
+++ b/protocol/communities_messenger_signers_test.go
@@ -562,6 +562,7 @@ func (s *MessengerCommunitiesSignersSuite) TestNewOwnerAcceptRequestToJoin() {
 	inputMessage.ChatId = chat.ID
 	inputMessage.Text = "some text"
 	inputMessage.CommunityID = community.IDString()
+	inputMessage.ContentType = protobuf.ChatMessage_COMMUNITY
 
 	err = s.alice.SaveChat(chat)
 	s.Require().NoError(err)

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -156,6 +156,7 @@ func (s *MessengerCommunitiesSuite) TestRetrieveCommunity() {
 	inputMessage.ChatId = chat.ID
 	inputMessage.Text = "some text"
 	inputMessage.CommunityID = community.IDString()
+	inputMessage.ContentType = protobuf.ChatMessage_COMMUNITY
 
 	err = s.bob.SaveChat(chat)
 	s.Require().NoError(err)
@@ -180,7 +181,6 @@ func (s *MessengerCommunitiesSuite) TestRetrieveCommunity() {
 	s.Require().Len(communities, 2)
 	s.Require().Len(response.Communities(), 1)
 	s.Require().Len(response.Messages(), 1)
-	s.Require().Equal(community.IDString(), response.Messages()[0].CommunityID)
 }
 
 func (s *MessengerCommunitiesSuite) TestJoiningOpenCommunityReturnsChatsResponse() {
@@ -353,6 +353,7 @@ func (s *MessengerCommunitiesSuite) TestJoinCommunity() {
 	inputMessage.ChatId = chat.ID
 	inputMessage.Text = "some text"
 	inputMessage.CommunityID = community.IDString()
+	inputMessage.ContentType = protobuf.ChatMessage_COMMUNITY
 
 	err = s.bob.SaveChat(chat)
 	s.Require().NoError(err)
@@ -377,7 +378,6 @@ func (s *MessengerCommunitiesSuite) TestJoinCommunity() {
 	s.Require().Len(communities, 2)
 	s.Require().Len(response.Communities(), 1)
 	s.Require().Len(response.Messages(), 1)
-	s.Require().Equal(community.IDString(), response.Messages()[0].CommunityID)
 
 	// We join the org
 	response, err = s.alice.JoinCommunity(ctx, community.ID(), false)

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2317,8 +2317,6 @@ func (m *Messenger) sendChatMessage(ctx context.Context, message *common.Message
 
 		message.Payload = &protobuf.ChatMessage_Community{Community: wrappedCommunity}
 		message.Shard = community.Shard().Protobuffer()
-
-		message.ContentType = protobuf.ChatMessage_COMMUNITY
 	} else if len(message.AudioPath) != 0 {
 		err := message.LoadAudio()
 		if err != nil {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2353,6 +2353,7 @@ func (m *Messenger) ShareCommunity(request *requests.ShareCommunity) (*Messenger
 	var messages []*common.Message
 	for _, pk := range request.Users {
 		message := common.NewMessage()
+		message.CommunityID = request.CommunityID.String()
 		message.StatusLinkPreviews = []common.StatusLinkPreview{statusLinkPreview}
 		message.ChatId = pk.String()
 		message.Shard = community.Shard().Protobuffer()

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -923,6 +923,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	inputMessage.ChatId = chat.ID
 	inputMessage.Text = "some text"
 	inputMessage.CommunityID = community.IDString()
+	inputMessage.ContentType = protobuf.ChatMessage_COMMUNITY
 
 	err = bob.SaveChat(chat)
 	s.NoError(err)


### PR DESCRIPTION
This ensures the most recent community is retrieved by the clients alongside the communnity link. Clients no longer need to rely on store node to fetch the description in that case.

fixes: status-im/status-desktop#13055
