### PR TITLE
fix(wallet) fix reading amount for pending transactions

### DIFF
--- a/services/wallet/activity/filter.sql
+++ b/services/wallet/activity/filter.sql
@@ -359,11 +359,7 @@ SELECT
 	CASE
 		WHEN from_join.address IS NOT NULL AND to_join.address IS NULL THEN fromTrType
 		WHEN to_join.address IS NOT NULL AND from_join.address IS NULL THEN toTrType
-		WHEN from_join.address IS NOT NULL AND to_join.address IS NOT NULL THEN
-			CASE
-				WHEN from_join.address < to_join.address THEN fromTrType
-				ELSE toTrType
-			END
+		WHEN from_join.address IS NOT NULL AND to_join.address IS NOT NULL THEN fromTrType
 		ELSE NULL
 	END as tr_type,
 	pending_transactions.from_address AS from_address,

--- a/services/wallet/activity/filter.sql
+++ b/services/wallet/activity/filter.sql
@@ -180,6 +180,7 @@ SELECT
 	transfers.tx_to_address AS to_address,
 	transfers.address AS owner_address,
 	transfers.amount_padded128hex AS tr_amount,
+	NULL AS ptr_amount,
 	NULL AS mt_from_amount,
 	NULL AS mt_to_amount,
 	CASE
@@ -365,7 +366,8 @@ SELECT
 	pending_transactions.from_address AS from_address,
 	pending_transactions.to_address AS to_address,
 	NULL AS owner_address,
-	pending_transactions.value AS tr_amount,
+	NULL AS tr_amount,
+	pending_transactions.value AS ptr_amount,
 	NULL AS mt_from_amount,
 	NULL AS mt_to_amount,
 	statusPending AS agg_status,
@@ -442,6 +444,7 @@ SELECT
 	multi_transactions.to_address AS to_address,
 	multi_transactions.from_address AS owner_address,
 	NULL AS tr_amount,
+	NULL AS ptr_amount,
 	multi_transactions.from_amount AS mt_from_amount,
 	multi_transactions.to_amount AS mt_to_amount,
 	CASE

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 
+	"github.com/status-im/status-go/services/wallet/bigint"
 	"github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/testutils"
 	"github.com/status-im/status-go/services/wallet/token"
@@ -348,7 +349,7 @@ func InsertTestPendingTransaction(tb testing.TB, db *sql.DB, tr *TestTransfer) {
 		INSERT INTO pending_transactions (network_id, hash, timestamp, from_address, to_address,
 			symbol, gas_price, gas_limit, value, data, type, additional_data, multi_transaction_id
 		) VALUES (?, ?, ?, ?, ?, 'ETH', 0, 0, ?, '', 'eth', '', ?)`,
-		tr.ChainID, tr.Hash, tr.Timestamp, tr.From, tr.To, tr.Value, tr.MultiTransactionID)
+		tr.ChainID, tr.Hash, tr.Timestamp, tr.From, tr.To, (*bigint.SQLBigIntBytes)(big.NewInt(tr.Value)), tr.MultiTransactionID)
 	require.NoError(tb, err)
 }
 

--- a/transactions/testhelpers.go
+++ b/transactions/testhelpers.go
@@ -61,15 +61,17 @@ func GenerateTestPendingTransactions(count int) []PendingTransaction {
 
 	txs := make([]PendingTransaction, count)
 	for i := 0; i < count; i++ {
+		// Avoid generating zero values hash and addresses
+		seed := i + 1
 		txs[i] = PendingTransaction{
-			Hash:           eth.Hash{byte(i)},
-			From:           eth.Address{byte(i)},
-			To:             eth.Address{byte(i * 2)},
+			Hash:           eth.Hash{byte(seed)},
+			From:           eth.Address{byte(seed)},
+			To:             eth.Address{byte(seed * 2)},
 			Type:           RegisterENS,
 			AdditionalData: "someuser.stateofus.eth",
-			Value:          bigint.BigInt{Int: big.NewInt(int64(i))},
+			Value:          bigint.BigInt{Int: big.NewInt(int64(seed))},
 			GasLimit:       bigint.BigInt{Int: big.NewInt(21000)},
-			GasPrice:       bigint.BigInt{Int: big.NewInt(int64(i))},
+			GasPrice:       bigint.BigInt{Int: big.NewInt(int64(seed))},
 			ChainID:        777,
 			Status:         new(TxStatus),
 			AutoDelete:     new(bool),


### PR DESCRIPTION
The reading of the amount for pending transactions was done in the same way as for the transfers table. However, the transfers table has a string hex representation of the amount, while the pending transactions table has a binary representation of the amount (*big.Int). This inconsistency was triggering the not int warning and the value was missing.

- [x] rebased on top of https://github.com/status-im/status-go/pull/4657

Updates status-desktop [#12120](https://github.com/status-im/status-desktop/issues/12120)