### PR TITLE
fix_: usdt token decimals on tokenstore for arbitrum

### DIFF
--- a/services/wallet/token/tokenstore.go
+++ b/services/wallet/token/tokenstore.go
@@ -1638,7 +1638,7 @@ func newDefaultStore() *DefaultStore {
 				Address:     common.HexToAddress("0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9"),
 				Name:        "Tether USD",
 				Symbol:      "USDT",
-				Decimals:    18,
+				Decimals:    6,
 				ChainID:     42161,
 				TokenListID: "status",
 			},


### PR DESCRIPTION
This PR fixes a mismatch of token decimals for USDT on Arbitrum in token store. Should be 6 instead of 18.

From arbiscan:
<img width="450" src="https://github.com/user-attachments/assets/359fa38a-13a7-419c-a16d-ce5986dbe4ce">

Should fix [this status-mobile issue](https://github.com/status-im/status-mobile/issues/21738)
