### PR TITLE
fix(logs)_: remove community private key logging in  'publishCommunityPrivilegedMemberSyncMessage'

### DIFF
--- a/protocol/communities/communnity_privileged_member_sync_msg.go
+++ b/protocol/communities/communnity_privileged_member_sync_msg.go
@@ -18,7 +18,6 @@ var ErrOutdatedSharedRequestToJoinClock = errors.New("outdated clock in shared r
 var ErrOutdatedSharedRequestToJoinState = errors.New("outdated state in shared request to join")
 
 type CommunityPrivilegedMemberSyncMessage struct {
-	CommunityPrivateKey                *ecdsa.PrivateKey
 	Receivers                          []*ecdsa.PublicKey
 	CommunityPrivilegedUserSyncMessage *protobuf.CommunityPrivilegedUserSyncMessage
 }

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -3190,8 +3190,7 @@ func (m *Manager) HandleCommunityEditSharedAddresses(signer *ecdsa.PublicKey, re
 	}
 
 	subscriptionMsg := &CommunityPrivilegedMemberSyncMessage{
-		CommunityPrivateKey: community.PrivateKey(),
-		Receivers:           community.GetTokenMasterMembers(),
+		Receivers: community.GetTokenMasterMembers(),
 		CommunityPrivilegedUserSyncMessage: &protobuf.CommunityPrivilegedUserSyncMessage{
 			Type:        protobuf.CommunityPrivilegedUserSyncMessage_CONTROL_NODE_MEMBER_EDIT_SHARED_ADDRESSES,
 			CommunityId: community.ID(),
@@ -4863,9 +4862,7 @@ func (m *Manager) ShareRequestsToJoinWithPrivilegedMembers(community *Community,
 		SyncRequestsToJoin: syncRequestsWithRevealedAccounts,
 	}
 
-	subscriptionMsg := &CommunityPrivilegedMemberSyncMessage{
-		CommunityPrivateKey: community.PrivateKey(),
-	}
+	subscriptionMsg := &CommunityPrivilegedMemberSyncMessage{}
 
 	for role, members := range privilegedMembers {
 		if len(members) == 0 {
@@ -4919,9 +4916,7 @@ func (m *Manager) shareAcceptedRequestToJoinWithPrivilegedMembers(community *Com
 	skipMembers[common.PubkeyToHex(&m.identity.PublicKey)] = struct{}{}
 	skipMembers[common.PubkeyToHex(pk)] = struct{}{}
 
-	subscriptionMsg := &CommunityPrivilegedMemberSyncMessage{
-		CommunityPrivateKey: community.PrivateKey(),
-	}
+	subscriptionMsg := &CommunityPrivilegedMemberSyncMessage{}
 
 	fileredPrivilegedMembers := community.GetFilteredPrivilegedMembers(skipMembers)
 	for role, members := range fileredPrivilegedMembers {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -188,8 +188,13 @@ func (m *Messenger) publishCommunityEvents(community *communities.Community, msg
 }
 
 func (m *Messenger) publishCommunityPrivilegedMemberSyncMessage(msg *communities.CommunityPrivilegedMemberSyncMessage) error {
+	community, err := m.GetCommunityByID(msg.CommunityPrivilegedUserSyncMessage.CommunityId)
+	if err != nil {
+		return err
+	}
 
-	m.logger.Debug("publishing privileged user sync message", zap.Any("event", msg))
+	m.logger.Debug("publishing privileged user sync message",
+		zap.Any("receivers", msg.Receivers), zap.Any("type", msg.CommunityPrivilegedUserSyncMessage.Type))
 
 	payload, err := proto.Marshal(msg.CommunityPrivilegedUserSyncMessage)
 	if err != nil {
@@ -198,7 +203,7 @@ func (m *Messenger) publishCommunityPrivilegedMemberSyncMessage(msg *communities
 
 	rawMessage := &common.RawMessage{
 		Payload:             payload,
-		Sender:              msg.CommunityPrivateKey, // if empty, sender private key will be used in SendPrivate
+		Sender:              community.PrivateKey(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_PRIVILEGED_USER_SYNC_MESSAGE,
 	}


### PR DESCRIPTION
In `publishCommunityPrivilegedMemberSyncMessage` we log community privateKey and members' addresses

Closes # https://github.com/status-im/status-go/issues/5544
