### PR TITLE
Fetch balances when db cache doesn't exist (second attempt)

### DIFF
--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -275,8 +275,17 @@ func (r *Reader) FetchOrGetCachedWalletBalances(ctx context.Context, addresses [
 	}
 
 	tokens, err := r.persistence.GetTokens()
+
+	addressWithoutCachedBalances := false
+	for _, address := range addresses {
+		if _, ok := tokens[address]; !ok {
+			addressWithoutCachedBalances = true
+			break
+		}
+	}
+
 	// there should be at least ETH balance
-	if len(tokens) == 0 {
+	if addressWithoutCachedBalances {
 		return r.GetWalletTokenBalances(ctx, addresses)
 	}
 


### PR DESCRIPTION
The case when the next generated acc doesn't have history was not properly handled in previous fix. 

