### PR TITLE
fix_: fix deleted communities query

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -888,10 +888,6 @@ func (m *Manager) JoinedAndPendingCommunitiesWithRequests() ([]*Community, error
 	return m.persistence.JoinedAndPendingCommunitiesWithRequests(&m.identity.PublicKey)
 }
 
-func (m *Manager) LeftCommunities() ([]*Community, error) {
-	return m.persistence.LeftCommunities(&m.identity.PublicKey)
-}
-
 func (m *Manager) DeletedCommunities() ([]*Community, error) {
 	return m.persistence.DeletedCommunities(&m.identity.PublicKey)
 }

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -327,17 +327,6 @@ func (p *Persistence) rowsToCommunities(rows *sql.Rows) (comms []*Community, err
 	return comms, nil
 }
 
-func (p *Persistence) LeftCommunities(memberIdentity *ecdsa.PublicKey) (comms []*Community, err error) {
-	query := communitiesBaseQuery + ` WHERE NOT c.Joined AND NOT c.spectated AND r.state != ?`
-
-	rows, err := p.db.Query(query, common.PubkeyToHex(memberIdentity), RequestToJoinStatePending)
-	if err != nil {
-		return nil, err
-	}
-
-	return p.rowsToCommunities(rows)
-}
-
 func (p *Persistence) JoinedAndPendingCommunitiesWithRequests(memberIdentity *ecdsa.PublicKey) (comms []*Community, err error) {
 	query := communitiesBaseQuery + ` WHERE c.Joined OR r.state = ?`
 
@@ -350,7 +339,7 @@ func (p *Persistence) JoinedAndPendingCommunitiesWithRequests(memberIdentity *ec
 }
 
 func (p *Persistence) DeletedCommunities(memberIdentity *ecdsa.PublicKey) (comms []*Community, err error) {
-	query := communitiesBaseQuery + ` WHERE NOT c.Joined AND (r.community_id IS NULL or r.state != ?)`
+	query := communitiesBaseQuery + ` WHERE NOT c.Joined AND r.state != ?`
 
 	rows, err := p.db.Query(query, common.PubkeyToHex(memberIdentity), RequestToJoinStatePending)
 	if err != nil {

--- a/protocol/messenger_backup.go
+++ b/protocol/messenger_backup.go
@@ -28,7 +28,6 @@ var backupIntervalSeconds uint64 = 28800
 
 type CommunitySet struct {
 	Joined  []*communities.Community
-	Left    []*communities.Community
 	Deleted []*communities.Community
 }
 
@@ -298,11 +297,6 @@ func (m *Messenger) retrieveAllCommunities() (*CommunitySet, error) {
 		return nil, err
 	}
 
-	leftCs, err := m.communitiesManager.LeftCommunities()
-	if err != nil {
-		return nil, err
-	}
-
 	deletedCs, err := m.communitiesManager.DeletedCommunities()
 	if err != nil {
 		return nil, err
@@ -310,7 +304,6 @@ func (m *Messenger) retrieveAllCommunities() (*CommunitySet, error) {
 
 	return &CommunitySet{
 		Joined:  joinedCs,
-		Left:    leftCs,
 		Deleted: deletedCs,
 	}, nil
 }
@@ -322,7 +315,7 @@ func (m *Messenger) backupCommunities(ctx context.Context, clock uint64) ([]*pro
 	}
 
 	var backupMessages []*protobuf.Backup
-	combinedCs := append(append(communitySet.Joined, communitySet.Left...), communitySet.Deleted...)
+	combinedCs := append(communitySet.Joined, communitySet.Deleted...)
 
 	for _, c := range combinedCs {
 		_, beingImported := m.importingCommunities[c.IDString()]


### PR DESCRIPTION
### Description

Removes the `community_id IS NULL` condition when fetching deleted communities and cleanup. This fixes #5222

### Important changes:
- [x] Remove the `community_id IS NULL` condition since base query for fetching communities contains a leftjoin `LEFT JOIN communities_requests_to_join r ON c.id = r.community_id AND r.public_key = ?`
- [x] Merge the the previously added `LeftCommunities` since the result is a subset of the Deleted communities requests 

### Note

I was able to test that after leaving the community, if the backup is performed, then the result is as expected. I faced some situations where I did the test very fast, but the result didn't match expected result (no backup actually done). Ticket https://github.com/status-im/status-go/issues/5189 might help.

Closes #5222
