### PR TITLE
fix_: no peers available supporting LightPush protocol after network restored from disabled state

### DIFF
--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1707,6 +1707,10 @@ func (w *Waku) handleNetworkChangeFromApp(state connection.State) {
 
 func (w *Waku) ConnectionChanged(state connection.State) {
 	isOnline := !state.Offline
+	if isOnline && !w.onlineChecker.IsOnline() { // we are online and we were offline before
+		//TODO: analyze if we need to discover and connect to peers for relay.
+		w.discoverAndConnectPeers()
+	}
 	if w.cfg.LightClient {
 		//TODO: Update this as per  https://github.com/waku-org/go-waku/issues/1114
 		go func() {
@@ -1718,8 +1722,6 @@ func (w *Waku) ConnectionChanged(state connection.State) {
 		// for lightClient state update and onlineChange is handled in filterManager.
 		// going online
 		if isOnline && !w.onlineChecker.IsOnline() {
-			//TODO: analyze if we need to discover and connect to peers for relay.
-			w.discoverAndConnectPeers()
 			select {
 			case w.goingOnline <- struct{}{}:
 			default:

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -1705,12 +1705,16 @@ func (w *Waku) handleNetworkChangeFromApp(state connection.State) {
 	}
 }
 
+func (w *Waku) isGoingOnline(state connection.State) bool {
+	return !state.Offline && !w.onlineChecker.IsOnline()
+}
+
 func (w *Waku) ConnectionChanged(state connection.State) {
-	isOnline := !state.Offline
-	if isOnline && !w.onlineChecker.IsOnline() { // we are online and we were offline before
+	if w.isGoingOnline(state) {
 		//TODO: analyze if we need to discover and connect to peers for relay.
 		w.discoverAndConnectPeers()
 	}
+	isOnline := !state.Offline
 	if w.cfg.LightClient {
 		//TODO: Update this as per  https://github.com/waku-org/go-waku/issues/1114
 		go func() {
@@ -1720,8 +1724,7 @@ func (w *Waku) ConnectionChanged(state connection.State) {
 		w.handleNetworkChangeFromApp(state)
 	} else {
 		// for lightClient state update and onlineChange is handled in filterManager.
-		// going online
-		if isOnline && !w.onlineChecker.IsOnline() {
+		if w.isGoingOnline(state) {
 			select {
 			case w.goingOnline <- struct{}{}:
 			default:


### PR DESCRIPTION
fix relate mobile issues: [21452](https://github.com/status-im/status-mobile/issues/21452) / [21394](https://github.com/status-im/status-mobile/issues/21394), and might also fix part(missing messages) of [21172](https://github.com/status-im/status-mobile/issues/21172)

relate mobile [PR](https://github.com/status-im/status-mobile/pull/21730)