### PR TITLE
fix(ci)_: remove workspace and tmp dir

### DIFF
--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -85,6 +85,9 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { sh 'make deep-clean' }
+    cleanup {
+      cleanWs()
+      dir("${env.WORKSPACE}@tmp") { deleteDir() }
+    }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -89,6 +89,9 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { sh 'make deep-clean' }
+    cleanup {
+      cleanWs()
+      dir("${env.WORKSPACE}@tmp") { deleteDir() }
+    }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.linux
+++ b/_assets/ci/Jenkinsfile.linux
@@ -92,6 +92,9 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { sh 'make deep-clean' }
+    cleanup {
+      cleanWs()
+      dir("${env.WORKSPACE}@tmp") { deleteDir() }
+    }
   } // post
 } // pipeline

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -238,8 +238,8 @@ pipeline {
       }
     }
     cleanup {
-      dir(env.TMPDIR) { deleteDir() }
-      sh "make git-clean"
+      cleanWs()
+      dir("${env.WORKSPACE}@tmp") { deleteDir() }
     }
   } // post
 } // pipeline


### PR DESCRIPTION
This ensures we do not encounter weird errors like:
```
+ ln -s /home/jenkins/workspace/go_prs_linux_x86_64_main_PR-5907 /home/jenkins/workspace/go_prs_linux_x86_64_main_PR-5907@tmp/go/src/github.com/status-im/status-go
ln: failed to create symbolic link '/home/jenkins/workspace/go_prs_linux_x86_64_main_PR-5907@tmp/go/src/github.com/status-im/status-go': File exists
script returned exit code 1
```