### PR TITLE
Router swap paraswap

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -543,6 +543,7 @@ type WalletConfig struct {
 	AlchemyAPIKeys       map[uint64]string `json:"AlchemyAPIKeys"`
 	InfuraAPIKey         string            `json:"InfuraAPIKey"`
 	InfuraAPIKeySecret   string            `json:"InfuraAPIKeySecret"`
+	EnableCelerBridge    bool              `json:"EnableCelerBridge"`
 }
 
 // LocalNotificationsConfig extra configuration for localnotifications.Service.

--- a/protocol/common/feature_flags.go
+++ b/protocol/common/feature_flags.go
@@ -26,4 +26,7 @@ type FeatureFlags struct {
 
 	// Peersyncing indicates whether we should advertise and sync messages with other peers
 	Peersyncing bool
+
+	// EnableCelerBridge indicates whether we should enable the Celer bridge in the Router
+	EnableCelerBridge bool
 }

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -35,7 +35,7 @@ import (
 
 func NewAPI(s *Service) *API {
 	router := router.NewRouter(s.GetRPCClient(), s.GetTransactor(), s.GetTokenManager(), s.GetMarketManager(), s.GetCollectiblesService(),
-		s.GetCollectiblesManager(), s.GetEnsService(), s.GetStickersService())
+		s.GetCollectiblesManager(), s.GetEnsService(), s.GetStickersService(), s.FeatureFlags())
 	return &API{s, s.reader, router}
 }
 

--- a/services/wallet/router/pathprocessor/processor.go
+++ b/services/wallet/router/pathprocessor/processor.go
@@ -37,6 +37,7 @@ type ProcessorInputParams struct {
 	FromToken *token.Token
 	ToToken   *token.Token
 	AmountIn  *big.Int
+	AmountOut *big.Int
 
 	// extra params
 	BonderFee *big.Int

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -589,7 +589,7 @@ func (r *Router) SuggestedRoutes(
 						continue
 					}
 
-					ProcessorInputParams := pathprocessor.ProcessorInputParams{
+					processorInputParams := pathprocessor.ProcessorInputParams{
 						FromChain: network,
 						ToChain:   dest,
 						FromToken: token,
@@ -599,7 +599,7 @@ func (r *Router) SuggestedRoutes(
 						AmountIn:  amountIn,
 					}
 
-					can, err := pProcessor.AvailableFor(ProcessorInputParams)
+					can, err := pProcessor.AvailableFor(processorInputParams)
 					if err != nil || !can {
 						continue
 					}
@@ -607,7 +607,7 @@ func (r *Router) SuggestedRoutes(
 						continue
 					}
 
-					bonderFees, tokenFees, err := pProcessor.CalculateFees(ProcessorInputParams)
+					bonderFees, tokenFees, err := pProcessor.CalculateFees(processorInputParams)
 					if err != nil {
 						continue
 					}
@@ -624,7 +624,7 @@ func (r *Router) SuggestedRoutes(
 					}
 					gasLimit := uint64(0)
 					if sendType.isTransfer(false) {
-						gasLimit, err = pProcessor.EstimateGas(ProcessorInputParams)
+						gasLimit, err = pProcessor.EstimateGas(processorInputParams)
 						if err != nil {
 							continue
 						}
@@ -632,7 +632,7 @@ func (r *Router) SuggestedRoutes(
 						gasLimit = sendType.EstimateGas(r.ensService, r.stickersService, network, addrFrom, tokenID)
 					}
 
-					approvalContractAddress, err := pProcessor.GetContractAddress(ProcessorInputParams)
+					approvalContractAddress, err := pProcessor.GetContractAddress(processorInputParams)
 					if err != nil {
 						continue
 					}
@@ -643,7 +643,7 @@ func (r *Router) SuggestedRoutes(
 
 					var l1GasFeeWei uint64
 					if sendType.needL1Fee() {
-						txInputData, err := pProcessor.PackTxInputData(ProcessorInputParams)
+						txInputData, err := pProcessor.PackTxInputData(processorInputParams)
 						if err != nil {
 							continue
 						}
@@ -723,7 +723,7 @@ func (r *Router) SuggestedRoutes(
 	suggestedRoutes.TokenPrice = prices[tokenID]
 	suggestedRoutes.NativeChainTokenPrice = prices["ETH"]
 	for _, path := range suggestedRoutes.Best {
-		ProcessorInputParams := pathprocessor.ProcessorInputParams{
+		processorInputParams := pathprocessor.ProcessorInputParams{
 			FromChain: path.From,
 			ToChain:   path.To,
 			AmountIn:  path.AmountIn.ToInt(),
@@ -732,7 +732,7 @@ func (r *Router) SuggestedRoutes(
 			},
 		}
 
-		amountOut, err := r.pathProcessors[path.BridgeName].CalculateAmountOut(ProcessorInputParams)
+		amountOut, err := r.pathProcessors[path.BridgeName].CalculateAmountOut(processorInputParams)
 		if err != nil {
 			continue
 		}

--- a/services/wallet/router/router_send_type.go
+++ b/services/wallet/router/router_send_type.go
@@ -103,9 +103,15 @@ func (s SendType) needL1Fee() bool {
 	return !s.IsEnsTransfer() && !s.IsStickersTransfer()
 }
 
+// canUseProcessor is used to check if certain SendType can be used with a given path processor
 func (s SendType) canUseProcessor(p pathprocessor.PathProcessor) bool {
 	pathProcessorName := p.Name()
 	switch s {
+	case Bridge:
+		return pathProcessorName == pathprocessor.ProcessorBridgeHopName ||
+			pathProcessorName == pathprocessor.ProcessorBridgeCelerName
+	case Swap:
+		return pathProcessorName == pathprocessor.ProcessorSwapParaswapName
 	case ERC721Transfer:
 		return pathProcessorName == pathprocessor.ProcessorERC721Name
 	case ERC1155Transfer:

--- a/services/wallet/router/router_v2.go
+++ b/services/wallet/router/router_v2.go
@@ -13,7 +13,6 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/ens"
 	"github.com/status-im/status-go/services/wallet/async"
-	"github.com/status-im/status-go/services/wallet/bigint"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/router/pathprocessor"
 	walletToken "github.com/status-im/status-go/services/wallet/token"
@@ -49,9 +48,9 @@ type RouteInputParams struct {
 	TestnetMode          bool                    `json:"testnetMode"`
 
 	// For send types like EnsRegister, EnsRelease, EnsSetPubKey, StickersBuy
-	Username  string         `json:"username"`
-	PublicKey string         `json:"publicKey"`
-	PackID    *bigint.BigInt `json:"packID"`
+	Username  string       `json:"username"`
+	PublicKey string       `json:"publicKey"`
+	PackID    *hexutil.Big `json:"packID"`
 }
 
 type PathV2 struct {
@@ -492,7 +491,7 @@ func (r *Router) SuggestedRoutesV2(ctx context.Context, input *RouteInputParams)
 
 						Username:  input.Username,
 						PublicKey: input.PublicKey,
-						PackID:    input.PackID.Int,
+						PackID:    input.PackID.ToInt(),
 					}
 
 					can, err := pProcessor.AvailableFor(processorInputParams)

--- a/services/wallet/router/router_v2.go
+++ b/services/wallet/router/router_v2.go
@@ -561,7 +561,7 @@ func (r *Router) SuggestedRoutesV2(ctx context.Context, input *RouteInputParams)
 					candidates = append(candidates, &PathV2{
 						ProcessorName:  pProcessor.Name(),
 						FromChain:      network,
-						ToChain:        network,
+						ToChain:        dest,
 						FromToken:      token,
 						AmountIn:       (*hexutil.Big)(amountToSend),
 						AmountInLocked: amountLocked,

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/params"
+	protocolCommon "github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/ens"
@@ -170,6 +171,11 @@ func NewService(
 
 	activity := activity.NewService(db, accountsDB, tokenManager, collectiblesManager, feed, pendingTxManager)
 
+	featureFlags := &protocolCommon.FeatureFlags{}
+	if config.WalletConfig.EnableCelerBridge {
+		featureFlags.EnableCelerBridge = true
+	}
+
 	return &Service{
 		db:                    db,
 		accountsDB:            accountsDB,
@@ -198,6 +204,7 @@ func NewService(
 		blockChainState:       blockChainState,
 		keycardPairings:       NewKeycardPairings(),
 		config:                config,
+		featureFlags:          featureFlags,
 	}
 }
 
@@ -231,6 +238,7 @@ type Service struct {
 	blockChainState       *blockchainstate.BlockChainState
 	keycardPairings       *KeycardPairings
 	config                *params.NodeConfig
+	featureFlags          *protocolCommon.FeatureFlags
 }
 
 // Start signals transmitter.
@@ -292,6 +300,10 @@ func (s *Service) KeycardPairings() *KeycardPairings {
 
 func (s *Service) Config() *params.NodeConfig {
 	return s.config
+}
+
+func (s *Service) FeatureFlags() *protocolCommon.FeatureFlags {
+	return s.featureFlags
 }
 
 func (s *Service) GetRPCClient() *rpc.Client {

--- a/services/wallet/thirdparty/paraswap/client_v5.go
+++ b/services/wallet/thirdparty/paraswap/client_v5.go
@@ -2,6 +2,13 @@ package paraswap
 
 import "github.com/status-im/status-go/services/wallet/thirdparty"
 
+type SwapSide string
+
+const (
+	SellSide = SwapSide("SELL")
+	BuySide  = SwapSide("BUY")
+)
+
 type ClientV5 struct {
 	httpClient *thirdparty.HTTPClient
 	chainID    uint64

--- a/services/wallet/thirdparty/paraswap/request_price_route.go
+++ b/services/wallet/thirdparty/paraswap/request_price_route.go
@@ -24,6 +24,7 @@ type Route struct {
 	DestTokenAddress  common.Address  `json:"destToken"`
 	DestTokenDecimals uint            `json:"destDecimals"`
 	RawPriceRoute     json.RawMessage `json:"rawPriceRoute"`
+	Side              SwapSide        `json:"side"`
 }
 
 type PriceRouteResponse struct {
@@ -33,7 +34,7 @@ type PriceRouteResponse struct {
 
 func (c *ClientV5) FetchPriceRoute(ctx context.Context, srcTokenAddress common.Address, srcTokenDecimals uint,
 	destTokenAddress common.Address, destTokenDecimals uint, amountWei *big.Int, addressFrom common.Address,
-	addressTo common.Address) (Route, error) {
+	addressTo common.Address, side SwapSide) (Route, error) {
 
 	params := netUrl.Values{}
 	params.Add("srcToken", srcTokenAddress.Hex())
@@ -44,7 +45,7 @@ func (c *ClientV5) FetchPriceRoute(ctx context.Context, srcTokenAddress common.A
 	// params.Add("receiver", addressTo.Hex())  // at this point paraswap doesn't allow swap and transfer transaction
 	params.Add("network", strconv.FormatUint(c.chainID, 10))
 	params.Add("amount", amountWei.String())
-	params.Add("side", "SELL")
+	params.Add("side", string(side))
 
 	url := pricesURL
 	response, err := c.httpClient.DoGetRequest(ctx, url, params)

--- a/services/wallet/thirdparty/paraswap/request_price_route_test.go
+++ b/services/wallet/thirdparty/paraswap/request_price_route_test.go
@@ -108,6 +108,7 @@ func TestUnmarshallPriceRoute(t *testing.T) {
 		DestAmount:        &bigint.BigInt{Int: big.NewInt(1000000000000000000)},
 		DestTokenAddress:  common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
 		DestTokenDecimals: 18,
+		Side:              SellSide,
 		RawPriceRoute:     data,
 	}
 


### PR DESCRIPTION
What's done:
- Celer bridge as a potential path disabled (at least for 2.30) due to making correct routes using a single (hop) bridge
- `AmountOut` and `SlippagePercentage` added to the input params and they will be currently used for the swap sending type only, but later it could be that we will add something similar to other swap/s or bridge/s processors that we want to support