### PR TITLE
feat(telemetry)_: track peers by shard and origin

### DIFF
--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -16,9 +16,9 @@ import (
 	"github.com/status-im/status-go/protocol/transport"
 	"github.com/status-im/status-go/wakuv2"
 
-	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
-
 	v1protocol "github.com/status-im/status-go/protocol/v1"
+	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
+	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
 )
 
 type TelemetryType string
@@ -32,8 +32,9 @@ const (
 	ErrorSendingEnvelopeMetric TelemetryType = "ErrorSendingEnvelope"
 	PeerCountMetric            TelemetryType = "PeerCount"
 	PeerConnFailuresMetric     TelemetryType = "PeerConnFailure"
-
-	MaxRetryCache = 5000
+	PeerCountByShardMetric     TelemetryType = "PeerCountByShard"
+	PeerCountByOriginMetric    TelemetryType = "PeerCountByOrigin"
+	MaxRetryCache                            = 5000
 )
 
 type TelemetryRequest struct {
@@ -79,6 +80,18 @@ func (c *Client) PushPeerConnFailures(ctx context.Context, peerConnFailures map[
 	}
 }
 
+func (c *Client) PushPeerCountByShard(ctx context.Context, peerCountByShard map[uint16]uint) {
+	for shard, count := range peerCountByShard {
+		c.processAndPushTelemetry(ctx, PeerCountByShard{Shard: shard, Count: count})
+	}
+}
+
+func (c *Client) PushPeerCountByOrigin(ctx context.Context, peerCountByOrigin map[wps.Origin]uint) {
+	for origin, count := range peerCountByOrigin {
+		c.processAndPushTelemetry(ctx, PeerCountByOrigin{Origin: origin, Count: count})
+	}
+}
+
 type ReceivedMessages struct {
 	Filter     transport.Filter
 	SSHMessage *types.Message
@@ -92,6 +105,16 @@ type PeerCount struct {
 type PeerConnFailure struct {
 	FailedPeerId string
 	FailureCount int
+}
+
+type PeerCountByShard struct {
+	Shard uint16
+	Count uint
+}
+
+type PeerCountByOrigin struct {
+	Origin wps.Origin
+	Count  uint
 }
 
 type Client struct {
@@ -246,6 +269,18 @@ func (c *Client) processAndPushTelemetry(ctx context.Context, data interface{}) 
 			TelemetryType: PeerConnFailuresMetric,
 			TelemetryData: c.ProcessPeerConnFailure(v),
 		}
+	case PeerCountByShard:
+		telemetryRequest = TelemetryRequest{
+			Id:            c.nextId,
+			TelemetryType: PeerCountByShardMetric,
+			TelemetryData: c.ProcessPeerCountByShard(v),
+		}
+	case PeerCountByOrigin:
+		telemetryRequest = TelemetryRequest{
+			Id:            c.nextId,
+			TelemetryType: PeerCountByOriginMetric,
+			TelemetryData: c.ProcessPeerCountByOrigin(v),
+		}
 	default:
 		c.logger.Error("Unknown telemetry data type")
 		return
@@ -378,6 +413,24 @@ func (c *Client) ProcessPeerConnFailure(peerConnFailure PeerConnFailure) *json.R
 	postBody["failedPeerId"] = peerConnFailure.FailedPeerId
 	postBody["failureCount"] = peerConnFailure.FailureCount
 	postBody["nodeKeyUID"] = c.keyUID
+	body, _ := json.Marshal(postBody)
+	jsonRawMessage := json.RawMessage(body)
+	return &jsonRawMessage
+}
+
+func (c *Client) ProcessPeerCountByShard(peerCountByShard PeerCountByShard) *json.RawMessage {
+	postBody := c.commonPostBody()
+	postBody["shard"] = peerCountByShard.Shard
+	postBody["count"] = peerCountByShard.Count
+	body, _ := json.Marshal(postBody)
+	jsonRawMessage := json.RawMessage(body)
+	return &jsonRawMessage
+}
+
+func (c *Client) ProcessPeerCountByOrigin(peerCountByOrigin PeerCountByOrigin) *json.RawMessage {
+	postBody := c.commonPostBody()
+	postBody["origin"] = peerCountByOrigin.Origin
+	postBody["count"] = peerCountByOrigin.Count
 	body, _ := json.Marshal(postBody)
 	jsonRawMessage := json.RawMessage(body)
 	return &jsonRawMessage


### PR DESCRIPTION
Periodically calculates number of connected peers per shard and discovery method, reports to telemetry

If telemetry is enabled, starts an additional go routine in `wakuv2.Start()` which periodically (currently set to 10 seconds) gets all connected peers. It iterates through each peer and counts how many were discovered using which method (via `wakuPeerStore.Origin(peerId)`) and how many peers support which shard ids. These counts are then reported to the telemetry service.

Important changes:
- [x] Depends on https://github.com/status-im/telemetry/pull/53

Related to https://github.com/status-im/telemetry/issues/21
