### PR TITLE
fix_: nightly test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,6 @@ test-unit: export UNIT_TEST_USE_DEVELOPMENT_LOGGER ?= true
 test-unit: export UNIT_TEST_REPORT_CODECLIMATE ?= false
 test-unit: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./... | grep -E '/waku(/.*|$$)|/wakuv2(/.*|$$)') \
 	$(call sh, go list ./... | \
-	grep -v '.*/protocol$$' | \
 	grep -v /vendor | \
 	grep -v /t/e2e | \
 	grep -v /t/benchmarks | \

--- a/Makefile
+++ b/Makefile
@@ -361,6 +361,7 @@ docker-test: ##@tests Run tests in a docker container with golang.
 test: test-unit ##@tests Run basic, short tests during development
 
 test-unit: export BUILD_TAGS ?=
+test-unit: export UNIT_TEST_DRY_RUN ?= false
 test-unit: export UNIT_TEST_COUNT ?= 1
 test-unit: export UNIT_TEST_FAILFAST ?= true
 test-unit: export UNIT_TEST_RERUN_FAILS ?= true

--- a/Makefile
+++ b/Makefile
@@ -367,14 +367,11 @@ test-unit: export UNIT_TEST_FAILFAST ?= true
 test-unit: export UNIT_TEST_RERUN_FAILS ?= true
 test-unit: export UNIT_TEST_USE_DEVELOPMENT_LOGGER ?= true
 test-unit: export UNIT_TEST_REPORT_CODECLIMATE ?= false
-test-unit: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./... | grep -E '/waku(/.*|$$)|/wakuv2(/.*|$$)') \
-	$(call sh, go list ./... | \
+test-unit: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./... | \
 	grep -v /vendor | \
 	grep -v /t/e2e | \
 	grep -v /t/benchmarks | \
-	grep -v /transactions/fake | \
-	grep -E -v '/waku(/.*|$$)' | \
-	grep -E -v '/wakuv2(/.*|$$)')
+	grep -v /transactions/fake)
 test-unit: ##@tests Run unit and integration tests
 	./_assets/scripts/run_unit_tests.sh
 

--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,7 @@ test-unit: export UNIT_TEST_USE_DEVELOPMENT_LOGGER ?= true
 test-unit: export UNIT_TEST_REPORT_CODECLIMATE ?= false
 test-unit: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./... | grep -E '/waku(/.*|$$)|/wakuv2(/.*|$$)') \
 	$(call sh, go list ./... | \
+	grep -v '.*/protocol$$' | \
 	grep -v /vendor | \
 	grep -v /t/e2e | \
 	grep -v /t/benchmarks | \

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -164,7 +164,7 @@ pipeline {
               nix.shell('make test-unit V=1', pure: false)
             }
             sh "mv c.out test-coverage.out"
-            archiveArtifacts('test-coverage.out, coverage/codeclimate.json, test-coverage.html')
+            archiveArtifacts('test-coverage.out, coverage/codeclimate.json, test-coverage.html, coverage_merged.out')
           }
         }
       } }
@@ -181,7 +181,7 @@ pipeline {
         env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText"
 
         if (isTestNightlyJob()) {
-          archiveArtifacts('report_*.xml, test_*.log, *.coverage.out')
+          archiveArtifacts('report_*.xml, test_*.log, exit_code_*.txt, *.coverage.out')
         }
         if (params.UNIT_TEST_RERUN_FAILS) {
           def rerunReports = findFiles(glob: 'report_rerun_fails_*.txt')
@@ -190,7 +190,7 @@ pipeline {
           }
         }
         junit(
-          testResults: 'report.xml',
+          testResults: 'report_*.xml',
           skipOldReports: true,
           skipPublishingChecks: true,
           skipMarkingBuildUnstable: true
@@ -210,7 +210,7 @@ pipeline {
     failure { 
       script { 
         github.notifyPR(false) 
-        archiveArtifacts('test.log')
+        archiveArtifacts('**/test_*.log')
       }
     }
     cleanup {

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -181,7 +181,7 @@ pipeline {
         env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText"
 
         if (isTestNightlyJob()) {
-          archiveArtifacts('report_*.xml, test_*.log, exit_code_*.txt, *.coverage.out')
+          archiveArtifacts('report_*.xml, test_*.log, test-coverage.html, test-coverage.out, coverage/codeclimate.json')
         }
         if (params.UNIT_TEST_RERUN_FAILS) {
           def rerunReports = findFiles(glob: 'report_rerun_fails_*.txt')

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -35,6 +35,11 @@ pipeline {
       defaultValue: true,
       description: 'Should the job report test coverage to CodeClimate?'
     )
+    booleanParam(
+      name: 'UNIT_TEST_DRY_RUN',
+      defaultValue: false,
+      description: 'Should the job report ignore the actual test run and just print the test plan?'
+    )
   }
 
   options {
@@ -72,6 +77,7 @@ pipeline {
     UNIT_TEST_RERUN_FAILS =            "${params.UNIT_TEST_RERUN_FAILS}"
     UNIT_TEST_USE_DEVELOPMENT_LOGGER = "${params.UNIT_TEST_USE_DEVELOPMENT_LOGGER}"
     UNIT_TEST_REPORT_CODECLIMATE =     "${params.UNIT_TEST_REPORT_CODECLIMATE}"
+    UNIT_TEST_DRY_RUN =                "${params.UNIT_TEST_DRY_RUN}"
   }
 
   stages {

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -181,12 +181,12 @@ pipeline {
         env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText"
 
         if (isTestNightlyJob()) {
-          archiveArtifacts('report.xml, test.log')
+          archiveArtifacts('report_*.xml, test_*.log')
         }
         if (params.UNIT_TEST_RERUN_FAILS) {
-          def rerunReports = findFiles(glob: 'report_rerun_fails.txt')
+          def rerunReports = findFiles(glob: 'report_rerun_fails_*.txt')
           if (rerunReports.length > 0) {
-            archiveArtifacts('report_rerun_fails.txt')
+            archiveArtifacts('report_rerun_fails_*.txt')
           }
         }
         junit(

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -181,7 +181,7 @@ pipeline {
         env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText"
 
         if (isTestNightlyJob()) {
-          archiveArtifacts('report_*.xml, test_*.log')
+          archiveArtifacts('report_*.xml, test_*.log, *.coverage.out')
         }
         if (params.UNIT_TEST_RERUN_FAILS) {
           def rerunReports = findFiles(glob: 'report_rerun_fails_*.txt')

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -94,8 +94,8 @@ rm -rf ./**/*.coverage.out
 
 echo -e "${GRN}Testing HEAD:${RST} $(git rev-parse HEAD)"
 
-DEFAULT_TIMEOUT_MINUTES=3
-PROTOCOL_TIMEOUT_MINUTES=40
+DEFAULT_TIMEOUT_MINUTES=5
+PROTOCOL_TIMEOUT_MINUTES=45
 if [[ "${UNIT_TEST_PACKAGES}" == *"github.com/status-im/status-go/protocol"* ]]; then
   HAS_PROTOCOL_PACKAGE=true
 fi

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -47,6 +47,14 @@ run_test_for_packages() {
   local exit_code_file="exit_code_${iteration}.txt"
   local timeout="$(( single_timeout * count))m"
 
+  if [[ "${UNIT_TEST_DRY_RUN}" == 'true' ]]; then
+    echo -e "${GRN}Dry run ${iteration}. message:${RST} ${log_message}\n"\
+    "${YLW}Dry run ${iteration}. packages:${RST} ${packages}\n"\
+    "${YLW}Dry run ${iteration}. count:${RST} ${count}\n"\
+    "${YLW}Dry run ${iteration}. timeout:${RST} ${timeout}"
+    return 0
+  fi
+
   echo -e "${GRN}Testing:${RST} ${log_message}. Iteration ${iteration}. -test.count=${count}. Timeout: ${timeout}"
 
   gotestsum_flags="${GOTESTSUM_EXTRAFLAGS}"

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -96,17 +96,19 @@ echo -e "${GRN}Testing HEAD:${RST} $(git rev-parse HEAD)"
 
 DEFAULT_TIMEOUT_MINUTES=5
 PROTOCOL_TIMEOUT_MINUTES=45
-if [[ "${UNIT_TEST_PACKAGES}" == *"github.com/status-im/status-go/protocol"* ]]; then
-  HAS_PROTOCOL_PACKAGE=true
+
+HAS_PROTOCOL_PACKAGE=true
+if [[ $(echo "${UNIT_TEST_PACKAGES}" | grep -E '.*/protocol\s+') == "" ]]; then
+  HAS_PROTOCOL_PACKAGE=false
 fi
 
-if [[ $HAS_PROTOCOL_PACKAGE != 'true' ]]; then
+if [[ $HAS_PROTOCOL_PACKAGE == 'false' ]]; then
   # This is the default single-line flow for testing all packages
   # The `else` branch is temporary and will be removed once the `protocol` package runtime is optimized.
   run_test_for_packages "${UNIT_TEST_PACKAGES}" "0" "${UNIT_TEST_COUNT}" "${DEFAULT_TIMEOUT_MINUTES}" "All packages"
 else
   # Spawn a process to test all packages except `protocol`
-  UNIT_TEST_PACKAGES=$(echo "${UNIT_TEST_PACKAGES}" | grep -v '.*/protocol$$')
+  UNIT_TEST_PACKAGES=$(echo "${UNIT_TEST_PACKAGES}" | grep -v '.*/protocol\s+')
   run_test_for_packages "${UNIT_TEST_PACKAGES}" "0" "${UNIT_TEST_COUNT}" "${DEFAULT_TIMEOUT_MINUTES}" "All packages except 'protocol'" &
 
   # Spawn separate processes to run `protocol` package

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -106,7 +106,7 @@ if [[ $HAS_PROTOCOL_PACKAGE != 'true' ]]; then
   run_test_for_packages "${UNIT_TEST_PACKAGES}" "0" "${UNIT_TEST_COUNT}" "${DEFAULT_TIMEOUT_MINUTES}" "All packages"
 else
   # Spawn a process to test all packages except `protocol`
-  UNIT_TEST_PACKAGES=$(echo "${UNIT_TEST_PACKAGES}" | sed 's/github.com\/status-im\/status-go\/protocol//g')
+  UNIT_TEST_PACKAGES=$(echo "${UNIT_TEST_PACKAGES}" | grep -v '.*/protocol$$')
   run_test_for_packages "${UNIT_TEST_PACKAGES}" "0" "${UNIT_TEST_COUNT}" "${DEFAULT_TIMEOUT_MINUTES}" "All packages except 'protocol'" &
 
   # Spawn separate processes to run `protocol` package

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -106,7 +106,7 @@ DEFAULT_TIMEOUT_MINUTES=5
 PROTOCOL_TIMEOUT_MINUTES=45
 
 HAS_PROTOCOL_PACKAGE=true
-if [[ $(echo "${UNIT_TEST_PACKAGES}" | grep -E '.*/protocol\s+') == "" ]]; then
+if [[ $(echo "${UNIT_TEST_PACKAGES}" | grep -E '\s?\S+protocol\s+') == "" ]]; then
   HAS_PROTOCOL_PACKAGE=false
 fi
 
@@ -116,8 +116,8 @@ if [[ $HAS_PROTOCOL_PACKAGE == 'false' ]]; then
   run_test_for_packages "${UNIT_TEST_PACKAGES}" "0" "${UNIT_TEST_COUNT}" "${DEFAULT_TIMEOUT_MINUTES}" "All packages"
 else
   # Spawn a process to test all packages except `protocol`
-  UNIT_TEST_PACKAGES=$(echo "${UNIT_TEST_PACKAGES}" | grep -v '.*/protocol\s+')
-  run_test_for_packages "${UNIT_TEST_PACKAGES}" "0" "${UNIT_TEST_COUNT}" "${DEFAULT_TIMEOUT_MINUTES}" "All packages except 'protocol'" &
+  UNIT_TEST_PACKAGES_FILTERED=$(echo "${UNIT_TEST_PACKAGES}" | tr ' ' '\n' | grep -v '/protocol$' | tr '\n' ' ')
+  run_test_for_packages "${UNIT_TEST_PACKAGES_FILTERED}" "0" "${UNIT_TEST_COUNT}" "${DEFAULT_TIMEOUT_MINUTES}" "All packages except 'protocol'" &
 
   # Spawn separate processes to run `protocol` package
   for ((i=1; i<=UNIT_TEST_COUNT; i++)); do

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -118,17 +118,23 @@ else
 fi
 
 # Gather test coverage results
+echo "Gathering test coverage results"
 rm -f c.out c-full.out
-go run ./cmd/test-coverage-utils/gocovmerge.go $(find -iname "*.coverage.out") >> c-full.out
+coverage_reports=$(find . -iname "*.coverage.out")
+echo "Found reports: ${coverage_reports}"
+go run ./cmd/test-coverage-utils/gocovmerge.go ${coverage_reports} >> c-full.out
 
 # Filter out test coverage for packages in ./cmd
+echo "Filtering out test coverage for packages in ./cmd"
 grep -v '^github.com/status-im/status-go/cmd/' c-full.out > c.out
 
 # Generate HTML coverage report
+echo "Generating HTML coverage report"
 go tool cover -html c.out -o test-coverage.html
 
 # Upload coverage report to CodeClimate
 if [[ $UNIT_TEST_REPORT_CODECLIMATE == 'true' ]]; then
+  echo "Uploading coverage report to CodeClimate"
   # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
   GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$')
   cc-test-reporter format-coverage --prefix=github.com/status-im/status-go # To generate 'coverage/codeclimate.json'
@@ -138,6 +144,7 @@ fi
 # Generate report with test stats
 shopt -s globstar nullglob # Enable recursive globbing
 if [[ "${UNIT_TEST_COUNT}" -gt 1 ]]; then
+  echo "Generating report with test stats"
   for exit_code_file in "${GIT_ROOT}"/**/exit_code_*.txt; do
     read exit_code < "${exit_code_file}"
     if [[ "${exit_code}" -ne 0 ]]; then
@@ -147,3 +154,5 @@ if [[ "${UNIT_TEST_COUNT}" -gt 1 ]]; then
     fi
   done
 fi
+
+echo "${GRN}Testing finished${RST}"

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -119,18 +119,19 @@ fi
 
 # Gather test coverage results
 echo "Gathering test coverage results"
-rm -f c.out c-full.out
+merged_coverage_report="coverage_merged.out"
+final_coverage_report="c.out" # Name expected by cc-test-reporter
 coverage_reports=$(find . -iname "*.coverage.out")
-echo "Found reports: ${coverage_reports}"
-go run ./cmd/test-coverage-utils/gocovmerge.go ${coverage_reports} >> c-full.out
+rm -f ${final_coverage_report} ${merged_coverage_report}
+echo $coverage_reports | xargs go run ./cmd/test-coverage-utils/gocovmerge.go >> ${merged_coverage_report}
 
 # Filter out test coverage for packages in ./cmd
 echo "Filtering out test coverage for packages in ./cmd"
-grep -v '^github.com/status-im/status-go/cmd/' c-full.out > c.out
+grep -v '^github.com/status-im/status-go/cmd/' ${merged_coverage_report} > ${final_coverage_report}
 
 # Generate HTML coverage report
 echo "Generating HTML coverage report"
-go tool cover -html c.out -o test-coverage.html
+go tool cover -html ${final_coverage_report} -o test-coverage.html
 
 # Upload coverage report to CodeClimate
 if [[ $UNIT_TEST_REPORT_CODECLIMATE == 'true' ]]; then
@@ -144,7 +145,7 @@ fi
 # Generate report with test stats
 shopt -s globstar nullglob # Enable recursive globbing
 if [[ "${UNIT_TEST_COUNT}" -gt 1 ]]; then
-  echo "Generating report with test stats"
+  echo "Generating test stats"
   for exit_code_file in "${GIT_ROOT}"/**/exit_code_*.txt; do
     read exit_code < "${exit_code_file}"
     if [[ "${exit_code}" -ne 0 ]]; then

--- a/_assets/scripts/test-with-coverage.sh
+++ b/_assets/scripts/test-with-coverage.sh
@@ -9,8 +9,8 @@ count=1
 # gotestsum will only pass the package when rerunning a test. Otherwise we should pass the package ourselves.
 # https://github.com/gotestyourself/gotestsum/blob/03568ab6d48faabdb632013632ac42687b5f17d1/cmd/main.go#L331-L336
 if [[ "$*" != *"-test.run"* ]]; then
-  packages="${UNIT_TEST_PACKAGES}"
-  count=${UNIT_TEST_COUNT}
+  packages="${TEST_WITH_COVERAGE_PACKAGES}"
+  count=${TEST_WITH_COVERAGE_COUNT}
 fi
 
 go test -json \

--- a/_assets/scripts/test-with-coverage.sh
+++ b/_assets/scripts/test-with-coverage.sh
@@ -2,7 +2,7 @@
 set -eu
 
 packages=""
-coverage_file_path="$(mktemp coverage.out.rerun.XXXXXXXXXX)"
+coverage_file_path="$(mktemp coverage.out.rerun.XXXXXXXXXX --tmpdir="${TEST_WITH_COVERAGE_REPORTS_DIR}")"
 count=1
 
 # This is a hack to workaround gotestsum behaviour. When using a --raw-command,

--- a/_assets/scripts/test_stats.py
+++ b/_assets/scripts/test_stats.py
@@ -8,7 +8,7 @@ import re
 test_stats = defaultdict(lambda: defaultdict(int))
 skipped_tests = {}  # Use a dictionary to store test names and their skip reasons
 
-file_path = "report_*.xml"
+file_path = "**/report_*.xml"
 
 for file in glob.glob(file_path, recursive=True):
     tree = ET.parse(file)

--- a/_assets/scripts/test_stats.py
+++ b/_assets/scripts/test_stats.py
@@ -8,7 +8,9 @@ import re
 test_stats = defaultdict(lambda: defaultdict(int))
 skipped_tests = {}  # Use a dictionary to store test names and their skip reasons
 
-for file in glob.glob("report.xml", recursive=True):
+file_path = "report_*.xml"
+
+for file in glob.glob(file_path, recursive=True):
     tree = ET.parse(file)
     root = tree.getroot()
     for testcase in root.iter("testcase"):


### PR DESCRIPTION
Fixes https://github.com/status-im/status-go/issues/5401

https://github.com/status-im/status-go/pull/5731 made nightly tests extremely long.

`go test ./protocol -test.count=20` was run in a single process, so it was taking `~30min * 20runs = 10hours`.
This is not acceptable. Quickly making the `protocol` package run faster didn't seem possible, so I reverted the solution to spawn multiple processes.

Yet, the result utilizes both approaches.
The `protocol` package is now an exclusion, all other packages are run with default `go test` behaviour.

Also fixed the coverage reporting for nightly tests

Test run for `count=20`: https://ci.status.im/job/status-go/job/tests-nightly/366/

NOTE: I currently included https://github.com/status-im/status-go/pull/5793 into this PR. 
Will remove it when it's merged.