### PR TITLE
fix(BC)_: Notify client on dapp connection changes

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -22,7 +22,7 @@ type API struct {
 
 func NewAPI(s *Service) *API {
 	r := NewCommandRegistry()
-	c := commands.NewClientSideHandler()
+	c := commands.NewClientSideHandler(s.db)
 
 	// Transactions and signing
 	r.Register("eth_sendTransaction", &commands.SendTransactionCommand{
@@ -121,7 +121,7 @@ func (api *API) CallRPC(ctx context.Context, inputJSON string) (interface{}, err
 
 func (api *API) RecallDAppPermission(origin string) error {
 	// TODO: close the websocket connection
-	return persistence.DeleteDApp(api.s.db, origin)
+	return api.c.RecallDAppPermissions(commands.RecallDAppPermissionsArgs{URL: origin})
 }
 
 func (api *API) GetPermittedDAppsList() ([]persistence.DApp, error) {

--- a/services/connector/commands/client_handler_test.go
+++ b/services/connector/commands/client_handler_test.go
@@ -4,11 +4,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/status-im/status-go/eth-node/types"
+	persistence "github.com/status-im/status-go/services/connector/database"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestClientHandlerTimeout(t *testing.T) {
-	clientHandler := NewClientSideHandler()
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	clientHandler := NewClientSideHandler(db)
 
 	backupWalletResponseMaxInterval := WalletResponseMaxInterval
 	WalletResponseMaxInterval = 1 * time.Millisecond
@@ -19,10 +25,48 @@ func TestClientHandlerTimeout(t *testing.T) {
 }
 
 func TestRequestRejectedWhileWaiting(t *testing.T) {
-	clientHandler := NewClientSideHandler()
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	clientHandler := NewClientSideHandler(db)
 
 	clientHandler.setRequestRunning()
 
 	_, _, err := clientHandler.RequestShareAccountForDApp(testDAppData)
 	assert.Equal(t, ErrAnotherConnectorOperationIsAwaitingFor, err)
+}
+
+func TestRecallDAppPermission(t *testing.T) {
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	dapp := persistence.DApp{
+		Name:          "Test DApp",
+		URL:           "http://testDAppURL",
+		IconURL:       "http://testDAppIconUrl",
+		SharedAccount: types.HexToAddress("0x1234567890"),
+		ChainID:       0x1,
+	}
+
+	err := persistence.UpsertDApp(db, &dapp)
+	assert.NoError(t, err)
+
+	persistedDapp, err := persistence.SelectDAppByUrl(db, dapp.URL)
+	assert.Equal(t, persistedDapp, &dapp)
+	assert.NoError(t, err)
+
+	clientHandler := NewClientSideHandler(db)
+	err = clientHandler.RecallDAppPermissions(RecallDAppPermissionsArgs{URL: dapp.URL})
+	assert.NoError(t, err)
+
+	err = clientHandler.RecallDAppPermissions(RecallDAppPermissionsArgs{})
+	assert.ErrorIs(t, err, ErrEmptyUrl)
+
+	err = clientHandler.RecallDAppPermissions(RecallDAppPermissionsArgs{URL: dapp.URL})
+	assert.ErrorIs(t, err, ErrDAppDoesNotHavePermissions)
+
+	recalledDapp, err := persistence.SelectDAppByUrl(db, dapp.URL)
+
+	assert.Equal(t, recalledDapp, (*persistence.DApp)(nil))
+	assert.NoError(t, err)
 }

--- a/services/connector/commands/request_accounts.go
+++ b/services/connector/commands/request_accounts.go
@@ -62,7 +62,7 @@ func (c *RequestAccountsCommand) Execute(ctx context.Context, request RPCRequest
 		if err != nil {
 			return "", err
 		}
-		signal.SendConnectorDAppPermissionGranted(connectorDApp)
+		signal.SendConnectorDAppPermissionGranted(connectorDApp, account, []uint64{chainID})
 	}
 
 	return FormatAccountAddressToResponse(dApp.SharedAccount), nil

--- a/services/connector/commands/rpc_traits.go
+++ b/services/connector/commands/rpc_traits.go
@@ -65,10 +65,15 @@ type RejectedArgs struct {
 	RequestID string `json:"requestId"`
 }
 
+type RecallDAppPermissionsArgs struct {
+	URL string `json:"url"`
+}
+
 type ClientSideHandlerInterface interface {
 	RequestShareAccountForDApp(dApp signal.ConnectorDApp) (types.Address, uint64, error)
 	RequestAccountsAccepted(args RequestAccountsAcceptedArgs) error
 	RequestAccountsRejected(args RejectedArgs) error
+	RecallDAppPermissions(args RecallDAppPermissionsArgs) error
 
 	RequestSendTransaction(dApp signal.ConnectorDApp, chainID uint64, txArgs *transactions.SendTxArgs) (types.Hash, error)
 	SendTransactionAccepted(args SendTransactionAcceptedArgs) error

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -81,7 +81,7 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 	})
 	require.NoError(t, err)
 
-	state.handler = NewClientSideHandler()
+	state.handler = NewClientSideHandler(state.db)
 
 	state.mockCtrl = gomock.NewController(t)
 	state.rpcClient = mock_rpcclient.NewMockClientInterface(state.mockCtrl)

--- a/signal/events_connector.go
+++ b/signal/events_connector.go
@@ -1,5 +1,9 @@
 package signal
 
+import (
+	"github.com/status-im/status-go/eth-node/types"
+)
+
 const (
 	EventConnectorSendRequestAccounts   = "connector.sendRequestAccounts"
 	EventConnectorSendTransaction       = "connector.sendTransaction"
@@ -27,6 +31,12 @@ type ConnectorSendTransactionSignal struct {
 	RequestID string `json:"requestId"`
 	ChainID   uint64 `json:"chainId"`
 	TxArgs    string `json:"txArgs"`
+}
+
+type ConnectorSendDappPermissionGrantedSignal struct {
+	ConnectorDApp
+	Chains        []uint64      `json:"chains"`
+	SharedAccount types.Address `json:"sharedAccount"`
 }
 
 type ConnectorPersonalSignSignal struct {
@@ -66,8 +76,12 @@ func SendConnectorPersonalSign(dApp ConnectorDApp, requestID, challenge, address
 	})
 }
 
-func SendConnectorDAppPermissionGranted(dApp ConnectorDApp) {
-	send(EventConnectorDAppPermissionGranted, dApp)
+func SendConnectorDAppPermissionGranted(dApp ConnectorDApp, account types.Address, chains []uint64) {
+	send(EventConnectorDAppPermissionGranted, ConnectorSendDappPermissionGrantedSignal{
+		ConnectorDApp: dApp,
+		Chains:        chains,
+		SharedAccount: account,
+	})
 }
 
 func SendConnectorDAppPermissionRevoked(dApp ConnectorDApp) {


### PR DESCRIPTION
1. Include chainIds and account on `PermissionsGranted` client signal.
2. Send a client event whenever the dapp permissions have been revoked.

+ update tests

PR needed for https://github.com/status-im/status-desktop/issues/16044