### PR TITLE
fix: ensure db opened in UpdateNodeConfigFleet

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -624,7 +624,7 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 
 	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig)
 
-	err = b.UpdateNodeConfigFleet(defaultCfg)
+	err = b.UpdateNodeConfigFleet(acc, password, defaultCfg)
 	if err != nil {
 		return err
 	}
@@ -697,9 +697,14 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 // UpdateNodeConfigFleet loads the fleet from the settings and updates the node configuration
 // If the fleet in settings is empty, or not supported anymore, it will be overridden with the default fleet.
 // In that case settings fleet value remain the same, only runtime node configuration is updated.
-func (b *GethStatusBackend) UpdateNodeConfigFleet(config *params.NodeConfig) error {
+func (b *GethStatusBackend) UpdateNodeConfigFleet(acc multiaccounts.Account, password string, config *params.NodeConfig) error {
 	if config == nil {
 		return nil
+	}
+
+	err := b.ensureDBsOpened(acc, password)
+	if err != nil {
+		return err
 	}
 
 	accountSettings, err := b.GetSettings()

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -231,7 +231,7 @@ func login(accountData, password, configJSON string) error {
 
 	api.RunAsync(func() error {
 		log.Debug("start a node with account", "key-uid", account.KeyUID)
-		err := statusBackend.UpdateNodeConfigFleet(&conf)
+		err := statusBackend.UpdateNodeConfigFleet(account, password, &conf)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
No idea how this wasn't included in https://github.com/status-im/status-go/pull/4813. 
I'm pretty confident of implementing this yesterday 🤦 

Required for https://github.com/status-im/status-desktop/pull/13753
Fixes this crash: https://github.com/status-im/status-desktop/pull/13753#issuecomment-1967159299