### PR TITLE
chore: TestFetchingHistoryWhenOnline

### DIFF
--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -1123,60 +1123,34 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchingCommunityWithOwnerToken() {
 }
 
 func (s *MessengerStoreNodeRequestSuite) TestFetchingHistoryWhenOnline() {
-	// Create a separate relay node
-	// It's possible to connect owner and bob directly, but the test was hard to read and understand.
-	relayWaku := NewWakuV2(&s.Suite, testWakuV2Config{
-		logger:                 s.logger.Named("relay-waku"),
-		enableStore:            false,
-		useShardAsDefaultTopic: false,
-		clusterID:              shard.UndefinedShardValue,
-	})
-
-	relayAddress := s.wakuListenAddress(relayWaku)
-	relayPeerID := relayWaku.PeerID().String()
+	storeAddress := s.storeNodeAddress
+	storePeerID := s.wakuStoreNode.PeerID().String()
 
 	// Create messengers
 	s.createOwner()
 	s.createBob()
 
 	s.logger.Debug("store node info", zap.String("peerID", s.wakuStoreNode.PeerID().String()))
-	s.logger.Debug("relay node info", zap.String("peerID", relayPeerID))
 	s.logger.Debug("owner node info", zap.String("peerID", gethbridge.GetGethWakuV2From(s.ownerWaku).PeerID().String()))
 	s.logger.Debug("bob node info", zap.String("peerID", gethbridge.GetGethWakuV2From(s.bobWaku).PeerID().String()))
 
-	// Connect owner and bob to our relay node
+	// Connect to store node to force "online" status
 	{
-		WaitForPeerConnected(&s.Suite, gethbridge.GetGethWakuV2From(s.ownerWaku), func() string {
-			err := s.owner.DialPeer(relayAddress)
-			s.Require().NoError(err)
-			return relayPeerID
-		})
-		s.Require().True(s.owner.Online())
-
 		WaitForPeerConnected(&s.Suite, gethbridge.GetGethWakuV2From(s.bobWaku), func() string {
-			err := s.bob.DialPeer(relayAddress)
+			err := s.bob.DialPeer(storeAddress)
 			s.Require().NoError(err)
-			return relayPeerID
+			return storePeerID
 		})
 		s.Require().True(s.bob.Online())
-	}
 
-	// Wait for mesh to be formed
-	// "This usually takes 2 seconds". Made it 3 to be reliability.
-	// https://github.com/libp2p/go-libp2p-pubsub/blob/048a4d30d0c3c00829181fd81aa697eb60497448/trace_test.go#L99
-	// https://github.com/libp2p/go-libp2p-pubsub/blob/048a4d30d0c3c00829181fd81aa697eb60497448/gossipsub_feat_test.go#L65
-	// TODO: This is a hack, we should wait for the mesh to be formed in a more reliable way
-	//		 Either by binding to HearbeatInterval (and probably set it to a lower value for tests)
-	// 		 or by catching a GRAFT event with EventTracer.
-	time.Sleep(3 * time.Second)
+		// Wait for bob to fetch backup and historic messages
+		time.Sleep(2 * time.Second)
+	}
 
 	// bob goes offline
 	{
 		WaitForConnectionStatus(&s.Suite, gethbridge.GetGethWakuV2From(s.bobWaku), func() bool {
-			err := s.bob.DropPeer(relayPeerID)
-			s.Require().NoError(err)
-			// Also drop store node. Although we didn't connect to it directly, it will be dialed with the first store query.
-			err = s.bob.DropPeer(s.wakuStoreNode.PeerID().String())
+			err := s.bob.DropPeer(storePeerID)
 			s.Require().NoError(err)
 			return false
 		})
@@ -1207,9 +1181,7 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchingHistoryWhenOnline() {
 	// owner goes offline to prevent message resend and any other side effects
 	// to go offline we disconnect from both relay and store peers
 	WaitForConnectionStatus(&s.Suite, gethbridge.GetGethWakuV2From(s.ownerWaku), func() bool {
-		err := s.owner.DropPeer(relayPeerID)
-		s.Require().NoError(err)
-		err = s.owner.DropPeer(s.wakuStoreNode.PeerID().String())
+		err := s.owner.DropPeer(storePeerID)
 		s.Require().NoError(err)
 		return false
 	})
@@ -1217,14 +1189,16 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchingHistoryWhenOnline() {
 
 	// bob goes back online, this should trigger fetching historic messages
 	{
+		// Enable auto request historic messages, so that when bob goes online it will fetch historic messages
+		// We don't enable it earlier to control when we connect to the store node.
+		s.bob.config.featureFlags.AutoRequestHistoricMessages = true
+
 		WaitForPeerConnected(&s.Suite, gethbridge.GetGethWakuV2From(s.bobWaku), func() string {
-			err := s.bob.DialPeer(relayAddress)
+			err := s.bob.DialPeer(storeAddress)
 			s.Require().NoError(err)
-			return relayPeerID
+			return storePeerID
 		})
 		s.Require().True(s.bob.Online())
-
-		s.logger.Debug("<<< bob online")
 
 		// Don't  dial the peer, message should be fetched from store node
 		response, err := WaitOnMessengerResponse(
@@ -1238,5 +1212,4 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchingHistoryWhenOnline() {
 		s.Require().NotNil(response)
 		s.Require().Len(response.Contacts, 1)
 	}
-
 }

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"fmt"
+	waku2 "github.com/status-im/status-go/wakuv2"
 	"math/big"
 	"sync"
 	"time"
@@ -170,6 +172,10 @@ func WaitForPeerConnected(s *suite.Suite, waku *waku2.Waku, action func() string
 
 	// Action should return the desired peer ID
 	peerID := action()
+
+	if _, ok := waku.Peers()[peerID]; ok {
+		return
+	}
 
 	for {
 		select {

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -5,10 +5,11 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	waku2 "github.com/status-im/status-go/wakuv2"
 	"math/big"
 	"sync"
 	"time"
+
+	waku2 "github.com/status-im/status-go/wakuv2"
 
 	"golang.org/x/exp/maps"
 


### PR DESCRIPTION
# Description

This is a test for this change: https://github.com/status-im/status-go/pull/4651

The test creates 4 waku nodes:
1. Store node
2. Relay node
3. User 1 (owner)
4. User 2 (bob)

Both owner and bob are connected to the store node.
Both owner and bob use _relay node_ to communicate to each other.

In the test `owner` sends a CR to `bob` while the latter is offline.
And we check that when `bob` is back online he successfully fetches the message from storenode.

# Links

Requires:
- https://github.com/status-im/status-go/pull/4702
- https://github.com/status-im/status-go/pull/4703
- https://github.com/status-im/status-go/pull/4704

Follow up tasks:
- https://github.com/status-im/status-go/issues/4707

Closes https://github.com/status-im/status-go/issues/4653