### PR TITLE
chore(telemetry)_: add telemetry publish retry

### DIFF
--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -115,7 +115,8 @@ func TestClient_ProcessReceivedMessages(t *testing.T) {
 		}
 
 		// Send the telemetry request
-		client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+		err := client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+		require.NoError(t, err)
 	})
 }
 
@@ -136,7 +137,8 @@ func TestClient_ProcessReceivedEnvelope(t *testing.T) {
 		}
 
 		// Send the telemetry request
-		client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+		err := client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+		require.NoError(t, err)
 	})
 }
 
@@ -160,7 +162,8 @@ func TestClient_ProcessSentEnvelope(t *testing.T) {
 		}
 
 		// Send the telemetry request
-		client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+		err := client.pushTelemetryRequest([]TelemetryRequest{telemetryRequest})
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
Latest change in telemetry client resulted in loss of messages if communication with Telemetry server failed. This PR presents one option to fix it - a new attribute is introduced serving as a cache which is kept in memory in case the communication fails and new telemetry messages are appended to this cache before retrying the communication.

A simple back-off mechanism is also added on retries - it might make sense to switch to exponential back-off and not cap it at 60s, consider this a draft or proposal open for comments/feedback:)

Important changes:
- [x] add telemtryRetryCache
- [x] use Timer instead of Ticker and add simple back-off mechanism
- [x] cap the retry cache size and drop messages from the start of the queue if it reaches the MaxRetryCache to avoid growing the slice indefinitely 
Closes #
