### PR TITLE
fix_: final coverage reports merging

### DIFF
--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -114,6 +114,8 @@ fi
 
 echo -e "${GRN}Testing HEAD:${RST} $(git rev-parse HEAD)"
 
+rm -rf ./**/*.coverage.out
+
 for package in ${UNIT_TEST_PACKAGES}; do
   for ((i=1; i<=UNIT_TEST_COUNT; i++)); do
     if ! is_parallelizable "${package}" || [[ "$UNIT_TEST_FAILFAST" == 'true' ]]; then
@@ -132,9 +134,9 @@ for package in ${UNIT_TEST_PACKAGES}; do
 done
 
 # Gather test coverage results
+rm -f c.out
 echo "mode: atomic" > c.out
-grep -h -v "^mode:" ./**/*.coverage.out >> c.out
-rm -rf ./**/*.coverage.out
+grep -r -h -v "^mode:" --include "*.coverage.out" >> c.out
 
 if [[ $UNIT_TEST_REPORT_CODECLIMATE == 'true' ]]; then
   # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds

--- a/_assets/scripts/test-with-coverage.sh
+++ b/_assets/scripts/test-with-coverage.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eu
-coverage_file_path="${PACKAGE_DIR}/$(mktemp coverage.out.rerun.XXXXXXXXXX)"
+coverage_file_path="$(mktemp coverage.out.rerun.XXXXXXXXXX --tmpdir="${PACKAGE_DIR}")"
 go test -json \
   -covermode=atomic \
   -coverprofile="${coverage_file_path}" \


### PR DESCRIPTION
For some reason `grep ./**/*.coverage.out` didn't work during the `make test` call, it just didn't find any files.
I was able to reproduce this locally. And if I run this line manually after running `make test`, it works for me.

This lead to some reports loss, e.g. `wallet` tests were not in the final report, although the test was executed:
https://github.com/status-im/status-go/pull/5312

Anyway, using internal `grep` wildcards is better I believe.

Also fixed a few minor things:
- only create the temp rerun report in the package directory (it was duplicating in the repo root as well)
- remove coverage reports before running tests, not after