### PR TITLE
chore(Makefile)_: run-anvil command with dev ports mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,10 @@ test-verif-proxy-wrapper:
 
 run-anvil: SHELL := /bin/sh
 run-anvil:
-	docker-compose -f tests-functional/docker-compose.anvil.yml up --remove-orphans
+	@docker compose \
+		-f tests-functional/docker-compose.anvil.yml \
+		-f tests-functional/docker-compose.anvil.dev.yml \
+		up --remove-orphans
 
 codecov-validate: SHELL := /bin/sh
 codecov-validate:

--- a/tests-functional/docker-compose.anvil.dev.yml
+++ b/tests-functional/docker-compose.anvil.dev.yml
@@ -1,0 +1,4 @@
+services:
+  anvil:
+    ports:
+      - 8545:8545


### PR DESCRIPTION
`make run-anvil` will now use the `tests-functional/docker-compose.anvil.dev.yml` file which adds ports mapping
Should only be used locally.