### PR TITLE
test_: Tests for wakuext messages 1

### DIFF
--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -75,6 +75,11 @@ class WakuextService(Service):
         response = self.rpc_request("setLightClient", params)
         return response.json()
 
+    def get_chat_messages(self, chat_id: str):
+        params = [chat_id, "", 10]
+        response = self.rpc_request("chatMessages", params)
+        return response.json()
+
     def peers(self):
         params = []
         response = self.rpc_request("peers", params)

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -75,8 +75,8 @@ class WakuextService(Service):
         response = self.rpc_request("setLightClient", params)
         return response.json()
 
-    def get_chat_messages(self, chat_id: str):
-        params = [chat_id, "", 10]
+    def get_chat_messages(self, chat_id: str, cursor="", limit=10):
+        params = [chat_id, cursor, limit]
         response = self.rpc_request("chatMessages", params)
         return response.json()
 

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -75,9 +75,14 @@ class WakuextService(Service):
         response = self.rpc_request("setLightClient", params)
         return response.json()
 
-    def get_chat_messages(self, chat_id: str, cursor="", limit=10):
+    def chat_messages(self, chat_id: str, cursor="", limit=10):
         params = [chat_id, cursor, limit]
         response = self.rpc_request("chatMessages", params)
+        return response.json()
+
+    def message_by_message_id(self, message_id: str):
+        params = [message_id]
+        response = self.rpc_request("messageByMessageID", params)
         return response.json()
 
     def peers(self):

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -75,6 +75,11 @@ class WakuextService(Service):
         response = self.rpc_request("setLightClient", params)
         return response.json()
 
+    def peers(self):
+        params = []
+        response = self.rpc_request("peers", params)
+        return response.json()
+
     def chat_messages(self, chat_id: str, cursor="", limit=10):
         params = [chat_id, cursor, limit]
         response = self.rpc_request("chatMessages", params)
@@ -85,7 +90,7 @@ class WakuextService(Service):
         response = self.rpc_request("messageByMessageID", params)
         return response.json()
 
-    def peers(self):
-        params = []
-        response = self.rpc_request("peers", params)
+    def all_messages_from_chat_which_match_term(self, chat_id: str, searchTerm: str, caseSensitive: bool):
+        params = [chat_id, searchTerm, caseSensitive]
+        response = self.rpc_request("allMessagesFromChatWhichMatchTerm", params)
         return response.json()

--- a/tests-functional/schemas/wakuext_allMessagesFromChatWhichMatchTerm
+++ b/tests-functional/schemas/wakuext_allMessagesFromChatWhichMatchTerm
@@ -1,0 +1,168 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "properties": {
+                "cursor": {
+                    "type": "string"
+                },
+                "messages": {
+                    "items": {
+                        "properties": {
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatId": {
+                                "type": "string"
+                            },
+                            "clock": {
+                                "type": "integer"
+                            },
+                            "compressedKey": {
+                                "type": "string"
+                            },
+                            "contentType": {
+                                "type": "integer"
+                            },
+                            "displayName": {
+                                "type": "string"
+                            },
+                            "emojiHash": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "ensName": {
+                                "type": "string"
+                            },
+                            "from": {
+                                "type": "string"
+                            },
+                            "gapParameters": {
+                                "type": "object"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "lineCount": {
+                                "type": "integer"
+                            },
+                            "localChatId": {
+                                "type": "string"
+                            },
+                            "messageType": {
+                                "type": "integer"
+                            },
+                            "outgoingStatus": {
+                                "type": "string"
+                            },
+                            "parsedText": {
+                                "items": {
+                                    "properties": {
+                                        "children": {
+                                            "items": {
+                                                "properties": {
+                                                    "literal": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "literal"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "children",
+                                        "type"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "quotedMessage": {
+                                "type": "null"
+                            },
+                            "replace": {
+                                "type": "string"
+                            },
+                            "responseTo": {
+                                "type": "string"
+                            },
+                            "rtl": {
+                                "type": "boolean"
+                            },
+                            "seen": {
+                                "type": "boolean"
+                            },
+                            "text": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "whisperTimestamp": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "alias",
+                            "chatId",
+                            "clock",
+                            "compressedKey",
+                            "contentType",
+                            "displayName",
+                            "emojiHash",
+                            "ensName",
+                            "from",
+                            "gapParameters",
+                            "id",
+                            "identicon",
+                            "lineCount",
+                            "localChatId",
+                            "messageType",
+                            "outgoingStatus",
+                            "parsedText",
+                            "quotedMessage",
+                            "replace",
+                            "responseTo",
+                            "rtl",
+                            "seen",
+                            "text",
+                            "timestamp",
+                            "whisperTimestamp"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cursor",
+                "messages"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/schemas/wakuext_chatMessages
+++ b/tests-functional/schemas/wakuext_chatMessages
@@ -1,0 +1,168 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "properties": {
+                "cursor": {
+                    "type": "string"
+                },
+                "messages": {
+                    "items": {
+                        "properties": {
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatId": {
+                                "type": "string"
+                            },
+                            "clock": {
+                                "type": "integer"
+                            },
+                            "compressedKey": {
+                                "type": "string"
+                            },
+                            "contentType": {
+                                "type": "integer"
+                            },
+                            "displayName": {
+                                "type": "string"
+                            },
+                            "emojiHash": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "ensName": {
+                                "type": "string"
+                            },
+                            "from": {
+                                "type": "string"
+                            },
+                            "gapParameters": {
+                                "type": "object"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "lineCount": {
+                                "type": "integer"
+                            },
+                            "localChatId": {
+                                "type": "string"
+                            },
+                            "messageType": {
+                                "type": "integer"
+                            },
+                            "outgoingStatus": {
+                                "type": "string"
+                            },
+                            "parsedText": {
+                                "items": {
+                                    "properties": {
+                                        "children": {
+                                            "items": {
+                                                "properties": {
+                                                    "literal": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "literal"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "children",
+                                        "type"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "quotedMessage": {
+                                "type": "null"
+                            },
+                            "replace": {
+                                "type": "string"
+                            },
+                            "responseTo": {
+                                "type": "string"
+                            },
+                            "rtl": {
+                                "type": "boolean"
+                            },
+                            "seen": {
+                                "type": "boolean"
+                            },
+                            "text": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "whisperTimestamp": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "alias",
+                            "chatId",
+                            "clock",
+                            "compressedKey",
+                            "contentType",
+                            "displayName",
+                            "emojiHash",
+                            "ensName",
+                            "from",
+                            "gapParameters",
+                            "id",
+                            "identicon",
+                            "lineCount",
+                            "localChatId",
+                            "messageType",
+                            "outgoingStatus",
+                            "parsedText",
+                            "quotedMessage",
+                            "replace",
+                            "responseTo",
+                            "rtl",
+                            "seen",
+                            "text",
+                            "timestamp",
+                            "whisperTimestamp"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cursor",
+                "messages"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/schemas/wakuext_messageByMessageID
+++ b/tests-functional/schemas/wakuext_messageByMessageID
@@ -1,0 +1,153 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "chatId": {
+                    "type": "string"
+                },
+                "clock": {
+                    "type": "integer"
+                },
+                "compressedKey": {
+                    "type": "string"
+                },
+                "contentType": {
+                    "type": "integer"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "emojiHash": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ensName": {
+                    "type": "string"
+                },
+                "from": {
+                    "type": "string"
+                },
+                "gapParameters": {
+                    "type": "object"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "identicon": {
+                    "type": "string"
+                },
+                "lineCount": {
+                    "type": "integer"
+                },
+                "localChatId": {
+                    "type": "string"
+                },
+                "messageType": {
+                    "type": "integer"
+                },
+                "outgoingStatus": {
+                    "type": "string"
+                },
+                "parsedText": {
+                    "items": {
+                        "properties": {
+                            "children": {
+                                "items": {
+                                    "properties": {
+                                        "literal": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "literal"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "children",
+                            "type"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "quotedMessage": {
+                    "type": "null"
+                },
+                "replace": {
+                    "type": "string"
+                },
+                "responseTo": {
+                    "type": "string"
+                },
+                "rtl": {
+                    "type": "boolean"
+                },
+                "seen": {
+                    "type": "boolean"
+                },
+                "text": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "integer"
+                },
+                "whisperTimestamp": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "alias",
+                "chatId",
+                "clock",
+                "compressedKey",
+                "contentType",
+                "displayName",
+                "emojiHash",
+                "ensName",
+                "from",
+                "gapParameters",
+                "id",
+                "identicon",
+                "lineCount",
+                "localChatId",
+                "messageType",
+                "outgoingStatus",
+                "parsedText",
+                "quotedMessage",
+                "replace",
+                "responseTo",
+                "rtl",
+                "seen",
+                "text",
+                "timestamp",
+                "whisperTimestamp"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/tests/test_cases.py
+++ b/tests-functional/tests/test_cases.py
@@ -382,6 +382,18 @@ class MessengerTestCase(NetworkConditionTestCase):
 
         return responses
 
+    def send_multiple_one_to_one_messages(self, message_count=1) -> tuple[list[str], list[dict]]:
+        sent_texts = []  # ordered from latest to earliest
+        messages = []  # ordered from latest to earliest
+
+        for i in range(message_count):
+            message_text = f"test_message_{i}_{uuid4()}"
+            sent_texts.insert(0, message_text)
+            response = self.sender.wakuext_service.send_message(self.receiver.public_key, message_text)
+            messages.insert(0, response.get("result", {}).get("messages", [])[0])
+
+        return sent_texts, messages
+
     def add_contact(self, execution_number, network_condition=None, privileged=True):
         message_text = f"test_contact_request_{execution_number}_{uuid4()}"
         sender = self.initialize_backend(await_signals=self.await_signals, privileged=privileged)

--- a/tests-functional/tests/test_cases.py
+++ b/tests-functional/tests/test_cases.py
@@ -357,18 +357,10 @@ class MessengerTestCase(NetworkConditionTestCase):
             )
 
     def one_to_one_message(self, message_count):
-        responses = []
-        sent_messages = []
+        _, responses = self.send_multiple_one_to_one_messages(message_count)
+        messages = list(map(lambda r: r.get("result", {}).get("messages", [])[0], responses))
 
-        for i in range(message_count):
-            message_text = f"test_message_{i+1}_{uuid4()}"
-            response = self.sender.wakuext_service.send_message(self.receiver.public_key, message_text)
-            responses.append(response)
-            expected_message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
-            sent_messages.append(expected_message)
-            time.sleep(0.01)
-
-        for i, expected_message in enumerate(sent_messages):
+        for expected_message in messages:
             messages_new_event = self.receiver.find_signal_containing_pattern(
                 SignalType.MESSAGES_NEW.value,
                 event_pattern=expected_message.get("id"),
@@ -384,15 +376,15 @@ class MessengerTestCase(NetworkConditionTestCase):
 
     def send_multiple_one_to_one_messages(self, message_count=1) -> tuple[list[str], list[dict]]:
         sent_texts = []
-        messages = []
+        responses = []
 
         for i in range(message_count):
             message_text = f"test_message_{i}_{uuid4()}"
             sent_texts.append(message_text)
             response = self.sender.wakuext_service.send_message(self.receiver.public_key, message_text)
-            messages.append(response.get("result", {}).get("messages", [])[0])
+            responses.append(response)
 
-        return sent_texts, messages
+        return sent_texts, responses
 
     def add_contact(self, execution_number, network_condition=None, privileged=True):
         message_text = f"test_contact_request_{execution_number}_{uuid4()}"

--- a/tests-functional/tests/test_cases.py
+++ b/tests-functional/tests/test_cases.py
@@ -383,14 +383,14 @@ class MessengerTestCase(NetworkConditionTestCase):
         return responses
 
     def send_multiple_one_to_one_messages(self, message_count=1) -> tuple[list[str], list[dict]]:
-        sent_texts = []  # ordered from latest to earliest
-        messages = []  # ordered from latest to earliest
+        sent_texts = []
+        messages = []
 
         for i in range(message_count):
             message_text = f"test_message_{i}_{uuid4()}"
-            sent_texts.insert(0, message_text)
+            sent_texts.append(message_text)
             response = self.sender.wakuext_service.send_message(self.receiver.public_key, message_text)
-            messages.insert(0, response.get("result", {}).get("messages", [])[0])
+            messages.append(response.get("result", {}).get("messages", [])[0])
 
         return sent_texts, messages
 

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -1,0 +1,22 @@
+from uuid import uuid4
+
+import pytest
+
+from tests.test_cases import MessengerTestCase
+
+
+@pytest.mark.usefixtures("setup_two_unprivileged_nodes")
+@pytest.mark.rpc
+class TestMessages(MessengerTestCase):
+
+    def test_get_chat_messages(self):
+        message_text = f"test_message_{uuid4()}"
+        self.sender.wakuext_service.send_message(self.receiver.public_key, message_text)
+
+        sender_chat_id = self.receiver.public_key
+        response = self.sender.wakuext_service.get_chat_messages(sender_chat_id)
+
+        messages = response.get("result", {}).get("messages", [])
+        assert len(messages) == 1
+        actual_text = messages[0].get("text", "")
+        assert actual_text == message_text

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -30,8 +30,8 @@ class TestChatMessages(MessengerTestCase):
         cursor1 = chat_messages_res1.get("result", {}).get("cursor", "")
         messages_page1 = chat_messages_res1.get("result", {}).get("messages", [])
         assert len(messages_page1) == 3
-        assert messages_page1[0].get("text", "") == sent_texts[0]
-        assert messages_page1[1].get("text", "") == sent_texts[1]
+        assert messages_page1[0].get("text", "") == sent_texts[4]
+        assert messages_page1[1].get("text", "") == sent_texts[3]
         assert messages_page1[2].get("text", "") == sent_texts[2]
 
         # Page 2
@@ -40,8 +40,8 @@ class TestChatMessages(MessengerTestCase):
         cursor2 = chat_messages_res2.get("result", {}).get("cursor", "")
         messages_page2 = chat_messages_res2.get("result", {}).get("messages", [])
         assert len(messages_page2) == 2
-        assert messages_page2[0].get("text", "") == sent_texts[3]
-        assert messages_page2[1].get("text", "") == sent_texts[4]
+        assert messages_page2[0].get("text", "") == sent_texts[1]
+        assert messages_page2[1].get("text", "") == sent_texts[0]
         assert cursor2 == ""
 
     def test_message_by_message_id(self):

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -1,37 +1,31 @@
 import pytest
-from uuid import uuid4
 
 from tests.test_cases import MessengerTestCase
 
 
 @pytest.mark.usefixtures("setup_two_unprivileged_nodes")
 @pytest.mark.rpc
-class TestMessages(MessengerTestCase):
+class TestChatMessages(MessengerTestCase):
 
-    def test_get_chat_messages(self):
-        message_text = f"test_message_{uuid4()}"
-        self.sender.wakuext_service.send_message(self.receiver.public_key, message_text)
+    def test_chat_messages(self):
+        sent_texts, _ = self.send_multiple_one_to_one_messages(1)
 
         sender_chat_id = self.receiver.public_key
-        response = self.sender.wakuext_service.get_chat_messages(sender_chat_id)
+        response = self.sender.wakuext_service.chat_messages(sender_chat_id)
 
         self.sender.verify_json_schema(response, method="wakuext_chatMessages")
 
         messages = response.get("result", {}).get("messages", [])
         assert len(messages) == 1
         actual_text = messages[0].get("text", "")
-        assert actual_text == message_text
+        assert actual_text == sent_texts[0]
 
-    def test_get_chat_messages_with_pagination(self):
+    def test_chat_messages_with_pagination(self):
+        sent_texts, _ = self.send_multiple_one_to_one_messages(5)
         sender_chat_id = self.receiver.public_key
-        sent_texts = []
-        for i in range(5):
-            message_text = f"test_message_{i}_{uuid4()}"
-            sent_texts.insert(0, message_text)  # sent_texts ordered from the latest
-            self.sender.wakuext_service.send_message(self.receiver.public_key, message_text)
 
         # Page 1
-        chat_messages_res1 = self.sender.wakuext_service.get_chat_messages(sender_chat_id, cursor="", limit=3)
+        chat_messages_res1 = self.sender.wakuext_service.chat_messages(sender_chat_id, cursor="", limit=3)
 
         cursor1 = chat_messages_res1.get("result", {}).get("cursor", "")
         messages_page1 = chat_messages_res1.get("result", {}).get("messages", [])
@@ -41,7 +35,7 @@ class TestMessages(MessengerTestCase):
         assert messages_page1[2].get("text", "") == sent_texts[2]
 
         # Page 2
-        chat_messages_res2 = self.sender.wakuext_service.get_chat_messages(sender_chat_id, cursor=cursor1, limit=3)
+        chat_messages_res2 = self.sender.wakuext_service.chat_messages(sender_chat_id, cursor=cursor1, limit=3)
 
         cursor2 = chat_messages_res2.get("result", {}).get("cursor", "")
         messages_page2 = chat_messages_res2.get("result", {}).get("messages", [])
@@ -49,3 +43,14 @@ class TestMessages(MessengerTestCase):
         assert messages_page2[0].get("text", "") == sent_texts[3]
         assert messages_page2[1].get("text", "") == sent_texts[4]
         assert cursor2 == ""
+
+    def test_message_by_message_id(self):
+        sent_texts, messages = self.send_multiple_one_to_one_messages(1)
+
+        messageId = messages[0].get("id", "")
+        response = self.sender.wakuext_service.message_by_message_id(messageId)
+
+        self.sender.verify_json_schema(response, method="wakuext_messageByMessageID")
+
+        actual_text = response.get("result", {}).get("text", "")
+        assert actual_text == sent_texts[0]

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -21,3 +21,31 @@ class TestMessages(MessengerTestCase):
         assert len(messages) == 1
         actual_text = messages[0].get("text", "")
         assert actual_text == message_text
+
+    def test_get_chat_messages_with_pagination(self):
+        sender_chat_id = self.receiver.public_key
+        sent_texts = []
+        for i in range(5):
+            message_text = f"test_message_{i}_{uuid4()}"
+            sent_texts.insert(0, message_text)  # sent_texts ordered from the latest
+            self.sender.wakuext_service.send_message(self.receiver.public_key, message_text)
+
+        # Page 1
+        chat_messages_res1 = self.sender.wakuext_service.get_chat_messages(sender_chat_id, cursor="", limit=3)
+
+        cursor1 = chat_messages_res1.get("result", {}).get("cursor", "")
+        messages_page1 = chat_messages_res1.get("result", {}).get("messages", [])
+        assert len(messages_page1) == 3
+        assert messages_page1[0].get("text", "") == sent_texts[0]
+        assert messages_page1[1].get("text", "") == sent_texts[1]
+        assert messages_page1[2].get("text", "") == sent_texts[2]
+
+        # Page 2
+        chat_messages_res2 = self.sender.wakuext_service.get_chat_messages(sender_chat_id, cursor=cursor1, limit=3)
+
+        cursor2 = chat_messages_res2.get("result", {}).get("cursor", "")
+        messages_page2 = chat_messages_res2.get("result", {}).get("messages", [])
+        assert len(messages_page2) == 2
+        assert messages_page2[0].get("text", "") == sent_texts[3]
+        assert messages_page2[1].get("text", "") == sent_texts[4]
+        assert cursor2 == ""

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -54,3 +54,22 @@ class TestChatMessages(MessengerTestCase):
 
         actual_text = response.get("result", {}).get("text", "")
         assert actual_text == sent_texts[0]
+
+    @pytest.mark.parametrize(
+        "searchTerm,caseSensitive,expectedCount",
+        [
+            ("test_message_1", False, 1),
+            ("TEST_MESSAGE_", False, 3),
+            ("TEST_MESSAGE_", True, 3),  # caseSensitive doesn't work?
+        ],
+    )
+    def test_all_messages_from_chat_which_match_term(self, searchTerm, caseSensitive, expectedCount):
+        self.send_multiple_one_to_one_messages(3)
+        sender_chat_id = self.receiver.public_key
+
+        response = self.sender.wakuext_service.all_messages_from_chat_which_match_term(sender_chat_id, searchTerm, caseSensitive)
+
+        self.sender.verify_json_schema(response, method="wakuext_allMessagesFromChatWhichMatchTerm")
+
+        messages = response.get("result", {}).get("messages", [])
+        assert len(messages) == expectedCount

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -45,9 +45,9 @@ class TestChatMessages(MessengerTestCase):
         assert cursor2 == ""
 
     def test_message_by_message_id(self):
-        sent_texts, messages = self.send_multiple_one_to_one_messages(1)
+        sent_texts, responses = self.send_multiple_one_to_one_messages(1)
 
-        messageId = messages[0].get("id", "")
+        messageId = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
         response = self.sender.wakuext_service.message_by_message_id(messageId)
 
         self.sender.verify_json_schema(response, method="wakuext_messageByMessageID")

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -33,6 +33,7 @@ class TestChatMessages(MessengerTestCase):
         assert messages_page1[0].get("text", "") == sent_texts[4]
         assert messages_page1[1].get("text", "") == sent_texts[3]
         assert messages_page1[2].get("text", "") == sent_texts[2]
+        assert cursor1 != ""
 
         # Page 2
         chat_messages_res2 = self.sender.wakuext_service.chat_messages(sender_chat_id, cursor=cursor1, limit=3)

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -1,6 +1,5 @@
-from uuid import uuid4
-
 import pytest
+from uuid import uuid4
 
 from tests.test_cases import MessengerTestCase
 
@@ -15,6 +14,8 @@ class TestMessages(MessengerTestCase):
 
         sender_chat_id = self.receiver.public_key
         response = self.sender.wakuext_service.get_chat_messages(sender_chat_id)
+
+        self.sender.verify_json_schema(response, method="wakuext_chatMessages")
 
         messages = response.get("result", {}).get("messages", [])
         assert len(messages) == 1

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -61,7 +61,7 @@ class TestChatMessages(MessengerTestCase):
         [
             ("test_message_1", False, 1),
             ("TEST_MESSAGE_", False, 3),
-            ("TEST_MESSAGE_", True, 3),  # caseSensitive doesn't work?
+            # ("TEST_MESSAGE_", True, 0),  # Skipped due to https://github.com/status-im/status-go/issues/6359
         ],
     )
     def test_all_messages_from_chat_which_match_term(self, searchTerm, caseSensitive, expectedCount):


### PR DESCRIPTION
Functional tests for `wakuext` messages methods: https://github.com/status-im/status-go/issues/6084

Important changes:
- [x] `wakuext_chatMessages`
- [x] `wakuext_messageByMessageID`
- [x] `wakuext_allMessagesFromChatWhichMatchTerm`
