### PR TITLE
feat(search): filter out messages from non-viewable channels

### DIFF
--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -514,6 +514,10 @@ func CreateCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, 
 	}
 }
 
+func (c *Chat) CommunityChannelID() string {
+	return strings.TrimPrefix(c.ID, c.CommunityID)
+}
+
 func (c *Chat) DeepLink() string {
 	if c.OneToOne() {
 		return "status-app://p/" + c.ID
@@ -523,7 +527,7 @@ func (c *Chat) DeepLink() string {
 	}
 
 	if c.CommunityChat() {
-		communityChannelID := strings.TrimPrefix(c.ID, c.CommunityID)
+		communityChannelID := c.CommunityChannelID()
 		pubkey, err := types.DecodeHex(c.CommunityID)
 		if err != nil {
 			return ""


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/14586

Make sure to filter out the non-viewable channels from the search results before sending back

Test run 1000 times:
```
go test -test.count 1000 -run MessengerCommunitiesTokenPermissionsSuite/TestSearchMessageinPermissionedChannel -failfast -timeout 3000s -tags gowaku_skip_migrations,gowaku_no_rln
PASS
ok  	github.com/status-im/status-go/protocol	1732.973s
```