### PR TITLE
fix_: flaky TestSignalsServer

### DIFF
--- a/cmd/statusd/server/signals_server.go
+++ b/cmd/statusd/server/signals_server.go
@@ -58,7 +58,9 @@ func (s *Server) Listen(address string) error {
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	http.HandleFunc("/signals", s.signals)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/signals", s.signals)
+	s.server.Handler = mux
 
 	listener, err := net.Listen("tcp", address)
 	if err != nil {


### PR DESCRIPTION
It panics in nightly:
```
TestSignalsServer: 50.0% (1 of 2 failed)
```
```go
=== FAIL: cmd/statusd/server TestSignalsServer (0.00s)
panic: http: multiple registrations for /signals [recovered]
	panic: http: multiple registrations for /signals
```

Instead of setting a global handler, we should use a `ServeMux`.