### PR TITLE
feat_: Integrate Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,8 +5,6 @@ coverage:
     project:
       default:
         informational: true
-#        paths:
-#          - "!cmd/"
     patch:
       default:
         informational: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# When modifying this file, please validate using:
+# make codecov-validate

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,12 @@
 coverage:
+  require_ci_to_pass: no
+  wait_for_ci: no
   status:
     project:
       default:
         informational: true
+#        paths:
+#          - "!cmd/"
     patch:
       default:
         informational: true

--- a/Makefile
+++ b/Makefile
@@ -499,3 +499,6 @@ run-integration-tests:
 run-anvil: SHELL := /bin/sh
 run-anvil:
 	docker-compose -f integration-tests/docker-compose.anvil.yml up --remove-orphans
+
+codecov-validate:
+	curl -X POST --data-binary @codecov.yml https://codecov.io/validate

--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ test-unit: export UNIT_TEST_FAILFAST ?= true
 test-unit: export UNIT_TEST_RERUN_FAILS ?= true
 test-unit: export UNIT_TEST_USE_DEVELOPMENT_LOGGER ?= true
 test-unit: export UNIT_TEST_REPORT_CODECLIMATE ?= false
-test-unit: export UNIT_TEST_REPORT_CODECOV ?= false
+test-unit: export UNIT_TEST_REPORT_CODECOV ?= true
 test-unit: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./... | \
 	grep -v /vendor | \
 	grep -v /t/e2e | \

--- a/Makefile
+++ b/Makefile
@@ -502,4 +502,4 @@ run-anvil:
 	docker-compose -f integration-tests/docker-compose.anvil.yml up --remove-orphans
 
 codecov-validate:
-	curl -X POST --data-binary @codecov.yml https://codecov.io/validate
+	curl -X POST --data-binary @.codecov.yml https://codecov.io/validate

--- a/Makefile
+++ b/Makefile
@@ -367,6 +367,7 @@ test-unit: export UNIT_TEST_FAILFAST ?= true
 test-unit: export UNIT_TEST_RERUN_FAILS ?= true
 test-unit: export UNIT_TEST_USE_DEVELOPMENT_LOGGER ?= true
 test-unit: export UNIT_TEST_REPORT_CODECLIMATE ?= false
+test-unit: export UNIT_TEST_REPORT_CODECOV ?= false
 test-unit: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./... | \
 	grep -v /vendor | \
 	grep -v /t/e2e | \

--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ test-unit: export UNIT_TEST_FAILFAST ?= true
 test-unit: export UNIT_TEST_RERUN_FAILS ?= true
 test-unit: export UNIT_TEST_USE_DEVELOPMENT_LOGGER ?= true
 test-unit: export UNIT_TEST_REPORT_CODECLIMATE ?= false
-test-unit: export UNIT_TEST_REPORT_CODECOV ?= true
+test-unit: export UNIT_TEST_REPORT_CODECOV ?= false
 test-unit: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./... | \
 	grep -v /vendor | \
 	grep -v /t/e2e | \

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -37,7 +37,7 @@ pipeline {
     )
     booleanParam(
       name: 'UNIT_TEST_REPORT_CODECOV',
-      defaultValue: false,
+      defaultValue: true,
       description: 'Should the job report test coverage to Codecov?'
     )
     booleanParam(

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -36,6 +36,11 @@ pipeline {
       description: 'Should the job report test coverage to CodeClimate?'
     )
     booleanParam(
+      name: 'UNIT_TEST_REPORT_CODECOV',
+      defaultValue: false,
+      description: 'Should the job report test coverage to Codecov?'
+    )
+    booleanParam(
       name: 'UNIT_TEST_DRY_RUN',
       defaultValue: false,
       description: 'Should the job report ignore the actual test run and just print the test plan?'
@@ -77,6 +82,7 @@ pipeline {
     UNIT_TEST_RERUN_FAILS =            "${params.UNIT_TEST_RERUN_FAILS}"
     UNIT_TEST_USE_DEVELOPMENT_LOGGER = "${params.UNIT_TEST_USE_DEVELOPMENT_LOGGER}"
     UNIT_TEST_REPORT_CODECLIMATE =     "${params.UNIT_TEST_REPORT_CODECLIMATE}"
+    UNIT_TEST_REPORT_CODECOV =         "${params.UNIT_TEST_REPORT_CODECOV}"
     UNIT_TEST_DRY_RUN =                "${params.UNIT_TEST_DRY_RUN}"
   }
 

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -172,6 +172,10 @@ pipeline {
                 credentialsId: 'codeclimate-test-reporter-id',
                 variable: 'CC_TEST_REPORTER_ID'
               ),
+              string(
+                credentialsId: 'codecov-repository-upload-token',
+                variable: 'CODECOV_TOKEN'
+              ),
             ]) {
               nix.shell('make test-unit V=1', pure: false)
             }

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -180,7 +180,7 @@ pipeline {
               nix.shell('make test-unit V=1', pure: false)
             }
             sh "mv c.out test-coverage.out"
-            archiveArtifacts('test-coverage.out, coverage/codeclimate.json, test-coverage.html, coverage_merged.out')
+            archiveArtifacts('report_*.xml, test_*.log, test-coverage.out, coverage/codeclimate.json, test-coverage.html, coverage_merged.out')
           }
         }
       } }

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -172,6 +172,10 @@ pipeline {
                 credentialsId: 'codeclimate-test-reporter-id',
                 variable: 'CC_TEST_REPORTER_ID'
               ),
+              string(
+                credentialsId: 'codecov-token',
+                variable: 'CODECOV_TOKEN'
+              ),
             ]) {
               nix.shell('make test-unit V=1', pure: false)
             }

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -172,10 +172,6 @@ pipeline {
                 credentialsId: 'codeclimate-test-reporter-id',
                 variable: 'CC_TEST_REPORTER_ID'
               ),
-              string(
-                credentialsId: 'codecov-token',
-                variable: 'CODECOV_TOKEN'
-              ),
             ]) {
               nix.shell('make test-unit V=1', pure: false)
             }

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -144,13 +144,20 @@ grep -v '^github.com/status-im/status-go/cmd/' ${merged_coverage_report} > ${fin
 echo -e "${GRN}Generating HTML coverage report${RST}"
 go tool cover -html ${final_coverage_report} -o test-coverage.html
 
+# https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
+GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$')
+
 # Upload coverage report to CodeClimate
 if [[ $UNIT_TEST_REPORT_CODECLIMATE == 'true' ]]; then
   echo -e "${GRN}Uploading coverage report to CodeClimate${RST}"
-  # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
-  GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$')
   cc-test-reporter format-coverage --prefix=github.com/status-im/status-go # To generate 'coverage/codeclimate.json'
   cc-test-reporter after-build --prefix=github.com/status-im/status-go
+fi
+
+if [[ $UNIT_TEST_REPORT_CODECOV == 'true' ]]; then
+  echo -e "${GRN}Uploading coverage report to Codecov${RST}"
+  # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
+  codecov -t ${CODECOV_TOKEN} -f ${final_coverage_report} -F "unit" ${GIT_COMMIT}
 fi
 
 # Generate report with test stats

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -157,7 +157,11 @@ fi
 if [[ $UNIT_TEST_REPORT_CODECOV == 'true' ]]; then
   echo -e "${GRN}Uploading coverage report to Codecov${RST}"
   # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
-  # codecovcli do-upload --report-type test_results # --file <report_name>.junit.xml
+  codecov_report_files_args=""
+  for file in report_*.xml; do
+    codecov_report_files_args+="--file ${file} "
+  done
+  codecov do-upload --report-type test_results -t ${CODECOV_TOKEN} ${codecov_report_files_args}
   codecov -t ${CODECOV_TOKEN} -f ${final_coverage_report} -F "unit"
 fi
 

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -157,7 +157,7 @@ fi
 if [[ $UNIT_TEST_REPORT_CODECOV == 'true' ]]; then
   echo -e "${GRN}Uploading coverage report to Codecov${RST}"
   # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
-  codecov -t ${CODECOV_TOKEN} -f ${final_coverage_report} -F "unit" ${GIT_COMMIT}
+  codecov -t ${CODECOV_TOKEN} -f ${final_coverage_report} -F "unit"
 fi
 
 # Generate report with test stats

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -157,6 +157,7 @@ fi
 if [[ $UNIT_TEST_REPORT_CODECOV == 'true' ]]; then
   echo -e "${GRN}Uploading coverage report to Codecov${RST}"
   # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
+  # codecovcli do-upload --report-type test_results # --file <report_name>.junit.xml
   codecov -t ${CODECOV_TOKEN} -f ${final_coverage_report} -F "unit"
 fi
 

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -144,12 +144,11 @@ grep -v '^github.com/status-im/status-go/cmd/' ${merged_coverage_report} > ${fin
 echo -e "${GRN}Generating HTML coverage report${RST}"
 go tool cover -html ${final_coverage_report} -o test-coverage.html
 
-# https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
-GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$')
-
 # Upload coverage report to CodeClimate
 if [[ $UNIT_TEST_REPORT_CODECLIMATE == 'true' ]]; then
   echo -e "${GRN}Uploading coverage report to CodeClimate${RST}"
+  # https://docs.codeclimate.com/docs/jenkins#jenkins-ci-builds
+  GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$')
   cc-test-reporter format-coverage --prefix=github.com/status-im/status-go # To generate 'coverage/codeclimate.json'
   cc-test-reporter after-build --prefix=github.com/status-im/status-go
 fi

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -161,8 +161,8 @@ if [[ $UNIT_TEST_REPORT_CODECOV == 'true' ]]; then
   for file in report_*.xml; do
     codecov_report_files_args+="--file ${file} "
   done
-  codecov do-upload --report-type test_results -t ${CODECOV_TOKEN} ${codecov_report_files_args}
-  codecov -t ${CODECOV_TOKEN} -f ${final_coverage_report} -F "unit"
+  codecov do-upload --token "${CODECOV_TOKEN}" --report-type test_results ${codecov_report_files_args}
+  codecov --token "${CODECOV_TOKEN}" -f ${final_coverage_report} -F "unit"
 fi
 
 # Generate report with test stats

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -52,6 +52,7 @@ in rec {
   # Custom packages
   go-modvendor = callPackage ./pkgs/go-modvendor { };
   cc-test-reporter = callPackage ./pkgs/cc-test-reporter { };
+  codecov-cli = callPackage ./pkgs/codecov-cli { };
 
   gomobile = (prev.gomobile.overrideAttrs (old: {
     patches = [

--- a/nix/pkgs/codecov-cli/default.nix
+++ b/nix/pkgs/codecov-cli/default.nix
@@ -1,0 +1,42 @@
+{ lib, stdenv, fetchurl }:
+
+let
+  platform = lib.getAttr builtins.currentSystem {
+    aarch64-linux = "linux-arm64";
+    x86_64-linux = "linux";
+    aarch64-darwin = "macos"; # There's no arm64 build for macOS, amd64 works on both
+    x86_64-darwin = "macos";
+  };
+
+in stdenv.mkDerivation rec {
+  pname = "codecov";
+  version = "0.7.4";
+
+  src = fetchurl {
+    url = "https://cli.codecov.io/v${version}/${platform}/codecov";
+    hash = lib.getAttr builtins.currentSystem {
+      aarch64-darwin = "sha256-CB1D8/zYF23Jes9sd6rJiadDg7nwwee9xWSYqSByAlU=";
+      x86_64-linux = "sha256-65AgCcuAD977zikcE1eVP4Dik4L0PHqYzOO1fStNjOw=";
+      aarch64-linux = "sha256-hALtVSXY40uTIaAtwWr7EXh7zclhK63r7a341Tn+q/g=";
+    };
+   };
+
+  dontUnpack = true;
+  stripDebug = false;
+  dontStrip = true; # This is to prevent `Could not load PyInstaller's embedded PKG archive from the executable` error
+
+  installPhase = ''
+    runHook preInstall
+    install -D $src $out/bin/codecov
+    chmod +x $out/bin/codecov
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Codecov CLI tool to upload coverage reports";
+    homepage = "https://docs.codecov.com/docs/the-codecov-cli";
+    license = licenses.asl20;
+    mainProgram = "codecov";
+    platforms = ["aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin"];
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -21,7 +21,7 @@ in pkgs.mkShell {
 
   buildInputs = with pkgs; [
     git jq which
-    go golangci-lint go-junit-report gopls go-bindata gomobileMod
+    go golangci-lint go-junit-report gopls go-bindata gomobileMod python312Packages.codecov
     mockgen protobuf3_20 protoc-gen-go gotestsum go-modvendor openjdk cc-test-reporter
    ] ++ lib.optionals (stdenv.isDarwin) [ xcodeWrapper ];
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -21,7 +21,7 @@ in pkgs.mkShell {
 
   buildInputs = with pkgs; [
     git jq which
-    go golangci-lint go-junit-report gopls go-bindata gomobileMod python312Packages.codecov
+    go golangci-lint go-junit-report gopls go-bindata gomobileMod codecov-cli
     mockgen protobuf3_20 protoc-gen-go gotestsum go-modvendor openjdk cc-test-reporter
    ] ++ lib.optionals (stdenv.isDarwin) [ xcodeWrapper ];
 


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/5772

https://app.codecov.io/github/status-im/status-go

## Implementation notes

I ended up writing a custom nix derivation instead of [python312Packages.codecov](https://github.com/NixOS/nixpkgs/blob/nixos-24.05/pkgs/development/python-modules/codecov/default.nix#L47), because it's outdated.

## Future plan

This is the first iteration. We can gradually improve the configuration when needed.
Next step will be to add coverage to `tests-rpc`. 
When Codecov checks are stable, we can disable the Codeclimate and make Codecov required instead.

## Features

### Code tree view of coverage

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/577e8aa6-4612-42fa-9610-f26a3d3b1bc6">

## Tests duration and failure rate

<img width="1304" alt="image" src="https://github.com/user-attachments/assets/1358fdcb-161c-453f-946f-c47ab31c7f47">