### PR TITLE
fix!: add forceRefresh parameter to FetchOrGetCachedWalletBalances endpoint

### DIFF
--- a/protocol/messenger_wallet.go
+++ b/protocol/messenger_wallet.go
@@ -50,7 +50,7 @@ func (m *Messenger) retrieveWalletBalances() error {
 	defer cancel()
 
 	// TODO: publish tokens as a signal
-	_, err = m.walletAPI.FetchOrGetCachedWalletBalances(ctx, ethAccounts)
+	_, err = m.walletAPI.FetchOrGetCachedWalletBalances(ctx, ethAccounts, false)
 	if err != nil {
 		return err
 	}

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -50,7 +50,7 @@ func NewAPI(s *Service) *API {
 // API is class with methods available over RPC.
 type API struct {
 	s      *Service
-	reader *Reader
+	reader ReaderInterface
 }
 
 func (api *API) StartWallet(ctx context.Context) error {
@@ -84,7 +84,7 @@ func (api *API) GetBalancesByChain(ctx context.Context, chainIDs []uint64, addre
 	return api.s.tokenManager.GetBalancesByChain(ctx, clients, addresses, tokens)
 }
 
-func (api *API) FetchOrGetCachedWalletBalances(ctx context.Context, addresses []common.Address) (map[common.Address][]token.StorageToken, error) {
+func (api *API) FetchOrGetCachedWalletBalances(ctx context.Context, addresses []common.Address, forceRefresh bool) (map[common.Address][]token.StorageToken, error) {
 	activeNetworks, err := api.s.rpcClient.NetworkManager.GetActiveNetworks()
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func (api *API) FetchOrGetCachedWalletBalances(ctx context.Context, addresses []
 		return nil, err
 	}
 
-	return api.reader.FetchOrGetCachedWalletBalances(ctx, clients, addresses, false)
+	return api.reader.FetchOrGetCachedWalletBalances(ctx, clients, addresses, forceRefresh)
 }
 
 type DerivedAddress struct {

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -1,5 +1,7 @@
 package wallet
 
+//go:generate mockgen -package=mock_reader -source=reader.go -destination=mock/reader/reader.go
+
 import (
 	"context"
 	"math"
@@ -40,6 +42,16 @@ func belongsToMandatoryTokens(symbol string) bool {
 		}
 	}
 	return false
+}
+
+type ReaderInterface interface {
+	Start() error
+	Stop()
+	Restart() error
+	FetchOrGetCachedWalletBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address, forceRefresh bool) (map[common.Address][]token.StorageToken, error)
+	FetchBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address) (map[common.Address][]token.StorageToken, error)
+	GetCachedBalances(clients map[uint64]chain.ClientInterface, addresses []common.Address) (map[common.Address][]token.StorageToken, error)
+	GetLastTokenUpdateTimestamps() map[common.Address]int64
 }
 
 func NewReader(tokenManager token.ManagerInterface, marketManager *market.Manager, persistence token.TokenBalancesStorage, walletFeed *event.Feed) *Reader {


### PR DESCRIPTION
We have this issue on mobile (and possibly on desktop as well), marked as critical by our QA team:

https://github.com/status-im/status-mobile/issues/21725

It appears to be a balance cache issue. Currently, in the `fetchOrGetCachedWalletBalances` endpoint, we cannot force a refresh of balances to bypass the cache, nor is there a way to clear the cache from the client side. At the moment, the only way to clean the cache is by logging out and logging back in, which is not ideal.

This PR proposes adding a parameter to the endpoint that allows forcing a balance refresh. The parameter will be passed to the reader, where the forceRefresh functionality is already implemented.

**Note:** This is a breaking change, so both mobile and desktop clients will need to adapt to it if this PR is merged.