### PR TITLE
fix(manager): make sure createCommunityPermission schedules the reeval

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1449,7 +1449,9 @@ func (m *Manager) ScheduleMembersReevaluation(communityID types.HexBytes) error 
 func (m *Manager) scheduleMembersReevaluation(communityID types.HexBytes, forceImmediateReevaluation bool) error {
 	t, exists := m.membersReevaluationTasks.Load(communityID.String())
 	if !exists {
-		return errors.New("reevaluation task doesn't exist")
+		// No reevaluation task yet. We start the loop which will create it
+		m.StartMembersReevaluationLoop(communityID, true)
+		return nil
 	}
 
 	task, ok := t.(*membersReevaluationTask)

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2739,7 +2739,10 @@ func (m *Messenger) CreateCommunityTokenPermission(request *requests.CreateCommu
 	}
 
 	if community.IsControlNode() {
-		m.communitiesManager.StartMembersReevaluationLoop(community.ID(), true)
+		err = m.communitiesManager.ScheduleMembersReevaluation(community.ID())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// ensure HRkeys are synced


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/15175

The problem was that we used StartMembersReevaluaitonLoop in createCommunityPermission, in case the loop was never started. Indeed it worked if it was the first ever permission, because the loop would then start and members would be re-evaluated.

However, if the loop was already started, in the case where there were previous permissions, the call would just early exit, because it was already started.

The solution here is to use `ScheduleMembersReevaluaiton` like other permission functions use. To make sure a first permission still works, we call startLoop in schedule if the task doesn't exist.

You can see the fixed behavior here (sorry for the long wait, I changed the reeval delay to be 1 minute instead of 5, but it's still something)

[reeval-on-create.webm](https://github.com/status-im/status-go/assets/11926403/54b259d0-db0c-46d0-be20-5eb2d9361a90)

