### PR TITLE
fix: restore FetchCommunity&TryDatabase fallback to store nodes

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2565,7 +2565,7 @@ func (m *Messenger) FetchCommunity(request *FetchCommunityRequest) (*communities
 
 	if request.TryDatabase {
 		community, err := m.FindCommunityInfoFromDB(communityID)
-		if err != nil {
+		if err != nil && err != communities.ErrOrgNotFound {
 			return nil, err
 		}
 		if community != nil {


### PR DESCRIPTION
Add missing check caused by recent `communities.GetByID` refactoring.
