### PR TITLE
fix_(Makefile): clear goroot env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: statusgo statusd-prune all test clean help
 .PHONY: statusgo-android statusgo-ios
 
+# Clear any GOROOT set outside of the Nix shell
+export GOROOT=
+
 # This is a code for automatic help generator.
 # It supports ANSI colors and categories.
 # To add new item into help output, simply add comments


### PR DESCRIPTION
We need to clear the `GOROOT` env variable to prevent using the host Go version.

More details here: https://github.com/status-im/status-go/pull/4388#pullrequestreview-1952972108