### PR TITLE
[CHERRY-PICK] fix_: add missing message verification flag when creating an account

### DIFF
--- a/api/defaults.go
+++ b/api/defaults.go
@@ -141,6 +141,7 @@ func SetFleet(fleet string, nodeConfig *params.NodeConfig) error {
 		// mobile may need override following options
 		LightClient:                            specifiedWakuV2Config.LightClient,
 		EnableStoreConfirmationForMessagesSent: specifiedWakuV2Config.EnableStoreConfirmationForMessagesSent,
+		EnableMissingMessageVerification:       specifiedWakuV2Config.EnableMissingMessageVerification,
 		Nameserver:                             specifiedWakuV2Config.Nameserver,
 	}
 
@@ -301,6 +302,10 @@ func defaultNodeConfig(installationID string, request *requests.CreateAccount, o
 
 	if request.WakuV2LightClient {
 		nodeConfig.WakuV2Config.LightClient = true
+	}
+
+	if request.WakuV2EnableMissingMessageVerification {
+		nodeConfig.WakuV2Config.EnableMissingMessageVerification = true
 	}
 
 	if request.WakuV2EnableStoreConfirmationForMessagesSent {

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -52,6 +52,7 @@ type CreateAccount struct {
 	WakuV2Nameserver                             *string `json:"wakuV2Nameserver"`
 	WakuV2LightClient                            bool    `json:"wakuV2LightClient"`
 	WakuV2EnableStoreConfirmationForMessagesSent bool    `json:"wakuV2EnableStoreConfirmationForMessagesSent"`
+	WakuV2EnableMissingMessageVerification       bool    `json:"wakuV2EnableMissingMessageVerification"`
 	WakuV2Fleet                                  string  `json:"wakuV2Fleet"`
 
 	LogLevel    *string `json:"logLevel"`


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-go/pull/5570

This makes sure new accounts also have that flag set to true
