### PR TITLE
chore_: extract message count from logs

### DIFF
--- a/_assets/scripts/README.md
+++ b/_assets/scripts/README.md
@@ -2,12 +2,12 @@
 
 # extract_logs.go
 
-This script analyzes geth.log files in a specific format and extracts information related to "sent-message" actions. It then prints relevant details such as timestamp, recipients, message ID, message type, and hashes to the console.
+This script analyzes geth.log files in a specific format and extracts information related to "sent-message" actions or received messages. It then prints relevant details such as timestamp, recipients, message ID, message type, and hashes to the console.
 
 ## Usage
 
 ```bash
-go run extract_logs.go <filename>
+go run extract_logs.go -messages -received-message-count <filename>
 ```
 
 It will output in tab separated values (TSV)


### PR DESCRIPTION
This commits extents the script for extracting logs to add the count of messages retrieved from store nodes, those that matched filters/did not, and the count of live messages