### PR TITLE
fix_: remove waku go generate instructions as unused

### DIFF
--- a/waku/api.go
+++ b/waku/api.go
@@ -209,8 +209,6 @@ func (api *PublicWakuAPI) CancelLightClient(ctx context.Context) bool {
 	return !api.w.LightClientMode()
 }
 
-//go:generate gencodec -type NewMessage -field-override newMessageOverride -out gen_newmessage_json.go
-
 // NewMessage represents a new waku message that is posted through the RPC.
 type NewMessage struct {
 	SymKeyID   string           `json:"symKeyID"`
@@ -427,8 +425,6 @@ func (api *PublicWakuAPI) Messages(ctx context.Context, crit Criteria) (*rpc.Sub
 
 	return rpcSub, nil
 }
-
-//go:generate gencodec -type Message -field-override messageOverride -out gen_message_json.go
 
 // Message is the RPC representation of a waku message.
 type Message struct {

--- a/wakuv2/api.go
+++ b/wakuv2/api.go
@@ -171,8 +171,6 @@ func (api *PublicWakuAPI) BloomFilter() []byte {
 	return nil
 }
 
-//go:generate gencodec -type NewMessage -field-override newMessageOverride -out gen_newmessage_json.go
-
 // NewMessage represents a new waku message that is posted through the RPC.
 type NewMessage struct {
 	SymKeyID     string           `json:"symKeyID"`
@@ -375,8 +373,6 @@ func (api *PublicWakuAPI) Messages(ctx context.Context, crit Criteria) (*rpc.Sub
 
 	return rpcSub, nil
 }
-
-//go:generate gencodec -type Message -field-override messageOverride -out gen_message_json.go
 
 // Message is the RPC representation of a waku message.
 type Message struct {


### PR DESCRIPTION
Removed some unused legacy `//go:generate` commands. Didn't even find the output files in the repo.

Required for https://github.com/status-im/status-go/pull/5878