### PR TITLE
fix(communities)_: fix curated comm fetch not starting for unknown comm

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -741,7 +741,7 @@ func (m *Manager) GetStoredDescriptionForCommunities(communityIDs []string) (*Kn
 		}
 
 		community, err := m.GetByID(types.HexBytes(communityIDBytes))
-		if err != nil {
+		if err != nil && err != ErrOrgNotFound {
 			return nil, err
 		}
 


### PR DESCRIPTION
We were returning an error when we didn't find the community, but in fact, that was a normal scenario, since if the community is not known, we put it in `UnknownCommunities` to then fetch it.

Without this fix, it would never fetch the community.