### PR TITLE
test_: Test reliability workflow

### DIFF
--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -64,7 +64,7 @@ jobs:
       uses: peaceiris/actions-gh-pages@v4
       if: env.WORKFLOW_CONCLUSION != 'cancelled'
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        personal_token: ${{ secrets.GITHUB_TOKEN }}
         external_repository: status-im/status-cli-tests
         publish_branch: gh-pages
         publish_dir: allure-history

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -31,4 +31,4 @@ jobs:
       run: cd tests-functional; docker compose -f docker-compose.anvil.yml -f docker-compose.test.status-go.yml -f docker-compose.status-go.local.yml up --build --remove-orphans -d
 
     - name: Run tests
-      run: pytest -m "reliability"
+      run: cd tests-functional; pytest -m "reliability"

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Get workflow status
+      uses: technote-space/workflow-conclusion-action@v3
+
     - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v4
@@ -34,4 +37,50 @@ jobs:
       run: cd tests-functional; docker compose -f docker-compose.anvil.yml -f docker-compose.test.status-go.yml -f docker-compose.status-go.local.yml up --build --remove-orphans -d
 
     - name: Run tests
-      run: pytest -m "reliability" -c tests-functional/pytest.ini
+      run: pytest -m "reliability" -c tests-functional/pytest.ini --alluredir=allure-results
+
+    - name: Get allure history
+      if: env.WORKFLOW_CONCLUSION != 'cancelled'
+      uses: actions/checkout@v4
+      continue-on-error: true
+      with:
+        repository: status-im/status-cli-tests
+        ref: gh-pages
+        path: gh-pages
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup allure report
+      uses: simple-elf/allure-report-action@master
+      if: env.WORKFLOW_CONCLUSION != 'cancelled'
+      id: allure-report
+      with:
+        allure_results: allure-results
+        gh_pages: gh-pages
+        allure_history: allure-history
+        keep_reports: 30
+        report_url: `https://status-im.github.io/status-cli-tests/`
+
+    - name: Deploy report to Github Pages
+      uses: peaceiris/actions-gh-pages@v4
+      if: env.WORKFLOW_CONCLUSION != 'cancelled'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        external_repository: status-im/status-cli-tests
+        publish_branch: gh-pages
+        publish_dir: allure-history
+
+    - name: Create job summary
+      if: always()
+      env:
+        JOB_STATUS: ${{ job.status }}
+      run: |
+        echo "## Run Information" >> $GITHUB_STEP_SUMMARY
+        echo "- **Event**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Actor**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+        echo "## Test Results" >> $GITHUB_STEP_SUMMARY
+        echo "Allure report will be available at: https://status-im.github.io/status-cli-tests/${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
+        {
+          echo 'JOB_SUMMARY<<EOF'
+          cat $GITHUB_STEP_SUMMARY
+          echo EOF
+        } >> $GITHUB_ENV

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -1,9 +1,6 @@
 name: Test Reliability
 
 on:
-  push:
-    branches:
-      - "test-reliability-workflow"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -2,6 +2,8 @@ name: Test Reliability
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron:  '0 2 * * *'
 
 env:
   FORCE_COLOR: "1"

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   FORCE_COLOR: "1"
+  DEPLOY_TEST_REPORTS_PAT: ${{ secrets.DEPLOY_TEST_REPORTS_PAT }}
 
 jobs:
   test-reliability:
@@ -64,7 +65,7 @@ jobs:
       uses: peaceiris/actions-gh-pages@v4
       if: env.WORKFLOW_CONCLUSION != 'cancelled'
       with:
-        personal_token: ${{ secrets.GITHUB_TOKEN }}
+        personal_token: ${{ env.DEPLOY_TEST_REPORTS_PAT }}
         external_repository: status-im/status-cli-tests
         publish_branch: gh-pages
         publish_dir: allure-history

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -6,6 +6,9 @@ on:
       - "test-reliability-workflow"
   workflow_dispatch:
 
+env:
+  FORCE_COLOR: "1"
+
 jobs:
   test-reliability:
     timeout-minutes: 90

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -1,0 +1,34 @@
+name: Test Reliability
+
+on:
+  push:
+    branches:
+      - "test-reliability-workflow"
+  workflow_dispatch:
+
+jobs:
+  test-reliability:
+    timeout-minutes: 90
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+
+    - name: Set up virtual environment in /tests-functional/
+      run: |
+        python -m venv tests-functional/.venv
+        echo "tests-functional/.venv/bin" >> $GITHUB_PATH  # Add virtualenv to PATH for subsequent steps
+
+    - name: Install dependencies based on requirements.txt
+      run: pip install -r tests-functional/requirements.txt
+
+    - name: Build status-backend
+      run: cd tests-functional; docker compose -f docker-compose.anvil.yml -f docker-compose.test.status-go.yml -f docker-compose.status-go.local.yml up --build --remove-orphans
+
+    - name: Run tests
+      run: pytest -m "reliability"

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -41,7 +41,7 @@ jobs:
       run: pytest -m "reliability" -c tests-functional/pytest.ini --alluredir=allure-results
 
     - name: Get allure history
-      if: env.WORKFLOW_CONCLUSION != 'cancelled'
+      if: always()
       uses: actions/checkout@v4
       continue-on-error: true
       with:
@@ -52,7 +52,7 @@ jobs:
 
     - name: Setup allure report
       uses: simple-elf/allure-report-action@master
-      if: env.WORKFLOW_CONCLUSION != 'cancelled'
+      if: always()
       id: allure-report
       with:
         allure_results: allure-results
@@ -63,7 +63,7 @@ jobs:
 
     - name: Deploy report to Github Pages
       uses: peaceiris/actions-gh-pages@v4
-      if: env.WORKFLOW_CONCLUSION != 'cancelled'
+      if: always()
       with:
         personal_token: ${{ env.DEPLOY_TEST_REPORTS_PAT }}
         external_repository: status-im/status-cli-tests

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -58,7 +58,7 @@ jobs:
         gh_pages: gh-pages
         allure_history: allure-history
         keep_reports: 30
-        report_url: `https://status-im.github.io/status-cli-tests/`
+        report_url: 'https://status-im.github.io/status-cli-tests/'
 
     - name: Deploy report to Github Pages
       uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -31,4 +31,4 @@ jobs:
       run: cd tests-functional; docker compose -f docker-compose.anvil.yml -f docker-compose.test.status-go.yml -f docker-compose.status-go.local.yml up --build --remove-orphans -d
 
     - name: Run tests
-      run: cd tests-functional; pytest -m "reliability"
+      run: pytest -m "reliability" -c tests-functional/pytest.ini

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -66,7 +66,7 @@ jobs:
       if: env.WORKFLOW_CONCLUSION != 'cancelled'
       with:
         personal_token: ${{ env.DEPLOY_TEST_REPORTS_PAT }}
-        external_repository: status-im/status-cli-tests
+        external_repository: waku-org/allure-jswaku
         publish_branch: gh-pages
         publish_dir: allure-history
 

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -16,9 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Get workflow status
-      uses: technote-space/workflow-conclusion-action@v3
-
     - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v4

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -48,7 +48,7 @@ jobs:
         repository: status-im/status-cli-tests
         ref: gh-pages
         path: gh-pages
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ env.DEPLOY_TEST_REPORTS_PAT }}
 
     - name: Setup allure report
       uses: simple-elf/allure-report-action@master
@@ -66,7 +66,7 @@ jobs:
       if: env.WORKFLOW_CONCLUSION != 'cancelled'
       with:
         personal_token: ${{ env.DEPLOY_TEST_REPORTS_PAT }}
-        external_repository: waku-org/allure-jswaku
+        external_repository: status-im/status-cli-tests
         publish_branch: gh-pages
         publish_dir: allure-history
 

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -28,7 +28,7 @@ jobs:
       run: pip install -r tests-functional/requirements.txt
 
     - name: Build status-backend
-      run: cd tests-functional; docker compose -f docker-compose.anvil.yml -f docker-compose.test.status-go.yml -f docker-compose.status-go.local.yml up --build --remove-orphans
+      run: cd tests-functional; docker compose -f docker-compose.anvil.yml -f docker-compose.test.status-go.yml -f docker-compose.status-go.local.yml up --build --remove-orphans -d
 
     - name: Run tests
       run: pytest -m "reliability"

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/checkout@v4
       continue-on-error: true
       with:
-        repository: status-im/status-cli-tests
+        repository: status-im/status-go-allure
         ref: gh-pages
         path: gh-pages
         token: ${{ env.DEPLOY_TEST_REPORTS_PAT }}
@@ -59,14 +59,14 @@ jobs:
         gh_pages: gh-pages
         allure_history: allure-history
         keep_reports: 30
-        report_url: 'https://status-im.github.io/status-cli-tests/'
+        report_url: 'https://status-im.github.io/status-go-allure/'
 
     - name: Deploy report to Github Pages
       uses: peaceiris/actions-gh-pages@v4
       if: always()
       with:
         personal_token: ${{ env.DEPLOY_TEST_REPORTS_PAT }}
-        external_repository: status-im/status-cli-tests
+        external_repository: status-im/status-go-allure
         publish_branch: gh-pages
         publish_dir: allure-history
 
@@ -79,7 +79,7 @@ jobs:
         echo "- **Event**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
         echo "- **Actor**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
         echo "## Test Results" >> $GITHUB_STEP_SUMMARY
-        echo "Allure report will be available at: https://status-im.github.io/status-cli-tests/${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
+        echo "Allure report will be available at: https://status-im.github.io/status-go-allure/${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
         {
           echo 'JOB_SUMMARY<<EOF'
           cat $GITHUB_STEP_SUMMARY

--- a/tests-functional/pytest.ini
+++ b/tests-functional/pytest.ini
@@ -14,3 +14,4 @@ markers =
     init
     transaction
     create_account
+    reliability

--- a/tests-functional/requirements.txt
+++ b/tests-functional/requirements.txt
@@ -10,3 +10,5 @@ docker==7.1.0
 pyright==1.1.388
 black==24.10.0
 pre-commit==3.6.2
+allure-pytest==2.13.5
+allure-python-commons==2.13.5

--- a/tests-functional/tests/reliability/test_contact_request.py
+++ b/tests-functional/tests/reliability/test_contact_request.py
@@ -82,12 +82,8 @@ class TestContactRequests(MessengerTestCase):
 
     @pytest.mark.dependency(depends=["test_contact_request_baseline"])
     def test_contact_request_with_node_pause_30_seconds(self):
-        await_signals = [
-            SignalType.MESSAGES_NEW.value,
-            SignalType.MESSAGE_DELIVERED.value,
-        ]
-        sender = self.initialize_backend(await_signals=await_signals)
-        receiver = self.initialize_backend(await_signals=await_signals)
+        sender = self.initialize_backend(await_signals=self.await_signals)
+        receiver = self.initialize_backend(await_signals=self.await_signals)
 
         with self.node_pause(receiver):
             message_text = f"test_contact_request_{uuid4()}"


### PR DESCRIPTION
Added a workflow that runs the reliability tests.
Tests can be run on demand on any branch ATM.
Reporting and deploying [allure reports](https://status-im.github.io/status-go-allure) with results
Run [example](https://github.com/status-im/status-go/actions/runs/12692100712). Report link can be seen in the job summary 
![image](https://github.com/user-attachments/assets/8d8a5717-2aba-4820-b9b7-51f2b1fa50e2)
