### PR TITLE
fix!: leftovers work for sync fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,3 @@ __pycache__/
 .pytest_cache/
 .envrc
 report/results.xml
-
-# make lint-fix
-.clj-kondo/
-.lsp/

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,7 @@ __pycache__/
 .pytest_cache/
 .envrc
 report/results.xml
+
+# make lint-fix
+.clj-kondo/
+.lsp/

--- a/protocol/activity_center.go
+++ b/protocol/activity_center.go
@@ -40,6 +40,8 @@ const (
 	ActivityCenterNotificationTypeFirstCommunityTokenReceived
 	ActivityCenterNotificationTypeCommunityBanned
 	ActivityCenterNotificationTypeCommunityUnbanned
+	ActivityCenterNotificationTypeNewInstallationReceived
+	ActivityCenterNotificationTypeNewInstallationCreated
 )
 
 type ActivityCenterMembershipStatus int
@@ -87,6 +89,7 @@ type ActivityCenterNotification struct {
 	MembershipStatus          ActivityCenterMembershipStatus `json:"membershipStatus"`
 	Name                      string                         `json:"name"`
 	Author                    string                         `json:"author"`
+	InstallationID            string                         `json:"installationId"`
 	Type                      ActivityCenterType             `json:"type"`
 	LastMessage               *common.Message                `json:"lastMessage"`
 	Message                   *common.Message                `json:"message"`

--- a/protocol/activity_center_persistence.go
+++ b/protocol/activity_center_persistence.go
@@ -148,9 +148,10 @@ func (db sqlitePersistence) SaveActivityCenterNotification(notification *Activit
 			dismissed,
 			token_data,
 			deleted,
-		    updated_at
+		    updated_at,
+			installation_id
 		)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 		`,
 		notification.ID,
 		notification.Timestamp,
@@ -168,6 +169,7 @@ func (db sqlitePersistence) SaveActivityCenterNotification(notification *Activit
 		encodedTokenData,
 		notification.Deleted,
 		notification.UpdatedAt,
+		notification.InstallationID,
 	)
 	if err != nil {
 		return 0, err
@@ -269,6 +271,7 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRow(row *sql.Row)
 	var tokenDataBytes []byte
 	var name sql.NullString
 	var author sql.NullString
+	var installationID sql.NullString
 	notification := &ActivityCenterNotification{}
 	err := row.Scan(
 		&notification.ID,
@@ -288,7 +291,9 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRow(row *sql.Row)
 		&name,
 		&author,
 		&tokenDataBytes,
-		&notification.UpdatedAt)
+		&notification.UpdatedAt,
+		&installationID,
+	)
 
 	if err != nil {
 		return nil, err
@@ -308,6 +313,10 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRow(row *sql.Row)
 
 	if author.Valid {
 		notification.Author = author.String
+	}
+
+	if installationID.Valid {
+		notification.InstallationID = installationID.String
 	}
 
 	if len(tokenDataBytes) > 0 {
@@ -359,6 +368,7 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRows(rows *sql.Ro
 		var tokenDataBytes []byte
 		var name sql.NullString
 		var author sql.NullString
+		var installationID sql.NullString
 		notification := &ActivityCenterNotification{}
 		err := rows.Scan(
 			&notification.ID,
@@ -378,7 +388,9 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRows(rows *sql.Ro
 			&author,
 			&tokenDataBytes,
 			&latestCursor,
-			&notification.UpdatedAt)
+			&notification.UpdatedAt,
+			&installationID,
+		)
 		if err != nil {
 			return "", nil, err
 		}
@@ -397,6 +409,10 @@ func (db sqlitePersistence) unmarshalActivityCenterNotificationRows(rows *sql.Ro
 
 		if author.Valid {
 			notification.Author = author.String
+		}
+
+		if installationID.Valid {
+			notification.InstallationID = installationID.String
 		}
 
 		if len(tokenDataBytes) > 0 {
@@ -539,7 +555,8 @@ func (db sqlitePersistence) buildActivityCenterQuery(tx *sql.Tx, params activity
 	a.author,
 	a.token_data,
 	substr('0000000000000000000000000000000000000000000000000000000000000000' || a.timestamp, -64, 64) || hex(a.id) as cursor,
-	a.updated_at
+	a.updated_at,
+	a.installation_id
 	FROM activity_center_notifications a
 	LEFT JOIN chats c
 	ON
@@ -660,7 +677,8 @@ func (db sqlitePersistence) GetActivityCenterNotificationsByID(ids []types.HexBy
 		a.author,
 		a.token_data,
 		substr('0000000000000000000000000000000000000000000000000000000000000000' || a.timestamp, -64, 64) || hex(a.id) as cursor,
-		a.updated_at
+		a.updated_at,
+		a.installation_id
 		FROM activity_center_notifications a
 		LEFT JOIN chats c
 		ON
@@ -700,7 +718,8 @@ func (db sqlitePersistence) GetActivityCenterNotificationByID(id types.HexBytes)
 		c.name,
 		a.author,
 		a.token_data,
-		a.updated_at
+		a.updated_at,
+		a.installation_id
 		FROM activity_center_notifications a
 		LEFT JOIN chats c
 		ON
@@ -1334,7 +1353,8 @@ func (db sqlitePersistence) ActiveContactRequestNotification(contactID string) (
 			c.name,
 			a.author,
 			a.token_data,
-			a.updated_at
+			a.updated_at,
+			a.installation_id
 		FROM activity_center_notifications a
 		LEFT JOIN chats c ON c.id = a.chat_id
 		WHERE a.author = ?

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3664,21 +3664,23 @@ func (m *Messenger) deleteNotification(response *MessengerResponse, installation
 		return err
 	}
 
-	if notification != nil {
-		updatedAt := m.GetCurrentTimeInMillis()
-		notification.UpdatedAt = updatedAt
-		notification.Deleted = true
-		// we shouldn't sync deleted notification here,
-		// as the same user on different devices will receive the same message(CommunityCancelRequestToJoin) ?
-		err = m.persistence.DeleteActivityCenterNotificationByID(types.FromHex(installationID), updatedAt)
-		if err != nil {
-			m.logger.Error("failed to delete notification from Activity Center", zap.Error(err))
-			return err
-		}
-
-		// sending signal to client to remove the activity center notification from UI
-		response.AddActivityCenterNotification(notification)
+	if notification == nil {
+		return nil
 	}
+
+	updatedAt := m.GetCurrentTimeInMillis()
+	notification.UpdatedAt = updatedAt
+	notification.Deleted = true
+	// we shouldn't sync deleted notification here,
+	// as the same user on different devices will receive the same message(CommunityCancelRequestToJoin) ?
+	err = m.persistence.DeleteActivityCenterNotificationByID(types.FromHex(installationID), updatedAt)
+	if err != nil {
+		m.logger.Error("failed to delete notification from Activity Center", zap.Error(err))
+		return err
+	}
+
+	// sending signal to client to remove the activity center notification from UI
+	response.AddActivityCenterNotification(notification)
 	return nil
 }
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3697,6 +3697,48 @@ func (m *Messenger) saveDataAndPrepareResponse(messageState *ReceivedMessageStat
 			}
 		}
 
+		if installation.Enabled {
+			// // Delete AC notif since the installation is now enabled
+			notification, err := m.persistence.GetActivityCenterNotificationByID(types.FromHex(id))
+			if err != nil {
+				return false
+			}
+
+			if notification != nil {
+				updatedAt := m.GetCurrentTimeInMillis()
+				notification.UpdatedAt = updatedAt
+				notification.Deleted = true
+				// we shouldn't sync deleted notification here,
+				// as the same user on different devices will receive the same message(CommunityCancelRequestToJoin) ?
+				err = m.persistence.DeleteActivityCenterNotificationByID(types.FromHex(id), updatedAt)
+				if err != nil {
+					m.logger.Error("failed to delete notification from Activity Center", zap.Error(err))
+					return false
+				}
+
+				// sending signal to client to remove the activity center notification from UI
+				messageState.Response.AddActivityCenterNotification(notification)
+			}
+		} else {
+			// Add activity center notification when we receive a new installation
+			if id != m.installationID {
+				notification := &ActivityCenterNotification{
+					ID:             types.FromHex(id),
+					Type:           ActivityCenterNotificationTypeNewInstallationReceived,
+					InstallationID: id,
+					Timestamp:      m.getTimesource().GetCurrentTime(),
+					Read:           false,
+					Deleted:        false,
+					UpdatedAt:      m.GetCurrentTimeInMillis(),
+				}
+
+				err = m.addActivityCenterNotification(messageState.Response, notification, nil)
+				if err != nil {
+					return false
+				}
+			}
+		}
+
 		return true
 	})
 	if err != nil {

--- a/protocol/messenger_pairing_and_syncing.go
+++ b/protocol/messenger_pairing_and_syncing.go
@@ -35,26 +35,11 @@ func (m *Messenger) EnableInstallationAndSync(request *requests.EnableInstallati
 	}
 
 	// Delete AC notif
-	notification, err := m.persistence.GetActivityCenterNotificationByID(types.FromHex(request.InstallationID))
+	err = m.deleteNotification(response, request.InstallationID)
 	if err != nil {
 		return nil, err
 	}
 
-	if notification != nil {
-		updatedAt := m.GetCurrentTimeInMillis()
-		notification.UpdatedAt = updatedAt
-		notification.Deleted = true
-		// we shouldn't sync deleted notification here,
-		// as the same user on different devices will receive the same message(CommunityCancelRequestToJoin) ?
-		err = m.persistence.DeleteActivityCenterNotificationByID(types.FromHex(request.InstallationID), updatedAt)
-		if err != nil {
-			m.logger.Error("failed to delete notification from Activity Center", zap.Error(err))
-			return nil, err
-		}
-
-		// sending signal to client to remove the activity center notification from UI
-		response.AddActivityCenterNotification(notification)
-	}
 	return response, nil
 }
 

--- a/protocol/messenger_pairing_and_syncing.go
+++ b/protocol/messenger_pairing_and_syncing.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
@@ -16,15 +17,45 @@ import (
 	"github.com/status-im/status-go/protocol/requests"
 )
 
-func (m *Messenger) EnableAndSyncInstallation(request *requests.EnableAndSyncInstallation) error {
+func (m *Messenger) EnableAndSyncInstallation(request *requests.EnableAndSyncInstallation) (*MessengerResponse, error) {
 	if err := request.Validate(); err != nil {
-		return err
+		return nil, err
 	}
 	err := m.EnableInstallation(request.InstallationID)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return m.SyncDevices(context.Background(), "", "", nil)
+	response, err := m.SendPairInstallation(context.Background(), nil)
+	if err != nil {
+		return nil, err
+	}
+	err = m.SyncDevices(context.Background(), "", "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Delete AC notif
+	notification, err := m.persistence.GetActivityCenterNotificationByID(types.FromHex(request.InstallationID))
+	if err != nil {
+		return nil, err
+	}
+
+	if notification != nil {
+		updatedAt := m.GetCurrentTimeInMillis()
+		notification.UpdatedAt = updatedAt
+		notification.Deleted = true
+		// we shouldn't sync deleted notification here,
+		// as the same user on different devices will receive the same message(CommunityCancelRequestToJoin) ?
+		err = m.persistence.DeleteActivityCenterNotificationByID(types.FromHex(request.InstallationID), updatedAt)
+		if err != nil {
+			m.logger.Error("failed to delete notification from Activity Center", zap.Error(err))
+			return nil, err
+		}
+
+		// sending signal to client to remove the activity center notification from UI
+		response.AddActivityCenterNotification(notification)
+	}
+	return response, nil
 }
 
 func (m *Messenger) EnableInstallationAndPair(request *requests.EnableInstallationAndPair) (*MessengerResponse, error) {
@@ -53,7 +84,26 @@ func (m *Messenger) EnableInstallationAndPair(request *requests.EnableInstallati
 		i.Enabled = true
 	}
 	m.allInstallations.Store(request.InstallationID, i)
-	return m.SendPairInstallation(context.Background(), nil)
+	response, err := m.SendPairInstallation(context.Background(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	notification := &ActivityCenterNotification{
+		ID:             types.FromHex(request.InstallationID),
+		Type:           ActivityCenterNotificationTypeNewInstallationCreated,
+		InstallationID: m.installationID, // Put our own installation ID, as we're the initiator of the pairing
+		Timestamp:      m.getTimesource().GetCurrentTime(),
+		Read:           false,
+		Deleted:        false,
+		UpdatedAt:      m.GetCurrentTimeInMillis(),
+	}
+
+	err = m.addActivityCenterNotification(response, notification, nil)
+	if err != nil {
+		return nil, err
+	}
+	return response, err
 }
 
 // SendPairInstallation sends a pair installation message

--- a/protocol/messenger_pairing_and_syncing.go
+++ b/protocol/messenger_pairing_and_syncing.go
@@ -17,7 +17,7 @@ import (
 	"github.com/status-im/status-go/protocol/requests"
 )
 
-func (m *Messenger) EnableAndSyncInstallation(request *requests.EnableAndSyncInstallation) (*MessengerResponse, error) {
+func (m *Messenger) EnableInstallationAndSync(request *requests.EnableInstallationAndSync) (*MessengerResponse, error) {
 	if err := request.Validate(); err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_pairing_and_syncing_test.go
+++ b/protocol/messenger_pairing_and_syncing_test.go
@@ -102,7 +102,8 @@ func (s *MessengerPairingSuite) TestMessengerPairAfterSeedPhrase() {
 	)
 	s.Require().NoError(err)
 
-	s.Require().NoError(alice1.EnableAndSyncInstallation(&requests.EnableAndSyncInstallation{InstallationID: installationID2}))
+	_, err = alice1.EnableAndSyncInstallation(&requests.EnableAndSyncInstallation{InstallationID: installationID2})
+	s.Require().NoError(err)
 
 	// check if the display name is synced
 	err = tt.RetryWithBackOff(func() error {

--- a/protocol/messenger_pairing_and_syncing_test.go
+++ b/protocol/messenger_pairing_and_syncing_test.go
@@ -102,7 +102,7 @@ func (s *MessengerPairingSuite) TestMessengerPairAfterSeedPhrase() {
 	)
 	s.Require().NoError(err)
 
-	_, err = alice1.EnableAndSyncInstallation(&requests.EnableAndSyncInstallation{InstallationID: installationID2})
+	_, err = alice1.EnableInstallationAndSync(&requests.EnableInstallationAndSync{InstallationID: installationID2})
 	s.Require().NoError(err)
 
 	// check if the display name is synced

--- a/protocol/migrations/migrations.go
+++ b/protocol/migrations/migrations.go
@@ -143,6 +143,7 @@
 // 1719906191_add_community_token_version.up.sql (65B)
 // 1720636181_add_community_encryption_keys_requests.up.sql (236B)
 // 1721222369_add_shared_addresses.up.sql (98B)
+// 1721919311_add_installation_id_activity_center.up.sql (87B)
 // README.md (554B)
 // doc.go (870B)
 
@@ -227,7 +228,7 @@ func _000001_initDownDbSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "000001_init.down.db.sql", size: 65, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "000001_init.down.db.sql", size: 65, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x5e, 0xbb, 0x3f, 0x1, 0x75, 0x19, 0x70, 0x86, 0xa7, 0x34, 0x40, 0x17, 0x34, 0x3e, 0x18, 0x51, 0x79, 0xd4, 0x22, 0xad, 0x8f, 0x80, 0xcc, 0xa6, 0xcc, 0x6, 0x2b, 0x62, 0x2, 0x47, 0xba, 0xf9}}
 	return a, nil
 }
@@ -247,7 +248,7 @@ func _000001_initUpDbSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "000001_init.up.db.sql", size: 2719, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "000001_init.up.db.sql", size: 2719, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x60, 0xdc, 0xeb, 0xe, 0xc2, 0x4f, 0x75, 0xa, 0xf6, 0x3e, 0xc7, 0xc4, 0x4, 0xe2, 0xe1, 0xa4, 0x73, 0x2f, 0x4a, 0xad, 0x1a, 0x0, 0xc3, 0x93, 0x9d, 0x77, 0x3e, 0x31, 0x91, 0x77, 0x2e, 0xc8}}
 	return a, nil
 }
@@ -267,7 +268,7 @@ func _000002_add_last_ens_clock_valueUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "000002_add_last_ens_clock_value.up.sql", size: 77, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "000002_add_last_ens_clock_value.up.sql", size: 77, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x4d, 0x3, 0x8f, 0xd5, 0x85, 0x83, 0x47, 0xbe, 0xf9, 0x82, 0x7e, 0x81, 0xa4, 0xbd, 0xaa, 0xd5, 0x98, 0x18, 0x5, 0x2d, 0x82, 0x42, 0x3b, 0x3, 0x50, 0xc3, 0x1e, 0x84, 0x35, 0xf, 0xb6, 0x2b}}
 	return a, nil
 }
@@ -287,7 +288,7 @@ func _1586358095_add_replaceUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1586358095_add_replace.up.sql", size: 224, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1586358095_add_replace.up.sql", size: 224, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd2, 0xb3, 0xa9, 0xc7, 0x7f, 0x9d, 0x8f, 0x43, 0x8c, 0x9e, 0x58, 0x8d, 0x44, 0xbc, 0xfa, 0x6b, 0x5f, 0x3f, 0x5a, 0xbe, 0xe8, 0xb1, 0x16, 0xf, 0x91, 0x2a, 0xa0, 0x71, 0xbb, 0x8d, 0x6b, 0xcb}}
 	return a, nil
 }
@@ -307,7 +308,7 @@ func _1588665364_add_image_dataUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1588665364_add_image_data.up.sql", size: 186, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1588665364_add_image_data.up.sql", size: 186, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd6, 0xc6, 0x35, 0xb4, 0x4c, 0x39, 0x96, 0x29, 0x30, 0xda, 0xf4, 0x8f, 0xcb, 0xf1, 0x9f, 0x84, 0xdc, 0x88, 0xd4, 0xd5, 0xbc, 0xb6, 0x5b, 0x46, 0x78, 0x67, 0x76, 0x1a, 0x5, 0x36, 0xdc, 0xe5}}
 	return a, nil
 }
@@ -327,7 +328,7 @@ func _1589365189_add_pow_targetUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1589365189_add_pow_target.up.sql", size: 66, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1589365189_add_pow_target.up.sql", size: 66, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x4e, 0x3a, 0xe2, 0x2e, 0x7d, 0xaf, 0xbb, 0xcc, 0x21, 0xa1, 0x7a, 0x41, 0x9a, 0xd0, 0xbb, 0xa9, 0xc8, 0x35, 0xf9, 0x32, 0x34, 0x46, 0x44, 0x9a, 0x86, 0x40, 0x7c, 0xb9, 0x23, 0xc7, 0x3, 0x3f}}
 	return a, nil
 }
@@ -347,7 +348,7 @@ func _1591277220_add_index_messagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1591277220_add_index_messages.up.sql", size: 240, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1591277220_add_index_messages.up.sql", size: 240, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9c, 0xfe, 0xbe, 0xd5, 0xb8, 0x8f, 0xdd, 0xef, 0xbb, 0xa8, 0xad, 0x7f, 0xed, 0x5b, 0x5b, 0x2f, 0xe6, 0x82, 0x27, 0x78, 0x1f, 0xb9, 0x57, 0xdc, 0x8, 0xc2, 0xb2, 0xa9, 0x9a, 0x4, 0xe1, 0x7a}}
 	return a, nil
 }
@@ -367,7 +368,7 @@ func _1593087212_add_mute_chat_and_raw_message_fieldsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1593087212_add_mute_chat_and_raw_message_fields.up.sql", size: 215, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1593087212_add_mute_chat_and_raw_message_fields.up.sql", size: 215, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x73, 0x99, 0x61, 0xd1, 0xaa, 0xb4, 0xbf, 0xaf, 0xd7, 0x20, 0x17, 0x40, 0xf9, 0x2, 0xfb, 0xcc, 0x40, 0x2a, 0xd, 0x86, 0x36, 0x30, 0x88, 0x89, 0x25, 0x80, 0x42, 0xb0, 0x5b, 0xe9, 0x73, 0x78}}
 	return a, nil
 }
@@ -387,7 +388,7 @@ func _1595862781_add_audio_dataUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1595862781_add_audio_data.up.sql", size: 246, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1595862781_add_audio_data.up.sql", size: 246, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xae, 0xd2, 0xee, 0x55, 0xfb, 0x36, 0xa4, 0x92, 0x66, 0xe, 0x81, 0x62, 0x1e, 0x7a, 0x69, 0xa, 0xd5, 0x4b, 0xa5, 0x6a, 0x8d, 0x1d, 0xce, 0xf3, 0x3e, 0xc0, 0x5f, 0x9c, 0x66, 0x1b, 0xb4, 0xed}}
 	return a, nil
 }
@@ -407,7 +408,7 @@ func _1595865249_create_emoji_reactions_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1595865249_create_emoji_reactions_table.up.sql", size: 300, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1595865249_create_emoji_reactions_table.up.sql", size: 300, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3e, 0xc5, 0x43, 0x5c, 0x3d, 0x53, 0x43, 0x2c, 0x1a, 0xa5, 0xb6, 0xbf, 0x7, 0x4, 0x5a, 0x3e, 0x40, 0x8b, 0xa4, 0x57, 0x12, 0x58, 0xbc, 0x42, 0xe2, 0xc3, 0xde, 0x76, 0x98, 0x80, 0xe2, 0xbe}}
 	return a, nil
 }
@@ -427,7 +428,7 @@ func _1596805115_create_group_chat_invitations_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1596805115_create_group_chat_invitations_table.up.sql", size: 231, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1596805115_create_group_chat_invitations_table.up.sql", size: 231, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6d, 0xb1, 0x14, 0x6d, 0x54, 0x28, 0x67, 0xc3, 0x23, 0x6a, 0xfc, 0x80, 0xdf, 0x9e, 0x4c, 0x35, 0x36, 0xf, 0xf8, 0xf3, 0x5f, 0xae, 0xad, 0xb, 0xc1, 0x51, 0x8e, 0x17, 0x7, 0xe5, 0x7f, 0x91}}
 	return a, nil
 }
@@ -447,7 +448,7 @@ func _1597322655_add_invitation_admin_chat_fieldUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1597322655_add_invitation_admin_chat_field.up.sql", size: 54, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1597322655_add_invitation_admin_chat_field.up.sql", size: 54, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa9, 0x7a, 0xa0, 0xf2, 0xdb, 0x13, 0x91, 0x91, 0xa8, 0x34, 0x1a, 0xa1, 0x49, 0x68, 0xd5, 0xae, 0x2c, 0xd8, 0xd5, 0xea, 0x8f, 0x8c, 0xc7, 0x2, 0x4e, 0x58, 0x2c, 0x3a, 0x14, 0xd4, 0x4f, 0x2c}}
 	return a, nil
 }
@@ -467,7 +468,7 @@ func _1597757544_add_nicknameUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1597757544_add_nickname.up.sql", size: 52, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1597757544_add_nickname.up.sql", size: 52, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf4, 0xa2, 0x64, 0x50, 0xc5, 0x4, 0xb9, 0x8b, 0xd1, 0x18, 0x9b, 0xc3, 0x91, 0x36, 0x2a, 0x1f, 0xc3, 0x6c, 0x2d, 0x92, 0xf8, 0x5e, 0xff, 0xb1, 0x59, 0x61, 0x2, 0x1c, 0xe1, 0x85, 0x90, 0xa4}}
 	return a, nil
 }
@@ -487,7 +488,7 @@ func _1598955122_add_mentionsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1598955122_add_mentions.up.sql", size: 52, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1598955122_add_mentions.up.sql", size: 52, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8d, 0x22, 0x17, 0x92, 0xd2, 0x11, 0x4e, 0x7, 0x93, 0x9a, 0x55, 0xfd, 0xb, 0x97, 0xc4, 0x63, 0x6a, 0x81, 0x97, 0xcd, 0xb2, 0xf8, 0x4b, 0x5f, 0x3c, 0xfa, 0x3a, 0x38, 0x53, 0x10, 0xed, 0x9d}}
 	return a, nil
 }
@@ -507,7 +508,7 @@ func _1599641390_add_emoji_reactions_indexUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1599641390_add_emoji_reactions_index.up.sql", size: 126, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1599641390_add_emoji_reactions_index.up.sql", size: 126, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf9, 0xd8, 0xdc, 0xa7, 0xb, 0x92, 0x7a, 0x61, 0x37, 0x24, 0x1c, 0x77, 0x5e, 0xe, 0x7e, 0xfc, 0x9f, 0x98, 0x7b, 0x65, 0xe7, 0xf9, 0x71, 0x57, 0x89, 0x2d, 0x90, 0x1b, 0xf6, 0x5e, 0x37, 0xe8}}
 	return a, nil
 }
@@ -527,7 +528,7 @@ func _1599720851_add_seen_index_remove_long_messagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1599720851_add_seen_index_remove_long_messages.up.sql", size: 150, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1599720851_add_seen_index_remove_long_messages.up.sql", size: 150, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x24, 0x1c, 0xc4, 0x78, 0x91, 0xc7, 0xeb, 0xfe, 0xc8, 0xa0, 0xd8, 0x13, 0x27, 0x97, 0xc8, 0x96, 0x56, 0x97, 0x33, 0x2c, 0x1e, 0x16, 0x8a, 0xd3, 0x49, 0x99, 0x3, 0xe9, 0xbb, 0xc4, 0x5, 0x3c}}
 	return a, nil
 }
@@ -547,7 +548,7 @@ func _1603198582_add_profile_chat_fieldUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1603198582_add_profile_chat_field.up.sql", size: 45, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1603198582_add_profile_chat_field.up.sql", size: 45, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xaa, 0xca, 0xe, 0x46, 0xa0, 0x9, 0x9d, 0x47, 0x57, 0xe9, 0xfb, 0x17, 0xeb, 0x9c, 0xf6, 0xb8, 0x1d, 0xe9, 0xd, 0x0, 0xd5, 0xe5, 0xd8, 0x9e, 0x60, 0xa, 0xbf, 0x32, 0x2c, 0x52, 0x7f, 0x6a}}
 	return a, nil
 }
@@ -567,7 +568,7 @@ func _1603816533_add_linksUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1603816533_add_links.up.sql", size: 48, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1603816533_add_links.up.sql", size: 48, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc9, 0x24, 0xd6, 0x1d, 0xa, 0x83, 0x1e, 0x4d, 0xf, 0xae, 0x4d, 0x8c, 0x51, 0x32, 0xa8, 0x37, 0xb0, 0x14, 0xfb, 0x32, 0x34, 0xc8, 0xc, 0x4e, 0x5b, 0xc5, 0x15, 0x65, 0x73, 0x0, 0x0, 0x1d}}
 	return a, nil
 }
@@ -587,7 +588,7 @@ func _1603888149_create_chat_identity_last_published_tableUpSql() (*asset, error
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1603888149_create_chat_identity_last_published_table.up.sql", size: 407, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1603888149_create_chat_identity_last_published_table.up.sql", size: 407, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7f, 0x9, 0xf, 0xfb, 0xdb, 0x3c, 0x86, 0x70, 0x82, 0xda, 0x10, 0x25, 0xe2, 0x4e, 0x40, 0x45, 0xab, 0x8b, 0x1c, 0x91, 0x7c, 0xf1, 0x70, 0x2e, 0x81, 0xf3, 0x71, 0x45, 0xda, 0xe2, 0xa4, 0x57}}
 	return a, nil
 }
@@ -607,7 +608,7 @@ func _1605075346_add_communitiesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1605075346_add_communities.up.sql", size: 6971, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1605075346_add_communities.up.sql", size: 6971, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1f, 0x64, 0xea, 0xb4, 0xae, 0x9e, 0xdb, 0x9, 0x58, 0xb6, 0x5c, 0x7a, 0x50, 0xc5, 0xfe, 0x93, 0x5d, 0x36, 0x85, 0x5d, 0x6a, 0xba, 0xc9, 0x7e, 0x84, 0xd7, 0xbf, 0x2a, 0x53, 0xf3, 0x97, 0xf1}}
 	return a, nil
 }
@@ -627,7 +628,7 @@ func _1610117927_add_message_cacheUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1610117927_add_message_cache.up.sql", size: 142, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1610117927_add_message_cache.up.sql", size: 142, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x34, 0xf1, 0xf0, 0x82, 0x79, 0x28, 0x19, 0xc2, 0x39, 0x6a, 0xa5, 0x96, 0x59, 0x23, 0xa0, 0xed, 0x60, 0x58, 0x86, 0x9, 0xb9, 0xad, 0xfb, 0xa, 0xe3, 0x47, 0x6e, 0xa1, 0x18, 0xe8, 0x39, 0x2c}}
 	return a, nil
 }
@@ -647,7 +648,7 @@ func _1610959908_add_dont_wrap_to_raw_messagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1610959908_add_dont_wrap_to_raw_messages.up.sql", size: 83, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1610959908_add_dont_wrap_to_raw_messages.up.sql", size: 83, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x71, 0x2, 0x9a, 0xca, 0xd4, 0x38, 0x44, 0x30, 0x2b, 0xa8, 0x27, 0x32, 0x63, 0x53, 0x22, 0x60, 0x59, 0x84, 0x23, 0x96, 0x77, 0xf0, 0x56, 0xd7, 0x94, 0xe0, 0x95, 0x28, 0x6, 0x1d, 0x4e, 0xb1}}
 	return a, nil
 }
@@ -667,7 +668,7 @@ func _1610960912_add_send_on_personal_topicUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1610960912_add_send_on_personal_topic.up.sql", size: 82, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1610960912_add_send_on_personal_topic.up.sql", size: 82, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x77, 0xac, 0x2f, 0xc4, 0xd, 0xa7, 0x1b, 0x37, 0x30, 0xc2, 0x68, 0xee, 0xde, 0x54, 0x5e, 0xbf, 0x3f, 0xa0, 0xd6, 0xc6, 0x9f, 0xd4, 0x34, 0x12, 0x76, 0x1e, 0x66, 0x4a, 0xfc, 0xf, 0xee, 0xc9}}
 	return a, nil
 }
@@ -687,7 +688,7 @@ func _1612870480_add_datasync_idUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1612870480_add_datasync_id.up.sql", size: 111, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1612870480_add_datasync_id.up.sql", size: 111, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x34, 0x9a, 0xbc, 0xfa, 0xaa, 0x8c, 0x9c, 0x37, 0x67, 0x15, 0x9c, 0x7e, 0x78, 0x75, 0x66, 0x82, 0x18, 0x72, 0x10, 0xbc, 0xd4, 0xab, 0x44, 0xfe, 0x57, 0x85, 0x6d, 0x19, 0xf5, 0x96, 0x8a, 0xbe}}
 	return a, nil
 }
@@ -707,7 +708,7 @@ func _1614152139_add_communities_request_to_joinUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1614152139_add_communities_request_to_join.up.sql", size: 831, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1614152139_add_communities_request_to_join.up.sql", size: 831, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x11, 0x3, 0x26, 0xf9, 0x29, 0x50, 0x4f, 0xcd, 0x46, 0xe5, 0xb1, 0x6b, 0xb9, 0x2, 0x40, 0xb1, 0xdf, 0x4a, 0x4c, 0x7a, 0xda, 0x3, 0x35, 0xcd, 0x2d, 0xcc, 0x80, 0x7d, 0x57, 0x5f, 0x3, 0x5c}}
 	return a, nil
 }
@@ -727,7 +728,7 @@ func _1615374373_add_confirmationsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1615374373_add_confirmations.up.sql", size: 227, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1615374373_add_confirmations.up.sql", size: 227, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdd, 0xa6, 0x65, 0xc5, 0x1d, 0xb2, 0x77, 0x36, 0xe3, 0x79, 0xda, 0xe8, 0x7a, 0xa4, 0xdf, 0x45, 0xae, 0xd8, 0xb4, 0xba, 0x90, 0xfd, 0x74, 0x71, 0x14, 0x75, 0x73, 0x72, 0xb9, 0x9e, 0x1, 0x81}}
 	return a, nil
 }
@@ -747,7 +748,7 @@ func _1617694931_add_notification_centerUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1617694931_add_notification_center.up.sql", size: 572, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1617694931_add_notification_center.up.sql", size: 572, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x10, 0x45, 0xc6, 0xc9, 0x73, 0xbb, 0x1f, 0xda, 0xa3, 0x4d, 0x19, 0x98, 0x85, 0x2d, 0xca, 0xda, 0xcc, 0x3b, 0x32, 0xff, 0xc7, 0x7b, 0xe3, 0x9f, 0x9b, 0x2a, 0x93, 0xf5, 0xdf, 0x65, 0x38, 0x91}}
 	return a, nil
 }
@@ -767,7 +768,7 @@ func _1618923660_create_pin_messagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1618923660_create_pin_messages.up.sql", size: 265, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1618923660_create_pin_messages.up.sql", size: 265, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x61, 0x44, 0x3a, 0xbe, 0x30, 0xd2, 0x7e, 0xc0, 0xe2, 0x8e, 0x65, 0x53, 0x54, 0xbb, 0x7a, 0x1c, 0xb3, 0x5d, 0xd2, 0xa6, 0xa9, 0x28, 0xb7, 0xa4, 0x5f, 0x8b, 0x9, 0x5f, 0x17, 0xc1, 0x85, 0x21}}
 	return a, nil
 }
@@ -787,7 +788,7 @@ func _1619094007_add_joined_chat_fieldUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1619094007_add_joined_chat_field.up.sql", size: 101, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1619094007_add_joined_chat_field.up.sql", size: 101, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xfa, 0x30, 0x81, 0x3a, 0x2f, 0x9f, 0xb3, 0x0, 0x55, 0x8e, 0x1d, 0xa8, 0xb0, 0x68, 0xf0, 0x40, 0x1a, 0x6c, 0xaa, 0xfc, 0x33, 0xd1, 0xd1, 0x55, 0x3f, 0xf2, 0xbd, 0x54, 0xa1, 0x2b, 0x40, 0x95}}
 	return a, nil
 }
@@ -807,7 +808,7 @@ func _1619099821_add_last_synced_fieldUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1619099821_add_last_synced_field.up.sql", size: 226, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1619099821_add_last_synced_field.up.sql", size: 226, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf, 0x52, 0x22, 0xe, 0x2f, 0xd7, 0x93, 0x5f, 0x42, 0xc2, 0x93, 0x4, 0x35, 0x6f, 0xc9, 0x19, 0xed, 0x6b, 0x52, 0x6f, 0xae, 0x99, 0xe2, 0x68, 0x3d, 0x4f, 0x40, 0xe, 0xe1, 0xa, 0x47, 0x21}}
 	return a, nil
 }
@@ -827,7 +828,7 @@ func _1621933219_add_mentionedUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1621933219_add_mentioned.up.sql", size: 70, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1621933219_add_mentioned.up.sql", size: 70, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x36, 0x76, 0x8a, 0xc9, 0x7, 0x8f, 0xa5, 0xcb, 0x12, 0x21, 0x4e, 0xfe, 0x96, 0x77, 0xcf, 0x7f, 0x76, 0x75, 0x36, 0x2c, 0xf8, 0x1d, 0x13, 0xcb, 0xcd, 0x6e, 0x70, 0xbf, 0xf5, 0x93, 0x67, 0xd1}}
 	return a, nil
 }
@@ -847,7 +848,7 @@ func _1622010048_add_unviewed_mentions_countUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1622010048_add_unviewed_mentions_count.up.sql", size: 114, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1622010048_add_unviewed_mentions_count.up.sql", size: 114, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7c, 0x16, 0x85, 0xa6, 0x5b, 0xe1, 0x66, 0xb9, 0x84, 0xbe, 0x7f, 0xa, 0x77, 0x23, 0xb9, 0xef, 0x8e, 0x2, 0x8, 0xfc, 0x61, 0xb2, 0x43, 0xa9, 0x63, 0xae, 0xb4, 0xdf, 0x30, 0xb1, 0x61, 0x4b}}
 	return a, nil
 }
@@ -867,7 +868,7 @@ func _1622061278_add_message_activity_center_notification_fieldUpSql() (*asset, 
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1622061278_add_message_activity_center_notification_field.up.sql", size: 80, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1622061278_add_message_activity_center_notification_field.up.sql", size: 80, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8, 0xc, 0xa6, 0x1f, 0xa5, 0xc6, 0x7c, 0x6f, 0xab, 0x2c, 0x2d, 0xb5, 0xa4, 0xdd, 0xc1, 0xd6, 0x44, 0x83, 0xf9, 0xb1, 0xa5, 0xce, 0x34, 0x3d, 0x2, 0xa9, 0x35, 0xcf, 0xc6, 0xb2, 0x43, 0x37}}
 	return a, nil
 }
@@ -887,7 +888,7 @@ func _1622464518_set_synced_to_fromUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1622464518_set_synced_to_from.up.sql", size: 105, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1622464518_set_synced_to_from.up.sql", size: 105, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x33, 0x3e, 0x2b, 0xa, 0x1e, 0xc7, 0x6d, 0x6f, 0xd1, 0x1d, 0xe8, 0x4b, 0xdd, 0x92, 0x76, 0xea, 0xf2, 0x3e, 0x15, 0x85, 0xc4, 0xc3, 0x31, 0xf1, 0xc0, 0xa2, 0xd7, 0x47, 0xde, 0x4e, 0xfd, 0xc6}}
 	return a, nil
 }
@@ -907,7 +908,7 @@ func _1622464519_add_chat_descriptionUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1622464519_add_chat_description.up.sql", size: 93, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1622464519_add_chat_description.up.sql", size: 93, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x36, 0x2e, 0x89, 0x31, 0xec, 0xef, 0xeb, 0x43, 0xf5, 0x96, 0x6d, 0xce, 0x91, 0x8a, 0x37, 0x2a, 0x11, 0x7a, 0x3f, 0xd9, 0x10, 0xbb, 0xa1, 0xbc, 0x7, 0xe0, 0x3b, 0xa5, 0xf4, 0xa6, 0xf4, 0xa1}}
 	return a, nil
 }
@@ -927,7 +928,7 @@ func _1622622253_add_pinned_by_to_pin_messagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1622622253_add_pinned_by_to_pin_messages.up.sql", size: 52, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1622622253_add_pinned_by_to_pin_messages.up.sql", size: 52, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9b, 0x94, 0xa3, 0x45, 0x91, 0x1e, 0x66, 0xd1, 0x96, 0x5a, 0xaf, 0xfa, 0x29, 0x39, 0xa8, 0x3a, 0x97, 0x4c, 0x65, 0x6, 0x96, 0x90, 0x4c, 0xfe, 0xce, 0x7d, 0x5d, 0xd4, 0xb3, 0x8, 0x6d, 0x5f}}
 	return a, nil
 }
@@ -947,7 +948,7 @@ func _1623938329_add_author_activity_center_notification_fieldUpSql() (*asset, e
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1623938329_add_author_activity_center_notification_field.up.sql", size: 66, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1623938329_add_author_activity_center_notification_field.up.sql", size: 66, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x36, 0xe6, 0xa7, 0xd5, 0x26, 0xff, 0xab, 0x92, 0x88, 0xf0, 0xd3, 0x34, 0xd9, 0x2f, 0xe7, 0x18, 0x1a, 0x40, 0xf9, 0xbe, 0x8e, 0xfc, 0xd0, 0x4f, 0x1f, 0x4a, 0xb9, 0x83, 0x3f, 0xa9, 0xde, 0xb}}
 	return a, nil
 }
@@ -967,7 +968,7 @@ func _1623938330_add_edit_messagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1623938330_add_edit_messages.up.sql", size: 369, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1623938330_add_edit_messages.up.sql", size: 369, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7e, 0xd2, 0xce, 0xe, 0x5c, 0x19, 0xbe, 0x5e, 0x29, 0xbe, 0x9b, 0x31, 0x53, 0x76, 0xb2, 0xc8, 0x56, 0xf0, 0x82, 0xfe, 0x7d, 0x6c, 0xe8, 0x5c, 0xe9, 0x7a, 0x5d, 0x5, 0xc4, 0x92, 0x38, 0xe3}}
 	return a, nil
 }
@@ -987,7 +988,7 @@ func _1624978434_add_muted_communityUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1624978434_add_muted_community.up.sql", size: 82, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1624978434_add_muted_community.up.sql", size: 82, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6, 0xdc, 0x6e, 0x6f, 0x97, 0xc7, 0x3d, 0x50, 0xab, 0x80, 0x87, 0x44, 0x43, 0x38, 0xe6, 0xc5, 0xc1, 0x91, 0x26, 0xf, 0x16, 0xe, 0xd9, 0x32, 0x37, 0x25, 0x96, 0x25, 0x6, 0xc8, 0xb5, 0x4a}}
 	return a, nil
 }
@@ -1007,7 +1008,7 @@ func _1625018910_add_repply_message_activity_center_notification_fieldUpSql() (*
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1625018910_add_repply_message_activity_center_notification_field.up.sql", size: 86, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1625018910_add_repply_message_activity_center_notification_field.up.sql", size: 86, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf2, 0x52, 0x12, 0x40, 0xd8, 0x6f, 0x71, 0x97, 0x46, 0x39, 0xaa, 0x74, 0x41, 0xcd, 0x45, 0x4c, 0xe8, 0xd9, 0xe2, 0x56, 0x8e, 0x78, 0x18, 0x62, 0xf6, 0xa8, 0x36, 0xe9, 0x9a, 0x1f, 0xc, 0xb1}}
 	return a, nil
 }
@@ -1027,7 +1028,7 @@ func _1625762506_add_deleted_messagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1625762506_add_deleted_messages.up.sql", size: 357, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1625762506_add_deleted_messages.up.sql", size: 357, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd5, 0x61, 0x42, 0xb6, 0x8c, 0x7f, 0x2d, 0xec, 0xa9, 0x6d, 0x3d, 0x0, 0xa3, 0x32, 0xd8, 0x4a, 0x38, 0x5c, 0x97, 0xfc, 0x68, 0xde, 0xa9, 0xb7, 0xd8, 0xde, 0xb, 0x29, 0x93, 0xdc, 0x81, 0xf8}}
 	return a, nil
 }
@@ -1047,7 +1048,7 @@ func _1627388946_add_communities_synced_atUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1627388946_add_communities_synced_at.up.sql", size: 87, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1627388946_add_communities_synced_at.up.sql", size: 87, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc1, 0xbd, 0x9b, 0x6a, 0xc9, 0x1a, 0x7a, 0x34, 0xcf, 0x5f, 0x80, 0x9e, 0x8c, 0x1c, 0xc0, 0xec, 0x4e, 0x78, 0xb0, 0x2d, 0x15, 0x77, 0x38, 0x4a, 0x6a, 0x5, 0x84, 0xf5, 0x8d, 0x8b, 0xbe, 0x9}}
 	return a, nil
 }
@@ -1067,7 +1068,7 @@ func _1628280060_createUsermessagesIndexSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1628280060_create-usermessages-index.sql", size: 80, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1628280060_create-usermessages-index.sql", size: 80, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x10, 0x6f, 0x70, 0x47, 0x40, 0xab, 0xa8, 0x60, 0xe0, 0xf9, 0x8, 0x7e, 0x19, 0x9d, 0xba, 0x33, 0x16, 0xfc, 0x3c, 0xdc, 0xa8, 0xa6, 0x53, 0x61, 0x39, 0x82, 0x91, 0xcf, 0x69, 0xd8, 0xf2, 0xcf}}
 	return a, nil
 }
@@ -1087,7 +1088,7 @@ func _1632303896_modify_contacts_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1632303896_modify_contacts_table.up.sql", size: 1574, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1632303896_modify_contacts_table.up.sql", size: 1574, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x81, 0x1e, 0x6c, 0x3c, 0xd, 0xd7, 0x7d, 0xbb, 0x19, 0xbc, 0xe4, 0x7, 0xfd, 0xf8, 0x66, 0x6d, 0x78, 0xf6, 0x4, 0xe6, 0x51, 0xe4, 0xe6, 0xdc, 0xe, 0x5a, 0x2e, 0xac, 0xe6, 0xe7, 0x24, 0x69}}
 	return a, nil
 }
@@ -1107,7 +1108,7 @@ func _1633349838_add_emoji_column_in_chatsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1633349838_add_emoji_column_in_chats.up.sql", size: 52, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1633349838_add_emoji_column_in_chats.up.sql", size: 52, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xcb, 0x33, 0xcb, 0x3b, 0xa9, 0x99, 0x77, 0x6a, 0xea, 0xc4, 0x39, 0xd7, 0xa1, 0x49, 0xa7, 0xdf, 0xff, 0x72, 0xda, 0x34, 0x21, 0x67, 0x66, 0xca, 0x65, 0x46, 0x1, 0xa6, 0x4e, 0xf9, 0x38, 0x86}}
 	return a, nil
 }
@@ -1127,7 +1128,7 @@ func _1634831235_add_highlight_column_in_chatsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1634831235_add_highlight_column_in_chats.up.sql", size: 62, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1634831235_add_highlight_column_in_chats.up.sql", size: 62, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xaa, 0x63, 0x5c, 0x73, 0x19, 0x83, 0xbd, 0x35, 0x80, 0x9f, 0x66, 0xec, 0x4c, 0xbc, 0x9d, 0x2d, 0x52, 0x91, 0x6d, 0xb3, 0x2b, 0x87, 0xde, 0x24, 0x46, 0x5c, 0xd, 0xfd, 0x78, 0xf5, 0xe3, 0xe9}}
 	return a, nil
 }
@@ -1147,7 +1148,7 @@ func _1634896007_add_last_updated_locally_and_removedUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1634896007_add_last_updated_locally_and_removed.up.sql", size: 131, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1634896007_add_last_updated_locally_and_removed.up.sql", size: 131, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2e, 0xa8, 0x34, 0xe2, 0xc0, 0x62, 0xc8, 0xd6, 0x5a, 0x87, 0xe3, 0x70, 0xe1, 0xc4, 0x16, 0x9c, 0x60, 0x2e, 0x98, 0xf0, 0x91, 0x84, 0xbe, 0xe0, 0xdf, 0x3e, 0x4d, 0x24, 0xc4, 0x6c, 0x40, 0x17}}
 	return a, nil
 }
@@ -1167,7 +1168,7 @@ func _1635840039_add_clock_read_at_column_in_chatsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1635840039_add_clock_read_at_column_in_chats.up.sql", size: 245, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1635840039_add_clock_read_at_column_in_chats.up.sql", size: 245, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6c, 0xba, 0x3f, 0xba, 0x1a, 0x71, 0xa8, 0x9, 0x19, 0xbe, 0x1e, 0x38, 0x50, 0x30, 0x3a, 0x52, 0x15, 0x29, 0xee, 0x49, 0x19, 0x6f, 0x53, 0xc2, 0xc6, 0x6c, 0xd9, 0x80, 0x7e, 0xb9, 0x58, 0x7a}}
 	return a, nil
 }
@@ -1187,7 +1188,7 @@ func _1637852321_add_received_invitation_admin_column_in_chatsUpSql() (*asset, e
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1637852321_add_received_invitation_admin_column_in_chats.up.sql", size: 72, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1637852321_add_received_invitation_admin_column_in_chats.up.sql", size: 72, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x70, 0x8b, 0x92, 0x56, 0x83, 0x70, 0x7f, 0x6, 0xb2, 0xd, 0x1c, 0x2f, 0xcc, 0x93, 0xc3, 0x85, 0x8c, 0xc2, 0x38, 0x94, 0x7e, 0x88, 0x3f, 0x39, 0x34, 0xf8, 0x90, 0xcf, 0x83, 0x68, 0x3d, 0xe5}}
 	return a, nil
 }
@@ -1207,7 +1208,7 @@ func _1645034601_display_nameUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1645034601_display_name.up.sql", size: 110, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1645034601_display_name.up.sql", size: 110, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x15, 0xfc, 0xda, 0x70, 0x53, 0x19, 0x90, 0x20, 0x4, 0x1c, 0x99, 0x42, 0x53, 0x1a, 0xd6, 0xb8, 0xbb, 0x8a, 0xe8, 0xbe, 0xcc, 0xb7, 0xc, 0x7f, 0x73, 0x50, 0x18, 0xf1, 0x8b, 0x18, 0x54, 0x64}}
 	return a, nil
 }
@@ -1227,7 +1228,7 @@ func _1645034602_add_mutual_contact_requestUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1645034602_add_mutual_contact_request.up.sql", size: 454, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1645034602_add_mutual_contact_request.up.sql", size: 454, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1a, 0xe0, 0x5d, 0x68, 0xb8, 0x50, 0xa4, 0xbb, 0x3e, 0x4f, 0x2, 0x87, 0xad, 0x87, 0x6e, 0x38, 0xdf, 0xc8, 0x4c, 0xe2, 0x5f, 0xd1, 0x6, 0xdc, 0xe7, 0xbd, 0x4a, 0x9c, 0xf3, 0x91, 0xa1, 0x51}}
 	return a, nil
 }
@@ -1247,7 +1248,7 @@ func _1650373957_add_contact_request_stateUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1650373957_add_contact_request_state.up.sql", size: 59, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1650373957_add_contact_request_state.up.sql", size: 59, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x5e, 0xc1, 0x3f, 0x29, 0xe, 0x19, 0x86, 0x1a, 0x4c, 0x6c, 0x2a, 0x90, 0x9d, 0xdf, 0xb1, 0xb, 0x72, 0x25, 0xcd, 0x6c, 0x5f, 0xd, 0x51, 0x9e, 0x85, 0xc0, 0x9, 0xb7, 0xbc, 0x87, 0x23, 0xec}}
 	return a, nil
 }
@@ -1267,7 +1268,7 @@ func _1656958989_contact_verificationUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1656958989_contact_verification.up.sql", size: 624, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1656958989_contact_verification.up.sql", size: 624, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3a, 0x3f, 0x28, 0x38, 0x33, 0xdb, 0xe9, 0x4d, 0xc0, 0x54, 0x8c, 0x2a, 0x73, 0xc4, 0xdd, 0x5c, 0xc5, 0x1a, 0x93, 0x4b, 0x6, 0x13, 0xbe, 0x42, 0xd2, 0x7f, 0xd4, 0xc, 0xc5, 0x4e, 0x6d, 0xce}}
 	return a, nil
 }
@@ -1287,7 +1288,7 @@ func _1658236268_add_discord_message_authors_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1658236268_add_discord_message_authors_table.up.sql", size: 191, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1658236268_add_discord_message_authors_table.up.sql", size: 191, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3d, 0xb7, 0xdb, 0x79, 0x1, 0x15, 0xe7, 0x76, 0x5d, 0x22, 0x54, 0x82, 0x9a, 0xbe, 0x24, 0xc1, 0x82, 0xcf, 0x67, 0x91, 0x53, 0xcc, 0xac, 0x74, 0x18, 0x61, 0x69, 0x68, 0x19, 0xca, 0x2b, 0xa8}}
 	return a, nil
 }
@@ -1307,7 +1308,7 @@ func _1659619997_add_discord_messages_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1659619997_add_discord_messages_table.up.sql", size: 371, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1659619997_add_discord_messages_table.up.sql", size: 371, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xde, 0x12, 0x9c, 0x96, 0xe2, 0x42, 0x3f, 0x94, 0x62, 0xc2, 0x76, 0xab, 0x3b, 0x4c, 0x85, 0x36, 0x48, 0xcc, 0x73, 0x60, 0x93, 0x5a, 0xd6, 0x7, 0xd6, 0x0, 0xee, 0x1b, 0x1e, 0x34, 0x58, 0x99}}
 	return a, nil
 }
@@ -1327,7 +1328,7 @@ func _1660226788_create_chat_identity_social_linksUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1660226788_create_chat_identity_social_links.up.sql", size: 318, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1660226788_create_chat_identity_social_links.up.sql", size: 318, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3c, 0x76, 0x40, 0xe9, 0x85, 0xc4, 0x38, 0xf8, 0xe5, 0x5d, 0xe8, 0x13, 0x46, 0x1b, 0xc, 0x1, 0xe9, 0x2f, 0x74, 0xd1, 0x79, 0x59, 0xa4, 0xdb, 0x4a, 0x4a, 0xf4, 0x98, 0x58, 0x3c, 0x57, 0xd3}}
 	return a, nil
 }
@@ -1347,7 +1348,7 @@ func _1660226789_add_walletconnectsessions_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1660226789_add_walletconnectsessions_table.up.sql", size: 215, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1660226789_add_walletconnectsessions_table.up.sql", size: 215, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf8, 0x5c, 0x72, 0x2, 0xed, 0x36, 0x19, 0x91, 0x4d, 0x1a, 0xc1, 0xab, 0x84, 0xfa, 0x41, 0xb1, 0x46, 0xa5, 0xdb, 0x3f, 0x76, 0x47, 0xd3, 0x75, 0x3c, 0x6a, 0x8e, 0x78, 0xe6, 0x41, 0xdc, 0x7f}}
 	return a, nil
 }
@@ -1367,7 +1368,7 @@ func _1661242854_add_communities_requests_to_leaveUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1661242854_add_communities_requests_to_leave.up.sql", size: 204, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1661242854_add_communities_requests_to_leave.up.sql", size: 204, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x49, 0x2e, 0x7d, 0x14, 0xef, 0x6e, 0x95, 0x4b, 0x6, 0x70, 0x2e, 0xd1, 0xf6, 0x59, 0xf9, 0xe, 0x56, 0xa, 0x9c, 0x80, 0x18, 0xca, 0xb9, 0x49, 0x19, 0xf, 0x89, 0x94, 0x36, 0x6d, 0x93, 0x9a}}
 	return a, nil
 }
@@ -1387,7 +1388,7 @@ func _1662044232_add_chat_imageUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1662044232_add_chat_image.up.sql", size: 49, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1662044232_add_chat_image.up.sql", size: 49, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb3, 0x74, 0xdf, 0x50, 0x79, 0x73, 0x9e, 0xd0, 0xff, 0xa4, 0xd3, 0x87, 0xc3, 0x48, 0x31, 0x6c, 0xdf, 0xa6, 0x20, 0x85, 0xe6, 0x4e, 0x19, 0x9d, 0xef, 0xcc, 0x84, 0x2b, 0x5d, 0x44, 0x34, 0x6}}
 	return a, nil
 }
@@ -1407,7 +1408,7 @@ func _1662106895_add_chat_first_message_timestampUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1662106895_add_chat_first_message_timestamp.up.sql", size: 113, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1662106895_add_chat_first_message_timestamp.up.sql", size: 113, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8b, 0x55, 0x74, 0xfa, 0xf5, 0x51, 0x85, 0x19, 0xfd, 0xfb, 0x6, 0x79, 0x4d, 0x1d, 0xd, 0x3, 0x46, 0x66, 0x34, 0x1e, 0xce, 0x91, 0x21, 0x29, 0xf6, 0x71, 0xe7, 0x31, 0x39, 0x8f, 0x9d, 0x5}}
 	return a, nil
 }
@@ -1427,7 +1428,7 @@ func _1662723928_add_discord_author_image_fieldsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1662723928_add_discord_author_image_fields.up.sql", size: 75, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1662723928_add_discord_author_image_fields.up.sql", size: 75, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1e, 0x5b, 0x48, 0x57, 0x98, 0x55, 0x9a, 0xf1, 0x75, 0xf7, 0xb5, 0x41, 0x5e, 0x96, 0xc5, 0xce, 0xfc, 0x30, 0x5c, 0x15, 0x35, 0x9e, 0x4e, 0x4a, 0x3b, 0x38, 0x42, 0xc4, 0x27, 0x3c, 0x87, 0xbf}}
 	return a, nil
 }
@@ -1447,7 +1448,7 @@ func _1664195977_add_deleted_for_mesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1664195977_add_deleted_for_mes.up.sql", size: 352, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1664195977_add_deleted_for_mes.up.sql", size: 352, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7d, 0x9d, 0x13, 0x9, 0xaa, 0x44, 0x14, 0x93, 0xe2, 0xf5, 0x53, 0xb7, 0x79, 0xa8, 0x18, 0xf0, 0x6c, 0xa4, 0x9c, 0x73, 0xc1, 0xaa, 0xc5, 0x2e, 0xc5, 0x41, 0xd7, 0x24, 0xb0, 0xd7, 0xb8, 0xdf}}
 	return a, nil
 }
@@ -1467,7 +1468,7 @@ func _1664367420_add_discord_attachments_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1664367420_add_discord_attachments_table.up.sql", size: 350, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1664367420_add_discord_attachments_table.up.sql", size: 350, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x48, 0xe1, 0xb6, 0x4f, 0x6f, 0x92, 0x0, 0xb4, 0xf, 0x55, 0x12, 0x1c, 0x98, 0x6d, 0xbc, 0x1e, 0xfd, 0xae, 0x1c, 0xce, 0xd1, 0x3d, 0x2, 0x21, 0x2e, 0xc0, 0x13, 0xa, 0xb2, 0xec, 0x81, 0x13}}
 	return a, nil
 }
@@ -1487,7 +1488,7 @@ func _1665079662_add_spectated_column_in_communitiesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1665079662_add_spectated_column_in_communities.up.sql", size: 86, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1665079662_add_spectated_column_in_communities.up.sql", size: 86, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa0, 0x5d, 0xfe, 0xe2, 0xbe, 0xdf, 0xba, 0x45, 0xe9, 0xfc, 0xa7, 0x5f, 0xda, 0x19, 0xdb, 0x40, 0x96, 0x59, 0x78, 0xa, 0xd7, 0x4a, 0xca, 0x1a, 0x93, 0xfb, 0xae, 0x6d, 0x74, 0x7, 0x36, 0xdd}}
 	return a, nil
 }
@@ -1507,7 +1508,7 @@ func _1665479047_add_community_id_in_notificationsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1665479047_add_community_id_in_notifications.up.sql", size: 169, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1665479047_add_community_id_in_notifications.up.sql", size: 169, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd9, 0x8f, 0x8b, 0x1c, 0xaa, 0x6a, 0x56, 0xd6, 0xa5, 0x88, 0x57, 0x13, 0x8f, 0xea, 0xb9, 0x23, 0x82, 0x50, 0xb7, 0x65, 0x1f, 0xab, 0xfa, 0x23, 0x6f, 0x0, 0x7, 0xb6, 0x6e, 0xb5, 0x85, 0x44}}
 	return a, nil
 }
@@ -1527,7 +1528,7 @@ func _1665484435_add_encrypted_messagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1665484435_add_encrypted_messages.up.sql", size: 402, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1665484435_add_encrypted_messages.up.sql", size: 402, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8f, 0x5c, 0x1e, 0x1c, 0x7f, 0xae, 0x5f, 0xeb, 0x3c, 0x6c, 0xcd, 0xc2, 0x99, 0x48, 0x5c, 0x83, 0xa0, 0xa2, 0x97, 0x5, 0x39, 0x82, 0x71, 0x90, 0x47, 0x21, 0x84, 0x29, 0x19, 0xa4, 0x7a, 0x90}}
 	return a, nil
 }
@@ -1547,7 +1548,7 @@ func _1665560200_add_contact_verification_individualUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1665560200_add_contact_verification_individual.up.sql", size: 509, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1665560200_add_contact_verification_individual.up.sql", size: 509, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc5, 0xbb, 0x61, 0xfd, 0xbf, 0x33, 0x1d, 0x4e, 0x5f, 0xbd, 0x86, 0x42, 0xb0, 0x6c, 0xf7, 0x39, 0x19, 0x6e, 0x72, 0x35, 0xfd, 0x1b, 0xd6, 0xbd, 0xf6, 0x81, 0x21, 0xc4, 0xaa, 0x6, 0x62, 0x40}}
 	return a, nil
 }
@@ -1567,7 +1568,7 @@ func _1670921937_add_album_idUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1670921937_add_album_id.up.sql", size: 55, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1670921937_add_album_id.up.sql", size: 55, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7e, 0xae, 0x83, 0x58, 0xb7, 0x77, 0x5, 0xca, 0xe3, 0xda, 0x32, 0x8f, 0x7b, 0xa4, 0x2f, 0x4c, 0xaf, 0x5f, 0xfa, 0x94, 0x36, 0xe4, 0xf9, 0x7, 0xc6, 0xd6, 0xb7, 0x90, 0xf3, 0xe5, 0xb5, 0x3}}
 	return a, nil
 }
@@ -1587,7 +1588,7 @@ func _1673373000_add_repliedUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1673373000_add_replied.up.sql", size: 67, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1673373000_add_replied.up.sql", size: 67, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd5, 0x1c, 0xae, 0xf2, 0xf, 0xb4, 0xc2, 0xba, 0x3c, 0xfe, 0x7b, 0xb0, 0xf, 0xf, 0xd5, 0xbc, 0xe2, 0xa7, 0xad, 0x50, 0xd9, 0x5a, 0xe8, 0x96, 0x22, 0x65, 0x89, 0xcf, 0x4a, 0x9a, 0x1b, 0x94}}
 	return a, nil
 }
@@ -1607,7 +1608,7 @@ func _1673428910_add_image_width_heightUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1673428910_add_image_width_height.up.sql", size: 117, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1673428910_add_image_width_height.up.sql", size: 117, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x74, 0xda, 0x93, 0x2a, 0x9b, 0x6b, 0xb7, 0x96, 0xcd, 0xac, 0xf, 0xaf, 0x54, 0x89, 0x9e, 0x91, 0x5b, 0xd0, 0x4a, 0xa, 0x8d, 0x9e, 0x80, 0x66, 0x26, 0x9e, 0xb5, 0xa9, 0x8, 0xec, 0x2d, 0x6c}}
 	return a, nil
 }
@@ -1627,7 +1628,7 @@ func _1674210659_add_contact_request_local_clockUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1674210659_add_contact_request_local_clock.up.sql", size: 691, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1674210659_add_contact_request_local_clock.up.sql", size: 691, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x92, 0x72, 0x39, 0xfe, 0x72, 0x98, 0xfc, 0x91, 0x20, 0x10, 0xe8, 0xf5, 0xac, 0x79, 0xa8, 0x1c, 0xca, 0x7b, 0x35, 0xa, 0xc1, 0x56, 0x49, 0x9a, 0xfc, 0xbd, 0x64, 0x9d, 0xdf, 0xd2, 0x60, 0x70}}
 	return a, nil
 }
@@ -1647,7 +1648,7 @@ func _1675212323_add_deleted_byUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1675212323_add_deleted_by.up.sql", size: 57, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1675212323_add_deleted_by.up.sql", size: 57, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x85, 0x37, 0x29, 0x2f, 0xd, 0x5a, 0xb6, 0xdb, 0xa7, 0x8, 0x86, 0xfc, 0x7a, 0x70, 0xd8, 0x4d, 0xe6, 0xf0, 0x57, 0xe7, 0xd1, 0x95, 0xd5, 0x4, 0x40, 0x2f, 0x7a, 0x5, 0x4f, 0xc2, 0x97, 0xbc}}
 	return a, nil
 }
@@ -1667,7 +1668,7 @@ func _1675247084_add_activity_center_statesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1675247084_add_activity_center_states.up.sql", size: 136, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1675247084_add_activity_center_states.up.sql", size: 136, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xba, 0x90, 0x7d, 0x55, 0xc7, 0x40, 0x29, 0x26, 0x97, 0x45, 0x5c, 0xdf, 0xba, 0x61, 0xb, 0xfc, 0x3d, 0x7a, 0x6c, 0x42, 0xe4, 0x95, 0x78, 0xb0, 0xc5, 0x1f, 0x73, 0xe9, 0x33, 0x51, 0xc8, 0x81}}
 	return a, nil
 }
@@ -1687,7 +1688,7 @@ func _1675272329_fix_protocol_migrationUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1675272329_fix_protocol_migration.up.sql", size: 183, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1675272329_fix_protocol_migration.up.sql", size: 183, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb6, 0xe0, 0x11, 0x4c, 0x66, 0x55, 0x72, 0xd3, 0xe6, 0x98, 0xa4, 0xe7, 0x44, 0xf9, 0x3b, 0x3a, 0x3f, 0xd9, 0x91, 0x1e, 0x4f, 0xfc, 0x56, 0x63, 0xe5, 0xa4, 0x83, 0xfc, 0x7c, 0xcf, 0x18, 0x99}}
 	return a, nil
 }
@@ -1707,7 +1708,7 @@ func _1676998418_fix_activity_center_migrationUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1676998418_fix_activity_center_migration.up.sql", size: 178, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1676998418_fix_activity_center_migration.up.sql", size: 178, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8a, 0xdc, 0x64, 0xb1, 0x47, 0x67, 0xda, 0x2c, 0x26, 0x29, 0x6b, 0x6f, 0xb, 0xfa, 0x45, 0xf3, 0xad, 0x8b, 0x1a, 0x5f, 0x1c, 0xed, 0xd7, 0xea, 0x54, 0xf5, 0x3f, 0xb8, 0xf6, 0xf9, 0x44, 0x53}}
 	return a, nil
 }
@@ -1727,7 +1728,7 @@ func _1677278861_add_deleted_column_to_activity_center_notifications_tableUpSql(
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1677278861_add_deleted_column_to_activity_center_notifications_table.up.sql", size: 381, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1677278861_add_deleted_column_to_activity_center_notifications_table.up.sql", size: 381, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x38, 0x3a, 0x95, 0xaf, 0x81, 0xb0, 0x85, 0x8d, 0x73, 0xda, 0x7b, 0x2a, 0x35, 0xa6, 0xaa, 0xcc, 0x4c, 0x35, 0xa3, 0xa8, 0xbd, 0xd1, 0x37, 0xe8, 0x5d, 0x83, 0xa4, 0x33, 0x1f, 0x10, 0xe4, 0xe6}}
 	return a, nil
 }
@@ -1747,7 +1748,7 @@ func _1677486338_add_community_tokens_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1677486338_add_community_tokens_table.up.sql", size: 527, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1677486338_add_community_tokens_table.up.sql", size: 527, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xfb, 0x7b, 0x3d, 0x7e, 0x79, 0xc4, 0x3a, 0xf1, 0xda, 0x4b, 0xc6, 0xd1, 0xd, 0xfb, 0xb2, 0xb9, 0x7f, 0x81, 0x29, 0xab, 0xd8, 0x1, 0x20, 0xd7, 0xe1, 0xaf, 0x3e, 0x67, 0x1b, 0xdb, 0xf9, 0xd5}}
 	return a, nil
 }
@@ -1767,7 +1768,7 @@ func _1678292329_add_collapsed_categoriesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1678292329_add_collapsed_categories.up.sql", size: 170, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1678292329_add_collapsed_categories.up.sql", size: 170, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x46, 0x63, 0x86, 0xd5, 0x7, 0xe2, 0x25, 0x15, 0x1b, 0xfe, 0xf3, 0xe, 0x50, 0x48, 0x11, 0x3c, 0x7c, 0xc6, 0xe5, 0xab, 0x8d, 0x1f, 0xe8, 0x3c, 0xcb, 0xf0, 0x8d, 0xa7, 0x49, 0x4c, 0x16, 0x4f}}
 	return a, nil
 }
@@ -1787,7 +1788,7 @@ func _1678800760_add_index_to_raw_messagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1678800760_add_index_to_raw_messages.up.sql", size: 88, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1678800760_add_index_to_raw_messages.up.sql", size: 88, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9d, 0xd9, 0x8d, 0x22, 0x46, 0xae, 0x7b, 0x53, 0x3e, 0x51, 0x39, 0xad, 0xad, 0x38, 0x50, 0x6, 0xfa, 0xb9, 0xc4, 0x9f, 0x8d, 0xd2, 0x67, 0x0, 0xef, 0x58, 0x13, 0xab, 0x6a, 0x67, 0xf3, 0x7e}}
 	return a, nil
 }
@@ -1807,7 +1808,7 @@ func _1678877478_add_communities_requests_to_join_revealed_addresses_tableUpSql(
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1678877478_add_communities_requests_to_join_revealed_addresses_table.up.sql", size: 168, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1678877478_add_communities_requests_to_join_revealed_addresses_table.up.sql", size: 168, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x82, 0x1, 0xb4, 0xb2, 0x94, 0x25, 0xd5, 0x2e, 0x45, 0xc3, 0xb1, 0x2c, 0xeb, 0x1a, 0x52, 0xe0, 0x4b, 0x9b, 0x46, 0xf4, 0xc, 0xac, 0x1, 0x1e, 0x90, 0xbc, 0x64, 0x38, 0x10, 0xf1, 0xaf, 0xac}}
 	return a, nil
 }
@@ -1827,7 +1828,7 @@ func _1679326850_add_community_token_ownersUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1679326850_add_community_token_owners.up.sql", size: 206, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1679326850_add_community_token_owners.up.sql", size: 206, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe9, 0xe6, 0x25, 0x67, 0xd1, 0xd6, 0x54, 0x88, 0xb1, 0x80, 0x1e, 0x2d, 0x9c, 0xfa, 0x1c, 0xc7, 0x63, 0x6e, 0xf9, 0x66, 0xb1, 0x68, 0xc6, 0xf8, 0x51, 0xb6, 0xd5, 0x4e, 0x93, 0x39, 0x5e, 0xc0}}
 	return a, nil
 }
@@ -1847,7 +1848,7 @@ func _1680011500_add_album_images_countUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1680011500_add_album_images_count.up.sql", size: 71, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1680011500_add_album_images_count.up.sql", size: 71, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x2e, 0x55, 0x99, 0x31, 0xcc, 0x80, 0x78, 0xc3, 0x51, 0x13, 0x63, 0x6f, 0x1a, 0xfd, 0x53, 0xd2, 0xf4, 0x13, 0x4b, 0xb2, 0x4f, 0x99, 0xb8, 0x7b, 0x7, 0x99, 0xb6, 0xab, 0x88, 0x2e, 0x7, 0x8}}
 	return a, nil
 }
@@ -1867,7 +1868,7 @@ func _1680114896_add_index_on_album_idUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1680114896_add_index_on_album_id.up.sql", size: 83, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1680114896_add_index_on_album_id.up.sql", size: 83, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb3, 0x7e, 0xd5, 0xcd, 0x2d, 0xab, 0xd4, 0x32, 0x26, 0x50, 0x3a, 0x5b, 0x8e, 0x1c, 0xcc, 0x35, 0xf8, 0xa1, 0x2a, 0xc1, 0x23, 0xf6, 0x90, 0xfe, 0x84, 0x3, 0xde, 0x5a, 0xee, 0xc6, 0xfc, 0x2a}}
 	return a, nil
 }
@@ -1887,7 +1888,7 @@ func _1681655289_add_mute_tillUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1681655289_add_mute_till.up.sql", size: 51, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1681655289_add_mute_till.up.sql", size: 51, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd1, 0xbe, 0xce, 0xb8, 0xe1, 0x30, 0xe7, 0xa7, 0xe0, 0x7d, 0x97, 0xf4, 0x26, 0xb8, 0x57, 0x1d, 0x2a, 0xed, 0x18, 0xf2, 0xa, 0xe3, 0x77, 0x29, 0x18, 0x55, 0x9, 0x74, 0x2c, 0x24, 0x5a, 0x19}}
 	return a, nil
 }
@@ -1907,7 +1908,7 @@ func _1681934966_add_index_response_toUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1681934966_add_index_response_to.up.sql", size: 70, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1681934966_add_index_response_to.up.sql", size: 70, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3b, 0xed, 0xa6, 0x7e, 0x51, 0xf2, 0xa1, 0x3c, 0x78, 0x9a, 0xa7, 0x7a, 0x51, 0x25, 0x7d, 0xdd, 0x4b, 0xf3, 0x45, 0xeb, 0x3f, 0xad, 0x23, 0x3e, 0xac, 0x16, 0x28, 0x62, 0x7, 0x8c, 0xe0, 0xa0}}
 	return a, nil
 }
@@ -1927,7 +1928,7 @@ func _1682528339_add_index_user_messages_unseenUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1682528339_add_index_user_messages_unseen.up.sql", size: 104, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1682528339_add_index_user_messages_unseen.up.sql", size: 104, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x35, 0xfa, 0x98, 0xdd, 0x74, 0x5e, 0x21, 0x1f, 0xf2, 0x56, 0x17, 0x96, 0xfe, 0xbb, 0x44, 0x4c, 0xa1, 0xd8, 0x9f, 0x2e, 0x6, 0x2f, 0xd8, 0x23, 0xec, 0x94, 0x8c, 0x53, 0xf3, 0xf0, 0x40, 0xe7}}
 	return a, nil
 }
@@ -1947,7 +1948,7 @@ func _1683707289_recreate_deleted_for_mesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1683707289_recreate_deleted_for_mes.up.sql", size: 408, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1683707289_recreate_deleted_for_mes.up.sql", size: 408, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x5b, 0x9d, 0xd6, 0x45, 0x41, 0x29, 0x44, 0xf6, 0x14, 0x38, 0xeb, 0xdf, 0x6b, 0x5d, 0x9c, 0x45, 0x4b, 0xc3, 0xa8, 0xbd, 0x38, 0x14, 0xd9, 0x73, 0xf1, 0x51, 0xbb, 0x9f, 0x14, 0x36, 0xf2, 0x11}}
 	return a, nil
 }
@@ -1967,7 +1968,7 @@ func _1683725607_mark_discord_messages_as_seenUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1683725607_mark_discord_messages_as_seen.up.sql", size: 108, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1683725607_mark_discord_messages_as_seen.up.sql", size: 108, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd7, 0x2a, 0xc3, 0x43, 0xea, 0x5e, 0x3, 0x2e, 0xce, 0x79, 0xea, 0xa5, 0x67, 0x61, 0x8c, 0xe4, 0xb9, 0xb7, 0x4d, 0xd5, 0xd5, 0xb0, 0x35, 0xc8, 0x2b, 0xa0, 0x3f, 0xd8, 0xde, 0xea, 0x4e, 0x16}}
 	return a, nil
 }
@@ -1987,7 +1988,7 @@ func _1684174617_add_url_previews_to_user_messagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1684174617_add_url_previews_to_user_messages.up.sql", size: 58, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1684174617_add_url_previews_to_user_messages.up.sql", size: 58, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xdc, 0xb0, 0x72, 0xe3, 0xe4, 0xa9, 0x63, 0x82, 0xea, 0x52, 0x70, 0xb6, 0xa0, 0x73, 0x55, 0x7a, 0x78, 0xa8, 0xd2, 0xb0, 0xf4, 0x78, 0x8a, 0xd, 0x5a, 0xa2, 0x9d, 0x92, 0xdc, 0xce, 0x1c, 0x71}}
 	return a, nil
 }
@@ -2007,7 +2008,7 @@ func _1684175608_add_token_balancesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1684175608_add_token_balances.up.sql", size: 467, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1684175608_add_token_balances.up.sql", size: 467, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1b, 0x4e, 0xe0, 0x48, 0x34, 0x1, 0x4d, 0x88, 0x11, 0x54, 0x20, 0x52, 0x5c, 0x57, 0x14, 0xa9, 0xa9, 0x36, 0xa4, 0x28, 0x59, 0x48, 0xa8, 0xa, 0x76, 0xec, 0x37, 0xee, 0x9e, 0xd2, 0x20, 0xaa}}
 	return a, nil
 }
@@ -2027,7 +2028,7 @@ func _1684979808_sync_activity_center_notificationsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1684979808_sync_activity_center_notifications.up.sql", size: 169, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1684979808_sync_activity_center_notifications.up.sql", size: 169, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd8, 0xf5, 0xf7, 0x94, 0xa9, 0xa1, 0x60, 0x26, 0x9d, 0xca, 0x31, 0xf, 0x14, 0xd, 0x70, 0xf8, 0xab, 0x40, 0x29, 0x73, 0x61, 0xbd, 0x1b, 0xb6, 0xc4, 0x31, 0x77, 0x9e, 0x32, 0xa8, 0xce, 0x6d}}
 	return a, nil
 }
@@ -2047,7 +2048,7 @@ func _1685383829_add_communities_mute_tillUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1685383829_add_communities_mute_till.up.sql", size: 69, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1685383829_add_communities_mute_till.up.sql", size: 69, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xbf, 0x58, 0x96, 0xe5, 0x66, 0xcb, 0xde, 0xed, 0x76, 0xb8, 0x5a, 0x86, 0x81, 0x9a, 0x60, 0x51, 0x12, 0x37, 0x54, 0x9a, 0x36, 0x3e, 0xd1, 0x4a, 0xbe, 0x9a, 0xab, 0x20, 0x7f, 0x1d, 0xf4, 0x73}}
 	return a, nil
 }
@@ -2067,7 +2068,7 @@ func _1685964183_add_chainids_to_revealed_addressesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1685964183_add_chainids_to_revealed_addresses.up.sql", size: 88, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1685964183_add_chainids_to_revealed_addresses.up.sql", size: 88, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc, 0xb5, 0xa8, 0xd7, 0xad, 0x9c, 0x54, 0xa5, 0xe9, 0xdb, 0x42, 0x2d, 0xd0, 0xd7, 0x22, 0x1, 0x93, 0xf3, 0x4f, 0x53, 0xf7, 0x1e, 0xbe, 0x4b, 0xac, 0xc7, 0x63, 0x15, 0xdf, 0xe0, 0x6, 0xf8}}
 	return a, nil
 }
@@ -2087,7 +2088,7 @@ func _1687370421_add_communities_muted_till_newUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1687370421_add_communities_muted_till_new.up.sql", size: 635, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1687370421_add_communities_muted_till_new.up.sql", size: 635, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x65, 0x73, 0x96, 0x1d, 0xc8, 0x3e, 0xca, 0xf5, 0xdc, 0xe3, 0xac, 0x3f, 0x9c, 0xc3, 0x67, 0x12, 0x9c, 0x19, 0x1, 0x4, 0x2b, 0xea, 0x6b, 0xe1, 0x59, 0x59, 0x89, 0x3d, 0xef, 0x4a, 0x6e, 0xbe}}
 	return a, nil
 }
@@ -2107,7 +2108,7 @@ func _1687416607_add_communities_check_channel_permission_responses_tableUpSql()
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1687416607_add_communities_check_channel_permission_responses_table.up.sql", size: 739, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1687416607_add_communities_check_channel_permission_responses_table.up.sql", size: 739, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc2, 0x6, 0x3, 0x1a, 0xde, 0x9d, 0xbc, 0x50, 0x9d, 0xf1, 0x6d, 0x5a, 0x1c, 0x28, 0x92, 0x19, 0x89, 0x76, 0x4e, 0x8b, 0x60, 0xa9, 0xf, 0xe9, 0x76, 0xf1, 0xee, 0x75, 0x92, 0xbd, 0xda, 0x72}}
 	return a, nil
 }
@@ -2127,7 +2128,7 @@ func _1687856939_add_community_tokens_decimalsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1687856939_add_community_tokens_decimals.up.sql", size: 65, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1687856939_add_community_tokens_decimals.up.sql", size: 65, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x59, 0x76, 0x42, 0x70, 0xc9, 0x7b, 0x16, 0xf6, 0xfe, 0x7, 0x1c, 0x99, 0xe5, 0x38, 0xfd, 0xa0, 0x3b, 0x93, 0x40, 0xbc, 0x66, 0xc2, 0xd1, 0xdd, 0xe9, 0xc7, 0xbf, 0xae, 0x36, 0xcc, 0x46, 0x57}}
 	return a, nil
 }
@@ -2147,7 +2148,7 @@ func _1687959987_modify_community_tokens_supply_as_stringUpSql() (*asset, error)
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1687959987_modify_community_tokens_supply_as_string.up.sql", size: 77, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1687959987_modify_community_tokens_supply_as_string.up.sql", size: 77, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x57, 0x89, 0xbf, 0x9b, 0xed, 0x9b, 0x18, 0x3f, 0x84, 0xb5, 0x3c, 0x78, 0x40, 0x60, 0xea, 0x33, 0x26, 0x50, 0x3, 0xda, 0x28, 0x92, 0xd3, 0xb6, 0xff, 0x40, 0xa7, 0x19, 0x2, 0xa7, 0x17, 0xf9}}
 	return a, nil
 }
@@ -2167,7 +2168,7 @@ func _1689258900_add_airdrop_address_to_revealed_addressesUpSql() (*asset, error
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1689258900_add_airdrop_address_to_revealed_addresses.up.sql", size: 99, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1689258900_add_airdrop_address_to_revealed_addresses.up.sql", size: 99, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xea, 0x7e, 0xaf, 0x5c, 0xd, 0xe5, 0x1e, 0x67, 0x1a, 0x6d, 0xd, 0x28, 0x20, 0x7a, 0x1a, 0x45, 0x6e, 0xba, 0x80, 0x91, 0xb0, 0xd6, 0xfd, 0xc2, 0xb9, 0x42, 0x5c, 0x8d, 0x6e, 0x3e, 0x6e, 0xb2}}
 	return a, nil
 }
@@ -2187,7 +2188,7 @@ func _1689266326_create_communities_events_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1689266326_create_communities_events_table.up.sql", size: 164, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1689266326_create_communities_events_table.up.sql", size: 164, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xf5, 0x4e, 0xe, 0xba, 0x29, 0x16, 0x46, 0x38, 0x19, 0xa4, 0x5, 0x40, 0x46, 0xaf, 0x9a, 0x6, 0x89, 0xe0, 0x9c, 0xcc, 0xec, 0x8a, 0xb, 0x40, 0x85, 0x6f, 0xcc, 0x5, 0x24, 0x2a, 0x33, 0xfa}}
 	return a, nil
 }
@@ -2207,7 +2208,7 @@ func _1689931300_add_community_tokens_deployer_and_priv_levelUpSql() (*asset, er
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1689931300_add_community_tokens_deployer_and_priv_level.up.sql", size: 156, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1689931300_add_community_tokens_deployer_and_priv_level.up.sql", size: 156, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3f, 0x24, 0xd9, 0x4d, 0xe, 0x4b, 0xe3, 0x4c, 0xd1, 0xc, 0x72, 0xd4, 0x99, 0xe4, 0xb9, 0xb8, 0xe9, 0x38, 0x9e, 0x11, 0x48, 0xea, 0xe3, 0x5d, 0xd9, 0xd0, 0xef, 0x96, 0x38, 0x5a, 0xd4, 0xa5}}
 	return a, nil
 }
@@ -2227,7 +2228,7 @@ func _1693311881_add_unfurled_links_to_message_editsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1693311881_add_unfurled_links_to_message_edits.up.sql", size: 64, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1693311881_add_unfurled_links_to_message_edits.up.sql", size: 64, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6b, 0xc7, 0x7c, 0xe4, 0x80, 0x6f, 0xf8, 0x96, 0xb, 0x37, 0xff, 0xa2, 0xab, 0x1c, 0xbd, 0x25, 0x8d, 0x1e, 0x9a, 0x65, 0xe9, 0x45, 0xaf, 0x7f, 0x77, 0x84, 0x1b, 0x10, 0x1b, 0x1a, 0x5, 0xcc}}
 	return a, nil
 }
@@ -2247,7 +2248,7 @@ func _1693311981_community_shardUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1693311981_community_shard.up.sql", size: 156, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1693311981_community_shard.up.sql", size: 156, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc9, 0x12, 0xf9, 0xde, 0x49, 0x9f, 0x95, 0xaa, 0x22, 0x5e, 0x54, 0x5a, 0x1, 0xd, 0xc6, 0x1f, 0x42, 0x93, 0xe8, 0x69, 0x30, 0x11, 0x69, 0x41, 0x7f, 0x87, 0x57, 0x56, 0x2a, 0x32, 0xb9, 0x3e}}
 	return a, nil
 }
@@ -2267,7 +2268,7 @@ func _1695331492_add_status_link_previewsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1695331492_add_status_link_previews.up.sql", size: 136, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1695331492_add_status_link_previews.up.sql", size: 136, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb6, 0x7d, 0x6e, 0x86, 0xf0, 0xf8, 0x23, 0x4b, 0x16, 0x3d, 0xca, 0x8f, 0xfc, 0x8, 0x22, 0xd5, 0x70, 0x14, 0xbb, 0xdd, 0xa9, 0xb8, 0x3e, 0xc6, 0x20, 0xfb, 0x0, 0x26, 0x73, 0xcb, 0x92, 0xb2}}
 	return a, nil
 }
@@ -2287,7 +2288,7 @@ func _1695918296_add_validated_atUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1695918296_add_validated_at.up.sql", size: 377, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1695918296_add_validated_at.up.sql", size: 377, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1d, 0x48, 0xa7, 0xd5, 0xb, 0xbb, 0x23, 0xfd, 0x40, 0x49, 0x33, 0x1b, 0x5c, 0xb3, 0x5b, 0x7a, 0xd8, 0xed, 0x5, 0xd, 0xb4, 0x91, 0xa3, 0x37, 0xaf, 0xaf, 0xc6, 0xa1, 0x13, 0xeb, 0x56, 0x1d}}
 	return a, nil
 }
@@ -2307,7 +2308,7 @@ func _1697699419_community_control_node_syncUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1697699419_community_control_node_sync.up.sql", size: 435, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1697699419_community_control_node_sync.up.sql", size: 435, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x11, 0xd6, 0x63, 0x10, 0x1b, 0x16, 0x35, 0x57, 0xf1, 0x4a, 0x4, 0x51, 0xe0, 0x1, 0xe1, 0xfc, 0x12, 0x3a, 0x10, 0x4f, 0xb1, 0x96, 0x53, 0x2, 0xf5, 0x66, 0x7b, 0xe0, 0x8a, 0xdf, 0x78, 0x53}}
 	return a, nil
 }
@@ -2327,7 +2328,7 @@ func _1698137561_add_profile_showcase_tablesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1698137561_add_profile_showcase_tables.up.sql", size: 440, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1698137561_add_profile_showcase_tables.up.sql", size: 440, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7c, 0xef, 0x89, 0x68, 0x42, 0xbf, 0xff, 0xb9, 0x8f, 0x8f, 0x19, 0x91, 0xd2, 0x6a, 0x85, 0xda, 0x2c, 0x63, 0x5f, 0x3c, 0x84, 0x4, 0x93, 0x16, 0x10, 0xf0, 0xe0, 0xd9, 0x9b, 0xbe, 0x8d, 0x62}}
 	return a, nil
 }
@@ -2347,7 +2348,7 @@ func _1698137562_fix_encryption_key_idUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1698137562_fix_encryption_key_id.up.sql", size: 758, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1698137562_fix_encryption_key_id.up.sql", size: 758, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe5, 0x61, 0x1b, 0x6a, 0xb1, 0x44, 0x8d, 0x47, 0xde, 0x55, 0x45, 0x77, 0x8e, 0x4f, 0xb, 0x6a, 0x7f, 0x83, 0x56, 0x9c, 0x80, 0xc0, 0xae, 0xda, 0xd8, 0xaf, 0x7e, 0x2b, 0xb4, 0x5e, 0xc3, 0x63}}
 	return a, nil
 }
@@ -2367,7 +2368,7 @@ func _1698414646_add_paddingUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1698414646_add_padding.up.sql", size: 69, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1698414646_add_padding.up.sql", size: 69, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xbf, 0x48, 0x8e, 0x18, 0x1b, 0x81, 0x78, 0xab, 0x42, 0xcb, 0x11, 0xf5, 0xe, 0x44, 0xd4, 0x35, 0x33, 0x4e, 0x8, 0x6f, 0x14, 0x90, 0xe6, 0x2b, 0x59, 0xee, 0x87, 0xb, 0x96, 0x62, 0x3, 0x45}}
 	return a, nil
 }
@@ -2387,7 +2388,7 @@ func _1698746210_add_signature_to_revealed_addressesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1698746210_add_signature_to_revealed_addresses.up.sql", size: 87, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1698746210_add_signature_to_revealed_addresses.up.sql", size: 87, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8f, 0x64, 0xef, 0xe7, 0x5d, 0x82, 0x3e, 0x7d, 0x5a, 0x34, 0xd2, 0xa, 0x5c, 0x48, 0xef, 0x40, 0xb4, 0x7d, 0x78, 0xc8, 0x11, 0xbc, 0xf3, 0xc5, 0x1d, 0xd5, 0xe9, 0x39, 0xd9, 0xfa, 0xc8, 0x27}}
 	return a, nil
 }
@@ -2407,7 +2408,7 @@ func _1699041816_profile_showcase_contactsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1699041816_profile_showcase_contacts.up.sql", size: 2206, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1699041816_profile_showcase_contacts.up.sql", size: 2206, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd5, 0x7b, 0x55, 0xda, 0x93, 0x4a, 0x92, 0xf8, 0x45, 0xb2, 0x9f, 0x32, 0xf4, 0x37, 0xc, 0x5f, 0x62, 0xba, 0x33, 0xe2, 0x5c, 0x91, 0x1c, 0xc, 0x7, 0x9, 0xc2, 0x27, 0x5, 0x90, 0x94, 0xf3}}
 	return a, nil
 }
@@ -2427,7 +2428,7 @@ func _1699554099_message_segmentsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1699554099_message_segments.up.sql", size: 426, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1699554099_message_segments.up.sql", size: 426, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x73, 0xca, 0xd, 0xfa, 0xfa, 0x17, 0xef, 0x7e, 0x24, 0xf9, 0x28, 0xbd, 0x39, 0x75, 0xff, 0x34, 0x31, 0x27, 0x58, 0x3c, 0x17, 0x77, 0xfd, 0xc2, 0x66, 0x47, 0x63, 0x58, 0x3e, 0xb3, 0x88, 0x1a}}
 	return a, nil
 }
@@ -2447,7 +2448,7 @@ func _1700044186_message_segments_timestampUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1700044186_message_segments_timestamp.up.sql", size: 322, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1700044186_message_segments_timestamp.up.sql", size: 322, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x3e, 0x4e, 0x7, 0x86, 0x71, 0xc8, 0x1f, 0x2f, 0xf4, 0xbc, 0xc5, 0xc4, 0x37, 0x56, 0xa1, 0x47, 0xd9, 0xc9, 0xfd, 0xdf, 0x9a, 0x48, 0x1d, 0xfd, 0xb4, 0xeb, 0xb6, 0xb1, 0xc2, 0x73, 0x11, 0x19}}
 	return a, nil
 }
@@ -2467,7 +2468,7 @@ func _1700044187_curated_communitiesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1700044187_curated_communities.up.sql", size: 131, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1700044187_curated_communities.up.sql", size: 131, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xed, 0xf1, 0xf1, 0x57, 0xb5, 0x83, 0xad, 0x9d, 0x9b, 0xf, 0x49, 0xe, 0x3d, 0xa5, 0xf6, 0xf5, 0x9c, 0x7f, 0xb3, 0xf7, 0x22, 0x43, 0x8a, 0xa0, 0x49, 0xfa, 0xcc, 0x9b, 0xea, 0xac, 0xc0, 0xb9}}
 	return a, nil
 }
@@ -2487,7 +2488,7 @@ func _1700820989_add_resend_automatically_indexUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1700820989_add_resend_automatically_index.up.sql", size: 77, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1700820989_add_resend_automatically_index.up.sql", size: 77, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x5a, 0x6a, 0xd4, 0xd2, 0x34, 0xa7, 0x68, 0xaa, 0xe5, 0x69, 0x9, 0xce, 0xcf, 0xcb, 0x13, 0x94, 0x9d, 0x3, 0x4c, 0x59, 0xac, 0x5f, 0x71, 0xb2, 0xe4, 0xda, 0x67, 0x42, 0xbe, 0xf2, 0x1d, 0xe8}}
 	return a, nil
 }
@@ -2507,7 +2508,7 @@ func _1702996953_add_communities_shards_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1702996953_add_communities_shards_table.up.sql", size: 208, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1702996953_add_communities_shards_table.up.sql", size: 208, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6, 0x40, 0x38, 0xcb, 0x1e, 0x85, 0x1, 0x6b, 0xe6, 0xe9, 0xf0, 0xf9, 0xe6, 0x6d, 0x23, 0x4d, 0xe6, 0x12, 0x61, 0xc8, 0x12, 0x25, 0x31, 0x39, 0x7d, 0x40, 0xad, 0x64, 0xfa, 0xf1, 0x87, 0x86}}
 	return a, nil
 }
@@ -2527,7 +2528,7 @@ func _1704489636_add_album_imagesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1704489636_add_album_images.up.sql", size: 66, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1704489636_add_album_images.up.sql", size: 66, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x28, 0x82, 0xf2, 0x12, 0x94, 0xb, 0x1b, 0x9f, 0x3f, 0xbf, 0x41, 0x96, 0x29, 0x63, 0x5e, 0x28, 0x4c, 0x9d, 0xd2, 0x26, 0xc9, 0x52, 0x4a, 0x19, 0x80, 0x10, 0xac, 0x1a, 0x51, 0x96, 0xe6, 0xa2}}
 	return a, nil
 }
@@ -2547,7 +2548,7 @@ func _1704821941_add_joined_at_for_communityUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1704821941_add_joined_at_for_community.up.sql", size: 84, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1704821941_add_joined_at_for_community.up.sql", size: 84, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x87, 0xa1, 0xca, 0xbe, 0x8e, 0xd1, 0xd5, 0xf, 0xe3, 0x4, 0x7, 0xdd, 0x62, 0x47, 0xc3, 0x90, 0xfb, 0x3, 0xb8, 0x48, 0x35, 0xc9, 0xc9, 0xe0, 0xe3, 0xb7, 0x36, 0x9f, 0xb8, 0x61, 0x1e, 0x18}}
 	return a, nil
 }
@@ -2567,7 +2568,7 @@ func _1704832511_add_last_opened_at_for_communitiesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1704832511_add_last_opened_at_for_communities.up.sql", size: 89, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1704832511_add_last_opened_at_for_communities.up.sql", size: 89, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa7, 0x73, 0x6, 0x6f, 0xa5, 0xc5, 0x5b, 0x5a, 0xf7, 0xf3, 0xb3, 0x28, 0x27, 0x61, 0x28, 0x2c, 0x6a, 0x1, 0x93, 0x14, 0x5b, 0xc0, 0xe8, 0xb5, 0xf6, 0xbf, 0x9f, 0xfb, 0x20, 0x7c, 0xd9, 0x54}}
 	return a, nil
 }
@@ -2587,7 +2588,7 @@ func _1704832512_add_peersyncingUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1704832512_add_peersyncing.up.sql", size: 276, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1704832512_add_peersyncing.up.sql", size: 276, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x32, 0xfc, 0x4c, 0x13, 0x67, 0xfb, 0x26, 0x58, 0xd3, 0x7f, 0x72, 0xd0, 0xe7, 0xd7, 0x28, 0x41, 0xa8, 0xa3, 0xf3, 0x9f, 0x1, 0x4c, 0xdd, 0xb6, 0x7b, 0xa4, 0x2a, 0x27, 0xb2, 0x31, 0xb1, 0x30}}
 	return a, nil
 }
@@ -2607,7 +2608,7 @@ func _1706028033_profile_showcase_address_and_communityUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1706028033_profile_showcase_address_and_community.up.sql", size: 2420, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1706028033_profile_showcase_address_and_community.up.sql", size: 2420, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa0, 0x8e, 0xc2, 0xbf, 0x32, 0x2d, 0x27, 0x4a, 0x83, 0xfc, 0x4c, 0xb5, 0x9b, 0x45, 0x12, 0xf0, 0xfc, 0x65, 0x36, 0xe0, 0x3c, 0x78, 0xd1, 0xdd, 0xd3, 0xfb, 0x44, 0x14, 0x20, 0x3, 0x3e, 0xcf}}
 	return a, nil
 }
@@ -2627,7 +2628,7 @@ func _1706520870_add_bridge_messages_tableUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1706520870_add_bridge_messages_table.up.sql", size: 389, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1706520870_add_bridge_messages_table.up.sql", size: 389, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xe4, 0xd8, 0xaa, 0x58, 0x51, 0xae, 0x28, 0x95, 0x4, 0x3e, 0xd, 0x9c, 0x73, 0xec, 0xe8, 0x84, 0xd, 0x77, 0xdf, 0x8f, 0xb0, 0x1a, 0xfe, 0xef, 0xfc, 0x5b, 0xe1, 0xe9, 0xc2, 0xc1, 0xe7, 0x73}}
 	return a, nil
 }
@@ -2647,7 +2648,7 @@ func _1706520871_add_community_description_cacheUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1706520871_add_community_description_cache.up.sql", size: 730, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1706520871_add_community_description_cache.up.sql", size: 730, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xfc, 0xe4, 0x66, 0xd6, 0x9d, 0xb8, 0x87, 0x6e, 0x70, 0xfd, 0x78, 0xa, 0x8c, 0xfb, 0xb2, 0xbc, 0xc4, 0x8c, 0x8d, 0x77, 0xc2, 0xf, 0xe1, 0x68, 0xf3, 0xd6, 0xf3, 0xb0, 0x42, 0x86, 0x3f, 0xf4}}
 	return a, nil
 }
@@ -2667,7 +2668,7 @@ func _1707749393_add_community_grantsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1707749393_add_community_grants.up.sql", size: 147, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1707749393_add_community_grants.up.sql", size: 147, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x59, 0xd9, 0xbb, 0x31, 0xf4, 0xb7, 0xbd, 0x1f, 0x57, 0x5b, 0x40, 0x28, 0xed, 0xf7, 0x2c, 0xb3, 0xf, 0xcc, 0x50, 0x7f, 0x2c, 0x74, 0xe1, 0x19, 0x7c, 0xa0, 0xec, 0xfc, 0xb7, 0xbe, 0x1e, 0xbc}}
 	return a, nil
 }
@@ -2687,7 +2688,7 @@ func _1707841194_add_profile_showcase_preferencesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1707841194_add_profile_showcase_preferences.up.sql", size: 132, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1707841194_add_profile_showcase_preferences.up.sql", size: 132, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xa4, 0x3b, 0x28, 0x2f, 0xd9, 0x3f, 0xe6, 0xe6, 0x22, 0xc7, 0x3, 0xcc, 0x4a, 0xc8, 0xc1, 0x8c, 0x32, 0xd5, 0x15, 0xc2, 0xaf, 0xf9, 0x2f, 0x2c, 0xaf, 0xab, 0xc4, 0xaf, 0x29, 0x8a, 0x33, 0x69}}
 	return a, nil
 }
@@ -2707,7 +2708,7 @@ func _1708062699_activity_dataUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1708062699_activity_data.up.sql", size: 82, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1708062699_activity_data.up.sql", size: 82, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8c, 0xfa, 0x24, 0x80, 0xea, 0xb0, 0xb, 0x50, 0xce, 0x10, 0xc9, 0x6c, 0x6f, 0xd4, 0x29, 0xe, 0xb, 0xe2, 0xa1, 0x70, 0x46, 0x2, 0x66, 0x40, 0x33, 0xb3, 0x4c, 0x6d, 0x82, 0x1f, 0xdf, 0x9}}
 	return a, nil
 }
@@ -2727,7 +2728,7 @@ func _1708423707_applied_community_eventsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1708423707_applied_community_events.up.sql", size: 201, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1708423707_applied_community_events.up.sql", size: 201, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x58, 0x5b, 0x9b, 0xed, 0x69, 0x1b, 0xf9, 0x11, 0xb8, 0xa3, 0x85, 0x97, 0xd, 0xe7, 0x2d, 0x44, 0xf2, 0x61, 0x51, 0x92, 0x1b, 0x13, 0x64, 0xb6, 0x75, 0x4c, 0x2b, 0x2f, 0xd4, 0x97, 0x39, 0x29}}
 	return a, nil
 }
@@ -2747,7 +2748,7 @@ func _1708440786_profile_showcase_social_linksUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1708440786_profile_showcase_social_links.up.sql", size: 906, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1708440786_profile_showcase_social_links.up.sql", size: 906, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xb7, 0xe4, 0xa2, 0xd6, 0x49, 0x3e, 0x3d, 0xc8, 0xe1, 0x75, 0x75, 0x36, 0x1e, 0x8a, 0xb1, 0xaf, 0xd3, 0xd8, 0xc7, 0x77, 0xe8, 0x8, 0xdb, 0xd9, 0x2c, 0x8e, 0x1e, 0xa, 0x7c, 0xda, 0x37, 0xf5}}
 	return a, nil
 }
@@ -2767,7 +2768,7 @@ func _1709805967_simplify_profile_showcase_preferencesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1709805967_simplify_profile_showcase_preferences.up.sql", size: 701, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1709805967_simplify_profile_showcase_preferences.up.sql", size: 701, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x8, 0xdc, 0xce, 0x1d, 0x56, 0x57, 0xf4, 0xa5, 0xc8, 0x15, 0x89, 0x92, 0xbf, 0x57, 0x5a, 0xbc, 0x37, 0x9e, 0xf0, 0xe4, 0x7a, 0x2c, 0x19, 0xd0, 0x3e, 0xca, 0xd0, 0xab, 0x2d, 0x8f, 0xe3, 0x16}}
 	return a, nil
 }
@@ -2787,7 +2788,7 @@ func _1709828431_add_community_description_cacheUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1709828431_add_community_description_cache.up.sql", size: 730, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1709828431_add_community_description_cache.up.sql", size: 730, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xfc, 0xe4, 0x66, 0xd6, 0x9d, 0xb8, 0x87, 0x6e, 0x70, 0xfd, 0x78, 0xa, 0x8c, 0xfb, 0xb2, 0xbc, 0xc4, 0x8c, 0x8d, 0x77, 0xc2, 0xf, 0xe1, 0x68, 0xf3, 0xd6, 0xf3, 0xb0, 0x42, 0x86, 0x3f, 0xf4}}
 	return a, nil
 }
@@ -2807,7 +2808,7 @@ func _1710331283_add_bio_to_contactsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1710331283_add_bio_to_contacts.up.sql", size: 42, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1710331283_add_bio_to_contacts.up.sql", size: 42, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc2, 0xe8, 0x4b, 0xa8, 0xd9, 0xa0, 0xc4, 0xd, 0x3d, 0x15, 0x3a, 0xc8, 0x98, 0x33, 0xb2, 0x8b, 0x4c, 0x0, 0xad, 0xfc, 0x92, 0x51, 0xeb, 0xf5, 0x1, 0xd2, 0x15, 0x8f, 0xc9, 0x79, 0x8e, 0x81}}
 	return a, nil
 }
@@ -2827,7 +2828,7 @@ func _1710331284_hash_ratchet_encrypted_messages_key_idUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1710331284_hash_ratchet_encrypted_messages_key_id.up.sql", size: 111, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1710331284_hash_ratchet_encrypted_messages_key_id.up.sql", size: 111, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd1, 0x8b, 0xfe, 0xb3, 0xa0, 0x73, 0x30, 0xe, 0x1a, 0xd5, 0x85, 0x3e, 0x22, 0xf9, 0xfe, 0x1, 0x5c, 0x5f, 0x9c, 0x26, 0x36, 0x9e, 0x11, 0x1c, 0x2b, 0x42, 0xa9, 0xcc, 0x9, 0x63, 0xe8, 0xff}}
 	return a, nil
 }
@@ -2847,7 +2848,7 @@ func _1711389881_add_profile_showcase_community_grantUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1711389881_add_profile_showcase_community_grant.up.sql", size: 86, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1711389881_add_profile_showcase_community_grant.up.sql", size: 86, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x45, 0x39, 0x37, 0xf3, 0x6a, 0xb, 0xb8, 0x38, 0x8, 0xcb, 0x62, 0xe1, 0x5b, 0xf2, 0xc, 0x6c, 0xf2, 0xa3, 0x5c, 0xeb, 0x22, 0x4f, 0x6c, 0xe1, 0x56, 0xd1, 0xd1, 0x3, 0xf9, 0x6d, 0x5e, 0x69}}
 	return a, nil
 }
@@ -2867,7 +2868,7 @@ func _1711937186_add_contact_customization_colorUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1711937186_add_contact_customization_color.up.sql", size: 172, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1711937186_add_contact_customization_color.up.sql", size: 172, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xce, 0x22, 0xe, 0x27, 0xfd, 0x4, 0xb9, 0x4, 0xc8, 0xec, 0xf4, 0x68, 0xa6, 0x30, 0xed, 0xa3, 0xe7, 0x77, 0x3c, 0x90, 0xf7, 0x8d, 0x70, 0xe2, 0xee, 0xe3, 0xd5, 0x9f, 0xce, 0xc4, 0x40, 0x3}}
 	return a, nil
 }
@@ -2887,7 +2888,7 @@ func _1712745141_hash_ratchet_encrypted_messages_key_idUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1712745141_hash_ratchet_encrypted_messages_key_id.up.sql", size: 111, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1712745141_hash_ratchet_encrypted_messages_key_id.up.sql", size: 111, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd1, 0x8b, 0xfe, 0xb3, 0xa0, 0x73, 0x30, 0xe, 0x1a, 0xd5, 0x85, 0x3e, 0x22, 0xf9, 0xfe, 0x1, 0x5c, 0x5f, 0x9c, 0x26, 0x36, 0x9e, 0x11, 0x1c, 0x2b, 0x42, 0xa9, 0xcc, 0x9, 0x63, 0xe8, 0xff}}
 	return a, nil
 }
@@ -2907,7 +2908,7 @@ func _1712905223_add_parity_to_message_segmentsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1712905223_add_parity_to_message_segments.up.sql", size: 792, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1712905223_add_parity_to_message_segments.up.sql", size: 792, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9, 0x78, 0x5e, 0x84, 0x2b, 0xf9, 0x52, 0x77, 0x7, 0x6c, 0xb6, 0x76, 0x6d, 0x59, 0xd2, 0x1f, 0x6c, 0xe6, 0xd, 0x86, 0x85, 0xeb, 0x34, 0x95, 0x6e, 0xa, 0xa9, 0xd8, 0x3b, 0x7a, 0xd, 0x1a}}
 	return a, nil
 }
@@ -2927,7 +2928,7 @@ func _1713169458_update_raw_messages_with_resend_featuresUpSql() (*asset, error)
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1713169458_update_raw_messages_with_resend_features.up.sql", size: 608, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1713169458_update_raw_messages_with_resend_features.up.sql", size: 608, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x67, 0x9b, 0x64, 0x54, 0x62, 0x84, 0x6, 0x98, 0x6d, 0x80, 0x67, 0xf2, 0x7e, 0x75, 0x1e, 0xd8, 0x3f, 0x8, 0xc5, 0xcc, 0x48, 0xe6, 0xe0, 0x22, 0x42, 0x9, 0xe4, 0x5d, 0xbf, 0xd3, 0x58, 0x8a}}
 	return a, nil
 }
@@ -2947,7 +2948,7 @@ func _1715163152_remove_status_communityUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1715163152_remove_status_community.up.sql", size: 354, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1715163152_remove_status_community.up.sql", size: 354, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xc, 0xc1, 0xbd, 0xc9, 0x4f, 0xf2, 0x70, 0x10, 0xd0, 0xb2, 0xa7, 0x8e, 0x5f, 0x8, 0xfb, 0x56, 0xd1, 0x37, 0x7b, 0x48, 0x7b, 0x13, 0x89, 0x28, 0xcc, 0xee, 0xfa, 0x66, 0x34, 0xd6, 0x87, 0xa0}}
 	return a, nil
 }
@@ -2967,7 +2968,7 @@ func _1715163262_rename_peersyncing_group_id_fieldUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1715163262_rename_peersyncing_group_id_field.up.sql", size: 212, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1715163262_rename_peersyncing_group_id_field.up.sql", size: 212, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7b, 0x8d, 0x51, 0xe3, 0x46, 0xc, 0x1e, 0xf1, 0xe, 0xc2, 0xb3, 0x43, 0xfb, 0xed, 0xb0, 0x30, 0x45, 0x63, 0x18, 0x59, 0x19, 0x9d, 0x7e, 0x3f, 0x54, 0x87, 0xbf, 0x9f, 0x6, 0x9, 0x78, 0xec}}
 	return a, nil
 }
@@ -2987,7 +2988,7 @@ func _1716413241_remove_social_linksUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1716413241_remove_social_links.up.sql", size: 38, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1716413241_remove_social_links.up.sql", size: 38, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x50, 0x9c, 0xd6, 0x47, 0xe6, 0xc8, 0xe7, 0x9b, 0xae, 0xaf, 0x43, 0xb0, 0xc5, 0x51, 0x74, 0x1c, 0x3e, 0xa3, 0x2c, 0x28, 0xaf, 0x9, 0x1d, 0x33, 0x8e, 0x82, 0xc0, 0x48, 0x6a, 0x74, 0x5a, 0xd3}}
 	return a, nil
 }
@@ -3007,7 +3008,7 @@ func _1716891408_add_community_token_transaction_hashUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1716891408_add_community_token_transaction_hash.up.sql", size: 65, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1716891408_add_community_token_transaction_hash.up.sql", size: 65, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7b, 0x3, 0x3d, 0x99, 0x3b, 0x47, 0xae, 0xa4, 0x94, 0x48, 0x3f, 0x40, 0xfb, 0x75, 0x8f, 0x1e, 0x38, 0x1c, 0x66, 0x13, 0x32, 0x2c, 0xb4, 0xbe, 0xce, 0x91, 0x55, 0xd5, 0x34, 0xe4, 0xb3, 0xda}}
 	return a, nil
 }
@@ -3027,7 +3028,7 @@ func _1719906191_add_community_token_versionUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1719906191_add_community_token_version.up.sql", size: 65, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1719906191_add_community_token_version.up.sql", size: 65, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xcf, 0x62, 0x0, 0xaa, 0x8e, 0xc5, 0xaa, 0x7f, 0xb8, 0xf4, 0x23, 0x93, 0xc1, 0x93, 0xf, 0x49, 0x7f, 0xa2, 0xda, 0xa0, 0x40, 0xed, 0x8b, 0x4d, 0x6e, 0x81, 0x2, 0x63, 0x18, 0xd9, 0x9c, 0x72}}
 	return a, nil
 }
@@ -3047,7 +3048,7 @@ func _1720636181_add_community_encryption_keys_requestsUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1720636181_add_community_encryption_keys_requests.up.sql", size: 236, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1720636181_add_community_encryption_keys_requests.up.sql", size: 236, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd3, 0x9c, 0x7c, 0xb6, 0x53, 0x6f, 0xe, 0xc3, 0xff, 0xd5, 0x82, 0xc9, 0x21, 0xd6, 0x51, 0x20, 0xeb, 0x29, 0x75, 0xb5, 0x90, 0x35, 0x6d, 0x28, 0xd6, 0xe9, 0x1d, 0x9c, 0x8b, 0x86, 0xdc, 0x68}}
 	return a, nil
 }
@@ -3067,8 +3068,28 @@ func _1721222369_add_shared_addressesUpSql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "1721222369_add_shared_addresses.up.sql", size: 98, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "1721222369_add_shared_addresses.up.sql", size: 98, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x6a, 0x12, 0x2, 0xed, 0xf4, 0xc7, 0xe3, 0xc8, 0x65, 0x43, 0x81, 0x34, 0x86, 0x1b, 0xc8, 0xfb, 0x22, 0x12, 0xd6, 0x1d, 0xe2, 0xa4, 0xec, 0xf4, 0x93, 0x5f, 0x92, 0x1, 0x53, 0x10, 0xb2, 0x70}}
+	return a, nil
+}
+
+var __1721919311_add_installation_id_activity_centerUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x1c\xc9\xc1\x0a\x82\x21\x0c\x07\xf0\x57\xf9\xbf\x47\xa7\x95\xeb\xb4\x0c\x62\x42\x37\x11\x33\x18\xc8\x84\x1c\x41\x6f\x1f\x7c\xe7\x1f\x89\xf2\x03\x4a\x67\x61\xb4\x1e\xf6\xb5\xf8\xd5\x3e\x3c\xc6\xa7\xfa\x0a\x7b\x5b\x6f\x61\xcb\x37\x28\x25\x5c\xee\x52\x6e\x19\xe6\x3b\xda\x9c\x07\x54\x7b\x41\xf9\xa9\x48\x7c\xa5\x22\x8a\x5c\x44\x4e\xff\x00\x00\x00\xff\xff\x97\xb0\x87\x0b\x57\x00\x00\x00")
+
+func _1721919311_add_installation_id_activity_centerUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1721919311_add_installation_id_activity_centerUpSql,
+		"1721919311_add_installation_id_activity_center.up.sql",
+	)
+}
+
+func _1721919311_add_installation_id_activity_centerUpSql() (*asset, error) {
+	bytes, err := _1721919311_add_installation_id_activity_centerUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1721919311_add_installation_id_activity_center.up.sql", size: 87, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xae, 0x66, 0xa3, 0x93, 0xc8, 0x46, 0xc2, 0xf5, 0x16, 0x26, 0x3f, 0x1c, 0x9b, 0x41, 0x66, 0x4d, 0x96, 0x9c, 0xe2, 0xcb, 0xb9, 0x9, 0x87, 0xa8, 0x43, 0x2b, 0xcd, 0x34, 0x83, 0x90, 0x7f, 0x9f}}
 	return a, nil
 }
 
@@ -3087,7 +3108,7 @@ func readmeMd() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "README.md", size: 554, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "README.md", size: 554, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x1c, 0x6e, 0xfb, 0xcc, 0x81, 0x94, 0x4d, 0x8c, 0xa0, 0x3b, 0x5, 0xb0, 0x18, 0xd6, 0xbb, 0xb3, 0x79, 0xc8, 0x8f, 0xff, 0xc1, 0x10, 0xf9, 0xf, 0x20, 0x1b, 0x4a, 0x74, 0x96, 0x42, 0xd7, 0xa8}}
 	return a, nil
 }
@@ -3107,7 +3128,7 @@ func docGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "doc.go", size: 870, mode: os.FileMode(0644), modTime: time.Unix(1700000000, 0)}
+	info := bindataFileInfo{name: "doc.go", size: 870, mode: os.FileMode(0664), modTime: time.Unix(1700000000, 0)}
 	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x64, 0x9a, 0x6c, 0x93, 0x57, 0xcc, 0xf2, 0xe0, 0xa7, 0x7d, 0xc3, 0x88, 0x1c, 0x88, 0xad, 0x8e, 0xb0, 0x16, 0x39, 0xda, 0x17, 0x1a, 0x2b, 0x9c, 0x6b, 0x3a, 0x3e, 0x2a, 0x3e, 0xae, 0x6e, 0xfb}}
 	return a, nil
 }
@@ -3346,8 +3367,9 @@ var _bindata = map[string]func() (*asset, error){
 	"1719906191_add_community_token_version.up.sql":                               _1719906191_add_community_token_versionUpSql,
 	"1720636181_add_community_encryption_keys_requests.up.sql":                    _1720636181_add_community_encryption_keys_requestsUpSql,
 	"1721222369_add_shared_addresses.up.sql":                                      _1721222369_add_shared_addressesUpSql,
-	"README.md":                                                                   readmeMd,
-	"doc.go":                                                                      docGo,
+	"1721919311_add_installation_id_activity_center.up.sql":                       _1721919311_add_installation_id_activity_centerUpSql,
+	"README.md": readmeMd,
+	"doc.go":    docGo,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -3539,8 +3561,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1719906191_add_community_token_version.up.sql":                               {_1719906191_add_community_token_versionUpSql, map[string]*bintree{}},
 	"1720636181_add_community_encryption_keys_requests.up.sql":                    {_1720636181_add_community_encryption_keys_requestsUpSql, map[string]*bintree{}},
 	"1721222369_add_shared_addresses.up.sql":                                      {_1721222369_add_shared_addressesUpSql, map[string]*bintree{}},
-	"README.md":                                                                   {readmeMd, map[string]*bintree{}},
-	"doc.go":                                                                      {docGo, map[string]*bintree{}},
+	"1721919311_add_installation_id_activity_center.up.sql":                       {_1721919311_add_installation_id_activity_centerUpSql, map[string]*bintree{}},
+	"README.md": {readmeMd, map[string]*bintree{}},
+	"doc.go":    {docGo, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/protocol/migrations/sqlite/1721919311_add_installation_id_activity_center.up.sql
+++ b/protocol/migrations/sqlite/1721919311_add_installation_id_activity_center.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activity_center_notifications ADD COLUMN installation_id TEXT DEFAULT NULL;

--- a/protocol/requests/enable_and_sync_installation.go
+++ b/protocol/requests/enable_and_sync_installation.go
@@ -4,15 +4,15 @@ import (
 	"errors"
 )
 
-var ErrEnableAndSyncInstallationInvalidID = errors.New("enable and sync installation: invalid installation id")
+var ErrEnableInstallationAndSyncInvalidID = errors.New("enable installation and sync : invalid installation id")
 
-type EnableAndSyncInstallation struct {
+type EnableInstallationAndSync struct {
 	InstallationID string `json:"installationId"`
 }
 
-func (j *EnableAndSyncInstallation) Validate() error {
+func (j *EnableInstallationAndSync) Validate() error {
 	if len(j.InstallationID) == 0 {
-		return ErrEnableAndSyncInstallationInvalidID
+		return ErrEnableInstallationAndSyncInvalidID
 	}
 
 	return nil

--- a/server/pairing/connection.go
+++ b/server/pairing/connection.go
@@ -59,6 +59,7 @@ func NewConnectionParams(netIPs []net.IP, port int, publicKey *ecdsa.PublicKey, 
 //   - AES encryption key
 //   - string InstallationID of the sending device
 //   - string KeyUID of the sending device
+//
 // NOTE:
 // - append(accrete) parameters instead of changing(breaking) existing parameters. Appending should **never** break, modifying existing parameters will break. Watch this before making changes: https://www.youtube.com/watch?v=oyLBGkS5ICk
 // - never strictly check version, unless you really want to break

--- a/server/pairing/connection.go
+++ b/server/pairing/connection.go
@@ -62,10 +62,6 @@ func NewConnectionParams(netIPs []net.IP, port int, publicKey *ecdsa.PublicKey, 
 // NOTE:
 // - append(accrete) parameters instead of changing(breaking) existing parameters. Appending should **never** break, modifying existing parameters will break. Watch this before making changes: https://www.youtube.com/watch?v=oyLBGkS5ICk
 // - never strictly check version, unless you really want to break
-
-// This flag is used to keep compatibility with 2.29. It will output a 5 parameters connection string with version 3.
-var keep229Compatibility bool = true
-
 func (cp *ConnectionParams) ToString() string {
 	v := base58.Encode(new(big.Int).SetInt64(int64(cp.version)).Bytes())
 	ips := base58.Encode(SerializeNetIps(cp.netIPs))
@@ -73,18 +69,12 @@ func (cp *ConnectionParams) ToString() string {
 	k := base58.Encode(elliptic.MarshalCompressed(cp.publicKey.Curve, cp.publicKey.X, cp.publicKey.Y))
 	ek := base58.Encode(cp.aesKey)
 
-	if keep229Compatibility {
-		return fmt.Sprintf("%s%s:%s:%s:%s:%s", connectionStringID, v, ips, p, k, ek)
-	}
-
 	var i string
 	if cp.installationID != "" {
-
 		u, err := uuid.Parse(cp.installationID)
 		if err != nil {
 			log.Fatalf("Failed to parse UUID: %v", err)
 		} else {
-
 			// Convert UUID to byte slice
 			byteSlice := u[:]
 			i = base58.Encode(byteSlice)
@@ -94,7 +84,6 @@ func (cp *ConnectionParams) ToString() string {
 	var kuid string
 	if cp.keyUID != "" {
 		kuid = base58.Encode([]byte(cp.keyUID))
-
 	}
 
 	return fmt.Sprintf("%s%s:%s:%s:%s:%s:%s:%s", connectionStringID, v, ips, p, k, ek, i, kuid)

--- a/server/pairing/connection_test.go
+++ b/server/pairing/connection_test.go
@@ -65,7 +65,6 @@ func (s *ConnectionParamsSuite) SetupSuite() {
 }
 
 func (s *ConnectionParamsSuite) TestConnectionParams_ToString() {
-	keep229Compatibility = false
 	cp, err := s.server.MakeConnectionParams()
 	s.Require().NoError(err)
 

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1063,6 +1063,11 @@ func (api *PublicAPI) SyncDevices(ctx context.Context, name, picture string) err
 	return api.service.messenger.SyncDevices(ctx, name, picture, nil)
 }
 
+// Deprecated: Use EnableInstallationAndSync instead
+func (api *PublicAPI) EnableAndSyncInstallation(request *requests.EnableInstallationAndSync) (*protocol.MessengerResponse, error) {
+	return api.service.messenger.EnableInstallationAndSync(request)
+}
+
 func (api *PublicAPI) EnableInstallationAndSync(request *requests.EnableInstallationAndSync) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.EnableInstallationAndSync(request)
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1063,8 +1063,8 @@ func (api *PublicAPI) SyncDevices(ctx context.Context, name, picture string) err
 	return api.service.messenger.SyncDevices(ctx, name, picture, nil)
 }
 
-func (api *PublicAPI) EnableAndSyncInstallation(request *requests.EnableAndSyncInstallation) (*protocol.MessengerResponse, error) {
-	return api.service.messenger.EnableAndSyncInstallation(request)
+func (api *PublicAPI) EnableInstallationAndSync(request *requests.EnableInstallationAndSync) (*protocol.MessengerResponse, error) {
+	return api.service.messenger.EnableInstallationAndSync(request)
 }
 
 func (api *PublicAPI) EnableInstallationAndPair(request *requests.EnableInstallationAndPair) (*protocol.MessengerResponse, error) {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1063,7 +1063,7 @@ func (api *PublicAPI) SyncDevices(ctx context.Context, name, picture string) err
 	return api.service.messenger.SyncDevices(ctx, name, picture, nil)
 }
 
-func (api *PublicAPI) EnableAndSyncInstallation(request *requests.EnableAndSyncInstallation) error {
+func (api *PublicAPI) EnableAndSyncInstallation(request *requests.EnableAndSyncInstallation) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.EnableAndSyncInstallation(request)
 }
 


### PR DESCRIPTION
This is a continue work to [PR](https://github.com/status-im/status-go/pull/5614#issue-2434423574)
2 Major changes in this PR:
- removed the compatibility with v2.29, in other word, version below v2.30 won't be able to parse the sync code generated with this PR
- add AC notifications when initiating the sync fallback

relate mobile [PR](https://github.com/status-im/status-mobile/pull/21090)