### PR TITLE
fix(dapps)_: don't require chain ID for signing typed data v4

### DIFF
--- a/services/typeddata/sign_test.go
+++ b/services/typeddata/sign_test.go
@@ -17,11 +17,11 @@ func TestChainIDValidation(t *testing.T) {
 	for _, tc := range []testCase{
 		{
 			"ChainIDMismatch",
-			map[string]json.RawMessage{chainIDKey: json.RawMessage("1")},
+			map[string]json.RawMessage{ChainIDKey: json.RawMessage("1")},
 		},
 		{
 			"ChainIDNotAnInt",
-			map[string]json.RawMessage{chainIDKey: json.RawMessage(`"aa"`)},
+			map[string]json.RawMessage{ChainIDKey: json.RawMessage(`"aa"`)},
 		},
 		{
 			"NoChainIDKey",

--- a/services/typeddata/types.go
+++ b/services/typeddata/types.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	eip712Domain = "EIP712Domain"
-	chainIDKey   = "chainId"
+	ChainIDKey   = "chainId"
 )
 
 // Types define fields for each composite type.
@@ -73,13 +73,13 @@ func (t TypedData) Validate() error {
 
 // ValidateChainID accept chain as big integer and verifies if typed data belongs to the same chain.
 func (t TypedData) ValidateChainID(chain *big.Int) error {
-	if _, exist := t.Domain[chainIDKey]; !exist {
-		return fmt.Errorf("domain misses chain key %s", chainIDKey)
+	if _, exist := t.Domain[ChainIDKey]; !exist {
+		return fmt.Errorf("domain misses chain key %s", ChainIDKey)
 	}
 	var chainID int64
-	if err := json.Unmarshal(t.Domain[chainIDKey], &chainID); err != nil {
+	if err := json.Unmarshal(t.Domain[ChainIDKey], &chainID); err != nil {
 		var chainIDString string
-		if err = json.Unmarshal(t.Domain[chainIDKey], &chainIDString); err != nil {
+		if err = json.Unmarshal(t.Domain[ChainIDKey], &chainIDString); err != nil {
 			return err
 		}
 		if chainID, err = strconv.ParseInt(chainIDString, 0, 64); err != nil {

--- a/services/wallet/walletconnect/walletconnect.go
+++ b/services/wallet/walletconnect/walletconnect.go
@@ -263,14 +263,18 @@ func SafeSignTypedDataForDApps(typedJson string, privateKey *ecdsa.PrivateKey, c
 	}
 
 	chain := new(big.Int).SetUint64(chainID)
-	if err := typed.ValidateChainID(chain); err != nil {
-		return types.HexBytes{}, err
-	}
 
 	var sig hexutil.Bytes
 	if legacy {
 		sig, err = typeddata.Sign(typed, privateKey, chain)
 	} else {
+		// Validate chainID if part of the typed data
+		if _, exist := typed.Domain[typeddata.ChainIDKey]; exist {
+			if err := typed.ValidateChainID(chain); err != nil {
+				return types.HexBytes{}, err
+			}
+		}
+
 		var typedV4 signercore.TypedData
 		err = json.Unmarshal([]byte(typedJson), &typedV4)
 		if err != nil {


### PR DESCRIPTION
### Updates: https://github.com/status-im/status-desktop/issues/15361

The reused implementation from signing typed data V1 is used in case of signing typed data V4. This implementation required chain ID to be present in the typed data. This change fixes the issue by making chainID optional for signing typed data V4.