### PR TITLE
fix: Add twitterHandle for a collectible

### DIFF
--- a/services/wallet/activity/service_test.go
+++ b/services/wallet/activity/service_test.go
@@ -42,6 +42,15 @@ func (m *mockCollectiblesManager) FetchAssetsByCollectibleUniqueID(ctx context.C
 	return res.([]thirdparty.FullCollectibleData), args.Error(1)
 }
 
+func (m *mockCollectiblesManager) FetchCollectionSocialsAsync(contractID thirdparty.ContractID) error {
+	args := m.Called(contractID)
+	res := args.Get(0)
+	if res == nil {
+		return args.Error(1)
+	}
+	return nil
+}
+
 // mockTokenManager implements the token.ManagerInterface
 type mockTokenManager struct {
 	mock.Mock

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -342,6 +342,12 @@ func (api *API) GetCollectiblesByUniqueIDAsync(requestID int32, uniqueIDs []thir
 	return nil
 }
 
+func (api *API) FetchCollectionSocialsAsync(contractID thirdparty.ContractID) error {
+	log.Debug("wallet.api.FetchCollectionSocialsAsync", "contractID", contractID)
+
+	return api.s.collectiblesManager.FetchCollectionSocialsAsync(contractID)
+}
+
 func (api *API) GetCollectibleOwnersByContractAddress(ctx context.Context, chainID wcommon.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error) {
 	log.Debug("call to GetCollectibleOwnersByContractAddress")
 	return api.s.collectiblesManager.FetchCollectibleOwnersByContractAddress(ctx, chainID, contractAddress)

--- a/services/wallet/collectibles/service.go
+++ b/services/wallet/collectibles/service.go
@@ -35,12 +35,18 @@ const (
 
 	EventOwnedCollectiblesFilteringDone walletevent.EventType = "wallet-owned-collectibles-filtering-done"
 	EventGetCollectiblesDetailsDone     walletevent.EventType = "wallet-get-collectibles-details-done"
+	EventGetCollectionSocialsDone       walletevent.EventType = "wallet-get-collection-socials-done"
 )
 
 type OwnershipUpdateMessage struct {
 	Added   []thirdparty.CollectibleUniqueID `json:"added"`
 	Updated []thirdparty.CollectibleUniqueID `json:"updated"`
 	Removed []thirdparty.CollectibleUniqueID `json:"removed"`
+}
+
+type CollectionSocialsMessage struct {
+	ID      thirdparty.ContractID         `json:"id"`
+	Socials *thirdparty.CollectionSocials `json:"socials"`
 }
 
 type CollectibleDataType byte

--- a/services/wallet/collectibles/types.go
+++ b/services/wallet/collectibles/types.go
@@ -32,9 +32,15 @@ type CollectibleData struct {
 }
 
 type CollectionData struct {
-	Name     string `json:"name"`
-	Slug     string `json:"slug"`
-	ImageURL string `json:"image_url"`
+	Name     string             `json:"name"`
+	Slug     string             `json:"slug"`
+	ImageURL string             `json:"image_url"`
+	Socials  *CollectionSocials `json:"socials"`
+}
+
+type CollectionSocials struct {
+	Website       string `json:"website"`
+	TwitterHandle string `json:"twitter_handle"`
 }
 
 type CommunityData struct {
@@ -64,6 +70,24 @@ func idsToCollectibles(ids []thirdparty.CollectibleUniqueID) []Collectible {
 	return res
 }
 
+func thirdpartyCollectionDataToCollectionData(collectionData *thirdparty.CollectionData) CollectionData {
+	ret := CollectionData{}
+	if collectionData != nil {
+		ret = CollectionData{
+			Name:     collectionData.Name,
+			Slug:     collectionData.Slug,
+			ImageURL: collectionData.ImageURL,
+		}
+		if collectionData.Socials != nil {
+			ret.Socials = &CollectionSocials{
+				Website:       collectionData.Socials.Website,
+				TwitterHandle: collectionData.Socials.TwitterHandle,
+			}
+		}
+	}
+	return ret
+}
+
 func getContractType(c thirdparty.FullCollectibleData) w_common.ContractType {
 	if c.CollectibleData.ContractType != w_common.ContractTypeUnknown {
 		return c.CollectibleData.ContractType
@@ -88,13 +112,8 @@ func fullCollectibleDataToHeader(c thirdparty.FullCollectibleData) Collectible {
 			Soulbound:          &c.CollectibleData.Soulbound,
 		},
 	}
-	if c.CollectionData != nil {
-		ret.CollectionData = &CollectionData{
-			Name:     c.CollectionData.Name,
-			Slug:     c.CollectionData.Slug,
-			ImageURL: c.CollectionData.ImageURL,
-		}
-	}
+	collectionData := thirdpartyCollectionDataToCollectionData(c.CollectionData)
+	ret.CollectionData = &collectionData
 	if c.CollectibleData.CommunityID != "" {
 		communityData := communityInfoToData(c.CollectibleData.CommunityID, c.CommunityInfo, c.CollectibleCommunityInfo)
 		ret.CommunityData = &communityData
@@ -130,13 +149,8 @@ func fullCollectibleDataToDetails(c thirdparty.FullCollectibleData) Collectible 
 			Soulbound:          &c.CollectibleData.Soulbound,
 		},
 	}
-	if c.CollectionData != nil {
-		ret.CollectionData = &CollectionData{
-			Name:     c.CollectionData.Name,
-			Slug:     c.CollectionData.Slug,
-			ImageURL: c.CollectionData.ImageURL,
-		}
-	}
+	collectionData := thirdpartyCollectionDataToCollectionData(c.CollectionData)
+	ret.CollectionData = &collectionData
 	if c.CollectibleData.CommunityID != "" {
 		communityData := communityInfoToData(c.CollectibleData.CommunityID, c.CommunityInfo, c.CollectibleCommunityInfo)
 		ret.CommunityData = &communityData

--- a/services/wallet/thirdparty/alchemy/client.go
+++ b/services/wallet/thirdparty/alchemy/client.go
@@ -376,6 +376,17 @@ func (o *Client) FetchAssetsByCollectibleUniqueID(ctx context.Context, uniqueIDs
 	return ret, nil
 }
 
+func (o *Client) FetchCollectionSocials(ctx context.Context, contractID thirdparty.ContractID) (*thirdparty.CollectionSocials, error) {
+	resp, err := o.FetchCollectionsDataByContractID(ctx, []thirdparty.ContractID{contractID})
+	if err != nil {
+		return nil, err
+	}
+	if len(resp) > 0 {
+		return resp[0].Socials, nil
+	}
+	return nil, nil
+}
+
 func getContractAddressBatches(ids []thirdparty.ContractID) []BatchContractAddresses {
 	batches := make([]BatchContractAddresses, 0)
 

--- a/services/wallet/thirdparty/alchemy/client_test.go
+++ b/services/wallet/thirdparty/alchemy/client_test.go
@@ -24,6 +24,7 @@ func TestUnmarshallCollection(t *testing.T) {
 		Name:         "CryptoKitties",
 		ImageURL:     "https://i.seadn.io/gae/C272ZRW1RGGef9vKMePFSCeKc1Lw6U40wl9ofNVxzUxFdj84hH9xJRQNf-7wgs7W8qw8RWe-1ybKp-VKuU5D-tg?w=500&auto=format",
 		Traits:       make(map[string]thirdparty.CollectionTrait),
+		Socials:      &thirdparty.CollectionSocials{Website: "", TwitterHandle: "CryptoKitties", Provider: "alchemy"},
 	}
 
 	collection := Contract{}
@@ -79,6 +80,7 @@ func TestUnmarshallOwnedCollectibles(t *testing.T) {
 				Slug:         "",
 				ImageURL:     "",
 				Traits:       make(map[string]thirdparty.CollectionTrait),
+				Socials:      &thirdparty.CollectionSocials{Website: "", TwitterHandle: "", Provider: "alchemy"},
 			},
 			AccountBalance: &bigint.BigInt{
 				Int: expectedBalance0,
@@ -137,6 +139,7 @@ func TestUnmarshallOwnedCollectibles(t *testing.T) {
 				Slug:         "",
 				ImageURL:     "https://raw.seadn.io/files/e7765f13c4658f514d0efc008ae7f300.png",
 				Traits:       make(map[string]thirdparty.CollectionTrait),
+				Socials:      &thirdparty.CollectionSocials{Website: "", TwitterHandle: "SimpsonPunksETH", Provider: "alchemy"},
 			},
 			AccountBalance: &bigint.BigInt{
 				Int: expectedBalance1,

--- a/services/wallet/thirdparty/alchemy/types.go
+++ b/services/wallet/thirdparty/alchemy/types.go
@@ -104,7 +104,9 @@ func (r *Raw) UnmarshalJSON(b []byte) error {
 }
 
 type OpenSeaMetadata struct {
-	ImageURL string `json:"imageUrl"`
+	ImageURL        string `json:"imageUrl"`
+	TwitterUsername string `json:"twitterUsername"`
+	ExternalURL     string `json:"externalUrl"`
 }
 
 type Contract struct {
@@ -184,6 +186,14 @@ func alchemyToContractType(tokenType string) walletCommon.ContractType {
 	}
 }
 
+func (c *Contract) toCollectionSocials() *thirdparty.CollectionSocials {
+	return &thirdparty.CollectionSocials{
+		Website:       c.OpenSeaMetadata.ExternalURL,
+		TwitterHandle: c.OpenSeaMetadata.TwitterUsername,
+		Provider:      AlchemyID,
+	}
+}
+
 func (c *Contract) toCollectionData(id thirdparty.ContractID) thirdparty.CollectionData {
 	ret := thirdparty.CollectionData{
 		ID:           id,
@@ -192,6 +202,7 @@ func (c *Contract) toCollectionData(id thirdparty.ContractID) thirdparty.Collect
 		Name:         c.Name,
 		ImageURL:     c.OpenSeaMetadata.ImageURL,
 		Traits:       make(map[string]thirdparty.CollectionTrait, 0),
+		Socials:      c.toCollectionSocials(),
 	}
 	return ret
 }

--- a/services/wallet/thirdparty/collectible_types.go
+++ b/services/wallet/thirdparty/collectible_types.go
@@ -152,6 +152,13 @@ type CollectionData struct {
 	ImageURL     string                `json:"image_url"`
 	ImagePayload []byte
 	Traits       map[string]CollectionTrait `json:"traits"`
+	Socials      *CollectionSocials         `json:"socials"`
+}
+
+type CollectionSocials struct {
+	Website       string `json:"website"`
+	TwitterHandle string `json:"twitter_handle"`
+	Provider      string `json:"provider"`
 }
 
 type CollectibleTrait struct {
@@ -273,6 +280,7 @@ type CollectibleAccountOwnershipProvider interface {
 type CollectibleDataProvider interface {
 	CollectibleProvider
 	FetchAssetsByCollectibleUniqueID(ctx context.Context, uniqueIDs []CollectibleUniqueID) ([]FullCollectibleData, error)
+	FetchCollectionSocials(ctx context.Context, contractID ContractID) (*CollectionSocials, error)
 }
 
 type CollectionDataProvider interface {

--- a/services/wallet/thirdparty/opensea/client_v2.go
+++ b/services/wallet/thirdparty/opensea/client_v2.go
@@ -133,6 +133,11 @@ func (o *ClientV2) FetchAssetsByCollectibleUniqueID(ctx context.Context, uniqueI
 	return o.fetchDetailedAssets(ctx, uniqueIDs)
 }
 
+func (o *ClientV2) FetchCollectionSocials(ctx context.Context, contractID thirdparty.ContractID) (*thirdparty.CollectionSocials, error) {
+	// we dont want to use opensea as any small number of requests can also lead to throttling
+	return nil, thirdparty.ErrEndpointNotSupported
+}
+
 func (o *ClientV2) fetchAssets(ctx context.Context, chainID walletCommon.ChainID, pathParams []string, queryParams url.Values, limit int, cursor string) (*thirdparty.FullCollectibleDataContainer, error) {
 	assets := new(thirdparty.FullCollectibleDataContainer)
 

--- a/services/wallet/thirdparty/opensea/types_v2.go
+++ b/services/wallet/thirdparty/opensea/types_v2.go
@@ -139,12 +139,14 @@ type ContractID struct {
 }
 
 type CollectionData struct {
-	Collection  string         `json:"collection"`
-	Name        string         `json:"name"`
-	Description string         `json:"description"`
-	Owner       common.Address `json:"owner"`
-	ImageURL    string         `json:"image_url"`
-	Contracts   []ContractID   `json:"contracts"`
+	Collection    string         `json:"collection"`
+	Name          string         `json:"name"`
+	Description   string         `json:"description"`
+	Owner         common.Address `json:"owner"`
+	ImageURL      string         `json:"image_url"`
+	Contracts     []ContractID   `json:"contracts"`
+	Website       string         `json:"project_url"`
+	TwitterHandle string         `json:"twitter_username"`
 }
 
 func (c *NFT) id(chainID walletCommon.ChainID) thirdparty.CollectibleUniqueID {
@@ -225,6 +227,14 @@ func (c *DetailedNFT) toCommon(chainID walletCommon.ChainID) thirdparty.FullColl
 	}
 }
 
+func (c *CollectionData) toCollectionSocials() *thirdparty.CollectionSocials {
+	return &thirdparty.CollectionSocials{
+		Website:       c.Website,
+		TwitterHandle: c.TwitterHandle,
+		Provider:      OpenseaV2ID,
+	}
+}
+
 func (c *CollectionData) toCommon(id thirdparty.ContractID, tokenStandard string) thirdparty.CollectionData {
 	ret := thirdparty.CollectionData{
 		ID:           id,
@@ -233,6 +243,7 @@ func (c *CollectionData) toCommon(id thirdparty.ContractID, tokenStandard string
 		Name:         c.Name,
 		Slug:         c.Collection,
 		ImageURL:     c.ImageURL,
+		Socials:      c.toCollectionSocials(),
 	}
 	return ret
 }

--- a/services/wallet/thirdparty/rarible/client.go
+++ b/services/wallet/thirdparty/rarible/client.go
@@ -390,6 +390,10 @@ func (o *Client) FetchAssetsByCollectibleUniqueID(ctx context.Context, uniqueIDs
 	return ret, nil
 }
 
+func (o *Client) FetchCollectionSocials(ctx context.Context, contractID thirdparty.ContractID) (*thirdparty.CollectionSocials, error) {
+	return nil, thirdparty.ErrEndpointNotSupported
+}
+
 func (o *Client) FetchCollectionsDataByContractID(ctx context.Context, contractIDs []thirdparty.ContractID) ([]thirdparty.CollectionData, error) {
 	ret := make([]thirdparty.CollectionData, 0, len(contractIDs))
 

--- a/services/wallet/thirdparty/rarible/client_test.go
+++ b/services/wallet/thirdparty/rarible/client_test.go
@@ -24,6 +24,7 @@ func TestUnmarshallCollection(t *testing.T) {
 		Name:         "CryptoKitties",
 		ImageURL:     "https://i.seadn.io/gae/C272ZRW1RGGef9vKMePFSCeKc1Lw6U40wl9ofNVxzUxFdj84hH9xJRQNf-7wgs7W8qw8RWe-1ybKp-VKuU5D-tg?w=500&auto=format",
 		Traits:       make(map[string]thirdparty.CollectionTrait),
+		Socials:      nil,
 	}
 
 	collection := Collection{}

--- a/services/wallet/thirdparty/test_utils.go
+++ b/services/wallet/thirdparty/test_utils.go
@@ -123,6 +123,7 @@ func GenerateTestCollectionsData(count int) (result []CollectionData) {
 			ImagePayload: []byte(fmt.Sprintf("imagepayload-%d", i)),
 			Traits:       traits,
 			CommunityID:  fmt.Sprintf("community-%d", i),
+			Socials:      nil,
 		}
 		result = append(result, newCollection)
 	}

--- a/walletdatabase/migrations/bindata.go
+++ b/walletdatabase/migrations/bindata.go
@@ -26,6 +26,7 @@
 // 1710189541_add_nonce_to_pending_transactions.up.sql (54B)
 // 1712567001_add_soulbound_collectible_cache.up.sql (75B)
 // 1714670633_add_id_to_multi_transaction_table.up.sql (1.15kB)
+// 1715637927_add_collection_socials.up.sql (356B)
 // doc.go (94B)
 
 package migrations
@@ -36,7 +37,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +46,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -54,7 +54,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func _1691753758_initialUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1691753758_initial.up.sql", size: 5738, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1691753758_initial.up.sql", size: 5738, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6b, 0x25, 0x31, 0xc8, 0x27, 0x3, 0x6b, 0x9f, 0x15, 0x42, 0x2f, 0x85, 0xfb, 0xe3, 0x6, 0xea, 0xf7, 0x97, 0x12, 0x56, 0x3c, 0x9a, 0x5b, 0x1a, 0xca, 0xb1, 0x23, 0xfa, 0xcd, 0x57, 0x25, 0x5c}}
 	return a, nil
 }
@@ -130,7 +130,7 @@ func _1692701329_add_collectibles_and_collections_data_cacheUpSql() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1692701329_add_collectibles_and_collections_data_cache.up.sql", size: 1808, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1692701329_add_collectibles_and_collections_data_cache.up.sql", size: 1808, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1, 0x51, 0xf4, 0x2b, 0x92, 0xde, 0x59, 0x65, 0xd8, 0x9b, 0x57, 0xe0, 0xfd, 0x7b, 0x12, 0xb, 0x29, 0x6e, 0x9d, 0xb5, 0x90, 0xe, 0xfa, 0x12, 0x97, 0xd, 0x61, 0x60, 0x7f, 0x32, 0x1d, 0xc3}}
 	return a, nil
 }
@@ -150,7 +150,7 @@ func _1692701339_add_scope_to_pendingUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1692701339_add_scope_to_pending.up.sql", size: 576, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1692701339_add_scope_to_pending.up.sql", size: 576, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x36, 0x8a, 0x5e, 0xe2, 0x63, 0x15, 0x37, 0xba, 0x55, 0x18, 0xf3, 0xcc, 0xe0, 0x5, 0x84, 0xe1, 0x5b, 0xe8, 0x1, 0x32, 0x6b, 0x9f, 0x7d, 0x9f, 0xd9, 0x23, 0x6c, 0xa9, 0xb5, 0xdc, 0xf4, 0x93}}
 	return a, nil
 }
@@ -170,7 +170,7 @@ func _1694540071_add_collectibles_ownership_update_timestampUpSql() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1694540071_add_collectibles_ownership_update_timestamp.up.sql", size: 349, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1694540071_add_collectibles_ownership_update_timestamp.up.sql", size: 349, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7f, 0x45, 0xc7, 0xce, 0x79, 0x63, 0xbc, 0x6f, 0x83, 0x5f, 0xe2, 0x3, 0x56, 0xcc, 0x5, 0x2f, 0x85, 0xda, 0x7e, 0xea, 0xf5, 0xd2, 0xac, 0x19, 0xd4, 0xd8, 0x5e, 0xdd, 0xed, 0xe2, 0xa9, 0x97}}
 	return a, nil
 }
@@ -190,7 +190,7 @@ func _1694692748_add_raw_balance_to_token_balancesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1694692748_add_raw_balance_to_token_balances.up.sql", size: 165, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1694692748_add_raw_balance_to_token_balances.up.sql", size: 165, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd4, 0xe0, 0x5b, 0x42, 0xf0, 0x96, 0xa5, 0xf5, 0xed, 0xc0, 0x97, 0x88, 0xb0, 0x6d, 0xfe, 0x7d, 0x97, 0x2e, 0x17, 0xd2, 0x16, 0xbc, 0x2a, 0xf2, 0xcc, 0x67, 0x9e, 0xc5, 0x47, 0xf6, 0x69, 0x1}}
 	return a, nil
 }
@@ -210,7 +210,7 @@ func _1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSq
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql", size: 275, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql", size: 275, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xfa, 0x2, 0xa, 0x7f, 0x4b, 0xd1, 0x3, 0xd0, 0x3, 0x29, 0x84, 0x31, 0xed, 0x49, 0x4f, 0xb1, 0x2d, 0xd7, 0x80, 0x41, 0x5b, 0xfa, 0x6, 0xae, 0xb4, 0xf6, 0x6b, 0x49, 0xee, 0x57, 0x33, 0x76}}
 	return a, nil
 }
@@ -230,7 +230,7 @@ func _1695932536_balance_history_v2UpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1695932536_balance_history_v2.up.sql", size: 653, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1695932536_balance_history_v2.up.sql", size: 653, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x37, 0xf4, 0x14, 0x91, 0xf6, 0x5f, 0xc4, 0x9b, 0xb7, 0x83, 0x32, 0x72, 0xbe, 0x82, 0x42, 0x39, 0xa4, 0x3b, 0xc9, 0x78, 0x3d, 0xca, 0xd4, 0xbf, 0xfc, 0x7a, 0x33, 0x1e, 0xcd, 0x9e, 0xe4, 0x85}}
 	return a, nil
 }
@@ -250,7 +250,7 @@ func _1696853635_input_dataUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1696853635_input_data.up.sql", size: 23140, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1696853635_input_data.up.sql", size: 23140, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x89, 0x30, 0x33, 0x33, 0x55, 0xc5, 0x57, 0x2b, 0xaf, 0xef, 0x3d, 0x8d, 0x2a, 0xaa, 0x5c, 0x32, 0xd1, 0xf4, 0xd, 0x4a, 0xd0, 0x33, 0x4a, 0xe8, 0xf6, 0x8, 0x6b, 0x65, 0xcc, 0xba, 0xed, 0x42}}
 	return a, nil
 }
@@ -270,7 +270,7 @@ func _1698117918_add_community_id_to_tokensUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1698117918_add_community_id_to_tokens.up.sql", size: 61, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1698117918_add_community_id_to_tokens.up.sql", size: 61, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb3, 0x82, 0xdb, 0xde, 0x3, 0x3, 0xc, 0x67, 0xf3, 0x54, 0xc4, 0xad, 0xd6, 0xce, 0x56, 0xfb, 0xc1, 0x87, 0xd7, 0xda, 0xab, 0xec, 0x1, 0xe1, 0x7d, 0xb3, 0x63, 0xd6, 0xe5, 0x5d, 0x1c, 0x15}}
 	return a, nil
 }
@@ -290,7 +290,7 @@ func _1698257443_add_community_metadata_to_wallet_dbUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1698257443_add_community_metadata_to_wallet_db.up.sql", size: 323, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1698257443_add_community_metadata_to_wallet_db.up.sql", size: 323, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x22, 0xd3, 0x4, 0x25, 0xfa, 0x23, 0x1, 0x48, 0x83, 0x26, 0x20, 0xf2, 0x3d, 0xbc, 0xc1, 0xa7, 0x7c, 0x27, 0x7c, 0x1d, 0x63, 0x3, 0xa, 0xd0, 0xce, 0x47, 0x86, 0xdc, 0xa1, 0x3c, 0x2, 0x1c}}
 	return a, nil
 }
@@ -310,7 +310,7 @@ func _1699987075_add_timestamp_and_state_to_community_data_cacheUpSql() (*asset,
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1699987075_add_timestamp_and_state_to_community_data_cache.up.sql", size: 865, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1699987075_add_timestamp_and_state_to_community_data_cache.up.sql", size: 865, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc3, 0xee, 0x37, 0xf9, 0x7f, 0x9e, 0xfe, 0x93, 0x66, 0x2b, 0xd, 0x57, 0xf4, 0x89, 0x6c, 0x51, 0xfd, 0x14, 0xe9, 0xcd, 0xab, 0x65, 0xe7, 0xa7, 0x83, 0x7e, 0xe0, 0x5c, 0x14, 0x49, 0xf3, 0xe5}}
 	return a, nil
 }
@@ -330,7 +330,7 @@ func _1700414564_add_wallet_connect_pairings_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1700414564_add_wallet_connect_pairings_table.up.sql", size: 439, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1700414564_add_wallet_connect_pairings_table.up.sql", size: 439, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa9, 0x77, 0x5e, 0x19, 0x62, 0x3c, 0x3a, 0x81, 0x16, 0xa0, 0x95, 0x35, 0x62, 0xab, 0x5e, 0x2b, 0xea, 0x11, 0x71, 0x11, 0xd0, 0x9, 0xab, 0x9c, 0xab, 0xf2, 0xdd, 0x5f, 0x88, 0x83, 0x9a, 0x93}}
 	return a, nil
 }
@@ -350,7 +350,7 @@ func _1701101493_add_token_blocks_rangeUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1701101493_add_token_blocks_range.up.sql", size: 469, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1701101493_add_token_blocks_range.up.sql", size: 469, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe0, 0x37, 0xfb, 0x1a, 0x6c, 0x8c, 0xa8, 0x1e, 0xa2, 0xa5, 0x1f, 0x90, 0x73, 0x3e, 0x31, 0x5f, 0x48, 0x1e, 0x9a, 0x37, 0x27, 0x1c, 0xc, 0x67, 0x1, 0xcd, 0xec, 0x85, 0x4c, 0x1c, 0x26, 0x52}}
 	return a, nil
 }
@@ -370,7 +370,7 @@ func _1702467441_wallet_connect_sessions_instead_of_pairingsUpSql() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1702467441_wallet_connect_sessions_instead_of_pairings.up.sql", size: 356, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1702467441_wallet_connect_sessions_instead_of_pairings.up.sql", size: 356, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x73, 0x5f, 0x0, 0x60, 0x6, 0x28, 0x76, 0x61, 0x39, 0xdc, 0xa1, 0x84, 0x80, 0x46, 0x8a, 0xe4, 0x42, 0xb5, 0x1f, 0x18, 0x14, 0x23, 0x46, 0xb9, 0x51, 0xf, 0x62, 0xac, 0xc, 0x7, 0x98, 0xe}}
 	return a, nil
 }
@@ -390,7 +390,7 @@ func _1702577524_add_community_collections_and_collectibles_images_cacheUpSql() 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1702577524_add_community_collections_and_collectibles_images_cache.up.sql", size: 210, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1702577524_add_community_collections_and_collectibles_images_cache.up.sql", size: 210, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8e, 0x1b, 0x32, 0x2c, 0xfa, 0x11, 0x5e, 0x5e, 0x5d, 0xef, 0x92, 0xa0, 0x29, 0x52, 0xbf, 0x6e, 0xe3, 0x30, 0xe4, 0xdf, 0xdc, 0x5, 0xbe, 0xd1, 0xf8, 0x3e, 0xd9, 0x9b, 0xd6, 0x9b, 0x95, 0x96}}
 	return a, nil
 }
@@ -410,7 +410,7 @@ func _1702867707_add_balance_to_collectibles_ownership_cacheUpSql() (*asset, err
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1702867707_add_balance_to_collectibles_ownership_cache.up.sql", size: 289, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1702867707_add_balance_to_collectibles_ownership_cache.up.sql", size: 289, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6f, 0x63, 0x30, 0x11, 0x22, 0xb9, 0xee, 0xae, 0xb8, 0xc4, 0xe6, 0xd3, 0x7, 0xc, 0xe6, 0xa3, 0x72, 0x8c, 0x6, 0x9d, 0x6c, 0x97, 0x8f, 0xb2, 0xd0, 0x37, 0x69, 0x69, 0x6, 0x7f, 0x67, 0x94}}
 	return a, nil
 }
@@ -430,7 +430,7 @@ func _1703686612_add_color_to_saved_addressesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1703686612_add_color_to_saved_addresses.up.sql", size: 114, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1703686612_add_color_to_saved_addresses.up.sql", size: 114, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb7, 0x6e, 0x8d, 0xc0, 0x49, 0xc, 0xb, 0x66, 0xa0, 0x77, 0x32, 0x76, 0xa8, 0xd0, 0x40, 0xce, 0x67, 0xa, 0x9e, 0x23, 0x36, 0xe, 0xc3, 0xd3, 0x9d, 0xe2, 0xde, 0x60, 0x19, 0xba, 0x44, 0xf1}}
 	return a, nil
 }
@@ -450,7 +450,7 @@ func _1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSq
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql", size: 894, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql", size: 894, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x70, 0xd3, 0xcf, 0x90, 0xb2, 0xa, 0x23, 0x41, 0x8a, 0xa5, 0x90, 0x7b, 0x34, 0xec, 0x3b, 0x3f, 0xa9, 0xb1, 0x95, 0xf3, 0x2a, 0xdf, 0xbb, 0x53, 0x57, 0x27, 0x2b, 0x12, 0x84, 0xf4, 0x83, 0xda}}
 	return a, nil
 }
@@ -470,7 +470,7 @@ func _1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql(
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql", size: 73, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql", size: 73, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa2, 0xf0, 0x71, 0xb5, 0xaf, 0x22, 0xac, 0x77, 0xdb, 0x6f, 0x62, 0x27, 0x12, 0x46, 0x60, 0x3, 0x59, 0x43, 0x6f, 0x1, 0xdc, 0xe8, 0x6e, 0x89, 0xa5, 0x77, 0x37, 0x36, 0xd9, 0x4e, 0x6d, 0x9b}}
 	return a, nil
 }
@@ -490,7 +490,7 @@ func _1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql() (*asse
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql", size: 84, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql", size: 84, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3c, 0x49, 0x9, 0xd9, 0x83, 0x3d, 0xd8, 0xb7, 0x4f, 0x8f, 0xc2, 0xa2, 0xd1, 0xb, 0x57, 0x1f, 0x5, 0x39, 0x55, 0xfb, 0x6e, 0x32, 0x9e, 0x19, 0x3d, 0x3c, 0x77, 0xa2, 0xc4, 0xf4, 0x53, 0x35}}
 	return a, nil
 }
@@ -510,7 +510,7 @@ func _1706531789_remove_gasfeeOnlyEthTransfersUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1706531789_remove_gasfee-only-eth-transfers.up.sql", size: 627, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1706531789_remove_gasfee-only-eth-transfers.up.sql", size: 627, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xae, 0x8c, 0x37, 0xd3, 0x2a, 0xf, 0x1a, 0x8, 0xe9, 0xa7, 0x1f, 0x5a, 0x10, 0xa7, 0x4c, 0x36, 0x4f, 0xc6, 0xdc, 0xeb, 0x79, 0x90, 0xe7, 0xcd, 0x4a, 0xef, 0xb7, 0x3, 0x6e, 0x88, 0x6f, 0x79}}
 	return a, nil
 }
@@ -530,7 +530,7 @@ func _1707160323_add_contract_type_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1707160323_add_contract_type_table.up.sql", size: 282, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1707160323_add_contract_type_table.up.sql", size: 282, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x45, 0x99, 0xd9, 0x86, 0x72, 0x37, 0x97, 0xfc, 0xa7, 0xbb, 0xe3, 0x86, 0xf1, 0xfd, 0x77, 0x31, 0x91, 0xcb, 0xa4, 0x2c, 0x5b, 0xaa, 0x4b, 0xa2, 0x7f, 0x8a, 0x2c, 0x7a, 0xda, 0x20, 0x7a, 0x97}}
 	return a, nil
 }
@@ -550,7 +550,7 @@ func _1708089811_add_nullable_fiesl_blocks_rangesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1708089811_add_nullable_fiesl_blocks_ranges.up.sql", size: 450, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1708089811_add_nullable_fiesl_blocks_ranges.up.sql", size: 450, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x92, 0xec, 0x7c, 0xd7, 0x99, 0x36, 0xa3, 0xb5, 0xc, 0xaa, 0x59, 0x40, 0x4c, 0x69, 0xc6, 0x62, 0x6e, 0x10, 0x6a, 0x2b, 0xc7, 0x37, 0x24, 0xad, 0x39, 0x9b, 0xe6, 0xeb, 0xbf, 0xb6, 0x32, 0x24}}
 	return a, nil
 }
@@ -570,7 +570,7 @@ func _1710189541_add_nonce_to_pending_transactionsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1710189541_add_nonce_to_pending_transactions.up.sql", size: 54, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1710189541_add_nonce_to_pending_transactions.up.sql", size: 54, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6, 0x2e, 0x35, 0x7c, 0xf, 0x9, 0x63, 0x64, 0x4d, 0xdf, 0x8f, 0x99, 0x96, 0x66, 0xda, 0x81, 0x56, 0x84, 0x3b, 0xbf, 0x88, 0xf9, 0xb0, 0x7d, 0x9f, 0x87, 0x74, 0xa9, 0xb, 0x9a, 0x70, 0xcb}}
 	return a, nil
 }
@@ -590,7 +590,7 @@ func _1712567001_add_soulbound_collectible_cacheUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1712567001_add_soulbound_collectible_cache.up.sql", size: 75, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1712567001_add_soulbound_collectible_cache.up.sql", size: 75, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2e, 0x6c, 0x8b, 0x92, 0x49, 0x6c, 0x6, 0x66, 0x4c, 0xbb, 0x63, 0x4a, 0xc6, 0x7, 0xf2, 0x75, 0xef, 0xa9, 0xe5, 0xd9, 0x6c, 0x90, 0x9, 0xe4, 0x5f, 0xd1, 0xf3, 0x0, 0xd2, 0xf3, 0x0, 0xb8}}
 	return a, nil
 }
@@ -610,8 +610,28 @@ func _1714670633_add_id_to_multi_transaction_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1714670633_add_id_to_multi_transaction_table.up.sql", size: 1150, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1714670633_add_id_to_multi_transaction_table.up.sql", size: 1150, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa2, 0x17, 0x7e, 0x5a, 0x17, 0x7c, 0xf8, 0x9c, 0x60, 0xe4, 0xca, 0xd9, 0x32, 0xe5, 0x37, 0xd1, 0xa5, 0xcb, 0x56, 0xf4, 0x1e, 0x9e, 0x8d, 0x1b, 0x8d, 0x66, 0xaa, 0xd9, 0xce, 0x68, 0x3e, 0xcd}}
+	return a, nil
+}
+
+var __1715637927_add_collection_socialsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x7c\x90\xc1\x6a\xc4\x20\x10\x86\xef\x79\x8a\xff\xb8\x0b\xfb\x06\x3d\xb9\x66\x92\x4a\x83\x01\xe3\x96\xf6\x24\x56\x85\x08\x41\x8b\x4a\xf7\xf5\x0b\x0d\x3d\xb4\x25\x3d\x7f\xdf\x0c\xdf\x0c\x57\xc4\x34\x41\xb3\xeb\x44\x10\x03\xe4\xac\x41\x2f\x62\xd1\x0b\x5c\xde\xb6\xe0\x5a\xcc\xc9\xd4\xec\xa2\xdd\xaa\x71\xd6\xad\x01\xa7\x0e\x00\xdc\x6a\x63\x32\xd1\xe3\x26\x17\x31\x4a\xea\x71\x15\xa3\x90\xfa\x6b\x85\xbc\x4d\xd3\x65\xd7\x72\x6a\xc5\xba\x66\xac\xf7\x25\xd4\x8a\x67\xa6\xf8\x23\x53\xbf\xb4\xf7\x92\x3f\xa2\x0f\xe5\x00\xdf\xc3\x5b\x8d\x2d\x1c\xd0\x76\x8f\xad\x85\x62\x56\x9b\xfc\x76\x24\x0d\xb3\x22\x31\x4a\x3c\xd1\xeb\xe9\xbb\xfd\xf2\x27\xef\x0c\x45\x03\x29\x92\x9c\x7e\x7c\xc0\xdb\x66\xf7\xf3\xff\x1d\x9e\x25\x7a\x9a\x48\x13\x38\x5b\x38\xeb\xa9\x3b\x3f\x74\x9f\x01\x00\x00\xff\xff\xe1\x4d\x07\x98\x64\x01\x00\x00")
+
+func _1715637927_add_collection_socialsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1715637927_add_collection_socialsUpSql,
+		"1715637927_add_collection_socials.up.sql",
+	)
+}
+
+func _1715637927_add_collection_socialsUpSql() (*asset, error) {
+	bytes, err := _1715637927_add_collection_socialsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1715637927_add_collection_socials.up.sql", size: 356, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x63, 0x61, 0xb1, 0x1a, 0x75, 0x85, 0x89, 0x81, 0x1f, 0x84, 0x64, 0x62, 0x57, 0x6c, 0x85, 0xef, 0x17, 0x1a, 0xf2, 0x14, 0xcb, 0xd5, 0x7, 0x25, 0x98, 0x3a, 0x93, 0x7e, 0xd5, 0x9, 0xf6, 0xa0}}
 	return a, nil
 }
 
@@ -630,7 +650,7 @@ func docGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "doc.go", size: 94, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "doc.go", size: 94, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2f, 0x81, 0x21, 0x7a, 0x87, 0xd2, 0xef, 0xcc, 0x25, 0x5e, 0x95, 0x3f, 0x25, 0x79, 0xf7, 0x18, 0xaf, 0x57, 0xe7, 0x1e, 0x58, 0x50, 0xbb, 0xea, 0x27, 0x98, 0x89, 0xe1, 0x9f, 0x5c, 0xf6, 0x0}}
 	return a, nil
 }
@@ -726,70 +746,50 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"1691753758_initial.up.sql": _1691753758_initialUpSql,
-
-	"1692701329_add_collectibles_and_collections_data_cache.up.sql": _1692701329_add_collectibles_and_collections_data_cacheUpSql,
-
-	"1692701339_add_scope_to_pending.up.sql": _1692701339_add_scope_to_pendingUpSql,
-
-	"1694540071_add_collectibles_ownership_update_timestamp.up.sql": _1694540071_add_collectibles_ownership_update_timestampUpSql,
-
-	"1694692748_add_raw_balance_to_token_balances.up.sql": _1694692748_add_raw_balance_to_token_balancesUpSql,
-
+	"1691753758_initial.up.sql":                                                     _1691753758_initialUpSql,
+	"1692701329_add_collectibles_and_collections_data_cache.up.sql":                 _1692701329_add_collectibles_and_collections_data_cacheUpSql,
+	"1692701339_add_scope_to_pending.up.sql":                                        _1692701339_add_scope_to_pendingUpSql,
+	"1694540071_add_collectibles_ownership_update_timestamp.up.sql":                 _1694540071_add_collectibles_ownership_update_timestampUpSql,
+	"1694692748_add_raw_balance_to_token_balances.up.sql":                           _1694692748_add_raw_balance_to_token_balancesUpSql,
 	"1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql": _1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSql,
-
-	"1695932536_balance_history_v2.up.sql": _1695932536_balance_history_v2UpSql,
-
-	"1696853635_input_data.up.sql": _1696853635_input_dataUpSql,
-
-	"1698117918_add_community_id_to_tokens.up.sql": _1698117918_add_community_id_to_tokensUpSql,
-
-	"1698257443_add_community_metadata_to_wallet_db.up.sql": _1698257443_add_community_metadata_to_wallet_dbUpSql,
-
-	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql": _1699987075_add_timestamp_and_state_to_community_data_cacheUpSql,
-
-	"1700414564_add_wallet_connect_pairings_table.up.sql": _1700414564_add_wallet_connect_pairings_tableUpSql,
-
-	"1701101493_add_token_blocks_range.up.sql": _1701101493_add_token_blocks_rangeUpSql,
-
-	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql": _1702467441_wallet_connect_sessions_instead_of_pairingsUpSql,
-
-	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql": _1702577524_add_community_collections_and_collectibles_images_cacheUpSql,
-
-	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql": _1702867707_add_balance_to_collectibles_ownership_cacheUpSql,
-
-	"1703686612_add_color_to_saved_addresses.up.sql": _1703686612_add_color_to_saved_addressesUpSql,
-
+	"1695932536_balance_history_v2.up.sql":                                          _1695932536_balance_history_v2UpSql,
+	"1696853635_input_data.up.sql":                                                  _1696853635_input_dataUpSql,
+	"1698117918_add_community_id_to_tokens.up.sql":                                  _1698117918_add_community_id_to_tokensUpSql,
+	"1698257443_add_community_metadata_to_wallet_db.up.sql":                         _1698257443_add_community_metadata_to_wallet_dbUpSql,
+	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql":             _1699987075_add_timestamp_and_state_to_community_data_cacheUpSql,
+	"1700414564_add_wallet_connect_pairings_table.up.sql":                           _1700414564_add_wallet_connect_pairings_tableUpSql,
+	"1701101493_add_token_blocks_range.up.sql":                                      _1701101493_add_token_blocks_rangeUpSql,
+	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql":                 _1702467441_wallet_connect_sessions_instead_of_pairingsUpSql,
+	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql":     _1702577524_add_community_collections_and_collectibles_images_cacheUpSql,
+	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql":                 _1702867707_add_balance_to_collectibles_ownership_cacheUpSql,
+	"1703686612_add_color_to_saved_addresses.up.sql":                                _1703686612_add_color_to_saved_addressesUpSql,
 	"1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql": _1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSql,
-
-	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql": _1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql,
-
-	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql": _1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql,
-
-	"1706531789_remove_gasfee-only-eth-transfers.up.sql": _1706531789_remove_gasfeeOnlyEthTransfersUpSql,
-
-	"1707160323_add_contract_type_table.up.sql": _1707160323_add_contract_type_tableUpSql,
-
-	"1708089811_add_nullable_fiesl_blocks_ranges.up.sql": _1708089811_add_nullable_fiesl_blocks_rangesUpSql,
-
-	"1710189541_add_nonce_to_pending_transactions.up.sql": _1710189541_add_nonce_to_pending_transactionsUpSql,
-
-	"1712567001_add_soulbound_collectible_cache.up.sql": _1712567001_add_soulbound_collectible_cacheUpSql,
-
-	"1714670633_add_id_to_multi_transaction_table.up.sql": _1714670633_add_id_to_multi_transaction_tableUpSql,
-
+	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql":   _1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql,
+	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql":           _1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql,
+	"1706531789_remove_gasfee-only-eth-transfers.up.sql":                            _1706531789_remove_gasfeeOnlyEthTransfersUpSql,
+	"1707160323_add_contract_type_table.up.sql":                                     _1707160323_add_contract_type_tableUpSql,
+	"1708089811_add_nullable_fiesl_blocks_ranges.up.sql":                            _1708089811_add_nullable_fiesl_blocks_rangesUpSql,
+	"1710189541_add_nonce_to_pending_transactions.up.sql":                           _1710189541_add_nonce_to_pending_transactionsUpSql,
+	"1712567001_add_soulbound_collectible_cache.up.sql":                             _1712567001_add_soulbound_collectible_cacheUpSql,
+	"1714670633_add_id_to_multi_transaction_table.up.sql":                           _1714670633_add_id_to_multi_transaction_tableUpSql,
+	"1715637927_add_collection_socials.up.sql":                                      _1715637927_add_collection_socialsUpSql,
 	"doc.go": docGo,
 }
+
+// AssetDebug is true if the assets were built with the debug flag enabled.
+const AssetDebug = false
 
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and
@@ -822,33 +822,34 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"1691753758_initial.up.sql":                                                     &bintree{_1691753758_initialUpSql, map[string]*bintree{}},
-	"1692701329_add_collectibles_and_collections_data_cache.up.sql":                 &bintree{_1692701329_add_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
-	"1692701339_add_scope_to_pending.up.sql":                                        &bintree{_1692701339_add_scope_to_pendingUpSql, map[string]*bintree{}},
-	"1694540071_add_collectibles_ownership_update_timestamp.up.sql":                 &bintree{_1694540071_add_collectibles_ownership_update_timestampUpSql, map[string]*bintree{}},
-	"1694692748_add_raw_balance_to_token_balances.up.sql":                           &bintree{_1694692748_add_raw_balance_to_token_balancesUpSql, map[string]*bintree{}},
-	"1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql": &bintree{_1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
-	"1695932536_balance_history_v2.up.sql":                                          &bintree{_1695932536_balance_history_v2UpSql, map[string]*bintree{}},
-	"1696853635_input_data.up.sql":                                                  &bintree{_1696853635_input_dataUpSql, map[string]*bintree{}},
-	"1698117918_add_community_id_to_tokens.up.sql":                                  &bintree{_1698117918_add_community_id_to_tokensUpSql, map[string]*bintree{}},
-	"1698257443_add_community_metadata_to_wallet_db.up.sql":                         &bintree{_1698257443_add_community_metadata_to_wallet_dbUpSql, map[string]*bintree{}},
-	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql":             &bintree{_1699987075_add_timestamp_and_state_to_community_data_cacheUpSql, map[string]*bintree{}},
-	"1700414564_add_wallet_connect_pairings_table.up.sql":                           &bintree{_1700414564_add_wallet_connect_pairings_tableUpSql, map[string]*bintree{}},
-	"1701101493_add_token_blocks_range.up.sql":                                      &bintree{_1701101493_add_token_blocks_rangeUpSql, map[string]*bintree{}},
-	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql":                 &bintree{_1702467441_wallet_connect_sessions_instead_of_pairingsUpSql, map[string]*bintree{}},
-	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql":     &bintree{_1702577524_add_community_collections_and_collectibles_images_cacheUpSql, map[string]*bintree{}},
-	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql":                 &bintree{_1702867707_add_balance_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
-	"1703686612_add_color_to_saved_addresses.up.sql":                                &bintree{_1703686612_add_color_to_saved_addressesUpSql, map[string]*bintree{}},
-	"1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql": &bintree{_1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSql, map[string]*bintree{}},
-	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql":   &bintree{_1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
-	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql":           &bintree{_1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql, map[string]*bintree{}},
-	"1706531789_remove_gasfee-only-eth-transfers.up.sql":                            &bintree{_1706531789_remove_gasfeeOnlyEthTransfersUpSql, map[string]*bintree{}},
-	"1707160323_add_contract_type_table.up.sql":                                     &bintree{_1707160323_add_contract_type_tableUpSql, map[string]*bintree{}},
-	"1708089811_add_nullable_fiesl_blocks_ranges.up.sql":                            &bintree{_1708089811_add_nullable_fiesl_blocks_rangesUpSql, map[string]*bintree{}},
-	"1710189541_add_nonce_to_pending_transactions.up.sql":                           &bintree{_1710189541_add_nonce_to_pending_transactionsUpSql, map[string]*bintree{}},
-	"1712567001_add_soulbound_collectible_cache.up.sql":                             &bintree{_1712567001_add_soulbound_collectible_cacheUpSql, map[string]*bintree{}},
-	"1714670633_add_id_to_multi_transaction_table.up.sql":                           &bintree{_1714670633_add_id_to_multi_transaction_tableUpSql, map[string]*bintree{}},
-	"doc.go": &bintree{docGo, map[string]*bintree{}},
+	"1691753758_initial.up.sql":                                                     {_1691753758_initialUpSql, map[string]*bintree{}},
+	"1692701329_add_collectibles_and_collections_data_cache.up.sql":                 {_1692701329_add_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
+	"1692701339_add_scope_to_pending.up.sql":                                        {_1692701339_add_scope_to_pendingUpSql, map[string]*bintree{}},
+	"1694540071_add_collectibles_ownership_update_timestamp.up.sql":                 {_1694540071_add_collectibles_ownership_update_timestampUpSql, map[string]*bintree{}},
+	"1694692748_add_raw_balance_to_token_balances.up.sql":                           {_1694692748_add_raw_balance_to_token_balancesUpSql, map[string]*bintree{}},
+	"1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql": {_1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
+	"1695932536_balance_history_v2.up.sql":                                          {_1695932536_balance_history_v2UpSql, map[string]*bintree{}},
+	"1696853635_input_data.up.sql":                                                  {_1696853635_input_dataUpSql, map[string]*bintree{}},
+	"1698117918_add_community_id_to_tokens.up.sql":                                  {_1698117918_add_community_id_to_tokensUpSql, map[string]*bintree{}},
+	"1698257443_add_community_metadata_to_wallet_db.up.sql":                         {_1698257443_add_community_metadata_to_wallet_dbUpSql, map[string]*bintree{}},
+	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql":             {_1699987075_add_timestamp_and_state_to_community_data_cacheUpSql, map[string]*bintree{}},
+	"1700414564_add_wallet_connect_pairings_table.up.sql":                           {_1700414564_add_wallet_connect_pairings_tableUpSql, map[string]*bintree{}},
+	"1701101493_add_token_blocks_range.up.sql":                                      {_1701101493_add_token_blocks_rangeUpSql, map[string]*bintree{}},
+	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql":                 {_1702467441_wallet_connect_sessions_instead_of_pairingsUpSql, map[string]*bintree{}},
+	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql":     {_1702577524_add_community_collections_and_collectibles_images_cacheUpSql, map[string]*bintree{}},
+	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql":                 {_1702867707_add_balance_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
+	"1703686612_add_color_to_saved_addresses.up.sql":                                {_1703686612_add_color_to_saved_addressesUpSql, map[string]*bintree{}},
+	"1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql": {_1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSql, map[string]*bintree{}},
+	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql":   {_1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
+	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql":           {_1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql, map[string]*bintree{}},
+	"1706531789_remove_gasfee-only-eth-transfers.up.sql":                            {_1706531789_remove_gasfeeOnlyEthTransfersUpSql, map[string]*bintree{}},
+	"1707160323_add_contract_type_table.up.sql":                                     {_1707160323_add_contract_type_tableUpSql, map[string]*bintree{}},
+	"1708089811_add_nullable_fiesl_blocks_ranges.up.sql":                            {_1708089811_add_nullable_fiesl_blocks_rangesUpSql, map[string]*bintree{}},
+	"1710189541_add_nonce_to_pending_transactions.up.sql":                           {_1710189541_add_nonce_to_pending_transactionsUpSql, map[string]*bintree{}},
+	"1712567001_add_soulbound_collectible_cache.up.sql":                             {_1712567001_add_soulbound_collectible_cacheUpSql, map[string]*bintree{}},
+	"1714670633_add_id_to_multi_transaction_table.up.sql":                           {_1714670633_add_id_to_multi_transaction_tableUpSql, map[string]*bintree{}},
+	"1715637927_add_collection_socials.up.sql":                                      {_1715637927_add_collection_socialsUpSql, map[string]*bintree{}},
+	"doc.go": {docGo, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.
@@ -865,7 +866,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/walletdatabase/migrations/sql/1715637927_add_collection_socials.up.sql
+++ b/walletdatabase/migrations/sql/1715637927_add_collection_socials.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS collection_socials_cache (
+    chain_id UNSIGNED BIGINT NOT NULL,
+    contract_address VARCHAR NOT NULL,
+    provider VARCHAR NOT NULL,
+    website VARCHAR NOT NULL,
+    twitter_handle VARCHAR NOT NULL,
+    FOREIGN KEY(chain_id, contract_address) REFERENCES collection_data_cache(chain_id, contract_address) ON DELETE CASCADE
+);


### PR DESCRIPTION
A short summary which serves as a squashed-commit message.

Adds new table to hold collection socials such website and twitter handle. We can only rely on Alchemy to provide this data as of now due to missing api in rarible and opensea requests limitation.

In case Alchemy is the default provider we add values in the collection_socials_cache db. And in case other providers are being used the socials will be fetched from alchmey async and a signal with filled data will be sent to the client.

A description to understand introduced changes without reading the code.

Important changes:
- [x] Something worth noting for reviewers.

Closes #
