### PR TITLE
test_: use foundry:v0.3.0

### DIFF
--- a/tests-functional/Dockerfile
+++ b/tests-functional/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/foundry-rs/foundry:stable
+FROM ghcr.io/foundry-rs/foundry:v0.3.0
 
 RUN apk update && \
     apk add git bash


### PR DESCRIPTION
fix `Error
failed on setup with "RuntimeError: Failed to start container on ports: [25919, 23448, 23867, 18630, 20984]"`