### PR TITLE
Extend out of order migration check

### DIFF
--- a/_assets/scripts/migration_check.sh
+++ b/_assets/scripts/migration_check.sh
@@ -9,7 +9,6 @@ check_migration_order() {
     current_migration=$(echo "$file" | cut -d'-' -f1)
 
     if [[ ! -z "$prev_migration" && "$current_migration" < "$prev_migration" ]]; then
-
       echo "migration ${current_migration} is not in order with ${prev_migration}"
       echo "Error: Migration files are out of order. Please ensure migrations are added in chronological order."
       exit 1
@@ -19,12 +18,31 @@ check_migration_order() {
   done
 }
 
-git fetch origin develop
+git checkout origin/develop
+git pull origin develop
+git checkout -
 committed_files=$(git ls-tree -r --name-only HEAD protocol/migrations/sqlite/*.sql | sort)
 staged_files=$(git diff --name-only origin/develop protocol/migrations/sqlite/*.sql | sort)
 
 all_files=$(echo -e "$committed_files\n$staged_files")
 
+# protocol migrations
+check_migration_order $all_files
+
+committed_files=$(git ls-tree -r --name-only HEAD appdatabase/migrations/sql/*.sql | sort)
+staged_files=$(git diff --name-only origin/develop appdatabase/migrations/sql/*.sql | sort)
+
+all_files=$(echo -e "$committed_files\n$staged_files")
+
+# account migrations
+check_migration_order $all_files
+
+committed_files=$(git ls-tree -r --name-only HEAD protocol/encryption/migrations/sqlite/*.sql | sort)
+staged_files=$(git diff --name-only origin/develop protocol/encryption/migrations/sqlite/*.sql | sort)
+
+all_files=$(echo -e "$committed_files\n$staged_files")
+
+# encryption migrations
 check_migration_order $all_files
 
 exit 0


### PR DESCRIPTION
The check was only checking the `protocol/migrations` directory.
This commit extends the checks on `appdatabase` and `protocol/encryption`
I had to also change how we fetch develop, as CI wasn't picking up the error by just fetching, so we checkout and pull instead (tested to work on CI)