### PR TITLE
fix_: enable tests to run with `-count` more than 1

### DIFF
--- a/logutils/zap_adapter.go
+++ b/logutils/zap_adapter.go
@@ -3,7 +3,6 @@ package logutils
 import (
 	"fmt"
 	"math"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -123,15 +122,11 @@ func NewZapAdapter(logger log.Logger, enab zapcore.LevelEnabler) zapcore.Core {
 	}
 }
 
-var registerOnce sync.Once
-
 // NewZapLoggerWithAdapter returns a logger forwarding all logs with level info and above.
 func NewZapLoggerWithAdapter(logger log.Logger) (*zap.Logger, error) {
-	registerOnce.Do(func() {
-		if err := zaputil.RegisterJSONHexEncoder(); err != nil {
-			panic(err)
-		}
-	})
+	if err := zaputil.RegisterJSONHexEncoder(); err != nil {
+		panic(err)
+	}
 
 	cfg := zap.Config{
 		Level:            zap.NewAtomicLevelAt(zapcore.DebugLevel),

--- a/multiaccounts/settings/database_test.go
+++ b/multiaccounts/settings/database_test.go
@@ -89,6 +89,11 @@ func TestClosingsqlDB(t *testing.T) {
 	d, err := MakeNewDB(db)
 	require.NoError(t, err)
 
+	// Cleanup dbInstances to enable running test with -count more than 1.
+	dbFileName, err := dbsetup.GetDBFilename(db)
+	require.NoError(t, err)
+	defer delete(dbInstances, dbFileName)
+
 	// Add settings data to the db
 	err = d.CreateSettings(settings, config)
 	require.NoError(t, err)

--- a/profiling/cpu.go
+++ b/profiling/cpu.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/pprof"
+	"errors"
 )
 
 // CPUFilename is a filename in which the CPU profiling is stored.
@@ -14,6 +15,9 @@ var cpuFile *os.File
 // StartCPUProfile enables CPU profiling for the current process. While profiling,
 // the profile will be buffered and written to the file in folder dataDir.
 func StartCPUProfile(dataDir string) error {
+	if cpuFile != nil {
+		return errors.New("cpu profiling is already started")
+	}
 	if cpuFile == nil {
 		var err error
 		cpuFile, err = os.Create(filepath.Join(dataDir, CPUFilename))
@@ -31,5 +35,7 @@ func StopCPUProfile() error {
 		return nil
 	}
 	pprof.StopCPUProfile()
-	return cpuFile.Close()
+	err := cpuFile.Close()
+	cpuFile = nil
+	return err
 }

--- a/profiling/cpu.go
+++ b/profiling/cpu.go
@@ -1,10 +1,10 @@
 package profiling
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime/pprof"
-	"errors"
 )
 
 // CPUFilename is a filename in which the CPU profiling is stored.

--- a/profiling/cpu.go
+++ b/profiling/cpu.go
@@ -18,12 +18,11 @@ func StartCPUProfile(dataDir string) error {
 	if cpuFile != nil {
 		return errors.New("cpu profiling is already started")
 	}
-	if cpuFile == nil {
-		var err error
-		cpuFile, err = os.Create(filepath.Join(dataDir, CPUFilename))
-		if err != nil {
-			return err
-		}
+
+	var err error
+	cpuFile, err = os.Create(filepath.Join(dataDir, CPUFilename))
+	if err != nil {
+		return err
 	}
 
 	return pprof.StartCPUProfile(cpuFile)

--- a/profiling/heap.go
+++ b/profiling/heap.go
@@ -21,8 +21,12 @@ func WriteHeapFile(dataDir string) error {
 		if err != nil {
 			return err
 		}
-		defer memFile.Close() //nolint: errcheck
+		defer func() {
+			memFile.Close() //nolint: errcheck
+			memFile = nil
+		}()
 	}
+
 	runtime.GC()
 	err = pprof.WriteHeapProfile(memFile)
 

--- a/protocol/tt/logger.go
+++ b/protocol/tt/logger.go
@@ -1,14 +1,10 @@
 package tt
 
 import (
-	"sync"
-
 	"github.com/status-im/status-go/protocol/zaputil"
 
 	"go.uber.org/zap"
 )
-
-var registerOnce sync.Once
 
 // MustCreateTestLogger returns a logger based on the passed flags.
 func MustCreateTestLogger() *zap.Logger {
@@ -16,11 +12,9 @@ func MustCreateTestLogger() *zap.Logger {
 }
 
 func MustCreateTestLoggerWithConfig(cfg zap.Config) *zap.Logger {
-	registerOnce.Do(func() {
-		if err := zaputil.RegisterConsoleHexEncoder(); err != nil {
-			panic(err)
-		}
-	})
+	if err := zaputil.RegisterConsoleHexEncoder(); err != nil {
+		panic(err)
+	}
 	cfg.Encoding = "console-hex"
 	l, err := cfg.Build()
 	if err != nil {

--- a/protocol/zaputil/encoder.go
+++ b/protocol/zaputil/encoder.go
@@ -5,6 +5,7 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"sync"
 )
 
 type jsonHexEncoder struct {
@@ -31,13 +32,22 @@ func (enc *jsonHexEncoder) Clone() zapcore.Encoder {
 	return &jsonHexEncoder{Encoder: encoderClone}
 }
 
+var (
+	registerJSONHexEncoderOnce   sync.Once
+	registerConsoleHexEncodeOnce sync.Once
+)
+
 // RegisterJSONHexEncoder registers a jsonHexEncoder under "json-hex" name.
 // Later, this name can be used as a value for zap.Config.Encoding to enable
 // jsonHexEncoder.
 func RegisterJSONHexEncoder() error {
-	return zap.RegisterEncoder("json-hex", func(cfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
-		return NewJSONHexEncoder(cfg), nil
+	var err error
+	registerJSONHexEncoderOnce.Do(func() {
+		err = zap.RegisterEncoder("json-hex", func(cfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
+			return NewJSONHexEncoder(cfg), nil
+		})
 	})
+	return err
 }
 
 type consoleHexEncoder struct {
@@ -61,7 +71,11 @@ func (enc *consoleHexEncoder) Clone() zapcore.Encoder {
 }
 
 func RegisterConsoleHexEncoder() error {
-	return zap.RegisterEncoder("console-hex", func(cfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
-		return NewConsoleHexEncoder(cfg), nil
+	var err error
+	registerConsoleHexEncodeOnce.Do(func() {
+		err = zap.RegisterEncoder("console-hex", func(cfg zapcore.EncoderConfig) (zapcore.Encoder, error) {
+			return NewConsoleHexEncoder(cfg), nil
+		})
 	})
+	return err
 }

--- a/protocol/zaputil/encoder.go
+++ b/protocol/zaputil/encoder.go
@@ -2,10 +2,10 @@ package zaputil
 
 import (
 	"encoding/hex"
+	"sync"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"sync"
 )
 
 type jsonHexEncoder struct {


### PR DESCRIPTION
> [!NOTE]
> PRO TIP: review by commits

Fixed some tests that were not running properly with `-test.count=2` (and anything more than 1).
In most cases it's just an override of a global variable. Some cases were more tricky, e.g. `MailServerPostgresDBSuite`.

Nightly run simulation here: https://ci.status.im/job/status-go/job/tests-nightly/327

-----

Some related PRs about `timesource` fix. Just a note for future developers.
- https://github.com/status-im/status-go/pull/3702/
- https://github.com/status-im/status-go/pull/4304/