### PR TITLE
fix: full nodes should run filter and lightpush

### DIFF
--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -319,7 +319,6 @@ func (b *StatusNode) wakuV2Service(nodeConfig *params.NodeConfig, telemetryServe
 			Rendezvous:              nodeConfig.Rendezvous,
 			WakuNodes:               nodeConfig.ClusterConfig.WakuNodes,
 			PeerExchange:            nodeConfig.WakuV2Config.PeerExchange,
-			EnableFilterFullNode:    nodeConfig.WakuV2Config.EnableFilterFullNode,
 			EnableStore:             nodeConfig.WakuV2Config.EnableStore,
 			StoreCapacity:           nodeConfig.WakuV2Config.StoreCapacity,
 			StoreSeconds:            nodeConfig.WakuV2Config.StoreSeconds,

--- a/params/config.go
+++ b/params/config.go
@@ -212,9 +212,6 @@ type WakuV2Config struct {
 	// StoreSeconds indicates the maximum number of seconds before a message is removed from the store
 	StoreSeconds int
 
-	// EnableFilterNode indicates if WakuFilter Full Node should be enabled
-	EnableFilterFullNode bool
-
 	// UseShardAsDefaultTopic indicates whether the default shard should be used instead of the default relay topic
 	UseShardAsDefaultTopic bool
 }

--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -51,7 +51,6 @@ type Config struct {
 	StoreCapacity           int              `toml:",omitempty"`
 	StoreSeconds            int              `toml:",omitempty"`
 	TelemetryServerURL      string           `toml:",omitempty"`
-	EnableFilterFullNode    bool             `toml:",omitempty"`
 	DefaultShardPubsubTopic string           `toml:",omitempty"`
 	UseShardAsDefaultTopic  bool             `toml:",omitempty"`
 	ClusterID               uint16           `toml:",omitempty"`

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -57,6 +57,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
+	"github.com/waku-org/go-waku/waku/v2/protocol/filter"
 	"github.com/waku-org/go-waku/waku/v2/protocol/lightpush"
 	"github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
@@ -303,8 +304,9 @@ func New(nodeKey string, fleet string, cfg *Config, logger *zap.Logger, appDB *s
 		opts = append(opts, node.WithMessageProvider(dbStore))
 	}
 
-	if cfg.EnableFilterFullNode {
-		opts = append(opts, node.WithWakuFilterFullNode())
+	if !cfg.LightClient {
+		opts = append(opts, node.WithWakuFilterFullNode(filter.WithMaxSubscribers(20)))
+		opts = append(opts, node.WithLightPush())
 	}
 
 	if appDB != nil {


### PR DESCRIPTION
When running a full node, filter full and lightpush protocols will be mounted. 
This also removes the flag to enable filter since it's expected that a full node would run these protocols.