### PR TITLE
Fix: Remove proof of membership for the profile showcase communities

### DIFF
--- a/protocol/identity/profile_showcase.go
+++ b/protocol/identity/profile_showcase.go
@@ -86,9 +86,8 @@ type ProfileShowcasePreferences struct {
 // Profile showcase for a contact
 
 type ProfileShowcaseCommunity struct {
-	CommunityID      string                          `json:"communityId"`
-	Order            int                             `json:"order"`
-	MembershipStatus ProfileShowcaseMembershipStatus `json:"membershipStatus"`
+	CommunityID string `json:"communityId"`
+	Order       int    `json:"order"`
 }
 
 type ProfileShowcaseAccount struct {

--- a/protocol/messenger_profile_showcase.go
+++ b/protocol/messenger_profile_showcase.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"bytes"
 	"context"
 	"crypto/ecdsa"
 	crand "crypto/rand"
@@ -16,7 +15,6 @@ import (
 
 	eth_common "github.com/ethereum/go-ethereum/common"
 
-	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/protocol/common"
@@ -235,40 +233,8 @@ func (m *Messenger) fromProfileShowcaseCommunityProto(senderPubKey *ecdsa.Public
 	entries := []*identity.ProfileShowcaseCommunity{}
 	for _, message := range messages {
 		entry := &identity.ProfileShowcaseCommunity{
-			CommunityID:      message.CommunityId,
-			Order:            int(message.Order),
-			MembershipStatus: identity.ProfileShowcaseMembershipStatusUnproven,
-		}
-
-		community, err := m.FetchCommunity(&FetchCommunityRequest{
-			CommunityKey:    message.CommunityId,
-			Shard:           nil,
-			TryDatabase:     true,
-			WaitForResponse: true,
-		})
-		if err != nil {
-			m.logger.Warn("failed to fetch community for profile entry ", zap.Error(err))
-		}
-
-		if community != nil && community.Encrypted() {
-			grant, err := community.VerifyGrantSignature(message.Grant)
-			if err != nil {
-				m.logger.Warn("failed to verify grant signature ", zap.Error(err))
-				entry.MembershipStatus = identity.ProfileShowcaseMembershipStatusNotAMember
-			} else {
-				if grant != nil && bytes.Equal(grant.MemberId, crypto.CompressPubkey(senderPubKey)) {
-					entry.MembershipStatus = identity.ProfileShowcaseMembershipStatusProvenMember
-				} else { // Show as not a member if membership can't be proven
-					entry.MembershipStatus = identity.ProfileShowcaseMembershipStatusNotAMember
-				}
-			}
-		} else if community != nil {
-			// Use member list as a proof for unecrypted communities
-			if community.HasMember(senderPubKey) {
-				entry.MembershipStatus = identity.ProfileShowcaseMembershipStatusProvenMember
-			} else {
-				entry.MembershipStatus = identity.ProfileShowcaseMembershipStatusNotAMember
-			}
+			CommunityID: message.CommunityId,
+			Order:       int(message.Order),
 		}
 
 		entries = append(entries, entry)

--- a/protocol/messenger_profile_showcase_test.go
+++ b/protocol/messenger_profile_showcase_test.go
@@ -628,9 +628,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipUnenc
 	// Verify community's data
 	s.Require().Len(profileShowcase.Communities, 2)
 	s.Require().Equal(profileShowcase.Communities[0].CommunityID, aliceCommunity.IDString())
-	s.Require().Equal(profileShowcase.Communities[0].MembershipStatus, identity.ProfileShowcaseMembershipStatusProvenMember)
 	s.Require().Equal(profileShowcase.Communities[1].CommunityID, bobCommunity.IDString())
-	s.Require().Equal(profileShowcase.Communities[1].MembershipStatus, identity.ProfileShowcaseMembershipStatusNotAMember)
 }
 
 func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipEncryptedCommunity() {
@@ -696,7 +694,5 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipEncry
 	// Verify community's data
 	s.Require().Len(profileShowcase.Communities, 2)
 	s.Require().Equal(profileShowcase.Communities[0].CommunityID, aliceCommunity.IDString())
-	s.Require().Equal(profileShowcase.Communities[0].MembershipStatus, identity.ProfileShowcaseMembershipStatusProvenMember)
 	s.Require().Equal(profileShowcase.Communities[1].CommunityID, bobCommunity.IDString())
-	s.Require().Equal(profileShowcase.Communities[1].MembershipStatus, identity.ProfileShowcaseMembershipStatusNotAMember)
 }

--- a/protocol/persistence_profile_showcase.go
+++ b/protocol/persistence_profile_showcase.go
@@ -405,9 +405,7 @@ func (db sqlitePersistence) getProfileShowcaseCommunitiesContact(tx *sql.Tx, con
 	communities := []*identity.ProfileShowcaseCommunity{}
 
 	for rows.Next() {
-		community := &identity.ProfileShowcaseCommunity{
-			MembershipStatus: identity.ProfileShowcaseMembershipStatusUnproven,
-		}
+		community := &identity.ProfileShowcaseCommunity{}
 
 		err := rows.Scan(&community.CommunityID, &community.Order)
 		if err != nil {


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/pull/13998

Remove proof of membership for the profile showcase communities. 
This code caused the receiving thread to hang when requesting a community for further membership verification.

Note: there are some leftovers for MembershipStatus, that supposted be re-used

Should be re-implemented in https://github.com/status-im/status-desktop/issues/14084