### PR TITLE
fix!: ensure deleting message does not accidentally delete unrelated notifications

### DIFF
--- a/protocol/activity_center_persistence.go
+++ b/protocol/activity_center_persistence.go
@@ -61,7 +61,10 @@ func (db sqlitePersistence) DeleteActivityCenterNotificationForMessage(chatID st
 
 	for _, notification := range notifications {
 		if notification.LastMessage != nil && notification.LastMessage.ID == messageID {
-			withNotification(notification)
+			switch notification.Type {
+			case ActivityCenterNotificationTypeNewOneToOne, ActivityCenterNotificationTypeNewPrivateGroupChat:
+				withNotification(notification)
+			}
 		}
 
 		if notification.Message != nil && notification.Message.ID == messageID {

--- a/protocol/activity_center_persistence.go
+++ b/protocol/activity_center_persistence.go
@@ -60,13 +60,6 @@ func (db sqlitePersistence) DeleteActivityCenterNotificationForMessage(chatID st
 	}
 
 	for _, notification := range notifications {
-		if notification.LastMessage != nil && notification.LastMessage.ID == messageID {
-			switch notification.Type {
-			case ActivityCenterNotificationTypeNewOneToOne, ActivityCenterNotificationTypeNewPrivateGroupChat:
-				withNotification(notification)
-			}
-		}
-
 		if notification.Message != nil && notification.Message.ID == messageID {
 			withNotification(notification)
 		}

--- a/protocol/activity_center_persistence_test.go
+++ b/protocol/activity_center_persistence_test.go
@@ -218,7 +218,6 @@ func (s *ActivityCenterPersistenceTestSuite) Test_DeleteActivityCenterNotificati
 	s.Require().True(notif.Read, notif.ID)
 
 	// Check that notifications with LastMessage.ID == messages[1].ID will remain.
-	// Unless the notification is of type NewOneToOne or NewPrivateGroupChat.
 	notif, err = p.GetActivityCenterNotificationByID(nID3)
 	s.Require().NoError(err)
 	s.Require().NotNil(notif)
@@ -332,9 +331,9 @@ func (s *ActivityCenterPersistenceTestSuite) Test_DeleteActivityCenterNotificati
 		notif, err = p.GetActivityCenterNotificationByID(id)
 		s.Require().NoError(err)
 		s.Require().NotNil(notif)
-		s.Require().True(notif.Deleted)
-		s.Require().True(notif.Dismissed)
-		s.Require().True(notif.Read)
+		s.Require().False(notif.Deleted)
+		s.Require().False(notif.Dismissed)
+		s.Require().False(notif.Read)
 	}
 }
 

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -295,7 +295,7 @@ func (m *Messenger) createMessageNotification(chat *Chat, messageState *Received
 	notification := &ActivityCenterNotification{
 		ID:          types.FromHex(chat.ID),
 		Name:        chat.Name,
-		LastMessage: message,
+		Message:     message,
 		Type:        notificationType,
 		Author:      messageState.CurrentMessageState.Contact.ID,
 		Timestamp:   messageState.CurrentMessageState.WhisperTimestamp,


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/17052
status-mobile PR: https://github.com/status-im/status-mobile/pull/21157
this PR is a follow up to: https://github.com/status-im/status-go/pull/5520/

## The Issue

* This PR attempts to resolve an issue with notifications being deleted for users after another user deletes a message inside a community.
  * The cause of the issue seems to be related to how notifications can reference a message with the `LastMessage` field. And if a message is deleted from a community and the notifications reference that message via `LastMessage`, then the notifications are also removed/deleted
    * We can see where the notifications are removed via `LastMessage` here: https://github.com/status-im/status-go/blob/bd0464d192971a284f29cf64c97a1914124307fe/protocol/activity_center_persistence.go#L51-L70
 
### Some Context
* It seems that `LastMessage` has been used for some notifications to represent the message for a `NewOneToOne` or `NewPrivateGroupChat` notification. The other activity-center notification types do not seem to use `LastMessage` field directly
* It's also important to note that the `LastMessage` field for notifications is not stored with the notification data. It is actually derived/joined from the `chat` data via the `chatID`. 
* Based on the git commit history, it seem the `LatestMessage` checks for deleting notifications were originally meant for detecting the `NewOneToOne` and `NewPrivateGroupChat` notifications. Here's the link to the original PR: https://github.com/status-im/status-go/pull/2854
* For context here's the main usage of the notification LastMessage field in status-mobile: https://github.com/status-im/status-mobile/blob/seanstrom/skip-audio-player-tests/src/status_im/contexts/shell/activity_center/notification/contact_requests/view.cljs#L68
* And here's the the main usage of the notification LastMessage field in status-go: https://github.com/status-im/status-desktop/blob/7c184f35002886947493070400500e7e05de74b6/src/app_service/service/activity_center/dto/notification.nim#L134-L138

### This PR Solution
* This PR tries to transition the activity notifications for `NewOneToOne` and `NewPrivateGroupChats` to use the `Message` field instead of the `LastMessage` field, which should remove the need to delete notifications via the `LatestMessage` field.
* This PR also attempts to focus on detecting `NewOneToOne` or `NewPrivateGroupChat` notification types that have references to a deleted message via `LastMessage`.
  * It might not be necessary to still detect these edge cases.