### PR TITLE
feat_: disable prior tx history fetching for all accounts

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1613,7 +1613,6 @@ func (b *GethStatusBackend) prepareSettings(request *requests.CreateAccount, inp
 	settings.TestNetworksEnabled = request.TestNetworksEnabled
 	if !input.restoringAccount {
 		settings.Mnemonic = &input.mnemonic
-		settings.OmitTransfersHistoryScan = true
 		// TODO(rasom): uncomment it as soon as address will be properly
 		// marked as shown on mobile client
 		//settings.MnemonicWasNotShown = true

--- a/appdatabase/migrations/bindata.go
+++ b/appdatabase/migrations/bindata.go
@@ -120,6 +120,7 @@
 // 1721215212_create_keycard_and_accounts.up.sql (725B)
 // 1721832718_rename_shard_test.up.sql (3.186kB)
 // 1722415278_remove_incorrectly_added_keycards.up.sql (67B)
+// 1724939813_remove_omit_transfers_history_scan_from_settings.up.sql (62B)
 // doc.go (94B)
 
 package migrations
@@ -2588,6 +2589,26 @@ func _1722415278_remove_incorrectly_added_keycardsUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1724939813_remove_omit_transfers_history_scan_from_settingsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\x28\x4e\x2d\x29\xc9\xcc\x4b\x2f\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\xc8\xcf\xcd\x2c\x89\x2f\x29\x4a\xcc\x2b\x4e\x4b\x2d\x2a\x8e\xcf\xc8\x2c\x2e\xc9\x2f\xaa\x8c\x2f\x4e\x4e\xcc\xb3\xe6\x02\x04\x00\x00\xff\xff\x7c\x2c\xfc\x27\x3e\x00\x00\x00")
+
+func _1724939813_remove_omit_transfers_history_scan_from_settingsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1724939813_remove_omit_transfers_history_scan_from_settingsUpSql,
+		"1724939813_remove_omit_transfers_history_scan_from_settings.up.sql",
+	)
+}
+
+func _1724939813_remove_omit_transfers_history_scan_from_settingsUpSql() (*asset, error) {
+	bytes, err := _1724939813_remove_omit_transfers_history_scan_from_settingsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1724939813_remove_omit_transfers_history_scan_from_settings.up.sql", size: 62, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x30, 0x96, 0x97, 0xae, 0x3b, 0x38, 0xc9, 0x4c, 0xcc, 0xbe, 0x5b, 0x67, 0x6d, 0xc9, 0xd7, 0xbd, 0xbe, 0xf5, 0x2, 0x54, 0x31, 0x38, 0x81, 0xfb, 0x49, 0x76, 0x8b, 0xa0, 0x56, 0xe, 0xb8, 0xbf}}
+	return a, nil
+}
+
 var _docGo = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x2c\xcb\x41\x0e\x02\x31\x08\x05\xd0\x7d\x4f\xf1\x2f\x00\xe8\xca\xc4\xc4\xc3\xa0\x43\x08\x19\x5b\xc6\x96\xfb\xc7\x4d\xdf\xfe\x5d\xfa\x39\xd5\x0d\xeb\xf7\x6d\x4d\xc4\xf3\xe9\x36\x6c\x6a\x19\x3c\xe9\x1d\xe3\xd0\x52\x50\xcf\xa3\xa2\xdb\xeb\xfe\xb8\x6d\xa0\xeb\x74\xf4\xf0\xa9\x15\x39\x16\x28\xc1\x2c\x7b\xb0\x27\x58\xda\x3f\x00\x00\xff\xff\x57\xd4\xd5\x90\x5e\x00\x00\x00")
 
 func docGoBytes() ([]byte, error) {
@@ -2819,6 +2840,7 @@ var _bindata = map[string]func() (*asset, error){
 	"1721215212_create_keycard_and_accounts.up.sql":                            _1721215212_create_keycard_and_accountsUpSql,
 	"1721832718_rename_shard_test.up.sql":                                      _1721832718_rename_shard_testUpSql,
 	"1722415278_remove_incorrectly_added_keycards.up.sql":                      _1722415278_remove_incorrectly_added_keycardsUpSql,
+	"1724939813_remove_omit_transfers_history_scan_from_settings.up.sql":       _1724939813_remove_omit_transfers_history_scan_from_settingsUpSql,
 	"doc.go": docGo,
 }
 
@@ -2988,6 +3010,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1721215212_create_keycard_and_accounts.up.sql":                            {_1721215212_create_keycard_and_accountsUpSql, map[string]*bintree{}},
 	"1721832718_rename_shard_test.up.sql":                                      {_1721832718_rename_shard_testUpSql, map[string]*bintree{}},
 	"1722415278_remove_incorrectly_added_keycards.up.sql":                      {_1722415278_remove_incorrectly_added_keycardsUpSql, map[string]*bintree{}},
+	"1724939813_remove_omit_transfers_history_scan_from_settings.up.sql":       {_1724939813_remove_omit_transfers_history_scan_from_settingsUpSql, map[string]*bintree{}},
 	"doc.go": {docGo, map[string]*bintree{}},
 }}
 

--- a/appdatabase/migrations/sql/1724939813_remove_omit_transfers_history_scan_from_settings.up.sql
+++ b/appdatabase/migrations/sql/1724939813_remove_omit_transfers_history_scan_from_settings.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings DROP COLUMN omit_transfers_history_scan;

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -420,7 +420,6 @@ func SaveAccountAndLogin(accountData, password, settingsJSON, configJSON, subacc
 	}
 
 	if *settings.Mnemonic != "" {
-		settings.OmitTransfersHistoryScan = true
 		settings.MnemonicWasNotShown = true
 	}
 

--- a/multiaccounts/settings/columns.go
+++ b/multiaccounts/settings/columns.go
@@ -496,11 +496,6 @@ var (
 			protobufType:      protobuf.SyncSetting_URL_UNFURLING_MODE,
 		},
 	}
-	OmitTransfersHistoryScan = SettingField{
-		reactFieldName: "omit-transfers-history-scan",
-		dBColumnName:   "omit_transfers_history_scan",
-		valueHandler:   BoolHandler,
-	}
 	MnemonicWasNotShown = SettingField{
 		reactFieldName: "mnemonic-was-not-shown?",
 		dBColumnName:   "mnemonic_was_not_shown",

--- a/multiaccounts/settings/database.go
+++ b/multiaccounts/settings/database.go
@@ -142,7 +142,6 @@ INSERT INTO settings (
   profile_pictures_show_to,
   profile_pictures_visibility,
   url_unfurling_mode,
-  omit_transfers_history_scan,
   mnemonic_was_not_shown,
   wallet_token_preferences_group_by_community,
   wallet_collectible_preferences_group_by_collection,
@@ -151,7 +150,7 @@ INSERT INTO settings (
   fleet
 ) VALUES (
 ?,?,?,?,?,?,?,?,?,?,?,?,?,?,
-?,?,?,?,?,?,?,?,?,'id',?,?,?,?,?,?,?,?,?,?,?)`,
+?,?,?,?,?,?,?,?,?,'id',?,?,?,?,?,?,?,?,?,?)`,
 		s.Address,
 		s.Currency,
 		s.CurrentNetwork,
@@ -179,7 +178,6 @@ INSERT INTO settings (
 		s.ProfilePicturesShowTo,
 		s.ProfilePicturesVisibility,
 		s.URLUnfurlingMode,
-		s.OmitTransfersHistoryScan,
 		s.MnemonicWasNotShown,
 		s.TokenGroupByCommunity,
 		s.CollectibleGroupByCollection,
@@ -388,7 +386,7 @@ func (db *Database) GetSettings() (Settings, error) {
 		waku_bloom_filter_mode, webview_allow_permission_requests, current_user_status, send_status_updates, gif_recents,
 		gif_favorites, opensea_enabled, last_backup, backup_enabled, telemetry_server_url, auto_message_enabled, gif_api_key,
 		test_networks_enabled, mutual_contact_enabled, profile_migration_needed, is_goerli_enabled, wallet_token_preferences_group_by_community, url_unfurling_mode,
-		omit_transfers_history_scan, mnemonic_was_not_shown, wallet_show_community_asset_when_sending_tokens, wallet_display_assets_below_balance,
+		mnemonic_was_not_shown, wallet_show_community_asset_when_sending_tokens, wallet_display_assets_below_balance,
 		wallet_display_assets_below_balance_threshold, wallet_collectible_preferences_group_by_collection, wallet_collectible_preferences_group_by_community, 
 		peer_syncing_enabled
 	FROM
@@ -467,7 +465,6 @@ func (db *Database) GetSettings() (Settings, error) {
 		&s.IsGoerliEnabled,
 		&s.TokenGroupByCommunity,
 		&s.URLUnfurlingMode,
-		&s.OmitTransfersHistoryScan,
 		&s.MnemonicWasNotShown,
 		&s.ShowCommunityAssetWhenSendingTokens,
 		&s.DisplayAssetsBelowBalance,

--- a/multiaccounts/settings/structs.go
+++ b/multiaccounts/settings/structs.go
@@ -150,12 +150,11 @@ type Settings struct {
 	MessagesFromContactsOnly  bool             `json:"messages-from-contacts-only"`
 	Mnemonic                  *string          `json:"mnemonic,omitempty"`
 	// NOTE(rasom): negation here because it safer/simpler to have false by default
-	MnemonicWasNotShown      bool             `json:"mnemonic-was-not-shown?,omitempty"`
-	MnemonicRemoved          bool             `json:"mnemonic-removed?,omitempty"`
-	OmitTransfersHistoryScan bool             `json:"omit-transfers-history-scan?,omitempty"`
-	MutualContactEnabled     bool             `json:"mutual-contact-enabled?"`
-	Name                     string           `json:"name,omitempty"`
-	Networks                 *json.RawMessage `json:"networks/networks"`
+	MnemonicWasNotShown  bool             `json:"mnemonic-was-not-shown?,omitempty"`
+	MnemonicRemoved      bool             `json:"mnemonic-removed?,omitempty"`
+	MutualContactEnabled bool             `json:"mutual-contact-enabled?"`
+	Name                 string           `json:"name,omitempty"`
+	Networks             *json.RawMessage `json:"networks/networks"`
 	// NotificationsEnabled indicates whether local notifications should be enabled (android only)
 	NotificationsEnabled bool             `json:"notifications-enabled?,omitempty"`
 	PhotoPath            string           `json:"photo-path"`

--- a/services/wallet/transfer/controller.go
+++ b/services/wallet/transfer/controller.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	statusaccounts "github.com/status-im/status-go/multiaccounts/accounts"
-	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/rpc/chain"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
@@ -120,21 +119,7 @@ func (c *Controller) CheckRecentHistory(chainIDs []uint64, accounts []common.Add
 		return nil
 	}
 
-	omitHistory := false
-	multiaccSettings, err := c.accountsDB.GetSettings()
-	if err != nil {
-		log.Error("Failed to get multiacc settings") // not critical
-	} else {
-		omitHistory = multiaccSettings.OmitTransfersHistoryScan
-	}
-
-	if omitHistory {
-		err := c.accountsDB.SaveSettingField(settings.OmitTransfersHistoryScan, false)
-		if err != nil {
-			return err
-		}
-	}
-
+	const omitHistory = true
 	c.reactor = NewReactor(c.db, c.blockDAO, c.blockRangesSeqDAO, c.accountsDB, c.TransferFeed, c.transactionManager,
 		c.pendingTxManager, c.tokenManager, c.balanceCacher, omitHistory, c.blockChainState)
 


### PR DESCRIPTION
This PR disables fetching of past transactions (prior to the addition of the account to Status) for all accounts. This used to be done only for newly-generated accounts, now it includes imported ones as well.
A related setting is removed as well.

This doesn't affect fetching transactions triggered from Status, since those are handled by the `TransactionWatcher`.

Also, external transactions are still fetched for blocks post account addition. This is just a quick win to reduce RPC calls by not adding the block range 0-CurrentBlock when we add the account.
![image](https://github.com/user-attachments/assets/6f246087-0b51-4614-a593-81f02896e33a)
 