### PR TITLE
test_: skip flaky `TestService_IncrementalUpdateMixed`

### DIFF
--- a/services/wallet/activity/session_service_test.go
+++ b/services/wallet/activity/session_service_test.go
@@ -83,6 +83,8 @@ func TestService_IncrementalUpdateOnTop(t *testing.T) {
 }
 
 func TestService_IncrementalUpdateMixed(t *testing.T) {
+	t.Skip("flaky test")
+
 	state := setupTestService(t)
 	defer state.close()
 


### PR DESCRIPTION
This test panics, so it's not even retried on CI and is very annoying.
Ticket opened: 
- https://github.com/status-im/status-go/issues/6141