### PR TITLE
fix_: ability to turn on/off interactive mode in serve

### DIFF
--- a/cmd/status-cli/README.md
+++ b/cmd/status-cli/README.md
@@ -30,7 +30,7 @@ You can also run `make status-cli` in the root directory to build the binary.
 ./status-cli serve -n charlie -p 8565 -a <alice-pubkey>
 ```
 
-You can send direct messages through terminal or JSON RPC.
+You can send direct messages through JSON RPC. If you also want to send messages through terminal enable `interactive` mode (with the `-i` flag)
 
 JSON RPC examples:
 

--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -76,6 +76,11 @@ var ServeFlags = append([]cli.Flag{
 		Value:   8545,
 		Usage:   "HTTP Server port to listen on",
 	},
+	&cli.BoolFlag{
+		Name:    InteractiveFlag,
+		Aliases: []string{"i"},
+		Usage:   "Use interactive mode to input the messages",
+	},
 }, CommonFlags...)
 
 var logger *zap.SugaredLogger


### PR DESCRIPTION
the clirunner might fail when interactive mode is enabled, also it doesn't need it. So addign the flag to enable or dissable it.

relates: #5266