### PR TITLE
fix_: persist left communities even for restored account

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -827,6 +827,10 @@ func (m *Manager) JoinedAndPendingCommunitiesWithRequests() ([]*Community, error
 	return m.persistence.JoinedAndPendingCommunitiesWithRequests(&m.identity.PublicKey)
 }
 
+func (m *Manager) LeftCommunities() ([]*Community, error) {
+	return m.persistence.LeftCommunities(&m.identity.PublicKey)
+}
+
 func (m *Manager) DeletedCommunities() ([]*Community, error) {
 	return m.persistence.DeletedCommunities(&m.identity.PublicKey)
 }

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -327,6 +327,17 @@ func (p *Persistence) rowsToCommunities(rows *sql.Rows) (comms []*Community, err
 	return comms, nil
 }
 
+func (p *Persistence) LeftCommunities(memberIdentity *ecdsa.PublicKey) (comms []*Community, err error) {
+	query := communitiesBaseQuery + ` WHERE NOT c.Joined AND NOT c.spectated AND r.state != ?`
+
+	rows, err := p.db.Query(query, common.PubkeyToHex(memberIdentity), RequestToJoinStatePending)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.rowsToCommunities(rows)
+}
+
 func (p *Persistence) JoinedAndPendingCommunitiesWithRequests(memberIdentity *ecdsa.PublicKey) (comms []*Community, err error) {
 	query := communitiesBaseQuery + ` WHERE c.Joined OR r.state = ?`
 


### PR DESCRIPTION
### Description

This PR fixes #7858  by making sure left persisted communities are restored during the backup restore flow

Closes #7858

### Screenshot

Since it's hard to make integration test that can simulate the delete of the data folder, I'll make a video to show that it works in principle.

[Screencast from 2024-05-16 13-51-32.webm](https://github.com/status-im/status-go/assets/2589171/271af41b-6dfa-4b7e-81a1-a60eedf2f634)
