### PR TITLE
chore: sync history regardless of connection type

### DIFF
--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -51,20 +51,7 @@ func (m *Messenger) shouldSync() (bool, error) {
 		return false, err
 	}
 
-	if !useMailserver {
-		return false, nil
-	}
-
-	if !m.connectionState.IsExpensive() {
-		return true, nil
-	}
-
-	syncingOnMobileNetwork, err := m.settings.CanSyncOnMobileNetwork()
-	if err != nil {
-		return false, err
-	}
-
-	return syncingOnMobileNetwork, nil
+	return useMailserver, nil
 }
 
 func (m *Messenger) scheduleSyncChat(chat *Chat) (bool, error) {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-mobile/issues/18637
According to https://github.com/status-im/status-mobile/issues/18637#issuecomment-1919958341 , this feature is no longer provided, so it can be removed.