### PR TITLE
feat(community)_: add version to image url to let clients update

### DIFF
--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -410,6 +410,7 @@ func (s *ManagerSuite) TestEditCommunity() {
 		Name:        "status",
 		Description: "status community description",
 		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,
+		Image:       "../../_assets/tests/elephant.jpg",
 	}
 
 	community, err := s.manager.CreateCommunity(createRequest, true)
@@ -421,12 +422,19 @@ func (s *ManagerSuite) TestEditCommunity() {
 		CreateCommunity: requests.CreateCommunity{
 			Name:        "statusEdited",
 			Description: "status community description edited",
+			Image:       "../../_assets/tests/status.png",
+			ImageBx:     5,
+			ImageBy:     5,
 		},
 	}
 
 	updatedCommunity, err := s.manager.EditCommunity(update)
 	s.Require().NoError(err)
 	s.Require().NotNil(updatedCommunity)
+	// Make sure the version of the image got updated with the new image
+	communityImageVersion, ok := s.manager.communityImageVersions[community.IDString()]
+	s.Require().True(ok)
+	s.Require().Equal(uint32(1), communityImageVersion)
 
 	//ensure updated community successfully stored
 	communities, err := s.manager.All()
@@ -438,10 +446,10 @@ func (s *ManagerSuite) TestEditCommunity() {
 		storedCommunity = communities[0]
 	}
 
-	s.Require().Equal(storedCommunity.ID(), updatedCommunity.ID())
-	s.Require().Equal(storedCommunity.PrivateKey(), updatedCommunity.PrivateKey())
-	s.Require().Equal(storedCommunity.config.CommunityDescription.Identity.DisplayName, update.CreateCommunity.Name)
-	s.Require().Equal(storedCommunity.config.CommunityDescription.Identity.Description, update.CreateCommunity.Description)
+	s.Require().Equal(updatedCommunity.ID(), storedCommunity.ID())
+	s.Require().Equal(updatedCommunity.PrivateKey(), storedCommunity.PrivateKey())
+	s.Require().Equal(update.CreateCommunity.Name, storedCommunity.config.CommunityDescription.Identity.DisplayName)
+	s.Require().Equal(update.CreateCommunity.Description, storedCommunity.config.CommunityDescription.Identity.Description)
 }
 
 func (s *ManagerSuite) TestGetControlledCommunitiesChatIDs() {

--- a/server/server_media_interface.go
+++ b/server/server_media_interface.go
@@ -5,6 +5,7 @@ import "github.com/status-im/status-go/protocol/protobuf"
 type MediaServerInterface interface {
 	MakeCommunityDescriptionTokenImageURL(communityID, symbol string) string
 	MakeCommunityImageURL(communityID, name string) string
+	SetCommunityImageVersionReader(func(communityID string) uint32)
 	SetCommunityImageReader(func(communityID string) (map[string]*protobuf.IdentityImage, error))
 	SetCommunityTokensReader(func(communityID string) ([]*protobuf.CommunityTokenMetadata, error))
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/16688

Since we use the local image server to show the community image, the URL never changes when we update the image, since it's served using a query string containing the community ID. eg: `https://Localhost:46739/communityDescriptionImages?communityID=0x03c5ece7da362d31199fb02d632f85fdf853af57d89c3204b4d1e90c6ec13bb23c&name=thumbnail` Because of that, the clients cannot know if the image was updated, so they had to force update the image every time, which was inefficient.

We discovered this issue when I refactored the community client code in Desktop so that we only update the changed properties of a community instead of reseting the whole thing.

The solution I came up with in the PR is to add a `version` to the URL when we detect that the image changed. This let,s the clients detect when the image was updated without having to do any extra logic.

