### PR TITLE
fix(communities)_: ensure community ID is populated with description

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -1627,6 +1627,12 @@ func (o *Community) marshaledDescription() ([]byte, error) {
 		}
 	}
 
+	// Ensure that communities created prior to the introduction of tokenized ownership
+	// propagate community ID through the description.
+	if len(clone.ID) == 0 {
+		clone.ID = o.IDString()
+	}
+
 	return proto.Marshal(clone)
 }
 


### PR DESCRIPTION
Ensure that communities created prior to the introduction of tokenized ownership propagate community ID through the description.

fixes: status-im/status-desktop#16226
