### PR TITLE
fix: flaky TestEncryptionDecryption

### DIFF
--- a/protocol/communities/community_description_encryption_test.go
+++ b/protocol/communities/community_description_encryption_test.go
@@ -110,8 +110,8 @@ func (s *CommunityEncryptionDescriptionSuite) description() *protobuf.CommunityD
 				ChatIds:       []string{},
 			},
 			"channel-level-permission": &protobuf.CommunityTokenPermission{
-				Id:            "community-level-permission",
-				Type:          protobuf.CommunityTokenPermission_BECOME_MEMBER,
+				Id:            "channel-level-permission",
+				Type:          protobuf.CommunityTokenPermission_CAN_VIEW_CHANNEL,
 				TokenCriteria: []*protobuf.TokenCriteria{},
 				ChatIds:       []string{types.EncodeHex(crypto.CompressPubkey(&s.identity.PublicKey)) + "channelB"},
 			},


### PR DESCRIPTION
fixes: #4510

```bash
go test -v ./protocol/communities -run ^TestCommunityEncryptionDescriptionSuite$ -testify.m TestEncryptionDecryption -test.count=60
=== RUN   TestCommunityEncryptionDescriptionSuite
=== RUN   TestCommunityEncryptionDescriptionSuite/TestEncryptionDecryption
--- PASS: TestCommunityEncryptionDescriptionSuite (0.00s)
    --- PASS: TestCommunityEncryptionDescriptionSuite/TestEncryptionDecryption (0.00s)
=== RUN   TestCommunityEncryptionDescriptionSuite
=== RUN   TestCommunityEncryptionDescriptionSuite/TestEncryptionDecryption
--- PASS: TestCommunityEncryptionDescriptionSuite (0.00s)
    --- PASS: TestCommunityEncryptionDescriptionSuite/TestEncryptionDecryption (0.00s)
=== RUN   TestCommunityEncryptionDescriptionSuite
=== RUN   TestCommunityEncryptionDescriptionSuite/TestEncryptionDecryption
--- PASS: TestCommunityEncryptionDescriptionSuite (0.00s)
    --- PASS: TestCommunityEncryptionDescriptionSuite/TestEncryptionDecryption (0.00s)
=== RUN   TestCommunityEncryptionDescriptionSuite
=== RUN   TestCommunityEncryptionDescriptionSuite/TestEncryptionDecryption
--- PASS: TestCommunityEncryptionDescriptionSuite (0.00s)
    --- PASS: TestCommunityEncryptionDescriptionSuite/TestEncryptionDecryption (0.00s)
=== RUN   TestCommunityEncryptionDescriptionSuite
=== RUN   TestCommunityEncryptionDescriptionSuite/TestEncryptionDecryption
--- PASS: TestCommunityEncryptionDescriptionSuite (0.00s)
    --- PASS: TestCommunityEncryptionDescriptionSuite/TestEncryptionDecryption (0.00s)
    ...
    ...
    ...
PASS
ok      github.com/status-im/status-go/protocol/communities     0.146s
```