### PR TITLE
fix_: profile name not displayed on the login page for synced device in the fallback flow

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -1647,6 +1647,7 @@ func TestRestoreAccountAndLogin(t *testing.T) {
 	account, err := backend.RestoreAccountAndLogin(restoreRequest)
 	require.NoError(t, err)
 	require.NotNil(t, account)
+	require.Equal(t, "Account1", account.Name)
 
 	// Test case 2: Invalid restore account request
 	invalidRequest := &requests.RestoreAccount{}
@@ -1658,6 +1659,29 @@ func TestRestoreAccountAndLogin(t *testing.T) {
 	mnemonic, err := db.Mnemonic()
 	require.NoError(t, err)
 	require.Empty(t, mnemonic)
+}
+
+func TestRestoreAccountAndLoginWithoutDisplayName(t *testing.T) {
+	utils.Init()
+	tmpdir := t.TempDir()
+
+	backend := NewGethStatusBackend()
+
+	// Test case: Valid restore account request without DisplayName
+	restoreRequest := &requests.RestoreAccount{
+		Mnemonic:    "test test test test test test test test test test test test",
+		FetchBackup: false,
+		CreateAccount: requests.CreateAccount{
+			DeviceName:         "StatusIM",
+			Password:           "password",
+			CustomizationColor: "0x000000",
+			RootDataDir:        tmpdir,
+		},
+	}
+	account, err := backend.RestoreAccountAndLogin(restoreRequest)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	require.NotEmpty(t, account.Name)
 }
 
 func TestCreateAccountPathsValidation(t *testing.T) {

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1492,6 +1492,10 @@ func (b *GethStatusBackend) prepareNodeAccount(request *requests.CreateAccount, 
 		return nil, errors.Wrap(err, "failed to prepare settings")
 	}
 
+	if response.account.Name == "" {
+		response.account.Name = response.settings.Name
+	}
+
 	response.nodeConfig, err = b.prepareConfig(request, input, response.settings.InstallationID)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to prepare node config")


### PR DESCRIPTION
fixes https://github.com/status-im/status-mobile/issues/21263

### Summary
This PR resolves the issue of missing profile names on the login page for synced devices using the fallback flow.

- Updated the test TestRestoreAccountAndLogin to ensure the account name is not empty.
- Modified prepareNodeAccount in geth_backend.go to assign the account name from settings if it’s initially empty.

status-mobile PR: https://github.com/status-im/status-mobile/pull/21321

status; ready