### PR TITLE
fix_: set log level to debug for mobile release build doesn't generate log file

### DIFF
--- a/nodecfg/node_config.go
+++ b/nodecfg/node_config.go
@@ -791,6 +791,11 @@ func SetLogLevel(db *sql.DB, logLevel string) error {
 	return err
 }
 
+func SetLogEnabled(db *sql.DB, enabled bool) error {
+	_, err := db.Exec(`UPDATE log_config SET enabled = ?`, enabled)
+	return err
+}
+
 func SetLogNamespaces(db *sql.DB, logNamespaces string) error {
 	_, err := db.Exec(`UPDATE log_config SET log_namespaces = ?`, logNamespaces)
 	return err

--- a/protocol/messenger_sync_settings.go
+++ b/protocol/messenger_sync_settings.go
@@ -9,6 +9,7 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/multiaccounts/errors"
 	"github.com/status-im/status-go/multiaccounts/settings"
+	"github.com/status-im/status-go/nodecfg"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -166,6 +167,7 @@ func (m *Messenger) startSettingsChangesLoop() {
 	channel := m.settings.SubscribeToChanges()
 	go func() {
 		defer gocommon.LogOnPanic()
+		logger := m.logger.Named("SettingsChangesLoop")
 		for {
 			select {
 			case s := <-channel:
@@ -179,10 +181,35 @@ func (m *Messenger) startSettingsChangesLoop() {
 				case settings.Bio.GetReactName():
 					m.selfContact.Bio = s.Value.(string)
 					m.publishSelfContactSubscriptions(&SelfContactChangeEvent{BioChanged: true})
+				case settings.LogLevel.GetReactName():
+					level := s.Value.(string)
+					m.updateLogConfig(level, logger)
 				}
 			case <-m.quit:
 				return
 			}
 		}
 	}()
+}
+
+func (m *Messenger) updateLogConfig(level string, logger *zap.Logger) {
+	m.setLogLevel(level, logger)
+	m.setLogEnabled(level != "", logger)
+}
+
+func (m *Messenger) setLogLevel(level string, logger *zap.Logger) {
+	if level == "" {
+		return
+	}
+	err := nodecfg.SetLogLevel(m.database, level)
+	if err != nil {
+		logger.Error("nodecfg.SetLogLevel", zap.Error(err))
+	}
+}
+
+func (m *Messenger) setLogEnabled(logEnabled bool, logger *zap.Logger) {
+	err := nodecfg.SetLogEnabled(m.database, logEnabled)
+	if err != nil {
+		logger.Error("nodecfg.SetLogEnabled", zap.Error(err))
+	}
 }

--- a/protocol/messenger_sync_settings_test.go
+++ b/protocol/messenger_sync_settings_test.go
@@ -11,6 +11,7 @@ import (
 	gethbridge "github.com/status-im/status-go/eth-node/bridge/geth"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts/settings"
+	"github.com/status-im/status-go/nodecfg"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/tt"
@@ -310,4 +311,32 @@ func (s *MessengerSyncSettingsSuite) TestSyncSettings_PreferredName() {
 	opn, err := s.alice2.settings.GetPreferredUsername()
 	s.Require().NoError(err)
 	s.Require().Equal(pf2, opn)
+}
+
+func (s *MessengerSyncSettingsSuite) TestUpdateLogConfig() {
+	// ensure log level is empty and log is disabled before the test
+	cfg, err := nodecfg.GetNodeConfigFromDB(s.alice.database)
+	s.Require().NoError(err)
+	s.Require().Equal(cfg.LogLevel, "")
+	s.Require().False(cfg.LogEnabled)
+
+	// case 1
+	// WHEN
+	expectedLogLevel := "debug"
+	s.alice.updateLogConfig(expectedLogLevel, s.logger)
+	// THEN
+	cfg, err = nodecfg.GetNodeConfigFromDB(s.alice.database)
+	s.Require().NoError(err)
+	s.Require().Equal(expectedLogLevel, cfg.LogLevel)
+	s.Require().True(cfg.LogEnabled)
+
+	// case 2
+	// empty log level should disable logging, but keep the log level
+	// WHEN
+	s.alice.updateLogConfig("", s.logger)
+	// THEN
+	cfg, err = nodecfg.GetNodeConfigFromDB(s.alice.database)
+	s.Require().NoError(err)
+	s.Require().Equal(expectedLogLevel, cfg.LogLevel)
+	s.Require().False(cfg.LogEnabled)
 }

--- a/protocol/node_config_persistence_test.go
+++ b/protocol/node_config_persistence_test.go
@@ -92,3 +92,18 @@ func (s *NodeConfigPersistenceTestSuite) Test_SetLogLevelDebug() {
 	s.Require().NoError(err)
 	s.Require().Equal("DEBUG", dbNodeConfig.LogLevel)
 }
+
+func (s *NodeConfigPersistenceTestSuite) Test_SetLogEnabled() {
+	dbNodeConfig, err := nodecfg.GetNodeConfigFromDB(s.db)
+	s.Require().NoError(err)
+	s.Require().False(dbNodeConfig.LogEnabled)
+
+	// WHEN
+	err = nodecfg.SetLogEnabled(s.db, true)
+	s.Require().NoError(err)
+
+	// THEN
+	dbNodeConfig, err = nodecfg.GetNodeConfigFromDB(s.db)
+	s.Require().NoError(err)
+	s.Require().True(dbNodeConfig.LogEnabled)
+}


### PR DESCRIPTION
Currently, mobile release build disabled log by default via `.env.release`, so there's no log files generated(it was generated before, that's because when log is disabled with `.env`, frontend will invoke `initLogging` with logLevel `ERROR` which should be an old bug). However, when user change log level from disabled to `debug`, then re-login, still no log files(e.g. geth.log) as log is still disabled in `log_config`, this PR fixed this issue,
relate mobile [issue](https://github.com/status-im/status-mobile/issues/20944#event-15626006115)

<img width="295" alt="image" src="https://github.com/user-attachments/assets/01656ece-a4b9-4110-ac90-b48ef2a4c6e2" />
