### PR TITLE
feat: fetch collectibles balances

### DIFF
--- a/services/wallet/collectibles/filter.go
+++ b/services/wallet/collectibles/filter.go
@@ -60,7 +60,7 @@ func filterOwnedCollectibles(ctx context.Context, db *sql.DB, chainIDs []wcommon
 		return nil, errors.New("no chainIDs provided")
 	}
 
-	q := sq.Select("ownership.chain_id,ownership.contract_address,ownership.token_id")
+	q := sq.Select("ownership.chain_id,ownership.contract_address,ownership.token_id").Distinct()
 	q = q.From("collectibles_ownership_cache ownership").
 		LeftJoin(`collectible_data_cache data ON 
 		ownership.chain_id = data.chain_id AND 

--- a/services/wallet/collectibles/ownership_db.go
+++ b/services/wallet/collectibles/ownership_db.go
@@ -397,7 +397,7 @@ func (o *OwnershipDB) Update(chainID w_common.ChainID, ownerAddress common.Addre
 }
 
 func (o *OwnershipDB) GetOwnedCollectibles(chainIDs []w_common.ChainID, ownerAddresses []common.Address, offset int, limit int) ([]thirdparty.CollectibleUniqueID, error) {
-	query, args, err := sqlx.In(fmt.Sprintf(`SELECT %s
+	query, args, err := sqlx.In(fmt.Sprintf(`SELECT DISTINCT %s
 		FROM collectibles_ownership_cache
 		WHERE chain_id IN (?) AND owner_address IN (?)
 		LIMIT ? OFFSET ?`, selectOwnershipColumns), chainIDs, ownerAddresses, limit, offset)

--- a/services/wallet/collectibles/ownership_db_test.go
+++ b/services/wallet/collectibles/ownership_db_test.go
@@ -115,8 +115,8 @@ func TestUpdateOwnership(t *testing.T) {
 
 	allChains := []w_common.ChainID{chainID0, chainID1, chainID2}
 	allOwnerAddresses := []common.Address{ownerAddress1, ownerAddress2, ownerAddress3}
-	allCollectibles := append(ownedList1, ownedList2...)
-	allCollectibles = append(allCollectibles, ownedList3...)
+	allCollectibles := append(ownedList1[1:], ownedList2...)
+	allCollectibles = append(allCollectibles, ownedList3[:len(ownedList3)-1]...) // the last element of ownerdList3 is a duplicate of the first element of ownedList2
 
 	randomAddress := common.HexToAddress("0xFFFF")
 

--- a/services/wallet/thirdparty/alchemy/client_test.go
+++ b/services/wallet/thirdparty/alchemy/client_test.go
@@ -43,6 +43,9 @@ func TestUnmarshallOwnedCollectibles(t *testing.T) {
 	expectedTokenID0, _ := big.NewInt(0).SetString("50659039041325838222074459099120411190538227963344971355684955900852972814336", 10)
 	expectedTokenID1, _ := big.NewInt(0).SetString("900", 10)
 
+	expectedBalance0, _ := big.NewInt(0).SetString("15", 10)
+	expectedBalance1, _ := big.NewInt(0).SetString("1", 10)
+
 	expectedCollectiblesData := []thirdparty.FullCollectibleData{
 		{
 			CollectibleData: thirdparty.CollectibleData{
@@ -76,6 +79,9 @@ func TestUnmarshallOwnedCollectibles(t *testing.T) {
 				Slug:         "",
 				ImageURL:     "",
 				Traits:       make(map[string]thirdparty.CollectionTrait),
+			},
+			AccountBalance: &bigint.BigInt{
+				Int: expectedBalance0,
 			},
 		},
 		{
@@ -131,6 +137,9 @@ func TestUnmarshallOwnedCollectibles(t *testing.T) {
 				Slug:         "",
 				ImageURL:     "https://raw.seadn.io/files/e7765f13c4658f514d0efc008ae7f300.png",
 				Traits:       make(map[string]thirdparty.CollectionTrait),
+			},
+			AccountBalance: &bigint.BigInt{
+				Int: expectedBalance1,
 			},
 		},
 	}

--- a/services/wallet/thirdparty/alchemy/client_test_data.go
+++ b/services/wallet/thirdparty/alchemy/client_test_data.go
@@ -87,7 +87,7 @@ const ownedCollectiblesJSON = `{
 		},
 		"owners": null,
 		"timeLastUpdated": "2024-01-03T19:11:04.681Z",
-		"balance": "1",
+		"balance": "15",
 		"acquiredAt": {
 		  "blockTimestamp": null,
 		  "blockNumber": null

--- a/services/wallet/thirdparty/alchemy/types.go
+++ b/services/wallet/thirdparty/alchemy/types.go
@@ -133,6 +133,7 @@ type Asset struct {
 	Image       Image          `json:"image"`
 	Raw         Raw            `json:"raw"`
 	TokenURI    string         `json:"tokenUri"`
+	Balance     *bigint.BigInt `json:"balance,omitempty"`
 }
 
 type OwnedNFTList struct {
@@ -216,6 +217,7 @@ func (c *Asset) toCommon(id thirdparty.CollectibleUniqueID) thirdparty.FullColle
 	return thirdparty.FullCollectibleData{
 		CollectibleData: c.toCollectiblesData(id),
 		CollectionData:  &contractData,
+		AccountBalance:  c.Balance,
 	}
 }
 

--- a/services/wallet/thirdparty/collectible_types.go
+++ b/services/wallet/thirdparty/collectible_types.go
@@ -97,6 +97,45 @@ func GroupContractIDsByChainID(ids []ContractID) map[w_common.ChainID][]Contract
 	return ret
 }
 
+func GroupCollectiblesByChainID(collectibles []*FullCollectibleData) map[w_common.ChainID][]*FullCollectibleData {
+	ret := make(map[w_common.ChainID][]*FullCollectibleData)
+
+	for i, collectible := range collectibles {
+		chainID := collectible.CollectibleData.ID.ContractID.ChainID
+		if _, ok := ret[chainID]; !ok {
+			ret[chainID] = make([]*FullCollectibleData, 0, len(collectibles))
+		}
+		ret[chainID] = append(ret[chainID], collectibles[i])
+	}
+
+	return ret
+}
+
+func GroupCollectiblesByContractAddress(collectibles []*FullCollectibleData) map[common.Address][]*FullCollectibleData {
+	ret := make(map[common.Address][]*FullCollectibleData)
+
+	for i, collectible := range collectibles {
+		contractAddress := collectible.CollectibleData.ID.ContractID.Address
+		if _, ok := ret[contractAddress]; !ok {
+			ret[contractAddress] = make([]*FullCollectibleData, 0, len(collectibles))
+		}
+		ret[contractAddress] = append(ret[contractAddress], collectibles[i])
+	}
+
+	return ret
+}
+
+func GroupCollectiblesByChainIDAndContractAddress(collectibles []*FullCollectibleData) map[w_common.ChainID]map[common.Address][]*FullCollectibleData {
+	ret := make(map[w_common.ChainID]map[common.Address][]*FullCollectibleData)
+
+	collectiblesByChainID := GroupCollectiblesByChainID(collectibles)
+	for chainID, chainCollectibles := range collectiblesByChainID {
+		ret[chainID] = GroupCollectiblesByContractAddress(chainCollectibles)
+	}
+
+	return ret
+}
+
 type CollectionTrait struct {
 	Min float64 `json:"min"`
 	Max float64 `json:"max"`
@@ -153,7 +192,8 @@ type FullCollectibleData struct {
 	CollectionData           *CollectionData
 	CommunityInfo            *CommunityInfo
 	CollectibleCommunityInfo *CollectibleCommunityInfo
-	Ownership                []AccountBalance
+	Ownership                []AccountBalance // This is a list of all the owners of the collectible
+	AccountBalance           *bigint.BigInt   // This is the balance of the collectible for the requested account
 }
 
 type CollectiblesContainer[T any] struct {
@@ -163,27 +203,36 @@ type CollectiblesContainer[T any] struct {
 	Provider       string
 }
 
-type CollectibleOwnershipContainer CollectiblesContainer[CollectibleUniqueID]
+type CollectibleOwnershipContainer CollectiblesContainer[CollectibleIDBalance]
 type CollectionDataContainer CollectiblesContainer[CollectionData]
 type CollectibleDataContainer CollectiblesContainer[CollectibleData]
 type FullCollectibleDataContainer CollectiblesContainer[FullCollectibleData]
 
 // Tried to find a way to make this generic, but couldn't, so the code below is duplicated somewhere else
-func collectibleItemsToIDs(items []FullCollectibleData) []CollectibleUniqueID {
-	ret := make([]CollectibleUniqueID, 0, len(items))
+func collectibleItemsToBalances(items []FullCollectibleData) []CollectibleIDBalance {
+	ret := make([]CollectibleIDBalance, 0, len(items))
 	for _, item := range items {
-		ret = append(ret, item.CollectibleData.ID)
+		balance := CollectibleIDBalance{
+			ID:      item.CollectibleData.ID,
+			Balance: item.AccountBalance,
+		}
+		ret = append(ret, balance)
 	}
 	return ret
 }
 
 func (c *FullCollectibleDataContainer) ToOwnershipContainer() CollectibleOwnershipContainer {
 	return CollectibleOwnershipContainer{
-		Items:          collectibleItemsToIDs(c.Items),
+		Items:          collectibleItemsToBalances(c.Items),
 		NextCursor:     c.NextCursor,
 		PreviousCursor: c.PreviousCursor,
 		Provider:       c.Provider,
 	}
+}
+
+type CollectibleIDBalance struct {
+	ID      CollectibleUniqueID `json:"id"`
+	Balance *bigint.BigInt      `json:"balance"`
 }
 
 type TokenBalance struct {


### PR DESCRIPTION
closes https://github.com/status-im/status-desktop/issues/13025

We were setting a value of 1 for the balance of every collectible. This is only true for ERC721 ones. We now properly fetch the balance for ERC1155 collectibles.

Alchemy provides this piece of information along with the collectibles list, so we use that. Other providers do not, so we just call the smart contract's `balanceOfBatch` method (https://docs.openzeppelin.com/contracts/3.x/api/token/erc1155#IERC1155-balanceOfBatch-address---uint256---)

2 small bugs were fixed as well:
- Avoid issues with possible concurrent ownership updates
- Return only 1 entry when the same collectible is owned by multiple acccounts

Ran some tests with both ways of getting the balance, works fine the first time and updates fine when a change occurs.