### PR TITLE
fix(dapps)_: fix bugs and expose wallet_GetWalletConnectActiveSessions API

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -840,6 +840,12 @@ func (api *API) DisconnectWalletConnectSession(ctx context.Context, topic wallet
 	return walletconnect.DisconnectSession(api.s.db, topic)
 }
 
+// GetWalletConnectActiveSessions returns all active wallet connect sessions
+func (api *API) GetWalletConnectActiveSessions(ctx context.Context, validAtTimestamp int64) ([]walletconnect.DBSession, error) {
+	log.Debug("wallet.api.GetWalletConnectActiveSessions")
+	return walletconnect.GetActiveSessions(api.s.db, validAtTimestamp)
+}
+
 // GetWalletConnectDapps returns all active wallet connect dapps
 // Active dApp are those having active sessions (not expired and not disconnected)
 func (api *API) GetWalletConnectDapps(ctx context.Context, validAtTimestamp int64, testChains bool) ([]walletconnect.DBDApp, error) {

--- a/services/wallet/api_test.go
+++ b/services/wallet/api_test.go
@@ -1,0 +1,23 @@
+package wallet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/services/wallet/walletconnect"
+)
+
+// TestAPI_GetWalletConnectActiveSessions tames coverage
+func TestAPI_GetWalletConnectActiveSessions(t *testing.T) {
+	db, close := walletconnect.SetupTestDB(t)
+	defer close()
+	api := &API{
+		s: &Service{db: db},
+	}
+
+	sessions, err := api.GetWalletConnectActiveSessions(context.Background(), 0)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(sessions))
+}

--- a/services/wallet/walletconnect/database.go
+++ b/services/wallet/walletconnect/database.go
@@ -8,13 +8,13 @@ import (
 )
 
 type DBSession struct {
-	Topic            Topic
-	Disconnected     bool
-	SessionJSON      string
-	Expiry           int64
-	CreatedTimestamp int64
-	PairingTopic     Topic
-	TestChains       bool
+	Topic            Topic  `json:"topic"`
+	Disconnected     bool   `json:"disconnected"`
+	SessionJSON      string `json:"sessionJson"`
+	Expiry           int64  `json:"expiry"`
+	CreatedTimestamp int64  `json:"createdTimestamp"`
+	PairingTopic     Topic  `json:"pairingTopic"`
+	TestChains       bool   `json:"testChains"`
 	DBDApp
 }
 

--- a/services/wallet/walletconnect/database_test.go
+++ b/services/wallet/walletconnect/database_test.go
@@ -7,19 +7,9 @@ import (
 	"database/sql"
 
 	"github.com/status-im/status-go/services/wallet/common"
-	"github.com/status-im/status-go/t/helpers"
-	"github.com/status-im/status-go/walletdatabase"
 
 	"github.com/stretchr/testify/require"
 )
-
-func setupTestDB(t *testing.T) (db *sql.DB, close func()) {
-	db, err := helpers.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
-	require.NoError(t, err)
-	return db, func() {
-		require.NoError(t, db.Close())
-	}
-}
 
 type urlOverride *string
 type timestampOverride *int64
@@ -102,7 +92,7 @@ func insertTestData(t *testing.T, db *sql.DB, entries []DBSession) {
 }
 
 func TestInsertUpdateAndGetSession(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	entry := generateTestData(make([]testSession, 1))[0]
@@ -128,7 +118,7 @@ func TestInsertUpdateAndGetSession(t *testing.T) {
 }
 
 func TestInsertAndGetSessionsByPairingTopic(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	generatedSessions := generateTestData(make([]testSession, 4))
@@ -158,7 +148,7 @@ func TestInsertAndGetSessionsByPairingTopic(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	entries := generateTestData(make([]testSession, 3))
@@ -178,7 +168,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestGetActiveSessions(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	// insert two disconnected and three active sessions
@@ -195,7 +185,7 @@ func TestGetActiveSessions(t *testing.T) {
 }
 
 func TestDeleteSession(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	entries := generateTestData(make([]testSession, 3))
@@ -233,7 +223,7 @@ func at(i int) timestampOverride {
 
 // TestGetActiveDapps_JoinWorksAsExpected also validates that GetActiveDapps returns the dapps in the order of the last first time added
 func TestGetActiveDapps_JoinWorksAsExpected(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	not := common.NewAndSet(false)
@@ -262,7 +252,7 @@ func TestGetActiveDapps_JoinWorksAsExpected(t *testing.T) {
 
 // TestGetActiveDapps_ActiveWorksAsExpected tests the combination of disconnected and expired sessions
 func TestGetActiveDapps_ActiveWorksAsExpected(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	not := common.NewAndSet(false)
@@ -290,7 +280,7 @@ func TestGetActiveDapps_ActiveWorksAsExpected(t *testing.T) {
 
 // TestGetActiveDapps_TestChainsWorksAsExpected tests the combination of disconnected and expired sessions
 func TestGetActiveDapps_TestChainsWorksAsExpected(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	not := common.NewAndSet(false)
@@ -316,7 +306,7 @@ func TestGetActiveDapps_TestChainsWorksAsExpected(t *testing.T) {
 
 // TestGetDapps_EmptyDB tests that an empty database will return an empty list
 func TestGetDapps_EmptyDB(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	entries := generateTestData([]testSession{})
@@ -331,7 +321,7 @@ func TestGetDapps_EmptyDB(t *testing.T) {
 
 // TestGetDapps_OrphanDapps tests that missing session will place the dapp at the end
 func TestGetDapps_OrphanDapps(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	not := common.NewAndSet(false)
@@ -357,7 +347,7 @@ func TestGetDapps_OrphanDapps(t *testing.T) {
 }
 
 func TestDisconnectSession(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	not := common.NewAndSet(false)

--- a/services/wallet/walletconnect/testing.go
+++ b/services/wallet/walletconnect/testing.go
@@ -1,0 +1,19 @@
+package walletconnect
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/t/helpers"
+	"github.com/status-im/status-go/walletdatabase"
+)
+
+func SetupTestDB(t *testing.T) (db *sql.DB, close func()) {
+	db, err := helpers.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(t, err)
+	return db, func() {
+		require.NoError(t, db.Close())
+	}
+}

--- a/services/wallet/walletconnect/walletconnect.go
+++ b/services/wallet/walletconnect/walletconnect.go
@@ -191,7 +191,7 @@ func AddSession(db *sql.DB, networks []params.Network, session_json string) erro
 	}
 
 	rowEntry := DBSession{
-		Topic:            session.PairingTopic,
+		Topic:            session.Topic,
 		Disconnected:     false,
 		SessionJSON:      session_json,
 		Expiry:           session.Expiry,

--- a/services/wallet/walletconnect/walletconnect_test.go
+++ b/services/wallet/walletconnect/walletconnect_test.go
@@ -380,7 +380,7 @@ func Test_caip10Accounts(t *testing.T) {
 
 // Test_AddSession validates that the new added session is active (not expired and not disconnected)
 func Test_AddSession(t *testing.T) {
-	db, close := setupTestDB(t)
+	db, close := SetupTestDB(t)
 	defer close()
 
 	// Add session for testnet


### PR DESCRIPTION
### Updates [#15189](https://github.com/status-im/status-desktop/issues/15189)

Required by https://github.com/status-im/status-desktop/pull/15322

Changes

- `HEAD` fix(dapps)_: fix session identity
  - The pairing topic was used instead the topic for the session identity which caused session management issues.
-  `HEAD~1` fix(dapps)_: fix JSON marshaling for `walletconnect.DBSession`
- `HEAD~2` feat(dapps)_: expose `wallet_GetWalletConnectActiveSessions` API