### PR TITLE
chore_: implement eth service for use in integration tests

### DIFF
--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -39,6 +39,7 @@ import (
 	"github.com/status-im/status-go/services/communitytokens"
 	"github.com/status-im/status-go/services/connector"
 	"github.com/status-im/status-go/services/ens"
+	"github.com/status-im/status-go/services/eth"
 	"github.com/status-im/status-go/services/gif"
 	localnotifications "github.com/status-im/status-go/services/local-notifications"
 	"github.com/status-im/status-go/services/mailservers"
@@ -132,6 +133,7 @@ type StatusNode struct {
 	pendingTracker         *transactions.PendingTxTracker
 	connectorSrvc          *connector.Service
 	appGeneralSrvc         *appgeneral.Service
+	ethSrvc                *eth.Service
 
 	accountsFeed event.Feed
 	walletFeed   event.Feed

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -40,6 +40,7 @@ import (
 	"github.com/status-im/status-go/services/communitytokens"
 	"github.com/status-im/status-go/services/connector"
 	"github.com/status-im/status-go/services/ens"
+	"github.com/status-im/status-go/services/eth"
 	"github.com/status-im/status-go/services/ext"
 	"github.com/status-im/status-go/services/gif"
 	localnotifications "github.com/status-im/status-go/services/local-notifications"
@@ -173,6 +174,8 @@ func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *server
 		return err
 	}
 	services = append(services, lns)
+
+	services = append(services, b.ethService())
 
 	b.peerSrvc.SetDiscoverer(b)
 
@@ -615,6 +618,13 @@ func (b *StatusNode) peerService() *peer.Service {
 		b.peerSrvc = peer.New()
 	}
 	return b.peerSrvc
+}
+
+func (b *StatusNode) ethService() *eth.Service {
+	if b.ethSrvc == nil {
+		b.ethSrvc = eth.NewService(b.rpcClient)
+	}
+	return b.ethSrvc
 }
 
 func registerWakuMailServer(wakuService *waku.Waku, config *params.WakuConfig) (err error) {

--- a/services/eth/private_api.go
+++ b/services/eth/private_api.go
@@ -1,0 +1,151 @@
+//go:build enable_private_api
+
+package eth
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	geth_rpc "github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/status-im/status-go/rpc"
+)
+
+func privateAPIs(client *rpc.Client) (apis []geth_rpc.API) {
+	return []geth_rpc.API{
+		{
+			Namespace: "ethclient",
+			Version:   "1.0",
+			Service:   NewPrivateAPI(client),
+			Public:    true,
+		},
+	}
+}
+
+type PrivateAPI struct {
+	client *rpc.Client
+}
+
+func NewPrivateAPI(client *rpc.Client) *PrivateAPI {
+	return &PrivateAPI{client: client}
+}
+
+type blockResponse struct {
+	Header       *types.Header      `json:"header"`
+	Transactions types.Transactions `json:"transactions"`
+	Withdrawals  types.Withdrawals  `json:"withdrawals"`
+}
+
+func newBlockResponse(b *types.Block) *blockResponse {
+	return &blockResponse{
+		Header:       b.Header(),
+		Transactions: b.Transactions(),
+		Withdrawals:  b.Withdrawals(),
+	}
+}
+
+func (pa *PrivateAPI) BlockByHash(ctx context.Context, chainId uint64, hash common.Hash) (*blockResponse, error) {
+	client, err := pa.client.EthClient(chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := client.BlockByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	return newBlockResponse(block), nil
+}
+
+func (pa *PrivateAPI) BlockByNumber(ctx context.Context, chainId uint64, number *hexutil.Big) (*blockResponse, error) {
+	client, err := pa.client.EthClient(chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := client.BlockByNumber(ctx, (*big.Int)(number))
+	if err != nil {
+		return nil, err
+	}
+
+	return newBlockResponse(block), nil
+}
+
+func (pa *PrivateAPI) HeaderByHash(ctx context.Context, chainId uint64, hash common.Hash) (*types.Header, error) {
+	client, err := pa.client.EthClient(chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.HeaderByHash(ctx, hash)
+}
+
+func (pa *PrivateAPI) HeaderByNumber(ctx context.Context, chainId uint64, number *hexutil.Big) (*types.Header, error) {
+	client, err := pa.client.EthClient(chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.HeaderByNumber(ctx, (*big.Int)(number))
+}
+
+type transactionByHashResponse struct {
+	Tx        *types.Transaction `json:"tx"`
+	IsPending bool               `json:"isPending"`
+}
+
+func (pa *PrivateAPI) TransactionByHash(ctx context.Context, chainId uint64, txHash common.Hash) (*transactionByHashResponse, error) {
+
+	client, err := pa.client.EthClient(chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, isPending, err := client.TransactionByHash(ctx, txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &transactionByHashResponse{
+		Tx:        tx,
+		IsPending: isPending,
+	}
+
+	return ret, nil
+}
+
+func (pa *PrivateAPI) TransactionReceipt(ctx context.Context, chainId uint64, txHash common.Hash) (*types.Receipt, error) {
+	client, err := pa.client.EthClient(chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.TransactionReceipt(ctx, txHash)
+}
+
+func (pa *PrivateAPI) SuggestGasPrice(ctx context.Context, chainId uint64) (*hexutil.Big, error) {
+	client, err := pa.client.EthClient(chainId)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, err := client.SuggestGasPrice(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return (*hexutil.Big)(ret), nil
+}
+
+func (pa *PrivateAPI) BlockNumber(ctx context.Context, chainId uint64) (uint64, error) {
+	client, err := pa.client.EthClient(chainId)
+	if err != nil {
+		return 0, err
+	}
+
+	return client.BlockNumber(ctx)
+}

--- a/services/eth/private_api_nop.go
+++ b/services/eth/private_api_nop.go
@@ -1,0 +1,12 @@
+//go:build !enable_private_api
+
+package eth
+
+import (
+	geth_rpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/status-im/status-go/rpc"
+)
+
+func privateAPIs(*rpc.Client) (apis []geth_rpc.API) {
+	return nil
+}

--- a/services/eth/service.go
+++ b/services/eth/service.go
@@ -1,0 +1,36 @@
+package eth
+
+import (
+	"github.com/ethereum/go-ethereum/p2p"
+	geth_rpc "github.com/ethereum/go-ethereum/rpc"
+
+	rpc_client "github.com/status-im/status-go/rpc"
+)
+
+type Service struct {
+	rpcClient *rpc_client.Client
+}
+
+func NewService(
+	rpcClient *rpc_client.Client,
+) *Service {
+	return &Service{
+		rpcClient: rpcClient,
+	}
+}
+
+func (s *Service) APIs() []geth_rpc.API {
+	return privateAPIs(s.rpcClient)
+}
+
+func (s *Service) Protocols() []p2p.Protocol {
+	return nil
+}
+
+func (s *Service) Start() error {
+	return nil
+}
+
+func (s *Service) Stop() error {
+	return nil
+}

--- a/tests-functional/config.json
+++ b/tests-functional/config.json
@@ -8,7 +8,7 @@
     "HTTPHost": "0.0.0.0",
     "HTTPPort": 3333,
     "HTTPVirtualHosts": ["*", "status-go"],
-    "APIModules": "eth,admin,wallet,accounts,waku,wakuext",
+    "APIModules": "eth,admin,wallet,accounts,waku,wakuext,ethclient",
     "WalletConfig": {
       "Enabled": true
     },

--- a/tests-functional/docker-compose.test.status-go.yml
+++ b/tests-functional/docker-compose.test.status-go.yml
@@ -5,7 +5,7 @@ services:
       context: ../
       dockerfile: _assets/build/Dockerfile
       args:
-        build_tags: gowaku_no_rln
+        build_tags: gowaku_no_rln,enable_private_api
         build_target: statusd
         build_flags: -cover
     entrypoint: [
@@ -37,7 +37,7 @@ services:
       context: ../
       dockerfile: _assets/build/Dockerfile
       args:
-        build_tags: gowaku_no_rln
+        build_tags: gowaku_no_rln,enable_private_api
         build_target: statusd
         build_flags: -cover
     entrypoint: [
@@ -72,7 +72,7 @@ services:
       dockerfile: Dockerfile.tests-rpc
     entrypoint: [
       "pytest",
-      "-m", "wallet",
+      "-m", "wallet or ethclient",
       "--rpc_url=http://status-go:3333",
       "--rpc_url_2=http://status-go-no-funds:3333",
       "--anvil_url=http://anvil:8545",

--- a/tests-functional/pytest.ini
+++ b/tests-functional/pytest.ini
@@ -10,3 +10,4 @@ markers =
     tx
     wakuext
     accounts
+    ethclient

--- a/tests-functional/tests/test_eth_api.py
+++ b/tests-functional/tests/test_eth_api.py
@@ -1,0 +1,53 @@
+import pytest
+from conftest import option
+from test_cases import EthApiTestCase
+
+def validateHeader(header, block_number, block_hash):
+    assert header["number"] == block_number
+    assert header["hash"] == block_hash
+
+def validateBlock(block, block_number, block_hash, expected_tx_hash):
+    validateHeader(block["header"], block_number, block_hash)
+    tx_hashes = [tx["hash"] for tx in block["transactions"]]
+    assert expected_tx_hash in tx_hashes
+
+def validateTransaction(tx, tx_hash):
+    assert tx["tx"]["hash"] == tx_hash
+
+def validateReceipt(receipt, tx_hash, block_number, block_hash):
+    assert receipt["transactionHash"] == tx_hash
+    assert receipt["blockNumber"] == block_number
+    assert receipt["blockHash"] == block_hash
+
+@pytest.mark.rpc
+@pytest.mark.ethclient
+class TestRpc(EthApiTestCase):
+    def test_block_number(self):
+        self.rpc_valid_request("ethclient_blockNumber", [self.network_id])
+
+    def test_suggest_gas_price(self):
+        self.rpc_valid_request("ethclient_suggestGasPrice", [self.network_id])
+
+    def test_header_by_number(self, tx_data):
+        response = self.rpc_valid_request("ethclient_headerByNumber", [self.network_id, tx_data.block_number])
+        validateHeader(response.json()["result"], tx_data.block_number, tx_data.block_hash)
+
+    def test_block_by_number(self, tx_data):
+        response = self.rpc_valid_request("ethclient_blockByNumber", [self.network_id, tx_data.block_number])
+        validateBlock(response.json()["result"], tx_data.block_number, tx_data.block_hash, tx_data.tx_hash)
+
+    def test_header_by_hash(self, tx_data):
+        response = self.rpc_valid_request("ethclient_headerByHash", [self.network_id, tx_data.block_hash])
+        validateHeader(response.json()["result"], tx_data.block_number, tx_data.block_hash)
+
+    def test_block_by_hash(self, tx_data):
+        response = self.rpc_valid_request("ethclient_blockByHash", [self.network_id, tx_data.block_hash])
+        validateBlock(response.json()["result"], tx_data.block_number, tx_data.block_hash, tx_data.tx_hash)
+
+    def test_transaction_by_hash(self, tx_data):
+        response = self.rpc_valid_request("ethclient_transactionByHash", [self.network_id, tx_data.tx_hash])
+        validateTransaction(response.json()["result"], tx_data.tx_hash)
+
+    def test_transaction_receipt(self, tx_data):
+        response = self.rpc_valid_request("ethclient_transactionReceipt", [self.network_id, tx_data.tx_hash])
+        validateReceipt(response.json()["result"], tx_data.tx_hash, tx_data.block_number, tx_data.block_hash)


### PR DESCRIPTION
- Implemented the `ethService`, currently with the sole purpose of exposing `rpc.Client` endpoints in the status-go API so they can be used in functional tests. These will only be available when build tag `enable_private_api` is used, which currently only happens during functional test status-go builds.
- Implemented a suite of functional tests checking valid responses for all available `ethService` endpoints.
