### PR TITLE
fix(wallet): activity duplicate in case of non-native transfer

### DIFF
--- a/services/wallet/transfer/commands.go
+++ b/services/wallet/transfer/commands.go
@@ -341,6 +341,7 @@ func (c *transfersCommand) confirmPendingTransactions(tx *sql.Tx, allTransfers [
 					continue
 				} else if err != nil {
 					log.Warn("GetOwnedMultiTransactionID", "error", err)
+				existingMTID, err := GetOwnedMultiTransactionID(tx, chainID, txHash, tr.Address)
 					continue
 				}
 				mTID = w_common.NewAndSet(existingMTID)

--- a/services/wallet/transfer/database.go
+++ b/services/wallet/transfer/database.go
@@ -562,8 +562,8 @@ func markBlocksAsLoaded(chainID uint64, creator statementCreator, address common
 }
 
 // GetOwnedMultiTransactionID returns sql.ErrNoRows if no transaction is found for the given identity
-func GetOwnedMultiTransactionID(tx *sql.Tx, chainID w_common.ChainID, id common.Hash, address common.Address) (mTID int64, err error) {
-	row := tx.QueryRow(`SELECT COALESCE(multi_transaction_id, 0) FROM transfers WHERE network_id = ? AND hash = ? AND address = ?`, chainID, id, address)
+func GetOwnedMultiTransactionID(tx *sql.Tx, chainID w_common.ChainID, hash common.Hash, address common.Address) (mTID int64, err error) {
+	row := tx.QueryRow(`SELECT COALESCE(multi_transaction_id, 0) FROM transfers WHERE network_id = ? AND tx_hash = ? AND address = ?`, chainID, hash, address)
 	err = row.Scan(&mTID)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
### Updates: status-desktop [#14071](https://github.com/status-im/status-desktop/issues/14071)

The "`hash`" (a.k.a. ID) column was used for matching transfer entry which works only for native transfers that have the `ID` same as hash. The fix switched matching by the `tx_hash` the real transaction hash. The ID disguised as `hash` column strikes again :(

The challenging part in finding the root cause was the fact that the issue is not reproducible by calling `wallet_checkRecentHistoryForChainIDs`, in which case the transaction is downloaded only once and multi-transaction ID extracted from pending. However, in the desktop app the transaction is updated twice and the second time it wasn't working, because it relies on extracting MTID from `transfers`,  :(

I also added an minor improvement in a separate commit.