### PR TITLE
Limit number of members in a community and number of pending requests

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1004,6 +1004,10 @@ func (o *Community) Edit(description *protobuf.CommunityDescription) {
 	o.config.CommunityDescription.AdminSettings.PinMessageAllMembersEnabled = description.AdminSettings.PinMessageAllMembersEnabled
 }
 
+func (o *Community) EditPermissionAccess(permissionAccess protobuf.CommunityPermissions_Access) {
+	o.config.CommunityDescription.Permissions.Access = permissionAccess
+}
+
 func (o *Community) Join() {
 	o.config.Joined = true
 	o.config.JoinedAt = time.Now().Unix()

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1006,6 +1006,9 @@ func (o *Community) Edit(description *protobuf.CommunityDescription) {
 
 func (o *Community) EditPermissionAccess(permissionAccess protobuf.CommunityPermissions_Access) {
 	o.config.CommunityDescription.Permissions.Access = permissionAccess
+	if o.IsControlNode() {
+		o.increaseClock()
+	}
 }
 
 func (o *Community) Join() {

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -56,8 +56,9 @@ var defaultAnnounceList = [][]string{
 var pieceLength = 100 * 1024
 
 const maxArchiveSizeInBytes = 30000000
-const maxNbMembers = 5000
-const maxNbPendingRequestedMembers = 100
+
+var maxNbMembers = 5000
+var maxNbPendingRequestedMembers = 100
 
 var memberPermissionsCheckInterval = 1 * time.Hour
 var validateInterval = 2 * time.Minute
@@ -65,6 +66,12 @@ var validateInterval = 2 * time.Minute
 // Used for testing only
 func SetValidateInterval(duration time.Duration) {
 	validateInterval = duration
+}
+func SetMaxNbMembers(maxNb int) {
+	maxNbMembers = maxNb
+}
+func SetMaxNbPendingRequestedMembers(maxNb int) {
+	maxNbPendingRequestedMembers = maxNb
 }
 
 // errors
@@ -2731,7 +2738,7 @@ func (m *Manager) HandleCommunityRequestToJoin(signer *ecdsa.PublicKey, receiver
 	if err != nil {
 		return nil, nil, err
 	}
-	if nbPendingRequestsToJoin > maxNbPendingRequestedMembers {
+	if nbPendingRequestsToJoin >= maxNbPendingRequestedMembers {
 		return nil, nil, errors.New("max number of requests to join reached")
 	}
 

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -842,6 +842,15 @@ func (p *Persistence) GetRequestToJoin(id []byte) (*RequestToJoin, error) {
 	return request, nil
 }
 
+func (p *Persistence) GetNumberOfPendingRequestsToJoin(communityID types.HexBytes) (int, error) {
+	var count int
+	err := p.db.QueryRow(`SELECT count(1) FROM communities_requests_to_join WHERE community_id = ? AND state = ?`, communityID.String(), RequestToJoinStatePending).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
 func (p *Persistence) GetRequestToJoinByPkAndCommunityID(pk string, communityID []byte) (*RequestToJoin, error) {
 	request := &RequestToJoin{}
 	err := p.db.QueryRow(`SELECT id,public_key,clock,ens_name,chat_id,community_id,state FROM communities_requests_to_join WHERE public_key = ? AND community_id = ?`, pk, communityID).Scan(&request.ID, &request.PublicKey, &request.Clock, &request.ENSName, &request.ChatID, &request.CommunityID, &request.State)

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -844,7 +844,7 @@ func (p *Persistence) GetRequestToJoin(id []byte) (*RequestToJoin, error) {
 
 func (p *Persistence) GetNumberOfPendingRequestsToJoin(communityID types.HexBytes) (int, error) {
 	var count int
-	err := p.db.QueryRow(`SELECT count(1) FROM communities_requests_to_join WHERE community_id = ? AND state = ?`, communityID.String(), RequestToJoinStatePending).Scan(&count)
+	err := p.db.QueryRow(`SELECT count(1) FROM communities_requests_to_join WHERE community_id = ? AND state = ?`, communityID, RequestToJoinStatePending).Scan(&count)
 	if err != nil {
 		return 0, err
 	}

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -1642,31 +1642,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.transport)
-
-	s.Require().NoError(s.bob.SaveChat(chat))
-
-	message := buildTestMessage(*chat)
-	message.CommunityID = community.IDString()
-
-	// We send a community link to alice
-	response, err = s.bob.SendChatMessage(context.Background(), message)
-	s.Require().NoError(err)
-	s.Require().NotNil(response)
-
-	// Retrieve community link & community
-	err = tt.RetryWithBackOff(func() error {
-		response, err = s.alice.RetrieveAll()
-		if err != nil {
-			return err
-		}
-		if len(response.Communities()) == 0 {
-			return errors.New("message not received")
-		}
-		return nil
-	})
-
-	s.Require().NoError(err)
+	s.advertiseCommunityTo(community, s.bob, s.alice)
 
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
 	// We try to join the org


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/14532

Once the limit of members is reached, the community switches to On Request (manual approval).

Also, I put a limit on the number of pending requests in case the spam gets crazy.

I added a test that I ran a hundred times (I can run it more if we want, but it's long :skull: )