### PR TITLE
feat(telemetry)_: track total bandwidth

### DIFF
--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -575,8 +575,9 @@ func (w *Waku) telemetryBandwidthStats(telemetryServerURL string) {
 			return
 		case <-ticker.C:
 			bandwidthPerProtocol := w.bandwidthCounter.GetBandwidthByProtocol()
+			totals := w.bandwidthCounter.GetBandwidthTotals()
 			w.bandwidthCounter.Reset()
-			go telemetry.PushProtocolStats(bandwidthPerProtocol)
+			go telemetry.PushProtocolStats(bandwidthPerProtocol, totals)
 		}
 	}
 }

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -790,7 +790,7 @@ func TestTelemetryFormat(t *testing.T) {
 	m[legacy_store.StoreID_v20beta4] = s
 	m[lightpush.LightPushID_v20beta1] = s
 
-	requestBody := tc.getTelemetryRequestBody(m)
+	requestBody := tc.getTelemetryRequestBody(m, s)
 	_, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Include total bandwidth in addition to bandwidth per protocol when pushing telemetry.

If telemetry is enabled, the node periodically sends the bandwidth as tracked by go-libp2p to the telemetry service. Currently, it sends the bandwidth as determined by which protocol was used. This adds an additional metric which tracks the total bandwidth as measured by libp2p.

Important changes:
- Depends on https://github.com/status-im/telemetry/pull/70

Closes https://github.com/status-im/telemetry/issues/62
