### PR TITLE
chore(wallet)_: returns last timestamps of successful GetWalletToken updates

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -89,7 +89,7 @@ func (api *API) GetWalletToken(ctx context.Context, addresses []common.Address) 
 	return api.reader.GetWalletToken(ctx, clients, addresses, currency)
 }
 
-func (api *API) GetLastWalletTokenUpdate() map[common.Address]time.Time {
+func (api *API) GetLastWalletTokenUpdate() map[common.Address]int64 {
 	return api.reader.GetLastTokenUpdateTimestamps()
 }
 

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -89,6 +89,10 @@ func (api *API) GetWalletToken(ctx context.Context, addresses []common.Address) 
 	return api.reader.GetWalletToken(ctx, clients, addresses, currency)
 }
 
+func (api *API) GetLastWalletTokenUpdate() map[common.Address]time.Time {
+	return api.reader.GetLastTokenUpdateTimestamps()
+}
+
 // GetBalancesByChain return a map with key as chain id and value as map of account address and map of token address and balance
 // [chainID][account][token]balance
 func (api *API) GetBalancesByChain(ctx context.Context, chainIDs []uint64, addresses, tokens []common.Address) (map[uint64]map[common.Address]map[common.Address]*hexutil.Big, error) {

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -558,14 +558,14 @@ func (r *Reader) GetWalletToken(ctx context.Context, clients map[uint64]chain.Cl
 }
 
 // GetLastTokenUpdateTimestamps returns last timestamps of successful token updates
-func (r *Reader) GetLastTokenUpdateTimestamps() map[common.Address]time.Time {
-	result := make(map[common.Address]time.Time)
+func (r *Reader) GetLastTokenUpdateTimestamps() map[common.Address]int64 {
+	result := make(map[common.Address]int64)
 
 	r.lastWalletTokenUpdateTimestamp.Range(func(key, value interface{}) bool {
 		addr, ok1 := key.(common.Address)
 		timestamp, ok2 := value.(int64)
 		if ok1 && ok2 {
-			result[addr] = time.Unix(timestamp, 0)
+			result[addr] = timestamp
 		}
 		return true
 	})

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -557,6 +557,22 @@ func (r *Reader) GetWalletToken(ctx context.Context, clients map[uint64]chain.Cl
 	return result, r.persistence.SaveTokens(result)
 }
 
+// GetLastTokenUpdateTimestamps returns last timestamps of successful token updates
+func (r *Reader) GetLastTokenUpdateTimestamps() map[common.Address]time.Time {
+	result := make(map[common.Address]time.Time)
+
+	r.lastWalletTokenUpdateTimestamp.Range(func(key, value interface{}) bool {
+		addr, ok1 := key.(common.Address)
+		timestamp, ok2 := value.(int64)
+		if ok1 && ok2 {
+			result[addr] = time.Unix(timestamp, 0)
+		}
+		return true
+	})
+
+	return result
+}
+
 func isCachedToken(cachedTokens map[common.Address][]token.StorageToken, address common.Address, symbol string, chainID uint64) bool {
 	if tokens, ok := cachedTokens[address]; ok {
 		for _, t := range tokens {

--- a/services/wallet/reader_test.go
+++ b/services/wallet/reader_test.go
@@ -1061,3 +1061,28 @@ func TestFetchOrGetCachedWalletBalances(t *testing.T) {
 	_, err := reader.FetchOrGetCachedWalletBalances(context.TODO(), clients, addresses, false)
 	require.Error(t, err)
 }
+
+// TestGetLastTokenUpdateTimestamps tests the GetLastTokenUpdateTimestamps method.
+func TestGetLastTokenUpdateTimestamps(t *testing.T) {
+	// Setup the Reader and mock dependencies.
+	reader, _, _, mockCtrl := setupReader(t)
+	defer mockCtrl.Finish()
+
+	// Define test addresses and specific timestamps.
+	address1 := testAccAddress1
+	address2 := testAccAddress2
+	timestamp1 := time.Now().Add(-1 * time.Hour).Unix()
+	timestamp2 := time.Now().Add(-2 * time.Hour).Unix()
+
+	// Store valid timestamps in the Reader's sync.Map.
+	reader.lastWalletTokenUpdateTimestamp.Store(address1, timestamp1)
+	reader.lastWalletTokenUpdateTimestamp.Store(address2, timestamp2)
+
+	timestamps := reader.GetLastTokenUpdateTimestamps()
+	require.Len(t, timestamps, 2, "Expected two timestamps in the result map")
+
+	// Verify that the retrieved timestamps match the stored values.
+	assert.Equal(t, time.Unix(timestamp1, 0), timestamps[address1], "Timestamp for address1 does not match")
+	assert.Equal(t, time.Unix(timestamp2, 0), timestamps[address2], "Timestamp for address2 does not match")
+
+}

--- a/services/wallet/reader_test.go
+++ b/services/wallet/reader_test.go
@@ -1078,11 +1078,11 @@ func TestGetLastTokenUpdateTimestamps(t *testing.T) {
 	reader.lastWalletTokenUpdateTimestamp.Store(address1, timestamp1)
 	reader.lastWalletTokenUpdateTimestamp.Store(address2, timestamp2)
 
+	// Call the method to retrieve timestamps.
 	timestamps := reader.GetLastTokenUpdateTimestamps()
 	require.Len(t, timestamps, 2, "Expected two timestamps in the result map")
 
 	// Verify that the retrieved timestamps match the stored values.
-	assert.Equal(t, time.Unix(timestamp1, 0), timestamps[address1], "Timestamp for address1 does not match")
-	assert.Equal(t, time.Unix(timestamp2, 0), timestamps[address2], "Timestamp for address2 does not match")
-
+	assert.Equal(t, timestamp1, timestamps[address1], "Timestamp for address1 does not match")
+	assert.Equal(t, timestamp2, timestamps[address2], "Timestamp for address2 does not match")
 }


### PR DESCRIPTION
In `wallet/reader.go` we already have a mechanism to store timestamps when token info is updated in `FetchBalances` and `GetWalletToken`.
In this PR I just expose this map (address -> last update timestamp) to the API.

This should help @alwx with status-im/status-mobile#21401
Closed #5987 