### PR TITLE
refactor: move lint args to configuration file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   concurrency: 4
-  deadline: 1m
+  timeout: 5m
   issues-exit-code: 1
   modules-download-mode: vendor
   tests: true
@@ -53,7 +53,9 @@ linters:
     - megacheck
     - misspell
     - structcheck
-#    - typecheck
+    # You can't disable typecheck, see:
+    # https://github.com/golangci/golangci-lint/blob/master/docs/src/docs/welcome/faq.mdx#why-do-you-have-typecheck-errors
+    - typecheck
     - unconvert
     - varcheck
   fast: false
@@ -64,6 +66,7 @@ issues:
     - "G304: Potential file inclusion via variable" # gosec
     - "G104: Errors unhandled." #gosec
     - "lib._Ctype_char, which can be annoying to use" # golint
+    - "SA1019" # staticcheck
   exclude-rules:
     - path: eth-node/keystore/passphrase\.go
       text: "make it a constant"

--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ canary-test: node-canary
 
 lint:
 	@echo "lint"
-	@golangci-lint --exclude=SA1019 run ./... --deadline=5m
+	@golangci-lint run ./...
 
 ci: lint canary-test test-unit test-e2e ##@tests Run all linters and tests at once
 


### PR DESCRIPTION
- lint args moved to conf file
- deadline was renamed to timeout some time ago, see https://github.com/golangci/golangci-lint/commit/0cc87df732aaf1d5ad9ce9ca538d38d916918b36
- added a comment, that typecheck cant be disabled, it's compilation errors, see [FAQ](https://github.com/golangci/golangci-lint/blob/master/docs/src/docs/welcome/faq.mdx#why-do-you-have-typecheck-errors)