### PR TITLE
upgrade nixpkgs to match the version in status-mobile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ statusgo-android: ##@cross-compile Build status-go for Android
 		-target=android -ldflags="-s -w" \
 		-tags '$(BUILD_TAGS) disable_torrent' \
 		$(BUILD_FLAGS_MOBILE) \
+		--androidapi="23" \
 		-o build/bin/statusgo.aar \
 		github.com/status-im/status-go/mobile
 	@echo "Android cross compilation done in build/bin/statusgo.aar"

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -9,18 +9,21 @@ let
   inherit (prev) callPackage;
 in rec {
   androidPkgs = prev.androidenv.composeAndroidPackages {
+    cmdLineToolsVersion = "9.0";
     toolsVersion = "26.1.1";
     platformToolsVersion = "33.0.3";
-    buildToolsVersions = [ "31.0.0" ];
-    platformVersions = [ "31" ];
-    cmakeVersions = [ "3.18.1" ];
-    ndkVersion = "22.1.7171670";
+    buildToolsVersions = [ "34.0.0" ];
+    platformVersions = [ "34" ];
+    cmakeVersions = [ "3.22.1" ];
+    ndkVersion = "25.2.9519653";
     includeNDK = true;
     includeExtras = [
       "extras;android;m2repository"
       "extras;google;m2repository"
     ];
   };
+
+  openjdk = prev.openjdk17_headless;
 
   go = prev.go_1_21;
   buildGoModule = prev.buildGo121Module;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -8,8 +8,8 @@ let
 
   # We follow the master branch of official nixpkgs.
   nixpkgsSrc = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/224fd9a362487ab2894dac0df161c84ab1d8880b.tar.gz";
-    sha256 = "sha256:1syvl39pi1h8lf5gkd9h7ksn5hp34cj7pa3abr59217kv0bdklhy";
+    url = "https://github.com/NixOS/nixpkgs/archive/48d567fc7b299de90f70a48e4263e31f690ba03e.tar.gz";
+    sha256 = "sha256:0zynbk52khdfhg4qfv26h3r5156xff5p0cga2cin7b07i7lqminh";
   };
 
   # Status specific configuration defaults


### PR DESCRIPTION
## Summary

- This PR bumps the nixpkgs version to use a commit in the unstable channel.
- Here we also get updated version of `mockgen` which fixes: https://github.com/status-im/status-go/issues/5668
- bump ndk,java and Android platform versions to match what we build in status-mobile.

> mockgen has changed to the [go.uber.org/mock](https://github.com/uber-go/mock) fork because [the original repository is no longer maintained](https://github.com/golang/mock#gomock).

ref -> https://github.com/NixOS/nixpkgs/blob/63dacb46bf939521bdc93981b4cbb7ecb58427a0/nixos/doc/manual/release-notes/rl-2405.section.md