### PR TITLE
Flush hystrix on going back online

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -15,6 +15,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/afex/hystrix-go/hystrix"
 	"github.com/pkg/errors"
 
 	"github.com/imdario/mergo"
@@ -2431,6 +2432,12 @@ func (b *GethStatusBackend) ConnectionChange(typ string, expensive bool) {
 	}
 
 	b.log.Info("Network state change", "old", b.connectionState, "new", state)
+
+	if b.connectionState.Offline && !state.Offline {
+		//  flush hystrix if we are going again online, since it doesn't behave
+		// well when offline
+		hystrix.Flush()
+	}
 
 	b.connectionState = state
 	b.statusNode.ConnectionChanged(state)


### PR DESCRIPTION
When going offline, all the rpc calls fail making hystrix open all the circuits.
This commit changes the behavior so that when we go back online, we close all the circuits.
We should also avoid making rpc requests while offline, but this should work for release.

It should not impact desktop I believe since I don't think you send over connection information, so the bug will still persist on desktop.
