### PR TITLE
fix(wallet)_: fixed some errors handling that caused provider up/down banner

### DIFF
--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -197,17 +197,13 @@ func (c *ClientWithFallback) Close() {
 }
 
 func isVMError(err error) bool {
-	if strings.HasPrefix(err.Error(), "execution reverted") {
-		return true
-	}
 	if strings.Contains(err.Error(), core.ErrInsufficientFunds.Error()) {
 		return true
 	}
 	for _, vmError := range propagateErrors {
-		if err == vmError {
+		if strings.Contains(err.Error(), vmError.Error()) {
 			return true
 		}
-
 	}
 	return false
 }

--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -584,7 +584,7 @@ func (o *Manager) fetchTokenURI(ctx context.Context, id thirdparty.CollectibleUn
 
 	if err != nil {
 		for _, errorPrefix := range noTokenURIErrorPrefixes {
-			if strings.HasPrefix(err.Error(), errorPrefix) {
+			if strings.Contains(err.Error(), errorPrefix) {
 				// Contract doesn't support "TokenURI" method
 				return "", nil
 			}


### PR DESCRIPTION
Errors can be wrapped (but not with %w) so `HasPrefix` and `errors.Is` can be not enough.

`execution reverted` is on the list of VMErrors so does not need special handling
