### PR TITLE
chore(nwaku)_: ping storenodes using AddrInfo

### DIFF
--- a/eth-node/bridge/geth/waku.go
+++ b/eth-node/bridge/geth/waku.go
@@ -63,11 +63,6 @@ func (w *GethWakuWrapper) StopDiscV5() error {
 	return errors.New("not available in WakuV1")
 }
 
-// PeerCount function only added for compatibility with waku V2
-func (w *GethWakuWrapper) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
-	return "", errors.New("not available in WakuV1")
-}
-
 // SubscribeToPubsubTopic function only added for compatibility with waku V2
 func (w *GethWakuWrapper) SubscribeToPubsubTopic(topic string, optPublicKey *ecdsa.PublicKey) error {
 	// not available in WakuV1

--- a/eth-node/bridge/geth/wakuv2.go
+++ b/eth-node/bridge/geth/wakuv2.go
@@ -206,10 +206,6 @@ func (w *gethWakuV2Wrapper) RemovePubsubTopicKey(topic string) error {
 	return w.waku.RemovePubsubTopicKey(topic)
 }
 
-func (w *gethWakuV2Wrapper) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
-	return w.waku.AddStorePeer(address)
-}
-
 func (w *gethWakuV2Wrapper) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return w.waku.AddRelayPeer(address)
 }

--- a/eth-node/types/waku.go
+++ b/eth-node/types/waku.go
@@ -134,8 +134,6 @@ type Waku interface {
 
 	RemovePubsubTopicKey(topic string) error
 
-	AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error)
-
 	AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error)
 
 	DialPeer(address multiaddr.Multiaddr) error

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20241024184757-fdb3c3d0b35a
+	github.com/waku-org/go-waku v0.8.1-0.20241028194639-dd82c24e0057
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -2136,8 +2136,8 @@ github.com/waku-org/go-libp2p-pubsub v0.12.0-gowaku.0.20240823143342-b0f2429ca27
 github.com/waku-org/go-libp2p-pubsub v0.12.0-gowaku.0.20240823143342-b0f2429ca27f/go.mod h1:Oi0zw9aw8/Y5GC99zt+Ef2gYAl+0nZlwdJonDyOz/sE=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20241024184757-fdb3c3d0b35a h1:epN2bp1mPzdg3S7S2iR72GsUPix7irc3UgM4W9NZJpU=
-github.com/waku-org/go-waku v0.8.1-0.20241024184757-fdb3c3d0b35a/go.mod h1:1BRnyg2mQ2aBNLTBaPq6vEvobzywGykPOhGQFbHGf74=
+github.com/waku-org/go-waku v0.8.1-0.20241028194639-dd82c24e0057 h1:C/UCg3Z4avOxvZEvY0JzYmeAoqZUBnSE6PK/SaxfEAM=
+github.com/waku-org/go-waku v0.8.1-0.20241028194639-dd82c24e0057/go.mod h1:1BRnyg2mQ2aBNLTBaPq6vEvobzywGykPOhGQFbHGf74=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -833,17 +833,10 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	}
 	response := &MessengerResponse{}
 
-	storenodes, err := m.AllMailservers()
+	response.Mailservers, err = m.AllMailservers()
 	if err != nil {
 		return nil, err
 	}
-
-	err = m.setupStorenodes(storenodes)
-	if err != nil {
-		return nil, err
-	}
-
-	response.Mailservers = storenodes
 
 	m.transport.SetStorenodeConfigProvider(m)
 

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -4,8 +4,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 
-	"github.com/waku-org/go-waku/waku/v2/utils"
-
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/mailservers"
@@ -37,28 +35,6 @@ func (m *Messenger) AllMailservers() ([]mailservers.Mailserver, error) {
 	}
 
 	return allMailservers, nil
-}
-
-func (m *Messenger) setupStorenodes(storenodes []mailservers.Mailserver) error {
-	if m.transport.WakuVersion() != 2 {
-		return nil
-	}
-
-	for _, storenode := range storenodes {
-
-		peerInfo, err := storenode.PeerInfo()
-		if err != nil {
-			return err
-		}
-
-		for _, addr := range utils.EncapsulatePeerID(peerInfo.ID, peerInfo.Addrs...) {
-			_, err := m.transport.AddStorePeer(addr)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func (m *Messenger) getFleet() (string, error) {
@@ -93,63 +69,64 @@ func (m *Messenger) asyncRequestAllHistoricMessages() {
 	}()
 }
 
-func (m *Messenger) GetPinnedStorenode() (peer.ID, error) {
+func (m *Messenger) GetPinnedStorenode() (peer.AddrInfo, error) {
 	fleet, err := m.getFleet()
 	if err != nil {
-		return "", err
+		return peer.AddrInfo{}, err
 	}
 
 	pinnedMailservers, err := m.settings.GetPinnedMailservers()
 	if err != nil {
-		return "", err
+		return peer.AddrInfo{}, err
 	}
 
 	pinnedMailserver, ok := pinnedMailservers[fleet]
 	if !ok {
-		return "", nil
+		return peer.AddrInfo{}, nil
 	}
 
 	fleetMailservers := mailservers.DefaultMailservers()
 
 	for _, c := range fleetMailservers {
 		if c.Fleet == fleet && c.ID == pinnedMailserver {
-			return c.PeerID()
+			return c.PeerInfo()
 		}
 	}
 
 	if m.mailserversDatabase != nil {
 		customMailservers, err := m.mailserversDatabase.Mailservers()
 		if err != nil {
-			return "", err
+			return peer.AddrInfo{}, err
 		}
 
 		for _, c := range customMailservers {
 			if c.Fleet == fleet && c.ID == pinnedMailserver {
-				return c.PeerID()
+				return c.PeerInfo()
 			}
 		}
 	}
 
-	return "", nil
+	return peer.AddrInfo{}, nil
 }
 
 func (m *Messenger) UseStorenodes() (bool, error) {
 	return m.settings.CanUseMailservers()
 }
 
-func (m *Messenger) Storenodes() ([]peer.ID, error) {
+func (m *Messenger) Storenodes() ([]peer.AddrInfo, error) {
 	mailservers, err := m.AllMailservers()
 	if err != nil {
 		return nil, err
 	}
 
-	var result []peer.ID
+	var result []peer.AddrInfo
 	for _, m := range mailservers {
-		peerID, err := m.PeerID()
+
+		peerInfo, err := m.PeerInfo()
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, peerID)
+		result = append(result, peerInfo)
 	}
 
 	return result, nil

--- a/protocol/messenger_peers.go
+++ b/protocol/messenger_peers.go
@@ -11,10 +11,6 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 )
 
-func (m *Messenger) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
-	return m.transport.AddStorePeer(address)
-}
-
 func (m *Messenger) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return m.transport.AddRelayPeer(address)
 }

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -516,10 +516,6 @@ func (t *Transport) ENR() (*enode.Node, error) {
 	return t.waku.ENR()
 }
 
-func (t *Transport) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
-	return t.waku.AddStorePeer(address)
-}
-
 func (t *Transport) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return t.waku.AddRelayPeer(address)
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1477,14 +1477,6 @@ func (api *PublicAPI) StorePubsubTopicKey(topic string, privKey string) error {
 	return api.service.messenger.StorePubsubTopicKey(topic, p)
 }
 
-func (api *PublicAPI) AddStorePeer(address string) (peer.ID, error) {
-	maddr, err := multiaddr.NewMultiaddr(address)
-	if err != nil {
-		return "", err
-	}
-	return api.service.messenger.AddStorePeer(maddr)
-}
-
 func (api *PublicAPI) AddRelayPeer(address string) (peer.ID, error) {
 	maddr, err := multiaddr.NewMultiaddr(address)
 	if err != nil {

--- a/services/mailservers/database.go
+++ b/services/mailservers/database.go
@@ -49,13 +49,13 @@ type Mailserver struct {
 	FailedRequests uint   `json:"-"`
 }
 
-func (m Mailserver) PeerInfo() (*peer.AddrInfo, error) {
+func (m Mailserver) PeerInfo() (peer.AddrInfo, error) {
 	var maddrs []multiaddr.Multiaddr
 
 	if m.ENR != nil {
 		addrInfo, err := enr.EnodeToPeerInfo(m.ENR)
 		if err != nil {
-			return nil, err
+			return peer.AddrInfo{}, err
 		}
 		addrInfo.Addrs = utils.EncapsulatePeerID(addrInfo.ID, addrInfo.Addrs...)
 		maddrs = append(maddrs, addrInfo.Addrs...)
@@ -67,14 +67,14 @@ func (m Mailserver) PeerInfo() (*peer.AddrInfo, error) {
 
 	p, err := peer.AddrInfosFromP2pAddrs(maddrs...)
 	if err != nil {
-		return nil, err
+		return peer.AddrInfo{}, err
 	}
 
 	if len(p) != 1 {
-		return nil, errors.New("invalid mailserver setup")
+		return peer.AddrInfo{}, errors.New("invalid mailserver setup")
 	}
 
-	return &p[0], nil
+	return p[0], nil
 }
 
 func (m Mailserver) PeerID() (peer.ID, error) {

--- a/vendor/github.com/waku-org/go-waku/waku/v2/api/common/pinger.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/api/common/pinger.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 )
 
 type Pinger interface {
-	PingPeer(ctx context.Context, peerID peer.ID) (time.Duration, error)
+	PingPeer(ctx context.Context, peerInfo peer.AddrInfo) (time.Duration, error)
 }
 
 type defaultPingImpl struct {
@@ -23,8 +24,9 @@ func NewDefaultPinger(host host.Host) Pinger {
 	}
 }
 
-func (d *defaultPingImpl) PingPeer(ctx context.Context, peerID peer.ID) (time.Duration, error) {
-	pingResultCh := ping.Ping(ctx, d.host, peerID)
+func (d *defaultPingImpl) PingPeer(ctx context.Context, peerInfo peer.AddrInfo) (time.Duration, error) {
+	d.host.Peerstore().AddAddrs(peerInfo.ID, peerInfo.Addrs, peerstore.AddressTTL)
+	pingResultCh := ping.Ping(ctx, d.host, peerInfo.ID)
 	select {
 	case <-ctx.Done():
 		return 0, ctx.Err()

--- a/vendor/github.com/waku-org/go-waku/waku/v2/api/filter/filter_manager.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/api/filter/filter_manager.go
@@ -230,6 +230,7 @@ func (mgr *FilterManager) UnsubscribeFilter(filterID string) {
 		}
 		if len(af.sub.ContentFilter.ContentTopics) == 0 {
 			af.cancel()
+			delete(mgr.filterSubscriptions, filterConfig.ID)
 		} else {
 			go af.sub.Unsubscribe(filterConfig.contentFilter)
 		}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/api/history/sort.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/api/history/sort.go
@@ -7,7 +7,7 @@ import (
 )
 
 type SortedStorenode struct {
-	Storenode       peer.ID
+	Storenode       peer.AddrInfo
 	RTT             time.Duration
 	CanConnectAfter time.Time
 }

--- a/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_manager.go
@@ -101,7 +101,9 @@ const (
 const maxFailedAttempts = 5
 const prunePeerStoreInterval = 10 * time.Minute
 const peerConnectivityLoopSecs = 15
-const maxConnsToPeerRatio = 5
+const maxConnsToPeerRatio = 3
+const badPeersCleanupInterval = 1 * time.Minute
+const maxDialFailures = 2
 
 // 80% relay peers 20% service peers
 func relayAndServicePeers(maxConnections int) (int, int) {
@@ -256,16 +258,32 @@ func (pm *PeerManager) Start(ctx context.Context) {
 	}
 }
 
+func (pm *PeerManager) removeBadPeers() {
+	if !pm.RelayEnabled {
+		for _, peerID := range pm.host.Peerstore().Peers() {
+			if pm.host.Peerstore().(wps.WakuPeerstore).ConnFailures(peerID) > maxDialFailures {
+				//delete peer from peerStore
+				pm.logger.Debug("removing bad peer due to recurring dial failures", zap.Stringer("peerID", peerID))
+				pm.RemovePeer(peerID)
+			}
+		}
+	}
+}
+
 func (pm *PeerManager) peerStoreLoop(ctx context.Context) {
 	defer utils.LogOnPanic()
 	t := time.NewTicker(prunePeerStoreInterval)
+	t1 := time.NewTicker(badPeersCleanupInterval)
 	defer t.Stop()
+	defer t1.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
 			pm.prunePeerStore()
+		case <-t1.C:
+			pm.removeBadPeers()
 		}
 	}
 }
@@ -743,5 +761,10 @@ func (pm *PeerManager) HandleDialError(err error, peerID peer.ID) {
 		if emitterErr != nil {
 			pm.logger.Error("failed to emit DialError", zap.Error(emitterErr))
 		}
+	}
+	if !pm.RelayEnabled && pm.host.Peerstore().(wps.WakuPeerstore).ConnFailures(peerID) >= maxDialFailures {
+		//delete peer from peerStore
+		pm.logger.Debug("removing bad peer due to recurring dial failures", zap.Stringer("peerID", peerID))
+		pm.RemovePeer(peerID)
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1015,7 +1015,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20241024184757-fdb3c3d0b35a
+# github.com/waku-org/go-waku v0.8.1-0.20241028194639-dd82c24e0057
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -1821,14 +1821,6 @@ func (w *Waku) restartDiscV5(useOnlyDNSDiscCache bool) error {
 	return w.node.SetDiscV5Bootnodes(bootnodes)
 }
 
-func (w *Waku) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
-	peerID, err := w.node.AddPeer(address, wps.Static, w.cfg.DefaultShardedPubsubTopics, store.StoreQueryID_v300)
-	if err != nil {
-		return "", err
-	}
-	return peerID, nil
-}
-
 func (w *Waku) timestamp() int64 {
 	return w.timesource.Now().UnixNano()
 }

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -1383,7 +1383,12 @@ func (w *Waku) Start() error {
 	w.HistoryRetriever = history.NewHistoryRetriever(newStorenodeRequestor(w.wakuCtx, w.logger), NewHistoryProcessorWrapper(w), w.logger)
 	w.StorenodeCycle.Start(w.ctx)
 
-	w.logger.Info("WakuV2 PeerID", zap.Stringer("id", w.PeerID()))
+	peerID, err := w.PeerID()
+	if err != nil {
+		return err
+	}
+
+	w.logger.Info("WakuV2 PeerID", zap.Stringer("id", peerID))
 
 	/* TODO-nwaku
 	w.discoverAndConnectPeers()
@@ -2141,17 +2146,6 @@ func (w *Waku) restartDiscV5(useOnlyDNSDiscCache bool) error {
 	return w.node.SetDiscV5Bootnodes(bootnodes)
 }
 */
-
-func (w *Waku) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
-	// TODO-nwaku
-	/*
-		peerID, err := w.node.AddPeer(address, wps.Static, w.cfg.DefaultShardedPubsubTopics, store.StoreQueryID_v300)
-		if err != nil {
-			return "", err
-		}
-		return peerID, nil */
-	return "", nil
-}
 
 func (w *Waku) timestamp() int64 {
 	return w.timesource.Now().UnixNano()
@@ -3078,9 +3072,14 @@ func newPinger(wakuCtx unsafe.Pointer) commonapi.Pinger {
 	}
 }
 
-func (p *pinger) PingPeer(ctx context.Context, peerID peer.ID) (time.Duration, error) {
+func (p *pinger) PingPeer(ctx context.Context, peerInfo peer.AddrInfo) (time.Duration, error) {
+	addrs := make([]string, len(peerInfo.Addrs))
+	for i, addr := range utils.EncapsulatePeerID(peerInfo.ID, peerInfo.Addrs...) {
+		addrs[i] = addr.String()
+	}
+
 	var resp = C.allocResp()
-	var cPeerId = C.CString(peerID.String())
+	var cPeerId = C.CString(strings.Join(addrs, ","))
 	defer C.freeResp(resp)
 	defer C.free(unsafe.Pointer(cPeerId))
 


### PR DESCRIPTION
Instead of populating the node's peerstore and later using the peerID to choose the peers, we use the multiaddresses, by passing an AddrInfo instead of peerID.