### PR TITLE
test_: unskip test initialize logging

### DIFF
--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -24,7 +24,7 @@ mkdir -p "${merged_coverage_reports_path}"
 mkdir -p "${test_results_path}"
 
 all_compose_files="-f ${root_path}/docker-compose.anvil.yml -f ${root_path}/docker-compose.test.status-go.yml"
-timestamp=$(python3 -c "import time; print(int(time.time() * 1000))") # Cross-platform timestamp in milliseconds
+timestamp=$(python3 -c "import time; print(int(time.time() * 1000))") # Keep in sync with status_backend.py
 project_name="status-go-func-tests-${timestamp}"
 
 export STATUS_BACKEND_URLS=$(eval echo http://${project_name}-status-backend-{1..${STATUS_BACKEND_COUNT}}:3333 | tr ' ' ,)

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -24,7 +24,8 @@ mkdir -p "${merged_coverage_reports_path}"
 mkdir -p "${test_results_path}"
 
 all_compose_files="-f ${root_path}/docker-compose.anvil.yml -f ${root_path}/docker-compose.test.status-go.yml"
-project_name="status-go-func-tests-$(date +%s)"
+timestamp=$(python3 -c "import time; print(int(time.time() * 1000))") # Cross-platform timestamp in milliseconds
+project_name="status-go-func-tests-${timestamp}"
 
 export STATUS_BACKEND_URLS=$(eval echo http://${project_name}-status-backend-{1..${STATUS_BACKEND_COUNT}}:3333 | tr ' ' ,)
 

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -158,7 +158,7 @@ class StatusBackend(RpcClient, SignalClient):
         data["StatusProxyStageName"] = "test"
         return data
 
-    def load_statusgo_data(self, path: str):
+    def extract_data(self, path: str):
         if not self.container:
             return path
 

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -1,5 +1,8 @@
+import io
 import json
 import logging
+import tarfile
+import tempfile
 import time
 import random
 import threading
@@ -18,6 +21,8 @@ NANOSECONDS_PER_SECOND = 1_000_000_000
 
 
 class StatusBackend(RpcClient, SignalClient):
+
+    container = None
 
     def __init__(self, await_signals=[]):
 
@@ -152,6 +157,27 @@ class StatusBackend(RpcClient, SignalClient):
         data["StatusProxyEnabled"] = True
         data["StatusProxyStageName"] = "test"
         return data
+
+    def load_statusgo_data(self, path: str):
+        if not self.container:
+            return path
+
+        try:
+            stream, _ = self.container.get_archive(path)
+        except docker.errors.NotFound:
+            return None
+
+        temp_dir = tempfile.mkdtemp()
+        tar_bytes = io.BytesIO(b"".join(stream))
+
+        with tarfile.open(fileobj=tar_bytes) as tar:
+            tar.extractall(path=temp_dir)
+            # If the tar contains a single file, return the path to that file
+            # Otherwise it's a directory, just return temp_dir.
+            if len(tar.getmembers()) == 1:
+                return os.path.join(temp_dir, tar.getmembers()[0].name)
+
+        return temp_dir
 
     def create_account_and_login(
         self,

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -8,6 +8,7 @@ import random
 import threading
 import requests
 import docker
+import docker.errors
 import os
 
 from tenacity import retry, stop_after_delay, wait_fixed

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -14,7 +14,6 @@ import os
 from tenacity import retry, stop_after_delay, wait_fixed
 from clients.signals import SignalClient
 from clients.rpc import RpcClient
-from datetime import datetime
 from conftest import option
 from resources.constants import user_1, DEFAULT_DISPLAY_NAME, USER_DIR
 
@@ -54,7 +53,7 @@ class StatusBackend(RpcClient, SignalClient):
     def _start_container(self, host_port):
         docker_project_name = option.docker_project_name
 
-        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        timestamp = int(time.time() * 1000)  # Keep in sync with run_functional_tests.sh
         image_name = f"{docker_project_name}-status-backend:latest"
         container_name = f"{docker_project_name}-status-backend-{timestamp}"
 

--- a/tests-functional/tests/test_init_status_app.py
+++ b/tests-functional/tests/test_init_status_app.py
@@ -44,53 +44,45 @@ class TestInitialiseApp:
         )
 
 
+def assert_file_first_line(path, pattern: str, expected: bool):
+    if not expected:
+        assert path is None
+        return
+    assert os.path.exists(path)
+    with open(path) as file:
+        line = file.readline()
+        line_found = line.find(pattern) >= 0
+        assert line_found == expected
+
 @pytest.mark.rpc
-class TestInitializeLogging:
+@pytest.mark.init
+@pytest.mark.parametrize("log_enabled,api_logging_enabled", [(True, True), (False, False)])
+def test_check_logs(log_enabled: bool, api_logging_enabled: bool):
+    data_dir = os.path.join(USER_DIR, "data")
+    logs_dir = os.path.join(USER_DIR, "logs")
 
-    @pytest.mark.init
-    def test_init_logging(self):
-        self.check_logs(log_enabled=True, api_logging_enabled=True)
+    backend = StatusBackend()
+    backend.api_valid_request(
+        "InitializeApplication",
+        {
+            "dataDir": str(data_dir),
+            "logDir": str(logs_dir),
+            "logEnabled": log_enabled,
+            "apiLoggingEnabled": api_logging_enabled,
+        },
+    )
 
-    @pytest.mark.init
-    def test_no_logging(self):
-        self.check_logs(log_enabled=False, api_logging_enabled=False)
+    local_geth_log = backend.load_statusgo_data(os.path.join(logs_dir, "geth.log"))
+    local_api_log = backend.load_statusgo_data(os.path.join(logs_dir, "api.log"))
 
-    def assert_file_first_line(self, path, pattern: str, expected: bool):
-        if not expected:
-            assert path is None
-            return
-        assert os.path.exists(path)
-        with open(path) as file:
-            line = file.readline()
-            line_found = line.find(pattern) >= 0
-            assert line_found == expected
+    assert_file_first_line(
+        path=local_geth_log,
+        pattern="logging initialised",
+        expected=log_enabled
+    )
 
-    def check_logs(self, log_enabled: bool, api_logging_enabled: bool):
-        data_dir = os.path.join(USER_DIR, "data")
-        logs_dir = os.path.join(USER_DIR, "logs")
-
-        backend = StatusBackend()
-        backend.api_valid_request(
-            "InitializeApplication",
-            {
-                "dataDir": str(data_dir),
-                "logDir": str(logs_dir),
-                "logEnabled": log_enabled,
-                "apiLoggingEnabled": api_logging_enabled,
-            },
-        )
-
-        local_geth_log = backend.load_statusgo_data(os.path.join(logs_dir, "geth.log"))
-        local_api_log = backend.load_statusgo_data(os.path.join(logs_dir, "api.log"))
-
-        self.assert_file_first_line(
-            path=local_geth_log,
-            pattern="logging initialised",
-            expected=log_enabled
-        )
-
-        self.assert_file_first_line(
-            path=local_api_log,
-            pattern='"method": "InitializeApplication"',
-            expected=api_logging_enabled,
-        )
+    assert_file_first_line(
+        path=local_api_log,
+        pattern='"method": "InitializeApplication"',
+        expected=api_logging_enabled,
+    )

--- a/tests-functional/tests/test_init_status_app.py
+++ b/tests-functional/tests/test_init_status_app.py
@@ -1,3 +1,6 @@
+import docker.errors
+
+from resources.constants import USER_DIR
 from test_cases import StatusBackend
 import pytest
 from clients.signals import SignalType
@@ -42,32 +45,29 @@ class TestInitialiseApp:
 
 
 @pytest.mark.rpc
-@pytest.mark.skip("waiting for status-backend to be executed on the same host/container")
 class TestInitializeLogging:
 
     @pytest.mark.init
-    def test_init_logging(self, tmp_path):
-        self.check_logs(tmp_path, log_enabled=True, api_logging_enabled=True)
+    def test_init_logging(self):
+        self.check_logs(log_enabled=True, api_logging_enabled=True)
 
     @pytest.mark.init
-    def test_no_logging(self, tmp_path):
-        self.check_logs(tmp_path, log_enabled=False, api_logging_enabled=False)
+    def test_no_logging(self):
+        self.check_logs(log_enabled=False, api_logging_enabled=False)
 
     def assert_file_first_line(self, path, pattern: str, expected: bool):
-        assert os.path.exists(path) == expected
         if not expected:
+            assert path is None
             return
+        assert os.path.exists(path)
         with open(path) as file:
             line = file.readline()
             line_found = line.find(pattern) >= 0
             assert line_found == expected
 
-    def check_logs(self, path, log_enabled: bool, api_logging_enabled: bool):
-        data_dir = path / "data"
-        logs_dir = path / "logs"
-
-        data_dir.mkdir()
-        logs_dir.mkdir()
+    def check_logs(self, log_enabled: bool, api_logging_enabled: bool):
+        data_dir = os.path.join(USER_DIR, "data")
+        logs_dir = os.path.join(USER_DIR, "logs")
 
         backend = StatusBackend()
         backend.api_valid_request(
@@ -80,10 +80,17 @@ class TestInitializeLogging:
             },
         )
 
-        self.assert_file_first_line(logs_dir / "geth.log", pattern="logging initialised", expected=log_enabled)
+        local_geth_log = backend.load_statusgo_data(os.path.join(logs_dir, "geth.log"))
+        local_api_log = backend.load_statusgo_data(os.path.join(logs_dir, "api.log"))
 
         self.assert_file_first_line(
-            logs_dir / "api.log",
+            path=local_geth_log,
+            pattern="logging initialised",
+            expected=log_enabled
+        )
+
+        self.assert_file_first_line(
+            path=local_api_log,
             pattern='"method": "InitializeApplication"',
             expected=api_logging_enabled,
         )

--- a/tests-functional/tests/test_init_status_app.py
+++ b/tests-functional/tests/test_init_status_app.py
@@ -72,8 +72,8 @@ def test_check_logs(log_enabled: bool, api_logging_enabled: bool):
         },
     )
 
-    local_geth_log = backend.load_statusgo_data(os.path.join(logs_dir, "geth.log"))
-    local_api_log = backend.load_statusgo_data(os.path.join(logs_dir, "api.log"))
+    local_geth_log = backend.extract_data(os.path.join(logs_dir, "geth.log"))
+    local_api_log = backend.extract_data(os.path.join(logs_dir, "api.log"))
 
     assert_file_first_line(
         path=local_geth_log,

--- a/tests-functional/tests/test_init_status_app.py
+++ b/tests-functional/tests/test_init_status_app.py
@@ -1,5 +1,3 @@
-import docker.errors
-
 from resources.constants import USER_DIR
 from test_cases import StatusBackend
 import pytest
@@ -54,6 +52,7 @@ def assert_file_first_line(path, pattern: str, expected: bool):
         line_found = line.find(pattern) >= 0
         assert line_found == expected
 
+
 @pytest.mark.rpc
 @pytest.mark.init
 @pytest.mark.parametrize("log_enabled,api_logging_enabled", [(True, True), (False, False)])
@@ -75,11 +74,7 @@ def test_check_logs(log_enabled: bool, api_logging_enabled: bool):
     local_geth_log = backend.extract_data(os.path.join(logs_dir, "geth.log"))
     local_api_log = backend.extract_data(os.path.join(logs_dir, "api.log"))
 
-    assert_file_first_line(
-        path=local_geth_log,
-        pattern="logging initialised",
-        expected=log_enabled
-    )
+    assert_file_first_line(path=local_geth_log, pattern="logging initialised", expected=log_enabled)
 
     assert_file_first_line(
         path=local_api_log,


### PR DESCRIPTION
1. Added `load_statusgo_data` that copies requested data from `status-backend` container to a temporary host path.
2. Unskipped `TestInitializeLogging` and updated it to use `load_statusgo_data`
3. `status-go` will no automatically create `DataDir` and `LogsDir` (if they don't exist) during `InitializeApplication`.
4. Switched to milliseconds precision for `project_name`, otherwise it failed when 2 backends are started within 1 second.