### PR TITLE
fix_: packing data for ens release path processor fixed

### DIFF
--- a/services/wallet/router/pathprocessor/common.go
+++ b/services/wallet/router/pathprocessor/common.go
@@ -3,6 +3,7 @@ package pathprocessor
 import (
 	"fmt"
 	"math/big"
+	"strings"
 
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 
@@ -24,4 +25,11 @@ func makeKey(fromChain, toChain uint64, fromTokenSymbol, toTokenSymbol string) s
 		return fmt.Sprintf("%d-%d-%s-%s", fromChain, toChain, fromTokenSymbol, toTokenSymbol)
 	}
 	return fmt.Sprintf("%d-%d", fromChain, toChain)
+}
+
+func getNameFromEnsUsername(ensUsername string) string {
+	if strings.HasSuffix(ensUsername, StatusDomain) {
+		return ensUsername[:len(ensUsername)-len(StatusDomain)]
+	}
+	return ensUsername
 }

--- a/services/wallet/router/pathprocessor/common_test.go
+++ b/services/wallet/router/pathprocessor/common_test.go
@@ -1,0 +1,21 @@
+package pathprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGettingNameFromEnsUsername(t *testing.T) {
+	ensName := "test"
+	name := getNameFromEnsUsername(ensName)
+	require.Equal(t, ensName, name)
+
+	ensStatusName := "test.stateofus.eth"
+	name = getNameFromEnsUsername(ensStatusName)
+	require.Equal(t, ensName, name)
+
+	ensNotStatusName := "test.eth"
+	name = getNameFromEnsUsername(ensNotStatusName)
+	require.Equal(t, ensNotStatusName, name)
+}

--- a/services/wallet/router/pathprocessor/constants.go
+++ b/services/wallet/router/pathprocessor/constants.go
@@ -4,6 +4,9 @@ const (
 	IncreaseEstimatedGasFactor = 1.1
 	SevenDaysInSeconds         = 60 * 60 * 24 * 7
 
+	StatusDomain = ".stateofus.eth"
+	EthDomain    = ".eth"
+
 	EthSymbol  = "ETH"
 	SntSymbol  = "SNT"
 	SttSymbol  = "STT"

--- a/services/wallet/router/pathprocessor/processor_ens_release.go
+++ b/services/wallet/router/pathprocessor/processor_ens_release.go
@@ -57,7 +57,8 @@ func (s *ENSReleaseProcessor) PackTxInputData(params ProcessorInputParams) ([]by
 		return []byte{}, createENSReleaseErrorResponse(err)
 	}
 
-	return registrarABI.Pack("release", ens.UsernameToLabel(params.Username))
+	name := getNameFromEnsUsername(params.Username)
+	return registrarABI.Pack("release", ens.UsernameToLabel(name))
 }
 
 func (s *ENSReleaseProcessor) EstimateGas(params ProcessorInputParams) (uint64, error) {

--- a/services/wallet/router/sendtype/send_type.go
+++ b/services/wallet/router/sendtype/send_type.go
@@ -128,7 +128,7 @@ func (s SendType) ProcessZeroAmountInProcessor(amountIn *big.Int, amountOut *big
 			if amountOut.Cmp(walletCommon.ZeroBigIntValue()) == 0 {
 				return false
 			}
-		} else {
+		} else if s != ENSRelease {
 			return false
 		}
 	}


### PR DESCRIPTION
This PR fixes packing data for releasing ens name.
Changes done here do not affect mobile app, cause it doesn't use a new sending flow, neither use the router for the suggested path in case of releasing ens username.