### PR TITLE
fix_: trying to figure correct hop bridge contract type if empty one is provided

### DIFF
--- a/services/wallet/router/pathprocessor/mock_pathprocessor/processor.go
+++ b/services/wallet/router/pathprocessor/mock_pathprocessor/processor.go
@@ -160,18 +160,18 @@ func (mr *MockPathProcessorMockRecorder) Name() *gomock.Call {
 }
 
 // PackTxInputData mocks base method.
-func (m *MockPathProcessor) PackTxInputData(params pathprocessor.ProcessorInputParams, contractType string) ([]byte, error) {
+func (m *MockPathProcessor) PackTxInputData(params pathprocessor.ProcessorInputParams) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PackTxInputData", params, contractType)
+	ret := m.ctrl.Call(m, "PackTxInputData", params)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PackTxInputData indicates an expected call of PackTxInputData.
-func (mr *MockPathProcessorMockRecorder) PackTxInputData(params, contractType interface{}) *gomock.Call {
+func (mr *MockPathProcessorMockRecorder) PackTxInputData(params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackTxInputData", reflect.TypeOf((*MockPathProcessor)(nil).PackTxInputData), params, contractType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PackTxInputData", reflect.TypeOf((*MockPathProcessor)(nil).PackTxInputData), params)
 }
 
 // Send mocks base method.

--- a/services/wallet/router/pathprocessor/processor.go
+++ b/services/wallet/router/pathprocessor/processor.go
@@ -20,7 +20,7 @@ type PathProcessor interface {
 	// calculates the fees for the bridge and returns the amount BonderFee and TokenFee (used for bridges)
 	CalculateFees(params ProcessorInputParams) (*big.Int, *big.Int, error)
 	// Pack the method for sending tx and method call's data
-	PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error)
+	PackTxInputData(params ProcessorInputParams) ([]byte, error)
 	EstimateGas(params ProcessorInputParams) (uint64, error)
 	CalculateAmountOut(params ProcessorInputParams) (*big.Int, error)
 	Send(sendArgs *MultipathProcessorTxArgs, verifiedAccount *account.SelectedExtKey) (types.Hash, error)

--- a/services/wallet/router/pathprocessor/processor_bridge_celar.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_celar.go
@@ -202,7 +202,7 @@ func (s *CelerBridgeProcessor) CalculateFees(params ProcessorInputParams) (*big.
 	return ZeroBigIntValue, new(big.Int).Add(baseFee, percFee), nil
 }
 
-func (c *CelerBridgeProcessor) PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error) {
+func (c *CelerBridgeProcessor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
 	abi, err := abi.JSON(strings.NewReader(celer.CelerABI))
 	if err != nil {
 		return []byte{}, err
@@ -231,7 +231,7 @@ func (c *CelerBridgeProcessor) PackTxInputData(params ProcessorInputParams, cont
 func (s *CelerBridgeProcessor) EstimateGas(params ProcessorInputParams) (uint64, error) {
 	value := new(big.Int)
 
-	input, err := s.PackTxInputData(params, "")
+	input, err := s.PackTxInputData(params)
 	if err != nil {
 		return 0, err
 	}

--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -164,6 +164,14 @@ func (c *HopBridgeProcessor) getAppropriateABI(contractType string, chainID uint
 }
 
 func (h *HopBridgeProcessor) PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error) {
+	if contractType == "" {
+		_, ct, err := hop.GetContractAddress(params.FromChain.ChainID, params.FromToken.Symbol)
+		if err != nil {
+			return []byte{}, err
+		}
+		contractType = ct
+	}
+
 	abi, err := h.getAppropriateABI(contractType, params.FromChain.ChainID, params.FromToken)
 	if err != nil {
 		return []byte{}, err

--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -163,15 +163,16 @@ func (c *HopBridgeProcessor) getAppropriateABI(contractType string, chainID uint
 	return abi.ABI{}, errors.New("not available for contract type")
 }
 
-func (h *HopBridgeProcessor) PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error) {
-	if contractType == "" {
-		_, ct, err := hop.GetContractAddress(params.FromChain.ChainID, params.FromToken.Symbol)
-		if err != nil {
-			return []byte{}, err
-		}
-		contractType = ct
+func (h *HopBridgeProcessor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
+	_, contractType, err := hop.GetContractAddress(params.FromChain.ChainID, params.FromToken.Symbol)
+	if err != nil {
+		return []byte{}, err
 	}
 
+	return h.packTxInputDataInternally(params, contractType)
+}
+
+func (h *HopBridgeProcessor) packTxInputDataInternally(params ProcessorInputParams, contractType string) ([]byte, error) {
 	abi, err := h.getAppropriateABI(contractType, params.FromChain.ChainID, params.FromToken)
 	if err != nil {
 		return []byte{}, err
@@ -204,7 +205,7 @@ func (h *HopBridgeProcessor) EstimateGas(params ProcessorInputParams) (uint64, e
 		return 0, err
 	}
 
-	input, err := h.PackTxInputData(params, contractType)
+	input, err := h.packTxInputDataInternally(params, contractType)
 	if err != nil {
 		return 0, err
 	}

--- a/services/wallet/router/pathprocessor/processor_ens_public_key.go
+++ b/services/wallet/router/pathprocessor/processor_ens_public_key.go
@@ -49,7 +49,7 @@ func (s *ENSPublicKeyProcessor) CalculateFees(params ProcessorInputParams) (*big
 	return ZeroBigIntValue, ZeroBigIntValue, nil
 }
 
-func (s *ENSPublicKeyProcessor) PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error) {
+func (s *ENSPublicKeyProcessor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
 	resolverABI, err := abi.JSON(strings.NewReader(resolver.PublicResolverABI))
 	if err != nil {
 		return []byte{}, err
@@ -65,7 +65,7 @@ func (s *ENSPublicKeyProcessor) EstimateGas(params ProcessorInputParams) (uint64
 		return 0, err
 	}
 
-	input, err := s.PackTxInputData(params, "")
+	input, err := s.PackTxInputData(params)
 	if err != nil {
 		return 0, err
 	}
@@ -94,7 +94,7 @@ func (s *ENSPublicKeyProcessor) EstimateGas(params ProcessorInputParams) (uint64
 
 func (s *ENSPublicKeyProcessor) BuildTx(params ProcessorInputParams) (*ethTypes.Transaction, error) {
 	toAddr := types.Address(params.ToAddr)
-	inputData, err := s.PackTxInputData(params, "")
+	inputData, err := s.PackTxInputData(params)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/router/pathprocessor/processor_ens_register.go
+++ b/services/wallet/router/pathprocessor/processor_ens_register.go
@@ -65,7 +65,7 @@ func (s *ENSRegisterProcessor) CalculateFees(params ProcessorInputParams) (*big.
 	return ZeroBigIntValue, ZeroBigIntValue, nil
 }
 
-func (s *ENSRegisterProcessor) PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error) {
+func (s *ENSRegisterProcessor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
 	price, err := s.GetPriceForRegisteringEnsName(params.FromChain.ChainID)
 	if err != nil {
 		return []byte{}, err
@@ -101,7 +101,7 @@ func (s *ENSRegisterProcessor) EstimateGas(params ProcessorInputParams) (uint64,
 		return 0, err
 	}
 
-	input, err := s.PackTxInputData(params, "")
+	input, err := s.PackTxInputData(params)
 	if err != nil {
 		return 0, err
 	}
@@ -130,7 +130,7 @@ func (s *ENSRegisterProcessor) EstimateGas(params ProcessorInputParams) (uint64,
 
 func (s *ENSRegisterProcessor) BuildTx(params ProcessorInputParams) (*ethTypes.Transaction, error) {
 	toAddr := types.Address(params.ToAddr)
-	inputData, err := s.PackTxInputData(params, "")
+	inputData, err := s.PackTxInputData(params)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/router/pathprocessor/processor_ens_release.go
+++ b/services/wallet/router/pathprocessor/processor_ens_release.go
@@ -49,7 +49,7 @@ func (s *ENSReleaseProcessor) CalculateFees(params ProcessorInputParams) (*big.I
 	return ZeroBigIntValue, ZeroBigIntValue, nil
 }
 
-func (s *ENSReleaseProcessor) PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error) {
+func (s *ENSReleaseProcessor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
 	registrarABI, err := abi.JSON(strings.NewReader(registrar.UsernameRegistrarABI))
 	if err != nil {
 		return []byte{}, err
@@ -64,7 +64,7 @@ func (s *ENSReleaseProcessor) EstimateGas(params ProcessorInputParams) (uint64, 
 		return 0, err
 	}
 
-	input, err := s.PackTxInputData(params, "")
+	input, err := s.PackTxInputData(params)
 	if err != nil {
 		return 0, err
 	}
@@ -93,7 +93,7 @@ func (s *ENSReleaseProcessor) EstimateGas(params ProcessorInputParams) (uint64, 
 
 func (s *ENSReleaseProcessor) BuildTx(params ProcessorInputParams) (*ethTypes.Transaction, error) {
 	toAddr := types.Address(params.ToAddr)
-	inputData, err := s.PackTxInputData(params, "")
+	inputData, err := s.PackTxInputData(params)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/router/pathprocessor/processor_erc1155.go
+++ b/services/wallet/router/pathprocessor/processor_erc1155.go
@@ -47,7 +47,7 @@ func (s *ERC1155Processor) CalculateFees(params ProcessorInputParams) (*big.Int,
 	return ZeroBigIntValue, ZeroBigIntValue, nil
 }
 
-func (s *ERC1155Processor) PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error) {
+func (s *ERC1155Processor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
 	abi, err := abi.JSON(strings.NewReader(ierc1155.Ierc1155ABI))
 	if err != nil {
 		return []byte{}, err
@@ -75,7 +75,7 @@ func (s *ERC1155Processor) EstimateGas(params ProcessorInputParams) (uint64, err
 
 	value := new(big.Int)
 
-	input, err := s.PackTxInputData(params, "")
+	input, err := s.PackTxInputData(params)
 	if err != nil {
 		return 0, err
 	}

--- a/services/wallet/router/pathprocessor/processor_erc721.go
+++ b/services/wallet/router/pathprocessor/processor_erc721.go
@@ -46,7 +46,7 @@ func (s *ERC721Processor) CalculateFees(params ProcessorInputParams) (*big.Int, 
 	return ZeroBigIntValue, ZeroBigIntValue, nil
 }
 
-func (s *ERC721Processor) PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error) {
+func (s *ERC721Processor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
 	abi, err := abi.JSON(strings.NewReader(collectibles.CollectiblesMetaData.ABI))
 	if err != nil {
 		return []byte{}, err
@@ -72,7 +72,7 @@ func (s *ERC721Processor) EstimateGas(params ProcessorInputParams) (uint64, erro
 
 	value := new(big.Int)
 
-	input, err := s.PackTxInputData(params, "")
+	input, err := s.PackTxInputData(params)
 	if err != nil {
 		return 0, err
 	}

--- a/services/wallet/router/pathprocessor/processor_swap_paraswap.go
+++ b/services/wallet/router/pathprocessor/processor_swap_paraswap.go
@@ -89,7 +89,7 @@ func (s *SwapParaswapProcessor) CalculateFees(params ProcessorInputParams) (*big
 	return ZeroBigIntValue, ZeroBigIntValue, nil
 }
 
-func (s *SwapParaswapProcessor) PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error) {
+func (s *SwapParaswapProcessor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
 	// not sure what we can do here since we're using the api to build the transaction
 	return []byte{}, nil
 }

--- a/services/wallet/router/pathprocessor/processor_transfer.go
+++ b/services/wallet/router/pathprocessor/processor_transfer.go
@@ -38,7 +38,7 @@ func (s *TransferProcessor) CalculateFees(params ProcessorInputParams) (*big.Int
 	return ZeroBigIntValue, ZeroBigIntValue, nil
 }
 
-func (s *TransferProcessor) PackTxInputData(params ProcessorInputParams, contractType string) ([]byte, error) {
+func (s *TransferProcessor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
 	if params.FromToken.IsNative() {
 		return []byte("eth_sendRawTransaction"), nil
 	} else {
@@ -57,7 +57,7 @@ func (s *TransferProcessor) EstimateGas(params ProcessorInputParams) (uint64, er
 	estimation := uint64(0)
 	var err error
 
-	input, err := s.PackTxInputData(params, "")
+	input, err := s.PackTxInputData(params)
 	if err != nil {
 		return 0, err
 	}

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -632,7 +632,7 @@ func (r *Router) SuggestedRoutes(
 
 					var l1GasFeeWei uint64
 					if sendType.needL1Fee() {
-						txInputData, err := pProcessor.PackTxInputData(ProcessorInputParams, "")
+						txInputData, err := pProcessor.PackTxInputData(ProcessorInputParams)
 						if err != nil {
 							continue
 						}

--- a/services/wallet/router/router_v2.go
+++ b/services/wallet/router/router_v2.go
@@ -471,7 +471,7 @@ func (r *Router) SuggestedRoutesV2(ctx context.Context, input *RouteInputParams)
 					var l1FeeWei uint64
 					if input.SendType.needL1Fee() {
 
-						txInputData, err := pProcessor.PackTxInputData(ProcessorInputParams, "")
+						txInputData, err := pProcessor.PackTxInputData(ProcessorInputParams)
 						if err != nil {
 							continue
 						}


### PR DESCRIPTION
The router doesn't know about the contract type, that's an internal Hop processor's thing and that's why it's removed from the PathProcessor interface.