### PR TITLE
feat_: call telemetry upon error pushing envelope

### DIFF
--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -22,6 +22,7 @@ const APIModulesFlag = "api-modules"
 const TelemetryServerURLFlag = "telemetry-server-url"
 const KeyUIDFlag = "key-uid"
 const DebugLevel = "debug"
+const MessageFailureFlag = "fail"
 
 const RetrieveInterval = 300 * time.Millisecond
 const SendInterval = 1 * time.Second
@@ -63,6 +64,12 @@ var SimulateFlags = append([]cli.Flag{
 		Aliases: []string{"c"},
 		Value:   1,
 		Usage:   "How many messages to sent from each user",
+	},
+	&cli.BoolFlag{
+		Name:    MessageFailureFlag,
+		Aliases: []string{"f"},
+		Usage:   "Causes messages to fail about 25% of the time",
+		Value:   false,
 	},
 }, CommonFlags...)
 

--- a/cmd/status-cli/simulate.go
+++ b/cmd/status-cli/simulate.go
@@ -33,6 +33,7 @@ func simulate(cCtx *cli.Context) error {
 	// Start messengers
 	apiModules := cCtx.String(APIModulesFlag)
 	telemetryUrl := cCtx.String(TelemetryServerURLFlag)
+	failMessages := cCtx.Bool(MessageFailureFlag)
 
 	alice, err := start("Alice", 0, apiModules, telemetryUrl, "", logger.Named("alice"))
 	if err != nil {
@@ -76,13 +77,13 @@ func simulate(cCtx *cli.Context) error {
 		interactiveSendMessageLoop(ctx, alice, charlie)
 	} else {
 		for i := 0; i < cCtx.Int(CountFlag); i++ {
-			err = alice.sendDirectMessage(ctx, fmt.Sprintf("message from alice, number: %d", i+1))
+			err = alice.sendDirectMessage(ctx, fmt.Sprintf("message from alice, number: %d", i+1), failMessages)
 			if err != nil {
 				return err
 			}
 			time.Sleep(WaitingInterval)
 
-			err = charlie.sendDirectMessage(ctx, fmt.Sprintf("message from charlie, number: %d", i+1))
+			err = charlie.sendDirectMessage(ctx, fmt.Sprintf("message from charlie, number: %d", i+1), failMessages)
 			if err != nil {
 				return err
 			}

--- a/multiaccounts/settings/structs.go
+++ b/multiaccounts/settings/structs.go
@@ -208,6 +208,7 @@ type Settings struct {
 	GifFavorites                        *json.RawMessage              `json:"gifs/favorite-gifs"`
 	OpenseaEnabled                      bool                          `json:"opensea-enabled?,omitempty"`
 	TelemetryServerURL                  string                        `json:"telemetry-server-url,omitempty"`
+	TelemetrySendPeriodMs               int                           `json:"telemetry-send-period-ms,omitempty"`
 	LastBackup                          uint64                        `json:"last-backup,omitempty"`
 	BackupEnabled                       bool                          `json:"backup-enabled?,omitempty"`
 	AutoMessageEnabled                  bool                          `json:"auto-message-enabled?,omitempty"`

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -529,7 +529,7 @@ func NewMessenger(
 
 	var telemetryClient *telemetry.Client
 	if c.telemetryServerURL != "" {
-		telemetryClient = telemetry.NewClient(logger, c.telemetryServerURL, c.account.KeyUID, nodeName, version, c.telemetrySendPeriod)
+		telemetryClient = telemetry.NewClient(logger, c.telemetryServerURL, c.account.KeyUID, nodeName, version)
 		if c.wakuService != nil {
 			c.wakuService.SetStatusTelemetryClient(telemetryClient)
 		}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -529,7 +529,7 @@ func NewMessenger(
 
 	var telemetryClient *telemetry.Client
 	if c.telemetryServerURL != "" {
-		telemetryClient = telemetry.NewClient(logger, c.telemetryServerURL, c.account.KeyUID, nodeName, version)
+		telemetryClient = telemetry.NewClient(logger, c.telemetryServerURL, c.account.KeyUID, nodeName, version, c.telemetrySendPeriod)
 		if c.wakuService != nil {
 			c.wakuService.SetStatusTelemetryClient(telemetryClient)
 		}

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -112,8 +112,9 @@ type config struct {
 
 	messengerSignalsHandler MessengerSignalsHandler
 
-	telemetryServerURL string
-	wakuService        *wakuv2.Waku
+	telemetryServerURL  string
+	telemetrySendPeriod time.Duration
+	wakuService         *wakuv2.Waku
 
 	messageResendMinDelay time.Duration
 	messageResendMaxCount int
@@ -258,9 +259,10 @@ func WithAnonMetricsServerConfig(anonMetricsServerConfig *anonmetrics.ServerConf
 	}
 }
 
-func WithTelemetry(serverURL string) Option {
+func WithTelemetry(serverURL string, sendPeriod time.Duration) Option {
 	return func(c *config) error {
 		c.telemetryServerURL = serverURL
+		c.telemetrySendPeriod = sendPeriod
 		return nil
 	}
 }

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -464,7 +464,7 @@ func buildMessengerOptions(
 	}
 
 	if settings.TelemetryServerURL != "" {
-		options = append(options, protocol.WithTelemetry(settings.TelemetryServerURL))
+		options = append(options, protocol.WithTelemetry(settings.TelemetryServerURL, time.Duration(settings.TelemetrySendPeriodMs)*time.Millisecond))
 	}
 
 	if settings.PushNotificationsServerEnabled {

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -1,9 +1,12 @@
 package telemetry
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,14 +16,22 @@ import (
 	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/transport"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 	"github.com/status-im/status-go/wakuv2"
 )
 
-func createMockServer(t *testing.T) *httptest.Server {
+var (
+	testContentTopic = "/waku/1/0x12345679/rfc26"
+)
+
+func createMockServer(t *testing.T, wg *sync.WaitGroup, expectedType TelemetryType) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer wg.Done() // Signal that a request was received
+
 		if r.Method != "POST" {
 			t.Errorf("Expected 'POST' request, got '%s'", r.Method)
 		}
@@ -38,121 +49,166 @@ func createMockServer(t *testing.T) *httptest.Server {
 		if len(received) != 1 {
 			t.Errorf("Unexpected data received: %+v", received)
 		} else {
-			// If the data is as expected, respond with success
-			t.Log("Responding with success")
-			w.WriteHeader(http.StatusOK)
+			if received[0].TelemetryType != expectedType {
+				t.Errorf("Unexpected telemetry type: got %v, want %v", received[0].TelemetryType, expectedType)
+			} else {
+				// If the data is as expected, respond with success
+				t.Log("Responding with success")
+				w.WriteHeader(http.StatusOK)
+			}
 		}
 	}))
 }
 
-func TestClient_ProcessReceivedMessages(t *testing.T) {
-	// Setup a mock server to handle post requests
-	mockServer := createMockServer(t)
-	defer mockServer.Close()
-
-	// Create a client with the mock server URL
+func createClient(t *testing.T, mockServerURL string) *Client {
 	config := zap.NewDevelopmentConfig()
 	config.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	logger, err := config.Build()
 	if err != nil {
 		t.Fatalf("Failed to create logger: %v", err)
 	}
-	client := NewClient(logger, mockServer.URL, "testUID", "testNode", "1.0")
+	return NewClient(logger, mockServerURL, "testUID", "testNode", "1.0", 500*time.Millisecond)
+}
 
-	// Create a telemetry request to send
-	data := ReceivedMessages{
-		Filter: transport.Filter{
-			ChatID:       "testChat",
-			PubsubTopic:  "testTopic",
-			ContentTopic: types.StringToTopic("testContentTopic"),
-		},
-		SSHMessage: &types.Message{
-			Hash:      []byte("hash"),
-			Timestamp: uint32(time.Now().Unix()),
-		},
-		Messages: []*v1protocol.StatusMessage{
-			{
-				ApplicationLayer: v1protocol.ApplicationLayer{
-					ID:   types.HexBytes("123"),
-					Type: 1,
+func withMockServer(t *testing.T, expectedType TelemetryType, testFunc func(t *testing.T, client *Client, wg *sync.WaitGroup)) {
+	var wg sync.WaitGroup
+	wg.Add(1) // Expecting one request
+
+	mockServer := createMockServer(t, &wg, expectedType)
+	defer mockServer.Close()
+
+	client := createClient(t, mockServer.URL)
+
+	testFunc(t, client, &wg)
+
+	// Wait for the request to be received
+	wg.Wait()
+}
+
+func TestClient_ProcessReceivedMessages(t *testing.T) {
+	withMockServer(t, ReceivedMessagesMetric, func(t *testing.T, client *Client, wg *sync.WaitGroup) {
+		// Create a telemetry request to send
+		data := ReceivedMessages{
+			Filter: transport.Filter{
+				ChatID:       "testChat",
+				PubsubTopic:  "testTopic",
+				ContentTopic: types.StringToTopic(testContentTopic),
+			},
+			SSHMessage: &types.Message{
+				Hash:      []byte("hash"),
+				Timestamp: uint32(time.Now().Unix()),
+			},
+			Messages: []*v1protocol.StatusMessage{
+				{
+					ApplicationLayer: v1protocol.ApplicationLayer{
+						ID:   types.HexBytes("123"),
+						Type: 1,
+					},
 				},
 			},
-		},
-	}
-	telemetryData := client.ProcessReceivedMessages(data)
-	telemetryRequest := TelemetryRequest{
-		Id:            1,
-		TelemetryType: ReceivedMessagesMetric,
-		TelemetryData: telemetryData,
-	}
+		}
+		telemetryData := client.ProcessReceivedMessages(data)
+		telemetryRequest := TelemetryRequest{
+			Id:            1,
+			TelemetryType: ReceivedMessagesMetric,
+			TelemetryData: telemetryData,
+		}
 
-	// Send the telemetry request
-	client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+		// Send the telemetry request
+		client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+	})
 }
 
 func TestClient_ProcessReceivedEnvelope(t *testing.T) {
-	// Setup a mock server to handle post requests
-	mockServer := createMockServer(t)
-	defer mockServer.Close()
+	withMockServer(t, ReceivedEnvelopeMetric, func(t *testing.T, client *Client, wg *sync.WaitGroup) {
+		// Create a telemetry request to send
+		envelope := v2protocol.NewEnvelope(&pb.WakuMessage{
+			Payload:      []byte{1, 2, 3, 4, 5},
+			ContentTopic: testContentTopic,
+			Version:      proto.Uint32(0),
+			Timestamp:    proto.Int64(time.Now().Unix()),
+		}, 0, "")
+		telemetryData := client.ProcessReceivedEnvelope(envelope)
+		telemetryRequest := TelemetryRequest{
+			Id:            2,
+			TelemetryType: ReceivedEnvelopeMetric,
+			TelemetryData: telemetryData,
+		}
 
-	// Create a client with the mock server URL
-	config := zap.NewDevelopmentConfig()
-	config.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
-	logger, err := config.Build()
-	if err != nil {
-		t.Fatalf("Failed to create logger: %v", err)
-	}
-	client := NewClient(logger, mockServer.URL, "testUID", "testNode", "1.0")
-
-	// Create a telemetry request to send
-	envelope := v2protocol.NewEnvelope(&pb.WakuMessage{
-		Payload:      []byte{1, 2, 3, 4, 5},
-		ContentTopic: "testContentTopic",
-		Version:      proto.Uint32(0),
-		Timestamp:    proto.Int64(time.Now().Unix()),
-	}, 0, "")
-	telemetryData := client.ProcessReceivedEnvelope(envelope)
-	telemetryRequest := TelemetryRequest{
-		Id:            2,
-		TelemetryType: ReceivedEnvelopeMetric,
-		TelemetryData: telemetryData,
-	}
-
-	// Send the telemetry request
-	client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+		// Send the telemetry request
+		client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+	})
 }
 
 func TestClient_ProcessSentEnvelope(t *testing.T) {
-	// Setup a mock server to handle post requests
-	mockServer := createMockServer(t)
-	defer mockServer.Close()
+	withMockServer(t, SentEnvelopeMetric, func(t *testing.T, client *Client, wg *sync.WaitGroup) {
+		// Create a telemetry request to send
+		sentEnvelope := wakuv2.SentEnvelope{
+			Envelope: v2protocol.NewEnvelope(&pb.WakuMessage{
+				Payload:      []byte{1, 2, 3, 4, 5},
+				ContentTopic: testContentTopic,
+				Version:      proto.Uint32(0),
+				Timestamp:    proto.Int64(time.Now().Unix()),
+			}, 0, ""),
+			PublishMethod: wakuv2.LightPush,
+		}
+		telemetryData := client.ProcessSentEnvelope(sentEnvelope)
+		telemetryRequest := TelemetryRequest{
+			Id:            3,
+			TelemetryType: SentEnvelopeMetric,
+			TelemetryData: telemetryData,
+		}
 
-	// Create a client with the mock server URL
-	config := zap.NewDevelopmentConfig()
-	config.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
-	logger, err := config.Build()
-	if err != nil {
-		t.Fatalf("Failed to create logger: %v", err)
-	}
-	client := NewClient(logger, mockServer.URL, "testUID", "testNode", "1.0")
+		// Send the telemetry request
+		client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+	})
+}
 
-	// Create a telemetry request to send
-	sentEnvelope := wakuv2.SentEnvelope{
-		Envelope: v2protocol.NewEnvelope(&pb.WakuMessage{
+var (
+	testENRBootstrap = "enrtree://AI4W5N5IFEUIHF5LESUAOSMV6TKWF2MB6GU2YK7PU4TYUGUNOCEPW@store.staging.shards.nodes.status.im"
+)
+
+func TestTelemetryUponPublishError(t *testing.T) {
+	withMockServer(t, ErrorSendingEnvelopeMetric, func(t *testing.T, client *Client, wg *sync.WaitGroup) {
+		enrTreeAddress := testENRBootstrap
+		envEnrTreeAddress := os.Getenv("ENRTREE_ADDRESS")
+		if envEnrTreeAddress != "" {
+			enrTreeAddress = envEnrTreeAddress
+		}
+
+		wakuConfig := &wakuv2.Config{}
+		wakuConfig.Port = 0
+		wakuConfig.EnablePeerExchangeClient = true
+		wakuConfig.LightClient = true
+		wakuConfig.EnableDiscV5 = false
+		wakuConfig.DiscV5BootstrapNodes = []string{enrTreeAddress}
+		wakuConfig.DiscoveryLimit = 20
+		wakuConfig.UseShardAsDefaultTopic = true
+		wakuConfig.ClusterID = 16
+		wakuConfig.WakuNodes = []string{enrTreeAddress}
+		wakuConfig.TelemetryServerURL = client.serverURL
+		wakuConfig.TelemetrySendPeriodMs = 500
+		w, err := wakuv2.New(nil, "", wakuConfig, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+
+		client.Start(context.Background())
+		w.SetStatusTelemetryClient(client)
+
+		// Setting this forces the publish function to fail when sending a message
+		w.SkipPublishToTopic(true)
+
+		err = w.Start()
+		require.NoError(t, err)
+
+		msg := &pb.WakuMessage{
 			Payload:      []byte{1, 2, 3, 4, 5},
-			ContentTopic: "testContentTopic",
+			ContentTopic: testContentTopic,
 			Version:      proto.Uint32(0),
 			Timestamp:    proto.Int64(time.Now().Unix()),
-		}, 0, ""),
-		PublishMethod: wakuv2.LightPush,
-	}
-	telemetryData := client.ProcessSentEnvelope(sentEnvelope)
-	telemetryRequest := TelemetryRequest{
-		Id:            3,
-		TelemetryType: SentEnvelopeMetric,
-		TelemetryData: telemetryData,
-	}
+		}
 
-	// Send the telemetry request
-	client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+		// This should result in a single request sent by the telemetry client
+		_, err = w.Send(wakuConfig.DefaultShardPubsubTopic, msg)
+		require.NoError(t, err)
+	})
 }

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -67,7 +67,7 @@ func createClient(t *testing.T, mockServerURL string) *Client {
 	if err != nil {
 		t.Fatalf("Failed to create logger: %v", err)
 	}
-	return NewClient(logger, mockServerURL, "testUID", "testNode", "1.0", 500*time.Millisecond)
+	return NewClient(logger, mockServerURL, "testUID", "testNode", "1.0", WithSendPeriod(500*time.Millisecond))
 }
 
 func withMockServer(t *testing.T, expectedType TelemetryType, testFunc func(t *testing.T, client *Client, wg *sync.WaitGroup)) {

--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	StoreCapacity              int              `toml:",omitempty"`
 	StoreSeconds               int              `toml:",omitempty"`
 	TelemetryServerURL         string           `toml:",omitempty"`
+	TelemetrySendPeriodMs      int              `toml:",omitempty"` // Number of milliseconds to wait between sending requests to telemetry service
 	DefaultShardPubsubTopic    string           `toml:",omitempty"` // Pubsub topic to be used by default for messages that do not have a topic assigned (depending whether sharding is used or not)
 	DefaultShardedPubsubTopics []string         `toml:", omitempty"`
 	UseShardAsDefaultTopic     bool             `toml:",omitempty"`


### PR DESCRIPTION
Sends request to telemetry upon error publishing envelope.

If telemetry is enabled and the publish function set in `func (w *Waku) broadcast()` fails, then the envelope details and resulting error will be pushed to the telemetry client for sending to the service. Also:
- adds configurable telemetry period to determine how much time must pass between each http request made to the telemetry service (for now it's not used when creating the client to make these changes work without having to change desktop). Defaults to 10 seconds.
- adds flag to cli for making ~60% of messages to fail
- includes refactor to avoid blocking routine from #5399 

Important changes:
- [x] Depends on https://github.com/status-im/telemetry/pull/22

Closes #5260
