### PR TITLE
fix: ensure no duplicate results when checking for missing collectibl…

### DIFF
--- a/services/wallet/collectibles/collectible_data_db.go
+++ b/services/wallet/collectibles/collectible_data_db.go
@@ -203,6 +203,12 @@ func scanCollectiblesDataRow(row *sql.Row) (*thirdparty.CollectibleData, error) 
 
 func (o *CollectibleDataDB) GetIDsNotInDB(ids []thirdparty.CollectibleUniqueID) ([]thirdparty.CollectibleUniqueID, error) {
 	ret := make([]thirdparty.CollectibleUniqueID, 0, len(ids))
+	idMap := make(map[string]thirdparty.CollectibleUniqueID, len(ids))
+
+	// Ensure we don't have duplicates
+	for _, id := range ids {
+		idMap[id.HashKey()] = id
+	}
 
 	exists, err := o.db.Prepare(`SELECT EXISTS (
 			SELECT 1 FROM collectible_data_cache
@@ -212,7 +218,7 @@ func (o *CollectibleDataDB) GetIDsNotInDB(ids []thirdparty.CollectibleUniqueID) 
 		return nil, err
 	}
 
-	for _, id := range ids {
+	for _, id := range idMap {
 		row := exists.QueryRow(
 			id.ContractID.ChainID,
 			id.ContractID.Address,

--- a/services/wallet/collectibles/collection_data_db.go
+++ b/services/wallet/collectibles/collection_data_db.go
@@ -180,6 +180,12 @@ func scanCollectionsDataRow(row *sql.Row) (*thirdparty.CollectionData, error) {
 
 func (o *CollectionDataDB) GetIDsNotInDB(ids []thirdparty.ContractID) ([]thirdparty.ContractID, error) {
 	ret := make([]thirdparty.ContractID, 0, len(ids))
+	idMap := make(map[string]thirdparty.ContractID, len(ids))
+
+	// Ensure we don't have duplicates
+	for _, id := range ids {
+		idMap[id.HashKey()] = id
+	}
 
 	exists, err := o.db.Prepare(`SELECT EXISTS (
 			SELECT 1 FROM collection_data_cache
@@ -189,7 +195,7 @@ func (o *CollectionDataDB) GetIDsNotInDB(ids []thirdparty.ContractID) ([]thirdpa
 		return nil, err
 	}
 
-	for _, id := range ids {
+	for _, id := range idMap {
 		row := exists.QueryRow(
 			id.ChainID,
 			id.Address,


### PR DESCRIPTION
…e/collection ids in the db

We weren't checking for duplicates when returning missing Collection/Collectible metadata from the DB. This caused them to be fetched several times unnecesarily.
