### PR TITLE
chore: lightmode ping peers when we come back online,

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20240724122952-11a258a4d8c7
+	github.com/waku-org/go-waku v0.8.1-0.20240724124731-a9be17fd4848
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20240724052716-50ad6698f64a
+	github.com/waku-org/go-waku v0.8.1-0.20240724122952-11a258a4d8c7
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20240716173432-8f3332d1a08d
+	github.com/waku-org/go-waku v0.8.1-0.20240724022917-58d9721026db
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20240724124731-a9be17fd4848
+	github.com/waku-org/go-waku v0.8.1-0.20240731185821-04a9af931f26
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20240724022917-58d9721026db
+	github.com/waku-org/go-waku v0.8.1-0.20240724052716-50ad6698f64a
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -2143,8 +2143,8 @@ github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5 h1:9u16E
 github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5/go.mod h1:QEb+hEV9WL9wCiUAnpY29FZR6W3zK8qYlaml8R4q6gQ=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20240724022917-58d9721026db h1:IS0jTp1kQC9VVw29BQlrm+ilOrw1oxo4pfWIi6+Ex68=
-github.com/waku-org/go-waku v0.8.1-0.20240724022917-58d9721026db/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
+github.com/waku-org/go-waku v0.8.1-0.20240724052716-50ad6698f64a h1:EQBJHJv+rO+lGpl/7SzcDDC7qiAA7isWLV7XGUKZ/7g=
+github.com/waku-org/go-waku v0.8.1-0.20240724052716-50ad6698f64a/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/go.sum
+++ b/go.sum
@@ -2143,8 +2143,8 @@ github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5 h1:9u16E
 github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5/go.mod h1:QEb+hEV9WL9wCiUAnpY29FZR6W3zK8qYlaml8R4q6gQ=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20240724124731-a9be17fd4848 h1:+1ZewlTZ7p6ophM5H3maC/Jb8aGM04ivfJyWc3oplDg=
-github.com/waku-org/go-waku v0.8.1-0.20240724124731-a9be17fd4848/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
+github.com/waku-org/go-waku v0.8.1-0.20240731185821-04a9af931f26 h1:F657EAwHvwTcVjMddQYGZjVC3mfYsdPD9AAHPvV9/hI=
+github.com/waku-org/go-waku v0.8.1-0.20240731185821-04a9af931f26/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/go.sum
+++ b/go.sum
@@ -2143,8 +2143,8 @@ github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5 h1:9u16E
 github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5/go.mod h1:QEb+hEV9WL9wCiUAnpY29FZR6W3zK8qYlaml8R4q6gQ=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20240724052716-50ad6698f64a h1:EQBJHJv+rO+lGpl/7SzcDDC7qiAA7isWLV7XGUKZ/7g=
-github.com/waku-org/go-waku v0.8.1-0.20240724052716-50ad6698f64a/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
+github.com/waku-org/go-waku v0.8.1-0.20240724122952-11a258a4d8c7 h1:+A37qW0vhnPj18wWu9d3Ud4x1GuI8ZapctslgJFmYgs=
+github.com/waku-org/go-waku v0.8.1-0.20240724122952-11a258a4d8c7/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/go.sum
+++ b/go.sum
@@ -2143,8 +2143,8 @@ github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5 h1:9u16E
 github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5/go.mod h1:QEb+hEV9WL9wCiUAnpY29FZR6W3zK8qYlaml8R4q6gQ=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20240716173432-8f3332d1a08d h1:thwE3nxBaINnQllutuZdMdyLMUZLKwX7TRufs1IrlQc=
-github.com/waku-org/go-waku v0.8.1-0.20240716173432-8f3332d1a08d/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
+github.com/waku-org/go-waku v0.8.1-0.20240724022917-58d9721026db h1:IS0jTp1kQC9VVw29BQlrm+ilOrw1oxo4pfWIi6+Ex68=
+github.com/waku-org/go-waku v0.8.1-0.20240724022917-58d9721026db/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/go.sum
+++ b/go.sum
@@ -2143,8 +2143,8 @@ github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5 h1:9u16E
 github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5/go.mod h1:QEb+hEV9WL9wCiUAnpY29FZR6W3zK8qYlaml8R4q6gQ=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20240724122952-11a258a4d8c7 h1:+A37qW0vhnPj18wWu9d3Ud4x1GuI8ZapctslgJFmYgs=
-github.com/waku-org/go-waku v0.8.1-0.20240724122952-11a258a4d8c7/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
+github.com/waku-org/go-waku v0.8.1-0.20240724124731-a9be17fd4848 h1:+1ZewlTZ7p6ophM5H3maC/Jb8aGM04ivfJyWc3oplDg=
+github.com/waku-org/go-waku v0.8.1-0.20240724124731-a9be17fd4848/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/vendor/github.com/waku-org/go-waku/waku/v2/api/filter.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/api/filter.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const FilterPingTimeout = 5 * time.Second
 const MultiplexChannelBuffer = 100
 
 type FilterConfig struct {

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/localnode.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/localnode.go
@@ -382,7 +382,7 @@ func (w *WakuNode) watchTopicShards(ctx context.Context) error {
 				}
 
 				if len(rs) == 1 {
-					w.log.Info("updating advertised relay shards in ENR")
+					w.log.Info("updating advertised relay shards in ENR", zap.Any("newShardInfo", rs[0]))
 					if len(rs[0].ShardIDs) != len(topics) {
 						w.log.Warn("A mix of named and static shards found. ENR shard will contain only the following shards", zap.Any("shards", rs[0]))
 					}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go
@@ -799,6 +799,17 @@ func (w *WakuNode) ClosePeerByAddress(address string) error {
 	return w.ClosePeerById(info.ID)
 }
 
+func (w *WakuNode) DisconnectAllPeers() {
+	w.host.Network().StopNotify(w.connectionNotif)
+	for _, peerID := range w.host.Network().Peers() {
+		err := w.ClosePeerById(peerID)
+		if err != nil {
+			w.log.Info("failed to close peer", zap.Stringer("peer", peerID), zap.Error(err))
+		}
+	}
+	w.host.Network().Notify(w.connectionNotif)
+}
+
 // ClosePeerById is used to close a connection to a peer
 func (w *WakuNode) ClosePeerById(id peer.ID) error {
 	err := w.host.Network().ClosePeer(id)

--- a/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go
@@ -112,7 +112,7 @@ func (pm *PeerManager) discoverPeersByPubsubTopics(pubsubTopics []string, proto 
 		for _, shardInfo := range shardsInfo {
 			err = pm.DiscoverAndConnectToPeers(ctx, shardInfo.ClusterID, shardInfo.ShardIDs[0], proto, maxCount)
 			if err != nil {
-				pm.logger.Error("failed to discover and connect to peers", zap.Error(err))
+				pm.logger.Warn("failed to discover and connect to peers", zap.Error(err))
 			}
 		}
 	} else {

--- a/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go
@@ -313,8 +313,10 @@ func (pm *PeerManager) ensureMinRelayConnsPerTopic() {
 		// peers. This will ensure that the peers returned by this function
 		// match those peers that are currently connected
 
-		curPeerLen := pm.checkAndUpdateTopicHealth(topicInst)
-		if curPeerLen < pm.OutPeersTarget {
+		meshPeerLen := pm.checkAndUpdateTopicHealth(topicInst)
+		topicPeers := pm.host.Peerstore().(wps.WakuPeerstore).PeersByPubSubTopic(topicStr)
+		curPeerLen := topicPeers.Len()
+		if meshPeerLen < waku_proto.GossipSubDMin || curPeerLen < pm.OutPeersTarget {
 			pm.logger.Debug("subscribed topic has not reached target peers, initiating more connections to maintain healthy mesh",
 				zap.String("pubSubTopic", topicStr), zap.Int("connectedPeerCount", curPeerLen),
 				zap.Int("targetPeers", pm.OutPeersTarget))

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/client.go
@@ -147,17 +147,6 @@ func (wf *WakuFilterLightNode) Stop() {
 	})
 }
 
-func (wf *WakuFilterLightNode) unsubscribeWithoutSubscription(cf protocol.ContentFilter, peerID peer.ID) {
-	err := wf.request(
-		wf.Context(),
-		protocol.GenerateRequestID(),
-		pb.FilterSubscribeRequest_UNSUBSCRIBE_ALL,
-		cf, peerID)
-	if err != nil {
-		wf.log.Warn("could not unsubscribe from peer", logging.HostID("peerID", peerID), zap.Error(err))
-	}
-}
-
 func (wf *WakuFilterLightNode) onRequest(ctx context.Context) func(network.Stream) {
 	return func(stream network.Stream) {
 		peerID := stream.Conn().RemotePeer()
@@ -168,8 +157,6 @@ func (wf *WakuFilterLightNode) onRequest(ctx context.Context) func(network.Strea
 			logger.Warn("received message push from unknown peer", logging.HostID("peerID", peerID))
 			wf.metrics.RecordError(unknownPeerMessagePush)
 			//Send a wildcard unsubscribe to this peer so that further requests are not forwarded to us
-			//This could be happening due to https://github.com/waku-org/go-waku/issues/1124
-			go wf.unsubscribeWithoutSubscription(protocol.ContentFilter{}, peerID)
 			if err := stream.Reset(); err != nil {
 				wf.log.Error("resetting connection", zap.Error(err))
 			}
@@ -216,8 +203,6 @@ func (wf *WakuFilterLightNode) onRequest(ctx context.Context) func(network.Strea
 		cf := protocol.NewContentFilter(pubSubTopic, messagePush.WakuMessage.ContentTopic)
 		if !wf.subscriptions.Has(peerID, cf) {
 			logger.Warn("received messagepush with invalid subscription parameters")
-			//Unsubscribe from that peer for the contentTopic, possibly due to https://github.com/waku-org/go-waku/issues/1124
-			go wf.unsubscribeWithoutSubscription(cf, peerID)
 			wf.metrics.RecordError(invalidSubscriptionMessage)
 			return
 		}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/server.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/libp2p/go-msgio/pbio"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/waku-org/go-waku/logging"
+	"github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/filter/pb"
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
@@ -273,6 +274,9 @@ func (wf *WakuFilterFullNode) pushMessage(ctx context.Context, logger *zap.Logge
 			wf.metrics.RecordError(pushTimeoutFailure)
 		} else {
 			wf.metrics.RecordError(dialFailure)
+			if ps, ok := wf.h.Peerstore().(peerstore.WakuPeerstore); ok {
+				ps.AddConnFailure(peer.AddrInfo{ID: peerID})
+			}
 		}
 		logger.Error("opening peer stream", zap.Error(err))
 		return err

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/legacy_store/waku_store_client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/legacy_store/waku_store_client.go
@@ -207,6 +207,9 @@ func (store *WakuStore) queryFrom(ctx context.Context, historyRequest *pb.Histor
 	if err != nil {
 		logger.Error("creating stream to peer", zap.Error(err))
 		store.metrics.RecordError(dialFailure)
+		if ps, ok := store.h.Peerstore().(peerstore.WakuPeerstore); ok {
+			ps.AddConnFailure(peer.AddrInfo{ID: selectedPeer})
+		}
 		return nil, err
 	}
 

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/metadata/waku_metadata.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/metadata/waku_metadata.go
@@ -15,6 +15,7 @@ import (
 	"github.com/libp2p/go-msgio/pbio"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/waku-org/go-waku/logging"
+	"github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/enr"
 	"github.com/waku-org/go-waku/waku/v2/protocol/metadata/pb"
@@ -103,6 +104,9 @@ func (wakuM *WakuMetadata) Request(ctx context.Context, peerID peer.ID) (*pb.Wak
 	stream, err := wakuM.h.NewStream(ctx, peerID, MetadataID_v1)
 	if err != nil {
 		logger.Error("creating stream to peer", zap.Error(err))
+		if ps, ok := wakuM.h.Peerstore().(peerstore.WakuPeerstore); ok {
+			ps.AddConnFailure(peer.AddrInfo{ID: peerID})
+		}
 		return nil, err
 	}
 

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/metadata/waku_metadata.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/metadata/waku_metadata.go
@@ -339,7 +339,7 @@ func (wakuM *WakuMetadata) DisconnectPeerOnShardMismatch(ctx context.Context, pe
 		return err
 	}
 
-	if !rs.ContainsAnyShard(rs.ClusterID, peerShards) {
+	if rs != nil && !rs.ContainsAnyShard(rs.ClusterID, peerShards) {
 		wakuM.log.Info("shard mismatch", logging.HostID("peerID", peerID), zap.Uint16("clusterID", rs.ClusterID), zap.Uint16s("ourShardIDs", rs.ShardIDs), zap.Uint16s("theirShardIDs", peerShards))
 		wakuM.disconnect(peerID)
 		return errors.New("shard mismatch")

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/client.go
@@ -76,6 +76,9 @@ func (wakuPX *WakuPeerExchange) Request(ctx context.Context, numPeers int, opts 
 
 	stream, err := wakuPX.h.NewStream(ctx, params.selectedPeer, PeerExchangeID_v20alpha1)
 	if err != nil {
+		if ps, ok := wakuPX.h.Peerstore().(peerstore.WakuPeerstore); ok {
+			ps.AddConnFailure(peer.AddrInfo{ID: params.selectedPeer})
+		}
 		return err
 	}
 

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/protocol.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/protocol.go
@@ -98,7 +98,7 @@ func (wakuPX *WakuPeerExchange) onRequest() func(network.Stream) {
 
 		if wakuPX.limiter != nil && !wakuPX.limiter.Allow() {
 			wakuPX.metrics.RecordError(rateLimitFailure)
-			wakuPX.log.Error("exceeds the rate limit")
+			wakuPX.log.Info("exceeds the rate limit")
 			// TODO: peer exchange protocol should contain an err field
 			if err := stream.Reset(); err != nil {
 				wakuPX.log.Error("resetting connection", zap.Error(err))

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
@@ -253,6 +253,9 @@ func (s *WakuStore) queryFrom(ctx context.Context, storeRequest *pb.StoreQueryRe
 	stream, err := s.h.NewStream(ctx, selectedPeer, StoreQueryID_v300)
 	if err != nil {
 		logger.Error("creating stream to peer", zap.Error(err))
+		if ps, ok := s.h.Peerstore().(peerstore.WakuPeerstore); ok {
+			ps.AddConnFailure(peer.AddrInfo{ID: selectedPeer})
+		}
 		return nil, err
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1018,7 +1018,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240724124731-a9be17fd4848
+# github.com/waku-org/go-waku v0.8.1-0.20240731185821-04a9af931f26
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1018,7 +1018,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240724122952-11a258a4d8c7
+# github.com/waku-org/go-waku v0.8.1-0.20240724124731-a9be17fd4848
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1018,7 +1018,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240716173432-8f3332d1a08d
+# github.com/waku-org/go-waku v0.8.1-0.20240724022917-58d9721026db
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1018,7 +1018,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240724052716-50ad6698f64a
+# github.com/waku-org/go-waku v0.8.1-0.20240724122952-11a258a4d8c7
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1018,7 +1018,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240724022917-58d9721026db
+# github.com/waku-org/go-waku v0.8.1-0.20240724052716-50ad6698f64a
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests

--- a/wakuv2/filter_manager.go
+++ b/wakuv2/filter_manager.go
@@ -111,7 +111,7 @@ func (mgr *FilterManager) addFilter(filterID string, f *common.Filter) {
 
 	afilter, ok := mgr.incompleteFilterBatch[f.PubsubTopic]
 	if !ok {
-		//no existing batch for pubsubTopic
+		// no existing batch for pubsubTopic
 		mgr.logger.Debug("new pubsubTopic batch", zap.String("topic", f.PubsubTopic))
 		cf := mgr.buildContentFilter(f.PubsubTopic, f.ContentTopics)
 		afilter = filterConfig{uuid.NewString(), cf}
@@ -120,9 +120,9 @@ func (mgr *FilterManager) addFilter(filterID string, f *common.Filter) {
 	} else {
 		mgr.logger.Debug("existing pubsubTopic batch", zap.String("agg-filter-id", afilter.ID), zap.String("topic", f.PubsubTopic))
 		if len(afilter.contentFilter.ContentTopics)+len(f.ContentTopics) > filterSubBatchSize {
-			//filter batch limit is hit
+			// filter batch limit is hit
 			if mgr.onlineChecker.IsOnline() {
-				//node is online, go ahead and subscribe the batch
+				// node is online, go ahead and subscribe the batch
 				mgr.logger.Debug("crossed pubsubTopic batchsize and online, subscribing to filters", zap.String("agg-filter-id", afilter.ID), zap.String("topic", f.PubsubTopic), zap.Int("batch-size", len(afilter.contentFilter.ContentTopics)+len(f.ContentTopics)))
 				go mgr.subscribeAndRunLoop(afilter)
 			} else {
@@ -136,7 +136,7 @@ func (mgr *FilterManager) addFilter(filterID string, f *common.Filter) {
 			mgr.incompleteFilterBatch[f.PubsubTopic] = afilter
 			mgr.filterConfigs[filterID] = filterConfig{afilter.ID, cf}
 		} else {
-			//add to existing batch as batch limit not reached
+			// add to existing batch as batch limit not reached
 			var contentTopics []string
 			for _, ct := range maps.Keys(f.ContentTopics) {
 				afilter.contentFilter.ContentTopics[ct.ContentTopic()] = struct{}{}
@@ -165,14 +165,14 @@ func (mgr *FilterManager) subscribeAndRunLoop(f filterConfig) {
 }
 
 func (mgr *FilterManager) networkChange() {
-	mgr.node.PingPeers() //Ping all peers to check if subscriptions are alive
+	mgr.node.PingPeers() // ping all peers to check if subscriptions are alive
 }
 
 func (mgr *FilterManager) onConnectionStatusChange(pubsubTopic string, newStatus bool) {
 	subs := mgr.node.Subscriptions()
 	mgr.logger.Debug("inside on connection status change", zap.Bool("new-status", newStatus),
 		zap.Int("agg filters count", len(mgr.filterSubscriptions)), zap.Int("filter subs count", len(subs)))
-	if newStatus && !mgr.onlineChecker.IsOnline() { //switched from offline to Online
+	if newStatus && !mgr.onlineChecker.IsOnline() { // switched from offline to Online
 		mgr.networkChange()
 		mgr.logger.Debug("switching from offline to online")
 		mgr.Lock()
@@ -180,7 +180,7 @@ func (mgr *FilterManager) onConnectionStatusChange(pubsubTopic string, newStatus
 			for af := range mgr.waitingToSubQueue {
 				// TODO: change the below logic once topic specific health is implemented for lightClients
 				if pubsubTopic == "" || pubsubTopic == af.contentFilter.PubsubTopic {
-					// Check if any filter subs are pending and subscribe them
+					// check if any filter subs are pending and subscribe them
 					mgr.logger.Debug("subscribing from filter queue", zap.String("filter-id", af.ID), zap.Stringer("content-filter", af.contentFilter))
 					go mgr.subscribeAndRunLoop(af)
 				} else {

--- a/wakuv2/filter_manager.go
+++ b/wakuv2/filter_manager.go
@@ -173,7 +173,7 @@ func (mgr *FilterManager) onConnectionStatusChange(pubsubTopic string, newStatus
 	mgr.logger.Debug("inside on connection status change", zap.Bool("new-status", newStatus),
 		zap.Int("agg filters count", len(mgr.filterSubscriptions)), zap.Int("filter subs count", len(subs)))
 	if newStatus && !mgr.onlineChecker.IsOnline() { //switched from offline to Online
-		mgr.node.PingPeers() //Ping all peers to check if subscriptions are alive
+		mgr.networkChange()
 		mgr.logger.Debug("switching from offline to online")
 		mgr.Lock()
 		if len(mgr.waitingToSubQueue) > 0 {

--- a/wakuv2/filter_manager.go
+++ b/wakuv2/filter_manager.go
@@ -170,9 +170,8 @@ func (mgr *FilterManager) networkChange() {
 
 func (mgr *FilterManager) onConnectionStatusChange(pubsubTopic string, newStatus bool) {
 	subs := mgr.node.Subscriptions()
-	mgr.logger.Debug("filter subs count", zap.Int("count", len(subs)))
 	mgr.logger.Debug("inside on connection status change", zap.Bool("new-status", newStatus),
-		zap.Int("agg filters count", len(mgr.filterSubscriptions)))
+		zap.Int("agg filters count", len(mgr.filterSubscriptions)), zap.Int("filter subs count", len(subs)))
 	if newStatus && !mgr.onlineChecker.IsOnline() { //switched from offline to Online
 		mgr.node.PingPeers() //Ping all peers to check if subscriptions are alive
 		mgr.logger.Debug("switching from offline to online")

--- a/wakuv2/filter_manager.go
+++ b/wakuv2/filter_manager.go
@@ -165,9 +165,12 @@ func (mgr *FilterManager) subscribeAndRunLoop(f filterConfig) {
 }
 
 func (mgr *FilterManager) onConnectionStatusChange(pubsubTopic string, newStatus bool) {
+	subs := mgr.node.Subscriptions()
+	mgr.logger.Debug("filter subs count", zap.Int("count", len(subs)))
 	mgr.logger.Debug("inside on connection status change", zap.Bool("new-status", newStatus),
 		zap.Int("agg filters count", len(mgr.filterSubscriptions)))
 	if newStatus && !mgr.onlineChecker.IsOnline() { //switched from offline to Online
+		go mgr.node.PingPeers() //Ping all peers to check if subscriptions are alive
 		mgr.logger.Debug("switching from offline to online")
 		mgr.Lock()
 		if len(mgr.waitingToSubQueue) > 0 {

--- a/wakuv2/filter_manager.go
+++ b/wakuv2/filter_manager.go
@@ -164,13 +164,17 @@ func (mgr *FilterManager) subscribeAndRunLoop(f filterConfig) {
 	}
 }
 
+func (mgr *FilterManager) networkChange() {
+	mgr.node.PingPeers() //Ping all peers to check if subscriptions are alive
+}
+
 func (mgr *FilterManager) onConnectionStatusChange(pubsubTopic string, newStatus bool) {
 	subs := mgr.node.Subscriptions()
 	mgr.logger.Debug("filter subs count", zap.Int("count", len(subs)))
 	mgr.logger.Debug("inside on connection status change", zap.Bool("new-status", newStatus),
 		zap.Int("agg filters count", len(mgr.filterSubscriptions)))
 	if newStatus && !mgr.onlineChecker.IsOnline() { //switched from offline to Online
-		go mgr.node.PingPeers() //Ping all peers to check if subscriptions are alive
+		mgr.node.PingPeers() //Ping all peers to check if subscriptions are alive
 		mgr.logger.Debug("switching from offline to online")
 		mgr.Lock()
 		if len(mgr.waitingToSubQueue) > 0 {

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1792,19 +1792,21 @@ func (w *Waku) ConnectionChanged(state connection.State) {
 	}
 
 	if isOnline && !w.onlineChecker.IsOnline() {
-		//TODO: analyze if we need to discover and connect to peers with peerExchange loop enabled.
-		w.discoverAndConnectPeers()
 		if !w.cfg.LightClient {
+			//TODO: analyze if we need to discover and connect to peers with peerExchange loop enabled.
+			w.discoverAndConnectPeers()
 			select {
 			case w.goingOnline <- struct{}{}:
 			default:
 				w.logger.Warn("could not write on connection changed channel")
 			}
-			//for lightClient state is updated in filterManager.
-			w.onlineChecker.SetOnline(isOnline)
+
 		}
 	}
-
+	if !w.cfg.LightClient {
+		//for lightClient state is updated in filterManager.
+		w.onlineChecker.SetOnline(isOnline)
+	}
 	w.state = state
 }
 

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1388,6 +1388,7 @@ func (w *Waku) Start() error {
 				}
 
 				w.ConnectionChanged(connection.State{
+					Type:    w.state.Type, //setting state type as previous one since there won't be a change here
 					Offline: !latestConnStatus.IsOnline,
 				})
 			}

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -657,6 +657,8 @@ func TestConfirmMessageDelivered(t *testing.T) {
 
 func TestOnlineChecker(t *testing.T) {
 	w, err := New(nil, "shards.staging", nil, nil, nil, nil, nil, nil)
+	require.NoError(t, w.Start())
+
 	require.NoError(t, err)
 	require.False(t, w.onlineChecker.IsOnline())
 


### PR DESCRIPTION
- Force a filter ping to all peers when node state changes from offline to online, this would check if any subscriptions are invalid and move them to other peers. This would ensure faster recovery during disconnections.
- Take some filter ping related changes from go-waku which ensure filter ping doesn't occur when node is offline.
- Handle connectionChange reported from status-mobile and pass it on to FilterManager
- Disconnect all peers when connectionChange is identified from application and in case of change in network i.e switch between wifi and cellular

Take changes from https://github.com/waku-org/go-waku/pull/1168