### PR TITLE
fix: properly detect relevant incoming token transfers

### DIFF
--- a/services/wallet/transfer/downloader.go
+++ b/services/wallet/transfer/downloader.go
@@ -478,7 +478,7 @@ func (d *ERC20TransfersDownloader) blocksFromLogs(parent context.Context, logs [
 		// Double check provider returned the correct log
 		if slices.Contains(d.accounts, from) {
 			address = from
-		} else if !slices.Contains(d.accounts, to) {
+		} else if slices.Contains(d.accounts, to) {
 			address = to
 		} else {
 			log.Error("from/to address mismatch", "log", l, "addresses", d.accounts)


### PR DESCRIPTION
Fixes [#13132](https://github.com/status-im/status-desktop/issues/13132)

There's a check in the transfer downloader making sure either the From or the To address is one of the wallet accounts. The condition for the To address was wrong. This PR fixes it.

This causes incoming token transfers to be properly detected again.