### PR TITLE
Fix/statusd crashes if wallet enabled

### DIFF
--- a/multiaccounts/accounts/database.go
+++ b/multiaccounts/accounts/database.go
@@ -296,6 +296,10 @@ type Database struct {
 
 // NewDB returns a new instance of *Database
 func NewDB(db *sql.DB) (*Database, error) {
+	if db == nil {
+		return nil, errDbPassedParameterIsNil
+	}
+
 	sDB, err := settings.MakeNewDB(db)
 	if err != nil {
 		return nil, err

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -79,6 +79,10 @@ func NewClient(client *gethrpc.Client, upstreamChainID uint64, upstream params.U
 
 	log := log.New("package", "status-go/rpc.Client")
 	networkManager := network.NewManager(db)
+	if networkManager == nil {
+		return nil, errors.New("failed to create network manager")
+	}
+
 	err = networkManager.Init(networks)
 	if err != nil {
 		log.Error("Network manager failed to initialize", "error", err)

--- a/services/wallet/history/service_test.go
+++ b/services/wallet/history/service_test.go
@@ -371,7 +371,7 @@ func Test_removeBalanceHistoryOnEventAccountRemoved(t *testing.T) {
 	txServiceMockCtrl := gomock.NewController(t)
 	server, _ := fake.NewTestServer(txServiceMockCtrl)
 	client := gethrpc.DialInProc(server)
-	rpcClient, _ := rpc.NewClient(client, chainID, params.UpstreamRPCConfig{}, nil, nil)
+	rpcClient, _ := rpc.NewClient(client, chainID, params.UpstreamRPCConfig{}, nil, appDB)
 	rpcClient.UpstreamChainID = chainID
 
 	service := NewService(walletDB, accountsDB, &accountFeed, &walletFeed, rpcClient, nil, nil, nil)

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -328,7 +328,7 @@ func Test_removeTokenBalanceOnEventAccountRemoved(t *testing.T) {
 	txServiceMockCtrl := gomock.NewController(t)
 	server, _ := fake.NewTestServer(txServiceMockCtrl)
 	client := gethrpc.DialInProc(server)
-	rpcClient, _ := rpc.NewClient(client, chainID, params.UpstreamRPCConfig{}, nil, nil)
+	rpcClient, _ := rpc.NewClient(client, chainID, params.UpstreamRPCConfig{}, nil, appDB)
 	rpcClient.UpstreamChainID = chainID
 	nm := network.NewManager(appDB)
 	mediaServer, err := mediaserver.NewMediaServer(appDB, nil, nil, walletDB)

--- a/services/wallet/transfer/controller.go
+++ b/services/wallet/transfer/controller.go
@@ -119,12 +119,14 @@ func (c *Controller) CheckRecentHistory(chainIDs []uint64, accounts []common.Add
 		return nil
 	}
 
+	omitHistory := false
 	multiaccSettings, err := c.accountsDB.GetSettings()
 	if err != nil {
-		return err
+		log.Error("Failed to get multiacc settings") // not critical
+	} else {
+		omitHistory = multiaccSettings.OmitTransfersHistoryScan
 	}
 
-	omitHistory := multiaccSettings.OmitTransfersHistoryScan
 	if omitHistory {
 		err := c.accountsDB.SaveSettingField(settings.OmitTransfersHistoryScan, false)
 		if err != nil {

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc"
+	"github.com/status-im/status-go/sqlite"
 	"github.com/status-im/status-go/t/utils"
 	"github.com/status-im/status-go/transactions/fake"
 )
@@ -51,7 +52,9 @@ func (s *TransactorSuite) SetupTest() {
 
 	// expected by simulated backend
 	chainID := gethparams.AllEthashProtocolChanges.ChainID.Uint64()
-	rpcClient, _ := rpc.NewClient(s.client, chainID, params.UpstreamRPCConfig{}, nil, nil)
+	db, err := sqlite.OpenUnecryptedDB(sqlite.InMemoryPath) // dummy to make rpc.Client happy
+	s.Require().NoError(err)
+	rpcClient, _ := rpc.NewClient(s.client, chainID, params.UpstreamRPCConfig{}, nil, db)
 	rpcClient.UpstreamChainID = chainID
 	nodeConfig, err := utils.MakeTestNodeConfigWithDataDir("", "/tmp", chainID)
 	s.Require().NoError(err)


### PR DESCRIPTION
- fix crash on nil db for statusd if wallet is enabled
- ensure paths for DBs are created
- ensure DBs are opened before calling `StartNode`
- ignore error if multiacc database is not available

Partially resolves [#14693](https://github.com/status-im/status-desktop/issues/14693)
