### PR TITLE
fix_: move version to separate package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,8 +120,8 @@ bindata.go
 migrations.go
 cmd/status-backend/server/endpoints.go
 protocol/messenger_handlers.go
-params/VERSION
-params/GIT_COMMIT
+internal/version/VERSION
+internal/version/GIT_COMMIT
 
 # Don't ignore generated files in the vendor/ directory
 !vendor/**/*.pb.go

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -35,6 +35,7 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/images"
+	"github.com/status-im/status-go/internal/version"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/accounts"
@@ -112,8 +113,8 @@ func NewGethStatusBackend(logger *zap.Logger) *GethStatusBackend {
 	backend.initialize()
 
 	logger.Info("Status backend initialized",
-		zap.String("backend geth version", params.Version()),
-		zap.String("commit", params.GitCommit()),
+		zap.String("backend geth version", version.Version()),
+		zap.String("commit", version.GitCommit()),
 		zap.String("IpfsGatewayURL", params.IpfsGatewayURL))
 
 	return backend
@@ -2062,10 +2063,10 @@ func (b *GethStatusBackend) loadNodeConfig(inputNodeCfg *params.NodeConfig) erro
 
 	// Start WakuV1 if WakuV2 is not enabled
 	conf.WakuConfig.Enabled = !conf.WakuV2Config.Enabled
-	// NodeConfig.Version should be taken from params.Version
+	// NodeConfig.Version should be taken from version.Version
 	// which is set at the compile time.
 	// What's cached is usually outdated so we overwrite it here.
-	conf.Version = params.Version()
+	conf.Version = version.Version()
 	conf.RootDataDir = b.rootDataDir
 	conf.DataDir = filepath.Join(b.rootDataDir, conf.DataDir)
 	conf.KeyStoreDir = filepath.Join(b.rootDataDir, conf.KeyStoreDir)
@@ -2112,8 +2113,8 @@ func (b *GethStatusBackend) startNode(config *params.NodeConfig) (err error) {
 	}()
 
 	b.logger.Info("status-go version details",
-		zap.String("version", params.Version()),
-		zap.String("commit", params.GitCommit()))
+		zap.String("version", version.Version()),
+		zap.String("commit", version.GitCommit()))
 	b.logger.Debug("starting node with config", zap.Stringer("config", config))
 	// Update config with some defaults.
 	if err := config.UpdateWithDefaults(); err != nil {

--- a/cmd/status-backend/main.go
+++ b/cmd/status-backend/main.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/status-im/status-go/cmd/status-backend/server"
+	"github.com/status-im/status-go/internal/version"
 	"github.com/status-im/status-go/logutils"
-	"github.com/status-im/status-go/params"
 )
 
 var (
@@ -45,8 +45,8 @@ func main() {
 
 	log.Info("status-backend started",
 		"address", srv.Address(),
-		"version", params.Version(),
-		"gitCommit", params.GitCommit(),
+		"version", version.Version(),
+		"gitCommit", version.GitCommit(),
 	)
 	srv.RegisterMobileAPI()
 	srv.Serve()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-package params
+package version
 
 import (
 	_ "embed"
@@ -8,7 +8,7 @@ import (
 // Use go:generate script to get the version and git commit.
 // VERSION and GIT_COMMIT files are used in further `go:embed` commands to load values to the variables.
 // Suppress errors, assuming files have already been properly generated. Required for Docker builds.
-//go:generate sh -c "../_assets/scripts/version.sh > VERSION || true"
+//go:generate sh -c "../../_assets/scripts/version.sh > VERSION || true"
 //go:generate sh -c "git rev-parse --short HEAD > GIT_COMMIT || true"
 
 var (
@@ -21,9 +21,6 @@ var (
 	//go:embed GIT_COMMIT
 	gitCommit string
 )
-
-// IpfsGatewayURL is the Gateway URL to use for IPFS
-const IpfsGatewayURL = "https://ipfs.status.im/"
 
 func init() {
 	version = strings.TrimSpace(version)

--- a/params/config.go
+++ b/params/config.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/internal/version"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/static"
 	wakucommon "github.com/status-im/status-go/waku/common"
@@ -919,7 +920,7 @@ func NewNodeConfig(dataDir string, networkID uint64) (*NodeConfig, error) {
 		DataDir:                dataDir,
 		KeyStoreDir:            keyStoreDir,
 		KeycardPairingDataFile: keycardPairingDataFile,
-		Version:                Version(),
+		Version:                version.Version(),
 		HTTPHost:               "localhost",
 		HTTPPort:               8545,
 		HTTPVirtualHosts:       []string{"localhost"},

--- a/params/defaults.go
+++ b/params/defaults.go
@@ -80,6 +80,9 @@ const (
 
 	// LESDiscoveryIdentifier is a prefix for topic used for LES peers discovery.
 	LESDiscoveryIdentifier = "LES2@"
+
+	// IpfsGatewayURL is the Gateway URL to use for IPFS
+	IpfsGatewayURL = "https://ipfs.status.im/"
 )
 
 var (

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	appCommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/healthmanager"
+	"github.com/status-im/status-go/internal/version"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc/chain"
@@ -59,17 +60,17 @@ var (
 
 var (
 	// rpcUserAgentName the user agent
-	rpcUserAgentName         = fmt.Sprintf(rpcUserAgentFormat, "no-GOOS", params.Version())
-	rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, "no-GOOS", params.Version())
+	rpcUserAgentName         = fmt.Sprintf(rpcUserAgentFormat, "no-GOOS", version.Version())
+	rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, "no-GOOS", version.Version())
 )
 
 func init() {
 	if appCommon.IsMobilePlatform() {
-		rpcUserAgentName = fmt.Sprintf(rpcUserAgentFormat, mobile, params.Version())
-		rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, mobile, params.Version())
+		rpcUserAgentName = fmt.Sprintf(rpcUserAgentFormat, mobile, version.Version())
+		rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, mobile, version.Version())
 	} else {
-		rpcUserAgentName = fmt.Sprintf(rpcUserAgentFormat, desktop, params.Version())
-		rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, desktop, params.Version())
+		rpcUserAgentName = fmt.Sprintf(rpcUserAgentFormat, desktop, version.Version())
+		rpcUserAgentUpstreamName = fmt.Sprintf(rpcUserAgentUpstreamFormat, desktop, version.Version())
 	}
 }
 

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -34,6 +34,7 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/images"
+	"github.com/status-im/status-go/internal/version"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/accounts"
@@ -176,7 +177,7 @@ func (s *Service) InitProtocol(nodeName string, identity *ecdsa.PrivateKey, appD
 		s.n,
 		s.config.ShhextConfig.InstallationID,
 		s.peerStore,
-		params.Version(),
+		version.Version(),
 		options...,
 	)
 	if err != nil {


### PR DESCRIPTION
Moved `params/version.go` to a separate `internal/version` package.
This is needed to prevent import loops, e.g.:

```mermaid
graph LR
    common --wants sentry--> sentry --needs version--> common
```

will now be:

```mermaid
graph LR
    common --wants sentry--> sentry --needs version--> version
    common --also wants version-->version
```