### PR TITLE
Fix balances cache

### DIFF
--- a/services/wallet/persistence.go
+++ b/services/wallet/persistence.go
@@ -33,7 +33,7 @@ func (p *Persistence) SaveTokens(tokens map[common.Address][]Token) (err error) 
 	for address, addressTokens := range tokens {
 		for _, t := range addressTokens {
 			for chainID, b := range t.BalancesPerChain {
-				if b.HasError || b.Balance.Cmp(big.NewFloat(0)) == 0 {
+				if b.HasError {
 					continue
 				}
 				_, err = tx.Exec(`INSERT INTO token_balances(user_address,token_name,token_symbol,token_address,token_decimals,token_description,token_url,balance,raw_balance,chain_id) VALUES (?,?,?,?,?,?,?,?,?,?)`, address.Hex(), t.Name, t.Symbol, b.Address.Hex(), t.Decimals, t.Description, t.AssetWebsiteURL, b.Balance.String(), b.RawBalance, chainID)

--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -67,7 +67,7 @@ func (c *findNewBlocksCommand) detectTransfers(parent context.Context, accounts 
 			tokenAddresses = append(tokenAddresses, token.Address)
 		}
 	}
-	log.Info("findNewBlocksCommand detectTransfers", "cnt", len(tokenAddresses), "addresses", tokenAddresses)
+	log.Info("findNewBlocksCommand detectTransfers", "cnt", len(tokenAddresses))
 
 	ctx, cancel := context.WithTimeout(parent, requestTimeout)
 	defer cancel()


### PR DESCRIPTION
The cache was not used and ethscan requests happened periodically even if no transfers were detected.

There were two problems
1. I misinterpreted what is actually stored in the database (only balances which are visible and non-zero)
2. Balances which were non-zero but become zero wouldn't be updated in the cache

The issue is fixed, next things were checked:
1. Usage of ethscan on restored acc
2. Usage of ethscan on a newly created acc
3. Update of balance on new account generation
4. Update of balance on recieveing/sending txs