### PR TITLE
feat: suggested derivation path endpoint added

### DIFF
--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -612,3 +612,11 @@ func (api *API) UpdateKeycardUID(ctx context.Context, oldKeycardUID string, newK
 func (api *API) AddressWasShown(address types.Address) error {
 	return api.db.AddressWasShown(address)
 }
+
+func (api *API) GetNumOfAddressesToGenerateForKeypair(keyUID string) (uint64, error) {
+	return api.db.GetNumOfAddressesToGenerateForKeypair(keyUID)
+}
+
+func (api *API) ResolveSuggestedPathForKeypair(keyUID string) (string, error) {
+	return api.db.ResolveSuggestedPathForKeypair(keyUID)
+}


### PR DESCRIPTION
This PR adds 2 new endpoints:
- `GetNumOfAddressesToGenerateForKeypair` it returns number of addresses that need to be generated (the number differs if they need to be generated on a Keycard or in the app)
- `ResolveSuggestedPathForKeypair` returns the next default derivation path if user is adding a new wallet account without editing it via custom derivation path section