### PR TITLE
fix_: flaky testReevaluateMemberPrivilegedRoleInClosedCommunity

### DIFF
--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -1833,6 +1833,13 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testReevaluateMemberPrivileg
 		PermissionID: tokenMemberPermission.Id,
 	}
 
+	waitOnReevaluation := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
+		if sub.Community == nil {
+			return false
+		}
+		return !checkRoleBasedOnThePermissionType(permissionType, &s.alice.identity.PublicKey, sub.Community)
+	})
+
 	response, err = s.owner.DeleteCommunityTokenPermission(deleteMemberTokenPermission)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
@@ -1842,13 +1849,6 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testReevaluateMemberPrivileg
 	community, err = s.owner.communitiesManager.GetByID(community.ID())
 	s.Require().NoError(err)
 	s.Require().Len(response.Communities()[0].TokenPermissions(), 0)
-
-	waitOnReevaluation := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
-		if sub.Community == nil {
-			return false
-		}
-		return !checkRoleBasedOnThePermissionType(permissionType, &s.alice.identity.PublicKey, sub.Community)
-	})
 
 	err = s.owner.communitiesManager.ForceMembersReevaluation(community.ID())
 	s.Require().NoError(err)


### PR DESCRIPTION
`waitOnCommunitiesEvent` must be invoked before action that triggers the event.

fixes: #4578
fixes: #4761
