### PR TITLE
fix(functional-tests)_: set networks prod mode

### DIFF
--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -94,7 +94,7 @@ class StatusBackend(RpcClient, SignalClient):
             "customizationColor": "blue",
             "logEnabled": True,
             "logLevel": "DEBUG",
-            "testNetworksEnabled": True,
+            "testNetworksEnabled": False,
             "networkId": 31337,
             "networksOverride": [
                 {


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/6010
NOTE: I didn't yet add a way to override networks with `CreateAccountAndLogin`. But it's not really needed for functional tests, because we're using Anvil pre-setup addresses). Let me know if it's needed, it's still possible to implement.

# Description

The test wasn't properly working because of this conflict:
https://github.com/status-im/status-go/blob/50933aa3286e54bfd407f109ce21eabf1417bae7/tests-functional/clients/status_backend.py#L94 https://github.com/status-im/status-go/blob/50933aa3286e54bfd407f109ce21eabf1417bae7/tests-functional/clients/status_backend.py#L106

Basically we were in `test` mode with single `prod` network. So there was never a matching network.