### PR TITLE
fix_: functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,6 +398,7 @@ test-e2e: ##@tests Run e2e tests
 test-e2e-race: export GOTEST_EXTRAFLAGS=-race
 test-e2e-race: test-e2e ##@tests Run e2e tests with -race flag
 
+test-functional: generate
 test-functional: export FUNCTIONAL_TESTS_DOCKER_UID ?= $(call sh, id -u)
 test-functional: export FUNCTIONAL_TESTS_REPORT_CODECOV ?= false
 test-functional:

--- a/tests-functional/tests/test_router.py
+++ b/tests-functional/tests/test_router.py
@@ -111,5 +111,5 @@ class TestTransactionFromRoute(SignalTestCase):
         tx_details = response.json()["result"]
 
         assert tx_details["value"] == amount_in
-        assert tx_details["to"] == user_2.address
-        assert tx_details["from"] == user_1.address
+        assert tx_details["to"].upper() == user_2.address.upper()
+        assert tx_details["from"].upper() == user_1.address.upper()


### PR DESCRIPTION
1. Run `generate` on `test-functional`
    ```
    [2024-10-23T09:08:14.647Z] Generating HTML coverage report
    [2024-10-23T09:08:15.912Z] cover: can't read "github.com/status-im/status-go/appdatabase/migrations/bindata.go": open /home/jenkins/workspace/status-go_prs_tests-rpc_PR-5969/appdatabase/migrations/bindata.go: no such file or directory
    ```
2. Fix case-sensitive comparison 
    ```
    tests/test_router.py:114: in test_tx_from_route
        assert tx_details["to"] == user_2.address
    E   AssertionError: assert '0x70997970C5...50e0d17dc79C8' == '0x70997970c5...50e0d17dc79c8'
    E     - 0x70997970c51812dc3a010c7d01b50e0d17dc79c8
    E     ?           ^        ^   ^                ^
    E     + 0x70997970C51812dc3A010C7d01b50e0d17dc79C8
    E     ?           ^        ^   ^                ^
    ```