### PR TITLE
fix(wallet)_: pass loop var by value to goroutine

### DIFF
--- a/services/wallet/async/scheduler.go
+++ b/services/wallet/async/scheduler.go
@@ -193,9 +193,9 @@ func (s *Scheduler) Stop() {
 	for pair := s.queue.Oldest(); pair != nil; pair = pair.Next() {
 		// Notify the queued one that they are canceled
 		if pair.Value.policy == ReplacementPolicyCancelOld {
-			go func() {
-				pair.Value.resFn(nil, pair.Value.taskType, context.Canceled)
-			}()
+			go func(val *taskContext) {
+				val.resFn(nil, val.taskType, context.Canceled)
+			}(pair.Value)
 		}
 		s.queue.Delete(pair.Value.taskType)
 	}


### PR DESCRIPTION
Related to https://github.com/status-im/status-mobile/issues/21032

### Summary

We are sometimes getting crashes on the mobile app, and the logs say:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x704ae1e930]

goroutine 11852 [running]:
github.com/status-im/status-go/services/wallet/async.(*Scheduler).Stop.func1()
	github.com/status-im/status-go/services/wallet/async/scheduler.go:197 +0x20
created by github.com/status-im/status-go/services/wallet/async.(*Scheduler).Stop in goroutine 11851
	github.com/status-im/status-go/services/wallet/async/scheduler.go:196 +0x1b8
```

The line number 197 is executed inside a goroutine and it references a value from the outer `for` loop. We know this can be a problem (and an [expensive](https://bugzilla.mozilla.org/show_bug.cgi?id=1619047) one), hence this PR captures the iteratee as a value for the closure. In go 1.22 the way loop vars behave was improved, but we are still using Go 1.21, so I'm applying the fix in this PR in hopes of fixing the crashes.

It's really hard to reproduce the bug on mobile, so I'm not sure this PR will reduce the number of crashes, but it shouldn't make things worse either.

**Note:** once merged, we want to cherry-pick this PR into the release branch.