### PR TITLE
Feat: Add 'IsDisplayNameDupeOfCommunityMember' endpoint

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -597,6 +598,28 @@ func (m *Messenger) ControlledCommunities() ([]*communities.Community, error) {
 
 func (m *Messenger) JoinedCommunities() ([]*communities.Community, error) {
 	return m.communitiesManager.Joined()
+}
+
+func (m *Messenger) IsDisplayNameDupeOfCommunityMember(name string) (bool, error) {
+	controlled, err := m.communitiesManager.Controlled()
+	if err != nil {
+		return false, err
+	}
+
+	joined, err := m.communitiesManager.Joined()
+	if err != nil {
+		return false, err
+	}
+
+	for _, community := range append(controlled, joined...) {
+		for memberKey := range community.Members() {
+			contact := m.GetContactByID(memberKey)
+			if strings.Compare(contact.DisplayName, name) == 0 {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func (m *Messenger) CommunityUpdateLastOpenedAt(communityID string) (int64, error) {

--- a/protocol/messenger_identity.go
+++ b/protocol/messenger_identity.go
@@ -26,6 +26,7 @@ var ErrInvalidDisplayNameEthSuffix = errors.New(`usernames ending with "eth" are
 var ErrInvalidDisplayNameNotAllowed = errors.New("name is not allowed")
 var ErrInvalidBioLength = errors.New("invalid bio length")
 var ErrInvalidSocialLinkTextLength = errors.New("invalid social link text length")
+var ErrDisplayNameDupeOfCommunityMember = errors.New("display name duplicates on of community members")
 
 func ValidateDisplayName(displayName *string) error {
 	name := strings.TrimSpace(*displayName)
@@ -64,6 +65,15 @@ func (m *Messenger) SetDisplayName(displayName string) error {
 
 	if err = ValidateDisplayName(&displayName); err != nil {
 		return err
+	}
+
+	isDupe, err := m.IsDisplayNameDupeOfCommunityMember(displayName)
+	if err != nil {
+		return err
+	}
+
+	if isDupe {
+		return ErrDisplayNameDupeOfCommunityMember
 	}
 
 	m.account.Name = displayName

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -401,6 +401,11 @@ func (api *PublicAPI) JoinedCommunities(parent context.Context) ([]*communities.
 	return api.service.messenger.JoinedCommunities()
 }
 
+// IsDisplayNameDupeOfCommunityMember returns if any controlled or joined community has a member with provided display name
+func (api *PublicAPI) IsDisplayNameDupeOfCommunityMember(name string) (bool, error) {
+	return api.service.messenger.IsDisplayNameDupeOfCommunityMember(name)
+}
+
 // CommunityTags return the list of possible community tags
 func (api *PublicAPI) CommunityTags(parent context.Context) map[string]string {
 	return requests.TagsEmojies


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/13434

Important changes:
- [x] Add 'IsDisplayNameDupeOfCommunityMember' endpoint to validate the display name against all members of joined communities

