### PR TITLE
feat_: add KeycardPairingKey

### DIFF
--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -79,7 +79,11 @@ type CreateAccount struct {
 
 	APIConfig *APIConfig `json:"apiConfig"`
 
-	KeycardInstanceUID     string  `json:"keycardInstanceUID"`
+	KeycardInstanceUID string `json:"keycardInstanceUID"`
+
+	// on mobile there is no KeycardPairingDataFile, so for now KeycardPairingKey will be used
+	// for recovering account
+	KeycardPairingKey      string  `json:"keycardPairingKey"`
 	KeycardPairingDataFile *string `json:"keycardPairingDataFile"`
 	StatusProxyEnabled     bool    `json:"statusProxyEnabled"`
 }


### PR DESCRIPTION
On mobile we don't have KeycardPairing json File, so we are unable to provide a path to it, so for recoveryAccount we'll pass a parameter KeycardPairingKey which will be used instead of KeycardPairing json File, on desktop it will continue work as it is