### PR TITLE
fix: avoid losing cached community collectibles data

### DIFF
--- a/services/wallet/collectibles/collectible_data_db_test.go
+++ b/services/wallet/collectibles/collectible_data_db_test.go
@@ -31,7 +31,7 @@ func TestUpdateCollectiblesData(t *testing.T) {
 
 	var err error
 
-	err = db.SetData(data)
+	err = db.SetData(data, true)
 	require.NoError(t, err)
 
 	ids := make([]thirdparty.CollectibleUniqueID, 0, len(data))
@@ -79,15 +79,29 @@ func TestUpdateCollectiblesData(t *testing.T) {
 	}
 
 	// update some collectibles, changing the provider
-	c0 := data[0]
+	c0Orig := data[0]
+	c0 := c0Orig
 	c0.Name = "new collectible name 0"
 	c0.Provider = "new collectible provider 0"
 
-	c1 := data[1]
+	c1Orig := data[1]
+	c1 := c1Orig
 	c1.Name = "new collectible name 1"
 	c1.Provider = "new collectible provider 1"
 
-	err = db.SetData([]thirdparty.CollectibleData{c0, c1})
+	// Test allowUpdate = false
+	err = db.SetData([]thirdparty.CollectibleData{c0, c1}, false)
+	require.NoError(t, err)
+
+	loadedMap, err = db.GetData([]thirdparty.CollectibleUniqueID{c0.ID, c1.ID})
+	require.NoError(t, err)
+	require.Equal(t, 2, len(loadedMap))
+
+	require.Equal(t, c0Orig, loadedMap[c0.ID.HashKey()])
+	require.Equal(t, c1Orig, loadedMap[c1.ID.HashKey()])
+
+	// Test allowUpdate = true
+	err = db.SetData([]thirdparty.CollectibleData{c0, c1}, true)
 	require.NoError(t, err)
 
 	loadedMap, err = db.GetData([]thirdparty.CollectibleUniqueID{c0.ID, c1.ID})
@@ -108,7 +122,7 @@ func TestUpdateCommunityData(t *testing.T) {
 
 	var err error
 
-	err = db.SetData(data)
+	err = db.SetData(data, true)
 	require.NoError(t, err)
 
 	for i := 0; i < nData; i++ {

--- a/services/wallet/collectibles/collection_data_db_test.go
+++ b/services/wallet/collectibles/collection_data_db_test.go
@@ -30,7 +30,7 @@ func TestUpdateCollectionsData(t *testing.T) {
 
 	var err error
 
-	err = db.SetData(data)
+	err = db.SetData(data, true)
 	require.NoError(t, err)
 
 	ids := make([]thirdparty.ContractID, 0, len(data))
@@ -72,15 +72,29 @@ func TestUpdateCollectionsData(t *testing.T) {
 	}
 
 	// update some collections, changing the provider
-	c0 := data[0]
+	c0Orig := data[0]
+	c0 := c0Orig
 	c0.Name = "new collection name 0"
 	c0.Provider = "new collection provider 0"
 
-	c1 := data[1]
+	c1Orig := data[1]
+	c1 := c1Orig
 	c1.Name = "new collection name 1"
 	c1.Provider = "new collection provider 1"
 
-	err = db.SetData([]thirdparty.CollectionData{c0, c1})
+	// Test allowUpdate = false
+	err = db.SetData([]thirdparty.CollectionData{c0, c1}, false)
+	require.NoError(t, err)
+
+	loadedMap, err = db.GetData([]thirdparty.ContractID{c0.ID, c1.ID})
+	require.NoError(t, err)
+	require.Equal(t, 2, len(loadedMap))
+
+	require.Equal(t, c0Orig, loadedMap[c0.ID.HashKey()])
+	require.Equal(t, c1Orig, loadedMap[c1.ID.HashKey()])
+
+	// Test allowUpdate = true
+	err = db.SetData([]thirdparty.CollectionData{c0, c1}, true)
 	require.NoError(t, err)
 
 	loadedMap, err = db.GetData([]thirdparty.ContractID{c0.ID, c1.ID})

--- a/services/wallet/collectibles/db_utils.go
+++ b/services/wallet/collectibles/db_utils.go
@@ -1,0 +1,8 @@
+package collectibles
+
+func insertStatement(allowUpdate bool) string {
+	if allowUpdate {
+		return `INSERT OR REPLACE`
+	}
+	return `INSERT OR IGNORE`
+}

--- a/services/wallet/collectibles/filter_test.go
+++ b/services/wallet/collectibles/filter_test.go
@@ -86,7 +86,7 @@ func TestFilterOwnedCollectibles(t *testing.T) {
 		}
 	}
 
-	err = cDB.SetData(data)
+	err = cDB.SetData(data, true)
 	require.NoError(t, err)
 	for i := 0; i < nData; i++ {
 		err = cDB.SetCommunityInfo(data[i].ID, communityData[i])


### PR DESCRIPTION
If the community couldn't be properly fetched, we would overwrite any previously cached collectible metadata with the one given by the providers (mostly empty since most metadata comes from Waku).
This PR changes this logic, so in that situation we now only insert new items but don't replace what's in the DB.