### PR TITLE
fix(ci): fix rpc tests file permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,7 +490,9 @@ build-verif-proxy-wrapper:
 test-verif-proxy-wrapper:
 	CGO_CFLAGS="$(CGO_CFLAGS)" go test -v github.com/status-im/status-go/rpc -tags gowaku_skip_migrations,nimbus_light_client -run ^TestProxySuite$$ -testify.m TestRun -ldflags $(LDFLAGS)
 
+
 run-integration-tests: SHELL := /bin/sh
+run-integration-tests: export INTEGRATION_TESTS_DOCKER_UID ?= $(shell id -u $$USER)
 run-integration-tests:
 	docker-compose -f integration-tests/docker-compose.anvil.yml -f integration-tests/docker-compose.test.status-go.yml up -d --build --remove-orphans; \
 	docker-compose -f integration-tests/docker-compose.anvil.yml -f integration-tests/docker-compose.test.status-go.yml logs -f tests-rpc; \

--- a/integration-tests/docker-compose.test.status-go.yml
+++ b/integration-tests/docker-compose.test.status-go.yml
@@ -21,6 +21,7 @@ services:
       retries: 120
 
   tests-rpc:
+    user: ${INTEGRATION_TESTS_DOCKER_UID}
     depends_on:
       status-go:
         condition: service_healthy


### PR DESCRIPTION
Builds are failing:
```
[Pipeline] checkout
...
Caused by: hudson.plugins.git.GitException: Command "git clean -fdx" returned status code 1:
...
stderr: warning: failed to remove integration-tests/.pytest_cache/README.md: Permission denied
warning: failed to remove integration-tests/.pytest_cache/.gitignore: Permission denied
warning: failed to remove integration-tests/.pytest_cache/CACHEDIR.TAG: Permission denied
warning: failed to remove integration-tests/.pytest_cache/v/cache/stepwise: Permission denied
warning: failed to remove integration-tests/.pytest_cache/v/cache/nodeids: Permission denied
warning: failed to remove integration-tests/__pycache__/conftest.cpython-310-pytest-6.2.4.pyc: Permission denied
warning: failed to remove integration-tests/tests/__pycache__/test_wallet_rpc.cpython-310-pytest-6.2.4.pyc: Permission denied
warning: failed to remove integration-tests/tests/__pycache__/test_cases.cpython-310-pytest-6.2.4.pyc: Permission denied
```
https://ci.status.im/blue/organizations/jenkins/status-go%2Fprs%2Ftests-rpc/detail/PR-5459/8/pipeline/

Files owned by `root`:
```
# find /home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459 -user root
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/tests/__pycache__
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/tests/__pycache__/test_wallet_rpc.cpython-310-pytest-6.2.4.pyc
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/tests/__pycache__/test_cases.cpython-310-pytest-6.2.4.pyc
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/.pytest_cache
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/.pytest_cache/README.md
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/.pytest_cache/.gitignore
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/.pytest_cache/CACHEDIR.TAG
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/.pytest_cache/v
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/.pytest_cache/v/cache
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/.pytest_cache/v/cache/stepwise
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/.pytest_cache/v/cache/nodeids
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/__pycache__
/home/jenkins/workspace/status-go_prs_tests-rpc_PR-5459/integration-tests/__pycache__/conftest.cpython-310-pytest-6.2.4.pyc
```

Created by rpc test docker container:
https://github.com/status-im/status-go/commit/0d82dbe2401d4be2430ba24ee3c486f814dd1c41