### PR TITLE
fix_: guard against malformed tokenID in router

### DIFF
--- a/services/wallet/router/router_helper.go
+++ b/services/wallet/router/router_helper.go
@@ -347,14 +347,24 @@ func (r *Router) evaluateAndUpdatePathDetails(ctx context.Context, path *routes.
 	return
 }
 
+func ParseCollectibleID(ID string) (contractAddress common.Address, tokenID *big.Int, success bool) {
+	success = false
+
+	parts := strings.Split(ID, ":")
+	if len(parts) != 2 {
+		return
+	}
+	contractAddress = common.HexToAddress(parts[0])
+	tokenID, success = new(big.Int).SetString(parts[1], 10)
+	return
+}
+
 func findToken(sendType sendtype.SendType, tokenManager *token.Manager, collectibles *collectibles.Service, account common.Address, network *params.Network, tokenID string) *token.Token {
 	if !sendType.IsCollectiblesTransfer() {
 		return tokenManager.FindToken(network, tokenID)
 	}
 
-	parts := strings.Split(tokenID, ":")
-	contractAddress := common.HexToAddress(parts[0])
-	collectibleTokenID, success := new(big.Int).SetString(parts[1], 10)
+	contractAddress, collectibleTokenID, success := ParseCollectibleID(tokenID)
 	if !success {
 		return nil
 	}

--- a/services/wallet/router/router_helper_test.go
+++ b/services/wallet/router/router_helper_test.go
@@ -84,3 +84,17 @@ func (s *CalculateFeesTestSuite) TestCalculateApprovalL1Fee_ZeroFeeOnContractCal
 func TestCalculateFeesTestSuite(t *testing.T) {
 	suite.Run(t, new(CalculateFeesTestSuite))
 }
+
+func TestParseCollectibleID(t *testing.T) {
+	collectibleID := "RANDOM"
+	_, _, success := router.ParseCollectibleID(collectibleID)
+	require.False(t, success)
+
+	collectibleID = "0xfC43ac5f309499385e91e059862bDb0Bfa2Cd16c:123"
+	expectedContractAddress := common.HexToAddress("0xfC43ac5f309499385e91e059862bDb0Bfa2Cd16c")
+	expectedCollectibleID := big.NewInt(123)
+	parsedContractAddress, parsedCollectibleID, success := router.ParseCollectibleID(collectibleID)
+	require.True(t, success)
+	require.Equal(t, expectedContractAddress, parsedContractAddress)
+	require.Equal(t, expectedCollectibleID, parsedCollectibleID)
+}


### PR DESCRIPTION
The client is apparently sending a malformed tokenID in some scenario I haven't determined yet when attempting to send a collectible. This check at least prevents the app from crashing.