### PR TITLE
feat(waku)_: add PeerExchange rate-limit

### DIFF
--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -340,6 +340,10 @@ func New(nodeKey *ecdsa.PrivateKey, fleet string, cfg *Config, logger *zap.Logge
 		}
 	}
 
+	if cfg.EnablePeerExchangeServer {
+		opts = append(opts, node.WithPeerExchange(peer_exchange.WithRateLimiter(1, 1)))
+	}
+
 	waku.options = opts
 	waku.logger.Info("setup the go-waku node successfully")
 
@@ -1325,14 +1329,7 @@ func (w *Waku) Start() error {
 		}
 	}
 
-	if w.cfg.EnablePeerExchangeServer {
-		err := w.node.PeerExchange().Start(w.ctx)
-		if err != nil {
-			return err
-		}
-	}
-
-	w.wg.Add(2)
+	w.wg.Add(3)
 
 	go func() {
 		defer w.wg.Done()

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1329,7 +1329,7 @@ func (w *Waku) Start() error {
 		}
 	}
 
-	w.wg.Add(3)
+	w.wg.Add(2)
 
 	go func() {
 		defer w.wg.Done()

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -341,6 +341,11 @@ func TestPeerExchange(t *testing.T) {
 	}, options)
 	require.NoError(t, err)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, discV5Node.node.PeerExchange().Request(ctx, 1))
+	require.Error(t, discV5Node.node.PeerExchange().Request(ctx, 1)) //should fail due to rate limit
+
 	require.NoError(t, lightNode.Stop())
 	require.NoError(t, pxServerNode.Stop())
 	require.NoError(t, discV5Node.Stop())


### PR DESCRIPTION
DRAFT: based on #5504, will rebase once that is merged, it also needs https://github.com/waku-org/go-waku/pull/1157 to be merged

Add Peer Exchange rate limit - currently adding 1 request/s - let me know if it needs to be configurable or higher in general.

Important changes:
- [x] Update go-waku to support PX options
- [x] Remove `PeerExchange().Start()` - as it gets already started on node creation by `WithPeerExchange` being specified
- [x] Use `peer_exchange.WithRateLimiter` 

Closes #4857
