### PR TITLE
[CHERRY-PICK] fix: lost wakuv2 nameserver with CreateAccountAndLogin

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -823,6 +823,7 @@ func TestLoginAccount(t *testing.T) {
 	utils.Init()
 	password := "some-password"
 	tmpdir := t.TempDir()
+	nameserver := "8.8.8.8"
 
 	b := NewGethStatusBackend()
 	createAccountRequest := &requests.CreateAccount{
@@ -833,15 +834,28 @@ func TestLoginAccount(t *testing.T) {
 		BackupDisabledDataDir: tmpdir,
 		NetworkID:             1,
 		LogFilePath:           tmpdir + "/log",
+		WakuV2Nameserver:      &nameserver,
 	}
 	c := make(chan interface{}, 10)
 	signal.SetMobileSignalHandler(func(data []byte) {
-		if strings.Contains(string(data), "node.login") {
+		if strings.Contains(string(data), signal.EventLoggedIn) {
 			c <- struct{}{}
 		}
 	})
+	waitForLogin := func(chan interface{}) {
+		select {
+		case <-c:
+			break
+		case <-time.After(5 * time.Second):
+			t.FailNow()
+		}
+	}
+
 	_, err := b.CreateAccountAndLogin(createAccountRequest)
 	require.NoError(t, err)
+	require.Equal(t, nameserver, b.config.WakuV2Config.Nameserver)
+
+	waitForLogin(c)
 	require.NoError(t, b.Logout())
 	require.NoError(t, b.StopNode())
 
@@ -850,16 +864,15 @@ func TestLoginAccount(t *testing.T) {
 	require.Len(t, accounts, 1)
 
 	loginAccountRequest := &requests.Login{
-		KeyUID:   accounts[0].KeyUID,
-		Password: password,
+		KeyUID:           accounts[0].KeyUID,
+		Password:         password,
+		WakuV2Nameserver: nameserver,
 	}
-	require.NoError(t, b.LoginAccount(loginAccountRequest))
-	select {
-	case <-c:
-		break
-	case <-time.After(5 * time.Second):
-		t.FailNow()
-	}
+	err = b.LoginAccount(loginAccountRequest)
+	require.NoError(t, err)
+	waitForLogin(c)
+
+	require.Equal(t, nameserver, b.config.WakuV2Config.Nameserver)
 }
 
 func TestVerifyDatabasePassword(t *testing.T) {

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -624,7 +624,7 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 
 	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig)
 
-	err = b.UpdateNodeConfigFleet(defaultCfg)
+	err = b.UpdateNodeConfigFleet(acc, password, defaultCfg)
 	if err != nil {
 		return err
 	}
@@ -697,9 +697,14 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 // UpdateNodeConfigFleet loads the fleet from the settings and updates the node configuration
 // If the fleet in settings is empty, or not supported anymore, it will be overridden with the default fleet.
 // In that case settings fleet value remain the same, only runtime node configuration is updated.
-func (b *GethStatusBackend) UpdateNodeConfigFleet(config *params.NodeConfig) error {
+func (b *GethStatusBackend) UpdateNodeConfigFleet(acc multiaccounts.Account, password string, config *params.NodeConfig) error {
 	if config == nil {
 		return nil
+	}
+
+	err := b.ensureDBsOpened(acc, password)
+	if err != nil {
+		return err
 	}
 
 	accountSettings, err := b.GetSettings()

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -624,7 +624,7 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 
 	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig)
 
-	err = b.updateNodeConfigFleet(defaultCfg)
+	err = b.UpdateNodeConfigFleet(defaultCfg)
 	if err != nil {
 		return err
 	}
@@ -694,10 +694,14 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 	return nil
 }
 
-// updateNodeConfigFleet loads the fleet from the settings and updates the node configuration
+// UpdateNodeConfigFleet loads the fleet from the settings and updates the node configuration
 // If the fleet in settings is empty, or not supported anymore, it will be overridden with the default fleet.
 // In that case settings fleet value remain the same, only runtime node configuration is updated.
-func (b *GethStatusBackend) updateNodeConfigFleet(config *params.NodeConfig) error {
+func (b *GethStatusBackend) UpdateNodeConfigFleet(config *params.NodeConfig) error {
+	if config == nil {
+		return nil
+	}
+
 	accountSettings, err := b.GetSettings()
 	if err != nil {
 		return err
@@ -722,13 +726,6 @@ func (b *GethStatusBackend) updateNodeConfigFleet(config *params.NodeConfig) err
 
 func (b *GethStatusBackend) startNodeWithAccount(acc multiaccounts.Account, password string, inputNodeCfg *params.NodeConfig) error {
 	err := b.ensureDBsOpened(acc, password)
-	if err != nil {
-		return err
-	}
-
-	// NOTE: This is code duplication from `loginAccount` method
-	//		 We should stop using this endpoint in desktop: https://github.com/status-im/status-desktop/issues/12977
-	err = b.updateNodeConfigFleet(inputNodeCfg)
 	if err != nil {
 		return err
 	}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -231,7 +231,7 @@ func login(accountData, password, configJSON string) error {
 
 	api.RunAsync(func() error {
 		log.Debug("start a node with account", "key-uid", account.KeyUID)
-		err := statusBackend.UpdateNodeConfigFleet(&conf)
+		err := statusBackend.UpdateNodeConfigFleet(account, password, &conf)
 		if err != nil {
 			return err
 		}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -231,7 +231,12 @@ func login(accountData, password, configJSON string) error {
 
 	api.RunAsync(func() error {
 		log.Debug("start a node with account", "key-uid", account.KeyUID)
-		err := statusBackend.StartNodeWithAccount(account, password, &conf)
+		err := statusBackend.UpdateNodeConfigFleet(&conf)
+		if err != nil {
+			return err
+		}
+
+		err = statusBackend.StartNodeWithAccount(account, password, &conf)
 		if err != nil {
 			log.Error("failed to start a node", "key-uid", account.KeyUID, "error", err)
 			return err


### PR DESCRIPTION
cherry-pick https://github.com/status-im/status-go/pull/4813 and https://github.com/status-im/status-go/pull/4822

This is important to cherry-pick. Seems that I also broke the change password flow, because didn't check nodeConfig for `nil`. It's fixed here.