### PR TITLE
chore: disable discv5 in tests

### DIFF
--- a/protocol/waku_builder_test.go
+++ b/protocol/waku_builder_test.go
@@ -28,7 +28,7 @@ func NewTestWakuV2(s *suite.Suite, cfg testWakuV2Config) *waku2.Waku {
 		LightClient:              false,
 		EnablePeerExchangeServer: true,
 		EnablePeerExchangeClient: false,
-		EnableDiscV5:             true,
+		EnableDiscV5:             false,
 	}
 
 	var db *sql.DB


### PR DESCRIPTION
There's no need for DiscoveryV5 in tests.
It only pollutes the logs with periodic errors:
```go
2024-05-07T15:03:07.180+0100	WARN	waku-owner	wakuv2/waku.go:1628	failed to restart discv5	{"error": "failed to fetch bootnodes"}
github.com/status-im/status-go/wakuv2.(*Waku).seedBootnodesForDiscV5
	/Users/igorsirotin/Repositories/Status/status-desktop/vendor/status-go/wakuv2/waku.go:1628
2024-05-07T15:03:07.187+0100	INFO	waku-bob	wakuv2/waku.go:1625	querying bootnodes to restore connectivity	{"peer-count": 2}
2024-05-07T15:03:07.187+0100	WARN	waku-bob	wakuv2/waku.go:1628	failed to restart discv5	{"error": "failed to fetch bootnodes"}
github.com/status-im/status-go/wakuv2.(*Waku).seedBootnodesForDiscV5
	/Users/igorsirotin/Repositories/Status/status-desktop/vendor/status-go/wakuv2/waku.go:1628
2024-05-07T15:03:07.194+0100	INFO	waku-alice	wakuv2/waku.go:1625	querying bootnodes to restore connectivity	{"peer-count": 2}
2024-05-07T15:03:07.194+0100	WARN	waku-alice	wakuv2/waku.go:1628	failed to restart discv5	{"error": "failed to fetch bootnodes"}
github.com/status-im/status-go/wakuv2.(*Waku).seedBootnodesForDiscV5
	/Users/igorsirotin/Repositories/Status/status-desktop/vendor/status-go/wakuv2/waku.go:1628

```