### PR TITLE
fix: add node config `RuntimeLogLevel` option

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -696,6 +696,74 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 	})
 }
 
+func TestRuntimeLogLevelIsNotWrittenToDatabase(t *testing.T) {
+	utils.Init()
+
+	b := NewGethStatusBackend()
+	chatKey, err := gethcrypto.GenerateKey()
+	require.NoError(t, err)
+	walletKey, err := gethcrypto.GenerateKey()
+	require.NoError(t, err)
+	keyUIDHex := sha256.Sum256(gethcrypto.FromECDSAPub(&chatKey.PublicKey))
+	keyUID := types.EncodeHex(keyUIDHex[:])
+	main := multiaccounts.Account{
+		KeyUID: keyUID,
+	}
+
+	tmpdir := t.TempDir()
+
+	json := `{
+		"NetworkId": 3,
+		"DataDir": "` + tmpdir + `",
+		"KeyStoreDir": "` + tmpdir + `",
+		"KeycardPairingDataFile": "` + path.Join(tmpdir, "keycard/pairings.json") + `",
+		"NoDiscovery": true,
+		"TorrentConfig": {
+			"Port": 9025,
+			"Enabled": false,
+			"DataDir": "` + tmpdir + `/archivedata",
+			"TorrentDir": "` + tmpdir + `/torrents"
+		},
+		"RuntimeLogLevel": "INFO",
+		"LogLevel": "DEBUG"
+	}`
+
+	conf, err := params.NewConfigFromJSON(json)
+	require.NoError(t, err)
+	require.Equal(t, "INFO", conf.RuntimeLogLevel)
+	keyhex := hex.EncodeToString(gethcrypto.FromECDSA(chatKey))
+
+	require.NoError(t, b.AccountManager().InitKeystore(conf.KeyStoreDir))
+	b.UpdateRootDataDir(conf.DataDir)
+	require.NoError(t, b.OpenAccounts())
+	require.NotNil(t, b.statusNode.HTTPServer())
+
+	address := crypto.PubkeyToAddress(walletKey.PublicKey)
+
+	settings := testSettings
+	settings.KeyUID = keyUID
+	settings.Address = crypto.PubkeyToAddress(walletKey.PublicKey)
+
+	chatPubKey := crypto.FromECDSAPub(&chatKey.PublicKey)
+	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", settings, conf,
+		[]*accounts.Account{
+			{Address: address, KeyUID: keyUID, Wallet: true},
+			{Address: crypto.PubkeyToAddress(chatKey.PublicKey), KeyUID: keyUID, Chat: true, PublicKey: chatPubKey}}, keyhex))
+	require.NoError(t, b.Logout())
+	require.NoError(t, b.StopNode())
+
+	require.NoError(t, b.StartNodeWithKey(main, "test-pass", keyhex, conf))
+	defer func() {
+		assert.NoError(t, b.Logout())
+		assert.NoError(t, b.StopNode())
+	}()
+
+	c, err := b.GetNodeConfig()
+	require.NoError(t, err)
+	require.Equal(t, "", c.RuntimeLogLevel)
+	require.Equal(t, "DEBUG", c.LogLevel)
+}
+
 func TestLoginWithKey(t *testing.T) {
 	utils.Init()
 

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1712,6 +1712,10 @@ func (b *GethStatusBackend) loadNodeConfig(inputNodeCfg *params.NodeConfig) erro
 
 	b.config = conf
 
+	if inputNodeCfg != nil && inputNodeCfg.RuntimeLogLevel != "" {
+		b.config.LogLevel = inputNodeCfg.RuntimeLogLevel
+	}
+
 	return nil
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -412,6 +412,9 @@ type NodeConfig struct {
 	// LogFile is filename where exposed logs get written to
 	LogFile string
 
+	// RuntimeLoglevel defines minimum log level for this session only, not affecting the db-stored node configuration
+	RuntimeLogLevel string `validate:"omitempty,eq=ERROR|eq=WARN|eq=INFO|eq=DEBUG|eq=TRACE"`
+
 	// LogLevel defines minimum log level. Valid names are "ERROR", "WARN", "INFO", "DEBUG", and "TRACE".
 	LogLevel string `validate:"eq=ERROR|eq=WARN|eq=INFO|eq=DEBUG|eq=TRACE"`
 

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -44,6 +44,8 @@ func TestNewNodeConfigWithDefaults(t *testing.T) {
 	assert.Equal(t, false, c.HTTPEnabled)
 	assert.Equal(t, false, c.IPCEnabled)
 
+	assert.Equal(t, "", c.RuntimeLogLevel)
+
 	assert.Equal(t, "/some/data/path/archivedata", c.TorrentConfig.DataDir)
 	assert.Equal(t, "/some/data/path/torrents", c.TorrentConfig.TorrentDir)
 	assert.Equal(t, 9025, c.TorrentConfig.Port)
@@ -61,12 +63,13 @@ func TestNewConfigFromJSON(t *testing.T) {
 		"KeyStoreDir": "` + tmpDir + `",
 		"KeycardPairingDataFile": "` + path.Join(tmpDir, "keycard/pairings.json") + `",
 		"NoDiscovery": true,
-    "TorrentConfig": {
-      "Port": 9025,
-      "Enabled": false,
-      "DataDir": "` + tmpDir + `/archivedata",
-      "TorrentDir": "` + tmpDir + `/torrents"
-    }
+		"TorrentConfig": {
+			"Port": 9025,
+			"Enabled": false,
+			"DataDir": "` + tmpDir + `/archivedata",
+			"TorrentDir": "` + tmpDir + `/torrents"
+		},
+		"RuntimeLogLevel": "DEBUG"
 	}`
 	c, err := params.NewConfigFromJSON(json)
 	require.NoError(t, err)
@@ -77,6 +80,7 @@ func TestNewConfigFromJSON(t *testing.T) {
 	require.Equal(t, 9025, c.TorrentConfig.Port)
 	require.Equal(t, tmpDir+"/archivedata", c.TorrentConfig.DataDir)
 	require.Equal(t, tmpDir+"/torrents", c.TorrentConfig.TorrentDir)
+	require.Equal(t, "DEBUG", c.RuntimeLogLevel)
 }
 
 func TestConfigWriteRead(t *testing.T) {


### PR DESCRIPTION
### Description

Closes https://github.com/status-im/status-desktop/issues/13139

linked to https://github.com/status-im/status-desktop/pull/13309

Previously it was not possible to change the state of the Debug toggle. This is because the code forced the setting the default value, ignoring the database setup, hence always setting the DEBUG as LogLevel.

This PR adds :
- A RuntimeLogLevel to enable setting ephemeral loggig strategy on status-go
