### PR TITLE
feat: kicked/banned member should not have spectated mode after the kick/ban

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -3106,8 +3106,8 @@ func (m *Manager) LeaveCommunity(id types.HexBytes) (*Community, error) {
 	return community, nil
 }
 
-// Same as LeaveCommunity, but we want to stay spectating
-func (m *Manager) KickedOutOfCommunity(id types.HexBytes) (*Community, error) {
+// Same as LeaveCommunity, but we have an option to stay spectating
+func (m *Manager) KickedOutOfCommunity(id types.HexBytes, spectateMode bool) (*Community, error) {
 	community, err := m.GetByID(id)
 	if err != nil {
 		return nil, err
@@ -3115,7 +3115,9 @@ func (m *Manager) KickedOutOfCommunity(id types.HexBytes) (*Community, error) {
 
 	community.RemoveOurselvesFromOrg(&m.identity.PublicKey)
 	community.Leave()
-	community.Spectate()
+	if spectateMode {
+		community.Spectate()
+	}
 
 	if err = m.persistence.SaveCommunity(community); err != nil {
 		return nil, err

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -2351,7 +2351,11 @@ func (s *MessengerCommunitiesSuite) TestBanUser() {
 			return len(r.Communities()) == 1 &&
 				len(r.Communities()[0].PendingAndBannedMembers()) == 1 &&
 				r.Communities()[0].IsBanned(&s.alice.identity.PublicKey) &&
-				len(r.ActivityCenterNotifications()) == 1 && !r.ActivityCenterState().HasSeen
+				len(r.ActivityCenterNotifications()) == 1 &&
+				!r.ActivityCenterState().HasSeen &&
+				!r.Communities()[0].Spectated() &&
+				!r.Communities()[0].Joined()
+
 		},
 		"no message about alice ban",
 	)
@@ -4094,5 +4098,5 @@ func (s *MessengerCommunitiesSuite) TestBanUserAndDeleteAllUserMessages() {
 	s.Require().True(community.IsBanned(&s.alice.identity.PublicKey))
 	s.Require().Len(community.PendingAndBannedMembers(), 1)
 	s.Require().False(community.Joined())
-	s.Require().True(community.Spectated())
+	s.Require().False(community.Spectated())
 }


### PR DESCRIPTION
Kicked/banned member should not have spectated mode after the kick/ban
Exception - if the user was kicked out due to a change of ownership

Closes # https://github.com/status-im/status-desktop/issues/13454

status-desktop PR: https://github.com/status-im/status-desktop/pull/13706

