### PR TITLE
fix: properly setup collectible providers exponential backoff

### DIFF
--- a/services/wallet/thirdparty/alchemy/client.go
+++ b/services/wallet/thirdparty/alchemy/client.go
@@ -129,14 +129,13 @@ func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any) (*
 }
 
 func (o *Client) doWithRetries(req *http.Request) (*http.Response, error) {
-	b := backoff.ExponentialBackOff{
-		InitialInterval:     time.Millisecond * 1000,
-		RandomizationFactor: 0.1,
-		Multiplier:          1.5,
-		MaxInterval:         time.Second * 32,
-		MaxElapsedTime:      time.Second * 128,
-		Clock:               backoff.SystemClock,
-	}
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = time.Millisecond * 1000
+	b.RandomizationFactor = 0.1
+	b.Multiplier = 1.5
+	b.MaxInterval = time.Second * 32
+	b.MaxElapsedTime = time.Second * 70
+
 	b.Reset()
 
 	op := func() (*http.Response, error) {
@@ -151,12 +150,13 @@ func (o *Client) doWithRetries(req *http.Request) (*http.Response, error) {
 
 		err = fmt.Errorf("unsuccessful request: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 		if resp.StatusCode == http.StatusTooManyRequests {
+			log.Error("doWithRetries failed with http.StatusTooManyRequests", "provider", o.ID(), "elapsed time", b.GetElapsedTime(), "next backoff", b.NextBackOff())
 			return nil, err
 		}
 		return nil, backoff.Permanent(err)
 	}
 
-	return backoff.RetryWithData(op, &b)
+	return backoff.RetryWithData(op, b)
 }
 
 func (o *Client) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletCommon.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error) {

--- a/services/wallet/thirdparty/opensea/client_v2.go
+++ b/services/wallet/thirdparty/opensea/client_v2.go
@@ -157,7 +157,9 @@ func (o *ClientV2) fetchAssets(ctx context.Context, chainID walletCommon.ChainID
 
 		body, err := o.client.doGetRequest(ctx, url, o.apiKey)
 		if err != nil {
-			o.connectionStatus.SetIsConnected(false)
+			if ctx.Err() == nil {
+				o.connectionStatus.SetIsConnected(false)
+			}
 			return nil, err
 		}
 		o.connectionStatus.SetIsConnected(true)
@@ -274,7 +276,9 @@ func (o *ClientV2) fetchCollectionDataBySlug(ctx context.Context, chainID wallet
 
 	body, err := o.client.doGetRequest(ctx, url, o.apiKey)
 	if err != nil {
-		o.connectionStatus.SetIsConnected(false)
+		if ctx.Err() == nil {
+			o.connectionStatus.SetIsConnected(false)
+		}
 		return nil, err
 	}
 	o.connectionStatus.SetIsConnected(true)


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/13725

Rarible has paid plans now (https://rarible.org/pricing) and we're most likely on the Free tier, which is insufficient for our needs (the requests/sec limit is shared by everyone using the same API keys set in CI), so we're getting a lot of `http.StatusTooManyRequests`. We do have a retry mechanism in place, but due to a bug (bad initialization), instead of stopping retrying after some time it would enter a infinite loop of retries with 0 delay 🤡 

![image](https://github.com/status-im/status-desktop/assets/11161531/2cf870aa-0b4d-4a41-898f-fc7ef3878c1c)

This PR fixes that.
