### PR TITLE
fix!: move `MuteFor24Hr` to the end of the enum

### DIFF
--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -60,15 +60,17 @@ const (
 	MuteFor1WeekDuration  = 7 * 24 * time.Hour
 )
 
+// NOTE: Add items to the end of the list, because desktop and mobile
+// use this enum by number rater than by string.
 const (
 	MuteFor15Min requests.MutingVariation = iota + 1
 	MuteFor1Hr
 	MuteFor8Hr
-	MuteFor24Hr
 	MuteFor1Week
 	MuteTillUnmuted
 	MuteTill1Min
 	Unmuted
+	MuteFor24Hr
 )
 
 const pkStringLength = 68


### PR DESCRIPTION
This fixes the change made here to be not breaking: https://github.com/status-im/status-go/pull/5020
More details here in comments: https://github.com/status-im/status-mobile/pull/21210#issuecomment-2338047155

I'm keeping this PR marked as breaking change, because it is, comparing to previous commit 🙂 

