### PR TITLE
fix(unfurl)_: The application crashes when generating status user profile link preview

### DIFF
--- a/protocol/linkpreview_unfurler_status.go
+++ b/protocol/linkpreview_unfurler_status.go
@@ -59,8 +59,12 @@ func (u *StatusUnfurler) buildContactData(publicKey string) (*common.StatusConta
 
 	// If no contact found locally, fetch it from waku
 	if contact == nil {
-		if contact, err = u.m.FetchContact(contactID, true); err != nil {
+		contact, err = u.m.FetchContact(contactID, true)
+		if err != nil {
 			return nil, fmt.Errorf("failed to request contact info from mailserver for public key '%s': %w", publicKey, err)
+		}
+		if contact == nil {
+			return nil, fmt.Errorf("contact wasn't found at the store node %s", publicKey)
 		}
 	}
 

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -150,6 +150,8 @@ func (m *StoreNodeRequestManager) FetchCommunities(communities []communities.Com
 	return outErr
 }
 
+// FetchContact - similar to FetchCommunity
+// If a `nil` contact and a `nil` error are returned, it means that the contact wasn't found at the store node.
 func (m *StoreNodeRequestManager) FetchContact(contactID string, opts []StoreNodeRequestOption) (*Contact, StoreNodeRequestStats, error) {
 
 	cfg := buildStoreNodeRequestConfig(opts)

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -633,6 +633,20 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestProfileInfo() {
 	s.fetchProfile(s.bob, s.owner.selfContact.ID, s.owner.selfContact)
 }
 
+func (s *MessengerStoreNodeRequestSuite) TestRequestProfileInfoError() {
+	s.createOwner()
+	defer s.tearDownOwner()
+	// Non-existent contact used by QA team for e2e autotests: (https://github.com/status-im/status-desktop/issues/15297)
+	fetchedContact, err := s.owner.FetchContact("0x04e972b2a794c315e16411fc0930a65bffffe4f885341683f4532fbbd883a447d849ac0be63d6a4f721affa0d0408160974ff831408433972de2c4556ef06d1ae1", true)
+	s.Require().Nil(fetchedContact)
+	s.Require().Nil(err)
+
+	u := "https://status.app/u/iwWACgoKCHNxdWlzaGVyAw==#zQ3shvMPZSyaUbjBjaNpNP1bPGsGpQDp59dZ4Gmz7UEy5o791"
+	response, err := s.owner.UnfurlURLs(nil, []string{u})
+	s.Require().NoError(err)
+	s.Require().Len(response.LinkPreviews, 0)
+}
+
 // TestSequentialUpdates checks that making updates to the community
 // immediately results in new store node fetched information.
 // Before adding storeNodeSubscription we had problems with the test setup that we didn't have a mechanism to wait for store node to


### PR DESCRIPTION

It happened because `FetchContact` returned the contact and the error both nil 

Closes status-im/status-desktop#15297

https://github.com/status-im/status-go/assets/1083341/04f943c6-010c-4636-a860-249d03308638

