### PR TITLE
chore: Fix Windows build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,9 @@ endef
 
 # TODO: Define more specific shells.
 TARGET := default
-SHELL := ./nix/scripts/shell.sh
+ifneq ($(detected_OS),Windows)
+ SHELL := ./nix/scripts/shell.sh
+endif
 shell: export TARGET ?= default
 shell: ##@prepare Enter into a pre-configured shell
 ifndef IN_NIX_SHELL


### PR DESCRIPTION
Windows doesn't have NIX platform.
Building status-go on Windows caused these errors:

$ make status-go
make status-go

Tip of the day: this will probably build faster if you use "make.exe -j32 ...".

Building: status-go
D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: line 10: cd: D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: Not a directory
D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: line 11: /scripts/colors.sh: No such file or directory
D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: line 12: /nix/scripts/source.sh: No such file or directory
Configuring Nix shell for target 'default'...
D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: line 65: /nix/scripts/gcroots.sh: No such file or directory
D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: line 73: exec: nix-shell: not found
D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: line 10: cd: D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: Not a directory
D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: line 11: /scripts/colors.sh: No such file or directory
D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: line 12: /nix/scripts/source.sh: No such file or directory
Configuring Nix shell for target 'default'...
D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: line 65: /nix/scripts/gcroots.sh: No such file or directory
D:\git\status\status-desktop-tmp\vendor\status-go\nix\scripts\shell.sh: line 73: exec: nix-shell: not found
make[1]: *** [Makefile:225: statusgo-shared-library] Error 127
make: *** [Makefile:433: vendor/status-go/build/bin/libstatus.dll] Error 2