### PR TITLE
feat_: Update alias generated

### DIFF
--- a/protocol/contact.go
+++ b/protocol/contact.go
@@ -15,6 +15,7 @@ import (
 	multiaccountscommon "github.com/status-im/status-go/multiaccounts/common"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/identity/alias"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/verification"
 )
@@ -363,18 +364,6 @@ func BuildContactFromPublicKey(publicKey *ecdsa.PublicKey) (*Contact, error) {
 	return buildContact(id, publicKey)
 }
 
-func getShortenedCompressedKey(publicKey string) string {
-	if len(publicKey) > 9 {
-		firstPart := publicKey[0:3]
-		ellipsis := "..."
-		publicKeySize := len(publicKey)
-		lastPart := publicKey[publicKeySize-6 : publicKeySize]
-		abbreviatedKey := fmt.Sprintf("%s%s%s", firstPart, ellipsis, lastPart)
-		return abbreviatedKey
-	}
-	return ""
-}
-
 func buildContact(publicKeyString string, publicKey *ecdsa.PublicKey) (*Contact, error) {
 	compressedKey, err := multiformat.SerializeLegacyKey(common.PubkeyToHex(publicKey))
 	if err != nil {
@@ -385,7 +374,7 @@ func buildContact(publicKeyString string, publicKey *ecdsa.PublicKey) (*Contact,
 
 	contact := &Contact{
 		ID:                 publicKeyString,
-		Alias:              getShortenedCompressedKey(compressedKey),
+		Alias:              alias.ShortenedCompressedKey(compressedKey),
 		Address:            types.EncodeHex(address[:]),
 		CustomizationColor: multiaccountscommon.CustomizationColorBlue,
 	}

--- a/protocol/identity/alias/generate.go
+++ b/protocol/identity/alias/generate.go
@@ -2,11 +2,10 @@ package alias
 
 import (
 	"crypto/ecdsa"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
-	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/api/multiformat"
 )
 
 const poly uint64 = 0xB8
@@ -29,19 +28,27 @@ func GenerateFromPublicKey(publicKey *ecdsa.PublicKey) string {
 	return generate(uint64(publicKey.X.Int64()))
 }
 
-// GenerateFromPublicKeyString returns the 3 words name given a public key
-// prefixed with 0x
+// GenerateFromPublicKeyString calculates the compressed key for the given publicKeyString
+// and returns its first 8 chars followed by an ellipsis char and its last 5 chars.
 func GenerateFromPublicKeyString(publicKeyString string) (string, error) {
-	pk := strings.TrimPrefix(publicKeyString, "0x")
-	publicKeyBytes, err := hex.DecodeString(pk)
+	//  Ensure there's `0x` prefix
+	if !strings.HasPrefix(publicKeyString, "0x") {
+		publicKeyString = "0x" + publicKeyString
+	}
+
+	compressedKey, err := multiformat.SerializeLegacyKey(publicKeyString)
 	if err != nil {
 		return "", err
 	}
 
-	publicKey, err := crypto.UnmarshalPubkey(publicKeyBytes)
-	if err != nil {
-		return "", err
-	}
+	return ShortenedCompressedKey(compressedKey), nil
+}
 
-	return GenerateFromPublicKey(publicKey), nil
+func ShortenedCompressedKey(compressedKey string) string {
+	if len(compressedKey) <= 12 {
+		return ""
+	}
+	prefix := compressedKey[0:8]
+	suffix := compressedKey[len(compressedKey)-5:]
+	return prefix + "…" + suffix
 }

--- a/protocol/identity/alias/generate_test.go
+++ b/protocol/identity/alias/generate_test.go
@@ -24,13 +24,13 @@ func TestGenerateFromPublicKeyString(t *testing.T) {
 		{
 			name:          "valid public key - start with 0x",
 			publicKey:     "0x04eedbaafd6adf4a9233a13e7b1c3c14461fffeba2e9054b8d456ce5f6ebeafadcbf3dce3716253fbc391277fa5a086b60b283daf61fb5b1f26895f456c2f31ae3",
-			alias:         "Darkorange Blue Bubblefish",
+			alias:         "zQ3shviW…k2bWB",
 			errorExpected: false,
 		},
 		{
 			name:          "valid public key - without 0x",
 			publicKey:     "04eedbaafd6adf4a9233a13e7b1c3c14461fffeba2e9054b8d456ce5f6ebeafadcbf3dce3716253fbc391277fa5a086b60b283daf61fb5b1f26895f456c2f31ae3",
-			alias:         "Darkorange Blue Bubblefish",
+			alias:         "zQ3shviW…k2bWB",
 			errorExpected: false,
 		},
 		{
@@ -42,6 +42,24 @@ func TestGenerateFromPublicKeyString(t *testing.T) {
 		{
 			name:          "empty public key",
 			publicKey:     "",
+			alias:         "",
+			errorExpected: true,
+		},
+		{
+			name:          "invalid public key length - 2 chars",
+			publicKey:     "0X",
+			alias:         "",
+			errorExpected: true,
+		},
+		{
+			name:          "invalid public key length - public key length minus 1 char",
+			publicKey:     "0x04eedbaafd6adf4a9233a13e7b1c3c14461fffeba2e9054b8d456ce5f6ebeafadcbf3dce3716253fbc391277fa5a086b60b283daf61fb5b1f26895f456c2f31ae",
+			alias:         "",
+			errorExpected: true,
+		},
+		{
+			name:          "invalid public key length - more chars than the public key",
+			publicKey:     "0x04eedbaafd6adf4a9233a13e7b1c3c14461fffeba2e9054b8d456ce5f6ebeafadcbf3dce3716253fbc391277fa5a086b60b283daf61fb5b1f26895f456c2f31ae304eedbaafd6adf4a9233a13e7b1c3c14461fffeba2e9054b8d456ce5f6ebeafadcbf3dce3716253fbc391277fa5a086b60b283daf61fb5b1f26895f456c2f31ae3",
 			alias:         "",
 			errorExpected: true,
 		},


### PR DESCRIPTION
This PR is required to acomplish

- https://github.com/status-im/status-mobile/issues/21924

The context about this change is mainly in [this Discord thread](https://discord.com/channels/1210237582470807632/1335942754152353844).

## Summary
This PR changes the implementation of `GenerateFromPublicKeyString` to return a compressed key with ellipsis instead of the 3-words name.

### Important changes:

- [x] Changed from the 3-words name to be the compressed key with an ellipsis
- [x] Update the shortened compressed key to be consistent with the alias

