### PR TITLE
fix_: create/restore account error signal

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -530,7 +530,7 @@ func createAccountAndLogin(requestJSON string) string {
 		_, err := statusBackend.CreateAccountAndLogin(&request)
 		if err != nil {
 			logutils.ZapLogger().Error("failed to create account", zap.Error(err))
-			return err
+			return statusBackend.LoggedIn("", err)
 		}
 		logutils.ZapLogger().Debug("started a node, and created account")
 		return nil
@@ -602,7 +602,7 @@ func restoreAccountAndLogin(requestJSON string) string {
 
 		if err != nil {
 			logutils.ZapLogger().Error("failed to restore account", zap.Error(err))
-			return err
+			return statusBackend.LoggedIn("", err)
 		}
 		logutils.ZapLogger().Debug("started a node, and restored account")
 		return nil

--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -87,6 +87,12 @@ class SignalClient:
             return self.received_signals[signal_type]["received"][-1]
         return self.received_signals[signal_type]["received"][-delta_count:]
 
+    def wait_for_login(self):
+        signal = self.wait_for_signal(SignalType.NODE_LOGIN.value)
+        if "error" in signal["event"]:
+            assert not signal["event"]["error"]
+        return signal
+
     def find_signal_containing_pattern(self, signal_type, event_pattern, timeout=20):
         start_time = time.time()
         while True:

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -64,6 +64,9 @@ class StatusBackend(RpcClient, SignalClient):
         method = "InitializeApplication"
         data = {
             "dataDir": data_dir,
+            "logEnabled": True,
+            "logLevel": "DEBUG",
+            "apiLogging": True,
         }
         return self.api_valid_request(method, data)
 
@@ -76,7 +79,7 @@ class StatusBackend(RpcClient, SignalClient):
             "password": password,
             "customizationColor": "primary",
             "logEnabled": True,
-            "logLevel": "INFO",
+            "logLevel": "DEBUG",
         }
         return self.api_valid_request(method, data)
 
@@ -90,7 +93,7 @@ class StatusBackend(RpcClient, SignalClient):
             "mnemonic": user.passphrase,
             "customizationColor": "blue",
             "logEnabled": True,
-            "logLevel": "INFO",
+            "logLevel": "DEBUG",
             "testNetworksEnabled": True,
             "networkId": 31337,
             "networksOverride": [

--- a/tests-functional/tests/test_cases.py
+++ b/tests-functional/tests/test_cases.py
@@ -25,7 +25,7 @@ class StatusDTestCase:
 class StatusBackendTestCase:
 
     await_signals = [
-        SignalType.NODE_READY.value
+        SignalType.NODE_LOGIN.value
     ]
 
     def setup_class(self):
@@ -33,7 +33,7 @@ class StatusBackendTestCase:
 
         self.rpc_client.init_status_backend()
         self.rpc_client.restore_account_and_login()
-        self.rpc_client.wait_for_signal(SignalType.NODE_READY.value)
+        self.rpc_client.wait_for_login()
 
         self.network_id = 31337
 

--- a/tests-functional/tests/test_init_status_app.py
+++ b/tests-functional/tests/test_init_status_app.py
@@ -30,7 +30,7 @@ class TestInitialiseApp:
         backend_client.verify_json_schema(
             backend_client.wait_for_signal(SignalType.NODE_READY.value), "signal_node_ready")
         backend_client.verify_json_schema(
-            backend_client.wait_for_signal(SignalType.NODE_LOGIN.value), "signal_node_login")
+            backend_client.wait_for_login(), "signal_node_login")
 
 
 @pytest.mark.rpc


### PR DESCRIPTION
# Description

1. `CreateAccountAndLogin` and `RestoreAccountAndLogin` weren't publishing `node.login` signal on error.
Fixed it.

2. Replaced waiting for `node.ready` to wait for `node.login` instead. And automatically check for error.
This signal is published in a about the same time, but has advantages:
- it reports an error
- it contains some useful information like the logged in `account`

3. Enabled API logging during functional tests

4. Switched log level to `DEBUG`

closes https://github.com/status-im/status-go/issues/6307