### PR TITLE
[CHERRY-PICK] fix: send LoggedIn signal when UpdateNodeConfigFleet failed on login

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -233,7 +233,8 @@ func login(accountData, password, configJSON string) error {
 		log.Debug("start a node with account", "key-uid", account.KeyUID)
 		err := statusBackend.UpdateNodeConfigFleet(account, password, &conf)
 		if err != nil {
-			return err
+			log.Error("failed to update node config fleet", "key-uid", account.KeyUID, "error", err)
+			return statusBackend.LoggedIn(account.KeyUID, err)
 		}
 
 		err = statusBackend.StartNodeWithAccount(account, password, &conf)


### PR DESCRIPTION
cherry-pick https://github.com/status-im/status-go/pull/4829