### PR TITLE
feat_: locally handled methods package base structure

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -1,15 +1,42 @@
 package connector
 
-func NewAPI(s *Service) *API {
-	return &API{
-		s: s,
-	}
-}
+import (
+	"encoding/json"
+	"fmt"
+)
 
 type API struct {
 	s *Service
+	r *CommandRegistry
+}
+
+func NewAPI(s *Service) *API {
+	r := NewCommandRegistry()
+
+	return &API{
+		s: s,
+		r: r,
+	}
+}
+
+type RPCRequest struct {
+	JSONRPC string        `json:"jsonrpc"`
+	ID      int           `json:"id"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
 }
 
 func (api *API) CallRPC(inputJSON string) (string, error) {
+	var request RPCRequest
+
+	err := json.Unmarshal([]byte(inputJSON), &request)
+	if err != nil {
+		return "", fmt.Errorf("error unmarshalling JSON: %v", err)
+	}
+
+	if command, exists := api.r.GetCommand(request.Method); exists {
+		return command.Execute(inputJSON)
+	}
+
 	return api.s.rpcClient.CallRaw(inputJSON), nil
 }

--- a/services/connector/command_registry.go
+++ b/services/connector/command_registry.go
@@ -1,0 +1,20 @@
+package connector
+
+type CommandRegistry struct {
+	commands map[string]RPCCommand
+}
+
+func NewCommandRegistry() *CommandRegistry {
+	return &CommandRegistry{
+		commands: make(map[string]RPCCommand),
+	}
+}
+
+func (r *CommandRegistry) Register(method string, command RPCCommand) {
+	r.commands[method] = command
+}
+
+func (r *CommandRegistry) GetCommand(method string) (RPCCommand, bool) {
+	command, exists := r.commands[method]
+	return command, exists
+}

--- a/services/connector/rpc_command.go
+++ b/services/connector/rpc_command.go
@@ -1,0 +1,5 @@
+package connector
+
+type RPCCommand interface {
+	Execute(inputJSON string) (string, error)
+}


### PR DESCRIPTION
### Description

fixes [#5417](https://github.com/status-im/status-go/issues/5417)

Connector service aims at handling `eth_` methods received through RPC or WS endpoints. However, some API's must be implemented locally. That's the case for : 

- `eth_sendTransaction`
- `eth_sign`
- `eth_chainId`
- `eth_requestAccounts`
 
This PR is created to implement the base structure for implementing those API's.

Important changes:

- [x] Add local node base structure for `eth*` calls
