### PR TITLE
Fix contact details large image is always empty

### DIFF
--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -31,6 +31,8 @@ var chatColors = []string{
 
 type ChatType int
 
+type ChatContext string
+
 const (
 	ChatTypeOneToOne ChatType = iota + 1
 	ChatTypePublic
@@ -635,4 +637,13 @@ func stringSliceContains(slice []string, item string) bool {
 		}
 	}
 	return false
+}
+
+func GetChatContextFromChatType(chatType ChatType) ChatContext {
+	switch chatType {
+	case ChatTypeOneToOne, ChatTypePrivateGroupChat:
+		return privateChat
+	default:
+		return publicChat
+	}
 }

--- a/protocol/chat_test.go
+++ b/protocol/chat_test.go
@@ -172,3 +172,29 @@ func (s *ChatTestSuite) TestDeepLink() {
 
 	s.Require().Equal(chat.DeepLink(), "status-app://cc/c432709e-fc73-440d-bb67-cb3a0929dfda#zQ3shZL6dXiFCbDyxnXxwQa9v8QFC2q19subFtyxd7kVszMVo")
 }
+
+func (s *ChatTestSuite) TestGetChatContextFromChatType() {
+	chat := &Chat{
+		CommunityID: "0x02b1",
+		ID:          "0x02b1",
+		ChatType:    ChatTypeCommunityChat,
+	}
+
+	s.Require().Equal(GetChatContextFromChatType(chat.ChatType), publicChat)
+
+	chat = &Chat{
+		CommunityID: "0x02b1",
+		ID:          "0x02b1",
+		ChatType:    ChatTypeOneToOne,
+	}
+
+	s.Require().Equal(GetChatContextFromChatType(chat.ChatType), privateChat)
+
+	chat = &Chat{
+		CommunityID: "0x02b1",
+		ID:          "0x02b1",
+		ChatType:    ChatTypePrivateGroupChat,
+	}
+
+	s.Require().Equal(GetChatContextFromChatType(chat.ChatType), privateChat)
+}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -73,16 +73,13 @@ import (
 	"github.com/status-im/status-go/telemetry"
 )
 
-// todo: kozieiev: get rid of wakutransp word
-type chatContext string
-
 const (
 	PubKeyStringLength = 132
 
 	transactionSentTxt = "Transaction sent"
 
-	publicChat  chatContext = "public-chat"
-	privateChat chatContext = "private-chat"
+	publicChat  ChatContext = "public-chat"
+	privateChat ChatContext = "private-chat"
 )
 
 var communityAdvertiseIntervalSecond int64 = 60 * 60
@@ -1127,7 +1124,9 @@ func (m *Messenger) handleStandaloneChatIdentity(chat *Chat) error {
 		return nil
 	}
 
-	ci, err := m.createChatIdentity(publicChat)
+	chatContext := GetChatContextFromChatType(chat.ChatType)
+
+	ci, err := m.createChatIdentity(chatContext)
 	if err != nil {
 		return err
 	}
@@ -1274,7 +1273,7 @@ func (m *Messenger) shouldPublishChatIdentity(chatID string) (bool, error) {
 // createChatIdentity creates a context based protobuf.ChatIdentity.
 // context 'public-chat' will attach only the 'thumbnail' IdentityImage
 // context 'private-chat' will attach all IdentityImage
-func (m *Messenger) createChatIdentity(context chatContext) (*protobuf.ChatIdentity, error) {
+func (m *Messenger) createChatIdentity(context ChatContext) (*protobuf.ChatIdentity, error) {
 	m.logger.Info(fmt.Sprintf("account keyUID '%s'", m.account.KeyUID))
 	m.logger.Info(fmt.Sprintf("context '%s'", context))
 
@@ -1324,7 +1323,7 @@ func (m *Messenger) adaptIdentityImageToProtobuf(img *images.IdentityImage) *pro
 	}
 }
 
-func (m *Messenger) attachIdentityImagesToChatIdentity(context chatContext, ci *protobuf.ChatIdentity) error {
+func (m *Messenger) attachIdentityImagesToChatIdentity(context ChatContext, ci *protobuf.ChatIdentity) error {
 	s, err := m.getSettings()
 	if err != nil {
 		return err

--- a/protocol/messenger_chat_context_test.go
+++ b/protocol/messenger_chat_context_test.go
@@ -1,0 +1,78 @@
+package protocol
+
+import (
+	_ "github.com/mutecomm/go-sqlcipher/v4" // require go-sqlcipher that overrides default implementation
+
+	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/images"
+	"github.com/status-im/status-go/multiaccounts/settings"
+	"github.com/status-im/status-go/protocol/protobuf"
+)
+
+func isImageWithNamePresent(imgs map[string]*protobuf.IdentityImage, name string) bool {
+	for k, v := range imgs {
+		if k == name && len(v.Payload) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *MessengerSuite) retrieveIdentityImages(alice, bob *Messenger, chat *Chat) map[string]*protobuf.IdentityImage {
+	s.Require().NoError(alice.settings.SaveSettingField(settings.DisplayName, "alice"))
+
+	identityImages := images.SampleIdentityImages()
+	identityImagesMap := make(map[string]images.IdentityImage)
+	for _, img := range identityImages {
+		img.KeyUID = s.m.account.KeyUID
+		identityImagesMap[img.Name] = img
+	}
+
+	err := s.m.multiAccounts.StoreIdentityImages(s.m.account.KeyUID, identityImages, true)
+	s.Require().NoError(err)
+	s.Require().NoError(alice.SaveChat(chat))
+	s.Require().NoError(bob.settings.SaveSettingField(settings.DisplayName, "bob"))
+	s.Require().NoError(bob.SaveChat(chat))
+
+	chatContext := GetChatContextFromChatType(chat.ChatType)
+
+	chatIdentity, err := alice.createChatIdentity(chatContext)
+	s.Require().NoError(err)
+
+	imgs := chatIdentity.Images
+	s.Require().NoError(err)
+
+	return imgs
+}
+
+func (s *MessengerSuite) TestTwoImagesAreAddedToChatIdentityForPrivateChat() {
+	alice := s.m
+	bob := s.newMessenger()
+	defer TearDownMessenger(&s.Suite, bob)
+
+	bobPkString := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
+
+	chat := CreateOneToOneChat(bobPkString, &bob.identity.PublicKey, alice.transport)
+	s.Require().Equal(privateChat, GetChatContextFromChatType(chat.ChatType))
+
+	imgs := s.retrieveIdentityImages(alice, bob, chat)
+	s.Require().Len(imgs, 2)
+	s.Require().Equal(true, isImageWithNamePresent(imgs, "thumbnail"))
+	s.Require().Equal(true, isImageWithNamePresent(imgs, "large"))
+}
+
+func (s *MessengerSuite) TestOneImageIsAddedToChatIdentityForPublicChat() {
+	alice := s.m
+	bob := s.newMessenger()
+	defer TearDownMessenger(&s.Suite, bob)
+
+	chat := CreatePublicChat("alic-and-bob-chat", &testTimeSource{})
+	s.Require().Equal(publicChat, GetChatContextFromChatType(chat.ChatType))
+
+	imgs := s.retrieveIdentityImages(alice, bob, chat)
+	s.Require().Len(imgs, 1)
+	s.Require().Equal(true, isImageWithNamePresent(imgs, "thumbnail"))
+	s.Require().Equal(false, isImageWithNamePresent(imgs, "large"))
+}

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -257,7 +257,7 @@ func (s *MessengerProfilePictureHandlerSuite) TestE2eSendingReceivingProfilePict
 		"bob":   {true, false},
 	}
 
-	chatContexts := []chatContext{
+	chatContexts := []ChatContext{
 		publicChat,
 		privateChat,
 	}


### PR DESCRIPTION
### Description

fixes https://github.com/status-im/status-desktop/issues/13563

The current code contains a bug where a 1:1 chat is incorrectly assigned a context of "Public chat." According to the existing logic:

> When the context is 'public-chat', only the 'thumbnail' IdentityImage is attached.
When the context is 'private-chat', all IdentityImages are attached.

As a consequence, messages with the ChatIdentity have only one image (thumbnail), leading to the large image being consistently empty on the client receiver side.

This PR corrects this behavior by ensuring that 1:1 chats are correctly assigned the 'private-chat' context, allowing all IdentityImages to be attached to messages, thus resolving the issue of the large image being empty.

### What does the PR do

The PR uses the ChatType store inside the chat passed in parameter, and uses the correct ChatType before adding the chatIdentity.

### Screenshot of functionality (including design for comparison)

[testing.webm](https://github.com/status-im/status-go/assets/2589171/0e1be89c-c144-4901-982d-cfe1c6d5eb21)
