### PR TITLE
feat_: hash based query for outgoing messages.

### DIFF
--- a/api/messenger_raw_message_resend_test.go
+++ b/api/messenger_raw_message_resend_test.go
@@ -232,7 +232,7 @@ func (s *MessengerRawMessageResendTest) TestMessageResend() {
 		rawMessage, err := s.bobMessenger.RawMessageByID(ids[0])
 		s.Require().NoError(err)
 		s.Require().NotNil(rawMessage)
-		if !rawMessage.Sent {
+		if rawMessage.SendCount < 2 {
 			return errors.New("message ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN was not resent yet")
 		}
 		return nil

--- a/api/messenger_raw_message_resend_test.go
+++ b/api/messenger_raw_message_resend_test.go
@@ -227,7 +227,7 @@ func (s *MessengerRawMessageResendTest) TestMessageResend() {
 	rawMessage, err := s.bobMessenger.RawMessageByID(ids[0])
 	s.Require().NoError(err)
 	s.Require().NotNil(rawMessage)
-	s.Require().NoError(s.bobMessenger.UpdateRawMessageSent(rawMessage.ID, false, 0))
+	s.Require().NoError(s.bobMessenger.UpdateRawMessageSent(rawMessage.ID, false))
 	err = tt.RetryWithBackOff(func() error {
 		rawMessage, err := s.bobMessenger.RawMessageByID(ids[0])
 		s.Require().NoError(err)

--- a/api/messenger_raw_message_resend_test.go
+++ b/api/messenger_raw_message_resend_test.go
@@ -228,6 +228,7 @@ func (s *MessengerRawMessageResendTest) TestMessageResend() {
 	s.Require().NoError(err)
 	s.Require().NotNil(rawMessage)
 	s.Require().NoError(s.bobMessenger.UpdateRawMessageSent(rawMessage.ID, false))
+	s.Require().NoError(s.bobMessenger.UpdateRawMessageLastSent(rawMessage.ID, 0))
 	err = tt.RetryWithBackOff(func() error {
 		rawMessage, err := s.bobMessenger.RawMessageByID(ids[0])
 		s.Require().NoError(err)

--- a/api/messenger_raw_message_resend_test.go
+++ b/api/messenger_raw_message_resend_test.go
@@ -211,7 +211,7 @@ func (s *MessengerRawMessageResendTest) TestMessageSent() {
 		rawMessage, err := s.bobMessenger.RawMessageByID(ids[0])
 		s.Require().NoError(err)
 		s.Require().NotNil(rawMessage)
-		if rawMessage.Sent {
+		if rawMessage.SendCount > 0 {
 			return nil
 		}
 		return errors.New("raw message should be sent finally")

--- a/eth-node/bridge/geth/waku.go
+++ b/eth-node/bridge/geth/waku.go
@@ -317,3 +317,6 @@ func (w *wakuFilterWrapper) ID() string {
 
 func (w *GethWakuWrapper) ConfirmMessageDelivered(hashes []common.Hash) {
 }
+
+func (w *GethWakuWrapper) SetStorePeerID(peerID peer.ID) {
+}

--- a/eth-node/bridge/geth/waku.go
+++ b/eth-node/bridge/geth/waku.go
@@ -314,3 +314,6 @@ func GetWakuFilterFrom(f types.Filter) *wakucommon.Filter {
 func (w *wakuFilterWrapper) ID() string {
 	return w.id
 }
+
+func (w *GethWakuWrapper) ConfirmMessageDelivered(hashes []common.Hash) {
+}

--- a/eth-node/bridge/geth/wakuv2.go
+++ b/eth-node/bridge/geth/wakuv2.go
@@ -333,3 +333,7 @@ func GetWakuV2FilterFrom(f types.Filter) *wakucommon.Filter {
 func (w *wakuV2FilterWrapper) ID() string {
 	return w.id
 }
+
+func (w *gethWakuV2Wrapper) ConfirmMessageDelivered(hashes []common.Hash) {
+	w.waku.ConfirmMessageDelivered(hashes)
+}

--- a/eth-node/bridge/geth/wakuv2.go
+++ b/eth-node/bridge/geth/wakuv2.go
@@ -337,3 +337,7 @@ func (w *wakuV2FilterWrapper) ID() string {
 func (w *gethWakuV2Wrapper) ConfirmMessageDelivered(hashes []common.Hash) {
 	w.waku.ConfirmMessageDelivered(hashes)
 }
+
+func (w *gethWakuV2Wrapper) SetStorePeerID(peerID peer.ID) {
+	w.waku.SetStorePeerID(peerID)
+}

--- a/eth-node/types/waku.go
+++ b/eth-node/types/waku.go
@@ -181,4 +181,7 @@ type Waku interface {
 
 	// ConfirmMessageDelivered updates a message has been delivered in waku
 	ConfirmMessageDelivered(hash []common.Hash)
+
+	// SetStorePeerID updates the peer id of store node
+	SetStorePeerID(peerID peer.ID)
 }

--- a/eth-node/types/waku.go
+++ b/eth-node/types/waku.go
@@ -178,4 +178,7 @@ type Waku interface {
 
 	// ClearEnvelopesCache clears waku envelopes cache
 	ClearEnvelopesCache()
+
+	// ConfirmMessageDelivered updates a message has been delivered in waku
+	ConfirmMessageDelivered(hash []common.Hash)
 }

--- a/protocol/common/raw_messages_persistence.go
+++ b/protocol/common/raw_messages_persistence.go
@@ -488,7 +488,7 @@ func (db *RawMessagesPersistence) RemoveMessageSegmentsCompletedOlderThan(timest
 	return err
 }
 
-func (db RawMessagesPersistence) UpdateRawMessageSent(id string, sent bool, lastSent uint64) error {
-	_, err := db.db.Exec("UPDATE raw_messages SET sent = ?, last_sent = ? WHERE id = ?", sent, lastSent, id)
+func (db RawMessagesPersistence) UpdateRawMessageSent(id string, sent bool) error {
+	_, err := db.db.Exec("UPDATE raw_messages SET sent = ? WHERE id = ?", sent, id)
 	return err
 }

--- a/protocol/common/raw_messages_persistence.go
+++ b/protocol/common/raw_messages_persistence.go
@@ -492,3 +492,8 @@ func (db RawMessagesPersistence) UpdateRawMessageSent(id string, sent bool) erro
 	_, err := db.db.Exec("UPDATE raw_messages SET sent = ? WHERE id = ?", sent, id)
 	return err
 }
+
+func (db RawMessagesPersistence) UpdateRawMessageLastSent(id string, lastSent uint64) error {
+	_, err := db.db.Exec("UPDATE raw_messages SET last_sent = ? WHERE id = ?", lastSent, id)
+	return err
+}

--- a/protocol/common/raw_messages_persistence_test.go
+++ b/protocol/common/raw_messages_persistence_test.go
@@ -73,7 +73,7 @@ func TestUpdateRawMessageSent(t *testing.T) {
 	require.True(t, rawMessage.Sent)
 	require.Greater(t, rawMessage.LastSent, uint64(0))
 
-	err = p.UpdateRawMessageSent(rawMessageID, false, 0)
+	err = p.UpdateRawMessageSent(rawMessageID, false)
 	require.NoError(t, err)
 
 	m, err := p.RawMessageByID(rawMessageID)

--- a/protocol/common/raw_messages_persistence_test.go
+++ b/protocol/common/raw_messages_persistence_test.go
@@ -54,18 +54,7 @@ func TestUpdateRawMessageSent(t *testing.T) {
 	require.NoError(t, err)
 
 	rawMessageID := "1"
-	err = p.SaveRawMessage(&RawMessage{
-		ID:                    rawMessageID,
-		ResendType:            ResendTypeRawMessage,
-		LocalChatID:           "",
-		CommunityID:           []byte("c1"),
-		CommunityKeyExMsgType: KeyExMsgRekey,
-		Sender:                pk,
-		ResendMethod:          ResendMethodSendPrivate,
-		Recipients:            []*ecdsa.PublicKey{pk.Public().(*ecdsa.PublicKey)},
-		Sent:                  true,
-		LastSent:              uint64(time.Now().UnixNano() / int64(time.Millisecond)),
-	})
+	err = p.SaveRawMessage(buildRawMessage(rawMessageID, pk))
 	require.NoError(t, err)
 
 	rawMessage, err := p.RawMessageByID(rawMessageID)
@@ -79,7 +68,6 @@ func TestUpdateRawMessageSent(t *testing.T) {
 	m, err := p.RawMessageByID(rawMessageID)
 	require.NoError(t, err)
 	require.False(t, m.Sent)
-	require.Equal(t, m.LastSent, uint64(0))
 }
 
 func TestUpdateRawMessageLastSent(t *testing.T) {
@@ -92,18 +80,7 @@ func TestUpdateRawMessageLastSent(t *testing.T) {
 	require.NoError(t, err)
 
 	rawMessageID := "1"
-	err = p.SaveRawMessage(&RawMessage{
-		ID:                    rawMessageID,
-		ResendType:            ResendTypeRawMessage,
-		LocalChatID:           "",
-		CommunityID:           []byte("c1"),
-		CommunityKeyExMsgType: KeyExMsgRekey,
-		Sender:                pk,
-		ResendMethod:          ResendMethodSendPrivate,
-		Recipients:            []*ecdsa.PublicKey{pk.Public().(*ecdsa.PublicKey)},
-		Sent:                  true,
-		LastSent:              uint64(time.Now().UnixNano() / int64(time.Millisecond)),
-	})
+	err = p.SaveRawMessage(buildRawMessage(rawMessageID, pk))
 	require.NoError(t, err)
 
 	rawMessage, err := p.RawMessageByID(rawMessageID)
@@ -117,4 +94,19 @@ func TestUpdateRawMessageLastSent(t *testing.T) {
 	m, err := p.RawMessageByID(rawMessageID)
 	require.NoError(t, err)
 	require.Equal(t, m.LastSent, uint64(0))
+}
+
+func buildRawMessage(rawMessageID string, pk *ecdsa.PrivateKey) *RawMessage {
+	return &RawMessage{
+		ID:                    rawMessageID,
+		ResendType:            ResendTypeRawMessage,
+		LocalChatID:           "",
+		CommunityID:           []byte("c1"),
+		CommunityKeyExMsgType: KeyExMsgRekey,
+		Sender:                pk,
+		ResendMethod:          ResendMethodSendPrivate,
+		Recipients:            []*ecdsa.PublicKey{pk.Public().(*ecdsa.PublicKey)},
+		Sent:                  true,
+		LastSent:              uint64(time.Now().UnixNano() / int64(time.Millisecond)),
+	}
 }

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -426,6 +426,11 @@ func (m *Messenger) connectToMailserver(ms mailservers.Mailserver) error {
 			m.logger.Info("mailserver available", zap.String("address", m.mailserverCycle.activeMailserver.UniqueID()))
 			m.EmitMailserverAvailable()
 			signal.SendMailserverAvailable(m.mailserverCycle.activeMailserver.Address, m.mailserverCycle.activeMailserver.ID)
+			peerID, err := m.mailserverCycle.activeMailserver.PeerID()
+			if err != nil {
+				m.logger.Error("could not decode the peer id of mailserver", zap.Error(err))
+			}
+			m.transport.SetStorePeerID(peerID)
 
 			// Query mailserver
 			if m.config.codeControlFlags.AutoRequestHistoricMessages {

--- a/protocol/messenger_messages_tracking_test.go
+++ b/protocol/messenger_messages_tracking_test.go
@@ -172,7 +172,7 @@ func (s *MessengerMessagesTrackingSuite) testMessageMarkedAsSent(textSize int) {
 	// Message should be marked as sent eventually
 	err = tt.RetryWithBackOff(func() error {
 		rawMessage, err = s.bob.persistence.RawMessageByID(inputMessage.ID)
-		if err != nil || !rawMessage.Sent {
+		if err != nil || rawMessage.SendCount < 1 {
 			return errors.New("message not marked as sent")
 		}
 		return nil

--- a/protocol/messenger_peers.go
+++ b/protocol/messenger_peers.go
@@ -13,7 +13,7 @@ func (m *Messenger) AddStorePeer(address string) (peer.ID, error) {
 }
 
 func (m *Messenger) AddRelayPeer(address string) (peer.ID, error) {
-	return m.transport.AddStorePeer(address)
+	return m.transport.AddRelayPeer(address)
 }
 
 func (m *Messenger) DialPeer(address string) error {

--- a/protocol/messenger_peersyncing.go
+++ b/protocol/messenger_peersyncing.go
@@ -43,6 +43,8 @@ func (m *Messenger) markDeliveredMessages(acks [][]byte) {
 			m.logger.Debug("Can't set message status as delivered", zap.Error(err))
 		}
 
+		m.transport.ConfirmMessageDelivered(messageID)
+
 		//send signal to client that message status updated
 		if m.config.messengerSignalsHandler != nil {
 			message, err := m.persistence.MessageByID(messageID)

--- a/protocol/messenger_peersyncing.go
+++ b/protocol/messenger_peersyncing.go
@@ -43,7 +43,6 @@ func (m *Messenger) markDeliveredMessages(acks [][]byte) {
 			m.logger.Debug("Can't set message status as delivered", zap.Error(err))
 		}
 
-		m.logger.Debug("got datasync acknowledge for message", zap.String("ack", hex.EncodeToString(ack)), zap.String("messageID", messageID))
 		m.transport.ConfirmMessageDelivered(messageID)
 
 		//send signal to client that message status updated

--- a/protocol/messenger_peersyncing.go
+++ b/protocol/messenger_peersyncing.go
@@ -43,6 +43,7 @@ func (m *Messenger) markDeliveredMessages(acks [][]byte) {
 			m.logger.Debug("Can't set message status as delivered", zap.Error(err))
 		}
 
+		m.logger.Debug("got datasync acknowledge for message", zap.String("ack", hex.EncodeToString(ack)), zap.String("messageID", messageID))
 		m.transport.ConfirmMessageDelivered(messageID)
 
 		//send signal to client that message status updated

--- a/protocol/messenger_peersyncing.go
+++ b/protocol/messenger_peersyncing.go
@@ -38,9 +38,16 @@ func (m *Messenger) markDeliveredMessages(acks [][]byte) {
 		messageID := messageIDBytes.String()
 		//mark messages as delivered
 
+		m.logger.Debug("got datasync acknowledge for message", zap.String("ack", hex.EncodeToString(ack)), zap.String("messageID", messageID))
+
 		err = m.UpdateMessageOutgoingStatus(messageID, common.OutgoingStatusDelivered)
 		if err != nil {
 			m.logger.Debug("Can't set message status as delivered", zap.Error(err))
+		}
+
+		err = m.UpdateRawMessageSent(messageID, true)
+		if err != nil {
+			m.logger.Debug("can't set raw message as sent", zap.Error(err))
 		}
 
 		m.transport.ConfirmMessageDelivered(messageID)

--- a/protocol/messenger_raw_message_resend.go
+++ b/protocol/messenger_raw_message_resend.go
@@ -203,3 +203,7 @@ func (m *Messenger) RawMessageByID(id string) (*common.RawMessage, error) {
 func (m *Messenger) UpdateRawMessageSent(id string, sent bool) error {
 	return m.persistence.UpdateRawMessageSent(id, sent)
 }
+
+func (m *Messenger) UpdateRawMessageLastSent(id string, lastSent uint64) error {
+	return m.persistence.UpdateRawMessageLastSent(id, lastSent)
+}

--- a/protocol/messenger_raw_message_resend.go
+++ b/protocol/messenger_raw_message_resend.go
@@ -200,6 +200,6 @@ func (m *Messenger) RawMessageByID(id string) (*common.RawMessage, error) {
 	return m.persistence.RawMessageByID(id)
 }
 
-func (m *Messenger) UpdateRawMessageSent(id string, sent bool, lastSent uint64) error {
-	return m.persistence.UpdateRawMessageSent(id, sent, lastSent)
+func (m *Messenger) UpdateRawMessageSent(id string, sent bool) error {
+	return m.persistence.UpdateRawMessageSent(id, sent)
 }

--- a/protocol/transport/envelopes_monitor.go
+++ b/protocol/transport/envelopes_monitor.go
@@ -136,7 +136,7 @@ func (m *EnvelopesMonitor) Add(messageIDs [][]byte, envelopeHashes []types.Hash,
 	defer m.mu.Unlock()
 
 	for _, messageID := range messageIDs {
-		m.messageEnvelopeHashes[string(messageID)] = envelopeHashes
+		m.messageEnvelopeHashes[types.HexBytes(messageID).String()] = envelopeHashes
 	}
 
 	for i, envelopeHash := range envelopeHashes {
@@ -399,7 +399,7 @@ func (m *EnvelopesMonitor) processMessageIDs(messageIDs [][]byte) {
 	sentMessageIDs := make([][]byte, 0, len(messageIDs))
 
 	for _, messageID := range messageIDs {
-		hashes, ok := m.messageEnvelopeHashes[string(messageID)]
+		hashes, ok := m.messageEnvelopeHashes[types.HexBytes(messageID).String()]
 		if !ok {
 			continue
 		}
@@ -432,6 +432,6 @@ func (m *EnvelopesMonitor) clearMessageState(envelopeID types.Hash) {
 	}
 	delete(m.envelopes, envelopeID)
 	for _, messageID := range envelope.messageIDs {
-		delete(m.messageEnvelopeHashes, string(messageID))
+		delete(m.messageEnvelopeHashes, types.HexBytes(messageID).String())
 	}
 }

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -719,7 +719,7 @@ func (t *Transport) RemovePubsubTopicKey(topic string) error {
 }
 
 func (t *Transport) ConfirmMessageDelivered(messageID string) {
-	hashes, ok := t.envelopesMonitor.identifierHashes[messageID]
+	hashes, ok := t.envelopesMonitor.messageEnvelopeHashes[messageID]
 	if !ok {
 		return
 	}

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -732,3 +732,7 @@ func (t *Transport) ConfirmMessageDelivered(messageID string) {
 	}
 	t.waku.ConfirmMessageDelivered(commHashes)
 }
+
+func (t *Transport) SetStorePeerID(peerID peer.ID) {
+	t.waku.SetStorePeerID(peerID)
+}

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -717,3 +717,15 @@ func (t *Transport) RemovePubsubTopicKey(topic string) error {
 	}
 	return nil
 }
+
+func (t *Transport) ConfirmMessageDelivered(messageID string) {
+	hashes, ok := t.envelopesMonitor.identifierHashes[messageID]
+	if !ok {
+		return
+	}
+	commHashes := make([]common.Hash, len(hashes))
+	for i, h := range hashes {
+		commHashes[i] = common.BytesToHash(h[:])
+	}
+	t.waku.ConfirmMessageDelivered(commHashes)
+}

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -719,6 +719,9 @@ func (t *Transport) RemovePubsubTopicKey(topic string) error {
 }
 
 func (t *Transport) ConfirmMessageDelivered(messageID string) {
+	if t.envelopesMonitor == nil {
+		return
+	}
 	hashes, ok := t.envelopesMonitor.messageEnvelopeHashes[messageID]
 	if !ok {
 		return

--- a/wakuv2/common/message.go
+++ b/wakuv2/common/message.go
@@ -22,6 +22,7 @@ type MessageType int
 const (
 	RelayedMessageType MessageType = iota
 	StoreMessageType
+	SendMessageType
 )
 
 // MessageParams specifies the exact way a message should be wrapped
@@ -46,7 +47,7 @@ type ReceivedMessage struct {
 	Padding   []byte
 	Signature []byte
 
-	Sent uint32           // Time when the message was posted into the network
+	Sent uint32           // Time when the message was posted into the network in seconds
 	Src  *ecdsa.PublicKey // Message recipient (identity used to decode the message)
 	Dst  *ecdsa.PublicKey // Message recipient (identity used to decode the message)
 

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -83,7 +83,7 @@ const requestTimeout = 30 * time.Second
 const bootnodesQueryBackoffMs = 200
 const bootnodesMaxRetries = 7
 const cacheTTL = 20 * time.Minute
-const maxHashQueryLength = 20
+const maxHashQueryLength = 100
 const hashQueryInterval = 5 * time.Second
 const messageSentPeriod = 5 // in seconds
 

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1041,6 +1041,21 @@ func (w *Waku) checkIfMessagesStored() {
 	}
 }
 
+func (w *Waku) ConfirmMessageDelivered(hashes []gethcommon.Hash) {
+	w.sendMsgIDsMu.Lock()
+	defer w.sendMsgIDsMu.Unlock()
+	for pubsubTopic, subMsgs := range w.sendMsgIDs {
+		for _, hash := range hashes {
+			delete(subMsgs, hash)
+			if len(subMsgs) == 0 {
+				delete(w.sendMsgIDs, pubsubTopic)
+			} else {
+				w.sendMsgIDs[pubsubTopic] = subMsgs
+			}
+		}
+	}
+}
+
 type publishFn = func(envelope *protocol.Envelope, logger *zap.Logger) error
 
 func (w *Waku) publishEnvelope(envelope *protocol.Envelope, publishFn publishFn, logger *zap.Logger) {

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1014,10 +1014,10 @@ func (w *Waku) checkIfMessagesStored() {
 			}
 			w.sendMsgIDsMu.Unlock()
 
-			pubsubProcessedMessages := make([][]gethcommon.Hash, len(pubsubMessageIds))
+			pubsubProcessedMessages := make([][]gethcommon.Hash, len(pubsubTopics))
 			for i, pubsubTopic := range pubsubTopics {
 				processedMessages := w.messageHashBasedQuery(w.ctx, pubsubMessageIds[i], pubsubTopic)
-				pubsubProcessedMessages = append(pubsubProcessedMessages, processedMessages)
+				pubsubProcessedMessages[i] = processedMessages
 			}
 
 			w.sendMsgIDsMu.Lock()
@@ -1035,6 +1035,7 @@ func (w *Waku) checkIfMessagesStored() {
 					}
 				}
 			}
+			w.logger.Debug("messages for next store hash query", zap.Any("messageIds", w.sendMsgIDs))
 			w.sendMsgIDsMu.Unlock()
 
 		}

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -991,8 +991,8 @@ func (w *Waku) checkIfMessagesStored() {
 			w.logger.Debug("stop the look for message stored check")
 			return
 		case <-ticker.C:
-			w.logger.Debug("running loop for messages stored check")
 			w.sendMsgIDsMu.Lock()
+			w.logger.Debug("running loop for messages stored check", zap.Any("messageIds", w.sendMsgIDs))
 			pubsubTopics := make([]string, 0, len(w.sendMsgIDs))
 			pubsubMessageIds := make([][]gethcommon.Hash, 0, len(w.sendMsgIDs))
 			for pubsubTopic, subMsgs := range w.sendMsgIDs {

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1113,19 +1113,8 @@ func (w *Waku) Send(pubsubTopic string, msg *pb.WakuMessage) ([]byte, error) {
 func (w *Waku) messageHashBasedQuery(ctx context.Context, hashes []gethcommon.Hash, pubsubTopic string) []gethcommon.Hash {
 	selectedPeer := w.storePeerID
 	if selectedPeer == "" {
-		selectedPeers, err := w.node.PeerManager().SelectPeers(
-			peermanager.PeerSelectionCriteria{
-				SelectionType: peermanager.Automatic,
-				Proto:         store.StoreQueryID_v300,
-				PubsubTopics:  []string{pubsubTopic},
-				Ctx:           ctx,
-			},
-		)
-		if err != nil {
-			w.logger.Error("could not select peers", zap.Error(err))
-			return []gethcommon.Hash{}
-		}
-		selectedPeer = selectedPeers[0]
+		w.logger.Error("no store peer id available", zap.String("pubsubTopic", pubsubTopic))
+		return []gethcommon.Hash{}
 	}
 
 	var opts []store.RequestOption

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1516,7 +1516,8 @@ func (w *Waku) processMessage(e *common.ReceivedMessage) {
 		w.storeMsgIDsMu.Unlock()
 	}
 
-	if e.MsgType == common.SendMessageType && !(*e.Envelope.Message().Ephemeral) {
+	ephemeral := e.Envelope.Message().Ephemeral
+	if e.MsgType == common.SendMessageType && (ephemeral == nil || !*ephemeral) {
 		w.sendMsgIDsMu.Lock()
 		subMsgs, ok := w.sendMsgIDs[e.PubsubTopic]
 		if !ok {

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1057,6 +1057,10 @@ func (w *Waku) ConfirmMessageDelivered(hashes []gethcommon.Hash) {
 	}
 }
 
+func (w *Waku) SetStorePeerID(peerID peer.ID) {
+	w.storePeerID = peerID
+}
+
 type publishFn = func(envelope *protocol.Envelope, logger *zap.Logger) error
 
 func (w *Waku) publishEnvelope(envelope *protocol.Envelope, publishFn publishFn, logger *zap.Logger) {

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cenkalti/backoff/v3"
 
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	ethdnsdisc "github.com/ethereum/go-ethereum/p2p/dnsdisc"
@@ -536,4 +537,62 @@ func waitForEnvelope(t *testing.T, contentTopic string, envCh chan common.Envelo
 			return
 		}
 	}
+}
+
+func TestConfirmMessageDelivered(t *testing.T) {
+	aliceConfig := &Config{}
+	aliceNode, err := New(nil, "", aliceConfig, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, aliceNode.Start())
+
+	bobConfig := &Config{}
+	bobNode, err := New(nil, "", bobConfig, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, bobNode.Start())
+
+	addrs := aliceNode.ListenAddresses()
+	require.Greater(t, len(addrs), 0)
+	_, err = bobNode.AddRelayPeer(addrs[0])
+	require.NoError(t, err)
+	err = bobNode.DialPeer(addrs[0])
+	require.NoError(t, err)
+
+	filter := &common.Filter{
+		Messages:      common.NewMemoryMessageStore(),
+		ContentTopics: common.NewTopicSetFromBytes([][]byte{[]byte{1, 2, 3, 4}}),
+	}
+
+	_, err = aliceNode.Subscribe(filter)
+	require.NoError(t, err)
+
+	msgTimestamp := aliceNode.timestamp()
+	contentTopic := maps.Keys(filter.ContentTopics)[0]
+
+	_, err = aliceNode.Send(relay.DefaultWakuTopic, &pb.WakuMessage{
+		Payload:      []byte{1, 2, 3, 4, 5},
+		ContentTopic: contentTopic.ContentTopic(),
+		Version:      proto.Uint32(0),
+		Timestamp:    &msgTimestamp,
+		Ephemeral:    proto.Bool(false),
+	})
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	messages := filter.Retrieve()
+	require.Len(t, messages, 1)
+
+	require.Len(t, aliceNode.sendMsgIDs, 1)
+	for _, msgs := range aliceNode.sendMsgIDs {
+		require.Len(t, msgs, 1)
+		for hash := range msgs {
+			require.Equal(t, hash, messages[0].Hash())
+		}
+	}
+
+	aliceNode.ConfirmMessageDelivered([]ethcommon.Hash{messages[0].Hash()})
+	require.Len(t, aliceNode.sendMsgIDs, 0)
+
+	require.NoError(t, aliceNode.Stop())
+	require.NoError(t, bobNode.Stop())
 }

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
 	"github.com/waku-org/go-waku/waku/v2/protocol/legacy_store"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"github.com/waku-org/go-waku/waku/v2/protocol/subscription"
 
 	"github.com/status-im/status-go/appdatabase"


### PR DESCRIPTION
For outgoing messages, only mark it as it sent after successfully found in store node, the messages are not found will be marked as expired and resend.

Important changes:
- [x] find outgoing messages which were sent 5s ago, query the store node with the hashes of the messages
- [x] message found will trigger `EventEnvelopeSent`, messages missed will trigger `EventEnvelopeExpired`

Relates to https://github.com/status-im/status-go/issues/5234
