### PR TITLE
feat(wallet)_: add status proxy RPC urls for blockchain providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,11 @@ GIT_AUTHOR := $(shell git config user.email || echo $$USER)
 ENABLE_METRICS ?= true
 BUILD_TAGS ?= gowaku_no_rln
 
+ifdef RELEASE
+	BUILD_TAGS += release
+endif
+
+
 BUILD_FLAGS ?= -ldflags="-X github.com/status-im/status-go/params.Version=$(RELEASE_TAG:v%=%) \
 	-X github.com/status-im/status-go/params.GitCommit=$(GIT_COMMIT) \
 	-X github.com/status-im/status-go/params.IpfsGatewayURL=$(IPFS_GATEWAY_URL) \

--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/buildinfo"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/requests"
 )
@@ -27,6 +29,8 @@ var ganacheTokenAddress = common.HexToAddress("0x8571Ddc46b10d31EF963aF49b6C7799
 var mainnet = params.Network{
 	ChainID:                mainnetChainID,
 	ChainName:              "Mainnet",
+	DefaultRPCURL:          fmt.Sprintf("https://%s.api.status.im/grove/ethereum/mainnet/", buildinfo.ApiProxyStageName),
+	DefaultFallbackURL:     fmt.Sprintf("https://%s.api.status.im/infura/ethereum/mainnet/", buildinfo.ApiProxyStageName),
 	RPCURL:                 "https://eth-archival.rpc.grove.city/v1/",
 	FallbackURL:            "https://mainnet.infura.io/v3/",
 	BlockExplorerURL:       "https://etherscan.io/",
@@ -63,6 +67,8 @@ var goerli = params.Network{
 var sepolia = params.Network{
 	ChainID:                sepoliaChainID,
 	ChainName:              "Mainnet",
+	DefaultRPCURL:          fmt.Sprintf("https://%s.api.status.im/grove/ethereum/sepolia/", buildinfo.ApiProxyStageName),
+	DefaultFallbackURL:     fmt.Sprintf("https://%s.api.status.im/infura/ethereum/sepolia/", buildinfo.ApiProxyStageName),
 	RPCURL:                 "https://sepolia-archival.rpc.grove.city/v1/",
 	FallbackURL:            "https://sepolia.infura.io/v3/",
 	BlockExplorerURL:       "https://sepolia.etherscan.io/",
@@ -81,6 +87,8 @@ var sepolia = params.Network{
 var optimism = params.Network{
 	ChainID:                optimismChainID,
 	ChainName:              "Optimism",
+	DefaultRPCURL:          fmt.Sprintf("https://%s.api.status.im/grove/optimism/mainnet/", buildinfo.ApiProxyStageName),
+	DefaultFallbackURL:     fmt.Sprintf("https://%s.api.status.im/infura/optimism/mainnet/", buildinfo.ApiProxyStageName),
 	RPCURL:                 "https://optimism-archival.rpc.grove.city/v1/",
 	FallbackURL:            "https://optimism-mainnet.infura.io/v3/",
 	BlockExplorerURL:       "https://optimistic.etherscan.io",
@@ -117,6 +125,8 @@ var optimismGoerli = params.Network{
 var optimismSepolia = params.Network{
 	ChainID:                optimismSepoliaChainID,
 	ChainName:              "Optimism",
+	DefaultRPCURL:          fmt.Sprintf("https://%s.api.status.im/grove/optimism/sepolia/", buildinfo.ApiProxyStageName),
+	DefaultFallbackURL:     fmt.Sprintf("https://%s.api.status.im/infura/optimism/sepolia/", buildinfo.ApiProxyStageName),
 	RPCURL:                 "https://optimism-sepolia-archival.rpc.grove.city/v1/",
 	FallbackURL:            "https://optimism-sepolia.infura.io/v3/",
 	BlockExplorerURL:       "https://sepolia-optimism.etherscan.io/",
@@ -135,6 +145,8 @@ var optimismSepolia = params.Network{
 var arbitrum = params.Network{
 	ChainID:                arbitrumChainID,
 	ChainName:              "Arbitrum",
+	DefaultRPCURL:          fmt.Sprintf("https://%s.api.status.im/grove/arbitrum/mainnet/", buildinfo.ApiProxyStageName),
+	DefaultFallbackURL:     fmt.Sprintf("https://%s.api.status.im/infura/arbitrum/mainnet/", buildinfo.ApiProxyStageName),
 	RPCURL:                 "https://arbitrum-one.rpc.grove.city/v1/",
 	FallbackURL:            "https://arbitrum-mainnet.infura.io/v3/",
 	BlockExplorerURL:       "https://arbiscan.io/",
@@ -171,6 +183,8 @@ var arbitrumGoerli = params.Network{
 var arbitrumSepolia = params.Network{
 	ChainID:                arbitrumSepoliaChainID,
 	ChainName:              "Arbitrum",
+	DefaultRPCURL:          fmt.Sprintf("https://%s.api.status.im/grove/arbitrum/sepolia/", buildinfo.ApiProxyStageName),
+	DefaultFallbackURL:     fmt.Sprintf("https://%s.api.status.im/infura/arbitrum/sepolia/", buildinfo.ApiProxyStageName),
 	RPCURL:                 "https://arbitrum-sepolia-archival.rpc.grove.city/v1/",
 	FallbackURL:            "https://arbitrum-sepolia.infura.io/v3/",
 	BlockExplorerURL:       "https://sepolia-explorer.arbitrum.io/",

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -161,7 +161,7 @@ func SetFleet(fleet string, nodeConfig *params.NodeConfig) error {
 	return nil
 }
 
-func buildWalletConfig(request *requests.WalletSecretsConfig) params.WalletConfig {
+func buildWalletConfig(request *requests.WalletSecretsConfig, statusProxyEnabled bool) params.WalletConfig {
 	walletConfig := params.WalletConfig{
 		Enabled:        true,
 		AlchemyAPIKeys: make(map[uint64]string),
@@ -220,6 +220,14 @@ func buildWalletConfig(request *requests.WalletSecretsConfig) params.WalletConfi
 	if request.StatusProxyMarketPassword != "" {
 		walletConfig.StatusProxyMarketPassword = request.StatusProxyMarketPassword
 	}
+	if request.StatusProxyBlockchainUser != "" {
+		walletConfig.StatusProxyBlockchainUser = request.StatusProxyBlockchainUser
+	}
+	if request.StatusProxyBlockchainPassword != "" {
+		walletConfig.StatusProxyBlockchainPassword = request.StatusProxyBlockchainPassword
+	}
+
+	walletConfig.StatusProxyEnabled = statusProxyEnabled
 
 	return walletConfig
 }
@@ -287,7 +295,7 @@ func defaultNodeConfig(installationID string, request *requests.CreateAccount, o
 	nodeConfig.MaxPeers = DefaultMaxPeers
 	nodeConfig.MaxPendingPeers = DefaultMaxPendingPeers
 
-	nodeConfig.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig)
+	nodeConfig.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig, request.StatusProxyEnabled)
 
 	nodeConfig.LocalNotificationsConfig = params.LocalNotificationsConfig{Enabled: true}
 	nodeConfig.BrowsersConfig = params.BrowsersConfig{Enabled: true}

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -601,7 +601,7 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 		KeycardPairingDataFile: DefaultKeycardPairingDataFile,
 	}
 
-	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig)
+	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig, request.StatusProxyEnabled)
 
 	err = b.UpdateNodeConfigFleet(acc, request.Password, defaultCfg)
 	if err != nil {

--- a/buildinfo/apiproxystage_dev.go
+++ b/buildinfo/apiproxystage_dev.go
@@ -1,0 +1,5 @@
+//go:build !release
+
+package buildinfo
+
+var ApiProxyStageName = "test"

--- a/buildinfo/apiproxystage_prod.go
+++ b/buildinfo/apiproxystage_prod.go
@@ -1,0 +1,5 @@
+//go:build release
+
+package buildinfo
+
+var ApiProxyStageName = "prod"

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -314,7 +314,20 @@ func (n *StatusNode) setupRPCClient() (err error) {
 	if err != nil {
 		return
 	}
-	n.rpcClient, err = rpc.NewClient(gethNodeClient, n.config.NetworkID, n.config.UpstreamConfig, n.config.Networks, n.appDB)
+
+	// ProviderConfigs should be passed not in wallet secrets config on login
+	// but some other way, as it's not wallet specific and should not be passed with login request
+	// but currently there is no other way to pass it
+	providerConfigs := []params.ProviderConfig{
+		{
+			Enabled:  n.config.WalletConfig.StatusProxyEnabled,
+			Name:     rpc.ProviderStatusProxy,
+			User:     n.config.WalletConfig.StatusProxyBlockchainUser,
+			Password: n.config.WalletConfig.StatusProxyBlockchainPassword,
+		},
+	}
+
+	n.rpcClient, err = rpc.NewClient(gethNodeClient, n.config.NetworkID, n.config.UpstreamConfig, n.config.Networks, n.appDB, providerConfigs)
 	if err != nil {
 		return
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -310,6 +310,21 @@ type UpstreamRPCConfig struct {
 	URL string
 }
 
+type ProviderConfig struct {
+	// Enabled flag specifies whether feature is enabled
+	Enabled bool `validate:"required"`
+
+	// To identify provider
+	Name string `validate:"required"`
+
+	// URL sets the rpc upstream host address for communication with
+	// a non-local infura endpoint.
+	User         string `json:",omitempty"`
+	Password     string `json:",omitempty"`
+	APIKey       string `json:"APIKey,omitempty"`
+	APIKeySecret string `json:"APIKeySecret,omitempty"`
+}
+
 // ----------
 // NodeConfig
 // ----------
@@ -531,6 +546,8 @@ type TokenOverride struct {
 type Network struct {
 	ChainID                uint64          `json:"chainId"`
 	ChainName              string          `json:"chainName"`
+	DefaultRPCURL          string          `json:"defaultRpcUrl"`      // proxy rpc url
+	DefaultFallbackURL     string          `json:"defaultFallbackURL"` // proxy fallback url
 	RPCURL                 string          `json:"rpcUrl"`
 	OriginalRPCURL         string          `json:"originalRpcUrl"`
 	FallbackURL            string          `json:"fallbackURL"`
@@ -551,16 +568,19 @@ type Network struct {
 
 // WalletConfig extra configuration for wallet.Service.
 type WalletConfig struct {
-	Enabled                   bool
-	OpenseaAPIKey             string            `json:"OpenseaAPIKey"`
-	RaribleMainnetAPIKey      string            `json:"RaribleMainnetAPIKey"`
-	RaribleTestnetAPIKey      string            `json:"RaribleTestnetAPIKey"`
-	AlchemyAPIKeys            map[uint64]string `json:"AlchemyAPIKeys"`
-	InfuraAPIKey              string            `json:"InfuraAPIKey"`
-	InfuraAPIKeySecret        string            `json:"InfuraAPIKeySecret"`
-	StatusProxyMarketUser     string            `json:"StatusProxyMarketUser"`
-	StatusProxyMarketPassword string            `json:"StatusProxyMarketPassword"`
-	EnableCelerBridge         bool              `json:"EnableCelerBridge"`
+	Enabled                       bool
+	OpenseaAPIKey                 string            `json:"OpenseaAPIKey"`
+	RaribleMainnetAPIKey          string            `json:"RaribleMainnetAPIKey"`
+	RaribleTestnetAPIKey          string            `json:"RaribleTestnetAPIKey"`
+	AlchemyAPIKeys                map[uint64]string `json:"AlchemyAPIKeys"`
+	InfuraAPIKey                  string            `json:"InfuraAPIKey"`
+	InfuraAPIKeySecret            string            `json:"InfuraAPIKeySecret"`
+	StatusProxyMarketUser         string            `json:"StatusProxyMarketUser"`
+	StatusProxyMarketPassword     string            `json:"StatusProxyMarketPassword"`
+	StatusProxyBlockchainUser     string            `json:"StatusProxyBlockchainUser"`
+	StatusProxyBlockchainPassword string            `json:"StatusProxyBlockchainPassword"`
+	StatusProxyEnabled            bool              `json:"StatusProxyEnabled"`
+	EnableCelerBridge             bool              `json:"EnableCelerBridge"`
 }
 
 // LocalNotificationsConfig extra configuration for localnotifications.Service.

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -86,6 +86,7 @@ type CreateAccount struct {
 
 	KeycardInstanceUID     string  `json:"keycardInstanceUID"`
 	KeycardPairingDataFile *string `json:"keycardPairingDataFile"`
+	StatusProxyEnabled     bool    `json:"statusProxyEnabled"`
 }
 
 type WalletSecretsConfig struct {
@@ -96,17 +97,19 @@ type WalletSecretsConfig struct {
 	RaribleMainnetAPIKey string `json:"raribleMainnetApiKey"`
 	RaribleTestnetAPIKey string `json:"raribleTestnetApiKey"`
 
-	AlchemyEthereumMainnetToken string `json:"alchemyEthereumMainnetToken"`
-	AlchemyEthereumGoerliToken  string `json:"alchemyEthereumGoerliToken"`
-	AlchemyEthereumSepoliaToken string `json:"alchemyEthereumSepoliaToken"`
-	AlchemyArbitrumMainnetToken string `json:"alchemyArbitrumMainnetToken"`
-	AlchemyArbitrumGoerliToken  string `json:"alchemyArbitrumGoerliToken"`
-	AlchemyArbitrumSepoliaToken string `json:"alchemyArbitrumSepoliaToken"`
-	AlchemyOptimismMainnetToken string `json:"alchemyOptimismMainnetToken"`
-	AlchemyOptimismGoerliToken  string `json:"alchemyOptimismGoerliToken"`
-	AlchemyOptimismSepoliaToken string `json:"alchemyOptimismSepoliaToken"`
-	StatusProxyMarketUser       string `json:"statusProxyMarketUser"`
-	StatusProxyMarketPassword   string `json:"statusProxyMarketPassword"`
+	AlchemyEthereumMainnetToken   string `json:"alchemyEthereumMainnetToken"`
+	AlchemyEthereumGoerliToken    string `json:"alchemyEthereumGoerliToken"`
+	AlchemyEthereumSepoliaToken   string `json:"alchemyEthereumSepoliaToken"`
+	AlchemyArbitrumMainnetToken   string `json:"alchemyArbitrumMainnetToken"`
+	AlchemyArbitrumGoerliToken    string `json:"alchemyArbitrumGoerliToken"`
+	AlchemyArbitrumSepoliaToken   string `json:"alchemyArbitrumSepoliaToken"`
+	AlchemyOptimismMainnetToken   string `json:"alchemyOptimismMainnetToken"`
+	AlchemyOptimismGoerliToken    string `json:"alchemyOptimismGoerliToken"`
+	AlchemyOptimismSepoliaToken   string `json:"alchemyOptimismSepoliaToken"`
+	StatusProxyMarketUser         string `json:"statusProxyMarketUser"`
+	StatusProxyMarketPassword     string `json:"statusProxyMarketPassword"`
+	StatusProxyBlockchainUser     string `json:"statusProxyBlockchainUser"`
+	StatusProxyBlockchainPassword string `json:"statusProxyBlockchainPassword"`
 
 	// Testing
 	GanacheURL string `json:"ganacheURL"`

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -35,7 +35,8 @@ type Login struct {
 
 	WalletSecretsConfig
 
-	APIConfig *APIConfig `json:"apiConfig"`
+	APIConfig          *APIConfig `json:"apiConfig"`
+	StatusProxyEnabled bool       `json:"statusProxyEnabled"`
 }
 
 func (c *Login) Validate() error {

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -36,7 +36,7 @@ func setupTestAPI(t *testing.T) (*API, func()) {
 	}
 
 	client := gethrpc.DialInProc(server)
-	rpcClient, err := statusRPC.NewClient(client, 1, upstreamConfig, nil, db)
+	rpcClient, err := statusRPC.NewClient(client, 1, upstreamConfig, nil, db, nil)
 	require.NoError(t, err)
 
 	service := NewService(db, rpcClient, nil)

--- a/services/connector/service_test.go
+++ b/services/connector/service_test.go
@@ -28,7 +28,7 @@ func TestNewService(t *testing.T) {
 	}
 
 	client := gethrpc.DialInProc(server)
-	rpcClient, err := statusRPC.NewClient(client, 1, upstreamConfig, nil, db)
+	rpcClient, err := statusRPC.NewClient(client, 1, upstreamConfig, nil, db, nil)
 	require.NoError(t, err)
 
 	service := NewService(db, rpcClient, rpcClient.NetworkManager)

--- a/services/ens/api_test.go
+++ b/services/ens/api_test.go
@@ -40,7 +40,7 @@ func setupTestAPI(t *testing.T) (*API, func()) {
 
 	_ = client
 
-	rpcClient, err := statusRPC.NewClient(nil, 1, upstreamConfig, nil, db)
+	rpcClient, err := statusRPC.NewClient(nil, 1, upstreamConfig, nil, db, nil)
 	require.NoError(t, err)
 
 	// import account keys

--- a/services/wallet/history/service_test.go
+++ b/services/wallet/history/service_test.go
@@ -405,7 +405,7 @@ func Test_removeBalanceHistoryOnEventAccountRemoved(t *testing.T) {
 	txServiceMockCtrl := gomock.NewController(t)
 	server, _ := fake.NewTestServer(txServiceMockCtrl)
 	client := gethrpc.DialInProc(server)
-	rpcClient, _ := rpc.NewClient(client, chainID, params.UpstreamRPCConfig{}, nil, appDB)
+	rpcClient, _ := rpc.NewClient(client, chainID, params.UpstreamRPCConfig{}, nil, appDB, nil)
 	rpcClient.UpstreamChainID = chainID
 
 	service := NewService(walletDB, accountsDB, &accountFeed, &walletFeed, rpcClient, nil, nil, nil)

--- a/services/wallet/router/router_v2_test.go
+++ b/services/wallet/router/router_v2_test.go
@@ -90,7 +90,7 @@ func setupTestNetworkDB(t *testing.T) (*sql.DB, func()) {
 func setupRouter(t *testing.T) (*Router, func()) {
 	db, cleanTmpDb := setupTestNetworkDB(t)
 
-	client, _ := rpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, defaultNetworks, db)
+	client, _ := rpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, defaultNetworks, db, nil)
 
 	router := NewRouter(client, nil, nil, nil, nil, nil, nil, nil)
 

--- a/services/wallet/thirdparty/cryptocompare/client.go
+++ b/services/wallet/thirdparty/cryptocompare/client.go
@@ -7,13 +7,15 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/status-im/status-go/buildinfo"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/services/wallet/thirdparty/utils"
 )
 
-const baseURL = "https://min-api.cryptocompare.com"
-const CryptoCompareStatusProxyURL = "https://cryptocompare.test.api.status.im"
 const extraParamStatus = "Status.im"
+const baseURL = "https://min-api.cryptocompare.com"
+
+var CryptoCompareStatusProxyURL = fmt.Sprintf("https://%s.api.status.im/cryptocompare/", buildinfo.ApiProxyStageName)
 
 type HistoricalPricesContainer struct {
 	Aggregated     bool                         `json:"Aggregated"`

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -331,7 +331,7 @@ func Test_removeTokenBalanceOnEventAccountRemoved(t *testing.T) {
 	txServiceMockCtrl := gomock.NewController(t)
 	server, _ := fake.NewTestServer(txServiceMockCtrl)
 	client := gethrpc.DialInProc(server)
-	rpcClient, _ := rpc.NewClient(client, chainID, params.UpstreamRPCConfig{}, nil, appDB)
+	rpcClient, _ := rpc.NewClient(client, chainID, params.UpstreamRPCConfig{}, nil, appDB, nil)
 	rpcClient.UpstreamChainID = chainID
 	nm := network.NewManager(appDB)
 	mediaServer, err := mediaserver.NewMediaServer(appDB, nil, nil, walletDB)

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -1076,7 +1076,7 @@ func setupFindBlocksCommand(t *testing.T, accountAddress common.Address, fromBlo
 
 		return nil
 	}
-	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db)
+	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
 	client.SetClient(tc.NetworkID(), tc)
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 	tokenManager.SetTokens([]*token.Token{
@@ -1339,7 +1339,7 @@ func TestFetchTransfersForLoadedBlocks(t *testing.T) {
 		currentBlock:           100,
 	}
 
-	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db)
+	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
 	client.SetClient(tc.NetworkID(), tc)
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
@@ -1463,7 +1463,7 @@ func TestFetchNewBlocksCommand_findBlocksWithEthTransfers(t *testing.T) {
 			currentBlock:           100,
 		}
 
-		client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db)
+		client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
 		client.SetClient(tc.NetworkID(), tc)
 		tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
@@ -1543,7 +1543,7 @@ func TestFetchNewBlocksCommand_nonceDetection(t *testing.T) {
 	mediaServer, err := server.NewMediaServer(appdb, nil, nil, db)
 	require.NoError(t, err)
 
-	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db)
+	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
 	client.SetClient(tc.NetworkID(), tc)
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
@@ -1657,7 +1657,7 @@ func TestFetchNewBlocksCommand(t *testing.T) {
 	}
 	//tc.printPreparedData = true
 
-	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db)
+	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
 	client.SetClient(tc.NetworkID(), tc)
 
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
@@ -1796,7 +1796,7 @@ func TestLoadBlocksAndTransfersCommand_FiniteFinishedInfiniteRunning(t *testing.
 	db, err := helpers.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
 	require.NoError(t, err)
 
-	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db)
+	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
 	maker, _ := contracts.NewContractMaker(client)
 
 	wdb := NewDB(db)

--- a/services/web3provider/api_test.go
+++ b/services/web3provider/api_test.go
@@ -45,7 +45,7 @@ func setupTestAPI(t *testing.T) (*API, func()) {
 	server, _ := fake.NewTestServer(txServiceMockCtrl)
 	client := gethrpc.DialInProc(server)
 
-	rpcClient, err := statusRPC.NewClient(client, 1, upstreamConfig, nil, db)
+	rpcClient, err := statusRPC.NewClient(client, 1, upstreamConfig, nil, db, nil)
 	require.NoError(t, err)
 
 	// import account keys

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -55,7 +55,7 @@ func (s *TransactorSuite) SetupTest() {
 	chainID := gethparams.AllEthashProtocolChanges.ChainID.Uint64()
 	db, err := sqlite.OpenUnecryptedDB(sqlite.InMemoryPath) // dummy to make rpc.Client happy
 	s.Require().NoError(err)
-	rpcClient, _ := rpc.NewClient(s.client, chainID, params.UpstreamRPCConfig{}, nil, db)
+	rpcClient, _ := rpc.NewClient(s.client, chainID, params.UpstreamRPCConfig{}, nil, db, nil)
 	rpcClient.UpstreamChainID = chainID
 	nodeConfig, err := utils.MakeTestNodeConfigWithDataDir("", "/tmp", chainID)
 	s.Require().NoError(err)


### PR DESCRIPTION
Changes:

- Add status proxy RPC urls for blockchain providers
- Replace the status proxy URL for cryptocompare.
- Use authentication for blockchain endpoint for status proxy
- replace RPC limiter key, as there is no API key passed for proxy
- switching "prod" and "test" endpoints rely on "RELEASE" env and uses build tags for now (we can change it later to be a runtime env, currently runtime envs are not used in status-go)

Closes #
