### PR TITLE
chore(onboarding)_: enable creating accounts without a displayName

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1750,7 +1750,7 @@ func (b *GethStatusBackend) getDerivedAddresses(id string) (map[string]generator
 // NOTE: requests.CreateAccount is used for public, params.Option maybe used for internal usage.
 func (b *GethStatusBackend) CreateAccountAndLogin(request *requests.CreateAccount, opts ...params.Option) (*multiaccounts.Account, error) {
 	validation := &requests.CreateAccountValidation{
-		AllowEmptyDisplayName: false,
+		AllowEmptyDisplayName: true,
 	}
 	if err := request.Validate(validation); err != nil {
 		return nil, err

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -529,7 +529,7 @@ func createAccountAndLogin(requestJSON string) string {
 	}
 
 	err = request.Validate(&requests.CreateAccountValidation{
-		AllowEmptyDisplayName: false,
+		AllowEmptyDisplayName: true,
 	})
 	if err != nil {
 		return makeJSONResponse(err)


### PR DESCRIPTION
The new onboarding flows let users create accounts without a display name to simplify the flows.