### PR TITLE
Fix messages sent from an account with an emoji ENS name

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -66,9 +66,5 @@ func IsENSName(displayName string) bool {
 		return false
 	}
 
-	if strings.HasSuffix(displayName, ".eth") {
-		return true
-	}
-
-	return false
+	return strings.HasSuffix(displayName, ".eth")
 }

--- a/protocol/messenger_backup_handler.go
+++ b/protocol/messenger_backup_handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
+	utils "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/multiaccounts/errors"
 	"github.com/status-im/status-go/multiaccounts/settings"
@@ -111,6 +112,10 @@ func (m *Messenger) handleBackedUpProfile(message *protobuf.BackedUpProfile, bac
 
 	response := wakusync.WakuBackedUpDataResponse{
 		Profile: &wakusync.BackedUpProfile{},
+	}
+
+	if err := utils.ValidateDisplayName(&message.DisplayName); err != nil {
+		return err
 	}
 
 	err := m.SaveSyncDisplayName(message.DisplayName, message.DisplayNameClock)

--- a/protocol/messenger_backup_test.go
+++ b/protocol/messenger_backup_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/status-im/status-go/protocol/identity"
+	v1protocol "github.com/status-im/status-go/protocol/v1"
 	"github.com/status-im/status-go/protocol/wakusync"
 
 	"github.com/stretchr/testify/suite"
@@ -270,6 +271,31 @@ func (s *MessengerBackupSuite) TestBackupProfile() {
 	s.Require().NoError(err)
 	s.Require().NotEmpty(lastBackup)
 	s.Require().Equal(clock, lastBackup)
+}
+
+func (s *MessengerBackupSuite) TestBackupProfileWithInvalidDisplayName() {
+	// Create bob1
+	bob1 := s.m
+
+	state := ReceivedMessageState{
+		Response: &MessengerResponse{},
+	}
+
+	err := bob1.HandleBackup(
+		&state,
+		&protobuf.Backup{
+			Profile: &protobuf.BackedUpProfile{
+				DisplayName: "bad-display-name_eth",
+			},
+			Clock: 1,
+		},
+		&v1protocol.StatusMessage{},
+	)
+	// The backup will still work, but the display name will be skipped
+	s.Require().NoError(err)
+	storedBob1DisplayName, err := bob1.settings.DisplayName()
+	s.Require().NoError(err)
+	s.Require().Equal("", storedBob1DisplayName)
 }
 
 func (s *MessengerBackupSuite) TestBackupSettings() {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/15284

Somehow, the display name could get messed up and when it happened, no message could be received, because we also validate the display name on reception.

I think the problem for the particular user happened because the special display name was added before we enforced it, or through the sync.

I don't know if we want to do a patch, but I'll at least create this build for the user. I'll cherry-pick later