### PR TITLE
Include test coverage from all packages

### DIFF
--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -135,8 +135,7 @@ done
 
 # Gather test coverage results
 rm -f c.out
-echo "mode: atomic" > c.out
-grep -r -h -v "^mode:" --include "*.coverage.out" >> c.out
+go run ./cmd/test-coverage-utils/gocovmerge.go $(find -iname "*.coverage.out") >> c.out
 
 if [[ $UNIT_TEST_REPORT_CODECLIMATE == 'true' ]]; then
   # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds

--- a/_assets/scripts/test-with-coverage.sh
+++ b/_assets/scripts/test-with-coverage.sh
@@ -4,4 +4,5 @@ coverage_file_path="$(mktemp coverage.out.rerun.XXXXXXXXXX --tmpdir="${PACKAGE_D
 go test -json \
   -covermode=atomic \
   -coverprofile="${coverage_file_path}" \
+  -coverpkg ./... \
   "$@"


### PR DESCRIPTION
Fixes https://github.com/status-im/status-go/issues/5389

The problem was that during `protocol` tests we also cover lines from other packages, e.g. `server` in this case.
`--coverpkg` flag + smart merging reports with `gocovmerge` fixes the issue.

Fixes the issue for https://github.com/status-im/status-go/pull/5336 (tested in this PR and dropped the commits after):

<img width="1046" alt="image" src="https://github.com/status-im/status-go/assets/25482501/7993517c-96bf-4420-8bdc-abaec4915225">

