### PR TITLE
test_: services approach

### DIFF
--- a/tests-functional/clients/rpc.py
+++ b/tests-functional/clients/rpc.py
@@ -6,6 +6,7 @@ from tenacity import retry, stop_after_delay, wait_fixed
 from conftest import option
 from json import JSONDecodeError
 
+
 class RpcClient:
 
     def __init__(self, rpc_url, client=requests.Session()):
@@ -43,7 +44,9 @@ class RpcClient:
         self._check_decode_and_key_errors_in_response(response, "error")
 
     @retry(stop=stop_after_delay(10), wait=wait_fixed(0.5), reraise=True)
-    def rpc_request(self, method, params=[], request_id=13, url=None):
+    def rpc_request(self, method, params=None, request_id=13, url=None):
+        if params is None:
+            params = []
         url = url if url else self.rpc_url
         data = {"jsonrpc": "2.0", "method": method, "id": request_id}
         if params:
@@ -59,7 +62,7 @@ class RpcClient:
             logging.info(f"Got response: {response.content}")
         return response
 
-    def rpc_valid_request(self, method, params=[], _id=None, url=None):
+    def rpc_valid_request(self, method, params=None, _id=None, url=None):
         response = self.rpc_request(method, params, _id, url)
         self.verify_is_valid_json_rpc_response(response, _id)
         return response

--- a/tests-functional/clients/services/service.py
+++ b/tests-functional/clients/services/service.py
@@ -1,0 +1,12 @@
+from clients.rpc import RpcClient
+
+
+class Service:
+    def __init__(self, client: RpcClient, name: str):
+        assert name is not ""
+        self.rpc_client = client
+        self.name = name
+
+    def rpc_request(self, method: str, params=None):
+        full_method_name = f"{self.name}_{method}"
+        return self.rpc_client.rpc_request(full_method_name, params)

--- a/tests-functional/clients/services/wallet.py
+++ b/tests-functional/clients/services/wallet.py
@@ -1,0 +1,11 @@
+from clients.rpc import RpcClient
+from clients.services.service import Service
+
+
+class WalletService(Service):
+    def __init__(self, client: RpcClient):
+        super().__init__(client, "wallet")
+
+    def get_balances_at_by_chain(self, chains: list, addresses: list, tokens: list):
+        params = [chains, addresses, tokens]
+        return self.rpc_request("getBalancesByChain", params)

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -13,7 +13,6 @@ from conftest import option
 from constants import user_1, DEFAULT_DISPLAY_NAME
 
 
-
 class StatusBackend(RpcClient, SignalClient):
 
     def __init__(self, await_signals=[], url=None):
@@ -26,7 +25,6 @@ class StatusBackend(RpcClient, SignalClient):
         self.api_url = f"{url}/statusgo"
         self.ws_url = f"{url}".replace("http", "ws")
         self.rpc_url = f"{url}/statusgo/CallRPC"
-
 
         RpcClient.__init__(self, self.rpc_url)
         SignalClient.__init__(self, self.ws_url, await_signals)
@@ -83,7 +81,8 @@ class StatusBackend(RpcClient, SignalClient):
         }
         return self.api_valid_request(method, data)
 
-    def restore_account_and_login(self, data_dir="/",display_name=DEFAULT_DISPLAY_NAME, user=user_1):
+    def restore_account_and_login(self, data_dir="/",display_name=DEFAULT_DISPLAY_NAME, user=user_1,
+                                  network_id=31337):
         method = "RestoreAccountAndLogin"
         data = {
             "rootDataDir": data_dir,
@@ -95,10 +94,10 @@ class StatusBackend(RpcClient, SignalClient):
             "logEnabled": True,
             "logLevel": "DEBUG",
             "testNetworksEnabled": False,
-            "networkId": 31337,
+            "networkId": network_id,
             "networksOverride": [
                 {
-                    "ChainID": 31337,
+                    "ChainID": network_id,
                     "ChainName": "Anvil",
                     "DefaultRPCURL": "http://anvil:8545",
                     "RPCURL": "http://anvil:8545",

--- a/tests-functional/tests/test_cases.py
+++ b/tests-functional/tests/test_cases.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 
 import pytest
 
+from clients.services.wallet import WalletService
 from clients.signals import SignalClient, SignalType
 from clients.status_backend import RpcClient, StatusBackend
 from conftest import option
@@ -28,14 +29,15 @@ class StatusBackendTestCase:
         SignalType.NODE_LOGIN.value
     ]
 
+    network_id = 31337
+
     def setup_class(self):
         self.rpc_client = StatusBackend(await_signals=self.await_signals)
+        self.wallet_service = WalletService(self.rpc_client)
 
         self.rpc_client.init_status_backend()
         self.rpc_client.restore_account_and_login()
         self.rpc_client.wait_for_login()
-
-        self.network_id = 31337
 
 
 class WalletTestCase(StatusBackendTestCase):


### PR DESCRIPTION
1. Added `Service` and `WalletService(Service)` classes.

    This is a way to group requests by service. They use given `RpcClient` and wrap requests to given service name.
    Instance of `WalletService` is created in `StatusBackendTestCase`.
    
    @antdanchenko @fbarbu15 @yevh-berdnyk let me know if you like the initiative.

2. Fixed linter complaining about `params=[]` default argument value

3. Added `network_id` argument to `restore_account_and_login`

~~4. Implemented `test_get_balance_error` test for https://github.com/status-im/status-go/pull/6169
(this PR is targeting that PR branch)~~

closes https://github.com/status-im/status-go/issues/6308