### PR TITLE
fix(wallet)_: use correct amount for erc1155 path processors

### DIFF
--- a/services/wallet/transfer/transaction_manager_route.go
+++ b/services/wallet/transfer/transaction_manager_route.go
@@ -164,7 +164,10 @@ func (tm *TransactionManager) buildTxForPath(path *routes.Path, pathProcessors m
 		// special handling for transfer tx if selected token is not ETH
 		// TODO: we should fix that in the trasactor, but till then, the best place to handle it is here
 		if !path.FromToken.IsNative() {
-			sendArgs.Value = (*hexutil.Big)(big.NewInt(0))
+
+			if path.ProcessorName != pathprocessor.ProcessorERC1155Name {
+				sendArgs.Value = (*hexutil.Big)(big.NewInt(0))
+			}
 
 			if path.ProcessorName == pathprocessor.ProcessorTransferName ||
 				path.ProcessorName == pathprocessor.ProcessorStickersBuyName ||


### PR DESCRIPTION
A proper amount is used for ERC1155 tokens.

Fixes https://github.com/status-im/status-desktop/issues/16664

This is the tx I've done sending erc1155:
- https://sepolia.etherscan.io//tx/0x9721fcd10cfcc3e5cc6525f9206d0ac9ca8155e399e865ed97fde338ad3063c4