### PR TITLE
fix(suggested-fees)_: crash caused by null GasPrice

### DIFF
--- a/services/wallet/router/fees/fees.go
+++ b/services/wallet/router/fees/fees.go
@@ -98,6 +98,7 @@ func (f *FeeManager) SuggestedFees(ctx context.Context, chainID uint64) (*Sugges
 	}
 
 	return &SuggestedFees{
+		GasPrice:             big.NewInt(0),
 		BaseFee:              baseFee,
 		CurrentBaseFee:       baseFee,
 		MaxPriorityFeePerGas: maxPriorityFeePerGas,

--- a/services/wallet/router/fees/fees_test.go
+++ b/services/wallet/router/fees/fees_test.go
@@ -156,7 +156,7 @@ func TestSuggestedFeesForEIP1559CompatibleChains(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, suggestedFees)
 
-	assert.Nil(t, suggestedFees.GasPrice)
+	assert.Equal(t, big.NewInt(0), suggestedFees.GasPrice)
 	assert.Equal(t, big.NewInt(6958609414), suggestedFees.BaseFee)
 	assert.Equal(t, big.NewInt(6958609414), suggestedFees.CurrentBaseFee)
 	assert.Equal(t, big.NewInt(7928609414), suggestedFees.MaxFeesLevels.Low.ToInt())


### PR DESCRIPTION
Fixed regression from this [commit](https://github.com/status-im/status-go/commit/90f4740adde188b0aa4b5807353ed02d38e4a802#diff-83298f3c4bcd1c4c2019cd466db559399fe93fbd79f5e2e20c3696da48879e14L133), which caused dapps transactions to fail (see error below).

```
ERROR[01-22|12:15:12.976] RPC method wallet_getSuggestedFees crashed: runtime error: invalid memory address or nil pointer dereference
goroutine 2524 [running]:
github.com/ethereum/go-ethereum/rpc.(*callback).call.func1()
        /home/cl/dev/work/status-go/vendor/github.com/ethereum/go-ethereum/rpc/service.go:199 +0x85
panic({0x25614c0?, 0x4654280?})
        /nix/store/mf08k94zrnzb2q8x303g14l2ryi2ws3w-go-1.21.10/share/go/src/runtime/panic.go:914 +0x21f
math/big.(*Int).BitLen(...)
        /nix/store/mf08k94zrnzb2q8x303g14l2ryi2ws3w-go-1.21.10/share/go/src/math/big/int.go:550
math/big.(*Float).SetInt(0xc001be1450?, 0x2957450?)
        /nix/store/mf08k94zrnzb2q8x303g14l2ryi2ws3w-go-1.21.10/share/go/src/math/big/float.go:604 +0x12
github.com/status-im/status-go/services/wallet/common.WeiToGwei(0x0)
        /home/cl/dev/work/status-go/services/wallet/common/utils.go:74 +0x171
github.com/status-im/status-go/services/wallet/router/fees.(*FeeManager).SuggestedFeesGwei(0xc001be1588?, {0x31b3250?, 0xc0037e0910?}, 0x0?)
        /home/cl/dev/work/status-go/services/wallet/router/fees/fees.go:133 +0x3e
github.com/status-im/status-go/services/wallet.(*API).GetSuggestedFees(0xc000ee94e8, {0x31b3250, 0xc0037e0910}, 0x473813?)
        /home/cl/dev/work/status-go/services/wallet/api.go:445 +0x66
reflect.Value.call({0xc00100cc60?, 0xc000a37db0?, 0x7ab2f89e5c80?}, {0x2932c8b, 0x4}, {0xc0037e0960, 0x3, 0x41baf2?})
        /nix/store/mf08k94zrnzb2q8x303g14l2ryi2ws3w-go-1.21.10/share/go/src/reflect/value.go:596 +0xce7
reflect.Value.Call({0xc00100cc60?, 0xc000a37db0?, 0x5480a5?}, {0xc0037e0960?, 0x1?, 0x16?})
        /nix/store/mf08k94zrnzb2q8x303g14l2ryi2ws3w-go-1.21.10/share/go/src/reflect/value.go:380 +0xb9
github.com/ethereum/go-ethereum/rpc.(*callback).call(0xc000cb5aa0, {0x31b3250?, 0xc0037e0910}, {0xc005124300, 0x17}, {0xc005b04600, 0x1, 0x4d978f?})
        /home/cl/dev/work/status-go/vendor/github.com/ethereum/go-ethereum/rpc/service.go:205 +0x379
github.com/ethereum/go-ethereum/rpc.(*handler).runMethod(0xc0017c5e38?, {0x31b3250?, 0xc0037e0910?}, 0xc003228620, 0x1?, {0xc005b04600?, 0x0?, 0xc0016dae08?})
        /home/cl/dev/work/status-go/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:391 +0x3c
github.com/ethereum/go-ethereum/rpc.(*handler).handleCall(0xc000842090, 0xc005f341e0, 0xc003228620)
        /home/cl/dev/work/status-go/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:336 +0x22f
github.com/ethereum/go-ethereum/rpc.(*handler).handleCallMsg(0xc000842090, 0x30?, 0xc003228620)
        /home/cl/dev/work/status-go/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:297 +0x22d
github.com/ethereum/go-ethereum/rpc.(*handler).handleMsg.func1(0xc005f341e0)
        /home/cl/dev/work/status-go/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:138 +0x2f
github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc.func1()
        /home/cl/dev/work/status-go/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:225 +0xbe
created by github.com/ethereum/go-ethereum/rpc.(*handler).startCallProc in goroutine 322
        /home/cl/dev/work/status-go/vendor/github.com/ethereum/go-ethereum/rpc/handler.go:221 +0x79

WARN [01-22|12:15:12.977] Served wallet_getSuggestedFees           reqid=45 duration=682.854141ms err="method handler crashed"
```

Related [#21967](https://github.com/status-im/status-mobile/issues/21967)
