### PR TITLE
chore_: status-go version 1.0.0

### DIFF
--- a/_assets/scripts/tag_version.sh
+++ b/_assets/scripts/tag_version.sh
@@ -18,10 +18,10 @@ bump_version() {
 
     # Bump the version based on the type of change
     if [[ "$is_breaking_change" = true ]]; then
-        ((minor++))
-        ((patch=0))
+        ((major++))
+        ((minor=0))
     else
-        ((patch++))
+        ((minor++))
     fi
 
     new_version="$major.$minor.$patch"


### PR DESCRIPTION
> [!CAUTION]
> By approving this PR you agree to release status-go `1.0.0`

As proposed before, the idea is to make a 1.0.0 release and from there:
- bump MAJOR on a breaking change (same as we bump MINOR now)
- bump MINOR on a non-breaking change (same as we bump PATCH now)
- manually bump PATCH on release branches

This will allow us to make patches to the release branch. Without the `+hotfix` stuff.

-----

When this PR is merged, I will push the `v1.0.0` tag.