### PR TITLE
fix: reporting connection change to filter manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20240806174951-6e1ff9818815
+	github.com/waku-org/go-waku v0.8.1-0.20240808103513-b96582a30bc5
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -2143,8 +2143,8 @@ github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5 h1:9u16E
 github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5/go.mod h1:QEb+hEV9WL9wCiUAnpY29FZR6W3zK8qYlaml8R4q6gQ=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20240806174951-6e1ff9818815 h1:arQLN7mhSJNBJLhnxiV9WqMEC5rYZZS7oHnuYBPEct8=
-github.com/waku-org/go-waku v0.8.1-0.20240806174951-6e1ff9818815/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
+github.com/waku-org/go-waku v0.8.1-0.20240808103513-b96582a30bc5 h1:AVbypRIcT8AWzuOxutErS6rYhTVbnOPA/kMyxjeJ6R4=
+github.com/waku-org/go-waku v0.8.1-0.20240808103513-b96582a30bc5/go.mod h1:ugDTCvcP6oJ9mTtINeo4EIsnC3oQCU3RsctNKu4MsRw=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/keepalive.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/keepalive.go
@@ -56,8 +56,8 @@ func (w *WakuNode) startKeepAlive(ctx context.Context, randomPeersPingDuration t
 	}
 
 	allPeersTickerC := make(<-chan time.Time)
-	if randomPeersPingDuration != 0 {
-		allPeersTicker := time.NewTicker(randomPeersPingDuration)
+	if allPeersPingDuration != 0 {
+		allPeersTicker := time.NewTicker(allPeersPingDuration)
 		defer allPeersTicker.Stop()
 		randomPeersTickerC = allPeersTicker.C
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1018,7 +1018,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20240806174951-6e1ff9818815
+# github.com/waku-org/go-waku v0.8.1-0.20240808103513-b96582a30bc5
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1376,7 +1376,7 @@ func (w *Waku) Start() error {
 					//TODO: needs fixing, right now invoking everytime.
 					//Trigger FilterManager to take care of any pending filter subscriptions
 					//TODO: Pass pubsubTopic based on topicHealth notif received.
-					go w.filterManager.onConnectionStatusChange(w.cfg.DefaultShardPubsubTopic, isOnline)
+					go w.filterManager.onConnectionStatusChange("", isOnline)
 
 				}
 				w.connStatusMu.Lock()


### PR DESCRIPTION
While working on https://github.com/status-im/status-go/pull/5653, had noticed an issue in connection change notification given to filterManager. 

The notification is being sent only for defaultShardPubSubTopic which means that any queued filters on the shard `64` will not get registered when they were adding in case user was in offline status.
This is a corner scenario that can happen during startup or when user looses connection, but nonetheless effects user experience in lightMode.

Important changes:
- [x] Pulling only the fix from the origin PR where connectionStatusChange is reported without any pubsubTopic/shard to filterManager.
- [x] include https://github.com/waku-org/go-waku/pull/1188 once PR is approved.

