### PR TITLE
fix(communities)_: prepare messages content for GetCommunityMemberAllMessages

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3547,12 +3547,9 @@ func (r *ReceivedMessageState) addNewActivityCenterNotification(publicKey ecdsa.
 			return err
 		}
 		if m.httpServer != nil {
-			for _, msg := range album {
-				err = m.prepareMessage(msg, m.httpServer)
-
-				if err != nil {
-					return err
-				}
+			err = m.prepareMessagesList(album)
+			if err != nil {
+				return err
 			}
 		}
 
@@ -4158,11 +4155,9 @@ func (m *Messenger) MessageByChatID(chatID, cursor string, limit int) ([]*common
 	}
 
 	if m.httpServer != nil {
-		for _, msg := range msgs {
-			err = m.prepareMessage(msg, m.httpServer)
-			if err != nil {
-				return nil, "", err
-			}
+		err = m.prepareMessagesList(msgs)
+		if err != nil {
+			return nil, "", err
 		}
 	}
 
@@ -4170,6 +4165,19 @@ func (m *Messenger) MessageByChatID(chatID, cursor string, limit int) ([]*common
 }
 
 func (m *Messenger) prepareMessages(messages map[string]*common.Message) error {
+	if m.httpServer == nil {
+		return nil
+	}
+	for idx := range messages {
+		err := m.prepareMessage(messages[idx], m.httpServer)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Messenger) prepareMessagesList(messages []*common.Message) error {
 	if m.httpServer == nil {
 		return nil
 	}

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4651,7 +4651,10 @@ func (m *Messenger) GetCommunityMemberAllMessages(request *requests.CommunityMem
 
 		messages = append(messages, updatedMessages...)
 	}
-
+	err = m.prepareMessagesList(messages)
+	if err != nil {
+		return nil, err
+	}
 	return messages, nil
 
 }


### PR DESCRIPTION
(Solution is similar to #[13684](https://github.com/status-im/status-desktop/issues/13684))

now there is a correct image previews in `Community settings -> Members -> and View member messages`
# Changes
* GetCommunityMemberAllMessages - returns messages with prepared content (links to images/emojis)
* Added a test 
 
<kbd>

<img width="1457" alt="image" src="https://github.com/status-im/status-go/assets/1083341/d007cfea-7bbf-46d1-a4de-5409bfedd505">

</kbd>

Closes #[14060](https://github.com/status-im/status-desktop/issues/14060)
