### PR TITLE
fix_: saving profile image changes ens display name to non-ens

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -15,6 +15,8 @@ var ErrInvalidDisplayNameRegExp = errors.New("only letters, numbers, underscores
 var ErrInvalidDisplayNameEthSuffix = errors.New(`usernames ending with "eth" are not allowed`)
 var ErrInvalidDisplayNameNotAllowed = errors.New("name is not allowed")
 
+var DISPLAY_NAME_EXT = []string{"_eth", ".eth", "-eth"}
+
 func RecoverKey(m *protobuf.ApplicationMetadataMessage) (*ecdsa.PublicKey, error) {
 	if m.Signature == nil {
 		return nil, nil
@@ -45,8 +47,10 @@ func ValidateDisplayName(displayName *string) error {
 	}
 
 	// .eth should not happen due to the regexp above, but let's keep it here in case the regexp is changed in the future
-	if strings.HasSuffix(name, "_eth") || strings.HasSuffix(name, ".eth") || strings.HasSuffix(name, "-eth") {
-		return ErrInvalidDisplayNameEthSuffix
+	for _, ext := range DISPLAY_NAME_EXT {
+		if strings.HasSuffix(*displayName, ext) {
+			return ErrInvalidDisplayNameEthSuffix
+		}
 	}
 
 	if alias.IsAlias(name) {
@@ -54,4 +58,17 @@ func ValidateDisplayName(displayName *string) error {
 	}
 
 	return nil
+}
+
+// implementation referenced from https://github.com/embarklabs/embark/blob/master/packages/plugins/ens/src/index.js
+func IsENSName(displayName string) bool {
+	if len(displayName) == 0 {
+		return false
+	}
+
+	if strings.HasSuffix(displayName, ".eth") {
+		return true
+	}
+
+	return false
 }

--- a/protocol/messenger_identity.go
+++ b/protocol/messenger_identity.go
@@ -31,7 +31,7 @@ func (m *Messenger) SetDisplayName(displayName string) error {
 		return err
 	}
 
-	if currDisplayName == displayName {
+	if utils.IsENSName(displayName) || currDisplayName == displayName {
 		return nil // Do nothing
 	}
 


### PR DESCRIPTION
### Description

When a user updates the preferred name, we should just ignore if the name is an ENS name, because the ENS name is set only in the ENS popup. But this also means that if a user set the profile name to an ENS name, this change will also be ignored.

### Detailed description/Analysis

I think I understand the problem. Let me try to summarize it.

Previously, we faced [issue](https://github.com/status-im/status-desktop/issues/14128) where the user could change the displayed name to `x.y.z`, and this prevented other clients from displaying messages due to the validation on the display name.

However, ENS names have the format `x.y.z`, for example : `kounkou.stateofus.eth`, and in the current ticket, we fall into a dilemma where we have 2 cases : 

1- If we have a display name not being in the `x.y.z` format and we want to change to the `x.y.z` format, the validation will fail.

2- If we had 2 ENS names to choose from, and we decided to move from one to another ENS name, then the validation will fail for the same.

Case 2 raises the question : 

- How is the ENS name set in the first place ?

This is because upon updating the ENS name, the actual call to update settings is https://github.com/status-im/status-desktop/blob/master/src/app_service/service/settings/service.nim#L148

### Solution Proposal

When a user update the preferred name, we should just ignore if the name is an ENS name, because the ENS name is set only in the ENS popup. But this also means that if a user set the profile  name to an ENS name, this change will also be ignored.

fixes https://github.com/status-im/status-desktop/issues/14048