### PR TITLE
fix(wallet)_: Fix handling of remote image URLs in image processing

### DIFF
--- a/images/adjust.go
+++ b/images/adjust.go
@@ -3,9 +3,13 @@ package images
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"image"
+	"io"
 	"io/ioutil"
+	"net/http"
 	"os"
+	"strings"
 )
 
 const (
@@ -16,48 +20,92 @@ const (
 
 var DefaultBounds = FileSizeLimits{Ideal: idealTargetImageSize, Max: resizeTargetImageSize}
 
-func OpenAndAdjustImage(inputImage CroppedImage, crop bool) ([]byte, error) {
-	file, err := os.Open(inputImage.ImagePath)
+func FetchAndStoreRemoteImage(url string) (string, error) {
+	resp, err := http.Get(url) //nolint
 	if err != nil {
-		return nil, err
+		return "", fmt.Errorf("error fetching image from URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("bad status code: %s", resp.Status)
+	}
+
+	tempFile, err := ioutil.TempFile("", "image-*")
+	if err != nil {
+		return "", fmt.Errorf("error creating a temporary file: %w", err)
+	}
+	defer tempFile.Close()
+
+	_, err = io.Copy(tempFile, resp.Body)
+	if err != nil {
+		os.Remove(tempFile.Name()) // Ensure temporary file is deleted on error
+		return "", fmt.Errorf("error writing image to temp file: %w", err)
+	}
+
+	return tempFile.Name(), nil
+}
+
+func OpenAndDecodeImage(imagePath string) (image.Image, error) {
+	file, err := os.Open(imagePath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening image file: %w", err)
 	}
 	defer file.Close()
 
-	payload, err := ioutil.ReadAll(file)
+	img, err := Decode(imagePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error decoding image: %w", err)
 	}
 
-	img, err := Decode(inputImage.ImagePath)
-	if err != nil {
-		return nil, err
-	}
+	return img, nil
+}
 
+func AdjustImage(img image.Image, crop bool, inputImage CroppedImage) ([]byte, error) {
 	if crop {
 		cropRect := image.Rectangle{
 			Min: image.Point{X: inputImage.X, Y: inputImage.Y},
 			Max: image.Point{X: inputImage.X + inputImage.Width, Y: inputImage.Y + inputImage.Height},
 		}
+		var err error
 		img, err = Crop(img, cropRect)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error cropping image: %w", err)
 		}
 	}
 
 	bb := bytes.NewBuffer([]byte{})
-	err = CompressToFileLimits(bb, img, DefaultBounds)
+	err := CompressToFileLimits(bb, img, DefaultBounds)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error compressing image: %w", err)
 	}
 
-	// We keep the smallest one
-	if len(payload) > len(bb.Bytes()) {
-		payload = bb.Bytes()
-	}
-
+	payload := bb.Bytes()
 	if len(payload) > maxChatMessageImageSize {
 		return nil, errors.New("image too large")
 	}
 
 	return payload, nil
+}
+func OpenAndAdjustImage(inputImage CroppedImage, crop bool) ([]byte, error) {
+	var imgPath string = inputImage.ImagePath
+	var err error
+
+	// Check if the image is from a remote source
+	if strings.HasPrefix(inputImage.ImagePath, "http://") || strings.HasPrefix(inputImage.ImagePath, "https://") {
+		imgPath, err = FetchAndStoreRemoteImage(inputImage.ImagePath)
+		if err != nil {
+			return nil, err
+		}
+		defer os.Remove(imgPath) // Clean up the temporary file
+	}
+
+	// Decode the image
+	img, err := OpenAndDecodeImage(imgPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Adjust (crop and compress) the image
+	return AdjustImage(img, crop, inputImage)
 }


### PR DESCRIPTION
### Description
This update extends the functionality of the image processing module to handle images sourced from web URLs, addressing a previous limitation where only local files were supported. The enhancement includes the ability to download and temporarily store images from HTTP and HTTPS URLs before processing them as if they were local files. This is particularly useful for environments where users might drag and drop or directly reference images hosted online.

### Important Changes
* The image processing function now checks if the input path starts with http:// or https://, indicating a web-sourced image. It then downloads these images, saves them to a temporary file, and processes them using the existing local file workflow.
* Temporary files are cleaned up appropriately to avoid storage overflow and maintain efficiency.
* Error handling has been improved to provide clearer messages in scenarios where image fetching or processing fails, enhancing user experience and debuggability.

Closes https://github.com/status-im/status-desktop/issues/15691


https://github.com/user-attachments/assets/6d12319e-d701-46d6-9804-c8350561102b


