### PR TITLE
fix_: check if bridge for token exists in ToChainId before returning contract address for FromChainId

### DIFF
--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -22,6 +22,7 @@ const (
 	SttSymbol  = "STT"
 	UsdcSymbol = "USDC"
 	HopSymbol  = "HOP"
+	DaiSymbol  = "DAI"
 )
 
 type ChainID uint64

--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -154,7 +154,12 @@ func (h *HopBridgeProcessor) AvailableFor(params ProcessorInputParams) (bool, er
 	if params.FromChain.ChainID == params.ToChain.ChainID {
 		return false, ErrFromAndToChainsMustBeDifferent
 	}
-	// We chcek if the contract is available on the network for the token
+	// We check if the contract is available on the receiver network for the token
+	if _, _, err := hop.GetContractAddress(params.ToChain.ChainID, params.FromToken.Symbol); err != nil {
+		return false, ErrToChainNotSupported
+	}
+
+	// We check if the contract is available on the sender network for the token
 	_, err := h.GetContractAddress(params)
 	// toToken is not nil only if the send type is Swap
 	return err == nil, err

--- a/services/wallet/router/pathprocessor/processor_test.go
+++ b/services/wallet/router/pathprocessor/processor_test.go
@@ -45,6 +45,22 @@ var optimism = params.Network{
 	RelatedChainID:         walletCommon.OptimismMainnet,
 }
 
+var base = params.Network{
+	ChainID:                walletCommon.BaseMainnet,
+	ChainName:              "Base",
+	BlockExplorerURL:       "https://basescan.org",
+	IconURL:                "network/Network=Base",
+	ChainColor:             "#0052FF",
+	ShortName:              "base",
+	NativeCurrencyName:     "Ether",
+	NativeCurrencySymbol:   "ETH",
+	NativeCurrencyDecimals: 18,
+	IsTest:                 false,
+	Layer:                  2,
+	Enabled:                true,
+	RelatedChainID:         walletCommon.BaseMainnet,
+}
+
 var testEstimationMap = map[string]requests.Estimation{
 	pathProcessorCommon.ProcessorTransferName:     {Value: uint64(1000)},
 	pathProcessorCommon.ProcessorBridgeHopName:    {Value: uint64(5000)},
@@ -265,6 +281,32 @@ func TestPathProcessors(t *testing.T) {
 				pathProcessorCommon.ProcessorSwapParaswapName: {
 					expected:      false,
 					expectedError: ErrFromAndToChainsMustBeSame,
+				},
+			},
+		},
+		{
+			name: "Different Chains Set - FormToken Set - No ToToken - Token Not Supported On ToChain",
+			input: ProcessorInputParams{
+				TestsMode: true,
+				FromChain: &optimism,
+				ToChain:   &base,
+				FromToken: &token.Token{
+					Symbol: walletCommon.DaiSymbol,
+				},
+				TestEstimationMap: testEstimationMap,
+			},
+			expected: map[string]expectedResult{
+				pathProcessorCommon.ProcessorTransferName: {
+					expected:      false,
+					expectedError: nil,
+				},
+				pathProcessorCommon.ProcessorBridgeHopName: {
+					expected:      false,
+					expectedError: ErrToChainNotSupported,
+				},
+				pathProcessorCommon.ProcessorSwapParaswapName: {
+					expected:      false,
+					expectedError: ErrToAndFromTokensMustBeSet,
 				},
 			},
 		},


### PR DESCRIPTION
Currently, Hop does not support some tokens on Base such as DAI or USDT, but the router returns a valid route for such transactions, ending on failed transactions and gas wasting for such cases.

This PR adds a check for the bridge contract receiving chain ID before returning the bridge contract for the sender chain ID, in that way we return an error if the token is not supported on Hop for the receiving chain ID.

We have an issue in status-mobile which this PR should partially fix it (proper fix would be to prevent the user to select unsupported tokens for selected chain): https://github.com/status-im/status-mobile/issues/21964