### PR TITLE
fix(config)_: fix TorrentConfig when loading node config from DB

### DIFF
--- a/api/defaults.go
+++ b/api/defaults.go
@@ -28,9 +28,6 @@ const walletAccountDefaultName = "Account 1"
 const keystoreRelativePath = "keystore"
 const DefaultKeycardPairingDataFile = "/ethereum/mainnet_rpc/keycard/pairings.json"
 
-const DefaultArchivesRelativePath = "data/archivedata"
-const DefaultTorrentTorrentsRelativePath = "data/torrents"
-
 const DefaultDataDir = "/ethereum/mainnet_rpc"
 const DefaultNodeName = "StatusIM"
 const DefaultLogFile = "geth.log"
@@ -325,8 +322,8 @@ func defaultNodeConfig(installationID string, request *requests.CreateAccount, o
 	nodeConfig.TorrentConfig = params.TorrentConfig{
 		Enabled:    false,
 		Port:       0,
-		DataDir:    filepath.Join(nodeConfig.RootDataDir, DefaultArchivesRelativePath),
-		TorrentDir: filepath.Join(nodeConfig.RootDataDir, DefaultTorrentTorrentsRelativePath),
+		DataDir:    filepath.Join(nodeConfig.RootDataDir, params.ArchivesRelativePath),
+		TorrentDir: filepath.Join(nodeConfig.RootDataDir, params.TorrentTorrentsRelativePath),
 	}
 
 	if request.TorrentConfigEnabled != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -819,6 +819,16 @@ func (c *NodeConfig) UpdateWithDefaults() error {
 		c.WakuConfig.MinimumPoW = WakuMinimumPoW
 	}
 
+	// Ensure TorrentConfig is valid
+	if c.TorrentConfig.Enabled {
+		if c.TorrentConfig.DataDir == "" {
+			c.TorrentConfig.DataDir = filepath.Join(c.RootDataDir, ArchivesRelativePath)
+		}
+		if c.TorrentConfig.TorrentDir == "" {
+			c.TorrentConfig.TorrentDir = filepath.Join(c.RootDataDir, TorrentTorrentsRelativePath)
+		}
+	}
+
 	return c.setDefaultPushNotificationsServers()
 }
 
@@ -1124,7 +1134,7 @@ func (c *TorrentConfig) Validate(validate *validator.Validate) error {
 		return err
 	}
 
-	if c.Enabled && c.DataDir == "" || c.TorrentDir == "" {
+	if c.Enabled && (c.DataDir == "" || c.TorrentDir == "") {
 		return fmt.Errorf("TorrentConfig.DataDir and TorrentConfig.TorrentDir cannot be \"\"")
 	}
 	return nil

--- a/params/defaults.go
+++ b/params/defaults.go
@@ -6,6 +6,9 @@ const (
 	// StatusDatabase path relative to DataDir.
 	StatusDatabase = "status-db"
 
+	ArchivesRelativePath        = "data/archivedata"
+	TorrentTorrentsRelativePath = "data/torrents"
+
 	// SendTransactionMethodName https://docs.walletconnect.com/advanced/rpc-reference/ethereum-rpc#eth_sendtransaction
 	SendTransactionMethodName = "eth_sendTransaction"
 

--- a/server/pairing/common.go
+++ b/server/pairing/common.go
@@ -347,8 +347,8 @@ func setDefaultNodeConfig(c *params.NodeConfig) error {
 	c.TorrentConfig = params.TorrentConfig{
 		Enabled:    specifiedTorrentConfigEnabled,
 		Port:       specifiedTorrentConfigPort,
-		DataDir:    filepath.Join(c.RootDataDir, api.DefaultArchivesRelativePath),
-		TorrentDir: filepath.Join(c.RootDataDir, api.DefaultTorrentTorrentsRelativePath),
+		DataDir:    filepath.Join(c.RootDataDir, params.ArchivesRelativePath),
+		TorrentDir: filepath.Join(c.RootDataDir, params.TorrentTorrentsRelativePath),
 	}
 
 	return nil


### PR DESCRIPTION
Closes [status-desktop/issues/14813](https://github.com/status-im/status-desktop/issues/14813)

* Repair TorrentConfig when starting the app (`UpdateWithDefaults`)
* Fix TorrentConfig validation condition `func (c *TorrentConfig) Validate`
* Do not save invalid configs in `SaveNodeConfig` (optional)
* Add tests
* Should help existing users who cannot login to the app:
<kbd>

![image](https://github.com/status-im/status-go/assets/1083341/1a76e56c-8f2c-4274-a9c5-7adad16d8502)

</kbd>

## Room for improvement

I found a similar code in the `setDefaultNodeConfig` function that fixes missing values. I wish the whole configuration was encapsulated (ideally behind an interface(s)), with read-only access methods and methods to modify config without corrupting it, and an API to serialise/deserialise. 
It seems there are multiple places with ad-hoc code that patches nodeconfig with default values.
(`UpdateWithDefaults`, `setDefaultNodeConfig`, `OverwriteNodeConfigValues`, `prepareConfig`).

## Related tickets
related to
https://github.com/status-im/status-desktop/issues/14643
https://github.com/status-im/status-desktop/issues/12918 

