### PR TITLE
fix(communities)_: Receiving mention notifications (@everyone) from spectated communities 

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -3694,17 +3694,20 @@ func (m *Manager) GetRequestToJoinIDByPkAndCommunityID(pk *ecdsa.PublicKey, comm
 }
 
 func (m *Manager) GetCommunityRequestToJoinClock(pk *ecdsa.PublicKey, communityID string) (uint64, error) {
-	request, err := m.persistence.GetRequestToJoinByPkAndCommunityID(common.PubkeyToHex(pk), []byte(communityID))
+	communityIDBytes, err := types.DecodeHex(communityID)
+	if err != nil {
+		return 0, err
+	}
+
+	joinClock, err := m.persistence.GetRequestToJoinClockByPkAndCommunityID(common.PubkeyToHex(pk), communityIDBytes)
+
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
 	} else if err != nil {
 		return 0, err
 	}
 
-	if request == nil || request.State != RequestToJoinStateAccepted {
-		return 0, nil
-	}
-	return request.Clock, nil
+	return joinClock, nil
 }
 
 func (m *Manager) GetRequestToJoinByPkAndCommunityID(pk *ecdsa.PublicKey, communityID []byte) (*RequestToJoin, error) {

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -862,6 +862,16 @@ func (p *Persistence) GetNumberOfPendingRequestsToJoin(communityID types.HexByte
 	return count, nil
 }
 
+func (p *Persistence) GetRequestToJoinClockByPkAndCommunityID(pk string, communityID types.HexBytes) (uint64, error) {
+	var clock uint64
+
+	err := p.db.QueryRow(`
+		SELECT clock 
+		FROM communities_requests_to_join 
+		WHERE public_key = ? AND community_id = ?`, pk, communityID).Scan(&clock)
+	return clock, err
+}
+
 func (p *Persistence) GetRequestToJoinByPkAndCommunityID(pk string, communityID []byte) (*RequestToJoin, error) {
 	request := &RequestToJoin{}
 	err := p.db.QueryRow(`SELECT id,public_key,clock,ens_name,customization_color,chat_id,community_id,state FROM communities_requests_to_join WHERE public_key = ? AND community_id = ?`, pk, communityID).Scan(&request.ID, &request.PublicKey, &request.Clock, &request.ENSName, &request.CustomizationColor, &request.ChatID, &request.CommunityID, &request.State)

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3560,13 +3560,13 @@ func (r *ReceivedMessageState) addNewActivityCenterNotification(publicKey ecdsa.
 	}
 
 	if chat.CommunityChat() {
-		joinedClock, err := m.communitiesManager.GetCommunityRequestToJoinClock(&publicKey, message.CommunityID)
+		// Ignore mentions & replies in community before joining
+		joinedClock, err := m.communitiesManager.GetCommunityRequestToJoinClock(&publicKey, chat.CommunityID)
 		if err != nil {
 			return err
 		}
 
-		// Ignore mentions & replies in community before joining
-		if message.Clock < joinedClock {
+		if joinedClock == 0 || message.Clock < joinedClock {
 			return nil
 		}
 	}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3542,6 +3542,28 @@ func (r *ReceivedMessageState) updateExistingActivityCenterNotification(publicKe
 	return nil
 }
 
+// function returns if the community is joined before the clock
+func (m *Messenger) isCommunityJoinedBeforeClock(publicKey ecdsa.PublicKey, communityID string, clock uint64) (bool, error) {
+	community, err := m.communitiesManager.GetByIDString(communityID)
+	if err != nil {
+		return false, err
+	}
+
+	if !community.Joined() || clock < uint64(community.JoinedAt()) {
+		joinedClock, err := m.communitiesManager.GetCommunityRequestToJoinClock(&publicKey, communityID)
+		if err != nil {
+			return false, err
+		}
+
+		// no request to join, or request to join is after the message
+		if joinedClock == 0 || clock < joinedClock {
+			return false, nil
+		}
+		return true, nil
+	}
+	return true, nil
+}
+
 // addNewActivityCenterNotification takes a common.Message and generates a new ActivityCenterNotification and appends it to the
 // []Response.ActivityCenterNotifications if the message is m.New
 func (r *ReceivedMessageState) addNewActivityCenterNotification(publicKey ecdsa.PublicKey, m *Messenger, message *common.Message, responseTo *common.Message) error {
@@ -3561,12 +3583,8 @@ func (r *ReceivedMessageState) addNewActivityCenterNotification(publicKey ecdsa.
 
 	if chat.CommunityChat() {
 		// Ignore mentions & replies in community before joining
-		joinedClock, err := m.communitiesManager.GetCommunityRequestToJoinClock(&publicKey, chat.CommunityID)
-		if err != nil {
-			return err
-		}
-
-		if joinedClock == 0 || message.Clock < joinedClock {
+		ok, err := m.isCommunityJoinedBeforeClock(publicKey, chat.CommunityID, message.Clock)
+		if err != nil || !ok {
 			return nil
 		}
 	}


### PR DESCRIPTION
## Changes 
1. Moved existing logic about whether we need to show community chat notifications to the `showMentionOrReplyActivityCenterNotification` method.
2. Added an explicit check if the community is not joined. And not show notification in that case

## Demo:


https://github.com/status-im/status-go/assets/1083341/6245a742-be86-4f36-81cd-004aeabfdc77


Closes [#14798](https://github.com/status-im/status-desktop/issues/14798)
