### PR TITLE
`account` - Refactor removal / replacement of deprecated and obsolete funcs

### DIFF
--- a/account/accounts_test.go
+++ b/account/accounts_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -328,7 +327,7 @@ func (s *ManagerTestSuite) TestMigrateKeyStoreDir() {
 	err := os.Mkdir(newKeyDir, 0777)
 	s.Require().NoError(err)
 
-	files, _ := ioutil.ReadDir(newKeyDir)
+	files, _ := os.ReadDir(newKeyDir)
 	s.Equal(0, len(files))
 
 	address := types.HexToAddress(s.walletAddress).Hex()
@@ -336,21 +335,21 @@ func (s *ManagerTestSuite) TestMigrateKeyStoreDir() {
 	err = s.accManager.MigrateKeyStoreDir(oldKeyDir, newKeyDir, addresses)
 	s.Require().NoError(err)
 
-	files, _ = ioutil.ReadDir(newKeyDir)
+	files, _ = os.ReadDir(newKeyDir)
 	s.Equal(1, len(files))
 }
 
 func (s *ManagerTestSuite) TestReEncryptKey() {
 	var firstKeyPath string
-	files, _ := ioutil.ReadDir(s.keydir)
+	files, _ := os.ReadDir(s.keydir)
 
-	// thiere is only one file in this dir,
+	// there is only one file in this dir,
 	// is there a better way to reference it?
 	for _, f := range files {
 		firstKeyPath = filepath.Join(s.keydir, f.Name())
 	}
 
-	rawKey, _ := ioutil.ReadFile(firstKeyPath)
+	rawKey, _ := os.ReadFile(firstKeyPath)
 	reEncryptedKey, _ := s.accManager.ReEncryptKey(rawKey, testPassword, newTestPassword)
 
 	type Key struct {
@@ -392,7 +391,7 @@ func (s *ManagerTestSuite) TestReEncryptKeyStoreDir() {
 		// walk should not throw callback errors
 		s.Require().NoError(err)
 
-		rawKeyFile, err := ioutil.ReadFile(path)
+		rawKeyFile, err := os.ReadFile(path)
 		s.Require().NoError(err)
 
 		// should not decrypt with old password

--- a/account/onboarding.go
+++ b/account/onboarding.go
@@ -89,10 +89,8 @@ func (o *Onboarding) generateAccount(mnemonicPhraseLength int) (*OnboardingAccou
 		ChatPubKey:    walletPubKey,
 	}
 
-	uuid := uuid.NewRandom().String()
-
 	account := &OnboardingAccount{
-		ID:       uuid,
+		ID:       uuid.NewRandom().String(),
 		mnemonic: mnemonicPhrase,
 		Info:     info,
 	}

--- a/account/utils.go
+++ b/account/utils.go
@@ -1,7 +1,6 @@
 package account
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -30,37 +29,6 @@ type ErrZeroAddress struct {
 
 func (e *ErrZeroAddress) Error() string {
 	return fmt.Sprintf("%s contains an empty address", e.field)
-}
-
-func newErrZeroAddress(field string) *ErrZeroAddress {
-	return &ErrZeroAddress{
-		field: field,
-	}
-}
-
-func ParseLoginParams(paramsJSON string) (LoginParams, error) {
-	var (
-		params      LoginParams
-		zeroAddress types.Address
-	)
-	if err := json.Unmarshal([]byte(paramsJSON), &params); err != nil {
-		return params, err
-	}
-
-	if params.ChatAddress == zeroAddress {
-		return params, newErrZeroAddress("ChatAddress")
-	}
-
-	if params.MainAccount == zeroAddress {
-		return params, newErrZeroAddress("MainAccount")
-	}
-
-	for _, address := range params.WatchAddresses {
-		if address == zeroAddress {
-			return params, newErrZeroAddress("WatchAddresses")
-		}
-	}
-	return params, nil
 }
 
 // Info contains wallet and chat addresses and public keys of an account.


### PR DESCRIPTION
I've resolved a number of refactor issues in the `account` package.

- Replaced deprecated ioutil functions `accounts_test.go`
- Removed uuid shadowing
- Removed unused ParseLoginParams and newErrZeroAddress functions

Mostly deleting things.

