### PR TITLE
Feat: Save and dispatch profile showcase on wallet account change

### DIFF
--- a/protocol/messenger_profile_showcase.go
+++ b/protocol/messenger_profile_showcase.go
@@ -454,7 +454,7 @@ func (m *Messenger) BuildProfileShowcaseFromIdentity(state *ReceivedMessageState
 }
 
 func (m *Messenger) UpdateProfileShowcaseWalletAccount(account *accounts.Account) error {
-	profileAccount, err := m.persistence.GetProfileShowcaseAccountPreferences(account.Address.Hex())
+	profileAccount, err := m.persistence.GetProfileShowcaseAccountPreference(account.Address.Hex())
 	if err != nil {
 		return err
 	}
@@ -469,6 +469,15 @@ func (m *Messenger) UpdateProfileShowcaseWalletAccount(account *accounts.Account
 	profileAccount.Emoji = account.Emoji
 
 	err = m.persistence.SaveProfileShowcaseAccountPreference(profileAccount)
+	if err != nil {
+		return err
+	}
+
+	return m.DispatchProfileShowcase()
+}
+
+func (m *Messenger) DeleteProfileShowcaseWalletAccount(account *accounts.Account) error {
+	err := m.persistence.DeleteProfileShowcaseAccountPreference(account.Address.Hex())
 	if err != nil {
 		return err
 	}

--- a/protocol/messenger_profile_showcase.go
+++ b/protocol/messenger_profile_showcase.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
+	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -206,6 +207,10 @@ func (m *Messenger) SetProfileShowcasePreferences(preferences *ProfileShowcasePr
 		return err
 	}
 
+	return m.DispatchProfileShowcase()
+}
+
+func (m *Messenger) DispatchProfileShowcase() error {
 	return m.publishContactCode()
 }
 
@@ -446,4 +451,27 @@ func (m *Messenger) BuildProfileShowcaseFromIdentity(state *ReceivedMessageState
 
 	state.Response.AddProfileShowcase(newShowcase)
 	return nil
+}
+
+func (m *Messenger) UpdateProfileShowcaseWalletAccount(account *accounts.Account) error {
+	profileAccount, err := m.persistence.GetProfileShowcaseAccountPreferences(account.Address.Hex())
+	if err != nil {
+		return err
+	}
+
+	if profileAccount == nil {
+		// No corresponding profile entry, exit
+		return nil
+	}
+
+	profileAccount.Name = account.Name
+	profileAccount.ColorID = string(account.ColorID)
+	profileAccount.Emoji = account.Emoji
+
+	err = m.persistence.SaveProfileShowcaseAccountPreference(profileAccount)
+	if err != nil {
+		return err
+	}
+
+	return m.DispatchProfileShowcase()
 }

--- a/protocol/messenger_wallet.go
+++ b/protocol/messenger_wallet.go
@@ -303,7 +303,12 @@ func (m *Messenger) DeleteAccount(address types.Address) error {
 		return err
 	}
 	// Since some keypairs may be received out of expected order, we're aligning that by sending accounts position sync msg.
-	return m.syncAccountsPositions(m.dispatchMessage)
+	err = m.syncAccountsPositions(m.dispatchMessage)
+	if err != nil {
+		return err
+	}
+
+	return m.DeleteProfileShowcaseWalletAccount(acc)
 }
 
 func (m *Messenger) DeleteKeypair(keyUID string) error {

--- a/protocol/messenger_wallet.go
+++ b/protocol/messenger_wallet.go
@@ -172,7 +172,12 @@ func (m *Messenger) SaveOrUpdateAccount(acc *accounts.Account) error {
 		return err
 	}
 
-	return m.resolveAndSyncKeypairOrJustWalletAccount(acc.KeyUID, acc.Address, acc.Clock, m.dispatchMessage)
+	err = m.resolveAndSyncKeypairOrJustWalletAccount(acc.KeyUID, acc.Address, acc.Clock, m.dispatchMessage)
+	if err != nil {
+		return err
+	}
+
+	return m.UpdateProfileShowcaseWalletAccount(acc)
 }
 
 func (m *Messenger) MarkKeypairFullyOperable(keyUID string) error {

--- a/protocol/persistence_profile_showcase.go
+++ b/protocol/persistence_profile_showcase.go
@@ -20,6 +20,7 @@ const selectProfileShowcaseCommunityPreferenceQuery = "SELECT community_id, visi
 
 const upsertProfileShowcaseAccountPreferenceQuery = "INSERT OR REPLACE INTO profile_showcase_accounts_preferences(address, name, color_id, emoji, visibility, sort_order) VALUES (?, ?, ?, ?, ?, ?)" // #nosec G101
 const selectProfileShowcaseAccountPreferenceQuery = "SELECT address, name, color_id, emoji, visibility, sort_order FROM profile_showcase_accounts_preferences"                                       // #nosec G101
+const selectSpecifiedShowcaseAccountPreferenceQuery = "SELECT address, name, color_id, emoji, visibility, sort_order FROM profile_showcase_accounts_preferences WHERE address = ?"                   // #nosec G101
 
 const upsertProfileShowcaseCollectiblePreferenceQuery = "INSERT OR REPLACE INTO profile_showcase_collectibles_preferences(contract_address, chain_id, token_id, community_id, account_address, visibility, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?)" // #nosec G101
 const selectProfileShowcaseCollectiblePreferenceQuery = "SELECT contract_address, chain_id, token_id, community_id, account_address, visibility, sort_order FROM profile_showcase_collectibles_preferences"                                          // #nosec G101
@@ -203,13 +204,10 @@ func (db sqlitePersistence) saveProfileShowcaseAccountPreference(tx *sql.Tx, acc
 	return err
 }
 
-func (db sqlitePersistence) getProfileShowcaseAccountsPreferences(tx *sql.Tx) ([]*ProfileShowcaseAccountPreference, error) {
-	rows, err := tx.Query(selectProfileShowcaseAccountPreferenceQuery)
-	if err != nil {
-		return nil, err
+func (db sqlitePersistence) processProfileShowcaseAccountPreferences(rows *sql.Rows) (result []*ProfileShowcaseAccountPreference, err error) {
+	if rows == nil {
+		return nil, errors.New("rows is nil")
 	}
-
-	accounts := []*ProfileShowcaseAccountPreference{}
 
 	for rows.Next() {
 		account := &ProfileShowcaseAccountPreference{}
@@ -227,9 +225,33 @@ func (db sqlitePersistence) getProfileShowcaseAccountsPreferences(tx *sql.Tx) ([
 			return nil, err
 		}
 
-		accounts = append(accounts, account)
+		result = append(result, account)
 	}
-	return accounts, nil
+
+	err = rows.Err()
+	return
+}
+
+func (db sqlitePersistence) getProfileShowcaseAccountsPreferences(tx *sql.Tx) ([]*ProfileShowcaseAccountPreference, error) {
+	rows, err := tx.Query(selectProfileShowcaseAccountPreferenceQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	return db.processProfileShowcaseAccountPreferences(rows)
+}
+
+func (db sqlitePersistence) GetProfileShowcaseAccountPreferences(accountAddress string) (*ProfileShowcaseAccountPreference, error) {
+	rows, err := db.db.Query(selectSpecifiedShowcaseAccountPreferenceQuery, accountAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	accounts, err := db.processProfileShowcaseAccountPreferences(rows)
+	if len(accounts) > 0 {
+		return accounts[0], err
+	}
+	return nil, err
 }
 
 func (db sqlitePersistence) saveProfileShowcaseCollectiblePreference(tx *sql.Tx, collectible *ProfileShowcaseCollectiblePreference) error {
@@ -626,6 +648,22 @@ func (db sqlitePersistence) SaveProfileShowcasePreferences(preferences *ProfileS
 	}
 
 	return nil
+}
+
+func (db sqlitePersistence) SaveProfileShowcaseAccountPreference(account *ProfileShowcaseAccountPreference) error {
+	tx, err := db.db.BeginTx(context.Background(), &sql.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+		// don't shadow original error
+		_ = tx.Rollback()
+	}()
+	return db.saveProfileShowcaseAccountPreference(tx, account)
 }
 
 func (db sqlitePersistence) GetProfileShowcasePreferences() (*ProfileShowcasePreferences, error) {

--- a/protocol/persistence_profile_showcase.go
+++ b/protocol/persistence_profile_showcase.go
@@ -21,6 +21,7 @@ const selectProfileShowcaseCommunityPreferenceQuery = "SELECT community_id, visi
 const upsertProfileShowcaseAccountPreferenceQuery = "INSERT OR REPLACE INTO profile_showcase_accounts_preferences(address, name, color_id, emoji, visibility, sort_order) VALUES (?, ?, ?, ?, ?, ?)" // #nosec G101
 const selectProfileShowcaseAccountPreferenceQuery = "SELECT address, name, color_id, emoji, visibility, sort_order FROM profile_showcase_accounts_preferences"                                       // #nosec G101
 const selectSpecifiedShowcaseAccountPreferenceQuery = "SELECT address, name, color_id, emoji, visibility, sort_order FROM profile_showcase_accounts_preferences WHERE address = ?"                   // #nosec G101
+const deleteProfileShowcaseAccountPreferenceQuery = "DELETE FROM profile_showcase_accounts_preferences WHERE address = ?"                                                                            // #nosec G101
 
 const upsertProfileShowcaseCollectiblePreferenceQuery = "INSERT OR REPLACE INTO profile_showcase_collectibles_preferences(contract_address, chain_id, token_id, community_id, account_address, visibility, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?)" // #nosec G101
 const selectProfileShowcaseCollectiblePreferenceQuery = "SELECT contract_address, chain_id, token_id, community_id, account_address, visibility, sort_order FROM profile_showcase_collectibles_preferences"                                          // #nosec G101
@@ -241,7 +242,7 @@ func (db sqlitePersistence) getProfileShowcaseAccountsPreferences(tx *sql.Tx) ([
 	return db.processProfileShowcaseAccountPreferences(rows)
 }
 
-func (db sqlitePersistence) GetProfileShowcaseAccountPreferences(accountAddress string) (*ProfileShowcaseAccountPreference, error) {
+func (db sqlitePersistence) GetProfileShowcaseAccountPreference(accountAddress string) (*ProfileShowcaseAccountPreference, error) {
 	rows, err := db.db.Query(selectSpecifiedShowcaseAccountPreferenceQuery, accountAddress)
 	if err != nil {
 		return nil, err
@@ -252,6 +253,12 @@ func (db sqlitePersistence) GetProfileShowcaseAccountPreferences(accountAddress 
 		return accounts[0], err
 	}
 	return nil, err
+}
+
+func (db sqlitePersistence) DeleteProfileShowcaseAccountPreference(accountAddress string) error {
+	_, err := db.db.Exec(deleteProfileShowcaseAccountPreferenceQuery, accountAddress)
+
+	return err
 }
 
 func (db sqlitePersistence) saveProfileShowcaseCollectiblePreference(tx *sql.Tx, collectible *ProfileShowcaseCollectiblePreference) error {

--- a/protocol/persistence_profile_showcase_test.go
+++ b/protocol/persistence_profile_showcase_test.go
@@ -380,12 +380,13 @@ func (s *TestProfileShowcasePersistence) TestUpdateProfileShowcaseAccountOnWalle
 	s.Require().NoError(err)
 	persistence := newSQLitePersistence(db)
 
-	accountAddress := "0x3845354643324"
+	deleteAccountAddress := "0x3243344513424"
+	updateAccountAddress := "0x3845354643324"
 
 	preferences := &ProfileShowcasePreferences{
 		Accounts: []*ProfileShowcaseAccountPreference{
 			&ProfileShowcaseAccountPreference{
-				Address:            "0x32433445133424",
+				Address:            deleteAccountAddress,
 				Name:               "Status Account",
 				ColorID:            "blue",
 				Emoji:              "-_-",
@@ -393,7 +394,7 @@ func (s *TestProfileShowcasePersistence) TestUpdateProfileShowcaseAccountOnWalle
 				Order:              0,
 			},
 			&ProfileShowcaseAccountPreference{
-				Address:            accountAddress,
+				Address:            updateAccountAddress,
 				Name:               "Money Box",
 				ColorID:            "red",
 				Emoji:              ":o)",
@@ -406,7 +407,7 @@ func (s *TestProfileShowcasePersistence) TestUpdateProfileShowcaseAccountOnWalle
 	err = persistence.SaveProfileShowcasePreferences(preferences)
 	s.Require().NoError(err)
 
-	account, err := persistence.GetProfileShowcaseAccountPreferences(accountAddress)
+	account, err := persistence.GetProfileShowcaseAccountPreference(updateAccountAddress)
 	s.Require().NoError(err)
 	s.Require().NotNil(account)
 	s.Require().Equal(*account, *preferences.Accounts[1])
@@ -420,9 +421,12 @@ func (s *TestProfileShowcasePersistence) TestUpdateProfileShowcaseAccountOnWalle
 	err = persistence.SaveProfileShowcaseAccountPreference(account)
 	s.Require().NoError(err)
 
+	err = persistence.DeleteProfileShowcaseAccountPreference(deleteAccountAddress)
+	s.Require().NoError(err)
+
 	preferencesBack, err := persistence.GetProfileShowcasePreferences()
 	s.Require().NoError(err)
 
-	s.Require().Equal(*preferencesBack.Accounts[0], *preferences.Accounts[0])
-	s.Require().Equal(*preferencesBack.Accounts[1], *account)
+	s.Require().Len(preferencesBack.Accounts, 1)
+	s.Require().Equal(*preferencesBack.Accounts[0], *account)
 }


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/13080

When a user updates a wallet account using [SaveOrUpdateAccount](https://github.com/status-im/status-go/blob/develop/protocol/messenger_wallet.go#L160-L175), the profile showcase preferences are updated and profile message is dispatched