### PR TITLE
feat(nwaku)_: message publisher and sent verifier

### DIFF
--- a/timesource/timesource_test.go
+++ b/timesource/timesource_test.go
@@ -277,14 +277,12 @@ func TestGetCurrentTimeInMillis(t *testing.T) {
 	// test repeat invoke GetCurrentTimeInMillis
 	n = ts.GetCurrentTimeInMillis()
 	require.Equal(t, expectedTime, n)
-	e := ts.Stop()
-	require.NoError(t, e)
+	ts.Stop()
 
 	// test invoke after stop
 	n = ts.GetCurrentTimeInMillis()
 	require.Equal(t, expectedTime, n)
-	e = ts.Stop()
-	require.NoError(t, e)
+	ts.Stop()
 }
 
 func TestGetCurrentTimeOffline(t *testing.T) {

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -1951,22 +1951,6 @@ func (w *Waku) LegacyStoreNode() legacy_store.Store {
 	return w.node.LegacyStore()
 }
 
-func (w *Waku) WakuLightpushPublish(message *pb.WakuMessage, pubsubTopic string) (string, error) {
-	msgHash, err := w.node.Lightpush().Publish(w.ctx, message, lightpush.WithPubSubTopic(pubsubTopic))
-	if err != nil {
-		return "", err
-	}
-	return msgHash.String(), nil
-}
-
-func (w *Waku) WakuRelayPublish(message *pb.WakuMessage, pubsubTopic string) (string, error) {
-	msgHash, err := w.node.Relay().Publish(w.ctx, message, relay.WithPubSubTopic(pubsubTopic))
-	if err != nil {
-		return "", err
-	}
-	return msgHash.String(), nil
-}
-
 func (w *Waku) ListPeersInMesh(pubsubTopic string) (int, error) {
 	listPeers := w.node.Relay().PubSub().ListPeers(pubsubTopic)
 	return len(listPeers), nil

--- a/wakuv2/message_publishing.go
+++ b/wakuv2/message_publishing.go
@@ -1,6 +1,5 @@
 package wakuv2
 
-/* TODO-nwaku
 import (
 	"errors"
 
@@ -93,6 +92,7 @@ func (w *Waku) publishEnvelope(envelope *protocol.Envelope) {
 		err = w.messageSender.Send(publish.NewRequest(w.ctx, envelope))
 	}
 
+	/* TODO-nwaku
 	if w.statusTelemetryClient != nil {
 		if err == nil {
 			w.statusTelemetryClient.PushSentEnvelope(w.ctx, SentEnvelope{Envelope: envelope, PublishMethod: w.messageSender.PublishMethod()})
@@ -100,6 +100,7 @@ func (w *Waku) publishEnvelope(envelope *protocol.Envelope) {
 			w.statusTelemetryClient.PushErrorSendingEnvelope(w.ctx, ErrorSendingEnvelope{Error: err, SentEnvelope: SentEnvelope{Envelope: envelope, PublishMethod: w.messageSender.PublishMethod()}})
 		}
 	}
+	*/
 
 	if err != nil {
 		logger.Error("could not send message", zap.Error(err))
@@ -117,4 +118,3 @@ func (w *Waku) publishEnvelope(envelope *protocol.Envelope) {
 		})
 	}
 }
-*/

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -163,6 +163,11 @@ func TestBasicWakuV2(t *testing.T) {
 	storeNodeInfo, err := GetNwakuInfo(nil, &extNodeRestPort)
 	require.NoError(t, err)
 
+	wakuConfig := Config{
+		UseThrottledPublish: true,
+		ClusterID:           16,
+	}
+
 	nwakuConfig := WakuConfig{
 		Port:            30303,
 		NodeKey:         "11d0dcea28e86f81937a3bd1163473c7fbc0a0db54fd72914849bc47bdf78710",
@@ -176,7 +181,7 @@ func TestBasicWakuV2(t *testing.T) {
 		Shards:          []uint16{64},
 	}
 
-	w, err := New(nil, "", &nwakuConfig, nil, nil, nil, nil, nil)
+	w, err := New(nil, "", &wakuConfig, &nwakuConfig, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 


### PR DESCRIPTION
Adds the message publisher and verifier implementation that uses nwaku for most of its functionality.
Note that it uses some protobuffers from go-waku. We should probably change this to generate the protobuffers from https://github.com/waku-org/waku-proto instead of using those from go-waku, but this is something that can be done on a separate PR.