### PR TITLE
fix: fetch community only when assets metadata is missing

### DIFF
--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -728,7 +728,7 @@ func (o *Manager) fillCommunityID(asset *thirdparty.FullCollectibleData) error {
 }
 
 func (o *Manager) fetchCommunityAssets(communityID string, communityAssets []*thirdparty.FullCollectibleData) error {
-	communityInfo, err := o.communityManager.FetchCommunityInfo(communityID)
+	communityInfo, err := o.communityManager.FetchCommunityInfoForCollectibles(communityID, idsFromAssets(communityAssets))
 
 	// If the community is found, we update the DB.
 	// If the community is not found, we only insert new entries to the DB (don't replace what is already there).

--- a/services/wallet/collectibles/types.go
+++ b/services/wallet/collectibles/types.go
@@ -201,3 +201,11 @@ func communityInfoToData(communityID string, community *thirdparty.CommunityInfo
 
 	return ret
 }
+
+func idsFromAssets(assets []*thirdparty.FullCollectibleData) []thirdparty.CollectibleUniqueID {
+	result := make([]thirdparty.CollectibleUniqueID, len(assets))
+	for i, asset := range assets {
+		result[i] = asset.CollectibleData.ID
+	}
+	return result
+}

--- a/services/wallet/community/manager.go
+++ b/services/wallet/community/manager.go
@@ -66,8 +66,8 @@ func (cm *Manager) setCommunityInfo(id string, c *thirdparty.CommunityInfo) (err
 	return cm.db.SetCommunityInfo(id, c)
 }
 
-func (cm *Manager) FetchCommunityInfo(communityID string) (*thirdparty.CommunityInfo, error) {
-	communityInfo, err := cm.communityInfoProvider.FetchCommunityInfo(communityID)
+func (cm *Manager) fetchCommunityInfo(communityID string, fetcher func() (*thirdparty.CommunityInfo, error)) (*thirdparty.CommunityInfo, error) {
+	communityInfo, err := fetcher()
 	if err != nil {
 		dbErr := cm.setCommunityInfo(communityID, nil)
 		if dbErr != nil {
@@ -77,6 +77,18 @@ func (cm *Manager) FetchCommunityInfo(communityID string) (*thirdparty.Community
 	}
 	err = cm.setCommunityInfo(communityID, communityInfo)
 	return communityInfo, err
+}
+
+func (cm *Manager) FetchCommunityInfo(communityID string) (*thirdparty.CommunityInfo, error) {
+	return cm.fetchCommunityInfo(communityID, func() (*thirdparty.CommunityInfo, error) {
+		return cm.communityInfoProvider.FetchCommunityInfo(communityID)
+	})
+}
+
+func (cm *Manager) FetchCommunityInfoForCollectibles(communityID string, ids []thirdparty.CollectibleUniqueID) (*thirdparty.CommunityInfo, error) {
+	return cm.fetchCommunityInfo(communityID, func() (*thirdparty.CommunityInfo, error) {
+		return cm.communityInfoProvider.FetchCommunityInfoForCollectibles(communityID, ids)
+	})
 }
 
 func (cm *Manager) FetchCommunityMetadataAsync(communityID string) {

--- a/services/wallet/thirdparty/community_types.go
+++ b/services/wallet/thirdparty/community_types.go
@@ -14,4 +14,5 @@ type CommunityInfoProvider interface {
 	// Collectible-related methods
 	GetCommunityID(tokenURI string) string
 	FillCollectibleMetadata(collectible *FullCollectibleData) error
+	FetchCommunityInfoForCollectibles(communityID string, ids []CollectibleUniqueID) (*CommunityInfo, error)
 }


### PR DESCRIPTION
fix: fetch community only when assets metadata is missing (also prevent fetching if we are a control node)

fixes: https://github.com/status-im/status-desktop/issues/14296

