### PR TITLE
chore_: exclude cmd from test coverage

### DIFF
--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -135,8 +135,11 @@ for package in ${UNIT_TEST_PACKAGES}; do
 done
 
 # Gather test coverage results
-rm -f c.out
-go run ./cmd/test-coverage-utils/gocovmerge.go $(find -iname "*.coverage.out") >> c.out
+rm -f c.out c-full.out
+go run ./cmd/test-coverage-utils/gocovmerge.go $(find -iname "*.coverage.out") >> c-full.out
+
+# Filter out test coverage for packages in ./cmd
+grep -v '^github.com/status-im/status-go/cmd/' c-full.out > c.out
 
 if [[ $UNIT_TEST_REPORT_CODECLIMATE == 'true' ]]; then
   # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -100,8 +100,6 @@ func init() {
 
 // nolint:gocyclo
 func main() {
-	fmt.Println("this new line doesn't affect test coverage")
-
 	colors := terminal.IsTerminal(int(os.Stdin.Fd()))
 	if err := logutils.OverrideRootLog(true, "ERROR", logutils.FileOptions{}, colors); err != nil {
 		stdlog.Fatalf("Error initializing logger: %v", err)

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -100,6 +100,8 @@ func init() {
 
 // nolint:gocyclo
 func main() {
+	fmt.Println("this new line doesn't affect test coverage")
+
 	colors := terminal.IsTerminal(int(os.Stdin.Fd()))
 	if err := logutils.OverrideRootLog(true, "ERROR", logutils.FileOptions{}, colors); err != nil {
 		stdlog.Fatalf("Error initializing logger: %v", err)


### PR DESCRIPTION
The snow blowers crew agreed that in our case _compile_ is enough for the `./cmd` directory

`./cmd/statusd/ package affects the coverage, because there's `flags_test.go`. As soon as there's at least 1 test in the package, it starts to affect the whole project test coverage. Therefore, this PR is blocked e.g: https://github.com/status-im/status-go/pull/5346
