### PR TITLE
chore(audit)_: Added fail conditions for malformed string ints

### DIFF
--- a/common/errors.go
+++ b/common/errors.go
@@ -1,0 +1,7 @@
+package common
+
+import "fmt"
+
+var (
+	ErrBigIntSetFromString = func(val string) error { return fmt.Errorf("failed to set big.Int balance from string '%s'", val) }
+)

--- a/common/errors_test.go
+++ b/common/errors_test.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrBigIntSetFromString(t *testing.T) {
+	tcs := []struct {
+		Value    string
+		Expected string
+	}{
+		{"hello", "failed to set big.Int balance from string 'hello'"},
+		{"123456.44abc", "failed to set big.Int balance from string '123456.44abc'"},
+		{"13e1234234", "failed to set big.Int balance from string '13e1234234'"},
+	}
+
+	for _, tc := range tcs {
+		require.Equal(t, tc.Expected, ErrBigIntSetFromString(tc.Value).Error())
+	}
+}

--- a/protocol/identity/utils.go
+++ b/protocol/identity/utils.go
@@ -39,7 +39,7 @@ func toBigBaseImpl(value *big.Int, base uint64, res *[](uint64)) {
 	*res = append(*res, new(big.Int).Mod(value, bigBase).Uint64())
 }
 
-// compressedPubKey = |1.5 bytes chars cutoff|20 bytes emoji hash|10 bytes color hash|1.5 bytes chars cutoff|
+// Slices compressedPubKey = |1.5 bytes chars cutoff|20 bytes emoji hash|10 bytes color hash|1.5 bytes chars cutoff|
 func Slices(compressedPubkey []byte) (res [4][]byte, err error) {
 	if len(compressedPubkey) != 33 {
 		return res, errors.New("incorrect compressed pubkey")

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -318,7 +318,7 @@ func (r *Reader) isBalanceUpdateNeededAnyway(clients map[uint64]chain.ClientInte
 	return updateAnyway
 }
 
-func tokensToBalancesPerChain(cachedTokens map[common.Address][]tokenTypes.StorageToken) map[uint64]map[common.Address]map[common.Address]*hexutil.Big {
+func tokensToBalancesPerChain(cachedTokens map[common.Address][]tokenTypes.StorageToken) (map[uint64]map[common.Address]map[common.Address]*hexutil.Big, error) {
 	cachedBalancesPerChain := map[uint64]map[common.Address]map[common.Address]*hexutil.Big{}
 	for address, tokens := range cachedTokens {
 		for _, token := range tokens {
@@ -330,13 +330,16 @@ func tokensToBalancesPerChain(cachedTokens map[common.Address][]tokenTypes.Stora
 					cachedBalancesPerChain[balance.ChainID][address] = map[common.Address]*hexutil.Big{}
 				}
 
-				bigBalance, _ := new(big.Int).SetString(balance.RawBalance, 10)
+				bigBalance, ok := new(big.Int).SetString(balance.RawBalance, 10)
+				if !ok {
+					return nil, gocommon.ErrBigIntSetFromString(balance.RawBalance)
+				}
 				cachedBalancesPerChain[balance.ChainID][address][balance.Address] = (*hexutil.Big)(bigBalance)
 			}
 		}
 	}
 
-	return cachedBalancesPerChain
+	return cachedBalancesPerChain, nil
 }
 
 func (r *Reader) fetchBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address, tokenAddresses []common.Address) (map[uint64]map[common.Address]map[common.Address]*hexutil.Big, error) {
@@ -567,6 +570,10 @@ func (r *Reader) GetCachedBalances(clients map[uint64]chain.ClientInterface, add
 		connectedPerChain[chainID] = client.IsConnected()
 	}
 
-	balances := tokensToBalancesPerChain(cachedTokens)
+	balances, err := tokensToBalancesPerChain(cachedTokens)
+	if err != nil {
+		return nil, err
+	}
+
 	return r.balancesToTokensByAddress(connectedPerChain, addresses, allTokens, balances, cachedTokens), nil
 }

--- a/services/wallet/reader_test.go
+++ b/services/wallet/reader_test.go
@@ -349,7 +349,8 @@ func TestTokensToBalancesPerChain(t *testing.T) {
 		},
 	}
 
-	result := tokensToBalancesPerChain(cachedTokens)
+	result, err := tokensToBalancesPerChain(cachedTokens)
+	assert.NoError(t, err)
 
 	assert.Equal(t, expectedBalancesPerChain, result)
 }

--- a/services/wallet/router/pathprocessor/processor_bridge_celar.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_celar.go
@@ -18,11 +18,12 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/status-im/status-go/accounts-management/generator"
+
+	statuscommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/contracts/celer"
 	"github.com/status-im/status-go/eth-node/types"
-	"github.com/status-im/status-go/rpc"
-
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/services/utils"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/router/pathprocessor/cbridge"
@@ -455,6 +456,9 @@ func (s *CelerBridgeProcessor) CalculateAmountOut(params ProcessorInputParams) (
 	if amt.Err != nil {
 		return nil, createBridgeCellerErrorResponse(err)
 	}
-	amountOut, _ := new(big.Int).SetString(amt.EqValueTokenAmt, 10)
+	amountOut, ok := new(big.Int).SetString(amt.EqValueTokenAmt, 10)
+	if !ok {
+		return nil, statuscommon.ErrBigIntSetFromString(amt.EqValueTokenAmt)
+	}
 	return amountOut, nil
 }


### PR DESCRIPTION
resolves https://github.com/status-im/least-authority-audit/issues/13

In a few places we've not handled the fail condition for `big.Int.SetString(string)`, this PR adds the handling as per the audit feedback. See the above link for more details.