### PR TITLE
feat: rpc request limiter

### DIFF
--- a/rpc/chain/rpc_limiter.go
+++ b/rpc/chain/rpc_limiter.go
@@ -1,0 +1,162 @@
+package chain
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	defaultMaxRequestsPerSecond = 100
+	minRequestsPerSecond        = 20
+	requestsPerSecondStep       = 10
+
+	tickerInterval = 1 * time.Second
+)
+
+var (
+	ErrRequestsOverLimit = fmt.Errorf("number of requests over limit")
+)
+
+type callerOnWait struct {
+	requests int
+	ch       chan bool
+}
+
+type RPCLimiter struct {
+	uuid uuid.UUID
+
+	maxRequestsPerSecond      int
+	maxRequestsPerSecondMutex sync.RWMutex
+
+	requestsMadeWithinSecond      int
+	requestsMadeWithinSecondMutex sync.RWMutex
+
+	callersOnWaitForRequests      []callerOnWait
+	callersOnWaitForRequestsMutex sync.RWMutex
+
+	quit chan bool
+}
+
+func NewRPCLimiter() *RPCLimiter {
+
+	limiter := RPCLimiter{
+		uuid:                 uuid.New(),
+		maxRequestsPerSecond: defaultMaxRequestsPerSecond,
+		quit:                 make(chan bool),
+	}
+
+	limiter.start()
+
+	return &limiter
+}
+
+func (rl *RPCLimiter) ReduceLimit() {
+	rl.maxRequestsPerSecondMutex.Lock()
+	defer rl.maxRequestsPerSecondMutex.Unlock()
+	if rl.maxRequestsPerSecond <= minRequestsPerSecond {
+		return
+	}
+	rl.maxRequestsPerSecond = rl.maxRequestsPerSecond - requestsPerSecondStep
+}
+
+func (rl *RPCLimiter) start() {
+	ticker := time.NewTicker(tickerInterval)
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				{
+					rl.requestsMadeWithinSecondMutex.Lock()
+					oldrequestsMadeWithinSecond := rl.requestsMadeWithinSecond
+					if rl.requestsMadeWithinSecond != 0 {
+						rl.requestsMadeWithinSecond = 0
+					}
+					rl.requestsMadeWithinSecondMutex.Unlock()
+					if oldrequestsMadeWithinSecond == 0 {
+						continue
+					}
+				}
+
+				rl.callersOnWaitForRequestsMutex.Lock()
+				numOfRequestsToMakeAvailable := rl.maxRequestsPerSecond
+				for {
+					if numOfRequestsToMakeAvailable == 0 || len(rl.callersOnWaitForRequests) == 0 {
+						break
+					}
+
+					var index = -1
+					for i := 0; i < len(rl.callersOnWaitForRequests); i++ {
+						if rl.callersOnWaitForRequests[i].requests <= numOfRequestsToMakeAvailable {
+							index = i
+							break
+						}
+					}
+
+					if index == -1 {
+						break
+					}
+
+					callerOnWait := rl.callersOnWaitForRequests[index]
+					numOfRequestsToMakeAvailable -= callerOnWait.requests
+					rl.callersOnWaitForRequests = append(rl.callersOnWaitForRequests[:index], rl.callersOnWaitForRequests[index+1:]...)
+
+					callerOnWait.ch <- true
+				}
+				rl.callersOnWaitForRequestsMutex.Unlock()
+
+			case <-rl.quit:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (rl *RPCLimiter) Stop() {
+	rl.quit <- true
+	close(rl.quit)
+	for _, callerOnWait := range rl.callersOnWaitForRequests {
+		close(callerOnWait.ch)
+	}
+	rl.callersOnWaitForRequests = nil
+}
+
+func (rl *RPCLimiter) WaitForRequestsAvailability(requests int) error {
+	if requests > rl.maxRequestsPerSecond {
+		return ErrRequestsOverLimit
+	}
+
+	{
+		rl.requestsMadeWithinSecondMutex.Lock()
+		if rl.requestsMadeWithinSecond+requests <= rl.maxRequestsPerSecond {
+			rl.requestsMadeWithinSecond += requests
+			rl.requestsMadeWithinSecondMutex.Unlock()
+			return nil
+		}
+		rl.requestsMadeWithinSecondMutex.Unlock()
+	}
+
+	callerOnWait := callerOnWait{
+		requests: requests,
+		ch:       make(chan bool),
+	}
+
+	{
+		rl.callersOnWaitForRequestsMutex.Lock()
+		rl.callersOnWaitForRequests = append(rl.callersOnWaitForRequests, callerOnWait)
+		rl.callersOnWaitForRequestsMutex.Unlock()
+	}
+
+	<-callerOnWait.ch
+
+	close(callerOnWait.ch)
+
+	rl.requestsMadeWithinSecondMutex.Lock()
+	rl.requestsMadeWithinSecond += requests
+	rl.requestsMadeWithinSecondMutex.Unlock()
+
+	return nil
+}

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -288,7 +288,7 @@ func (tc *TestClient) CallBlockHashByTransaction(ctx context.Context, blockNumbe
 	return common.BigToHash(blockNumber), nil
 }
 
-func (tc *TestClient) GetBaseFeeFromBlock(blockNumber *big.Int) (string, error) {
+func (tc *TestClient) GetBaseFeeFromBlock(ctx context.Context, blockNumber *big.Int) (string, error) {
 	tc.incCounter("GetBaseFeeFromBlock")
 	if tc.traceAPICalls {
 		tc.t.Log("GetBaseFeeFromBlock")

--- a/services/wallet/transfer/downloader.go
+++ b/services/wallet/transfer/downloader.go
@@ -109,7 +109,7 @@ func getTransferByHash(ctx context.Context, client chain.ClientInterface, signer
 		return nil, err
 	}
 
-	baseGasFee, err := client.GetBaseFeeFromBlock(big.NewInt(int64(transactionLog.BlockNumber)))
+	baseGasFee, err := client.GetBaseFeeFromBlock(ctx, big.NewInt(int64(transactionLog.BlockNumber)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This limiter limits the number of requests that can be done within a single second to the `maxRequestPerSecond` value.

`WaitForRequestsAvailability` checks if there is room for making a request immediately and if not it waits till the moment when placing a request won't exceed the limit.

In a single go we cannot do more requests than it's set by `maxRequestPerSecond`.

`RPCLimiter`s are maintained per providers, not per chain.

In case an error like this one is got, then we reduce the RPS limit by `requestsPerSecondStep` (at this moment 10):
```
"\nstatus-go error [methodName:ens_publicKeyOf, code:-32000, message:fallback failed with '429 Too Many Requests: {\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32005,\"message\":\"exceeded project rate limit\",\"data\":{\"rate\":{\"allowed_rps\":5,\"backoff_seconds\":30,\"current_rps\":5.2},\"see\":\"https://infura.io/dashboard\"}}}'. run error was '429 Too Many Requests: {\"jsonrpc\":\"2.0\",\"id\":84,\"error\":{\"code\":-32005,\"message\":\"exceeded project rate limit\",\"data\":{\"rate\":{\"allowed_rps\":5,\"backoff_seconds\":30,\"current_rps\":5.233333333333333},\"see\":\"https://infura.io/dashboard\"}}}' ]\n"
```

RPS are maintained per limiter, that further means by the provider.


Issue https://github.com/status-im/status-go/issues/4096