### PR TITLE
chore_: configure codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@
 #  make codecov-validate
 
 codecov:
-  require_ci_to_pass: false
+  require_ci_to_pass: true
   notify:
     wait_for_ci: true
 
@@ -16,25 +16,25 @@ ignore:
 coverage:
   status:
     project:
-      default:
-        informational: true
       unit-tests:
         target: auto
+        threshold: 1
         flags:
           - unit
       functional-tests:
+        threshold: 0.1
         target: auto
         flags:
           - functional
     patch:
       default:
-        informational: true
+        target: 50
       unit-tests:
-        target: auto
+        informational: true
         flags:
           - unit
       functional-tests:
-        target: auto
+        informational: true
         flags:
           - functional
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,9 +2,10 @@
 #  make codecov-validate
 
 codecov:
-  require_ci_to_pass: true
+  require_ci_to_pass: false
   notify:
-    wait_for_ci: true
+    wait_for_ci: false
+    after_n_builds: 2
 
 ignore:
   - "_.*"


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/5978

Configured to have 5 status checks as following:
- Full coverage
  - `project/unit-tests`  - not to decrease, threshold 1%
  - `project/functional-tests` - not to decrease, threshold 0.1%
- Diff coverage
  - `patch` (total) - minimum 50%
  - `patch/unit-tests` - always passing, just show information
  - `patch/functional-tests` - always passing, just show information

Also added `require_ci_to_pass: true`. This should make all coverage reports to only be uploaded after both unit and functional tests finished execution.