### PR TITLE
fix: improve performance of `GetHashRatchetMessages`

### DIFF
--- a/protocol/migrations/migrations.go
+++ b/protocol/migrations/migrations.go
@@ -130,6 +130,7 @@
 // 1709805967_simplify_profile_showcase_preferences.up.sql (701B)
 // 1709828431_add_community_description_cache.up.sql (730B)
 // 1710331283_add_bio_to_contacts.up.sql (42B)
+// 1710331284_hash_ratchet_encrypted_messages_key_id.up.sql (111B)
 // README.md (554B)
 // doc.go (870B)
 
@@ -2799,6 +2800,26 @@ func _1710331283_add_bio_to_contactsUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1710331284_hash_ratchet_encrypted_messages_key_idUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x0e\x72\x75\x0c\x71\x55\xf0\xf4\x73\x71\x8d\x50\xf0\x74\x53\xf0\xf3\x0f\x51\x70\x8d\xf0\x0c\x0e\x09\x56\xc8\x48\x2c\xce\x88\x2f\x4a\x2c\x49\xce\x48\x2d\x89\x4f\xcd\x4b\x2e\xaa\x2c\x28\x49\x4d\x89\xcf\x4d\x2d\x2e\x4e\x4c\x4f\x2d\x8e\xcf\x4e\xad\x8c\xcf\x4c\x51\xf0\xf7\x23\xa4\x52\x41\x03\xa2\x54\xd3\x9a\x0b\x10\x00\x00\xff\xff\x0e\x85\x79\x48\x6f\x00\x00\x00")
+
+func _1710331284_hash_ratchet_encrypted_messages_key_idUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1710331284_hash_ratchet_encrypted_messages_key_idUpSql,
+		"1710331284_hash_ratchet_encrypted_messages_key_id.up.sql",
+	)
+}
+
+func _1710331284_hash_ratchet_encrypted_messages_key_idUpSql() (*asset, error) {
+	bytes, err := _1710331284_hash_ratchet_encrypted_messages_key_idUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1710331284_hash_ratchet_encrypted_messages_key_id.up.sql", size: 111, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd1, 0x8b, 0xfe, 0xb3, 0xa0, 0x73, 0x30, 0xe, 0x1a, 0xd5, 0x85, 0x3e, 0x22, 0xf9, 0xfe, 0x1, 0x5c, 0x5f, 0x9c, 0x26, 0x36, 0x9e, 0x11, 0x1c, 0x2b, 0x42, 0xa9, 0xcc, 0x9, 0x63, 0xe8, 0xff}}
+	return a, nil
+}
+
 var _readmeMd = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x54\x91\xc1\xce\xd3\x30\x10\x84\xef\x7e\x8a\x91\x7a\x01\xa9\x2a\x8f\xc0\x0d\x71\x82\x03\x48\x1c\xc9\x36\x9e\x36\x96\x1c\x6f\xf0\xae\x93\xe6\xed\x91\xa3\xc2\xdf\xff\x66\xed\xd8\x33\xdf\x78\x4f\xa7\x13\xbe\xea\x06\x57\x6c\x35\x39\x31\xa7\x7b\x15\x4f\x5a\xec\x73\x08\xbf\x08\x2d\x79\x7f\x4a\x43\x5b\x86\x17\xfd\x8c\x21\xea\x56\x5e\x47\x90\x4a\x14\x75\x48\xde\x64\x37\x2c\x6a\x96\xae\x99\x48\x05\xf6\x27\x77\x13\xad\x08\xae\x8a\x51\xe7\x25\xf3\xf1\xa9\x9f\xf9\x58\x58\x2c\xad\xbc\xe0\x8b\x56\xf0\x21\x5d\xeb\x4c\x95\xb3\xae\x84\x60\xd4\xdc\xe6\x82\x5d\x1b\x36\x6d\x39\x62\x92\xf5\xb8\x11\xdb\x92\xd3\x28\xce\xe0\x13\xe1\x72\xcd\x3c\x63\xd4\x65\x87\xae\xac\xe8\xc3\x28\x2e\x67\x44\x66\x3a\x21\x25\xa2\x72\xac\x14\x67\xbc\x84\x9f\x53\x32\x8c\x52\x70\x25\x56\xd6\xfd\x8d\x05\x37\xad\x30\x9d\x9f\xa6\x86\x0f\xcd\x58\x7f\xcf\x34\x93\x3b\xed\x90\x9f\xa4\x1f\xcf\x30\x85\x4d\x07\x58\xaf\x7f\x25\xc4\x9d\xf3\x72\x64\x84\xd0\x7f\xf9\x9b\x3a\x2d\x84\xef\x85\x48\x66\x8d\xd8\x88\x9b\x8c\x8c\x98\x5b\xf6\x74\x14\x4e\x33\x0d\xc9\xe0\x93\x38\xda\x12\xc5\x69\xbd\xe4\xf0\x2e\x7a\x78\x07\x1c\xfe\x13\x9f\x91\x29\x31\x95\x7b\x7f\x62\x59\x37\xb4\xe5\x5e\x25\xfe\x33\xee\xd5\x53\x71\xd6\xda\x3a\xd8\xcb\xde\x2e\xf8\xa1\x90\x55\x53\x0c\xc7\xaa\x0d\xe9\x76\x14\x29\x1c\x7b\x68\xdd\x2f\xe1\x6f\x00\x00\x00\xff\xff\x3c\x0a\xc2\xfe\x2a\x02\x00\x00")
 
 func readmeMdBytes() ([]byte, error) {
@@ -3060,8 +3081,9 @@ var _bindata = map[string]func() (*asset, error){
 	"1709805967_simplify_profile_showcase_preferences.up.sql":                     _1709805967_simplify_profile_showcase_preferencesUpSql,
 	"1709828431_add_community_description_cache.up.sql":                           _1709828431_add_community_description_cacheUpSql,
 	"1710331283_add_bio_to_contacts.up.sql":                                       _1710331283_add_bio_to_contactsUpSql,
-	"README.md":                                                                   readmeMd,
-	"doc.go":                                                                      docGo,
+	"1710331284_hash_ratchet_encrypted_messages_key_id.up.sql":                    _1710331284_hash_ratchet_encrypted_messages_key_idUpSql,
+	"README.md": readmeMd,
+	"doc.go":    docGo,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -3240,8 +3262,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1709805967_simplify_profile_showcase_preferences.up.sql":                     {_1709805967_simplify_profile_showcase_preferencesUpSql, map[string]*bintree{}},
 	"1709828431_add_community_description_cache.up.sql":                           {_1709828431_add_community_description_cacheUpSql, map[string]*bintree{}},
 	"1710331283_add_bio_to_contacts.up.sql":                                       {_1710331283_add_bio_to_contactsUpSql, map[string]*bintree{}},
-	"README.md":                                                                   {readmeMd, map[string]*bintree{}},
-	"doc.go":                                                                      {docGo, map[string]*bintree{}},
+	"1710331284_hash_ratchet_encrypted_messages_key_id.up.sql":                    {_1710331284_hash_ratchet_encrypted_messages_key_idUpSql, map[string]*bintree{}},
+	"README.md": {readmeMd, map[string]*bintree{}},
+	"doc.go":    {docGo, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/protocol/migrations/sqlite/1710331284_hash_ratchet_encrypted_messages_key_id.up.sql
+++ b/protocol/migrations/sqlite/1710331284_hash_ratchet_encrypted_messages_key_id.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS hash_ratchet_encrypted_messages_key_id ON hash_ratchet_encrypted_messages (key_id);


### PR DESCRIPTION
This time with proper migration timestamp.

part of: #5036
