### PR TITLE
feat(telemetry)_: include device type in metrics

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -554,7 +554,10 @@ func NewMessenger(
 
 	var telemetryClient *telemetry.Client
 	if c.telemetryServerURL != "" {
-		telemetryClient = telemetry.NewClient(logger, c.telemetryServerURL, c.account.KeyUID, nodeName, version, telemetry.WithPeerID(peerId.String()))
+		options := []telemetry.TelemetryClientOption{
+			telemetry.WithPeerID(peerId.String()),
+		}
+		telemetryClient = telemetry.NewClient(logger, c.telemetryServerURL, c.account.KeyUID, nodeName, version, options...)
 		if c.wakuService != nil {
 			c.wakuService.SetStatusTelemetryClient(telemetryClient)
 		}

--- a/protocol/messenger_pairing_and_syncing.go
+++ b/protocol/messenger_pairing_and_syncing.go
@@ -415,6 +415,13 @@ func (m *Messenger) InitInstallations() error {
 		return err
 	}
 
+	if m.telemetryClient != nil {
+		installation, ok := m.allInstallations.Load(m.installationID)
+		if ok {
+			m.telemetryClient.SetDeviceType(installation.InstallationMetadata.DeviceType)
+		}
+	}
+
 	return nil
 }
 

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -102,6 +102,7 @@ type ErrorSendingEnvelope struct {
 }
 
 type ITelemetryClient interface {
+	SetDeviceType(deviceType string)
 	PushReceivedEnvelope(ctx context.Context, receivedEnvelope *protocol.Envelope)
 	PushSentEnvelope(ctx context.Context, sentEnvelope SentEnvelope)
 	PushErrorSendingEnvelope(ctx context.Context, errorSendingEnvelope ErrorSendingEnvelope)


### PR DESCRIPTION
Initializes telemetry client with device type and includes in all calls to telemetry server.

At the end of `injectAccountsIntoWakuService`, finds the installation based on installation ID set in messenger, and calls Waku service to set it in the telemetry client. Does nothing if the telemetry client is not set.

Important changes:
- [ ] depends on https://github.com/status-im/telemetry/pull/44

Closes #
