### PR TITLE
ci_: remove jenkins commit check

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -120,18 +120,6 @@ pipeline {
       } }
     }
 
-    stage('Commit') {
-      environment {
-        BASE_BRANCH = "${env.BASE_BRANCH}"
-      }
-      when { // https://github.com/status-im/status-go/issues/4993#issuecomment-2022685544
-        expression { isPRJob() }
-      }
-      steps { script {
-        nix.shell('make commit-check', pure: false)
-      } }
-    }
-
     stage('Lint') {
       steps { script {
         nix.shell('make lint', pure: true)


### PR DESCRIPTION
Commit messages are now checked as part of Github Action added in https://github.com/status-im/status-go/pull/5835.
The check is stable and marked as required.