### PR TITLE
chore_: remove Light permission checks that are no longer needed

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2703,17 +2703,6 @@ func (m *Manager) CheckPermissionToJoin(id []byte, addresses []gethcommon.Addres
 	return m.PermissionChecker.CheckPermissionToJoin(community, addresses)
 }
 
-// Light version of CheckPermissionToJoin, which does not use network requests.
-// Instead of checking wallet balances it checks if there is an access to a member list of the community.
-func (m *Manager) CheckPermissionToJoinLight(id []byte) (bool, error) {
-	community, err := m.GetByID(id)
-	if err != nil {
-		return false, err
-	}
-	meAsMember := community.GetMember(&m.identity.PublicKey)
-	return meAsMember != nil, nil
-}
-
 func (m *Manager) accountsSatisfyPermissionsToJoin(
 	communityPermissionsPreParsedData map[protobuf.CommunityTokenPermission_Type]*PreParsedCommunityPermissionsData,
 	accountsAndChainIDs []*AccountChainIDsCombination) (bool, protobuf.CommunityMember_Roles, error) {
@@ -3286,59 +3275,6 @@ func (m *Manager) CheckChannelPermissions(communityID types.HexBytes, chatID str
 	return response, nil
 }
 
-func (m *Manager) checkChannelPermissionsLight(community *Community, communityChat *protobuf.CommunityChat, channelID string) *CheckChannelPermissionsResponse {
-
-	viewOnlyPermissions := community.ChannelTokenPermissionsByType(community.IDString()+channelID, protobuf.CommunityTokenPermission_CAN_VIEW_CHANNEL)
-	viewAndPostPermissions := community.ChannelTokenPermissionsByType(community.IDString()+channelID, protobuf.CommunityTokenPermission_CAN_VIEW_AND_POST_CHANNEL)
-
-	hasViewOnlyPermissions := len(viewOnlyPermissions) > 0
-	hasViewAndPostPermissions := len(viewAndPostPermissions) > 0
-
-	meAsMember := communityChat.Members[common.PubkeyToHex(&m.identity.PublicKey)]
-
-	viewSatisfied := !hasViewOnlyPermissions || (meAsMember != nil && meAsMember.GetChannelRole() == protobuf.CommunityMember_CHANNEL_ROLE_VIEWER)
-	postSatisfied := !hasViewAndPostPermissions || (meAsMember != nil && meAsMember.GetChannelRole() == protobuf.CommunityMember_CHANNEL_ROLE_POSTER)
-
-	finalViewSatisfied := computeViewOnlySatisfied(hasViewOnlyPermissions, hasViewAndPostPermissions, viewSatisfied, postSatisfied)
-	finalPostSatisfied := computeViewAndPostSatisfied(hasViewOnlyPermissions, hasViewAndPostPermissions, postSatisfied)
-
-	return &CheckChannelPermissionsResponse{
-		ViewOnlyPermissions: &CheckChannelViewOnlyPermissionsResult{
-			Satisfied:   finalViewSatisfied,
-			Permissions: make(map[string]*PermissionTokenCriteriaResult),
-		},
-		ViewAndPostPermissions: &CheckChannelViewAndPostPermissionsResult{
-			Satisfied:   finalPostSatisfied,
-			Permissions: make(map[string]*PermissionTokenCriteriaResult),
-		},
-	}
-}
-
-// Light version of CheckChannelPermissions, which does not use network requests.
-// Instead of checking wallet balances it checks if there is an access to a member list of the chat.
-func (m *Manager) CheckChannelPermissionsLight(communityID types.HexBytes, chatID string) (*CheckChannelPermissionsResponse, error) {
-	community, err := m.GetByID(communityID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Remove communityID prefix from chatID if exists
-	if strings.HasPrefix(chatID, communityID.String()) {
-		chatID = strings.TrimPrefix(chatID, communityID.String())
-	}
-
-	if chatID == "" {
-		return nil, errors.New(fmt.Sprintf("couldn't check channel permissions, invalid chat id: %s", chatID))
-	}
-
-	communityChat, err := community.GetChat(chatID)
-	if err != nil {
-		return nil, err
-	}
-
-	return m.checkChannelPermissionsLight(community, communityChat, chatID), nil
-}
-
 type CheckChannelPermissionsResponse struct {
 	ViewOnlyPermissions    *CheckChannelViewOnlyPermissionsResult    `json:"viewOnlyPermissions"`
 	ViewAndPostPermissions *CheckChannelViewAndPostPermissionsResult `json:"viewAndPostPermissions"`
@@ -3487,27 +3423,6 @@ func (m *Manager) CheckAllChannelsPermissions(communityID types.HexBytes, addres
 			return nil, err
 		}
 		response.Channels[chatId] = channelPermissionsResponse
-	}
-	return response, nil
-}
-
-// Light version of CheckAllChannelsPermissionsLight, which does not use network requests.
-// Instead of checking wallet balances it checks if there is an access to a member list of chats.
-func (m *Manager) CheckAllChannelsPermissionsLight(communityID types.HexBytes) (*CheckAllChannelsPermissionsResponse, error) {
-
-	community, err := m.GetByID(communityID)
-	if err != nil {
-		return nil, err
-	}
-
-	response := &CheckAllChannelsPermissionsResponse{
-		Channels: make(map[string]*CheckChannelPermissionsResponse),
-	}
-
-	channels := community.Chats()
-
-	for channelID, channel := range channels {
-		response.Channels[community.IDString()+channelID] = m.checkChannelPermissionsLight(community, channel, channelID)
 	}
 	return response, nil
 }

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4371,14 +4371,6 @@ func (m *Messenger) CheckPermissionsToJoinCommunity(request *requests.CheckPermi
 	return m.communitiesManager.CheckPermissionToJoin(request.CommunityID, addresses)
 }
 
-func (m *Messenger) CheckPermissionsToJoinCommunityLight(request *requests.CheckPermissionToJoinCommunity) (bool, error) {
-	if err := request.Validate(); err != nil {
-		return false, err
-	}
-
-	return m.communitiesManager.CheckPermissionToJoinLight(request.CommunityID)
-}
-
 func (m *Messenger) getSharedAddresses(communityID types.HexBytes, requestAddresses []string) ([]gethcommon.Address, error) {
 	addressesMap := make(map[string]struct{})
 
@@ -4440,22 +4432,6 @@ func (m *Messenger) CheckAllCommunityChannelsPermissions(request *requests.Check
 	}
 
 	return m.communitiesManager.CheckAllChannelsPermissions(request.CommunityID, addresses)
-}
-
-func (m *Messenger) CheckCommunityChannelPermissionsLight(request *requests.CheckCommunityChannelPermissions) (*communities.CheckChannelPermissionsResponse, error) {
-	if err := request.Validate(); err != nil {
-		return nil, err
-	}
-
-	return m.communitiesManager.CheckChannelPermissionsLight(request.CommunityID, request.ChatID)
-}
-
-func (m *Messenger) CheckAllCommunityChannelsPermissionsLight(request *requests.CheckAllCommunityChannelsPermissions) (*communities.CheckAllChannelsPermissionsResponse, error) {
-	if err := request.Validate(); err != nil {
-		return nil, err
-	}
-
-	return m.communitiesManager.CheckAllChannelsPermissionsLight(request.CommunityID)
 }
 
 func (m *Messenger) GetCommunityCheckChannelPermissionResponses(communityID types.HexBytes) (*communities.CheckAllChannelsPermissionsResponse, error) {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1590,24 +1590,12 @@ func (api *PublicAPI) CheckPermissionsToJoinCommunity(request *requests.CheckPer
 	return api.service.messenger.CheckPermissionsToJoinCommunity(request)
 }
 
-func (api *PublicAPI) CheckPermissionsToJoinCommunityLight(request *requests.CheckPermissionToJoinCommunity) (bool, error) {
-	return api.service.messenger.CheckPermissionsToJoinCommunityLight(request)
-}
-
 func (api *PublicAPI) CheckCommunityChannelPermissions(request *requests.CheckCommunityChannelPermissions) (*communities.CheckChannelPermissionsResponse, error) {
 	return api.service.messenger.CheckCommunityChannelPermissions(request)
 }
 
-func (api *PublicAPI) CheckCommunityChannelPermissionsLight(request *requests.CheckCommunityChannelPermissions) (*communities.CheckChannelPermissionsResponse, error) {
-	return api.service.messenger.CheckCommunityChannelPermissionsLight(request)
-}
-
 func (api *PublicAPI) CheckAllCommunityChannelsPermissions(request *requests.CheckAllCommunityChannelsPermissions) (*communities.CheckAllChannelsPermissionsResponse, error) {
 	return api.service.messenger.CheckAllCommunityChannelsPermissions(request)
-}
-
-func (api *PublicAPI) CheckAllCommunityChannelsPermissionsLight(request *requests.CheckAllCommunityChannelsPermissions) (*communities.CheckAllChannelsPermissionsResponse, error) {
-	return api.service.messenger.CheckAllCommunityChannelsPermissionsLight(request)
 }
 
 func (api *PublicAPI) CollectCommunityMetrics(request *requests.CommunityMetricsRequest) (*protocol.CommunityMetricsResponse, error) {


### PR DESCRIPTION
For https://github.com/status-im/status-desktop/issues/14983

We didn't actually need those apis. We could just check `canPost` and `canView`

Sorry @endulab I'm basically removing all your code :sweat_smile: 
It's my fault, I forgot/didn't realize that it was possible to use just `canPost` and `canView`. To be fair, we had not exposed them in Nim yet.