### PR TITLE
chore: use custom logger for message timestamps and log query duration

### DIFF
--- a/logutils/custom.go
+++ b/logutils/custom.go
@@ -1,0 +1,15 @@
+package logutils
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+)
+
+func WakuMessageTimestamp(key string, value *int64) zap.Field {
+	valueStr := "-"
+	if value != nil {
+		valueStr = fmt.Sprintf("%d", *value)
+	}
+	return zap.String(key, valueStr)
+}

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -69,6 +69,7 @@ import (
 
 	"github.com/status-im/status-go/connection"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/timesource"
 	"github.com/status-im/status-go/wakuv2/common"
 	"github.com/status-im/status-go/wakuv2/persistence"
@@ -1079,8 +1080,8 @@ func (w *Waku) query(ctx context.Context, peerID peer.ID, pubsubTopic string, to
 
 	w.logger.Debug("store.query",
 		zap.String("requestID", hexutil.Encode(requestID)),
-		zap.Int64p("startTime", query.StartTime),
-		zap.Int64p("endTime", query.EndTime),
+		logutils.WakuMessageTimestamp("startTime", query.StartTime),
+		logutils.WakuMessageTimestamp("endTime", query.StartTime),
 		zap.Strings("contentTopics", query.ContentTopics),
 		zap.String("pubsubTopic", query.PubsubTopic),
 		zap.Stringer("peerID", peerID))


### PR DESCRIPTION
With this we will no longer use thousand separator for unix epochs (because it makes no sense).
It also measures the query duration

Part of #5197 