### PR TITLE
Bug: Fix view&post token-permitted channel input not locked

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4067,26 +4067,51 @@ func (m *Messenger) CheckPermissionsToJoinCommunity(request *requests.CheckPermi
 	return m.communitiesManager.CheckPermissionToJoin(request.CommunityID, addresses)
 }
 
-func (m *Messenger) CheckCommunityChannelPermissions(request *requests.CheckCommunityChannelPermissions) (*communities.CheckChannelPermissionsResponse, error) {
-	if err := request.Validate(); err != nil {
-		return nil, err
+func (m *Messenger) getSharedAddresses(communityID types.HexBytes, requestAddresses []string) ([]gethcommon.Address, error) {
+	addressesMap := make(map[string]struct{})
+
+	for _, v := range requestAddresses {
+		addressesMap[v] = struct{}{}
 	}
 
-	var addresses []gethcommon.Address
+	if len(requestAddresses) == 0 {
+		sharedAddresses, err := m.GetRevealedAccounts(communityID, common.PubkeyToHex(&m.identity.PublicKey))
+		if err != nil {
+			return nil, err
+		}
 
-	if len(request.Addresses) == 0 {
+		for _, v := range sharedAddresses {
+			addressesMap[v.Address] = struct{}{}
+		}
+	}
+
+	if len(addressesMap) == 0 {
 		accounts, err := m.settings.GetActiveAccounts()
 		if err != nil {
 			return nil, err
 		}
 
 		for _, a := range accounts {
-			addresses = append(addresses, gethcommon.HexToAddress(a.Address.Hex()))
+			addressesMap[a.Address.Hex()] = struct{}{}
 		}
-	} else {
-		for _, v := range request.Addresses {
-			addresses = append(addresses, gethcommon.HexToAddress(v))
-		}
+	}
+
+	var addresses []gethcommon.Address
+	for addr := range addressesMap {
+		addresses = append(addresses, gethcommon.HexToAddress(addr))
+	}
+
+	return addresses, nil
+}
+
+func (m *Messenger) CheckCommunityChannelPermissions(request *requests.CheckCommunityChannelPermissions) (*communities.CheckChannelPermissionsResponse, error) {
+	if err := request.Validate(); err != nil {
+		return nil, err
+	}
+
+	addresses, err := m.getSharedAddresses(request.CommunityID, request.Addresses)
+	if err != nil {
+		return nil, err
 	}
 
 	return m.communitiesManager.CheckChannelPermissions(request.CommunityID, request.ChatID, addresses)
@@ -4097,21 +4122,9 @@ func (m *Messenger) CheckAllCommunityChannelsPermissions(request *requests.Check
 		return nil, err
 	}
 
-	var addresses []gethcommon.Address
-
-	if len(request.Addresses) == 0 {
-		accounts, err := m.settings.GetActiveAccounts()
-		if err != nil {
-			return nil, err
-		}
-
-		for _, a := range accounts {
-			addresses = append(addresses, gethcommon.HexToAddress(a.Address.Hex()))
-		}
-	} else {
-		for _, v := range request.Addresses {
-			addresses = append(addresses, gethcommon.HexToAddress(v))
-		}
+	addresses, err := m.getSharedAddresses(request.CommunityID, request.Addresses)
+	if err != nil {
+		return nil, err
 	}
 
 	return m.communitiesManager.CheckAllChannelsPermissions(request.CommunityID, addresses)


### PR DESCRIPTION
### Description

In previous version of status-go, we failed to compute the permission for communities with token permitted channels. This caused the UI to display the wrong UI when displaying the channel UI. Indeed, the user was enable to view the channel and couldn't send messages.
In this PR, we are now able to lock consistently the channel if we do not have permission to view&post. This PR fixes [#14117](https://github.com/status-im/status-desktop/issues/14117)
The change consists in adding a retrieval of the Revealed accounts for cases when the addresses are not shared, and where the purpose isn't to have all accounts considered for the calculation of permissions on channel.

### Testing

Multiple tests already cover the functions `CheckAllChannelsPermissions` and `CheckChannelPermissions`, making sure all tests are passed. If any strong opinion on the testing side, I can allocate a bit more time.

- community_test.go
- manager_test.go

I have also checked the flows : 

-[x] Restore write when channel is unlocked
-[x] Set the channel permissions at boot
-[x] Detect changes when user
   -[x] edit permissions
   -[x] create permissions
   -[x] delete permissions

### Demo

[Screencast from 2024-04-08 12:18:14 AM.webm](https://github.com/status-im/status-go/assets/2589171/100bbd52-d622-49d4-b87f-9bd0c713dc77)
