### PR TITLE
refactor(api)_: removal / replacement of deprecated and obsolete funcs

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -5,6 +5,7 @@ import (
 
 	signercore "github.com/ethereum/go-ethereum/signer/core/apitypes"
 
+	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/accounts"
@@ -17,22 +18,20 @@ import (
 
 // StatusBackend defines the contract for the Status.im service
 type StatusBackend interface {
-	// IsNodeRunning() bool                       // NOTE: Only used in tests
-	StartNode(config *params.NodeConfig) error
+	StartNode(config *params.NodeConfig) error // NOTE: Only used in canary
 	StartNodeWithKey(acc multiaccounts.Account, password string, keyHex string, conf *params.NodeConfig) error
 	StartNodeWithAccount(acc multiaccounts.Account, password string, conf *params.NodeConfig, chatKey *ecdsa.PrivateKey) error
 	StartNodeWithAccountAndInitialConfig(account multiaccounts.Account, password string, settings settings.Settings, conf *params.NodeConfig, subaccs []*accounts.Account, chatKey *ecdsa.PrivateKey) error
 	StopNode() error
-	// RestartNode() error // NOTE: Only used in tests
 
 	GetNodeConfig() (*params.NodeConfig, error)
 	UpdateRootDataDir(datadir string)
 
-	// SelectAccount(loginParams account.LoginParams) error
+	SelectAccount(loginParams account.LoginParams) error
 	OpenAccounts() error
 	GetAccounts() ([]multiaccounts.Account, error)
 	LocalPairingStarted() error
-	// SaveAccount(account multiaccounts.Account) error
+	SaveAccount(account multiaccounts.Account) error
 	SaveAccountAndStartNodeWithKey(acc multiaccounts.Account, password string, settings settings.Settings, conf *params.NodeConfig, subaccs []*accounts.Account, keyHex string) error
 	Recover(rpcParams personal.RecoverParams) (types.Address, error)
 	Logout() error

--- a/api/backend.go
+++ b/api/backend.go
@@ -5,7 +5,6 @@ import (
 
 	signercore "github.com/ethereum/go-ethereum/signer/core/apitypes"
 
-	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/accounts"
@@ -27,7 +26,7 @@ type StatusBackend interface {
 	GetNodeConfig() (*params.NodeConfig, error)
 	UpdateRootDataDir(datadir string)
 
-	SelectAccount(loginParams account.LoginParams) error
+	SelectAccount(loginParams LoginParams) error
 	OpenAccounts() error
 	GetAccounts() ([]multiaccounts.Account, error)
 	LocalPairingStarted() error

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/brianvoe/gofakeit/v6"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+
 	accsmanagement "github.com/status-im/status-go/accounts-management"
 	accscommon "github.com/status-im/status-go/accounts-management/common"
 	"github.com/status-im/status-go/accounts-management/generator"
@@ -924,8 +925,8 @@ func TestLoginAccount(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, accs, 1)
 
-	require.NotEmpty(t, accounts[0].KeyUID)
-	require.Equal(t, acc.KeyUID, accounts[0].KeyUID)
+	require.NotEmpty(t, accs[0].KeyUID)
+	require.Equal(t, acc.KeyUID, accs[0].KeyUID)
 
 	loginAccountRequest := &requests.Login{
 		KeyUID:           accs[0].KeyUID,

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -83,7 +82,7 @@ func setupTestWalletDB() (*sql.DB, func() error, error) {
 }
 
 func setupTestMultiDB() (*multiaccounts.Database, func() error, error) {
-	tmpfile, err := ioutil.TempFile("", "tests")
+	tmpfile, err := os.CreateTemp("", "tests")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,6 +132,12 @@ func setKeystore(accManager *accsmanagement.AccountsManager, keyStoreDir string)
 	}
 	accManager.SetKeystore(keystoreAdapter)
 	return nil
+}
+
+func handleError(t *testing.T, err error) {
+	if err != nil {
+		t.Logf("deferred function error: '%s'", err)
+	}
 }
 
 func TestBackendStartNodeConcurrently(t *testing.T) {
@@ -652,7 +657,7 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 			Name:   "private key keypair",
 			Type:   accounts.KeypairTypeKey,
 			Accounts: []*accounts.Account{
-				&accounts.Account{
+				{
 					Address: address,
 					KeyUID:  keyUID,
 				},
@@ -686,7 +691,7 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 			Name:   "profile keypair",
 			Type:   accounts.KeypairTypeProfile,
 			Accounts: []*accounts.Account{
-				&accounts.Account{
+				{
 					Address:   types.HexToAddress(derivedInfo.Address),
 					KeyUID:    walletInfo.KeyUID,
 					Type:      accounts.AccountTypeGenerated,
@@ -715,7 +720,7 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 
 		db, err := accounts.NewDB(backend.appDB)
 		require.NoError(t, err)
-		defer db.Close()
+		defer handleError(t, db.Close())
 
 		_, err = backend.AccountManager().CreateFromPrivateKeyAndStoreAccount(privateKeyHex, password)
 		require.NoError(t, err)
@@ -725,7 +730,7 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 			Name:   "private key keypair",
 			Type:   accounts.KeypairTypeKey,
 			Accounts: []*accounts.Account{
-				&accounts.Account{
+				{
 					Address: address,
 					KeyUID:  keyUID,
 				},
@@ -754,7 +759,7 @@ func TestRuntimeLogLevelIsNotWrittenToDatabase(t *testing.T) {
 
 	tmpdir := t.TempDir()
 
-	json := `{
+	config := `{
 		"NetworkId": 3,
 		"DataDir": "` + tmpdir + `",
 		"KeyStoreDir": "` + tmpdir + `",
@@ -770,7 +775,7 @@ func TestRuntimeLogLevelIsNotWrittenToDatabase(t *testing.T) {
 		"LogLevel": "DEBUG"
 	}`
 
-	conf, err := params.NewConfigFromJSON(json)
+	conf, err := params.NewConfigFromJSON(config)
 	require.NoError(t, err)
 	require.Equal(t, "INFO", conf.RuntimeLogLevel)
 	keyhex := hex.EncodeToString(gethcrypto.FromECDSA(chatKey))
@@ -783,12 +788,12 @@ func TestRuntimeLogLevelIsNotWrittenToDatabase(t *testing.T) {
 
 	address := crypto.PubkeyToAddress(walletKey.PublicKey)
 
-	settings := testSettings
-	settings.KeyUID = keyUID
-	settings.Address = crypto.PubkeyToAddress(walletKey.PublicKey)
+	s := testSettings
+	s.KeyUID = keyUID
+	s.Address = crypto.PubkeyToAddress(walletKey.PublicKey)
 
 	chatPubKey := crypto.FromECDSAPub(&chatKey.PublicKey)
-	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", settings, conf,
+	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", s, conf,
 		[]*accounts.Account{
 			{Address: address, KeyUID: keyUID, Wallet: true},
 			{Address: crypto.PubkeyToAddress(chatKey.PublicKey), KeyUID: keyUID, Chat: true, PublicKey: chatPubKey}}, keyhex))
@@ -834,12 +839,12 @@ func TestLoginWithKey(t *testing.T) {
 
 	address := crypto.PubkeyToAddress(walletKey.PublicKey)
 
-	settings := testSettings
-	settings.KeyUID = keyUID
-	settings.Address = crypto.PubkeyToAddress(walletKey.PublicKey)
+	s := testSettings
+	s.KeyUID = keyUID
+	s.Address = crypto.PubkeyToAddress(walletKey.PublicKey)
 
 	chatPubKey := crypto.FromECDSAPub(&chatKey.PublicKey)
-	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", settings, conf,
+	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", s, conf,
 		[]*accounts.Account{
 			{Address: address, KeyUID: keyUID, Wallet: true},
 			{Address: crypto.PubkeyToAddress(chatKey.PublicKey), KeyUID: keyUID, Chat: true, PublicKey: chatPubKey}}, keyhex))
@@ -915,15 +920,15 @@ func TestLoginAccount(t *testing.T) {
 	require.NoError(t, b.Logout())
 	require.NoError(t, b.StopNode())
 
-	accounts, err := b.GetAccounts()
+	accs, err := b.GetAccounts()
 	require.NoError(t, err)
-	require.Len(t, accounts, 1)
+	require.Len(t, accs, 1)
 
 	require.NotEmpty(t, accounts[0].KeyUID)
 	require.Equal(t, acc.KeyUID, accounts[0].KeyUID)
 
 	loginAccountRequest := &requests.Login{
-		KeyUID:           accounts[0].KeyUID,
+		KeyUID:           accs[0].KeyUID,
 		Password:         password,
 		WakuV2Nameserver: nameserver,
 	}
@@ -960,13 +965,13 @@ func TestVerifyDatabasePassword(t *testing.T) {
 
 	address := crypto.PubkeyToAddress(walletKey.PublicKey)
 
-	settings := testSettings
-	settings.KeyUID = keyUID
-	settings.Address = crypto.PubkeyToAddress(walletKey.PublicKey)
+	s := testSettings
+	s.KeyUID = keyUID
+	s.Address = crypto.PubkeyToAddress(walletKey.PublicKey)
 
 	chatPubKey := crypto.FromECDSAPub(&chatKey.PublicKey)
 
-	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", settings, conf, []*accounts.Account{
+	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", s, conf, []*accounts.Account{
 		{Address: address, KeyUID: keyUID, Wallet: true},
 		{Address: crypto.PubkeyToAddress(chatKey.PublicKey), KeyUID: keyUID, Chat: true, PublicKey: chatPubKey}}, keyhex))
 	require.NoError(t, b.Logout())
@@ -1044,14 +1049,14 @@ func TestDeleteMultiaccount(t *testing.T) {
 	err = backend.SaveAccount(account)
 	require.NoError(t, err)
 
-	files, err := ioutil.ReadDir(rootDataDir)
+	files, err := os.ReadDir(rootDataDir)
 	require.NoError(t, err)
 	require.NotEqual(t, 3, len(files))
 
 	err = backend.DeleteMultiaccount(account.KeyUID, keyStoreDir)
 	require.NoError(t, err)
 
-	files, err = ioutil.ReadDir(rootDataDir)
+	files, err = os.ReadDir(rootDataDir)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(files))
 }
@@ -1204,13 +1209,13 @@ func TestConvertAccount(t *testing.T) {
 
 	err = backend.StartNodeWithAccountAndInitialConfig(account, password, *defaultSettings, nodeConfig, profileKeypair.Accounts, nil)
 	require.NoError(t, err)
-	multiaccounts, err := backend.GetAccounts()
+	multiaccs, err := backend.GetAccounts()
 	require.NoError(t, err)
-	require.NotEmpty(t, multiaccounts[0].ColorHash)
+	require.NotEmpty(t, multiaccs[0].ColorHash)
 	serverMessenger := backend.Messenger()
 	require.NotNil(t, serverMessenger)
 
-	files, err := ioutil.ReadDir(rootDataDir)
+	files, err := os.ReadDir(rootDataDir)
 	require.NoError(t, err)
 	require.NotEqual(t, 3, len(files))
 
@@ -1309,19 +1314,19 @@ func TestConvertAccount(t *testing.T) {
 }
 
 func copyFile(srcFolder string, dstFolder string, fileName string, t *testing.T) {
-	data, err := ioutil.ReadFile(path.Join(srcFolder, fileName))
+	data, err := os.ReadFile(path.Join(srcFolder, fileName))
 	if err != nil {
 		t.Fail()
 	}
 
-	err = ioutil.WriteFile(path.Join(dstFolder, fileName), data, 0600)
+	err = os.WriteFile(path.Join(dstFolder, fileName), data, 0600)
 	if err != nil {
 		t.Fail()
 	}
 }
 
 func copyDir(srcFolder string, dstFolder string, t *testing.T) {
-	files, err := ioutil.ReadDir(srcFolder)
+	files, err := os.ReadDir(srcFolder)
 	require.NoError(t, err)
 	for _, file := range files {
 		if !file.IsDir() {
@@ -1354,18 +1359,18 @@ func loginDesktopUser(t *testing.T, conf *params.NodeConfig) {
 
 	require.NoError(t, b.OpenAccounts())
 
-	accounts, err := b.GetAccounts()
+	accs, err := b.GetAccounts()
 	require.NoError(t, err)
 
-	require.Len(t, accounts, 1)
-	require.Equal(t, username, accounts[0].Name)
-	require.Equal(t, keyUID, accounts[0].KeyUID)
+	require.Len(t, accs, 1)
+	require.Equal(t, username, accs[0].Name)
+	require.Equal(t, keyUID, accs[0].KeyUID)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := b.StartNodeWithAccount(accounts[0], passwd, conf, nil)
+		err := b.StartNodeWithAccount(accs[0], passwd, conf, nil)
 		require.NoError(t, err)
 	}()
 
@@ -1507,13 +1512,13 @@ func TestChangeDatabasePassword(t *testing.T) {
 	require.NoError(t, err)
 	appDb, err := sqlite.OpenDB(appDbPath, newPassword, account.KDFIterations)
 	require.NoError(t, err)
-	appDb.Close()
+	defer handleError(t, appDb.Close())
 
 	walletDbPath, err := backend.getWalletDBPath(account.KeyUID)
 	require.NoError(t, err)
 	walletDb, err := sqlite.OpenDB(walletDbPath, newPassword, account.KDFIterations)
 	require.NoError(t, err)
-	walletDb.Close()
+	defer handleError(t, walletDb.Close())
 
 	// Test that keystore can be decrypted with the new password
 	acc, err := backend.accountManager.LoadAccount(genAccount.Address(), newPassword)

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -721,7 +721,9 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 
 		db, err := accounts.NewDB(backend.appDB)
 		require.NoError(t, err)
-		defer handleError(t, db.Close())
+		defer func() {
+			handleError(t, db.Close())
+		}()
 
 		_, err = backend.AccountManager().CreateFromPrivateKeyAndStoreAccount(privateKeyHex, password)
 		require.NoError(t, err)
@@ -1513,13 +1515,17 @@ func TestChangeDatabasePassword(t *testing.T) {
 	require.NoError(t, err)
 	appDb, err := sqlite.OpenDB(appDbPath, newPassword, account.KDFIterations)
 	require.NoError(t, err)
-	defer handleError(t, appDb.Close())
+	defer func() {
+		handleError(t, appDb.Close())
+	}()
 
 	walletDbPath, err := backend.getWalletDBPath(account.KeyUID)
 	require.NoError(t, err)
 	walletDb, err := sqlite.OpenDB(walletDbPath, newPassword, account.KDFIterations)
 	require.NoError(t, err)
-	defer handleError(t, walletDb.Close())
+	defer func() {
+		handleError(t, walletDb.Close())
+	}()
 
 	// Test that keystore can be decrypted with the new password
 	acc, err := backend.accountManager.LoadAccount(genAccount.Address(), newPassword)

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -71,10 +71,6 @@ import (
 )
 
 var (
-	// ErrWhisperClearIdentitiesFailure clearing whisper identities has failed.
-	ErrWhisperClearIdentitiesFailure = errors.New("failed to clear whisper identities")
-	// ErrWhisperIdentityInjectionFailure injecting whisper identities has failed.
-	ErrWhisperIdentityInjectionFailure = errors.New("failed to inject identity into Whisper")
 	// ErrWakuIdentityInjectionFailure injecting whisper identities has failed.
 	ErrWakuIdentityInjectionFailure = errors.New("failed to inject identity into waku")
 	// ErrUnsupportedRPCMethod is for methods not supported by the RPC interface
@@ -971,12 +967,12 @@ func (b *GethStatusBackend) GetSettings() (*settings.Settings, error) {
 		return nil, err
 	}
 
-	settings, err := accountsDB.GetSettings()
+	s, err := accountsDB.GetSettings()
 	if err != nil {
 		return nil, err
 	}
 
-	return &settings, nil
+	return &s, nil
 }
 
 func (b *GethStatusBackend) GetEnsUsernames() ([]*ens.UsernameDetail, error) {
@@ -1007,11 +1003,11 @@ func (b *GethStatusBackend) LoggedIn(keyUID string, err error) error {
 		signal.SendLoggedIn(nil, nil, nil, err)
 		return err
 	}
-	settings, err := b.GetSettings()
+	s, err := b.GetSettings()
 	if err != nil {
 		return err
 	}
-	account, err := b.getAccountByKeyUID(keyUID)
+	acc, err := b.getAccountByKeyUID(keyUID)
 	if err != nil {
 		return err
 	}
@@ -1027,7 +1023,7 @@ func (b *GethStatusBackend) LoggedIn(keyUID string, err error) error {
 			return err
 		}
 	}
-	signal.SendLoggedIn(account, settings, ensUsernamesJSON, nil)
+	signal.SendLoggedIn(acc, s, ensUsernamesJSON, nil)
 	return nil
 }
 
@@ -1083,7 +1079,7 @@ func (b *GethStatusBackend) reEncryptKeyStoreDir(currentPassword string, newPass
 }
 
 func (b *GethStatusBackend) ChangeDatabasePassword(keyUID string, password string, newPassword string) error {
-	account, err := b.multiaccountsDB.GetAccount(keyUID)
+	acc, err := b.multiaccountsDB.GetAccount(keyUID)
 	if err != nil {
 		return err
 	}
@@ -1120,7 +1116,7 @@ func (b *GethStatusBackend) ChangeDatabasePassword(keyUID string, password strin
 			// because UI calls Logout and Quit afterwards. It should not be UI-dependent
 			// and should be handled gracefully here if it makes sense to run dummy node after
 			// logout
-			err = b.startNodeWithAccount(*account, pass, b.config, nil)
+			err = b.startNodeWithAccount(*acc, pass, b.config, nil)
 			if err != nil {
 				b.logger.Error("failed to start node", zap.Error(err))
 				return
@@ -1139,16 +1135,16 @@ func (b *GethStatusBackend) ChangeDatabasePassword(keyUID string, password strin
 	// First change app DB password, because it also reencrypts the keystore,
 	// otherwise if we call changeWalletDbPassword first and logout, we will fail
 	// to reencrypt	the keystore
-	err = b.changeAppDBPassword(account, logout, password, newPassword)
+	err = b.changeAppDBPassword(acc, logout, password, newPassword)
 	if err != nil {
 		return err
 	}
 
 	// Already logged out but pass a param to decouple the logic for testing
-	err = b.changeWalletDBPassword(account, noLogout, password, newPassword)
+	err = b.changeWalletDBPassword(acc, noLogout, password, newPassword)
 	if err != nil {
 		// Revert the password to original
-		err2 := b.changeAppDBPassword(account, noLogout, newPassword, password)
+		err2 := b.changeAppDBPassword(acc, noLogout, newPassword, password)
 		if err2 != nil {
 			b.logger.Error("failed to revert app db password", zap.Error(err2))
 		}
@@ -1335,7 +1331,7 @@ func (b *GethStatusBackend) ConvertToKeycardAccount(account multiaccounts.Accoun
 		return err
 	}
 
-	// This check is added due to mobile app cause it doesn't support a Keycard features as desktop app.
+	// This check is added due to mobile app because it doesn't support a Keycard features as desktop app.
 	// We should remove the following line once mobile and desktop app align.
 	if len(keycardUID) > 0 {
 		displayName, err := accountDB.DisplayName()
@@ -1741,7 +1737,7 @@ func (b *GethStatusBackend) buildAccount(request *requests.CreateAccount, input 
 }
 
 func (b *GethStatusBackend) prepareSettings(request *requests.CreateAccount, input *prepareAccountInput) (*settings.Settings, error) {
-	settings, err := defaultSettings(input.keyUID, input.address, input.derivedAddresses)
+	s, err := defaultSettings(input.keyUID, input.address, input.derivedAddresses)
 	if err != nil {
 		return nil, err
 	}
@@ -1756,7 +1752,7 @@ func (b *GethStatusBackend) prepareSettings(request *requests.CreateAccount, inp
 		settings.Mnemonic = &input.mnemonic
 		// TODO(rasom): uncomment it as soon as address will be properly
 		// marked as shown on mobile client
-		//settings.MnemonicWasNotShown = true
+		//s.MnemonicWasNotShown = true
 	}
 
 	if !input.fetchBackup {
@@ -1980,7 +1976,7 @@ func (b *GethStatusBackend) VerifyDatabasePassword(keyUID string, password strin
 	}
 
 	if !b.appDBExists(keyUID) || !b.walletDBExists(keyUID) {
-		return errors.New("One or more databases not created")
+		return errors.New("one or more databases not created")
 	}
 
 	err = b.ensureDBsOpened(multiaccounts.Account{KeyUID: keyUID, KDFIterations: kdfIterations}, password)
@@ -2130,7 +2126,7 @@ func (b *GethStatusBackend) saveAccountsAndSettings(settings settings.Settings, 
 		LastUsedDerivationIndex: 0,
 	}
 
-	// When creating a new account, the chat account should have position -1, cause it doesn't participate
+	// When creating a new account, the chat account should have position -1, because it doesn't participate
 	// in the wallet view and default wallet account should be at position 0.
 	for _, acc := range subaccs {
 		if acc.Chat {
@@ -2391,26 +2387,26 @@ func (b *GethStatusBackend) Recover(rpcParams personal.RecoverParams) (types.Add
 
 // SignTypedData accepts data and password. Gets verified account and signs typed data.
 func (b *GethStatusBackend) SignTypedData(typed typeddata.TypedData, address string, password string) (types.HexBytes, error) {
-	account, err := b.getVerifiedWalletAccount(address, password)
+	acc, err := b.getVerifiedWalletAccount(address, password)
 	if err != nil {
 		return types.HexBytes{}, err
 	}
 	chain := new(big.Int).SetUint64(b.StatusNode().Config().NetworkID)
-	sig, err := typeddata.Sign(typed, account.PrivateKey(), chain)
+	sig, err := typeddata.Sign(typed, acc.PrivateKey(), chain)
 	if err != nil {
 		return types.HexBytes{}, err
 	}
-	return types.HexBytes(sig), err
+	return sig, err
 }
 
 // SignTypedDataV4 accepts data and password. Gets verified account and signs typed data.
 func (b *GethStatusBackend) SignTypedDataV4(typed signercore.TypedData, address string, password string) (types.HexBytes, error) {
-	account, err := b.getVerifiedWalletAccount(address, password)
+	acc, err := b.getVerifiedWalletAccount(address, password)
 	if err != nil {
 		return types.HexBytes{}, err
 	}
 	chain := new(big.Int).SetUint64(b.StatusNode().Config().NetworkID)
-	sig, err := typeddata.SignTypedDataV4(typed, account.PrivateKey(), chain)
+	sig, err := typeddata.SignTypedDataV4(typed, acc.PrivateKey(), chain)
 	if err != nil {
 		return types.HexBytes{}, err
 	}
@@ -2471,7 +2467,7 @@ func (b *GethStatusBackend) registerHandlers() error {
 	return nil
 }
 
-func unsupportedMethodHandler(ctx context.Context, chainID uint64, rpcParams ...interface{}) (interface{}, error) {
+func unsupportedMethodHandler(_ context.Context, _ uint64, _ ...interface{}) (interface{}, error) {
 	return nil, ErrUnsupportedRPCMethod
 }
 
@@ -2609,7 +2605,7 @@ func (b *GethStatusBackend) switchToPreLoginLog() error {
 	return logutils.OverrideRootLoggerWithConfig(b.preLoginLogConfig.ConvertToLogSettings())
 }
 
-// cleanupServices stops parts of services that doesn't managed by a node and removes injected data from services.
+// cleanupServices stops parts of services that aren't managed by a node and removes injected data from services.
 func (b *GethStatusBackend) cleanupServices() error {
 	b.selectedAccountKeyID = ""
 	if b.statusNode == nil {
@@ -2786,9 +2782,9 @@ func (b *GethStatusBackend) SignGroupMembership(content string) (string, error) 
 }
 
 func (b *GethStatusBackend) Messenger() *protocol.Messenger {
-	node := b.StatusNode()
-	if node != nil {
-		accountService := node.AccountService()
+	statusNode := b.StatusNode()
+	if statusNode != nil {
+		accountService := statusNode.AccountService()
 		if accountService != nil {
 			return accountService.GetMessenger()
 		}

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -26,6 +26,7 @@ import (
 	signercore "github.com/ethereum/go-ethereum/signer/core/apitypes"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+
 	accsmanagement "github.com/status-im/status-go/accounts-management"
 	accscommon "github.com/status-im/status-go/accounts-management/common"
 	"github.com/status-im/status-go/accounts-management/generator"
@@ -1742,29 +1743,29 @@ func (b *GethStatusBackend) prepareSettings(request *requests.CreateAccount, inp
 		return nil, err
 	}
 
-	settings.DeviceName = request.DeviceName
-	settings.DisplayName = request.DisplayName
-	settings.PreviewPrivacy = request.PreviewPrivacy
-	settings.CurrentNetwork = request.CurrentNetwork
-	settings.TestNetworksEnabled = request.TestNetworksEnabled
-	settings.AutoRefreshTokensEnabled = request.AutoRefreshTokensEnabled
+	s.DeviceName = request.DeviceName
+	s.DisplayName = request.DisplayName
+	s.PreviewPrivacy = request.PreviewPrivacy
+	s.CurrentNetwork = request.CurrentNetwork
+	s.TestNetworksEnabled = request.TestNetworksEnabled
+	s.AutoRefreshTokensEnabled = request.AutoRefreshTokensEnabled
 	if !input.restoringAccount {
-		settings.Mnemonic = &input.mnemonic
+		s.Mnemonic = &input.mnemonic
 		// TODO(rasom): uncomment it as soon as address will be properly
 		// marked as shown on mobile client
 		//s.MnemonicWasNotShown = true
 	}
 
 	if !input.fetchBackup {
-		// This is a an account created from scratch, we can mark the BackupFetched as true
-		settings.BackupFetched = true
+		// This is an account created from scratch, we can mark the BackupFetched as true
+		s.BackupFetched = true
 	}
 
 	if request.WakuV2Fleet != "" {
-		settings.Fleet = &request.WakuV2Fleet
+		s.Fleet = &request.WakuV2Fleet
 	}
 
-	return settings, nil
+	return s, nil
 }
 
 func (b *GethStatusBackend) prepareConfig(request *requests.CreateAccount, input *prepareAccountInput, installationID string) (*params.NodeConfig, error) {


### PR DESCRIPTION
I've resolved a number of refactor issues in the `api` package.

- `backend` : Updated the `StatusBackend` interface to match usage
- `backend_test` : Resolved unhandled errors, import collisions and upgraded deprecated funcs
- `eth_backend` : resolved import collisions