### PR TITLE
chore_: use the old name for backward compatibility

### DIFF
--- a/services/wallet/router/pathprocessor/multipath_processor.go
+++ b/services/wallet/router/pathprocessor/multipath_processor.go
@@ -8,7 +8,7 @@ import (
 )
 
 type MultipathProcessorTxArgs struct {
-	Name              string
+	Name              string `json:"bridgeName"`
 	ChainID           uint64
 	TransferTx        *transactions.SendTxArgs
 	HopTx             *HopBridgeTxArgs


### PR DESCRIPTION
In the PR https://github.com/status-im/status-go/pull/5310 `BridgeName` property of the `MultipathProcessorTxArgs` type was renamed to `Name` that caused issues on clients that are not adapted to that change.