### PR TITLE
chore_: get version with go generate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,8 @@ bindata.go
 migrations.go
 cmd/status-backend/server/endpoints.go
 protocol/messenger_handlers.go
+params/VERSION
+params/GIT_COMMIT
 
 # Don't ignore generated files in the vendor/ directory
 !vendor/**/*.pb.go

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ help: ##@other Show this help
 RELEASE_TAG ?= $(shell ./_assets/scripts/version.sh)
 RELEASE_DIR ?= /tmp/release-$(RELEASE_TAG)
 GOLANGCI_BINARY = golangci-lint
-IPFS_GATEWAY_URL ?= https://ipfs.status.im/
 
 ifeq ($(OS),Windows_NT)     # is Windows_NT on XP, 2000, 7, Vista, 10...
  detected_OS := Windows
@@ -61,14 +60,8 @@ GIT_AUTHOR ?= $(shell git config user.email || echo $$USER)
 ENABLE_METRICS ?= true
 BUILD_TAGS ?= gowaku_no_rln
 
-BUILD_FLAGS ?= -ldflags="-X github.com/status-im/status-go/params.Version=$(RELEASE_TAG:v%=%) \
-	-X github.com/status-im/status-go/params.GitCommit=$(GIT_COMMIT) \
-	-X github.com/status-im/status-go/params.IpfsGatewayURL=$(IPFS_GATEWAY_URL) \
-	-X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=$(ENABLE_METRICS)"
-
-BUILD_FLAGS_MOBILE ?= -ldflags="-X github.com/status-im/status-go/params.Version=$(RELEASE_TAG:v%=%) \
-	-X github.com/status-im/status-go/params.GitCommit=$(GIT_COMMIT) \
-	-X github.com/status-im/status-go/params.IpfsGatewayURL=$(IPFS_GATEWAY_URL)"
+BUILD_FLAGS ?= -ldflags="-X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=$(ENABLE_METRICS)"
+BUILD_FLAGS_MOBILE ?=
 
 networkid ?= StatusChain
 

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.21-alpine3.18 as builder
 ENV CC=clang
 ENV CXX=clang++
 
-RUN apk add --no-cache git make llvm clang musl-dev linux-headers protobuf-dev~3.21
+RUN apk add --no-cache git bash make llvm clang musl-dev linux-headers protobuf-dev~3.21
 
 ARG build_tags
 ARG build_flags

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -112,8 +112,8 @@ func NewGethStatusBackend(logger *zap.Logger) *GethStatusBackend {
 	backend.initialize()
 
 	logger.Info("Status backend initialized",
-		zap.String("backend geth version", params.Version),
-		zap.String("commit", params.GitCommit),
+		zap.String("backend geth version", params.Version()),
+		zap.String("commit", params.GitCommit()),
 		zap.String("IpfsGatewayURL", params.IpfsGatewayURL))
 
 	return backend
@@ -2065,7 +2065,7 @@ func (b *GethStatusBackend) loadNodeConfig(inputNodeCfg *params.NodeConfig) erro
 	// NodeConfig.Version should be taken from params.Version
 	// which is set at the compile time.
 	// What's cached is usually outdated so we overwrite it here.
-	conf.Version = params.Version
+	conf.Version = params.Version()
 	conf.RootDataDir = b.rootDataDir
 	conf.DataDir = filepath.Join(b.rootDataDir, conf.DataDir)
 	conf.KeyStoreDir = filepath.Join(b.rootDataDir, conf.KeyStoreDir)
@@ -2111,7 +2111,9 @@ func (b *GethStatusBackend) startNode(config *params.NodeConfig) (err error) {
 		}
 	}()
 
-	b.logger.Info("status-go version details", zap.String("version", params.Version), zap.String("commit", params.GitCommit))
+	b.logger.Info("status-go version details",
+		zap.String("version", params.Version()),
+		zap.String("commit", params.GitCommit()))
 	b.logger.Debug("starting node with config", zap.Stringer("config", config))
 	// Update config with some defaults.
 	if err := config.UpdateWithDefaults(); err != nil {

--- a/cmd/status-backend/main.go
+++ b/cmd/status-backend/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/status-im/status-go/cmd/status-backend/server"
 	"github.com/status-im/status-go/logutils"
+	"github.com/status-im/status-go/params"
 )
 
 var (
@@ -42,7 +43,11 @@ func main() {
 		return
 	}
 
-	log.Info("server started", "address", srv.Address())
+	log.Info("status-backend started",
+		"address", srv.Address(),
+		"version", params.Version(),
+		"gitCommit", params.GitCommit(),
+	)
 	srv.RegisterMobileAPI()
 	srv.Serve()
 }

--- a/params/config.go
+++ b/params/config.go
@@ -919,7 +919,7 @@ func NewNodeConfig(dataDir string, networkID uint64) (*NodeConfig, error) {
 		DataDir:                dataDir,
 		KeyStoreDir:            keyStoreDir,
 		KeycardPairingDataFile: keycardPairingDataFile,
-		Version:                Version,
+		Version:                Version(),
 		HTTPHost:               "localhost",
 		HTTPPort:               8545,
 		HTTPVirtualHosts:       []string{"localhost"},

--- a/params/version.go
+++ b/params/version.go
@@ -1,11 +1,28 @@
 package params
 
-// Version is defined in git tags.
-// We set it from the Makefile.
-var Version string
+import _ "embed"
 
-// GitCommit is a commit hash.
-var GitCommit string
+//go:generate sh -c "../_assets/scripts/version.sh > VERSION"
+//go:generate sh -c "git rev-parse --short HEAD > GIT_COMMIT"
+
+var (
+	// version is defined in git tags.
+	// We set it from the Makefile.
+	//go:embed VERSION
+	version string
+
+	// gitCommit is a commit hash.
+	//go:embed GIT_COMMIT
+	gitCommit string
+)
 
 // IpfsGatewayURL is the Gateway URL to use for IPFS
-var IpfsGatewayURL string
+const IpfsGatewayURL = "https://ipfs.status.im/"
+
+func Version() string {
+	return version
+}
+
+func GitCommit() string {
+	return gitCommit
+}

--- a/params/version.go
+++ b/params/version.go
@@ -2,8 +2,11 @@ package params
 
 import _ "embed"
 
-//go:generate sh -c "../_assets/scripts/version.sh > VERSION"
-//go:generate sh -c "git rev-parse --short HEAD > GIT_COMMIT"
+// Use go:generate script to get the version and git commit.
+// VERSION and GIT_COMMIT files are used in further `go:embed` commands to load values to the variables.
+// Suppress errors, assuming files have already been properly generated. Required for Docker builds.
+//go:generate sh -c "../_assets/scripts/version.sh > VERSION || true"
+//go:generate sh -c "git rev-parse --short HEAD > GIT_COMMIT || true"
 
 var (
 	// version is defined in git tags.

--- a/params/version.go
+++ b/params/version.go
@@ -1,6 +1,9 @@
 package params
 
-import _ "embed"
+import (
+	_ "embed"
+	"strings"
+)
 
 // Use go:generate script to get the version and git commit.
 // VERSION and GIT_COMMIT files are used in further `go:embed` commands to load values to the variables.
@@ -21,6 +24,11 @@ var (
 
 // IpfsGatewayURL is the Gateway URL to use for IPFS
 const IpfsGatewayURL = "https://ipfs.status.im/"
+
+func init() {
+	version = strings.TrimSpace(version)
+	gitCommit = strings.TrimSpace(gitCommit)
+}
 
 func Version() string {
 	return version

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -59,17 +59,17 @@ var (
 
 var (
 	// rpcUserAgentName the user agent
-	rpcUserAgentName         = fmt.Sprintf(rpcUserAgentFormat, "no-GOOS", params.Version)
-	rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, "no-GOOS", params.Version)
+	rpcUserAgentName         = fmt.Sprintf(rpcUserAgentFormat, "no-GOOS", params.Version())
+	rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, "no-GOOS", params.Version())
 )
 
 func init() {
 	if appCommon.IsMobilePlatform() {
-		rpcUserAgentName = fmt.Sprintf(rpcUserAgentFormat, mobile, params.Version)
-		rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, mobile, params.Version)
+		rpcUserAgentName = fmt.Sprintf(rpcUserAgentFormat, mobile, params.Version())
+		rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, mobile, params.Version())
 	} else {
-		rpcUserAgentName = fmt.Sprintf(rpcUserAgentFormat, desktop, params.Version)
-		rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, desktop, params.Version)
+		rpcUserAgentName = fmt.Sprintf(rpcUserAgentFormat, desktop, params.Version())
+		rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, desktop, params.Version())
 	}
 }
 

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -184,6 +185,6 @@ func TestGetClientsUsingCache(t *testing.T) {
 }
 
 func TestUserAgent(t *testing.T) {
-	require.Equal(t, "procuratee-desktop/", rpcUserAgentName)
-	require.Equal(t, "procuratee-desktop-upstream/", rpcUserAgentUpstreamName)
+	require.True(t, strings.HasPrefix(rpcUserAgentName, "procuratee-desktop/"))
+	require.True(t, strings.HasPrefix(rpcUserAgentUpstreamName, "procuratee-desktop-upstream/"))
 }

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -176,7 +176,7 @@ func (s *Service) InitProtocol(nodeName string, identity *ecdsa.PrivateKey, appD
 		s.n,
 		s.config.ShhextConfig.InstallationID,
 		s.peerStore,
-		params.Version,
+		params.Version(),
 		options...,
 	)
 	if err != nil {

--- a/telemetry/client.go
+++ b/telemetry/client.go
@@ -19,9 +19,10 @@ import (
 
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 
+	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
+
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 	v2common "github.com/status-im/status-go/wakuv2/common"
-	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
 )
 
 type TelemetryType string

--- a/tests-functional/Dockerfile
+++ b/tests-functional/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/foundry-rs/foundry:latest
 
 RUN apk update && \
-    apk add git
+    apk add git bash
 
 WORKDIR /app
 


### PR DESCRIPTION
1. Version

    I've used a combination of `go:generate` and `go:embed` to get the version into Go code.
    
    Currently version is only properly set when you build with Makefile commands. This solution makes it Makefile-agnostic. 
    For example, I'm running `status-backend` with my IDE, which does `go run ...` (and attaches debugger).

2. `IPFS_GATEWAY_URL`
    
    I've removed this parameter from Makefile, as it's not used.
    It's only set in `status-mobile`, but to the same value as the default one (and a fixme to remove it):
    https://github.com/status-im/status-mobile/blob/9c3ff8c88ca321e22bbfcece34ea389c9b18c5cd/nix/status-go/default.nix#L20-L21