### PR TITLE
feat_: force members reevaluation

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1157,7 +1157,6 @@ func (m *Manager) reevaluateMembersLoop(communityID types.HexBytes, reevaluateOn
 
 		// Ensure reevaluation is performed not more often than once per minute
 		if !force && task.lastSuccessTime.After(time.Now().Add(-1*time.Minute)) {
-			logger.Debug("<<< reevaluateMembers: skipping as too frequent")
 			return nil
 		}
 

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -954,8 +954,7 @@ func (m *Manager) EditCommunityTokenPermission(request *requests.EditCommunityTo
 	return community, changes, nil
 }
 
-// WARNING: ReevaluateMembers is only public to be used in messenger tests.
-func (m *Manager) ReevaluateMembers(communityID types.HexBytes) (*Community, map[protobuf.CommunityMember_Roles][]*ecdsa.PublicKey, error) {
+func (m *Manager) reevaluateMembers(communityID types.HexBytes) (*Community, map[protobuf.CommunityMember_Roles][]*ecdsa.PublicKey, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -1233,7 +1232,7 @@ func (m *Manager) reevaluateCommunityMembersPermissions(communityID types.HexByt
 	// Publish when the reevluation started since it can take a while
 	signal.SendCommunityMemberReevaluationStarted(types.EncodeHex(communityID))
 
-	community, newPrivilegedMembers, err := m.ReevaluateMembers(communityID)
+	community, newPrivilegedMembers, err := m.reevaluateMembers(communityID)
 
 	// Publish the reevaluation ending, even if it errored
 	// A possible improvement would be to pass the error here

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -580,7 +580,7 @@ func waitOnCommunitiesEvent(user *Messenger, condition func(*communities.Subscri
 					return
 				}
 
-			case <-time.After(500 * time.Millisecond):
+			case <-time.After(5 * time.Second):
 				errCh <- errors.New("timed out when waiting for communities event")
 				return
 			}

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -104,7 +104,7 @@ func (tckd *TestCommunitiesKeyDistributor) waitOnKeyDistribution(condition func(
 					return
 				}
 
-			case <-time.After(500 * time.Millisecond):
+			case <-time.After(5 * time.Second):
 				errCh <- errors.New("timed out when waiting for key distribution")
 				return
 			}

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -184,6 +184,11 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TearDownTest() {
 }
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) newMessenger(password string, walletAddresses []string, waku types.Waku, name string, extraOptions []Option) *Messenger {
+	communityManagerOptions := []communities.ManagerOption{
+		communities.WithAllowForcingCommunityMembersReevaluation(true),
+	}
+	extraOptions = append(extraOptions, WithCommunityManagerOptions(communityManagerOptions))
+
 	return newTestCommunitiesMessenger(&s.Suite, waku, testCommunitiesMessengerConfig{
 		testMessengerConfig: testMessengerConfig{
 			logger:       s.logger.Named(name),

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -1503,9 +1503,20 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testReevaluateMemberPrivileg
 	s.Require().NoError(err)
 	s.Require().True(checkRoleBasedOnThePermissionType(permissionType, &s.alice.identity.PublicKey, community))
 
+	waitOnPermissionsReevaluated := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
+		if sub.Community == nil {
+			return false
+		}
+		return checkRoleBasedOnThePermissionType(permissionType, &s.alice.identity.PublicKey, sub.Community)
+	})
+
 	// the control node re-evaluates the roles of the participants, checking that the privileged user has not lost his role
 	err = s.owner.communitiesManager.ForceMembersReevaluation(community.ID())
 	s.Require().NoError(err)
+
+	err = <-waitOnPermissionsReevaluated
+	s.Require().NoError(err)
+
 	community, err = s.owner.communitiesManager.GetByID(community.ID())
 	s.Require().NoError(err)
 	s.Require().True(checkRoleBasedOnThePermissionType(permissionType, &s.alice.identity.PublicKey, community))
@@ -1526,7 +1537,17 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testReevaluateMemberPrivileg
 	s.Require().NoError(err)
 	s.Require().False(community.HasTokenPermissions())
 
+	waitOnPermissionsReevaluated = waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
+		if sub.Community == nil {
+			return false
+		}
+		return !checkRoleBasedOnThePermissionType(permissionType, &s.alice.identity.PublicKey, sub.Community)
+	})
+
 	err = s.owner.communitiesManager.ForceMembersReevaluation(community.ID())
+	s.Require().NoError(err)
+
+	err = <-waitOnPermissionsReevaluated
 	s.Require().NoError(err)
 
 	community, err = s.owner.communitiesManager.GetByID(community.ID())
@@ -1611,6 +1632,13 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testReevaluateMemberPrivileg
 	s.makeAddressSatisfyTheCriteria(testChainID1, aliceAddress1, tokenPermission.TokenCriteria[0])
 	s.makeAddressSatisfyTheCriteria(testChainID1, aliceAddress1, tokenMemberPermission.TokenCriteria[0])
 
+	waitOnAliceAddedToCommunity := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
+		if sub.Community == nil {
+			return false
+		}
+		return checkRoleBasedOnThePermissionType(permissionType, &s.alice.identity.PublicKey, sub.Community)
+	})
+
 	// join community as a privileged user
 	s.joinCommunity(community, s.alice, alicePassword, []string{aliceAddress1})
 
@@ -1620,6 +1648,9 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testReevaluateMemberPrivileg
 
 	// the control node reevaluates the roles of the participants, checking that the privileged user has not lost his role
 	err = s.owner.communitiesManager.ForceMembersReevaluation(community.ID())
+	s.Require().NoError(err)
+
+	err = <-waitOnAliceAddedToCommunity
 	s.Require().NoError(err)
 
 	community, err = s.owner.communitiesManager.GetByID(community.ID())
@@ -1642,7 +1673,17 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testReevaluateMemberPrivileg
 	s.Require().NoError(err)
 	s.Require().Len(response.Communities()[0].TokenPermissions(), 1)
 
+	waitOnAliceLostPermission := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
+		if sub.Community == nil {
+			return false
+		}
+		return !checkRoleBasedOnThePermissionType(permissionType, &s.alice.identity.PublicKey, sub.Community)
+	})
+
 	err = s.owner.communitiesManager.ForceMembersReevaluation(community.ID())
+	s.Require().NoError(err)
+
+	err = <-waitOnAliceLostPermission
 	s.Require().NoError(err)
 
 	community, err = s.owner.communitiesManager.GetByID(community.ID())
@@ -1666,7 +1707,17 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testReevaluateMemberPrivileg
 	s.Require().NoError(err)
 	s.Require().Len(response.Communities()[0].TokenPermissions(), 0)
 
+	waitOnReevaluation := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
+		if sub.Community == nil {
+			return false
+		}
+		return !checkRoleBasedOnThePermissionType(permissionType, &s.alice.identity.PublicKey, sub.Community)
+	})
+
 	err = s.owner.communitiesManager.ForceMembersReevaluation(community.ID())
+	s.Require().NoError(err)
+
+	err = <-waitOnReevaluation
 	s.Require().NoError(err)
 
 	community, err = s.owner.communitiesManager.GetByID(community.ID())

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -477,6 +477,8 @@ func NewMessenger(
 		managerOptions = append(managerOptions, communities.WithCommunityTokensService(c.communityTokensService))
 	}
 
+	managerOptions = append(managerOptions, c.communityManagerOptions...)
+
 	communitiesKeyDistributor := &CommunitiesKeyDistributorImpl{
 		sender:    sender,
 		encryptor: encryptionProtocol,

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -118,6 +118,8 @@ type config struct {
 
 	messageResendMinDelay time.Duration
 	messageResendMaxCount int
+
+	communityManagerOptions []communities.ManagerOption
 }
 
 func messengerDefaultConfig() config {

--- a/protocol/messenger_config_test.go
+++ b/protocol/messenger_config_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/services/mailservers"
 	"github.com/status-im/status-go/t/helpers"
 )
@@ -41,6 +42,13 @@ func WithAutoRequestHistoricMessages(enabled bool) Option {
 func WithCuratedCommunitiesUpdateLoop(enabled bool) Option {
 	return func(c *config) error {
 		c.codeControlFlags.CuratedCommunitiesUpdateLoopEnabled = enabled
+		return nil
+	}
+}
+
+func WithCommunityManagerOptions(options []communities.ManagerOption) Option {
+	return func(c *config) error {
+		c.communityManagerOptions = options
 		return nil
 	}
 }


### PR DESCRIPTION
> [!Tip]
> Review by commits

1. Implement `ForceMembersReevaluation` to be used in tests.
All reevaluation is now done in the community manager loop. There's a 10sec ticker, but we want the reevaluation to be triggered immediately.
I covered this code carefully so that it's not used in production.

2. Enable adding community manager options from messenger config

3. Make `ReevaluateMembers` a private method. It shouldn't be called directly.
Because now in tests we're using `ForceMembersReevaluation`.

4. Increase timeouts in `waitOnCommunitiesEvent` and `waitOnKeyDistribution`.
This seems to be really required now. Tests are simply not running fast enough.