### PR TITLE
feat(wallet)_: add Approve transaction type

### DIFF
--- a/services/wallet/activity/activity.go
+++ b/services/wallet/activity/activity.go
@@ -57,9 +57,9 @@ type Entry struct {
 	activityType    Type
 	activityStatus  Status
 	amountOut       *hexutil.Big // Used for activityType SendAT, SwapAT, BridgeAT
-	amountIn        *hexutil.Big // Used for activityType ReceiveAT, BuyAT, SwapAT, BridgeAT
+	amountIn        *hexutil.Big // Used for activityType ReceiveAT, BuyAT, SwapAT, BridgeAT, ApproveAT
 	tokenOut        *Token       // Used for activityType SendAT, SwapAT, BridgeAT
-	tokenIn         *Token       // Used for activityType ReceiveAT, BuyAT, SwapAT, BridgeAT
+	tokenIn         *Token       // Used for activityType ReceiveAT, BuyAT, SwapAT, BridgeAT, ApproveAT
 	symbolOut       *string
 	symbolIn        *string
 	sender          *eth.Address
@@ -260,6 +260,8 @@ func multiTransactionTypeToActivityType(mtType transfer.MultiTransactionType) Ty
 		return SwapAT
 	} else if mtType == transfer.MultiTransactionBridge {
 		return BridgeAT
+	} else if mtType == transfer.MultiTransactionApprove {
+		return ApproveAT
 	}
 	panic("unknown multi transaction type")
 }
@@ -321,6 +323,8 @@ func activityTypesToMultiTransactionTypes(trTypes []Type) []transfer.MultiTransa
 			mtType = transfer.MultiTransactionSwap
 		} else if t == BridgeAT {
 			mtType = transfer.MultiTransactionBridge
+		} else if t == ApproveAT {
+			mtType = transfer.MultiTransactionApprove
 		} else {
 			continue
 		}
@@ -648,7 +652,7 @@ func getActivityEntries(ctx context.Context, deps FilterDependencies, addresses 
 
 			mtInAmount, mtOutAmount := getMtInAndOutAmounts(dbMtFromAmount, dbMtToAmount)
 
-			// Extract activity type: SendAT/SwapAT/BridgeAT
+			// Extract activity type: SendAT/SwapAT/BridgeAT/ApproveAT
 			activityType := multiTransactionTypeToActivityType(transfer.MultiTransactionType(dbMtType.Byte))
 
 			if outChainIDDB.Valid && outChainIDDB.Int64 != 0 {

--- a/services/wallet/activity/filter.go
+++ b/services/wallet/activity/filter.go
@@ -41,6 +41,7 @@ const (
 	BridgeAT
 	ContractDeploymentAT
 	MintAT
+	ApproveAT
 )
 
 func allActivityTypesFilter() []Type {

--- a/services/wallet/transfer/multi_transaction_db.go
+++ b/services/wallet/transfer/multi_transaction_db.go
@@ -19,6 +19,7 @@ const (
 	MultiTransactionDBSend        = iota
 	MultiTransactionDBSwap
 	MultiTransactionDBBridge
+	MultiTransactionDBApprove
 )
 
 func mtDBTypeToMTType(mtDBType MultiTransactionDBType) MultiTransactionType {

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -148,6 +148,20 @@ func GenerateTestBridgeMultiTransaction(fromTr, toTr TestTransfer) MultiTransact
 	}
 }
 
+func GenerateTestApproveMultiTransaction(tr TestTransfer) MultiTransaction {
+	return MultiTransaction{
+		ID:          multiTransactionIDGenerator(),
+		Type:        MultiTransactionApprove,
+		FromAddress: tr.From,
+		ToAddress:   tr.To,
+		FromAsset:   tr.Token.Symbol,
+		ToAsset:     tr.Token.Symbol,
+		FromAmount:  (*hexutil.Big)(big.NewInt(tr.Value)),
+		ToAmount:    (*hexutil.Big)(big.NewInt(0)),
+		Timestamp:   uint64(tr.Timestamp),
+	}
+}
+
 // GenerateTestTransfers will generate transaction based on the TestTokens index and roll over if there are more than
 // len(TestTokens) transactions
 func GenerateTestTransfers(tb testing.TB, db *sql.DB, firstStartIndex int, count int) (result []TestTransfer, fromAddresses, toAddresses []eth_common.Address) {

--- a/services/wallet/transfer/transaction_manager.go
+++ b/services/wallet/transfer/transaction_manager.go
@@ -84,6 +84,7 @@ const (
 	MultiTransactionSend = iota
 	MultiTransactionSwap
 	MultiTransactionBridge
+	MultiTransactionApprove
 	MultiTransactionTypeInvalid = 255
 )
 


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/14824

Adds new mutliTx type Approve, to allow triggering explicit `approve` txs from the client. 
Logic for building the actual approve routs is kept as is (client-side).
