### PR TITLE
fix(wallet)_: fix single chain operation check

### DIFF
--- a/services/wallet/router/pathprocessor/constants.go
+++ b/services/wallet/router/pathprocessor/constants.go
@@ -32,3 +32,11 @@ const (
 	ProcessorENSPublicKeyName = "ENSPublicKey"
 	ProcessorStickersBuyName  = "StickersBuy"
 )
+
+func IsProcessorBridge(name string) bool {
+	return name == ProcessorBridgeHopName || name == ProcessorBridgeCelerName
+}
+
+func IsProcessorSwap(name string) bool {
+	return name == ProcessorSwapParaswapName
+}

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -317,24 +317,10 @@ func arrayContainsElement[T comparable](el T, arr []T) bool {
 	return false
 }
 
-func arraysWithSameElements[T comparable](ar1 []T, ar2 []T, isEqual func(T, T) bool) bool {
-	if len(ar1) != len(ar2) {
-		return false
-	}
-	for _, el := range ar1 {
-		if !arrayContainsElement(el, ar2) {
-			return false
-		}
-	}
-	return true
-}
-
-func sameSingleChainTransfer(fromChains []*params.Network, toChains []*params.Network) bool {
+func isSingleChainOperation(fromChains []*params.Network, toChains []*params.Network) bool {
 	return len(fromChains) == 1 &&
 		len(toChains) == 1 &&
-		arraysWithSameElements(fromChains, toChains, func(a, b *params.Network) bool {
-			return a.ChainID == b.ChainID
-		})
+		fromChains[0].ChainID == toChains[0].ChainID
 }
 
 type Router struct {

--- a/services/wallet/router/router_send_type.go
+++ b/services/wallet/router/router_send_type.go
@@ -109,13 +109,11 @@ func (s SendType) canUseProcessor(p pathprocessor.PathProcessor) bool {
 	switch s {
 	case Transfer:
 		return pathProcessorName == pathprocessor.ProcessorTransferName ||
-			pathProcessorName == pathprocessor.ProcessorBridgeHopName ||
-			pathProcessorName == pathprocessor.ProcessorBridgeCelerName
+			pathprocessor.IsProcessorBridge(pathProcessorName)
 	case Bridge:
-		return pathProcessorName == pathprocessor.ProcessorBridgeHopName ||
-			pathProcessorName == pathprocessor.ProcessorBridgeCelerName
+		return pathprocessor.IsProcessorBridge(pathProcessorName)
 	case Swap:
-		return pathProcessorName == pathprocessor.ProcessorSwapParaswapName
+		return pathprocessor.IsProcessorSwap(pathProcessorName)
 	case ERC721Transfer:
 		return pathProcessorName == pathprocessor.ProcessorERC721Name
 	case ERC1155Transfer:
@@ -131,10 +129,6 @@ func (s SendType) canUseProcessor(p pathprocessor.PathProcessor) bool {
 	default:
 		return true
 	}
-}
-
-func (s SendType) simpleTransfer(p pathprocessor.PathProcessor) bool {
-	return s == Transfer && p.Name() == pathprocessor.ProcessorTransferName
 }
 
 func (s SendType) processZeroAmountInProcessor(amountIn *big.Int, amountOut *big.Int, processorName string) bool {

--- a/services/wallet/router/router_v2.go
+++ b/services/wallet/router/router_v2.go
@@ -893,8 +893,8 @@ func (r *Router) resolveCandidates(ctx context.Context, input *RouteInputParams,
 						continue
 					}
 
-					// if just a single from and to chain is selected for transfer, we can skip the bridge as potential path
-					if !input.SendType.simpleTransfer(pProcessor) && sameSingleChainTransfer(selectedFromChains, selectedToChains) {
+					// if we're doing a single chain operation, we can skip bridge processors
+					if isSingleChainOperation(selectedFromChains, selectedToChains) && pathprocessor.IsProcessorBridge(pProcessor.Name()) {
 						continue
 					}
 


### PR DESCRIPTION
Fixed a couple of bugs, made some parts of the code tidier:
- Swap was broken, since [this check](https://github.com/status-im/status-go/pull/5784/files#diff-15991723d09f0a991be1caafa148d1840acd316437041021a7ac2ee392541da5L897) was skipping all processors other than Transfer for all single chain operations. We're now skipping all bridge processors for single chain operations instead.
- Parameter `isEqual` wasn't getting used [here](https://github.com/status-im/status-go/pull/5784/files#diff-941af95883f454369740b8d06f39c18f2bb31aec105e2509825ce141538968aeL320), so we were doing pointer comparison [here](https://github.com/status-im/status-go/pull/5784/files#diff-941af95883f454369740b8d06f39c18f2bb31aec105e2509825ce141538968aeL332). It was simplified to a`==` since we check the slices have a single element before anyway.
- Added functions to group all Bridge and Swap processors, avoiding duplication and easing maintainability when we add providers.