### PR TITLE
fix_: test timed out after 5m0s

### DIFF
--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -491,8 +491,11 @@ func (w *Waku) dnsDiscover(ctx context.Context, enrtreeAddress string, apply fnA
 
 func (w *Waku) retryDnsDiscoveryWithBackoff(ctx context.Context, addr string, successChan chan<- struct{}) {
 	retries := 0
+	applyFn := func(_ dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {
+		wg.Done()
+	}
 	for {
-		err := w.dnsDiscover(ctx, addr, func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {}, false)
+		err := w.dnsDiscover(ctx, addr, applyFn, false)
 		if err == nil {
 			select {
 			case successChan <- struct{}{}:


### PR DESCRIPTION
Found [issue](https://github.com/status-im/status-go/issues/6372) while trying to fix timed out issue.

Pls see [message1](https://discord.com/channels/1210237582470807632/1344034516372819998/1344566122883710996) and [message2](https://discord.com/channels/1210237582470807632/1344034516372819998/1344582078557061190) for context.

Relate [goroutines](https://gist.github.com/qfrank/37a4204f5d1f605541ba70d841a7dc6d).

~~I think we should flag these tests as flaky first as they're blocking PRs from merging. I'll draft a PR to address parts of the issues of the tests later.~~

**EDIT**: Unfortunately, marking tests as flaky in this way is not feasible because too many tests trigger "panic: test timed out after 5m0s." I suspect this is due to an issue with "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im," which causes [DNS errors](https://discord.com/channels/1210237582470807632/13440345163728199981344582078557061190) during resolution. The code related to discV5 has not handled this situation well, leading to deadlocks. We need to fix the code related to discV5 or fix `enrtree:...`.

this should also fix [issue](https://github.com/status-im/status-go/issues/6357)

The stuck can be reproduced by running `TestSyncDeviceSuite` multi times locally.

**status**: ready.