### PR TITLE
feat_: use SensitiveString in WalletConfig and RpcProvider

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -22,11 +22,13 @@ import (
 
 	gethcrypto "github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/brianvoe/gofakeit/v6"
 	"github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/connection"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/multiaccounts/settings"
@@ -1523,22 +1525,26 @@ func TestSetFleet(t *testing.T) {
 	require.NoError(t, b.Logout())
 }
 
+func fakeToken() security.SensitiveString {
+	return security.NewSensitiveString(gofakeit.LetterN(10))
+}
+
 func TestWalletConfigOnLoginAccount(t *testing.T) {
 	utils.Init()
-	password := "some-password2" // nolint: goconst
+	password := "some-password2"
 	tmpdir := t.TempDir()
-	poktToken := "grove-token"    // nolint: goconst
-	infuraToken := "infura-token" // nolint: goconst
-	alchemyEthereumMainnetToken := "alchemy-ethereum-mainnet-token"
-	alchemyEthereumSepoliaToken := "alchemy-ethereum-sepolia-token"
-	alchemyArbitrumMainnetToken := "alchemy-arbitrum-mainnet-token"
-	alchemyArbitrumSepoliaToken := "alchemy-arbitrum-sepolia-token"
-	alchemyOptimismMainnetToken := "alchemy-optimism-mainnet-token"
-	alchemyOptimismSepoliaToken := "alchemy-optimism-sepolia-token"
-	alchemyBaseMainnetToken := "alchemy-base-mainnet-token" // nolint: gosec
-	alchemyBaseSepoliaToken := "alchemy-base-sepolia-token" // nolint: gosec
-	raribleMainnetAPIKey := "rarible-mainnet-api-key"       // nolint: gosec
-	raribleTestnetAPIKey := "rarible-testnet-api-key"       // nolint: gosec
+	poktToken := fakeToken()
+	infuraToken := fakeToken()
+	alchemyEthereumMainnetToken := fakeToken()
+	alchemyEthereumSepoliaToken := fakeToken()
+	alchemyArbitrumMainnetToken := fakeToken()
+	alchemyArbitrumSepoliaToken := fakeToken()
+	alchemyOptimismMainnetToken := fakeToken()
+	alchemyOptimismSepoliaToken := fakeToken()
+	alchemyBaseMainnetToken := fakeToken()
+	alchemyBaseSepoliaToken := fakeToken()
+	raribleMainnetAPIKey := fakeToken()
+	raribleTestnetAPIKey := fakeToken()
 
 	b := NewGethStatusBackend(tt.MustCreateTestLogger())
 	createAccountRequest := &requests.CreateAccount{

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -23,6 +23,7 @@ import (
 	gethcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/brianvoe/gofakeit/v6"
+
 	"github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/connection"

--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -390,8 +390,8 @@ func bnbSmartChain(proxyHost string) params.Network {
 		// Smart proxy provider
 		*params.NewEthRpcProxyProvider(chainID, StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectInfura, "https://bsc-mainnet.infura.io/v3/", true),
-		*params.NewDirectProvider(chainID, DirectGrove, "https://bsc.rpc.grove.city/v1/", false),
+		*params.NewDirectProvider(chainID, DirectInfura, security.NewSensitiveString("https://bsc-mainnet.infura.io/v3/"), true),
+		*params.NewDirectProvider(chainID, DirectGrove, security.NewSensitiveString("https://bsc.rpc.grove.city/v1/"), false),
 	}
 
 	return params.Network{
@@ -423,7 +423,7 @@ func bnbSmartChainTestnet(proxyHost string) params.Network {
 		// Smart proxy provider
 		*params.NewEthRpcProxyProvider(chainID, StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectInfura, "https://bsc-testnet.infura.io/v3/", true),
+		*params.NewDirectProvider(chainID, DirectInfura, security.NewSensitiveString("https://bsc-testnet.infura.io/v3/"), true),
 	}
 
 	return params.Network{

--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -470,7 +470,7 @@ func setRPCs(networks []params.Network, walletConfig *requests.WalletSecretsConf
 	networks = networkhelper.OverrideDirectProvidersAuth(networks, authTokens)
 
 	// Apply auth for new smart proxy
-	hasSmartProxyCredentials := walletConfig.EthRpcProxyUser.NotEmpty() && walletConfig.EthRpcProxyPassword.NotEmpty()
+	hasSmartProxyCredentials := !walletConfig.EthRpcProxyUser.Empty() && !walletConfig.EthRpcProxyPassword.Empty()
 	networks = networkhelper.OverrideBasicAuth(
 		networks,
 		params.EmbeddedEthRpcProxyProviderType,
@@ -479,7 +479,7 @@ func setRPCs(networks []params.Network, walletConfig *requests.WalletSecretsConf
 		walletConfig.EthRpcProxyPassword)
 
 	// Apply auth for old proxy
-	hasOldProxyCredentials := walletConfig.StatusProxyBlockchainUser.NotEmpty() && walletConfig.StatusProxyBlockchainPassword.NotEmpty()
+	hasOldProxyCredentials := !walletConfig.StatusProxyBlockchainUser.Empty() && !walletConfig.StatusProxyBlockchainPassword.Empty()
 	networks = networkhelper.OverrideBasicAuth(
 		networks,
 		params.EmbeddedProxyProviderType,

--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/status-im/status-go/api/common"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/protocol/requests"
@@ -462,14 +463,14 @@ func defaultNetworks(proxyHost, stageName string) []params.Network {
 }
 
 func setRPCs(networks []params.Network, walletConfig *requests.WalletSecretsConfig) []params.Network {
-	authTokens := map[string]string{
+	authTokens := map[string]security.SensitiveString{
 		"infura.io":  walletConfig.InfuraToken,
 		"grove.city": walletConfig.PoktToken,
 	}
 	networks = networkhelper.OverrideDirectProvidersAuth(networks, authTokens)
 
 	// Apply auth for new smart proxy
-	hasSmartProxyCredentials := walletConfig.EthRpcProxyUser != "" && walletConfig.EthRpcProxyPassword != ""
+	hasSmartProxyCredentials := walletConfig.EthRpcProxyUser.NotEmpty() && walletConfig.EthRpcProxyPassword.NotEmpty()
 	networks = networkhelper.OverrideBasicAuth(
 		networks,
 		params.EmbeddedEthRpcProxyProviderType,
@@ -478,7 +479,7 @@ func setRPCs(networks []params.Network, walletConfig *requests.WalletSecretsConf
 		walletConfig.EthRpcProxyPassword)
 
 	// Apply auth for old proxy
-	hasOldProxyCredentials := walletConfig.StatusProxyBlockchainUser != "" && walletConfig.StatusProxyBlockchainPassword != ""
+	hasOldProxyCredentials := walletConfig.StatusProxyBlockchainUser.NotEmpty() && walletConfig.StatusProxyBlockchainPassword.NotEmpty()
 	networks = networkhelper.OverrideBasicAuth(
 		networks,
 		params.EmbeddedProxyProviderType,
@@ -490,6 +491,6 @@ func setRPCs(networks []params.Network, walletConfig *requests.WalletSecretsConf
 }
 
 func BuildDefaultNetworks(walletSecretsConfig *requests.WalletSecretsConfig) []params.Network {
-	proxyHost := getProxyHost(walletSecretsConfig.EthRpcProxyUrl, walletSecretsConfig.StatusProxyStageName)
+	proxyHost := getProxyHost(walletSecretsConfig.EthRpcProxyUrl.Reveal(), walletSecretsConfig.StatusProxyStageName)
 	return setRPCs(defaultNetworks(proxyHost, walletSecretsConfig.StatusProxyStageName), walletSecretsConfig)
 }

--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -35,8 +35,8 @@ const (
 )
 
 // Direct proxy endpoint (1 endpoint per chain/network)
-func proxyUrl(stageName, provider, chainName, networkName string) string {
-	return fmt.Sprintf("https://%s.%s/%s/%s/%s/", stageName, ProxyHostSuffix, provider, chainName, networkName)
+func proxyUrl(stageName, provider, chainName, networkName string) security.SensitiveString {
+	return security.NewSensitiveStringPrintf("https://%s.%s/%s/%s/%s/", stageName, ProxyHostSuffix, provider, chainName, networkName)
 }
 
 // New eth-rpc-proxy endpoint (provider agnostic)
@@ -48,8 +48,8 @@ func getProxyHost(customUrl, stageName string) string {
 }
 
 // New eth-rpc-proxy endpoint with smart proxy URL
-func smartProxyUrl(proxyHost, chainName, networkName string) string {
-	return fmt.Sprintf("%s/%s/%s/", proxyHost, chainName, networkName)
+func smartProxyUrl(proxyHost, chainName, networkName string) security.SensitiveString {
+	return security.NewSensitiveStringPrintf("%s/%s/%s/", proxyHost, chainName, networkName)
 }
 
 func mainnet(proxyHost, stageName string) params.Network {
@@ -65,8 +65,8 @@ func mainnet(proxyHost, stageName string) params.Network {
 		*params.NewProxyProvider(chainID, ProxyInfura, proxyUrl(stageName, Infura, chainName, networkName), false),
 		*params.NewProxyProvider(chainID, ProxyGrove, proxyUrl(stageName, Grove, chainName, networkName), false),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectInfura, "https://mainnet.infura.io/v3/", true),
-		*params.NewDirectProvider(chainID, DirectGrove, "https://eth.rpc.grove.city/v1/", false),
+		*params.NewDirectProvider(chainID, DirectInfura, security.NewSensitiveString("https://mainnet.infura.io/v3/"), true),
+		*params.NewDirectProvider(chainID, DirectGrove, security.NewSensitiveString("https://eth.rpc.grove.city/v1/"), false),
 	}
 
 	return params.Network{
@@ -102,8 +102,8 @@ func sepolia(proxyHost, stageName string) params.Network {
 		*params.NewProxyProvider(chainID, ProxyInfura, proxyUrl(stageName, Infura, chainName, networkName), false),
 		*params.NewProxyProvider(chainID, ProxyGrove, proxyUrl(stageName, Grove, chainName, networkName), true),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectInfura, "https://sepolia.infura.io/v3/", true),
-		*params.NewDirectProvider(chainID, DirectGrove, "https://eth-sepolia-testnet.rpc.grove.city/v1/", false),
+		*params.NewDirectProvider(chainID, DirectInfura, security.NewSensitiveString("https://sepolia.infura.io/v3/"), true),
+		*params.NewDirectProvider(chainID, DirectGrove, security.NewSensitiveString("https://eth-sepolia-testnet.rpc.grove.city/v1/"), false),
 	}
 
 	return params.Network{
@@ -139,8 +139,8 @@ func optimism(proxyHost, stageName string) params.Network {
 		*params.NewProxyProvider(chainID, ProxyInfura, proxyUrl(stageName, Infura, chainName, networkName), false),
 		*params.NewProxyProvider(chainID, ProxyGrove, proxyUrl(stageName, Grove, chainName, networkName), true),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectInfura, "https://optimism-mainnet.infura.io/v3/", true),
-		*params.NewDirectProvider(chainID, DirectGrove, "https://optimism.rpc.grove.city/v1/", false),
+		*params.NewDirectProvider(chainID, DirectInfura, security.NewSensitiveString("https://optimism-mainnet.infura.io/v3/"), true),
+		*params.NewDirectProvider(chainID, DirectGrove, security.NewSensitiveString("https://optimism.rpc.grove.city/v1/"), false),
 	}
 
 	return params.Network{
@@ -176,8 +176,8 @@ func optimismSepolia(proxyHost, stageName string) params.Network {
 		*params.NewProxyProvider(chainID, ProxyInfura, proxyUrl(stageName, Infura, chainName, networkName), false),
 		*params.NewProxyProvider(chainID, ProxyGrove, proxyUrl(stageName, Grove, chainName, networkName), true),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectInfura, "https://optimism-sepolia.infura.io/v3/", true),
-		*params.NewDirectProvider(chainID, DirectGrove, "https://optimism-sepolia-testnet.rpc.grove.city/v1/", false),
+		*params.NewDirectProvider(chainID, DirectInfura, security.NewSensitiveString("https://optimism-sepolia.infura.io/v3/"), true),
+		*params.NewDirectProvider(chainID, DirectGrove, security.NewSensitiveString("https://optimism-sepolia-testnet.rpc.grove.city/v1/"), false),
 	}
 
 	return params.Network{
@@ -213,8 +213,8 @@ func arbitrum(proxyHost, stageName string) params.Network {
 		*params.NewProxyProvider(chainID, ProxyInfura, proxyUrl(stageName, Infura, chainName, networkName), false),
 		*params.NewProxyProvider(chainID, ProxyGrove, proxyUrl(stageName, Grove, chainName, networkName), true),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectInfura, "https://arbitrum-mainnet.infura.io/v3/", true),
-		*params.NewDirectProvider(chainID, DirectGrove, "https://arbitrum-one.rpc.grove.city/v1/", false),
+		*params.NewDirectProvider(chainID, DirectInfura, security.NewSensitiveString("https://arbitrum-mainnet.infura.io/v3/"), true),
+		*params.NewDirectProvider(chainID, DirectGrove, security.NewSensitiveString("https://arbitrum-one.rpc.grove.city/v1/"), false),
 	}
 
 	return params.Network{
@@ -250,8 +250,8 @@ func arbitrumSepolia(proxyHost, stageName string) params.Network {
 		*params.NewProxyProvider(chainID, ProxyInfura, proxyUrl(stageName, Infura, chainName, networkName), false),
 		*params.NewProxyProvider(chainID, ProxyGrove, proxyUrl(stageName, Grove, chainName, networkName), true),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectInfura, "https://arbitrum-sepolia.infura.io/v3/", true),
-		*params.NewDirectProvider(chainID, DirectGrove, "https://arbitrum-sepolia-testnet.rpc.grove.city/v1/", false),
+		*params.NewDirectProvider(chainID, DirectInfura, security.NewSensitiveString("https://arbitrum-sepolia.infura.io/v3/"), true),
+		*params.NewDirectProvider(chainID, DirectGrove, security.NewSensitiveString("https://arbitrum-sepolia-testnet.rpc.grove.city/v1/"), false),
 	}
 
 	return params.Network{
@@ -287,8 +287,8 @@ func base(proxyHost, stageName string) params.Network {
 		*params.NewProxyProvider(chainID, ProxyInfura, proxyUrl(stageName, Infura, chainName, networkName), false),
 		*params.NewProxyProvider(chainID, ProxyGrove, proxyUrl(stageName, Grove, chainName, networkName), true),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectInfura, "https://base-mainnet.infura.io/v3/", true),
-		*params.NewDirectProvider(chainID, DirectGrove, "https://base.rpc.grove.city/v1/", false),
+		*params.NewDirectProvider(chainID, DirectInfura, security.NewSensitiveString("https://base-mainnet.infura.io/v3/"), true),
+		*params.NewDirectProvider(chainID, DirectGrove, security.NewSensitiveString("https://base.rpc.grove.city/v1/"), false),
 	}
 
 	return params.Network{
@@ -324,8 +324,8 @@ func baseSepolia(proxyHost, stageName string) params.Network {
 		*params.NewProxyProvider(chainID, ProxyInfura, proxyUrl(stageName, Infura, chainName, networkName), false),
 		*params.NewProxyProvider(chainID, ProxyGrove, proxyUrl(stageName, Grove, chainName, networkName), true),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectInfura, "https://base-sepolia.infura.io/v3/", true),
-		*params.NewDirectProvider(chainID, DirectGrove, "https://base-testnet.rpc.grove.city/v1/", false),
+		*params.NewDirectProvider(chainID, DirectInfura, security.NewSensitiveString("https://base-sepolia.infura.io/v3/"), true),
+		*params.NewDirectProvider(chainID, DirectGrove, security.NewSensitiveString("https://base-testnet.rpc.grove.city/v1/"), false),
 	}
 
 	return params.Network{
@@ -357,7 +357,7 @@ func statusNetworkSepolia(proxyHost string) params.Network {
 		// Smart proxy provider
 		*params.NewEthRpcProxyProvider(chainID, StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 		// Direct providers
-		*params.NewDirectProvider(chainID, DirectStatus, "https://public.sepolia.rpc.status.network", false),
+		*params.NewDirectProvider(chainID, DirectStatus, security.NewSensitiveString("https://public.sepolia.rpc.status.network"), false),
 	}
 
 	return params.Network{

--- a/api/default_networks_test.go
+++ b/api/default_networks_test.go
@@ -1,16 +1,15 @@
 package api
 
 import (
-	"github.com/status-im/status-go/internal/security"
 	"strings"
 	"testing"
-
-	"github.com/status-im/status-go/api/common"
-	"github.com/status-im/status-go/params"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/status-im/status-go/api/common"
+	"github.com/status-im/status-go/internal/security"
+	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/requests"
 )
 

--- a/api/default_networks_test.go
+++ b/api/default_networks_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/status-im/status-go/internal/security"
 	"strings"
 	"testing"
 
@@ -14,8 +15,8 @@ import (
 )
 
 func TestBuildDefaultNetworks(t *testing.T) {
-	infuraToken := "infura-token"
-	poktToken := "pokt-token"
+	infuraToken := security.NewSensitiveString("infura-token")
+	poktToken := security.NewSensitiveString("pokt-token")
 	stageName := "fast-n-bulbous"
 	request := &requests.CreateAccount{
 		WalletSecretsConfig: requests.WalletSecretsConfig{
@@ -60,16 +61,16 @@ func TestBuildDefaultNetworks(t *testing.T) {
 
 		// check fallback options
 		if strings.Contains(n.RPCURL, "infura.io") {
-			require.True(t, strings.Contains(n.RPCURL, infuraToken))
+			require.True(t, strings.Contains(n.RPCURL, infuraToken.Reveal()))
 		}
 		if strings.Contains(n.FallbackURL, "grove.city") {
-			require.True(t, strings.Contains(n.FallbackURL, poktToken))
+			require.True(t, strings.Contains(n.FallbackURL, poktToken.Reveal()))
 		}
 
 		// Check proxy providers for stageName
 		for _, provider := range n.RpcProviders {
 			if provider.Type == params.EmbeddedProxyProviderType {
-				require.Contains(t, provider.URL, stageName, "Proxy provider URL should contain stageName")
+				require.Contains(t, provider.URL.Reveal(), stageName, "Proxy provider URL should contain stageName")
 			}
 		}
 
@@ -78,9 +79,9 @@ func TestBuildDefaultNetworks(t *testing.T) {
 			if provider.Type != params.EmbeddedDirectProviderType {
 				continue
 			}
-			if strings.Contains(provider.URL, "infura.io") {
+			if provider.URL.Contains("infura.io") {
 				require.Equal(t, provider.AuthToken, infuraToken, "Direct provider URL should have infuraToken")
-			} else if strings.Contains(provider.URL, "grove.city") {
+			} else if provider.URL.Contains("grove.city") {
 				require.Equal(t, provider.AuthToken, poktToken, "Direct provider URL should have poktToken")
 			}
 		}

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -11,6 +11,7 @@ import (
 	"github.com/status-im/status-go/api/common"
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol"
@@ -163,7 +164,7 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 	walletConfig := params.WalletConfig{
 		Enabled:                true,
 		EnableMercuryoProvider: true,
-		AlchemyAPIKeys:         make(map[uint64]string),
+		AlchemyAPIKeys:         make(map[uint64]security.SensitiveString),
 
 		TokensListsAutoRefreshCheckInterval: walletRequest.TokensListsAutoRefreshCheckInterval,
 		TokensListsAutoRefreshInterval:      walletRequest.TokensListsAutoRefreshInterval,
@@ -173,54 +174,54 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 		walletConfig.StatusProxyStageName = request.StatusProxyStageName
 	}
 
-	if request.OpenseaAPIKey != "" {
+	if request.OpenseaAPIKey.NotEmpty() {
 		walletConfig.OpenseaAPIKey = request.OpenseaAPIKey
 	}
 
-	if request.RaribleMainnetAPIKey != "" {
+	if request.RaribleMainnetAPIKey.NotEmpty() {
 		walletConfig.RaribleMainnetAPIKey = request.RaribleMainnetAPIKey
 	}
 
-	if request.RaribleTestnetAPIKey != "" {
+	if request.RaribleTestnetAPIKey.NotEmpty() {
 		walletConfig.RaribleTestnetAPIKey = request.RaribleTestnetAPIKey
 	}
 
-	if request.InfuraToken != "" {
+	if request.InfuraToken.NotEmpty() {
 		walletConfig.InfuraAPIKey = request.InfuraToken
 	}
 
-	if request.InfuraSecret != "" {
+	if request.InfuraSecret.NotEmpty() {
 		walletConfig.InfuraAPIKeySecret = request.InfuraSecret
 	}
 
-	if request.AlchemyEthereumMainnetToken != "" {
+	if request.AlchemyEthereumMainnetToken.NotEmpty() {
 		walletConfig.AlchemyAPIKeys[common.MainnetChainID] = request.AlchemyEthereumMainnetToken
 	}
-	if request.AlchemyEthereumSepoliaToken != "" {
+	if request.AlchemyEthereumSepoliaToken.NotEmpty() {
 		walletConfig.AlchemyAPIKeys[common.SepoliaChainID] = request.AlchemyEthereumSepoliaToken
 	}
-	if request.AlchemyArbitrumMainnetToken != "" {
+	if request.AlchemyArbitrumMainnetToken.NotEmpty() {
 		walletConfig.AlchemyAPIKeys[common.ArbitrumChainID] = request.AlchemyArbitrumMainnetToken
 	}
-	if request.AlchemyArbitrumSepoliaToken != "" {
+	if request.AlchemyArbitrumSepoliaToken.NotEmpty() {
 		walletConfig.AlchemyAPIKeys[common.ArbitrumSepoliaChainID] = request.AlchemyArbitrumSepoliaToken
 	}
-	if request.AlchemyOptimismMainnetToken != "" {
+	if request.AlchemyOptimismMainnetToken.NotEmpty() {
 		walletConfig.AlchemyAPIKeys[common.OptimismChainID] = request.AlchemyOptimismMainnetToken
 	}
-	if request.AlchemyOptimismSepoliaToken != "" {
+	if request.AlchemyOptimismSepoliaToken.NotEmpty() {
 		walletConfig.AlchemyAPIKeys[common.OptimismSepoliaChainID] = request.AlchemyOptimismSepoliaToken
 	}
-	if request.AlchemyBaseMainnetToken != "" {
+	if request.AlchemyBaseMainnetToken.NotEmpty() {
 		walletConfig.AlchemyAPIKeys[common.BaseChainID] = request.AlchemyBaseMainnetToken
 	}
-	if request.AlchemyBaseSepoliaToken != "" {
+	if request.AlchemyBaseSepoliaToken.NotEmpty() {
 		walletConfig.AlchemyAPIKeys[common.BaseSepoliaChainID] = request.AlchemyBaseSepoliaToken
 	}
-	if request.StatusProxyMarketUser != "" {
+	if request.StatusProxyMarketUser.NotEmpty() {
 		walletConfig.StatusProxyMarketUser = request.StatusProxyMarketUser
 	}
-	if request.StatusProxyMarketPassword != "" {
+	if request.StatusProxyMarketPassword.NotEmpty() {
 		walletConfig.StatusProxyMarketPassword = request.StatusProxyMarketPassword
 	}
 	if request.MarketDataProxyUser != "" {
@@ -240,20 +241,20 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 	}
 
 	// FIXME: remove when EthRpcProxy* is integrated
-	if request.StatusProxyBlockchainUser != "" {
+	if request.StatusProxyBlockchainUser.NotEmpty() {
 		walletConfig.StatusProxyBlockchainUser = request.StatusProxyBlockchainUser
 	}
-	if request.StatusProxyBlockchainPassword != "" {
+	if request.StatusProxyBlockchainPassword.NotEmpty() {
 		walletConfig.StatusProxyBlockchainPassword = request.StatusProxyBlockchainPassword
 	}
 
-	if request.EthRpcProxyUrl != "" {
+	if request.EthRpcProxyUrl.NotEmpty() {
 		walletConfig.EthRpcProxyUrl = request.EthRpcProxyUrl
 	}
-	if request.EthRpcProxyUser != "" {
+	if request.EthRpcProxyUser.NotEmpty() {
 		walletConfig.EthRpcProxyUser = request.EthRpcProxyUser
 	}
-	if request.EthRpcProxyPassword != "" {
+	if request.EthRpcProxyPassword.NotEmpty() {
 		walletConfig.EthRpcProxyPassword = request.EthRpcProxyPassword
 	}
 

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -283,7 +283,7 @@ func getMainnetRPCURL(networks []params.Network) string {
 		}
 		for _, provider := range network.RpcProviders {
 			if provider.AuthType == params.TokenAuth && provider.Enabled {
-				return provider.GetFullURL()
+				return provider.GetFullURL().Reveal()
 			}
 		}
 		break

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -174,54 +174,54 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 		walletConfig.StatusProxyStageName = request.StatusProxyStageName
 	}
 
-	if request.OpenseaAPIKey.NotEmpty() {
+	if !request.OpenseaAPIKey.Empty() {
 		walletConfig.OpenseaAPIKey = request.OpenseaAPIKey
 	}
 
-	if request.RaribleMainnetAPIKey.NotEmpty() {
+	if !request.RaribleMainnetAPIKey.Empty() {
 		walletConfig.RaribleMainnetAPIKey = request.RaribleMainnetAPIKey
 	}
 
-	if request.RaribleTestnetAPIKey.NotEmpty() {
+	if !request.RaribleTestnetAPIKey.Empty() {
 		walletConfig.RaribleTestnetAPIKey = request.RaribleTestnetAPIKey
 	}
 
-	if request.InfuraToken.NotEmpty() {
+	if !request.InfuraToken.Empty() {
 		walletConfig.InfuraAPIKey = request.InfuraToken
 	}
 
-	if request.InfuraSecret.NotEmpty() {
+	if !request.InfuraSecret.Empty() {
 		walletConfig.InfuraAPIKeySecret = request.InfuraSecret
 	}
 
-	if request.AlchemyEthereumMainnetToken.NotEmpty() {
+	if !request.AlchemyEthereumMainnetToken.Empty() {
 		walletConfig.AlchemyAPIKeys[common.MainnetChainID] = request.AlchemyEthereumMainnetToken
 	}
-	if request.AlchemyEthereumSepoliaToken.NotEmpty() {
+	if !request.AlchemyEthereumSepoliaToken.Empty() {
 		walletConfig.AlchemyAPIKeys[common.SepoliaChainID] = request.AlchemyEthereumSepoliaToken
 	}
-	if request.AlchemyArbitrumMainnetToken.NotEmpty() {
+	if !request.AlchemyArbitrumMainnetToken.Empty() {
 		walletConfig.AlchemyAPIKeys[common.ArbitrumChainID] = request.AlchemyArbitrumMainnetToken
 	}
-	if request.AlchemyArbitrumSepoliaToken.NotEmpty() {
+	if !request.AlchemyArbitrumSepoliaToken.Empty() {
 		walletConfig.AlchemyAPIKeys[common.ArbitrumSepoliaChainID] = request.AlchemyArbitrumSepoliaToken
 	}
-	if request.AlchemyOptimismMainnetToken.NotEmpty() {
+	if !request.AlchemyOptimismMainnetToken.Empty() {
 		walletConfig.AlchemyAPIKeys[common.OptimismChainID] = request.AlchemyOptimismMainnetToken
 	}
-	if request.AlchemyOptimismSepoliaToken.NotEmpty() {
+	if !request.AlchemyOptimismSepoliaToken.Empty() {
 		walletConfig.AlchemyAPIKeys[common.OptimismSepoliaChainID] = request.AlchemyOptimismSepoliaToken
 	}
-	if request.AlchemyBaseMainnetToken.NotEmpty() {
+	if !request.AlchemyBaseMainnetToken.Empty() {
 		walletConfig.AlchemyAPIKeys[common.BaseChainID] = request.AlchemyBaseMainnetToken
 	}
-	if request.AlchemyBaseSepoliaToken.NotEmpty() {
+	if !request.AlchemyBaseSepoliaToken.Empty() {
 		walletConfig.AlchemyAPIKeys[common.BaseSepoliaChainID] = request.AlchemyBaseSepoliaToken
 	}
-	if request.StatusProxyMarketUser.NotEmpty() {
+	if !request.StatusProxyMarketUser.Empty() {
 		walletConfig.StatusProxyMarketUser = request.StatusProxyMarketUser
 	}
-	if request.StatusProxyMarketPassword.NotEmpty() {
+	if !request.StatusProxyMarketPassword.Empty() {
 		walletConfig.StatusProxyMarketPassword = request.StatusProxyMarketPassword
 	}
 	if request.MarketDataProxyUser != "" {
@@ -241,20 +241,20 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 	}
 
 	// FIXME: remove when EthRpcProxy* is integrated
-	if request.StatusProxyBlockchainUser.NotEmpty() {
+	if !request.StatusProxyBlockchainUser.Empty() {
 		walletConfig.StatusProxyBlockchainUser = request.StatusProxyBlockchainUser
 	}
-	if request.StatusProxyBlockchainPassword.NotEmpty() {
+	if !request.StatusProxyBlockchainPassword.Empty() {
 		walletConfig.StatusProxyBlockchainPassword = request.StatusProxyBlockchainPassword
 	}
 
-	if request.EthRpcProxyUrl.NotEmpty() {
+	if !request.EthRpcProxyUrl.Empty() {
 		walletConfig.EthRpcProxyUrl = request.EthRpcProxyUrl
 	}
-	if request.EthRpcProxyUser.NotEmpty() {
+	if !request.EthRpcProxyUser.Empty() {
 		walletConfig.EthRpcProxyUser = request.EthRpcProxyUser
 	}
-	if request.EthRpcProxyPassword.NotEmpty() {
+	if !request.EthRpcProxyPassword.Empty() {
 		walletConfig.EthRpcProxyPassword = request.EthRpcProxyPassword
 	}
 

--- a/internal/security/sensitive_string.go
+++ b/internal/security/sensitive_string.go
@@ -3,6 +3,7 @@ package security
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 const RedactionPlaceholder = "***"
@@ -73,4 +74,12 @@ func (s SensitiveString) Plus(other SensitiveString) SensitiveString {
 
 func (s SensitiveString) PlusString(other string) SensitiveString {
 	return NewSensitiveString(s.value + other)
+}
+
+func (s SensitiveString) TrimRight(cutset string) SensitiveString {
+	return NewSensitiveString(strings.TrimRight(s.value, cutset))
+}
+
+func (s SensitiveString) Contains(substr string) bool {
+	return strings.Contains(s.value, substr)
 }

--- a/internal/security/sensitive_string.go
+++ b/internal/security/sensitive_string.go
@@ -1,6 +1,7 @@
 package security
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -98,4 +99,24 @@ func getValue(v any) string {
 	default:
 		panic(fmt.Sprintf("unsupported type: %T", v))
 	}
+}
+
+// Value implements the driver.Valuer interface for SensitiveString
+func (s SensitiveString) Value() (driver.Value, error) {
+	return s.value, nil
+}
+
+// Scan implements the sql.Scanner interface for SensitiveString
+func (s *SensitiveString) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case nil:
+		s.value = ""
+	case string:
+		s.value = v
+	case []byte:
+		s.value = string(v)
+	default:
+		return fmt.Errorf("cannot scan type %T into SensitiveString", value)
+	}
+	return nil
 }

--- a/internal/security/sensitive_string.go
+++ b/internal/security/sensitive_string.go
@@ -69,10 +69,6 @@ func (s SensitiveString) NotEmpty() bool {
 	return !s.Empty()
 }
 
-func (s SensitiveString) Plus(other any) SensitiveString {
-	return NewSensitiveString(s.value + getValue(other))
-}
-
 func (s SensitiveString) TrimRight(cutset any) SensitiveString {
 	return NewSensitiveString(strings.TrimRight(s.value, getValue(cutset)))
 }

--- a/internal/security/sensitive_string.go
+++ b/internal/security/sensitive_string.go
@@ -68,18 +68,34 @@ func (s SensitiveString) NotEmpty() bool {
 	return !s.Empty()
 }
 
-func (s SensitiveString) Plus(other SensitiveString) SensitiveString {
-	return NewSensitiveString(s.value + other.value)
+func (s SensitiveString) Plus(other any) SensitiveString {
+	return NewSensitiveString(s.value + getValue(other))
 }
 
-func (s SensitiveString) PlusString(other string) SensitiveString {
-	return NewSensitiveString(s.value + other)
+func (s SensitiveString) TrimRight(cutset any) SensitiveString {
+	return NewSensitiveString(strings.TrimRight(s.value, getValue(cutset)))
 }
 
-func (s SensitiveString) TrimRight(cutset string) SensitiveString {
-	return NewSensitiveString(strings.TrimRight(s.value, cutset))
+func (s SensitiveString) Contains(substr any) bool {
+	return strings.Contains(s.value, getValue(substr))
 }
 
-func (s SensitiveString) Contains(substr string) bool {
-	return strings.Contains(s.value, substr)
+func (s SensitiveString) Append(others ...any) SensitiveString {
+	result := s.value
+	for _, other := range others {
+		result += getValue(other)
+	}
+	return NewSensitiveString(result)
+}
+
+// getValue extracts the string value from various types
+func getValue(v any) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case SensitiveString:
+		return x.value
+	default:
+		panic(fmt.Sprintf("unsupported type: %T", v))
+	}
 }

--- a/internal/security/sensitive_string.go
+++ b/internal/security/sensitive_string.go
@@ -65,10 +65,6 @@ func (s SensitiveString) Empty() bool {
 	return s.value == ""
 }
 
-func (s SensitiveString) NotEmpty() bool {
-	return !s.Empty()
-}
-
 func (s SensitiveString) TrimRight(cutset any) SensitiveString {
 	return NewSensitiveString(strings.TrimRight(s.value, getValue(cutset)))
 }

--- a/internal/security/sensitive_string.go
+++ b/internal/security/sensitive_string.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 const RedactionPlaceholder = "***"
@@ -18,6 +19,11 @@ type SensitiveString struct {
 // NewSensitiveString creates a new SensitiveString
 func NewSensitiveString(value string) SensitiveString {
 	return SensitiveString{value: value}
+}
+
+func NewSensitiveStringPrintf(format string, args ...interface{}) SensitiveString {
+	str := fmt.Sprintf(format, args...)
+	return NewSensitiveString(str)
 }
 
 // String provides a redacted version of the sensitive string
@@ -55,4 +61,16 @@ func (s SensitiveString) Reveal() string {
 // Empty checks if the value is empty
 func (s SensitiveString) Empty() bool {
 	return s.value == ""
+}
+
+func (s SensitiveString) NotEmpty() bool {
+	return !s.Empty()
+}
+
+func (s SensitiveString) Plus(other SensitiveString) SensitiveString {
+	return NewSensitiveString(s.value + other.value)
+}
+
+func (s SensitiveString) PlusString(other string) SensitiveString {
+	return NewSensitiveString(s.value + other)
 }

--- a/internal/security/sensitive_string_test.go
+++ b/internal/security/sensitive_string_test.go
@@ -79,13 +79,13 @@ func TestPlusString(t *testing.T) {
 }
 
 func TestTrimRight(t *testing.T) {
-	secretValue := "¡¡¡Hello, Gophers!!!"
+	secretValue := "¡¡¡Hello, Gophers!!!" // #nosec G101
 	s1 := NewSensitiveString(secretValue)
 	require.Equal(t, s1.TrimRight("!"), NewSensitiveString("¡¡¡Hello, Gophers"))
 }
 
 func TestContains(t *testing.T) {
-	secretValue := "¡¡¡Hello, Gophers!!!"
+	secretValue := "¡¡¡Hello, Gophers!!!" // #nosec G101
 	s1 := NewSensitiveString(secretValue)
 	require.True(t, s1.Contains("Hello"))
 	require.False(t, s1.Contains("World"))

--- a/internal/security/sensitive_string_test.go
+++ b/internal/security/sensitive_string_test.go
@@ -77,3 +77,16 @@ func TestPlusString(t *testing.T) {
 	s1 := NewSensitiveString(secretValue)
 	require.Equal(t, s1.PlusString(secretValue), NewSensitiveString(secretValue+secretValue))
 }
+
+func TestTrimRight(t *testing.T) {
+	secretValue := "¡¡¡Hello, Gophers!!!"
+	s1 := NewSensitiveString(secretValue)
+	require.Equal(t, s1.TrimRight("!"), NewSensitiveString("¡¡¡Hello, Gophers"))
+}
+
+func TestContains(t *testing.T) {
+	secretValue := "¡¡¡Hello, Gophers!!!"
+	s1 := NewSensitiveString(secretValue)
+	require.True(t, s1.Contains("Hello"))
+	require.False(t, s1.Contains("World"))
+}

--- a/internal/security/sensitive_string_test.go
+++ b/internal/security/sensitive_string_test.go
@@ -5,88 +5,107 @@ import (
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestNewSensitiveString(t *testing.T) {
-	secretValue := gofakeit.LetterN(10)
-	s := NewSensitiveString(secretValue)
-	require.Equal(t, secretValue, s.Reveal())
+// SensitiveStringSuite defines a testify suite for testing SensitiveString
+type SensitiveStringSuite struct {
+	suite.Suite
 }
 
-func TestStringRedaction(t *testing.T) {
+// SensitiveStringSuite is the test suite for all SensitiveString behaviors.
+func (suite *SensitiveStringSuite) TestNewSensitiveString() {
 	secretValue := gofakeit.LetterN(10)
 	s := NewSensitiveString(secretValue)
-	require.Equal(t, RedactionPlaceholder, s.String())
+	suite.Require().Equal(secretValue, s.Reveal())
 }
 
-func TestEmptyStringRedaction(t *testing.T) {
+func (suite *SensitiveStringSuite) TestStringRedaction() {
+	secretValue := gofakeit.LetterN(10)
+	s := NewSensitiveString(secretValue)
+	suite.Require().Equal(RedactionPlaceholder, s.String())
+}
+
+func (suite *SensitiveStringSuite) TestEmptyStringRedaction() {
 	s := NewSensitiveString("")
-	require.Equal(t, "", s.String())
+	suite.Require().Equal("", s.String())
 }
 
-func TestMarshalJSON(t *testing.T) {
+func (suite *SensitiveStringSuite) TestMarshalJSON() {
 	secretValue := gofakeit.LetterN(10)
 	s := NewSensitiveString(secretValue)
+
 	data, err := json.Marshal(s)
-	require.NoError(t, err)
-	require.JSONEq(t, `"`+RedactionPlaceholder+`"`, string(data))
+	suite.Require().NoError(err)
+	suite.Require().JSONEq(`"`+RedactionPlaceholder+`"`, string(data))
 }
 
-func TestMarshalJSONPointer(t *testing.T) {
+func (suite *SensitiveStringSuite) TestMarshalJSONPointer() {
 	secretValue := gofakeit.LetterN(10)
-	s := NewSensitiveString(secretValue)
-	data, err := json.Marshal(&s)
-	require.NoError(t, err)
-	require.JSONEq(t, `"`+RedactionPlaceholder+`"`, string(data))
+	sVal := NewSensitiveString(secretValue)
+
+	data, err := json.Marshal(&sVal)
+	suite.Require().NoError(err)
+	suite.Require().JSONEq(`"`+RedactionPlaceholder+`"`, string(data))
 }
 
-func TestUnmarshalJSON(t *testing.T) {
+func (suite *SensitiveStringSuite) TestUnmarshalJSON() {
 	secretValue := gofakeit.LetterN(10)
-	data := `"` + secretValue + `"`
+	payload := `"` + secretValue + `"`
 	var s SensitiveString
-	err := json.Unmarshal([]byte(data), &s)
-	require.NoError(t, err)
-	require.Equal(t, secretValue, s.Reveal())
+
+	suite.Require().NoError(json.Unmarshal([]byte(payload), &s))
+	suite.Require().Equal(secretValue, s.Reveal())
 }
 
-func TestUnamarshalJSONError(t *testing.T) {
+func (suite *SensitiveStringSuite) TestUnmarshalJSONError() {
 	// Can't unmarshal a non-string value
 	var s SensitiveString
-	data := `{"key": "value"}`
-	err := json.Unmarshal([]byte(data), &s)
-	require.Error(t, err)
+	payload := `{"key":"value"}`
+	suite.Require().Error(json.Unmarshal([]byte(payload), &s))
 }
 
-func TestCopySensitiveString(t *testing.T) {
+func (suite *SensitiveStringSuite) TestCopySensitiveString() {
 	secretValue := gofakeit.LetterN(10)
 	s := NewSensitiveString(secretValue)
 	sCopy := s
-	require.Equal(t, secretValue, sCopy.Reveal())
+	suite.Require().Equal(secretValue, sCopy.Reveal())
 }
 
-func TestPlus(t *testing.T) {
+func (suite *SensitiveStringSuite) TestPlus() {
 	secretValue := gofakeit.LetterN(10)
 	s1 := NewSensitiveString(secretValue)
 	s2 := NewSensitiveString(secretValue)
-	require.Equal(t, s1.Plus(s2), NewSensitiveString(secretValue+secretValue))
+
+	suite.Require().Equal(s1.Plus(s2), NewSensitiveString(secretValue+secretValue))
 }
 
-func TestPlusString(t *testing.T) {
+func (suite *SensitiveStringSuite) TestPlusString() {
 	secretValue := gofakeit.LetterN(10)
 	s1 := NewSensitiveString(secretValue)
-	require.Equal(t, s1.PlusString(secretValue), NewSensitiveString(secretValue+secretValue))
+
+	suite.Require().Equal(s1.PlusString(secretValue), NewSensitiveString(secretValue+secretValue))
 }
 
-func TestTrimRight(t *testing.T) {
+func (suite *SensitiveStringSuite) TestTrimRight() {
 	secretValue := "¡¡¡Hello, Gophers!!!" // #nosec G101
 	s1 := NewSensitiveString(secretValue)
-	require.Equal(t, s1.TrimRight("!"), NewSensitiveString("¡¡¡Hello, Gophers"))
+
+	suite.Require().Equal(
+		s1.TrimRight("!"),
+		NewSensitiveString("¡¡¡Hello, Gophers"),
+	)
 }
 
-func TestContains(t *testing.T) {
+func (suite *SensitiveStringSuite) TestContains() {
 	secretValue := "¡¡¡Hello, Gophers!!!" // #nosec G101
 	s1 := NewSensitiveString(secretValue)
-	require.True(t, s1.Contains("Hello"))
-	require.False(t, s1.Contains("World"))
+
+	suite.Require().True(s1.Contains("Hello"))
+	suite.Require().False(s1.Contains("World"))
+}
+
+// Entry point for the suite
+func TestSensitiveStringSuite(t *testing.T) {
+	suite.Run(t, new(SensitiveStringSuite))
 }

--- a/internal/security/sensitive_string_test.go
+++ b/internal/security/sensitive_string_test.go
@@ -14,95 +14,99 @@ type SensitiveStringSuite struct {
 }
 
 // SensitiveStringSuite is the test suite for all SensitiveString behaviors.
-func (suite *SensitiveStringSuite) TestNewSensitiveString() {
+func (s *SensitiveStringSuite) TestNewSensitiveString() {
 	secretValue := gofakeit.LetterN(10)
-	s := NewSensitiveString(secretValue)
-	suite.Require().Equal(secretValue, s.Reveal())
+	ss := NewSensitiveString(secretValue)
+	s.Require().Equal(secretValue, ss.Reveal())
 }
 
-func (suite *SensitiveStringSuite) TestStringRedaction() {
+func (s *SensitiveStringSuite) TestStringRedaction() {
 	secretValue := gofakeit.LetterN(10)
-	s := NewSensitiveString(secretValue)
-	suite.Require().Equal(RedactionPlaceholder, s.String())
+	ss := NewSensitiveString(secretValue)
+	s.Require().Equal(RedactionPlaceholder, ss.String())
 }
 
-func (suite *SensitiveStringSuite) TestEmptyStringRedaction() {
-	s := NewSensitiveString("")
-	suite.Require().Equal("", s.String())
+func (s *SensitiveStringSuite) TestEmptyStringRedaction() {
+	ss := NewSensitiveString("")
+	s.Require().Equal("", ss.String())
 }
 
-func (suite *SensitiveStringSuite) TestMarshalJSON() {
+func (s *SensitiveStringSuite) TestMarshalJSON() {
 	secretValue := gofakeit.LetterN(10)
-	s := NewSensitiveString(secretValue)
+	ss := NewSensitiveString(secretValue)
 
-	data, err := json.Marshal(s)
-	suite.Require().NoError(err)
-	suite.Require().JSONEq(`"`+RedactionPlaceholder+`"`, string(data))
+	data, err := json.Marshal(ss)
+	s.Require().NoError(err)
+	s.Require().JSONEq(`"`+RedactionPlaceholder+`"`, string(data))
 }
 
-func (suite *SensitiveStringSuite) TestMarshalJSONPointer() {
+func (s *SensitiveStringSuite) TestMarshalJSONPointer() {
 	secretValue := gofakeit.LetterN(10)
 	sVal := NewSensitiveString(secretValue)
 
 	data, err := json.Marshal(&sVal)
-	suite.Require().NoError(err)
-	suite.Require().JSONEq(`"`+RedactionPlaceholder+`"`, string(data))
+	s.Require().NoError(err)
+	s.Require().JSONEq(`"`+RedactionPlaceholder+`"`, string(data))
 }
 
-func (suite *SensitiveStringSuite) TestUnmarshalJSON() {
+func (s *SensitiveStringSuite) TestUnmarshalJSON() {
 	secretValue := gofakeit.LetterN(10)
 	payload := `"` + secretValue + `"`
-	var s SensitiveString
+	var ss SensitiveString
 
-	suite.Require().NoError(json.Unmarshal([]byte(payload), &s))
-	suite.Require().Equal(secretValue, s.Reveal())
+	s.Require().NoError(json.Unmarshal([]byte(payload), &ss))
+	s.Require().Equal(secretValue, ss.Reveal())
 }
 
-func (suite *SensitiveStringSuite) TestUnmarshalJSONError() {
+func (s *SensitiveStringSuite) TestUnmarshalJSONError() {
 	// Can't unmarshal a non-string value
-	var s SensitiveString
+	var ss SensitiveString
 	payload := `{"key":"value"}`
-	suite.Require().Error(json.Unmarshal([]byte(payload), &s))
+	s.Require().Error(json.Unmarshal([]byte(payload), &ss))
 }
 
-func (suite *SensitiveStringSuite) TestCopySensitiveString() {
+func (s *SensitiveStringSuite) TestCopySensitiveString() {
 	secretValue := gofakeit.LetterN(10)
-	s := NewSensitiveString(secretValue)
-	sCopy := s
-	suite.Require().Equal(secretValue, sCopy.Reveal())
+	ss := NewSensitiveString(secretValue)
+	ssCopy := ss
+	s.Require().Equal(secretValue, ssCopy.Reveal())
 }
 
-func (suite *SensitiveStringSuite) TestPlus() {
+func (s *SensitiveStringSuite) TestPlus() {
 	secretValue := gofakeit.LetterN(10)
 	s1 := NewSensitiveString(secretValue)
 	s2 := NewSensitiveString(secretValue)
 
-	suite.Require().Equal(s1.Plus(s2), NewSensitiveString(secretValue+secretValue))
+	s.Require().Equal(s1.Plus(s2), NewSensitiveString(secretValue+secretValue))
+	s.Require().Equal(s1.Plus(secretValue), NewSensitiveString(secretValue+secretValue))
 }
 
-func (suite *SensitiveStringSuite) TestPlusString() {
-	secretValue := gofakeit.LetterN(10)
+func (s *SensitiveStringSuite) TestTrimRight() {
+	const secretValue = "¡¡¡Hello, Gophers!!!" // #nosec G101
 	s1 := NewSensitiveString(secretValue)
 
-	suite.Require().Equal(s1.PlusString(secretValue), NewSensitiveString(secretValue+secretValue))
-}
-
-func (suite *SensitiveStringSuite) TestTrimRight() {
-	secretValue := "¡¡¡Hello, Gophers!!!" // #nosec G101
-	s1 := NewSensitiveString(secretValue)
-
-	suite.Require().Equal(
+	s.Require().Equal(
 		s1.TrimRight("!"),
 		NewSensitiveString("¡¡¡Hello, Gophers"),
 	)
 }
 
-func (suite *SensitiveStringSuite) TestContains() {
-	secretValue := "¡¡¡Hello, Gophers!!!" // #nosec G101
+func (s *SensitiveStringSuite) TestContains() {
+	const secretValue = "¡¡¡Hello, Gophers!!!" // #nosec G101
 	s1 := NewSensitiveString(secretValue)
 
-	suite.Require().True(s1.Contains("Hello"))
-	suite.Require().False(s1.Contains("World"))
+	s.Require().True(s1.Contains("Hello"))
+	s.Require().False(s1.Contains("World"))
+}
+
+func (s *SensitiveStringSuite) TestAppend() {
+	secretValue := gofakeit.LetterN(10)
+	s1 := NewSensitiveString(secretValue)
+	s2 := NewSensitiveString(secretValue)
+
+	s.Require().Equal(s1.Append(s2), NewSensitiveString(secretValue+secretValue))
+	s.Require().Equal(s1.Append(secretValue), NewSensitiveString(secretValue+secretValue))
+	s.Require().Equal(s1.Append(secretValue, secretValue), NewSensitiveString(secretValue+secretValue+secretValue))
 }
 
 // Entry point for the suite

--- a/internal/security/sensitive_string_test.go
+++ b/internal/security/sensitive_string_test.go
@@ -64,3 +64,16 @@ func TestCopySensitiveString(t *testing.T) {
 	sCopy := s
 	require.Equal(t, secretValue, sCopy.Reveal())
 }
+
+func TestPlus(t *testing.T) {
+	secretValue := gofakeit.LetterN(10)
+	s1 := NewSensitiveString(secretValue)
+	s2 := NewSensitiveString(secretValue)
+	require.Equal(t, s1.Plus(s2), NewSensitiveString(secretValue+secretValue))
+}
+
+func TestPlusString(t *testing.T) {
+	secretValue := gofakeit.LetterN(10)
+	s1 := NewSensitiveString(secretValue)
+	require.Equal(t, s1.PlusString(secretValue), NewSensitiveString(secretValue+secretValue))
+}

--- a/internal/security/sensitive_string_test.go
+++ b/internal/security/sensitive_string_test.go
@@ -72,15 +72,6 @@ func (s *SensitiveStringSuite) TestCopySensitiveString() {
 	s.Require().Equal(secretValue, ssCopy.Reveal())
 }
 
-func (s *SensitiveStringSuite) TestPlus() {
-	secretValue := gofakeit.LetterN(10)
-	s1 := NewSensitiveString(secretValue)
-	s2 := NewSensitiveString(secretValue)
-
-	s.Require().Equal(s1.Plus(s2), NewSensitiveString(secretValue+secretValue))
-	s.Require().Equal(s1.Plus(secretValue), NewSensitiveString(secretValue+secretValue))
-}
-
 func (s *SensitiveStringSuite) TestTrimRight() {
 	const secretValue = "¡¡¡Hello, Gophers!!!" // #nosec G101
 	s1 := NewSensitiveString(secretValue)

--- a/messaging/api.go
+++ b/messaging/api.go
@@ -8,6 +8,8 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
 
+	"github.com/waku-org/go-waku/waku/v2/api/history"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/status-im/status-go/connection"
@@ -16,7 +18,6 @@ import (
 	"github.com/status-im/status-go/messaging/layers/transport"
 	"github.com/status-im/status-go/messaging/types"
 	wakutypes "github.com/status-im/status-go/waku/types"
-	"github.com/waku-org/go-waku/waku/v2/api/history"
 )
 
 type API struct {

--- a/params/config.go
+++ b/params/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/static"
 	wakuv2common "github.com/status-im/status-go/wakuv2/common"
+	"github.com/status-im/status-go/internal/security"
 )
 
 // ----------
@@ -420,25 +421,25 @@ type NodeConfig struct {
 // WalletConfig extra configuration for wallet.Service.
 type WalletConfig struct {
 	Enabled                   bool
-	OpenseaAPIKey             string                `json:"OpenseaAPIKey"`
-	RaribleMainnetAPIKey      string                `json:"RaribleMainnetAPIKey"`
-	RaribleTestnetAPIKey      string                `json:"RaribleTestnetAPIKey"`
-	AlchemyAPIKeys            map[uint64]string     `json:"AlchemyAPIKeys"`
-	InfuraAPIKey              string                `json:"InfuraAPIKey"`
-	InfuraAPIKeySecret        string                `json:"InfuraAPIKeySecret"`
-	StatusProxyMarketUser     string                `json:"StatusProxyMarketUser"`
-	StatusProxyMarketPassword string                `json:"StatusProxyMarketPassword"`
+	OpenseaAPIKey             security.SensitiveString            `json:"OpenseaAPIKey"`
+	RaribleMainnetAPIKey      security.SensitiveString            `json:"RaribleMainnetAPIKey"`
+	RaribleTestnetAPIKey      security.SensitiveString            `json:"RaribleTestnetAPIKey"`
+	AlchemyAPIKeys            map[uint64]security.SensitiveString `json:"AlchemyAPIKeys"`
+	InfuraAPIKey              security.SensitiveString            `json:"InfuraAPIKey"`
+	InfuraAPIKeySecret        security.SensitiveString            `json:"InfuraAPIKeySecret"`
+	StatusProxyMarketUser     security.SensitiveString            `json:"StatusProxyMarketUser"`
+	StatusProxyMarketPassword security.SensitiveString            `json:"StatusProxyMarketPassword"`
 	MarketDataProxyConfig     MarketDataProxyConfig `json:"MarketDataProxyConfig"`
 	// FIXME: remove when EthRpcProxy* is integrated
-	StatusProxyBlockchainUser     string `json:"StatusProxyBlockchainUser"`
-	StatusProxyBlockchainPassword string `json:"StatusProxyBlockchainPassword"`
+	StatusProxyBlockchainUser     security.SensitiveString `json:"StatusProxyBlockchainUser"`
+	StatusProxyBlockchainPassword security.SensitiveString `json:"StatusProxyBlockchainPassword"`
 
 	StatusProxyStageName   string `json:"StatusProxyStageName"`
 	EnableCelerBridge      bool   `json:"EnableCelerBridge"`
 	EnableMercuryoProvider bool   `json:"EnableMercuryoProvider"`
-	EthRpcProxyUrl         string `json:"EthRpcProxyUrl"`
-	EthRpcProxyUser        string `json:"EthRpcProxyUser"`
-	EthRpcProxyPassword    string `json:"EthRpcProxyPassword"`
+	EthRpcProxyUrl         security.SensitiveString `json:"EthRpcProxyUrl"`
+	EthRpcProxyUser        security.SensitiveString `json:"EthRpcProxyUser"`
+	EthRpcProxyPassword    security.SensitiveString `json:"EthRpcProxyPassword"`
 
 	TokensListsAutoRefreshInterval      int `json:"TokensListsAutoRefreshInterval"`      // in seconds
 	TokensListsAutoRefreshCheckInterval int `json:"TokensListsAutoRefreshCheckInterval"` // in seconds

--- a/params/config.go
+++ b/params/config.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/internal/version"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/static"
 	wakuv2common "github.com/status-im/status-go/wakuv2/common"
-	"github.com/status-im/status-go/internal/security"
 )
 
 // ----------
@@ -434,9 +434,9 @@ type WalletConfig struct {
 	StatusProxyBlockchainUser     security.SensitiveString `json:"StatusProxyBlockchainUser"`
 	StatusProxyBlockchainPassword security.SensitiveString `json:"StatusProxyBlockchainPassword"`
 
-	StatusProxyStageName   string `json:"StatusProxyStageName"`
-	EnableCelerBridge      bool   `json:"EnableCelerBridge"`
-	EnableMercuryoProvider bool   `json:"EnableMercuryoProvider"`
+	StatusProxyStageName   string                   `json:"StatusProxyStageName"`
+	EnableCelerBridge      bool                     `json:"EnableCelerBridge"`
+	EnableMercuryoProvider bool                     `json:"EnableMercuryoProvider"`
 	EthRpcProxyUrl         security.SensitiveString `json:"EthRpcProxyUrl"`
 	EthRpcProxyUser        security.SensitiveString `json:"EthRpcProxyUser"`
 	EthRpcProxyPassword    security.SensitiveString `json:"EthRpcProxyPassword"`

--- a/params/config.go
+++ b/params/config.go
@@ -429,7 +429,7 @@ type WalletConfig struct {
 	InfuraAPIKeySecret        security.SensitiveString            `json:"InfuraAPIKeySecret"`
 	StatusProxyMarketUser     security.SensitiveString            `json:"StatusProxyMarketUser"`
 	StatusProxyMarketPassword security.SensitiveString            `json:"StatusProxyMarketPassword"`
-	MarketDataProxyConfig     MarketDataProxyConfig `json:"MarketDataProxyConfig"`
+	MarketDataProxyConfig     MarketDataProxyConfig               `json:"MarketDataProxyConfig"`
 	// FIXME: remove when EthRpcProxy* is integrated
 	StatusProxyBlockchainUser     security.SensitiveString `json:"StatusProxyBlockchainUser"`
 	StatusProxyBlockchainPassword security.SensitiveString `json:"StatusProxyBlockchainPassword"`

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -10,10 +10,11 @@ import (
 
 	validator "gopkg.in/go-playground/validator.v9"
 
+	"github.com/brianvoe/gofakeit/v6"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/t/utils"

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/t/utils"
-	"github.com/status-im/status-go/internal/security"
-	"github.com/brianvoe/gofakeit/v6"
 )
 
 func TestNewNodeConfigWithDefaults(t *testing.T) {
@@ -323,5 +323,5 @@ func TestMarshalWalletConfigJSON(t *testing.T) {
 	walletConfig = params.WalletConfig{}
 	err = json.Unmarshal([]byte(`{"OpenseaAPIKey":"some-key"}`), &walletConfig)
 	require.NoError(t, err)
-	require.Equal(t, "some-key", walletConfig.OpenseaAPIKey)
+	require.Equal(t, "some-key", walletConfig.OpenseaAPIKey.Reveal())
 }

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/t/utils"
+	"github.com/status-im/status-go/internal/security"
+	"github.com/brianvoe/gofakeit/v6"
 )
 
 func TestNewNodeConfigWithDefaults(t *testing.T) {
@@ -309,8 +311,8 @@ func TestNodeConfigValidate(t *testing.T) {
 
 func TestMarshalWalletConfigJSON(t *testing.T) {
 	walletConfig := params.WalletConfig{
-		OpenseaAPIKey:        "some-key",
-		RaribleMainnetAPIKey: "some-key2",
+		OpenseaAPIKey:        security.NewSensitiveString(gofakeit.LetterN(10)),
+		RaribleMainnetAPIKey: security.NewSensitiveString(gofakeit.LetterN(10)),
 	}
 	bytes, err := json.Marshal(walletConfig)
 	require.NoError(t, err)

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -2,7 +2,6 @@ package params
 
 import (
 	"net/url"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -33,7 +32,7 @@ type RpcProvider struct {
 	ID               int64           `json:"id" validate:"omitempty"`          // Auto-increment ID (for sorting order)
 	ChainID          uint64          `json:"chainId" validate:"required,gt=0"` // Chain ID of the network
 	Name             string          `json:"name" validate:"required,min=1"`   // Provider name for identification
-	URL              string          `json:"url" validate:"required,url"`      // Current Provider URL
+	URL              security.SensitiveString          `json:"url" validate:"required,url"`      // Current Provider URL
 	EnableRPSLimiter bool            `json:"enableRpsLimiter"`                 // Enable RPC rate limiting for this provider
 	Type             RpcProviderType `json:"type" validate:"required,oneof=embedded-proxy embedded-direct user"`
 	Enabled          bool            `json:"enabled"` // Whether the provider is enabled
@@ -45,16 +44,16 @@ type RpcProvider struct {
 }
 
 // GetFullURL returns the URL with auth token if TokenAuth is used
-func (p RpcProvider) GetFullURL() string {
+func (p RpcProvider) GetFullURL() security.SensitiveString {
 	if p.AuthType == TokenAuth && p.AuthToken.NotEmpty() {
-		return strings.TrimRight(p.URL, "/") + "/" + p.AuthToken.Reveal()
+		return p.URL.TrimRight("/").PlusString("/").Plus(p.AuthToken)
 	}
 	return p.URL
 }
 
 // GetHost returns the host from the provider's URL
 func (p RpcProvider) GetHost() string {
-	u, err := url.Parse(p.URL)
+	u, err := url.Parse(p.URL.Reveal())
 	if err != nil {
 		return ""
 	}
@@ -106,7 +105,7 @@ func (n *Network) DeepCopy() Network {
 	return updatedNetwork
 }
 
-func newRpcProvider(chainID uint64, name, url string, enableRpsLimiter bool, providerType RpcProviderType) *RpcProvider {
+func newRpcProvider(chainID uint64, name string, url security.SensitiveString, enableRpsLimiter bool, providerType RpcProviderType) *RpcProvider {
 	return &RpcProvider{
 		ChainID:          chainID,
 		Name:             name,
@@ -118,18 +117,18 @@ func newRpcProvider(chainID uint64, name, url string, enableRpsLimiter bool, pro
 	}
 }
 
-func NewUserProvider(chainID uint64, name, url string, enableRpsLimiter bool) *RpcProvider {
+func NewUserProvider(chainID uint64, name string, url security.SensitiveString, enableRpsLimiter bool) *RpcProvider {
 	return newRpcProvider(chainID, name, url, enableRpsLimiter, UserProviderType)
 }
 
-func NewProxyProvider(chainID uint64, name, url string, enableRpsLimiter bool) *RpcProvider {
+func NewProxyProvider(chainID uint64, name string, url security.SensitiveString, enableRpsLimiter bool) *RpcProvider {
 	return newRpcProvider(chainID, name, url, enableRpsLimiter, EmbeddedProxyProviderType)
 }
 
-func NewEthRpcProxyProvider(chainID uint64, name, url string, enableRpsLimiter bool) *RpcProvider {
+func NewEthRpcProxyProvider(chainID uint64, name string, url security.SensitiveString, enableRpsLimiter bool) *RpcProvider {
 	return newRpcProvider(chainID, name, url, enableRpsLimiter, EmbeddedEthRpcProxyProviderType)
 }
 
-func NewDirectProvider(chainID uint64, name, url string, enableRpsLimiter bool) *RpcProvider {
+func NewDirectProvider(chainID uint64, name string, url security.SensitiveString, enableRpsLimiter bool) *RpcProvider {
 	return newRpcProvider(chainID, name, url, enableRpsLimiter, EmbeddedDirectProviderType)
 }

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -46,7 +46,7 @@ type RpcProvider struct {
 // GetFullURL returns the URL with auth token if TokenAuth is used
 func (p RpcProvider) GetFullURL() security.SensitiveString {
 	if p.AuthType == TokenAuth && p.AuthToken.NotEmpty() {
-		return p.URL.TrimRight("/").Plus("/").Plus(p.AuthToken)
+		return p.URL.TrimRight("/").Append("/", p.AuthToken)
 	}
 	return p.URL
 }

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -45,7 +45,7 @@ type RpcProvider struct {
 
 // GetFullURL returns the URL with auth token if TokenAuth is used
 func (p RpcProvider) GetFullURL() security.SensitiveString {
-	if p.AuthType == TokenAuth && p.AuthToken.NotEmpty() {
+	if p.AuthType == TokenAuth && !p.AuthToken.Empty() {
 		return p.URL.TrimRight("/").Append("/", p.AuthToken)
 	}
 	return p.URL

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -29,18 +29,18 @@ const (
 
 // RpcProvider represents an RPC provider configuration with various options
 type RpcProvider struct {
-	ID               int64           `json:"id" validate:"omitempty"`          // Auto-increment ID (for sorting order)
-	ChainID          uint64          `json:"chainId" validate:"required,gt=0"` // Chain ID of the network
-	Name             string          `json:"name" validate:"required,min=1"`   // Provider name for identification
-	URL              security.SensitiveString          `json:"url" validate:"required,url"`      // Current Provider URL
-	EnableRPSLimiter bool            `json:"enableRpsLimiter"`                 // Enable RPC rate limiting for this provider
-	Type             RpcProviderType `json:"type" validate:"required,oneof=embedded-proxy embedded-direct user"`
-	Enabled          bool            `json:"enabled"` // Whether the provider is enabled
+	ID               int64                    `json:"id" validate:"omitempty"`          // Auto-increment ID (for sorting order)
+	ChainID          uint64                   `json:"chainId" validate:"required,gt=0"` // Chain ID of the network
+	Name             string                   `json:"name" validate:"required,min=1"`   // Provider name for identification
+	URL              security.SensitiveString `json:"url" validate:"required,url"`      // Current Provider URL
+	EnableRPSLimiter bool                     `json:"enableRpsLimiter"`                 // Enable RPC rate limiting for this provider
+	Type             RpcProviderType          `json:"type" validate:"required,oneof=embedded-proxy embedded-direct user"`
+	Enabled          bool                     `json:"enabled"` // Whether the provider is enabled
 	// Authentication
-	AuthType     RpcProviderAuthType `json:"authType" validate:"required,oneof=no-auth basic-auth token-auth"` // Type of authentication
-	AuthLogin    security.SensitiveString              `json:"authLogin" validate:"omitempty,min=1"`                             // Login for BasicAuth (empty string if not used)
-	AuthPassword security.SensitiveString              `json:"authPassword" validate:"omitempty,min=1"`                          // Password for BasicAuth (empty string if not used)
-	AuthToken    security.SensitiveString              `json:"authToken" validate:"omitempty,min=1"`                             // Token for TokenAuth (empty string if not used)
+	AuthType     RpcProviderAuthType      `json:"authType" validate:"required,oneof=no-auth basic-auth token-auth"` // Type of authentication
+	AuthLogin    security.SensitiveString `json:"authLogin" validate:"omitempty,min=1"`                             // Login for BasicAuth (empty string if not used)
+	AuthPassword security.SensitiveString `json:"authPassword" validate:"omitempty,min=1"`                          // Password for BasicAuth (empty string if not used)
+	AuthToken    security.SensitiveString `json:"authToken" validate:"omitempty,min=1"`                             // Token for TokenAuth (empty string if not used)
 }
 
 // GetFullURL returns the URL with auth token if TokenAuth is used

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/status-im/status-go/internal/security"
 )
 
 // RpcProviderAuthType defines the different types of authentication for RPC providers
@@ -37,15 +39,15 @@ type RpcProvider struct {
 	Enabled          bool            `json:"enabled"` // Whether the provider is enabled
 	// Authentication
 	AuthType     RpcProviderAuthType `json:"authType" validate:"required,oneof=no-auth basic-auth token-auth"` // Type of authentication
-	AuthLogin    string              `json:"authLogin" validate:"omitempty,min=1"`                             // Login for BasicAuth (empty string if not used)
-	AuthPassword string              `json:"authPassword" validate:"omitempty,min=1"`                          // Password for BasicAuth (empty string if not used)
-	AuthToken    string              `json:"authToken" validate:"omitempty,min=1"`                             // Token for TokenAuth (empty string if not used)
+	AuthLogin    security.SensitiveString              `json:"authLogin" validate:"omitempty,min=1"`                             // Login for BasicAuth (empty string if not used)
+	AuthPassword security.SensitiveString              `json:"authPassword" validate:"omitempty,min=1"`                          // Password for BasicAuth (empty string if not used)
+	AuthToken    security.SensitiveString              `json:"authToken" validate:"omitempty,min=1"`                             // Token for TokenAuth (empty string if not used)
 }
 
 // GetFullURL returns the URL with auth token if TokenAuth is used
 func (p RpcProvider) GetFullURL() string {
-	if p.AuthType == TokenAuth && p.AuthToken != "" {
-		return strings.TrimRight(p.URL, "/") + "/" + p.AuthToken
+	if p.AuthType == TokenAuth && p.AuthToken.NotEmpty() {
+		return strings.TrimRight(p.URL, "/") + "/" + p.AuthToken.Reveal()
 	}
 	return p.URL
 }

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -46,7 +46,7 @@ type RpcProvider struct {
 // GetFullURL returns the URL with auth token if TokenAuth is used
 func (p RpcProvider) GetFullURL() security.SensitiveString {
 	if p.AuthType == TokenAuth && p.AuthToken.NotEmpty() {
-		return p.URL.TrimRight("/").PlusString("/").Plus(p.AuthToken)
+		return p.URL.TrimRight("/").Plus("/").Plus(p.AuthToken)
 	}
 	return p.URL
 }

--- a/params/network_config_test.go
+++ b/params/network_config_test.go
@@ -1,6 +1,7 @@
 package params_test
 
 import (
+	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	"github.com/status-im/status-go/params"
@@ -9,17 +10,20 @@ import (
 )
 
 func TestRpcProvider_GetHost(t *testing.T) {
-	provider := params.RpcProvider{URL: "https://api.example.com/path"}
+	provider := params.RpcProvider{URL: security.NewSensitiveString("https://api.example.com/path")}
 	expectedHost := "api.example.com"
 	assert.Equal(t, expectedHost, provider.GetHost())
 }
 
 func TestRpcProvider_GetFullURL(t *testing.T) {
-	provider := params.RpcProvider{URL: "https://api.example.com", AuthType: params.TokenAuth, AuthToken: "mytoken"}
+	provider := params.RpcProvider{
+		URL: security.NewSensitiveString("https://api.example.com"),
+		AuthType: params.TokenAuth,
+		AuthToken: security.NewSensitiveString("mytoken")}
 	expectedFullURL := "https://api.example.com/mytoken"
-	assert.Equal(t, expectedFullURL, provider.GetFullURL())
+	assert.Equal(t, expectedFullURL, provider.GetFullURL().Reveal())
 
 	provider.AuthType = params.NoAuth
 	expectedFullURL = "https://api.example.com"
-	assert.Equal(t, expectedFullURL, provider.GetFullURL())
+	assert.Equal(t, expectedFullURL, provider.GetFullURL().Reveal())
 }

--- a/params/network_config_test.go
+++ b/params/network_config_test.go
@@ -1,12 +1,12 @@
 package params_test
 
 import (
-	"github.com/status-im/status-go/internal/security"
 	"testing"
 
-	"github.com/status-im/status-go/params"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/status-im/status-go/internal/security"
+	"github.com/status-im/status-go/params"
 )
 
 func TestRpcProvider_GetHost(t *testing.T) {
@@ -17,9 +17,10 @@ func TestRpcProvider_GetHost(t *testing.T) {
 
 func TestRpcProvider_GetFullURL(t *testing.T) {
 	provider := params.RpcProvider{
-		URL: security.NewSensitiveString("https://api.example.com"),
-		AuthType: params.TokenAuth,
-		AuthToken: security.NewSensitiveString("mytoken")}
+		URL:       security.NewSensitiveString("https://api.example.com"),
+		AuthType:  params.TokenAuth,
+		AuthToken: security.NewSensitiveString("mytoken"),
+	}
 	expectedFullURL := "https://api.example.com/mytoken"
 	assert.Equal(t, expectedFullURL, provider.GetFullURL().Reveal())
 

--- a/params/networkhelper/provider_utils.go
+++ b/params/networkhelper/provider_utils.go
@@ -141,7 +141,7 @@ func OverrideDirectProvidersAuth(networks []params.Network, authTokens map[strin
 			}
 
 			for suffix, token := range authTokens {
-				if strings.HasSuffix(host, suffix) && token.NotEmpty() {
+				if strings.HasSuffix(host, suffix) && !token.Empty() {
 					provider.AuthType = params.TokenAuth
 					provider.AuthToken = token
 					break

--- a/params/networkhelper/provider_utils.go
+++ b/params/networkhelper/provider_utils.go
@@ -135,7 +135,7 @@ func OverrideDirectProvidersAuth(networks []params.Network, authTokens map[strin
 				continue
 			}
 
-			host, err := extractHost(provider.URL)
+			host, err := extractHost(provider.URL.Reveal())
 			if err != nil {
 				continue
 			}

--- a/params/networkhelper/provider_utils.go
+++ b/params/networkhelper/provider_utils.go
@@ -4,9 +4,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/status-im/status-go/rpc/network/db"
-
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/rpc/network/db"
 )
 
 // MergeProvidersPreservingUsersAndEnabledState merges new embedded providers with the current ones,
@@ -95,7 +95,7 @@ func ReplaceEmbeddedProviders(currentProviders, newEmbeddedProviders []params.Rp
 
 // OverrideBasicAuth updates providers of the specified type in the given networks.
 // It sets the `Enabled` flag and configures the `AuthLogin` and `AuthPassword` for each matching provider.
-func OverrideBasicAuth(networks []params.Network, providerType params.RpcProviderType, enabled bool, user, password string) []params.Network {
+func OverrideBasicAuth(networks []params.Network, providerType params.RpcProviderType, enabled bool, user, password security.SensitiveString) []params.Network {
 	updatedNetworks := DeepCopyNetworks(networks)
 
 	for i := range updatedNetworks {
@@ -122,7 +122,7 @@ func DeepCopyNetworks(networks []params.Network) []params.Network {
 	return updatedNetworks
 }
 
-func OverrideDirectProvidersAuth(networks []params.Network, authTokens map[string]string) []params.Network {
+func OverrideDirectProvidersAuth(networks []params.Network, authTokens map[string]security.SensitiveString) []params.Network {
 	updatedNetworks := DeepCopyNetworks(networks)
 
 	for i := range updatedNetworks {
@@ -141,7 +141,7 @@ func OverrideDirectProvidersAuth(networks []params.Network, authTokens map[strin
 			}
 
 			for suffix, token := range authTokens {
-				if strings.HasSuffix(host, suffix) && token != "" {
+				if strings.HasSuffix(host, suffix) && token.NotEmpty() {
 					provider.AuthType = params.TokenAuth
 					provider.AuthToken = token
 					break

--- a/params/networkhelper/provider_utils_test.go
+++ b/params/networkhelper/provider_utils_test.go
@@ -1,7 +1,6 @@
 package networkhelper_test
 
 import (
-	"github.com/status-im/status-go/internal/security"
 	"reflect"
 	"testing"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	api_common "github.com/status-im/status-go/api/common"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/rpc/network/testutil"

--- a/params/networkhelper/provider_utils_test.go
+++ b/params/networkhelper/provider_utils_test.go
@@ -1,8 +1,8 @@
 package networkhelper_test
 
 import (
+	"github.com/status-im/status-go/internal/security"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -22,19 +22,19 @@ func TestMergeProvidersPreserveEnabledAndOrder(t *testing.T) {
 
 	// Current providers with mixed types
 	currentProviders := []params.RpcProvider{
-		*params.NewUserProvider(chainID, "UserProvider1", "https://userprovider1.example.com", true),
-		*params.NewUserProvider(chainID, "UserProvider2", "https://userprovider2.example.com", true),
-		*params.NewDirectProvider(chainID, "EmbeddedProvider1", "https://embeddedprovider1.example.com", true),
-		*params.NewProxyProvider(chainID, "EmbeddedProvider2", "https://embeddedprovider2.example.com", true),
+		*params.NewUserProvider(chainID, "UserProvider1", security.NewSensitiveString("https://userprovider1.example.com"), true),
+		*params.NewUserProvider(chainID, "UserProvider2", security.NewSensitiveString("https://userprovider2.example.com"), true),
+		*params.NewDirectProvider(chainID, "EmbeddedProvider1", security.NewSensitiveString("https://embeddedprovider1.example.com"), true),
+		*params.NewProxyProvider(chainID, "EmbeddedProvider2", security.NewSensitiveString("https://embeddedprovider2.example.com"), true),
 	}
 	currentProviders[1].Enabled = false // UserProvider2 is disabled
 	currentProviders[2].Enabled = false // EmbeddedProvider1 is disabled
 
 	// New providers to merge
 	newProviders := []params.RpcProvider{
-		*params.NewDirectProvider(chainID, "EmbeddedProvider1", "https://embeddedprovider1-new.example.com", true), // Should retain Enabled: false
-		*params.NewProxyProvider(chainID, "EmbeddedProvider3", "https://embeddedprovider3.example.com", true),      // New embedded provider
-		*params.NewDirectProvider(chainID, "EmbeddedProvider4", "https://embeddedprovider4.example.com", true),     // New embedded provider
+		*params.NewDirectProvider(chainID, "EmbeddedProvider1", security.NewSensitiveString("https://embeddedprovider1-new.example.com"), true), // Should retain Enabled: false
+		*params.NewProxyProvider(chainID, "EmbeddedProvider3", security.NewSensitiveString("https://embeddedprovider3.example.com"), true),      // New embedded provider
+		*params.NewDirectProvider(chainID, "EmbeddedProvider4", security.NewSensitiveString("https://embeddedprovider4.example.com"), true),     // New embedded provider
 	}
 
 	// Call MergeProviders
@@ -59,14 +59,14 @@ func TestOverrideBasicAuth(t *testing.T) {
 	// Arrange: Create a sample list of networks with various provider types
 	networks := []params.Network{
 		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			*params.NewUserProvider(api_common.MainnetChainID, "Provider1", "https://userprovider.example.com", true),
-			*params.NewProxyProvider(api_common.MainnetChainID, "Provider2", "https://proxyprovider.example.com", true),
-			*params.NewEthRpcProxyProvider(api_common.MainnetChainID, "Provider3", "https://ethrpcproxy.example.com", true),
+			*params.NewUserProvider(api_common.MainnetChainID, "Provider1", security.NewSensitiveString("https://userprovider.example.com"), true),
+			*params.NewProxyProvider(api_common.MainnetChainID, "Provider2", security.NewSensitiveString("https://proxyprovider.example.com"), true),
+			*params.NewEthRpcProxyProvider(api_common.MainnetChainID, "Provider3", security.NewSensitiveString("https://ethrpcproxy.example.com"), true),
 		}),
 		*testutil.CreateNetwork(api_common.OptimismChainID, "Optimism", []params.RpcProvider{
-			*params.NewDirectProvider(api_common.OptimismChainID, "Provider4", "https://directprovider.example.com", true),
-			*params.NewProxyProvider(api_common.OptimismChainID, "Provider5", "https://proxyprovider2.example.com", true),
-			*params.NewEthRpcProxyProvider(api_common.OptimismChainID, "Provider6", "https://ethrpcproxy2.example.com", true),
+			*params.NewDirectProvider(api_common.OptimismChainID, "Provider4", security.NewSensitiveString("https://directprovider.example.com"), true),
+			*params.NewProxyProvider(api_common.OptimismChainID, "Provider5", security.NewSensitiveString("https://proxyprovider2.example.com"), true),
+			*params.NewEthRpcProxyProvider(api_common.OptimismChainID, "Provider6", security.NewSensitiveString("https://ethrpcproxy2.example.com"), true),
 		}),
 	}
 	networks[0].RpcProviders[1].Enabled = false
@@ -74,8 +74,8 @@ func TestOverrideBasicAuth(t *testing.T) {
 	networks[1].RpcProviders[1].Enabled = false
 	networks[1].RpcProviders[2].Enabled = false
 
-	user := gofakeit.Username()
-	password := gofakeit.LetterN(5)
+	user := security.NewSensitiveString(gofakeit.Username())
+	password := security.NewSensitiveString(gofakeit.LetterN(5))
 
 	// Test updating EmbeddedProxyProviderType providers
 	updatedNetworks := networkhelper.OverrideBasicAuth(networks, params.EmbeddedProxyProviderType, true, user, password)
@@ -102,8 +102,8 @@ func TestOverrideBasicAuth(t *testing.T) {
 	}
 
 	// Test updating EmbeddedEthRpcProxyProviderType providers
-	user2 := gofakeit.Username()
-	password2 := gofakeit.LetterN(5)
+	user2 := security.NewSensitiveString(gofakeit.Username())
+	password2 := security.NewSensitiveString(gofakeit.LetterN(5))
 	updatedNetworks = networkhelper.OverrideBasicAuth(networks, params.EmbeddedEthRpcProxyProviderType, true, user2, password2)
 
 	// Verify the networks
@@ -132,20 +132,20 @@ func TestOverrideDirectProvidersAuth(t *testing.T) {
 	// Create a sample list of networks with various provider types
 	networks := []params.Network{
 		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			*params.NewUserProvider(api_common.MainnetChainID, "Provider1", "https://user.example.com/", true),
-			*params.NewDirectProvider(api_common.MainnetChainID, "Provider2", "https://mainnet.infura.io/v3/", true),
-			*params.NewDirectProvider(api_common.MainnetChainID, "Provider3", "https://eth-archival.rpc.grove.city/v1/", true),
+			*params.NewUserProvider(api_common.MainnetChainID, "Provider1", security.NewSensitiveString("https://user.example.com/"), true),
+			*params.NewDirectProvider(api_common.MainnetChainID, "Provider2", security.NewSensitiveString("https://mainnet.infura.io/v3/"), true),
+			*params.NewDirectProvider(api_common.MainnetChainID, "Provider3", security.NewSensitiveString("https://eth-archival.rpc.grove.city/v1/"), true),
 		}),
 		*testutil.CreateNetwork(api_common.OptimismChainID, "Optimism", []params.RpcProvider{
-			*params.NewDirectProvider(api_common.OptimismChainID, "Provider4", "https://optimism.infura.io/v3/", true),
-			*params.NewDirectProvider(api_common.OptimismChainID, "Provider5", "https://op.grove.city/v1/", true),
+			*params.NewDirectProvider(api_common.OptimismChainID, "Provider4", security.NewSensitiveString("https://optimism.infura.io/v3/"), true),
+			*params.NewDirectProvider(api_common.OptimismChainID, "Provider5", security.NewSensitiveString("https://op.grove.city/v1/"), true),
 		}),
 	}
 
-	authTokens := map[string]string{
-		"infura.io":   gofakeit.UUID(),
-		"grove.city":  gofakeit.UUID(),
-		"example.com": gofakeit.UUID(),
+	authTokens := map[string]security.SensitiveString{
+		"infura.io":   security.NewSensitiveString(gofakeit.UUID()),
+		"grove.city":  security.NewSensitiveString(gofakeit.UUID()),
+		"example.com": security.NewSensitiveString(gofakeit.UUID()),
 	}
 
 	// Call OverrideDirectProvidersAuth
@@ -156,15 +156,15 @@ func TestOverrideDirectProvidersAuth(t *testing.T) {
 		for j, provider := range network.RpcProviders {
 			expectedProvider := networks[i].RpcProviders[j]
 			switch {
-			case strings.Contains(provider.URL, "infura.io"):
+			case provider.URL.Contains("infura.io"):
 				assert.Equal(t, params.TokenAuth, provider.AuthType)
 				assert.Equal(t, authTokens["infura.io"], provider.AuthToken)
 				assert.NotEqual(t, expectedProvider.AuthToken, provider.AuthToken)
-			case strings.Contains(provider.URL, "grove.city"):
+			case provider.URL.Contains("grove.city"):
 				assert.Equal(t, params.TokenAuth, provider.AuthType)
 				assert.Equal(t, authTokens["grove.city"], provider.AuthToken)
 				assert.NotEqual(t, expectedProvider.AuthToken, provider.AuthToken)
-			case strings.Contains(provider.URL, "example.com"):
+			case provider.URL.Contains("example.com"):
 				assert.Equal(t, params.NoAuth, provider.AuthType) // should not update user providers
 			default:
 				assert.Equal(t, expectedProvider.AuthType, provider.AuthType)
@@ -176,8 +176,8 @@ func TestOverrideDirectProvidersAuth(t *testing.T) {
 
 func TestDeepCopyNetwork(t *testing.T) {
 	originalNetwork := testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-		*params.NewUserProvider(api_common.MainnetChainID, "Provider1", "https://userprovider.example.com", true),
-		*params.NewDirectProvider(api_common.MainnetChainID, "Provider2", "https://mainnet.infura.io/v3/", true),
+		*params.NewUserProvider(api_common.MainnetChainID, "Provider1", security.NewSensitiveString("https://userprovider.example.com"), true),
+		*params.NewDirectProvider(api_common.MainnetChainID, "Provider2", security.NewSensitiveString("https://mainnet.infura.io/v3/"), true),
 	})
 
 	originalNetwork.TokenOverrides = []params.TokenOverride{

--- a/params/networkhelper/validate.go
+++ b/params/networkhelper/validate.go
@@ -20,26 +20,26 @@ func rpcProviderStructLevelValidation(sl validator.StructLevel) {
 
 	switch provider.AuthType {
 	case params.NoAuth:
-		if provider.AuthLogin != "" || provider.AuthPassword != "" || provider.AuthToken != "" {
+		if provider.AuthLogin.NotEmpty() || provider.AuthPassword.NotEmpty() || provider.AuthToken.NotEmpty() {
 			sl.ReportError(provider.AuthLogin, "AuthLogin", "authLogin", "noauth_fields_empty", "")
 			sl.ReportError(provider.AuthPassword, "AuthPassword", "authPassword", "noauth_fields_empty", "")
 			sl.ReportError(provider.AuthToken, "AuthToken", "authToken", "noauth_fields_empty", "")
 		}
 	case params.BasicAuth:
-		if provider.AuthLogin == "" {
+		if provider.AuthLogin.Empty() {
 			sl.ReportError(provider.AuthLogin, "AuthLogin", "authLogin", "required", "")
 		}
-		if provider.AuthPassword == "" {
+		if provider.AuthPassword.Empty() {
 			sl.ReportError(provider.AuthPassword, "AuthPassword", "authPassword", "required", "")
 		}
-		if provider.AuthToken != "" {
+		if provider.AuthToken.NotEmpty() {
 			sl.ReportError(provider.AuthToken, "AuthToken", "authToken", "basic_auth_token_empty", "")
 		}
 	case params.TokenAuth:
-		if provider.AuthToken == "" {
+		if provider.AuthToken.Empty() {
 			sl.ReportError(provider.AuthToken, "AuthToken", "authToken", "required", "")
 		}
-		if provider.AuthLogin != "" || provider.AuthPassword != "" {
+		if provider.AuthLogin.NotEmpty() || provider.AuthPassword.NotEmpty() {
 			sl.ReportError(provider.AuthLogin, "AuthLogin", "authLogin", "tokenauth_fields_empty", "")
 			sl.ReportError(provider.AuthPassword, "AuthPassword", "authPassword", "tokenauth_fields_empty", "")
 		}

--- a/params/networkhelper/validate.go
+++ b/params/networkhelper/validate.go
@@ -20,7 +20,7 @@ func rpcProviderStructLevelValidation(sl validator.StructLevel) {
 
 	switch provider.AuthType {
 	case params.NoAuth:
-		if provider.AuthLogin.NotEmpty() || provider.AuthPassword.NotEmpty() || provider.AuthToken.NotEmpty() {
+		if !provider.AuthLogin.Empty() || !provider.AuthPassword.Empty() || !provider.AuthToken.Empty() {
 			sl.ReportError(provider.AuthLogin, "AuthLogin", "authLogin", "noauth_fields_empty", "")
 			sl.ReportError(provider.AuthPassword, "AuthPassword", "authPassword", "noauth_fields_empty", "")
 			sl.ReportError(provider.AuthToken, "AuthToken", "authToken", "noauth_fields_empty", "")
@@ -32,14 +32,14 @@ func rpcProviderStructLevelValidation(sl validator.StructLevel) {
 		if provider.AuthPassword.Empty() {
 			sl.ReportError(provider.AuthPassword, "AuthPassword", "authPassword", "required", "")
 		}
-		if provider.AuthToken.NotEmpty() {
+		if !provider.AuthToken.Empty() {
 			sl.ReportError(provider.AuthToken, "AuthToken", "authToken", "basic_auth_token_empty", "")
 		}
 	case params.TokenAuth:
 		if provider.AuthToken.Empty() {
 			sl.ReportError(provider.AuthToken, "AuthToken", "authToken", "required", "")
 		}
-		if provider.AuthLogin.NotEmpty() || provider.AuthPassword.NotEmpty() {
+		if !provider.AuthLogin.Empty() || !provider.AuthPassword.Empty() {
 			sl.ReportError(provider.AuthLogin, "AuthLogin", "authLogin", "tokenauth_fields_empty", "")
 			sl.ReportError(provider.AuthPassword, "AuthPassword", "authPassword", "tokenauth_fields_empty", "")
 		}

--- a/params/networkhelper/validate_test.go
+++ b/params/networkhelper/validate_test.go
@@ -1,16 +1,15 @@
 package networkhelper_test
 
 import (
-	"github.com/status-im/status-go/internal/security"
 	"testing"
-
-	"github.com/status-im/status-go/params/networkhelper"
 
 	"github.com/stretchr/testify/require"
 
 	"gopkg.in/go-playground/validator.v9"
 
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/params/networkhelper"
 )
 
 func TestValidation(t *testing.T) {

--- a/params/networkhelper/validate_test.go
+++ b/params/networkhelper/validate_test.go
@@ -1,6 +1,7 @@
 package networkhelper_test
 
 import (
+	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	"github.com/status-im/status-go/params/networkhelper"
@@ -26,7 +27,7 @@ func TestValidation(t *testing.T) {
 			provider: params.RpcProvider{
 				ChainID:          1,
 				Name:             "Mainnet Provider",
-				URL:              "https://provider.example.com",
+				URL:              security.NewSensitiveString("https://provider.example.com"),
 				Type:             params.UserProviderType,
 				Enabled:          true,
 				AuthType:         params.NoAuth,
@@ -38,7 +39,7 @@ func TestValidation(t *testing.T) {
 			name: "Missing Provider Name",
 			provider: params.RpcProvider{
 				ChainID: 1,
-				URL:     "https://provider.example.com",
+				URL:     security.NewSensitiveString("https://provider.example.com"),
 				Type:    params.UserProviderType,
 			},
 			expectErr: true,
@@ -48,7 +49,7 @@ func TestValidation(t *testing.T) {
 			provider: params.RpcProvider{
 				ChainID:  1,
 				Name:     "Invalid Auth Provider",
-				URL:      "https://provider.example.com",
+				URL:      security.NewSensitiveString("https://provider.example.com"),
 				Type:     params.UserProviderType,
 				AuthType: "invalid-auth-type",
 			},
@@ -59,7 +60,7 @@ func TestValidation(t *testing.T) {
 			provider: params.RpcProvider{
 				ChainID:  1,
 				Name:     "BasicAuth Provider",
-				URL:      "https://provider.example.com",
+				URL:      security.NewSensitiveString("https://provider.example.com"),
 				Type:     params.UserProviderType,
 				AuthType: params.BasicAuth,
 			},
@@ -70,7 +71,7 @@ func TestValidation(t *testing.T) {
 			provider: params.RpcProvider{
 				ChainID:  1,
 				Name:     "TokenAuth Provider",
-				URL:      "https://provider.example.com",
+				URL:      security.NewSensitiveString("https://provider.example.com"),
 				Type:     params.UserProviderType,
 				AuthType: params.TokenAuth,
 			},
@@ -81,10 +82,10 @@ func TestValidation(t *testing.T) {
 			provider: params.RpcProvider{
 				ChainID:   1,
 				Name:      "NoAuth Provider",
-				URL:       "https://provider.example.com",
+				URL:       security.NewSensitiveString("https://provider.example.com"),
 				Type:      params.UserProviderType,
 				AuthType:  params.NoAuth,
-				AuthLogin: "user",
+				AuthLogin: security.NewSensitiveString("user"),
 			},
 			expectErr: true,
 		},
@@ -129,7 +130,7 @@ func TestNetworkValidation(t *testing.T) {
 					{
 						ChainID:  1,
 						Name:     "Mainnet Provider",
-						URL:      "https://provider.example.com",
+						URL:      security.NewSensitiveString("https://provider.example.com"),
 						Type:     params.UserProviderType,
 						Enabled:  true,
 						AuthType: params.NoAuth,
@@ -146,7 +147,7 @@ func TestNetworkValidation(t *testing.T) {
 					{
 						ChainID: 1,
 						Name:    "Mainnet Provider",
-						URL:     "https://provider.example.com",
+						URL:     security.NewSensitiveString("https://provider.example.com"),
 						Type:    params.UserProviderType,
 						Enabled: true,
 					},
@@ -163,7 +164,7 @@ func TestNetworkValidation(t *testing.T) {
 					{
 						ChainID: 1,
 						Name:    "",
-						URL:     "https://provider.example.com",
+						URL:     security.NewSensitiveString("https://provider.example.com"),
 						Type:    params.UserProviderType,
 						Enabled: true,
 					},

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/mutecomm/go-sqlcipher/v4" // require go-sqlcipher that overrides default implementation
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+
 	"github.com/status-im/status-go/internal/security"
 )
 

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/mutecomm/go-sqlcipher/v4" // require go-sqlcipher that overrides default implementation
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	"github.com/status-im/status-go/internal/security"
 )
 
 func TestManagerSuite(t *testing.T) {
@@ -220,7 +221,7 @@ func (s *ManagerSuite) setupManagerForTokenPermissions() (*Manager, *testCollect
 
 	options := []ManagerOption{
 		WithWalletConfig(&params.WalletConfig{
-			OpenseaAPIKey: "some-key",
+			OpenseaAPIKey: security.NewSensitiveString("some-key"),
 		}),
 		WithCollectiblesManager(cm),
 		WithTokenManager(tm),

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -4,8 +4,8 @@ import (
 	"github.com/pkg/errors"
 
 	utils "github.com/status-im/status-go/common"
-	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/internal/security"
+	"github.com/status-im/status-go/params"
 )
 
 var ErrCreateAccountInvalidDisplayName = errors.New("create-account: invalid display name")
@@ -113,7 +113,7 @@ type WalletSecretsConfig struct {
 	AlchemyBaseMainnetToken     security.SensitiveString `json:"alchemyBaseMainnetToken"`
 	AlchemyBaseSepoliaToken     security.SensitiveString `json:"alchemyBaseSepoliaToken"`
 
-	StatusProxyStageName      string `json:"statusProxyStageName"`
+	StatusProxyStageName      string                   `json:"statusProxyStageName"`
 	StatusProxyMarketUser     security.SensitiveString `json:"statusProxyMarketUser"`
 	StatusProxyMarketPassword security.SensitiveString `json:"statusProxyMarketPassword"`
 

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -5,6 +5,7 @@ import (
 
 	utils "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/internal/security"
 )
 
 var ErrCreateAccountInvalidDisplayName = errors.New("create-account: invalid display name")
@@ -96,36 +97,36 @@ type WalletConfig struct {
 	MarketDataPriceRefreshInterval      int `json:"marketDataPriceRefreshInterval"`      // in seconds
 }
 type WalletSecretsConfig struct {
-	PoktToken            string `json:"poktToken"`
-	InfuraToken          string `json:"infuraToken"`
-	InfuraSecret         string `json:"infuraSecret"`
-	OpenseaAPIKey        string `json:"openseaApiKey"`
-	RaribleMainnetAPIKey string `json:"raribleMainnetApiKey"`
-	RaribleTestnetAPIKey string `json:"raribleTestnetApiKey"`
+	PoktToken            security.SensitiveString `json:"poktToken"`
+	InfuraToken          security.SensitiveString `json:"infuraToken"`
+	InfuraSecret         security.SensitiveString `json:"infuraSecret"`
+	OpenseaAPIKey        security.SensitiveString `json:"openseaApiKey"`
+	RaribleMainnetAPIKey security.SensitiveString `json:"raribleMainnetApiKey"`
+	RaribleTestnetAPIKey security.SensitiveString `json:"raribleTestnetApiKey"`
 
-	AlchemyEthereumMainnetToken string `json:"alchemyEthereumMainnetToken"`
-	AlchemyEthereumSepoliaToken string `json:"alchemyEthereumSepoliaToken"`
-	AlchemyArbitrumMainnetToken string `json:"alchemyArbitrumMainnetToken"`
-	AlchemyArbitrumSepoliaToken string `json:"alchemyArbitrumSepoliaToken"`
-	AlchemyOptimismMainnetToken string `json:"alchemyOptimismMainnetToken"`
-	AlchemyOptimismSepoliaToken string `json:"alchemyOptimismSepoliaToken"`
-	AlchemyBaseMainnetToken     string `json:"alchemyBaseMainnetToken"`
-	AlchemyBaseSepoliaToken     string `json:"alchemyBaseSepoliaToken"`
+	AlchemyEthereumMainnetToken security.SensitiveString `json:"alchemyEthereumMainnetToken"`
+	AlchemyEthereumSepoliaToken security.SensitiveString `json:"alchemyEthereumSepoliaToken"`
+	AlchemyArbitrumMainnetToken security.SensitiveString `json:"alchemyArbitrumMainnetToken"`
+	AlchemyArbitrumSepoliaToken security.SensitiveString `json:"alchemyArbitrumSepoliaToken"`
+	AlchemyOptimismMainnetToken security.SensitiveString `json:"alchemyOptimismMainnetToken"`
+	AlchemyOptimismSepoliaToken security.SensitiveString `json:"alchemyOptimismSepoliaToken"`
+	AlchemyBaseMainnetToken     security.SensitiveString `json:"alchemyBaseMainnetToken"`
+	AlchemyBaseSepoliaToken     security.SensitiveString `json:"alchemyBaseSepoliaToken"`
 
 	StatusProxyStageName      string `json:"statusProxyStageName"`
-	StatusProxyMarketUser     string `json:"statusProxyMarketUser"`
-	StatusProxyMarketPassword string `json:"statusProxyMarketPassword"`
+	StatusProxyMarketUser     security.SensitiveString `json:"statusProxyMarketUser"`
+	StatusProxyMarketPassword security.SensitiveString `json:"statusProxyMarketPassword"`
 
 	MarketDataProxyUrl      string `json:"marketDataProxyUrl"`
 	MarketDataProxyUser     string `json:"marketDataProxyUser"`
 	MarketDataProxyPassword string `json:"marketDataProxyPassword"`
 	// FIXME: remove when EthRpcProxy* is integrated
-	StatusProxyBlockchainUser     string `json:"statusProxyBlockchainUser"`
-	StatusProxyBlockchainPassword string `json:"statusProxyBlockchainPassword"`
+	StatusProxyBlockchainUser     security.SensitiveString `json:"statusProxyBlockchainUser"`
+	StatusProxyBlockchainPassword security.SensitiveString `json:"statusProxyBlockchainPassword"`
 
-	EthRpcProxyUrl      string `json:"ethRpcProxyUrl"`
-	EthRpcProxyUser     string `json:"ethRpcProxyUser"`
-	EthRpcProxyPassword string `json:"ethRpcProxyPassword"`
+	EthRpcProxyUrl      security.SensitiveString `json:"ethRpcProxyUrl"`
+	EthRpcProxyUser     security.SensitiveString `json:"ethRpcProxyUser"`
+	EthRpcProxyPassword security.SensitiveString `json:"ethRpcProxyPassword"`
 }
 
 func (c *CreateAccount) Validate(validation *CreateAccountValidation) error {

--- a/rpc/chain/client_utils.go
+++ b/rpc/chain/client_utils.go
@@ -24,7 +24,7 @@ func CreateEthClientFromProvider(provider params.RpcProvider, rpcUserAgentName s
 	// Set up authentication if needed
 	switch provider.AuthType {
 	case params.BasicAuth:
-		authEncoded := base64.StdEncoding.EncodeToString([]byte(provider.AuthLogin.PlusString(":").Plus(provider.AuthPassword).Reveal()))
+		authEncoded := base64.StdEncoding.EncodeToString([]byte(provider.AuthLogin.Plus(":").Plus(provider.AuthPassword).Reveal()))
 		headers.Set("Authorization", "Basic "+authEncoded)
 	case params.TokenAuth:
 		provider.URL = provider.URL.Plus(provider.AuthToken)

--- a/rpc/chain/client_utils.go
+++ b/rpc/chain/client_utils.go
@@ -24,10 +24,10 @@ func CreateEthClientFromProvider(provider params.RpcProvider, rpcUserAgentName s
 	// Set up authentication if needed
 	switch provider.AuthType {
 	case params.BasicAuth:
-		authEncoded := base64.StdEncoding.EncodeToString([]byte(provider.AuthLogin + ":" + provider.AuthPassword))
+		authEncoded := base64.StdEncoding.EncodeToString([]byte(provider.AuthLogin.PlusString(":").Plus(provider.AuthPassword).Reveal()))
 		headers.Set("Authorization", "Basic "+authEncoded)
 	case params.TokenAuth:
-		provider.URL = provider.URL + provider.AuthToken
+		provider.URL = provider.URL + provider.AuthToken.Reveal()
 	case params.NoAuth:
 		// no-op
 	default:

--- a/rpc/chain/client_utils.go
+++ b/rpc/chain/client_utils.go
@@ -24,10 +24,10 @@ func CreateEthClientFromProvider(provider params.RpcProvider, rpcUserAgentName s
 	// Set up authentication if needed
 	switch provider.AuthType {
 	case params.BasicAuth:
-		authEncoded := base64.StdEncoding.EncodeToString([]byte(provider.AuthLogin.Plus(":").Plus(provider.AuthPassword).Reveal()))
+		authEncoded := base64.StdEncoding.EncodeToString([]byte(provider.AuthLogin.Append(":", provider.AuthPassword).Reveal()))
 		headers.Set("Authorization", "Basic "+authEncoded)
 	case params.TokenAuth:
-		provider.URL = provider.URL.Plus(provider.AuthToken)
+		provider.URL = provider.URL.Append(provider.AuthToken)
 	case params.NoAuth:
 		// no-op
 	default:

--- a/rpc/chain/client_utils.go
+++ b/rpc/chain/client_utils.go
@@ -27,7 +27,7 @@ func CreateEthClientFromProvider(provider params.RpcProvider, rpcUserAgentName s
 		authEncoded := base64.StdEncoding.EncodeToString([]byte(provider.AuthLogin.PlusString(":").Plus(provider.AuthPassword).Reveal()))
 		headers.Set("Authorization", "Basic "+authEncoded)
 	case params.TokenAuth:
-		provider.URL = provider.URL + provider.AuthToken.Reveal()
+		provider.URL = provider.URL.Plus(provider.AuthToken)
 	case params.NoAuth:
 		// no-op
 	default:
@@ -37,7 +37,7 @@ func CreateEthClientFromProvider(provider params.RpcProvider, rpcUserAgentName s
 	opts = append(opts, rpc.WithHeaders(headers))
 
 	// Dial the RPC client
-	rpcClient, err := rpc.DialOptions(context.Background(), provider.URL, opts...)
+	rpcClient, err := rpc.DialOptions(context.Background(), provider.URL.Reveal(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("dial server failed for provider %s: %w", provider.Name, err)
 	}

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -154,7 +154,7 @@ func TestGetClientsUsingCache(t *testing.T) {
 			providers = append(providers, params.RpcProvider{
 				Name:         fmt.Sprintf("Provider%d", i+1),
 				ChainID:      1,
-				URL:          security.NewSensitiveString(baseURL).PlusString(path),
+				URL:          security.NewSensitiveString(baseURL).Plus(path),
 				Type:         params.EmbeddedProxyProviderType,
 				AuthType:     params.BasicAuth,
 				AuthLogin:    security.NewSensitiveString("incorrectUser"),

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -154,7 +154,7 @@ func TestGetClientsUsingCache(t *testing.T) {
 			providers = append(providers, params.RpcProvider{
 				Name:         fmt.Sprintf("Provider%d", i+1),
 				ChainID:      1,
-				URL:          security.NewSensitiveString(baseURL).Plus(path),
+				URL:          security.NewSensitiveString(baseURL).Append(path),
 				Type:         params.EmbeddedProxyProviderType,
 				AuthType:     params.BasicAuth,
 				AuthLogin:    security.NewSensitiveString("incorrectUser"),

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
-	"github.com/status-im/status-go/internal/security"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -13,14 +12,14 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/status-im/status-go/params/networkhelper"
-
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/t/helpers"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -179,7 +178,7 @@ func TestGetClientsUsingCache(t *testing.T) {
 		params.EmbeddedProxyProviderType,
 		true,
 		security.NewSensitiveString(user),
-			security.NewSensitiveString(password))
+		security.NewSensitiveString(password))
 
 	config := ClientConfig{
 		Client:          nil,

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
+	"github.com/status-im/status-go/internal/security"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -154,11 +155,11 @@ func TestGetClientsUsingCache(t *testing.T) {
 			providers = append(providers, params.RpcProvider{
 				Name:         fmt.Sprintf("Provider%d", i+1),
 				ChainID:      1,
-				URL:          baseURL + path,
+				URL:          security.NewSensitiveString(baseURL).PlusString(path),
 				Type:         params.EmbeddedProxyProviderType,
 				AuthType:     params.BasicAuth,
-				AuthLogin:    "incorrectUser",
-				AuthPassword: "incorrectPwd", // will be replaced by correct values by OverrideBasicAuth
+				AuthLogin:    security.NewSensitiveString("incorrectUser"),
+				AuthPassword: security.NewSensitiveString("incorrectPwd"), // will be replaced by correct values by OverrideBasicAuth
 				Enabled:      true,
 			})
 		}
@@ -173,7 +174,12 @@ func TestGetClientsUsingCache(t *testing.T) {
 		},
 	}
 
-	networks = networkhelper.OverrideBasicAuth(networks, params.EmbeddedProxyProviderType, true, user, password)
+	networks = networkhelper.OverrideBasicAuth(
+		networks,
+		params.EmbeddedProxyProviderType,
+		true,
+		security.NewSensitiveString(user),
+			security.NewSensitiveString(password))
 
 	config := ClientConfig{
 		Client:          nil,

--- a/rpc/network/db/network_db_test.go
+++ b/rpc/network/db/network_db_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"database/sql"
+	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -47,7 +48,7 @@ func DefaultProviders(chainID uint64) []params.RpcProvider {
 		{
 			Name:     "Provider1",
 			ChainID:  chainID,
-			URL:      "https://rpc.provider1.io",
+			URL:      security.NewSensitiveString("https://rpc.provider1.io"),
 			Type:     params.UserProviderType,
 			Enabled:  true,
 			AuthType: params.NoAuth,
@@ -55,12 +56,12 @@ func DefaultProviders(chainID uint64) []params.RpcProvider {
 		{
 			Name:         "Provider2",
 			ChainID:      chainID,
-			URL:          "https://rpc.provider2.io",
+			URL:          security.NewSensitiveString("https://rpc.provider2.io"),
 			Type:         params.EmbeddedProxyProviderType,
 			Enabled:      true,
 			AuthType:     params.BasicAuth,
-			AuthLogin:    "user1",
-			AuthPassword: "password1",
+			AuthLogin:    security.NewSensitiveString("user1"),
+			AuthPassword: security.NewSensitiveString("password1"),
 		},
 	}
 }
@@ -99,8 +100,8 @@ func (s *NetworksPersistenceTestSuite) verifyNetworkDeletion(chainID uint64) {
 
 func (s *NetworksPersistenceTestSuite) TestAddAndGetNetworkWithProviders() {
 	network := testutil.CreateNetwork(api_common.OptimismChainID, "Optimism Mainnet", []params.RpcProvider{
-		testutil.CreateProvider(api_common.OptimismChainID, "Provider1", params.UserProviderType, true, "https://rpc.optimism.io"),
-		testutil.CreateProvider(api_common.OptimismChainID, "Provider2", params.EmbeddedProxyProviderType, false, "https://backup.optimism.io"),
+		testutil.CreateProvider(api_common.OptimismChainID, "Provider1", params.UserProviderType, true, security.NewSensitiveString("https://rpc.optimism.io")),
+		testutil.CreateProvider(api_common.OptimismChainID, "Provider2", params.EmbeddedProxyProviderType, false, security.NewSensitiveString("https://backup.optimism.io")),
 	})
 	s.addAndVerifyNetworks([]*params.Network{network})
 }
@@ -122,7 +123,7 @@ func (s *NetworksPersistenceTestSuite) TestUpdateNetworkAndProviders() {
 	// Update fields
 	network.ChainName = "Updated Optimism Mainnet"
 	network.RpcProviders = []params.RpcProvider{
-		testutil.CreateProvider(api_common.OptimismChainID, "UpdatedProvider", params.UserProviderType, true, "https://rpc.optimism.updated.io"),
+		testutil.CreateProvider(api_common.OptimismChainID, "UpdatedProvider", params.UserProviderType, true, security.NewSensitiveString("https://rpc.optimism.updated.io")),
 	}
 
 	s.addAndVerifyNetworks([]*params.Network{network})
@@ -171,7 +172,7 @@ func (s *NetworksPersistenceTestSuite) TestValidationForNetworksAndProviders() {
 	invalidProvider := params.RpcProvider{
 		Name:    "InvalidProvider",
 		ChainID: api_common.MainnetChainID,
-		URL:     "", // Invalid
+		URL:     security.NewSensitiveString(""), // Invalid
 		Type:    params.UserProviderType,
 		Enabled: true,
 	}

--- a/rpc/network/db/network_db_test.go
+++ b/rpc/network/db/network_db_test.go
@@ -2,7 +2,6 @@ package db_test
 
 import (
 	"database/sql"
-	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,6 +9,7 @@ import (
 
 	api_common "github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc/network/db"
 	"github.com/status-im/status-go/rpc/network/testutil"

--- a/rpc/network/db/rpc_provider_db.go
+++ b/rpc/network/db/rpc_provider_db.go
@@ -6,6 +6,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"gopkg.in/go-playground/validator.v9"
 
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/sqlite"
 )
@@ -68,22 +69,31 @@ func (p *RpcProvidersPersistence) GetRpcProviders(chainID uint64) ([]params.RpcP
 	var providers []params.RpcProvider
 	for rows.Next() {
 		var provider params.RpcProvider
+		var url, authLogin, authPassword, authToken string
+
 		err := rows.Scan(
 			&provider.ID,
 			&provider.ChainID,
 			&provider.Name,
-			&provider.URL,
+			&url,
 			&provider.EnableRPSLimiter,
 			&provider.Type,
 			&provider.Enabled,
 			&provider.AuthType,
-			&provider.AuthLogin,
-			&provider.AuthPassword,
-			&provider.AuthToken,
+			&authLogin,
+			&authPassword,
+			&authToken,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
+
+		// Convert strings to SensitiveString
+		provider.URL = security.NewSensitiveString(url)
+		provider.AuthLogin = security.NewSensitiveString(authLogin)
+		provider.AuthPassword = security.NewSensitiveString(authPassword)
+		provider.AuthToken = security.NewSensitiveString(authToken)
+
 		providers = append(providers, provider)
 	}
 
@@ -118,6 +128,12 @@ func (p *RpcProvidersPersistence) AddRpcProvider(provider params.RpcProvider) er
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
+	// Extract values from SensitiveString fields
+	url := provider.URL.Reveal()
+	authLogin := provider.AuthLogin.Reveal()
+	authPassword := provider.AuthPassword.Reveal()
+	authToken := provider.AuthToken.Reveal()
+
 	// Proceed with adding the provider to the database
 	q := sq.Insert("rpc_providers").
 		Columns(
@@ -135,14 +151,14 @@ func (p *RpcProvidersPersistence) AddRpcProvider(provider params.RpcProvider) er
 		Values(
 			provider.ChainID,
 			provider.Name,
-			provider.URL,
+			url,
 			provider.EnableRPSLimiter,
 			provider.Type,
 			provider.Enabled,
 			provider.AuthType,
-			provider.AuthLogin,
-			provider.AuthPassword,
-			provider.AuthToken,
+			authLogin,
+			authPassword,
+			authToken,
 		)
 
 	query, args, err := q.ToSql()
@@ -200,17 +216,23 @@ func (p *RpcProvidersPersistence) UpdateRpcProvider(provider params.RpcProvider)
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
+	// Extract values from SensitiveString fields
+	url := provider.URL.Reveal()
+	authLogin := provider.AuthLogin.Reveal()
+	authPassword := provider.AuthPassword.Reveal()
+	authToken := provider.AuthToken.Reveal()
+
 	// Proceed with updating the provider in the database
 	q := sq.Update("rpc_providers").
 		SetMap(sq.Eq{
-			"url":                provider.URL,
+			"url":                url,
 			"enable_rps_limiter": provider.EnableRPSLimiter,
 			"type":               provider.Type,
 			"enabled":            provider.Enabled,
 			"auth_type":          provider.AuthType,
-			"auth_login":         provider.AuthLogin,
-			"auth_password":      provider.AuthPassword,
-			"auth_token":         provider.AuthToken,
+			"auth_login":         authLogin,
+			"auth_password":      authPassword,
+			"auth_token":         authToken,
 		}).
 		Where(sq.Eq{"id": provider.ID})
 

--- a/rpc/network/db/rpc_provider_db.go
+++ b/rpc/network/db/rpc_provider_db.go
@@ -6,7 +6,6 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"gopkg.in/go-playground/validator.v9"
 
-	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/sqlite"
 )
@@ -69,30 +68,23 @@ func (p *RpcProvidersPersistence) GetRpcProviders(chainID uint64) ([]params.RpcP
 	var providers []params.RpcProvider
 	for rows.Next() {
 		var provider params.RpcProvider
-		var url, authLogin, authPassword, authToken string
 
 		err := rows.Scan(
 			&provider.ID,
 			&provider.ChainID,
 			&provider.Name,
-			&url,
+			&provider.URL,
 			&provider.EnableRPSLimiter,
 			&provider.Type,
 			&provider.Enabled,
 			&provider.AuthType,
-			&authLogin,
-			&authPassword,
-			&authToken,
+			&provider.AuthLogin,
+			&provider.AuthPassword,
+			&provider.AuthToken,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
-
-		// Convert strings to SensitiveString
-		provider.URL = security.NewSensitiveString(url)
-		provider.AuthLogin = security.NewSensitiveString(authLogin)
-		provider.AuthPassword = security.NewSensitiveString(authPassword)
-		provider.AuthToken = security.NewSensitiveString(authToken)
 
 		providers = append(providers, provider)
 	}
@@ -128,12 +120,6 @@ func (p *RpcProvidersPersistence) AddRpcProvider(provider params.RpcProvider) er
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
-	// Extract values from SensitiveString fields
-	url := provider.URL.Reveal()
-	authLogin := provider.AuthLogin.Reveal()
-	authPassword := provider.AuthPassword.Reveal()
-	authToken := provider.AuthToken.Reveal()
-
 	// Proceed with adding the provider to the database
 	q := sq.Insert("rpc_providers").
 		Columns(
@@ -151,14 +137,14 @@ func (p *RpcProvidersPersistence) AddRpcProvider(provider params.RpcProvider) er
 		Values(
 			provider.ChainID,
 			provider.Name,
-			url,
+			provider.URL,
 			provider.EnableRPSLimiter,
 			provider.Type,
 			provider.Enabled,
 			provider.AuthType,
-			authLogin,
-			authPassword,
-			authToken,
+			provider.AuthLogin,
+			provider.AuthPassword,
+			provider.AuthToken,
 		)
 
 	query, args, err := q.ToSql()
@@ -216,23 +202,17 @@ func (p *RpcProvidersPersistence) UpdateRpcProvider(provider params.RpcProvider)
 		return fmt.Errorf("validation failed: %w", err)
 	}
 
-	// Extract values from SensitiveString fields
-	url := provider.URL.Reveal()
-	authLogin := provider.AuthLogin.Reveal()
-	authPassword := provider.AuthPassword.Reveal()
-	authToken := provider.AuthToken.Reveal()
-
 	// Proceed with updating the provider in the database
 	q := sq.Update("rpc_providers").
 		SetMap(sq.Eq{
-			"url":                url,
+			"url":                provider.URL,
 			"enable_rps_limiter": provider.EnableRPSLimiter,
 			"type":               provider.Type,
 			"enabled":            provider.Enabled,
 			"auth_type":          provider.AuthType,
-			"auth_login":         authLogin,
-			"auth_password":      authPassword,
-			"auth_token":         authToken,
+			"auth_login":         provider.AuthLogin,
+			"auth_password":      provider.AuthPassword,
+			"auth_token":         provider.AuthToken,
 		}).
 		Where(sq.Eq{"id": provider.ID})
 

--- a/rpc/network/db/rpc_provider_db_test.go
+++ b/rpc/network/db/rpc_provider_db_test.go
@@ -2,7 +2,6 @@ package db_test
 
 import (
 	"database/sql"
-	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,6 +9,7 @@ import (
 
 	api_common "github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc/network/db"
 	"github.com/status-im/status-go/rpc/network/testutil"
@@ -146,10 +146,10 @@ func (s *RpcProviderPersistenceTestSuite) TestSetRpcProviders() {
 
 func (s *RpcProviderPersistenceTestSuite) TestAddRpcProviderValidation() {
 	invalidProvider := params.RpcProvider{
-		ChainID: 0,              // Invalid: must be greater than 0
-		Name:    "",             // Invalid: cannot be empty
-		URL:     security.NewSensitiveString("invalid-url"),  // Invalid: not a valid URL
-		Type:    "invalid-type", // Invalid: not in allowed values
+		ChainID: 0,                                          // Invalid: must be greater than 0
+		Name:    "",                                         // Invalid: cannot be empty
+		URL:     security.NewSensitiveString("invalid-url"), // Invalid: not a valid URL
+		Type:    "invalid-type",                             // Invalid: not in allowed values
 	}
 
 	err := s.rpcPersistence.AddRpcProvider(invalidProvider)

--- a/rpc/network/db/rpc_provider_db_test.go
+++ b/rpc/network/db/rpc_provider_db_test.go
@@ -2,6 +2,7 @@ package db_test
 
 import (
 	"database/sql"
+	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,7 +42,7 @@ func TestRpcProviderPersistenceTestSuite(t *testing.T) {
 // Test cases
 
 func (s *RpcProviderPersistenceTestSuite) TestAddAndGetRpcProvider() {
-	provider := testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com")
+	provider := testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, security.NewSensitiveString("https://provider1.example.com"))
 
 	err := s.rpcPersistence.AddRpcProvider(provider)
 	s.Require().NoError(err)
@@ -54,10 +55,10 @@ func (s *RpcProviderPersistenceTestSuite) TestAddAndGetRpcProvider() {
 
 func (s *RpcProviderPersistenceTestSuite) TestGetRpcProvidersByType() {
 	providers := []params.RpcProvider{
-		testutil.CreateProvider(api_common.MainnetChainID, "UserProvider1", params.UserProviderType, true, "https://provider1.example.com"),
-		testutil.CreateProvider(api_common.MainnetChainID, "EmbeddedDirect1", params.EmbeddedDirectProviderType, false, "https://provider2.example.com"),
-		testutil.CreateProvider(api_common.MainnetChainID, "UserProvider2", params.UserProviderType, false, "https://provider3.example.com"),
-		testutil.CreateProvider(api_common.MainnetChainID, "EmbeddedProxy1", params.EmbeddedProxyProviderType, true, "https://provider4.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "UserProvider1", params.UserProviderType, true, security.NewSensitiveString("https://provider1.example.com")),
+		testutil.CreateProvider(api_common.MainnetChainID, "EmbeddedDirect1", params.EmbeddedDirectProviderType, false, security.NewSensitiveString("https://provider2.example.com")),
+		testutil.CreateProvider(api_common.MainnetChainID, "UserProvider2", params.UserProviderType, false, security.NewSensitiveString("https://provider3.example.com")),
+		testutil.CreateProvider(api_common.MainnetChainID, "EmbeddedProxy1", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://provider4.example.com")),
 	}
 
 	for _, provider := range providers {
@@ -80,7 +81,7 @@ func (s *RpcProviderPersistenceTestSuite) TestGetRpcProvidersByType() {
 }
 
 func (s *RpcProviderPersistenceTestSuite) TestDeleteRpcProviders() {
-	provider := testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com")
+	provider := testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, security.NewSensitiveString("https://provider1.example.com"))
 
 	err := s.rpcPersistence.AddRpcProvider(provider)
 	s.Require().NoError(err)
@@ -95,7 +96,7 @@ func (s *RpcProviderPersistenceTestSuite) TestDeleteRpcProviders() {
 }
 
 func (s *RpcProviderPersistenceTestSuite) TestUpdateRpcProvider() {
-	provider := testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com")
+	provider := testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, security.NewSensitiveString("https://provider1.example.com"))
 
 	err := s.rpcPersistence.AddRpcProvider(provider)
 	s.Require().NoError(err)
@@ -106,7 +107,7 @@ func (s *RpcProviderPersistenceTestSuite) TestUpdateRpcProvider() {
 	s.Require().Len(providers, 1)
 
 	provider.ID = providers[0].ID
-	provider.URL = "https://provider1-updated.example.com"
+	provider.URL = security.NewSensitiveString("https://provider1-updated.example.com")
 	provider.EnableRPSLimiter = false
 
 	err = s.rpcPersistence.UpdateRpcProvider(provider)
@@ -120,8 +121,8 @@ func (s *RpcProviderPersistenceTestSuite) TestUpdateRpcProvider() {
 
 func (s *RpcProviderPersistenceTestSuite) TestSetRpcProviders() {
 	initialProviders := []params.RpcProvider{
-		testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com"),
-		testutil.CreateProvider(api_common.MainnetChainID, "Provider2", params.EmbeddedDirectProviderType, false, "https://provider2.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, security.NewSensitiveString("https://provider1.example.com")),
+		testutil.CreateProvider(api_common.MainnetChainID, "Provider2", params.EmbeddedDirectProviderType, false, security.NewSensitiveString("https://provider2.example.com")),
 	}
 
 	for _, provider := range initialProviders {
@@ -130,8 +131,8 @@ func (s *RpcProviderPersistenceTestSuite) TestSetRpcProviders() {
 	}
 
 	newProviders := []params.RpcProvider{
-		testutil.CreateProvider(api_common.MainnetChainID, "NewProvider1", params.UserProviderType, true, "https://newprovider1.example.com"),
-		testutil.CreateProvider(api_common.MainnetChainID, "NewProvider2", params.EmbeddedProxyProviderType, true, "https://newprovider2.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "NewProvider1", params.UserProviderType, true, security.NewSensitiveString("https://newprovider1.example.com")),
+		testutil.CreateProvider(api_common.MainnetChainID, "NewProvider2", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://newprovider2.example.com")),
 	}
 
 	err := s.rpcPersistence.SetRpcProviders(api_common.MainnetChainID, newProviders)
@@ -147,7 +148,7 @@ func (s *RpcProviderPersistenceTestSuite) TestAddRpcProviderValidation() {
 	invalidProvider := params.RpcProvider{
 		ChainID: 0,              // Invalid: must be greater than 0
 		Name:    "",             // Invalid: cannot be empty
-		URL:     "invalid-url",  // Invalid: not a valid URL
+		URL:     security.NewSensitiveString("invalid-url"),  // Invalid: not a valid URL
 		Type:    "invalid-type", // Invalid: not in allowed values
 	}
 

--- a/rpc/network/db/utils.go
+++ b/rpc/network/db/utils.go
@@ -30,17 +30,17 @@ func FillDeprecatedURLs(network *params.Network, providers []params.RpcProvider)
 
 	// Set original_*_url fields based on EmbeddedDirectProviderType providers
 	if len(embeddedDirect) > 0 {
-		network.OriginalRPCURL = embeddedDirect[0].GetFullURL()
+		network.OriginalRPCURL = embeddedDirect[0].GetFullURL().Reveal()
 		if len(embeddedDirect) > 1 {
-			network.OriginalFallbackURL = embeddedDirect[1].GetFullURL()
+			network.OriginalFallbackURL = embeddedDirect[1].GetFullURL().Reveal()
 		}
 	}
 
 	// Set rpc_url and fallback_url based on User providers or EmbeddedDirectProviderType if no User providers exist
 	if len(userProviders) > 0 {
-		network.RPCURL = userProviders[0].GetFullURL()
+		network.RPCURL = userProviders[0].GetFullURL().Reveal()
 		if len(userProviders) > 1 {
-			network.FallbackURL = userProviders[1].GetFullURL()
+			network.FallbackURL = userProviders[1].GetFullURL().Reveal()
 		}
 	} else {
 		// Default to EmbeddedDirectProviderType providers if no User providers exist
@@ -50,12 +50,12 @@ func FillDeprecatedURLs(network *params.Network, providers []params.RpcProvider)
 
 	// Set default_*_url fields based on EmbeddedProxyProviderType providers
 	if len(embeddedProxy) > 0 {
-		network.DefaultRPCURL = embeddedProxy[0].GetFullURL()
+		network.DefaultRPCURL = embeddedProxy[0].GetFullURL().Reveal()
 		if len(embeddedProxy) > 1 {
-			network.DefaultFallbackURL = embeddedProxy[1].GetFullURL()
+			network.DefaultFallbackURL = embeddedProxy[1].GetFullURL().Reveal()
 		}
 		if len(embeddedProxy) > 2 {
-			network.DefaultFallbackURL2 = embeddedProxy[2].GetFullURL()
+			network.DefaultFallbackURL2 = embeddedProxy[2].GetFullURL().Reveal()
 		}
 	}
 }

--- a/rpc/network/network_test.go
+++ b/rpc/network/network_test.go
@@ -2,6 +2,7 @@ package network_test
 
 import (
 	"database/sql"
+	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	api_common "github.com/status-im/status-go/api/common"
@@ -35,22 +36,22 @@ func (s *NetworkManagerTestSuite) SetupTest() {
 	// Use testutil to initialize networks
 	initNetworks := []params.Network{
 		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.UserProviderType, true, "https://mainnet.infura.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.UserProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 		*testutil.CreateNetwork(api_common.SepoliaChainID, "Sepolia Testnet", []params.RpcProvider{
-			testutil.CreateProvider(api_common.SepoliaChainID, "Infura Sepolia", params.UserProviderType, true, "https://sepolia.infura.io"),
+			testutil.CreateProvider(api_common.SepoliaChainID, "Infura Sepolia", params.UserProviderType, true, security.NewSensitiveString("https://sepolia.infura.io")),
 		}),
 		*testutil.CreateNetwork(api_common.OptimismChainID, "Optimistic Ethereum", []params.RpcProvider{
-			testutil.CreateProvider(api_common.OptimismChainID, "Infura Optimism", params.UserProviderType, true, "https://optimism.infura.io"),
+			testutil.CreateProvider(api_common.OptimismChainID, "Infura Optimism", params.UserProviderType, true, security.NewSensitiveString("https://optimism.infura.io")),
 		}),
 		*testutil.CreateNetwork(api_common.OptimismSepoliaChainID, "Optimistic Sepolia", []params.RpcProvider{
-			testutil.CreateProvider(api_common.OptimismSepoliaChainID, "Infura Optimism Sepolia", params.UserProviderType, true, "https://optimism-sepolia.infura.io"),
+			testutil.CreateProvider(api_common.OptimismSepoliaChainID, "Infura Optimism Sepolia", params.UserProviderType, true, security.NewSensitiveString("https://optimism-sepolia.infura.io")),
 		}),
 		*testutil.CreateNetwork(api_common.BaseChainID, "Base", []params.RpcProvider{
-			testutil.CreateProvider(api_common.BaseChainID, "Infura Base", params.UserProviderType, true, "https://base.infura.io"),
+			testutil.CreateProvider(api_common.BaseChainID, "Infura Base", params.UserProviderType, true, security.NewSensitiveString("https://base.infura.io")),
 		}),
 		*testutil.CreateNetwork(api_common.BaseSepoliaChainID, "Base Sepolia", []params.RpcProvider{
-			testutil.CreateProvider(api_common.BaseSepoliaChainID, "Infura Base Sepolia", params.UserProviderType, true, "https://base-sepolia.infura.io"),
+			testutil.CreateProvider(api_common.BaseSepoliaChainID, "Infura Base Sepolia", params.UserProviderType, true, security.NewSensitiveString("https://base-sepolia.infura.io")),
 		}),
 	}
 	// Make "Ethereum Mainnet" network not deactivatable
@@ -91,8 +92,8 @@ func (s *NetworkManagerTestSuite) assertDbNetworks(expectedNetworks []params.Net
 func (s *NetworkManagerTestSuite) TestUserAddsCustomProviders() {
 	// Adding custom providers
 	customProviders := []params.RpcProvider{
-		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider1", params.UserProviderType, true, "https://custom1.example.com"),
-		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider2", params.UserProviderType, false, "https://custom2.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider1", params.UserProviderType, true, security.NewSensitiveString("https://custom1.example.com")),
+		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider2", params.UserProviderType, false, security.NewSensitiveString("https://custom2.example.com")),
 	}
 	err := s.manager.SetUserRpcProviders(api_common.MainnetChainID, customProviders)
 	s.Require().NoError(err)
@@ -107,8 +108,8 @@ func (s *NetworkManagerTestSuite) TestUserAddsCustomProviders() {
 func (s *NetworkManagerTestSuite) TestInitNetworksKeepsUserProviders() {
 	// Add custom providers
 	customProviders := []params.RpcProvider{
-		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider1", params.UserProviderType, true, "https://custom1.example.com"),
-		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider2", params.UserProviderType, false, "https://custom2.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider1", params.UserProviderType, true, security.NewSensitiveString("https://custom1.example.com")),
+		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider2", params.UserProviderType, false, security.NewSensitiveString("https://custom2.example.com")),
 	}
 	err := s.manager.SetUserRpcProviders(api_common.MainnetChainID, customProviders)
 	s.Require().NoError(err)
@@ -116,7 +117,7 @@ func (s *NetworkManagerTestSuite) TestInitNetworksKeepsUserProviders() {
 	// Re-initialize networks
 	initNetworks := []params.Network{
 		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 	}
 	err = s.manager.InitEmbeddedNetworks(initNetworks)
@@ -136,7 +137,7 @@ func (s *NetworkManagerTestSuite) TestInitNetworksDoesNotSaveEmbeddedProviders()
 	// Re-initialize networks
 	initNetworks := []params.Network{
 		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 	}
 	err := s.manager.InitEmbeddedNetworks(initNetworks)
@@ -153,7 +154,7 @@ func (s *NetworkManagerTestSuite) TestInitEmbeddedNetworks() {
 	// Re-initialize networks
 	initNetworks := []params.Network{
 		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 	}
 	expectedProviders := networkhelper.GetEmbeddedProviders(initNetworks[0].RpcProviders)
@@ -208,13 +209,13 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulation() {
 	// Create initial test networks with various providers
 	initNetworks := []params.Network{
 		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(api_common.MainnetChainID, "DirectProvider1", params.EmbeddedDirectProviderType, true, "https://direct1.ethereum.io"),
-			testutil.CreateProvider(api_common.MainnetChainID, "DirectProvider2", params.EmbeddedDirectProviderType, true, "https://direct2.ethereum.io"),
-			testutil.CreateProvider(api_common.MainnetChainID, "ProxyProvider1", params.EmbeddedProxyProviderType, true, "https://proxy1.ethereum.io"),
-			testutil.CreateProvider(api_common.MainnetChainID, "ProxyProvider2", params.EmbeddedProxyProviderType, true, "https://proxy2.ethereum.io"),
-			testutil.CreateProvider(api_common.MainnetChainID, "ProxyProvider3", params.EmbeddedProxyProviderType, true, "https://proxy3.ethereum.io"),
-			testutil.CreateProvider(api_common.MainnetChainID, "UserProvider1", params.UserProviderType, true, "https://user1.ethereum.io"),
-			testutil.CreateProvider(api_common.MainnetChainID, "UserProvider2", params.UserProviderType, true, "https://user2.ethereum.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "DirectProvider1", params.EmbeddedDirectProviderType, true, security.NewSensitiveString("https://direct1.ethereum.io")),
+			testutil.CreateProvider(api_common.MainnetChainID, "DirectProvider2", params.EmbeddedDirectProviderType, true, security.NewSensitiveString("https://direct2.ethereum.io")),
+			testutil.CreateProvider(api_common.MainnetChainID, "ProxyProvider1", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://proxy1.ethereum.io")),
+			testutil.CreateProvider(api_common.MainnetChainID, "ProxyProvider2", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://proxy2.ethereum.io")),
+			testutil.CreateProvider(api_common.MainnetChainID, "ProxyProvider3", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://proxy3.ethereum.io")),
+			testutil.CreateProvider(api_common.MainnetChainID, "UserProvider1", params.UserProviderType, true, security.NewSensitiveString("https://user1.ethereum.io")),
+			testutil.CreateProvider(api_common.MainnetChainID, "UserProvider2", params.UserProviderType, true, security.NewSensitiveString("https://user2.ethereum.io")),
 		}),
 	}
 
@@ -244,9 +245,9 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulationWithoutUserProviders(
 	// Create a test network with only EmbeddedDirect and EmbeddedProxy providers
 	initNetworks := []params.Network{
 		*testutil.CreateNetwork(api_common.SepoliaChainID, "Sepolia Testnet", []params.RpcProvider{
-			testutil.CreateProvider(api_common.SepoliaChainID, "DirectProvider1", params.EmbeddedDirectProviderType, true, "https://direct1.sepolia.io"),
-			testutil.CreateProvider(api_common.SepoliaChainID, "ProxyProvider1", params.EmbeddedProxyProviderType, true, "https://proxy1.sepolia.io"),
-			testutil.CreateProvider(api_common.SepoliaChainID, "ProxyProvider2", params.EmbeddedProxyProviderType, true, "https://proxy2.sepolia.io"),
+			testutil.CreateProvider(api_common.SepoliaChainID, "DirectProvider1", params.EmbeddedDirectProviderType, true, security.NewSensitiveString("https://direct1.sepolia.io")),
+			testutil.CreateProvider(api_common.SepoliaChainID, "ProxyProvider1", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://proxy1.sepolia.io")),
+			testutil.CreateProvider(api_common.SepoliaChainID, "ProxyProvider2", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://proxy2.sepolia.io")),
 		}),
 	}
 
@@ -277,7 +278,7 @@ func (s *NetworkManagerTestSuite) TestUpsertNetwork() {
 
 	// Create a new network
 	newNetwork := testutil.CreateNetwork(chainID, "Ethereum Mainnet", []params.RpcProvider{
-		testutil.CreateProvider(chainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
+		testutil.CreateProvider(chainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 	})
 	// Check that these values are overiden for upserted networks
 	newNetwork.IsActive = true

--- a/rpc/network/network_test.go
+++ b/rpc/network/network_test.go
@@ -2,19 +2,19 @@ package network_test
 
 import (
 	"database/sql"
-	"github.com/status-im/status-go/internal/security"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 
 	api_common "github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/rpc/network"
 	"github.com/status-im/status-go/rpc/network/db"
 	"github.com/status-im/status-go/rpc/network/testutil"
 	"github.com/status-im/status-go/t/helpers"
-
-	"github.com/stretchr/testify/suite"
 )
 
 type NetworkManagerTestSuite struct {

--- a/rpc/network/testutil/testutil.go
+++ b/rpc/network/testutil/testutil.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"github.com/status-im/status-go/internal/security"
 	"github.com/stretchr/testify/require"
 
 	api_common "github.com/status-im/status-go/api/common"
@@ -17,9 +18,9 @@ func CreateProvider(chainID uint64, name string, providerType params.RpcProvider
 		Type:             providerType,
 		Enabled:          enabled,
 		AuthType:         params.BasicAuth,
-		AuthLogin:        "user1",
-		AuthPassword:     "password1",
-		AuthToken:        "",
+		AuthLogin:        security.NewSensitiveString("user1"),
+		AuthPassword:     security.NewSensitiveString("password1"),
+		AuthToken:        security.NewSensitiveString(""),
 	}
 }
 

--- a/rpc/network/testutil/testutil.go
+++ b/rpc/network/testutil/testutil.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Helper function to create a provider
-func CreateProvider(chainID uint64, name string, providerType params.RpcProviderType, enabled bool, url string) params.RpcProvider {
+func CreateProvider(chainID uint64, name string, providerType params.RpcProviderType, enabled bool, url security.SensitiveString) params.RpcProvider {
 	return params.RpcProvider{
 		ChainID:          chainID,
 		Name:             name,

--- a/rpc/network/testutil/testutil.go
+++ b/rpc/network/testutil/testutil.go
@@ -1,10 +1,10 @@
 package testutil
 
 import (
-	"github.com/status-im/status-go/internal/security"
 	"github.com/stretchr/testify/require"
 
 	api_common "github.com/status-im/status-go/api/common"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 )
 

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -72,10 +73,10 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 
 	initNetworks := []params.Network{
 		*network_testutil.CreateNetwork(walletCommon.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
-			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
+			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 		*network_testutil.CreateNetwork(walletCommon.OptimismMainnet, "Optimism Mainnet", []params.RpcProvider{
-			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.optimism.io"),
+			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.optimism.io")),
 		}),
 	}
 	err := networkManager.InitEmbeddedNetworks(initNetworks)

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	mock_rpcclient "github.com/status-im/status-go/rpc/mock/client"
 	"github.com/status-im/status-go/rpc/network"

--- a/services/connector/test_helpers.go
+++ b/services/connector/test_helpers.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
 	mock_rpcclient "github.com/status-im/status-go/rpc/mock/client"

--- a/services/connector/test_helpers.go
+++ b/services/connector/test_helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"github.com/status-im/status-go/internal/security"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -76,10 +77,10 @@ func setupTests(t *testing.T) (state testState, close func()) {
 
 	initNetworks := []params.Network{
 		*network_testutil.CreateNetwork(walletCommon.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
-			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
+			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.infura.io")),
 		}),
 		*network_testutil.CreateNetwork(walletCommon.OptimismMainnet, "Optimism Mainnet", []params.RpcProvider{
-			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.optimism.io"),
+			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedProxyProviderType, true, security.NewSensitiveString("https://mainnet.optimism.io")),
 		}),
 	}
 	err = networkManager.InitEmbeddedNetworks(initNetworks)

--- a/services/wallet/api_test.go
+++ b/services/wallet/api_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/status-im/status-go/internal/security"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/rpc/network/testutil"
 

--- a/services/wallet/api_test.go
+++ b/services/wallet/api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/status-im/status-go/internal/security"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -138,12 +139,12 @@ func TestAPI_GetAddressDetails(t *testing.T) {
 
 	networks := []params.Network{
 		*testutil.CreateNetwork(chainID, "Ethereum Mainnet", []params.RpcProvider{
-			*params.NewProxyProvider(chainID, "Test Provider", serverWith1SecDelay.URL+"/nodefleet/", false),
+			*params.NewProxyProvider(chainID, "Test Provider", security.NewSensitiveString(serverWith1SecDelay.URL+"/nodefleet/"), false),
 		},
 		),
 	}
 
-	networks = networkhelper.OverrideBasicAuth(networks, params.EmbeddedProxyProviderType, true, gofakeit.Username(), gofakeit.LetterN(5))
+	networks = networkhelper.OverrideBasicAuth(networks, params.EmbeddedProxyProviderType, true, security.NewSensitiveString(gofakeit.Username()), security.NewSensitiveString(gofakeit.LetterN(5)))
 	require.NotEmpty(t, networks)
 
 	config := rpc.ClientConfig{
@@ -230,12 +231,12 @@ func TestAPI_FetchOrGetCachedWalletBalances(t *testing.T) {
 				{
 					ChainID:      chainID,
 					Name:         "Test Provider",
-					URL:          server.URL + "/nodefleet/",
+					URL:          security.NewSensitiveString(server.URL + "/nodefleet/"),
 					Type:         params.EmbeddedProxyProviderType,
 					Enabled:      true,
 					AuthType:     params.BasicAuth,
-					AuthLogin:    "user1",
-					AuthPassword: "pass1",
+					AuthLogin:    security.NewSensitiveString("user1"),
+					AuthPassword: security.NewSensitiveString("pass1"),
 				},
 			},
 		},

--- a/services/wallet/leaderboard/fetcher.go
+++ b/services/wallet/leaderboard/fetcher.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/status-im/status-go/internal/security"
+
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/common"
@@ -215,8 +217,8 @@ func (f *ProxyFetcher) fetchData(ctx context.Context, endpoint string, etag stri
 	}
 
 	options = append(options, thirdparty.WithCredentials(&thirdparty.BasicCreds{
-		User:     f.config.User,
-		Password: f.config.Password,
+		User:     security.NewSensitiveString(f.config.User),
+		Password: security.NewSensitiveString(f.config.Password),
 	}))
 
 	body, newEtag, err := f.client.DoGetRequestWithEtag(ctx, url, nil, etag, options...)

--- a/services/wallet/router/router_test_data.go
+++ b/services/wallet/router/router_test_data.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"fmt"
+	"github.com/status-im/status-go/internal/security"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -110,11 +111,11 @@ var mainnet = params.Network{
 	ChainID:   walletCommon.EthereumMainnet,
 	ChainName: "Ethereum",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyNodefleet, fmt.Sprintf("https://%s.api.status.im/nodefleet/ethereum/mainnet/", stageName), false),
-		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyInfura, fmt.Sprintf("https://%s.api.status.im/infura/ethereum/mainnet/", stageName), false),
-		*params.NewDirectProvider(walletCommon.EthereumMainnet, directInfura, "https://mainnet.infura.io/v3/", true),
-		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyGrove, fmt.Sprintf("https://%s.api.status.im/grove/ethereum/mainnet/", stageName), false),
-		*params.NewDirectProvider(walletCommon.EthereumMainnet, directGrove, "https://eth-archival.rpc.grove.city/v1/", false),
+		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyNodefleet, security.NewSensitiveStringPrintf("https://%s.api.status.im/nodefleet/ethereum/mainnet/", stageName), false),
+		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/ethereum/mainnet/", stageName), false),
+		*params.NewDirectProvider(walletCommon.EthereumMainnet, directInfura, security.NewSensitiveString("https://mainnet.infura.io/v3/"), true),
+		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyGrove, security.NewSensitiveStringPrintf("https://%s.api.status.im/grove/ethereum/mainnet/", stageName), false),
+		*params.NewDirectProvider(walletCommon.EthereumMainnet, directGrove, security.NewSensitiveStringPrintf("https://eth-archival.rpc.grove.city/v1/"), false),
 	},
 	BlockExplorerURL:       "https://etherscan.io/",
 	IconURL:                "network/Network=Ethereum",
@@ -133,11 +134,11 @@ var optimism = params.Network{
 	ChainID:   walletCommon.OptimismMainnet,
 	ChainName: "Optimism",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.OptimismMainnet, proxyNodefleet, fmt.Sprintf("https://%s.api.status.im/nodefleet/optimism/mainnet/", stageName), false),
-		*params.NewProxyProvider(walletCommon.OptimismMainnet, proxyInfura, fmt.Sprintf("https://%s.api.status.im/infura/optimism/mainnet/", stageName), false),
-		*params.NewDirectProvider(walletCommon.OptimismMainnet, directInfura, "https://optimism-mainnet.infura.io/v3/", true),
-		*params.NewProxyProvider(walletCommon.OptimismMainnet, proxyGrove, fmt.Sprintf("https://%s.api.status.im/grove/optimism/mainnet/", stageName), true),
-		*params.NewDirectProvider(walletCommon.OptimismMainnet, directGrove, "https://optimism.rpc.grove.city/v1/", false),
+		*params.NewProxyProvider(walletCommon.OptimismMainnet, proxyNodefleet, security.NewSensitiveStringPrintf("https://%s.api.status.im/nodefleet/optimism/mainnet/", stageName), false),
+		*params.NewProxyProvider(walletCommon.OptimismMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/optimism/mainnet/", stageName), false),
+		*params.NewDirectProvider(walletCommon.OptimismMainnet, directInfura, security.NewSensitiveString("https://optimism-mainnet.infura.io/v3/"), true),
+		*params.NewProxyProvider(walletCommon.OptimismMainnet, proxyGrove, security.NewSensitiveStringPrintf("https://%s.api.status.im/grove/optimism/mainnet/", stageName), true),
+		*params.NewDirectProvider(walletCommon.OptimismMainnet, directGrove, security.NewSensitiveString("https://optimism.rpc.grove.city/v1/"), false),
 	},
 	BlockExplorerURL:       "https://optimistic.etherscan.io",
 	IconURL:                "network/Network=Optimism",
@@ -156,11 +157,11 @@ var arbitrum = params.Network{
 	ChainID:   walletCommon.ArbitrumMainnet,
 	ChainName: "Arbitrum",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.ArbitrumMainnet, proxyNodefleet, fmt.Sprintf("https://%s.api.status.im/nodefleet/arbitrum/mainnet/", stageName), false),
-		*params.NewProxyProvider(walletCommon.ArbitrumMainnet, proxyInfura, fmt.Sprintf("https://%s.api.status.im/infura/arbitrum/mainnet/", stageName), false),
-		*params.NewDirectProvider(walletCommon.ArbitrumMainnet, directInfura, "https://arbitrum-mainnet.infura.io/v3/", true),
-		*params.NewProxyProvider(walletCommon.ArbitrumMainnet, proxyGrove, fmt.Sprintf("https://%s.api.status.im/grove/arbitrum/mainnet/", stageName), true),
-		*params.NewDirectProvider(walletCommon.ArbitrumMainnet, directGrove, "https://arbitrum-one.rpc.grove.city/v1/", false),
+		*params.NewProxyProvider(walletCommon.ArbitrumMainnet, proxyNodefleet, security.NewSensitiveStringPrintf("https://%s.api.status.im/nodefleet/arbitrum/mainnet/", stageName), false),
+		*params.NewProxyProvider(walletCommon.ArbitrumMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/arbitrum/mainnet/", stageName), false),
+		*params.NewDirectProvider(walletCommon.ArbitrumMainnet, directInfura, security.NewSensitiveString("https://arbitrum-mainnet.infura.io/v3/"), true),
+		*params.NewProxyProvider(walletCommon.ArbitrumMainnet, proxyGrove, security.NewSensitiveStringPrintf("https://%s.api.status.im/grove/arbitrum/mainnet/", stageName), true),
+		*params.NewDirectProvider(walletCommon.ArbitrumMainnet, directGrove, security.NewSensitiveString("https://arbitrum-one.rpc.grove.city/v1/"), false),
 	},
 	BlockExplorerURL:       "https://arbiscan.io/",
 	IconURL:                "network/Network=Arbitrum",
@@ -179,11 +180,11 @@ var base = params.Network{
 	ChainID:   walletCommon.BaseMainnet,
 	ChainName: "Base",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.BaseMainnet, proxyNodefleet, fmt.Sprintf("https://%s.api.status.im/nodefleet/base/mainnet/", stageName), false),
-		*params.NewProxyProvider(walletCommon.BaseMainnet, proxyInfura, fmt.Sprintf("https://%s.api.status.im/infura/base/mainnet/", stageName), false),
-		*params.NewDirectProvider(walletCommon.BaseMainnet, directInfura, "https://base-mainnet.infura.io/v3/", true),
-		*params.NewProxyProvider(walletCommon.BaseMainnet, proxyGrove, fmt.Sprintf("https://%s.api.status.im/grove/base/mainnet/", stageName), true),
-		*params.NewDirectProvider(walletCommon.BaseMainnet, directGrove, "https://base.rpc.grove.city/v1/", false),
+		*params.NewProxyProvider(walletCommon.BaseMainnet, proxyNodefleet, security.NewSensitiveStringPrintf("https://%s.api.status.im/nodefleet/base/mainnet/", stageName), false),
+		*params.NewProxyProvider(walletCommon.BaseMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/base/mainnet/", stageName), false),
+		*params.NewDirectProvider(walletCommon.BaseMainnet, directInfura, security.NewSensitiveString("https://base-mainnet.infura.io/v3/"), true),
+		*params.NewProxyProvider(walletCommon.BaseMainnet, proxyGrove, security.NewSensitiveStringPrintf("https://%s.api.status.im/grove/base/mainnet/", stageName), true),
+		*params.NewDirectProvider(walletCommon.BaseMainnet, directGrove, security.NewSensitiveString("https://base.rpc.grove.city/v1/"), false),
 	},
 	BlockExplorerURL:       "https://basescan.org",
 	IconURL:                "network/Network=Base",

--- a/services/wallet/router/router_test_data.go
+++ b/services/wallet/router/router_test_data.go
@@ -203,8 +203,8 @@ var bsc = params.Network{
 	ChainID:   walletCommon.BSCMainnet,
 	ChainName: "bsc",
 	RpcProviders: []params.RpcProvider{
-		*params.NewDirectProvider(walletCommon.BSCMainnet, directInfura, "https://bsc-mainnet.infura.io/v3/", true),
-		*params.NewDirectProvider(walletCommon.BSCMainnet, directGrove, "https://bsc.rpc.grove.city/v1/", false),
+		*params.NewDirectProvider(walletCommon.BSCMainnet, directInfura, security.NewSensitiveString("https://bsc-mainnet.infura.io/v3/"), true),
+		*params.NewDirectProvider(walletCommon.BSCMainnet, directGrove, security.NewSensitiveString("https://bsc.rpc.grove.city/v1/"), false),
 	},
 	BlockExplorerURL:       "https://bscscan.com/",
 	IconURL:                "network/Network=bsc",

--- a/services/wallet/router/router_test_data.go
+++ b/services/wallet/router/router_test_data.go
@@ -2,7 +2,6 @@ package router
 
 import (
 	"fmt"
-	"github.com/status-im/status-go/internal/security"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/status-im/status-go/errors"
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/params"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/requests"

--- a/services/wallet/thirdparty/collectibles/alchemy/client.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/client.go
@@ -15,11 +15,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/logutils"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
-	"github.com/status-im/status-go/internal/security"
 )
 
 const nftMetadataBatchLimit = 100
@@ -75,7 +75,7 @@ func getNFTBaseURL(chainID walletCommon.ChainID, apiKey security.SensitiveString
 		return "", err
 	}
 
-	return fmt.Sprintf("%s/nft/v3/%s", baseURL, getAPIKeySubpath(apiKey)), nil
+	return fmt.Sprintf("%s/nft/v3/%s", baseURL, getAPIKeySubpath(apiKey).Reveal()), nil
 }
 
 type Client struct {

--- a/services/wallet/thirdparty/collectibles/alchemy/client.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/client.go
@@ -19,6 +19,7 @@ import (
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
+	"github.com/status-im/status-go/internal/security"
 )
 
 const nftMetadataBatchLimit = 100
@@ -60,14 +61,14 @@ func (o *Client) IsConnected() bool {
 	return o.connectionStatus.IsConnected()
 }
 
-func getAPIKeySubpath(apiKey string) string {
-	if apiKey == "" {
-		return "demo"
+func getAPIKeySubpath(apiKey security.SensitiveString) security.SensitiveString {
+	if apiKey.Empty() {
+		return security.NewSensitiveString("demo")
 	}
 	return apiKey
 }
 
-func getNFTBaseURL(chainID walletCommon.ChainID, apiKey string) (string, error) {
+func getNFTBaseURL(chainID walletCommon.ChainID, apiKey security.SensitiveString) (string, error) {
 	baseURL, err := getBaseURL(chainID)
 
 	if err != nil {
@@ -80,13 +81,14 @@ func getNFTBaseURL(chainID walletCommon.ChainID, apiKey string) (string, error) 
 type Client struct {
 	thirdparty.CollectibleContractOwnershipProvider
 	client           *http.Client
-	apiKeys          map[uint64]string
+	apiKeys          map[uint64]security.SensitiveString
 	connectionStatus *connection.Status
 }
 
-func NewClient(apiKeys map[uint64]string) *Client {
+func NewClient(apiKeys map[uint64]security.SensitiveString) *Client {
 	for _, chainID := range walletCommon.AllChainIDs() {
-		if apiKeys[uint64(chainID)] == "" {
+		key := apiKeys[uint64(chainID)]
+		if key.Empty() {
 			logutils.ZapLogger().Warn("Alchemy API key not available for", zap.Stringer("chainID", chainID))
 		}
 	}

--- a/services/wallet/thirdparty/collectibles/opensea/client_v2.go
+++ b/services/wallet/thirdparty/collectibles/opensea/client_v2.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/logutils"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
-	"github.com/status-im/status-go/internal/security"
 )
 
 const assetLimitV2 = 50

--- a/services/wallet/thirdparty/collectibles/opensea/client_v2.go
+++ b/services/wallet/thirdparty/collectibles/opensea/client_v2.go
@@ -14,6 +14,7 @@ import (
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
+	"github.com/status-im/status-go/internal/security"
 )
 
 const assetLimitV2 = 50
@@ -53,14 +54,14 @@ func getV2URL(chainID walletCommon.ChainID, path string) (string, error) {
 
 type ClientV2 struct {
 	client           *HTTPClient
-	apiKey           string
+	apiKey           security.SensitiveString
 	connectionStatus *connection.Status
 	urlGetter        urlGetter
 }
 
 // new opensea v2 client.
-func NewClientV2(apiKey string, httpClient *HTTPClient) *ClientV2 {
-	if apiKey == "" {
+func NewClientV2(apiKey security.SensitiveString, httpClient *HTTPClient) *ClientV2 {
+	if apiKey.Empty() {
 		logutils.ZapLogger().Warn("OpenseaV2 API key not available")
 	}
 

--- a/services/wallet/thirdparty/collectibles/opensea/http_client.go
+++ b/services/wallet/thirdparty/collectibles/opensea/http_client.go
@@ -50,7 +50,7 @@ func (o *HTTPClient) doGetRequest(ctx context.Context, url string, apiKey securi
 
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:96.0) Gecko/20100101 Firefox/96.0")
-		if tmpAPIKey.NotEmpty() {
+		if !tmpAPIKey.Empty() {
 			req.Header.Set("X-API-KEY", tmpAPIKey.Reveal())
 		}
 
@@ -83,7 +83,7 @@ func (o *HTTPClient) doGetRequest(ctx context.Context, url string, apiKey securi
 			// break and error
 		case http.StatusForbidden:
 			// Request requires an apiKey, set it and retry
-			if tmpAPIKey.Empty() && apiKey.NotEmpty() {
+			if tmpAPIKey.Empty() && !apiKey.Empty() {
 				tmpAPIKey = apiKey
 				// sleep and retry
 				time.Sleep(getRequestWaitTime)

--- a/services/wallet/thirdparty/collectibles/opensea/http_client.go
+++ b/services/wallet/thirdparty/collectibles/opensea/http_client.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/logutils"
 )
 
@@ -30,7 +31,7 @@ func NewHTTPClient() *HTTPClient {
 	}
 }
 
-func (o *HTTPClient) doGetRequest(ctx context.Context, url string, apiKey string) ([]byte, error) {
+func (o *HTTPClient) doGetRequest(ctx context.Context, url string, apiKey security.SensitiveString) ([]byte, error) {
 	// Ensure only one thread makes a request at a time
 	o.getRequestLock.Lock()
 	defer o.getRequestLock.Unlock()
@@ -39,7 +40,7 @@ func (o *HTTPClient) doGetRequest(ctx context.Context, url string, apiKey string
 	statusCode := http.StatusOK
 
 	// Try to do the request without an apiKey first
-	tmpAPIKey := ""
+	var tmpAPIKey security.SensitiveString
 
 	for {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -49,8 +50,8 @@ func (o *HTTPClient) doGetRequest(ctx context.Context, url string, apiKey string
 
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:96.0) Gecko/20100101 Firefox/96.0")
-		if len(tmpAPIKey) > 0 {
-			req.Header.Set("X-API-KEY", tmpAPIKey)
+		if tmpAPIKey.NotEmpty() {
+			req.Header.Set("X-API-KEY", tmpAPIKey.Reveal())
 		}
 
 		resp, err := o.client.Do(req)
@@ -82,7 +83,7 @@ func (o *HTTPClient) doGetRequest(ctx context.Context, url string, apiKey string
 			// break and error
 		case http.StatusForbidden:
 			// Request requires an apiKey, set it and retry
-			if tmpAPIKey == "" && apiKey != "" {
+			if tmpAPIKey.Empty() && apiKey.NotEmpty() {
 				tmpAPIKey = apiKey
 				// sleep and retry
 				time.Sleep(getRequestWaitTime)

--- a/services/wallet/thirdparty/collectibles/rarible/client.go
+++ b/services/wallet/thirdparty/collectibles/rarible/client.go
@@ -20,6 +20,7 @@ import (
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
+	"github.com/status-im/status-go/internal/security"
 )
 
 const ownedNFTLimit = 100
@@ -85,17 +86,17 @@ func getCollectionBaseURL(chainID walletCommon.ChainID) (string, error) {
 type Client struct {
 	thirdparty.CollectibleContractOwnershipProvider
 	client           *http.Client
-	mainnetAPIKey    string
-	testnetAPIKey    string
+	mainnetAPIKey    security.SensitiveString
+	testnetAPIKey    security.SensitiveString
 	connectionStatus *connection.Status
 }
 
-func NewClient(mainnetAPIKey string, testnetAPIKey string) *Client {
-	if mainnetAPIKey == "" {
+func NewClient(mainnetAPIKey security.SensitiveString, testnetAPIKey security.SensitiveString) *Client {
+	if mainnetAPIKey.Empty() {
 		logutils.ZapLogger().Warn("Rarible API key not available for Mainnet")
 	}
 
-	if testnetAPIKey == "" {
+	if testnetAPIKey.Empty() {
 		logutils.ZapLogger().Warn("Rarible API key not available for Testnet")
 	}
 
@@ -107,14 +108,14 @@ func NewClient(mainnetAPIKey string, testnetAPIKey string) *Client {
 	}
 }
 
-func (o *Client) getAPIKey(chainID walletCommon.ChainID) string {
+func (o *Client) getAPIKey(chainID walletCommon.ChainID) security.SensitiveString {
 	if chainID.IsMainnet() {
 		return o.mainnetAPIKey
 	}
 	return o.testnetAPIKey
 }
 
-func (o *Client) doQuery(ctx context.Context, url string, apiKey string) (*http.Response, error) {
+func (o *Client) doQuery(ctx context.Context, url string, apiKey security.SensitiveString) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -125,7 +126,7 @@ func (o *Client) doQuery(ctx context.Context, url string, apiKey string) (*http.
 	return o.doWithRetries(req, apiKey)
 }
 
-func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any, apiKey string) (*http.Response, error) {
+func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any, apiKey security.SensitiveString) (*http.Response, error) {
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
@@ -145,7 +146,7 @@ func (o *Client) doPostWithJSON(ctx context.Context, url string, payload any, ap
 	return o.doWithRetries(req, apiKey)
 }
 
-func (o *Client) doWithRetries(req *http.Request, apiKey string) (*http.Response, error) {
+func (o *Client) doWithRetries(req *http.Request, apiKey security.SensitiveString) (*http.Response, error) {
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = time.Millisecond * 1000
 	b.RandomizationFactor = 0.1
@@ -155,7 +156,7 @@ func (o *Client) doWithRetries(req *http.Request, apiKey string) (*http.Response
 
 	b.Reset()
 
-	req.Header.Set("X-API-KEY", apiKey)
+	req.Header.Set("X-API-KEY", apiKey.Reveal())
 
 	op := func() (*http.Response, error) {
 		resp, err := o.client.Do(req)

--- a/services/wallet/thirdparty/collectibles/rarible/client.go
+++ b/services/wallet/thirdparty/collectibles/rarible/client.go
@@ -16,11 +16,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/logutils"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/connection"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
-	"github.com/status-im/status-go/internal/security"
 )
 
 const ownedNFTLimit = 100

--- a/services/wallet/thirdparty/collectibles/rarible/client_int_test.go
+++ b/services/wallet/thirdparty/collectibles/rarible/client_int_test.go
@@ -2,13 +2,13 @@ package rarible
 
 import (
 	"context"
-	"github.com/status-im/status-go/internal/security"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/status-im/status-go/internal/security"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 

--- a/services/wallet/thirdparty/collectibles/rarible/client_int_test.go
+++ b/services/wallet/thirdparty/collectibles/rarible/client_int_test.go
@@ -2,6 +2,7 @@ package rarible
 
 import (
 	"context"
+	"github.com/status-im/status-go/internal/security"
 	"os"
 	"testing"
 	"time"
@@ -35,7 +36,7 @@ func (s *RaribleClientIntegrationSuite) SetupTest() {
 		testnetKey = os.Getenv("STATUS_RUNTIME_RARIBLE_TESTNET_API_KEY")
 	}
 
-	s.client = NewClient(mainnetKey, testnetKey)
+	s.client = NewClient(security.NewSensitiveString(mainnetKey), security.NewSensitiveString(testnetKey))
 }
 
 func (s *RaribleClientIntegrationSuite) TestAPIKeysAvailable() {

--- a/services/wallet/thirdparty/http_client.go
+++ b/services/wallet/thirdparty/http_client.go
@@ -15,6 +15,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/logutils"
 )
 
@@ -25,8 +26,8 @@ const (
 )
 
 type BasicCreds struct {
-	User     string
-	Password string
+	User     security.SensitiveString
+	Password security.SensitiveString
 }
 
 // HTTPClient represents an HTTP client with configurable options
@@ -52,7 +53,7 @@ func WithGzip() RequestOption {
 func WithCredentials(creds *BasicCreds) RequestOption {
 	return func(req *http.Request, _ *requestModifiers) {
 		if creds != nil {
-			req.SetBasicAuth(creds.User, creds.Password)
+			req.SetBasicAuth(creds.User.Reveal(), creds.Password.Reveal())
 		}
 	}
 }
@@ -258,7 +259,7 @@ func (c *HTTPClient) DoPostRequest(ctx context.Context, url string, params map[s
 	}
 
 	if creds != nil {
-		req.SetBasicAuth(creds.User, creds.Password)
+		req.SetBasicAuth(creds.User.Reveal(), creds.Password.Reveal())
 	}
 
 	req.Header.Set("Content-Type", "application/json")

--- a/services/wallet/thirdparty/http_client_test.go
+++ b/services/wallet/thirdparty/http_client_test.go
@@ -120,7 +120,7 @@ func TestHTTPClient_GetRequests(t *testing.T) {
 					require.Equal(t, value[0], r.URL.Query().Get(param))
 				}
 				if data.credentials != nil {
-					authToken := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", data.credentials.User, data.credentials.Password)))
+					authToken := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", data.credentials.User.Reveal(), data.credentials.Password.Reveal())))
 					require.Equal(t, fmt.Sprintf("Basic %s", authToken), r.Header.Get("Authorization"))
 				}
 

--- a/services/wallet/thirdparty/http_client_test.go
+++ b/services/wallet/thirdparty/http_client_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/status-im/status-go/internal/security"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -63,8 +64,8 @@ func TestHTTPClient_GetRequests(t *testing.T) {
 			url:        "/test-credentials",
 			statusCode: http.StatusOK,
 			credentials: &BasicCreds{
-				User:     "username",
-				Password: "password",
+				User:     security.NewSensitiveString("username"),
+				Password: security.NewSensitiveString("password"),
 			},
 			expectedHeaders: map[string]string{
 				"Content-Type": "application/json",

--- a/services/wallet/thirdparty/http_client_test.go
+++ b/services/wallet/thirdparty/http_client_test.go
@@ -6,13 +6,14 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/status-im/status-go/internal/security"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/internal/security"
 )
 
 func TestHTTPClient_GetRequests(t *testing.T) {

--- a/services/wallet/thirdparty/http_client_test.go
+++ b/services/wallet/thirdparty/http_client_test.go
@@ -246,7 +246,7 @@ func TestFetchDataCompression(t *testing.T) {
 
 	ctx := context.Background()
 	client := NewHTTPClient()
-	creds := BasicCreds{User: "testuser", Password: "testpass"}
+	creds := BasicCreds{User: security.NewSensitiveString("testuser"), Password: security.NewSensitiveString("testpass")}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create test server

--- a/services/wallet/thirdparty/market/cryptocompare/client.go
+++ b/services/wallet/thirdparty/market/cryptocompare/client.go
@@ -63,7 +63,7 @@ func NewClient() *Client {
 
 func NewClientWithParams(params Params) *Client {
 	var creds *thirdparty.BasicCreds
-	if params.User.NotEmpty() {
+	if !params.User.Empty() {
 		creds = &thirdparty.BasicCreds{
 			User:     params.User,
 			Password: params.Password,

--- a/services/wallet/thirdparty/market/cryptocompare/client.go
+++ b/services/wallet/thirdparty/market/cryptocompare/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/status-im/status-go/internal/security"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/services/wallet/thirdparty/utils"
 )
@@ -42,8 +43,8 @@ type MarketValuesContainer struct {
 type Params struct {
 	ID       string
 	URL      string
-	User     string
-	Password string
+	User     security.SensitiveString
+	Password security.SensitiveString
 }
 
 type Client struct {
@@ -62,7 +63,7 @@ func NewClient() *Client {
 
 func NewClientWithParams(params Params) *Client {
 	var creds *thirdparty.BasicCreds
-	if params.User != "" {
+	if params.User.NotEmpty() {
 		creds = &thirdparty.BasicCreds{
 			User:     params.User,
 			Password: params.Password,


### PR DESCRIPTION
Main changes:

- Introduce and propagate a new `security.SensitiveString` type for all sensitive data (URLs, tokens, credentials, API keys), replacing raw `string` fields.
- Add core helpers on `SensitiveString`—e.g. `NotEmpty()`, `Empty()`, `Plus()`, `PlusString()`, `TrimRight()`, `Contains()`—and implement JSON marshalling with automatic redaction.
- Update all structs, constructors and methods (RPC providers, wallet configs, HTTP clients, network utils, etc.) to accept/return `SensitiveString` instead of `string`, calling `.Reveal()` only when needed.
- Refactor existing tests to use a `testify` suite and to generate fake secrets with `gofakeit`, aligning them with the new `SensitiveString` API.
- Add the `internal/security` import across affected packages and adjust logic (e.g. validation, URL‐building, authentication) for the new type.
