### PR TITLE
Improve chats and communities unmute logic

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -838,12 +838,12 @@ func (m *Messenger) CheckCommunitiesToUnmute() (*MessengerResponse, error) {
 	m.logger.Debug("watching communities to unmute")
 	response := &MessengerResponse{}
 	communities, err := m.communitiesManager.All()
+	currTime := time.Now()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get all communities: %v", err)
 	}
 	for _, community := range communities {
-		communityMuteTill := community.MuteTill().Truncate(time.Second)
-		currTime := time.Now().Truncate(time.Second)
+		communityMuteTill := community.MuteTill()
 
 		if currTime.After(communityMuteTill) && !communityMuteTill.Equal(time.Time{}) && community.Muted() {
 			err := m.communitiesManager.SetMuted(community.ID(), false)


### PR DESCRIPTION
### Summary

Improvements/Bug fixes
- Execute the initial check immediately upon starting to unmute chats for which the mute timer has expired.
- If a user mutes a chat for 1 minute at 11:12:33, the client displays the mute status as lasting until 11:13. Consequently, the chat should be unmuted as soon as 11:14. Currently, the routine does not run precisely at the top of the minute (hh:mm:00), leading to inconsistencies where the mute timer may expire, but the chat remains muted. This PR ensures that the unmute timer is synchronized to run exactly on the 00 seconds mark.

Required for https://github.com/status-im/status-mobile/issues/20977
Status mobile PR: https://github.com/status-im/status-mobile/pull/21052

Closes #
