### PR TITLE
Added improvements in resolving the best route

### DIFF
--- a/services/wallet/router/errors.go
+++ b/services/wallet/router/errors.go
@@ -21,12 +21,14 @@ var (
 	ErrLockedAmountNotNegative                   = &errors.ErrorResponse{Code: errors.ErrorCode("WR-013"), Details: "locked amount must not be negative"}
 	ErrLockedAmountExceedsTotalSendAmount        = &errors.ErrorResponse{Code: errors.ErrorCode("WR-014"), Details: "locked amount exceeds the total amount to send"}
 	ErrLockedAmountLessThanSendAmountAllNetworks = &errors.ErrorResponse{Code: errors.ErrorCode("WR-015"), Details: "locked amount is less than the total amount to send, but all networks are locked"}
-	ErrNotEnoughTokenBalance                     = &errors.ErrorResponse{Code: errors.ErrorCode("WR-016"), Details: "not enough token balance"}
-	ErrNotEnoughNativeBalance                    = &errors.ErrorResponse{Code: errors.ErrorCode("WR-017"), Details: "not enough native balance"}
+	ErrNotEnoughTokenBalance                     = &errors.ErrorResponse{Code: errors.ErrorCode("WR-016"), Details: "{\"token\": %s, \"chainId\": %d}"}
+	ErrNotEnoughNativeBalance                    = &errors.ErrorResponse{Code: errors.ErrorCode("WR-017"), Details: "{\"token\": %s, \"chainId\": %d}"}
 	ErrNativeTokenNotFound                       = &errors.ErrorResponse{Code: errors.ErrorCode("WR-018"), Details: "native token not found"}
 	ErrDisabledChainFoundAmongLockedNetworks     = &errors.ErrorResponse{Code: errors.ErrorCode("WR-019"), Details: "disabled chain found among locked networks"}
 	ErrENSSetPubKeyInvalidUsername               = &errors.ErrorResponse{Code: errors.ErrorCode("WR-020"), Details: "a valid username, ending in '.eth', is required for ENSSetPubKey"}
 	ErrLockedAmountExcludesAllSupported          = &errors.ErrorResponse{Code: errors.ErrorCode("WR-021"), Details: "all supported chains are excluded, routing impossible"}
 	ErrTokenNotFound                             = &errors.ErrorResponse{Code: errors.ErrorCode("WR-022"), Details: "token not found"}
 	ErrNoBestRouteFound                          = &errors.ErrorResponse{Code: errors.ErrorCode("WR-023"), Details: "no best route found"}
+	ErrCannotCheckReceiverBalance                = &errors.ErrorResponse{Code: errors.ErrorCode("WR-024"), Details: "cannot check receiver balance"}
+	ErrCannotCheckLockedAmounts                  = &errors.ErrorResponse{Code: errors.ErrorCode("WR-025"), Details: "cannot check locked amounts"}
 )

--- a/services/wallet/router/fees.go
+++ b/services/wallet/router/fees.go
@@ -54,27 +54,23 @@ type SuggestedFeesGwei struct {
 	EIP1559Enabled       bool       `json:"eip1559Enabled"`
 }
 
-func (s *SuggestedFees) feeFor(mode GasFeeMode) *big.Int {
-	if !s.EIP1559Enabled {
-		return s.GasPrice
-	}
-
+func (m *MaxFeesLevels) feeFor(mode GasFeeMode) *big.Int {
 	if mode == GasFeeLow {
-		return s.MaxFeesLevels.Low.ToInt()
+		return m.Low.ToInt()
 	}
 
 	if mode == GasFeeHigh {
-		return s.MaxFeesLevels.High.ToInt()
+		return m.High.ToInt()
 	}
 
-	return s.MaxFeesLevels.Medium.ToInt()
+	return m.Medium.ToInt()
+}
+
+func (s *SuggestedFees) feeFor(mode GasFeeMode) *big.Int {
+	return s.MaxFeesLevels.feeFor(mode)
 }
 
 func (s *SuggestedFeesGwei) feeFor(mode GasFeeMode) *big.Float {
-	if !s.EIP1559Enabled {
-		return s.GasPrice
-	}
-
 	if mode == GasFeeLow {
 		return s.MaxFeePerGasLow
 	}
@@ -141,9 +137,9 @@ func (f *FeeManager) SuggestedFees(ctx context.Context, chainID uint64) (*Sugges
 			BaseFee:              big.NewInt(0),
 			MaxPriorityFeePerGas: big.NewInt(0),
 			MaxFeesLevels: &MaxFeesLevels{
-				Low:    (*hexutil.Big)(big.NewInt(0)),
-				Medium: (*hexutil.Big)(big.NewInt(0)),
-				High:   (*hexutil.Big)(big.NewInt(0)),
+				Low:    (*hexutil.Big)(gasPrice),
+				Medium: (*hexutil.Big)(gasPrice),
+				High:   (*hexutil.Big)(gasPrice),
 			},
 			EIP1559Enabled: false,
 		}, nil

--- a/services/wallet/router/filter_test.go
+++ b/services/wallet/router/filter_test.go
@@ -979,7 +979,6 @@ func TestFilterRoutesV2(t *testing.T) {
 			},
 			expectedRoutes: [][]*PathV2{
 				{pathC1A1, pathC2A2},
-				{pathC1A1, pathC2A1, pathC3A1},
 			},
 		},
 		{

--- a/services/wallet/router/filter_test.go
+++ b/services/wallet/router/filter_test.go
@@ -27,11 +27,20 @@ var (
 	amount5 = hexutil.Big(*big.NewInt(500))
 
 	path0 = &PathV2{FromChain: network4, AmountIn: &amount0}
-	path1 = &PathV2{FromChain: network1, AmountIn: &amount1}
-	path2 = &PathV2{FromChain: network2, AmountIn: &amount2}
-	path3 = &PathV2{FromChain: network3, AmountIn: &amount3}
-	path4 = &PathV2{FromChain: network4, AmountIn: &amount4}
-	path5 = &PathV2{FromChain: network5, AmountIn: &amount5}
+
+	pathC1A1 = &PathV2{FromChain: network1, AmountIn: &amount1}
+
+	pathC2A1 = &PathV2{FromChain: network2, AmountIn: &amount1}
+	pathC2A2 = &PathV2{FromChain: network2, AmountIn: &amount2}
+
+	pathC3A1 = &PathV2{FromChain: network3, AmountIn: &amount1}
+	pathC3A2 = &PathV2{FromChain: network3, AmountIn: &amount2}
+	pathC3A3 = &PathV2{FromChain: network3, AmountIn: &amount3}
+
+	pathC4A1 = &PathV2{FromChain: network4, AmountIn: &amount1}
+	pathC4A4 = &PathV2{FromChain: network4, AmountIn: &amount4}
+
+	pathC5A5 = &PathV2{FromChain: network5, AmountIn: &amount5}
 )
 
 func routesEqual(t *testing.T, expected, actual [][]*PathV2) bool {
@@ -167,33 +176,33 @@ func TestCalculateRestAmountInV2(t *testing.T) {
 		expected    *big.Int
 	}{
 		{
-			name:        "Exclude path1",
-			route:       []*PathV2{path1, path2, path3},
-			excludePath: path1,
+			name:        "Exclude pathC1A1",
+			route:       []*PathV2{pathC1A1, pathC2A2, pathC3A3},
+			excludePath: pathC1A1,
 			expected:    big.NewInt(500), // 200 + 300
 		},
 		{
-			name:        "Exclude path2",
-			route:       []*PathV2{path1, path2, path3},
-			excludePath: path2,
+			name:        "Exclude pathC2A2",
+			route:       []*PathV2{pathC1A1, pathC2A2, pathC3A3},
+			excludePath: pathC2A2,
 			expected:    big.NewInt(400), // 100 + 300
 		},
 		{
-			name:        "Exclude path3",
-			route:       []*PathV2{path1, path2, path3},
-			excludePath: path3,
+			name:        "Exclude pathC3A3",
+			route:       []*PathV2{pathC1A1, pathC2A2, pathC3A3},
+			excludePath: pathC3A3,
 			expected:    big.NewInt(300), // 100 + 200
 		},
 		{
 			name:        "Single path, exclude that path",
-			route:       []*PathV2{path1},
-			excludePath: path1,
+			route:       []*PathV2{pathC1A1},
+			excludePath: pathC1A1,
 			expected:    big.NewInt(0), // No other paths
 		},
 		{
 			name:        "Empty route",
 			route:       []*PathV2{},
-			excludePath: path1,
+			excludePath: pathC1A1,
 			expected:    big.NewInt(0), // No paths
 		},
 		{
@@ -222,42 +231,42 @@ func TestIsValidForNetworkComplianceV2(t *testing.T) {
 	}{
 		{
 			name:           "Route with all included chain IDs",
-			route:          []*PathV2{path1, path2},
+			route:          []*PathV2{pathC1A1, pathC2A2},
 			fromIncluded:   map[uint64]bool{1: true, 2: true},
 			fromExcluded:   map[uint64]bool{},
 			expectedResult: true,
 		},
 		{
 			name:           "Route with fromExcluded only",
-			route:          []*PathV2{path1, path2},
+			route:          []*PathV2{pathC1A1, pathC2A2},
 			fromIncluded:   map[uint64]bool{},
 			fromExcluded:   map[uint64]bool{3: false, 4: false},
 			expectedResult: true,
 		},
 		{
 			name:           "Route without excluded chain IDs",
-			route:          []*PathV2{path1, path2},
+			route:          []*PathV2{pathC1A1, pathC2A2},
 			fromIncluded:   map[uint64]bool{1: false, 2: false},
 			fromExcluded:   map[uint64]bool{3: false, 4: false},
 			expectedResult: true,
 		},
 		{
 			name:           "Route with an excluded chain ID",
-			route:          []*PathV2{path1, path3},
+			route:          []*PathV2{pathC1A1, pathC3A3},
 			fromIncluded:   map[uint64]bool{1: false, 2: false},
 			fromExcluded:   map[uint64]bool{3: false, 4: false},
 			expectedResult: false,
 		},
 		{
 			name:           "Route missing one included chain ID",
-			route:          []*PathV2{path1},
+			route:          []*PathV2{pathC1A1},
 			fromIncluded:   map[uint64]bool{1: false, 2: false},
 			fromExcluded:   map[uint64]bool{},
 			expectedResult: false,
 		},
 		{
 			name:           "Route with no fromIncluded or fromExcluded",
-			route:          []*PathV2{path1, path2},
+			route:          []*PathV2{pathC1A1, pathC2A2},
 			fromIncluded:   map[uint64]bool{},
 			fromExcluded:   map[uint64]bool{},
 			expectedResult: true,
@@ -289,7 +298,7 @@ func TestHasSufficientCapacityV2(t *testing.T) {
 	}{
 		{
 			name:             "All paths meet required amount",
-			route:            []*PathV2{path1, path2, path3},
+			route:            []*PathV2{pathC1A1, pathC2A2, pathC3A3},
 			amountIn:         big.NewInt(600),
 			fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1, 2: &amount2, 3: &amount3},
 			expected:         true,
@@ -299,7 +308,7 @@ func TestHasSufficientCapacityV2(t *testing.T) {
 		/*
 			{
 				name:             "A path does not meet required amount",
-				route:            []*PathV2{path1, path2, path3},
+				route:            []*PathV2{pathC1A1, pathC2A2, pathC3A3},
 				amountIn:         big.NewInt(600),
 				fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1, 2: &amount2, 4: &amount4},
 				expected:         false,
@@ -307,35 +316,35 @@ func TestHasSufficientCapacityV2(t *testing.T) {
 		*/
 		{
 			name:             "No fromLockedAmount",
-			route:            []*PathV2{path1, path2, path3},
+			route:            []*PathV2{pathC1A1, pathC2A2, pathC3A3},
 			amountIn:         big.NewInt(600),
 			fromLockedAmount: map[uint64]*hexutil.Big{},
 			expected:         true,
 		},
 		{
 			name:             "Single path meets required amount",
-			route:            []*PathV2{path1},
+			route:            []*PathV2{pathC1A1},
 			amountIn:         big.NewInt(100),
 			fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1},
 			expected:         true,
 		},
 		{
 			name:             "Single path does not meet required amount",
-			route:            []*PathV2{path1},
+			route:            []*PathV2{pathC1A1},
 			amountIn:         big.NewInt(200),
 			fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1},
 			expected:         false,
 		},
 		{
 			name:             "Path meets required amount with excess",
-			route:            []*PathV2{path1, path2},
+			route:            []*PathV2{pathC1A1, pathC2A2},
 			amountIn:         big.NewInt(250),
 			fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1, 2: &amount2},
 			expected:         true,
 		},
 		{
 			name:             "Path does not meet required amount due to insufficient rest",
-			route:            []*PathV2{path1, path2, path4},
+			route:            []*PathV2{pathC1A1, pathC2A2, pathC4A4},
 			amountIn:         big.NewInt(800),
 			fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1, 4: &amount4},
 			expected:         false,
@@ -596,40 +605,40 @@ func TestFilterNetworkComplianceV2(t *testing.T) {
 		{
 			name: "Routes without excluded chain IDs, missing included path",
 			routes: [][]*PathV2{
-				{path1, path2},
-				{path2, path3},
+				{pathC1A1, pathC2A2},
+				{pathC2A2, pathC3A3},
 			},
 			fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1, 2: &amount2},
 			expected: [][]*PathV2{
-				{path1, path2},
+				{pathC1A1, pathC2A2},
 			},
 		},
 		{
 			name: "Routes with an excluded chain ID",
 			routes: [][]*PathV2{
-				{path1, path2},
-				{path2, path3, path0},
+				{pathC1A1, pathC2A2},
+				{pathC2A2, pathC3A3, path0},
 			},
 			fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1, 2: &amount2, 4: &amount0},
 			expected: [][]*PathV2{
-				{path1, path2},
+				{pathC1A1, pathC2A2},
 			},
 		},
 		{
 			name: "Routes with all included chain IDs",
 			routes: [][]*PathV2{
-				{path1, path2, path3},
+				{pathC1A1, pathC2A2, pathC3A3},
 			},
 			fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1, 2: &amount2, 3: &amount3},
 			expected: [][]*PathV2{
-				{path1, path2, path3},
+				{pathC1A1, pathC2A2, pathC3A3},
 			},
 		},
 		{
 			name: "Routes missing one included chain ID",
 			routes: [][]*PathV2{
-				{path1, path2},
-				{path1},
+				{pathC1A1, pathC2A2},
+				{pathC1A1},
 			},
 			fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1, 2: &amount2, 3: &amount3},
 			expected:         [][]*PathV2{},
@@ -637,32 +646,32 @@ func TestFilterNetworkComplianceV2(t *testing.T) {
 		{
 			name: "Routes with no fromLockedAmount",
 			routes: [][]*PathV2{
-				{path1, path2},
-				{path2, path3},
+				{pathC1A1, pathC2A2},
+				{pathC2A2, pathC3A3},
 			},
 			fromLockedAmount: map[uint64]*hexutil.Big{},
 			expected: [][]*PathV2{
-				{path1, path2},
-				{path2, path3},
+				{pathC1A1, pathC2A2},
+				{pathC2A2, pathC3A3},
 			},
 		},
 		{
 			name: "Routes with fromExcluded only",
 			routes: [][]*PathV2{
-				{path1, path2},
-				{path2, path3},
+				{pathC1A1, pathC2A2},
+				{pathC2A2, pathC3A3},
 			},
 			fromLockedAmount: map[uint64]*hexutil.Big{4: &amount0},
 			expected: [][]*PathV2{
-				{path1, path2},
-				{path2, path3},
+				{pathC1A1, pathC2A2},
+				{pathC2A2, pathC3A3},
 			},
 		},
 		{
 			name: "Routes with all excluded chain IDs",
 			routes: [][]*PathV2{
-				{path0, path1},
-				{path0, path2},
+				{path0, pathC1A1},
+				{path0, pathC2A2},
 			},
 			fromLockedAmount: map[uint64]*hexutil.Big{1: &amount1, 2: &amount2, 3: &amount3, 4: &amount0},
 			expected:         [][]*PathV2{},
@@ -691,27 +700,32 @@ func TestFilterCapacityValidationV2(t *testing.T) {
 			name: "Sufficient capacity with multiple paths",
 			routes: [][]*PathV2{
 				{
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100))},
-					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(200))},
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50))},
+					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+					{FromChain: network3, AmountIn: (*hexutil.Big)(big.NewInt(100))},
 				},
 				{
 					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50))},
-					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(200))},
+				},
+				{
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(200))},
 				},
 			},
-			amountIn: big.NewInt(150),
+			amountIn: big.NewInt(250),
 			fromLockedAmount: map[uint64]*hexutil.Big{
 				1: (*hexutil.Big)(big.NewInt(50)),
-				2: (*hexutil.Big)(big.NewInt(100)),
 			},
 			expectedRoutes: [][]*PathV2{
 				{
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50)), AmountInLocked: true},
-					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(100)), AmountInLocked: true},
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50))},
+					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+					{FromChain: network3, AmountIn: (*hexutil.Big)(big.NewInt(100))},
 				},
 				{
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50)), AmountInLocked: true},
-					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(100)), AmountInLocked: true},
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50))},
+					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(200))},
 				},
 			},
 		},
@@ -745,8 +759,8 @@ func TestFilterCapacityValidationV2(t *testing.T) {
 			},
 			expectedRoutes: [][]*PathV2{
 				{
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100)), AmountInLocked: true},
-					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(50)), AmountInLocked: true},
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(50))},
 				},
 			},
 		},
@@ -762,17 +776,35 @@ func TestFilterCapacityValidationV2(t *testing.T) {
 			fromLockedAmount: map[uint64]*hexutil.Big{},
 			expectedRoutes: [][]*PathV2{
 				{
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100)), AmountInLocked: false},
-					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(50)), AmountInLocked: false},
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(50))},
 				},
 			},
 		},
 		{
-			// TODO Is the behaviour of this test correct? It looks wrong
 			name: "Single route with sufficient capacity",
 			routes: [][]*PathV2{
 				{
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(200))},
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50))},
+					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+				},
+			},
+			amountIn: big.NewInt(150),
+			fromLockedAmount: map[uint64]*hexutil.Big{
+				1: (*hexutil.Big)(big.NewInt(50)),
+			},
+			expectedRoutes: [][]*PathV2{
+				{
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50))},
+					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+				},
+			},
+		},
+		{
+			name: "Single route with inappropriately locked amount",
+			routes: [][]*PathV2{
+				{
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100))},
 				},
 			},
 			amountIn: big.NewInt(150),
@@ -785,7 +817,7 @@ func TestFilterCapacityValidationV2(t *testing.T) {
 			name: "Single route with insufficient capacity",
 			routes: [][]*PathV2{
 				{
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50))},
 				},
 			},
 			amountIn: big.NewInt(150),
@@ -804,27 +836,12 @@ func TestFilterCapacityValidationV2(t *testing.T) {
 			expectedRoutes: [][]*PathV2{},
 		},
 		{
-			// TODO this seems wrong also. Should this test case work?
-			name: "Routes with duplicate chain IDs",
-			routes: [][]*PathV2{
-				{
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100))},
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100))},
-				},
-			},
-			amountIn: big.NewInt(150),
-			fromLockedAmount: map[uint64]*hexutil.Big{
-				1: (*hexutil.Big)(big.NewInt(50)),
-			},
-			expectedRoutes: [][]*PathV2{},
-		},
-		{
 			name: "Partial locked amounts",
 			routes: [][]*PathV2{
 				{
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100))},
-					{FromChain: network2, AmountIn: (*hexutil.Big)(big.NewInt(100))},
-					{FromChain: network3, AmountIn: (*hexutil.Big)(big.NewInt(200))},
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50))},
+					{FromChain: network3, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+					{FromChain: network4, AmountIn: (*hexutil.Big)(big.NewInt(100))},
 				},
 			},
 			amountIn: big.NewInt(250),
@@ -833,7 +850,13 @@ func TestFilterCapacityValidationV2(t *testing.T) {
 				2: (*hexutil.Big)(big.NewInt(0)), // Excluded path
 				3: (*hexutil.Big)(big.NewInt(100)),
 			},
-			expectedRoutes: [][]*PathV2{},
+			expectedRoutes: [][]*PathV2{
+				{
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(50))},
+					{FromChain: network3, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+					{FromChain: network4, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+				},
+			},
 		},
 		{
 			name: "Mixed networks with sufficient capacity",
@@ -843,15 +866,15 @@ func TestFilterCapacityValidationV2(t *testing.T) {
 					{FromChain: network3, AmountIn: (*hexutil.Big)(big.NewInt(200))},
 				},
 			},
-			amountIn: big.NewInt(250),
+			amountIn: big.NewInt(300),
 			fromLockedAmount: map[uint64]*hexutil.Big{
 				1: (*hexutil.Big)(big.NewInt(100)),
 				3: (*hexutil.Big)(big.NewInt(200)),
 			},
 			expectedRoutes: [][]*PathV2{
 				{
-					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100)), AmountInLocked: true},
-					{FromChain: network3, AmountIn: (*hexutil.Big)(big.NewInt(200)), AmountInLocked: true},
+					{FromChain: network1, AmountIn: (*hexutil.Big)(big.NewInt(100))},
+					{FromChain: network3, AmountIn: (*hexutil.Big)(big.NewInt(200))},
 				},
 			},
 		},
@@ -891,23 +914,46 @@ func TestFilterRoutesV2(t *testing.T) {
 		expectedRoutes   [][]*PathV2
 	}{
 		{
-			name: "Empty fromLockedAmount",
+			name: "Empty fromLockedAmount and routes don't match amountIn",
 			routes: [][]*PathV2{
-				{path1, path2},
-				{path3, path4},
+				{pathC1A1, pathC2A2},
+				{pathC3A3, pathC4A4},
 			},
 			amountIn:         big.NewInt(150),
 			fromLockedAmount: map[uint64]*hexutil.Big{},
+			expectedRoutes:   [][]*PathV2{},
+		},
+		{
+			name: "Empty fromLockedAmount and sigle route match amountIn",
+			routes: [][]*PathV2{
+				{pathC1A1, pathC2A2},
+				{pathC3A3, pathC4A4},
+			},
+			amountIn:         big.NewInt(300),
+			fromLockedAmount: map[uint64]*hexutil.Big{},
 			expectedRoutes: [][]*PathV2{
-				{path1, path2},
-				{path3, path4},
+				{pathC1A1, pathC2A2},
+			},
+		},
+		{
+			name: "Empty fromLockedAmount and more routes match amountIn",
+			routes: [][]*PathV2{
+				{pathC1A1, pathC2A2},
+				{pathC3A3, pathC4A4},
+				{pathC1A1, pathC2A1, pathC3A1},
+			},
+			amountIn:         big.NewInt(300),
+			fromLockedAmount: map[uint64]*hexutil.Big{},
+			expectedRoutes: [][]*PathV2{
+				{pathC1A1, pathC2A2},
+				{pathC1A1, pathC2A1, pathC3A1},
 			},
 		},
 		{
 			name: "All paths appear in fromLockedAmount but not within a single route",
 			routes: [][]*PathV2{
-				{path1, path3},
-				{path2, path4},
+				{pathC1A1, pathC3A3},
+				{pathC2A2, pathC4A4},
 			},
 			amountIn: big.NewInt(500),
 			fromLockedAmount: map[uint64]*hexutil.Big{
@@ -919,11 +965,12 @@ func TestFilterRoutesV2(t *testing.T) {
 			expectedRoutes: [][]*PathV2{},
 		},
 		{
-			name: "Mixed valid and invalid routes",
+			name: "Mixed valid and invalid routes I",
 			routes: [][]*PathV2{
-				{path1, path2},
-				{path2, path3},
-				{path1, path4},
+				{pathC1A1, pathC2A2},
+				{pathC2A2, pathC3A3},
+				{pathC1A1, pathC4A4},
+				{pathC1A1, pathC2A1, pathC3A1},
 			},
 			amountIn: big.NewInt(300),
 			fromLockedAmount: map[uint64]*hexutil.Big{
@@ -931,14 +978,32 @@ func TestFilterRoutesV2(t *testing.T) {
 				2: &amount2,
 			},
 			expectedRoutes: [][]*PathV2{
-				{path1, path2},
+				{pathC1A1, pathC2A2},
+				{pathC1A1, pathC2A1, pathC3A1},
+			},
+		},
+		{
+			name: "Mixed valid and invalid routes II",
+			routes: [][]*PathV2{
+				{pathC1A1, pathC2A2},
+				{pathC2A2, pathC3A3},
+				{pathC1A1, pathC4A4},
+				{pathC1A1, pathC2A1, pathC3A1},
+			},
+			amountIn: big.NewInt(300),
+			fromLockedAmount: map[uint64]*hexutil.Big{
+				1: &amount1,
+			},
+			expectedRoutes: [][]*PathV2{
+				{pathC1A1, pathC2A2},
+				{pathC1A1, pathC2A1, pathC3A1},
 			},
 		},
 		{
 			name: "All invalid routes",
 			routes: [][]*PathV2{
-				{path2, path3},
-				{path4, path5},
+				{pathC2A2, pathC3A3},
+				{pathC4A4, pathC5A5},
 			},
 			amountIn: big.NewInt(300),
 			fromLockedAmount: map[uint64]*hexutil.Big{
@@ -949,22 +1014,22 @@ func TestFilterRoutesV2(t *testing.T) {
 		{
 			name: "Single valid route",
 			routes: [][]*PathV2{
-				{path1, path3},
-				{path2, path3},
+				{pathC1A1, pathC3A3},
+				{pathC2A2, pathC3A3},
 			},
-			amountIn: big.NewInt(150),
+			amountIn: big.NewInt(400),
 			fromLockedAmount: map[uint64]*hexutil.Big{
 				1: &amount1,
 				3: &amount3,
 			},
 			expectedRoutes: [][]*PathV2{
-				{path1, path3},
+				{pathC1A1, pathC3A3},
 			},
 		},
 		{
-			name: "Route with mixed valid and invalid paths",
+			name: "Route with mixed valid and invalid paths I",
 			routes: [][]*PathV2{
-				{path1, path2, path3},
+				{pathC1A1, pathC2A2, pathC3A3},
 			},
 			amountIn: big.NewInt(300),
 			fromLockedAmount: map[uint64]*hexutil.Big{
@@ -972,6 +1037,36 @@ func TestFilterRoutesV2(t *testing.T) {
 				2: &amount0, // This path should be filtered out due to being excluded via a zero amount
 			},
 			expectedRoutes: [][]*PathV2{},
+		},
+		{
+			name: "Route with mixed valid and invalid paths II",
+			routes: [][]*PathV2{
+				{pathC1A1, pathC3A3},
+			},
+			amountIn: big.NewInt(400),
+			fromLockedAmount: map[uint64]*hexutil.Big{
+				1: &amount1,
+				2: &amount0, // This path should be filtered out due to being excluded via a zero amount, 0 value locked means this chain is disabled
+			},
+			expectedRoutes: [][]*PathV2{
+				{pathC1A1, pathC3A3},
+			},
+		},
+		{
+			name: "Route with mixed valid and invalid paths III",
+			routes: [][]*PathV2{
+				{pathC1A1, pathC3A3},
+				{pathC1A1, pathC3A2, pathC4A1},
+			},
+			amountIn: big.NewInt(400),
+			fromLockedAmount: map[uint64]*hexutil.Big{
+				1: &amount1,
+				2: &amount0, // This path should be filtered out due to being excluded via a zero amount, 0 value locked means this chain is disabled
+			},
+			expectedRoutes: [][]*PathV2{
+				{pathC1A1, pathC3A3},
+				{pathC1A1, pathC3A2, pathC4A1},
+			},
 		},
 	}
 

--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -305,9 +305,9 @@ func (h *HopBridgeProcessor) GetContractAddress(params ProcessorInputParams) (co
 }
 
 func (h *HopBridgeProcessor) sendOrBuild(sendArgs *MultipathProcessorTxArgs, signerFn bind.SignerFn) (tx *ethTypes.Transaction, err error) {
-	fromChain := h.networkManager.Find(sendArgs.ChainID)
+	fromChain := h.networkManager.Find(sendArgs.HopTx.ChainID)
 	if fromChain == nil {
-		return tx, fmt.Errorf("ChainID not supported %d", sendArgs.ChainID)
+		return tx, fmt.Errorf("ChainID not supported %d", sendArgs.HopTx.ChainID)
 	}
 
 	token := h.tokenManager.FindToken(fromChain, sendArgs.HopTx.Symbol)
@@ -344,22 +344,22 @@ func (h *HopBridgeProcessor) sendOrBuild(sendArgs *MultipathProcessorTxArgs, sig
 
 	switch contractType {
 	case hop.CctpL1Bridge:
-		tx, err = h.sendCctpL1BridgeTx(contractAddress, ethClient, sendArgs.HopTx.ChainID, sendArgs.HopTx.Recipient, txOpts, bonderFee)
+		tx, err = h.sendCctpL1BridgeTx(contractAddress, ethClient, sendArgs.HopTx.ChainIDTo, sendArgs.HopTx.Recipient, txOpts, bonderFee)
 	case hop.L1Bridge:
-		tx, err = h.sendL1BridgeTx(contractAddress, ethClient, sendArgs.HopTx.ChainID, sendArgs.HopTx.Recipient, txOpts, token, bonderFee)
+		tx, err = h.sendL1BridgeTx(contractAddress, ethClient, sendArgs.HopTx.ChainIDTo, sendArgs.HopTx.Recipient, txOpts, token, bonderFee)
 	case hop.L2AmmWrapper:
-		tx, err = h.sendL2AmmWrapperTx(contractAddress, ethClient, sendArgs.HopTx.ChainID, sendArgs.HopTx.Recipient, txOpts, bonderFee)
+		tx, err = h.sendL2AmmWrapperTx(contractAddress, ethClient, sendArgs.HopTx.ChainIDTo, sendArgs.HopTx.Recipient, txOpts, bonderFee)
 	case hop.CctpL2Bridge:
-		tx, err = h.sendCctpL2BridgeTx(contractAddress, ethClient, sendArgs.HopTx.ChainID, sendArgs.HopTx.Recipient, txOpts, bonderFee)
+		tx, err = h.sendCctpL2BridgeTx(contractAddress, ethClient, sendArgs.HopTx.ChainIDTo, sendArgs.HopTx.Recipient, txOpts, bonderFee)
 	case hop.L2Bridge:
-		tx, err = h.sendL2BridgeTx(contractAddress, ethClient, sendArgs.HopTx.ChainID, sendArgs.HopTx.Recipient, txOpts, bonderFee)
+		tx, err = h.sendL2BridgeTx(contractAddress, ethClient, sendArgs.HopTx.ChainIDTo, sendArgs.HopTx.Recipient, txOpts, bonderFee)
 	default:
 		return tx, ErrContractTypeNotSupported
 	}
 	if err != nil {
 		return tx, createBridgeHopErrorResponse(err)
 	}
-	err = h.transactor.StoreAndTrackPendingTx(txOpts.From, sendArgs.HopTx.Symbol, sendArgs.ChainID, sendArgs.HopTx.MultiTransactionID, tx)
+	err = h.transactor.StoreAndTrackPendingTx(txOpts.From, sendArgs.HopTx.Symbol, sendArgs.HopTx.ChainID, sendArgs.HopTx.MultiTransactionID, tx)
 	if err != nil {
 		return tx, createBridgeHopErrorResponse(err)
 	}
@@ -367,7 +367,7 @@ func (h *HopBridgeProcessor) sendOrBuild(sendArgs *MultipathProcessorTxArgs, sig
 }
 
 func (h *HopBridgeProcessor) Send(sendArgs *MultipathProcessorTxArgs, verifiedAccount *account.SelectedExtKey) (hash types.Hash, err error) {
-	tx, err := h.sendOrBuild(sendArgs, getSigner(sendArgs.ChainID, sendArgs.HopTx.From, verifiedAccount))
+	tx, err := h.sendOrBuild(sendArgs, getSigner(sendArgs.HopTx.ChainID, sendArgs.HopTx.From, verifiedAccount))
 	if err != nil {
 		return types.Hash{}, createBridgeHopErrorResponse(err)
 	}

--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -450,7 +450,7 @@ func (h *HopBridgeProcessor) CalculateAmountOut(params ProcessorInputParams) (*b
 		return nil, ErrNoBonderFeeFound
 	}
 	bonderFee := bonderFeeIns.(*BonderFee)
-	return bonderFee.EstimatedRecieved.Int, nil
+	return bonderFee.AmountOutMin.Int, nil
 }
 
 func (h *HopBridgeProcessor) packCctpL1BridgeTx(abi abi.ABI, toChainID uint64, to common.Address, bonderFee *BonderFee) ([]byte, error) {

--- a/services/wallet/router/router_v2_test_data.go
+++ b/services/wallet/router/router_v2_test_data.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -2499,6 +2500,90 @@ func getNormalTestParamsList() []normalTestParams {
 			},
 			expectedError:      ErrNoBestRouteFound,
 			expectedCandidates: []*PathV2{},
+		},
+		{
+			name: "ETH transfer - Not Enough Native Balance",
+			input: &RouteInputParams{
+				testnetMode:          false,
+				Uuid:                 uuid.NewString(),
+				SendType:             Transfer,
+				AddrFrom:             common.HexToAddress("0x1"),
+				AddrTo:               common.HexToAddress("0x2"),
+				AmountIn:             (*hexutil.Big)(big.NewInt(testAmount3ETHInWei)),
+				TokenID:              pathprocessor.EthSymbol,
+				DisabledFromChainIDs: []uint64{walletCommon.OptimismMainnet, walletCommon.ArbitrumMainnet},
+				DisabledToChainIDs:   []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet},
+
+				testsMode: true,
+				testParams: &routerTestParams{
+					tokenFrom: &token.Token{
+						ChainID:  1,
+						Symbol:   pathprocessor.EthSymbol,
+						Decimals: 18,
+					},
+					tokenPrices:           testTokenPrices,
+					suggestedFees:         testSuggestedFees,
+					balanceMap:            testBalanceMapPerChain,
+					estimationMap:         testEstimationMap,
+					bonderFeeMap:          testBbonderFeeMap,
+					approvalGasEstimation: testApprovalGasEstimation,
+					approvalL1Fee:         testApprovalL1Fee,
+				},
+			},
+			expectedError: &errors.ErrorResponse{
+				Code:    ErrNotEnoughNativeBalance.Code,
+				Details: fmt.Sprintf(ErrNotEnoughNativeBalance.Details, pathprocessor.EthSymbol, walletCommon.EthereumMainnet),
+			},
+			expectedCandidates: []*PathV2{
+				{
+					ProcessorName:    pathprocessor.ProcessorBridgeHopName,
+					FromChain:        &mainnet,
+					ToChain:          &optimism,
+					ApprovalRequired: false,
+				},
+			},
+		},
+		{
+			name: "ETH transfer - Not Enough Native Balance",
+			input: &RouteInputParams{
+				testnetMode:          false,
+				Uuid:                 uuid.NewString(),
+				SendType:             Transfer,
+				AddrFrom:             common.HexToAddress("0x1"),
+				AddrTo:               common.HexToAddress("0x2"),
+				AmountIn:             (*hexutil.Big)(big.NewInt(5 * testAmount100USDC)),
+				TokenID:              pathprocessor.UsdcSymbol,
+				DisabledFromChainIDs: []uint64{walletCommon.OptimismMainnet, walletCommon.ArbitrumMainnet},
+				DisabledToChainIDs:   []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet},
+
+				testsMode: true,
+				testParams: &routerTestParams{
+					tokenFrom: &token.Token{
+						ChainID:  1,
+						Symbol:   pathprocessor.UsdcSymbol,
+						Decimals: 6,
+					},
+					tokenPrices:           testTokenPrices,
+					suggestedFees:         testSuggestedFees,
+					balanceMap:            testBalanceMapPerChain,
+					estimationMap:         testEstimationMap,
+					bonderFeeMap:          testBbonderFeeMap,
+					approvalGasEstimation: testApprovalGasEstimation,
+					approvalL1Fee:         testApprovalL1Fee,
+				},
+			},
+			expectedError: &errors.ErrorResponse{
+				Code:    ErrNotEnoughTokenBalance.Code,
+				Details: fmt.Sprintf(ErrNotEnoughTokenBalance.Details, pathprocessor.UsdcSymbol, walletCommon.EthereumMainnet),
+			},
+			expectedCandidates: []*PathV2{
+				{
+					ProcessorName:    pathprocessor.ProcessorBridgeHopName,
+					FromChain:        &mainnet,
+					ToChain:          &optimism,
+					ApprovalRequired: true,
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
This PR adds improvements in resolving the best route for multi tx, should fix https://github.com/status-im/status-desktop/issues/15762

Some new params are also exposed in this PR for convenience:
- `MaxFeesPerGas                   *hexutil.Big   // Max fees per gas (determined by client via GasFeeMode, in ETH WEI)`
- `TxFee   *hexutil.Big // fee for the transaction (includes tx fee only, doesn't include approval fees, l1 fees, l1 approval fees, token fees or bonders fees, in ETH WEI)`
- `ApprovalFee   *hexutil.Big // Total fee for the approval transaction (includes approval tx fees only, doesn't include approval l1 fees, in ETH WEI)`
- `TxTotalFee *hexutil.Big // Total fee for the transaction (includes tx fees, approval fees, l1 fees, l1 approval fees, in ETH WEI)`

This is the issue we had:
<img width="591" alt="_a1" src="https://github.com/user-attachments/assets/06498ea4-90e6-49ab-a514-2316abce7c4b">


And with these changes it looks like this:
<img width="592" alt="_a2" src="https://github.com/user-attachments/assets/15c450bc-729e-4d12-a52f-5fe35859b083">
