### PR TITLE
feat_: integrate on-demand DNS discovery and implement discoverAndConnectPeers

### DIFF
--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -851,24 +851,27 @@ func (w *Waku) retryDnsDiscoveryWithBackoff(ctx context.Context, addr string, su
 	}
 }
 
+*/
+
 func (w *Waku) discoverAndConnectPeers() {
-	fnApply := func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {
-		defer wg.Done()
-		if len(d.PeerInfo.Addrs) != 0 {
-			go w.connect(d.PeerInfo, d.ENR, wps.DNSDiscovery)
-		}
-	}
+	var addrsToConnect []multiaddr.Multiaddr
+	nameserver := "1.1.1.1"
+	timeout := int(requestTimeout / time.Millisecond)
 
 	for _, addrString := range w.cfg.WakuNodes {
 		addrString := addrString
 		if strings.HasPrefix(addrString, "enrtree://") {
+
 			// Use DNS Discovery
-			go func() {
-				defer gocommon.LogOnPanic()
-				if err := w.dnsDiscover(w.ctx, addrString, fnApply, false); err != nil {
-					w.logger.Error("could not obtain dns discovery peers for ClusterConfig.WakuNodes", zap.Error(err), zap.String("dnsDiscURL", addrString))
-				}
-			}()
+			res, err := w.WakuDnsDiscovery(addrString, nameserver, timeout)
+			if err != nil {
+				w.logger.Error("could not obtain dns discovery peers for ClusterConfig.WakuNodes", zap.Error(err), zap.String("dnsDiscURL", addrString))
+				continue
+			}
+			for _, ma := range res {
+				addrsToConnect = append(addrsToConnect, ma)
+			}
+
 		} else {
 			// It is a normal multiaddress
 			addr, err := multiaddr.NewMultiaddr(addrString)
@@ -876,17 +879,16 @@ func (w *Waku) discoverAndConnectPeers() {
 				w.logger.Warn("invalid peer multiaddress", zap.String("ma", addrString), zap.Error(err))
 				continue
 			}
-
-			peerInfo, err := peer.AddrInfoFromP2pAddr(addr)
-			if err != nil {
-				w.logger.Warn("invalid peer multiaddress", zap.Stringer("addr", addr), zap.Error(err))
-				continue
-			}
-
-			go w.connect(*peerInfo, nil, wps.Static)
+			addrsToConnect = append(addrsToConnect, addr)
 		}
 	}
-} */
+
+	// Now connect to all the Multiaddresses
+	for _, ma := range addrsToConnect {
+		w.WakuConnect(ma.String(), timeout)
+	}
+
+}
 
 func (w *Waku) connect(peerInfo peer.AddrInfo, enr *enode.Node, origin wps.Origin) {
 	defer gocommon.LogOnPanic()

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -292,6 +292,20 @@ package wakuv2
 									resp));
 	}
 
+	static void cGoWakuDnsDiscovery(void* wakuCtx,
+									 const char* entTreeUrl,
+									 const char* nameDnsServer,
+									 int timeoutMs,
+									 void* resp) {
+
+		WAKU_CALL (waku_dns_discovery(wakuCtx,
+									entTreeUrl,
+									nameDnsServer,
+									timeoutMs,
+									(WakuCallBack) callback,
+									resp));
+	}
+
 */
 import "C"
 
@@ -2724,6 +2738,38 @@ func (self *Waku) WakuDialPeerById(peerId peer.ID, protocol string, timeoutMs in
 	errMsg := "error DialPeerById: " +
 		C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
 	return errors.New(errMsg)
+}
+
+func (self *Waku) WakuDnsDiscovery(entTreeUrl string, nameDnsServer string, timeoutMs int) ([]multiaddr.Multiaddr, error) {
+	var resp = C.allocResp()
+	var cEnrTree = C.CString(entTreeUrl)
+	var cDnsServer = C.CString(nameDnsServer)
+	defer C.freeResp(resp)
+	defer C.free(unsafe.Pointer(cEnrTree))
+	defer C.free(unsafe.Pointer(cDnsServer))
+
+	C.cGoWakuDnsDiscovery(self.wakuCtx, cEnrTree, cDnsServer, C.int(timeoutMs), resp)
+
+	if C.getRet(resp) == C.RET_OK {
+
+		var addrsRet []multiaddr.Multiaddr
+		nodeAddresses := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+		addrss := strings.Split(nodeAddresses, ",")
+		for _, addr := range addrss {
+			addr, err := multiaddr.NewMultiaddr(addr)
+			if err != nil {
+				return nil, err
+			}
+
+			addrsRet = append(addrsRet, addr)
+		}
+
+		return addrsRet, nil
+	}
+	errMsg := "error WakuDnsDiscovery: " +
+		C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+
+	return nil, errors.New(errMsg)
 }
 
 func (self *Waku) ListenAddresses() ([]multiaddr.Multiaddr, error) {

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -855,7 +855,10 @@ func (w *Waku) retryDnsDiscoveryWithBackoff(ctx context.Context, addr string, su
 
 func (w *Waku) discoverAndConnectPeers() {
 	var addrsToConnect []multiaddr.Multiaddr
-	nameserver := "1.1.1.1"
+	nameserver := w.cfg.Nameserver
+	if nameserver == "" {
+		nameserver = "8.8.8.8"
+	}
 	timeout := int(requestTimeout / time.Millisecond)
 
 	for _, addrString := range w.cfg.WakuNodes {

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -639,6 +639,7 @@ func TestDnsDiscover(t *testing.T) {
 	nodeConfig := Config{
 		UseThrottledPublish: true,
 		ClusterID:           16,
+		Nameserver:          "8.8.8.8",
 	}
 	nodeWakuConfig := WakuConfig{
 		EnableRelay:   true,
@@ -653,9 +654,8 @@ func TestDnsDiscover(t *testing.T) {
 	require.NoError(t, node.Start())
 	time.Sleep(1 * time.Second)
 	sampleEnrTree := "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im"
-	nameserver := "1.1.1.1"
 
-	res, err := node.WakuDnsDiscovery(sampleEnrTree, nameserver, int(requestTimeout/time.Millisecond))
+	res, err := node.WakuDnsDiscovery(sampleEnrTree, nodeConfig.Nameserver, int(requestTimeout/time.Millisecond))
 	require.NoError(t, err)
 
 	require.True(t, len(res) > 1, "multiple nodes should be returned from the DNS Discovery query")

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -655,7 +655,8 @@ func TestDnsDiscover(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	sampleEnrTree := "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im"
 	nameserver := "1.1.1.1"
-	res, err := node.WakuDnsDiscovery(sampleEnrTree, nameserver, 1000)
+
+	res, err := node.WakuDnsDiscovery(sampleEnrTree, nameserver, int(requestTimeout/time.Millisecond))
 	require.NoError(t, err)
 
 	require.True(t, len(res) > 1, "multiple nodes should be returned from the DNS Discovery query")

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -640,7 +640,6 @@ func TestDnsDiscover(t *testing.T) {
 		UseThrottledPublish: true,
 		ClusterID:           16,
 	}
-	// start node that will initiate t
 	nodeWakuConfig := WakuConfig{
 		EnableRelay:   true,
 		LogLevel:      "DEBUG",

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -633,6 +633,37 @@ func TestDial(t *testing.T) {
 
 }
 
+func TestDnsDiscover(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	nodeConfig := Config{
+		UseThrottledPublish: true,
+		ClusterID:           16,
+	}
+	// start node that will initiate t
+	nodeWakuConfig := WakuConfig{
+		EnableRelay:   true,
+		LogLevel:      "DEBUG",
+		ClusterID:     16,
+		Shards:        []uint16{64},
+		Discv5UdpPort: 9040,
+		TcpPort:       60040,
+	}
+	node, err := New(nil, "", &nodeConfig, &nodeWakuConfig, logger.Named("node"), nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, node.Start())
+	time.Sleep(1 * time.Second)
+	sampleEnrTree := "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im"
+	nameserver := "1.1.1.1"
+	res, err := node.WakuDnsDiscovery(sampleEnrTree, nameserver, 1000)
+	require.NoError(t, err)
+
+	require.True(t, len(res) > 1, "multiple nodes should be returned from the DNS Discovery query")
+
+	// Stop nodes
+	require.NoError(t, node.Stop())
+}
+
 /*
 
 func TestWakuV2Filter(t *testing.T) {


### PR DESCRIPTION
Same PR as https://github.com/status-im/status-go/pull/6000 but over the updated base branch (rebase is not working properly in this case)

Integrating libwaku's on-demand DNS discovery functionality and implementing `discoverAndConnectPeers`

Notice that for `discoverAndConnectPeers`, we have to do it sequentially and not with goroutines, as libwaku doesn't work properly with goroutines for now (because of goroutines spinning up multiple threads and Nim being set up only in one).

Important changes:
- [x] integrated libwaku's `waku_dns_discovery` procedure
- [x] added test for DNS discovery
- [x] implemented  `discoverAndConnectPeers`

Issue https://github.com/waku-org/nwaku/issues/3076
