### PR TITLE
feat(cli)_: add a command 'server-account' to be able to re-run existing accounts

### DIFF
--- a/cmd/status-cli/README.md
+++ b/cmd/status-cli/README.md
@@ -48,8 +48,17 @@ curl -XPOST http://127.0.0.1:8565 -H 'Content-type: application/json' -d '{"json
 curl -XPOST http://127.0.0.1:8545 -H 'Content-type: application/json' -d '{"jsonrpc":"2.0","method":"wakuext_sendOneToOneMessage","params":[{"id": "0x042c0ce856c41ad6d3f651a84c83f646cdafdf3a26a3d69bce3a6ccf59b23b5a366c12162045d5066abad7912741a6e6c6e8e11e7826c4c850a1de7a2bae24a79c", "message": "Im fine, and you?"}],"id":1}'
 ```
 
+### Run `serve-account` command
 
-### Run `simulate` command:
+The `./status-cli serve` command will generate a new account, it will print in the console the key UID of that account, if you want to re-run that created account (i.e.: run the account with the same public key), you can do so with this command:
+
+```bash
+./status-cli serve-account -n alice -kid 0x02887ff8dddb774ad836c00c8fd30ef9bc45d6b23f1f8cad1bff07d09cb378c3
+```
+
+You will need the same name and key
+
+### Run `simulate` command
 
 ```bash
 # simulate DM between two accounts

--- a/cmd/status-cli/README.md
+++ b/cmd/status-cli/README.md
@@ -83,27 +83,27 @@ Logs are recorded in file `*.log` and terminal.
 
 ## JSON-RPC use cases
 
-### Start two CLIs and making them contacts
+### Start two CLIs adding each other as contacts
 
 ```bash
 # terminal 1 (alice)
-./status-cli serve -n alice -p5500
+./status-cli serve -n alice -p 5500
 # note the public key and the key id from the output
 
-# terminal 2 (bob)
-./status-cli serve -n bob -p5501 -a <alice_pub_key>
+# terminal 2 (bobby)
+./status-cli serve -n bobby -p 5501 -a <alice_pub_key>
 ```
 
 ## Restart any existing account
 
 ```bash
-# notice we need the key id not the pub key here
-./status-cli serve -n bob -kid <bob_key_id>
+# notice we need both the name and the key id (not the pub key here)
+./status-cli serve -n bobby -kid <bob_key_id>
 ```
 
 ### Create community
 
-Have two CLIs running (`alice` and `bob`)
+Have two CLIs running (`alice` and `bobby`)
 
 ```bash
 # 1. (alice) create community
@@ -124,7 +124,7 @@ curl --request POST \
  "id": 1
 }'
 
-# 2. (bob & alice) fetch community
+# 2. (bobby & alice) fetch community
 curl --request POST \
   --url http://127.0.0.1:5501/ \
   --header 'Content-type: application/json' \
@@ -141,7 +141,7 @@ curl --request POST \
  "id": 1
 }'
 
-# 3. (bob) request to join community
+# 3. (bobby) request to join community
 curl --request POST \
   --url http://127.0.0.1:5501/ \
   --header 'Content-type: application/json' \
@@ -156,7 +156,7 @@ curl --request POST \
  "id": 1
 }'
 
-# 4. (alice) accept request to join community from bob
+# 4. (alice) accept request to join community from bobby
 curl --request POST \
   --url http://127.0.0.1:5500/ \
   --header 'Content-type: application/json' \
@@ -171,7 +171,7 @@ curl --request POST \
  "id": 1
 }'
 
-# 5. (alice) send chat message (bob should receive it)
+# 5. (alice) send chat message (bobby should receive it)
 # chatId is the community id concatenated to the chat id
 curl --request POST \
   --url http://127.0.0.1:5500/ \
@@ -189,7 +189,7 @@ curl --request POST \
  "id": 1
 }'
 
-# 6. (bob) leave the community
+# 6. (bobby) leave the community
 curl --request POST \
   --url http://127.0.0.1:5501/ \
   --header 'Content-type: application/json' \
@@ -203,17 +203,17 @@ curl --request POST \
 }'
 
 # Optional:
-# 7. (bob & alice) fetch community again and verify the members (curl from step 2.)
-# 8. Instead of creating a community always you can restart alice and bob and proceed from step 2. Alice is the owner
+# 7. (bobby & alice) fetch community again and verify the members (curl from step 2.)
+# 8. Instead of creating a community always you can restart alice and bobby and proceed from step 2. Alice is the owner
 
 ```
 
 ### Private group chat
 
-Have two CLIs running (`alice` and `bob`)
+Have two CLIs running (`alice` and `bobby`)
 
 ```bash
-# 1. (alice) create the group chat including bob in it, save the id of the response
+# 1. (alice) create the group chat including bobby in it, save the id of the response
 curl --request POST \
   --url http://127.0.0.1:8545/ \
   --header 'Content-type: application/json' \

--- a/cmd/status-cli/README.md
+++ b/cmd/status-cli/README.md
@@ -98,6 +98,7 @@ Logs are recorded in file `*.log` and terminal.
 
 ```bash
 # notice we need both the name and the key id (not the pub key here)
+# the key id will be pressent in the logs when a new account is created, same as the public key
 ./status-cli serve -n bobby -kid <bob_key_id>
 ```
 
@@ -107,6 +108,7 @@ Have two CLIs running (`alice` and `bobby`)
 
 ```bash
 # 1. (alice) create community
+# this call will return the community id
 curl --request POST \
   --url http://127.0.0.1:5500/ \
   --header 'Content-type: application/json' \
@@ -124,7 +126,7 @@ curl --request POST \
  "id": 1
 }'
 
-# 2. (bobby & alice) fetch community
+# 2. (bobby & alice) fetch community (use communityId from step 1 response)
 curl --request POST \
   --url http://127.0.0.1:5501/ \
   --header 'Content-type: application/json' \
@@ -141,7 +143,8 @@ curl --request POST \
  "id": 1
 }'
 
-# 3. (bobby) request to join community
+# 3. (bobby) request to join community (use communityId from step 1 response)
+# this call will return the requestsToJoinCommunity.id
 curl --request POST \
   --url http://127.0.0.1:5501/ \
   --header 'Content-type: application/json' \
@@ -156,7 +159,8 @@ curl --request POST \
  "id": 1
 }'
 
-# 4. (alice) accept request to join community from bobby
+# 4. (alice) accept request to join community from bobby (use requestsToJoinCommunity.id from step 3 response)
+# in the response you can see the community id and the chats' ids for that community ($.result.communities[*].chats[*].id)
 curl --request POST \
   --url http://127.0.0.1:5500/ \
   --header 'Content-type: application/json' \
@@ -172,7 +176,7 @@ curl --request POST \
 }'
 
 # 5. (alice) send chat message (bobby should receive it)
-# chatId is the community id concatenated to the chat id
+# chatId is the community id concatenated to the chat id (from step 4 response)
 curl --request POST \
   --url http://127.0.0.1:5500/ \
   --header 'Content-type: application/json' \
@@ -189,7 +193,7 @@ curl --request POST \
  "id": 1
 }'
 
-# 6. (bobby) leave the community
+# 6. (bobby) leave the community (use communityId from step 1 response)
 curl --request POST \
   --url http://127.0.0.1:5501/ \
   --header 'Content-type: application/json' \
@@ -213,7 +217,8 @@ curl --request POST \
 Have two CLIs running (`alice` and `bobby`)
 
 ```bash
-# 1. (alice) create the group chat including bobby in it, save the id of the response
+# 1. (alice) create the group chat including bobby's public key in it, 
+# the response will have the group chat id to send messages to it
 curl --request POST \
   --url http://127.0.0.1:8545/ \
   --header 'Content-type: application/json' \
@@ -230,7 +235,7 @@ curl --request POST \
  "id": 1
 }'
 
-# 2. (alice) send the message to the id of the group chat
+# 2. (alice) send the message to the id of the group chat (from step 1 response)
 curl --request POST \
   --url http://127.0.0.1:5500/ \
   --header 'Content-type: application/json' \

--- a/cmd/status-cli/README.md
+++ b/cmd/status-cli/README.md
@@ -38,6 +38,9 @@ JSON RPC examples:
 # get waku info
 curl -XPOST http://127.0.0.1:8545 -H 'Content-type: application/json' -d '{"jsonrpc":"2.0","method":"waku_info","params":[],"id":1}'
 
+# get peer info
+curl --request POST --url http://127.0.0.1:8545 --header 'Content-type: application/json' --data '{"jsonrpc": "2.0", "method": "wakuext_peers", "params": [], "id": 1}'
+
 # send contact request from charlie to alice (use -a flag will automatacally send contact request when starting)
 curl -XPOST http://127.0.0.1:8565 -H 'Content-type: application/json' -d '{"jsonrpc":"2.0","method":"wakuext_sendContactRequest","params":[{"id": "0x0436470da23039f10c1588bc6b9fcbd4b815bf9fae4dc09c0fb05a7eaaf1670b5dbdbc757630d54bf2f8be45a796304dc42506c3f4172f499f610a9ed85d9b0d4c", "message": "hello"}],"id":1}'
 
@@ -77,3 +80,169 @@ You will need the same name and key
 You can run the commands with `--light` to work as a light client.
 
 Logs are recorded in file `*.log` and terminal.
+
+## JSON-RPC use cases
+
+### Start two CLIs and making them contacts
+
+```bash
+# terminal 1 (alice)
+./status-cli serve -n alice -p5500
+# note the public key and the key id from the output
+
+# terminal 2 (bob)
+./status-cli serve -n bob -p5501 -a <alice_pub_key>
+```
+
+## Restart any existing account
+
+```bash
+# notice we need the key id not the pub key here
+./status-cli serve -n bob -kid <bob_key_id>
+```
+
+### Create community
+
+Have two CLIs running (`alice` and `bob`)
+
+```bash
+# 1. (alice) create community
+curl --request POST \
+  --url http://127.0.0.1:5500/ \
+  --header 'Content-type: application/json' \
+  --data '{
+ "jsonrpc": "2.0",
+ "method": "wakuext_createCommunity",
+ "params": [
+  {
+   "membership": 3,
+   "name": "cli-test-1",
+   "color": "#ffffff",
+   "description": "cli-test-1"  
+  }
+ ],
+ "id": 1
+}'
+
+# 2. (bob & alice) fetch community
+curl --request POST \
+  --url http://127.0.0.1:5501/ \
+  --header 'Content-type: application/json' \
+  --data '{
+ "jsonrpc": "2.0",
+ "method": "wakuext_fetchCommunity",
+ "params": [
+  {
+   "communityKey": "0x02bea5af5779d5f742f2419cc0d819d3ce33adb922e8e90bdf3533fd121d52d4bc",
+   "waitForResponse": true,
+   "tryDatabase": true
+  }
+ ],
+ "id": 1
+}'
+
+# 3. (bob) request to join community
+curl --request POST \
+  --url http://127.0.0.1:5501/ \
+  --header 'Content-type: application/json' \
+  --data '{
+ "jsonrpc": "2.0",
+ "method": "wakuext_requestToJoinCommunity",
+ "params": [
+  {
+   "communityId": "0x02bea5af5779d5f742f2419cc0d819d3ce33adb922e8e90bdf3533fd121d52d4bc"
+  }
+ ],
+ "id": 1
+}'
+
+# 4. (alice) accept request to join community from bob
+curl --request POST \
+  --url http://127.0.0.1:5500/ \
+  --header 'Content-type: application/json' \
+  --data '{
+ "jsonrpc": "2.0",
+ "method": "wakuext_acceptRequestToJoinCommunity",
+ "params": [
+  {
+   "id": "0x1b828fe8c778403268ffcf80b892f8be46cf9a85ba2c9f479bfb0c0a807a71f4"
+  }
+ ],
+ "id": 1
+}'
+
+# 5. (alice) send chat message (bob should receive it)
+# chatId is the community id concatenated to the chat id
+curl --request POST \
+  --url http://127.0.0.1:5500/ \
+  --header 'Content-type: application/json' \
+  --data '{
+ "jsonrpc": "2.0",
+ "method": "wakuext_sendChatMessage",
+ "params": [
+  {
+   "chatId": "0x02bea5af5779d5f742f2419cc0d819d3ce33adb922e8e90bdf3533fd121d52d4bcdfe601d1-096c-4201-b692-fcdb81ef0cec",
+   "text": "hello there",
+   "contentType": 1
+  }
+ ],
+ "id": 1
+}'
+
+# 6. (bob) leave the community
+curl --request POST \
+  --url http://127.0.0.1:5501/ \
+  --header 'Content-type: application/json' \
+  --data '{
+ "jsonrpc": "2.0",
+ "method": "wakuext_leaveCommunity",
+ "params": [
+  "0x02bea5af5779d5f742f2419cc0d819d3ce33adb922e8e90bdf3533fd121d52d4bc"
+ ],
+ "id": 1
+}'
+
+# Optional:
+# 7. (bob & alice) fetch community again and verify the members (curl from step 2.)
+# 8. Instead of creating a community always you can restart alice and bob and proceed from step 2. Alice is the owner
+
+```
+
+### Private group chat
+
+Have two CLIs running (`alice` and `bob`)
+
+```bash
+# 1. (alice) create the group chat including bob in it, save the id of the response
+curl --request POST \
+  --url http://127.0.0.1:8545/ \
+  --header 'Content-type: application/json' \
+  --data '{
+ "jsonrpc": "2.0",
+ "method": "wakuext_createGroupChatWithMembers",
+ "params": [
+  null,
+  "group-chat-name",
+  [
+   "0x04d3c86dfc77b195b705e1831935066076018aa0d7c40044829801ebbfe9b06480ce4662072bf16a3ca7cb8f6289207614deceaf7d33e099dfc9281610375fec08"
+  ]
+ ],
+ "id": 1
+}'
+
+# 2. (alice) send the message to the id of the group chat
+curl --request POST \
+  --url http://127.0.0.1:5500/ \
+  --header 'Content-type: application/json' \
+  --data '{
+ "jsonrpc": "2.0",
+ "method": "wakuext_sendGroupChatMessage",
+ "params": [
+  {
+   "id": "8291eae1-338c-4481-9997-04edd2d2bbed-0x0490cbce029eaf094c7f2dcf1feb2d60e91ab1498847eb29fa98cc5ea5a36666b3f9ada142f3080f5074abd942c863438f6af9475f30781790c7e36f9acd2ac93e",
+   "message": "hello"
+  }
+ ],
+ "id": 1
+}'
+```

--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -109,7 +109,33 @@ func main() {
 				Usage:   "Start a server to send and receive messages",
 				Flags:   ServeFlags,
 				Action: func(cCtx *cli.Context) error {
-					return serve(cCtx)
+					return serve(cCtx, false)
+				},
+			},
+			{
+				Name:    "servelast",
+				Aliases: []string{"sl"},
+				Usage:   "Start a server with the lastest input name's account\n\n  E.g.: if last time you created an account with name 'Alice',\n  you can start the server with 'Alice' account by running 'servelast -n Alice'",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:     NameFlag,
+						Aliases:  []string{"n"},
+						Usage:    "Name of the existing user",
+						Required: true,
+					},
+					&cli.BoolFlag{
+						Name:    InteractiveFlag,
+						Aliases: []string{"i"},
+						Usage:   "Use interactive mode to input the messages",
+					},
+					&cli.StringFlag{
+						Name:    AddFlag,
+						Aliases: []string{"a"},
+						Usage:   "Add a friend with the public key",
+					},
+				},
+				Action: func(cCtx *cli.Context) error {
+					return serve(cCtx, true)
 				},
 			},
 		},

--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -20,6 +20,7 @@ const AddFlag = "add"
 const PortFlag = "port"
 const APIModulesFlag = "api-modules"
 const TelemetryServerURLFlag = "telemetry-server-url"
+const KeyUIDFlag = "key-uid"
 
 const RetrieveInterval = 300 * time.Millisecond
 const SendInterval = 1 * time.Second
@@ -113,7 +114,7 @@ func main() {
 				},
 			},
 			{
-				Name:    "servelast",
+				Name:    "serve-account",
 				Aliases: []string{"sl"},
 				Usage:   "Start a server with the lastest input name's account\n\n  E.g.: if last time you created an account with name 'Alice',\n  you can start the server with 'Alice' account by running 'servelast -n Alice'",
 				Flags: []cli.Flag{
@@ -122,6 +123,11 @@ func main() {
 						Aliases:  []string{"n"},
 						Usage:    "Name of the existing user",
 						Required: true,
+					},
+					&cli.StringFlag{
+						Name:    KeyUIDFlag,
+						Aliases: []string{"kid"},
+						Usage:   "Key ID of the existing user (if not provided the last account will be used)",
 					},
 					&cli.BoolFlag{
 						Name:    InteractiveFlag,

--- a/cmd/status-cli/serve.go
+++ b/cmd/status-cli/serve.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func serve(cCtx *cli.Context, useLastAccount bool) error {
+func serve(cCtx *cli.Context, useExistingAccount bool) error {
 	rawLogger, err := zap.NewDevelopment()
 	if err != nil {
 		log.Fatalf("Error initializing logger: %v", err)
@@ -36,7 +36,7 @@ func serve(cCtx *cli.Context, useLastAccount bool) error {
 	dest := cCtx.String(AddFlag)
 	keyUID := cCtx.String(KeyUIDFlag)
 
-	cli, err := start(name, port, apiModules, telemetryUrl, useLastAccount, keyUID)
+	cli, err := start(name, port, apiModules, telemetryUrl, useExistingAccount, keyUID)
 	if err != nil {
 		return err
 	}

--- a/cmd/status-cli/serve.go
+++ b/cmd/status-cli/serve.go
@@ -34,8 +34,9 @@ func serve(cCtx *cli.Context, useLastAccount bool) error {
 	telemetryUrl := cCtx.String(TelemetryServerURLFlag)
 	interactive := cCtx.Bool(InteractiveFlag)
 	dest := cCtx.String(AddFlag)
+	keyUID := cCtx.String(KeyUIDFlag)
 
-	cli, err := start(name, port, apiModules, telemetryUrl, useLastAccount)
+	cli, err := start(name, port, apiModules, telemetryUrl, useLastAccount, keyUID)
 	if err != nil {
 		return err
 	}

--- a/cmd/status-cli/serve.go
+++ b/cmd/status-cli/serve.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func serve(cCtx *cli.Context) error {
+func serve(cCtx *cli.Context, useLastAccount bool) error {
 	rawLogger, err := zap.NewDevelopment()
 	if err != nil {
 		log.Fatalf("Error initializing logger: %v", err)
@@ -35,7 +35,7 @@ func serve(cCtx *cli.Context) error {
 	interactive := cCtx.Bool(InteractiveFlag)
 	dest := cCtx.String(AddFlag)
 
-	cli, err := start(name, port, apiModules, telemetryUrl)
+	cli, err := start(name, port, apiModules, telemetryUrl, useLastAccount)
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func serve(cCtx *cli.Context) error {
 	msignal.SetMobileSignalHandler(msignal.MobileSignalHandler(func(s []byte) {
 		var ev MobileSignalEvent
 		if err := json.Unmarshal(s, &ev); err != nil {
-			logger.Errorf("unmarshaling signal event: %v", err)
+			logger.Error("unmarshaling signal event", zap.Error(err), zap.String("event", string(s)))
 			return
 		}
 

--- a/cmd/status-cli/simulate.go
+++ b/cmd/status-cli/simulate.go
@@ -39,13 +39,13 @@ func simulate(cCtx *cli.Context) error {
 	apiModules := cCtx.String(APIModulesFlag)
 	telemetryUrl := cCtx.String(TelemetryServerURLFlag)
 
-	alice, err := start("Alice", 0, apiModules, telemetryUrl)
+	alice, err := start("Alice", 0, apiModules, telemetryUrl, false)
 	if err != nil {
 		return err
 	}
 	defer alice.stop()
 
-	charlie, err := start("Charlie", 0, apiModules, telemetryUrl)
+	charlie, err := start("Charlie", 0, apiModules, telemetryUrl, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/status-cli/simulate.go
+++ b/cmd/status-cli/simulate.go
@@ -39,13 +39,13 @@ func simulate(cCtx *cli.Context) error {
 	apiModules := cCtx.String(APIModulesFlag)
 	telemetryUrl := cCtx.String(TelemetryServerURLFlag)
 
-	alice, err := start("Alice", 0, apiModules, telemetryUrl, false)
+	alice, err := start("Alice", 0, apiModules, telemetryUrl, false, "")
 	if err != nil {
 		return err
 	}
 	defer alice.stop()
 
-	charlie, err := start("Charlie", 0, apiModules, telemetryUrl, false)
+	charlie, err := start("Charlie", 0, apiModules, telemetryUrl, false, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/status-cli/util.go
+++ b/cmd/status-cli/util.go
@@ -34,7 +34,7 @@ func setupLogger(file string) *zap.Logger {
 	return logutils.ZapLogger()
 }
 
-func start(name string, port int, apiModules string, telemetryUrl string, useLastAccount bool, keyUID string) (*StatusCLI, error) {
+func start(name string, port int, apiModules string, telemetryUrl string, useExistingAccount bool, keyUID string) (*StatusCLI, error) {
 	var (
 		rootDataDir = fmt.Sprintf("./test-%s", strings.ToLower(name))
 		password    = "some-password"
@@ -44,7 +44,7 @@ func start(name string, port int, apiModules string, telemetryUrl string, useLas
 	nlog.Info("starting messager")
 
 	backend := api.NewGethStatusBackend()
-	if useLastAccount {
+	if useExistingAccount {
 		if err := getAccountAndLogin(backend, name, rootDataDir, password, keyUID); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Reason: because on testing community join req/response we only want to create a community by a cli and remain the owner over multiple runs

closes: #5266
