### PR TITLE
Fix/outdated community shard key msgs

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1075,9 +1075,9 @@ func (m *Manager) DeleteCommunity(id types.HexBytes) error {
 	return m.persistence.DeleteCommunitySettings(id)
 }
 
-func (m *Manager) UpdateShard(community *Community, shard *shard.Shard) error {
+func (m *Manager) UpdateShard(community *Community, shard *shard.Shard, clock uint64) error {
 	community.config.Shard = shard
-	return m.persistence.SaveCommunityShard(community.ID(), shard, community.Clock())
+	return m.persistence.SaveCommunityShard(community.ID(), shard, clock)
 }
 
 // SetShard assigns a shard to a community
@@ -1092,7 +1092,7 @@ func (m *Manager) SetShard(communityID types.HexBytes, shard *shard.Shard) (*Com
 
 	community.increaseClock()
 
-	err = m.UpdateShard(community, shard)
+	err = m.UpdateShard(community, shard, community.Clock())
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -178,6 +178,9 @@ type Messenger struct {
 	// used to track dispatched messages
 	dispatchMessageTestCallback func(common.RawMessage)
 
+	// used to track unhandled messages
+	unhandledMessagesTracker func(*v1protocol.StatusMessage, error)
+
 	peersyncing         *peersyncing.PeerSyncing
 	peersyncingOffers   map[string]uint64
 	peersyncingRequests map[string]uint64
@@ -3836,6 +3839,9 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 					if err != nil {
 						allMessagesProcessed = false
 						logger.Warn("failed to process protobuf", zap.Error(err))
+						if m.unhandledMessagesTracker != nil {
+							m.unhandledMessagesTracker(msg, err)
+						}
 						continue
 					}
 					logger.Debug("Handled parsed message")

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/status-im/status-go/multiaccounts/settings"
 	walletsettings "github.com/status-im/status-go/multiaccounts/settings_wallet"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/identity"
@@ -1636,7 +1635,14 @@ func (m *Messenger) HandleCommunityRequestToJoinResponse(state *ReceivedMessageS
 			return err
 		}
 
-		err = m.handleCommunityShardAndFiltersFromProto(community, shard.FromProtobuff(requestToJoinResponseProto.Shard), requestToJoinResponseProto.ProtectedTopicPrivateKey)
+		communityShardKey := &protobuf.CommunityShardKey{
+			CommunityId: requestToJoinResponseProto.CommunityId,
+			PrivateKey:  requestToJoinResponseProto.ProtectedTopicPrivateKey,
+			Clock:       requestToJoinResponseProto.Community.Clock,
+			Shard:       requestToJoinResponseProto.Shard,
+		}
+
+		err = m.handleCommunityShardAndFiltersFromProto(community, communityShardKey)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
fix: ignore outdated COMMUNITY_SHARD_KEY messages 

This mitigates issue where community shard on client's side was not in
sync with owner's.

relates to: status-im/status-desktop#13217