### PR TITLE
chore_: improve rpc errors logging

### DIFF
--- a/circuitbreaker/circuit_breaker.go
+++ b/circuitbreaker/circuit_breaker.go
@@ -26,24 +26,25 @@ type FunctorCallStatus struct {
 	Err       error
 }
 
-func (cr CommandResult) Result() []any {
+func (cr *CommandResult) Result() []any {
 	return cr.res
 }
 
-func (cr CommandResult) Error() error {
+func (cr *CommandResult) Error() error {
 	return cr.err
 }
-func (cr CommandResult) Cancelled() bool {
+
+func (cr *CommandResult) Cancelled() bool {
 	return cr.cancelled
 }
 
-func (cr CommandResult) FunctorCallStatuses() []FunctorCallStatus {
+func (cr *CommandResult) FunctorCallStatuses() []FunctorCallStatus {
 	return cr.functorCallStatuses
 }
 
-func (cr *CommandResult) addCallStatus(circuitName string, err error) {
+func (cr *CommandResult) addCallStatus(providerName string, err error) {
 	cr.functorCallStatuses = append(cr.functorCallStatuses, FunctorCallStatus{
-		Name:      circuitName,
+		Name:      providerName,
 		Timestamp: time.Now(),
 		Err:       err,
 	})
@@ -62,8 +63,8 @@ func NewCommand(ctx context.Context, functors []*Functor) *Command {
 	}
 }
 
-func (cmd *Command) Add(ftor *Functor) {
-	cmd.functors = append(cmd.functors, ftor)
+func (cmd *Command) Add(functor *Functor) {
+	cmd.functors = append(cmd.functors, functor)
 }
 
 func (cmd *Command) IsEmpty() bool {
@@ -94,14 +95,19 @@ func NewCircuitBreaker(config Config) *CircuitBreaker {
 }
 
 type Functor struct {
-	exec        FallbackFunc
-	circuitName string
+	exec         FallbackFunc
+	circuitName  string
+	providerName string
 }
 
-func NewFunctor(exec FallbackFunc, circuitName string) *Functor {
+// NewFunctor creates a new Functor with the provided FallbackFunc, circuitName and providerName.
+// The circuitName is the name of the circuit to be used by the Functor. If the circuitName is empty,
+// or there is only one Functor in the Command, the command will be executed without a circuit.
+func NewFunctor(exec FallbackFunc, circuitName, providerName string) *Functor {
 	return &Functor{
-		exec:        exec,
-		circuitName: circuitName,
+		exec:         exec,
+		circuitName:  circuitName,
+		providerName: providerName,
 	}
 }
 
@@ -115,7 +121,7 @@ func accumulateCommandError(result CommandResult, circuitName string, err error)
 	return result
 }
 
-// Executes the command in its circuit if set.
+// Execute the command in its circuit if set.
 // If the command's circuit is not configured, the circuit of the CircuitBreaker is used.
 // This is a blocking function.
 func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
@@ -137,19 +143,20 @@ func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
 
 		var err error
 		circuitName := f.circuitName
+		providerName := f.providerName
 		if cb.circuitNameHandler != nil {
 			circuitName = cb.circuitNameHandler(circuitName)
 		}
 
 		// if last command, execute without circuit
-		if i == len(cmd.functors)-1 {
+		if i == len(cmd.functors)-1 || circuitName == "" {
 			res, execErr := f.exec()
 			err = execErr
 			if err == nil {
 				result.res = res
 				result.err = nil
 			}
-			result.addCallStatus(circuitName, err)
+			result.addCallStatus(f.providerName, err)
 		} else {
 			if hystrix.GetCircuitSettings()[circuitName] == nil {
 				hystrix.ConfigureCommand(circuitName, hystrix.CommandConfig{
@@ -168,10 +175,10 @@ func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
 					result.res = res
 					result.err = nil
 				}
-				result.addCallStatus(circuitName, err)
+				result.addCallStatus(f.providerName, err)
 
 				// If the command has been cancelled, we don't count
-				// the error towars breaking the circuit, and then we break
+				// the error towards breaking the circuit, and then we break
 				if cmd.cancel {
 					result = accumulateCommandError(result, circuitName, err)
 					result.cancelled = true
@@ -187,25 +194,24 @@ func (cb *CircuitBreaker) Execute(cmd *Command) CommandResult {
 			break
 		}
 
-		result = accumulateCommandError(result, circuitName, err)
-
-		// Lets abuse every provider with the same amount of MaxConcurrentRequests,
+		result = accumulateCommandError(result, providerName, err)
+		// Let's abuse every provider with the same amount of MaxConcurrentRequests,
 		// keep iterating even in case of ErrMaxConcurrency error
 	}
 	return result
 }
 
-func (c *CircuitBreaker) SetOverrideCircuitNameHandler(f func(string) string) {
-	c.circuitNameHandler = f
+func (cb *CircuitBreaker) SetOverrideCircuitNameHandler(f func(string) string) {
+	cb.circuitNameHandler = f
 }
 
-// Expects a circuit to exist because a new circuit is always closed.
-// Call CircuitExists to check if a circuit exists.
+// IsCircuitOpen Expects a circuit to exist because a new circuit is always closed.
 func IsCircuitOpen(circuitName string) bool {
 	circuit, wasCreated, _ := hystrix.GetCircuit(circuitName)
 	return !wasCreated && circuit.IsOpen()
 }
 
+// CircuitExists checks if a circuit exists.
 func CircuitExists(circuitName string) bool {
 	_, wasCreated, _ := hystrix.GetCircuit(circuitName)
 	return !wasCreated

--- a/healthmanager/aggregator/aggregator.go
+++ b/healthmanager/aggregator/aggregator.go
@@ -44,6 +44,7 @@ func (a *Aggregator) Update(providerStatus rpcstatus.ProviderStatus) {
 	// Update existing provider status or add a new provider.
 	if ps, exists := a.providerStatuses[providerStatus.Name]; exists {
 		ps.Status = providerStatus.Status
+		ps.ChainID = providerStatus.ChainID
 		if providerStatus.Status == rpcstatus.StatusUp {
 			ps.LastSuccessAt = providerStatus.LastSuccessAt
 		} else if providerStatus.Status == rpcstatus.StatusDown {
@@ -53,6 +54,7 @@ func (a *Aggregator) Update(providerStatus rpcstatus.ProviderStatus) {
 	} else {
 		a.providerStatuses[providerStatus.Name] = &rpcstatus.ProviderStatus{
 			Name:          providerStatus.Name,
+			ChainID:       providerStatus.ChainID,
 			LastSuccessAt: providerStatus.LastSuccessAt,
 			LastErrorAt:   providerStatus.LastErrorAt,
 			LastError:     providerStatus.LastError,
@@ -81,6 +83,8 @@ func (a *Aggregator) ComputeAggregatedStatus() rpcstatus.ProviderStatus {
 	var lastError error
 	anyUp := false
 	anyUnknown := false
+	// chainid
+	var chainID uint64 = 0
 
 	for _, ps := range a.providerStatuses {
 		switch ps.Status {
@@ -97,10 +101,12 @@ func (a *Aggregator) ComputeAggregatedStatus() rpcstatus.ProviderStatus {
 				lastError = ps.LastError
 			}
 		}
+		chainID = ps.ChainID
 	}
 
 	aggregatedStatus := rpcstatus.ProviderStatus{
 		Name:          a.name,
+		ChainID:       chainID,
 		LastSuccessAt: lastSuccessAt,
 		LastErrorAt:   lastErrorAt,
 		LastError:     lastError,

--- a/healthmanager/aggregator/aggregator.go
+++ b/healthmanager/aggregator/aggregator.go
@@ -44,7 +44,6 @@ func (a *Aggregator) Update(providerStatus rpcstatus.ProviderStatus) {
 	// Update existing provider status or add a new provider.
 	if ps, exists := a.providerStatuses[providerStatus.Name]; exists {
 		ps.Status = providerStatus.Status
-		ps.ChainID = providerStatus.ChainID
 		if providerStatus.Status == rpcstatus.StatusUp {
 			ps.LastSuccessAt = providerStatus.LastSuccessAt
 		} else if providerStatus.Status == rpcstatus.StatusDown {
@@ -54,7 +53,6 @@ func (a *Aggregator) Update(providerStatus rpcstatus.ProviderStatus) {
 	} else {
 		a.providerStatuses[providerStatus.Name] = &rpcstatus.ProviderStatus{
 			Name:          providerStatus.Name,
-			ChainID:       providerStatus.ChainID,
 			LastSuccessAt: providerStatus.LastSuccessAt,
 			LastErrorAt:   providerStatus.LastErrorAt,
 			LastError:     providerStatus.LastError,
@@ -83,8 +81,6 @@ func (a *Aggregator) ComputeAggregatedStatus() rpcstatus.ProviderStatus {
 	var lastError error
 	anyUp := false
 	anyUnknown := false
-	// chainid
-	var chainID uint64 = 0
 
 	for _, ps := range a.providerStatuses {
 		switch ps.Status {
@@ -101,12 +97,10 @@ func (a *Aggregator) ComputeAggregatedStatus() rpcstatus.ProviderStatus {
 				lastError = ps.LastError
 			}
 		}
-		chainID = ps.ChainID
 	}
 
 	aggregatedStatus := rpcstatus.ProviderStatus{
 		Name:          a.name,
-		ChainID:       chainID,
 		LastSuccessAt: lastSuccessAt,
 		LastErrorAt:   lastErrorAt,
 		LastError:     lastError,

--- a/healthmanager/blockchain_health_manager.go
+++ b/healthmanager/blockchain_health_manager.go
@@ -27,8 +27,8 @@ type BlockchainHealthManager struct {
 	aggregator          *aggregator.Aggregator
 	subscriptionManager *SubscriptionManager
 
-	providers   map[uint64]*ProvidersHealthManager
-	cancelFuncs map[uint64]context.CancelFunc // Map chainID to cancel functions
+	providers   map[uint64]*ProvidersHealthManager // ChainID to its providers health manager
+	cancelFuncs map[uint64]context.CancelFunc      // Map chainID to cancel functions
 	lastStatus  *BlockchainStatus
 	wg          sync.WaitGroup
 }

--- a/healthmanager/rpcstatus/provider_status.go
+++ b/healthmanager/rpcstatus/provider_status.go
@@ -25,13 +25,6 @@ type ProviderStatus struct {
 	Status        StatusType `json:"status"`
 }
 
-// ProviderCallStatus represents the result of an arbitrary provider call.
-type ProviderCallStatus struct {
-	Name      string
-	Timestamp time.Time
-	Err       error
-}
-
 // RpcProviderCallStatus represents the result of an RPC provider call.
 type RpcProviderCallStatus struct {
 	Name      string
@@ -50,25 +43,6 @@ func NewRpcProviderStatus(res RpcProviderCallStatus) ProviderStatus {
 
 	// Determine if the error is critical
 	if res.Err == nil || provider_errors.IsNonCriticalRpcError(res.Err) || provider_errors.IsNonCriticalProviderError(res.Err) {
-		status.LastSuccessAt = res.Timestamp
-		status.Status = StatusUp
-	} else {
-		status.LastErrorAt = res.Timestamp
-		status.LastError = res.Err
-		status.Status = StatusDown
-	}
-
-	return status
-}
-
-// NewProviderStatus processes ProviderCallStatus and returns a new ProviderStatus.
-func NewProviderStatus(res ProviderCallStatus) ProviderStatus {
-	status := ProviderStatus{
-		Name: res.Name,
-	}
-
-	// Determine if the error is critical
-	if res.Err == nil || provider_errors.IsNonCriticalProviderError(res.Err) {
 		status.LastSuccessAt = res.Timestamp
 		status.Status = StatusUp
 	} else {

--- a/healthmanager/rpcstatus/provider_status.go
+++ b/healthmanager/rpcstatus/provider_status.go
@@ -37,6 +37,7 @@ type RpcProviderCallStatus struct {
 	Name      string
 	ChainID   uint64
 	Timestamp time.Time
+	Method    string
 	Err       error
 }
 

--- a/healthmanager/rpcstatus/provider_status.go
+++ b/healthmanager/rpcstatus/provider_status.go
@@ -18,6 +18,7 @@ const (
 // ProviderStatus holds the status information for a single provider.
 type ProviderStatus struct {
 	Name          string     `json:"name"`
+	ChainID       uint64     `json:"chain_id"`
 	LastSuccessAt time.Time  `json:"last_success_at"`
 	LastErrorAt   time.Time  `json:"last_error_at"`
 	LastError     error      `json:"last_error"`
@@ -34,6 +35,7 @@ type ProviderCallStatus struct {
 // RpcProviderCallStatus represents the result of an RPC provider call.
 type RpcProviderCallStatus struct {
 	Name      string
+	ChainID   uint64
 	Timestamp time.Time
 	Err       error
 }
@@ -41,7 +43,8 @@ type RpcProviderCallStatus struct {
 // NewRpcProviderStatus processes RpcProviderCallStatus and returns a new ProviderStatus.
 func NewRpcProviderStatus(res RpcProviderCallStatus) ProviderStatus {
 	status := ProviderStatus{
-		Name: res.Name,
+		Name:    res.Name,
+		ChainID: res.ChainID,
 	}
 
 	// Determine if the error is critical

--- a/healthmanager/rpcstatus/provider_status.go
+++ b/healthmanager/rpcstatus/provider_status.go
@@ -20,7 +20,6 @@ const (
 // ProviderStatus holds the status information for a single provider.
 type ProviderStatus struct {
 	Name          string     `json:"name"`
-	ChainID       uint64     `json:"chain_id"`
 	LastSuccessAt time.Time  `json:"last_success_at"`
 	LastErrorAt   time.Time  `json:"last_error_at"`
 	LastError     error      `json:"-"` // ignore this field during standard marshaling
@@ -49,7 +48,6 @@ func (ps ProviderStatus) MarshalJSON() ([]byte, error) {
 // RpcProviderCallStatus represents the result of an RPC provider call.
 type RpcProviderCallStatus struct {
 	Name      string
-	ChainID   uint64
 	Timestamp time.Time
 	Method    string
 	Err       error
@@ -58,8 +56,7 @@ type RpcProviderCallStatus struct {
 // NewRpcProviderStatus processes RpcProviderCallStatus and returns a new ProviderStatus.
 func NewRpcProviderStatus(res RpcProviderCallStatus) ProviderStatus {
 	status := ProviderStatus{
-		Name:    res.Name,
-		ChainID: res.ChainID,
+		Name: res.Name,
 	}
 
 	// Determine if the error is critical

--- a/healthmanager/rpcstatus/provider_status.go
+++ b/healthmanager/rpcstatus/provider_status.go
@@ -2,6 +2,7 @@ package rpcstatus
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/status-im/status-go/healthmanager/provider_errors"
@@ -67,7 +68,7 @@ func NewRpcProviderStatus(res RpcProviderCallStatus) ProviderStatus {
 		status.Status = StatusUp
 	} else {
 		status.LastErrorAt = res.Timestamp
-		status.LastError = res.Err
+		status.LastError = fmt.Errorf("method: %s, error: %w", res.Method, res.Err)
 		status.Status = StatusDown
 	}
 

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -1,6 +1,8 @@
 package params
 
 import (
+	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -47,6 +49,20 @@ func (p RpcProvider) GetFullURL() string {
 		return strings.TrimRight(p.URL, "/") + "/" + p.AuthToken
 	}
 	return p.URL
+}
+
+// GetHost returns the host from the provider's URL
+func (p RpcProvider) GetHost() string {
+	u, err := url.Parse(p.URL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+// NameAndChain returns a string in the format 'Name:ChainID'
+func (p RpcProvider) GetNameAndChainID() string {
+	return p.Name + ":" + strconv.FormatUint(p.ChainID, 10)
 }
 
 type TokenOverride struct {

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -2,7 +2,6 @@ package params
 
 import (
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -58,11 +57,6 @@ func (p RpcProvider) GetHost() string {
 		return ""
 	}
 	return u.Host
-}
-
-// NameAndChain returns a string in the format 'Name:ChainID'
-func (p RpcProvider) GetNameAndChainID() string {
-	return p.Name + ":" + strconv.FormatUint(p.ChainID, 10)
 }
 
 type TokenOverride struct {

--- a/params/network_config_test.go
+++ b/params/network_config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/status-im/status-go/params"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/params/network_config_test.go
+++ b/params/network_config_test.go
@@ -13,12 +13,6 @@ func TestRpcProvider_GetHost(t *testing.T) {
 	assert.Equal(t, expectedHost, provider.GetHost())
 }
 
-func TestRpcProvider_NameAndChainID(t *testing.T) {
-	provider := params.RpcProvider{Name: "TestProvider", ChainID: 12345}
-	expectedNameAndChain := "TestProvider:12345"
-	assert.Equal(t, expectedNameAndChain, provider.GetNameAndChainID())
-}
-
 func TestRpcProvider_GetFullURL(t *testing.T) {
 	provider := params.RpcProvider{URL: "https://api.example.com", AuthType: params.TokenAuth, AuthToken: "mytoken"}
 	expectedFullURL := "https://api.example.com/mytoken"

--- a/params/network_config_test.go
+++ b/params/network_config_test.go
@@ -1,0 +1,30 @@
+package params_test
+
+import (
+	"testing"
+
+	"github.com/status-im/status-go/params"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRpcProvider_GetHost(t *testing.T) {
+	provider := params.RpcProvider{URL: "https://api.example.com/path"}
+	expectedHost := "api.example.com"
+	assert.Equal(t, expectedHost, provider.GetHost())
+}
+
+func TestRpcProvider_NameAndChainID(t *testing.T) {
+	provider := params.RpcProvider{Name: "TestProvider", ChainID: 12345}
+	expectedNameAndChain := "TestProvider:12345"
+	assert.Equal(t, expectedNameAndChain, provider.GetNameAndChainID())
+}
+
+func TestRpcProvider_GetFullURL(t *testing.T) {
+	provider := params.RpcProvider{URL: "https://api.example.com", AuthType: params.TokenAuth, AuthToken: "mytoken"}
+	expectedFullURL := "https://api.example.com/mytoken"
+	assert.Equal(t, expectedFullURL, provider.GetFullURL())
+
+	provider.AuthType = params.NoAuth
+	expectedFullURL = "https://api.example.com"
+	assert.Equal(t, expectedFullURL, provider.GetFullURL())
+}

--- a/rpc/chain/blockchain_health_test.go
+++ b/rpc/chain/blockchain_health_test.go
@@ -50,8 +50,12 @@ func (s *BlockchainHealthSuite) setupClients(chainIDs []uint64) {
 
 	for _, chainID := range chainIDs {
 		mockEthClient := mockEthclient.NewMockRPSLimitedEthClientInterface(s.mockCtrl)
-		mockEthClient.EXPECT().GetName().AnyTimes().Return(fmt.Sprintf("test_client_chain_%d", chainID))
+		mockEthClient.EXPECT().GetProviderName().AnyTimes().Return(fmt.Sprintf("test_client_chain_%d_provider", chainID))
+		mockEthClient.EXPECT().GetCircuitName().AnyTimes().Return(fmt.Sprintf("test_client_chain_%d_circuit", chainID))
 		mockEthClient.EXPECT().GetLimiter().AnyTimes().Return(nil)
+		mockEthClient.EXPECT().ExecuteWithRPSLimit(gomock.Any()).DoAndReturn(func(f func(client ethclient.EthClientInterface) (interface{}, error)) (interface{}, error) {
+			return f(mockEthClient)
+		}).AnyTimes()
 
 		phm := healthmanager.NewProvidersHealthManager(chainID)
 		client := NewClient([]ethclient.RPSLimitedEthClientInterface{mockEthClient}, chainID, phm)

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -215,7 +215,7 @@ func (c *ClientWithFallback) makeCall(ctx context.Context, ethClients []ethclien
 
 	result := c.circuitbreaker.Execute(cmd)
 	if c.providersHealthManager != nil {
-		rpcCallStatuses := convertFunctorCallStatuses(result.FunctorCallStatuses())
+		rpcCallStatuses := convertFunctorCallStatuses(result.FunctorCallStatuses(), c.ChainID)
 		c.providersHealthManager.Update(ctx, rpcCallStatuses)
 	}
 	if result.Error() != nil {
@@ -823,9 +823,13 @@ func (c *ClientWithFallback) SetCircuitBreaker(cb *circuitbreaker.CircuitBreaker
 	c.circuitbreaker = cb
 }
 
-func convertFunctorCallStatuses(statuses []circuitbreaker.FunctorCallStatus) (result []rpcstatus.RpcProviderCallStatus) {
+func convertFunctorCallStatuses(statuses []circuitbreaker.FunctorCallStatus, chainID uint64) (result []rpcstatus.RpcProviderCallStatus) {
 	for _, f := range statuses {
-		result = append(result, rpcstatus.RpcProviderCallStatus{Name: f.Name, Timestamp: f.Timestamp, Err: f.Err})
+		result = append(result, rpcstatus.RpcProviderCallStatus{
+			Name:      f.Name,
+			ChainID:   chainID,
+			Timestamp: f.Timestamp,
+			Err:       f.Err})
 	}
 	return
 }

--- a/rpc/chain/client_test.go
+++ b/rpc/chain/client_test.go
@@ -25,8 +25,12 @@ func setupClientTest(t *testing.T) (*ClientWithFallback, []*mock_ethclient.MockR
 
 	for i := 0; i < 3; i++ {
 		ethCl := mock_ethclient.NewMockRPSLimitedEthClientInterface(mockCtrl)
-		ethCl.EXPECT().GetName().AnyTimes().Return("test" + strconv.Itoa(i))
+		ethCl.EXPECT().GetProviderName().AnyTimes().Return("test" + strconv.Itoa(i) + "_provider")
+		ethCl.EXPECT().GetCircuitName().AnyTimes().Return("test" + strconv.Itoa(i) + "_circuit")
 		ethCl.EXPECT().GetLimiter().AnyTimes().Return(nil)
+		ethCl.EXPECT().ExecuteWithRPSLimit(gomock.Any()).DoAndReturn(func(f func(client ethclient.EthClientInterface) (interface{}, error)) (interface{}, error) {
+			return f(ethCl)
+		}).AnyTimes()
 
 		mockEthClients = append(mockEthClients, ethCl)
 		ethClients = append(ethClients, ethCl)

--- a/rpc/chain/client_utils.go
+++ b/rpc/chain/client_utils.go
@@ -1,0 +1,46 @@
+package chain
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/status-im/status-go/params"
+)
+
+// CreateEthClientFromProvider creates an Ethereum RPC client from the given RpcProvider.
+func CreateEthClientFromProvider(provider params.RpcProvider, rpcUserAgentName string) (*rpc.Client, error) {
+	if !provider.Enabled {
+		return nil, nil
+	}
+
+	// Create RPC client options
+	var opts []rpc.ClientOption
+	headers := http.Header{}
+	headers.Set("User-Agent", rpcUserAgentName)
+
+	// Set up authentication if needed
+	switch provider.AuthType {
+	case params.BasicAuth:
+		authEncoded := base64.StdEncoding.EncodeToString([]byte(provider.AuthLogin + ":" + provider.AuthPassword))
+		headers.Set("Authorization", "Basic "+authEncoded)
+	case params.TokenAuth:
+		provider.URL = provider.URL + provider.AuthToken
+	case params.NoAuth:
+		// no-op
+	default:
+		return nil, fmt.Errorf("unknown auth type: %s", provider.AuthType)
+	}
+
+	opts = append(opts, rpc.WithHeaders(headers))
+
+	// Dial the RPC client
+	rpcClient, err := rpc.DialOptions(context.Background(), provider.URL, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("dial server failed for provider %s: %w", provider.Name, err)
+	}
+
+	return rpcClient, nil
+}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -312,7 +312,7 @@ func (c *Client) getEthClients(network *params.Network) []ethclient.RPSLimitedEt
 		}
 
 		// Create ethclient with RPS limiter
-		ethClient := ethclient.NewRPSLimitedEthClient(rpcClient, rpcLimiter, limiterKey)
+		ethClient := ethclient.NewRPSLimitedEthClient(rpcClient, rpcLimiter, limiterKey, provider.Name)
 		ethClients = append(ethClients, ethClient)
 	}
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -302,6 +302,7 @@ func (c *Client) getEthClients(network *params.Network) []ethclient.RPSLimitedEt
 			continue
 		}
 		if rpcClient == nil {
+			// Provider is disabled
 			continue
 		}
 
@@ -311,7 +312,7 @@ func (c *Client) getEthClients(network *params.Network) []ethclient.RPSLimitedEt
 			continue
 		}
 
-		// Create ethclient with RPS limiter
+		// Create ethclient with RPS limiter. If limiter is not enabled, it will be nil
 		ethClient := ethclient.NewRPSLimitedEthClient(rpcClient, rpcLimiter, limiterKey, provider.Name)
 		ethClients = append(ethClients, ethClient)
 	}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"reflect"
 	"sync"
 	"time"
@@ -275,13 +274,8 @@ func (c *Client) getProviderRPCLimiter(provider params.RpcProvider) (*rpclimiter
 	if !provider.EnableRPSLimiter {
 		return nil, "", nil
 	}
-
-	// Generate a unique key for the provider based on its URL or host
-	limiterKey := provider.URL
-	parsedURL, err := url.Parse(provider.URL)
-	if err == nil {
-		limiterKey = parsedURL.Host
-	}
+	// Generate a unique key for the provider based on its host
+	limiterKey := provider.GetHost()
 
 	// Check if the limiter already exists
 	if limiter, ok := c.limiterPerProvider[limiterKey]; ok {

--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -241,8 +241,7 @@ func (o *Manager) FetchAllAssetsByOwnerAndContractAddress(ctx context.Context, c
 						zap.Error(err))
 				}
 				return []interface{}{assetContainer}, err
-			}, getCircuitName(provider, chainID),
-		)
+			}, getCircuitName(provider, chainID), provider.ID())
 		cmd.Add(f)
 	}
 
@@ -292,8 +291,7 @@ func (o *Manager) FetchAllAssetsByOwner(ctx context.Context, chainID walletCommo
 					)
 				}
 				return []interface{}{assetContainer}, err
-			}, getCircuitName(provider, chainID),
-		)
+			}, getCircuitName(provider, chainID), provider.ID())
 		cmd.Add(f)
 	}
 
@@ -501,7 +499,7 @@ func (o *Manager) fetchMissingAssetsForChainByCollectibleUniqueID(ctx context.Co
 			}
 
 			return []any{fetchedAssets}, err
-		}, getCircuitName(provider, chainID)))
+		}, getCircuitName(provider, chainID), provider.ID()))
 	}
 
 	if cmd.IsEmpty() {
@@ -543,7 +541,7 @@ func (o *Manager) FetchCollectionsDataByContractID(ctx context.Context, ids []th
 				cmd.Add(circuitbreaker.NewFunctor(func() ([]any, error) {
 					fetchedCollections, err := provider.FetchCollectionsDataByContractID(ctx, idsToFetch)
 					return []any{fetchedCollections}, err
-				}, getCircuitName(provider, chainID)))
+				}, getCircuitName(provider, chainID), provider.ID()))
 			}
 
 			if cmd.IsEmpty() {
@@ -607,7 +605,7 @@ func (o *Manager) FetchCollectibleOwnersByContractAddress(ctx context.Context, c
 				)
 			}
 			return []any{res}, err
-		}, getCircuitName(provider, chainID)))
+		}, getCircuitName(provider, chainID), provider.ID()))
 	}
 
 	if cmd.IsEmpty() {
@@ -1183,7 +1181,7 @@ func (o *Manager) fetchSocialsForCollection(ctx context.Context, contractID thir
 				)
 			}
 			return []interface{}{socials}, err
-		}, getCircuitName(provider, contractID.ChainID)))
+		}, getCircuitName(provider, contractID.ChainID), provider.ID()))
 	}
 
 	if cmd.IsEmpty() {

--- a/services/wallet/market/market.go
+++ b/services/wallet/market/market.go
@@ -96,7 +96,7 @@ func (pm *Manager) makeCall(providers []thirdparty.MarketDataProvider, f func(pr
 		cmd.Add(circuitbreaker.NewFunctor(func() ([]interface{}, error) {
 			result, err := f(provider)
 			return []interface{}{result}, err
-		}, provider.ID()))
+		}, provider.ID(), provider.ID()))
 	}
 
 	result := pm.circuitbreaker.Execute(cmd)

--- a/services/wallet/market/market.go
+++ b/services/wallet/market/market.go
@@ -93,10 +93,12 @@ func (pm *Manager) makeCall(providers []thirdparty.MarketDataProvider, f func(pr
 	cmd := circuitbreaker.NewCommand(context.Background(), nil)
 	for _, provider := range providers {
 		provider := provider
+		// FIXME: we might want a different circuitName. See other uses of NewFunctor
+		circuitName := provider.ID()
 		cmd.Add(circuitbreaker.NewFunctor(func() ([]interface{}, error) {
 			result, err := f(provider)
 			return []interface{}{result}, err
-		}, provider.ID(), provider.ID()))
+		}, circuitName, provider.ID()))
 	}
 
 	result := pm.circuitbreaker.Execute(cmd)

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -75,7 +75,7 @@ func (s *TransactorSuite) SetupTest() {
 	rpcClient.UpstreamChainID = chainID
 
 	ethClients := []ethclient.RPSLimitedEthClientInterface{
-		ethclient.NewRPSLimitedEthClient(s.client, rpclimiter.NewRPCRpsLimiter(), "local-1-chain-id-1"),
+		ethclient.NewRPSLimitedEthClient(s.client, rpclimiter.NewRPCRpsLimiter(), "local-1-chain-id-1-circuit", "local-1-chain-id-1-provider"),
 	}
 	localClient := chain.NewClient(ethClients, chainID, nil)
 	rpcClient.SetClient(chainID, localClient)


### PR DESCRIPTION
While debugging https://github.com/status-im/status-mobile/issues/22155 I needed more information in the logs.

So this PR addresses 2 issues:
* No last error in geth.logs (needed for debugging RPC provider issues)
* No reliable way to map ProviderStatus to an RpcProvider from networks (needed by @dlipicar)

Changes:
* Add rpc method name to error message (logs and health manager status)
* Add chainID to ProviderStatus
* Fix health-manager last error messages in geth.log
* Removed unused types
* Use ProviderName as key in health-manager (since circuit name doesn't map directly to a provider and could be empty in some cases)


Closes #6266
