### PR TITLE
fix: remove store node envelopes ordering hotfix

### DIFF
--- a/contracts/contracts.go
+++ b/contracts/contracts.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/contracts/balancechecker"
 	"github.com/status-im/status-go/contracts/directory"
 	"github.com/status-im/status-go/contracts/ethscan"
-	"github.com/status-im/status-go/contracts/balancechecker"
 	"github.com/status-im/status-go/contracts/hop"
 	hopBridge "github.com/status-im/status-go/contracts/hop/bridge"
 	hopSwap "github.com/status-im/status-go/contracts/hop/swap"

--- a/protocol/messenger_store_node_request_manager_config.go
+++ b/protocol/messenger_store_node_request_manager_config.go
@@ -21,10 +21,6 @@ func defaultStoreNodeRequestConfig() StoreNodeRequestConfig {
 func buildStoreNodeRequestConfig(opts []StoreNodeRequestOption) StoreNodeRequestConfig {
 	cfg := defaultStoreNodeRequestConfig()
 
-	// TODO: remove these 2 when fixed: https://github.com/waku-org/nwaku/issues/2317
-	opts = append(opts, WithStopWhenDataFound(false))
-	opts = append(opts, WithInitialPageSize(defaultStoreNodeRequestPageSize))
-
 	for _, opt := range opts {
 		opt(&cfg)
 	}

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -685,10 +685,11 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestCommunityEnvelopesOrder() {
 	s.createOwner()
 	s.createBob()
 
+	const descriptionsCount = 4
 	community := s.createCommunity(s.owner)
 
-	// Push 5 descriptions to the store node
-	for i := 0; i < 4; i++ {
+	// Push a few descriptions to the store node
+	for i := 0; i < descriptionsCount-1; i++ {
 		err := s.owner.publishOrg(community)
 		s.Require().NoError(err)
 	}
@@ -699,15 +700,17 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestCommunityEnvelopesOrder() {
 	contentTopic := wakuV2common.BytesToTopic(transport.ToTopic(community.IDString()))
 
 	var prevEnvelope *wakuV2common.ReceivedMessage
+	receivedEnvelopesCount := 0
 
 	s.setupEnvelopesWatcher(bobWakuV2, &contentTopic, func(envelope *wakuV2common.ReceivedMessage) {
 		// We check that each next envelope fetched is newer than the previous one
 		if prevEnvelope != nil {
-			s.Require().Greater(
+			s.Require().Less(
 				envelope.Envelope.Message().GetTimestamp(),
 				prevEnvelope.Envelope.Message().GetTimestamp())
 		}
 		prevEnvelope = envelope
+		receivedEnvelopesCount += 1
 	})
 
 	// Force a single-envelope page size to be able to check the order.
@@ -725,6 +728,9 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestCommunityEnvelopesOrder() {
 	fetchedCommunity, _, err := s.bob.storeNodeRequestsManager.FetchCommunity(community.CommunityShard(), options)
 	s.Require().NoError(err)
 	s.requireCommunitiesEqual(fetchedCommunity, community)
+
+	// Ensure all expected envelopes were received
+	s.Require().Equal(receivedEnvelopesCount, descriptionsCount)
 }
 
 /*

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -710,7 +710,7 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestCommunityEnvelopesOrder() {
 				prevEnvelope.Envelope.Message().GetTimestamp())
 		}
 		prevEnvelope = envelope
-		receivedEnvelopesCount += 1
+		receivedEnvelopesCount++
 	})
 
 	// Force a single-envelope page size to be able to check the order.

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -455,7 +455,7 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestCommunityPagingAlgorithm() {
 	// First we fetch a more up-to-date, but an invalid spam message, fail to decrypt it as community description,
 	// then we fetch another page of data and successfully decrypt a community description.
 	s.Require().Equal(spamAmount+1, stats.FetchedEnvelopesCount)
-	s.Require().Equal(2, stats.FetchedPagesCount) // TODO: revert to 3 when fixed: https://github.com/waku-org/nwaku/issues/2317
+	s.Require().Equal(3, stats.FetchedPagesCount)
 }
 
 func (s *MessengerStoreNodeRequestSuite) TestRequestCommunityWithSameContentTopic() {


### PR DESCRIPTION
The issue has been addressed in nwaku implementation and deployed to all fleets.

nwaku issue: https://github.com/waku-org/nwaku/issues/2317