### PR TITLE
chore_: decreased limits for concurrent requests and rps

### DIFF
--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -138,7 +138,7 @@ func NewSimpleClient(mainLimiter *RPCRpsLimiter, main *rpc.Client, chainID uint6
 	circuitBreakerCmdName := fmt.Sprintf("ethClient_%d", chainID)
 	hystrix.ConfigureCommand(circuitBreakerCmdName, hystrix.CommandConfig{
 		Timeout:               10000,
-		MaxConcurrentRequests: 100,
+		MaxConcurrentRequests: 10,
 		SleepWindow:           300000,
 		ErrorPercentThreshold: 25,
 	})
@@ -163,7 +163,7 @@ func NewClient(mainLimiter *RPCRpsLimiter, main *rpc.Client, fallbackLimiter *RP
 	circuitBreakerCmdName := fmt.Sprintf("ethClient_%d", chainID)
 	hystrix.ConfigureCommand(circuitBreakerCmdName, hystrix.CommandConfig{
 		Timeout:               20000,
-		MaxConcurrentRequests: 100,
+		MaxConcurrentRequests: 10,
 		SleepWindow:           300000,
 		ErrorPercentThreshold: 25,
 	})

--- a/rpc/chain/rpc_limiter.go
+++ b/rpc/chain/rpc_limiter.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	defaultMaxRequestsPerSecond = 50
-	minRequestsPerSecond        = 20
-	requestsPerSecondStep       = 10
+	defaultMaxRequestsPerSecond = 20
+	minRequestsPerSecond        = 10
+	requestsPerSecondStep       = 5
 
 	tickerInterval  = 1 * time.Second
 	LimitInfinitely = 0

--- a/services/wallet/market/market.go
+++ b/services/wallet/market/market.go
@@ -38,7 +38,7 @@ type Manager struct {
 func NewManager(main thirdparty.MarketDataProvider, fallback thirdparty.MarketDataProvider, feed *event.Feed) *Manager {
 	hystrix.ConfigureCommand("marketClient", hystrix.CommandConfig{
 		Timeout:               10000,
-		MaxConcurrentRequests: 100,
+		MaxConcurrentRequests: 10,
 		SleepWindow:           300000,
 		ErrorPercentThreshold: 25,
 	})


### PR DESCRIPTION
These changes are needed to avoid the providers' limits we're facing.

@anastasiyaig and @Valentina1133 have checked it and can confirm that it fixed many failed tests in the desktop app.

Does anybody have any concerns regarding reducing the limits in this PR?

In my opinion, the only part that might be affected by these changes is app loading, at the app start, cause then we're doing a lot of rpc calls and it may take a bit longer than earlier, but after that, all should be the same.