### PR TITLE
Delete accepted requests to join applicant side, On acceptance

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2229,7 +2229,7 @@ func (m *Manager) markRequestToJoinAsAcceptedPending(pk *ecdsa.PublicKey, commun
 	return m.persistence.SetRequestToJoinState(common.PubkeyToHex(pk), community.ID(), RequestToJoinStateAcceptedPending)
 }
 
-func (m *Manager) DeletePendingRequestToJoin(request *RequestToJoin) error {
+func (m *Manager) DeleteRequestToJoin(request *RequestToJoin) error {
 	community, err := m.GetByID(request.CommunityID)
 	if err != nil {
 		return err

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2235,7 +2235,7 @@ func (m *Manager) DeletePendingRequestToJoin(request *RequestToJoin) error {
 		return err
 	}
 
-	err = m.persistence.DeletePendingRequestToJoin(request.ID)
+	err = m.persistence.DeleteRequestToJoin(request.ID)
 	if err != nil {
 		return err
 	}

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -809,7 +809,7 @@ func (p *Persistence) SetRequestToJoinState(pk string, communityID []byte, state
 	return err
 }
 
-func (p *Persistence) DeletePendingRequestToJoin(id []byte) error {
+func (p *Persistence) DeleteRequestToJoin(id []byte) error {
 	_, err := p.db.Exec(`DELETE FROM communities_requests_to_join WHERE id = ?`, id)
 	return err
 }

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1858,7 +1858,7 @@ func (m *Messenger) CheckAndDeletePendingRequestToJoinCommunity(ctx context.Cont
 		}
 
 		if timeNow >= requestTimeOutClock {
-			err := m.communitiesManager.DeletePendingRequestToJoin(requestToJoin)
+			err := m.communitiesManager.DeleteRequestToJoin(requestToJoin)
 			if err != nil {
 				m.logger.Error("failed to delete pending request to join", zap.String("req-id", requestToJoin.ID.String()), zap.Error(err))
 				return nil, err

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1656,7 +1656,7 @@ func (m *Messenger) HandleCommunityRequestToJoinResponse(state *ReceivedMessageS
 	if updatedRequest != nil {
 		state.Response.AddRequestToJoinCommunity(updatedRequest)
 		if updatedRequest.State == communities.RequestToJoinStateAccepted {
-			err := m.communitiesManager.DeletePendingRequestToJoin(updatedRequest)
+			err := m.communitiesManager.DeleteRequestToJoin(updatedRequest)
 			if err != nil {
 				return err
 			}

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1655,6 +1655,12 @@ func (m *Messenger) HandleCommunityRequestToJoinResponse(state *ReceivedMessageS
 
 	if updatedRequest != nil {
 		state.Response.AddRequestToJoinCommunity(updatedRequest)
+		if updatedRequest.State == communities.RequestToJoinStateAccepted {
+			err := m.communitiesManager.DeletePendingRequestToJoin(updatedRequest)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	community, err := m.communitiesManager.GetByID(requestToJoinResponseProto.CommunityId)


### PR DESCRIPTION
Fixes an issue on mobile, Where admin sent multiple `ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE` and that caused multiple toasts showing that the user joined the community and deleting the request when it's accepted fixes that.

Closes https://github.com/status-im/status-mobile/issues/17955 on status-mobile
