### PR TITLE
fix(telemetry)_: properly handle the size of the retryCache slice

### DIFF
--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -140,7 +140,7 @@ func (c *Client) Start(ctx context.Context) {
 				if len(telemetryRequests) > 0 {
 					err := c.pushTelemetryRequest(telemetryRequests)
 					if err != nil {
-						if sendPeriod < 60 { //Stop the growing if the timer is > 60s to at least retry every minute
+						if sendPeriod < 60*time.Second { //Stop the growing if the timer is > 60s to at least retry every minute
 							sendPeriod = sendPeriod * 2
 						}
 					} else {
@@ -196,8 +196,8 @@ func (c *Client) processAndPushTelemetry(data interface{}) {
 
 // This is assuming to not run concurrently as we are not locking the `telemetryRetryCache`
 func (c *Client) pushTelemetryRequest(request []TelemetryRequest) error {
-	if len(c.telemetryRetryCache)+len(request) > MaxRetryCache { //Limit the size of the cache to not grow the slice indefinitely in case the Telemetry server is gone for longer time
-		removeNum := len(c.telemetryRetryCache) + len(request) - MaxRetryCache
+	if len(c.telemetryRetryCache) > MaxRetryCache { //Limit the size of the cache to not grow the slice indefinitely in case the Telemetry server is gone for longer time
+		removeNum := len(c.telemetryRetryCache) - MaxRetryCache
 		c.telemetryRetryCache = c.telemetryRetryCache[removeNum:]
 	}
 	c.telemetryRetryCache = append(c.telemetryRetryCache, request...)


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/status-im/status-go/commit/131cfe7b3daec24f2ea56bdfa3b26ab931ea7a0f and discovered here https://github.com/status-im/status-desktop/issues/15526#issuecomment-2222838905


Important changes:
- [x] Fix the backoff check
- [x] Only check the cache size and truncate it if needed 


