### PR TITLE
feat_: graceful shutdown with status-backend

### DIFF
--- a/cmd/status-backend/main.go
+++ b/cmd/status-backend/main.go
@@ -62,9 +62,8 @@ func main() {
 	srv.Serve()
 }
 
-// haltOnInterruptSignal catches interrupt signal (SIGINT) and
-// stops the node. It times out after 5 seconds
-// if the node can not be stopped.
+// handleInterrupts catches interrupt signal (SIGTERM/SIGINT) and
+// gracefully logouts and stops the node.
 func handleInterrupts() {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/status-backend/main.go
+++ b/cmd/status-backend/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	stdlog "log"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -13,6 +15,7 @@ import (
 	"github.com/status-im/status-go/internal/sentry"
 	"github.com/status-im/status-go/internal/version"
 	"github.com/status-im/status-go/logutils"
+	statusgo "github.com/status-im/status-go/mobile"
 )
 
 var (
@@ -39,6 +42,7 @@ func main() {
 	defer sentry.Recover()
 
 	flag.Parse()
+	go handleInterrupts()
 
 	srv := server.NewServer()
 	srv.Setup()
@@ -56,4 +60,18 @@ func main() {
 	)
 	srv.RegisterMobileAPI()
 	srv.Serve()
+}
+
+// haltOnInterruptSignal catches interrupt signal (SIGINT) and
+// stops the node. It times out after 5 seconds
+// if the node can not be stopped.
+func handleInterrupts() {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(ch)
+
+	receivedSignal := <-ch
+	logger.Info("interrupt signal received", "signal", receivedSignal)
+	_ = statusgo.Logout()
+	os.Exit(0)
 }


### PR DESCRIPTION
1. This is just common sense to do
2. It's required for functional tests, because coverage data is only saved correctly with graceful shutdown of the app
3. Added support for `SIGTERM`
For `statusd` we only support `SIGINT`, so I had to change the emitted signal. We won't need to do it for `status-backend`.
https://github.com/status-im/status-go/blob/35dc84fa7fb56b7343accf0e1381a47946a27057/tests-functional/docker-compose.test.status-go.yml#L28

closes https://github.com/status-im/status-go/issues/6306