### PR TITLE
fix(wallet)_: use consistent invalid timestamp constant 

### DIFF
--- a/services/wallet/collectibles/ownership_db.go
+++ b/services/wallet/collectibles/ownership_db.go
@@ -3,7 +3,6 @@ package collectibles
 import (
 	"database/sql"
 	"fmt"
-	"math"
 	"math/big"
 	"sync"
 
@@ -29,8 +28,6 @@ func NewOwnershipDB(sqlDb *sql.DB) *OwnershipDB {
 		db: sqlDb,
 	}
 }
-
-const unknownUpdateTimestamp = int64(math.MaxInt64)
 
 const selectOwnershipColumns = "chain_id, contract_address, token_id"
 
@@ -565,7 +562,7 @@ func (o *OwnershipDB) GetOwnership(id thirdparty.CollectibleUniqueID) ([]thirdpa
 		LEFT JOIN transfers t ON
 			c.transfer_id = t.hash
 		WHERE
-		c.chain_id = ? AND c.contract_address = ? AND c.token_id = ?`, unknownUpdateTimestamp)
+                c.chain_id = ? AND c.contract_address = ? AND c.token_id = ?`, InvalidTimestamp)
 
 	stmt, err := o.db.Prepare(query)
 	if err != nil {

--- a/services/wallet/collectibles/ownership_db_test.go
+++ b/services/wallet/collectibles/ownership_db_test.go
@@ -271,12 +271,12 @@ func TestUpdateOwnership(t *testing.T) {
 		{
 			Address:     ownerAddress2,
 			Balance:     commonBalanceAddress2,
-			TxTimestamp: unknownUpdateTimestamp,
+			TxTimestamp: InvalidTimestamp,
 		},
 		{
 			Address:     ownerAddress3,
 			Balance:     commonBalanceAddress3,
-			TxTimestamp: unknownUpdateTimestamp,
+			TxTimestamp: InvalidTimestamp,
 		},
 	}
 
@@ -387,7 +387,7 @@ func TestLargeTokenID(t *testing.T) {
 		{
 			Address:     ownerAddress,
 			Balance:     balance,
-			TxTimestamp: unknownUpdateTimestamp,
+			TxTimestamp: InvalidTimestamp,
 		},
 	}
 
@@ -471,10 +471,10 @@ func TestCollectibleTransferID(t *testing.T) {
 	}
 
 	// Even though the first collectible has a TransferID set, since there's no matching entry in the transfers table it
-	// should return unknownUpdateTimestamp
+	// should return InvalidTimestamp
 	firstOwnership, err := oDB.GetOwnership(firstCollectibleID)
 	require.NoError(t, err)
-	require.Equal(t, unknownUpdateTimestamp, firstOwnership[0].TxTimestamp)
+	require.Equal(t, InvalidTimestamp, firstOwnership[0].TxTimestamp)
 
 	trs, _, _ := transfer.GenerateTestTransfers(t, oDB.db, 1, 5)
 	trs[0].To = ownerAddress1


### PR DESCRIPTION
- Replaced `unknownUpdateTimestamp` with `InvalidTimestamp` to maintain consistency.
