### PR TITLE
Fix: Ignore community descriptions from ourselves if we are the control node

### DIFF
--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -555,15 +555,6 @@ func joinOnRequestCommunity(s *suite.Suite, community *communities.Community, co
 	userCommunity, err := user.GetCommunityByID(community.ID())
 	s.Require().NoError(err)
 	s.Require().True(userCommunity.HasMember(&user.identity.PublicKey))
-
-	_, err = WaitOnMessengerResponse(
-		controlNode,
-		func(r *MessengerResponse) bool {
-			return len(r.Communities()) > 0 && r.Communities()[0].HasMember(&user.identity.PublicKey)
-		},
-		"control node did not receive request to join response",
-	)
-	s.Require().NoError(err)
 }
 
 func sendChatMessage(s *suite.Suite, sender *Messenger, chatID string, text string) *common.Message {

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -4554,3 +4554,19 @@ func (s *MessengerCommunitiesSuite) TestAliceDidNotProcessOutdatedCommunityReque
 	err = s.alice.HandleCommunityRequestToJoinResponse(state, requestToJoinResponse, nil)
 	s.Require().NoError(err)
 }
+
+func (s *MessengerCommunitiesSuite) TestMembershipRequestAutoAcceptedDuringReevaluateMembers() {
+	community, _ := s.createCommunity()
+	community2, _ := s.createCommunity()
+
+	s.Require().NotEqual(community.ID(), community2.ID())
+	s.Require().True(community.AutoAccept())
+
+	advertiseCommunityToUserOldWay(&s.Suite, community, s.owner, s.alice)
+
+	// No need to actually reevaluate members, just lock on other community
+	s.owner.communitiesManager.LockOnCommunity(community2.ID())
+
+	s.joinCommunity(community, s.owner, s.alice)
+	s.owner.communitiesManager.UnlockOnCommunity(community2.ID())
+}


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/14700

My assumption: controlNode receives and processes its own `protobuf.CommunityDescription` which can lead to a hang of the receiver thread. It might explain why one community's prolonged reevaluation would cause another community to freeze up. 


