### PR TITLE
fix: process empty albumId in albumMessages

### DIFF
--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -648,6 +648,9 @@ func (db sqlitePersistence) messageByID(tx *sql.Tx, id string) (*common.Message,
 }
 
 func (db sqlitePersistence) albumMessages(chatID, albumID string) ([]*common.Message, error) {
+	if albumID == "" {
+		return nil, nil
+	}
 	query := db.buildMessagesQuery("WHERE m1.album_id = ? and m1.local_chat_id = ?")
 	rows, err := db.db.Query(query, albumID, chatID)
 	if err != nil {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4200,7 +4200,7 @@ func (m *Messenger) prepareMessage(msg *common.Message, s *server.MediaServer) e
 					return err
 				}
 
-				var quotedImages = extractQuotedImages(albumMessages, s)
+				quotedImages := extractQuotedImages(albumMessages, s)
 				quotedImagesJSON, err := json.Marshal(quotedImages)
 				if err != nil {
 					return err

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4143,9 +4143,8 @@ func (m *Messenger) MessageByChatID(chatID, cursor string, limit int) ([]*common
 	}
 
 	if m.httpServer != nil {
-		for idx := range msgs {
-			err = m.prepareMessage(msgs[idx], m.httpServer)
-
+		for _, msg := range msgs {
+			err = m.prepareMessage(msg, m.httpServer)
 			if err != nil {
 				return nil, "", err
 			}
@@ -4156,13 +4155,13 @@ func (m *Messenger) MessageByChatID(chatID, cursor string, limit int) ([]*common
 }
 
 func (m *Messenger) prepareMessages(messages map[string]*common.Message) error {
-	if m.httpServer != nil {
-		for idx := range messages {
-			err := m.prepareMessage(messages[idx], m.httpServer)
-
-			if err != nil {
-				return err
-			}
+	if m.httpServer == nil {
+		return nil
+	}
+	for idx := range messages {
+		err := m.prepareMessage(messages[idx], m.httpServer)
+		if err != nil {
+			return err
 		}
 	}
 	return nil
@@ -4192,18 +4191,22 @@ func (m *Messenger) prepareMessage(msg *common.Message, s *server.MediaServer) e
 		}
 
 		if quotedMessage.ChatMessage != nil {
+			image := quotedMessage.ChatMessage.GetImage()
 			albumID := quotedMessage.ChatMessage.GetImage().AlbumId
-			albumMessages, err := m.persistence.albumMessages(quotedMessage.LocalChatID, albumID)
-			if err != nil {
-				return err
-			}
 
-			var quotedImages = extractQuotedImages(albumMessages, s)
+			if image != nil && image.GetAlbumId() != "" {
+				albumMessages, err := m.persistence.albumMessages(quotedMessage.LocalChatID, albumID)
+				if err != nil {
+					return err
+				}
 
-			if quotedImagesJSON, err := json.Marshal(quotedImages); err == nil {
+				var quotedImages = extractQuotedImages(albumMessages, s)
+				quotedImagesJSON, err := json.Marshal(quotedImages)
+				if err != nil {
+					return err
+				}
+
 				msg.QuotedMessage.AlbumImages = quotedImagesJSON
-			} else {
-				return err
 			}
 		}
 	}

--- a/protocol/persistence_quoted_message_test.go
+++ b/protocol/persistence_quoted_message_test.go
@@ -3,11 +3,13 @@ package protocol
 import (
 	"encoding/json"
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/server"
-	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 func TestMessengerPrepareMessage(t *testing.T) {
@@ -50,7 +52,7 @@ func (s *TestMessengerPrepareMessageSuite) generateTextMessage(ID string, From s
 	}
 }
 
-func (s *TestMessengerPrepareMessageSuite) Test_WHEN_MessageContainsImage_Then_preparedMessageAddsAlbumImageWithImageGeneratedLink() {
+func (s *TestMessengerPrepareMessageSuite) testMessageContainsImage(testAlbum bool) {
 	message1 := s.generateTextMessage("id-1", "1", 1, "")
 	message1.ContentType = protobuf.ChatMessage_IMAGE
 	message1.Payload = &protobuf.ChatMessage_Image{
@@ -63,7 +65,26 @@ func (s *TestMessengerPrepareMessageSuite) Test_WHEN_MessageContainsImage_Then_p
 	message2 := s.generateTextMessage("id-2", "2", 2, message1.ID)
 	messages := []*common.Message{message1, message2}
 
-	err := s.m.SaveMessages([]*common.Message{message1, message2})
+	var message3 *common.Message
+
+	if testAlbum {
+		albumID := RandomLettersString(5)
+		message1.GetImage().AlbumId = albumID
+
+		message3 = s.generateTextMessage("id-3", "1", 0, "")
+		message3.ContentType = protobuf.ChatMessage_IMAGE
+		message3.Payload = &protobuf.ChatMessage_Image{
+			Image: &protobuf.ImageMessage{
+				Format:  1,
+				Payload: RandomBytes(10),
+				AlbumId: albumID,
+			},
+		}
+
+		messages = append(messages, message3)
+	}
+
+	err := s.m.SaveMessages(messages)
 	s.Require().NoError(err)
 
 	err = s.p.SaveMessages(messages)
@@ -75,15 +96,55 @@ func (s *TestMessengerPrepareMessageSuite) Test_WHEN_MessageContainsImage_Then_p
 
 	retrievedMessages, _, err := s.p.MessageByChatID(s.chatID, "", 10)
 	s.Require().NoError(err)
+	if testAlbum {
+		s.Require().Len(retrievedMessages, 3)
+	} else {
+		s.Require().Len(retrievedMessages, 2)
+	}
 	s.Require().Equal(message2.ID, retrievedMessages[0].ID)
 	s.Require().Equal(message1.ID, retrievedMessages[0].ResponseTo)
 
 	err = s.m.prepareMessage(retrievedMessages[0], mediaServer)
 	s.Require().NoError(err)
 
-	expectedURL := fmt.Sprintf(`["https://Localhost:%d/messages/images?messageId=id-1"]`, mediaServer.GetPort())
+	mediaServerImageLink := func(messageID string) string {
+		return fmt.Sprintf(`https://Localhost:%d/messages/images?messageId=%s`,
+			mediaServer.GetPort(),
+			messageID)
+	}
 
-	s.Require().Equal(json.RawMessage(expectedURL), retrievedMessages[0].QuotedMessage.AlbumImages)
+	if testAlbum {
+		expectedJSON := fmt.Sprintf(`["%s","%s"]`,
+			mediaServerImageLink(message1.ID),
+			mediaServerImageLink(message3.ID),
+		)
+		s.Require().Equal(json.RawMessage(expectedJSON), retrievedMessages[0].QuotedMessage.AlbumImages)
+	} else {
+		expectedURL := mediaServerImageLink(message1.ID)
+		s.Require().Equal(expectedURL, retrievedMessages[0].QuotedMessage.ImageLocalURL)
+	}
+}
+
+func (s *TestMessengerPrepareMessageSuite) Test_WHEN_MessageContainsImage_THEN_preparedMessageAddsAlbumImageWithImageGeneratedLink() {
+	testCases := []struct {
+		name  string
+		album bool
+	}{
+		{
+			name:  "single image",
+			album: false,
+		},
+		{
+			name:  "album",
+			album: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.testMessageContainsImage(tc.album)
+		})
+	}
 }
 
 func (s *TestMessengerPrepareMessageSuite) Test_WHEN_NoQuotedMessage_THEN_RetrievedMessageDoesNotContainQuotedMessage() {


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/13814
Might fix https://github.com/status-im/status-desktop/issues/13533

Related: https://github.com/status-im/status-go/pull/4516

# TLDR;

- When getting `albumMessages` from the DB, we should check `albumID` is empty. Otherwise we load ALL messages for given `chatID`
- Refactored `protocol/persistence_quoted_message_test.go` a bit. 

# Investigation details

The "never ending loading animation" was actually ending. In 3-7 minutes on my machine.
Because getting chat messages from the database was taking too much time.
```
DEBUG[03-05|17:24:16.741|rpc/handler.go:307] Served wakuext_chatMessages reqid=94 duration=3m42.088951167s
```

I figured out that this happens for particular message `0x8df1708a98b077fc7850ce07a8c10895a2bdbf853285bbdbae75c8b0008d5c83`, which turned out to be a response to a message with an image.