### PR TITLE
Fix/community tags indices

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -460,7 +460,7 @@ func (o *Community) Tags() []CommunityTag {
 	for _, t := range o.config.CommunityDescription.Tags {
 		result = append(result, CommunityTag{
 			Name:  t,
-			Emoji: requests.TagsEmojis[t],
+			Emoji: requests.TagEmoji(t),
 		})
 	}
 	return result
@@ -473,7 +473,7 @@ func (o *Community) TagsRaw() []string {
 func (o *Community) TagsIndices() []uint32 {
 	var indices []uint32
 	for _, t := range o.config.CommunityDescription.Tags {
-		indices = append(indices, requests.TagsIndices[t])
+		indices = append(indices, requests.TagIndex(t))
 	}
 	return indices
 }

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -450,19 +450,20 @@ func (o *Community) CommunityTokensMetadata() []*protobuf.CommunityTokenMetadata
 }
 
 func (o *Community) Tags() []CommunityTag {
-	if o != nil &&
-		o.config != nil &&
-		o.config.CommunityDescription != nil {
-		var result []CommunityTag
-		for _, t := range o.config.CommunityDescription.Tags {
-			result = append(result, CommunityTag{
-				Name:  t,
-				Emoji: requests.TagsEmojies[t],
-			})
-		}
-		return result
+	if o == nil ||
+		o.config == nil ||
+		o.config.CommunityDescription == nil {
+		return nil
 	}
-	return nil
+
+	result := make([]CommunityTag, 0, len(o.config.CommunityDescription.Tags))
+	for _, t := range o.config.CommunityDescription.Tags {
+		result = append(result, CommunityTag{
+			Name:  t,
+			Emoji: requests.TagsEmojis[t],
+		})
+	}
+	return result
 }
 
 func (o *Community) TagsRaw() []string {
@@ -470,17 +471,10 @@ func (o *Community) TagsRaw() []string {
 }
 
 func (o *Community) TagsIndices() []uint32 {
-	indices := []uint32{}
+	var indices []uint32
 	for _, t := range o.config.CommunityDescription.Tags {
-		i := uint32(0)
-		for k := range requests.TagsEmojies {
-			if k == t {
-				indices = append(indices, i)
-			}
-			i++
-		}
+		indices = append(indices, requests.TagsIndices[t])
 	}
-
 	return indices
 }
 

--- a/protocol/messenger_share_urls_test.go
+++ b/protocol/messenger_share_urls_test.go
@@ -41,6 +41,7 @@ func (s *MessengerShareUrlsSuite) createCommunity() *communities.Community {
 		Name:        "status",
 		Color:       "#ffffff",
 		Description: "status community description",
+		Tags:        RandomCommunityTags(3),
 	}
 
 	// Create an community chat
@@ -245,6 +246,13 @@ func (s *MessengerShareUrlsSuite) TestShareCommunityURLWithData() {
 
 	expectedURL := fmt.Sprintf("%s/c/%s#%s", baseShareURL, communityData, chatKey)
 	s.Require().Equal(expectedURL, url)
+
+	response, err := ParseSharedURL(url)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+	s.Require().NotNil(response.Community)
+	s.Require().Equal(community.IDString(), response.Community.CommunityID)
+	s.Require().Equal(community.TagsIndices(), response.Community.TagIndices)
 }
 
 func (s *MessengerShareUrlsSuite) TestParseCommunityURLWithData() {

--- a/protocol/messenger_share_urls_test.go
+++ b/protocol/messenger_share_urls_test.go
@@ -44,7 +44,7 @@ func (s *MessengerShareUrlsSuite) createCommunity() *communities.Community {
 		Tags:        RandomCommunityTags(3),
 	}
 
-	// Create an community chat
+	// Create a community chat
 	response, err := s.m.CreateCommunity(description, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	mathRand "math/rand"
 	"sync"
 	"time"
 
@@ -390,19 +391,19 @@ func RandomColor() string {
 
 func RandomCommunityTags(count int) []string {
 	availableTagsCount := requests.AvailableTagsCount()
-	tags := make([]string, 0, count)
-	indexes := map[int]struct{}{}
 
-	for len(indexes) != count {
-		index := randomInt(availableTagsCount)
-		indexes[index] = struct{}{}
+	if count > availableTagsCount {
+		count = availableTagsCount
 	}
 
-	for index := range indexes {
-		tags = append(tags, requests.TagByIndex(index))
+	//source := mathRand.New(mathRand.NewSource(time.Now().UnixNano()))
+	indices := mathRand.Perm(availableTagsCount)
+	shuffled := make([]string, count)
+	for i := 0; i < count; i++ {
+		shuffled[i] = requests.TagByIndex(uint32(indices[i]))
 	}
 
-	return tags
+	return shuffled
 }
 
 func RandomBytes(length int) []byte {

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -389,17 +389,17 @@ func RandomColor() string {
 }
 
 func RandomCommunityTags(count int) []string {
-	all := requests.Tags
+	availableTagsCount := requests.AvailableTagsCount()
 	tags := make([]string, 0, count)
 	indexes := map[int]struct{}{}
 
 	for len(indexes) != count {
-		index := randomInt(len(all))
+		index := randomInt(availableTagsCount)
 		indexes[index] = struct{}{}
 	}
 
 	for index := range indexes {
-		tags = append(tags, all[index])
+		tags = append(tags, requests.TagByIndex(index))
 	}
 
 	return tags

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -16,8 +16,6 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 	waku2 "github.com/status-im/status-go/wakuv2"
 
-	"golang.org/x/exp/maps"
-
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/protocol/common"
@@ -391,7 +389,7 @@ func RandomColor() string {
 }
 
 func RandomCommunityTags(count int) []string {
-	all := maps.Keys(requests.TagsEmojies)
+	all := requests.Tags
 	tags := make([]string, 0, count)
 	indexes := map[int]struct{}{}
 

--- a/protocol/requests/community_tags.go
+++ b/protocol/requests/community_tags.go
@@ -1,66 +1,79 @@
 package requests
 
-var TagsEmojies map[string]string
+var Tags []string
+var TagsEmojis map[string]string
+var TagsIndices map[string]uint32
 
 func init() {
-	TagsEmojies = make(map[string]string)
-	TagsEmojies["Activism"] = "✊"
-	TagsEmojies["Art"] = "🎨"
-	TagsEmojies["Blockchain"] = "🔗"
-	TagsEmojies["Books & blogs"] = "📚"
-	TagsEmojies["Career"] = "💼"
-	TagsEmojies["Collaboration"] = "🤝"
-	TagsEmojies["Commerce"] = "🛒"
-	TagsEmojies["Culture"] = "🎎"
-	TagsEmojies["DAO"] = "🚀"
-	TagsEmojies["DeFi"] = "📈"
-	TagsEmojies["Design"] = "🧩"
-	TagsEmojies["DIY"] = "🔨"
-	TagsEmojies["Environment"] = "🌿"
-	TagsEmojies["Education"] = "🎒"
-	TagsEmojies["Entertainment"] = "🍿"
-	TagsEmojies["Ethereum"] = "Ξ"
-	TagsEmojies["Event"] = "🗓"
-	TagsEmojies["Fantasy"] = "🧙‍♂️"
-	TagsEmojies["Fashion"] = "🧦"
-	TagsEmojies["Food"] = "🌶"
-	TagsEmojies["Gaming"] = "🎮"
-	TagsEmojies["Global"] = "🌍"
-	TagsEmojies["Health"] = "🧠"
-	TagsEmojies["Hobby"] = "📐"
-	TagsEmojies["Innovation"] = "🧪"
-	TagsEmojies["Language"] = "📜"
-	TagsEmojies["Lifestyle"] = "✨"
-	TagsEmojies["Local"] = "📍"
-	TagsEmojies["Love"] = "❤️"
-	TagsEmojies["Markets"] = "💎"
-	TagsEmojies["Movies & TV"] = "🎞"
-	TagsEmojies["Music"] = "🎶"
-	TagsEmojies["News"] = "🗞"
-	TagsEmojies["NFT"] = "🖼"
-	TagsEmojies["Non-profit"] = "🙏"
-	TagsEmojies["NSFW"] = "🍆"
-	TagsEmojies["Org"] = "🏢"
-	TagsEmojies["Pets"] = "🐶"
-	TagsEmojies["Play"] = "🎲"
-	TagsEmojies["Podcast"] = "🎙️"
-	TagsEmojies["Politics"] = "🗳️"
-	TagsEmojies["Product"] = "🍱"
-	TagsEmojies["Psyche"] = "🍁"
-	TagsEmojies["Privacy"] = "👻"
-	TagsEmojies["Security"] = "🔒"
-	TagsEmojies["Social"] = "☕"
-	TagsEmojies["Software dev"] = "👩‍💻"
-	TagsEmojies["Sports"] = "⚽️"
-	TagsEmojies["Tech"] = "📱"
-	TagsEmojies["Travel"] = "🗺"
-	TagsEmojies["Vehicles"] = "🚕"
-	TagsEmojies["Web3"] = "🌐"
+	orderedInput := [][]string{
+		{"Activism", "✊"},
+		{"Art", "🎨"},
+		{"Blockchain", "🔗"},
+		{"Books & blogs", "📚"},
+		{"Career", "💼"},
+		{"Collaboration", "🤝"},
+		{"Commerce", "🛒"},
+		{"Culture", "🎎"},
+		{"DAO", "🚀"},
+		{"DeFi", "📈"},
+		{"Design", "🧩"},
+		{"DIY", "🔨"},
+		{"Environment", "🌿"},
+		{"Education", "🎒"},
+		{"Entertainment", "🍿"},
+		{"Ethereum", "Ξ"},
+		{"Event", "🗓"},
+		{"Fantasy", "🧙‍♂️"},
+		{"Fashion", "🧦"},
+		{"Food", "🌶"},
+		{"Gaming", "🎮"},
+		{"Global", "🌍"},
+		{"Health", "🧠"},
+		{"Hobby", "📐"},
+		{"Innovation", "🧪"},
+		{"Language", "📜"},
+		{"Lifestyle", "✨"},
+		{"Local", "📍"},
+		{"Love", "❤️"},
+		{"Markets", "💎"},
+		{"Movies & TV", "🎞"},
+		{"Music", "🎶"},
+		{"News", "🗞"},
+		{"NFT", "🖼"},
+		{"Non-profit", "🙏"},
+		{"NSFW", "🍆"},
+		{"Org", "🏢"},
+		{"Pets", "🐶"},
+		{"Play", "🎲"},
+		{"Podcast", "🎙️"},
+		{"Politics", "🗳️"},
+		{"Product", "🍱"},
+		{"Psyche", "🍁"},
+		{"Privacy", "👻"},
+		{"Security", "🔒"},
+		{"Social", "☕"},
+		{"Software dev", "👩‍💻"},
+		{"Sports", "⚽️"},
+		{"Tech", "📱"},
+		{"Travel", "🗺"},
+		{"Vehicles", "🚕"},
+		{"Web3", "🌐"},
+	}
+
+	Tags = make([]string, 0, len(orderedInput))
+	TagsEmojis = make(map[string]string, len(orderedInput))
+	TagsIndices = make(map[string]uint32, len(orderedInput))
+
+	for i, pair := range orderedInput {
+		Tags = append(Tags, pair[0])
+		TagsEmojis[pair[0]] = pair[1]
+		TagsIndices[pair[0]] = uint32(i)
+	}
 }
 
 func ValidateTags(input []string) bool {
 	for _, t := range input {
-		_, ok := TagsEmojies[t]
+		_, ok := TagsEmojis[t]
 		if !ok {
 			return false
 		}
@@ -73,7 +86,7 @@ func ValidateTags(input []string) bool {
 func RemoveUnknownAndDeduplicateTags(input []string) []string {
 	var result []string
 	for _, t := range input {
-		_, ok := TagsEmojies[t]
+		_, ok := TagsEmojis[t]
 		if ok {
 			result = append(result, t)
 		}

--- a/protocol/requests/community_tags.go
+++ b/protocol/requests/community_tags.go
@@ -1,79 +1,24 @@
 package requests
 
-var Tags []string
-var TagsEmojis map[string]string
-var TagsIndices map[string]uint32
+var tags []string
+var tagsEmojis map[string]string
+var tagsIndices map[string]uint32
 
 func init() {
-	orderedInput := [][]string{
-		{"Activism", "✊"},
-		{"Art", "🎨"},
-		{"Blockchain", "🔗"},
-		{"Books & blogs", "📚"},
-		{"Career", "💼"},
-		{"Collaboration", "🤝"},
-		{"Commerce", "🛒"},
-		{"Culture", "🎎"},
-		{"DAO", "🚀"},
-		{"DeFi", "📈"},
-		{"Design", "🧩"},
-		{"DIY", "🔨"},
-		{"Environment", "🌿"},
-		{"Education", "🎒"},
-		{"Entertainment", "🍿"},
-		{"Ethereum", "Ξ"},
-		{"Event", "🗓"},
-		{"Fantasy", "🧙‍♂️"},
-		{"Fashion", "🧦"},
-		{"Food", "🌶"},
-		{"Gaming", "🎮"},
-		{"Global", "🌍"},
-		{"Health", "🧠"},
-		{"Hobby", "📐"},
-		{"Innovation", "🧪"},
-		{"Language", "📜"},
-		{"Lifestyle", "✨"},
-		{"Local", "📍"},
-		{"Love", "❤️"},
-		{"Markets", "💎"},
-		{"Movies & TV", "🎞"},
-		{"Music", "🎶"},
-		{"News", "🗞"},
-		{"NFT", "🖼"},
-		{"Non-profit", "🙏"},
-		{"NSFW", "🍆"},
-		{"Org", "🏢"},
-		{"Pets", "🐶"},
-		{"Play", "🎲"},
-		{"Podcast", "🎙️"},
-		{"Politics", "🗳️"},
-		{"Product", "🍱"},
-		{"Psyche", "🍁"},
-		{"Privacy", "👻"},
-		{"Security", "🔒"},
-		{"Social", "☕"},
-		{"Software dev", "👩‍💻"},
-		{"Sports", "⚽️"},
-		{"Tech", "📱"},
-		{"Travel", "🗺"},
-		{"Vehicles", "🚕"},
-		{"Web3", "🌐"},
-	}
+	tags = make([]string, 0, len(allTags))
+	tagsEmojis = make(map[string]string, len(allTags))
+	tagsIndices = make(map[string]uint32, len(allTags))
 
-	Tags = make([]string, 0, len(orderedInput))
-	TagsEmojis = make(map[string]string, len(orderedInput))
-	TagsIndices = make(map[string]uint32, len(orderedInput))
-
-	for i, pair := range orderedInput {
-		Tags = append(Tags, pair[0])
-		TagsEmojis[pair[0]] = pair[1]
-		TagsIndices[pair[0]] = uint32(i)
+	for i, pair := range allTags {
+		tags = append(tags, pair[0])
+		tagsEmojis[pair[0]] = pair[1]
+		tagsIndices[pair[0]] = uint32(i)
 	}
 }
 
 func ValidateTags(input []string) bool {
 	for _, t := range input {
-		_, ok := TagsEmojis[t]
+		_, ok := tagsEmojis[t]
 		if !ok {
 			return false
 		}
@@ -86,7 +31,7 @@ func ValidateTags(input []string) bool {
 func RemoveUnknownAndDeduplicateTags(input []string) []string {
 	var result []string
 	for _, t := range input {
-		_, ok := TagsEmojis[t]
+		_, ok := tagsEmojis[t]
 		if ok {
 			result = append(result, t)
 		}
@@ -104,4 +49,84 @@ func unique(slice []string) []string {
 		uniqSlice = append(uniqSlice, v)
 	}
 	return uniqSlice
+}
+
+func TagByIndex(i uint32) string {
+	return tags[i]
+}
+
+func TagEmoji(tag string) string {
+	return tagsEmojis[tag]
+}
+
+func TagIndex(tag string) uint32 {
+	return tagsIndices[tag]
+}
+
+func AvailableTagsCount() int {
+	return len(tags)
+}
+
+func AvailableTagsEmojis() map[string]string {
+	// Make a deep copy of the map to keep it immutable
+	emojis := make(map[string]string, len(tagsEmojis))
+	for t, e := range tagsEmojis {
+		emojis[t] = e
+	}
+	return emojis
+}
+
+var allTags = [][]string{
+	{"Activism", "✊"},
+	{"Art", "🎨"},
+	{"Blockchain", "🔗"},
+	{"Books & blogs", "📚"},
+	{"Career", "💼"},
+	{"Collaboration", "🤝"},
+	{"Commerce", "🛒"},
+	{"Culture", "🎎"},
+	{"DAO", "🚀"},
+	{"DeFi", "📈"},
+	{"Design", "🧩"},
+	{"DIY", "🔨"},
+	{"Environment", "🌿"},
+	{"Education", "🎒"},
+	{"Entertainment", "🍿"},
+	{"Ethereum", "Ξ"},
+	{"Event", "🗓"},
+	{"Fantasy", "🧙‍♂️"},
+	{"Fashion", "🧦"},
+	{"Food", "🌶"},
+	{"Gaming", "🎮"},
+	{"Global", "🌍"},
+	{"Health", "🧠"},
+	{"Hobby", "📐"},
+	{"Innovation", "🧪"},
+	{"Language", "📜"},
+	{"Lifestyle", "✨"},
+	{"Local", "📍"},
+	{"Love", "❤️"},
+	{"Markets", "💎"},
+	{"Movies & TV", "🎞"},
+	{"Music", "🎶"},
+	{"News", "🗞"},
+	{"NFT", "🖼"},
+	{"Non-profit", "🙏"},
+	{"NSFW", "🍆"},
+	{"Org", "🏢"},
+	{"Pets", "🐶"},
+	{"Play", "🎲"},
+	{"Podcast", "🎙️"},
+	{"Politics", "🗳️"},
+	{"Product", "🍱"},
+	{"Psyche", "🍁"},
+	{"Privacy", "👻"},
+	{"Security", "🔒"},
+	{"Social", "☕"},
+	{"Software dev", "👩‍💻"},
+	{"Sports", "⚽️"},
+	{"Tech", "📱"},
+	{"Travel", "🗺"},
+	{"Vehicles", "🚕"},
+	{"Web3", "🌐"},
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -408,7 +408,7 @@ func (api *PublicAPI) IsDisplayNameDupeOfCommunityMember(name string) (bool, err
 
 // CommunityTags return the list of possible community tags
 func (api *PublicAPI) CommunityTags(parent context.Context) map[string]string {
-	return requests.TagsEmojis
+	return requests.AvailableTagsEmojis()
 }
 
 // CuratedCommunities returns the list of curated communities stored in the smart contract. If a community is

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -408,7 +408,7 @@ func (api *PublicAPI) IsDisplayNameDupeOfCommunityMember(name string) (bool, err
 
 // CommunityTags return the list of possible community tags
 func (api *PublicAPI) CommunityTags(parent context.Context) map[string]string {
-	return requests.TagsEmojies
+	return requests.TagsEmojis
 }
 
 // CuratedCommunities returns the list of curated communities stored in the smart contract. If a community is


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/13963

1. The random indices were there because of the loop over `map` in `community.TagsIndices()` function.
Fixed that by defining a strict ordered array of tags and some handful `maps` for better performance.

2. Made `tags`, `tagsEmojis` and `tagsIndices` private and immutable

3. Also fixed a "tagsEmojies" typo 🙂 

