### PR TITLE
fix_: simplify version used in go:generate

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,7 +8,7 @@ import (
 // Use go:generate script to get the version and git commit.
 // VERSION and GIT_COMMIT files are used in further `go:embed` commands to load values to the variables.
 // Suppress errors, assuming files have already been properly generated. Required for Docker builds.
-//go:generate sh -c "../../_assets/scripts/version.sh > VERSION || true"
+//go:generate sh -c "git describe --tags --dirty='-dirty' > VERSION || true"
 //go:generate sh -c "git rev-parse --short HEAD > GIT_COMMIT || true"
 
 var (


### PR DESCRIPTION
## Summary

This PR simplifies version generation.
Mobile `nix` derivation for `status-go` is unable to find this script since its filtered out via our `mkfilter`.
https://github.com/status-im/status-mobile/blob/develop/nix/status-go/source.nix#L31

Otherwise we get errors like : 

```
sh: line 1: ../../_assets/scripts/version.sh: cannot execute: required file not found
```