### PR TITLE
chore_: remove flaky test TestEnableInstallationAndPair

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -17,8 +16,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/status-im/status-go/protocol/tt"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -880,106 +877,6 @@ func TestLoginAccount(t *testing.T) {
 	waitForLogin(c)
 
 	require.Equal(t, nameserver, b.config.WakuV2Config.Nameserver)
-}
-
-func TestEnableInstallationAndPair(t *testing.T) {
-	// create account acc
-	utils.Init()
-	displayName := "some-display-name"
-	password := "some-password"
-	tmpdir := t.TempDir()
-	nameserver := "8.8.8.8"
-	b := NewGethStatusBackend()
-	createAccountRequest := &requests.CreateAccount{
-		DisplayName:        displayName,
-		CustomizationColor: "#ffffff",
-		Password:           password,
-		RootDataDir:        tmpdir,
-		LogFilePath:        tmpdir + "/log",
-		WakuV2Nameserver:   &nameserver,
-		WakuV2Fleet:        "status.staging",
-	}
-	acc, err := b.CreateAccountAndLogin(createAccountRequest)
-	require.NoError(t, err)
-	require.NotNil(t, acc)
-	_, err = b.Messenger().Start()
-	require.NoError(t, err)
-	s, err := b.GetSettings()
-	require.NoError(t, err)
-	mn := *s.Mnemonic
-	db, err := accounts.NewDB(b.appDB)
-	require.NoError(t, err)
-	n, err := db.GetSettingLastSynced(settings.DisplayName)
-	require.NoError(t, err)
-	require.True(t, n > 0)
-
-	// restore account acc as acc2 use Mnemonic from acc
-	restoreRequest := &requests.RestoreAccount{
-		Mnemonic:    mn,
-		FetchBackup: true,
-		CreateAccount: requests.CreateAccount{
-			Password:           password,
-			CustomizationColor: "0x000000",
-			RootDataDir:        t.TempDir(),
-		},
-	}
-	b2 := NewGethStatusBackend()
-	acc2, err := b2.RestoreAccountAndLogin(restoreRequest)
-	require.NoError(t, err)
-	require.NotNil(t, acc2)
-	_, err = b2.Messenger().Start()
-	require.NoError(t, err)
-	s2, err := b2.GetSettings()
-	require.NoError(t, err)
-
-	t.Logf("acc2 settings.name: %s", s2.Name)
-	// should be 3 words random name
-	require.Len(t, strings.Split(s2.Name, " "), 3)
-	require.Empty(t, acc2.Name)
-	require.Empty(t, s2.DisplayName)
-	db2, err := accounts.NewDB(b2.appDB)
-	require.NoError(t, err)
-	n, err = db2.GetSettingLastSynced(settings.DisplayName)
-	require.NoError(t, err)
-	require.True(t, n == 0)
-
-	// pair installation
-	_, err = b2.Messenger().EnableInstallationAndPair(&requests.EnableInstallationAndPair{InstallationID: s.InstallationID})
-	require.NoError(t, err)
-	// ensure acc received the installation from acc2
-	err = tt.RetryWithBackOff(func() error {
-		r, err := b.Messenger().RetrieveAll()
-		require.NoError(t, err)
-		if len(r.Installations()) > 0 {
-			return nil
-		}
-		return errors.New("new installation not received yet")
-	})
-	require.NoError(t, err)
-
-	// sync data from acc to acc2
-	err = b.Messenger().EnableAndSyncInstallation(&requests.EnableAndSyncInstallation{InstallationID: s2.InstallationID})
-	require.NoError(t, err)
-	// ensure acc2's display name get synced
-	err = tt.RetryWithBackOff(func() error {
-		r, err := b2.Messenger().RetrieveAll()
-		require.NoError(t, err)
-		for _, ss := range r.Settings {
-			if ss.GetDBName() == "display_name" {
-				return nil
-			}
-		}
-		return errors.New("display name setting not received yet")
-	})
-	require.NoError(t, err)
-
-	// check display name for acc2
-	s2, err = b2.GetSettings()
-	require.NoError(t, err)
-	require.Equal(t, displayName, s2.DisplayName)
-	acc2, err = b2.GetActiveAccount()
-	require.NoError(t, err)
-	require.Equal(t, displayName, acc2.Name)
 }
 
 func TestVerifyDatabasePassword(t *testing.T) {

--- a/protocol/messenger_pairing_and_syncing_test.go
+++ b/protocol/messenger_pairing_and_syncing_test.go
@@ -1,13 +1,17 @@
 package protocol
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/multiaccounts/accounts"
+	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/requests"
+	"github.com/status-im/status-go/protocol/tt"
 )
 
 func TestMessengerPairingTest(t *testing.T) {
@@ -54,24 +58,38 @@ func (s *MessengerPairingSuite) TestEnableNonExistingInstallation() {
 
 }
 
+// TestMessengerPairAfterSeedPhrase tests the scenario where alice2 wants to sync with alice1
+// alice1 generated the connection string for bootstraping alice2
+// alice2 failed to connect to alice1 and restored from seed phrase
+// alice2 get the installationID1 from alice1 via parsing the connection string
+// alice2 should get the display name from alice1 after pairing
 func (s *MessengerPairingSuite) TestMessengerPairAfterSeedPhrase() {
-	// assuming alice2 want to sync with alice1
-	// alice1 generated the connection string for bootstraping alice2
-	// alice2 failed to connect to alice1 and restored from seed phrase
-	// alice2 get the installationID1 from alice1 via parsing the connection string
 	alice1 := s.m
 	alice2, err := newMessengerWithKey(s.shh, s.privateKey, s.logger, nil)
 	s.Require().NoError(err)
 	defer TearDownMessenger(&s.Suite, alice2)
+
+	alice1ProfileKp := accounts.GetProfileKeypairForTest(true, false, false)
+	alice1ProfileKp.KeyUID = alice1.account.KeyUID
+	alice1ProfileKp.Accounts[0].KeyUID = alice1.account.KeyUID
+	err = alice1.settings.SaveOrUpdateKeypair(alice1ProfileKp)
+	s.Require().NoError(err)
+
+	expectedDisplayName := "alice1"
+	s.Require().NoError(alice1.SetDisplayName(expectedDisplayName))
+	ss, err := alice2.getSettings()
+	s.Require().NoError(err)
+	s.Require().NotEqual(expectedDisplayName, ss.DisplayName)
 	installationID1 := alice1.installationID
 	installationID2 := alice2.installationID
 	s.Require().NotEqual(installationID1, installationID2)
+
 	_, err = alice2.EnableInstallationAndPair(&requests.EnableInstallationAndPair{InstallationID: installationID1})
 	s.Require().NoError(err)
 
 	// alice1 should get the installationID1 from alice2
 	_, err = WaitOnMessengerResponse(
-		alice2,
+		alice1,
 		func(r *MessengerResponse) bool {
 			for _, i := range r.Installations() {
 				if i.ID == installationID2 {
@@ -82,7 +100,23 @@ func (s *MessengerPairingSuite) TestMessengerPairAfterSeedPhrase() {
 		},
 		"no messages",
 	)
-
 	s.Require().NoError(err)
 
+	s.Require().NoError(alice1.EnableAndSyncInstallation(&requests.EnableAndSyncInstallation{InstallationID: installationID2}))
+
+	// check if the display name is synced
+	err = tt.RetryWithBackOff(func() error {
+		r, err := alice2.RetrieveAll()
+		s.Require().NoError(err)
+		for _, ss := range r.Settings {
+			if ss.GetDBName() == settings.DisplayName.GetDBName() {
+				return nil
+			}
+		}
+		return errors.New("display name setting not received yet")
+	})
+	s.Require().NoError(err)
+	ss, err = alice2.getSettings()
+	s.Require().NoError(err)
+	s.Require().Equal(expectedDisplayName, ss.DisplayName)
 }


### PR DESCRIPTION
The main changes include:
- Removing the TestEnableInstallationAndPair function from api/backend_test.go.
- Enhancing the TestMessengerPairAfterSeedPhrase to include partial test logic existed in  `TestEnableInstallationAndPair` so that test won't depend on real network