### PR TITLE
set $GIT_COMMIT for codeclimate uploads

### DIFF
--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -128,7 +128,9 @@ grep -h -v "^mode:" ./**/*.coverage.out >> c.out
 rm -rf ./**/*.coverage.out
 
 if [[ $UNIT_TEST_REPORT_CODECLIMATE == 'true' ]]; then
-	cc-test-reporter after-build --prefix=github.com/status-im/status-go
+  # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
+  GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$')
+  cc-test-reporter after-build --prefix=github.com/status-im/status-go
 fi
 
 shopt -s globstar nullglob # Enable recursive globbing


### PR DESCRIPTION
When Jenkins creates a build, it can sometimes run the build on a detached HEAD, causing the commit SHA to be different from the SHA of your branch. This will cause issues when reporting test coverage to Code Climate.

Setting `GIT_COMMIT` fixes code climate upload errors.

ref -> https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds

Closes #5294
