### PR TITLE
fix(ci)_: skip windows build cleanup stage

### DIFF
--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -110,18 +110,14 @@ pipeline {
             }
         }
     }
-    stage('Cleanup') {
-        steps {
-            script {
-                cleanTmp()
-                }
-            }
-        }
 } // stages
   post {
      success { script { github.notifyPR(true) } }
      failure { script { github.notifyPR(false) } }
-     cleanup { cleanWs() }
+     cleanup {
+       cleanWs()
+       cleanTmp()
+     }
   } // post
 } // pipeline
 
@@ -158,9 +154,8 @@ def shell(cmd) {
 }
 
 def cleanTmp() {
-    if (env.PLATFORM == 'windows') {
-        sh "rm -rf ${env.WORKSPACE}@tmp"
-    } else {
+    /* Fails on windows due to Durable Task plugin failure. */
+    if (env.PLATFORM != 'windows') {
         dir("${env.WORKSPACE}@tmp") { deleteDir() }
     }
 }


### PR DESCRIPTION
Windows build pipeline has errors while running:
```sh
sh "rm -rf ${env.WORKSPACE}@tmp"
```
In cleanup stage:
```groovy
process apparently never started in J:/Users/jenkins/workspace/_prs_windows_x86_64_main_PR-5990@tmp/durable-478fb71e
(running Jenkins temporarily with -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true might make the problem clearer)
```
Related with [Durable Task Plugin](https://plugins.jenkins.io/durable-task/).

Quick fix would be skipping this stage on Windows due to `tmp` folder being empty, as they should be at the end of the pipeline. 
Opting only for
```groovy
cleanup { cleanWs() }
```
as post cleanup step.