### PR TITLE
Remove restriction to call InitLogger only once

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1409,7 +1409,7 @@ func InitLogging(logSettingsJSON string) string {
 	if err = json.Unmarshal([]byte(logSettingsJSON), &logSettings); err != nil {
 		return makeJSONResponse(err)
 	}
-	
+
 	if err = logutils.OverrideRootLogWithConfig(logSettings, false); err == nil {
 		log.Info("logging initialised", "logSettings", logSettingsJSON)
 	}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 	"unsafe"
 
 	validator "gopkg.in/go-playground/validator.v9"
@@ -1401,10 +1400,8 @@ func DeserializeAndCompressKey(DesktopKey string) string {
 	return CompressPublicKey(sanitisedKey)
 }
 
-var initLoggingOnce sync.Once
-
-// InitLogging The InitLogging function should be called only once during the application's lifetime,
-// specifically when the application starts. This ensures that we can capture logs before the user login.
+// InitLogging The InitLogging function should be called when the application starts.
+// This ensures that we can capture logs before the user login. Subsequent calls will update the logger settings.
 // Before this, we can only capture logs after user login since we will only configure the logging after the login process.
 func InitLogging(logSettingsJSON string) string {
 	var logSettings logutils.LogSettings
@@ -1412,12 +1409,10 @@ func InitLogging(logSettingsJSON string) string {
 	if err = json.Unmarshal([]byte(logSettingsJSON), &logSettings); err != nil {
 		return makeJSONResponse(err)
 	}
-
-	initLoggingOnce.Do(func() {
-		if err = logutils.OverrideRootLogWithConfig(logSettings, false); err == nil {
-			log.Info("logging initialised", "logSettings", logSettingsJSON)
-		}
-	})
+	
+	if err = logutils.OverrideRootLogWithConfig(logSettings, false); err == nil {
+		log.Info("logging initialised", "logSettings", logSettingsJSON)
+	}
 
 	return makeJSONResponse(err)
 }


### PR DESCRIPTION
Remove restriction to call InitLogger only once

There is an [issue](https://github.com/status-im/status-mobile/issues/20944) in mobile PR - debug logs don't show up in `geth.log` file. After investigation, it turned out that `InitLogger` function was implemented in a way that implies it will be called only once on app start. But in fact, status mobile app calls it once on app startup, plus whenever a user logs in to set the debug level for that user. That last call didn't work due to `var initLoggingOnce sync.Once` in code. So per discussion with @qfrank that restriction was removed.

