### PR TITLE
chore_: map insufficient funds error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -27,6 +27,28 @@ func IsErrorResponse(err error) bool {
 	return ok
 }
 
+// ErrorCodeFromError returns the ErrorCode from an error.
+func ErrorCodeFromError(err error) ErrorCode {
+	if err == nil {
+		return GenericErrorCode
+	}
+	if errResp, ok := err.(*ErrorResponse); ok {
+		return errResp.Code
+	}
+	return GenericErrorCode
+}
+
+// DetailsFromError returns the details from an error.
+func DetailsFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errResp, ok := err.(*ErrorResponse); ok {
+		return errResp.Details
+	}
+	return err.Error()
+}
+
 // CreateErrorResponseFromError creates an ErrorResponse from a generic error.
 func CreateErrorResponseFromError(err error) error {
 	if err == nil {

--- a/services/wallet/router/errors.go
+++ b/services/wallet/router/errors.go
@@ -32,4 +32,5 @@ var (
 	ErrCannotCheckBalance                        = &errors.ErrorResponse{Code: errors.ErrorCode("WR-024"), Details: "cannot check balance"}
 	ErrCannotCheckLockedAmounts                  = &errors.ErrorResponse{Code: errors.ErrorCode("WR-025"), Details: "cannot check locked amounts"}
 	ErrLowAmountInForHopBridge                   = &errors.ErrorResponse{Code: errors.ErrorCode("WR-026"), Details: "bonder fee greater than estimated received, a higher amount is needed to cover fees"}
+	ErrNoPositiveBalance                         = &errors.ErrorResponse{Code: errors.ErrorCode("WR-027"), Details: "no positive balance"}
 )

--- a/services/wallet/router/pathprocessor/processor.go
+++ b/services/wallet/router/pathprocessor/processor.go
@@ -56,8 +56,13 @@ type ProcessorInputParams struct {
 
 	// for testing purposes
 	TestsMode                 bool
-	TestEstimationMap         map[string]uint64   // [brifge-name, estimated-value]
-	TestBonderFeeMap          map[string]*big.Int // [token-symbol, bonder-fee]
+	TestEstimationMap         map[string]Estimation // [bridge-name, estimation]
+	TestBonderFeeMap          map[string]*big.Int   // [token-symbol, bonder-fee]
 	TestApprovalGasEstimation uint64
 	TestApprovalL1Fee         uint64
+}
+
+type Estimation struct {
+	Value uint64
+	Err   error
 }

--- a/services/wallet/router/pathprocessor/processor_bridge_celar.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_celar.go
@@ -236,7 +236,7 @@ func (s *CelerBridgeProcessor) EstimateGas(params ProcessorInputParams) (uint64,
 	if params.TestsMode {
 		if params.TestEstimationMap != nil {
 			if val, ok := params.TestEstimationMap[s.Name()]; ok {
-				return val, nil
+				return val.Value, val.Err
 			}
 		}
 		return 0, ErrNoEstimationFound

--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -228,7 +228,7 @@ func (h *HopBridgeProcessor) EstimateGas(params ProcessorInputParams) (uint64, e
 	if params.TestsMode {
 		if params.TestEstimationMap != nil {
 			if val, ok := params.TestEstimationMap[h.Name()]; ok {
-				return val, nil
+				return val.Value, val.Err
 			}
 		}
 		return 0, ErrNoEstimationFound

--- a/services/wallet/router/pathprocessor/processor_ens_public_key.go
+++ b/services/wallet/router/pathprocessor/processor_ens_public_key.go
@@ -65,7 +65,7 @@ func (s *ENSPublicKeyProcessor) EstimateGas(params ProcessorInputParams) (uint64
 	if params.TestsMode {
 		if params.TestEstimationMap != nil {
 			if val, ok := params.TestEstimationMap[s.Name()]; ok {
-				return val, nil
+				return val.Value, val.Err
 			}
 		}
 		return 0, ErrNoEstimationFound

--- a/services/wallet/router/pathprocessor/processor_ens_register.go
+++ b/services/wallet/router/pathprocessor/processor_ens_register.go
@@ -101,7 +101,7 @@ func (s *ENSRegisterProcessor) EstimateGas(params ProcessorInputParams) (uint64,
 	if params.TestsMode {
 		if params.TestEstimationMap != nil {
 			if val, ok := params.TestEstimationMap[s.Name()]; ok {
-				return val, nil
+				return val.Value, val.Err
 			}
 		}
 		return 0, ErrNoEstimationFound

--- a/services/wallet/router/pathprocessor/processor_ens_release.go
+++ b/services/wallet/router/pathprocessor/processor_ens_release.go
@@ -64,7 +64,7 @@ func (s *ENSReleaseProcessor) EstimateGas(params ProcessorInputParams) (uint64, 
 	if params.TestsMode {
 		if params.TestEstimationMap != nil {
 			if val, ok := params.TestEstimationMap[s.Name()]; ok {
-				return val, nil
+				return val.Value, val.Err
 			}
 		}
 		return 0, ErrNoEstimationFound

--- a/services/wallet/router/pathprocessor/processor_erc1155.go
+++ b/services/wallet/router/pathprocessor/processor_erc1155.go
@@ -75,7 +75,7 @@ func (s *ERC1155Processor) EstimateGas(params ProcessorInputParams) (uint64, err
 	if params.TestsMode {
 		if params.TestEstimationMap != nil {
 			if val, ok := params.TestEstimationMap[s.Name()]; ok {
-				return val, nil
+				return val.Value, val.Err
 			}
 		}
 		return 0, ErrNoEstimationFound

--- a/services/wallet/router/pathprocessor/processor_erc721.go
+++ b/services/wallet/router/pathprocessor/processor_erc721.go
@@ -112,7 +112,7 @@ func (s *ERC721Processor) EstimateGas(params ProcessorInputParams) (uint64, erro
 	if params.TestsMode {
 		if params.TestEstimationMap != nil {
 			if val, ok := params.TestEstimationMap[s.Name()]; ok {
-				return val, nil
+				return val.Value, val.Err
 			}
 		}
 		return 0, ErrNoEstimationFound

--- a/services/wallet/router/pathprocessor/processor_stickers_buy.go
+++ b/services/wallet/router/pathprocessor/processor_stickers_buy.go
@@ -93,7 +93,7 @@ func (s *StickersBuyProcessor) EstimateGas(params ProcessorInputParams) (uint64,
 	if params.TestsMode {
 		if params.TestEstimationMap != nil {
 			if val, ok := params.TestEstimationMap[s.Name()]; ok {
-				return val, nil
+				return val.Value, val.Err
 			}
 		}
 		return 0, ErrNoEstimationFound

--- a/services/wallet/router/pathprocessor/processor_swap_paraswap.go
+++ b/services/wallet/router/pathprocessor/processor_swap_paraswap.go
@@ -173,7 +173,7 @@ func (s *SwapParaswapProcessor) EstimateGas(params ProcessorInputParams) (uint64
 	if params.TestsMode {
 		if params.TestEstimationMap != nil {
 			if val, ok := params.TestEstimationMap[s.Name()]; ok {
-				return val, nil
+				return val.Value, val.Err
 			}
 		}
 		return 0, ErrNoEstimationFound

--- a/services/wallet/router/pathprocessor/processor_test.go
+++ b/services/wallet/router/pathprocessor/processor_test.go
@@ -47,10 +47,10 @@ var optimism = params.Network{
 	RelatedChainID:         walletCommon.OptimismMainnet,
 }
 
-var testEstimationMap = map[string]uint64{
-	ProcessorTransferName:     uint64(1000),
-	ProcessorBridgeHopName:    uint64(5000),
-	ProcessorSwapParaswapName: uint64(2000),
+var testEstimationMap = map[string]Estimation{
+	ProcessorTransferName:     {uint64(1000), nil},
+	ProcessorBridgeHopName:    {uint64(5000), nil},
+	ProcessorSwapParaswapName: {uint64(2000), nil},
 }
 
 type expectedResult struct {
@@ -329,17 +329,17 @@ func TestPathProcessors(t *testing.T) {
 					assert.Greater(t, estimatedGas, uint64(0))
 
 					input := tt.input
-					input.TestEstimationMap = map[string]uint64{
-						"randomName": 10000,
+					input.TestEstimationMap = map[string]Estimation{
+						"randomName": {10000, nil},
 					}
 					estimatedGas, err = processor.EstimateGas(input)
 					assert.Error(t, err)
-					assert.Equal(t, err, ErrNoEstimationFound)
+					assert.Equal(t, ErrNoEstimationFound, err)
 					assert.Equal(t, uint64(0), estimatedGas)
 				} else {
 					estimatedGas, err := processor.EstimateGas(tt.input)
 					assert.Error(t, err)
-					assert.Equal(t, err, ErrNoEstimationFound)
+					assert.Equal(t, ErrNoEstimationFound, err)
 					assert.Equal(t, uint64(0), estimatedGas)
 				}
 			})

--- a/services/wallet/router/pathprocessor/processor_transfer.go
+++ b/services/wallet/router/pathprocessor/processor_transfer.go
@@ -69,7 +69,7 @@ func (s *TransferProcessor) EstimateGas(params ProcessorInputParams) (uint64, er
 	if params.TestsMode {
 		if params.TestEstimationMap != nil {
 			if val, ok := params.TestEstimationMap[s.Name()]; ok {
-				return val, nil
+				return val.Value, val.Err
 			}
 		}
 		return 0, ErrNoEstimationFound

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -308,14 +308,33 @@ func (r *Router) GetPathProcessors() map[string]pathprocessor.PathProcessor {
 	return r.pathProcessors
 }
 
-func containsNetworkChainID(chainID uint64, chainIDs []uint64) bool {
-	for _, cID := range chainIDs {
-		if cID == chainID {
+func arrayContainsElement[T comparable](el T, arr []T) bool {
+	for _, e := range arr {
+		if e == el {
 			return true
 		}
 	}
-
 	return false
+}
+
+func arraysWithSameElements[T comparable](ar1 []T, ar2 []T, isEqual func(T, T) bool) bool {
+	if len(ar1) != len(ar2) {
+		return false
+	}
+	for _, el := range ar1 {
+		if !arrayContainsElement(el, ar2) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameSingleChainTransfer(fromChains []*params.Network, toChains []*params.Network) bool {
+	return len(fromChains) == 1 &&
+		len(toChains) == 1 &&
+		arraysWithSameElements(fromChains, toChains, func(a, b *params.Network) bool {
+			return a.ChainID == b.ChainID
+		})
 }
 
 type Router struct {
@@ -484,7 +503,7 @@ func (r *Router) SuggestedRoutes(
 			continue
 		}
 
-		if containsNetworkChainID(network.ChainID, disabledFromChainIDs) {
+		if arrayContainsElement(network.ChainID, disabledFromChainIDs) {
 			continue
 		}
 
@@ -568,10 +587,10 @@ func (r *Router) SuggestedRoutes(
 						continue
 					}
 
-					if len(preferedChainIDs) > 0 && !containsNetworkChainID(dest.ChainID, preferedChainIDs) {
+					if len(preferedChainIDs) > 0 && !arrayContainsElement(dest.ChainID, preferedChainIDs) {
 						continue
 					}
-					if containsNetworkChainID(dest.ChainID, disabledToChainIDs) {
+					if arrayContainsElement(dest.ChainID, disabledToChainIDs) {
 						continue
 					}
 

--- a/services/wallet/router/router_send_type.go
+++ b/services/wallet/router/router_send_type.go
@@ -133,6 +133,10 @@ func (s SendType) canUseProcessor(p pathprocessor.PathProcessor) bool {
 	}
 }
 
+func (s SendType) simpleTransfer(p pathprocessor.PathProcessor) bool {
+	return s == Transfer && p.Name() == pathprocessor.ProcessorTransferName
+}
+
 func (s SendType) processZeroAmountInProcessor(amountIn *big.Int, amountOut *big.Int, processorName string) bool {
 	if amountIn.Cmp(pathprocessor.ZeroBigIntValue) == 0 {
 		if s == Transfer {

--- a/services/wallet/router/router_v2_test.go
+++ b/services/wallet/router/router_v2_test.go
@@ -216,8 +216,12 @@ func TestNoBalanceForTheBestRouteRouterV2(t *testing.T) {
 			if tt.expectedError != nil {
 				assert.Error(t, err)
 				assert.Equal(t, tt.expectedError.Error(), err.Error())
-				assert.NotNil(t, routes)
-				assertPathsEqual(t, tt.expectedCandidates, routes.Candidates)
+				if tt.expectedError == ErrNoPositiveBalance {
+					assert.Nil(t, routes)
+				} else {
+					assert.NotNil(t, routes)
+					assertPathsEqual(t, tt.expectedCandidates, routes.Candidates)
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, len(tt.expectedCandidates), len(routes.Candidates))


### PR DESCRIPTION
Changes done here map these kinds of errors
`status-proxy-0.error: failed with 50011064 gas: insufficient funds for gas * price + value: address 0x4eeB09cf0076F840b38511D808464eE48efD4305 have 0 want 10000000000000` to this form:
`status-proxy-0.error: failed with 50011064 gas: insufficient funds for gas * price + value: address 0x4eeB09cf0076F840b38511D808464eE48efD4305`

which means that we don't want to display to a user details of how much they have and how much is needed for fees, cause those data are very often misleading, referring mostly to "how much user has".

New error added in case there are no positive balances across all enabled chains.

One more improvement here is that we don't even check if bridge is possible for transfer sending type if the same chain is selected for "from" and "to" chains.