### PR TITLE
chore: extend tests timeout

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -161,4 +161,4 @@ def getDefaultUnitTestUseDevelopmentLogger() { isTestNightlyJob() ? false : true
 
 def getDefaultUnitTestFailfast() { isTestNightlyJob() ? false : true }
 
-def getDefaultTimeout() { isTestNightlyJob() ? 5*60 : 40 }
+def getDefaultTimeout() { isTestNightlyJob() ? 5*60 : 50 }


### PR DESCRIPTION
Due to an increased volume of tests, numerous test jobs have been timing out. The timeout has been extended by 10 minutes.
