### PR TITLE
fix_: wait for mailserver available signal to change missing messages criteria

### DIFF
--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -396,10 +396,16 @@ func (m *Messenger) checkForMissingMessagesLoop() {
 	t := time.NewTicker(missingMessageCheckPeriod)
 	defer t.Stop()
 
+	mailserverAvailableSignal := m.SubscribeMailserverAvailable()
+
 	for {
 		select {
 		case <-m.quit:
 			return
+
+		// Wait for mailserver available, also triggered on mailserver change
+		case <-mailserverAvailableSignal:
+			mailserverAvailableSignal = m.SubscribeMailserverAvailable()
 
 		case <-t.C:
 


### PR DESCRIPTION
Adds back the code removed in https://github.com/status-im/status-go/pull/5684 while also fixing the code that caused a mem leak