### PR TITLE
fix_: return default chainID instead of throwing error for unregistered dApps

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -28,7 +28,10 @@ func NewAPI(s *Service) *API {
 	})
 
 	// Active chain per dapp management
-	r.Register("eth_chainId", &commands.ChainIDCommand{Db: s.db})
+	r.Register("eth_chainId", &commands.ChainIDCommand{
+		Db:             s.db,
+		NetworkManager: s.nm,
+	})
 	r.Register("wallet_switchEthereumChain", &commands.SwitchEthereumChainCommand{
 		Db:             s.db,
 		NetworkManager: s.nm,

--- a/services/connector/chainutils/utils.go
+++ b/services/connector/chainutils/utils.go
@@ -1,0 +1,41 @@
+package chainutils
+
+import (
+	"errors"
+
+	"github.com/status-im/status-go/params"
+)
+
+type NetworkManagerInterface interface {
+	GetActiveNetworks() ([]*params.Network, error)
+}
+
+var ErrNoActiveNetworks = errors.New("no active networks available")
+
+// GetSupportedChainIDs retrieves the chain IDs from the provided NetworkManager.
+func GetSupportedChainIDs(networkManager NetworkManagerInterface) ([]uint64, error) {
+	activeNetworks, err := networkManager.GetActiveNetworks()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(activeNetworks) < 1 {
+		return nil, ErrNoActiveNetworks
+	}
+
+	chainIDs := make([]uint64, len(activeNetworks))
+	for i, network := range activeNetworks {
+		chainIDs[i] = network.ChainID
+	}
+
+	return chainIDs, nil
+}
+
+func GetDefaultChainID(networkManager NetworkManagerInterface) (uint64, error) {
+	chainIDs, err := GetSupportedChainIDs(networkManager)
+	if err != nil {
+		return 0, err
+	}
+
+	return chainIDs[0], nil
+}

--- a/services/connector/commands/chain_id.go
+++ b/services/connector/commands/chain_id.go
@@ -2,13 +2,16 @@ package commands
 
 import (
 	"database/sql"
+	"strconv"
 
+	"github.com/status-im/status-go/services/connector/chainutils"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 )
 
 type ChainIDCommand struct {
-	Db *sql.DB
+	NetworkManager NetworkManagerInterface
+	Db             *sql.DB
 }
 
 func (c *ChainIDCommand) Execute(request RPCRequest) (string, error) {
@@ -23,7 +26,11 @@ func (c *ChainIDCommand) Execute(request RPCRequest) (string, error) {
 	}
 
 	if dApp == nil {
-		return "", ErrDAppIsNotPermittedByUser
+		defaultChainID, err := chainutils.GetDefaultChainID(c.NetworkManager)
+		if err != nil {
+			return "", err
+		}
+		return strconv.FormatUint(defaultChainID, 16), nil
 	}
 
 	return walletCommon.ChainID(dApp.ChainID).String(), nil

--- a/services/connector/commands/switch_ethereum_chain.go
+++ b/services/connector/commands/switch_ethereum_chain.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"slices"
 
+	"github.com/status-im/status-go/services/connector/chainutils"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 )
@@ -41,21 +42,7 @@ func (r *RPCRequest) getChainID() (uint64, error) {
 }
 
 func (c *SwitchEthereumChainCommand) getSupportedChainIDs() ([]uint64, error) {
-	activeNetworks, err := c.NetworkManager.GetActiveNetworks()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(activeNetworks) < 1 {
-		return nil, ErrNoActiveNetworks
-	}
-
-	chainIDs := make([]uint64, len(activeNetworks))
-	for i, network := range activeNetworks {
-		chainIDs[i] = network.ChainID
-	}
-
-	return chainIDs, nil
+	return chainutils.GetSupportedChainIDs(c.NetworkManager)
 }
 
 func (c *SwitchEthereumChainCommand) Execute(request RPCRequest) (string, error) {


### PR DESCRIPTION
### Description

Currently we do not return default chainID for unregistered dApp with Connector service. Recommendation from design is to return default ChainID for unregistered dApps.
A short summary which serves as a squashed-commit message.

### Testing

![Screenshot from 2024-07-25 11-26-20](https://github.com/user-attachments/assets/0cf43745-156f-4f7b-8c8e-9f288aadc1f9)


### Important changes:
- [x] Returns default ChainID for unregistered dApps

Closes #5583
