### PR TITLE
fix: fetch history when back online

### DIFF
--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -309,7 +309,9 @@ func (m *Messenger) resetFiltersPriority(filters []*transport.Filter) {
 }
 
 func (m *Messenger) RequestAllHistoricMessagesWithRetries(forceFetchingBackup bool) (*MessengerResponse, error) {
-	return m.performMailserverRequest(func() (*MessengerResponse, error) { return m.RequestAllHistoricMessages(forceFetchingBackup) })
+	return m.performMailserverRequest(func() (*MessengerResponse, error) {
+		return m.RequestAllHistoricMessages(forceFetchingBackup)
+	})
 }
 
 // RequestAllHistoricMessages requests all the historic messages for any topic

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1218,7 +1218,9 @@ func (w *Waku) Start() error {
 			case c := <-w.connStatusChan:
 				w.connStatusMu.Lock()
 				latestConnStatus := formatConnStatus(w.node, c)
-				w.logger.Debug("PeerStats", zap.Any("stats", latestConnStatus))
+				w.logger.Debug("peer stats",
+					zap.Int("peersCount", len(latestConnStatus.Peers)),
+					zap.Any("stats", latestConnStatus))
 				for k, subs := range w.connStatusSubscriptions {
 					if subs.Active() {
 						subs.C <- latestConnStatus
@@ -1355,6 +1357,7 @@ func (w *Waku) OnNewEnvelopes(envelope *protocol.Envelope, msgType common.Messag
 	}
 
 	logger := w.logger.With(
+		zap.Any("messageType", msgType),
 		zap.String("envelopeHash", hexutil.Encode(envelope.Hash())),
 		zap.String("contentTopic", envelope.Message().ContentTopic),
 		zap.Int64("timestamp", envelope.Message().GetTimestamp()),


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/13270

If internet connection was lost, we should make a history request to get the missed messages.
https://github.com/status-im/status-go/blob/c2823b6d1caee005ebd80142f7edf96a08a8986f/protocol/messenger.go#L948-L951

Also made some minor refactoring and added some useful logs on the way.