### PR TITLE
Scheduled store node fetches

### DIFF
--- a/protocol/common/code_control_flags.go
+++ b/protocol/common/code_control_flags.go
@@ -8,4 +8,6 @@ type CodeControlFlags struct {
 	// CuratedCommunitiesUpdateLoopEnabled indicates whether we should disable the curated communities update loop.
 	// Usually should be disabled in tests.
 	CuratedCommunitiesUpdateLoopEnabled bool
+	// Store node re-fetching interval in seconds
+	StoreNodeFetchInterval int
 }

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -129,6 +129,7 @@ func messengerDefaultConfig() config {
 
 	c.codeControlFlags.AutoRequestHistoricMessages = true
 	c.codeControlFlags.CuratedCommunitiesUpdateLoopEnabled = true
+	c.codeControlFlags.StoreNodeFetchInterval = 120
 	return c
 }
 


### PR DESCRIPTION
Fixes #5283

### Description
  - `Messenger.asyncRequestAllHistoricMessages()` is replaced by `Messenger.startStoreNodeFetchLoop()`
  - all requests for complete store node fetching go through `Messenger.storeSchedulerCh` that is read from by the loop above
  - Here https://github.com/status-im/status-go/blob/631b1afe428fc079b550eb274a30be300bc8197c/protocol/messenger_mailserver_cycle.go#L432 i don't understand the need to wrap `RequestAllHistoricMessages(false, false)` with `performMailserverRequest`, if same functionality is achieved with `RequestAllHistoricMessages(false, true)`. So this was removed