### PR TITLE
fix: omit l1GasFee in json

### DIFF
--- a/services/wallet/fees.go
+++ b/services/wallet/fees.go
@@ -30,7 +30,7 @@ type SuggestedFees struct {
 	MaxFeePerGasLow      *big.Float `json:"maxFeePerGasLow"`
 	MaxFeePerGasMedium   *big.Float `json:"maxFeePerGasMedium"`
 	MaxFeePerGasHigh     *big.Float `json:"maxFeePerGasHigh"`
-	L1GasFee             *big.Float `json:"l1GasFee"`
+	L1GasFee             *big.Float `json:"l1GasFee,omitempty"`
 	EIP1559Enabled       bool       `json:"eip1559Enabled"`
 }
 


### PR DESCRIPTION
To make json conversion easier in Nim side.

Needed for [this](https://github.com/status-im/status-desktop/issues/14307).