### PR TITLE
feat(ci)_: add Jenkinsfil for RPC integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -491,7 +491,11 @@ test-verif-proxy-wrapper:
 
 run-integration-tests: SHELL := /bin/sh
 run-integration-tests:
-	docker-compose -f integration-tests/docker-compose.anvil.yml -f integration-tests/docker-compose.test.status-go.yml up --remove-orphans --build
+	docker-compose -f integration-tests/docker-compose.anvil.yml -f integration-tests/docker-compose.test.status-go.yml up -d --build --remove-orphans; \
+	docker-compose -f integration-tests/docker-compose.anvil.yml -f integration-tests/docker-compose.test.status-go.yml logs -f tests-rpc; \
+	exit_code=$$(docker inspect integration-tests_tests-rpc_1 -f '{{.State.ExitCode}}'); \
+	docker-compose -f integration-tests/docker-compose.anvil.yml -f integration-tests/docker-compose.test.status-go.yml down; \
+	exit $$exit_code
 
 run-anvil: SHELL := /bin/sh
 run-anvil:

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer="support@status.im"
 LABEL source="https://github.com/status-im/status-go"
 LABEL description="status-go is an underlying part of Status - a browser, messenger, and gateway to a decentralized world."
 
-RUN apk add --no-cache ca-certificates bash libgcc libstdc++
+RUN apk add --no-cache ca-certificates bash libgcc libstdc++ curl
 RUN mkdir -p /static/keys
 RUN mkdir -p /static/configs
 

--- a/_assets/ci/Jenkinsfile.tests-rpc
+++ b/_assets/ci/Jenkinsfile.tests-rpc
@@ -1,0 +1,57 @@
+library 'status-jenkins-lib@v1.8.17'
+
+pipeline {
+  agent { label 'linux && x86_64 && nix-2.19' }
+
+  parameters {
+    string(
+      name: 'BRANCH',
+      defaultValue: 'develop',
+      description: 'Name of branch to build.'
+    )
+  }
+
+  options {
+    timestamps()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 30, unit: 'MINUTES')
+    disableConcurrentBuilds()
+    /* manage how many builds we keep */
+    buildDiscarder(logRotator(
+      numToKeepStr: '5',
+      daysToKeepStr: '30',
+      artifactNumToKeepStr: '1',
+    ))
+  }
+
+  environment {
+    PLATFORM = 'tests-rpc'
+    PKG_URL = "${currentBuild.absoluteUrl}/consoleText"
+  }
+
+  stages {
+    stage('RPC Tests') {
+      steps { script {
+        sh 'make run-integration-tests'
+      } }
+    }
+  } // stages
+
+  post {
+    always {
+      script {
+        archiveArtifacts artifacts: '**/results.xml', allowEmptyArchive: true
+
+        junit(
+          testResults: '**/results.xml',
+          skipOldReports: true,
+          skipPublishingChecks: true,
+          skipMarkingBuildUnstable: true
+        )
+      }
+    }
+    success { script { github.notifyPR(true) } }
+    failure { script { github.notifyPR(false) } }
+    cleanup { sh "make git-clean" }
+  } // post
+} // pipeline

--- a/api/default_test.go
+++ b/api/default_test.go
@@ -9,16 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOverrideApiConfig(t *testing.T) {
+func setupConfigs() (*params.NodeConfig, *requests.APIConfig) {
 	newNodeConfig := &params.NodeConfig{
-		APIModules:      "test, eth, wakuv2",
-		ConnectorConfig: params.ConnectorConfig{Enabled: true},
-		HTTPEnabled:     true,
-		HTTPHost:        "0.0.0.0",
-		HTTPPort:        8545,
-		WSEnabled:       false,
-		WSHost:          "127.0.0.1",
-		WSPort:          8586,
+		APIModules:       "test, eth, wakuv2",
+		ConnectorConfig:  params.ConnectorConfig{Enabled: true},
+		HTTPEnabled:      true,
+		HTTPHost:         "0.0.0.0",
+		HTTPPort:         8545,
+		HTTPVirtualHosts: []string{"status-go"},
+		WSEnabled:        false,
+		WSHost:           "127.0.0.1",
+		WSPort:           8586,
 	}
 
 	apiConfig := &requests.APIConfig{
@@ -27,11 +28,17 @@ func TestOverrideApiConfig(t *testing.T) {
 		HTTPEnabled:      false,
 		HTTPHost:         "127.0.0.1",
 		HTTPPort:         8080,
+		HTTPVirtualHosts: []string{"*"},
 		WSEnabled:        true,
 		WSHost:           "192.168.0.1",
 		WSPort:           7777,
 	}
 
+	return newNodeConfig, apiConfig
+}
+
+func TestOverrideApiConfig(t *testing.T) {
+	newNodeConfig, apiConfig := setupConfigs()
 	overrideApiConfig(newNodeConfig, apiConfig)
 
 	require.Equal(t, apiConfig.APIModules, newNodeConfig.APIModules)
@@ -39,7 +46,17 @@ func TestOverrideApiConfig(t *testing.T) {
 	require.Equal(t, apiConfig.HTTPEnabled, newNodeConfig.HTTPEnabled)
 	require.Equal(t, apiConfig.HTTPHost, newNodeConfig.HTTPHost)
 	require.Equal(t, apiConfig.HTTPPort, newNodeConfig.HTTPPort)
+	require.Equal(t, apiConfig.HTTPVirtualHosts, newNodeConfig.HTTPVirtualHosts)
 	require.Equal(t, apiConfig.WSEnabled, newNodeConfig.WSEnabled)
 	require.Equal(t, apiConfig.WSHost, newNodeConfig.WSHost)
 	require.Equal(t, apiConfig.WSPort, newNodeConfig.WSPort)
+}
+
+func TestOverrideApiConfigTest(t *testing.T) {
+	newNodeConfig, apiConfig := setupConfigs()
+	newNodeConfig.HTTPVirtualHosts = []string{"status-go"}
+	apiConfig.HTTPVirtualHosts = []string{"*"}
+	overrideApiConfigTest(newNodeConfig, apiConfig)
+
+	require.Equal(t, apiConfig.HTTPVirtualHosts, newNodeConfig.HTTPVirtualHosts)
 }

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -43,6 +43,8 @@ var paths = []string{pathWalletRoot, pathEIP1581, pathDefaultChat, pathDefaultWa
 
 var DefaultFleet = params.FleetShardsTest
 
+var overrideApiConfig = overrideApiConfigProd
+
 func defaultSettings(keyUID string, address string, derivedAddresses map[string]generator.AccountInfo) (*settings.Settings, error) {
 	chatKeyString := derivedAddresses[pathDefaultChat].PublicKey
 
@@ -215,13 +217,14 @@ func buildWalletConfig(request *requests.WalletSecretsConfig) params.WalletConfi
 	return walletConfig
 }
 
-func overrideApiConfig(nodeConfig *params.NodeConfig, config *requests.APIConfig) {
+func overrideApiConfigProd(nodeConfig *params.NodeConfig, config *requests.APIConfig) {
 	nodeConfig.APIModules = config.APIModules
 	nodeConfig.ConnectorConfig.Enabled = config.ConnectorEnabled
 
 	nodeConfig.HTTPEnabled = config.HTTPEnabled
 	nodeConfig.HTTPHost = config.HTTPHost
 	nodeConfig.HTTPPort = config.HTTPPort
+	nodeConfig.HTTPVirtualHosts = config.HTTPVirtualHosts
 
 	nodeConfig.WSEnabled = config.WSEnabled
 	nodeConfig.WSHost = config.WSHost

--- a/api/test_helpers.go
+++ b/api/test_helpers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/protocol/requests"
 
 	"github.com/stretchr/testify/require"
 )
@@ -98,4 +99,14 @@ func setupWalletTest(t *testing.T, password string) (backend *GethStatusBackend,
 	})
 
 	return
+}
+
+// Only for tests
+func overrideApiConfigTest(nodeConfig *params.NodeConfig, config *requests.APIConfig) {
+	overrideApiConfigProd(nodeConfig, config)
+	nodeConfig.HTTPVirtualHosts = config.HTTPVirtualHosts
+}
+
+func OverrideApiConfigTest() {
+	overrideApiConfig = overrideApiConfigTest
 }

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -215,6 +215,7 @@ func main() {
 					HTTPEnabled:      config.HTTPEnabled,
 					HTTPHost:         config.HTTPHost,
 					HTTPPort:         config.HTTPPort,
+					HTTPVirtualHosts: config.HTTPVirtualHosts,
 					WSEnabled:        config.WSEnabled,
 					WSHost:           config.WSHost,
 					WSPort:           config.WSPort,
@@ -224,6 +225,8 @@ func main() {
 				TestOverrideNetworks: config.Networks,
 			},
 		}
+
+		api.OverrideApiConfigTest()
 
 		_, err := backend.RestoreAccountAndLogin(&request)
 		if err != nil {

--- a/integration-tests/Dockerfile.tests-rpc
+++ b/integration-tests/Dockerfile.tests-rpc
@@ -1,0 +1,18 @@
+FROM python:3.10.14-slim AS build
+
+RUN apt-get update && apt-get install -y gcc python3-dev
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+COPY requirements.txt .
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+FROM python:3.10.14-slim AS run
+
+ENV PATH="/opt/venv/bin:$PATH"
+COPY --from=build /opt/venv /opt/venv
+
+WORKDIR tests-rpc
+COPY . .
+
+ENTRYPOINT ["pytest"]

--- a/integration-tests/README.MD
+++ b/integration-tests/README.MD
@@ -22,10 +22,10 @@ Integration tests for status-go
 ### Running dev RPC (anvil with contracts)
 - In `integration-tests` run `docker compose -f docker-compose.anvil.yml up --remove-orphans --build`, as result:
     * an [anvil](https://book.getfoundry.sh/reference/anvil/) container with ChainID 31337 exposed on `0.0.0.0:8545` will start running
-    * all Status-im contracts will be deployed to the network
+    * Status-im contracts will be deployed to the network
 
 ### Run tests
-- In `integration-tests` run `docker compose -f docker-compose.anvil.yml -f docker-compose.test.status-go.yml up --remove-orphans`, as result:
+- In `integration-tests` run `docker compose -f docker-compose.anvil.yml -f docker-compose.test.status-go.yml up --build --remove-orphans`, as result:
     * a container with [status-go as daemon](https://github.com/status-im/status-go/issues/5175) will be created with APIModules exposed on `0.0.0.0:3333`
     * status-go will use [anvil](https://book.getfoundry.sh/reference/anvil/) as RPCURL with ChainID 31337 
     * all Status-im contracts will be deployed to the network

--- a/integration-tests/config.json
+++ b/integration-tests/config.json
@@ -7,6 +7,7 @@
     "HTTPEnabled": true,
     "HTTPHost": "0.0.0.0",
     "HTTPPort": 3333,
+    "HTTPVirtualHosts": ["*", "status-go"],
     "APIModules": "eth,admin,wallet",
     "WalletConfig": {
       "Enabled": true

--- a/integration-tests/docker-compose.test.status-go.yml
+++ b/integration-tests/docker-compose.test.status-go.yml
@@ -14,3 +14,21 @@ services:
       - 30303:30303/udp
       - 30304:30304/udp
     entrypoint: ["statusd", "-c", "/static/configs/config.json", "--seed-phrase=test test test test test test test test test test test junk", "--password=Strong12345"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"net_version\",\"params\":[],\"id\":1}' -H 'Content-Type: application/json' http://0.0.0.0:3333 || exit 1"]
+      interval: 5s
+      timeout: 2s
+      retries: 120
+
+  tests-rpc:
+    depends_on:
+      status-go:
+        condition: service_healthy
+      deploy-communities-contracts:
+        condition: service_completed_successfully
+    build:
+      context: .
+      dockerfile: Dockerfile.tests-rpc
+    entrypoint: ["pytest", "-m", "wallet", "--rpc_url=http://status-go:3333"]
+    volumes:
+      - .:/tests-rpc

--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -s -v --tb=short
+addopts = -s -v --tb=short --junitxml=results.xml
 
 markers =
     rpc

--- a/integration-tests/schemas/wallet_getEthereumChains
+++ b/integration-tests/schemas/wallet_getEthereumChains
@@ -8,7 +8,82 @@
             "type": "string"
         },
         "result": {
-            "type": "null"
+            "items": {
+                "properties": {
+                    "Prod": {
+                        "properties": {
+                            "chainColor": {
+                                "type": "string"
+                            },
+                            "chainId": {
+                                "type": "integer"
+                            },
+                            "chainName": {
+                                "type": "string"
+                            },
+                            "enabled": {
+                                "type": "boolean"
+                            },
+                            "fallbackURL": {
+                                "type": "string"
+                            },
+                            "isTest": {
+                                "type": "boolean"
+                            },
+                            "layer": {
+                                "type": "integer"
+                            },
+                            "nativeCurrencyDecimals": {
+                                "type": "integer"
+                            },
+                            "originalFallbackURL": {
+                                "type": "string"
+                            },
+                            "originalRpcUrl": {
+                                "type": "string"
+                            },
+                            "relatedChainId": {
+                                "type": "integer"
+                            },
+                            "rpcUrl": {
+                                "type": "string"
+                            },
+                            "shortName": {
+                                "type": "string"
+                            },
+                            "tokenOverrides": {
+                                "type": "null"
+                            }
+                        },
+                        "required": [
+                            "chainColor",
+                            "chainId",
+                            "chainName",
+                            "enabled",
+                            "fallbackURL",
+                            "isTest",
+                            "layer",
+                            "nativeCurrencyDecimals",
+                            "originalFallbackURL",
+                            "originalRpcUrl",
+                            "relatedChainId",
+                            "rpcUrl",
+                            "shortName",
+                            "tokenOverrides"
+                        ],
+                        "type": "object"
+                    },
+                    "Test": {
+                        "type": "null"
+                    }
+                },
+                "required": [
+                    "Prod",
+                    "Test"
+                ],
+                "type": "object"
+            },
+            "type": "array"
         }
     },
     "required": [

--- a/integration-tests/tests/test_wallet_rpc.py
+++ b/integration-tests/tests/test_wallet_rpc.py
@@ -41,7 +41,7 @@ class TestTransactionRpc(TransactionTestCase):
         
         # how to create schema:
         # from schema_builder import CustomSchemaBuilder
-        # CustomSchemaBuilder("wallet_createMultiTransaction").create_schema(response.json())
+        # CustomSchemaBuilder(method).create_schema(response.json())
         
         with open(f"{option.base_dir}/schemas/wallet_createMultiTransaction", "r") as schema:
             jsonschema.validate(instance=response.json(), schema=json.load(schema))

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -21,14 +21,15 @@ type ImageCropRectangle struct {
 }
 
 type APIConfig struct {
-	APIModules       string `json:"apiModules"`
-	ConnectorEnabled bool   `json:"connectorEnabled"`
-	HTTPEnabled      bool   `json:"httpEnabled"`
-	HTTPHost         string `json:"httpHost"`
-	HTTPPort         int    `json:"httpPort"`
-	WSEnabled        bool   `json:"wsEnabled"`
-	WSHost           string `json:"wsHost"`
-	WSPort           int    `json:"wsPort"`
+	APIModules       string   `json:"apiModules"`
+	ConnectorEnabled bool     `json:"connectorEnabled"`
+	HTTPEnabled      bool     `json:"httpEnabled"`
+	HTTPHost         string   `json:"httpHost"`
+	HTTPPort         int      `json:"httpPort"`
+	HTTPVirtualHosts []string `json:"httpVirtualHosts"`
+	WSEnabled        bool     `json:"wsEnabled"`
+	WSHost           string   `json:"wsHost"`
+	WSPort           int      `json:"wsPort"`
 }
 
 type CreateAccount struct {


### PR DESCRIPTION
This PR will enable status-go RPC integration tests to run against every commit using following workflow:

- spin up anvil
- deploy [communities-contracts ](https://github.com/status-im/communities-contracts)
- deploy[ status-network-token-v2](https://github.com/status-im/status-network-token-v2) 
- build and start status-go as daemon with anvil as RPC endpoint
- run RPC wallet tests

Running time for RPC tests including build time is ~3 minutes, we are committing to keep it reasonable which is less then 5 minutes
More info regarding RPC tests https://github.com/status-im/status-go/pull/5302

Please note, more contracts will be added in future as part of https://github.com/status-im/status-desktop/issues/15148
Please note, more RPC tests including not only wallet will be added in future e.g. https://github.com/status-im/status-go/pull/5413