### PR TITLE
fix_: Add contact to removeTrustStatus response

### DIFF
--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -999,6 +999,10 @@ func (api *PublicAPI) RemoveTrustStatus(ctx context.Context, contactID string) e
 	return api.service.messenger.RemoveTrustStatus(ctx, contactID)
 }
 
+func (api *PublicAPI) RemoveTrustVerificationStatus(ctx context.Context, contactID string) (*protocol.MessengerResponse, error) {
+	return api.service.messenger.RemoveTrustVerificationStatus(ctx, contactID)
+}
+
 func (api *PublicAPI) GetTrustStatus(ctx context.Context, contactID string) (verification.TrustStatus, error) {
 	return api.service.messenger.GetTrustStatus(contactID)
 }


### PR DESCRIPTION
`removeTrustStatus` resets trust status and verification. The function returns the updated contact.

<s>If a contact was untrusted and then became uknown - the verification is not changed</s>

Important changes:
- Moved logic from status-desktop "contacts/service.nim RemoveTrustStatus"

Closes [#13619](https://github.com/status-im/status-desktop/issues/13619)
Desktop PR: https://github.com/status-im/status-desktop/pull/14308

# future improvements
<s>
I suggest making a ticket for refactoring. The code of RemoveTrustStatus, DeclineContactVerificationRequest, VerifiedUntrustworthy, VerifiedTrusted contain code duplication and non-obvious logic. Ideally, the storage, logic and synchronization parts should be separated.</s>
Implemented in this PR