### PR TITLE
fix_: ignore log partial API request

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -316,7 +316,7 @@ func MigrateKeyStoreDirV2(requestJSON string) string {
 }
 
 func migrateKeyStoreDirV2(requestJSON string) string {
-	var request requests.MigrateKeyStoreDir
+	var request requests.MigrateKeystoreDir
 	err := json.Unmarshal([]byte(requestJSON), &request)
 	if err != nil {
 		return makeJSONResponse(err)

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -282,7 +282,7 @@ func verifyAccountPassword(keyStoreDir, address, password string) string {
 }
 
 func VerifyDatabasePasswordV2(requestJSON string) string {
-	return logAndCallString(verifyDatabasePasswordV2, requestJSON)
+	return callWithResponse(verifyDatabasePasswordV2, requestJSON)
 }
 
 func verifyDatabasePasswordV2(requestJSON string) string {
@@ -559,7 +559,7 @@ func deleteMultiaccount(keyUID, keyStoreDir string) string {
 }
 
 func DeleteImportedKeyV2(requestJSON string) string {
-	return logAndCallString(deleteImportedKeyV2, requestJSON)
+	return callWithResponse(deleteImportedKeyV2, requestJSON)
 }
 
 func deleteImportedKeyV2(requestJSON string) string {

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -281,8 +281,28 @@ func verifyAccountPassword(keyStoreDir, address, password string) string {
 	return makeJSONResponse(err)
 }
 
+func VerifyDatabasePasswordV2(requestJSON string) string {
+	return logAndCallString(verifyDatabasePasswordV2, requestJSON)
+}
+
+func verifyDatabasePasswordV2(requestJSON string) string {
+	var request requests.VerifyDatabasePassword
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = request.Validate()
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	err = statusBackend.VerifyDatabasePassword(request.KeyUID, request.Password)
+	return makeJSONResponse(err)
+}
+
+// Deprecated: use VerifyDatabasePasswordV2 instead
 func VerifyDatabasePassword(keyUID, password string) string {
-	return callWithResponse(verifyDatabasePassword, keyUID, password)
+	return verifyDatabasePassword(keyUID, password)
 }
 
 // verifyDatabasePassword verifies database password.
@@ -291,8 +311,29 @@ func verifyDatabasePassword(keyUID, password string) string {
 	return makeJSONResponse(err)
 }
 
+func MigrateKeyStoreDirV2(requestJSON string) string {
+	return callWithResponse(migrateKeyStoreDirV2, requestJSON)
+}
+
+func migrateKeyStoreDirV2(requestJSON string) string {
+	var request requests.MigrateKeyStoreDir
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = request.Validate()
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = statusBackend.MigrateKeyStoreDir(request.Account, request.Password, request.OldDir, request.NewDir)
+	return makeJSONResponse(err)
+}
+
+// Deprecated: Use MigrateKeyStoreDirV2 instead
 func MigrateKeyStoreDir(accountData, password, oldDir, newDir string) string {
-	return callWithResponse(migrateKeyStoreDir, accountData, password, oldDir, newDir)
+	return migrateKeyStoreDir(accountData, password, oldDir, newDir)
 }
 
 // migrateKeyStoreDir migrates key files to a new directory
@@ -517,8 +558,29 @@ func deleteMultiaccount(keyUID, keyStoreDir string) string {
 	return makeJSONResponse(err)
 }
 
+func DeleteImportedKeyV2(requestJSON string) string {
+	return logAndCallString(deleteImportedKeyV2, requestJSON)
+}
+
+func deleteImportedKeyV2(requestJSON string) string {
+	var request requests.DeleteImportedKey
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = request.Validate()
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = statusBackend.DeleteImportedKey(request.Address, request.Password, request.KeyStoreDir)
+	return makeJSONResponse(err)
+}
+
+// Deprecated: Use DeleteImportedKeyV2 instead
 func DeleteImportedKey(address, password, keyStoreDir string) string {
-	return callWithResponse(deleteImportedKey, address, password, keyStoreDir)
+	return deleteImportedKey(address, password, keyStoreDir)
 }
 
 // deleteImportedKey
@@ -629,9 +691,9 @@ func signMessage(rpcParams string) string {
 // SignTypedData unmarshall data into TypedData, validate it and signs with selected account,
 // if password matches selected account.
 //
-//export SignTypedData
+// Deprecated: Use SignTypedDataV2 instead.
 func SignTypedData(data, address, password string) string {
-	return callWithResponse(signTypedData, data, address, password)
+	return signTypedData(data, address, password)
 }
 
 func signTypedData(data, address, password string) string {
@@ -644,6 +706,26 @@ func signTypedData(data, address, password string) string {
 		return prepareJSONResponseWithCode(nil, err, codeFailedParseParams)
 	}
 	result, err := statusBackend.SignTypedData(typed, address, password)
+	return prepareJSONResponse(result.String(), err)
+}
+
+func SignTypedDataV2(requestJSON string) string {
+	return callWithResponse(signTypedDataV2, requestJSON)
+}
+
+func signTypedDataV2(requestJSON string) string {
+	var request requests.SignTypedData
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return prepareJSONResponseWithCode(nil, err, codeFailedParseParams)
+	}
+
+	err = request.Validate()
+	if err != nil {
+		return prepareJSONResponseWithCode(nil, err, codeFailedParseParams)
+	}
+
+	result, err := statusBackend.SignTypedData(request.TypedData, request.Address, request.Password)
 	return prepareJSONResponse(result.String(), err)
 }
 
@@ -672,7 +754,7 @@ func hashTypedData(data string) string {
 //
 //export SignTypedDataV4
 func SignTypedDataV4(data, address, password string) string {
-	return callWithResponse(signTypedDataV4, data, address, password)
+	return signTypedDataV4(data, address, password)
 }
 
 func signTypedDataV4(data, address, password string) string {
@@ -718,8 +800,9 @@ func recoverWithRPCParams(rpcParams string) string {
 	return prepareJSONResponse(addr.String(), err)
 }
 
+// SendTransactionWithChainID converts RPC args and calls backend.SendTransactionWithChainID.
 func SendTransactionWithChainID(chainID int, txArgsJSON, password string) string {
-	return callWithResponse(sendTransactionWithChainID, chainID, txArgsJSON, password)
+	return sendTransactionWithChainID(chainID, txArgsJSON, password)
 }
 
 // sendTransactionWithChainID converts RPC args and calls backend.SendTransactionWithChainID.
@@ -738,7 +821,7 @@ func sendTransactionWithChainID(chainID int, txArgsJSON, password string) string
 }
 
 func SendTransaction(txArgsJSON, password string) string {
-	return callWithResponse(sendTransaction, txArgsJSON, password)
+	return sendTransaction(txArgsJSON, password)
 }
 
 // sendTransaction converts RPC args and calls backend.SendTransaction.
@@ -1035,7 +1118,7 @@ func colorID(pk string) string {
 }
 
 func ValidateMnemonic(mnemonic string) string {
-	return callWithResponse(validateMnemonic, mnemonic)
+	return validateMnemonic(mnemonic)
 }
 
 func validateMnemonic(mnemonic string) string {
@@ -1134,7 +1217,7 @@ func multiformatDeserializePublicKey(key, outBase string) string {
 }
 
 func ExportUnencryptedDatabase(accountData, password, databasePath string) string {
-	return callWithResponse(exportUnencryptedDatabase, accountData, password, databasePath)
+	return exportUnencryptedDatabase(accountData, password, databasePath)
 }
 
 // exportUnencryptedDatabase exports the database unencrypted to the given path
@@ -1149,7 +1232,7 @@ func exportUnencryptedDatabase(accountData, password, databasePath string) strin
 }
 
 func ImportUnencryptedDatabase(accountData, password, databasePath string) string {
-	return callWithResponse(importUnencryptedDatabase, accountData, password, databasePath)
+	return importUnencryptedDatabase(accountData, password, databasePath)
 }
 
 // importUnencryptedDatabase imports the database unencrypted to the given directory
@@ -1163,18 +1246,18 @@ func importUnencryptedDatabase(accountData, password, databasePath string) strin
 	return makeJSONResponse(err)
 }
 
-func ChangeDatabasePassword(KeyUID, password, newPassword string) string {
-	return callWithResponse(changeDatabasePassword, KeyUID, password, newPassword)
+func ChangeDatabasePassword(keyUID, password, newPassword string) string {
+	return changeDatabasePassword(keyUID, password, newPassword)
 }
 
 // changeDatabasePassword changes the password of the database
-func changeDatabasePassword(KeyUID, password, newPassword string) string {
-	err := statusBackend.ChangeDatabasePassword(KeyUID, password, newPassword)
+func changeDatabasePassword(keyUID, password, newPassword string) string {
+	err := statusBackend.ChangeDatabasePassword(keyUID, password, newPassword)
 	return makeJSONResponse(err)
 }
 
 func ConvertToKeycardAccount(accountData, settingsJSON, keycardUID, password, newPassword string) string {
-	return callWithResponse(convertToKeycardAccount, accountData, settingsJSON, keycardUID, password, newPassword)
+	return convertToKeycardAccount(accountData, settingsJSON, keycardUID, password, newPassword)
 }
 
 // convertToKeycardAccount converts the account to a keycard account
@@ -1195,7 +1278,7 @@ func convertToKeycardAccount(accountData, settingsJSON, keycardUID, password, ne
 }
 
 func ConvertToRegularAccount(mnemonic, currPassword, newPassword string) string {
-	return callWithResponse(convertToRegularAccount, mnemonic, currPassword, newPassword)
+	return convertToRegularAccount(mnemonic, currPassword, newPassword)
 }
 
 // convertToRegularAccount converts the account to a regular account

--- a/mobile/status_request_log.go
+++ b/mobile/status_request_log.go
@@ -13,7 +13,28 @@ import (
 	"github.com/status-im/status-go/logutils/requestlog"
 )
 
-var sensitiveRegex = regexp.MustCompile(`(?i)(".*?(password|mnemonic|openseaAPIKey|poktToken|alchemyArbitrumMainnetToken|raribleTestnetAPIKey|alchemyOptimismMainnetToken|statusProxyBlockchainUser|alchemyEthereumSepoliaToken|alchemyArbitrumSepoliaToken|infuraToken|raribleMainnetAPIKey|alchemyEthereumMainnetToken).*?")\s*:\s*("[^"]*")`)
+var sensitiveKeys = []string{
+	"password",
+	"mnemonic",
+	"openseaAPIKey",
+	"poktToken",
+	"alchemyArbitrumMainnetToken",
+	"raribleTestnetAPIKey",
+	"alchemyOptimismMainnetToken",
+	"statusProxyBlockchainUser",
+	"alchemyEthereumSepoliaToken",
+	"alchemyArbitrumSepoliaToken",
+	"infuraToken",
+	"raribleMainnetAPIKey",
+	"alchemyEthereumMainnetToken",
+	"alchemyOptimismSepoliaToken",
+	"verifyENSURL",
+	"verifyTransactionURL",
+}
+
+var sensitiveRegexString = fmt.Sprintf(`(?i)(".*?(%s).*?")\s*:\s*("[^"]*")`, strings.Join(sensitiveKeys, "|"))
+
+var sensitiveRegex = regexp.MustCompile(sensitiveRegexString)
 
 func getFunctionName(fn any) string {
 	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()

--- a/protocol/requests/delete_imported_key.go
+++ b/protocol/requests/delete_imported_key.go
@@ -1,0 +1,37 @@
+package requests
+
+import (
+	"errors"
+)
+
+// DeleteImportedKey represents a request to delete an imported key.
+type DeleteImportedKey struct {
+	// Address is the address of the imported key to delete.
+	Address string `json:"address"`
+
+	// Password is the password used to decrypt the key.
+	Password string `json:"password"`
+
+	// KeyStoreDir is the directory where the key is stored.
+	KeyStoreDir string `json:"keyStoreDir"`
+}
+
+// Validate checks the validity of the DeleteImportedKey request.
+var (
+	ErrDeleteImportedKeyEmptyAddress     = errors.New("delete-imported-key: Address cannot be empty")
+	ErrDeleteImportedKeyEmptyPassword    = errors.New("delete-imported-key: Password cannot be empty")
+	ErrDeleteImportedKeyEmptyKeyStoreDir = errors.New("delete-imported-key: KeyStoreDir cannot be empty")
+)
+
+func (r *DeleteImportedKey) Validate() error {
+	if r.Address == "" {
+		return ErrDeleteImportedKeyEmptyAddress
+	}
+	if r.Password == "" {
+		return ErrDeleteImportedKeyEmptyPassword
+	}
+	if r.KeyStoreDir == "" {
+		return ErrDeleteImportedKeyEmptyKeyStoreDir
+	}
+	return nil
+}

--- a/protocol/requests/delete_imported_key.go
+++ b/protocol/requests/delete_imported_key.go
@@ -1,37 +1,22 @@
 package requests
 
 import (
-	"errors"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // DeleteImportedKey represents a request to delete an imported key.
 type DeleteImportedKey struct {
 	// Address is the address of the imported key to delete.
-	Address string `json:"address"`
+	Address string `json:"address" validate:"required"`
 
 	// Password is the password used to decrypt the key.
-	Password string `json:"password"`
+	Password string `json:"password" validate:"required"`
 
 	// KeyStoreDir is the directory where the key is stored.
-	KeyStoreDir string `json:"keyStoreDir"`
+	KeyStoreDir string `json:"keyStoreDir" validate:"required"`
 }
 
 // Validate checks the validity of the DeleteImportedKey request.
-var (
-	ErrDeleteImportedKeyEmptyAddress     = errors.New("delete-imported-key: Address cannot be empty")
-	ErrDeleteImportedKeyEmptyPassword    = errors.New("delete-imported-key: Password cannot be empty")
-	ErrDeleteImportedKeyEmptyKeyStoreDir = errors.New("delete-imported-key: KeyStoreDir cannot be empty")
-)
-
 func (r *DeleteImportedKey) Validate() error {
-	if r.Address == "" {
-		return ErrDeleteImportedKeyEmptyAddress
-	}
-	if r.Password == "" {
-		return ErrDeleteImportedKeyEmptyPassword
-	}
-	if r.KeyStoreDir == "" {
-		return ErrDeleteImportedKeyEmptyKeyStoreDir
-	}
-	return nil
+	return validator.New().Struct(r)
 }

--- a/protocol/requests/delete_imported_key_test.go
+++ b/protocol/requests/delete_imported_key_test.go
@@ -10,7 +10,7 @@ func TestDeleteImportedKey_Validate(t *testing.T) {
 	testCases := []struct {
 		name        string
 		req         DeleteImportedKey
-		expectedErr error
+		expectedErr string
 	}{
 		{
 			name: "valid request",
@@ -19,7 +19,6 @@ func TestDeleteImportedKey_Validate(t *testing.T) {
 				Password:    "password",
 				KeyStoreDir: "/keystore/dir",
 			},
-			expectedErr: nil,
 		},
 		{
 			name: "empty address",
@@ -27,7 +26,7 @@ func TestDeleteImportedKey_Validate(t *testing.T) {
 				Password:    "password",
 				KeyStoreDir: "/keystore/dir",
 			},
-			expectedErr: ErrDeleteImportedKeyEmptyAddress,
+			expectedErr: "Address",
 		},
 		{
 			name: "empty password",
@@ -35,7 +34,7 @@ func TestDeleteImportedKey_Validate(t *testing.T) {
 				Address:     "0x1234567890123456789012345678901234567890",
 				KeyStoreDir: "/keystore/dir",
 			},
-			expectedErr: ErrDeleteImportedKeyEmptyPassword,
+			expectedErr: "Password",
 		},
 		{
 			name: "empty keystore dir",
@@ -43,15 +42,16 @@ func TestDeleteImportedKey_Validate(t *testing.T) {
 				Address:  "0x1234567890123456789012345678901234567890",
 				Password: "password",
 			},
-			expectedErr: ErrDeleteImportedKeyEmptyKeyStoreDir,
+			expectedErr: "KeyStoreDir",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.req.Validate()
-			if tc.expectedErr != nil {
-				require.Equal(t, tc.expectedErr, err)
+			if tc.expectedErr != "" {
+				t.Log("err", err.Error())
+				require.Contains(t, err.Error(), tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/protocol/requests/delete_imported_key_test.go
+++ b/protocol/requests/delete_imported_key_test.go
@@ -1,0 +1,60 @@
+package requests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteImportedKey_Validate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		req         DeleteImportedKey
+		expectedErr error
+	}{
+		{
+			name: "valid request",
+			req: DeleteImportedKey{
+				Address:     "0x1234567890123456789012345678901234567890",
+				Password:    "password",
+				KeyStoreDir: "/keystore/dir",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "empty address",
+			req: DeleteImportedKey{
+				Password:    "password",
+				KeyStoreDir: "/keystore/dir",
+			},
+			expectedErr: ErrDeleteImportedKeyEmptyAddress,
+		},
+		{
+			name: "empty password",
+			req: DeleteImportedKey{
+				Address:     "0x1234567890123456789012345678901234567890",
+				KeyStoreDir: "/keystore/dir",
+			},
+			expectedErr: ErrDeleteImportedKeyEmptyPassword,
+		},
+		{
+			name: "empty keystore dir",
+			req: DeleteImportedKey{
+				Address:  "0x1234567890123456789012345678901234567890",
+				Password: "password",
+			},
+			expectedErr: ErrDeleteImportedKeyEmptyKeyStoreDir,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.req.Validate()
+			if tc.expectedErr != nil {
+				require.Equal(t, tc.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/protocol/requests/migrate_keystore_dir.go
+++ b/protocol/requests/migrate_keystore_dir.go
@@ -1,0 +1,46 @@
+package requests
+
+import (
+	"errors"
+
+	"github.com/status-im/status-go/multiaccounts"
+)
+
+// MigrateKeyStoreDir represents a request to migrate key files to a new directory.
+type MigrateKeyStoreDir struct {
+	// Account represents the account associated with the key files.
+	Account multiaccounts.Account `json:"account"`
+
+	// Password is the password used to decrypt the key files.
+	Password string `json:"password"`
+
+	// OldDir is the old directory path where the key files are currently located.
+	OldDir string `json:"oldDir"`
+
+	// NewDir is the new directory path where the key files will be migrated to.
+	NewDir string `json:"newDir"`
+}
+
+// Validate checks the validity of the MigrateKeyStoreDir request.
+var (
+	ErrMigrateKeyStoreDirEmptyAccount  = errors.New("migrate-keystore-dir: Account cannot be empty")
+	ErrMigrateKeyStoreDirEmptyPassword = errors.New("migrate-keystore-dir: Password cannot be empty")
+	ErrMigrateKeyStoreDirEmptyOldDir   = errors.New("migrate-keystore-dir: OldDir cannot be empty")
+	ErrMigrateKeyStoreDirEmptyNewDir   = errors.New("migrate-keystore-dir: NewDir cannot be empty")
+)
+
+func (r *MigrateKeyStoreDir) Validate() error {
+	if r.Account.KeyUID == "" {
+		return ErrMigrateKeyStoreDirEmptyAccount
+	}
+	if r.Password == "" {
+		return ErrMigrateKeyStoreDirEmptyPassword
+	}
+	if r.OldDir == "" {
+		return ErrMigrateKeyStoreDirEmptyOldDir
+	}
+	if r.NewDir == "" {
+		return ErrMigrateKeyStoreDirEmptyNewDir
+	}
+	return nil
+}

--- a/protocol/requests/migrate_keystore_dir.go
+++ b/protocol/requests/migrate_keystore_dir.go
@@ -1,46 +1,27 @@
 package requests
 
 import (
-	"errors"
+	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/status-im/status-go/multiaccounts"
 )
 
-// MigrateKeyStoreDir represents a request to migrate key files to a new directory.
-type MigrateKeyStoreDir struct {
-	// Account represents the account associated with the key files.
+// MigrateKeystoreDir represents a request to migrate keystore directory.
+type MigrateKeystoreDir struct {
+	// Account is the account associated with the keystore.
 	Account multiaccounts.Account `json:"account"`
 
-	// Password is the password used to decrypt the key files.
-	Password string `json:"password"`
+	// Password is the password for the keystore.
+	Password string `json:"password" validate:"required"`
 
-	// OldDir is the old directory path where the key files are currently located.
-	OldDir string `json:"oldDir"`
+	// OldDir is the old keystore directory.
+	OldDir string `json:"oldDir" validate:"required"`
 
-	// NewDir is the new directory path where the key files will be migrated to.
-	NewDir string `json:"newDir"`
+	// NewDir is the new keystore directory.
+	NewDir string `json:"newDir" validate:"required"`
 }
 
-// Validate checks the validity of the MigrateKeyStoreDir request.
-var (
-	ErrMigrateKeyStoreDirEmptyAccount  = errors.New("migrate-keystore-dir: Account cannot be empty")
-	ErrMigrateKeyStoreDirEmptyPassword = errors.New("migrate-keystore-dir: Password cannot be empty")
-	ErrMigrateKeyStoreDirEmptyOldDir   = errors.New("migrate-keystore-dir: OldDir cannot be empty")
-	ErrMigrateKeyStoreDirEmptyNewDir   = errors.New("migrate-keystore-dir: NewDir cannot be empty")
-)
-
-func (r *MigrateKeyStoreDir) Validate() error {
-	if r.Account.KeyUID == "" {
-		return ErrMigrateKeyStoreDirEmptyAccount
-	}
-	if r.Password == "" {
-		return ErrMigrateKeyStoreDirEmptyPassword
-	}
-	if r.OldDir == "" {
-		return ErrMigrateKeyStoreDirEmptyOldDir
-	}
-	if r.NewDir == "" {
-		return ErrMigrateKeyStoreDirEmptyNewDir
-	}
-	return nil
+// Validate checks the validity of the MigrateKeystoreDir request.
+func (r *MigrateKeystoreDir) Validate() error {
+	return validator.New().Struct(r)
 }

--- a/protocol/requests/migrate_keystore_dir_test.go
+++ b/protocol/requests/migrate_keystore_dir_test.go
@@ -1,0 +1,75 @@
+package requests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/multiaccounts"
+)
+
+func TestMigrateKeyStoreDir_Validate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		req         MigrateKeyStoreDir
+		expectedErr error
+	}{
+		{
+			name: "valid request",
+			req: MigrateKeyStoreDir{
+				Account:  multiaccounts.Account{KeyUID: "0x1234"},
+				Password: "password",
+				OldDir:   "/old/dir",
+				NewDir:   "/new/dir",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "empty account",
+			req: MigrateKeyStoreDir{
+				Password: "password",
+				OldDir:   "/old/dir",
+				NewDir:   "/new/dir",
+			},
+			expectedErr: ErrMigrateKeyStoreDirEmptyAccount,
+		},
+		{
+			name: "empty password",
+			req: MigrateKeyStoreDir{
+				Account: multiaccounts.Account{KeyUID: "0x1234"},
+				OldDir:  "/old/dir",
+				NewDir:  "/new/dir",
+			},
+			expectedErr: ErrMigrateKeyStoreDirEmptyPassword,
+		},
+		{
+			name: "empty old dir",
+			req: MigrateKeyStoreDir{
+				Account:  multiaccounts.Account{KeyUID: "0x1234"},
+				Password: "password",
+				NewDir:   "/new/dir",
+			},
+			expectedErr: ErrMigrateKeyStoreDirEmptyOldDir,
+		},
+		{
+			name: "empty new dir",
+			req: MigrateKeyStoreDir{
+				Account:  multiaccounts.Account{KeyUID: "0x1234"},
+				Password: "password",
+				OldDir:   "/old/dir",
+			},
+			expectedErr: ErrMigrateKeyStoreDirEmptyNewDir,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.req.Validate()
+			if tc.expectedErr != nil {
+				require.Equal(t, tc.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/protocol/requests/migrate_keystore_dir_test.go
+++ b/protocol/requests/migrate_keystore_dir_test.go
@@ -8,65 +8,64 @@ import (
 	"github.com/status-im/status-go/multiaccounts"
 )
 
-func TestMigrateKeyStoreDir_Validate(t *testing.T) {
+func TestMigrateKeystoreDir_Validate(t *testing.T) {
 	testCases := []struct {
 		name        string
-		req         MigrateKeyStoreDir
-		expectedErr error
+		req         MigrateKeystoreDir
+		expectedErr string
 	}{
 		{
 			name: "valid request",
-			req: MigrateKeyStoreDir{
-				Account:  multiaccounts.Account{KeyUID: "0x1234"},
-				Password: "password",
-				OldDir:   "/old/dir",
-				NewDir:   "/new/dir",
+			req: MigrateKeystoreDir{
+				Account:  multiaccounts.Account{Name: "test-account"},
+				Password: "test-password",
+				OldDir:   "/old/keystore/dir",
+				NewDir:   "/new/keystore/dir",
 			},
-			expectedErr: nil,
 		},
 		{
 			name: "empty account",
-			req: MigrateKeyStoreDir{
-				Password: "password",
-				OldDir:   "/old/dir",
-				NewDir:   "/new/dir",
+			req: MigrateKeystoreDir{
+				Password: "test-password",
+				OldDir:   "/old/keystore/dir",
+				NewDir:   "/new/keystore/dir",
 			},
-			expectedErr: ErrMigrateKeyStoreDirEmptyAccount,
 		},
 		{
 			name: "empty password",
-			req: MigrateKeyStoreDir{
-				Account: multiaccounts.Account{KeyUID: "0x1234"},
-				OldDir:  "/old/dir",
-				NewDir:  "/new/dir",
+			req: MigrateKeystoreDir{
+				Account: multiaccounts.Account{Name: "test-account"},
+				OldDir:  "/old/keystore/dir",
+				NewDir:  "/new/keystore/dir",
 			},
-			expectedErr: ErrMigrateKeyStoreDirEmptyPassword,
+			expectedErr: "Password",
 		},
 		{
 			name: "empty old dir",
-			req: MigrateKeyStoreDir{
-				Account:  multiaccounts.Account{KeyUID: "0x1234"},
-				Password: "password",
-				NewDir:   "/new/dir",
+			req: MigrateKeystoreDir{
+				Account:  multiaccounts.Account{Name: "test-account"},
+				Password: "test-password",
+				NewDir:   "/new/keystore/dir",
 			},
-			expectedErr: ErrMigrateKeyStoreDirEmptyOldDir,
+			expectedErr: "OldDir",
 		},
 		{
 			name: "empty new dir",
-			req: MigrateKeyStoreDir{
-				Account:  multiaccounts.Account{KeyUID: "0x1234"},
-				Password: "password",
-				OldDir:   "/old/dir",
+			req: MigrateKeystoreDir{
+				Account:  multiaccounts.Account{Name: "test-account"},
+				Password: "test-password",
+				OldDir:   "/old/keystore/dir",
 			},
-			expectedErr: ErrMigrateKeyStoreDirEmptyNewDir,
+			expectedErr: "NewDir",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.req.Validate()
-			if tc.expectedErr != nil {
-				require.Equal(t, tc.expectedErr, err)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/protocol/requests/sign_typed_data.go
+++ b/protocol/requests/sign_typed_data.go
@@ -1,0 +1,39 @@
+package requests
+
+import (
+	"errors"
+
+	"github.com/status-im/status-go/services/typeddata"
+)
+
+// SignTypedData represents a request to sign typed data.
+type SignTypedData struct {
+	// TypedData is the typed data to sign.
+	TypedData typeddata.TypedData `json:"typedData"`
+
+	// Address is the address of the account to sign with.
+	Address string `json:"address"`
+
+	// Password is the password of the account to sign with.
+	Password string `json:"password"`
+}
+
+// Validate checks the validity of the SignTypedData request.
+var (
+	ErrSignTypedDataEmptyTypedData = errors.New("sign-typed-data: TypedData cannot be empty")
+	ErrSignTypedDataEmptyAddress   = errors.New("sign-typed-data: Address cannot be empty")
+	ErrSignTypedDataEmptyPassword  = errors.New("sign-typed-data: Password cannot be empty")
+)
+
+func (r *SignTypedData) Validate() error {
+	if err := r.TypedData.Validate(); err != nil {
+		return ErrSignTypedDataEmptyTypedData
+	}
+	if r.Address == "" {
+		return ErrSignTypedDataEmptyAddress
+	}
+	if r.Password == "" {
+		return ErrSignTypedDataEmptyPassword
+	}
+	return nil
+}

--- a/protocol/requests/sign_typed_data.go
+++ b/protocol/requests/sign_typed_data.go
@@ -1,7 +1,7 @@
 package requests
 
 import (
-	"errors"
+	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/status-im/status-go/services/typeddata"
 )
@@ -9,31 +9,26 @@ import (
 // SignTypedData represents a request to sign typed data.
 type SignTypedData struct {
 	// TypedData is the typed data to sign.
-	TypedData typeddata.TypedData `json:"typedData"`
+	TypedData typeddata.TypedData `json:"typedData" validate:"required"`
 
 	// Address is the address of the account to sign with.
-	Address string `json:"address"`
+	Address string `json:"address" validate:"required"`
 
 	// Password is the password of the account to sign with.
-	Password string `json:"password"`
+	Password string `json:"password" validate:"required"`
 }
 
 // Validate checks the validity of the SignTypedData request.
-var (
-	ErrSignTypedDataEmptyTypedData = errors.New("sign-typed-data: TypedData cannot be empty")
-	ErrSignTypedDataEmptyAddress   = errors.New("sign-typed-data: Address cannot be empty")
-	ErrSignTypedDataEmptyPassword  = errors.New("sign-typed-data: Password cannot be empty")
-)
-
 func (r *SignTypedData) Validate() error {
+	// Use the validator package to validate the struct fields
+	if err := validator.New().Struct(r); err != nil {
+		return err
+	}
+
+	// Additional validation logic from the old signTypedData function
 	if err := r.TypedData.Validate(); err != nil {
-		return ErrSignTypedDataEmptyTypedData
+		return err
 	}
-	if r.Address == "" {
-		return ErrSignTypedDataEmptyAddress
-	}
-	if r.Password == "" {
-		return ErrSignTypedDataEmptyPassword
-	}
+
 	return nil
 }

--- a/protocol/requests/sign_typed_data_test.go
+++ b/protocol/requests/sign_typed_data_test.go
@@ -1,0 +1,102 @@
+package requests
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/services/typeddata"
+)
+
+func TestSignTypedData_Validate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		req         SignTypedData
+		expectedErr error
+	}{
+		{
+			name: "valid request",
+			req: SignTypedData{
+				TypedData: typeddata.TypedData{
+					Types: typeddata.Types{
+						"EIP712Domain": []typeddata.Field{
+							{Name: "name", Type: "string"},
+						},
+					},
+					Domain: map[string]json.RawMessage{
+						"name": json.RawMessage(`"test"`),
+					},
+					PrimaryType: "EIP712Domain",
+					Message: map[string]json.RawMessage{
+						"name": json.RawMessage(`"test"`),
+					},
+				},
+				Address:  "0x1234567890123456789012345678901234567890",
+				Password: "password",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "empty typed data",
+			req: SignTypedData{
+				Address:  "0x1234567890123456789012345678901234567890",
+				Password: "password",
+			},
+			expectedErr: ErrSignTypedDataEmptyTypedData,
+		},
+		{
+			name: "empty address",
+			req: SignTypedData{
+				TypedData: typeddata.TypedData{
+					Types: typeddata.Types{
+						"EIP712Domain": []typeddata.Field{
+							{Name: "name", Type: "string"},
+						},
+					},
+					Domain: map[string]json.RawMessage{
+						"name": json.RawMessage(`"test"`),
+					},
+					PrimaryType: "EIP712Domain",
+					Message: map[string]json.RawMessage{
+						"name": json.RawMessage(`"test"`),
+					},
+				},
+				Password: "password",
+			},
+			expectedErr: ErrSignTypedDataEmptyAddress,
+		},
+		{
+			name: "empty password",
+			req: SignTypedData{
+				TypedData: typeddata.TypedData{
+					Types: typeddata.Types{
+						"EIP712Domain": []typeddata.Field{
+							{Name: "name", Type: "string"},
+						},
+					},
+					Domain: map[string]json.RawMessage{
+						"name": json.RawMessage(`"test"`),
+					},
+					PrimaryType: "EIP712Domain",
+					Message: map[string]json.RawMessage{
+						"name": json.RawMessage(`"test"`),
+					},
+				},
+				Address: "0x1234567890123456789012345678901234567890",
+			},
+			expectedErr: ErrSignTypedDataEmptyPassword,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.req.Validate()
+			if tc.expectedErr != nil {
+				require.Equal(t, tc.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/protocol/requests/sign_typed_data_test.go
+++ b/protocol/requests/sign_typed_data_test.go
@@ -13,7 +13,7 @@ func TestSignTypedData_Validate(t *testing.T) {
 	testCases := []struct {
 		name        string
 		req         SignTypedData
-		expectedErr error
+		expectedErr string
 	}{
 		{
 			name: "valid request",
@@ -35,18 +35,24 @@ func TestSignTypedData_Validate(t *testing.T) {
 				Address:  "0x1234567890123456789012345678901234567890",
 				Password: "password",
 			},
-			expectedErr: nil,
+			expectedErr: "",
 		},
 		{
-			name: "empty typed data",
+			name: "missing typed data",
 			req: SignTypedData{
+				TypedData: typeddata.TypedData{
+					Types:       typeddata.Types{},
+					Domain:      map[string]json.RawMessage{},
+					PrimaryType: "",
+					Message:     map[string]json.RawMessage{},
+				},
 				Address:  "0x1234567890123456789012345678901234567890",
 				Password: "password",
 			},
-			expectedErr: ErrSignTypedDataEmptyTypedData,
+			expectedErr: "`EIP712Domain` must be in `types`",
 		},
 		{
-			name: "empty address",
+			name: "missing address",
 			req: SignTypedData{
 				TypedData: typeddata.TypedData{
 					Types: typeddata.Types{
@@ -64,10 +70,10 @@ func TestSignTypedData_Validate(t *testing.T) {
 				},
 				Password: "password",
 			},
-			expectedErr: ErrSignTypedDataEmptyAddress,
+			expectedErr: "Key: 'SignTypedData.Address' Error:Field validation for 'Address' failed on the 'required' tag",
 		},
 		{
-			name: "empty password",
+			name: "missing password",
 			req: SignTypedData{
 				TypedData: typeddata.TypedData{
 					Types: typeddata.Types{
@@ -85,15 +91,37 @@ func TestSignTypedData_Validate(t *testing.T) {
 				},
 				Address: "0x1234567890123456789012345678901234567890",
 			},
-			expectedErr: ErrSignTypedDataEmptyPassword,
+			expectedErr: "Key: 'SignTypedData.Password' Error:Field validation for 'Password' failed on the 'required' tag",
+		},
+		{
+			name: "invalid typed data",
+			req: SignTypedData{
+				TypedData: typeddata.TypedData{
+					Types: typeddata.Types{
+						"EIP712Domain": []typeddata.Field{
+							{Name: "name", Type: "string"},
+						},
+					},
+					Domain: map[string]json.RawMessage{
+						"name": json.RawMessage(`"test"`),
+					},
+					PrimaryType: "InvalidType",
+					Message: map[string]json.RawMessage{
+						"name": json.RawMessage(`"test"`),
+					},
+				},
+				Address:  "0x1234567890123456789012345678901234567890",
+				Password: "password",
+			},
+			expectedErr: "primary type `InvalidType` not defined in types",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.req.Validate()
-			if tc.expectedErr != nil {
-				require.Equal(t, tc.expectedErr, err)
+			if tc.expectedErr != "" {
+				require.EqualError(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/protocol/requests/verify_database_password.go
+++ b/protocol/requests/verify_database_password.go
@@ -1,30 +1,19 @@
 package requests
 
 import (
-	"errors"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // VerifyDatabasePassword represents a request to verify the database password.
 type VerifyDatabasePassword struct {
 	// KeyUID identifies the specific key in the database.
-	KeyUID string `json:"keyUID"`
+	KeyUID string `json:"keyUID" validate:"required"`
 
 	// Password is the password to verify against the database entry.
-	Password string `json:"password"`
+	Password string `json:"password" validate:"required"`
 }
 
-// Validate checks the validity of the VerifyDatabasePasswordV2 request.
-var (
-	ErrVerifyDatabasePasswordEmptyKeyUID   = errors.New("verify-database-password: KeyUID cannot be empty")
-	ErrVerifyDatabasePasswordEmptyPassword = errors.New("verify-database-password: Password cannot be empty")
-)
-
+// Validate checks the validity of the VerifyDatabasePassword request.
 func (v *VerifyDatabasePassword) Validate() error {
-	if v.KeyUID == "" {
-		return ErrVerifyDatabasePasswordEmptyKeyUID
-	}
-	if v.Password == "" {
-		return ErrVerifyDatabasePasswordEmptyPassword
-	}
-	return nil
+	return validator.New().Struct(v)
 }

--- a/protocol/requests/verify_database_password.go
+++ b/protocol/requests/verify_database_password.go
@@ -1,0 +1,30 @@
+package requests
+
+import (
+	"errors"
+)
+
+// VerifyDatabasePassword represents a request to verify the database password.
+type VerifyDatabasePassword struct {
+	// KeyUID identifies the specific key in the database.
+	KeyUID string `json:"keyUID"`
+
+	// Password is the password to verify against the database entry.
+	Password string `json:"password"`
+}
+
+// Validate checks the validity of the VerifyDatabasePasswordV2 request.
+var (
+	ErrVerifyDatabasePasswordEmptyKeyUID   = errors.New("verify-database-password: KeyUID cannot be empty")
+	ErrVerifyDatabasePasswordEmptyPassword = errors.New("verify-database-password: Password cannot be empty")
+)
+
+func (v *VerifyDatabasePassword) Validate() error {
+	if v.KeyUID == "" {
+		return ErrVerifyDatabasePasswordEmptyKeyUID
+	}
+	if v.Password == "" {
+		return ErrVerifyDatabasePasswordEmptyPassword
+	}
+	return nil
+}

--- a/protocol/requests/verify_database_password_test.go
+++ b/protocol/requests/verify_database_password_test.go
@@ -1,0 +1,36 @@
+package requests
+
+import "testing"
+
+func TestVerifyDatabasePasswordV2Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		request VerifyDatabasePassword
+		wantErr error
+	}{
+		{
+			name:    "Empty KeyUID",
+			request: VerifyDatabasePassword{KeyUID: "", Password: "password"},
+			wantErr: ErrVerifyDatabasePasswordEmptyKeyUID,
+		},
+		{
+			name:    "Empty Password",
+			request: VerifyDatabasePassword{KeyUID: "keyuid", Password: ""},
+			wantErr: ErrVerifyDatabasePasswordEmptyPassword,
+		},
+		{
+			name:    "Valid Request",
+			request: VerifyDatabasePassword{KeyUID: "keyuid", Password: "password"},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if err != tt.wantErr {
+				t.Errorf("VerifyDatabasePasswordV2.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/protocol/requests/verify_database_password_test.go
+++ b/protocol/requests/verify_database_password_test.go
@@ -1,35 +1,41 @@
 package requests
 
-import "testing"
+import (
+	"testing"
 
-func TestVerifyDatabasePasswordV2Validate(t *testing.T) {
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyDatabasePassword_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
 		request VerifyDatabasePassword
-		wantErr error
+		wantErr string
 	}{
 		{
 			name:    "Empty KeyUID",
 			request: VerifyDatabasePassword{KeyUID: "", Password: "password"},
-			wantErr: ErrVerifyDatabasePasswordEmptyKeyUID,
+			wantErr: "KeyUID",
 		},
 		{
 			name:    "Empty Password",
 			request: VerifyDatabasePassword{KeyUID: "keyuid", Password: ""},
-			wantErr: ErrVerifyDatabasePasswordEmptyPassword,
+			wantErr: "Password",
 		},
 		{
 			name:    "Valid Request",
 			request: VerifyDatabasePassword{KeyUID: "keyuid", Password: "password"},
-			wantErr: nil,
+			wantErr: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.request.Validate()
-			if err != tt.wantErr {
-				t.Errorf("VerifyDatabasePasswordV2.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr != "" {
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
Major changes:
- Added extra sensitive fields in regex.

- Added some new V2 APIs and removed logging for the old ones:
```
VerifyDatabasePassword -> VerifyDatabasePasswordV2
MigrateKeyStoreDir -> MigrateKeyStoreDirV2
DeleteImportedKey -> DeleteImportedKeyV2
SignTypedData -> SignTypedDataV2
```

- Removed the following sensitive APIs for logging as a quick fix, we can create a separate pull request to create V2 APIs for them later if needed:
```
SignTypedDataV4 
SendTransactionWithChainID 
SendTransaction 
ValidateMnemonic
ExportUnencryptedDatabase
ImportUnencryptedDatabase
ChangeDatabasePassword
ConvertToKeycardAccount
ConvertToRegularAccount
```

Relate [comment](https://github.com/status-im/status-go/pull/5812#issuecomment-2364600859)

Please review the code by commit , tx