### PR TITLE
fix: Use correct chains when checking permissions: mainnet or testnet

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -155,9 +155,16 @@ func (m *DefaultTokenManager) GetAllChainIDs() ([]uint64, error) {
 		return nil, err
 	}
 
+	areTestNetworksEnabled, err := m.tokenManager.RPCClient.NetworkManager.GetTestNetworksEnabled()
+	if err != nil {
+		return nil, err
+	}
+
 	chainIDs := make([]uint64, 0)
 	for _, network := range networks {
-		chainIDs = append(chainIDs, network.ChainID)
+		if areTestNetworksEnabled == network.IsTest {
+			chainIDs = append(chainIDs, network.ChainID)
+		}
 	}
 	return chainIDs, nil
 }

--- a/rpc/network/network.go
+++ b/rpc/network/network.go
@@ -320,3 +320,7 @@ func (nm *Manager) GetCombinedNetworks() ([]*CombinedNetwork, error) {
 func (nm *Manager) GetConfiguredNetworks() []params.Network {
 	return nm.configuredNetworks
 }
+
+func (nm *Manager) GetTestNetworksEnabled() (result bool, err error) {
+	return nm.accountsDB.GetTestNetworksEnabled()
+}


### PR DESCRIPTION
GetAllChainIDs will return chains according to networkTestEnabled parameter.
It is used by PermissionChecker.

Fix [#18896](https://github.com/status-im/status-mobile/issues/18896)