### PR TITLE
fix: add patch for xcode-15 compatibility

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -62,6 +62,10 @@ in rec {
         url = "https://github.com/golang/mobile/commit/406ed3a7b8e44dc32844953647b49696d8847d51.patch";
         sha256 = "sha256-dqbYukHkQEw8npOkKykOAzMC3ot/Y4DEuh7fE+ptlr8=";
       })
+      (final.fetchurl { # https://github.com/golang/go/issues/63141
+        url = "https://github.com/golang/mobile/commit/e2f452493d570cfe278e63eccec99e62d4c775e5.patch";
+        sha256 = "sha256-gFcy/Ikh7MzmDx5Tpxe3qCnP36+ZTKU2XkJGH6n5l7Q=";
+      })
     ];
   }));
 }


### PR DESCRIPTION
## Summary

This issue exists in `gomobile` here -> https://github.com/golang/go/issues/63141
This PR makes sure `make statusgo-ios` works with Xcode 15 by applying [this](https://go-review.googlesource.com/c/mobile/+/530135/5/cmd/gomobile/bind_iosapp.go) patch on top of our existing `gomobile` overlay.

## Review notes

On Macos with Xcode 15 `make statusgo-ios` should work.

Closes #5034
