### PR TITLE
chore: bring in xcodewrapper nix derivation

### DIFF
--- a/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
+++ b/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
@@ -1,0 +1,50 @@
+{ stdenv, lib, writeShellScriptBin }:
+{ versions ? [ "14.3" "15.1" "15.2" "15.3" ]
+, xcodeBaseDir ? "/Applications/Xcode.app" }:
+
+assert stdenv.isDarwin;
+
+let
+  xcodebuildPath = "${xcodeBaseDir}/Contents/Developer/usr/bin/xcodebuild";
+
+  xcodebuildWrapper = writeShellScriptBin "xcodebuild" ''
+    currentVer="$(${xcodebuildPath} -version | awk 'NR==1{print $2}')"
+    wrapperVers=(${lib.concatStringsSep " " versions})
+
+    for ver in "''${wrapperVers[@]}"; do
+      if [[ "$currentVer" == "$ver" ]]; then
+        # here exec replaces the shell without creating a new process
+        # https://www.gnu.org/software/bash/manual/bash.html#index-exec
+        exec "${xcodebuildPath}" "$@"
+      fi
+    done
+
+    echo "The installed Xcode version ($currentVer) does not match any of the allowed versions: ${lib.concatStringsSep ", " versions}"
+    echo "Please update your local Xcode installation to match one of the allowed versions"
+    exit 1
+  '';
+in
+stdenv.mkDerivation {
+  pname = "xcode-wrapper-plus";
+  version = lib.concatStringsSep "," versions;
+  # Fails in sandbox. Use `--option sandbox relaxed` or `--option sandbox false`.
+  __noChroot = true;
+  buildCommand = ''
+    mkdir -p $out/bin
+    cd $out/bin
+    ln -s "${xcodebuildWrapper}/bin/xcode-select"
+    ln -s /usr/bin/security
+    ln -s /usr/bin/codesign
+    ln -s /usr/bin/xcrun
+    ln -s /usr/bin/plutil
+    ln -s /usr/bin/clang
+    ln -s /usr/bin/lipo
+    ln -s /usr/bin/file
+    ln -s /usr/bin/rev
+    ln -s "${xcodebuildWrapper}/bin/xcodebuild"
+    ln -s "${xcodeBaseDir}/Contents/Developer/Applications/Simulator.app/Contents/MacOS/Simulator"
+
+    cd ..
+    ln -s "${xcodeBaseDir}/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs"
+  '';
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -2,14 +2,15 @@
 , pkgs ? import ./pkgs.nix { inherit config; } }:
 
 let
-  inherit (pkgs) lib stdenv;
+  inherit (pkgs) lib stdenv callPackage;
   /* No Android SDK for Darwin aarch64. */
   isMacM1 = stdenv.isDarwin && stdenv.isAarch64;
+
   /* Lock requires Xcode verison. */
-  xcodeWrapper = pkgs.xcodeenv.composeXcodeWrapper {
-    version = "14.3";
-    allowHigher = true;
+  xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
+      versions = ["14.3" "15.1" "15.2" "15.3" "15.4"];
   };
+
   /* Gomobile also needs the Xcode wrapper. */
   gomobileMod = pkgs.gomobile.override {
     inherit xcodeWrapper;


### PR DESCRIPTION
## Summary
This PR brings in xcode-wrapper nix derivation and doesn't rely on the version in nixpkgs.
There is a fix for this in nixpkgs here -> https://github.com/NixOS/nixpkgs/pull/324248 
We can remove this derivation when this fix is available and backported to a release we use.


Fixes the following issue : 

```
Running phase: unpackPhase
unpacking source archive /nix/store/6pgidabd04p8ggj76j7z948i0dskvd74-source
error: builder for '/nix/store/81hpb4179zgsr5hrw3m8f92bbs8a36fa-xcode-wrapper-plus-14.3.drv' 
failed with exit code 141
error (ignored): error: cannot unlink 
'"/private/tmp/nix-build-golangci-lint-1.54.0.drv-9/source/test/testdata"': Directory not empty
error: build of '/nix/store/81hpb4179zgsr5hrw3m8f92bbs8a36fa-xcode-wrapper-plus-14.3.drv', 
'/nix/store/ahpl1sjw5g633kdcwafz2jjcc5rxz5i3-golangci-lint-1.54.0.drv', 
'/nix/store/h3sj6grz66svlr9rg8w5grkl91x64pk6-gomobile-unstable-2022-05-18.drv', 
'/nix/store/jp500nsqmm7wg3ch6lkp07lf5fg5lixs-go-modvendor-0.5.0.drv', 
'/nix/store/p06sr4p6fb01b55pkkbk68cvfhszr891-cc-test-reporter-0.11.1.drv' failed
make: *** [shell] Error 1
```

reported by @smohamedjavid @plopezlpz 


## Review Notes: 
- execute `make shell` should run without any errors on macOS

