### PR TITLE
fix(wallet): exclude paraswap providers not supporting partner fees

### DIFF
--- a/services/wallet/thirdparty/paraswap/request_price_route.go
+++ b/services/wallet/thirdparty/paraswap/request_price_route.go
@@ -47,6 +47,8 @@ func (c *ClientV5) FetchPriceRoute(ctx context.Context, srcTokenAddress common.A
 	params.Add("amount", amountWei.String())
 	params.Add("side", string(side))
 	params.Add("partner", c.partnerID)
+	params.Add("excludeContractMethodsWithoutFeeModel", "true")
+	params.Add("excludeDEXS", "AugustusRFQ") // This DEX causes issues when creating the transaction
 
 	url := pricesURL
 	response, err := c.httpClient.DoGetRequest(ctx, url, params)


### PR DESCRIPTION
Some methods use by Paraswap do not support taking partner fees. In this PR, we add the required parameters to avoid them.

Moreover, one provider that causes errors when building the transaction is exluded.

Closes https://github.com/status-im/status-desktop/issues/15755
