### PR TITLE
fix(tests)_: prevent crash when creating wakuv2 from multiple goroutines

### DIFF
--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -1062,6 +1062,7 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchRealCommunity() {
 
 	results := map[string]singleResult{}
 	wg := sync.WaitGroup{}
+	wakuCreationMutex := sync.Mutex{}
 
 	// We run a separate request for each node in the fleet.
 	for i, mailserver := range nodesList {
@@ -1088,8 +1089,10 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchRealCommunity() {
 				enableStore: false,
 				clusterID:   clusterID,
 			}
+			wakuCreationMutex.Lock()
 			wakuV2 := NewTestWakuV2(&s.Suite, cfg)
 			userWaku := gethbridge.NewGethWakuV2Wrapper(wakuV2)
+			wakuCreationMutex.Unlock()
 
 			//
 			// Create a messenger to process envelopes


### PR DESCRIPTION
Creating wakuv2 from multiple goroutines results in a race condition where multiple in-memory databases with the same name are attempted to be opened
