### PR TITLE
fix_: code duplication with setup log settings

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -492,18 +492,8 @@ func (b *GethStatusBackend) ensureWalletDBOpened(account multiaccounts.Account, 
 }
 
 func (b *GethStatusBackend) setupLogSettings() error {
-	logSettings := logutils.LogSettings{
-		Enabled:         b.config.LogEnabled,
-		Level:           b.config.LogLevel,
-		File:            b.config.LogFile,
-		MaxSize:         b.config.LogMaxSize,
-		MaxBackups:      b.config.LogMaxBackups,
-		CompressRotated: b.config.LogCompressRotated,
-	}
-	if err := logutils.OverrideRootLoggerWithConfig(logSettings); err != nil {
-		return err
-	}
-	return nil
+	logSettings := b.config.LogSettings()
+	return logutils.OverrideRootLoggerWithConfig(logSettings)
 }
 
 // Deprecated: Use StartNodeWithAccount instead.

--- a/cmd/ping-community/main.go
+++ b/cmd/ping-community/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/multiaccounts/settings"
 
+	"github.com/status-im/status-go/cmd/utils"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol"
@@ -116,7 +117,7 @@ func main() {
 	}
 
 	// set up logging options
-	setupLogging(config)
+	utils.SetupLogging(logLevel, logWithoutColors, config)
 
 	// We want statusd to be distinct from StatusIM client.
 	config.Name = serverClientName
@@ -229,25 +230,6 @@ func getDefaultDataDir() string {
 		return filepath.Join(home, ".statusd")
 	}
 	return "./statusd-data"
-}
-
-func setupLogging(config *params.NodeConfig) {
-	if *logLevel != "" {
-		config.LogLevel = *logLevel
-	}
-
-	logSettings := logutils.LogSettings{
-		Enabled:         config.LogEnabled,
-		Level:           config.LogLevel,
-		File:            config.LogFile,
-		MaxSize:         config.LogMaxSize,
-		MaxBackups:      config.LogMaxBackups,
-		CompressRotated: config.LogCompressRotated,
-		Colorized:       !(*logWithoutColors) && terminal.IsTerminal(int(os.Stdin.Fd())),
-	}
-	if err := logutils.OverrideRootLoggerWithConfig(logSettings); err != nil {
-		stdlog.Fatalf("Error initializing logger: %v", err)
-	}
 }
 
 // printVersion prints verbose output about version and config.

--- a/cmd/populate-db/main.go
+++ b/cmd/populate-db/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/status-im/status-go/account/generator"
 	"github.com/status-im/status-go/api"
+	"github.com/status-im/status-go/cmd/utils"
 	"github.com/status-im/status-go/common/dbsetup"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
@@ -125,7 +126,7 @@ func main() {
 	}
 
 	// set up logging options
-	setupLogging(config)
+	utils.SetupLogging(logLevel, logWithoutColors, config)
 
 	// We want statusd to be distinct from StatusIM client.
 	config.Name = serverClientName
@@ -273,25 +274,6 @@ func getDefaultDataDir() string {
 		return filepath.Join(home, ".statusd")
 	}
 	return "./statusd-data"
-}
-
-func setupLogging(config *params.NodeConfig) {
-	if *logLevel != "" {
-		config.LogLevel = *logLevel
-	}
-
-	logSettings := logutils.LogSettings{
-		Enabled:         config.LogEnabled,
-		Level:           config.LogLevel,
-		File:            config.LogFile,
-		MaxSize:         config.LogMaxSize,
-		MaxBackups:      config.LogMaxBackups,
-		CompressRotated: config.LogCompressRotated,
-		Colorized:       !(*logWithoutColors) && terminal.IsTerminal(int(os.Stdin.Fd())),
-	}
-	if err := logutils.OverrideRootLoggerWithConfig(logSettings); err != nil {
-		stdlog.Fatalf("Error initializing logger: %v", err)
-	}
 }
 
 // printVersion prints verbose output about version and config.

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/status-im/status-go/api"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/cmd/status-backend/server"
+	"github.com/status-im/status-go/cmd/utils"
 	"github.com/status-im/status-go/common/dbsetup"
 	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
 	"github.com/status-im/status-go/eth-node/crypto"
@@ -163,7 +164,7 @@ func main() {
 	}
 
 	// set up logging options
-	setupLogging(config)
+	utils.SetupLogging(logLevel, logWithoutColors, config)
 
 	// We want statusd to be distinct from StatusIM client.
 	config.Name = serverClientName
@@ -387,25 +388,6 @@ func getDefaultDataDir() string {
 		return filepath.Join(home, ".statusd")
 	}
 	return "./statusd-data"
-}
-
-func setupLogging(config *params.NodeConfig) {
-	if *logLevel != "" {
-		config.LogLevel = *logLevel
-	}
-
-	logSettings := logutils.LogSettings{
-		Enabled:         config.LogEnabled,
-		Level:           config.LogLevel,
-		File:            config.LogFile,
-		MaxSize:         config.LogMaxSize,
-		MaxBackups:      config.LogMaxBackups,
-		CompressRotated: config.LogCompressRotated,
-		Colorized:       !(*logWithoutColors) && terminal.IsTerminal(int(os.Stdin.Fd())),
-	}
-	if err := logutils.OverrideRootLoggerWithConfig(logSettings); err != nil {
-		stdlog.Fatalf("Error initializing logger: %v", err)
-	}
 }
 
 // loop for notifying systemd about process being alive

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	stdlog "log"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/status-im/status-go/logutils"
+	"github.com/status-im/status-go/params"
+)
+
+func SetupLogging(logLevel *string, logWithoutColors *bool, config *params.NodeConfig) {
+	if *logLevel != "" {
+		config.LogLevel = *logLevel
+	}
+
+	logSettings := config.LogSettings()
+	logSettings.Colorized = !(*logWithoutColors) && terminal.IsTerminal(int(os.Stdin.Fd()))
+	if err := logutils.OverrideRootLoggerWithConfig(logSettings); err != nil {
+		stdlog.Fatalf("Error initializing logger: %v", err)
+	}
+}

--- a/params/config.go
+++ b/params/config.go
@@ -1191,3 +1191,14 @@ func LesTopic(netid int) string {
 		return ""
 	}
 }
+
+func (c *NodeConfig) LogSettings() logutils.LogSettings {
+	return logutils.LogSettings{
+		Enabled:         c.LogEnabled,
+		Level:           c.LogLevel,
+		File:            c.LogFile,
+		MaxSize:         c.LogMaxSize,
+		MaxBackups:      c.LogMaxBackups,
+		CompressRotated: c.LogCompressRotated,
+	}
+}


### PR DESCRIPTION
Removed code duplication for setting `LogSettings` from `NodeConfig`.

1. Added direct `func (c *NodeConfig) LogSettings() logutils.LogSettings`.
This package already had `import .../logutils`, so I thought it's fine.

2. Added `cmd/utils` directory for various functions used by many cmds. 