### PR TITLE
fix_: panic: send on closed channel

### DIFF
--- a/protocol/transport/envelopes_monitor.go
+++ b/protocol/transport/envelopes_monitor.go
@@ -172,7 +172,6 @@ func (m *EnvelopesMonitor) handleEnvelopeEvents() {
 	events := make(chan types.EnvelopeEvent, 100) // must be buffered to prevent blocking waku
 	sub := m.w.SubscribeEnvelopeEvents(events)
 	defer func() {
-		close(events)
 		sub.Unsubscribe()
 	}()
 	for {


### PR DESCRIPTION
this is a quick fix for:
```
panic: send on closed channel
goroutine 7511 [running]:
github.com/status-im/status-go/eth-node/bridge/geth.(*GethWakuWrapper).SubscribeEnvelopeEvents.func1()
	/home/jenkins/workspace/status-go_prs_tests_PR-5336/eth-node/bridge/geth/waku.go:154 +0xd4
created by github.com/status-im/status-go/eth-node/bridge/geth.(*GethWakuWrapper).SubscribeEnvelopeEvents in goroutine 7631
	/home/jenkins/workspace/status-go_prs_tests_PR-5336/eth-node/bridge/geth/waku.go:152 +0x85
```

this panic can be reproduced with `TestShhExtSuite` running locally for some times.
this panic might also occur on PR test randomly and block PR, following logs were recorded with one of my previous PR:
[TestRequestMessagesSuccess-error.log](https://github.com/user-attachments/files/15833115/TestRequestMessagesSuccess-error.log)
[TestMultipleRequestMessagesWithoutForce-error.log](https://github.com/user-attachments/files/15833116/TestMultipleRequestMessagesWithoutForce-error.log)
[TestFailedRequestWithUnknownMailServerPeer-error.log](https://github.com/user-attachments/files/15833117/TestFailedRequestWithUnknownMailServerPeer-error.log)
[TestShhExtSuite-error.log](https://github.com/user-attachments/files/15833118/TestShhExtSuite-error.log)

The interesting thing I found is that when I was trying to search for the usage of `SubscribeEnvelopeEvents`, all the usages  just pass `events` to `SubscribeEnvelopeEvents` without any `close` operation, except for the one removed in this PR. memory leak could be happen? that's why it's a quick fix.
<img width="715" alt="image" src="https://github.com/status-im/status-go/assets/12406719/7028a315-3beb-4c44-aee6-6b322fb0453a">

	