### PR TITLE
chore_: add name length error

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -3,6 +3,7 @@ package common
 import (
 	"crypto/ecdsa"
 	"errors"
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -19,11 +20,18 @@ import (
 var ErrInvalidDisplayNameRegExp = errors.New("only letters, numbers, underscores and hyphens allowed")
 var ErrInvalidDisplayNameEthSuffix = errors.New(`usernames ending with "eth" are not allowed`)
 var ErrInvalidDisplayNameNotAllowed = errors.New("name is not allowed")
-var ErrInvalidDisplayNameLength = errors.New("length must be between 5 and 24 characters")
+var ErrInvalidDisplayNameLength = fmt.Errorf("length must be between %d and %d characters", MinDisplayNameLength, MaxDisplayNameLength)
 
 var DISPLAY_NAME_EXT = []string{"_eth", ".eth", "-eth"}
 
-const DefaultTruncateLength = 8
+const (
+	DefaultTruncateLength = 8
+	MinDisplayNameLength  = 5
+	MaxDisplayNameLength  = 24
+)
+
+// Compiled regex pattern for validating display names
+var displayNameRegex = regexp.MustCompile(fmt.Sprintf("^[\\w-\\s]{%d,%d}$", MinDisplayNameLength, MaxDisplayNameLength))
 
 func RecoverKey(m *protobuf.ApplicationMetadataMessage) (*ecdsa.PublicKey, error) {
 	if m.Signature == nil {
@@ -49,13 +57,12 @@ func ValidateDisplayName(displayName *string) error {
 		return nil
 	}
 
-	//keep in sync with he regex below!
-	if len(name) < 5 || len(name) > 24 {
+	if len(name) < MinDisplayNameLength || len(name) > MaxDisplayNameLength {
 		return ErrInvalidDisplayNameLength
 	}
 
-	// ^[\\w-\\s]{5,24}$ to allow spaces
-	if match, _ := regexp.MatchString("^[\\w-\\s]{5,24}$", name); !match {
+	// Use pre-compiled regex to validate name format
+	if !displayNameRegex.MatchString(name) {
 		return ErrInvalidDisplayNameRegExp
 	}
 

--- a/common/utils.go
+++ b/common/utils.go
@@ -19,6 +19,7 @@ import (
 var ErrInvalidDisplayNameRegExp = errors.New("only letters, numbers, underscores and hyphens allowed")
 var ErrInvalidDisplayNameEthSuffix = errors.New(`usernames ending with "eth" are not allowed`)
 var ErrInvalidDisplayNameNotAllowed = errors.New("name is not allowed")
+var ErrInvalidDisplayNameLength = errors.New("length must be between 5 and 24 characters")
 
 var DISPLAY_NAME_EXT = []string{"_eth", ".eth", "-eth"}
 
@@ -46,6 +47,11 @@ func ValidateDisplayName(displayName *string) error {
 
 	if name == "" {
 		return nil
+	}
+
+	//keep in sync with he regex below!
+	if len(name) < 5 || len(name) > 24 {
+		return ErrInvalidDisplayNameLength
 	}
 
 	// ^[\\w-\\s]{5,24}$ to allow spaces

--- a/protocol/messenger_identity_display_name_test.go
+++ b/protocol/messenger_identity_display_name_test.go
@@ -210,11 +210,11 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestDisplayNameRestrictions() 
 	}
 
 	setInvalidName("dot.not", utils.ErrInvalidDisplayNameRegExp)
-	setInvalidName("t", utils.ErrInvalidDisplayNameRegExp)
-	setInvalidName("tt", utils.ErrInvalidDisplayNameRegExp)
-	setInvalidName("ttt", utils.ErrInvalidDisplayNameRegExp)
-	setInvalidName("tttt", utils.ErrInvalidDisplayNameRegExp)
-	setInvalidName("name is bigger than 24 symb", utils.ErrInvalidDisplayNameRegExp)
+	setInvalidName("t", utils.ErrInvalidDisplayNameLength)
+	setInvalidName("tt", utils.ErrInvalidDisplayNameLength)
+	setInvalidName("ttt", utils.ErrInvalidDisplayNameLength)
+	setInvalidName("tttt", utils.ErrInvalidDisplayNameLength)
+	setInvalidName("name is bigger than 24 symb", utils.ErrInvalidDisplayNameLength)
 
 	err = s.m.SetDisplayName("name with space")
 	s.Require().NoError(err)


### PR DESCRIPTION
add an error and a check to handle the invalid name length explicitly

While trying out `status-cli` I got the `ErrInvalidDisplayNameRegExp` error, but it was not immediately clear what is the issue. I thought about adding more into that error, but it felt like it would get a bit overwhelming, so I added a separate one.

Definitely low priority, just something I hit while looking at status-go

---

## Update from @igor-sirotin 

I have:
1. Extracted `5` and `24` to constants
2. Extracted the regex to `MustCompile`. This will improve performance.
3. Fixed the test.
