### PR TITLE
chore: up re-evaluation interval to 8 hours to avoid Alchemy limit

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -61,7 +61,7 @@ const maxArchiveSizeInBytes = 30000000
 var maxNbMembers = 5000
 var maxNbPendingRequestedMembers = 100
 
-var memberPermissionsCheckInterval = 1 * time.Hour
+var memberPermissionsCheckInterval = 8 * time.Hour
 var validateInterval = 2 * time.Minute
 
 // Used for testing only
@@ -1402,8 +1402,8 @@ func (m *Manager) reevaluateMembersLoop(communityID types.HexBytes, reevaluateOn
 		task.mutex.Lock()
 		defer task.mutex.Unlock()
 
-		// Ensure reevaluation is performed not more often than once per minute
-		if !force && task.lastSuccessTime.After(time.Now().Add(-1*time.Minute)) {
+		// Ensure reevaluation is performed not more often than once per 5 minutes
+		if !force && task.lastSuccessTime.After(time.Now().Add(-5*time.Minute)) {
 			return false
 		}
 


### PR DESCRIPTION
The re-evaluation costs a lot of CUs on Alchemy, so we need to be more careful with re-evaluations.

The downside of the higher interval means that if someone sells their tokens, they will be kicked more slowly, though this can't be done in the Status community since we use soulbound tokens.

The other downside is if someone is airdropped a token, they won't have access to the new channels or new powers (for admins) until the re-evaluation, which will take time.