### PR TITLE
fix(sentry)_: trim production env variable

### DIFF
--- a/internal/sentry/params.go
+++ b/internal/sentry/params.go
@@ -3,6 +3,7 @@ package sentry
 import (
 	_ "embed"
 	"os"
+	"strings"
 )
 
 //go:generate sh -c "echo $SENTRY_CONTEXT_NAME > SENTRY_CONTEXT_NAME"
@@ -22,6 +23,10 @@ var (
 	production string
 )
 
+func init() {
+	production = strings.TrimSpace(production)
+}
+
 func DefaultContext() string {
 	return defaultContextName
 }
@@ -38,8 +43,8 @@ func Environment() string {
 	return environment(Production(), DefaultEnvVarEnvironment)
 }
 
-func environment(production bool, envvar string) string {
-	if production {
+func environment(forceProduction bool, envvar string) string {
+	if forceProduction {
 		return productionEnvironment
 	}
 	env := os.Getenv(envvar)

--- a/internal/sentry/stacktrace.go
+++ b/internal/sentry/stacktrace.go
@@ -20,7 +20,7 @@ var stacktraceFilters = []struct {
 	},
 	{
 		Module:    "github.com/status-im/status-go/mobile/callog",
-		Functions: []string{"Call.func1"},
+		Functions: []string{"Recover"},
 	},
 }
 

--- a/internal/sentry/stacktrace_test.go
+++ b/internal/sentry/stacktrace_test.go
@@ -34,7 +34,7 @@ func TestTrimStacktrace(t *testing.T) {
 			stacktrace: &sentry.Stacktrace{
 				Frames: []sentry.Frame{
 					{Module: "github.com/status-im/status-go/other", Function: "OtherFunc"},
-					{Module: "github.com/status-im/status-go/mobile/callog", Function: "Call.func1"},
+					{Module: "github.com/status-im/status-go/mobile/callog", Function: "Recover"},
 					{Module: "github.com/status-im/status-go/internal/sentry", Function: "RecoverError"},
 				},
 			},
@@ -92,7 +92,7 @@ func TestTrimStacktrace(t *testing.T) {
 					{Module: "github.com/status-im/status-go/other", Function: "OtherFunc2"},
 					{Module: "github.com/status-im/status-go/other", Function: "OtherFunc3"},
 					{Module: "github.com/status-im/status-go/internal/sentry", Function: "Recover"},
-					{Module: "github.com/status-im/status-go/mobile/callog", Function: "Call.func1"},
+					{Module: "github.com/status-im/status-go/mobile/callog", Function: "Recover"},
 					{Module: "github.com/status-im/status-go/common", Function: "LogOnPanic"},
 				},
 			},
@@ -107,13 +107,13 @@ func TestTrimStacktrace(t *testing.T) {
 			name: "break if non-matching frame found",
 			stacktrace: &sentry.Stacktrace{
 				Frames: []sentry.Frame{
-					{Module: "github.com/status-im/status-go/mobile/callog", Function: "Call.func1"},
+					{Module: "github.com/status-im/status-go/mobile/callog", Function: "Recover"},
 					{Module: "github.com/status-im/status-go/internal/sentry", Function: "RecoverError"},
 					{Module: "github.com/status-im/status-go/other", Function: "OtherFunc1"},
 				},
 			},
 			expected: []sentry.Frame{
-				{Module: "github.com/status-im/status-go/mobile/callog", Function: "Call.func1"},
+				{Module: "github.com/status-im/status-go/mobile/callog", Function: "Recover"},
 				{Module: "github.com/status-im/status-go/internal/sentry", Function: "RecoverError"},
 				{Module: "github.com/status-im/status-go/other", Function: "OtherFunc1"},
 			},


### PR DESCRIPTION
1. After using https://github.com/status-im/status-go/blob/987a9e8707e97c1757f87f621c036d671bb046fe/internal/sentry/params.go#L10 and https://github.com/status-im/status-go/blob/987a9e8707e97c1757f87f621c036d671bb046fe/internal/sentry/params.go#L21-L22
... `production` variable needs to be trimmed. Otherwise later comparison with `true` and `1` fails.

2. Updated the `stacktraceFilters` location of `callog.Recover` function.