### PR TITLE
Cleanup transfers scheduler and handle errors gracefully

### DIFF
--- a/services/wallet/async/async.go
+++ b/services/wallet/async/async.go
@@ -47,7 +47,6 @@ func (c SingleShotCommand) Run(ctx context.Context) error {
 type FiniteCommand struct {
 	Interval time.Duration
 	Runable  func(context.Context) error
-	OnExit   *func(context.Context, error)
 }
 
 func (c FiniteCommand) Run(ctx context.Context) error {
@@ -134,7 +133,7 @@ func NewAtomicGroup(parent context.Context) *AtomicGroup {
 	return ag
 }
 
-// AtomicGroup terminates as soon as first goroutine terminates..
+// AtomicGroup terminates as soon as first goroutine terminates with error.
 type AtomicGroup struct {
 	ctx    context.Context
 	cancel func()
@@ -319,18 +318,11 @@ func (c FiniteCommandWithErrorCounter) Run(ctx context.Context) error {
 
 		if c.ErrorCounter.SetError(err) {
 			return false, err
-		} else {
-			return true, err
 		}
+		return true, err
 	}
 
 	quit, err := f(ctx)
-	defer func() {
-		if c.OnExit != nil {
-			(*c.OnExit)(ctx, err)
-		}
-	}()
-
 	if quit {
 		return err
 	}

--- a/services/wallet/async/async_test.go
+++ b/services/wallet/async/async_test.go
@@ -1,0 +1,52 @@
+package async
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicGroupTerminatesOnOneCommandFailed(t *testing.T) {
+	ctx := context.Background()
+	group := NewAtomicGroup(ctx)
+
+	err := errors.New("error")
+	group.Add(func(ctx context.Context) error {
+		return err // failure
+	})
+	group.Add(func(ctx context.Context) error {
+		<-ctx.Done()
+		return nil
+	})
+
+	group.Wait()
+	require.Equal(t, err, group.Error())
+}
+
+func TestAtomicGroupWaitsAllToFinish(t *testing.T) {
+	ctx := context.Background()
+	group := NewAtomicGroup(ctx)
+
+	finished := false
+	group.Add(func(ctx context.Context) error {
+		time.Sleep(1 * time.Millisecond)
+		return nil // success
+	})
+	group.Add(func(ctx context.Context) error {
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(3 * time.Millisecond):
+				finished = true
+				return nil
+			}
+		}
+	})
+
+	group.Wait()
+	require.True(t, finished)
+}

--- a/services/wallet/balance/testutils.go
+++ b/services/wallet/balance/testutils.go
@@ -1,0 +1,5 @@
+package balance
+
+type TestCacher struct {
+	cacherImpl
+}


### PR DESCRIPTION
Handle errors in findBlocksCommand and findNewBlocksCommand gracefully.
Add ErrorCounter type for async package and a FiniteCommandWithErrorCounter to exit on errors overflow
Add tests

Closes [#11074](https://github.com/status-im/status-desktop/issues/11074)