### PR TITLE
feat(discord_import): send signal when the import was cleaned up

### DIFF
--- a/protocol/messenger_communities_import_discord.go
+++ b/protocol/messenger_communities_import_discord.go
@@ -382,6 +382,7 @@ func (m *Messenger) cleanUpImport(communityID string) {
 	if deleteErr != nil {
 		m.logger.Error("clean up failed, couldn't delete community messages", zap.Error(deleteErr))
 	}
+	m.config.messengerSignalsHandler.DiscordCommunityImportCleanedUp(communityID)
 }
 
 func (m *Messenger) cleanUpImportChannel(communityID string, channelID string) {

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -57,6 +57,7 @@ type MessengerSignalsHandler interface {
 	DiscordCommunityImportProgress(importProgress *discord.ImportProgress)
 	DiscordCommunityImportFinished(communityID string)
 	DiscordCommunityImportCancelled(communityID string)
+	DiscordCommunityImportCleanedUp(communityID string)
 	DiscordChannelImportProgress(importProgress *discord.ImportProgress)
 	DiscordChannelImportFinished(communityID string, channelID string)
 	DiscordChannelImportCancelled(channelID string)

--- a/services/ext/signal.go
+++ b/services/ext/signal.go
@@ -153,6 +153,10 @@ func (m *MessengerSignalsHandler) DiscordCommunityImportCancelled(id string) {
 	signal.SendDiscordCommunityImportCancelled(id)
 }
 
+func (m *MessengerSignalsHandler) DiscordCommunityImportCleanedUp(id string) {
+	signal.SendDiscordCommunityImportCleanedUp(id)
+}
+
 func (m *MessengerSignalsHandler) DiscordChannelImportCancelled(id string) {
 	signal.SendDiscordChannelImportCancelled(id)
 }

--- a/signal/events_discord_import.go
+++ b/signal/events_discord_import.go
@@ -22,6 +22,9 @@ const (
 	// the discord community was cancelled
 	EventDiscordCommunityImportCancelled = "community.discordCommunityImportCancelled"
 
+	// EventDiscordCommunityImportCleanedUp triggered when the community has been cleaned up (deleted)
+	EventDiscordCommunityImportCleanedUp = "community.discordCommunityImportCleanedUp"
+
 	// EventDiscordChannelImportProgress is triggered during the import
 	// of a discord community channel as it progresses
 	EventDiscordChannelImportProgress = "community.discordChannelImportProgress"
@@ -51,6 +54,10 @@ type DiscordCommunityImportFinishedSignal struct {
 }
 
 type DiscordCommunityImportCancelledSignal struct {
+	CommunityID string `json:"communityId"`
+}
+
+type DiscordCommunityImportCleanedUpSignal struct {
 	CommunityID string `json:"communityId"`
 }
 
@@ -103,6 +110,12 @@ func SendDiscordChannelImportFinished(communityID string, channelID string) {
 
 func SendDiscordCommunityImportCancelled(communityID string) {
 	send(EventDiscordCommunityImportCancelled, DiscordCommunityImportCancelledSignal{
+		CommunityID: communityID,
+	})
+}
+
+func SendDiscordCommunityImportCleanedUp(communityID string) {
+	send(EventDiscordCommunityImportCleanedUp, DiscordCommunityImportCleanedUpSignal{
 		CommunityID: communityID,
 	})
 }


### PR DESCRIPTION
This is to let the front end know that the community was deleted so it can also delete it from the UI

 Needed for https://github.com/status-im/status-desktop/issues/12724