### PR TITLE
Allow for timestamps to be saved with accounts

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1358,6 +1358,7 @@ func (b *GethStatusBackend) generateOrImportAccount(mnemonic string, customizati
 		CustomizationColor:      multiacccommon.CustomizationColor(request.CustomizationColor),
 		CustomizationColorClock: customizationColorClock,
 		KDFIterations:           request.KdfIterations,
+		Timestamp:               time.Now().Unix(),
 	}
 
 	if account.KDFIterations == 0 {

--- a/multiaccounts/database.go
+++ b/multiaccounts/database.go
@@ -323,7 +323,7 @@ func (db *Database) SaveAccount(account Account) error {
 		account.KDFIterations = dbsetup.ReducedKDFIterationsNumber
 	}
 
-	_, err = db.db.Exec("INSERT OR REPLACE INTO accounts (name, identicon, colorHash, colorId, customizationColor, customizationColorClock, keycardPairing, keyUid, kdfIterations) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", account.Name, account.Identicon, colorHash, account.ColorID, account.CustomizationColor, account.CustomizationColorClock, account.KeycardPairing, account.KeyUID, account.KDFIterations)
+	_, err = db.db.Exec("INSERT OR REPLACE INTO accounts (name, identicon, colorHash, colorId, customizationColor, customizationColorClock, keycardPairing, keyUid, kdfIterations, loginTimestamp) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", account.Name, account.Identicon, colorHash, account.ColorID, account.CustomizationColor, account.CustomizationColorClock, account.KeycardPairing, account.KeyUID, account.KDFIterations, account.Timestamp)
 	if err != nil {
 		return err
 	}

--- a/multiaccounts/database_test.go
+++ b/multiaccounts/database_test.go
@@ -28,7 +28,7 @@ func setupTestDB(t *testing.T) (*Database, func()) {
 func TestAccounts(t *testing.T) {
 	db, stop := setupTestDB(t)
 	defer stop()
-	expected := Account{Name: "string", KeyUID: "string", CustomizationColor: common.CustomizationColorBlue, ColorHash: ColorHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10, KDFIterations: dbsetup.ReducedKDFIterationsNumber}
+	expected := Account{Name: "string", KeyUID: "string", CustomizationColor: common.CustomizationColorBlue, ColorHash: ColorHash{{4, 3}, {4, 0}, {4, 3}, {4, 0}}, ColorID: 10, KDFIterations: dbsetup.ReducedKDFIterationsNumber, Timestamp: 1712856359}
 	require.NoError(t, db.SaveAccount(expected))
 	accounts, err := db.GetAccounts()
 	require.NoError(t, err)


### PR DESCRIPTION
Related status-mobile PR: https://github.com/status-im/status-mobile/pull/19612

### Summary

* This PR attempts to fix an issue with restoring accounts.
  * At the moment, when calling `SaveAccount` we do not persist the timestamp associated with the account.
    * This can lead to issues when re-saving an account because it will accidentally remove the timestamp from the account. The removal of the timestamp is caused by the `INSERT or REPLACE` statement when saving an account.
  * And when we're restoring an account, some message/contact request notifications appear while syncing. Those notifications/messages being synced seem to cause a backup event to happen, which then causes the account to be re-saved, and the account timestamp can be accidentally replaced with nothing.
  * The changes in this PR allow for saving and re-saving the timestamp with the account, which seems to avoid accidentally replacing the timestamp with nothing.
