### PR TITLE
Fix: ignore nil contact 'IsDisplayNameDupeOfCommunityMember'

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -614,6 +614,9 @@ func (m *Messenger) IsDisplayNameDupeOfCommunityMember(name string) (bool, error
 	for _, community := range append(controlled, joined...) {
 		for memberKey := range community.Members() {
 			contact := m.GetContactByID(memberKey)
+			if contact == nil {
+				continue
+			}
 			if strings.Compare(contact.DisplayName, name) == 0 {
 				return true, nil
 			}


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/14047
Desktop PR:  https://github.com/status-im/status-desktop/pull/14064

Fix crash if it's not possible to fetch community member as a contact