### PR TITLE
fix(edit)_: make sure the contentType stays the same after an edit

### DIFF
--- a/protocol/messenger_messages.go
+++ b/protocol/messenger_messages.go
@@ -70,7 +70,7 @@ func (m *Messenger) EditMessage(ctx context.Context, request *requests.EditMessa
 			replacedText = request.Text
 		}
 		editMessage.Text = replacedText
-		editMessage.ContentType = request.ContentType
+		editMessage.ContentType = message.ContentType // The contentType cannot change
 		editMessage.ChatId = message.ChatId
 		editMessage.MessageId = message.ID
 		editMessage.Clock = clock

--- a/protocol/requests/edit_message.go
+++ b/protocol/requests/edit_message.go
@@ -5,18 +5,16 @@ import (
 
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/protobuf"
 )
 
 var ErrEditMessageInvalidID = errors.New("edit-message: invalid id")
 var ErrEditMessageInvalidText = errors.New("edit-message: invalid text")
 
 type EditMessage struct {
-	ID                 types.HexBytes                   `json:"id"`
-	Text               string                           `json:"text"`
-	ContentType        protobuf.ChatMessage_ContentType `json:"content-type"`
-	LinkPreviews       []common.LinkPreview             `json:"linkPreviews"`
-	StatusLinkPreviews []common.StatusLinkPreview       `json:"statusLinkPreviews"`
+	ID                 types.HexBytes             `json:"id"`
+	Text               string                     `json:"text"`
+	LinkPreviews       []common.LinkPreview       `json:"linkPreviews"`
+	StatusLinkPreviews []common.StatusLinkPreview `json:"statusLinkPreviews"`
 }
 
 func (e *EditMessage) Validate() error {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/16741

The issue was that in image messages, you can update the text, but then the ContentType would become Text and lose the image. The solution is to ignore ContentType changes, since there is no way to change the type of message.

I'm not sure if I should mark as a breaking change or not since I deprecate one of `EditMessage`'s param. You can still send it obviously, but we should remove it as it's no longer used. cc @igor-sirotin @ilmotta 