### PR TITLE
fix_: no test reporting to codecov

### DIFF
--- a/_assets/scripts/codecov.sh
+++ b/_assets/scripts/codecov.sh
@@ -16,7 +16,11 @@ report_to_codecov() {
     report_files_args+="--file ${file} "
   done
 
-  codecov do-upload --token "${CODECOV_TOKEN}" --report-type test_results ${report_files_args}
+  # Don't upload test results to Codecov while we re-run tests on failure.
+  # This results in having both failure and success results in the same report, which Codecov treats as a failure
+  # and doesn't report coverage to Github. More details here: https://github.com/status-im/status-go/issues/5963
+  #  codecov do-upload --token "${CODECOV_TOKEN}" --report-type test_results ${report_files_args}
+
   codecov upload-process --token "${CODECOV_TOKEN}" -f ${coverage_report} -F "${flag}"
 }
 


### PR DESCRIPTION
Part of https://github.com/status-im/status-go/issues/5963

# Description

Remove uploading test results to Codecov. Can be brought back when we don't re-run tests on failure.

Re-running tests results in having both failure and success results in the same report, which Codecov treats as a failure and doesn't report coverage to Github. More details here: https://github.com/status-im/status-go/issues/5963

# Result

Sems to work ok now, even when a test is failing once:

<img width="796" alt="image" src="https://github.com/user-attachments/assets/b774386d-91e1-40b3-bcc8-6239c06161a7">

<img width="660" alt="image" src="https://github.com/user-attachments/assets/446d670f-f5cc-4a2f-8b5b-3f59b2bee267">

<img width="773" alt="image" src="https://github.com/user-attachments/assets/b5f18e92-b6fd-4567-9d5e-601e6f6bc181">

<details>
    <summary>Flaky test example</summary>

```go

package flaky_test
import (
	"os"
	"testing"
)
const stateFile = "test_state.txt"
func TestFlaky(t *testing.T) {
	if !checkState() {
		// First run: fail the test
		t.Errorf("Test failed on first run!")
	} else {
		// Second run: pass the test
		t.Log("Test passed on second run!")
		resetState()
	}
}
func checkState() bool {
	// Check if the state file exists
	if _, err := os.Stat(stateFile); !os.IsNotExist(err) {
		// If file exists, return true (pass on second run)
		return true
	}
	// If file doesn't exist, create it and return false (fail on first run)
	f, _ := os.Create(stateFile)
	defer f.Close()
	return false
}
func resetState() {
	// Remove the state file to reset the test state
	os.Remove(stateFile)
}
```

</details>