### PR TITLE
feat(community): send signals about member reevaluation in progress

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1227,7 +1227,15 @@ func (m *Manager) DeleteCommunityTokenPermission(request *requests.DeleteCommuni
 }
 
 func (m *Manager) reevaluateCommunityMembersPermissions(communityID types.HexBytes) error {
+	// Publish when the reevluation started since it can take a while
+	signal.SendCommunityMemberReevaluationStarted(types.EncodeHex(communityID))
+
 	community, newPrivilegedMembers, err := m.ReevaluateMembers(communityID)
+
+	// Publish the reevaluation ending, even if it errored
+	// A possible improvement would be to pass the error here
+	signal.SendCommunityMemberReevaluationEnded(types.EncodeHex(communityID))
+
 	if err != nil {
 		return err
 	}

--- a/signal/events_community_reevaluation.go
+++ b/signal/events_community_reevaluation.go
@@ -1,0 +1,26 @@
+package signal
+
+const (
+	MemberReevaluationStatus = "community.memberReevaluationStatus"
+)
+
+type ReevaluationStatus uint
+
+const (
+	None ReevaluationStatus = iota
+	InProgress
+	Done
+)
+
+type CommunityMemberReevaluationSignal struct {
+	CommunityID string             `json:"communityId"`
+	Status      ReevaluationStatus `json:"status"`
+}
+
+func SendCommunityMemberReevaluationStarted(communityID string) {
+	send(MemberReevaluationStatus, CommunityMemberReevaluationSignal{CommunityID: communityID, Status: InProgress})
+}
+
+func SendCommunityMemberReevaluationEnded(communityID string) {
+	send(MemberReevaluationStatus, CommunityMemberReevaluationSignal{CommunityID: communityID, Status: Done})
+}


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/14378

Sends signals when the member re-evaluation is ongoing
