### PR TITLE
chore_: remove rpclimiter from rpc/chain/client.go

### DIFF
--- a/healthmanager/provider_errors/rpc_provider_errors.go
+++ b/healthmanager/provider_errors/rpc_provider_errors.go
@@ -62,9 +62,7 @@ func determineRpcErrorType(err error) RpcProviderErrorType {
 	if err == nil {
 		return RpcErrorTypeNone
 	}
-	//if IsRpsLimitError(err) {
-	//	return RpcErrorTypeRPSLimit
-	//}
+
 	if IsMethodNotFoundError(err) || IsNotFoundError(err) {
 		return RpcErrorTypeMethodNotFound
 	}


### PR DESCRIPTION
Removing rpc limiter usage from rpc/chain/client

Full refactoring will be added here: https://github.com/status-im/status-go/pull/5952

Closes #5942
