### PR TITLE
feat(network)_: implement deactivatable networks

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -22,6 +22,7 @@ import (
 
 	gethcrypto "github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/connection"
 	"github.com/status-im/status-go/eth-node/crypto"
@@ -1583,14 +1584,14 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 	}
 
 	require.Equal(t, b.config.WalletConfig.InfuraAPIKey, infuraToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[MainnetChainID], alchemyEthereumMainnetToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[SepoliaChainID], alchemyEthereumSepoliaToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[ArbitrumChainID], alchemyArbitrumMainnetToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[ArbitrumSepoliaChainID], alchemyArbitrumSepoliaToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[OptimismChainID], alchemyOptimismMainnetToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[OptimismSepoliaChainID], alchemyOptimismSepoliaToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[BaseChainID], alchemyBaseMainnetToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[BaseSepoliaChainID], alchemyBaseSepoliaToken)
+	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.MainnetChainID], alchemyEthereumMainnetToken)
+	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.SepoliaChainID], alchemyEthereumSepoliaToken)
+	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.ArbitrumChainID], alchemyArbitrumMainnetToken)
+	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.ArbitrumSepoliaChainID], alchemyArbitrumSepoliaToken)
+	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.OptimismChainID], alchemyOptimismMainnetToken)
+	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.OptimismSepoliaChainID], alchemyOptimismSepoliaToken)
+	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.BaseChainID], alchemyBaseMainnetToken)
+	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.BaseSepoliaChainID], alchemyBaseSepoliaToken)
 	require.Equal(t, b.config.WalletConfig.RaribleMainnetAPIKey, raribleMainnetAPIKey)
 	require.Equal(t, b.config.WalletConfig.RaribleTestnetAPIKey, raribleTestnetAPIKey)
 

--- a/api/common/const.go
+++ b/api/common/const.go
@@ -1,0 +1,12 @@
+package common
+
+const (
+	MainnetChainID         uint64 = 1
+	SepoliaChainID         uint64 = 11155111
+	OptimismChainID        uint64 = 10
+	OptimismSepoliaChainID uint64 = 11155420
+	ArbitrumChainID        uint64 = 42161
+	ArbitrumSepoliaChainID uint64 = 421614
+	BaseChainID            uint64 = 8453
+	BaseSepoliaChainID     uint64 = 84532
+)

--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -92,6 +92,8 @@ func mainnet(proxyHost, stageName string) params.Network {
 		Layer:                  1,
 		Enabled:                true,
 		RelatedChainID:         SepoliaChainID,
+		IsActive:               true,
+		IsDeactivatable:        false,
 	}
 }
 
@@ -114,10 +116,10 @@ func sepolia(proxyHost, stageName string) params.Network {
 
 	return params.Network{
 		ChainID:                chainID,
-		ChainName:              "Mainnet",
+		ChainName:              "Sepolia",
 		RpcProviders:           rpcProviders,
 		BlockExplorerURL:       "https://sepolia.etherscan.io/",
-		IconURL:                "network/Network=Ethereum",
+		IconURL:                "network/Network=Ethereum-test",
 		ChainColor:             "#627EEA",
 		ShortName:              "eth",
 		NativeCurrencyName:     "Ether",
@@ -127,6 +129,8 @@ func sepolia(proxyHost, stageName string) params.Network {
 		Layer:                  1,
 		Enabled:                true,
 		RelatedChainID:         MainnetChainID,
+		IsActive:               true,
+		IsDeactivatable:        false,
 	}
 }
 
@@ -162,6 +166,8 @@ func optimism(proxyHost, stageName string) params.Network {
 		Layer:                  2,
 		Enabled:                true,
 		RelatedChainID:         OptimismSepoliaChainID,
+		IsActive:               true,
+		IsDeactivatable:        true,
 	}
 }
 
@@ -184,10 +190,10 @@ func optimismSepolia(proxyHost, stageName string) params.Network {
 
 	return params.Network{
 		ChainID:                chainID,
-		ChainName:              "Optimism",
+		ChainName:              "Optimism Sepolia",
 		RpcProviders:           rpcProviders,
 		BlockExplorerURL:       "https://sepolia-optimism.etherscan.io/",
-		IconURL:                "network/Network=Optimism",
+		IconURL:                "network/Network=Optimism-test",
 		ChainColor:             "#E90101",
 		ShortName:              "oeth",
 		NativeCurrencyName:     "Ether",
@@ -197,6 +203,8 @@ func optimismSepolia(proxyHost, stageName string) params.Network {
 		Layer:                  2,
 		Enabled:                false,
 		RelatedChainID:         OptimismChainID,
+		IsActive:               true,
+		IsDeactivatable:        true,
 	}
 }
 
@@ -232,6 +240,8 @@ func arbitrum(proxyHost, stageName string) params.Network {
 		Layer:                  2,
 		Enabled:                true,
 		RelatedChainID:         ArbitrumSepoliaChainID,
+		IsActive:               true,
+		IsDeactivatable:        true,
 	}
 }
 
@@ -254,10 +264,10 @@ func arbitrumSepolia(proxyHost, stageName string) params.Network {
 
 	return params.Network{
 		ChainID:                chainID,
-		ChainName:              "Arbitrum",
+		ChainName:              "Arbitrum Sepolia",
 		RpcProviders:           rpcProviders,
 		BlockExplorerURL:       "https://sepolia-explorer.arbitrum.io/",
-		IconURL:                "network/Network=Arbitrum",
+		IconURL:                "network/Network=Arbitrum-test",
 		ChainColor:             "#51D0F0",
 		ShortName:              "arb1",
 		NativeCurrencyName:     "Ether",
@@ -267,6 +277,8 @@ func arbitrumSepolia(proxyHost, stageName string) params.Network {
 		Layer:                  2,
 		Enabled:                false,
 		RelatedChainID:         ArbitrumChainID,
+		IsActive:               true,
+		IsDeactivatable:        true,
 	}
 }
 
@@ -302,6 +314,8 @@ func base(proxyHost, stageName string) params.Network {
 		Layer:                  2,
 		Enabled:                true,
 		RelatedChainID:         BaseSepoliaChainID,
+		IsActive:               true,
+		IsDeactivatable:        true,
 	}
 }
 
@@ -324,10 +338,10 @@ func baseSepolia(proxyHost, stageName string) params.Network {
 
 	return params.Network{
 		ChainID:                chainID,
-		ChainName:              "Base",
+		ChainName:              "Base Sepolia",
 		RpcProviders:           rpcProviders,
 		BlockExplorerURL:       "https://sepolia.basescan.org/",
-		IconURL:                "network/Network=Base",
+		IconURL:                "network/Network=Base-test",
 		ChainColor:             "#0052FF",
 		ShortName:              "base",
 		NativeCurrencyName:     "Ether",
@@ -337,6 +351,8 @@ func baseSepolia(proxyHost, stageName string) params.Network {
 		Layer:                  2,
 		Enabled:                false,
 		RelatedChainID:         BaseChainID,
+		IsActive:               true,
+		IsDeactivatable:        true,
 	}
 }
 

--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -4,23 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/protocol/requests"
 )
 
 const (
-	MainnetChainID         uint64 = 1
-	SepoliaChainID         uint64 = 11155111
-	OptimismChainID        uint64 = 10
-	OptimismSepoliaChainID uint64 = 11155420
-	ArbitrumChainID        uint64 = 42161
-	ArbitrumSepoliaChainID uint64 = 421614
-	BaseChainID            uint64 = 8453
-	BaseSepoliaChainID     uint64 = 84532
-	sntSymbol                     = "SNT"
-	sttSymbol                     = "STT"
-
 	// Host suffixes for providers
 	SmartProxyHostSuffix = "eth-rpc.status.im"
 	ProxyHostSuffix      = "api.status.im"
@@ -61,7 +51,7 @@ func smartProxyUrl(proxyHost, chainName, networkName string) string {
 }
 
 func mainnet(proxyHost, stageName string) params.Network {
-	const chainID = MainnetChainID
+	const chainID = common.MainnetChainID
 	const chainName = "ethereum"
 	const networkName = "mainnet"
 
@@ -91,14 +81,14 @@ func mainnet(proxyHost, stageName string) params.Network {
 		IsTest:                 false,
 		Layer:                  1,
 		Enabled:                true,
-		RelatedChainID:         SepoliaChainID,
+		RelatedChainID:         common.SepoliaChainID,
 		IsActive:               true,
 		IsDeactivatable:        false,
 	}
 }
 
 func sepolia(proxyHost, stageName string) params.Network {
-	const chainID = SepoliaChainID
+	const chainID = common.SepoliaChainID
 	const chainName = "ethereum"
 	const networkName = "sepolia"
 
@@ -128,14 +118,14 @@ func sepolia(proxyHost, stageName string) params.Network {
 		IsTest:                 true,
 		Layer:                  1,
 		Enabled:                true,
-		RelatedChainID:         MainnetChainID,
+		RelatedChainID:         common.MainnetChainID,
 		IsActive:               true,
 		IsDeactivatable:        false,
 	}
 }
 
 func optimism(proxyHost, stageName string) params.Network {
-	const chainID = OptimismChainID
+	const chainID = common.OptimismChainID
 	const chainName = "optimism"
 	const networkName = "mainnet"
 
@@ -165,14 +155,14 @@ func optimism(proxyHost, stageName string) params.Network {
 		IsTest:                 false,
 		Layer:                  2,
 		Enabled:                true,
-		RelatedChainID:         OptimismSepoliaChainID,
+		RelatedChainID:         common.OptimismSepoliaChainID,
 		IsActive:               true,
 		IsDeactivatable:        true,
 	}
 }
 
 func optimismSepolia(proxyHost, stageName string) params.Network {
-	const chainID = OptimismSepoliaChainID
+	const chainID = common.OptimismSepoliaChainID
 	const chainName = "optimism"
 	const networkName = "sepolia"
 
@@ -202,14 +192,14 @@ func optimismSepolia(proxyHost, stageName string) params.Network {
 		IsTest:                 true,
 		Layer:                  2,
 		Enabled:                false,
-		RelatedChainID:         OptimismChainID,
+		RelatedChainID:         common.OptimismChainID,
 		IsActive:               true,
 		IsDeactivatable:        true,
 	}
 }
 
 func arbitrum(proxyHost, stageName string) params.Network {
-	const chainID = ArbitrumChainID
+	const chainID = common.ArbitrumChainID
 	const chainName = "arbitrum"
 	const networkName = "mainnet"
 
@@ -239,14 +229,14 @@ func arbitrum(proxyHost, stageName string) params.Network {
 		IsTest:                 false,
 		Layer:                  2,
 		Enabled:                true,
-		RelatedChainID:         ArbitrumSepoliaChainID,
+		RelatedChainID:         common.ArbitrumSepoliaChainID,
 		IsActive:               true,
 		IsDeactivatable:        true,
 	}
 }
 
 func arbitrumSepolia(proxyHost, stageName string) params.Network {
-	const chainID = ArbitrumSepoliaChainID
+	const chainID = common.ArbitrumSepoliaChainID
 	const chainName = "arbitrum"
 	const networkName = "sepolia"
 
@@ -276,14 +266,14 @@ func arbitrumSepolia(proxyHost, stageName string) params.Network {
 		IsTest:                 true,
 		Layer:                  2,
 		Enabled:                false,
-		RelatedChainID:         ArbitrumChainID,
+		RelatedChainID:         common.ArbitrumChainID,
 		IsActive:               true,
 		IsDeactivatable:        true,
 	}
 }
 
 func base(proxyHost, stageName string) params.Network {
-	const chainID = BaseChainID
+	const chainID = common.BaseChainID
 	const chainName = "base"
 	const networkName = "mainnet"
 
@@ -313,14 +303,14 @@ func base(proxyHost, stageName string) params.Network {
 		IsTest:                 false,
 		Layer:                  2,
 		Enabled:                true,
-		RelatedChainID:         BaseSepoliaChainID,
+		RelatedChainID:         common.BaseSepoliaChainID,
 		IsActive:               true,
 		IsDeactivatable:        true,
 	}
 }
 
 func baseSepolia(proxyHost, stageName string) params.Network {
-	const chainID = BaseSepoliaChainID
+	const chainID = common.BaseSepoliaChainID
 	const chainName = "base"
 	const networkName = "sepolia"
 
@@ -350,7 +340,7 @@ func baseSepolia(proxyHost, stageName string) params.Network {
 		IsTest:                 true,
 		Layer:                  2,
 		Enabled:                false,
-		RelatedChainID:         BaseChainID,
+		RelatedChainID:         common.BaseChainID,
 		IsActive:               true,
 		IsDeactivatable:        true,
 	}

--- a/api/default_networks_test.go
+++ b/api/default_networks_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/params"
 
 	"github.com/pkg/errors"
@@ -30,14 +31,14 @@ func TestBuildDefaultNetworks(t *testing.T) {
 	for _, n := range actualNetworks {
 		var err error
 		switch n.ChainID {
-		case MainnetChainID:
-		case SepoliaChainID:
-		case OptimismChainID:
-		case OptimismSepoliaChainID:
-		case ArbitrumChainID:
-		case ArbitrumSepoliaChainID:
-		case BaseChainID:
-		case BaseSepoliaChainID:
+		case common.MainnetChainID:
+		case common.SepoliaChainID:
+		case common.OptimismChainID:
+		case common.OptimismSepoliaChainID:
+		case common.ArbitrumChainID:
+		case common.ArbitrumSepoliaChainID:
+		case common.BaseChainID:
+		case common.BaseSepoliaChainID:
 		default:
 			err = errors.Errorf("unexpected chain id: %d", n.ChainID)
 		}

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/status-im/status-go/account/generator"
+	"github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
@@ -199,28 +200,28 @@ func buildWalletConfig(request *requests.WalletSecretsConfig, statusProxyEnabled
 	}
 
 	if request.AlchemyEthereumMainnetToken != "" {
-		walletConfig.AlchemyAPIKeys[MainnetChainID] = request.AlchemyEthereumMainnetToken
+		walletConfig.AlchemyAPIKeys[common.MainnetChainID] = request.AlchemyEthereumMainnetToken
 	}
 	if request.AlchemyEthereumSepoliaToken != "" {
-		walletConfig.AlchemyAPIKeys[SepoliaChainID] = request.AlchemyEthereumSepoliaToken
+		walletConfig.AlchemyAPIKeys[common.SepoliaChainID] = request.AlchemyEthereumSepoliaToken
 	}
 	if request.AlchemyArbitrumMainnetToken != "" {
-		walletConfig.AlchemyAPIKeys[ArbitrumChainID] = request.AlchemyArbitrumMainnetToken
+		walletConfig.AlchemyAPIKeys[common.ArbitrumChainID] = request.AlchemyArbitrumMainnetToken
 	}
 	if request.AlchemyArbitrumSepoliaToken != "" {
-		walletConfig.AlchemyAPIKeys[ArbitrumSepoliaChainID] = request.AlchemyArbitrumSepoliaToken
+		walletConfig.AlchemyAPIKeys[common.ArbitrumSepoliaChainID] = request.AlchemyArbitrumSepoliaToken
 	}
 	if request.AlchemyOptimismMainnetToken != "" {
-		walletConfig.AlchemyAPIKeys[OptimismChainID] = request.AlchemyOptimismMainnetToken
+		walletConfig.AlchemyAPIKeys[common.OptimismChainID] = request.AlchemyOptimismMainnetToken
 	}
 	if request.AlchemyOptimismSepoliaToken != "" {
-		walletConfig.AlchemyAPIKeys[OptimismSepoliaChainID] = request.AlchemyOptimismSepoliaToken
+		walletConfig.AlchemyAPIKeys[common.OptimismSepoliaChainID] = request.AlchemyOptimismSepoliaToken
 	}
 	if request.AlchemyBaseMainnetToken != "" {
-		walletConfig.AlchemyAPIKeys[BaseChainID] = request.AlchemyBaseMainnetToken
+		walletConfig.AlchemyAPIKeys[common.BaseChainID] = request.AlchemyBaseMainnetToken
 	}
 	if request.AlchemyBaseSepoliaToken != "" {
-		walletConfig.AlchemyAPIKeys[BaseSepoliaChainID] = request.AlchemyBaseSepoliaToken
+		walletConfig.AlchemyAPIKeys[common.BaseSepoliaChainID] = request.AlchemyBaseSepoliaToken
 	}
 	if request.StatusProxyMarketUser != "" {
 		walletConfig.StatusProxyMarketUser = request.StatusProxyMarketUser

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -270,7 +270,7 @@ func overrideApiConfigProd(nodeConfig *params.NodeConfig, config *requests.APICo
 // getMainnetRPCURL retuevrns URL of the first provider with TokenAuth from mainnet network
 func getMainnetRPCURL(networks []params.Network) string {
 	for _, network := range networks {
-		if network.ChainID != MainnetChainID {
+		if network.ChainID != common.MainnetChainID {
 			continue
 		}
 		for _, provider := range network.RpcProviders {

--- a/appdatabase/migrations/sql/1737662319_add_active_column_to_networks.up.sql
+++ b/appdatabase/migrations/sql/1737662319_add_active_column_to_networks.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE networks ADD COLUMN is_active BOOLEAN DEFAULT true;

--- a/appdatabase/migrations/sql/1738081630_add_is_deactiveable_column_to_networks.up.sql
+++ b/appdatabase/migrations/sql/1738081630_add_is_deactiveable_column_to_networks.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE networks ADD COLUMN is_deactivatable BOOLEAN DEFAULT true;

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -140,6 +140,8 @@ type StatusNode struct {
 
 	accountsFeed event.Feed
 	walletFeed   event.Feed
+	networksFeed event.Feed
+	settingsFeed event.Feed
 }
 
 // New makes new instance of StatusNode.
@@ -341,7 +343,10 @@ func (n *StatusNode) setupRPCClient() (err error) {
 		UpstreamChainID: n.config.NetworkID,
 		Networks:        n.config.Networks,
 		DB:              n.appDB,
+		AccountsFeed:    &n.accountsFeed,
 		WalletFeed:      &n.walletFeed,
+		SettingsFeed:    &n.settingsFeed,
+		NetworksFeed:    &n.networksFeed,
 	}
 	n.rpcClient, err = rpc.NewClient(config)
 	if err != nil {

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -81,6 +81,8 @@ type Network struct {
 	ShortName              string          `json:"shortName" validate:"omitempty,min=1"`
 	TokenOverrides         []TokenOverride `json:"tokenOverrides" validate:"omitempty,dive"`
 	RelatedChainID         uint64          `json:"relatedChainId" validate:"omitempty"`
+	IsActive               bool            `json:"isActive"`
+	IsDeactivatable        bool            `json:"isDeactivatable"`
 }
 
 func (n *Network) DeepCopy() Network {

--- a/params/networkhelper/provider_utils_test.go
+++ b/params/networkhelper/provider_utils_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/status-im/status-go/api"
+	api_common "github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/params/networkhelper"
 	"github.com/status-im/status-go/rpc/network/testutil"
@@ -58,15 +58,15 @@ func TestMergeProvidersPreserveEnabledAndOrder(t *testing.T) {
 func TestOverrideBasicAuth(t *testing.T) {
 	// Arrange: Create a sample list of networks with various provider types
 	networks := []params.Network{
-		*testutil.CreateNetwork(api.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			*params.NewUserProvider(api.MainnetChainID, "Provider1", "https://userprovider.example.com", true),
-			*params.NewProxyProvider(api.MainnetChainID, "Provider2", "https://proxyprovider.example.com", true),
-			*params.NewEthRpcProxyProvider(api.MainnetChainID, "Provider3", "https://ethrpcproxy.example.com", true),
+		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
+			*params.NewUserProvider(api_common.MainnetChainID, "Provider1", "https://userprovider.example.com", true),
+			*params.NewProxyProvider(api_common.MainnetChainID, "Provider2", "https://proxyprovider.example.com", true),
+			*params.NewEthRpcProxyProvider(api_common.MainnetChainID, "Provider3", "https://ethrpcproxy.example.com", true),
 		}),
-		*testutil.CreateNetwork(api.OptimismChainID, "Optimism", []params.RpcProvider{
-			*params.NewDirectProvider(api.OptimismChainID, "Provider4", "https://directprovider.example.com", true),
-			*params.NewProxyProvider(api.OptimismChainID, "Provider5", "https://proxyprovider2.example.com", true),
-			*params.NewEthRpcProxyProvider(api.OptimismChainID, "Provider6", "https://ethrpcproxy2.example.com", true),
+		*testutil.CreateNetwork(api_common.OptimismChainID, "Optimism", []params.RpcProvider{
+			*params.NewDirectProvider(api_common.OptimismChainID, "Provider4", "https://directprovider.example.com", true),
+			*params.NewProxyProvider(api_common.OptimismChainID, "Provider5", "https://proxyprovider2.example.com", true),
+			*params.NewEthRpcProxyProvider(api_common.OptimismChainID, "Provider6", "https://ethrpcproxy2.example.com", true),
 		}),
 	}
 	networks[0].RpcProviders[1].Enabled = false
@@ -131,14 +131,14 @@ func TestOverrideBasicAuth(t *testing.T) {
 func TestOverrideDirectProvidersAuth(t *testing.T) {
 	// Create a sample list of networks with various provider types
 	networks := []params.Network{
-		*testutil.CreateNetwork(api.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			*params.NewUserProvider(api.MainnetChainID, "Provider1", "https://user.example.com/", true),
-			*params.NewDirectProvider(api.MainnetChainID, "Provider2", "https://mainnet.infura.io/v3/", true),
-			*params.NewDirectProvider(api.MainnetChainID, "Provider3", "https://eth-archival.rpc.grove.city/v1/", true),
+		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
+			*params.NewUserProvider(api_common.MainnetChainID, "Provider1", "https://user.example.com/", true),
+			*params.NewDirectProvider(api_common.MainnetChainID, "Provider2", "https://mainnet.infura.io/v3/", true),
+			*params.NewDirectProvider(api_common.MainnetChainID, "Provider3", "https://eth-archival.rpc.grove.city/v1/", true),
 		}),
-		*testutil.CreateNetwork(api.OptimismChainID, "Optimism", []params.RpcProvider{
-			*params.NewDirectProvider(api.OptimismChainID, "Provider4", "https://optimism.infura.io/v3/", true),
-			*params.NewDirectProvider(api.OptimismChainID, "Provider5", "https://op.grove.city/v1/", true),
+		*testutil.CreateNetwork(api_common.OptimismChainID, "Optimism", []params.RpcProvider{
+			*params.NewDirectProvider(api_common.OptimismChainID, "Provider4", "https://optimism.infura.io/v3/", true),
+			*params.NewDirectProvider(api_common.OptimismChainID, "Provider5", "https://op.grove.city/v1/", true),
 		}),
 	}
 
@@ -175,9 +175,9 @@ func TestOverrideDirectProvidersAuth(t *testing.T) {
 }
 
 func TestDeepCopyNetwork(t *testing.T) {
-	originalNetwork := testutil.CreateNetwork(api.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-		*params.NewUserProvider(api.MainnetChainID, "Provider1", "https://userprovider.example.com", true),
-		*params.NewDirectProvider(api.MainnetChainID, "Provider2", "https://mainnet.infura.io/v3/", true),
+	originalNetwork := testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
+		*params.NewUserProvider(api_common.MainnetChainID, "Provider1", "https://userprovider.example.com", true),
+		*params.NewDirectProvider(api_common.MainnetChainID, "Provider2", "https://mainnet.infura.io/v3/", true),
 	})
 
 	originalNetwork.TokenOverrides = []params.TokenOverride{

--- a/rpc/network/db/network_db_test.go
+++ b/rpc/network/db/network_db_test.go
@@ -196,6 +196,31 @@ func (s *NetworksPersistenceTestSuite) TestValidationForNetworksAndProviders() {
 	s.Require().Len(allNetworks, 0, "No invalid networks should be saved")
 }
 
+func (s *NetworksPersistenceTestSuite) TestSetActive() {
+	network := testutil.CreateNetwork(api.OptimismChainID, "Optimism Mainnet", DefaultProviders(api.OptimismChainID))
+	s.addAndVerifyNetworks([]*params.Network{network})
+
+	// Deactivate the network
+	err := s.networksPersistence.SetActive(network.ChainID, false)
+	s.Require().NoError(err)
+
+	// Verify the network is deactivated
+	updatedNetwork, err := s.networksPersistence.GetNetworkByChainID(network.ChainID)
+	s.Require().NoError(err)
+	s.Require().Len(updatedNetwork, 1)
+	s.Require().False(updatedNetwork[0].IsActive)
+
+	// Activate the network
+	err = s.networksPersistence.SetActive(network.ChainID, true)
+	s.Require().NoError(err)
+
+	// Verify the network is enabled
+	updatedNetwork, err = s.networksPersistence.GetNetworkByChainID(network.ChainID)
+	s.Require().NoError(err)
+	s.Require().Len(updatedNetwork, 1)
+	s.Require().True(updatedNetwork[0].IsActive)
+}
+
 func (s *NetworksPersistenceTestSuite) TestSetEnabled() {
 	network := testutil.CreateNetwork(api.OptimismChainID, "Optimism Mainnet", DefaultProviders(api.OptimismChainID))
 	s.addAndVerifyNetworks([]*params.Network{network})

--- a/rpc/network/db/network_db_test.go
+++ b/rpc/network/db/network_db_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/status-im/status-go/api"
+	api_common "github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc/network/db"
@@ -98,15 +98,15 @@ func (s *NetworksPersistenceTestSuite) verifyNetworkDeletion(chainID uint64) {
 // Tests
 
 func (s *NetworksPersistenceTestSuite) TestAddAndGetNetworkWithProviders() {
-	network := testutil.CreateNetwork(api.OptimismChainID, "Optimism Mainnet", []params.RpcProvider{
-		testutil.CreateProvider(api.OptimismChainID, "Provider1", params.UserProviderType, true, "https://rpc.optimism.io"),
-		testutil.CreateProvider(api.OptimismChainID, "Provider2", params.EmbeddedProxyProviderType, false, "https://backup.optimism.io"),
+	network := testutil.CreateNetwork(api_common.OptimismChainID, "Optimism Mainnet", []params.RpcProvider{
+		testutil.CreateProvider(api_common.OptimismChainID, "Provider1", params.UserProviderType, true, "https://rpc.optimism.io"),
+		testutil.CreateProvider(api_common.OptimismChainID, "Provider2", params.EmbeddedProxyProviderType, false, "https://backup.optimism.io"),
 	})
 	s.addAndVerifyNetworks([]*params.Network{network})
 }
 
 func (s *NetworksPersistenceTestSuite) TestDeleteNetworkWithProviders() {
-	network := testutil.CreateNetwork(api.OptimismChainID, "Optimism Mainnet", DefaultProviders(api.OptimismChainID))
+	network := testutil.CreateNetwork(api_common.OptimismChainID, "Optimism Mainnet", DefaultProviders(api_common.OptimismChainID))
 	s.addAndVerifyNetworks([]*params.Network{network})
 
 	err := s.networksPersistence.DeleteNetwork(network.ChainID)
@@ -116,13 +116,13 @@ func (s *NetworksPersistenceTestSuite) TestDeleteNetworkWithProviders() {
 }
 
 func (s *NetworksPersistenceTestSuite) TestUpdateNetworkAndProviders() {
-	network := testutil.CreateNetwork(api.OptimismChainID, "Optimism Mainnet", DefaultProviders(api.OptimismChainID))
+	network := testutil.CreateNetwork(api_common.OptimismChainID, "Optimism Mainnet", DefaultProviders(api_common.OptimismChainID))
 	s.addAndVerifyNetworks([]*params.Network{network})
 
 	// Update fields
 	network.ChainName = "Updated Optimism Mainnet"
 	network.RpcProviders = []params.RpcProvider{
-		testutil.CreateProvider(api.OptimismChainID, "UpdatedProvider", params.UserProviderType, true, "https://rpc.optimism.updated.io"),
+		testutil.CreateProvider(api_common.OptimismChainID, "UpdatedProvider", params.UserProviderType, true, "https://rpc.optimism.updated.io"),
 	}
 
 	s.addAndVerifyNetworks([]*params.Network{network})
@@ -130,8 +130,8 @@ func (s *NetworksPersistenceTestSuite) TestUpdateNetworkAndProviders() {
 
 func (s *NetworksPersistenceTestSuite) TestDeleteAllNetworks() {
 	networks := []*params.Network{
-		testutil.CreateNetwork(api.MainnetChainID, "Ethereum Mainnet", DefaultProviders(api.MainnetChainID)),
-		testutil.CreateNetwork(api.SepoliaChainID, "Sepolia Testnet", DefaultProviders(api.SepoliaChainID)),
+		testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", DefaultProviders(api_common.MainnetChainID)),
+		testutil.CreateNetwork(api_common.SepoliaChainID, "Sepolia Testnet", DefaultProviders(api_common.SepoliaChainID)),
 	}
 	s.addAndVerifyNetworks(networks)
 
@@ -145,11 +145,11 @@ func (s *NetworksPersistenceTestSuite) TestDeleteAllNetworks() {
 
 func (s *NetworksPersistenceTestSuite) TestSetNetworks() {
 	initialNetworks := []*params.Network{
-		testutil.CreateNetwork(api.MainnetChainID, "Ethereum Mainnet", DefaultProviders(api.MainnetChainID)),
-		testutil.CreateNetwork(api.SepoliaChainID, "Sepolia Testnet", DefaultProviders(api.SepoliaChainID)),
+		testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", DefaultProviders(api_common.MainnetChainID)),
+		testutil.CreateNetwork(api_common.SepoliaChainID, "Sepolia Testnet", DefaultProviders(api_common.SepoliaChainID)),
 	}
 	newNetworks := []*params.Network{
-		testutil.CreateNetwork(api.OptimismChainID, "Optimism Mainnet", DefaultProviders(api.OptimismChainID)),
+		testutil.CreateNetwork(api_common.OptimismChainID, "Optimism Mainnet", DefaultProviders(api_common.OptimismChainID)),
 	}
 
 	// Add initial networks
@@ -159,25 +159,25 @@ func (s *NetworksPersistenceTestSuite) TestSetNetworks() {
 	s.addAndVerifyNetworks(newNetworks)
 
 	// Verify old networks are removed
-	s.verifyNetworkDeletion(api.MainnetChainID)
-	s.verifyNetworkDeletion(api.SepoliaChainID)
+	s.verifyNetworkDeletion(api_common.MainnetChainID)
+	s.verifyNetworkDeletion(api_common.SepoliaChainID)
 }
 
 func (s *NetworksPersistenceTestSuite) TestValidationForNetworksAndProviders() {
 	// Invalid Network: Missing required ChainName
-	invalidNetwork := testutil.CreateNetwork(api.MainnetChainID, "", DefaultProviders(api.MainnetChainID))
+	invalidNetwork := testutil.CreateNetwork(api_common.MainnetChainID, "", DefaultProviders(api_common.MainnetChainID))
 
 	// Invalid Provider: Missing URL
 	invalidProvider := params.RpcProvider{
 		Name:    "InvalidProvider",
-		ChainID: api.MainnetChainID,
+		ChainID: api_common.MainnetChainID,
 		URL:     "", // Invalid
 		Type:    params.UserProviderType,
 		Enabled: true,
 	}
 
 	// Add invalid provider to a valid network
-	validNetworkWithInvalidProvider := testutil.CreateNetwork(api.OptimismChainID, "Optimism Mainnet", []params.RpcProvider{invalidProvider})
+	validNetworkWithInvalidProvider := testutil.CreateNetwork(api_common.OptimismChainID, "Optimism Mainnet", []params.RpcProvider{invalidProvider})
 
 	// Invalid networks and providers should fail validation
 	networksToValidate := []*params.Network{
@@ -197,7 +197,7 @@ func (s *NetworksPersistenceTestSuite) TestValidationForNetworksAndProviders() {
 }
 
 func (s *NetworksPersistenceTestSuite) TestSetActive() {
-	network := testutil.CreateNetwork(api.OptimismChainID, "Optimism Mainnet", DefaultProviders(api.OptimismChainID))
+	network := testutil.CreateNetwork(api_common.OptimismChainID, "Optimism Mainnet", DefaultProviders(api_common.OptimismChainID))
 	s.addAndVerifyNetworks([]*params.Network{network})
 
 	// Deactivate the network
@@ -222,7 +222,7 @@ func (s *NetworksPersistenceTestSuite) TestSetActive() {
 }
 
 func (s *NetworksPersistenceTestSuite) TestSetEnabled() {
-	network := testutil.CreateNetwork(api.OptimismChainID, "Optimism Mainnet", DefaultProviders(api.OptimismChainID))
+	network := testutil.CreateNetwork(api_common.OptimismChainID, "Optimism Mainnet", DefaultProviders(api_common.OptimismChainID))
 	s.addAndVerifyNetworks([]*params.Network{network})
 
 	// Disable the network

--- a/rpc/network/db/rpc_provider_db_test.go
+++ b/rpc/network/db/rpc_provider_db_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/status-im/status-go/api"
+	api_common "github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc/network/db"
@@ -41,23 +41,23 @@ func TestRpcProviderPersistenceTestSuite(t *testing.T) {
 // Test cases
 
 func (s *RpcProviderPersistenceTestSuite) TestAddAndGetRpcProvider() {
-	provider := testutil.CreateProvider(api.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com")
+	provider := testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com")
 
 	err := s.rpcPersistence.AddRpcProvider(provider)
 	s.Require().NoError(err)
 
 	// Verify the added provider
-	providers, err := s.rpcPersistence.GetRpcProviders(api.MainnetChainID)
+	providers, err := s.rpcPersistence.GetRpcProviders(api_common.MainnetChainID)
 	s.Require().NoError(err)
 	testutil.CompareProvidersList(s.T(), []params.RpcProvider{provider}, providers)
 }
 
 func (s *RpcProviderPersistenceTestSuite) TestGetRpcProvidersByType() {
 	providers := []params.RpcProvider{
-		testutil.CreateProvider(api.MainnetChainID, "UserProvider1", params.UserProviderType, true, "https://provider1.example.com"),
-		testutil.CreateProvider(api.MainnetChainID, "EmbeddedDirect1", params.EmbeddedDirectProviderType, false, "https://provider2.example.com"),
-		testutil.CreateProvider(api.MainnetChainID, "UserProvider2", params.UserProviderType, false, "https://provider3.example.com"),
-		testutil.CreateProvider(api.MainnetChainID, "EmbeddedProxy1", params.EmbeddedProxyProviderType, true, "https://provider4.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "UserProvider1", params.UserProviderType, true, "https://provider1.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "EmbeddedDirect1", params.EmbeddedDirectProviderType, false, "https://provider2.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "UserProvider2", params.UserProviderType, false, "https://provider3.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "EmbeddedProxy1", params.EmbeddedProxyProviderType, true, "https://provider4.example.com"),
 	}
 
 	for _, provider := range providers {
@@ -66,42 +66,42 @@ func (s *RpcProviderPersistenceTestSuite) TestGetRpcProvidersByType() {
 	}
 
 	// Verify by type
-	userProviders, err := s.rpcPersistence.GetRpcProvidersByType(api.MainnetChainID, params.UserProviderType)
+	userProviders, err := s.rpcPersistence.GetRpcProvidersByType(api_common.MainnetChainID, params.UserProviderType)
 	s.Require().NoError(err)
 	testutil.CompareProvidersList(s.T(), []params.RpcProvider{providers[0], providers[2]}, userProviders)
 
-	embeddedDirectProviders, err := s.rpcPersistence.GetRpcProvidersByType(api.MainnetChainID, params.EmbeddedDirectProviderType)
+	embeddedDirectProviders, err := s.rpcPersistence.GetRpcProvidersByType(api_common.MainnetChainID, params.EmbeddedDirectProviderType)
 	s.Require().NoError(err)
 	testutil.CompareProvidersList(s.T(), []params.RpcProvider{providers[1]}, embeddedDirectProviders)
 
-	embeddedProxyProviders, err := s.rpcPersistence.GetRpcProvidersByType(api.MainnetChainID, params.EmbeddedProxyProviderType)
+	embeddedProxyProviders, err := s.rpcPersistence.GetRpcProvidersByType(api_common.MainnetChainID, params.EmbeddedProxyProviderType)
 	s.Require().NoError(err)
 	testutil.CompareProvidersList(s.T(), []params.RpcProvider{providers[3]}, embeddedProxyProviders)
 }
 
 func (s *RpcProviderPersistenceTestSuite) TestDeleteRpcProviders() {
-	provider := testutil.CreateProvider(api.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com")
+	provider := testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com")
 
 	err := s.rpcPersistence.AddRpcProvider(provider)
 	s.Require().NoError(err)
 
-	err = s.rpcPersistence.DeleteRpcProviders(api.MainnetChainID)
+	err = s.rpcPersistence.DeleteRpcProviders(api_common.MainnetChainID)
 	s.Require().NoError(err)
 
 	// Verify deletion
-	providers, err := s.rpcPersistence.GetRpcProviders(api.MainnetChainID)
+	providers, err := s.rpcPersistence.GetRpcProviders(api_common.MainnetChainID)
 	s.Require().NoError(err)
 	s.Require().Empty(providers)
 }
 
 func (s *RpcProviderPersistenceTestSuite) TestUpdateRpcProvider() {
-	provider := testutil.CreateProvider(api.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com")
+	provider := testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com")
 
 	err := s.rpcPersistence.AddRpcProvider(provider)
 	s.Require().NoError(err)
 
 	// Retrieve provider to get the ID
-	providers, err := s.rpcPersistence.GetRpcProviders(api.MainnetChainID)
+	providers, err := s.rpcPersistence.GetRpcProviders(api_common.MainnetChainID)
 	s.Require().NoError(err)
 	s.Require().Len(providers, 1)
 
@@ -113,15 +113,15 @@ func (s *RpcProviderPersistenceTestSuite) TestUpdateRpcProvider() {
 	s.Require().NoError(err)
 
 	// Verify update
-	updatedProviders, err := s.rpcPersistence.GetRpcProviders(api.MainnetChainID)
+	updatedProviders, err := s.rpcPersistence.GetRpcProviders(api_common.MainnetChainID)
 	s.Require().NoError(err)
 	testutil.CompareProvidersList(s.T(), []params.RpcProvider{provider}, updatedProviders)
 }
 
 func (s *RpcProviderPersistenceTestSuite) TestSetRpcProviders() {
 	initialProviders := []params.RpcProvider{
-		testutil.CreateProvider(api.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com"),
-		testutil.CreateProvider(api.MainnetChainID, "Provider2", params.EmbeddedDirectProviderType, false, "https://provider2.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "Provider1", params.UserProviderType, true, "https://provider1.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "Provider2", params.EmbeddedDirectProviderType, false, "https://provider2.example.com"),
 	}
 
 	for _, provider := range initialProviders {
@@ -130,15 +130,15 @@ func (s *RpcProviderPersistenceTestSuite) TestSetRpcProviders() {
 	}
 
 	newProviders := []params.RpcProvider{
-		testutil.CreateProvider(api.MainnetChainID, "NewProvider1", params.UserProviderType, true, "https://newprovider1.example.com"),
-		testutil.CreateProvider(api.MainnetChainID, "NewProvider2", params.EmbeddedProxyProviderType, true, "https://newprovider2.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "NewProvider1", params.UserProviderType, true, "https://newprovider1.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "NewProvider2", params.EmbeddedProxyProviderType, true, "https://newprovider2.example.com"),
 	}
 
-	err := s.rpcPersistence.SetRpcProviders(api.MainnetChainID, newProviders)
+	err := s.rpcPersistence.SetRpcProviders(api_common.MainnetChainID, newProviders)
 	s.Require().NoError(err)
 
 	// Verify replacement
-	providers, err := s.rpcPersistence.GetRpcProviders(api.MainnetChainID)
+	providers, err := s.rpcPersistence.GetRpcProviders(api_common.MainnetChainID)
 	s.Require().NoError(err)
 	testutil.CompareProvidersList(s.T(), newProviders, providers)
 }

--- a/rpc/network/errors.go
+++ b/rpc/network/errors.go
@@ -1,0 +1,12 @@
+package network
+
+import (
+	"github.com/status-im/status-go/errors"
+)
+
+// Abbreviation `NET` for the error code stands for Networks
+var (
+	ErrNetworkNotDeactivatable    = &errors.ErrorResponse{Code: errors.ErrorCode("NET-001"), Details: "network is not deactivatable"}
+	ErrActiveNetworksLimitReached = &errors.ErrorResponse{Code: errors.ErrorCode("NET-002"), Details: "maximum number of active networks reached"}
+	ErrUnsupportedChainId         = &errors.ErrorResponse{Code: errors.ErrorCode("NET-003"), Details: "chainID is not supported"}
+)

--- a/rpc/network/network_test.go
+++ b/rpc/network/network_test.go
@@ -4,8 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/status-im/status-go/api"
-
+	api_common "github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/params/networkhelper"
@@ -35,23 +34,23 @@ func (s *NetworkManagerTestSuite) SetupTest() {
 
 	// Use testutil to initialize networks
 	initNetworks := []params.Network{
-		*testutil.CreateNetwork(api.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(api.MainnetChainID, "Infura Mainnet", params.UserProviderType, true, "https://mainnet.infura.io"),
+		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
+			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.UserProviderType, true, "https://mainnet.infura.io"),
 		}),
-		*testutil.CreateNetwork(api.SepoliaChainID, "Sepolia Testnet", []params.RpcProvider{
-			testutil.CreateProvider(api.SepoliaChainID, "Infura Sepolia", params.UserProviderType, true, "https://sepolia.infura.io"),
+		*testutil.CreateNetwork(api_common.SepoliaChainID, "Sepolia Testnet", []params.RpcProvider{
+			testutil.CreateProvider(api_common.SepoliaChainID, "Infura Sepolia", params.UserProviderType, true, "https://sepolia.infura.io"),
 		}),
-		*testutil.CreateNetwork(api.OptimismChainID, "Optimistic Ethereum", []params.RpcProvider{
-			testutil.CreateProvider(api.OptimismChainID, "Infura Optimism", params.UserProviderType, true, "https://optimism.infura.io"),
+		*testutil.CreateNetwork(api_common.OptimismChainID, "Optimistic Ethereum", []params.RpcProvider{
+			testutil.CreateProvider(api_common.OptimismChainID, "Infura Optimism", params.UserProviderType, true, "https://optimism.infura.io"),
 		}),
-		*testutil.CreateNetwork(api.OptimismSepoliaChainID, "Optimistic Sepolia", []params.RpcProvider{
-			testutil.CreateProvider(api.OptimismSepoliaChainID, "Infura Optimism Sepolia", params.UserProviderType, true, "https://optimism-sepolia.infura.io"),
+		*testutil.CreateNetwork(api_common.OptimismSepoliaChainID, "Optimistic Sepolia", []params.RpcProvider{
+			testutil.CreateProvider(api_common.OptimismSepoliaChainID, "Infura Optimism Sepolia", params.UserProviderType, true, "https://optimism-sepolia.infura.io"),
 		}),
-		*testutil.CreateNetwork(api.BaseChainID, "Base", []params.RpcProvider{
-			testutil.CreateProvider(api.BaseChainID, "Infura Base", params.UserProviderType, true, "https://base.infura.io"),
+		*testutil.CreateNetwork(api_common.BaseChainID, "Base", []params.RpcProvider{
+			testutil.CreateProvider(api_common.BaseChainID, "Infura Base", params.UserProviderType, true, "https://base.infura.io"),
 		}),
-		*testutil.CreateNetwork(api.BaseSepoliaChainID, "Base Sepolia", []params.RpcProvider{
-			testutil.CreateProvider(api.BaseSepoliaChainID, "Infura Base Sepolia", params.UserProviderType, true, "https://base-sepolia.infura.io"),
+		*testutil.CreateNetwork(api_common.BaseSepoliaChainID, "Base Sepolia", []params.RpcProvider{
+			testutil.CreateProvider(api_common.BaseSepoliaChainID, "Infura Base Sepolia", params.UserProviderType, true, "https://base-sepolia.infura.io"),
 		}),
 	}
 	// Make "Ethereum Mainnet" network not deactivatable
@@ -92,14 +91,14 @@ func (s *NetworkManagerTestSuite) assertDbNetworks(expectedNetworks []params.Net
 func (s *NetworkManagerTestSuite) TestUserAddsCustomProviders() {
 	// Adding custom providers
 	customProviders := []params.RpcProvider{
-		testutil.CreateProvider(api.MainnetChainID, "CustomProvider1", params.UserProviderType, true, "https://custom1.example.com"),
-		testutil.CreateProvider(api.MainnetChainID, "CustomProvider2", params.UserProviderType, false, "https://custom2.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider1", params.UserProviderType, true, "https://custom1.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider2", params.UserProviderType, false, "https://custom2.example.com"),
 	}
-	err := s.manager.SetUserRpcProviders(api.MainnetChainID, customProviders)
+	err := s.manager.SetUserRpcProviders(api_common.MainnetChainID, customProviders)
 	s.Require().NoError(err)
 
 	// Assert providers
-	foundNetwork := s.manager.Find(api.MainnetChainID)
+	foundNetwork := s.manager.Find(api_common.MainnetChainID)
 	s.Require().NotNil(foundNetwork)
 	expectedProviders := append(customProviders, networkhelper.GetEmbeddedProviders(foundNetwork.RpcProviders)...)
 	testutil.CompareProvidersList(s.T(), expectedProviders, foundNetwork.RpcProviders)
@@ -108,23 +107,23 @@ func (s *NetworkManagerTestSuite) TestUserAddsCustomProviders() {
 func (s *NetworkManagerTestSuite) TestInitNetworksKeepsUserProviders() {
 	// Add custom providers
 	customProviders := []params.RpcProvider{
-		testutil.CreateProvider(api.MainnetChainID, "CustomProvider1", params.UserProviderType, true, "https://custom1.example.com"),
-		testutil.CreateProvider(api.MainnetChainID, "CustomProvider2", params.UserProviderType, false, "https://custom2.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider1", params.UserProviderType, true, "https://custom1.example.com"),
+		testutil.CreateProvider(api_common.MainnetChainID, "CustomProvider2", params.UserProviderType, false, "https://custom2.example.com"),
 	}
-	err := s.manager.SetUserRpcProviders(api.MainnetChainID, customProviders)
+	err := s.manager.SetUserRpcProviders(api_common.MainnetChainID, customProviders)
 	s.Require().NoError(err)
 
 	// Re-initialize networks
 	initNetworks := []params.Network{
-		*testutil.CreateNetwork(api.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(api.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
+		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
+			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
 		}),
 	}
 	err = s.manager.InitEmbeddedNetworks(initNetworks)
 	s.Require().NoError(err)
 
 	// Check that custom providers are retained
-	foundNetwork := s.manager.Find(api.MainnetChainID)
+	foundNetwork := s.manager.Find(api_common.MainnetChainID)
 	s.Require().NotNil(foundNetwork)
 	expectedProviders := append(customProviders, networkhelper.GetEmbeddedProviders(initNetworks[0].RpcProviders)...)
 	testutil.CompareProvidersList(s.T(), expectedProviders, foundNetwork.RpcProviders)
@@ -136,8 +135,8 @@ func (s *NetworkManagerTestSuite) TestInitNetworksDoesNotSaveEmbeddedProviders()
 
 	// Re-initialize networks
 	initNetworks := []params.Network{
-		*testutil.CreateNetwork(api.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(api.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
+		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
+			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
 		}),
 	}
 	err := s.manager.InitEmbeddedNetworks(initNetworks)
@@ -153,8 +152,8 @@ func (s *NetworkManagerTestSuite) TestInitNetworksDoesNotSaveEmbeddedProviders()
 func (s *NetworkManagerTestSuite) TestInitEmbeddedNetworks() {
 	// Re-initialize networks
 	initNetworks := []params.Network{
-		*testutil.CreateNetwork(api.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(api.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
+		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
+			testutil.CreateProvider(api_common.MainnetChainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
 		}),
 	}
 	expectedProviders := networkhelper.GetEmbeddedProviders(initNetworks[0].RpcProviders)
@@ -164,7 +163,7 @@ func (s *NetworkManagerTestSuite) TestInitEmbeddedNetworks() {
 	// functor tests if embedded providers are present in the networks
 	expectEmbeddedProviders := func(networks []*params.Network) {
 		for _, network := range networks {
-			if network.ChainID == api.MainnetChainID {
+			if network.ChainID == api_common.MainnetChainID {
 				storedEmbeddedProviders := networkhelper.GetEmbeddedProviders(network.RpcProviders)
 				testutil.CompareProvidersList(s.T(), expectedProviders, storedEmbeddedProviders)
 			}
@@ -190,11 +189,11 @@ func (s *NetworkManagerTestSuite) TestInitEmbeddedNetworks() {
 	combinedNetworks, err := s.manager.GetCombinedNetworks()
 	s.Require().NoError(err)
 	for _, combinedNetwork := range combinedNetworks {
-		if combinedNetwork.Test != nil && combinedNetwork.Test.ChainID == api.MainnetChainID {
+		if combinedNetwork.Test != nil && combinedNetwork.Test.ChainID == api_common.MainnetChainID {
 			storedEmbeddedProviders := networkhelper.GetEmbeddedProviders(combinedNetwork.Test.RpcProviders)
 			testutil.CompareProvidersList(s.T(), expectedProviders, storedEmbeddedProviders)
 		}
-		if combinedNetwork.Prod != nil && combinedNetwork.Prod.ChainID == api.MainnetChainID {
+		if combinedNetwork.Prod != nil && combinedNetwork.Prod.ChainID == api_common.MainnetChainID {
 			storedEmbeddedProviders := networkhelper.GetEmbeddedProviders(combinedNetwork.Prod.RpcProviders)
 			testutil.CompareProvidersList(s.T(), expectedProviders, storedEmbeddedProviders)
 		}
@@ -208,14 +207,14 @@ func (s *NetworkManagerTestSuite) TestInitEmbeddedNetworks() {
 func (s *NetworkManagerTestSuite) TestLegacyFieldPopulation() {
 	// Create initial test networks with various providers
 	initNetworks := []params.Network{
-		*testutil.CreateNetwork(api.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
-			testutil.CreateProvider(api.MainnetChainID, "DirectProvider1", params.EmbeddedDirectProviderType, true, "https://direct1.ethereum.io"),
-			testutil.CreateProvider(api.MainnetChainID, "DirectProvider2", params.EmbeddedDirectProviderType, true, "https://direct2.ethereum.io"),
-			testutil.CreateProvider(api.MainnetChainID, "ProxyProvider1", params.EmbeddedProxyProviderType, true, "https://proxy1.ethereum.io"),
-			testutil.CreateProvider(api.MainnetChainID, "ProxyProvider2", params.EmbeddedProxyProviderType, true, "https://proxy2.ethereum.io"),
-			testutil.CreateProvider(api.MainnetChainID, "ProxyProvider3", params.EmbeddedProxyProviderType, true, "https://proxy3.ethereum.io"),
-			testutil.CreateProvider(api.MainnetChainID, "UserProvider1", params.UserProviderType, true, "https://user1.ethereum.io"),
-			testutil.CreateProvider(api.MainnetChainID, "UserProvider2", params.UserProviderType, true, "https://user2.ethereum.io"),
+		*testutil.CreateNetwork(api_common.MainnetChainID, "Ethereum Mainnet", []params.RpcProvider{
+			testutil.CreateProvider(api_common.MainnetChainID, "DirectProvider1", params.EmbeddedDirectProviderType, true, "https://direct1.ethereum.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "DirectProvider2", params.EmbeddedDirectProviderType, true, "https://direct2.ethereum.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "ProxyProvider1", params.EmbeddedProxyProviderType, true, "https://proxy1.ethereum.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "ProxyProvider2", params.EmbeddedProxyProviderType, true, "https://proxy2.ethereum.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "ProxyProvider3", params.EmbeddedProxyProviderType, true, "https://proxy3.ethereum.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "UserProvider1", params.UserProviderType, true, "https://user1.ethereum.io"),
+			testutil.CreateProvider(api_common.MainnetChainID, "UserProvider2", params.UserProviderType, true, "https://user2.ethereum.io"),
 		}),
 	}
 
@@ -244,10 +243,10 @@ func (s *NetworkManagerTestSuite) TestLegacyFieldPopulation() {
 func (s *NetworkManagerTestSuite) TestLegacyFieldPopulationWithoutUserProviders() {
 	// Create a test network with only EmbeddedDirect and EmbeddedProxy providers
 	initNetworks := []params.Network{
-		*testutil.CreateNetwork(api.SepoliaChainID, "Sepolia Testnet", []params.RpcProvider{
-			testutil.CreateProvider(api.SepoliaChainID, "DirectProvider1", params.EmbeddedDirectProviderType, true, "https://direct1.sepolia.io"),
-			testutil.CreateProvider(api.SepoliaChainID, "ProxyProvider1", params.EmbeddedProxyProviderType, true, "https://proxy1.sepolia.io"),
-			testutil.CreateProvider(api.SepoliaChainID, "ProxyProvider2", params.EmbeddedProxyProviderType, true, "https://proxy2.sepolia.io"),
+		*testutil.CreateNetwork(api_common.SepoliaChainID, "Sepolia Testnet", []params.RpcProvider{
+			testutil.CreateProvider(api_common.SepoliaChainID, "DirectProvider1", params.EmbeddedDirectProviderType, true, "https://direct1.sepolia.io"),
+			testutil.CreateProvider(api_common.SepoliaChainID, "ProxyProvider1", params.EmbeddedProxyProviderType, true, "https://proxy1.sepolia.io"),
+			testutil.CreateProvider(api_common.SepoliaChainID, "ProxyProvider2", params.EmbeddedProxyProviderType, true, "https://proxy2.sepolia.io"),
 		}),
 	}
 
@@ -303,25 +302,25 @@ func (s *NetworkManagerTestSuite) TestSetActive() {
 	var n *params.Network
 
 	// Check that the  "Base" network is active by default
-	n = s.manager.Find(api.BaseChainID)
+	n = s.manager.Find(api_common.BaseChainID)
 	s.Require().NotNil(n)
 	s.True(n.IsActive)
 
 	// Set the "Base" network to inactive
-	err = s.manager.SetActive(api.BaseChainID, false)
+	err = s.manager.SetActive(api_common.BaseChainID, false)
 	s.Require().NoError(err)
 
 	// Verify the network was set to inactive
-	n = s.manager.Find(api.BaseChainID)
+	n = s.manager.Find(api_common.BaseChainID)
 	s.Require().NotNil(n)
 	s.False(n.IsActive)
 
 	// Set the "Base" network to active
-	err = s.manager.SetActive(api.BaseChainID, true)
+	err = s.manager.SetActive(api_common.BaseChainID, true)
 	s.Require().NoError(err)
 
 	// Verify the network was set to active
-	n = s.manager.Find(api.BaseChainID)
+	n = s.manager.Find(api_common.BaseChainID)
 	s.Require().NotNil(n)
 	s.True(n.IsActive)
 }
@@ -331,11 +330,11 @@ func (s *NetworkManagerTestSuite) TestSetActiveNotDeactivatable() {
 	var n *params.Network
 
 	// Try to set Ethereum Mainnet to inactive (should fail)
-	err = s.manager.SetActive(api.MainnetChainID, false)
+	err = s.manager.SetActive(api_common.MainnetChainID, false)
 	s.Require().Error(err)
 
 	// Verify the network was not set to inactive
-	n = s.manager.Find(api.MainnetChainID)
+	n = s.manager.Find(api_common.MainnetChainID)
 	s.Require().NotNil(n)
 	s.True(n.IsActive)
 }
@@ -350,16 +349,16 @@ func (s *NetworkManagerTestSuite) TestSetActiveMaxNumberOfActiveNetworks() {
 	s.Require().Len(activeNetworks, network.MaxActiveNetworks)
 
 	// Check that the "Optimistic Ethereum" network is inactive by default
-	n = s.manager.Find(api.OptimismChainID)
+	n = s.manager.Find(api_common.OptimismChainID)
 	s.Require().NotNil(n)
 	s.False(n.IsActive)
 
 	// Try to set the "Optimistic Ethereum" network to active (should fail due to number networks active)
-	err = s.manager.SetActive(api.OptimismChainID, true)
+	err = s.manager.SetActive(api_common.OptimismChainID, true)
 	s.Require().Error(err)
 
 	// Verify the network was not set to active
-	n = s.manager.Find(api.OptimismChainID)
+	n = s.manager.Find(api_common.OptimismChainID)
 	s.Require().NotNil(n)
 	s.False(n.IsActive)
 }

--- a/rpc/network/network_test.go
+++ b/rpc/network/network_test.go
@@ -280,7 +280,7 @@ func (s *NetworkManagerTestSuite) TestUpsertNetwork() {
 	newNetwork := testutil.CreateNetwork(chainID, "Ethereum Mainnet", []params.RpcProvider{
 		testutil.CreateProvider(chainID, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
 	})
-	// Check that these values are overriden for upserted networks
+	// Check that these values are overiden for upserted networks
 	newNetwork.IsActive = true
 	newNetwork.IsDeactivatable = false
 

--- a/rpc/network/network_test.go
+++ b/rpc/network/network_test.go
@@ -30,7 +30,7 @@ func (s *NetworkManagerTestSuite) SetupTest() {
 	s.Require().NoError(err)
 	s.db = testDb
 	s.cleanup = func() { s.Require().NoError(cleanup()) }
-	s.manager = network.NewManager(testDb)
+	s.manager = network.NewManager(testDb, nil, nil, nil)
 	persistence := db.NewNetworksPersistence(testDb)
 
 	// Use testutil to initialize networks

--- a/rpc/network/networksevent/events.go
+++ b/rpc/network/networksevent/events.go
@@ -5,17 +5,10 @@ type EventType string
 
 // Event is a type for networks events.
 type Event struct {
-	Type                        EventType                    `json:"type"`
-	ActiveNetworksChangedParams *ActiveNetworksChangedParams `json:"activeNetworksChangedParams,omitempty"` // Only for EventTypeActiveNetworksChanged
+	Type EventType `json:"type"`
 }
 
 const (
 	// EventTypeActiveNetworksChanged is emitted when networks are activated/deactivated. This includes Testnet mode change.
 	EventTypeActiveNetworksChanged EventType = "active-networks-changed"
 )
-
-type ActiveNetworksChangedParams struct {
-	ActivatedChainIDs     []uint64 `json:"activatedChainIds"`
-	DeactivatedChainIDs   []uint64 `json:"deactivatedChainIds"`
-	CurrentActiveChainIDs []uint64 `json:"currentActiveChainIds"`
-}

--- a/rpc/network/networksevent/events.go
+++ b/rpc/network/networksevent/events.go
@@ -1,0 +1,21 @@
+package networksevent
+
+// EventType type for event types.
+type EventType string
+
+// Event is a type for networks events.
+type Event struct {
+	Type                        EventType                    `json:"type"`
+	ActiveNetworksChangedParams *ActiveNetworksChangedParams `json:"activeNetworksChangedParams,omitempty"` // Only for EventTypeActiveNetworksChanged
+}
+
+const (
+	// EventTypeActiveNetworksChanged is emitted when networks are activated/deactivated. This includes Testnet mode change.
+	EventTypeActiveNetworksChanged EventType = "active-networks-changed"
+)
+
+type ActiveNetworksChangedParams struct {
+	ActivatedChainIDs     []uint64 `json:"activatedChainIds"`
+	DeactivatedChainIDs   []uint64 `json:"deactivatedChainIds"`
+	CurrentActiveChainIDs []uint64 `json:"currentActiveChainIds"`
+}

--- a/rpc/network/networksevent/watcher.go
+++ b/rpc/network/networksevent/watcher.go
@@ -14,7 +14,7 @@ type EventCallbacks struct {
 	ActiveNetworksChangeCb ActiveNetworksChangeCb
 }
 
-type ActiveNetworksChangeCb func(params *ActiveNetworksChangedParams)
+type ActiveNetworksChangeCb func()
 
 // Watcher executes a given callback whenever a network event is emitted
 type Watcher struct {
@@ -49,17 +49,12 @@ func (w *Watcher) Stop() {
 	}
 }
 
-func onActiveNetworksChange(callback ActiveNetworksChangeCb, params *ActiveNetworksChangedParams) {
+func onActiveNetworksChange(callback ActiveNetworksChangeCb) {
 	if callback == nil {
 		return
 	}
 
-	if params == nil {
-		logutils.ZapLogger().Error("no params in event EventTypeActiveNetworksChanged")
-		return
-	}
-
-	callback(params)
+	callback()
 }
 
 func watch(ctx context.Context, accountFeed *event.Feed, callbacks EventCallbacks) error {
@@ -78,7 +73,7 @@ func watch(ctx context.Context, accountFeed *event.Feed, callbacks EventCallback
 		case ev := <-ch:
 			switch ev.Type {
 			case EventTypeActiveNetworksChanged:
-				onActiveNetworksChange(callbacks.ActiveNetworksChangeCb, ev.ActiveNetworksChangedParams)
+				onActiveNetworksChange(callbacks.ActiveNetworksChangeCb)
 			}
 		}
 	}

--- a/rpc/network/networksevent/watcher.go
+++ b/rpc/network/networksevent/watcher.go
@@ -1,0 +1,86 @@
+package networksevent
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/status-im/status-go/logutils"
+	"github.com/status-im/status-go/services/wallet/async"
+)
+
+type EventCallbacks struct {
+	ActiveNetworksChangeCb ActiveNetworksChangeCb
+}
+
+type ActiveNetworksChangeCb func(params *ActiveNetworksChangedParams)
+
+// Watcher executes a given callback whenever a network event is emitted
+type Watcher struct {
+	accountFeed *event.Feed
+	group       *async.Group
+	callbacks   EventCallbacks
+}
+
+func NewWatcher(accountFeed *event.Feed, callbacks EventCallbacks) *Watcher {
+	return &Watcher{
+		accountFeed: accountFeed,
+		callbacks:   callbacks,
+	}
+}
+
+func (w *Watcher) Start() {
+	if w.group != nil {
+		return
+	}
+
+	w.group = async.NewGroup(context.Background())
+	w.group.Add(func(ctx context.Context) error {
+		return watch(ctx, w.accountFeed, w.callbacks)
+	})
+}
+
+func (w *Watcher) Stop() {
+	if w.group != nil {
+		w.group.Stop()
+		w.group.Wait()
+		w.group = nil
+	}
+}
+
+func onActiveNetworksChange(callback ActiveNetworksChangeCb, params *ActiveNetworksChangedParams) {
+	if callback == nil {
+		return
+	}
+
+	if params == nil {
+		logutils.ZapLogger().Error("no params in event EventTypeActiveNetworksChanged")
+		return
+	}
+
+	callback(params)
+}
+
+func watch(ctx context.Context, accountFeed *event.Feed, callbacks EventCallbacks) error {
+	ch := make(chan Event, 1)
+	sub := accountFeed.Subscribe(ch)
+	defer sub.Unsubscribe()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-sub.Err():
+			if err != nil {
+				logutils.ZapLogger().Error("network events watcher subscription failed", zap.Error(err))
+			}
+		case ev := <-ch:
+			switch ev.Type {
+			case EventTypeActiveNetworksChanged:
+				onActiveNetworksChange(callbacks.ActiveNetworksChangeCb, ev.ActiveNetworksChangedParams)
+			}
+		}
+	}
+
+}

--- a/rpc/network/testutil/testutil.go
+++ b/rpc/network/testutil/testutil.go
@@ -3,7 +3,7 @@ package testutil
 import (
 	"github.com/stretchr/testify/require"
 
-	"github.com/status-im/status-go/api"
+	api_common "github.com/status-im/status-go/api/common"
 	"github.com/status-im/status-go/params"
 )
 
@@ -38,7 +38,7 @@ func CreateNetwork(chainID uint64, chainName string, providers []params.RpcProvi
 		Enabled:                true,
 		ChainColor:             "#E90101",
 		ShortName:              "eth",
-		RelatedChainID:         api.OptimismSepoliaChainID,
+		RelatedChainID:         api_common.OptimismSepoliaChainID,
 		RpcProviders:           providers,
 		IsActive:               true,
 		IsDeactivatable:        true,

--- a/rpc/network/testutil/testutil.go
+++ b/rpc/network/testutil/testutil.go
@@ -40,6 +40,8 @@ func CreateNetwork(chainID uint64, chainName string, providers []params.RpcProvi
 		ShortName:              "eth",
 		RelatedChainID:         api.OptimismSepoliaChainID,
 		RpcProviders:           providers,
+		IsActive:               true,
+		IsDeactivatable:        true,
 	}
 }
 
@@ -71,6 +73,8 @@ func CompareNetworks(t require.TestingT, expected, actual *params.Network) {
 	require.Equal(t, expected.ChainColor, actual.ChainColor)
 	require.Equal(t, expected.ShortName, actual.ShortName)
 	require.Equal(t, expected.RelatedChainID, actual.RelatedChainID)
+	require.Equal(t, expected.IsActive, actual.IsActive)
+	require.Equal(t, expected.IsDeactivatable, actual.IsDeactivatable)
 }
 
 // Helper function to compare lists of providers

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -66,7 +66,7 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 	state.db, closeDb = createDB(t)
 	state.walletDb, closeWalletDb = createWalletDB(t)
 
-	networkManager := network.NewManager(state.db)
+	networkManager := network.NewManager(state.db, nil, nil, nil)
 	require.NotNil(t, networkManager)
 
 	err := networkManager.InitEmbeddedNetworks([]params.Network{

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/status-im/status-go/params"
 	mock_rpcclient "github.com/status-im/status-go/rpc/mock/client"
 	"github.com/status-im/status-go/rpc/network"
+	network_testutil "github.com/status-im/status-go/rpc/network/testutil"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/signal"
@@ -69,18 +70,15 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 	networkManager := network.NewManager(state.db, nil, nil, nil)
 	require.NotNil(t, networkManager)
 
-	err := networkManager.InitEmbeddedNetworks([]params.Network{
-		{
-			ChainID:   walletCommon.EthereumMainnet,
-			ChainName: "Ethereum Mainnet",
-			Layer:     1,
-		},
-		{
-			ChainID:   walletCommon.OptimismMainnet,
-			ChainName: "Optimism Mainnet",
-			Layer:     1,
-		},
-	})
+	initNetworks := []params.Network{
+		*network_testutil.CreateNetwork(walletCommon.EthereumMainnet, "Ethereum Mainnet", []params.RpcProvider{
+			network_testutil.CreateProvider(walletCommon.EthereumMainnet, "Infura Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.infura.io"),
+		}),
+		*network_testutil.CreateNetwork(walletCommon.OptimismMainnet, "Optimism Mainnet", []params.RpcProvider{
+			network_testutil.CreateProvider(walletCommon.OptimismMainnet, "Optimism Mainnet", params.EmbeddedProxyProviderType, true, "https://mainnet.optimism.io"),
+		}),
+	}
+	err := networkManager.InitEmbeddedNetworks(initNetworks)
 	require.NoError(t, err)
 
 	state.handler = NewClientSideHandler(state.db)

--- a/services/connector/test_helpers.go
+++ b/services/connector/test_helpers.go
@@ -70,7 +70,7 @@ func setupTests(t *testing.T) (state testState, close func()) {
 	state.mockCtrl = gomock.NewController(t)
 	state.rpcClient = mock_rpcclient.NewMockClientInterface(state.mockCtrl)
 
-	networkManager := network.NewManager(state.db)
+	networkManager := network.NewManager(state.db, nil, nil, nil)
 	require.NotNil(t, networkManager)
 
 	err = networkManager.InitEmbeddedNetworks([]params.Network{

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -395,9 +395,16 @@ func (api *API) SearchCollections(ctx context.Context, chainID wcommon.ChainID, 
    Collectibles API End
 */
 
+// @deprecated: Custom networks not currently supported. Change settings using specific API functions.
 func (api *API) AddEthereumChain(ctx context.Context, network params.Network) error {
 	logutils.ZapLogger().Debug("call to AddEthereumChain")
 	return api.s.rpcClient.NetworkManager.Upsert(&network)
+}
+
+// @deprecated: Custom networks not currently supported. Change settings using specific API functions.
+func (api *API) DeleteEthereumChain(ctx context.Context, chainID uint64) error {
+	logutils.ZapLogger().Debug("call to DeleteEthereumChain")
+	return api.s.rpcClient.NetworkManager.Delete(chainID)
 }
 
 func (api *API) SetChainUserRpcProviders(ctx context.Context, chainID uint64, rpcProviders []params.RpcProvider) error {
@@ -405,19 +412,28 @@ func (api *API) SetChainUserRpcProviders(ctx context.Context, chainID uint64, rp
 	return api.s.rpcClient.NetworkManager.SetUserRpcProviders(chainID, rpcProviders)
 }
 
+// Active chains are the ones that are available for selection across the whole application
+// Providers are expected to be accessed only for active chains.
+func (api *API) SetChainActive(ctx context.Context, chainID uint64, active bool) error {
+	logutils.ZapLogger().Debug("call to SetChainActive")
+	return api.s.rpcClient.NetworkManager.SetActive(chainID, active)
+}
+
+// Enabled chains are the ones taken into account when displaying balances, collectibles, activity, etc.
 func (api *API) SetChainEnabled(ctx context.Context, chainID uint64, enabled bool) error {
 	logutils.ZapLogger().Debug("call to SetChainEnabled")
 	return api.s.rpcClient.NetworkManager.SetEnabled(chainID, enabled)
 }
 
-func (api *API) DeleteEthereumChain(ctx context.Context, chainID uint64) error {
-	logutils.ZapLogger().Debug("call to DeleteEthereumChain")
-	return api.s.rpcClient.NetworkManager.Delete(chainID)
-}
-
+// @deprecated: Combined networks are not used anymore, use GetFlatEthereumChains instead
 func (api *API) GetEthereumChains(ctx context.Context) ([]*network.CombinedNetwork, error) {
 	logutils.ZapLogger().Debug("call to GetEthereumChains")
 	return api.s.rpcClient.NetworkManager.GetCombinedNetworks()
+}
+
+func (api *API) GetFlatEthereumChains(ctx context.Context) ([]*params.Network, error) {
+	logutils.ZapLogger().Debug("call to GetFlatEthereumChains")
+	return api.s.rpcClient.NetworkManager.GetAll()
 }
 
 // @deprecated

--- a/services/wallet/api_test.go
+++ b/services/wallet/api_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/status-im/status-go/params/networkhelper"
+	"github.com/status-im/status-go/rpc/network/testutil"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
@@ -136,20 +137,10 @@ func TestAPI_GetAddressDetails(t *testing.T) {
 	defer serverWith1SecDelay.Close()
 
 	networks := []params.Network{
-		{
-			ChainID:   chainID,
-			ChainName: "Ethereum Mainnet",
-			RpcProviders: []params.RpcProvider{
-				{
-					ChainID:  chainID,
-					Name:     "Test Provider",
-					URL:      serverWith1SecDelay.URL + "/nodefleet/",
-					Type:     params.EmbeddedProxyProviderType,
-					Enabled:  true,
-					AuthType: params.NoAuth,
-				},
-			},
+		*testutil.CreateNetwork(chainID, "Ethereum Mainnet", []params.RpcProvider{
+			*params.NewProxyProvider(chainID, "Test Provider", serverWith1SecDelay.URL+"/nodefleet/", false),
 		},
+		),
 	}
 
 	networks = networkhelper.OverrideBasicAuth(networks, params.EmbeddedProxyProviderType, true, gofakeit.Username(), gofakeit.LetterN(5))

--- a/services/wallet/collectibles/controller.go
+++ b/services/wallet/collectibles/controller.go
@@ -365,15 +365,13 @@ func (c *Controller) startNetworkEventsWatcher() {
 		return
 	}
 
-	activeNetworksChangeCb := func(params *networksevent.ActiveNetworksChangedParams) {
+	activeNetworksChangeCb := func() {
 		// Lazy logic for now, just restart everything if there's any network change.
 		// TODO #17183: Per-network logic
-		if len(params.ActivatedChainIDs) > 0 || len(params.DeactivatedChainIDs) > 0 {
-			c.stopPeriodicalOwnershipFetch()
-			err := c.startPeriodicalOwnershipFetch()
-			if err != nil {
-				logutils.ZapLogger().Error("Error starting periodical collectibles fetch", zap.Error(err))
-			}
+		c.stopPeriodicalOwnershipFetch()
+		err := c.startPeriodicalOwnershipFetch()
+		if err != nil {
+			logutils.ZapLogger().Error("Error starting periodical collectibles fetch", zap.Error(err))
 		}
 	}
 

--- a/services/wallet/collectibles/service.go
+++ b/services/wallet/collectibles/service.go
@@ -107,13 +107,13 @@ func NewService(
 	walletFeed *event.Feed,
 	accountsDB *accounts.Database,
 	accountsFeed *event.Feed,
-	settingsFeed *event.Feed,
+	networksFeed *event.Feed,
 	communityManager *community.Manager,
 	networkManager *network.Manager,
 	manager *Manager) *Service {
 	s := &Service{
 		manager:          manager,
-		controller:       NewController(db, walletFeed, accountsDB, accountsFeed, settingsFeed, networkManager, manager),
+		controller:       NewController(db, walletFeed, accountsDB, accountsFeed, networksFeed, networkManager, manager),
 		db:               db,
 		ownershipDB:      NewOwnershipDB(db),
 		transferDB:       transfer.NewDB(db),

--- a/services/wallet/keycard_pairings_test.go
+++ b/services/wallet/keycard_pairings_test.go
@@ -29,7 +29,7 @@ func TestKeycardPairingsFile(t *testing.T) {
 
 	accountFeed := &event.Feed{}
 
-	service := NewService(db, accountsDb, appDB, &rpc.Client{NetworkManager: network.NewManager(db)}, accountFeed, nil, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
+	service := NewService(db, accountsDb, appDB, &rpc.Client{NetworkManager: network.NewManager(db, nil, nil, nil)}, accountFeed, nil, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
 
 	data, err := service.KeycardPairings().GetPairingsJSONFileContent()
 	require.NoError(t, err)

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -55,7 +55,7 @@ func NewService(
 	appDB *sql.DB,
 	rpcClient *rpc.Client,
 	accountFeed *event.Feed,
-	settingsFeed *event.Feed,
+	networksFeed *event.Feed,
 	gethManager *account.GethManager,
 	transactor *transactions.Transactor,
 	config *params.NodeConfig,

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -193,7 +193,7 @@ func NewService(
 		mediaServer,
 		feed,
 	)
-	collectibles := collectibles.NewService(db, feed, accountsDB, accountFeed, settingsFeed, communityManager, rpcClient.NetworkManager, collectiblesManager)
+	collectibles := collectibles.NewService(db, feed, accountsDB, accountFeed, networksFeed, communityManager, rpcClient.NetworkManager, collectiblesManager)
 
 	activity := activity.NewService(db, accountsDB, tokenManager, collectiblesManager, feed, pendingTxManager)
 

--- a/services/wallet/token/balance_persistence_test.go
+++ b/services/wallet/token/balance_persistence_test.go
@@ -225,7 +225,7 @@ func TestGetCachedBalancesByChain(t *testing.T) {
 
 	require.NoError(t, persistence.SaveTokens(tokens))
 
-	tokenManager := NewTokenManager(db, nil, community.NewManager(db, nil, nil), network.NewManager(db), db, nil, nil, nil, nil, persistence)
+	tokenManager := NewTokenManager(db, nil, community.NewManager(db, nil, nil), network.NewManager(db, nil, nil, nil), db, nil, nil, nil, nil, persistence)
 
 	// Verify that the token balance was inserted correctly
 	var count int

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -342,7 +342,7 @@ func Test_removeTokenBalanceOnEventAccountRemoved(t *testing.T) {
 	rpcClient, _ := rpc.NewClient(config)
 
 	rpcClient.UpstreamChainID = chainID
-	nm := network.NewManager(appDB)
+	nm := network.NewManager(appDB, nil, nil, nil)
 	mediaServer, err := mediaserver.NewMediaServer(appDB, nil, nil, walletDB)
 	require.NoError(t, err)
 
@@ -406,7 +406,7 @@ func Test_tokensListsValidity(t *testing.T) {
 	accountsDB, err := accounts.NewDB(appDB)
 	require.NoError(t, err)
 
-	nm := network.NewManager(appDB)
+	nm := network.NewManager(appDB, nil, nil, nil)
 
 	manager := NewTokenManager(walletDB, nil, nil, nm, appDB, nil, nil, nil, accountsDB, NewPersistence(walletDB))
 	require.NotNil(t, manager)

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -1091,7 +1091,7 @@ func setupFindBlocksCommand(t *testing.T, accountAddress common.Address, fromBlo
 	require.NoError(t, err)
 
 	client.SetClient(tc.NetworkID(), tc)
-	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
+	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb, nil, nil, nil), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 	tokenManager.SetTokens([]*token.Token{
 		{
 			Address:  tokenTXXAddress,
@@ -1361,7 +1361,7 @@ func TestFetchTransfersForLoadedBlocks(t *testing.T) {
 	client, _ := statusRpc.NewClient(config)
 
 	client.SetClient(tc.NetworkID(), tc)
-	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
+	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb, nil, nil, nil), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
 	tokenManager.SetTokens([]*token.Token{
 		{
@@ -1492,7 +1492,7 @@ func TestFetchNewBlocksCommand_findBlocksWithEthTransfers(t *testing.T) {
 		client, _ := statusRpc.NewClient(config)
 
 		client.SetClient(tc.NetworkID(), tc)
-		tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
+		tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb, nil, nil, nil), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
 		tokenManager.SetTokens([]*token.Token{
 			{
@@ -1580,7 +1580,7 @@ func TestFetchNewBlocksCommand_nonceDetection(t *testing.T) {
 	client, _ := statusRpc.NewClient(config)
 
 	client.SetClient(tc.NetworkID(), tc)
-	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
+	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb, nil, nil, nil), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
 	wdb := NewDB(db)
 	blockChannel := make(chan []*DBHeader, 10)
@@ -1703,7 +1703,7 @@ func TestFetchNewBlocksCommand(t *testing.T) {
 
 	client.SetClient(tc.NetworkID(), tc)
 
-	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
+	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb, nil, nil, nil), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
 	tokenManager.SetTokens([]*token.Token{
 		{


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/17091

I swear `deactivatable` is a real word: https://en.wiktionary.org/wiki/deactivatable

There's basically three parts to this PR:

1) Add parameters `IsActive` and `IsDeactivatable` to each network: https://github.com/status-im/status-go/pull/6315/commits/f87f53e8f85ec29bac62850b3770ef773785c929

`IsActive` lets the user select which chains are available for use across the app (as opposed to `IsEnabled`, which simply means whether a chain is considered when displaying balances, collectibles and activity). No provider calls should occur for networks that are not active at a given time (just like what's expected of Testnet chains when the app is in Mainnet mode and viceversa)
`IsDeactivatable` lets the client know whether a network can be deactivated. Some critical app features require specific networks to always be active (Mainnet and Sepolia). 
New API `SetChainActive` lets the user toggle this setting. Some checks are in place to ensure only Deactivatable chains can be deactivated, and no more than 5 chains are active at a given time.

Since custom chains are not supported for now `AddEthereumChain` and `DeleteEthereumChain` are marked as deprecated. Half the app will malfunction if the client uses these endpoints to add new chains, and we've got dedicated endpoints for network user-editable fields. 

2) Implement network events: https://github.com/status-im/status-go/pull/6315/commits/05d0f3705ddb115efc585fac1bc4bb7d162b1799

This is just a pub-subby way for status-go modules to react to changes in the list of networks. 

3) Use networks events for automatic collectibles ownership refreshes: https://github.com/status-im/status-go/pull/6315/commits/f3bfddb625c26d9c5b82fd2ab9f4630872d526d6

Ideally we extend this to other modules which depend on the client to notify about network changes, which is more error-prone. (Separate issues https://github.com/status-im/status-desktop/issues/17182 and https://github.com/status-im/status-desktop/issues/17183)

The rest is just changes to make tests happy.
