### PR TITLE
fix_: disable libp2p logs in prod

### DIFF
--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -318,7 +318,7 @@ func New(nodeKey *ecdsa.PrivateKey, fleet string, cfg *Config, logger *zap.Logge
 			pubsub.WithMaxMessageSize(int(waku.cfg.MaxMessageSize)),
 		}
 
-		if waku.logger.Level() == zap.DebugLevel {
+		if testing.Testing() {
 			relayOpts = append(relayOpts, pubsub.WithEventTracer(waku))
 		}
 


### PR DESCRIPTION
Some time ago I added libp2p trace logs:
- https://github.com/status-im/status-go/pull/4706

Which was very useful for debugging. But in production it makes almost no sense. 
It stores tremendous amount of data. E.g. after creating a new account and waiting 1 minute, I get ~11000 lines of `pubsub trace`, for ~25000 lines `geth.log`, which is 44% of almost useless data.

And it's even more in terms of size: 4.9Mb of 9Mb - 54% 😵