### PR TITLE
chore(ci)_: always clean linux workspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,7 @@ test-e2e: ##@tests Run e2e tests
 test-e2e-race: export GOTEST_EXTRAFLAGS=-race
 test-e2e-race: test-e2e ##@tests Run e2e tests with -race flag
 
+test-functional: generate
 test-functional: export FUNCTIONAL_TESTS_DOCKER_UID ?= $(call sh, id -u)
 test-functional: export FUNCTIONAL_TESTS_REPORT_CODECOV ?= false
 test-functional:

--- a/tests-functional/tests/test_router.py
+++ b/tests-functional/tests/test_router.py
@@ -111,5 +111,5 @@ class TestTransactionFromRoute(SignalTestCase):
         tx_details = response.json()["result"]
 
         assert tx_details["value"] == amount_in
-        assert tx_details["to"] == user_2.address
-        assert tx_details["from"] == user_1.address
+        assert tx_details["to"].upper() == user_2.address.upper()
+        assert tx_details["from"].upper() == user_1.address.upper()


### PR DESCRIPTION
## Summary

Add `cleanWs()` at the end of Linux pipeline, to clean up workspace.
Otherwise we may see errors like these : 

```
[2024-10-21T13:35:07.111Z] + ln -s /home/jenkins/workspace/go_prs_linux_x86_64_main_PR-5941
/home/jenkins/workspace/go_prs_linux_x86_64_main_PR-5941@tmp/go/src/github.com/status-im/status-go

[2024-10-21T13:35:07.111Z] ln: failed to create symbolic link 
'/home/jenkins/workspace/go_prs_linux_x86_64_main_PR-5941@tmp/go/src/github.com/status-im/status-go': 
File exists

script returned exit code 1
```
as reported by @alaibe, @dlipicar  

This PR also : 
- adds `generate` a dependency of `functional-test` target to fix errors like this : 
```
[+] Running 7/7
 ✔ Container tests-functional-tests-rpc-1                     Removed                                                                                                                                                                                                      0.0s
 ✔ Container tests-functional-status-backend-1                Removed                                                                                                                                                                                                      0.0s
 ✔ Container tests-functional-status-go-1                     Removed                                                                                                                                                                                                      0.0s
 ✔ Container tests-functional-deploy-communities-contracts-1  Removed                                                                                                                                                                                                      0.0s
 ✔ Container tests-functional-deploy-sntv2-1                  Removed                                                                                                                                                                                                      0.0s
 ✔ Container tests-functional-anvil-1                         Removed                                                                                                                                                                                                      0.0s
 ✔ Network tests-functional_default                           Removed                                                                                                                                                                                                      0.0s
Collecting code coverage reports
Generating HTML coverage report
cover: can't read "github.com/status-im/status-go/appdatabase/migrations/bindata.go": open
 /Users/siddarthkumar/gopath/src/github.com/status-im/status-go/appdatabase/migrations/bindata.go: 
 no such file or directory
Testing finished
```
- fixes assert statement in `tests/test_router.py` for this failure : 
```
Error
AssertionError: assert '0x70997970C5...50e0d17dc79C8' == '0x70997970c5...50e0d17dc79c8'
  - 0x70997970c51812dc3a010c7d01b50e0d17dc79c8
  ?           ^        ^   ^                ^
  + 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
  ?           ^        ^   ^                ^
Stacktrace
tests/test_router.py:114: in test_tx_from_route
    assert tx_details["to"] == user_2.address
E   AssertionError: assert '0x70997970C5...50e0d17dc79C8' == '0x70997970c5...50e0d17dc79c8'
E     - 0x70997970c51812dc3a010c7d01b50e0d17dc79c8
E     ?           ^        ^   ^                ^
E     + 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
E     ?   
```



