### PR TITLE
chore(communities)_: reevaluate permissions with pre-fetched owners

### DIFF
--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -24,7 +24,7 @@ if [[ -z "${UNIT_TEST_COUNT}" ]]; then
 fi
 
 UNIT_TEST_PACKAGE_TIMEOUT="2m"
-UNIT_TEST_PACKAGE_TIMEOUT_EXTENDED="30m"
+UNIT_TEST_PACKAGE_TIMEOUT_EXTENDED="35m"
 
 redirect_stdout() {
   output_file=$1

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -261,6 +261,7 @@ func (m *DefaultTokenManager) GetAllChainIDs() ([]uint64, error) {
 type CollectiblesManager interface {
 	FetchBalancesByOwnerAndContractAddress(ctx context.Context, chainID walletcommon.ChainID, ownerAddress gethcommon.Address, contractAddresses []gethcommon.Address) (thirdparty.TokenBalancesPerContractAddress, error)
 	GetCollectibleOwnership(id thirdparty.CollectibleUniqueID) ([]thirdparty.AccountBalance, error)
+	FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletcommon.ChainID, contractAddress gethcommon.Address) (*thirdparty.CollectibleContractOwnership, error)
 }
 
 func (m *DefaultTokenManager) GetBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error) {
@@ -1097,6 +1098,27 @@ func (rmr *reevaluateMembersResult) newPrivilegedRoles() (map[protobuf.Community
 	return result, nil
 }
 
+// Fetch all owners for all collectibles.
+func (m *Manager) fetchCollectiblesOwners(collectibles map[walletcommon.ChainID]map[gethcommon.Address]struct{}) (CollectiblesOwners, error) {
+	if m.collectiblesManager == nil {
+		return nil, errors.New("no collectibles manager")
+	}
+
+	collectiblesOwners := make(CollectiblesOwners)
+	for chainID, contractAddresses := range collectibles {
+		collectiblesOwners[chainID] = make(map[gethcommon.Address]*thirdparty.CollectibleContractOwnership)
+
+		for contractAddress := range contractAddresses {
+			ownership, err := m.collectiblesManager.FetchCollectibleOwnersByContractAddress(context.Background(), chainID, contractAddress)
+			if err != nil {
+				return nil, err
+			}
+			collectiblesOwners[chainID][contractAddress] = ownership
+		}
+	}
+	return collectiblesOwners, nil
+}
+
 // use it only for testing purposes
 func (m *Manager) ReevaluateMembers(communityID types.HexBytes) (*Community, map[protobuf.CommunityMember_Roles][]*ecdsa.PublicKey, error) {
 	return m.reevaluateMembers(communityID)
@@ -1121,6 +1143,12 @@ func (m *Manager) reevaluateMembers(communityID types.HexBytes) (*Community, map
 	}
 
 	communityPermissionsPreParsedData, channelPermissionsPreParsedData := PreParsePermissionsData(community.tokenPermissions())
+
+	// Optimization: Fetch all collectibles owners before members iteration to avoid asking providers for the same collectibles.
+	collectiblesOwners, err := m.fetchCollectiblesOwners(CollectibleAddressesFromPreParsedPermissionsData(communityPermissionsPreParsedData, channelPermissionsPreParsedData))
+	if err != nil {
+		return nil, nil, err
+	}
 
 	result := &reevaluateMembersResult{
 		membersToRemove:             map[string]struct{}{},
@@ -1159,7 +1187,7 @@ func (m *Manager) reevaluateMembers(communityID types.HexBytes) (*Community, map
 
 		becomeTokenMasterPermissions := communityPermissionsPreParsedData[protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER]
 		if becomeTokenMasterPermissions != nil {
-			permissionResponse, err := m.PermissionChecker.CheckPermissions(becomeTokenMasterPermissions, accountsAndChainIDs, true)
+			permissionResponse, err := m.PermissionChecker.CheckPermissionsWithPreFetchedData(becomeTokenMasterPermissions, accountsAndChainIDs, true, collectiblesOwners)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1173,7 +1201,7 @@ func (m *Manager) reevaluateMembers(communityID types.HexBytes) (*Community, map
 
 		becomeAdminPermissions := communityPermissionsPreParsedData[protobuf.CommunityTokenPermission_BECOME_ADMIN]
 		if becomeAdminPermissions != nil {
-			permissionResponse, err := m.PermissionChecker.CheckPermissions(becomeAdminPermissions, accountsAndChainIDs, true)
+			permissionResponse, err := m.PermissionChecker.CheckPermissionsWithPreFetchedData(becomeAdminPermissions, accountsAndChainIDs, true, collectiblesOwners)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1187,7 +1215,7 @@ func (m *Manager) reevaluateMembers(communityID types.HexBytes) (*Community, map
 
 		becomeMemberPermissions := communityPermissionsPreParsedData[protobuf.CommunityTokenPermission_BECOME_MEMBER]
 		if becomeMemberPermissions != nil {
-			permissionResponse, err := m.PermissionChecker.CheckPermissions(becomeMemberPermissions, accountsAndChainIDs, true)
+			permissionResponse, err := m.PermissionChecker.CheckPermissionsWithPreFetchedData(becomeMemberPermissions, accountsAndChainIDs, true, collectiblesOwners)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1199,7 +1227,7 @@ func (m *Manager) reevaluateMembers(communityID types.HexBytes) (*Community, map
 			}
 		}
 
-		addToChannels, removeFromChannels, err := m.reevaluateMemberChannelsPermissions(community, memberPubKey, channelPermissionsPreParsedData, accountsAndChainIDs)
+		addToChannels, removeFromChannels, err := m.reevaluateMemberChannelsPermissions(community, memberPubKey, channelPermissionsPreParsedData, accountsAndChainIDs, collectiblesOwners)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1312,13 +1340,13 @@ func (m *Manager) applyReevaluateMembersResult(communityID types.HexBytes, resul
 }
 
 func (m *Manager) reevaluateMemberChannelsPermissions(community *Community, memberPubKey *ecdsa.PublicKey,
-	channelPermissionsPreParsedData map[string]*PreParsedCommunityPermissionsData, accountsAndChainIDs []*AccountChainIDsCombination) (map[string]protobuf.CommunityMember_ChannelRole, map[string]struct{}, error) {
+	channelPermissionsPreParsedData map[string]*PreParsedCommunityPermissionsData, accountsAndChainIDs []*AccountChainIDsCombination, collectiblesOwners CollectiblesOwners) (map[string]protobuf.CommunityMember_ChannelRole, map[string]struct{}, error) {
 
 	addToChannels := map[string]protobuf.CommunityMember_ChannelRole{}
 	removeFromChannels := map[string]struct{}{}
 
 	// check which permissions we satisfy and which not
-	channelPermissionsCheckResult, err := m.checkChannelsPermissions(channelPermissionsPreParsedData, accountsAndChainIDs, true)
+	channelPermissionsCheckResult, err := m.checkChannelsPermissionsWithPreFetchedData(channelPermissionsPreParsedData, accountsAndChainIDs, true, collectiblesOwners)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1354,10 +1382,18 @@ func (m *Manager) reevaluateMemberChannelsPermissions(community *Community, memb
 	return addToChannels, removeFromChannels, nil
 }
 
-func (m *Manager) checkChannelsPermissions(channelsPermissionsPreParsedData map[string]*PreParsedCommunityPermissionsData, accountsAndChainIDs []*AccountChainIDsCombination, shortcircuit bool) (map[string]map[protobuf.CommunityTokenPermission_Type]bool, error) {
+func (m *Manager) checkChannelsPermissionsImpl(channelsPermissionsPreParsedData map[string]*PreParsedCommunityPermissionsData, accountsAndChainIDs []*AccountChainIDsCombination, shortcircuit bool, collectiblesOwners CollectiblesOwners) (map[string]map[protobuf.CommunityTokenPermission_Type]bool, error) {
+	checkPermissions := func(channelsPermissionPreParsedData *PreParsedCommunityPermissionsData) (*CheckPermissionsResponse, error) {
+		if collectiblesOwners != nil {
+			return m.PermissionChecker.CheckPermissionsWithPreFetchedData(channelsPermissionPreParsedData, accountsAndChainIDs, true, collectiblesOwners)
+		} else {
+			return m.PermissionChecker.CheckPermissions(channelsPermissionPreParsedData, accountsAndChainIDs, true)
+		}
+	}
+
 	channelPermissionsCheckResult := make(map[string]map[protobuf.CommunityTokenPermission_Type]bool)
 	for _, channelsPermissionPreParsedData := range channelsPermissionsPreParsedData {
-		permissionResponse, err := m.PermissionChecker.CheckPermissions(channelsPermissionPreParsedData, accountsAndChainIDs, true)
+		permissionResponse, err := checkPermissions(channelsPermissionPreParsedData)
 		if err != nil {
 			return channelPermissionsCheckResult, err
 		}
@@ -1375,6 +1411,14 @@ func (m *Manager) checkChannelsPermissions(channelsPermissionsPreParsedData map[
 		}
 	}
 	return channelPermissionsCheckResult, nil
+}
+
+func (m *Manager) checkChannelsPermissionsWithPreFetchedData(channelsPermissionsPreParsedData map[string]*PreParsedCommunityPermissionsData, accountsAndChainIDs []*AccountChainIDsCombination, shortcircuit bool, collectiblesOwners CollectiblesOwners) (map[string]map[protobuf.CommunityTokenPermission_Type]bool, error) {
+	return m.checkChannelsPermissionsImpl(channelsPermissionsPreParsedData, accountsAndChainIDs, shortcircuit, collectiblesOwners)
+}
+
+func (m *Manager) checkChannelsPermissions(channelsPermissionsPreParsedData map[string]*PreParsedCommunityPermissionsData, accountsAndChainIDs []*AccountChainIDsCombination, shortcircuit bool) (map[string]map[protobuf.CommunityTokenPermission_Type]bool, error) {
+	return m.checkChannelsPermissionsImpl(channelsPermissionsPreParsedData, accountsAndChainIDs, shortcircuit, nil)
 }
 
 func (m *Manager) StartMembersReevaluationLoop(communityID types.HexBytes, reevaluateOnStart bool) {

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -120,6 +120,32 @@ func (m *testCollectiblesManager) GetCollectibleOwnership(id thirdparty.Collecti
 	return nil, errors.New("GetCollectibleOwnership is not implemented for testCollectiblesManager")
 }
 
+func (m *testCollectiblesManager) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletCommon.ChainID, contractAddress gethcommon.Address) (*thirdparty.CollectibleContractOwnership, error) {
+	ret := &thirdparty.CollectibleContractOwnership{
+		ContractAddress: contractAddress,
+		Owners:          []thirdparty.CollectibleOwner{},
+	}
+
+	balancesPerOwner, ok := m.response[uint64(chainID)]
+	if !ok {
+		return ret, nil
+	}
+
+	for ownerAddress, collectibles := range balancesPerOwner {
+		for collectibleAddress, balances := range collectibles {
+			if collectibleAddress == contractAddress {
+				ret.Owners = append(ret.Owners, thirdparty.CollectibleOwner{
+					OwnerAddress:  ownerAddress,
+					TokenBalances: balances,
+				})
+				break
+			}
+		}
+	}
+
+	return ret, nil
+}
+
 type testTokenManager struct {
 	response map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big
 }

--- a/protocol/communities_events_eventual_consistency_test.go
+++ b/protocol/communities_events_eventual_consistency_test.go
@@ -27,6 +27,8 @@ func (s *CommunityEventsEventualConsistencySuite) SetupTest() {
 	s.logger = tt.MustCreateTestLogger()
 	s.collectiblesServiceMock = &CollectiblesServiceMock{}
 
+	s.mockedBalances = createMockedWalletBalance(&s.Suite)
+
 	config := waku.DefaultConfig
 	config.MinimumAcceptedPoW = 0
 	shh := waku.New(&config, s.logger)
@@ -48,7 +50,6 @@ func (s *CommunityEventsEventualConsistencySuite) SetupTest() {
 	_, err = s.alice.Start()
 	s.Require().NoError(err)
 
-	s.mockedBalances = createMockedWalletBalance(&s.Suite)
 }
 
 func (s *CommunityEventsEventualConsistencySuite) TearDownTest() {

--- a/protocol/communities_events_owner_without_community_key_test.go
+++ b/protocol/communities_events_owner_without_community_key_test.go
@@ -61,6 +61,8 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) SetupTest() {
 	s.logger = tt.MustCreateTestLogger()
 	s.collectiblesServiceMock = &CollectiblesServiceMock{}
 
+	s.mockedBalances = createMockedWalletBalance(&s.Suite)
+
 	config := waku.DefaultConfig
 	config.MinimumAcceptedPoW = 0
 	shh := waku.New(&config, s.logger)
@@ -76,8 +78,6 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) SetupTest() {
 	s.Require().NoError(err)
 	_, err = s.alice.Start()
 	s.Require().NoError(err)
-
-	s.mockedBalances = createMockedWalletBalance(&s.Suite)
 }
 
 func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TearDownTest() {

--- a/protocol/communities_events_token_master_test.go
+++ b/protocol/communities_events_token_master_test.go
@@ -61,6 +61,8 @@ func (s *TokenMasterCommunityEventsSuite) SetupTest() {
 	s.logger = tt.MustCreateTestLogger()
 	s.collectiblesServiceMock = &CollectiblesServiceMock{}
 
+	s.mockedBalances = createMockedWalletBalance(&s.Suite)
+
 	config := waku.DefaultConfig
 	config.MinimumAcceptedPoW = 0
 	shh := waku.New(&config, s.logger)
@@ -77,7 +79,6 @@ func (s *TokenMasterCommunityEventsSuite) SetupTest() {
 	_, err = s.alice.Start()
 	s.Require().NoError(err)
 
-	s.mockedBalances = createMockedWalletBalance(&s.Suite)
 }
 
 func (s *TokenMasterCommunityEventsSuite) TearDownTest() {

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -67,6 +67,8 @@ func (s *AdminCommunityEventsSuiteBase) SetupTest() {
 	s.logger = tt.MustCreateTestLogger()
 	s.collectiblesServiceMock = &CollectiblesServiceMock{}
 
+	s.mockedBalances = createMockedWalletBalance(&s.Suite)
+
 	config := waku.DefaultConfig
 	config.MinimumAcceptedPoW = 0
 	shh := waku.New(&config, s.logger)
@@ -82,8 +84,6 @@ func (s *AdminCommunityEventsSuiteBase) SetupTest() {
 	s.Require().NoError(err)
 	_, err = s.alice.Start()
 	s.Require().NoError(err)
-
-	s.mockedBalances = createMockedWalletBalance(&s.Suite)
 }
 
 func (s *AdminCommunityEventsSuiteBase) TearDownTest() {

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
+	"math/big"
 	"sync"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
+	"github.com/status-im/status-go/services/wallet/bigint"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	walletToken "github.com/status-im/status-go/services/wallet/token"
@@ -75,34 +77,84 @@ func (m *TokenManagerMock) FindOrCreateTokenByAddress(ctx context.Context, chain
 }
 
 type CollectiblesManagerMock struct {
-	response map[thirdparty.CollectibleUniqueID][]thirdparty.AccountBalance
+	Balances                     *map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big
+	collectibleOwnershipResponse map[string][]thirdparty.AccountBalance
 }
 
 func (m *CollectiblesManagerMock) FetchBalancesByOwnerAndContractAddress(ctx context.Context, chainID walletCommon.ChainID,
 	ownerAddress gethcommon.Address, contractAddresses []gethcommon.Address) (thirdparty.TokenBalancesPerContractAddress, error) {
-	return nil, errors.New("FetchBalancesByOwnerAndContractAddress is not implemented for testCollectiblesManager")
+	ret := make(thirdparty.TokenBalancesPerContractAddress)
+	accountsBalances, ok := (*m.Balances)[uint64(chainID)]
+	if !ok {
+		return ret, nil
+	}
+
+	balances, ok := accountsBalances[ownerAddress]
+	if !ok {
+		return ret, nil
+	}
+
+	for _, contractAddress := range contractAddresses {
+		balance, ok := balances[contractAddress]
+		if ok {
+			ret[contractAddress] = []thirdparty.TokenBalance{
+				{
+					TokenID: &bigint.BigInt{},
+					Balance: &bigint.BigInt{
+						Int: (*big.Int)(balance),
+					},
+				},
+			}
+		}
+	}
+
+	return ret, nil
 }
 
 func (m *CollectiblesManagerMock) GetCollectibleOwnership(requestedID thirdparty.CollectibleUniqueID) ([]thirdparty.AccountBalance, error) {
-	// NOTE: TokenID inside of thirdparty.CollectibleUniqueID is a pointer so m.response[id] is now working
-	for id, balances := range m.response {
-		if id.ContractID.Address == requestedID.ContractID.Address &&
-			id.ContractID.ChainID == requestedID.ContractID.ChainID {
+	for id, balances := range m.collectibleOwnershipResponse {
+		if id == requestedID.HashKey() {
 			return balances, nil
 		}
 	}
 	return []thirdparty.AccountBalance{}, nil
 }
 
-func (m *CollectiblesManagerMock) SetResponse(id thirdparty.CollectibleUniqueID, balances []thirdparty.AccountBalance) {
-	if m.response == nil {
-		m.response = map[thirdparty.CollectibleUniqueID][]thirdparty.AccountBalance{}
+func (m *CollectiblesManagerMock) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletCommon.ChainID, contractAddress gethcommon.Address) (*thirdparty.CollectibleContractOwnership, error) {
+	ret := &thirdparty.CollectibleContractOwnership{
+		ContractAddress: contractAddress,
+		Owners:          []thirdparty.CollectibleOwner{},
 	}
-	m.response[id] = balances
+	accountsBalances, ok := (*m.Balances)[uint64(chainID)]
+	if !ok {
+		return ret, nil
+	}
+
+	for wallet, collectiblesBalance := range accountsBalances {
+		balance, ok := collectiblesBalance[contractAddress]
+		if ok {
+			ret.Owners = append(ret.Owners, thirdparty.CollectibleOwner{
+				OwnerAddress: wallet,
+				TokenBalances: []thirdparty.TokenBalance{
+					{
+						TokenID: &bigint.BigInt{},
+						Balance: &bigint.BigInt{
+							Int: (*big.Int)(balance),
+						},
+					},
+				},
+			})
+		}
+	}
+
+	return ret, nil
 }
 
-func (m *CollectiblesManagerMock) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletCommon.ChainID, contractAddress gethcommon.Address) (*thirdparty.CollectibleContractOwnership, error) {
-	return nil, errors.New("FetchCollectibleOwnersByContractAddress is not implemented for CollectiblesManagerMock")
+func (m *CollectiblesManagerMock) SetCollectibleOwnershipResponse(id thirdparty.CollectibleUniqueID, balances []thirdparty.AccountBalance) {
+	if m.collectibleOwnershipResponse == nil {
+		m.collectibleOwnershipResponse = map[string][]thirdparty.AccountBalance{}
+	}
+	m.collectibleOwnershipResponse[id.HashKey()] = balances
 }
 
 type CollectiblesServiceMock struct {
@@ -260,7 +312,9 @@ func newTestCommunitiesMessenger(s *suite.Suite, waku types.Waku, config testCom
 		Balances: config.mockedBalances,
 	}
 
-	collectiblesManagerMock := &CollectiblesManagerMock{}
+	collectiblesManagerMock := &CollectiblesManagerMock{
+		Balances: config.mockedBalances,
+	}
 
 	options := []Option{
 		WithAccountManager(accountsManagerMock),

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -3624,6 +3624,10 @@ func (t *testPermissionChecker) CheckPermissions(permissionsParsedData *communit
 	return &communities.CheckPermissionsResponse{Satisfied: true}, nil
 }
 
+func (t *testPermissionChecker) CheckPermissionsWithPreFetchedData(permissionsParsedData *communities.PreParsedCommunityPermissionsData, accountsAndChainIDs []*communities.AccountChainIDsCombination, shortcircuit bool, collectiblesOwners communities.CollectiblesOwners) (*communities.CheckPermissionsResponse, error) {
+	return &communities.CheckPermissionsResponse{Satisfied: true}, nil
+}
+
 func (s *MessengerCommunitiesSuite) TestStartCommunityRekeyLoop() {
 	community, chat := createEncryptedCommunity(&s.Suite, s.owner)
 	s.Require().True(community.Encrypted())

--- a/protocol/messenger_profile_showcase_test.go
+++ b/protocol/messenger_profile_showcase_test.go
@@ -187,7 +187,7 @@ func (s *TestMessengerProfileShowcase) TestSaveAndGetProfileShowcasePreferences(
 			TxTimestamp: 0,
 		},
 	}
-	s.collectiblesMock.SetResponse(collectibleID, balances)
+	s.collectiblesMock.SetCollectibleOwnershipResponse(collectibleID, balances)
 
 	err = s.m.SetProfileShowcasePreferences(request, false)
 	s.Require().NoError(err)
@@ -258,7 +258,7 @@ func (s *TestMessengerProfileShowcase) TestFailToSaveProfileShowcasePreferencesW
 			TxTimestamp: 0,
 		},
 	}
-	s.collectiblesMock.SetResponse(collectibleID, balances)
+	s.collectiblesMock.SetCollectibleOwnershipResponse(collectibleID, balances)
 
 	err = s.m.SetProfileShowcasePreferences(request, false)
 	s.Require().Equal(errorAccountVisibilityLowerThanCollectible, err)
@@ -441,7 +441,7 @@ func (s *TestMessengerProfileShowcase) TestShareShowcasePreferences() {
 			TxTimestamp: 32443424,
 		},
 	}
-	s.collectiblesMock.SetResponse(collectibleID, balances)
+	s.collectiblesMock.SetCollectibleOwnershipResponse(collectibleID, balances)
 
 	err = s.m.SetProfileShowcasePreferences(request, false)
 	s.Require().NoError(err)

--- a/protocol/messenger_profile_showcase_test.go
+++ b/protocol/messenger_profile_showcase_test.go
@@ -25,38 +25,10 @@ import (
 	"github.com/status-im/status-go/protocol/sqlite"
 	"github.com/status-im/status-go/protocol/tt"
 	"github.com/status-im/status-go/services/wallet/bigint"
-	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/waku"
 )
-
-type CollectiblesManagerMock struct {
-	response map[thirdparty.CollectibleUniqueID][]thirdparty.AccountBalance
-}
-
-func (m *CollectiblesManagerMock) FetchBalancesByOwnerAndContractAddress(ctx context.Context, chainID walletCommon.ChainID,
-	ownerAddress gethcommon.Address, contractAddresses []gethcommon.Address) (thirdparty.TokenBalancesPerContractAddress, error) {
-	return nil, errors.New("FetchBalancesByOwnerAndContractAddress is not implemented for testCollectiblesManager")
-}
-
-func (m *CollectiblesManagerMock) GetCollectibleOwnership(requestedID thirdparty.CollectibleUniqueID) ([]thirdparty.AccountBalance, error) {
-	// NOTE: TokenID inside of thirdparty.CollectibleUniqueID is a pointer so m.response[id] is now working
-	for id, balances := range m.response {
-		if id.ContractID.Address == requestedID.ContractID.Address &&
-			id.ContractID.ChainID == requestedID.ContractID.ChainID {
-			return balances, nil
-		}
-	}
-	return []thirdparty.AccountBalance{}, nil
-}
-
-func (m *CollectiblesManagerMock) SetResponse(id thirdparty.CollectibleUniqueID, balances []thirdparty.AccountBalance) {
-	if m.response == nil {
-		m.response = map[thirdparty.CollectibleUniqueID][]thirdparty.AccountBalance{}
-	}
-	m.response[id] = balances
-}
 
 func TestMessengerProfileShowcaseSuite(t *testing.T) { // nolint: deadcode,unused
 	suite.Run(t, new(TestMessengerProfileShowcase))

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -326,6 +326,11 @@ func (api *API) GetCollectibleOwnersByContractAddress(ctx context.Context, chain
 	return api.s.collectiblesManager.FetchCollectibleOwnersByContractAddress(ctx, chainID, contractAddress)
 }
 
+func (api *API) FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID wcommon.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error) {
+	log.Debug("call to FetchCollectibleOwnersByContractAddress")
+	return api.s.collectiblesManager.FetchCollectibleOwnersByContractAddress(ctx, chainID, contractAddress)
+}
+
 func (api *API) SearchCollectibles(ctx context.Context, chainID wcommon.ChainID, text string, cursor string, limit int, providerID string) (*thirdparty.FullCollectibleDataContainer, error) {
 	log.Debug("call to SearchCollectibles")
 	return api.s.collectiblesManager.SearchCollectibles(ctx, chainID, text, cursor, limit, providerID)


### PR DESCRIPTION
That's an optimisation. Instead of fetching collectibles owners for each member, it is fetched once, before members iteration.

It should significantly reduce amount of queries to providers.

closes: status-im/status-desktop#14914

**NOTE**: The implementation adds another piece of technical debt to the check permissions flow. Doing it the proper way would require refactoring `CheckPermissions` and all its derivatives, which would be very risky at this moment.

