### PR TITLE
feat_:implement connector requestPermissions api

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -34,6 +34,9 @@ func NewAPI(s *Service) *API {
 		NetworkManager: s.nm,
 	})
 
+	// Request permissions
+	r.Register("wallet_requestPermissions", &commands.RequestPermissionsCommand{})
+
 	return &API{
 		s: s,
 		r: r,

--- a/services/connector/commands/request_permissions.go
+++ b/services/connector/commands/request_permissions.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+type RequestPermissionsCommand struct {
+}
+
+type Permission struct {
+	ParentCapability string `json:"parentCapability"`
+	Date             string `json:"date"`
+}
+
+type PermissionsResponse struct {
+	JSONRPC string       `json:"jsonrpc"`
+	ID      int          `json:"id"`
+	Result  []Permission `json:"result"`
+}
+
+var (
+	ErrNoRequestPermissionsParamsFound = errors.New("no request permission params found")
+	ErrMultipleKeysFound               = errors.New("Multiple methodNames found in request permissions params")
+	ErrInvalidParamType                = errors.New("Invalid parameter type")
+)
+
+func (r *RPCRequest) getRequestPermissionsParam() (string, error) {
+	if r.Params == nil || len(r.Params) == 0 {
+		return "", ErrEmptyRPCParams
+	}
+
+	paramMap, ok := r.Params[0].(map[string]interface{})
+	if !ok {
+		return "", ErrInvalidParamType
+	}
+
+	if len(paramMap) > 1 {
+		return "", ErrMultipleKeysFound
+	}
+
+	for methodName := range paramMap {
+		return methodName, nil
+	}
+
+	return "", ErrNoRequestPermissionsParamsFound
+}
+
+func (c *RequestPermissionsCommand) getPermissionResponse(methodName string) (string, error) {
+	date := time.Now().UnixNano() / int64(time.Millisecond)
+
+	response := Permission{
+		ParentCapability: methodName,
+		Date:             fmt.Sprintf("%d", date),
+	}
+
+	responseJSON, err := json.Marshal(response)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal response: %v", err)
+	}
+
+	return string(responseJSON), nil
+}
+
+func (c *RequestPermissionsCommand) Execute(request RPCRequest) (string, error) {
+	err := request.Validate()
+	if err != nil {
+		return "", err
+	}
+
+	methodName, err := request.getRequestPermissionsParam()
+	if err != nil {
+		return "", err
+	}
+
+	return c.getPermissionResponse(methodName)
+}


### PR DESCRIPTION
### Description

This is the implementation of the `requestPermissions` api for the Browser plugin connector.

### How tested

Tested using postman with the following request : 

```bash
{
    "jsonrpc": "2.0",
    "id": 37,
    "method": "connector_callRPC",
    "params": ["{\"method\": \"wallet_requestPermissions\", \"params\": [{\"eth_requestAccounts\":{}}], \"url\": \"https://www.status-im.cn\", \"name\": \"Satus\", \"iconUrl\": \"https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/osa.svg\" }"]
}
```

And I could see the result : 

```bash
{
    "jsonrpc": "2.0",
    "id": 37,
    "result": "{\"parentCapability\":\"eth_requestAccounts\",\"date\":\"1721870990324\"}"
}
```

### Important changes:
- [x] Add requestPermissions api

Closes #5565
