### PR TITLE
fix: override unsupported settings.fleet

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -1461,13 +1461,13 @@ func TestSetFleet(t *testing.T) {
 
 	accountsDB, err := b.accountsDB()
 	require.NoError(t, err)
-	err = accountsDB.SaveSettingField(settings.Fleet, statusTestFleet)
+	err = accountsDB.SaveSettingField(settings.Fleet, params.FleetShardsTest)
 	require.NoError(t, err)
 
 	savedSettings, err = b.GetSettings()
 	require.NoError(t, err)
 	require.NotEmpty(t, savedSettings.Fleet)
-	require.Equal(t, statusTestFleet, *savedSettings.Fleet)
+	require.Equal(t, params.FleetShardsTest, *savedSettings.Fleet)
 
 	require.NoError(t, b.Logout())
 
@@ -1483,7 +1483,7 @@ func TestSetFleet(t *testing.T) {
 		t.FailNow()
 	}
 	// Check is using the right fleet
-	require.Equal(t, b.config.ClusterConfig.WakuNodes, DefaultWakuNodes[statusTestFleet])
+	require.Equal(t, b.config.ClusterConfig.WakuNodes, params.DefaultWakuNodes(params.FleetShardsTest))
 
 	require.NoError(t, b.Logout())
 }

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -27,23 +27,7 @@ const defaultKeycardPairingDataFile = "/ethereum/mainnet_rpc/keycard/pairings.js
 
 var paths = []string{pathWalletRoot, pathEIP1581, pathDefaultChat, pathDefaultWallet}
 
-const (
-	statusProdFleet = "status.prod"
-	statusTestFleet = "status.test"
-	wakuv2ProdFleet = "wakuv2.prod"
-	wakuv2TestFleet = "wakuv2.test"
-	shardsTest      = "shards.test"
-)
-
-var DefaultWakuNodes = map[string][]string{
-	statusProdFleet: []string{"enrtree://AL65EKLJAUXKKPG43HVTML5EFFWEZ7L4LOKTLZCLJASG4DSESQZEC@prod.status.nodes.status.im"},
-	statusTestFleet: []string{"enrtree://AIO6LUM3IVWCU2KCPBBI6FEH2W42IGK3ASCZHZGG5TIXUR56OGQUO@test.status.nodes.status.im"},
-	wakuv2ProdFleet: []string{"enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im"},
-	wakuv2TestFleet: []string{"enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im"},
-	shardsTest:      []string{"enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.test.shards.nodes.status.im"},
-}
-
-var DefaultFleet = shardsTest
+var DefaultFleet = params.FleetShardsTest
 
 func defaultSettings(generatedAccountInfo generator.GeneratedAccountInfo, derivedAddresses map[string]generator.AccountInfo, mnemonic *string) (*settings.Settings, error) {
 	chatKeyString := derivedAddresses[pathDefaultChat].PublicKey
@@ -134,10 +118,10 @@ func SetFleet(fleet string, nodeConfig *params.NodeConfig) error {
 	}
 	nodeConfig.ClusterConfig = *clusterConfig
 	nodeConfig.ClusterConfig.Fleet = fleet
-	nodeConfig.ClusterConfig.WakuNodes = DefaultWakuNodes[fleet]
-	nodeConfig.ClusterConfig.DiscV5BootstrapNodes = DefaultWakuNodes[fleet]
+	nodeConfig.ClusterConfig.WakuNodes = params.DefaultWakuNodes(fleet)
+	nodeConfig.ClusterConfig.DiscV5BootstrapNodes = params.DefaultWakuNodes(fleet)
 
-	if fleet == shardsTest {
+	if fleet == params.FleetShardsTest {
 		nodeConfig.ClusterConfig.ClusterID = shardsTestClusterID
 		nodeConfig.WakuV2Config.UseShardAsDefaultTopic = true
 	}

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -624,20 +624,7 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 
 	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig)
 
-	settings, err := b.GetSettings()
-	if err != nil {
-		return err
-	}
-
-	var fleet string
-	fleetPtr := settings.Fleet
-	if fleetPtr == nil || *fleetPtr == "" {
-		fleet = DefaultFleet
-	} else {
-		fleet = *fleetPtr
-	}
-
-	err = SetFleet(fleet, defaultCfg)
+	err = b.updateNodeConfigFleet(defaultCfg)
 	if err != nil {
 		return err
 	}
@@ -705,11 +692,43 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 	}
 
 	return nil
+}
 
+// updateNodeConfigFleet loads the fleet from the settings and updates the node configuration
+// If the fleet in settings is empty, or not supported anymore, it will be overridden with the default fleet.
+// In that case settings fleet value remain the same, only runtime node configuration is updated.
+func (b *GethStatusBackend) updateNodeConfigFleet(config *params.NodeConfig) error {
+	accountSettings, err := b.GetSettings()
+	if err != nil {
+		return err
+	}
+
+	fleet := accountSettings.GetFleet()
+
+	if !params.IsFleetSupported(fleet) {
+		b.log.Warn("fleet is not supported, overriding with default value",
+			"fleet", fleet,
+			"defaultFleet", DefaultFleet)
+		fleet = DefaultFleet
+	}
+
+	err = SetFleet(fleet, config)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (b *GethStatusBackend) startNodeWithAccount(acc multiaccounts.Account, password string, inputNodeCfg *params.NodeConfig) error {
 	err := b.ensureDBsOpened(acc, password)
+	if err != nil {
+		return err
+	}
+
+	// NOTE: This is code duplication from `loginAccount` method
+	//		 We should stop using this endpoint in desktop: https://github.com/status-im/status-desktop/issues/12977
+	err = b.updateNodeConfigFleet(inputNodeCfg)
 	if err != nil {
 		return err
 	}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -998,7 +998,7 @@ type FleetDescription struct {
 func Fleets() string {
 	fleets := FleetDescription{
 		DefaultFleet: api.DefaultFleet,
-		Fleets:       api.DefaultWakuNodes,
+		Fleets:       params.GetSupportedFleets(),
 	}
 
 	data, err := json.Marshal(fleets)

--- a/multiaccounts/settings/structs.go
+++ b/multiaccounts/settings/structs.go
@@ -6,6 +6,7 @@ import (
 
 	accountJson "github.com/status-im/status-go/account/json"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -223,4 +224,11 @@ func (s Settings) MarshalJSON() ([]byte, error) {
 func (s Settings) IsEmpty() bool {
 	empty := reflect.Zero(reflect.TypeOf(s)).Interface()
 	return reflect.DeepEqual(s, empty)
+}
+
+func (s Settings) GetFleet() string {
+	if s.Fleet == nil {
+		return params.FleetUndefined
+	}
+	return *s.Fleet
 }

--- a/params/cluster.go
+++ b/params/cluster.go
@@ -20,3 +20,24 @@ type Cluster struct {
 	MailServers     []string `json:"mailservers"` // list of trusted mail servers
 	RendezvousNodes []string `json:"rendezvousnodes"`
 }
+
+// DefaultWakuNodes is a list of "supported" fleets. This list is populated to clients UI settings.
+var supportedFleets = map[string][]string{
+	FleetWakuV2Prod: {"enrtree://ANEDLO25QVUGJOUTQFRYKWX6P4Z4GKVESBMHML7DZ6YK4LGS5FC5O@prod.wakuv2.nodes.status.im"},
+	FleetWakuV2Test: {"enrtree://AO47IDOLBKH72HIZZOXQP6NMRESAN7CHYWIBNXDXWRJRZWLODKII6@test.wakuv2.nodes.status.im"},
+	FleetShardsTest: {"enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.test.shards.nodes.status.im"},
+}
+
+func DefaultWakuNodes(fleet string) []string {
+	return supportedFleets[fleet]
+}
+
+func IsFleetSupported(fleet string) bool {
+	_, ok := supportedFleets[fleet]
+	return !ok
+}
+
+func GetSupportedFleets() map[string][]string {
+	return supportedFleets
+}
+

--- a/params/cluster.go
+++ b/params/cluster.go
@@ -34,7 +34,7 @@ func DefaultWakuNodes(fleet string) []string {
 
 func IsFleetSupported(fleet string) bool {
 	_, ok := supportedFleets[fleet]
-	return !ok
+	return ok
 }
 
 func GetSupportedFleets() map[string][]string {

--- a/params/cluster.go
+++ b/params/cluster.go
@@ -40,4 +40,3 @@ func IsFleetSupported(fleet string) bool {
 func GetSupportedFleets() map[string][]string {
 	return supportedFleets
 }
-


### PR DESCRIPTION
1. Remove fleet enum duplication
2. Define a list of "supported" fleets
3. Implemented `updateNodeConfigFleet` which:
- loads the `settings.fleet`
- checks if the fleet is supported
- sets a proper fleet to nodeConfig
4. Call `updateNodeConfigFleet` from both desktop and mobile endpoints
5. Remove `status.prod` and `status.test` from supported fleets

Part of https://github.com/status-im/status-desktop/issues/13625