### PR TITLE
chore_: `LoginAccount` simplifications

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -609,7 +609,11 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 	}
 
 	if acc.KDFIterations == 0 {
-		acc.KDFIterations = dbsetup.ReducedKDFIterationsNumber
+		var err error
+		acc.KDFIterations, err = b.multiaccountsDB.GetAccountKDFIterationsNumber(acc.KeyUID)
+		if err != nil {
+			return errors.Wrap(err, "failed to get account kdf iterations number")
+		}
 	}
 
 	err := b.ensureDBsOpened(acc, request.Password)

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -590,6 +590,10 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 			return errors.Wrap(err, "failed to generate account info")
 		}
 
+		if info.KeyUID != request.KeyUID {
+			return errors.New("mnemonic does not match this account")
+		}
+
 		derivedAddresses, err := b.getDerivedAddresses(info.ID)
 		if err != nil {
 			return errors.Wrap(err, "failed to get derived addresses")

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -31,6 +31,7 @@ type Login struct {
 	// When non-empty, mnemonic is used to generate required keypairs and:
 	// - Password is ignored and replaced with encryption public key
 	// - KeycardWhisperPrivateKey is ignored and replaced with chat private key
+	// - KeyUID is ignored and replaced with hash of the master public key
 	Mnemonic string `json:"mnemonic"`
 
 	WalletSecretsConfig

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -17,7 +17,9 @@ type Login struct {
 	Password string `json:"password"`
 	KeyUID   string `json:"keyUid"`
 
-	KdfIterations         int    `json:"kdfIterations"` // FIXME: KdfIterations should be loaded from multiaccounts db.
+	// Deprecated: KdfIterations will be automatically fetched from the multiaccounts db.
+	// For now the automation is done when KdfIterations is 0. In future this field will be completely ignored.
+	KdfIterations         int    `json:"kdfIterations"`
 	RuntimeLogLevel       string `json:"runtimeLogLevel"`
 	WakuV2Nameserver      string `json:"wakuV2Nameserver"`
 	BandwidthStatsEnabled bool   `json:"bandwidthStatsEnabled"`


### PR DESCRIPTION
Required for https://github.com/status-im/status-desktop/pull/17273

# Description

In `LoginAccount`:
1. Ensure provided `Mnemonic` key uid matches the given `KeyUID`
2. Automatically get `kdfIterations` from multiaccounts database.`kdfIteractions` argument is deprecated with a fallback.

Both changes are needed for `Start using this account without account` login flow.