### PR TITLE
fix_: panic when enr exceeds 300 bytes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20240626004844-19a47a1ac1f5
+	github.com/waku-org/go-waku v0.8.1-0.20240628140035-3604bf39ad28
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -2137,8 +2137,8 @@ github.com/waku-org/go-discover v0.0.0-20240506173252-4912704efdc5 h1:4K3IS97Jry
 github.com/waku-org/go-discover v0.0.0-20240506173252-4912704efdc5/go.mod h1:eBHgM6T4EG0RZzxpxKy+rGz/6Dw2Nd8DWxS0lm9ESDw=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20240626004844-19a47a1ac1f5 h1:9UyIIy/IvlJB2nHIXydne6OfNfOWPPL08+XmCI3iEBo=
-github.com/waku-org/go-waku v0.8.1-0.20240626004844-19a47a1ac1f5/go.mod h1:biffO55kWbvfO8jdu/aAPiWcmozrfFKPum4EMFDib+k=
+github.com/waku-org/go-waku v0.8.1-0.20240628140035-3604bf39ad28 h1:7BqEcKgJs9QNzrLlC4jn1opCjGKZxNX2B/AVqhsvwzw=
+github.com/waku-org/go-waku v0.8.1-0.20240628140035-3604bf39ad28/go.mod h1:fHQ6WCSAlTollYHvAeZeO+d7lOYwcvQxHk+DyGLeoMI=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/localnode.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/localnode.go
@@ -23,6 +23,12 @@ func (w *WakuNode) updateLocalNode(localnode *enode.LocalNode, multiaddrs []ma.M
 	options = append(options, wenr.WithUDPPort(udpPort))
 	options = append(options, wenr.WithWakuBitfield(wakuFlags))
 
+	// Reset ENR fields
+	wenr.DeleteField(localnode, wenr.MultiaddrENRField)
+	wenr.DeleteField(localnode, enr.TCP(0).ENRKey())
+	wenr.DeleteField(localnode, enr.IPv4{}.ENRKey())
+	wenr.DeleteField(localnode, enr.IPv6{}.ENRKey())
+
 	if advertiseAddr != nil {
 		// An advertised address disables libp2p address updates
 		// and discv5 predictions
@@ -244,7 +250,6 @@ func selectCircuitRelayListenAddresses(ctx context.Context, addresses []ma.Multi
 
 	return result, nil
 }
-
 
 func filter0Port(addresses []ma.Multiaddr) ([]ma.Multiaddr, error) {
 	var result []ma.Multiaddr

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go
@@ -270,7 +270,7 @@ func New(opts ...WakuNodeOption) (*WakuNode, error) {
 		}
 	}
 
-	w.peerExchange, err = peer_exchange.NewWakuPeerExchange(w.DiscV5(), w.peerConnector, w.peermanager, w.opts.prometheusReg, w.log)
+	w.peerExchange, err = peer_exchange.NewWakuPeerExchange(w.DiscV5(), w.opts.clusterID, w.peerConnector, w.peermanager, w.opts.prometheusReg, w.log)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/enr_cache.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/enr_cache.go
@@ -6,25 +6,40 @@ import (
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
+	wenr "github.com/waku-org/go-waku/waku/v2/protocol/enr"
 	"github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/pb"
 )
 
 // simpleLRU internal uses container/list, which is ring buffer(double linked list)
 type enrCache struct {
 	// using lru, saves us from periodically cleaning the cache to mauintain a certain size
-	data *shardLRU
+	data      *shardLRU
+	clusterID uint16
 }
 
 // err on negative size
-func newEnrCache(size int) *enrCache {
+func newEnrCache(size int, clusterID uint16) *enrCache {
 	inner := newShardLRU(int(size))
 	return &enrCache{
-		data: inner,
+		data:      inner,
+		clusterID: clusterID,
 	}
 }
 
 // updating cache
 func (c *enrCache) updateCache(node *enode.Node) error {
+	if c.clusterID != 0 {
+		rs, err := wenr.RelaySharding(node.Record())
+		if err != nil || rs == nil {
+			// Node does not contain valid shard information, ignoring...
+			return nil
+		}
+
+		if rs.ClusterID != c.clusterID {
+			return nil
+		}
+	}
+
 	currNode := c.data.Get(node.ID())
 	if currNode == nil || node.Seq() > currNode.Seq() {
 		return c.data.Add(node)

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/protocol.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/protocol.go
@@ -54,12 +54,12 @@ type WakuPeerExchange struct {
 // NewWakuPeerExchange returns a new instance of WakuPeerExchange struct
 // Takes an optional peermanager if WakuPeerExchange is being created along with WakuNode.
 // If using libp2p host, then pass peermanager as nil
-func NewWakuPeerExchange(disc *discv5.DiscoveryV5, peerConnector PeerConnector, pm *peermanager.PeerManager, reg prometheus.Registerer, log *zap.Logger, opts ...Option) (*WakuPeerExchange, error) {
+func NewWakuPeerExchange(disc *discv5.DiscoveryV5, clusterID uint16, peerConnector PeerConnector, pm *peermanager.PeerManager, reg prometheus.Registerer, log *zap.Logger, opts ...Option) (*WakuPeerExchange, error) {
 	wakuPX := new(WakuPeerExchange)
 	wakuPX.disc = disc
 	wakuPX.metrics = newMetrics(reg)
 	wakuPX.log = log.Named("wakupx")
-	wakuPX.enrCache = newEnrCache(MaxCacheSize)
+	wakuPX.enrCache = newEnrCache(MaxCacheSize, clusterID)
 	wakuPX.peerConnector = peerConnector
 	wakuPX.pm = pm
 	wakuPX.CommonService = service.NewCommonService()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1015,7 +1015,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240626004844-19a47a1ac1f5
+# github.com/waku-org/go-waku v0.8.1-0.20240628140035-3604bf39ad28
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests


### PR DESCRIPTION
Fixes an issue described in https://github.com/waku-org/go-waku/issues/1138

```
panic: enode: can't sign record: record bigger than 300 bytes

goroutine 2234124 [running]:
github.com/ethereum/go-ethereum/p2p/enode.(*LocalNode).sign(0x2400110e000)
	/Users/prem/Code/status-desktop/vendor/status-go/vendor/github.com/ethereum/go-ethereum/p2p/enode/localnode.go:310 +0x41c
github.com/ethereum/go-ethereum/p2p/enode.(*LocalNode).Node(0x2400110e000)
	/Users/prem/Code/status-desktop/vendor/status-go/vendor/github.com/ethereum/go-ethereum/p2p/enode/localnode.go:122 +0x158
github.com/waku-org/go-discover/discover.(*UDPv5).Self(...)
	/Users/prem/Code/status-desktop/vendor/status-go/vendor/github.com/waku-org/go-discover/discover/v5_udp.go:178
github.com/waku-org/go-discover/discover.(*UDPv5).lookupWorker(0x24003a69d00, 0x2400a81f050, {0x49, 0xc9, 0xc, 0x7b, 0x44, 0x98, 0x4c, 0x96, ...})
	/Users/prem/Code/status-desktop/vendor/status-go/vendor/github.com/waku-org/go-discover/discover/v5_udp.go:313 +0x154
github.com/waku-org/go-discover/discover.(*UDPv5).lookupSelf.(*UDPv5).newLookup.func1(0x45fe71fd67876148?)
	/Users/prem/Code/status-desktop/vendor/status-go/vendor/github.com/waku-org/go-discover/discover/v5_udp.go:296 +0x38
github.com/waku-org/go-discover/discover.(*lookup).query(0x2400e4d5ef0, 0x2400a81f050, 0x240061d4380?)
	/Users/prem/Code/status-desktop/vendor/status-go/vendor/github.com/waku-org/go-discover/discover/lookup.go:144 +0x98
created by github.com/waku-org/go-discover/discover.(*lookup).startQueries in goroutine 546
	/Users/prem/Code/status-desktop/vendor/status-go/vendor/github.com/waku-org/go-discover/discover/lookup.go:126 +0x1d4
SIGABRT: Abnormal termination.
make: *** [run-macos] Abort trap: 6
```