### PR TITLE
fix(messenger): make sure chats have an unread count of 0 for channels you can't view

### DIFF
--- a/protocol/communities/community_changes.go
+++ b/protocol/communities/community_changes.go
@@ -183,6 +183,7 @@ func evaluateCommunityChangesByDescription(origin, modified *protobuf.CommunityD
 		if _, ok := origin.Chats[chatID]; !ok {
 			changes.ChatsAdded[chatID] = chat
 		} else {
+
 			// Check for members added
 			for pk, member := range modified.Chats[chatID].Members {
 				if _, ok := origin.Chats[chatID].Members[pk]; !ok {
@@ -192,7 +193,6 @@ func evaluateCommunityChangesByDescription(origin, modified *protobuf.CommunityD
 							MembersRemoved: make(map[string]*protobuf.CommunityMember),
 						}
 					}
-
 					changes.ChatsModified[chatID].MembersAdded[pk] = member
 				}
 			}
@@ -206,7 +206,6 @@ func evaluateCommunityChangesByDescription(origin, modified *protobuf.CommunityD
 							MembersRemoved: make(map[string]*protobuf.CommunityMember),
 						}
 					}
-
 					changes.ChatsModified[chatID].MembersRemoved[pk] = member
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/14421

The problem is that you can receive messages to  a channel, then later, before marking them as read, a permission is added to them, so you no longer have access. Then, you can't even mark it as read if it's hidden. Here, I fix it by setting the unread count on Init at 0 if the user doesn't have view access to it.

It's not the cleanest solution, but it's the simplest one to fix previous accounts that had that issue.

Another solution would be to change the DB value of the chat when we receive a new permission and detect that we no longer have view access. It's cleaner, but it doesn't fix previous account having the issue.
Also, keeping the DB value means that if the channel goes back to visible to us, we'll have a badge for the previous unread messages we had.

Let me know what you guys think.