### PR TITLE
chore_: remove deprecated `CreateAccount.BackupDisabledDataDir`

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -1744,11 +1744,11 @@ func TestRestoreAccountAndLogin(t *testing.T) {
 		Mnemonic:    "test test test test test test test test test test test test",
 		FetchBackup: false,
 		CreateAccount: requests.CreateAccount{
-			DisplayName:           "Account1",
-			DeviceName:            "StatusIM",
-			Password:              "password",
-			CustomizationColor:    "0x000000",
-			BackupDisabledDataDir: tmpdir,
+			DisplayName:        "Account1",
+			DeviceName:         "StatusIM",
+			Password:           "password",
+			CustomizationColor: "0x000000",
+			RootDataDir:        tmpdir,
 		},
 	}
 	account, err := backend.RestoreAccountAndLogin(restoreRequest)
@@ -1783,12 +1783,6 @@ func TestCreateAccountPathsValidation(t *testing.T) {
 
 	err := request.Validate(validation)
 	require.NoError(t, err)
-
-	request.RootDataDir = ""
-	request.BackupDisabledDataDir = tmpdir
-	err = request.Validate(validation)
-	require.NoError(t, err)
-	require.Equal(t, tmpdir, request.RootDataDir)
 }
 
 func TestRestoreKeycardAccountAndLogin(t *testing.T) {

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -1783,6 +1783,10 @@ func TestCreateAccountPathsValidation(t *testing.T) {
 
 	err := request.Validate(validation)
 	require.NoError(t, err)
+
+	request.RootDataDir = ""
+	err = request.Validate(validation)
+	require.ErrorIs(t, err, requests.ErrCreateAccountInvalidRootDataDir)
 }
 
 func TestRestoreKeycardAccountAndLogin(t *testing.T) {

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -204,11 +204,11 @@ func main() {
 			Mnemonic:    *seedPhrase,
 			FetchBackup: false,
 			CreateAccount: requests.CreateAccount{
-				DisplayName:           "Account1",
-				DeviceName:            "StatusIM",
-				Password:              *password,
-				CustomizationColor:    "0x000000",
-				BackupDisabledDataDir: config.DataDir,
+				DisplayName:        "Account1",
+				DeviceName:         "StatusIM",
+				Password:           *password,
+				CustomizationColor: "0x000000",
+				RootDataDir:        config.DataDir,
 				APIConfig: &requests.APIConfig{
 					ConnectorEnabled: config.ClusterConfig.Enabled,
 					HTTPEnabled:      config.HTTPEnabled,

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -33,10 +33,6 @@ type APIConfig struct {
 }
 
 type CreateAccount struct {
-	// Deprecated: BackupDisabledDataDir is the directory where backup is disabled
-	// Use `RootDataDir` instead. Effective BackupDisabledDataDir value will default to RootDataDir + "./".
-	BackupDisabledDataDir string `json:"backupDisabledDataDir"`
-
 	// RootDataDir is an absolute path to the root directory where all data will be stored.
 	RootDataDir   string `json:"rootDataDir"`
 	KdfIterations int    `json:"kdfIterations"`
@@ -135,13 +131,7 @@ func (c *CreateAccount) Validate(validation *CreateAccountValidation) error {
 	}
 
 	if len(c.RootDataDir) == 0 {
-		if c.BackupDisabledDataDir == "" {
-			return ErrCreateAccountInvalidRootDataDir
-		}
-		// NOTE: Fallback to old BackupDisabledDataDir field.
-		// Remove this when both desktop and mobile use the new `RootDataDir` field.
-		// Return error if `RootDataDir` is empty.
-		c.RootDataDir = c.BackupDisabledDataDir
+		return ErrCreateAccountInvalidRootDataDir
 	}
 
 	return nil


### PR DESCRIPTION
Both clients were updated to new API.

Mobile: 
- https://github.com/status-im/status-mobile/pull/20425

Desktop:
- https://github.com/status-im/status-desktop/pull/15090