### PR TITLE
fix(run_unit_tests.sh)_: proper exit code on test fail

### DIFF
--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -127,6 +127,14 @@ else
   wait
 fi
 
+for exit_code_file in "${GIT_ROOT}"/exit_code_*.txt; do
+  read exit_code < "${exit_code_file}"
+  if [[ "${exit_code}" -ne 0 ]]; then
+    echo -e "${RED}Testing failed${RST}, exit code: ${exit_code}"
+    exit ${exit_code}
+  fi
+done
+
 # Gather test coverage results
 merged_coverage_report="coverage_merged.out"
 final_coverage_report="c.out" # Name expected by cc-test-reporter


### PR DESCRIPTION
The issue was introduced by me here: https://github.com/status-im/status-go/pull/5791
When launching `run_test_for_packages ... &`, we should read the exit code from file after.