### PR TITLE
chore_: limit max number of ephemeral keys to 3

### DIFF
--- a/protocol/common/message_sender_test.go
+++ b/protocol/common/message_sender_test.go
@@ -361,3 +361,20 @@ func (s *MessageSenderSuite) TestHandleSegmentMessages() {
 	_, err = s.sender.HandleMessages(message)
 	s.Require().ErrorIs(err, ErrMessageSegmentsAlreadyCompleted)
 }
+
+func (s *MessageSenderSuite) TestGetEphemeralKey() {
+	keyMap := make(map[string]bool)
+	for i := 0; i < maxMessageSenderEphemeralKeys; i++ {
+		key, err := s.sender.GetEphemeralKey()
+		s.Require().NoError(err)
+		s.Require().NotNil(key)
+		keyMap[PubkeyToHex(&key.PublicKey)] = true
+	}
+	s.Require().Len(keyMap, maxMessageSenderEphemeralKeys)
+	// Add one more
+	key, err := s.sender.GetEphemeralKey()
+	s.Require().NoError(err)
+	s.Require().NotNil(key)
+
+	s.Require().True(keyMap[PubkeyToHex(&key.PublicKey)])
+}

--- a/protocol/pushnotificationclient/client.go
+++ b/protocol/pushnotificationclient/client.go
@@ -1375,12 +1375,7 @@ func (c *Client) SendNotification(publicKey *ecdsa.PublicKey, installationIDs []
 
 	c.config.Logger.Debug("actionable info", zap.Int("count", len(actionableInfos)))
 
-	// add ephemeral key and listen to it
-	ephemeralKey, err := crypto.GenerateKey()
-	if err != nil {
-		return nil, err
-	}
-	_, err = c.messageSender.AddEphemeralKey(ephemeralKey)
+	ephemeralKey, err := c.messageSender.GetEphemeralKey()
 	if err != nil {
 		return nil, err
 	}
@@ -1688,7 +1683,7 @@ func (c *Client) queryPushNotificationInfo(publicKey *ecdsa.PublicKey) error {
 		return err
 	}
 
-	ephemeralKey, err := crypto.GenerateKey()
+	ephemeralKey, err := c.messageSender.GetEphemeralKey()
 	if err != nil {
 		return err
 	}
@@ -1699,11 +1694,6 @@ func (c *Client) queryPushNotificationInfo(publicKey *ecdsa.PublicKey) error {
 		// we don't want to wrap in an encryption layer message
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_PUSH_NOTIFICATION_QUERY,
-	}
-
-	_, err = c.messageSender.AddEphemeralKey(ephemeralKey)
-	if err != nil {
-		return err
 	}
 
 	// this is the topic of message


### PR DESCRIPTION
This commit limits the number of ephemeral keys used by the push notification client to 3, as it was noticed that it would greatly increase the number of filters installed and was unbound.

