### PR TITLE
Router v2 integration

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -94,6 +94,7 @@ func (api *API) StartWallet(ctx context.Context) error {
 }
 
 func (api *API) StopWallet(ctx context.Context) error {
+	api.router.Stop()
 	return api.s.Stop()
 }
 
@@ -507,6 +508,18 @@ func (api *API) GetSuggestedRoutesV2(ctx context.Context, input *router.RouteInp
 	log.Debug("call to GetSuggestedRoutesV2")
 
 	return api.router.SuggestedRoutesV2(ctx, input)
+}
+
+func (api *API) GetSuggestedRoutesV2Async(ctx context.Context, input *router.RouteInputParams) {
+	log.Debug("call to GetSuggestedRoutesV2Async")
+
+	api.router.SuggestedRoutesV2Async(input)
+}
+
+func (api *API) StopSuggestedRoutesV2AsyncCalcualtion(ctx context.Context) {
+	log.Debug("call to StopSuggestedRoutesV2AsyncCalcualtion")
+
+	api.router.StopSuggestedRoutesV2AsyncCalcualtion()
 }
 
 // Generates addresses for the provided paths, response doesn't include `HasActivity` value (if you need it check `GetAddressDetails` function)

--- a/services/wallet/router/errors.go
+++ b/services/wallet/router/errors.go
@@ -24,4 +24,5 @@ var (
 	ErrNotEnoughTokenBalance                     = &errors.ErrorResponse{Code: errors.ErrorCode("WR-016"), Details: "not enough token balance"}
 	ErrNotEnoughNativeBalance                    = &errors.ErrorResponse{Code: errors.ErrorCode("WR-017"), Details: "not enough native balance"}
 	ErrNativeTokenNotFound                       = &errors.ErrorResponse{Code: errors.ErrorCode("WR-018"), Details: "native token not found"}
+	ErrDisabledChainFoundAmongLockedNetworks     = &errors.ErrorResponse{Code: errors.ErrorCode("WR-019"), Details: "disabled chain found among locked networks"}
 )

--- a/services/wallet/router/fees.go
+++ b/services/wallet/router/fees.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/params"
 	gaspriceoracle "github.com/status-im/status-go/contracts/gas-price-oracle"
@@ -25,9 +26,9 @@ const (
 )
 
 type MaxFeesLevels struct {
-	Low    *big.Int `json:"low"`
-	Medium *big.Int `json:"medium"`
-	High   *big.Int `json:"high"`
+	Low    *hexutil.Big `json:"low"`
+	Medium *hexutil.Big `json:"medium"`
+	High   *hexutil.Big `json:"high"`
 }
 
 type SuggestedFees struct {
@@ -59,14 +60,14 @@ func (s *SuggestedFees) feeFor(mode GasFeeMode) *big.Int {
 	}
 
 	if mode == GasFeeLow {
-		return s.MaxFeesLevels.Low
+		return s.MaxFeesLevels.Low.ToInt()
 	}
 
 	if mode == GasFeeHigh {
-		return s.MaxFeesLevels.High
+		return s.MaxFeesLevels.High.ToInt()
 	}
 
-	return s.MaxFeesLevels.Medium
+	return s.MaxFeesLevels.Medium.ToInt()
 }
 
 func (s *SuggestedFeesGwei) feeFor(mode GasFeeMode) *big.Float {
@@ -140,9 +141,9 @@ func (f *FeeManager) SuggestedFees(ctx context.Context, chainID uint64) (*Sugges
 			BaseFee:              big.NewInt(0),
 			MaxPriorityFeePerGas: big.NewInt(0),
 			MaxFeesLevels: &MaxFeesLevels{
-				Low:    big.NewInt(0),
-				Medium: big.NewInt(0),
-				High:   big.NewInt(0),
+				Low:    (*hexutil.Big)(big.NewInt(0)),
+				Medium: (*hexutil.Big)(big.NewInt(0)),
+				High:   (*hexutil.Big)(big.NewInt(0)),
 			},
 			EIP1559Enabled: false,
 		}, nil
@@ -158,9 +159,9 @@ func (f *FeeManager) SuggestedFees(ctx context.Context, chainID uint64) (*Sugges
 		BaseFee:              baseFee,
 		MaxPriorityFeePerGas: maxPriorityFeePerGas,
 		MaxFeesLevels: &MaxFeesLevels{
-			Low:    new(big.Int).Add(baseFee, maxPriorityFeePerGas),
-			Medium: new(big.Int).Add(new(big.Int).Mul(baseFee, big.NewInt(2)), maxPriorityFeePerGas),
-			High:   new(big.Int).Add(new(big.Int).Mul(baseFee, big.NewInt(3)), maxPriorityFeePerGas),
+			Low:    (*hexutil.Big)(new(big.Int).Add(baseFee, maxPriorityFeePerGas)),
+			Medium: (*hexutil.Big)(new(big.Int).Add(new(big.Int).Mul(baseFee, big.NewInt(2)), maxPriorityFeePerGas)),
+			High:   (*hexutil.Big)(new(big.Int).Add(new(big.Int).Mul(baseFee, big.NewInt(3)), maxPriorityFeePerGas)),
 		},
 		EIP1559Enabled: true,
 	}, nil
@@ -175,9 +176,9 @@ func (f *FeeManager) SuggestedFeesGwei(ctx context.Context, chainID uint64) (*Su
 		GasPrice:             weiToGwei(fees.GasPrice),
 		BaseFee:              weiToGwei(fees.BaseFee),
 		MaxPriorityFeePerGas: weiToGwei(fees.MaxPriorityFeePerGas),
-		MaxFeePerGasLow:      weiToGwei(fees.MaxFeesLevels.Low),
-		MaxFeePerGasMedium:   weiToGwei(fees.MaxFeesLevels.Medium),
-		MaxFeePerGasHigh:     weiToGwei(fees.MaxFeesLevels.High),
+		MaxFeePerGasLow:      weiToGwei(fees.MaxFeesLevels.Low.ToInt()),
+		MaxFeePerGasMedium:   weiToGwei(fees.MaxFeesLevels.Medium.ToInt()),
+		MaxFeePerGasHigh:     weiToGwei(fees.MaxFeesLevels.High.ToInt()),
 		EIP1559Enabled:       fees.EIP1559Enabled,
 	}, nil
 }

--- a/services/wallet/router/router_v2.go
+++ b/services/wallet/router/router_v2.go
@@ -94,7 +94,8 @@ type PathV2 struct {
 	ProcessorName  string
 	FromChain      *params.Network    // Source chain
 	ToChain        *params.Network    // Destination chain
-	FromToken      *walletToken.Token // Token on the source chain
+	FromToken      *walletToken.Token // Source token
+	ToToken        *walletToken.Token // Destination token, set if applicable
 	AmountIn       *hexutil.Big       // Amount that will be sent from the source chain
 	AmountInLocked bool               // Is the amount locked
 	AmountOut      *hexutil.Big       // Amount that will be received on the destination chain
@@ -664,6 +665,7 @@ func (r *Router) resolveCandidates(ctx context.Context, input *RouteInputParams)
 						FromChain:      network,
 						ToChain:        dest,
 						FromToken:      token,
+						ToToken:        toToken,
 						AmountIn:       (*hexutil.Big)(amountToSend),
 						AmountInLocked: amountLocked,
 						AmountOut:      (*hexutil.Big)(amountOut),

--- a/services/wallet/router/router_v2.go
+++ b/services/wallet/router/router_v2.go
@@ -16,6 +16,14 @@ import (
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/router/pathprocessor"
 	walletToken "github.com/status-im/status-go/services/wallet/token"
+	"github.com/status-im/status-go/signal"
+)
+
+var (
+	routerTask = async.TaskType{
+		ID:     1,
+		Policy: async.ReplacementPolicyCancelOld,
+	}
 )
 
 var (
@@ -33,6 +41,7 @@ var (
 )
 
 type RouteInputParams struct {
+	Uuid                 string                  `json:"uuid"`
 	SendType             SendType                `json:"sendType" validate:"required"`
 	AddrFrom             common.Address          `json:"addrFrom" validate:"required"`
 	AddrTo               common.Address          `json:"addrTo" validate:"required"`
@@ -106,10 +115,16 @@ func (p *PathV2) Equal(o *PathV2) bool {
 }
 
 type SuggestedRoutesV2 struct {
+	Uuid                  string
 	Best                  []*PathV2
 	Candidates            []*PathV2
 	TokenPrice            float64
 	NativeChainTokenPrice float64
+}
+
+type ErrorResponseWithUUID struct {
+	Uuid          string
+	ErrorResponse error
 }
 
 type GraphV2 = []*NodeV2
@@ -120,6 +135,7 @@ type NodeV2 struct {
 }
 
 func newSuggestedRoutesV2(
+	uuid string,
 	amountIn *big.Int,
 	candidates []*PathV2,
 	fromLockedAmount map[uint64]*hexutil.Big,
@@ -127,6 +143,7 @@ func newSuggestedRoutesV2(
 	nativeChainTokenPrice float64,
 ) *SuggestedRoutesV2 {
 	suggestedRoutes := &SuggestedRoutesV2{
+		Uuid:                  uuid,
 		Candidates:            candidates,
 		Best:                  candidates,
 		TokenPrice:            tokenPrice,
@@ -388,6 +405,9 @@ func validateInputData(input *RouteInputParams) error {
 		totalLockedAmount := big.NewInt(0)
 
 		for chainID, amount := range input.FromLockedAmount {
+			if containsNetworkChainID(chainID, input.DisabledFromChainIDs) {
+				return ErrDisabledChainFoundAmongLockedNetworks
+			}
 			if input.testnetMode {
 				if !supportedTestNetworks[chainID] {
 					return ErrLockedAmountNotSupportedForNetwork
@@ -417,7 +437,34 @@ func validateInputData(input *RouteInputParams) error {
 	return nil
 }
 
+func (r *Router) SuggestedRoutesV2Async(input *RouteInputParams) {
+	r.scheduler.Enqueue(routerTask, func(ctx context.Context) (interface{}, error) {
+		return r.SuggestedRoutesV2(ctx, input)
+	}, func(result interface{}, taskType async.TaskType, err error) {
+		if err != nil {
+			errResponse := &ErrorResponseWithUUID{
+				Uuid:          input.Uuid,
+				ErrorResponse: errors.CreateErrorResponseFromError(err),
+			}
+			signal.SendWalletEvent(signal.SuggestedRoutes, errResponse)
+			return
+		}
+		signal.SendWalletEvent(signal.SuggestedRoutes, result)
+	})
+}
+
+func (r *Router) StopSuggestedRoutesV2AsyncCalcualtion() {
+	r.scheduler.Stop()
+}
+
 func (r *Router) SuggestedRoutesV2(ctx context.Context, input *RouteInputParams) (*SuggestedRoutesV2, error) {
+	testnetMode, err := r.rpcClient.NetworkManager.GetTestNetworksEnabled()
+	if err != nil {
+		return nil, errors.CreateErrorResponseFromError(err)
+	}
+
+	input.testnetMode = testnetMode
+
 	// clear all processors
 	for _, processor := range r.pathProcessors {
 		if clearable, ok := processor.(pathprocessor.PathProcessorClearable); ok {
@@ -425,17 +472,10 @@ func (r *Router) SuggestedRoutesV2(ctx context.Context, input *RouteInputParams)
 		}
 	}
 
-	err := validateInputData(input)
+	err = validateInputData(input)
 	if err != nil {
 		return nil, errors.CreateErrorResponseFromError(err)
 	}
-
-	testnetMode, err := r.rpcClient.NetworkManager.GetTestNetworksEnabled()
-	if err != nil {
-		return nil, errors.CreateErrorResponseFromError(err)
-	}
-
-	input.testnetMode = testnetMode
 
 	candidates, err := r.resolveCandidates(ctx, input)
 	if err != nil {
@@ -467,7 +507,7 @@ func (r *Router) resolveCandidates(ctx context.Context, input *RouteInputParams)
 			continue
 		}
 
-		if containsNetworkChainID(network, input.DisabledFromChainIDs) {
+		if containsNetworkChainID(network.ChainID, input.DisabledFromChainIDs) {
 			continue
 		}
 
@@ -507,11 +547,17 @@ func (r *Router) resolveCandidates(ctx context.Context, input *RouteInputParams)
 			}
 		}
 
-		group.Add(func(c context.Context) error {
+		var fees *SuggestedFees
+		if testsMode {
+			fees = input.testParams.suggestedFees
+		} else {
+			fees, err = r.feesManager.SuggestedFees(ctx, network.ChainID)
 			if err != nil {
-				return errors.CreateErrorResponseFromError(err)
+				continue
 			}
+		}
 
+		group.Add(func(c context.Context) error {
 			for _, pProcessor := range r.pathProcessors {
 				// With the condition below we're eliminating `Swap` as potential path that can participate in calculating the best route
 				// once we decide to inlcude `Swap` in the calculation we need to update `canUseProcessor` function.
@@ -546,7 +592,7 @@ func (r *Router) resolveCandidates(ctx context.Context, input *RouteInputParams)
 						continue
 					}
 
-					if containsNetworkChainID(dest, input.DisabledToChainIDs) {
+					if containsNetworkChainID(dest.ChainID, input.DisabledToChainIDs) {
 						continue
 					}
 
@@ -558,7 +604,7 @@ func (r *Router) resolveCandidates(ctx context.Context, input *RouteInputParams)
 						ToAddr:    input.AddrTo,
 						FromAddr:  input.AddrFrom,
 						AmountIn:  amountToSend,
-						AmountOut: amountToSend,
+						AmountOut: input.AmountOut.ToInt(),
 
 						Username:  input.Username,
 						PublicKey: input.PublicKey,
@@ -604,16 +650,6 @@ func (r *Router) resolveCandidates(ctx context.Context, input *RouteInputParams)
 						}
 
 						l1FeeWei, _ = r.feesManager.GetL1Fee(ctx, network.ChainID, txInputData)
-					}
-
-					var fees *SuggestedFees
-					if testsMode {
-						fees = input.testParams.suggestedFees
-					} else {
-						fees, err = r.feesManager.SuggestedFees(ctx, network.ChainID)
-						if err != nil {
-							continue
-						}
 					}
 
 					amountOut, err := pProcessor.CalculateAmountOut(processorInputParams)
@@ -679,7 +715,7 @@ func (r *Router) resolveRoutes(ctx context.Context, input *RouteInputParams, can
 		}
 	}
 
-	suggestedRoutes = newSuggestedRoutesV2(input.AmountIn.ToInt(), candidates, input.FromLockedAmount, prices[input.TokenID], prices[pathprocessor.EthSymbol])
+	suggestedRoutes = newSuggestedRoutesV2(input.Uuid, input.AmountIn.ToInt(), candidates, input.FromLockedAmount, prices[input.TokenID], prices[pathprocessor.EthSymbol])
 
 	// check the best route for the required balances
 	for _, path := range suggestedRoutes.Best {
@@ -693,12 +729,12 @@ func (r *Router) resolveRoutes(ctx context.Context, input *RouteInputParams, can
 				if input.SendType == ERC1155Transfer {
 					tokenBalance, err = r.getERC1155Balance(ctx, path.FromChain, path.FromToken, input.AddrFrom)
 					if err != nil {
-						return nil, errors.CreateErrorResponseFromError(err)
+						return suggestedRoutes, errors.CreateErrorResponseFromError(err)
 					}
 				} else if input.SendType != ERC721Transfer {
 					tokenBalance, err = r.getBalance(ctx, path.FromChain, path.FromToken, input.AddrFrom)
 					if err != nil {
-						return nil, errors.CreateErrorResponseFromError(err)
+						return suggestedRoutes, errors.CreateErrorResponseFromError(err)
 					}
 				}
 			}
@@ -716,12 +752,12 @@ func (r *Router) resolveRoutes(ctx context.Context, input *RouteInputParams, can
 		} else {
 			nativeToken := r.tokenManager.FindToken(path.FromChain, path.FromChain.NativeCurrencySymbol)
 			if nativeToken == nil {
-				return nil, ErrNativeTokenNotFound
+				return suggestedRoutes, ErrNativeTokenNotFound
 			}
 
 			nativeBalance, err = r.getBalance(ctx, path.FromChain, nativeToken, input.AddrFrom)
 			if err != nil {
-				return nil, errors.CreateErrorResponseFromError(err)
+				return suggestedRoutes, errors.CreateErrorResponseFromError(err)
 			}
 		}
 

--- a/services/wallet/router/router_v2_test.go
+++ b/services/wallet/router/router_v2_test.go
@@ -67,9 +67,9 @@ var (
 		BaseFee:              big.NewInt(testBaseFee),
 		MaxPriorityFeePerGas: big.NewInt(testPriorityFeeLow),
 		MaxFeesLevels: &MaxFeesLevels{
-			Low:    big.NewInt(testPriorityFeeLow),
-			Medium: big.NewInt(testPriorityFeeMedium),
-			High:   big.NewInt(testPriorityFeeHigh),
+			Low:    (*hexutil.Big)(big.NewInt(testPriorityFeeLow)),
+			Medium: (*hexutil.Big)(big.NewInt(testPriorityFeeMedium)),
+			High:   (*hexutil.Big)(big.NewInt(testPriorityFeeHigh)),
 		},
 		EIP1559Enabled: false,
 	}

--- a/services/wallet/router/router_v2_test.go
+++ b/services/wallet/router/router_v2_test.go
@@ -74,9 +74,13 @@ var (
 		EIP1559Enabled: false,
 	}
 
-	testBalanceMap = map[string]*big.Int{
-		pathprocessor.EthSymbol:  big.NewInt(testAmount2ETHInWei),
-		pathprocessor.UsdcSymbol: big.NewInt(testAmount100USDC),
+	testBalanceMapPerChain = map[string]*big.Int{
+		makeTestBalanceKey(walletCommon.EthereumMainnet, pathprocessor.EthSymbol):  big.NewInt(testAmount2ETHInWei),
+		makeTestBalanceKey(walletCommon.EthereumMainnet, pathprocessor.UsdcSymbol): big.NewInt(testAmount100USDC),
+		makeTestBalanceKey(walletCommon.OptimismMainnet, pathprocessor.EthSymbol):  big.NewInt(testAmount2ETHInWei),
+		makeTestBalanceKey(walletCommon.OptimismMainnet, pathprocessor.UsdcSymbol): big.NewInt(testAmount100USDC),
+		makeTestBalanceKey(walletCommon.ArbitrumMainnet, pathprocessor.EthSymbol):  big.NewInt(testAmount2ETHInWei),
+		makeTestBalanceKey(walletCommon.ArbitrumMainnet, pathprocessor.UsdcSymbol): big.NewInt(testAmount100USDC),
 	}
 )
 
@@ -203,9 +207,8 @@ func setupTestNetworkDB(t *testing.T) (*sql.DB, func()) {
 	return db, func() { require.NoError(t, cleanup()) }
 }
 
-func TestRouterV2(t *testing.T) {
-	db, stop := setupTestNetworkDB(t)
-	defer stop()
+func setupRouter(t *testing.T) (*Router, func()) {
+	db, cleanTmpDb := setupTestNetworkDB(t)
 
 	client, _ := rpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, defaultNetworks, db)
 
@@ -238,6 +241,13 @@ func TestRouterV2(t *testing.T) {
 	buyStickers := pathprocessor.NewStickersBuyProcessor(nil, nil, nil)
 	router.AddPathProcessor(buyStickers)
 
+	return router, cleanTmpDb
+}
+
+func TestRouterV2(t *testing.T) {
+	router, cleanTmpDb := setupRouter(t)
+	defer cleanTmpDb()
+
 	tests := []struct {
 		name               string
 		input              *RouteInputParams
@@ -263,7 +273,7 @@ func TestRouterV2(t *testing.T) {
 					},
 					tokenPrices:           testTokenPrices,
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -348,7 +358,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -397,7 +407,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -464,7 +474,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:   testTokenPrices,
 					baseFee:       big.NewInt(testBaseFee),
 					suggestedFees: testSuggestedFees,
-					balanceMap:    testBalanceMap,
+					balanceMap:    testBalanceMapPerChain,
 
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
@@ -514,7 +524,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -582,7 +592,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -620,7 +630,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -658,7 +668,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -696,7 +706,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -752,7 +762,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -790,7 +800,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:   testTokenPrices,
 					baseFee:       big.NewInt(testBaseFee),
 					suggestedFees: testSuggestedFees,
-					balanceMap:    testBalanceMap,
+					balanceMap:    testBalanceMapPerChain,
 
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
@@ -823,7 +833,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -921,7 +931,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -976,7 +986,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1074,7 +1084,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1172,7 +1182,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1206,7 +1216,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1236,7 +1246,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1321,7 +1331,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1370,7 +1380,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1437,7 +1447,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1486,7 +1496,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1554,7 +1564,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1592,7 +1602,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1630,7 +1640,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1668,7 +1678,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1724,7 +1734,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1762,7 +1772,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1791,7 +1801,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1858,7 +1868,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1901,7 +1911,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1956,7 +1966,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -1999,7 +2009,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -2055,7 +2065,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -2086,7 +2096,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -2124,7 +2134,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -2155,7 +2165,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -2199,7 +2209,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -2237,7 +2247,7 @@ func TestRouterV2(t *testing.T) {
 					tokenPrices:           testTokenPrices,
 					baseFee:               big.NewInt(testBaseFee),
 					suggestedFees:         testSuggestedFees,
-					balanceMap:            testBalanceMap,
+					balanceMap:            testBalanceMapPerChain,
 					estimationMap:         testEstimationMap,
 					bonderFeeMap:          testBbonderFeeMap,
 					approvalGasEstimation: testApprovalGasEstimation,
@@ -2264,6 +2274,315 @@ func TestRouterV2(t *testing.T) {
 				for _, c := range routes.Candidates {
 					found := false
 					for _, expC := range tt.expectedCandidates {
+						if c.ProcessorName == expC.ProcessorName &&
+							c.FromChain.ChainID == expC.FromChain.ChainID &&
+							c.ToChain.ChainID == expC.ToChain.ChainID &&
+							c.ApprovalRequired == expC.ApprovalRequired &&
+							(expC.AmountOut == nil || c.AmountOut.ToInt().Cmp(expC.AmountOut.ToInt()) == 0) {
+							found = true
+							break
+						}
+					}
+
+					assert.True(t, found)
+				}
+			}
+		})
+	}
+}
+
+func TestNoBalanceForTheBestRouteRouterV2(t *testing.T) {
+	router, cleanTmpDb := setupRouter(t)
+	defer cleanTmpDb()
+
+	tests := []struct {
+		name               string
+		input              *RouteInputParams
+		expectedCandidates []*PathV2
+		expectedBest       []*PathV2
+		expectedError      error
+	}{
+		{
+			name: "ERC20 transfer - Specific FromChain - Specific ToChain - Not Enough Token Balance",
+			input: &RouteInputParams{
+				testnetMode:          false,
+				SendType:             Transfer,
+				AddrFrom:             common.HexToAddress("0x1"),
+				AddrTo:               common.HexToAddress("0x2"),
+				AmountIn:             (*hexutil.Big)(big.NewInt(testAmount100USDC)),
+				TokenID:              pathprocessor.UsdcSymbol,
+				DisabledFromChainIDs: []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet},
+				DisabledToChainIDs:   []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet},
+
+				testsMode: true,
+				testParams: &routerTestParams{
+					tokenFrom: &token.Token{
+						ChainID:  1,
+						Symbol:   pathprocessor.UsdcSymbol,
+						Decimals: 6,
+					},
+					tokenPrices:           testTokenPrices,
+					suggestedFees:         testSuggestedFees,
+					balanceMap:            map[string]*big.Int{},
+					estimationMap:         testEstimationMap,
+					bonderFeeMap:          testBbonderFeeMap,
+					approvalGasEstimation: testApprovalGasEstimation,
+					approvalL1Fee:         testApprovalL1Fee,
+				},
+			},
+			expectedError: ErrNotEnoughTokenBalance,
+			expectedCandidates: []*PathV2{
+				{
+					ProcessorName:         pathprocessor.ProcessorTransferName,
+					FromChain:             &optimism,
+					ToChain:               &optimism,
+					ApprovalRequired:      false,
+					requiredTokenBalance:  big.NewInt(testAmount100USDC),
+					requiredNativeBalance: big.NewInt((testBaseFee + testPriorityFeeLow) * testApprovalGasEstimation),
+				},
+			},
+		},
+		{
+			name: "ERC20 transfer - Specific FromChain - Specific ToChain - Not Enough Native Balance",
+			input: &RouteInputParams{
+				testnetMode:          false,
+				SendType:             Transfer,
+				AddrFrom:             common.HexToAddress("0x1"),
+				AddrTo:               common.HexToAddress("0x2"),
+				AmountIn:             (*hexutil.Big)(big.NewInt(testAmount100USDC)),
+				TokenID:              pathprocessor.UsdcSymbol,
+				DisabledFromChainIDs: []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet},
+				DisabledToChainIDs:   []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet},
+
+				testsMode: true,
+				testParams: &routerTestParams{
+					tokenFrom: &token.Token{
+						ChainID:  1,
+						Symbol:   pathprocessor.UsdcSymbol,
+						Decimals: 6,
+					},
+					tokenPrices:   testTokenPrices,
+					suggestedFees: testSuggestedFees,
+					balanceMap: map[string]*big.Int{
+						makeTestBalanceKey(walletCommon.OptimismMainnet, pathprocessor.UsdcSymbol): big.NewInt(testAmount100USDC),
+					},
+					estimationMap:         testEstimationMap,
+					bonderFeeMap:          testBbonderFeeMap,
+					approvalGasEstimation: testApprovalGasEstimation,
+					approvalL1Fee:         testApprovalL1Fee,
+				},
+			},
+			expectedError: ErrNotEnoughNativeBalance,
+			expectedCandidates: []*PathV2{
+				{
+					ProcessorName:         pathprocessor.ProcessorTransferName,
+					FromChain:             &optimism,
+					ToChain:               &optimism,
+					ApprovalRequired:      false,
+					requiredTokenBalance:  big.NewInt(testAmount100USDC),
+					requiredNativeBalance: big.NewInt((testBaseFee + testPriorityFeeLow) * testApprovalGasEstimation),
+				},
+			},
+		},
+		{
+			name: "ERC20 transfer - No Specific FromChain - Specific ToChain - Not Enough Token Balance Across All Chains",
+			input: &RouteInputParams{
+				testnetMode:        false,
+				SendType:           Transfer,
+				AddrFrom:           common.HexToAddress("0x1"),
+				AddrTo:             common.HexToAddress("0x2"),
+				AmountIn:           (*hexutil.Big)(big.NewInt(testAmount100USDC)),
+				TokenID:            pathprocessor.UsdcSymbol,
+				DisabledToChainIDs: []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet},
+
+				testsMode: true,
+				testParams: &routerTestParams{
+					tokenFrom: &token.Token{
+						ChainID:  1,
+						Symbol:   pathprocessor.UsdcSymbol,
+						Decimals: 6,
+					},
+					tokenPrices:           testTokenPrices,
+					suggestedFees:         testSuggestedFees,
+					balanceMap:            map[string]*big.Int{},
+					estimationMap:         testEstimationMap,
+					bonderFeeMap:          testBbonderFeeMap,
+					approvalGasEstimation: testApprovalGasEstimation,
+					approvalL1Fee:         testApprovalL1Fee,
+				},
+			},
+			expectedError: ErrNotEnoughTokenBalance,
+			expectedCandidates: []*PathV2{
+				{
+					ProcessorName:    pathprocessor.ProcessorBridgeHopName,
+					FromChain:        &mainnet,
+					ToChain:          &optimism,
+					ApprovalRequired: true,
+				},
+				{
+					ProcessorName:    pathprocessor.ProcessorTransferName,
+					FromChain:        &optimism,
+					ToChain:          &optimism,
+					ApprovalRequired: false,
+				},
+				{
+					ProcessorName:    pathprocessor.ProcessorBridgeHopName,
+					FromChain:        &arbitrum,
+					ToChain:          &optimism,
+					ApprovalRequired: true,
+				},
+			},
+		},
+		{
+			name: "ERC20 transfer - No Specific FromChain - Specific ToChain - Enough Token Balance On Arbitrum Chain But Not Enough Native Balance",
+			input: &RouteInputParams{
+				testnetMode:        false,
+				SendType:           Transfer,
+				AddrFrom:           common.HexToAddress("0x1"),
+				AddrTo:             common.HexToAddress("0x2"),
+				AmountIn:           (*hexutil.Big)(big.NewInt(testAmount100USDC)),
+				TokenID:            pathprocessor.UsdcSymbol,
+				DisabledToChainIDs: []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet},
+
+				testsMode: true,
+				testParams: &routerTestParams{
+					tokenFrom: &token.Token{
+						ChainID:  1,
+						Symbol:   pathprocessor.UsdcSymbol,
+						Decimals: 6,
+					},
+					tokenPrices:   testTokenPrices,
+					suggestedFees: testSuggestedFees,
+					balanceMap: map[string]*big.Int{
+						makeTestBalanceKey(walletCommon.ArbitrumMainnet, pathprocessor.UsdcSymbol): big.NewInt(testAmount100USDC + testAmount100USDC),
+					},
+					estimationMap:         testEstimationMap,
+					bonderFeeMap:          testBbonderFeeMap,
+					approvalGasEstimation: testApprovalGasEstimation,
+					approvalL1Fee:         testApprovalL1Fee,
+				},
+			},
+			expectedError: ErrNotEnoughNativeBalance,
+			expectedCandidates: []*PathV2{
+				{
+					ProcessorName:    pathprocessor.ProcessorBridgeHopName,
+					FromChain:        &mainnet,
+					ToChain:          &optimism,
+					ApprovalRequired: true,
+				},
+				{
+					ProcessorName:         pathprocessor.ProcessorTransferName,
+					FromChain:             &optimism,
+					ToChain:               &optimism,
+					ApprovalRequired:      false,
+					requiredTokenBalance:  big.NewInt(testAmount100USDC),
+					requiredNativeBalance: big.NewInt((testBaseFee + testPriorityFeeLow) * testApprovalGasEstimation),
+				},
+				{
+					ProcessorName:    pathprocessor.ProcessorBridgeHopName,
+					FromChain:        &arbitrum,
+					ToChain:          &optimism,
+					ApprovalRequired: true,
+				},
+			},
+		},
+		{
+			name: "ERC20 transfer - No Specific FromChain - Specific ToChain - Enough Token Balance On Arbitrum Chain And Enough Native Balance On Arbitrum Chain",
+			input: &RouteInputParams{
+				testnetMode:        false,
+				SendType:           Transfer,
+				AddrFrom:           common.HexToAddress("0x1"),
+				AddrTo:             common.HexToAddress("0x2"),
+				AmountIn:           (*hexutil.Big)(big.NewInt(testAmount100USDC)),
+				TokenID:            pathprocessor.UsdcSymbol,
+				DisabledToChainIDs: []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet},
+
+				testsMode: true,
+				testParams: &routerTestParams{
+					tokenFrom: &token.Token{
+						ChainID:  1,
+						Symbol:   pathprocessor.UsdcSymbol,
+						Decimals: 6,
+					},
+					tokenPrices:   testTokenPrices,
+					suggestedFees: testSuggestedFees,
+					balanceMap: map[string]*big.Int{
+						makeTestBalanceKey(walletCommon.ArbitrumMainnet, pathprocessor.UsdcSymbol): big.NewInt(testAmount100USDC + testAmount100USDC),
+						makeTestBalanceKey(walletCommon.ArbitrumMainnet, pathprocessor.EthSymbol):  big.NewInt(testAmount1ETHInWei),
+					},
+					estimationMap:         testEstimationMap,
+					bonderFeeMap:          testBbonderFeeMap,
+					approvalGasEstimation: testApprovalGasEstimation,
+					approvalL1Fee:         testApprovalL1Fee,
+				},
+			},
+			expectedCandidates: []*PathV2{
+				{
+					ProcessorName:    pathprocessor.ProcessorBridgeHopName,
+					FromChain:        &mainnet,
+					ToChain:          &optimism,
+					ApprovalRequired: true,
+				},
+				{
+					ProcessorName:         pathprocessor.ProcessorTransferName,
+					FromChain:             &optimism,
+					ToChain:               &optimism,
+					ApprovalRequired:      false,
+					requiredTokenBalance:  big.NewInt(testAmount100USDC),
+					requiredNativeBalance: big.NewInt((testBaseFee + testPriorityFeeLow) * testApprovalGasEstimation),
+				},
+				{
+					ProcessorName:    pathprocessor.ProcessorBridgeHopName,
+					FromChain:        &arbitrum,
+					ToChain:          &optimism,
+					ApprovalRequired: true,
+				},
+			},
+			expectedBest: []*PathV2{
+				{
+					ProcessorName:    pathprocessor.ProcessorBridgeHopName,
+					FromChain:        &arbitrum,
+					ToChain:          &optimism,
+					ApprovalRequired: true,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			routes, err := router.SuggestedRoutesV2(context.Background(), tt.input)
+
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError, err)
+				assert.NotNil(t, routes)
+				assert.Equal(t, len(tt.expectedCandidates), len(routes.Candidates))
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, len(tt.expectedCandidates), len(routes.Candidates))
+				assert.Equal(t, len(tt.expectedBest), len(routes.Best))
+
+				for _, c := range routes.Candidates {
+					found := false
+					for _, expC := range tt.expectedCandidates {
+						if c.ProcessorName == expC.ProcessorName &&
+							c.FromChain.ChainID == expC.FromChain.ChainID &&
+							c.ToChain.ChainID == expC.ToChain.ChainID &&
+							c.ApprovalRequired == expC.ApprovalRequired &&
+							(expC.AmountOut == nil || c.AmountOut.ToInt().Cmp(expC.AmountOut.ToInt()) == 0) {
+							found = true
+							break
+						}
+					}
+
+					assert.True(t, found)
+				}
+
+				for _, c := range routes.Best {
+					found := false
+					for _, expC := range tt.expectedBest {
 						if c.ProcessorName == expC.ProcessorName &&
 							c.FromChain.ChainID == expC.FromChain.ChainID &&
 							c.ToChain.ChainID == expC.ToChain.ChainID &&

--- a/services/wallet/transfer/transaction_manager_multitransaction.go
+++ b/services/wallet/transfer/transaction_manager_multitransaction.go
@@ -68,7 +68,7 @@ func (tm *TransactionManager) SendTransactionForSigningToKeycard(ctx context.Con
 		return err
 	}
 
-	signal.SendTransactionsForSigningEvent(hashes)
+	signal.SendWalletEvent(signal.SignTransactions, hashes)
 
 	return nil
 }

--- a/services/wallet/walletevent/transmitter.go
+++ b/services/wallet/walletevent/transmitter.go
@@ -48,7 +48,7 @@ func (tmr *SignalsTransmitter) Start() error {
 				return
 			case event := <-events:
 				if !event.Type.IsInternal() {
-					signal.SendWalletEvent(event)
+					signal.SendWalletEvent(signal.Wallet, event)
 				}
 			}
 		}

--- a/signal/events_wallet.go
+++ b/signal/events_wallet.go
@@ -1,19 +1,13 @@
 package signal
 
+type SignalType string
+
 const (
-	walletEvent = "wallet"
+	Wallet           = SignalType("wallet")
+	SignTransactions = SignalType("wallet.sign.transactions")
 )
 
-type UnsignedTransactions struct {
-	Type         string   `json:"type"`
-	Transactions []string `json:"transactions"`
-}
-
 // SendWalletEvent sends event from services/wallet/events.
-func SendWalletEvent(event interface{}) {
-	send(walletEvent, event)
-}
-
-func SendTransactionsForSigningEvent(transactions []string) {
-	send(walletEvent, UnsignedTransactions{Type: "sing-transactions", Transactions: transactions})
+func SendWalletEvent(signalType SignalType, event interface{}) {
+	send(string(signalType), event)
 }

--- a/signal/events_wallet.go
+++ b/signal/events_wallet.go
@@ -5,6 +5,7 @@ type SignalType string
 const (
 	Wallet           = SignalType("wallet")
 	SignTransactions = SignalType("wallet.sign.transactions")
+	SuggestedRoutes  = SignalType("wallet.suggested.routes")
 )
 
 // SendWalletEvent sends event from services/wallet/events.


### PR DESCRIPTION
What's done in this PR:
- `GetSuggestedRoutesV2Async` exposed via `wallet` API which calculates the best route in an async way and notifies the client via `"wallet.suggested.routes"` signal
- Old wallet event with signal type `"wallet"` and event type "sign-transaction", like this `{"type":"wallet","event":{"type":"sing-transactions", "transactions":["0x123", ...] .... } }` is now  set to signal type  `"wallet.sign.transactions"` and looks like this `{"type":"wallet.sign.transactions","event":["0x123", ...] }`
- A ew event type added `"wallet.suggested.routes"`, it carries the best path (list of paths v2) or error (code and description)