### PR TITLE
refactor: onlinechecker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20240625022701-1cf180ebc659
+	github.com/waku-org/go-waku v0.8.1-0.20240626004844-19a47a1ac1f5
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -2137,8 +2137,8 @@ github.com/waku-org/go-discover v0.0.0-20240506173252-4912704efdc5 h1:4K3IS97Jry
 github.com/waku-org/go-discover v0.0.0-20240506173252-4912704efdc5/go.mod h1:eBHgM6T4EG0RZzxpxKy+rGz/6Dw2Nd8DWxS0lm9ESDw=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20240625022701-1cf180ebc659 h1:bTz24QgoRBXoS/WIy8+7jrQ/7hpE63td0fMteq5qZQM=
-github.com/waku-org/go-waku v0.8.1-0.20240625022701-1cf180ebc659/go.mod h1:biffO55kWbvfO8jdu/aAPiWcmozrfFKPum4EMFDib+k=
+github.com/waku-org/go-waku v0.8.1-0.20240626004844-19a47a1ac1f5 h1:9UyIIy/IvlJB2nHIXydne6OfNfOWPPL08+XmCI3iEBo=
+github.com/waku-org/go-waku v0.8.1-0.20240626004844-19a47a1ac1f5/go.mod h1:biffO55kWbvfO8jdu/aAPiWcmozrfFKPum4EMFDib+k=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/vendor/github.com/waku-org/go-waku/waku/v2/api/filter.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/api/filter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/waku-org/go-waku/waku/v2/onlinechecker"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/filter"
 	"github.com/waku-org/go-waku/waku/v2/protocol/subscription"
@@ -39,13 +40,13 @@ type Sub struct {
 	cancel                context.CancelFunc
 	log                   *zap.Logger
 	closing               chan string
-	isNodeOnline          bool //indicates if node has connectivity, this helps subscribe loop takes decision as to resubscribe or not.
+	onlineChecker         onlinechecker.OnlineChecker
 	resubscribeInProgress bool
 	id                    string
 }
 
 // Subscribe
-func Subscribe(ctx context.Context, wf *filter.WakuFilterLightNode, contentFilter protocol.ContentFilter, config FilterConfig, log *zap.Logger, online bool) (*Sub, error) {
+func Subscribe(ctx context.Context, wf *filter.WakuFilterLightNode, contentFilter protocol.ContentFilter, config FilterConfig, log *zap.Logger) (*Sub, error) {
 	sub := new(Sub)
 	sub.id = uuid.NewString()
 	sub.wf = wf
@@ -56,14 +57,16 @@ func Subscribe(ctx context.Context, wf *filter.WakuFilterLightNode, contentFilte
 	sub.Config = config
 	sub.log = log.Named("filter-api").With(zap.String("apisub-id", sub.id), zap.Stringer("content-filter", sub.ContentFilter))
 	sub.log.Debug("filter subscribe params", zap.Int("max-peers", config.MaxPeers))
-	sub.isNodeOnline = online
 	sub.closing = make(chan string, config.MaxPeers)
-	if online {
+
+	sub.onlineChecker = wf.OnlineChecker()
+	if wf.OnlineChecker().IsOnline() {
 		subs, err := sub.subscribe(contentFilter, sub.Config.MaxPeers)
 		if err == nil {
 			sub.multiplex(subs)
 		}
 	}
+
 	go sub.subscriptionLoop()
 	return sub, nil
 }
@@ -72,17 +75,13 @@ func (apiSub *Sub) Unsubscribe() {
 	apiSub.cancel()
 }
 
-func (apiSub *Sub) SetNodeState(online bool) {
-	apiSub.isNodeOnline = online
-}
-
 func (apiSub *Sub) subscriptionLoop() {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			if apiSub.isNodeOnline && len(apiSub.subs) < apiSub.Config.MaxPeers &&
+			if apiSub.onlineChecker.IsOnline() && len(apiSub.subs) < apiSub.Config.MaxPeers &&
 				!apiSub.resubscribeInProgress && len(apiSub.closing) < apiSub.Config.MaxPeers {
 				apiSub.closing <- ""
 			}
@@ -109,7 +108,7 @@ func (apiSub *Sub) checkAndResubscribe(subId string) {
 		delete(apiSub.subs, subId)
 	}
 	apiSub.log.Debug("subscription status", zap.Int("sub-count", len(apiSub.subs)), zap.Stringer("content-filter", apiSub.ContentFilter))
-	if apiSub.isNodeOnline && len(apiSub.subs) < apiSub.Config.MaxPeers {
+	if apiSub.onlineChecker.IsOnline() && len(apiSub.subs) < apiSub.Config.MaxPeers {
 		apiSub.resubscribe(failedPeer)
 	}
 	apiSub.resubscribeInProgress = false

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go
@@ -258,7 +258,7 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 	//Initialize peer manager.
 	w.peermanager = peermanager.NewPeerManager(w.opts.maxPeerConnections, w.opts.peerStoreCapacity, metadata, params.enableRelay, w.log)
 
-	w.peerConnector, err = peermanager.NewPeerConnectionStrategy(w.peermanager, discoveryConnectTimeout, w.log)
+	w.peerConnector, err = peermanager.NewPeerConnectionStrategy(w.peermanager, w.opts.onlineChecker, discoveryConnectTimeout, w.log)
 	if err != nil {
 		w.log.Error("creating peer connection strategy", zap.Error(err))
 	}
@@ -290,7 +290,7 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 	w.opts.filterOpts = append(w.opts.filterOpts, filter.WithPeerManager(w.peermanager))
 
 	w.filterFullNode = filter.NewWakuFilterFullNode(w.timesource, w.opts.prometheusReg, w.log, w.opts.filterOpts...)
-	w.filterLightNode = filter.NewWakuFilterLightNode(w.bcaster, w.peermanager, w.timesource, w.opts.prometheusReg, w.log)
+	w.filterLightNode = filter.NewWakuFilterLightNode(w.bcaster, w.peermanager, w.timesource, w.opts.onlineChecker, w.opts.prometheusReg, w.log)
 	w.lightPush = lightpush.NewWakuLightPush(w.Relay(), w.peermanager, w.opts.prometheusReg, w.log, w.opts.lightpushOpts...)
 
 	w.store = store.NewWakuStore(w.peermanager, w.timesource, w.log)

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/wakuoptions.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/wakuoptions.go
@@ -25,6 +25,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/waku-org/go-waku/waku/v2/onlinechecker"
 	"github.com/waku-org/go-waku/waku/v2/peermanager"
 	"github.com/waku-org/go-waku/waku/v2/protocol/filter"
 	"github.com/waku-org/go-waku/waku/v2/protocol/legacy_store"
@@ -62,6 +63,8 @@ type WakuNodeParameters struct {
 
 	circuitRelayMinInterval time.Duration
 	circuitRelayBootDelay   time.Duration
+
+	onlineChecker onlinechecker.OnlineChecker
 
 	enableNTP bool
 	ntpURLs   []string
@@ -130,6 +133,7 @@ var DefaultWakuNodeOptions = []WakuNodeOption{
 	WithMaxConnectionsPerIP(DefaultMaxConnectionsPerIP),
 	WithCircuitRelayParams(2*time.Second, 3*time.Minute),
 	WithPeerStoreCapacity(DefaultMaxPeerStoreCapacity),
+	WithOnlineChecker(onlinechecker.NewDefaultOnlineChecker(true)),
 }
 
 // MultiAddresses return the list of multiaddresses configured in the node
@@ -550,6 +554,16 @@ func WithCircuitRelayParams(minInterval time.Duration, bootDelay time.Duration) 
 func WithTopicHealthStatusChannel(ch chan<- peermanager.TopicHealthStatus) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.topicHealthNotifCh = ch
+		return nil
+	}
+}
+
+// WithOnlineChecker sets up an OnlineChecker which will be used to determine whether the node
+// is online or not. The OnlineChecker must be implemented by consumers of go-waku since they
+// have additional context to determine what it means for a node to be online/offline
+func WithOnlineChecker(onlineChecker onlinechecker.OnlineChecker) WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.onlineChecker = onlineChecker
 		return nil
 	}
 }

--- a/vendor/github.com/waku-org/go-waku/waku/v2/onlinechecker/online.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/onlinechecker/online.go
@@ -1,0 +1,24 @@
+package onlinechecker
+
+// OnlineChecker is used to determine if node has connectivity.
+type OnlineChecker interface {
+	IsOnline() bool
+}
+
+type DefaultOnlineChecker struct {
+	online bool
+}
+
+func NewDefaultOnlineChecker(online bool) OnlineChecker {
+	return &DefaultOnlineChecker{
+		online: online,
+	}
+}
+
+func (o *DefaultOnlineChecker) SetOnline(online bool) {
+	o.online = online
+}
+
+func (o *DefaultOnlineChecker) IsOnline() bool {
+	return o.online
+}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go
@@ -55,7 +55,7 @@ func (pm *PeerManager) discoverOnDemand(cluster uint16,
 
 	wakuProtoInfo, ok := pm.wakuprotoToENRFieldMap[wakuProtocol]
 	if !ok {
-		pm.logger.Info("cannot do on demand discovery for non-waku protocol", zap.String("protocol", string(wakuProtocol)))
+		pm.logger.Warn("cannot do on demand discovery for non-waku protocol", zap.String("protocol", string(wakuProtocol)))
 		return nil, errors.New("cannot do on demand discovery for non-waku protocol")
 	}
 	iterator, err := pm.discoveryService.PeerIterator(

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/test_utils.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/test_utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/suite"
 	"github.com/waku-org/go-waku/tests"
+	"github.com/waku-org/go-waku/waku/v2/onlinechecker"
 	"github.com/waku-org/go-waku/waku/v2/peermanager"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
@@ -165,7 +166,7 @@ func (s *FilterTestSuite) GetWakuFilterLightNode() LightNodeData {
 	b := relay.NewBroadcaster(10)
 	s.Require().NoError(b.Start(context.Background()))
 	pm := peermanager.NewPeerManager(5, 5, nil, true, s.Log)
-	filterPush := NewWakuFilterLightNode(b, pm, timesource.NewDefaultClock(), prometheus.DefaultRegisterer, s.Log)
+	filterPush := NewWakuFilterLightNode(b, pm, timesource.NewDefaultClock(), onlinechecker.NewDefaultOnlineChecker(true), prometheus.DefaultRegisterer, s.Log)
 	filterPush.SetHost(host)
 	pm.SetHost(host)
 	return LightNodeData{filterPush, host}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1015,7 +1015,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240625022701-1cf180ebc659
+# github.com/waku-org/go-waku v0.8.1-0.20240626004844-19a47a1ac1f5
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests
@@ -1025,6 +1025,7 @@ github.com/waku-org/go-waku/waku/v2/discv5
 github.com/waku-org/go-waku/waku/v2/dnsdisc
 github.com/waku-org/go-waku/waku/v2/hash
 github.com/waku-org/go-waku/waku/v2/node
+github.com/waku-org/go-waku/waku/v2/onlinechecker
 github.com/waku-org/go-waku/waku/v2/payload
 github.com/waku-org/go-waku/waku/v2/peermanager
 github.com/waku-org/go-waku/waku/v2/peerstore


### PR DESCRIPTION
I noticed that if the node is offline, the peer connector will still attempt to connect to nodes reported by discv5.
This has a negative impact because the connection to the node will obviously fail, and it will increase the backoff period for the next reconnection attempt.

With this change, the peer connector will no longer attempt to connect to any peer when it's notified that the node is offline.  

A similar approach is also used for the filter subscriptions, instead of having to notify each subscription that the node is online/offline, it's done in a single step with the online checker