### PR TITLE
feat_: recalculate route fees with every new block

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -507,6 +507,12 @@ func (api *API) StopSuggestedRoutesAsyncCalculation(ctx context.Context) {
 	api.router.StopSuggestedRoutesAsyncCalculation()
 }
 
+func (api *API) StopSuggestedRoutesCalculation(ctx context.Context) {
+	log.Debug("call to StopSuggestedRoutesCalculation")
+
+	api.router.StopSuggestedRoutesCalculation()
+}
+
 // Generates addresses for the provided paths, response doesn't include `HasActivity` value (if you need it check `GetAddressDetails` function)
 func (api *API) GetDerivedAddresses(ctx context.Context, password string, derivedFrom string, paths []string) ([]*DerivedAddress, error) {
 	info, err := api.s.gethManager.AccountsGenerator().LoadAccount(derivedFrom, password)

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -73,6 +73,14 @@ type Router struct {
 	feesManager         *fees.FeeManager
 	pathProcessors      map[string]pathprocessor.PathProcessor
 	scheduler           *async.Scheduler
+
+	activeRoutesMutex sync.Mutex
+	activeRoutes      *SuggestedRoutes
+
+	lastInputParamsMutex sync.Mutex
+	lastInputParams      *requests.RouteInputParams
+
+	clientsForUpdatesPerChains sync.Map
 }
 
 func NewRouter(rpcClient *rpc.Client, transactor *transactions.Transactor, tokenManager *token.Manager, marketManager *market.Manager,
@@ -147,41 +155,46 @@ func newSuggestedRoutes(
 	return suggestedRoutes, allRoutes
 }
 
+func sendRouterResult(uuid string, result interface{}, err error) {
+	routesResponse := responses.RouterSuggestedRoutes{
+		Uuid: uuid,
+	}
+
+	if err != nil {
+		errorResponse := errors.CreateErrorResponseFromError(err)
+		routesResponse.ErrorResponse = errorResponse.(*errors.ErrorResponse)
+	}
+
+	if suggestedRoutes, ok := result.(*SuggestedRoutes); ok && suggestedRoutes != nil {
+		routesResponse.Best = suggestedRoutes.Best
+		routesResponse.Candidates = suggestedRoutes.Candidates
+		routesResponse.TokenPrice = &suggestedRoutes.TokenPrice
+		routesResponse.NativeChainTokenPrice = &suggestedRoutes.NativeChainTokenPrice
+	}
+
+	signal.SendWalletEvent(signal.SuggestedRoutes, routesResponse)
+}
+
 func (r *Router) SuggestedRoutesAsync(input *requests.RouteInputParams) {
 	r.scheduler.Enqueue(routerTask, func(ctx context.Context) (interface{}, error) {
 		return r.SuggestedRoutes(ctx, input)
 	}, func(result interface{}, taskType async.TaskType, err error) {
-		routesResponse := responses.RouterSuggestedRoutes{
-			Uuid: input.Uuid,
-		}
-
-		if err != nil {
-			errorResponse := errors.CreateErrorResponseFromError(err)
-			routesResponse.ErrorResponse = errorResponse.(*errors.ErrorResponse)
-		}
-
-		if suggestedRoutes, ok := result.(*SuggestedRoutes); ok && suggestedRoutes != nil {
-			routesResponse.Best = suggestedRoutes.Best
-			routesResponse.Candidates = suggestedRoutes.Candidates
-			routesResponse.TokenPrice = &suggestedRoutes.TokenPrice
-			routesResponse.NativeChainTokenPrice = &suggestedRoutes.NativeChainTokenPrice
-		}
-
-		signal.SendWalletEvent(signal.SuggestedRoutes, routesResponse)
+		sendRouterResult(input.Uuid, result, err)
 	})
 }
 
 func (r *Router) StopSuggestedRoutesAsyncCalculation() {
+	r.unsubscribeFeesUpdateAccrossAllChains()
 	r.scheduler.Stop()
 }
 
-func (r *Router) SuggestedRoutes(ctx context.Context, input *requests.RouteInputParams) (*SuggestedRoutes, error) {
-	testnetMode, err := r.rpcClient.NetworkManager.GetTestNetworksEnabled()
-	if err != nil {
-		return nil, errors.CreateErrorResponseFromError(err)
-	}
+func (r *Router) StopSuggestedRoutesCalculation() {
+	r.unsubscribeFeesUpdateAccrossAllChains()
+}
 
-	input.TestnetMode = testnetMode
+func (r *Router) SuggestedRoutes(ctx context.Context, input *requests.RouteInputParams) (suggestedRoutes *SuggestedRoutes, err error) {
+	// unsubscribe from updates
+	r.unsubscribeFeesUpdateAccrossAllChains()
 
 	// clear all processors
 	for _, processor := range r.pathProcessors {
@@ -189,6 +202,29 @@ func (r *Router) SuggestedRoutes(ctx context.Context, input *requests.RouteInput
 			clearable.Clear()
 		}
 	}
+
+	r.lastInputParamsMutex.Lock()
+	r.lastInputParams = input
+	r.lastInputParamsMutex.Unlock()
+
+	defer func() {
+		r.activeRoutesMutex.Lock()
+		r.activeRoutes = suggestedRoutes
+		r.activeRoutesMutex.Unlock()
+		if suggestedRoutes != nil {
+			// subscribe for updates
+			for _, path := range suggestedRoutes.Best {
+				err = r.subscribeForUdates(path.FromChain.ChainID)
+			}
+		}
+	}()
+
+	testnetMode, err := r.rpcClient.NetworkManager.GetTestNetworksEnabled()
+	if err != nil {
+		return nil, errors.CreateErrorResponseFromError(err)
+	}
+
+	input.TestnetMode = testnetMode
 
 	err = input.Validate()
 	if err != nil {
@@ -224,7 +260,7 @@ func (r *Router) SuggestedRoutes(ctx context.Context, input *requests.RouteInput
 		return nil, errors.CreateErrorResponseFromError(err)
 	}
 
-	suggestedRoutes, err := r.resolveRoutes(ctx, input, candidates, balanceMap)
+	suggestedRoutes, err = r.resolveRoutes(ctx, input, candidates, balanceMap)
 
 	if err == nil && (suggestedRoutes == nil || len(suggestedRoutes.Best) == 0) {
 		// No best route found, but no error given.
@@ -657,22 +693,24 @@ func (r *Router) resolveCandidates(ctx context.Context, input *requests.RouteInp
 							appendProcessorErrorFn(pProcessor.Name(), input.SendType, processorInputParams.FromChain.ChainID, processorInputParams.ToChain.ChainID, processorInputParams.AmountIn, err)
 							continue
 						}
-						approvalRequired, approvalAmountRequired, approvalGasLimit, l1ApprovalFee, err := r.requireApproval(ctx, input.SendType, &approvalContractAddress, processorInputParams)
+						approvalRequired, approvalAmountRequired, err := r.requireApproval(ctx, input.SendType, &approvalContractAddress, processorInputParams)
 						if err != nil {
 							appendProcessorErrorFn(pProcessor.Name(), input.SendType, processorInputParams.FromChain.ChainID, processorInputParams.ToChain.ChainID, processorInputParams.AmountIn, err)
 							continue
 						}
 
-						// TODO: keep l1 fees at 0 until we have the correct algorithm, as we do base fee x 2 that should cover the l1 fees
-						var l1FeeWei uint64 = 0
-						// if input.SendType.needL1Fee() {
-						// 	txInputData, err := pProcessor.PackTxInputData(processorInputParams)
-						// 	if err != nil {
-						// 		continue
-						// 	}
-
-						// 	l1FeeWei, _ = r.feesManager.GetL1Fee(ctx, network.ChainID, txInputData)
-						// }
+						var approvalGasLimit uint64
+						if approvalRequired {
+							if processorInputParams.TestsMode {
+								approvalGasLimit = processorInputParams.TestApprovalGasEstimation
+							} else {
+								approvalGasLimit, err = r.estimateGasForApproval(processorInputParams, &approvalContractAddress)
+								if err != nil {
+									appendProcessorErrorFn(pProcessor.Name(), input.SendType, processorInputParams.FromChain.ChainID, processorInputParams.ToChain.ChainID, processorInputParams.AmountIn, err)
+									continue
+								}
+							}
+						}
 
 						amountOut, err := pProcessor.CalculateAmountOut(processorInputParams)
 						if err != nil {
@@ -687,44 +725,7 @@ func (r *Router) resolveCandidates(ctx context.Context, input *requests.RouteInp
 							estimatedTime += 1
 						}
 
-						// calculate ETH fees
-						ethTotalFees := big.NewInt(0)
-						txFeeInWei := new(big.Int).Mul(maxFeesPerGas, big.NewInt(int64(gasLimit)))
-						ethTotalFees.Add(ethTotalFees, txFeeInWei)
-
-						txL1FeeInWei := big.NewInt(0)
-						if l1FeeWei > 0 {
-							txL1FeeInWei = big.NewInt(int64(l1FeeWei))
-							ethTotalFees.Add(ethTotalFees, txL1FeeInWei)
-						}
-
-						approvalFeeInWei := big.NewInt(0)
-						approvalL1FeeInWei := big.NewInt(0)
-						if approvalRequired {
-							approvalFeeInWei.Mul(maxFeesPerGas, big.NewInt(int64(approvalGasLimit)))
-							ethTotalFees.Add(ethTotalFees, approvalFeeInWei)
-
-							if l1ApprovalFee > 0 {
-								approvalL1FeeInWei = big.NewInt(int64(l1ApprovalFee))
-								ethTotalFees.Add(ethTotalFees, approvalL1FeeInWei)
-							}
-						}
-
-						// calculate required balances (bonder and token fees are already included in the amountIn by Hop bridge (once we include Celar we need to check how they handle the fees))
-						requiredNativeBalance := big.NewInt(0)
-						requiredTokenBalance := big.NewInt(0)
-
-						if token.IsNative() {
-							requiredNativeBalance.Add(requiredNativeBalance, amountOption.amount)
-							if !amountOption.subtractFees {
-								requiredNativeBalance.Add(requiredNativeBalance, ethTotalFees)
-							}
-						} else {
-							requiredTokenBalance.Add(requiredTokenBalance, amountOption.amount)
-							requiredNativeBalance.Add(requiredNativeBalance, ethTotalFees)
-						}
-
-						appendPathFn(&routes.Path{
+						path := &routes.Path{
 							ProcessorName:  pProcessor.Name(),
 							FromChain:      network,
 							ToChain:        dest,
@@ -734,36 +735,28 @@ func (r *Router) resolveCandidates(ctx context.Context, input *requests.RouteInp
 							AmountInLocked: amountOption.locked,
 							AmountOut:      (*hexutil.Big)(amountOut),
 
-							SuggestedLevelsForMaxFeesPerGas: fetchedFees.MaxFeesLevels,
-							MaxFeesPerGas:                   (*hexutil.Big)(maxFeesPerGas),
-
-							TxBaseFee:     (*hexutil.Big)(fetchedFees.BaseFee),
-							TxPriorityFee: (*hexutil.Big)(fetchedFees.MaxPriorityFeePerGas),
-							TxGasAmount:   gasLimit,
-							TxBonderFees:  (*hexutil.Big)(bonderFees),
-							TxTokenFees:   (*hexutil.Big)(tokenFees),
-
-							TxFee:   (*hexutil.Big)(txFeeInWei),
-							TxL1Fee: (*hexutil.Big)(txL1FeeInWei),
+							// set params that we don't want to be recalculated with every new block creation
+							TxGasAmount:  gasLimit,
+							TxBonderFees: (*hexutil.Big)(bonderFees),
+							TxTokenFees:  (*hexutil.Big)(tokenFees),
 
 							ApprovalRequired:        approvalRequired,
 							ApprovalAmountRequired:  (*hexutil.Big)(approvalAmountRequired),
 							ApprovalContractAddress: &approvalContractAddress,
-							ApprovalBaseFee:         (*hexutil.Big)(fetchedFees.BaseFee),
-							ApprovalPriorityFee:     (*hexutil.Big)(fetchedFees.MaxPriorityFeePerGas),
 							ApprovalGasAmount:       approvalGasLimit,
-
-							ApprovalFee:   (*hexutil.Big)(approvalFeeInWei),
-							ApprovalL1Fee: (*hexutil.Big)(approvalL1FeeInWei),
-
-							TxTotalFee: (*hexutil.Big)(ethTotalFees),
 
 							EstimatedTime: estimatedTime,
 
-							SubtractFees:          amountOption.subtractFees,
-							RequiredTokenBalance:  requiredTokenBalance,
-							RequiredNativeBalance: requiredNativeBalance,
-						})
+							SubtractFees: amountOption.subtractFees,
+						}
+
+						err = r.cacluateFees(ctx, path, fetchedFees, processorInputParams.TestsMode, processorInputParams.TestApprovalL1Fee)
+						if err != nil {
+							appendProcessorErrorFn(pProcessor.Name(), input.SendType, processorInputParams.FromChain.ChainID, processorInputParams.ToChain.ChainID, processorInputParams.AmountIn, err)
+							continue
+						}
+
+						appendPathFn(path)
 					}
 				}
 			}

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -74,6 +74,8 @@ type Router struct {
 	pathProcessors      map[string]pathprocessor.PathProcessor
 	scheduler           *async.Scheduler
 
+	activeBalanceMap sync.Map // map[string]*big.Int
+
 	activeRoutesMutex sync.Mutex
 	activeRoutes      *SuggestedRoutes
 
@@ -117,6 +119,12 @@ func (r *Router) GetFeesManager() *fees.FeeManager {
 
 func (r *Router) GetPathProcessors() map[string]pathprocessor.PathProcessor {
 	return r.pathProcessors
+}
+
+func (r *Router) SetTestBalanceMap(balanceMap map[string]*big.Int) {
+	for k, v := range balanceMap {
+		r.activeBalanceMap.Store(k, v)
+	}
 }
 
 func newSuggestedRoutes(
@@ -236,31 +244,29 @@ func (r *Router) SuggestedRoutes(ctx context.Context, input *requests.RouteInput
 		return nil, errors.CreateErrorResponseFromError(err)
 	}
 
-	balanceMap, err := r.getBalanceMapForTokenOnChains(ctx, input, selectedFromChains)
+	err = r.prepareBalanceMapForTokenOnChains(ctx, input, selectedFromChains)
 	// return only if there are no balances, otherwise try to resolve the candidates for chains we know the balances for
-	if len(balanceMap) == 0 {
+	noBalanceOnAnyChain := true
+	r.activeBalanceMap.Range(func(key, value interface{}) bool {
+		if value.(*big.Int).Cmp(pathprocessor.ZeroBigIntValue) > 0 {
+			noBalanceOnAnyChain = false
+			return false
+		}
+		return true
+	})
+	if noBalanceOnAnyChain {
 		if err != nil {
 			return nil, errors.CreateErrorResponseFromError(err)
 		}
-	} else {
-		noBalanceOnAnyChain := true
-		for _, value := range balanceMap {
-			if value.Cmp(pathprocessor.ZeroBigIntValue) > 0 {
-				noBalanceOnAnyChain = false
-				break
-			}
-		}
-		if noBalanceOnAnyChain {
-			return nil, ErrNoPositiveBalance
-		}
+		return nil, ErrNoPositiveBalance
 	}
 
-	candidates, processorErrors, err := r.resolveCandidates(ctx, input, selectedFromChains, selectedToChains, balanceMap)
+	candidates, processorErrors, err := r.resolveCandidates(ctx, input, selectedFromChains, selectedToChains)
 	if err != nil {
 		return nil, errors.CreateErrorResponseFromError(err)
 	}
 
-	suggestedRoutes, err = r.resolveRoutes(ctx, input, candidates, balanceMap)
+	suggestedRoutes, err = r.resolveRoutes(ctx, input, candidates)
 
 	if err == nil && (suggestedRoutes == nil || len(suggestedRoutes.Best) == 0) {
 		// No best route found, but no error given.
@@ -300,14 +306,15 @@ func (r *Router) SuggestedRoutes(ctx context.Context, input *requests.RouteInput
 	return suggestedRoutes, mapError(err)
 }
 
-// getBalanceMapForTokenOnChains returns the balance map for passed address, where the key is in format "chainID-tokenSymbol" and
+// prepareBalanceMapForTokenOnChains prepares the balance map for passed address, where the key is in format "chainID-tokenSymbol" and
 // value is the balance of the token. Native token (EHT) is always added to the balance map.
-func (r *Router) getBalanceMapForTokenOnChains(ctx context.Context, input *requests.RouteInputParams, selectedFromChains []*params.Network) (balanceMap map[string]*big.Int, err error) {
+func (r *Router) prepareBalanceMapForTokenOnChains(ctx context.Context, input *requests.RouteInputParams, selectedFromChains []*params.Network) (err error) {
 	if input.TestsMode {
-		return input.TestParams.BalanceMap, nil
+		for k, v := range input.TestParams.BalanceMap {
+			r.activeBalanceMap.Store(k, v)
+		}
+		return nil
 	}
-
-	balanceMap = make(map[string]*big.Int)
 
 	chainError := func(chainId uint64, token string, intErr error) {
 		if err == nil {
@@ -348,7 +355,7 @@ func (r *Router) getBalanceMapForTokenOnChains(ctx context.Context, input *reque
 		}
 		// add only if balance is not nil
 		if tokenBalance != nil {
-			balanceMap[makeBalanceKey(chain.ChainID, token.Symbol)] = tokenBalance
+			r.activeBalanceMap.Store(makeBalanceKey(chain.ChainID, token.Symbol), tokenBalance)
 		}
 
 		if token.IsNative() {
@@ -362,7 +369,7 @@ func (r *Router) getBalanceMapForTokenOnChains(ctx context.Context, input *reque
 		}
 		// add only if balance is not nil
 		if nativeBalance != nil {
-			balanceMap[makeBalanceKey(chain.ChainID, nativeToken.Symbol)] = nativeBalance
+			r.activeBalanceMap.Store(makeBalanceKey(chain.ChainID, nativeToken.Symbol), nativeBalance)
 		}
 	}
 
@@ -383,7 +390,7 @@ func (r *Router) getSelectedUnlockedChains(input *requests.RouteInputParams, pro
 }
 
 func (r *Router) getOptionsForAmoutToSplitAccrossChainsForProcessingChain(input *requests.RouteInputParams, amountToSplit *big.Int, processingChain *params.Network,
-	selectedFromChains []*params.Network, balanceMap map[string]*big.Int) map[uint64][]amountOption {
+	selectedFromChains []*params.Network) map[uint64][]amountOption {
 	selectedButNotLockedChains := r.getSelectedUnlockedChains(input, processingChain, selectedFromChains)
 
 	crossChainAmountOptions := make(map[uint64][]amountOption)
@@ -393,7 +400,12 @@ func (r *Router) getOptionsForAmoutToSplitAccrossChainsForProcessingChain(input 
 			tokenBalance *big.Int
 		)
 
-		if tokenBalance, ok = balanceMap[makeBalanceKey(chain.ChainID, input.TokenID)]; !ok {
+		value, ok := r.activeBalanceMap.Load(makeBalanceKey(chain.ChainID, input.TokenID))
+		if !ok {
+			continue
+		}
+		tokenBalance, ok = value.(*big.Int)
+		if !ok {
 			continue
 		}
 
@@ -419,8 +431,7 @@ func (r *Router) getOptionsForAmoutToSplitAccrossChainsForProcessingChain(input 
 	return crossChainAmountOptions
 }
 
-func (r *Router) getCrossChainsOptionsForSendingAmount(input *requests.RouteInputParams, selectedFromChains []*params.Network,
-	balanceMap map[string]*big.Int) map[uint64][]amountOption {
+func (r *Router) getCrossChainsOptionsForSendingAmount(input *requests.RouteInputParams, selectedFromChains []*params.Network) map[uint64][]amountOption {
 	// All we do in this block we're free to do, because of the validateInputData function which checks if the locked amount
 	// was properly set and if there is something unexpected it will return an error and we will not reach this point
 	finalCrossChainAmountOptions := make(map[uint64][]amountOption) // represents all possible amounts that can be sent from the "from" chain
@@ -471,7 +482,7 @@ func (r *Router) getCrossChainsOptionsForSendingAmount(input *requests.RouteInpu
 				// was properly set and if there is something unexpected it will return an error and we will not reach this point
 				amountToSplitAccrossChains := new(big.Int).Set(amountToSend)
 
-				crossChainAmountOptions := r.getOptionsForAmoutToSplitAccrossChainsForProcessingChain(input, amountToSend, selectedFromChain, selectedFromChains, balanceMap)
+				crossChainAmountOptions := r.getOptionsForAmoutToSplitAccrossChainsForProcessingChain(input, amountToSend, selectedFromChain, selectedFromChains)
 
 				// sum up all the allocated amounts accorss all chains
 				allocatedAmount := big.NewInt(0)
@@ -494,10 +505,9 @@ func (r *Router) getCrossChainsOptionsForSendingAmount(input *requests.RouteInpu
 	return finalCrossChainAmountOptions
 }
 
-func (r *Router) findOptionsForSendingAmount(input *requests.RouteInputParams, selectedFromChains []*params.Network,
-	balanceMap map[string]*big.Int) (map[uint64][]amountOption, error) {
+func (r *Router) findOptionsForSendingAmount(input *requests.RouteInputParams, selectedFromChains []*params.Network) (map[uint64][]amountOption, error) {
 
-	crossChainAmountOptions := r.getCrossChainsOptionsForSendingAmount(input, selectedFromChains, balanceMap)
+	crossChainAmountOptions := r.getCrossChainsOptionsForSendingAmount(input, selectedFromChains)
 
 	// filter out duplicates values for the same chain
 	for chainID, amountOptions := range crossChainAmountOptions {
@@ -540,14 +550,14 @@ func (r *Router) getSelectedChains(input *requests.RouteInputParams) (selectedFr
 }
 
 func (r *Router) resolveCandidates(ctx context.Context, input *requests.RouteInputParams, selectedFromChains []*params.Network,
-	selectedToChains []*params.Network, balanceMap map[string]*big.Int) (candidates routes.Route, processorErrors []*ProcessorError, err error) {
+	selectedToChains []*params.Network) (candidates routes.Route, processorErrors []*ProcessorError, err error) {
 	var (
 		testsMode = input.TestsMode && input.TestParams != nil
 		group     = async.NewAtomicGroup(ctx)
 		mu        sync.Mutex
 	)
 
-	crossChainAmountOptions, err := r.findOptionsForSendingAmount(input, selectedFromChains, balanceMap)
+	crossChainAmountOptions, err := r.findOptionsForSendingAmount(input, selectedFromChains)
 	if err != nil {
 		return nil, nil, errors.CreateErrorResponseFromError(err)
 	}
@@ -774,10 +784,13 @@ func (r *Router) resolveCandidates(ctx context.Context, input *requests.RouteInp
 	return candidates, processorErrors, nil
 }
 
-func (r *Router) checkBalancesForTheBestRoute(ctx context.Context, bestRoute routes.Route, balanceMap map[string]*big.Int) (hasPositiveBalance bool, err error) {
-	balanceMapCopy := walletCommon.CopyMapGeneric(balanceMap, func(v interface{}) interface{} {
-		return new(big.Int).Set(v.(*big.Int))
-	}).(map[string]*big.Int)
+func (r *Router) checkBalancesForTheBestRoute(ctx context.Context, bestRoute routes.Route) (hasPositiveBalance bool, err error) {
+	// make a copy of the active balance map
+	balanceMapCopy := make(map[string]*big.Int)
+	r.activeBalanceMap.Range(func(k, v interface{}) bool {
+		balanceMapCopy[k.(string)] = new(big.Int).Set(v.(*big.Int))
+		return true
+	})
 	if balanceMapCopy == nil {
 		return false, ErrCannotCheckBalance
 	}
@@ -830,7 +843,7 @@ func (r *Router) checkBalancesForTheBestRoute(ctx context.Context, bestRoute rou
 	return hasPositiveBalance, nil
 }
 
-func (r *Router) resolveRoutes(ctx context.Context, input *requests.RouteInputParams, candidates routes.Route, balanceMap map[string]*big.Int) (suggestedRoutes *SuggestedRoutes, err error) {
+func (r *Router) resolveRoutes(ctx context.Context, input *requests.RouteInputParams, candidates routes.Route) (suggestedRoutes *SuggestedRoutes, err error) {
 	var prices map[string]float64
 	if input.TestsMode {
 		prices = input.TestParams.TokenPrices
@@ -866,7 +879,7 @@ func (r *Router) resolveRoutes(ctx context.Context, input *requests.RouteInputPa
 	for len(allRoutes) > 0 {
 		bestRoute = routes.FindBestRoute(allRoutes, tokenPrice, nativeTokenPrice)
 		var hasPositiveBalance bool
-		hasPositiveBalance, err = r.checkBalancesForTheBestRoute(ctx, bestRoute, balanceMap)
+		hasPositiveBalance, err = r.checkBalancesForTheBestRoute(ctx, bestRoute)
 
 		if err != nil {
 			// If it's about transfer or bridge and there is more routes, but on the best (cheapest) one there is not enugh balance

--- a/services/wallet/router/router_helper.go
+++ b/services/wallet/router/router_helper.go
@@ -10,43 +10,46 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/status-im/status-go/contracts"
 	gaspriceoracle "github.com/status-im/status-go/contracts/gas-price-oracle"
 	"github.com/status-im/status-go/contracts/ierc20"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/wallet/bigint"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/router/fees"
 	"github.com/status-im/status-go/services/wallet/router/pathprocessor"
+	routs "github.com/status-im/status-go/services/wallet/router/routes"
 	"github.com/status-im/status-go/services/wallet/router/sendtype"
 	"github.com/status-im/status-go/services/wallet/token"
 )
 
 func (r *Router) requireApproval(ctx context.Context, sendType sendtype.SendType, approvalContractAddress *common.Address, params pathprocessor.ProcessorInputParams) (
-	bool, *big.Int, uint64, uint64, error) {
+	bool, *big.Int, error) {
 	if sendType.IsCollectiblesTransfer() || sendType.IsEnsTransfer() || sendType.IsStickersTransfer() {
-		return false, nil, 0, 0, nil
+		return false, nil, nil
 	}
 
 	if params.FromToken.IsNative() {
-		return false, nil, 0, 0, nil
+		return false, nil, nil
 	}
 
 	contractMaker, err := contracts.NewContractMaker(r.rpcClient)
 	if err != nil {
-		return false, nil, 0, 0, err
+		return false, nil, err
 	}
 
 	contract, err := contractMaker.NewERC20(params.FromChain.ChainID, params.FromToken.Address)
 	if err != nil {
-		return false, nil, 0, 0, err
+		return false, nil, err
 	}
 
 	if approvalContractAddress == nil || *approvalContractAddress == pathprocessor.ZeroAddress {
-		return false, nil, 0, 0, nil
+		return false, nil, nil
 	}
 
 	if params.TestsMode {
-		return true, params.AmountIn, params.TestApprovalGasEstimation, params.TestApprovalL1Fee, nil
+		return true, params.AmountIn, nil
 	}
 
 	allowance, err := contract.Allowance(&bind.CallOpts{
@@ -54,45 +57,65 @@ func (r *Router) requireApproval(ctx context.Context, sendType sendtype.SendType
 	}, params.FromAddr, *approvalContractAddress)
 
 	if err != nil {
-		return false, nil, 0, 0, err
+		return false, nil, err
 	}
 
 	if allowance.Cmp(params.AmountIn) >= 0 {
-		return false, nil, 0, 0, nil
+		return false, nil, nil
 	}
 
-	ethClient, err := r.rpcClient.EthClient(params.FromChain.ChainID)
-	if err != nil {
-		return false, nil, 0, 0, err
+	return true, params.AmountIn, nil
+}
+
+func (r *Router) packApprovalInputData(amountIn *big.Int, approvalContractAddress *common.Address) ([]byte, error) {
+	if approvalContractAddress == nil || *approvalContractAddress == pathprocessor.ZeroAddress {
+		return []byte{}, nil
 	}
 
 	erc20ABI, err := abi.JSON(strings.NewReader(ierc20.IERC20ABI))
 	if err != nil {
-		return false, nil, 0, 0, err
+		return []byte{}, err
 	}
 
-	data, err := erc20ABI.Pack("approve", approvalContractAddress, params.AmountIn)
+	return erc20ABI.Pack("approve", approvalContractAddress, amountIn)
+}
+
+func (r *Router) estimateGasForApproval(params pathprocessor.ProcessorInputParams, approvalContractAddress *common.Address) (uint64, error) {
+	data, err := r.packApprovalInputData(params.AmountIn, approvalContractAddress)
 	if err != nil {
-		return false, nil, 0, 0, err
+		return 0, err
 	}
 
-	estimate, err := ethClient.EstimateGas(context.Background(), ethereum.CallMsg{
+	ethClient, err := r.rpcClient.EthClient(params.FromChain.ChainID)
+	if err != nil {
+		return 0, err
+	}
+
+	return ethClient.EstimateGas(context.Background(), ethereum.CallMsg{
 		From:  params.FromAddr,
 		To:    &params.FromToken.Address,
 		Value: pathprocessor.ZeroBigIntValue,
 		Data:  data,
 	})
+}
+
+func (r *Router) calculateApprovalL1Fee(amountIn *big.Int, chainID uint64, approvalContractAddress *common.Address) (uint64, error) {
+	data, err := r.packApprovalInputData(amountIn, approvalContractAddress)
 	if err != nil {
-		return false, nil, 0, 0, err
+		return 0, err
 	}
 
-	// fetching l1 fee
+	ethClient, err := r.rpcClient.EthClient(chainID)
+	if err != nil {
+		return 0, err
+	}
+
 	var l1Fee uint64
-	oracleContractAddress, err := gaspriceoracle.ContractAddress(params.FromChain.ChainID)
+	oracleContractAddress, err := gaspriceoracle.ContractAddress(chainID)
 	if err == nil {
 		oracleContract, err := gaspriceoracle.NewGaspriceoracleCaller(oracleContractAddress, ethClient)
 		if err != nil {
-			return false, nil, 0, 0, err
+			return 0, err
 		}
 
 		callOpt := &bind.CallOpts{}
@@ -101,7 +124,7 @@ func (r *Router) requireApproval(ctx context.Context, sendType sendtype.SendType
 		l1Fee = l1FeeResult.Uint64()
 	}
 
-	return true, params.AmountIn, estimate, l1Fee, nil
+	return l1Fee, nil
 }
 
 func (r *Router) getERC1155Balance(ctx context.Context, network *params.Network, token *token.Token, account common.Address) (*big.Int, error) {
@@ -135,4 +158,97 @@ func (r *Router) getBalance(ctx context.Context, chainID uint64, token *token.To
 	}
 
 	return r.tokenManager.GetBalance(ctx, client, account, token.Address)
+}
+
+func (r *Router) cacluateFees(ctx context.Context, path *routs.Path, fetchedFees *fees.SuggestedFees, testsMode bool, testApprovalL1Fee uint64) (err error) {
+
+	var (
+		l1ApprovalFee uint64
+	)
+	if path.ApprovalRequired {
+		if testsMode {
+			l1ApprovalFee = testApprovalL1Fee
+		} else {
+			l1ApprovalFee, err = r.calculateApprovalL1Fee(path.AmountIn.ToInt(), path.FromChain.ChainID, path.ApprovalContractAddress)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// TODO: keep l1 fees at 0 until we have the correct algorithm, as we do base fee x 2 that should cover the l1 fees
+	var l1FeeWei uint64 = 0
+	// if input.SendType.needL1Fee() {
+	// 	txInputData, err := pProcessor.PackTxInputData(processorInputParams)
+	// 	if err != nil {
+	// 		continue
+	// 	}
+
+	// 	l1FeeWei, _ = r.feesManager.GetL1Fee(ctx, network.ChainID, txInputData)
+	// }
+
+	r.lastInputParamsMutex.Lock()
+	gasFeeMode := r.lastInputParams.GasFeeMode
+	r.lastInputParamsMutex.Unlock()
+	maxFeesPerGas := fetchedFees.FeeFor(gasFeeMode)
+
+	// calculate ETH fees
+	ethTotalFees := big.NewInt(0)
+	txFeeInWei := new(big.Int).Mul(maxFeesPerGas, big.NewInt(int64(path.TxGasAmount)))
+	ethTotalFees.Add(ethTotalFees, txFeeInWei)
+
+	txL1FeeInWei := big.NewInt(0)
+	if l1FeeWei > 0 {
+		txL1FeeInWei = big.NewInt(int64(l1FeeWei))
+		ethTotalFees.Add(ethTotalFees, txL1FeeInWei)
+	}
+
+	approvalFeeInWei := big.NewInt(0)
+	approvalL1FeeInWei := big.NewInt(0)
+	if path.ApprovalRequired {
+		approvalFeeInWei.Mul(maxFeesPerGas, big.NewInt(int64(path.ApprovalGasAmount)))
+		ethTotalFees.Add(ethTotalFees, approvalFeeInWei)
+
+		if l1ApprovalFee > 0 {
+			approvalL1FeeInWei = big.NewInt(int64(l1ApprovalFee))
+			ethTotalFees.Add(ethTotalFees, approvalL1FeeInWei)
+		}
+	}
+
+	// calculate required balances (bonder and token fees are already included in the amountIn by Hop bridge (once we include Celar we need to check how they handle the fees))
+	requiredNativeBalance := big.NewInt(0)
+	requiredTokenBalance := big.NewInt(0)
+
+	if path.FromToken.IsNative() {
+		requiredNativeBalance.Add(requiredNativeBalance, path.AmountIn.ToInt())
+		if !path.SubtractFees {
+			requiredNativeBalance.Add(requiredNativeBalance, ethTotalFees)
+		}
+	} else {
+		requiredTokenBalance.Add(requiredTokenBalance, path.AmountIn.ToInt())
+		requiredNativeBalance.Add(requiredNativeBalance, ethTotalFees)
+	}
+
+	// set the values
+	path.SuggestedLevelsForMaxFeesPerGas = fetchedFees.MaxFeesLevels
+	path.MaxFeesPerGas = (*hexutil.Big)(maxFeesPerGas)
+
+	path.TxBaseFee = (*hexutil.Big)(fetchedFees.BaseFee)
+	path.TxPriorityFee = (*hexutil.Big)(fetchedFees.MaxPriorityFeePerGas)
+
+	path.TxFee = (*hexutil.Big)(txFeeInWei)
+	path.TxL1Fee = (*hexutil.Big)(txL1FeeInWei)
+
+	path.ApprovalBaseFee = (*hexutil.Big)(fetchedFees.BaseFee)
+	path.ApprovalPriorityFee = (*hexutil.Big)(fetchedFees.MaxPriorityFeePerGas)
+
+	path.ApprovalFee = (*hexutil.Big)(approvalFeeInWei)
+	path.ApprovalL1Fee = (*hexutil.Big)(approvalL1FeeInWei)
+
+	path.TxTotalFee = (*hexutil.Big)(ethTotalFees)
+
+	path.RequiredTokenBalance = requiredTokenBalance
+	path.RequiredNativeBalance = requiredNativeBalance
+
+	return nil
 }

--- a/services/wallet/router/router_test.go
+++ b/services/wallet/router/router_test.go
@@ -268,7 +268,8 @@ func TestAmountOptions(t *testing.T) {
 			selectedFromChains, _, err := router.getSelectedChains(tt.input)
 			assert.NoError(t, err)
 
-			amountOptions, err := router.findOptionsForSendingAmount(tt.input, selectedFromChains, tt.input.TestParams.BalanceMap)
+			router.SetTestBalanceMap(tt.input.TestParams.BalanceMap)
+			amountOptions, err := router.findOptionsForSendingAmount(tt.input, selectedFromChains)
 			assert.NoError(t, err)
 
 			assert.Equal(t, len(tt.expectedAmountOptions), len(amountOptions))

--- a/services/wallet/router/router_updates.go
+++ b/services/wallet/router/router_updates.go
@@ -102,7 +102,9 @@ func (r *Router) subscribeForUdates(chainID uint64) error {
 							}
 						}
 
-						sendRouterResult(uuid, r.activeRoutes, nil)
+						_, err = r.checkBalancesForTheBestRoute(ctx, r.activeRoutes.Best)
+
+						sendRouterResult(uuid, r.activeRoutes, err)
 					}
 					r.activeRoutesMutex.Unlock()
 				}


### PR DESCRIPTION
Base branch is `router-clean-up`, please review it first. :)

Since we cannot use `SubscribeNewHead` call to be notified about every new block creation, cause our providers do not support that approach, we have to check for a new block creation in some intervals.

They are set here:
https://github.com/status-im/status-go/blob/6c3f87b5e18fabe697f485923ac574336a81b378/services/wallet/router/router_updates.go#L12-L18

Every time fees get recalculated a signal `"wallet.suggested.routes"` will be sent, and the uuid will be the same as when the client asked for routes. 

If the client calculating route was initiated calling `GetSuggestedRoutesAsync` or `GetSuggestedRoutes` then it should be closed calling `StopSuggestedRoutesAsyncCalcualtion` or `StopSuggestedRoutesCalcualtion`.

I've tested this in the desktop app, and it works nicely. Will open a PR for the desktop app later.