### PR TITLE
fix(wallet): do not return gas-only ETH entries of transfers table for

### DIFF
--- a/services/wallet/activity/filter.sql
+++ b/services/wallet/activity/filter.sql
@@ -157,6 +157,7 @@ layer2_networks(network_id) AS (
 mint_methods(method_hash) AS (
 	%s
 )
+
 SELECT
 	transfers.hash AS transfer_hash,
 	NULL AS pending_hash,
@@ -208,7 +209,7 @@ SELECT
 		WHEN transfers.tx_from_address = zeroAddress AND transfers.type = "erc20" THEN substr(json_extract(tx, '$.input'), 1, 10)
 		ELSE NULL
 	END AS method_hash,
-	CASE 
+	CASE
 		WHEN transfers.tx_from_address = zeroAddress AND transfers.type = "erc20" THEN (SELECT 1 FROM json_each(transfers.receipt, '$.logs' ) WHERE json_extract( value, '$.topics[0]' ) = communityMintEvent)
 		ELSE NULL
 	END AS community_mint_event
@@ -254,11 +255,11 @@ WHERE
 				AND (
 					transfers.type = 'erc721'
 					OR (
-						transfers.type = 'erc20' 
+						transfers.type = 'erc20'
 						AND (
 							(method_hash IS NOT NULL AND method_hash IN mint_methods)
 							OR community_mint_event IS NOT NULL
-						) 
+						)
 					)
 				)
 			)
@@ -281,11 +282,11 @@ WHERE
 			AND (
 				transfers.type = 'erc721'
 				OR (
-					transfers.type = 'erc20' 
+					transfers.type = 'erc20'
 					AND (
 						(method_hash IS NOT NULL AND method_hash IN mint_methods)
 						OR community_mint_event IS NOT NULL
-					) 
+					)
 				)
 			)
 		)

--- a/services/wallet/transfer/block_ranges_sequential_dao.go
+++ b/services/wallet/transfer/block_ranges_sequential_dao.go
@@ -90,8 +90,8 @@ func (b *BlockRangeSequentialDAO) upsertRange(chainID uint64, account common.Add
 		return err
 	}
 
-	ethBlockRange := prepareUpdatedBlockRange(chainID, account, ethTokensBlockRange.eth, newBlockRange.eth)
-	tokensBlockRange := prepareUpdatedBlockRange(chainID, account, ethTokensBlockRange.tokens, newBlockRange.tokens)
+	ethBlockRange := prepareUpdatedBlockRange(ethTokensBlockRange.eth, newBlockRange.eth)
+	tokensBlockRange := prepareUpdatedBlockRange(ethTokensBlockRange.tokens, newBlockRange.tokens)
 
 	log.Debug("update eth and tokens blocks range", "account", account, "chainID", chainID,
 		"eth.start", ethBlockRange.Start, "eth.first", ethBlockRange.FirstKnown, "eth.last", ethBlockRange.LastKnown,
@@ -117,7 +117,7 @@ func (b *BlockRangeSequentialDAO) upsertEthRange(chainID uint64, account common.
 		return err
 	}
 
-	blockRange := prepareUpdatedBlockRange(chainID, account, ethTokensBlockRange.eth, newBlockRange)
+	blockRange := prepareUpdatedBlockRange(ethTokensBlockRange.eth, newBlockRange)
 
 	log.Debug("update eth blocks range", "account", account, "chainID", chainID,
 		"start", blockRange.Start, "first", blockRange.FirstKnown, "last", blockRange.LastKnown, "old hash", ethTokensBlockRange.balanceCheckHash)
@@ -146,7 +146,7 @@ func (b *BlockRangeSequentialDAO) updateTokenRange(chainID uint64, account commo
 		return err
 	}
 
-	blockRange := prepareUpdatedBlockRange(chainID, account, ethTokensBlockRange.tokens, newBlockRange)
+	blockRange := prepareUpdatedBlockRange(ethTokensBlockRange.tokens, newBlockRange)
 
 	log.Debug("update tokens blocks range", "account", account, "chainID", chainID,
 		"start", blockRange.Start, "first", blockRange.FirstKnown, "last", blockRange.LastKnown, "old hash", ethTokensBlockRange.balanceCheckHash)
@@ -162,7 +162,7 @@ func (b *BlockRangeSequentialDAO) updateTokenRange(chainID uint64, account commo
 	return err
 }
 
-func prepareUpdatedBlockRange(chainID uint64, account common.Address, blockRange, newBlockRange *BlockRange) *BlockRange {
+func prepareUpdatedBlockRange(blockRange, newBlockRange *BlockRange) *BlockRange {
 	// Update existing range
 	if blockRange != nil {
 		if newBlockRange != nil {


### PR DESCRIPTION
activities request
- remove gas-fee-only ETH transfers once token transfers with the same tx_hash, nonce, networkd_id and address are loaded
- delete such history transfers on migration
- minor refactoring of `saveAndConfirmPending` (unrelated to the task)
- removed redundant parameters from `prepareUpdatedBlockRange` method
