### PR TITLE
feat(cli)_: add a command 'servelast' to be able to run the latest account.

### DIFF
--- a/cmd/status-cli/README.md
+++ b/cmd/status-cli/README.md
@@ -30,7 +30,7 @@ You can also run `make status-cli` in the root directory to build the binary.
 ./status-cli serve -n charlie -p 8565 -a <alice-pubkey>
 ```
 
-You can send direct messages through terminal or JSON RPC.
+You can send direct messages through JSON RPC. If you also want to send messages through terminal enable `interactive` mode (with the `-i` flag)
 
 JSON RPC examples:
 

--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -109,7 +109,33 @@ func main() {
 				Usage:   "Start a server to send and receive messages",
 				Flags:   ServeFlags,
 				Action: func(cCtx *cli.Context) error {
-					return serve(cCtx)
+					return serve(cCtx, false)
+				},
+			},
+			{
+				Name:    "servelast",
+				Aliases: []string{"sl"},
+				Usage:   "Start a server with the lastest input name's account\n\n  E.g.: if last time you created an account with name 'Alice',\n  you can start the server with 'Alice' account by running 'servelast -n Alice'",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     NameFlag,
+						Aliases:  []string{"n"},
+						Usage:    "Name of the existing user",
+						Required: true,
+					},
+					&cli.BoolFlag{
+						Name:    InteractiveFlag,
+						Aliases: []string{"i"},
+						Usage:   "Use interactive mode to input the messages",
+					},
+					&cli.StringFlag{
+						Name:    AddFlag,
+						Aliases: []string{"a"},
+						Usage:   "Add a friend with the public key",
+					},
+				},
+				Action: func(cCtx *cli.Context) error {
+					return serve(cCtx, true)
 				},
 			},
 		},

--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -76,6 +76,11 @@ var ServeFlags = append([]cli.Flag{
 		Value:   8545,
 		Usage:   "HTTP Server port to listen on",
 	},
+	&cli.BoolFlag{
+		Name:    InteractiveFlag,
+		Aliases: []string{"i"},
+		Usage:   "Use interactive mode to input the messages",
+	},
 }, CommonFlags...)
 
 var logger *zap.SugaredLogger

--- a/cmd/status-cli/serve.go
+++ b/cmd/status-cli/serve.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func serve(cCtx *cli.Context) error {
+func serve(cCtx *cli.Context, useLastAccount bool) error {
 	rawLogger, err := zap.NewDevelopment()
 	if err != nil {
 		log.Fatalf("Error initializing logger: %v", err)
@@ -35,7 +35,7 @@ func serve(cCtx *cli.Context) error {
 	interactive := cCtx.Bool(InteractiveFlag)
 	dest := cCtx.String(AddFlag)
 
-	cli, err := start(name, port, apiModules, telemetryUrl)
+	cli, err := start(name, port, apiModules, telemetryUrl, useLastAccount)
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func serve(cCtx *cli.Context) error {
 	msignal.SetMobileSignalHandler(msignal.MobileSignalHandler(func(s []byte) {
 		var ev MobileSignalEvent
 		if err := json.Unmarshal(s, &ev); err != nil {
-			logger.Errorf("unmarshaling signal event: %v", err)
+			logger.Error("unmarshaling signal event", zap.Error(err), zap.String("event", string(s)))
 			return
 		}
 

--- a/cmd/status-cli/simulate.go
+++ b/cmd/status-cli/simulate.go
@@ -39,13 +39,13 @@ func simulate(cCtx *cli.Context) error {
 	apiModules := cCtx.String(APIModulesFlag)
 	telemetryUrl := cCtx.String(TelemetryServerURLFlag)
 
-	alice, err := start("Alice", 0, apiModules, telemetryUrl)
+	alice, err := start("Alice", 0, apiModules, telemetryUrl, false)
 	if err != nil {
 		return err
 	}
 	defer alice.stop()
 
-	charlie, err := start("Charlie", 0, apiModules, telemetryUrl)
+	charlie, err := start("Charlie", 0, apiModules, telemetryUrl, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Reason: because on testing community join req/response we only want to create a community by a cli and remain the owner over multiple runs
