### PR TITLE
fix(search)_: search now works with Discord import and bridged messages

### DIFF
--- a/protocol/messenger_bridge_message_test.go
+++ b/protocol/messenger_bridge_message_test.go
@@ -100,3 +100,77 @@ func (s *BridgeMessageSuite) TestSendBridgeMessage() {
 	s.Require().Equal(receivedBridgeMessagePayload.MessageID, "456")
 	s.Require().Equal(receivedBridgeMessagePayload.ParentMessageID, "789")
 }
+
+func (s *BridgeMessageSuite) TestSearchForDiscordMessages() {
+	//send bridged message
+	chat := CreatePublicChat("test-chat", s.m.transport)
+	err := s.m.SaveChat(chat)
+	s.NoError(err)
+
+	bridgeMessage := buildTestMessage(*chat)
+	bridgeMessage.ContentType = protobuf.ChatMessage_BRIDGE_MESSAGE
+	bridgeMessage.Payload = &protobuf.ChatMessage_BridgeMessage{
+		BridgeMessage: &protobuf.BridgeMessage{
+			BridgeName:      "discord",
+			UserName:        "user1",
+			UserAvatar:      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAjklEQVR4nOzXwQmFMBAAUZXUYh32ZB32ZB02sxYQQSZGsod55/91WFgSS0RM+SyjA56ZRZhFmEWYRRT6h+M6G16zrxv6fdJpmUWYRbxsYr13dKfanpN0WmYRZhGzXz6AWYRZRIfbaX26fT9Jk07LLMIsosPt9I/dTDotswizCG+nhFmEWYRZhFnEHQAA///z1CFkYamgfQAAAABJRU5ErkJggg==",
+			UserID:          "123",
+			Content:         "bridged discord message",
+			MessageID:       "456",
+			ParentMessageID: "789",
+		},
+	}
+
+	_, err = s.m.SendChatMessage(context.Background(), bridgeMessage)
+	s.NoError(err)
+
+	// Search for the message
+	messages, err := s.m.AllMessageByChatIDWhichMatchTerm(chat.ID, "bridged", true)
+	s.NoError(err)
+	s.Require().Len(messages, 1)
+
+	//send discord import message
+	discordMessage := &protobuf.DiscordMessage{
+		Id:        "discordMessageID",
+		Type:      "Default",
+		Timestamp: "123456",
+		Content:   "discord import message",
+		Author: &protobuf.DiscordMessageAuthor{
+			Id: "2",
+		},
+		Reference: &protobuf.DiscordMessageReference{},
+	}
+
+	err = s.m.persistence.SaveDiscordMessage(discordMessage)
+	s.NoError(err)
+	bridgeMessage = buildTestMessage(*chat)
+	bridgeMessage.ContentType = protobuf.ChatMessage_DISCORD_MESSAGE
+	bridgeMessage.Payload = &protobuf.ChatMessage_DiscordMessage{
+		DiscordMessage: discordMessage,
+	}
+
+	_, err = s.m.SendChatMessage(context.Background(), bridgeMessage)
+	s.NoError(err)
+
+	// Search for the message
+	messages, err = s.m.AllMessageByChatIDWhichMatchTerm(chat.ID, "import", true)
+	s.NoError(err)
+	s.Require().Len(messages, 1)
+
+	// Search for discord messages
+	messages, err = s.m.AllMessageByChatIDWhichMatchTerm(chat.ID, "discord", true)
+	s.NoError(err)
+	s.Require().Len(messages, 2)
+
+	// Search for discord messages using AllMessagesFromChatsAndCommunitiesWhichMatchTerm
+	chatIDs := make([]string, 1)
+	chatIDs = append(chatIDs, chat.ID)
+	messages, err = s.m.AllMessagesFromChatsAndCommunitiesWhichMatchTerm(make([]string, 0), chatIDs, "discord", true)
+	s.NoError(err)
+	s.Require().Len(messages, 2)
+
+	// Same with case insensitive
+	messages, err = s.m.AllMessagesFromChatsAndCommunitiesWhichMatchTerm(make([]string, 0), chatIDs, "discord", false)
+	s.NoError(err)
+	s.Require().Len(messages, 2)
+}


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/8721

Adds the right condition and a test

Ran the test 1000 times:
```
go test -test.count 1000 -run BridgeMessageSuite/TestSearchForDiscordMessages -failfast -timeout 3000s -tags gowaku_skip_migrations,gowaku_no_r
ln
PASS
ok      github.com/status-im/status-go/protocol 299.099s
```