### PR TITLE
feat: new endpoint added which returns accounts of all contacts that match the passed address

### DIFF
--- a/protocol/contact.go
+++ b/protocol/contact.go
@@ -380,9 +380,12 @@ func buildContact(publicKeyString string, publicKey *ecdsa.PublicKey) (*Contact,
 		return nil, err
 	}
 
+	address := crypto.PubkeyToAddress(*publicKey)
+
 	contact := &Contact{
-		ID:    publicKeyString,
-		Alias: getShortenedCompressedKey(compressedKey),
+		ID:      publicKeyString,
+		Alias:   getShortenedCompressedKey(compressedKey),
+		Address: types.EncodeHex(address[:]),
 	}
 
 	return contact, nil

--- a/protocol/messenger_profile_showcase.go
+++ b/protocol/messenger_profile_showcase.go
@@ -217,6 +217,10 @@ func (m *Messenger) GetProfileShowcaseForContact(contactID string) (*ProfileShow
 	return m.persistence.GetProfileShowcaseForContact(contactID)
 }
 
+func (m *Messenger) GetProfileShowcaseAccountsByAddress(address string) ([]*ProfileShowcaseAccount, error) {
+	return m.persistence.GetProfileShowcaseAccountsByAddress(address)
+}
+
 func (m *Messenger) EncryptProfileShowcaseEntriesWithContactPubKeys(entries *protobuf.ProfileShowcaseEntries, contacts []*Contact) (*protobuf.ProfileShowcaseEntriesEncrypted, error) {
 	// Make AES key
 	AESKey := make([]byte, 32)

--- a/protocol/persistence_profile_showcase_test.go
+++ b/protocol/persistence_profile_showcase_test.go
@@ -142,18 +142,20 @@ func (s *TestProfileShowcasePersistence) TestProfileShowcaseContacts() {
 		},
 		Accounts: []*ProfileShowcaseAccount{
 			&ProfileShowcaseAccount{
-				Address: "0x32433445133424",
-				Name:    "Status Account",
-				ColorID: "blue",
-				Emoji:   "-_-",
-				Order:   0,
+				ContactID: "contact_1",
+				Address:   "0x32433445133424",
+				Name:      "Status Account",
+				ColorID:   "blue",
+				Emoji:     "-_-",
+				Order:     0,
 			},
 			&ProfileShowcaseAccount{
-				Address: "0x3845354643324",
-				Name:    "Money Box",
-				ColorID: "red",
-				Emoji:   ":o)",
-				Order:   1,
+				ContactID: "contact_1",
+				Address:   "0x3845354643324",
+				Name:      "Money Box",
+				ColorID:   "red",
+				Emoji:     ":o)",
+				Order:     1,
 			},
 		},
 		Collectibles: []*ProfileShowcaseCollectible{
@@ -257,4 +259,118 @@ func (s *TestProfileShowcasePersistence) TestProfileShowcaseContacts() {
 	s.Require().Equal(0, len(showcase2Back.Accounts))
 	s.Require().Equal(0, len(showcase2Back.VerifiedTokens))
 	s.Require().Equal(0, len(showcase2Back.UnverifiedTokens))
+}
+
+func (s *TestProfileShowcasePersistence) TestFetchingProfileShowcaseAccountsByAddress() {
+	db, err := openTestDB()
+	s.Require().NoError(err)
+	persistence := newSQLitePersistence(db)
+
+	conatacts := []*Contact{
+		&Contact{
+			ID: "contact_1",
+		},
+		&Contact{
+			ID: "contact_2",
+		},
+		&Contact{
+			ID: "contact_3",
+		},
+	}
+
+	err = persistence.SaveContacts(conatacts)
+	s.Require().NoError(err)
+
+	showcase1 := &ProfileShowcase{
+		ContactID: "contact_1",
+		Accounts: []*ProfileShowcaseAccount{
+			&ProfileShowcaseAccount{
+				ContactID: "contact_1",
+				Address:   "0x0000000000000000000000000000000000000001",
+				Name:      "Contact1-Account1",
+				ColorID:   "blue",
+				Emoji:     "-_-",
+				Order:     0,
+			},
+			&ProfileShowcaseAccount{
+				ContactID: "contact_1",
+				Address:   "0x0000000000000000000000000000000000000002",
+				Name:      "Contact1-Account2",
+				ColorID:   "blue",
+				Emoji:     "-_-",
+				Order:     1,
+			},
+		},
+	}
+	showcase2 := &ProfileShowcase{
+		ContactID: "contact_2",
+		Accounts: []*ProfileShowcaseAccount{
+			&ProfileShowcaseAccount{
+				ContactID: "contact_2",
+				Address:   "0x0000000000000000000000000000000000000001",
+				Name:      "Contact2-Account1",
+				ColorID:   "blue",
+				Emoji:     "-_-",
+				Order:     0,
+			},
+			&ProfileShowcaseAccount{
+				ContactID: "contact_2",
+				Address:   "0x0000000000000000000000000000000000000002",
+				Name:      "Contact2-Account2",
+				ColorID:   "blue",
+				Emoji:     "-_-",
+				Order:     1,
+			},
+		},
+	}
+	showcase3 := &ProfileShowcase{
+		ContactID: "contact_3",
+		Accounts: []*ProfileShowcaseAccount{
+			&ProfileShowcaseAccount{
+				ContactID: "contact_3",
+				Address:   "0x0000000000000000000000000000000000000001",
+				Name:      "Contact3-Account1",
+				ColorID:   "blue",
+				Emoji:     "-_-",
+				Order:     0,
+			},
+		},
+	}
+
+	err = persistence.SaveProfileShowcaseForContact(showcase1)
+	s.Require().NoError(err)
+	err = persistence.SaveProfileShowcaseForContact(showcase2)
+	s.Require().NoError(err)
+	err = persistence.SaveProfileShowcaseForContact(showcase3)
+	s.Require().NoError(err)
+
+	showcaseAccounts, err := persistence.GetProfileShowcaseAccountsByAddress(showcase1.Accounts[0].Address)
+	s.Require().NoError(err)
+
+	s.Require().Equal(3, len(showcaseAccounts))
+	for i := 0; i < len(showcaseAccounts); i++ {
+		if showcaseAccounts[i].ContactID == showcase1.ContactID {
+			s.Require().Equal(showcase1.Accounts[0].Address, showcase1.Accounts[0].Address)
+		} else if showcaseAccounts[i].ContactID == showcase2.ContactID {
+			s.Require().Equal(showcase2.Accounts[0].Address, showcase2.Accounts[0].Address)
+		} else if showcaseAccounts[i].ContactID == showcase3.ContactID {
+			s.Require().Equal(showcase3.Accounts[0].Address, showcase3.Accounts[0].Address)
+		} else {
+			s.Require().Fail("unexpected contact id")
+		}
+	}
+
+	showcaseAccounts, err = persistence.GetProfileShowcaseAccountsByAddress(showcase1.Accounts[1].Address)
+	s.Require().NoError(err)
+
+	s.Require().Equal(2, len(showcaseAccounts))
+	for i := 0; i < len(showcaseAccounts); i++ {
+		if showcaseAccounts[i].ContactID == showcase1.ContactID {
+			s.Require().Equal(showcase1.Accounts[0].Address, showcase1.Accounts[0].Address)
+		} else if showcaseAccounts[i].ContactID == showcase2.ContactID {
+			s.Require().Equal(showcase2.Accounts[0].Address, showcase2.Accounts[0].Address)
+		} else {
+			s.Require().Fail("unexpected contact id")
+		}
+	}
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1668,6 +1668,11 @@ func (api *PublicAPI) GetProfileShowcaseForContact(contactID string) (*protocol.
 	return api.service.messenger.GetProfileShowcaseForContact(contactID)
 }
 
+// Get profile showcase accounts by address
+func (api *PublicAPI) GetProfileShowcaseAccountsByAddress(address string) ([]*protocol.ProfileShowcaseAccount, error) {
+	return api.service.messenger.GetProfileShowcaseAccountsByAddress(address)
+}
+
 // Returns response with AC notification when owner token is received
 func (api *PublicAPI) RegisterOwnerTokenReceivedNotification(communityID string) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.CreateResponseWithACNotification(communityID, protocol.ActivityCenterNotificationTypeOwnerTokenReceived, false)


### PR DESCRIPTION
We need this on the desktop app side, for the case when the user is about to add a new address to the saved addresses list, we need to check if that address belongs to any of his contacts, which means we need to check the list of profile showcases accounts of all of the users' contacts.