### PR TITLE
fix(GetStatusBackend)_: Made sure BackupDisabledDataDir is always a valid absolute path.

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1752,7 +1752,16 @@ func (b *GethStatusBackend) loadNodeConfig(inputNodeCfg *params.NodeConfig) erro
 	conf.Version = params.Version
 	conf.RootDataDir = b.rootDataDir
 	conf.DataDir = filepath.Join(b.rootDataDir, conf.DataDir)
-	conf.ShhextConfig.BackupDisabledDataDir = filepath.Join(b.rootDataDir, conf.ShhextConfig.BackupDisabledDataDir)
+
+	backupDir := conf.ShhextConfig.BackupDisabledDataDir
+	if !filepath.IsAbs(backupDir) {
+		backupDir = filepath.Join(b.rootDataDir, backupDir)
+	}
+	if !filepath.IsAbs(backupDir) {
+		b.log.Warn("BackupDisabledDataDir was expected to be absolute path, instead it is ", backupDir)
+	}
+	conf.ShhextConfig.BackupDisabledDataDir = backupDir
+
 	if len(conf.LogDir) == 0 {
 		conf.LogFile = filepath.Join(b.rootDataDir, conf.LogFile)
 	} else {


### PR DESCRIPTION
In GethStatusBackend loadNodeConfig sometimes BackupDisabledDataDir is passed as absolute path and sometimes as relative "./" . And `filepath.Join` will always concatenate its arguments which may result on Windows in invalid pathname. Later in the code, Mkdir will fail and prevent new users from logging in, not allow device sync from other app instances, and may not allow current user to login.
I've tried to modify all BackupDisabledDataDir  to be either absolute paths or relative paths, but those changes did not cover all needed use cases.

Checking PR https://github.com/status-im/status-desktop/pull/14930 that fixes some of the config issue proved that it does not fix BackupDisabledDataDir  problem.
Although this fix is might be far from optimal solution, it at least allows new users to be able to login on Windows' Status client

Closes #5186
