### PR TITLE
test(wallet)_: fix flaky circuit breaker test on window timeout

### DIFF
--- a/circuitbreaker/circuit_breaker_test.go
+++ b/circuitbreaker/circuit_breaker_test.go
@@ -171,7 +171,7 @@ func TestCircuitBreaker_ExecuteHealthCheckOnWindowTimeout(t *testing.T) {
 		require.Equal(t, expectedResult, result.Result()[0].(string))
 	}
 
-	assert.Equal(t, 1, prov1Called)
+	assert.Less(t, prov1Called, 3) // most of the time only 1 call is made, but occasionally 2 can happen
 	assert.Equal(t, 10, prov2Called)
 
 	// Wait for the sleep window to expire
@@ -189,7 +189,7 @@ func TestCircuitBreaker_ExecuteHealthCheckOnWindowTimeout(t *testing.T) {
 	result := cb.Execute(cmd)
 	require.NoError(t, result.Error())
 
-	assert.Equal(t, 2, prov1Called)
+	assert.Less(t, prov1Called, 4) // most of the time only 2 calls are made, but occasionally 3 can happen
 	assert.Equal(t, 10, prov2Called)
 }
 

--- a/services/rpcstats/stats.go
+++ b/services/rpcstats/stats.go
@@ -11,8 +11,12 @@ type RPCUsageStats struct {
 }
 
 var stats *RPCUsageStats
+var mu sync.Mutex
 
 func getInstance() *RPCUsageStats {
+	mu.Lock()
+	defer mu.Unlock()
+
 	if stats == nil {
 		stats = &RPCUsageStats{}
 		stats.counterPerMethod = &sync.Map{}


### PR DESCRIPTION
On slow machines or heavy load, it could be that either that timeout expires before the all the commands executed or due to async way of channels an extra call could be made faster that tripping the circuit.

Fixed racing condition, when RPC stats can be already created but not initialized