### PR TITLE
refactor_: use concrete datatypes instead of `string`

### DIFF
--- a/eth-node/bridge/geth/waku.go
+++ b/eth-node/bridge/geth/waku.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/status-im/status-go/connection"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/waku"
@@ -59,7 +61,7 @@ func (w *GethWakuWrapper) StopDiscV5() error {
 }
 
 // PeerCount function only added for compatibility with waku V2
-func (w *GethWakuWrapper) AddStorePeer(address string) (peer.ID, error) {
+func (w *GethWakuWrapper) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return "", errors.New("not available in WakuV1")
 }
 
@@ -90,22 +92,22 @@ func (w *GethWakuWrapper) RemovePubsubTopicKey(topic string) error {
 }
 
 // AddRelayPeer function only added for compatibility with waku V2
-func (w *GethWakuWrapper) AddRelayPeer(address string) (peer.ID, error) {
+func (w *GethWakuWrapper) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return "", errors.New("not available in WakuV1")
 }
 
 // DialPeer function only added for compatibility with waku V2
-func (w *GethWakuWrapper) DialPeer(address string) error {
+func (w *GethWakuWrapper) DialPeer(address multiaddr.Multiaddr) error {
 	return errors.New("not available in WakuV1")
 }
 
 // DialPeerByID function only added for compatibility with waku V2
-func (w *GethWakuWrapper) DialPeerByID(peerID string) error {
+func (w *GethWakuWrapper) DialPeerByID(peerID peer.ID) error {
 	return errors.New("not available in WakuV1")
 }
 
 // ListenAddresses function only added for compatibility with waku V2
-func (w *GethWakuWrapper) ListenAddresses() ([]string, error) {
+func (w *GethWakuWrapper) ListenAddresses() ([]multiaddr.Multiaddr, error) {
 	return nil, errors.New("not available in WakuV1")
 }
 
@@ -114,12 +116,12 @@ func (w *GethWakuWrapper) RelayPeersByTopic(topic string) (*types.PeerList, erro
 }
 
 // ENR function only added for compatibility with waku V2
-func (w *GethWakuWrapper) ENR() (string, error) {
-	return "", errors.New("not available in WakuV1")
+func (w *GethWakuWrapper) ENR() (*enode.Node, error) {
+	return nil, errors.New("not available in WakuV1")
 }
 
 // PeerCount function only added for compatibility with waku V2
-func (w *GethWakuWrapper) DropPeer(peerID string) error {
+func (w *GethWakuWrapper) DropPeer(peerID peer.ID) error {
 	return errors.New("not available in WakuV1")
 }
 
@@ -132,8 +134,8 @@ func (w *GethWakuWrapper) SetCriteriaForMissingMessageVerification(peerID peer.I
 }
 
 // Peers function only added for compatibility with waku V2
-func (w *GethWakuWrapper) Peers() map[string]types.WakuV2Peer {
-	p := make(map[string]types.WakuV2Peer)
+func (w *GethWakuWrapper) Peers() types.PeerStats {
+	p := make(types.PeerStats)
 	return p
 }
 

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -496,7 +496,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestBecomeMemberPermissions(
 	s.Require().LessOrEqual(1, len(storeNodeListenAddresses))
 
 	storeNodeAddress := storeNodeListenAddresses[0]
-	s.logger.Info("store node ready", zap.String("address", storeNodeAddress))
+	s.logger.Info("store node ready", zap.Stringer("address", storeNodeAddress))
 
 	// Create messengers
 

--- a/protocol/messenger_config_test.go
+++ b/protocol/messenger_config_test.go
@@ -1,6 +1,7 @@
 package protocol
 
 import (
+	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/appdatabase"
@@ -10,7 +11,7 @@ import (
 	"github.com/status-im/status-go/t/helpers"
 )
 
-func WithTestStoreNode(s *suite.Suite, id string, address string, fleet string, collectiblesServiceMock *CollectiblesServiceMock) Option {
+func WithTestStoreNode(s *suite.Suite, id string, address multiaddr.Multiaddr, fleet string, collectiblesServiceMock *CollectiblesServiceMock) Option {
 	return func(c *config) error {
 		sqldb, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
 		s.Require().NoError(err)
@@ -19,7 +20,7 @@ func WithTestStoreNode(s *suite.Suite, id string, address string, fleet string, 
 		err = db.Add(mailservers.Mailserver{
 			ID:      id,
 			Name:    id,
-			Address: address,
+			Address: address.String(),
 			Fleet:   fleet,
 		})
 		s.Require().NoError(err)

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -78,7 +79,12 @@ func (m *Messenger) StartMailserverCycle(mailservers []mailservers.Mailserver) e
 			return nil
 		}
 		for _, storenode := range mailservers {
-			_, err := m.transport.AddStorePeer(storenode.Address)
+			maddr, err := multiaddr.NewMultiaddr(storenode.Address)
+			if err != nil {
+				return err
+			}
+
+			_, err = m.AddStorePeer(maddr)
 			if err != nil {
 				return err
 			}

--- a/protocol/messenger_peers.go
+++ b/protocol/messenger_peers.go
@@ -4,31 +4,34 @@ import (
 	"crypto/ecdsa"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
 
 	"github.com/status-im/status-go/eth-node/types"
 )
 
-func (m *Messenger) AddStorePeer(address string) (peer.ID, error) {
+func (m *Messenger) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return m.transport.AddStorePeer(address)
 }
 
-func (m *Messenger) AddRelayPeer(address string) (peer.ID, error) {
+func (m *Messenger) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return m.transport.AddRelayPeer(address)
 }
 
-func (m *Messenger) DialPeer(address string) error {
+func (m *Messenger) DialPeer(address multiaddr.Multiaddr) error {
 	return m.transport.DialPeer(address)
 }
 
-func (m *Messenger) DialPeerByID(peerID string) error {
+func (m *Messenger) DialPeerByID(peerID peer.ID) error {
 	return m.transport.DialPeerByID(peerID)
 }
 
-func (m *Messenger) DropPeer(peerID string) error {
+func (m *Messenger) DropPeer(peerID peer.ID) error {
 	return m.transport.DropPeer(peerID)
 }
 
-func (m *Messenger) Peers() map[string]types.WakuV2Peer {
+func (m *Messenger) Peers() types.PeerStats {
 	return m.transport.Peers()
 }
 
@@ -36,11 +39,11 @@ func (m *Messenger) RelayPeersByTopic(topic string) (*types.PeerList, error) {
 	return m.transport.RelayPeersByTopic(topic)
 }
 
-func (m *Messenger) ListenAddresses() ([]string, error) {
+func (m *Messenger) ListenAddresses() ([]multiaddr.Multiaddr, error) {
 	return m.transport.ListenAddresses()
 }
 
-func (m *Messenger) ENR() (string, error) {
+func (m *Messenger) ENR() (*enode.Node, error) {
 	return m.transport.ENR()
 }
 

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
+
 	"github.com/status-im/status-go/protocol/wakusync"
 
 	"github.com/status-im/status-go/protocol/identity"
@@ -226,7 +228,7 @@ func WaitForConnectionStatus(s *suite.Suite, waku *waku2.Waku, action func() boo
 	}
 }
 
-func hasAllPeers(m map[string]types.WakuV2Peer, checkSlice []string) bool {
+func hasAllPeers(m map[peer.ID]types.WakuV2Peer, checkSlice peer.IDSlice) bool {
 	for _, check := range checkSlice {
 		if _, ok := m[check]; !ok {
 			return false
@@ -235,7 +237,7 @@ func hasAllPeers(m map[string]types.WakuV2Peer, checkSlice []string) bool {
 	return true
 }
 
-func WaitForPeersConnected(s *suite.Suite, waku *waku2.Waku, action func() []string) {
+func WaitForPeersConnected(s *suite.Suite, waku *waku2.Waku, action func() peer.IDSlice) {
 	subscription := waku.SubscribeToConnStatusChanges()
 	defer subscription.Unsubscribe()
 

--- a/protocol/storenodes/database.go
+++ b/protocol/storenodes/database.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/multiformats/go-multiaddr"
+
 	"github.com/status-im/status-go/eth-node/types"
 )
 
@@ -135,7 +137,7 @@ func (d *Database) upsert(n Storenode, tx *sql.Tx) error {
 		n.CommunityID,
 		n.StorenodeID,
 		n.Name,
-		n.Address,
+		n.Address.String(),
 		n.Fleet,
 		n.Version,
 		n.Clock,
@@ -162,11 +164,12 @@ func toStorenodes(rows *sql.Rows) ([]Storenode, error) {
 
 	for rows.Next() {
 		var m Storenode
+		var addr string
 		if err := rows.Scan(
 			&m.CommunityID,
 			&m.StorenodeID,
 			&m.Name,
-			&m.Address,
+			&addr,
 			&m.Fleet,
 			&m.Version,
 			&m.Clock,
@@ -175,6 +178,12 @@ func toStorenodes(rows *sql.Rows) ([]Storenode, error) {
 		); err != nil {
 			return nil, err
 		}
+
+		maddr, err := multiaddr.NewMultiaddr(addr)
+		if err != nil {
+			return nil, err
+		}
+		m.Address = maddr
 		result = append(result, m)
 	}
 

--- a/protocol/storenodes/database_test.go
+++ b/protocol/storenodes/database_test.go
@@ -3,6 +3,7 @@ package storenodes
 import (
 	"testing"
 
+	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/eth-node/types"
@@ -16,12 +17,16 @@ var (
 func TestSyncSave(t *testing.T) {
 	db, close := setupTestDB(t, communityID1)
 	defer close()
+
+	maddr, err := multiaddr.NewMultiaddr("/dns4/test.net/tcp/30303/p2p/16Uiu2HAmMELCo218hncCtTvC2Dwbej3rbyHQcR8erXNnKGei7WPZ")
+	require.NoError(t, err)
+
 	snodes := []Storenode{
 		{
 			CommunityID: communityID1,
 			StorenodeID: "storenode001",
 			Name:        "My Mailserver",
-			Address:     "enode://...",
+			Address:     maddr,
 			Fleet:       "prod",
 			Version:     2,
 		},
@@ -30,7 +35,7 @@ func TestSyncSave(t *testing.T) {
 	// ========
 	// Save
 
-	err := db.syncSave(communityID1, snodes, 0)
+	err = db.syncSave(communityID1, snodes, 0)
 	require.NoError(t, err)
 
 	dbNodes, err := db.getByCommunityID(communityID1)
@@ -47,7 +52,7 @@ func TestSyncSave(t *testing.T) {
 			CommunityID: communityID1,
 			StorenodeID: "storenode001",
 			Name:        "My Mailserver 2",
-			Address:     "enode://...",
+			Address:     maddr,
 			Fleet:       "prod",
 			Version:     2,
 		},

--- a/protocol/storenodes/models.go
+++ b/protocol/storenodes/models.go
@@ -1,6 +1,8 @@
 package storenodes
 
 import (
+	"github.com/multiformats/go-multiaddr"
+
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/services/mailservers"
@@ -8,15 +10,15 @@ import (
 
 // Storenode is a struct that represents a storenode, it is very closely related to `mailservers.Mailserver`
 type Storenode struct {
-	CommunityID types.HexBytes `json:"community_id"`
-	StorenodeID string         `json:"storenode_id"`
-	Name        string         `json:"name"`
-	Address     string         `json:"address"`
-	Fleet       string         `json:"fleet"`
-	Version     uint           `json:"version"`
-	Clock       uint64         `json:"-"` // used to sync
-	Removed     bool           `json:"-"`
-	DeletedAt   int64          `json:"-"`
+	CommunityID types.HexBytes      `json:"community_id"`
+	StorenodeID string              `json:"storenode_id"`
+	Name        string              `json:"name"`
+	Address     multiaddr.Multiaddr `json:"address"`
+	Fleet       string              `json:"fleet"`
+	Version     uint                `json:"version"`
+	Clock       uint64              `json:"-"` // used to sync
+	Removed     bool                `json:"-"`
+	DeletedAt   int64               `json:"-"`
 }
 
 type Storenodes []Storenode
@@ -29,7 +31,7 @@ func (m Storenodes) ToProtobuf() []*protobuf.Storenode {
 			CommunityId: n.CommunityID,
 			StorenodeId: n.StorenodeID,
 			Name:        n.Name,
-			Address:     n.Address,
+			Address:     n.Address.String(),
 			Fleet:       n.Fleet,
 			Version:     uint32(n.Version),
 			Removed:     n.Removed,
@@ -42,11 +44,15 @@ func (m Storenodes) ToProtobuf() []*protobuf.Storenode {
 func FromProtobuf(storenodes []*protobuf.Storenode, clock uint64) Storenodes {
 	result := make(Storenodes, 0, len(storenodes))
 	for _, s := range storenodes {
+		sAddress, err := multiaddr.NewMultiaddr(s.Address)
+		if err != nil {
+			continue
+		}
 		result = append(result, Storenode{
 			CommunityID: s.CommunityId,
 			StorenodeID: s.StorenodeId,
 			Name:        s.Name,
-			Address:     s.Address,
+			Address:     sAddress,
 			Fleet:       s.Fleet,
 			Version:     uint(s.Version),
 			Removed:     s.Removed,
@@ -62,7 +68,7 @@ func toMailserver(m Storenode) mailservers.Mailserver {
 		ID:      m.StorenodeID,
 		Name:    m.Name,
 		Custom:  true,
-		Address: m.Address,
+		Address: m.Address.String(),
 		Fleet:   m.Fleet,
 		Version: m.Version,
 	}

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -12,12 +12,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/status-im/status-go/connection"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
@@ -457,7 +459,7 @@ func (t *Transport) PeerCount() int {
 	return t.waku.PeerCount()
 }
 
-func (t *Transport) Peers() map[string]types.WakuV2Peer {
+func (t *Transport) Peers() types.PeerStats {
 	return t.waku.Peers()
 }
 
@@ -647,7 +649,7 @@ func (t *Transport) StopDiscV5() error {
 	return t.waku.StopDiscV5()
 }
 
-func (t *Transport) ListenAddresses() ([]string, error) {
+func (t *Transport) ListenAddresses() ([]multiaddr.Multiaddr, error) {
 	return t.waku.ListenAddresses()
 }
 
@@ -655,27 +657,27 @@ func (t *Transport) RelayPeersByTopic(topic string) (*types.PeerList, error) {
 	return t.waku.RelayPeersByTopic(topic)
 }
 
-func (t *Transport) ENR() (string, error) {
+func (t *Transport) ENR() (*enode.Node, error) {
 	return t.waku.ENR()
 }
 
-func (t *Transport) AddStorePeer(address string) (peer.ID, error) {
+func (t *Transport) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return t.waku.AddStorePeer(address)
 }
 
-func (t *Transport) AddRelayPeer(address string) (peer.ID, error) {
+func (t *Transport) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return t.waku.AddRelayPeer(address)
 }
 
-func (t *Transport) DialPeer(address string) error {
+func (t *Transport) DialPeer(address multiaddr.Multiaddr) error {
 	return t.waku.DialPeer(address)
 }
 
-func (t *Transport) DialPeerByID(peerID string) error {
+func (t *Transport) DialPeerByID(peerID peer.ID) error {
 	return t.waku.DialPeerByID(peerID)
 }
 
-func (t *Transport) DropPeer(peerID string) error {
+func (t *Transport) DropPeer(peerID peer.ID) error {
 	return t.waku.DropPeer(peerID)
 }
 

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -9,6 +9,9 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+
 	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/services/browsers"
 	"github.com/status-im/status-go/services/wallet"
@@ -16,6 +19,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -1480,29 +1484,47 @@ func (api *PublicAPI) StorePubsubTopicKey(topic string, privKey string) error {
 	return api.service.messenger.StorePubsubTopicKey(topic, p)
 }
 
-func (api *PublicAPI) AddStorePeer(address string) (string, error) {
-	peerID, err := api.service.messenger.AddStorePeer(address)
-	return string(peerID), err
+func (api *PublicAPI) AddStorePeer(address string) (peer.ID, error) {
+	maddr, err := multiaddr.NewMultiaddr(address)
+	if err != nil {
+		return "", err
+	}
+	return api.service.messenger.AddStorePeer(maddr)
 }
 
-func (api *PublicAPI) AddRelayPeer(address string) (string, error) {
-	peerID, err := api.service.messenger.AddRelayPeer(address)
-	return string(peerID), err
+func (api *PublicAPI) AddRelayPeer(address string) (peer.ID, error) {
+	maddr, err := multiaddr.NewMultiaddr(address)
+	if err != nil {
+		return "", err
+	}
+	return api.service.messenger.AddRelayPeer(maddr)
 }
 
 func (api *PublicAPI) DialPeer(address string) error {
-	return api.service.messenger.DialPeer(address)
+	maddr, err := multiaddr.NewMultiaddr(address)
+	if err != nil {
+		return err
+	}
+	return api.service.messenger.DialPeer(maddr)
 }
 
 func (api *PublicAPI) DialPeerByID(peerID string) error {
-	return api.service.messenger.DialPeerByID(peerID)
+	pID, err := peer.Decode(peerID)
+	if err != nil {
+		return err
+	}
+	return api.service.messenger.DialPeerByID(pID)
 }
 
 func (api *PublicAPI) DropPeer(peerID string) error {
-	return api.service.messenger.DropPeer(peerID)
+	pID, err := peer.Decode(peerID)
+	if err != nil {
+		return err
+	}
+	return api.service.messenger.DropPeer(pID)
 }
 
-func (api *PublicAPI) Peers() map[string]types.WakuV2Peer {
+func (api *PublicAPI) Peers() types.PeerStats {
 	return api.service.messenger.Peers()
 }
 
@@ -1510,11 +1532,11 @@ func (api *PublicAPI) RelayPeersByTopic(topic string) (*types.PeerList, error) {
 	return api.service.messenger.RelayPeersByTopic(topic)
 }
 
-func (api *PublicAPI) ListenAddresses() ([]string, error) {
+func (api *PublicAPI) ListenAddresses() ([]multiaddr.Multiaddr, error) {
 	return api.service.messenger.ListenAddresses()
 }
 
-func (api *PublicAPI) Enr() (string, error) {
+func (api *PublicAPI) Enr() (*enode.Node, error) {
 	return api.service.messenger.ENR()
 }
 

--- a/services/mailservers/database.go
+++ b/services/mailservers/database.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+
+	"github.com/waku-org/go-waku/waku/v2/utils"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
@@ -33,11 +36,12 @@ func (m Mailserver) Enode() (*enode.Node, error) {
 
 func (m Mailserver) IDBytes() ([]byte, error) {
 	if m.Version == 2 {
-		id, err := peer.Decode(m.UniqueID())
+		p, err := m.PeerID()
 		if err != nil {
 			return nil, err
 		}
-		return []byte(id.String()), err
+
+		return p.Marshal()
 	}
 
 	node, err := enode.ParseV4(m.Address)
@@ -52,18 +56,18 @@ func (m Mailserver) PeerID() (peer.ID, error) {
 		return "", errors.New("not available")
 	}
 
-	pID, err := peer.Decode(m.UniqueID())
+	addr, err := multiaddr.NewMultiaddr(m.Address)
 	if err != nil {
 		return "", err
 	}
 
-	return pID, nil
+	return utils.GetPeerID(addr)
 }
 
 func (m Mailserver) UniqueID() string {
 	if m.Version == 2 {
-		s := strings.Split(m.Address, "/")
-		return s[len(s)-1]
+		p, _ := m.PeerID()
+		return p.String()
 	}
 	return m.Address
 }


### PR DESCRIPTION
While attempting to refactor the mailserver cycle code, I ran into some issues due to the code having a lot of unnecessary conversions to string (the API code will automatically call `String()` when possible). Besides using proper types when possible, I also ended up moving the conversion from string to peerID/multiaddr to the API layer since this can be considered input validation, and shouldnt be part of the waku layer of status-go