### PR TITLE
fix(wallet)_: limit max parameter length in cryptocompare price fetches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,21 +362,30 @@ docker-test: ##@tests Run tests in a docker container with golang.
 
 test: test-unit ##@tests Run basic, short tests during development
 
-test-unit: generate
-test-unit: export BUILD_TAGS ?=
-test-unit: export UNIT_TEST_DRY_RUN ?= false
-test-unit: export UNIT_TEST_COUNT ?= 1
-test-unit: export UNIT_TEST_FAILFAST ?= true
+test-unit-prep: generate
+test-unit-prep: export BUILD_TAGS ?=
+test-unit-prep: export UNIT_TEST_DRY_RUN ?= false
+test-unit-prep: export UNIT_TEST_COUNT ?= 1
+test-unit-prep: export UNIT_TEST_FAILFAST ?= true
+test-unit-prep: export UNIT_TEST_USE_DEVELOPMENT_LOGGER ?= true
+test-unit-prep: export UNIT_TEST_REPORT_CODECLIMATE ?= false
+test-unit-prep: export UNIT_TEST_REPORT_CODECOV ?= false
+
+test-unit: test-unit-prep
 test-unit: export UNIT_TEST_RERUN_FAILS ?= true
-test-unit: export UNIT_TEST_USE_DEVELOPMENT_LOGGER ?= true
-test-unit: export UNIT_TEST_REPORT_CODECLIMATE ?= false
-test-unit: export UNIT_TEST_REPORT_CODECOV ?= false
 test-unit: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./... | \
 	grep -v /vendor | \
 	grep -v /t/e2e | \
 	grep -v /t/benchmarks | \
-	grep -v /transactions/fake)
+	grep -v /transactions/fake | \
+	grep -v /tests-unit-network)
 test-unit: ##@tests Run unit and integration tests
+	./_assets/scripts/run_unit_tests.sh
+
+test-unit-network: test-unit-prep
+test-unit-network: export UNIT_TEST_RERUN_FAILS ?= false
+test-unit-network: export UNIT_TEST_PACKAGES ?= $(call sh, go list ./tests-unit-network/...)
+test-unit-network: ##@tests Run unit and integration tests with network access
 	./_assets/scripts/run_unit_tests.sh
 
 test-unit-race: export GOTEST_EXTRAFLAGS=-race

--- a/services/wallet/thirdparty/cryptocompare/client.go
+++ b/services/wallet/thirdparty/cryptocompare/client.go
@@ -73,7 +73,15 @@ func NewClientWithParams(params Params) *Client {
 }
 
 func (c *Client) FetchPrices(symbols []string, currencies []string) (map[string]map[string]float64, error) {
-	chunks := utils.ChunkSymbols(symbols, 60)
+	const maxFsymsLength = 300
+	chunkSymbolParams := utils.ChunkSymbolsParams{
+		MaxCharsPerChunk:    maxFsymsLength,
+		ExtraCharsPerSymbol: 1, // joined with a comma
+	}
+	chunks, err := utils.ChunkSymbols(symbols, chunkSymbolParams)
+	if err != nil {
+		return nil, err
+	}
 	result := make(map[string]map[string]float64)
 	realCurrencies := utils.RenameSymbols(currencies)
 	for _, smbls := range chunks {
@@ -82,6 +90,7 @@ func (c *Client) FetchPrices(symbols []string, currencies []string) (map[string]
 		params := url.Values{}
 		params.Add("fsyms", strings.Join(realSymbols, ","))
 		params.Add("tsyms", strings.Join(realCurrencies, ","))
+		params.Add("relaxedValidation", "true")
 		params.Add("extraParams", extraParamStatus)
 
 		url := fmt.Sprintf("%s/data/pricemulti", c.baseURL)
@@ -129,7 +138,15 @@ func (c *Client) FetchTokenDetails(symbols []string) (map[string]thirdparty.Toke
 }
 
 func (c *Client) FetchTokenMarketValues(symbols []string, currency string) (map[string]thirdparty.TokenMarketValues, error) {
-	chunks := utils.ChunkSymbols(symbols)
+	const maxFsymsLength = 300
+	chunkSymbolParams := utils.ChunkSymbolsParams{
+		MaxCharsPerChunk:    maxFsymsLength,
+		ExtraCharsPerSymbol: 1, // joined with a comma
+	}
+	chunks, err := utils.ChunkSymbols(symbols, chunkSymbolParams)
+	if err != nil {
+		return nil, err
+	}
 	realCurrency := utils.GetRealSymbol(currency)
 	item := map[string]thirdparty.TokenMarketValues{}
 	for _, smbls := range chunks {
@@ -138,6 +155,7 @@ func (c *Client) FetchTokenMarketValues(symbols []string, currency string) (map[
 		params := url.Values{}
 		params.Add("fsyms", strings.Join(realSymbols, ","))
 		params.Add("tsyms", realCurrency)
+		params.Add("relaxedValidation", "true")
 		params.Add("extraParams", extraParamStatus)
 
 		url := fmt.Sprintf("%s/data/pricemultifull", c.baseURL)

--- a/services/wallet/thirdparty/cryptocompare/client_test.go
+++ b/services/wallet/thirdparty/cryptocompare/client_test.go
@@ -3,7 +3,17 @@ package cryptocompare
 import (
 	"testing"
 
+	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/params"
+	mock_network "github.com/status-im/status-go/rpc/network/mock"
+	w_common "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/token"
+	"github.com/status-im/status-go/t/helpers"
+	"github.com/status-im/status-go/walletdatabase"
+
 	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
 )
 
 func TestIDs(t *testing.T) {
@@ -14,4 +24,72 @@ func TestIDs(t *testing.T) {
 		ID: "testID",
 	})
 	require.Equal(t, "testID", clientWithParams.ID())
+}
+
+func getTokenSymbols(t *testing.T) []string {
+	appDB, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
+	require.NoError(t, err)
+
+	walletDB, err := helpers.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(t, err)
+
+	networksList := []params.Network{
+		{
+			ChainID: w_common.EthereumMainnet,
+		},
+		{
+			ChainID: w_common.OptimismMainnet,
+		},
+		{
+			ChainID: w_common.ArbitrumMainnet,
+		},
+	}
+
+	ptrNetworkList := make([]*params.Network, 0, len(networksList))
+	for i := range networksList {
+		ptrNetworkList = append(ptrNetworkList, &networksList[i])
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	networkManager := mock_network.NewMockManagerInterface(ctrl)
+	networkManager.EXPECT().Get(gomock.Any()).Return(ptrNetworkList, nil).AnyTimes()
+	networkManager.EXPECT().GetAll().Return(ptrNetworkList, nil).AnyTimes()
+	networkManager.EXPECT().GetConfiguredNetworks().Return(networksList).AnyTimes()
+
+	// Skeleton token store to get full list of tokens
+	tm := token.NewTokenManager(walletDB, nil, nil, networkManager, appDB, nil, nil, nil, nil, nil)
+
+	tokens, err := tm.GetAllTokens()
+	require.NoError(t, err)
+
+	symbolsMap := make(map[string]bool)
+	for _, token := range tokens {
+		symbolsMap[token.Symbol] = true
+	}
+
+	symbols := make([]string, 0, len(symbolsMap))
+	for symbol := range symbolsMap {
+		symbols = append(symbols, symbol)
+	}
+
+	return symbols
+}
+
+func TestFetchPrices(t *testing.T) {
+	t.Skip("Accesses network, only to be run in dev machine")
+	symbols := getTokenSymbols(t)
+
+	stdClient := NewClient()
+	_, err := stdClient.FetchPrices(symbols, []string{"USD"})
+	require.NoError(t, err)
+}
+
+func TestFetchTokenMarketValues(t *testing.T) {
+	t.Skip("Accesses network, only to be run manually in dev machine")
+	symbols := getTokenSymbols(t)
+
+	stdClient := NewClient()
+	_, err := stdClient.FetchTokenMarketValues(symbols, "USD")
+	require.NoError(t, err)
 }

--- a/services/wallet/thirdparty/cryptocompare/client_test.go
+++ b/services/wallet/thirdparty/cryptocompare/client_test.go
@@ -3,17 +3,7 @@ package cryptocompare
 import (
 	"testing"
 
-	"github.com/status-im/status-go/appdatabase"
-	"github.com/status-im/status-go/params"
-	mock_network "github.com/status-im/status-go/rpc/network/mock"
-	w_common "github.com/status-im/status-go/services/wallet/common"
-	"github.com/status-im/status-go/services/wallet/token"
-	"github.com/status-im/status-go/t/helpers"
-	"github.com/status-im/status-go/walletdatabase"
-
 	"github.com/stretchr/testify/require"
-
-	"go.uber.org/mock/gomock"
 )
 
 func TestIDs(t *testing.T) {
@@ -24,72 +14,4 @@ func TestIDs(t *testing.T) {
 		ID: "testID",
 	})
 	require.Equal(t, "testID", clientWithParams.ID())
-}
-
-func getTokenSymbols(t *testing.T) []string {
-	appDB, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
-	require.NoError(t, err)
-
-	walletDB, err := helpers.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
-	require.NoError(t, err)
-
-	networksList := []params.Network{
-		{
-			ChainID: w_common.EthereumMainnet,
-		},
-		{
-			ChainID: w_common.OptimismMainnet,
-		},
-		{
-			ChainID: w_common.ArbitrumMainnet,
-		},
-	}
-
-	ptrNetworkList := make([]*params.Network, 0, len(networksList))
-	for i := range networksList {
-		ptrNetworkList = append(ptrNetworkList, &networksList[i])
-	}
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	networkManager := mock_network.NewMockManagerInterface(ctrl)
-	networkManager.EXPECT().Get(gomock.Any()).Return(ptrNetworkList, nil).AnyTimes()
-	networkManager.EXPECT().GetAll().Return(ptrNetworkList, nil).AnyTimes()
-	networkManager.EXPECT().GetConfiguredNetworks().Return(networksList).AnyTimes()
-
-	// Skeleton token store to get full list of tokens
-	tm := token.NewTokenManager(walletDB, nil, nil, networkManager, appDB, nil, nil, nil, nil, nil)
-
-	tokens, err := tm.GetAllTokens()
-	require.NoError(t, err)
-
-	symbolsMap := make(map[string]bool)
-	for _, token := range tokens {
-		symbolsMap[token.Symbol] = true
-	}
-
-	symbols := make([]string, 0, len(symbolsMap))
-	for symbol := range symbolsMap {
-		symbols = append(symbols, symbol)
-	}
-
-	return symbols
-}
-
-func TestFetchPrices(t *testing.T) {
-	t.Skip("Accesses network, only to be run in dev machine")
-	symbols := getTokenSymbols(t)
-
-	stdClient := NewClient()
-	_, err := stdClient.FetchPrices(symbols, []string{"USD"})
-	require.NoError(t, err)
-}
-
-func TestFetchTokenMarketValues(t *testing.T) {
-	t.Skip("Accesses network, only to be run manually in dev machine")
-	symbols := getTokenSymbols(t)
-
-	stdClient := NewClient()
-	_, err := stdClient.FetchTokenMarketValues(symbols, "USD")
-	require.NoError(t, err)
 }

--- a/services/wallet/thirdparty/utils/symbols_test.go
+++ b/services/wallet/thirdparty/utils/symbols_test.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RenameSymbols(t *testing.T) {
+	symbols := []string{"STT", "ETH", "BTC"}
+	renames := RenameSymbols(symbols)
+	require.Equal(t, []string{"SNT", "ETH", "BTC"}, renames)
+}
+
+func Test_RemoveDuplicates(t *testing.T) {
+	strings := []string{"STT", "ETH", "BTC", "ETH", "BTC"}
+	uniqueStrings := RemoveDuplicates(strings)
+	require.Equal(t, []string{"STT", "ETH", "BTC"}, uniqueStrings)
+}
+
+func Test_GetRealSymbol(t *testing.T) {
+	require.Equal(t, "SNT", GetRealSymbol("STT"))
+	require.Equal(t, "ETH", GetRealSymbol("ETH"))
+}
+
+func Test_ChunkSymbols(t *testing.T) {
+	symbols := []string{"STT", "ETH", "BTC"}
+	params := ChunkSymbolsParams{MaxCharsPerChunk: 10, ExtraCharsPerSymbol: 1}
+	chunks, err := ChunkSymbols(symbols, params)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"STT", "ETH"}, {"BTC"}}, chunks)
+
+	params = ChunkSymbolsParams{MaxCharsPerChunk: 10, ExtraCharsPerSymbol: 2}
+	chunks, err = ChunkSymbols(symbols, params)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"STT", "ETH"}, {"BTC"}}, chunks)
+
+	params = ChunkSymbolsParams{MaxCharsPerChunk: 4, ExtraCharsPerSymbol: 1}
+	chunks, err = ChunkSymbols(symbols, params)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"STT"}, {"ETH"}, {"BTC"}}, chunks)
+
+	params = ChunkSymbolsParams{MaxSymbolsPerChunk: 1, MaxCharsPerChunk: 10, ExtraCharsPerSymbol: 2}
+	chunks, err = ChunkSymbols(symbols, params)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"STT"}, {"ETH"}, {"BTC"}}, chunks)
+
+	params = ChunkSymbolsParams{MaxCharsPerChunk: 9, ExtraCharsPerSymbol: 2}
+	chunks, err = ChunkSymbols(symbols, params)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{{"STT"}, {"ETH"}, {"BTC"}}, chunks)
+
+	params = ChunkSymbolsParams{MaxCharsPerChunk: 2, ExtraCharsPerSymbol: 1}
+	chunks, err = ChunkSymbols([]string{}, params)
+	require.NoError(t, err)
+	require.Len(t, chunks, 0)
+
+	params = ChunkSymbolsParams{MaxCharsPerChunk: 2, ExtraCharsPerSymbol: 1}
+	_, err = ChunkSymbols(symbols, params)
+	require.Error(t, err)
+}

--- a/tests-unit-network/README.MD
+++ b/tests-unit-network/README.MD
@@ -1,0 +1,12 @@
+## Overview
+
+Tests for status-go that require access to the network (for example, chain/market/collectibles providers).
+
+## Table of Contents
+
+- [Overview](#overview)
+- [How to Run](#how-to-run)
+
+## How to Run
+
+`make test-unit-network`

--- a/tests-unit-network/cryptocompare/cryptocompare_test.go
+++ b/tests-unit-network/cryptocompare/cryptocompare_test.go
@@ -1,0 +1,84 @@
+package cryptocompare_tests
+
+import (
+	"testing"
+
+	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/params"
+	mock_network "github.com/status-im/status-go/rpc/network/mock"
+	w_common "github.com/status-im/status-go/services/wallet/common"
+	"github.com/status-im/status-go/services/wallet/thirdparty/cryptocompare"
+	"github.com/status-im/status-go/services/wallet/token"
+	"github.com/status-im/status-go/t/helpers"
+	"github.com/status-im/status-go/walletdatabase"
+
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/mock/gomock"
+)
+
+func getTokenSymbols(t *testing.T) []string {
+	appDB, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
+	require.NoError(t, err)
+
+	walletDB, err := helpers.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
+	require.NoError(t, err)
+
+	networksList := []params.Network{
+		{
+			ChainID: w_common.EthereumMainnet,
+		},
+		{
+			ChainID: w_common.OptimismMainnet,
+		},
+		{
+			ChainID: w_common.ArbitrumMainnet,
+		},
+	}
+
+	ptrNetworkList := make([]*params.Network, 0, len(networksList))
+	for i := range networksList {
+		ptrNetworkList = append(ptrNetworkList, &networksList[i])
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	networkManager := mock_network.NewMockManagerInterface(ctrl)
+	networkManager.EXPECT().Get(gomock.Any()).Return(ptrNetworkList, nil).AnyTimes()
+	networkManager.EXPECT().GetAll().Return(ptrNetworkList, nil).AnyTimes()
+	networkManager.EXPECT().GetConfiguredNetworks().Return(networksList).AnyTimes()
+
+	// Skeleton token store to get full list of tokens
+	tm := token.NewTokenManager(walletDB, nil, nil, networkManager, appDB, nil, nil, nil, nil, nil)
+
+	tokens, err := tm.GetAllTokens()
+	require.NoError(t, err)
+
+	symbolsMap := make(map[string]bool)
+	for _, token := range tokens {
+		symbolsMap[token.Symbol] = true
+	}
+
+	symbols := make([]string, 0, len(symbolsMap))
+	for symbol := range symbolsMap {
+		symbols = append(symbols, symbol)
+	}
+
+	return symbols
+}
+
+func TestFetchPrices(t *testing.T) {
+	symbols := getTokenSymbols(t)
+
+	stdClient := cryptocompare.NewClient()
+	_, err := stdClient.FetchPrices(symbols, []string{"USD"})
+	require.NoError(t, err)
+}
+
+func TestFetchTokenMarketValues(t *testing.T) {
+	symbols := getTokenSymbols(t)
+
+	stdClient := cryptocompare.NewClient()
+	_, err := stdClient.FetchTokenMarketValues(symbols, "USD")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Attempt to fix errors 1-3 listed here https://github.com/status-im/status-mobile/pull/21445#issuecomment-2417307858

Cryptocompare doesn't allow specifying a list of currencies longer than 300 characters. 
![image](https://github.com/user-attachments/assets/2da08503-ddbc-4606-817f-fd48b89e867e)
We were using a limit of 60 symbols for `FetchPrices` and 100 symbols for `FetchTokenMarketValues`. The first one is wasteful, the second one results in an error if some symbols have more than 3 chars.
We're now using the actual 300 character limit when building the chunks, so we should never face the error again.

One additional change. Even though it should be the same as the default value, we're now setting parameter `relaxedValidation` explicitly to true. This way we ensure we won't get an error if no market data is available for some of the requested symbols.

![image](https://github.com/user-attachments/assets/d9959a16-57f2-43fe-aafe-1a5c64dde314)
