### PR TITLE
fix(sha3)_: support hex string

### DIFF
--- a/abi-spec/utils.go
+++ b/abi-spec/utils.go
@@ -1,14 +1,18 @@
 package abispec
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"regexp"
 	"strings"
 	"unicode"
 
+	"go.uber.org/zap"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/logutils"
 )
 
 var unicodeZeroPattern = regexp.MustCompile("^(?:\u0000)*")
@@ -19,6 +23,8 @@ var hexPrefixPattern = regexp.MustCompile("(?i)^0x")
 var addressBasicPattern = regexp.MustCompile("(?i)^(0x)?[0-9a-f]{40}$")
 var addressLowerCasePattern = regexp.MustCompile("^(0x|0X)?[0-9a-f]{40}$")
 var addressUpperCasePattern = regexp.MustCompile("^(0x|0X)?[0-9A-F]{40}$")
+
+var hexStrictPattern = regexp.MustCompile(`(?i)^((-)?0x[0-9a-f]+|(0x))$`)
 
 func HexToNumber(hex string) string {
 	num, success := big.NewInt(0).SetString(hex, 16)
@@ -37,7 +43,18 @@ func NumberToHex(numString string) string {
 }
 
 func Sha3(str string) string {
-	bytes := crypto.Keccak256([]byte(str))
+	var bytes []byte
+	var err error
+	if hexStrictPattern.MatchString(str) {
+		bytes, err = hex.DecodeString(str[2:])
+		if err != nil {
+			logutils.ZapLogger().Error("failed to decode hex string when sha3", zap.String("hex", str), zap.Error(err))
+			return ""
+		}
+	} else {
+		bytes = []byte(str)
+	}
+	bytes = crypto.Keccak256(bytes)
 	return common.Bytes2Hex(bytes)
 }
 

--- a/abi-spec/utils_test.go
+++ b/abi-spec/utils_test.go
@@ -36,6 +36,9 @@ func TestNumberToHex(t *testing.T) {
 
 func TestSha3(t *testing.T) {
 	require.Equal(t, "48bed44d1bcd124a28c27f343a817e5f5243190d3c52bf347daf876de1dbbf77", Sha3("abcd"))
+	require.Equal(t, "79bc958fa37445ba1b909c34a73cecfa4966a6e6783f90863dd6df5a80f96ad0", Sha3("12786e7b2111caae36dd91aca91ce627f26fa3c77018a98880ab50a82ac6b6aa835f6bbf96da54aa6b88ceffb8107ef40a4ef8a85bf4eb0e81a9464e0a27fcf3"))
+	require.Equal(t, "04d874cdee68658bd64a07b6180dd36b735b60876ca79a29f88114bc78e6fc32", Sha3("0x12786e7b2111caae36dd91aca91ce627f26fa3c77018a98880ab50a82ac6b6aa835f6bbf96da54aa6b88ceffb8107ef40a4ef8a85bf4eb0e81a9464e0a27fcf3"))
+	require.Equal(t, "04d874cdee68658bd64a07b6180dd36b735b60876ca79a29f88114bc78e6fc32", Sha3("0x12786E7b2111caae36dd91aca91ce627f26fa3c77018a98880ab50a82ac6b6aa835f6bbf96da54aa6b88ceffb8107ef40a4ef8a85bf4eb0e81a9464e0a27fcf3"))
 }
 
 func TestHexToUtf8(t *testing.T) {


### PR DESCRIPTION
This PR adds a check to determine if a `str` starts with `0x`.

Relate mobile [issue](https://github.com/status-im/status-mobile/issues/21819).

This is what `web3` implemented:
```ts
export const sha3 = (data: Bytes): string | undefined => {
    let updatedData: Uint8Array;

    if (typeof data === 'string') {
        if (data.startsWith('0x') && isHexStrict(data)) {
            updatedData = hexToBytes(data);
        } else {
            updatedData = utf8ToBytes(data);
        }
    } else {
        updatedData = data;
    }
    const hash = keccak256Wrapper(updatedData);

    // EIP-1052 if hash is equal to c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, keccak was given empty data
    return hash === SHA3_EMPTY_BYTES ? undefined : hash;
};
```