### PR TITLE
fix_: clear leftover route execution data on new route calculation

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -482,11 +482,15 @@ func gweiToWei(val *big.Float) *big.Int {
 func (api *API) GetSuggestedRoutes(ctx context.Context, input *requests.RouteInputParams) (*router.SuggestedRoutes, error) {
 	logutils.ZapLogger().Debug("call to GetSuggestedRoutes")
 
+	api.s.routeExecutionManager.ClearLocalRouteData()
+
 	return api.s.router.SuggestedRoutes(ctx, input)
 }
 
 func (api *API) GetSuggestedRoutesAsync(ctx context.Context, input *requests.RouteInputParams) {
 	logutils.ZapLogger().Debug("call to GetSuggestedRoutesAsync")
+
+	api.s.routeExecutionManager.ClearLocalRouteData()
 
 	api.s.router.SuggestedRoutesAsync(input)
 }

--- a/services/wallet/routeexecution/manager.go
+++ b/services/wallet/routeexecution/manager.go
@@ -52,7 +52,7 @@ func NewManager(walletDB *sql.DB, eventFeed *event.Feed, router *router.Router, 
 	}
 }
 
-func (m *Manager) clearLocalRouteData() {
+func (m *Manager) ClearLocalRouteData() {
 	m.buildInputParams = nil
 	m.transactionManager.ClearLocalRouterTransactionsData()
 }
@@ -72,7 +72,7 @@ func (m *Manager) BuildTransactionsFromRoute(ctx context.Context, buildInputPara
 
 		defer func() {
 			if err != nil {
-				m.clearLocalRouteData()
+				m.ClearLocalRouteData()
 				err = statusErrors.CreateErrorResponseFromError(err)
 				response.SendDetails.ErrorResponse = err.(*statusErrors.ErrorResponse)
 			}
@@ -134,7 +134,7 @@ func (m *Manager) SendRouterTransactionsWithSignatures(ctx context.Context, send
 			}
 
 			if clearLocalData {
-				m.clearLocalRouteData()
+				m.ClearLocalRouteData()
 			}
 
 			if err != nil {


### PR DESCRIPTION
Swap is the only transaction type where we do a 2 step process. If we did the first step for one route, then started the process again for a different route, we weren't properly clearing the old route execution data. Concretely, we considered the old approval (1st step) valid and attempted to directly perform the swap, even though the required approved amount could've changed. This PR fixes that.