### PR TITLE
fix(communities)_: delay starting torrent client until connection is established

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -444,15 +444,18 @@ func (m *Manager) Start() error {
 	if m.ownerVerifier != nil {
 		m.runOwnerVerificationLoop()
 	}
+	return nil
+}
 
-	if m.torrentConfig != nil && m.torrentConfig.Enabled {
-		err := m.StartTorrentClient()
-		if err != nil {
-			m.LogStdout("couldn't start torrent client", zap.Error(err))
+func (m *Manager) SetOnline(online bool) {
+	if online {
+		if m.torrentConfig != nil && m.torrentConfig.Enabled && !m.TorrentClientStarted() {
+			err := m.StartTorrentClient()
+			if err != nil {
+				m.LogStdout("couldn't start torrent client", zap.Error(err))
+			}
 		}
 	}
-
-	return nil
 }
 
 func (m *Manager) runENSVerificationLoop() {

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -501,6 +501,16 @@ func (s *ManagerSuite) TestStopTorrentClient_ShouldStopHistoryArchiveTasks() {
 	s.Require().Equal(count, 0)
 }
 
+func (s *ManagerSuite) TestStartTorrentClient_DelayedUntilOnline() {
+	torrentConfig := buildTorrentConfig()
+	s.manager.SetTorrentConfig(&torrentConfig)
+
+	s.Require().False(s.manager.TorrentClientStarted())
+
+	s.manager.SetOnline(true)
+	s.Require().True(s.manager.TorrentClientStarted())
+}
+
 func (s *ManagerSuite) TestCreateHistoryArchiveTorrent_WithoutMessages() {
 
 	torrentConfig := buildTorrentConfig()

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -899,6 +899,11 @@ func (m *Messenger) handleConnectionChange(online bool) {
 		}
 	}
 
+	// Update Communities manager
+	if m.communitiesManager != nil {
+		m.communitiesManager.SetOnline(online)
+	}
+
 	// Publish contact code
 	if online && m.shouldPublishContactCode {
 		if err := m.publishContactCode(); err != nil {


### PR DESCRIPTION
* `Messenger` is subscribed to connectivity status updates. Whenever status is updated, `Messenger` calls `Manager.setOnline` 
* `Manager` launches TorrentClient on first connection

Closes https://github.com/status-im/status-desktop/issues/14510
