### PR TITLE
fix_: tag version script

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -32,12 +32,13 @@ jobs:
           echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
           
           if [[ $exit_code -ne 0 ]]; then
+            invalid_commit_messages=$(echo $output | sed '1d;$d')
             EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
             echo "error_message<<$EOF" >> "$GITHUB_ENV"
-            echo "$output" >> "$GITHUB_ENV"
+            echo "invalid_commit_messages" >> "$GITHUB_ENV"
             echo "$EOF" >> "$GITHUB_ENV"
           else
-            has_breaking_changes=$(echo "$output" | sed -n '2p')
+            has_breaking_changes=$(echo "$output" | tail -n 1)
             echo "has_breaking_changes=$has_breaking_changes" >> $GITHUB_OUTPUT
           fi
 

--- a/_assets/scripts/commit_check.sh
+++ b/_assets/scripts/commit_check.sh
@@ -1,36 +1,4 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
-parse_commits() {
-
-    BASE_BRANCH=${BASE_BRANCH:-develop}
-
-    start_commit=${1:-origin/${BASE_BRANCH}}
-    end_commit=${2:-HEAD}
-    is_breaking_change=false
-    exit_code=0
-
-    echo "checking commits between: $start_commit $end_commit"
-    # Run the loop in the current shell using process substitution
-    while IFS= read -r message || [ -n "$message" ]; do
-        # Check if commit message follows conventional commits format
-        if [[ $message =~ ^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?(\_|!):.*$ ]]; then
-            # Check for breaking changes
-            if [[ ${BASH_REMATCH[3]} == *'!'* ]]; then
-                is_breaking_change=true
-            fi
-        else
-            echo "Commit message \"$message\" is not well-formed"
-            exit_code=1
-        fi
-    done < <(git log --format=%s "$start_commit".."$end_commit")
-
-    if [[ $exit_code -ne 0 ]]; then
-        exit ${exit_code}
-    fi
-
-    echo "$is_breaking_change"
-}
-
+source _assets/scripts/parse_commits.sh
 parse_commits "$@"

--- a/_assets/scripts/parse_commits.sh
+++ b/_assets/scripts/parse_commits.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# The output of this script is as follows:
+# 1. One line "checking commits between: <start_commit> <end_commit>"
+# 2. One line for each commit message that is not well-formed
+# 3. One line with the value of "is_breaking_change" (true/false)
+
+set -euo pipefail
+
+source _assets/scripts/colors.sh
+
+parse_commits() {
+
+    BASE_BRANCH=${BASE_BRANCH:-develop}
+
+    start_commit=${1:-origin/${BASE_BRANCH}}
+    end_commit=${2:-HEAD}
+    is_breaking_change=false
+    exit_code=0
+
+    echo -e "${GRN}Checking commits between:${RST} $start_commit $end_commit"
+    # Run the loop in the current shell using process substitution
+    while IFS= read -r message || [ -n "$message" ]; do
+        # Check if commit message follows conventional commits format
+        if [[ $message =~ ^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?(\_|!):.*$ ]]; then
+            # Check for breaking changes
+            if [[ ${BASH_REMATCH[3]} == *'!'* ]]; then
+                is_breaking_change=true
+            fi
+        else
+            echo -e "${YLW}Commit message is not well-formed:${RST} \"$message\""
+            exit_code=1
+        fi
+    done < <(git log --format=%s "$start_commit".."$end_commit")
+
+    echo "$is_breaking_change"
+    exit ${exit_code}
+}

--- a/_assets/scripts/tag_version.sh
+++ b/_assets/scripts/tag_version.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-source _assets/scripts/commit_check.sh
+source _assets/scripts/parse_commits.sh
+source _assets/scripts/colors.sh
 
 get_latest_tag() {
     # Get the latest tag on develop
@@ -28,26 +29,44 @@ bump_version() {
 }
 
 calculate_new_version() {
-    # Get the latest tag
-    latest_tag=$(get_latest_tag)
-
-    echo "calculating new tag from $latest_tag and $1" >&2
+    target_commit=$1
+    latest_tag=$2
 
     # Parse commits to determine if there are breaking changes
-    is_breaking_change=$(parse_commits "$latest_tag" "$1")
+    output=$(parse_commits "$latest_tag" "$target_commit")
+    exit_code=$?
+
+    a=$(echo "$output" | sed '$d')
+    is_breaking_change=$(echo "$output" | tail -n 1)
+
+    echo "$a" >&2
+
+
+    if [[ $is_breaking_change == 'true' ]]; then
+      echo -e "${YLW}Breaking change detected${RST}" >&2
+    fi
+
+    if [[ $exit_code -ne 0 && $is_breaking_change != true ]]; then
+        echo -e "${YLW}Some commits are ill-formed, can not to auto-calculate new version${RST}" >&2
+        read -p "Any of the commits above have a breaking change? (y/n): " yn
+        case $yn in
+            [Yy]* ) is_breaking_change=true;;
+            [Nn]* ) is_breaking_change=false;;
+            * ) echo "Please answer yes or no."; exit 1;;
+        esac
+    fi
 
     # Bump version accordingly
-    echo "$(bump_version "$latest_tag" "$is_breaking_change")"
-  }
-
-
-main() {
-    new_version=$(calculate_new_version "$1")
-    echo "calculated new version: $new_version" >&2
-
-    git tag -a "$new_version" "$1" -m "release $new_version"
+    bump_version "$latest_tag" "$is_breaking_change"
 }
 
-target_commit=${1:-HEAD}
+latest_tag=$(get_latest_tag)
+echo -e "${GRN}Latest tag found:${RST} $latest_tag" >&2
 
-main "$target_commit"
+target_commit=${1:-HEAD}
+echo -e "${GRN}Calculating new version for:${RST} $target_commit" >&2
+
+new_version=$(calculate_new_version "$target_commit" "$latest_tag")
+echo -e "${GRN}Calculated new version:${RST} $new_version" >&2
+
+git tag -a "$new_version" "$target_commit" -m "release $new_version"


### PR DESCRIPTION
1. Fixed the `tag_version` script. It wasn't properly checking the output of `parse_commits`.
2. Refactored the `tag_version` script:
    - print the list of ill-formed commit messages
    - when there're ill-formed commit message, we can't identify if there are breaking changes. So it will wait for user input:
        ```
        [10/09/24 5:17:58] ➜  status-go git:(develop) ✗ _assets/scripts/tag_version.sh 
        calculating new version for: HEAD
        latest tag found: v0.184.53
        checking commits between: v0.184.53 HEAD
        Commit message "chore: remove urls package (#5810)" is not well-formed
        Commit message "refactor: remove wakuv1 code from mailserver cycle and add ENR to list of storenodes (#5753)" is not well-formed
        some commits are ill-formed, can not to auto-calculate new version
        any of the commits above have a breaking change? (y/n): y
        calculated new version: v0.185.0
        ```
        ```
        [10/09/24 5:18:17] ➜  status-go git:(develop) ✗ _assets/scripts/tag_version.sh
        calculating new version for: HEAD
        latest tag found: v0.184.53
        checking commits between: v0.184.53 HEAD
        Commit message "chore: remove urls package (#5810)" is not well-formed
        Commit message "refactor: remove wakuv1 code from mailserver cycle and add ENR to list of storenodes (#5753)" is not well-formed
        some commits are ill-formed, can not to auto-calculate new version
        any of the commits above have a breaking change? (y/n): n
        calculated new version: v0.184.54
        ```
    - Use colors
    - Clean up a bit