### PR TITLE
fix(permissions): private permissions shouldn't affect the check

### DIFF
--- a/protocol/communities/permission_checker.go
+++ b/protocol/communities/permission_checker.go
@@ -412,10 +412,6 @@ func (p *DefaultPermissionChecker) CheckPermissions(permissions []*CommunityToke
 		}
 		response.Permissions[tokenPermission.Id].ID = tokenPermission.Id
 
-		if tokenPermission.IsPrivate && !permissionRequirementsMet {
-			delete(response.Permissions, tokenPermission.Id)
-		}
-
 		// multiple permissions are treated as logical OR, meaning
 		// if only one of them is fulfilled, the user gets permission
 		// to join and we can stop early


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/14608

The permission check was incorrectly deleting the response to a permission that was private.

What this caused is that the permission check was completely ignored, which meant that the channel would be open to everyone.

@ajayesivan I saw that you were the one that added those lines. The way we hide the permissions is on the UI side for Desktop.
Otherwise, you can try to do it on the status-go side, but it would need to be only when passing the community to the front-end, though that's a bit harder.
Either way, doing it during the CheckPermissions is not the right way, since it makes it so that we completely ignore the permission.