### PR TITLE
fix_: don't ignore generated files in vendor/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ bindata.go
 migrations.go
 cmd/statusd/server/endpoints.go
 protocol/messenger_handlers.go
+
+# Don't ignore generated files in the vendor/ directory
+!vendor/**/*.pb.go
+!vendor/**/migrations.go


### PR DESCRIPTION
This avoids compilation issues like those happening in https://github.com/status-im/status-go/pull/5909
(i.e. go-libp2p and go-waku do include generated files).
