### PR TITLE
fix: set a separate id (and circuit) for the cryptcompare proxy

### DIFF
--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -120,6 +120,7 @@ func NewService(
 	cryptoCompare := cryptocompare.NewClient()
 	coingecko := coingecko.NewClient()
 	cryptoCompareProxy := cryptocompare.NewClientWithParams(cryptocompare.Params{
+		ID:       fmt.Sprintf("%s-proxy", cryptoCompare.ID()),
 		URL:      fmt.Sprintf("https://%s.api.status.im/cryptocompare/", statusProxyStageName),
 		User:     config.WalletConfig.StatusProxyMarketUser,
 		Password: config.WalletConfig.StatusProxyMarketPassword,

--- a/services/wallet/thirdparty/cryptocompare/client.go
+++ b/services/wallet/thirdparty/cryptocompare/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/thirdparty/utils"
 )
 
+const baseID = "cryptocompare"
 const extraParamStatus = "Status.im"
 const baseURL = "https://min-api.cryptocompare.com"
 
@@ -34,22 +35,24 @@ type MarketValuesContainer struct {
 }
 
 type Params struct {
+	ID       string
 	URL      string
 	User     string
 	Password string
 }
 
 type Client struct {
+	id         string
 	httpClient *thirdparty.HTTPClient
 	baseURL    string
 	creds      *thirdparty.BasicCreds
 }
 
 func NewClient() *Client {
-	return &Client{
-		httpClient: thirdparty.NewHTTPClient(),
-		baseURL:    baseURL,
-	}
+	return NewClientWithParams(Params{
+		ID:  baseID,
+		URL: baseURL,
+	})
 }
 
 func NewClientWithParams(params Params) *Client {
@@ -62,6 +65,7 @@ func NewClientWithParams(params Params) *Client {
 	}
 
 	return &Client{
+		id:         params.ID,
 		httpClient: thirdparty.NewHTTPClient(),
 		baseURL:    params.URL,
 		creds:      creds,
@@ -215,5 +219,5 @@ func (c *Client) FetchHistoricalDailyPrices(symbol string, currency string, limi
 }
 
 func (c *Client) ID() string {
-	return "cryptocompare"
+	return c.id
 }

--- a/services/wallet/thirdparty/cryptocompare/client_test.go
+++ b/services/wallet/thirdparty/cryptocompare/client_test.go
@@ -1,0 +1,17 @@
+package cryptocompare
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIDs(t *testing.T) {
+	stdClient := NewClient()
+	require.Equal(t, baseID, stdClient.ID())
+
+	clientWithParams := NewClientWithParams(Params{
+		ID: "testID",
+	})
+	require.Equal(t, "testID", clientWithParams.ID())
+}


### PR DESCRIPTION
The Cryptocompare proxy client had the same ID as the "direct" client. The ID is used to identify the circuit in the circuit breaker (https://github.com/status-im/status-go/blob/89662aa3007a045321aab5a53f19272a484d025e/services/wallet/market/market.go#L83), so the two of them were in fact sharing the circuit, causing unintended side effects.
This PR sets different IDs for the two client instances. 

Tested by blocking direct access to the providers and using the app.
<img width="419" alt="image" src="https://github.com/user-attachments/assets/c0831051-3be1-49b5-a4c9-fe29f7f117d9">

 