### PR TITLE
Chore/community events eventual consistency

### DIFF
--- a/eth-node/bridge/geth/public_waku_api.go
+++ b/eth-node/bridge/geth/public_waku_api.go
@@ -10,7 +10,7 @@ import (
 	wakucommon "github.com/status-im/status-go/waku/common"
 )
 
-type gethPublicWakuAPIWrapper struct {
+type GethPublicWakuAPIWrapper struct {
 	api *waku.PublicWakuAPI
 }
 
@@ -20,29 +20,29 @@ func NewGethPublicWakuAPIWrapper(api *waku.PublicWakuAPI) types.PublicWakuAPI {
 		panic("PublicWakuAPI cannot be nil")
 	}
 
-	return &gethPublicWakuAPIWrapper{
+	return &GethPublicWakuAPIWrapper{
 		api: api,
 	}
 }
 
 // AddPrivateKey imports the given private key.
-func (w *gethPublicWakuAPIWrapper) AddPrivateKey(ctx context.Context, privateKey types.HexBytes) (string, error) {
+func (w *GethPublicWakuAPIWrapper) AddPrivateKey(ctx context.Context, privateKey types.HexBytes) (string, error) {
 	return w.api.AddPrivateKey(ctx, hexutil.Bytes(privateKey))
 }
 
 // GenerateSymKeyFromPassword derives a key from the given password, stores it, and returns its ID.
-func (w *gethPublicWakuAPIWrapper) GenerateSymKeyFromPassword(ctx context.Context, passwd string) (string, error) {
+func (w *GethPublicWakuAPIWrapper) GenerateSymKeyFromPassword(ctx context.Context, passwd string) (string, error) {
 	return w.api.GenerateSymKeyFromPassword(ctx, passwd)
 }
 
 // DeleteKeyPair removes the key with the given key if it exists.
-func (w *gethPublicWakuAPIWrapper) DeleteKeyPair(ctx context.Context, key string) (bool, error) {
+func (w *GethPublicWakuAPIWrapper) DeleteKeyPair(ctx context.Context, key string) (bool, error) {
 	return w.api.DeleteKeyPair(ctx, key)
 }
 
 // NewMessageFilter creates a new filter that can be used to poll for
 // (new) messages that satisfy the given criteria.
-func (w *gethPublicWakuAPIWrapper) NewMessageFilter(req types.Criteria) (string, error) {
+func (w *GethPublicWakuAPIWrapper) NewMessageFilter(req types.Criteria) (string, error) {
 	topics := make([]wakucommon.TopicType, len(req.Topics))
 	for index, tt := range req.Topics {
 		topics[index] = wakucommon.TopicType(tt)
@@ -59,13 +59,13 @@ func (w *gethPublicWakuAPIWrapper) NewMessageFilter(req types.Criteria) (string,
 	return w.api.NewMessageFilter(criteria)
 }
 
-func (w *gethPublicWakuAPIWrapper) BloomFilter() []byte {
+func (w *GethPublicWakuAPIWrapper) BloomFilter() []byte {
 	return w.api.BloomFilter()
 }
 
 // GetFilterMessages returns the messages that match the filter criteria and
 // are received between the last poll and now.
-func (w *gethPublicWakuAPIWrapper) GetFilterMessages(id string) ([]*types.Message, error) {
+func (w *GethPublicWakuAPIWrapper) GetFilterMessages(id string) ([]*types.Message, error) {
 	msgs, err := w.api.GetFilterMessages(id)
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func (w *gethPublicWakuAPIWrapper) GetFilterMessages(id string) ([]*types.Messag
 
 // Post posts a message on the network.
 // returns the hash of the message in case of success.
-func (w *gethPublicWakuAPIWrapper) Post(ctx context.Context, req types.NewMessage) ([]byte, error) {
+func (w *GethPublicWakuAPIWrapper) Post(ctx context.Context, req types.NewMessage) ([]byte, error) {
 	msg := waku.NewMessage{
 		SymKeyID:   req.SymKeyID,
 		PublicKey:  req.PublicKey,

--- a/eth-node/bridge/geth/waku.go
+++ b/eth-node/bridge/geth/waku.go
@@ -15,7 +15,7 @@ import (
 	wakucommon "github.com/status-im/status-go/waku/common"
 )
 
-type gethWakuWrapper struct {
+type GethWakuWrapper struct {
 	waku *waku.Waku
 }
 
@@ -25,112 +25,112 @@ func NewGethWakuWrapper(w *waku.Waku) types.Waku {
 		panic("waku cannot be nil")
 	}
 
-	return &gethWakuWrapper{
+	return &GethWakuWrapper{
 		waku: w,
 	}
 }
 
 // GetGethWhisperFrom retrieves the underlying whisper Whisper struct from a wrapped Whisper interface
 func GetGethWakuFrom(m types.Waku) *waku.Waku {
-	return m.(*gethWakuWrapper).waku
+	return m.(*GethWakuWrapper).waku
 }
 
-func (w *gethWakuWrapper) PublicWakuAPI() types.PublicWakuAPI {
+func (w *GethWakuWrapper) PublicWakuAPI() types.PublicWakuAPI {
 	return NewGethPublicWakuAPIWrapper(waku.NewPublicWakuAPI(w.waku))
 }
 
-func (w *gethWakuWrapper) Version() uint {
+func (w *GethWakuWrapper) Version() uint {
 	return 1
 }
 
 // Added for compatibility with waku V2
-func (w *gethWakuWrapper) PeerCount() int {
+func (w *GethWakuWrapper) PeerCount() int {
 	return -1
 }
 
 // Added for compatibility with waku V2
-func (w *gethWakuWrapper) StartDiscV5() error {
+func (w *GethWakuWrapper) StartDiscV5() error {
 	return errors.New("not available in WakuV1")
 }
 
 // Added for compatibility with waku V2
-func (w *gethWakuWrapper) StopDiscV5() error {
+func (w *GethWakuWrapper) StopDiscV5() error {
 	return errors.New("not available in WakuV1")
 }
 
 // PeerCount function only added for compatibility with waku V2
-func (w *gethWakuWrapper) AddStorePeer(address string) (peer.ID, error) {
+func (w *GethWakuWrapper) AddStorePeer(address string) (peer.ID, error) {
 	return "", errors.New("not available in WakuV1")
 }
 
 // SubscribeToPubsubTopic function only added for compatibility with waku V2
-func (w *gethWakuWrapper) SubscribeToPubsubTopic(topic string, optPublicKey *ecdsa.PublicKey) error {
+func (w *GethWakuWrapper) SubscribeToPubsubTopic(topic string, optPublicKey *ecdsa.PublicKey) error {
 	// not available in WakuV1
 	return errors.New("not available in WakuV1")
 }
 
-func (w *gethWakuWrapper) UnsubscribeFromPubsubTopic(topic string) error {
+func (w *GethWakuWrapper) UnsubscribeFromPubsubTopic(topic string) error {
 	// not available in WakuV1
 	return errors.New("not available in WakuV1")
 }
 
-func (w *gethWakuWrapper) RetrievePubsubTopicKey(topic string) (*ecdsa.PrivateKey, error) {
+func (w *GethWakuWrapper) RetrievePubsubTopicKey(topic string) (*ecdsa.PrivateKey, error) {
 	// not available in WakuV1
 	return nil, errors.New("not available in WakuV1")
 }
 
-func (w *gethWakuWrapper) StorePubsubTopicKey(topic string, privKey *ecdsa.PrivateKey) error {
+func (w *GethWakuWrapper) StorePubsubTopicKey(topic string, privKey *ecdsa.PrivateKey) error {
 	// not available in WakuV1
 	return errors.New("not available in WakuV1")
 }
 
-func (w *gethWakuWrapper) RemovePubsubTopicKey(topic string) error {
+func (w *GethWakuWrapper) RemovePubsubTopicKey(topic string) error {
 	// not available in WakuV1
 	return errors.New("not available in WakuV1")
 }
 
 // AddRelayPeer function only added for compatibility with waku V2
-func (w *gethWakuWrapper) AddRelayPeer(address string) (peer.ID, error) {
+func (w *GethWakuWrapper) AddRelayPeer(address string) (peer.ID, error) {
 	return "", errors.New("not available in WakuV1")
 }
 
 // DialPeer function only added for compatibility with waku V2
-func (w *gethWakuWrapper) DialPeer(address string) error {
+func (w *GethWakuWrapper) DialPeer(address string) error {
 	return errors.New("not available in WakuV1")
 }
 
 // DialPeerByID function only added for compatibility with waku V2
-func (w *gethWakuWrapper) DialPeerByID(peerID string) error {
+func (w *GethWakuWrapper) DialPeerByID(peerID string) error {
 	return errors.New("not available in WakuV1")
 }
 
 // ListenAddresses function only added for compatibility with waku V2
-func (w *gethWakuWrapper) ListenAddresses() ([]string, error) {
+func (w *GethWakuWrapper) ListenAddresses() ([]string, error) {
 	return nil, errors.New("not available in WakuV1")
 }
 
 // PeerCount function only added for compatibility with waku V2
-func (w *gethWakuWrapper) DropPeer(peerID string) error {
+func (w *GethWakuWrapper) DropPeer(peerID string) error {
 	return errors.New("not available in WakuV1")
 }
 
-func (w *gethWakuWrapper) SubscribeToConnStatusChanges() (*types.ConnStatusSubscription, error) {
+func (w *GethWakuWrapper) SubscribeToConnStatusChanges() (*types.ConnStatusSubscription, error) {
 	return nil, errors.New("not available in WakuV1")
 }
 
 // Peers function only added for compatibility with waku V2
-func (w *gethWakuWrapper) Peers() map[string]types.WakuV2Peer {
+func (w *GethWakuWrapper) Peers() map[string]types.WakuV2Peer {
 	p := make(map[string]types.WakuV2Peer)
 	return p
 }
 
 // MinPow returns the PoW value required by this node.
-func (w *gethWakuWrapper) MinPow() float64 {
+func (w *GethWakuWrapper) MinPow() float64 {
 	return w.waku.MinPow()
 }
 
 // MaxMessageSize returns the MaxMessageSize set
-func (w *gethWakuWrapper) MaxMessageSize() uint32 {
+func (w *GethWakuWrapper) MaxMessageSize() uint32 {
 	return w.waku.MaxMessageSize()
 }
 
@@ -138,16 +138,16 @@ func (w *gethWakuWrapper) MaxMessageSize() uint32 {
 // The nodes are required to send only messages that match the advertised bloom filter.
 // If a message does not match the bloom, it will tantamount to spam, and the peer will
 // be disconnected.
-func (w *gethWakuWrapper) BloomFilter() []byte {
+func (w *GethWakuWrapper) BloomFilter() []byte {
 	return w.waku.BloomFilter()
 }
 
 // GetCurrentTime returns current time.
-func (w *gethWakuWrapper) GetCurrentTime() time.Time {
+func (w *GethWakuWrapper) GetCurrentTime() time.Time {
 	return w.waku.CurrentTime()
 }
 
-func (w *gethWakuWrapper) SubscribeEnvelopeEvents(eventsProxy chan<- types.EnvelopeEvent) types.Subscription {
+func (w *GethWakuWrapper) SubscribeEnvelopeEvents(eventsProxy chan<- types.EnvelopeEvent) types.Subscription {
 	events := make(chan wakucommon.EnvelopeEvent, 100) // must be buffered to prevent blocking whisper
 	go func() {
 		for e := range events {
@@ -158,37 +158,37 @@ func (w *gethWakuWrapper) SubscribeEnvelopeEvents(eventsProxy chan<- types.Envel
 	return NewGethSubscriptionWrapper(w.waku.SubscribeEnvelopeEvents(events))
 }
 
-func (w *gethWakuWrapper) GetPrivateKey(id string) (*ecdsa.PrivateKey, error) {
+func (w *GethWakuWrapper) GetPrivateKey(id string) (*ecdsa.PrivateKey, error) {
 	return w.waku.GetPrivateKey(id)
 }
 
 // AddKeyPair imports a asymmetric private key and returns a deterministic identifier.
-func (w *gethWakuWrapper) AddKeyPair(key *ecdsa.PrivateKey) (string, error) {
+func (w *GethWakuWrapper) AddKeyPair(key *ecdsa.PrivateKey) (string, error) {
 	return w.waku.AddKeyPair(key)
 }
 
 // DeleteKeyPair deletes the key with the specified ID if it exists.
-func (w *gethWakuWrapper) DeleteKeyPair(keyID string) bool {
+func (w *GethWakuWrapper) DeleteKeyPair(keyID string) bool {
 	return w.waku.DeleteKeyPair(keyID)
 }
 
-func (w *gethWakuWrapper) AddSymKeyDirect(key []byte) (string, error) {
+func (w *GethWakuWrapper) AddSymKeyDirect(key []byte) (string, error) {
 	return w.waku.AddSymKeyDirect(key)
 }
 
-func (w *gethWakuWrapper) AddSymKeyFromPassword(password string) (string, error) {
+func (w *GethWakuWrapper) AddSymKeyFromPassword(password string) (string, error) {
 	return w.waku.AddSymKeyFromPassword(password)
 }
 
-func (w *gethWakuWrapper) DeleteSymKey(id string) bool {
+func (w *GethWakuWrapper) DeleteSymKey(id string) bool {
 	return w.waku.DeleteSymKey(id)
 }
 
-func (w *gethWakuWrapper) GetSymKey(id string) ([]byte, error) {
+func (w *GethWakuWrapper) GetSymKey(id string) ([]byte, error) {
 	return w.waku.GetSymKey(id)
 }
 
-func (w *gethWakuWrapper) Subscribe(opts *types.SubscriptionOptions) (string, error) {
+func (w *GethWakuWrapper) Subscribe(opts *types.SubscriptionOptions) (string, error) {
 	var (
 		err     error
 		keyAsym *ecdsa.PrivateKey
@@ -222,23 +222,23 @@ func (w *gethWakuWrapper) Subscribe(opts *types.SubscriptionOptions) (string, er
 	return id, nil
 }
 
-func (w *gethWakuWrapper) GetStats() types.StatsSummary {
+func (w *GethWakuWrapper) GetStats() types.StatsSummary {
 	return w.waku.GetStats()
 }
 
-func (w *gethWakuWrapper) GetFilter(id string) types.Filter {
+func (w *GethWakuWrapper) GetFilter(id string) types.Filter {
 	return NewWakuFilterWrapper(w.waku.GetFilter(id), id)
 }
 
-func (w *gethWakuWrapper) Unsubscribe(ctx context.Context, id string) error {
+func (w *GethWakuWrapper) Unsubscribe(ctx context.Context, id string) error {
 	return w.waku.Unsubscribe(id)
 }
 
-func (w *gethWakuWrapper) UnsubscribeMany(ids []string) error {
+func (w *GethWakuWrapper) UnsubscribeMany(ids []string) error {
 	return w.waku.UnsubscribeMany(ids)
 }
 
-func (w *gethWakuWrapper) createFilterWrapper(id string, keyAsym *ecdsa.PrivateKey, keySym []byte, pow float64, topics [][]byte) (types.Filter, error) {
+func (w *GethWakuWrapper) createFilterWrapper(id string, keyAsym *ecdsa.PrivateKey, keySym []byte, pow float64, topics [][]byte) (types.Filter, error) {
 	return NewWakuFilterWrapper(&wakucommon.Filter{
 		KeyAsym:  keyAsym,
 		KeySym:   keySym,
@@ -249,7 +249,7 @@ func (w *gethWakuWrapper) createFilterWrapper(id string, keyAsym *ecdsa.PrivateK
 	}, id), nil
 }
 
-func (w *gethWakuWrapper) SendMessagesRequest(peerID []byte, r types.MessagesRequest) error {
+func (w *GethWakuWrapper) SendMessagesRequest(peerID []byte, r types.MessagesRequest) error {
 	return w.waku.SendMessagesRequest(peerID, wakucommon.MessagesRequest{
 		ID:     r.ID,
 		From:   r.From,
@@ -266,25 +266,25 @@ func (w *gethWakuWrapper) SendMessagesRequest(peerID []byte, r types.MessagesReq
 // request and respond with a number of peer-to-peer messages (possibly expired),
 // which are not supposed to be forwarded any further.
 // The whisper protocol is agnostic of the format and contents of envelope.
-func (w *gethWakuWrapper) RequestHistoricMessagesWithTimeout(peerID []byte, envelope types.Envelope, timeout time.Duration) error {
+func (w *GethWakuWrapper) RequestHistoricMessagesWithTimeout(peerID []byte, envelope types.Envelope, timeout time.Duration) error {
 	return w.waku.RequestHistoricMessagesWithTimeout(peerID, envelope.Unwrap().(*wakucommon.Envelope), timeout)
 }
 
-func (w *gethWakuWrapper) ProcessingP2PMessages() bool {
+func (w *GethWakuWrapper) ProcessingP2PMessages() bool {
 	return w.waku.ProcessingP2PMessages()
 }
 
-func (w *gethWakuWrapper) MarkP2PMessageAsProcessed(hash common.Hash) {
+func (w *GethWakuWrapper) MarkP2PMessageAsProcessed(hash common.Hash) {
 	w.waku.MarkP2PMessageAsProcessed(hash)
 }
 
-func (w *gethWakuWrapper) RequestStoreMessages(ctx context.Context, peerID []byte, r types.MessagesRequest, processEnvelopes bool) (*types.StoreRequestCursor, int, error) {
+func (w *GethWakuWrapper) RequestStoreMessages(ctx context.Context, peerID []byte, r types.MessagesRequest, processEnvelopes bool) (*types.StoreRequestCursor, int, error) {
 	return nil, 0, errors.New("not implemented")
 }
 
-func (w *gethWakuWrapper) ConnectionChanged(_ connection.State) {}
+func (w *GethWakuWrapper) ConnectionChanged(_ connection.State) {}
 
-func (w *gethWakuWrapper) ClearEnvelopesCache() {
+func (w *GethWakuWrapper) ClearEnvelopesCache() {
 	w.waku.ClearEnvelopesCache()
 }
 

--- a/protocol/communities_events_eventual_consistency_test.go
+++ b/protocol/communities_events_eventual_consistency_test.go
@@ -1,0 +1,178 @@
+package protocol
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/protocol/protobuf"
+	"github.com/status-im/status-go/protocol/requests"
+	"github.com/status-im/status-go/protocol/tt"
+	"github.com/status-im/status-go/waku"
+)
+
+func TestCommunityEventsEventualConsistencySuite(t *testing.T) {
+	suite.Run(t, new(CommunityEventsEventualConsistencySuite))
+}
+
+type CommunityEventsEventualConsistencySuite struct {
+	AdminCommunityEventsSuite
+
+	messagesOrderController *MessagesOrderController
+}
+
+func (s *CommunityEventsEventualConsistencySuite) SetupTest() {
+	s.logger = tt.MustCreateTestLogger()
+	s.collectiblesServiceMock = &CollectiblesServiceMock{}
+
+	config := waku.DefaultConfig
+	config.MinimumAcceptedPoW = 0
+	shh := waku.New(&config, s.logger)
+	wakuWrapper, err := newTestWakuWrapper(&config, s.logger)
+	s.Require().NoError(err)
+	s.Require().NoError(shh.Start())
+	s.shh = wakuWrapper
+
+	s.messagesOrderController = NewMessagesOrderController(messagesOrderRandom)
+	s.messagesOrderController.Start(wakuWrapper.SubscribePostEvents())
+
+	s.owner = s.newMessenger("", []string{})
+	s.admin = s.newMessenger(accountPassword, []string{eventsSenderAccountAddress})
+	s.alice = s.newMessenger(accountPassword, []string{aliceAccountAddress})
+	_, err = s.owner.Start()
+	s.Require().NoError(err)
+	_, err = s.admin.Start()
+	s.Require().NoError(err)
+	_, err = s.alice.Start()
+	s.Require().NoError(err)
+
+	s.mockedBalances = createMockedWalletBalance(&s.Suite)
+}
+
+func (s *CommunityEventsEventualConsistencySuite) TearDownTest() {
+	s.AdminCommunityEventsSuite.TearDownTest()
+	s.messagesOrderController.Stop()
+}
+
+func (s *CommunityEventsEventualConsistencySuite) newMessenger(password string, walletAddresses []string) *Messenger {
+	return newTestCommunitiesMessenger(&s.Suite, s.shh, testCommunitiesMessengerConfig{
+		testMessengerConfig: testMessengerConfig{
+			logger:                  s.logger,
+			messagesOrderController: s.messagesOrderController,
+		},
+		password:            password,
+		walletAddresses:     walletAddresses,
+		mockedBalances:      &s.mockedBalances,
+		collectiblesService: s.collectiblesServiceMock,
+	})
+}
+
+// TODO: remove once eventual consistency is implemented
+var communityRequestsEventualConsistencyFixed = false
+
+func (s *CommunityEventsEventualConsistencySuite) TestAdminAcceptRejectRequestToJoin() {
+	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{})
+
+	// set up additional user that will send request to join
+	user := s.newMessenger("", []string{})
+	s.SetupAdditionalMessengers([]*Messenger{user})
+
+	advertiseCommunityToUserOldWay(&s.Suite, community, s.owner, user)
+
+	// user sends request to join
+	requestToJoin := &requests.RequestToJoinCommunity{CommunityID: community.ID(), ENSName: "testName"}
+	response, err := user.RequestToJoinCommunity(requestToJoin)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+	s.Require().Len(response.RequestsToJoinCommunity, 1)
+
+	sentRequest := response.RequestsToJoinCommunity[0]
+
+	checkRequestToJoin := func(r *MessengerResponse) bool {
+		for _, request := range r.RequestsToJoinCommunity {
+			if request.ENSName == requestToJoin.ENSName {
+				return true
+			}
+		}
+		return false
+	}
+
+	// admin receives request to join
+	response, err = WaitOnMessengerResponse(
+		s.admin,
+		checkRequestToJoin,
+		"event sender did not receive community request to join",
+	)
+	s.Require().NoError(err)
+	s.Require().Len(response.RequestsToJoinCommunity, 1)
+
+	// accept request to join
+	acceptRequestToJoin := &requests.AcceptRequestToJoinCommunity{ID: sentRequest.ID}
+	_, err = s.admin.AcceptRequestToJoinCommunity(acceptRequestToJoin)
+	s.Require().NoError(err)
+
+	// then reject request to join
+	rejectRequestToJoin := &requests.DeclineRequestToJoinCommunity{ID: sentRequest.ID}
+	_, err = s.admin.DeclineRequestToJoinCommunity(rejectRequestToJoin)
+	s.Require().NoError(err)
+
+	// ensure both messages are pushed to waku
+	/*
+		FIXME: we should do it smarter, as follows:
+		```
+		hashes1, err := admin.SendEvent()
+		hashes2, err := admin.SendEvent()
+		WaitForHashes([][]byte{hashes1, hashes2}, admin.waku)
+		s.messagesOrderController.setCustomOrder([][]{hashes1, hashes2})
+		```
+	*/
+	time.Sleep(1 * time.Second)
+
+	// ensure events are received in order
+	s.messagesOrderController.order = messagesOrderAsPosted
+
+	waitForAcceptedRequestToJoin := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
+		return len(sub.AcceptedRequestsToJoin) == 1
+	})
+
+	waitOnAdminEventsRejection := waitOnCommunitiesEvent(s.owner, func(s *communities.Subscription) bool {
+		return s.CommunityEventsMessageInvalidClock != nil
+	})
+
+	_, err = s.owner.RetrieveAll()
+	s.Require().NoError(err)
+
+	// first owner handles AcceptRequestToJoinCommunity event
+	err = <-waitForAcceptedRequestToJoin
+	s.Require().NoError(err)
+
+	// then owner rejects DeclineRequestToJoinCommunity event due to invalid clock
+	err = <-waitOnAdminEventsRejection
+	s.Require().NoError(err)
+
+	if communityRequestsEventualConsistencyFixed {
+		// admin receives rejected DeclineRequestToJoinCommunity event and re-applies it,
+		// there is no signal whatsoever, we just wait for admin to process all incoming messages
+		_, _ = WaitOnMessengerResponse(s.admin, func(response *MessengerResponse) bool {
+			return false
+		}, "")
+
+		waitForRejectedRequestToJoin := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
+			return len(sub.RejectedRequestsToJoin) == 1
+		})
+
+		_, err = s.owner.RetrieveAll()
+		s.Require().NoError(err)
+
+		// owner handles DeclineRequestToJoinCommunity event eventually
+		err = <-waitForRejectedRequestToJoin
+		s.Require().NoError(err)
+
+		// user should be removed from community
+		community, err = s.owner.GetCommunityByID(community.ID())
+		s.Require().NoError(err)
+		s.Require().False(community.HasMember(&user.identity.PublicKey))
+	}
+}

--- a/protocol/messages_iterator.go
+++ b/protocol/messages_iterator.go
@@ -1,0 +1,40 @@
+package protocol
+
+import (
+	"golang.org/x/exp/maps"
+
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/protocol/transport"
+)
+
+type MessagesIterator interface {
+	HasNext() bool
+	Next() (transport.Filter, []*types.Message)
+}
+
+type DefaultMessagesIterator struct {
+	chatWithMessages map[transport.Filter][]*types.Message
+	keys             []transport.Filter
+	currentIndex     int
+}
+
+func NewDefaultMessagesIterator(chatWithMessages map[transport.Filter][]*types.Message) MessagesIterator {
+	return &DefaultMessagesIterator{
+		chatWithMessages: chatWithMessages,
+		keys:             maps.Keys(chatWithMessages),
+		currentIndex:     0,
+	}
+}
+
+func (it *DefaultMessagesIterator) HasNext() bool {
+	return it.currentIndex < len(it.keys)
+}
+
+func (it *DefaultMessagesIterator) Next() (transport.Filter, []*types.Message) {
+	if it.HasNext() {
+		key := it.keys[it.currentIndex]
+		it.currentIndex++
+		return key, it.chatWithMessages[key]
+	}
+	return transport.Filter{}, nil
+}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -181,6 +181,9 @@ type Messenger struct {
 	// used to track unhandled messages
 	unhandledMessagesTracker func(*v1protocol.StatusMessage, error)
 
+	// enables control over chat messages iteration
+	retrievedMessagesIteratorFactory func(map[transport.Filter][]*types.Message) MessagesIterator
+
 	peersyncing         *peersyncing.PeerSyncing
 	peersyncingOffers   map[string]uint64
 	peersyncingRequests map[string]uint64
@@ -577,8 +580,9 @@ func NewMessenger(
 			func() error { _ = logger.Sync; return nil },
 			database.Close,
 		},
-		logger:                logger,
-		savedAddressesManager: savedAddressesManager,
+		logger:                           logger,
+		savedAddressesManager:            savedAddressesManager,
+		retrievedMessagesIteratorFactory: NewDefaultMessagesIterator,
 	}
 
 	if c.rpcClient != nil {
@@ -3735,7 +3739,10 @@ func (m *Messenger) handleRetrievedMessages(chatWithMessages map[transport.Filte
 		logger.Info("failed to retrieve admin communities", zap.Error(err))
 	}
 
-	for filter, messages := range chatWithMessages {
+	iterator := m.retrievedMessagesIteratorFactory(chatWithMessages)
+	for iterator.HasNext() {
+		filter, messages := iterator.Next()
+
 		var processedMessages []string
 		for _, shhMessage := range messages {
 			logger := logger.With(zap.String("hash", types.EncodeHex(shhMessage.Hash)))

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -25,7 +25,9 @@ type testMessengerConfig struct {
 	logger     *zap.Logger
 
 	unhandledMessagesTracker *unhandledMessagesTracker
-	extraOptions             []Option
+	messagesOrderController  *MessagesOrderController
+
+	extraOptions []Option
 }
 
 func (tmc *testMessengerConfig) complete() error {
@@ -97,6 +99,10 @@ func newTestMessenger(waku types.Waku, config testMessengerConfig) (*Messenger, 
 
 	if config.unhandledMessagesTracker != nil {
 		m.unhandledMessagesTracker = config.unhandledMessagesTracker.addMessage
+	}
+
+	if config.messagesOrderController != nil {
+		m.retrievedMessagesIteratorFactory = config.messagesOrderController.newMessagesIterator
 	}
 
 	err = m.Init()

--- a/protocol/messenger_messages_order_controller_test.go
+++ b/protocol/messenger_messages_order_controller_test.go
@@ -1,0 +1,130 @@
+package protocol
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/protocol/transport"
+)
+
+type messagesOrderType int
+
+const (
+	messagesOrderRandom messagesOrderType = iota
+	messagesOrderAsPosted
+	messagesOrderReversed
+)
+
+type MessagesOrderController struct {
+	order               messagesOrderType
+	messagesInPostOrder [][]byte
+	mutex               sync.RWMutex
+	quit                chan struct{}
+	quitOnce            sync.Once
+}
+
+func NewMessagesOrderController(order messagesOrderType) *MessagesOrderController {
+	return &MessagesOrderController{
+		order:               order,
+		messagesInPostOrder: [][]byte{},
+		mutex:               sync.RWMutex{},
+		quit:                make(chan struct{}),
+	}
+}
+
+func (m *MessagesOrderController) Start(c chan *PostMessageSubscription) {
+	go func() {
+		for {
+			select {
+			case sub, more := <-c:
+				if !more {
+					return
+				}
+				m.mutex.Lock()
+				m.messagesInPostOrder = append(m.messagesInPostOrder, sub.id)
+				m.mutex.Unlock()
+
+			case <-m.quit:
+				return
+			}
+		}
+	}()
+}
+
+func (m *MessagesOrderController) Stop() {
+	m.quitOnce.Do(func() {
+		close(m.quit)
+	})
+}
+
+func (m *MessagesOrderController) newMessagesIterator(chatWithMessages map[transport.Filter][]*types.Message) MessagesIterator {
+	switch m.order {
+	case messagesOrderAsPosted, messagesOrderReversed:
+		return &messagesIterator{chatWithMessages: m.sort(chatWithMessages, m.order)}
+	}
+
+	return NewDefaultMessagesIterator(chatWithMessages)
+}
+
+func buildIndexMap(messages [][]byte) map[string]int {
+	indexMap := make(map[string]int)
+	for i, hash := range messages {
+		hashStr := string(hash)
+		indexMap[hashStr] = i
+	}
+	return indexMap
+}
+
+func (m *MessagesOrderController) sort(chatWithMessages map[transport.Filter][]*types.Message, order messagesOrderType) []*chatWithMessage {
+	allMessages := make([]*chatWithMessage, 0)
+	for chat, messages := range chatWithMessages {
+		for _, message := range messages {
+			allMessages = append(allMessages, &chatWithMessage{chat: chat, message: message})
+		}
+	}
+
+	m.mutex.RLock()
+	indexMap := buildIndexMap(m.messagesInPostOrder)
+	m.mutex.RUnlock()
+
+	sort.SliceStable(allMessages, func(i, j int) bool {
+		indexI, okI := indexMap[string(allMessages[i].message.Hash)]
+		indexJ, okJ := indexMap[string(allMessages[j].message.Hash)]
+
+		if okI && okJ {
+			if order == messagesOrderReversed {
+				return indexI > indexJ
+			}
+			return indexI < indexJ
+		}
+
+		return !okI && okJ // keep messages with unknown hashes at the end
+	})
+
+	return allMessages
+}
+
+type chatWithMessage struct {
+	chat    transport.Filter
+	message *types.Message
+}
+
+type messagesIterator struct {
+	chatWithMessages []*chatWithMessage
+	currentIndex     int
+}
+
+func (it *messagesIterator) HasNext() bool {
+	return it.currentIndex < len(it.chatWithMessages)
+}
+
+func (it *messagesIterator) Next() (transport.Filter, []*types.Message) {
+	if it.HasNext() {
+		m := it.chatWithMessages[it.currentIndex]
+		it.currentIndex++
+		return m.chat, []*types.Message{m.message}
+	}
+
+	return transport.Filter{}, nil
+}

--- a/protocol/messenger_waku_wrapper_test.go
+++ b/protocol/messenger_waku_wrapper_test.go
@@ -1,0 +1,76 @@
+package protocol
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/waku"
+)
+
+type testWakuWrapper struct {
+	*gethbridge.GethWakuWrapper
+
+	publicWakuAPIWrapper *testPublicWakuAPIWrapper
+}
+
+func newTestWaku(w *waku.Waku) types.Waku {
+	wrapper := gethbridge.NewGethWakuWrapper(w)
+	return &testWakuWrapper{
+		GethWakuWrapper:      wrapper.(*gethbridge.GethWakuWrapper),
+		publicWakuAPIWrapper: newTestPublicWakuAPI(waku.NewPublicWakuAPI(w)).(*testPublicWakuAPIWrapper),
+	}
+}
+
+func (tw *testWakuWrapper) PublicWakuAPI() types.PublicWakuAPI {
+	return tw.publicWakuAPIWrapper
+}
+
+func (tw *testWakuWrapper) SubscribePostEvents() chan *PostMessageSubscription {
+	subscription := make(chan *PostMessageSubscription, 100)
+	tw.publicWakuAPIWrapper.postSubscriptions = append(tw.publicWakuAPIWrapper.postSubscriptions, subscription)
+	return subscription
+}
+
+type PostMessageSubscription struct {
+	id  []byte
+	msg *types.NewMessage
+}
+
+type testPublicWakuAPIWrapper struct {
+	*gethbridge.GethPublicWakuAPIWrapper
+
+	postSubscriptions []chan *PostMessageSubscription
+}
+
+func newTestPublicWakuAPI(api *waku.PublicWakuAPI) types.PublicWakuAPI {
+	wrapper := gethbridge.NewGethPublicWakuAPIWrapper(api)
+	return &testPublicWakuAPIWrapper{
+		GethPublicWakuAPIWrapper: wrapper.(*gethbridge.GethPublicWakuAPIWrapper),
+	}
+}
+
+func (tp *testPublicWakuAPIWrapper) Post(ctx context.Context, req types.NewMessage) ([]byte, error) {
+	id, err := tp.GethPublicWakuAPIWrapper.Post(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range tp.postSubscriptions {
+		select {
+		case s <- &PostMessageSubscription{id: id, msg: &req}:
+		default:
+			// subscription channel full
+		}
+	}
+	return id, err
+}
+
+func newTestWakuWrapper(config *waku.Config, logger *zap.Logger) (*testWakuWrapper, error) {
+	if config == nil {
+		config = &waku.DefaultConfig
+	}
+	w := waku.New(config, logger)
+	return newTestWaku(w).(*testWakuWrapper), w.Start()
+}


### PR DESCRIPTION
Review commit by commit (commits have description).

- Enables customization of iteration strategy for retrieved messages.
- Enables `PublicWakuAPI` introspection.
- Enables controlling order of messages in tests. Useful for deterministic
reproduction of out-of-order messages.
- It proves eventual consistency is broken for contact request events.

Iterates https://github.com/status-im/status-desktop/issues/13387