### PR TITLE
fix_: send accounts event on handling backed up accounts

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -2651,7 +2651,7 @@ func (b *GethStatusBackend) injectAccountsIntoWakuService(w types.WakuKeyManager
 	}
 
 	if st != nil {
-		if err := st.InitProtocol(b.statusNode.GethNode().Config().Name, identity, b.appDB, b.walletDB, b.statusNode.HTTPServer(), b.multiaccountsDB, acc, b.accountManager, b.statusNode.RPCClient(), b.statusNode.WalletService(), b.statusNode.CommunityTokensService(), b.statusNode.WakuV2Service(), logutils.ZapLogger()); err != nil {
+		if err := st.InitProtocol(b.statusNode.GethNode().Config().Name, identity, b.appDB, b.walletDB, b.statusNode.HTTPServer(), b.multiaccountsDB, acc, b.accountManager, b.statusNode.RPCClient(), b.statusNode.WalletService(), b.statusNode.CommunityTokensService(), b.statusNode.WakuV2Service(), logutils.ZapLogger(), b.statusNode.AccountsFeed()); err != nil {
 			return err
 		}
 		// Set initial connection state

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -133,7 +133,8 @@ type StatusNode struct {
 	connectorSrvc          *connector.Service
 	appGeneralSrvc         *appgeneral.Service
 
-	walletFeed event.Feed
+	accountsFeed event.Feed
+	walletFeed   event.Feed
 }
 
 // New makes new instance of StatusNode.

--- a/protocol/messenger_backup_test.go
+++ b/protocol/messenger_backup_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 	"github.com/status-im/status-go/protocol/wakusync"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
@@ -814,7 +815,8 @@ func (s *MessengerBackupSuite) TestBackupWatchOnlyAccounts() {
 	s.Require().True(haveSameElements(woAccounts, dbWoAccounts1, accounts.SameAccounts))
 
 	// Create bob2
-	bob2, err := newMessengerWithKey(s.shh, bob1.identity, s.logger, nil)
+	accountsFeed := &event.Feed{}
+	bob2, err := newMessengerWithKey(s.shh, bob1.identity, s.logger, []Option{WithAccountsFeed(accountsFeed)})
 	s.Require().NoError(err)
 	s.Require().NotNil(bob2.config.accountsFeed)
 	ch := make(chan accountsevent.Event, 20)
@@ -852,7 +854,7 @@ func (s *MessengerBackupSuite) TestBackupWatchOnlyAccounts() {
 	case event := <-ch:
 		switch event.Type {
 		case accountsevent.EventTypeAdded:
-			s.Require().Equal(1, len(event.Accounts))
+			s.Require().Len(event.Accounts, 1)
 			s.Require().Equal(common.Address(dbWoAccounts2[0].Address), event.Accounts[0])
 		}
 	}

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
-	"github.com/ethereum/go-ethereum/event"
-
 	"github.com/status-im/status-go/account/generator"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/common/dbsetup"
@@ -75,8 +73,6 @@ func newTestMessenger(waku types.Waku, config testMessengerConfig) (*Messenger, 
 		return nil, err
 	}
 
-	accountsFeed := &event.Feed{}
-
 	options := []Option{
 		WithCustomLogger(config.logger),
 		WithDatabase(appDb),
@@ -87,7 +83,6 @@ func newTestMessenger(waku types.Waku, config testMessengerConfig) (*Messenger, 
 		WithToplevelDatabaseMigrations(),
 		WithBrowserDatabase(nil),
 		WithCuratedCommunitiesUpdateLoop(false),
-		WithAccountsFeed(accountsFeed),
 	}
 	options = append(options, config.extraOptions...)
 

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/ethereum/go-ethereum/event"
+
 	"github.com/status-im/status-go/account/generator"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/common/dbsetup"
@@ -73,6 +75,8 @@ func newTestMessenger(waku types.Waku, config testMessengerConfig) (*Messenger, 
 		return nil, err
 	}
 
+	accountsFeed := &event.Feed{}
+
 	options := []Option{
 		WithCustomLogger(config.logger),
 		WithDatabase(appDb),
@@ -83,6 +87,7 @@ func newTestMessenger(waku types.Waku, config testMessengerConfig) (*Messenger, 
 		WithToplevelDatabaseMigrations(),
 		WithBrowserDatabase(nil),
 		WithCuratedCommunitiesUpdateLoop(false),
+		WithAccountsFeed(accountsFeed),
 	}
 	options = append(options, config.extraOptions...)
 

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/ethereum/go-ethereum/event"
+
 	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/server"
@@ -120,6 +122,8 @@ type config struct {
 	messageResendMaxCount int
 
 	communityManagerOptions []communities.ManagerOption
+
+	accountsFeed *event.Feed
 }
 
 func messengerDefaultConfig() config {
@@ -411,6 +415,13 @@ func WithCollectiblesManager(collectiblesManager communities.CollectiblesManager
 func WithAccountManager(accountManager account.Manager) Option {
 	return func(c *config) error {
 		c.accountsManager = accountManager
+		return nil
+	}
+}
+
+func WithAccountsFeed(feed *event.Feed) Option {
+	return func(c *config) error {
+		c.accountsFeed = feed
 		return nil
 	}
 }

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -3699,10 +3699,6 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 			for _, acc := range dbKeypair.Accounts {
 				removedAddresses = append(removedAddresses, gethcommon.Address(acc.Address))
 			}
-			m.config.accountsFeed.Send(accountsevent.Event{
-				Type:     accountsevent.EventTypeRemoved,
-				Accounts: removedAddresses,
-			})
 		} else {
 			for _, acc := range dbKeypair.Accounts {
 				if acc.Chat {
@@ -3714,10 +3710,14 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 					addedAddresses = append(addedAddresses, gethcommon.Address(acc.Address))
 				}
 			}
+		}
+		if len(addedAddresses) > 0 {
 			m.config.accountsFeed.Send(accountsevent.Event{
 				Type:     accountsevent.EventTypeAdded,
 				Accounts: addedAddresses,
 			})
+		}
+		if len(removedAddresses) > 0 {
 			m.config.accountsFeed.Send(accountsevent.Event{
 				Type:     accountsevent.EventTypeRemoved,
 				Accounts: removedAddresses,

--- a/services/wakuext/api_test.go
+++ b/services/wakuext/api_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/status-im/status-go/appdatabase"
@@ -136,7 +137,9 @@ func TestInitProtocol(t *testing.T) {
 	defer func() { require.NoError(t, cleanupWalletDB()) }()
 	require.NoError(t, err)
 
-	err = service.InitProtocol("Test", privateKey, appDB, walletDB, nil, multiAccounts, acc, nil, nil, nil, nil, nil, zap.NewNop())
+	accountsFeed := &event.Feed{}
+
+	err = service.InitProtocol("Test", privateKey, appDB, walletDB, nil, multiAccounts, acc, nil, nil, nil, nil, nil, zap.NewNop(), accountsFeed)
 	require.NoError(t, err)
 }
 
@@ -207,7 +210,9 @@ func (s *ShhExtSuite) createAndAddNode() {
 	walletDB, err := helpers.SetupTestMemorySQLDB(&walletdatabase.DbInitializer{})
 	s.Require().NoError(err)
 
-	err = service.InitProtocol("Test", privateKey, appDB, walletDB, nil, multiAccounts, acc, nil, nil, nil, nil, nil, zap.NewNop())
+	accountsFeed := &event.Feed{}
+
+	err = service.InitProtocol("Test", privateKey, appDB, walletDB, nil, multiAccounts, acc, nil, nil, nil, nil, nil, zap.NewNop(), accountsFeed)
 	s.NoError(err)
 
 	stack.RegisterLifecycle(service)


### PR DESCRIPTION
Needed for https://github.com/status-im/status-mobile/issues/18613

### Summary

##### Issue:
The collectables are not fetched whenever a profile is recovered with multiple wallet accounts.

##### Root cause:
We don't send any accounts event whenever we handle the accounts from backed-up data. This makes watchers fail to react to it. 

##### Changes / fixes:
This PR moves the `accountsFeed` from `initServices` to the status node config, and adds a reference to messenger config for sending events on handling backed-up data.






