### PR TITLE
fix: improve `fetchCommunityAssets` performance

### DIFF
--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -52,6 +52,7 @@ import (
 	"github.com/status-im/status-go/services/ext/mailservers"
 	mailserversDB "github.com/status-im/status-go/services/mailservers"
 	"github.com/status-im/status-go/services/wallet"
+	"github.com/status-im/status-go/services/wallet/collectibles"
 	w_common "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/wakuv2"
@@ -533,7 +534,30 @@ func (s *Service) GetCommunityID(tokenURI string) string {
 	return ""
 }
 
-func (s *Service) FillCollectibleMetadata(collectible *thirdparty.FullCollectibleData) error {
+func (s *Service) FillCollectiblesMetadata(communityID string, cs []*thirdparty.FullCollectibleData) (bool, error) {
+	if s.messenger == nil {
+		return false, fmt.Errorf("messenger not ready")
+	}
+
+	community, err := s.fetchCommunityInfoForCollectibles(communityID, collectibles.IDsFromAssets(cs))
+	if err != nil {
+		return false, err
+	}
+	if community == nil {
+		return false, nil
+	}
+
+	for _, collectible := range cs {
+		err := s.FillCollectibleMetadata(community, collectible)
+		if err != nil {
+			return true, err
+		}
+	}
+
+	return true, nil
+}
+
+func (s *Service) FillCollectibleMetadata(community *communities.Community, collectible *thirdparty.FullCollectibleData) error {
 	if s.messenger == nil {
 		return fmt.Errorf("messenger not ready")
 	}
@@ -547,14 +571,6 @@ func (s *Service) FillCollectibleMetadata(collectible *thirdparty.FullCollectibl
 
 	if communityID == "" {
 		return fmt.Errorf("invalid communityID")
-	}
-
-	community, err := s.messenger.FindCommunityInfoFromDB(communityID)
-	if err != nil {
-		if err == communities.ErrOrgNotFound {
-			return nil
-		}
-		return err
 	}
 
 	tokenMetadata, err := s.fetchCommunityCollectibleMetadata(community, id.ContractID)
@@ -631,7 +647,7 @@ func communityToInfo(community *communities.Community) *thirdparty.CommunityInfo
 	}
 }
 
-func (s *Service) fetchCommunityFromStoreNodes(communityID string) (*thirdparty.CommunityInfo, error) {
+func (s *Service) fetchCommunityFromStoreNodes(communityID string) (*communities.Community, error) {
 	community, err := s.messenger.FetchCommunity(&protocol.FetchCommunityRequest{
 		CommunityKey:    communityID,
 		TryDatabase:     false,
@@ -640,7 +656,7 @@ func (s *Service) fetchCommunityFromStoreNodes(communityID string) (*thirdparty.
 	if err != nil {
 		return nil, err
 	}
-	return communityToInfo(community), nil
+	return community, nil
 }
 
 // Fetch latest community from store nodes.
@@ -656,18 +672,17 @@ func (s *Service) FetchCommunityInfo(communityID string) (*thirdparty.CommunityI
 
 	// Fetch latest version from store nodes
 	if community == nil || !community.IsControlNode() {
-		return s.fetchCommunityFromStoreNodes(communityID)
+		community, err = s.fetchCommunityFromStoreNodes(communityID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return communityToInfo(community), nil
 }
 
 // Fetch latest community from store nodes only if any collectibles data is missing.
-func (s *Service) FetchCommunityInfoForCollectibles(communityID string, ids []thirdparty.CollectibleUniqueID) (*thirdparty.CommunityInfo, error) {
-	if s.messenger == nil {
-		return nil, fmt.Errorf("messenger not ready")
-	}
-
+func (s *Service) fetchCommunityInfoForCollectibles(communityID string, ids []thirdparty.CollectibleUniqueID) (*communities.Community, error) {
 	community, err := s.messenger.FindCommunityInfoFromDB(communityID)
 	if err != nil && err != communities.ErrOrgNotFound {
 		return nil, err
@@ -678,7 +693,7 @@ func (s *Service) FetchCommunityInfoForCollectibles(communityID string, ids []th
 	}
 
 	if community.IsControlNode() {
-		return communityToInfo(community), nil
+		return community, nil
 	}
 
 	contractIDs := func() map[string]thirdparty.ContractID {
@@ -705,7 +720,7 @@ func (s *Service) FetchCommunityInfoForCollectibles(communityID string, ids []th
 		return s.fetchCommunityFromStoreNodes(communityID)
 	}
 
-	return communityToInfo(community), nil
+	return community, nil
 }
 
 func (s *Service) fetchCommunityToken(communityID string, contractID thirdparty.ContractID) (*token.CommunityToken, error) {

--- a/services/wallet/collectibles/types.go
+++ b/services/wallet/collectibles/types.go
@@ -202,7 +202,7 @@ func communityInfoToData(communityID string, community *thirdparty.CommunityInfo
 	return ret
 }
 
-func idsFromAssets(assets []*thirdparty.FullCollectibleData) []thirdparty.CollectibleUniqueID {
+func IDsFromAssets(assets []*thirdparty.FullCollectibleData) []thirdparty.CollectibleUniqueID {
 	result := make([]thirdparty.CollectibleUniqueID, len(assets))
 	for i, asset := range assets {
 		result[i] = asset.CollectibleData.ID

--- a/services/wallet/community/manager.go
+++ b/services/wallet/community/manager.go
@@ -58,8 +58,8 @@ func (cm *Manager) GetCommunityID(tokenURI string) string {
 	return cm.communityInfoProvider.GetCommunityID(tokenURI)
 }
 
-func (cm *Manager) FillCollectibleMetadata(c *thirdparty.FullCollectibleData) error {
-	return cm.communityInfoProvider.FillCollectibleMetadata(c)
+func (cm *Manager) FillCollectiblesMetadata(communityID string, cs []*thirdparty.FullCollectibleData) (bool, error) {
+	return cm.communityInfoProvider.FillCollectiblesMetadata(communityID, cs)
 }
 
 func (cm *Manager) setCommunityInfo(id string, c *thirdparty.CommunityInfo) (err error) {
@@ -82,12 +82,6 @@ func (cm *Manager) fetchCommunityInfo(communityID string, fetcher func() (*third
 func (cm *Manager) FetchCommunityInfo(communityID string) (*thirdparty.CommunityInfo, error) {
 	return cm.fetchCommunityInfo(communityID, func() (*thirdparty.CommunityInfo, error) {
 		return cm.communityInfoProvider.FetchCommunityInfo(communityID)
-	})
-}
-
-func (cm *Manager) FetchCommunityInfoForCollectibles(communityID string, ids []thirdparty.CollectibleUniqueID) (*thirdparty.CommunityInfo, error) {
-	return cm.fetchCommunityInfo(communityID, func() (*thirdparty.CommunityInfo, error) {
-		return cm.communityInfoProvider.FetchCommunityInfoForCollectibles(communityID, ids)
 	})
 }
 

--- a/services/wallet/thirdparty/community_types.go
+++ b/services/wallet/thirdparty/community_types.go
@@ -13,6 +13,5 @@ type CommunityInfoProvider interface {
 
 	// Collectible-related methods
 	GetCommunityID(tokenURI string) string
-	FillCollectibleMetadata(collectible *FullCollectibleData) error
-	FetchCommunityInfoForCollectibles(communityID string, ids []CollectibleUniqueID) (*CommunityInfo, error)
+	FillCollectiblesMetadata(communityID string, cs []*FullCollectibleData) (bool, error)
 }


### PR DESCRIPTION
Instead of fetching community for each asset, it is fetched once and then propagated to `FillCollectibleMetadata`.

fixes: #5038
