### PR TITLE
Feat/rpc limiter common

### DIFF
--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -237,7 +237,7 @@ func (c *ClientWithFallback) IsConnected() bool {
 
 func (c *ClientWithFallback) makeCall(ctx context.Context, main func() ([]any, error), fallback func() ([]any, error)) ([]any, error) {
 	if c.commonLimiter != nil {
-		if limited, err := c.commonLimiter.IsLimitReached(c.tag); limited {
+		if allow, err := c.commonLimiter.Allow(c.tag); !allow {
 			return nil, fmt.Errorf("tag=%s, %w", c.tag, err)
 		}
 	}

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -238,7 +238,7 @@ func (c *ClientWithFallback) IsConnected() bool {
 func (c *ClientWithFallback) makeCall(ctx context.Context, main func() ([]any, error), fallback func() ([]any, error)) ([]any, error) {
 	if c.commonLimiter != nil {
 		if limited, err := c.commonLimiter.IsLimitReached(c.tag); limited {
-			return nil, fmt.Errorf("rate limit exceeded for %s: %s", c.tag, err)
+			return nil, fmt.Errorf("tag=%s, %w", c.tag, err)
 		}
 	}
 

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -80,7 +80,7 @@ func ClientWithTag(chainClient ClientInterface, tag, groupTag string) ClientInte
 	if tagIface, ok := chainClient.(Tagger); ok {
 		tagIface = DeepCopyTagger(tagIface)
 		tagIface.SetTag(tag)
-		tagIface.SetGroupTag(tag)
+		tagIface.SetGroupTag(groupTag)
 		newClient = tagIface.(ClientInterface)
 	}
 

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -1005,7 +1006,7 @@ func (c *ClientWithFallback) SetWalletNotifier(notifier func(chainId uint64, mes
 func (c *ClientWithFallback) toggleConnectionState(err error) {
 	connected := true
 	if err != nil {
-		if !isVMError(err) && err != ErrRequestsOverLimit {
+		if !isVMError(err) && !errors.Is(ErrRequestsOverLimit, err) {
 			connected = false
 		}
 	}

--- a/rpc/chain/rpc_limiter.go
+++ b/rpc/chain/rpc_limiter.go
@@ -80,7 +80,7 @@ func (s *LimitsDBStorage) Set(data *LimitData) error {
 	}
 
 	limit, err := s.db.GetRPCLimit(data.Tag)
-	if err != nil {
+	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
 
@@ -166,13 +166,8 @@ func (rl *RPCRequestLimiter) Allow(tag string) (bool, error) {
 		return true, nil
 	}
 
-	// Check if period is forever
-	if data.Period.Milliseconds() == LimitInfinitely {
-		return false, nil
-	}
-
 	// Check if a number of requests is over the limit within the interval
-	if time.Since(data.CreatedAt) < data.Period {
+	if time.Since(data.CreatedAt) < data.Period || data.Period.Milliseconds() == LimitInfinitely {
 		if data.NumReqs >= data.MaxReqs {
 			return false, nil
 		}

--- a/rpc/chain/rpc_limiter.go
+++ b/rpc/chain/rpc_limiter.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/google/uuid"
 )
 
@@ -25,7 +26,68 @@ type callerOnWait struct {
 	ch       chan bool
 }
 
-type RPCLimiter struct {
+type RequestsStorage interface {
+	Get(tag string) (RequestData, error)
+	Set(data RequestData) error
+}
+
+type RequestData struct {
+	Tag       string
+	CreatedAt time.Time
+	Period    time.Duration
+}
+
+type RequestLimiter interface {
+	SetMaxRequests(tag string, maxRequests int, interval time.Duration)
+	IsLimitReached(tag string) bool
+}
+
+type RPCRequestLimiter struct {
+	storage RequestsStorage
+}
+
+func NewRequestLimiter(storage RequestsStorage) *RPCRequestLimiter {
+	return &RPCRequestLimiter{
+		storage: storage,
+	}
+}
+
+func (rl *RPCRequestLimiter) SetMaxRequests(tag string, maxRequests int, interval time.Duration) {
+	err := rl.saveToStorage(tag, maxRequests, interval)
+	if err != nil {
+		log.Error("Failed to save request data to storage", "error", err)
+		return
+	}
+
+	// Set max requests logic here
+}
+
+func (rl *RPCRequestLimiter) saveToStorage(tag string, maxRequests int, interval time.Duration) error {
+	data := RequestData{
+		Tag:       tag,
+		CreatedAt: time.Now(),
+		Period:    interval,
+	}
+
+	err := rl.storage.Set(data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (rl *RPCRequestLimiter) IsLimitReached(tag string) bool {
+	data, err := rl.storage.Get(tag)
+	if err != nil {
+		log.Error("Failed to get request data from storage", "error", err, "tag", tag)
+		return false
+	}
+
+	return time.Since(data.CreatedAt) >= data.Period
+}
+
+type RPCRpsLimiter struct {
 	uuid uuid.UUID
 
 	maxRequestsPerSecond      int
@@ -40,9 +102,9 @@ type RPCLimiter struct {
 	quit chan bool
 }
 
-func NewRPCLimiter() *RPCLimiter {
+func NewRPCRpsLimiter() *RPCRpsLimiter {
 
-	limiter := RPCLimiter{
+	limiter := RPCRpsLimiter{
 		uuid:                 uuid.New(),
 		maxRequestsPerSecond: defaultMaxRequestsPerSecond,
 		quit:                 make(chan bool),
@@ -53,7 +115,7 @@ func NewRPCLimiter() *RPCLimiter {
 	return &limiter
 }
 
-func (rl *RPCLimiter) ReduceLimit() {
+func (rl *RPCRpsLimiter) ReduceLimit() {
 	rl.maxRequestsPerSecondMutex.Lock()
 	defer rl.maxRequestsPerSecondMutex.Unlock()
 	if rl.maxRequestsPerSecond <= minRequestsPerSecond {
@@ -62,7 +124,7 @@ func (rl *RPCLimiter) ReduceLimit() {
 	rl.maxRequestsPerSecond = rl.maxRequestsPerSecond - requestsPerSecondStep
 }
 
-func (rl *RPCLimiter) start() {
+func (rl *RPCRpsLimiter) start() {
 	ticker := time.NewTicker(tickerInterval)
 	go func() {
 		for {
@@ -115,7 +177,7 @@ func (rl *RPCLimiter) start() {
 	}()
 }
 
-func (rl *RPCLimiter) Stop() {
+func (rl *RPCRpsLimiter) Stop() {
 	rl.quit <- true
 	close(rl.quit)
 	for _, callerOnWait := range rl.callersOnWaitForRequests {
@@ -124,7 +186,7 @@ func (rl *RPCLimiter) Stop() {
 	rl.callersOnWaitForRequests = nil
 }
 
-func (rl *RPCLimiter) WaitForRequestsAvailability(requests int) error {
+func (rl *RPCRpsLimiter) WaitForRequestsAvailability(requests int) error {
 	if requests > rl.maxRequestsPerSecond {
 		return ErrRequestsOverLimit
 	}

--- a/rpc/chain/rpc_limiter.go
+++ b/rpc/chain/rpc_limiter.go
@@ -16,7 +16,8 @@ const (
 	minRequestsPerSecond        = 20
 	requestsPerSecondStep       = 10
 
-	tickerInterval = 1 * time.Second
+	tickerInterval  = 1 * time.Second
+	LimitInfinitely = 0
 )
 
 var (
@@ -163,6 +164,11 @@ func (rl *RPCRequestLimiter) Allow(tag string) (bool, error) {
 
 	if data == nil {
 		return true, nil
+	}
+
+	// Check if period is forever
+	if data.Period.Milliseconds() == LimitInfinitely {
+		return false, nil
 	}
 
 	// Check if a number of requests is over the limit within the interval

--- a/rpc/chain/rpc_limiter.go
+++ b/rpc/chain/rpc_limiter.go
@@ -70,6 +70,7 @@ type RequestLimiter interface {
 
 type RPCRequestLimiter struct {
 	storage RequestsStorage
+	mu      sync.Mutex
 }
 
 func NewRequestLimiter(storage RequestsStorage) *RPCRequestLimiter {
@@ -116,8 +117,10 @@ func (rl *RPCRequestLimiter) saveToStorage(tag string, maxRequests int, interval
 }
 
 func (rl *RPCRequestLimiter) Allow(tag string) (bool, error) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
 	data, err := rl.storage.Get(tag)
-	log.Info("Allow", "data", data)
 	if err != nil {
 		return true, err
 	}

--- a/rpc/chain/rpc_limiter_db.go
+++ b/rpc/chain/rpc_limiter_db.go
@@ -1,0 +1,53 @@
+package chain
+
+import (
+	"database/sql"
+)
+
+type RPCLimiterDB struct {
+	db *sql.DB
+}
+
+func NewRPCLimiterDB(db *sql.DB) *RPCLimiterDB {
+	return &RPCLimiterDB{
+		db: db,
+	}
+}
+
+func (r *RPCLimiterDB) CreateRPCLimit(limit LimitData) error {
+	query := `INSERT INTO rpc_limits (tag, created_at, period, max_requests, counter) VALUES (?, ?, ?, ?, ?)`
+	_, err := r.db.Exec(query, limit.Tag, limit.CreatedAt, limit.Period, limit.MaxReqs, limit.NumReqs)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *RPCLimiterDB) GetRPCLimit(tag string) (*LimitData, error) {
+	query := `SELECT tag, created_at, period, max_requests, counter FROM rpc_limits WHERE tag = ?`
+	row := r.db.QueryRow(query, tag)
+	limit := &LimitData{}
+	err := row.Scan(limit.Tag, limit.CreatedAt, limit.Period, limit.MaxReqs, limit.NumReqs)
+	if err != nil || err == sql.ErrNoRows {
+		return nil, err
+	}
+	return limit, nil
+}
+
+func (r *RPCLimiterDB) UpdateRPCLimit(limit LimitData) error {
+	query := `UPDATE rpc_limits SET created_at = ?, period = ?, limit = ?, counter = ? WHERE tag = ?`
+	_, err := r.db.Exec(query, limit.CreatedAt, limit.Period, limit.MaxReqs, limit.NumReqs, limit.Tag)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *RPCLimiterDB) DeleteRPCLimit(tag string) error {
+	query := `DELETE FROM rpc_limits WHERE tag = ?`
+	_, err := r.db.Exec(query, tag)
+	if err != nil || err == sql.ErrNoRows {
+		return err
+	}
+	return nil
+}

--- a/rpc/chain/rpc_limiter_db.go
+++ b/rpc/chain/rpc_limiter_db.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"database/sql"
+	"time"
 )
 
 type RPCLimiterDB struct {
@@ -16,7 +17,7 @@ func NewRPCLimiterDB(db *sql.DB) *RPCLimiterDB {
 
 func (r *RPCLimiterDB) CreateRPCLimit(limit LimitData) error {
 	query := `INSERT INTO rpc_limits (tag, created_at, period, max_requests, counter) VALUES (?, ?, ?, ?, ?)`
-	_, err := r.db.Exec(query, limit.Tag, limit.CreatedAt, limit.Period, limit.MaxReqs, limit.NumReqs)
+	_, err := r.db.Exec(query, limit.Tag, limit.CreatedAt.Unix(), limit.Period, limit.MaxReqs, limit.NumReqs)
 	if err != nil {
 		return err
 	}
@@ -27,16 +28,19 @@ func (r *RPCLimiterDB) GetRPCLimit(tag string) (*LimitData, error) {
 	query := `SELECT tag, created_at, period, max_requests, counter FROM rpc_limits WHERE tag = ?`
 	row := r.db.QueryRow(query, tag)
 	limit := &LimitData{}
-	err := row.Scan(limit.Tag, limit.CreatedAt, limit.Period, limit.MaxReqs, limit.NumReqs)
-	if err != nil || err == sql.ErrNoRows {
+	createdAtSecs := int64(0)
+	err := row.Scan(&limit.Tag, &createdAtSecs, &limit.Period, &limit.MaxReqs, &limit.NumReqs)
+	if err != nil {
 		return nil, err
 	}
+
+	limit.CreatedAt = time.Unix(createdAtSecs, 0)
 	return limit, nil
 }
 
 func (r *RPCLimiterDB) UpdateRPCLimit(limit LimitData) error {
-	query := `UPDATE rpc_limits SET created_at = ?, period = ?, limit = ?, counter = ? WHERE tag = ?`
-	_, err := r.db.Exec(query, limit.CreatedAt, limit.Period, limit.MaxReqs, limit.NumReqs, limit.Tag)
+	query := `UPDATE rpc_limits SET created_at = ?, period = ?, max_requests = ?, counter = ? WHERE tag = ?`
+	_, err := r.db.Exec(query, limit.CreatedAt.Unix(), limit.Period, limit.MaxReqs, limit.NumReqs, limit.Tag)
 	if err != nil {
 		return err
 	}
@@ -46,7 +50,7 @@ func (r *RPCLimiterDB) UpdateRPCLimit(limit LimitData) error {
 func (r *RPCLimiterDB) DeleteRPCLimit(tag string) error {
 	query := `DELETE FROM rpc_limits WHERE tag = ?`
 	_, err := r.db.Exec(query, tag)
-	if err != nil || err == sql.ErrNoRows {
+	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
 	return nil

--- a/rpc/chain/rpc_limiter_test.go
+++ b/rpc/chain/rpc_limiter_test.go
@@ -38,7 +38,7 @@ func TestGetLimit(t *testing.T) {
 	storage, rl := setupTest()
 
 	// Define test inputs
-	data := &RequestData{
+	data := &LimitData{
 		Tag:     "testTag",
 		Period:  time.Second,
 		MaxReqs: 10,
@@ -63,7 +63,7 @@ func TestAllowWithinPeriod(t *testing.T) {
 	interval := time.Second
 
 	// Set up the storage with test data
-	data := &RequestData{
+	data := &LimitData{
 		Tag:       tag,
 		Period:    interval,
 		CreatedAt: time.Now(),
@@ -95,7 +95,7 @@ func TestAllowWhenPeriodPassed(t *testing.T) {
 	interval := time.Second
 
 	// Set up the storage with test data
-	data := &RequestData{
+	data := &LimitData{
 		Tag:       tag,
 		Period:    interval,
 		CreatedAt: time.Now().Add(-interval),

--- a/rpc/chain/rpc_limiter_test.go
+++ b/rpc/chain/rpc_limiter_test.go
@@ -140,3 +140,29 @@ func TestAllowRestrictInfinitelyWhenLimitReached(t *testing.T) {
 	// Verify the result
 	require.False(t, allow)
 }
+
+func TestAllowWhenLimitNotReachedForInfinitePeriod(t *testing.T) {
+	storage, rl := setupTest()
+
+	// Define test inputs
+	tag := "testTag"
+	maxRequests := 10
+
+	// Set up the storage with test data
+	data := &LimitData{
+		Tag:       tag,
+		Period:    LimitInfinitely,
+		CreatedAt: time.Now(),
+		MaxReqs:   maxRequests,
+		NumReqs:   maxRequests - 1,
+	}
+	err := storage.Set(data)
+	require.NoError(t, err)
+
+	// Call the Allow method
+	allow, err := rl.Allow(tag)
+	require.NoError(t, err)
+
+	// Verify the result
+	require.True(t, allow)
+}

--- a/rpc/chain/rpc_limiter_test.go
+++ b/rpc/chain/rpc_limiter_test.go
@@ -114,3 +114,29 @@ func TestAllowWhenPeriodPassed(t *testing.T) {
 	// Verify the result
 	require.True(t, allow)
 }
+
+func TestAllowRestrictInfinitelyWhenLimitReached(t *testing.T) {
+	storage, rl := setupTest()
+
+	// Define test inputs
+	tag := "testTag"
+	maxRequests := 10
+
+	// Set up the storage with test data
+	data := &LimitData{
+		Tag:       tag,
+		Period:    LimitInfinitely,
+		CreatedAt: time.Now(),
+		MaxReqs:   maxRequests,
+		NumReqs:   maxRequests,
+	}
+	err := storage.Set(data)
+	require.NoError(t, err)
+
+	// Call the Allow method
+	allow, err := rl.Allow(tag)
+	require.NoError(t, err)
+
+	// Verify the result
+	require.False(t, allow)
+}

--- a/rpc/chain/rpc_limiter_test.go
+++ b/rpc/chain/rpc_limiter_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupTest() (*InMemRequestsStorage, RequestLimiter) {
-	storage := NewInMemRequestsStorage()
+func setupTest() (*InMemRequestsMapStorage, RequestLimiter) {
+	storage := NewInMemRequestsMapStorage()
 	rl := NewRequestLimiter(storage)
 	return storage, rl
 }
@@ -37,7 +37,7 @@ func TestSetMaxRequests(t *testing.T) {
 func TestGetMaxRequests(t *testing.T) {
 	storage, rl := setupTest()
 
-	data := RequestData{
+	data := &RequestData{
 		Tag:     "testTag",
 		Period:  time.Second,
 		MaxReqs: 10,
@@ -63,7 +63,7 @@ func TestIsLimitReachedWithinPeriod(t *testing.T) {
 	interval := time.Second
 
 	// Set up the storage with test data
-	data := RequestData{
+	data := &RequestData{
 		Tag:       tag,
 		Period:    interval,
 		CreatedAt: time.Now(),
@@ -95,7 +95,7 @@ func TestIsLimitReachedWhenPeriodPassed(t *testing.T) {
 	interval := time.Second
 
 	// Set up the storage with test data
-	data := RequestData{
+	data := &RequestData{
 		Tag:       tag,
 		Period:    interval,
 		CreatedAt: time.Now().Add(-interval),

--- a/rpc/chain/rpc_limiter_test.go
+++ b/rpc/chain/rpc_limiter_test.go
@@ -13,7 +13,7 @@ func setupTest() (*InMemRequestsMapStorage, RequestLimiter) {
 	return storage, rl
 }
 
-func TestSetMaxRequests(t *testing.T) {
+func TestSetLimit(t *testing.T) {
 	storage, rl := setupTest()
 
 	// Define test inputs
@@ -21,8 +21,8 @@ func TestSetMaxRequests(t *testing.T) {
 	maxRequests := 10
 	interval := time.Second
 
-	// Call the SetMaxRequests method
-	err := rl.SetMaxRequests(tag, maxRequests, interval)
+	// Call the SetLimit method
+	err := rl.SetLimit(tag, maxRequests, interval)
 	require.NoError(t, err)
 
 	// Verify that the data was saved to storage correctly
@@ -34,27 +34,27 @@ func TestSetMaxRequests(t *testing.T) {
 	require.Equal(t, 0, data.NumReqs)
 }
 
-func TestGetMaxRequests(t *testing.T) {
+func TestGetLimit(t *testing.T) {
 	storage, rl := setupTest()
 
+	// Define test inputs
 	data := &RequestData{
 		Tag:     "testTag",
 		Period:  time.Second,
 		MaxReqs: 10,
 		NumReqs: 1,
 	}
-	// Define test inputs
 	storage.Set(data)
 
-	// Call the GetMaxRequests method
-	ret, err := rl.GetMaxRequests(data.Tag)
+	// Call the GetLimit method
+	ret, err := rl.GetLimit(data.Tag)
 	require.NoError(t, err)
 
 	// Verify the returned data
 	require.Equal(t, data, ret)
 }
 
-func TestIsLimitReachedWithinPeriod(t *testing.T) {
+func TestAllowWithinPeriod(t *testing.T) {
 	storage, rl := setupTest()
 
 	// Define test inputs
@@ -71,22 +71,22 @@ func TestIsLimitReachedWithinPeriod(t *testing.T) {
 	}
 	storage.Set(data)
 
-	// Call the IsLimitReached method
+	// Call the Allow method
 	for i := 0; i < maxRequests; i++ {
-		limitReached, err := rl.IsLimitReached(tag)
+		allow, err := rl.Allow(tag)
 		require.NoError(t, err)
 
 		// Verify the result
-		require.False(t, limitReached)
+		require.True(t, allow)
 	}
 
-	// Call the IsLimitReached method again
-	limitReached, err := rl.IsLimitReached(tag)
+	// Call the Allow method again
+	allow, err := rl.Allow(tag)
 	require.NoError(t, err)
-	require.True(t, limitReached)
+	require.False(t, allow)
 }
 
-func TestIsLimitReachedWhenPeriodPassed(t *testing.T) {
+func TestAllowWhenPeriodPassed(t *testing.T) {
 	storage, rl := setupTest()
 
 	// Define test inputs
@@ -104,10 +104,10 @@ func TestIsLimitReachedWhenPeriodPassed(t *testing.T) {
 	}
 	storage.Set(data)
 
-	// Call the IsLimitReached method
-	limitReached, err := rl.IsLimitReached(tag)
+	// Call the Allow method
+	allow, err := rl.Allow(tag)
 	require.NoError(t, err)
 
 	// Verify the result
-	require.False(t, limitReached)
+	require.True(t, allow)
 }

--- a/rpc/chain/rpc_limiter_test.go
+++ b/rpc/chain/rpc_limiter_test.go
@@ -1,0 +1,113 @@
+package chain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setupTest() (*InMemRequestsStorage, RequestLimiter) {
+	storage := NewInMemRequestsStorage()
+	rl := NewRequestLimiter(storage)
+	return storage, rl
+}
+
+func TestSetMaxRequests(t *testing.T) {
+	storage, rl := setupTest()
+
+	// Define test inputs
+	tag := "testTag"
+	maxRequests := 10
+	interval := time.Second
+
+	// Call the SetMaxRequests method
+	err := rl.SetMaxRequests(tag, maxRequests, interval)
+	require.NoError(t, err)
+
+	// Verify that the data was saved to storage correctly
+	data, err := storage.Get(tag)
+	require.NoError(t, err)
+	require.Equal(t, tag, data.Tag)
+	require.Equal(t, interval, data.Period)
+	require.Equal(t, maxRequests, data.MaxReqs)
+	require.Equal(t, 0, data.NumReqs)
+}
+
+func TestGetMaxRequests(t *testing.T) {
+	storage, rl := setupTest()
+
+	data := RequestData{
+		Tag:     "testTag",
+		Period:  time.Second,
+		MaxReqs: 10,
+		NumReqs: 1,
+	}
+	// Define test inputs
+	storage.Set(data)
+
+	// Call the GetMaxRequests method
+	ret, err := rl.GetMaxRequests(data.Tag)
+	require.NoError(t, err)
+
+	// Verify the returned data
+	require.Equal(t, data, ret)
+}
+
+func TestIsLimitReachedWithinPeriod(t *testing.T) {
+	storage, rl := setupTest()
+
+	// Define test inputs
+	tag := "testTag"
+	maxRequests := 10
+	interval := time.Second
+
+	// Set up the storage with test data
+	data := RequestData{
+		Tag:       tag,
+		Period:    interval,
+		CreatedAt: time.Now(),
+		MaxReqs:   maxRequests,
+	}
+	storage.Set(data)
+
+	// Call the IsLimitReached method
+	for i := 0; i < maxRequests; i++ {
+		limitReached, err := rl.IsLimitReached(tag)
+		require.NoError(t, err)
+
+		// Verify the result
+		require.False(t, limitReached)
+	}
+
+	// Call the IsLimitReached method again
+	limitReached, err := rl.IsLimitReached(tag)
+	require.NoError(t, err)
+	require.True(t, limitReached)
+}
+
+func TestIsLimitReachedWhenPeriodPassed(t *testing.T) {
+	storage, rl := setupTest()
+
+	// Define test inputs
+	tag := "testTag"
+	maxRequests := 10
+	interval := time.Second
+
+	// Set up the storage with test data
+	data := RequestData{
+		Tag:       tag,
+		Period:    interval,
+		CreatedAt: time.Now().Add(-interval),
+		MaxReqs:   maxRequests,
+		NumReqs:   maxRequests,
+	}
+	storage.Set(data)
+
+	// Call the IsLimitReached method
+	limitReached, err := rl.IsLimitReached(tag)
+	require.NoError(t, err)
+
+	// Verify the result
+	require.False(t, limitReached)
+}

--- a/rpc/chain/rpc_limiter_test.go
+++ b/rpc/chain/rpc_limiter_test.go
@@ -44,7 +44,8 @@ func TestGetLimit(t *testing.T) {
 		MaxReqs: 10,
 		NumReqs: 1,
 	}
-	storage.Set(data)
+	err := storage.Set(data)
+	require.NoError(t, err)
 
 	// Call the GetLimit method
 	ret, err := rl.GetLimit(data.Tag)
@@ -69,7 +70,8 @@ func TestAllowWithinPeriod(t *testing.T) {
 		CreatedAt: time.Now(),
 		MaxReqs:   maxRequests,
 	}
-	storage.Set(data)
+	err := storage.Set(data)
+	require.NoError(t, err)
 
 	// Call the Allow method
 	for i := 0; i < maxRequests; i++ {
@@ -102,7 +104,8 @@ func TestAllowWhenPeriodPassed(t *testing.T) {
 		MaxReqs:   maxRequests,
 		NumReqs:   maxRequests,
 	}
-	storage.Set(data)
+	err := storage.Set(data)
+	require.NoError(t, err)
 
 	// Call the Allow method
 	allow, err := rl.Allow(tag)

--- a/services/rpcstats/api.go
+++ b/services/rpcstats/api.go
@@ -24,11 +24,18 @@ type RPCStats struct {
 	CounterPerMethod map[string]uint `json:"methods"`
 }
 
-// GetStats retrun RPC usage stats
+// GetStats returns RPC usage stats
 func (api *PublicAPI) GetStats(context context.Context) (RPCStats, error) {
 	total, perMethod := getStats()
+
+	counterPerMethod := make(map[string]uint)
+	perMethod.Range(func(key, value interface{}) bool {
+		counterPerMethod[key.(string)] = value.(uint)
+		return true
+	})
+
 	return RPCStats{
 		Total:            total,
-		CounterPerMethod: perMethod,
+		CounterPerMethod: counterPerMethod,
 	}, nil
 }

--- a/services/rpcstats/api.go
+++ b/services/rpcstats/api.go
@@ -2,6 +2,7 @@ package rpcstats
 
 import (
 	"context"
+	"sync"
 )
 
 // PublicAPI represents a set of APIs from the namespace.
@@ -26,11 +27,22 @@ type RPCStats struct {
 
 // GetStats returns RPC usage stats
 func (api *PublicAPI) GetStats(context context.Context) (RPCStats, error) {
-	total, perMethod := getStats()
+	total, perMethod, perMethodPerTag := getStats()
 
 	counterPerMethod := make(map[string]uint)
 	perMethod.Range(func(key, value interface{}) bool {
 		counterPerMethod[key.(string)] = value.(uint)
+		return true
+	})
+	perMethodPerTag.Range(func(key, value interface{}) bool {
+		tag := key.(string)
+		methods := value.(*sync.Map)
+		methods.Range(func(key, value interface{}) bool {
+			method := key.(string)
+			count := value.(uint)
+			counterPerMethod[method+"_"+tag] = count
+			return true
+		})
 		return true
 	})
 

--- a/services/rpcstats/stats.go
+++ b/services/rpcstats/stats.go
@@ -51,6 +51,5 @@ func CountCallWithTag(method string, tag string) {
 	methodMap := value.(*sync.Map)
 	value, _ = methodMap.LoadOrStore(method, uint(0))
 	methodMap.Store(method, value.(uint)+1)
-
-	CountCall(method)
+	stats.total++
 }

--- a/services/rpcstats/stats.go
+++ b/services/rpcstats/stats.go
@@ -2,14 +2,12 @@ package rpcstats
 
 import (
 	"sync"
-
-	"github.com/ethereum/go-ethereum/log"
 )
 
 type RPCUsageStats struct {
 	total                  uint
-	counterPerMethod       sync.Map
-	counterPerMethodPerTag sync.Map
+	counterPerMethod       *sync.Map
+	counterPerMethodPerTag *sync.Map
 }
 
 var stats *RPCUsageStats
@@ -17,36 +15,25 @@ var stats *RPCUsageStats
 func getInstance() *RPCUsageStats {
 	if stats == nil {
 		stats = &RPCUsageStats{}
+		stats.counterPerMethod = &sync.Map{}
+		stats.counterPerMethodPerTag = &sync.Map{}
 	}
 	return stats
 }
 
-func getStats() (uint, sync.Map) {
+func getStats() (uint, *sync.Map, *sync.Map) {
 	stats := getInstance()
-	return stats.total, stats.counterPerMethod
+	return stats.total, stats.counterPerMethod, stats.counterPerMethodPerTag
 }
-
-// func getStatsWithTag(tag string) (sync.Map, bool) {
-// 	stats := getInstance()
-// 	value, ok := stats.counterPerMethodPerTag.Load(tag)
-// 	return value.(sync.Map), ok
-// }
 
 func resetStats() {
 	stats := getInstance()
 	stats.total = 0
-	stats.counterPerMethod = sync.Map{}
-	stats.counterPerMethodPerTag = sync.Map{}
+	stats.counterPerMethod = &sync.Map{}
+	stats.counterPerMethodPerTag = &sync.Map{}
 }
 
-// func resetStatsWithTag(tag string) {
-// 	stats := getInstance()
-// 	stats.counterPerMethodPerTag.Delete(tag)
-// }
-
 func CountCall(method string) {
-	log.Info("CountCall", "method", method)
-
 	stats := getInstance()
 	stats.total++
 	value, _ := stats.counterPerMethod.LoadOrStore(method, uint(0))
@@ -60,12 +47,10 @@ func CountCallWithTag(method string, tag string) {
 	}
 
 	stats := getInstance()
-	value, _ := stats.counterPerMethodPerTag.LoadOrStore(tag, sync.Map{})
-	methodMap := value.(sync.Map)
+	value, _ := stats.counterPerMethodPerTag.LoadOrStore(tag, &sync.Map{})
+	methodMap := value.(*sync.Map)
 	value, _ = methodMap.LoadOrStore(method, uint(0))
 	methodMap.Store(method, value.(uint)+1)
-
-	log.Info("CountCallWithTag", "method", method, "tag", tag, "count", value.(uint)+1)
 
 	CountCall(method)
 }

--- a/services/wallet/connection/status.go
+++ b/services/wallet/connection/status.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+type Connectable interface {
+	SetIsConnected(bool)
+	IsConnected() bool
+}
+
 type StateChangeCb func(State)
 
 type Status struct {

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -446,7 +446,7 @@ func (r *Reader) getWalletTokenBalances(ctx context.Context, addresses []common.
 
 					hasError := false
 					if client, ok := clients[token.ChainID]; ok {
-						hasError = err != nil || !client.GetIsConnected()
+						hasError = err != nil || !client.IsConnected()
 					}
 					if !isVisible {
 						isVisible = balance.Cmp(big.NewFloat(0.0)) > 0 || r.isCachedToken(cachedTokens, address, token.Symbol, token.ChainID)
@@ -582,7 +582,7 @@ func (r *Reader) GetWalletToken(ctx context.Context, addresses []common.Address)
 					}
 					hasError := false
 					if client, ok := clients[token.ChainID]; ok {
-						hasError = err != nil || !client.GetIsConnected()
+						hasError = err != nil || !client.IsConnected()
 					}
 					if !isVisible {
 						isVisible = balance.Cmp(big.NewFloat(0.0)) > 0 || r.isCachedToken(cachedTokens, address, token.Symbol, token.ChainID)

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -769,7 +769,7 @@ func (tm *Manager) GetBalancesAtByChain(parent context.Context, clients map[uint
 					BlockNumber: atBlock,
 				}, accounts)
 				if err != nil {
-					log.Error("can't fetch chain balance 5", err)
+					log.Error("can't fetch chain balance 5", "err", err)
 					return nil
 				}
 				for idx, account := range accounts {
@@ -804,7 +804,7 @@ func (tm *Manager) GetBalancesAtByChain(parent context.Context, clients map[uint
 						}
 
 						if len(res) != len(chunk) {
-							log.Error("can't fetch erc20 token balance 7", "account", account, "error response not complete")
+							log.Error("can't fetch erc20 token balance 7", "account", account, "error", "response not complete")
 							return nil
 						}
 
@@ -823,7 +823,7 @@ func (tm *Manager) GetBalancesAtByChain(parent context.Context, clients map[uint
 						balance, err := tm.GetTokenBalanceAt(ctx, client, account, token, atBlock)
 						if err != nil {
 							if err != bind.ErrNoCode {
-								log.Error("can't fetch erc20 token balance 8", "account", account, "token", token, "error on fetching token balance")
+								log.Error("can't fetch erc20 token balance 8", "account", account, "token", token, "error", "on fetching token balance")
 
 								return nil
 							}

--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -29,8 +29,8 @@ const (
 	transferHistoryTag    = "transfer_history"
 	newTransferHistoryTag = "new_transfer_history"
 
-	transferHistoryMaxRequests       = 100
-	transferHistoryMaxRequestsPeriod = 10 * time.Second
+	transferHistoryMaxRequests       = 10000
+	transferHistoryMaxRequestsPeriod = 24 * time.Hour
 )
 
 type nonceInfo struct {
@@ -1122,7 +1122,7 @@ func (c *loadBlocksAndTransfersCommand) fetchHistoryBlocksForAccount(group *asyn
 		log.Debug("range item", "r", rangeItem, "n", c.chainClient.NetworkID(), "a", account)
 
 		chainClient := chain.ClientWithTag(c.chainClient, transferHistoryTag)
-		limiter := chain.NewRequestLimiter(chain.NewInMemRequestsStorage())
+		limiter := chain.NewRequestLimiter(chain.NewInMemRequestsMapStorage())
 		limiter.SetMaxRequests(transferHistoryTag, transferHistoryMaxRequests, transferHistoryMaxRequestsPeriod)
 		chainClient.SetLimiter(limiter)
 

--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -29,8 +29,8 @@ const (
 	transferHistoryTag    = "transfer_history"
 	newTransferHistoryTag = "new_transfer_history"
 
-	transferHistoryMaxRequests       = 10000
-	transferHistoryMaxRequestsPeriod = 24 * time.Hour
+	transferHistoryLimit       = 10000
+	transferHistoryLimitPeriod = 24 * time.Hour
 )
 
 type nonceInfo struct {
@@ -1123,7 +1123,7 @@ func (c *loadBlocksAndTransfersCommand) fetchHistoryBlocksForAccount(group *asyn
 
 		chainClient := chain.ClientWithTag(c.chainClient, transferHistoryTag)
 		limiter := chain.NewRequestLimiter(chain.NewInMemRequestsMapStorage())
-		limiter.SetMaxRequests(transferHistoryTag, transferHistoryMaxRequests, transferHistoryMaxRequestsPeriod)
+		limiter.SetLimit(transferHistoryTag, transferHistoryLimit, transferHistoryLimitPeriod)
 		chainClient.SetLimiter(limiter)
 
 		fbc := &findBlocksCommand{

--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -1127,8 +1127,14 @@ func (c *loadBlocksAndTransfersCommand) fetchHistoryBlocksForAccount(group *asyn
 		chainClient := chain.ClientWithTag(c.chainClient, accountTag, transferHistoryTag)
 		storage := chain.NewLimitsDBStorage(c.db.client)
 		limiter := chain.NewRequestLimiter(storage)
-		limiter.SetLimit(accountTag, transferHistoryLimitPerAccount, transferHistoryLimitPeriod)
-		limiter.SetLimit(transferHistoryTag, transferHistoryLimit, transferHistoryLimitPeriod)
+		err := limiter.SetLimit(accountTag, transferHistoryLimitPerAccount, transferHistoryLimitPeriod)
+		if err != nil {
+			log.Error("fetchHistoryBlocksForAccount SetLimit", "error", err, "accountTag", accountTag)
+		}
+		err = limiter.SetLimit(transferHistoryTag, transferHistoryLimit, transferHistoryLimitPeriod)
+		if err != nil {
+			log.Error("fetchHistoryBlocksForAccount SetLimit", "error", err, "groupTag", transferHistoryTag)
+		}
 		chainClient.SetLimiter(limiter)
 
 		fbc := &findBlocksCommand{

--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -1130,6 +1130,7 @@ func (c *loadBlocksAndTransfersCommand) fetchHistoryBlocksForAccount(group *asyn
 
 		// Check if limit is already reached, then skip the comamnd
 		if allow, _ := limiter.Allow(accountTag); !allow {
+			log.Debug("fetchHistoryBlocksForAccount limit reached", "account", account, "chain", c.chainClient.NetworkID())
 			continue
 		}
 

--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -1127,7 +1127,13 @@ func (c *loadBlocksAndTransfersCommand) fetchHistoryBlocksForAccount(group *asyn
 		chainClient := chain.ClientWithTag(c.chainClient, accountTag, transferHistoryTag)
 		storage := chain.NewLimitsDBStorage(c.db.client)
 		limiter := chain.NewRequestLimiter(storage)
-		err := limiter.SetLimit(accountTag, transferHistoryLimitPerAccount, transferHistoryLimitPeriod)
+
+		// Check if limit is already reached, then skip the comamnd
+		if allow, _ := limiter.Allow(accountTag); !allow {
+			continue
+		}
+
+		err := limiter.SetLimit(accountTag, transferHistoryLimitPerAccount, chain.LimitInfinitely)
 		if err != nil {
 			log.Error("fetchHistoryBlocksForAccount SetLimit", "error", err, "accountTag", accountTag)
 		}

--- a/services/wallet/transfer/commands_sequential.go
+++ b/services/wallet/transfer/commands_sequential.go
@@ -1125,7 +1125,7 @@ func (c *loadBlocksAndTransfersCommand) fetchHistoryBlocksForAccount(group *asyn
 		// Each account has its own limit and a global limit for all accounts
 		accountTag := transferHistoryTag + "_" + account.String()
 		chainClient := chain.ClientWithTag(c.chainClient, accountTag, transferHistoryTag)
-		storage := chain.NewInMemRequestsMapStorage()
+		storage := chain.NewLimitsDBStorage(c.db.client)
 		limiter := chain.NewRequestLimiter(storage)
 		limiter.SetLimit(accountTag, transferHistoryLimitPerAccount, transferHistoryLimitPeriod)
 		limiter.SetLimit(transferHistoryTag, transferHistoryLimit, transferHistoryLimitPeriod)

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -1047,7 +1047,7 @@ func setupFindBlocksCommand(t *testing.T, accountAddress common.Address, fromBlo
 	// Reimplement the common function that is called from every method to check for the limit
 	countAndlog = func(tc *TestClient, method string, params ...interface{}) error {
 		if tc.GetLimiter() != nil {
-			if limited, _ := tc.GetLimiter().IsLimitReached(transferHistoryTag); limited {
+			if allow, _ := tc.GetLimiter().Allow(transferHistoryTag); !allow {
 				t.Log("ERROR: requests over limit")
 				return chain.ErrRequestsOverLimit
 			}
@@ -1180,7 +1180,7 @@ func TestFindBlocksCommandWithLimiter(t *testing.T) {
 	fbc, tc, blockChannel, _ := setupFindBlocksCommand(t, accountAddress, big.NewInt(0), big.NewInt(20), rangeSize, balances, nil, nil, nil, nil)
 
 	limiter := chain.NewRequestLimiter(chain.NewInMemRequestsMapStorage())
-	limiter.SetMaxRequests(transferHistoryTag, maxRequests, time.Hour)
+	limiter.SetLimit(transferHistoryTag, maxRequests, time.Hour)
 	tc.SetLimiter(limiter)
 
 	ctx := context.Background()
@@ -1207,7 +1207,7 @@ func TestFindBlocksCommandWithLimiterTagDifferentThanTransfers(t *testing.T) {
 
 	fbc, tc, blockChannel, _ := setupFindBlocksCommand(t, accountAddress, big.NewInt(0), big.NewInt(20), rangeSize, balances, outgoingERC20Transfers, incomingERC20Transfers, nil, nil)
 	limiter := chain.NewRequestLimiter(chain.NewInMemRequestsMapStorage())
-	limiter.SetMaxRequests("some-other-tag-than-transfer-history", maxRequests, time.Hour)
+	limiter.SetLimit("some-other-tag-than-transfer-history", maxRequests, time.Hour)
 	tc.SetLimiter(limiter)
 
 	ctx := context.Background()

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -1175,10 +1175,6 @@ func TestFindBlocksCommand(t *testing.T) {
 }
 
 func TestFindBlocksCommandWithLimiter(t *testing.T) {
-	// Set up logging
-	// handler := log.StreamHandler(os.Stdout, log.TerminalFormat(true))
-	// log.Root().SetHandler(handler)
-
 	maxRequests := 1
 	rangeSize := 20
 	accountAddress := common.HexToAddress("0x1234")
@@ -1188,6 +1184,7 @@ func TestFindBlocksCommandWithLimiter(t *testing.T) {
 	limiter := chain.NewRequestLimiter(chain.NewInMemRequestsMapStorage())
 	limiter.SetLimit(transferHistoryTag, maxRequests, time.Hour)
 	tc.SetLimiter(limiter)
+	tc.tag = transferHistoryTag
 
 	ctx := context.Background()
 	group := async.NewAtomicGroup(ctx)
@@ -1803,6 +1800,7 @@ func TestLoadBlocksAndTransfersCommand_FiniteFinishedInfiniteRunning(t *testing.
 			},
 		},
 		accountsDB:    accDB,
+		db:            wdb,
 		contractMaker: maker,
 	}
 

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -332,7 +332,10 @@ var ethscanAddress = common.HexToAddress("0x000000000000000000000000000000000077
 var balanceCheckAddress = common.HexToAddress("0x0000000000000000000000000000000010777333")
 
 func (tc *TestClient) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {
-	tc.countAndlog("CodeAt", fmt.Sprintf("contract: %s, blockNumber: %d", contract, blockNumber))
+	err := tc.countAndlog("CodeAt", fmt.Sprintf("contract: %s, blockNumber: %d", contract, blockNumber))
+	if err != nil {
+		return nil, err
+	}
 
 	if ethscanAddress == contract || balanceCheckAddress == contract {
 		return []byte{1}, nil
@@ -1182,7 +1185,8 @@ func TestFindBlocksCommandWithLimiter(t *testing.T) {
 	fbc, tc, blockChannel, _ := setupFindBlocksCommand(t, accountAddress, big.NewInt(0), big.NewInt(20), rangeSize, balances, nil, nil, nil, nil)
 
 	limiter := chain.NewRequestLimiter(chain.NewInMemRequestsMapStorage())
-	limiter.SetLimit(transferHistoryTag, maxRequests, time.Hour)
+	err := limiter.SetLimit(transferHistoryTag, maxRequests, time.Hour)
+	require.NoError(t, err)
 	tc.SetLimiter(limiter)
 	tc.tag = transferHistoryTag
 
@@ -1210,7 +1214,8 @@ func TestFindBlocksCommandWithLimiterTagDifferentThanTransfers(t *testing.T) {
 
 	fbc, tc, blockChannel, _ := setupFindBlocksCommand(t, accountAddress, big.NewInt(0), big.NewInt(20), rangeSize, balances, outgoingERC20Transfers, incomingERC20Transfers, nil, nil)
 	limiter := chain.NewRequestLimiter(chain.NewInMemRequestsMapStorage())
-	limiter.SetLimit("some-other-tag-than-transfer-history", maxRequests, time.Hour)
+	err := limiter.SetLimit("some-other-tag-than-transfer-history", maxRequests, time.Hour)
+	require.NoError(t, err)
 	tc.SetLimiter(limiter)
 
 	ctx := context.Background()
@@ -1247,8 +1252,10 @@ func TestFindBlocksCommandWithLimiterForMultipleAccountsSameGroup(t *testing.T) 
 	tc.groupTag = transferHistoryTag
 
 	limiter1 := chain.NewRequestLimiter(storage)
-	limiter1.SetLimit(transferHistoryTag, maxRequestsTotal, time.Hour)
-	limiter1.SetLimit(transferHistoryTag+account1.String(), limit1, time.Hour)
+	err := limiter1.SetLimit(transferHistoryTag, maxRequestsTotal, time.Hour)
+	require.NoError(t, err)
+	err = limiter1.SetLimit(transferHistoryTag+account1.String(), limit1, time.Hour)
+	require.NoError(t, err)
 	tc.SetLimiter(limiter1)
 
 	// Set up the second account
@@ -1256,8 +1263,10 @@ func TestFindBlocksCommandWithLimiterForMultipleAccountsSameGroup(t *testing.T) 
 	tc2.tag = transferHistoryTag + account2.String()
 	tc2.groupTag = transferHistoryTag
 	limiter2 := chain.NewRequestLimiter(storage)
-	limiter2.SetLimit(transferHistoryTag, maxRequestsTotal, time.Hour)
-	limiter2.SetLimit(transferHistoryTag+account2.String(), limit2, time.Hour)
+	err = limiter2.SetLimit(transferHistoryTag, maxRequestsTotal, time.Hour)
+	require.NoError(t, err)
+	err = limiter2.SetLimit(transferHistoryTag+account2.String(), limit2, time.Hour)
+	require.NoError(t, err)
 	tc2.SetLimiter(limiter2)
 	fbc2.blocksLoadedCh = blockChannel
 

--- a/services/wallet/transfer/database.go
+++ b/services/wallet/transfer/database.go
@@ -540,7 +540,7 @@ func removeGasOnlyEthTransfer(creator statementCreator, t transferDBFields) erro
 	if err != nil {
 		return err
 	}
-	log.Debug("removeGasOnlyEthTransfer row deleted ", count)
+	log.Debug("removeGasOnlyEthTransfer rows deleted", "count", count)
 	return nil
 }
 

--- a/services/wallet/transfer/downloader.go
+++ b/services/wallet/transfer/downloader.go
@@ -533,7 +533,7 @@ func (d *ERC20TransfersDownloader) blocksFromLogs(parent context.Context, logs [
 // time to get logs for 100000 blocks = 1.144686979s. with 249 events in the result set.
 func (d *ERC20TransfersDownloader) GetHeadersInRange(parent context.Context, from, to *big.Int) ([]*DBHeader, error) {
 	start := time.Now()
-	log.Debug("get erc20 transfers in range start", "chainID", d.client.NetworkID(), "from", from, "to", to)
+	log.Debug("get erc20 transfers in range start", "chainID", d.client.NetworkID(), "from", from, "to", to, "accounts", d.accounts)
 	headers := []*DBHeader{}
 	ctx := context.Background()
 	var err error
@@ -596,7 +596,7 @@ func (d *ERC20TransfersDownloader) GetHeadersInRange(parent context.Context, fro
 	}
 
 	log.Debug("get erc20 transfers in range end", "chainID", d.client.NetworkID(),
-		"from", from, "to", to, "headers", len(headers), "took", time.Since(start))
+		"from", from, "to", to, "headers", len(headers), "accounts", d.accounts, "took", time.Since(start))
 	return headers, nil
 }
 

--- a/walletdatabase/migrations/bindata.go
+++ b/walletdatabase/migrations/bindata.go
@@ -28,6 +28,7 @@
 // 1714670633_add_id_to_multi_transaction_table.up.sql (1.15kB)
 // 1715637927_add_collection_socials.up.sql (356B)
 // 1715839555_rename_chain_prefixes.up.sql (259B)
+// 1716313614_add_rpc_limits_table.up.sql (203B)
 // doc.go (94B)
 
 package migrations
@@ -38,6 +39,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +49,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %w", name, err)
+		return nil, fmt.Errorf("read %q: %v", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -55,7 +57,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %w", name, err)
+		return nil, fmt.Errorf("read %q: %v", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -656,6 +658,26 @@ func _1715839555_rename_chain_prefixesUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1716313614_add_rpc_limits_tableUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x74\xca\xc1\xaa\x82\x40\x14\x06\xe0\xbd\x4f\xf1\x2f\xef\x85\xde\xa0\x95\xd5\xa1\x86\x4c\x63\x38\x62\xae\x64\x18\x0f\x31\x90\x69\x33\x47\xe8\xf1\x83\x82\x36\xe1\xfa\xfb\xb6\x96\x72\x26\x70\xbe\x29\x08\x71\xf2\xdd\x2d\x0c\x41\x13\xfe\x32\x00\x50\x77\x05\xd3\x85\x51\x56\x8c\xb2\x2e\x0a\x9c\xad\x39\xe5\xb6\xc5\x91\xda\xd5\xbb\xf8\x28\x4e\xa5\xef\x9c\xc2\x94\x4c\x7b\xb2\xdf\xfc\x09\x93\xc4\x30\xf6\x0b\x38\xb8\x67\x17\xe5\x31\x4b\xd2\xb4\x50\xfc\x38\xdf\x55\xe2\x8f\x66\xff\x68\x0c\x1f\xaa\x9a\x61\xab\xc6\xec\xd6\xaf\x00\x00\x00\xff\xff\x4f\x5e\x6d\x01\xcb\x00\x00\x00")
+
+func _1716313614_add_rpc_limits_tableUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1716313614_add_rpc_limits_tableUpSql,
+		"1716313614_add_rpc_limits_table.up.sql",
+	)
+}
+
+func _1716313614_add_rpc_limits_tableUpSql() (*asset, error) {
+	bytes, err := _1716313614_add_rpc_limits_tableUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1716313614_add_rpc_limits_table.up.sql", size: 203, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x60, 0x71, 0xb7, 0xd0, 0xa5, 0x81, 0x7, 0xdc, 0xed, 0x41, 0x23, 0x91, 0xdb, 0xcb, 0xb9, 0xb1, 0x42, 0xa3, 0x12, 0x1c, 0x94, 0x1c, 0xee, 0x1f, 0x5a, 0x8f, 0x73, 0x61, 0xff, 0xb2, 0x66, 0x9c}}
+	return a, nil
+}
+
 var _docGo = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x2c\xcb\x41\x0e\x02\x31\x08\x05\xd0\x7d\x4f\xf1\x2f\x00\xe8\xca\xc4\xc4\xc3\xa0\x43\x08\x19\x5b\xc6\x96\xfb\xc7\x4d\xdf\xfe\x5d\xfa\x39\xd5\x0d\xeb\xf7\x6d\x4d\xc4\xf3\xe9\x36\x6c\x6a\x19\x3c\xe9\x1d\xe3\xd0\x52\x50\xcf\xa3\xa2\xdb\xeb\xfe\xb8\x6d\xa0\xeb\x74\xf4\xf0\xa9\x15\x39\x16\x28\xc1\x2c\x7b\xb0\x27\x58\xda\x3f\x00\x00\xff\xff\x57\xd4\xd5\x90\x5e\x00\x00\x00")
 
 func docGoBytes() ([]byte, error) {
@@ -767,51 +789,76 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"1691753758_initial.up.sql":                                                     _1691753758_initialUpSql,
-	"1692701329_add_collectibles_and_collections_data_cache.up.sql":                 _1692701329_add_collectibles_and_collections_data_cacheUpSql,
-	"1692701339_add_scope_to_pending.up.sql":                                        _1692701339_add_scope_to_pendingUpSql,
-	"1694540071_add_collectibles_ownership_update_timestamp.up.sql":                 _1694540071_add_collectibles_ownership_update_timestampUpSql,
-	"1694692748_add_raw_balance_to_token_balances.up.sql":                           _1694692748_add_raw_balance_to_token_balancesUpSql,
+	"1691753758_initial.up.sql": _1691753758_initialUpSql,
+
+	"1692701329_add_collectibles_and_collections_data_cache.up.sql": _1692701329_add_collectibles_and_collections_data_cacheUpSql,
+
+	"1692701339_add_scope_to_pending.up.sql": _1692701339_add_scope_to_pendingUpSql,
+
+	"1694540071_add_collectibles_ownership_update_timestamp.up.sql": _1694540071_add_collectibles_ownership_update_timestampUpSql,
+
+	"1694692748_add_raw_balance_to_token_balances.up.sql": _1694692748_add_raw_balance_to_token_balancesUpSql,
+
 	"1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql": _1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSql,
-	"1695932536_balance_history_v2.up.sql":                                          _1695932536_balance_history_v2UpSql,
-	"1696853635_input_data.up.sql":                                                  _1696853635_input_dataUpSql,
-	"1698117918_add_community_id_to_tokens.up.sql":                                  _1698117918_add_community_id_to_tokensUpSql,
-	"1698257443_add_community_metadata_to_wallet_db.up.sql":                         _1698257443_add_community_metadata_to_wallet_dbUpSql,
-	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql":             _1699987075_add_timestamp_and_state_to_community_data_cacheUpSql,
-	"1700414564_add_wallet_connect_pairings_table.up.sql":                           _1700414564_add_wallet_connect_pairings_tableUpSql,
-	"1701101493_add_token_blocks_range.up.sql":                                      _1701101493_add_token_blocks_rangeUpSql,
-	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql":                 _1702467441_wallet_connect_sessions_instead_of_pairingsUpSql,
-	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql":     _1702577524_add_community_collections_and_collectibles_images_cacheUpSql,
-	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql":                 _1702867707_add_balance_to_collectibles_ownership_cacheUpSql,
-	"1703686612_add_color_to_saved_addresses.up.sql":                                _1703686612_add_color_to_saved_addressesUpSql,
+
+	"1695932536_balance_history_v2.up.sql": _1695932536_balance_history_v2UpSql,
+
+	"1696853635_input_data.up.sql": _1696853635_input_dataUpSql,
+
+	"1698117918_add_community_id_to_tokens.up.sql": _1698117918_add_community_id_to_tokensUpSql,
+
+	"1698257443_add_community_metadata_to_wallet_db.up.sql": _1698257443_add_community_metadata_to_wallet_dbUpSql,
+
+	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql": _1699987075_add_timestamp_and_state_to_community_data_cacheUpSql,
+
+	"1700414564_add_wallet_connect_pairings_table.up.sql": _1700414564_add_wallet_connect_pairings_tableUpSql,
+
+	"1701101493_add_token_blocks_range.up.sql": _1701101493_add_token_blocks_rangeUpSql,
+
+	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql": _1702467441_wallet_connect_sessions_instead_of_pairingsUpSql,
+
+	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql": _1702577524_add_community_collections_and_collectibles_images_cacheUpSql,
+
+	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql": _1702867707_add_balance_to_collectibles_ownership_cacheUpSql,
+
+	"1703686612_add_color_to_saved_addresses.up.sql": _1703686612_add_color_to_saved_addressesUpSql,
+
 	"1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql": _1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSql,
-	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql":   _1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql,
-	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql":           _1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql,
-	"1706531789_remove_gasfee-only-eth-transfers.up.sql":                            _1706531789_remove_gasfeeOnlyEthTransfersUpSql,
-	"1707160323_add_contract_type_table.up.sql":                                     _1707160323_add_contract_type_tableUpSql,
-	"1708089811_add_nullable_fiesl_blocks_ranges.up.sql":                            _1708089811_add_nullable_fiesl_blocks_rangesUpSql,
-	"1710189541_add_nonce_to_pending_transactions.up.sql":                           _1710189541_add_nonce_to_pending_transactionsUpSql,
-	"1712567001_add_soulbound_collectible_cache.up.sql":                             _1712567001_add_soulbound_collectible_cacheUpSql,
-	"1714670633_add_id_to_multi_transaction_table.up.sql":                           _1714670633_add_id_to_multi_transaction_tableUpSql,
-	"1715637927_add_collection_socials.up.sql":                                      _1715637927_add_collection_socialsUpSql,
-	"1715839555_rename_chain_prefixes.up.sql":                                       _1715839555_rename_chain_prefixesUpSql,
+
+	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql": _1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql,
+
+	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql": _1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql,
+
+	"1706531789_remove_gasfee-only-eth-transfers.up.sql": _1706531789_remove_gasfeeOnlyEthTransfersUpSql,
+
+	"1707160323_add_contract_type_table.up.sql": _1707160323_add_contract_type_tableUpSql,
+
+	"1708089811_add_nullable_fiesl_blocks_ranges.up.sql": _1708089811_add_nullable_fiesl_blocks_rangesUpSql,
+
+	"1710189541_add_nonce_to_pending_transactions.up.sql": _1710189541_add_nonce_to_pending_transactionsUpSql,
+
+	"1712567001_add_soulbound_collectible_cache.up.sql": _1712567001_add_soulbound_collectible_cacheUpSql,
+
+	"1714670633_add_id_to_multi_transaction_table.up.sql": _1714670633_add_id_to_multi_transaction_tableUpSql,
+
+	"1715637927_add_collection_socials.up.sql": _1715637927_add_collection_socialsUpSql,
+
+	"1715839555_rename_chain_prefixes.up.sql": _1715839555_rename_chain_prefixesUpSql,
+
+	"1716313614_add_rpc_limits_table.up.sql": _1716313614_add_rpc_limits_tableUpSql,
+
 	"doc.go": docGo,
 }
-
-// AssetDebug is true if the assets were built with the debug flag enabled.
-const AssetDebug = false
 
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//
-//	data/
-//	  foo.txt
-//	  img/
-//	    a.png
-//	    b.png
-//
+//     data/
+//       foo.txt
+//       img/
+//         a.png
+//         b.png
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and
@@ -844,35 +891,36 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"1691753758_initial.up.sql":                                                     {_1691753758_initialUpSql, map[string]*bintree{}},
-	"1692701329_add_collectibles_and_collections_data_cache.up.sql":                 {_1692701329_add_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
-	"1692701339_add_scope_to_pending.up.sql":                                        {_1692701339_add_scope_to_pendingUpSql, map[string]*bintree{}},
-	"1694540071_add_collectibles_ownership_update_timestamp.up.sql":                 {_1694540071_add_collectibles_ownership_update_timestampUpSql, map[string]*bintree{}},
-	"1694692748_add_raw_balance_to_token_balances.up.sql":                           {_1694692748_add_raw_balance_to_token_balancesUpSql, map[string]*bintree{}},
-	"1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql": {_1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
-	"1695932536_balance_history_v2.up.sql":                                          {_1695932536_balance_history_v2UpSql, map[string]*bintree{}},
-	"1696853635_input_data.up.sql":                                                  {_1696853635_input_dataUpSql, map[string]*bintree{}},
-	"1698117918_add_community_id_to_tokens.up.sql":                                  {_1698117918_add_community_id_to_tokensUpSql, map[string]*bintree{}},
-	"1698257443_add_community_metadata_to_wallet_db.up.sql":                         {_1698257443_add_community_metadata_to_wallet_dbUpSql, map[string]*bintree{}},
-	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql":             {_1699987075_add_timestamp_and_state_to_community_data_cacheUpSql, map[string]*bintree{}},
-	"1700414564_add_wallet_connect_pairings_table.up.sql":                           {_1700414564_add_wallet_connect_pairings_tableUpSql, map[string]*bintree{}},
-	"1701101493_add_token_blocks_range.up.sql":                                      {_1701101493_add_token_blocks_rangeUpSql, map[string]*bintree{}},
-	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql":                 {_1702467441_wallet_connect_sessions_instead_of_pairingsUpSql, map[string]*bintree{}},
-	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql":     {_1702577524_add_community_collections_and_collectibles_images_cacheUpSql, map[string]*bintree{}},
-	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql":                 {_1702867707_add_balance_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
-	"1703686612_add_color_to_saved_addresses.up.sql":                                {_1703686612_add_color_to_saved_addressesUpSql, map[string]*bintree{}},
-	"1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql": {_1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSql, map[string]*bintree{}},
-	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql":   {_1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
-	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql":           {_1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql, map[string]*bintree{}},
-	"1706531789_remove_gasfee-only-eth-transfers.up.sql":                            {_1706531789_remove_gasfeeOnlyEthTransfersUpSql, map[string]*bintree{}},
-	"1707160323_add_contract_type_table.up.sql":                                     {_1707160323_add_contract_type_tableUpSql, map[string]*bintree{}},
-	"1708089811_add_nullable_fiesl_blocks_ranges.up.sql":                            {_1708089811_add_nullable_fiesl_blocks_rangesUpSql, map[string]*bintree{}},
-	"1710189541_add_nonce_to_pending_transactions.up.sql":                           {_1710189541_add_nonce_to_pending_transactionsUpSql, map[string]*bintree{}},
-	"1712567001_add_soulbound_collectible_cache.up.sql":                             {_1712567001_add_soulbound_collectible_cacheUpSql, map[string]*bintree{}},
-	"1714670633_add_id_to_multi_transaction_table.up.sql":                           {_1714670633_add_id_to_multi_transaction_tableUpSql, map[string]*bintree{}},
-	"1715637927_add_collection_socials.up.sql":                                      {_1715637927_add_collection_socialsUpSql, map[string]*bintree{}},
-	"1715839555_rename_chain_prefixes.up.sql":                                       {_1715839555_rename_chain_prefixesUpSql, map[string]*bintree{}},
-	"doc.go": {docGo, map[string]*bintree{}},
+	"1691753758_initial.up.sql":                                                     &bintree{_1691753758_initialUpSql, map[string]*bintree{}},
+	"1692701329_add_collectibles_and_collections_data_cache.up.sql":                 &bintree{_1692701329_add_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
+	"1692701339_add_scope_to_pending.up.sql":                                        &bintree{_1692701339_add_scope_to_pendingUpSql, map[string]*bintree{}},
+	"1694540071_add_collectibles_ownership_update_timestamp.up.sql":                 &bintree{_1694540071_add_collectibles_ownership_update_timestampUpSql, map[string]*bintree{}},
+	"1694692748_add_raw_balance_to_token_balances.up.sql":                           &bintree{_1694692748_add_raw_balance_to_token_balancesUpSql, map[string]*bintree{}},
+	"1695133989_add_community_id_to_collectibles_and_collections_data_cache.up.sql": &bintree{_1695133989_add_community_id_to_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
+	"1695932536_balance_history_v2.up.sql":                                          &bintree{_1695932536_balance_history_v2UpSql, map[string]*bintree{}},
+	"1696853635_input_data.up.sql":                                                  &bintree{_1696853635_input_dataUpSql, map[string]*bintree{}},
+	"1698117918_add_community_id_to_tokens.up.sql":                                  &bintree{_1698117918_add_community_id_to_tokensUpSql, map[string]*bintree{}},
+	"1698257443_add_community_metadata_to_wallet_db.up.sql":                         &bintree{_1698257443_add_community_metadata_to_wallet_dbUpSql, map[string]*bintree{}},
+	"1699987075_add_timestamp_and_state_to_community_data_cache.up.sql":             &bintree{_1699987075_add_timestamp_and_state_to_community_data_cacheUpSql, map[string]*bintree{}},
+	"1700414564_add_wallet_connect_pairings_table.up.sql":                           &bintree{_1700414564_add_wallet_connect_pairings_tableUpSql, map[string]*bintree{}},
+	"1701101493_add_token_blocks_range.up.sql":                                      &bintree{_1701101493_add_token_blocks_rangeUpSql, map[string]*bintree{}},
+	"1702467441_wallet_connect_sessions_instead_of_pairings.up.sql":                 &bintree{_1702467441_wallet_connect_sessions_instead_of_pairingsUpSql, map[string]*bintree{}},
+	"1702577524_add_community_collections_and_collectibles_images_cache.up.sql":     &bintree{_1702577524_add_community_collections_and_collectibles_images_cacheUpSql, map[string]*bintree{}},
+	"1702867707_add_balance_to_collectibles_ownership_cache.up.sql":                 &bintree{_1702867707_add_balance_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
+	"1703686612_add_color_to_saved_addresses.up.sql":                                &bintree{_1703686612_add_color_to_saved_addressesUpSql, map[string]*bintree{}},
+	"1704701942_remove_favourite_and_change_primary_key_for_saved_addresses.up.sql": &bintree{_1704701942_remove_favourite_and_change_primary_key_for_saved_addressesUpSql, map[string]*bintree{}},
+	"1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cache.up.sql":   &bintree{_1704913491_add_type_and_tx_timestamp_to_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
+	"1705664490_add_balance_check_fields_blocks_ranges_sequential.up.sql":           &bintree{_1705664490_add_balance_check_fields_blocks_ranges_sequentialUpSql, map[string]*bintree{}},
+	"1706531789_remove_gasfee-only-eth-transfers.up.sql":                            &bintree{_1706531789_remove_gasfeeOnlyEthTransfersUpSql, map[string]*bintree{}},
+	"1707160323_add_contract_type_table.up.sql":                                     &bintree{_1707160323_add_contract_type_tableUpSql, map[string]*bintree{}},
+	"1708089811_add_nullable_fiesl_blocks_ranges.up.sql":                            &bintree{_1708089811_add_nullable_fiesl_blocks_rangesUpSql, map[string]*bintree{}},
+	"1710189541_add_nonce_to_pending_transactions.up.sql":                           &bintree{_1710189541_add_nonce_to_pending_transactionsUpSql, map[string]*bintree{}},
+	"1712567001_add_soulbound_collectible_cache.up.sql":                             &bintree{_1712567001_add_soulbound_collectible_cacheUpSql, map[string]*bintree{}},
+	"1714670633_add_id_to_multi_transaction_table.up.sql":                           &bintree{_1714670633_add_id_to_multi_transaction_tableUpSql, map[string]*bintree{}},
+	"1715637927_add_collection_socials.up.sql":                                      &bintree{_1715637927_add_collection_socialsUpSql, map[string]*bintree{}},
+	"1715839555_rename_chain_prefixes.up.sql":                                       &bintree{_1715839555_rename_chain_prefixesUpSql, map[string]*bintree{}},
+	"1716313614_add_rpc_limits_table.up.sql":                                        &bintree{_1716313614_add_rpc_limits_tableUpSql, map[string]*bintree{}},
+	"doc.go":                                                                        &bintree{docGo, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.
@@ -889,7 +937,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/walletdatabase/migrations/sql/1716313614_add_rpc_limits_table.up.sql
+++ b/walletdatabase/migrations/sql/1716313614_add_rpc_limits_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE rpc_limits (
+    tag TEXT NOT NULL PRIMARY KEY,
+    created_at INTEGER NOT NULL,
+    period INTEGER NOT NULL,
+    max_requests INTEGER NOT NULL,
+    counter INTEGER NOT NULL
+) WITHOUT ROWID;


### PR DESCRIPTION
Implemented limiter for transfers `history` RPC requests (it does not limit for now any other RPC calls. Though it is easily possible to do if needed)

Limits for transfer history:
- 5k requests per account (totally for all history, not per day)
- 10k requests totally per day

Since we should allow requests to blockchain to detect new transactions, we should differentiate those with history requests. For that purpose I added tags to rpc.Client:
- tag (used to mark history calls per account)
- groupTag (used to limit total history calls)

Other improvements and things to mention:
- ClientInterface split to ChainInterface and others for better clarity
- Fixed RPC stats to properly display tagged RPC calls
- RPCLimiter renamed to RPCRpsLimiter, as there are 2 limiters now
- Replaced some fields and corresponding locks to atomics and `sync` types where needed since chain.Client is now copied
- Used connection.Connectable for ClientInterface

Closes #5173 