### PR TITLE
chore: reduce filter batch duration to 500ms

### DIFF
--- a/wakuv2/filter_manager.go
+++ b/wakuv2/filter_manager.go
@@ -67,7 +67,7 @@ func newFilterManager(ctx context.Context, logger *zap.Logger, cfg *Config, onNe
 	mgr.node = node
 	mgr.onlineChecker = onlinechecker.NewDefaultOnlineChecker(false).(*onlinechecker.DefaultOnlineChecker)
 	mgr.node.SetOnlineChecker(mgr.onlineChecker)
-	mgr.filterSubBatchDuration = 5 * time.Second
+	mgr.filterSubBatchDuration = 500 * time.Millisecond
 	mgr.incompleteFilterBatch = make(map[string]filterConfig)
 	mgr.filterConfigs = make(appFilterMap)
 	mgr.waitingToSubQueue = make(chan filterConfig, 100)


### PR DESCRIPTION
As described in the discussion in https://github.com/status-im/status-mobile/issues/21120
Temporarily reduce the duration of the filter batch to 500ms to not block the release