### PR TITLE
feat(ci)_: use s5cmd instead of s3cmd

### DIFF
--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
   options {
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 40, unit: 'MINUTES')
+    ansiColor('xterm')
     disableConcurrentBuilds()
     /* Go requires a certain directory structure */
     checkoutToSubdirectory('src/github.com/status-im/status-go')

--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -19,6 +19,7 @@ pipeline {
 
   options {
     timestamps()
+    ansiColor('xterm')
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 10, unit: 'MINUTES')
     disableConcurrentBuilds()

--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.18'
+library 'status-jenkins-lib@v1.9.0'
 
 pipeline {
   agent { label 'linux && x86_64 && nix-2.19' }
@@ -64,7 +64,7 @@ pipeline {
 
     stage('Upload') {
       steps { script {
-        env.PKG_URL = s3.uploadArtifact(ARTIFACT)
+        env.PKG_URL = s5cmd.upload(ARTIFACT)
       } }
     }
   } // stages

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -19,6 +19,7 @@ pipeline {
 
   options {
     timestamps()
+    ansiColor('xterm')
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 10, unit: 'MINUTES')
     disableConcurrentBuilds()

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.18'
+library 'status-jenkins-lib@v1.9.0'
 
 pipeline {
   agent { label 'macos && aarch64 && xcode-15.1 && nix-2.19' }

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -19,6 +19,7 @@ pipeline {
 
   options {
     timestamps()
+    ansiColor('xterm')
     /* Prevent Jenkins jobs from running forever */
     timeout(time: 10, unit: 'MINUTES')
     disableConcurrentBuilds()

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.8.18'
+library 'status-jenkins-lib@v1.9.0'
 
 pipeline {
   agent { label 'linux && x86_64 && nix-2.19' }
@@ -71,7 +71,7 @@ pipeline {
 
     stage('Upload') {
       steps { script {
-        env.PKG_URL = s3.uploadArtifact(ARTIFACT)
+        env.PKG_URL = s5cmd.upload(ARTIFACT)
       } }
     }
   } // stages

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -39,6 +39,7 @@ pipeline {
 
   options {
     timestamps()
+    ansiColor('xterm')
     /* Prevent Jenkins jobs from running forever */
     timeout(time: getDefaultTimeout(), unit: 'MINUTES')
     disableConcurrentBuilds()


### PR DESCRIPTION
It's actively maintained and has better concurrency support.

Depends on:
- https://github.com/status-im/status-jenkins-lib/pull/92