### PR TITLE
fix_: flaky TestSimulationBloomFilter

### DIFF
--- a/waku/simulation_test.go
+++ b/waku/simulation_test.go
@@ -102,6 +102,12 @@ var masterPow = 0.00000001
 var round = 1
 
 func TestSimulationBloomFilter(t *testing.T) {
+	result = TestData{}
+	nodes = [NumNodes]*TestNode{}
+	masterBloomFilter = []byte{}
+	masterPow = 0.00000001
+	round = 1
+
 	// create a chain of waku nodes,
 	// installs the filters with shared (predefined) parameters
 	initializeBloomFilterMode(t)


### PR DESCRIPTION
```
TestSimulationBloomFilter: 95.0% (19 of 20 failed)
```

Fixed. Yet another example of [Code Smell #8: Modifying global variables in tests](https://www.notion.so/Code-Smell-8-Modifying-global-variables-in-tests-2996491814fb495b8ef0ceeb4e657798?pvs=4).