### PR TITLE
fix_: zero value update to be a value, not a function pointer

### DIFF
--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -544,7 +544,7 @@ func (h *HopBridgeProcessor) packL1BridgeTx(abi abi.ABI, toChainID uint64, to co
 		bonderFee.AmountOutMin.Int,
 		big.NewInt(bonderFee.Deadline),
 		common.Address{},
-		walletCommon.ZeroBigIntValue)
+		walletCommon.ZeroBigIntValue())
 }
 
 func (h *HopBridgeProcessor) sendL1BridgeTx(contractAddress common.Address, ethClient chain.ClientInterface, toChainID uint64,


### PR DESCRIPTION
When a change was made, guarding a possibility for unintentional update of a big int zero value and we moved to return it via function, at this line `()` were missed and function pointer was passed to the `api.Pack` function instead of real value.

Fixes https://github.com/status-im/status-mobile/issues/21385