### PR TITLE
chore(logging): default waku node logs to INFO level

### DIFF
--- a/appdatabase/migrations/sql/1761335412_default_log_namespaces.up.sql
+++ b/appdatabase/migrations/sql/1761335412_default_log_namespaces.up.sql
@@ -1,0 +1,6 @@
+UPDATE log_config
+SET
+    log_namespaces = 'wakunode:info'
+WHERE
+    log_namespaces IS NULL
+    OR log_namespaces = '';

--- a/messaging/waku/gowaku.go
+++ b/messaging/waku/gowaku.go
@@ -292,7 +292,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, protectedTo
 		node.WithConnectionNotification(waku.connectionNotifChan),
 		node.WithTopicHealthStatusChannel(waku.topicHealthStatusChan),
 		node.WithKeepAlive(randomPeersKeepAliveInterval, allPeersKeepAliveInterval),
-		node.WithLogger(logger),
+		node.WithLogger(logger.Named("wakunode")),
 		node.WithLogLevel(logger.Level()),
 		node.WithClusterID(cfg.ClusterID),
 		node.WithMaxMsgSize(1024 * 1024),
@@ -1003,7 +1003,7 @@ func (w *Waku) GetFilter(id string) types.Filter {
 // Unsubscribe removes an installed message handler.
 func (w *Waku) UnsubscribeMany(ids []string) error {
 	for _, id := range ids {
-		w.logger.Info("cleaning up filter", zap.String("id", id))
+		w.logger.Debug("cleaning up filter", zap.String("id", id))
 		ok := w.filters.Uninstall(id)
 		if !ok {
 			w.logger.Warn("could not remove filter with id", zap.String("id", id))
@@ -1432,7 +1432,7 @@ func (w *Waku) OnNewEnvelopes(envelope *protocol.Envelope, msgType common.Messag
 
 	_, err := w.add(recvMessage, processImmediately)
 	if err != nil {
-		logger.Info("invalid envelope received", zap.Error(err))
+		logger.Debug("invalid envelope received", zap.Error(err))
 		trouble = true
 	}
 

--- a/messaging/waku/message_publishing.go
+++ b/messaging/waku/message_publishing.go
@@ -87,7 +87,7 @@ func (w *Waku) publishEnvelope(envelope *protocol.Envelope) {
 	var err error
 	// only used in testing to simulate going offline
 	if w.cfg.SkipPublishToTopic {
-		logger.Info("skipping publish to topic")
+		logger.Debug("skipping publish to topic")
 		err = errors.New("test send failure")
 	} else {
 		err = w.messageSender.Send(publish.NewRequest(w.ctx, envelope))


### PR DESCRIPTION
This ensures waku node logs remain at INFO level, even if the global
logging level is set lower (e.g. DEBUG). To enable waku logs at a
specific level, one can execute:
`wakuext_setLogNamespaces([{"logNamespaces": "wakunode:debug"}])`.

iterates: status-im/status-desktop#16511

