### PR TITLE
feat_: endpoint for getting address details with/without blocking added

### DIFF
--- a/services/wallet/requests/address_details.go
+++ b/services/wallet/requests/address_details.go
@@ -1,0 +1,23 @@
+package requests
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var ErrAddresInvalid = errors.New("address-details: invalid address")
+
+type AddressDetails struct {
+	Address               string   `json:"address"`
+	ChainIDs              []uint64 `json:"chainIds"`
+	TimeoutInMilliseconds int64    `json:"timeoutInMilliseconds"`
+}
+
+func (a *AddressDetails) Validate() error {
+	if !common.IsHexAddress(a.Address) {
+		return ErrAddresInvalid
+	}
+
+	return nil
+}


### PR DESCRIPTION
`AddressDetails` is added, basically it is the same as `GetAddressDetails`,
but does the check for address activity (if has balance) across all chains if the
chainIDs list is empty. Setting `timeoutInMilliseconds` param ensures that in case
of network congestion or no internet `AddressDetails` will return the response
setting `hasActivity` property to `false`.

Necessary for this issue: https://github.com/status-im/status-desktop/issues/15299