### PR TITLE
Fix/prevent filterlogs backwards range

### DIFF
--- a/services/wallet/transfer/downloader.go
+++ b/services/wallet/transfer/downloader.go
@@ -534,6 +534,13 @@ func (d *ERC20TransfersDownloader) blocksFromLogs(parent context.Context, logs [
 func (d *ERC20TransfersDownloader) GetHeadersInRange(parent context.Context, from, to *big.Int) ([]*DBHeader, error) {
 	start := time.Now()
 	log.Debug("get erc20 transfers in range start", "chainID", d.client.NetworkID(), "from", from, "to", to, "accounts", d.accounts)
+
+	// TODO #16062: Figure out real root cause of invalid range
+	if from != nil && to != nil && from.Cmp(to) > 0 {
+		log.Error("invalid range", "chainID", d.client.NetworkID(), "from", from, "to", to, "accounts", d.accounts)
+		return nil, errors.New("invalid range")
+	}
+
 	headers := []*DBHeader{}
 	ctx := context.Background()
 	var err error

--- a/services/wallet/transfer/downloader_test.go
+++ b/services/wallet/transfer/downloader_test.go
@@ -1,0 +1,47 @@
+package transfer
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/golang/mock/gomock"
+
+	mock_client "github.com/status-im/status-go/rpc/chain/mock/client"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestERC20Downloader_getHeadersInRange(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockClientIface := mock_client.NewMockClientInterface(mockCtrl)
+
+	accounts := []common.Address{
+		common.HexToAddress("0x1"),
+	}
+	chainID := walletCommon.EthereumMainnet
+	signer := types.LatestSignerForChainID(big.NewInt(int64(chainID)))
+	mockClientIface.EXPECT().NetworkID().Return(chainID).AnyTimes()
+
+	downloader := NewERC20TransfersDownloader(
+		mockClientIface,
+		accounts,
+		signer,
+		false,
+	)
+
+	ctx := context.Background()
+
+	_, err := downloader.GetHeadersInRange(ctx, big.NewInt(10), big.NewInt(0))
+	require.Error(t, err)
+
+	mockClientIface.EXPECT().FilterLogs(ctx, gomock.Any()).Return(nil, nil).AnyTimes()
+	_, err = downloader.GetHeadersInRange(ctx, big.NewInt(0), big.NewInt(10))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Prevent making an RPC call we know is going to fail (when `from` block is larger than `to` block in `GetHeadersInRange`) to somewhat mitigate [#16062](https://github.com/status-im/status-desktop/issues/16062). Real root cause still being investigated.

Client side behavior should be identical when fetching history, we only fail locally instead of getting the error from the blockchain providers.
