### PR TITLE
chore(test_stats)_: better stats, print skipped tests

### DIFF
--- a/_assets/scripts/test_stats.py
+++ b/_assets/scripts/test_stats.py
@@ -3,8 +3,10 @@
 import glob
 import xml.etree.ElementTree as ET
 from collections import defaultdict
+import re
 
 test_stats = defaultdict(lambda: defaultdict(int))
+skipped_tests = {}  # Use a dictionary to store test names and their skip reasons
 
 for file in glob.glob("report.xml", recursive=True):
     tree = ET.parse(file)
@@ -19,6 +21,21 @@ for file in glob.glob("report.xml", recursive=True):
         elif testcase.find("error") is not None:
             test_stats[test_name]["failed_runs"] += 1
 
+        # Check for skipped tests
+        skipped_element = testcase.find("skipped")
+        if skipped_element is not None:
+            message = skipped_element.attrib.get("message", "")
+            # Extract the real reason from the message
+            match = re.search(r': (.*?)\s*--- SKIP', message)
+            skip_reason = match.group(1).strip() if match else "unknown reason"
+            skipped_tests[test_name] = skip_reason  # Store test name and skip reason
+
+# Filter out root test cases if they have subtests
+filtered_test_stats = {
+    name: stats for name, stats in test_stats.items()
+    if not any(subtest.startswith(name + "/") for subtest in test_stats)
+}
+
 failing_test_stats = [
     {
         "name": name,
@@ -26,20 +43,28 @@ failing_test_stats = [
         "failed_runs": stats["failed_runs"],
         "total_runs": stats["total_runs"]
     }
-    for name, stats in test_stats.items() if stats["failed_runs"] != 0
+    for name, stats in filtered_test_stats.items() if stats["failed_runs"] != 0
 ]
 
 sorted_failing_test_stats = sorted(failing_test_stats,
                                    key=lambda x: x["failure_rate"],
                                    reverse=True)
 
+flaky_skipped_count = sum(1 for reason in skipped_tests.values() if reason == "flaky test")
+
 print("---")
-print("Failing tests stats")
+print(f"Failing tests stats (total: {len(failing_test_stats)})")
 print("---")
 for test_stat in sorted_failing_test_stats:
-    print("{}: {}% ({} of {} failed)".format(
+    print("{}: {:.1f}% ({} of {} failed)".format(
         test_stat['name'],
         test_stat['failure_rate'] * 100,
         test_stat['failed_runs'],
         test_stat['total_runs']
     ))
+
+print("---")
+print(f"Skipped tests (total: {len(skipped_tests)}, skipped as flaky: {flaky_skipped_count})")
+print("---")
+for test_name, skip_reason in skipped_tests.items():
+    print(f"{test_name}: {skip_reason}")

--- a/protocol/messenger_peersyncing_test.go
+++ b/protocol/messenger_peersyncing_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestMessengerPeersyncingSuite(t *testing.T) {
-	t.SkipNow() // FIXME
+	t.Skip("broken test") // FIXME
 	suite.Run(t, new(MessengerPeersyncingSuite))
 }
 

--- a/services/rpcfilters/api_test.go
+++ b/services/rpcfilters/api_test.go
@@ -82,7 +82,7 @@ func TestGetFilterChangesResetsTimer(t *testing.T) {
 }
 
 func TestGetFilterLogs(t *testing.T) {
-	t.Skip("Skipping due to flakiness: https://github.com/status-im/status-go/issues/1281")
+	t.Skip("flaky test")
 
 	tracker := new(callTracker)
 	api := &PublicAPI{


### PR DESCRIPTION
# Description

Many thanks to GitHub Copilot 🙂 

1. Print skipped tests
2. Print total count for failing and skipped tests
3. For skipped tests, print the reason of skipping
4. For failed tests, skip the root test, if a subtest is failing.
5. 1 digit precision for failure rate

### Looks like this now

```nim
---
Failing tests stats (total: 52)
---
TestSimulationBloomFilter: 99.0% (99 of 100 failed)
TestMakeNodeDefaultConfig: 53.0% (53 of 100 failed)
TestLoginWithKey: 50.0% (1 of 2 failed)
TestMessengerCommunitiesTokenPermissionsSuite/TestReevaluateMemberTokenMasterRoleInOpenCommunity_ERC721: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestAliceOfflineRetractsAndAddsCorrectOrder: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestAliceTriesToSpamBobWithContactRequests: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestReceiveAcceptAndRetractContactRequest: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestReceiveAndAcceptContactRequest: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestAliceRecoverStateReceiveContactRequest: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestAliceRestoresOutgoingContactRequestFromSyncInstallationContactV2: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestBuildContact: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestReceiveAcceptAndRetractContactRequestOutOfOrder: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestAliceResendsContactRequestAfterRemovingBobFromContacts: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestAcceptCRRemoveAndRepeat: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestReceiveAndAcceptContactRequestTwice: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestAliceRecoverStateSendContactRequest: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestBlockedContactSyncing: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestBobSendsContactRequestAfterDecliningOneFromAlice: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestAliceOfflineRetractsAndAddsWrongOrder: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestBobRestoresIncomingContactRequestFromSyncInstallationContactV2: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestAcceptLatestContactRequestForContact: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestPairedDevicesRemoveContact: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestAliceSeesOnlyOneAcceptFromBob: 50.0% (1 of 2 failed)
TestMessengerContactRequestSuite/TestDismissLatestContactRequestForContact: 50.0% (1 of 2 failed)
TestPeerExchange: 11.1% (1 of 9 failed)
TestPeerPoolSimulationSuite/TestUpdateTopicLimits: 9.5% (2 of 21 failed)
TestPeerPoolSimulationSuite/TestMailServerPeersDiscovery: 9.1% (2 of 22 failed)
TestSyncDeviceSuite/TestPairingThreeDevices: 8.0% (2 of 25 failed)
TestPeerPoolSimulationSuite/TestPeerPoolCacheEthV5: 4.5% (1 of 22 failed)
TestSyncDeviceSuite/TestPairingSyncDeviceClientAsSender: 4.0% (1 of 25 failed)
TestSyncDeviceSuite/TestPairAcceptContactRequest: 4.0% (1 of 25 failed)
TestSyncDeviceSuite/TestPairPendingContactRequest: 4.0% (1 of 25 failed)
TestSyncDeviceSuite/TestPairingSyncDeviceClientAsReceiver: 4.0% (1 of 25 failed)
TestSyncDeviceSuite/TestPairDeclineContactRequest: 4.0% (1 of 25 failed)
TestSyncDeviceSuite/TestPreventLoggedInAccountLocalPairingClientAsReceiver: 4.0% (1 of 25 failed)
TestShhExtSuite/TestMultipleRequestMessagesWithoutForce: 4.0% (4 of 100 failed)
TestSubscriptionRemove: 3.2% (1 of 31 failed)
TestSubscriptionGetData: 3.1% (1 of 32 failed)
TestSubscriptionGetError: 3.1% (1 of 32 failed)
TestSQLLitePersistenceKeysStorageTestSuite/TestKeysStorageSqlLiteGetMissing: 2.0% (1 of 50 failed)
TestSQLLitePersistenceKeysStorageTestSuite/TestKeysStorageSqlLite_Count: 2.0% (1 of 50 failed)
TestPersistenceSuite/TestGetCommunityToValidateByID: 1.9% (1 of 53 failed)
TestPersistenceSuite/TestGetCommunityRequestsToJoinWithRevealedAddresses: 1.9% (1 of 53 failed)
TestPersistenceSuite/TestAllNonApprovedCommunitiesRequestsToJoin: 1.9% (1 of 53 failed)
TestPersistenceSuite/TestGetCommunityRequestToJoinWithRevealedAddresses: 1.9% (1 of 53 failed)
TestPersistenceSuite/TestCuratedCommunities: 1.9% (1 of 53 failed)
TestPersistenceSuite/TestDecryptedCommunityCache: 1.9% (1 of 53 failed)
TestPersistenceSuite/TestDeleteCommunitySettings: 1.9% (1 of 53 failed)
TestPersistenceSuite/TestGetCommunityRequestsToJoinRevealedAddresses: 1.9% (1 of 53 failed)
TestPersistenceSuite/TestDecryptedCommunityCacheClock: 1.9% (1 of 53 failed)
TestPersistenceSuite/TestGetCommunitiesSettings: 1.9% (1 of 53 failed)
TestShhExtSuite/TestRequestMessagesSuccess: 1.0% (1 of 100 failed)
---
Skipped tests (total: 30, skipped as flaky: 7)
---
TestOwnerWithoutCommunityKeyCommunityEventsSuite/TestOwnerControlNodeHandlesMultipleEventSenderRequestToJoinDecisions: flaky test
TestTokenMasterCommunityEventsSuite/TestTokenMasterControlNodeHandlesMultipleEventSenderRequestToJoinDecisions: flaky test
TestAdminCommunityEventsSuite/TestAdminControlNodeHandlesMultipleEventSenderRequestToJoinDecisions: flaky test
TestMessengerCommunitiesTokenPermissionsSuite/TestBecomeMemberPermissions: emitter is closed
TestMessengerCommunitiesTokenPermissionsSuite/TestRequestAccessWithENSTokenPermission: unknown reason
TestMessengerBackupSuite/TestBackupSettings: flaky test
TestMessengerPeersyncingSuite: unknown reason
TestMessengerStoreNodeCommunitySuite: requires storev3 node
TestMessengerStoreNodeRequestSuite: requires storev3 node
TestMessengerSyncSettings/TestSyncSettings_StickerPacks: Currently sticker pack syncing has been deactivated, testing to resume after sticker packs works correctly
TestSyncDeviceSuite/TestTransferringKeystoreFilesAfterStopUisngKeycard: flaky test
TestResolver: skip test using infura
TestGetName: skip test using infura
TestOwnerOf: skip test using infura
TestContentHash: skip test using infura
TestPublicKeyOf: skip test using infura
TestAddressOf: skip test using infura
TestExpireAt: skip test using infura
TestPrice: skip test using infura
TestResourceURL: skip test using infura
TestGetFilterLogs: Skipping due to flakiness: https://github.com/status-im/status-go/issues/1281
TestRaribleClientIntegrationSuite/TestAPIKeysAvailable: integration test
TestRaribleClientIntegrationSuite/TestSearchCollectibles: integration test
TestRaribleClientIntegrationSuite/TestSearchCollections: integration test
TestRequestPermission: skip test using infura
TestWeb3Call: skip test using infura
TestWeb3Signature: skip test using infura
TestPeerCount: flaky test
TestWakuV2Filter: flaky test
TestWakuV2Store: deprecated. Storenode must use nwaku
```