### PR TITLE
Allow gas estimation for DynamicFeeTx in transactor

### DIFF
--- a/transactions/transactor.go
+++ b/transactions/transactor.go
@@ -334,7 +334,7 @@ func (t *Transactor) HashTransaction(args SendTxArgs) (validatedArgs SendTxArgs,
 	newNonce := hexutil.Uint64(nonce)
 	newGas := hexutil.Uint64(gas)
 	validatedArgs.Nonce = &newNonce
-	if args.IsDynamicFeeTx() {
+	if !args.IsDynamicFeeTx() {
 		validatedArgs.GasPrice = (*hexutil.Big)(gasPrice)
 	} else {
 		validatedArgs.MaxPriorityFeePerGas = (*hexutil.Big)(gasTipCap)

--- a/transactions/transactor.go
+++ b/transactions/transactor.go
@@ -281,7 +281,7 @@ func (t *Transactor) HashTransaction(args SendTxArgs) (validatedArgs SendTxArgs,
 	gasPrice := (*big.Int)(args.GasPrice)
 	gasFeeCap := (*big.Int)(args.MaxFeePerGas)
 	gasTipCap := (*big.Int)(args.MaxPriorityFeePerGas)
-	if args.GasPrice == nil && args.MaxFeePerGas == nil && args.MaxPriorityFeePerGas == nil {
+	if args.GasPrice == nil && !args.IsDynamicFeeTx() {
 		ctx, cancel := context.WithTimeout(context.Background(), t.rpcCallTimeout)
 		defer cancel()
 		gasPrice, err = t.rpcWrapper.SuggestGasPrice(ctx)


### PR DESCRIPTION
Needed for https://github.com/status-im/status-mobile/issues/20361

Currently, when using `transactor.ValidateAndBuildTransaction`, if the Tx doesn't have a `gas` property and has `maxFeePerGas` and `maxPriorityFeePerGas` (making it a `DynamicFeeTx`), the `gas` will not be estimated. This is different for `LegacyTx` (which don't have the dynamic fees), for which we do estimate the `gas`. This PR adds gas estimation for both types of transactions.

Important changes:
- [x] using `IsDynamicFeeTx` instead of checking for the `gasPrice`, which is the way we check for dynamic fees everywhere
- [x] estimating `gas` for `DynamicFeeTxx`
- [x] adding tests for `ValidateAndBuildTransaction`

