### PR TITLE
chore(community)_: reevaluateMembers optimization

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -2186,6 +2186,14 @@ func (o *Community) AddMemberToChat(chatID string, publicKey *ecdsa.PublicKey,
 	return changes, nil
 }
 
+func (o *Community) PopulateChannelsWithAllMembers() {
+	members := o.Members()
+	for _, channel := range o.Chats() {
+		channel.Members = members
+	}
+	o.increaseClock()
+}
+
 func (o *Community) PopulateChatWithAllMembers(chatID string) (*CommunityChanges, error) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
@@ -2479,6 +2487,7 @@ func (o *Community) deleteTokenPermission(permissionID string) (*CommunityChange
 	changes := o.emptyCommunityChanges()
 
 	changes.TokenPermissionsRemoved[permissionID] = NewCommunityTokenPermission(permission)
+
 	return changes, nil
 }
 

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -991,6 +991,11 @@ func (m *Manager) EditCommunityTokenPermission(request *requests.EditCommunityTo
 	return community, changes, nil
 }
 
+// use it only for testing purposes
+func (m *Manager) ReevaluateMembers(communityID types.HexBytes) (*Community, map[protobuf.CommunityMember_Roles][]*ecdsa.PublicKey, error) {
+	return m.reevaluateMembers(communityID)
+}
+
 func (m *Manager) reevaluateMembers(communityID types.HexBytes) (*Community, map[protobuf.CommunityMember_Roles][]*ecdsa.PublicKey, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -210,6 +210,8 @@ func (s *ManagerSuite) TestRetrieveTokens() {
 		},
 	}
 
+	preParsedPermissions := preParsedCommunityPermissionsData(permissions)
+
 	accountChainIDsCombination := []*AccountChainIDsCombination{
 		&AccountChainIDsCombination{
 			Address:  gethcommon.HexToAddress("0xD6b912e09E797D291E8D0eA3D3D17F8000e01c32"),
@@ -218,14 +220,14 @@ func (s *ManagerSuite) TestRetrieveTokens() {
 	}
 	// Set response to exactly the right one
 	tm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(contractAddresses[chainID]), int64(1*math.Pow(10, float64(decimals))))
-	resp, err := m.PermissionChecker.CheckPermissions(permissions, accountChainIDsCombination, false)
+	resp, err := m.PermissionChecker.CheckPermissions(preParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 	s.Require().True(resp.Satisfied)
 
 	// Set response to 0
 	tm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(contractAddresses[chainID]), 0)
-	resp, err = m.PermissionChecker.CheckPermissions(permissions, accountChainIDsCombination, false)
+	resp, err = m.PermissionChecker.CheckPermissions(preParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 	s.Require().False(resp.Satisfied)
@@ -259,6 +261,8 @@ func (s *ManagerSuite) TestRetrieveCollectibles() {
 		},
 	}
 
+	preParsedPermissions := preParsedCommunityPermissionsData(permissions)
+
 	accountChainIDsCombination := []*AccountChainIDsCombination{
 		&AccountChainIDsCombination{
 			Address:  gethcommon.HexToAddress("0xD6b912e09E797D291E8D0eA3D3D17F8000e01c32"),
@@ -269,7 +273,7 @@ func (s *ManagerSuite) TestRetrieveCollectibles() {
 	// Set response to exactly the right one
 	tokenBalances = []thirdparty.TokenBalance{tokenBalance(tokenID, 1)}
 	cm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(contractAddresses[chainID]), tokenBalances)
-	resp, err := m.PermissionChecker.CheckPermissions(permissions, accountChainIDsCombination, false)
+	resp, err := m.PermissionChecker.CheckPermissions(preParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 	s.Require().True(resp.Satisfied)
@@ -277,7 +281,7 @@ func (s *ManagerSuite) TestRetrieveCollectibles() {
 	// Set balances to 0
 	tokenBalances = []thirdparty.TokenBalance{}
 	cm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(contractAddresses[chainID]), tokenBalances)
-	resp, err = m.PermissionChecker.CheckPermissions(permissions, accountChainIDsCombination, false)
+	resp, err = m.PermissionChecker.CheckPermissions(preParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 	s.Require().False(resp.Satisfied)
@@ -932,9 +936,11 @@ func (s *ManagerSuite) TestCheckChannelPermissions_NoPermissions() {
 
 	var viewOnlyPermissions = make([]*CommunityTokenPermission, 0)
 	var viewAndPostPermissions = make([]*CommunityTokenPermission, 0)
+	viewOnlyPreParsedPermissions := preParsedCommunityPermissionsData(viewOnlyPermissions)
+	viewAndPostPreParsedPermissions := preParsedCommunityPermissionsData(viewAndPostPermissions)
 
 	tm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(contractAddresses[chainID]), 0)
-	resp, err := m.checkChannelPermissions(viewOnlyPermissions, viewAndPostPermissions, accountChainIDsCombination, false)
+	resp, err := m.checkChannelPermissions(viewOnlyPreParsedPermissions, viewAndPostPreParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -984,8 +990,11 @@ func (s *ManagerSuite) TestCheckChannelPermissions_ViewOnlyPermissions() {
 
 	var viewAndPostPermissions = make([]*CommunityTokenPermission, 0)
 
+	viewOnlyPreParsedPermissions := preParsedCommunityPermissionsData(viewOnlyPermissions)
+	viewAndPostPreParsedPermissions := preParsedCommunityPermissionsData(viewAndPostPermissions)
+
 	tm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(contractAddresses[chainID]), 0)
-	resp, err := m.checkChannelPermissions(viewOnlyPermissions, viewAndPostPermissions, accountChainIDsCombination, false)
+	resp, err := m.checkChannelPermissions(viewOnlyPreParsedPermissions, viewAndPostPreParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -996,7 +1005,7 @@ func (s *ManagerSuite) TestCheckChannelPermissions_ViewOnlyPermissions() {
 
 	// Set response to exactly the right one
 	tm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(contractAddresses[chainID]), int64(1*math.Pow(10, float64(decimals))))
-	resp, err = m.checkChannelPermissions(viewOnlyPermissions, viewAndPostPermissions, accountChainIDsCombination, false)
+	resp, err = m.checkChannelPermissions(viewOnlyPreParsedPermissions, viewAndPostPreParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -1044,8 +1053,11 @@ func (s *ManagerSuite) TestCheckChannelPermissions_ViewAndPostPermissions() {
 
 	var viewOnlyPermissions = make([]*CommunityTokenPermission, 0)
 
+	viewOnlyPreParsedPermissions := preParsedCommunityPermissionsData(viewOnlyPermissions)
+	viewAndPostPreParsedPermissions := preParsedCommunityPermissionsData(viewAndPostPermissions)
+
 	tm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(contractAddresses[chainID]), 0)
-	resp, err := m.checkChannelPermissions(viewOnlyPermissions, viewAndPostPermissions, accountChainIDsCombination, false)
+	resp, err := m.checkChannelPermissions(viewOnlyPreParsedPermissions, viewAndPostPreParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -1056,7 +1068,7 @@ func (s *ManagerSuite) TestCheckChannelPermissions_ViewAndPostPermissions() {
 
 	// Set response to exactly the right one
 	tm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(contractAddresses[chainID]), int64(1*math.Pow(10, float64(decimals))))
-	resp, err = m.checkChannelPermissions(viewOnlyPermissions, viewAndPostPermissions, accountChainIDsCombination, false)
+	resp, err = m.checkChannelPermissions(viewOnlyPreParsedPermissions, viewAndPostPreParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -1134,7 +1146,10 @@ func (s *ManagerSuite) TestCheckChannelPermissions_ViewAndPostPermissionsCombina
 	// Set resopnse for viewAndPost permissions
 	tm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(testContractAddresses[chainID]), 0)
 
-	resp, err := m.checkChannelPermissions(viewOnlyPermissions, viewAndPostPermissions, accountChainIDsCombination, false)
+	viewOnlyPreParsedPermissions := preParsedCommunityPermissionsData(viewOnlyPermissions)
+	viewAndPostPreParsedPermissions := preParsedCommunityPermissionsData(viewAndPostPermissions)
+
+	resp, err := m.checkChannelPermissions(viewOnlyPreParsedPermissions, viewAndPostPreParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -1213,7 +1228,10 @@ func (s *ManagerSuite) TestCheckChannelPermissions_ViewAndPostPermissionsCombina
 	// Set resopnse for viewAndPost permissions
 	tm.setResponse(chainID, accountChainIDsCombination[0].Address, gethcommon.HexToAddress(testContractAddresses[chainID]), int64(1*math.Pow(10, float64(decimals))))
 
-	resp, err := m.checkChannelPermissions(viewOnlyPermissions, viewAndPostPermissions, accountChainIDsCombination, false)
+	viewOnlyPreParsedPermissions := preParsedCommunityPermissionsData(viewOnlyPermissions)
+	viewAndPostPreParsedPermissions := preParsedCommunityPermissionsData(viewAndPostPermissions)
+
+	resp, err := m.checkChannelPermissions(viewOnlyPreParsedPermissions, viewAndPostPreParsedPermissions, accountChainIDsCombination, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 

--- a/protocol/communities/permission_checker.go
+++ b/protocol/communities/permission_checker.go
@@ -34,7 +34,6 @@ type DefaultPermissionChecker struct {
 }
 
 type PreParsedPermissionsData struct {
-	Erc20TokenRequirements  map[uint64]map[string]*protobuf.TokenCriteria
 	Erc721TokenRequirements map[uint64]map[string]*protobuf.TokenCriteria
 	Erc20TokenAddresses     []gethcommon.Address
 	Erc20ChainIDsMap        map[uint64]bool
@@ -467,7 +466,6 @@ func preParsedPermissionsData(permissions []*CommunityTokenPermission) *PreParse
 	}
 
 	return &PreParsedPermissionsData{
-		Erc20TokenRequirements:  erc20TokenRequirements,
 		Erc721TokenRequirements: erc721TokenRequirements,
 		Erc20TokenAddresses:     erc20TokenAddresses,
 		Erc20ChainIDsMap:        erc20ChainIDsMap,

--- a/protocol/communities/permission_checker.go
+++ b/protocol/communities/permission_checker.go
@@ -22,7 +22,7 @@ import (
 
 type PermissionChecker interface {
 	CheckPermissionToJoin(*Community, []gethcommon.Address) (*CheckPermissionToJoinResponse, error)
-	CheckPermissions(permissions []*CommunityTokenPermission, accountsAndChainIDs []*AccountChainIDsCombination, shortcircuit bool) (*CheckPermissionsResponse, error)
+	CheckPermissions(permissionsParsedData *PreParsedCommunityPermissionsData, accountsAndChainIDs []*AccountChainIDsCombination, shortcircuit bool) (*CheckPermissionsResponse, error)
 }
 
 type DefaultPermissionChecker struct {
@@ -31,6 +31,19 @@ type DefaultPermissionChecker struct {
 	ensVerifier         *ens.Verifier
 
 	logger *zap.Logger
+}
+
+type PreParsedPermissionsData struct {
+	Erc20TokenRequirements  map[uint64]map[string]*protobuf.TokenCriteria
+	Erc721TokenRequirements map[uint64]map[string]*protobuf.TokenCriteria
+	Erc20TokenAddresses     []gethcommon.Address
+	Erc20ChainIDsMap        map[uint64]bool
+	Erc721ChainIDsMap       map[uint64]bool
+}
+
+type PreParsedCommunityPermissionsData struct {
+	*PreParsedPermissionsData
+	Permissions []*CommunityTokenPermission
 }
 
 func (p *DefaultPermissionChecker) getOwnedENS(addresses []gethcommon.Address) ([]string, error) {
@@ -159,8 +172,8 @@ func (p *DefaultPermissionChecker) CheckPermissionToJoin(community *Community, a
 		return becomeMemberPermissionsResponse, nil
 	}
 	// If there are any admin or token master permissions, combine result.
-
-	adminOrTokenPermissionsResponse, err := p.CheckPermissions(adminOrTokenMasterPermissionsToJoin, accountsAndChainIDs, false)
+	preParsedPermissions := preParsedCommunityPermissionsData(adminOrTokenMasterPermissionsToJoin)
+	adminOrTokenPermissionsResponse, err := p.CheckPermissions(preParsedPermissions, accountsAndChainIDs, false)
 	if err != nil {
 		return nil, err
 	}
@@ -191,13 +204,15 @@ func (p *DefaultPermissionChecker) checkPermissionsOrDefault(permissions []*Comm
 		}
 		return response, nil
 	}
-	return p.CheckPermissions(permissions, accountsAndChainIDs, false)
+
+	preParsedPermissions := preParsedCommunityPermissionsData(permissions)
+	return p.CheckPermissions(preParsedPermissions, accountsAndChainIDs, false)
 }
 
 // CheckPermissions will retrieve balances and check whether the user has
 // permission to join the community, if shortcircuit is true, it will stop as soon
 // as we know the answer
-func (p *DefaultPermissionChecker) CheckPermissions(permissions []*CommunityTokenPermission, accountsAndChainIDs []*AccountChainIDsCombination, shortcircuit bool) (*CheckPermissionsResponse, error) {
+func (p *DefaultPermissionChecker) CheckPermissions(permissionsParsedData *PreParsedCommunityPermissionsData, accountsAndChainIDs []*AccountChainIDsCombination, shortcircuit bool) (*CheckPermissionsResponse, error) {
 
 	response := &CheckPermissionsResponse{
 		Satisfied:         false,
@@ -205,28 +220,23 @@ func (p *DefaultPermissionChecker) CheckPermissions(permissions []*CommunityToke
 		ValidCombinations: make([]*AccountChainIDsCombination, 0),
 	}
 
-	erc20TokenRequirements, erc721TokenRequirements, _ := ExtractTokenCriteria(permissions)
+	if permissionsParsedData == nil {
+		response.Satisfied = true
+		return response, nil
+	}
 
-	erc20ChainIDsMap := make(map[uint64]bool)
-	erc721ChainIDsMap := make(map[uint64]bool)
+	erc721TokenRequirements := permissionsParsedData.Erc721TokenRequirements
 
-	erc20TokenAddresses := make([]gethcommon.Address, 0)
+	erc20ChainIDsMap := permissionsParsedData.Erc20ChainIDsMap
+	erc721ChainIDsMap := permissionsParsedData.Erc721ChainIDsMap
+
+	erc20TokenAddresses := permissionsParsedData.Erc20TokenAddresses
+
 	accounts := make([]gethcommon.Address, 0)
 
+	// TODO: move outside in order not to convert it
 	for _, accountAndChainIDs := range accountsAndChainIDs {
 		accounts = append(accounts, accountAndChainIDs.Address)
-	}
-
-	// figure out chain IDs we're interested in
-	for chainID, tokens := range erc20TokenRequirements {
-		erc20ChainIDsMap[chainID] = true
-		for contractAddress := range tokens {
-			erc20TokenAddresses = append(erc20TokenAddresses, gethcommon.HexToAddress(contractAddress))
-		}
-	}
-
-	for chainID := range erc721TokenRequirements {
-		erc721ChainIDsMap[chainID] = true
 	}
 
 	chainIDsForERC20 := calculateChainIDsSet(accountsAndChainIDs, erc20ChainIDsMap)
@@ -260,7 +270,7 @@ func (p *DefaultPermissionChecker) CheckPermissions(permissions []*CommunityToke
 
 	accountsChainIDsCombinations := make(map[gethcommon.Address]map[uint64]bool)
 
-	for _, tokenPermission := range permissions {
+	for _, tokenPermission := range permissionsParsedData.Permissions {
 
 		permissionRequirementsMet := true
 		response.Permissions[tokenPermission.Id] = &PermissionTokenCriteriaResult{Role: tokenPermission.Type}
@@ -434,4 +444,66 @@ func (p *DefaultPermissionChecker) CheckPermissions(permissions []*CommunityToke
 	response.calculateSatisfied()
 
 	return response, nil
+}
+
+func preParsedPermissionsData(permissions []*CommunityTokenPermission) *PreParsedPermissionsData {
+	erc20TokenRequirements, erc721TokenRequirements, _ := ExtractTokenCriteria(permissions)
+
+	erc20ChainIDsMap := make(map[uint64]bool)
+	erc721ChainIDsMap := make(map[uint64]bool)
+
+	erc20TokenAddresses := make([]gethcommon.Address, 0)
+
+	// figure out chain IDs we're interested in
+	for chainID, tokens := range erc20TokenRequirements {
+		erc20ChainIDsMap[chainID] = true
+		for contractAddress := range tokens {
+			erc20TokenAddresses = append(erc20TokenAddresses, gethcommon.HexToAddress(contractAddress))
+		}
+	}
+
+	for chainID := range erc721TokenRequirements {
+		erc721ChainIDsMap[chainID] = true
+	}
+
+	return &PreParsedPermissionsData{
+		Erc20TokenRequirements:  erc20TokenRequirements,
+		Erc721TokenRequirements: erc721TokenRequirements,
+		Erc20TokenAddresses:     erc20TokenAddresses,
+		Erc20ChainIDsMap:        erc20ChainIDsMap,
+		Erc721ChainIDsMap:       erc721ChainIDsMap,
+	}
+}
+
+func preParsedCommunityPermissionsData(permissions []*CommunityTokenPermission) *PreParsedCommunityPermissionsData {
+	if len(permissions) == 0 {
+		return nil
+	}
+
+	return &PreParsedCommunityPermissionsData{
+		Permissions:              permissions,
+		PreParsedPermissionsData: preParsedPermissionsData(permissions),
+	}
+}
+
+func PreParsePermissionsData(permissions map[string]*CommunityTokenPermission) (map[protobuf.CommunityTokenPermission_Type]*PreParsedCommunityPermissionsData, map[string]*PreParsedCommunityPermissionsData) {
+	becomeMemberPermissions := TokenPermissionsByType(permissions, protobuf.CommunityTokenPermission_BECOME_MEMBER)
+	becomeAdminPermissions := TokenPermissionsByType(permissions, protobuf.CommunityTokenPermission_BECOME_ADMIN)
+	becomeTokenMasterPermissions := TokenPermissionsByType(permissions, protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER)
+
+	viewOnlyPermissions := TokenPermissionsByType(permissions, protobuf.CommunityTokenPermission_CAN_VIEW_CHANNEL)
+	viewAndPostPermissions := TokenPermissionsByType(permissions, protobuf.CommunityTokenPermission_CAN_VIEW_AND_POST_CHANNEL)
+	channelPermissions := append(viewAndPostPermissions, viewOnlyPermissions...)
+
+	communityPermissionsPreParsedData := make(map[protobuf.CommunityTokenPermission_Type]*PreParsedCommunityPermissionsData)
+	communityPermissionsPreParsedData[protobuf.CommunityTokenPermission_BECOME_MEMBER] = preParsedCommunityPermissionsData(becomeMemberPermissions)
+	communityPermissionsPreParsedData[protobuf.CommunityTokenPermission_BECOME_ADMIN] = preParsedCommunityPermissionsData(becomeAdminPermissions)
+	communityPermissionsPreParsedData[protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER] = preParsedCommunityPermissionsData(becomeTokenMasterPermissions)
+
+	channelPermissionsPreParsedData := make(map[string]*PreParsedCommunityPermissionsData)
+	for _, channelPermission := range channelPermissions {
+		channelPermissionsPreParsedData[channelPermission.Id] = preParsedCommunityPermissionsData([]*CommunityTokenPermission{channelPermission})
+	}
+
+	return communityPermissionsPreParsedData, channelPermissionsPreParsedData
 }

--- a/protocol/communities/utils.go
+++ b/protocol/communities/utils.go
@@ -38,7 +38,7 @@ func ExtractTokenCriteria(permissions []*CommunityTokenPermission) (erc20TokenCr
 				if isERC20 && !existsERC20 {
 					erc20TokenCriteria[chainID] = make(map[string]*protobuf.TokenCriteria)
 				}
-
+				// TODO: check if we do not duplicate this due to ToLower case
 				_, existsERC721 = erc721TokenCriteria[chainID][contractAddress]
 				if isERC721 && !existsERC721 {
 					erc721TokenCriteria[chainID][strings.ToLower(contractAddress)] = tokenRequirement

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -3619,7 +3619,8 @@ func (t *testPermissionChecker) CheckPermissionToJoin(*communities.Community, []
 	return &communities.CheckPermissionsResponse{Satisfied: true}, nil
 
 }
-func (t *testPermissionChecker) CheckPermissions(permissions []*communities.CommunityTokenPermission, accountsAndChainIDs []*communities.AccountChainIDsCombination, shortcircuit bool) (*communities.CheckPermissionsResponse, error) {
+
+func (t *testPermissionChecker) CheckPermissions(permissionsParsedData *communities.PreParsedCommunityPermissionsData, accountsAndChainIDs []*communities.AccountChainIDsCombination, shortcircuit bool) (*communities.CheckPermissionsResponse, error) {
 	return &communities.CheckPermissionsResponse{Satisfied: true}, nil
 }
 

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
@@ -2010,4 +2012,124 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestResendEncryptionKeyOnBac
 	)
 	s.Require().NoError(err)
 	s.Require().Len(response.Messages(), 1)
+}
+
+func (s *MessengerCommunitiesTokenPermissionsSuite) TestReevaluateMemberPermissionsPerformance() {
+	// This test is created for a performance degradation tracking for reevaluateMember permissions
+	// current scenario mostly track channels permissions reevaluating, but feel free to expand it to
+	// other scenarios or test you performance improvements
+
+	// in average, it took nearly 100-105 ms to check one permission for a current scenario:
+	// - 10 members
+	// - 10 channels
+	// - one permission (channel permission for all 10 channels is set up)
+
+	// currently, adding any new permission to test must twice the current test average time
+
+	community, chat := s.createCommunity()
+
+	community, err := s.owner.communitiesManager.GetByID(community.ID())
+	s.Require().NoError(err)
+	s.Require().Len(community.Chats(), 2)
+
+	requestToJoin := &communities.RequestToJoin{
+		Clock:       uint64(time.Now().Unix()),
+		CommunityID: community.ID(),
+		State:       communities.RequestToJoinStateAccepted,
+		RevealedAccounts: []*protobuf.RevealedAccount{
+			{
+				Address:          bobAddress,
+				ChainIds:         []uint64{testChainID1},
+				IsAirdropAddress: true,
+				Signature:        []byte("test"),
+			},
+		},
+	}
+	communityRole := []protobuf.CommunityMember_Roles{}
+
+	keysCount := 10
+
+	for i := 0; i < keysCount; i++ {
+		privateKey, err := crypto.GenerateKey()
+		s.Require().NoError(err)
+
+		memberPubKeyStr := common.PubkeyToHex(&privateKey.PublicKey)
+		requestId := communities.CalculateRequestID(memberPubKeyStr, community.ID())
+		requestToJoin.ID = requestId
+		requestToJoin.PublicKey = memberPubKeyStr
+
+		err = s.owner.communitiesManager.SaveRequestToJoin(requestToJoin)
+		s.Require().NoError(err)
+		err = s.owner.communitiesManager.SaveRequestToJoinRevealedAddresses(requestId, requestToJoin.RevealedAccounts)
+		s.Require().NoError(err)
+		_, err = community.AddMember(&privateKey.PublicKey, communityRole)
+		s.Require().NoError(err)
+		_, err = community.AddMemberToChat(chat.CommunityChatID(), &privateKey.PublicKey, communityRole, protobuf.CommunityMember_CHANNEL_ROLE_POSTER)
+		s.Require().NoError(err)
+	}
+
+	s.Require().Equal(community.MembersCount(), keysCount+1) // 1 is owner
+
+	chatsCount := 8 // in total will be 10, 2 channels were created during creating the community
+
+	for i := 0; i < chatsCount; i++ {
+		newChat := &protobuf.CommunityChat{
+			Permissions: &protobuf.CommunityPermissions{
+				Access: protobuf.CommunityPermissions_AUTO_ACCEPT,
+			},
+			Identity: &protobuf.ChatIdentity{
+				DisplayName: "name-" + strconv.Itoa(i),
+				Description: "",
+			},
+		}
+
+		chatID := uuid.New().String()
+		_, err = community.CreateChat(chatID, newChat)
+		s.Require().NoError(err)
+	}
+
+	s.Require().Len(community.Chats(), chatsCount+2) // 2 chats were created during community creation
+
+	err = s.owner.communitiesManager.SaveCommunity(community)
+	s.Require().NoError(err)
+
+	// setup view channel permission
+	channelPermissionRequest := requests.CreateCommunityTokenPermission{
+		CommunityID: community.ID(),
+		Type:        protobuf.CommunityTokenPermission_CAN_VIEW_CHANNEL,
+		TokenCriteria: []*protobuf.TokenCriteria{
+			&protobuf.TokenCriteria{
+				Type:              protobuf.CommunityTokenType_ERC20,
+				ContractAddresses: map[uint64]string{testChainID1: "0x123"},
+				Symbol:            "TEST",
+				AmountInWei:       "100000000000000000000",
+				Decimals:          uint64(18),
+			},
+		},
+		ChatIds: community.ChatIDs(),
+	}
+
+	s.makeAddressSatisfyTheCriteria(testChainID1, bobAddress, channelPermissionRequest.TokenCriteria[0])
+	defer s.resetMockedBalances() // reset mocked balances, this test in run with different test cases
+
+	response, err := s.owner.CreateCommunityTokenPermission(&channelPermissionRequest)
+	s.Require().NoError(err)
+	s.Require().Len(response.Communities(), 1)
+	s.Require().Len(response.Communities()[0].TokenPermissions(), 1)
+
+	for _, ids := range response.Communities()[0].ChatIDs() {
+		s.Require().True(s.owner.communitiesManager.IsChannelEncrypted(community.IDString(), ids))
+	}
+
+	// force owner to reevaluate channel members
+	// in production it will happen automatically, by periodic check
+	start := time.Now()
+
+	err = s.owner.communitiesManager.ScheduleMembersReevaluation(community.ID())
+	s.Require().NoError(err)
+
+	elapsed := time.Since(start)
+
+	fmt.Println("ReevaluateMembers Time: ", elapsed)
+	s.Require().Less(elapsed.Seconds(), 2.0)
 }


### PR DESCRIPTION
ReevaluateMembers optimization:
1. Refactored channels permission reevaluation. First, we need to check if we passed the channel permission and then update channels based on the permission results
2. Request all revealed accounts from a DB instead of doing it in a cycle
3. Moved out from `checkPermissions` repeated pre-parsing data related to the permissions, which is used by all members during reevaluation

Before the changes:
10 members, 10 chats, 1 permission to 10 chats = ~ 10 s (new channel increases the time on 1 sec)

Now:
10 members, 10 chats, 1 permission to 10 chats = ~ 1 sec (new channel mostly does not have any impact on performance )

Closes # https://github.com/status-im/status-desktop/issues/14379
