### PR TITLE
fix: notify collectible data update when transferID is set

### DIFF
--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -806,6 +806,18 @@ func (o *Manager) getCacheFullCollectibleData(uniqueIDs []thirdparty.Collectible
 	return ret, nil
 }
 
+func (o *Manager) SetCollectibleTransferID(ownerAddress common.Address, id thirdparty.CollectibleUniqueID, transferID common.Hash, notify bool) error {
+	changed, err := o.ownershipDB.SetTransferID(ownerAddress, id, transferID)
+	if err != nil {
+		return err
+	}
+
+	if changed && notify {
+		o.signalUpdatedCollectiblesData([]thirdparty.CollectibleUniqueID{id})
+	}
+	return nil
+}
+
 // Reset connection status to trigger notifications
 // on the next status update
 func (o *Manager) ResetConnectionStatus() {

--- a/services/wallet/collectibles/ownership_db_test.go
+++ b/services/wallet/collectibles/ownership_db_test.go
@@ -426,6 +426,7 @@ func TestCollectibleTransferID(t *testing.T) {
 	timestampChain0 := int64(1234567890)
 
 	var err error
+	var changed bool
 
 	_, _, _, err = oDB.Update(chainID0, ownerAddress1, ownedBalancesChain0, timestampChain0)
 	require.NoError(t, err)
@@ -440,10 +441,24 @@ func TestCollectibleTransferID(t *testing.T) {
 		require.Nil(t, loadedTransferID)
 	}
 
+	randomAddress := common.HexToAddress("0xFFFF")
+	randomCollectibleID := thirdparty.CollectibleUniqueID{
+		ContractID: thirdparty.ContractID{
+			ChainID: 0xABCDEF,
+			Address: common.BigToAddress(big.NewInt(int64(123456789))),
+		},
+		TokenID: &bigint.BigInt{Int: big.NewInt(int64(987654321))},
+	}
+	randomTxID := common.HexToHash("0xEEEE")
+	changed, err = oDB.SetTransferID(randomAddress, randomCollectibleID, randomTxID)
+	require.NoError(t, err)
+	require.False(t, changed)
+
 	firstCollectibleID := ownedListChain0[0]
 	firstTxID := common.HexToHash("0x1234")
-	err = oDB.SetTransferID(ownerAddress1, firstCollectibleID, firstTxID)
+	changed, err = oDB.SetTransferID(ownerAddress1, firstCollectibleID, firstTxID)
 	require.NoError(t, err)
+	require.True(t, changed)
 
 	for _, id := range ownedListChain0 {
 		loadedTransferID, err := oDB.GetTransferID(ownerAddress1, id)

--- a/services/wallet/collectibles/service.go
+++ b/services/wallet/collectibles/service.go
@@ -430,7 +430,7 @@ func (s *Service) onCollectiblesTransfer(account common.Address, chainID walletC
 			},
 			TokenID: &bigint.BigInt{Int: transfer.TokenID},
 		}
-		err := s.ownershipDB.SetTransferID(account, id, transfer.ID)
+		err := s.manager.SetCollectibleTransferID(account, id, transfer.ID, true)
 		if err != nil {
 			log.Error("Error setting transfer ID for collectible", "error", err)
 		}
@@ -452,7 +452,7 @@ func (s *Service) lookupTransferForCollectibles(ownedCollectibles OwnedCollectib
 			continue
 		}
 		if transfer != nil {
-			err = s.ownershipDB.SetTransferID(ownedCollectibles.account, id, transfer.ID)
+			err = s.manager.SetCollectibleTransferID(ownedCollectibles.account, id, transfer.ID, false)
 			if err != nil {
 				log.Error("Error setting transfer ID for collectible", "error", err)
 			}


### PR DESCRIPTION
Notify of Collectible ownership changes when the transfer is detected (and the transfer ID is set) between owned collectibles refreshes.

Part of https://github.com/status-im/status-desktop/issues/13254