### PR TITLE
fix(backup)_: dont generate a CR if the synced contact is mutual

### DIFF
--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -601,6 +601,7 @@ func (m *Messenger) generateContactRequest(clock uint64, timestamp uint64, conta
 	contactRequest := common.NewMessage()
 	contactRequest.ChatId = contact.ID
 	contactRequest.WhisperTimestamp = timestamp
+	contactRequest.Timestamp = timestamp
 	contactRequest.Seen = true
 	contactRequest.Text = text
 	if outgoing {

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -478,6 +478,10 @@ func (m *Messenger) handleCommandMessage(state *ReceivedMessageState, message *c
 }
 
 func (m *Messenger) syncContactRequestForInstallationContact(contact *Contact, state *ReceivedMessageState, chat *Chat, outgoing bool) error {
+	if contact.mutual() {
+		// We only need to generate a contact request if we are not mutual
+		return nil
+	}
 
 	if chat == nil {
 		return fmt.Errorf("no chat restored during the contact synchronisation, contact.ID = %s", contact.ID)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/15849

The problem was that we generated a "fake" contact request for all synced contacts. While it's true that even mutual contacts have a contact request, we don't need it anymore once mutual and since we don't sync messages, we had to generate it with a default message and that message looked very out of place after a recovery.

Mutual contact:
![image](https://github.com/user-attachments/assets/4164d300-c73e-457c-8c0d-44b1715c9559)

Contact that sent us a CR (not sure why the image and name don't show:
![image](https://github.com/user-attachments/assets/8820f6b4-ebc3-459b-81ca-e9f0cbefef26)

Contact to whom we sent a CR:
![image](https://github.com/user-attachments/assets/d370764a-9044-4de0-a9ea-d1eb81457ea2)

Now, the CR messages at least make sense