### PR TITLE
chore(wallet)_: remove unused upstream client

### DIFF
--- a/api/defaults.go
+++ b/api/defaults.go
@@ -288,16 +288,6 @@ func DefaultNodeConfig(installationID string, request *requests.CreateAccount, o
 		nodeConfig.NetworkID = nodeConfig.Networks[0].ChainID
 	}
 
-	if request.UpstreamConfig != "" {
-		nodeConfig.UpstreamConfig = params.UpstreamRPCConfig{
-			Enabled: true,
-			URL:     request.UpstreamConfig,
-		}
-	} else {
-		nodeConfig.UpstreamConfig.URL = mainnet(request.WalletSecretsConfig.StatusProxyStageName).RPCURL
-		nodeConfig.UpstreamConfig.Enabled = true
-	}
-
 	nodeConfig.Name = DefaultNodeName
 	nodeConfig.NoDiscovery = true
 	nodeConfig.MaxPeers = DefaultMaxPeers

--- a/appdatabase/migrations/sql/1728661600_drop_upstream_config.up.sql
+++ b/appdatabase/migrations/sql/1728661600_drop_upstream_config.up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS upstream_config;

--- a/appdatabase/node_config_test.go
+++ b/appdatabase/node_config_test.go
@@ -167,7 +167,6 @@ func randomNodeConfig() *params.NodeConfig {
 		LogMaxSize:                randomInt(math.MaxInt64),
 		LogCompressRotated:        randomBool(),
 		LogToStderr:               randomBool(),
-		UpstreamConfig:            params.UpstreamRPCConfig{Enabled: randomBool(), URL: randomString()},
 		ClusterConfig: params.ClusterConfig{
 			Enabled:     randomBool(),
 			Fleet:       randomString(),

--- a/cmd/ping-community/main.go
+++ b/cmd/ping-community/main.go
@@ -345,10 +345,6 @@ func defaultNodeConfig(installationID string) (*params.NodeConfig, error) {
 	nodeConfig.NetworkID = 1
 	nodeConfig.LogLevel = "ERROR"
 	nodeConfig.DataDir = api.DefaultDataDir
-	nodeConfig.UpstreamConfig = params.UpstreamRPCConfig{
-		Enabled: true,
-		URL:     "https://mainnet.infura.io/v3/800c641949d64d768a5070a1b0511938",
-	}
 
 	nodeConfig.Name = "StatusIM"
 	clusterConfig, err := params.LoadClusterConfigFromFleet("eth.prod")

--- a/cmd/populate-db/main.go
+++ b/cmd/populate-db/main.go
@@ -393,10 +393,6 @@ func defaultNodeConfig(installationID string) (*params.NodeConfig, error) {
 	nodeConfig.NetworkID = 1
 	nodeConfig.LogLevel = "ERROR"
 	nodeConfig.DataDir = api.DefaultDataDir
-	nodeConfig.UpstreamConfig = params.UpstreamRPCConfig{
-		Enabled: true,
-		URL:     "https://mainnet.infura.io/v3/800c641949d64d768a5070a1b0511938",
-	}
 
 	nodeConfig.Name = "StatusIM"
 	clusterConfig, err := params.LoadClusterConfigFromFleet("eth.prod")

--- a/cmd/spiff-workflow/main.go
+++ b/cmd/spiff-workflow/main.go
@@ -302,11 +302,6 @@ func defaultNodeConfig(installationID string) (*params.NodeConfig, error) {
 	// Disable to avoid errors about empty ClusterConfig.BootNodes.
 	nodeConfig.NoDiscovery = true
 
-	nodeConfig.UpstreamConfig = params.UpstreamRPCConfig{
-		Enabled: true,
-		URL:     "https://mainnet.infura.io/v3/800c641949d64d768a5070a1b0511938",
-	}
-
 	nodeConfig.Name = "StatusIM"
 	clusterConfig, err := params.LoadClusterConfigFromFleet("status.prod")
 	if err != nil {

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -331,7 +331,7 @@ func (n *StatusNode) setupRPCClient() (err error) {
 		},
 	}
 
-	n.rpcClient, err = rpc.NewClient(gethNodeClient, n.config.NetworkID, n.config.UpstreamConfig, n.config.Networks, n.appDB, providerConfigs)
+	n.rpcClient, err = rpc.NewClient(gethNodeClient, n.config.NetworkID, n.config.Networks, n.appDB, providerConfigs)
 	if err != nil {
 		return
 	}

--- a/node/status_node_rpc_client_test.go
+++ b/node/status_node_rpc_client_test.go
@@ -121,9 +121,6 @@ func TestNodeRPCClientCallOnlyPublicAPIs(t *testing.T) {
 
 	statusNode, err := createAndStartStatusNode(&params.NodeConfig{
 		APIModules: "", // no whitelisted API modules; use only public APIs
-		UpstreamConfig: params.UpstreamRPCConfig{
-			URL:     "https://infura.io",
-			Enabled: true},
 		WakuConfig: params.WakuConfig{
 			Enabled: true,
 		},

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -84,7 +84,7 @@ func (b *StatusNode) initServices(config *params.NodeConfig, mediaServer *server
 	setSettingsNotifier(accDB, settingsFeed)
 
 	services := []common.StatusService{}
-	services = appendIf(config.UpstreamConfig.Enabled, services, b.rpcFiltersService())
+	services = append(services, b.rpcFiltersService())
 	services = append(services, b.subscriptionService())
 	services = append(services, b.rpcStatsService())
 	services = append(services, b.appmetricsService())

--- a/nodecfg/node_config.go
+++ b/nodecfg/node_config.go
@@ -151,11 +151,6 @@ func insertClusterConfig(tx *sql.Tx, c *params.NodeConfig) error {
 	return err
 }
 
-func insertUpstreamConfig(tx *sql.Tx, c *params.NodeConfig) error {
-	_, err := tx.Exec(`INSERT OR REPLACE INTO upstream_config (enabled, url, synthetic_id) VALUES (?, ?, 'id')`, c.UpstreamConfig.Enabled, c.UpstreamConfig.URL)
-	return err
-}
-
 func insertLightETHConfig(tx *sql.Tx, c *params.NodeConfig) error {
 	_, err := tx.Exec(`INSERT OR REPLACE INTO light_eth_config (enabled, database_cache, min_trusted_fraction, synthetic_id) VALUES (?, ?, ?, 'id')`, c.LightEthConfig.Enabled, c.LightEthConfig.DatabaseCache, c.LightEthConfig.MinTrustedFraction)
 	return err
@@ -336,7 +331,6 @@ func nodeConfigUpgradeInserts() []insertFn {
 		insertHTTPConfig,
 		insertIPCConfig,
 		insertLogConfig,
-		insertUpstreamConfig,
 		insertClusterConfig,
 		insertClusterConfigNodes,
 		insertLightETHConfig,
@@ -360,7 +354,6 @@ func nodeConfigNormalInserts() []insertFn {
 		insertHTTPConfig,
 		insertIPCConfig,
 		insertLogConfig,
-		insertUpstreamConfig,
 		insertClusterConfig,
 		insertClusterConfigNodes,
 		insertLightETHConfig,
@@ -497,11 +490,6 @@ func loadNodeConfig(tx *sql.Tx) (*params.NodeConfig, error) {
 
 	err = tx.QueryRow("SELECT enabled, mobile_system, log_dir, log_level, file, max_backups, max_size, compress_rotated, log_to_stderr FROM log_config WHERE synthetic_id = 'id'").Scan(
 		&nodecfg.LogEnabled, &nodecfg.LogMobileSystem, &nodecfg.LogDir, &nodecfg.LogLevel, &nodecfg.LogFile, &nodecfg.LogMaxBackups, &nodecfg.LogMaxSize, &nodecfg.LogCompressRotated, &nodecfg.LogToStderr)
-	if err != nil && err != sql.ErrNoRows {
-		return nil, err
-	}
-
-	err = tx.QueryRow("SELECT enabled, url FROM upstream_config WHERE synthetic_id = 'id'").Scan(&nodecfg.UpstreamConfig.Enabled, &nodecfg.UpstreamConfig.URL)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, err
 	}

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -166,21 +166,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Error: "NodeKey is invalid",
 		},
 		{
-			Name: "Validate that UpstreamConfig.URL is validated if UpstreamConfig is enabled",
-			Config: `{
-				"NetworkId": 1,
-				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
-				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
-				"NoDiscovery": true,
-				"UpstreamConfig": {
-					"Enabled": true,
-					"URL": "[bad.url]"
-				}
-			}`,
-			Error: "'[bad.url]' is invalid",
-		},
-		{
 			Name: "Validate that UpstreamConfig.URL is not validated if UpstreamConfig is disabled",
 			Config: `{
 				"NetworkId": 1,

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -377,10 +377,9 @@ func (c *Client) CallContextIgnoringLocalHandlers(ctx context.Context, result in
 
 	if c.router.routeRemote(method) {
 		client, err := c.getClientUsingCache(chainID)
-		if err != nil {
-			return err
+		if err == nil {
+			return client.CallContext(ctx, result, method, args...)
 		}
-		return client.CallContext(ctx, result, method, args...)
 	}
 
 	if c.local == nil {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -377,9 +377,10 @@ func (c *Client) CallContextIgnoringLocalHandlers(ctx context.Context, result in
 
 	if c.router.routeRemote(method) {
 		client, err := c.getClientUsingCache(chainID)
-		if err == nil {
-			return client.CallContext(ctx, result, method, args...)
+		if err != nil {
+			return err
 		}
+		return client.CallContext(ctx, result, method, args...)
 	}
 
 	if c.local == nil {

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -44,7 +44,7 @@ func TestBlockedRoutesCall(t *testing.T) {
 	gethRPCClient, err := gethrpc.Dial(ts.URL)
 	require.NoError(t, err)
 
-	c, err := NewClient(gethRPCClient, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
+	c, err := NewClient(gethRPCClient, 1, []params.Network{}, db, nil)
 	require.NoError(t, err)
 
 	for _, m := range blockedMethods {
@@ -83,7 +83,7 @@ func TestBlockedRoutesRawCall(t *testing.T) {
 	gethRPCClient, err := gethrpc.Dial(ts.URL)
 	require.NoError(t, err)
 
-	c, err := NewClient(gethRPCClient, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
+	c, err := NewClient(gethRPCClient, 1, []params.Network{}, db, nil)
 	require.NoError(t, err)
 
 	for _, m := range blockedMethods {
@@ -95,47 +95,6 @@ func TestBlockedRoutesRawCall(t *testing.T) {
 		}`, m))
 		require.Contains(t, rawResult, fmt.Sprintf(`{"code":-32700,"message":"%s"}`, ErrMethodNotFound))
 	}
-}
-
-func TestUpdateUpstreamURL(t *testing.T) {
-	db, close := setupTestNetworkDB(t)
-	defer close()
-
-	ts := createTestServer("")
-	defer ts.Close()
-
-	updatedUpstreamTs := createTestServer("")
-	defer updatedUpstreamTs.Close()
-
-	gethRPCClient, err := gethrpc.Dial(ts.URL)
-	require.NoError(t, err)
-
-	c, err := NewClient(gethRPCClient, 1, params.UpstreamRPCConfig{Enabled: true, URL: ts.URL}, []params.Network{}, db, nil)
-	require.NoError(t, err)
-	require.Equal(t, ts.URL, c.upstreamURL)
-
-	// cache the original upstream client
-	originalUpstreamClient := c.upstream
-
-	err = c.UpdateUpstreamURL(updatedUpstreamTs.URL)
-	require.NoError(t, err)
-	// the upstream cleint instance should change
-	require.NotEqual(t, originalUpstreamClient, c.upstream)
-	require.Equal(t, updatedUpstreamTs.URL, c.upstreamURL)
-}
-
-func createTestServer(resp string) *httptest.Server {
-	if resp == "" {
-		resp = `{
-			"id": 1,
-			"jsonrpc": "2.0",
-			"result": "0x234234e22b9ffc2387e18636e0534534a3d0c56b0243567432453264c16e78a2adc"
-		}`
-	}
-
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, resp)
-	}))
 }
 
 func TestGetClientsUsingCache(t *testing.T) {
@@ -183,7 +142,7 @@ func TestGetClientsUsingCache(t *testing.T) {
 			DefaultFallbackURL2: server.URL + path3,
 		},
 	}
-	c, err := NewClient(nil, 1, params.UpstreamRPCConfig{}, networks, db, providerConfigs)
+	c, err := NewClient(nil, 1, networks, db, providerConfigs)
 	require.NoError(t, err)
 
 	// Networks from DB must pick up DefaultRPCURL, DefaultFallbackURL, DefaultFallbackURL2

--- a/rpc/verif_proxy_test.go
+++ b/rpc/verif_proxy_test.go
@@ -48,7 +48,7 @@ func (s *ProxySuite) startRpcClient(infuraURL string) *Client {
 
 	db, close := setupTestNetworkDB(s.T())
 	defer close()
-	c, err := NewClient(gethRPCClient, 1, params.UpstreamRPCConfig{Enabled: true, URL: infuraURL}, []params.Network{}, db)
+	c, err := NewClient(gethRPCClient, 1, []params.Network{}, db)
 	require.NoError(s.T(), err)
 
 	return c

--- a/services/ens/api_test.go
+++ b/services/ens/api_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/status-im/status-go/appdatabase"
-	"github.com/status-im/status-go/params"
 	statusRPC "github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/t/utils"
@@ -28,19 +27,13 @@ func createDB(t *testing.T) (*sql.DB, func()) {
 func setupTestAPI(t *testing.T) (*API, func()) {
 	db, cancel := createDB(t)
 
-	// Creating a dummy status node to simulate what it's done in get_status_node.go
-	upstreamConfig := params.UpstreamRPCConfig{
-		URL:     "https://mainnet.infura.io/v3/800c641949d64d768a5070a1b0511938",
-		Enabled: true,
-	}
-
 	txServiceMockCtrl := gomock.NewController(t)
 	server, _ := fake.NewTestServer(txServiceMockCtrl)
 	client := gethrpc.DialInProc(server)
 
 	_ = client
 
-	rpcClient, err := statusRPC.NewClient(nil, 1, upstreamConfig, nil, db, nil)
+	rpcClient, err := statusRPC.NewClient(nil, 1, nil, db, nil)
 	require.NoError(t, err)
 
 	// import account keys

--- a/services/wallet/api_test.go
+++ b/services/wallet/api_test.go
@@ -144,7 +144,7 @@ func TestAPI_GetAddressDetails(t *testing.T) {
 			DefaultFallbackURL: serverWith1SecDelay.URL,
 		},
 	}
-	c, err := rpc.NewClient(nil, chainID, params.UpstreamRPCConfig{}, networks, appDB, providerConfigs)
+	c, err := rpc.NewClient(nil, chainID, networks, appDB, providerConfigs)
 	require.NoError(t, err)
 
 	chainClient, err := c.EthClient(chainID)

--- a/services/wallet/history/service_test.go
+++ b/services/wallet/history/service_test.go
@@ -17,7 +17,6 @@ import (
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/multiaccounts/accounts"
-	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
 	"github.com/status-im/status-go/t/helpers"
@@ -405,7 +404,7 @@ func Test_removeBalanceHistoryOnEventAccountRemoved(t *testing.T) {
 	txServiceMockCtrl := gomock.NewController(t)
 	server, _ := fake.NewTestServer(txServiceMockCtrl)
 	client := gethrpc.DialInProc(server)
-	rpcClient, _ := rpc.NewClient(client, chainID, params.UpstreamRPCConfig{}, nil, appDB, nil)
+	rpcClient, _ := rpc.NewClient(client, chainID, nil, appDB, nil)
 	rpcClient.UpstreamChainID = chainID
 
 	service := NewService(walletDB, accountsDB, &accountFeed, &walletFeed, rpcClient, nil, nil, nil)

--- a/services/wallet/router/router_test.go
+++ b/services/wallet/router/router_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/status-im/status-go/appdatabase"
-	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/services/wallet/responses"
 	"github.com/status-im/status-go/services/wallet/router/pathprocessor"
@@ -92,7 +91,7 @@ func setupTestNetworkDB(t *testing.T) (*sql.DB, func()) {
 func setupRouter(t *testing.T) (*Router, func()) {
 	db, cleanTmpDb := setupTestNetworkDB(t)
 
-	client, _ := rpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, defaultNetworks, db, nil)
+	client, _ := rpc.NewClient(nil, 1, defaultNetworks, db, nil)
 
 	router := NewRouter(client, nil, nil, nil, nil, nil, nil, nil)
 

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -331,7 +331,7 @@ func Test_removeTokenBalanceOnEventAccountRemoved(t *testing.T) {
 	txServiceMockCtrl := gomock.NewController(t)
 	server, _ := fake.NewTestServer(txServiceMockCtrl)
 	client := gethrpc.DialInProc(server)
-	rpcClient, _ := rpc.NewClient(client, chainID, params.UpstreamRPCConfig{}, nil, appDB, nil)
+	rpcClient, _ := rpc.NewClient(client, chainID, nil, appDB, nil)
 	rpcClient.UpstreamChainID = chainID
 	nm := network.NewManager(appDB)
 	mediaServer, err := mediaserver.NewMediaServer(appDB, nil, nil, walletDB)

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -1079,7 +1079,7 @@ func setupFindBlocksCommand(t *testing.T, accountAddress common.Address, fromBlo
 
 		return nil
 	}
-	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
+	client, _ := statusRpc.NewClient(nil, 1, []params.Network{}, db, nil)
 	client.SetClient(tc.NetworkID(), tc)
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 	tokenManager.SetTokens([]*token.Token{
@@ -1342,7 +1342,7 @@ func TestFetchTransfersForLoadedBlocks(t *testing.T) {
 		currentBlock:           100,
 	}
 
-	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
+	client, _ := statusRpc.NewClient(nil, 1, []params.Network{}, db, nil)
 	client.SetClient(tc.NetworkID(), tc)
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
@@ -1466,7 +1466,7 @@ func TestFetchNewBlocksCommand_findBlocksWithEthTransfers(t *testing.T) {
 			currentBlock:           100,
 		}
 
-		client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
+		client, _ := statusRpc.NewClient(nil, 1, []params.Network{}, db, nil)
 		client.SetClient(tc.NetworkID(), tc)
 		tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
@@ -1546,7 +1546,7 @@ func TestFetchNewBlocksCommand_nonceDetection(t *testing.T) {
 	mediaServer, err := server.NewMediaServer(appdb, nil, nil, db)
 	require.NoError(t, err)
 
-	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
+	client, _ := statusRpc.NewClient(nil, 1, []params.Network{}, db, nil)
 	client.SetClient(tc.NetworkID(), tc)
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
@@ -1660,7 +1660,7 @@ func TestFetchNewBlocksCommand(t *testing.T) {
 	}
 	//tc.printPreparedData = true
 
-	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
+	client, _ := statusRpc.NewClient(nil, 1, []params.Network{}, db, nil)
 	client.SetClient(tc.NetworkID(), tc)
 
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
@@ -1799,7 +1799,7 @@ func TestLoadBlocksAndTransfersCommand_FiniteFinishedInfiniteRunning(t *testing.
 	db, err := helpers.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
 	require.NoError(t, err)
 
-	client, _ := statusRpc.NewClient(nil, 1, params.UpstreamRPCConfig{Enabled: false, URL: ""}, []params.Network{}, db, nil)
+	client, _ := statusRpc.NewClient(nil, 1, []params.Network{}, db, nil)
 	maker, _ := contracts.NewContractMaker(client)
 
 	wdb := NewDB(db)

--- a/services/web3provider/api_test.go
+++ b/services/web3provider/api_test.go
@@ -35,17 +35,11 @@ func setupTestAPI(t *testing.T) (*API, func()) {
 
 	keyStoreDir := t.TempDir()
 
-	// Creating a dummy status node to simulate what it's done in get_status_node.go
-	upstreamConfig := params.UpstreamRPCConfig{
-		URL:     "https://mainnet.infura.io/v3/800c641949d64d768a5070a1b0511938",
-		Enabled: true,
-	}
-
 	txServiceMockCtrl := gomock.NewController(t)
 	server, _ := fake.NewTestServer(txServiceMockCtrl)
 	client := gethrpc.DialInProc(server)
 
-	rpcClient, err := statusRPC.NewClient(client, 1, upstreamConfig, nil, db, nil)
+	rpcClient, err := statusRPC.NewClient(client, 1, nil, db, nil)
 	require.NoError(t, err)
 
 	// import account keys

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -56,7 +56,7 @@ func (s *TransactorSuite) SetupTest() {
 	chainID := gethparams.AllEthashProtocolChanges.ChainID.Uint64()
 	db, err := sqlite.OpenUnecryptedDB(sqlite.InMemoryPath) // dummy to make rpc.Client happy
 	s.Require().NoError(err)
-	rpcClient, _ := rpc.NewClient(s.client, chainID, params.UpstreamRPCConfig{}, nil, db, nil)
+	rpcClient, _ := rpc.NewClient(s.client, chainID, nil, db, nil)
 	rpcClient.UpstreamChainID = chainID
 	nodeConfig, err := utils.MakeTestNodeConfigWithDataDir("", "/tmp", chainID)
 	s.Require().NoError(err)

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/status-im/status-go/rpc/chain"
+	"github.com/status-im/status-go/rpc/chain/ethclient"
+	"github.com/status-im/status-go/rpc/chain/rpclimiter"
+
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 
@@ -58,6 +62,13 @@ func (s *TransactorSuite) SetupTest() {
 	s.Require().NoError(err)
 	rpcClient, _ := rpc.NewClient(s.client, chainID, nil, db, nil)
 	rpcClient.UpstreamChainID = chainID
+
+	ethClients := []ethclient.RPSLimitedEthClientInterface{
+		ethclient.NewRPSLimitedEthClient(s.client, rpclimiter.NewRPCRpsLimiter(), "local-1-chain-id-1"),
+	}
+	localClient := chain.NewClient(ethClients, chainID)
+	rpcClient.SetClient(chainID, localClient)
+
 	nodeConfig, err := utils.MakeTestNodeConfigWithDataDir("", "/tmp", chainID)
 	s.Require().NoError(err)
 	s.nodeConfig = nodeConfig


### PR DESCRIPTION
Upstream RPC provider is no longer used. And breaks health monitoring logic

**Further improvements:**
Remove route.go, as upstream enabled is always false: https://github.com/status-im/status-go/issues/5937


Closes #5933