### PR TITLE
fix_: update defaultGorushURL

### DIFF
--- a/protocol/pushnotificationserver/server.go
+++ b/protocol/pushnotificationserver/server.go
@@ -19,7 +19,7 @@ import (
 )
 
 const encryptedPayloadKeyLength = 16
-const defaultGorushURL = "https://gorush.status.im"
+const defaultGorushURL = "https://gorush.infra.status.im/"
 
 var errUnhandledPushNotificationType = errors.New("unhandled push notification type")
 


### PR DESCRIPTION
The old gorush instance was decomissioned today:
- [infra-misc#cc1da9ef](https://github.com/status-im/infra-misc/commit/cc1da9ef) - gorush: decomission no longer used service

It was used with old eth.prod fleet which was also decomissioned a few weeks back: https://github.com/status-im/infra-eth-cluster/commit/bb56c3cc

The correct new address is https://gorush.infra.status.im/

-----

This fixes the failing `MessengerPushNotificationSuite` tests.

Ideally, we should run a `gorush` server locally. It's fairly [simple to do with docker](https://github.com/appleboy/gorush?tab=readme-ov-file#run-gorush-in-docker). But it's probably not worth it.
