### PR TITLE
fix(discord_images): fix discord images missing the attachment ID

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -275,6 +275,10 @@ func ParseImageParams(logger *zap.Logger, params url.Values) ImageParams {
 		parsed.AuthorID = authorIds[0]
 	}
 
+	if attachmentIDs := params["attachmentId"]; len(attachmentIDs) != 0 {
+		parsed.AttachmentID = attachmentIDs[0]
+	}
+
 	if imageIds := params["image-id"]; len(imageIds) != 0 {
 		parsed.ImageID = imageIds[0]
 	}


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/13466

![image](https://github.com/status-im/status-go/assets/11926403/3ed99c42-97b9-4118-9780-8d53466753ae)
