### PR TITLE
fix_: bring back waku tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,11 +358,13 @@ test-unit: export UNIT_TEST_FAILFAST ?= true
 test-unit: export UNIT_TEST_RERUN_FAILS ?= true
 test-unit: export UNIT_TEST_USE_DEVELOPMENT_LOGGER ?= true
 test-unit: export UNIT_TEST_REPORT_CODECLIMATE ?= false
-test-unit: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./... | \
+test-unit: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./... | grep -E '/waku(/.*|$$)|/wakuv2(/.*|$$)') \
+	$(call sh, go list ./... | \
 	grep -v /vendor | \
 	grep -v /t/e2e | \
 	grep -v /t/benchmarks | \
 	grep -v /transactions/fake | \
+	grep -E -v '/waku(/.*|$$)' | \
 	grep -E -v '/wakuv2(/.*|$$)')
 test-unit: export UNIT_TEST_PACKAGES_NOT_PARALLELIZABLE ?= \
 	github.com/status-im/status-go/api \

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -125,6 +125,8 @@ func TestRestartDiscoveryV5(t *testing.T) {
 }
 
 func TestBasicWakuV2(t *testing.T) {
+	t.Skip("test is broken, #5439")
+	
 	enrTreeAddress := testENRBootstrap //"enrtree://AL65EKLJAUXKKPG43HVTML5EFFWEZ7L4LOKTLZCLJASG4DSESQZEC@prod.status.nodes.status.im"
 	envEnrTreeAddress := os.Getenv("ENRTREE_ADDRESS")
 	if envEnrTreeAddress != "" {
@@ -321,6 +323,8 @@ func TestPeerExchange(t *testing.T) {
 }
 
 func TestWakuV2Filter(t *testing.T) {
+	t.Skip("test is broken, #5439")
+
 	enrTreeAddress := testENRBootstrap
 	envEnrTreeAddress := os.Getenv("ENRTREE_ADDRESS")
 	if envEnrTreeAddress != "" {

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -126,7 +126,7 @@ func TestRestartDiscoveryV5(t *testing.T) {
 
 func TestBasicWakuV2(t *testing.T) {
 	t.Skip("test is broken, #5439")
-	
+
 	enrTreeAddress := testENRBootstrap //"enrtree://AL65EKLJAUXKKPG43HVTML5EFFWEZ7L4LOKTLZCLJASG4DSESQZEC@prod.status.nodes.status.im"
 	envEnrTreeAddress := os.Getenv("ENRTREE_ADDRESS")
 	if envEnrTreeAddress != "" {


### PR DESCRIPTION
Run wakuv2 tests. It was (probably by accident) removed here:
- https://github.com/status-im/status-go/pull/4237

Skip broken tests:
- https://github.com/status-im/status-go/issues/5439