### PR TITLE
Fix Discord Import getting stuck

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -47,7 +47,7 @@ var messageArchiveInterval = 7 * 24 * time.Hour
 // 1 day interval
 var updateActiveMembersInterval = 24 * time.Hour
 
-const discordTimestampLayout = "2006-01-02T15:04:05+00:00"
+const discordTimestampLayout = time.RFC3339
 
 const (
 	importSlowRate          = time.Second / 1


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/13438 and https://github.com/status-im/status-desktop/issues/13439

The official problem to the hanging was that the timestamp format used in the code didn't support `-` time zones, like `-4`.
Using the default format from the `time` library fixes it.

The bigger problem however was that the progress got stuck at 75% in case of that type of error. Since the messages array ended up being empty because all the timestamps were "wrong", the progress missed the 25% needed that would have been done with a loop.
I guess if you imported a channel with no messages, you'd also have run in that issue.

The solution I found is to set the progress to 100% for messages if there are no messages. The errors still show.

I also cover our asses in case another problem like this happens again with another task and make sure all tasks are set to 100% if we end up reaching the end of the process. That way, the user knows that we actually finished and can check the errors to either try again or leave it as is.
