### PR TITLE
feat_: accept community join request with mvds

### DIFF
--- a/protocol/common/raw_message.go
+++ b/protocol/common/raw_message.go
@@ -65,6 +65,7 @@ type RawMessage struct {
 	// don't wrap message into ProtocolMessage.
 	// when this is true, the message will not be resent via ResendTypeDataSync, but it's possible to
 	// resend it via ResendTypeRawMessage specified in ResendType
+	// MVDS only supports sending encrypted message.
 	SkipEncryptionLayer   bool
 	SendPushNotification  bool
 	MessageType           protobuf.ApplicationMetadataMessage_Type

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -3520,6 +3520,7 @@ func (m *Manager) HandleCommunityRequestToJoinResponse(signer *ecdsa.PublicKey, 
 
 	isControlNodeSigner := common.IsPubKeyEqual(community.ControlNode(), signer)
 	if !isControlNodeSigner {
+		m.logger.Debug("signer is not control node", zap.String("signer", common.PubkeyToHex(signer)), zap.String("controlNode", common.PubkeyToHex(community.ControlNode())))
 		return nil, ErrNotAuthorized
 	}
 

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2023,6 +2023,10 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 			Priority:            &common.HighPriority,
 		}
 
+		// Non-tokenized community treat community public key as the control node,
+		// tokenized community set control node to the public key of token owner.
+		// MVDS doesn't support custom sender, and use the identity key for signing messages,
+		// receiver will verify the message of community join response is signed by control node.
 		if !community.PublicKey().Equal(community.ControlNode()) {
 			rawMessage.ResendType = common.ResendTypeDataSync
 			rawMessage.SkipEncryptionLayer = false

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2010,10 +2010,10 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 			Payload:             payload,
 			Sender:              community.PrivateKey(),
 			CommunityID:         community.ID(),
-			SkipEncryptionLayer: true,
+			SkipEncryptionLayer: false,
 			MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE,
 			PubsubTopic:         shard.DefaultNonProtectedPubsubTopic(),
-			ResendType:          common.ResendTypeRawMessage,
+			ResendType:          common.ResendTypeDataSync,
 			ResendMethod:        common.ResendMethodSendPrivate,
 			Recipients:          []*ecdsa.PublicKey{pk},
 			Priority:            &common.HighPriority,
@@ -2026,10 +2026,6 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 
 		_, err = m.sender.SendPrivate(context.Background(), pk, rawMessage)
 		if err != nil {
-			return nil, err
-		}
-
-		if _, err = m.AddRawMessageToWatch(rawMessage); err != nil {
 			return nil, err
 		}
 	}

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2008,7 +2008,6 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 
 		rawMessage := &common.RawMessage{
 			Payload:             payload,
-			Sender:              community.PrivateKey(),
 			CommunityID:         community.ID(),
 			SkipEncryptionLayer: false,
 			MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE,


### PR DESCRIPTION
Make ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE message to use MVDS.

Important changes:
- [x] resend with mvds, and remove logic to watch raw_message for tokenized community.

Closes #
