### PR TITLE
fix_: re-trying http requests up to the predefined max retries

### DIFF
--- a/services/wallet/thirdparty/coingecko/client_test.go
+++ b/services/wallet/thirdparty/coingecko/client_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,9 +70,9 @@ func TestGetTokensSuccess(t *testing.T) {
 	defer stop()
 
 	geckoClient := &Client{
-		client:    srv.Client(),
-		tokens:    make(map[string][]GeckoToken),
-		tokensURL: srv.URL,
+		httpClient: thirdparty.NewHTTPClient(),
+		tokens:     make(map[string][]GeckoToken),
+		tokensURL:  srv.URL,
 	}
 
 	tokenMap, err := geckoClient.getTokens()
@@ -150,9 +152,9 @@ func TestGetTokensEthPlatform(t *testing.T) {
 	defer stop()
 
 	geckoClient := &Client{
-		client:    srv.Client(),
-		tokens:    make(map[string][]GeckoToken),
-		tokensURL: srv.URL,
+		httpClient: thirdparty.NewHTTPClient(),
+		tokens:     make(map[string][]GeckoToken),
+		tokensURL:  srv.URL,
 	}
 
 	tokenMap, err := geckoClient.getTokens()
@@ -166,9 +168,9 @@ func TestGetTokensFailure(t *testing.T) {
 	defer stop()
 
 	geckoClient := &Client{
-		client:    srv.Client(),
-		tokens:    make(map[string][]GeckoToken),
-		tokensURL: srv.URL,
+		httpClient: thirdparty.NewHTTPClient(),
+		tokens:     make(map[string][]GeckoToken),
+		tokensURL:  srv.URL,
 	}
 
 	_, err := geckoClient.getTokens()

--- a/services/wallet/thirdparty/http_client.go
+++ b/services/wallet/thirdparty/http_client.go
@@ -11,6 +11,7 @@ import (
 )
 
 const requestTimeout = 5 * time.Second
+const maxNumOfRequestRetries = 5
 
 type HTTPClient struct {
 	client *http.Client
@@ -34,7 +35,14 @@ func (c *HTTPClient) DoGetRequest(ctx context.Context, url string, params netUrl
 		return nil, err
 	}
 
-	resp, err := c.client.Do(req)
+	var resp *http.Response
+	for i := 0; i < maxNumOfRequestRetries; i++ {
+		resp, err = c.client.Do(req)
+		if err == nil || i == maxNumOfRequestRetries-1 {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit should fix the issue with Cryptocompare and CoinGecko providers down. Often happens that the first request fails and because of that:
- the Router cannot complete calculation successfully
- some tests are failing
- some users very often see a red banner line saying the providers are down