### PR TITLE
fix_: sync fallback notification

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3147,11 +3147,10 @@ type ReceivedMessageState struct {
 	// List of contacts modified
 	ModifiedContacts *stringBoolMap
 	// All installations in memory
-	AllInstallations *installationMap
-	// List of communities modified
+	AllInstallations      *installationMap
 	ModifiedInstallations *stringBoolMap
 	// List of installations targeted to this device modified
-	ModifiedInstallationsTargetedToThisDevice *stringBoolMap
+	TargetedInstallations *stringBoolMap
 	// Map of existing messages
 	ExistingMessagesMap map[string]bool
 	// EmojiReactions is a list of emoji reactions for the current batch
@@ -3324,15 +3323,15 @@ func (m *Messenger) buildMessageState() *ReceivedMessageState {
 		ModifiedContacts:      new(stringBoolMap),
 		AllInstallations:      m.allInstallations,
 		ModifiedInstallations: m.modifiedInstallations,
-		ModifiedInstallationsTargetedToThisDevice: new(stringBoolMap),
-		ExistingMessagesMap:                       make(map[string]bool),
-		EmojiReactions:                            make(map[string]*EmojiReaction),
-		GroupChatInvitations:                      make(map[string]*GroupChatInvitation),
-		Response:                                  &MessengerResponse{},
-		Timesource:                                m.getTimesource(),
-		ResolvePrimaryName:                        m.ResolvePrimaryName,
-		AllBookmarks:                              make(map[string]*browsers.Bookmark),
-		AllTrustStatus:                            make(map[string]verification.TrustStatus),
+		TargetedInstallations: new(stringBoolMap),
+		ExistingMessagesMap:   make(map[string]bool),
+		EmojiReactions:        make(map[string]*EmojiReaction),
+		GroupChatInvitations:  make(map[string]*GroupChatInvitation),
+		Response:              &MessengerResponse{},
+		Timesource:            m.getTimesource(),
+		ResolvePrimaryName:    m.ResolvePrimaryName,
+		AllBookmarks:          make(map[string]*browsers.Bookmark),
+		AllTrustStatus:        make(map[string]verification.TrustStatus),
 	}
 }
 
@@ -3738,7 +3737,7 @@ func (m *Messenger) saveDataAndPrepareResponse(messageState *ReceivedMessageStat
 			}
 		}
 
-		targeted, _ := messageState.ModifiedInstallationsTargetedToThisDevice.Load(id)
+		targeted, _ := messageState.TargetedInstallations.Load(id)
 		if targeted {
 			if installation.Enabled {
 				// Delete AC notif since the installation is now enabled

--- a/protocol/messenger_delete_message_for_me_test.go
+++ b/protocol/messenger_delete_message_for_me_test.go
@@ -101,7 +101,7 @@ func (s *MessengerDeleteMessageForMeSuite) Pair() {
 	s.Require().Equal("alice2", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice2", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.alice1.EnableInstallation(s.alice2.installationID)
+	_, err = s.alice1.EnableInstallation(s.alice2.installationID)
 	s.Require().NoError(err)
 }
 

--- a/protocol/messenger_delete_message_for_me_test.go
+++ b/protocol/messenger_delete_message_for_me_test.go
@@ -81,7 +81,7 @@ func (s *MessengerDeleteMessageForMeSuite) Pair() {
 		DeviceType: "alice2",
 	})
 	s.Require().NoError(err)
-	response, err := s.alice2.SendPairInstallation(context.Background(), nil)
+	response, err := s.alice2.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1322,7 +1322,7 @@ func (m *Messenger) HandleSyncPairInstallation(state *ReceivedMessageState, mess
 	state.AllInstallations.Store(message.InstallationId, installation)
 	state.ModifiedInstallations.Store(message.InstallationId, true)
 	targeted := message.TargetInstallationId == m.installationID
-	state.ModifiedInstallationsTargetedToThisDevice.Store(message.InstallationId, targeted)
+	state.TargetedInstallations.Store(message.InstallationId, targeted)
 
 	return nil
 }

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1321,6 +1321,8 @@ func (m *Messenger) HandleSyncPairInstallation(state *ReceivedMessageState, mess
 	// TODO(samyoul) remove storing of an updated reference pointer?
 	state.AllInstallations.Store(message.InstallationId, installation)
 	state.ModifiedInstallations.Store(message.InstallationId, true)
+	targeted := message.TargetInstallationId == m.installationID
+	state.ModifiedInstallationsTargetedToThisDevice.Store(message.InstallationId, targeted)
 
 	return nil
 }

--- a/protocol/messenger_identity_display_name_test.go
+++ b/protocol/messenger_identity_display_name_test.go
@@ -133,7 +133,7 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestDisplayNameSync() {
 	s.Require().Equal("alice's-other-device", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice's-other-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(alicesOtherDevice.installationID)
+	_, err = s.m.EnableInstallation(alicesOtherDevice.installationID)
 	s.Require().NoError(err)
 
 	// Set new display name on alice's device

--- a/protocol/messenger_identity_display_name_test.go
+++ b/protocol/messenger_identity_display_name_test.go
@@ -113,7 +113,7 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestDisplayNameSync() {
 	}
 	err = alicesOtherDevice.SetInstallationMetadata(alicesOtherDevice.installationID, im1)
 	s.Require().NoError(err)
-	response, err := alicesOtherDevice.SendPairInstallation(context.Background(), nil)
+	response, err := alicesOtherDevice.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)

--- a/protocol/messenger_installations_test.go
+++ b/protocol/messenger_installations_test.go
@@ -43,7 +43,7 @@ func (s *MessengerInstallationSuite) TestReceiveInstallation() {
 		DeviceType: "their-device-type",
 	})
 	s.Require().NoError(err)
-	response, err := theirMessenger.SendPairInstallation(context.Background(), nil)
+	response, err := theirMessenger.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)
@@ -242,7 +242,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 		DeviceType: "their-device-type",
 	})
 	s.Require().NoError(err)
-	response, err = theirMessenger.SendPairInstallation(context.Background(), nil)
+	response, err = theirMessenger.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)
@@ -366,7 +366,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallationNewMessages() {
 		DeviceType: "their-device-type",
 	})
 	s.Require().NoError(err)
-	response, err := bob2.SendPairInstallation(context.Background(), nil)
+	response, err := bob2.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)

--- a/protocol/messenger_installations_test.go
+++ b/protocol/messenger_installations_test.go
@@ -63,7 +63,7 @@ func (s *MessengerInstallationSuite) TestReceiveInstallation() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	contactKey, err := crypto.GenerateKey()
@@ -262,7 +262,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	// sync
@@ -382,7 +382,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallationNewMessages() {
 	s.Require().NoError(err)
 	actualInstallation := response.Installations()[0]
 	s.Require().Equal(bob2.installationID, actualInstallation.ID)
-	err = bob1.EnableInstallation(bob2.installationID)
+	_, err = bob1.EnableInstallation(bob2.installationID)
 	s.Require().NoError(err)
 
 	// send a message from bob1 to alice, it should be received on both bob1 and bob2

--- a/protocol/messenger_pairing_and_syncing.go
+++ b/protocol/messenger_pairing_and_syncing.go
@@ -30,7 +30,7 @@ func (m *Messenger) EnableInstallationAndSync(request *requests.EnableInstallati
 	response := &MessengerResponse{}
 	response.AddInstallation(installation)
 
-	pairResponse, err := m.SendPairInstallation(context.Background(), nil)
+	pairResponse, err := m.SendPairInstallation(context.Background(), request.InstallationID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (m *Messenger) EnableInstallationAndPair(request *requests.EnableInstallati
 		i.Enabled = true
 	}
 	m.allInstallations.Store(request.InstallationID, i)
-	response, err := m.SendPairInstallation(context.Background(), nil)
+	response, err := m.SendPairInstallation(context.Background(), request.GetInstallationId(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (m *Messenger) EnableInstallationAndPair(request *requests.EnableInstallati
 }
 
 // SendPairInstallation sends a pair installation message
-func (m *Messenger) SendPairInstallation(ctx context.Context, rawMessageHandler RawMessageHandler) (*MessengerResponse, error) {
+func (m *Messenger) SendPairInstallation(ctx context.Context, targetInstallationID string, rawMessageHandler RawMessageHandler) (*MessengerResponse, error) {
 	var err error
 	var response MessengerResponse
 
@@ -115,11 +115,13 @@ func (m *Messenger) SendPairInstallation(ctx context.Context, rawMessageHandler 
 	clock, chat := m.getLastClockWithRelatedChat()
 
 	pairMessage := &protobuf.SyncPairInstallation{
-		Clock:          clock,
-		Name:           installation.InstallationMetadata.Name,
-		InstallationId: installation.ID,
-		DeviceType:     installation.InstallationMetadata.DeviceType,
-		Version:        installation.Version}
+		Clock:                clock,
+		Name:                 installation.InstallationMetadata.Name,
+		InstallationId:       installation.ID,
+		DeviceType:           installation.InstallationMetadata.DeviceType,
+		Version:              installation.Version,
+		TargetInstallationId: targetInstallationID,
+	}
 	encodedMessage, err := proto.Marshal(pairMessage)
 	if err != nil {
 		return nil, err

--- a/protocol/messenger_pairing_and_syncing.go
+++ b/protocol/messenger_pairing_and_syncing.go
@@ -22,7 +22,7 @@ func (m *Messenger) EnableInstallationAndSync(request *requests.EnableInstallati
 		return nil, err
 	}
 
-	installation, err := m.EnableInstallationV2(request.InstallationID)
+	installation, err := m.EnableInstallation(request.InstallationID)
 	if err != nil {
 		return nil, err
 	}
@@ -503,25 +503,8 @@ func (m *Messenger) SetInstallationName(id string, name string) error {
 	return m.encryptor.SetInstallationName(m.IdentityPublicKey(), id, name)
 }
 
-// Deprecated: use EnableInstallationV2 instead
-func (m *Messenger) EnableInstallation(id string) error {
-	installation, ok := m.allInstallations.Load(id)
-	if !ok {
-		return errors.New("no installation found")
-	}
-
-	err := m.encryptor.EnableInstallation(&m.identity.PublicKey, id)
-	if err != nil {
-		return err
-	}
-	installation.Enabled = true
-	// TODO(samyoul) remove storing of an updated reference pointer?
-	m.allInstallations.Store(id, installation)
-	return nil
-}
-
-// EnableInstallationV2 enables an installation and returns the installation
-func (m *Messenger) EnableInstallationV2(id string) (*multidevice.Installation, error) {
+// EnableInstallation enables an installation and returns the installation
+func (m *Messenger) EnableInstallation(id string) (*multidevice.Installation, error) {
 	installation, ok := m.allInstallations.Load(id)
 	if !ok {
 		return nil, errors.New("no installation found")

--- a/protocol/messenger_pairing_and_syncing_test.go
+++ b/protocol/messenger_pairing_and_syncing_test.go
@@ -102,8 +102,17 @@ func (s *MessengerPairingSuite) TestMessengerPairAfterSeedPhrase() {
 	)
 	s.Require().NoError(err)
 
-	_, err = alice1.EnableInstallationAndSync(&requests.EnableInstallationAndSync{InstallationID: installationID2})
+	// check response from alice1
+	resp, err := alice1.EnableInstallationAndSync(&requests.EnableInstallationAndSync{InstallationID: installationID2})
 	s.Require().NoError(err)
+	installationID2Exist := false
+	for _, i := range resp.Installations() {
+		if i.ID == installationID2 {
+			installationID2Exist = true
+			break
+		}
+	}
+	s.Require().True(installationID2Exist)
 
 	// check if the display name is synced
 	err = tt.RetryWithBackOff(func() error {

--- a/protocol/messenger_pairing_and_syncing_test.go
+++ b/protocol/messenger_pairing_and_syncing_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
@@ -58,25 +59,41 @@ func (s *MessengerPairingSuite) TestEnableNonExistingInstallation() {
 
 }
 
-func (s *MessengerPairingSuite) TestWrongTargetInstallationID() {
+type stubEnableInstallationAndPair struct {
+	installationID                string
+	getInstallationIDInvokedFirst bool
+}
+
+func (m *stubEnableInstallationAndPair) GetInstallationID() string {
+	if !m.getInstallationIDInvokedFirst {
+		m.getInstallationIDInvokedFirst = true
+		return m.installationID
+	}
+	return "wrong installation ID"
+}
+
+func (m *stubEnableInstallationAndPair) Validate() error {
+	return nil
+}
+
+// TestNewInstallationReceivedIsNotCreated tests the scenario where alice2 wants to pair with alice1
+// but the target installation ID is wrong so no AC notification(ActivityCenterNotificationTypeNewInstallationReceived)
+// should be created for alice1
+func (s *MessengerPairingSuite) TestNewInstallationReceivedIsNotCreated() {
 	alice1 := s.m
 	alice2, err := newMessengerWithKey(s.shh, s.privateKey, s.logger, nil)
 	s.Require().NoError(err)
 	defer TearDownMessenger(&s.Suite, alice2)
 
-	wrongTargetInstallationID := uuid.New().String()
-	mockRequest := requests.NewMockEnableInstallationAndPair(alice1.installationID, func() string {
-		return wrongTargetInstallationID
-	})
+	mockRequest := &stubEnableInstallationAndPair{installationID: alice1.installationID}
 	_, err = alice2.EnableInstallationAndPair(mockRequest)
 	s.Require().NoError(err)
 
-	_, err = WaitOnMessengerResponse(
+	resp, err := WaitOnMessengerResponse(
 		alice1,
 		func(r *MessengerResponse) bool {
 			for _, i := range r.Installations() {
-				// We expect the installation to be added but no activity center notification
-				if i.ID == alice2.installationID && len(r.ActivityCenterNotifications()) == 0 {
+				if i.ID == alice2.installationID {
 					return true
 				}
 			}
@@ -85,6 +102,76 @@ func (s *MessengerPairingSuite) TestWrongTargetInstallationID() {
 		"no messages",
 	)
 	s.Require().NoError(err)
+	s.Require().Len(resp.ActivityCenterNotifications(), 0)
+}
+
+// TestNewInstallationCreatedIsNotDeleted tests the scenario
+// 1. prepare AC NewInstallationCreated for alice2
+// 2. prepare AC NewInstallationCreated for alice3
+// 3. alice1.EnableInstallationAndSync
+// 4. check AC NewInstallationCreated for alice3 is not deleted
+func (s *MessengerPairingSuite) TestNewInstallationCreatedIsNotDeleted() {
+	alice1 := s.m
+	alice2, err := newMessengerWithKey(s.shh, s.privateKey, s.logger, nil)
+	s.Require().NoError(err)
+	alice3, err := newMessengerWithKey(s.shh, s.privateKey, s.logger, nil)
+	s.Require().NoError(err)
+	defer TearDownMessenger(&s.Suite, alice2)
+	defer TearDownMessenger(&s.Suite, alice3)
+
+	// prepare AC NewInstallationCreated for alice2
+	_, err = alice2.EnableInstallationAndPair(&requests.EnableInstallationAndPair{InstallationID: alice1.installationID})
+	s.Require().NoError(err)
+
+	// alice1 should get the installationID2 from alice2
+	s.expectInstallationReceived(alice1, alice2.installationID)
+
+	// prepare AC NewInstallationCreated for alice3
+	_, err = alice3.EnableInstallationAndPair(&requests.EnableInstallationAndPair{InstallationID: alice1.installationID})
+	s.Require().NoError(err)
+
+	// alice1 should get the installationID3 from alice3
+	s.expectInstallationReceived(alice1, alice3.installationID)
+
+	_, err = alice1.EnableInstallationAndSync(&requests.EnableInstallationAndSync{InstallationID: alice2.installationID})
+	s.Require().NoError(err)
+
+	_, err = WaitOnMessengerResponse(
+		alice3,
+		func(r *MessengerResponse) bool {
+			for _, i := range r.Installations() {
+				if i.ID == alice1.installationID {
+					return true
+				}
+			}
+			return false
+		},
+		"alice3 should get the installationID from alice1",
+	)
+	s.Require().NoError(err)
+
+	ac, err := alice3.ActivityCenterNotification(types.FromHex(alice1.installationID))
+	s.Require().NoError(err)
+	s.Require().Equal(ActivityCenterNotificationTypeNewInstallationCreated, ac.Type)
+	s.Require().False(ac.Deleted)
+}
+
+func (s *MessengerPairingSuite) expectInstallationReceived(m *Messenger, installationID string) {
+	resp, err := WaitOnMessengerResponse(
+		m,
+		func(r *MessengerResponse) bool {
+			for _, i := range r.Installations() {
+				if i.ID == installationID {
+					return true
+				}
+			}
+			return false
+		},
+		"installation not received",
+	)
+	s.Require().NoError(err)
+	s.Require().Len(resp.ActivityCenterNotifications(), 1)
+	s.Require().Equal(ActivityCenterNotificationTypeNewInstallationReceived, resp.ActivityCenterNotifications()[0].Type)
 }
 
 // TestMessengerSyncFallback tests the scenario where alice2 wants to sync with alice1
@@ -116,20 +203,8 @@ func (s *MessengerPairingSuite) TestMessengerSyncFallback() {
 	_, err = alice2.EnableInstallationAndPair(&requests.EnableInstallationAndPair{InstallationID: installationID1})
 	s.Require().NoError(err)
 
-	// alice1 should get the installationID1 from alice2
-	_, err = WaitOnMessengerResponse(
-		alice1,
-		func(r *MessengerResponse) bool {
-			for _, i := range r.Installations() {
-				if i.ID == installationID2 && len(r.ActivityCenterNotifications()) == 1 && r.ActivityCenterNotifications()[0].Type == ActivityCenterNotificationTypeNewInstallationReceived {
-					return true
-				}
-			}
-			return false
-		},
-		"no messages",
-	)
-	s.Require().NoError(err)
+	// alice1 should get the installationID2 from alice2
+	s.expectInstallationReceived(alice1, installationID2)
 
 	// check response from alice1
 	resp, err := alice1.EnableInstallationAndSync(&requests.EnableInstallationAndSync{InstallationID: installationID2})

--- a/protocol/messenger_sync_bookmark_test.go
+++ b/protocol/messenger_sync_bookmark_test.go
@@ -60,7 +60,7 @@ func (s *MessengerSyncBookmarkSuite) TestSyncBookmark() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	// sync

--- a/protocol/messenger_sync_bookmark_test.go
+++ b/protocol/messenger_sync_bookmark_test.go
@@ -40,7 +40,7 @@ func (s *MessengerSyncBookmarkSuite) TestSyncBookmark() {
 		DeviceType: "their-device-type",
 	})
 	s.Require().NoError(err)
-	response, err := theirMessenger.SendPairInstallation(context.Background(), nil)
+	response, err := theirMessenger.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)

--- a/protocol/messenger_sync_chat_test.go
+++ b/protocol/messenger_sync_chat_test.go
@@ -102,7 +102,7 @@ func (s *MessengerSyncChatSuite) Pair() {
 	s.Require().Equal("alice2", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice2", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.alice1.EnableInstallation(s.alice2.installationID)
+	_, err = s.alice1.EnableInstallation(s.alice2.installationID)
 	s.Require().NoError(err)
 }
 

--- a/protocol/messenger_sync_chat_test.go
+++ b/protocol/messenger_sync_chat_test.go
@@ -82,7 +82,7 @@ func (s *MessengerSyncChatSuite) Pair() {
 		DeviceType: "alice2",
 	})
 	s.Require().NoError(err)
-	response, err := s.alice2.SendPairInstallation(context.Background(), nil)
+	response, err := s.alice2.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)

--- a/protocol/messenger_sync_clear_history_test.go
+++ b/protocol/messenger_sync_clear_history_test.go
@@ -31,7 +31,7 @@ func (s *MessengerSyncClearHistory) pair() *Messenger {
 		DeviceType: "their-device-type",
 	})
 	s.Require().NoError(err)
-	response, err := theirMessenger.SendPairInstallation(context.Background(), nil)
+	response, err := theirMessenger.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 

--- a/protocol/messenger_sync_clear_history_test.go
+++ b/protocol/messenger_sync_clear_history_test.go
@@ -49,7 +49,7 @@ func (s *MessengerSyncClearHistory) pair() *Messenger {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	return theirMessenger

--- a/protocol/messenger_sync_keycard_change_test.go
+++ b/protocol/messenger_sync_keycard_change_test.go
@@ -70,7 +70,7 @@ func (s *MessengerSyncKeycardChangeSuite) SetupTest() {
 	)
 	s.Require().NoError(err)
 
-	err = s.main.EnableInstallation(s.other.installationID)
+	_, err = s.main.EnableInstallation(s.other.installationID)
 	s.Require().NoError(err)
 
 	// Pre-condition - both sides have to know about keypairs migrated to a keycards

--- a/protocol/messenger_sync_keycard_change_test.go
+++ b/protocol/messenger_sync_keycard_change_test.go
@@ -58,7 +58,7 @@ func (s *MessengerSyncKeycardChangeSuite) SetupTest() {
 	}
 	err = s.other.SetInstallationMetadata(s.other.installationID, imOther)
 	s.Require().NoError(err)
-	response, err := s.other.SendPairInstallation(context.Background(), nil)
+	response, err := s.other.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 

--- a/protocol/messenger_sync_keycards_state_test.go
+++ b/protocol/messenger_sync_keycards_state_test.go
@@ -70,7 +70,7 @@ func (s *MessengerSyncKeycardsStateSuite) SetupTest() {
 	)
 	s.Require().NoError(err)
 
-	err = s.main.EnableInstallation(s.other.installationID)
+	_, err = s.main.EnableInstallation(s.other.installationID)
 	s.Require().NoError(err)
 
 	// Pre-condition - both sides have to know about keypairs migrated to a keycards

--- a/protocol/messenger_sync_keycards_state_test.go
+++ b/protocol/messenger_sync_keycards_state_test.go
@@ -58,7 +58,7 @@ func (s *MessengerSyncKeycardsStateSuite) SetupTest() {
 	}
 	err = s.other.SetInstallationMetadata(s.other.installationID, imOther)
 	s.Require().NoError(err)
-	response, err := s.other.SendPairInstallation(context.Background(), nil)
+	response, err := s.other.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 

--- a/protocol/messenger_sync_profile_picture_test.go
+++ b/protocol/messenger_sync_profile_picture_test.go
@@ -35,7 +35,7 @@ func (s *MessengerSyncProfilePictureSuite) TestSyncProfilePicture() {
 		DeviceType: "their-device-type",
 	})
 	s.Require().NoError(err)
-	response, err := theirMessenger.SendPairInstallation(context.Background(), nil)
+	response, err := theirMessenger.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)

--- a/protocol/messenger_sync_profile_picture_test.go
+++ b/protocol/messenger_sync_profile_picture_test.go
@@ -55,7 +55,7 @@ func (s *MessengerSyncProfilePictureSuite) TestSyncProfilePicture() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	// Sync happens via subscription triggered from within StoreIdentityImages

--- a/protocol/messenger_sync_raw_messages.go
+++ b/protocol/messenger_sync_raw_messages.go
@@ -312,7 +312,7 @@ func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) er
 			}
 			// if receiver already logged in before local pairing, we need force enable the installation,
 			// AddInstallations won't make sure enable it, e.g. installation maybe already exist in db but not enabled yet
-			err = m.EnableInstallation(message.InstallationId)
+			_, err = m.EnableInstallation(message.InstallationId)
 			if err != nil {
 				return err
 			}

--- a/protocol/messenger_sync_saved_addresses_test.go
+++ b/protocol/messenger_sync_saved_addresses_test.go
@@ -74,7 +74,7 @@ func (s *MessengerSyncSavedAddressesSuite) SetupTest() {
 	)
 	s.Require().NoError(err)
 
-	err = s.main.EnableInstallation(s.other.installationID)
+	_, err = s.main.EnableInstallation(s.other.installationID)
 	s.Require().NoError(err)
 }
 

--- a/protocol/messenger_sync_saved_addresses_test.go
+++ b/protocol/messenger_sync_saved_addresses_test.go
@@ -62,7 +62,7 @@ func (s *MessengerSyncSavedAddressesSuite) SetupTest() {
 	}
 	err = s.other.SetInstallationMetadata(s.other.installationID, imOther)
 	s.Require().NoError(err)
-	response, err := s.other.SendPairInstallation(context.Background(), nil)
+	response, err := s.other.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 

--- a/protocol/messenger_sync_verification_test.go
+++ b/protocol/messenger_sync_verification_test.go
@@ -63,7 +63,7 @@ func (s *MessengerSyncVerificationRequests) TestSyncVerificationRequests() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	// sync
@@ -127,7 +127,7 @@ func (s *MessengerSyncVerificationRequests) TestSyncTrust() {
 	s.Require().Equal("their-name", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("their-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(theirMessenger.installationID)
+	_, err = s.m.EnableInstallation(theirMessenger.installationID)
 	s.Require().NoError(err)
 
 	// sync

--- a/protocol/messenger_sync_verification_test.go
+++ b/protocol/messenger_sync_verification_test.go
@@ -43,7 +43,7 @@ func (s *MessengerSyncVerificationRequests) TestSyncVerificationRequests() {
 		DeviceType: "their-device-type",
 	})
 	s.Require().NoError(err)
-	response, err := theirMessenger.SendPairInstallation(context.Background(), nil)
+	response, err := theirMessenger.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)
@@ -107,7 +107,7 @@ func (s *MessengerSyncVerificationRequests) TestSyncTrust() {
 		DeviceType: "their-device-type",
 	})
 	s.Require().NoError(err)
-	response, err := theirMessenger.SendPairInstallation(context.Background(), nil)
+	response, err := theirMessenger.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)

--- a/protocol/messenger_sync_wallets_test.go
+++ b/protocol/messenger_sync_wallets_test.go
@@ -121,7 +121,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWallets() {
 	s.Require().Equal("alice's-other-device", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice's-other-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(alicesOtherDevice.installationID)
+	_, err = s.m.EnableInstallation(alicesOtherDevice.installationID)
 	s.Require().NoError(err)
 
 	// Store seed phrase keypair with accounts on alice's device
@@ -341,7 +341,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountsReorder() {
 	s.Require().Equal("alice's-other-device", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice's-other-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(alicesOtherDevice.installationID)
+	_, err = s.m.EnableInstallation(alicesOtherDevice.installationID)
 	s.Require().NoError(err)
 
 	// Move down account from position 1 to position 4
@@ -531,7 +531,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 	s.Require().Equal("alice's-other-device", actualInstallation.InstallationMetadata.Name)
 	s.Require().Equal("alice's-other-device-type", actualInstallation.InstallationMetadata.DeviceType)
 
-	err = s.m.EnableInstallation(alicesOtherDevice.installationID)
+	_, err = s.m.EnableInstallation(alicesOtherDevice.installationID)
 	s.Require().NoError(err)
 
 	// Trigger's a sync between devices

--- a/protocol/messenger_sync_wallets_test.go
+++ b/protocol/messenger_sync_wallets_test.go
@@ -101,7 +101,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWallets() {
 	}
 	err = alicesOtherDevice.SetInstallationMetadata(alicesOtherDevice.installationID, im1)
 	s.Require().NoError(err)
-	response, err := alicesOtherDevice.SendPairInstallation(context.Background(), nil)
+	response, err := alicesOtherDevice.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)
@@ -321,7 +321,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountsReorder() {
 	}
 	err = alicesOtherDevice.SetInstallationMetadata(alicesOtherDevice.installationID, im1)
 	s.Require().NoError(err)
-	response, err := alicesOtherDevice.SendPairInstallation(context.Background(), nil)
+	response, err := alicesOtherDevice.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)
@@ -511,7 +511,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 	}
 	err = alicesOtherDevice.SetInstallationMetadata(alicesOtherDevice.installationID, im1)
 	s.Require().NoError(err)
-	response, err := alicesOtherDevice.SendPairInstallation(context.Background(), nil)
+	response, err := alicesOtherDevice.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -277,7 +277,7 @@ func FindFirstByContentType(messages []*common.Message, contentType protobuf.Cha
 
 func PairDevices(s *suite.Suite, device1, device2 *Messenger) {
 	// Send pairing data
-	response, err := device1.SendPairInstallation(context.Background(), nil)
+	response, err := device1.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Len(response.Chats(), 1)

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -306,7 +306,7 @@ func PairDevices(s *suite.Suite, device1, device2 *Messenger) {
 	s.Require().NotNil(response)
 
 	// Ensure installation is enabled
-	err = device2.EnableInstallation(device1.installationID)
+	_, err = device2.EnableInstallation(device1.installationID)
 	s.Require().NoError(err)
 }
 

--- a/protocol/protobuf/pairing.proto
+++ b/protocol/protobuf/pairing.proto
@@ -91,8 +91,9 @@ message SyncPairInstallation {
   string installation_id = 2;
   string device_type = 3;
   string name = 4;
-  // following fields used for local pairing
+  // used for local pairing
   uint32 version = 5;
+  string target_installation_id = 6;
 }
 
 message SyncInstallationContactV2 {

--- a/protocol/requests/enable_installation_and_pair.go
+++ b/protocol/requests/enable_installation_and_pair.go
@@ -7,8 +7,7 @@ import (
 var ErrEnableInstallationAndPairInvalidID = errors.New("enable installation and pair: invalid installation id")
 
 type EnableInstallationAndPair struct {
-	InstallationID    string `json:"installationId"`
-	getInstallationID func() string
+	InstallationID string `json:"installationId"`
 }
 
 func (j *EnableInstallationAndPair) Validate() error {
@@ -19,16 +18,6 @@ func (j *EnableInstallationAndPair) Validate() error {
 	return nil
 }
 
-func (j *EnableInstallationAndPair) GetInstallationId() string {
-	if j.getInstallationID != nil {
-		return j.getInstallationID()
-	}
+func (j *EnableInstallationAndPair) GetInstallationID() string {
 	return j.InstallationID
-}
-
-func NewMockEnableInstallationAndPair(installationID string, mockGetInstallationID func() string) *EnableInstallationAndPair {
-	return &EnableInstallationAndPair{
-		InstallationID:    installationID,
-		getInstallationID: mockGetInstallationID,
-	}
 }

--- a/protocol/requests/enable_installation_and_pair.go
+++ b/protocol/requests/enable_installation_and_pair.go
@@ -7,7 +7,8 @@ import (
 var ErrEnableInstallationAndPairInvalidID = errors.New("enable installation and pair: invalid installation id")
 
 type EnableInstallationAndPair struct {
-	InstallationID string `json:"installationId"`
+	InstallationID    string `json:"installationId"`
+	getInstallationID func() string
 }
 
 func (j *EnableInstallationAndPair) Validate() error {
@@ -16,4 +17,18 @@ func (j *EnableInstallationAndPair) Validate() error {
 	}
 
 	return nil
+}
+
+func (j *EnableInstallationAndPair) GetInstallationId() string {
+	if j.getInstallationID != nil {
+		return j.getInstallationID()
+	}
+	return j.InstallationID
+}
+
+func NewMockEnableInstallationAndPair(installationID string, mockGetInstallationID func() string) *EnableInstallationAndPair {
+	return &EnableInstallationAndPair{
+		InstallationID:    installationID,
+		getInstallationID: mockGetInstallationID,
+	}
 }

--- a/server/pairing/raw_message_handler.go
+++ b/server/pairing/raw_message_handler.go
@@ -36,7 +36,7 @@ func (s *SyncRawMessageHandler) CollectInstallationData(rawMessageCollector *Raw
 	if err != nil {
 		return err
 	}
-	_, err = messenger.SendPairInstallation(context.TODO(), rawMessageCollector.dispatchMessage)
+	_, err = messenger.SendPairInstallation(context.TODO(), "", rawMessageCollector.dispatchMessage)
 	return err
 }
 

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -907,7 +907,7 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterStopUisngKeycard() {
 	s.Require().NoError(err)
 	err = clientMessenger.SetInstallationMetadata(settings.InstallationID, im1)
 	s.Require().NoError(err)
-	response, err := clientMessenger.SendPairInstallation(context.Background(), nil)
+	response, err := clientMessenger.SendPairInstallation(context.Background(), "", nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Chats(), 1)

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -940,7 +940,7 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterStopUisngKeycard() {
 	}
 	s.Require().True(found)
 
-	err = serverMessenger.EnableInstallation(settings.InstallationID)
+	_, err = serverMessenger.EnableInstallation(settings.InstallationID)
 	s.Require().NoError(err)
 
 	// Check if the logged in account is the same on server and client

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1057,7 +1057,7 @@ func (api *PublicAPI) VerifiedUntrustworthy(ctx context.Context, request *reques
 }
 
 func (api *PublicAPI) SendPairInstallation(ctx context.Context) (*protocol.MessengerResponse, error) {
-	return api.service.messenger.SendPairInstallation(ctx, nil)
+	return api.service.messenger.SendPairInstallation(ctx, "", nil)
 }
 
 func (api *PublicAPI) SyncDevices(ctx context.Context, name, picture string) error {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -373,7 +373,8 @@ func (api *PublicAPI) RemoveFilters(parent context.Context, chats []*transport.F
 
 // EnableInstallation enables an installation for multi-device sync.
 func (api *PublicAPI) EnableInstallation(installationID string) error {
-	return api.service.messenger.EnableInstallation(installationID)
+	_, err := api.service.messenger.EnableInstallation(installationID)
+	return err
 }
 
 // DisableInstallation disables an installation for multi-device sync.

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -332,7 +332,8 @@ func (s *Service) verifyTransactionLoop(tick time.Duration, cancel <-chan struct
 }
 
 func (s *Service) EnableInstallation(installationID string) error {
-	return s.messenger.EnableInstallation(installationID)
+	_, err := s.messenger.EnableInstallation(installationID)
+	return err
 }
 
 // DisableInstallation disables an installation for multi-device sync.


### PR DESCRIPTION
This PR already contains the changes made in [PR 5869](https://github.com/status-im/status-go/pull/5869), because these two PRs have some intersections. To make things simple, let's just use this PR instead.

This PR mainly focuses on solving mobile [issue 21260](https://github.com/status-im/status-mobile/issues/21260)
We should not create/delete the notification if the target is not equal current installation id.

Relate mobile [PR 21315](https://github.com/status-im/status-mobile/pull/21315)

status: ready.
