### PR TITLE
fix: recovering/migrating keypairs fixes

### DIFF
--- a/multiaccounts/database.go
+++ b/multiaccounts/database.go
@@ -31,6 +31,10 @@ type Account struct {
 	CustomizationColorClock uint64                    `json:"-"`
 }
 
+func (a *Account) RefersToKeycard() bool {
+	return a.KeycardPairing != ""
+}
+
 func (a *Account) ToProtobuf() *protobuf.MultiAccount {
 	var colorHashes []*protobuf.MultiAccount_ColorHash
 	for _, index := range a.ColorHash {

--- a/protocol/messenger_backup.go
+++ b/protocol/messenger_backup.go
@@ -497,7 +497,7 @@ func (m *Messenger) backupProfile(ctx context.Context, clock uint64) ([]*protobu
 }
 
 func (m *Messenger) backupKeypairs() ([]*protobuf.Backup, error) {
-	keypairs, err := m.settings.GetActiveKeypairs()
+	keypairs, err := m.settings.GetAllKeypairs()
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_backup_handler.go
+++ b/protocol/messenger_backup_handler.go
@@ -250,7 +250,7 @@ func (m *Messenger) handleKeypair(message *protobuf.SyncKeypair) error {
 	}
 	// If user is recovering his account via seed phrase, but the backed up messages indicate that the profile keypair
 	// is a keycard related profile, then we need to remove related profile keycards (only profile, other keycards should remain).
-	if multiAcc != nil && multiAcc.KeyUID == message.KeyUid && multiAcc.KeycardPairing == "" && len(message.Keycards) > 0 {
+	if multiAcc != nil && multiAcc.KeyUID == message.KeyUid && !multiAcc.RefersToKeycard() && len(message.Keycards) > 0 {
 		message.Keycards = []*protobuf.SyncKeycard{}
 	}
 

--- a/protocol/messenger_identity.go
+++ b/protocol/messenger_identity.go
@@ -95,16 +95,9 @@ func (m *Messenger) SaveSyncDisplayName(displayName string, clock uint64) error 
 	if err != nil {
 		return err
 	}
-	preferredNameClock, err := m.settings.GetSettingLastSynced(settings.PreferredName)
-	if err != nil {
-		return err
-	}
-	// check clock of preferred name to avoid override account name
-	if preferredNameClock < clock {
-		m.account.Name = displayName
-		return m.multiAccounts.SaveAccount(*m.account)
-	}
-	return nil
+
+	m.account.Name = displayName
+	return m.multiAccounts.SaveAccount(*m.account)
 }
 
 func ValidateBio(bio *string) error {


### PR DESCRIPTION
- fixed issue with displaying 3-words name on the login screen after recovering from waku
- fixed inability to delete account after recovering from waku

All recovering and syncing flows are tested in the desktop app.
Detailed behavior and results are placed here https://github.com/status-im/status-desktop/issues/10772#issuecomment-1972728450 just to keep the related info in a single place.