### PR TITLE
chore_: refactor `TestMessengerCollapsedComunityCategoriesSuite`

### DIFF
--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"crypto/ecdsa"
+
 	"github.com/stretchr/testify/suite"
 
 	"go.uber.org/zap"

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -2,8 +2,6 @@ package protocol
 
 import (
 	"crypto/ecdsa"
-	"testing"
-
 	"github.com/stretchr/testify/suite"
 
 	"go.uber.org/zap"
@@ -18,10 +16,6 @@ import (
 )
 
 const DefaultProfileDisplayName = ""
-
-func TestMessengerCollapsedComunityCategoriesSuite(t *testing.T) {
-	suite.Run(t, new(MessengerCollapsedCommunityCategoriesSuite))
-}
 
 func (s *MessengerBaseTestSuite) SetupTest() {
 	s.logger = tt.MustCreateTestLogger()

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/settings"
-	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/tt"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
@@ -29,8 +28,7 @@ type testMessengerConfig struct {
 	unhandledMessagesTracker *unhandledMessagesTracker
 	messagesOrderController  *MessagesOrderController
 
-	extraOptions   []Option
-	createSettings bool
+	extraOptions []Option
 }
 
 func (tmc *testMessengerConfig) complete() error {
@@ -49,17 +47,6 @@ func (tmc *testMessengerConfig) complete() error {
 	if tmc.logger == nil {
 		logger := tt.MustCreateTestLogger()
 		tmc.logger = logger.Named(tmc.name)
-	}
-
-	if tmc.createSettings {
-		s := settings.Settings{
-			DisplayName:               DefaultProfileDisplayName,
-			ProfilePicturesShowTo:     1,
-			ProfilePicturesVisibility: 1,
-			URLUnfurlingMode:          settings.URLUnfurlingAlwaysAsk,
-		}
-		opt := WithAppSettings(s, params.NodeConfig{})
-		tmc.extraOptions = append(tmc.extraOptions, opt)
 	}
 
 	return nil
@@ -155,4 +142,13 @@ func (u *unhandledMessagesTracker) addMessage(msg *v1protocol.StatusMessage, err
 		err:           err,
 	}
 	u.messages[msgType] = append(u.messages[msgType], newMessage)
+}
+
+func newTestSettings() settings.Settings {
+	return settings.Settings{
+		DisplayName:               DefaultProfileDisplayName,
+		ProfilePicturesShowTo:     1,
+		ProfilePicturesVisibility: 1,
+		URLUnfurlingMode:          settings.URLUnfurlingAlwaysAsk,
+	}
 }

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts"
+	"github.com/status-im/status-go/multiaccounts/settings"
+	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/tt"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
@@ -27,7 +29,8 @@ type testMessengerConfig struct {
 	unhandledMessagesTracker *unhandledMessagesTracker
 	messagesOrderController  *MessagesOrderController
 
-	extraOptions []Option
+	extraOptions   []Option
+	createSettings bool
 }
 
 func (tmc *testMessengerConfig) complete() error {
@@ -46,6 +49,17 @@ func (tmc *testMessengerConfig) complete() error {
 	if tmc.logger == nil {
 		logger := tt.MustCreateTestLogger()
 		tmc.logger = logger.Named(tmc.name)
+	}
+
+	if tmc.createSettings {
+		s := settings.Settings{
+			DisplayName:               DefaultProfileDisplayName,
+			ProfilePicturesShowTo:     1,
+			ProfilePicturesVisibility: 1,
+			URLUnfurlingMode:          settings.URLUnfurlingAlwaysAsk,
+		}
+		opt := WithAppSettings(s, params.NodeConfig{})
+		tmc.extraOptions = append(tmc.extraOptions, opt)
 	}
 
 	return nil

--- a/protocol/messenger_collapsed_community_categories_test.go
+++ b/protocol/messenger_collapsed_community_categories_test.go
@@ -1,9 +1,11 @@
 package protocol
 
 import (
-	"github.com/status-im/status-go/protocol/requests"
-	"github.com/stretchr/testify/suite"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/status-im/status-go/protocol/requests"
 )
 
 func TestMessengerCollapsedCommunityCategoriesSuite(t *testing.T) {

--- a/protocol/messenger_collapsed_community_categories_test.go
+++ b/protocol/messenger_collapsed_community_categories_test.go
@@ -2,7 +2,13 @@ package protocol
 
 import (
 	"github.com/status-im/status-go/protocol/requests"
+	"github.com/stretchr/testify/suite"
+	"testing"
 )
+
+func TestMessengerCollapsedCommunityCategoriesSuite(t *testing.T) {
+	suite.Run(t, new(MessengerCollapsedCommunityCategoriesSuite))
+}
 
 type MessengerCollapsedCommunityCategoriesSuite struct {
 	MessengerBaseTestSuite

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -235,16 +235,16 @@ func (s *MessengerProfilePictureHandlerSuite) TestPictureInPrivateChatOneSided()
 }
 
 func (s *MessengerProfilePictureHandlerSuite) TestE2eSendingReceivingProfilePicture() {
-	profilePicShowSettings := map[string]settings.ProfilePicturesShowToType{
-		"ShowToContactsOnly": settings.ProfilePicturesShowToContactsOnly,
-		"ShowToEveryone":     settings.ProfilePicturesShowToEveryone,
-		"ShowToNone":         settings.ProfilePicturesShowToNone,
+	profilePicShowSettings := []settings.ProfilePicturesShowToType{
+		settings.ProfilePicturesShowToContactsOnly,
+		settings.ProfilePicturesShowToEveryone,
+		settings.ProfilePicturesShowToNone,
 	}
 
-	profilePicViewSettings := map[string]settings.ProfilePicturesVisibilityType{
-		"ViewFromContactsOnly": settings.ProfilePicturesVisibilityContactsOnly,
-		"ViewFromEveryone":     settings.ProfilePicturesVisibilityEveryone,
-		"ViewFromNone":         settings.ProfilePicturesVisibilityNone,
+	profilePicViewSettings := []settings.ProfilePicturesVisibilityType{
+		settings.ProfilePicturesVisibilityContactsOnly,
+		settings.ProfilePicturesVisibilityEveryone,
+		settings.ProfilePicturesVisibilityNone,
 	}
 
 	isContactFor := map[string][]bool{
@@ -259,15 +259,13 @@ func (s *MessengerProfilePictureHandlerSuite) TestE2eSendingReceivingProfilePict
 
 	// TODO see if possible to push each test scenario into a go routine
 	for _, cc := range chatContexts {
-		for sn, ss := range profilePicShowSettings {
-			for vn, vs := range profilePicViewSettings {
+		for _, ss := range profilePicShowSettings {
+			for _, vs := range profilePicViewSettings {
 				for _, ac := range isContactFor["alice"] {
 					for _, bc := range isContactFor["bob"] {
 						args := &e2eArgs{
 							cc: cc,
-							sn: sn,
 							ss: ss,
-							vn: vn,
 							vs: vs,
 							ac: ac,
 							bc: bc,
@@ -351,6 +349,8 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 		response, err := s.alice.SendChatMessage(context.Background(), message)
 		s.Require().NoError(err)
 		s.Require().NotNil(response)
+
+		s.Require().Len(response.messages, 1)
 
 	case privateChat:
 		aChat = CreateOneToOneChat(s.bob.IdentityPublicKeyString(), &s.bobKey.PublicKey, s.bob.transport)
@@ -444,21 +444,17 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 
 type e2eArgs struct {
 	cc ChatContext
-	sn string
 	ss settings.ProfilePicturesShowToType
-	vn string
 	vs settings.ProfilePicturesVisibilityType
 	ac bool
 	bc bool
 }
 
 func (args *e2eArgs) String() string {
-	return fmt.Sprintf("ChatContext: %s, ShowTo: %s, ShowSettings: %d, ViewTo: %s, ViewSettings: %d, AliceContact: %t, BobContact: %t",
+	return fmt.Sprintf("ChatContext: %s, ShowTo: %s, Visibility: %s, AliceContact: %t, BobContact: %t",
 		string(args.cc),
-		args.sn,
-		int(args.ss),
-		args.vn,
-		int(args.vs),
+		profilePicShowSettingsMap[args.ss],
+		profilePicViewSettingsMap[args.vs],
 		args.ac,
 		args.bc,
 	)
@@ -492,4 +488,16 @@ func (args *e2eArgs) resultExpectedVS() (bool, error) {
 	default:
 		return false, errors.New("unknown ProfilePicturesVisibilityType")
 	}
+}
+
+var profilePicShowSettingsMap = map[settings.ProfilePicturesShowToType]string{
+	settings.ProfilePicturesShowToContactsOnly: "ShowToContactsOnly",
+	settings.ProfilePicturesShowToEveryone:     "ShowToEveryone",
+	settings.ProfilePicturesShowToNone:         "ShowToNone",
+}
+
+var profilePicViewSettingsMap = map[settings.ProfilePicturesVisibilityType]string{
+	settings.ProfilePicturesVisibilityContactsOnly: "ViewFromContactsOnly",
+	settings.ProfilePicturesVisibilityEveryone:     "ViewFromEveryone",
+	settings.ProfilePicturesVisibilityNone:         "ViewFromNone",
 }

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -268,239 +269,16 @@ func (s *MessengerProfilePictureHandlerSuite) TestE2eSendingReceivingProfilePict
 			for vn, vs := range profilePicViewSettings {
 				for _, ac := range isContactFor["alice"] {
 					for _, bc := range isContactFor["bob"] {
-						s.logger.Debug("top of the loop")
-						s.SetupTest()
-						s.logger.Info("testing with criteria:",
-							zap.String("chat context type", string(cc)),
-							zap.String("profile picture Show Settings", sn),
-							zap.String("profile picture View Settings", vn),
-							zap.Bool("bob in Alice's Contacts", ac),
-							zap.Bool("alice in Bob's Contacts", bc),
-						)
-
-						expectPicture, err := resultExpected(ss, vs, ac, bc)
-						s.logger.Debug("expect to receive a profile pic?",
-							zap.Bool("result", expectPicture),
-							zap.Error(err))
-
-						// Setting up Bob
-						s.logger.Debug("Setting up test criteria for Bob")
-
-						s.logger.Debug("Save bob profile-pictures-visibility setting before")
-						err = s.bob.settings.SaveSettingField(settings.ProfilePicturesVisibility, vs)
-						s.Require().NoError(err)
-						s.logger.Debug("Save bob profile-pictures-visibility setting after")
-
-						s.logger.Debug("bob add contact before")
-						if bc {
-							s.logger.Debug("bob has contact to add")
-							_, err = s.bob.AddContact(context.Background(), &requests.AddContact{ID: s.generateKeyUID(&s.alice.identity.PublicKey)})
-							s.Require().NoError(err)
-							s.logger.Debug("bob add contact after")
+						args := &e2eArgs{
+							cc: cc,
+							sn: sn,
+							ss: ss,
+							vn: vn,
+							vs: vs,
+							ac: ac,
+							bc: bc,
 						}
-						s.logger.Debug("bob add contact after after")
-
-						// Create Bob's chats
-						switch cc {
-						case publicChat:
-							s.logger.Debug("making publicChats for bob")
-
-							// Bob opens up the public chat and joins it
-							bChat := CreatePublicChat("status", s.alice.transport)
-							err = s.bob.SaveChat(bChat)
-							s.Require().NoError(err)
-
-							_, err = s.bob.Join(bChat)
-							s.Require().NoError(err)
-						case privateChat:
-							s.logger.Debug("making privateChats for bob")
-
-							s.logger.Debug("Bob making one to one chat with alice")
-							bChat := CreateOneToOneChat(s.generateKeyUID(&s.aliceKey.PublicKey), &s.aliceKey.PublicKey, s.alice.transport)
-							s.logger.Debug("Bob saving one to one chat with alice")
-							err = s.bob.SaveChat(bChat)
-							s.Require().NoError(err)
-							s.logger.Debug("Bob saved one to one chat with alice")
-
-							s.logger.Debug("Bob joining one to one chat with alice")
-							_, err = s.bob.Join(bChat)
-							s.Require().NoError(err)
-							s.logger.Debug("Bob joined one to one chat with alice")
-						default:
-							s.Failf("unexpected chat context type", "%s", string(cc))
-						}
-
-						// Setting up Alice
-						s.logger.Debug("Setting up test criteria for Alice")
-
-						s.logger.Debug("Save alice profile-pictures-show-to setting before")
-						err = s.alice.settings.SaveSettingField(settings.ProfilePicturesShowTo, ss)
-						s.Require().NoError(err)
-						s.logger.Debug("Save alice profile-pictures-show-to setting after")
-
-						s.logger.Debug("alice add contact before")
-						if ac {
-							s.logger.Debug("alice has contact to add")
-							_, err = s.alice.AddContact(context.Background(), &requests.AddContact{ID: s.generateKeyUID(&s.bob.identity.PublicKey)})
-							s.Require().NoError(err)
-							s.logger.Debug("alice add contact after")
-						}
-						s.logger.Debug("alice add contact after after")
-
-						s.logger.Debug("generateAndStoreIdentityImages before")
-						iis := s.generateAndStoreIdentityImages(s.alice)
-						s.logger.Debug("generateAndStoreIdentityImages after")
-
-						s.logger.Debug("Before making chat for alice")
-						// Create chats
-						var aChat *Chat
-						switch cc {
-						case publicChat:
-							s.logger.Debug("making publicChats for alice")
-
-							// Alice opens creates a public chat
-							aChat = CreatePublicChat("status", s.alice.transport)
-							err = s.alice.SaveChat(aChat)
-							s.Require().NoError(err)
-
-						case privateChat:
-							s.logger.Debug("making privateChats for alice")
-
-							s.logger.Debug("Alice making one to one chat with bob")
-							aChat = CreateOneToOneChat(s.generateKeyUID(&s.bobKey.PublicKey), &s.bobKey.PublicKey, s.bob.transport)
-							s.logger.Debug("Alice saving one to one chat with bob")
-							err = s.alice.SaveChat(aChat)
-							s.Require().NoError(err)
-							s.logger.Debug("Alice saved one to one chat with bob")
-
-							s.logger.Debug("Alice joining one to one chat with bob")
-							_, err = s.alice.Join(aChat)
-							s.Require().NoError(err)
-							s.logger.Debug("Alice joined one to one chat with bob")
-
-							s.logger.Debug("alice before manually triggering publishContactCode")
-							err = s.alice.publishContactCode()
-							s.logger.Debug("alice after manually triggering publishContactCode",
-								zap.Error(err))
-							s.Require().NoError(err)
-						default:
-							s.Failf("unexpected chat context type", "%s", string(cc))
-						}
-
-						s.logger.Debug("Build and send a chat from alice")
-
-						// Alice sends a message to the public chat
-						message := buildTestMessage(*aChat)
-						response, err := s.alice.SendChatMessage(context.Background(), message)
-						s.Require().NoError(err)
-						s.Require().NotNil(response)
-
-						// Poll bob to see if he got the chatIdentity
-						// Retrieve ChatIdentity
-						var contacts []*Contact
-
-						s.logger.Debug("Checking Bob to see if he got the chatIdentity")
-						options := func(b *backoff.ExponentialBackOff) {
-							b.MaxElapsedTime = 2 * time.Second
-						}
-						err = tt.RetryWithBackOff(func() error {
-
-							response, err = s.bob.RetrieveAll()
-							if err != nil {
-								return err
-							}
-
-							contacts = response.Contacts
-							s.logger.Debug("RetryWithBackOff contact data", zap.Any("contacts", contacts))
-
-							if len(contacts) > 0 && len(contacts[0].Images) > 0 {
-								s.logger.Debug("", zap.Any("contacts", contacts))
-								return nil
-							}
-
-							return errors.New("no new contacts with images received")
-						}, options)
-
-						s.logger.Debug("Finished RetryWithBackOff got Bob",
-							zap.Any("contacts", contacts),
-							zap.Error(err))
-
-						if expectPicture {
-							s.logger.Debug("expecting a contact with images")
-							s.Require().NoError(err)
-							s.Require().NotNil(contacts)
-						} else {
-							s.logger.Debug("expecting no contacts with images")
-							s.Require().EqualError(err, "no new contacts with images received")
-							s.logger.Info("Completed testing with criteria:",
-								zap.String("chat context type", string(cc)),
-								zap.String("profile picture Show Settings", sn),
-								zap.String("profile picture View Settings", vn),
-								zap.Bool("bob in Alice's Contacts", ac),
-								zap.Bool("alice in Bob's Contacts", bc),
-							)
-							s.TearDownTest()
-							continue
-						}
-
-						s.logger.Debug("checking alice's contact")
-
-						// Check if alice's contact data with profile picture is there
-						var contact *Contact
-						for _, c := range contacts {
-							if c.ID == s.generateKeyUID(&s.alice.identity.PublicKey) {
-								contact = c
-							}
-						}
-						s.Require().NotNil(contact)
-
-						s.logger.Debug("checked alice's contact info all good")
-
-						// Check that Bob now has Alice's profile picture(s)
-						switch cc {
-						case publicChat:
-							// In public chat context we only need the images.SmallDimName, but also may have the large
-							s.Require().GreaterOrEqual(len(contact.Images), 1)
-
-							// Check if the result matches expectation
-							smImg, ok := contact.Images[images.SmallDimName]
-							s.Require().True(ok, "contact images must contain the images.SmallDimName")
-
-							for _, ii := range iis {
-								if ii.Name == images.SmallDimName {
-									s.Require().Equal(ii.Payload, smImg.Payload)
-								}
-							}
-						case privateChat:
-							s.Require().Equal(len(contact.Images), 2)
-							s.logger.Info("private chat chat images", zap.Any("iis", iis))
-
-							// Check if the result matches expectation
-							smImg, ok := contact.Images[images.SmallDimName]
-							s.Require().True(ok, "contact images must contain the images.SmallDimName")
-
-							lgImg, ok := contact.Images[images.LargeDimName]
-							s.Require().True(ok, "contact images must contain the images.LargeDimName")
-
-							for _, ii := range iis {
-								switch ii.Name {
-								case images.SmallDimName:
-									s.Require().Equal(ii.Payload, smImg.Payload)
-								case images.LargeDimName:
-									s.Require().Equal(ii.Payload, lgImg.Payload)
-								}
-							}
-
-						}
-
-						s.logger.Info("Completed testing with criteria:",
-							zap.String("chat context type", string(cc)),
-							zap.String("profile picture Show Settings", sn),
-							zap.String("profile picture View Settings", vn),
-							zap.Bool("bob in Alice's Contacts", ac),
-							zap.Bool("alice in Bob's Contacts", bc),
-						)
-						s.TearDownTest()
+						s.testE2eSendingReceivingProfilePicture(args)
 					}
 				}
 			}
@@ -510,15 +288,253 @@ func (s *MessengerProfilePictureHandlerSuite) TestE2eSendingReceivingProfilePict
 	s.SetupTest()
 }
 
-func resultExpected(ss settings.ProfilePicturesShowToType, vs settings.ProfilePicturesVisibilityType, ac, bc bool) (bool, error) {
-	switch ss {
+func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePicture(args *e2eArgs) {
+	s.SetupTest()
+	defer s.TearDownTest()
+
+	s.logger.Info("testing with criteria:", zap.Any("args", args))
+	defer s.logger.Info("Completed testing with criteria:", zap.Any("args", args))
+
+	expectPicture, err := args.resultExpected()
+	s.Require().NoError(err)
+
+	s.logger.Debug("expect to receive a profile pic?",
+		zap.Bool("result", expectPicture),
+		zap.Error(err))
+
+	// Setting up Bob
+	s.logger.Debug("Setting up test criteria for Bob")
+
+	s.logger.Debug("Save bob profile-pictures-visibility setting before")
+	err = s.bob.settings.SaveSettingField(settings.ProfilePicturesVisibility, args.vs)
+	s.Require().NoError(err)
+	s.logger.Debug("Save bob profile-pictures-visibility setting after")
+
+	s.logger.Debug("bob add contact before")
+	if args.bc {
+		s.logger.Debug("bob has contact to add")
+		_, err = s.bob.AddContact(context.Background(), &requests.AddContact{ID: s.generateKeyUID(&s.alice.identity.PublicKey)})
+		s.Require().NoError(err)
+		s.logger.Debug("bob add contact after")
+	}
+	s.logger.Debug("bob add contact after after")
+
+	// Create Bob's chats
+	switch args.cc {
+	case publicChat:
+		s.logger.Debug("making publicChats for bob")
+
+		// Bob opens up the public chat and joins it
+		bChat := CreatePublicChat("status", s.alice.transport)
+		err = s.bob.SaveChat(bChat)
+		s.Require().NoError(err)
+
+		_, err = s.bob.Join(bChat)
+		s.Require().NoError(err)
+	case privateChat:
+		s.logger.Debug("making privateChats for bob")
+
+		s.logger.Debug("Bob making one to one chat with alice")
+		bChat := CreateOneToOneChat(s.generateKeyUID(&s.aliceKey.PublicKey), &s.aliceKey.PublicKey, s.alice.transport)
+		s.logger.Debug("Bob saving one to one chat with alice")
+		err = s.bob.SaveChat(bChat)
+		s.Require().NoError(err)
+		s.logger.Debug("Bob saved one to one chat with alice")
+
+		s.logger.Debug("Bob joining one to one chat with alice")
+		_, err = s.bob.Join(bChat)
+		s.Require().NoError(err)
+		s.logger.Debug("Bob joined one to one chat with alice")
+	default:
+		s.Failf("unexpected chat context type", "%s", string(args.cc))
+	}
+
+	// Setting up Alice
+	s.logger.Debug("Setting up test criteria for Alice")
+
+	s.logger.Debug("Save alice profile-pictures-show-to setting before")
+	err = s.alice.settings.SaveSettingField(settings.ProfilePicturesShowTo, args.ss)
+	s.Require().NoError(err)
+	s.logger.Debug("Save alice profile-pictures-show-to setting after")
+
+	s.logger.Debug("alice add contact before")
+	if args.ac {
+		s.logger.Debug("alice has contact to add")
+		_, err = s.alice.AddContact(context.Background(), &requests.AddContact{ID: s.generateKeyUID(&s.bob.identity.PublicKey)})
+		s.Require().NoError(err)
+		s.logger.Debug("alice add contact after")
+	}
+	s.logger.Debug("alice add contact after after")
+
+	s.logger.Debug("generateAndStoreIdentityImages before")
+	iis := s.generateAndStoreIdentityImages(s.alice)
+	s.logger.Debug("generateAndStoreIdentityImages after")
+
+	s.logger.Debug("Before making chat for alice")
+	// Create chats
+	var aChat *Chat
+	switch args.cc {
+	case publicChat:
+		s.logger.Debug("making publicChats for alice")
+
+		// Alice opens creates a public chat
+		aChat = CreatePublicChat("status", s.alice.transport)
+		err = s.alice.SaveChat(aChat)
+		s.Require().NoError(err)
+
+	case privateChat:
+		s.logger.Debug("making privateChats for alice")
+
+		s.logger.Debug("Alice making one to one chat with bob")
+		aChat = CreateOneToOneChat(s.generateKeyUID(&s.bobKey.PublicKey), &s.bobKey.PublicKey, s.bob.transport)
+		s.logger.Debug("Alice saving one to one chat with bob")
+		err = s.alice.SaveChat(aChat)
+		s.Require().NoError(err)
+		s.logger.Debug("Alice saved one to one chat with bob")
+
+		s.logger.Debug("Alice joining one to one chat with bob")
+		_, err = s.alice.Join(aChat)
+		s.Require().NoError(err)
+		s.logger.Debug("Alice joined one to one chat with bob")
+
+		s.logger.Debug("alice before manually triggering publishContactCode")
+		err = s.alice.publishContactCode()
+		s.logger.Debug("alice after manually triggering publishContactCode",
+			zap.Error(err))
+		s.Require().NoError(err)
+	default:
+		s.Failf("unexpected chat context type", "%s", string(args.cc))
+	}
+
+	s.logger.Debug("Build and send a chat from alice")
+
+	// Alice sends a message to the public chat
+	message := buildTestMessage(*aChat)
+	response, err := s.alice.SendChatMessage(context.Background(), message)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+
+	// Poll bob to see if he got the chatIdentity
+	// Retrieve ChatIdentity
+	var contacts []*Contact
+
+	s.logger.Debug("Checking Bob to see if he got the chatIdentity")
+	options := func(b *backoff.ExponentialBackOff) {
+		b.MaxElapsedTime = 2 * time.Second
+	}
+	err = tt.RetryWithBackOff(func() error {
+
+		response, err = s.bob.RetrieveAll()
+		if err != nil {
+			return err
+		}
+
+		contacts = response.Contacts
+		s.logger.Debug("RetryWithBackOff contact data", zap.Any("contacts", contacts))
+
+		if len(contacts) > 0 && len(contacts[0].Images) > 0 {
+			s.logger.Debug("", zap.Any("contacts", contacts))
+			return nil
+		}
+
+		return errors.New("no new contacts with images received")
+	}, options)
+
+	s.logger.Debug("Finished RetryWithBackOff got Bob",
+		zap.Any("contacts", contacts),
+		zap.Error(err))
+
+	if !expectPicture {
+		s.logger.Debug("expecting no contacts with images")
+		s.Require().EqualError(err, "no new contacts with images received")
+		return
+	}
+
+	s.logger.Debug("expecting a contact with images")
+	s.Require().NoError(err)
+	s.Require().NotNil(contacts)
+
+	s.logger.Debug("checking alice's contact")
+
+	// Check if alice's contact data with profile picture is there
+	var contact *Contact
+	for _, c := range contacts {
+		if c.ID == s.generateKeyUID(&s.alice.identity.PublicKey) {
+			contact = c
+		}
+	}
+	s.Require().NotNil(contact)
+
+	s.logger.Debug("checked alice's contact info all good")
+
+	// Check that Bob now has Alice's profile picture(s)
+	switch args.cc {
+	case publicChat:
+		// In public chat context we only need the images.SmallDimName, but also may have the large
+		s.Require().GreaterOrEqual(len(contact.Images), 1)
+
+		// Check if the result matches expectation
+		smImg, ok := contact.Images[images.SmallDimName]
+		s.Require().True(ok, "contact images must contain the images.SmallDimName")
+
+		for _, ii := range iis {
+			if ii.Name == images.SmallDimName {
+				s.Require().Equal(ii.Payload, smImg.Payload)
+			}
+		}
+	case privateChat:
+		s.Require().Equal(len(contact.Images), 2)
+		s.logger.Info("private chat chat images", zap.Any("iis", iis))
+
+		// Check if the result matches expectation
+		smImg, ok := contact.Images[images.SmallDimName]
+		s.Require().True(ok, "contact images must contain the images.SmallDimName")
+
+		lgImg, ok := contact.Images[images.LargeDimName]
+		s.Require().True(ok, "contact images must contain the images.LargeDimName")
+
+		for _, ii := range iis {
+			switch ii.Name {
+			case images.SmallDimName:
+				s.Require().Equal(ii.Payload, smImg.Payload)
+			case images.LargeDimName:
+				s.Require().Equal(ii.Payload, lgImg.Payload)
+			}
+		}
+	}
+}
+
+type e2eArgs struct {
+	cc ChatContext
+	sn string
+	ss settings.ProfilePicturesShowToType
+	vn string
+	vs settings.ProfilePicturesVisibilityType
+	ac bool
+	bc bool
+}
+
+func (args *e2eArgs) String() string {
+	return fmt.Sprintf("ChatContext: %s, ShowTo: %s, ShowSettings: %d, ViewTo: %s, ViewSettings: %d, AliceContact: %t, BobContact: %t",
+		string(args.cc),
+		args.sn,
+		int(args.ss),
+		args.vn,
+		int(args.vs),
+		args.ac,
+		args.bc,
+	)
+}
+
+func (args *e2eArgs) resultExpected() (bool, error) {
+	switch args.ss {
 	case settings.ProfilePicturesShowToContactsOnly:
-		if ac {
-			return resultExpectedVS(vs, bc)
+		if args.ac {
+			return args.resultExpectedVS()
 		}
 		return false, nil
 	case settings.ProfilePicturesShowToEveryone:
-		return resultExpectedVS(vs, bc)
+		return args.resultExpectedVS()
 	case settings.ProfilePicturesShowToNone:
 		return false, nil
 	default:
@@ -526,15 +542,15 @@ func resultExpected(ss settings.ProfilePicturesShowToType, vs settings.ProfilePi
 	}
 }
 
-func resultExpectedVS(vs settings.ProfilePicturesVisibilityType, bc bool) (bool, error) {
-	switch vs {
+func (args *e2eArgs) resultExpectedVS() (bool, error) {
+	switch args.vs {
 	case settings.ProfilePicturesVisibilityContactsOnly:
 		return true, nil
 	case settings.ProfilePicturesVisibilityEveryone:
 		return true, nil
 	case settings.ProfilePicturesVisibilityNone:
 		// If we are contacts, we save the image regardless
-		return bc, nil
+		return args.bc, nil
 	default:
 		return false, errors.New("unknown ProfilePicturesVisibilityType")
 	}

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -67,18 +67,14 @@ func (s *MessengerProfilePictureHandlerSuite) SetupTest() {
 	aliceLogger := s.logger.Named("Alice messenger")
 	s.alice, err = newMessengerWithKey(s.shh, s.aliceKey, aliceLogger, []Option{})
 	s.Require().NoError(err)
-	s.logger.Debug("alice messenger created")
 
 	// Generate Bob Messenger
 	bobLogger := s.logger.Named("Bob messenger")
 	s.bob, err = newMessengerWithKey(s.shh, s.bobKey, bobLogger, []Option{})
 	s.Require().NoError(err)
-	s.logger.Debug("bob messenger created")
 
 	// Setup MultiAccount for Alice Messenger
-	s.logger.Debug("alice setupMultiAccount before")
 	s.setupMultiAccount(s.alice)
-	s.logger.Debug("alice setupMultiAccount after")
 }
 
 func (s *MessengerProfilePictureHandlerSuite) TearDownTest() {
@@ -430,7 +426,6 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 		}
 
 		contacts = response.Contacts
-		s.logger.Debug("RetryWithBackOff contact data", zap.Any("contacts", contacts))
 
 		if len(contacts) > 0 && len(contacts[0].Images) > 0 {
 			s.logger.Debug("", zap.Any("contacts", contacts))

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -86,12 +86,8 @@ func (s *MessengerProfilePictureHandlerSuite) TearDownTest() {
 	_ = s.logger.Sync()
 }
 
-func (s *MessengerProfilePictureHandlerSuite) generateKeyUID(publicKey *ecdsa.PublicKey) string {
-	return types.EncodeHex(crypto.FromECDSAPub(publicKey))
-}
-
 func (s *MessengerProfilePictureHandlerSuite) setupMultiAccount(m *Messenger) {
-	keyUID := s.generateKeyUID(&m.identity.PublicKey)
+	keyUID := m.IdentityPublicKeyString()
 	m.account = &multiaccounts.Account{KeyUID: keyUID}
 
 	err := m.multiAccounts.SaveAccount(multiaccounts.Account{Name: "string", KeyUID: keyUID})
@@ -99,7 +95,7 @@ func (s *MessengerProfilePictureHandlerSuite) setupMultiAccount(m *Messenger) {
 }
 
 func (s *MessengerProfilePictureHandlerSuite) generateAndStoreIdentityImages(m *Messenger) []images.IdentityImage {
-	keyUID := s.generateKeyUID(&m.identity.PublicKey)
+	keyUID := m.IdentityPublicKeyString()
 	iis := images.SampleIdentityImages()
 	s.Require().NoError(m.multiAccounts.StoreIdentityImages(keyUID, iis, false))
 
@@ -199,7 +195,7 @@ func (s *MessengerProfilePictureHandlerSuite) TestPictureInPrivateChatOneSided()
 	err = s.alice.settings.SaveSettingField(settings.ProfilePicturesVisibility, settings.ProfilePicturesShowToEveryone)
 	s.Require().NoError(err)
 
-	bChat := CreateOneToOneChat(s.generateKeyUID(&s.aliceKey.PublicKey), &s.aliceKey.PublicKey, s.alice.transport)
+	bChat := CreateOneToOneChat(s.alice.IdentityPublicKeyString(), &s.aliceKey.PublicKey, s.alice.transport)
 	err = s.bob.SaveChat(bChat)
 	s.Require().NoError(err)
 
@@ -309,7 +305,7 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 	s.logger.Debug("bob add contact before")
 	if args.bc {
 		s.logger.Debug("bob has contact to add")
-		_, err = s.bob.AddContact(context.Background(), &requests.AddContact{ID: s.generateKeyUID(&s.alice.identity.PublicKey)})
+		_, err = s.bob.AddContact(context.Background(), &requests.AddContact{ID: s.alice.IdentityPublicKeyString()})
 		s.Require().NoError(err)
 		s.logger.Debug("bob add contact after")
 	}
@@ -331,7 +327,7 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 		s.logger.Debug("making privateChats for bob")
 
 		s.logger.Debug("Bob making one to one chat with alice")
-		bChat := CreateOneToOneChat(s.generateKeyUID(&s.aliceKey.PublicKey), &s.aliceKey.PublicKey, s.alice.transport)
+		bChat := CreateOneToOneChat(s.alice.IdentityPublicKeyString(), &s.aliceKey.PublicKey, s.alice.transport)
 		s.logger.Debug("Bob saving one to one chat with alice")
 		err = s.bob.SaveChat(bChat)
 		s.Require().NoError(err)
@@ -356,7 +352,7 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 	s.logger.Debug("alice add contact before")
 	if args.ac {
 		s.logger.Debug("alice has contact to add")
-		_, err = s.alice.AddContact(context.Background(), &requests.AddContact{ID: s.generateKeyUID(&s.bob.identity.PublicKey)})
+		_, err = s.alice.AddContact(context.Background(), &requests.AddContact{ID: s.bob.IdentityPublicKeyString()})
 		s.Require().NoError(err)
 		s.logger.Debug("alice add contact after")
 	}
@@ -382,7 +378,7 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 		s.logger.Debug("making privateChats for alice")
 
 		s.logger.Debug("Alice making one to one chat with bob")
-		aChat = CreateOneToOneChat(s.generateKeyUID(&s.bobKey.PublicKey), &s.bobKey.PublicKey, s.bob.transport)
+		aChat = CreateOneToOneChat(s.bob.IdentityPublicKeyString(), &s.bobKey.PublicKey, s.bob.transport)
 		s.logger.Debug("Alice saving one to one chat with bob")
 		err = s.alice.SaveChat(aChat)
 		s.Require().NoError(err)
@@ -454,7 +450,7 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 	// Check if alice's contact data with profile picture is there
 	var contact *Contact
 	for _, c := range contacts {
-		if c.ID == s.generateKeyUID(&s.alice.identity.PublicKey) {
+		if c.ID == s.alice.IdentityPublicKeyString() {
 			contact = c
 		}
 	}

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/status-im/status-go/protocol/tt"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 	"github.com/status-im/status-go/wakuv2"
-	"github.com/waku-org/go-waku/waku/v2/api/publish"
 )
 
 var (

--- a/wakuv2/common/filter_test.go
+++ b/wakuv2/common/filter_test.go
@@ -11,11 +11,12 @@ import (
 	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/waku-org/go-waku/waku/v2/payload"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 )
 
 const testShard = "/waku/2/rs/16/32"


### PR DESCRIPTION
Initially i tried to figure out the culprit of `TestE2eSendingReceivingProfilePicture` and improve it.
But I couldn't make it faster yet, so for now just it's just a test refactoring 😐

Though I believe it's more readable and usable now 🙂 

You can review by commits, if you wish to see the logic of changes.

-----

Also moved `TestMessengerCollapsedComunityCategoriesSuite` to the right place.