### PR TITLE
refactor: introduce `newTestMessenger`

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -232,6 +232,7 @@ func main() {
 			protocol.WithTorrentConfig(&config.TorrentConfig),
 			protocol.WithWalletConfig(&config.WalletConfig),
 			protocol.WithRPCClient(backend.StatusNode().RPCClient()),
+			protocol.WithAccountManager(backend.AccountManager()),
 		}
 
 		messenger, err := protocol.NewMessenger(
@@ -240,7 +241,6 @@ func main() {
 			gethbridge.NewNodeBridge(backend.StatusNode().GethNode(), backend.StatusNode().WakuService(), backend.StatusNode().WakuV2Service()),
 			installationID.String(),
 			nil,
-			backend.AccountManager(),
 			options...,
 		)
 		if err != nil {

--- a/multiaccounts/settings/database.go
+++ b/multiaccounts/settings/database.go
@@ -119,6 +119,7 @@ INSERT INTO settings (
   current_network,
   dapps_address,
   device_name,
+  preferred_name,
   display_name,
   bio,
   eip1581_address,
@@ -150,13 +151,14 @@ INSERT INTO settings (
   wallet_collectible_preferences_group_by_collection,
   wallet_collectible_preferences_group_by_community
 ) VALUES (
-?,?,?,?,?,?,?,?,?,?,?,?,?,
+?,?,?,?,?,?,?,?,?,?,?,?,?,?,
 ?,?,?,?,?,?,?,?,?,'id',?,?,?,?,?,?,?,?,?,?,?,?)`,
 		s.Address,
 		s.Currency,
 		s.CurrentNetwork,
 		s.DappsAddress,
 		s.DeviceName,
+		s.PreferredName,
 		s.DisplayName,
 		s.Bio,
 		s.EIP1581Address,

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -279,7 +279,6 @@ func NewMessenger(
 	node types.Node,
 	installationID string,
 	peerStore *mailservers.PeerStore,
-	accountsManager account.Manager,
 	opts ...Option,
 ) (*Messenger, error) {
 	var messenger *Messenger
@@ -446,7 +445,7 @@ func NewMessenger(
 	}
 
 	managerOptions := []communities.ManagerOption{
-		communities.WithAccountManager(accountsManager),
+		communities.WithAccountManager(c.accountsManager),
 	}
 
 	if walletAPI != nil {
@@ -508,7 +507,7 @@ func NewMessenger(
 		pushNotificationServer:     pushNotificationServer,
 		communitiesManager:         communitiesManager,
 		communitiesKeyDistributor:  communitiesKeyDistributor,
-		accountsManager:            accountsManager,
+		accountsManager:            c.accountsManager,
 		ensVerifier:                ensVerifier,
 		featureFlags:               c.featureFlags,
 		systemMessagesTranslations: c.systemMessagesTranslations,

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -6,22 +6,15 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/google/uuid"
 	"go.uber.org/zap"
 
-	"github.com/status-im/status-go/account/generator"
-	"github.com/status-im/status-go/appdatabase"
-	"github.com/status-im/status-go/common/dbsetup"
 	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
-	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/tt"
-	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/waku"
-	"github.com/status-im/status-go/walletdatabase"
 )
 
 const DefaultProfileDisplayName = ""
@@ -68,56 +61,20 @@ type MessengerBaseTestSuite struct {
 }
 
 func newMessengerWithKey(shh types.Waku, privateKey *ecdsa.PrivateKey, logger *zap.Logger, extraOptions []Option) (*Messenger, error) {
-	madb, err := multiaccounts.InitializeDB(dbsetup.InMemoryPath)
-	if err != nil {
-		return nil, err
-	}
-
-	acc := generator.NewAccount(privateKey, nil)
-	iai := acc.ToIdentifiedAccountInfo("")
-
-	walletDb, err := helpers.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
-	if err != nil {
-		return nil, err
-	}
-	appDb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
-	if err != nil {
-		return nil, err
-	}
-
 	options := []Option{
-		WithCustomLogger(logger),
-		WithDatabase(appDb),
-		WithWalletDatabase(walletDb),
-		WithMultiAccounts(madb),
-		WithAccount(iai.ToMultiAccount()),
-		WithDatasync(),
-		WithToplevelDatabaseMigrations(),
 		WithAppSettings(settings.Settings{
 			DisplayName:               DefaultProfileDisplayName,
 			ProfilePicturesShowTo:     1,
 			ProfilePicturesVisibility: 1,
 			URLUnfurlingMode:          settings.URLUnfurlingAlwaysAsk,
 		}, params.NodeConfig{}),
-		WithBrowserDatabase(nil),
 	}
-
 	options = append(options, extraOptions...)
 
-	m, err := NewMessenger(
-		"Test",
-		privateKey,
-		&testNode{shh: shh},
-		uuid.New().String(),
-		nil,
-		nil,
-		options...,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	err = m.Init()
+	m, err := newTestMessenger(shh, testMessengerConfig{
+		privateKey: privateKey,
+		logger:     logger,
+	}, options)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -1,0 +1,99 @@
+package protocol
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/account/generator"
+	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/common/dbsetup"
+	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/multiaccounts"
+	"github.com/status-im/status-go/protocol/tt"
+	"github.com/status-im/status-go/t/helpers"
+	"github.com/status-im/status-go/walletdatabase"
+)
+
+type testMessengerConfig struct {
+	name       string
+	privateKey *ecdsa.PrivateKey
+	logger     *zap.Logger
+}
+
+func (tmc *testMessengerConfig) complete() error {
+	if len(tmc.name) == 0 {
+		tmc.name = uuid.NewString()
+	}
+
+	if tmc.privateKey == nil {
+		privateKey, err := crypto.GenerateKey()
+		if err != nil {
+			return err
+		}
+		tmc.privateKey = privateKey
+	}
+
+	if tmc.logger == nil {
+		logger := tt.MustCreateTestLogger()
+		tmc.logger = logger.With(zap.String("name", tmc.name))
+	}
+
+	return nil
+}
+
+func newTestMessenger(waku types.Waku, config testMessengerConfig, extraOptions []Option) (*Messenger, error) {
+	err := config.complete()
+	if err != nil {
+		return nil, err
+	}
+
+	acc := generator.NewAccount(config.privateKey, nil)
+	iai := acc.ToIdentifiedAccountInfo("")
+
+	madb, err := multiaccounts.InitializeDB(dbsetup.InMemoryPath)
+	if err != nil {
+		return nil, err
+	}
+	walletDb, err := helpers.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	if err != nil {
+		return nil, err
+	}
+	appDb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
+	if err != nil {
+		return nil, err
+	}
+
+	options := []Option{
+		WithCustomLogger(config.logger),
+		WithDatabase(appDb),
+		WithWalletDatabase(walletDb),
+		WithMultiAccounts(madb),
+		WithAccount(iai.ToMultiAccount()),
+		WithDatasync(),
+		WithToplevelDatabaseMigrations(),
+		WithBrowserDatabase(nil),
+	}
+	options = append(options, extraOptions...)
+
+	m, err := NewMessenger(
+		config.name,
+		config.privateKey,
+		&testNode{shh: waku},
+		uuid.New().String(),
+		nil,
+		options...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = m.Init()
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 
+	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/browsers"
@@ -90,6 +91,7 @@ type config struct {
 	httpServer             *server.MediaServer
 	rpcClient              *rpc.Client
 	tokenManager           communities.TokenManager
+	accountsManager        account.Manager
 
 	verifyTransactionClient  EthClient
 	verifyENSURL             string
@@ -377,6 +379,13 @@ func WithWakuService(s *wakuv2.Waku) Option {
 func WithTokenManager(tokenManager communities.TokenManager) Option {
 	return func(c *config) error {
 		c.tokenManager = tokenManager
+		return nil
+	}
+}
+
+func WithAccountManager(accountManager account.Manager) Option {
+	return func(c *config) error {
+		c.accountsManager = accountManager
 		return nil
 	}
 }

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -162,7 +162,7 @@ func (s *Service) InitProtocol(nodeName string, identity *ecdsa.PrivateKey, appD
 	s.multiAccountsDB = multiAccountDb
 	s.account = acc
 
-	options, err := buildMessengerOptions(s.config, identity, appDb, walletDb, httpServer, s.rpcClient, s.multiAccountsDB, acc, envelopesMonitorConfig, s.accountsDB, walletService, communityTokensService, wakuService, logger, &MessengerSignalsHandler{})
+	options, err := buildMessengerOptions(s.config, identity, appDb, walletDb, httpServer, s.rpcClient, s.multiAccountsDB, acc, envelopesMonitorConfig, s.accountsDB, walletService, communityTokensService, wakuService, logger, &MessengerSignalsHandler{}, accountManager)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,6 @@ func (s *Service) InitProtocol(nodeName string, identity *ecdsa.PrivateKey, appD
 		s.n,
 		s.config.ShhextConfig.InstallationID,
 		s.peerStore,
-		accountManager,
 		options...,
 	)
 	if err != nil {
@@ -391,6 +390,7 @@ func buildMessengerOptions(
 	wakuService *wakuv2.Waku,
 	logger *zap.Logger,
 	messengerSignalsHandler protocol.MessengerSignalsHandler,
+	accountManager account.Manager,
 ) ([]protocol.Option, error) {
 	options := []protocol.Option{
 		protocol.WithCustomLogger(logger),
@@ -413,6 +413,7 @@ func buildMessengerOptions(
 		protocol.WithWalletService(walletService),
 		protocol.WithCommunityTokensService(communityTokensService),
 		protocol.WithWakuService(wakuService),
+		protocol.WithAccountManager(accountManager),
 	}
 
 	if config.ShhextConfig.DataSyncEnabled {


### PR DESCRIPTION
This avoids duplication and enables better configuration possibilities for clients.

Next step is to cleanup all `newMessenger` derivatives in tests.