### PR TITLE
refactor_: set default node config values for frontend when doing local pair sync

### DIFF
--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -253,6 +253,6 @@ func setRPCs(networks []params.Network, request *requests.WalletSecretsConfig) [
 	return networksWithRPC
 }
 
-func BuildDefaultNetworks(request *requests.CreateAccount) []params.Network {
-	return setRPCs(defaultNetworks, &request.WalletSecretsConfig)
+func BuildDefaultNetworks(walletSecretsConfig *requests.WalletSecretsConfig) []params.Network {
+	return setRPCs(defaultNetworks, walletSecretsConfig)
 }

--- a/api/default_networks_test.go
+++ b/api/default_networks_test.go
@@ -19,7 +19,7 @@ func TestBuildDefaultNetworks(t *testing.T) {
 		},
 	}
 
-	actualNetworks := BuildDefaultNetworks(request)
+	actualNetworks := BuildDefaultNetworks(&request.WalletSecretsConfig)
 
 	require.Len(t, actualNetworks, 9)
 
@@ -75,7 +75,7 @@ func TestBuildDefaultNetworksGanache(t *testing.T) {
 		},
 	}
 
-	actualNetworks := BuildDefaultNetworks(request)
+	actualNetworks := BuildDefaultNetworks(&request.WalletSecretsConfig)
 
 	require.Len(t, actualNetworks, 9)
 

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -31,6 +31,8 @@ const defaultKeycardPairingDataFile = "/ethereum/mainnet_rpc/keycard/pairings.js
 const defaultArchivesRelativePath = "data/archivedata"
 const defaultTorrentTorrentsRelativePath = "data/torrents"
 
+const DefaultDataDir = "/ethereum/mainnet_rpc"
+
 var paths = []string{pathWalletRoot, pathEIP1581, pathDefaultChat, pathDefaultWallet}
 
 var DefaultFleet = params.FleetShardsTest
@@ -212,7 +214,7 @@ func defaultNodeConfig(installationID string, request *requests.CreateAccount) (
 	nodeConfig.LogFile = "geth.log"
 	nodeConfig.LogDir = request.LogFilePath
 	nodeConfig.LogLevel = "ERROR"
-	nodeConfig.DataDir = "/ethereum/mainnet_rpc"
+	nodeConfig.DataDir = DefaultDataDir
 	nodeConfig.KeycardPairingDataFile = defaultKeycardPairingDataFile
 	nodeConfig.ProcessBackedupMessages = false
 
@@ -223,7 +225,7 @@ func defaultNodeConfig(installationID string, request *requests.CreateAccount) (
 		nodeConfig.LogEnabled = false
 	}
 
-	nodeConfig.Networks = BuildDefaultNetworks(request)
+	nodeConfig.Networks = BuildDefaultNetworks(&request.WalletSecretsConfig)
 
 	if request.NetworkID != nil {
 		nodeConfig.NetworkID = *request.NetworkID

--- a/cmd/ping-community/main.go
+++ b/cmd/ping-community/main.go
@@ -344,7 +344,7 @@ func defaultNodeConfig(installationID string) (*params.NodeConfig, error) {
 	nodeConfig := &params.NodeConfig{}
 	nodeConfig.NetworkID = 1
 	nodeConfig.LogLevel = "ERROR"
-	nodeConfig.DataDir = "/ethereum/mainnet_rpc"
+	nodeConfig.DataDir = api.DefaultDataDir
 	nodeConfig.UpstreamConfig = params.UpstreamRPCConfig{
 		Enabled: true,
 		URL:     "https://mainnet.infura.io/v3/800c641949d64d768a5070a1b0511938",

--- a/cmd/populate-db/main.go
+++ b/cmd/populate-db/main.go
@@ -392,7 +392,7 @@ func defaultNodeConfig(installationID string) (*params.NodeConfig, error) {
 	nodeConfig := &params.NodeConfig{}
 	nodeConfig.NetworkID = 1
 	nodeConfig.LogLevel = "ERROR"
-	nodeConfig.DataDir = "/ethereum/mainnet_rpc"
+	nodeConfig.DataDir = api.DefaultDataDir
 	nodeConfig.UpstreamConfig = params.UpstreamRPCConfig{
 		Enabled: true,
 		URL:     "https://mainnet.infura.io/v3/800c641949d64d768a5070a1b0511938",

--- a/cmd/spiff-workflow/main.go
+++ b/cmd/spiff-workflow/main.go
@@ -269,7 +269,7 @@ func defaultNodeConfig(installationID string) (*params.NodeConfig, error) {
 	nodeConfig := &params.NodeConfig{}
 	nodeConfig.NetworkID = 1
 	nodeConfig.LogLevel = "DEBUG"
-	nodeConfig.DataDir = "/ethereum/mainnet_rpc"
+	nodeConfig.DataDir = api.DefaultDataDir
 	nodeConfig.HTTPEnabled = true
 	nodeConfig.HTTPPort = 8545
 	// FIXME: This should be taken from CLI flags.

--- a/server/pairing/client.go
+++ b/server/pairing/client.go
@@ -523,7 +523,11 @@ func setupReceivingClient(backend *api.GethStatusBackend, cs, configJSON string)
 	if err != nil {
 		return nil, err
 	}
-	err = validateAndVerifyNodeConfig(conf, conf.ReceiverConfig)
+	receiverConf := conf.ReceiverConfig
+	if err = setDefaultNodeConfig(receiverConf.NodeConfig); err != nil {
+		return nil, err
+	}
+	err = validateAndVerifyNodeConfig(conf, receiverConf)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pairing/config_test.go
+++ b/server/pairing/config_test.go
@@ -75,9 +75,9 @@ func (s *ConfigTestSuite) TestValidationKeyUID() {
 }
 
 func (s *ConfigTestSuite) TestValidationNotEndKeyUID() {
-	nodeConfig, err := defaultNodeConfig(uuid.New().String(), "")
+	nodeConfig, err := nodeConfigForLocalPairSync(uuid.New().String(), "", "/dummy/path")
 	nodeConfig.RootDataDir = "/tmp"
-	require.NoError(s.T(), err, "defaultNodeConfig should not return error")
+	require.NoError(s.T(), err, "nodeConfigForLocalPairSync should not return error")
 	s.T().Run("Valid keystore path without keyUID", func(t *testing.T) {
 		r := &ReceiverConfig{
 			NodeConfig:            nodeConfig,
@@ -86,7 +86,7 @@ func (s *ConfigTestSuite) TestValidationNotEndKeyUID() {
 			KDFIterations:         1,
 			SettingCurrentNetwork: "mainnet",
 		}
-
+		assert.NoError(t, setDefaultNodeConfig(r.NodeConfig))
 		assert.NoError(t, validateAndVerifyNodeConfig(r, r), "ReceiverConfig validation should pass")
 	})
 
@@ -98,6 +98,7 @@ func (s *ConfigTestSuite) TestValidationNotEndKeyUID() {
 			KDFIterations:         1,
 			SettingCurrentNetwork: "mainnet",
 		}
+		assert.NoError(t, setDefaultNodeConfig(r.NodeConfig))
 		assert.Error(t, validateAndVerifyNodeConfig(r, r), "ReceiverConfig validation should fail")
 	})
 }

--- a/server/pairing/server.go
+++ b/server/pairing/server.go
@@ -291,7 +291,11 @@ func StartUpReceiverServer(backend *api.GethStatusBackend, configJSON string) (s
 	if err != nil {
 		return "", err
 	}
-	err = validateAndVerifyNodeConfig(conf, conf.ReceiverConfig)
+	receiverConf := conf.ReceiverConfig
+	if err = setDefaultNodeConfig(receiverConf.NodeConfig); err != nil {
+		return "", err
+	}
+	err = validateAndVerifyNodeConfig(conf, receiverConf)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Because mobile won't pass NetworkID/UpstreamConfig/Datadir anymore when doing local pair sync, backend will set the default value instead. 