### PR TITLE
feat(logging)_: enable runtime logs configuration

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -2198,12 +2198,6 @@ func (b *GethStatusBackend) loadNodeConfig(inputNodeCfg *params.NodeConfig) erro
 		}
 	}
 
-	if len(conf.LogDir) == 0 {
-		conf.LogFile = filepath.Join(b.rootDataDir, conf.LogFile)
-	} else {
-		conf.LogFile = filepath.Join(conf.LogDir, conf.LogFile)
-	}
-
 	b.config = conf
 
 	if inputNodeCfg != nil && inputNodeCfg.RuntimeLogLevel != "" {
@@ -2983,4 +2977,30 @@ func (b *GethStatusBackend) TogglePanicReporting(enabled bool) error {
 		return b.EnablePanicReporting()
 	}
 	return b.DisablePanicReporting()
+}
+
+func (b *GethStatusBackend) SetLogLevel(level string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	err := nodecfg.SetLogLevel(b.appDB, level)
+	if err != nil {
+		return err
+	}
+	b.config.LogLevel = level
+
+	return logutils.OverrideRootLoggerWithConfig(b.config.DefaultLogSettings())
+}
+
+func (b *GethStatusBackend) SetLogNamespaces(namespaces string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	err := nodecfg.SetLogNamespaces(b.appDB, namespaces)
+	if err != nil {
+		return err
+	}
+	b.config.LogNamespaces = namespaces
+
+	return logutils.OverrideRootLoggerWithConfig(b.config.DefaultLogSettings())
 }

--- a/logutils/core.go
+++ b/logutils/core.go
@@ -107,7 +107,8 @@ func (core *Core) Sync() error {
 }
 
 func (core *Core) UpdateSyncer(newSyncer zapcore.WriteSyncer) {
-	core.syncer.Store(writeSyncerWrapper{WriteSyncer: newSyncer})
+	oldSyncer := core.syncer.Swap(writeSyncerWrapper{WriteSyncer: newSyncer})
+	_ = oldSyncer.(zapcore.WriteSyncer).Sync() // may fail but doesn't impact syncer update
 }
 
 func (core *Core) UpdateEncoder(newEncoder zapcore.Encoder) {

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1248,7 +1248,7 @@ func exportNodeLogs() string {
 	if config == nil {
 		return makeJSONResponse(errors.New("config and log file are not available"))
 	}
-	data, err := json.Marshal(exportlogs.ExportFromBaseFile(config.LogFile))
+	data, err := json.Marshal(exportlogs.ExportFromBaseFile(config.LogFilePath()))
 	if err != nil {
 		return makeJSONResponse(fmt.Errorf("error marshalling to json: %v", err))
 	}
@@ -2321,6 +2321,44 @@ func addCentralizedMetric(requestJSON string) string {
 	}
 
 	return metric.ID
+}
+
+func SetLogLevel(requestJSON string) string {
+	return callWithResponse(setLogLevel, requestJSON)
+}
+
+func setLogLevel(requestJSON string) string {
+	var request requests.SetLogLevel
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = request.Validate()
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	return makeJSONResponse(statusBackend.SetLogLevel(request.LogLevel))
+}
+
+func SetLogNamespaces(requestJSON string) string {
+	return callWithResponse(setLogNamespaces, requestJSON)
+}
+
+func setLogNamespaces(requestJSON string) string {
+	var request requests.SetLogNamespaces
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = request.Validate()
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	return makeJSONResponse(statusBackend.SetLogNamespaces(request.LogNamespaces))
 }
 
 func IntendedPanic(message string) string {

--- a/params/config.go
+++ b/params/config.go
@@ -1048,12 +1048,19 @@ func LesTopic(netid int) string {
 	}
 }
 
+func (c *NodeConfig) LogFilePath() string {
+	if c.LogDir == "" {
+		return filepath.Join(c.RootDataDir, c.LogFile)
+	}
+	return filepath.Join(c.LogDir, c.LogFile)
+}
+
 func (c *NodeConfig) DefaultLogSettings() logutils.LogSettings {
 	return logutils.LogSettings{
 		Enabled:         c.LogEnabled,
 		Level:           c.LogLevel,
 		Namespaces:      c.LogNamespaces,
-		File:            c.LogFile,
+		File:            c.LogFilePath(),
 		MaxSize:         c.LogMaxSize,
 		MaxBackups:      c.LogMaxBackups,
 		CompressRotated: c.LogCompressRotated,

--- a/protocol/messenger_settings.go
+++ b/protocol/messenger_settings.go
@@ -30,6 +30,7 @@ func (m *Messenger) SetSyncingOnMobileNetwork(request *requests.SetSyncingOnMobi
 	return nil
 }
 
+// Deprecated: Use SetLogLevel from status.go instead.
 func (m *Messenger) SetLogLevel(request *requests.SetLogLevel) error {
 	if err := request.Validate(); err != nil {
 		return err
@@ -38,6 +39,7 @@ func (m *Messenger) SetLogLevel(request *requests.SetLogLevel) error {
 	return nodecfg.SetLogLevel(m.database, request.LogLevel)
 }
 
+// Deprecated: Use SetLogNamespaces from status.go instead.
 func (m *Messenger) SetLogNamespaces(request *requests.SetLogNamespaces) error {
 	if err := request.Validate(); err != nil {
 		return err

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -335,6 +335,9 @@ class StatusBackend(RpcClient, SignalClient):
     def find_public_key(self):
         self.public_key = self.node_login_event.get("event", {}).get("settings", {}).get("public-key")
 
+    def find_key_uid(self):
+        return self.node_login_event.get("event", {}).get("account", {}).get("key-uid")
+
     @retry(stop=stop_after_delay(10), wait=wait_fixed(0.1), reraise=True)
     def change_container_ip(self, new_ipv4=None, new_ipv6=None):
         if not self.container:


### PR DESCRIPTION
Add endpoints for log level and namespaces configuration to `status.go` and deprecate equivalents from service.

Endpoints are defined in `status.go`, as it has access to `statusBackend`, the only entity capable of manipulating node configuration without requiring a restart.