### PR TITLE
feat_: support enable and disable log

### DIFF
--- a/nodecfg/node_config.go
+++ b/nodecfg/node_config.go
@@ -828,6 +828,11 @@ func SetLogNamespaces(db *sql.DB, logNamespaces string) error {
 	return err
 }
 
+func SetLogEnabled(db *sql.DB, enabled bool) error {
+	_, err := db.Exec(`UPDATE log_config SET enabled = ?`, enabled)
+	return err
+}
+
 func SetMaxLogBackups(db *sql.DB, maxLogBackups uint) error {
 	_, err := db.Exec(`UPDATE log_config SET max_backups = ?`, maxLogBackups)
 	return err

--- a/protocol/messenger_settings.go
+++ b/protocol/messenger_settings.go
@@ -46,6 +46,10 @@ func (m *Messenger) SetLogNamespaces(request *requests.SetLogNamespaces) error {
 	return nodecfg.SetLogNamespaces(m.database, request.LogNamespaces)
 }
 
+func (m *Messenger) SetLogEnabled(enabled bool) error {
+	return nodecfg.SetLogEnabled(m.database, enabled)
+}
+
 func (m *Messenger) SetMaxLogBackups(request *requests.SetMaxLogBackups) error {
 	return nodecfg.SetMaxLogBackups(m.database, request.MaxLogBackups)
 }

--- a/protocol/node_config_persistence_test.go
+++ b/protocol/node_config_persistence_test.go
@@ -92,3 +92,23 @@ func (s *NodeConfigPersistenceTestSuite) Test_SetLogLevelDebug() {
 	s.Require().NoError(err)
 	s.Require().Equal("DEBUG", dbNodeConfig.LogLevel)
 }
+
+func (s *NodeConfigPersistenceTestSuite) Test_SetLogEnabled() {
+	// WHEN
+	err := nodecfg.SetLogEnabled(s.db, false)
+	s.Require().NoError(err)
+
+	// THEN
+	dbNodeConfig, err := nodecfg.GetNodeConfigFromDB(s.db)
+	s.Require().NoError(err)
+	s.Require().Equal(false, dbNodeConfig.LogEnabled)
+
+	// WHEN
+	err = nodecfg.SetLogEnabled(s.db, true)
+	s.Require().NoError(err)
+
+	// THEN
+	dbNodeConfig, err = nodecfg.GetNodeConfigFromDB(s.db)
+	s.Require().NoError(err)
+	s.Require().Equal(true, dbNodeConfig.LogEnabled)
+}

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1807,6 +1807,10 @@ func (api *PublicAPI) SetLogNamespaces(request *requests.SetLogNamespaces) error
 	return api.service.messenger.SetLogNamespaces(request)
 }
 
+func (api *PublicAPI) SetLogEnabled(enabled bool) error {
+	return api.service.messenger.SetLogEnabled(enabled)
+}
+
 func (api *PublicAPI) SetMaxLogBackups(request *requests.SetMaxLogBackups) error {
 	return api.service.messenger.SetMaxLogBackups(request)
 }


### PR DESCRIPTION
this PR added a new endpoint `SetLogEnabled` so that frontend can enable log when log is disabled by default for release build.

relate mobile [PR](https://github.com/status-im/status-mobile/pull/22122)
relate [comment](https://github.com/status-im/status-go/pull/6202#pullrequestreview-2502170310)

NOTE: I haven't review the way we store settings and all this mess with NodeConfig yet.