### PR TITLE
feat_: endpoint for testing panic reports

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -2261,3 +2261,13 @@ func addCentralizedMetric(requestJSON string) string {
 
 	return metric.ID
 }
+
+func Panic(message string) string {
+	type intendedPanic struct {
+		error
+	}
+	return callWithResponse(func() {
+		err := intendedPanic{error: errors.New(message)}
+		panic(err)
+	})
+}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -2262,7 +2262,7 @@ func addCentralizedMetric(requestJSON string) string {
 	return metric.ID
 }
 
-func Panic(message string) string {
+func IntendedPanic(message string) string {
 	type intendedPanic struct {
 		error
 	}

--- a/mobile/status_test.go
+++ b/mobile/status_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	
+	"github.com/brianvoe/gofakeit/v6"
 
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/settings"
@@ -37,4 +39,11 @@ func TestSetMobileSignalHandler(t *testing.T) {
 	require.Contains(t, handler.receivedSignal, `"key-uid":"0x1"`, "Signal should contain the correct KeyUID")
 	require.Contains(t, handler.receivedSignal, `"name":"test"`, "Signal should contain the correct account name")
 	require.Contains(t, handler.receivedSignal, `"ensUsernames":{"test":"test"}`, "Signal should contain the correct ENS usernames")
+}
+
+func TestIntendedPanic(t *testing.T) {
+	message := gofakeit.LetterN(5)
+	require.PanicsWithError(t, message, func() {
+		IntendedPanic(message)
+	})
 }

--- a/mobile/status_test.go
+++ b/mobile/status_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	
+
 	"github.com/brianvoe/gofakeit/v6"
 
 	"github.com/status-im/status-go/multiaccounts"

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -8,10 +8,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/waku-org/go-waku/waku/v2/api/history"
+
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/protocol/common/shard"
-	"github.com/waku-org/go-waku/waku/v2/api/history"
 
 	"go.uber.org/zap"
 

--- a/wakuv2/history_processor_wrapper.go
+++ b/wakuv2/history_processor_wrapper.go
@@ -3,9 +3,10 @@ package wakuv2
 import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
-	"github.com/status-im/status-go/wakuv2/common"
 	"github.com/waku-org/go-waku/waku/v2/api/history"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
+
+	"github.com/status-im/status-go/wakuv2/common"
 )
 
 type HistoryProcessorWrapper struct {


### PR DESCRIPTION
Simple endpoint for testing Sentry integration.
Used a custom `intendedPanic` error type for simple distinguishing in Sentry:

<img width="615" alt="image" src="https://github.com/user-attachments/assets/65681162-2e04-4d4d-934c-14f46acb6f82">

https://sentry.infra.status.im/organizations/sentry/issues/135/?project=7&query=&statsPeriod=30d&stream_index=0

The `message` argument is there for simplicity of searching specific event just in case.
