### PR TITLE
ci_: configure test-run jobs

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -22,7 +22,7 @@ pipeline {
     )
     booleanParam(
       name: 'UNIT_TEST_RERUN_FAILS',
-      defaultValue: isPRJob(),
+      defaultValue: !isNightlyJob(),
       description: 'Should the job rerun failed tests?'
     )
     booleanParam(
@@ -56,7 +56,7 @@ pipeline {
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: getAmountToKeep(),
-      daysToKeepStr: '30',
+      daysToKeepStr: '-1',
       artifactNumToKeepStr: getAmountToKeep(),
     ))
   }
@@ -254,4 +254,4 @@ def getDefaultUnitTestCount() { isNightlyJob() ? '20' : '1' }
 
 def getDefaultTimeout() { isNightlyJob() ? 5*60 : 50 }
 
-def getAmountToKeep() { isNightlyJob() ? '14' : isDevelopJob() ? '10' : '5' }
+def getAmountToKeep() { isNightlyJob() ? '14' : isDevelopJob() ? '30' : '5' }

--- a/_assets/ci/Jenkinsfile.tests-rpc
+++ b/_assets/ci/Jenkinsfile.tests-rpc
@@ -24,9 +24,9 @@ pipeline {
     disableConcurrentBuilds()
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
-      numToKeepStr: '5',
-      daysToKeepStr: '30',
-      artifactNumToKeepStr: '1',
+      numToKeepStr: getAmountToKeep(),
+      daysToKeepStr: '-1',
+      artifactNumToKeepStr: getAmountToKeep(),
     ))
   }
 
@@ -74,3 +74,7 @@ pipeline {
     cleanup { sh 'make git-clean' }
   } // post
 } // pipeline
+
+def isDevelopJob() { env.JOB_BASE_NAME == 'tests-rpc-develop' }
+
+def getAmountToKeep() { isDevelopJob() ? '30' : '5' }


### PR DESCRIPTION
1. `UNIT_TEST_RERUN_FAILS` - rerun tests on `develop` jobs.
Otherwise if a flaky test fails, we don't get coverage report (don't know what I was thinking of in https://github.com/status-im/status-go/pull/5956)

2. Increase `develop` job storage to 30

3. Set `daysToKeepStr: '-1'`, as we only want to operate with number of runs and don't clean them up when they're somewhat old.

4. Setup same limits for `tests-rpc` job