### PR TITLE
fix: increase mute interval check

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -161,4 +161,4 @@ def getDefaultUnitTestUseDevelopmentLogger() { isTestNightlyJob() ? false : true
 
 def getDefaultUnitTestFailfast() { isTestNightlyJob() ? false : true }
 
-def getDefaultTimeout() { isTestNightlyJob() ? 5*60 : 40 }
+def getDefaultTimeout() { isTestNightlyJob() ? 5*60 : 50 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1558,7 +1558,7 @@ func (m *Messenger) watchChatsAndCommunitiesToUnmute() {
 	go func() {
 		for {
 			select {
-			case <-time.After(3 * time.Second): // Poll every 3 seconds
+			case <-time.After(1 * time.Minute):
 				response := &MessengerResponse{}
 				m.allChats.Range(func(chatID string, c *Chat) bool {
 					chatMuteTill, _ := time.Parse(time.RFC3339, c.MuteTill.Format(time.RFC3339))
@@ -1593,7 +1593,7 @@ func (m *Messenger) watchCommunitiesToUnmute() {
 	go func() {
 		for {
 			select {
-			case <-time.After(3 * time.Second): // Poll every 3 seconds
+			case <-time.After(1 * time.Minute):
 				response, err := m.CheckCommunitiesToUnmute()
 				if err != nil {
 					return


### PR DESCRIPTION
Each 3 seconds is much too frequent, it leads to all communities being read from the database and as a consequence to extensive memory consumption (most likely garbage collector was not fast enough to cleanup allocated memory).

mitigates: status-im/status-desktop#14281

@endulab was the one who found the culprit:
![alloc-bridge3](https://github.com/status-im/status-go/assets/33099791/4f65e78d-964b-435a-b187-9850da3abd58)
