### PR TITLE
fix: flaky test TestController_watchAccountChanges by changing the order

### DIFF
--- a/services/wallet/transfer/controller.go
+++ b/services/wallet/transfer/controller.go
@@ -150,8 +150,8 @@ func (c *Controller) startAccountWatcher(chainIDs []uint64) {
 		c.accWatcher = accountsevent.NewWatcher(c.accountsDB, c.accountFeed, func(changedAddresses []common.Address, eventType accountsevent.EventType, currentAddresses []common.Address) {
 			c.onAccountsChanged(changedAddresses, eventType, currentAddresses, chainIDs)
 		})
-		c.accWatcher.Start()
 	}
+	c.accWatcher.Start()
 }
 
 func (c *Controller) onAccountsChanged(changedAddresses []common.Address, eventType accountsevent.EventType, currentAddresses []common.Address, chainIDs []uint64) {


### PR DESCRIPTION
Checking transfers now in account's remove event handler.
`watcher.Start` has its own protection against starting an already started watcher, so moved it to be able to override the watcher in tests.

NOTE: I was not able to reproduce the failure even with option `-count=1000`

Closes #4847
