### PR TITLE
chore: improve StoreNodeRequestManager for community custom storenodes

### DIFF
--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -583,6 +583,7 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestProfileInfo() {
 	s.Require().NoError(err)
 
 	s.createBob()
+	s.waitForAvailableStoreNode(s.bob)
 	s.fetchProfile(s.bob, s.owner.selfContact.ID, s.owner.selfContact)
 }
 


### PR DESCRIPTION
Might fix: https://github.com/status-im/status-go/issues/4845

Improved the logic for selecting a storenode in `StoreNodeRequestManager`.

There was a problem of trimming `CommunityShardInfoTopicPrefix` suffix in all cases, but it's only needed to be done when requesting the shard. And it's not needed when requesting the community info.