### PR TITLE
fix(wallet) fix ERC721 and ERC1155 transfer router

### DIFF
--- a/services/wallet/bridge/erc721_transfer.go
+++ b/services/wallet/bridge/erc721_transfer.go
@@ -99,18 +99,26 @@ func (s *ERC721TransferBridge) EstimateGas(fromNetwork *params.Network, toNetwor
 }
 
 func (s *ERC721TransferBridge) BuildTx(network *params.Network, fromAddress common.Address, toAddress common.Address, token *token.Token, amountIn *big.Int) (*ethTypes.Transaction, error) {
-	toAddr := types.Address(toAddress)
+	contractAddress := types.Address(token.Address)
+
+	// We store ERC721 Token ID using big.Int.String() in token.Symbol
+	tokenID, success := new(big.Int).SetString(token.Symbol, 10)
+	if !success {
+		return nil, fmt.Errorf("failed to convert ERC721's Symbol %s to big.Int", token.Symbol)
+	}
+
 	sendArgs := &TransactionBridge{
 		ERC721TransferTx: &ERC721TransferTxArgs{
 			SendTxArgs: transactions.SendTxArgs{
 				From:  types.Address(fromAddress),
-				To:    &toAddr,
+				To:    &contractAddress,
 				Value: (*hexutil.Big)(amountIn),
 				Data:  types.HexBytes("0x0"),
 			},
-			TokenID:   (*hexutil.Big)(big.NewInt(0)),
+			TokenID:   (*hexutil.Big)(tokenID),
 			Recipient: toAddress,
 		},
+		ChainID: network.ChainID,
 	}
 
 	return s.BuildTransaction(sendArgs)

--- a/services/wallet/router.go
+++ b/services/wallet/router.go
@@ -713,7 +713,7 @@ func (r *Router) suggestedRoutes(
 						continue
 					}
 
-					tx, err := bridge.BuildTx(network, addrTo, addrFrom, token, amountIn)
+					tx, err := bridge.BuildTx(network, addrFrom, addrTo, token, amountIn)
 					if err != nil {
 						continue
 					}


### PR DESCRIPTION
### Updates status-desktop [#14212](https://github.com/status-im/status-desktop/issues/14212)

Changes

- Use token's contract address for `[ERC721 | ERC1155]TransferTxArgs.to` because it is used as such later on.
- Extract Token ID from the symbol as we encoded and set the corresponding value in the `[ERC721 | ERC1155]TransferTxArgs`.
- Set ChainID in `[ERC721 | ERC1155]TransferTxArgs`
- Fix wrong order of arguments in `BuildTx`.