### PR TITLE
Added User Agent to rpc client configuration

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -196,3 +196,8 @@ func TestGetClientsUsingCache(t *testing.T) {
 	assert.Nil(t, balance)
 	wg.Wait()
 }
+
+func TestUserAgent(t *testing.T) {
+	require.Equal(t, "procuratee-desktop/1.0", rpcUserAgentName)
+	require.Equal(t, "procuratee-desktop-upstream/1.0", rpcUserAgentUpstreamName)
+}


### PR DESCRIPTION
As an attempt to debug proxy server logs for this issue https://github.com/status-im/status-mobile/issues/20975 , I've added user agents to `status-go` based RPC clients.

I've added `User Agent` values to both the legacy upstream client and the current per network client.

This will help to debug the proxy server logs by ensuring we can tell which client is being used to access the server in which cases.

New `User Agent`s are:

- `procuratee-desktop/1.0`
- `procuratee-mobile/1.0`
- `procuratee-desktop-upstream/1.0`
- `procuratee-mobile-upstream/1.0`