### PR TITLE
fix(status-cli)_: exit on sigint, actualyl print error log on failure

### DIFF
--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"os"
 	"time"
 
@@ -168,6 +169,6 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		zap.L().Fatal("main", zap.Error(err))
+		log.Fatal(err)
 	}
 }

--- a/cmd/status-cli/simulate.go
+++ b/cmd/status-cli/simulate.go
@@ -21,6 +21,8 @@ func simulate(cCtx *cli.Context) error {
 		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 		<-sig
 		cancel()
+		time.Sleep(1 * time.Second)
+		os.Exit(1)
 	}()
 
 	logger, err := getSLogger(cCtx.Bool(DebugLevel))


### PR DESCRIPTION
This PR makes sure `status-cli simulate` exits when `SIGINT` is sent, even if it is stuck at waiting for a channel. 

Also tweaked the logging for the top-level error which was not printed for some reason


