### PR TITLE
fix_: bandwidthCounter should be reset each time it is retrieved otherwise it behaves like an accumulator

### DIFF
--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -519,20 +519,14 @@ func (w *Waku) telemetryBandwidthStats(telemetryServerURL string) {
 	ticker := time.NewTicker(time.Second * 20)
 	defer ticker.Stop()
 
-	today := time.Now()
-
 	for {
 		select {
 		case <-w.ctx.Done():
 			return
-		case now := <-ticker.C:
-			// Reset totals when day changes
-			if now.Day() != today.Day() {
-				today = now
-				w.bandwidthCounter.Reset()
-			}
-
-			go telemetry.PushProtocolStats(w.bandwidthCounter.GetBandwidthByProtocol())
+		case <-ticker.C:
+			bandwidthPerProtocol := w.bandwidthCounter.GetBandwidthByProtocol()
+			w.bandwidthCounter.Reset()
+			go telemetry.PushProtocolStats(bandwidthPerProtocol)
 		}
 	}
 }


### PR DESCRIPTION
While adding prometheus bandwidth metrics to go-waku, @AlbertoSoutullo noticed that go-waku service nodes metric value was incorrect. 
This PR includes the fix that was applied to the go-waku service node