### PR TITLE
chore: remove misleading comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,8 +318,6 @@ test-unit: export UNIT_TEST_COUNT ?= 1
 test-unit: export UNIT_TEST_FAILFAST ?= true
 test-unit: export UNIT_TEST_RERUN_FAILS ?= true
 test-unit: export UNIT_TEST_USE_DEVELOPMENT_LOGGER ?= true
-# Ensure 'waku' and 'wakuv2' tests are executed first to reduce the impact of flaky tests.
-# Otherwise, the entire target might fail at the end, making re-runs time-consuming.
 test-unit: export UNIT_TEST_PACKAGES ?= $(shell go list ./... | \
 	grep -v /vendor | \
 	grep -v /t/e2e | \


### PR DESCRIPTION
The comment is no longer relevant after:
d3558d8e09e16199e5dc7758819298da36b7009e
