### PR TITLE
feat(wallet)_: incorporate partner fees for L1 paraswap swaps

### DIFF
--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -3,6 +3,8 @@ package common
 import (
 	"strconv"
 	"time"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
 )
 
 type MultiTransactionIDType int64
@@ -26,6 +28,10 @@ const (
 	ArbitrumSepolia    uint64 = 421614
 	BinanceChainID     uint64 = 56 // obsolete?
 	BinanceTestChainID uint64 = 97 // obsolete?
+)
+
+var (
+	ZeroAddress = ethCommon.HexToAddress("0x0000000000000000000000000000000000000000")
 )
 
 type ContractType byte

--- a/services/wallet/router/pathprocessor/processor_swap_paraswap_test.go
+++ b/services/wallet/router/pathprocessor/processor_swap_paraswap_test.go
@@ -1,0 +1,71 @@
+package pathprocessor
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/services/wallet/bigint"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty/paraswap"
+	"github.com/status-im/status-go/services/wallet/token"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParaswapWithPartnerFee(t *testing.T) {
+	testPriceRoute := &paraswap.Route{
+		GasCost:           &bigint.BigInt{Int: big.NewInt(500)},
+		SrcAmount:         &bigint.BigInt{Int: big.NewInt(1000)},
+		SrcTokenAddress:   common.HexToAddress("0x123"),
+		SrcTokenDecimals:  18,
+		DestAmount:        &bigint.BigInt{Int: big.NewInt(2000)},
+		DestTokenAddress:  common.HexToAddress("0x465"),
+		DestTokenDecimals: 6,
+		Side:              paraswap.SellSide,
+	}
+
+	processor := NewSwapParaswapProcessor(nil, nil, nil)
+
+	fromToken := token.Token{
+		Symbol: EthSymbol,
+	}
+	toToken := token.Token{
+		Symbol: UsdcSymbol,
+	}
+	chainIDs := []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet, walletCommon.OptimismMainnet, walletCommon.UnknownChainID}
+
+	for _, chainID := range chainIDs {
+		key := makeKey(chainID, chainID, fromToken.Symbol, toToken.Symbol)
+		processor.priceRoute.Store(key, testPriceRoute)
+
+		testInputParams := ProcessorInputParams{
+			FromChain: &params.Network{ChainID: chainID},
+			ToChain:   &params.Network{ChainID: chainID},
+			FromToken: &fromToken,
+			ToToken:   &toToken,
+		}
+
+		partnerAddress, partnerFeePcnt := getPartnerAddressAndFeePcnt(chainID)
+
+		if partnerAddress != walletCommon.ZeroAddress {
+			require.Greater(t, partnerFeePcnt, 0.0)
+
+			expectedFee := uint64(float64(testPriceRoute.DestAmount.Uint64()) * partnerFeePcnt / 100.0)
+			expectedDestAmount := testPriceRoute.DestAmount.Uint64() - expectedFee
+
+			amountOut, err := processor.CalculateAmountOut(testInputParams)
+			require.NoError(t, err)
+			require.NotNil(t, amountOut)
+			require.InEpsilon(t, expectedDestAmount, amountOut.Uint64(), 2.0)
+		} else {
+			require.Equal(t, 0.0, partnerFeePcnt)
+
+			amountOut, err := processor.CalculateAmountOut(testInputParams)
+			require.NoError(t, err)
+			require.NotNil(t, amountOut)
+			require.Equal(t, testPriceRoute.DestAmount.Uint64(), amountOut.Uint64())
+		}
+	}
+}

--- a/services/wallet/thirdparty/paraswap/client_v5.go
+++ b/services/wallet/thirdparty/paraswap/client_v5.go
@@ -1,6 +1,9 @@
 package paraswap
 
-import "github.com/status-im/status-go/services/wallet/thirdparty"
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
+)
 
 type SwapSide string
 
@@ -10,17 +13,35 @@ const (
 )
 
 type ClientV5 struct {
-	httpClient *thirdparty.HTTPClient
-	chainID    uint64
+	httpClient     *thirdparty.HTTPClient
+	chainID        uint64
+	partnerID      string
+	partnerAddress common.Address
+	partnerFeePcnt float64
 }
 
-func NewClientV5(chainID uint64) *ClientV5 {
+func NewClientV5(
+	chainID uint64,
+	partnerID string,
+	partnerAddress common.Address,
+	partnerFeePcnt float64) *ClientV5 {
 	return &ClientV5{
-		httpClient: thirdparty.NewHTTPClient(),
-		chainID:    chainID,
+		httpClient:     thirdparty.NewHTTPClient(),
+		chainID:        chainID,
+		partnerID:      partnerID,
+		partnerAddress: partnerAddress,
+		partnerFeePcnt: partnerFeePcnt,
 	}
 }
 
 func (c *ClientV5) SetChainID(chainID uint64) {
 	c.chainID = chainID
+}
+
+func (c *ClientV5) SetPartnerAddress(partnerAddress common.Address) {
+	c.partnerAddress = partnerAddress
+}
+
+func (c *ClientV5) SetPartnerFeePcnt(partnerFeePcnt float64) {
+	c.partnerFeePcnt = partnerFeePcnt
 }

--- a/services/wallet/thirdparty/paraswap/request_build_transaction.go
+++ b/services/wallet/thirdparty/paraswap/request_build_transaction.go
@@ -8,6 +8,8 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
 )
 
 const transactionsURL = "https://apiv5.paraswap.io/transactions/%d"
@@ -46,6 +48,11 @@ func (c *ClientV5) BuildTransaction(ctx context.Context, srcTokenAddress common.
 	} else {
 		params["srcAmount"] = srcAmountWei.String()
 		params["destAmount"] = destAmountWei.String()
+	}
+	params["partner"] = c.partnerID
+	if c.partnerAddress != walletCommon.ZeroAddress && c.partnerFeePcnt > 0 {
+		params["partnerAddress"] = c.partnerAddress.Hex()
+		params["partnerFeeBps"] = uint(c.partnerFeePcnt * 100)
 	}
 
 	url := fmt.Sprintf(transactionsURL, c.chainID)

--- a/services/wallet/thirdparty/paraswap/request_price_route.go
+++ b/services/wallet/thirdparty/paraswap/request_price_route.go
@@ -46,6 +46,7 @@ func (c *ClientV5) FetchPriceRoute(ctx context.Context, srcTokenAddress common.A
 	params.Add("network", strconv.FormatUint(c.chainID, 10))
 	params.Add("amount", amountWei.String())
 	params.Add("side", string(side))
+	params.Add("partner", c.partnerID)
 
 	url := pricesURL
 	response, err := c.httpClient.DoGetRequest(ctx, url, params)


### PR DESCRIPTION
Added the required parameters to get fees when performing swaps on L1, Arb and Opt.
If no parner fees are set, Paraswap only takes the "surplus" (extra money due to lower price since the route was built). If a partner fee is set, we need to subtract that from the amount reported to the user. That's properly calculated in this PR.

Partner Addresses for Opt and Arb to be introduced at a later PR.