### PR TITLE
feat(waku2): allow using an env variable to set the node's key

### DIFF
--- a/api/messenger_raw_message_resend_test.go
+++ b/api/messenger_raw_message_resend_test.go
@@ -54,7 +54,7 @@ func (s *MessengerRawMessageResendTest) SetupTest() {
 		UseShardAsDefaultTopic:   true,
 		DefaultShardPubsubTopic:  shard.DefaultShardPubsubTopic(),
 	}
-	s.exchangeBootNode, err = wakuv2.New("", "", exchangeNodeConfig, logger.Named("pxServerNode"), nil, nil, nil, nil)
+	s.exchangeBootNode, err = wakuv2.New(nil, "", exchangeNodeConfig, logger.Named("pxServerNode"), nil, nil, nil, nil)
 	s.Require().NoError(err)
 	s.Require().NoError(s.exchangeBootNode.Start())
 

--- a/protocol/waku_builder_test.go
+++ b/protocol/waku_builder_test.go
@@ -44,7 +44,7 @@ func NewTestWakuV2(s *suite.Suite, cfg testWakuV2Config) *waku2.Waku {
 	}
 
 	wakuNode, err := waku2.New(
-		"",
+		nil,
 		"",
 		wakuConfig,
 		cfg.logger,

--- a/wakuv2/api_test.go
+++ b/wakuv2/api_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestMultipleTopicCopyInNewMessageFilter(t *testing.T) {
-	w, err := New("", "", nil, nil, nil, nil, nil, nil)
+	w, err := New(nil, "", nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Error creating WakuV2 client: %v", err)
 	}

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -165,7 +165,7 @@ func newTTLCache() *ttlcache.Cache[gethcommon.Hash, *common.ReceivedMessage] {
 }
 
 // New creates a WakuV2 client ready to communicate through the LibP2P network.
-func New(nodeKey string, fleet string, cfg *Config, logger *zap.Logger, appDB *sql.DB, ts *timesource.NTPTimeSource, onHistoricMessagesRequestFailed func([]byte, peer.ID, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
+func New(nodeKey *ecdsa.PrivateKey, fleet string, cfg *Config, logger *zap.Logger, appDB *sql.DB, ts *timesource.NTPTimeSource, onHistoricMessagesRequestFailed func([]byte, peer.ID, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
 	var err error
 	if logger == nil {
 		logger, err = zap.NewDevelopment()
@@ -215,16 +215,12 @@ func New(nodeKey string, fleet string, cfg *Config, logger *zap.Logger, appDB *s
 	waku.filters = common.NewFilters(waku.cfg.DefaultShardPubsubTopic, waku.logger)
 	waku.bandwidthCounter = metrics.NewBandwidthCounter()
 
-	var privateKey *ecdsa.PrivateKey
-	if nodeKey != "" {
-		privateKey, err = crypto.HexToECDSA(nodeKey)
-	} else {
-		// If no nodekey is provided, create an ephemeral key
-		privateKey, err = crypto.GenerateKey()
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to setup the go-waku private key: %v", err)
+	if nodeKey == nil {
+		// No nodekey is provided, create an ephemeral key
+		nodeKey, err = crypto.GenerateKey()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate a random go-waku private key: %v", err)
+		}
 	}
 
 	hostAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprint(cfg.Host, ":", cfg.Port))
@@ -242,7 +238,7 @@ func New(nodeKey string, fleet string, cfg *Config, logger *zap.Logger, appDB *s
 
 	opts := []node.WakuNodeOption{
 		node.WithLibP2POptions(libp2pOpts...),
-		node.WithPrivateKey(privateKey),
+		node.WithPrivateKey(nodeKey),
 		node.WithHostAddress(hostAddr),
 		node.WithConnectionStatusChannel(waku.connStatusChan),
 		node.WithKeepAlive(time.Duration(cfg.KeepAliveInterval) * time.Second),

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -42,7 +42,7 @@ func TestDiscoveryV5(t *testing.T) {
 	config.EnableDiscV5 = true
 	config.DiscV5BootstrapNodes = []string{testENRBootstrap}
 	config.DiscoveryLimit = 20
-	w, err := New("", "", config, nil, nil, nil, nil, nil)
+	w, err := New(nil, "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, w.Start())
@@ -67,7 +67,7 @@ func TestRestartDiscoveryV5(t *testing.T) {
 	config.DiscV5BootstrapNodes = []string{"enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@1.1.1.2"}
 	config.DiscoveryLimit = 20
 	config.UDPPort = 9002
-	w, err := New("", "", config, nil, nil, nil, nil, nil)
+	w, err := New(nil, "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, w.Start())
@@ -120,7 +120,7 @@ func TestBasicWakuV2(t *testing.T) {
 	config.DiscV5BootstrapNodes = []string{enrTreeAddress}
 	config.DiscoveryLimit = 20
 	config.WakuNodes = []string{enrTreeAddress}
-	w, err := New("", "", config, nil, nil, nil, nil, nil)
+	w, err := New(nil, "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 
@@ -229,7 +229,7 @@ func TestPeerExchange(t *testing.T) {
 	config.EnableDiscV5 = true
 	config.EnablePeerExchangeServer = true
 	config.EnablePeerExchangeClient = false
-	pxServerNode, err := New("", "", config, logger.Named("pxServerNode"), nil, nil, nil, nil)
+	pxServerNode, err := New(nil, "", config, logger.Named("pxServerNode"), nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, pxServerNode.Start())
 
@@ -241,7 +241,7 @@ func TestPeerExchange(t *testing.T) {
 	config.EnablePeerExchangeServer = false
 	config.EnablePeerExchangeClient = false
 	config.DiscV5BootstrapNodes = []string{pxServerNode.node.ENR().String()}
-	discV5Node, err := New("", "", config, logger.Named("discV5Node"), nil, nil, nil, nil)
+	discV5Node, err := New(nil, "", config, logger.Named("discV5Node"), nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, discV5Node.Start())
 
@@ -259,7 +259,7 @@ func TestPeerExchange(t *testing.T) {
 	config.Resolver = resolver
 
 	config.WakuNodes = []string{url}
-	lightNode, err := New("", "", config, logger.Named("lightNode"), nil, nil, nil, nil)
+	lightNode, err := New(nil, "", config, logger.Named("lightNode"), nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, lightNode.Start())
 
@@ -301,7 +301,7 @@ func TestWakuV2Filter(t *testing.T) {
 	config.DiscoveryLimit = 20
 	config.WakuNodes = []string{enrTreeAddress}
 	fleet := "status.test" // Need a name fleet so that LightClient is not set to false
-	w, err := New("", fleet, config, nil, nil, nil, nil, nil)
+	w, err := New(nil, fleet, config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 
@@ -390,7 +390,7 @@ func TestWakuV2Store(t *testing.T) {
 	w1PeersCh := make(chan []string, 100) // buffered not to block on the send side
 
 	// Start the first Waku node
-	w1, err := New("", "", config1, nil, nil, nil, nil, func(cs types.ConnStatus) {
+	w1, err := New(nil, "", config1, nil, nil, nil, nil, func(cs types.ConnStatus) {
 		w1PeersCh <- maps.Keys(cs.Peers)
 	})
 	require.NoError(t, err)
@@ -414,7 +414,7 @@ func TestWakuV2Store(t *testing.T) {
 	}
 
 	// Start the second Waku node
-	w2, err := New("", "", config2, nil, sql2, nil, nil, nil)
+	w2, err := New(nil, "", config2, nil, sql2, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w2.Start())
 	w2EnvelopeCh := make(chan common.EnvelopeEvent, 100)


### PR DESCRIPTION
Required so it's possible to have a fixed peerID to simplify debugging
