### PR TITLE
fix_: Remove rpc client from push notification servers and avoid panic

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -231,7 +231,6 @@ func main() {
 			protocol.WithWalletDatabase(walletDB),
 			protocol.WithTorrentConfig(&config.TorrentConfig),
 			protocol.WithWalletConfig(&config.WalletConfig),
-			protocol.WithRPCClient(backend.StatusNode().RPCClient()),
 			protocol.WithAccountManager(backend.AccountManager()),
 		}
 

--- a/protocol/messenger_backup.go
+++ b/protocol/messenger_backup.go
@@ -429,6 +429,10 @@ func (m *Messenger) backupProfile(ctx context.Context, clock uint64) ([]*protobu
 		return nil, err
 	}
 
+	if m.account == nil {
+		return nil, nil
+	}
+
 	keyUID := m.account.KeyUID
 	images, err := m.multiAccounts.GetIdentityImages(keyUID)
 	if err != nil {


### PR DESCRIPTION
removes unused rpc client, and prevents a panic on push notification server.