### PR TITLE
fix_: add method to retrieve prepared message

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4197,7 +4197,17 @@ func (m *Messenger) storeSyncBookmarks(bookmarkMap map[string]*browsers.Bookmark
 }
 
 func (m *Messenger) MessageByID(id string) (*common.Message, error) {
-	return m.persistence.MessageByID(id)
+	msg, err := m.persistence.MessageByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if m.httpServer != nil {
+		err = m.prepareMessage(msg, m.httpServer)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return msg, nil
 }
 
 func (m *Messenger) MessagesExist(ids []string) (map[string]bool, error) {


### PR DESCRIPTION
fixes #13684

* Add Messenger.PreparedMessageByID to get message with non-null attachment links (images, stickers)
* Add test

status-desktop PR: TODO

Closes [13684](https://github.com/status-im/status-desktop/issues/13684)
Status-desktop PR: [14549](https://github.com/status-im/status-desktop/pull/14549)
