### PR TITLE
chore(wallet)_: swap processor update

### DIFF
--- a/contracts/hop/address.go
+++ b/contracts/hop/address.go
@@ -398,3 +398,12 @@ func GetContractAddress(chainID uint64, symbol string) (addr common.Address, con
 	}
 	return
 }
+
+func GetSymbolsAvailableOnChain(chainID uint64) (symbols []string) {
+	for symbol, chainchainID := range hopBridgeContractAddresses {
+		if _, ok := chainchainID[chainID]; ok {
+			symbols = append(symbols, symbol)
+		}
+	}
+	return
+}

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -214,6 +214,11 @@ func (api *API) GetTokenList(ctx context.Context) (*token.ListWrapper, error) {
 	return rst, nil
 }
 
+func (api *API) GetTokensAvailableForBridgeOnChain(ctx context.Context, chainID uint64) []*token.Token {
+	logutils.ZapLogger().Debug("call to get tokens available for bridge on chain")
+	return api.s.router.GetTokensAvailableForBridgeOnChain(chainID)
+}
+
 // @deprecated
 func (api *API) GetTokens(ctx context.Context, chainID uint64) ([]*token.Token, error) {
 	logutils.ZapLogger().Debug("call to get tokens")

--- a/services/wallet/router/router_helper.go
+++ b/services/wallet/router/router_helper.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/status-im/status-go/contracts"
 	gaspriceproxy "github.com/status-im/status-go/contracts/gas-price-proxy"
+	"github.com/status-im/status-go/contracts/hop"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc/chain"
@@ -408,4 +409,18 @@ func fetchPrices(sendType sendtype.SendType, marketManager *market.Manager, toke
 		}
 	}
 	return prices, nil
+}
+
+func (r *Router) GetTokensAvailableForBridgeOnChain(chainID uint64) []*token.Token {
+	symbols := hop.GetSymbolsAvailableOnChain(chainID)
+
+	tokens := make([]*token.Token, 0)
+	for _, symbol := range symbols {
+		t, _ := r.tokenManager.LookupToken(&chainID, symbol)
+		if t == nil {
+			continue
+		}
+		tokens = append(tokens, t)
+	}
+	return tokens
 }


### PR DESCRIPTION
Based on what's said here https://developers.paraswap.network/api/get-tokens-list
```
ParaSwap's API is not limited to the tokens that are listed on the tokens endpoint. Tokens endpoint is merely a list of tokens curated by ParaSwap. This list is not actively maintained and will soon be deprecated. To use a more up-to-date list of tokens it is suggested to use token-lists.
```

We should not take tokens announced in that list as the only tokens available for swap, but try with any token the Status app supports and the Router will throw an error if swapping is not possible.

----

This endpoint returns tokens available for the bridge for the selected chain.
Can be used on both from and to side.