### PR TITLE
fix(dapps) bring back missing wallet_connect_dapps migration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 */**/.DS_Store
 .ethtest
 */**/*tx_database*
-*/**/*dapps*
 vendor/github.com/ethereum/go-ethereum/vendor
 node_modules/
 tags

--- a/walletdatabase/migrations/sql/1716912885_add_wallet_connect_dapps.up.sql
+++ b/walletdatabase/migrations/sql/1716912885_add_wallet_connect_dapps.up.sql
@@ -1,0 +1,21 @@
+-- wallet_connect_dapps table keeps track of connected dApps to provide a link to their individual sessions
+CREATE TABLE IF NOT EXISTS wallet_connect_dapps (
+    url TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    icon_url TEXT
+) WITHOUT ROWID;
+
+DROP TABLE wallet_connect_sessions;
+
+-- wallet_connect_sessions table keeps track of connected sessions for each dApp
+CREATE TABLE wallet_connect_sessions (
+    topic TEXT PRIMARY KEY NOT NULL,
+    disconnected BOOLEAN NOT NULL,
+    session_json JSON NOT NULL,
+    expiry INTEGER NOT NULL,
+    created_timestamp INTEGER NOT NULL,
+    pairing_topic TEXT NOT NULL,
+    test_chains BOOLEAN NOT NULL,
+    dapp_url TEXT NOT NULL,
+    FOREIGN KEY (dapp_url) REFERENCES wallet_connect_dapps(url)
+) WITHOUT ROWID;


### PR DESCRIPTION
The file was missing from the original commit due to the ignore rule in the .gitignore file. Therefore I removed the ignore `dapps` files rule and restored the file from the `bindata.go`

I run the `go generate ./walletdatabase/migrations/sql` which didn't affect the `bindata.go` so all things should be back to normal after we merge this PR.

Original commit `36273bc9b2b0a148d4e2439811a211e70391c14e`