### PR TITLE
fix(protocol): crash in concurrent map write/read

### DIFF
--- a/protocol/transport/envelopes_monitor.go
+++ b/protocol/transport/envelopes_monitor.go
@@ -123,6 +123,9 @@ func (m *EnvelopesMonitor) Add(identifiers [][]byte, envelopeHashes []types.Hash
 		return errors.New("hashes don't match messages")
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	for _, identifier := range identifiers {
 		m.identifierHashes[string(identifier)] = envelopeHashes
 	}


### PR DESCRIPTION
```
 503 fatal error: concurrent map read and map write
 504
 505 goroutine 872 [running]:
 506 github.com/status-im/status-go/protocol/transport.(*EnvelopesMonitor).Add(0x14000840f30, {0x1400646c288?, 0x1, 0x1}, {0x140055d6080, 0x1, 0x1}, {0x1400083c060, 0x1?, 0x0?})
 507         /Users/blade/work/projects/Status/status-desktop/vendor/status-go/protocol/transport/rnvelopes_monitor.go:131 +0x1ac
 508 github.com/status-im/status-go/protocol/transport.(*Transport).TrackMany(0x1400033ddc0, {0x1400646c288, 0x1, 0x1}, {0x1400646c210, 0x1, 0x10?}, {0x1400083c060, 0x1, 0x1})
 509         /Users/blade/work/projects/Status/status-desktop/vendor/status-go/protocol/transport/transport.go:404 +0x188
 510 github.com/status-im/status-go/protocol/transport.(*Transport).Track(...)
 511         /Users/blade/work/projects/Status/status-desktop/vendor/status-go/protocol/transport/transport.go:391
 512 github.com/status-im/status-go/protocol/common.(*MessageSender).SendPublic(0x14001cae880, {0x10e535510, 0x1400019e018}, {0x140005bed20, 0x91}, {{0x0, 0x0}, {0x140005bed20, 0x91}, 0x0, ...})
 513         /Users/blade/work/projects/Status/status-desktop/vendor/status-go/protocol/common/message_sender.go:725 +0xa38
 514 github.com/status-im/status-go/protocol.(*Messenger).sendUserStatus(0x14000486900, {0x10e535510, 0x1400019e018}, {{0x14000478000, 0x84}, 0x1, 0x65c0dc35, {0x0, 0x0}})
 515         /Users/blade/work/projects/Status/status-desktop/vendor/status-go/protocol/messenger_status_updates.go:75 +0x29c
 516 github.com/status-im/status-go/protocol.(*Messenger).sendCurrentUserStatus(0x14000486900, {0x10e535510, 0x1400019e018})
 517         /Users/blade/work/projects/Status/status-desktop/vendor/status-go/protocol/messenger_status_updates.go:120 +0x3c0
 518 github.com/status-im/status-go/protocol.(*Messenger).broadcastLatestUserStatus.func2()
 519         /Users/blade/work/projects/Status/status-desktop/vendor/status-go/protocol/messenger_status_updates.go:200 +0x44
 520 created by github.com/status-im/status-go/protocol.(*Messenger).broadcastLatestUserStatus
 521         /Users/blade/work/projects/Status/status-desktop/vendor/status-go/protocol/messenger_status_updates.go:196 +0x13

```