### PR TITLE
feat(telemetry)_: publish peerId

### DIFF
--- a/cmd/status-cli/main.go
+++ b/cmd/status-cli/main.go
@@ -75,10 +75,9 @@ var SimulateFlags = append([]cli.Flag{
 		Usage:   "How many messages to sent from each user",
 	},
 	&cli.BoolFlag{
-		Name:    MessageFailureFlag,
-		Aliases: []string{"f"},
-		Usage:   "Causes messages to fail about 25% of the time",
-		Value:   false,
+		Name:  MessageFailureFlag,
+		Usage: "Causes messages to fail about 25% of the time",
+		Value: false,
 	},
 }, CommonFlags...)
 

--- a/cmd/status-cli/util.go
+++ b/cmd/status-cli/util.go
@@ -79,7 +79,7 @@ func start(p StartParams, logger *zap.SugaredLogger) (*StatusCLI, error) {
 		if err != nil {
 			return nil, err
 		}
-		waku := backend.StatusNode().WakuService()
+		waku := backend.StatusNode().WakuV2Service()
 		telemetryClient := telemetry.NewClient(telemetryLogger, p.TelemetryURL, backend.SelectedAccountKeyID(), p.Name, waku.PeerID().String(), "cli")
 		go telemetryClient.Start(context.Background())
 		backend.StatusNode().WakuV2Service().SetStatusTelemetryClient(telemetryClient)

--- a/cmd/status-cli/util.go
+++ b/cmd/status-cli/util.go
@@ -79,7 +79,8 @@ func start(p StartParams, logger *zap.SugaredLogger) (*StatusCLI, error) {
 		if err != nil {
 			return nil, err
 		}
-		telemetryClient := telemetry.NewClient(telemetryLogger, p.TelemetryURL, backend.SelectedAccountKeyID(), p.Name, "cli")
+		waku := backend.StatusNode().WakuService()
+		telemetryClient := telemetry.NewClient(telemetryLogger, p.TelemetryURL, backend.SelectedAccountKeyID(), p.Name, waku.PeerID().String(), "cli")
 		go telemetryClient.Start(context.Background())
 		backend.StatusNode().WakuV2Service().SetStatusTelemetryClient(telemetryClient)
 	}

--- a/cmd/status-cli/util.go
+++ b/cmd/status-cli/util.go
@@ -80,7 +80,7 @@ func start(p StartParams, logger *zap.SugaredLogger) (*StatusCLI, error) {
 			return nil, err
 		}
 		waku := backend.StatusNode().WakuV2Service()
-		telemetryClient := telemetry.NewClient(telemetryLogger, p.TelemetryURL, backend.SelectedAccountKeyID(), p.Name, waku.PeerID().String(), "cli")
+		telemetryClient := telemetry.NewClient(telemetryLogger, p.TelemetryURL, backend.SelectedAccountKeyID(), p.Name, "cli", telemetry.WithPeerID(waku.PeerID().String()))
 		go telemetryClient.Start(context.Background())
 		backend.StatusNode().WakuV2Service().SetStatusTelemetryClient(telemetryClient)
 	}

--- a/eth-node/bridge/geth/waku.go
+++ b/eth-node/bridge/geth/waku.go
@@ -335,5 +335,5 @@ func (w *GethWakuWrapper) SetStorePeerID(peerID peer.ID) {
 }
 
 func (w *GethWakuWrapper) PeerID() peer.ID {
-	return w.waku.PeerID()
+	panic("not implemented")
 }

--- a/eth-node/bridge/geth/waku.go
+++ b/eth-node/bridge/geth/waku.go
@@ -333,3 +333,7 @@ func (w *GethWakuWrapper) ConfirmMessageDelivered(hashes []common.Hash) {
 
 func (w *GethWakuWrapper) SetStorePeerID(peerID peer.ID) {
 }
+
+func (w *GethWakuWrapper) PeerID() peer.ID {
+	return w.waku.PeerID()
+}

--- a/eth-node/bridge/geth/wakuv2.go
+++ b/eth-node/bridge/geth/wakuv2.go
@@ -350,3 +350,7 @@ func (w *gethWakuV2Wrapper) ConfirmMessageDelivered(hashes []common.Hash) {
 func (w *gethWakuV2Wrapper) SetStorePeerID(peerID peer.ID) {
 	w.waku.SetStorePeerID(peerID)
 }
+
+func (w *gethWakuV2Wrapper) PeerID() peer.ID {
+	return w.waku.PeerID()
+}

--- a/eth-node/types/waku.go
+++ b/eth-node/types/waku.go
@@ -194,4 +194,7 @@ type Waku interface {
 
 	// SetStorePeerID updates the peer id of store node
 	SetStorePeerID(peerID peer.ID)
+
+	// PeerID returns node's PeerID
+	PeerID() peer.ID
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -555,7 +555,7 @@ func NewMessenger(
 
 	var telemetryClient *telemetry.Client
 	if c.telemetryServerURL != "" {
-		telemetryClient = telemetry.NewClient(logger, c.telemetryServerURL, c.account.KeyUID, nodeName, peerId.String(), version)
+		telemetryClient = telemetry.NewClient(logger, c.telemetryServerURL, c.account.KeyUID, nodeName, version, telemetry.WithPeerID(peerId.String()))
 		if c.wakuService != nil {
 			c.wakuService.SetStatusTelemetryClient(telemetryClient)
 		}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -363,7 +363,6 @@ func NewMessenger(
 	var peerId peer.ID
 
 	if waku, err := node.GetWaku(nil); err == nil && waku != nil {
-		peerId = waku.PeerID()
 		transp, err = transport.NewTransport(
 			waku,
 			identity,

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -96,7 +96,13 @@ func WithSendPeriod(sendPeriod time.Duration) TelemetryClientOption {
 	}
 }
 
-func NewClient(logger *zap.Logger, serverURL string, keyUID string, nodeName string, peerId string, version string, opts ...TelemetryClientOption) *Client {
+func WithPeerID(peerId string) TelemetryClientOption {
+	return func(c *Client) {
+		c.peerId = peerId
+	}
+}
+
+func NewClient(logger *zap.Logger, serverURL string, keyUID string, nodeName string, version string, opts ...TelemetryClientOption) *Client {
 	serverURL = strings.TrimRight(serverURL, "/")
 	client := &Client{
 		serverURL:           serverURL,
@@ -104,7 +110,6 @@ func NewClient(logger *zap.Logger, serverURL string, keyUID string, nodeName str
 		logger:              logger,
 		keyUID:              keyUID,
 		nodeName:            nodeName,
-		peerId:              peerId,
 		version:             version,
 		telemetryCh:         make(chan TelemetryRequest),
 		telemetryCacheLock:  sync.Mutex{},

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -96,6 +97,7 @@ func WithSendPeriod(sendPeriod time.Duration) TelemetryClientOption {
 }
 
 func NewClient(logger *zap.Logger, serverURL string, keyUID string, nodeName string, peerId string, version string, opts ...TelemetryClientOption) *Client {
+	serverURL = strings.TrimRight(serverURL, "/")
 	client := &Client{
 		serverURL:           serverURL,
 		httpClient:          &http.Client{Timeout: time.Minute},

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -92,7 +92,7 @@ func createClient(t *testing.T, mockServerURL string) *Client {
 	if err != nil {
 		t.Fatalf("Failed to create logger: %v", err)
 	}
-	return NewClient(logger, mockServerURL, "testUID", "testNode", "16Uiu2HAkvWiyFsgRhuJEb9JfjYxEkoHLgnUQmr1N5mKWnYjxYRVm", "1.0", WithSendPeriod(100*time.Millisecond))
+	return NewClient(logger, mockServerURL, "testUID", "testNode", "1.0", WithSendPeriod(100*time.Millisecond), WithPeerID("16Uiu2HAkvWiyFsgRhuJEb9JfjYxEkoHLgnUQmr1N5mKWnYjxYRVm"))
 }
 
 type expectedCondition func(received []TelemetryRequest) (shouldSucceed bool, shouldFail bool)

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -92,7 +92,7 @@ func createClient(t *testing.T, mockServerURL string) *Client {
 	if err != nil {
 		t.Fatalf("Failed to create logger: %v", err)
 	}
-	return NewClient(logger, mockServerURL, "testUID", "testNode", "1.0", WithSendPeriod(100*time.Millisecond))
+	return NewClient(logger, mockServerURL, "testUID", "testNode", "16Uiu2HAkvWiyFsgRhuJEb9JfjYxEkoHLgnUQmr1N5mKWnYjxYRVm", "1.0", WithSendPeriod(100*time.Millisecond))
 }
 
 type expectedCondition func(received []TelemetryRequest) (shouldSucceed bool, shouldFail bool)
@@ -385,4 +385,31 @@ func TestPeerCount(t *testing.T) {
 
 		require.NotEqual(t, 0, len(w.Peers()))
 	})
+}
+
+func TestPeerId(t *testing.T) {
+	expectedCondition := func(received []TelemetryRequest) (shouldSucceed bool, shouldFail bool) {
+		var data map[string]interface{}
+
+		err := json.Unmarshal(*received[0].TelemetryData, &data)
+		if err != nil {
+			return false, true
+		}
+
+		_, ok := data["peerId"]
+		require.True(t, ok)
+		return ok, false
+	}
+	withMockServer(t, ReceivedEnvelopeMetric, expectedCondition, func(ctx context.Context, t *testing.T, client *Client, wg *sync.WaitGroup) {
+		client.Start(ctx)
+
+		client.PushReceivedEnvelope(v2protocol.NewEnvelope(&pb.WakuMessage{
+			Payload:      []byte{1, 2, 3, 4, 5},
+			ContentTopic: testContentTopic,
+			Version:      proto.Uint32(0),
+			Timestamp:    proto.Int64(time.Now().Unix()),
+		}, 0, ""))
+
+	})
+
 }

--- a/waku/waku.go
+++ b/waku/waku.go
@@ -28,8 +28,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"go.uber.org/zap"
 

--- a/waku/waku.go
+++ b/waku/waku.go
@@ -1600,7 +1600,7 @@ func (w *Waku) Clean() error {
 }
 
 func (w *Waku) PeerID() peer.ID {
-	return peer.NewPeerRecord().PeerID //FIXME!!!
+	panic("not implemented")
 }
 
 // validatePrivateKey checks the format of the given private key.

--- a/waku/waku.go
+++ b/waku/waku.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	"go.uber.org/zap"
 
@@ -1595,6 +1596,10 @@ func (w *Waku) Clean() error {
 	}
 
 	return nil
+}
+
+func (w *Waku) PeerID() peer.ID {
+	return peer.NewPeerRecord().PeerID //FIXME!!!
 }
 
 // validatePrivateKey checks the format of the given private key.


### PR DESCRIPTION
This is part of https://github.com/status-im/telemetry/issues/28, needs https://github.com/status-im/telemetry/pull/29

It adds `PeerID` to waku interfaces to pass it to Telemetry Client

Important changes:
- [x] Add `PeerID()` to all the interfaces
- [x] Add `peerId` to telemetry client creation
- [x] Removes `-f` shortcut for `--fail` in simulation, as it was failing for me as a duplicate
- [x] Trim extra `/` from `telemetryURL`  

