### PR TITLE
fix(healthmanager)_: extract subscriber logic from RPC Health Manager

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,4 @@ shell.nix             @status-im/devops
 # Feel free to add yourself for any new packages you implement.
 /cmd/status-backend   @igor-sirotin
 /internal/sentry      @igor-sirotin
+/healthmanager	      @friofry

--- a/healthmanager/subscription_manager.go
+++ b/healthmanager/subscription_manager.go
@@ -1,0 +1,52 @@
+package healthmanager
+
+import (
+	"context"
+	"sync"
+)
+
+type SubscriptionManager struct {
+	mu          sync.RWMutex
+	subscribers map[chan struct{}]struct{}
+}
+
+func NewSubscriptionManager() *SubscriptionManager {
+	return &SubscriptionManager{
+		subscribers: make(map[chan struct{}]struct{}),
+	}
+}
+
+func (s *SubscriptionManager) Subscribe() chan struct{} {
+	ch := make(chan struct{}, 1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.subscribers[ch] = struct{}{}
+	return ch
+}
+
+func (s *SubscriptionManager) Unsubscribe(ch chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, exist := s.subscribers[ch]
+	if !exist {
+		return
+	}
+	delete(s.subscribers, ch)
+	close(ch)
+}
+
+func (s *SubscriptionManager) Emit(ctx context.Context) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for subscriber := range s.subscribers {
+		select {
+		case <-ctx.Done():
+			// Stop sending notifications when the context is cancelled
+			return
+		case subscriber <- struct{}{}:
+			// Notified successfully
+		default:
+			// Skip notification if the subscriber's channel is full (non-blocking)
+		}
+	}
+}

--- a/healthmanager/subscription_manager_test.go
+++ b/healthmanager/subscription_manager_test.go
@@ -1,0 +1,101 @@
+package healthmanager
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscriptionManager(t *testing.T) {
+	// Create a new SubscriptionManager
+	sm := NewSubscriptionManager()
+
+	// Create a context for cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create a WaitGroup to wait for all goroutines to finish
+	var wg sync.WaitGroup
+
+	// Test adding subscribers and receiving notifications
+	subscriberCount := 5
+	notificationReceived := make([]bool, subscriberCount)
+
+	for i := 0; i < subscriberCount; i++ {
+		ch := sm.Subscribe()
+		idx := i // Copy the value of i to use inside the goroutine
+
+		wg.Add(1)
+		go func(ch chan struct{}, idx int) {
+			defer wg.Done()
+			select {
+			case <-ch:
+				notificationReceived[idx] = true
+			case <-time.After(1 * time.Second):
+				// Timeout waiting for notification
+			}
+		}(ch, idx)
+	}
+
+	// Emit a notification to all subscribers
+	sm.Emit(ctx)
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	// Verify that all subscribers received the notification
+	for i, received := range notificationReceived {
+		require.Truef(t, received, "Subscriber %d did not receive notification", i)
+	}
+
+	// Test that notifications are not sent to closed channels
+	chClosed := sm.Subscribe()
+	// Ensure that unsubscribe handles already closed channels properly
+	sm.Unsubscribe(chClosed)
+
+	// ensure subscription is removed
+	_, exists := sm.subscribers[chClosed]
+	require.False(t, exists, "Subscription was not removed")
+
+	sm.Unsubscribe(chClosed)
+	// Emit a notification
+	sm.Emit(ctx)
+
+	// If no panic occurs, the test is successful
+}
+
+func TestSubscriptionManager_MultipleEmitsCollapse(t *testing.T) {
+	sm := NewSubscriptionManager()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := sm.Subscribe()
+	defer sm.Unsubscribe(ch)
+
+	var received int
+	var mu sync.Mutex
+
+	go func() {
+		for range ch {
+			mu.Lock()
+			received++
+			mu.Unlock()
+		}
+	}()
+
+	// Emit multiple notifications
+	sm.Emit(ctx)
+	sm.Emit(ctx)
+	sm.Emit(ctx)
+
+	// Allow some time for the goroutine to process notifications
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	require.Equalf(t, 1, received, "Expected 1 notifications, but received %d", received)
+	mu.Unlock()
+}

--- a/rpc/chain/blockchain_health_test.go
+++ b/rpc/chain/blockchain_health_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/status-im/status-go/rpc/chain/ethclient"
 )
 
-type BlockchainHealthManagerSuite struct {
+type BlockchainHealthSuite struct {
 	suite.Suite
 	blockchainHealthManager *healthmanager.BlockchainHealthManager
 	mockProviders           map[uint64]*healthmanager.ProvidersHealthManager
@@ -32,7 +32,7 @@ type BlockchainHealthManagerSuite struct {
 	mockCtrl                *gomock.Controller
 }
 
-func (s *BlockchainHealthManagerSuite) SetupTest() {
+func (s *BlockchainHealthSuite) SetupTest() {
 	s.blockchainHealthManager = healthmanager.NewBlockchainHealthManager()
 	s.mockProviders = make(map[uint64]*healthmanager.ProvidersHealthManager)
 	s.mockEthClients = make(map[uint64]*mockEthclient.MockRPSLimitedEthClientInterface)
@@ -40,12 +40,12 @@ func (s *BlockchainHealthManagerSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 }
 
-func (s *BlockchainHealthManagerSuite) TearDownTest() {
+func (s *BlockchainHealthSuite) TearDownTest() {
 	s.blockchainHealthManager.Stop()
 	s.mockCtrl.Finish()
 }
 
-func (s *BlockchainHealthManagerSuite) setupClients(chainIDs []uint64) {
+func (s *BlockchainHealthSuite) setupClients(chainIDs []uint64) {
 	ctx := context.Background()
 
 	for _, chainID := range chainIDs {
@@ -65,7 +65,7 @@ func (s *BlockchainHealthManagerSuite) setupClients(chainIDs []uint64) {
 	}
 }
 
-func (s *BlockchainHealthManagerSuite) simulateChainStatus(chainID uint64, up bool) {
+func (s *BlockchainHealthSuite) simulateChainStatus(chainID uint64, up bool) {
 	client, exists := s.clients[chainID]
 	require.True(s.T(), exists, "Client for chainID %d not found", chainID)
 
@@ -85,7 +85,7 @@ func (s *BlockchainHealthManagerSuite) simulateChainStatus(chainID uint64, up bo
 	}
 }
 
-func (s *BlockchainHealthManagerSuite) waitForStatus(statusCh chan struct{}, expectedStatus rpcstatus.StatusType) {
+func (s *BlockchainHealthSuite) waitForStatus(statusCh chan struct{}, expectedStatus rpcstatus.StatusType) {
 	timeout := time.After(2 * time.Second)
 	for {
 		select {
@@ -101,7 +101,7 @@ func (s *BlockchainHealthManagerSuite) waitForStatus(statusCh chan struct{}, exp
 	}
 }
 
-func (s *BlockchainHealthManagerSuite) TestAllChainsUp() {
+func (s *BlockchainHealthSuite) TestAllChainsUp() {
 	s.setupClients([]uint64{1, 2, 3})
 
 	statusCh := s.blockchainHealthManager.Subscribe()
@@ -114,7 +114,7 @@ func (s *BlockchainHealthManagerSuite) TestAllChainsUp() {
 	s.waitForStatus(statusCh, rpcstatus.StatusUp)
 }
 
-func (s *BlockchainHealthManagerSuite) TestSomeChainsDown() {
+func (s *BlockchainHealthSuite) TestSomeChainsDown() {
 	s.setupClients([]uint64{1, 2, 3})
 
 	statusCh := s.blockchainHealthManager.Subscribe()
@@ -127,7 +127,7 @@ func (s *BlockchainHealthManagerSuite) TestSomeChainsDown() {
 	s.waitForStatus(statusCh, rpcstatus.StatusUp)
 }
 
-func (s *BlockchainHealthManagerSuite) TestAllChainsDown() {
+func (s *BlockchainHealthSuite) TestAllChainsDown() {
 	s.setupClients([]uint64{1, 2})
 
 	statusCh := s.blockchainHealthManager.Subscribe()
@@ -139,7 +139,7 @@ func (s *BlockchainHealthManagerSuite) TestAllChainsDown() {
 	s.waitForStatus(statusCh, rpcstatus.StatusDown)
 }
 
-func (s *BlockchainHealthManagerSuite) TestChainStatusChanges() {
+func (s *BlockchainHealthSuite) TestChainStatusChanges() {
 	s.setupClients([]uint64{1, 2})
 
 	statusCh := s.blockchainHealthManager.Subscribe()
@@ -153,7 +153,7 @@ func (s *BlockchainHealthManagerSuite) TestChainStatusChanges() {
 	s.waitForStatus(statusCh, rpcstatus.StatusUp)
 }
 
-func (s *BlockchainHealthManagerSuite) TestGetFullStatus() {
+func (s *BlockchainHealthSuite) TestGetFullStatus() {
 	// Setup clients for chain IDs 1 and 2
 	s.setupClients([]uint64{1, 2})
 
@@ -233,7 +233,7 @@ func (s *BlockchainHealthManagerSuite) TestGetFullStatus() {
 	require.NotEmpty(s.T(), jsonData)
 }
 
-func (s *BlockchainHealthManagerSuite) TestGetShortStatus() {
+func (s *BlockchainHealthSuite) TestGetShortStatus() {
 	// Setup clients for chain IDs 1 and 2
 	s.setupClients([]uint64{1, 2})
 
@@ -294,6 +294,6 @@ func (s *BlockchainHealthManagerSuite) TestGetShortStatus() {
 	require.NotEmpty(s.T(), jsonData)
 }
 
-func TestBlockchainHealthManagerSuite(t *testing.T) {
-	suite.Run(t, new(BlockchainHealthManagerSuite))
+func TestBlockchainHealthSuite(t *testing.T) {
+	suite.Run(t, new(BlockchainHealthSuite))
 }


### PR DESCRIPTION
* Subscription common logic is extracted to a separate type.
* Fix race where go routing extracts value from sync.map and then another go routine calls unsubscribe and closes the channel before the first go routing tries to write to the channel.
* moved TestInterleavedChainStatusChanges TestDelayedChainUpdate to the correct file
* Renamed test suites with duplicate names

closes #6139 