### PR TITLE
fix: better calculation of from/to mailserver batch parameters

### DIFF
--- a/protocol/messenger_chats.go
+++ b/protocol/messenger_chats.go
@@ -656,7 +656,7 @@ func (m *Messenger) FetchMessages(request *requests.FetchMessages) error {
 		return ErrChatNotFound
 	}
 
-	_, err := m.fetchMessages(chat.ID, oneMonthInSeconds)
+	_, err := m.fetchMessages(chat.ID, oneMonthDuration)
 	if err != nil {
 		return err
 	}

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -3,7 +3,6 @@ package protocol
 import (
 	"database/sql"
 	"fmt"
-	"math"
 	"strings"
 	"sync"
 	"time"
@@ -518,8 +517,7 @@ func (r *storeNodeRequest) routine() {
 	}
 
 	// Start store node request
-	to := uint32(math.Ceil(float64(r.manager.messenger.GetCurrentTimeInMillis()) / 1000))
-	from := to - oneMonthInSeconds
+	from, to := r.manager.messenger.calculateMailserverTimeBounds(oneMonthDuration)
 
 	_, err := r.manager.messenger.performMailserverRequest(func() (*MessengerResponse, error) {
 		batch := MailserverBatch{


### PR DESCRIPTION
When making a store node query, we should round up `to` and round down `from`.
This is because we set the from/to in seconds, but the store node uses nanoseconds precision. So by rounding down the top bound we will miss the messages arrived in current second.

This problem is easily faced within tests. And also possible in day-to-day app usage.

I previously discovered this when implementing `MessengerStoreNodeRequestSuite`, but only fixed it in `StoreNodeRequestManager`. Now fixed for all store node queries.

Required for https://github.com/status-im/status-go/pull/4701
Tested there as well.
