### PR TITLE
fix_: cancel request to join to a community

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1914,6 +1914,10 @@ func (m *Messenger) CancelRequestToJoinCommunity(ctx context.Context, request *r
 		}
 
 		for _, privilegedMember := range privMembersArray {
+			// Reset rawMessage.Sender to nil on each iteration so that SendPrivate can
+			// assign the correct sender. This prevents any modifications from previous
+			// SendPrivate calls from affecting subsequent ones.
+			rawMessage.Sender = nil
 			_, err := m.sender.SendPrivate(context.Background(), privilegedMember, &rawMessage)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Fixes the issue originally reported here:

- https://github.com/status-im/status-mobile/issues/21961

Where the "cancel request to join" action threw an error,

Ran the test suite and nothing broke.

Thanks to @osmaczko for the solution
