### PR TITLE
chore_: fix sqlcipher build for android on ndkr26b

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace github.com/nfnt/resize => github.com/status-im/resize v0.0.0-20201215164
 
 replace github.com/forPelevin/gomoji => github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4
 
-replace github.com/mutecomm/go-sqlcipher/v4 v4.4.2 => github.com/status-im/go-sqlcipher/v4 v4.5.4-status.2
+replace github.com/mutecomm/go-sqlcipher/v4 v4.4.2 => github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3
 
 replace github.com/libp2p/go-libp2p-pubsub v0.11.0 => github.com/waku-org/go-libp2p-pubsub v0.0.0-20240703191659-2cbb09eac9b5
 

--- a/go.sum
+++ b/go.sum
@@ -2020,8 +2020,8 @@ github.com/status-im/doubleratchet v3.0.0+incompatible h1:aJ1ejcSERpSzmWZBgtfYti
 github.com/status-im/doubleratchet v3.0.0+incompatible/go.mod h1:1sqR0+yhiM/bd+wrdX79AOt2csZuJOni0nUDzKNuqOU=
 github.com/status-im/go-ethereum v1.10.25-status.16 h1:6CjK8qdlUc/7n42UJ743rf13x/ICSwxrh/NlDGyvmOk=
 github.com/status-im/go-ethereum v1.10.25-status.16/go.mod h1:Dt4K5JYMhJRdtXJwBEyGZLZn9iz/chSOZyjVmt5ZhwQ=
-github.com/status-im/go-sqlcipher/v4 v4.5.4-status.2 h1:Oi9JTAI2DZEe5UKlpUcvKBCCSn3ULsLIrix7jPnEoPE=
-github.com/status-im/go-sqlcipher/v4 v4.5.4-status.2/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
+github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3 h1:/73h1w1hUfb3wVyTlNrUIwahZxatgesCHa6lwO57C2M=
+github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4 h1:CtobZoiNdHpx+xurFxnuJ1xsGm3oKMfcZkB3vmomJmA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4/go.mod h1:hmpnZzkzSZJbFYWAUkrPV8I36x7mdYiPhPqnALP4fKA=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=

--- a/vendor/github.com/mutecomm/go-sqlcipher/v4/aesce.c
+++ b/vendor/github.com/mutecomm/go-sqlcipher/v4/aesce.c
@@ -101,6 +101,7 @@ int mbedtls_aesce_has_support(void)
 #endif
 }
 
+__attribute__((target("aes,crypto")))
 static uint8x16_t aesce_encrypt_block(uint8x16_t block,
                                       unsigned char *keys,
                                       int rounds)
@@ -125,6 +126,7 @@ static uint8x16_t aesce_encrypt_block(uint8x16_t block,
     return block;
 }
 
+__attribute__((target("aes,crypto")))
 static uint8x16_t aesce_decrypt_block(uint8x16_t block,
                                       unsigned char *keys,
                                       int rounds)
@@ -182,10 +184,12 @@ int mbedtls_aesce_crypt_ecb(mbedtls_aes_context *ctx,
 /*
  * Compute decryption round keys from encryption round keys
  */
+__attribute__((target("aes,crypto")))
 void mbedtls_aesce_inverse_key(unsigned char *invkey,
                                const unsigned char *fwdkey,
                                int nr)
 {
+
     int i, j;
     j = nr;
     vst1q_u8(invkey, vld1q_u8(fwdkey + j * 16));
@@ -202,6 +206,7 @@ static inline uint32_t aes_rot_word(uint32_t word)
     return (word << (32 - 8)) | (word >> 8);
 }
 
+__attribute__((target("aes,crypto")))
 static inline uint32_t aes_sub_word(uint32_t in)
 {
     uint8x16_t v = vreinterpretq_u8_u32(vdupq_n_u32(in));

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -677,7 +677,7 @@ github.com/multiformats/go-multistream
 # github.com/multiformats/go-varint v0.0.7
 ## explicit; go 1.18
 github.com/multiformats/go-varint
-# github.com/mutecomm/go-sqlcipher/v4 v4.4.2 => github.com/status-im/go-sqlcipher/v4 v4.5.4-status.2
+# github.com/mutecomm/go-sqlcipher/v4 v4.4.2 => github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3
 ## explicit; go 1.12
 github.com/mutecomm/go-sqlcipher/v4
 # github.com/nfnt/resize v0.0.0-00010101000000-000000000000 => github.com/status-im/resize v0.0.0-20201215164250-7c6d9f0d3088


### PR DESCRIPTION
## Summary

This PR bumps the version of our fork of `go-sqlcipher` to obtain a fix for building `status-go` for `android`.
I observed that the builds started failing after I upgraded to NDK `r26b`.

related PR in `go-sqlcipher` repo : https://github.com/status-im/go-sqlcipher/pull/2

needed for : https://github.com/status-im/status-mobile/pull/21268
