### PR TITLE
fix(wallet)_: in case of sepolia optimism returned a nonce is not generated the same way as it is for optimism mainnet

### DIFF
--- a/transactions/transactor.go
+++ b/transactions/transactor.go
@@ -119,7 +119,11 @@ func (t *Transactor) NextNonce(rpcClient rpc.ClientInterface, chainID uint64, fr
 			if err != nil {
 				return 0, err
 			}
-			return nonce + countOfPendingTXs, nil
+			nonce = nonce + countOfPendingTXs
+		}
+		// sepolia optimism returns nonce differently than mainnet optimism, that's why we need to increment it by 1
+		if chainID == wallet_common.OptimismSepolia {
+			nonce++
 		}
 	}
 


### PR DESCRIPTION
Changes done here simply increment the resolved nonce by sepolia optimism chain by one, cause it's differently generated that it is for mainnet sepolia and other chains. This change aligns on that.