### PR TITLE
ci_: prevent code coverage to drop dramatically

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,11 +19,11 @@ coverage:
     project:
       unit-tests:
         target: auto
-        threshold: 1
+        threshold: 10%
         flags:
           - unit
       functional-tests:
-        threshold: 0.1
+        threshold: 10%
         target: auto
         flags:
           - functional


### PR DESCRIPTION
# Description

Set project (total) coverage thresholds to 10%.
This means that even if the total coverage drops by 10%, the PR check will report success and not block the merge.

But, if the drop is >10%, then the PR merge will be blocked.
After merging this PR, I intend to make the project (total) coverage checks **required**.

E.g. it looks like this with the revert of https://github.com/status-im/status-go/pull/6368:
<img width="545" alt="image" src="https://github.com/user-attachments/assets/cba28c7f-ef36-4f0e-8fc2-739cb1229425" />


# Rationale

The intention of this check is to prevent full loss of coverage, like we had to fix in https://github.com/status-im/status-go/pull/6368.

# PR-level Requirements change

> [!CAUTION]
> After merging this PR I will make these PR-level coverage checks **REQUIRED**:
> - `project/functional-tests`
> - `project/unit-tests`