### PR TITLE
fix_: nil *MessengerResponse is a valid result

### DIFF
--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -111,10 +111,7 @@ func (m *Messenger) performStorenodeTask(task func() (*MessengerResponse, error)
 
 	select {
 	case r := <-responseCh:
-		if r != nil {
-			return r, nil
-		}
-		return nil, errors.New("no response available")
+		return r, nil
 	case <-m.ctx.Done():
 		return nil, m.ctx.Err()
 	}


### PR DESCRIPTION
Removes an if that returned an error if there's no MessengerResponse available. This is incorrect because as we can see here: https://github.com/status-im/status-go/blob/987a9e8707e97c1757f87f621c036d671bb046fe/protocol/messenger_store_node_request_manager.go#L558 returning a `nil` value should be valid.