### PR TITLE
fix(cli)_: fixed unmarshaling error and improved logging

### DIFF
--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -91,8 +91,6 @@ var ServeFlags = append([]cli.Flag{
 	},
 }, CommonFlags...)
 
-var logger *zap.SugaredLogger
-
 type StatusCLI struct {
 	name      string
 	messenger *protocol.Messenger

--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -115,7 +115,7 @@ func main() {
 				Usage:   "Start a server to send and receive messages",
 				Flags:   ServeFlags,
 				Action: func(cCtx *cli.Context) error {
-					return serve(cCtx, false)
+					return serve(cCtx)
 				},
 			},
 			{
@@ -130,14 +130,16 @@ func main() {
 						Required: true,
 					},
 					&cli.StringFlag{
-						Name:    KeyUIDFlag,
-						Aliases: []string{"kid"},
-						Usage:   "Key ID of the existing user (if not provided the last account will be used)",
+						Name:     KeyUIDFlag,
+						Aliases:  []string{"kid"},
+						Usage:    "Key ID of the existing user (find them under '<data-dir>/keystore' on in logs when using the 'serve' command)",
+						Required: true,
 					},
 					&cli.BoolFlag{
 						Name:    InteractiveFlag,
 						Aliases: []string{"i"},
 						Usage:   "Use interactive mode to input the messages",
+						Value:   false,
 					},
 					&cli.StringFlag{
 						Name:    AddFlag,
@@ -152,7 +154,7 @@ func main() {
 					},
 				},
 				Action: func(cCtx *cli.Context) error {
-					return serve(cCtx, true)
+					return serve(cCtx)
 				},
 			},
 		},

--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -21,6 +21,7 @@ const PortFlag = "port"
 const APIModulesFlag = "api-modules"
 const TelemetryServerURLFlag = "telemetry-server-url"
 const KeyUIDFlag = "key-uid"
+const DebugLevel = "debug"
 
 const RetrieveInterval = 300 * time.Millisecond
 const SendInterval = 1 * time.Second
@@ -42,6 +43,12 @@ var CommonFlags = []cli.Flag{
 		Name:    TelemetryServerURLFlag,
 		Aliases: []string{"t"},
 		Usage:   "Telemetry server URL",
+	},
+	&cli.BoolFlag{
+		Name:    DebugLevel,
+		Aliases: []string{"d"},
+		Usage:   "Enable CLI's debug level logging",
+		Value:   false,
 	},
 }
 
@@ -139,6 +146,12 @@ func main() {
 						Aliases: []string{"a"},
 						Usage:   "Add a friend with the public key",
 					},
+					&cli.BoolFlag{
+						Name:    DebugLevel,
+						Aliases: []string{"d"},
+						Usage:   "Enable CLI's debug level logging",
+						Value:   false,
+					},
 				},
 				Action: func(cCtx *cli.Context) error {
 					return serve(cCtx, true)
@@ -148,6 +161,6 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		logger.Fatal(err)
+		zap.L().Fatal("main", zap.Error(err))
 	}
 }

--- a/cmd/status-cli/serve.go
+++ b/cmd/status-cli/serve.go
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func serve(cCtx *cli.Context, useExistingAccount bool) error {
+func serve(cCtx *cli.Context) error {
 	name := cCtx.String(NameFlag)
 	port := cCtx.Int(PortFlag)
 	apiModules := cCtx.String(APIModulesFlag)
@@ -34,7 +34,7 @@ func serve(cCtx *cli.Context, useExistingAccount bool) error {
 
 	logger = logger.Named(name)
 
-	cli, err := start(name, port, apiModules, telemetryUrl, useExistingAccount, keyUID, logger)
+	cli, err := start(name, port, apiModules, telemetryUrl, keyUID, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/status-cli/serve.go
+++ b/cmd/status-cli/serve.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"log"
 	"os"
 	"os/signal"
 	"syscall"
@@ -17,17 +16,6 @@ import (
 )
 
 func serve(cCtx *cli.Context, useExistingAccount bool) error {
-	rawLogger, err := zap.NewDevelopment()
-	if err != nil {
-		log.Fatalf("Error initializing logger: %v", err)
-	}
-	logger = rawLogger.Sugar()
-
-	logger.Info("Running serve command, flags passed:")
-	for _, flag := range ServeFlags {
-		logger.Infof("-%s %v", flag.Names()[0], cCtx.Value(flag.Names()[0]))
-	}
-
 	name := cCtx.String(NameFlag)
 	port := cCtx.Int(PortFlag)
 	apiModules := cCtx.String(APIModulesFlag)
@@ -35,8 +23,18 @@ func serve(cCtx *cli.Context, useExistingAccount bool) error {
 	interactive := cCtx.Bool(InteractiveFlag)
 	dest := cCtx.String(AddFlag)
 	keyUID := cCtx.String(KeyUIDFlag)
+	isDebugLevel := cCtx.Bool(DebugLevel)
+	cmdName := cCtx.Command.Name
 
-	cli, err := start(name, port, apiModules, telemetryUrl, useExistingAccount, keyUID)
+	logger, err := getSLogger(isDebugLevel)
+	if err != nil {
+		zap.S().Fatalf("Error initializing logger: %v", err)
+	}
+	logger.Infof("Running %v command, with:\n%v", cmdName, flagsUsed(cCtx))
+
+	logger = logger.Named(name)
+
+	cli, err := start(name, port, apiModules, telemetryUrl, useExistingAccount, keyUID, logger)
 	if err != nil {
 		return err
 	}
@@ -47,14 +45,20 @@ func serve(cCtx *cli.Context, useExistingAccount bool) error {
 	// and the retrieve messages loop is started when starting a node, so we needed a different appproach,
 	// alternatively we could have implemented another notification mechanism in the messenger, but this signal is already in place
 	msignal.SetMobileSignalHandler(msignal.MobileSignalHandler(func(s []byte) {
-		var ev MobileSignalEvent
-		if err := json.Unmarshal(s, &ev); err != nil {
-			logger.Error("unmarshaling signal event", zap.Error(err), zap.String("event", string(s)))
+		var evt EventType
+		if err := json.Unmarshal(s, &evt); err != nil {
+			logger.Error("unmarshaling event type", zap.Error(err), zap.String("event", string(s)))
 			return
 		}
 
-		if ev.Type == msignal.EventNewMessages {
-			for _, message := range ev.Event.Messages {
+		switch evt.Type {
+		case msignal.EventNewMessages:
+			var ev EventNewMessages
+			if err := json.Unmarshal(evt.Event, &ev); err != nil {
+				logger.Error("unmarshaling new message event", zap.Error(err), zap.Any("event", evt.Event))
+				return
+			}
+			for _, message := range ev.Messages {
 				logger.Infof("message received: %v (ID=%v)", message.Text, message.ID)
 				// if request contact, accept it
 				if message.ContentType == protobuf.ChatMessage_SYSTEM_MESSAGE_MUTUAL_EVENT_SENT {
@@ -64,6 +68,8 @@ func serve(cCtx *cli.Context, useExistingAccount bool) error {
 					}
 				}
 			}
+		default:
+			logger.Debugf("received event type '%v'\t%v", evt.Type, string(evt.Event))
 		}
 	}))
 
@@ -94,11 +100,13 @@ func serve(cCtx *cli.Context, useExistingAccount bool) error {
 	return nil
 }
 
-type MobileSignalEvent struct {
-	Type  string `json:"type"`
-	Event struct {
-		Messages []*common.Message `json:"messages"`
-	} `json:"event"`
+type EventType struct {
+	Type  string          `json:"type"`
+	Event json.RawMessage `json:"event"`
+}
+
+type EventNewMessages struct {
+	Messages []*common.Message `json:"messages"`
 }
 
 func waitForSigExit() {

--- a/cmd/status-cli/simulate.go
+++ b/cmd/status-cli/simulate.go
@@ -34,13 +34,13 @@ func simulate(cCtx *cli.Context) error {
 	apiModules := cCtx.String(APIModulesFlag)
 	telemetryUrl := cCtx.String(TelemetryServerURLFlag)
 
-	alice, err := start("Alice", 0, apiModules, telemetryUrl, false, "", logger.Named("alice"))
+	alice, err := start("Alice", 0, apiModules, telemetryUrl, "", logger.Named("alice"))
 	if err != nil {
 		return err
 	}
 	defer alice.stop()
 
-	charlie, err := start("Charlie", 0, apiModules, telemetryUrl, false, "", logger.Named("charlie"))
+	charlie, err := start("Charlie", 0, apiModules, telemetryUrl, "", logger.Named("charlie"))
 	if err != nil {
 		return err
 	}

--- a/cmd/status-cli/util.go
+++ b/cmd/status-cli/util.go
@@ -8,14 +8,16 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/status-im/status-go/api"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/services/wakuv2ext"
 	"github.com/status-im/status-go/telemetry"
+
 	"github.com/urfave/cli/v2"
-	"go.uber.org/zap"
 )
 
 func setupLogger(file string) *zap.Logger {

--- a/cmd/status-cli/util.go
+++ b/cmd/status-cli/util.go
@@ -15,7 +15,6 @@ import (
 	"github.com/status-im/status-go/services/wakuv2ext"
 	"github.com/status-im/status-go/telemetry"
 	"github.com/urfave/cli/v2"
-
 	"go.uber.org/zap"
 )
 
@@ -36,7 +35,7 @@ func setupLogger(file string) *zap.Logger {
 	return logutils.ZapLogger()
 }
 
-func start(name string, port int, apiModules string, telemetryUrl string, useExistingAccount bool, keyUID string, logger *zap.SugaredLogger) (*StatusCLI, error) {
+func start(name string, port int, apiModules string, telemetryUrl string, keyUID string, logger *zap.SugaredLogger) (*StatusCLI, error) {
 	var (
 		rootDataDir = fmt.Sprintf("./test-%s", strings.ToLower(name))
 		password    = "some-password"
@@ -45,7 +44,7 @@ func start(name string, port int, apiModules string, telemetryUrl string, useExi
 	logger.Info("starting messenger")
 
 	backend := api.NewGethStatusBackend()
-	if useExistingAccount {
+	if keyUID != "" {
 		if err := getAccountAndLogin(backend, name, rootDataDir, password, keyUID); err != nil {
 			return nil, err
 		}
@@ -105,19 +104,17 @@ func getAccountAndLogin(b *api.GethStatusBackend, name, rootDataDir, password st
 		return errors.New("no accounts found")
 	}
 
-	acc := accs[0] // use last if no keyUID is provided
-	if keyUID != "" {
-		found := false
-		for _, a := range accs {
-			if a.KeyUID == keyUID {
-				acc = a
-				found = true
-				break
-			}
+	var acc multiaccounts.Account
+	found := false
+	for _, a := range accs {
+		if a.KeyUID == keyUID {
+			acc = a
+			found = true
+			break
 		}
-		if !found {
-			return fmt.Errorf("account not found for keyUID: %v", keyUID)
-		}
+	}
+	if !found {
+		return fmt.Errorf("account not found for keyUID: %v", keyUID)
 	}
 
 	return b.LoginAccount(&requests.Login{


### PR DESCRIPTION
there was an error sometimes when event was not a struct, also improved logging so that cli logs by default are in info (what the runner needs) but for manual testing in debug, eth.log still running on debug for fixing issues by runner