### PR TITLE
fix(communities)_: do not auto-delete tracking SetSignerPubKey transaction

### DIFF
--- a/services/communitytokens/service.go
+++ b/services/communitytokens/service.go
@@ -525,7 +525,7 @@ func (s *Service) SetSignerPubKey(ctx context.Context, chainID uint64, contractA
 		common.Address(txArgs.From),
 		common.HexToAddress(contractAddress),
 		transactions.SetSignerPublicKey,
-		transactions.AutoDelete,
+		transactions.Keep,
 		"",
 	)
 	if err != nil {


### PR DESCRIPTION
Do not auto-delete tracking `SetSignerPubKey` transaction
If `AutoDelete` parameter is set to true, `SetSignerPubKey` transaction will be deleted before `handleWalletEvent` and `handleWalletEvent` will return an error due to non-existing tx

IMPACT:
- ownership change

Closes # https://github.com/status-im/status-desktop/issues/15363
