### PR TITLE
fix_: clean up tests with `ResetMobileSignalHandler`

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -842,7 +842,7 @@ func TestLoginAccount(t *testing.T) {
 			c <- struct{}{}
 		}
 	})
-	defer signal.SetMobileSignalHandler(nil)
+	t.Cleanup(signal.ResetMobileSignalHandler)
 	waitForLogin := func(chan interface{}) {
 		select {
 		case <-c:
@@ -1403,6 +1403,7 @@ func TestCreateWallet(t *testing.T) {
 			c <- struct{}{}
 		}
 	})
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	account, err := b.CreateAccountAndLogin(createAccountRequest)
 	require.NoError(t, err)
@@ -1463,6 +1464,7 @@ func TestSetFleet(t *testing.T) {
 			c <- struct{}{}
 		}
 	})
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	newAccount, err := b.CreateAccountAndLogin(createAccountRequest)
 	require.NoError(t, err)
@@ -1531,6 +1533,7 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 			c <- struct{}{}
 		}
 	})
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	newAccount, err := b.CreateAccountAndLogin(createAccountRequest)
 	require.NoError(t, err)

--- a/services/connector/commands/personal_sign_test.go
+++ b/services/connector/commands/personal_sign_test.go
@@ -135,6 +135,7 @@ func TestPersonalSignWithSignalAccepted(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	response, err := cmd.Execute(request)
 	assert.NoError(t, err)
@@ -177,6 +178,7 @@ func TestPersonalSignWithSignalRejected(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	_, err = cmd.Execute(request)
 	assert.Equal(t, ErrPersonalSignRejectedByUser, err)

--- a/services/connector/commands/request_accounts_test.go
+++ b/services/connector/commands/request_accounts_test.go
@@ -88,6 +88,7 @@ func TestRequestAccountsAcceptedAndRequestAgain(t *testing.T) {
 			dAppPermissionGranted = true
 		}
 	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	expectedResponse := FormatAccountAddressToResponse(accountAddress)
 	response, err := cmd.Execute(request)
@@ -142,6 +143,7 @@ func TestRequestAccountsRejected(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	_, err = cmd.Execute(request)
 	assert.Equal(t, ErrRequestAccountsRejectedByUser, err)

--- a/services/connector/commands/revoke_permissions_test.go
+++ b/services/connector/commands/revoke_permissions_test.go
@@ -56,6 +56,7 @@ func TestRevokePermissionsSucceeded(t *testing.T) {
 			dAppPermissionRevoked = true
 		}
 	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	err := PersistDAppData(db, testDAppData, sharedAccount, 0x123)
 	assert.NoError(t, err)

--- a/services/connector/commands/send_transaction_test.go
+++ b/services/connector/commands/send_transaction_test.go
@@ -129,6 +129,7 @@ func TestSendTransactionWithSignalAccepted(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	response, err := cmd.Execute(request)
 	assert.NoError(t, err)
@@ -169,6 +170,7 @@ func TestSendTransactionWithSignalRejected(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	_, err = cmd.Execute(request)
 	assert.Equal(t, ErrSendTransactionRejectedByUser, err)

--- a/services/connector/commands/switch_ethereum_chain_test.go
+++ b/services/connector/commands/switch_ethereum_chain_test.go
@@ -102,6 +102,7 @@ func TestSwitchEthereumChainSuccess(t *testing.T) {
 			chainIdSwitched = true
 		}
 	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	cmd := &SwitchEthereumChainCommand{
 		Db:             db,

--- a/services/connector/connector_flows_test.go
+++ b/services/connector/connector_flows_test.go
@@ -86,6 +86,7 @@ func TestRequestAccountsSwitchChainAndSendTransactionFlow(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	// Request accounts, now for real
 	request := "{\"method\": \"eth_requestAccounts\", \"params\": [], \"url\": \"http://testDAppURL123\", \"name\": \"testDAppName\", \"iconUrl\": \"http://testDAppIconUrl\" }"
@@ -221,6 +222,7 @@ func TestRequestAccountsAfterPermisasionsRevokeTest(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	}))
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	for range [10]int{} {
 		dAppPermissionRevoked = false

--- a/services/local-notifications/core_test.go
+++ b/services/local-notifications/core_test.go
@@ -91,6 +91,7 @@ func TestTransactionNotification(t *testing.T) {
 	})
 
 	signal.SetMobileSignalHandler(signalHandler)
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	feed := &event.Feed{}
 	require.NoError(t, s.SubscribeWallet(feed))

--- a/services/wallet/router/router_v2_test.go
+++ b/services/wallet/router/router_v2_test.go
@@ -144,10 +144,10 @@ func setupSignalHandler(t *testing.T) (chan SuggestedRoutesV2Response, func()) {
 		}
 	})
 	signal.SetMobileSignalHandler(signalHandler)
+	t.Cleanup(signal.ResetMobileSignalHandler)
 
 	closeFn := func() {
 		close(suggestedRoutesCh)
-		signal.SetMobileSignalHandler(nil)
 	}
 
 	return suggestedRoutesCh, closeFn

--- a/signal/signals.go
+++ b/signal/signals.go
@@ -111,6 +111,10 @@ func SetMobileSignalHandler(handler MobileSignalHandler) {
 	mobileSignalHandler = handler
 }
 
+func ResetMobileSignalHandler() {
+	mobileSignalHandler = nil
+}
+
 // SetSignalEventCallback set callback
 // this function uses C implementation (see `signals.c` file)
 func SetSignalEventCallback(cb unsafe.Pointer) {


### PR DESCRIPTION
Without this tests don't run properly with `-test.count` more than 1.

In general, global variables should be cleaned up after the run.
In this case the issue was when the signal handler was writing to some channel:
https://github.com/status-im/status-go/blob/5eb2af000eb1c15a7c2a9197ef51b7bdf242f8b6/api/backend_test.go#L1461-L1467

When the test finishes, the channel is stopped being read, so there's a block happening, preventing all tests to contunue executing.