### PR TITLE
fix_: commit-check support forks

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Fetch tags
         run: |
           git fetch --tags --quiet
-          git checkout origin/${GITHUB_HEAD_REF}
+          git checkout ${{ github.event.pull_request.head.ref }}
 
       - name: Check commit message
         id: check_commit_message

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -4,7 +4,10 @@ on:
   pull_request_target:
     types:
       - opened
+      - reopened
       - synchronize
+      - labeled
+      - unlabeled
 jobs:
   main:
     name: Validate format

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,7 +1,7 @@
 name: "Conventional Commits"
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
1. commit-check workflow doesn't work for the forks: 
    https://github.com/status-im/status-go/actions/runs/10939245256/job/30369087700?pr=5833
    
    As I understand correctly, one of the ways to fix this is to use `pull_request_target` events instead of `pull_request`:
    https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
    
    Though I'm not sure if it works properly. For example, the check didn't appear in this PR. Neither it appeared in the fork PR I made for testing: https://github.com/status-im/status-go/pull/5853.
    
    I assume that we have to merge it first to work, but I am very unsure if I'm doing the right thing. 
    Please let me know what you think.

2. Also added some more event types for trigger.
    - `reopened` (obvious reason)
    - `labeled` and `unlabeled` - to prevent removing `breaking change` label where it's required.