### PR TITLE
refactor(server_media)_: pass a func to get the images instead of using the cache

### DIFF
--- a/server/server_media_interface.go
+++ b/server/server_media_interface.go
@@ -1,6 +1,10 @@
 package server
 
+import "github.com/status-im/status-go/protocol/protobuf"
+
 type MediaServerInterface interface {
 	MakeCommunityDescriptionTokenImageURL(communityID, symbol string) string
 	MakeCommunityImageURL(communityID, name string) string
+	SetCommunityImageReader(func(communityID string) (map[string]*protobuf.IdentityImage, error))
+	SetCommunityTokensReader(func(communityID string) ([]*protobuf.CommunityTokenMetadata, error))
 }


### PR DESCRIPTION
Issue raised in this PR https://github.com/status-im/status-go/pull/6118#discussion_r1857255843

The community cache that the image server was using was not intended to be used for that. It can be invalidated at any moment. Also, it did not contain changes made by admins (admin events).
Using this new approach, we pass functions from the community manager to the media server so that it can have access to the correct community description.