### PR TITLE
feat: testing discovery and dialing with nwaku integration

### DIFF
--- a/wakuv2/api.go
+++ b/wakuv2/api.go
@@ -18,7 +18,8 @@
 
 package wakuv2
 
-/* import (
+/* TODO-nwaku
+import (
 	"context"
 	"crypto/ecdsa"
 	"errors"

--- a/wakuv2/api.go
+++ b/wakuv2/api.go
@@ -18,27 +18,7 @@
 
 package wakuv2
 
-import (
-	"context"
-	"crypto/ecdsa"
-	"errors"
-	"fmt"
-	"sync"
-	"time"
-
-	"github.com/waku-org/go-waku/waku/v2/payload"
-	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
-
-	"github.com/status-im/status-go/wakuv2/common"
-
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/rpc"
-
-	"google.golang.org/protobuf/proto"
-)
-
+/*
 // List of errors
 var (
 	ErrSymAsym              = errors.New("specify either a symmetric or an asymmetric key")
@@ -513,4 +493,4 @@ func (api *PublicWakuAPI) NewMessageFilter(req Criteria) (string, error) {
 	api.mu.Unlock()
 
 	return id, nil
-}
+} */

--- a/wakuv2/api.go
+++ b/wakuv2/api.go
@@ -18,7 +18,27 @@
 
 package wakuv2
 
-/*
+/* import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/waku-org/go-waku/waku/v2/payload"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+
+	"github.com/status-im/status-go/wakuv2/common"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"google.golang.org/protobuf/proto"
+)
+
 // List of errors
 var (
 	ErrSymAsym              = errors.New("specify either a symmetric or an asymmetric key")

--- a/wakuv2/api_test.go
+++ b/wakuv2/api_test.go
@@ -18,7 +18,16 @@
 
 package wakuv2
 
-/* func TestMultipleTopicCopyInNewMessageFilter(t *testing.T) {
+/* import (
+	"testing"
+	"time"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/status-im/status-go/wakuv2/common"
+)
+
+func TestMultipleTopicCopyInNewMessageFilter(t *testing.T) {
 	w, err := New(nil, "", nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Error creating WakuV2 client: %v", err)
@@ -58,5 +67,4 @@ package wakuv2
 	if !found {
 		t.Fatalf("Could not find filter with both topics")
 	}
-}
-*/
+} */

--- a/wakuv2/api_test.go
+++ b/wakuv2/api_test.go
@@ -18,7 +18,8 @@
 
 package wakuv2
 
-/* import (
+/* TODO-nwaku
+import (
 	"testing"
 	"time"
 

--- a/wakuv2/api_test.go
+++ b/wakuv2/api_test.go
@@ -18,16 +18,7 @@
 
 package wakuv2
 
-import (
-	"testing"
-	"time"
-
-	"golang.org/x/exp/maps"
-
-	"github.com/status-im/status-go/wakuv2/common"
-)
-
-func TestMultipleTopicCopyInNewMessageFilter(t *testing.T) {
+/* func TestMultipleTopicCopyInNewMessageFilter(t *testing.T) {
 	w, err := New(nil, "", nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Error creating WakuV2 client: %v", err)
@@ -68,3 +59,4 @@ func TestMultipleTopicCopyInNewMessageFilter(t *testing.T) {
 		t.Fatalf("Could not find filter with both topics")
 	}
 }
+*/

--- a/wakuv2/message_publishing.go
+++ b/wakuv2/message_publishing.go
@@ -1,5 +1,19 @@
 package wakuv2
 
+/* import (
+	"errors"
+
+	"go.uber.org/zap"
+
+	"github.com/waku-org/go-waku/waku/v2/api/publish"
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/wakuv2/common"
+)
+
 type PublishMethod int
 
 const (
@@ -20,7 +34,7 @@ func (pm PublishMethod) String() string {
 
 // Send injects a message into the waku send queue, to be distributed in the
 // network in the coming cycles.
-/* func (w *Waku) Send(pubsubTopic string, msg *pb.WakuMessage, priority *int) ([]byte, error) {
+func (w *Waku) Send(pubsubTopic string, msg *pb.WakuMessage, priority *int) ([]byte, error) {
 	pubsubTopic = w.GetPubsubTopic(pubsubTopic)
 	if w.protectedTopicStore != nil {
 		privKey, err := w.protectedTopicStore.FetchPrivateKey(pubsubTopic)

--- a/wakuv2/message_publishing.go
+++ b/wakuv2/message_publishing.go
@@ -1,6 +1,7 @@
 package wakuv2
 
-/* import (
+/* TODO-nwaku
+import (
 	"errors"
 
 	"go.uber.org/zap"

--- a/wakuv2/message_publishing.go
+++ b/wakuv2/message_publishing.go
@@ -1,19 +1,5 @@
 package wakuv2
 
-import (
-	"errors"
-
-	"go.uber.org/zap"
-
-	"github.com/waku-org/go-waku/waku/v2/api/publish"
-	"github.com/waku-org/go-waku/waku/v2/protocol"
-	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
-	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
-
-	gethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/status-im/status-go/wakuv2/common"
-)
-
 type PublishMethod int
 
 const (
@@ -34,7 +20,7 @@ func (pm PublishMethod) String() string {
 
 // Send injects a message into the waku send queue, to be distributed in the
 // network in the coming cycles.
-func (w *Waku) Send(pubsubTopic string, msg *pb.WakuMessage, priority *int) ([]byte, error) {
+/* func (w *Waku) Send(pubsubTopic string, msg *pb.WakuMessage, priority *int) ([]byte, error) {
 	pubsubTopic = w.GetPubsubTopic(pubsubTopic)
 	if w.protectedTopicStore != nil {
 		privKey, err := w.protectedTopicStore.FetchPrivateKey(pubsubTopic)
@@ -160,4 +146,4 @@ func (w *Waku) publishEnvelope(envelope *protocol.Envelope, publishFn publish.Pu
 			})
 		}
 	}
-}
+} */

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -1813,7 +1813,8 @@ func wakuNew(nodeKey *ecdsa.PrivateKey,
 		ts = timesource.Default()
 	}
 
-	/* cfg = setDefaults(cfg)
+	/* TODO-nwaku 
+	cfg = setDefaults(cfg)
 	if err = cfg.Validate(logger); err != nil {
 		return nil, err
 	} */
@@ -1859,7 +1860,7 @@ func wakuNew(nodeKey *ecdsa.PrivateKey,
 			onHistoricMessagesRequestFailed: onHistoricMessagesRequestFailed,
 			onPeerStats:                     onPeerStats,
 			onlineChecker:                   onlinechecker.NewDefaultOnlineChecker(false).(*onlinechecker.DefaultOnlineChecker),
-		  //sendQueue:                       publish.NewMessageQueue(1000, cfg.UseThrottledPublish),
+		  //sendQueue:                       publish.NewMessageQueue(1000, cfg.UseThrottledPublish), // TODO-nwaku
 		}, nil
 	}
 

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -1676,7 +1676,8 @@ type WakuConfig struct {
 	DnsDiscovery 		 string `json:"dnsDiscovery,omitempty"`
 	DnsDiscoveryUrl 	 string `json:"dnsDiscoveryUrl,omitempty"`
 	MaxMessageSize		 string `json:"maxMessageSize,omitempty"`
-	DiscV5BootstrapNodes []string `json:"discv5BootstrapNodes,omitempty"`
+	Discv5BootstrapNodes []string `json:"discv5BootstrapNodes,omitempty"`
+	Discv5Discovery		 bool `json:"discv5Discovery,omitempty"`
 }
 
 type Waku struct {
@@ -1834,7 +1835,7 @@ func wakuNew(nodeKey *ecdsa.PrivateKey,
 			timesource:                      ts,
 			storeMsgIDsMu:                   sync.RWMutex{},
 			logger:                          logger,
-			discV5BootstrapNodes:            cfg.DiscV5BootstrapNodes,
+			discV5BootstrapNodes:            cfg.Discv5BootstrapNodes,
 			onHistoricMessagesRequestFailed: onHistoricMessagesRequestFailed,
 			onPeerStats:                     onPeerStats,
 			onlineChecker:                   onlinechecker.NewDefaultOnlineChecker(false).(*onlinechecker.DefaultOnlineChecker),

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -332,7 +332,8 @@ const peersToPublishForLightpush = 2
 const publishingLimiterRate = rate.Limit(2)
 const publishingLimitBurst = 4
 
-/* type SentEnvelope struct {
+/* TODO-nwaku 
+type SentEnvelope struct {
 	Envelope      *protocol.Envelope
 	PublishMethod PublishMethod
 }
@@ -368,7 +369,8 @@ func (w *Waku) SubscribeToConnStatusChanges() *types.ConnStatusSubscription {
 	return subscription
 }
 
-/* func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string) ([]*enode.Node, error) {
+/* TODO-nwaku 
+func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string) ([]*enode.Node, error) {
 	wg := sync.WaitGroup{}
 	mu := sync.Mutex{}
 	var result []*enode.Node
@@ -502,7 +504,8 @@ func (w *Waku) connect(peerInfo peer.AddrInfo, enr *enode.Node, origin wps.Origi
 	w.WakuConnect(addr.String(), 1000)
 }
 
-/* func (w *Waku) telemetryBandwidthStats(telemetryServerURL string) {
+/* TODO-nwaku 
+func (w *Waku) telemetryBandwidthStats(telemetryServerURL string) {
 	w.wg.Add(1)
 	defer w.wg.Done()
 
@@ -867,7 +870,8 @@ func (w *Waku) GetSymKey(id string) ([]byte, error) {
 	return nil, fmt.Errorf("non-existent key ID")
 }
 
-/* // Subscribe installs a new message handler used for filtering, decrypting
+/* TODO-nwaku 
+// Subscribe installs a new message handler used for filtering, decrypting
 // and subsequent storing of incoming messages.
 func (w *Waku) Subscribe(f *common.Filter) (string, error) {
 	f.PubsubTopic = w.GetPubsubTopic(f.PubsubTopic)
@@ -1017,7 +1021,8 @@ func (w *Waku) Query(ctx context.Context,
 	return nil, 0, nil
 }
 
-/* // OnNewEnvelope is an interface from Waku FilterManager API that gets invoked when any new message is received by Filter.
+/* TODO-nwaku 
+// OnNewEnvelope is an interface from Waku FilterManager API that gets invoked when any new message is received by Filter.
 func (w *Waku) OnNewEnvelope(env *protocol.Envelope) error {
 	return w.OnNewEnvelopes(env, common.RelayedMessageType, false)
 } */
@@ -1208,7 +1213,8 @@ func (w *Waku) MessageExists(mh pb.MessageHash) (bool, error) {
 	return w.envelopeCache.Has(gethcommon.Hash(mh)), nil
 }
 
-/* func (w *Waku) SetTopicsToVerifyForMissingMessages(peerID peer.ID, pubsubTopic string, contentTopics []string) {
+/* TODO-nwaku 
+func (w *Waku) SetTopicsToVerifyForMissingMessages(peerID peer.ID, pubsubTopic string, contentTopics []string) {
 	if !w.cfg.EnableMissingMessageVerification {
 		return
 	}
@@ -1250,7 +1256,8 @@ func (w *Waku) setupRelaySubscriptions() error {
 	return nil
 } */
 
-/* func (w *Waku) OnNewEnvelopes(envelope *protocol.Envelope, msgType common.MessageType, processImmediately bool) error {
+/* TODO-nwaku 
+func (w *Waku) OnNewEnvelopes(envelope *protocol.Envelope, msgType common.MessageType, processImmediately bool) error {
 	if envelope == nil {
 		return nil
 	}
@@ -1339,7 +1346,8 @@ func (w *Waku) postEvent(envelope *common.ReceivedMessage) {
 	w.msgQueue <- envelope
 }
 
-/* // processQueueLoop delivers the messages to the watchers during the lifetime of the waku node.
+/* TODO-nwaku
+// processQueueLoop delivers the messages to the watchers during the lifetime of the waku node.
 func (w *Waku) processQueueLoop() {
 	if w.ctx == nil {
 		return
@@ -1435,7 +1443,8 @@ func (w *Waku) Peers() types.PeerStats {
 	// return FormatPeerStats(w.node)
 }
 
-/* func (w *Waku) RelayPeersByTopic(topic string) (*types.PeerList, error) {
+/* TODO-nwaku 
+func (w *Waku) RelayPeersByTopic(topic string) (*types.PeerList, error) {
 	if w.cfg.LightClient {
 		return nil, errors.New("only available in relay mode")
 	}
@@ -1511,7 +1520,8 @@ func (w *Waku) handleNetworkChangeFromApp(state connection.State) {
 	// }
 }
 
-/* func (w *Waku) ConnectionChanged(state connection.State) {
+/* TODO-nwaku 
+func (w *Waku) ConnectionChanged(state connection.State) {
 	isOnline := !state.Offline
 	if w.cfg.LightClient {
 		//TODO: Update this as per  https://github.com/waku-org/go-waku/issues/1114
@@ -1762,7 +1772,7 @@ type Waku struct {
 	onHistoricMessagesRequestFailed func([]byte, peer.ID, error)
 	onPeerStats                     func(types.ConnStatus)
 
-	// statusTelemetryClient ITelemetryClient
+	// statusTelemetryClient ITelemetryClient // TODO-nwaku
 
 	defaultShardInfo protocol.RelayShards
 }
@@ -2424,7 +2434,8 @@ func (self *Waku) DisconnectPeerById(peerId peer.ID) error {
 // }
 
 // MaxMessageSize returns the maximum accepted message size.
-/* func (w *Waku) MaxMessageSize() uint32 {
+/* TODO-nwaku 
+func (w *Waku) MaxMessageSize() uint32 {
 	return w.cfg.MaxMessageSize
 } */
 

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -256,13 +256,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"os/signal"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 	"unsafe"
 
@@ -1027,9 +1024,9 @@ func (w *Waku) Start() error {
 		return err
 	}
 
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-	<-ch
+	// ch := make(chan os.Signal, 1)
+	// signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	//<-ch
 
 	// if err = w.node.Start(w.ctx); err != nil {
 	// 	return fmt.Errorf("failed to start go-waku node: %v", err)

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -269,7 +269,6 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/libp2p/go-libp2p/core/metrics"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -350,7 +349,7 @@ func (w *Waku) SubscribeToConnStatusChanges() *types.ConnStatusSubscription {
 	return subscription
 }
 
-func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string) ([]*enode.Node, error) {
+/* func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string) ([]*enode.Node, error) {
 	wg := sync.WaitGroup{}
 	mu := sync.Mutex{}
 	var result []*enode.Node
@@ -394,11 +393,12 @@ func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string) 
 	wg.Wait()
 
 	return result, nil
-}
+} */
 
 type fnApplyToEachPeer func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup)
 
-func (w *Waku) dnsDiscover(ctx context.Context, enrtreeAddress string, apply fnApplyToEachPeer) error {
+// This should be handled by nwaku?
+/* func (w *Waku) dnsDiscover(ctx context.Context, enrtreeAddress string, apply fnApplyToEachPeer) error {
 	w.logger.Info("retrieving nodes", zap.String("enr", enrtreeAddress))
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
@@ -439,9 +439,10 @@ func (w *Waku) dnsDiscover(ctx context.Context, enrtreeAddress string, apply fnA
 	wg.Wait()
 
 	return nil
-}
+} */
 
-func (w *Waku) discoverAndConnectPeers() {
+// This too? nwaku?
+/* func (w *Waku) discoverAndConnectPeers() {
 	fnApply := func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {
 		defer wg.Done()
 		if len(d.PeerInfo.Addrs) != 0 {
@@ -475,7 +476,7 @@ func (w *Waku) discoverAndConnectPeers() {
 			go w.connect(*peerInfo, nil, wps.Static)
 		}
 	}
-}
+} */
 
 func (w *Waku) connect(peerInfo peer.AddrInfo, enr *enode.Node, origin wps.Origin) {
 	// Connection will be prunned eventually by the connection manager if needed
@@ -484,7 +485,7 @@ func (w *Waku) connect(peerInfo peer.AddrInfo, enr *enode.Node, origin wps.Origi
 	w.WakuConnect(addr.String(), 1000)
 }
 
-func (w *Waku) telemetryBandwidthStats(telemetryServerURL string) {
+/* func (w *Waku) telemetryBandwidthStats(telemetryServerURL string) {
 	w.wg.Add(1)
 	defer w.wg.Done()
 
@@ -571,22 +572,22 @@ func (w *Waku) runPeerExchangeLoop() {
 			}
 		}
 	}
-}
+} */
 
-func (w *Waku) GetPubsubTopic(topic string) string {
+/* func (w *Waku) GetPubsubTopic(topic string) string {
 	if topic == "" {
 		topic = w.cfg.DefaultShardPubsubTopic
 	}
 
 	return topic
-}
+} */
 
 // CurrentTime returns current time.
 func (w *Waku) CurrentTime() time.Time {
 	return w.timesource.Now()
 }
 
-// APIs returns the RPC descriptors the Waku implementation offers
+/* // APIs returns the RPC descriptors the Waku implementation offers
 func (w *Waku) APIs() []rpc.API {
 	return []rpc.API{
 		{
@@ -596,7 +597,7 @@ func (w *Waku) APIs() []rpc.API {
 			Public:    false,
 		},
 	}
-}
+} */
 
 // Protocols returns the waku sub-protocols ran by this particular client.
 func (w *Waku) Protocols() []p2p.Protocol {
@@ -851,7 +852,7 @@ func (w *Waku) GetSymKey(id string) ([]byte, error) {
 
 // Subscribe installs a new message handler used for filtering, decrypting
 // and subsequent storing of incoming messages.
-func (w *Waku) Subscribe(f *common.Filter) (string, error) {
+/* func (w *Waku) Subscribe(f *common.Filter) (string, error) {
 	f.PubsubTopic = w.GetPubsubTopic(f.PubsubTopic)
 	id, err := w.filters.Install(f)
 	if err != nil {
@@ -878,7 +879,7 @@ func (w *Waku) Unsubscribe(ctx context.Context, id string) error {
 	}
 
 	return nil
-}
+} */
 
 // GetFilter returns the filter by id.
 func (w *Waku) GetFilter(id string) *common.Filter {
@@ -897,7 +898,7 @@ func (w *Waku) UnsubscribeMany(ids []string) error {
 	return nil
 }
 
-func (w *Waku) SkipPublishToTopic(value bool) {
+/* func (w *Waku) SkipPublishToTopic(value bool) {
 	w.cfg.SkipPublishToTopic = value
 }
 
@@ -906,7 +907,7 @@ func (w *Waku) ConfirmMessageDelivered(hashes []gethcommon.Hash) {
 		return
 	}
 	w.messageSentCheck.DeleteByMessageIDs(hashes)
-}
+} */
 
 func (w *Waku) SetStorePeerID(peerID peer.ID) {
 	if w.messageSentCheck != nil {
@@ -999,10 +1000,10 @@ func (w *Waku) Query(ctx context.Context,
 	return nil, 0, nil
 }
 
-// OnNewEnvelope is an interface from Waku FilterManager API that gets invoked when any new message is received by Filter.
+/* // OnNewEnvelope is an interface from Waku FilterManager API that gets invoked when any new message is received by Filter.
 func (w *Waku) OnNewEnvelope(env *protocol.Envelope) error {
 	return w.OnNewEnvelopes(env, common.RelayedMessageType, false)
-}
+} */
 
 // Start implements node.Service, starting the background data propagation thread
 // of the Waku protocol.
@@ -1188,7 +1189,7 @@ func (w *Waku) checkForConnectionChanges() {
 // 	}()
 // }
 
-func (w *Waku) MessageExists(mh pb.MessageHash) (bool, error) {
+/* func (w *Waku) MessageExists(mh pb.MessageHash) (bool, error) {
 	w.poolMu.Lock()
 	defer w.poolMu.Unlock()
 	return w.envelopeCache.Has(gethcommon.Hash(mh)), nil
@@ -1200,9 +1201,9 @@ func (w *Waku) SetTopicsToVerifyForMissingMessages(peerID peer.ID, pubsubTopic s
 	}
 
 	w.missingMsgVerifier.SetCriteriaInterest(peerID, protocol.NewContentFilter(pubsubTopic, contentTopics...))
-}
+} */
 
-func (w *Waku) setupRelaySubscriptions() error {
+/* func (w *Waku) setupRelaySubscriptions() error {
 	if w.cfg.LightClient {
 		return nil
 	}
@@ -1234,9 +1235,9 @@ func (w *Waku) setupRelaySubscriptions() error {
 	}
 
 	return nil
-}
+} */
 
-func (w *Waku) OnNewEnvelopes(envelope *protocol.Envelope, msgType common.MessageType, processImmediately bool) error {
+/* func (w *Waku) OnNewEnvelopes(envelope *protocol.Envelope, msgType common.MessageType, processImmediately bool) error {
 	if envelope == nil {
 		return nil
 	}
@@ -1323,9 +1324,9 @@ func (w *Waku) add(recvMessage *common.ReceivedMessage, processImmediately bool)
 // postEvent queues the message for further processing.
 func (w *Waku) postEvent(envelope *common.ReceivedMessage) {
 	w.msgQueue <- envelope
-}
+} */
 
-// processQueueLoop delivers the messages to the watchers during the lifetime of the waku node.
+/* // processQueueLoop delivers the messages to the watchers during the lifetime of the waku node.
 func (w *Waku) processQueueLoop() {
 	if w.ctx == nil {
 		return
@@ -1379,7 +1380,7 @@ func (w *Waku) processMessage(e *common.ReceivedMessage) {
 		Hash:  e.Hash(),
 		Event: common.EventEnvelopeAvailable,
 	})
-}
+} */
 
 // GetEnvelope retrieves an envelope from the message queue by its hash.
 // It returns nil if the envelope can not be found.
@@ -1421,7 +1422,7 @@ func (w *Waku) Peers() types.PeerStats {
 	// return FormatPeerStats(w.node)
 }
 
-func (w *Waku) RelayPeersByTopic(topic string) (*types.PeerList, error) {
+/* func (w *Waku) RelayPeersByTopic(topic string) (*types.PeerList, error) {
 	if w.cfg.LightClient {
 		return nil, errors.New("only available in relay mode")
 	}
@@ -1483,7 +1484,7 @@ func (w *Waku) RemovePubsubTopicKey(topic string) error {
 	}
 
 	return w.protectedTopicStore.Delete(topic)
-}
+} */
 
 func (w *Waku) handleNetworkChangeFromApp(state connection.State) {
 	//If connection state is reported by something other than peerCount becoming 0 e.g from mobile app, disconnect all peers
@@ -1497,7 +1498,7 @@ func (w *Waku) handleNetworkChangeFromApp(state connection.State) {
 	// }
 }
 
-func (w *Waku) ConnectionChanged(state connection.State) {
+/* func (w *Waku) ConnectionChanged(state connection.State) {
 	isOnline := !state.Offline
 	if w.cfg.LightClient {
 		//TODO: Update this as per  https://github.com/waku-org/go-waku/issues/1114
@@ -1519,7 +1520,7 @@ func (w *Waku) ConnectionChanged(state connection.State) {
 		w.onlineChecker.SetOnline(isOnline)
 	}
 	w.state = state
-}
+} */
 
 func (w *Waku) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	// peerID, err := w.node.AddPeer(address, wps.Static, w.cfg.DefaultShardedPubsubTopics, store.StoreQueryID_v300)
@@ -1667,14 +1668,16 @@ type WakuPubsubTopic = string
 type WakuContentTopic = string
 
 type WakuConfig struct {
-	Host        string `json:"host,omitempty"`
-	Port        int    `json:"port,omitempty"`
-	NodeKey     string `json:"key,omitempty"`
-	EnableRelay bool   `json:"relay"`
-	LogLevel    string `json:"logLevel"`
+	Host        		 string `json:"host,omitempty"`
+	Port        		 int    `json:"port,omitempty"`
+	NodeKey     		 string `json:"key,omitempty"`
+	EnableRelay  		 bool   `json:"relay"`
+	LogLevel     		 string `json:"logLevel"`
+	DnsDiscovery 		 string `json:"dnsDiscovery,omitempty"`
+	DnsDiscoveryUrl 	 string `json:"dnsDiscoveryUrl,omitempty"`
+	MaxMessageSize		 string `json:"maxMessageSize,omitempty"`
+	DiscV5BootstrapNodes []string `json:"discv5BootstrapNodes,omitempty"`
 }
-
-var jamon unsafe.Pointer
 
 type Waku struct {
 	wakuCtx unsafe.Pointer
@@ -1710,7 +1713,8 @@ type Waku struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
-	cfg     *Config
+	// cfg     *Config
+	cfg		*WakuConfig
 	options []node.WakuNodeOption
 
 	envelopeFeed event.Feed
@@ -1769,19 +1773,11 @@ func printStackTrace() {
 
 func wakuNew(nodeKey *ecdsa.PrivateKey,
 	fleet string,
-	cfg *Config,
+	cfg *WakuConfig,
 	logger *zap.Logger,
 	appDB *sql.DB,
 	ts *timesource.NTPTimeSource,
 	onHistoricMessagesRequestFailed func([]byte, peer.ID, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
-
-	nwakuConfig := WakuConfig{
-		Host:        cfg.Host,
-		Port:        30303,
-		NodeKey:     "11d0dcea28e86f81937a3bd1163473c7fbc0a0db54fd72914849bc47bdf78710",
-		EnableRelay: true,
-		LogLevel:    "DEBUG",
-	}
 
 	var err error
 	if logger == nil {
@@ -1794,17 +1790,19 @@ func wakuNew(nodeKey *ecdsa.PrivateKey,
 		ts = timesource.Default()
 	}
 
-	cfg = setDefaults(cfg)
+	/* cfg = setDefaults(cfg)
 	if err = cfg.Validate(logger); err != nil {
 		return nil, err
-	}
+	} */
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	jsonConfig, err := json.Marshal(nwakuConfig)
+	jsonConfig, err := json.Marshal(cfg)
 	if err != nil {
 		return nil, err
 	}
+
+	fmt.Println("-------- CREATING CONFIG, jsonConfig: ", string(jsonConfig))
 
 	var cJsonConfig = C.CString(string(jsonConfig))
 	var resp = C.allocResp()
@@ -1813,7 +1811,6 @@ func wakuNew(nodeKey *ecdsa.PrivateKey,
 	defer C.freeResp(resp)
 
 	wakuCtx := C.cGoWakuNew(cJsonConfig, resp)
-	jamon = wakuCtx
 	// Notice that the events for self node are handled by the 'MyEventCallback' method
 
 	if C.getRet(resp) == C.RET_OK {
@@ -1841,7 +1838,7 @@ func wakuNew(nodeKey *ecdsa.PrivateKey,
 			onHistoricMessagesRequestFailed: onHistoricMessagesRequestFailed,
 			onPeerStats:                     onPeerStats,
 			onlineChecker:                   onlinechecker.NewDefaultOnlineChecker(false).(*onlinechecker.DefaultOnlineChecker),
-			sendQueue:                       publish.NewMessageQueue(1000, cfg.UseThrottledPublish),
+		  //sendQueue:                       publish.NewMessageQueue(1000, cfg.UseThrottledPublish),
 		}, nil
 	}
 
@@ -2386,14 +2383,14 @@ func (self *Waku) GetPeerIdsByProtocol(protocol string) (peer.IDSlice, error) {
 // }
 
 // MaxMessageSize returns the maximum accepted message size.
-func (w *Waku) MaxMessageSize() uint32 {
+/* func (w *Waku) MaxMessageSize() uint32 {
 	return w.cfg.MaxMessageSize
-}
+} */
 
 // New creates a WakuV2 client ready to communicate through the LibP2P network.
 func New(nodeKey *ecdsa.PrivateKey,
 	fleet string,
-	cfg *Config,
+	cfg *WakuConfig,
 	logger *zap.Logger,
 	appDB *sql.DB,
 	ts *timesource.NTPTimeSource,

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -332,7 +332,7 @@ const peersToPublishForLightpush = 2
 const publishingLimiterRate = rate.Limit(2)
 const publishingLimitBurst = 4
 
-type SentEnvelope struct {
+/* type SentEnvelope struct {
 	Envelope      *protocol.Envelope
 	PublishMethod PublishMethod
 }
@@ -352,7 +352,7 @@ type ITelemetryClient interface {
 
 func (w *Waku) SetStatusTelemetryClient(client ITelemetryClient) {
 	w.statusTelemetryClient = client
-}
+} */
 
 func newTTLCache() *ttlcache.Cache[gethcommon.Hash, *common.ReceivedMessage] {
 	cache := ttlcache.New[gethcommon.Hash, *common.ReceivedMessage](ttlcache.WithTTL[gethcommon.Hash, *common.ReceivedMessage](cacheTTL))
@@ -412,12 +412,11 @@ func (w *Waku) SubscribeToConnStatusChanges() *types.ConnStatusSubscription {
 	wg.Wait()
 
 	return result, nil
-} */
+}
 
 type fnApplyToEachPeer func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup)
 
-// This should be handled by nwaku?
-/* func (w *Waku) dnsDiscover(ctx context.Context, enrtreeAddress string, apply fnApplyToEachPeer) error {
+func (w *Waku) dnsDiscover(ctx context.Context, enrtreeAddress string, apply fnApplyToEachPeer) error {
 	w.logger.Info("retrieving nodes", zap.String("enr", enrtreeAddress))
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
@@ -458,10 +457,9 @@ type fnApplyToEachPeer func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup)
 	wg.Wait()
 
 	return nil
-} */
+}
 
-// This too? nwaku?
-/* func (w *Waku) discoverAndConnectPeers() {
+func (w *Waku) discoverAndConnectPeers() {
 	fnApply := func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {
 		defer wg.Done()
 		if len(d.PeerInfo.Addrs) != 0 {
@@ -591,22 +589,22 @@ func (w *Waku) runPeerExchangeLoop() {
 			}
 		}
 	}
-} */
+}
 
-/* func (w *Waku) GetPubsubTopic(topic string) string {
+func (w *Waku) GetPubsubTopic(topic string) string {
 	if topic == "" {
 		topic = w.cfg.DefaultShardPubsubTopic
 	}
 
 	return topic
-} */
+}
 
 // CurrentTime returns current time.
 func (w *Waku) CurrentTime() time.Time {
 	return w.timesource.Now()
 }
 
-/* // APIs returns the RPC descriptors the Waku implementation offers
+// APIs returns the RPC descriptors the Waku implementation offers
 func (w *Waku) APIs() []rpc.API {
 	return []rpc.API{
 		{
@@ -869,9 +867,9 @@ func (w *Waku) GetSymKey(id string) ([]byte, error) {
 	return nil, fmt.Errorf("non-existent key ID")
 }
 
-// Subscribe installs a new message handler used for filtering, decrypting
+/* // Subscribe installs a new message handler used for filtering, decrypting
 // and subsequent storing of incoming messages.
-/* func (w *Waku) Subscribe(f *common.Filter) (string, error) {
+func (w *Waku) Subscribe(f *common.Filter) (string, error) {
 	f.PubsubTopic = w.GetPubsubTopic(f.PubsubTopic)
 	id, err := w.filters.Install(f)
 	if err != nil {
@@ -898,7 +896,7 @@ func (w *Waku) Unsubscribe(ctx context.Context, id string) error {
 	}
 
 	return nil
-} */
+}
 
 // GetFilter returns the filter by id.
 func (w *Waku) GetFilter(id string) *common.Filter {
@@ -917,7 +915,7 @@ func (w *Waku) UnsubscribeMany(ids []string) error {
 	return nil
 }
 
-/* func (w *Waku) SkipPublishToTopic(value bool) {
+func (w *Waku) SkipPublishToTopic(value bool) {
 	w.cfg.SkipPublishToTopic = value
 }
 
@@ -1043,10 +1041,6 @@ func (w *Waku) Start() error {
 		fmt.Println("Error happened:", err.Error())
 		return err
 	}
-
-	// ch := make(chan os.Signal, 1)
-	// signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-	//<-ch
 
 	// if err = w.node.Start(w.ctx); err != nil {
 	// 	return fmt.Errorf("failed to start go-waku node: %v", err)
@@ -1208,21 +1202,21 @@ func (w *Waku) checkForConnectionChanges() {
 // 	}()
 // }
 
-/* func (w *Waku) MessageExists(mh pb.MessageHash) (bool, error) {
+func (w *Waku) MessageExists(mh pb.MessageHash) (bool, error) {
 	w.poolMu.Lock()
 	defer w.poolMu.Unlock()
 	return w.envelopeCache.Has(gethcommon.Hash(mh)), nil
 }
 
-func (w *Waku) SetTopicsToVerifyForMissingMessages(peerID peer.ID, pubsubTopic string, contentTopics []string) {
+/* func (w *Waku) SetTopicsToVerifyForMissingMessages(peerID peer.ID, pubsubTopic string, contentTopics []string) {
 	if !w.cfg.EnableMissingMessageVerification {
 		return
 	}
 
 	w.missingMsgVerifier.SetCriteriaInterest(peerID, protocol.NewContentFilter(pubsubTopic, contentTopics...))
-} */
+}
 
-/* func (w *Waku) setupRelaySubscriptions() error {
+func (w *Waku) setupRelaySubscriptions() error {
 	if w.cfg.LightClient {
 		return nil
 	}
@@ -1338,12 +1332,12 @@ func (w *Waku) add(recvMessage *common.ReceivedMessage, processImmediately bool)
 	}
 
 	return true, nil
-}
+} */
 
 // postEvent queues the message for further processing.
 func (w *Waku) postEvent(envelope *common.ReceivedMessage) {
 	w.msgQueue <- envelope
-} */
+}
 
 /* // processQueueLoop delivers the messages to the watchers during the lifetime of the waku node.
 func (w *Waku) processQueueLoop() {
@@ -1733,7 +1727,6 @@ type Waku struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
-	// cfg     *Config
 	cfg		*WakuConfig
 	options []node.WakuNodeOption
 
@@ -1769,7 +1762,7 @@ type Waku struct {
 	onHistoricMessagesRequestFailed func([]byte, peer.ID, error)
 	onPeerStats                     func(types.ConnStatus)
 
-	statusTelemetryClient ITelemetryClient
+	// statusTelemetryClient ITelemetryClient
 
 	defaultShardInfo protocol.RelayShards
 }
@@ -1822,8 +1815,6 @@ func wakuNew(nodeKey *ecdsa.PrivateKey,
 		return nil, err
 	}
 
-	fmt.Println("-------- CREATING CONFIG, jsonConfig: ", string(jsonConfig))
-
 	var cJsonConfig = C.CString(string(jsonConfig))
 	var resp = C.allocResp()
 
@@ -1870,8 +1861,6 @@ func (self *Waku) WakuStart() error {
 
 	var resp = C.allocResp()
 	defer C.freeResp(resp)
-	
-	
 	C.cGoWakuStart(self.wakuCtx, resp)
 
 	if C.getRet(resp) == C.RET_OK {

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -1678,6 +1678,8 @@ type WakuConfig struct {
 	MaxMessageSize		 string `json:"maxMessageSize,omitempty"`
 	Discv5BootstrapNodes []string `json:"discv5BootstrapNodes,omitempty"`
 	Discv5Discovery		 bool `json:"discv5Discovery,omitempty"`
+	ClusterID			 uint16 `json:"clusterId,omitempty"`
+	Shards			     []uint16 `json:"shards,omitempty"`	
 }
 
 type Waku struct {

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -55,9 +55,7 @@ package wakuv2
 
 	// resp must be set != NULL in case interest on retrieving data from the callback
 	static void callback(int ret, char* msg, size_t len, void* resp) {
-		printf("---------- GABRIEL calling callback 1 ----\n");
 		if (resp != NULL) {
-			printf("---------- GABRIEL calling callback 2 ----\n");
 			Resp* m = (Resp*) resp;
 			m->ret = ret;
 			m->msg = msg;
@@ -67,7 +65,6 @@ package wakuv2
 
 	#define WAKU_CALL(call)                                                        \
 	do {                                                                           \
-		printf("---------- GABRIEL calling WAKU_CALL 1 ----\n"); 						\
 		int ret = call;                                                              \
 		if (ret != 0) {                                                              \
 			printf("Failed the call to: %s. Returned code: %d\n", #call, ret);         \
@@ -1875,17 +1872,12 @@ func (self *Waku) WakuStart() error {
 	defer C.freeResp(resp)
 	
 	
-	fmt.Println("------------ GABRIEL called wakuStart")
 	C.cGoWakuStart(self.wakuCtx, resp)
-	fmt.Println("------------ GABRIEL wakuStart 2")
 
 	if C.getRet(resp) == C.RET_OK {
-		fmt.Println("------------ GABRIEL wakuStart received RET_OK")
 		return nil
 	}
-	fmt.Println("------------ GABRIEL wakuStart 3")
 	errMsg := "error WakuStart: " + C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
-	fmt.Println("------------ GABRIEL error in wakuStart ", errMsg)
 	return errors.New(errMsg)
 }
 
@@ -2457,16 +2449,11 @@ func New(nodeKey *ecdsa.PrivateKey,
 	onHistoricMessagesRequestFailed func([]byte, peer.ID, error),
 	onPeerStats func(types.ConnStatus)) (*Waku, error) {
 
-	fmt.Println("-------- GABRIEL func New 1 ---------")
-
 	// Lock the main goroutine to its current OS thread
 	runtime.LockOSThread()
 
-	fmt.Println("-------- GABRIEL func New 2 ---------")
-
 	WakuSetup() // This should only be called once in the whole app's life
 
-	fmt.Println("-------- GABRIEL func New 3 ---------")
 	node, err := wakuNew(nodeKey,
 		fleet,
 		cfg, logger, appDB, ts, onHistoricMessagesRequestFailed,
@@ -2475,21 +2462,17 @@ func New(nodeKey *ecdsa.PrivateKey,
 		return nil, err
 	}
 
-	fmt.Println("-------- GABRIEL func New 4 ---------")
 	defaultPubsubTopic, err := node.WakuDefaultPubsubTopic()
 	if err != nil {
 		fmt.Println("Error happened:", err.Error())
 	}
 
-	fmt.Println("-------- GABRIEL func New 5 ---------")
 	err = node.WakuRelaySubscribe(defaultPubsubTopic)
 	if err != nil {
 		fmt.Println("Error happened:", err.Error())
 	}
 
-	fmt.Println("-------- GABRIEL func New 6 ---------")
 	node.WakuSetEventCallback()
-	fmt.Println("-------- GABRIEL func New 7 ---------")
 
 	return node, nil
 

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -1673,9 +1673,10 @@ type WakuConfig struct {
 	NodeKey     		 string `json:"key,omitempty"`
 	EnableRelay  		 bool   `json:"relay"`
 	LogLevel     		 string `json:"logLevel"`
-	DnsDiscovery 		 string `json:"dnsDiscovery,omitempty"`
+	DnsDiscovery 		 bool `json:"dnsDiscovery,omitempty"`
 	DnsDiscoveryUrl 	 string `json:"dnsDiscoveryUrl,omitempty"`
 	MaxMessageSize		 string `json:"maxMessageSize,omitempty"`
+	Staticnodes          []string `json:"staticnodes,omitempty"`
 	Discv5BootstrapNodes []string `json:"discv5BootstrapNodes,omitempty"`
 	Discv5Discovery		 bool `json:"discv5Discovery,omitempty"`
 	ClusterID			 uint16 `json:"clusterId,omitempty"`

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -213,9 +213,14 @@ func TestBasicWakuV2(t *testing.T) {
 	connectedStoreNodes, err := w.GetPeerIdsByProtocol(string(store.StoreQueryID_v300))
 	require.True(t, slices.Contains(connectedStoreNodes, storeNode.ID), "nwaku should be connected to the store node")
 
-	err = w.DropPeer(storeNode.ID)
+	err = w.DisconnectPeerById(storeNode.ID)
 	require.NoError(t, err)
 
+	connectedStoreNodes, err = w.GetPeerIdsByProtocol(string(store.StoreQueryID_v300))
+	require.NoError(t, err)
+	isDisconnected := !slices.Contains(connectedStoreNodes, storeNode.ID)
+	require.True(t, isDisconnected, "nwaku should be disconnected from the store node")
+	
 	/* // Dropping Peer
 	err = w.DropPeer(storeNode.PeerID)
 	require.NoError(t, err)

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -228,22 +228,7 @@ func TestBasicWakuV2(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, slices.Contains(connectedStoreNodes, storeNode.ID), "nwaku should be connected to the store node")
 	
-	/* // Dropping Peer
-	err = w.DropPeer(storeNode.PeerID)
-	require.NoError(t, err)
-
-	// Dialing with peerID
-	err = w.DialPeerByID(storeNode.PeerID)
-	require.NoError(t, err)
-
-	err = tt.RetryWithBackOff(func() error {
-		if len(w.Peers()) < 1 {
-			return errors.New("no peers discovered")
-		}
-		return nil
-	}, options)
-	require.NoError(t, err)
-
+	/* 
 	filter := &common.Filter{
 		PubsubTopic:   config.DefaultShardPubsubTopic,
 		Messages:      common.NewMemoryMessageStore(),

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -190,7 +190,8 @@ func TestBasicWakuV2(t *testing.T) {
 		NodeKey:     "11d0dcea28e86f81937a3bd1163473c7fbc0a0db54fd72914849bc47bdf78710",
 		EnableRelay: true,
 		LogLevel:    "DEBUG",
-		DiscV5BootstrapNodes: []string{nwakuInfo.EnrUri},
+		Discv5BootstrapNodes: []string{nwakuInfo.EnrUri},
+		Discv5Discovery: true,
 	}
 	
 	w, err := New(nil, "", &nwakuConfig, nil, nil, nil, nil, nil)

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -5,11 +5,8 @@ package wakuv2
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -21,16 +18,8 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
-	"google.golang.org/protobuf/proto"
-
-	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
-	"github.com/waku-org/go-waku/waku/v2/protocol"
-	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
-	"github.com/waku-org/go-waku/waku/v2/protocol/store"
 
 	"github.com/status-im/status-go/protocol/tt"
-	"github.com/status-im/status-go/wakuv2/common"
 )
 
 var testStoreENRBootstrap = "enrtree://AI4W5N5IFEUIHF5LESUAOSMV6TKWF2MB6GU2YK7PU4TYUGUNOCEPW@store.staging.status.nodes.status.im"
@@ -174,7 +163,7 @@ func TestBasicWakuV2(t *testing.T) {
 	require.NoError(t, err)
 	fmt.Println("---------- GABRIEL 2 ----------")
 
-	// Creating a fake DNS Discovery ENRTree
+	/* // Creating a fake DNS Discovery ENRTree
 	tree, url := makeTestTree("n", parseNodes([]string{nwakuInfo.EnrUri}), nil)
 	fmt.Println("---------- GABRIEL 3 ----------")
 	enrTreeAddress := url
@@ -184,14 +173,27 @@ func TestBasicWakuV2(t *testing.T) {
 	}
 
 	fmt.Println("---------- GABRIEL 4 ----------")
-	config := &Config{}
+	fmt.Println("---------- enrTreeAddress: ", enrTreeAddress) */
+	
+	// Instead of the Config type, use WakuConfig
+	/* config := &Config{}
 	setDefaultConfig(config, false)
 	config.Port = 0
 	config.Resolver = mapResolver(tree.ToTXT("n"))
 	config.DiscV5BootstrapNodes = []string{enrTreeAddress}
 	config.DiscoveryLimit = 20
-	config.WakuNodes = []string{enrTreeAddress}
-	w, err := New(nil, "", config, nil, nil, nil, nil, nil)
+	config.WakuNodes = []string{enrTreeAddress} */
+
+	nwakuConfig := WakuConfig{
+	 // Host:        cfg.Host,
+		Port:        30303,
+		NodeKey:     "11d0dcea28e86f81937a3bd1163473c7fbc0a0db54fd72914849bc47bdf78710",
+		EnableRelay: true,
+		LogLevel:    "DEBUG",
+		DiscV5BootstrapNodes: []string{nwakuInfo.EnrUri},
+	}
+	
+	w, err := New(nil, "", &nwakuConfig, nil, nil, nil, nil, nil)
 	fmt.Println("---------- GABRIEL 5 ----------")
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
@@ -203,6 +205,7 @@ func TestBasicWakuV2(t *testing.T) {
 
 	fmt.Println("---------- GABRIEL 7 ----------")
 
+	/*
 	// DNSDiscovery
 	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
 	defer cancel()
@@ -212,12 +215,19 @@ func TestBasicWakuV2(t *testing.T) {
 	discoveredNodes, err := dnsdisc.RetrieveNodes(ctx, enrTreeAddress, dnsdisc.WithResolver(config.Resolver))
 	require.NoError(t, err)
 
+	fmt.Println("---------- discoveredNodes: ", discoveredNodes)
+	
 	fmt.Println("---------- GABRIEL 9 ----------")
 	// Peer used for retrieving history
 	r, err := rand.Int(rand.Reader, big.NewInt(int64(len(discoveredNodes))))
 	require.NoError(t, err)
 
 	storeNode := discoveredNodes[int(r.Int64())]
+
+	fmt.Println("---------- storeNode: ", storeNode)
+	*/
+
+	// storeNode := discoveredNodes[int(r.Int64())]
 
 	fmt.Println("---------- GABRIEL 10 ----------")
 	options := func(b *backoff.ExponentialBackOff) {
@@ -236,7 +246,7 @@ func TestBasicWakuV2(t *testing.T) {
 
 	fmt.Println("---------- GABRIEL 12 ----------")
 
-	// Dropping Peer
+	/* // Dropping Peer
 	err = w.DropPeer(storeNode.PeerID)
 	require.NoError(t, err)
 
@@ -309,7 +319,7 @@ func TestBasicWakuV2(t *testing.T) {
 		}
 		return nil
 	}, options)
-	require.NoError(t, err)
+	require.NoError(t, err) */
 
 	require.NoError(t, w.Stop())
 }

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -6,7 +6,6 @@ package wakuv2
 import (
 	"context"
 	"errors"
-	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -193,7 +192,6 @@ func TestBasicWakuV2(t *testing.T) {
 	err = tt.RetryWithBackOff(func() error {
 		
 		numConnected, err := w.GetNumConnectedPeers()
-		fmt.Println("numConnected: ", numConnected)
 		if err != nil {
 			return err
 		}

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -153,12 +153,11 @@ func parseNodes(rec []string) []*enode.Node {
 //
 // Using Docker:
 //
-// IP_ADDRESS=$(ipconfig getifaddr en0)
-// docker run \
-// -p 61000:61000/tcp -p 8000:8000/udp -p 8646:8646/tcp harbor.status.im/wakuorg/nwaku:v0.33.0 \
-// --discv5-discovery=true --cluster-id=16 --log-level=DEBUG \
-// --nat=extip:${IP_ADDRESS} --discv5-discovery --discv5-udp-port=8000 --rest-address=0.0.0.0 --store --rest-port=8646 \
-// --tcp-port=61000 --rest-admin=true --shard=64 --dns-discovery=true --dns-discovery-url="/dns4/boot-01.do-ams3.status.prod.status.im/tcp/30303/p2p/16Uiu2HAmAR24Mbb6VuzoyUiGx42UenDkshENVDj4qnmmbabLvo31"
+//		IP_ADDRESS=$(hostname -I | awk '{print $1}');
+// 		docker run \
+// 		-p 61000:61000/tcp -p 8000:8000/udp -p 8646:8646/tcp harbor.status.im/wakuorg/nwaku:v0.33.0 \
+// 		--discv5-discovery=true --cluster-id=16 --log-level=DEBUG \
+// 		--nat=extip:${IP_ADDRESS} --discv5-discovery --discv5-udp-port=8000 --rest-address=0.0.0.0 --store --rest-port=8646 \
 
 func TestBasicWakuV2(t *testing.T) {
 	extNodeRestPort := 8646
@@ -211,6 +210,7 @@ func TestBasicWakuV2(t *testing.T) {
 	require.NoError(t, err)
 
 	connectedStoreNodes, err := w.GetPeerIdsByProtocol(string(store.StoreQueryID_v300))
+	require.NoError(t, err)
 	require.True(t, slices.Contains(connectedStoreNodes, storeNode.ID), "nwaku should be connected to the store node")
 
 	err = w.DisconnectPeerById(storeNode.ID)
@@ -220,6 +220,13 @@ func TestBasicWakuV2(t *testing.T) {
 	require.NoError(t, err)
 	isDisconnected := !slices.Contains(connectedStoreNodes, storeNode.ID)
 	require.True(t, isDisconnected, "nwaku should be disconnected from the store node")
+	
+	err = w.DialPeerByID(storeNode.ID)
+	require.NoError(t, err)
+
+	connectedStoreNodes, err = w.GetPeerIdsByProtocol(string(store.StoreQueryID_v300))
+	require.NoError(t, err)
+	require.True(t, slices.Contains(connectedStoreNodes, storeNode.ID), "nwaku should be connected to the store node")
 	
 	/* // Dropping Peer
 	err = w.DropPeer(storeNode.PeerID)

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -7,10 +7,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v3"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/waku-org/go-waku/waku/v2/protocol/store"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -201,6 +204,16 @@ func TestBasicWakuV2(t *testing.T) {
 		}
 		return errors.New("no peers discovered")
 	}, options)
+	require.NoError(t, err)
+
+	storeNode, err :=peer.AddrInfoFromString(storeNodeInfo.ListenAddresses[0])
+	require.NoError(t, err)
+	require.NoError(t, err)
+
+	connectedStoreNodes, err := w.GetPeerIdsByProtocol(string(store.StoreQueryID_v300))
+	require.True(t, slices.Contains(connectedStoreNodes, storeNode.ID), "nwaku should be connected to the store node")
+
+	err = w.DropPeer(storeNode.ID)
 	require.NoError(t, err)
 
 	/* // Dropping Peer

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -153,11 +153,11 @@ func parseNodes(rec []string) []*enode.Node {
 //
 // Using Docker:
 //
-//		IP_ADDRESS=$(hostname -I | awk '{print $1}');
-// 		docker run \
-// 		-p 61000:61000/tcp -p 8000:8000/udp -p 8646:8646/tcp harbor.status.im/wakuorg/nwaku:v0.33.0 \
-// 		--discv5-discovery=true --cluster-id=16 --log-level=DEBUG \
-// 		--nat=extip:${IP_ADDRESS} --discv5-discovery --discv5-udp-port=8000 --rest-address=0.0.0.0 --store --rest-port=8646 \
+//	IP_ADDRESS=$(hostname -I | awk '{print $1}');
+// 	docker run \
+// 	-p 61000:61000/tcp -p 8000:8000/udp -p 8646:8646/tcp harbor.status.im/wakuorg/nwaku:v0.33.0 \
+// 	--discv5-discovery=true --cluster-id=16 --log-level=DEBUG \
+// 	--nat=extip:${IP_ADDRESS} --discv5-discovery --discv5-udp-port=8000 --rest-address=0.0.0.0 --store --rest-port=8646 \
 
 func TestBasicWakuV2(t *testing.T) {
 	extNodeRestPort := 8646


### PR DESCRIPTION
## Description

Testing DNS discovery and peer connections and disconnections when integrating nwaku.
I commented everything in `api.go`, `api_test.go`, `message_publishing.go` and a big part of `nwaku.go`. I propose to remove the comments incrementally while we implement and test new features with the nwaku integration.



Important changes:
- [x] commenting `api.go`, `api_test.go`, `message_publishing.go` and part of `nwaku.go`
- [x] changed C function definitions to static to avoid compilation error
- [x] added `cGoWakuDialPeerById` and `cGoWakuDisconnectPeerById` using newly added bindings  
- [x] extended `WakuConfig` with more nwaku node configurations 
- [x] changed `cfg` field in `Waku` to be of type `*WakuConfig` 
- [x] added `WakuDialPeerById` and `DisconnectPeerById` functions 
- [x] adapting `TestBasicWakuV2`to use nwkaku's DNS discovery, dialing and disconnecting from peers and checking that it indeed works 

## How to test it
1. compile libwaku in nwaku's `chore-adding-libwaku-dial-and-disconnect-by-id` branch to have the new libwaku's procs that are used
2. In another terminal, run
```
IP_ADDRESS=$(hostname -I | awk '{print $1}');
docker run \
-p 61000:61000/tcp -p 8000:8000/udp -p 8646:8646/tcp harbor.status.im/wakuorg/nwaku:v0.33.0 \
--discv5-discovery=true --cluster-id=16 --log-level=DEBUG \
--nat=extip:${IP_ADDRESS} --discv5-udp-port=8000 --rest-address=0.0.0.0 --store --rest-port=8646 \
```
3. Compile and execute `TestBasicWakuV2` by running
```
go test -tags="use_nwaku,gowaku_no_rln" -run TestBasicWakuV2 ./wakuv2/... -count 1 -v -json | jq -r '.Output'
```

Closes https://github.com/waku-org/nwaku/issues/3039
