### PR TITLE
fix: validate community events read from database

### DIFF
--- a/protocol/communities/community_events_processing.go
+++ b/protocol/communities/community_events_processing.go
@@ -88,7 +88,8 @@ func (e *eventsProcessor) validateEvent(event *CommunityEvent) error {
 
 // Filter invalid and outdated events.
 func (e *eventsProcessor) filterEvents() {
-	for _, event := range e.message.Events {
+	for _, ev := range e.message.Events {
+		event := ev
 		if err := e.validateEvent(&event); err == nil {
 			e.eventsToApply = append(e.eventsToApply, event)
 		} else {
@@ -100,7 +101,8 @@ func (e *eventsProcessor) filterEvents() {
 // Merge message's events with community's events.
 func (e *eventsProcessor) mergeEvents() {
 	if e.community.config.EventsData != nil {
-		for _, event := range e.community.config.EventsData.Events {
+		for _, ev := range e.community.config.EventsData.Events {
+			event := ev
 			if err := e.validateEvent(&event); err == nil {
 				e.eventsToApply = append(e.eventsToApply, event)
 			} else {


### PR DESCRIPTION
Despite the expectation that only validated events are stored in the database, instances have been identified where invalid events are saved. This can lead to unexpected behavior or crashes.

This commit adds validation for community events read from the database to prevent such cases.

**NOTE**: this fix does not address the root cause, which involves invalid events being saved to the database. The exact scenario leading to this issue has yet to be identified.

mitigates: status-im/status-desktop#14106
