### PR TITLE
test(rpc)_: wakuext add contact

### DIFF
--- a/integration-tests/config.json
+++ b/integration-tests/config.json
@@ -8,7 +8,7 @@
     "HTTPHost": "0.0.0.0",
     "HTTPPort": 3333,
     "HTTPVirtualHosts": ["*", "status-go"],
-    "APIModules": "eth,admin,wallet",
+    "APIModules": "eth,admin,wallet,accounts,waku,wakuext",
     "WalletConfig": {
       "Enabled": true
     },

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -10,6 +10,13 @@ def pytest_addoption(parser):
         default="http://0.0.0.0:3333",
     )
     parser.addoption(
+        "--rpc_url_2",
+        action="store",
+        help="",
+        default="http://0.0.0.0:3334",
+    )
+
+    parser.addoption(
         "--password",
         action="store",
         help="",

--- a/integration-tests/docker-compose.test.status-go.yml
+++ b/integration-tests/docker-compose.test.status-go.yml
@@ -8,6 +8,25 @@ services:
         build_target: statusd
         build_flags: -ldflags="-X github.com/status-im/status-go/params.Version= -X github.com/status-im/status-go/params.GitCommit=11f83780d -X github.com/status-im/status-go/params.IpfsGatewayURL=https://ipfs.status.im/ -X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=true"
     entrypoint: ["statusd", "-c", "/static/configs/config.json", "--seed-phrase=test test test test test test test test test test test junk", "--password=Strong12345"]
+    ports:
+      - 3333:3333
+    healthcheck:
+      test: ["CMD-SHELL", "curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"net_version\",\"params\":[],\"id\":1}' -H 'Content-Type: application/json' http://0.0.0.0:3333 || exit 1"]
+      interval: 5s
+      timeout: 2s
+      retries: 120
+
+  status-go-no-funds:
+    build:
+      context: ../
+      dockerfile: _assets/build/Dockerfile
+      args:
+        build_tags: gowaku_no_rln
+        build_target: statusd
+        build_flags: -ldflags="-X github.com/status-im/status-go/params.Version= -X github.com/status-im/status-go/params.GitCommit=11f83780d -X github.com/status-im/status-go/params.IpfsGatewayURL=https://ipfs.status.im/ -X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=true"
+    entrypoint: ["statusd", "-c", "/static/configs/config.json", "--seed-phrase=test test test test test test test test test test test takoe", "--password=Strong12345"]
+    ports:
+      - 3334:3333
     healthcheck:
       test: ["CMD-SHELL", "curl -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"net_version\",\"params\":[],\"id\":1}' -H 'Content-Type: application/json' http://0.0.0.0:3333 || exit 1"]
       interval: 5s
@@ -19,11 +38,13 @@ services:
     depends_on:
       status-go:
         condition: service_healthy
+      # status-go-no-funds:
+      #   condition: service_healthy
       deploy-communities-contracts:
         condition: service_completed_successfully
     build:
       context: .
       dockerfile: Dockerfile.tests-rpc
-    entrypoint: ["pytest", "-m", "wallet", "--rpc_url=http://status-go:3333"]
+    entrypoint: ["pytest", "-m", "wallet", "--rpc_url=http://status-go:3333", "--rpc_url_2=http://status-go-no-funds:3333"]
     volumes:
       - .:/tests-rpc

--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -5,3 +5,5 @@ markers =
     rpc
     wallet
     tx
+    wakuext
+    accounts

--- a/integration-tests/schemas/wakuext_peers
+++ b/integration-tests/schemas/wakuext_peers
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "addresses": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "protocols": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "required": [
+                    "addresses",
+                    "protocols"
+                ]
+            }
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ]
+}

--- a/integration-tests/tests/test_cases.py
+++ b/integration-tests/tests/test_cases.py
@@ -1,4 +1,5 @@
 import json
+import jsonschema
 import requests
 from conftest import option, user_1, user_2
 
@@ -28,17 +29,22 @@ class RpcTestCase:
                 raise AssertionError(f"no id in response {response.json()}")
         return response
 
-    def rpc_request(self, method, params=[], _id=None):
+    def rpc_request(self, method, params=[], _id=None, client=None, url=None):
+        client = client if client else requests.Session()
+        url = url if url else option.rpc_url
 
         data = {"jsonrpc": "2.0", "method": method}
         if params:
             data["params"] = params
         data["id"] = _id if _id else 13
 
-        response = requests.post(option.rpc_url, json=data)
+        response = client.post(url, json=data)
 
         return response
 
+    def verify_json_schema(self, response, method):
+        with open(f"{option.base_dir}/schemas/{method}", "r") as schema:
+            jsonschema.validate(instance=response.json(), schema=json.load(schema))
 
 class TransactionTestCase(RpcTestCase):
 

--- a/integration-tests/tests/test_waku_rpc.py
+++ b/integration-tests/tests/test_waku_rpc.py
@@ -1,0 +1,108 @@
+import random
+import pytest
+import jsonschema
+import json
+import time
+from conftest import option, user_1, user_2
+from test_cases import RpcTestCase, TransactionTestCase
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@pytest.mark.rpc
+@pytest.mark.wakuext
+class TestRpc(RpcTestCase):
+
+    @pytest.mark.parametrize(
+        "method, params",
+        [
+            ("wakuext_peers", []),
+        ],
+    )
+    def test_(self, method, params):
+        _id = str(random.randint(1, 8888))
+
+        response = self.rpc_request(method, params, _id, url=option.rpc_url_2)
+        self.verify_is_valid_json_rpc_response(response)
+        self.verify_json_schema(response, method)
+
+
+@pytest.mark.rpc
+@pytest.mark.accounts
+@pytest.mark.wakuext
+class TestRpcMessaging(RpcTestCase):
+
+    @dataclass
+    class User:
+        rpc_url: str
+        chat_public_key: Optional[str] = None
+        chat_id: Optional[str] = None
+
+    def test_add_contact(self):
+        _id = str(random.randint(1, 8888))
+
+        self.user_1 = self.User(rpc_url=option.rpc_url)
+        self.user_2 = self.User(rpc_url=option.rpc_url_2)
+
+        # get chat public key
+        for user in self.user_1, self.user_2:
+            response = self.rpc_request(
+                "accounts_getAccounts", [], _id, url=user.rpc_url
+            )
+            self.verify_is_valid_json_rpc_response(response)
+
+            user.chat_public_key = next(
+                (
+                    item["public-key"]
+                    for item in response.json()["result"]
+                    if item["chat"]
+                ),
+                None,
+            )
+
+        # send contact requests
+        for sender in self.user_1, self.user_2:
+            for receiver in self.user_1, self.user_2:
+                if sender != receiver:
+                    response = self.rpc_request(
+                        method="wakuext_sendContactRequest",
+                        params=[
+                            {
+                                "id": receiver.chat_public_key,
+                                "message": f"contact request from {sender.chat_public_key}: sent at {time.time()}",
+                            }
+                        ],
+                        _id=99,
+                        url=sender.rpc_url,
+                    )
+
+                    self.verify_is_valid_json_rpc_response(response)
+                    sender.chat_id = response.json()["result"]["chats"][0]["lastMessage"]["id"]
+
+        # accept contact requests
+        for user in self.user_1, self.user_2:
+            response = self.rpc_request(
+                method="wakuext_acceptContactRequest",
+                params=[
+                    {
+                        "id": user.chat_id,
+                    }
+                ],
+                _id=99,
+                url=user.rpc_url,
+            )
+            self.verify_is_valid_json_rpc_response(response)
+
+        # verify contacts
+        for user in (self.user_1, self.user_2), (self.user_2, self.user_1):
+            response = self.rpc_request(
+                method="wakuext_contacts",
+                params=[],
+                _id=99,
+                url=user[0].rpc_url,
+            )
+            self.verify_is_valid_json_rpc_response(response)
+
+            response = response.json()
+            assert response["result"][0]["added"] == True
+            assert response["result"][0]["id"] == user[1].chat_public_key

--- a/integration-tests/tests/test_wallet_rpc.py
+++ b/integration-tests/tests/test_wallet_rpc.py
@@ -8,6 +8,7 @@ from test_cases import RpcTestCase, TransactionTestCase
 
 @pytest.mark.wallet
 @pytest.mark.tx
+@pytest.mark.rpc
 class TestTransactionRpc(TransactionTestCase):
 
     @pytest.mark.parametrize(
@@ -48,6 +49,7 @@ class TestTransactionRpc(TransactionTestCase):
 
 
 @pytest.mark.wallet
+@pytest.mark.rpc
 class TestRpc(RpcTestCase):
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
A description to understand introduced changes without reading the code.

added second instance of status-go
added test for add contact flow:

- `accounts_getAccounts` -> retrieve own public key for messaging
- each status-go instance sends a contact request to the other via  `wakuext_sendContactRequest`
- each status-go instance accepts contact request from other via `wakuext_acceptContactRequest`
- send wakuext_contacts request and verify: added == True, id == to the correct contact

 added test for wakuext_peers that uses schema as vereficatio

