### PR TITLE
ci_: validate pr title

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -9,8 +9,8 @@ on:
       - labeled
       - unlabeled
 jobs:
-  main:
-    name: Validate format
+  lint_pr_commits:
+    name: Validate commit messages
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -23,6 +23,7 @@ jobs:
 
       - name: Check commit message
         id: check_commit_message
+        if: always()
         run: |
           set +e
           
@@ -50,7 +51,6 @@ jobs:
             echo "error_message<<$EOF" >> "$GITHUB_ENV"
             echo "${invalid_commit_messages}" >> "$GITHUB_ENV"
             echo "$EOF" >> "$GITHUB_ENV"
-          
           fi
 
       - name: "Publish failed commit messages"

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,21 @@
+name: "Conventional Commits"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+jobs:
+  lint_pr_title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep regex in sync with ./_assets/scripts/parse_commits.sh#L25
+          headerPattern: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?(\_|!): (.*)$'
+          headerPatternCorrespondence: type, scope, breaking, subject


### PR DESCRIPTION
# Description

Added a new status check to force PR title to match our required commit message format.

<img width="699" alt="image" src="https://github.com/user-attachments/assets/95ed08a8-5441-4948-b350-117254358967">

# Why?

Although we require commit messages to follow specific format, `Squash and merge` button enables to workaround this. As a consequence, we have some ill-formed commit messages in the `develop` branch. And later we use the commit messages to calculate the version, so we need this infromation.
