### PR TITLE
Fix/missing wallet community info cache

### DIFF
--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -659,6 +659,11 @@ func (s *Service) fetchCommunityFromStoreNodes(communityID string) (*communities
 	return community, nil
 }
 
+func (s *Service) GetCommunityInfoFromDB(communityID string) (*thirdparty.CommunityInfo, error) {
+	community, err := s.messenger.FindCommunityInfoFromDB(communityID)
+	return communityToInfo(community), err
+}
+
 // Fetch latest community from store nodes.
 func (s *Service) FetchCommunityInfo(communityID string) (*thirdparty.CommunityInfo, error) {
 	if s.messenger == nil {

--- a/services/wallet/community/manager.go
+++ b/services/wallet/community/manager.go
@@ -59,7 +59,24 @@ func (cm *Manager) GetCommunityID(tokenURI string) string {
 }
 
 func (cm *Manager) FillCollectiblesMetadata(communityID string, cs []*thirdparty.FullCollectibleData) (bool, error) {
-	return cm.communityInfoProvider.FillCollectiblesMetadata(communityID, cs)
+	communityFound, err := cm.communityInfoProvider.FillCollectiblesMetadata(communityID, cs)
+	if err != nil {
+		return communityFound, err
+	}
+
+	if communityFound {
+		// Update local community data cache
+		community, err := cm.communityInfoProvider.GetCommunityInfoFromDB(communityID)
+		if err != nil {
+			log.Error("GetCommunityInfoFromDB failed", "communityID", communityID, "err", err)
+			return communityFound, err
+		}
+		err = cm.setCommunityInfo(communityID, community)
+		if err != nil {
+			log.Error("SetCommunityInfo failed", "communityID", community)
+		}
+	}
+	return communityFound, nil
 }
 
 func (cm *Manager) setCommunityInfo(id string, c *thirdparty.CommunityInfo) (err error) {

--- a/services/wallet/thirdparty/community_types.go
+++ b/services/wallet/thirdparty/community_types.go
@@ -9,6 +9,7 @@ type CommunityInfo struct {
 }
 
 type CommunityInfoProvider interface {
+	GetCommunityInfoFromDB(communityID string) (*CommunityInfo, error)
 	FetchCommunityInfo(communityID string) (*CommunityInfo, error)
 
 	// Collectible-related methods


### PR DESCRIPTION
The wallet's local community info cache was only getting updated with ERC20 updates, not with collectibles ones. This PR fixes that.

Part of https://github.com/orgs/status-im/projects/97/views/1?pane=issue&itemId=59942686
