### PR TITLE
chore(block)!: remove desktop BlockContact function for parity

### DIFF
--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -973,35 +973,13 @@ func (m *Messenger) BlockContact(ctx context.Context, contactID string, fromSync
 	//		 https://github.com/status-im/status-go/issues/3720
 	if !fromSyncing {
 		updatedAt := m.GetCurrentTimeInMillis()
-		_, err = m.DismissAllActivityCenterNotificationsFromUser(ctx, contactID, updatedAt)
+		notifications, err := m.DismissAllActivityCenterNotificationsFromUser(ctx, contactID, updatedAt)
 		if err != nil {
 			return nil, err
 		}
+		response.AddActivityCenterNotifications(notifications)
 	}
 
-	return response, nil
-}
-
-// The same function as the one above.
-// Should be removed with https://github.com/status-im/status-desktop/issues/8805
-func (m *Messenger) BlockContactDesktop(ctx context.Context, contactID string) (*MessengerResponse, error) {
-	response := &MessengerResponse{}
-
-	err := m.blockContact(ctx, response, contactID, true, false)
-	if err != nil {
-		return nil, err
-	}
-
-	response, err = m.DeclineAllPendingGroupInvitesFromUser(ctx, response, contactID)
-	if err != nil {
-		return nil, err
-	}
-
-	notifications, err := m.DismissAllActivityCenterNotificationsFromUser(ctx, contactID, m.GetCurrentTimeInMillis())
-	if err != nil {
-		return nil, err
-	}
-	response.AddActivityCenterNotifications(notifications)
 	return response, nil
 }
 

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -345,13 +345,6 @@ func (api *PublicAPI) BlockContact(ctx context.Context, contactID string) (*prot
 	return api.service.messenger.BlockContact(ctx, contactID, false)
 }
 
-// This function is the same as the one above, but used only on the desktop side, since at the end it doesn't set
-// `Added` flag to `false`, but only `Blocked` to `true`
-func (api *PublicAPI) BlockContactDesktop(ctx context.Context, contactID string) (*protocol.MessengerResponse, error) {
-	api.logger.Info("blocking contact", zap.String("contact", contactID))
-	return api.service.messenger.BlockContactDesktop(ctx, contactID)
-}
-
 func (api *PublicAPI) UnblockContact(parent context.Context, contactID string) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.UnblockContact(contactID)
 }


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/16640

In Desktop, we still used a "forked" version of the BlockContact function that had as differences that it didn't leave the chat nor delete the messages.

However, we want to have parity now and those features, so it makes no sense to use a different function.

This is a breaking change because it removes an API, but I took care of removing the use of that function in the Desktop app and Mobile never used it, so it's an inoffensive breaking change.

Additionally, I added the notifications to the messenger response.
