### PR TITLE
feat: handling replies for bridged messages

### DIFF
--- a/protocol/common/message.go
+++ b/protocol/common/message.go
@@ -49,6 +49,7 @@ type QuotedMessage struct {
 	DeletedForMe bool `json:"deletedForMe,omitempty"`
 
 	DiscordMessage *protobuf.DiscordMessage `json:"discordMessage,omitempty"`
+	BridgeMessage  *protobuf.BridgeMessage  `json:"bridgeMessage,omitempty"`
 }
 
 type CommandState int


### PR DESCRIPTION
BridgeMessage struct has MessageID and ParentMessageID. 
MessageID keeps the original Discord message ID.
ParentMessageID keeps the original Discord parent message ID (response_to). 
When the new bridge message is received, corresponding status message response_to field is updated.

Issue [#13258](https://github.com/status-im/status-desktop/issues/13258)