### PR TITLE
feat(wallet) use sql activity filter for incremental updates

### DIFF
--- a/services/wallet/activity/activity.go
+++ b/services/wallet/activity/activity.go
@@ -68,6 +68,8 @@ type Entry struct {
 	chainIDIn       *common.ChainID
 	transferType    *TransferType
 	contractAddress *eth.Address
+
+	isNew bool
 }
 
 // Only used for JSON marshalling
@@ -90,6 +92,8 @@ type EntryData struct {
 	ChainIDIn       *common.ChainID                  `json:"chainIdIn,omitempty"`
 	TransferType    *TransferType                    `json:"transferType,omitempty"`
 	ContractAddress *eth.Address                     `json:"contractAddress,omitempty"`
+
+	IsNew *bool `json:"isNew,omitempty"`
 
 	NftName *string `json:"nftName,omitempty"`
 	NftURL  *string `json:"nftUrl,omitempty"`
@@ -121,6 +125,9 @@ func (e *Entry) MarshalJSON() ([]byte, error) {
 	}
 
 	data.PayloadType = e.payloadType
+	if e.isNew {
+		data.IsNew = &e.isNew
+	}
 
 	return json.Marshal(data)
 }
@@ -155,6 +162,9 @@ func (e *Entry) UnmarshalJSON(data []byte) error {
 	e.chainIDOut = aux.ChainIDOut
 	e.chainIDIn = aux.ChainIDIn
 	e.transferType = aux.TransferType
+
+	e.isNew = aux.IsNew != nil && *aux.IsNew
+
 	return nil
 }
 
@@ -229,6 +239,14 @@ func (e *Entry) anyIdentity() *thirdparty.CollectibleUniqueID {
 		}
 	}
 	return nil
+}
+
+func (e *Entry) getIdentity() EntryIdentity {
+	return EntryIdentity{
+		payloadType: e.payloadType,
+		id:          e.id,
+		transaction: e.transaction,
+	}
 }
 
 func multiTransactionTypeToActivityType(mtType transfer.MultiTransactionType) Type {

--- a/services/wallet/activity/service.go
+++ b/services/wallet/activity/service.go
@@ -376,7 +376,7 @@ func sendResponseEvent(eventFeed *event.Feed, requestID *int32, eventType wallet
 		err = resErr
 	}
 
-	requestIDStr := "nil"
+	requestIDStr := nilStr
 	if requestID != nil {
 		requestIDStr = strconv.Itoa(int(*requestID))
 	}

--- a/services/wallet/activity/session_test.go
+++ b/services/wallet/activity/session_test.go
@@ -1,0 +1,107 @@
+package activity
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/transfer"
+)
+
+// TODO #12120: cover missing cases
+func TestFindUpdates(t *testing.T) {
+	txIds := []transfer.TransactionIdentity{
+		transfer.TransactionIdentity{
+			ChainID: 1,
+			Hash:    common.HexToHash("0x1234"),
+			Address: common.HexToAddress("0x1234"),
+		},
+	}
+
+	type findUpdatesResult struct {
+		new     []mixedIdentityResult
+		removed []EntryIdentity
+	}
+
+	tests := []struct {
+		name       string
+		identities []EntryIdentity
+		updated    []Entry
+		want       findUpdatesResult
+	}{
+		{
+			name:       "Empty to single MT update",
+			identities: []EntryIdentity{},
+			updated: []Entry{
+				{payloadType: MultiTransactionPT, id: 1},
+			},
+			want: findUpdatesResult{
+				new: []mixedIdentityResult{{0, EntryIdentity{payloadType: MultiTransactionPT, id: 1}}},
+			},
+		},
+		{
+			name: "No updates",
+			identities: []EntryIdentity{
+				EntryIdentity{
+					payloadType: SimpleTransactionPT, transaction: &txIds[0],
+				},
+			},
+			updated: []Entry{
+				{payloadType: SimpleTransactionPT, transaction: &txIds[0]},
+			},
+			want: findUpdatesResult{},
+		},
+		{
+			name:       "Empty to mixed updates",
+			identities: []EntryIdentity{},
+			updated: []Entry{
+				{payloadType: MultiTransactionPT, id: 1},
+				{payloadType: PendingTransactionPT, transaction: &txIds[0]},
+			},
+			want: findUpdatesResult{
+				new: []mixedIdentityResult{{0, EntryIdentity{payloadType: MultiTransactionPT, id: 1}},
+					{1, EntryIdentity{payloadType: PendingTransactionPT, transaction: &txIds[0]}},
+				},
+			},
+		},
+		{
+			name: "Add one on top of one",
+			identities: []EntryIdentity{
+				EntryIdentity{
+					payloadType: MultiTransactionPT, id: 1,
+				},
+			},
+			updated: []Entry{
+				{payloadType: PendingTransactionPT, transaction: &txIds[0]},
+				{payloadType: MultiTransactionPT, id: 1},
+			},
+			want: findUpdatesResult{
+				new: []mixedIdentityResult{{0, EntryIdentity{payloadType: PendingTransactionPT, transaction: &txIds[0]}}},
+			},
+		},
+		{
+			name: "Add one on top keep window",
+			identities: []EntryIdentity{
+				EntryIdentity{payloadType: MultiTransactionPT, id: 1},
+				EntryIdentity{payloadType: PendingTransactionPT, transaction: &txIds[0]},
+			},
+			updated: []Entry{
+				{payloadType: MultiTransactionPT, id: 2},
+				{payloadType: MultiTransactionPT, id: 1},
+			},
+			want: findUpdatesResult{
+				new:     []mixedIdentityResult{{0, EntryIdentity{payloadType: MultiTransactionPT, id: 2}}},
+				removed: []EntryIdentity{EntryIdentity{payloadType: PendingTransactionPT, transaction: &txIds[0]}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNew, gotRemoved := findUpdates(tt.identities, tt.updated)
+			if !reflect.DeepEqual(gotNew, tt.want.new) || !reflect.DeepEqual(gotRemoved, tt.want.removed) {
+				t.Errorf("findUpdates() = %v, %v, want %v, %v", gotNew, gotRemoved, tt.want.new, tt.want.removed)
+			}
+		})
+	}
+}

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -602,6 +602,12 @@ func (api *API) StartActivityFilterSession(addresses []common.Address, allAddres
 	return api.s.activity.StartFilterSession(addresses, allAddresses, chainIDs, filter, firstPageCount), nil
 }
 
+func (api *API) ResetFilterSession(id activity.SessionID, firstPageCount int) error {
+	log.Debug("wallet.api.ResetFilterSession", "id", id, "firstPageCount", firstPageCount)
+
+	return api.s.activity.ResetFilterSession(id, firstPageCount)
+}
+
 func (api *API) StopActivityFilterSession(id activity.SessionID) {
 	log.Debug("wallet.api.StopActivityFilterSession", "id", id)
 

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -241,6 +241,15 @@ var TestTokens = []*token.Token{
 	&EthMainnet, &EthGoerli, &EthOptimism, &UsdcMainnet, &UsdcGoerli, &UsdcOptimism, &SntMainnet, &DaiMainnet, &DaiGoerli,
 }
 
+func LookupTokenIdentity(chainID uint64, address eth_common.Address, native bool) *token.Token {
+	for _, token := range TestTokens {
+		if token.ChainID == chainID && token.Address == address && token.IsNative() == native {
+			return token
+		}
+	}
+	return nil
+}
+
 var NativeTokenIndices = []int{0, 1, 2}
 
 func InsertTestTransfer(tb testing.TB, db *sql.DB, address eth_common.Address, tr *TestTransfer) {

--- a/transactions/pendingtxtracker_test.go
+++ b/transactions/pendingtxtracker_test.go
@@ -138,7 +138,7 @@ func TestPendingTxTracker_InterruptWatching(t *testing.T) {
 	m, stop, chainClient, eventFeed := setupTestTransactionDB(t, nil)
 	defer stop()
 
-	txs := GenerateTestPendingTransactions(2)
+	txs := GenerateTestPendingTransactions(0, 2)
 
 	// Mock the first call to getTransactionByHash
 	chainClient.SetAvailableClients([]common.ChainID{txs[0].ChainID})
@@ -259,7 +259,7 @@ func TestPendingTxTracker_MultipleClients(t *testing.T) {
 	m, stop, chainClient, eventFeed := setupTestTransactionDB(t, nil)
 	defer stop()
 
-	txs := GenerateTestPendingTransactions(2)
+	txs := GenerateTestPendingTransactions(0, 2)
 	txs[1].ChainID++
 
 	// Mock the both clients to be available
@@ -344,7 +344,7 @@ func TestPendingTxTracker_Watch(t *testing.T) {
 	m, stop, chainClient, eventFeed := setupTestTransactionDB(t, nil)
 	defer stop()
 
-	txs := GenerateTestPendingTransactions(2)
+	txs := GenerateTestPendingTransactions(0, 2)
 	// Make the second already confirmed
 	*txs[0].Status = Success
 
@@ -428,7 +428,7 @@ func TestPendingTxTracker_Watch_StatusChangeIncrementally(t *testing.T) {
 	m, stop, chainClient, eventFeed := setupTestTransactionDB(t, common.NewAndSet(1*time.Nanosecond))
 	defer stop()
 
-	txs := GenerateTestPendingTransactions(2)
+	txs := GenerateTestPendingTransactions(0, 2)
 
 	var firsDoneWG sync.WaitGroup
 	firsDoneWG.Add(1)
@@ -544,7 +544,7 @@ func TestPendingTransactions(t *testing.T) {
 	manager, stop, _, _ := setupTestTransactionDB(t, nil)
 	defer stop()
 
-	tx := GenerateTestPendingTransactions(1)[0]
+	tx := GenerateTestPendingTransactions(0, 1)[0]
 
 	rst, err := manager.GetAllPending()
 	require.NoError(t, err)

--- a/transactions/testhelpers.go
+++ b/transactions/testhelpers.go
@@ -54,27 +54,27 @@ func (m *MockChainClient) AbstractEthClient(chainID common.ChainID) (chain.Batch
 	return m.Clients[chainID], nil
 }
 
-func GenerateTestPendingTransactions(count int) []PendingTransaction {
+func GenerateTestPendingTransactions(start int, count int) []PendingTransaction {
 	if count > 127 {
 		panic("can't generate more than 127 distinct transactions")
 	}
 
 	txs := make([]PendingTransaction, count)
-	for i := 0; i < count; i++ {
-		// Avoid generating zero values hash and addresses
-		seed := i + 1
+	for i := start; i < count; i++ {
 		txs[i] = PendingTransaction{
-			Hash:           eth.Hash{byte(seed)},
-			From:           eth.Address{byte(seed)},
-			To:             eth.Address{byte(seed * 2)},
+			Hash:           eth.HexToHash(fmt.Sprintf("0x1%d", i)),
+			From:           eth.HexToAddress(fmt.Sprintf("0x2%d", i)),
+			To:             eth.HexToAddress(fmt.Sprintf("0x3%d", i)),
 			Type:           RegisterENS,
 			AdditionalData: "someuser.stateofus.eth",
-			Value:          bigint.BigInt{Int: big.NewInt(int64(seed))},
+			Value:          bigint.BigInt{Int: big.NewInt(int64(i))},
 			GasLimit:       bigint.BigInt{Int: big.NewInt(21000)},
-			GasPrice:       bigint.BigInt{Int: big.NewInt(int64(seed))},
+			GasPrice:       bigint.BigInt{Int: big.NewInt(int64(i))},
 			ChainID:        777,
 			Status:         new(TxStatus),
 			AutoDelete:     new(bool),
+			Symbol:         "ETH",
+			Timestamp:      uint64(i),
 		}
 		*txs[i].Status = Pending  // set to pending by default
 		*txs[i].AutoDelete = true // set to true by default
@@ -84,40 +84,56 @@ func GenerateTestPendingTransactions(count int) []PendingTransaction {
 
 type TestTxSummary struct {
 	failStatus  bool
-	dontConfirm bool
+	DontConfirm bool
+	// Timestamp will be used to mock the Timestamp if greater than 0
+	Timestamp int
 }
 
 func MockTestTransactions(t *testing.T, chainClient *MockChainClient, testTxs []TestTxSummary) []PendingTransaction {
-	txs := GenerateTestPendingTransactions(len(testTxs))
+	txs := GenerateTestPendingTransactions(0, len(testTxs))
 
-	// Mock the first call to getTransactionByHash
-	chainClient.SetAvailableClients([]common.ChainID{txs[0].ChainID})
-	cl := chainClient.Clients[txs[0].ChainID]
-	cl.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
-		ok := len(b) == len(testTxs)
-		for i := range b {
-			ok = ok && b[i].Method == GetTransactionReceiptRPCName && b[i].Args[0] == txs[0].Hash
+	for txIdx := range txs {
+		tx := &txs[txIdx]
+		if testTxs[txIdx].Timestamp > 0 {
+			tx.Timestamp = uint64(testTxs[txIdx].Timestamp)
 		}
-		return ok
-	})).Return(nil).Once().Run(func(args mock.Arguments) {
-		elems := args.Get(1).([]rpc.BatchElem)
-		for i := range elems {
-			receiptWrapper, ok := elems[i].Result.(*nullableReceipt)
-			require.True(t, ok)
-			require.NotNil(t, receiptWrapper)
-			// Simulate parsing of eth_getTransactionReceipt response
-			if !testTxs[i].dontConfirm {
-				status := types.ReceiptStatusSuccessful
-				if testTxs[i].failStatus {
-					status = types.ReceiptStatusFailed
-				}
 
-				receiptWrapper.Receipt = &types.Receipt{
-					BlockNumber: new(big.Int).SetUint64(1),
-					Status:      status,
+		// Mock the first call to getTransactionByHash
+		chainClient.SetAvailableClients([]common.ChainID{tx.ChainID})
+		cl := chainClient.Clients[tx.ChainID]
+		call := cl.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
+			ok := len(b) == len(testTxs)
+			for i := range b {
+				ok = ok && b[i].Method == GetTransactionReceiptRPCName && b[i].Args[0] == tx.Hash
+			}
+			return ok
+		})).Return(nil)
+		if testTxs[txIdx].DontConfirm {
+			call = call.Times(0)
+		} else {
+			call = call.Once()
+		}
+
+		call.Run(func(args mock.Arguments) {
+			elems := args.Get(1).([]rpc.BatchElem)
+			for i := range elems {
+				receiptWrapper, ok := elems[i].Result.(*nullableReceipt)
+				require.True(t, ok)
+				require.NotNil(t, receiptWrapper)
+				// Simulate parsing of eth_getTransactionReceipt response
+				if !testTxs[i].DontConfirm {
+					status := types.ReceiptStatusSuccessful
+					if testTxs[i].failStatus {
+						status = types.ReceiptStatusFailed
+					}
+
+					receiptWrapper.Receipt = &types.Receipt{
+						BlockNumber: new(big.Int).SetUint64(1),
+						Status:      status,
+					}
 				}
 			}
-		}
-	})
+		})
+	}
 	return txs
 }


### PR DESCRIPTION
### Updates status-desktop [#12120](https://github.com/status-im/status-desktop/issues/12120)

Switch from the prototype of duplicating the SQL filter as a runtime and keeping them in sync on each event that might invalidate the current filtered entries to a simpler approach of requesting the filter again and doing the diff to detect the new changes.

Also, add a new reset API to model the new entries design requirements.

The new approach shows fewer corner cases to handle and follows one source of truth, making debugging and future maintenance easier.

Other changes

- Fix pending mocking to work with multiple calls
- Refactor tests to account for the new changes