### PR TITLE
fix_: crash sending collectibles fixed

### DIFF
--- a/services/wallet/router/pathprocessor/processor_erc721.go
+++ b/services/wallet/router/pathprocessor/processor_erc721.go
@@ -16,6 +16,7 @@ import (
 	"github.com/status-im/status-go/contracts/community-tokens/collectibles"
 	"github.com/status-im/status-go/contracts/erc721"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/transactions"
@@ -150,6 +151,9 @@ func (s *ERC721Processor) sendOrBuild(sendArgs *MultipathProcessorTxArgs, signer
 
 	useSafeTransferFrom := true
 	inputParams := ProcessorInputParams{
+		FromChain: &params.Network{
+			ChainID: sendArgs.ChainID,
+		},
 		FromAddr: from,
 		ToAddr:   sendArgs.ERC721TransferTx.Recipient,
 		FromToken: &token.Token{

--- a/services/wallet/router/router_v2.go
+++ b/services/wallet/router/router_v2.go
@@ -554,7 +554,7 @@ func (r *Router) getBalanceMapForTokenOnChains(ctx context.Context, input *Route
 		// check token existence
 		token := input.SendType.FindToken(r.tokenManager, r.collectiblesService, input.AddrFrom, chain, input.TokenID)
 		if token == nil {
-			chainError(chain.ChainID, token.Symbol, ErrTokenNotFound)
+			chainError(chain.ChainID, input.TokenID, ErrTokenNotFound)
 			continue
 		}
 		// check native token existence


### PR DESCRIPTION
When mapping `MultipathProcessorTxArgs` to `ProcessorInputParams` setting `FromChain` was missed.

Closes https://github.com/status-im/status-desktop/issues/16136

