### PR TITLE
fix(ActivityCenterNotification)_: update pending state of request to join ActivityCenterNotification when member was joined

### DIFF
--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1730,29 +1730,6 @@ func (m *Messenger) HandleCommunityRequestToJoinResponse(state *ReceivedMessageS
 		}
 	}
 
-	// Activity Center notification
-	requestID := communities.CalculateRequestID(common.PubkeyToHex(&m.identity.PublicKey), requestToJoinResponseProto.CommunityId)
-	notification, err := m.persistence.GetActivityCenterNotificationByID(requestID)
-	if err != nil {
-		return err
-	}
-
-	if notification != nil {
-		if requestToJoinResponseProto.Accepted {
-			notification.MembershipStatus = ActivityCenterMembershipStatusAccepted
-			notification.Read = false
-			notification.Deleted = false
-		} else {
-			notification.MembershipStatus = ActivityCenterMembershipStatusDeclined
-		}
-		notification.UpdatedAt = m.GetCurrentTimeInMillis()
-		err = m.addActivityCenterNotification(state.Response, notification, nil)
-		if err != nil {
-			m.logger.Error("failed to update notification", zap.Error(err))
-			return err
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
The issue happens when `ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE` msg will be delivered after `ApplicationMetadataMessage_COMMUNITY_DESCRIPTION`

During `processCommunityChanges` after `ApplicationMetadataMessage_COMMUNITY_DESCRIPTION` we will be added to the community.
When we process `ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE`, we  joined already, so we will have an early return and notification will be ignored

Closes # https://github.com/status-im/status-desktop/issues/14739
