### PR TITLE
fix(community)_: handle outdated request to join and request to join response when we have been joined

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -3999,10 +3999,6 @@ func (m *Manager) CanceledRequestsToJoinForUser(pk *ecdsa.PublicKey) ([]*Request
 	return m.persistence.CanceledRequestsToJoinForUser(common.PubkeyToHex(pk))
 }
 
-func (m *Manager) CanceledRequestToJoinForUserForCommunityID(pk *ecdsa.PublicKey, communityID []byte) (*RequestToJoin, error) {
-	return m.persistence.CanceledRequestToJoinForUserForCommunityID(common.PubkeyToHex(pk), communityID)
-}
-
 func (m *Manager) PendingRequestsToJoin() ([]*RequestToJoin, error) {
 	return m.persistence.PendingRequestsToJoin()
 }

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -691,26 +691,6 @@ func (p *Persistence) CanceledRequestsToJoinForUser(pk string) ([]*RequestToJoin
 	return requests, nil
 }
 
-func (p *Persistence) CanceledRequestToJoinForUserForCommunityID(pk string, communityID []byte) (*RequestToJoin, error) {
-	row := p.db.QueryRow(`SELECT id,public_key,clock,ens_name,chat_id,community_id,state
-	FROM
-	communities_requests_to_join
-	WHERE
-	state = ? AND public_key = ? AND community_id = ?`,
-		RequestToJoinStateCanceled, pk, communityID)
-
-	request := &RequestToJoin{}
-
-	err := row.Scan(&request.ID, &request.PublicKey, &request.Clock, &request.ENSName, &request.ChatID, &request.CommunityID, &request.State)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	} else if err != nil {
-		return nil, err
-	}
-
-	return request, nil
-}
-
 func (p *Persistence) RequestsToJoinForUserByState(pk string, state RequestToJoinState) ([]*RequestToJoin, error) {
 	var requests []*RequestToJoin
 	rows, err := p.db.Query(`SELECT id,public_key,clock,ens_name,chat_id,community_id,state FROM communities_requests_to_join WHERE state = ? AND public_key = ?`, state, pk)
@@ -855,8 +835,8 @@ func (p *Persistence) GetRequestToJoinClockByPkAndCommunityID(pk string, communi
 	var clock uint64
 
 	err := p.db.QueryRow(`
-		SELECT clock 
-		FROM communities_requests_to_join 
+		SELECT clock
+		FROM communities_requests_to_join
 		WHERE public_key = ? AND community_id = ?`, pk, communityID).Scan(&clock)
 	return clock, err
 }

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1037,6 +1037,7 @@ func (m *Messenger) joinCommunity(ctx context.Context, communityID types.HexByte
 	if err = m.PublishIdentityImage(); err != nil {
 		return nil, err
 	}
+
 	// Was applicant not a member and successfully joined?
 	if !isCommunityMember && community.Joined() {
 		joinedNotification := &localnotifications.Notification{
@@ -2904,10 +2905,6 @@ func (m *Messenger) ShareCommunity(request *requests.ShareCommunity) (*Messenger
 
 func (m *Messenger) MyCanceledRequestsToJoin() ([]*communities.RequestToJoin, error) {
 	return m.communitiesManager.CanceledRequestsToJoinForUser(&m.identity.PublicKey)
-}
-
-func (m *Messenger) MyCanceledRequestToJoinForCommunityID(communityID []byte) (*communities.RequestToJoin, error) {
-	return m.communitiesManager.CanceledRequestToJoinForUserForCommunityID(&m.identity.PublicKey, communityID)
 }
 
 func (m *Messenger) MyPendingRequestsToJoin() ([]*communities.RequestToJoin, error) {


### PR DESCRIPTION
This fix fixed 2 issues:
1. If the user receives an outdated community request to join response - he will apply it. It leads to an issue described in the closed ticket
2. While accepting the request to join by the control node, the control node sends 2 msgs: `COMMUNITY_REQUEST_TO_JOIN_RESPONSE` and `COMMUNITY_DESCRIPTION`. There is no guarantee, that `COMMUNITY_REQUEST_TO_JOIN_RESPONSE` will be delivered before `COMMUNITY_DESCRIPTION`. If this happens, the client will join the community during `COMMUNITY_DESCRIPTION` and `COMMUNITY_REQUEST_TO_JOIN_RESPONSE` will fail with an error `ErrOrgAlreadyJoined` and launching `HistoryArchiveDownloadTask` will be skipped

Closes # https://github.com/status-im/status-desktop/issues/14456
