### PR TITLE
feat: support use http for media server when run status backend server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,9 +169,10 @@ status-backend: ##@build Build status-backend to run status-go as HTTP server
 status-backend: build/bin/status-backend
 
 run-status-backend: PORT ?= 0
+MEDIA_HTTPS ?= true
 run-status-backend: generate
 run-status-backend: ##@run Start status-backend server listening to localhost:PORT
-	go run ./cmd/status-backend --address localhost:${PORT}
+	go run ./cmd/status-backend --address localhost:${PORT} --media-https=${MEDIA_HTTPS}
 
 statusd-prune-docker-image: SHELL := /bin/sh
 statusd-prune-docker-image: ##@statusd-prune Build statusd-prune docker image

--- a/cmd/status-backend/main.go
+++ b/cmd/status-backend/main.go
@@ -9,14 +9,16 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 
-	"github.com/status-im/status-go/cmd/status-backend/server"
+	backendServer "github.com/status-im/status-go/cmd/status-backend/server"
 	"github.com/status-im/status-go/internal/version"
 	"github.com/status-im/status-go/logutils"
+	mediaServer "github.com/status-im/status-go/server"
 )
 
 var (
-	address = flag.String("address", "", "host:port to listen")
-	logger  = log.New("package", "status-go/cmd/status-backend")
+	address       = flag.String("address", "", "host:port to listen")
+	useMediaHTTPS = flag.Bool("media-https", true, "use HTTPS for media server (default: true)")
+	logger        = log.New("package", "status-go/cmd/status-backend")
 )
 
 func init() {
@@ -34,7 +36,9 @@ func init() {
 func main() {
 	flag.Parse()
 
-	srv := server.NewServer()
+	mediaServer.UseHTTP = !*useMediaHTTPS
+
+	srv := backendServer.NewServer()
 	srv.Setup()
 
 	err := srv.Listen(*address)


### PR DESCRIPTION
base status-go [PR](https://github.com/status-im/status-go/pull/5943)
relate mobile [PR](https://github.com/status-im/status-mobile/pull/21550)

pls see the [doc](https://github.com/status-im/status-react/blob/073385bc08b0f8b4dbd117f9813d0a510f5f5df0/doc/use-status-backend-server.md#L38) why we need it.
