### PR TITLE
feat_: api logging signals

### DIFF
--- a/mobile/callog/status_request_log.go
+++ b/mobile/callog/status_request_log.go
@@ -14,7 +14,7 @@ import (
 	"github.com/status-im/status-go/internal/sentry"
 )
 
-const placeholder = "***"
+const redactionPlaceholder = "***"
 
 var sensitiveKeys = []string{
 	"password",
@@ -109,7 +109,7 @@ func removeSensitiveInfo(jsonStr string) string {
 	// see related test for the usage of this function
 	return sensitiveRegex.ReplaceAllStringFunc(jsonStr, func(match string) string {
 		parts := sensitiveRegex.FindStringSubmatch(match)
-		return fmt.Sprintf(`%s:"%s"`, parts[1], placeholder)
+		return fmt.Sprintf(`%s:"%s"`, parts[1], redactionPlaceholder)
 	})
 }
 

--- a/mobile/callog/status_request_log.go
+++ b/mobile/callog/status_request_log.go
@@ -168,11 +168,11 @@ func dataField(name string, data any) zap.Field {
 }
 
 func marshalData(data any) string {
-	switch data.(type) {
+	switch d := data.(type) {
 	case string:
-		return data.(string)
+		return d
 	default:
-		bytes, err := json.Marshal(data)
+		bytes, err := json.Marshal(d)
 		if err != nil {
 			return "<failed to marshal value>"
 		}

--- a/mobile/callog/status_request_log.go
+++ b/mobile/callog/status_request_log.go
@@ -14,6 +14,8 @@ import (
 	"github.com/status-im/status-go/internal/sentry"
 )
 
+const placeholder = "***"
+
 var sensitiveKeys = []string{
 	"password",
 	"newPassword",
@@ -32,6 +34,7 @@ var sensitiveKeys = []string{
 	"alchemyOptimismSepoliaToken",
 	"verifyENSURL",
 	"verifyTransactionURL",
+	"gifs/api-key",
 }
 
 var sensitiveRegexString = fmt.Sprintf(`(?i)(".*?(%s).*?")\s*:\s*("[^"]*")`, strings.Join(sensitiveKeys, "|"))
@@ -106,7 +109,7 @@ func removeSensitiveInfo(jsonStr string) string {
 	// see related test for the usage of this function
 	return sensitiveRegex.ReplaceAllStringFunc(jsonStr, func(match string) string {
 		parts := sensitiveRegex.FindStringSubmatch(match)
-		return fmt.Sprintf(`%s:"***"`, parts[1])
+		return fmt.Sprintf(`%s:"%s"`, parts[1], placeholder)
 	})
 }
 
@@ -156,10 +159,23 @@ func LogSignal(logger *zap.Logger, eventType string, event interface{}) {
 }
 
 func dataField(name string, data any) zap.Field {
-	dataString := removeSensitiveInfo(fmt.Sprintf("%+v", data))
+	dataString := removeSensitiveInfo(marshalData(data))
 	var paramsParsed any
 	if json.Unmarshal([]byte(dataString), &paramsParsed) == nil {
 		return zap.Any(name, paramsParsed)
 	}
 	return zap.String(name, dataString)
+}
+
+func marshalData(data any) string {
+	switch data.(type) {
+	case string:
+		return data.(string)
+	default:
+		bytes, err := json.Marshal(data)
+		if err != nil {
+			return "<failed to marshal value>"
+		}
+		return string(bytes)
+	}
 }

--- a/mobile/callog/status_request_log.go
+++ b/mobile/callog/status_request_log.go
@@ -88,7 +88,7 @@ func Call(logger, requestLogger *zap.Logger, fn any, params ...any) any {
 
 	if requestLogger != nil {
 		methodName := getShortFunctionName(fn)
-		Log(requestLogger, methodName, params, resp, startTime)
+		LogCall(requestLogger, methodName, params, resp, startTime)
 	}
 
 	return resp
@@ -132,7 +132,7 @@ func Recover(logger *zap.Logger) {
 	panic(err)
 }
 
-func Log(logger *zap.Logger, method string, params any, resp any, startTime time.Time) {
+func LogCall(logger *zap.Logger, method string, params any, resp any, startTime time.Time) {
 	if logger == nil {
 		return
 	}
@@ -142,6 +142,16 @@ func Log(logger *zap.Logger, method string, params any, resp any, startTime time
 		zap.Duration("duration", duration),
 		dataField("request", params),
 		dataField("response", resp),
+	)
+}
+
+func LogSignal(logger *zap.Logger, eventType string, event interface{}) {
+	if logger == nil {
+		return
+	}
+	logger.Debug("signal",
+		zap.String("type", eventType),
+		dataField("event", event),
 	)
 }
 

--- a/mobile/callog/status_request_log_test.go
+++ b/mobile/callog/status_request_log_test.go
@@ -2,6 +2,8 @@ package callog
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -10,6 +12,8 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/brianvoe/gofakeit/v6"
 
 	"github.com/status-im/status-go/logutils/requestlog"
 )
@@ -23,22 +27,22 @@ func TestRemoveSensitiveInfo(t *testing.T) {
 		{
 			name:     "basic test",
 			input:    `{"username":"user1","password":"secret123","mnemonic":"mnemonic123 xyz"}`,
-			expected: `{"username":"user1","password":"***","mnemonic":"***"}`,
+			expected: fmt.Sprintf(`{"username":"user1","password":"%s","mnemonic":"%s"}`, placeholder, placeholder),
 		},
 		{
 			name:     "uppercase password field",
 			input:    `{"USERNAME":"user1","PASSWORD":"secret123"}`,
-			expected: `{"USERNAME":"user1","PASSWORD":"***"}`,
+			expected: fmt.Sprintf(`{"USERNAME":"user1","PASSWORD":"%s"}`, placeholder),
 		},
 		{
 			name:     "password field with spaces",
 			input:    `{"username":"user1", "password" : "secret123"}`,
-			expected: `{"username":"user1", "password":"***"}`,
+			expected: fmt.Sprintf(`{"username":"user1", "password":"%s"}`, placeholder),
 		},
 		{
 			name:     "multiple password fields",
 			input:    `{"password":"secret123","data":{"nested_password":"nested_secret"}}`,
-			expected: `{"password":"***","data":{"nested_password":"***"}}`,
+			expected: fmt.Sprintf(`{"password":"%s","data":{"nested_password":"%s"}}`, placeholder, placeholder),
 		},
 		{
 			name:     "no password field",
@@ -178,4 +182,56 @@ func TestDataField(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buf)
 	require.Equal(t, `{"root":"{non-json content}"}`+"\n", buf.String())
+}
+
+func TestSignal(t *testing.T) {
+	entry := zapcore.Entry{}
+	enc := zapcore.NewJSONEncoder(zapcore.EncoderConfig{})
+
+	// Simulate pairing.AccountData and pairing.Event without importing the package
+	type Data struct {
+		Name     string `json:"name" fake:"{firstname}"`
+		Password string `json:"password"`
+	}
+	type Event struct {
+		Data any `json:"data,omitempty"`
+	}
+
+	data := Data{}
+	err := gofakeit.Struct(&data)
+	require.NoError(t, err)
+
+	event := Event{Data: data}
+
+	f := dataField("event", event)
+	require.NotNil(t, f)
+	require.Equal(t, "event", f.Key)
+	require.Equal(t, zapcore.ReflectType, f.Type)
+
+	buf, err := enc.EncodeEntry(entry, []zapcore.Field{f})
+	require.NoError(t, err)
+	require.NotNil(t, buf)
+
+	t.Logf("encoded event: %s", buf.String())
+
+	var result map[string]interface{}
+	err = json.Unmarshal(buf.Bytes(), &result)
+	require.NoError(t, err)
+
+	resultEvent, ok := result["event"]
+	require.True(t, ok)
+	require.NotNil(t, resultEvent)
+
+	resultEventMap, ok := resultEvent.(map[string]interface{})
+	require.True(t, ok)
+	require.NotNil(t, resultEventMap)
+
+	resultData, ok := resultEventMap["data"]
+	require.True(t, ok)
+	require.NotNil(t, resultData)
+
+	resultDataMap, ok := resultData.(map[string]interface{})
+	require.True(t, ok)
+	require.NotNil(t, resultDataMap)
+	require.Equal(t, placeholder, resultDataMap["password"])
 }

--- a/mobile/callog/status_request_log_test.go
+++ b/mobile/callog/status_request_log_test.go
@@ -27,22 +27,22 @@ func TestRemoveSensitiveInfo(t *testing.T) {
 		{
 			name:     "basic test",
 			input:    `{"username":"user1","password":"secret123","mnemonic":"mnemonic123 xyz"}`,
-			expected: fmt.Sprintf(`{"username":"user1","password":"%s","mnemonic":"%s"}`, placeholder, placeholder),
+			expected: fmt.Sprintf(`{"username":"user1","password":"%s","mnemonic":"%s"}`, redactionPlaceholder, redactionPlaceholder),
 		},
 		{
 			name:     "uppercase password field",
 			input:    `{"USERNAME":"user1","PASSWORD":"secret123"}`,
-			expected: fmt.Sprintf(`{"USERNAME":"user1","PASSWORD":"%s"}`, placeholder),
+			expected: fmt.Sprintf(`{"USERNAME":"user1","PASSWORD":"%s"}`, redactionPlaceholder),
 		},
 		{
 			name:     "password field with spaces",
 			input:    `{"username":"user1", "password" : "secret123"}`,
-			expected: fmt.Sprintf(`{"username":"user1", "password":"%s"}`, placeholder),
+			expected: fmt.Sprintf(`{"username":"user1", "password":"%s"}`, redactionPlaceholder),
 		},
 		{
 			name:     "multiple password fields",
 			input:    `{"password":"secret123","data":{"nested_password":"nested_secret"}}`,
-			expected: fmt.Sprintf(`{"password":"%s","data":{"nested_password":"%s"}}`, placeholder, placeholder),
+			expected: fmt.Sprintf(`{"password":"%s","data":{"nested_password":"%s"}}`, redactionPlaceholder, redactionPlaceholder),
 		},
 		{
 			name:     "no password field",
@@ -233,5 +233,5 @@ func TestSignal(t *testing.T) {
 	resultDataMap, ok := resultData.(map[string]interface{})
 	require.True(t, ok)
 	require.NotNil(t, resultDataMap)
-	require.Equal(t, placeholder, resultDataMap["password"])
+	require.Equal(t, redactionPlaceholder, resultDataMap["password"])
 }

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -76,7 +76,7 @@ func InitializeApplication(requestJSON string) string {
 
 	startTime := time.Now()
 	response := initializeApplication(requestJSON)
-	callog.Log(
+	callog.LogCall(
 		requestlog.GetRequestLogger(),
 		"InitializeApplication",
 		requestJSON,

--- a/signal/signals.go
+++ b/signal/signals.go
@@ -17,6 +17,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/logutils"
+	"github.com/status-im/status-go/logutils/requestlog"
+	"github.com/status-im/status-go/mobile/callog"
 )
 
 // MobileSignalHandler is a simple callback function that gets called when any signal is received
@@ -50,6 +52,8 @@ func send(typ string, event interface{}) {
 		logger.Error("Marshalling signal envelope", zap.Error(err))
 		return
 	}
+	callog.LogSignal(requestlog.GetRequestLogger(), typ, event)
+
 	// If a Go implementation of signal handler is set, let's use it.
 	if mobileSignalHandler != nil {
 		mobileSignalHandler(data)


### PR DESCRIPTION
# Major changes

1. Log signals 🎉 

2. Replaced default text marshalling with json marshalling. 
We have `removeSensitiveInfo` expecting JSONs, otherwise its not doing it's job. In this case it didn't work for `pairing.Event.Data any`, which was marshalled to this:
    ```
    2024-12-05T12:44:10.275Z	DEBUG	RequestLogger	signal	{"type": "localPairing", "event": "{Type:received-account Error: Action:2 Data:{Account:0x24001908e70 Password:0xbaf4c353a3...277da307f6bc25199c ChatKey:}}"}
    ```
    (I added the `...` manually, it's fully logged).
    Not that it's not a json. And that's why `Password` was never redacted in such case.

# Minor changes

1. Extracted `placeholder` constant