### PR TITLE
fix: closing tmp db file after creation

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1090,10 +1090,14 @@ func (b *GethStatusBackend) createTempDBFile(pattern string) (tmpDbPath string, 
 	if err != nil {
 		return
 	}
+	err = file.Close()
+	if err != nil {
+		return
+	}
+
 	tmpDbPath = file.Name()
 	cleanup = func() {
 		filePath := file.Name()
-		_ = file.Close()
 		_ = os.Remove(filePath)
 		_ = os.Remove(filePath + "-wal")
 		_ = os.Remove(filePath + "-shm")


### PR DESCRIPTION
Changes done in this commit solve the " The process cannot access the file because it is being used by another process." error which was noticeable on Windows while migrating a profile keypair to a Keycard.