### PR TITLE
fix_: suggested path calculation updated when adding previously deleted key pair

### DIFF
--- a/multiaccounts/accounts/database_test.go
+++ b/multiaccounts/accounts/database_test.go
@@ -662,4 +662,16 @@ func TestResolvingSuggestedDerivationPath(t *testing.T) {
 	suggestedPath, err = db.ResolveSuggestedPathForKeypair(kp.KeyUID)
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("%s%d", statusWalletRootPath, expectedLastUsedDerivationIndex+1), suggestedPath)
+
+	// remove kaypair
+	err = db.RemoveKeypair(kp.KeyUID, 0)
+	require.NoError(t, err)
+	_, err = db.GetKeypairByKeyUID(kp.KeyUID)
+	require.Error(t, err)
+	require.True(t, err == ErrDbKeypairNotFound)
+
+	// check suggested path after removing keypair when adding the same keypair again
+	suggestedPath, err = db.ResolveSuggestedPathForKeypair(kp.KeyUID)
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("%s%d", statusWalletRootPath, 0), suggestedPath)
 }


### PR DESCRIPTION
When adding an account via seed phrase, for a key pair that was previously deleted, suggested path should start from index 0. It was not like that before, this commit fixes that.

Fixes the desktop issue https://github.com/status-im/status-desktop/issues/16380