### PR TITLE
[#4646] Return l2 block number when calling BalanceChecker on Arbitrum

### DIFF
--- a/contracts/balancechecker/address.go
+++ b/contracts/balancechecker/address.go
@@ -11,12 +11,12 @@ var errorNotAvailableOnChainID = errors.New("BalanceChecker not available for ch
 var contractDataByChainID = map[uint64]common.Address{
 	1:        common.HexToAddress("0x040EA8bFE441597849A9456182fa46D38B75BC05"), // mainnet
 	10:       common.HexToAddress("0x55bD303eA3D50FC982A8a5b43972d7f38D129bbF"), // optimism
-	42161:    common.HexToAddress("0x55bD303eA3D50FC982A8a5b43972d7f38D129bbF"), // arbitrum
+	42161:    common.HexToAddress("0x54764eF12d29b249fDC7FC3caDc039955A396A8e"), // arbitrum
 	5:        common.HexToAddress("0xA5522A3194B78Dd231b64d0ccd6deA6156DCa7C8"), // goerli
-	421613:   common.HexToAddress("0x55bD303eA3D50FC982A8a5b43972d7f38D129bbF"), // goerli arbitrum
+	421613:   common.HexToAddress("0x54764eF12d29b249fDC7FC3caDc039955A396A8e"), // goerli arbitrum
 	420:      common.HexToAddress("0x55bD303eA3D50FC982A8a5b43972d7f38D129bbF"), // goerli optimism
 	11155111: common.HexToAddress("0x55bD303eA3D50FC982A8a5b43972d7f38D129bbF"), // sepolia
-	421614:   common.HexToAddress("0x55bD303eA3D50FC982A8a5b43972d7f38D129bbF"), // sepolia arbitrum
+	421614:   common.HexToAddress("0x54764eF12d29b249fDC7FC3caDc039955A396A8e"), // sepolia arbitrum
 	11155420: common.HexToAddress("0x55bD303eA3D50FC982A8a5b43972d7f38D129bbF"), // sepolia optimism
 	777333:   common.HexToAddress("0x0000000000000000000000000000000010777333"), // unit tests
 }

--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -20,7 +20,6 @@ import (
 	"github.com/status-im/status-go/services/wallet/async"
 	"github.com/status-im/status-go/services/wallet/balance"
 	"github.com/status-im/status-go/services/wallet/blockchainstate"
-	walletcommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/services/wallet/walletevent"
 	"github.com/status-im/status-go/transactions"
@@ -70,19 +69,6 @@ func (c *findNewBlocksCommand) detectTransfers(parent context.Context, accounts 
 	if err != nil {
 		log.Error("findNewBlocksCommand can't get balances hashes", "error", err)
 		return nil, nil, err
-	}
-
-	networkID := c.chainClient.NetworkID()
-	// TODO(rasom): remove this as soon as BalanceChecker contract for
-	// Arbitrum networks will return l2 block number instead of l1
-	if networkID == walletcommon.ArbitrumMainnet || networkID == walletcommon.ArbitrumGoerli || networkID == walletcommon.ArbitrumSepolia {
-		header, err := c.chainClient.HeaderByNumber(context.Background(), nil)
-		if err != nil {
-			log.Error("findNewBlocksCommand error getting header", "error", err, "chain", c.chainClient.NetworkID())
-			return nil, nil, err
-		}
-
-		blockNum = header.Number
 	}
 
 	addressesToCheck := []common.Address{}


### PR DESCRIPTION
BalanceChecker is updated to return l2 block number.

``` Solidity
// SPDX-License-Identifier: MIT
pragma solidity >=0.4.22 <0.9.0;

// ERC20 contract interface
abstract contract Token {
    function balanceOf(address) public view virtual returns (uint);
}

abstract contract ArbSys {
    function arbBlockNumber() public view virtual returns (uint);
}

contract BalanceChecker {
    function tokenBalance(
        address user,
        address token
    ) public view returns (uint) {
        return Token(token).balanceOf(user);
    }

    function arbBlockNumber() public view returns (uint) {
        return ArbSys(address(100)).arbBlockNumber();
    }

    function balancesPerAddress(
        address user,
        address[] memory tokens
    ) public view returns (uint[] memory) {
        uint[] memory addrBalances = new uint[](
            tokens.length + 1
        );
        for (uint i = 0; i < tokens.length; i++) {
            addrBalances[i] = tokenBalance(user, tokens[i]);
        }

        addrBalances[tokens.length] = user.balance;
        return addrBalances;
    }

    function balancesHash(
        address[] calldata users,
        address[] calldata tokens
    ) external view returns (uint256, bytes32[] memory) {
        bytes32[] memory addrBalances = new bytes32[](users.length);

        for (uint i = 0; i < users.length; i++) {
            addrBalances[i] = keccak256(
                abi.encodePacked(balancesPerAddress(users[i], tokens))
            );
        }

        return (arbBlockNumber(), addrBalances);
    }
}
```
