### PR TITLE
chore(wallet) remove unused multi-transaction-update event

### DIFF
--- a/services/wallet/transfer/transaction_manager.go
+++ b/services/wallet/transfer/transaction_manager.go
@@ -17,13 +17,7 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/wallet/bridge"
 	wallet_common "github.com/status-im/status-go/services/wallet/common"
-	"github.com/status-im/status-go/services/wallet/walletevent"
 	"github.com/status-im/status-go/transactions"
-)
-
-const (
-	// EventMTTransactionUpdate is emitted when a multi-transaction is updated (added or deleted)
-	EventMTTransactionUpdate walletevent.EventType = "multi-transaction-update"
 )
 
 type SignatureDetails struct {


### PR DESCRIPTION
A leftover after migrating to incremental activity updates session-based We now use pending instead of `multi-transaction-update`, there is no multi-transaction update without an equivalent pending or transfer update