### PR TITLE
chore_: bring back jenkins commit check

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -99,6 +99,18 @@ pipeline {
       } }
     }
 
+    stage('Commit') {
+      environment {
+        BASE_BRANCH = "${env.BASE_BRANCH}"
+      }
+      when { // https://github.com/status-im/status-go/issues/4993#issuecomment-2022685544
+        expression { !isTestNightlyJob() }
+      }
+      steps { script {
+        nix.shell('make commit-check', pure: false)
+      } }
+    }
+
     stage('Lint') {
       steps { script {
         nix.shell('make lint', pure: true)


### PR DESCRIPTION
I removed it here: https://github.com/status-im/status-go/pull/5773
But it's better to do it gradually. Ensure all commits have the new check and then make it required and remove the old check.