### PR TITLE
[CHERRY-PICK] fix: force verifiedOwner in `handleSyncInstallationCommunity` (#4405)

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1372,6 +1372,10 @@ func (o *Community) Description() *protobuf.CommunityDescription {
 	return o.config.CommunityDescription
 }
 
+func (o *Community) DescriptionProtocolMessage() []byte {
+	return o.config.CommunityDescriptionProtocolMessage
+}
+
 func (o *Community) marshaledDescription() ([]byte, error) {
 	clone := proto.Clone(o.config.CommunityDescription).(*protobuf.CommunityDescription)
 

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1638,7 +1638,12 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 
 	if hasTokenOwnership && verifiedOwner != nil {
 		// Override verified owner
-		m.logger.Info("updating verified owner", zap.String("communityID", community.IDString()), zap.String("owner", common.PubkeyToHex(verifiedOwner)))
+		m.logger.Info("updating verified owner",
+			zap.String("communityID", community.IDString()),
+			zap.String("verifiedOwner", common.PubkeyToHex(verifiedOwner)),
+			zap.String("signer", common.PubkeyToHex(signer)),
+			zap.String("controlNode", common.PubkeyToHex(community.ControlNode())),
+		)
 
 		// If we are not the verified owner anymore, drop the private key
 		if !common.IsPubKeyEqual(verifiedOwner, &m.identity.PublicKey) {

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -331,7 +331,8 @@ func advertiseCommunityTo(s *suite.Suite, community *communities.Community, owne
 	messageState := user.buildMessageState()
 	messageState.CurrentMessageState = &CurrentMessageState{}
 	messageState.CurrentMessageState.PublicKey = &user.identity.PublicKey
-	err = user.handleCommunityDescription(messageState, signer, description, wrappedCommunity, nil)
+	// TODO: handle shards?
+	err = user.handleCommunityDescription(messageState, signer, description, wrappedCommunity, nil, nil)
 	s.Require().NoError(err)
 }
 

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -20,6 +20,8 @@ import (
 
 	"go.uber.org/zap"
 
+	utils "github.com/status-im/status-go/common"
+
 	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
@@ -2603,8 +2605,8 @@ func (m *Messenger) passStoredCommunityInfoToSignalHandler(community *communitie
 }
 
 // handleCommunityDescription handles an community description
-func (m *Messenger) handleCommunityDescription(state *ReceivedMessageState, signer *ecdsa.PublicKey, description *protobuf.CommunityDescription, rawPayload []byte, shard *protobuf.Shard) error {
-	communityResponse, err := m.communitiesManager.HandleCommunityDescriptionMessage(signer, description, rawPayload, nil, shard)
+func (m *Messenger) handleCommunityDescription(state *ReceivedMessageState, signer *ecdsa.PublicKey, description *protobuf.CommunityDescription, rawPayload []byte, verifiedOwner *ecdsa.PublicKey, shard *protobuf.Shard) error {
+	communityResponse, err := m.communitiesManager.HandleCommunityDescriptionMessage(signer, description, rawPayload, verifiedOwner, shard)
 	if err != nil {
 		return err
 	}
@@ -2945,7 +2947,7 @@ func (m *Messenger) HandleSyncInstallationCommunity(messageState *ReceivedMessag
 }
 
 func (m *Messenger) handleSyncInstallationCommunity(messageState *ReceivedMessageState, syncCommunity *protobuf.SyncInstallationCommunity, statusMessage *v1protocol.StatusMessage) error {
-	logger := m.logger.Named("handleSyncCommunity")
+	logger := m.logger.Named("handleSyncInstallationCommunity")
 
 	// Should handle community
 	shouldHandle, err := m.communitiesManager.ShouldHandleSyncCommunity(syncCommunity)
@@ -3008,8 +3010,17 @@ func (m *Messenger) handleSyncInstallationCommunity(messageState *ReceivedMessag
 		return err
 	}
 
+	// This is our own message, so we can trust the set community owner
+	// This is good to do so that we don't have to queue all the actions done after the handled community description.
+	// `signer` is `communityID` for a community with no owner token and `owner public key` otherwise
+	signer, err := utils.RecoverKey(&amm)
+	if err != nil {
+		logger.Debug("failed to recover community description signer", zap.Error(err))
+		return err
+	}
+
 	// TODO: handle shard
-	err = m.handleCommunityDescription(messageState, orgPubKey, &cd, syncCommunity.Description, nil)
+	err = m.handleCommunityDescription(messageState, signer, &cd, syncCommunity.Description, signer, nil)
 	if err != nil {
 		logger.Debug("m.handleCommunityDescription error", zap.Error(err))
 		return err
@@ -3029,22 +3040,6 @@ func (m *Messenger) handleSyncInstallationCommunity(messageState *ReceivedMessag
 			logger.Debug("m.SetSyncControlNode", zap.Error(err))
 			return err
 		}
-	}
-
-	savedCommunity, err := m.communitiesManager.GetByID(syncCommunity.Id)
-	if err != nil {
-		return err
-	}
-
-	// TODO: if the community is token gated, it will be validated asynchronously
-	// syncing needs to be adjusted in this case
-	if savedCommunity == nil {
-		return nil
-	}
-
-	if err := m.handleCommunityTokensMetadataByPrivilegedMembers(savedCommunity); err != nil {
-		logger.Debug("m.handleCommunityTokensMetadataByPrivilegedMembers", zap.Error(err))
-		return err
 	}
 
 	// if we are not waiting for approval, join or leave the community
@@ -3100,10 +3095,6 @@ func (m *Messenger) HandleSyncCommunitySettings(messageState *ReceivedMessageSta
 
 	messageState.Response.AddCommunitySettings(communitySettings)
 	return nil
-}
-
-func (m *Messenger) handleCommunityTokensMetadataByPrivilegedMembers(community *communities.Community) error {
-	return m.communitiesManager.HandleCommunityTokensMetadataByPrivilegedMembers(community)
 }
 
 func (m *Messenger) InitHistoryArchiveTasks(communities []*communities.Community) {

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2324,7 +2324,7 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 			return err
 		}
 
-		err = m.handleCommunityDescription(state, signer, description, receivedMessage.GetCommunity(), receivedMessage.GetShard())
+		err = m.handleCommunityDescription(state, signer, description, receivedMessage.GetCommunity(), nil, receivedMessage.GetShard())
 		if err != nil {
 			return err
 		}
@@ -3667,7 +3667,7 @@ func (m *Messenger) HandlePushNotificationRequest(state *ReceivedMessageState, m
 
 func (m *Messenger) HandleCommunityDescription(state *ReceivedMessageState, message *protobuf.CommunityDescription, statusMessage *v1protocol.StatusMessage) error {
 	// TODO: handle shard
-	err := m.handleCommunityDescription(state, state.CurrentMessageState.PublicKey, message, statusMessage.EncryptionLayer.Payload, nil)
+	err := m.handleCommunityDescription(state, state.CurrentMessageState.PublicKey, message, statusMessage.EncryptionLayer.Payload, nil, nil)
 	if err != nil {
 		m.logger.Warn("failed to handle CommunityDescription", zap.Error(err))
 		return err


### PR DESCRIPTION
cherry-pick https://github.com/status-im/status-go/pull/4405/files
part of https://github.com/status-im/status-go/issues/4529

This removes https://github.com/status-im/status-go/pull/4401 hotfix, because there's a proper fix in the cherry-picked PR.