### PR TITLE
chore_: set lower max delivery attempts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,9 @@ generate-handlers:
 generate: ##@other Regenerate assets and other auto-generated stuff
 	go generate ./static ./static/mailserver_db_migrations ./t ./multiaccounts/... ./appdatabase/... ./protocol/... ./walletdatabase/... ./_assets/generate_handlers
 
+generate-appdatabase:
+	go generate ./appdatabase/...
+
 prepare-release: clean-release
 	mkdir -p $(RELEASE_DIR)
 	mv build/bin/statusgo.aar $(RELEASE_DIR)/status-go-android.aar

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -35,7 +35,7 @@ const DefaultLogLevel = "ERROR"
 const DefaultMaxPeers = 20
 const DefaultMaxPendingPeers = 20
 const DefaultListenAddr = ":0"
-const DefaultMaxMessageDeliveryAttempts = 6
+const DefaultMaxMessageDeliveryAttempts = 3
 const DefaultVerifyTransactionChainID = 1
 
 var paths = []string{pathWalletRoot, pathEIP1581, pathDefaultChat, pathDefaultWallet}

--- a/appdatabase/migrations/bindata.go
+++ b/appdatabase/migrations/bindata.go
@@ -112,6 +112,7 @@
 // 1709795716_migration_order_fix.up.sql (7.909kB)
 // 1715756976_network_short_names_update.up.sql (256B)
 // 1716385243_no_discovery.up.sql (44B)
+// 1718785164_max_delivery_attempts_update.up.sql (60B)
 // doc.go (94B)
 
 package migrations
@@ -122,7 +123,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -132,7 +132,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -140,7 +140,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -2421,6 +2421,26 @@ func _1716385243_no_discoveryUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1718785164_max_delivery_attempts_updateUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x0a\x0d\x70\x71\x0c\x71\x55\x28\xce\xc8\x48\xad\x28\x89\x4f\xce\xcf\x4b\xcb\x4c\x57\x08\x76\x0d\x51\xc8\x4d\xac\x88\xcf\x4d\x2d\x2e\x4e\x4c\x4f\x8d\x4f\x49\xcd\xc9\x2c\x4b\x2d\xaa\x8c\x4f\x2c\x29\x49\xcd\x2d\x28\x29\x56\xb0\x55\x30\xb6\xe6\x02\x04\x00\x00\xff\xff\xf1\x6f\x04\xda\x3c\x00\x00\x00")
+
+func _1718785164_max_delivery_attempts_updateUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1718785164_max_delivery_attempts_updateUpSql,
+		"1718785164_max_delivery_attempts_update.up.sql",
+	)
+}
+
+func _1718785164_max_delivery_attempts_updateUpSql() (*asset, error) {
+	bytes, err := _1718785164_max_delivery_attempts_updateUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1718785164_max_delivery_attempts_update.up.sql", size: 60, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3e, 0x65, 0xfe, 0x22, 0x2c, 0x78, 0x3, 0x50, 0x5d, 0x30, 0x94, 0xc3, 0x72, 0xa4, 0x38, 0x82, 0x8f, 0x2c, 0xf2, 0xbc, 0xfd, 0xb7, 0x61, 0xa6, 0x1a, 0x27, 0xc4, 0xb5, 0xc8, 0xfe, 0xcc, 0xe}}
+	return a, nil
+}
+
 var _docGo = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x2c\xcb\x41\x0e\x02\x31\x08\x05\xd0\x7d\x4f\xf1\x2f\x00\xe8\xca\xc4\xc4\xc3\xa0\x43\x08\x19\x5b\xc6\x96\xfb\xc7\x4d\xdf\xfe\x5d\xfa\x39\xd5\x0d\xeb\xf7\x6d\x4d\xc4\xf3\xe9\x36\x6c\x6a\x19\x3c\xe9\x1d\xe3\xd0\x52\x50\xcf\xa3\xa2\xdb\xeb\xfe\xb8\x6d\xa0\xeb\x74\xf4\xf0\xa9\x15\x39\x16\x28\xc1\x2c\x7b\xb0\x27\x58\xda\x3f\x00\x00\xff\xff\x57\xd4\xd5\x90\x5e\x00\x00\x00")
 
 func docGoBytes() ([]byte, error) {
@@ -2532,242 +2552,136 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"1640111208_dummy.up.sql": _1640111208_dummyUpSql,
-
-	"1642666031_add_removed_clock_to_bookmarks.up.sql": _1642666031_add_removed_clock_to_bookmarksUpSql,
-
-	"1643644541_gif_api_key_setting.up.sql": _1643644541_gif_api_key_settingUpSql,
-
-	"1644188994_recent_stickers.up.sql": _1644188994_recent_stickersUpSql,
-
-	"1646659233_add_address_to_dapp_permisssion.up.sql": _1646659233_add_address_to_dapp_permisssionUpSql,
-
-	"1646841105_add_emoji_account.up.sql": _1646841105_add_emoji_accountUpSql,
-
-	"1647278782_display_name.up.sql": _1647278782_display_nameUpSql,
-
-	"1647862838_reset_last_backup.up.sql": _1647862838_reset_last_backupUpSql,
-
-	"1647871652_add_settings_sync_clock_table.up.sql": _1647871652_add_settings_sync_clock_tableUpSql,
-
-	"1647880168_add_torrent_config.up.sql": _1647880168_add_torrent_configUpSql,
-
-	"1647882837_add_communities_settings_table.up.sql": _1647882837_add_communities_settings_tableUpSql,
-
-	"1647956635_add_waku_messages_table.up.sql": _1647956635_add_waku_messages_tableUpSql,
-
-	"1648554928_network_test.up.sql": _1648554928_network_testUpSql,
-
-	"1649174829_add_visitble_token.up.sql": _1649174829_add_visitble_tokenUpSql,
-
-	"1649882262_add_derived_from_accounts.up.sql": _1649882262_add_derived_from_accountsUpSql,
-
-	"1650612625_add_community_message_archive_hashes_table.up.sql": _1650612625_add_community_message_archive_hashes_tableUpSql,
-
-	"1650616788_add_communities_archives_info_table.up.sql": _1650616788_add_communities_archives_info_tableUpSql,
-
-	"1652715604_add_clock_accounts.up.sql": _1652715604_add_clock_accountsUpSql,
-
-	"1653037334_add_notifications_settings_table.up.sql": _1653037334_add_notifications_settings_tableUpSql,
-
-	"1654702119_add_mutual_contact_settings.up.sql": _1654702119_add_mutual_contact_settingsUpSql,
-
-	"1655375270_add_clock_field_to_communities_settings_table.up.sql": _1655375270_add_clock_field_to_communities_settings_tableUpSql,
-
-	"1655385721_drop_networks_config.up.sql": _1655385721_drop_networks_configUpSql,
-
-	"1655385724_networks_chainColor_shortName.up.sql": _1655385724_networks_chaincolor_shortnameUpSql,
-
-	"1655456688_add_deleted_at_field_to_bookmarks_table.up.sql": _1655456688_add_deleted_at_field_to_bookmarks_tableUpSql,
-
-	"1655462032_create_bookmarks_deleted_at_index.up.sql": _1655462032_create_bookmarks_deleted_at_indexUpSql,
-
-	"1657617291_add_multi_transactions_table.up.sql": _1657617291_add_multi_transactions_tableUpSql,
-
-	"1660134042_add_social_links_settings_table.up.sql": _1660134042_add_social_links_settings_tableUpSql,
-
-	"1660134060_settings_bio.up.sql": _1660134060_settings_bioUpSql,
-
-	"1660134070_add_wakuv2_store.up.sql": _1660134070_add_wakuv2_storeUpSql,
-
-	"1660134072_waku2_store_messages.up.sql": _1660134072_waku2_store_messagesUpSql,
-
-	"1662365868_add_key_uid_accounts.up.sql": _1662365868_add_key_uid_accountsUpSql,
-
-	"1662447680_add_keypairs_table.up.sql": _1662447680_add_keypairs_tableUpSql,
-
-	"1662460056_move_favourites_to_saved_addresses.up.sql": _1662460056_move_favourites_to_saved_addressesUpSql,
-
-	"1662738097_add_base_fee_transaction.up.sql": _1662738097_add_base_fee_transactionUpSql,
-
-	"1662972194_add_keypairs_table.up.sql": _1662972194_add_keypairs_tableUpSql,
-
-	"1664392661_add_third_party_id_to_waku_messages.up.sql": _1664392661_add_third_party_id_to_waku_messagesUpSql,
-
-	"1664783660_add_sync_info_to_saved_addresses.up.sql": _1664783660_add_sync_info_to_saved_addressesUpSql,
-
-	"1668109917_wakunodes.up.sql": _1668109917_wakunodesUpSql,
-
-	"1670249678_display_name_to_settings_sync_clock_table.up.sql": _1670249678_display_name_to_settings_sync_clock_tableUpSql,
-
-	"1670836810_add_imported_flag_to_community_archive_hashes.up.sql": _1670836810_add_imported_flag_to_community_archive_hashesUpSql,
-
-	"1671438731_add_magnetlink_uri_to_communities_archive_info.up.sql": _1671438731_add_magnetlink_uri_to_communities_archive_infoUpSql,
-
-	"1672933930_switcher_card.up.sql": _1672933930_switcher_cardUpSql,
-
-	"1674056187_add_price_cache.up.sql": _1674056187_add_price_cacheUpSql,
-
-	"1674136690_ens_usernames.up.sql": _1674136690_ens_usernamesUpSql,
-
-	"1674232431_add_balance_history.up.sql": _1674232431_add_balance_historyUpSql,
-
-	"1676368933_keypairs_to_keycards.up.sql": _1676368933_keypairs_to_keycardsUpSql,
-
-	"1676951398_add_currency_format_cache.up.sql": _1676951398_add_currency_format_cacheUpSql,
-
-	"1676968196_keycards_add_clock_column.up.sql": _1676968196_keycards_add_clock_columnUpSql,
-
-	"1676968197_add_fallback_rpc_to_networks.up.sql": _1676968197_add_fallback_rpc_to_networksUpSql,
-
-	"1677674090_add_chains_ens_istest_to_saved_addresses.up.sql": _1677674090_add_chains_ens_istest_to_saved_addressesUpSql,
-
-	"1677681143_accounts_table_type_column_update.up.sql": _1677681143_accounts_table_type_column_updateUpSql,
-
-	"1678264207_accounts_table_new_columns_added.up.sql": _1678264207_accounts_table_new_columns_addedUpSql,
-
-	"1680770368_add_bio_to_settings_sync_clock_table.up.sql": _1680770368_add_bio_to_settings_sync_clock_tableUpSql,
-
-	"1681110436_add_mnemonic_to_settings_sync_clock_table.up.sql": _1681110436_add_mnemonic_to_settings_sync_clock_tableUpSql,
-
-	"1681392602_9d_sync_period.up.sql": _1681392602_9d_sync_periodUpSql,
-
-	"1681762078_default_sync_period_9d.up.sql": _1681762078_default_sync_period_9dUpSql,
-
-	"1681780680_add_clock_to_social_links_settings.up.sql": _1681780680_add_clock_to_social_links_settingsUpSql,
-
-	"1682073779_settings_table_remove_latest_derived_path_column.up.sql": _1682073779_settings_table_remove_latest_derived_path_columnUpSql,
-
-	"1682146075_add_created_at_to_saved_addresses.up.sql": _1682146075_add_created_at_to_saved_addressesUpSql,
-
-	"1682393575_sync_ens_name.up.sql": _1682393575_sync_ens_nameUpSql,
-
-	"1683457503_add_blocks_ranges_sequential_table.up.sql": _1683457503_add_blocks_ranges_sequential_tableUpSql,
-
-	"1683627613_accounts_and_keycards_improvements.up.sql": _1683627613_accounts_and_keycards_improvementsUpSql,
-
-	"1685041348_settings_table_add_latest_derived_path_column.up.sql": _1685041348_settings_table_add_latest_derived_path_columnUpSql,
-
-	"1685440989_update_color_id_accounts.up.sql": _1685440989_update_color_id_accountsUpSql,
-
-	"1685463947_add_to_asset_to_multitransaction.up.sql": _1685463947_add_to_asset_to_multitransactionUpSql,
-
-	"1685880973_add_profile_links_settings_table.up.sql": _1685880973_add_profile_links_settings_tableUpSql,
-
-	"1686041510_add_idx_transfers_blkno_loaded.up.sql": _1686041510_add_idx_transfers_blkno_loadedUpSql,
-
-	"1686048341_transfers_receipt_json_blob_out.up.sql.down.sql": _1686048341_transfers_receipt_json_blob_outUpSqlDownSql,
-
-	"1686048341_transfers_receipt_json_blob_out.up.sql.up.sql": _1686048341_transfers_receipt_json_blob_outUpSqlUpSql,
-
-	"1686825075_cleanup_token_address.up.sql": _1686825075_cleanup_token_addressUpSql,
-
-	"1687193315_transfers_extract_from_to_address.down.sql": _1687193315_transfers_extract_from_to_addressDownSql,
-
-	"1687193315_transfers_extract_from_to_address.up.sql": _1687193315_transfers_extract_from_to_addressUpSql,
-
-	"1687249080_add_position_accounts.up..sql": _1687249080_add_position_accountsUpSql,
-
-	"1687269871_add_device_name.up.sql": _1687269871_add_device_nameUpSql,
-
-	"1687506642_include_watch_only_account_setting.up.sql": _1687506642_include_watch_only_account_settingUpSql,
-
-	"1688022264_add_include_watch_only_account_to_settings_sync_clock.up.sql": _1688022264_add_include_watch_only_account_to_settings_sync_clockUpSql,
-
-	"1688054680_add_columns_to_multitransaction.up.sql": _1688054680_add_columns_to_multitransactionUpSql,
-
-	"1688636552_keycards_table_columns_update.up.sql": _1688636552_keycards_table_columns_updateUpSql,
-
-	"1689248269_add_related_chain_id_networks.up.sql": _1689248269_add_related_chain_id_networksUpSql,
-
-	"1689340211_index_filter_columns.up.sql": _1689340211_index_filter_columnsUpSql,
-
-	"1689498471_make_wallet_accounts_positions_non_negative.up.sql": _1689498471_make_wallet_accounts_positions_non_negativeUpSql,
-
-	"1689856991_add_soft_remove_column_for_keypairs_and_accounts.up.sql": _1689856991_add_soft_remove_column_for_keypairs_and_accountsUpSql,
-
-	"1690225863_add_collectibles_ownership_cache.up.sql": _1690225863_add_collectibles_ownership_cacheUpSql,
-
-	"1690734354_add_preferred_chain_ids.up.sql": _1690734354_add_preferred_chain_idsUpSql,
-
-	"1691173699_add_collectibles_and_collections_data_cache.up.sql": _1691173699_add_collectibles_and_collections_data_cacheUpSql,
-
-	"1691753758_move_wallet_tables_to_wallet_db.up.sql": _1691753758_move_wallet_tables_to_wallet_dbUpSql,
-
-	"1691753800_pubsubtopic_key.up.sql": _1691753800_pubsubtopic_keyUpSql,
-
-	"1693900971_add_profile_migration_needed_column_to_settings_table.up.sql": _1693900971_add_profile_migration_needed_column_to_settings_tableUpSql,
-
-	"1694764094_add_original_to_networks.up.sql": _1694764094_add_original_to_networksUpSql,
-
-	"1695974515_add_is_sepolia_enabled_to_settings.up.sql": _1695974515_add_is_sepolia_enabled_to_settingsUpSql,
-
-	"1696259336_settings_add_url_unfurling_mode.up.sql": _1696259336_settings_add_url_unfurling_modeUpSql,
-
-	"1697123140_drop_include_watch_only_accounts.up.sql": _1697123140_drop_include_watch_only_accountsUpSql,
-
+	"1640111208_dummy.up.sql":                                                  _1640111208_dummyUpSql,
+	"1642666031_add_removed_clock_to_bookmarks.up.sql":                         _1642666031_add_removed_clock_to_bookmarksUpSql,
+	"1643644541_gif_api_key_setting.up.sql":                                    _1643644541_gif_api_key_settingUpSql,
+	"1644188994_recent_stickers.up.sql":                                        _1644188994_recent_stickersUpSql,
+	"1646659233_add_address_to_dapp_permisssion.up.sql":                        _1646659233_add_address_to_dapp_permisssionUpSql,
+	"1646841105_add_emoji_account.up.sql":                                      _1646841105_add_emoji_accountUpSql,
+	"1647278782_display_name.up.sql":                                           _1647278782_display_nameUpSql,
+	"1647862838_reset_last_backup.up.sql":                                      _1647862838_reset_last_backupUpSql,
+	"1647871652_add_settings_sync_clock_table.up.sql":                          _1647871652_add_settings_sync_clock_tableUpSql,
+	"1647880168_add_torrent_config.up.sql":                                     _1647880168_add_torrent_configUpSql,
+	"1647882837_add_communities_settings_table.up.sql":                         _1647882837_add_communities_settings_tableUpSql,
+	"1647956635_add_waku_messages_table.up.sql":                                _1647956635_add_waku_messages_tableUpSql,
+	"1648554928_network_test.up.sql":                                           _1648554928_network_testUpSql,
+	"1649174829_add_visitble_token.up.sql":                                     _1649174829_add_visitble_tokenUpSql,
+	"1649882262_add_derived_from_accounts.up.sql":                              _1649882262_add_derived_from_accountsUpSql,
+	"1650612625_add_community_message_archive_hashes_table.up.sql":             _1650612625_add_community_message_archive_hashes_tableUpSql,
+	"1650616788_add_communities_archives_info_table.up.sql":                    _1650616788_add_communities_archives_info_tableUpSql,
+	"1652715604_add_clock_accounts.up.sql":                                     _1652715604_add_clock_accountsUpSql,
+	"1653037334_add_notifications_settings_table.up.sql":                       _1653037334_add_notifications_settings_tableUpSql,
+	"1654702119_add_mutual_contact_settings.up.sql":                            _1654702119_add_mutual_contact_settingsUpSql,
+	"1655375270_add_clock_field_to_communities_settings_table.up.sql":          _1655375270_add_clock_field_to_communities_settings_tableUpSql,
+	"1655385721_drop_networks_config.up.sql":                                   _1655385721_drop_networks_configUpSql,
+	"1655385724_networks_chainColor_shortName.up.sql":                          _1655385724_networks_chaincolor_shortnameUpSql,
+	"1655456688_add_deleted_at_field_to_bookmarks_table.up.sql":                _1655456688_add_deleted_at_field_to_bookmarks_tableUpSql,
+	"1655462032_create_bookmarks_deleted_at_index.up.sql":                      _1655462032_create_bookmarks_deleted_at_indexUpSql,
+	"1657617291_add_multi_transactions_table.up.sql":                           _1657617291_add_multi_transactions_tableUpSql,
+	"1660134042_add_social_links_settings_table.up.sql":                        _1660134042_add_social_links_settings_tableUpSql,
+	"1660134060_settings_bio.up.sql":                                           _1660134060_settings_bioUpSql,
+	"1660134070_add_wakuv2_store.up.sql":                                       _1660134070_add_wakuv2_storeUpSql,
+	"1660134072_waku2_store_messages.up.sql":                                   _1660134072_waku2_store_messagesUpSql,
+	"1662365868_add_key_uid_accounts.up.sql":                                   _1662365868_add_key_uid_accountsUpSql,
+	"1662447680_add_keypairs_table.up.sql":                                     _1662447680_add_keypairs_tableUpSql,
+	"1662460056_move_favourites_to_saved_addresses.up.sql":                     _1662460056_move_favourites_to_saved_addressesUpSql,
+	"1662738097_add_base_fee_transaction.up.sql":                               _1662738097_add_base_fee_transactionUpSql,
+	"1662972194_add_keypairs_table.up.sql":                                     _1662972194_add_keypairs_tableUpSql,
+	"1664392661_add_third_party_id_to_waku_messages.up.sql":                    _1664392661_add_third_party_id_to_waku_messagesUpSql,
+	"1664783660_add_sync_info_to_saved_addresses.up.sql":                       _1664783660_add_sync_info_to_saved_addressesUpSql,
+	"1668109917_wakunodes.up.sql":                                              _1668109917_wakunodesUpSql,
+	"1670249678_display_name_to_settings_sync_clock_table.up.sql":              _1670249678_display_name_to_settings_sync_clock_tableUpSql,
+	"1670836810_add_imported_flag_to_community_archive_hashes.up.sql":          _1670836810_add_imported_flag_to_community_archive_hashesUpSql,
+	"1671438731_add_magnetlink_uri_to_communities_archive_info.up.sql":         _1671438731_add_magnetlink_uri_to_communities_archive_infoUpSql,
+	"1672933930_switcher_card.up.sql":                                          _1672933930_switcher_cardUpSql,
+	"1674056187_add_price_cache.up.sql":                                        _1674056187_add_price_cacheUpSql,
+	"1674136690_ens_usernames.up.sql":                                          _1674136690_ens_usernamesUpSql,
+	"1674232431_add_balance_history.up.sql":                                    _1674232431_add_balance_historyUpSql,
+	"1676368933_keypairs_to_keycards.up.sql":                                   _1676368933_keypairs_to_keycardsUpSql,
+	"1676951398_add_currency_format_cache.up.sql":                              _1676951398_add_currency_format_cacheUpSql,
+	"1676968196_keycards_add_clock_column.up.sql":                              _1676968196_keycards_add_clock_columnUpSql,
+	"1676968197_add_fallback_rpc_to_networks.up.sql":                           _1676968197_add_fallback_rpc_to_networksUpSql,
+	"1677674090_add_chains_ens_istest_to_saved_addresses.up.sql":               _1677674090_add_chains_ens_istest_to_saved_addressesUpSql,
+	"1677681143_accounts_table_type_column_update.up.sql":                      _1677681143_accounts_table_type_column_updateUpSql,
+	"1678264207_accounts_table_new_columns_added.up.sql":                       _1678264207_accounts_table_new_columns_addedUpSql,
+	"1680770368_add_bio_to_settings_sync_clock_table.up.sql":                   _1680770368_add_bio_to_settings_sync_clock_tableUpSql,
+	"1681110436_add_mnemonic_to_settings_sync_clock_table.up.sql":              _1681110436_add_mnemonic_to_settings_sync_clock_tableUpSql,
+	"1681392602_9d_sync_period.up.sql":                                         _1681392602_9d_sync_periodUpSql,
+	"1681762078_default_sync_period_9d.up.sql":                                 _1681762078_default_sync_period_9dUpSql,
+	"1681780680_add_clock_to_social_links_settings.up.sql":                     _1681780680_add_clock_to_social_links_settingsUpSql,
+	"1682073779_settings_table_remove_latest_derived_path_column.up.sql":       _1682073779_settings_table_remove_latest_derived_path_columnUpSql,
+	"1682146075_add_created_at_to_saved_addresses.up.sql":                      _1682146075_add_created_at_to_saved_addressesUpSql,
+	"1682393575_sync_ens_name.up.sql":                                          _1682393575_sync_ens_nameUpSql,
+	"1683457503_add_blocks_ranges_sequential_table.up.sql":                     _1683457503_add_blocks_ranges_sequential_tableUpSql,
+	"1683627613_accounts_and_keycards_improvements.up.sql":                     _1683627613_accounts_and_keycards_improvementsUpSql,
+	"1685041348_settings_table_add_latest_derived_path_column.up.sql":          _1685041348_settings_table_add_latest_derived_path_columnUpSql,
+	"1685440989_update_color_id_accounts.up.sql":                               _1685440989_update_color_id_accountsUpSql,
+	"1685463947_add_to_asset_to_multitransaction.up.sql":                       _1685463947_add_to_asset_to_multitransactionUpSql,
+	"1685880973_add_profile_links_settings_table.up.sql":                       _1685880973_add_profile_links_settings_tableUpSql,
+	"1686041510_add_idx_transfers_blkno_loaded.up.sql":                         _1686041510_add_idx_transfers_blkno_loadedUpSql,
+	"1686048341_transfers_receipt_json_blob_out.up.sql.down.sql":               _1686048341_transfers_receipt_json_blob_outUpSqlDownSql,
+	"1686048341_transfers_receipt_json_blob_out.up.sql.up.sql":                 _1686048341_transfers_receipt_json_blob_outUpSqlUpSql,
+	"1686825075_cleanup_token_address.up.sql":                                  _1686825075_cleanup_token_addressUpSql,
+	"1687193315_transfers_extract_from_to_address.down.sql":                    _1687193315_transfers_extract_from_to_addressDownSql,
+	"1687193315_transfers_extract_from_to_address.up.sql":                      _1687193315_transfers_extract_from_to_addressUpSql,
+	"1687249080_add_position_accounts.up..sql":                                 _1687249080_add_position_accountsUpSql,
+	"1687269871_add_device_name.up.sql":                                        _1687269871_add_device_nameUpSql,
+	"1687506642_include_watch_only_account_setting.up.sql":                     _1687506642_include_watch_only_account_settingUpSql,
+	"1688022264_add_include_watch_only_account_to_settings_sync_clock.up.sql":  _1688022264_add_include_watch_only_account_to_settings_sync_clockUpSql,
+	"1688054680_add_columns_to_multitransaction.up.sql":                        _1688054680_add_columns_to_multitransactionUpSql,
+	"1688636552_keycards_table_columns_update.up.sql":                          _1688636552_keycards_table_columns_updateUpSql,
+	"1689248269_add_related_chain_id_networks.up.sql":                          _1689248269_add_related_chain_id_networksUpSql,
+	"1689340211_index_filter_columns.up.sql":                                   _1689340211_index_filter_columnsUpSql,
+	"1689498471_make_wallet_accounts_positions_non_negative.up.sql":            _1689498471_make_wallet_accounts_positions_non_negativeUpSql,
+	"1689856991_add_soft_remove_column_for_keypairs_and_accounts.up.sql":       _1689856991_add_soft_remove_column_for_keypairs_and_accountsUpSql,
+	"1690225863_add_collectibles_ownership_cache.up.sql":                       _1690225863_add_collectibles_ownership_cacheUpSql,
+	"1690734354_add_preferred_chain_ids.up.sql":                                _1690734354_add_preferred_chain_idsUpSql,
+	"1691173699_add_collectibles_and_collections_data_cache.up.sql":            _1691173699_add_collectibles_and_collections_data_cacheUpSql,
+	"1691753758_move_wallet_tables_to_wallet_db.up.sql":                        _1691753758_move_wallet_tables_to_wallet_dbUpSql,
+	"1691753800_pubsubtopic_key.up.sql":                                        _1691753800_pubsubtopic_keyUpSql,
+	"1693900971_add_profile_migration_needed_column_to_settings_table.up.sql":  _1693900971_add_profile_migration_needed_column_to_settings_tableUpSql,
+	"1694764094_add_original_to_networks.up.sql":                               _1694764094_add_original_to_networksUpSql,
+	"1695974515_add_is_sepolia_enabled_to_settings.up.sql":                     _1695974515_add_is_sepolia_enabled_to_settingsUpSql,
+	"1696259336_settings_add_url_unfurling_mode.up.sql":                        _1696259336_settings_add_url_unfurling_modeUpSql,
+	"1697123140_drop_include_watch_only_accounts.up.sql":                       _1697123140_drop_include_watch_only_accountsUpSql,
 	"1697123233_drop_include_watch_only_account_to_settings_sync_clock.up.sql": _1697123233_drop_include_watch_only_account_to_settings_sync_clockUpSql,
-
-	"1697623289_add_omit_transfers_history_scan_to_settings.up.sql": _1697623289_add_omit_transfers_history_scan_to_settingsUpSql,
-
-	"1699577175_use_shards.up.sql": _1699577175_use_shardsUpSql,
-
-	"1700741911_clusterID.up.sql": _1700741911_clusteridUpSql,
-
-	"1701084316_add_wallet_was_not_shown_to_keypairs_accounts.up.sql": _1701084316_add_wallet_was_not_shown_to_keypairs_accountsUpSql,
-
-	"1701084317_add_mnemonic_was_not_shown_to_settings.up.sql": _1701084317_add_mnemonic_was_not_shown_to_settingsUpSql,
-
-	"1701444172_token_preferences.up.sql": _1701444172_token_preferencesUpSql,
-
-	"1701961850_shards_test.up.sql": _1701961850_shards_testUpSql,
-
-	"1702395750_fix_enr_shards_test.up.sql": _1702395750_fix_enr_shards_testUpSql,
-
-	"1702999401_add_dns_discovery_url.up.sql": _1702999401_add_dns_discovery_urlUpSql,
-
-	"1704281285_tokens_advanced_settings.up.sql": _1704281285_tokens_advanced_settingsUpSql,
-
-	"1705338819_collectible_preferences.up.sql": _1705338819_collectible_preferencesUpSql,
-
-	"1706097653_migration_order_fix.up.sql": _1706097653_migration_order_fixUpSql,
-
-	"1706955596_community_storenodes.up.sql": _1706955596_community_storenodesUpSql,
-
-	"1708352924_add_peer_syncing_enabled_to_settings.up.sql": _1708352924_add_peer_syncing_enabled_to_settingsUpSql,
-
-	"1708416025_make_sepolia_default.up.sql": _1708416025_make_sepolia_defaultUpSql,
-
-	"1709203128_fix_chain_colors.up.sql": _1709203128_fix_chain_colorsUpSql,
-
-	"1709795716_migration_order_fix.up.sql": _1709795716_migration_order_fixUpSql,
-
-	"1715756976_network_short_names_update.up.sql": _1715756976_network_short_names_updateUpSql,
-
-	"1716385243_no_discovery.up.sql": _1716385243_no_discoveryUpSql,
-
+	"1697623289_add_omit_transfers_history_scan_to_settings.up.sql":            _1697623289_add_omit_transfers_history_scan_to_settingsUpSql,
+	"1699577175_use_shards.up.sql":                                             _1699577175_use_shardsUpSql,
+	"1700741911_clusterID.up.sql":                                              _1700741911_clusteridUpSql,
+	"1701084316_add_wallet_was_not_shown_to_keypairs_accounts.up.sql":          _1701084316_add_wallet_was_not_shown_to_keypairs_accountsUpSql,
+	"1701084317_add_mnemonic_was_not_shown_to_settings.up.sql":                 _1701084317_add_mnemonic_was_not_shown_to_settingsUpSql,
+	"1701444172_token_preferences.up.sql":                                      _1701444172_token_preferencesUpSql,
+	"1701961850_shards_test.up.sql":                                            _1701961850_shards_testUpSql,
+	"1702395750_fix_enr_shards_test.up.sql":                                    _1702395750_fix_enr_shards_testUpSql,
+	"1702999401_add_dns_discovery_url.up.sql":                                  _1702999401_add_dns_discovery_urlUpSql,
+	"1704281285_tokens_advanced_settings.up.sql":                               _1704281285_tokens_advanced_settingsUpSql,
+	"1705338819_collectible_preferences.up.sql":                                _1705338819_collectible_preferencesUpSql,
+	"1706097653_migration_order_fix.up.sql":                                    _1706097653_migration_order_fixUpSql,
+	"1706955596_community_storenodes.up.sql":                                   _1706955596_community_storenodesUpSql,
+	"1708352924_add_peer_syncing_enabled_to_settings.up.sql":                   _1708352924_add_peer_syncing_enabled_to_settingsUpSql,
+	"1708416025_make_sepolia_default.up.sql":                                   _1708416025_make_sepolia_defaultUpSql,
+	"1709203128_fix_chain_colors.up.sql":                                       _1709203128_fix_chain_colorsUpSql,
+	"1709795716_migration_order_fix.up.sql":                                    _1709795716_migration_order_fixUpSql,
+	"1715756976_network_short_names_update.up.sql":                             _1715756976_network_short_names_updateUpSql,
+	"1716385243_no_discovery.up.sql":                                           _1716385243_no_discoveryUpSql,
+	"1718785164_max_delivery_attempts_update.up.sql":                           _1718785164_max_delivery_attempts_updateUpSql,
 	"doc.go": docGo,
 }
+
+// AssetDebug is true if the assets were built with the debug flag enabled.
+const AssetDebug = false
 
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and
@@ -2800,119 +2714,120 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"1640111208_dummy.up.sql":                                                  &bintree{_1640111208_dummyUpSql, map[string]*bintree{}},
-	"1642666031_add_removed_clock_to_bookmarks.up.sql":                         &bintree{_1642666031_add_removed_clock_to_bookmarksUpSql, map[string]*bintree{}},
-	"1643644541_gif_api_key_setting.up.sql":                                    &bintree{_1643644541_gif_api_key_settingUpSql, map[string]*bintree{}},
-	"1644188994_recent_stickers.up.sql":                                        &bintree{_1644188994_recent_stickersUpSql, map[string]*bintree{}},
-	"1646659233_add_address_to_dapp_permisssion.up.sql":                        &bintree{_1646659233_add_address_to_dapp_permisssionUpSql, map[string]*bintree{}},
-	"1646841105_add_emoji_account.up.sql":                                      &bintree{_1646841105_add_emoji_accountUpSql, map[string]*bintree{}},
-	"1647278782_display_name.up.sql":                                           &bintree{_1647278782_display_nameUpSql, map[string]*bintree{}},
-	"1647862838_reset_last_backup.up.sql":                                      &bintree{_1647862838_reset_last_backupUpSql, map[string]*bintree{}},
-	"1647871652_add_settings_sync_clock_table.up.sql":                          &bintree{_1647871652_add_settings_sync_clock_tableUpSql, map[string]*bintree{}},
-	"1647880168_add_torrent_config.up.sql":                                     &bintree{_1647880168_add_torrent_configUpSql, map[string]*bintree{}},
-	"1647882837_add_communities_settings_table.up.sql":                         &bintree{_1647882837_add_communities_settings_tableUpSql, map[string]*bintree{}},
-	"1647956635_add_waku_messages_table.up.sql":                                &bintree{_1647956635_add_waku_messages_tableUpSql, map[string]*bintree{}},
-	"1648554928_network_test.up.sql":                                           &bintree{_1648554928_network_testUpSql, map[string]*bintree{}},
-	"1649174829_add_visitble_token.up.sql":                                     &bintree{_1649174829_add_visitble_tokenUpSql, map[string]*bintree{}},
-	"1649882262_add_derived_from_accounts.up.sql":                              &bintree{_1649882262_add_derived_from_accountsUpSql, map[string]*bintree{}},
-	"1650612625_add_community_message_archive_hashes_table.up.sql":             &bintree{_1650612625_add_community_message_archive_hashes_tableUpSql, map[string]*bintree{}},
-	"1650616788_add_communities_archives_info_table.up.sql":                    &bintree{_1650616788_add_communities_archives_info_tableUpSql, map[string]*bintree{}},
-	"1652715604_add_clock_accounts.up.sql":                                     &bintree{_1652715604_add_clock_accountsUpSql, map[string]*bintree{}},
-	"1653037334_add_notifications_settings_table.up.sql":                       &bintree{_1653037334_add_notifications_settings_tableUpSql, map[string]*bintree{}},
-	"1654702119_add_mutual_contact_settings.up.sql":                            &bintree{_1654702119_add_mutual_contact_settingsUpSql, map[string]*bintree{}},
-	"1655375270_add_clock_field_to_communities_settings_table.up.sql":          &bintree{_1655375270_add_clock_field_to_communities_settings_tableUpSql, map[string]*bintree{}},
-	"1655385721_drop_networks_config.up.sql":                                   &bintree{_1655385721_drop_networks_configUpSql, map[string]*bintree{}},
-	"1655385724_networks_chainColor_shortName.up.sql":                          &bintree{_1655385724_networks_chaincolor_shortnameUpSql, map[string]*bintree{}},
-	"1655456688_add_deleted_at_field_to_bookmarks_table.up.sql":                &bintree{_1655456688_add_deleted_at_field_to_bookmarks_tableUpSql, map[string]*bintree{}},
-	"1655462032_create_bookmarks_deleted_at_index.up.sql":                      &bintree{_1655462032_create_bookmarks_deleted_at_indexUpSql, map[string]*bintree{}},
-	"1657617291_add_multi_transactions_table.up.sql":                           &bintree{_1657617291_add_multi_transactions_tableUpSql, map[string]*bintree{}},
-	"1660134042_add_social_links_settings_table.up.sql":                        &bintree{_1660134042_add_social_links_settings_tableUpSql, map[string]*bintree{}},
-	"1660134060_settings_bio.up.sql":                                           &bintree{_1660134060_settings_bioUpSql, map[string]*bintree{}},
-	"1660134070_add_wakuv2_store.up.sql":                                       &bintree{_1660134070_add_wakuv2_storeUpSql, map[string]*bintree{}},
-	"1660134072_waku2_store_messages.up.sql":                                   &bintree{_1660134072_waku2_store_messagesUpSql, map[string]*bintree{}},
-	"1662365868_add_key_uid_accounts.up.sql":                                   &bintree{_1662365868_add_key_uid_accountsUpSql, map[string]*bintree{}},
-	"1662447680_add_keypairs_table.up.sql":                                     &bintree{_1662447680_add_keypairs_tableUpSql, map[string]*bintree{}},
-	"1662460056_move_favourites_to_saved_addresses.up.sql":                     &bintree{_1662460056_move_favourites_to_saved_addressesUpSql, map[string]*bintree{}},
-	"1662738097_add_base_fee_transaction.up.sql":                               &bintree{_1662738097_add_base_fee_transactionUpSql, map[string]*bintree{}},
-	"1662972194_add_keypairs_table.up.sql":                                     &bintree{_1662972194_add_keypairs_tableUpSql, map[string]*bintree{}},
-	"1664392661_add_third_party_id_to_waku_messages.up.sql":                    &bintree{_1664392661_add_third_party_id_to_waku_messagesUpSql, map[string]*bintree{}},
-	"1664783660_add_sync_info_to_saved_addresses.up.sql":                       &bintree{_1664783660_add_sync_info_to_saved_addressesUpSql, map[string]*bintree{}},
-	"1668109917_wakunodes.up.sql":                                              &bintree{_1668109917_wakunodesUpSql, map[string]*bintree{}},
-	"1670249678_display_name_to_settings_sync_clock_table.up.sql":              &bintree{_1670249678_display_name_to_settings_sync_clock_tableUpSql, map[string]*bintree{}},
-	"1670836810_add_imported_flag_to_community_archive_hashes.up.sql":          &bintree{_1670836810_add_imported_flag_to_community_archive_hashesUpSql, map[string]*bintree{}},
-	"1671438731_add_magnetlink_uri_to_communities_archive_info.up.sql":         &bintree{_1671438731_add_magnetlink_uri_to_communities_archive_infoUpSql, map[string]*bintree{}},
-	"1672933930_switcher_card.up.sql":                                          &bintree{_1672933930_switcher_cardUpSql, map[string]*bintree{}},
-	"1674056187_add_price_cache.up.sql":                                        &bintree{_1674056187_add_price_cacheUpSql, map[string]*bintree{}},
-	"1674136690_ens_usernames.up.sql":                                          &bintree{_1674136690_ens_usernamesUpSql, map[string]*bintree{}},
-	"1674232431_add_balance_history.up.sql":                                    &bintree{_1674232431_add_balance_historyUpSql, map[string]*bintree{}},
-	"1676368933_keypairs_to_keycards.up.sql":                                   &bintree{_1676368933_keypairs_to_keycardsUpSql, map[string]*bintree{}},
-	"1676951398_add_currency_format_cache.up.sql":                              &bintree{_1676951398_add_currency_format_cacheUpSql, map[string]*bintree{}},
-	"1676968196_keycards_add_clock_column.up.sql":                              &bintree{_1676968196_keycards_add_clock_columnUpSql, map[string]*bintree{}},
-	"1676968197_add_fallback_rpc_to_networks.up.sql":                           &bintree{_1676968197_add_fallback_rpc_to_networksUpSql, map[string]*bintree{}},
-	"1677674090_add_chains_ens_istest_to_saved_addresses.up.sql":               &bintree{_1677674090_add_chains_ens_istest_to_saved_addressesUpSql, map[string]*bintree{}},
-	"1677681143_accounts_table_type_column_update.up.sql":                      &bintree{_1677681143_accounts_table_type_column_updateUpSql, map[string]*bintree{}},
-	"1678264207_accounts_table_new_columns_added.up.sql":                       &bintree{_1678264207_accounts_table_new_columns_addedUpSql, map[string]*bintree{}},
-	"1680770368_add_bio_to_settings_sync_clock_table.up.sql":                   &bintree{_1680770368_add_bio_to_settings_sync_clock_tableUpSql, map[string]*bintree{}},
-	"1681110436_add_mnemonic_to_settings_sync_clock_table.up.sql":              &bintree{_1681110436_add_mnemonic_to_settings_sync_clock_tableUpSql, map[string]*bintree{}},
-	"1681392602_9d_sync_period.up.sql":                                         &bintree{_1681392602_9d_sync_periodUpSql, map[string]*bintree{}},
-	"1681762078_default_sync_period_9d.up.sql":                                 &bintree{_1681762078_default_sync_period_9dUpSql, map[string]*bintree{}},
-	"1681780680_add_clock_to_social_links_settings.up.sql":                     &bintree{_1681780680_add_clock_to_social_links_settingsUpSql, map[string]*bintree{}},
-	"1682073779_settings_table_remove_latest_derived_path_column.up.sql":       &bintree{_1682073779_settings_table_remove_latest_derived_path_columnUpSql, map[string]*bintree{}},
-	"1682146075_add_created_at_to_saved_addresses.up.sql":                      &bintree{_1682146075_add_created_at_to_saved_addressesUpSql, map[string]*bintree{}},
-	"1682393575_sync_ens_name.up.sql":                                          &bintree{_1682393575_sync_ens_nameUpSql, map[string]*bintree{}},
-	"1683457503_add_blocks_ranges_sequential_table.up.sql":                     &bintree{_1683457503_add_blocks_ranges_sequential_tableUpSql, map[string]*bintree{}},
-	"1683627613_accounts_and_keycards_improvements.up.sql":                     &bintree{_1683627613_accounts_and_keycards_improvementsUpSql, map[string]*bintree{}},
-	"1685041348_settings_table_add_latest_derived_path_column.up.sql":          &bintree{_1685041348_settings_table_add_latest_derived_path_columnUpSql, map[string]*bintree{}},
-	"1685440989_update_color_id_accounts.up.sql":                               &bintree{_1685440989_update_color_id_accountsUpSql, map[string]*bintree{}},
-	"1685463947_add_to_asset_to_multitransaction.up.sql":                       &bintree{_1685463947_add_to_asset_to_multitransactionUpSql, map[string]*bintree{}},
-	"1685880973_add_profile_links_settings_table.up.sql":                       &bintree{_1685880973_add_profile_links_settings_tableUpSql, map[string]*bintree{}},
-	"1686041510_add_idx_transfers_blkno_loaded.up.sql":                         &bintree{_1686041510_add_idx_transfers_blkno_loadedUpSql, map[string]*bintree{}},
-	"1686048341_transfers_receipt_json_blob_out.up.sql.down.sql":               &bintree{_1686048341_transfers_receipt_json_blob_outUpSqlDownSql, map[string]*bintree{}},
-	"1686048341_transfers_receipt_json_blob_out.up.sql.up.sql":                 &bintree{_1686048341_transfers_receipt_json_blob_outUpSqlUpSql, map[string]*bintree{}},
-	"1686825075_cleanup_token_address.up.sql":                                  &bintree{_1686825075_cleanup_token_addressUpSql, map[string]*bintree{}},
-	"1687193315_transfers_extract_from_to_address.down.sql":                    &bintree{_1687193315_transfers_extract_from_to_addressDownSql, map[string]*bintree{}},
-	"1687193315_transfers_extract_from_to_address.up.sql":                      &bintree{_1687193315_transfers_extract_from_to_addressUpSql, map[string]*bintree{}},
-	"1687249080_add_position_accounts.up..sql":                                 &bintree{_1687249080_add_position_accountsUpSql, map[string]*bintree{}},
-	"1687269871_add_device_name.up.sql":                                        &bintree{_1687269871_add_device_nameUpSql, map[string]*bintree{}},
-	"1687506642_include_watch_only_account_setting.up.sql":                     &bintree{_1687506642_include_watch_only_account_settingUpSql, map[string]*bintree{}},
-	"1688022264_add_include_watch_only_account_to_settings_sync_clock.up.sql":  &bintree{_1688022264_add_include_watch_only_account_to_settings_sync_clockUpSql, map[string]*bintree{}},
-	"1688054680_add_columns_to_multitransaction.up.sql":                        &bintree{_1688054680_add_columns_to_multitransactionUpSql, map[string]*bintree{}},
-	"1688636552_keycards_table_columns_update.up.sql":                          &bintree{_1688636552_keycards_table_columns_updateUpSql, map[string]*bintree{}},
-	"1689248269_add_related_chain_id_networks.up.sql":                          &bintree{_1689248269_add_related_chain_id_networksUpSql, map[string]*bintree{}},
-	"1689340211_index_filter_columns.up.sql":                                   &bintree{_1689340211_index_filter_columnsUpSql, map[string]*bintree{}},
-	"1689498471_make_wallet_accounts_positions_non_negative.up.sql":            &bintree{_1689498471_make_wallet_accounts_positions_non_negativeUpSql, map[string]*bintree{}},
-	"1689856991_add_soft_remove_column_for_keypairs_and_accounts.up.sql":       &bintree{_1689856991_add_soft_remove_column_for_keypairs_and_accountsUpSql, map[string]*bintree{}},
-	"1690225863_add_collectibles_ownership_cache.up.sql":                       &bintree{_1690225863_add_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
-	"1690734354_add_preferred_chain_ids.up.sql":                                &bintree{_1690734354_add_preferred_chain_idsUpSql, map[string]*bintree{}},
-	"1691173699_add_collectibles_and_collections_data_cache.up.sql":            &bintree{_1691173699_add_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
-	"1691753758_move_wallet_tables_to_wallet_db.up.sql":                        &bintree{_1691753758_move_wallet_tables_to_wallet_dbUpSql, map[string]*bintree{}},
-	"1691753800_pubsubtopic_key.up.sql":                                        &bintree{_1691753800_pubsubtopic_keyUpSql, map[string]*bintree{}},
-	"1693900971_add_profile_migration_needed_column_to_settings_table.up.sql":  &bintree{_1693900971_add_profile_migration_needed_column_to_settings_tableUpSql, map[string]*bintree{}},
-	"1694764094_add_original_to_networks.up.sql":                               &bintree{_1694764094_add_original_to_networksUpSql, map[string]*bintree{}},
-	"1695974515_add_is_sepolia_enabled_to_settings.up.sql":                     &bintree{_1695974515_add_is_sepolia_enabled_to_settingsUpSql, map[string]*bintree{}},
-	"1696259336_settings_add_url_unfurling_mode.up.sql":                        &bintree{_1696259336_settings_add_url_unfurling_modeUpSql, map[string]*bintree{}},
-	"1697123140_drop_include_watch_only_accounts.up.sql":                       &bintree{_1697123140_drop_include_watch_only_accountsUpSql, map[string]*bintree{}},
-	"1697123233_drop_include_watch_only_account_to_settings_sync_clock.up.sql": &bintree{_1697123233_drop_include_watch_only_account_to_settings_sync_clockUpSql, map[string]*bintree{}},
-	"1697623289_add_omit_transfers_history_scan_to_settings.up.sql":            &bintree{_1697623289_add_omit_transfers_history_scan_to_settingsUpSql, map[string]*bintree{}},
-	"1699577175_use_shards.up.sql":                                             &bintree{_1699577175_use_shardsUpSql, map[string]*bintree{}},
-	"1700741911_clusterID.up.sql":                                              &bintree{_1700741911_clusteridUpSql, map[string]*bintree{}},
-	"1701084316_add_wallet_was_not_shown_to_keypairs_accounts.up.sql":          &bintree{_1701084316_add_wallet_was_not_shown_to_keypairs_accountsUpSql, map[string]*bintree{}},
-	"1701084317_add_mnemonic_was_not_shown_to_settings.up.sql":                 &bintree{_1701084317_add_mnemonic_was_not_shown_to_settingsUpSql, map[string]*bintree{}},
-	"1701444172_token_preferences.up.sql":                                      &bintree{_1701444172_token_preferencesUpSql, map[string]*bintree{}},
-	"1701961850_shards_test.up.sql":                                            &bintree{_1701961850_shards_testUpSql, map[string]*bintree{}},
-	"1702395750_fix_enr_shards_test.up.sql":                                    &bintree{_1702395750_fix_enr_shards_testUpSql, map[string]*bintree{}},
-	"1702999401_add_dns_discovery_url.up.sql":                                  &bintree{_1702999401_add_dns_discovery_urlUpSql, map[string]*bintree{}},
-	"1704281285_tokens_advanced_settings.up.sql":                               &bintree{_1704281285_tokens_advanced_settingsUpSql, map[string]*bintree{}},
-	"1705338819_collectible_preferences.up.sql":                                &bintree{_1705338819_collectible_preferencesUpSql, map[string]*bintree{}},
-	"1706097653_migration_order_fix.up.sql":                                    &bintree{_1706097653_migration_order_fixUpSql, map[string]*bintree{}},
-	"1706955596_community_storenodes.up.sql":                                   &bintree{_1706955596_community_storenodesUpSql, map[string]*bintree{}},
-	"1708352924_add_peer_syncing_enabled_to_settings.up.sql":                   &bintree{_1708352924_add_peer_syncing_enabled_to_settingsUpSql, map[string]*bintree{}},
-	"1708416025_make_sepolia_default.up.sql":                                   &bintree{_1708416025_make_sepolia_defaultUpSql, map[string]*bintree{}},
-	"1709203128_fix_chain_colors.up.sql":                                       &bintree{_1709203128_fix_chain_colorsUpSql, map[string]*bintree{}},
-	"1709795716_migration_order_fix.up.sql":                                    &bintree{_1709795716_migration_order_fixUpSql, map[string]*bintree{}},
-	"1715756976_network_short_names_update.up.sql":                             &bintree{_1715756976_network_short_names_updateUpSql, map[string]*bintree{}},
-	"1716385243_no_discovery.up.sql":                                           &bintree{_1716385243_no_discoveryUpSql, map[string]*bintree{}},
-	"doc.go":                                                                   &bintree{docGo, map[string]*bintree{}},
+	"1640111208_dummy.up.sql":                                                  {_1640111208_dummyUpSql, map[string]*bintree{}},
+	"1642666031_add_removed_clock_to_bookmarks.up.sql":                         {_1642666031_add_removed_clock_to_bookmarksUpSql, map[string]*bintree{}},
+	"1643644541_gif_api_key_setting.up.sql":                                    {_1643644541_gif_api_key_settingUpSql, map[string]*bintree{}},
+	"1644188994_recent_stickers.up.sql":                                        {_1644188994_recent_stickersUpSql, map[string]*bintree{}},
+	"1646659233_add_address_to_dapp_permisssion.up.sql":                        {_1646659233_add_address_to_dapp_permisssionUpSql, map[string]*bintree{}},
+	"1646841105_add_emoji_account.up.sql":                                      {_1646841105_add_emoji_accountUpSql, map[string]*bintree{}},
+	"1647278782_display_name.up.sql":                                           {_1647278782_display_nameUpSql, map[string]*bintree{}},
+	"1647862838_reset_last_backup.up.sql":                                      {_1647862838_reset_last_backupUpSql, map[string]*bintree{}},
+	"1647871652_add_settings_sync_clock_table.up.sql":                          {_1647871652_add_settings_sync_clock_tableUpSql, map[string]*bintree{}},
+	"1647880168_add_torrent_config.up.sql":                                     {_1647880168_add_torrent_configUpSql, map[string]*bintree{}},
+	"1647882837_add_communities_settings_table.up.sql":                         {_1647882837_add_communities_settings_tableUpSql, map[string]*bintree{}},
+	"1647956635_add_waku_messages_table.up.sql":                                {_1647956635_add_waku_messages_tableUpSql, map[string]*bintree{}},
+	"1648554928_network_test.up.sql":                                           {_1648554928_network_testUpSql, map[string]*bintree{}},
+	"1649174829_add_visitble_token.up.sql":                                     {_1649174829_add_visitble_tokenUpSql, map[string]*bintree{}},
+	"1649882262_add_derived_from_accounts.up.sql":                              {_1649882262_add_derived_from_accountsUpSql, map[string]*bintree{}},
+	"1650612625_add_community_message_archive_hashes_table.up.sql":             {_1650612625_add_community_message_archive_hashes_tableUpSql, map[string]*bintree{}},
+	"1650616788_add_communities_archives_info_table.up.sql":                    {_1650616788_add_communities_archives_info_tableUpSql, map[string]*bintree{}},
+	"1652715604_add_clock_accounts.up.sql":                                     {_1652715604_add_clock_accountsUpSql, map[string]*bintree{}},
+	"1653037334_add_notifications_settings_table.up.sql":                       {_1653037334_add_notifications_settings_tableUpSql, map[string]*bintree{}},
+	"1654702119_add_mutual_contact_settings.up.sql":                            {_1654702119_add_mutual_contact_settingsUpSql, map[string]*bintree{}},
+	"1655375270_add_clock_field_to_communities_settings_table.up.sql":          {_1655375270_add_clock_field_to_communities_settings_tableUpSql, map[string]*bintree{}},
+	"1655385721_drop_networks_config.up.sql":                                   {_1655385721_drop_networks_configUpSql, map[string]*bintree{}},
+	"1655385724_networks_chainColor_shortName.up.sql":                          {_1655385724_networks_chaincolor_shortnameUpSql, map[string]*bintree{}},
+	"1655456688_add_deleted_at_field_to_bookmarks_table.up.sql":                {_1655456688_add_deleted_at_field_to_bookmarks_tableUpSql, map[string]*bintree{}},
+	"1655462032_create_bookmarks_deleted_at_index.up.sql":                      {_1655462032_create_bookmarks_deleted_at_indexUpSql, map[string]*bintree{}},
+	"1657617291_add_multi_transactions_table.up.sql":                           {_1657617291_add_multi_transactions_tableUpSql, map[string]*bintree{}},
+	"1660134042_add_social_links_settings_table.up.sql":                        {_1660134042_add_social_links_settings_tableUpSql, map[string]*bintree{}},
+	"1660134060_settings_bio.up.sql":                                           {_1660134060_settings_bioUpSql, map[string]*bintree{}},
+	"1660134070_add_wakuv2_store.up.sql":                                       {_1660134070_add_wakuv2_storeUpSql, map[string]*bintree{}},
+	"1660134072_waku2_store_messages.up.sql":                                   {_1660134072_waku2_store_messagesUpSql, map[string]*bintree{}},
+	"1662365868_add_key_uid_accounts.up.sql":                                   {_1662365868_add_key_uid_accountsUpSql, map[string]*bintree{}},
+	"1662447680_add_keypairs_table.up.sql":                                     {_1662447680_add_keypairs_tableUpSql, map[string]*bintree{}},
+	"1662460056_move_favourites_to_saved_addresses.up.sql":                     {_1662460056_move_favourites_to_saved_addressesUpSql, map[string]*bintree{}},
+	"1662738097_add_base_fee_transaction.up.sql":                               {_1662738097_add_base_fee_transactionUpSql, map[string]*bintree{}},
+	"1662972194_add_keypairs_table.up.sql":                                     {_1662972194_add_keypairs_tableUpSql, map[string]*bintree{}},
+	"1664392661_add_third_party_id_to_waku_messages.up.sql":                    {_1664392661_add_third_party_id_to_waku_messagesUpSql, map[string]*bintree{}},
+	"1664783660_add_sync_info_to_saved_addresses.up.sql":                       {_1664783660_add_sync_info_to_saved_addressesUpSql, map[string]*bintree{}},
+	"1668109917_wakunodes.up.sql":                                              {_1668109917_wakunodesUpSql, map[string]*bintree{}},
+	"1670249678_display_name_to_settings_sync_clock_table.up.sql":              {_1670249678_display_name_to_settings_sync_clock_tableUpSql, map[string]*bintree{}},
+	"1670836810_add_imported_flag_to_community_archive_hashes.up.sql":          {_1670836810_add_imported_flag_to_community_archive_hashesUpSql, map[string]*bintree{}},
+	"1671438731_add_magnetlink_uri_to_communities_archive_info.up.sql":         {_1671438731_add_magnetlink_uri_to_communities_archive_infoUpSql, map[string]*bintree{}},
+	"1672933930_switcher_card.up.sql":                                          {_1672933930_switcher_cardUpSql, map[string]*bintree{}},
+	"1674056187_add_price_cache.up.sql":                                        {_1674056187_add_price_cacheUpSql, map[string]*bintree{}},
+	"1674136690_ens_usernames.up.sql":                                          {_1674136690_ens_usernamesUpSql, map[string]*bintree{}},
+	"1674232431_add_balance_history.up.sql":                                    {_1674232431_add_balance_historyUpSql, map[string]*bintree{}},
+	"1676368933_keypairs_to_keycards.up.sql":                                   {_1676368933_keypairs_to_keycardsUpSql, map[string]*bintree{}},
+	"1676951398_add_currency_format_cache.up.sql":                              {_1676951398_add_currency_format_cacheUpSql, map[string]*bintree{}},
+	"1676968196_keycards_add_clock_column.up.sql":                              {_1676968196_keycards_add_clock_columnUpSql, map[string]*bintree{}},
+	"1676968197_add_fallback_rpc_to_networks.up.sql":                           {_1676968197_add_fallback_rpc_to_networksUpSql, map[string]*bintree{}},
+	"1677674090_add_chains_ens_istest_to_saved_addresses.up.sql":               {_1677674090_add_chains_ens_istest_to_saved_addressesUpSql, map[string]*bintree{}},
+	"1677681143_accounts_table_type_column_update.up.sql":                      {_1677681143_accounts_table_type_column_updateUpSql, map[string]*bintree{}},
+	"1678264207_accounts_table_new_columns_added.up.sql":                       {_1678264207_accounts_table_new_columns_addedUpSql, map[string]*bintree{}},
+	"1680770368_add_bio_to_settings_sync_clock_table.up.sql":                   {_1680770368_add_bio_to_settings_sync_clock_tableUpSql, map[string]*bintree{}},
+	"1681110436_add_mnemonic_to_settings_sync_clock_table.up.sql":              {_1681110436_add_mnemonic_to_settings_sync_clock_tableUpSql, map[string]*bintree{}},
+	"1681392602_9d_sync_period.up.sql":                                         {_1681392602_9d_sync_periodUpSql, map[string]*bintree{}},
+	"1681762078_default_sync_period_9d.up.sql":                                 {_1681762078_default_sync_period_9dUpSql, map[string]*bintree{}},
+	"1681780680_add_clock_to_social_links_settings.up.sql":                     {_1681780680_add_clock_to_social_links_settingsUpSql, map[string]*bintree{}},
+	"1682073779_settings_table_remove_latest_derived_path_column.up.sql":       {_1682073779_settings_table_remove_latest_derived_path_columnUpSql, map[string]*bintree{}},
+	"1682146075_add_created_at_to_saved_addresses.up.sql":                      {_1682146075_add_created_at_to_saved_addressesUpSql, map[string]*bintree{}},
+	"1682393575_sync_ens_name.up.sql":                                          {_1682393575_sync_ens_nameUpSql, map[string]*bintree{}},
+	"1683457503_add_blocks_ranges_sequential_table.up.sql":                     {_1683457503_add_blocks_ranges_sequential_tableUpSql, map[string]*bintree{}},
+	"1683627613_accounts_and_keycards_improvements.up.sql":                     {_1683627613_accounts_and_keycards_improvementsUpSql, map[string]*bintree{}},
+	"1685041348_settings_table_add_latest_derived_path_column.up.sql":          {_1685041348_settings_table_add_latest_derived_path_columnUpSql, map[string]*bintree{}},
+	"1685440989_update_color_id_accounts.up.sql":                               {_1685440989_update_color_id_accountsUpSql, map[string]*bintree{}},
+	"1685463947_add_to_asset_to_multitransaction.up.sql":                       {_1685463947_add_to_asset_to_multitransactionUpSql, map[string]*bintree{}},
+	"1685880973_add_profile_links_settings_table.up.sql":                       {_1685880973_add_profile_links_settings_tableUpSql, map[string]*bintree{}},
+	"1686041510_add_idx_transfers_blkno_loaded.up.sql":                         {_1686041510_add_idx_transfers_blkno_loadedUpSql, map[string]*bintree{}},
+	"1686048341_transfers_receipt_json_blob_out.up.sql.down.sql":               {_1686048341_transfers_receipt_json_blob_outUpSqlDownSql, map[string]*bintree{}},
+	"1686048341_transfers_receipt_json_blob_out.up.sql.up.sql":                 {_1686048341_transfers_receipt_json_blob_outUpSqlUpSql, map[string]*bintree{}},
+	"1686825075_cleanup_token_address.up.sql":                                  {_1686825075_cleanup_token_addressUpSql, map[string]*bintree{}},
+	"1687193315_transfers_extract_from_to_address.down.sql":                    {_1687193315_transfers_extract_from_to_addressDownSql, map[string]*bintree{}},
+	"1687193315_transfers_extract_from_to_address.up.sql":                      {_1687193315_transfers_extract_from_to_addressUpSql, map[string]*bintree{}},
+	"1687249080_add_position_accounts.up..sql":                                 {_1687249080_add_position_accountsUpSql, map[string]*bintree{}},
+	"1687269871_add_device_name.up.sql":                                        {_1687269871_add_device_nameUpSql, map[string]*bintree{}},
+	"1687506642_include_watch_only_account_setting.up.sql":                     {_1687506642_include_watch_only_account_settingUpSql, map[string]*bintree{}},
+	"1688022264_add_include_watch_only_account_to_settings_sync_clock.up.sql":  {_1688022264_add_include_watch_only_account_to_settings_sync_clockUpSql, map[string]*bintree{}},
+	"1688054680_add_columns_to_multitransaction.up.sql":                        {_1688054680_add_columns_to_multitransactionUpSql, map[string]*bintree{}},
+	"1688636552_keycards_table_columns_update.up.sql":                          {_1688636552_keycards_table_columns_updateUpSql, map[string]*bintree{}},
+	"1689248269_add_related_chain_id_networks.up.sql":                          {_1689248269_add_related_chain_id_networksUpSql, map[string]*bintree{}},
+	"1689340211_index_filter_columns.up.sql":                                   {_1689340211_index_filter_columnsUpSql, map[string]*bintree{}},
+	"1689498471_make_wallet_accounts_positions_non_negative.up.sql":            {_1689498471_make_wallet_accounts_positions_non_negativeUpSql, map[string]*bintree{}},
+	"1689856991_add_soft_remove_column_for_keypairs_and_accounts.up.sql":       {_1689856991_add_soft_remove_column_for_keypairs_and_accountsUpSql, map[string]*bintree{}},
+	"1690225863_add_collectibles_ownership_cache.up.sql":                       {_1690225863_add_collectibles_ownership_cacheUpSql, map[string]*bintree{}},
+	"1690734354_add_preferred_chain_ids.up.sql":                                {_1690734354_add_preferred_chain_idsUpSql, map[string]*bintree{}},
+	"1691173699_add_collectibles_and_collections_data_cache.up.sql":            {_1691173699_add_collectibles_and_collections_data_cacheUpSql, map[string]*bintree{}},
+	"1691753758_move_wallet_tables_to_wallet_db.up.sql":                        {_1691753758_move_wallet_tables_to_wallet_dbUpSql, map[string]*bintree{}},
+	"1691753800_pubsubtopic_key.up.sql":                                        {_1691753800_pubsubtopic_keyUpSql, map[string]*bintree{}},
+	"1693900971_add_profile_migration_needed_column_to_settings_table.up.sql":  {_1693900971_add_profile_migration_needed_column_to_settings_tableUpSql, map[string]*bintree{}},
+	"1694764094_add_original_to_networks.up.sql":                               {_1694764094_add_original_to_networksUpSql, map[string]*bintree{}},
+	"1695974515_add_is_sepolia_enabled_to_settings.up.sql":                     {_1695974515_add_is_sepolia_enabled_to_settingsUpSql, map[string]*bintree{}},
+	"1696259336_settings_add_url_unfurling_mode.up.sql":                        {_1696259336_settings_add_url_unfurling_modeUpSql, map[string]*bintree{}},
+	"1697123140_drop_include_watch_only_accounts.up.sql":                       {_1697123140_drop_include_watch_only_accountsUpSql, map[string]*bintree{}},
+	"1697123233_drop_include_watch_only_account_to_settings_sync_clock.up.sql": {_1697123233_drop_include_watch_only_account_to_settings_sync_clockUpSql, map[string]*bintree{}},
+	"1697623289_add_omit_transfers_history_scan_to_settings.up.sql":            {_1697623289_add_omit_transfers_history_scan_to_settingsUpSql, map[string]*bintree{}},
+	"1699577175_use_shards.up.sql":                                             {_1699577175_use_shardsUpSql, map[string]*bintree{}},
+	"1700741911_clusterID.up.sql":                                              {_1700741911_clusteridUpSql, map[string]*bintree{}},
+	"1701084316_add_wallet_was_not_shown_to_keypairs_accounts.up.sql":          {_1701084316_add_wallet_was_not_shown_to_keypairs_accountsUpSql, map[string]*bintree{}},
+	"1701084317_add_mnemonic_was_not_shown_to_settings.up.sql":                 {_1701084317_add_mnemonic_was_not_shown_to_settingsUpSql, map[string]*bintree{}},
+	"1701444172_token_preferences.up.sql":                                      {_1701444172_token_preferencesUpSql, map[string]*bintree{}},
+	"1701961850_shards_test.up.sql":                                            {_1701961850_shards_testUpSql, map[string]*bintree{}},
+	"1702395750_fix_enr_shards_test.up.sql":                                    {_1702395750_fix_enr_shards_testUpSql, map[string]*bintree{}},
+	"1702999401_add_dns_discovery_url.up.sql":                                  {_1702999401_add_dns_discovery_urlUpSql, map[string]*bintree{}},
+	"1704281285_tokens_advanced_settings.up.sql":                               {_1704281285_tokens_advanced_settingsUpSql, map[string]*bintree{}},
+	"1705338819_collectible_preferences.up.sql":                                {_1705338819_collectible_preferencesUpSql, map[string]*bintree{}},
+	"1706097653_migration_order_fix.up.sql":                                    {_1706097653_migration_order_fixUpSql, map[string]*bintree{}},
+	"1706955596_community_storenodes.up.sql":                                   {_1706955596_community_storenodesUpSql, map[string]*bintree{}},
+	"1708352924_add_peer_syncing_enabled_to_settings.up.sql":                   {_1708352924_add_peer_syncing_enabled_to_settingsUpSql, map[string]*bintree{}},
+	"1708416025_make_sepolia_default.up.sql":                                   {_1708416025_make_sepolia_defaultUpSql, map[string]*bintree{}},
+	"1709203128_fix_chain_colors.up.sql":                                       {_1709203128_fix_chain_colorsUpSql, map[string]*bintree{}},
+	"1709795716_migration_order_fix.up.sql":                                    {_1709795716_migration_order_fixUpSql, map[string]*bintree{}},
+	"1715756976_network_short_names_update.up.sql":                             {_1715756976_network_short_names_updateUpSql, map[string]*bintree{}},
+	"1716385243_no_discovery.up.sql":                                           {_1716385243_no_discoveryUpSql, map[string]*bintree{}},
+	"1718785164_max_delivery_attempts_update.up.sql":                           {_1718785164_max_delivery_attempts_updateUpSql, map[string]*bintree{}},
+	"doc.go": {docGo, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.
@@ -2929,7 +2844,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}

--- a/appdatabase/migrations/sql/1718785164_max_delivery_attempts_update.up.sql
+++ b/appdatabase/migrations/sql/1718785164_max_delivery_attempts_update.up.sql
@@ -1,0 +1,1 @@
+UPDATE shhext_config SET max_message_delivery_attempts = 3;

--- a/appdatabase/migrationsprevnodecfg/bindata.go
+++ b/appdatabase/migrationsprevnodecfg/bindata.go
@@ -63,7 +63,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,7 +72,7 @@ import (
 func bindataRead(data []byte, name string) ([]byte, error) {
 	gz, err := gzip.NewReader(bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 
 	var buf bytes.Buffer
@@ -81,7 +80,7 @@ func bindataRead(data []byte, name string) ([]byte, error) {
 	clErr := gz.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("read %q: %v", name, err)
+		return nil, fmt.Errorf("read %q: %w", name, err)
 	}
 	if clErr != nil {
 		return nil, err
@@ -1293,124 +1292,76 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"0001_app.down.sql": _0001_appDownSql,
-
-	"0001_app.up.sql": _0001_appUpSql,
-
-	"0002_tokens.down.sql": _0002_tokensDownSql,
-
-	"0002_tokens.up.sql": _0002_tokensUpSql,
-
-	"0003_settings.down.sql": _0003_settingsDownSql,
-
-	"0003_settings.up.sql": _0003_settingsUpSql,
-
-	"0004_pending_stickers.down.sql": _0004_pending_stickersDownSql,
-
-	"0004_pending_stickers.up.sql": _0004_pending_stickersUpSql,
-
-	"0005_waku_mode.down.sql": _0005_waku_modeDownSql,
-
-	"0005_waku_mode.up.sql": _0005_waku_modeUpSql,
-
-	"0006_appearance.up.sql": _0006_appearanceUpSql,
-
-	"0007_enable_waku_default.up.sql": _0007_enable_waku_defaultUpSql,
-
-	"0008_add_push_notifications.up.sql": _0008_add_push_notificationsUpSql,
-
-	"0009_enable_sending_push_notifications.down.sql": _0009_enable_sending_push_notificationsDownSql,
-
-	"0009_enable_sending_push_notifications.up.sql": _0009_enable_sending_push_notificationsUpSql,
-
-	"0010_add_block_mentions.down.sql": _0010_add_block_mentionsDownSql,
-
-	"0010_add_block_mentions.up.sql": _0010_add_block_mentionsUpSql,
-
-	"0011_allow_webview_permission_requests.down.sql": _0011_allow_webview_permission_requestsDownSql,
-
-	"0011_allow_webview_permission_requests.up.sql": _0011_allow_webview_permission_requestsUpSql,
-
-	"0012_pending_transactions.down.sql": _0012_pending_transactionsDownSql,
-
-	"0012_pending_transactions.up.sql": _0012_pending_transactionsUpSql,
-
-	"0013_favourites.down.sql": _0013_favouritesDownSql,
-
-	"0013_favourites.up.sql": _0013_favouritesUpSql,
-
-	"0014_add_use_mailservers.down.sql": _0014_add_use_mailserversDownSql,
-
-	"0014_add_use_mailservers.up.sql": _0014_add_use_mailserversUpSql,
-
-	"0015_link_previews.down.sql": _0015_link_previewsDownSql,
-
-	"0015_link_previews.up.sql": _0015_link_previewsUpSql,
-
-	"0016_local_notifications_preferences.down.sql": _0016_local_notifications_preferencesDownSql,
-
-	"0016_local_notifications_preferences.up.sql": _0016_local_notifications_preferencesUpSql,
-
-	"0017_bookmarks.down.sql": _0017_bookmarksDownSql,
-
-	"0017_bookmarks.up.sql": _0017_bookmarksUpSql,
-
-	"0018_profile_pictures_visibility.up.sql": _0018_profile_pictures_visibilityUpSql,
-
-	"0019_blocks_ranges_extra_data.up.sql": _0019_blocks_ranges_extra_dataUpSql,
-
-	"0020_metrics.up.sql": _0020_metricsUpSql,
-
-	"0021_add_session_id_to_metrics.up.sql": _0021_add_session_id_to_metricsUpSql,
-
-	"0022_pending_transfers.up.sql": _0022_pending_transfersUpSql,
-
-	"1618237885_settings_anon_metrics_should_send.up.sql": _1618237885_settings_anon_metrics_should_sendUpSql,
-
-	"1618395756_contacts_only.up.sql": _1618395756_contacts_onlyUpSql,
-
-	"1622184614_add_default_sync_period.up.sql": _1622184614_add_default_sync_periodUpSql,
-
-	"1625872445_user_status.up.sql": _1625872445_user_statusUpSql,
-
-	"1627983977_add_gif_to_settings.up.sql": _1627983977_add_gif_to_settingsUpSql,
-
-	"1628580203_add_hidden_account.up.sql": _1628580203_add_hidden_accountUpSql,
-
-	"1629123384_add_id_to_app_metrics.up.sql": _1629123384_add_id_to_app_metricsUpSql,
-
-	"1630401853_add_opensea_enabled_to_settings.up.sql": _1630401853_add_opensea_enabled_to_settingsUpSql,
-
-	"1630464455_create-saved_addresses-table.down.sql": _1630464455_createSaved_addressesTableDownSql,
-
-	"1630464455_create-saved_addresses-table.up.sql": _1630464455_createSaved_addressesTableUpSql,
-
-	"1630485153_networks.down.sql": _1630485153_networksDownSql,
-
-	"1630485153_networks.up.sql": _1630485153_networksUpSql,
-
-	"1632262444_profile_pictures_show_to.up.sql": _1632262444_profile_pictures_show_toUpSql,
-
+	"0001_app.down.sql":                                      _0001_appDownSql,
+	"0001_app.up.sql":                                        _0001_appUpSql,
+	"0002_tokens.down.sql":                                   _0002_tokensDownSql,
+	"0002_tokens.up.sql":                                     _0002_tokensUpSql,
+	"0003_settings.down.sql":                                 _0003_settingsDownSql,
+	"0003_settings.up.sql":                                   _0003_settingsUpSql,
+	"0004_pending_stickers.down.sql":                         _0004_pending_stickersDownSql,
+	"0004_pending_stickers.up.sql":                           _0004_pending_stickersUpSql,
+	"0005_waku_mode.down.sql":                                _0005_waku_modeDownSql,
+	"0005_waku_mode.up.sql":                                  _0005_waku_modeUpSql,
+	"0006_appearance.up.sql":                                 _0006_appearanceUpSql,
+	"0007_enable_waku_default.up.sql":                        _0007_enable_waku_defaultUpSql,
+	"0008_add_push_notifications.up.sql":                     _0008_add_push_notificationsUpSql,
+	"0009_enable_sending_push_notifications.down.sql":        _0009_enable_sending_push_notificationsDownSql,
+	"0009_enable_sending_push_notifications.up.sql":          _0009_enable_sending_push_notificationsUpSql,
+	"0010_add_block_mentions.down.sql":                       _0010_add_block_mentionsDownSql,
+	"0010_add_block_mentions.up.sql":                         _0010_add_block_mentionsUpSql,
+	"0011_allow_webview_permission_requests.down.sql":        _0011_allow_webview_permission_requestsDownSql,
+	"0011_allow_webview_permission_requests.up.sql":          _0011_allow_webview_permission_requestsUpSql,
+	"0012_pending_transactions.down.sql":                     _0012_pending_transactionsDownSql,
+	"0012_pending_transactions.up.sql":                       _0012_pending_transactionsUpSql,
+	"0013_favourites.down.sql":                               _0013_favouritesDownSql,
+	"0013_favourites.up.sql":                                 _0013_favouritesUpSql,
+	"0014_add_use_mailservers.down.sql":                      _0014_add_use_mailserversDownSql,
+	"0014_add_use_mailservers.up.sql":                        _0014_add_use_mailserversUpSql,
+	"0015_link_previews.down.sql":                            _0015_link_previewsDownSql,
+	"0015_link_previews.up.sql":                              _0015_link_previewsUpSql,
+	"0016_local_notifications_preferences.down.sql":          _0016_local_notifications_preferencesDownSql,
+	"0016_local_notifications_preferences.up.sql":            _0016_local_notifications_preferencesUpSql,
+	"0017_bookmarks.down.sql":                                _0017_bookmarksDownSql,
+	"0017_bookmarks.up.sql":                                  _0017_bookmarksUpSql,
+	"0018_profile_pictures_visibility.up.sql":                _0018_profile_pictures_visibilityUpSql,
+	"0019_blocks_ranges_extra_data.up.sql":                   _0019_blocks_ranges_extra_dataUpSql,
+	"0020_metrics.up.sql":                                    _0020_metricsUpSql,
+	"0021_add_session_id_to_metrics.up.sql":                  _0021_add_session_id_to_metricsUpSql,
+	"0022_pending_transfers.up.sql":                          _0022_pending_transfersUpSql,
+	"1618237885_settings_anon_metrics_should_send.up.sql":    _1618237885_settings_anon_metrics_should_sendUpSql,
+	"1618395756_contacts_only.up.sql":                        _1618395756_contacts_onlyUpSql,
+	"1622184614_add_default_sync_period.up.sql":              _1622184614_add_default_sync_periodUpSql,
+	"1625872445_user_status.up.sql":                          _1625872445_user_statusUpSql,
+	"1627983977_add_gif_to_settings.up.sql":                  _1627983977_add_gif_to_settingsUpSql,
+	"1628580203_add_hidden_account.up.sql":                   _1628580203_add_hidden_accountUpSql,
+	"1629123384_add_id_to_app_metrics.up.sql":                _1629123384_add_id_to_app_metricsUpSql,
+	"1630401853_add_opensea_enabled_to_settings.up.sql":      _1630401853_add_opensea_enabled_to_settingsUpSql,
+	"1630464455_create-saved_addresses-table.down.sql":       _1630464455_createSaved_addressesTableDownSql,
+	"1630464455_create-saved_addresses-table.up.sql":         _1630464455_createSaved_addressesTableUpSql,
+	"1630485153_networks.down.sql":                           _1630485153_networksDownSql,
+	"1630485153_networks.up.sql":                             _1630485153_networksUpSql,
+	"1632262444_profile_pictures_show_to.up.sql":             _1632262444_profile_pictures_show_toUpSql,
 	"1635942153_add_telemetry_server_url_to_settings.up.sql": _1635942153_add_telemetry_server_url_to_settingsUpSql,
-
-	"1635942154_add_backup_setting.up.sql": _1635942154_add_backup_settingUpSql,
-
-	"1637745568_add_auto_message_setting.up.sql": _1637745568_add_auto_message_settingUpSql,
-
-	"1640111208_nodeconfig.up.sql": _1640111208_nodeconfigUpSql,
-
-	"doc.go": docGo,
+	"1635942154_add_backup_setting.up.sql":                   _1635942154_add_backup_settingUpSql,
+	"1637745568_add_auto_message_setting.up.sql":             _1637745568_add_auto_message_settingUpSql,
+	"1640111208_nodeconfig.up.sql":                           _1640111208_nodeconfigUpSql,
+	"doc.go":                                                 docGo,
 }
+
+// AssetDebug is true if the assets were built with the debug flag enabled.
+const AssetDebug = false
 
 // AssetDir returns the file names below a certain
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"},
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and
@@ -1443,60 +1394,60 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"0001_app.down.sql":                                      &bintree{_0001_appDownSql, map[string]*bintree{}},
-	"0001_app.up.sql":                                        &bintree{_0001_appUpSql, map[string]*bintree{}},
-	"0002_tokens.down.sql":                                   &bintree{_0002_tokensDownSql, map[string]*bintree{}},
-	"0002_tokens.up.sql":                                     &bintree{_0002_tokensUpSql, map[string]*bintree{}},
-	"0003_settings.down.sql":                                 &bintree{_0003_settingsDownSql, map[string]*bintree{}},
-	"0003_settings.up.sql":                                   &bintree{_0003_settingsUpSql, map[string]*bintree{}},
-	"0004_pending_stickers.down.sql":                         &bintree{_0004_pending_stickersDownSql, map[string]*bintree{}},
-	"0004_pending_stickers.up.sql":                           &bintree{_0004_pending_stickersUpSql, map[string]*bintree{}},
-	"0005_waku_mode.down.sql":                                &bintree{_0005_waku_modeDownSql, map[string]*bintree{}},
-	"0005_waku_mode.up.sql":                                  &bintree{_0005_waku_modeUpSql, map[string]*bintree{}},
-	"0006_appearance.up.sql":                                 &bintree{_0006_appearanceUpSql, map[string]*bintree{}},
-	"0007_enable_waku_default.up.sql":                        &bintree{_0007_enable_waku_defaultUpSql, map[string]*bintree{}},
-	"0008_add_push_notifications.up.sql":                     &bintree{_0008_add_push_notificationsUpSql, map[string]*bintree{}},
-	"0009_enable_sending_push_notifications.down.sql":        &bintree{_0009_enable_sending_push_notificationsDownSql, map[string]*bintree{}},
-	"0009_enable_sending_push_notifications.up.sql":          &bintree{_0009_enable_sending_push_notificationsUpSql, map[string]*bintree{}},
-	"0010_add_block_mentions.down.sql":                       &bintree{_0010_add_block_mentionsDownSql, map[string]*bintree{}},
-	"0010_add_block_mentions.up.sql":                         &bintree{_0010_add_block_mentionsUpSql, map[string]*bintree{}},
-	"0011_allow_webview_permission_requests.down.sql":        &bintree{_0011_allow_webview_permission_requestsDownSql, map[string]*bintree{}},
-	"0011_allow_webview_permission_requests.up.sql":          &bintree{_0011_allow_webview_permission_requestsUpSql, map[string]*bintree{}},
-	"0012_pending_transactions.down.sql":                     &bintree{_0012_pending_transactionsDownSql, map[string]*bintree{}},
-	"0012_pending_transactions.up.sql":                       &bintree{_0012_pending_transactionsUpSql, map[string]*bintree{}},
-	"0013_favourites.down.sql":                               &bintree{_0013_favouritesDownSql, map[string]*bintree{}},
-	"0013_favourites.up.sql":                                 &bintree{_0013_favouritesUpSql, map[string]*bintree{}},
-	"0014_add_use_mailservers.down.sql":                      &bintree{_0014_add_use_mailserversDownSql, map[string]*bintree{}},
-	"0014_add_use_mailservers.up.sql":                        &bintree{_0014_add_use_mailserversUpSql, map[string]*bintree{}},
-	"0015_link_previews.down.sql":                            &bintree{_0015_link_previewsDownSql, map[string]*bintree{}},
-	"0015_link_previews.up.sql":                              &bintree{_0015_link_previewsUpSql, map[string]*bintree{}},
-	"0016_local_notifications_preferences.down.sql":          &bintree{_0016_local_notifications_preferencesDownSql, map[string]*bintree{}},
-	"0016_local_notifications_preferences.up.sql":            &bintree{_0016_local_notifications_preferencesUpSql, map[string]*bintree{}},
-	"0017_bookmarks.down.sql":                                &bintree{_0017_bookmarksDownSql, map[string]*bintree{}},
-	"0017_bookmarks.up.sql":                                  &bintree{_0017_bookmarksUpSql, map[string]*bintree{}},
-	"0018_profile_pictures_visibility.up.sql":                &bintree{_0018_profile_pictures_visibilityUpSql, map[string]*bintree{}},
-	"0019_blocks_ranges_extra_data.up.sql":                   &bintree{_0019_blocks_ranges_extra_dataUpSql, map[string]*bintree{}},
-	"0020_metrics.up.sql":                                    &bintree{_0020_metricsUpSql, map[string]*bintree{}},
-	"0021_add_session_id_to_metrics.up.sql":                  &bintree{_0021_add_session_id_to_metricsUpSql, map[string]*bintree{}},
-	"0022_pending_transfers.up.sql":                          &bintree{_0022_pending_transfersUpSql, map[string]*bintree{}},
-	"1618237885_settings_anon_metrics_should_send.up.sql":    &bintree{_1618237885_settings_anon_metrics_should_sendUpSql, map[string]*bintree{}},
-	"1618395756_contacts_only.up.sql":                        &bintree{_1618395756_contacts_onlyUpSql, map[string]*bintree{}},
-	"1622184614_add_default_sync_period.up.sql":              &bintree{_1622184614_add_default_sync_periodUpSql, map[string]*bintree{}},
-	"1625872445_user_status.up.sql":                          &bintree{_1625872445_user_statusUpSql, map[string]*bintree{}},
-	"1627983977_add_gif_to_settings.up.sql":                  &bintree{_1627983977_add_gif_to_settingsUpSql, map[string]*bintree{}},
-	"1628580203_add_hidden_account.up.sql":                   &bintree{_1628580203_add_hidden_accountUpSql, map[string]*bintree{}},
-	"1629123384_add_id_to_app_metrics.up.sql":                &bintree{_1629123384_add_id_to_app_metricsUpSql, map[string]*bintree{}},
-	"1630401853_add_opensea_enabled_to_settings.up.sql":      &bintree{_1630401853_add_opensea_enabled_to_settingsUpSql, map[string]*bintree{}},
-	"1630464455_create-saved_addresses-table.down.sql":       &bintree{_1630464455_createSaved_addressesTableDownSql, map[string]*bintree{}},
-	"1630464455_create-saved_addresses-table.up.sql":         &bintree{_1630464455_createSaved_addressesTableUpSql, map[string]*bintree{}},
-	"1630485153_networks.down.sql":                           &bintree{_1630485153_networksDownSql, map[string]*bintree{}},
-	"1630485153_networks.up.sql":                             &bintree{_1630485153_networksUpSql, map[string]*bintree{}},
-	"1632262444_profile_pictures_show_to.up.sql":             &bintree{_1632262444_profile_pictures_show_toUpSql, map[string]*bintree{}},
-	"1635942153_add_telemetry_server_url_to_settings.up.sql": &bintree{_1635942153_add_telemetry_server_url_to_settingsUpSql, map[string]*bintree{}},
-	"1635942154_add_backup_setting.up.sql":                   &bintree{_1635942154_add_backup_settingUpSql, map[string]*bintree{}},
-	"1637745568_add_auto_message_setting.up.sql":             &bintree{_1637745568_add_auto_message_settingUpSql, map[string]*bintree{}},
-	"1640111208_nodeconfig.up.sql":                           &bintree{_1640111208_nodeconfigUpSql, map[string]*bintree{}},
-	"doc.go":                                                 &bintree{docGo, map[string]*bintree{}},
+	"0001_app.down.sql":                                      {_0001_appDownSql, map[string]*bintree{}},
+	"0001_app.up.sql":                                        {_0001_appUpSql, map[string]*bintree{}},
+	"0002_tokens.down.sql":                                   {_0002_tokensDownSql, map[string]*bintree{}},
+	"0002_tokens.up.sql":                                     {_0002_tokensUpSql, map[string]*bintree{}},
+	"0003_settings.down.sql":                                 {_0003_settingsDownSql, map[string]*bintree{}},
+	"0003_settings.up.sql":                                   {_0003_settingsUpSql, map[string]*bintree{}},
+	"0004_pending_stickers.down.sql":                         {_0004_pending_stickersDownSql, map[string]*bintree{}},
+	"0004_pending_stickers.up.sql":                           {_0004_pending_stickersUpSql, map[string]*bintree{}},
+	"0005_waku_mode.down.sql":                                {_0005_waku_modeDownSql, map[string]*bintree{}},
+	"0005_waku_mode.up.sql":                                  {_0005_waku_modeUpSql, map[string]*bintree{}},
+	"0006_appearance.up.sql":                                 {_0006_appearanceUpSql, map[string]*bintree{}},
+	"0007_enable_waku_default.up.sql":                        {_0007_enable_waku_defaultUpSql, map[string]*bintree{}},
+	"0008_add_push_notifications.up.sql":                     {_0008_add_push_notificationsUpSql, map[string]*bintree{}},
+	"0009_enable_sending_push_notifications.down.sql":        {_0009_enable_sending_push_notificationsDownSql, map[string]*bintree{}},
+	"0009_enable_sending_push_notifications.up.sql":          {_0009_enable_sending_push_notificationsUpSql, map[string]*bintree{}},
+	"0010_add_block_mentions.down.sql":                       {_0010_add_block_mentionsDownSql, map[string]*bintree{}},
+	"0010_add_block_mentions.up.sql":                         {_0010_add_block_mentionsUpSql, map[string]*bintree{}},
+	"0011_allow_webview_permission_requests.down.sql":        {_0011_allow_webview_permission_requestsDownSql, map[string]*bintree{}},
+	"0011_allow_webview_permission_requests.up.sql":          {_0011_allow_webview_permission_requestsUpSql, map[string]*bintree{}},
+	"0012_pending_transactions.down.sql":                     {_0012_pending_transactionsDownSql, map[string]*bintree{}},
+	"0012_pending_transactions.up.sql":                       {_0012_pending_transactionsUpSql, map[string]*bintree{}},
+	"0013_favourites.down.sql":                               {_0013_favouritesDownSql, map[string]*bintree{}},
+	"0013_favourites.up.sql":                                 {_0013_favouritesUpSql, map[string]*bintree{}},
+	"0014_add_use_mailservers.down.sql":                      {_0014_add_use_mailserversDownSql, map[string]*bintree{}},
+	"0014_add_use_mailservers.up.sql":                        {_0014_add_use_mailserversUpSql, map[string]*bintree{}},
+	"0015_link_previews.down.sql":                            {_0015_link_previewsDownSql, map[string]*bintree{}},
+	"0015_link_previews.up.sql":                              {_0015_link_previewsUpSql, map[string]*bintree{}},
+	"0016_local_notifications_preferences.down.sql":          {_0016_local_notifications_preferencesDownSql, map[string]*bintree{}},
+	"0016_local_notifications_preferences.up.sql":            {_0016_local_notifications_preferencesUpSql, map[string]*bintree{}},
+	"0017_bookmarks.down.sql":                                {_0017_bookmarksDownSql, map[string]*bintree{}},
+	"0017_bookmarks.up.sql":                                  {_0017_bookmarksUpSql, map[string]*bintree{}},
+	"0018_profile_pictures_visibility.up.sql":                {_0018_profile_pictures_visibilityUpSql, map[string]*bintree{}},
+	"0019_blocks_ranges_extra_data.up.sql":                   {_0019_blocks_ranges_extra_dataUpSql, map[string]*bintree{}},
+	"0020_metrics.up.sql":                                    {_0020_metricsUpSql, map[string]*bintree{}},
+	"0021_add_session_id_to_metrics.up.sql":                  {_0021_add_session_id_to_metricsUpSql, map[string]*bintree{}},
+	"0022_pending_transfers.up.sql":                          {_0022_pending_transfersUpSql, map[string]*bintree{}},
+	"1618237885_settings_anon_metrics_should_send.up.sql":    {_1618237885_settings_anon_metrics_should_sendUpSql, map[string]*bintree{}},
+	"1618395756_contacts_only.up.sql":                        {_1618395756_contacts_onlyUpSql, map[string]*bintree{}},
+	"1622184614_add_default_sync_period.up.sql":              {_1622184614_add_default_sync_periodUpSql, map[string]*bintree{}},
+	"1625872445_user_status.up.sql":                          {_1625872445_user_statusUpSql, map[string]*bintree{}},
+	"1627983977_add_gif_to_settings.up.sql":                  {_1627983977_add_gif_to_settingsUpSql, map[string]*bintree{}},
+	"1628580203_add_hidden_account.up.sql":                   {_1628580203_add_hidden_accountUpSql, map[string]*bintree{}},
+	"1629123384_add_id_to_app_metrics.up.sql":                {_1629123384_add_id_to_app_metricsUpSql, map[string]*bintree{}},
+	"1630401853_add_opensea_enabled_to_settings.up.sql":      {_1630401853_add_opensea_enabled_to_settingsUpSql, map[string]*bintree{}},
+	"1630464455_create-saved_addresses-table.down.sql":       {_1630464455_createSaved_addressesTableDownSql, map[string]*bintree{}},
+	"1630464455_create-saved_addresses-table.up.sql":         {_1630464455_createSaved_addressesTableUpSql, map[string]*bintree{}},
+	"1630485153_networks.down.sql":                           {_1630485153_networksDownSql, map[string]*bintree{}},
+	"1630485153_networks.up.sql":                             {_1630485153_networksUpSql, map[string]*bintree{}},
+	"1632262444_profile_pictures_show_to.up.sql":             {_1632262444_profile_pictures_show_toUpSql, map[string]*bintree{}},
+	"1635942153_add_telemetry_server_url_to_settings.up.sql": {_1635942153_add_telemetry_server_url_to_settingsUpSql, map[string]*bintree{}},
+	"1635942154_add_backup_setting.up.sql":                   {_1635942154_add_backup_settingUpSql, map[string]*bintree{}},
+	"1637745568_add_auto_message_setting.up.sql":             {_1637745568_add_auto_message_settingUpSql, map[string]*bintree{}},
+	"1640111208_nodeconfig.up.sql":                           {_1640111208_nodeconfigUpSql, map[string]*bintree{}},
+	"doc.go":                                                 {docGo, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.
@@ -1513,7 +1464,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = os.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When network is not healthy, the retry can be helpful, but retry 6 times seems too many and may result in "message jam", lower it to 3.

