### PR TITLE
fix(manager)_: make sure to re-add revealed accounts in the response

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -4897,8 +4897,8 @@ func (m *Manager) ShareRequestsToJoinWithPrivilegedMembers(community *Community,
 	return nil
 }
 
-func (m *Manager) shareAcceptedRequestToJoinWithPrivilegedMembers(community *Community, requestsToJoin *RequestToJoin) error {
-	pk, err := common.HexToPubkey(requestsToJoin.PublicKey)
+func (m *Manager) shareAcceptedRequestToJoinWithPrivilegedMembers(community *Community, requestToJoin *RequestToJoin) error {
+	pk, err := common.HexToPubkey(requestToJoin.PublicKey)
 	if err != nil {
 		return err
 	}
@@ -4906,9 +4906,13 @@ func (m *Manager) shareAcceptedRequestToJoinWithPrivilegedMembers(community *Com
 	acceptedRequestsToJoinWithoutRevealedAccounts := make(map[string]*protobuf.CommunityRequestToJoin)
 	acceptedRequestsToJoinWithRevealedAccounts := make(map[string]*protobuf.CommunityRequestToJoin)
 
-	acceptedRequestsToJoinWithRevealedAccounts[requestsToJoin.PublicKey] = requestsToJoin.ToCommunityRequestToJoinProtobuf()
-	requestsToJoin.RevealedAccounts = make([]*protobuf.RevealedAccount, 0)
-	acceptedRequestsToJoinWithoutRevealedAccounts[requestsToJoin.PublicKey] = requestsToJoin.ToCommunityRequestToJoinProtobuf()
+	acceptedRequestsToJoinWithRevealedAccounts[requestToJoin.PublicKey] = requestToJoin.ToCommunityRequestToJoinProtobuf()
+
+	revealedAccounts := requestToJoin.RevealedAccounts
+	requestToJoin.RevealedAccounts = make([]*protobuf.RevealedAccount, 0)
+	acceptedRequestsToJoinWithoutRevealedAccounts[requestToJoin.PublicKey] = requestToJoin.ToCommunityRequestToJoinProtobuf()
+	// Set back the revealed accounts
+	requestToJoin.RevealedAccounts = revealedAccounts
 
 	msgWithRevealedAccounts := &protobuf.CommunityPrivilegedUserSyncMessage{
 		Type:          protobuf.CommunityPrivilegedUserSyncMessage_CONTROL_NODE_ACCEPT_REQUEST_TO_JOIN,

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -922,6 +922,8 @@ func (s *MessengerCommunitiesSuite) TestRequestAccess() {
 	response, err = s.bob.AcceptRequestToJoinCommunity(acceptRequestToJoin)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
+	s.Require().NotEmpty(response.RequestsToJoinCommunity())
+	s.Require().Len(response.RequestsToJoinCommunity()[0].RevealedAccounts, 1)
 
 	s.Require().Len(response.Communities(), 1)
 


### PR DESCRIPTION
We remove the shared accounts to send normal admins to not leak the addresses, however, that was a destructive action that also removed them from the `requestToJoin` param, which is reused later in the code, so it created an unwanted side effect. The side effect is now erased.