### PR TITLE
fix_: separate commit message check

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - synchronize
 jobs:
   main:

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,0 +1,82 @@
+name: "Conventional Commits"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+jobs:
+  main:
+    name: Validate format
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GITHUB_HEAD_REF }}
+          fetch-tags: true
+
+      - name: Fetch tags
+        run: |
+          git fetch --tags --quiet
+          git checkout origin/${GITHUB_HEAD_REF}
+
+      - name: Check commit message
+        id: check_commit_message
+        run: |
+          set +e
+
+          output=$(./_assets/scripts/commit_check.sh 2>&1)          
+          exit_code=$?
+          echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
+          
+          if [[ $exit_code -ne 0 ]]; then
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "error_message<<$EOF" >> "$GITHUB_ENV"
+            echo "$output" >> "$GITHUB_ENV"
+            echo "$EOF" >> "$GITHUB_ENV"
+          else
+            has_breaking_changes=$(echo "$output" | sed -n '2p')
+            echo "has_breaking_changes=$has_breaking_changes" >> $GITHUB_OUTPUT
+          fi
+
+      - name: "Publish failed commit messages"
+        uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.check_commit_message.outputs.exit_code != 0)
+        with:
+          header: commit-message-lint-error
+          message: |
+            Thank you for opening this pull request!
+            
+            We require commits to follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), but with `_` for non-breaking changes. 
+            And it looks like your PR needs to be adjusted.
+
+            Details:
+            ```
+            ${{ env.error_message }}
+            ```
+
+      - name: "Publish breaking changes message"
+        uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.check_commit_message.outputs.exit_code == 0 && steps.check_commit_message.outputs.has_breaking_changes == 'true')
+        with:
+          header: commit-message-lint-error
+          message: |
+            Thank you for opening this pull request!
+            
+            Looks like you have BREAKING CHANGES in your PR. 
+            Please make sure to update [status-desktop](https://github.com/status-im/status-desktop) and [status-mobile](https://github.com/status-im/status-mobile) clients accordingly.
+
+      # Delete a previous comment when the issue has been resolved
+      - name: "Delete previous comment"
+        if: ${{ steps.check_commit_message.outputs.exit_code == 0 && steps.check_commit_message.outputs.has_breaking_changes == 'false' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: commit-message-lint-error
+          delete: true

--- a/Makefile
+++ b/Makefile
@@ -453,8 +453,9 @@ migration:
 migration-check:
 	bash _assets/scripts/migration_check.sh
 
+commit-check: SHELL := /bin/sh
 commit-check:
-	bash _assets/scripts/commit_check.sh
+	@bash _assets/scripts/commit_check.sh
 
 tag-version:
 	bash _assets/scripts/tag_version.sh $(TARGET_COMMIT)

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -99,18 +99,6 @@ pipeline {
       } }
     }
 
-    stage('Commit') {
-      environment {
-        BASE_BRANCH = "${env.BASE_BRANCH}"
-      }
-      when { // https://github.com/status-im/status-go/issues/4993#issuecomment-2022685544
-        expression { !isTestNightlyJob() }
-      }
-      steps { script {
-        nix.shell('make commit-check', pure: false)
-      } }
-    }
-
     stage('Lint') {
       steps { script {
         nix.shell('make lint', pure: true)

--- a/_assets/scripts/commit_check.sh
+++ b/_assets/scripts/commit_check.sh
@@ -19,7 +19,6 @@ parse_commits() {
             # Check for breaking changes
             if [[ ${BASH_REMATCH[3]} == *'!'* ]]; then
                 is_breaking_change=true
-                break # FIXME: This break shouldn't be here
             fi
         else
             echo "Commit message \"$message\" is not well-formed"

--- a/_assets/scripts/commit_check.sh
+++ b/_assets/scripts/commit_check.sh
@@ -9,8 +9,9 @@ parse_commits() {
     start_commit=${1:-origin/${BASE_BRANCH}}
     end_commit=${2:-HEAD}
     is_breaking_change=false
+    exit_code=0
 
-    echo "checking commits between: $start_commit $end_commit" >&2
+    echo "checking commits between: $start_commit $end_commit"
     # Run the loop in the current shell using process substitution
     while IFS= read -r message || [ -n "$message" ]; do
         # Check if commit message follows conventional commits format
@@ -18,14 +19,17 @@ parse_commits() {
             # Check for breaking changes
             if [[ ${BASH_REMATCH[3]} == *'!'* ]]; then
                 is_breaking_change=true
-                break
+                break # FIXME: This break shouldn't be here
             fi
         else
-            echo "Commit message \"$message\" is not well-formed. Aborting merge. We use https://www.conventionalcommits.org/en/v1.0.0/ but with _ for non-breaking changes"
-            # Uncomment the line below if you want to exit on an invalid commit message
-            exit 1
+            echo "Commit message \"$message\" is not well-formed"
+            exit_code=1
         fi
     done < <(git log --format=%s "$start_commit".."$end_commit")
+
+    if [[ $exit_code -ne 0 ]]; then
+        exit ${exit_code}
+    fi
 
     echo "$is_breaking_change"
 }


### PR DESCRIPTION
# Description

We want a separate check for commit messages. When an issue happen with commit messages, we still want to know tests run results. Because sometimes we want for force-merge. And because it makes sense in general, it's easier to see the issue fro the developer.

Also, I fixed a bug. A commit with breaking change would mitigate a commit with malformed message.

Inspired by go-waku repository

edit

## Comment when commit check is not passing
 
<img width="924" alt="image" src="https://github.com/user-attachments/assets/62a7796f-5d2e-4865-9bab-c1a4d2957241">

The comment is automatically deleted when the issues are resolved.

## Comment when commit check is passing and breaking changes are detected

<img width="916" alt="image" src="https://github.com/user-attachments/assets/f383636e-dee1-4817-acb2-4cbab816becc">