### PR TITLE
fix_: conversion from int to string causes code scanning error

### DIFF
--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -44,7 +44,7 @@ const (
 )
 
 func (c ChainID) String() string {
-	return strconv.Itoa(int(c))
+	return strconv.FormatUint(uint64(c), 10)
 }
 
 func (c ChainID) IsMainnet() bool {


### PR DESCRIPTION
### Description

Several PR's are seeing error due to code scanning error. This PR fixes the issue by updating the conversion function to a more secure code.

fixes #5599

Important changes:
- [x] Code scanning issue disappears

Closes #5599
