### PR TITLE
fix_: Send transaction failures

### DIFF
--- a/transactions/transactor.go
+++ b/transactions/transactor.go
@@ -153,6 +153,10 @@ func (t *Transactor) SendTransactionWithChainID(chainID uint64, sendArgs SendTxA
 func (t *Transactor) ValidateAndBuildTransaction(chainID uint64, sendArgs SendTxArgs, lastUsedNonce int64) (tx *gethtypes.Transaction, nonce uint64, err error) {
 	wrapper := newRPCWrapper(t.rpcWrapper.RPCClient, chainID)
 	tx, err = t.validateAndBuildTransaction(wrapper, sendArgs, lastUsedNonce)
+	if err != nil {
+		return nil, 0, err
+	}
+
 	return tx, tx.Nonce(), err
 }
 
@@ -412,7 +416,7 @@ func (t *Transactor) validateAndBuildTransaction(rpcWrapper *rpcWrapper, args Se
 		if args.IsDynamicFeeTx() {
 			gasFeeCap := (*big.Int)(args.MaxFeePerGas)
 			gasTipCap := (*big.Int)(args.MaxPriorityFeePerGas)
-			gas, err = t.rpcWrapper.EstimateGas(ctx, ethereum.CallMsg{
+			gas, err = rpcWrapper.EstimateGas(ctx, ethereum.CallMsg{
 				From:      common.Address(args.From),
 				To:        gethToPtr,
 				GasFeeCap: gasFeeCap,
@@ -421,7 +425,7 @@ func (t *Transactor) validateAndBuildTransaction(rpcWrapper *rpcWrapper, args Se
 				Data:      args.GetInput(),
 			})
 		} else {
-			gas, err = t.rpcWrapper.EstimateGas(ctx, ethereum.CallMsg{
+			gas, err = rpcWrapper.EstimateGas(ctx, ethereum.CallMsg{
 				From:     common.Address(args.From),
 				To:       gethToPtr,
 				GasPrice: gasPrice,


### PR DESCRIPTION
A short summary which serves as a squashed-commit message.

1. Fixing a crash on `ValidateAndBuildTransaction`: tx.Nonce() is called on a null tx whenever it fails to build the transaction
2. Fixing gas extimations. The estimations are always done on mainnet and the requested chainId is ignored in the estimation

A description to understand introduced changes without reading the code.

Had two failures on send transactions flows on Optimism. First is the crash whenever we can't build a transaction -> added error handling. And the second one is a failure on gas estimations because the estimation is ignoring the chain selection.
