### PR TITLE
feat_: dapp connected notification

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -2706,6 +2706,10 @@ func (b *GethStatusBackend) injectAccountsIntoWakuService(w types.WakuKeyManager
 		b.statusNode.ChatService(accDB).Init(messenger)
 		b.statusNode.EnsService().Init(messenger.SyncEnsNamesWithDispatchMessage)
 		b.statusNode.CommunityTokensService().Init(messenger)
+
+		if walletService := b.statusNode.WalletService(); walletService != nil {
+			walletService.InjectMessenger(messenger)
+		}
 	}
 
 	return nil

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -2707,9 +2707,7 @@ func (b *GethStatusBackend) injectAccountsIntoWakuService(w types.WakuKeyManager
 		b.statusNode.EnsService().Init(messenger.SyncEnsNamesWithDispatchMessage)
 		b.statusNode.CommunityTokensService().Init(messenger)
 
-		if walletService := b.statusNode.WalletService(); walletService != nil {
-			walletService.InjectMessenger(messenger)
-		}
+		b.statusNode.ActivityCenterService().Init(messenger)
 	}
 
 	return nil

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -11,6 +11,8 @@ import (
 	"reflect"
 	"sync"
 
+	"github.com/status-im/status-go/services/activitycenter"
+
 	"github.com/syndtr/goleveldb/leveldb"
 	"go.uber.org/zap"
 
@@ -135,9 +137,11 @@ type StatusNode struct {
 	connectorSrvc          *connector.Service
 	appGeneralSrvc         *appgeneral.Service
 	ethSrvc                *eth.Service
+	activityCenterSrvc     *activitycenter.Service
 
-	accountsFeed event.Feed
-	walletFeed   event.Feed
+	accountsFeed      event.Feed
+	walletFeed        event.Feed
+	walletConnectFeed event.Feed
 }
 
 // New makes new instance of StatusNode.
@@ -509,6 +513,7 @@ func (n *StatusNode) stop() error {
 	n.publicMethods = make(map[string]bool)
 	n.pendingTracker = nil
 	n.appGeneralSrvc = nil
+	n.activityCenterSrvc = nil
 	n.logger.Debug("status node stopped")
 	return nil
 }

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -10,6 +10,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/status-im/status-go/services/activitycenter"
+
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/protocol/common/shard"
@@ -107,11 +109,12 @@ func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *server
 	services = appendIf(config.ConnectorConfig.Enabled, services, b.connectorService())
 	services = append(services, b.gifService(accDB))
 	services = append(services, b.ChatService(accDB))
+	services = append(services, b.activityCenterService(&b.walletConnectFeed))
 
 	// Wallet Service is used by wakuExtSrvc/wakuV2ExtSrvc
 	// Keep this initialization before the other two
 	if config.WalletConfig.Enabled {
-		walletService := b.walletService(accDB, b.appDB, &b.accountsFeed, settingsFeed, &b.walletFeed, config.WalletConfig.StatusProxyStageName)
+		walletService := b.walletService(accDB, b.appDB, &b.accountsFeed, settingsFeed, &b.walletFeed, &b.walletConnectFeed, config.WalletConfig.StatusProxyStageName)
 		services = append(services, walletService)
 	}
 
@@ -589,13 +592,14 @@ func (b *StatusNode) SetWalletCommunityInfoProvider(provider thirdparty.Communit
 	}
 }
 
-func (b *StatusNode) walletService(accountsDB *accounts.Database, appDB *sql.DB, accountsFeed *event.Feed, settingsFeed *event.Feed, walletFeed *event.Feed, statusProxyStageName string) *wallet.Service {
+func (b *StatusNode) walletService(accountsDB *accounts.Database, appDB *sql.DB, accountsFeed *event.Feed, settingsFeed *event.Feed, walletFeed *event.Feed, walletConnectFeed *event.Feed, statusProxyStageName string) *wallet.Service {
 	if b.walletSrvc == nil {
 		b.walletSrvc = wallet.NewService(
 			b.walletDB, accountsDB, appDB, b.rpcClient, accountsFeed, settingsFeed, b.gethAccountManager, b.transactor, b.config,
 			b.ensService(b.timeSourceNow()),
 			b.pendingTracker,
 			walletFeed,
+			walletConnectFeed,
 			b.httpServer,
 			statusProxyStageName,
 		)
@@ -788,4 +792,16 @@ func (b *StatusNode) CallRPC(inputJSON string) (string, error) {
 	}
 
 	return b.rpcClient.CallRaw(inputJSON), nil
+}
+
+func (b *StatusNode) activityCenterService(walletConnectFeed *event.Feed) *activitycenter.Service {
+	b.logger.Debug("Initializing activityCenterService activity center service")
+	if b.activityCenterSrvc == nil {
+		b.activityCenterSrvc = activitycenter.NewService(walletConnectFeed)
+	}
+	return b.activityCenterSrvc
+}
+
+func (b *StatusNode) ActivityCenterService() *activitycenter.Service {
+	return b.activityCenterSrvc
 }

--- a/protocol/activity_center.go
+++ b/protocol/activity_center.go
@@ -42,6 +42,8 @@ const (
 	ActivityCenterNotificationTypeCommunityUnbanned
 	ActivityCenterNotificationTypeNewInstallationReceived
 	ActivityCenterNotificationTypeNewInstallationCreated
+	ActivityCenterNotificationTypeDAppConnected
+	ActivityCenterNotificationTypeDAppDisconnected
 )
 
 type ActivityCenterMembershipStatus int
@@ -103,8 +105,12 @@ type ActivityCenterNotification struct {
 	TokenData                 *ActivityTokenData             `json:"tokenData"`
 	//Used for synchronization. Each update should increment the UpdatedAt.
 	//The value should represent the time when the update occurred.
-	UpdatedAt     uint64            `json:"updatedAt"`
-	AlbumMessages []*common.Message `json:"albumMessages"`
+	UpdatedAt                  uint64            `json:"updatedAt"`
+	AlbumMessages              []*common.Message `json:"albumMessages"`
+	WalletProviderSessionTopic string            `json:"walletProviderSessionTopic"`
+	DAppURL                    string            `json:"dappURL,omitempty"`
+	DAppName                   string            `json:"dappName,omitempty"`
+	DAppIconURL                string            `json:"dappIconURL,omitempty"`
 }
 
 func (n *ActivityCenterNotification) IncrementUpdatedAt(timesource common.TimeSource) {

--- a/protocol/activity_center_persistence.go
+++ b/protocol/activity_center_persistence.go
@@ -284,6 +284,10 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRow(row *sql.Row)
 	var name sql.NullString
 	var author sql.NullString
 	var installationID sql.NullString
+	var walletProviderSessionTopic sql.NullString
+	var dAppURL sql.NullString
+	var dAppName sql.NullString
+	var dAppIconURL sql.NullString
 	notification := &ActivityCenterNotification{}
 	err := row.Scan(
 		&notification.ID,
@@ -303,12 +307,12 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRow(row *sql.Row)
 		&name,
 		&author,
 		&tokenDataBytes,
-		&notification.WalletProviderSessionTopic,
-		&notification.DAppURL,
-		&notification.DAppName,
-		&notification.DAppIconURL,
+		&walletProviderSessionTopic,
+		&dAppURL,
+		&dAppName,
+		&dAppIconURL,
 		&notification.UpdatedAt,
-	    &installationID)
+		&installationID)
 
 	if err != nil {
 		return nil, err
@@ -332,6 +336,22 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRow(row *sql.Row)
 
 	if installationID.Valid {
 		notification.InstallationID = installationID.String
+	}
+
+	if walletProviderSessionTopic.Valid {
+		notification.WalletProviderSessionTopic = walletProviderSessionTopic.String
+	}
+
+	if dAppURL.Valid {
+		notification.DAppURL = dAppURL.String
+	}
+
+	if dAppName.Valid {
+		notification.DAppName = dAppName.String
+	}
+
+	if dAppIconURL.Valid {
+		notification.DAppIconURL = dAppIconURL.String
 	}
 
 	if len(tokenDataBytes) > 0 {
@@ -384,6 +404,10 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRows(rows *sql.Ro
 		var name sql.NullString
 		var author sql.NullString
 		var installationID sql.NullString
+		var walletProviderSessionTopic sql.NullString
+		var dAppURL sql.NullString
+		var dAppName sql.NullString
+		var dAppIconURL sql.NullString
 		notification := &ActivityCenterNotification{}
 		err := rows.Scan(
 			&notification.ID,
@@ -402,10 +426,10 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRows(rows *sql.Ro
 			&name,
 			&author,
 			&tokenDataBytes,
-			&notification.WalletProviderSessionTopic,
-			&notification.DAppURL,
-			&notification.DAppName,
-			&notification.DAppIconURL,
+			&walletProviderSessionTopic,
+			&dAppURL,
+			&dAppName,
+			&dAppIconURL,
 			&latestCursor,
 			&notification.UpdatedAt,
 			&installationID,
@@ -432,6 +456,22 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRows(rows *sql.Ro
 
 		if installationID.Valid {
 			notification.InstallationID = installationID.String
+		}
+
+		if walletProviderSessionTopic.Valid {
+			notification.WalletProviderSessionTopic = walletProviderSessionTopic.String
+		}
+
+		if dAppURL.Valid {
+			notification.DAppURL = dAppURL.String
+		}
+
+		if dAppName.Valid {
+			notification.DAppName = dAppName.String
+		}
+
+		if dAppIconURL.Valid {
+			notification.DAppIconURL = dAppIconURL.String
 		}
 
 		if len(tokenDataBytes) > 0 {

--- a/protocol/activity_center_persistence.go
+++ b/protocol/activity_center_persistence.go
@@ -12,7 +12,7 @@ import (
 )
 
 const allFieldsForTableActivityCenterNotification = `id, timestamp, notification_type, chat_id, read, dismissed, accepted, message, author,
-    reply_message, community_id, membership_status, contact_verification_status, token_data, deleted, updated_at`
+    reply_message, community_id, membership_status, contact_verification_status, token_data, wallet_provider_session_topic, dapp_url, dapp_name, dapp_icon_url, deleted, updated_at`
 
 var emptyNotifications = make([]*ActivityCenterNotification, 0)
 
@@ -147,11 +147,15 @@ func (db sqlitePersistence) SaveActivityCenterNotification(notification *Activit
 			accepted,
 			dismissed,
 			token_data,
+			wallet_provider_session_topic,
+			dapp_url,
+			dapp_name,
+			dapp_icon_url,
 			deleted,
-		    updated_at,
-			installation_id
+			updated_at,
+		    installation_id
 		)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 		`,
 		notification.ID,
 		notification.Timestamp,
@@ -167,6 +171,10 @@ func (db sqlitePersistence) SaveActivityCenterNotification(notification *Activit
 		notification.Accepted,
 		notification.Dismissed,
 		encodedTokenData,
+		notification.WalletProviderSessionTopic,
+		notification.DAppURL,
+		notification.DAppName,
+		notification.DAppIconURL,
 		notification.Deleted,
 		notification.UpdatedAt,
 		notification.InstallationID,
@@ -213,6 +221,10 @@ func (db sqlitePersistence) parseRowFromTableActivityCenterNotification(rows *sq
 			&notification.MembershipStatus,
 			&notification.ContactVerificationStatus,
 			&tokenDataBytes,
+			&notification.WalletProviderSessionTopic,
+			&notification.DAppURL,
+			&notification.DAppName,
+			&notification.DAppIconURL,
 			&notification.Deleted,
 			&notification.UpdatedAt,
 		)
@@ -291,9 +303,12 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRow(row *sql.Row)
 		&name,
 		&author,
 		&tokenDataBytes,
+		&notification.WalletProviderSessionTopic,
+		&notification.DAppURL,
+		&notification.DAppName,
+		&notification.DAppIconURL,
 		&notification.UpdatedAt,
-		&installationID,
-	)
+	    &installationID)
 
 	if err != nil {
 		return nil, err
@@ -387,6 +402,10 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRows(rows *sql.Ro
 			&name,
 			&author,
 			&tokenDataBytes,
+			&notification.WalletProviderSessionTopic,
+			&notification.DAppURL,
+			&notification.DAppName,
+			&notification.DAppIconURL,
 			&latestCursor,
 			&notification.UpdatedAt,
 			&installationID,
@@ -554,6 +573,10 @@ func (db sqlitePersistence) buildActivityCenterQuery(tx *sql.Tx, params activity
 	c.name,
 	a.author,
 	a.token_data,
+	a.wallet_provider_session_topic,
+	a.dapp_url,
+	a.dapp_name,
+	a.dapp_icon_url,
 	substr('0000000000000000000000000000000000000000000000000000000000000000' || a.timestamp, -64, 64) || hex(a.id) as cursor,
 	a.updated_at,
 	a.installation_id
@@ -676,6 +699,10 @@ func (db sqlitePersistence) GetActivityCenterNotificationsByID(ids []types.HexBy
 		c.name,
 		a.author,
 		a.token_data,
+		a.wallet_provider_session_topic,
+		a.dapp_url,
+		a.dapp_name,
+		a.dapp_icon_url,
 		substr('0000000000000000000000000000000000000000000000000000000000000000' || a.timestamp, -64, 64) || hex(a.id) as cursor,
 		a.updated_at,
 		a.installation_id
@@ -718,6 +745,10 @@ func (db sqlitePersistence) GetActivityCenterNotificationByID(id types.HexBytes)
 		c.name,
 		a.author,
 		a.token_data,
+		a.wallet_provider_session_topic,
+		a.dapp_url,
+		a.dapp_name,
+		a.dapp_icon_url,
 		a.updated_at,
 		a.installation_id
 		FROM activity_center_notifications a
@@ -1353,6 +1384,10 @@ func (db sqlitePersistence) ActiveContactRequestNotification(contactID string) (
 			c.name,
 			a.author,
 			a.token_data,
+			a.wallet_provider_session_topic,
+			a.dapp_url,
+			a.dapp_name,
+			a.dapp_icon_url,
 			a.updated_at,
 			a.installation_id
 		FROM activity_center_notifications a

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4932,6 +4932,19 @@ func (m *Messenger) AddActivityCenterNotificationToResponse(communityID string, 
 	}
 }
 
+func (m *Messenger) AddNotificationToActivityCenter(notification *ActivityCenterNotification) error {
+	response := &MessengerResponse{}
+	err := m.addActivityCenterNotification(response, notification, nil)
+	if err != nil {
+		return err
+	}
+
+	if m.config.messengerSignalsHandler != nil {
+		m.config.messengerSignalsHandler.MessengerResponse(response)
+	}
+	return nil
+}
+
 func (m *Messenger) leaveCommunityDueToKickOrBan(changes *communities.CommunityChanges, acType ActivityCenterType, stateResponse *MessengerResponse) {
 	response, err := m.kickedOutOfCommunity(changes.Community.ID(), false)
 	if err != nil {

--- a/protocol/messenger_walletconnect.go
+++ b/protocol/messenger_walletconnect.go
@@ -49,7 +49,12 @@ func (m *Messenger) NewWalletConnectV2SessionCreatedNotification(session walletc
 		notification.DAppIconURL = session.Peer.Metadata.Icons[0]
 	}
 
-	_, err := m.persistence.SaveActivityCenterNotification(notification, true)
+	response := &MessengerResponse{}
+	err := m.addActivityCenterNotification(response, notification, nil)
+
+	if m.config.messengerSignalsHandler != nil {
+		m.config.messengerSignalsHandler.MessengerResponse(response)
+	}
 
 	return err
 }

--- a/protocol/messenger_walletconnect.go
+++ b/protocol/messenger_walletconnect.go
@@ -1,7 +1,9 @@
 package protocol
 
 import (
+	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/requests"
+	"github.com/status-im/status-go/services/wallet/walletconnect"
 )
 
 type WalletConnectSession struct {
@@ -28,6 +30,28 @@ func (m *Messenger) AddWalletConnectSession(request *requests.AddWalletConnectSe
 	}
 
 	return m.persistence.InsertWalletConnectSession(session)
+}
+
+func (m *Messenger) NewWalletConnectV2SessionCreatedNotification(session walletconnect.Session) error {
+	now := m.GetCurrentTimeInMillis()
+
+	notification := &ActivityCenterNotification{
+		ID:                         types.FromHex(string(session.Topic) + "_dapp_connected"),
+		Type:                       ActivityCenterNotificationTypeDAppConnected,
+		DAppURL:                    session.Peer.Metadata.URL,
+		DAppName:                   session.Peer.Metadata.Name,
+		WalletProviderSessionTopic: string(session.Topic),
+		Timestamp:                  now,
+		UpdatedAt:                  now,
+	}
+
+	if len(session.Peer.Metadata.Icons) > 0 {
+		notification.DAppIconURL = session.Peer.Metadata.Icons[0]
+	}
+
+	_, err := m.persistence.SaveActivityCenterNotification(notification, true)
+
+	return err
 }
 
 func (m *Messenger) GetWalletConnectSession() ([]WalletConnectSession, error) {

--- a/protocol/messenger_walletconnect.go
+++ b/protocol/messenger_walletconnect.go
@@ -1,9 +1,7 @@
 package protocol
 
 import (
-	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/requests"
-	"github.com/status-im/status-go/services/wallet/walletconnect"
 )
 
 type WalletConnectSession struct {
@@ -30,33 +28,6 @@ func (m *Messenger) AddWalletConnectSession(request *requests.AddWalletConnectSe
 	}
 
 	return m.persistence.InsertWalletConnectSession(session)
-}
-
-func (m *Messenger) NewWalletConnectV2SessionCreatedNotification(session walletconnect.Session) error {
-	now := m.GetCurrentTimeInMillis()
-
-	notification := &ActivityCenterNotification{
-		ID:                         types.FromHex(string(session.Topic) + "_dapp_connected"),
-		Type:                       ActivityCenterNotificationTypeDAppConnected,
-		DAppURL:                    session.Peer.Metadata.URL,
-		DAppName:                   session.Peer.Metadata.Name,
-		WalletProviderSessionTopic: string(session.Topic),
-		Timestamp:                  now,
-		UpdatedAt:                  now,
-	}
-
-	if len(session.Peer.Metadata.Icons) > 0 {
-		notification.DAppIconURL = session.Peer.Metadata.Icons[0]
-	}
-
-	response := &MessengerResponse{}
-	err := m.addActivityCenterNotification(response, notification, nil)
-
-	if m.config.messengerSignalsHandler != nil {
-		m.config.messengerSignalsHandler.MessengerResponse(response)
-	}
-
-	return err
 }
 
 func (m *Messenger) GetWalletConnectSession() ([]WalletConnectSession, error) {

--- a/protocol/migrations/sqlite/1722231142_add_dapp_and_wallet_provider_to_activity_center_notifications.up.sql
+++ b/protocol/migrations/sqlite/1722231142_add_dapp_and_wallet_provider_to_activity_center_notifications.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE activity_center_notifications ADD COLUMN dapp_url TEXT NULL;
+ALTER TABLE activity_center_notifications ADD COLUMN dapp_name TEXT NULL;
+ALTER TABLE activity_center_notifications ADD COLUMN dapp_icon_url TEXT NULL;
+ALTER TABLE activity_center_notifications ADD COLUMN wallet_provider_session_topic TEXT NULL;

--- a/services/activitycenter/controller.go
+++ b/services/activitycenter/controller.go
@@ -1,0 +1,89 @@
+package activitycenter
+
+import (
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/logutils"
+	"github.com/status-im/status-go/protocol"
+	"github.com/status-im/status-go/services/wallet/walletconnect"
+	"github.com/status-im/status-go/services/wallet/walletconnect/walletconnectevent"
+)
+
+type Controller struct {
+	messenger            *protocol.Messenger
+	walletConnectsFeed   *event.Feed
+	walletConnectWatcher *walletconnectevent.Watcher
+	commandsLock         sync.RWMutex
+}
+
+func NewController(walletConnectsFeed *event.Feed) *Controller {
+	return &Controller{
+		walletConnectsFeed: walletConnectsFeed,
+	}
+}
+
+func (c *Controller) Start(messenger *protocol.Messenger) {
+	c.messenger = messenger
+	c.startWalletConnectConnectionWatcher()
+}
+
+func (c *Controller) Stop() {
+	c.stopWalletConnectConnectionWatcher()
+}
+
+func (c *Controller) startWalletConnectConnectionWatcher() {
+	logutils.ZapLogger().Debug("Starting wallet connect connection watcher")
+	if c.walletConnectWatcher != nil {
+		return
+	}
+
+	walletConnectChangeCb := func(eventType walletconnectevent.EventType, session walletconnect.Session) {
+		c.commandsLock.Lock()
+		defer c.commandsLock.Unlock()
+		// Whenever an dApp gets added, add it to activity center
+		if eventType == walletconnectevent.EventTypeAdded {
+			err := c.createNewSessionActivityCenterNotification(&session)
+			if err != nil {
+				logutils.ZapLogger().Error("Failed to create new session activity center notification", zap.Error(err))
+			}
+
+		}
+	}
+
+	c.walletConnectWatcher = walletconnectevent.NewWatcher(c.walletConnectsFeed, walletConnectChangeCb)
+
+	c.walletConnectWatcher.Start()
+}
+
+func (c *Controller) stopWalletConnectConnectionWatcher() {
+	if c.walletConnectWatcher != nil {
+		c.walletConnectWatcher.Stop()
+		c.walletConnectWatcher = nil
+	}
+}
+
+func (c *Controller) createNewSessionActivityCenterNotification(session *walletconnect.Session) error {
+	now := c.messenger.GetCurrentTimeInMillis()
+
+	logutils.ZapLogger().Info("Creating new session activity center notification", zap.Any("session", session))
+
+	notification := &protocol.ActivityCenterNotification{
+		ID:                         types.FromHex(string(session.Topic) + "_dapp_connected"),
+		Type:                       protocol.ActivityCenterNotificationTypeDAppConnected,
+		DAppURL:                    session.Peer.Metadata.URL,
+		DAppName:                   session.Peer.Metadata.Name,
+		WalletProviderSessionTopic: string(session.Topic),
+		Timestamp:                  now,
+		UpdatedAt:                  now,
+	}
+
+	if len(session.Peer.Metadata.Icons) > 0 {
+		notification.DAppIconURL = session.Peer.Metadata.Icons[0]
+	}
+
+	return c.messenger.AddNotificationToActivityCenter(notification)
+}

--- a/services/activitycenter/service.go
+++ b/services/activitycenter/service.go
@@ -1,0 +1,50 @@
+package activitycenter
+
+import (
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/status-im/status-go/logutils"
+	"github.com/status-im/status-go/protocol"
+)
+
+type Service struct {
+	messenger          *protocol.Messenger
+	walletConnectsFeed *event.Feed
+	controller         *Controller
+}
+
+func NewService(walletConnectFeed *event.Feed) *Service {
+	return &Service{
+		walletConnectsFeed: walletConnectFeed,
+		controller:         NewController(walletConnectFeed),
+	}
+}
+
+func (s *Service) Init(messenger *protocol.Messenger) {
+	logutils.ZapLogger().Debug("Initializing activity center service")
+	s.messenger = messenger
+}
+
+func (s *Service) Start() error {
+	if s.messenger != nil {
+		logutils.ZapLogger().Debug("Starting activity center service")
+		s.controller.Start(s.messenger)
+	} else {
+		logutils.ZapLogger().Error("Activity center service not started, messenger is nil")
+	}
+	return nil
+}
+
+func (s *Service) Stop() error {
+	s.controller.Stop()
+	return nil
+}
+
+func (s *Service) Protocols() []p2p.Protocol {
+	return nil
+}
+
+func (s *Service) APIs() []rpc.API {
+	return nil
+}

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/event"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 	signercore "github.com/ethereum/go-ethereum/signer/core/apitypes"
 	abi_spec "github.com/status-im/status-go/abi-spec"
@@ -39,17 +40,20 @@ import (
 	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/services/wallet/transfer"
 	"github.com/status-im/status-go/services/wallet/walletconnect"
+	"github.com/status-im/status-go/services/wallet/walletconnect/walletconnectevent"
 	"github.com/status-im/status-go/transactions"
 )
 
 func NewAPI(s *Service) *API {
-	return &API{s, s.reader}
+	return &API{s, s.reader, s.feed, s.walletConnectFeed}
 }
 
 // API is class with methods available over RPC.
 type API struct {
-	s      *Service
-	reader *Reader
+	s                 *Service
+	reader            *Reader
+	feed              *event.Feed
+	walletConnectFeed *event.Feed
 }
 
 func (api *API) StartWallet(ctx context.Context) error {
@@ -926,9 +930,19 @@ func (api *API) getVerifiedWalletAccount(address, password string) (*account.Sel
 }
 
 // AddWalletConnectSession adds or updates a session wallet connect session
-func (api *API) AddWalletConnectSession(ctx context.Context, session_json string) error {
+func (api *API) AddWalletConnectSession(ctx context.Context, session_json string) (walletconnect.Session, error) {
 	logutils.ZapLogger().Debug("wallet.api.AddWalletConnectSession", zap.Int("rpcURL", len(session_json)))
-	return walletconnect.AddSession(api.s.db, api.s.config.Networks, session_json)
+	session, err := walletconnect.AddSession(api.s.db, api.s.config.Networks, session_json)
+	if err != nil {
+		logutils.ZapLogger().Error("wallet.api.AddWalletConnectSession", zap.Error(err))
+	}
+
+	api.walletConnectFeed.Send(walletconnectevent.Event{
+		Type:    walletconnectevent.EventTypeAdded,
+		Session: session,
+	})
+
+	return session, err
 }
 
 // DisconnectWalletConnectSession removes a wallet connect session

--- a/services/wallet/api_test.go
+++ b/services/wallet/api_test.go
@@ -159,7 +159,7 @@ func TestAPI_GetAddressDetails(t *testing.T) {
 	chainClient.SetWalletNotifier(func(chainID uint64, message string) {})
 	c.SetWalletNotifier(func(chainID uint64, message string) {})
 
-	service := NewService(db, accountsDb, appDB, c, accountFeed, nil, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
+	service := NewService(db, accountsDb, appDB, c, accountFeed, nil, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, nil, "")
 
 	api := &API{
 		s: service,

--- a/services/wallet/keycard_pairings_test.go
+++ b/services/wallet/keycard_pairings_test.go
@@ -29,7 +29,7 @@ func TestKeycardPairingsFile(t *testing.T) {
 
 	accountFeed := &event.Feed{}
 
-	service := NewService(db, accountsDb, appDB, &rpc.Client{NetworkManager: network.NewManager(db)}, accountFeed, nil, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
+	service := NewService(db, accountsDb, appDB, &rpc.Client{NetworkManager: network.NewManager(db)}, accountFeed, nil, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, nil, "")
 
 	data, err := service.KeycardPairings().GetPairingsJSONFileContent()
 	require.NoError(t, err)

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -62,6 +62,7 @@ func NewService(
 	ens *ens.Service,
 	pendingTxManager *transactions.PendingTxTracker,
 	feed *event.Feed,
+	walletConnectFeed *event.Feed,
 	mediaServer *server.MediaServer,
 	statusProxyStageName string,
 ) *Service {
@@ -216,6 +217,7 @@ func NewService(
 		transactor:            transactor,
 		ens:                   ens,
 		feed:                  feed,
+		walletConnectFeed:     walletConnectFeed,
 		signals:               signals,
 		reader:                reader,
 		history:               history,
@@ -296,6 +298,7 @@ type Service struct {
 	transactor            *transactions.Transactor
 	ens                   *ens.Service
 	feed                  *event.Feed
+	walletConnectFeed     *event.Feed
 	signals               *walletevent.SignalsTransmitter
 	reader                *Reader
 	history               *history.Service

--- a/services/wallet/walletconnect/walletconnect.go
+++ b/services/wallet/walletconnect/walletconnect.go
@@ -194,17 +194,17 @@ func (p *SessionProposal) ValidateProposal() bool {
 }
 
 // AddSession adds a new active session to the database
-func AddSession(db *sql.DB, networks []params.Network, session_json string) error {
+func AddSession(db *sql.DB, networks []params.Network, session_json string) (Session, error) {
 	var session Session
 	err := json.Unmarshal([]byte(session_json), &session)
 	if err != nil {
-		return fmt.Errorf("unmarshal session: %v", err)
+		return session, fmt.Errorf("unmarshal session: %v", err)
 	}
 
 	chains := supportedChainsInSession(session)
 	testChains, err := areTestChains(networks, chains)
 	if err != nil {
-		return fmt.Errorf("areTestChains: %v", err)
+		return session, fmt.Errorf("areTestChains: %v", err)
 	}
 
 	rowEntry := DBSession{
@@ -224,7 +224,7 @@ func AddSession(db *sql.DB, networks []params.Network, session_json string) erro
 		rowEntry.IconURL = session.Peer.Metadata.Icons[0]
 	}
 
-	return UpsertSession(db, rowEntry)
+	return session, UpsertSession(db, rowEntry)
 }
 
 // areTestChains assumes chains to tests are all testnets or all mainnets

--- a/services/wallet/walletconnect/walletconnect_test.go
+++ b/services/wallet/walletconnect/walletconnect_test.go
@@ -395,7 +395,7 @@ func Test_AddSession(t *testing.T) {
 		{ChainID: uint64(chainID), IsTest: true},
 	}
 	timestampBeforeAddSession := time.Now().Unix()
-	err := AddSession(db, networks, sessionJSON)
+	_, err := AddSession(db, networks, sessionJSON)
 	assert.NoError(t, err)
 
 	// Validate that session was written correctly to the database

--- a/services/wallet/walletconnect/walletconnectevent/events.go
+++ b/services/wallet/walletconnect/walletconnectevent/events.go
@@ -1,0 +1,19 @@
+package walletconnectevent
+
+import (
+	"github.com/status-im/status-go/services/wallet/walletconnect"
+)
+
+// EventType type for event types.
+type EventType string
+
+// Event is a type for walletConnect events.
+type Event struct {
+	Type    EventType             `json:"type"`
+	Session walletconnect.Session `json:"session"`
+}
+
+const (
+	// EventTypeAdded is emitted when a new session is added.
+	EventTypeAdded EventType = "added"
+)

--- a/services/wallet/walletconnect/walletconnectevent/watcher.go
+++ b/services/wallet/walletconnect/walletconnectevent/watcher.go
@@ -1,0 +1,73 @@
+package walletconnectevent
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/status-im/status-go/logutils"
+	"github.com/status-im/status-go/services/wallet/async"
+	"github.com/status-im/status-go/services/wallet/walletconnect"
+)
+
+type WalletConnectsChangeCb func(eventType EventType, Session walletconnect.Session)
+
+// Watcher executes a given callback whenever an walletConnect gets added/removed
+type Watcher struct {
+	walletConnectFeed *event.Feed
+	group             *async.Group
+	callback          WalletConnectsChangeCb
+}
+
+func NewWatcher(walletConnectFeed *event.Feed, callback WalletConnectsChangeCb) *Watcher {
+	return &Watcher{
+		walletConnectFeed: walletConnectFeed,
+		callback:          callback,
+	}
+}
+
+func (w *Watcher) Start() {
+	logutils.ZapLogger().Debug("Starting wallet connect connection watcher")
+	if w.group != nil {
+		return
+	}
+
+	w.group = async.NewGroup(context.Background())
+	w.group.Add(func(ctx context.Context) error {
+		return watch(ctx, w.walletConnectFeed, w.callback)
+	})
+}
+
+func (w *Watcher) Stop() {
+	if w.group != nil {
+		w.group.Stop()
+		w.group.Wait()
+		w.group = nil
+	}
+}
+
+func onWalletConnectSessionChange(callback WalletConnectsChangeCb, session walletconnect.Session, eventType EventType) {
+	if callback != nil {
+		callback(eventType, session)
+	}
+}
+
+func watch(ctx context.Context, walletConnectFeed *event.Feed, callback WalletConnectsChangeCb) error {
+	ch := make(chan Event, 1)
+	sub := walletConnectFeed.Subscribe(ch)
+	defer sub.Unsubscribe()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-sub.Err():
+			if err != nil {
+				logutils.ZapLogger().Error("accounts watcher subscription failed", zap.Error(err))
+			}
+		case ev := <-ch:
+			onWalletConnectSessionChange(callback, ev.Session, ev.Type)
+		}
+	}
+}


### PR DESCRIPTION
create a new activity center notification when new wallet connect session added

mobile PR https://github.com/status-im/status-mobile/pull/20905
mobile ISSUE https://github.com/status-im/status-mobile/issues/20467

Important changes:
- add a `InjectedMessenger` in wallet service to avoid import cycle
- inject messenger into wallet service
- create and persist new notification at the end of `AddWalletConnectSession`
- add wallet connect session topic, dapp name, URL, icon URL to `activity_center_notifications` table
  <!-- - seems dapps in `wallet_connect_dapps` won't be deleted ever -->