### PR TITLE
fix_: skip nix-shell for `install-git-hooks`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,6 +456,10 @@ commit-check: SHELL := /bin/sh
 commit-check:
 	@bash _assets/scripts/commit_check.sh
 
+version: SHELL := /bin/sh
+version:
+	@./_assets/scripts/version.sh
+
 tag-version:
 	bash _assets/scripts/tag_version.sh $(TARGET_COMMIT)
 
@@ -463,6 +467,7 @@ migration-wallet: DEFAULT_WALLET_MIGRATION_PATH := walletdatabase/migrations/sql
 migration-wallet:
 	touch $(DEFAULT_WALLET_MIGRATION_PATH)/$$(date +%s)_$(D).up.sql
 
+install-git-hooks: SHELL := /bin/sh
 install-git-hooks:
 	@ln -sf $(if $(filter $(detected_OS), Linux),-r,) \
 		$(GIT_ROOT)/_assets/hooks/* $(GIT_ROOT)/.git/hooks


### PR DESCRIPTION
This target is included for all targets.

So even when I run an unrelated `make version`, I had to wait 5 seconds before executing the script:

https://github.com/user-attachments/assets/996cabfa-2b26-451a-bacc-808375090cab

----

Also added `make version`. Simple way to see the current version:
```
> make version
v1.0.0-3-g48877ec79
```

