### PR TITLE
chore_: add test-coverage.html report

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -134,7 +134,7 @@ pipeline {
             nix.shell('make test-unit V=1', pure: false)
           }
           sh "mv c.out test-coverage.out"
-          archiveArtifacts('test-coverage.out, coverage/codeclimate.json')
+          archiveArtifacts('test-coverage.out, coverage/codeclimate.json, test-coverage.html')
         }
       } }
       post { cleanup { /* Leftover DB containers. */

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -141,9 +141,13 @@ go run ./cmd/test-coverage-utils/gocovmerge.go $(find -iname "*.coverage.out") >
 # Filter out test coverage for packages in ./cmd
 grep -v '^github.com/status-im/status-go/cmd/' c-full.out > c.out
 
+# Generate HTML coverage report
+go tool cover -html c.out -o test-coverage.html
+
 if [[ $UNIT_TEST_REPORT_CODECLIMATE == 'true' ]]; then
   # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
   GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$')
+  cc-test-reporter format-coverage --prefix=github.com/status-im/status-go # To generate 'coverage/codeclimate.json'
   cc-test-reporter after-build --prefix=github.com/status-im/status-go
 fi
 


### PR DESCRIPTION
Code Climate extension was caught lying about which lines are covered for large diffs.
So we need some actual easy-viewable report.