### PR TITLE
fix(contacts): fix blocking a non-contact sends a signal to the other

### DIFF
--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -854,6 +854,7 @@ func (m *Messenger) blockContact(ctx context.Context, response *MessengerRespons
 		return err
 	}
 
+	contactWasAdded := contact.added()
 	contact.Block(clock)
 
 	contact.LastUpdatedLocally = m.getTimesource().GetCurrentTime()
@@ -876,9 +877,11 @@ func (m *Messenger) blockContact(ctx context.Context, response *MessengerRespons
 	}
 
 	if !fromSyncing {
-		err = m.sendRetractContactRequest(contact)
-		if err != nil {
-			return err
+		if contactWasAdded {
+			err = m.sendRetractContactRequest(contact)
+			if err != nil {
+				return err
+			}
 		}
 
 		err = m.syncContact(context.Background(), contact, m.dispatchMessage)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/13545

The code is correct in sending an updated CR to make sure the sync doesn't sync back the previous state or at least overrides it. 

However, if we never were a contact with the person sending us a CR, and we block them, it sends them a "you got removed" message, which first doesn't make sense but also could let them know they got blocked/ignored.

The trick is just to make sure we added them first. Then dismissing the CR makes sense.

