### PR TITLE
Feat: Dispatch profile showcase on contacts change

### DIFF
--- a/protocol/messenger_contact_verification.go
+++ b/protocol/messenger_contact_verification.go
@@ -451,6 +451,12 @@ func (m *Messenger) VerifiedTrusted(ctx context.Context, request *requests.Verif
 		return nil, err
 	}
 
+	// Dispatch profile message to save a contact to the encrypted profile part
+	err = m.DispatchProfileShowcase()
+	if err != nil {
+		return nil, err
+	}
+
 	response := &MessengerResponse{}
 
 	notification.ContactVerificationStatus = verification.RequestStatusTRUSTED
@@ -554,6 +560,12 @@ func (m *Messenger) VerifiedUntrustworthy(ctx context.Context, request *requests
 
 	// We sync the contact with the other devices
 	err = m.syncContact(context.Background(), contact, m.dispatchMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	// Dispatch profile message to remove a contact from the encrypted profile part
+	err = m.DispatchProfileShowcase()
 	if err != nil {
 		return nil, err
 	}
@@ -709,6 +721,12 @@ func (m *Messenger) MarkAsUntrustworthy(ctx context.Context, contactID string) e
 
 func (m *Messenger) RemoveTrustStatus(ctx context.Context, contactID string) error {
 	err := m.verificationDatabase.SetTrustStatus(contactID, verification.TrustStatusUNKNOWN, m.getTimesource().GetCurrentTime())
+	if err != nil {
+		return err
+	}
+
+	// Dispatch profile message to remove a contact from the encrypted profile part
+	err = m.DispatchProfileShowcase()
 	if err != nil {
 		return err
 	}

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -303,6 +303,12 @@ func (m *Messenger) updateAcceptedContactRequest(response *MessengerResponse, co
 		if err != nil {
 			return nil, err
 		}
+
+		// Dispatch profile message to add a contact to the encrypted profile part
+		err = m.DispatchProfileShowcase()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if response == nil {
@@ -678,6 +684,12 @@ func (m *Messenger) removeContact(ctx context.Context, response *MessengerRespon
 
 	// And we re-register for push notications
 	err = m.reregisterForPushNotifications()
+	if err != nil {
+		return err
+	}
+
+	// Dispatch profile message to remove a contact from the encrypted profile part
+	err = m.DispatchProfileShowcase()
 	if err != nil {
 		return err
 	}

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1038,6 +1038,12 @@ func (m *Messenger) handleAcceptContactRequestMessage(state *ReceivedMessageStat
 				return err
 			}
 			chat.UnviewedMessagesCount++
+
+			// Dispatch profile message to add a contact to the encrypted profile part
+			err = m.DispatchProfileShowcase()
+			if err != nil {
+				return err
+			}
 		}
 
 		state.Response.AddChat(chat)
@@ -1106,6 +1112,12 @@ func (m *Messenger) handleRetractContactRequest(state *ReceivedMessageState, con
 
 	timestamp := m.getTimesource().GetCurrentTime()
 	updateMessage, err := m.prepareMutualStateUpdateMessage(contact.ID, MutualStateUpdateTypeRemoved, clock, timestamp, false)
+	if err != nil {
+		return err
+	}
+
+	// Dispatch profile message to remove a contact from the encrypted profile part
+	err = m.DispatchProfileShowcase()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/13083

Dispatch the profile showcase message when a user is adding/removing/verifying/refutes a contact. That's needed because profile showcase message contains two encrypted parts signed by mutual and id verified contacts.
