### PR TITLE
fix(wallet)_: fix crash on cbridge fee calculation

### DIFF
--- a/services/wallet/bridge/cbridge.go
+++ b/services/wallet/bridge/cbridge.go
@@ -215,8 +215,14 @@ func (s *CBridge) CalculateFees(from, to *params.Network, token *token.Token, am
 	if err != nil {
 		return nil, nil, err
 	}
-	baseFee, _ := new(big.Int).SetString(amt.BaseFee, 10)
-	percFee, _ := new(big.Int).SetString(amt.PercFee, 10)
+	baseFee, ok := new(big.Int).SetString(amt.BaseFee, 10)
+	if !ok {
+		return nil, nil, errors.New("failed to parse base fee")
+	}
+	percFee, ok := new(big.Int).SetString(amt.PercFee, 10)
+	if !ok {
+		return nil, nil, errors.New("failed to parse percentage fee")
+	}
 
 	return big.NewInt(0), new(big.Int).Add(baseFee, percFee), nil
 }


### PR DESCRIPTION
Closes [#19610](https://github.com/status-im/status-mobile/issues/19610)

cbridge does not handle such small values, though we pass them correctly:
`"{\n  \"err\": {\n    \"code\": 500,\n    \"msg\": \"amount should \\u003e 0\"\n  },\n  \"eq_value_token_amt\": \"\",\n  \"bridge_rate\": 0,\n  \"perc_fee\": \"\",\n  \"base_fee\": \"\",\n  \"slippage_tolerance\": 0,\n  \"max_slippage\": 0,\n  \"estimated_receive_amt\": \"\",\n  \"drop_gas_amt\": \"\",\n  \"op_fee_rebate\": 0,\n  \"op_fee_rebate_portion\": 0,\n  \"op_fee_rebate_end_time\": \"0\"\n}" url="https://cbridge-prod2.celer.app/v2/estimateAmt?src_chain_id=1&dst_chain_id=10&token_symbol=WETH&amt=10000&usr_addr=0xaa47c83316edc05cf9ff7136296b026c5de7eccd&slippage_tolerance=500" amountIn=10000`
It returns err, that `amount should be > 0` and base_fee and perc_fee are empty, so we can't parse them into a bigInt anf get nil. 