### PR TITLE
fix(contact_request)_: potential fix to contact request with no saved message

### DIFF
--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2276,84 +2276,6 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 
 	contact := state.CurrentMessageState.Contact
 
-	// If we receive some propagated state from someone who's not
-	// our paired device, we handle it
-	if receivedMessage.ContactRequestPropagatedState != nil && !isSyncMessage {
-		result := contact.ContactRequestPropagatedStateReceived(receivedMessage.ContactRequestPropagatedState)
-		if result.sendBackState {
-			_, err = m.sendContactUpdate(context.Background(), contact.ID, "", "", "", "", m.dispatchMessage)
-			if err != nil {
-				return err
-			}
-		}
-		if result.newContactRequestReceived {
-
-			if contact.hasAddedUs() && !contact.mutual() {
-				receivedMessage.ContactRequestState = common.ContactRequestStatePending
-			}
-
-			// Add mutual state update message for outgoing contact request
-			clock := receivedMessage.Clock - 1
-			updateMessage, err := m.prepareMutualStateUpdateMessage(contact.ID, MutualStateUpdateTypeSent, clock, receivedMessage.Timestamp, false)
-			if err != nil {
-				return err
-			}
-
-			err = m.prepareMessage(updateMessage, m.httpServer)
-			if err != nil {
-				return err
-			}
-			err = m.persistence.SaveMessages([]*common.Message{updateMessage})
-			if err != nil {
-				return err
-			}
-			state.Response.AddMessage(updateMessage)
-
-			err = m.createIncomingContactRequestNotification(contact, state, receivedMessage, true)
-			if err != nil {
-				return err
-			}
-		}
-		state.ModifiedContacts.Store(contact.ID, true)
-		state.AllContacts.Store(contact.ID, contact)
-	}
-
-	if receivedMessage.ContentType == protobuf.ChatMessage_CONTACT_REQUEST && chat.OneToOne() {
-		chatContact := contact
-		if isSyncMessage {
-			chatContact, err = m.BuildContact(&requests.BuildContact{PublicKey: chat.ID})
-			if err != nil {
-				return err
-			}
-		}
-
-		if receivedMessage.CustomizationColor != 0 {
-			chatContact.CustomizationColor = multiaccountscommon.IDToColorFallbackToBlue(receivedMessage.CustomizationColor)
-		}
-
-		if chatContact.mutual() || chatContact.dismissed() {
-			m.logger.Info("ignoring contact request message for a mutual or dismissed contact")
-			return nil
-		}
-
-		sendNotification, err := handleContactRequestChatMessage(receivedMessage, chatContact, isSyncMessage, m.logger)
-		if err != nil {
-			m.logger.Error("failed to handle contact request message", zap.Error(err))
-			return err
-		}
-		state.ModifiedContacts.Store(chatContact.ID, true)
-		state.AllContacts.Store(chatContact.ID, chatContact)
-
-		if sendNotification {
-			err = m.createIncomingContactRequestNotification(chatContact, state, receivedMessage, true)
-			if err != nil {
-				return err
-			}
-		}
-	} else if receivedMessage.ContentType == protobuf.ChatMessage_COMMUNITY {
-		chat.Highlight = true
-	}
-
 	if receivedMessage.ContentType == protobuf.ChatMessage_DISCORD_MESSAGE {
 		discordMessage := receivedMessage.GetDiscordMessage()
 		discordMessageAuthor := discordMessage.GetAuthor()
@@ -2440,6 +2362,84 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 	err = m.addPeersyncingMessage(chat, state.CurrentMessageState.StatusMessage)
 	if err != nil {
 		m.logger.Warn("failed to add peersyncing message", zap.Error(err))
+	}
+
+	// If we receive some propagated state from someone who's not
+	// our paired device, we handle it
+	if receivedMessage.ContactRequestPropagatedState != nil && !isSyncMessage {
+		result := contact.ContactRequestPropagatedStateReceived(receivedMessage.ContactRequestPropagatedState)
+		if result.sendBackState {
+			_, err = m.sendContactUpdate(context.Background(), contact.ID, "", "", "", "", m.dispatchMessage)
+			if err != nil {
+				return err
+			}
+		}
+		if result.newContactRequestReceived {
+
+			if contact.hasAddedUs() && !contact.mutual() {
+				receivedMessage.ContactRequestState = common.ContactRequestStatePending
+			}
+
+			// Add mutual state update message for outgoing contact request
+			clock := receivedMessage.Clock - 1
+			updateMessage, err := m.prepareMutualStateUpdateMessage(contact.ID, MutualStateUpdateTypeSent, clock, receivedMessage.Timestamp, false)
+			if err != nil {
+				return err
+			}
+
+			err = m.prepareMessage(updateMessage, m.httpServer)
+			if err != nil {
+				return err
+			}
+			err = m.persistence.SaveMessages([]*common.Message{updateMessage})
+			if err != nil {
+				return err
+			}
+			state.Response.AddMessage(updateMessage)
+
+			err = m.createIncomingContactRequestNotification(contact, state, receivedMessage, true)
+			if err != nil {
+				return err
+			}
+		}
+		state.ModifiedContacts.Store(contact.ID, true)
+		state.AllContacts.Store(contact.ID, contact)
+	}
+
+	if receivedMessage.ContentType == protobuf.ChatMessage_CONTACT_REQUEST && chat.OneToOne() {
+		chatContact := contact
+		if isSyncMessage {
+			chatContact, err = m.BuildContact(&requests.BuildContact{PublicKey: chat.ID})
+			if err != nil {
+				return err
+			}
+		}
+
+		if receivedMessage.CustomizationColor != 0 {
+			chatContact.CustomizationColor = multiaccountscommon.IDToColorFallbackToBlue(receivedMessage.CustomizationColor)
+		}
+
+		if chatContact.mutual() || chatContact.dismissed() {
+			m.logger.Info("ignoring contact request message for a mutual or dismissed contact")
+			return nil
+		}
+
+		sendNotification, err := handleContactRequestChatMessage(receivedMessage, chatContact, isSyncMessage, m.logger)
+		if err != nil {
+			m.logger.Error("failed to handle contact request message", zap.Error(err))
+			return err
+		}
+		state.ModifiedContacts.Store(chatContact.ID, true)
+		state.AllContacts.Store(chatContact.ID, chatContact)
+
+		if sendNotification {
+			err = m.createIncomingContactRequestNotification(chatContact, state, receivedMessage, true)
+			if err != nil {
+				return err
+			}
+		}
+	} else if receivedMessage.ContentType == protobuf.ChatMessage_COMMUNITY {
+		chat.Highlight = true
 	}
 
 	receivedMessage.New = true


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/15930

The issue happened because I received a notification about a contact request, but the request was not associated with a message in the DB. The DB didn't have a message with the required ID in it.

This potential fix moves the creation of the contact request later in the handling code, because the only way this bug can happen as far as I see it is if there is an error later in the handler function and the message is never added to the response, and therefore never saved.

Sadly, I lost my repro state, but still, this fix doesn't fix a state that already has a "bad contact request". It tries to avoid the problem happening again.
However, I also don't know exactly how it happened, since my logs were already overwritten when I started investigating the bad contact request. The contact request I had was from a user, so maybe it was someone using an old version or something?