### PR TITLE
chore(tests)_: createCommunityConfigurable creates only one chat

### DIFF
--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -328,27 +328,12 @@ func createCommunityConfigurable(s *suite.Suite, owner *Messenger, permission pr
 	community := response.Communities()[0]
 	s.Require().True(community.Joined())
 	s.Require().True(community.IsControlNode())
+	s.Require().Len(community.Chats(), 1)
 
 	s.Require().Len(response.CommunitiesSettings(), 1)
 	communitySettings := response.CommunitiesSettings()[0]
 	s.Require().Equal(communitySettings.CommunityID, community.IDString())
 	s.Require().Equal(communitySettings.HistoryArchiveSupportEnabled, false)
-
-	orgChat := &protobuf.CommunityChat{
-		Permissions: &protobuf.CommunityPermissions{
-			Access: protobuf.CommunityPermissions_AUTO_ACCEPT,
-		},
-		Identity: &protobuf.ChatIdentity{
-			DisplayName: "status-core",
-			Emoji:       "😎",
-			Description: "status-core community chat",
-		},
-	}
-
-	response, err = owner.CreateCommunityChat(community.ID(), orgChat)
-	s.Require().NoError(err)
-	s.Require().NotNil(response)
-	s.Require().Len(response.Chats(), 1)
 
 	return community, response.Chats()[0]
 }

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -2172,7 +2172,7 @@ func (s *MessengerCommunitiesSuite) TestLeaveAndRejoinCommunity() {
 			numberInactiveChats++
 		}
 	}
-	s.Require().Equal(3, numberInactiveChats)
+	s.Require().Equal(2, numberInactiveChats)
 
 	// alice can rejoin
 	s.joinCommunity(community, s.owner, s.alice)

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -2030,7 +2030,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestReevaluateMemberPermissi
 
 	community, err := s.owner.communitiesManager.GetByID(community.ID())
 	s.Require().NoError(err)
-	s.Require().Len(community.Chats(), 2)
+	s.Require().Len(community.Chats(), 1)
 
 	requestToJoin := &communities.RequestToJoin{
 		Clock:       uint64(time.Now().Unix()),
@@ -2070,7 +2070,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestReevaluateMemberPermissi
 
 	s.Require().Equal(community.MembersCount(), keysCount+1) // 1 is owner
 
-	chatsCount := 8 // in total will be 10, 2 channels were created during creating the community
+	chatsCount := 9 // in total will be 10, 1 channel were created during creating the community
 
 	for i := 0; i < chatsCount; i++ {
 		newChat := &protobuf.CommunityChat{
@@ -2088,7 +2088,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestReevaluateMemberPermissi
 		s.Require().NoError(err)
 	}
 
-	s.Require().Len(community.Chats(), chatsCount+2) // 2 chats were created during community creation
+	s.Require().Len(community.Chats(), chatsCount+1) // 1 chat were created during community creation
 
 	err = s.owner.communitiesManager.SaveCommunity(community)
 	s.Require().NoError(err)


### PR DESCRIPTION
Fix: `createCommunityConfigurable` creates only one chat

`createCommunity` util fn uses `createCommunityConfigurable` which will return `community + chat A` and one more `chat B`, but `community` will be outdated and contains only 1 `chat`.

This leads to confusion in tests when we advertise outdated `community` with `chat A` only and expect the receiver will have `chat B`, returned from `createCommunity` util

Closes # https://github.com/status-im/status-go/issues/5202
