### PR TITLE
fix(communities)_: naive fix for spectated communities new channels member list

### DIFF
--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -495,12 +495,24 @@ func CreateCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, 
 	}
 
 	timestamp := timesource.GetCurrentTime()
+
+	// Populate community _channel_ members to _chat_ members
+	chatMembers := []ChatMember{}
+	for pubKey := range orgChat.Members {
+		chatMember := ChatMember{
+			ID:    pubKey,
+			Admin: false,
+		}
+		chatMembers = append(chatMembers, chatMember)
+	}
+
 	return &Chat{
 		CommunityID:              orgID,
 		CategoryID:               orgChat.CategoryId,
 		HideIfPermissionsNotMet:  orgChat.HideIfPermissionsNotMet,
 		Name:                     orgChat.Identity.DisplayName,
 		Description:              orgChat.Identity.Description,
+		Members:                  chatMembers,
 		Active:                   true,
 		Color:                    color,
 		Emoji:                    orgChat.Identity.Emoji,
@@ -570,6 +582,7 @@ func CreatePublicChat(name string, timesource common.TimeSource) *Chat {
 		ReadMessagesAtClockValue: 0,
 		Color:                    chatColors[rand.Intn(len(chatColors))], // nolint: gosec
 		ChatType:                 ChatTypePublic,
+		Members:                  []ChatMember{},
 	}
 }
 

--- a/protocol/persistence.go
+++ b/protocol/persistence.go
@@ -517,6 +517,7 @@ func (db sqlitePersistence) Chat(chatID string) (*Chat, error) {
 		chat.UnviewedMentionsCount = uint(unviewedMentionsCount)
 
 		// Restore members
+		chat.Members = []ChatMember{}
 		membersDecoder := gob.NewDecoder(bytes.NewBuffer(encodedMembers))
 		err = membersDecoder.Decode(&chat.Members)
 		if err != nil {


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/14442
- [x] Populate chat with channel members
- [x] Add a test to make sure the user gets the correct list of users for channels added to the observed community.
