### PR TITLE
chore(mentions)_: Add suggestion limit for mention recommendations

### DIFF
--- a/protocol/messenger_mention.go
+++ b/protocol/messenger_mention.go
@@ -30,6 +30,8 @@ const (
 	charCodeBlock  = "`"
 
 	intUnknown = -1
+
+	suggestionsLimit = 10
 )
 
 var (
@@ -370,7 +372,7 @@ func (m *MentionManager) calculateSuggestionsWithMentionableUsers(chatID string,
 		searchedText := strings.ToLower(subs(fullText, atSignIdx+1, end))
 		m.logger.Debug("calculateSuggestionsWithMentionableUsers", zap.Int("atSignIdx", atSignIdx), zap.String("searchedText", searchedText), zap.String("fullText", fullText), zap.Any("state", state), zap.Int("end", end))
 		if end-atSignIdx <= 100 {
-			suggestions = getUserSuggestions(mentionableUsers, searchedText, -1)
+			suggestions = getUserSuggestions(mentionableUsers, searchedText, suggestionsLimit)
 		}
 	}
 
@@ -729,7 +731,7 @@ func matchMention(text string, users map[string]*MentionableUser, mentionKeyIdx 
 			searchedText = string(tt[:lastChar])
 		}
 
-		userSuggestions := getUserSuggestions(users, searchedText, -1)
+		userSuggestions := getUserSuggestions(users, searchedText, suggestionsLimit)
 		userSuggestionsCnt := len(userSuggestions)
 		switch {
 		case userSuggestionsCnt == 0:


### PR DESCRIPTION
- Introduce a constant `suggestionsLimit` set to 15
- Apply the suggestion limit when calculating mention suggestions
- Replace unlimited suggestions (-1) with the new limit in relevant function calls
- This change aims to improve performance and user experience by limiting the number of mention suggestions displayed

fix relate mobile [issue](https://github.com/status-im/status-mobile/issues/20722)
