### PR TITLE
fix: crash on control node side during handling edited shared address from the member who left the community

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1176,7 +1176,12 @@ func (o *Community) ValidateEditSharedAddresses(signer *ecdsa.PublicKey, request
 		return errors.New("no addresses were shared")
 	}
 
-	if request.Clock < o.config.CommunityDescription.Members[common.PubkeyToHex(signer)].LastUpdateClock {
+	member, exists := o.config.CommunityDescription.Members[common.PubkeyToHex(signer)]
+	if !exists {
+		return errors.New("signer is not a community member")
+	}
+
+	if request.Clock < member.LastUpdateClock {
 		return errors.New("edit request is older than the last one we have. Ignore")
 	}
 


### PR DESCRIPTION

Fix the crash caused by receiving edit shared addresses message after the member leaves the community

Closes # https://github.com/status-im/status-desktop/issues/14112
