### PR TITLE
fix: decrypt and propagate community when missing keys are received

### DIFF
--- a/protocol/communities/persistence_test.go
+++ b/protocol/communities/persistence_test.go
@@ -977,7 +977,7 @@ func (s *PersistenceSuite) TestDecryptedCommunityCache() {
 	s.Require().Nil(retrievedCommunity)
 
 	// invalidating the cache
-	err = s.db.InvalidateDecryptedCommunityCacheForKeys([]*encryption.HashRatchetInfo{{KeyID: keyID1}})
+	_, err = s.db.InvalidateDecryptedCommunityCacheForKeys([]*encryption.HashRatchetInfo{{KeyID: keyID1}})
 	s.Require().NoError(err)
 
 	// community cannot be retrieved anymore


### PR DESCRIPTION
If a channel's encryption key arrives after the `CommunityDescription`, the channel's member list would be empty. To mitigate this, the Community is decrypted and propagated to the Client each time missing keys for it are received.

**NOTE**:
There can still be cases where the channel's member list is empty, i.e., when the encryption key is not delivered at all to members. However, there's not much we can do about it.

fixes: status-im/status-desktop#13647
