### PR TITLE
ci_: upgrade go to 1.22

### DIFF
--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -1,5 +1,5 @@
 # Build status-go in a Go builder container
-FROM golang:1.21-alpine3.18 as builder
+FROM golang:1.22-alpine3.18 as builder
 
 # Set environment variables to use Clang
 ENV CC=clang

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/status-im/status-go
 
-go 1.21
-
-toolchain go1.21.8
+go 1.22
 
 replace github.com/ethereum/go-ethereum v1.10.26 => github.com/status-im/go-ethereum v1.10.25-status.18
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -25,20 +25,20 @@ in rec {
 
   openjdk = prev.openjdk17_headless;
 
-  go = prev.go_1_21;
-  buildGoModule = prev.buildGo121Module;
-  buildGoPackage = prev.buildGo121Package;
+  go = prev.go_1_22;
+  buildGoModule = prev.buildGo122Module;
+  buildGoPackage = prev.buildGo122Package;
 
   golangci-lint = prev.golangci-lint.override {
-    buildGoModule = args: prev.buildGo121Module ( args // rec {
-      version = "1.54.0";
+    buildGoModule = args: prev.buildGo122Module ( args // rec {
+      version = "1.59.1";
       src = prev.fetchFromGitHub {
         owner = "golangci";
         repo = "golangci-lint";
         rev = "v${version}";
-        hash = "sha256-UXN5gN1SNv3uvBCliJQ+5PSGHRL7RyU6pmZtGUTFsrQ=";
+        hash = "sha256-VFU/qGyKBMYr0wtHXyaMjS5fXKAHWe99wDZuSyH8opg=";
       };
-      vendorHash = "sha256-jUlK/A0HxBrIby2C0zYFtnxQX1bgKVyypI3QdH4u/rg=";
+      vendorHash = "sha256-yYwYISK1wM/mSlAcDSIwYRo8sRWgw2u+SsvgjH+Z/7M=";
     });
   };
 
@@ -56,21 +56,9 @@ in rec {
   go-modvendor = callPackage ./pkgs/go-modvendor { };
   codecov-cli = callPackage ./pkgs/codecov-cli { };
   go-generate-fast = callPackage ./pkgs/go-generate-fast { };
-
-  gomobile = (prev.gomobile.overrideAttrs (old: {
-    patches = [
-      (final.fetchurl { # https://github.com/golang/mobile/pull/84
-        url = "https://github.com/golang/mobile/commit/f20e966e05b8f7e06bed500fa0da81cf6ebca307.patch";
-        sha256 = "sha256-TZ/Yhe8gMRQUZFAs9G5/cf2b9QGtTHRSObBFD5Pbh7Y=";
-      })
-      (final.fetchurl { # https://github.com/golang/go/issues/58426
-        url = "https://github.com/golang/mobile/commit/406ed3a7b8e44dc32844953647b49696d8847d51.patch";
-        sha256 = "sha256-dqbYukHkQEw8npOkKykOAzMC3ot/Y4DEuh7fE+ptlr8=";
-      })
-      (final.fetchurl { # https://github.com/golang/go/issues/63141
-        url = "https://github.com/golang/mobile/commit/e2f452493d570cfe278e63eccec99e62d4c775e5.patch";
-        sha256 = "sha256-gFcy/Ikh7MzmDx5Tpxe3qCnP36+ZTKU2XkJGH6n5l7Q=";
-      })
-    ];
-  }));
+  # brough in gomobile derivation from https://github.com/NixOS/nixpkgs/commit/f5abef98e8b8c9f9e6da4bdab63f8be1e57ea8c0
+  # enabled CGO_ENABLED for status-mobile
+  # swapped --replace plag with --replace-queit in substituteInPlace block because its deprecated in newer nix versions
+  # swapped buildGoModule with buildGo122Module to ensure derivation is built with go 1.22
+  gomobile = callPackage ./pkgs/gomobile { };
 }

--- a/nix/pkgs/gomobile/default.nix
+++ b/nix/pkgs/gomobile/default.nix
@@ -1,0 +1,85 @@
+{
+  stdenv,
+  lib,
+  fetchgit,
+  fetchurl,
+  buildGo122Module,
+  zlib,
+  makeWrapper,
+  xcodeenv,
+  androidenv,
+  xcodeWrapperArgs ? { },
+  xcodeWrapper ? xcodeenv.composeXcodeWrapper xcodeWrapperArgs,
+  withAndroidPkgs ? true,
+  androidPkgs ? (
+    androidenv.composeAndroidPackages {
+      includeNDK = true;
+    }
+  ),
+}:
+buildGo122Module {
+  pname = "gomobile";
+  version = "0-unstable-2024-12-13";
+
+  src = fetchgit {
+    name = "gomobile";
+    url = "https://go.googlesource.com/mobile";
+    rev = "a87c1cf6cf463f0d4476cfe0fcf67c2953d76e7c";
+    hash = "sha256-7j4rdmCZMC8tn4vAsC9x/mMNkom/+Tl7uAY+5gkSvfY=";
+  };
+
+  vendorHash = "sha256-6ycxEDEE0/i6Lxo0gb8wq3U2U7Q49AJj+PdzSl57wwI=";
+
+  CGO_ENABLED = "1";
+
+  subPackages = [
+    "bind"
+    "cmd/gobind"
+    "cmd/gomobile"
+  ];
+
+  # Fails with: go: cannot find GOROOT directory
+  doCheck = false;
+
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcodeWrapper ];
+
+  # Prevent a non-deterministic temporary directory from polluting the resulting object files
+  postPatch = ''
+    substituteInPlace cmd/gomobile/env.go --replace-quiet \
+      'tmpdir, err = ioutil.TempDir("", "gomobile-work-")' \
+      'tmpdir = filepath.Join(os.Getenv("NIX_BUILD_TOP"), "gomobile-work")'
+    substituteInPlace cmd/gomobile/init.go --replace-quiet \
+      'tmpdir, err = ioutil.TempDir(gomobilepath, "work-")' \
+      'tmpdir = filepath.Join(os.Getenv("NIX_BUILD_TOP"), "work")'
+
+    # To fix unable to import bind: no Go package in golang.org/x/mobile/bind
+    substituteInPlace cmd/gomobile/init.go --replace \
+      'golang.org/x/mobile/cmd/gobind@latest' \
+      'golang.org/x/mobile/cmd/gobind'
+  '';
+
+  # Necessary for GOPATH when using gomobile.
+  postInstall = ''
+    mkdir -p $out/src/golang.org/x
+    ln -s $src $out/src/golang.org/x/mobile
+  '';
+
+  postFixup = ''
+    for prog in gomobile gobind; do
+      wrapProgram $out/bin/$prog \
+        --suffix GOPATH : $out \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ zlib ]}" \
+        ${lib.optionalString withAndroidPkgs ''
+          --prefix PATH : "${androidPkgs.androidsdk}/bin" \
+          --set-default ANDROID_HOME "${androidPkgs.androidsdk}/libexec/android-sdk"
+        ''}
+    done
+  '';
+
+  meta = {
+    description = "Tool for building and running mobile apps written in Go";
+    homepage = "https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile";
+    license = with lib.licenses; [ bsd3 ];
+    maintainers = with lib.maintainers; [ jakubgs ];
+  };
+}

--- a/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
+++ b/nix/pkgs/xcodeenv/compose-xcodewrapper.nix
@@ -1,9 +1,14 @@
-{ stdenv, lib, writeShellScriptBin }:
-{ versions ? [ "14.3" "15.1" "15.2" "15.3" ]
-, xcodeBaseDir ? "/Applications/Xcode.app" }:
+{
+  lib,
+  stdenv,
+  writeShellScriptBin,
+}:
+{
+  versions ? [ ],
+  xcodeBaseDir ? "/Applications/Xcode.app",
+}:
 
-assert stdenv.isDarwin;
-
+assert stdenv.hostPlatform.isDarwin;
 let
   xcodebuildPath = "${xcodeBaseDir}/Contents/Developer/usr/bin/xcodebuild";
 
@@ -25,14 +30,22 @@ let
   '';
 in
 stdenv.mkDerivation {
-  pname = "xcode-wrapper-plus";
-  version = lib.concatStringsSep "," versions;
+  name = "xcode-wrapper-impure";
   # Fails in sandbox. Use `--option sandbox relaxed` or `--option sandbox false`.
   __noChroot = true;
   buildCommand = ''
     mkdir -p $out/bin
     cd $out/bin
-    ln -s "${xcodebuildWrapper}/bin/xcode-select"
+    ${
+      if versions == [ ] then
+        ''
+          ln -s "${xcodebuildPath}"
+        ''
+      else
+        ''
+          ln -s "${xcodebuildWrapper}/bin/xcode-select"
+        ''
+    }
     ln -s /usr/bin/security
     ln -s /usr/bin/codesign
     ln -s /usr/bin/xcrun
@@ -41,7 +54,6 @@ stdenv.mkDerivation {
     ln -s /usr/bin/lipo
     ln -s /usr/bin/file
     ln -s /usr/bin/rev
-    ln -s "${xcodebuildWrapper}/bin/xcodebuild"
     ln -s "${xcodeBaseDir}/Contents/Developer/Applications/Simulator.app/Contents/MacOS/Simulator"
 
     cd ..

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -8,7 +8,7 @@ let
 
   /* Lock requires Xcode verison. */
   xcodeWrapper = callPackage ./pkgs/xcodeenv/compose-xcodewrapper.nix { } {
-      versions = ["14.3" "15.1" "15.2" "15.3" "15.4"];
+      versions = [ ];
   };
 
   /* Gomobile also needs the Xcode wrapper. */

--- a/params/config.go
+++ b/params/config.go
@@ -1113,6 +1113,7 @@ func (c *NodeConfig) Save() error {
 	}
 
 	configFilePath := filepath.Join(c.DataDir, "config.json")
+	//nolint:gosec
 	if err := ioutil.WriteFile(configFilePath, data, os.ModePerm); err != nil {
 		return err
 	}

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -2100,6 +2100,7 @@ func (p *Persistence) GetCommunityRequestsToJoinRevealedAddresses(communityID []
 func (p *Persistence) GetEncryptionKeyRequests(communityID []byte, channelIDs map[string]struct{}) (map[string]*EncryptionKeysRequestRecord, error) {
 	result := map[string]*EncryptionKeysRequestRecord{}
 
+	//nolint:gosec
 	query := "SELECT channel_id, requested_at, requested_count FROM community_encryption_keys_requests WHERE community_id = ? AND channel_id IN (?" + strings.Repeat(",?", len(channelIDs)-1) + ")"
 
 	args := make([]interface{}, 0, len(channelIDs)+1)
@@ -2160,6 +2161,7 @@ func (p *Persistence) UpdateAndPruneEncryptionKeyRequests(communityID types.HexB
 	}
 
 	// Delete entries that do not match the channelIDs list
+	//nolint:gosec
 	deleteQuery := "DELETE FROM community_encryption_keys_requests WHERE community_id = ? AND channel_id NOT IN (?" + strings.Repeat(",?", len(channelIDs)-1) + ")"
 	args := make([]interface{}, 0, len(channelIDs)+1)
 	args = append(args, communityID)

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -835,6 +835,7 @@ func (tm *Manager) GetCachedBalancesByChain(accounts, tokenAddresses []common.Ad
 		chainIDStrings[i] = fmt.Sprintf("%d", chainID)
 	}
 
+	//nolint: gosec
 	query := `SELECT chain_id, user_address, token_address, raw_balance
 			  	FROM token_balances
 				WHERE user_address IN (` + strings.Join(accountStrings, ",") + `)


### PR DESCRIPTION
related issue: https://github.com/status-im/status-go/issues/6254

## Summary
- upgrade `go` to `1.22`
- modify `xcodewrapper` to latest version from `nixpkgs`
- bring in `gomobile` derivation with newer version.
- upgrade golangci-lint to `1.59.1` for `go` version `1.22` support https://github.com/golangci/golangci-lint/releases/tag/v1.59.1
  -  make few exceptions incase of db queries for `gosec`

## Pending
- [x] status-mobile PR -> https://github.com/status-im/status-mobile/pull/21940
- [x] status-desktop PR -> https://github.com/status-im/status-desktop/pull/17084

## Related 
- https://github.com/golang/go/issues/67927
- https://github.com/golang/go/issues/34181