### PR TITLE
fix_: handling throughput limit error from providers

### DIFF
--- a/rpc/chain/rpc_limiter.go
+++ b/rpc/chain/rpc_limiter.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	defaultMaxRequestsPerSecond = 100
+	defaultMaxRequestsPerSecond = 50
 	minRequestsPerSecond        = 20
 	requestsPerSecondStep       = 10
 


### PR DESCRIPTION
Refers to the issue logged in the desktop repo https://github.com/status-im/status-desktop/issues/14665

We're using `hystrix` and how it was when we reached the maximum request per second limit for pokt, fallback was part was executed requesting data from infura and very often we're reaching the limit there, usually on the app start or when an action like finding the best route for transaction is called, where we do a lot of request in a very short period of time.

What's changed here is, when we try to get data from the main server and we get a request per second limit we don't proceed  immediately to fallback server, but use the power of rpcLimiter and wait one second and then try to fetch data from the main server again, if that fails then we proceed with fallback server.

Also `defaultMaxRequestsPerSecond` is reduced. 

Testing this locally I noticed slightly slower app start, but also noticed there is no infura calls anymore, all request were handled by pokt, which is our main server.

