### PR TITLE
fix: waku udp port conflict

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -751,7 +751,6 @@ func TestLoginWithKey(t *testing.T) {
 	require.NotNil(t, activeAccount.ColorHash)
 }
 
-/*
 func TestLoginAccount(t *testing.T) {
 	utils.Init()
 	password := "some-password"
@@ -794,7 +793,6 @@ func TestLoginAccount(t *testing.T) {
 		t.FailNow()
 	}
 }
-*/
 
 func TestVerifyDatabasePassword(t *testing.T) {
 	utils.Init()

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -173,18 +173,6 @@ func (w *Waku) SetStatusTelemetryClient(client ITelemetryClient) {
 	w.statusTelemetryClient = client
 }
 
-func getUsableUDPPort() (int, error) {
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{
-		IP:   net.IPv4zero,
-		Port: 0,
-	})
-	if err != nil {
-		return 0, err
-	}
-	defer conn.Close()
-	return conn.LocalAddr().(*net.UDPAddr).Port, nil
-}
-
 // New creates a WakuV2 client ready to communicate through the LibP2P network.
 func New(nodeKey string, fleet string, cfg *Config, logger *zap.Logger, appDB *sql.DB, ts *timesource.NTPTimeSource, onHistoricMessagesRequestFailed func([]byte, peer.ID, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
 	var err error
@@ -200,13 +188,6 @@ func New(nodeKey string, fleet string, cfg *Config, logger *zap.Logger, appDB *s
 	}
 
 	cfg = setDefaults(cfg)
-
-	if cfg.UDPPort == 0 {
-		cfg.UDPPort, err = getUsableUDPPort()
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	logger.Info("starting wakuv2 with config", zap.Any("config", cfg))
 

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -40,7 +40,6 @@ func TestDiscoveryV5(t *testing.T) {
 	config.EnableDiscV5 = true
 	config.DiscV5BootstrapNodes = []string{testENRBootstrap}
 	config.DiscoveryLimit = 20
-	config.UDPPort = 9001
 	w, err := New("", "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
@@ -288,7 +287,6 @@ func TestWakuV2Filter(t *testing.T) {
 	config.EnableDiscV5 = true
 	config.DiscV5BootstrapNodes = []string{enrTreeAddress}
 	config.DiscoveryLimit = 20
-	config.UDPPort = 9001
 	config.WakuNodes = []string{enrTreeAddress}
 	fleet := "status.test" // Need a name fleet so that LightClient is not set to false
 	w, err := New("", fleet, config, nil, nil, nil, nil, nil)


### PR DESCRIPTION
waku already support udp port 0, we can remove `getUsableUDPPort` now.

<img width="786" alt="image" src="https://github.com/status-im/status-go/assets/12406719/e943b0e4-61af-401a-a7b8-f8910160730b">

Closes #4403 #4112