### PR TITLE
perf(login)!: Set-up messenger filters outside login flow

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -287,9 +287,15 @@ func main() {
 				return
 			}
 
-			err = messenger.Init()
+			err = messenger.InitInstallations()
 			if err != nil {
-				logger.Error("failed to init messenger", "error", err)
+				logger.Error("failed to init messenger installations", "error", err)
+				return
+			}
+
+			err = messenger.InitFilters()
+			if err != nil {
+				logger.Error("failed to init messenger filters", "error", err)
 				return
 			}
 
@@ -424,11 +430,11 @@ func printUsage() {
 	usage := `
 Usage: statusd [options]
 Examples:
-  statusd                                        # run regular Whisper node that joins Status network
-  statusd -c ./default.json                      # run node with configuration specified in ./default.json file
-  statusd -c ./default.json -c ./standalone.json # run node with configuration specified in ./default.json file, after merging ./standalone.json file
-  statusd -c ./default.json -metrics             # run node with configuration specified in ./default.json file, and expose ethereum metrics with debug_metrics jsonrpc call
-  statusd -c ./default.json -log DEBUG --seed-phrase="test test test test test test test test test test test junk" --password=password # run node with configuration specified in ./default.json file, and import account with seed phrase and password
+	statusd                                        # run regular Whisper node that joins Status network
+	statusd -c ./default.json                      # run node with configuration specified in ./default.json file
+	statusd -c ./default.json -c ./standalone.json # run node with configuration specified in ./default.json file, after merging ./standalone.json file
+	statusd -c ./default.json -metrics             # run node with configuration specified in ./default.json file, and expose ethereum metrics with debug_metrics jsonrpc call
+	statusd -c ./default.json -log DEBUG --seed-phrase="test test test test test test test test test test test junk" --password=password # run node with configuration specified in ./default.json file, and import account with seed phrase and password
 
 Options:
 `

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -106,7 +106,12 @@ func newTestMessenger(waku types.Waku, config testMessengerConfig) (*Messenger, 
 		m.retrievedMessagesIteratorFactory = config.messagesOrderController.newMessagesIterator
 	}
 
-	err = m.Init()
+	err = m.InitInstallations()
+	if err != nil {
+		return nil, err
+	}
+
+	err = m.InitFilters()
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_identity.go
+++ b/protocol/messenger_identity.go
@@ -150,6 +150,8 @@ func (m *Messenger) setInstallationHostname() error {
 			if err != nil {
 				return err
 			}
+			// REVIEW(ilmotta) imd.Name is always empty in this else branch, so why do
+			// we concatenate it?
 			imd.Name = fmt.Sprintf("%s %s", hn, imd.Name)
 		}
 	}

--- a/protocol/messenger_identity.go
+++ b/protocol/messenger_identity.go
@@ -150,8 +150,8 @@ func (m *Messenger) setInstallationHostname() error {
 			if err != nil {
 				return err
 			}
-			// REVIEW(ilmotta) imd.Name is always empty in this else branch, so why do
-			// we concatenate it?
+			// NOTE: imd.Name is always empty in this else branch, which leads to the
+			// result of Sprintf having a trailing whitespace.
 			imd.Name = fmt.Sprintf("%s %s", hn, imd.Name)
 		}
 	}

--- a/protocol/messenger_installations_test.go
+++ b/protocol/messenger_installations_test.go
@@ -6,9 +6,11 @@ import (
 	"image"
 	"image/png"
 	"os"
+	"runtime"
 	"testing"
 
 	userimage "github.com/status-im/status-go/images"
+	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/browsers"
 
 	"github.com/stretchr/testify/suite"
@@ -402,4 +404,24 @@ func (s *MessengerInstallationSuite) TestSyncInstallationNewMessages() {
 	s.Require().NoError(err)
 	s.Require().NoError(bob2.Shutdown())
 	s.Require().NoError(alice.Shutdown())
+}
+
+func (s *MessengerInstallationSuite) TestInitInstallations() {
+	m, err := newMessengerWithKey(s.shh, s.privateKey, s.logger, nil)
+	s.Require().NoError(err)
+
+	// m.InitInstallations is already called when we set-up the messenger for
+	// testing, thus this test has no act phase.
+	// err = m.InitInstallations()
+
+	// We get one installation when the messenger initializes installations
+	// correctly.
+	s.Require().Equal(1, m.allInstallations.Len())
+
+	deviceName, err := server.GetDeviceName()
+	s.Require().NoError(err)
+	installation, ok := m.allInstallations.Load(m.installationID)
+	s.Require().True(ok)
+	s.Require().Equal(deviceName+" ", installation.InstallationMetadata.Name)
+	s.Require().Equal(runtime.GOOS, installation.InstallationMetadata.DeviceType)
 }

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -81,7 +81,7 @@ func (n *testNode) PeersCount() int {
 	return 1
 }
 
-func (s *MessengerSuite) TestInit() {
+func (s *MessengerSuite) TestInitFilters() {
 	testCases := []struct {
 		Name         string
 		Prep         func()
@@ -174,7 +174,7 @@ func (s *MessengerSuite) TestInit() {
 	for _, tc := range testCases {
 		s.Run(tc.Name, func() {
 			tc.Prep()
-			err := s.m.Init()
+			err := s.m.InitFilters()
 			s.Require().NoError(err)
 			filters := s.m.transport.Filters()
 			expectedFilters += tc.AddedFilters

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -184,7 +184,11 @@ func (s *Service) InitProtocol(nodeName string, identity *ecdsa.PrivateKey, appD
 	if s.config.ProcessBackedupMessages {
 		s.messenger.EnableBackedupMessagesProcessing()
 	}
-	return messenger.Init()
+
+	// Be mindful of adding more initialization code, as it can easily
+	// impact login times for mobile users. For example, we avoid calling
+	// messenger.InitFilters here.
+	return s.messenger.InitInstallations()
 }
 
 func (s *Service) StartMessenger() (*protocol.MessengerResponse, error) {


### PR DESCRIPTION
- Root issue https://github.com/status-im/status-mobile/issues/20059
- Related mobile PR https://github.com/status-im/status-mobile/pull/20173

### Summary

This PR fixes the slow login in mobile devices when users have joined large communities, such as the Status one. A user would get stuck for almost 20s in some devices.

We identified that the step to set-up filters in the messenger is potentially expensive and that it is not critical to happen before the `node.login` signal is emitted. The solution presented in this PR is to set-up filters inside `messenger.Start()`, which the client already calls immediately after login.

With this change, users of the mobile app can login pretty fast even when they joined large 
communities. They can immediately interact with other parts of the app even if filter initialization is running in the background, like Wallet, Activity Center, Settings, and Profile.

### But does this PR work?

This PR was in WIP and it was tested sufficiently well that we know the solution solves the problem and doesn't cause regressions. But it will surely go through another round of QA after mobile and status-go PRs are approved.

### Breaking changes

In the mobile code, we had to change where the endpoint `wakuext_startMessenger` was called and the order of a few events to process chats. So essentially ordering, but no data changes. We hope the story for Desktop is similar :)

Status: ready