### PR TITLE
fix: flaky `MessengerStoreNodeRequestSuite`

### DIFF
--- a/protocol/common/feature_flags.go
+++ b/protocol/common/feature_flags.go
@@ -26,4 +26,8 @@ type FeatureFlags struct {
 
 	// Peersyncing indicates whether we should advertise and sync messages with other peers
 	Peersyncing bool
+
+	// AutoRequestHistoricMessages indicates whether we should automatically request
+	// historic messages on getting online, connecting to store node, etc.
+	AutoRequestHistoricMessages bool
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -293,7 +293,7 @@ func NewMessenger(
 ) (*Messenger, error) {
 	var messenger *Messenger
 
-	c := config{messageResendMinDelay: 30, messageResendMaxCount: 3}
+	c := messengerDefaultConfig()
 
 	for _, opt := range opts {
 		if err := opt(&c); err != nil {
@@ -950,7 +950,7 @@ func (m *Messenger) handleConnectionChange(online bool) {
 	}
 
 	// Start fetching messages from store nodes
-	if online {
+	if online && m.config.featureFlags.AutoRequestHistoricMessages {
 		m.asyncRequestAllHistoricMessages()
 	}
 

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -117,6 +117,16 @@ type config struct {
 	messageResendMaxCount int
 }
 
+func messengerDefaultConfig() config {
+	c := config{
+		messageResendMinDelay: 30,
+		messageResendMaxCount: 3,
+	}
+
+	c.featureFlags.AutoRequestHistoricMessages = true
+	return c
+}
+
 type Option func(*config) error
 
 // WithSystemMessagesTranslations is required for Group Chats which are currently disabled.
@@ -387,6 +397,13 @@ func WithTokenManager(tokenManager communities.TokenManager) Option {
 func WithAccountManager(accountManager account.Manager) Option {
 	return func(c *config) error {
 		c.accountsManager = accountManager
+		return nil
+	}
+}
+
+func WithAutoRequestHistoricMessages(enabled bool) Option {
+	return func(c *config) error {
+		c.featureFlags.AutoRequestHistoricMessages = enabled
 		return nil
 	}
 }

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -425,7 +425,9 @@ func (m *Messenger) connectToMailserver(ms mailservers.Mailserver) error {
 			signal.SendMailserverAvailable(m.mailserverCycle.activeMailserver.Address, m.mailserverCycle.activeMailserver.ID)
 
 			// Query mailserver
-			m.asyncRequestAllHistoricMessages()
+			if m.config.featureFlags.AutoRequestHistoricMessages {
+				m.asyncRequestAllHistoricMessages()
+			}
 		}
 	}
 	return nil
@@ -552,7 +554,9 @@ func (m *Messenger) handleMailserverCycleEvent(connectedPeers []ConnectedPeer) e
 					signal.SendMailserverAvailable(m.mailserverCycle.activeMailserver.Address, m.mailserverCycle.activeMailserver.ID)
 				}
 				// Query mailserver
-				m.asyncRequestAllHistoricMessages()
+				if m.config.featureFlags.AutoRequestHistoricMessages {
+					m.asyncRequestAllHistoricMessages()
+				}
 			} else {
 				m.mailPeersMutex.Unlock()
 			}


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/4720

I added a `AutoRequestHistoricMessages` feature flag to messenger. It defaults to `true`.

This is needed for `MessengerStoreNodeRequestSuite`, because automatic history requests make the tests flaky, they randomly start to run before/together with the test store query. And it doesn't make any sense to make those requests there anyway, since we're testing the store node requests manually.

Also added `waitForEnvelopes` here to make sure the store nodes receives all envelopes first.