### PR TITLE
Comment out all logged flaky tests

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"context"
+	//"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -34,7 +34,8 @@ import (
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/services/typeddata"
-	walletservice "github.com/status-im/status-go/services/wallet"
+
+	//walletservice "github.com/status-im/status-go/services/wallet"
 	"github.com/status-im/status-go/signal"
 	"github.com/status-im/status-go/sqlite"
 	"github.com/status-im/status-go/t/helpers"
@@ -750,6 +751,7 @@ func TestLoginWithKey(t *testing.T) {
 	require.NotNil(t, activeAccount.ColorHash)
 }
 
+/*
 func TestLoginAccount(t *testing.T) {
 	utils.Init()
 	password := "some-password"
@@ -792,6 +794,7 @@ func TestLoginAccount(t *testing.T) {
 		t.FailNow()
 	}
 }
+*/
 
 func TestVerifyDatabasePassword(t *testing.T) {
 	utils.Init()
@@ -908,6 +911,7 @@ func TestDeleteMultiaccount(t *testing.T) {
 	require.Equal(t, 3, len(files))
 }
 
+/*
 func TestConvertAccount(t *testing.T) {
 	const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 	const password = "111111"        // represents password for a regular user
@@ -1156,6 +1160,7 @@ func TestConvertAccount(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, len(keycards))
 }
+*/
 
 func copyFile(srcFolder string, dstFolder string, fileName string, t *testing.T) {
 	data, err := ioutil.ReadFile(path.Join(srcFolder, fileName))
@@ -1295,6 +1300,7 @@ func TestChangeDatabasePassword(t *testing.T) {
 	require.Equal(t, acc.Address, key.Address)
 }
 
+/*
 func TestCreateWallet(t *testing.T) {
 	utils.Init()
 	password := "some-password2" // nolint: goconst
@@ -1354,6 +1360,7 @@ func TestCreateWallet(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+*/
 
 func TestSetFleet(t *testing.T) {
 	utils.Init()

--- a/api/create_account_and_login_test.go
+++ b/api/create_account_and_login_test.go
@@ -1,16 +1,15 @@
 package api
 
-import (
-	"encoding/json"
-	"fmt"
-	"testing"
-	"time"
+//"encoding/json"
+//"fmt"
+//"testing"
+//"time"
 
-	"github.com/stretchr/testify/require"
+//"github.com/stretchr/testify/require"
 
-	"github.com/status-im/status-go/protocol/requests"
-)
+//"github.com/status-im/status-go/protocol/requests"
 
+/*
 func TestCreateAccountAndLogin(t *testing.T) {
 	rootDir := t.TempDir()
 	t.Logf("TestCreateAccountAndLogin: rootDir: %s", rootDir)
@@ -61,3 +60,4 @@ func TestCreateAccountAndLogin(t *testing.T) {
 	_, err = statusBackend.CreateAccountAndLogin(&request)
 	require.NoError(t, err)
 }
+*/

--- a/protocol/communities_events_owner_without_community_key_test.go
+++ b/protocol/communities_events_owner_without_community_key_test.go
@@ -147,6 +147,7 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerRejectMemberRequ
 	testRejectMemberRequestToJoin(s, community, user)
 }
 
+/*
 func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerControlNodeHandlesMultipleEventSenderRequestToJoinDecisions() {
 	additionalOwner := s.newMessenger("", []string{})
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER, []*Messenger{additionalOwner})
@@ -155,6 +156,7 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerControlNodeHandl
 	user := s.newMessenger("", []string{})
 	testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(s, community, user, additionalOwner)
 }
+*/
 
 func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerCreateEditDeleteCategories() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER)

--- a/protocol/communities_events_token_master_test.go
+++ b/protocol/communities_events_token_master_test.go
@@ -114,11 +114,13 @@ func (s *TokenMasterCommunityEventsSuite) TestTokenMasterCannotCreateBecomeToken
 	testEventSenderCannotCreatePrivilegedCommunityPermission(s, community, protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER)
 }
 
+/*
 func (s *TokenMasterCommunityEventsSuite) TestTokenMasterCannotEditBecomeAdminPermission() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER)
 	testEventSenderCannotEditPrivilegedCommunityPermission(
 		s, community, protobuf.CommunityTokenPermission_BECOME_ADMIN, protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER)
 }
+*/
 
 func (s *TokenMasterCommunityEventsSuite) TestTokenMasterCannotEditBecomeTokenMasterPermission() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER)
@@ -168,6 +170,7 @@ func (s *TokenMasterCommunityEventsSuite) TestTokenMasterRejectMemberRequestToJo
 	testRejectMemberRequestToJoin(s, community, user)
 }
 
+/*
 func (s *TokenMasterCommunityEventsSuite) TestTokenMasterControlNodeHandlesMultipleEventSenderRequestToJoinDecisions() {
 	additionalTokenMaster := s.newMessenger("qwerty", []string{eventsSenderAccountAddress})
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{additionalTokenMaster})
@@ -176,6 +179,7 @@ func (s *TokenMasterCommunityEventsSuite) TestTokenMasterControlNodeHandlesMulti
 	user := s.newMessenger("", []string{})
 	testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(s, community, user, additionalTokenMaster)
 }
+*/
 
 func (s *TokenMasterCommunityEventsSuite) TestTokenMasterCreateEditDeleteCategories() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER)

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1432,6 +1432,7 @@ func testRejectMemberRequestToJoin(base CommunityEventsTestsInterface, community
 	s.Require().Len(declinedRequestsPending, 0)
 }
 
+/*
 func testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(base CommunityEventsTestsInterface, community *communities.Community, user *Messenger, additionalEventSender *Messenger) {
 	_, err := user.Start()
 
@@ -1521,6 +1522,7 @@ func testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(base Commun
 	// we expect user's request to join still to be rejected
 	s.Require().Equal(rejectedRequests[0].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
 }
+*/
 
 func testCreateEditDeleteCategories(base CommunityEventsTestsInterface, community *communities.Community) {
 	newCategory := &requests.CreateCommunityCategory{

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -175,6 +175,7 @@ func (s *AdminCommunityEventsSuite) TestAdminRejectMemberRequestToJoin() {
 	testRejectMemberRequestToJoin(s, community, user)
 }
 
+/*
 func (s *AdminCommunityEventsSuite) TestAdminControlNodeHandlesMultipleEventSenderRequestToJoinDecisions() {
 	additionalAdmin := s.newMessenger("qwerty", []string{eventsSenderAccountAddress})
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{additionalAdmin})
@@ -183,6 +184,7 @@ func (s *AdminCommunityEventsSuite) TestAdminControlNodeHandlesMultipleEventSend
 	user := s.newMessenger("", []string{})
 	testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(s, community, user, additionalAdmin)
 }
+*/
 
 func (s *AdminCommunityEventsSuite) TestAdminCreateEditDeleteCategories() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN)
@@ -287,6 +289,7 @@ func (s *AdminCommunityEventsSuite) TestMemberReceiveOwnerEventsWhenControlNodeO
 	testMemberReceiveEventsWhenControlNodeOffline(s, community)
 }
 
+/*
 func (s *AdminCommunityEventsSuite) TestAdminResendRejectedEvents() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN)
 
@@ -356,6 +359,7 @@ func (s *AdminCommunityEventsSuite) TestAdminResendRejectedEvents() {
 	s.Require().NoError(err)
 	s.Require().Equal(adminEditRequest.Description, response.Communities()[0].DescriptionText())
 }
+*/
 
 func (s *AdminCommunityEventsSuite) TestJoinedAdminReceiveRequestsToJoinWithoutRevealedAccounts() {
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{})

--- a/protocol/communities_messenger_signers_test.go
+++ b/protocol/communities_messenger_signers_test.go
@@ -1,12 +1,12 @@
 package protocol
 
 import (
-	"bytes"
+	//"bytes"
 	"context"
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	//"github.com/golang/protobuf/proto"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
@@ -14,7 +14,7 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	hexutil "github.com/ethereum/go-ethereum/common/hexutil"
 
-	utils "github.com/status-im/status-go/common"
+	//utils "github.com/status-im/status-go/common"
 	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
@@ -586,6 +586,7 @@ func (s *MessengerCommunitiesSignersSuite) TestNewOwnerAcceptRequestToJoin() {
 
 }
 
+/*
 func (s *MessengerCommunitiesSignersSuite) testDescriptionSignature(description []byte) {
 	var amm protobuf.ApplicationMetadataMessage
 	err := proto.Unmarshal(description, &amm)
@@ -595,7 +596,9 @@ func (s *MessengerCommunitiesSignersSuite) testDescriptionSignature(description 
 	s.Require().NoError(err)
 	s.NotNil(signer)
 }
+*/
 
+/*
 func (s *MessengerCommunitiesSignersSuite) forceCommunityChange(community *communities.Community, owner *Messenger, user *Messenger) {
 	newDescription := community.DescriptionText() + " new"
 	_, err := owner.EditCommunity(&requests.EditCommunity{
@@ -615,7 +618,9 @@ func (s *MessengerCommunitiesSignersSuite) forceCommunityChange(community *commu
 	}, "new description not received")
 	s.Require().NoError(err)
 }
+*/
 
+/*
 func (s *MessengerCommunitiesSignersSuite) testSyncCommunity(mintOwnerToken bool) {
 	community := s.createCommunity(s.john)
 	s.advertiseCommunityTo(s.john, community, s.alice)
@@ -719,7 +724,9 @@ func (s *MessengerCommunitiesSignersSuite) testSyncCommunity(mintOwnerToken bool
 	s.Require().Equal(community.IDString(), responseCommunity.IDString())
 	s.Require().True(common.IsPubKeyEqual(expectedControlNode, responseCommunity.ControlNode()))
 }
+*/
 
+/*
 func (s *MessengerCommunitiesSignersSuite) TestSyncTokenGatedCommunity() {
 	testCases := []struct {
 		name           string
@@ -741,3 +748,4 @@ func (s *MessengerCommunitiesSignersSuite) TestSyncTokenGatedCommunity() {
 		})
 	}
 }
+*/

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -1178,6 +1178,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccess() {
 
 }
 
+/*
 func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccessWithDeclinedState() {
 	ctx := context.Background()
 
@@ -1429,7 +1430,9 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccessWithDeclinedSt
 	s.Require().False(notification.Deleted)
 
 }
+*/
 
+/*
 func (s *MessengerCommunitiesSuite) TestCancelRequestAccess() {
 	ctx := context.Background()
 
@@ -1606,6 +1609,7 @@ func (s *MessengerCommunitiesSuite) TestCancelRequestAccess() {
 	s.Require().Equal(communities.RequestToJoinStateCanceled, cancelRequestToJoin2.State)
 
 }
+*/
 
 func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 	description := &requests.CreateCommunity{

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -1,7 +1,7 @@
 package protocol
 
 import (
-	"bytes"
+	//"bytes"
 	"crypto/ecdsa"
 	"errors"
 	"math/big"
@@ -350,6 +350,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestCommunityTokensMetadata(
 	s.Require().Equal(tokensMetadata[0].Decimals, newToken.Decimals)
 }
 
+/*
 func (s *MessengerCommunitiesTokenPermissionsSuite) TestRequestAccessWithENSTokenPermission() {
 	community, _ := s.createCommunity()
 
@@ -398,6 +399,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestRequestAccessWithENSToke
 		s.Require().False(allCommunities[0].HasMember(&s.alice.identity.PublicKey))
 	}
 }
+*/
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) TestJoinedCommunityMembersSharedAddress() {
 	community, _ := s.createCommunity()
@@ -599,6 +601,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestEditSharedAddresses() {
 	s.Require().Equal(true, alicesRevealedAccounts[0].IsAirdropAddress)
 }
 
+/*
 func (s *MessengerCommunitiesTokenPermissionsSuite) TestBecomeMemberPermissions() {
 	community, chat := s.createCommunity()
 
@@ -740,6 +743,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestBecomeMemberPermissions(
 	)
 	s.Require().NoError(err)
 }
+*/
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) TestJoinCommunityWithAdminPermission() {
 	community, _ := s.createCommunity()
@@ -1312,9 +1316,11 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestReevaluateMemberAdminRol
 	s.testReevaluateMemberPrivilegedRoleInClosedCommunity(protobuf.CommunityTokenPermission_BECOME_ADMIN)
 }
 
+/*
 func (s *MessengerCommunitiesTokenPermissionsSuite) TestReevaluateMemberTokenMasterRoleInClosedCommunity() {
 	s.testReevaluateMemberPrivilegedRoleInClosedCommunity(protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER)
 }
+*/
 
 func checkRoleBasedOnThePermissionType(permissionType protobuf.CommunityTokenPermission_Type, member *ecdsa.PublicKey, community *communities.Community) bool {
 	switch permissionType {

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -414,6 +414,7 @@ func (s *MessengerActivityCenterMessageSuite) confirmMentionAndReplyNotification
 	s.Require().Equal(read, notifResponse.Notifications[0].Read)
 }
 
+/*
 func (s *MessengerActivityCenterMessageSuite) TestMarkMessagesSeenMarksNotificationsRead() {
 	alice, _, mentionMessage, replyMessage, _ := s.prepareCommunityChannelWithMentionAndReply()
 
@@ -426,6 +427,7 @@ func (s *MessengerActivityCenterMessageSuite) TestMarkMessagesSeenMarksNotificat
 
 	s.confirmMentionAndReplyNotificationsRead(alice, mentionMessage, replyMessage, true)
 }
+*/
 
 func (s *MessengerActivityCenterMessageSuite) TestMarkAllReadMarksNotificationsRead() {
 	alice, _, mentionMessage, replyMessage, _ := s.prepareCommunityChannelWithMentionAndReply()

--- a/protocol/messenger_backup_test.go
+++ b/protocol/messenger_backup_test.go
@@ -687,6 +687,7 @@ func (s *MessengerBackupSuite) TestBackupCommunities() {
 	s.Require().Equal(clock, lastBackup)
 }
 
+/*
 func (s *MessengerBackupSuite) TestBackupKeypairs() {
 	// Create bob1
 	bob1 := s.m
@@ -742,6 +743,7 @@ func (s *MessengerBackupSuite) TestBackupKeypairs() {
 	s.Require().NoError(err)
 	s.Require().True(accounts.SameKeypairsWithDifferentSyncedFrom(seedKp, dbSeedKp2, false, accounts.SyncedFromBackup, accounts.AccountNonOperable))
 }
+*/
 
 func (s *MessengerBackupSuite) TestBackupKeycards() {
 	// Create bob1

--- a/protocol/messenger_delete_message_for_me_test.go
+++ b/protocol/messenger_delete_message_for_me_test.go
@@ -3,7 +3,8 @@ package protocol
 import (
 	"context"
 	"crypto/ecdsa"
-	"errors"
+
+	//"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -109,6 +110,7 @@ func (s *MessengerDeleteMessageForMeSuite) Pair() {
 	s.Require().NoError(err)
 }
 
+/*
 func (s *MessengerDeleteMessageForMeSuite) TestDeleteMessageForMe() {
 	s.Pair()
 	chatID := "foobarsynctest"
@@ -211,6 +213,7 @@ func (s *MessengerDeleteMessageForMeSuite) TestDeleteMessageForMe() {
 	s.Require().NoError(err)
 	s.Require().False(otherMessage.DeletedForMe)
 }
+*/
 
 func (s *MessengerDeleteMessageForMeSuite) TestDeleteImageMessageFromReceiverSide() {
 

--- a/protocol/messenger_sync_wallets_test.go
+++ b/protocol/messenger_sync_wallets_test.go
@@ -445,6 +445,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountsReorder() {
 	s.Require().Equal(dbClock, dbClockOtherDevice)
 }
 
+/*
 func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 	profileKp := accounts.GetProfileKeypairForTest(true, true, true)
 	// set clocks for accounts
@@ -544,9 +545,11 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 			return err
 		}
 
+                // we don't include chat account in position ordering
 		if len(response.Keypairs) != 3 || // 3 keypairs (profile, seed, priv key)
 			len(response.WatchOnlyAccounts) != len(woAccounts) ||
-			len(response.AccountsPositions) != totalNumOfAccounts-1 /* we don't include chat account in position ordering*/ {
+			len(response.AccountsPositions) != totalNumOfAccounts-1
+                        {
 			return errors.New("no sync wallet account received")
 		}
 		return nil
@@ -619,3 +622,4 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 
 	s.Require().True(haveSameElements(dbAccounts1, dbAccounts2, accounts.SameAccountsIncludingPosition))
 }
+*/

--- a/services/wakuext/api_test.go
+++ b/services/wakuext/api_test.go
@@ -239,6 +239,7 @@ func (s *ShhExtSuite) TearDownTest() {
 	s.services = nil
 }
 
+/*
 func (s *ShhExtSuite) TestRequestMessagesSuccess() {
 	// two nodes needed: client and mailserver
 	s.createAndAddNode()
@@ -256,6 +257,7 @@ func (s *ShhExtSuite) TestRequestMessagesSuccess() {
 	})
 	s.NoError(err)
 }
+*/
 
 func (s *ShhExtSuite) TestMultipleRequestMessagesWithoutForce() {
 	// two nodes needed: client and mailserver

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -1462,6 +1462,7 @@ func (b *BlockRangeSequentialDAOMockSuccess) getBlockRange(chainID uint64, addre
 	return newEthTokensBlockRanges(), nil
 }
 
+/*
 func TestLoadBlocksAndTransfersCommand_FiniteFinishedInfiniteRunning(t *testing.T) {
 	appdb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
 	require.NoError(t, err)
@@ -1512,3 +1513,4 @@ func TestLoadBlocksAndTransfersCommand_FiniteFinishedInfiniteRunning(t *testing.
 		}, 100*time.Millisecond, 10*time.Millisecond))
 	}
 }
+*/

--- a/services/web3provider/api_test.go
+++ b/services/web3provider/api_test.go
@@ -124,6 +124,7 @@ func TestRequestPermission(t *testing.T) {
 	require.Error(t, err)
 }
 
+/*
 func TestWeb3Call(t *testing.T) {
 	api, cancel := setupTestAPI(t)
 	defer cancel()
@@ -165,6 +166,7 @@ func TestWeb3Call(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, data, response.Result.(JSONRPCResponse).Result)
 }
+*/
 
 func TestWeb3Signature(t *testing.T) {
 	api, cancel := setupTestAPI(t)

--- a/transactions/pendingtxtracker_test.go
+++ b/transactions/pendingtxtracker_test.go
@@ -2,10 +2,11 @@ package transactions
 
 import (
 	"context"
-	"database/sql"
+	//"database/sql"
 	"encoding/json"
 	"math/big"
-	"sync"
+
+	//"sync"
 	"testing"
 	"time"
 
@@ -422,6 +423,7 @@ func TestPendingTxTracker_Watch(t *testing.T) {
 	sub.Unsubscribe()
 }
 
+/*
 func TestPendingTxTracker_Watch_StatusChangeIncrementally(t *testing.T) {
 	m, stop, chainClient, eventFeed := setupTestTransactionDB(t, common.NewAndSet(1*time.Nanosecond))
 	defer stop()
@@ -536,6 +538,7 @@ func TestPendingTxTracker_Watch_StatusChangeIncrementally(t *testing.T) {
 
 	sub.Unsubscribe()
 }
+*/
 
 func TestPendingTransactions(t *testing.T) {
 	manager, stop, _, _ := setupTestTransactionDB(t, nil)


### PR DESCRIPTION
It gets more and more difficult to merge PRs because of false tests failures.
It also makes it difficult sometimes to catch genuine failures of newly introduced code/tests.

The goal of this PR is to comment out as many of those tests as needed to get relatively reliable results. The metric for "reliable" is 5 subsequent successful runs of tests suite on Jenkins (arbitrary but should be good enough).

There are separate issues for all commented out tests which can be found [here](https://github.com/status-im/status-go/issues?q=is%3Aopen+is%3Aissue+label%3A%22E%3AFlaky+Test%22).

My suggestion would be that person who fixes a flaky test runs it at least 1000 times locally and only after that files a PR with fix. We also can have a separate Jenkins job for that purpose. 

Anyway all that stuff is open for discussion.