### PR TITLE
fix: Wallet -> Cant delete generated account

### DIFF
--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -3219,7 +3219,7 @@ func (m *Messenger) resolveAccountOperability(syncAcc *protobuf.SyncAccount, syn
 		return accounts.AccountOperable(syncAcc.Operable), nil
 	}
 
-	if syncKpMigratedToKeycard || m.account.KeyUID == syncAcc.KeyUid {
+	if syncKpMigratedToKeycard {
 		return accounts.AccountFullyOperable, nil
 	}
 


### PR DESCRIPTION
fixes #13628

A short summary which serves as a squashed-commit message.

The issue was that a synced generated account for the profile key[air was being marked as fully operable by the check I have removed in the code.

Now it fulfils condition for partially operable which is what it should be, since we do not have the passphrase at that moment in order to create the  missing keystore in order to make fully operable. 

was introduced under https://github.com/status-im/status-go/pull/3841/files#diff-59d196f7f72de56c64ba2c559fcbb51762c418a22d2b83c59662b772a09b3c0a


A description to understand introduced changes without reading the code.

Important changes:
- [x] Something worth noting for reviewers.

Closes #
