### PR TITLE
editted emoji msg formatting

### DIFF
--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -226,6 +226,28 @@ func buildTestMessage(chat Chat) *common.Message {
 	return message
 }
 
+func buildTestEmojiMessage(chat Chat) *common.Message {
+	clock, timestamp := chat.NextClockAndTimestamp(&testTimeSource{})
+	message := common.NewMessage()
+	message.Text = "test-emoji"
+	message.ChatId = chat.ID
+	message.Clock = clock
+	message.Timestamp = timestamp
+	message.WhisperTimestamp = clock
+	message.LocalChatID = chat.ID
+	message.ContentType = protobuf.ChatMessage_EMOJI
+	switch chat.ChatType {
+	case ChatTypePublic, ChatTypeProfile:
+		message.MessageType = protobuf.MessageType_PUBLIC_GROUP
+	case ChatTypeOneToOne:
+		message.MessageType = protobuf.MessageType_ONE_TO_ONE
+	case ChatTypePrivateGroupChat:
+		message.MessageType = protobuf.MessageType_PRIVATE_GROUP
+	}
+
+	return message
+}
+
 func buildTestGapMessage(chat Chat) *common.Message {
 	clock, timestamp := chat.NextClockAndTimestamp(&testTimeSource{})
 	message := common.NewMessage()


### PR DESCRIPTION
Closes #5357

When sending an emoji message from desktop to mobile  and the message is editted and replaced with a pure text message, it seems that the contentType is not updated to `TEXT_PLAIN` and is the case when the message is mix of textual content and emoji. 

This issue does not occur when the message of from mobile to mobile. This pr fixes the issue on the recieving mobile client by updating the contentType of the editted message to `TEXT_PLAIN` 
