### PR TITLE
fix: logic for checking if the route can be established updated

### DIFF
--- a/services/wallet/bridge/cbridge.go
+++ b/services/wallet/bridge/cbridge.go
@@ -154,7 +154,7 @@ func (s *CBridge) getTransferConfig(isTest bool) (*cbridge.GetTransferConfigsRes
 }
 
 func (s *CBridge) Can(from, to *params.Network, token *token.Token, toToken *token.Token, balance *big.Int) (bool, error) {
-	if from.ChainID == to.ChainID {
+	if from.ChainID == to.ChainID || toToken != nil {
 		return false, nil
 	}
 

--- a/services/wallet/bridge/erc1155_transfer.go
+++ b/services/wallet/bridge/erc1155_transfer.go
@@ -42,7 +42,7 @@ func (s *ERC1155TransferBridge) Name() string {
 }
 
 func (s *ERC1155TransferBridge) Can(from, to *params.Network, token *token.Token, toToken *token.Token, balance *big.Int) (bool, error) {
-	return from.ChainID == to.ChainID, nil
+	return from.ChainID == to.ChainID && toToken == nil, nil
 }
 
 func (s *ERC1155TransferBridge) CalculateFees(from, to *params.Network, token *token.Token, amountIn *big.Int, nativeTokenPrice, tokenPrice float64, gasPrice *big.Float) (*big.Int, *big.Int, error) {

--- a/services/wallet/bridge/erc721_transfer.go
+++ b/services/wallet/bridge/erc721_transfer.go
@@ -41,7 +41,7 @@ func (s *ERC721TransferBridge) Name() string {
 }
 
 func (s *ERC721TransferBridge) Can(from, to *params.Network, token *token.Token, toToken *token.Token, balance *big.Int) (bool, error) {
-	return from.ChainID == to.ChainID, nil
+	return from.ChainID == to.ChainID && toToken == nil, nil
 }
 
 func (s *ERC721TransferBridge) CalculateFees(from, to *params.Network, token *token.Token, amountIn *big.Int, nativeTokenPrice, tokenPrice float64, gasPrice *big.Float) (*big.Int, *big.Int, error) {

--- a/services/wallet/bridge/hop.go
+++ b/services/wallet/bridge/hop.go
@@ -114,7 +114,7 @@ func (h *HopBridge) Can(from, to *params.Network, token *token.Token, toToken *t
 		return false, nil
 	}
 
-	if from.ChainID == to.ChainID {
+	if from.ChainID == to.ChainID || toToken != nil {
 		return false, nil
 	}
 

--- a/services/wallet/bridge/transfer.go
+++ b/services/wallet/bridge/transfer.go
@@ -33,7 +33,7 @@ func (s *TransferBridge) Name() string {
 }
 
 func (s *TransferBridge) Can(from, to *params.Network, token *token.Token, toToken *token.Token, balance *big.Int) (bool, error) {
-	return from.ChainID == to.ChainID, nil
+	return from.ChainID == to.ChainID && token != nil && toToken == nil, nil
 }
 
 func (s *TransferBridge) CalculateFees(from, to *params.Network, token *token.Token, amountIn *big.Int, nativeTokenPrice, tokenPrice float64, gasPrice *big.Float) (*big.Int, *big.Int, error) {


### PR DESCRIPTION
`toToken` is used only when the user wants to swap, since `Can` function from the `Bridge` interface receives `toToken` which is `nil` for all but for the swap, we need to consider it and return appropriately from the function.