### PR TITLE
feat: adapt create/restore/login endpoints for keycard usage

### DIFF
--- a/api/backend.go
+++ b/api/backend.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"crypto/ecdsa"
+
 	signercore "github.com/ethereum/go-ethereum/signer/core/apitypes"
 
 	"github.com/status-im/status-go/eth-node/types"
@@ -18,8 +20,8 @@ type StatusBackend interface {
 	// IsNodeRunning() bool                       // NOTE: Only used in tests
 	StartNode(config *params.NodeConfig) error // NOTE: Only used in canary
 	StartNodeWithKey(acc multiaccounts.Account, password string, keyHex string, conf *params.NodeConfig) error
-	StartNodeWithAccount(acc multiaccounts.Account, password string, conf *params.NodeConfig) error
-	StartNodeWithAccountAndInitialConfig(account multiaccounts.Account, password string, settings settings.Settings, conf *params.NodeConfig, subaccs []*accounts.Account) error
+	StartNodeWithAccount(acc multiaccounts.Account, password string, conf *params.NodeConfig, chatKey *ecdsa.PrivateKey) error
+	StartNodeWithAccountAndInitialConfig(account multiaccounts.Account, password string, settings settings.Settings, conf *params.NodeConfig, subaccs []*accounts.Account, chatKey *ecdsa.PrivateKey) error
 	StopNode() error
 	// RestartNode() error // NOTE: Only used in tests
 

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -1816,18 +1816,19 @@ func TestRestoreKeycardAccountAndLogin(t *testing.T) {
 
 	keycardPairingDataFile := exampleRequest["createAccountRequest"].(map[string]interface{})["keycardPairingDataFile"].(string)
 
-	request := &requests.RestoreKeycardAccount{
-		KeyUID:              exampleKeycardEvent["keyUid"].(string),
-		Address:             exampleKeycardEvent["masterKey"].(map[string]interface{})["address"].(string),
-		WhisperPrivateKey:   exampleKeycardEvent["whisperKey"].(map[string]interface{})["privateKey"].(string),
-		WhisperPublicKey:    exampleKeycardEvent["whisperKey"].(map[string]interface{})["publicKey"].(string),
-		WhisperAddress:      exampleKeycardEvent["whisperKey"].(map[string]interface{})["address"].(string),
-		WalletPublicKey:     exampleKeycardEvent["walletKey"].(map[string]interface{})["publicKey"].(string),
-		WalletAddress:       exampleKeycardEvent["walletKey"].(map[string]interface{})["address"].(string),
-		WalletRootAddress:   exampleKeycardEvent["walletRootKey"].(map[string]interface{})["address"].(string),
-		Eip1581Address:      exampleKeycardEvent["eip1581Key"].(map[string]interface{})["address"].(string),
-		EncryptionPublicKey: exampleKeycardEvent["encryptionKey"].(map[string]interface{})["publicKey"].(string),
-
+	request := &requests.RestoreAccount{
+		Keycard: &requests.KeycardData{
+			KeyUID:              exampleKeycardEvent["keyUid"].(string),
+			Address:             exampleKeycardEvent["masterKey"].(map[string]interface{})["address"].(string),
+			WhisperPrivateKey:   exampleKeycardEvent["whisperKey"].(map[string]interface{})["privateKey"].(string),
+			WhisperPublicKey:    exampleKeycardEvent["whisperKey"].(map[string]interface{})["publicKey"].(string),
+			WhisperAddress:      exampleKeycardEvent["whisperKey"].(map[string]interface{})["address"].(string),
+			WalletPublicKey:     exampleKeycardEvent["walletKey"].(map[string]interface{})["publicKey"].(string),
+			WalletAddress:       exampleKeycardEvent["walletKey"].(map[string]interface{})["address"].(string),
+			WalletRootAddress:   exampleKeycardEvent["walletRootKey"].(map[string]interface{})["address"].(string),
+			Eip1581Address:      exampleKeycardEvent["eip1581Key"].(map[string]interface{})["address"].(string),
+			EncryptionPublicKey: exampleKeycardEvent["encryptionKey"].(map[string]interface{})["publicKey"].(string),
+		},
 		CreateAccount: requests.CreateAccount{
 			DisplayName:            "User-1",
 			Password:               "password123",

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -1135,7 +1135,7 @@ func TestConvertAccount(t *testing.T) {
 	err = backend.ensureAppDBOpened(account, password)
 	require.NoError(t, err)
 
-	err = backend.StartNodeWithAccountAndInitialConfig(account, password, *defaultSettings, nodeConfig, profileKeypair.Accounts)
+	err = backend.StartNodeWithAccountAndInitialConfig(account, password, *defaultSettings, nodeConfig, profileKeypair.Accounts, nil)
 	require.NoError(t, err)
 	multiaccounts, err := backend.GetAccounts()
 	require.NoError(t, err)
@@ -1294,7 +1294,7 @@ func loginDesktopUser(t *testing.T, conf *params.NodeConfig) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := b.StartNodeWithAccount(accounts[0], passwd, conf)
+		err := b.StartNodeWithAccount(accounts[0], passwd, conf, nil)
 		require.NoError(t, err)
 	}()
 

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -1073,7 +1073,7 @@ func TestConvertAccount(t *testing.T) {
 	found = keystoreContainsFileForAccount(keyStoreDir, chatAddress)
 	require.True(t, found)
 
-	defaultSettings, err := defaultSettings(genAccInfo, derivedAccounts)
+	defaultSettings, err := defaultSettings(genAccInfo.KeyUID, genAccInfo.Address, derivedAccounts)
 	require.NoError(t, err)
 	nodeConfig, err := defaultNodeConfig(defaultSettings.InstallationID, &requests.CreateAccount{
 		LogLevel: defaultSettings.LogLevel,
@@ -1681,4 +1681,164 @@ func TestCreateAccountPathsValidation(t *testing.T) {
 	err = request.Validate(validation)
 	require.NoError(t, err)
 	require.Equal(t, tmpdir, request.RootDataDir)
+}
+
+func TestRestoreKeycardAccountAndLogin(t *testing.T) {
+	//storeToKeychain := false
+	//recoverAccount := true
+
+	exampleKeycardEvent := map[string]interface{}{
+		"error":       "",
+		"instanceUID": "a84599394887b742eed9a99d3834a797",
+		"applicationInfo": map[string]interface{}{
+			"initialized":    false,
+			"instanceUID":    "",
+			"version":        0,
+			"availableSlots": 0,
+			"keyUID":         "",
+		},
+		"seedPhraseIndexes": []interface{}{},
+		"freePairingSlots":  0,
+		"keyUid":            "0x579324c53f347e18961c775a00ec13ed7d59a225b1859d5125ff36b450b8778d",
+		"pinRetries":        0,
+		"pukRetries":        0,
+		"cardMetadata": map[string]interface{}{
+			"name":           "",
+			"walletAccounts": []interface{}{},
+		},
+		"generatedWalletAccount": map[string]interface{}{
+			"address":    "",
+			"publicKey":  "",
+			"privateKey": "",
+		},
+		"generatedWalletAccounts": []interface{}{},
+		"txSignature": map[string]interface{}{
+			"r": "",
+			"s": "",
+			"v": "",
+		},
+		"eip1581Key": map[string]interface{}{
+			"address":    "0xA8d50f0B3bc581298446be8FBfF5c71684Ea6c01",
+			"publicKey":  "0x040d7e6e3761ab3d17c220e484ede2f3fa02998b859d4d0e9d34216c6e41b03dc94996fdea23a9233092cee50a768e7428d5de7bd42e8e32c10d6b0e36b10f0e7a",
+			"privateKey": "",
+		},
+		"encryptionKey": map[string]interface{}{
+			"address":    "0x1ec12f2b323ddDD076A1127cEc8FA0B592c46cD3",
+			"publicKey":  "0x04c4b16f670b51702dc130673bf9c64ffd1f69383cef2127dfa05031b9b1359120f7342134af9a350465126a85e87cb003b7c4f93d2ba2ff98bb73277b119c7a87",
+			"privateKey": "68c830d5b327382a65e6c302594744ec0d28b01d1ea8124f49714f05c9625ddd"},
+		"masterKey": map[string]interface{}{
+			"address":    "0xbf9dE86774051537b2192Ce9c8d2496f129bA24b",
+			"publicKey":  "0x040d909a07ecca18bbfa7d53d10a86bd956f54b8b446eabd94940e642ae18421b516ec5b63677c4ce65e0e266b58bdb716d8266b25356154eb61713ecb23824075",
+			"privateKey": "",
+		},
+		"walletKey": map[string]interface{}{
+			"address":    "0xB9E1998e1A8854887CA327D1aF5894B6CB0AC07D",
+			"publicKey":  "0x04c16e7748f34e0ab2c9c13350d7872d928e942934dd8b8abd3fb12b8c742a5ee8cf0919731e800907068afec25f577bde3a9c534795e359ee48097e4e55f4aaca",
+			"privateKey": "",
+		},
+		"walletRootKey": map[string]interface{}{
+			"address":    "0xFf59db9F2f97Db7104A906C390D33C342a1309C8",
+			"publicKey":  "0x04c436532398e19ed14b4eb41545b82014435d60e7db4449a371fd80d0d5cd557f60d81f6c2b35ca5440aa60934c23b70489b0e7963e63ec66b51a7e52db711262",
+			"privateKey": "",
+		},
+		"whisperKey": map[string]interface{}{
+			"address":    "0xBa122B9c0Ef560813b5D2C0961094aC36289f846",
+			"publicKey":  "0x0441468c39b579259676350b9736b01cdadb740f67bfd022fa2b985123b1d66fc3191cfe73205e3d3d84148f0248f9a2978afeeda16d7c3db90bd2579f0de33459",
+			"privateKey": "5a42b4f15ff1a5da95d116442ce11a31e9020f562224bf60b1d8d3a99d90653d",
+		},
+		"masterKeyAddress": "",
+	}
+
+	exampleRequest := map[string]interface{}{
+		"mnemonic":    "",
+		"fetchBackup": true,
+		"createAccountRequest": map[string]interface{}{
+			"rootDataDir":   "/Users/igorsirotin/Repositories/Status/status-desktop/Status/data/",
+			"kdfIterations": 256000,
+			"deviceName":    "",
+			"displayName":   "",
+			"password":      "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+			"imagePath":     "",
+			"imageCropRectangle": map[string]interface{}{
+				"ax": 0, "ay": 0, "bx": 0, "by": 0},
+			"customizationColor":       "primary",
+			"emoji":                    "",
+			"wakuV2Nameserver":         nil,
+			"wakuV2LightClient":        false,
+			"logLevel":                 "DEBUG",
+			"logFilePath":              "",
+			"logEnabled":               false,
+			"previewPrivacy":           true,
+			"verifyTransactionURL":     nil,
+			"verifyENSURL":             nil,
+			"verifyENSContractAddress": nil,
+			"verifyTransactionChainID": nil,
+			"upstreamConfig":           "",
+			"networkID":                nil,
+			"walletSecretsConfig": map[string]interface{}{"poktToken": "849214fd2f85acead08f5184",
+				"infuraToken":                 "220a1abb4b6943a093c35d0ce4fb0732",
+				"infuraSecret":                "",
+				"openseaApiKey":               "",
+				"raribleMainnetApiKey":        "",
+				"raribleTestnetApiKey":        "",
+				"alchemyEthereumMainnetToken": "",
+				"alchemyEthereumGoerliToken":  "",
+				"alchemyEthereumSepoliaToken": "",
+				"alchemyArbitrumMainnetToken": "",
+				"alchemyArbitrumGoerliToken":  "",
+				"alchemyArbitrumSepoliaToken": "",
+				"alchemyOptimismMainnetToken": "",
+				"alchemyOptimismGoerliToken":  "",
+				"alchemyOptimismSepoliaToken": "",
+			},
+			"torrentConfigEnabled":   false,
+			"torrentConfigPort":      0,
+			"keycardInstanceUID":     "a84599394887b742eed9a99d3834a797",
+			"keycardPairingDataFile": "/Users/igorsirotin/Repositories/Status/status-desktop/Status/data/keycard/pairings.json",
+		},
+	}
+
+	require.NotNil(t, exampleKeycardEvent)
+	require.NotNil(t, exampleRequest)
+
+	utils.Init()
+	tmpdir := t.TempDir()
+
+	conf, err := params.NewNodeConfig(tmpdir, 1777)
+	require.NoError(t, err)
+
+	backend := NewGethStatusBackend()
+
+	require.NoError(t, backend.AccountManager().InitKeystore(conf.KeyStoreDir))
+	backend.UpdateRootDataDir(conf.DataDir)
+
+	require.NoError(t, backend.OpenAccounts())
+
+	keycardPairingDataFile := exampleRequest["createAccountRequest"].(map[string]interface{})["keycardPairingDataFile"].(string)
+
+	request := &requests.RestoreKeycardAccount{
+		KeyUID:              exampleKeycardEvent["keyUid"].(string),
+		Address:             exampleKeycardEvent["masterKey"].(map[string]interface{})["address"].(string),
+		WhisperPrivateKey:   exampleKeycardEvent["whisperKey"].(map[string]interface{})["privateKey"].(string),
+		WhisperPublicKey:    exampleKeycardEvent["whisperKey"].(map[string]interface{})["publicKey"].(string),
+		WhisperAddress:      exampleKeycardEvent["whisperKey"].(map[string]interface{})["address"].(string),
+		WalletPublicKey:     exampleKeycardEvent["walletKey"].(map[string]interface{})["publicKey"].(string),
+		WalletAddress:       exampleKeycardEvent["walletKey"].(map[string]interface{})["address"].(string),
+		WalletRootAddress:   exampleKeycardEvent["walletRootKey"].(map[string]interface{})["address"].(string),
+		Eip1581Address:      exampleKeycardEvent["eip1581Key"].(map[string]interface{})["address"].(string),
+		EncryptionPublicKey: exampleKeycardEvent["encryptionKey"].(map[string]interface{})["publicKey"].(string),
+
+		CreateAccount: requests.CreateAccount{
+			DisplayName:            "User-1",
+			Password:               "password123",
+			CustomizationColor:     "#ffffff",
+			RootDataDir:            tmpdir,
+			KeycardInstanceUID:     exampleKeycardEvent["instanceUID"].(string),
+			KeycardPairingDataFile: &keycardPairingDataFile,
+		},
+	}
+
+	acc, err := backend.RestoreKeycardAccountAndLogin(request)
+	require.NoError(t, err)
+	require.NotNil(t, acc)
 }

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -21,6 +21,7 @@ import (
 const pathWalletRoot = "m/44'/60'/0'/0"
 const pathEIP1581 = "m/43'/60'/1581'"
 const pathDefaultChat = pathEIP1581 + "/0'/0"
+const pathEncryption = pathEIP1581 + "/1'/0"
 const pathDefaultWallet = pathWalletRoot + "/0"
 const defaultMnemonicLength = 12
 const shardsTestClusterID = 16
@@ -38,7 +39,7 @@ const DefaultListenAddr = ":0"
 const DefaultMaxMessageDeliveryAttempts = 6
 const DefaultVerifyTransactionChainID = 1
 
-var paths = []string{pathWalletRoot, pathEIP1581, pathDefaultChat, pathDefaultWallet}
+var paths = []string{pathWalletRoot, pathEIP1581, pathDefaultChat, pathDefaultWallet, pathEncryption}
 
 var DefaultFleet = params.FleetShardsTest
 

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -223,8 +223,11 @@ func defaultNodeConfig(installationID string, request *requests.CreateAccount, o
 	nodeConfig.LogDir = request.LogFilePath
 	nodeConfig.LogLevel = DefaultLogLevel
 	nodeConfig.DataDir = DefaultDataDir
-	nodeConfig.KeycardPairingDataFile = DefaultKeycardPairingDataFile
 	nodeConfig.ProcessBackedupMessages = false
+	nodeConfig.KeycardPairingDataFile = DefaultKeycardPairingDataFile
+	if request.KeycardPairingDataFile != nil {
+		nodeConfig.KeycardPairingDataFile = *request.KeycardPairingDataFile
+	}
 
 	if request.LogLevel != nil {
 		nodeConfig.LogLevel = *request.LogLevel

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -43,7 +43,7 @@ var paths = []string{pathWalletRoot, pathEIP1581, pathDefaultChat, pathDefaultWa
 
 var DefaultFleet = params.FleetShardsTest
 
-func defaultSettings(generatedAccountInfo generator.GeneratedAccountInfo, derivedAddresses map[string]generator.AccountInfo) (*settings.Settings, error) {
+func defaultSettings(keyUID string, address string, derivedAddresses map[string]generator.AccountInfo) (*settings.Settings, error) {
 	chatKeyString := derivedAddresses[pathDefaultChat].PublicKey
 
 	s := &settings.Settings{}
@@ -52,8 +52,8 @@ func defaultSettings(generatedAccountInfo generator.GeneratedAccountInfo, derive
 	s.LogLevel = &logLevel
 	s.ProfilePicturesShowTo = settings.ProfilePicturesShowToEveryone
 	s.ProfilePicturesVisibility = settings.ProfilePicturesVisibilityEveryone
-	s.KeyUID = generatedAccountInfo.KeyUID
-	s.Address = types.HexToAddress(generatedAccountInfo.Address)
+	s.KeyUID = keyUID
+	s.Address = types.HexToAddress(address)
 	s.WalletRootAddress = types.HexToAddress(derivedAddresses[pathWalletRoot].Address)
 	s.URLUnfurlingMode = settings.URLUnfurlingAlwaysAsk
 

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -532,6 +532,9 @@ func (b *GethStatusBackend) LoginAccount(request *requests.Login) error {
 		// Stop node for clean up
 		_ = b.StopNode()
 	}
+	if b.LocalPairingStateManager.IsPairing() {
+		return nil
+	}
 	return b.LoggedIn(request.KeyUID, err)
 }
 

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -475,13 +475,12 @@ func (b *GethStatusBackend) StartNodeWithKey(acc multiaccounts.Account, password
 	if err != nil {
 		// Stop node for clean up
 		_ = b.StopNode()
-		return err
 	}
 	// get logged in
-	if !b.LocalPairingStateManager.IsPairing() {
-		return b.LoggedIn(acc.KeyUID, err)
+	if b.LocalPairingStateManager.IsPairing() {
+		return nil
 	}
-	return nil
+	return b.LoggedIn(acc.KeyUID, err)
 }
 
 func (b *GethStatusBackend) OverwriteNodeConfigValues(conf *params.NodeConfig, n *params.NodeConfig) (*params.NodeConfig, error) {

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1306,42 +1306,42 @@ func (b *GethStatusBackend) RestoreAccountAndLogin(request *requests.RestoreAcco
 	return response.account, nil
 }
 
-func (b *GethStatusBackend) RestoreKeycardAccountAndLogin(request *requests.RestoreKeycardAccount) (*multiaccounts.Account, error) {
+func (b *GethStatusBackend) RestoreKeycardAccountAndLogin(request *requests.RestoreAccount) (*multiaccounts.Account, error) {
 	if err := request.Validate(); err != nil {
 		return nil, err
 	}
 
-	keyStoreDir, err := b.initKeyStoreDirWithAccount(request.RootDataDir, request.KeyUID)
+	keyStoreDir, err := b.initKeyStoreDirWithAccount(request.RootDataDir, request.Keycard.KeyUID)
 	if err != nil {
 		return nil, err
 	}
 
 	derivedAddresses := map[string]generator.AccountInfo{
 		pathDefaultChat: {
-			Address:    request.WhisperAddress,
-			PublicKey:  request.WhisperPublicKey,
-			PrivateKey: request.WhisperPrivateKey,
+			Address:    request.Keycard.WhisperAddress,
+			PublicKey:  request.Keycard.WhisperPublicKey,
+			PrivateKey: request.Keycard.WhisperPrivateKey,
 		},
 		pathWalletRoot: {
-			Address: request.WalletRootAddress,
+			Address: request.Keycard.WalletRootAddress,
 		},
 		pathDefaultWallet: {
-			Address:   request.WalletAddress,
-			PublicKey: request.WalletPublicKey,
+			Address:   request.Keycard.WalletAddress,
+			PublicKey: request.Keycard.WalletPublicKey,
 		},
 		pathEIP1581: {
-			Address: request.Eip1581Address,
+			Address: request.Keycard.Eip1581Address,
 		},
 		pathEncryption: {
-			PublicKey: request.EncryptionPublicKey,
+			PublicKey: request.Keycard.EncryptionPublicKey,
 		},
 	}
 
 	input := &prepareAccountInput{
 		customizationColorClock: 0,
 		accountID:               "", // empty for keycard
-		keyUID:                  request.KeyUID,
-		address:                 request.Address,
+		keyUID:                  request.Keycard.KeyUID,
+		address:                 request.Keycard.Address,
 		mnemonic:                "",
 		restoringAccount:        true,
 		derivedAddresses:        derivedAddresses,

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1294,7 +1294,8 @@ func (b *GethStatusBackend) RestoreAccountAndLogin(request *requests.RestoreAcco
 		*response.account,
 		request.Password,
 		*response.settings,
-		response.nodeConfig, response.subAccounts,
+		response.nodeConfig,
+		response.subAccounts,
 		response.chatPrivateKey,
 	)
 
@@ -1581,18 +1582,6 @@ func (b *GethStatusBackend) prepareSettings(request *requests.CreateAccount, inp
 	settings.CurrentNetwork = request.CurrentNetwork
 	settings.TestNetworksEnabled = request.TestNetworksEnabled
 
-	/*
-		 Case 1. Generating new account
-			mnemonic +
-			omit +
-		 Case 2. Restoring from seed phrase
-			mnemonic -
-			omit -
-		 Case 3. Login with keycard (account not generated, but need to fetch backup)
-			mnemonic -
-			omit -
-	*/
-
 	if !input.restoringAccount {
 		settings.Mnemonic = &input.mnemonic
 		settings.OmitTransfersHistoryScan = true
@@ -1621,18 +1610,15 @@ func (b *GethStatusBackend) prepareConfig(request *requests.CreateAccount, input
 func (b *GethStatusBackend) prepareSubAccounts(request *requests.CreateAccount, input *prepareAccountInput) ([]*accounts.Account, error) {
 	walletDerivedAccount := input.derivedAddresses[pathDefaultWallet]
 	walletAccount := &accounts.Account{
-		PublicKey: types.Hex2Bytes(walletDerivedAccount.PublicKey),
-		KeyUID:    input.keyUID,
-		Address:   types.HexToAddress(walletDerivedAccount.Address),
-		ColorID:   multiacccommon.CustomizationColor(request.CustomizationColor),
-		Emoji:     request.Emoji,
-		Wallet:    true,
-		Path:      pathDefaultWallet,
-		Name:      walletAccountDefaultName,
-	}
-
-	if input.restoringAccount {
-		walletAccount.AddressWasNotShown = true
+		PublicKey:          types.Hex2Bytes(walletDerivedAccount.PublicKey),
+		KeyUID:             input.keyUID,
+		Address:            types.HexToAddress(walletDerivedAccount.Address),
+		ColorID:            multiacccommon.CustomizationColor(request.CustomizationColor),
+		Emoji:              request.Emoji,
+		Wallet:             true,
+		Path:               pathDefaultWallet,
+		Name:               walletAccountDefaultName,
+		AddressWasNotShown: !input.restoringAccount,
 	}
 
 	chatDerivedAccount := input.derivedAddresses[pathDefaultChat]

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1444,6 +1444,10 @@ func (b *GethStatusBackend) prepareNodeAccount(request *requests.CreateAccount, 
 		request.Password = input.derivedAddresses[pathEncryption].PublicKey
 	}
 
+	// NOTE: I intentionally left this condition separately and not an `else` branch. Technically it's an `else`,
+	// 		 but the statements inside are not the opposite statement of the first statement. It's just kinda like this:
+	// 		 - replace password when we're using keycard
+	// 		 - store account when we're not using keycard
 	if request.KeycardInstanceUID == "" {
 		err = b.storeAccount(input.accountID, request.Password, paths)
 		if err != nil {

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1884,15 +1884,6 @@ func (b *GethStatusBackend) SaveAccountAndStartNodeWithKey(
 	subaccs []*accounts.Account,
 	keyHex string,
 ) error {
-	b.log.Info("<<< SaveAccountAndStartNodeWithKey",
-		"account", account,
-		"settings", settings,
-		"nodecfg", nodecfg,
-		"subaccs", subaccs,
-		"keyHex", keyHex,
-		"password", password,
-	)
-
 	err := enrichMultiAccountBySubAccounts(&account, subaccs)
 	if err != nil {
 		return err
@@ -1924,8 +1915,6 @@ func (b *GethStatusBackend) StartNodeWithAccountAndInitialConfig(
 	subaccs []*accounts.Account,
 	chatKey *ecdsa.PrivateKey,
 ) error {
-	b.log.Info("<<< node config", "config", nodecfg)
-
 	err := enrichMultiAccountBySubAccounts(&account, subaccs)
 	if err != nil {
 		return err

--- a/api/messenger_raw_message_resend_test.go
+++ b/api/messenger_raw_message_resend_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/protocol/tt"
 	"github.com/status-im/status-go/services/utils"
+	"github.com/status-im/status-go/signal"
+	tutils "github.com/status-im/status-go/t/utils"
 	"github.com/status-im/status-go/wakuv2"
 
 	"github.com/stretchr/testify/suite"
@@ -29,6 +31,7 @@ import (
 
 type MessengerRawMessageResendTest struct {
 	suite.Suite
+	logger         *zap.Logger
 	aliceBackend   *GethStatusBackend
 	bobBackend     *GethStatusBackend
 	aliceMessenger *protocol.Messenger
@@ -43,8 +46,13 @@ func TestMessengerRawMessageResendTestSuite(t *testing.T) {
 }
 
 func (s *MessengerRawMessageResendTest) SetupTest() {
-	logger, err := zap.NewDevelopment()
+	tutils.Init()
+
+	var err error
+	s.logger, err = zap.NewDevelopment()
 	s.Require().NoError(err)
+
+	signal.SetMobileSignalHandler(nil)
 
 	exchangeNodeConfig := &wakuv2.Config{
 		Port:                     0,
@@ -54,7 +62,7 @@ func (s *MessengerRawMessageResendTest) SetupTest() {
 		UseShardAsDefaultTopic:   true,
 		DefaultShardPubsubTopic:  shard.DefaultShardPubsubTopic(),
 	}
-	s.exchangeBootNode, err = wakuv2.New(nil, "", exchangeNodeConfig, logger.Named("pxServerNode"), nil, nil, nil, nil)
+	s.exchangeBootNode, err = wakuv2.New(nil, "", exchangeNodeConfig, s.logger.Named("pxServerNode"), nil, nil, nil, nil)
 	s.Require().NoError(err)
 	s.Require().NoError(s.exchangeBootNode.Start())
 

--- a/cmd/ping-community/main.go
+++ b/cmd/ping-community/main.go
@@ -449,7 +449,7 @@ func ImportAccount(seedPhrase string, backend *api.GethStatusBackend) error {
 
 	fmt.Println(nodeConfig)
 	accounts := []*accounts.Account{walletAccount, chatAccount}
-	err = backend.StartNodeWithAccountAndInitialConfig(account, "", *settings, nodeConfig, accounts)
+	err = backend.StartNodeWithAccountAndInitialConfig(account, "", *settings, nodeConfig, accounts, nil)
 	if err != nil {
 		logger.Error("start node", err)
 		return err

--- a/cmd/populate-db/main.go
+++ b/cmd/populate-db/main.go
@@ -498,7 +498,7 @@ func ImportAccount(seedPhrase string, backend *api.GethStatusBackend) error {
 
 	fmt.Println(nodeConfig)
 	accounts := []*accounts.Account{walletAccount, chatAccount}
-	err = backend.StartNodeWithAccountAndInitialConfig(account, "", *settings, nodeConfig, accounts)
+	err = backend.StartNodeWithAccountAndInitialConfig(account, "", *settings, nodeConfig, accounts, nil)
 	if err != nil {
 		logger.Error("start node", err)
 		return err

--- a/cmd/spiff-workflow/main.go
+++ b/cmd/spiff-workflow/main.go
@@ -420,9 +420,9 @@ func ImportAccount(seedPhrase string, backend *api.GethStatusBackend) error {
 	fmt.Println(nodeConfig)
 	accounts := []*accounts.Account{walletAccount, chatAccount}
 	if !exist {
-		return backend.StartNodeWithAccountAndInitialConfig(account, "", *settings, nodeConfig, accounts)
+		return backend.StartNodeWithAccountAndInitialConfig(account, "", *settings, nodeConfig, accounts, nil)
 	}
-	return backend.StartNodeWithAccount(account, "", nodeConfig)
+	return backend.StartNodeWithAccount(account, "", nodeConfig, nil)
 }
 
 func retrieveMessagesLoop(messenger *protocol.Messenger, tick time.Duration) {

--- a/eth-node/types/key.go
+++ b/eth-node/types/key.go
@@ -18,7 +18,7 @@ type Key struct {
 	// ExtendedKey is the extended key of the PrivateKey itself, and it's used
 	// to derive child keys.
 	ExtendedKey *extkeys.ExtendedKey
-	// SubAccountIndex is DEPRECATED
+	// Deprecated: SubAccountIndex
 	// It was use in Status to keep track of the number of sub-account created
 	// before having multi-account support.
 	SubAccountIndex uint32

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -237,7 +237,7 @@ func login(accountData, password, configJSON string) error {
 			return statusBackend.LoggedIn(account.KeyUID, err)
 		}
 
-		err = statusBackend.StartNodeWithAccount(account, password, &conf)
+		err = statusBackend.StartNodeWithAccount(account, password, &conf, nil)
 		if err != nil {
 			log.Error("failed to start a node", "key-uid", account.KeyUID, "error", err)
 			return err
@@ -382,7 +382,7 @@ func SaveAccountAndLogin(accountData, password, settingsJSON, configJSON, subacc
 
 	api.RunAsync(func() error {
 		log.Debug("starting a node, and saving account with configuration", "key-uid", account.KeyUID)
-		err := statusBackend.StartNodeWithAccountAndInitialConfig(account, password, settings, &conf, subaccs)
+		err := statusBackend.StartNodeWithAccountAndInitialConfig(account, password, settings, &conf, subaccs, nil)
 		if err != nil {
 			log.Error("failed to start node and save account", "key-uid", account.KeyUID, "error", err)
 			return err
@@ -419,7 +419,8 @@ func InitKeystore(keydir string) string {
 	return makeJSONResponse(err)
 }
 
-// SaveAccountAndLoginWithKeycard saves account in status-go database..
+// SaveAccountAndLoginWithKeycard saves account in status-go database.
+// Deprecated: Use CreateAndAccountAndLogin with required keycard properties.
 func SaveAccountAndLoginWithKeycard(accountData, password, settingsJSON, configJSON, subaccountData string, keyHex string) string {
 	var account multiaccounts.Account
 	err := json.Unmarshal([]byte(accountData), &account)
@@ -457,6 +458,7 @@ func SaveAccountAndLoginWithKeycard(accountData, password, settingsJSON, configJ
 
 // LoginWithKeycard initializes an account with a chat key and encryption key used for PFS.
 // It purges all the previous identities from Whisper, and injects the key as shh identity.
+// Deprecated: Use LoginAccount instead.
 func LoginWithKeycard(accountData, password, keyHex string, configJSON string) string {
 	var account multiaccounts.Account
 	err := json.Unmarshal([]byte(accountData), &account)

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -339,7 +339,13 @@ func RestoreAccountAndLogin(requestJSON string) string {
 
 	api.RunAsync(func() error {
 		log.Debug("starting a node and restoring account")
-		_, err := statusBackend.RestoreAccountAndLogin(&request)
+
+		if request.Keycard != nil {
+			_, err = statusBackend.RestoreKeycardAccountAndLogin(&request)
+		} else {
+			_, err = statusBackend.RestoreAccountAndLogin(&request)
+		}
+
 		if err != nil {
 			log.Error("failed to restore account", "error", err)
 			return err
@@ -347,6 +353,7 @@ func RestoreAccountAndLogin(requestJSON string) string {
 		log.Debug("started a node, and restored account")
 		return nil
 	})
+
 	return makeJSONResponse(nil)
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -328,6 +328,9 @@ type NodeConfig struct {
 	KeyStoreDir string `validate:"required"`
 
 	// KeycardPairingDataFile is the file where we keep keycard pairings data.
+	// It's specified by clients (and not in status-go) when creating a new account,
+	// because this file is initialized by status-keycard-go and we need to use it before initializing the node.
+	// I guess proper way would be to ask status-go for the file path, or just duplicate the file path in both backend and client.
 	// note: this field won't be saved into db, it's local to the device.
 	KeycardPairingDataFile string
 

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -75,9 +75,8 @@ type CreateAccount struct {
 
 	APIConfig *APIConfig `json:"apiConfig"`
 
-	KeycardInstanceUID       string  `json:"keycardInstanceUID"`
-	KeycardPairingDataFile   *string `json:"keycardPairingDataFile"`
-	KeycardWhisperPrivateKey string  `json:"keycardWhisperPrivateKey"`
+	KeycardInstanceUID     string  `json:"keycardInstanceUID"`
+	KeycardPairingDataFile *string `json:"keycardPairingDataFile"` // WARNING: Do we actually need to pass it from client?
 }
 
 type WalletSecretsConfig struct {

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -74,6 +74,10 @@ type CreateAccount struct {
 	TelemetryServerURL string `json:"telemetryServerURL"`
 
 	APIConfig *APIConfig `json:"apiConfig"`
+
+	KeycardInstanceUID       string  `json:"keycardInstanceUID"`
+	KeycardPairingDataFile   *string `json:"keycardPairingDataFile"`
+	KeycardWhisperPrivateKey string  `json:"keycardWhisperPrivateKey"`
 }
 
 type WalletSecretsConfig struct {

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -76,7 +76,7 @@ type CreateAccount struct {
 	APIConfig *APIConfig `json:"apiConfig"`
 
 	KeycardInstanceUID     string  `json:"keycardInstanceUID"`
-	KeycardPairingDataFile *string `json:"keycardPairingDataFile"` // WARNING: Do we actually need to pass it from client?
+	KeycardPairingDataFile *string `json:"keycardPairingDataFile"`
 }
 
 type WalletSecretsConfig struct {

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -17,12 +17,17 @@ type Login struct {
 	Password string `json:"password"`
 	KeyUID   string `json:"keyUid"`
 
-	KdfIterations         int    `json:"kdfIterations"`
+	KdfIterations         int    `json:"kdfIterations"` // FIXME: KdfIterations should be loaded from multiaccounts db.
 	RuntimeLogLevel       string `json:"runtimeLogLevel"`
 	WakuV2Nameserver      string `json:"wakuV2Nameserver"`
 	BandwidthStatsEnabled bool   `json:"bandwidthStatsEnabled"`
-
+	
 	KeycardWhisperPrivateKey string `json:"keycardWhisperPrivateKey"`
+
+	// Mnemonic is used when the keycard is lost. When non-empty, mnemonic is used to generate required keypairs and:
+	// - Password is ignored and replaced with encryption private key
+	// - KeycardWhisperPrivateKey is ignored and replaced with chat private key
+	Mnemonic string `json:"mnemonic"`
 
 	WalletSecretsConfig
 }

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -24,7 +24,11 @@ type Login struct {
 	
 	KeycardWhisperPrivateKey string `json:"keycardWhisperPrivateKey"`
 
-	// Mnemonic is used when the keycard is lost. When non-empty, mnemonic is used to generate required keypairs and:
+	// Mnemonic allows to log in to an account when password is lost.
+	// This is needed for the "Lost keycard -> Start using without keycard" flow, when a keycard account database
+	// exists locally, but now the keycard is lost. In this case client is responsible for calling
+	// `convertToRegularAccount` after a successful login. This could be improved in the future.
+	// When non-empty, mnemonic is used to generate required keypairs and:
 	// - Password is ignored and replaced with encryption private key
 	// - KeycardWhisperPrivateKey is ignored and replaced with chat private key
 	Mnemonic string `json:"mnemonic"`

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -29,7 +29,7 @@ type Login struct {
 	// exists locally, but now the keycard is lost. In this case client is responsible for calling
 	// `convertToRegularAccount` after a successful login. This could be improved in the future.
 	// When non-empty, mnemonic is used to generate required keypairs and:
-	// - Password is ignored and replaced with encryption private key
+	// - Password is ignored and replaced with encryption public key
 	// - KeycardWhisperPrivateKey is ignored and replaced with chat private key
 	Mnemonic string `json:"mnemonic"`
 

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	ErrLoginInvalidKeyUID                           = errors.New("login: invalid key-uid")
-	ErrCreateAccountInvalidKeycardWhisperPrivateKey = errors.New("create-account: invalid keycard whisper private key")
+	ErrLoginInvalidKeyUID                   = errors.New("login: invalid key-uid")
+	ErrLoginInvalidKeycardWhisperPrivateKey = errors.New("login: invalid keycard whisper private key")
 )
 
 type Login struct {
@@ -40,7 +40,7 @@ func (c *Login) Validate() error {
 	if c.KeycardWhisperPrivateKey != "" {
 		_, err := parsePrivateKey(c.KeycardWhisperPrivateKey)
 		if err != nil {
-			return ErrCreateAccountInvalidKeycardWhisperPrivateKey
+			return ErrLoginInvalidKeycardWhisperPrivateKey
 		}
 	}
 

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -21,7 +21,7 @@ type Login struct {
 	RuntimeLogLevel       string `json:"runtimeLogLevel"`
 	WakuV2Nameserver      string `json:"wakuV2Nameserver"`
 	BandwidthStatsEnabled bool   `json:"bandwidthStatsEnabled"`
-	
+
 	KeycardWhisperPrivateKey string `json:"keycardWhisperPrivateKey"`
 
 	// Mnemonic allows to log in to an account when password is lost.

--- a/protocol/requests/restore_account.go
+++ b/protocol/requests/restore_account.go
@@ -21,3 +21,26 @@ func (c *RestoreAccount) Validate() error {
 		AllowEmptyDisplayName: true,
 	})
 }
+
+type RestoreKeycardAccount struct {
+	FetchBackup bool `json:"fetchBackup"`
+
+	KeyUID              string `json:"keyUID"`
+	Address             string `json:"address"`
+	WhisperPrivateKey   string `json:"whisperPrivateKey"`
+	WhisperPublicKey    string `json:"whisperPublicKey"`
+	WhisperAddress      string `json:"whisperAddress"`
+	WalletPublicKey     string `json:"walletPublicKey"`
+	WalletAddress       string `json:"walletAddress"`
+	WalletRootAddress   string `json:"walletRootAddress"`
+	Eip1581Address      string `json:"eip1581Address"`
+	EncryptionPublicKey string `json:"encryptionPublicKey"`
+
+	CreateAccount
+}
+
+func (c *RestoreKeycardAccount) Validate() error {
+	return c.CreateAccount.Validate(&CreateAccountValidation{
+		AllowEmptyDisplayName: true,
+	})
+}

--- a/server/pairing/raw_message_handler.go
+++ b/server/pairing/raw_message_handler.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
@@ -99,7 +100,8 @@ func (s *SyncRawMessageHandler) HandleRawMessage(accountPayload *AccountPayload,
 
 		var chatKey *ecdsa.PrivateKey
 		if accountPayload.chatKey != "" {
-			chatKey, err = ethcrypto.HexToECDSA(accountPayload.chatKey)
+			chatKeyHex := strings.Trim(accountPayload.chatKey, "0x")
+			chatKey, err = ethcrypto.HexToECDSA(chatKeyHex)
 			if err != nil {
 				return err
 			}

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -140,7 +140,7 @@ func (s *SyncDeviceSuite) prepareBackendWithAccount(mnemonic, tmpdir string) *ap
 	}
 
 	accounts := []*accounts.Account{walletAccount, chatAccount}
-	err = backend.StartNodeWithAccountAndInitialConfig(account, s.password, *settings, nodeConfig, accounts)
+	err = backend.StartNodeWithAccountAndInitialConfig(account, s.password, *settings, nodeConfig, accounts, nil)
 	require.NoError(s.T(), err)
 	multiaccounts, err := backend.GetAccounts()
 	require.NoError(s.T(), err)

--- a/services/wallet/keycard_pairings.go
+++ b/services/wallet/keycard_pairings.go
@@ -56,6 +56,10 @@ func (kp *KeycardPairings) GetPairings() (map[string]KeycardPairing, error) {
 		return nil, err
 	}
 
+	if len(content) == 0 {
+		return nil, os.ErrNotExist
+	}
+
 	pairings := make(map[string]KeycardPairing)
 	err = json.Unmarshal(content, &pairings)
 	if err != nil {

--- a/services/wallet/keycard_pairings.go
+++ b/services/wallet/keycard_pairings.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -8,6 +9,11 @@ import (
 
 type KeycardPairings struct {
 	pairingsFile string
+}
+
+type KeycardPairing struct {
+	Key   string `json:"key"`
+	Index int    `json:"index"`
 }
 
 func NewKeycardPairings() *KeycardPairings {
@@ -42,4 +48,19 @@ func (kp *KeycardPairings) SetPairingsJSONFileContent(content []byte) error {
 	}
 
 	return ioutil.WriteFile(kp.pairingsFile, content, 0600)
+}
+
+func (kp *KeycardPairings) GetPairings() (map[string]KeycardPairing, error) {
+	content, err := kp.GetPairingsJSONFileContent()
+	if err != nil {
+		return nil, err
+	}
+
+	pairings := make(map[string]KeycardPairing)
+	err = json.Unmarshal(content, &pairings)
+	if err != nil {
+		return nil, err
+	}
+
+	return pairings, nil
 }


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/4977

##  Modified endpoints to support keycard

1. Set keycard-related properties in settings and nodeConfig
2. Added keycard-related parameters to:
    - `CreateAccount`
      - `KeycardInstanceUID`
      - `KeycardPairingDataFile`
    - `RestoreAccount`
      - `Keycard`
    - `LoginAccount`
      - `KeycardWhisperPrivateKey`
      - `Mnemonic`
3. Added `RestoreKeycardAccountAndLogin` method
It's used for `Login with Keycard`, when the account exists on keycard, but was never logged in on this device.
4. `RestoreAccountAndLogin` endpoint will call keycard methods if `Keycard` parameter is present.
5. Added `pathEncryption` to be generated by default.
PublicKey is used as db password for keycard accounts.

## Refactoring

1. Refactoring
  - Wrap all errors in `loginAccount`
  - Single `accountBundle` return from `generateOrImportAccount`
  - Inside `generateOrImportAccount` grouped all prepare calls into `prepareNodeAccount` to be reused in another func
2. Deprecate:
  - `StartNodeWithKey`
  - `startNodeWithAccount`
  - `SaveAccountAndStartNodeWithKey`
  - `SaveAccountAndLoginWithKeycard`
  - `LoginWithKeycard`

## Accompanying changes

1. Implemented `KeycardPairing.GetPairings` method.
2. Fixes
- Added `setMobileHandler(nil)` to `MessengerRawMessageResendTest`
Otherwise it hangs when running all `api` package tests, because some of mobile handlers set in previous tests are still working, but the channel is not read and has a limit of 10. This should be fixed properly in a separate PR:
https://github.com/status-im/status-go/blob/c068d473c2425bf696c03dba76f0b4922fe21a5a/api/backend_test.go#L839-L843

# QA

Desktop will be tested here: https://github.com/status-im/status-desktop/pull/15090
I will request Mobile testing after this is reviews and tested in desktop.