### PR TITLE
chore_: partially revert ContentTopicOverride

### DIFF
--- a/eth-node/types/rpc.go
+++ b/eth-node/types/rpc.go
@@ -6,20 +6,19 @@ import (
 
 // NewMessage represents a new whisper message that is posted through the RPC.
 type NewMessage struct {
-	SymKeyID             string    `json:"symKeyID"`
-	PublicKey            []byte    `json:"pubKey"`
-	SigID                string    `json:"sig"`
-	TTL                  uint32    `json:"ttl"`
-	PubsubTopic          string    `json:"pubsubTopic"`
-	Topic                TopicType `json:"topic"`
-	Payload              []byte    `json:"payload"`
-	Padding              []byte    `json:"padding"`
-	PowTime              uint32    `json:"powTime"`
-	PowTarget            float64   `json:"powTarget"`
-	TargetPeer           string    `json:"targetPeer"`
-	Ephemeral            bool      `json:"ephemeral"`
-	Priority             *int      `json:"priority"`
-	ContentTopicOverride string    `json:"contentTopicOverride"`
+	SymKeyID    string    `json:"symKeyID"`
+	PublicKey   []byte    `json:"pubKey"`
+	SigID       string    `json:"sig"`
+	TTL         uint32    `json:"ttl"`
+	PubsubTopic string    `json:"pubsubTopic"`
+	Topic       TopicType `json:"topic"`
+	Payload     []byte    `json:"payload"`
+	Padding     []byte    `json:"padding"`
+	PowTime     uint32    `json:"powTime"`
+	PowTarget   float64   `json:"powTarget"`
+	TargetPeer  string    `json:"targetPeer"`
+	Ephemeral   bool      `json:"ephemeral"`
+	Priority    *int      `json:"priority"`
 }
 
 // Message is the RPC representation of a whisper message.

--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -683,7 +683,7 @@ func (s *MessageSender) dispatchCommunityChatMessage(ctx context.Context, rawMes
 
 	hashes := make([][]byte, 0, len(newMessages))
 	for _, newMessage := range newMessages {
-		hash, err := s.transport.SendPublic(ctx, newMessage, rawMessage.LocalChatID)
+		hash, err := s.transport.SendPublic(ctx, newMessage, rawMessage.ContentTopic)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -660,12 +660,11 @@ func (s *MessageSender) dispatchCommunityChatMessage(ctx context.Context, rawMes
 	}
 
 	newMessage := &types.NewMessage{
-		TTL:                  whisperTTL,
-		Payload:              payload,
-		PowTarget:            calculatePoW(payload),
-		PowTime:              whisperPoWTime,
-		PubsubTopic:          rawMessage.PubsubTopic,
-		ContentTopicOverride: rawMessage.ContentTopicOverride,
+		TTL:         whisperTTL,
+		Payload:     payload,
+		PowTarget:   calculatePoW(payload),
+		PowTime:     whisperPoWTime,
+		PubsubTopic: rawMessage.PubsubTopic,
 	}
 
 	if rawMessage.BeforeDispatch != nil {
@@ -766,7 +765,6 @@ func (s *MessageSender) SendPublic(
 	newMessage.Ephemeral = rawMessage.Ephemeral
 	newMessage.PubsubTopic = rawMessage.PubsubTopic
 	newMessage.Priority = rawMessage.Priority
-	newMessage.ContentTopicOverride = rawMessage.ContentTopicOverride
 
 	messageID := v1protocol.MessageID(&rawMessage.Sender.PublicKey, wrappedMessage)
 

--- a/protocol/common/raw_message.go
+++ b/protocol/common/raw_message.go
@@ -80,6 +80,7 @@ type RawMessage struct {
 	Ephemeral             bool
 	BeforeDispatch        func(*RawMessage) error
 	HashRatchetGroupID    []byte
+	ContentTopic          string
 	PubsubTopic           string
 	ResendType            ResendType
 	ResendMethod          ResendMethod

--- a/protocol/common/raw_message.go
+++ b/protocol/common/raw_message.go
@@ -84,5 +84,4 @@ type RawMessage struct {
 	ResendType            ResendType
 	ResendMethod          ResendMethod
 	Priority              *MessagePriority
-	ContentTopicOverride  string
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1957,6 +1957,10 @@ func (m *Messenger) dispatchPairInstallationMessage(ctx context.Context, spec co
 }
 
 func (m *Messenger) dispatchMessage(ctx context.Context, rawMessage common.RawMessage) (common.RawMessage, error) {
+	if rawMessage.ContentTopic == "" {
+		rawMessage.ContentTopic = rawMessage.LocalChatID
+	}
+
 	var err error
 	var id []byte
 	logger := m.logger.With(zap.String("site", "dispatchMessage"), zap.String("chatID", rawMessage.LocalChatID))
@@ -1991,7 +1995,7 @@ func (m *Messenger) dispatchMessage(ctx context.Context, rawMessage common.RawMe
 
 	case ChatTypePublic, ChatTypeProfile:
 		logger.Debug("sending public message", zap.String("chatName", chat.Name))
-		id, err = m.sender.SendPublic(ctx, chat.ID, rawMessage)
+		id, err = m.sender.SendPublic(ctx, rawMessage.ContentTopic, rawMessage)
 		if err != nil {
 			return rawMessage, err
 		}
@@ -2001,6 +2005,9 @@ func (m *Messenger) dispatchMessage(ctx context.Context, rawMessage common.RawMe
 		if err != nil {
 			return rawMessage, err
 		}
+		// Use a single content-topic for all community chats.
+		// Reasoning: https://github.com/status-im/status-go/pull/5864
+		rawMessage.ContentTopic = community.UniversalChatID()
 		rawMessage.PubsubTopic = community.PubsubTopic()
 
 		canPost, err := m.communitiesManager.CanPost(&m.identity.PublicKey, chat.CommunityID, chat.CommunityChatID(), rawMessage.MessageType)
@@ -2028,7 +2035,7 @@ func (m *Messenger) dispatchMessage(ctx context.Context, rawMessage common.RawMe
 		}
 		isEncrypted := isCommunityEncrypted || isChannelEncrypted
 		if !isEncrypted {
-			id, err = m.sender.SendPublic(ctx, chat.ID, rawMessage)
+			id, err = m.sender.SendPublic(ctx, rawMessage.ContentTopic, rawMessage)
 			if err != nil {
 				return rawMessage, err
 			}

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2016,8 +2016,7 @@ func (m *Messenger) dispatchMessage(ctx context.Context, rawMessage common.RawMe
 			)
 			return rawMessage, fmt.Errorf("can't post message type '%d' on chat '%s'", rawMessage.MessageType, chat.ID)
 		}
-		//setting content-topic over-ride for community messages to use memberUpdatesChannelID
-		rawMessage.ContentTopicOverride = community.MemberUpdateChannelID()
+
 		logger.Debug("sending community chat message", zap.String("chatName", chat.Name))
 		isCommunityEncrypted, err := m.communitiesManager.IsEncrypted(chat.CommunityID)
 		if err != nil {

--- a/protocol/transport/filters_manager.go
+++ b/protocol/transport/filters_manager.go
@@ -99,7 +99,7 @@ func (f *FiltersManager) Init(
 
 	// Add public, one-to-one and negotiated filters.
 	for _, fi := range filtersToInit {
-		_, err := f.LoadPublic(fi.ChatID, fi.PubsubTopic, fi.ContentTopicOverrideID)
+		_, err := f.LoadPublic(fi.ChatID, fi.PubsubTopic)
 		if err != nil {
 			return nil, err
 		}
@@ -123,16 +123,15 @@ func (f *FiltersManager) Init(
 }
 
 type FiltersToInitialize struct {
-	ChatID                 string
-	PubsubTopic            string
-	ContentTopicOverrideID string //litte hacky but this is used to override content-topic in filtersManager.
+	ChatID      string
+	PubsubTopic string
 }
 
 func (f *FiltersManager) InitPublicFilters(publicFiltersToInit []FiltersToInitialize) ([]*Filter, error) {
 	var filters []*Filter
 	// Add public, one-to-one and negotiated filters.
 	for _, pf := range publicFiltersToInit {
-		f, err := f.LoadPublic(pf.ChatID, pf.PubsubTopic, pf.ContentTopicOverrideID)
+		f, err := f.LoadPublic(pf.ChatID, pf.PubsubTopic)
 		if err != nil {
 			return nil, err
 		}
@@ -456,7 +455,7 @@ func (f *FiltersManager) LoadNegotiated(secret types.NegotiatedSecret) (*Filter,
 	}
 
 	keyString := hex.EncodeToString(secret.Key)
-	filter, err := f.addSymmetric(keyString, "", "")
+	filter, err := f.addSymmetric(keyString, "")
 	if err != nil {
 		f.logger.Debug("could not register negotiated topic", zap.Error(err))
 		return nil, err
@@ -535,16 +534,11 @@ func (f *FiltersManager) PersonalTopicFilter() *Filter {
 }
 
 // LoadPublic adds a filter for a public chat.
-func (f *FiltersManager) LoadPublic(chatID string, pubsubTopic string, contentTopicID string) (*Filter, error) {
+func (f *FiltersManager) LoadPublic(chatID string, pubsubTopic string) (*Filter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
-	chatIDToLoad := chatID
-	if contentTopicID != "" {
-		chatIDToLoad = contentTopicID
-	}
-
-	if chat, ok := f.filters[chatIDToLoad]; ok {
+	if chat, ok := f.filters[chatID]; ok {
 		if chat.PubsubTopic != pubsubTopic {
 			f.logger.Debug("updating pubsub topic for filter",
 				zap.String("chatID", chatID),
@@ -553,13 +547,13 @@ func (f *FiltersManager) LoadPublic(chatID string, pubsubTopic string, contentTo
 				zap.String("newTopic", pubsubTopic),
 			)
 			chat.PubsubTopic = pubsubTopic
-			f.filters[chatIDToLoad] = chat //TODO: Do we need to update watchers as well on modification?
+			f.filters[chatID] = chat
 		}
 
 		return chat, nil
 	}
 
-	filterAndTopic, err := f.addSymmetric(chatID, pubsubTopic, contentTopicID)
+	filterAndTopic, err := f.addSymmetric(chatID, pubsubTopic)
 	if err != nil {
 		f.logger.Debug("could not register public chat topic", zap.String("chatID", chatID), zap.Error(err))
 		return nil, err
@@ -598,7 +592,7 @@ func (f *FiltersManager) LoadContactCode(pubKey *ecdsa.PublicKey) (*Filter, erro
 		return f.filters[chatID], nil
 	}
 
-	contactCodeFilter, err := f.addSymmetric(chatID, "", "")
+	contactCodeFilter, err := f.addSymmetric(chatID, "")
 	if err != nil {
 		f.logger.Debug("could not register contact code topic", zap.String("chatID", chatID), zap.Error(err))
 		return nil, err
@@ -621,7 +615,7 @@ func (f *FiltersManager) LoadContactCode(pubKey *ecdsa.PublicKey) (*Filter, erro
 }
 
 // addSymmetric adds a symmetric key filter
-func (f *FiltersManager) addSymmetric(chatID string, pubsubTopic string, contentTopicID string) (*RawFilter, error) {
+func (f *FiltersManager) addSymmetric(chatID string, pubsubTopic string) (*RawFilter, error) {
 	var symKeyID string
 	var err error
 
@@ -648,12 +642,6 @@ func (f *FiltersManager) addSymmetric(chatID string, pubsubTopic string, content
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if contentTopicID != "" {
-		//add receive filter for the single default contentTopic for all community chats
-		topic = ToTopic(contentTopicID)
-		topics = append(topics, topic)
 	}
 
 	id, err := f.service.Subscribe(&types.SubscriptionOptions{

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -191,7 +191,7 @@ func (t *Transport) ProcessNegotiatedSecret(secret types.NegotiatedSecret) (*Fil
 }
 
 func (t *Transport) JoinPublic(chatID string) (*Filter, error) {
-	return t.filters.LoadPublic(chatID, "", "")
+	return t.filters.LoadPublic(chatID, "")
 }
 
 func (t *Transport) LeavePublic(chatID string) error {
@@ -223,8 +223,6 @@ func (t *Transport) GetStats() types.StatsSummary {
 	return t.waku.GetStats()
 }
 
-// With change in filter used for communities, messages are indexed here with common filter and not their own chatID filter.
-// The caller should not use chatID from the filter to determine chatID of the message, rather should dervice it from messaage itself.
 func (t *Transport) RetrieveRawAll() (map[Filter][]*types.Message, error) {
 	result := make(map[Filter][]*types.Message)
 	logger := t.logger.With(zap.String("site", "retrieveRawAll"))
@@ -278,16 +276,16 @@ func (t *Transport) RetrieveRawAll() (map[Filter][]*types.Message, error) {
 // SendPublic sends a new message using the Whisper service.
 // For public filters, chat name is used as an ID as well as
 // a topic.
-// In case of communities a single topic is used to send all messages.
 func (t *Transport) SendPublic(ctx context.Context, newMessage *types.NewMessage, chatName string) ([]byte, error) {
 	if err := t.addSig(newMessage); err != nil {
 		return nil, err
 	}
-	//passing content-topic override, it will be used if set. otherwise chatName will be used to load filter.
-	filter, err := t.filters.LoadPublic(chatName, newMessage.PubsubTopic, newMessage.ContentTopicOverride)
+
+	filter, err := t.filters.LoadPublic(chatName, newMessage.PubsubTopic)
 	if err != nil {
 		return nil, err
 	}
+
 	newMessage.SymKeyID = filter.SymKeyID
 	newMessage.Topic = filter.ContentTopic
 	newMessage.PubsubTopic = filter.PubsubTopic
@@ -364,8 +362,7 @@ func (t *Transport) SendCommunityMessage(ctx context.Context, newMessage *types.
 	}
 
 	// We load the filter to make sure we can post on it
-	//passing content-topic override, it will be used if set. otherwise chatName will be used to load filter.
-	filter, err := t.filters.LoadPublic(PubkeyToHex(publicKey)[2:], newMessage.PubsubTopic, newMessage.ContentTopicOverride)
+	filter, err := t.filters.LoadPublic(PubkeyToHex(publicKey)[2:], newMessage.PubsubTopic)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Revert `ContentTopicOverride` and use `ContentTopic` only at `RawMessage` level.