### PR TITLE
test_: profile tests

### DIFF
--- a/tests-functional/tests/test_wakuext_profile.py
+++ b/tests-functional/tests/test_wakuext_profile.py
@@ -1,0 +1,31 @@
+import random
+
+import pytest
+
+from test_cases import StatusBackendTestCase
+
+
+class TestProfile(StatusBackendTestCase):
+
+    @pytest.mark.parametrize(
+        "method, params",
+        [
+            ("wakuext_setDisplayName", ["new valid username"]),
+            ("wakuext_setBio", ["some valid bio"]),
+            ("wakuext_setCustomizationColor", [{'customizationColor': 'magenta',
+                                                'keyUid': '0xea42dd9a4e668b0b76c7a5210ca81576d51cd19cdd0f6a0c22196219dc423f29'}]),
+            ("wakuext_setUserStatus", [3, ""]),
+            ("wakuext_setSyncingOnMobileNetwork", [{"enabled": False}]),
+            ("wakuext_togglePeerSyncing", [{"enabled": True}]),
+            ("wakuext_backupData", []),
+            ("settings_saveSetting", ["messages-from-contacts-only", True]),
+            ("settings_saveSetting", ["notifications-enabled?", True]),
+            ("settings_saveSetting", ["send-status-updates?", True]),
+            ("settings_saveSetting", ["preview-privacy?", False]),
+            ("settings_saveSetting", ["currency", "eth"]),
+            ("settings_saveSetting", ["default-sync-period", 259200]),
+        ],
+    )
+    def test_(self, method, params):
+        _id = str(random.randint(1, 8888))
+        self.rpc_client.rpc_valid_request(method, params, _id)


### PR DESCRIPTION
First iteration on profile tests that can be extracted from `requests.log`. So far there is no obvious option to check that the settings is saved (see the question [here](https://discord.com/channels/1210237582470807632/1217172931197800468/1303697751632252948))

Example of test case:
```
INFO     root:status_backend.py:56 Sending POST request to url http://0.0.0.0:3334/statusgo/CallRPC with data: {
    "id": "4657",
    "jsonrpc": "2.0",
    "method": "wakuext_setBio",
    "params": [
        "some valid bio"
    ]
}
INFO     root:status_backend.py:59 Got response: {
    "id": "4657",
    "jsonrpc": "2.0",
    "result": null
}
```

In future will be extended with different input params.

**Notes:** no schema is returned from `statusd` as well, so this response means that this change is successful.

All questions / future steps that I bumped into I documented [here](https://www.notion.so/Status-backend-difficulties-1358f96fb65c8021ba2ecc58afc3f8dc)

