### PR TITLE
fix_: improve filter and clean up orphan containers

### DIFF
--- a/_assets/ci/Jenkinsfile.tests-rpc
+++ b/_assets/ci/Jenkinsfile.tests-rpc
@@ -76,7 +76,14 @@ pipeline {
     }
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { sh 'make git-clean' }
+      cleanup {
+        script {
+          sh '''
+            docker ps -a --filter "name=status-go-func-tests-${BUILD_ID}" -q | xargs -r docker rm
+            make git-clean
+          '''
+        }
+      }
   } // post
 } // pipeline
 

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -24,13 +24,13 @@ mkdir -p "${merged_coverage_reports_path}"
 mkdir -p "${test_results_path}"
 
 all_compose_files="-f ${root_path}/docker-compose.anvil.yml -f ${root_path}/docker-compose.test.status-go.yml"
-timestamp=$(python3 -c "import time; print(int(time.time() * 1000))") # Keep in sync with status_backend.py
-project_name="status-go-func-tests-${timestamp}"
+identifier=${BUILD_ID:-$(git rev-parse --short HEAD)}
+project_name="status-go-func-tests-${identifier}"
 
 export STATUS_BACKEND_URLS=$(eval echo http://${project_name}-status-backend-{1..${STATUS_BACKEND_COUNT}}:3333 | tr ' ' ,)
 
 # Remove orphans
-docker ps -a --filter "name=status-go-func-tests-*-status-backend-*" --filter "status=exited" -q | xargs -r docker rm
+docker ps -a --filter "status-go-func-tests-${identifier}" --filter "status=exited" -q | xargs -r docker rm
 
 # Run docker
 echo -e "${GRN}Running tests${RST}, HEAD: $(git rev-parse HEAD)"

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -63,9 +63,9 @@ class StatusBackend(RpcClient, SignalClient):
     def _start_container(self, host_port, privileged):
         docker_project_name = option.docker_project_name
 
-        timestamp = int(time.time() * 1000)  # Keep in sync with run_functional_tests.sh
+        identifier = os.environ.get("BUILD_ID") if os.environ.get("CI") else os.popen("git rev-parse --short HEAD").read().strip()
         image_name = f"{docker_project_name}-status-backend:latest"
-        container_name = f"{docker_project_name}-status-backend-{timestamp}"
+        container_name = f"{docker_project_name}-{identifier}-status-backend-{host_port}"
 
         coverage_path = option.codecov_dir if option.codecov_dir else os.path.abspath("./coverage/binary")
 


### PR DESCRIPTION
## Summary

This PR:
- updates both status `docker` container names to include short `git sha` locally and jenkins `BUILD_ID` on CI
- updates cleanup command to filter by `identifier` which could be either `git sha` or `BUILD_ID`
- updates the cleanup stage in `jenkins` file to remove docker container via this identifier

This approach is more reliable in cleaning up `docker` containers and was tested by me on `linux-05`


