### PR TITLE
fix(Makefile)_: generate before vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,7 @@ deep-clean: clean git-clean
 tidy:
 	go mod tidy
 
-vendor:
+vendor: generate
 	go mod tidy
 	go mod vendor
 	modvendor -copy="**/*.c **/*.h" -v


### PR DESCRIPTION
Fixing an issue introduced in https://github.com/status-im/status-go/pull/5878.
`generate` must be run before `vendor`.