### PR TITLE
fix: properly handle tokenID 0 when filtering activity by collectibles

### DIFF
--- a/services/wallet/activity/activity_test.go
+++ b/services/wallet/activity/activity_test.go
@@ -1086,6 +1086,10 @@ func TestGetActivityEntriesFilterByCollectibles(t *testing.T) {
 	entries, err = getActivityEntries(context.Background(), deps, allAddresses, true, []common.ChainID{}, filter, 0, 15)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(entries))
+	require.Equal(t, entries[0].tokenIn.Address, transfer.TestCollectibles[2].TokenAddress)
+	require.True(t, (*big.Int)(entries[0].tokenIn.TokenID).Cmp(transfer.TestCollectibles[2].TokenID) == 0)
+	require.Equal(t, entries[1].tokenIn.Address, transfer.TestCollectibles[1].TokenAddress)
+	require.True(t, (*big.Int)(entries[1].tokenIn.TokenID).Cmp(transfer.TestCollectibles[1].TokenID) == 0)
 }
 
 func TestGetActivityEntriesFilterByToAddresses(t *testing.T) {

--- a/services/wallet/activity/filter.sql
+++ b/services/wallet/activity/filter.sql
@@ -198,7 +198,10 @@ SELECT
 	END AS agg_status,
 	1 AS agg_count,
 	transfers.token_address AS token_address,
-	transfers.token_id AS token_id,
+	CASE
+		WHEN LENGTH(transfers.token_id) = 0 THEN X'00'
+		ELSE transfers.token_id
+	END AS tmp_token_id,
 	NULL AS token_code,
 	NULL AS from_token_code,
 	NULL AS to_token_code,
@@ -323,7 +326,7 @@ WHERE
 			AND (
 				(
 					transfers.network_id,
-					transfers.token_id,
+					tmp_token_id,
 					transfers.token_address
 				) IN assets_erc721
 			)
@@ -373,7 +376,7 @@ SELECT
 	statusPending AS agg_status,
 	1 AS agg_count,
 	NULL AS token_address,
-	NULL AS token_id,
+	NULL AS tmp_token_id,
 	pending_transactions.symbol AS token_code,
 	NULL AS from_token_code,
 	NULL AS to_token_code,
@@ -465,7 +468,7 @@ SELECT
 	END AS agg_status,
 	COALESCE(tr_status.count, 0) + COALESCE(pending_status.count, 0) AS agg_count,
 	NULL AS token_address,
-	NULL AS token_id,
+	NULL AS tmp_token_id,
 	NULL AS token_code,
 	multi_transactions.from_asset AS from_token_code,
 	multi_transactions.to_asset AS to_token_code,

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -161,6 +161,11 @@ var TestCollectibles = []TestCollectible{
 		TokenID:      big.NewInt(1),
 		ChainID:      1,
 	},
+	TestCollectible{ // TokenID (big.Int) value 0 might be problematic if not handled properly
+		TokenAddress: eth_common.HexToAddress("0x97a04fda4d97c6e3547d66b572e29f4a4ff4ABCD"),
+		TokenID:      big.NewInt(0),
+		ChainID:      420,
+	},
 	TestCollectible{
 		TokenAddress: eth_common.HexToAddress("0x1dea7a3e04849840c0eb15fd26a55f6c40c4a69b"),
 		TokenID:      big.NewInt(11),


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/13660

We weren't properly handling tokenID 0 value when filtering activity by collectible. This is due to big.Int representing value 0 as a zero-length byte array instead of a single 0 byte.

This was fixed in this PR. When scanning, we now either get nil or the proper value.

