### PR TITLE
feat(wallet)_: add new API to restart the wallet reload timer

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -819,3 +819,7 @@ func (api *API) SignTypedDataV4(typedJson string, address string, password strin
 	}
 	return types.HexBytes(sig), err
 }
+
+func (api *API) RestartWalletReloadTimer(ctx context.Context) error {
+	return api.s.reader.Restart()
+}

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -143,6 +143,11 @@ func (r *Reader) Stop() {
 	r.lastWalletTokenUpdateTimestamp = sync.Map{}
 }
 
+func (r *Reader) Restart() error {
+	r.Stop()
+	return r.Start()
+}
+
 func (r *Reader) triggerWalletReload() {
 	r.cancelDelayedWalletReload()
 


### PR DESCRIPTION
- Added `restartWalletReloadTimer` method in `api.go` to expose an API for restarting the wallet reload timer.
- Implemented `Restart` method in `reader.go` to stop and start the wallet reader.
- Updated reader_test.go to comply with minimum test coverage threshold
