### PR TITLE
feat(telemetry)_: add metrics for message reliability

### DIFF
--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -18,27 +18,48 @@ import (
 	"github.com/status-im/status-go/wakuv2"
 
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
-	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
 
 	v1protocol "github.com/status-im/status-go/protocol/v1"
+	v2common "github.com/status-im/status-go/wakuv2/common"
+	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
 )
 
 type TelemetryType string
 
 const (
-	ProtocolStatsMetric        TelemetryType = "ProtocolStats"
-	SentEnvelopeMetric         TelemetryType = "SentEnvelope"
-	UpdateEnvelopeMetric       TelemetryType = "UpdateEnvelope"
-	ReceivedMessagesMetric     TelemetryType = "ReceivedMessages"
+	// Bandwidth as reported by libp2p
+	ProtocolStatsMetric TelemetryType = "ProtocolStats"
+	// Envelopes sent by this node
+	SentEnvelopeMetric TelemetryType = "SentEnvelope"
+	// Change in status of a sent envelope (usually processing errors)
+	UpdateEnvelopeMetric TelemetryType = "UpdateEnvelope"
+	// Messages received by this node
+	ReceivedMessagesMetric TelemetryType = "ReceivedMessages"
+	// Errors encountered when sending envelopes
 	ErrorSendingEnvelopeMetric TelemetryType = "ErrorSendingEnvelope"
-	PeerCountMetric            TelemetryType = "PeerCount"
-	PeerConnFailuresMetric     TelemetryType = "PeerConnFailure"
-	MessageCheckSuccessMetric  TelemetryType = "MessageCheckSuccess"
-	MessageCheckFailureMetric  TelemetryType = "MessageCheckFailure"
-	PeerCountByShardMetric     TelemetryType = "PeerCountByShard"
-	PeerCountByOriginMetric    TelemetryType = "PeerCountByOrigin"
-	MaxRetryCache                            = 5000
+	// Total connections for this node at a given time
+	PeerCountMetric TelemetryType = "PeerCount"
+	// Number of failed peer connections for this node at a given time
+	PeerConnFailuresMetric TelemetryType = "PeerConnFailure"
+	// Store confirmation for a sent message successful
+	MessageCheckSuccessMetric TelemetryType = "MessageCheckSuccess"
+	// Store confirmation for a sent message failed
+	MessageCheckFailureMetric TelemetryType = "MessageCheckFailure"
+	// Total connections for this node per shard at a given time
+	PeerCountByShardMetric TelemetryType = "PeerCountByShard"
+	// Total connections for this node per discovery origin at a given time
+	PeerCountByOriginMetric TelemetryType = "PeerCountByOrigin"
+	// Error encountered when attempting to dial a peer
+	DialFailureMetric TelemetryType = "DialFailure"
+	// Missed message as detected by periodic store query
+	MissedMessageMetric TelemetryType = "MissedMessages"
+	// Missed message with a relevant filter
+	MissedRelevantMessageMetric TelemetryType = "MissedRelevantMessages"
+	// MVDS ack received for a sent message
+	MessageDeliveryConfirmedMetric TelemetryType = "MessageDeliveryConfirmed"
 )
+
+const MaxRetryCache = 5000
 
 type TelemetryRequest struct {
 	Id            int              `json:"id"`
@@ -103,6 +124,26 @@ func (c *Client) PushPeerCountByOrigin(ctx context.Context, peerCountByOrigin ma
 	}
 }
 
+func (c *Client) PushDialFailure(ctx context.Context, dialFailure v2common.DialError) {
+	var errorMessage string = ""
+	if dialFailure.ErrType == v2common.ErrorUnknown {
+		errorMessage = dialFailure.ErrMsg
+	}
+	c.processAndPushTelemetry(ctx, DialFailure{ErrorType: dialFailure.ErrType, ErrorMsg: errorMessage, Protocols: dialFailure.Protocols})
+}
+
+func (c *Client) PushMissedMessage(ctx context.Context, envelope *v2protocol.Envelope) {
+	c.processAndPushTelemetry(ctx, MissedMessage{Envelope: envelope})
+}
+
+func (c *Client) PushMissedRelevantMessage(ctx context.Context, receivedMessage *v2common.ReceivedMessage) {
+	c.processAndPushTelemetry(ctx, MissedRelevantMessage{ReceivedMessage: receivedMessage})
+}
+
+func (c *Client) PushMessageDeliveryConfirmed(ctx context.Context, messageHash string) {
+	c.processAndPushTelemetry(ctx, MessageDeliveryConfirmed{MessageHash: messageHash})
+}
+
 type ReceivedMessages struct {
 	Filter     transport.Filter
 	SSHMessage *types.Message
@@ -134,6 +175,24 @@ type PeerCountByShard struct {
 type PeerCountByOrigin struct {
 	Origin wps.Origin
 	Count  uint
+}
+
+type DialFailure struct {
+	ErrorType v2common.DialErrorType
+	ErrorMsg  string
+	Protocols string
+}
+
+type MissedMessage struct {
+	Envelope *v2protocol.Envelope
+}
+
+type MissedRelevantMessage struct {
+	ReceivedMessage *v2common.ReceivedMessage
+}
+
+type MessageDeliveryConfirmed struct {
+	MessageHash string
 }
 
 type Client struct {
@@ -308,6 +367,30 @@ func (c *Client) processAndPushTelemetry(ctx context.Context, data interface{}) 
 			TelemetryType: PeerCountByOriginMetric,
 			TelemetryData: c.ProcessPeerCountByOrigin(v),
 		}
+	case DialFailure:
+		telemetryRequest = TelemetryRequest{
+			Id:            c.nextId,
+			TelemetryType: DialFailureMetric,
+			TelemetryData: c.ProcessDialFailure(v),
+		}
+	case MissedMessage:
+		telemetryRequest = TelemetryRequest{
+			Id:            c.nextId,
+			TelemetryType: MissedMessageMetric,
+			TelemetryData: c.ProcessMissedMessage(v),
+		}
+	case MissedRelevantMessage:
+		telemetryRequest = TelemetryRequest{
+			Id:            c.nextId,
+			TelemetryType: MissedRelevantMessageMetric,
+			TelemetryData: c.ProcessMissedRelevantMessage(v),
+		}
+	case MessageDeliveryConfirmed:
+		telemetryRequest = TelemetryRequest{
+			Id:            c.nextId,
+			TelemetryType: MessageDeliveryConfirmedMetric,
+			TelemetryData: c.ProcessMessageDeliveryConfirmed(v),
+		}
 	default:
 		c.logger.Error("Unknown telemetry data type")
 		return
@@ -462,6 +545,46 @@ func (c *Client) ProcessPeerCountByOrigin(peerCountByOrigin PeerCountByOrigin) *
 	postBody := c.commonPostBody()
 	postBody["origin"] = peerCountByOrigin.Origin
 	postBody["count"] = peerCountByOrigin.Count
+	body, _ := json.Marshal(postBody)
+	jsonRawMessage := json.RawMessage(body)
+	return &jsonRawMessage
+}
+
+func (c *Client) ProcessDialFailure(dialFailure DialFailure) *json.RawMessage {
+	postBody := c.commonPostBody()
+	postBody["errorType"] = dialFailure.ErrorType
+	postBody["errorMsg"] = dialFailure.ErrorMsg
+	postBody["protocols"] = dialFailure.Protocols
+	body, _ := json.Marshal(postBody)
+	jsonRawMessage := json.RawMessage(body)
+	return &jsonRawMessage
+}
+
+func (c *Client) ProcessMissedMessage(missedMessage MissedMessage) *json.RawMessage {
+	postBody := c.commonPostBody()
+	postBody["messageHash"] = missedMessage.Envelope.Hash().String()
+	postBody["sentAt"] = uint32(missedMessage.Envelope.Message().GetTimestamp() / int64(time.Second))
+	postBody["pubsubTopic"] = missedMessage.Envelope.PubsubTopic()
+	postBody["contentTopic"] = missedMessage.Envelope.Message().ContentTopic
+	body, _ := json.Marshal(postBody)
+	jsonRawMessage := json.RawMessage(body)
+	return &jsonRawMessage
+}
+
+func (c *Client) ProcessMissedRelevantMessage(missedMessage MissedRelevantMessage) *json.RawMessage {
+	postBody := c.commonPostBody()
+	postBody["messageHash"] = missedMessage.ReceivedMessage.Envelope.Hash().String()
+	postBody["sentAt"] = missedMessage.ReceivedMessage.Sent
+	postBody["pubsubTopic"] = missedMessage.ReceivedMessage.PubsubTopic
+	postBody["contentTopic"] = missedMessage.ReceivedMessage.ContentTopic
+	body, _ := json.Marshal(postBody)
+	jsonRawMessage := json.RawMessage(body)
+	return &jsonRawMessage
+}
+
+func (c *Client) ProcessMessageDeliveryConfirmed(messageDeliveryConfirmed MessageDeliveryConfirmed) *json.RawMessage {
+	postBody := c.commonPostBody()
+	postBody["messageHash"] = messageDeliveryConfirmed.MessageHash
 	body, _ := json.Marshal(postBody)
 	jsonRawMessage := json.RawMessage(body)
 	return &jsonRawMessage

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -479,9 +479,7 @@ func (c *Client) ProcessSentEnvelope(sentEnvelope wakuv2.SentEnvelope) *json.Raw
 	postBody["topic"] = sentEnvelope.Envelope.Message().ContentTopic
 	postBody["senderKeyUID"] = c.keyUID
 	postBody["publishMethod"] = sentEnvelope.PublishMethod.String()
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessErrorSendingEnvelope(errorSendingEnvelope wakuv2.ErrorSendingEnvelope) *json.RawMessage {
@@ -493,17 +491,13 @@ func (c *Client) ProcessErrorSendingEnvelope(errorSendingEnvelope wakuv2.ErrorSe
 	postBody["senderKeyUID"] = c.keyUID
 	postBody["publishMethod"] = errorSendingEnvelope.SentEnvelope.PublishMethod.String()
 	postBody["error"] = errorSendingEnvelope.Error.Error()
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessPeerCount(peerCount PeerCount) *json.RawMessage {
 	postBody := c.commonPostBody()
 	postBody["peerCount"] = peerCount.PeerCount
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessPeerConnFailure(peerConnFailure PeerConnFailure) *json.RawMessage {
@@ -511,43 +505,33 @@ func (c *Client) ProcessPeerConnFailure(peerConnFailure PeerConnFailure) *json.R
 	postBody["failedPeerId"] = peerConnFailure.FailedPeerId
 	postBody["failureCount"] = peerConnFailure.FailureCount
 	postBody["nodeKeyUID"] = c.keyUID
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessMessageCheckSuccess(messageCheckSuccess MessageCheckSuccess) *json.RawMessage {
 	postBody := c.commonPostBody()
 	postBody["messageHash"] = messageCheckSuccess.MessageHash
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessPeerCountByShard(peerCountByShard PeerCountByShard) *json.RawMessage {
 	postBody := c.commonPostBody()
 	postBody["shard"] = peerCountByShard.Shard
 	postBody["count"] = peerCountByShard.Count
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessMessageCheckFailure(messageCheckFailure MessageCheckFailure) *json.RawMessage {
 	postBody := c.commonPostBody()
 	postBody["messageHash"] = messageCheckFailure.MessageHash
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessPeerCountByOrigin(peerCountByOrigin PeerCountByOrigin) *json.RawMessage {
 	postBody := c.commonPostBody()
 	postBody["origin"] = peerCountByOrigin.Origin
 	postBody["count"] = peerCountByOrigin.Count
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessDialFailure(dialFailure DialFailure) *json.RawMessage {
@@ -555,9 +539,7 @@ func (c *Client) ProcessDialFailure(dialFailure DialFailure) *json.RawMessage {
 	postBody["errorType"] = dialFailure.ErrorType
 	postBody["errorMsg"] = dialFailure.ErrorMsg
 	postBody["protocols"] = dialFailure.Protocols
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessMissedMessage(missedMessage MissedMessage) *json.RawMessage {
@@ -566,9 +548,7 @@ func (c *Client) ProcessMissedMessage(missedMessage MissedMessage) *json.RawMess
 	postBody["sentAt"] = uint32(missedMessage.Envelope.Message().GetTimestamp() / int64(time.Second))
 	postBody["pubsubTopic"] = missedMessage.Envelope.PubsubTopic()
 	postBody["contentTopic"] = missedMessage.Envelope.Message().ContentTopic
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessMissedRelevantMessage(missedMessage MissedRelevantMessage) *json.RawMessage {
@@ -577,15 +557,22 @@ func (c *Client) ProcessMissedRelevantMessage(missedMessage MissedRelevantMessag
 	postBody["sentAt"] = missedMessage.ReceivedMessage.Sent
 	postBody["pubsubTopic"] = missedMessage.ReceivedMessage.PubsubTopic
 	postBody["contentTopic"] = missedMessage.ReceivedMessage.ContentTopic
-	body, _ := json.Marshal(postBody)
-	jsonRawMessage := json.RawMessage(body)
-	return &jsonRawMessage
+	return c.marshalPostBody(postBody)
 }
 
 func (c *Client) ProcessMessageDeliveryConfirmed(messageDeliveryConfirmed MessageDeliveryConfirmed) *json.RawMessage {
 	postBody := c.commonPostBody()
 	postBody["messageHash"] = messageDeliveryConfirmed.MessageHash
-	body, _ := json.Marshal(postBody)
+	return c.marshalPostBody(postBody)
+}
+
+// Helper function to marshal post body and handle errors
+func (c *Client) marshalPostBody(postBody map[string]interface{}) *json.RawMessage {
+	body, err := json.Marshal(postBody)
+	if err != nil {
+		c.logger.Error("Error marshaling post body", zap.Error(err))
+		return nil
+	}
 	jsonRawMessage := json.RawMessage(body)
 	return &jsonRawMessage
 }

--- a/wakuv2/common/helpers.go
+++ b/wakuv2/common/helpers.go
@@ -6,6 +6,10 @@ import (
 	"errors"
 	"fmt"
 	mrand "math/rand"
+	"regexp"
+	"strings"
+
+	"github.com/multiformats/go-multiaddr"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -109,4 +113,127 @@ func ValidateDataIntegrity(k []byte, expectedSize int) bool {
 		return false
 	}
 	return true
+}
+
+func ParseDialErrors(errMsg string) []DialError {
+	// Regular expression to match the array of failed dial attempts
+	re := regexp.MustCompile(`all dials failed\n((?:\s*\*\s*\[.*\].*\n?)+)`)
+
+	match := re.FindStringSubmatch(errMsg)
+	if len(match) < 2 {
+		return nil
+	}
+
+	// Split the matched string into individual dial attempts
+	dialAttempts := strings.Split(strings.TrimSpace(match[1]), "\n")
+
+	// Regular expression to extract multiaddr and error message
+	reAttempt := regexp.MustCompile(`\[(.*?)\]\s*(.*)`)
+
+	var dialErrors []DialError
+	for _, attempt := range dialAttempts {
+		attempt = strings.TrimSpace(strings.Trim(attempt, "* "))
+		matches := reAttempt.FindStringSubmatch(attempt)
+		if len(matches) != 3 {
+			continue
+		}
+		errMsg := strings.TrimSpace(matches[2])
+		ma, err := multiaddr.NewMultiaddr(matches[1])
+		if err != nil {
+			continue
+		}
+		protocols := ma.Protocols()
+		protocolsStr := "/"
+		for i, protocol := range protocols {
+			protocolsStr += protocol.Name
+			if i < len(protocols)-1 {
+				protocolsStr += "/"
+			}
+		}
+		dialErrors = append(dialErrors, DialError{
+			Protocols: protocolsStr,
+			MultiAddr: matches[1],
+			ErrMsg:    errMsg,
+			ErrType:   CategorizeDialError(errMsg),
+		})
+
+	}
+
+	return dialErrors
+}
+
+// DialErrorType represents the type of dial error
+type DialErrorType int
+
+const (
+	ErrorUnknown DialErrorType = iota
+	ErrorIOTimeout
+	ErrorConnectionRefused
+	ErrorRelayCircuitFailed
+	ErrorRelayNoReservation
+	ErrorSecurityNegotiationFailed
+	ErrorConcurrentDialSucceeded
+	ErrorConcurrentDialFailed
+	ErrorConnectionsPerIPLimitExceeded
+	ErrorStreamReset
+	ErrorRelayResourceLimitExceeded
+	ErrorOpeningHopStreamToRelay
+	ErrorDialBackoff
+)
+
+func (det DialErrorType) String() string {
+	return [...]string{
+		"Unknown",
+		"I/O Timeout",
+		"Connection Refused",
+		"Relay Circuit Failed",
+		"Relay No Reservation",
+		"Security Negotiation Failed",
+		"Concurrent Dial Succeeded",
+		"Concurrent Dial Failed",
+		"Connections Per IP Limit Exceeded",
+		"Stream Reset",
+		"Relay Resource Limit Exceeded",
+		"Error Opening Hop Stream to Relay",
+		"Dial Backoff",
+	}[det]
+}
+
+func CategorizeDialError(errMsg string) DialErrorType {
+	switch {
+	case strings.Contains(errMsg, "i/o timeout"):
+		return ErrorIOTimeout
+	case strings.Contains(errMsg, "connect: connection refused"):
+		return ErrorConnectionRefused
+	case strings.Contains(errMsg, "error opening relay circuit: CONNECTION_FAILED"):
+		return ErrorRelayCircuitFailed
+	case strings.Contains(errMsg, "error opening relay circuit: NO_RESERVATION"):
+		return ErrorRelayNoReservation
+	case strings.Contains(errMsg, "failed to negotiate security protocol"):
+		return ErrorSecurityNegotiationFailed
+	case strings.Contains(errMsg, "concurrent active dial succeeded"):
+		return ErrorConcurrentDialSucceeded
+	case strings.Contains(errMsg, "concurrent active dial through the same relay failed"):
+		return ErrorConcurrentDialFailed
+	case strings.Contains(errMsg, "connections per ip limit exceeded"):
+		return ErrorConnectionsPerIPLimitExceeded
+	case strings.Contains(errMsg, "stream reset"):
+		return ErrorStreamReset
+	case strings.Contains(errMsg, "error opening relay circuit: RESOURCE_LIMIT_EXCEEDED"):
+		return ErrorRelayResourceLimitExceeded
+	case strings.Contains(errMsg, "error opening hop stream to relay: connection failed"):
+		return ErrorOpeningHopStreamToRelay
+	case strings.Contains(errMsg, "dial backoff"):
+		return ErrorDialBackoff
+	default:
+		return ErrorUnknown
+	}
+}
+
+// DialError represents a single dial error with its multiaddr and error message
+type DialError struct {
+	MultiAddr string
+	ErrMsg    string
+	ErrType   DialErrorType
+	Protocols string
 }

--- a/wakuv2/common/helpers_test.go
+++ b/wakuv2/common/helpers_test.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"testing"
+)
+
+var testCases = []struct {
+	errorString string
+	errorTypes  []DialErrorType
+}{
+	{
+		errorString: "failed to dial: failed to dial 16Uiu2HAmNFvubdwLtyScgQKMVL7Ppwvd7RZskgThtPAGqMrUfs1V: all dials failed\n  * [/ip4/0.0.0.0/tcp/55136] dial tcp4 0.0.0.0:60183->146.4.106.194:55136: i/o timeout",
+		errorTypes:  []DialErrorType{ErrorIOTimeout},
+	},
+	{
+		errorString: "failed to dial: failed to dial 16Uiu2HAmC1BsqZfy9exnA3DiQHAo3gdAopTQRErLUjK8WoospTwq: all dials failed\n  * [/ip4/0.0.0.0/tcp/46949] dial tcp4 0.0.0.0:60183->0.0.0.0:46949: i/o timeout\n  * [/ip4/0.0.0.0/tcp/51063] dial tcp4 0.0.0.0:60183->0.0.0.0:51063: i/o timeout",
+		errorTypes:  []DialErrorType{ErrorIOTimeout, ErrorIOTimeout},
+	},
+	{
+		errorString: "failed to dial: failed ito dial 16Uiu2HAkyjvXPmymR5eRnvxCufRGZdfRrgjME6bmn3Xo6aprE1eo: all dials failed\n  * [/ip4/0.0.0.0/tcp/443/wss/p2p/16Uiu2HAmB7Ur9HQqo3cWDPovRQjo57fxWWDaQx27WxSzDGhN4JKg/p2p-circuit] error opening relay circuit: CONNECTION_FAILED (203)\n  * [/ip4/0.0.0.0/tcp/30303/p2p/16Uiu2HAmB7Ur9HQqo3cWDPovRQjo57fxWWDaQx27WxSzDGhN4JKg/p2p-circuit] concurrent active dial through the same relay failed with a protocol error\n  * [/ip4/0.0.0.0/tcp/30303/p2p/16Uiu2HAmAUdrQ3uwzuE4Gy4D56hX6uLKEeerJAnhKEHZ3DxF1EfT/p2p-circuit] error opening relay circuit: CONNECTION_FAILED (203)\n  * [/ip4/0.0.0.0/tcp/443/wss/p2p/16Uiu2HAmAUdrQ3uwzuE4Gy4D56hX6uLKEeerJAnhKEHZ3DxF1EfT/p2p-circuit] concurrent active dial through the same relay failed with a protocol error",
+		errorTypes:  []DialErrorType{ErrorRelayCircuitFailed, ErrorConcurrentDialFailed, ErrorRelayCircuitFailed, ErrorConcurrentDialFailed},
+	},
+	{
+		errorString: "failed to dial: failed to dial 16Uiu2HAm9QijC9d2GsGKPLLF7cZXMFEadqvN7FqhFJ2z5jdW6AFY: all dials failed\n  * [/ip4/0.0.0.0/tcp/64012] dial tcp4 0.0.0.0:64012: connect: connection refused",
+		errorTypes:  []DialErrorType{ErrorConnectionRefused},
+	},
+	{
+		errorString: "failed to dial: failed to dial 16Uiu2HAm7jXmopqB6BUJAQH1PKcZULfSKgj9rC9pyBRKwJGTiRHf: all dials failed\n  * [/ip4/34.135.13.87/tcp/30303/p2p/16Uiu2HAm8mUZ18tBWPXDQsaF7PbCKYA35z7WB2xNZH2EVq1qS8LJ/p2p-circuit] error opening relay circuit: NO_RESERVATION (204)\n  * [/ip4/34.170.192.39/tcp/30303/p2p/16Uiu2HAmMELCo218hncCtTvC2Dwbej3rbyHQcR8erXNnKGei7WPZ/p2p-circuit] error opening relay circuit: NO_RESERVATION (204)\n  * [/ip4/178.72.78.116/tcp/42841] dial tcp4 0.0.0.0:60183->178.72.78.116:42841: i/o timeout",
+		errorTypes:  []DialErrorType{ErrorRelayNoReservation, ErrorRelayNoReservation, ErrorIOTimeout},
+	},
+	{
+		errorString: "failed to dial: failed to dial 16Uiu2HAmMUYpufreYsUBo4A56BQDnbMwN4mhP3wMWTM4reS8ivxd: all dials failed\n  * [/ip4/0.0.0.0/tcp/52957] unknown",
+		errorTypes:  []DialErrorType{ErrorUnknown},
+	},
+}
+
+func TestParseDialErrors(t *testing.T) {
+	for _, testCase := range testCases {
+		parsedErrors := ParseDialErrors(testCase.errorString)
+		for i, err := range parsedErrors {
+			if err.ErrType != testCase.errorTypes[i] {
+				t.Errorf("Expected error type %v, got %v", testCase.errorTypes[i], err.ErrType)
+			}
+		}
+	}
+}

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -113,6 +113,10 @@ type ITelemetryClient interface {
 	PushMessageCheckFailure(ctx context.Context, messageHash string)
 	PushPeerCountByShard(ctx context.Context, peerCountByShard map[uint16]uint)
 	PushPeerCountByOrigin(ctx context.Context, peerCountByOrigin map[wps.Origin]uint)
+	PushDialFailure(ctx context.Context, dialFailure common.DialError)
+	PushMissedMessage(ctx context.Context, envelope *protocol.Envelope)
+	PushMissedRelevantMessage(ctx context.Context, message *common.ReceivedMessage)
+	PushMessageDeliveryConfirmed(ctx context.Context, messageHash string)
 }
 
 // Waku represents a dark communication interface through the Ethereum
@@ -1023,6 +1027,11 @@ func (w *Waku) SkipPublishToTopic(value bool) {
 
 func (w *Waku) ConfirmMessageDelivered(hashes []gethcommon.Hash) {
 	w.messageSender.MessagesDelivered(hashes)
+	if w.statusTelemetryClient != nil {
+		for _, hash := range hashes {
+			w.statusTelemetryClient.PushMessageDeliveryConfirmed(w.ctx, hash.String())
+		}
+	}
 }
 
 func (w *Waku) SetStorePeerID(peerID peer.ID) {
@@ -1146,12 +1155,24 @@ func (w *Waku) Start() error {
 			peerTelemetryTicker := time.NewTicker(peerTelemetryTickerInterval)
 			defer peerTelemetryTicker.Stop()
 
+			sub, err := w.node.Host().EventBus().Subscribe(new(utils.DialError))
+			if err != nil {
+				w.logger.Error("failed to subscribe to dial errors", zap.Error(err))
+				return
+			}
+			defer sub.Close()
+
 			for {
 				select {
 				case <-w.ctx.Done():
 					return
 				case <-peerTelemetryTicker.C:
 					w.reportPeerMetrics()
+				case dialErr := <-sub.Out():
+					errors := common.ParseDialErrors(dialErr.(utils.DialError).Err.Error())
+					for _, dialError := range errors {
+						w.statusTelemetryClient.PushDialFailure(w.ctx, common.DialError{ErrType: dialError.ErrType, ErrMsg: dialError.ErrMsg, Protocols: dialError.Protocols})
+					}
 				}
 			}
 		}()
@@ -1166,7 +1187,6 @@ func (w *Waku) Start() error {
 	go w.runPeerExchangeLoop()
 
 	if w.cfg.EnableMissingMessageVerification {
-
 		w.missingMsgVerifier = missing.NewMissingMessageVerifier(
 			w.node.Store(),
 			w,
@@ -1444,6 +1464,12 @@ func (w *Waku) OnNewEnvelopes(envelope *protocol.Envelope, msgType common.Messag
 		return nil
 	}
 
+	if w.statusTelemetryClient != nil {
+		if msgType == common.MissingMessageType {
+			w.statusTelemetryClient.PushMissedMessage(w.ctx, envelope)
+		}
+	}
+
 	logger := w.logger.With(
 		zap.String("messageType", msgType),
 		zap.Stringer("envelopeHash", envelope.Hash()),
@@ -1562,6 +1588,9 @@ func (w *Waku) processMessage(e *common.ReceivedMessage) {
 		w.storeMsgIDsMu.Unlock()
 	} else {
 		logger.Debug("filters did match")
+		if w.statusTelemetryClient != nil && e.MsgType == common.MissingMessageType {
+			w.statusTelemetryClient.PushMissedRelevantMessage(w.ctx, e)
+		}
 		e.Processed.Store(true)
 	}
 


### PR DESCRIPTION
Adds metrics for missed messages, delivery confirmation, and peer count by shard/origin.

Tracks additional events in telemetry:
- when a message is successfully delivered
- when a check against a store node detects missed messages (with a separate count for if it was a message relevant to the user, as determined if the filter matches)
- when a dial to a peer fails, what kind of failure was encountered

Important changes:
- Depends on https://github.com/status-im/telemetry/pull/69

Dogfooding PR: https://github.com/status-im/status-desktop/pull/16540
