### PR TITLE
Add canView to chat & fix admin role

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1006,7 +1006,7 @@ func (m *Manager) ReevaluateMembers(community *Community) (map[protobuf.Communit
 		if isNewRoleAdmin {
 			if !isCurrentRoleAdmin {
 				newPrivilegedRoles[protobuf.CommunityMember_ROLE_ADMIN] =
-					append(newPrivilegedRoles[protobuf.CommunityMember_ROLE_TOKEN_MASTER], memberPubKey)
+					append(newPrivilegedRoles[protobuf.CommunityMember_ROLE_ADMIN], memberPubKey)
 			}
 			// Skip further validation if user has Admin permissions
 			continue


### PR DESCRIPTION
Adds a `CanView` field to commuinty and fixes a problem with `CanPost`.

The code checking contact requests is separate to the periodical check, I have a different branch where I reuse the same, but since we want to cut 2.28, it will go after the branch is cut, since it's a bit risky.