### PR TITLE
fix(NodeConfig)_: Added Waku nodes are lost after a restart

### DIFF
--- a/cmd/ping-community/main.go
+++ b/cmd/ping-community/main.go
@@ -344,6 +344,7 @@ func defaultNodeConfig(installationID string) (*params.NodeConfig, error) {
 	nodeConfig := &params.NodeConfig{}
 	nodeConfig.NetworkID = 1
 	nodeConfig.LogLevel = "ERROR"
+	// FIXME: should be absolute path https://github.com/status-im/status-go/issues/5563
 	nodeConfig.DataDir = api.DefaultDataDir
 	nodeConfig.UpstreamConfig = params.UpstreamRPCConfig{
 		Enabled: true,

--- a/cmd/populate-db/main.go
+++ b/cmd/populate-db/main.go
@@ -392,6 +392,7 @@ func defaultNodeConfig(installationID string) (*params.NodeConfig, error) {
 	nodeConfig := &params.NodeConfig{}
 	nodeConfig.NetworkID = 1
 	nodeConfig.LogLevel = "ERROR"
+	// FIXME: should be absolute path https://github.com/status-im/status-go/issues/5563
 	nodeConfig.DataDir = api.DefaultDataDir
 	nodeConfig.UpstreamConfig = params.UpstreamRPCConfig{
 		Enabled: true,

--- a/cmd/spiff-workflow/main.go
+++ b/cmd/spiff-workflow/main.go
@@ -291,6 +291,7 @@ func defaultNodeConfig(installationID string) (*params.NodeConfig, error) {
 	nodeConfig := &params.NodeConfig{}
 	nodeConfig.NetworkID = 1
 	nodeConfig.LogLevel = "DEBUG"
+	// FIXME: should be absolute path https://github.com/status-im/status-go/issues/5563
 	nodeConfig.DataDir = api.DefaultDataDir
 	nodeConfig.HTTPEnabled = true
 	nodeConfig.HTTPPort = 8545

--- a/server/pairing/common.go
+++ b/server/pairing/common.go
@@ -298,6 +298,7 @@ func setDefaultNodeConfig(c *params.NodeConfig) error {
 	c.LogFile = api.DefaultLogFile
 
 	c.Name = api.DefaultNodeName
+	// FIXME: should be absolute path https://github.com/status-im/status-go/issues/5563
 	c.DataDir = api.DefaultDataDir
 	c.KeycardPairingDataFile = api.DefaultKeycardPairingDataFile
 	c.Rendezvous = false


### PR DESCRIPTION
fixes status-im/status-desktop#14929

Changes:
swapped parameters for mergo.Merge call and cluster_nodes.waku is loaded correctly from DB.

We are using `mergo.Merge(dst, src, mergo.WithOverride)` 
refs https://pkg.go.dev/gopkg.in/imdario/mergo.v0#WithOverride :
> WithOverride makes the merge override non-empty dst attributes with non-empty src attribute values

with dst - `inputNodeCfg` (defaultCfg)
and src - `conf` (from the database)

previously any changes to cluster_nodes were lost on login
(LoginAccount -> loginAccount -> loadNodeConfig -> OverwriteNodeConfigValues)

demo (created a tool to watch the changes to tables that are related to the node config, to make sure that nothing else is affected)

https://github.com/user-attachments/assets/8ec87ff9-1ebc-4bf9-84fb-1bb72c07bf4c

