### PR TITLE
fix(wallet)_: fixed disconnected event sent for all providers ignoring

### DIFF
--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -409,9 +409,6 @@ func (r *Reader) getWalletTokenBalances(ctx context.Context, addresses []common.
 	if updateBalances || updateAnyway {
 		latestBalances, err = r.tokenManager.GetBalancesByChain(ctx, clients, addresses, tokenAddresses)
 		if err != nil {
-			for _, client := range clients {
-				client.SetIsConnected(false)
-			}
 			log.Info("tokenManager.GetBalancesByChain error", "err", err)
 			return nil, err
 		}
@@ -554,9 +551,6 @@ func (r *Reader) GetWalletToken(ctx context.Context, addresses []common.Address)
 
 	balances, err := r.tokenManager.GetBalancesByChain(ctx, clients, addresses, tokenAddresses)
 	if err != nil {
-		for _, client := range clients {
-			client.SetIsConnected(false)
-		}
 		log.Info("tokenManager.GetBalancesByChain error", "err", err)
 		return nil, err
 	}


### PR DESCRIPTION
Switching connection state is done in `rpc.chain.Client`, it also respects type of error - in case of RPS error, we do not emit `wallet-blockchain-status-changed` event there.

The fixed places switched connection place redundantly, also ignoring type of error (including RPS error), which could cause wallet-blockchain-status-changed event sent even in case of RPS error.

Closes #
