### PR TITLE
feat_: light, no-network versions of permission checking functions

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4322,6 +4322,14 @@ func (m *Messenger) CheckPermissionsToJoinCommunity(request *requests.CheckPermi
 	return m.communitiesManager.CheckPermissionToJoin(request.CommunityID, addresses)
 }
 
+func (m *Messenger) CheckPermissionsToJoinCommunityLight(request *requests.CheckPermissionToJoinCommunity) (bool, error) {
+	if err := request.Validate(); err != nil {
+		return false, err
+	}
+
+	return m.communitiesManager.CheckPermissionToJoinLight(request.CommunityID)
+}
+
 func (m *Messenger) getSharedAddresses(communityID types.HexBytes, requestAddresses []string) ([]gethcommon.Address, error) {
 	addressesMap := make(map[string]struct{})
 
@@ -4383,6 +4391,22 @@ func (m *Messenger) CheckAllCommunityChannelsPermissions(request *requests.Check
 	}
 
 	return m.communitiesManager.CheckAllChannelsPermissions(request.CommunityID, addresses)
+}
+
+func (m *Messenger) CheckCommunityChannelPermissionsLight(request *requests.CheckCommunityChannelPermissions) (*communities.CheckChannelPermissionsResponse, error) {
+	if err := request.Validate(); err != nil {
+		return nil, err
+	}
+
+	return m.communitiesManager.CheckChannelPermissionsLight(request.CommunityID, request.ChatID)
+}
+
+func (m *Messenger) CheckAllCommunityChannelsPermissionsLight(request *requests.CheckAllCommunityChannelsPermissions) (*communities.CheckAllChannelsPermissionsResponse, error) {
+	if err := request.Validate(); err != nil {
+		return nil, err
+	}
+
+	return m.communitiesManager.CheckAllChannelsPermissionsLight(request.CommunityID)
 }
 
 func (m *Messenger) GetCommunityCheckChannelPermissionResponses(communityID types.HexBytes) (*communities.CheckAllChannelsPermissionsResponse, error) {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1590,12 +1590,24 @@ func (api *PublicAPI) CheckPermissionsToJoinCommunity(request *requests.CheckPer
 	return api.service.messenger.CheckPermissionsToJoinCommunity(request)
 }
 
+func (api *PublicAPI) CheckPermissionsToJoinCommunityLight(request *requests.CheckPermissionToJoinCommunity) (bool, error) {
+	return api.service.messenger.CheckPermissionsToJoinCommunityLight(request)
+}
+
 func (api *PublicAPI) CheckCommunityChannelPermissions(request *requests.CheckCommunityChannelPermissions) (*communities.CheckChannelPermissionsResponse, error) {
 	return api.service.messenger.CheckCommunityChannelPermissions(request)
 }
 
+func (api *PublicAPI) CheckCommunityChannelPermissionsLight(request *requests.CheckCommunityChannelPermissions) (*communities.CheckChannelPermissionsResponse, error) {
+	return api.service.messenger.CheckCommunityChannelPermissionsLight(request)
+}
+
 func (api *PublicAPI) CheckAllCommunityChannelsPermissions(request *requests.CheckAllCommunityChannelsPermissions) (*communities.CheckAllChannelsPermissionsResponse, error) {
 	return api.service.messenger.CheckAllCommunityChannelsPermissions(request)
+}
+
+func (api *PublicAPI) CheckAllCommunityChannelsPermissionsLight(request *requests.CheckAllCommunityChannelsPermissions) (*communities.CheckAllChannelsPermissionsResponse, error) {
+	return api.service.messenger.CheckAllCommunityChannelsPermissionsLight(request)
 }
 
 func (api *PublicAPI) CollectCommunityMetrics(request *requests.CommunityMetricsRequest) (*protocol.CommunityMetricsResponse, error) {


### PR DESCRIPTION
For all permissions-check functions, corresponding light versions are added: CheckAllChannelsPermissionsLight, CheckChannelPermissionsLight, CheckPermissionToJoinLight (we can discuss naming convention).
Light functions are based on the fact that permissions are met if the user is on community/channel member list. If the user is not on the list, permissions will not be met and the client is responsible to use regular permissions-check functions. 

Issue [#14220](https://github.com/status-im/status-desktop/issues/14220)