### PR TITLE
fix: ensure `CommunityDescription` reprocessing on decryption failure

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1066,7 +1066,8 @@ func (o *Community) UpdateCommunityDescription(description *protobuf.CommunityDe
 
 	response := o.emptyCommunityChanges()
 
-	if description.Clock <= o.config.CommunityDescription.Clock {
+	// Enables processing of identical clocks. Identical descriptions may be reprocessed upon subsequent receipt of the previously missing encryption key.
+	if description.Clock < o.config.CommunityDescription.Clock {
 		return response, nil
 	}
 


### PR DESCRIPTION
Previously, `CommunityDescription` instances failing partial decryption were not reprocessed due to duplicate message check. This commit fixes the issue by bypassing the check for such descriptions, allowing their reprocessing upon receiving missing encryption key.

fixes: status-im/status-desktop#13647
