### PR TITLE
fix_: replace define statements in makefile with assignments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,20 +60,15 @@ GIT_AUTHOR := $(shell git config user.email || echo $$USER)
 
 ENABLE_METRICS ?= true
 BUILD_TAGS ?= gowaku_no_rln
-define BUILD_FLAGS ?=
-	-ldflags="\
-	-X github.com/status-im/status-go/params.Version=$(RELEASE_TAG:v%=%) \
+
+BUILD_FLAGS ?= -ldflags="-X github.com/status-im/status-go/params.Version=$(RELEASE_TAG:v%=%) \
 	-X github.com/status-im/status-go/params.GitCommit=$(GIT_COMMIT) \
 	-X github.com/status-im/status-go/params.IpfsGatewayURL=$(IPFS_GATEWAY_URL) \
 	-X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=$(ENABLE_METRICS)"
-endef
 
-define BUILD_FLAGS_MOBILE ?=
-	-ldflags="\
-	-X github.com/status-im/status-go/params.Version=$(RELEASE_TAG:v%=%) \
+BUILD_FLAGS_MOBILE ?= -ldflags="-X github.com/status-im/status-go/params.Version=$(RELEASE_TAG:v%=%) \
 	-X github.com/status-im/status-go/params.GitCommit=$(GIT_COMMIT) \
 	-X github.com/status-im/status-go/params.IpfsGatewayURL=$(IPFS_GATEWAY_URL)"
-endef
 
 networkid ?= StatusChain
 


### PR DESCRIPTION
Faced here: https://github.com/status-im/status-desktop/issues/14938

Replacing define statements with assignments required to build with a lower version of GNU Make 3.81, which is the default for macOS 14.3.1.