### PR TITLE
fix(sync)_: Improve EnableInstallationAndSync to include installation in MessengerResponse

### DIFF
--- a/protocol/messenger_delete_message_for_me_test.go
+++ b/protocol/messenger_delete_message_for_me_test.go
@@ -101,7 +101,7 @@ func (s *MessengerDeleteMessageForMeSuite) Pair() {
 	s.Require().Equal("alice2", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice2", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.alice1.EnableInstallation(s.alice2.installationID)
+	_, err = s.alice1.EnableInstallation(s.alice2.installationID)
 	s.Require().NoError(err)
 }
 

--- a/protocol/messenger_identity_display_name_test.go
+++ b/protocol/messenger_identity_display_name_test.go
@@ -133,7 +133,7 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestDisplayNameSync() {
 	s.Require().Equal("alice's-other-device", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice's-other-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(alicesOtherDevice.installationID)
+	_, err = s.m.EnableInstallation(alicesOtherDevice.installationID)
 	s.Require().NoError(err)
 
 	// Set new display name on alice's device

--- a/protocol/messenger_installations_test.go
+++ b/protocol/messenger_installations_test.go
@@ -63,7 +63,7 @@ func (s *MessengerInstallationSuite) TestReceiveInstallation() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	contactKey, err := crypto.GenerateKey()
@@ -262,7 +262,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	// sync
@@ -382,7 +382,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallationNewMessages() {
 	s.Require().NoError(err)
 	actualInstallation := response.Installations()[0]
 	s.Require().Equal(bob2.installationID, actualInstallation.ID)
-	err = bob1.EnableInstallation(bob2.installationID)
+	_, err = bob1.EnableInstallation(bob2.installationID)
 	s.Require().NoError(err)
 
 	// send a message from bob1 to alice, it should be received on both bob1 and bob2

--- a/protocol/messenger_pairing_and_syncing.go
+++ b/protocol/messenger_pairing_and_syncing.go
@@ -22,7 +22,7 @@ func (m *Messenger) EnableInstallationAndSync(request *requests.EnableInstallati
 		return nil, err
 	}
 
-	installation, err := m.EnableInstallationV2(request.InstallationID)
+	installation, err := m.EnableInstallation(request.InstallationID)
 	if err != nil {
 		return nil, err
 	}
@@ -503,25 +503,8 @@ func (m *Messenger) SetInstallationName(id string, name string) error {
 	return m.encryptor.SetInstallationName(m.IdentityPublicKey(), id, name)
 }
 
-// Deprecated: use EnableInstallationV2 instead
-func (m *Messenger) EnableInstallation(id string) error {
-	installation, ok := m.allInstallations.Load(id)
-	if !ok {
-		return errors.New("no installation found")
-	}
-
-	err := m.encryptor.EnableInstallation(&m.identity.PublicKey, id)
-	if err != nil {
-		return err
-	}
-	installation.Enabled = true
-	// TODO(samyoul) remove storing of an updated reference pointer?
-	m.allInstallations.Store(id, installation)
-	return nil
-}
-
-// EnableInstallationV2 enables an installation and returns the installation
-func (m *Messenger) EnableInstallationV2(id string) (*multidevice.Installation, error) {
+// EnableInstallation enables an installation and returns the installation
+func (m *Messenger) EnableInstallation(id string) (*multidevice.Installation, error) {
 	installation, ok := m.allInstallations.Load(id)
 	if !ok {
 		return nil, errors.New("no installation found")

--- a/protocol/messenger_pairing_and_syncing_test.go
+++ b/protocol/messenger_pairing_and_syncing_test.go
@@ -102,8 +102,17 @@ func (s *MessengerPairingSuite) TestMessengerPairAfterSeedPhrase() {
 	)
 	s.Require().NoError(err)
 
-	_, err = alice1.EnableInstallationAndSync(&requests.EnableInstallationAndSync{InstallationID: installationID2})
+	// check response from alice1
+	resp, err := alice1.EnableInstallationAndSync(&requests.EnableInstallationAndSync{InstallationID: installationID2})
 	s.Require().NoError(err)
+	installationID2Exist := false
+	for _, i := range resp.Installations() {
+		if i.ID == installationID2 {
+			installationID2Exist = true
+			break
+		}
+	}
+	s.Require().True(installationID2Exist)
 
 	// check if the display name is synced
 	err = tt.RetryWithBackOff(func() error {

--- a/protocol/messenger_sync_bookmark_test.go
+++ b/protocol/messenger_sync_bookmark_test.go
@@ -60,7 +60,7 @@ func (s *MessengerSyncBookmarkSuite) TestSyncBookmark() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	// sync

--- a/protocol/messenger_sync_chat_test.go
+++ b/protocol/messenger_sync_chat_test.go
@@ -102,7 +102,7 @@ func (s *MessengerSyncChatSuite) Pair() {
 	s.Require().Equal("alice2", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice2", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.alice1.EnableInstallation(s.alice2.installationID)
+	_, err = s.alice1.EnableInstallation(s.alice2.installationID)
 	s.Require().NoError(err)
 }
 

--- a/protocol/messenger_sync_clear_history_test.go
+++ b/protocol/messenger_sync_clear_history_test.go
@@ -49,7 +49,7 @@ func (s *MessengerSyncClearHistory) pair() *Messenger {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	return theirMessenger

--- a/protocol/messenger_sync_keycard_change_test.go
+++ b/protocol/messenger_sync_keycard_change_test.go
@@ -70,7 +70,7 @@ func (s *MessengerSyncKeycardChangeSuite) SetupTest() {
 	)
 	s.Require().NoError(err)
 
-	err = s.main.EnableInstallation(s.other.installationID)
+	_, err = s.main.EnableInstallation(s.other.installationID)
 	s.Require().NoError(err)
 
 	// Pre-condition - both sides have to know about keypairs migrated to a keycards

--- a/protocol/messenger_sync_keycards_state_test.go
+++ b/protocol/messenger_sync_keycards_state_test.go
@@ -70,7 +70,7 @@ func (s *MessengerSyncKeycardsStateSuite) SetupTest() {
 	)
 	s.Require().NoError(err)
 
-	err = s.main.EnableInstallation(s.other.installationID)
+	_, err = s.main.EnableInstallation(s.other.installationID)
 	s.Require().NoError(err)
 
 	// Pre-condition - both sides have to know about keypairs migrated to a keycards

--- a/protocol/messenger_sync_profile_picture_test.go
+++ b/protocol/messenger_sync_profile_picture_test.go
@@ -55,7 +55,7 @@ func (s *MessengerSyncProfilePictureSuite) TestSyncProfilePicture() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	// Sync happens via subscription triggered from within StoreIdentityImages

--- a/protocol/messenger_sync_raw_messages.go
+++ b/protocol/messenger_sync_raw_messages.go
@@ -312,7 +312,7 @@ func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) er
 			}
 			// if receiver already logged in before local pairing, we need force enable the installation,
 			// AddInstallations won't make sure enable it, e.g. installation maybe already exist in db but not enabled yet
-			err = m.EnableInstallation(message.InstallationId)
+			_, err = m.EnableInstallation(message.InstallationId)
 			if err != nil {
 				return err
 			}

--- a/protocol/messenger_sync_saved_addresses_test.go
+++ b/protocol/messenger_sync_saved_addresses_test.go
@@ -74,7 +74,7 @@ func (s *MessengerSyncSavedAddressesSuite) SetupTest() {
 	)
 	s.Require().NoError(err)
 
-	err = s.main.EnableInstallation(s.other.installationID)
+	_, err = s.main.EnableInstallation(s.other.installationID)
 	s.Require().NoError(err)
 }
 

--- a/protocol/messenger_sync_verification_test.go
+++ b/protocol/messenger_sync_verification_test.go
@@ -63,7 +63,7 @@ func (s *MessengerSyncVerificationRequests) TestSyncVerificationRequests() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	// sync
@@ -127,7 +127,7 @@ func (s *MessengerSyncVerificationRequests) TestSyncTrust() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	// sync

--- a/protocol/messenger_sync_wallets_test.go
+++ b/protocol/messenger_sync_wallets_test.go
@@ -121,7 +121,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWallets() {
 	s.Require().Equal("alice's-other-device", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice's-other-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(alicesOtherDevice.installationID)
+	_, err = s.m.EnableInstallation(alicesOtherDevice.installationID)
 	s.Require().NoError(err)
 
 	// Store seed phrase keypair with accounts on alice's device
@@ -341,7 +341,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountsReorder() {
 	s.Require().Equal("alice's-other-device", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice's-other-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(alicesOtherDevice.installationID)
+	_, err = s.m.EnableInstallation(alicesOtherDevice.installationID)
 	s.Require().NoError(err)
 
 	// Move down account from position 1 to position 4
@@ -531,7 +531,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 	s.Require().Equal("alice's-other-device", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice's-other-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(alicesOtherDevice.installationID)
+	_, err = s.m.EnableInstallation(alicesOtherDevice.installationID)
 	s.Require().NoError(err)
 
 	// Trigger's a sync between devices

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -306,7 +306,7 @@ func PairDevices(s *suite.Suite, device1, device2 *Messenger) {
 	s.Require().NotNil(response)
 
 	// Ensure installation is enabled
-	err = device2.EnableInstallation(device1.installationID)
+	_, err = device2.EnableInstallation(device1.installationID)
 	s.Require().NoError(err)
 }
 

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -940,7 +940,7 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterStopUisngKeycard() {
 	}
 	s.Require().True(found)
 
-	err = serverMessenger.EnableInstallation(settings.InstallationID)
+	_, err = serverMessenger.EnableInstallation(settings.InstallationID)
 	s.Require().NoError(err)
 
 	// Check if the logged in account is the same on server and client

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -373,7 +373,8 @@ func (api *PublicAPI) RemoveFilters(parent context.Context, chats []*transport.F
 
 // EnableInstallation enables an installation for multi-device sync.
 func (api *PublicAPI) EnableInstallation(installationID string) error {
-	return api.service.messenger.EnableInstallation(installationID)
+	_, err := api.service.messenger.EnableInstallation(installationID)
+	return err
 }
 
 // DisableInstallation disables an installation for multi-device sync.

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -332,7 +332,8 @@ func (s *Service) verifyTransactionLoop(tick time.Duration, cancel <-chan struct
 }
 
 func (s *Service) EnableInstallation(installationID string) error {
-	return s.messenger.EnableInstallation(installationID)
+	_, err := s.messenger.EnableInstallation(installationID)
+	return err
 }
 
 // DisableInstallation disables an installation for multi-device sync.


### PR DESCRIPTION
Major changes:
- Refactor EnableInstallationAndSync for better error handling and response merging
- Add new EnableInstallationV2 method returning the installation
- Update tests to check for installation in response
- Deprecate old EnableInstallation method

fix relate [comment](https://github.com/status-im/status-mobile/issues/21259#issuecomment-2367648024)

status: ready
