### PR TITLE
Fix typo

### DIFF
--- a/cmd/status-cli/README.md
+++ b/cmd/status-cli/README.md
@@ -1,6 +1,6 @@
 # Status CLI
 
-The Status CLI is a command line interface for interacting with the Status messenging process. It is a tool for developers and QAs to test the communication workflow without running Status desktop and mobile app.
+The Status CLI is a command line interface for interacting with the Status messaging process. It is a tool for developers and QAs to test the communication workflow without running Status desktop and mobile app.
 
 ## Features
 

--- a/services/ext/README.md
+++ b/services/ext/README.md
@@ -45,7 +45,7 @@ Sends a request for historic messages to a mail server.
 
 1. `Object` - The message request object:
 
-- `mailServerPeer`:`URL` - Mail servers' enode addess
+- `mailServerPeer`:`URL` - Mail servers' enode address
 - `from`:`QUANTITY` - (optional) Lower bound of time range as unix timestamp, default is 24 hours back from now
 - `to`:`QUANTITY`- (optional) Upper bound of time range as unix timestamp, default is now
 - `topic`:`DATA`, 4 Bytes - Regular whisper topic


### PR DESCRIPTION
# Fix typos in `README.md` files

## Description
This PR fixes typos in two `README.md` files:
1. In `cmd/status-cli/README.md`, the word "messenging" was corrected to "messaging."
2. In `services/ext/README.md`, the word "addess" was corrected to "address."

## Changes
- **File 1:** `cmd/status-cli/README.md`
  - **Line:** 1
  - **Change:** Replaced "messenging" with "messaging."
- **File 2:** `services/ext/README.md`
  - **Line:** 45
  - **Change:** Replaced "addess" with "address."

## Commit Details
- **Commit 1:** Typo fix in `README.md`
  - **Author:** @petryshkaCODE
  - **Date:** January 27, 2025
- **Commit 2:** Typo fix in the `README.md`
  - **Author:** @petryshkaCODE
  - **Date:** January 27, 2025

## Checklist
- [x] My code follows the repository's contributing guidelines.
- [x] I have reviewed my changes for accuracy.
- [x] I have tested my changes (if applicable).

## Additional Notes
These are minor typo fixes and do not impact functionality.

---

**Able to merge:** These branches can be automatically merged.

**Allow edits by maintainers:** ✅

---

Thank you for reviewing this pull request! Let me know if any further changes are needed.