### PR TITLE
fix(tests-rpc)_: Remove port bind

### DIFF
--- a/integration-tests/docker-compose.anvil.yml
+++ b/integration-tests/docker-compose.anvil.yml
@@ -4,8 +4,6 @@ services:
     platform: linux/amd64
     command:
       - anvil --host 0.0.0.0
-    ports:
-      - 8545:8545
 
   deploy-sntv2:
     platform: linux/amd64

--- a/integration-tests/docker-compose.test.status-go.yml
+++ b/integration-tests/docker-compose.test.status-go.yml
@@ -7,12 +7,6 @@ services:
         build_tags: gowaku_no_rln
         build_target: statusd
         build_flags: -ldflags="-X github.com/status-im/status-go/params.Version= -X github.com/status-im/status-go/params.GitCommit=11f83780d -X github.com/status-im/status-go/params.IpfsGatewayURL=https://ipfs.status.im/ -X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=true"
-    ports:
-      - 3333:3333
-      - 8080:8080
-      - 30303:30303
-      - 30303:30303/udp
-      - 30304:30304/udp
     entrypoint: ["statusd", "-c", "/static/configs/config.json", "--seed-phrase=test test test test test test test test test test test junk", "--password=Strong12345"]
     healthcheck:
       test: ["CMD-SHELL", "curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"net_version\",\"params\":[],\"id\":1}' -H 'Content-Type: application/json' http://0.0.0.0:3333 || exit 1"]


### PR DESCRIPTION
Fix for 

```09:44:35  ERROR: for integration-tests_anvil_1  Cannot start service anvil: driver failed programming external connectivity on endpoint integration-tests_anvil_1 (cbcfe565ab66c477d11bb1f957b0e8cca17c967f647a6bcf60aea0abe4684bd7): listen tcp4 0.0.0.0:8545: bind: address already in use```

e.g. 
https://ci.status.im/job/status-go/job/prs/job/tests-rpc/job/PR-5551/1//consoleText

Please note, there will be separate PR with a make command to run locally with port binding while this PR is a quick fix for CI