### PR TITLE
fix_: ensure generated identity-images have a valid clock value

### DIFF
--- a/images/main.go
+++ b/images/main.go
@@ -3,6 +3,7 @@ package images
 import (
 	"bytes"
 	"image"
+	"time"
 )
 
 func GenerateImageVariants(cImg image.Image) ([]IdentityImage, error) {
@@ -25,6 +26,7 @@ func GenerateImageVariants(cImg image.Image) ([]IdentityImage, error) {
 			Height:       rImg.Bounds().Dy(),
 			FileSize:     bb.Len(),
 			ResizeTarget: int(s),
+			Clock:        uint64(time.Now().UnixMilli()),
 		}
 
 		iis = append(iis, ii)

--- a/images/main_test.go
+++ b/images/main_test.go
@@ -44,3 +44,27 @@ func TestGenerateBannerImage_ShrinkOnly(t *testing.T) {
 	require.Exactly(t, identityImage.Width, int(BannerDim))
 	require.Exactly(t, identityImage.Height, 805)
 }
+
+func TestGenerateIdentityImages(t *testing.T) {
+	// Create image data
+	testImage := image.NewRGBA(image.Rect(0, 0, int(BannerDim)+10, int(BannerDim)+20))
+
+	// Create a temporary file for storing the image data
+	tmpTestFilePath := t.TempDir() + "/test.png"
+	file, err := os.Create(tmpTestFilePath)
+	require.NoError(t, err)
+	defer file.Close()
+
+	// Save the image data to the temporary file
+	err = png.Encode(file, testImage)
+	require.NoError(t, err)
+
+	// Generate the identity images
+	identityImages, err := GenerateIdentityImages(tmpTestFilePath, 100, 100, 500, 500)
+	require.NoError(t, err)
+
+	// Check the identity images have a valid clock value
+	for _, image := range identityImages {
+		require.NotEqual(t, image.Clock, uint64(0))
+	}
+}

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -779,7 +779,7 @@ func (m *Messenger) updateContactImagesURL(contact *Contact) error {
 			if err != nil {
 				return err
 			}
-			v.LocalURL = m.httpServer.MakeContactImageURL(common.PubkeyToHex(publicKey), k)
+			v.LocalURL = m.httpServer.MakeContactImageURL(common.PubkeyToHex(publicKey), k, v.Clock)
 			contact.Images[k] = v
 		}
 	}

--- a/server/server_media.go
+++ b/server/server_media.go
@@ -230,10 +230,10 @@ func (s *MediaServer) MakeQRURL(qurul string,
 	return u.String()
 }
 
-func (s *MediaServer) MakeContactImageURL(publicKey string, imageType string) string {
+func (s *MediaServer) MakeContactImageURL(publicKey string, imageType string, imageClock uint64) string {
 	u := s.MakeBaseURL()
 	u.Path = contactImagesPath
-	u.RawQuery = url.Values{"publicKey": {publicKey}, "imageName": {imageType}}.Encode()
+	u.RawQuery = url.Values{"publicKey": {publicKey}, "imageName": {imageType}, "clock": {fmt.Sprint(imageClock)}}.Encode()
 
 	return u.String()
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -145,6 +145,15 @@ func (s *ServerURLSuite) TestServer_MakeStickerURL() {
 		s.serverNoPort.MakeStickerURL("0xdeadbeef4ac0"))
 }
 
+func (s *ServerURLSuite) TestServer_MakeContactImageURL() {
+	s.Require().Equal(
+		baseURLWithCustomPort+"/contactImages?clock=1&imageName=Test&publicKey=0x1",
+		s.server.MakeContactImageURL("0x1", "Test", uint64(1)))
+	s.testNoPort(
+		baseURLWithDefaultPort+"/contactImages?clock=1&imageName=Test&publicKey=0x1",
+		s.serverNoPort.MakeContactImageURL("0x1", "Test", uint64(1)))
+}
+
 // TestQRCodeGeneration tests if we provide all the correct parameters to the media server
 // do we get a valid QR code or not as part of the response payload.
 // we have stored a generated QR code in tests folder, and we compare their bytes.


### PR DESCRIPTION
status-mobile PR: https://github.com/status-im/status-mobile/pull/21931
status-desktop PR: https://github.com/status-im/status-desktop/pull/17054

### Summary

* This PR attempts to resolve an issue related to how identity images are generated with clock field defaulted to zero. The clock field is likely used for determining the creation time of the identity images, we can help with detecting changes to identity images after they've been updated.
* For example, here's the current work-around being used inside status-mobile: https://github.com/status-im/status-mobile/pull/21795/files