### PR TITLE
feat_: improve PR commit messages processing 

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -78,7 +78,7 @@ jobs:
             
             ### Check-list
             
-            - [ ] Tried to prevent this breaking change
+            - [ ] Tried to avoid this breaking change
             - [ ] Updated [status-desktop](https://github.com/status-im/status-desktop) 
             - [ ] Updated [status-mobile](https://github.com/status-im/status-mobile)
 

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -27,19 +27,28 @@ jobs:
         run: |
           set +e
 
-          output=$(./_assets/scripts/commit_check.sh 2>&1)          
+          output=$(./_assets/scripts/commit_check.sh 2>&1)
           exit_code=$?
+          
+          echo "$output" | sed '$d'
+          echo "has_breaking_changes=$has_breaking_changes"
+          
           echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
           
+          has_breaking_changes=$(echo "$output" | tail -n 1)
+          echo "has_breaking_changes=$has_breaking_changes" >> $GITHUB_OUTPUT
+          
+          invalid_commit_messages=$(echo "$output" | sed '1d;$d')
+          invalid_commit_messages=$(echo "$output" | sed '1d;$d')
+          invalid_commit_messages=$(echo "$invalid_commit_messages" | sed 's/\x1b\[[0-9;]*m//g') # Remove color codes
+          invalid_commit_messages=$(echo "$invalid_commit_messages" | sed 's/^Commit message is ill-formed: //') # Remove prefix
+          
           if [[ $exit_code -ne 0 ]]; then
-            invalid_commit_messages=$(echo $output | sed '1d;$d')
             EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
             echo "error_message<<$EOF" >> "$GITHUB_ENV"
-            echo "invalid_commit_messages" >> "$GITHUB_ENV"
+            echo "$invalid_commit_messages" >> "$GITHUB_ENV"
             echo "$EOF" >> "$GITHUB_ENV"
-          else
-            has_breaking_changes=$(echo "$output" | tail -n 1)
-            echo "has_breaking_changes=$has_breaking_changes" >> $GITHUB_OUTPUT
+          
           fi
 
       - name: "Publish failed commit messages"
@@ -50,12 +59,8 @@ jobs:
         with:
           header: commit-message-lint-error
           message: |
-            Thank you for opening this pull request!
-            
             We require commits to follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), but with `_` for non-breaking changes. 
-            And it looks like your PR needs to be adjusted.
-
-            Details:
+            Please fix these commit messages:
             ```
             ${{ env.error_message }}
             ```
@@ -68,10 +73,14 @@ jobs:
         with:
           header: commit-message-lint-error
           message: |
-            Thank you for opening this pull request!
-            
             Looks like you have BREAKING CHANGES in your PR. 
-            Please make sure to update [status-desktop](https://github.com/status-im/status-desktop) and [status-mobile](https://github.com/status-im/status-mobile) clients accordingly.
+            Please make sure to follow [💔How to introduce breaking changes](https://www.notion.so/How-to-introduce-breaking-changes-ded9ec2d91464a46a2593c0d8de62fbe?pvs=4) guide:
+            
+            ### Check-list
+            
+            - [ ] Tried to prevent this breaking change
+            - [ ] Updated [status-desktop](https://github.com/status-im/status-desktop) 
+            - [ ] Updated [status-mobile](https://github.com/status-im/status-mobile)
 
       # Delete a previous comment when the issue has been resolved
       - name: "Delete previous comment"
@@ -80,3 +89,25 @@ jobs:
         with:
           header: commit-message-lint-error
           delete: true
+
+      - name: "Mark as failed"
+        if: steps.check_commit_message.outputs.exit_code != 0
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.setFailed("Some commit messages are ill-formed")
+
+      - name: "Update breaking changes label"
+        if: always()
+        run: |
+          if [[ $ADD_LABEL == 'true' ]]; then
+            command="--add-label"
+          else
+            command="--remove-label"
+          fi
+          gh issue edit "$NUMBER" $command "breaking change"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          ADD_LABEL: ${{ steps.check_commit_message.outputs.has_breaking_changes == 'true' }}

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -30,23 +30,23 @@ jobs:
           output=$(./_assets/scripts/commit_check.sh 2>&1)
           exit_code=$?
           
-          echo "$output" | sed '$d'
-          echo "has_breaking_changes=$has_breaking_changes"
+          echo "${output}" | sed '$d'
+          echo "has_breaking_changes=${has_breaking_changes}"
           
-          echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
+          echo "exit_code=${exit_code}" >> $GITHUB_OUTPUT
           
-          has_breaking_changes=$(echo "$output" | tail -n 1)
-          echo "has_breaking_changes=$has_breaking_changes" >> $GITHUB_OUTPUT
+          has_breaking_changes=$(echo "${output}" | tail -n 1)
+          echo "has_breaking_changes=${has_breaking_changes}" >> $GITHUB_OUTPUT
           
-          invalid_commit_messages=$(echo "$output" | sed '1d;$d')
-          invalid_commit_messages=$(echo "$output" | sed '1d;$d')
-          invalid_commit_messages=$(echo "$invalid_commit_messages" | sed 's/\x1b\[[0-9;]*m//g') # Remove color codes
-          invalid_commit_messages=$(echo "$invalid_commit_messages" | sed 's/^Commit message is ill-formed: //') # Remove prefix
+          invalid_commit_messages=$(echo "${output}" | sed '1d;$d')
+          invalid_commit_messages=$(echo "${output}" | sed '1d;$d')
+          invalid_commit_messages=$(echo "${invalid_commit_messages}" | sed 's/\x1b\[[0-9;]*m//g') # Remove color codes
+          invalid_commit_messages=$(echo "${invalid_commit_messages}" | sed 's/^Commit message is ill-formed: //') # Remove prefix
           
           if [[ $exit_code -ne 0 ]]; then
             EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
             echo "error_message<<$EOF" >> "$GITHUB_ENV"
-            echo "$invalid_commit_messages" >> "$GITHUB_ENV"
+            echo "${invalid_commit_messages}" >> "$GITHUB_ENV"
             echo "$EOF" >> "$GITHUB_ENV"
           
           fi

--- a/_assets/scripts/parse_commits.sh
+++ b/_assets/scripts/parse_commits.sh
@@ -28,7 +28,7 @@ parse_commits() {
                 is_breaking_change=true
             fi
         else
-            echo -e "${YLW}Commit message is not well-formed:${RST} \"$message\""
+            echo -e "${YLW}Commit message is ill-formed:${RST} $message"
             exit_code=1
         fi
     done < <(git log --format=%s "$start_commit".."$end_commit")

--- a/_assets/scripts/tag_version.sh
+++ b/_assets/scripts/tag_version.sh
@@ -37,12 +37,9 @@ calculate_new_version() {
     # Parse commits to determine if there are breaking changes
     output=$(parse_commits "$latest_tag" "$target_commit")
     exit_code=$?
+    echo "$output" | sed '$d' >&2 # Skip the last line, it contains the breaking change flag
 
-    a=$(echo "$output" | sed '$d')
     is_breaking_change=$(echo "$output" | tail -n 1)
-
-    echo "$a" >&2
-
 
     if [[ $is_breaking_change == 'true' ]]; then
       echo -e "${YLW}Breaking change detected${RST}" >&2


### PR DESCRIPTION
1. Fixed `parse_commits` output processing

2. Fail status check when found commit ill-formed commit messages
    <img width="592" alt="image" src="https://github.com/user-attachments/assets/4cd5f043-8b14-4fe8-94ed-40ffc0f23c28">

3. Automatically add `breaking change` label:
    <img width="525" alt="image" src="https://github.com/user-attachments/assets/391570c2-7320-40dd-8334-a43fcb34f02f">
    And remove it if the breaking change is no more present:
    <img width="529" alt="image" src="https://github.com/user-attachments/assets/27c94fc8-2f8f-4f5b-99d2-72b5fada1bb3">


4. Better comment on a breaking change.
    Has a link to the guide. Has a simple check-list.

    <img width="600" alt="image" src="https://github.com/user-attachments/assets/5b7a3ff5-d964-43dc-881b-78c685124c32">
