### PR TITLE
fix(manager): make both perms satisfied if viewAndPost is satisfied

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2870,8 +2870,7 @@ func (m *Manager) checkChannelPermissions(viewOnlyPermissions []*CommunityTokenP
 	}
 	response.ViewOnlyPermissions.Permissions = viewOnlyPermissionsResponse.Permissions
 
-	if (hasViewOnlyPermissions && !viewOnlyPermissionsResponse.Satisfied) ||
-		(hasViewOnlyPermissions && !hasViewAndPostPermissions) {
+	if hasViewOnlyPermissions && !hasViewAndPostPermissions {
 		response.ViewAndPostPermissions.Satisfied = false
 	} else {
 		response.ViewAndPostPermissions.Satisfied = viewAndPostPermissionsResponse.Satisfied


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/14209

The condition not right. Unless the requirements were different when it was implemented, it should be that when a view and post permission is respected, it will overwrite the read only permission.