### PR TITLE
fix_: add peer stats update interval

### DIFF
--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	ClusterID                uint16           `toml:",omitempty"`
 	EnableConfirmations      bool             `toml:",omitempty"` // Enable sending message confirmations
 	SkipPublishToTopic       bool             `toml:",omitempty"` // Used in testing
+	PeerStatsUpdateInterval  uint             `toml:",omitempty"`
 }
 
 func (c *Config) Validate(logger *zap.Logger) error {
@@ -118,6 +119,10 @@ func setDefaults(cfg *Config) *Config {
 
 	if cfg.MinPeersForFilter == 0 {
 		cfg.MinPeersForFilter = DefaultConfig.MinPeersForFilter
+	}
+
+	if cfg.PeerStatsUpdateInterval == 0 {
+		cfg.PeerStatsUpdateInterval = 5
 	}
 
 	if cfg.DefaultShardPubsubTopic == "" {

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"math/big"
 	"os"
 	"testing"
@@ -383,6 +384,36 @@ func TestWakuV2Filter(t *testing.T) {
 	require.Greater(t, len(stats[filterID]), 0)
 
 	require.NoError(t, w.Stop())
+}
+
+func TestWakuV2PeerUpdateInterval(t *testing.T) {
+	// Configuration for the first Waku node
+	config1 := &Config{
+		Port:                    0,
+		EnableDiscV5:            false,
+		DiscoveryLimit:          20,
+		EnableStore:             false,
+		StoreCapacity:           100,
+		StoreSeconds:            3600,
+		KeepAliveInterval:       10,
+		PeerStatsUpdateInterval: 1,
+	}
+
+	updateCnt := 0
+	// Start the first Waku node
+	w1, err := New(nil, "", config1, nil, nil, nil, nil, func(cs types.ConnStatus) {
+		updateCnt++
+	})
+	require.NoError(t, err)
+	require.NoError(t, w1.Start())
+
+	defer func() {
+		require.NoError(t, w1.Stop())
+	}()
+	nSeconds := 5
+	time.Sleep(time.Duration(nSeconds) * time.Second)
+	fmt.Println("### cnt: ", zap.Int("cnt", updateCnt))
+	require.True(t, updateCnt < nSeconds)
 }
 
 func TestWakuV2Store(t *testing.T) {


### PR DESCRIPTION
Add an update interval for health status/peer stats updates. Affects both Messenger and clients that listen to peer status updates via `Waku.onPeerStats`.
