### PR TITLE
fix: crash in 'dbRecordBundleToCommunity' if event was signed not by a control node

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -3330,7 +3330,7 @@ func (m *Manager) dbRecordBundleToCommunity(r *CommunityRecordBundle) (*Communit
 			if err != nil {
 				m.logger.Error("invalid EventsBaseCommunityDescription", zap.Error(err))
 			}
-			if eventsDescription.Clock == community.Clock() {
+			if eventsDescription != nil && eventsDescription.Clock == community.Clock() {
 				community.applyEvents()
 			}
 		}


### PR DESCRIPTION
Crash in `dbRecordBundleToCommunity` if event was signed not by a control node

Closes # https://github.com/status-im/status-desktop/issues/14263
