### PR TITLE
fix(wallet) prioritize type SendAT for pending entries in activity

### DIFF
--- a/services/wallet/activity/filter.sql
+++ b/services/wallet/activity/filter.sql
@@ -359,11 +359,7 @@ SELECT
 	CASE
 		WHEN from_join.address IS NOT NULL AND to_join.address IS NULL THEN fromTrType
 		WHEN to_join.address IS NOT NULL AND from_join.address IS NULL THEN toTrType
-		WHEN from_join.address IS NOT NULL AND to_join.address IS NOT NULL THEN
-			CASE
-				WHEN from_join.address < to_join.address THEN fromTrType
-				ELSE toTrType
-			END
+		WHEN from_join.address IS NOT NULL AND to_join.address IS NOT NULL THEN fromTrType
 		ELSE NULL
 	END as tr_type,
 	pending_transactions.from_address AS from_address,


### PR DESCRIPTION
In case both to/from addresses are present in the list we were using the same logic as for transfers. However, this doesn't make sense given that we can have only one entry in pending activity.

The following cases are still covered

- When the receiver is in addresses we get received
- When both receiver and sender are in the list will get sent
- When the sender is on the list we will get sent

Updates status-desktop [#12120](https://github.com/status-im/status-desktop/issues/12120)