### PR TITLE
fix(community)_: fix missing mediaserver when cloning a community

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -2444,7 +2444,8 @@ func (o *Community) CreateDeepCopy() *Community {
 			PubsubTopicPrivateKey:               o.config.PubsubTopicPrivateKey,
 			LastOpenedAt:                        o.config.LastOpenedAt,
 		},
-		timesource: o.timesource,
+		timesource:  o.timesource,
+		mediaServer: o.mediaServer,
 	}
 }
 


### PR DESCRIPTION
Found while fixing https://github.com/status-im/status-desktop/issues/16688

This caused communities being passed to the client via `handleCommunitiesSubscription` to not have images and they would "flash" in the client because it would disappear for a second then come back when another signal updated it back.
