### PR TITLE
fix: disable Goerli in the OpenSea client

### DIFF
--- a/services/wallet/thirdparty/opensea/client_v2.go
+++ b/services/wallet/thirdparty/opensea/client_v2.go
@@ -22,7 +22,7 @@ func getV2BaseURL(chainID walletCommon.ChainID) (string, error) {
 	switch uint64(chainID) {
 	case walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet, walletCommon.OptimismMainnet:
 		return "https://api.opensea.io/v2", nil
-	case walletCommon.EthereumGoerli, walletCommon.EthereumSepolia, walletCommon.ArbitrumSepolia, walletCommon.OptimismSepolia:
+	case walletCommon.EthereumSepolia, walletCommon.ArbitrumSepolia, walletCommon.OptimismSepolia:
 		return "https://testnets-api.opensea.io/v2", nil
 	}
 

--- a/services/wallet/thirdparty/opensea/types_v2.go
+++ b/services/wallet/thirdparty/opensea/types_v2.go
@@ -20,7 +20,6 @@ const (
 	ethereumMainnetString = "ethereum"
 	arbitrumMainnetString = "arbitrum"
 	optimismMainnetString = "optimism"
-	ethereumGoerliString  = "goerli"
 	ethereumSepoliaString = "sepolia"
 	arbitrumSepoliaString = "arbitrum_sepolia"
 	optimismSepoliaString = "optimism_sepolia"
@@ -37,8 +36,6 @@ func chainIDToChainString(chainID walletCommon.ChainID) string {
 		chainString = arbitrumMainnetString
 	case walletCommon.OptimismMainnet:
 		chainString = optimismMainnetString
-	case walletCommon.EthereumGoerli:
-		chainString = ethereumGoerliString
 	case walletCommon.EthereumSepolia:
 		chainString = ethereumSepoliaString
 	case walletCommon.ArbitrumSepolia:


### PR DESCRIPTION
Disable Goerli in the OpenSea client, since that chain is no longer supported.

![image](https://github.com/status-im/status-go/assets/11161531/7cc8dd1e-7a2f-43c7-92a3-78a4c2e598ac)
