### PR TITLE
fix_: nightly tests report

### DIFF
--- a/_assets/scripts/test_stats.py
+++ b/_assets/scripts/test_stats.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 test_stats = defaultdict(lambda: defaultdict(int))
 
-for file in glob.glob("**/report_*.xml", recursive=True):
+for file in glob.glob("report.xml", recursive=True):
     tree = ET.parse(file)
     root = tree.getroot()
     for testcase in root.iter("testcase"):


### PR DESCRIPTION
Fixing an issue introduced here: https://github.com/status-im/status-go/pull/5731
Now the report with stats of failing tests is empty on Jenkins.

Test run: https://ci.status.im/job/status-go/job/tests-nightly/340