### PR TITLE
feat(wallet): add contract type to collectibles

### DIFF
--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -586,6 +586,7 @@ func (s *Service) FillCollectibleMetadata(collectible *thirdparty.FullCollectibl
 
 	imagePayload, _ := images.GetPayloadFromURI(tokenMetadata.GetImage())
 
+	collectible.CollectibleData.ContractType = w_common.ContractTypeERC721
 	collectible.CollectibleData.Provider = providerID
 	collectible.CollectibleData.Name = tokenMetadata.GetName()
 	collectible.CollectibleData.Description = tokenMetadata.GetDescription()
@@ -598,6 +599,7 @@ func (s *Service) FillCollectibleMetadata(collectible *thirdparty.FullCollectibl
 			CommunityID: communityID,
 		}
 	}
+	collectible.CollectionData.ContractType = w_common.ContractTypeERC721
 	collectible.CollectionData.Provider = providerID
 	collectible.CollectionData.Name = tokenMetadata.GetName()
 	collectible.CollectionData.ImagePayload = imagePayload

--- a/services/wallet/collectibles/collectible_data_db.go
+++ b/services/wallet/collectibles/collectible_data_db.go
@@ -134,6 +134,11 @@ func setCollectiblesData(creator sqlite.StatementCreator, collectibles []thirdpa
 			return err
 		}
 
+		err = upsertContractType(creator, c.ID.ContractID, c.ContractType)
+		if err != nil {
+			return err
+		}
+
 		if allowUpdate {
 			err = upsertCollectibleTraits(creator, c.ID, c.Traits)
 			if err != nil {
@@ -253,6 +258,13 @@ func (o *CollectibleDataDB) GetData(ids []thirdparty.CollectibleUniqueID) (map[s
 			if err != nil {
 				return nil, err
 			}
+
+			// Get contract type from different table
+			c.ContractType, err = readContractType(o.db, c.ID.ContractID)
+			if err != nil {
+				return nil, err
+			}
+
 			ret[c.ID.HashKey()] = *c
 		}
 	}

--- a/services/wallet/collectibles/collection_data_db.go
+++ b/services/wallet/collectibles/collection_data_db.go
@@ -120,6 +120,11 @@ func setCollectionsData(creator sqlite.StatementCreator, collections []thirdpart
 			return err
 		}
 
+		err = upsertContractType(creator, c.ID, c.ContractType)
+		if err != nil {
+			return err
+		}
+
 		if allowUpdate {
 			err = upsertCollectionTraits(creator, c.ID, c.Traits)
 			if err != nil {
@@ -228,6 +233,13 @@ func (o *CollectionDataDB) GetData(ids []thirdparty.ContractID) (map[string]thir
 			if err != nil {
 				return nil, err
 			}
+
+			// Get contract type from different table
+			c.ContractType, err = readContractType(o.db, c.ID)
+			if err != nil {
+				return nil, err
+			}
+
 			ret[c.ID.HashKey()] = *c
 		}
 	}

--- a/services/wallet/collectibles/contract_type_db.go
+++ b/services/wallet/collectibles/contract_type_db.go
@@ -1,0 +1,68 @@
+package collectibles
+
+import (
+	"database/sql"
+
+	sq "github.com/Masterminds/squirrel"
+
+	w_common "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+	"github.com/status-im/status-go/sqlite"
+)
+
+func upsertContractType(creator sqlite.StatementCreator, id thirdparty.ContractID, contractType w_common.ContractType) error {
+	if contractType == w_common.ContractTypeUnknown {
+		return nil
+	}
+
+	q := sq.Replace("contract_type_cache").
+		SetMap(sq.Eq{"chain_id": id.ChainID, "contract_address": id.Address, "contract_type": contractType})
+
+	query, args, err := q.ToSql()
+	if err != nil {
+		return err
+	}
+
+	stmt, err := creator.Prepare(query)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(args...)
+
+	return err
+}
+
+func readContractType(creator sqlite.StatementCreator, id thirdparty.ContractID) (w_common.ContractType, error) {
+	q := sq.Select("contract_type").
+		From("contract_type_cache").
+		Where(sq.Eq{"chain_id": id.ChainID, "contract_address": id.Address})
+
+	query, args, err := q.ToSql()
+	if err != nil {
+		return w_common.ContractTypeUnknown, err
+	}
+
+	stmt, err := creator.Prepare(query)
+	if err != nil {
+		return w_common.ContractTypeUnknown, err
+	}
+	defer stmt.Close()
+
+	_, err = stmt.Exec(args...)
+	if err != nil {
+		return w_common.ContractTypeUnknown, err
+	}
+
+	var transferType w_common.ContractType
+	err = stmt.QueryRow(args...).Scan(&transferType)
+
+	if err == sql.ErrNoRows {
+		return w_common.ContractTypeUnknown, nil
+	} else if err != nil {
+		return w_common.ContractTypeUnknown, err
+	}
+
+	return transferType, nil
+}

--- a/services/wallet/collectibles/types.go
+++ b/services/wallet/collectibles/types.go
@@ -2,6 +2,7 @@ package collectibles
 
 import (
 	"github.com/status-im/status-go/protocol/communities/token"
+	w_common "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 )
 
@@ -9,6 +10,7 @@ import (
 type Collectible struct {
 	DataType        CollectibleDataType            `json:"data_type"`
 	ID              thirdparty.CollectibleUniqueID `json:"id"`
+	ContractType    w_common.ContractType          `json:"contract_type"`
 	CollectibleData *CollectibleData               `json:"collectible_data,omitempty"`
 	CollectionData  *CollectionData                `json:"collection_data,omitempty"`
 	CommunityData   *CommunityData                 `json:"community_data,omitempty"`
@@ -58,10 +60,21 @@ func idsToCollectibles(ids []thirdparty.CollectibleUniqueID) []Collectible {
 	return res
 }
 
+func getContractType(c thirdparty.FullCollectibleData) w_common.ContractType {
+	if c.CollectibleData.ContractType != w_common.ContractTypeUnknown {
+		return c.CollectibleData.ContractType
+	}
+	if c.CollectionData != nil && c.CollectionData.ContractType != w_common.ContractTypeUnknown {
+		return c.CollectionData.ContractType
+	}
+	return w_common.ContractTypeUnknown
+}
+
 func fullCollectibleDataToHeader(c thirdparty.FullCollectibleData) Collectible {
 	ret := Collectible{
-		DataType: CollectibleDataTypeHeader,
-		ID:       c.CollectibleData.ID,
+		DataType:     CollectibleDataTypeHeader,
+		ID:           c.CollectibleData.ID,
+		ContractType: getContractType(c),
 		CollectibleData: &CollectibleData{
 			Name:               c.CollectibleData.Name,
 			ImageURL:           &c.CollectibleData.ImageURL,
@@ -98,8 +111,9 @@ func fullCollectiblesDataToHeaders(data []thirdparty.FullCollectibleData) []Coll
 
 func fullCollectibleDataToDetails(c thirdparty.FullCollectibleData) Collectible {
 	ret := Collectible{
-		DataType: CollectibleDataTypeDetails,
-		ID:       c.CollectibleData.ID,
+		DataType:     CollectibleDataTypeDetails,
+		ID:           c.CollectibleData.ID,
+		ContractType: getContractType(c),
 		CollectibleData: &CollectibleData{
 			Name:               c.CollectibleData.Name,
 			Description:        &c.CollectibleData.Description,
@@ -150,7 +164,8 @@ func fullCollectiblesDataToCommunityHeader(data []thirdparty.FullCollectibleData
 		communityData := communityInfoToData(communityID, c.CommunityInfo, c.CollectibleCommunityInfo)
 
 		header := Collectible{
-			ID: collectibleID,
+			ID:           collectibleID,
+			ContractType: getContractType(c),
 			CollectibleData: &CollectibleData{
 				Name: c.CollectibleData.Name,
 			},

--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -20,6 +20,15 @@ const (
 	ArbitrumSepolia uint64 = 421614
 )
 
+type ContractType byte
+
+const (
+	ContractTypeUnknown ContractType = iota
+	ContractTypeERC20
+	ContractTypeERC721
+	ContractTypeERC1155
+)
+
 func (c ChainID) String() string {
 	return strconv.Itoa(int(c))
 }

--- a/services/wallet/thirdparty/alchemy/client_test.go
+++ b/services/wallet/thirdparty/alchemy/client_test.go
@@ -1,0 +1,145 @@
+package alchemy
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/bigint"
+	w_common "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshallCollection(t *testing.T) {
+	expectedCollectionData := thirdparty.CollectionData{
+		ID: thirdparty.ContractID{
+			ChainID: 1,
+			Address: common.HexToAddress("0x06012c8cf97bead5deae237070f9587f8e7a266d"),
+		},
+		ContractType: w_common.ContractTypeERC721,
+		Provider:     "alchemy",
+		Name:         "CryptoKitties",
+		ImageURL:     "https://i.seadn.io/gae/C272ZRW1RGGef9vKMePFSCeKc1Lw6U40wl9ofNVxzUxFdj84hH9xJRQNf-7wgs7W8qw8RWe-1ybKp-VKuU5D-tg?w=500&auto=format",
+		Traits:       make(map[string]thirdparty.CollectionTrait),
+	}
+
+	collection := Contract{}
+	err := json.Unmarshal([]byte(collectionJSON), &collection)
+	assert.NoError(t, err)
+
+	contractID := thirdparty.ContractID{
+		ChainID: 1,
+		Address: common.HexToAddress("0x06012c8cf97bead5deae237070f9587f8e7a266d"),
+	}
+
+	collectionData := collection.toCollectionData(contractID)
+	assert.Equal(t, expectedCollectionData, collectionData)
+}
+
+func TestUnmarshallOwnedCollectibles(t *testing.T) {
+	expectedTokenID0, _ := big.NewInt(0).SetString("50659039041325838222074459099120411190538227963344971355684955900852972814336", 10)
+	expectedTokenID1, _ := big.NewInt(0).SetString("900", 10)
+
+	expectedCollectiblesData := []thirdparty.FullCollectibleData{
+		{
+			CollectibleData: thirdparty.CollectibleData{
+				ID: thirdparty.CollectibleUniqueID{
+					ContractID: thirdparty.ContractID{
+						ChainID: 1,
+						Address: common.HexToAddress("0x2b1870752208935fDA32AB6A016C01a27877CF12"),
+					},
+					TokenID: &bigint.BigInt{
+						Int: expectedTokenID0,
+					},
+				},
+				ContractType: w_common.ContractTypeERC1155,
+				Provider:     "alchemy",
+				Name:         "HODL",
+				Description:  "The enemy king sent a single message, written on a parchment stained by blood.\n“You are advised to submit without further delay, for if I bring my army into your land, I will destroy your hodlings, slay your people, and burn your city to ashes.”\nHodlers of ENJ sent a single word as reply:\n“If.”\nThe battle that followed does not come around too often, a battle that began every legend told about the warriors that gained eternal glory. \nThe battle that followed seemed like a lost one from the very beginning. \nThe enemy army was revealed at dawn, illuminated by the rising Sun.The ground shook as countless hordes marched towards a small band of men armed with shields, spears and swords.\nThe hodlers were outnumbered, one thousand to one. \nFear, doubt and uncertainty did not reach their hearts and minds - for they were born for this. \nEach hodler was bred for warfare, instructed in bloodshed, groomed to become a poet of death. \nA philosopher of war, blood and glory. \nEach man was forged into an invincible soldier that had a single driving force during each battle.\nStand your ground - at all costs. \nAs the swarm of enemies approached, the king yelled, asking his men: \n“Hodlers! What is your profession?”\n“HODL! HODL! HODL! HODL!!! HODL!!!!!” they replied, hitting spears against their shields. \nAn endless stream of arrows fell from the heavens only moments later, blocking out the Sun so they could fight in the shade. They emerged from the darkness without even a single scratch, protected by their legendary Enjin shields. \nWave after wave, their enemies rushed towards their doom, as they were met with cold tips of thrusting spears and sharp edges of crimson swords.\nAgainst all odds, the wall of men and steel held against the never-ending, shilling swarm. \nWhat was left of the enemy army retreated, fleeing in absolute panic and indisputable terror.\nBathed in blood, the ENJ hodlers were victorious.\nTheir story will be told for thousands of years, immortalized with divine blocks and chains.\n* * *\n“HODL” was minted in 2018 for our amazing community of epic Enjin HODLers. We are extremely grateful for the trust you've put in us and the products we're making - and the mission we're trying to accomplish, and hope you’ll love this token of our appreciation. ", // nolint: misspell
+				Permalink:    "",
+				ImageURL:     "https://res.cloudinary.com/alchemyapi/image/upload/convert-png/eth-mainnet/c5c93ffa8146ade7d3694c0f28463f0c",
+				AnimationURL: "https://nft-cdn.alchemy.com/eth-mainnet/c5c93ffa8146ade7d3694c0f28463f0c",
+				Traits:       []thirdparty.CollectibleTrait{},
+				TokenURI:     "https://cdn.enjin.io/mint/meta/70000000000001b2.json",
+			},
+			CollectionData: &thirdparty.CollectionData{
+				ID: thirdparty.ContractID{
+					ChainID: 1,
+					Address: common.HexToAddress("0x2b1870752208935fDA32AB6A016C01a27877CF12"),
+				},
+				ContractType: w_common.ContractTypeERC1155,
+				Provider:     "alchemy",
+				Name:         "",
+				Slug:         "",
+				ImageURL:     "",
+				Traits:       make(map[string]thirdparty.CollectionTrait),
+			},
+		},
+		{
+			CollectibleData: thirdparty.CollectibleData{
+				ID: thirdparty.CollectibleUniqueID{
+					ContractID: thirdparty.ContractID{
+						ChainID: 1,
+						Address: common.HexToAddress("0x3f6B1585AfeFc56433C8d28AA89dbc77af59278f"),
+					},
+					TokenID: &bigint.BigInt{
+						Int: expectedTokenID1,
+					},
+				},
+				ContractType: w_common.ContractTypeERC721,
+				Provider:     "alchemy",
+				Name:         "#900",
+				Description:  "5,555 SimpsonPunks entered the Ethereum Blockchain🍩",
+				Permalink:    "",
+				ImageURL:     "https://res.cloudinary.com/alchemyapi/image/upload/convert-png/eth-mainnet/52accf48dc609088738b15808fe07e8c",
+				AnimationURL: "https://nft-cdn.alchemy.com/eth-mainnet/52accf48dc609088738b15808fe07e8c",
+				Traits: []thirdparty.CollectibleTrait{
+					{
+						TraitType: "layers",
+						Value:     "Background",
+					},
+					{
+						TraitType: "Face",
+						Value:     "Monkey",
+					},
+					{
+						TraitType: "Head",
+						Value:     "Sweatband Blue",
+					},
+					{
+						TraitType: "Facial Hair",
+						Value:     "Thin Full",
+					},
+					{
+						TraitType: "Mouth",
+						Value:     "Burger",
+					},
+				},
+				TokenURI: "https://alchemy.mypinata.cloud/ipfs/bafybeidqbmbglapk2bkffa4o2ws5jhxnhlbdeqh7k6tk62pukse3xhvv2e/900.json",
+			},
+			CollectionData: &thirdparty.CollectionData{
+				ID: thirdparty.ContractID{
+					ChainID: 1,
+					Address: common.HexToAddress("0x3f6B1585AfeFc56433C8d28AA89dbc77af59278f"),
+				},
+				ContractType: w_common.ContractTypeERC721,
+				Provider:     "alchemy",
+				Name:         "Simpson Punk",
+				Slug:         "",
+				ImageURL:     "https://raw.seadn.io/files/e7765f13c4658f514d0efc008ae7f300.png",
+				Traits:       make(map[string]thirdparty.CollectionTrait),
+			},
+		},
+	}
+
+	var container OwnedNFTList
+	err := json.Unmarshal([]byte(ownedCollectiblesJSON), &container)
+	assert.NoError(t, err)
+
+	collectiblesData := alchemyToCollectiblesData(w_common.ChainID(w_common.EthereumMainnet), container.OwnedNFTs)
+
+	assert.Equal(t, expectedCollectiblesData, collectiblesData)
+}

--- a/services/wallet/thirdparty/alchemy/client_test_data.go
+++ b/services/wallet/thirdparty/alchemy/client_test_data.go
@@ -1,0 +1,197 @@
+// nolint: misspell
+package alchemy
+
+const collectionJSON = `{
+	"address": "0x06012c8cf97BEaD5deAe237070F9587f8E7A266d",
+	"name": "CryptoKitties",
+	"symbol": "CK",
+	"totalSupply": "2023564",
+	"tokenType": "ERC721",
+	"contractDeployer": "0xba52c75764d6F594735dc735Be7F1830CDf58dDf",
+	"deployedBlockNumber": 4605167,
+	"openSeaMetadata": {
+	  "floorPrice": 0.003,
+	  "collectionName": "CryptoKitties",
+	  "collectionSlug": "cryptokitties",
+	  "safelistRequestStatus": "verified",
+	  "imageUrl": "https://i.seadn.io/gae/C272ZRW1RGGef9vKMePFSCeKc1Lw6U40wl9ofNVxzUxFdj84hH9xJRQNf-7wgs7W8qw8RWe-1ybKp-VKuU5D-tg?w=500&auto=format",
+	  "description": "CryptoKitties is a game centered around breedable, collectible, and oh-so-adorable creatures we call CryptoKitties! Each cat is one-of-a-kind and 100% owned by you; it cannot be replicated, taken away, or destroyed.",
+	  "externalUrl": null,
+	  "twitterUsername": "CryptoKitties",
+	  "discordUrl": "https://discord.gg/cryptokitties",
+	  "bannerImageUrl": "https://i.seadn.io/gcs/static/banners/cryptokitties-banner2.png?w=500&auto=format",
+	  "lastIngestedAt": "2024-02-05T23:13:45.000Z"
+	}
+  }`
+
+const ownedCollectiblesJSON = `{
+	"ownedNfts": [
+	  {
+		"contract": {
+		  "address": "0x2b1870752208935fDA32AB6A016C01a27877CF12",
+		  "name": null,
+		  "symbol": null,
+		  "totalSupply": null,
+		  "tokenType": "ERC1155",
+		  "contractDeployer": "0x5Df2E003CEcb0ebf69cBd8F7Fbb6F44F690331F2",
+		  "deployedBlockNumber": 8088320,
+		  "openSeaMetadata": {
+			"floorPrice": 0,
+			"collectionName": "Unidentified contract - SkdH8ZQtyB",
+			"collectionSlug": "unidentified-contract-skdh8zqtyb",
+			"safelistRequestStatus": "not_requested",
+			"imageUrl": null,
+			"description": null,
+			"externalUrl": null,
+			"twitterUsername": null,
+			"discordUrl": null,
+			"bannerImageUrl": null,
+			"lastIngestedAt": "2024-01-28T06:17:57.000Z"
+		  },
+		  "isSpam": null,
+		  "spamClassifications": []
+		},
+		"tokenId": "50659039041325838222074459099120411190538227963344971355684955900852972814336",
+		"tokenType": "ERC1155",
+		"name": "HODL",
+		"description": "The enemy king sent a single message, written on a parchment stained by blood.\n“You are advised to submit without further delay, for if I bring my army into your land, I will destroy your hodlings, slay your people, and burn your city to ashes.”\nHodlers of ENJ sent a single word as reply:\n“If.”\nThe battle that followed does not come around too often, a battle that began every legend told about the warriors that gained eternal glory. \nThe battle that followed seemed like a lost one from the very beginning. \nThe enemy army was revealed at dawn, illuminated by the rising Sun.The ground shook as countless hordes marched towards a small band of men armed with shields, spears and swords.\nThe hodlers were outnumbered, one thousand to one. \nFear, doubt and uncertainty did not reach their hearts and minds - for they were born for this. \nEach hodler was bred for warfare, instructed in bloodshed, groomed to become a poet of death. \nA philosopher of war, blood and glory. \nEach man was forged into an invincible soldier that had a single driving force during each battle.\nStand your ground - at all costs. \nAs the swarm of enemies approached, the king yelled, asking his men: \n“Hodlers! What is your profession?”\n“HODL! HODL! HODL! HODL!!! HODL!!!!!” they replied, hitting spears against their shields. \nAn endless stream of arrows fell from the heavens only moments later, blocking out the Sun so they could fight in the shade. They emerged from the darkness without even a single scratch, protected by their legendary Enjin shields. \nWave after wave, their enemies rushed towards their doom, as they were met with cold tips of thrusting spears and sharp edges of crimson swords.\nAgainst all odds, the wall of men and steel held against the never-ending, shilling swarm. \nWhat was left of the enemy army retreated, fleeing in absolute panic and indisputable terror.\nBathed in blood, the ENJ hodlers were victorious.\nTheir story will be told for thousands of years, immortalized with divine blocks and chains.\n* * *\n“HODL” was minted in 2018 for our amazing community of epic Enjin HODLers. We are extremely grateful for the trust you've put in us and the products we're making - and the mission we're trying to accomplish, and hope you’ll love this token of our appreciation. ",
+		"tokenUri": "https://cdn.enjin.io/mint/meta/70000000000001b2.json",
+		"image": {
+		  "cachedUrl": "https://nft-cdn.alchemy.com/eth-mainnet/c5c93ffa8146ade7d3694c0f28463f0c",
+		  "thumbnailUrl": "https://res.cloudinary.com/alchemyapi/image/upload/thumbnailv2/eth-mainnet/c5c93ffa8146ade7d3694c0f28463f0c",
+		  "pngUrl": "https://res.cloudinary.com/alchemyapi/image/upload/convert-png/eth-mainnet/c5c93ffa8146ade7d3694c0f28463f0c",
+		  "contentType": "image/jpeg",
+		  "size": 256926,
+		  "originalUrl": "https://cdn.enjin.io/mint/image/70000000000001b2.jpg"
+		},
+		"raw": {
+		  "tokenUri": "https://cdn.enjin.io/mint/meta/70000000000001b2.json",
+		  "metadata": {
+			"name": "HODL",
+			"description": "The enemy king sent a single message, written on a parchment stained by blood.\n“You are advised to submit without further delay, for if I bring my army into your land, I will destroy your hodlings, slay your people, and burn your city to ashes.”\nHodlers of ENJ sent a single word as reply:\n“If.”\nThe battle that followed does not come around too often, a battle that began every legend told about the warriors that gained eternal glory. \nThe battle that followed seemed like a lost one from the very beginning. \nThe enemy army was revealed at dawn, illuminated by the rising Sun.The ground shook as countless hordes marched towards a small band of men armed with shields, spears and swords.\nThe hodlers were outnumbered, one thousand to one. \nFear, doubt and uncertainty did not reach their hearts and minds - for they were born for this. \nEach hodler was bred for warfare, instructed in bloodshed, groomed to become a poet of death. \nA philosopher of war, blood and glory. \nEach man was forged into an invincible soldier that had a single driving force during each battle.\nStand your ground - at all costs. \nAs the swarm of enemies approached, the king yelled, asking his men: \n“Hodlers! What is your profession?”\n“HODL! HODL! HODL! HODL!!! HODL!!!!!” they replied, hitting spears against their shields. \nAn endless stream of arrows fell from the heavens only moments later, blocking out the Sun so they could fight in the shade. They emerged from the darkness without even a single scratch, protected by their legendary Enjin shields. \nWave after wave, their enemies rushed towards their doom, as they were met with cold tips of thrusting spears and sharp edges of crimson swords.\nAgainst all odds, the wall of men and steel held against the never-ending, shilling swarm. \nWhat was left of the enemy army retreated, fleeing in absolute panic and indisputable terror.\nBathed in blood, the ENJ hodlers were victorious.\nTheir story will be told for thousands of years, immortalized with divine blocks and chains.\n* * *\n“HODL” was minted in 2018 for our amazing community of epic Enjin HODLers. We are extremely grateful for the trust you've put in us and the products we're making - and the mission we're trying to accomplish, and hope you’ll love this token of our appreciation. ",
+			"image": "https://cdn.enjin.io/mint/image/70000000000001b2.jpg"
+		  },
+		  "error": null
+		},
+		"collection": {
+		  "name": "Unidentified contract - SkdH8ZQtyB",
+		  "slug": "unidentified-contract-skdh8zqtyb",
+		  "externalUrl": null,
+		  "bannerImageUrl": null
+		},
+		"mint": {
+		  "mintAddress": null,
+		  "blockNumber": null,
+		  "timestamp": null,
+		  "transactionHash": null
+		},
+		"owners": null,
+		"timeLastUpdated": "2024-01-03T19:11:04.681Z",
+		"balance": "1",
+		"acquiredAt": {
+		  "blockTimestamp": null,
+		  "blockNumber": null
+		}
+	  },
+	  {
+		"contract": {
+		  "address": "0x3f6B1585AfeFc56433C8d28AA89dbc77af59278f",
+		  "name": "Simpson Punk",
+		  "symbol": "SIMPUNK",
+		  "totalSupply": "1789",
+		  "tokenType": "ERC721",
+		  "contractDeployer": "0xa74E02F671e00eeFbf4e13D9D89B397523653E67",
+		  "deployedBlockNumber": 18607457,
+		  "openSeaMetadata": {
+			"floorPrice": 0.00069,
+			"collectionName": "SimpsonPunks",
+			"collectionSlug": "simpsonpunkseth",
+			"safelistRequestStatus": "not_requested",
+			"imageUrl": "https://raw.seadn.io/files/e7765f13c4658f514d0efc008ae7f300.png",
+			"description": "1,789 SimpsonPunks entered the Blockchain????",
+			"externalUrl": null,
+			"twitterUsername": "SimpsonPunksETH",
+			"discordUrl": null,
+			"bannerImageUrl": null,
+			"lastIngestedAt": "2024-01-31T00:06:00.000Z"
+		  },
+		  "isSpam": null,
+		  "spamClassifications": []
+		},
+		"tokenId": "900",
+		"tokenType": "ERC721",
+		"name": "#900",
+		"description": "5,555 SimpsonPunks entered the Ethereum Blockchain🍩",
+		"tokenUri": "https://alchemy.mypinata.cloud/ipfs/bafybeidqbmbglapk2bkffa4o2ws5jhxnhlbdeqh7k6tk62pukse3xhvv2e/900.json",
+		"image": {
+		  "cachedUrl": "https://nft-cdn.alchemy.com/eth-mainnet/52accf48dc609088738b15808fe07e8c",
+		  "thumbnailUrl": "https://res.cloudinary.com/alchemyapi/image/upload/thumbnailv2/eth-mainnet/52accf48dc609088738b15808fe07e8c",
+		  "pngUrl": "https://res.cloudinary.com/alchemyapi/image/upload/convert-png/eth-mainnet/52accf48dc609088738b15808fe07e8c",
+		  "contentType": "image/png",
+		  "size": 21206,
+		  "originalUrl": "https://ipfs.io/ipfs/bafybeib2metombffkovfzbjhljpcmobb5wqazsbpenz2drysgm7und47ym/900.png"
+		},
+		"raw": {
+		  "tokenUri": "ipfs://bafybeidqbmbglapk2bkffa4o2ws5jhxnhlbdeqh7k6tk62pukse3xhvv2e/900.json",
+		  "metadata": {
+			"date": 1700514890266,
+			"image": "ipfs://bafybeib2metombffkovfzbjhljpcmobb5wqazsbpenz2drysgm7und47ym/900.png",
+			"name": "#900",
+			"description": "5,555 SimpsonPunks entered the Ethereum Blockchain🍩",
+			"edition": 900,
+			"attributes": [
+			  {
+				"value": "Background",
+				"trait_type": "layers"
+			  },
+			  {
+				"value": "Monkey",
+				"trait_type": "Face"
+			  },
+			  {
+				"value": "Sweatband Blue",
+				"trait_type": "Head"
+			  },
+			  {
+				"value": "Thin Full",
+				"trait_type": "Facial Hair"
+			  },
+			  {
+				"value": "Burger",
+				"trait_type": "Mouth"
+			  }
+			],
+			"imageHash": "c1055d7f183405a5ec934bf6d83ac653740795cbf40031e3b34e957a352b471c",
+			"compiler": "HashLips Art Engine - NFTChef fork"
+		  },
+		  "error": null
+		},
+		"collection": {
+		  "name": "SimpsonPunks",
+		  "slug": "simpsonpunkseth",
+		  "externalUrl": null,
+		  "bannerImageUrl": null
+		},
+		"mint": {
+		  "mintAddress": null,
+		  "blockNumber": null,
+		  "timestamp": null,
+		  "transactionHash": null
+		},
+		"owners": null,
+		"timeLastUpdated": "2024-01-03T21:02:33.333Z",
+		"balance": "1",
+		"acquiredAt": {
+		  "blockTimestamp": null,
+		  "blockNumber": null
+		}
+	  }
+	],
+	"totalCount": 53,
+	"validAt": {
+	  "blockNumber": 19169748,
+	  "blockHash": "0x95badbc2af9d0fa4ecfb614e6f24910e027b3e0a5c6fa4c32521ff5bc7754693",
+	  "blockTimestamp": "2024-02-06T14:20:11Z"
+	},
+	"pageKey": "MHgyYjE4NzA3NTIyMDg5MzVmZGEzMmFiNmEwMTZjMDFhMjc4NzdjZjEyOjB4NzgwMDAwMDAwMDAwMDIyZTAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDpmYWxzZQ=="
+  }`

--- a/services/wallet/thirdparty/alchemy/types.go
+++ b/services/wallet/thirdparty/alchemy/types.go
@@ -172,13 +172,25 @@ func alchemyToCollectibleTraits(attributes []Attribute) []thirdparty.Collectible
 	return ret
 }
 
+func alchemyToContractType(tokenType string) walletCommon.ContractType {
+	switch tokenType {
+	case "ERC721":
+		return walletCommon.ContractTypeERC721
+	case "ERC1155":
+		return walletCommon.ContractTypeERC1155
+	default:
+		return walletCommon.ContractTypeUnknown
+	}
+}
+
 func (c *Contract) toCollectionData(id thirdparty.ContractID) thirdparty.CollectionData {
 	ret := thirdparty.CollectionData{
-		ID:       id,
-		Provider: AlchemyID,
-		Name:     c.Name,
-		ImageURL: c.OpenSeaMetadata.ImageURL,
-		Traits:   make(map[string]thirdparty.CollectionTrait, 0),
+		ID:           id,
+		ContractType: alchemyToContractType(c.TokenType),
+		Provider:     AlchemyID,
+		Name:         c.Name,
+		ImageURL:     c.OpenSeaMetadata.ImageURL,
+		Traits:       make(map[string]thirdparty.CollectionTrait, 0),
 	}
 	return ret
 }
@@ -188,6 +200,7 @@ func (c *Asset) toCollectiblesData(id thirdparty.CollectibleUniqueID) thirdparty
 
 	return thirdparty.CollectibleData{
 		ID:           id,
+		ContractType: alchemyToContractType(c.Contract.TokenType),
 		Provider:     AlchemyID,
 		Name:         c.Name,
 		Description:  c.Description,

--- a/services/wallet/thirdparty/collectible_types.go
+++ b/services/wallet/thirdparty/collectible_types.go
@@ -104,12 +104,13 @@ type CollectionTrait struct {
 
 // Collection info
 type CollectionData struct {
-	ID           ContractID `json:"id"`
-	CommunityID  string     `json:"community_id"`
-	Provider     string     `json:"provider"`
-	Name         string     `json:"name"`
-	Slug         string     `json:"slug"`
-	ImageURL     string     `json:"image_url"`
+	ID           ContractID            `json:"id"`
+	ContractType w_common.ContractType `json:"contract_type"`
+	CommunityID  string                `json:"community_id"`
+	Provider     string                `json:"provider"`
+	Name         string                `json:"name"`
+	Slug         string                `json:"slug"`
+	ImageURL     string                `json:"image_url"`
 	ImagePayload []byte
 	Traits       map[string]CollectionTrait `json:"traits"`
 }
@@ -123,13 +124,14 @@ type CollectibleTrait struct {
 
 // Collectible info
 type CollectibleData struct {
-	ID                 CollectibleUniqueID `json:"id"`
-	CommunityID        string              `json:"community_id"`
-	Provider           string              `json:"provider"`
-	Name               string              `json:"name"`
-	Description        string              `json:"description"`
-	Permalink          string              `json:"permalink"`
-	ImageURL           string              `json:"image_url"`
+	ID                 CollectibleUniqueID   `json:"id"`
+	ContractType       w_common.ContractType `json:"contract_type"`
+	CommunityID        string                `json:"community_id"`
+	Provider           string                `json:"provider"`
+	Name               string                `json:"name"`
+	Description        string                `json:"description"`
+	Permalink          string                `json:"permalink"`
+	ImageURL           string                `json:"image_url"`
 	ImagePayload       []byte
 	AnimationURL       string             `json:"animation_url"`
 	AnimationMediaType string             `json:"animation_media_type"`

--- a/services/wallet/thirdparty/opensea/client_v2.go
+++ b/services/wallet/thirdparty/opensea/client_v2.go
@@ -311,7 +311,7 @@ func (o *ClientV2) FetchCollectionsDataByContractID(ctx context.Context, contrac
 			return nil, err
 		}
 
-		ret = append(ret, collectionData.toCommon(id))
+		ret = append(ret, collectionData.toCommon(id, contractData.ContractStandard))
 	}
 
 	return ret, nil

--- a/services/wallet/thirdparty/opensea/types_v2.go
+++ b/services/wallet/thirdparty/opensea/types_v2.go
@@ -46,6 +46,17 @@ func chainIDToChainString(chainID walletCommon.ChainID) string {
 	return chainString
 }
 
+func openseaToContractType(contractType string) walletCommon.ContractType {
+	switch contractType {
+	case "cryptopunks", "erc721":
+		return walletCommon.ContractTypeERC721
+	case "erc1155":
+		return walletCommon.ContractTypeERC1155
+	default:
+		return walletCommon.ContractTypeUnknown
+	}
+}
+
 type NFTContainer struct {
 	NFTs       []NFT  `json:"nfts"`
 	NextCursor string `json:"next"`
@@ -149,6 +160,7 @@ func (c *NFT) id(chainID walletCommon.ChainID) thirdparty.CollectibleUniqueID {
 func (c *NFT) toCollectiblesData(chainID walletCommon.ChainID) thirdparty.CollectibleData {
 	return thirdparty.CollectibleData{
 		ID:           c.id(chainID),
+		ContractType: openseaToContractType(c.TokenStandard),
 		Provider:     OpenseaV2ID,
 		Name:         c.Name,
 		Description:  c.Description,
@@ -195,6 +207,7 @@ func (c *DetailedNFT) id(chainID walletCommon.ChainID) thirdparty.CollectibleUni
 func (c *DetailedNFT) toCollectiblesData(chainID walletCommon.ChainID) thirdparty.CollectibleData {
 	return thirdparty.CollectibleData{
 		ID:           c.id(chainID),
+		ContractType: openseaToContractType(c.TokenStandard),
 		Provider:     OpenseaV2ID,
 		Name:         c.Name,
 		Description:  c.Description,
@@ -212,13 +225,14 @@ func (c *DetailedNFT) toCommon(chainID walletCommon.ChainID) thirdparty.FullColl
 	}
 }
 
-func (c *CollectionData) toCommon(id thirdparty.ContractID) thirdparty.CollectionData {
+func (c *CollectionData) toCommon(id thirdparty.ContractID, tokenStandard string) thirdparty.CollectionData {
 	ret := thirdparty.CollectionData{
-		ID:       id,
-		Provider: OpenseaV2ID,
-		Name:     c.Name,
-		Slug:     c.Collection,
-		ImageURL: c.ImageURL,
+		ID:           id,
+		ContractType: openseaToContractType(tokenStandard),
+		Provider:     OpenseaV2ID,
+		Name:         c.Name,
+		Slug:         c.Collection,
+		ImageURL:     c.ImageURL,
 	}
 	return ret
 }

--- a/services/wallet/thirdparty/rarible/client_test.go
+++ b/services/wallet/thirdparty/rarible/client_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/services/wallet/bigint"
+	w_common "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 
 	"github.com/stretchr/testify/assert"
@@ -18,10 +19,11 @@ func TestUnmarshallCollection(t *testing.T) {
 			ChainID: 1,
 			Address: common.HexToAddress("0x06012c8cf97bead5deae237070f9587f8e7a266d"),
 		},
-		Provider: "rarible",
-		Name:     "CryptoKitties",
-		ImageURL: "https://i.seadn.io/gae/C272ZRW1RGGef9vKMePFSCeKc1Lw6U40wl9ofNVxzUxFdj84hH9xJRQNf-7wgs7W8qw8RWe-1ybKp-VKuU5D-tg?w=500&auto=format",
-		Traits:   make(map[string]thirdparty.CollectionTrait),
+		ContractType: w_common.ContractTypeERC721,
+		Provider:     "rarible",
+		Name:         "CryptoKitties",
+		ImageURL:     "https://i.seadn.io/gae/C272ZRW1RGGef9vKMePFSCeKc1Lw6U40wl9ofNVxzUxFdj84hH9xJRQNf-7wgs7W8qw8RWe-1ybKp-VKuU5D-tg?w=500&auto=format",
+		Traits:       make(map[string]thirdparty.CollectionTrait),
 	}
 
 	collection := Collection{}
@@ -51,6 +53,7 @@ func TestUnmarshallOwnedCollectibles(t *testing.T) {
 						Int: expectedTokenID0,
 					},
 				},
+				ContractType: w_common.ContractTypeUnknown,
 				Provider:     "rarible",
 				Name:         "Rariversary #002",
 				Description:  "Today marks your Second Rariversary! Can you believe it’s already been two years? Time flies when you’re having fun! Thank you for everything you contribute!",
@@ -85,6 +88,7 @@ func TestUnmarshallOwnedCollectibles(t *testing.T) {
 						Int: expectedTokenID1,
 					},
 				},
+				ContractType: w_common.ContractTypeUnknown,
 				Provider:     "rarible",
 				Name:         "Rariversary #003",
 				Description:  "Today marks your Third Rariversary! Can you believe it’s already been three years? Time flies when you’re having fun! We’ve loved working with you these years and can’t wait to see what the next few years bring. Thank you for everything you contribute!",

--- a/services/wallet/thirdparty/rarible/types.go
+++ b/services/wallet/thirdparty/rarible/types.go
@@ -54,6 +54,17 @@ func chainIDToChainString(chainID walletCommon.ChainID) string {
 	return chainString
 }
 
+func raribleToContractType(contractType string) walletCommon.ContractType {
+	switch contractType {
+	case "CRYPTO_PUNKS", "ERC721":
+		return walletCommon.ContractTypeERC721
+	case "ERC1155":
+		return walletCommon.ContractTypeERC1155
+	default:
+		return walletCommon.ContractTypeUnknown
+	}
+}
+
 func raribleContractIDToUniqueID(contractID string, isMainnet bool) (thirdparty.ContractID, error) {
 	ret := thirdparty.ContractID{}
 
@@ -147,10 +158,11 @@ func (st *AttributeValue) UnmarshalJSON(b []byte) error {
 }
 
 type Collection struct {
-	ID         string             `json:"id"`
-	Blockchain string             `json:"blockchain"`
-	Name       string             `json:"name"`
-	Metadata   CollectionMetadata `json:"meta"`
+	ID           string             `json:"id"`
+	Blockchain   string             `json:"blockchain"`
+	ContractType string             `json:"type"`
+	Name         string             `json:"name"`
+	Metadata     CollectionMetadata `json:"meta"`
 }
 
 type CollectionMetadata struct {
@@ -237,12 +249,13 @@ func raribleToCollectiblesData(l []Collectible, isMainnet bool) []thirdparty.Ful
 
 func (c *Collection) toCommon(id thirdparty.ContractID) thirdparty.CollectionData {
 	ret := thirdparty.CollectionData{
-		ID:       id,
-		Provider: RaribleID,
-		Name:     c.Metadata.Name,
-		Slug:     "", /* Missing from the API for now */
-		ImageURL: getImageURL(c.Metadata.Contents),
-		Traits:   make(map[string]thirdparty.CollectionTrait, 0), /* Missing from the API for now */
+		ID:           id,
+		ContractType: raribleToContractType(c.ContractType),
+		Provider:     RaribleID,
+		Name:         c.Metadata.Name,
+		Slug:         "", /* Missing from the API for now */
+		ImageURL:     getImageURL(c.Metadata.Contents),
+		Traits:       make(map[string]thirdparty.CollectionTrait, 0), /* Missing from the API for now */
 	}
 	return ret
 }
@@ -326,6 +339,7 @@ func (c *Collectible) toCollectibleData(id thirdparty.CollectibleUniqueID) third
 
 	return thirdparty.CollectibleData{
 		ID:           id,
+		ContractType: walletCommon.ContractTypeUnknown, // Rarible doesn't provide the contract type with the collectible
 		Provider:     RaribleID,
 		Name:         c.Metadata.Name,
 		Description:  c.Metadata.Description,

--- a/services/wallet/thirdparty/test_utils.go
+++ b/services/wallet/thirdparty/test_utils.go
@@ -11,6 +11,13 @@ import (
 	w_common "github.com/status-im/status-go/services/wallet/common"
 )
 
+func generateContractType(seed int) w_common.ContractType {
+	if seed%2 == 0 {
+		return w_common.ContractTypeERC721
+	}
+	return w_common.ContractTypeERC1155
+}
+
 func GenerateTestCollectiblesData(count int) (result []CollectibleData) {
 	base := rand.Intn(100) // nolint: gosec
 
@@ -25,6 +32,7 @@ func GenerateTestCollectiblesData(count int) (result []CollectibleData) {
 				},
 				TokenID: &bigint.BigInt{Int: bigI},
 			},
+			ContractType:       generateContractType(i),
 			Provider:           fmt.Sprintf("provider-%d", i),
 			Name:               fmt.Sprintf("name-%d", i),
 			Description:        fmt.Sprintf("description-%d", i),
@@ -107,6 +115,7 @@ func GenerateTestCollectionsData(count int) (result []CollectionData) {
 				ChainID: w_common.ChainID(i),
 				Address: common.BigToAddress(bigI),
 			},
+			ContractType: generateContractType(i),
 			Provider:     fmt.Sprintf("provider-%d", i),
 			Name:         fmt.Sprintf("name-%d", i),
 			Slug:         fmt.Sprintf("slug-%d", i),
@@ -150,6 +159,9 @@ func GenerateTestFullCollectiblesData(count int) []FullCollectibleData {
 
 	ret := make([]FullCollectibleData, 0, count)
 	for i := 0; i < count; i++ {
+		// Ensure consistent ContracType
+		collectionsData[i].ContractType = collectiblesData[i].ContractType
+
 		ret = append(ret, FullCollectibleData{
 			CollectibleData:          collectiblesData[i],
 			CollectionData:           &collectionsData[i],

--- a/walletdatabase/migrations/bindata.go
+++ b/walletdatabase/migrations/bindata.go
@@ -21,6 +21,7 @@
 // 1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql (73B)
 // 1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql (84B)
 // 1706531789_remove_gasfee-only-eth-transfers.up.sql (627B)
+// 1707160323_add_contract_type_table.up.sql (282B)
 // doc.go (74B)
 
 package migrations
@@ -31,7 +32,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,7 +41,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -49,7 +49,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -105,7 +105,7 @@ func _1691753758_initialUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1691753758_initial.up.sql", size: 5738, mode: os.FileMode(0644), modTime: time.Unix(1701079799, 0)}
+	info := bindataFileInfo{name: "1691753758_initial.up.sql", size: 5738, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6b, 0x25, 0x31, 0xc8, 0x27, 0x3, 0x6b, 0x9f, 0x15, 0x42, 0x2f, 0x85, 0xfb, 0xe3, 0x6, 0xea, 0xf7, 0x97, 0x12, 0x56, 0x3c, 0x9a, 0x5b, 0x1a, 0xca, 0xb1, 0x23, 0xfa, 0xcd, 0x57, 0x25, 0x5c}}
 	return a, nil
 }
@@ -125,7 +125,7 @@ func _1692701329_add_collectibles_and_collections_data_cacheUpSql() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1692701329_add_collectibles_and_collections_data_cache.up.sql", size: 1808, mode: os.FileMode(0644), modTime: time.Unix(1699882401, 0)}
+	info := bindataFileInfo{name: "1692701329_add_collectibles_and_collections_data_cache.up.sql", size: 1808, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1, 0x51, 0xf4, 0x2b, 0x92, 0xde, 0x59, 0x65, 0xd8, 0x9b, 0x57, 0xe0, 0xfd, 0x7b, 0x12, 0xb, 0x29, 0x6e, 0x9d, 0xb5, 0x90, 0xe, 0xfa, 0x12, 0x97, 0xd, 0x61, 0x60, 0x7f, 0x32, 0x1d, 0xc3}}
 	return a, nil
 }
@@ -145,7 +145,7 @@ func _1692701339_add_scope_to_pendingUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1692701339_add_scope_to_pending.up.sql", size: 576, mode: os.FileMode(0644), modTime: time.Unix(1699882401, 0)}
+	info := bindataFileInfo{name: "1692701339_add_scope_to_pending.up.sql", size: 576, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x36, 0x8a, 0x5e, 0xe2, 0x63, 0x15, 0x37, 0xba, 0x55, 0x18, 0xf3, 0xcc, 0xe0, 0x5, 0x84, 0xe1, 0x5b, 0xe8, 0x1, 0x32, 0x6b, 0x9f, 0x7d, 0x9f, 0xd9, 0x23, 0x6c, 0xa9, 0xb5, 0xdc, 0xf4, 0x93}}
 	return a, nil
 }
@@ -165,7 +165,7 @@ func _1694540071_add_collectibles_ownership_update_timestampUpSql() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1694540071_add_collectibles_ownership_update_timestamp.up.sql", size: 349, mode: os.FileMode(0644), modTime: time.Unix(1699882401, 0)}
+	info := bindataFileInfo{name: "1694540071_add_collectibles_ownership_update_timestamp.up.sql", size: 349, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7f, 0x45, 0xc7, 0xce, 0x79, 0x63, 0xbc, 0x6f, 0x83, 0x5f, 0xe2, 0x3, 0x56, 0xcc, 0x5, 0x2f, 0x85, 0xda, 0x7e, 0xea, 0xf5, 0xd2, 0xac, 0x19, 0xd4, 0xd8, 0x5e, 0xdd, 0xed, 0xe2, 0xa9, 0x97}}
 	return a, nil
 }
@@ -185,7 +185,7 @@ func _1694692748_add_raw_balance_to_token_balancesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1694692748_add_raw_balance_to_token_balances.up.sql", size: 165, mode: os.FileMode(0644), modTime: time.Unix(1699882401, 0)}
+	info := bindataFileInfo{name: "1694692748_add_raw_balance_to_token_balances.up.sql", size: 165, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd4, 0xe0, 0x5b, 0x42, 0xf0, 0x96, 0xa5, 0xf5, 0xed, 0xc0, 0x97, 0x88, 0xb0, 0x6d, 0xfe, 0x7d, 0x97, 0x2e, 0x17, 0xd2, 0x16, 0xbc, 0x2a, 0xf2, 0xcc, 0x67, 0x9e, 0xc5, 0x47, 0xf6, 0x69, 0x1}}
 	return a, nil
 }
@@ -205,7 +205,7 @@ func _1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSq
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql", size: 275, mode: os.FileMode(0644), modTime: time.Unix(1699882401, 0)}
+	info := bindataFileInfo{name: "1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql", size: 275, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xfa, 0x2, 0xa, 0x7f, 0x4b, 0xd1, 0x3, 0xd0, 0x3, 0x29, 0x84, 0x31, 0xed, 0x49, 0x4f, 0xb1, 0x2d, 0xd7, 0x80, 0x41, 0x5b, 0xfa, 0x6, 0xae, 0xb4, 0xf6, 0x6b, 0x49, 0xee, 0x57, 0x33, 0x76}}
 	return a, nil
 }
@@ -225,7 +225,7 @@ func _1695932536_balance_history_v2UpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1695932536_balance_history_v2.up.sql", size: 653, mode: os.FileMode(0644), modTime: time.Unix(1699882401, 0)}
+	info := bindataFileInfo{name: "1695932536_balance_history_v2.up.sql", size: 653, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x37, 0xf4, 0x14, 0x91, 0xf6, 0x5f, 0xc4, 0x9b, 0xb7, 0x83, 0x32, 0x72, 0xbe, 0x82, 0x42, 0x39, 0xa4, 0x3b, 0xc9, 0x78, 0x3d, 0xca, 0xd4, 0xbf, 0xfc, 0x7a, 0x33, 0x1e, 0xcd, 0x9e, 0xe4, 0x85}}
 	return a, nil
 }
@@ -245,7 +245,7 @@ func _1696853635_input_dataUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1696853635_input_data.up.sql", size: 23140, mode: os.FileMode(0644), modTime: time.Unix(1699882401, 0)}
+	info := bindataFileInfo{name: "1696853635_input_data.up.sql", size: 23140, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x89, 0x30, 0x33, 0x33, 0x55, 0xc5, 0x57, 0x2b, 0xaf, 0xef, 0x3d, 0x8d, 0x2a, 0xaa, 0x5c, 0x32, 0xd1, 0xf4, 0xd, 0x4a, 0xd0, 0x33, 0x4a, 0xe8, 0xf6, 0x8, 0x6b, 0x65, 0xcc, 0xba, 0xed, 0x42}}
 	return a, nil
 }
@@ -265,7 +265,7 @@ func _1698117918_add_community_id_to_tokensUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1698117918_add_community_id_to_tokens.up.sql", size: 61, mode: os.FileMode(0644), modTime: time.Unix(1699882401, 0)}
+	info := bindataFileInfo{name: "1698117918_add_community_id_to_tokens.up.sql", size: 61, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb3, 0x82, 0xdb, 0xde, 0x3, 0x3, 0xc, 0x67, 0xf3, 0x54, 0xc4, 0xad, 0xd6, 0xce, 0x56, 0xfb, 0xc1, 0x87, 0xd7, 0xda, 0xab, 0xec, 0x1, 0xe1, 0x7d, 0xb3, 0x63, 0xd6, 0xe5, 0x5d, 0x1c, 0x15}}
 	return a, nil
 }
@@ -285,7 +285,7 @@ func _1698257443_add_community_metadata_to_wallet_dbUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1698257443_add_community_metadata_to_wallet_db.up.sql", size: 323, mode: os.FileMode(0644), modTime: time.Unix(1699882401, 0)}
+	info := bindataFileInfo{name: "1698257443_add_community_metadata_to_wallet_db.up.sql", size: 323, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x22, 0xd3, 0x4, 0x25, 0xfa, 0x23, 0x1, 0x48, 0x83, 0x26, 0x20, 0xf2, 0x3d, 0xbc, 0xc1, 0xa7, 0x7c, 0x27, 0x7c, 0x1d, 0x63, 0x3, 0xa, 0xd0, 0xce, 0x47, 0x86, 0xdc, 0xa1, 0x3c, 0x2, 0x1c}}
 	return a, nil
 }
@@ -305,7 +305,7 @@ func _1699987075_add_timestamp_and_state_to_community_data_cacheUpSql() (*asset,
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1699987075_add_timestamp_and_state_to_community_data_cache.up.sql", size: 865, mode: os.FileMode(0644), modTime: time.Unix(1701152469, 0)}
+	info := bindataFileInfo{name: "1699987075_add_timestamp_and_state_to_community_data_cache.up.sql", size: 865, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc3, 0xee, 0x37, 0xf9, 0x7f, 0x9e, 0xfe, 0x93, 0x66, 0x2b, 0xd, 0x57, 0xf4, 0x89, 0x6c, 0x51, 0xfd, 0x14, 0xe9, 0xcd, 0xab, 0x65, 0xe7, 0xa7, 0x83, 0x7e, 0xe0, 0x5c, 0x14, 0x49, 0xf3, 0xe5}}
 	return a, nil
 }
@@ -325,7 +325,7 @@ func _1700414564_add_wallet_connect_pairings_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1700414564_add_wallet_connect_pairings_table.up.sql", size: 439, mode: os.FileMode(0644), modTime: time.Unix(1701326149, 0)}
+	info := bindataFileInfo{name: "1700414564_add_wallet_connect_pairings_table.up.sql", size: 439, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa9, 0x77, 0x5e, 0x19, 0x62, 0x3c, 0x3a, 0x81, 0x16, 0xa0, 0x95, 0x35, 0x62, 0xab, 0x5e, 0x2b, 0xea, 0x11, 0x71, 0x11, 0xd0, 0x9, 0xab, 0x9c, 0xab, 0xf2, 0xdd, 0x5f, 0x88, 0x83, 0x9a, 0x93}}
 	return a, nil
 }
@@ -345,7 +345,7 @@ func _1701101493_add_token_blocks_rangeUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1701101493_add_token_blocks_range.up.sql", size: 469, mode: os.FileMode(0644), modTime: time.Unix(1701789135, 0)}
+	info := bindataFileInfo{name: "1701101493_add_token_blocks_range.up.sql", size: 469, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe0, 0x37, 0xfb, 0x1a, 0x6c, 0x8c, 0xa8, 0x1e, 0xa2, 0xa5, 0x1f, 0x90, 0x73, 0x3e, 0x31, 0x5f, 0x48, 0x1e, 0x9a, 0x37, 0x27, 0x1c, 0xc, 0x67, 0x1, 0xcd, 0xec, 0x85, 0x4c, 0x1c, 0x26, 0x52}}
 	return a, nil
 }
@@ -365,7 +365,7 @@ func _1702467441_wallet_connect_sessions_instead_of_pairingsUpSql() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1702467441_wallet_connect_sessions_instead_of_pairings.up.sql", size: 356, mode: os.FileMode(0644), modTime: time.Unix(1705494454, 0)}
+	info := bindataFileInfo{name: "1702467441_wallet_connect_sessions_instead_of_pairings.up.sql", size: 356, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x73, 0x5f, 0x0, 0x60, 0x6, 0x28, 0x76, 0x61, 0x39, 0xdc, 0xa1, 0x84, 0x80, 0x46, 0x8a, 0xe4, 0x42, 0xb5, 0x1f, 0x18, 0x14, 0x23, 0x46, 0xb9, 0x51, 0xf, 0x62, 0xac, 0xc, 0x7, 0x98, 0xe}}
 	return a, nil
 }
@@ -385,7 +385,7 @@ func _1702577524_add_community_collections_and_collectibles_images_cacheUpSql() 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1702577524_add_community_collections_and_collectibles_images_cache.up.sql", size: 210, mode: os.FileMode(0644), modTime: time.Unix(1705494454, 0)}
+	info := bindataFileInfo{name: "1702577524_add_community_collections_and_collectibles_images_cache.up.sql", size: 210, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8e, 0x1b, 0x32, 0x2c, 0xfa, 0x11, 0x5e, 0x5e, 0x5d, 0xef, 0x92, 0xa0, 0x29, 0x52, 0xbf, 0x6e, 0xe3, 0x30, 0xe4, 0xdf, 0xdc, 0x5, 0xbe, 0xd1, 0xf8, 0x3e, 0xd9, 0x9b, 0xd6, 0x9b, 0x95, 0x96}}
 	return a, nil
 }
@@ -405,7 +405,7 @@ func _1702867707_add_balance_to_collectibles_ownership_cacheUpSql() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1702867707_add_balance_to_collectibles_ownership_cache.up.sql", size: 289, mode: os.FileMode(0644), modTime: time.Unix(1705494454, 0)}
+	info := bindataFileInfo{name: "1702867707_add_balance_to_collectibles_ownership_cache.up.sql", size: 289, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6f, 0x63, 0x30, 0x11, 0x22, 0xb9, 0xee, 0xae, 0xb8, 0xc4, 0xe6, 0xd3, 0x7, 0xc, 0xe6, 0xa3, 0x72, 0x8c, 0x6, 0x9d, 0x6c, 0x97, 0x8f, 0xb2, 0xd0, 0x37, 0x69, 0x69, 0x6, 0x7f, 0x67, 0x94}}
 	return a, nil
 }
@@ -425,7 +425,7 @@ func _1703686612_add_color_to_saved_addressesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1703686612_add_color_to_saved_addresses.up.sql", size: 114, mode: os.FileMode(0644), modTime: time.Unix(1705494454, 0)}
+	info := bindataFileInfo{name: "1703686612_add_color_to_saved_addresses.up.sql", size: 114, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb7, 0x6e, 0x8d, 0xc0, 0x49, 0xc, 0xb, 0x66, 0xa0, 0x77, 0x32, 0x76, 0xa8, 0xd0, 0x40, 0xce, 0x67, 0xa, 0x9e, 0x23, 0x36, 0xe, 0xc3, 0xd3, 0x9d, 0xe2, 0xde, 0x60, 0x19, 0xba, 0x44, 0xf1}}
 	return a, nil
 }
@@ -445,7 +445,7 @@ func _1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSq
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql", size: 894, mode: os.FileMode(0644), modTime: time.Unix(1705494454, 0)}
+	info := bindataFileInfo{name: "1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql", size: 894, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x70, 0xd3, 0xcf, 0x90, 0xb2, 0xa, 0x23, 0x41, 0x8a, 0xa5, 0x90, 0x7b, 0x34, 0xec, 0x3b, 0x3f, 0xa9, 0xb1, 0x95, 0xf3, 0x2a, 0xdf, 0xbb, 0x53, 0x57, 0x27, 0x2b, 0x12, 0x84, 0xf4, 0x83, 0xda}}
 	return a, nil
 }
@@ -465,7 +465,7 @@ func _1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql(
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql", size: 73, mode: os.FileMode(0644), modTime: time.Unix(1705494454, 0)}
+	info := bindataFileInfo{name: "1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql", size: 73, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa2, 0xf0, 0x71, 0xb5, 0xaf, 0x22, 0xac, 0x77, 0xdb, 0x6f, 0x62, 0x27, 0x12, 0x46, 0x60, 0x3, 0x59, 0x43, 0x6f, 0x1, 0xdc, 0xe8, 0x6e, 0x89, 0xa5, 0x77, 0x37, 0x36, 0xd9, 0x4e, 0x6d, 0x9b}}
 	return a, nil
 }
@@ -485,7 +485,7 @@ func _1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql() (*asse
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql", size: 84, mode: os.FileMode(0644), modTime: time.Unix(1705924960, 0)}
+	info := bindataFileInfo{name: "1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql", size: 84, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3c, 0x49, 0x9, 0xd9, 0x83, 0x3d, 0xd8, 0xb7, 0x4f, 0x8f, 0xc2, 0xa2, 0xd1, 0xb, 0x57, 0x1f, 0x5, 0x39, 0x55, 0xfb, 0x6e, 0x32, 0x9e, 0x19, 0x3d, 0x3c, 0x77, 0xa2, 0xc4, 0xf4, 0x53, 0x35}}
 	return a, nil
 }
@@ -505,8 +505,28 @@ func _1706531789_remove_gasfeeOnlyEthTransfersUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1706531789_remove_gasfee-only-eth-transfers.up.sql", size: 627, mode: os.FileMode(0644), modTime: time.Unix(1706616444, 0)}
+	info := bindataFileInfo{name: "1706531789_remove_gasfee-only-eth-transfers.up.sql", size: 627, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xae, 0x8c, 0x37, 0xd3, 0x2a, 0xf, 0x1a, 0x8, 0xe9, 0xa7, 0x1f, 0x5a, 0x10, 0xa7, 0x4c, 0x36, 0x4f, 0xc6, 0xdc, 0xeb, 0x79, 0x90, 0xe7, 0xcd, 0x4a, 0xef, 0xb7, 0x3, 0x6e, 0x88, 0x6f, 0x79}}
+	return a, nil
+}
+
+var __1707160323_add_contract_type_tableUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x7c\x8f\x3b\x6e\x85\x30\x10\x45\x7b\xaf\xe2\x96\x79\xd2\xdb\xc1\xab\x0c\x4c\xc8\x48\x68\x50\xc0\x8e\xe8\x2c\xcb\x76\x84\x1b\x27\x02\x37\xec\x3e\xca\x07\xa5\xc8\xa7\x3f\x33\xf7\x9c\x76\x22\x6d\x08\x46\x37\x03\x81\xef\x21\xa3\x01\x2d\x3c\x9b\x19\xe1\xa5\xd4\xcd\x87\xea\xea\xf1\x9a\x5c\xf0\x61\x4d\xb8\x53\x00\x10\x56\x9f\x8b\xcb\x11\x56\x66\xee\x85\x3a\x34\xdc\xb3\x98\x8f\x6b\xb1\xc3\x70\xfd\xc4\xce\x07\x3e\xc6\x2d\xed\x3b\x9e\xf4\xd4\x3e\xe8\xe9\x2f\xec\x7d\x07\x2c\x86\x7a\xfa\x66\xd4\xe5\xa6\xd4\x97\xa5\x15\x7e\xb4\x04\x96\x8e\x96\x7f\x65\x73\x4c\xa5\xe6\xe7\xc3\xa5\x52\xb7\x03\xa3\xfc\x1e\x73\x76\x5c\x7f\xa8\x5e\x6e\xea\x2d\x00\x00\xff\xff\x18\xc9\x3c\xf4\x1a\x01\x00\x00")
+
+func _1707160323_add_contract_type_tableUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1707160323_add_contract_type_tableUpSql,
+		"1707160323_add_contract_type_table.up.sql",
+	)
+}
+
+func _1707160323_add_contract_type_tableUpSql() (*asset, error) {
+	bytes, err := _1707160323_add_contract_type_tableUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1707160323_add_contract_type_table.up.sql", size: 282, mode: os.FileMode(0644), modTime: time.Unix(1707160521, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x45, 0x99, 0xd9, 0x86, 0x72, 0x37, 0x97, 0xfc, 0xa7, 0xbb, 0xe3, 0x86, 0xf1, 0xfd, 0x77, 0x31, 0x91, 0xcb, 0xa4, 0x2c, 0x5b, 0xaa, 0x4b, 0xa2, 0x7f, 0x8a, 0x2c, 0x7a, 0xda, 0x20, 0x7a, 0x97}}
 	return a, nil
 }
 
@@ -525,7 +545,7 @@ func docGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "doc.go", size: 74, mode: os.FileMode(0644), modTime: time.Unix(1699882401, 0)}
+	info := bindataFileInfo{name: "doc.go", size: 74, mode: os.FileMode(0644), modTime: time.Unix(1707132935, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xde, 0x7c, 0x28, 0xcd, 0x47, 0xf2, 0xfa, 0x7c, 0x51, 0x2d, 0xd8, 0x38, 0xb, 0xb0, 0x34, 0x9d, 0x4c, 0x62, 0xa, 0x9e, 0x28, 0xc3, 0x31, 0x23, 0xd9, 0xbb, 0x89, 0x9f, 0xa0, 0x89, 0x1f, 0xe8}}
 	return a, nil
 }
@@ -621,60 +641,45 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"1691753758_initial.up.sql": _1691753758_initialUpSql,
-
-	"1692701329_add_collectibles_and_collections_data_cache.up.sql": _1692701329_add_collectibles_and_collections_data_cacheUpSql,
-
-	"1692701339_add_scope_to_pending.up.sql": _1692701339_add_scope_to_pendingUpSql,
-
-	"1694540071_add_collectibles_ownership_update_timestamp.up.sql": _1694540071_add_collectibles_ownership_update_timestampUpSql,
-
-	"1694692748_add_raw_balance_to_token_balances.up.sql": _1694692748_add_raw_balance_to_token_balancesUpSql,
-
+	"1691753758_initial.up.sql":                                                     _1691753758_initialUpSql,
+	"1692701329_add_collectibles_and_collections_data_cache.up.sql":                 _1692701329_add_collectibles_and_collections_data_cacheUpSql,
+	"1692701339_add_scope_to_pending.up.sql":                                        _1692701339_add_scope_to_pendingUpSql,
+	"1694540071_add_collectibles_ownership_update_timestamp.up.sql":                 _1694540071_add_collectibles_ownership_update_timestampUpSql,
+	"1694692748_add_raw_balance_to_token_balances.up.sql":                           _1694692748_add_raw_balance_to_token_balancesUpSql,
 	"1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql": _1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSql,
-
-	"1695932536_balance_history_v2.up.sql": _1695932536_balance_history_v2UpSql,
-
-	"1696853635_input_data.up.sql": _1696853635_input_dataUpSql,
-
-	"1698117918_add_community_id_to_tokens.up.sql": _1698117918_add_community_id_to_tokensUpSql,
-
-	"1698257443_add_community_metadata_to_wallet_db.up.sql": _1698257443_add_community_metadata_to_wallet_dbUpSql,
-
-	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql": _1699987075_add_timestamp_and_state_to_community_data_cacheUpSql,
-
-	"1700414564_add_wallet_connect_pairings_table.up.sql": _1700414564_add_wallet_connect_pairings_tableUpSql,
-
-	"1701101493_add_token_blocks_range.up.sql": _1701101493_add_token_blocks_rangeUpSql,
-
-	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql": _1702467441_wallet_connect_sessions_instead_of_pairingsUpSql,
-
-	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql": _1702577524_add_community_collections_and_collectibles_images_cacheUpSql,
-
-	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql": _1702867707_add_balance_to_collectibles_ownership_cacheUpSql,
-
-	"1703686612_add_color_to_saved_addresses.up.sql": _1703686612_add_color_to_saved_addressesUpSql,
-
+	"1695932536_balance_history_v2.up.sql":                                          _1695932536_balance_history_v2UpSql,
+	"1696853635_input_data.up.sql":                                                  _1696853635_input_dataUpSql,
+	"1698117918_add_community_id_to_tokens.up.sql":                                  _1698117918_add_community_id_to_tokensUpSql,
+	"1698257443_add_community_metadata_to_wallet_db.up.sql":                         _1698257443_add_community_metadata_to_wallet_dbUpSql,
+	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql":             _1699987075_add_timestamp_and_state_to_community_data_cacheUpSql,
+	"1700414564_add_wallet_connect_pairings_table.up.sql":                           _1700414564_add_wallet_connect_pairings_tableUpSql,
+	"1701101493_add_token_blocks_range.up.sql":                                      _1701101493_add_token_blocks_rangeUpSql,
+	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql":                 _1702467441_wallet_connect_sessions_instead_of_pairingsUpSql,
+	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql":     _1702577524_add_community_collections_and_collectibles_images_cacheUpSql,
+	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql":                 _1702867707_add_balance_to_collectibles_ownership_cacheUpSql,
+	"1703686612_add_color_to_saved_addresses.up.sql":                                _1703686612_add_color_to_saved_addressesUpSql,
 	"1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql": _1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSql,
-
-	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql": _1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql,
-
-	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql": _1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql,
-
-	"1706531789_remove_gasfee-only-eth-transfers.up.sql": _1706531789_remove_gasfeeOnlyEthTransfersUpSql,
-
+	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql":   _1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql,
+	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql":           _1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql,
+	"1706531789_remove_gasfee-only-eth-transfers.up.sql":                            _1706531789_remove_gasfeeOnlyEthTransfersUpSql,
+	"1707160323_add_contract_type_table.up.sql":                                     _1707160323_add_contract_type_tableUpSql,
 	"doc.go": docGo,
 }
+
+// AssetDebug is true if the assets were built with the debug flag enabled.
+const AssetDebug = false
 
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and
@@ -707,28 +712,29 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"1691753758_initial.up.sql":                                                     &bintree{_1691753758_initialUpSql, map[string]*bintree{}},
-	"1692701329_add_collectibles_and_collections_data_cache.up.sql":                 &bintree{_1692701329_add_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
-	"1692701339_add_scope_to_pending.up.sql":                                        &bintree{_1692701339_add_scope_to_pendingUpSql, map[string]*bintree{}},
-	"1694540071_add_collectibles_ownership_update_timestamp.up.sql":                 &bintree{_1694540071_add_collectibles_ownership_update_timestampUpSql, map[string]*bintree{}},
-	"1694692748_add_raw_balance_to_token_balances.up.sql":                           &bintree{_1694692748_add_raw_balance_to_token_balancesUpSql, map[string]*bintree{}},
-	"1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql": &bintree{_1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
-	"1695932536_balance_history_v2.up.sql":                                          &bintree{_1695932536_balance_history_v2UpSql, map[string]*bintree{}},
-	"1696853635_input_data.up.sql":                                                  &bintree{_1696853635_input_dataUpSql, map[string]*bintree{}},
-	"1698117918_add_community_id_to_tokens.up.sql":                                  &bintree{_1698117918_add_community_id_to_tokensUpSql, map[string]*bintree{}},
-	"1698257443_add_community_metadata_to_wallet_db.up.sql":                         &bintree{_1698257443_add_community_metadata_to_wallet_dbUpSql, map[string]*bintree{}},
-	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql":             &bintree{_1699987075_add_timestamp_and_state_to_community_data_cacheUpSql, map[string]*bintree{}},
-	"1700414564_add_wallet_connect_pairings_table.up.sql":                           &bintree{_1700414564_add_wallet_connect_pairings_tableUpSql, map[string]*bintree{}},
-	"1701101493_add_token_blocks_range.up.sql":                                      &bintree{_1701101493_add_token_blocks_rangeUpSql, map[string]*bintree{}},
-	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql":                 &bintree{_1702467441_wallet_connect_sessions_instead_of_pairingsUpSql, map[string]*bintree{}},
-	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql":     &bintree{_1702577524_add_community_collections_and_collectibles_images_cacheUpSql, map[string]*bintree{}},
-	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql":                 &bintree{_1702867707_add_balance_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
-	"1703686612_add_color_to_saved_addresses.up.sql":                                &bintree{_1703686612_add_color_to_saved_addressesUpSql, map[string]*bintree{}},
-	"1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql": &bintree{_1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSql, map[string]*bintree{}},
-	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql":   &bintree{_1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
-	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql":           &bintree{_1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql, map[string]*bintree{}},
-	"1706531789_remove_gasfee-only-eth-transfers.up.sql":                            &bintree{_1706531789_remove_gasfeeOnlyEthTransfersUpSql, map[string]*bintree{}},
-	"doc.go": &bintree{docGo, map[string]*bintree{}},
+	"1691753758_initial.up.sql":                                                     {_1691753758_initialUpSql, map[string]*bintree{}},
+	"1692701329_add_collectibles_and_collections_data_cache.up.sql":                 {_1692701329_add_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
+	"1692701339_add_scope_to_pending.up.sql":                                        {_1692701339_add_scope_to_pendingUpSql, map[string]*bintree{}},
+	"1694540071_add_collectibles_ownership_update_timestamp.up.sql":                 {_1694540071_add_collectibles_ownership_update_timestampUpSql, map[string]*bintree{}},
+	"1694692748_add_raw_balance_to_token_balances.up.sql":                           {_1694692748_add_raw_balance_to_token_balancesUpSql, map[string]*bintree{}},
+	"1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql": {_1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
+	"1695932536_balance_history_v2.up.sql":                                          {_1695932536_balance_history_v2UpSql, map[string]*bintree{}},
+	"1696853635_input_data.up.sql":                                                  {_1696853635_input_dataUpSql, map[string]*bintree{}},
+	"1698117918_add_community_id_to_tokens.up.sql":                                  {_1698117918_add_community_id_to_tokensUpSql, map[string]*bintree{}},
+	"1698257443_add_community_metadata_to_wallet_db.up.sql":                         {_1698257443_add_community_metadata_to_wallet_dbUpSql, map[string]*bintree{}},
+	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql":             {_1699987075_add_timestamp_and_state_to_community_data_cacheUpSql, map[string]*bintree{}},
+	"1700414564_add_wallet_connect_pairings_table.up.sql":                           {_1700414564_add_wallet_connect_pairings_tableUpSql, map[string]*bintree{}},
+	"1701101493_add_token_blocks_range.up.sql":                                      {_1701101493_add_token_blocks_rangeUpSql, map[string]*bintree{}},
+	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql":                 {_1702467441_wallet_connect_sessions_instead_of_pairingsUpSql, map[string]*bintree{}},
+	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql":     {_1702577524_add_community_collections_and_collectibles_images_cacheUpSql, map[string]*bintree{}},
+	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql":                 {_1702867707_add_balance_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
+	"1703686612_add_color_to_saved_addresses.up.sql":                                {_1703686612_add_color_to_saved_addressesUpSql, map[string]*bintree{}},
+	"1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql": {_1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSql, map[string]*bintree{}},
+	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql":   {_1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
+	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql":           {_1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql, map[string]*bintree{}},
+	"1706531789_remove_gasfee-only-eth-transfers.up.sql":                            {_1706531789_remove_gasfeeOnlyEthTransfersUpSql, map[string]*bintree{}},
+	"1707160323_add_contract_type_table.up.sql":                                     {_1707160323_add_contract_type_tableUpSql, map[string]*bintree{}},
+	"doc.go": {docGo, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.
@@ -745,7 +751,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/walletdatabase/migrations/sql/1707160323_add_contract_type_table.up.sql
+++ b/walletdatabase/migrations/sql/1707160323_add_contract_type_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS contract_type_cache (
+    chain_id UNSIGNED BIGINT NOT NULL,
+    contract_address VARCHAR NOT NULL,
+    contract_type INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS contract_type_identify_entry ON contract_type_cache (chain_id, contract_address);


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/13433

We now fetch the contract type (ERC721 / ERC1155) for collectibles from our providers and include that info in the data types available in the API.

Some providers return this info in each Collectible entry and some return it only in the Collection data, there's some logic to account for that. 
