### PR TITLE
fix_: return array of account without accounts key

### DIFF
--- a/services/connector/commands/accounts.go
+++ b/services/connector/commands/accounts.go
@@ -13,15 +13,9 @@ type AccountsCommand struct {
 	Db *sql.DB
 }
 
-type AccountsResponse struct {
-	Accounts []types.Address `json:"accounts"`
-}
-
 func (c *AccountsCommand) dAppToAccountsResponse(dApp *persistence.DApp) (string, error) {
-	response := AccountsResponse{
-		Accounts: []types.Address{dApp.SharedAccount},
-	}
-	responseJSON, err := json.Marshal(response)
+	addresses := []types.Address{dApp.SharedAccount}
+	responseJSON, err := json.Marshal(addresses)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal response: %v", err)
 	}

--- a/services/connector/commands/accounts_test.go
+++ b/services/connector/commands/accounts_test.go
@@ -55,10 +55,11 @@ func TestGetAccountForPermittedDApp(t *testing.T) {
 	response, err := cmd.Execute(request)
 	assert.NoError(t, err)
 
-	result := &AccountsResponse{}
-	err = json.Unmarshal([]byte(response), result)
+	// Unmarshal the response into a slice of addresses
+	var result []types.Address
+	err = json.Unmarshal([]byte(response), &result)
 
 	assert.NoError(t, err)
-	assert.Len(t, result.Accounts, 1)
-	assert.Equal(t, sharedAccount, result.Accounts[0])
+	assert.Len(t, result, 1)
+	assert.Equal(t, sharedAccount, result[0])
 }

--- a/services/connector/commands/request_accounts_test.go
+++ b/services/connector/commands/request_accounts_test.go
@@ -89,12 +89,13 @@ func TestRequestAccountsAcceptedAndRequestAgain(t *testing.T) {
 	response, err := cmd.Execute(request)
 	assert.NoError(t, err)
 
-	result := &AccountsResponse{}
-	err = json.Unmarshal([]byte(response), result)
+	// Unmarshal the response into a slice of addresses
+	var result []types.Address
+	err = json.Unmarshal([]byte(response), &result)
 
 	assert.NoError(t, err)
-	assert.Len(t, result.Accounts, 1)
-	assert.Equal(t, accountAddress, result.Accounts[0])
+	assert.Len(t, result, 1)
+	assert.Equal(t, accountAddress, result[0])
 
 	// Check dApp in the database
 	dApp, err := persistence.SelectDAppByUrl(db, request.URL)
@@ -108,11 +109,11 @@ func TestRequestAccountsAcceptedAndRequestAgain(t *testing.T) {
 	response, err = cmd.Execute(request)
 	assert.NoError(t, err)
 
-	err = json.Unmarshal([]byte(response), result)
+	err = json.Unmarshal([]byte(response), &result)
 
 	assert.NoError(t, err)
-	assert.Len(t, result.Accounts, 1)
-	assert.Equal(t, accountAddress, result.Accounts[0])
+	assert.Len(t, result, 1)
+	assert.Equal(t, accountAddress, result[0])
 }
 
 func TestRequestAccountsRejected(t *testing.T) {

--- a/services/connector/connector_flows_test.go
+++ b/services/connector/connector_flows_test.go
@@ -77,7 +77,7 @@ func TestRequestAccountsSwitchChainAndSendTransactionFlow(t *testing.T) {
 
 	// Request accounts, now for real
 	request = "{\"method\": \"eth_requestAccounts\", \"params\": [], \"url\": \"http://testDAppURL123\", \"name\": \"testDAppName\", \"iconUrl\": \"http://testDAppIconUrl\" }"
-	expectedResponse := strings.ToLower(fmt.Sprintf(`{"accounts":["%s"]}`, accountAddress.Hex()))
+	expectedResponse := strings.ToLower(fmt.Sprintf(`["%s"]`, accountAddress.Hex()))
 	response, err = api.CallRPC(request)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResponse, response)
@@ -98,7 +98,7 @@ func TestRequestAccountsSwitchChainAndSendTransactionFlow(t *testing.T) {
 
 	// Check the account after switching chain
 	request = "{\"method\": \"eth_accounts\", \"params\": [], \"url\": \"http://testDAppURL123\", \"name\": \"testDAppName\", \"iconUrl\": \"http://testDAppIconUrl\" }"
-	expectedResponse = strings.ToLower(fmt.Sprintf(`{"accounts":["%s"]}`, accountAddress.Hex()))
+	expectedResponse = strings.ToLower(fmt.Sprintf(`["%s"]`, accountAddress.Hex()))
 	response, err = api.CallRPC(request)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedResponse, response)


### PR DESCRIPTION
### Description

Currently, the request account API returns 

```bash
"{\"accounts\":[\"0xa77392123a1085f75e62eec7dea7e0e1e5142d5f\"]}"
```

instead of 

```bash
[\"0xa77392123a1085f75e62eec7dea7e0e1e5142d5f\"]
```

In other words, we do not require assigning to accounts.

fix #5575

### Test performed

![Screenshot from 2024-07-24 15-05-00](https://github.com/user-attachments/assets/33be1550-448e-402d-957e-9f7d76c2b612)

![Screenshot from 2024-07-24 15-04-34](https://github.com/user-attachments/assets/5c4f9d7e-272f-4c5e-bbf7-20b50156b838)

### Important changes:
- [x] Update existing package to not embed the accounts in an `accounts` key

Closes #5575
