### PR TITLE
fix_: status backend server websocket IO wait

### DIFF
--- a/cmd/status-backend/server/server.go
+++ b/cmd/status-backend/server/server.go
@@ -53,13 +53,11 @@ func (s *Server) signalHandler(data []byte) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	var disconnected []*websocket.Conn
-
 	for connection := range s.connections {
 		err := connection.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		if err != nil {
 			log.Error("failed to set write deadline", "error", err)
-			disconnected = append(disconnected, connection)
+			delete(s.connections, connection)
 			_ = connection.Close()
 			continue
 		}
@@ -67,13 +65,9 @@ func (s *Server) signalHandler(data []byte) {
 		err = connection.WriteMessage(websocket.TextMessage, data)
 		if err != nil {
 			log.Error("failed to write signal message", "error", err)
-			disconnected = append(disconnected, connection)
+			delete(s.connections, connection)
 			_ = connection.Close()
 		}
-	}
-
-	for _, conn := range disconnected {
-		delete(s.connections, conn)
 	}
 }
 

--- a/cmd/status-backend/server/server.go
+++ b/cmd/status-backend/server/server.go
@@ -53,20 +53,26 @@ func (s *Server) signalHandler(data []byte) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	deleteConnection := func(connection *websocket.Conn) {
+		delete(s.connections, connection)
+		err := connection.Close()
+		if err != nil {
+			log.Error("failed to close connection", "error", err)
+		}
+	}
+
 	for connection := range s.connections {
 		err := connection.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		if err != nil {
 			log.Error("failed to set write deadline", "error", err)
-			delete(s.connections, connection)
-			_ = connection.Close()
+			deleteConnection(connection)
 			continue
 		}
 
 		err = connection.WriteMessage(websocket.TextMessage, data)
 		if err != nil {
 			log.Error("failed to write signal message", "error", err)
-			delete(s.connections, connection)
-			_ = connection.Close()
+			deleteConnection(connection)
 		}
 	}
 }

--- a/cmd/status-backend/server/server.go
+++ b/cmd/status-backend/server/server.go
@@ -53,11 +53,27 @@ func (s *Server) signalHandler(data []byte) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
+	var disconnected []*websocket.Conn
+
 	for connection := range s.connections {
-		err := connection.WriteMessage(websocket.TextMessage, data)
+		err := connection.SetWriteDeadline(time.Now().Add(5 * time.Second))
 		if err != nil {
-			log.Error("failed to write message: %w", err)
+			log.Error("failed to set write deadline", "error", err)
+			disconnected = append(disconnected, connection)
+			_ = connection.Close()
+			continue
 		}
+
+		err = connection.WriteMessage(websocket.TextMessage, data)
+		if err != nil {
+			log.Error("failed to write signal message", "error", err)
+			disconnected = append(disconnected, connection)
+			_ = connection.Close()
+		}
+	}
+
+	for _, conn := range disconnected {
+		delete(s.connections, conn)
 	}
 }
 
@@ -130,6 +146,7 @@ func (s *Server) signals(w http.ResponseWriter, r *http.Request) {
 		log.Error("failed to upgrade connection: %w", err)
 		return
 	}
+	log.Debug("new websocket connection")
 
 	s.connections[connection] = struct{}{}
 }

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -318,7 +318,7 @@ func main() {
 
 		// Check if profiling shall be enabled.
 		if *pprofEnabled {
-			profiling.NewProfiler(*pprofPort).Go()
+			profiling.NewProfiler(fmt.Sprintf(":%d", *pprofPort)).Go()
 		}
 
 		if config.PushNotificationServerConfig.Enabled {

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"runtime"
 	"unsafe"
 
 	"go.uber.org/zap"
@@ -1069,6 +1072,32 @@ func WriteHeapProfile(dataDir string) string {
 func writeHeapProfile(dataDir string) string { //nolint: deadcode
 	err := profiling.WriteHeapFile(dataDir)
 	return makeJSONResponse(err)
+}
+
+// StartMutexProfiling starts mutex profiling and HTTP server for pprof
+func StartMutexProfiling(address string) string {
+	return callWithResponse(startMutexProfiling, address)
+}
+
+func startMutexProfiling(address string) string {
+	runtime.SetMutexProfileFraction(5)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/mutex", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	go func() {
+		if err := http.ListenAndServe(address, mux); err != nil {
+			logutils.ZapLogger().Error("failed to start pprof server", zap.Error(err))
+		}
+	}()
+
+	return makeJSONResponse(nil)
 }
 
 func makeJSONResponse(err error) string {

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/http/pprof"
 	"runtime"
 	"unsafe"
 
@@ -1081,22 +1079,7 @@ func StartMutexProfiling(address string) string {
 
 func startMutexProfiling(address string) string {
 	runtime.SetMutexProfileFraction(5)
-
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/debug/pprof/", pprof.Index)
-	mux.HandleFunc("/debug/pprof/mutex", pprof.Index)
-	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-
-	go func() {
-		if err := http.ListenAndServe(address, mux); err != nil {
-			logutils.ZapLogger().Error("failed to start pprof server", zap.Error(err))
-		}
-	}()
-
+	profiling.NewProfiler(address).Go()
 	return makeJSONResponse(nil)
 }
 

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1072,12 +1072,12 @@ func writeHeapProfile(dataDir string) string { //nolint: deadcode
 	return makeJSONResponse(err)
 }
 
-// StartMutexProfiling starts mutex profiling and HTTP server for pprof
-func StartMutexProfiling(address string) string {
-	return callWithResponse(startMutexProfiling, address)
+// StartProfiling starts profiling and HTTP server for pprof
+func StartProfiling(address string) string {
+	return callWithResponse(startProfiling, address)
 }
 
-func startMutexProfiling(address string) string {
+func startProfiling(address string) string {
 	runtime.SetMutexProfileFraction(5)
 	profiling.NewProfiler(address).Go()
 	return makeJSONResponse(nil)

--- a/profiling/profiler.go
+++ b/profiling/profiler.go
@@ -1,7 +1,6 @@
 package profiling
 
 import (
-	"fmt"
 	"net/http"
 	hpprof "net/http/pprof"
 	"time"
@@ -19,7 +18,7 @@ type Profiler struct {
 
 // NewProfiler creates an instance of the profiler with
 // the given port.
-func NewProfiler(port int) *Profiler {
+func NewProfiler(address string) *Profiler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/debug/pprof/", hpprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", hpprof.Cmdline)
@@ -28,7 +27,7 @@ func NewProfiler(port int) *Profiler {
 	mux.HandleFunc("/debug/pprof/trace", hpprof.Trace)
 	p := Profiler{
 		server: &http.Server{
-			Addr:              fmt.Sprintf(":%d", port),
+			Addr:              address,
 			ReadHeaderTimeout: 5 * time.Second,
 			Handler:           mux,
 		},


### PR DESCRIPTION
The I/O wait issue caused mobile users to be unable to send messages due to a deadlock. For more details, please refer to the attachment: [websocket_io_wait.log](https://github.com/user-attachments/files/17977273/websocket_io_wait.log)

Major changes in this PR:
- added an endpoint `StartMutexProfiling` to improve develop XP.
- fixed wrong num of params passed to `log.Error`
- added a timeout for `onnection.WriteMessage`


