### PR TITLE
Remove member list in non-encrypted channels

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -511,7 +511,6 @@ func (o *Community) MarshalJSON() ([]byte, error) {
 				Color:                   c.Identity.Color,
 				Description:             c.Identity.Description,
 				Permissions:             c.Permissions,
-				Members:                 c.Members,
 				CanPost:                 canPost,
 				CanView:                 canView,
 				CanPostReactions:        canPostReactions,
@@ -520,6 +519,10 @@ func (o *Community) MarshalJSON() ([]byte, error) {
 				CategoryID:              c.CategoryId,
 				HideIfPermissionsNotMet: c.HideIfPermissionsNotMet,
 				Position:                int(c.Position),
+			}
+
+			if chat.TokenGated {
+				chat.Members = c.Members
 			}
 			communityItem.Chats[id] = chat
 		}


### PR DESCRIPTION
This commit removes the list of members from non token gated channels. Unfortunately is a breaking change. I could make it non-breaking, but we would lose any performance benefit.

For clients, the pseudo code for checking the member list of a channel is:

```
members := channel.TokenGated ? channel.Members : community.Members
```
