### PR TITLE
feat(telemetry)_: message check success and failure, peers by shard and origin

### DIFF
--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	StoreSeconds                           int              `toml:",omitempty"`
 	TelemetryServerURL                     string           `toml:",omitempty"`
 	TelemetrySendPeriodMs                  int              `toml:",omitempty"` // Number of milliseconds to wait between sending requests to telemetry service
+	TelemetryPeerCountSendPeriod           int              `toml:",omitempty"` // Number of milliseconds to wait between checking peer count
 	DefaultShardPubsubTopic                string           `toml:",omitempty"` // Pubsub topic to be used by default for messages that do not have a topic assigned (depending whether sharding is used or not)
 	DefaultShardedPubsubTopics             []string         `toml:", omitempty"`
 	ClusterID                              uint16           `toml:",omitempty"`

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -109,6 +109,8 @@ type ITelemetryClient interface {
 	PushErrorSendingEnvelope(ctx context.Context, errorSendingEnvelope ErrorSendingEnvelope)
 	PushPeerCount(ctx context.Context, peerCount int)
 	PushPeerConnFailures(ctx context.Context, peerConnFailures map[string]int)
+	PushMessageCheckSuccess(ctx context.Context, messageHash string)
+	PushMessageCheckFailure(ctx context.Context, messageHash string)
 }
 
 // Waku represents a dark communication interface through the Ethereum
@@ -1233,11 +1235,17 @@ func (w *Waku) startMessageSender() error {
 						Hash:  hash,
 						Event: common.EventEnvelopeSent,
 					})
+					if w.statusTelemetryClient != nil {
+						w.statusTelemetryClient.PushMessageCheckSuccess(w.ctx, hash.Hex())
+					}
 				case hash := <-msgExpiredChan:
 					w.SendEnvelopeEvent(common.EnvelopeEvent{
 						Hash:  hash,
 						Event: common.EventEnvelopeExpired,
 					})
+					if w.statusTelemetryClient != nil {
+						w.statusTelemetryClient.PushMessageCheckFailure(w.ctx, hash.Hex())
+					}
 				}
 			}
 		}()


### PR DESCRIPTION
Adds new metrics for peers by shard and origin, and message check success/failure

If telemetry is enabled, will report any hashes that are read from `msgStoredChan` or `msgExpiredChan`, which represent messages that succeeded and failed the store query check, respectively.
If telemetry is enabled, starts an additional go routine in wakuv2.Start() which periodically (currently set to 10 seconds) gets all connected peers. It iterates through each peer and counts how many were discovered using which method (via wakuPeerStore.Origin(peerId)) and how many peers support which shard ids. These counts are then reported to the telemetry service.

Important changes:
- [x] Depends on https://github.com/status-im/telemetry/pull/56
- [x] Depends on https://github.com/status-im/telemetry/pull/53

Closes #
