### PR TITLE
fix(mailservers)_: ToggleUseMailservers should connect/disconnect from active store node

### DIFF
--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -98,7 +98,7 @@ func (m *Messenger) connectToNewMailserverAndWait() error {
 	}
 	// If pinned mailserver is not nil, no need to disconnect and wait for it to be available
 	if pinnedMailserver == nil {
-		m.disconnectActiveMailserver()
+		m.disconnectActiveMailserver(graylistBackoff)
 	}
 
 	return m.findNewMailserver()
@@ -1045,12 +1045,11 @@ func (m *Messenger) ToggleUseMailservers(value bool) error {
 		return err
 	}
 
+	m.disconnectActiveMailserver(backoffByUserAction)
 	if value {
 		m.cycleMailservers()
 		return nil
 	}
-
-	m.disconnectActiveMailserver()
 	return nil
 }
 
@@ -1060,6 +1059,7 @@ func (m *Messenger) SetPinnedMailservers(mailservers map[string]string) error {
 		return err
 	}
 
+	m.disconnectActiveMailserver(backoffByUserAction)
 	m.cycleMailservers()
 	return nil
 }

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -151,7 +151,18 @@ func (m *Messenger) cycleMailservers() {
 		m.disconnectActiveMailserver()
 	}
 
-	err := m.findNewMailserver()
+	useMailserver, err := m.settings.CanUseMailservers()
+	if err != nil {
+		m.logger.Error("failed to get use mailservers", zap.Error(err))
+		return
+	}
+
+	if !useMailserver {
+		m.logger.Info("Skipping mailserver search due to useMailserver being false")
+		return
+	}
+
+	err = m.findNewMailserver()
 	if err != nil {
 		m.logger.Error("Error getting new mailserver", zap.Error(err))
 	}

--- a/protocol/messenger_storenode_comunity_test.go
+++ b/protocol/messenger_storenode_comunity_test.go
@@ -342,3 +342,15 @@ func (s *MessengerStoreNodeCommunitySuite) TestSetStorenodeForCommunity_fetchMes
 	})
 	s.Require().NoError(err)
 }
+
+func (s *MessengerStoreNodeCommunitySuite) TestToggleUseMailservers() {
+	// Enable use of mailservers
+	err := s.owner.ToggleUseMailservers(true)
+	s.Require().NoError(err)
+	s.Require().NotNil(s.owner.mailserverCycle.activeMailserver)
+
+	// Disable use of mailservers
+	err = s.owner.ToggleUseMailservers(false)
+	s.Require().NoError(err)
+	s.Require().Nil(s.owner.mailserverCycle.activeMailserver)
+}


### PR DESCRIPTION
fixes status-im/status-desktop#15032

`disconnectStorenodeIfRequired` is called periodically and runs `m.cycleMailservers()`.

Now `cycleMailservers` will skip the mail server search if `UseMailservers` is disabled.


https://github.com/user-attachments/assets/cfdd702b-edfa-47a4-b109-0296591468df


graph (I wrote a small script to visualise callstack when app is running):

<img width="787" alt="image" src="https://github.com/user-attachments/assets/1ccfdc07-0e1e-4e1a-84dc-3283e745d6c6">

