### PR TITLE
fix(pins)_: delete pins when the og message is deleted

### DIFF
--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -1250,6 +1250,7 @@ func (db sqlitePersistence) PinnedMessageByChatIDs(chatIDs []string, currCursor 
  			WHERE
  				pm.pinned = 1
  				AND NOT(m1.hide) AND m1.local_chat_id IN %s %s
+				AND m1.deleted = 0
  			ORDER BY cursor DESC
  			%s
  		`, allFields, cursorField, "(?"+strings.Repeat(",?", len(chatIDs)-1)+")", cursorWhere, limitStr),

--- a/protocol/migrations/sqlite/1733428521_pinned_messages_add_on_delete_clause.up.sql
+++ b/protocol/migrations/sqlite/1733428521_pinned_messages_add_on_delete_clause.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE pin_messages_new (
+  id VARCHAR PRIMARY KEY NOT NULL,
+  message_id VARCHAR NOT NULL,
+  whisper_timestamp INTEGER NOT NULL,
+  chat_id VARCHAR NOT NULL,
+  local_chat_id VARCHAR NOT NULL,
+  clock_value INT NOT NULL,
+  pinned BOOLEAN NOT NULL,
+  pinned_by TEXT,
+  FOREIGN KEY (message_id) REFERENCES user_messages(id) ON DELETE CASCADE
+);
+
+INSERT INTO pin_messages_new (id, message_id, whisper_timestamp, chat_id, local_chat_id, clock_value, pinned, pinned_by)
+SELECT id, message_id, whisper_timestamp, chat_id, local_chat_id, clock_value, pinned, pinned_by
+FROM pin_messages;
+
+DROP TABLE pin_messages;
+
+ALTER TABLE pin_messages_new RENAME TO pin_messages;


### PR DESCRIPTION
Found when fixing https://github.com/status-im/status-desktop/issues/16639

When a message is deleted, we need to delete the pins too as they are no longer available. I also made sure the SELECT query for the pins doesn't return deleted messages

Before the fix, the pin would reappear on restart

[deleted-pins.webm](https://github.com/user-attachments/assets/0261b916-fd78-4c43-b237-107e88bc9c34)
