### PR TITLE
fix: saved addresses sync (`TestSyncDeletesOfSavedAddresses` flaky test)

### DIFF
--- a/protocol/messenger_response.go
+++ b/protocol/messenger_response.go
@@ -3,6 +3,8 @@ package protocol
 import (
 	"encoding/json"
 
+	"golang.org/x/exp/maps"
+
 	ensservice "github.com/status-im/status-go/services/ens"
 
 	"github.com/status-im/status-go/services/browsers"
@@ -510,11 +512,7 @@ func (r *MessengerResponse) AddSavedAddress(er *wallet.SavedAddress) {
 }
 
 func (r *MessengerResponse) SavedAddresses() []*wallet.SavedAddress {
-	var ers []*wallet.SavedAddress
-	for _, er := range r.savedAddresses {
-		ers = append(ers, er)
-	}
-	return ers
+	return maps.Values(r.savedAddresses)
 }
 
 func (r *MessengerResponse) AddEnsUsernameDetail(detail *ensservice.UsernameDetail) {

--- a/protocol/messenger_sync_saved_addresses_test.go
+++ b/protocol/messenger_sync_saved_addresses_test.go
@@ -309,14 +309,27 @@ func (s *MessengerSyncSavedAddressesSuite) testSyncDeletesOfSavedAddressesWithTe
 	s.Require().Equal(0, len(savedAddresses))
 }
 
-func (s *MessengerSyncSavedAddressesSuite) TestSyncDeletesOfSavedAddressesSameTestModeOnBothDevices() {
-	testModeMain := true
-	testModeOther := testModeMain
-	s.testSyncDeletesOfSavedAddressesWithTestModes(testModeMain, testModeOther)
-}
+func (s *MessengerSyncSavedAddressesSuite) TestSyncDeletesOfSavedAddresses() {
+	testCases := []struct {
+		Name          string
+		TestModeMain  bool
+		TestModeOther bool
+	}{
+		{
+			Name:          "same test mode on both devices",
+			TestModeMain:  true,
+			TestModeOther: true,
+		},
+		{
+			Name:          "different test mode on devices",
+			TestModeMain:  true,
+			TestModeOther: false,
+		},
+	}
 
-func (s *MessengerSyncSavedAddressesSuite) TestSyncDeletesOfSavedAddressesDifferentTestModeOnDevices() {
-	testModeMain := true
-	testModeOther := !testModeMain
-	s.testSyncDeletesOfSavedAddressesWithTestModes(testModeMain, testModeOther)
+	for _, tc := range testCases {
+		s.Run(tc.Name, func() {
+			s.testSyncDeletesOfSavedAddressesWithTestModes(tc.TestModeMain, tc.TestModeOther)
+		})
+	}
 }

--- a/protocol/messenger_sync_saved_addresses_test.go
+++ b/protocol/messenger_sync_saved_addresses_test.go
@@ -144,10 +144,6 @@ func (s *MessengerSyncSavedAddressesSuite) TestSyncExistingSavedAddresses() {
 	err = s.main.UpsertSavedAddress(context.Background(), sa2)
 	s.Require().NoError(err)
 
-	//// Trigger's a sync between devices
-	//err = s.main.SyncDevices(context.Background(), "ens-name", "profile-image", nil)
-	//s.Require().NoError(err)
-
 	// Wait and check that saved addresses are synced
 	_, err = WaitOnMessengerResponse(
 		s.other,

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1075,7 +1075,7 @@ func (api *PublicAPI) DeleteSavedAddress(ctx context.Context, address ethcommon.
 	return api.service.messenger.DeleteSavedAddress(ctx, address, isTest)
 }
 
-func (api *PublicAPI) GetSavedAddresses(ctx context.Context) ([]wallet.SavedAddress, error) {
+func (api *PublicAPI) GetSavedAddresses(ctx context.Context) ([]*wallet.SavedAddress, error) {
 	return api.service.messenger.GetSavedAddresses(ctx)
 }
 

--- a/services/wallet/saved_addresses_test.go
+++ b/services/wallet/saved_addresses_test.go
@@ -45,7 +45,7 @@ func TestSavedAddressesAdd(t *testing.T) {
 		IsTest:          false,
 	}
 
-	_, err = manager.UpdateMetadataAndUpsertSavedAddress(sa)
+	err = manager.UpdateMetadataAndUpsertSavedAddress(sa)
 	require.NoError(t, err)
 
 	rst, err = manager.GetRawSavedAddresses()
@@ -77,7 +77,7 @@ func haveSameElements[T comparable](a []T, b []T, isEqual func(T, T) bool) bool 
 	return true
 }
 
-func savedAddressDataIsEqual(a, b SavedAddress) bool {
+func savedAddressDataIsEqual(a, b *SavedAddress) bool {
 	return a.Address == b.Address && a.Name == b.Name && a.ChainShortNames == b.ChainShortNames &&
 		a.ENSName == b.ENSName && a.IsTest == b.IsTest && a.ColorID == b.ColorID
 }
@@ -117,10 +117,12 @@ func TestSavedAddressesMetadata(t *testing.T) {
 		Name:    "Simple",
 		ColorID: multiAccCommon.CustomizationColorBlue,
 		IsTest:  false,
+		savedAddressMeta: savedAddressMeta{
+			UpdateClock: 42,
+		},
 	}
 
-	var sa2UpdatedClock uint64
-	sa2UpdatedClock, err = manager.UpdateMetadataAndUpsertSavedAddress(sa2)
+	err = manager.UpdateMetadataAndUpsertSavedAddress(sa2)
 	require.NoError(t, err)
 
 	dbSavedAddresses, err = manager.GetRawSavedAddresses()
@@ -129,7 +131,7 @@ func TestSavedAddressesMetadata(t *testing.T) {
 	// The order is not guaranteed check raw entry to decide
 	rawIndex := 0
 	simpleIndex := 1
-	if dbSavedAddresses[0] != sa1 {
+	if dbSavedAddresses[0].Address == sa1.Address {
 		rawIndex = 1
 		simpleIndex = 0
 	}
@@ -141,18 +143,20 @@ func TestSavedAddressesMetadata(t *testing.T) {
 
 	// Check the default values
 	require.False(t, dbSavedAddresses[rawIndex].Removed)
-	require.Equal(t, dbSavedAddresses[rawIndex].UpdateClock, sa2UpdatedClock)
+	require.Equal(t, dbSavedAddresses[rawIndex].UpdateClock, sa2.UpdateClock)
 	require.Greater(t, dbSavedAddresses[rawIndex].UpdateClock, uint64(0))
 
 	sa2Older := sa2
 	sa2Older.IsTest = false
+	sa2Older.UpdateClock = dbSavedAddresses[rawIndex].UpdateClock - 1
 
 	sa2Newer := sa2
 	sa2Newer.IsTest = false
+	sa2Newer.UpdateClock = dbSavedAddresses[rawIndex].UpdateClock + 1
 
 	// Try to add an older entry
 	updated := false
-	updated, err = manager.AddSavedAddressIfNewerUpdate(sa2Older, dbSavedAddresses[rawIndex].UpdateClock-1)
+	updated, err = manager.AddSavedAddressIfNewerUpdate(sa2Older)
 	require.NoError(t, err)
 	require.False(t, updated)
 
@@ -161,18 +165,18 @@ func TestSavedAddressesMetadata(t *testing.T) {
 
 	rawIndex = 0
 	simpleIndex = 1
-	if dbSavedAddresses[0] != sa1 {
+	if dbSavedAddresses[0].Address == sa1.Address {
 		rawIndex = 1
 		simpleIndex = 0
 	}
 
 	require.Equal(t, 2, len(dbSavedAddresses))
-	require.True(t, haveSameElements([]SavedAddress{sa1, sa2}, dbSavedAddresses, savedAddressDataIsEqual))
+	require.True(t, haveSameElements([]*SavedAddress{&sa1, &sa2}, dbSavedAddresses, savedAddressDataIsEqual))
 	require.Equal(t, sa1.savedAddressMeta, dbSavedAddresses[simpleIndex].savedAddressMeta)
 
 	// Try to update sa2 with a newer entry
 	updatedClock := dbSavedAddresses[rawIndex].UpdateClock + 1
-	updated, err = manager.AddSavedAddressIfNewerUpdate(sa2Newer, updatedClock)
+	updated, err = manager.AddSavedAddressIfNewerUpdate(sa2Newer)
 	require.NoError(t, err)
 	require.True(t, updated)
 
@@ -180,7 +184,7 @@ func TestSavedAddressesMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 2, len(dbSavedAddresses))
-	require.True(t, haveSameElements([]SavedAddress{sa1, sa2Newer}, dbSavedAddresses, savedAddressDataIsEqual))
+	require.True(t, haveSameElements([]*SavedAddress{&sa1, &sa2Newer}, dbSavedAddresses, savedAddressDataIsEqual))
 	require.Equal(t, updatedClock, dbSavedAddresses[rawIndex].UpdateClock)
 
 	// Try to delete the sa2 newer entry
@@ -254,7 +258,7 @@ func TestSavedAddressesGet(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(dbSavedAddresses))
 
-	require.True(t, savedAddressDataIsEqual(sa, dbSavedAddresses[0]))
+	require.True(t, savedAddressDataIsEqual(&sa, dbSavedAddresses[0]))
 
 	dbSavedAddresses, err = manager.GetSavedAddresses()
 	require.NoError(t, err)
@@ -277,7 +281,7 @@ func TestSavedAddressesDelete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rst))
 
-	require.True(t, savedAddressDataIsEqual(sa0, rst[0]))
+	require.True(t, savedAddressDataIsEqual(&sa0, rst[0]))
 
 	// Modify IsTest flag, insert
 	sa1 := sa0
@@ -294,7 +298,7 @@ func TestSavedAddressesDelete(t *testing.T) {
 	rst, err = manager.GetSavedAddresses()
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rst))
-	require.True(t, savedAddressDataIsEqual(sa1, rst[0]))
+	require.True(t, savedAddressDataIsEqual(&sa1, rst[0]))
 
 	// Test that we still have both addresses
 	rst, err = manager.GetRawSavedAddresses()
@@ -325,7 +329,7 @@ func testInsertSameAddressWithOneChange(t *testing.T, member int) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rst))
 
-	require.True(t, savedAddressDataIsEqual(sa, rst[0]))
+	require.True(t, savedAddressDataIsEqual(&sa, rst[0]))
 
 	sa2 := sa
 
@@ -350,12 +354,12 @@ func testInsertSameAddressWithOneChange(t *testing.T, member int) {
 	// guaranteed to be the same as insertions, so swap indices if first record does not match
 	firstIndex := 0
 	secondIndex := 1
-	if rst[firstIndex] != sa {
+	if rst[firstIndex].Address == sa.Address {
 		firstIndex = 1
 		secondIndex = 0
 	}
-	require.True(t, savedAddressDataIsEqual(sa, rst[firstIndex]))
-	require.True(t, savedAddressDataIsEqual(sa2, rst[secondIndex]))
+	require.True(t, savedAddressDataIsEqual(&sa, rst[firstIndex]))
+	require.True(t, savedAddressDataIsEqual(&sa2, rst[secondIndex]))
 }
 
 func TestSavedAddressesAddDifferentIsTest(t *testing.T) {
@@ -380,7 +384,7 @@ func TestSavedAddressesAddSame(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(rst))
 
-	require.True(t, savedAddressDataIsEqual(sa, rst[0]))
+	require.True(t, savedAddressDataIsEqual(&sa, rst[0]))
 
 	sa2 := sa
 	err = manager.upsertSavedAddress(sa2, nil)


### PR DESCRIPTION
1. The actual fix is to use `getLastClockWithRelatedChat()` instead of `time.Now()` for `UpdatedClock`. 
Otherwise it's second-precise, and in tests the insertion/removal happen in the same second, so the removal doesn't actually happen.

2. Improved the test to catch if removal didn't happened even before syncing.

3. Refactored `TestSyncDeletesOfSavedAddresses` to use test cases.

4. Fixed `haveSameElements`, which DIDN'T CHECK THE NUMBER OF ELEMENTS.
Don't know, maybe I didn't get some initial intentions. Anyway, we shouldn't write such function our own. There're standard ways for such cases, e.g. `reflect.DeepEqual`. We shouldn't write custom functions just to ignore clock fields. Instead, such fields should also be checked for correct values.
I refactored some of places using `haveSameElements`, but not all of them.

5. Refactored `testSyncDeletesOfSavedAddresses` to be more readable.

Closes https://github.com/status-im/status-go/issues/4732
