### PR TITLE
Feat: delete profile showcase community entry on community leave or kicked

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1816,6 +1816,11 @@ func (m *Messenger) leaveCommunity(communityID types.HexBytes) (*MessengerRespon
 		}
 	}
 
+	err = m.DeleteProfileShowcaseCommunity(community)
+	if err != nil {
+		return nil, err
+	}
+
 	_, err = m.transport.RemoveFilterByChatID(communityID.String())
 	if err != nil {
 		return nil, err
@@ -1829,6 +1834,11 @@ func (m *Messenger) kickedOutOfCommunity(communityID types.HexBytes) (*Messenger
 	response := &MessengerResponse{}
 
 	community, err := m.communitiesManager.KickedOutOfCommunity(communityID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = m.DeleteProfileShowcaseCommunity(community)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_profile_showcase.go
+++ b/protocol/messenger_profile_showcase.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -477,10 +478,25 @@ func (m *Messenger) UpdateProfileShowcaseWalletAccount(account *accounts.Account
 }
 
 func (m *Messenger) DeleteProfileShowcaseWalletAccount(account *accounts.Account) error {
-	err := m.persistence.DeleteProfileShowcaseAccountPreference(account.Address.Hex())
+	deleted, err := m.persistence.DeleteProfileShowcaseAccountPreference(account.Address.Hex())
 	if err != nil {
 		return err
 	}
 
-	return m.DispatchProfileShowcase()
+	if deleted {
+		return m.DispatchProfileShowcase()
+	}
+	return nil
+}
+
+func (m *Messenger) DeleteProfileShowcaseCommunity(community *communities.Community) error {
+	deleted, err := m.persistence.DeleteProfileShowcaseCommunityPreference(community.IDString())
+	if err != nil {
+		return err
+	}
+
+	if deleted {
+		return m.DispatchProfileShowcase()
+	}
+	return nil
 }

--- a/protocol/persistence_profile_showcase.go
+++ b/protocol/persistence_profile_showcase.go
@@ -17,6 +17,7 @@ const (
 
 const upsertProfileShowcaseCommunityPreferenceQuery = "INSERT OR REPLACE INTO profile_showcase_communities_preferences(community_id, visibility, sort_order) VALUES (?, ?, ?)" // #nosec G101
 const selectProfileShowcaseCommunityPreferenceQuery = "SELECT community_id, visibility, sort_order FROM profile_showcase_communities_preferences"                              // #nosec G101
+const deleteProfileShowcaseCommunityPreferenceQuery = "DELETE FROM profile_showcase_communities_preferences WHERE community_id = ?"                                            // #nosec G101
 
 const upsertProfileShowcaseAccountPreferenceQuery = "INSERT OR REPLACE INTO profile_showcase_accounts_preferences(address, name, color_id, emoji, visibility, sort_order) VALUES (?, ?, ?, ?, ?, ?)" // #nosec G101
 const selectProfileShowcaseAccountPreferenceQuery = "SELECT address, name, color_id, emoji, visibility, sort_order FROM profile_showcase_accounts_preferences"                                       // #nosec G101
@@ -255,10 +256,24 @@ func (db sqlitePersistence) GetProfileShowcaseAccountPreference(accountAddress s
 	return nil, err
 }
 
-func (db sqlitePersistence) DeleteProfileShowcaseAccountPreference(accountAddress string) error {
-	_, err := db.db.Exec(deleteProfileShowcaseAccountPreferenceQuery, accountAddress)
+func (db sqlitePersistence) DeleteProfileShowcaseAccountPreference(accountAddress string) (bool, error) {
+	result, err := db.db.Exec(deleteProfileShowcaseAccountPreferenceQuery, accountAddress)
+	if err != nil {
+		return false, err
+	}
 
-	return err
+	rows, err := result.RowsAffected()
+	return rows > 0, err
+}
+
+func (db sqlitePersistence) DeleteProfileShowcaseCommunityPreference(communityID string) (bool, error) {
+	result, err := db.db.Exec(deleteProfileShowcaseCommunityPreferenceQuery, communityID)
+	if err != nil {
+		return false, err
+	}
+
+	rows, err := result.RowsAffected()
+	return rows > 0, err
 }
 
 func (db sqlitePersistence) saveProfileShowcaseCollectiblePreference(tx *sql.Tx, collectible *ProfileShowcaseCollectiblePreference) error {


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/13076

Important changes:
- [x] Dispatch the profile showcase message when a user leaves or being kicked from a community

(This PR should have had a bit more changes, but because of the new approach in the UI, these are the only changes needed)
