### PR TITLE
chore: disable curated communities loop in tests

### DIFF
--- a/protocol/common/code_control_flags.go
+++ b/protocol/common/code_control_flags.go
@@ -1,0 +1,11 @@
+package common
+
+type CodeControlFlags struct {
+	// AutoRequestHistoricMessages indicates whether we should automatically request
+	// historic messages on getting online, connecting to store node, etc.
+	AutoRequestHistoricMessages bool
+
+	// CuratedCommunitiesUpdateLoopEnabled indicates whether we should disable the curated communities update loop.
+	// Usually should be disabled in tests.
+	CuratedCommunitiesUpdateLoopEnabled bool
+}

--- a/protocol/common/feature_flags.go
+++ b/protocol/common/feature_flags.go
@@ -30,4 +30,8 @@ type FeatureFlags struct {
 	// AutoRequestHistoricMessages indicates whether we should automatically request
 	// historic messages on getting online, connecting to store node, etc.
 	AutoRequestHistoricMessages bool
+
+	// CuratedCommunitiesUpdateLoopEnabled indicates whether we should disable the curated communities update loop.
+	// Usually should be disabled in tests.
+	CuratedCommunitiesUpdateLoopEnabled bool
 }

--- a/protocol/common/feature_flags.go
+++ b/protocol/common/feature_flags.go
@@ -26,12 +26,4 @@ type FeatureFlags struct {
 
 	// Peersyncing indicates whether we should advertise and sync messages with other peers
 	Peersyncing bool
-
-	// AutoRequestHistoricMessages indicates whether we should automatically request
-	// historic messages on getting online, connecting to store node, etc.
-	AutoRequestHistoricMessages bool
-
-	// CuratedCommunitiesUpdateLoopEnabled indicates whether we should disable the curated communities update loop.
-	// Usually should be disabled in tests.
-	CuratedCommunitiesUpdateLoopEnabled bool
 }

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -14,7 +14,6 @@ import (
 	hexutil "github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/status-im/status-go/account"
-	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts/accounts"
@@ -26,9 +25,7 @@ import (
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/services/communitytokens"
-	mailserversDB "github.com/status-im/status-go/services/mailservers"
 	walletToken "github.com/status-im/status-go/services/wallet/token"
-	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/transactions"
 )
 
@@ -589,26 +586,4 @@ func waitOnCommunitiesEvent(user *Messenger, condition func(*communities.Subscri
 	}()
 
 	return errCh
-}
-
-func WithTestStoreNode(s *suite.Suite, id string, address string, fleet string, collectiblesServiceMock *CollectiblesServiceMock) Option {
-	return func(c *config) error {
-		sqldb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
-		s.Require().NoError(err)
-
-		db := mailserversDB.NewDB(sqldb)
-		err = db.Add(mailserversDB.Mailserver{
-			ID:      id,
-			Name:    id,
-			Address: address,
-			Fleet:   fleet,
-		})
-		s.Require().NoError(err)
-
-		c.mailserversDatabase = db
-		c.clusterConfig = params.ClusterConfig{Fleet: fleet}
-		c.communityTokensService = collectiblesServiceMock
-
-		return nil
-	}
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -834,7 +834,7 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	m.startSyncSettingsLoop()
 	m.startSettingsChangesLoop()
 	m.startCommunityRekeyLoop()
-	if m.config.featureFlags.CuratedCommunitiesUpdateLoopEnabled {
+	if m.config.codeControlFlags.CuratedCommunitiesUpdateLoopEnabled {
 		m.startCuratedCommunitiesUpdateLoop()
 	}
 	m.startMessageSegmentsCleanupLoop()
@@ -962,7 +962,7 @@ func (m *Messenger) handleConnectionChange(online bool) {
 	}
 
 	// Start fetching messages from store nodes
-	if online && m.config.featureFlags.AutoRequestHistoricMessages {
+	if online && m.config.codeControlFlags.AutoRequestHistoricMessages {
 		m.asyncRequestAllHistoricMessages()
 	}
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -834,7 +834,9 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	m.startSyncSettingsLoop()
 	m.startSettingsChangesLoop()
 	m.startCommunityRekeyLoop()
-	m.startCuratedCommunitiesUpdateLoop()
+	if m.config.featureFlags.CuratedCommunitiesUpdateLoopEnabled {
+		m.startCuratedCommunitiesUpdateLoop()
+	}
 	m.startMessageSegmentsCleanupLoop()
 
 	if err := m.cleanTopics(); err != nil {

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -82,6 +82,7 @@ func newTestMessenger(waku types.Waku, config testMessengerConfig) (*Messenger, 
 		WithDatasync(),
 		WithToplevelDatabaseMigrations(),
 		WithBrowserDatabase(nil),
+		WithCuratedCommunitiesUpdateLoop(false),
 	}
 	options = append(options, config.extraOptions...)
 

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -76,7 +76,8 @@ type config struct {
 	// Config for the envelopes monitor
 	envelopesMonitorConfig *transport.EnvelopesMonitorConfig
 
-	featureFlags common.FeatureFlags
+	featureFlags     common.FeatureFlags
+	codeControlFlags common.CodeControlFlags
 
 	appDb                  *sql.DB
 	walletDb               *sql.DB
@@ -125,8 +126,8 @@ func messengerDefaultConfig() config {
 		messageResendMaxCount: 3,
 	}
 
-	c.featureFlags.AutoRequestHistoricMessages = true
-	c.featureFlags.CuratedCommunitiesUpdateLoopEnabled = true
+	c.codeControlFlags.AutoRequestHistoricMessages = true
+	c.codeControlFlags.CuratedCommunitiesUpdateLoopEnabled = true
 	return c
 }
 
@@ -407,20 +408,6 @@ func WithCollectiblesManager(collectiblesManager communities.CollectiblesManager
 func WithAccountManager(accountManager account.Manager) Option {
 	return func(c *config) error {
 		c.accountsManager = accountManager
-		return nil
-	}
-}
-
-func WithAutoRequestHistoricMessages(enabled bool) Option {
-	return func(c *config) error {
-		c.featureFlags.AutoRequestHistoricMessages = enabled
-		return nil
-	}
-}
-
-func WithCuratedCommunitiesUpdateLoop(enabled bool) Option {
-	return func(c *config) error {
-		c.featureFlags.CuratedCommunitiesUpdateLoopEnabled = enabled
 		return nil
 	}
 }

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -126,6 +126,7 @@ func messengerDefaultConfig() config {
 	}
 
 	c.featureFlags.AutoRequestHistoricMessages = true
+	c.featureFlags.CuratedCommunitiesUpdateLoopEnabled = true
 	return c
 }
 
@@ -413,6 +414,13 @@ func WithAccountManager(accountManager account.Manager) Option {
 func WithAutoRequestHistoricMessages(enabled bool) Option {
 	return func(c *config) error {
 		c.featureFlags.AutoRequestHistoricMessages = enabled
+		return nil
+	}
+}
+
+func WithCuratedCommunitiesUpdateLoop(enabled bool) Option {
+	return func(c *config) error {
+		c.featureFlags.CuratedCommunitiesUpdateLoopEnabled = enabled
 		return nil
 	}
 }

--- a/protocol/messenger_config_test.go
+++ b/protocol/messenger_config_test.go
@@ -1,11 +1,12 @@
 package protocol
 
 import (
+	"github.com/stretchr/testify/suite"
+
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/params"
-	mailserversDB "github.com/status-im/status-go/services/mailservers"
+	"github.com/status-im/status-go/services/mailservers"
 	"github.com/status-im/status-go/t/helpers"
-	"github.com/stretchr/testify/suite"
 )
 
 func WithTestStoreNode(s *suite.Suite, id string, address string, fleet string, collectiblesServiceMock *CollectiblesServiceMock) Option {
@@ -13,8 +14,8 @@ func WithTestStoreNode(s *suite.Suite, id string, address string, fleet string, 
 		sqldb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
 		s.Require().NoError(err)
 
-		db := mailserversDB.NewDB(sqldb)
-		err = db.Add(mailserversDB.Mailserver{
+		db := mailservers.NewDB(sqldb)
+		err = db.Add(mailservers.Mailserver{
 			ID:      id,
 			Name:    id,
 			Address: address,

--- a/protocol/messenger_config_test.go
+++ b/protocol/messenger_config_test.go
@@ -1,0 +1,45 @@
+package protocol
+
+import (
+	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/params"
+	mailserversDB "github.com/status-im/status-go/services/mailservers"
+	"github.com/status-im/status-go/t/helpers"
+	"github.com/stretchr/testify/suite"
+)
+
+func WithTestStoreNode(s *suite.Suite, id string, address string, fleet string, collectiblesServiceMock *CollectiblesServiceMock) Option {
+	return func(c *config) error {
+		sqldb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
+		s.Require().NoError(err)
+
+		db := mailserversDB.NewDB(sqldb)
+		err = db.Add(mailserversDB.Mailserver{
+			ID:      id,
+			Name:    id,
+			Address: address,
+			Fleet:   fleet,
+		})
+		s.Require().NoError(err)
+
+		c.mailserversDatabase = db
+		c.clusterConfig = params.ClusterConfig{Fleet: fleet}
+		c.communityTokensService = collectiblesServiceMock
+
+		return nil
+	}
+}
+
+func WithAutoRequestHistoricMessages(enabled bool) Option {
+	return func(c *config) error {
+		c.codeControlFlags.AutoRequestHistoricMessages = enabled
+		return nil
+	}
+}
+
+func WithCuratedCommunitiesUpdateLoop(enabled bool) Option {
+	return func(c *config) error {
+		c.codeControlFlags.CuratedCommunitiesUpdateLoopEnabled = enabled
+		return nil
+	}
+}

--- a/protocol/messenger_curated_communities.go
+++ b/protocol/messenger_curated_communities.go
@@ -20,7 +20,12 @@ const (
 
 // Regularly gets list of curated communities and signals them to client
 func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
-	logger := m.logger.Named("startCuratedCommunitiesUpdateLoop")
+	logger := m.logger.Named("curatedCommunitiesUpdateLoop")
+
+	if m.contractMaker == nil {
+		logger.Warn("not starting curated communities loop: contract maker not initialized")
+		return
+	}
 
 	go func() {
 		// Initialize interval to 0 for immediate execution
@@ -76,7 +81,6 @@ func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
 
 func (m *Messenger) getCuratedCommunitiesFromContract() (*communities.CuratedCommunities, error) {
 	if m.contractMaker == nil {
-		m.logger.Warn("contract maker not initialized")
 		return nil, errors.New("contract maker not initialized")
 	}
 

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -409,7 +409,7 @@ func (m *Messenger) connectToMailserver(ms mailservers.Mailserver) error {
 			signal.SendMailserverAvailable(m.mailserverCycle.activeMailserver.Address, m.mailserverCycle.activeMailserver.ID)
 
 			// Query mailserver
-			if m.config.featureFlags.AutoRequestHistoricMessages {
+			if m.config.codeControlFlags.AutoRequestHistoricMessages {
 				go func() {
 					_, err := m.performMailserverRequest(&ms, func(_ mailservers.Mailserver) (*MessengerResponse, error) {
 						return m.RequestAllHistoricMessages(false, false)
@@ -564,7 +564,7 @@ func (m *Messenger) handleMailserverCycleEvent(connectedPeers []ConnectedPeer) e
 					signal.SendMailserverAvailable(m.mailserverCycle.activeMailserver.Address, m.mailserverCycle.activeMailserver.ID)
 				}
 				// Query mailserver
-				if m.config.featureFlags.AutoRequestHistoricMessages {
+				if m.config.codeControlFlags.AutoRequestHistoricMessages {
 					go func() {
 						_, err := m.RequestAllHistoricMessages(false, true)
 						if err != nil {

--- a/protocol/messenger_storenode_comunity_test.go
+++ b/protocol/messenger_storenode_comunity_test.go
@@ -131,6 +131,7 @@ func (s *MessengerStoreNodeCommunitySuite) newMessenger(name, storenodeAddress s
 
 	options := []Option{
 		WithAutoRequestHistoricMessages(false),
+		WithCuratedCommunitiesUpdateLoop(false),
 	}
 
 	if storenodeAddress != "" {

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -207,6 +207,7 @@ func (s *MessengerStoreNodeRequestSuite) newMessenger(shh types.Waku, logger *za
 
 	options := []Option{
 		WithAutoRequestHistoricMessages(false),
+		WithCuratedCommunitiesUpdateLoop(false),
 	}
 
 	if mailserverAddress != "" {

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -1194,7 +1194,7 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchingHistoryWhenOnline() {
 	{
 		// Enable auto request historic messages, so that when bob goes online it will fetch historic messages
 		// We don't enable it earlier to control when we connect to the store node.
-		s.bob.config.featureFlags.AutoRequestHistoricMessages = true
+		s.bob.config.codeControlFlags.AutoRequestHistoricMessages = true
 
 		WaitForPeersConnected(&s.Suite, gethbridge.GetGethWakuV2From(s.bobWaku), func() []string {
 			err := s.bob.DialPeer(storeAddress)


### PR DESCRIPTION
1. Introduced `WithCuratedCommunitiesUpdateLoop` messenger option
It defaults to `true` (as old behaviour). But allows to disable it.

2. Disabled CuratedCommunitiesUpdateLoop in tests.
Because it makes no sense there, just spamming the log with errors.