### PR TITLE
fix(login)_: Locally cache communities outside chat loop

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1724,6 +1724,8 @@ func (m *Messenger) Init() error {
 	if err != nil {
 		return err
 	}
+
+	communityInfo := make(map[string]*communities.Community)
 	for _, chat := range chats {
 		if err := chat.Validate(); err != nil {
 			logger.Warn("failed to validate chat", zap.Error(err))
@@ -1740,20 +1742,13 @@ func (m *Messenger) Init() error {
 			continue
 		}
 
-		communityInfo := make(map[string]*communities.Community)
-
 		switch chat.ChatType {
 		case ChatTypePublic, ChatTypeProfile:
 			filtersToInit = append(filtersToInit, transport.FiltersToInitialize{ChatID: chat.ID})
 		case ChatTypeCommunityChat:
-			communityID, err := hexutil.Decode(chat.CommunityID)
-			if err != nil {
-				return err
-			}
-
 			community, ok := communityInfo[chat.CommunityID]
 			if !ok {
-				community, err = m.communitiesManager.GetByID(communityID)
+				community, err = m.communitiesManager.GetByIDString(chat.CommunityID)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Mitigates https://github.com/status-im/status-mobile/issues/20059

### Summary

This PR mitigates the slow login on mobile devices for users with many chats. For example, users in the Status community have at least 119 chats as of now. Mobile PR https://github.com/status-im/status-mobile/pull/20164

### Details

For each community chat we were calling the expensive `communitiesManager.GetByID` at least twice. On an Android Galaxy A71, a single call takes ~120ms. These calls pile up and a single Status community can take ~14s to be processed during login!

Because `GetByID` calls dominated the total time to login (up to 90%), by moving the map of communities (the local cache) outside the loop, we see a reduction of ~40% in login time for a user who has joined the Status community (disregarding other factors).

The other calls to `GetByID` are derived from calling `messenger.initChatFirstMessageTimestamp`. These are harder to solve because we can't safely cache the community as it is mutated on every iteration. We decided the best would be to process chats outside the messenger initialization flow in a follow-up PR, thus preventing login times from scaling up linearly with the number of chats.
