### PR TITLE
apply DNS override hack for iOS as well

### DIFF
--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -28,7 +28,7 @@ const defaultBackoff = 10 * time.Second
 const graylistBackoff = 3 * time.Minute
 const isAndroidEmulator = runtime.GOOS == "android" && runtime.GOARCH == "amd64"
 const findNearestMailServer = !isAndroidEmulator
-const overrideDNS = runtime.GOOS == "android"
+const overrideDNS = runtime.GOOS == "android" || runtime.GOOS == "ios"
 const bootstrapDNS = "8.8.8.8:53"
 
 func (m *Messenger) mailserversByFleet(fleet string) []mailservers.Mailserver {


### PR DESCRIPTION
We need to apply the DNS override hack for iOS as well.

This PR -> https://github.com/status-im/status-mobile/pull/19798 in status-mobile fixes the DNS resolution issue for 
iOS ARM Simulators and for Android x86 Emulators.
But we still need this change to ensure storenodes are found on real iOS devices and on Android arm Emulators.

