### PR TITLE
chore(ci)_: use sc5cmd for iOS uploads

### DIFF
--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.12'
+library 'status-jenkins-lib@v1.9.20'
 
 pipeline {
   agent { label 'linux' }

--- a/_assets/ci/Jenkinsfile.android
+++ b/_assets/ci/Jenkinsfile.android
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.20'
 
 pipeline {
   agent { label 'linux && x86_64 && nix-2.24' }

--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.12'
+library 'status-jenkins-lib@v1.9.20'
 
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */

--- a/_assets/ci/Jenkinsfile.docker
+++ b/_assets/ci/Jenkinsfile.docker
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.20'
 
 pipeline {
   agent { label 'linux' }

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -82,7 +82,7 @@ pipeline {
 
     stage('Upload') {
       steps { script {
-        env.PKG_URL = s3.uploadArtifact(ARTIFACT)
+        env.PKG_URL = s5cmd.upload(ARTIFACT)
       } }
     }
   } // stages

--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.20'
 
 pipeline {
   agent { label 'macos && aarch64 && xcode-15.1 && nix-2.24' }

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.20'
 
 pipeline {
   agent { label 'linux && x86_64 && nix-2.24' }

--- a/_assets/ci/Jenkinsfile.tests-rpc
+++ b/_assets/ci/Jenkinsfile.tests-rpc
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.6'
+library 'status-jenkins-lib@v1.9.20'
 
 pipeline {
   agent { label 'linux && x86_64 && nix-2.24' }


### PR DESCRIPTION
## Summary
This PR : 
- updates jenkins lib to v1.9.20
- swaps sc3cmd with sc5cmd for failing iOS uploads which fixes issues like this : 
```
[2025-02-24T15:24:48.601Z] + s3cmd --stats --acl-public --no-preserve --host=ams3.digitaloceanspaces.com '
--host-bucket=%(bucket)s.ams3.digitaloceanspaces.com' put status-go-ios-250224-150854-bb9ff6-pr6342.zip
 s3://status-im-prs/
[2025-02-24T15:24:48.601Z] /opt/homebrew/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.13/
site-packages/S3/S3Uri.py:122: SyntaxWarning: invalid escape sequence '\.'
[2025-02-24T15:24:48.601Z]   m = re.match("(.*\.)?s3(?:\-[^\.]*)?(?:\.dualstack)?(?:\.[^\.]*)?\.amazonaws\.com
(?:\.cn)?$",
[2025-02-24T15:24:48.601Z] /opt/homebrew/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.13/site-packages/S3/
S3Uri.py:170: SyntaxWarning: invalid escape sequence '\w'
[2025-02-24T15:24:48.601Z]   _re = re.compile("^(\w+://)?(.*)", re.UNICODE)
[2025-02-24T15:24:48.601Z] /opt/homebrew/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.13/site-packages/S3/
FileLists.py:525: SyntaxWarning: invalid escape sequence '\*'
[2025-02-24T15:24:48.601Z]   wildcard_split_result = re.split("\*|\?", uri_str, maxsplit=1)
[2025-02-24T15:24:49.038Z] ERROR: SSL certificate verification failure: [SSL: CERTIFICATE_VERIFY_FAILED] 
certificate verify failed: unable to get local issuer certificate (_ssl.c:1018)
script returned exit code 77
```
