### PR TITLE
fix_: make member use wallet tokens during permission checking

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -243,7 +243,8 @@ type managerOptions struct {
 }
 
 type TokenManager interface {
-	GetBalancesByChain(ctx context.Context, accounts, tokens []gethcommon.Address, chainIDs []uint64) (map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big, error)
+	GetBalancesByChain(ctx context.Context, accounts, tokens []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error)
+	GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error)
 	FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *token.Token
 	GetAllChainIDs() ([]uint64, error)
 }
@@ -301,6 +302,7 @@ func (m *DefaultTokenManager) GetAllChainIDs() ([]uint64, error) {
 
 type CollectiblesManager interface {
 	FetchBalancesByOwnerAndContractAddress(ctx context.Context, chainID walletcommon.ChainID, ownerAddress gethcommon.Address, contractAddresses []gethcommon.Address) (thirdparty.TokenBalancesPerContractAddress, error)
+	FetchCachedBalancesByOwnerAndContractAddress(ctx context.Context, chainID walletcommon.ChainID, ownerAddress gethcommon.Address, contractAddresses []gethcommon.Address) (thirdparty.TokenBalancesPerContractAddress, error)
 	GetCollectibleOwnership(id thirdparty.CollectibleUniqueID) ([]thirdparty.AccountBalance, error)
 	FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletcommon.ChainID, contractAddress gethcommon.Address) (*thirdparty.CollectibleContractOwnership, error)
 }
@@ -313,6 +315,15 @@ func (m *DefaultTokenManager) GetBalancesByChain(ctx context.Context, accounts, 
 
 	resp, err := m.tokenManager.GetBalancesByChain(context.Background(), clients, accounts, tokenAddresses)
 	return resp, err
+}
+
+func (m *DefaultTokenManager) GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error) {
+	resp, err := m.tokenManager.GetCachedBalancesByChain(accounts, tokenAddresses, chainIDs)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
 }
 
 func (m *DefaultTokenManager) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *token.Token {

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -163,6 +163,10 @@ func (m *testCollectiblesManager) FetchCollectibleOwnersByContractAddress(ctx co
 	return ret, nil
 }
 
+func (m *testCollectiblesManager) FetchCachedBalancesByOwnerAndContractAddress(ctx context.Context, chainID walletCommon.ChainID, ownerAddress gethcommon.Address, contractAddresses []gethcommon.Address) (thirdparty.TokenBalancesPerContractAddress, error) {
+	return m.response[uint64(chainID)][ownerAddress], nil
+}
+
 type testTokenManager struct {
 	response map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big
 }
@@ -190,6 +194,10 @@ func (m *testTokenManager) GetAllChainIDs() ([]uint64, error) {
 }
 
 func (m *testTokenManager) GetBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big, error) {
+	return m.response, nil
+}
+
+func (m *testTokenManager) GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error) {
 	return m.response, nil
 }
 

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -71,6 +71,11 @@ func (m *TokenManagerMock) GetBalancesByChain(ctx context.Context, accounts, tok
 	return *m.Balances, nil
 }
 
+func (m *TokenManagerMock) GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big, error) {
+	time.Sleep(100 * time.Millisecond) // simulate response time
+	return *m.Balances, nil
+}
+
 func (m *TokenManagerMock) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *walletToken.Token {
 	time.Sleep(100 * time.Millisecond) // simulate response time
 	return nil
@@ -79,6 +84,11 @@ func (m *TokenManagerMock) FindOrCreateTokenByAddress(ctx context.Context, chain
 type CollectiblesManagerMock struct {
 	Balances                     *map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big
 	collectibleOwnershipResponse map[string][]thirdparty.AccountBalance
+}
+
+func (m *CollectiblesManagerMock) FetchCachedBalancesByOwnerAndContractAddress(ctx context.Context, chainID walletCommon.ChainID,
+	ownerAddress gethcommon.Address, contractAddresses []gethcommon.Address) (thirdparty.TokenBalancesPerContractAddress, error) {
+	return m.FetchBalancesByOwnerAndContractAddress(ctx, chainID, ownerAddress, contractAddresses)
 }
 
 func (m *CollectiblesManagerMock) FetchBalancesByOwnerAndContractAddress(ctx context.Context, chainID walletCommon.ChainID,

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -284,6 +284,12 @@ func (api *API) GetCryptoOnRamps(ctx context.Context) ([]onramp.CryptoOnRamp, er
    Collectibles API Start
 */
 
+func (api *API) FetchCachedBalancesByOwnerAndContractAddress(ctx context.Context, chainID wcommon.ChainID, ownerAddress common.Address, contractAddresses []common.Address) (thirdparty.TokenBalancesPerContractAddress, error) {
+	log.Debug("call to FetchCachedBalancesByOwnerAndContractAddress")
+
+	return api.s.collectiblesManager.FetchCachedBalancesByOwnerAndContractAddress(ctx, chainID, ownerAddress, contractAddresses)
+}
+
 func (api *API) FetchBalancesByOwnerAndContractAddress(ctx context.Context, chainID wcommon.ChainID, ownerAddress common.Address, contractAddresses []common.Address) (thirdparty.TokenBalancesPerContractAddress, error) {
 	log.Debug("call to FetchBalancesByOwnerAndContractAddress")
 


### PR DESCRIPTION
### Description

During the checking of permissions that happens either on edit shared addresses or during the blurred screen when joining a community, the member will perform some permissions checking. Currently the permission checking is done by fetching tokens from the chain which is wasteful in terms of resources. These changes aims at using the cached tokens from the wallet which improves the speed of tokens retrieval and improve the user experience.

fixes #14913

### Acceptance criteria

- [x] the channel and join permission screens work as before, same with the shared addresses popup. The UI/UX should't be affected at all. If anything, it should be faster
- [x] members no longer call the providers
- [ ] Ensure that no integration breaking changes `In progress`

### Important changes:
- [x] Add a switch to differentiate fetching token by member and owner
- [x] Add API to fetch tokens from the wallet db

Closes https://github.com/status-im/status-desktop/issues/14913

### Manual testing

Please notince how fast the evaluation is compared to before

### Before 

[Screencast from 2024-06-02 01-17-01.webm](https://github.com/status-im/status-go/assets/2589171/b8705900-9697-41f4-97a7-70a84fb39865)

### After

[Screencast from 2024-06-02 01-59-40.webm](https://github.com/status-im/status-go/assets/2589171/33f75e36-a43a-4758-8456-768551d1675c)

