### PR TITLE
chore(wallet)_: from and to chains added to send details

### DIFF
--- a/services/wallet/responses/router_transactions.go
+++ b/services/wallet/responses/router_transactions.go
@@ -15,6 +15,8 @@ type SendDetails struct {
 	SendType            int                   `json:"sendType"`
 	FromAddress         types.Address         `json:"fromAddress"`
 	ToAddress           types.Address         `json:"toAddress"`
+	FromChain           uint64                `json:"fromChain"` // this chain should be used only if en error occurred while sending a transaction
+	ToChain             uint64                `json:"toChain"`   // this chain should be used only if en error occurred while sending a transaction
 	FromToken           string                `json:"fromToken"`
 	ToToken             string                `json:"toToken"`
 	FromAmount          string                `json:"fromAmount"` // total amount
@@ -88,7 +90,7 @@ func NewRouterSentTransaction(sendArgs *wallettypes.SendTxArgs, hash types.Hash,
 	}
 }
 
-func (sd *SendDetails) UpdateFields(inputParams requests.RouteInputParams) {
+func (sd *SendDetails) UpdateFields(inputParams requests.RouteInputParams, fromChain uint64, toChain uint64) {
 	sd.SendType = int(inputParams.SendType)
 	sd.FromAddress = types.Address(inputParams.AddrFrom)
 	sd.ToAddress = types.Address(inputParams.AddrTo)
@@ -106,4 +108,8 @@ func (sd *SendDetails) UpdateFields(inputParams requests.RouteInputParams) {
 	if inputParams.PackID != nil {
 		sd.PackID = inputParams.PackID.String()
 	}
+
+	// Set chain IDs, in case of an error while sending a transaction
+	sd.FromChain = fromChain
+	sd.ToChain = toChain
 }

--- a/services/wallet/router/routes/route.go
+++ b/services/wallet/router/routes/route.go
@@ -17,6 +17,19 @@ func (r Route) Copy() Route {
 	return newRoute
 }
 
+// GetFirstPathChains returns the chain IDs (from and to) of the first path in the route
+// If certain tx fails or succeeds status--go will send from/to chains along with other tx details to client to let
+// thc client know about failed/successful tx. But if an error occurs before the first path, during the preparation
+// of the route, the client will not have the chain IDs to know where the tx was supposed to be sent. This function
+// is used to get the chain IDs of the first path in the route to send them to the client in case of an error.
+func (r Route) GetFirstPathChains() (uint64, uint64) {
+	if len(r) == 0 {
+		return 0, 0
+	}
+
+	return r[0].FromChain.ChainID, r[0].ToChain.ChainID
+}
+
 func FindBestRoute(routes []Route, tokenPrice float64, nativeTokenPrice float64) Route {
 	var best Route
 	bestCost := big.NewFloat(math.Inf(1))

--- a/transactions/pendingtxtracker.go
+++ b/transactions/pendingtxtracker.go
@@ -358,7 +358,7 @@ func (tm *PendingTxTracker) updateTxDetails(txDetails *TxDetails, chainID uint64
 	}
 	if routeData != nil {
 		if routeData.RouteInputParams != nil {
-			txDetails.SendDetails.UpdateFields(*routeData.RouteInputParams)
+			txDetails.SendDetails.UpdateFields(*routeData.RouteInputParams, 0, 0)
 		}
 
 		for _, pd := range routeData.PathsData {


### PR DESCRIPTION
From and to chains added to SendDetails type that can be used on the client side if the sending fails that we can display appropriate ephemeral notifications, saying sending from which chain has failed.

We will improve more on this when dealing with this issue https://github.com/status-im/status-desktop/issues/16556