### PR TITLE
fix(waku)_: only use requestId in store query if defined

### DIFF
--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1061,7 +1061,9 @@ func (w *Waku) Send(pubsubTopic string, msg *pb.WakuMessage) ([]byte, error) {
 
 func (w *Waku) query(ctx context.Context, peerID peer.ID, pubsubTopic string, topics []common.TopicType, from uint64, to uint64, requestID []byte, opts []legacy_store.HistoryRequestOption) (*legacy_store.Result, error) {
 
-	opts = append(opts, legacy_store.WithRequestID(requestID))
+	if len(requestID) != 0 {
+		opts = append(opts, legacy_store.WithRequestID(requestID))
+	}
 
 	strTopics := make([]string, len(topics))
 	for i, t := range topics {

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -183,7 +183,16 @@ func TestBasicWakuV2(t *testing.T) {
 		b.InitialInterval = 500 * time.Millisecond
 	}
 	err = tt.RetryWithBackOff(func() error {
-		storeResult, err := w.query(context.Background(), storeNode.PeerID, relay.DefaultWakuTopic, []common.TopicType{contentTopic}, uint64(timestampInSeconds-int64(marginInSeconds)), uint64(timestampInSeconds+int64(marginInSeconds)), []byte{}, []legacy_store.HistoryRequestOption{})
+		storeResult, err := w.query(
+			context.Background(),
+			storeNode.PeerID,
+			relay.DefaultWakuTopic,
+			[]common.TopicType{contentTopic},
+			uint64(timestampInSeconds-int64(marginInSeconds)),
+			uint64(timestampInSeconds+int64(marginInSeconds)),
+			[]byte{},
+			[]legacy_store.HistoryRequestOption{},
+		)
 		if err != nil || len(storeResult.Messages) == 0 {
 			// in case of failure extend timestamp margin up to 40secs
 			if marginInSeconds < 40 {
@@ -461,7 +470,16 @@ func TestWakuV2Store(t *testing.T) {
 	marginInSeconds := 5
 
 	// Query the second node's store for the message
-	storeResult, err := w1.query(context.Background(), w2.node.Host().ID(), relay.DefaultWakuTopic, []common.TopicType{contentTopic}, uint64(timestampInSeconds-int64(marginInSeconds)), uint64(timestampInSeconds+int64(marginInSeconds)), []byte{}, []legacy_store.HistoryRequestOption{})
+	storeResult, err := w1.query(
+		context.Background(),
+		w2.node.Host().ID(),
+		relay.DefaultWakuTopic,
+		[]common.TopicType{contentTopic},
+		uint64(timestampInSeconds-int64(marginInSeconds)),
+		uint64(timestampInSeconds+int64(marginInSeconds)),
+		[]byte{},
+		[]legacy_store.HistoryRequestOption{},
+	)
 	require.NoError(t, err)
 	require.True(t, len(storeResult.Messages) > 0, "no messages received from store node")
 }


### PR DESCRIPTION
only use requestId param in store query if defined 

If not defined, default is used - which is automatically generated requestId (https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/legacy_store/waku_store_client.go#L196)

I also reformatted the long `query` calls to be more readable


