### PR TITLE
chore_: ignore sensitive fields of WalletConfig when logging

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -583,6 +583,20 @@ type WalletConfig struct {
 	EnableCelerBridge             bool              `json:"EnableCelerBridge"`
 }
 
+// MarshalJSON custom marshalling to avoid exposing sensitive data in log,
+// there's a function called `startNode` will log NodeConfig which include WalletConfig
+func (wc WalletConfig) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Enabled            bool `json:"Enabled"`
+		StatusProxyEnabled bool `json:"StatusProxyEnabled"`
+		EnableCelerBridge  bool `json:"EnableCelerBridge"`
+	}{
+		Enabled:            wc.Enabled,
+		StatusProxyEnabled: wc.StatusProxyEnabled,
+		EnableCelerBridge:  wc.EnableCelerBridge,
+	})
+}
+
 // LocalNotificationsConfig extra configuration for localnotifications.Service.
 type LocalNotificationsConfig struct {
 	Enabled bool

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -1,6 +1,7 @@
 package params_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -337,4 +338,23 @@ func TestNodeConfigValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMarshalWalletConfigJSON(t *testing.T) {
+	walletConfig := params.WalletConfig{
+		OpenseaAPIKey:        "some-key",
+		RaribleMainnetAPIKey: "some-key2",
+	}
+	bytes, err := json.Marshal(walletConfig)
+	require.NoError(t, err)
+	// check if sensitive fields are not present
+	require.NotContains(t, string(bytes), "OpenseaAPIKey")
+	require.Contains(t, string(bytes), "StatusProxyEnabled")
+
+	// check if deserializing are still working with sensitive fields
+	walletConfig = params.WalletConfig{}
+	err = json.Unmarshal([]byte(`{"OpenseaAPIKey":"some-key", "StatusProxyEnabled":true}`), &walletConfig)
+	require.NoError(t, err)
+	require.Equal(t, "some-key", walletConfig.OpenseaAPIKey)
+	require.True(t, walletConfig.StatusProxyEnabled)
 }


### PR DESCRIPTION
We used env to hide sensitive configuration, but there's a chance to write the sensitive data into log file, this PR fixed it.