### PR TITLE
chore: fetch community token metadata during handling community description

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1643,7 +1643,7 @@ func (m *Manager) handleCommunityDescriptionMessageCommon(community *Community, 
 		return nil, err
 	}
 
-	if err = m.HandleCommunityTokensMetadataByPrivilegedMembers(community); err != nil {
+	if err = m.handleCommunityTokensMetadata(community); err != nil {
 		return nil, err
 	}
 
@@ -1814,7 +1814,7 @@ func (m *Manager) HandleCommunityEventsMessage(signer *ecdsa.PublicKey, message 
 		return nil, err
 	}
 
-	if err = m.HandleCommunityTokensMetadataByPrivilegedMembers(community); err != nil {
+	if err = m.handleCommunityTokensMetadata(community); err != nil {
 		return nil, err
 	}
 
@@ -2858,7 +2858,7 @@ func (m *Manager) HandleCommunityRequestToJoinResponse(signer *ecdsa.PublicKey, 
 		return nil, err
 	}
 
-	if err = m.HandleCommunityTokensMetadataByPrivilegedMembers(community); err != nil {
+	if err = m.handleCommunityTokensMetadata(community); err != nil {
 		return nil, err
 	}
 
@@ -4721,16 +4721,7 @@ func (m *Manager) ReevaluatePrivilegedMember(community *Community, tokenPermissi
 	return alreadyHasPrivilegedRole, nil
 }
 
-func (m *Manager) HandleCommunityTokensMetadataByPrivilegedMembers(community *Community) error {
-	if community.HasPermissionToSendCommunityEvents() || community.IsControlNode() {
-		if err := m.HandleCommunityTokensMetadata(community); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *Manager) HandleCommunityTokensMetadata(community *Community) error {
+func (m *Manager) handleCommunityTokensMetadata(community *Community) error {
 	communityID := community.IDString()
 	communityTokens := community.CommunityTokensMetadata()
 

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1887,10 +1887,10 @@ func testAddAndSyncTokenFromControlNode(base CommunityEventsTestsInterface, comm
 	s.Require().Len(syncTokens, 1)
 	s.Require().Equal(syncTokens[0].PrivilegesLevel, privilegesLvl)
 
-	// check CommunityToken was not added to the DB
+	// check CommunityToken was added to the DB
 	syncTokens, err = base.GetMember().communitiesManager.GetAllCommunityTokens()
 	s.Require().NoError(err)
-	s.Require().Len(syncTokens, 0)
+	s.Require().Len(syncTokens, 1)
 }
 
 func testAddAndSyncOwnerTokenFromControlNode(base CommunityEventsTestsInterface, community *communities.Community,
@@ -2002,7 +2002,7 @@ func testAddAndSyncTokenFromEventSenderByControlNode(base CommunityEventsTestsIn
 
 	s.Require().NoError(err)
 
-	// check member did not receive sync message with the token
+	// check member received sync message with the token
 	_, err = WaitOnMessengerResponse(
 		base.GetMember(),
 		func(r *MessengerResponse) bool {
@@ -2012,7 +2012,7 @@ func testAddAndSyncTokenFromEventSenderByControlNode(base CommunityEventsTestsIn
 		"no token sync message from event sender",
 	)
 
-	s.Require().Error(err)
+	s.Require().NoError(err)
 }
 
 func testEventSenderAddTokenMasterAndOwnerToken(base CommunityEventsTestsInterface, community *communities.Community) {

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/services/communitytokens"
@@ -119,6 +120,21 @@ func (c *CollectiblesServiceMock) SetMockCollectibleContractData(chainID uint64,
 	}
 	c.Collectibles[chainID] = make(map[string]*communitytokens.CollectibleContractData)
 	c.Collectibles[chainID][contractAddress] = collectible
+}
+
+func (c *CollectiblesServiceMock) SetMockCommunityTokenData(token *token.CommunityToken) {
+	if c.Collectibles == nil {
+		c.Collectibles = make(map[uint64]map[string]*communitytokens.CollectibleContractData)
+	}
+
+	data := &communitytokens.CollectibleContractData{
+		TotalSupply:    token.Supply,
+		Transferable:   token.Transferable,
+		RemoteBurnable: token.RemoteSelfDestruct,
+		InfiniteSupply: token.InfiniteSupply,
+	}
+
+	c.SetMockCollectibleContractData(uint64(token.ChainID), token.Address, data)
 }
 
 func (c *CollectiblesServiceMock) SafeGetSignerPubKey(ctx context.Context, chainID uint64, communityID string) (string, error) {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3663,10 +3663,6 @@ func (m *Messenger) RemoveCommunityToken(chainID int, contractAddress string) er
 	return m.communitiesManager.RemoveCommunityToken(chainID, contractAddress)
 }
 
-func (m *Messenger) FetchMissingCommunityTokens(community *communities.Community) error {
-	return m.communitiesManager.HandleCommunityTokensMetadata(community)
-}
-
 func (m *Messenger) CheckPermissionsToJoinCommunity(request *requests.CheckPermissionToJoinCommunity) (*communities.CheckPermissionToJoinResponse, error) {
 	if err := request.Validate(); err != nil {
 		return nil, err

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -674,14 +674,6 @@ func (s *Service) fetchCommunity(communityID string, fetchLatest bool) (*communi
 		return nil, err
 	}
 
-	if community != nil {
-		// Call this to ensure CommunityTokens are stored to DB
-		err = s.messenger.FetchMissingCommunityTokens(community)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return community, nil
 }
 


### PR DESCRIPTION
Fetch community token metadata by all clients while handling community description

This information is required for the wallet team to restore all token data if a user receives a community token

Not doing this inside `(s *Service) fetchCommunity)` will help us to escape race conditions (when we are trying to write twice the same data and getting SQLite unique constraint error) and escape unnecessary locks

IMPACT: community tokens receive