### PR TITLE
fix: remove color sequences from tests output

### DIFF
--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -26,6 +26,15 @@ redirect_stdout() {
   fi
 }
 
+remove_color_sequences() {
+  if [[ "${CI}" == 'true' ]];
+  then
+    sed 's/\x1b\[[0-9;]*m//g'
+  else
+    cat
+  fi
+}
+
 last_failing_exit_code=0
 
 for package in ${UNIT_TEST_PACKAGES}; do
@@ -37,6 +46,7 @@ for package in ${UNIT_TEST_PACKAGES}; do
     -timeout "${UNIT_TEST_PACKAGE_TIMEOUT}" \
     -count "${UNIT_TEST_COUNT}" \
     -tags "${BUILD_TAGS}" | \
+    remove_color_sequences | \
     redirect_stdout "${output_file}"
   go_test_exit=$?
 

--- a/_assets/scripts/test_stats.py
+++ b/_assets/scripts/test_stats.py
@@ -7,7 +7,12 @@ from collections import defaultdict
 test_stats = defaultdict(lambda: defaultdict(int))
 
 for file in glob.glob("**/report.xml", recursive=True):
-    tree = ET.parse(file)
+    try:
+        tree = ET.parse(file)
+    except Exception as e:
+        print(f"Error parsing {file}: {e}")
+        raise
+
     root = tree.getroot()
     for testcase in root.iter("testcase"):
         test_name = testcase.attrib["name"]


### PR DESCRIPTION
Removed colorized output from tests due to lack of control over various loggers. This ensures valid input for go-junit-report.

fixes: #4587
