### PR TITLE
fix(commit_check)_: release branch commit check

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -52,14 +52,15 @@ pipeline {
   }
 
   environment {
-    PLATFORM = 'tests'
-    DB_CONT  = "status-go-test-db-${env.EXECUTOR_NUMBER.toInteger() + 1}"
-    DB_PORT  = "${5432 + env.EXECUTOR_NUMBER.toInteger()}"
-    TMPDIR   = "${WORKSPACE_TMP}"
-    GOPATH   = "${WORKSPACE_TMP}/go"
-    GOCACHE  = "${WORKSPACE_TMP}/gocache"
-    PATH     = "${PATH}:${GOPATH}/bin"
-    REPO_SRC = "${GOPATH}/src/github.com/status-im/status-go"
+    PLATFORM    = 'tests'
+    DB_CONT     = "status-go-test-db-${env.EXECUTOR_NUMBER.toInteger() + 1}"
+    DB_PORT     = "${5432 + env.EXECUTOR_NUMBER.toInteger()}"
+    TMPDIR      = "${WORKSPACE_TMP}"
+    GOPATH      = "${WORKSPACE_TMP}/go"
+    GOCACHE     = "${WORKSPACE_TMP}/gocache"
+    PATH        = "${PATH}:${GOPATH}/bin"
+    REPO_SRC    = "${GOPATH}/src/github.com/status-im/status-go"
+    BASE_BRANCH = "${env.CHANGE_TARGET}"
 
     /* Hack-fix for params not being set in env on first job run. */
     UNIT_TEST_FAILFAST =               "${params.UNIT_TEST_FAILFAST}"
@@ -94,6 +95,9 @@ pipeline {
     }
 
     stage('Commit') {
+      environment {
+        BASE_BRANCH = "${env.BASE_BRANCH}"
+      }
       when { // https://github.com/status-im/status-go/issues/4993#issuecomment-2022685544
         expression { !isTestNightlyJob() }
       }

--- a/_assets/scripts/commit_check.sh
+++ b/_assets/scripts/commit_check.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 parse_commits() {
-    start_commit=${1:-origin/develop}
+    start_commit=${1:-origin/${BASE_BRANCH}}
     end_commit=${2:-HEAD}
     is_breaking_change=false
 
@@ -27,4 +27,4 @@ parse_commits() {
     echo "$is_breaking_change"
 }
 
-parse_commits
+parse_commits "$@"


### PR DESCRIPTION
This will fix the lock in PR like in https://github.com/status-im/status-go/pull/5697.
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/33c08a3b-3620-4790-8e75-74eeb98868a5">

Also would be super-cool to implement this https://github.com/status-im/status-go/issues/5610. Then we'll just not have any bad-formed commit messages.

-----

It's green on CI now.

PR for `release/0.182.x` branch:
```nim
[2024-08-12T21:30:03.364Z] bash _assets/scripts/commit_check.sh
[2024-08-12T21:30:03.364Z] Configuring Nix shell for target 'default'...
[2024-08-12T21:30:06.685Z] checking commits between: origin/release/0.182.x HEAD
[2024-08-12T21:30:06.685Z] false
```

PR for `develop` branch:
```nim
[2024-08-12T21:35:24.158Z] bash _assets/scripts/commit_check.sh
[2024-08-12T21:35:24.158Z] Configuring Nix shell for target 'default'...
[2024-08-12T21:35:27.345Z] checking commits between: origin/develop HEAD
[2024-08-12T21:35:27.345Z] false
```