### PR TITLE
fix(BC)_: Fix personal_sign RPC event processing

### DIFF
--- a/services/connector/commands/personal_sign.go
+++ b/services/connector/commands/personal_sign.go
@@ -29,18 +29,17 @@ func (r *RPCRequest) getPersonalSignParams() (*PersonalSignParams, error) {
 		return nil, ErrEmptyRPCParams
 	}
 
-	paramMap, ok := r.Params[0].(map[string]interface{})
-	if !ok {
+	if len(r.Params) < 2 {
 		return nil, ErrInvalidParamsStructure
 	}
 
-	// Extract the Challenge and Address fields from paramMap
-	challenge, ok := paramMap["challenge"].(string)
+	// Extract the Challenge and Address fields from paramsArray
+	challenge, ok := r.Params[0].(string)
 	if !ok {
 		return nil, fmt.Errorf("missing or invalid 'challenge' field")
 	}
 
-	address, ok := paramMap["address"].(string)
+	address, ok := r.Params[1].(string)
 	if !ok {
 		return nil, fmt.Errorf("missing or invalid 'address' field")
 	}

--- a/services/connector/commands/personal_sign_test.go
+++ b/services/connector/commands/personal_sign_test.go
@@ -12,12 +12,7 @@ import (
 )
 
 func preparePersonalSignRequest(dApp signal.ConnectorDApp, challenge, address string) (RPCRequest, error) {
-	params := map[string]interface{}{
-		"challenge": challenge,
-		"address":   address,
-	}
-
-	return ConstructRPCRequest("personal_sign", []interface{}{params}, &dApp)
+	return ConstructRPCRequest("personal_sign", []interface{}{challenge, address}, &dApp)
 }
 
 func TestFailToPersonalSignWithMissingDAppFields(t *testing.T) {

--- a/services/connector/connector_flows_test.go
+++ b/services/connector/connector_flows_test.go
@@ -116,7 +116,7 @@ func TestRequestAccountsSwitchChainAndSendTransactionFlow(t *testing.T) {
 	assert.Equal(t, expectedHash.Hex(), response)
 
 	// Personal sign
-	request = "{\"method\": \"personal_sign\", \"params\":[{\"challenge\": \"0x506c65617365207369676e2074686973206d65737361676520746f20636f6e6669726d20796f7572206964656e746974792e\",\"address\":\"0x4B0897b0513FdBeEc7C469D9aF4fA6C0752aBea7\"}], \"url\": \"http://testDAppURL123\", \"name\": \"testDAppName\", \"iconUrl\": \"http://testDAppIconUrl\" }"
+	request = "{\"method\": \"personal_sign\", \"params\":[\"0x506c65617365207369676e2074686973206d65737361676520746f20636f6e6669726d20796f7572206964656e746974792e\",\"0x4B0897b0513FdBeEc7C469D9aF4fA6C0752aBea7\"], \"url\": \"http://testDAppURL123\", \"name\": \"testDAppName\", \"iconUrl\": \"http://testDAppIconUrl\" }"
 	response, err = state.api.CallRPC(state.ctx, request)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSignature, response)


### PR DESCRIPTION
Fixing the personal_sign RPC event parsing. Changed `params` from object array to string array.

https://docs.metamask.io/wallet/reference/json-rpc-methods/personal_sign/

Needed for https://github.com/status-im/status-desktop/issues/16015
