### PR TITLE
feat: Cast int64 for settings

### DIFF
--- a/multiaccounts/settings/columns.go
+++ b/multiaccounts/settings/columns.go
@@ -425,9 +425,10 @@ var (
 		},
 	}
 	DisplayAssetsBelowBalanceThreshold = SettingField{
-		reactFieldName: "display-assets-below-balance-threshold",
-		dBColumnName:   "wallet_display_assets_below_balance_threshold",
-		valueHandler:   Int64Handler,
+		reactFieldName:   "display-assets-below-balance-threshold",
+		dBColumnName:     "wallet_display_assets_below_balance_threshold",
+		valueHandler:     Int64Handler,
+		valueCastHandler: Float64ToInt64Handler,
 		syncProtobufFactory: &SyncProtobufFactory{
 			fromInterface:     displayAssetsBelowBalanceThresholdProtobufFactory,
 			fromStruct:        displayAssetsBelowBalanceThresholdProtobufFactoryStruct,

--- a/multiaccounts/settings/columns_test.go
+++ b/multiaccounts/settings/columns_test.go
@@ -67,3 +67,34 @@ func TestGetFieldFromProtobufType(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestValueHandler(t *testing.T) {
+	boolSetting := SettingField{
+		valueHandler: BoolHandler,
+	}
+
+	boolValue := true
+	require.NotNil(t, boolSetting.ValueHandler())
+	handledBoolValue, err := boolSetting.ValueHandler()(boolValue)
+	require.NoError(t, err)
+	require.True(t, boolValue == handledBoolValue)
+
+	// Incorrect value should be return error
+	int64Value := int64(5)
+	handledInt64Value, err := boolSetting.ValueHandler()(int64Value)
+	require.Error(t, err)
+	require.True(t, handledInt64Value == int64Value)
+}
+
+func TestValueCastHandler(t *testing.T) {
+	int64Setting := SettingField{
+		valueCastHandler: Float64ToInt64Handler,
+	}
+
+	float64Value := float64(5)
+
+	require.NotNil(t, int64Setting.ValueCastHandler())
+	handledInt64Value, err := int64Setting.ValueCastHandler()(float64Value)
+	require.NoError(t, err)
+	require.True(t, handledInt64Value == int64(5))
+}

--- a/multiaccounts/settings/database.go
+++ b/multiaccounts/settings/database.go
@@ -255,6 +255,13 @@ func (db *Database) saveSetting(setting SettingField, value interface{}) error {
 }
 
 func (db *Database) parseSaveAndSyncSetting(sf SettingField, value interface{}) (err error) {
+	if sf.ValueCastHandler() != nil {
+		value, err = sf.ValueCastHandler()(value)
+		if err != nil {
+			return err
+		}
+	}
+
 	if sf.ValueHandler() != nil {
 		value, err = sf.ValueHandler()(value)
 		if err != nil {

--- a/multiaccounts/settings/structs.go
+++ b/multiaccounts/settings/structs.go
@@ -11,6 +11,7 @@ import (
 )
 
 type ValueHandler func(interface{}) (interface{}, error)
+type ValueCastHandler func(interface{}) (interface{}, error)
 type SyncSettingProtobufFactoryInterface func(interface{}, uint64, string) (*common.RawMessage, *protobuf.SyncSetting, error)
 type SyncSettingProtobufFactoryStruct func(Settings, uint64, string) (*common.RawMessage, *protobuf.SyncSetting, error)
 type SyncSettingProtobufToValue func(setting *protobuf.SyncSetting) interface{}
@@ -69,6 +70,7 @@ type SettingField struct {
 	dBColumnName        string
 	valueHandler        ValueHandler
 	syncProtobufFactory *SyncProtobufFactory
+	valueCastHandler    ValueCastHandler
 }
 
 func (s SettingField) GetReactName() string {
@@ -81,6 +83,10 @@ func (s SettingField) GetDBName() string {
 
 func (s SettingField) ValueHandler() ValueHandler {
 	return s.valueHandler
+}
+
+func (s SettingField) ValueCastHandler() ValueCastHandler {
+	return s.valueCastHandler
 }
 
 func (s SettingField) SyncProtobufFactory() *SyncProtobufFactory {

--- a/multiaccounts/settings/value_handlers.go
+++ b/multiaccounts/settings/value_handlers.go
@@ -72,3 +72,12 @@ func NodeConfigHandler(value interface{}) (interface{}, error) {
 
 	return nodeConfig, nil
 }
+
+func Float64ToInt64Handler(value interface{}) (interface{}, error) {
+	floatValue, ok := value.(float64)
+	if !ok {
+		// Ignore if not float64
+		return value, nil
+	}
+	return int64(floatValue), nil
+}


### PR DESCRIPTION
Settings sent as `int64` from Nim are read as `float64`, which brakes protobuf sync value handlers.

Added the cast for this specific settings field to cast it into int64.