### PR TITLE
feat_: add unique key to each activity entry

### DIFF
--- a/services/wallet/activity/activity.go
+++ b/services/wallet/activity/activity.go
@@ -85,9 +85,21 @@ type Entry struct {
 	isNew bool // isNew is used to indicate if the entry is newer than session start (changed state also)
 }
 
+func (e *Entry) Key() string {
+	if e.payloadType == MultiTransactionPT {
+		key := fmt.Sprintf("%d", e.id)
+		for _, t := range e.transactions {
+			key += fmt.Sprintf("-%s", t.Key())
+		}
+		return key
+	}
+	return e.transaction.Key()
+}
+
 // Only used for JSON marshalling
 type EntryData struct {
 	PayloadType               PayloadType                     `json:"payloadType"`
+	Key                       string                          `json:"key"`
 	Transaction               *transfer.TransactionIdentity   `json:"transaction,omitempty"`
 	ID                        *common.MultiTransactionIDType  `json:"id,omitempty"`
 	Transactions              []*transfer.TransactionIdentity `json:"transactions,omitempty"`
@@ -118,6 +130,7 @@ type EntryData struct {
 
 func (e *Entry) MarshalJSON() ([]byte, error) {
 	data := EntryData{
+		Key:                       e.Key(),
 		Timestamp:                 &e.timestamp,
 		ActivityType:              &e.activityType,
 		ActivityStatus:            &e.activityStatus,

--- a/services/wallet/activity/activity_v2.go
+++ b/services/wallet/activity/activity_v2.go
@@ -59,7 +59,7 @@ func getActivityEntriesV2(ctx context.Context, deps FilterDependencies, addresse
 			rpt.uuid = rbtp.uuid`).
 		LeftJoin(`route_input_parameters rip ON 
 			rpt.uuid = rip.uuid`)
-	q = q.OrderBy("tt.timestamp DESC")
+	q = q.OrderBy("tt.timestamp DESC", "rpt.is_approval ASC")
 
 	qConditions := sq.And{}
 

--- a/services/wallet/activity/service.go
+++ b/services/wallet/activity/service.go
@@ -276,6 +276,7 @@ func (s *Service) getActivityDetails(ctx context.Context, entries []Entry) ([]*E
 			}
 			for _, e := range entryList {
 				data := &EntryData{
+					Key:     e.Key(),
 					NftName: nftName,
 					NftURL:  nftURL,
 				}

--- a/services/wallet/activity/session_service.go
+++ b/services/wallet/activity/session_service.go
@@ -456,6 +456,7 @@ func (s *Service) processEntryDataUpdates(sessionID SessionID, entries []Entry, 
 		}
 
 		data := &EntryData{
+			Key:            e.Key(),
 			ActivityStatus: &e.activityStatus,
 		}
 		if e.payloadType == MultiTransactionPT {

--- a/services/wallet/transfer/transaction_manager.go
+++ b/services/wallet/transfer/transaction_manager.go
@@ -126,6 +126,10 @@ type TransactionIdentity struct {
 	Address common.Address        `json:"address"`
 }
 
+func (tid *TransactionIdentity) Key() string {
+	return fmt.Sprintf("%d-%s-%s", tid.ChainID, tid.Hash.Hex(), tid.Address.Hex())
+}
+
 type TxResponse struct {
 	KeyUID        string                 `json:"keyUid,omitempty"`
 	Address       types.Address          `json:"address,omitempty"`


### PR DESCRIPTION
We used to have different unique identifiers for activity entries based on the payload type, which required client-side handling and was error prone. This PR introduces a status-go side unique key for each activity entry.

A small fix was introduced as well to ensure approvals for a given operation are shown before the intended transaction.