### PR TITLE
fix(telemetry)_: remove received envelopes metric

### DIFF
--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -26,7 +26,6 @@ type TelemetryType string
 
 const (
 	ProtocolStatsMetric        TelemetryType = "ProtocolStats"
-	ReceivedEnvelopeMetric     TelemetryType = "ReceivedEnvelope"
 	SentEnvelopeMetric         TelemetryType = "SentEnvelope"
 	UpdateEnvelopeMetric       TelemetryType = "UpdateEnvelope"
 	ReceivedMessagesMetric     TelemetryType = "ReceivedMessages"
@@ -258,12 +257,6 @@ func (c *Client) processAndPushTelemetry(ctx context.Context, data interface{}) 
 			TelemetryType: ReceivedMessagesMetric,
 			TelemetryData: c.ProcessReceivedMessages(v),
 		}
-	case *v2protocol.Envelope:
-		telemetryRequest = TelemetryRequest{
-			Id:            c.nextId,
-			TelemetryType: ReceivedEnvelopeMetric,
-			TelemetryData: c.ProcessReceivedEnvelope(v),
-		}
 	case wakuv2.SentEnvelope:
 		telemetryRequest = TelemetryRequest{
 			Id:            c.nextId,
@@ -387,18 +380,6 @@ func (c *Client) ProcessReceivedMessages(receivedMessages ReceivedMessages) *jso
 		messageBody["messageSize"] = len(receivedMessages.SSHMessage.Payload)
 		postBody = append(postBody, messageBody)
 	}
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
-}
-
-func (c *Client) ProcessReceivedEnvelope(envelope *v2protocol.Envelope) *json.RawMessage {
-	postBody := c.commonPostBody()
-	postBody["messageHash"] = envelope.Hash().String()
-	postBody["sentAt"] = uint32(envelope.Message().GetTimestamp() / int64(time.Second))
-	postBody["pubsubTopic"] = envelope.PubsubTopic()
-	postBody["topic"] = envelope.Message().ContentTopic
-	postBody["receiverKeyUID"] = c.keyUID
 	body, _ := json.Marshal(postBody)
 	jsonRawMessage := json.RawMessage(body)
 	return &jsonRawMessage

--- a/telemetry/client_test.go
+++ b/telemetry/client_test.go
@@ -116,6 +116,18 @@ func withMockServer(t *testing.T, expectedType TelemetryType, expectedCondition 
 	wg.Wait()
 }
 
+func sendEnvelope(ctx context.Context, client *Client) {
+	client.PushSentEnvelope(ctx, wakuv2.SentEnvelope{
+		Envelope: v2protocol.NewEnvelope(&pb.WakuMessage{
+			Payload:      []byte{1, 2, 3, 4, 5},
+			ContentTopic: testContentTopic,
+			Version:      proto.Uint32(0),
+			Timestamp:    proto.Int64(time.Now().Unix()),
+		}, 0, ""),
+		PublishMethod: publish.LightPush,
+	})
+}
+
 func TestClient_ProcessReceivedMessages(t *testing.T) {
 	withMockServer(t, ReceivedMessagesMetric, nil, func(ctx context.Context, t *testing.T, client *Client, wg *sync.WaitGroup) {
 		// Create a telemetry request to send
@@ -147,20 +159,9 @@ func TestClient_ProcessReceivedMessages(t *testing.T) {
 
 func TestClient_ProcessSentEnvelope(t *testing.T) {
 	withMockServer(t, SentEnvelopeMetric, nil, func(ctx context.Context, t *testing.T, client *Client, wg *sync.WaitGroup) {
-		// Create a telemetry request to send
-		sentEnvelope := wakuv2.SentEnvelope{
-			Envelope: v2protocol.NewEnvelope(&pb.WakuMessage{
-				Payload:      []byte{1, 2, 3, 4, 5},
-				ContentTopic: testContentTopic,
-				Version:      proto.Uint32(0),
-				Timestamp:    proto.Int64(time.Now().Unix()),
-			}, 0, ""),
-			PublishMethod: publish.LightPush,
-		}
-
 		// Send the telemetry request
 		client.Start(ctx)
-		client.PushSentEnvelope(ctx, sentEnvelope)
+		sendEnvelope(ctx, client)
 	})
 }
 
@@ -267,24 +268,14 @@ func TestRetryCache(t *testing.T) {
 	client.Start(ctx)
 
 	for i := 0; i < 3; i++ {
-		client.PushReceivedEnvelope(ctx, v2protocol.NewEnvelope(&pb.WakuMessage{
-			Payload:      []byte{1, 2, 3, 4, 5},
-			ContentTopic: testContentTopic,
-			Version:      proto.Uint32(0),
-			Timestamp:    proto.Int64(time.Now().Unix()),
-		}, 0, ""))
+		sendEnvelope(ctx, client)
 	}
 
 	time.Sleep(110 * time.Millisecond)
 
 	require.Equal(t, 3, len(client.telemetryRetryCache))
 
-	client.PushReceivedEnvelope(ctx, v2protocol.NewEnvelope(&pb.WakuMessage{
-		Payload:      []byte{1, 2, 3, 4, 5},
-		ContentTopic: testContentTopic,
-		Version:      proto.Uint32(0),
-		Timestamp:    proto.Int64(time.Now().Unix()),
-	}, 0, ""))
+	sendEnvelope(ctx, client)
 
 	wg.Wait()
 
@@ -300,24 +291,14 @@ func TestRetryCacheCleanup(t *testing.T) {
 	client.Start(ctx)
 
 	for i := 0; i < 6000; i++ {
-		client.PushReceivedEnvelope(ctx, v2protocol.NewEnvelope(&pb.WakuMessage{
-			Payload:      []byte{1, 2, 3, 4, 5},
-			ContentTopic: testContentTopic,
-			Version:      proto.Uint32(0),
-			Timestamp:    proto.Int64(time.Now().Unix()),
-		}, 0, ""))
+		sendEnvelope(ctx, client)
 	}
 
 	time.Sleep(110 * time.Millisecond)
 
 	require.Equal(t, 6000, len(client.telemetryRetryCache))
 
-	client.PushReceivedEnvelope(ctx, v2protocol.NewEnvelope(&pb.WakuMessage{
-		Payload:      []byte{1, 2, 3, 4, 5},
-		ContentTopic: testContentTopic,
-		Version:      proto.Uint32(0),
-		Timestamp:    proto.Int64(time.Now().Unix()),
-	}, 0, ""))
+	sendEnvelope(ctx, client)
 
 	time.Sleep(210 * time.Millisecond)
 
@@ -393,21 +374,9 @@ func TestPeerId(t *testing.T) {
 		return ok, false
 	}
 	withMockServer(t, SentEnvelopeMetric, expectedCondition, func(ctx context.Context, t *testing.T, client *Client, wg *sync.WaitGroup) {
-		client.Start(ctx)
-		// Create a telemetry request to send
-		sentEnvelope := wakuv2.SentEnvelope{
-			Envelope: v2protocol.NewEnvelope(&pb.WakuMessage{
-				Payload:      []byte{1, 2, 3, 4, 5},
-				ContentTopic: testContentTopic,
-				Version:      proto.Uint32(0),
-				Timestamp:    proto.Int64(time.Now().Unix()),
-			}, 0, ""),
-			PublishMethod: publish.LightPush,
-		}
-
 		// Send the telemetry request
 		client.Start(ctx)
-		client.PushSentEnvelope(ctx, sentEnvelope)
+		sendEnvelope(ctx, client)
 
 	})
 

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -104,7 +104,6 @@ type ErrorSendingEnvelope struct {
 
 type ITelemetryClient interface {
 	SetDeviceType(deviceType string)
-	PushReceivedEnvelope(ctx context.Context, receivedEnvelope *protocol.Envelope)
 	PushSentEnvelope(ctx context.Context, sentEnvelope SentEnvelope)
 	PushErrorSendingEnvelope(ctx context.Context, errorSendingEnvelope ErrorSendingEnvelope)
 	PushPeerCount(ctx context.Context, peerCount int)
@@ -1399,10 +1398,6 @@ func (w *Waku) OnNewEnvelopes(envelope *protocol.Envelope, msgType common.Messag
 	recvMessage := common.NewReceivedMessage(envelope, msgType)
 	if recvMessage == nil {
 		return nil
-	}
-
-	if w.statusTelemetryClient != nil {
-		w.statusTelemetryClient.PushReceivedEnvelope(w.ctx, envelope)
 	}
 
 	logger := w.logger.With(


### PR DESCRIPTION
Removes metric sent upon receiving an envelope.

Removes function in telemetry client (and its invocation) that reports any received envelopes.
