### PR TITLE
fix_: make StoreNodeRequestManager filters ephemeral

### DIFF
--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -279,6 +279,8 @@ func (m *StoreNodeRequestManager) getFilter(requestType storeNodeRequestType, da
 		return nil, false, fmt.Errorf("invalid store node request type: %d", requestType)
 	}
 
+	filter.Ephemeral = true
+
 	return filter, true, nil
 }
 

--- a/protocol/transport/filters_manager.go
+++ b/protocol/transport/filters_manager.go
@@ -543,7 +543,7 @@ func (f *FiltersManager) LoadPublic(chatID string, pubsubTopic string) (*Filter,
 			f.logger.Debug("updating pubsub topic for filter",
 				zap.String("chatID", chatID),
 				zap.String("type", "public"),
-				zap.String("oldTOpic", chat.PubsubTopic),
+				zap.String("oldTopic", chat.PubsubTopic),
 				zap.String("newTopic", pubsubTopic),
 			)
 			chat.PubsubTopic = pubsubTopic


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/15768

When `StoreNodeRequestManager` is working, it installs a corresponding filter and uninstalls it when finished.
But in the meantime these filters might be picked up by the historic messages request loop.

Marking filter as `Ephemeral` fixes that.