### PR TITLE
chore: add telemetry url flag to status cli

### DIFF
--- a/api/defaults.go
+++ b/api/defaults.go
@@ -283,6 +283,10 @@ func defaultNodeConfig(installationID string, request *requests.CreateAccount, o
 		nodeConfig.WakuV2Config.Nameserver = *request.WakuV2Nameserver
 	}
 
+	if request.TelemetryServerURL != "" {
+		nodeConfig.WakuV2Config.TelemetryServerURL = request.TelemetryServerURL
+	}
+
 	nodeConfig.ShhextConfig = params.ShhextConfig{
 		BackupDisabledDataDir:      request.BackupDisabledDataDir,
 		InstallationID:             installationID,

--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -19,6 +19,7 @@ const NameFlag = "name"
 const AddFlag = "add"
 const PortFlag = "port"
 const APIModulesFlag = "api-modules"
+const TelemetryServerURLFlag = "telemetry-server-url"
 
 const RetrieveInterval = 300 * time.Millisecond
 const SendInterval = 1 * time.Second
@@ -35,6 +36,11 @@ var CommonFlags = []cli.Flag{
 		Aliases: []string{"m"},
 		Value:   "waku,wakuext,wakuv2,permissions,eth",
 		Usage:   "API modules to enable",
+	},
+	&cli.StringFlag{
+		Name:    TelemetryServerURLFlag,
+		Aliases: []string{"t"},
+		Usage:   "Telemetry server URL",
 	},
 }
 

--- a/cmd/status-cli/serve.go
+++ b/cmd/status-cli/serve.go
@@ -36,8 +36,9 @@ func serve(cCtx *cli.Context) error {
 	name := cCtx.String(NameFlag)
 	port := cCtx.Int(PortFlag)
 	apiModules := cCtx.String(APIModulesFlag)
+	telemetryUrl := cCtx.String(TelemetryServerURLFlag)
 
-	cli, err := start(cCtx, name, port, apiModules)
+	cli, err := start(cCtx, name, port, apiModules, telemetryUrl)
 	if err != nil {
 		return err
 	}

--- a/cmd/status-cli/simulate.go
+++ b/cmd/status-cli/simulate.go
@@ -37,14 +37,15 @@ func simulate(cCtx *cli.Context) error {
 
 	// Start messengers
 	apiModules := cCtx.String(APIModulesFlag)
+	telemetryUrl := cCtx.String(TelemetryServerURLFlag)
 
-	alice, err := start(cCtx, "Alice", 0, apiModules)
+	alice, err := start(cCtx, "Alice", 0, apiModules, telemetryUrl)
 	if err != nil {
 		return err
 	}
 	defer alice.stop()
 
-	charlie, err := start(cCtx, "Charlie", 0, apiModules)
+	charlie, err := start(cCtx, "Charlie", 0, apiModules, telemetryUrl)
 	if err != nil {
 		return err
 	}

--- a/cmd/status-cli/util.go
+++ b/cmd/status-cli/util.go
@@ -34,7 +34,7 @@ func setupLogger(file string) *zap.Logger {
 	return logutils.ZapLogger()
 }
 
-func start(cCtx *cli.Context, name string, port int, apiModules string) (*StatusCLI, error) {
+func start(cCtx *cli.Context, name string, port int, apiModules string, telemetryUrl string) (*StatusCLI, error) {
 	namedLogger := logger.Named(name)
 	namedLogger.Info("starting messager")
 
@@ -60,6 +60,7 @@ func start(cCtx *cli.Context, name string, port int, apiModules string) (*Status
 			HTTPHost:   "127.0.0.1",
 			HTTPPort:   port,
 		},
+		TelemetryServerURL: telemetryUrl,
 	}
 	_, err = backend.CreateAccountAndLogin(createAccountRequest)
 	if err != nil {

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -138,9 +138,11 @@ func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *server
 			if err != nil {
 				return err
 			}
+			if telemetryServerURL != "" {
+				config.WakuV2Config.TelemetryServerURL = telemetryServerURL
+			}
 		}
-
-		waku2Service, err := b.wakuV2Service(config, telemetryServerURL)
+		waku2Service, err := b.wakuV2Service(config)
 		if err != nil {
 			return err
 		}
@@ -308,7 +310,7 @@ func (b *StatusNode) wakuService(wakuCfg *params.WakuConfig, clusterCfg *params.
 
 }
 
-func (b *StatusNode) wakuV2Service(nodeConfig *params.NodeConfig, telemetryServerURL string) (*wakuv2.Waku, error) {
+func (b *StatusNode) wakuV2Service(nodeConfig *params.NodeConfig) (*wakuv2.Waku, error) {
 	if b.wakuV2Srvc == nil {
 		cfg := &wakuv2.Config{
 			MaxMessageSize:          wakucommon.DefaultMaxMessageSize,
@@ -328,7 +330,7 @@ func (b *StatusNode) wakuV2Service(nodeConfig *params.NodeConfig, telemetryServe
 			AutoUpdate:              nodeConfig.WakuV2Config.AutoUpdate,
 			DefaultShardPubsubTopic: shard.DefaultShardPubsubTopic(),
 			UseShardAsDefaultTopic:  nodeConfig.WakuV2Config.UseShardAsDefaultTopic,
-			TelemetryServerURL:      telemetryServerURL,
+			TelemetryServerURL:      nodeConfig.WakuV2Config.TelemetryServerURL,
 			ClusterID:               nodeConfig.ClusterConfig.ClusterID,
 		}
 

--- a/params/config.go
+++ b/params/config.go
@@ -214,6 +214,8 @@ type WakuV2Config struct {
 	// StoreSeconds indicates the maximum number of seconds before a message is removed from the store
 	StoreSeconds int
 
+	TelemetryServerURL string
+
 	// UseShardAsDefaultTopic indicates whether the default shard should be used instead of the default relay topic
 	UseShardAsDefaultTopic bool
 }

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -66,6 +66,8 @@ type CreateAccount struct {
 	TorrentConfigEnabled *bool
 	TorrentConfigPort    *int
 
+	TelemetryServerURL string `json:"telemetryServerURL"`
+
 	APIConfig *APIConfig `json:"apiConfig"`
 }
 


### PR DESCRIPTION
This commit adds a TelemetryUrl param to request for creating account and to the WakuV2Config. Adds a flag to the cli for passing in the telemetry server url.




