### PR TITLE
fix_: loading `hash_ratchet_encryption` from database checks `group_id`

### DIFF
--- a/protocol/encryption/helpers.go
+++ b/protocol/encryption/helpers.go
@@ -18,7 +18,7 @@ const keyBumpValue = uint64(10)
 
 // GetCurrentTime64 returns the current unix time in milliseconds
 func GetCurrentTime() uint64 {
-	return (uint64)(time.Now().UnixNano() / int64(time.Second))
+	return (uint64)(time.Now().UnixMilli())
 }
 
 // bumpKeyID takes a timestampID and returns its value incremented by the keyBumpValue

--- a/protocol/encryption/helpers.go
+++ b/protocol/encryption/helpers.go
@@ -18,7 +18,7 @@ const keyBumpValue = uint64(10)
 
 // GetCurrentTime64 returns the current unix time in milliseconds
 func GetCurrentTime() uint64 {
-	return (uint64)(time.Now().UnixNano() / int64(time.Millisecond))
+	return (uint64)(time.Now().UnixNano() / int64(time.Second))
 }
 
 // bumpKeyID takes a timestampID and returns its value incremented by the keyBumpValue

--- a/protocol/encryption/persistence.go
+++ b/protocol/encryption/persistence.go
@@ -764,7 +764,11 @@ func (s *sqlitePersistence) GetHashRatchetCache(ratchet *HashRatchetKeyCompatibi
 		}
 	}
 
-	err = tx.QueryRow("SELECT key FROM hash_ratchet_encryption WHERE key_id = ? OR deprecated_key_id = ?", keyID, ratchet.DeprecatedKeyID()).Scan(&key)
+	err = tx.QueryRow("SELECT key FROM hash_ratchet_encryption WHERE key_id = ? OR (deprecated_key_id = ? AND group_id = ?)",
+		keyID,
+		ratchet.DeprecatedKeyID(),
+		ratchet.GroupID,
+	).Scan(&key)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}


### PR DESCRIPTION
Fixed `GetHashRatchetCache` implementation.

1. For `deprecated_key_id` we also use `group_id` as condition.
2. Fixed time precision in `encryption.GetCurrentTime`, which returned seconds instead of desired milliseconds. This caused issues in tests.

Required for https://github.com/status-im/status-go/pull/5076
Tested there as well. Keeping a separate PR for clarity.