### PR TITLE
fix(communities)!: stop syncing community on `LastOpenedAt` update

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -934,11 +934,7 @@ func (m *Messenger) CommunityUpdateLastOpenedAt(communityID string) (int64, erro
 		return 0, err
 	}
 	currentTime := time.Now().Unix()
-	updatedCommunity, err := m.communitiesManager.CommunityUpdateLastOpenedAt(id, currentTime)
-	if err != nil {
-		return 0, err
-	}
-	err = m.syncCommunity(context.Background(), updatedCommunity, m.dispatchMessage)
+	_, err = m.communitiesManager.CommunityUpdateLastOpenedAt(id, currentTime)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Syncing the entire community for potentially frequent actions like `LastOpenedAt` updates is highly inefficient when using Waku as the transport layer, as it can result in significant bandwidth overhead.

**NOTE**: it might break syncing flow on mobile as `LastOpenedAt` is no longer synced.
