### PR TITLE
chore: set extended timeout only for `protocol` package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,7 @@ test-unit: export UNIT_TEST_PACKAGES ?= $(shell go list ./... | \
 	grep -v /t/benchmarks | \
 	grep -v /transactions/fake | \
 	grep -E -v '/wakuv2(/.*|$$)')
+test-unit: export UNIT_TEST_PACKAGES_WITH_EXTENDED_TIMEOUT ?= github.com/status-im/status-go/protocol
 test-unit: ##@tests Run unit and integration tests
 	./_assets/scripts/run_unit_tests.sh
 


### PR DESCRIPTION
It mitigates https://github.com/status-im/status-go/issues/4585 until the root cause is fixed.

_All other packages take much less than 2mins._