### PR TITLE
fix_: wakuv2 waitgroups

### DIFF
--- a/wakuv2/message_publishing.go
+++ b/wakuv2/message_publishing.go
@@ -59,6 +59,7 @@ func (w *Waku) Send(pubsubTopic string, msg *pb.WakuMessage, priority *int) ([]b
 }
 
 func (w *Waku) broadcast() {
+	defer w.wg.Done()
 	for {
 		var envelope *protocol.Envelope
 

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1610,11 +1610,7 @@ func (w *Waku) ConnectionChanged(state connection.State) {
 	isOnline := !state.Offline
 	if w.cfg.LightClient {
 		//TODO: Update this as per  https://github.com/waku-org/go-waku/issues/1114
-		w.wg.Add(1)
-		go func() {
-			defer w.wg.Done()
-			w.filterManager.OnConnectionStatusChange("", isOnline)
-		}()
+		go w.filterManager.OnConnectionStatusChange("", isOnline)
 		w.handleNetworkChangeFromApp(state)
 	} else {
 		// for lightClient state update and onlineChange is handled in filterManager.


### PR DESCRIPTION
# Problem

In nightly tests, there was a panic:
```nim
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x17747a8]

goroutine 1180314 [running]:
github.com/status-im/status-go/wakuv2.(*Waku).processQueueLoop(0xc04ff7eb40)
	/home/jenkins/workspace/status-go/tests-nightly/wakuv2/waku.go:1416 +0xc8
created by github.com/status-im/status-go/wakuv2.(*Waku).Start in goroutine 1179373
	/home/jenkins/workspace/status-go/tests-nightly/wakuv2/waku.go:1146 +0x8d6
```

That's because there's a loop and we might access a nil `w.ctx` when stopping waku.
https://github.com/status-im/status-go/blob/daa3695cb58386f62919a0d7b7660cc317839324/wakuv2/waku.go#L1421-L1428

# Fixes

1. I fixed the panic by adding a waitgroup to it.
2. Refactored the way we add to waitgroups, which should be done outside the goroutine (my mistake actually).

