### PR TITLE
fix_: fix swap in routerV2

### DIFF
--- a/services/wallet/router/router_v2.go
+++ b/services/wallet/router/router_v2.go
@@ -94,7 +94,8 @@ type PathV2 struct {
 	ProcessorName  string
 	FromChain      *params.Network    // Source chain
 	ToChain        *params.Network    // Destination chain
-	FromToken      *walletToken.Token // Token on the source chain
+	FromToken      *walletToken.Token // Source token
+	ToToken        *walletToken.Token // Destination token, set if applicable
 	AmountIn       *hexutil.Big       // Amount that will be sent from the source chain
 	AmountInLocked bool               // Is the amount locked
 	AmountOut      *hexutil.Big       // Amount that will be received on the destination chain
@@ -661,6 +662,7 @@ func (r *Router) resolveCandidates(ctx context.Context, input *RouteInputParams)
 						FromChain:      network,
 						ToChain:        dest,
 						FromToken:      token,
+						ToToken:        toToken,
 						AmountIn:       (*hexutil.Big)(amountToSend),
 						AmountInLocked: amountLocked,
 						AmountOut:      (*hexutil.Big)(amountOut),


### PR DESCRIPTION
Part of [#15095](https://github.com/status-im/status-desktop/issues/15095)

Sending Swap transactions was broken due to changes in [this PR](https://github.com/status-im/status-go/pull/5362).

A map was introduced which requires the from/to token symbols to form the key, which wasn't available when sending the Tx. We fix that here.