### PR TITLE
fix(statusd)_: proper db initialization for imported accounts

### DIFF
--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -251,15 +251,9 @@ func main() {
 			return
 		}
 
-		appDB, walletDB, err := openDatabases(config.DataDir + "/" + installationID.String())
-		if err != nil {
-			log.Error("failed to open databases")
-			return
-		}
-
 		options := []protocol.Option{
-			protocol.WithDatabase(appDB),
-			protocol.WithWalletDatabase(walletDB),
+			protocol.WithDatabase(backend.StatusNode().GetAppDB()),
+			protocol.WithWalletDatabase(backend.StatusNode().GetWalletDB()),
 			protocol.WithTorrentConfig(&config.TorrentConfig),
 			protocol.WithWalletConfig(&config.WalletConfig),
 			protocol.WithAccountManager(backend.AccountManager()),

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -690,10 +690,18 @@ func (n *StatusNode) SetAppDB(db *sql.DB) {
 	n.appDB = db
 }
 
+func (n *StatusNode) GetAppDB() *sql.DB {
+	return n.appDB
+}
+
 func (n *StatusNode) SetMultiaccountsDB(db *multiaccounts.Database) {
 	n.multiaccountsDB = db
 }
 
 func (n *StatusNode) SetWalletDB(db *sql.DB) {
 	n.walletDB = db
+}
+
+func (n *StatusNode) GetWalletDB() *sql.DB {
+	return n.walletDB
 }


### PR DESCRIPTION
When importing an account with a seedphrase, statusd was using a weird mixture of
- the encrypted DB for the given account using the given password (set when calling `backend.RestoreAccountAndLogin(&request)`)
- the default unencrypted DB (set when calling `openDatabases(config.DataDir + "/" + installationID.String())`)

Since DBs are initialized when restoring the account, we use those same DB instances for the following steps.

With this fix, statusd generates a single set of DB files matching the imported account:
![image](https://github.com/user-attachments/assets/8e3bfef4-1cb0-4f1c-87a6-c3c8f501961c)

