### PR TITLE
fix_: chats and message history loading after login takes too much time

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -2001,6 +2001,12 @@ func (m *Manager) EditChatFirstMessageTimestamp(communityID types.HexBytes, chat
 	return community, changes, nil
 }
 
+func (m *Manager) UpdateChatFirstMessageTimestamp(community *Community, chatID string, timestamp uint32) (*CommunityChanges, error) {
+	communityID := community.ID().String()
+	chatID = strings.TrimPrefix(chatID, communityID)
+	return community.UpdateChatFirstMessageTimestamp(chatID, timestamp)
+}
+
 func (m *Manager) ReorderCategories(request *requests.ReorderCommunityCategories) (*Community, *CommunityChanges, error) {
 	m.communityLock.Lock(request.CommunityID)
 	defer m.communityLock.Unlock(request.CommunityID)
@@ -4428,6 +4434,10 @@ func (m *Manager) accountsHasPrivilegedPermission(preParsedCommunityPermissionDa
 		return permissionResponse.Satisfied
 	}
 	return false
+}
+
+func (m *Manager) SaveAndPublish(community *Community) error {
+	return m.saveAndPublish(community)
 }
 
 func (m *Manager) saveAndPublish(community *Community) error {

--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -1310,7 +1310,7 @@ func (db sqlitePersistence) OldestMessageWhisperTimestampByChatIDs(chatIDs []str
 		return nil, nil
 	}
 
-	args := make([]interface{}, len(chatIDs))
+	args := make([]any, len(chatIDs))
 	for i, id := range chatIDs {
 		args[i] = id
 	}
@@ -1346,6 +1346,9 @@ func (db sqlitePersistence) OldestMessageWhisperTimestampByChatIDs(chatIDs []str
 			return nil, err
 		}
 		result[chatID] = whisperTimestamp
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return result, nil

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1859,17 +1859,18 @@ func (m *Messenger) InitFilters() error {
 	}
 
 	communityInfo := make(map[string]*communities.Community)
+	var validChats []*Chat
 	for _, chat := range chats {
 		if err := chat.Validate(); err != nil {
 			logger.Warn("failed to validate chat", zap.Error(err))
 			continue
 		}
+		validChats = append(validChats, chat)
+	}
 
-		if err = m.initChatFirstMessageTimestamp(chat); err != nil {
-			logger.Warn("failed to init first message timestamp", zap.Error(err))
-			continue
-		}
+	m.initChatsFirstMessageTimestamp(communityInfo, validChats)
 
+	for _, chat := range validChats {
 		if !chat.Active || chat.Timeline() {
 			m.allChats.Store(chat.ID, chat)
 			continue
@@ -2043,24 +2044,70 @@ func (m *Messenger) Mailservers() ([]string, error) {
 	return nil, ErrNotImplemented
 }
 
-func (m *Messenger) initChatFirstMessageTimestamp(chat *Chat) error {
-	if !chat.CommunityChat() || chat.FirstMessageTimestamp != FirstMessageTimestampUndefined {
-		return nil
+func (m *Messenger) initChatsFirstMessageTimestamp(communityCache map[string]*communities.Community, chats []*Chat) {
+	var communityChats []*Chat
+	var communityChatIDs []string
+	for _, chat := range chats {
+		if !chat.CommunityChat() || chat.FirstMessageTimestamp != FirstMessageTimestampUndefined {
+			continue
+		}
+		communityChats = append(communityChats, chat)
+		communityChatIDs = append(communityChatIDs, chat.ID)
+	}
+	if len(communityChatIDs) == 0 {
+		return
 	}
 
-	oldestMessageTimestamp, hasAnyMessage, err := m.persistence.OldestMessageWhisperTimestampByChatID(chat.ID)
+	oldestMessageTimestamps, err := m.persistence.OldestMessageWhisperTimestampByChatIDs(communityChatIDs)
 	if err != nil {
-		return err
+		m.logger.Warn("failed to get oldest message timestamps", zap.Error(err))
+		return
 	}
 
-	if hasAnyMessage {
-		if oldestMessageTimestamp == FirstMessageTimestampUndefined {
+	getCommunity := func(communityID string) *communities.Community {
+		community, ok := communityCache[communityID]
+		if ok {
+			return community
+		}
+		community, err := m.communitiesManager.GetByIDString(communityID)
+		if err != nil {
+			m.logger.Warn("failed to get community", zap.Error(err), zap.String("communityID", communityID))
 			return nil
 		}
-		return m.updateChatFirstMessageTimestamp(chat, whisperToUnixTimestamp(oldestMessageTimestamp), &MessengerResponse{})
+		communityCache[communityID] = community
+		return community
 	}
 
-	return m.updateChatFirstMessageTimestamp(chat, FirstMessageTimestampNoMessage, &MessengerResponse{})
+	var changedCommunities []*communities.Community
+	for _, chat := range communityChats {
+		community := getCommunity(chat.CommunityID)
+		if community == nil {
+			continue
+		}
+
+		oldestMessageTimestamp, ok := oldestMessageTimestamps[chat.ID]
+		timestamp := uint32(FirstMessageTimestampNoMessage)
+		if ok {
+			if oldestMessageTimestamp == FirstMessageTimestampUndefined {
+				continue
+			}
+			timestamp = whisperToUnixTimestamp(oldestMessageTimestamp)
+		}
+
+		changes, err := m.updateChatFirstMessageTimestampForCommunity(chat, timestamp, community)
+		if err != nil {
+			m.logger.Warn("failed to init first message timestamp", zap.Error(err), zap.String("chatID", chat.ID))
+		} else if changes != nil {
+			changedCommunities = append(changedCommunities, community)
+		}
+	}
+
+	for _, community := range changedCommunities {
+		err := m.communitiesManager.SaveAndPublish(community)
+		if err != nil {
+			m.logger.Warn("failed to save and publish community", zap.Error(err), zap.String("communityID", community.IDString()))
+		}
+	}
 }
 
 func (m *Messenger) addMessagesAndChat(chat *Chat, messages []*common.Message, response *MessengerResponse) (*MessengerResponse, error) {
@@ -2555,6 +2602,13 @@ func (m *Messenger) updateChatFirstMessageTimestamp(chat *Chat, timestamp uint32
 	}
 
 	return nil
+}
+
+func (m *Messenger) updateChatFirstMessageTimestampForCommunity(chat *Chat, timestamp uint32, community *communities.Community) (*communities.CommunityChanges, error) {
+	if community.IsControlNode() && chat.UpdateFirstMessageTimestamp(timestamp) {
+		return m.communitiesManager.UpdateChatFirstMessageTimestamp(community, chat.ID, chat.FirstMessageTimestamp)
+	}
+	return nil, nil
 }
 
 func (m *Messenger) ShareImageMessage(request *requests.ShareImageMessage) (*MessengerResponse, error) {

--- a/protocol/persistence_test.go
+++ b/protocol/persistence_test.go
@@ -322,15 +322,15 @@ func TestLatestMessageByChatID(t *testing.T) {
 	require.Equal(t, m[0].ID, ids[9])
 }
 
-func TestOldestMessageWhisperTimestampByChatID(t *testing.T) {
+func TestOldestMessageWhisperTimestampByChatIDs(t *testing.T) {
 	db, err := openTestDB()
 	require.NoError(t, err)
 	p := newSQLitePersistence(db)
 	chatID := testPublicChatID
 
-	_, hasMessage, err := p.OldestMessageWhisperTimestampByChatID(chatID)
+	timestamps, err := p.OldestMessageWhisperTimestampByChatIDs([]string{chatID})
 	require.NoError(t, err)
-	require.False(t, hasMessage)
+	require.Equal(t, 0, len(timestamps))
 
 	var messages []*common.Message
 	for i := 0; i < 10; i++ {
@@ -348,10 +348,10 @@ func TestOldestMessageWhisperTimestampByChatID(t *testing.T) {
 	err = p.SaveMessages(messages)
 	require.NoError(t, err)
 
-	timestamp, hasMessage, err := p.OldestMessageWhisperTimestampByChatID(chatID)
+	timestamps, err = p.OldestMessageWhisperTimestampByChatIDs([]string{chatID})
 	require.NoError(t, err)
-	require.True(t, hasMessage)
-	require.Equal(t, uint64(10), timestamp)
+	require.Equal(t, 1, len(timestamps))
+	require.Equal(t, uint64(10), timestamps[chatID])
 }
 
 func TestPinMessageByChatID(t *testing.T) {


### PR DESCRIPTION
The status community has around 60 chats. Each chat costs `initChatFirstMessageTimestamp` around 120 ms in my ios simulator, so there is around an 8-second delay for `InitFilters`. The major cause is db io consumption. To reduce this, I combined all the chat parameters into one db query and made a simple cache for community queries. Also, I call save community only once for each community. Now the delay for `InitFilters` is reduced to around 800 ms. `initChatFirstMessageTimestamp` took around 251 ms

fix mobile [issue](https://github.com/status-im/status-mobile/issues/21358)
