### PR TITLE
feat(telemetry)_: send connection failure metric

### DIFF
--- a/wakuv2/message_publishing.go
+++ b/wakuv2/message_publishing.go
@@ -109,8 +109,6 @@ func (w *Waku) broadcast() {
 			}
 		}
 
-		fn = w.limiter.ThrottlePublishFn(w.ctx, fn)
-
 		// Wraps the publish function with a call to the telemetry client
 		if w.statusTelemetryClient != nil {
 			sendFn := fn
@@ -124,6 +122,9 @@ func (w *Waku) broadcast() {
 				return err
 			}
 		}
+
+		// Wraps the publish function with rate limiter
+		fn = w.limiter.ThrottlePublishFn(w.ctx, fn)
 
 		w.wg.Add(1)
 		go w.publishEnvelope(envelope, fn, logger)


### PR DESCRIPTION
A short summary which serves as a squashed-commit message.

A description to understand introduced changes without reading the code.

Important changes:
- [x] Depends on https://github.com/waku-org/go-waku/pull/1163
- [x] Depends on https://github.com/status-im/telemetry/pull/27

Related to https://github.com/status-im/telemetry/issues/21
