### PR TITLE
Add optional BIP39Passphrase parameter on account restoration

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -567,7 +567,7 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 	}
 
 	if request.Mnemonic != "" {
-		info, err := b.generateAccountInfo(request.Mnemonic)
+		info, err := b.generateAccountInfo(request.Mnemonic, request.BIP39Passphrase)
 		if err != nil {
 			return errors.Wrap(err, "failed to generate account info")
 		}
@@ -1312,7 +1312,7 @@ func (b *GethStatusBackend) RestoreAccountAndLogin(request *requests.RestoreAcco
 		return nil, err
 	}
 
-	response, err := b.generateOrImportAccount(request.Mnemonic, 0, request.FetchBackup, &request.CreateAccount)
+	response, err := b.generateOrImportAccount(request.Mnemonic, request.BIP39Passphrase, 0, request.FetchBackup, &request.CreateAccount)
 	if err != nil {
 		return nil, err
 	}
@@ -1399,10 +1399,10 @@ func (b *GethStatusBackend) RestoreKeycardAccountAndLogin(request *requests.Rest
 	return response.account, nil
 }
 
-func (b *GethStatusBackend) GetKeyUIDByMnemonic(mnemonic string) (string, error) {
+func (b *GethStatusBackend) GetKeyUIDByMnemonic(mnemonic, passphrase string) (string, error) {
 	accountGenerator := b.accountManager.AccountsGenerator()
 
-	info, err := accountGenerator.ImportMnemonic(mnemonic, "")
+	info, err := accountGenerator.ImportMnemonic(mnemonic, passphrase)
 	if err != nil {
 		return "", err
 	}
@@ -1431,8 +1431,8 @@ type accountBundle struct {
 	chatPrivateKey *ecdsa.PrivateKey
 }
 
-func (b *GethStatusBackend) generateOrImportAccount(mnemonic string, customizationColorClock uint64, fetchBackup bool, request *requests.CreateAccount, opts ...params.Option) (*accountBundle, error) {
-	info, err := b.generateAccountInfo(mnemonic)
+func (b *GethStatusBackend) generateOrImportAccount(mnemonic, passphrase string, customizationColorClock uint64, fetchBackup bool, request *requests.CreateAccount, opts ...params.Option) (*accountBundle, error) {
+	info, err := b.generateAccountInfo(mnemonic, passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -1517,7 +1517,7 @@ func (b *GethStatusBackend) InitKeyStoreDirWithAccount(rootDataDir, keyUID strin
 	return keyStoreRelativePath, b.accountManager.InitKeystore(keystoreAbsolutePath)
 }
 
-func (b *GethStatusBackend) generateAccountInfo(mnemonic string) (*generator.GeneratedAccountInfo, error) {
+func (b *GethStatusBackend) generateAccountInfo(mnemonic, BIP39Passphrase string) (*generator.GeneratedAccountInfo, error) {
 	accountGenerator := b.accountManager.AccountsGenerator()
 
 	var info generator.GeneratedAccountInfo
@@ -1532,7 +1532,7 @@ func (b *GethStatusBackend) generateAccountInfo(mnemonic string) (*generator.Gen
 		}
 	} else {
 
-		info, err = accountGenerator.ImportMnemonic(mnemonic, "")
+		info, err = accountGenerator.ImportMnemonic(mnemonic, BIP39Passphrase)
 		if err != nil {
 			return nil, err
 		}
@@ -1717,7 +1717,7 @@ func (b *GethStatusBackend) CreateAccountAndLogin(request *requests.CreateAccoun
 		return nil, err
 	}
 
-	response, err := b.generateOrImportAccount("", 1, false, request, opts...)
+	response, err := b.generateOrImportAccount("", "", 1, false, request, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1035,17 +1035,22 @@ func colorID(pk string) string {
 }
 
 func ValidateMnemonic(mnemonic string) string {
-	return logAndCallString(validateMnemonic, mnemonic)
+	return logAndCallString(validateMnemonic, mnemonic, "")
 }
 
-func validateMnemonic(mnemonic string) string {
+func ValidateMnemonicWithPassphrase(mnemonic, passphrase string) string {
+	return logAndCallString(validateMnemonic, mnemonic, passphrase)
+}
+
+func validateMnemonic(mnemonic, passphrase string) string {
 	m := extkeys.NewMnemonic()
 	err := m.ValidateMnemonic(mnemonic, extkeys.Language(0))
 	if err != nil {
 		return makeJSONResponse(err)
 	}
 
-	keyUID, err := statusBackend.GetKeyUIDByMnemonic(mnemonic)
+	keyUID, err := statusBackend.GetKeyUIDByMnemonic(mnemonic, passphrase)
+
 	if err != nil {
 		return makeJSONResponse(err)
 	}

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -32,6 +32,10 @@ type Login struct {
 	// - Password is ignored and replaced with encryption public key
 	// - KeycardWhisperPrivateKey is ignored and replaced with chat private key
 	Mnemonic string `json:"mnemonic"`
+	// https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed
+	// A user may decide to protect their mnemonic with a passphrase. If a passphrase is not present,
+	// an empty string "" is used instead.
+	BIP39Passphrase string `json:"BIP39Passphrase"`
 
 	WalletSecretsConfig
 

--- a/protocol/requests/restore_account.go
+++ b/protocol/requests/restore_account.go
@@ -11,6 +11,7 @@ var (
 
 type RestoreAccount struct {
 	Mnemonic string `json:"mnemonic"`
+	BIP39Passphrase string `json:"BIP39Passphrase"`
 
 	// Keycard info can be set instead of Mnemonic.
 	// This is to log in using a keycard with existing account.


### PR DESCRIPTION
https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed

There is no option to restore account with mnemonic and passphrase at the moment. It was possible to restore account with a passphrase in the old version of status mobile. Apparently the functionality is missing because nobody uses it, but I still do. 

This PR is an attempt to bring it back (at least for account restoration process). We could also add an option to restore wallet account with passphrase as well.

`ValidateMnemonic` had to be changed because it returns `keyUid`, and it depends on both mnemonic and passphrase. Returning `keyUid` from this method is a bit misleading, but well... It works.