### PR TITLE
chore: skip flaky tests

### DIFF
--- a/protocol/communities_events_token_master_test.go
+++ b/protocol/communities_events_token_master_test.go
@@ -294,6 +294,7 @@ func (s *TokenMasterCommunityEventsSuite) TestMemberReceiveTokenMasterEventsWhen
 }
 
 func (s *TokenMasterCommunityEventsSuite) TestJoinedTokenMasterReceiveRequestsToJoinWithRevealedAccounts() {
+	s.T().Skip("flaky test")
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{})
 
 	// set up additional user (bob) that will send request to join
@@ -308,6 +309,7 @@ func (s *TokenMasterCommunityEventsSuite) TestJoinedTokenMasterReceiveRequestsTo
 }
 
 func (s *TokenMasterCommunityEventsSuite) TestReceiveRequestsToJoinWithRevealedAccountsAfterGettingTokenMasterRole() {
+	s.T().Skip("flaky test")
 	// set up additional user (bob) that will send request to join
 	bob := s.newMessenger(accountPassword, []string{bobAccountAddress})
 	s.SetupAdditionalMessengers([]*Messenger{bob})

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -326,6 +326,7 @@ func (s *AdminCommunityEventsSuite) TestMemberReceiveOwnerEventsWhenControlNodeO
 }
 
 func (s *AdminCommunityEventsSuite) TestJoinedAdminReceiveRequestsToJoinWithoutRevealedAccounts() {
+	s.T().Skip("flaky test")
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{})
 
 	// set up additional user (bob) that will send request to join


### PR DESCRIPTION
Skipped 3 _community_ tests that has >50% failure in [latest nightly](https://ci.status.im/job/status-go/job/tests-nightly/292/Reports).


