### PR TITLE
chore_: move sync and pair test to protocol

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -17,8 +16,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/status-im/status-go/protocol/tt"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -880,106 +877,6 @@ func TestLoginAccount(t *testing.T) {
 	waitForLogin(c)
 
 	require.Equal(t, nameserver, b.config.WakuV2Config.Nameserver)
-}
-
-func TestEnableInstallationAndPair(t *testing.T) {
-	// create account acc
-	utils.Init()
-	displayName := "some-display-name"
-	password := "some-password"
-	tmpdir := t.TempDir()
-	nameserver := "8.8.8.8"
-	b := NewGethStatusBackend()
-	createAccountRequest := &requests.CreateAccount{
-		DisplayName:        displayName,
-		CustomizationColor: "#ffffff",
-		Password:           password,
-		RootDataDir:        tmpdir,
-		LogFilePath:        tmpdir + "/log",
-		WakuV2Nameserver:   &nameserver,
-		WakuV2Fleet:        "status.staging",
-	}
-	acc, err := b.CreateAccountAndLogin(createAccountRequest)
-	require.NoError(t, err)
-	require.NotNil(t, acc)
-	_, err = b.Messenger().Start()
-	require.NoError(t, err)
-	s, err := b.GetSettings()
-	require.NoError(t, err)
-	mn := *s.Mnemonic
-	db, err := accounts.NewDB(b.appDB)
-	require.NoError(t, err)
-	n, err := db.GetSettingLastSynced(settings.DisplayName)
-	require.NoError(t, err)
-	require.True(t, n > 0)
-
-	// restore account acc as acc2 use Mnemonic from acc
-	restoreRequest := &requests.RestoreAccount{
-		Mnemonic:    mn,
-		FetchBackup: true,
-		CreateAccount: requests.CreateAccount{
-			Password:           password,
-			CustomizationColor: "0x000000",
-			RootDataDir:        t.TempDir(),
-		},
-	}
-	b2 := NewGethStatusBackend()
-	acc2, err := b2.RestoreAccountAndLogin(restoreRequest)
-	require.NoError(t, err)
-	require.NotNil(t, acc2)
-	_, err = b2.Messenger().Start()
-	require.NoError(t, err)
-	s2, err := b2.GetSettings()
-	require.NoError(t, err)
-
-	t.Logf("acc2 settings.name: %s", s2.Name)
-	// should be 3 words random name
-	require.Len(t, strings.Split(s2.Name, " "), 3)
-	require.Empty(t, acc2.Name)
-	require.Empty(t, s2.DisplayName)
-	db2, err := accounts.NewDB(b2.appDB)
-	require.NoError(t, err)
-	n, err = db2.GetSettingLastSynced(settings.DisplayName)
-	require.NoError(t, err)
-	require.True(t, n == 0)
-
-	// pair installation
-	_, err = b2.Messenger().EnableInstallationAndPair(&requests.EnableInstallationAndPair{InstallationID: s.InstallationID})
-	require.NoError(t, err)
-	// ensure acc received the installation from acc2
-	err = tt.RetryWithBackOff(func() error {
-		r, err := b.Messenger().RetrieveAll()
-		require.NoError(t, err)
-		if len(r.Installations()) > 0 {
-			return nil
-		}
-		return errors.New("new installation not received yet")
-	})
-	require.NoError(t, err)
-
-	// sync data from acc to acc2
-	err = b.Messenger().EnableAndSyncInstallation(&requests.EnableAndSyncInstallation{InstallationID: s2.InstallationID})
-	require.NoError(t, err)
-	// ensure acc2's display name get synced
-	err = tt.RetryWithBackOff(func() error {
-		r, err := b2.Messenger().RetrieveAll()
-		require.NoError(t, err)
-		for _, ss := range r.Settings {
-			if ss.GetDBName() == "display_name" {
-				return nil
-			}
-		}
-		return errors.New("display name setting not received yet")
-	})
-	require.NoError(t, err)
-
-	// check display name for acc2
-	s2, err = b2.GetSettings()
-	require.NoError(t, err)
-	require.Equal(t, displayName, s2.DisplayName)
-	acc2, err = b2.GetActiveAccount()
-	require.NoError(t, err)
-	require.Equal(t, displayName, acc2.Name)
 }
 
 func TestVerifyDatabasePassword(t *testing.T) {

--- a/protocol/messenger_pairing_and_syncing_test.go
+++ b/protocol/messenger_pairing_and_syncing_test.go
@@ -1,13 +1,17 @@
 package protocol
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap"
 
+	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/requests"
+	"github.com/status-im/status-go/protocol/tt"
 )
 
 func TestMessengerPairingTest(t *testing.T) {
@@ -85,4 +89,80 @@ func (s *MessengerPairingSuite) TestMessengerPairAfterSeedPhrase() {
 
 	s.Require().NoError(err)
 
+}
+
+func (s *MessengerPairingSuite) TestMessengerPairEnableAndSync() {
+	// assuming alice2 want to sync with alice1
+	// alice1 generated the connection string for bootstraping alice2
+	// alice2 failed to connect to alice1 and restored from seed phrase
+	// alice2 get the installationID1 from alice1 via parsing the connection string
+	alice1 := s.m
+	alice2logger := s.logger.With(zap.Namespace("alice2"))
+	alice2, err := newMessengerWithKey(s.shh, s.privateKey, alice2logger, nil)
+	s.Require().NoError(err)
+	defer TearDownMessenger(&s.Suite, alice2)
+	installationID1 := alice1.installationID
+	installationID2 := alice2.installationID
+	s.Require().NotEqual(installationID1, installationID2)
+	_, err = alice2.EnableInstallationAndPair(&requests.EnableInstallationAndPair{InstallationID: installationID1})
+	s.Require().NoError(err)
+
+	profileKp := accounts.GetProfileKeypairForTest(true, false, false)
+	profileKp.KeyUID = alice2.account.KeyUID
+	profileKp.Accounts[0].KeyUID = alice2.account.KeyUID
+
+	err = alice2.settings.SaveOrUpdateKeypair(profileKp)
+	s.Require().NoError(err)
+
+	profileKp = accounts.GetProfileKeypairForTest(true, false, false)
+	profileKp.KeyUID = alice1.account.KeyUID
+	profileKp.Accounts[0].KeyUID = alice1.account.KeyUID
+
+	err = alice1.settings.SaveOrUpdateKeypair(profileKp)
+	s.Require().NoError(err)
+
+	// alice1 should get the installationID1 from alice2
+	_, err = WaitOnMessengerResponse(
+		alice1,
+		func(r *MessengerResponse) bool {
+			for _, i := range r.Installations() {
+				if i.ID == installationID2 {
+					return true
+				}
+			}
+			return false
+		},
+		"no messages",
+	)
+
+	s.Require().NoError(err)
+
+	displayName := "new-display-name"
+	err = alice1.SetDisplayName(displayName)
+	s.Require().NoError(err)
+
+	// sync data from acc to acc2
+	err = alice1.EnableAndSyncInstallation(&requests.EnableAndSyncInstallation{InstallationID: alice2.InstallationID()})
+	s.Require().NoError(err)
+	installations := alice1.Installations()
+	s.Require().Len(installations, 2)
+
+	if installations[0].ID == alice2.InstallationID() {
+		s.Require().True(installations[0].Enabled)
+	} else {
+		s.Require().Equal(alice2.InstallationID(), installations[1].ID)
+		s.Require().True(installations[1].Enabled)
+	}
+	// ensure acc2's display name get synced
+	err = tt.RetryWithBackOff(func() error {
+		r, err := alice2.RetrieveAll()
+		s.Require().NoError(err)
+		for _, ss := range r.Settings {
+			if ss.GetDBName() == "display_name" && ss.Value == displayName {
+				return nil
+			}
+		}
+		return errors.New("display name setting not received yet")
+	})
+	s.Require().NoError(err)
 }


### PR DESCRIPTION
The test was flaky as it was using the real network, I have moved the test to `protocol/` directory so it doesn't use actual waku nodes. The test is not 100% equivalent as it's not restoring the accounts, but it covers the most part of the feature.