### PR TITLE
fix: udp port 0 in go-waku

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,8 @@ require (
 	github.com/mutecomm/go-sqlcipher/v4 v4.4.2
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
-	github.com/waku-org/go-waku v0.8.1-0.20240301034357-3aa391058a0b
+	github.com/urfave/cli/v2 v2.24.4
+	github.com/waku-org/go-waku v0.8.1-0.20240322182925-dd81e1d46971
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1
@@ -260,7 +261,6 @@ require (
 	github.com/tklauser/go-sysconf v0.3.6 // indirect
 	github.com/tklauser/numcpus v0.2.2 // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
-	github.com/urfave/cli/v2 v2.24.4 // indirect
 	github.com/waku-org/go-discover v0.0.0-20240129014929-85f2c00b96a3 // indirect
 	github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 // indirect
 	github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2101,8 +2101,8 @@ github.com/waku-org/go-discover v0.0.0-20240129014929-85f2c00b96a3 h1:Kk0KYXZE/u
 github.com/waku-org/go-discover v0.0.0-20240129014929-85f2c00b96a3/go.mod h1:eBHgM6T4EG0RZzxpxKy+rGz/6Dw2Nd8DWxS0lm9ESDw=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7 h1:0e1h+p84yBp0IN7AqgbZlV7lgFBjm214lgSOE7CeJmE=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20230628220917-7b4e5ae4c0e7/go.mod h1:pFvOZ9YTFsW0o5zJW7a0B5tr1owAijRWJctXJ2toL04=
-github.com/waku-org/go-waku v0.8.1-0.20240301034357-3aa391058a0b h1:/as1NPzReDHPWz00dk5IWWwjL91As7gDcGieKUwq3zo=
-github.com/waku-org/go-waku v0.8.1-0.20240301034357-3aa391058a0b/go.mod h1:RjTvkTrIwpoT1cM9HeQqwa2Q7t7WOkb3hpuB/zuZ6SM=
+github.com/waku-org/go-waku v0.8.1-0.20240322182925-dd81e1d46971 h1:HSR8JmscSmCtpIAzFO5sNZRyYZbO8nw7rGM3QcC9bak=
+github.com/waku-org/go-waku v0.8.1-0.20240322182925-dd81e1d46971/go.mod h1:RjTvkTrIwpoT1cM9HeQqwa2Q7t7WOkb3hpuB/zuZ6SM=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/vendor/github.com/waku-org/go-waku/waku/v2/discv5/discover.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/discv5/discover.go
@@ -178,6 +178,7 @@ func (d *DiscoveryV5) listen(ctx context.Context) error {
 
 	}
 
+	d.params.udpPort = uint(d.udpAddr.Port)
 	d.localnode.SetFallbackUDP(d.udpAddr.Port)
 
 	listener, err := discover.ListenV5(ctx, conn, d.localnode, d.config)

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/enr/localnode.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/enr/localnode.go
@@ -79,6 +79,10 @@ func WithIP(ipAddr *net.TCPAddr) ENROption {
 
 func WithUDPPort(udpPort uint) ENROption {
 	return func(localnode *enode.LocalNode) (err error) {
+		if udpPort == 0 {
+			return nil
+		}
+
 		if udpPort > math.MaxUint16 {
 			return errors.New("invalid udp port number")
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1020,7 +1020,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240301034357-3aa391058a0b
+# github.com/waku-org/go-waku v0.8.1-0.20240322182925-dd81e1d46971
 ## explicit; go 1.19
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/waku/persistence


### PR DESCRIPTION
The ENR used in discoveryV5 was not updated with the real port number if port 0 was used