### PR TITLE
ci_: bring back cmd coverage

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -159,8 +159,7 @@ pipeline {
             ]) {
               nix.shell('make test-unit V=1', pure: false)
             }
-            sh "mv c.out test-coverage.out"
-            archiveArtifacts('report_*.xml, test_*.log, test-coverage.out, test-coverage.html, coverage_merged.out')
+            archiveArtifacts('report_*.xml, test_*.log, test-coverage.html')
           }
         }
       } }

--- a/_assets/scripts/run_unit_tests.sh
+++ b/_assets/scripts/run_unit_tests.sh
@@ -137,22 +137,17 @@ fi
 
 # Gather test coverage results
 merged_coverage_report="coverage_merged.out"
-final_coverage_report="c.out"
 coverage_reports=$(find . -iname "*.coverage.out")
-rm -f ${final_coverage_report} ${merged_coverage_report}
+rm -f ${merged_coverage_report}
 
 echo -e "${GRN}Gathering test coverage results: ${RST} output: ${merged_coverage_report}, input: ${coverage_reports}"
 echo $coverage_reports | xargs go run ./cmd/test-coverage-utils/gocovmerge.go > ${merged_coverage_report}
 
-# Filter out test coverage for packages in ./cmd
-echo -e "${GRN}Filtering test coverage packages:${RST} ./cmd"
-grep -v '^github.com/status-im/status-go/cmd/' ${merged_coverage_report} > ${final_coverage_report}
-
 # Generate HTML coverage report
-convert_coverage_to_html ${final_coverage_report} "test-coverage.html"
+convert_coverage_to_html ${merged_coverage_report} "test-coverage.html"
 
 if [[ $UNIT_TEST_REPORT_CODECOV == 'true' ]]; then
-  report_to_codecov "report_*.xml" ${final_coverage_report} "unit"
+  report_to_codecov "report_*.xml" ${merged_coverage_report} "unit"
 fi
 
 # Generate report with test stats


### PR DESCRIPTION
1. The way we were cutting out `/cmd` coverage from reports was working for Codeclimate, but doens't work for Codecov
2. There are some tests in that directory already
3. We do have ways to introduce tests for apps in `./cmd`, e.g. with functional tests. And coverage will be measured.
4. If some specific directory needs to be filtered out, it should be done in `.codecov.yml`