### PR TITLE
feat(wallet)_: upgrade paraswap client to v6.2

### DIFF
--- a/services/wallet/router/pathprocessor/processor_swap_paraswap.go
+++ b/services/wallet/router/pathprocessor/processor_swap_paraswap.go
@@ -197,16 +197,15 @@ func (s *SwapParaswapProcessor) EstimateGas(params ProcessorInputParams) (uint64
 }
 
 func (s *SwapParaswapProcessor) GetContractAddress(params ProcessorInputParams) (address common.Address, err error) {
-	if params.FromChain.ChainID == walletCommon.EthereumMainnet {
-		address = common.HexToAddress("0x216b4b4ba9f3e719726886d34a177484278bfcae")
-	} else if params.FromChain.ChainID == walletCommon.ArbitrumMainnet {
-		address = common.HexToAddress("0x216b4b4ba9f3e719726886d34a177484278bfcae")
-	} else if params.FromChain.ChainID == walletCommon.OptimismMainnet {
-		address = common.HexToAddress("0x216b4b4ba9f3e719726886d34a177484278bfcae")
-	} else {
-		err = ErrContractNotFound
+	key := makeKey(params.FromChain.ChainID, params.ToChain.ChainID, params.FromToken.Symbol, params.ToToken.Symbol)
+	priceRouteIns, ok := s.priceRoute.Load(key)
+	if !ok {
+		err = ErrPriceRouteNotFound
+		return
 	}
-	return
+	priceRoute := priceRouteIns.(*paraswap.Route)
+
+	return priceRoute.TokenTransferProxy, nil
 }
 
 func (s *SwapParaswapProcessor) prepareTransaction(sendArgs *MultipathProcessorTxArgs) error {

--- a/services/wallet/router/pathprocessor/processor_swap_paraswap_test.go
+++ b/services/wallet/router/pathprocessor/processor_swap_paraswap_test.go
@@ -21,14 +21,16 @@ import (
 
 func TestParaswapWithPartnerFee(t *testing.T) {
 	testPriceRoute := &paraswap.Route{
-		GasCost:           &bigint.BigInt{Int: big.NewInt(500)},
-		SrcAmount:         &bigint.BigInt{Int: big.NewInt(1000)},
-		SrcTokenAddress:   common.HexToAddress("0x123"),
-		SrcTokenDecimals:  18,
-		DestAmount:        &bigint.BigInt{Int: big.NewInt(2000)},
-		DestTokenAddress:  common.HexToAddress("0x465"),
-		DestTokenDecimals: 6,
-		Side:              paraswap.SellSide,
+		GasCost:            &bigint.BigInt{Int: big.NewInt(500)},
+		SrcAmount:          &bigint.BigInt{Int: big.NewInt(1000)},
+		SrcTokenAddress:    common.HexToAddress("0x123"),
+		SrcTokenDecimals:   18,
+		DestAmount:         &bigint.BigInt{Int: big.NewInt(2000)},
+		DestTokenAddress:   common.HexToAddress("0x465"),
+		DestTokenDecimals:  6,
+		Side:               paraswap.SellSide,
+		ContractAddress:    common.HexToAddress("0x789"),
+		TokenTransferProxy: common.HexToAddress("0xabc"),
 	}
 
 	processor := NewSwapParaswapProcessor(nil, nil, nil)
@@ -72,6 +74,11 @@ func TestParaswapWithPartnerFee(t *testing.T) {
 			require.NotNil(t, amountOut)
 			require.Equal(t, testPriceRoute.DestAmount.Uint64(), amountOut.Uint64())
 		}
+
+		// Check contract address
+		contractAddress, err := processor.GetContractAddress(testInputParams)
+		require.NoError(t, err)
+		require.Equal(t, testPriceRoute.TokenTransferProxy, contractAddress)
 	}
 }
 

--- a/services/wallet/thirdparty/paraswap/request_build_transaction.go
+++ b/services/wallet/thirdparty/paraswap/request_build_transaction.go
@@ -12,7 +12,7 @@ import (
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 )
 
-const transactionsURL = "https://apiv5.paraswap.io/transactions/%d"
+const transactionsURL = "https://api.paraswap.io/transactions/%d"
 
 type Transaction struct {
 	From     string `json:"from"`

--- a/services/wallet/thirdparty/paraswap/request_price_route.go
+++ b/services/wallet/thirdparty/paraswap/request_price_route.go
@@ -13,18 +13,20 @@ import (
 	"github.com/status-im/status-go/services/wallet/bigint"
 )
 
-const pricesURL = "https://apiv5.paraswap.io/prices"
+const pricesURL = "https://api.paraswap.io/prices"
 
 type Route struct {
-	GasCost           *bigint.BigInt  `json:"gasCost"`
-	SrcAmount         *bigint.BigInt  `json:"srcAmount"`
-	SrcTokenAddress   common.Address  `json:"srcToken"`
-	SrcTokenDecimals  uint            `json:"srcDecimals"`
-	DestAmount        *bigint.BigInt  `json:"destAmount"`
-	DestTokenAddress  common.Address  `json:"destToken"`
-	DestTokenDecimals uint            `json:"destDecimals"`
-	RawPriceRoute     json.RawMessage `json:"rawPriceRoute"`
-	Side              SwapSide        `json:"side"`
+	GasCost            *bigint.BigInt  `json:"gasCost"`
+	SrcAmount          *bigint.BigInt  `json:"srcAmount"`
+	SrcTokenAddress    common.Address  `json:"srcToken"`
+	SrcTokenDecimals   uint            `json:"srcDecimals"`
+	DestAmount         *bigint.BigInt  `json:"destAmount"`
+	DestTokenAddress   common.Address  `json:"destToken"`
+	DestTokenDecimals  uint            `json:"destDecimals"`
+	RawPriceRoute      json.RawMessage `json:"rawPriceRoute"`
+	Side               SwapSide        `json:"side"`
+	ContractAddress    common.Address  `json:"contractAddress"`
+	TokenTransferProxy common.Address  `json:"tokenTransferProxy"`
 }
 
 type PriceRouteResponse struct {
@@ -48,7 +50,7 @@ func (c *ClientV5) FetchPriceRoute(ctx context.Context, srcTokenAddress common.A
 	params.Add("side", string(side))
 	params.Add("partner", c.partnerID)
 	params.Add("excludeContractMethodsWithoutFeeModel", "true")
-	params.Add("excludeDEXS", "AugustusRFQ") // This DEX causes issues when creating the transaction
+	params.Add("version", "6.2")
 
 	url := pricesURL
 	response, err := c.httpClient.DoGetRequest(ctx, url, params, nil)

--- a/services/wallet/thirdparty/paraswap/request_price_route_test.go
+++ b/services/wallet/thirdparty/paraswap/request_price_route_test.go
@@ -101,15 +101,17 @@ func TestUnmarshallPriceRoute(t *testing.T) {
 	responseData := []byte(fmt.Sprintf(`{"priceRoute":%s}`, string(data)))
 
 	route := Route{
-		GasCost:           &bigint.BigInt{Int: big.NewInt(111435)},
-		SrcAmount:         &bigint.BigInt{Int: big.NewInt(1000000000000000000)},
-		SrcTokenAddress:   common.HexToAddress("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
-		SrcTokenDecimals:  18,
-		DestAmount:        &bigint.BigInt{Int: big.NewInt(1000000000000000000)},
-		DestTokenAddress:  common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
-		DestTokenDecimals: 18,
-		Side:              SellSide,
-		RawPriceRoute:     data,
+		GasCost:            &bigint.BigInt{Int: big.NewInt(111435)},
+		SrcAmount:          &bigint.BigInt{Int: big.NewInt(1000000000000000000)},
+		SrcTokenAddress:    common.HexToAddress("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"),
+		SrcTokenDecimals:   18,
+		DestAmount:         &bigint.BigInt{Int: big.NewInt(1000000000000000000)},
+		DestTokenAddress:   common.HexToAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
+		DestTokenDecimals:  18,
+		Side:               SellSide,
+		RawPriceRoute:      data,
+		ContractAddress:    common.HexToAddress("0x485D2446711E141D2C8a94bC24BeaA5d5A110D74"),
+		TokenTransferProxy: common.HexToAddress("0x3e7d31751347BAacf35945074a4a4A41581B2271"),
 	}
 
 	receivedRoute, err := handlePriceRouteResponse(responseData)

--- a/services/wallet/thirdparty/paraswap/request_token_list.go
+++ b/services/wallet/thirdparty/paraswap/request_token_list.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 )
 
-const tokensURL = "https://apiv5.paraswap.io/tokens/%d" // nolint: gosec
+const tokensURL = "https://api.paraswap.io/tokens/%d" // nolint: gosec
 
 type Token struct {
 	Symbol   string `json:"symbol"`


### PR DESCRIPTION
Switch Paraswap API version from v5 to v6.2
https://developers.paraswap.network/api/master/api-v6.2

The v5 will surely get deprecated at some point. On top of that, the new contract is more gas efficient.
