### PR TITLE
fix: update test fetch real community

### DIFF
--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -110,7 +110,9 @@ func (c *CollectiblesServiceMock) SetMockCollectibleContractData(chainID uint64,
 	if c.Collectibles == nil {
 		c.Collectibles = make(map[uint64]map[string]*communitytokens.CollectibleContractData)
 	}
-	c.Collectibles[chainID] = make(map[string]*communitytokens.CollectibleContractData)
+	if _, ok := c.Collectibles[chainID]; !ok {
+		c.Collectibles[chainID] = make(map[string]*communitytokens.CollectibleContractData)
+	}
 	c.Collectibles[chainID][contractAddress] = collectible
 }
 

--- a/protocol/waku_builder_test.go
+++ b/protocol/waku_builder_test.go
@@ -23,8 +23,12 @@ type testWakuV2Config struct {
 
 func NewTestWakuV2(s *suite.Suite, cfg testWakuV2Config) *waku2.Waku {
 	wakuConfig := &waku2.Config{
-		UseShardAsDefaultTopic: cfg.useShardAsDefaultTopic,
-		ClusterID:              cfg.clusterID,
+		UseShardAsDefaultTopic:   cfg.useShardAsDefaultTopic,
+		ClusterID:                cfg.clusterID,
+		LightClient:              false,
+		EnablePeerExchangeServer: true,
+		EnablePeerExchangeClient: false,
+		EnableDiscV5:             true,
 	}
 
 	var db *sql.DB


### PR DESCRIPTION
1. Fixed `NewTestWakuV2` to actually work
2. Improved `TestFetchRealCommunity`:
    - fixed `SetMockCollectibleContractData` not to clear `Collectibles[chainID]` map on each collectible add
    - added `CommunityURL` and `CustomOptions` test parameters
    - added Status community to the list