### PR TITLE
chore_: move filter mgr to go-waku

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20240801160005-d047df3859e2
+	github.com/waku-org/go-waku v0.8.1-0.20240806122111-5aa11311f833
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -2143,8 +2143,8 @@ github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5 h1:9u16E
 github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5/go.mod h1:QEb+hEV9WL9wCiUAnpY29FZR6W3zK8qYlaml8R4q6gQ=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20240801160005-d047df3859e2 h1:S8KqFD9b1T+fJvKqDbb95e4X9TS0gf8XOJUR551+tRQ=
-github.com/waku-org/go-waku v0.8.1-0.20240801160005-d047df3859e2/go.mod h1:OH0Z4ZMVXbgs6cNRap+ENDSNrfp1v2LA6K1qWWMT30M=
+github.com/waku-org/go-waku v0.8.1-0.20240806122111-5aa11311f833 h1:ywaQQJ4WASimv8Y6ut7xhkBYMXyRZQCEw64CFPJJCbQ=
+github.com/waku-org/go-waku v0.8.1-0.20240806122111-5aa11311f833/go.mod h1:VNbVmh5UYg3vIvhGV4hCw8QEykq3RScDACo2Y2dIFfg=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go
@@ -309,19 +309,15 @@ func (pm *PeerManager) ensureMinRelayConnsPerTopic() {
 	defer pm.topicMutex.RUnlock()
 	for topicStr, topicInst := range pm.subRelayTopics {
 
-		// @cammellos reported that ListPeers returned an invalid number of
-		// peers. This will ensure that the peers returned by this function
-		// match those peers that are currently connected
-
 		meshPeerLen := pm.checkAndUpdateTopicHealth(topicInst)
-		topicPeers := pm.host.Peerstore().(wps.WakuPeerstore).PeersByPubSubTopic(topicStr)
-		curPeerLen := topicPeers.Len()
-		if meshPeerLen < waku_proto.GossipSubDMin || curPeerLen < pm.OutPeersTarget {
+		curConnectedPeerLen := pm.getPeersBasedOnconnectionStatus(topicStr, network.Connected).Len()
+
+		if meshPeerLen < waku_proto.GossipSubDMin || curConnectedPeerLen < pm.OutPeersTarget {
 			pm.logger.Debug("subscribed topic has not reached target peers, initiating more connections to maintain healthy mesh",
-				zap.String("pubSubTopic", topicStr), zap.Int("connectedPeerCount", curPeerLen),
+				zap.String("pubSubTopic", topicStr), zap.Int("connectedPeerCount", curConnectedPeerLen),
 				zap.Int("targetPeers", pm.OutPeersTarget))
 			//Find not connected peers.
-			notConnectedPeers := pm.getNotConnectedPers(topicStr)
+			notConnectedPeers := pm.getPeersBasedOnconnectionStatus(topicStr, network.NotConnected)
 			if notConnectedPeers.Len() == 0 {
 				pm.logger.Debug("could not find any peers in peerstore to connect to, discovering more", zap.String("pubSubTopic", topicStr))
 				go pm.discoverPeersByPubsubTopics([]string{topicStr}, relay.WakuRelayID_v200, pm.ctx, 2)
@@ -329,12 +325,13 @@ func (pm *PeerManager) ensureMinRelayConnsPerTopic() {
 			}
 			pm.logger.Debug("connecting to eligible peers in peerstore", zap.String("pubSubTopic", topicStr))
 			//Connect to eligible peers.
-			numPeersToConnect := pm.OutPeersTarget - curPeerLen
-
-			if numPeersToConnect > notConnectedPeers.Len() {
-				numPeersToConnect = notConnectedPeers.Len()
+			numPeersToConnect := pm.OutPeersTarget - curConnectedPeerLen
+			if numPeersToConnect > 0 {
+				if numPeersToConnect > notConnectedPeers.Len() {
+					numPeersToConnect = notConnectedPeers.Len()
+				}
+				pm.connectToSpecifiedPeers(notConnectedPeers[0:numPeersToConnect])
 			}
-			pm.connectToSpecifiedPeers(notConnectedPeers[0:numPeersToConnect])
 		}
 	}
 }
@@ -374,8 +371,8 @@ func (pm *PeerManager) connectToSpecifiedPeers(peers peer.IDSlice) {
 	}
 }
 
-// getNotConnectedPers returns peers for a pubSubTopic that are not connected.
-func (pm *PeerManager) getNotConnectedPers(pubsubTopic string) (notConnectedPeers peer.IDSlice) {
+// getPeersBasedOnconnectionStatus returns peers for a pubSubTopic that are either connected/not-connected based on status passed.
+func (pm *PeerManager) getPeersBasedOnconnectionStatus(pubsubTopic string, connected network.Connectedness) (filteredPeers peer.IDSlice) {
 	var peerList peer.IDSlice
 	if pubsubTopic == "" {
 		peerList = pm.host.Peerstore().Peers()
@@ -383,8 +380,8 @@ func (pm *PeerManager) getNotConnectedPers(pubsubTopic string) (notConnectedPeer
 		peerList = pm.host.Peerstore().(*wps.WakuPeerstoreImpl).PeersByPubSubTopic(pubsubTopic)
 	}
 	for _, peerID := range peerList {
-		if pm.host.Network().Connectedness(peerID) != network.Connected {
-			notConnectedPeers = append(notConnectedPeers, peerID)
+		if pm.host.Network().Connectedness(peerID) == connected {
+			filteredPeers = append(filteredPeers, peerID)
 		}
 	}
 	return

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/test_utils.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/test_utils.go
@@ -47,7 +47,7 @@ type FilterTestSuite struct {
 	ctx              context.Context
 	ctxCancel        context.CancelFunc
 	wg               *sync.WaitGroup
-	contentFilter    protocol.ContentFilter
+	ContentFilter    protocol.ContentFilter
 	subDetails       []*subscription.SubscriptionDetails
 
 	Log *zap.Logger
@@ -63,7 +63,7 @@ type WakuMsg struct {
 }
 
 func (s *FilterTestSuite) SetupTest() {
-	log := utils.Logger() //.Named("filterv2-test")
+	log := utils.Logger()
 	s.Log = log
 
 	s.Log.Info("SetupTest()")
@@ -192,7 +192,7 @@ func (s *FilterTestSuite) waitForMsgFromChan(msg *WakuMsg, ch chan *protocol.Env
 		defer s.wg.Done()
 		select {
 		case env := <-ch:
-			for _, topic := range s.contentFilter.ContentTopicsList() {
+			for _, topic := range s.ContentFilter.ContentTopicsList() {
 				if topic == env.Message().GetContentTopic() {
 					msgFound = true
 				}
@@ -308,8 +308,8 @@ func (s *FilterTestSuite) subscribe(pubsubTopic string, contentTopic string, pee
 	for _, sub := range s.subDetails {
 		if sub.ContentFilter.PubsubTopic == pubsubTopic {
 			sub.Add(contentTopic)
-			s.contentFilter = sub.ContentFilter
-			subDetails, err := s.LightNode.Subscribe(s.ctx, s.contentFilter, WithPeer(peer))
+			s.ContentFilter = sub.ContentFilter
+			subDetails, err := s.LightNode.Subscribe(s.ctx, s.ContentFilter, WithPeer(peer))
 			s.subDetails = subDetails
 			s.Require().NoError(err)
 			return
@@ -317,7 +317,7 @@ func (s *FilterTestSuite) subscribe(pubsubTopic string, contentTopic string, pee
 	}
 
 	s.subDetails = s.getSub(pubsubTopic, contentTopic, peer)
-	s.contentFilter = s.subDetails[0].ContentFilter
+	s.ContentFilter = s.subDetails[0].ContentFilter
 }
 
 func (s *FilterTestSuite) unsubscribe(pubsubTopic string, contentTopic string, peer peer.ID) []*subscription.SubscriptionDetails {
@@ -331,7 +331,7 @@ func (s *FilterTestSuite) unsubscribe(pubsubTopic string, contentTopic string, p
 			} else {
 				sub.Remove(contentTopic)
 			}
-			s.contentFilter = sub.ContentFilter
+			s.ContentFilter = sub.ContentFilter
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1018,7 +1018,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240801160005-d047df3859e2
+# github.com/waku-org/go-waku v0.8.1-0.20240806122111-5aa11311f833
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests

--- a/wakuv2/common/topic.go
+++ b/wakuv2/common/topic.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"strings"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
@@ -101,4 +103,12 @@ func ExtractTopicFromContentTopic(s string) (TopicType, error) {
 
 	result := BytesToTopic(str)
 	return result, nil
+}
+
+func (t TopicSet) ContentTopics() []string {
+	contentTopics := make([]string, len(t))
+	for i, ct := range maps.Keys(t) {
+		contentTopics[i] = ct.ContentTopic()
+	}
+	return contentTopics
 }

--- a/wakuv2/common/topic_test.go
+++ b/wakuv2/common/topic_test.go
@@ -21,6 +21,8 @@ package common
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var topicStringTests = []struct {
@@ -31,6 +33,13 @@ var topicStringTests = []struct {
 	{topic: TopicType{0x00, 0x7f, 0x80, 0xff}, str: "0x007f80ff"},
 	{topic: TopicType{0xff, 0x80, 0x7f, 0x00}, str: "0xff807f00"},
 	{topic: TopicType{0xf2, 0x6e, 0x77, 0x79}, str: "0xf26e7779"},
+}
+
+func TestTopicSet(t *testing.T) {
+
+	tSet := NewTopicSet([]TopicType{{0x00, 0x00, 0x00, 0x00}, {0x00, 0x7f, 0x80, 0xff}})
+	topics := tSet.ContentTopics()
+	require.Equal(t, len(topics), 2)
 }
 
 func TestTopicString(t *testing.T) {

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -57,6 +57,7 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/metrics"
 
+	filterapi "github.com/waku-org/go-waku/waku/v2/api/filter"
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
 	"github.com/waku-org/go-waku/waku/v2/onlinechecker"
@@ -125,7 +126,7 @@ type Waku struct {
 
 	// Filter-related
 	filters       *common.Filters // Message filters installed with Subscribe function
-	filterManager *FilterManager
+	filterManager *filterapi.FilterManager
 
 	privateKeys map[string]*ecdsa.PrivateKey // Private key storage
 	symKeys     map[string][]byte            // Symmetric key storage
@@ -955,7 +956,8 @@ func (w *Waku) Subscribe(f *common.Filter) (string, error) {
 	}
 
 	if w.cfg.LightClient {
-		w.filterManager.addFilter(id, f)
+		cf := protocol.NewContentFilter(f.PubsubTopic, f.ContentTopics.ContentTopics()...)
+		w.filterManager.SubscribeFilter(id, cf)
 	}
 
 	return id, nil
@@ -969,7 +971,7 @@ func (w *Waku) Unsubscribe(ctx context.Context, id string) error {
 	}
 
 	if w.cfg.LightClient {
-		w.filterManager.removeFilter(id)
+		w.filterManager.UnsubscribeFilter(id)
 	}
 
 	return nil
@@ -1206,6 +1208,11 @@ func (w *Waku) Query(ctx context.Context, peerID peer.ID, query store.FilterCrit
 	return result.Cursor(), envelopesCount, nil
 }
 
+// OnNewEnvelope is an interface from Waku FilterManager API that gets invoked when any new message is received by Filter.
+func (w *Waku) OnNewEnvelope(env *protocol.Envelope) error {
+	return w.OnNewEnvelopes(env, common.RelayedMessageType, false)
+}
+
 // Start implements node.Service, starting the background data propagation thread
 // of the Waku protocol.
 func (w *Waku) Start() error {
@@ -1299,8 +1306,8 @@ func (w *Waku) Start() error {
 	if w.cfg.LightClient {
 		// Create FilterManager that will main peer connectivity
 		// for installed filters
-		w.filterManager = newFilterManager(w.ctx, w.logger, w.cfg,
-			func(env *protocol.Envelope) error { return w.OnNewEnvelopes(env, common.RelayedMessageType, false) },
+		w.filterManager = filterapi.NewFilterManager(w.ctx, w.logger, w.cfg.MinPeersForFilter,
+			w,
 			w.node.FilterLightnode())
 	}
 
@@ -1673,7 +1680,7 @@ func (w *Waku) handleNetworkChangeFromApp(state connection.State) {
 		w.logger.Info("connection switched or offline detected via mobile, disconnecting all peers")
 		w.node.DisconnectAllPeers()
 		if w.cfg.LightClient {
-			w.filterManager.networkChange()
+			w.filterManager.NetworkChange()
 		}
 	}
 }
@@ -1682,8 +1689,7 @@ func (w *Waku) ConnectionChanged(state connection.State) {
 	isOnline := !state.Offline
 	if w.cfg.LightClient {
 		//TODO: Update this as per  https://github.com/waku-org/go-waku/issues/1114
-		// trigger FilterManager to take care of any pending filter subscriptions
-		go w.filterManager.onConnectionStatusChange(w.cfg.DefaultShardPubsubTopic, isOnline)
+		go w.filterManager.OnConnectionStatusChange("", isOnline)
 		w.handleNetworkChangeFromApp(state)
 	} else {
 		// for lightClient state update and onlineChange is handled in filterManager.

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -376,7 +376,6 @@ func TestWakuV2Filter(t *testing.T) {
 	w, err := New(nil, "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
-	w.filterManager.filterSubBatchDuration = 1 * time.Second
 
 	options := func(b *backoff.ExponentialBackOff) {
 		b.MaxElapsedTime = 10 * time.Second
@@ -689,8 +688,8 @@ func TestOnlineChecker(t *testing.T) {
 	require.NoError(t, err)
 
 	require.False(t, lightNode.onlineChecker.IsOnline())
-
-	lightNode.filterManager.addFilter("test", &common.Filter{})
+	f := &common.Filter{}
+	lightNode.filterManager.SubscribeFilter("test", protocol.NewContentFilter(f.PubsubTopic, f.ContentTopics.ContentTopics()...))
 
 }
 


### PR DESCRIPTION
Migrate filter manager logic to api layer in go-waku.
This would make API between status-go and go-waku cleaner.

Also pulled in a crash fix for relay https://github.com/waku-org/go-waku/pull/1182.