### PR TITLE
chore_: better community json log

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -6,7 +6,6 @@ import (
 	"crypto/ecdsa"
 	"database/sql"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -5428,12 +5427,11 @@ func (m *Manager) encryptCommunityDescriptionImpl(groupID []byte, d *protobuf.Co
 		return "", nil, err
 	}
 
-	communityJSON, err := json.Marshal(d)
-	if err != nil {
-		return "", nil, err
-	}
+	m.logger.Debug("encrypting community description",
+		zap.Any("community", d),
+		zap.String("groupID", types.Bytes2Hex(groupID)),
+		zap.String("keyID", types.Bytes2Hex(keyID)))
 
-	m.logger.Debug("encrypting community description", zap.String("community", string(communityJSON)), zap.String("groupID", types.Bytes2Hex(groupID)), zap.String("key-id", types.Bytes2Hex(keyID)))
 	keyIDSeqNo := fmt.Sprintf("%s%d", hex.EncodeToString(keyID), newSeqNo)
 
 	return keyIDSeqNo, encryptedPayload, nil

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -109,11 +109,12 @@ func (m *Messenger) publishOrg(org *communities.Community, shouldRekey bool) err
 		return nil
 	}
 
-	communityJSON, err := json.Marshal(org)
-	if err != nil {
-		return err
-	}
-	m.logger.Debug("publishing org", zap.String("org-id", org.IDString()), zap.Uint64("clock", org.Clock()), zap.String("org", string(communityJSON)))
+	m.logger.Debug("publishing community",
+		zap.Uint64("clock", org.Clock()),
+		zap.String("communityID", org.IDString()),
+		zap.Any("community", org),
+	)
+
 	payload, err := org.MarshaledDescription()
 
 	if err != nil {


### PR DESCRIPTION
I found 2 places where we were manually calling `json.Marshal(community` for logging.
I replaced this using `zap.Any`.

It [was like that before](https://github.com/status-im/status-go/pull/4613/files#diff-e8ae84ba629f58c08abd2b2b3864896c92dd9b3898cf7b450d378f76004bf312), and the intention of replacing was to prevent crashes on desktop.

But I don't see any way this would prevent crash. I made a test and eventual behaviour is the same:
- `zap.Any` internally will call out custom `community.MarshalJSON`.
- `json.Marshal` will also call `community.MarshalJSON`.

And logging json is just very ugly, because it's an escaped JSON field inside a proper json from zap.
