### PR TITLE
fix(tests)_: use non-standard port to avoid conflicts

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -64,7 +64,7 @@ pipeline {
   environment {
     PLATFORM    = 'tests'
     DB_CONT     = "status-go-test-db-${env.EXECUTOR_NUMBER.toInteger() + 1}"
-    DB_PORT     = "${5432 + env.EXECUTOR_NUMBER.toInteger()}"
+    DB_PORT     = "${54321 + env.EXECUTOR_NUMBER.toInteger()}"
     TMPDIR      = "${WORKSPACE_TMP}"
     GOPATH      = "${WORKSPACE_TMP}/go"
     GOCACHE     = "${WORKSPACE_TMP}/gocache"


### PR DESCRIPTION
We have observed `nimbus-eth2` build failures reporting this port:
```json
{
  "lvl": "NTC",
  "ts": "2024-10-28 13:51:32.308+00:00",
  "msg": "REST HTTP server could not be started",
  "topics": "beacnde",
  "address": "127.0.0.1:5432",
  "reason": "(98) Address already in use"
}
```
https://ci.status.im/job/nimbus-eth2/job/platforms/job/linux/job/x86_64/job/main/job/PR-6683/3/