### PR TITLE
feat_: API logging objects with `zap.Any`

### DIFF
--- a/mobile/callog/status_request_log.go
+++ b/mobile/callog/status_request_log.go
@@ -1,6 +1,7 @@
 package callog
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -138,8 +139,17 @@ func Log(logger *zap.Logger, method string, params any, resp any, startTime time
 	duration := time.Since(startTime)
 	logger.Debug("call",
 		zap.String("method", method),
-		zap.String("params", removeSensitiveInfo(fmt.Sprintf("%+v", params))),
-		zap.String("resp", removeSensitiveInfo(fmt.Sprintf("%+v", resp))),
 		zap.Duration("duration", duration),
+		dataField("request", params),
+		dataField("response", resp),
 	)
+}
+
+func dataField(name string, data any) zap.Field {
+	dataString := removeSensitiveInfo(fmt.Sprintf("%+v", data))
+	var paramsParsed any
+	if json.Unmarshal([]byte(dataString), &paramsParsed) == nil {
+		return zap.Any(name, paramsParsed)
+	}
+	return zap.String(name, dataString)
 }

--- a/mobile/callog/status_request_log_test.go
+++ b/mobile/callog/status_request_log_test.go
@@ -95,7 +95,7 @@ func TestCall(t *testing.T) {
 	requestLogOutput := string(logData)
 
 	// Check if the log contains expected information
-	expectedLogParts := []string{getShortFunctionName(testFunc), "params", testParam, "resp", expectedResult}
+	expectedLogParts := []string{getShortFunctionName(testFunc), "request", testParam, "response", expectedResult}
 	for _, part := range expectedLogParts {
 		if !strings.Contains(requestLogOutput, part) {
 			t.Errorf("Log output doesn't contain expected part: %s", part)

--- a/mobile/callog/status_request_log_test.go
+++ b/mobile/callog/status_request_log_test.go
@@ -134,3 +134,48 @@ func TestGetFunctionName(t *testing.T) {
 	fn := getShortFunctionName(initializeApplication)
 	require.Equal(t, "initializeApplication", fn)
 }
+
+func TestDataField(t *testing.T) {
+	entry := zapcore.Entry{}
+	enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{})
+
+	f := dataField("root", "value")
+	require.NotNil(t, f)
+	require.Equal(t, "root", f.Key)
+	require.Equal(t, zapcore.StringType, f.Type)
+	require.Equal(t, "value", f.String)
+
+	// Test JSON object
+	f = dataField("root", `{"key1": "value1"}`)
+	require.NotNil(t, f)
+	require.Equal(t, "root", f.Key)
+	require.Equal(t, zapcore.ReflectType, f.Type)
+
+	buf, err := enc.EncodeEntry(entry, []zapcore.Field{f})
+	require.NoError(t, err)
+	require.NotNil(t, buf)
+	require.Equal(t, `{"root":{"key1":"value1"}}`+"\n", buf.String())
+
+	// Test JSON array
+	f = dataField("root", `["value1", "value2"]`)
+	require.NotNil(t, f)
+	require.Equal(t, "root", f.Key)
+	require.Equal(t, zapcore.ReflectType, f.Type)
+
+	buf, err = enc.EncodeEntry(entry, []zapcore.Field{f})
+	require.NoError(t, err)
+	require.NotNil(t, buf)
+	require.Equal(t, `{"root":["value1","value2"]}`+"\n", buf.String())
+
+	// Test non-json content
+	f = dataField("root", `{non-json content}`)
+	require.NotNil(t, f)
+	require.Equal(t, "root", f.Key)
+	require.Equal(t, zapcore.StringType, f.Type)
+	require.Equal(t, `{non-json content}`, f.String)
+
+	buf, err = enc.EncodeEntry(entry, []zapcore.Field{f})
+	require.NoError(t, err)
+	require.NotNil(t, buf)
+	require.Equal(t, `{"root":"{non-json content}"}`+"\n", buf.String())
+}


### PR DESCRIPTION
Addresses:
- https://github.com/status-im/status-desktop/pull/16808#issuecomment-2497818236

# Description

Automatically detect if the request/response is a JSON string (which it is in most cases) and log it as object then.

# Example

Before:
```json
{
  "method": "InitializeApplication",
  "params": "{\"dataDir\":\"/Users/igorsirotin/Repositories/Status/status-desktop/Status/data/\",\"mixpanelAppId\":\"3350627\",\"mixpanelToken\":\"5c73bda2d36a9f688a5ee45641fb6775\",\"logEnabled\":true,\"logDir\":\"\",\"logLevel\":\"DEBUG\",\"apiLoggingEnabled\":true}",
  "resp": "{\"accounts\":null,\"centralizedMetricsInfo\":{\"enabled\":false,\"userConfirmed\":false}}",
  "duration": "4.534458ms"
}
```
After:
```json
{
  "method": "InitializeApplication",
  "duration": "511.916µs",
  "params": {
    "apiLoggingEnabled": true,
    "dataDir": "/Users/igorsirotin/Repositories/Status/status-desktop/Status/data"
  },
  "resp": {
    "accounts": null,
    "centralizedMetricsInfo": {
      "enabled": false,
      "userConfirmed": false
    }
  }
}

```
