### PR TITLE
fix: ensure needed community tokens are available in the db

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3667,6 +3667,10 @@ func (m *Messenger) RemoveCommunityToken(chainID int, contractAddress string) er
 	return m.communitiesManager.RemoveCommunityToken(chainID, contractAddress)
 }
 
+func (m *Messenger) FetchMissingCommunityTokens(community *communities.Community) error {
+	return m.communitiesManager.HandleCommunityTokensMetadata(community)
+}
+
 func (m *Messenger) CheckPermissionsToJoinCommunity(request *requests.CheckPermissionToJoinCommunity) (*communities.CheckPermissionToJoinResponse, error) {
 	if err := request.Validate(); err != nil {
 		return nil, err

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -674,6 +674,14 @@ func (s *Service) fetchCommunity(communityID string, fetchLatest bool) (*communi
 		return nil, err
 	}
 
+	if community != nil {
+		// Call this to ensure CommunityTokens are stored to DB
+		err = s.messenger.FetchMissingCommunityTokens(community)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return community, nil
 }
 


### PR DESCRIPTION
Fixes [#13171](https://github.com/status-im/status-desktop/issues/13171)

Community Tokens were only added to the DB if the user was a privileged member of the community. We need this to build the collectibles metadata, so we now do it for every community of which an account owns a collectible.
