### PR TITLE
fix(wallet)_: preserve value for token swaps to properly form path key

### DIFF
--- a/services/wallet/transfer/transaction_manager_route.go
+++ b/services/wallet/transfer/transaction_manager_route.go
@@ -164,7 +164,8 @@ func (tm *TransactionManager) buildTxForPath(path *routes.Path, pathProcessors m
 
 		// special handling for transfer tx if selected token is not ETH
 		// TODO: we should fix that in the trasactor, but till then, the best place to handle it is here
-		if !path.FromToken.IsNative() {
+		// Paraswap needs the value to form the path key
+		if path.ProcessorName != pathprocessor.ProcessorSwapParaswapName && !path.FromToken.IsNative() {
 			sendArgs.Value = (*hexutil.Big)(big.NewInt(0))
 
 			if path.ProcessorName == pathprocessor.ProcessorTransferName ||


### PR DESCRIPTION
Value was getting set to 0 for the Paraswap processor. This would normally not be a problem since that value isn't used for actually building the transaction, but since the amount is now used to form the key in the paths map, this caused the path not to be found for swaps with input token different than ETH.

We now preserve the value.

Fixes https://github.com/status-im/status-mobile/issues/21555
