### PR TITLE
feat_: request to join community message use mvds

### DIFF
--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1180,10 +1180,21 @@ func testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(base Commu
 
 	// user sends request to join
 	requestID := testSendRequestToJoin(base, user, community.ID())
+	checkRequestToJoin := func(r *MessengerResponse) bool {
+		if len(r.RequestsToJoinCommunity()) == 0 {
+			return false
+		}
+		for _, request := range r.RequestsToJoinCommunity() {
+			if request.PublicKey == user.IdentityPublicKeyString() {
+				return true
+			}
+		}
+		return false
+	}
 	// event sender receives request to join
 	_, err := WaitOnMessengerResponse(
 		base.GetEventSender(),
-		func(r *MessengerResponse) bool { return len(r.RequestsToJoinCommunity()) > 0 },
+		checkRequestToJoin,
 		"event sender did not receive community request to join",
 	)
 	s.Require().NoError(err)
@@ -1191,7 +1202,7 @@ func testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(base Commu
 	// event sender 2 receives request to join
 	_, err = WaitOnMessengerResponse(
 		additionalEventSender,
-		func(r *MessengerResponse) bool { return len(r.RequestsToJoinCommunity()) > 0 },
+		checkRequestToJoin,
 		"event sender did not receive community request to join",
 	)
 	s.Require().NoError(err)

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1517,6 +1517,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 
 		rawMessage.ResendMethod = common.ResendMethodSendPrivate
 		rawMessage.ResendType = common.ResendTypeDataSync
+		// MVDS only supports sending encrypted message
 		rawMessage.SkipEncryptionLayer = false
 		rawMessage.ID = ""
 		rawMessage.Recipients = privMembersArray
@@ -4869,6 +4870,7 @@ func (m *Messenger) SendMessageToControlNode(community *communities.Community, r
 		m.logger.Debug("control node is different with community pubkey", zap.Any("control:", community.ControlNode()), zap.Any("communityPubkey:", community.PublicKey()))
 		rawMessage.ResendMethod = common.ResendMethodSendPrivate
 		rawMessage.ResendType = common.ResendTypeDataSync
+		// MVDS only supports sending encrypted message
 		rawMessage.SkipEncryptionLayer = false
 		rawMessage.Recipients = append(rawMessage.Recipients, community.ControlNode())
 		return m.sender.SendPrivate(context.Background(), community.ControlNode(), rawMessage)

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1531,6 +1531,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 		rawMessage.Payload = payload
 
 		for _, member := range rawMessage.Recipients {
+			rawMessage.Sender = nil
 			_, err := m.sender.SendPrivate(context.Background(), member, rawMessage)
 			if err != nil {
 				return nil, err

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4865,7 +4865,6 @@ func (m *Messenger) CreateResponseWithACNotification(communityID string, acType 
 // SendMessageToControlNode sends a message to the control node of the community.
 // use pointer to rawMessage to get the message ID and other updated properties.
 func (m *Messenger) SendMessageToControlNode(community *communities.Community, rawMessage *common.RawMessage) ([]byte, error) {
-	m.logger.Debug("send message to control node", zap.Any("rawMessage:", rawMessage), zap.Any("community:", community))
 	if !community.PublicKey().Equal(community.ControlNode()) {
 		m.logger.Debug("control node is different with community pubkey", zap.Any("control:", community.ControlNode()), zap.Any("communityPubkey:", community.PublicKey()))
 		rawMessage.ResendMethod = common.ResendMethodSendPrivate

--- a/protocol/messenger_raw_message_resend_test.go
+++ b/protocol/messenger_raw_message_resend_test.go
@@ -101,22 +101,20 @@ func (s *MessengerRawMessageResendTest) waitForMessageSent(messageID string) {
 func (s *MessengerRawMessageResendTest) TestMessageSent() {
 	ids, err := s.bobMessenger.RawMessagesIDsByType(protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN)
 	s.Require().NoError(err)
-	// one request to join to control node and another to privileged member
-	s.Require().Len(ids, 2)
+	// one request to join to control node
+	s.Require().Len(ids, 1)
 
 	s.waitForMessageSent(ids[0])
-	s.waitForMessageSent(ids[1])
 }
 
 // TestMessageResend tests if ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN is resent
 func (s *MessengerRawMessageResendTest) TestMessageResend() {
 	ids, err := s.bobMessenger.RawMessagesIDsByType(protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN)
 	s.Require().NoError(err)
-	s.Require().Len(ids, 2)
+	s.Require().Len(ids, 1)
 	// wait for Sent status for already sent message to make sure that sent message was delivered
 	// before testing resend
 	s.waitForMessageSent(ids[0])
-	s.waitForMessageSent(ids[1])
 
 	rawMessage := s.GetRequestToJoinToControlNodeRawMessage(ids)
 	s.Require().NotNil(rawMessage)
@@ -145,10 +143,9 @@ func (s *MessengerRawMessageResendTest) TestMessageResend() {
 func (s *MessengerRawMessageResendTest) TestInvalidRawMessageToWatchDoesNotProduceResendLoop() {
 	ids, err := s.bobMessenger.RawMessagesIDsByType(protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN)
 	s.Require().NoError(err)
-	s.Require().Len(ids, 2)
+	s.Require().Len(ids, 1)
 
 	s.waitForMessageSent(ids[0])
-	s.waitForMessageSent(ids[1])
 
 	rawMessage := s.GetRequestToJoinToControlNodeRawMessage(ids)
 	s.Require().NotNil(rawMessage)


### PR DESCRIPTION
Make `ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN` message to use MVDS when recipient exists. Only affect tokenized communities. 
We may also want to apply non-tokenized communities by setting control node to the creator's public key when creating a new community. cc @cammellos @osmaczko 

Important changes:
- [x] `AddRawMessageToWatch` only applied to messages with `ResendTypeRawMessage`
- [x] set `SkipEncryptionLayer` to false and `ResendType` to ResendTypeDataSync if recipient exists.

Closes https://github.com/status-im/status-go/issues/5693
