### PR TITLE
feat_: use a single content-topic for all community chats

### DIFF
--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -685,7 +685,7 @@ func (s *MessageSender) dispatchCommunityChatMessage(ctx context.Context, rawMes
 
 	hashes := make([][]byte, 0, len(newMessages))
 	for _, newMessage := range newMessages {
-		hash, err := s.transport.SendPublic(ctx, newMessage, rawMessage.LocalChatID)
+		hash, err := s.transport.SendPublic(ctx, newMessage, rawMessage.ContentTopic)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/protocol/common/raw_message.go
+++ b/protocol/common/raw_message.go
@@ -80,6 +80,7 @@ type RawMessage struct {
 	Ephemeral             bool
 	BeforeDispatch        func(*RawMessage) error
 	HashRatchetGroupID    []byte
+	ContentTopic          string
 	PubsubTopic           string
 	ResendType            ResendType
 	ResendMethod          ResendMethod

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1568,6 +1568,13 @@ func (o *Community) setPrivateKey(pk *ecdsa.PrivateKey) {
 	}
 }
 
+func (o *Community) UniversalChatID() string {
+	// Using Member updates channelID as chatID to act as a universal content-topic for all chats in the community as explained here https://forum.vac.dev/t/status-communities-review-and-proposed-usage-of-waku-content-topics/335
+	// This is to match filter criteria of community with the content-topic usage.
+	// This specific topic is chosen as existing users before the change are already subscribed to this and will not get affected by it.
+	return o.MemberUpdateChannelID()
+}
+
 func (o *Community) SetResendAccountsClock(clock uint64) {
 	o.config.CommunityDescription.ResendAccountsClock = clock
 }

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -4279,6 +4279,20 @@ func (m *Manager) GetOwnedCommunitiesChatIDs() (map[string]bool, error) {
 	return chatIDs, nil
 }
 
+func (m *Manager) GetOwnedCommunitiesUniversalChatIDs() (map[string]bool, error) {
+	ownedCommunities, err := m.Controlled()
+	if err != nil {
+		return nil, err
+	}
+	chatIDs := make(map[string]bool)
+	for _, c := range ownedCommunities {
+		if c.Joined() {
+			chatIDs[c.UniversalChatID()] = true
+		}
+	}
+	return chatIDs, nil
+}
+
 func (m *Manager) StoreWakuMessage(message *wakutypes.Message) error {
 	return m.persistence.SaveWakuMessage(message)
 }

--- a/protocol/communities/manager_archive.go
+++ b/protocol/communities/manager_archive.go
@@ -356,6 +356,10 @@ func (m *ArchiveManager) StartHistoryArchiveTasksInterval(community *Community, 
 				m.logger.Error("failed to get community chat topics ", zap.Error(err))
 				continue
 			}
+			// adding the content-topic used for member updates.
+			// since member updates would not be too frequent i.e only addition/deletion would add a new message,
+			// this shouldn't cause too much increase in size of archive generated.
+			topics = append(topics, m.transport.FilterByChatID(community.UniversalChatID()).ContentTopic)
 
 			ts := time.Now().Unix()
 			to := time.Unix(ts, 0)

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -2154,7 +2154,8 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestImportDecryptedArchiveMe
 	startDate := messageDate.Add(-time.Minute)
 	endDate := messageDate.Add(time.Minute)
 	topic := wakutypes.BytesToTopic(transport.ToTopic(chat.ID))
-	topics := []wakutypes.TopicType{topic}
+	communityCommonTopic := wakutypes.BytesToTopic(transport.ToTopic(community.UniversalChatID()))
+	topics := []wakutypes.TopicType{topic, communityCommonTopic}
 
 	torrentConfig := params.TorrentConfig{
 		Enabled:    true,

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2717,7 +2717,12 @@ func (m *Messenger) UpdateCommunityFilters(community *communities.Community) err
 	publicFiltersToInit := make([]transport.FiltersToInitialize, 0, len(defaultFilters)+len(community.Chats()))
 
 	publicFiltersToInit = append(publicFiltersToInit, defaultFilters...)
-
+	for _, filter := range defaultFilters {
+		_, err := m.transport.RemoveFilterByChatID(filter.ChatID)
+		if err != nil {
+			return err
+		}
+	}
 	for chatID := range community.Chats() {
 		communityChatID := community.IDString() + chatID
 		_, err := m.transport.RemoveFilterByChatID(communityChatID)
@@ -3953,6 +3958,8 @@ func (m *Messenger) InitHistoryArchiveTasks(communities []*communities.Community
 			for _, filter := range filters {
 				topics = append(topics, filter.ContentTopic)
 			}
+
+			filters = append(filters, m.transport.FilterByChatID(c.UniversalChatID()))
 
 			// First we need to know the timestamp of the latest waku message
 			// we've received for this community, so we can request messages we've


### PR DESCRIPTION
This PR is first step i moving towards using a single content-topic for all community chats and most of the control messages. 
Once this is released , in a subsequent release we can disable installing filters using chatIDs for communities altogether.

Detailed proposal https://forum.vac.dev/t/status-communities-review-and-proposed-usage-of-waku-content-topics/335

Refer to https://github.com/waku-org/pm/issues/268 -> `Implementation Details` for the plan of this feature.

All channels shall use content-topic used for MemberUpdates which is being called UniversalChatID.

Important changes:
- [x] pass `UniversalChatID` to filter while sending all community chat messages. 
- [x] note that only sending of messages shall use this new content-topic , receiving of messages shall work if msg is sent on older content-topic (based on chatID) or communityID based content-topic . this is to ensure non-breaking migration for existing users. In a subsequent release receiving and store queries would also be modified to use single content-topic based on universalChatID
- [x] validated message send/receive with this code and 2.31 code in communities. 
- [x] check if any other control messages that can be migrated to same content-topic.
- [x] validate other actions of community 
- [x] validate send/receive with lightClients using new code and 2.30 release
- [x] dogfooded these changes locally by using this version of status-desktop in relay and light modes and also verifying messages sent are received between 2.30 desktop, mobile and this version of desktop(relay and light modes).
- [x] dogfooding by others in desktop and mobile interworking with 2.30 releases
- [x] testing all community features (expected to be done by QA)