### PR TITLE
refactor(waku): expire envelope cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/jellydator/ttlcache/v3 v3.1.0
+	github.com/jellydator/ttlcache/v3 v3.2.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/ladydascalie/currency v1.6.0
 	github.com/meirf/gopart v0.0.0-20180520194036-37e9492a85a8

--- a/go.sum
+++ b/go.sum
@@ -1222,8 +1222,8 @@ github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABo
 github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPwbGVtZVWC34vc5WLsDk=
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
-github.com/jellydator/ttlcache/v3 v3.1.0 h1:0gPFG0IHHP6xyUyXq+JaD8fwkDCqgqwohXNJBcYE71g=
-github.com/jellydator/ttlcache/v3 v3.1.0/go.mod h1:hi7MGFdMAwZna5n2tuvh63DvFLzVKySzCVW6+0gA2n4=
+github.com/jellydator/ttlcache/v3 v3.2.0 h1:6lqVJ8X3ZaUwvzENqPAobDsXNExfUJd61u++uW8a3LE=
+github.com/jellydator/ttlcache/v3 v3.2.0/go.mod h1:hi7MGFdMAwZna5n2tuvh63DvFLzVKySzCVW6+0gA2n4=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/vendor/github.com/jellydator/ttlcache/v3/item.go
+++ b/vendor/github.com/jellydator/ttlcache/v3/item.go
@@ -9,6 +9,10 @@ const (
 	// NoTTL indicates that an item should never expire.
 	NoTTL time.Duration = -1
 
+	// PreviousOrDefaultTTL indicates that existing TTL of item should be used
+	// default TTL will be used as fallback if item doesn't exist
+	PreviousOrDefaultTTL time.Duration = -2
+
 	// DefaultTTL indicates that the default TTL value of the cache
 	// instance should be used.
 	DefaultTTL time.Duration = 0
@@ -58,17 +62,23 @@ func (item *Item[K, V]) update(value V, ttl time.Duration) {
 	defer item.mu.Unlock()
 
 	item.value = value
+
+	// update version if enabled
+	if item.version > -1 {
+		item.version++
+	}
+
+	// no need to update ttl or expiry in this case
+	if ttl == PreviousOrDefaultTTL {
+		return
+	}
+
 	item.ttl = ttl
 
 	// reset expiration timestamp because the new TTL may be
 	// 0 or below
 	item.expiresAt = time.Time{}
 	item.touchUnsafe()
-
-	// update version if enabled
-	if item.version > -1 {
-		item.version++
-	}
 }
 
 // touch updates the item's expiration timestamp.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -436,7 +436,7 @@ github.com/jackpal/go-nat-pmp
 # github.com/jbenet/go-temp-err-catcher v0.1.0
 ## explicit; go 1.13
 github.com/jbenet/go-temp-err-catcher
-# github.com/jellydator/ttlcache/v3 v3.1.0
+# github.com/jellydator/ttlcache/v3 v3.2.0
 ## explicit; go 1.18
 github.com/jellydator/ttlcache/v3
 # github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a


### PR DESCRIPTION
While trying to debug the memory leak related to WakuMessages reported by @endulab in https://github.com/status-im/status-go/issues/4990#issuecomment-2031591778  I confirmed that in go-waku itself we do not keep a cache for messages anywhere, so after consuming a message, there's no reference to any WakuMessage pointer stored in go-waku, so the problem likely happens in the consumer of go-waku library.

Looking at the flow followed by messages in status-go, i noticed that we keep a cache for messages that is only cleared when leaving chats or clearing message history, so if none of these operations happen, the cache will keep growing. With this PR i replace the cache for a structure that contains a TTL, which after 20m it should expire and remove older messages.

Hopefully it will improve the memory usage of status-go.

cc: @endulab to take it for a spin in matterbridge.