### PR TITLE
fix: update the list of chains supported by opensea

### DIFF
--- a/services/wallet/thirdparty/opensea/client_v2.go
+++ b/services/wallet/thirdparty/opensea/client_v2.go
@@ -22,7 +22,7 @@ func getV2BaseURL(chainID walletCommon.ChainID) (string, error) {
 	switch uint64(chainID) {
 	case walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet, walletCommon.OptimismMainnet:
 		return "https://api.opensea.io/v2", nil
-	case walletCommon.EthereumGoerli, walletCommon.EthereumSepolia, walletCommon.ArbitrumGoerli, walletCommon.ArbitrumSepolia, walletCommon.OptimismGoerli:
+	case walletCommon.EthereumGoerli, walletCommon.EthereumSepolia, walletCommon.ArbitrumSepolia, walletCommon.OptimismSepolia:
 		return "https://testnets-api.opensea.io/v2", nil
 	}
 

--- a/services/wallet/thirdparty/opensea/types_v2.go
+++ b/services/wallet/thirdparty/opensea/types_v2.go
@@ -22,9 +22,8 @@ const (
 	optimismMainnetString = "optimism"
 	ethereumGoerliString  = "goerli"
 	ethereumSepoliaString = "sepolia"
-	arbitrumGoerliString  = "arbitrum_goerli"
 	arbitrumSepoliaString = "arbitrum_sepolia"
-	optimismGoerliString  = "optimism_goerli"
+	optimismSepoliaString = "optimism_sepolia"
 )
 
 type urlGetter func(walletCommon.ChainID, string) (string, error)
@@ -42,12 +41,10 @@ func chainIDToChainString(chainID walletCommon.ChainID) string {
 		chainString = ethereumGoerliString
 	case walletCommon.EthereumSepolia:
 		chainString = ethereumSepoliaString
-	case walletCommon.ArbitrumGoerli:
-		chainString = arbitrumGoerliString
 	case walletCommon.ArbitrumSepolia:
 		chainString = arbitrumSepoliaString
-	case walletCommon.OptimismGoerli:
-		chainString = optimismGoerliString
+	case walletCommon.OptimismSepolia:
+		chainString = optimismSepoliaString
 	}
 	return chainString
 }


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/13190

Opensea no longer supports Arbitrum Goerli and Optimism Goerli (they were replaced by Sepolia).

Moreover, they don't return any kind of error when trying to use the endpoints for those chains, but the results are not correct (not up to date).

This PR updated the list of supported chains for the Opensea client.
