### PR TITLE
chore: testWakuV2Config

### DIFF
--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -628,7 +628,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestBecomeMemberPermissions(
 	var err error
 
 	storeNodeLogger := s.logger.Named("store-node-waku")
-	wakuStoreNode := NewWakuV2(&s.Suite, storeNodeLogger, true, true, false, shard.UndefinedShardValue)
+	wakuStoreNode := NewTestWakuV2(&s.Suite, storeNodeLogger, true, true, false, shard.UndefinedShardValue)
 
 	storeNodeListenAddresses := wakuStoreNode.ListenAddresses()
 	s.Require().LessOrEqual(1, len(storeNodeListenAddresses))

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -161,7 +161,7 @@ func (s *MessengerStoreNodeRequestSuite) createStore() {
 		clusterID:              shard.UndefinedShardValue,
 	}
 
-	s.wakuStoreNode = NewWakuV2(&s.Suite, cfg)
+	s.wakuStoreNode = NewTestWakuV2(&s.Suite, cfg)
 	s.storeNodeAddress = s.wakuListenAddress(s.wakuStoreNode)
 	s.logger.Info("store node ready", zap.String("address", s.storeNodeAddress))
 }
@@ -175,7 +175,7 @@ func (s *MessengerStoreNodeRequestSuite) createOwner() {
 		clusterID:              shard.UndefinedShardValue,
 	}
 
-	wakuV2 := NewWakuV2(&s.Suite, cfg)
+	wakuV2 := NewTestWakuV2(&s.Suite, cfg)
 	s.ownerWaku = gethbridge.NewGethWakuV2Wrapper(wakuV2)
 
 	messengerLogger := s.logger.Named("owner-messenger")
@@ -193,7 +193,7 @@ func (s *MessengerStoreNodeRequestSuite) createBob() {
 		useShardAsDefaultTopic: false,
 		clusterID:              shard.UndefinedShardValue,
 	}
-	wakuV2 := NewWakuV2(&s.Suite, cfg)
+	wakuV2 := NewTestWakuV2(&s.Suite, cfg)
 	s.bobWaku = gethbridge.NewGethWakuV2Wrapper(wakuV2)
 
 	messengerLogger := s.logger.Named("bob-messenger")
@@ -973,7 +973,7 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchRealCommunity() {
 				useShardAsDefaultTopic: useShardAsDefaultTopic,
 				clusterID:              clusterID,
 			}
-			wakuV2 := NewWakuV2(&s.Suite, cfg)
+			wakuV2 := NewTestWakuV2(&s.Suite, cfg)
 			userWaku := gethbridge.NewGethWakuV2Wrapper(wakuV2)
 
 			//

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -138,24 +138,12 @@ func (r *singleResult) toString() string {
 }
 
 func (s *MessengerStoreNodeRequestSuite) SetupTest() {
-	cfg := zap.NewDevelopmentConfig()
-	cfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
-	cfg.Development = false
-	cfg.DisableStacktrace = true
-	s.logger = tt.MustCreateTestLoggerWithConfig(cfg)
+	s.logger = tt.MustCreateTestLogger()
 
 	s.cancel = make(chan struct{}, 10)
-
-	storeNodeLogger := s.logger.Named("store-node-waku")
-	s.wakuStoreNode = NewWakuV2(&s.Suite, storeNodeLogger, true, true, false, 0)
-
-	storeNodeListenAddresses := s.wakuStoreNode.ListenAddresses()
-	s.Require().LessOrEqual(1, len(storeNodeListenAddresses))
-
-	s.storeNodeAddress = storeNodeListenAddresses[0]
-	s.logger.Info("store node ready", zap.String("address", s.storeNodeAddress))
-
 	s.collectiblesServiceMock = &CollectiblesServiceMock{}
+
+	s.createStore()
 }
 
 func (s *MessengerStoreNodeRequestSuite) TearDown() {
@@ -165,9 +153,29 @@ func (s *MessengerStoreNodeRequestSuite) TearDown() {
 	TearDownMessenger(&s.Suite, s.bob)
 }
 
+func (s *MessengerStoreNodeRequestSuite) createStore() {
+	cfg := testWakuV2Config{
+		logger:                 s.logger.Named("store-waku"),
+		enableStore:            true,
+		useShardAsDefaultTopic: false,
+		clusterID:              shard.UndefinedShardValue,
+	}
+
+	s.wakuStoreNode = NewWakuV2(&s.Suite, cfg)
+	s.storeNodeAddress = s.wakuListenAddress(s.wakuStoreNode)
+	s.logger.Info("store node ready", zap.String("address", s.storeNodeAddress))
+}
+
 func (s *MessengerStoreNodeRequestSuite) createOwner() {
-	wakuLogger := s.logger.Named("owner-waku-node")
-	wakuV2 := NewWakuV2(&s.Suite, wakuLogger, true, false, false, 0)
+
+	cfg := testWakuV2Config{
+		logger:                 s.logger.Named("owner-waku"),
+		enableStore:            false,
+		useShardAsDefaultTopic: false,
+		clusterID:              shard.UndefinedShardValue,
+	}
+
+	wakuV2 := NewWakuV2(&s.Suite, cfg)
 	s.ownerWaku = gethbridge.NewGethWakuV2Wrapper(wakuV2)
 
 	messengerLogger := s.logger.Named("owner-messenger")
@@ -179,8 +187,13 @@ func (s *MessengerStoreNodeRequestSuite) createOwner() {
 }
 
 func (s *MessengerStoreNodeRequestSuite) createBob() {
-	wakuLogger := s.logger.Named("bob-waku-node")
-	wakuV2 := NewWakuV2(&s.Suite, wakuLogger, true, false, false, 0)
+	cfg := testWakuV2Config{
+		logger:                 s.logger.Named("bob-waku"),
+		enableStore:            false,
+		useShardAsDefaultTopic: false,
+		clusterID:              shard.UndefinedShardValue,
+	}
+	wakuV2 := NewWakuV2(&s.Suite, cfg)
 	s.bobWaku = gethbridge.NewGethWakuV2Wrapper(wakuV2)
 
 	messengerLogger := s.logger.Named("bob-messenger")
@@ -191,8 +204,12 @@ func (s *MessengerStoreNodeRequestSuite) newMessenger(shh types.Waku, logger *za
 	privateKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 
-	options := []Option{
-		WithTestStoreNode(&s.Suite, localMailserverID, mailserverAddress, localFleet, s.collectiblesServiceMock),
+	var options []Option
+
+	if mailserverAddress != "" {
+		options = append(options,
+			WithTestStoreNode(&s.Suite, localMailserverID, mailserverAddress, localFleet, s.collectiblesServiceMock),
+		)
 	}
 
 	messenger, err := newMessengerWithKey(shh, privateKey, logger, options)
@@ -314,13 +331,22 @@ func (s *MessengerStoreNodeRequestSuite) setupStoreNodeEnvelopesWatcher(topic *w
 }
 
 func (s *MessengerStoreNodeRequestSuite) waitForEnvelopes(subscription <-chan string, expectedEnvelopesCount int) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	for i := 0; i < expectedEnvelopesCount; i++ {
 		select {
 		case <-subscription:
-		case <-time.After(5 * time.Second):
+		case <-ctx.Done():
 			s.Require().Fail("timeout waiting for store node to receive envelopes")
 		}
 	}
+}
+
+func (s *MessengerStoreNodeRequestSuite) wakuListenAddress(waku *waku2.Waku) string {
+	addresses := waku.ListenAddresses()
+	s.Require().LessOrEqual(1, len(addresses))
+	return addresses[0]
 }
 
 func (s *MessengerStoreNodeRequestSuite) TestRequestCommunityInfo() {
@@ -938,10 +964,16 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchRealCommunity() {
 			// 		 But this turned out to be harder to implement.
 			//
 
-			wakuLogger := s.logger.Named(fmt.Sprintf("user-waku-node-%d", i))
+			wakuLogger := s.logger.Named(fmt.Sprintf("user-waku-%d", i))
 			messengerLogger := s.logger.Named(fmt.Sprintf("user-messenger-%d", i))
 
-			wakuV2 := NewWakuV2(&s.Suite, wakuLogger, true, false, useShardAsDefaultTopic, clusterID)
+			cfg := testWakuV2Config{
+				logger:                 wakuLogger,
+				enableStore:            false,
+				useShardAsDefaultTopic: useShardAsDefaultTopic,
+				clusterID:              clusterID,
+			}
+			wakuV2 := NewWakuV2(&s.Suite, cfg)
 			userWaku := gethbridge.NewGethWakuV2Wrapper(wakuV2)
 
 			//

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -19,8 +19,6 @@ import (
 	"github.com/status-im/status-go/protocol/tt"
 )
 
-const testENRBootstrap = "enrtree://AL65EKLJAUXKKPG43HVTML5EFFWEZ7L4LOKTLZCLJASG4DSESQZEC@prod.status.nodes.status.im"
-
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 var hexRunes = []rune("0123456789abcdef")
 

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -3,29 +3,20 @@ package protocol
 import (
 	"context"
 	"crypto/rand"
-	"database/sql"
 	"errors"
 	"math/big"
-	"os"
 	"sync"
 	"time"
 
 	"golang.org/x/exp/maps"
 
-	"go.uber.org/zap"
-
 	"github.com/stretchr/testify/suite"
 
-	"github.com/status-im/status-go/appdatabase"
-	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
-	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/protocol/tt"
-	"github.com/status-im/status-go/t/helpers"
-	waku2 "github.com/status-im/status-go/wakuv2"
 )
 
 const testENRBootstrap = "enrtree://AL65EKLJAUXKKPG43HVTML5EFFWEZ7L4LOKTLZCLJASG4DSESQZEC@prod.status.nodes.status.im"
@@ -248,96 +239,6 @@ func SetIdentityImagesAndWaitForChange(s *suite.Suite, messenger *Messenger, tim
 func WaitForAvailableStoreNode(s *suite.Suite, m *Messenger, timeout time.Duration) {
 	available := m.waitForAvailableStoreNode(timeout)
 	s.Require().True(available)
-}
-
-func NewWakuV2(s *suite.Suite, logger *zap.Logger, useLocalWaku bool, enableStore bool, useShardAsDefaultTopic bool, clusterID uint16) *waku2.Waku {
-	wakuConfig := &waku2.Config{
-		UseShardAsDefaultTopic: useShardAsDefaultTopic,
-		ClusterID:              clusterID,
-	}
-
-	var onPeerStats func(connStatus types.ConnStatus)
-	var connStatusChan chan struct{}
-	var db *sql.DB
-
-	if !useLocalWaku {
-		enrTreeAddress := testENRBootstrap
-		envEnrTreeAddress := os.Getenv("ENRTREE_ADDRESS")
-		if envEnrTreeAddress != "" {
-			enrTreeAddress = envEnrTreeAddress
-		}
-
-		wakuConfig.EnableDiscV5 = true
-		wakuConfig.DiscV5BootstrapNodes = []string{enrTreeAddress}
-		wakuConfig.DiscoveryLimit = 20
-		wakuConfig.WakuNodes = []string{enrTreeAddress}
-
-		connStatusChan = make(chan struct{})
-		terminator := sync.Once{}
-		onPeerStats = func(connStatus types.ConnStatus) {
-			if connStatus.IsOnline {
-				terminator.Do(func() {
-					connStatusChan <- struct{}{}
-				})
-			}
-		}
-	}
-
-	if enableStore {
-		var err error
-		db, err = helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
-		s.Require().NoError(err)
-
-		wakuConfig.EnableStore = true
-		wakuConfig.StoreCapacity = 200
-		wakuConfig.StoreSeconds = 200
-	}
-
-	wakuNode, err := waku2.New("", "", wakuConfig, logger, db, nil, nil, onPeerStats)
-	s.Require().NoError(err)
-	s.Require().NoError(wakuNode.Start())
-
-	if !useLocalWaku {
-		select {
-		case <-time.After(30 * time.Second):
-			s.Require().Fail("timeout elapsed")
-		case <-connStatusChan:
-			// proceed, peers found
-			close(connStatusChan)
-		}
-	}
-
-	return wakuNode
-}
-
-func CreateWakuV2Network(s *suite.Suite, parentLogger *zap.Logger, useShardAsDefaultTopic bool, nodeNames []string) []types.Waku {
-	nodes := make([]*waku2.Waku, len(nodeNames))
-	for i, name := range nodeNames {
-		logger := parentLogger.Named(name + "-waku")
-		wakuNode := NewWakuV2(s, logger, true, false, useShardAsDefaultTopic, 0)
-		nodes[i] = wakuNode
-	}
-
-	// Setup local network graph
-	for i := 0; i < len(nodes); i++ {
-		for j := 0; j < len(nodes); j++ {
-			if i == j {
-				continue
-			}
-
-			addrs := nodes[j].ListenAddresses()
-			s.Require().Greater(len(addrs), 0)
-			_, err := nodes[i].AddRelayPeer(addrs[0])
-			s.Require().NoError(err)
-			err = nodes[i].DialPeer(addrs[0])
-			s.Require().NoError(err)
-		}
-	}
-	wrappers := make([]types.Waku, len(nodes))
-	for i, n := range nodes {
-		wrappers[i] = gethbridge.NewGethWakuV2Wrapper(n)
-	}
-	return wrappers
 }
 
 func TearDownMessenger(s *suite.Suite, m *Messenger) {

--- a/protocol/waku_builder_test.go
+++ b/protocol/waku_builder_test.go
@@ -1,0 +1,92 @@
+package protocol
+
+import (
+	"database/sql"
+
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/appdatabase"
+	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/protocol/common/shard"
+	"github.com/status-im/status-go/t/helpers"
+	waku2 "github.com/status-im/status-go/wakuv2"
+)
+
+type testWakuV2Config struct {
+	logger                 *zap.Logger
+	enableStore            bool
+	useShardAsDefaultTopic bool
+	clusterID              uint16
+}
+
+func NewWakuV2(s *suite.Suite, cfg testWakuV2Config) *waku2.Waku {
+	wakuConfig := &waku2.Config{
+		UseShardAsDefaultTopic: cfg.useShardAsDefaultTopic,
+		ClusterID:              cfg.clusterID,
+	}
+
+	var db *sql.DB
+
+	if cfg.enableStore {
+		var err error
+		db, err = helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
+		s.Require().NoError(err)
+
+		wakuConfig.EnableStore = true
+		wakuConfig.StoreCapacity = 200
+		wakuConfig.StoreSeconds = 200
+	}
+
+	wakuNode, err := waku2.New(
+		"",
+		"",
+		wakuConfig,
+		cfg.logger,
+		db,
+		nil,
+		nil,
+		nil)
+
+	s.Require().NoError(err)
+
+	err = wakuNode.Start()
+	s.Require().NoError(err)
+
+	return wakuNode
+}
+
+func CreateWakuV2Network(s *suite.Suite, parentLogger *zap.Logger, useShardAsDefaultTopic bool, nodeNames []string) []types.Waku {
+	nodes := make([]*waku2.Waku, len(nodeNames))
+	wrappers := make([]types.Waku, len(nodes))
+
+	for i, name := range nodeNames {
+		nodes[i] = NewWakuV2(s, testWakuV2Config{
+			logger:                 parentLogger.Named("waku-" + name),
+			enableStore:            false,
+			useShardAsDefaultTopic: useShardAsDefaultTopic,
+			clusterID:              shard.UndefinedShardValue, // FIXME: why it was 0 here?
+		})
+	}
+
+	// Setup local network graph
+	for i := 0; i < len(nodes); i++ {
+		for j := 0; j < len(nodes); j++ {
+			if i == j {
+				continue
+			}
+
+			addrs := nodes[j].ListenAddresses()
+			s.Require().Greater(len(addrs), 0)
+			_, err := nodes[i].AddRelayPeer(addrs[0])
+			s.Require().NoError(err)
+			err = nodes[i].DialPeer(addrs[0])
+			s.Require().NoError(err)
+		}
+	}
+	for i, n := range nodes {
+		wrappers[i] = gethbridge.NewGethWakuV2Wrapper(n)
+	}
+	return wrappers
+}

--- a/protocol/waku_builder_test.go
+++ b/protocol/waku_builder_test.go
@@ -21,7 +21,7 @@ type testWakuV2Config struct {
 	clusterID              uint16
 }
 
-func NewWakuV2(s *suite.Suite, cfg testWakuV2Config) *waku2.Waku {
+func NewTestWakuV2(s *suite.Suite, cfg testWakuV2Config) *waku2.Waku {
 	wakuConfig := &waku2.Config{
 		UseShardAsDefaultTopic: cfg.useShardAsDefaultTopic,
 		ClusterID:              cfg.clusterID,
@@ -62,7 +62,7 @@ func CreateWakuV2Network(s *suite.Suite, parentLogger *zap.Logger, useShardAsDef
 	wrappers := make([]types.Waku, len(nodes))
 
 	for i, name := range nodeNames {
-		nodes[i] = NewWakuV2(s, testWakuV2Config{
+		nodes[i] = NewTestWakuV2(s, testWakuV2Config{
 			logger:                 parentLogger.Named("waku-" + name),
 			enableStore:            false,
 			useShardAsDefaultTopic: useShardAsDefaultTopic,

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1820,6 +1820,10 @@ func (w *Waku) Clean() error {
 	return nil
 }
 
+func (w *Waku) PeerID() peer.ID {
+	return w.node.Host().ID()
+}
+
 // validatePrivateKey checks the format of the given private key.
 func validatePrivateKey(k *ecdsa.PrivateKey) bool {
 	if k == nil || k.D == nil || k.D.Sign() == 0 {


### PR DESCRIPTION
Refactored `NewWakuV2` to get a single configuration struct argument, same approach as `newTestMessenger`.

Required for https://github.com/status-im/status-go/pull/4701