### PR TITLE
fix(wallet)_: fix rpc limiter to reset counters on timeout

### DIFF
--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -1006,7 +1006,7 @@ func (c *ClientWithFallback) SetWalletNotifier(notifier func(chainId uint64, mes
 func (c *ClientWithFallback) toggleConnectionState(err error) {
 	connected := true
 	if err != nil {
-		if !isVMError(err) && !errors.Is(ErrRequestsOverLimit, err) {
+		if !isVMError(err) && !errors.Is(err, ErrRequestsOverLimit) {
 			connected = false
 		}
 	}

--- a/services/wallet/transfer/controller.go
+++ b/services/wallet/transfer/controller.go
@@ -15,6 +15,7 @@ import (
 	statusaccounts "github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/rpc"
+	"github.com/status-im/status-go/rpc/chain"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
 	"github.com/status-im/status-go/services/wallet/balance"
 	"github.com/status-im/status-go/services/wallet/blockchainstate"
@@ -272,6 +273,12 @@ func (c *Controller) cleanUpRemovedAccount(address common.Address) {
 	err = c.transactionManager.removeMultiTransactionByAddress(address)
 	if err != nil {
 		log.Error("Failed to delete multitransactions", "error", err)
+	}
+
+	rpcLimitsStorage := chain.NewLimitsDBStorage(c.db.client)
+	err = rpcLimitsStorage.Delete(accountLimiterTag(address))
+	if err != nil {
+		log.Error("Failed to delete limits", "error", err)
 	}
 }
 


### PR DESCRIPTION
Fixes:

- fix rpc limiter to reset counters on timeout
- fix rpc limiter to delete limits on account removal
- fix rpc limiter to not overwrite existing account limit on startup
- fix providers down banner on limit reached error

Closes [#14642](https://github.com/status-im/status-desktop/issues/14642)