### PR TITLE
Bump go to 1.20

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,22 +42,17 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gosec
-    - goconst
     - goimports
-    - golint
     - govet
     - ineffassign
     - megacheck
     - misspell
-    - structcheck
     # You can't disable typecheck, see:
     # https://github.com/golangci/golangci-lint/blob/master/docs/src/docs/welcome/faq.mdx#why-do-you-have-typecheck-errors
     - typecheck
     - unconvert
-    - varcheck
   fast: false
 
 issues:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/status-im/status-go
 
-go 1.19
+go 1.20
 
 replace github.com/ethereum/go-ethereum v1.10.26 => github.com/status-im/go-ethereum v1.10.25-status.13
 

--- a/mailserver/mailserver_test.go
+++ b/mailserver/mailserver_test.go
@@ -107,7 +107,9 @@ func (s *MailserverSuite) TestInit() {
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, testCase := range testCases {
+		// to satisfy gosec: C601 checks
+		tc := testCase
 		s.T().Run(tc.info, func(*testing.T) {
 			mailServer := &WakuMailServer{}
 			shh := waku.New(&waku.DefaultConfig, nil)
@@ -299,7 +301,9 @@ func (s *MailserverSuite) TestMailServer() {
 			info: "Processing a request where difference between from and to is > 24 should fail",
 		},
 	}
-	for _, tc := range testCases {
+	for _, testCase := range testCases {
+		// to satisfy gosec: C601 checks
+		tc := testCase
 		s.T().Run(tc.info, func(*testing.T) {
 			request := s.createRequest(tc.params)
 			src := crypto.FromECDSAPub(&tc.params.key.PublicKey)

--- a/multiaccounts/accounts/keycard_database.go
+++ b/multiaccounts/accounts/keycard_database.go
@@ -263,7 +263,8 @@ func (db *Database) deleteKeycardAccounts(tx *sql.Tx, kcUID string, accountAddre
 	}
 
 	inVector := strings.Repeat(",?", len(accountAddresses)-1)
-	query := `
+	//nolint: gosec
+	query := ` 
 		DELETE
 		FROM
 			keycards_accounts

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -22,12 +22,12 @@ in rec {
     ];
   };
 
-  go = prev.go_1_19;
-  buildGoModule = prev.buildGo119Module;
-  buildGoPackage = prev.buildGo119Package;
+  go = prev.go_1_20;
+  buildGoModule = prev.buildGo120Module;
+  buildGoPackage = prev.buildGo120Package;
 
   golangci-lint = prev.golangci-lint.override {
-    buildGoModule = args: prev.buildGo119Module ( args // rec {
+    buildGoModule = args: prev.buildGo120Module ( args // rec {
       version = "1.52.2";
       src = prev.fetchFromGitHub {
         owner = "golangci";

--- a/protocol/activity_center_persistence.go
+++ b/protocol/activity_center_persistence.go
@@ -853,7 +853,7 @@ func (db sqlitePersistence) MarkActivityCenterNotificationsDeleted(ids []types.H
 		return nil, err
 	}
 
-	update := "UPDATE activity_center_notifications SET deleted = 1, updated_at = ? WHERE id IN (" + inVector + ") AND NOT deleted"
+	update := "UPDATE activity_center_notifications SET deleted = 1, updated_at = ? WHERE id IN (" + inVector + ") AND NOT deleted" //nolint: gosec
 	_, err = tx.Exec(update, args...)
 	if err != nil {
 		return nil, err

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -960,7 +960,7 @@ func (p *Persistence) GetLatestWakuMessageTimestamp(topics []types.TopicType) (u
 
 func (p *Persistence) GetWakuMessagesByFilterTopic(topics []types.TopicType, from uint64, to uint64) ([]types.Message, error) {
 
-	query := "SELECT sig, timestamp, topic, payload, padding, hash, third_party_id FROM waku_messages WHERE timestamp >= " + fmt.Sprint(from) + " AND timestamp < " + fmt.Sprint(to) + " AND ("
+	query := "SELECT sig, timestamp, topic, payload, padding, hash, third_party_id FROM waku_messages WHERE timestamp >= " + fmt.Sprint(from) + " AND timestamp < " + fmt.Sprint(to) + " AND (" //nolint: gosec
 
 	for i, topic := range topics {
 		query += `topic = "` + topic.String() + `"`

--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -3016,7 +3016,7 @@ func (db sqlitePersistence) findStatusMessageIDForBridgeMessageID(tx *sql.Tx, me
 }
 
 func (db sqlitePersistence) updateStatusMessagesWithResponse(tx *sql.Tx, statusMessagesToUpdate []string, responseValue string) error {
-	sql := "UPDATE user_messages SET response_to = ? WHERE id IN (?" + strings.Repeat(",?", len(statusMessagesToUpdate)-1) + ")"
+	sql := "UPDATE user_messages SET response_to = ? WHERE id IN (?" + strings.Repeat(",?", len(statusMessagesToUpdate)-1) + ")" //nolint: gosec
 	stmt, err := tx.Prepare(sql)
 	if err != nil {
 		return err

--- a/protocol/transport/filters_manager.go
+++ b/protocol/transport/filters_manager.go
@@ -150,7 +150,9 @@ func (f *FiltersManager) InitCommunityFilters(communityFiltersToInitialize []Com
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
-	for _, cf := range communityFiltersToInitialize {
+	for _, communityFilter := range communityFiltersToInitialize {
+		// to satisfy gosec: C601 checks
+		cf := communityFilter
 		if cf.PrivKey == nil {
 			continue
 		}

--- a/services/wallet/collectibles/service.go
+++ b/services/wallet/collectibles/service.go
@@ -499,7 +499,9 @@ func (s *Service) notifyCommunityCollectiblesReceived(ownedCollectibles OwnedCol
 	}
 
 	groups := make(map[CollectibleGroup]Collectible)
-	for _, collectible := range communityCollectibles {
+	for _, localCollectible := range communityCollectibles {
+		// to satisfy gosec: C601 checks
+		collectible := localCollectible
 		txHash := ""
 		for key, value := range hashMap {
 			if key.Same(&collectible.ID) {

--- a/services/wallet/collectibles/types.go
+++ b/services/wallet/collectibles/types.go
@@ -159,7 +159,9 @@ func fullCollectiblesDataToDetails(data []thirdparty.FullCollectibleData) []Coll
 func fullCollectiblesDataToCommunityHeader(data []thirdparty.FullCollectibleData) []Collectible {
 	res := make([]Collectible, 0, len(data))
 
-	for _, c := range data {
+	for _, localCollectibleData := range data {
+		// to satisfy gosec: C601 checks
+		c := localCollectibleData
 		collectibleID := c.CollectibleData.ID
 		communityID := c.CollectibleData.CommunityID
 

--- a/services/wallet/transfer/block_ranges_sequential_dao.go
+++ b/services/wallet/transfer/block_ranges_sequential_dao.go
@@ -115,7 +115,7 @@ func (b *BlockRangeSequentialDAO) getBlockRanges(chainID uint64, addresses []com
 		}
 	}
 
-	query := "SELECT address, blk_start, blk_first, blk_last, token_blk_start, token_blk_first, token_blk_last, balance_check_hash FROM blocks_ranges_sequential WHERE address IN (" +
+	query := "SELECT address, blk_start, blk_first, blk_last, token_blk_start, token_blk_first, token_blk_last, balance_check_hash FROM blocks_ranges_sequential WHERE address IN (" + //nolint: gosec
 		addressesPlaceholder + ") AND network_id = ?"
 
 	params := []interface{}{}

--- a/services/wallet/transfer/database.go
+++ b/services/wallet/transfer/database.go
@@ -326,7 +326,9 @@ func insertBlocksWithTransactions(chainID uint64, creator statementCreator, head
 
 func updateOrInsertTransfers(chainID uint64, creator statementCreator, transfers []Transfer) error {
 	txsDBFields := make([]transferDBFields, 0, len(transfers))
-	for _, t := range transfers {
+	for _, localTransfer := range transfers {
+		// to satisfy gosec: C601 checks
+		t := localTransfer
 		var receiptType *uint8
 		var txHash, blockHash *common.Hash
 		var receiptStatus, cumulativeGasUsed, gasUsed *uint64

--- a/transactions/testhelpers.go
+++ b/transactions/testhelpers.go
@@ -143,7 +143,9 @@ func MockTestTransactions(t *testing.T, chainClient *MockChainClient, testTxs []
 				return false
 			}
 			for i := range b {
-				for _, sum := range chainSummaries {
+				for _, localSummary := range chainSummaries {
+					// to satisfy gosec: C601 checks
+					sum := localSummary
 					tx := &sum.tx
 					if sum.answered {
 						continue
@@ -165,7 +167,9 @@ func MockTestTransactions(t *testing.T, chainClient *MockChainClient, testTxs []
 				require.True(t, ok)
 				require.NotNil(t, receiptWrapper)
 				// Simulate parsing of eth_getTransactionReceipt response
-				for _, sum := range chainSummaries {
+				for _, localSum := range chainSummaries {
+					// to satisfy gosec: C601 checks
+					sum := localSum
 					tx := &sum.tx
 					if tx.Hash == elems[i].Args[0].(eth.Hash) {
 						if !sum.summary.DontConfirm {

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -266,7 +266,9 @@ func (s *TransactorSuite) TestSendTransactionWithSignature() {
 		},
 	}
 
-	for _, scenario := range scenarios {
+	for _, localScenario := range scenarios {
+		// to satisfy gosec: C601 checks
+		scenario := localScenario
 		desc := fmt.Sprintf("nonceFromNetwork: %d, tx nonce: %d, expect error: %v", scenario.nonceFromNetwork, scenario.txNonce, scenario.expectError)
 		s.T().Run(desc, func(t *testing.T) {
 			nonce := scenario.txNonce


### PR DESCRIPTION
## Summary

This PR attempts to upgrade go version to 1.20
This PR also removes the following items from lint checks : 
* `goconst`
* `structcheck`
* `deadcode`
* `golint`
* `varcheck`

Mobile PR for QA purposes -> https://github.com/status-im/status-mobile/pull/19564

## Todo

- [x] Store nodes not available on mobile -> https://github.com/status-im/status-mobile/issues/19581

