### PR TITLE
ci_: add go-generate-fast to nix

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -56,6 +56,7 @@ in rec {
   go-modvendor = callPackage ./pkgs/go-modvendor { };
   cc-test-reporter = callPackage ./pkgs/cc-test-reporter { };
   codecov-cli = callPackage ./pkgs/codecov-cli { };
+  go-generate-fast = callPackage ./pkgs/go-generate-fast { };
 
   gomobile = (prev.gomobile.overrideAttrs (old: {
     patches = [

--- a/nix/pkgs/go-generate-fast/default.nix
+++ b/nix/pkgs/go-generate-fast/default.nix
@@ -1,0 +1,16 @@
+{ buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "go-generate-fast";
+  version = "0.3.0";
+
+  subPackages = [ "." ];
+
+  src = fetchFromGitHub rec {
+    owner = "oNaiPs";
+    repo = "go-generate-fast";
+    rev = "v${version}";
+    hash = "sha256-NMGXOI3y3PGt+hrHhOsugACL8c5LIzpwwdt+Ne0MkY8=";
+  };
+  vendorHash = "sha256-8nmnTuDZvnFEPQAxOv19gUgHy6FpI3HLRtqLLob+zrE=";
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -21,7 +21,7 @@ in pkgs.mkShell {
 
   buildInputs = with pkgs; [
     git jq which
-    go golangci-lint go-junit-report gopls go-bindata gomobileMod codecov-cli
+    go golangci-lint go-junit-report gopls go-bindata gomobileMod codecov-cli go-generate-fast
     mockgen protobuf3_20 protoc-gen-go gotestsum go-modvendor openjdk cc-test-reporter
    ] ++ lib.optionals (stdenv.isDarwin) [ xcodeWrapper ];
 


### PR DESCRIPTION
Added nix derivation for https://github.com/oNaiPs/go-generate-fast

Required for https://github.com/status-im/status-go/pull/5878