### PR TITLE
chore(wallet): removed all addresses parameter as redundant.

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -598,10 +598,10 @@ func (api *API) FetchAllCurrencyFormats() (currency.FormatPerSymbol, error) {
 }
 
 // @deprecated replaced by session APIs; see #12120
-func (api *API) FilterActivityAsync(requestID int32, addresses []common.Address, allAddresses bool, chainIDs []wcommon.ChainID, filter activity.Filter, offset int, limit int) error {
-	log.Debug("wallet.api.FilterActivityAsync", "requestID", requestID, "addr.count", len(addresses), "allAddresses", allAddresses, "chainIDs.count", len(chainIDs), "offset", offset, "limit", limit)
+func (api *API) FilterActivityAsync(requestID int32, addresses []common.Address, chainIDs []wcommon.ChainID, filter activity.Filter, offset int, limit int) error {
+	log.Debug("wallet.api.FilterActivityAsync", "requestID", requestID, "addr.count", len(addresses), "chainIDs.count", len(chainIDs), "offset", offset, "limit", limit)
 
-	api.s.activity.FilterActivityAsync(requestID, addresses, allAddresses, chainIDs, filter, offset, limit)
+	api.s.activity.FilterActivityAsync(requestID, addresses, chainIDs, filter, offset, limit)
 	return nil
 }
 
@@ -613,10 +613,10 @@ func (api *API) CancelActivityFilterTask(requestID int32) error {
 	return nil
 }
 
-func (api *API) StartActivityFilterSession(addresses []common.Address, allAddresses bool, chainIDs []wcommon.ChainID, filter activity.Filter, firstPageCount int) (activity.SessionID, error) {
-	log.Debug("wallet.api.StartActivityFilterSession", "addr.count", len(addresses), "allAddresses", allAddresses, "chainIDs.count", len(chainIDs), "firstPageCount", firstPageCount)
+func (api *API) StartActivityFilterSession(addresses []common.Address, chainIDs []wcommon.ChainID, filter activity.Filter, firstPageCount int) (activity.SessionID, error) {
+	log.Debug("wallet.api.StartActivityFilterSession", "addr.count", len(addresses), "chainIDs.count", len(chainIDs), "firstPageCount", firstPageCount)
 
-	return api.s.activity.StartFilterSession(addresses, allAddresses, chainIDs, filter, firstPageCount), nil
+	return api.s.activity.StartFilterSession(addresses, chainIDs, filter, firstPageCount), nil
 }
 
 func (api *API) UpdateActivityFilterForSession(sessionID activity.SessionID, filter activity.Filter, firstPageCount int) error {

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -168,7 +168,7 @@ func NewService(
 	)
 	collectibles := collectibles.NewService(db, feed, accountsDB, accountFeed, settingsFeed, communityManager, rpcClient.NetworkManager, collectiblesManager)
 
-	activity := activity.NewService(db, tokenManager, collectiblesManager, feed, pendingTxManager)
+	activity := activity.NewService(db, accountsDB, tokenManager, collectiblesManager, feed, pendingTxManager)
 
 	walletconnect := walletconnect.NewService(db, rpcClient.NetworkManager, accountsDB, transactionManager, gethManager, feed, config)
 


### PR DESCRIPTION
Instead we check directly if passed addresses are all wallet addresses that we have in accounts DB.

Part of [14216](https://github.com/status-im/status-desktop/issues/14216) and [14162](https://github.com/status-im/status-desktop/issues/14162)

Important changes:
- [x] Existing tests were run with `allAddresses` flag on, effectively testing the case when `All accounts` selected. Now they are run without this flag, testing activities for either individual accounts or without the optimisation for `All accounts`
