### PR TITLE
feat(message)_: add PinnedBy to common.Message

### DIFF
--- a/protocol/common/message.go
+++ b/protocol/common/message.go
@@ -221,6 +221,9 @@ type Message struct {
 	ContactVerificationState ContactVerificationState `json:"contactVerificationState,omitempty"`
 
 	DiscordMessage *protobuf.DiscordMessage `json:"discordMessage,omitempty"`
+
+	// When a message is pinned, the pubkey of the user that pinned it is stored here
+	PinnedBy string `json:"pinnedBy,omitempty"`
 }
 
 func (m *Message) MarshalJSON() ([]byte, error) {
@@ -284,6 +287,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		DiscordMessage           *protobuf.DiscordMessage         `json:"discordMessage,omitempty"`
 		BridgeMessage            *protobuf.BridgeMessage          `json:"bridgeMessage,omitempty"`
 		PaymentRequests          []*protobuf.PaymentRequest       `json:"paymentRequests,omitempty"`
+		PinnedBy                 string                           `json:"pinnedBy,omitempty"`
 	}
 	item := MessageStructType{
 		ID:                       m.ID,
@@ -327,6 +331,7 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		ContactRequestState:      m.ContactRequestState,
 		ContactVerificationState: m.ContactVerificationState,
 		PaymentRequests:          m.PaymentRequests,
+		PinnedBy:                 m.PinnedBy,
 	}
 
 	if sticker := m.GetSticker(); sticker != nil {

--- a/protocol/persistence_test.go
+++ b/protocol/persistence_test.go
@@ -476,6 +476,23 @@ func TestPinMessageByChatID(t *testing.T) {
 	for i := 0; i < len(result)-1; i++ {
 		require.Equal(t, testPK, result[i].PinnedBy)
 	}
+
+	// The Message itself should have the pinnedBy field
+	pinnedMessageID := result[len(result)-1].Message.ID
+
+	m, err := p.MessagesByIDs([]string{pinnedMessageID})
+	require.NoError(t, err)
+	require.Len(t, m, 1)
+	require.Equal(t, "them", m[0].PinnedBy)
+
+	msgs, _, err := p.MessageByChatID(chatID, cursor, 10)
+	require.NoError(t, err)
+	require.Len(t, msgs, 10)
+	for _, msg := range msgs {
+		if msg.ID == pinnedMessageID {
+			require.Equal(t, "them", msg.PinnedBy)
+		}
+	}
 }
 
 func TestMessageReplies(t *testing.T) {


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/16896

Having `PinnedBy`  directly in the Message object makes it way simpler in the client to know if a message is pinned. This saves us from having to keep a cache of the pinned messages and comparing all new messages.