### PR TITLE
fix: make mailserver availability subscriptions concurrency safe

### DIFF
--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -401,7 +401,7 @@ func (m *Messenger) checkForMissingMessagesLoop() {
 	t := time.NewTicker(missingMessageCheckPeriod)
 	defer t.Stop()
 
-	mailserverAvailableSignal := m.SubscribeMailserverAvailable()
+	mailserverAvailableSignal := m.mailserverCycle.availabilitySubscriptions.Subscribe()
 
 	for {
 		select {
@@ -410,7 +410,7 @@ func (m *Messenger) checkForMissingMessagesLoop() {
 
 		// Wait for mailserver available, also triggered on mailserver change
 		case <-mailserverAvailableSignal:
-			mailserverAvailableSignal = m.SubscribeMailserverAvailable()
+			mailserverAvailableSignal = m.mailserverCycle.availabilitySubscriptions.Subscribe()
 
 		case <-t.C:
 


### PR DESCRIPTION
Fixes:
```
panic: send on closed channel

goroutine 2192 [running]:
github.com/status-im/status-go/protocol.(*Messenger).EmitMailserverAvailable(...)
    /Users/anastasiya/status-desktop/vendor/status-go/protocol/messenger_mailserver_cycle.go:761
github.com/status-im/status-go/protocol.(*Messenger).connectToMailserver(0x240015df180, {{0x10edb0969, 0x25}, {0x0, 0x0}, 0x0, {0x10ee2a96a, 0x79}, {0x0, 0x0}, ...})
    /Users/anastasiya/status-desktop/vendor/status-go/protocol/messenger_mailserver_cycle.go:447 +0x6d8
github.com/status-im/status-go/protocol.(*Messenger).findNewMailserver(0x240015df180)
    /Users/anastasiya/status-desktop/vendor/status-go/protocol/messenger_mailserver_cycle.go:359 +0xc20
github.com/status-im/status-go/protocol.(*Messenger).connectToNewMailserverAndWait(0x240015df180)
    /Users/anastasiya/status-desktop/vendor/status-go/protocol/messenger_mailserver.go:104 +0x16c
github.com/status-im/status-go/protocol.(*Messenger).disconnectStorenodeIfRequired(0x240015df180)
    /Users/anastasiya/status-desktop/vendor/status-go/protocol/messenger_mailserver_cycle.go:789 +0x1f8
github.com/status-im/status-go/protocol.(*Messenger).verifyStorenodeStatus(0x240015df180)
    /Users/anastasiya/status-desktop/vendor/status-go/protocol/messenger_mailserver_cycle.go:706 +0xac
created by github.com/status-im/status-go/protocol.(*Messenger).StartMailserverCycle in goroutine 1660
    /Users/anastasiya/status-desktop/vendor/status-go/protocol/messenger_mailserver_cycle.go:92 +0x2f4
SIGABRT: Abnormal termination.
make: *** [run-macos] Abort trap: 6
```
found by @anastasiyaig 