### PR TITLE
fix_: allow running commit-check on forks - attempt 2

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -17,20 +17,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.GITHUB_HEAD_REF }}
-          fetch-tags: true
-
-      - name: Fetch tags
-        run: |
-          git fetch --tags --quiet
-          git checkout ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Check commit message
         id: check_commit_message
         run: |
           set +e
+          
+          base_sha=${{ github.event.pull_request.base.sha }} 
+          head_sha=${{ github.event.pull_request.head.sha }}
 
-          output=$(./_assets/scripts/commit_check.sh 2>&1)
+          output=$(./_assets/scripts/commit_check.sh "${base_sha}" "${head_sha}" 2>&1)
           exit_code=$?
           
           echo "${output}" | sed '$d'


### PR DESCRIPTION
Unfortunately, https://github.com/status-im/status-go/pull/5851 wasn't enough. And even worse, it broke the check 😄 

1. `actions/checkout` checkouts a merge ref, while we want to checkout fork's context. 
Found the solution here: https://github.com/actions/checkout/issues/455#issuecomment-792228083

2. `commit_check.sh` should be called with commits sha, because branches don't exist when with forks.
Another benefit here is that now the check properly uses base commit. Before it was always comparing with `develop` branch.

-----

This time I properly tested this with an external repo: https://github.com/six78/test-fork-gh-actions
