### PR TITLE
fix: execute BeforeDispatch only once

### DIFF
--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -241,8 +241,6 @@ func (s *MessageSender) SendGroup(
 		}
 	}
 
-	rawMessage.BeforeDispatch = nil
-
 	// Send to each recipients
 	for _, recipient := range recipients {
 		_, err = s.sendPrivate(ctx, recipient, &rawMessage)

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2399,6 +2399,9 @@ func (m *Messenger) sendChatMessage(ctx context.Context, message *common.Message
 			return err
 		}
 
+		// ensure that the message is saved only once
+		rawMessage.BeforeDispatch = nil
+
 		return m.persistence.SaveMessages([]*common.Message{message})
 	}
 


### PR DESCRIPTION
Issue #4557

In message_sender.go:

line 293 in MessageSender::sendCommunity() - first execution of BeforeDispatch
line 397 in MessageSender::sendCommunity() - executing s.dispatchCommunityChatMessage
line 606 in MessageSender::sendCommunity() - second execution of BeforeDispatch
