### PR TITLE
fix_: delivered message should not send envelope sent signal

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -269,14 +269,13 @@ func (interceptor EnvelopeEventsInterceptor) EnvelopeSent(identifiers [][]byte) 
 			message, err := interceptor.Messenger.MessageByID(messageID)
 			if err != nil {
 				interceptor.Messenger.logger.Error("failed to query message outgoing status", zap.Error(err))
-			} else {
-				if message.OutgoingStatus == common.OutgoingStatusDelivered {
-					// We don't want to send the signal if the message was already marked as delivered
-					continue
-				} else {
-					signalIDs = append(signalIDs, identifierBytes)
-				}
+				continue
 			}
+			if message.OutgoingStatus == common.OutgoingStatusDelivered {
+				// We don't want to send the signal if the message was already marked as delivered
+				continue
+			}
+			signalIDs = append(signalIDs, identifierBytes)
 		}
 		interceptor.EnvelopeEventsHandler.EnvelopeSent(signalIDs)
 	} else {

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -2167,7 +2167,7 @@ func (s *MessengerSuite) TestSentEventTracking() {
 	s.False(rawMessage.Sent)
 
 	//when message sent, its sent field should be true after we got confirmation
-	err = s.m.processSentMessages([]string{inputMessage.ID})
+	err = s.m.processSentMessage(inputMessage.ID)
 	s.NoError(err)
 
 	rawMessage, err = s.m.persistence.RawMessageByID(inputMessage.ID)
@@ -2392,7 +2392,7 @@ func (s *MessengerSuite) TestMessageSent() {
 	s.False(rawMessage.Sent)
 
 	//imitate chat message sent
-	err = s.m.processSentMessages([]string{inputMessage.ID})
+	err = s.m.processSentMessage(inputMessage.ID)
 	s.NoError(err)
 
 	rawMessage, err = s.m.persistence.RawMessageByID(inputMessage.ID)
@@ -2402,8 +2402,7 @@ func (s *MessengerSuite) TestMessageSent() {
 }
 
 func (s *MessengerSuite) TestProcessSentMessages() {
-	ids := []string{"a"}
-	err := s.m.processSentMessages(ids)
+	err := s.m.processSentMessage("a")
 	s.Require().NoError(err)
 }
 


### PR DESCRIPTION
Check the message outgoing status before trigger the envelope sent signal.

So that ui doesn't receive inconsistent signal. This usually happens when delivered (MVDS ack) is faster that sent (store hash query).

Important changes:
- [x] outgoing status check before send signal.

Closes https://github.com/status-im/status-go/issues/5464
