### PR TITLE
fix(wallet)_: properly use amount in erc1155 transfers

### DIFF
--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -592,7 +592,6 @@ func (b *StatusNode) walletService(accountsDB *accounts.Database, appDB *sql.DB,
 		b.walletSrvc = wallet.NewService(
 			b.walletDB, accountsDB, appDB, b.rpcClient, accountsFeed, settingsFeed, b.gethAccountManager, b.transactor, b.config,
 			b.ensService(b.timeSourceNow()),
-			b.stickersService(accountsDB),
 			b.pendingTracker,
 			walletFeed,
 			b.httpServer,

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -49,11 +49,10 @@ func NewAPI(s *Service) *API {
 	transactor := s.GetTransactor()
 	tokenManager := s.GetTokenManager()
 	ensService := s.GetEnsService()
-	stickersService := s.GetStickersService()
 	featureFlags := s.FeatureFlags()
 
 	router := router.NewRouter(rpcClient, transactor, tokenManager, s.GetMarketManager(), s.GetCollectiblesService(),
-		s.GetCollectiblesManager(), ensService, stickersService)
+		s.GetCollectiblesManager(), ensService)
 
 	transfer := pathprocessor.NewTransferProcessor(rpcClient, transactor)
 	router.AddPathProcessor(transfer)
@@ -85,7 +84,7 @@ func NewAPI(s *Service) *API {
 	ensPublicKey := pathprocessor.NewENSPublicKeyProcessor(rpcClient, transactor, ensService)
 	router.AddPathProcessor(ensPublicKey)
 
-	buyStickers := pathprocessor.NewStickersBuyProcessor(rpcClient, transactor, stickersService)
+	buyStickers := pathprocessor.NewStickersBuyProcessor(rpcClient, transactor)
 	router.AddPathProcessor(buyStickers)
 
 	return &API{s, s.reader, router}

--- a/services/wallet/api_test.go
+++ b/services/wallet/api_test.go
@@ -159,7 +159,7 @@ func TestAPI_GetAddressDetails(t *testing.T) {
 	chainClient.SetWalletNotifier(func(chainID uint64, message string) {})
 	c.SetWalletNotifier(func(chainID uint64, message string) {})
 
-	service := NewService(db, accountsDb, appDB, c, accountFeed, nil, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, nil, "")
+	service := NewService(db, accountsDb, appDB, c, accountFeed, nil, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
 
 	api := &API{
 		s: service,

--- a/services/wallet/keycard_pairings_test.go
+++ b/services/wallet/keycard_pairings_test.go
@@ -29,7 +29,7 @@ func TestKeycardPairingsFile(t *testing.T) {
 
 	accountFeed := &event.Feed{}
 
-	service := NewService(db, accountsDb, appDB, &rpc.Client{NetworkManager: network.NewManager(db)}, accountFeed, nil, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, nil, "")
+	service := NewService(db, accountsDb, appDB, &rpc.Client{NetworkManager: network.NewManager(db)}, accountFeed, nil, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
 
 	data, err := service.KeycardPairings().GetPairingsJSONFileContent()
 	require.NoError(t, err)

--- a/services/wallet/router/pathprocessor/processor_bridge_celar.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_celar.go
@@ -443,6 +443,9 @@ func (s *CelerBridgeProcessor) BuildTransaction(sendArgs *MultipathProcessorTxAr
 
 func (s *CelerBridgeProcessor) BuildTransactionV2(sendArgs *transactions.SendTxArgs, lastUsedNonce int64) (*ethTypes.Transaction, uint64, error) {
 	tx, err := s.sendOrBuildV2(sendArgs, nil, lastUsedNonce)
+	if err != nil {
+		return nil, 0, createBridgeCellerErrorResponse(err)
+	}
 	return tx, tx.Nonce(), err
 }
 

--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -432,6 +432,9 @@ func (h *HopBridgeProcessor) BuildTransaction(sendArgs *MultipathProcessorTxArgs
 
 func (h *HopBridgeProcessor) BuildTransactionV2(sendArgs *transactions.SendTxArgs, lastUsedNonce int64) (*ethTypes.Transaction, uint64, error) {
 	tx, err := h.sendOrBuildV2(sendArgs, nil, lastUsedNonce)
+	if err != nil {
+		return nil, 0, createBridgeHopErrorResponse(err)
+	}
 	return tx, tx.Nonce(), createBridgeHopErrorResponse(err)
 }
 

--- a/services/wallet/router/pathprocessor/processor_erc1155.go
+++ b/services/wallet/router/pathprocessor/processor_erc1155.go
@@ -151,54 +151,6 @@ func (s *ERC1155Processor) sendOrBuild(sendArgs *MultipathProcessorTxArgs, signe
 	return tx, nil
 }
 
-func (s *ERC1155Processor) sendOrBuildV2(sendArgs *transactions.SendTxArgs, signerFn bind.SignerFn, lastUsedNonce int64) (tx *ethTypes.Transaction, err error) {
-	ethClient, err := s.rpcClient.EthClient(sendArgs.FromChainID)
-	if err != nil {
-		return tx, createERC1155ErrorResponse(err)
-	}
-
-	contract, err := ierc1155.NewIerc1155(common.Address(sendArgs.ToContractAddress), ethClient)
-	if err != nil {
-		return tx, createERC1155ErrorResponse(err)
-	}
-
-	id, err := walletCommon.GetTokenIdFromSymbol(sendArgs.FromTokenID)
-	if err != nil {
-		return tx, createERC1155ErrorResponse(err)
-	}
-
-	var nonce uint64
-	if lastUsedNonce < 0 {
-		nonce, err = s.transactor.NextNonce(s.rpcClient, sendArgs.FromChainID, sendArgs.From)
-		if err != nil {
-			return tx, createERC1155ErrorResponse(err)
-		}
-	} else {
-		nonce = uint64(lastUsedNonce) + 1
-	}
-
-	argNonce := hexutil.Uint64(nonce)
-	sendArgs.Nonce = &argNonce
-	txOpts := sendArgs.ToTransactOpts(signerFn)
-	from := common.Address(sendArgs.From)
-	tx, err = contract.SafeTransferFrom(
-		txOpts,
-		from,
-		common.Address(*sendArgs.To),
-		id,
-		sendArgs.Value.ToInt(),
-		[]byte{},
-	)
-	if err != nil {
-		return tx, createERC1155ErrorResponse(err)
-	}
-	err = s.transactor.StoreAndTrackPendingTx(from, sendArgs.FromTokenID, sendArgs.FromChainID, sendArgs.MultiTransactionID, tx)
-	if err != nil {
-		return tx, createERC1155ErrorResponse(err)
-	}
-	return tx, nil
-}
-
 func (s *ERC1155Processor) Send(sendArgs *MultipathProcessorTxArgs, lastUsedNonce int64, verifiedAccount *account.SelectedExtKey) (hash types.Hash, usedNonce uint64, err error) {
 	tx, err := s.sendOrBuild(sendArgs, getSigner(sendArgs.ChainID, sendArgs.ERC1155TransferTx.From, verifiedAccount), lastUsedNonce)
 	if err != nil {
@@ -213,8 +165,7 @@ func (s *ERC1155Processor) BuildTransaction(sendArgs *MultipathProcessorTxArgs, 
 }
 
 func (s *ERC1155Processor) BuildTransactionV2(sendArgs *transactions.SendTxArgs, lastUsedNonce int64) (*ethTypes.Transaction, uint64, error) {
-	tx, err := s.sendOrBuildV2(sendArgs, nil, lastUsedNonce)
-	return tx, tx.Nonce(), err
+	return s.transactor.ValidateAndBuildTransaction(sendArgs.FromChainID, *sendArgs, lastUsedNonce)
 }
 
 func (s *ERC1155Processor) CalculateAmountOut(params ProcessorInputParams) (*big.Int, error) {

--- a/services/wallet/router/pathprocessor/processor_erc721.go
+++ b/services/wallet/router/pathprocessor/processor_erc721.go
@@ -209,76 +209,6 @@ func (s *ERC721Processor) sendOrBuild(sendArgs *MultipathProcessorTxArgs, signer
 	return tx, nil
 }
 
-func (s *ERC721Processor) sendOrBuildV2(sendArgs *transactions.SendTxArgs, signerFn bind.SignerFn, lastUsedNonce int64) (tx *ethTypes.Transaction, err error) {
-	from := common.Address(sendArgs.From)
-	to := common.Address(*sendArgs.To)
-
-	useSafeTransferFrom := true
-	inputParams := ProcessorInputParams{
-		FromChain: &params.Network{
-			ChainID: sendArgs.FromChainID,
-		},
-		FromAddr: from,
-		ToAddr:   to,
-		FromToken: &token.Token{
-			Symbol:  sendArgs.FromTokenID,
-			Address: common.Address(sendArgs.ToContractAddress),
-		},
-	}
-	err = s.checkIfFunctionExists(inputParams, functionNameSafeTransferFrom)
-	if err != nil {
-		useSafeTransferFrom = false
-	}
-
-	ethClient, err := s.rpcClient.EthClient(sendArgs.FromChainID)
-	if err != nil {
-		return tx, createERC721ErrorResponse(err)
-	}
-
-	contract, err := collectibles.NewCollectibles(common.Address(sendArgs.ToContractAddress), ethClient)
-	if err != nil {
-		return tx, createERC721ErrorResponse(err)
-	}
-
-	id, err := walletCommon.GetTokenIdFromSymbol(sendArgs.FromTokenID)
-	if err != nil {
-		return tx, createERC1155ErrorResponse(err)
-	}
-
-	var nonce uint64
-	if lastUsedNonce < 0 {
-		nonce, err = s.transactor.NextNonce(s.rpcClient, sendArgs.FromChainID, sendArgs.From)
-		if err != nil {
-			return tx, createERC721ErrorResponse(err)
-		}
-	} else {
-		nonce = uint64(lastUsedNonce) + 1
-	}
-
-	argNonce := hexutil.Uint64(nonce)
-	sendArgs.Nonce = &argNonce
-	txOpts := sendArgs.ToTransactOpts(signerFn)
-	if useSafeTransferFrom {
-		tx, err = contract.SafeTransferFrom(txOpts,
-			from,
-			to,
-			id)
-	} else {
-		tx, err = contract.TransferFrom(txOpts,
-			from,
-			to,
-			id)
-	}
-	if err != nil {
-		return tx, createERC721ErrorResponse(err)
-	}
-	err = s.transactor.StoreAndTrackPendingTx(from, sendArgs.FromTokenID, sendArgs.FromChainID, sendArgs.MultiTransactionID, tx)
-	if err != nil {
-		return tx, createERC721ErrorResponse(err)
-	}
-	return tx, nil
-}
-
 func (s *ERC721Processor) Send(sendArgs *MultipathProcessorTxArgs, lastUsedNonce int64, verifiedAccount *account.SelectedExtKey) (hash types.Hash, usedNonce uint64, err error) {
 	tx, err := s.sendOrBuild(sendArgs, getSigner(sendArgs.ChainID, sendArgs.ERC721TransferTx.From, verifiedAccount), lastUsedNonce)
 	if err != nil {
@@ -293,8 +223,7 @@ func (s *ERC721Processor) BuildTransaction(sendArgs *MultipathProcessorTxArgs, l
 }
 
 func (s *ERC721Processor) BuildTransactionV2(sendArgs *transactions.SendTxArgs, lastUsedNonce int64) (*ethTypes.Transaction, uint64, error) {
-	tx, err := s.sendOrBuildV2(sendArgs, nil, lastUsedNonce)
-	return tx, tx.Nonce(), err
+	return s.transactor.ValidateAndBuildTransaction(sendArgs.FromChainID, *sendArgs, lastUsedNonce)
 }
 
 func (s *ERC721Processor) CalculateAmountOut(params ProcessorInputParams) (*big.Int, error) {

--- a/services/wallet/router/pathprocessor/processor_stickers_buy.go
+++ b/services/wallet/router/pathprocessor/processor_stickers_buy.go
@@ -16,24 +16,21 @@ import (
 	stickersContracts "github.com/status-im/status-go/contracts/stickers"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/rpc"
-	"github.com/status-im/status-go/services/stickers"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/transactions"
 )
 
 type StickersBuyProcessor struct {
-	contractMaker   *contracts.ContractMaker
-	transactor      transactions.TransactorIface
-	stickersService *stickers.Service
+	contractMaker *contracts.ContractMaker
+	transactor    transactions.TransactorIface
 }
 
-func NewStickersBuyProcessor(rpcClient *rpc.Client, transactor transactions.TransactorIface, stickersService *stickers.Service) *StickersBuyProcessor {
+func NewStickersBuyProcessor(rpcClient *rpc.Client, transactor transactions.TransactorIface) *StickersBuyProcessor {
 	return &StickersBuyProcessor{
 		contractMaker: &contracts.ContractMaker{
 			RPCClient: rpcClient,
 		},
-		transactor:      transactor,
-		stickersService: stickersService,
+		transactor: transactor,
 	}
 }
 

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -15,7 +15,6 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/services/ens"
-	"github.com/status-im/status-go/services/stickers"
 	"github.com/status-im/status-go/services/wallet/async"
 	"github.com/status-im/status-go/services/wallet/collectibles"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -68,7 +67,6 @@ type Router struct {
 	collectiblesService *collectibles.Service
 	collectiblesManager *collectibles.Manager
 	ensService          *ens.Service
-	stickersService     *stickers.Service
 	feesManager         *fees.FeeManager
 	pathProcessors      map[string]pathprocessor.PathProcessor
 	scheduler           *async.Scheduler
@@ -88,7 +86,7 @@ type Router struct {
 }
 
 func NewRouter(rpcClient *rpc.Client, transactor *transactions.Transactor, tokenManager *token.Manager, marketManager *market.Manager,
-	collectibles *collectibles.Service, collectiblesManager *collectibles.Manager, ensService *ens.Service, stickersService *stickers.Service) *Router {
+	collectibles *collectibles.Service, collectiblesManager *collectibles.Manager, ensService *ens.Service) *Router {
 	processors := make(map[string]pathprocessor.PathProcessor)
 
 	return &Router{
@@ -98,7 +96,6 @@ func NewRouter(rpcClient *rpc.Client, transactor *transactions.Transactor, token
 		collectiblesService: collectibles,
 		collectiblesManager: collectiblesManager,
 		ensService:          ensService,
-		stickersService:     stickersService,
 		feesManager: &fees.FeeManager{
 			RPCClient: rpcClient,
 		},

--- a/services/wallet/router/router_test.go
+++ b/services/wallet/router/router_test.go
@@ -101,7 +101,7 @@ func setupRouter(t *testing.T) (*Router, func()) {
 	}
 	client, _ := rpc.NewClient(config)
 
-	router := NewRouter(client, nil, nil, nil, nil, nil, nil, nil)
+	router := NewRouter(client, nil, nil, nil, nil, nil, nil)
 
 	transfer := pathprocessor.NewTransferProcessor(nil, nil)
 	router.AddPathProcessor(transfer)
@@ -127,7 +127,7 @@ func setupRouter(t *testing.T) (*Router, func()) {
 	ensPublicKey := pathprocessor.NewENSPublicKeyProcessor(nil, nil, nil)
 	router.AddPathProcessor(ensPublicKey)
 
-	buyStickers := pathprocessor.NewStickersBuyProcessor(nil, nil, nil)
+	buyStickers := pathprocessor.NewStickersBuyProcessor(nil, nil)
 	router.AddPathProcessor(buyStickers)
 
 	return router, cleanTmpDb

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -20,7 +20,6 @@ import (
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/ens"
-	"github.com/status-im/status-go/services/stickers"
 	"github.com/status-im/status-go/services/wallet/activity"
 	"github.com/status-im/status-go/services/wallet/balance"
 	"github.com/status-im/status-go/services/wallet/blockchainstate"
@@ -58,7 +57,6 @@ func NewService(
 	transactor *transactions.Transactor,
 	config *params.NodeConfig,
 	ens *ens.Service,
-	stickers *stickers.Service,
 	pendingTxManager *transactions.PendingTxTracker,
 	feed *event.Feed,
 	mediaServer *server.MediaServer,
@@ -205,7 +203,6 @@ func NewService(
 		marketManager:         marketManager,
 		transactor:            transactor,
 		ens:                   ens,
-		stickers:              stickers,
 		feed:                  feed,
 		signals:               signals,
 		reader:                reader,
@@ -239,7 +236,6 @@ type Service struct {
 	gethManager           *account.GethManager
 	transactor            *transactions.Transactor
 	ens                   *ens.Service
-	stickers              *stickers.Service
 	feed                  *event.Feed
 	signals               *walletevent.SignalsTransmitter
 	reader                *Reader
@@ -344,8 +340,4 @@ func (s *Service) GetCollectiblesManager() *collectibles.Manager {
 
 func (s *Service) GetEnsService() *ens.Service {
 	return s.ens
-}
-
-func (s *Service) GetStickersService() *stickers.Service {
-	return s.stickers
 }

--- a/services/wallet/transfer/transaction_manager_route.go
+++ b/services/wallet/transfer/transaction_manager_route.go
@@ -170,7 +170,9 @@ func (tm *TransactionManager) buildTxForPath(path *routes.Path, pathProcessors m
 				path.ProcessorName == pathprocessor.ProcessorStickersBuyName ||
 				path.ProcessorName == pathprocessor.ProcessorENSRegisterName ||
 				path.ProcessorName == pathprocessor.ProcessorENSReleaseName ||
-				path.ProcessorName == pathprocessor.ProcessorENSPublicKeyName {
+				path.ProcessorName == pathprocessor.ProcessorENSPublicKeyName ||
+				path.ProcessorName == pathprocessor.ProcessorERC721Name ||
+				path.ProcessorName == pathprocessor.ProcessorERC1155Name {
 				// TODO: update functions from `TransactorIface` to use `ToContractAddress` (as an address of the contract a transaction should be sent to)
 				// and `To` (as the destination address, recipient) of `SendTxArgs` struct appropriately
 				toContractAddr := types.Address(path.FromToken.Address)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/16664

- ERC721 and ERC1155 are using a different mechanism than the other processors when executing the routes. ~For some reason the tx gets sent to the chain at the `BuildTransaction` stage, instead of only building the transactions for the client to sign and confirm~ This is wrong, the parameters used imply the Tx doesn't get sent to the chain, it's only generated.
- Moreover, for the particular case of ERC1155 transfers, this "extra" send mechanism didn't properly use the set Amount, which resulted in sends having Amount 0.
- This PR removes this secondary tx creation mechanism (with the abigen wrapper), reuses the data packing mechanism used for estimating gas fees, which also fixes the mentioned bug.



https://github.com/user-attachments/assets/e129b31a-4ce2-43d2-a190-9c29653bb730


