### PR TITLE
chore(ci)_: adjust nightly tests build retention to 14 runs

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -45,9 +45,9 @@ pipeline {
     disableConcurrentBuilds()
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
-      numToKeepStr: '5',
+      numToKeepStr: isTestNightlyJob() ? '14' : '5',
       daysToKeepStr: '30',
-      artifactNumToKeepStr: '1',
+      artifactNumToKeepStr: isTestNightlyJob() ? '14' : '1',
     ))
   }
 


### PR DESCRIPTION
Increased build and artifact retention, as more context is usually needed when analyzing flakiness thorugh nightly tests.