### PR TITLE
fix: enable pxclient and filter peerExchange peers returned

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20240612113959-d9dc91a162d9
+	github.com/waku-org/go-waku v0.8.1-0.20240625022701-1cf180ebc659
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -2137,8 +2137,8 @@ github.com/waku-org/go-discover v0.0.0-20240506173252-4912704efdc5 h1:4K3IS97Jry
 github.com/waku-org/go-discover v0.0.0-20240506173252-4912704efdc5/go.mod h1:eBHgM6T4EG0RZzxpxKy+rGz/6Dw2Nd8DWxS0lm9ESDw=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20240612113959-d9dc91a162d9 h1:OvO9PxpYYh4cNuuHpwXguZBQWEppdhdHAT2jIDls02k=
-github.com/waku-org/go-waku v0.8.1-0.20240612113959-d9dc91a162d9/go.mod h1:biffO55kWbvfO8jdu/aAPiWcmozrfFKPum4EMFDib+k=
+github.com/waku-org/go-waku v0.8.1-0.20240625022701-1cf180ebc659 h1:bTz24QgoRBXoS/WIy8+7jrQ/7hpE63td0fMteq5qZQM=
+github.com/waku-org/go-waku v0.8.1-0.20240625022701-1cf180ebc659/go.mod h1:biffO55kWbvfO8jdu/aAPiWcmozrfFKPum4EMFDib+k=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/vendor/github.com/waku-org/go-waku/logging/logging.go
+++ b/vendor/github.com/waku-org/go-waku/logging/logging.go
@@ -8,6 +8,7 @@ package logging
 
 import (
 	"encoding/hex"
+	"fmt"
 	"net"
 	"time"
 
@@ -146,4 +147,9 @@ func TCPAddr(key string, ip net.IP, port int) zap.Field {
 // UDPAddr creates a field for UDP v4/v6 address and port
 func UDPAddr(key string, ip net.IP, port int) zap.Field {
 	return zap.Stringer(key, &net.UDPAddr{IP: ip, Port: port})
+}
+
+func Uint64(key string, value uint64) zap.Field {
+	valueStr := fmt.Sprintf("%v", value)
+	return zap.String(key, valueStr)
 }

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/localnode.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/localnode.go
@@ -9,7 +9,9 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/libp2p/go-libp2p/core/event"
+	"github.com/multiformats/go-multiaddr"
 	ma "github.com/multiformats/go-multiaddr"
+	madns "github.com/multiformats/go-multiaddr-dns"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	wenr "github.com/waku-org/go-waku/waku/v2/protocol/enr"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
@@ -20,7 +22,6 @@ func (w *WakuNode) updateLocalNode(localnode *enode.LocalNode, multiaddrs []ma.M
 	var options []wenr.ENROption
 	options = append(options, wenr.WithUDPPort(udpPort))
 	options = append(options, wenr.WithWakuBitfield(wakuFlags))
-	options = append(options, wenr.WithMultiaddress(multiaddrs...))
 
 	if advertiseAddr != nil {
 		// An advertised address disables libp2p address updates
@@ -36,32 +37,38 @@ func (w *WakuNode) updateLocalNode(localnode *enode.LocalNode, multiaddrs []ma.M
 		// Using a static ip will disable endpoint prediction.
 		options = append(options, wenr.WithIP(ipAddr))
 	} else {
-		// We received a libp2p address update, but we should still
-		// allow discv5 to update the enr record. We set the localnode
-		// keys manually. It's possible that the ENR record might get
-		// updated automatically
-		ip4 := ipAddr.IP.To4()
-		ip6 := ipAddr.IP.To16()
-		if ip4 != nil && !ip4.IsUnspecified() {
-			localnode.SetFallbackIP(ip4)
-			localnode.Set(enr.IPv4(ip4))
-			localnode.Set(enr.TCP(uint16(ipAddr.Port)))
-		} else {
-			localnode.Delete(enr.IPv4{})
-			localnode.Delete(enr.TCP(0))
-			localnode.SetFallbackIP(net.IP{127, 0, 0, 1})
-		}
+		if ipAddr.Port != 0 {
+			// We received a libp2p address update, but we should still
+			// allow discv5 to update the enr record. We set the localnode
+			// keys manually. It's possible that the ENR record might get
+			// updated automatically
+			ip4 := ipAddr.IP.To4()
+			ip6 := ipAddr.IP.To16()
+			if ip4 != nil && !ip4.IsUnspecified() {
+				localnode.SetFallbackIP(ip4)
+				localnode.Set(enr.IPv4(ip4))
+				localnode.Set(enr.TCP(uint16(ipAddr.Port)))
+			} else {
+				localnode.Delete(enr.IPv4{})
+				localnode.Delete(enr.TCP(0))
+				localnode.SetFallbackIP(net.IP{127, 0, 0, 1})
+			}
 
-		if ip4 == nil && ip6 != nil && !ip6.IsUnspecified() {
-			localnode.Set(enr.IPv6(ip6))
-			localnode.Set(enr.TCP6(ipAddr.Port))
-		} else {
-			localnode.Delete(enr.IPv6{})
-			localnode.Delete(enr.TCP6(0))
+			if ip4 == nil && ip6 != nil && !ip6.IsUnspecified() {
+				localnode.Set(enr.IPv6(ip6))
+				localnode.Set(enr.TCP6(ipAddr.Port))
+			} else {
+				localnode.Delete(enr.IPv6{})
+				localnode.Delete(enr.TCP6(0))
+			}
 		}
 	}
 
-	return wenr.Update(localnode, options...)
+	// Writing the IP + Port has priority over writting the multiaddress which might fail or not
+	// depending on the enr having space
+	options = append(options, wenr.WithMultiaddress(multiaddrs...))
+
+	return wenr.Update(w.log, localnode, options...)
 }
 
 func isPrivate(addr *net.TCPAddr) bool {
@@ -177,7 +184,7 @@ func decapsulateP2P(addr ma.Multiaddr) (ma.Multiaddr, error) {
 	return addr, nil
 }
 
-func decapsulateCircuitRelayAddr(addr ma.Multiaddr) (ma.Multiaddr, error) {
+func decapsulateCircuitRelayAddr(ctx context.Context, addr ma.Multiaddr) (ma.Multiaddr, error) {
 	_, err := addr.ValueForProtocol(ma.P_CIRCUIT)
 	if err != nil {
 		return nil, errors.New("not a circuit relay address")
@@ -187,6 +194,16 @@ func decapsulateCircuitRelayAddr(addr ma.Multiaddr) (ma.Multiaddr, error) {
 	addr, _ = ma.SplitFunc(addr, func(c ma.Component) bool {
 		return c.Protocol().Code == ma.P_CIRCUIT
 	})
+
+	// If the multiaddress is a dns4 address, we resolve it
+	addrs, err := madns.DefaultResolver.Resolve(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(addrs) > 0 {
+		return addrs[0], nil
+	}
 
 	return addr, nil
 }
@@ -215,10 +232,10 @@ func selectWSListenAddresses(addresses []ma.Multiaddr) ([]ma.Multiaddr, error) {
 	return result, nil
 }
 
-func selectCircuitRelayListenAddresses(addresses []ma.Multiaddr) ([]ma.Multiaddr, error) {
+func selectCircuitRelayListenAddresses(ctx context.Context, addresses []ma.Multiaddr) ([]ma.Multiaddr, error) {
 	var result []ma.Multiaddr
 	for _, addr := range addresses {
-		addr, err := decapsulateCircuitRelayAddr(addr)
+		addr, err := decapsulateCircuitRelayAddr(ctx, addr)
 		if err != nil {
 			continue
 		}
@@ -228,8 +245,29 @@ func selectCircuitRelayListenAddresses(addresses []ma.Multiaddr) ([]ma.Multiaddr
 	return result, nil
 }
 
-func (w *WakuNode) getENRAddresses(addrs []ma.Multiaddr) (extAddr *net.TCPAddr, multiaddr []ma.Multiaddr, err error) {
 
+func filter0Port(addresses []ma.Multiaddr) ([]ma.Multiaddr, error) {
+	var result []ma.Multiaddr
+	for _, addr := range addresses {
+		portStr, err := addr.ValueForProtocol(ma.P_TCP)
+		if err != nil && !errors.Is(err, multiaddr.ErrProtocolNotFound) {
+			return nil, err
+		}
+
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			return nil, err
+		}
+
+		if port != 0 {
+			result = append(result, addr)
+		}
+	}
+
+	return result, nil
+}
+
+func (w *WakuNode) getENRAddresses(ctx context.Context, addrs []ma.Multiaddr) (extAddr *net.TCPAddr, multiaddr []ma.Multiaddr, err error) {
 	extAddr, err = selectMostExternalAddress(addrs)
 	if err != nil {
 		return nil, nil, err
@@ -240,7 +278,7 @@ func (w *WakuNode) getENRAddresses(addrs []ma.Multiaddr) (extAddr *net.TCPAddr, 
 		return nil, nil, err
 	}
 
-	circuitAddrs, err := selectCircuitRelayListenAddresses(addrs)
+	circuitAddrs, err := selectCircuitRelayListenAddresses(ctx, addrs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -253,11 +291,16 @@ func (w *WakuNode) getENRAddresses(addrs []ma.Multiaddr) (extAddr *net.TCPAddr, 
 		multiaddr = append(multiaddr, wssAddrs...)
 	}
 
+	multiaddr, err = filter0Port(multiaddr)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return
 }
 
 func (w *WakuNode) setupENR(ctx context.Context, addrs []ma.Multiaddr) error {
-	ipAddr, multiaddresses, err := w.getENRAddresses(addrs)
+	ipAddr, multiaddresses, err := w.getENRAddresses(ctx, addrs)
 	if err != nil {
 		w.log.Error("obtaining external address", zap.Error(err))
 		return err
@@ -323,7 +366,7 @@ func (w *WakuNode) watchTopicShards(ctx context.Context) error {
 						w.log.Warn("A mix of named and static shards found. ENR shard will contain only the following shards", zap.Any("shards", rs[0]))
 					}
 
-					err = wenr.Update(w.localNode, wenr.WithWakuRelaySharding(rs[0]))
+					err = wenr.Update(w.log, w.localNode, wenr.WithWakuRelaySharding(rs[0]))
 					if err != nil {
 						w.log.Warn("could not set ENR shard info", zap.Error(err))
 						continue

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go
@@ -256,7 +256,7 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 	w.metadata = metadata
 
 	//Initialize peer manager.
-	w.peermanager = peermanager.NewPeerManager(w.opts.maxPeerConnections, w.opts.peerStoreCapacity, metadata, w.log)
+	w.peermanager = peermanager.NewPeerManager(w.opts.maxPeerConnections, w.opts.peerStoreCapacity, metadata, params.enableRelay, w.log)
 
 	w.peerConnector, err = peermanager.NewPeerConnectionStrategy(w.peermanager, discoveryConnectTimeout, w.log)
 	if err != nil {
@@ -554,9 +554,9 @@ func (w *WakuNode) watchENRChanges(ctx context.Context) {
 				currNodeVal := w.localNode.Node().String()
 				if prevNodeVal != currNodeVal {
 					if prevNodeVal == "" {
-						w.log.Info("enr record", logging.ENode("enr", w.localNode.Node()))
+						w.log.Info("local node enr record", logging.ENode("enr", w.localNode.Node()))
 					} else {
-						w.log.Info("new enr record", logging.ENode("enr", w.localNode.Node()))
+						w.log.Info("local node new enr record", logging.ENode("enr", w.localNode.Node()))
 					}
 					prevNodeVal = currNodeVal
 				}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/wakuoptions.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/wakuoptions.go
@@ -44,6 +44,8 @@ const UserAgent string = "go-waku"
 const defaultMinRelayPeersToPublish = 0
 
 const DefaultMaxConnectionsPerIP = 5
+const DefaultMaxConnections = 300
+const DefaultMaxPeerStoreCapacity = 300
 
 type WakuNodeParameters struct {
 	hostAddr            *net.TCPAddr
@@ -124,9 +126,10 @@ type WakuNodeOption func(*WakuNodeParameters) error
 // Default options used in the libp2p node
 var DefaultWakuNodeOptions = []WakuNodeOption{
 	WithPrometheusRegisterer(prometheus.NewRegistry()),
-	WithMaxPeerConnections(50),
+	WithMaxPeerConnections(DefaultMaxConnections),
 	WithMaxConnectionsPerIP(DefaultMaxConnectionsPerIP),
 	WithCircuitRelayParams(2*time.Second, 3*time.Minute),
+	WithPeerStoreCapacity(DefaultMaxPeerStoreCapacity),
 }
 
 // MultiAddresses return the list of multiaddresses configured in the node

--- a/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_connector.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_connector.go
@@ -17,7 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/backoff"
 	"github.com/waku-org/go-waku/logging"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
-	waku_proto "github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/service"
 
 	"go.uber.org/zap"
@@ -127,10 +126,9 @@ func (c *PeerConnectionStrategy) consumeSubscription(s subscription) {
 				triggerImmediateConnection := false
 				//Not connecting to peer as soon as it is discovered,
 				// rather expecting this to be pushed from PeerManager based on the need.
-				if len(c.host.Network().Peers()) < waku_proto.GossipSubDMin {
+				if len(c.host.Network().Peers()) < c.pm.OutPeersTarget {
 					triggerImmediateConnection = true
 				}
-				c.logger.Debug("adding discovered peer", logging.HostID("peerID", p.AddrInfo.ID))
 				c.pm.AddDiscoveredPeer(p, triggerImmediateConnection)
 
 			case <-time.After(1 * time.Second):
@@ -227,7 +225,7 @@ func (c *PeerConnectionStrategy) addConnectionBackoff(peerID peer.ID) {
 func (c *PeerConnectionStrategy) dialPeers() {
 	defer c.WaitGroup().Done()
 
-	maxGoRoutines := c.pm.OutRelayPeersTarget
+	maxGoRoutines := c.pm.OutPeersTarget
 	if maxGoRoutines > maxActiveDials {
 		maxGoRoutines = maxActiveDials
 	}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go
@@ -55,7 +55,7 @@ func (pm *PeerManager) discoverOnDemand(cluster uint16,
 
 	wakuProtoInfo, ok := pm.wakuprotoToENRFieldMap[wakuProtocol]
 	if !ok {
-		pm.logger.Error("cannot do on demand discovery for non-waku protocol", zap.String("protocol", string(wakuProtocol)))
+		pm.logger.Info("cannot do on demand discovery for non-waku protocol", zap.String("protocol", string(wakuProtocol)))
 		return nil, errors.New("cannot do on demand discovery for non-waku protocol")
 	}
 	iterator, err := pm.discoveryService.PeerIterator(

--- a/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go
@@ -73,8 +73,8 @@ type PeerManager struct {
 	maxPeers               int
 	maxRelayPeers          int
 	logger                 *zap.Logger
-	InRelayPeersTarget     int
-	OutRelayPeersTarget    int
+	InPeersTarget          int
+	OutPeersTarget         int
 	host                   host.Host
 	serviceSlots           *ServiceSlots
 	ctx                    context.Context
@@ -85,6 +85,7 @@ type PeerManager struct {
 	wakuprotoToENRFieldMap map[protocol.ID]WakuProtoInfo
 	TopicHealthNotifCh     chan<- TopicHealthStatus
 	rttCache               *FastestPeerSelector
+	RelayEnabled           bool
 }
 
 // PeerSelection provides various options based on which Peer is selected from a list of peers.
@@ -127,7 +128,7 @@ func (pm *PeerManager) checkAndUpdateTopicHealth(topic *NodeTopicDetails) int {
 			pThreshold, err := pm.host.Peerstore().(wps.WakuPeerstore).Score(p)
 			if err == nil {
 				if pThreshold < relay.PeerPublishThreshold {
-					pm.logger.Debug("peer score below publish threshold", logging.HostID("peer", p), zap.Float64("score", pThreshold))
+					pm.logger.Debug("peer score below publish threshold", zap.Stringer("peer", p), zap.Float64("score", pThreshold))
 				} else {
 					healthyPeerCount++
 				}
@@ -135,14 +136,15 @@ func (pm *PeerManager) checkAndUpdateTopicHealth(topic *NodeTopicDetails) int {
 				if errors.Is(err, peerstore.ErrNotFound) {
 					// For now considering peer as healthy if we can't fetch score.
 					healthyPeerCount++
-					pm.logger.Debug("peer score is not available yet", logging.HostID("peer", p))
+					pm.logger.Debug("peer score is not available yet", zap.Stringer("peer", p))
 				} else {
-					pm.logger.Warn("failed to fetch peer score ", zap.Error(err), logging.HostID("peer", p))
+					pm.logger.Warn("failed to fetch peer score ", zap.Error(err), zap.Stringer("peer", p))
 				}
 			}
 		}
 	}
 	//Update topic's health
+	//TODO: This should be done based on number of full-mesh peers.
 	oldHealth := topic.healthStatus
 	if healthyPeerCount < 1 { //Ideally this check should be done with minPeersForRelay, but leaving it as is for now.
 		topic.healthStatus = UnHealthy
@@ -174,31 +176,38 @@ func (pm *PeerManager) TopicHealth(pubsubTopic string) (TopicHealth, error) {
 }
 
 // NewPeerManager creates a new peerManager instance.
-func NewPeerManager(maxConnections int, maxPeers int, metadata *metadata.WakuMetadata, logger *zap.Logger) *PeerManager {
+func NewPeerManager(maxConnections int, maxPeers int, metadata *metadata.WakuMetadata, relayEnabled bool, logger *zap.Logger) *PeerManager {
+	var inPeersTarget, outPeersTarget, maxRelayPeers int
+	if relayEnabled {
+		maxRelayPeers, _ := relayAndServicePeers(maxConnections)
+		inPeersTarget, outPeersTarget = inAndOutRelayPeers(maxRelayPeers)
 
-	maxRelayPeers, _ := relayAndServicePeers(maxConnections)
-	inRelayPeersTarget, outRelayPeersTarget := inAndOutRelayPeers(maxRelayPeers)
-
-	if maxPeers == 0 || maxConnections > maxPeers {
-		maxPeers = maxConnsToPeerRatio * maxConnections
+		if maxPeers == 0 || maxConnections > maxPeers {
+			maxPeers = maxConnsToPeerRatio * maxConnections
+		}
+	} else {
+		maxRelayPeers = 0
+		inPeersTarget = 0
+		//TODO: ideally this should be 2 filter peers per topic, 2 lightpush peers per topic and 2-4 store nodes per topic
+		outPeersTarget = 10
 	}
-
 	pm := &PeerManager{
 		logger:                 logger.Named("peer-manager"),
 		metadata:               metadata,
 		maxRelayPeers:          maxRelayPeers,
-		InRelayPeersTarget:     inRelayPeersTarget,
-		OutRelayPeersTarget:    outRelayPeersTarget,
+		InPeersTarget:          inPeersTarget,
+		OutPeersTarget:         outPeersTarget,
 		serviceSlots:           NewServiceSlot(),
 		subRelayTopics:         make(map[string]*NodeTopicDetails),
 		maxPeers:               maxPeers,
 		wakuprotoToENRFieldMap: map[protocol.ID]WakuProtoInfo{},
 		rttCache:               NewFastestPeerSelector(logger),
+		RelayEnabled:           relayEnabled,
 	}
 	logger.Info("PeerManager init values", zap.Int("maxConnections", maxConnections),
 		zap.Int("maxRelayPeers", maxRelayPeers),
-		zap.Int("outRelayPeersTarget", outRelayPeersTarget),
-		zap.Int("inRelayPeersTarget", pm.InRelayPeersTarget),
+		zap.Int("outPeersTarget", outPeersTarget),
+		zap.Int("inPeersTarget", pm.InPeersTarget),
 		zap.Int("maxPeers", maxPeers))
 
 	return pm
@@ -225,7 +234,7 @@ func (pm *PeerManager) Start(ctx context.Context) {
 	pm.RegisterWakuProtocol(relay.WakuRelayID_v200, relay.WakuRelayENRField)
 
 	pm.ctx = ctx
-	if pm.sub != nil {
+	if pm.sub != nil && pm.RelayEnabled {
 		go pm.peerEventLoop(ctx)
 	}
 	go pm.connectivityLoop(ctx)
@@ -233,7 +242,7 @@ func (pm *PeerManager) Start(ctx context.Context) {
 
 // This is a connectivity loop, which currently checks and prunes inbound connections.
 func (pm *PeerManager) connectivityLoop(ctx context.Context) {
-	pm.connectToRelayPeers()
+	pm.connectToPeers()
 	t := time.NewTicker(peerConnectivityLoopSecs * time.Second)
 	defer t.Stop()
 	for {
@@ -241,7 +250,7 @@ func (pm *PeerManager) connectivityLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			pm.connectToRelayPeers()
+			pm.connectToPeers()
 		}
 	}
 }
@@ -262,7 +271,7 @@ func (pm *PeerManager) GroupPeersByDirection(specificPeers ...peer.ID) (inPeers 
 			}
 		} else {
 			pm.logger.Error("failed to retrieve peer direction",
-				logging.HostID("peerID", p), zap.Error(err))
+				zap.Stringer("peerID", p), zap.Error(err))
 		}
 	}
 	return inPeers, outPeers, nil
@@ -302,10 +311,10 @@ func (pm *PeerManager) ensureMinRelayConnsPerTopic() {
 		// match those peers that are currently connected
 
 		curPeerLen := pm.checkAndUpdateTopicHealth(topicInst)
-		if curPeerLen < waku_proto.GossipSubDMin {
-			pm.logger.Debug("subscribed topic is not sufficiently healthy, initiating more connections to maintain health",
+		if curPeerLen < pm.OutPeersTarget {
+			pm.logger.Debug("subscribed topic has not reached target peers, initiating more connections to maintain healthy mesh",
 				zap.String("pubSubTopic", topicStr), zap.Int("connectedPeerCount", curPeerLen),
-				zap.Int("optimumPeers", waku_proto.GossipSubDMin))
+				zap.Int("targetPeers", pm.OutPeersTarget))
 			//Find not connected peers.
 			notConnectedPeers := pm.getNotConnectedPers(topicStr)
 			if notConnectedPeers.Len() == 0 {
@@ -315,35 +324,42 @@ func (pm *PeerManager) ensureMinRelayConnsPerTopic() {
 			}
 			pm.logger.Debug("connecting to eligible peers in peerstore", zap.String("pubSubTopic", topicStr))
 			//Connect to eligible peers.
-			numPeersToConnect := waku_proto.GossipSubDMin - curPeerLen
+			numPeersToConnect := pm.OutPeersTarget - curPeerLen
 
 			if numPeersToConnect > notConnectedPeers.Len() {
 				numPeersToConnect = notConnectedPeers.Len()
 			}
-			pm.connectToPeers(notConnectedPeers[0:numPeersToConnect])
+			pm.connectToSpecifiedPeers(notConnectedPeers[0:numPeersToConnect])
 		}
 	}
 }
 
-// connectToRelayPeers ensures minimum D connections are there for each pubSubTopic.
+// connectToPeers ensures minimum D connections are there for each pubSubTopic.
 // If not, initiates connections to additional peers.
 // It also checks for incoming relay connections and prunes once they cross inRelayTarget
-func (pm *PeerManager) connectToRelayPeers() {
-	//Check for out peer connections and connect to more peers.
-	pm.ensureMinRelayConnsPerTopic()
+func (pm *PeerManager) connectToPeers() {
+	if pm.RelayEnabled {
+		//Check for out peer connections and connect to more peers.
+		pm.ensureMinRelayConnsPerTopic()
 
-	inRelayPeers, outRelayPeers := pm.getRelayPeers()
-	pm.logger.Debug("number of relay peers connected",
-		zap.Int("in", inRelayPeers.Len()),
-		zap.Int("out", outRelayPeers.Len()))
-	if inRelayPeers.Len() > 0 &&
-		inRelayPeers.Len() > pm.InRelayPeersTarget {
-		pm.pruneInRelayConns(inRelayPeers)
+		inRelayPeers, outRelayPeers := pm.getRelayPeers()
+		pm.logger.Debug("number of relay peers connected",
+			zap.Int("in", inRelayPeers.Len()),
+			zap.Int("out", outRelayPeers.Len()))
+		if inRelayPeers.Len() > 0 &&
+			inRelayPeers.Len() > pm.InPeersTarget {
+			pm.pruneInRelayConns(inRelayPeers)
+		}
+	} else {
+		//TODO: Connect to filter peers per topic as of now.
+		//Fetch filter peers from peerStore, TODO: topics for lightNode not available here?
+		//Filter subscribe to notify peerManager whenever a new topic/shard is subscribed to.
+		pm.logger.Debug("light mode..not doing anything")
 	}
 }
 
-// connectToPeers connects to peers provided in the list if the addresses have not expired.
-func (pm *PeerManager) connectToPeers(peers peer.IDSlice) {
+// connectToSpecifiedPeers connects to peers provided in the list if the addresses have not expired.
+func (pm *PeerManager) connectToSpecifiedPeers(peers peer.IDSlice) {
 	for _, peerID := range peers {
 		peerData := AddrInfoToPeerData(wps.PeerManager, peerID, pm.host)
 		if peerData == nil {
@@ -377,16 +393,16 @@ func (pm *PeerManager) pruneInRelayConns(inRelayPeers peer.IDSlice) {
 	//TODO: Need to have more intelligent way of doing this, maybe peer scores.
 	//TODO: Keep optimalPeersRequired for a pubSubTopic in mind while pruning connections to peers.
 	pm.logger.Info("peer connections exceed target relay peers, hence pruning",
-		zap.Int("cnt", inRelayPeers.Len()), zap.Int("target", pm.InRelayPeersTarget))
-	for pruningStartIndex := pm.InRelayPeersTarget; pruningStartIndex < inRelayPeers.Len(); pruningStartIndex++ {
+		zap.Int("cnt", inRelayPeers.Len()), zap.Int("target", pm.InPeersTarget))
+	for pruningStartIndex := pm.InPeersTarget; pruningStartIndex < inRelayPeers.Len(); pruningStartIndex++ {
 		p := inRelayPeers[pruningStartIndex]
 		err := pm.host.Network().ClosePeer(p)
 		if err != nil {
 			pm.logger.Warn("failed to disconnect connection towards peer",
-				logging.HostID("peerID", p))
+				zap.Stringer("peerID", p))
 		}
 		pm.logger.Debug("successfully disconnected connection towards peer",
-			logging.HostID("peerID", p))
+			zap.Stringer("peerID", p))
 	}
 }
 
@@ -394,7 +410,7 @@ func (pm *PeerManager) processPeerENR(p *service.PeerData) []protocol.ID {
 	shards, err := wenr.RelaySharding(p.ENR.Record())
 	if err != nil {
 		pm.logger.Error("could not derive relayShards from ENR", zap.Error(err),
-			logging.HostID("peer", p.AddrInfo.ID), zap.String("enr", p.ENR.String()))
+			zap.Stringer("peer", p.AddrInfo.ID), zap.String("enr", p.ENR.String()))
 	} else {
 		if shards != nil {
 			p.PubsubTopics = make([]string, 0)
@@ -404,7 +420,7 @@ func (pm *PeerManager) processPeerENR(p *service.PeerData) []protocol.ID {
 				p.PubsubTopics = append(p.PubsubTopics, topicStr)
 			}
 		} else {
-			pm.logger.Debug("ENR doesn't have relay shards", logging.HostID("peer", p.AddrInfo.ID))
+			pm.logger.Debug("ENR doesn't have relay shards", zap.Stringer("peer", p.AddrInfo.ID))
 		}
 	}
 	supportedProtos := []protocol.ID{}
@@ -430,6 +446,7 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 	if pm.maxPeers <= pm.host.Peerstore().Peers().Len() {
 		return
 	}
+
 	//Check if the peer is already present, if so skip adding
 	_, err := pm.host.Peerstore().(wps.WakuPeerstore).Origin(p.AddrInfo.ID)
 	if err == nil {
@@ -442,16 +459,17 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 				}
 				//Peer is already in peer-store but stored ENR is older than discovered one.
 				pm.logger.Info("peer already found in peerstore, but re-adding it as ENR sequence is higher than locally stored",
-					logging.HostID("peer", p.AddrInfo.ID), zap.Uint64("newENRSeq", p.ENR.Seq()), zap.Uint64("storedENRSeq", enr.Record().Seq()))
+					zap.Stringer("peer", p.AddrInfo.ID), logging.Uint64("newENRSeq", p.ENR.Record().Seq()), logging.Uint64("storedENRSeq", enr.Record().Seq()))
 			} else {
-				pm.logger.Info("peer already found in peerstore, but no new ENR", logging.HostID("peer", p.AddrInfo.ID))
+				pm.logger.Info("peer already found in peerstore, but no new ENR", zap.Stringer("peer", p.AddrInfo.ID))
 			}
 		} else {
 			//Peer is in peer-store but it doesn't have an enr
 			pm.logger.Info("peer already found in peerstore, but doesn't have an ENR record, re-adding",
-				logging.HostID("peer", p.AddrInfo.ID))
+				zap.Stringer("peer", p.AddrInfo.ID))
 		}
 	}
+	pm.logger.Debug("adding discovered peer", zap.Stringer("peerID", p.AddrInfo.ID))
 
 	supportedProtos := []protocol.ID{}
 	if len(p.PubsubTopics) == 0 && p.ENR != nil {
@@ -462,14 +480,15 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 	_ = pm.addPeer(p.AddrInfo.ID, p.AddrInfo.Addrs, p.Origin, p.PubsubTopics, supportedProtos...)
 
 	if p.ENR != nil {
+		pm.logger.Debug("setting ENR for peer", zap.Stringer("peerID", p.AddrInfo.ID), zap.Stringer("enr", p.ENR))
 		err := pm.host.Peerstore().(wps.WakuPeerstore).SetENR(p.AddrInfo.ID, p.ENR)
 		if err != nil {
 			pm.logger.Error("could not store enr", zap.Error(err),
-				logging.HostID("peer", p.AddrInfo.ID), zap.String("enr", p.ENR.String()))
+				zap.Stringer("peer", p.AddrInfo.ID), zap.String("enr", p.ENR.String()))
 		}
 	}
 	if connectNow {
-		pm.logger.Debug("connecting now to discovered peer", logging.HostID("peer", p.AddrInfo.ID))
+		pm.logger.Debug("connecting now to discovered peer", zap.Stringer("peer", p.AddrInfo.ID))
 		go pm.peerConnector.PushToChan(p)
 	}
 }
@@ -478,10 +497,10 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 // It also sets additional metadata such as origin, ENR and supported protocols
 func (pm *PeerManager) addPeer(ID peer.ID, addrs []ma.Multiaddr, origin wps.Origin, pubSubTopics []string, protocols ...protocol.ID) error {
 	if pm.maxPeers <= pm.host.Peerstore().Peers().Len() {
-		pm.logger.Error("could not add peer as peer store capacity is reached", logging.HostID("peer", ID), zap.Int("capacity", pm.maxPeers))
+		pm.logger.Error("could not add peer as peer store capacity is reached", zap.Stringer("peer", ID), zap.Int("capacity", pm.maxPeers))
 		return errors.New("peer store capacity reached")
 	}
-	pm.logger.Info("adding peer to peerstore", logging.HostID("peer", ID))
+	pm.logger.Info("adding peer to peerstore", zap.Stringer("peer", ID))
 	if origin == wps.Static {
 		pm.host.Peerstore().AddAddrs(ID, addrs, peerstore.PermanentAddrTTL)
 	} else {
@@ -491,14 +510,14 @@ func (pm *PeerManager) addPeer(ID peer.ID, addrs []ma.Multiaddr, origin wps.Orig
 	}
 	err := pm.host.Peerstore().(wps.WakuPeerstore).SetOrigin(ID, origin)
 	if err != nil {
-		pm.logger.Error("could not set origin", zap.Error(err), logging.HostID("peer", ID))
+		pm.logger.Error("could not set origin", zap.Error(err), zap.Stringer("peer", ID))
 		return err
 	}
 
 	if len(protocols) > 0 {
 		err = pm.host.Peerstore().AddProtocols(ID, protocols...)
 		if err != nil {
-			pm.logger.Error("could not set protocols", zap.Error(err), logging.HostID("peer", ID))
+			pm.logger.Error("could not set protocols", zap.Error(err), zap.Stringer("peer", ID))
 			return err
 		}
 	}
@@ -510,7 +529,7 @@ func (pm *PeerManager) addPeer(ID peer.ID, addrs []ma.Multiaddr, origin wps.Orig
 	err = pm.host.Peerstore().(wps.WakuPeerstore).SetPubSubTopics(ID, pubSubTopics)
 	if err != nil {
 		pm.logger.Error("could not store pubSubTopic", zap.Error(err),
-			logging.HostID("peer", ID), zap.Strings("topics", pubSubTopics))
+			zap.Stringer("peer", ID), zap.Strings("topics", pubSubTopics))
 	}
 	return nil
 }
@@ -588,7 +607,7 @@ func (pm *PeerManager) addPeerToServiceSlot(proto protocol.ID, peerID peer.ID) {
 
 	//For now adding the peer to serviceSlot which means the latest added peer would be given priority.
 	//TODO: Ideally we should sort the peers per service and return best peer based on peer score or RTT etc.
-	pm.logger.Info("adding peer to service slots", logging.HostID("peer", peerID),
+	pm.logger.Info("adding peer to service slots", zap.Stringer("peer", peerID),
 		zap.String("service", string(proto)))
 	// getPeers returns nil for WakuRelayIDv200 protocol, but we don't run this ServiceSlot code for WakuRelayIDv200 protocol
 	pm.serviceSlots.getPeers(proto).add(peerID)

--- a/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go
@@ -450,6 +450,11 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 	//Check if the peer is already present, if so skip adding
 	_, err := pm.host.Peerstore().(wps.WakuPeerstore).Origin(p.AddrInfo.ID)
 	if err == nil {
+		//Add addresses if existing addresses have expired
+		existingAddrs := pm.host.Peerstore().Addrs(p.AddrInfo.ID)
+		if len(existingAddrs) == 0 {
+			pm.host.Peerstore().AddAddrs(p.AddrInfo.ID, p.AddrInfo.Addrs, peerstore.AddressTTL)
+		}
 		enr, err := pm.host.Peerstore().(wps.WakuPeerstore).ENR(p.AddrInfo.ID)
 		// Verifying if the enr record is more recent (DiscV5 and peer exchange can return peers already seen)
 		if err == nil {
@@ -493,8 +498,8 @@ func (pm *PeerManager) AddDiscoveredPeer(p service.PeerData, connectNow bool) {
 	}
 }
 
-// addPeer adds peer to only the peerStore.
-// It also sets additional metadata such as origin, ENR and supported protocols
+// addPeer adds peer to the peerStore.
+// It also sets additional metadata such as origin and supported protocols
 func (pm *PeerManager) addPeer(ID peer.ID, addrs []ma.Multiaddr, origin wps.Origin, pubSubTopics []string, protocols ...protocol.ID) error {
 	if pm.maxPeers <= pm.host.Peerstore().Peers().Len() {
 		pm.logger.Error("could not add peer as peer store capacity is reached", zap.Stringer("peer", ID), zap.Int("capacity", pm.maxPeers))

--- a/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/topic_event_handler.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/topic_event_handler.go
@@ -48,7 +48,9 @@ func (pm *PeerManager) handleNewRelayTopicSubscription(pubsubTopic string, topic
 
 	pm.checkAndUpdateTopicHealth(pm.subRelayTopics[pubsubTopic])
 
-	if connectedPeers >= waku_proto.GossipSubDMin { //TODO: Use a config rather than hard-coding.
+	//Leaving this logic based on gossipSubDMin as this is a good start for a subscribed topic.
+	// subsequent connectivity loop iteration would initiate more connections which should take it towards a healthy mesh.
+	if connectedPeers >= waku_proto.GossipSubDMin {
 		// Should we use optimal number or define some sort of a config for the node to choose from?
 		// A desktop node may choose this to be 4-6, whereas a service node may choose this to be 8-12 based on resources it has
 		// or bandwidth it can support.
@@ -70,7 +72,7 @@ func (pm *PeerManager) handleNewRelayTopicSubscription(pubsubTopic string, topic
 		}
 		//For now all peers are being given same priority,
 		// Later we may want to choose peers that have more shards in common over others.
-		pm.connectToPeers(notConnectedPeers[0:numPeersToConnect])
+		pm.connectToSpecifiedPeers(notConnectedPeers[0:numPeersToConnect])
 	} else {
 		triggerDiscovery = true
 	}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/common.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/common.go
@@ -5,10 +5,11 @@ import (
 	"time"
 )
 
-const DefaultMaxSubscriptions = 1000
+const DefaultMaxSubscribers = 20
 const MaxCriteriaPerSubscription = 1000
-const MaxContentTopicsPerRequest = 30
+const MaxContentTopicsPerRequest = 100
 const MessagePushTimeout = 20 * time.Second
+const DefaultIdleSubscriptionTimeout = 5 * time.Minute
 
 type FilterError struct {
 	Code    int

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/options.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/options.go
@@ -204,7 +204,7 @@ func WithPeerManager(pm *peermanager.PeerManager) Option {
 
 func DefaultOptions() []Option {
 	return []Option{
-		WithTimeout(5 * time.Minute),
-		WithMaxSubscribers(DefaultMaxSubscriptions),
+		WithTimeout(DefaultIdleSubscriptionTimeout),
+		WithMaxSubscribers(DefaultMaxSubscribers),
 	}
 }

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/test_utils.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/test_utils.go
@@ -164,7 +164,7 @@ func (s *FilterTestSuite) GetWakuFilterLightNode() LightNodeData {
 	s.Require().NoError(err)
 	b := relay.NewBroadcaster(10)
 	s.Require().NoError(b.Start(context.Background()))
-	pm := peermanager.NewPeerManager(5, 5, nil, s.Log)
+	pm := peermanager.NewPeerManager(5, 5, nil, true, s.Log)
 	filterPush := NewWakuFilterLightNode(b, pm, timesource.NewDefaultClock(), prometheus.DefaultRegisterer, s.Log)
 	filterPush.SetHost(host)
 	pm.SetHost(host)

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/relay/waku_relay.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/relay/waku_relay.go
@@ -513,7 +513,7 @@ func (w *WakuRelay) unsubscribeFromPubsubTopic(topicData *pubsubTopicSubscriptio
 
 	err := topicData.topic.Close()
 	if err != nil {
-		w.log.Error("failed to close the pubsubTopic", zap.String("topic", pubSubTopic))
+		w.log.Error("failed to close the pubsubTopic", zap.String("topic", pubSubTopic), zap.Error(err))
 		return err
 	}
 
@@ -521,7 +521,7 @@ func (w *WakuRelay) unsubscribeFromPubsubTopic(topicData *pubsubTopicSubscriptio
 
 	err = w.pubsub.UnregisterTopicValidator(pubSubTopic)
 	if err != nil {
-		w.log.Error("failed to unregister topic validator", zap.String("topic", pubSubTopic))
+		w.log.Error("failed to unregister topic validator", zap.String("topic", pubSubTopic), zap.Error(err))
 		return err
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1015,7 +1015,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240612113959-d9dc91a162d9
+# github.com/waku-org/go-waku v0.8.1-0.20240625022701-1cf180ebc659
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -172,6 +172,8 @@ type Waku struct {
 	onPeerStats                     func(types.ConnStatus)
 
 	statusTelemetryClient ITelemetryClient
+
+	defaultShardInfo protocol.RelayShards
 }
 
 func (w *Waku) SetStatusTelemetryClient(client ITelemetryClient) {
@@ -283,7 +285,12 @@ func New(nodeKey *ecdsa.PrivateKey, fleet string, cfg *Config, logger *zap.Logge
 
 	if cfg.LightClient {
 		opts = append(opts, node.WithWakuFilterLightNode())
-		cfg.EnablePeerExchangeClient = false //TODO: Need to fix: Disabling for now to test only with fleet nodes.
+		shards, err := protocol.TopicsToRelayShards(cfg.DefaultShardPubsubTopic)
+		if err != nil {
+			logger.Error("FATAL ERROR: failed to parse relay shards", zap.Error(err))
+			return nil, errors.New("failed to parse relay shard, invalid pubsubTopic configuration")
+		}
+		waku.defaultShardInfo = shards[0]
 	} else {
 		relayOpts := []pubsub.Option{
 			pubsub.WithMaxMessageSize(int(waku.cfg.MaxMessageSize)),
@@ -551,7 +558,8 @@ func (w *Waku) runPeerExchangeLoop() {
 			w.dnsAddressCacheLock.RUnlock()
 
 			if len(peers) != 0 {
-				err := w.node.PeerExchange().Request(w.ctx, w.cfg.DiscoveryLimit, peer_exchange.WithAutomaticPeerSelection(peers...))
+				err := w.node.PeerExchange().Request(w.ctx, w.cfg.DiscoveryLimit, peer_exchange.WithAutomaticPeerSelection(peers...),
+					peer_exchange.FilterByShard(int(w.defaultShardInfo.ClusterID), int(w.defaultShardInfo.ShardIDs[0])))
 				if err != nil {
 					w.logger.Error("couldnt request peers via peer exchange", zap.Error(err))
 				}


### PR DESCRIPTION
I had to disable peerExchange client in https://github.com/status-im/status-go/pull/4665 as e2e tests were failing when it is enabled.
But while debugging another issue, had noticed that we are not filtering the peers returned via peerExchange based on cluster and shards. This could mean we could be trying to connecting to peers outside cluster 16.

A description to understand introduced changes without reading the code.

Important changes:
- [x] added logic to filter based on DefaultShard (32) and cluster 16  as it is expected that all nodes for status waku network shall support shard 32 by default.
- [x] Re-enabled peerExchange client so that non fleet peers are also connected to
- [x] Few additional fixes identified in go-waku to handle some scenarios noticed while debugging peer-connectivity should also be included. 

- > https://github.com/waku-org/go-waku/pull/1130
- > https://github.com/waku-org/go-waku/pull/1128
- > https://github.com/waku-org/go-waku/pull/1129


Fixes https://github.com/status-im/status-go/issues/5344

Note that due to connectivity issues, it takes about 30-45 seconds for all filter subscriptions to happen after start of node. That should get addressed as part of some of go-waku PRs above and dogfooding.