### PR TITLE
chore(community)_: reuse createCommunityItem in MarshalJSONWithMediaServer

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -3,6 +3,7 @@ package common
 import (
 	"crypto/ecdsa"
 	"errors"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -70,5 +71,16 @@ func IsENSName(displayName string) bool {
 		return true
 	}
 
+	return false
+}
+
+func IsNil(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	switch reflect.TypeOf(i).Kind() {
+	case reflect.Ptr, reflect.Interface:
+		return reflect.ValueOf(i).IsNil()
+	}
 	return false
 }

--- a/protocol/communities/community_encryption_key_action_test.go
+++ b/protocol/communities/community_encryption_key_action_test.go
@@ -34,7 +34,7 @@ func createTestCommunity(identity *ecdsa.PrivateKey) (*Community, error) {
 		MemberIdentity: identity,
 	}
 
-	return New(config, &TimeSourceStub{}, &DescriptionEncryptorMock{})
+	return New(config, &TimeSourceStub{}, &DescriptionEncryptorMock{}, nil)
 }
 
 func TestCommunityEncryptionKeyActionSuite(t *testing.T) {

--- a/protocol/communities/community_test.go
+++ b/protocol/communities/community_test.go
@@ -444,7 +444,7 @@ func (s *CommunitySuite) TestValidateRequestToJoin() {
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
-			org, err := New(tc.config, &TimeSourceStub{}, &DescriptionEncryptorMock{})
+			org, err := New(tc.config, &TimeSourceStub{}, &DescriptionEncryptorMock{}, nil)
 			s.Require().NoError(err)
 			err = org.ValidateRequestToJoin(tc.signer, tc.request)
 			s.Require().Equal(tc.err, err)
@@ -530,7 +530,7 @@ func (s *CommunitySuite) TestCanPost() {
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			var err error
-			org, err := New(tc.config, &TimeSourceStub{}, &DescriptionEncryptorMock{})
+			org, err := New(tc.config, &TimeSourceStub{}, &DescriptionEncryptorMock{}, nil)
 			s.Require().NoError(err)
 
 			canPost, err := org.CanPost(tc.member, testChatID1, protobuf.ApplicationMetadataMessage_CHAT_MESSAGE)
@@ -927,7 +927,7 @@ func (s *CommunitySuite) buildCommunity(owner *ecdsa.PublicKey) *Community {
 	config.ID = owner
 	config.CommunityDescription = s.buildCommunityDescription()
 
-	org, err := New(config, &TimeSourceStub{}, &DescriptionEncryptorMock{})
+	org, err := New(config, &TimeSourceStub{}, &DescriptionEncryptorMock{}, nil)
 	s.Require().NoError(err)
 	return org
 }

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -60,7 +60,7 @@ func (s *ManagerSuite) buildManagers(ownerVerifier OwnerVerifier) (*Manager, *Ar
 	logger, err := zap.NewDevelopment()
 	s.Require().NoError(err)
 
-	m, err := NewManager(key, "", db, nil, logger, nil, ownerVerifier, nil, &TimeSourceStub{}, nil)
+	m, err := NewManager(key, "", db, nil, logger, nil, ownerVerifier, nil, &TimeSourceStub{}, nil, nil)
 	s.Require().NoError(err)
 	s.Require().NoError(m.Start())
 
@@ -226,7 +226,7 @@ func (s *ManagerSuite) setupManagerForTokenPermissions() (*Manager, *testCollect
 		WithTokenManager(tm),
 	}
 
-	m, err := NewManager(key, "", db, nil, nil, nil, nil, nil, &TimeSourceStub{}, nil, options...)
+	m, err := NewManager(key, "", db, nil, nil, nil, nil, nil, &TimeSourceStub{}, nil, nil, options...)
 	s.Require().NoError(err)
 	s.Require().NoError(m.Start())
 

--- a/protocol/communities/persistence_mapping.go
+++ b/protocol/communities/persistence_mapping.go
@@ -8,6 +8,7 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/common/shard"
+	"github.com/status-im/status-go/server"
 )
 
 func communityToRecord(community *Community) (*CommunityRecord, error) {
@@ -71,8 +72,16 @@ func recordToRequestToJoin(r *RequestToJoinRecord) *RequestToJoin {
 	}
 }
 
-func recordBundleToCommunity(r *CommunityRecordBundle, memberIdentity *ecdsa.PrivateKey, installationID string,
-	logger *zap.Logger, timesource common.TimeSource, encryptor DescriptionEncryptor, initializer func(*Community) error) (*Community, error) {
+func recordBundleToCommunity(
+	r *CommunityRecordBundle,
+	memberIdentity *ecdsa.PrivateKey,
+	installationID string,
+	logger *zap.Logger,
+	timesource common.TimeSource,
+	encryptor DescriptionEncryptor,
+	mediaServer server.MediaServerInterface,
+	initializer func(*Community) error,
+) (*Community, error) {
 	var privateKey *ecdsa.PrivateKey
 	var controlNode *ecdsa.PublicKey
 	var err error
@@ -139,7 +148,7 @@ func recordBundleToCommunity(r *CommunityRecordBundle, memberIdentity *ecdsa.Pri
 		Shard:                               s,
 	}
 
-	community, err := New(config, timesource, encryptor)
+	community, err := New(config, timesource, encryptor, mediaServer)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/communities/persistence_test.go
+++ b/protocol/communities/persistence_test.go
@@ -48,7 +48,7 @@ func (s *PersistenceSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	s.db = &Persistence{db: db, recordBundleToCommunity: func(r *CommunityRecordBundle) (*Community, error) {
-		return recordBundleToCommunity(r, s.identity, "", nil, &TimeSourceStub{}, &DescriptionEncryptorMock{}, nil)
+		return recordBundleToCommunity(r, s.identity, "", nil, &TimeSourceStub{}, &DescriptionEncryptorMock{}, nil, nil)
 	}}
 }
 
@@ -264,7 +264,7 @@ func (s *PersistenceSuite) makeNewCommunity(identity *ecdsa.PrivateKey) *Communi
 		ControlNode:    &comPrivKey.PublicKey,
 		ControlDevice:  true,
 		ID:             &comPrivKey.PublicKey,
-	}, &TimeSourceStub{}, &DescriptionEncryptorMock{})
+	}, &TimeSourceStub{}, &DescriptionEncryptorMock{}, nil)
 	s.NoError(err, "New shouldn't give any error")
 
 	md, err := com.MarshaledDescription()

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -4352,15 +4352,15 @@ func (s *MessengerCommunitiesSuite) sendImageToCommunity(sender *Messenger, chat
 }
 
 func (s *MessengerCommunitiesSuite) TestSerializedCommunities() {
-	community, _ := s.createCommunity()
 	addMediaServer := func(messenger *Messenger) {
 		mediaServer, err := server.NewMediaServer(messenger.database, nil, nil, nil)
 		s.Require().NoError(err)
 		s.Require().NoError(mediaServer.Start())
-		messenger.httpServer = mediaServer
+		messenger.SetMediaServer(mediaServer)
 	}
 	addMediaServer(s.owner)
 
+	community, _ := s.createCommunity()
 	// update community description
 	description := community.Description()
 	identImageName := "small"
@@ -4393,7 +4393,7 @@ func (s *MessengerCommunitiesSuite) TestSerializedCommunities() {
 	s.Len(b.Description().Identity.Images, 1)
 	s.Equal(identImagePayload, b.Description().Identity.Images[identImageName].Payload)
 
-	c, err := s.owner.SerializedCommunities()
+	c, err := s.owner.Communities()
 	s.Require().NoError(err)
 	s.Require().Len(c, 1)
 	d, err := json.Marshal(c)
@@ -4516,17 +4516,16 @@ func (s *MessengerCommunitiesSuite) fetchImage(fullURL string) ([]byte, error) {
 
 func (s *MessengerCommunitiesSuite) TestMemberMessagesHasImageLink() {
 	// GIVEN
-	community, communityChat := s.createCommunity()
-
 	addMediaServer := func(messenger *Messenger) {
 		mediaServer, err := server.NewMediaServer(messenger.database, nil, nil, nil)
 		s.Require().NoError(err)
 		s.Require().NoError(mediaServer.Start())
-		messenger.httpServer = mediaServer
+		messenger.SetMediaServer(mediaServer)
 	}
 	addMediaServer(s.alice)
 	addMediaServer(s.bob)
 	addMediaServer(s.owner)
+	community, communityChat := s.createCommunity()
 
 	request := &requests.RequestToJoinCommunity{CommunityID: community.ID()}
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -491,7 +491,20 @@ func NewMessenger(
 		encryptor: encryptionProtocol,
 	}
 
-	communitiesManager, err := communities.NewManager(identity, installationID, database, encryptionProtocol, logger, ensVerifier, c.communityTokensService, transp, transp, communitiesKeyDistributor, managerOptions...)
+	communitiesManager, err := communities.NewManager(
+		identity,
+		installationID,
+		database,
+		encryptionProtocol,
+		logger,
+		ensVerifier,
+		c.communityTokensService,
+		transp,
+		transp,
+		communitiesKeyDistributor,
+		c.httpServer,
+		managerOptions...,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -923,6 +936,11 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	}
 
 	return response, nil
+}
+
+func (m *Messenger) SetMediaServer(server *server.MediaServer) {
+	m.httpServer = server
+	m.communitiesManager.SetMediaServer(server)
 }
 
 func (m *Messenger) IdentityPublicKey() *ecdsa.PublicKey {

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -137,7 +137,7 @@ func (s *MessengerActivityCenterMessageSuite) TestReplyWithImage() {
 	s.Require().NoError(err)
 	s.Require().NotNil(mediaServer)
 	s.Require().NoError(mediaServer.Start())
-	alice.httpServer = mediaServer
+	alice.SetMediaServer(mediaServer)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4839,22 +4839,6 @@ func (m *Messenger) CreateResponseWithACNotification(communityID string, acType 
 	return response, nil
 }
 
-func (m *Messenger) SerializedCommunities() ([]json.RawMessage, error) {
-	cs, err := m.Communities()
-	if err != nil {
-		return nil, err
-	}
-	res := make([]json.RawMessage, 0, len(cs))
-	for _, c := range cs {
-		b, err := c.MarshalJSONWithMediaServer(m.httpServer)
-		if err != nil {
-			return nil, err
-		}
-		res = append(res, b)
-	}
-	return res, nil
-}
-
 // SendMessageToControlNode sends a message to the control node of the community.
 // use pointer to rawMessage to get the message ID and other updated properties.
 func (m *Messenger) SendMessageToControlNode(community *communities.Community, rawMessage *common.RawMessage) ([]byte, error) {

--- a/protocol/messenger_remove_message_test.go
+++ b/protocol/messenger_remove_message_test.go
@@ -502,7 +502,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageReplyToImage() {
 	s.Require().NotNil(mediaServer)
 	s.Require().NoError(mediaServer.Start())
 
-	theirMessenger.httpServer = mediaServer
+	theirMessenger.SetMediaServer(mediaServer)
 
 	// We reply to our own message with an image
 	imageMessage, err := buildImageWithoutAlbumIDMessage(*theirChat)
@@ -555,7 +555,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageForMeReplyToImage() {
 	s.Require().NotNil(mediaServer)
 	s.Require().NoError(mediaServer.Start())
 
-	theirMessenger.httpServer = mediaServer
+	theirMessenger.SetMediaServer(mediaServer)
 
 	// We reply to our own message with an image
 	imageMessage, err := buildImageWithoutAlbumIDMessage(*theirChat)

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -2269,7 +2269,7 @@ func (s *MessengerSuite) TestSendMessageWithPreviews() {
 	s.Require().NoError(err)
 	err = httpServer.SetPort(9876)
 	s.NoError(err)
-	s.m.httpServer = httpServer
+	s.m.SetMediaServer(httpServer)
 
 	chat := CreatePublicChat("test-chat", s.m.transport)
 	err = s.m.SaveChat(chat)

--- a/protocol/persistence_quoted_message_test.go
+++ b/protocol/persistence_quoted_message_test.go
@@ -217,7 +217,7 @@ func (s *TestMessengerPrepareMessageSuite) Test_WHEN_MessageContainsImage_THEN_P
 	mediaServer, err := server.NewMediaServer(s.m.database, nil, nil, nil)
 	s.Require().NoError(err)
 	s.Require().NoError(mediaServer.Start())
-	s.m.httpServer = mediaServer
+	s.m.SetMediaServer(mediaServer)
 
 	// WHEN: message is prepared
 	loadedMessage, err := s.m.MessageByID(message.ID)

--- a/server/server_media_interface.go
+++ b/server/server_media_interface.go
@@ -1,0 +1,6 @@
+package server
+
+type MediaServerInterface interface {
+	MakeCommunityDescriptionTokenImageURL(communityID, symbol string) string
+	MakeCommunityImageURL(communityID, name string) string
+}

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -395,16 +394,13 @@ func (api *PublicAPI) SetInstallationName(installationID string, name string) er
 }
 
 // Communities returns a list of communities that are stored
-// Deprecated: Use SerializedCommunities instead
 func (api *PublicAPI) Communities(parent context.Context) ([]*communities.Community, error) {
 	return api.service.messenger.Communities()
 }
 
-// SerializedCommunities returns a list of serialized communities.
-// The key difference from the Communities function is that it uses MediaServer
-// to construct image URLs for all the images rather than using base64 encoding.
-func (api *PublicAPI) SerializedCommunities(parent context.Context) ([]json.RawMessage, error) {
-	return api.service.messenger.SerializedCommunities()
+// Deprecated: renamed back to Communities. Should be removed after implementing on all platforms
+func (api *PublicAPI) SerializedCommunities(parent context.Context) ([]*communities.Community, error) {
+	return api.Communities(parent)
 }
 
 // JoinedCommunities returns a list of communities that the user has joined


### PR DESCRIPTION
as per discussion https://github.com/status-im/status-go/pull/5336#discussion_r1639029431

> A quick solution since both marshal functions are so similar is to create a common private function and parameterize what's different. But if the desktop team can adjust to the new endpoint soon(ish) than it's totally fine.

Important changes:

* added CommunityItemBase type
* added createCommunityItem (logic from MarshalJSON) 
* Reuse createCommunityItem in MarshalJSONWithMediaServer. Override `communityItem.CommunityTokensMetadata` `communityItem.Images`

fixes status-im/status-desktop#15340
