### PR TITLE
fix: clear waku envelopes cache when deleting a chat

### DIFF
--- a/eth-node/bridge/geth/waku.go
+++ b/eth-node/bridge/geth/waku.go
@@ -274,6 +274,10 @@ func (w *gethWakuWrapper) RequestStoreMessages(ctx context.Context, peerID []byt
 
 func (w *gethWakuWrapper) ConnectionChanged(_ connection.State) {}
 
+func (w *gethWakuWrapper) ClearEnvelopesCache() {
+	w.waku.ClearEnvelopesCache()
+}
+
 type wakuFilterWrapper struct {
 	filter *wakucommon.Filter
 	id     string

--- a/eth-node/bridge/geth/wakuv2.go
+++ b/eth-node/bridge/geth/wakuv2.go
@@ -289,6 +289,10 @@ func (w *gethWakuV2Wrapper) ConnectionChanged(state connection.State) {
 	w.waku.ConnectionChanged(state)
 }
 
+func (w *gethWakuV2Wrapper) ClearEnvelopesCache() {
+	w.waku.ClearEnvelopesCache()
+}
+
 type wakuV2FilterWrapper struct {
 	filter *wakucommon.Filter
 	id     string

--- a/eth-node/types/waku.go
+++ b/eth-node/types/waku.go
@@ -161,4 +161,7 @@ type Waku interface {
 
 	// ConnectionChanged is called whenever the client knows its connection status has changed
 	ConnectionChanged(connection.State)
+
+	// ClearEnvelopesCache clears waku envelopes cache
+	ClearEnvelopesCache()
 }

--- a/protocol/communities/errors.go
+++ b/protocol/communities/errors.go
@@ -44,3 +44,4 @@ var ErrInvalidManageTokensPermission = errors.New("no privileges to manage token
 var ErrRevealedAccountsAbsent = errors.New("revealed accounts is absent")
 var ErrNoRevealedAccountsSignature = errors.New("revealed accounts without the signature")
 var ErrNoFreeSpaceForHistoryArchives = errors.New("history archive: No free space for downloading history archives")
+var ErrPermissionToJoinNotSatisfied = errors.New("permission to join not satisfied")

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -489,7 +489,6 @@ func joinOnRequestCommunity(s *suite.Suite, community *communities.Community, co
 	s.Require().NoError(err)
 }
 
-/*
 func sendChatMessage(s *suite.Suite, sender *Messenger, chatID string, text string) *common.Message {
 	msg := &common.Message{
 		ChatMessage: &protobuf.ChatMessage{
@@ -503,7 +502,7 @@ func sendChatMessage(s *suite.Suite, sender *Messenger, chatID string, text stri
 	s.Require().NoError(err)
 
 	return msg
-}*/
+}
 
 func grantPermission(s *suite.Suite, community *communities.Community, controlNode *Messenger, target *Messenger, role protobuf.CommunityMember_Roles) {
 	responseAddRole, err := controlNode.AddRoleToMember(&requests.AddRoleToMember{

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -489,6 +489,7 @@ func joinOnRequestCommunity(s *suite.Suite, community *communities.Community, co
 	s.Require().NoError(err)
 }
 
+/*
 func sendChatMessage(s *suite.Suite, sender *Messenger, chatID string, text string) *common.Message {
 	msg := &common.Message{
 		ChatMessage: &protobuf.ChatMessage{
@@ -503,6 +504,7 @@ func sendChatMessage(s *suite.Suite, sender *Messenger, chatID string, text stri
 
 	return msg
 }
+*/
 
 func grantPermission(s *suite.Suite, community *communities.Community, controlNode *Messenger, target *Messenger, role protobuf.CommunityMember_Roles) {
 	responseAddRole, err := controlNode.AddRoleToMember(&requests.AddRoleToMember{

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -229,7 +229,9 @@ func newTestCommunitiesMessenger(s *suite.Suite, waku types.Waku, config testCom
 		WithAppSettings(*config.appSettings, *config.nodeConfig),
 	}
 
-	messenger, err := newTestMessenger(waku, config.testMessengerConfig, options)
+	config.extraOptions = append(config.extraOptions, options...)
+
+	messenger, err := newTestMessenger(waku, config.testMessengerConfig)
 	s.Require().NoError(err)
 
 	currentDistributorObj, ok := messenger.communitiesKeyDistributor.(*CommunitiesKeyDistributorImpl)

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -223,7 +223,6 @@ func newTestCommunitiesMessenger(s *suite.Suite, waku types.Waku, config testCom
 	}
 
 	options := []Option{
-		WithResendParams(3, 3),
 		WithAccountManager(accountsManagerMock),
 		WithTokenManager(tokenManagerMock),
 		WithCommunityTokensService(config.collectiblesService),

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"math/big"
-	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -18,7 +17,6 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
@@ -71,6 +69,7 @@ func (tckd *TestCommunitiesKeyDistributor) Distribute(community *communities.Com
 	return nil
 }
 
+/*
 func (tckd *TestCommunitiesKeyDistributor) waitOnKeyDistribution(condition func(*CommunityAndKeyActions) bool) <-chan error {
 	errCh := make(chan error, 1)
 
@@ -110,6 +109,7 @@ func (tckd *TestCommunitiesKeyDistributor) waitOnKeyDistribution(condition func(
 
 	return errCh
 }
+*/
 
 func TestMessengerCommunitiesTokenPermissionsSuite(t *testing.T) {
 	suite.Run(t, new(MessengerCommunitiesTokenPermissionsSuite))
@@ -221,9 +221,11 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) createCommunity() (*communit
 	return createCommunity(&s.Suite, s.owner)
 }
 
+/*
 func (s *MessengerCommunitiesTokenPermissionsSuite) sendChatMessage(sender *Messenger, chatID string, text string) *common.Message {
 	return sendChatMessage(&s.Suite, sender, chatID, text)
 }
+*/
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) makeAddressSatisfyTheCriteria(chainID uint64, address string, criteria *protobuf.TokenCriteria) {
 	walletAddress := gethcommon.HexToAddress(address)
@@ -236,11 +238,13 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) makeAddressSatisfyTheCriteri
 	s.mockedBalances[chainID][walletAddress][contractAddress] = (*hexutil.Big)(balance)
 }
 
+/*
 func (s *MessengerCommunitiesTokenPermissionsSuite) waitOnKeyDistribution(condition func(*CommunityAndKeyActions) bool) <-chan error {
 	testCommunitiesKeyDistributor, ok := s.owner.communitiesKeyDistributor.(*TestCommunitiesKeyDistributor)
 	s.Require().True(ok)
 	return testCommunitiesKeyDistributor.waitOnKeyDistribution(condition)
 }
+*/
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) TestCreateTokenPermission() {
 	community, _ := s.createCommunity()
@@ -628,7 +632,8 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestEditSharedAddresses() {
 // NOTE(cammellos): Disabling for now as flaky, the reason it fails is that the community
 // key sometimes will be coming after the community description, working on a fix in a separate
 // PR
-func (s *MessengerCommunitiesTokenPermissionsSuite) TestBecomeMemberPermissions() {
+/*
+func(s *MessengerCommunitiesTokenPermissionsSuite) TestBecomeMemberPermissions() {
 	// Create a store node
 	// This is needed to fetch the messages after rejoining the community
 	var err error
@@ -846,7 +851,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestBecomeMemberPermissions(
 	})
 
 	s.Require().Equal(messages[0], bobMessages[0].Text)
-}
+}*/
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) TestJoinCommunityWithAdminPermission() {
 	community, _ := s.createCommunity()

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -136,17 +136,14 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) SetupTest() {
 
 	wakuNodes := CreateWakuV2Network(&s.Suite, s.logger, false, []string{"owner", "bob", "alice"})
 
-	ownerLogger := s.logger.With(zap.String("name", "owner"))
 	s.ownerWaku = wakuNodes[0]
-	s.owner = s.newMessenger(ownerPassword, []string{ownerAddress}, s.ownerWaku, ownerLogger)
+	s.owner = s.newMessenger(ownerPassword, []string{ownerAddress}, s.ownerWaku, "owner", []Option{})
 
-	bobLogger := s.logger.With(zap.String("name", "bob"))
 	s.bobWaku = wakuNodes[1]
-	s.bob = s.newMessenger(bobPassword, []string{bobAddress}, s.bobWaku, bobLogger)
+	s.bob = s.newMessenger(bobPassword, []string{bobAddress}, s.bobWaku, "bob", []Option{})
 
-	aliceLogger := s.logger.With(zap.String("name", "alice"))
 	s.aliceWaku = wakuNodes[2]
-	s.alice = s.newMessenger(alicePassword, []string{aliceAddress1, aliceAddress2}, s.aliceWaku, aliceLogger)
+	s.alice = s.newMessenger(alicePassword, []string{aliceAddress1, aliceAddress2}, s.aliceWaku, "alice", []Option{})
 
 	_, err := s.owner.Start()
 	s.Require().NoError(err)
@@ -186,10 +183,11 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TearDownTest() {
 	_ = s.logger.Sync()
 }
 
-func (s *MessengerCommunitiesTokenPermissionsSuite) newMessenger(password string, walletAddresses []string, waku types.Waku, logger *zap.Logger) *Messenger {
+func (s *MessengerCommunitiesTokenPermissionsSuite) newMessenger(password string, walletAddresses []string, waku types.Waku, name string, extraOptions []Option) *Messenger {
 	return newTestCommunitiesMessenger(&s.Suite, waku, testCommunitiesMessengerConfig{
 		testMessengerConfig: testMessengerConfig{
-			logger: logger,
+			logger:       s.logger.Named(name),
+			extraOptions: extraOptions,
 		},
 		password:            password,
 		walletAddresses:     walletAddresses,

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -730,8 +730,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestEditSharedAddresses() {
 	// bob tries to join, but he doesn't satisfy so the request isn't sent
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID(), AddressesToReveal: []string{bobAddress}, AirdropAddress: bobAddress}
 	_, err = s.bob.RequestToJoinCommunity(request)
-	s.Require().Error(err)
-	s.Require().ErrorContains(err, "permission to join not satisfied")
+	s.Require().ErrorIs(err, communities.ErrPermissionToJoinNotSatisfied)
 
 	// make sure bob does not have a pending request to join
 	requests, err := s.bob.MyPendingRequestsToJoin()

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -202,8 +202,6 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) joinCommunity(community *com
 }
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) joinCommunityWithAirdropAddress(community *communities.Community, user *Messenger, password string, addresses []string, airdropAddress string) {
-	s.Require().NotEmpty(addresses)
-
 	passwdHash := types.EncodeHex(crypto.Keccak256([]byte(password)))
 	if airdropAddress == "" && len(addresses) > 0 {
 		airdropAddress = addresses[0]

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1549,7 +1549,7 @@ func (m *Messenger) watchExpiredMessages() {
 				if m.Online() {
 					err := m.resendExpiredMessages()
 					if err != nil {
-						m.logger.Debug("Error when resending expired emoji reactions", zap.Error(err))
+						m.logger.Debug("failed to resend expired message", zap.Error(err))
 					}
 				}
 			case <-m.quit:

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -72,9 +72,10 @@ func newMessengerWithKey(shh types.Waku, privateKey *ecdsa.PrivateKey, logger *z
 	options = append(options, extraOptions...)
 
 	m, err := newTestMessenger(shh, testMessengerConfig{
-		privateKey: privateKey,
-		logger:     logger,
-	}, options)
+		privateKey:   privateKey,
+		logger:       logger,
+		extraOptions: options,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -81,7 +81,7 @@ func newTestMessenger(waku types.Waku, config testMessengerConfig) (*Messenger, 
 		WithToplevelDatabaseMigrations(),
 		WithBrowserDatabase(nil),
 	}
-	options = append(options, extraOptions...)
+	options = append(options, config.extraOptions...)
 
 	m, err := NewMessenger(
 		config.name,

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -25,7 +25,7 @@ type testMessengerConfig struct {
 	logger     *zap.Logger
 
 	unhandledMessagesTracker *unhandledMessagesTracker
-	extraOptions []Option
+	extraOptions             []Option
 }
 
 func (tmc *testMessengerConfig) complete() error {

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -25,6 +25,7 @@ type testMessengerConfig struct {
 	logger     *zap.Logger
 
 	unhandledMessagesTracker *unhandledMessagesTracker
+	extraOptions []Option
 }
 
 func (tmc *testMessengerConfig) complete() error {
@@ -42,13 +43,13 @@ func (tmc *testMessengerConfig) complete() error {
 
 	if tmc.logger == nil {
 		logger := tt.MustCreateTestLogger()
-		tmc.logger = logger.With(zap.String("name", tmc.name))
+		tmc.logger = logger.Named(tmc.name)
 	}
 
 	return nil
 }
 
-func newTestMessenger(waku types.Waku, config testMessengerConfig, extraOptions []Option) (*Messenger, error) {
+func newTestMessenger(waku types.Waku, config testMessengerConfig) (*Messenger, error) {
 	err := config.complete()
 	if err != nil {
 		return nil, err

--- a/protocol/messenger_chats.go
+++ b/protocol/messenger_chats.go
@@ -364,6 +364,13 @@ func (m *Messenger) deleteChat(chatID string) error {
 	if err != nil {
 		return err
 	}
+
+	// We clean the cache to be able to receive the messages again later
+	err = m.transport.ClearProcessedMessageIDsCache()
+	if err != nil {
+		return err
+	}
+
 	chat, ok := m.allChats.Load(chatID)
 
 	if ok && chat.Active && chat.Public() {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1046,7 +1046,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 			return nil, err
 		}
 		if !permissions.Satisfied {
-			return nil, errors.New("permission to join not satisfied")
+			return nil, communities.ErrPermissionToJoinNotSatisfied
 		}
 
 		for _, accountAndChainIDs := range permissions.ValidCombinations {

--- a/protocol/messenger_offline_test.go
+++ b/protocol/messenger_offline_test.go
@@ -90,6 +90,9 @@ func (s *MessengerOfflineSuite) newMessenger(waku types.Waku, logger *zap.Logger
 	return newTestCommunitiesMessenger(&s.Suite, waku, testCommunitiesMessengerConfig{
 		testMessengerConfig: testMessengerConfig{
 			logger: s.logger,
+			extraOptions: []Option{
+				WithResendParams(3, 3),
+			},
 		},
 	})
 }

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -191,24 +191,8 @@ func (s *MessengerStoreNodeRequestSuite) newMessenger(shh types.Waku, logger *za
 	privateKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 
-	mailserversSQLDb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
-	s.Require().NoError(err)
-
-	mailserversDatabase := mailserversDB.NewDB(mailserversSQLDb)
-	err = mailserversDatabase.Add(mailserversDB.Mailserver{
-		ID:      localMailserverID,
-		Name:    localMailserverID,
-		Address: mailserverAddress,
-		Fleet:   localFleet,
-	})
-	s.Require().NoError(err)
-
 	options := []Option{
-		WithMailserversDatabase(mailserversDatabase),
-		WithClusterConfig(params.ClusterConfig{
-			Fleet: localFleet,
-		}),
-		WithCommunityTokensService(s.collectiblesServiceMock),
+		WithTestStoreNode(&s.Suite, localMailserverID, mailserverAddress, localFleet, s.collectiblesServiceMock),
 	}
 
 	messenger, err := newMessengerWithKey(shh, privateKey, logger, options)
@@ -617,7 +601,6 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestShardAndCommunityInfo() {
 	s.createOwner()
 	s.createBob()
 
-	s.waitForAvailableStoreNode(s.owner)
 	community := s.createCommunity(s.owner)
 
 	expectedShard := &shard.Shard{

--- a/protocol/messenger_sync_settings_test.go
+++ b/protocol/messenger_sync_settings_test.go
@@ -134,7 +134,9 @@ func (s *MessengerSyncSettingsSuite) newMessenger() *Messenger {
 		Currency:                  "eth",
 	}
 
-	m, err := newTestMessenger(s.shh, testMessengerConfig{}, []Option{WithAppSettings(setting, config)})
+	m, err := newTestMessenger(s.shh, testMessengerConfig{
+		extraOptions: []Option{WithAppSettings(setting, config)},
+	})
 	s.Require().NoError(err)
 	return m
 }

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -314,7 +314,7 @@ func NewWakuV2(s *suite.Suite, logger *zap.Logger, useLocalWaku bool, enableStor
 func CreateWakuV2Network(s *suite.Suite, parentLogger *zap.Logger, useShardAsDefaultTopic bool, nodeNames []string) []types.Waku {
 	nodes := make([]*waku2.Waku, len(nodeNames))
 	for i, name := range nodeNames {
-		logger := parentLogger.With(zap.String("name", name+"-waku"))
+		logger := parentLogger.Named(name + "-waku")
 		wakuNode := NewWakuV2(s, logger, true, false, useShardAsDefaultTopic, 0)
 		nodes[i] = wakuNode
 	}

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -608,6 +608,7 @@ func (t *Transport) waitForRequestCompleted(ctx context.Context, requestID []byt
 // ConfirmMessagesProcessed marks the messages as processed in the cache so
 // they won't be passed to the next layer anymore
 func (t *Transport) ConfirmMessagesProcessed(ids []string, timestamp uint64) error {
+	t.logger.Debug("confirming message processed", zap.Any("ids", ids), zap.Any("timestamp", timestamp))
 	return t.cache.Add(ids, timestamp)
 }
 
@@ -625,6 +626,8 @@ func (t *Transport) SetEnvelopeEventsHandler(handler EnvelopeEventsHandler) erro
 }
 
 func (t *Transport) ClearProcessedMessageIDsCache() error {
+	t.logger.Debug("clearing processed messages cache")
+	t.waku.ClearEnvelopesCache()
 	return t.cache.Clear()
 }
 

--- a/waku/waku.go
+++ b/waku/waku.go
@@ -1580,6 +1580,12 @@ func (w *Waku) MarkP2PMessageAsProcessed(hash gethcommon.Hash) {
 	delete(w.p2pMsgIDs, hash)
 }
 
+func (w *Waku) ClearEnvelopesCache() {
+	w.poolMu.Lock()
+	defer w.poolMu.Unlock()
+	w.envelopes = make(map[gethcommon.Hash]*common.Envelope)
+}
+
 func (w *Waku) Clean() error {
 	w.poolMu.Lock()
 	defer w.poolMu.Unlock()

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1506,6 +1506,12 @@ func (w *Waku) IsEnvelopeCached(hash gethcommon.Hash) bool {
 	return exist
 }
 
+func (w *Waku) ClearEnvelopesCache() {
+	w.poolMu.Lock()
+	defer w.poolMu.Unlock()
+	w.envelopes = make(map[gethcommon.Hash]*common.ReceivedMessage)
+}
+
 func (w *Waku) PeerCount() int {
 	return w.node.PeerCount()
 }


### PR DESCRIPTION
➡️  PRO TIP: Review by commits 🤓 

# Description

When a user leaves or gets auto-kicked from a token-gated community, all of the messages are deleted from the database. These messages should be fetched again if the user rejoins the community, but waku envelopes cache prevented this.

Because we don't have a `messageId` -> `envelopeHash` information, we clear the whole cache.

"Clearing envelopes cache" consists 2 operations:
  - clear in-memory `waku.envelopes` cache
  - clear in-database `transport_message_cache` table

# Main things done:

1. Implement and expose methods for clearing waku in-memory envelopes cache
1. Clean waku enveloeps cache when deleting a chat from database
3. Update `TestBecomeMemberPermissions` to check that messages are there after rejoining the community
4. Remove `WithResendParams(3, 3)` option from communities tests

# Minor refactoring on the way:

1. Move `newTestMessenger` `extraOptions` argument to `testMessengerConfig`
6. Implement `WithTestStoreNode` messenger option, which should be used in tests
7. Define `ErrPermissionToJoinNotSatisfied` instead of duplicating `permission to join not satisfied` string
8. Use `logger.Named` instead of `logger.With(zap.String("name", ...)`

Fixes https://github.com/status-im/status-desktop/issues/11686