### PR TITLE
chore_: skip waku tests as flaky

### DIFF
--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -128,6 +128,8 @@ func TestRestartDiscoveryV5(t *testing.T) {
 }
 
 func TestBasicWakuV2(t *testing.T) {
+	t.Skip("flaky test")
+
 	enrTreeAddress := testStoreENRBootstrap //"enrtree://AL65EKLJAUXKKPG43HVTML5EFFWEZ7L4LOKTLZCLJASG4DSESQZEC@prod.status.nodes.status.im"
 	envEnrTreeAddress := os.Getenv("ENRTREE_ADDRESS")
 	if envEnrTreeAddress != "" {

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -326,6 +326,7 @@ func TestPeerExchange(t *testing.T) {
 }
 
 func TestWakuV2Filter(t *testing.T) {
+	t.Skip("flaky test")
 
 	enrTreeAddress := testBootENRBootstrap
 	envEnrTreeAddress := os.Getenv("ENRTREE_ADDRESS")


### PR DESCRIPTION
It's too flaky 🙁 
```
TestBasicWakuV2: 80.0% (16 of 20 failed)
```

Tracked here:
- https://github.com/status-im/status-go/issues/4105
- https://github.com/status-im/status-go/issues/5488