### PR TITLE
Fix some issues with Community members and edits for the Reaction in view channel feature

### DIFF
--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -87,6 +87,9 @@ type Chat struct {
 	// Active indicates whether the chat has been soft deleted
 	Active bool `json:"active"`
 
+	// ViewersCanPostReactions indicates whether users can post reactions in view only mode
+	ViewersCanPostReactions bool `json:"viewersCanPostReactions"`
+
 	ChatType ChatType `json:"chatType"`
 
 	// Timestamp indicates the last time this chat has received/sent a message
@@ -500,6 +503,7 @@ func CreateCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, 
 		ReadMessagesAtClockValue: 0,
 		ChatType:                 ChatTypeCommunityChat,
 		FirstMessageTimestamp:    orgChat.Identity.FirstMessageTimestamp,
+		ViewersCanPostReactions:  orgChat.ViewersCanPostReactions,
 	}
 }
 

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -96,16 +96,17 @@ type CommunityAdminSettings struct {
 }
 
 type CommunityChat struct {
-	ID          string                               `json:"id"`
-	Name        string                               `json:"name"`
-	Color       string                               `json:"color"`
-	Emoji       string                               `json:"emoji"`
-	Description string                               `json:"description"`
-	Members     map[string]*protobuf.CommunityMember `json:"members"`
-	Permissions *protobuf.CommunityPermissions       `json:"permissions"`
-	CanPost     bool                                 `json:"canPost"`
-	Position    int                                  `json:"position"`
-	CategoryID  string                               `json:"categoryID"`
+	ID                      string                               `json:"id"`
+	Name                    string                               `json:"name"`
+	Color                   string                               `json:"color"`
+	Emoji                   string                               `json:"emoji"`
+	Description             string                               `json:"description"`
+	Members                 map[string]*protobuf.CommunityMember `json:"members"`
+	Permissions             *protobuf.CommunityPermissions       `json:"permissions"`
+	CanPost                 bool                                 `json:"canPost"`
+	ViewersCanPostReactions bool                                 `json:"viewersCanPostReactions"`
+	Position                int                                  `json:"position"`
+	CategoryID              string                               `json:"categoryID"`
 }
 
 type CommunityCategory struct {
@@ -184,16 +185,17 @@ func (o *Community) MarshalPublicAPIJSON() ([]byte, error) {
 				return nil, err
 			}
 			chat := CommunityChat{
-				ID:          id,
-				Name:        c.Identity.DisplayName,
-				Color:       c.Identity.Color,
-				Emoji:       c.Identity.Emoji,
-				Description: c.Identity.Description,
-				Permissions: c.Permissions,
-				Members:     c.Members,
-				CanPost:     canPost,
-				CategoryID:  c.CategoryId,
-				Position:    int(c.Position),
+				ID:                      id,
+				Name:                    c.Identity.DisplayName,
+				Color:                   c.Identity.Color,
+				Emoji:                   c.Identity.Emoji,
+				Description:             c.Identity.Description,
+				Permissions:             c.Permissions,
+				Members:                 c.Members,
+				CanPost:                 canPost,
+				ViewersCanPostReactions: c.ViewersCanPostReactions,
+				CategoryID:              c.CategoryId,
+				Position:                int(c.Position),
 			}
 			communityItem.Chats[id] = chat
 		}
@@ -320,16 +322,17 @@ func (o *Community) MarshalJSON() ([]byte, error) {
 				return nil, err
 			}
 			chat := CommunityChat{
-				ID:          id,
-				Name:        c.Identity.DisplayName,
-				Emoji:       c.Identity.Emoji,
-				Color:       c.Identity.Color,
-				Description: c.Identity.Description,
-				Permissions: c.Permissions,
-				Members:     c.Members,
-				CanPost:     canPost,
-				CategoryID:  c.CategoryId,
-				Position:    int(c.Position),
+				ID:                      id,
+				Name:                    c.Identity.DisplayName,
+				Emoji:                   c.Identity.Emoji,
+				Color:                   c.Identity.Color,
+				Description:             c.Identity.Description,
+				Permissions:             c.Permissions,
+				Members:                 c.Members,
+				CanPost:                 canPost,
+				ViewersCanPostReactions: c.ViewersCanPostReactions,
+				CategoryID:              c.CategoryId,
+				Position:                int(c.Position),
 			}
 			communityItem.Chats[id] = chat
 		}

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1913,8 +1913,9 @@ func (o *Community) CanPost(pk *ecdsa.PublicKey, chatID string, messageType prot
 		if !isChatMember {
 			return false, nil
 		}
-		isPoster := member.ChannelRole == protobuf.CommunityMember_CHANNEL_ROLE_POSTER
-		isViewer := member.ChannelRole == protobuf.CommunityMember_CHANNEL_ROLE_VIEWER
+
+		isPoster := member.GetChannelRole() == protobuf.CommunityMember_CHANNEL_ROLE_POSTER
+		isViewer := member.GetChannelRole() == protobuf.CommunityMember_CHANNEL_ROLE_VIEWER
 		return isPoster || (isViewer && chat.ViewersCanPostReactions), nil
 
 	default:

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -621,6 +621,15 @@ func (o *Community) GetMember(pk *ecdsa.PublicKey) *protobuf.CommunityMember {
 	return o.getMember(pk)
 }
 
+func (o *Community) GetChat(chatID string) (*protobuf.CommunityChat, error) {
+	chat, ok := o.config.CommunityDescription.Chats[chatID]
+	if !ok {
+		return nil, ErrChatNotFound
+	}
+
+	return chat, nil
+}
+
 func (o *Community) getChatMember(pk *ecdsa.PublicKey, chatID string) *protobuf.CommunityMember {
 	if !o.hasMember(pk) {
 		return nil

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1050,11 +1050,11 @@ func (m *Manager) ReevaluateMembers(community *Community) (map[protobuf.Communit
 				if response.ViewAndPostPermissions.Satisfied {
 					channelRole = protobuf.CommunityMember_CHANNEL_ROLE_POSTER
 				}
-				if !isMemberAlreadyInChannel {
-					_, err := community.AddMemberToChat(channelID, memberPubKey, []protobuf.CommunityMember_Roles{}, channelRole)
-					if err != nil {
-						return nil, err
-					}
+
+				// Add the member back to the chat member list in case the role changed (it replaces the previous values)
+				_, err := community.AddMemberToChat(channelID, memberPubKey, []protobuf.CommunityMember_Roles{}, channelRole)
+				if err != nil {
+					return nil, err
 				}
 			} else if isMemberAlreadyInChannel {
 				_, err := community.RemoveUserFromChat(memberPubKey, channelID)

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1399,6 +1399,15 @@ func (m *Manager) EditChat(communityID types.HexBytes, chatID string, chat *prot
 		chatID = strings.TrimPrefix(chatID, communityID.String())
 	}
 
+	oldChat, err := community.GetChat(chatID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// We can't edit permissions and members with an Edit, so we set to what we had, otherwise they will be lost
+	chat.Permissions = oldChat.Permissions
+	chat.Members = oldChat.Members
+
 	changes, err := community.EditChat(chatID, chat)
 	if err != nil {
 		return nil, nil, err

--- a/services/chat/api.go
+++ b/services/chat/api.go
@@ -477,6 +477,9 @@ func (api *API) getCommunityByID(id string) (*communities.Community, error) {
 }
 
 func (chat *Chat) populateCommunityFields(community *communities.Community) error {
+	chat.CanPost = true
+	chat.CanPostMessages = true
+	chat.CanPostReactions = true
 	if community == nil {
 		return nil
 	}

--- a/services/chat/api.go
+++ b/services/chat/api.go
@@ -79,10 +79,11 @@ type Chat struct {
 	PinnedMessages           *PinnedMessages                    `json:"pinnedMessages,omitempty"`
 	// Deprecated: CanPost is deprecated in favor of CanPostMessages/CanPostReactions/etc.
 	// For now CanPost will equal to CanPostMessages.
-	CanPost          bool   `json:"canPost"`
-	CanPostMessages  bool   `json:"canPostMessages"`
-	CanPostReactions bool   `json:"canPostReactions"`
-	Base64Image      string `json:"image,omitempty"`
+	CanPost                 bool   `json:"canPost"`
+	CanPostMessages         bool   `json:"canPostMessages"`
+	CanPostReactions        bool   `json:"canPostReactions"`
+	ViewersCanPostReactions bool   `json:"viewersCanPostReactions"`
+	Base64Image             string `json:"image,omitempty"`
 }
 
 type ChannelGroup struct {
@@ -505,6 +506,7 @@ func (chat *Chat) populateCommunityFields(community *communities.Community) erro
 	chat.CanPost = canPostMessages
 	chat.CanPostMessages = canPostMessages
 	chat.CanPostReactions = canPostReactions
+	chat.ViewersCanPostReactions = commChat.ViewersCanPostReactions
 
 	return nil
 }


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/13523

- First commit: adds ViewersCanPostReactions to Chat object so that when the owner updates the value, it is added to the response, so that we can update the UI
- Second commit: Fices an issue where calling edit doesn't contain the members from the API, so we lost members. The solution is to add the members before saving and publishing
- Third commit: fixes the member role when we reevaluate the permissions. What happened is we evaluated the role, but didn't update it if the member was already part of the community