### PR TITLE
feat: change how we compute fees

### DIFF
--- a/services/communitytokens/estimations.go
+++ b/services/communitytokens/estimations.go
@@ -23,8 +23,8 @@ import (
 )
 
 type CommunityTokenFees struct {
-	GasUnits      uint64                `json:"gasUnits"`
-	SuggestedFees *router.SuggestedFees `json:"suggestedFees"`
+	GasUnits      uint64                    `json:"gasUnits"`
+	SuggestedFees *router.SuggestedFeesGwei `json:"suggestedFees"`
 }
 
 func weiToGwei(val *big.Int) *big.Float {
@@ -356,7 +356,7 @@ func (s *Service) mintTokensGasUnits(ctx context.Context, chainID uint64, contra
 }
 
 func (s *Service) prepareCommunityTokenFees(ctx context.Context, from common.Address, to *common.Address, gasUnits uint64, chainID uint64) (*CommunityTokenFees, error) {
-	suggestedFees, err := s.feeManager.SuggestedFees(ctx, chainID)
+	suggestedFees, err := s.feeManager.SuggestedFeesGwei(ctx, chainID)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (s *Service) prepareCommunityTokenFees(ctx context.Context, from common.Add
 	}, nil
 }
 
-func (s *Service) suggestedFeesToSendTxArgs(from common.Address, to *common.Address, gas uint64, suggestedFees *router.SuggestedFees) transactions.SendTxArgs {
+func (s *Service) suggestedFeesToSendTxArgs(from common.Address, to *common.Address, gas uint64, suggestedFees *router.SuggestedFeesGwei) transactions.SendTxArgs {
 	sendArgs := transactions.SendTxArgs{}
 	sendArgs.From = types.Address(from)
 	sendArgs.To = (*types.Address)(to)

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -396,9 +396,9 @@ func (api *API) FetchTokenDetails(ctx context.Context, symbols []string) (map[st
 	return api.s.marketManager.FetchTokenDetails(symbols)
 }
 
-func (api *API) GetSuggestedFees(ctx context.Context, chainID uint64) (*router.SuggestedFees, error) {
+func (api *API) GetSuggestedFees(ctx context.Context, chainID uint64) (*router.SuggestedFeesGwei, error) {
 	log.Debug("call to GetSuggestedFees")
-	return api.router.GetFeesManager().SuggestedFees(ctx, chainID)
+	return api.router.GetFeesManager().SuggestedFeesGwei(ctx, chainID)
 }
 
 func (api *API) GetEstimatedLatestBlockNumber(ctx context.Context, chainID uint64) (uint64, error) {
@@ -409,7 +409,12 @@ func (api *API) GetEstimatedLatestBlockNumber(ctx context.Context, chainID uint6
 // @deprecated
 func (api *API) GetTransactionEstimatedTime(ctx context.Context, chainID uint64, maxFeePerGas *big.Float) (router.TransactionEstimation, error) {
 	log.Debug("call to getTransactionEstimatedTime")
-	return api.router.GetFeesManager().TransactionEstimatedTime(ctx, chainID, maxFeePerGas), nil
+	return api.router.GetFeesManager().TransactionEstimatedTime(ctx, chainID, gweiToWei(maxFeePerGas)), nil
+}
+
+func gweiToWei(val *big.Float) *big.Int {
+	res, _ := new(big.Float).Mul(val, big.NewFloat(1000000000)).Int(nil)
+	return res
 }
 
 func (api *API) GetSuggestedRoutes(

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -51,7 +51,7 @@ type Path struct {
 	AmountInLocked          bool
 	AmountOut               *hexutil.Big
 	GasAmount               uint64
-	GasFees                 *SuggestedFees
+	GasFees                 *SuggestedFeesGwei
 	BonderFees              *hexutil.Big
 	TokenFees               *big.Float
 	Cost                    *big.Float
@@ -522,7 +522,7 @@ func (r *Router) SuggestedRoutes(
 		}
 
 		group.Add(func(c context.Context) error {
-			gasFees, err := r.feesManager.SuggestedFees(ctx, network.ChainID)
+			gasFees, err := r.feesManager.SuggestedFeesGwei(ctx, network.ChainID)
 			if err != nil {
 				return err
 			}
@@ -555,7 +555,7 @@ func (r *Router) SuggestedRoutes(
 			}
 			maxFees := gasFees.feeFor(gasFeeMode)
 
-			estimatedTime := r.feesManager.TransactionEstimatedTime(ctx, network.ChainID, maxFees)
+			estimatedTime := r.feesManager.TransactionEstimatedTime(ctx, network.ChainID, gweiToWei(maxFees))
 			for _, pProcessor := range r.pathProcessors {
 				// Skip processors that are added because of the Router V2, to not break the current functionality
 				if pProcessor.Name() == pathprocessor.ProcessorENSRegisterName ||


### PR DESCRIPTION
Rather than using previous tx to compute fees, be more expensive by using:
2 * base fee + priority fee

That way if base fee increase, with a factor of 2 we should nearly guarantee that the transaction will be executed quite quickly.

Why accepting to pay more:
We do not have a way to edit fees and nonce.
As a result we cannot cancel tx in app and we need to provide as much guarantee as possible the transaction will be executed