### PR TITLE
test_: Tests for wakuext messages 3

### DIFF
--- a/tests-functional/clients/rpc.py
+++ b/tests-functional/clients/rpc.py
@@ -21,7 +21,10 @@ class RpcClient:
         except KeyError:
             raise AssertionError(f"Key '{key}' not found in the JSON response: {response.content}")
 
-    def verify_is_valid_json_rpc_response(self, response, _id=None):
+    def verify_is_valid_json_rpc_response(self, response, _id=None, skip_validation=False):
+        if skip_validation:
+            return response
+
         assert response.status_code == 200, f"Got response {response.content}, status code {response.status_code}"
         assert response.content
         self._check_decode_and_key_errors_in_response(response, "result")
@@ -60,9 +63,9 @@ class RpcClient:
             logging.info(f"Got response: {response.content}")
         return response
 
-    def rpc_valid_request(self, method, params=None, _id=None, url=None):
+    def rpc_valid_request(self, method, params=None, _id=None, url=None, skip_validation=False):
         response = self.rpc_request(method, params, _id, url)
-        self.verify_is_valid_json_rpc_response(response, _id)
+        self.verify_is_valid_json_rpc_response(response, _id, skip_validation=skip_validation)
         return response
 
     def verify_json_schema(self, response, method):

--- a/tests-functional/clients/services/service.py
+++ b/tests-functional/clients/services/service.py
@@ -7,6 +7,6 @@ class Service:
         self.rpc_client = client
         self.name = name
 
-    def rpc_request(self, method: str, params=None):
+    def rpc_request(self, method: str, params=None, skip_validation=False):
         full_method_name = f"{self.name}_{method}"
-        return self.rpc_client.rpc_valid_request(full_method_name, params)
+        return self.rpc_client.rpc_valid_request(full_method_name, params, skip_validation=skip_validation)

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -127,6 +127,11 @@ class WakuextService(Service):
         response = self.rpc_request("statusUpdates", params)
         return response.json()
 
+    def edit_message(self, message_id: str, new_text: str):
+        params = [{"id": message_id, "text": new_text}]
+        response = self.rpc_request("editMessage", params)
+        return response.json()
+
     def delete_message(self, message_id: str):
         params = [message_id]
         response = self.rpc_request("deleteMessage", params)

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -126,3 +126,13 @@ class WakuextService(Service):
         params = []
         response = self.rpc_request("statusUpdates", params)
         return response.json()
+
+    def delete_message(self, message_id: str):
+        params = [message_id]
+        response = self.rpc_request("deleteMessage", params)
+        return response.json()
+
+    def delete_messages_by_chat_id(self, chat_id: str):
+        params = [chat_id]
+        response = self.rpc_request("deleteMessagesByChatID", params)
+        return response.json()

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -141,3 +141,13 @@ class WakuextService(Service):
         params = [chat_id]
         response = self.rpc_request("deleteMessagesByChatID", params)
         return response.json()
+
+    def mark_message_as_unread(self, chat_id: str, message_id: str):
+        params = [chat_id, message_id]
+        response = self.rpc_request("markMessageAsUnread", params)
+        return response.json()
+
+    def first_unseen_message_id(self, chat_id: str):
+        params = [chat_id]
+        response = self.rpc_request("firstUnseenMessageID", params)
+        return response.json()

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -142,6 +142,11 @@ class WakuextService(Service):
         response = self.rpc_request("deleteMessagesByChatID", params)
         return response.json()
 
+    def delete_message_and_send(self, message_id: str):
+        params = [message_id]
+        response = self.rpc_request("deleteMessageAndSend", params)
+        return response.json()
+
     def mark_message_as_unread(self, chat_id: str, message_id: str):
         params = [chat_id, message_id]
         response = self.rpc_request("markMessageAsUnread", params)

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -147,6 +147,11 @@ class WakuextService(Service):
         response = self.rpc_request("deleteMessageAndSend", params)
         return response.json()
 
+    def delete_message_for_me_and_sync(self, localChatID: str, message_id: str):
+        params = [localChatID, message_id]
+        response = self.rpc_request("deleteMessageForMeAndSync", params)
+        return response.json()
+
     def mark_message_as_unread(self, chat_id: str, message_id: str):
         params = [chat_id, message_id]
         response = self.rpc_request("markMessageAsUnread", params)

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -97,9 +97,9 @@ class WakuextService(Service):
         response = self.rpc_request("chatMessages", params)
         return response.json()
 
-    def message_by_message_id(self, message_id: str):
+    def message_by_message_id(self, message_id: str, skip_validation=False):
         params = [message_id]
-        response = self.rpc_request("messageByMessageID", params)
+        response = self.rpc_request("messageByMessageID", params, skip_validation=skip_validation)
         return response.json()
 
     def all_messages_from_chat_which_match_term(self, chat_id: str, searchTerm: str, caseSensitive: bool):

--- a/tests-functional/schemas/wakuext_deleteMessage
+++ b/tests-functional/schemas/wakuext_deleteMessage
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "type": "null"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/schemas/wakuext_deleteMessageAndSend
+++ b/tests-functional/schemas/wakuext_deleteMessageAndSend
@@ -1,0 +1,299 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "properties": {
+                "chats": {
+                    "items": {
+                        "properties": {
+                            "ReadMessagesAtClockValue": {
+                                "type": "integer"
+                            },
+                            "active": {
+                                "type": "boolean"
+                            },
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatType": {
+                                "type": "integer"
+                            },
+                            "color": {
+                                "type": "string"
+                            },
+                            "deletedAtClockValue": {
+                                "type": "integer"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "emoji": {
+                                "type": "string"
+                            },
+                            "highlight": {
+                                "type": "boolean"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "joined": {
+                                "type": "integer"
+                            },
+                            "lastClockValue": {
+                                "type": "integer"
+                            },
+                            "lastMessage": {
+                                "properties": {
+                                    "alias": {
+                                        "type": "string"
+                                    },
+                                    "chatId": {
+                                        "type": "string"
+                                    },
+                                    "clock": {
+                                        "type": "integer"
+                                    },
+                                    "compressedKey": {
+                                        "type": "string"
+                                    },
+                                    "contentType": {
+                                        "type": "integer"
+                                    },
+                                    "deleted": {
+                                        "type": "boolean"
+                                    },
+                                    "displayName": {
+                                        "type": "string"
+                                    },
+                                    "emojiHash": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "ensName": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "gapParameters": {
+                                        "type": "object"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "identicon": {
+                                        "type": "string"
+                                    },
+                                    "lineCount": {
+                                        "type": "integer"
+                                    },
+                                    "localChatId": {
+                                        "type": "string"
+                                    },
+                                    "messageType": {
+                                        "type": "integer"
+                                    },
+                                    "outgoingStatus": {
+                                        "type": "string"
+                                    },
+                                    "parsedText": {
+                                        "items": {
+                                            "properties": {
+                                                "children": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "literal": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "literal"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "children",
+                                                "type"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "quotedMessage": {
+                                        "type": "null"
+                                    },
+                                    "replace": {
+                                        "type": "string"
+                                    },
+                                    "responseTo": {
+                                        "type": "string"
+                                    },
+                                    "rtl": {
+                                        "type": "boolean"
+                                    },
+                                    "seen": {
+                                        "type": "boolean"
+                                    },
+                                    "text": {
+                                        "type": "string"
+                                    },
+                                    "timestamp": {
+                                        "type": "integer"
+                                    },
+                                    "whisperTimestamp": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "alias",
+                                    "chatId",
+                                    "clock",
+                                    "compressedKey",
+                                    "contentType",
+                                    "deleted",
+                                    "displayName",
+                                    "emojiHash",
+                                    "ensName",
+                                    "from",
+                                    "gapParameters",
+                                    "id",
+                                    "identicon",
+                                    "lineCount",
+                                    "localChatId",
+                                    "messageType",
+                                    "outgoingStatus",
+                                    "parsedText",
+                                    "quotedMessage",
+                                    "replace",
+                                    "responseTo",
+                                    "rtl",
+                                    "seen",
+                                    "text",
+                                    "timestamp",
+                                    "whisperTimestamp"
+                                ],
+                                "type": "object"
+                            },
+                            "members": {
+                                "type": "null"
+                            },
+                            "membershipUpdateEvents": {
+                                "type": "null"
+                            },
+                            "muteTill": {
+                                "type": "string"
+                            },
+                            "muted": {
+                                "type": "boolean"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "syncedFrom": {
+                                "type": "integer"
+                            },
+                            "syncedTo": {
+                                "type": "integer"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "unviewedMentionsCount": {
+                                "type": "integer"
+                            },
+                            "unviewedMessagesCount": {
+                                "type": "integer"
+                            },
+                            "viewersCanPostReactions": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "ReadMessagesAtClockValue",
+                            "active",
+                            "alias",
+                            "chatType",
+                            "color",
+                            "deletedAtClockValue",
+                            "description",
+                            "emoji",
+                            "highlight",
+                            "id",
+                            "identicon",
+                            "joined",
+                            "lastClockValue",
+                            "lastMessage",
+                            "members",
+                            "membershipUpdateEvents",
+                            "muteTill",
+                            "muted",
+                            "name",
+                            "syncedFrom",
+                            "syncedTo",
+                            "timestamp",
+                            "unviewedMentionsCount",
+                            "unviewedMessagesCount",
+                            "viewersCanPostReactions"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "discordOldestMessageTimestamp": {
+                    "type": "integer"
+                },
+                "notifications": {
+                    "type": "null"
+                },
+                "removedMessages": {
+                    "items": {
+                        "properties": {
+                            "chatId": {
+                                "type": "string"
+                            },
+                            "messageId": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "chatId",
+                            "messageId"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "chats",
+                "discordOldestMessageTimestamp",
+                "notifications",
+                "removedMessages"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/schemas/wakuext_deleteMessageForMeAndSync
+++ b/tests-functional/schemas/wakuext_deleteMessageForMeAndSync
@@ -1,0 +1,424 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "properties": {
+                "chats": {
+                    "items": {
+                        "properties": {
+                            "ReadMessagesAtClockValue": {
+                                "type": "integer"
+                            },
+                            "active": {
+                                "type": "boolean"
+                            },
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatType": {
+                                "type": "integer"
+                            },
+                            "color": {
+                                "type": "string"
+                            },
+                            "deletedAtClockValue": {
+                                "type": "integer"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "emoji": {
+                                "type": "string"
+                            },
+                            "highlight": {
+                                "type": "boolean"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "joined": {
+                                "type": "integer"
+                            },
+                            "lastClockValue": {
+                                "type": "integer"
+                            },
+                            "lastMessage": {
+                                "properties": {
+                                    "alias": {
+                                        "type": "string"
+                                    },
+                                    "chatId": {
+                                        "type": "string"
+                                    },
+                                    "clock": {
+                                        "type": "integer"
+                                    },
+                                    "compressedKey": {
+                                        "type": "string"
+                                    },
+                                    "contentType": {
+                                        "type": "integer"
+                                    },
+                                    "deletedForMe": {
+                                        "type": "boolean"
+                                    },
+                                    "displayName": {
+                                        "type": "string"
+                                    },
+                                    "emojiHash": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "ensName": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "gapParameters": {
+                                        "type": "object"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "identicon": {
+                                        "type": "string"
+                                    },
+                                    "lineCount": {
+                                        "type": "integer"
+                                    },
+                                    "localChatId": {
+                                        "type": "string"
+                                    },
+                                    "messageType": {
+                                        "type": "integer"
+                                    },
+                                    "outgoingStatus": {
+                                        "type": "string"
+                                    },
+                                    "parsedText": {
+                                        "items": {
+                                            "properties": {
+                                                "children": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "literal": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "literal"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "children",
+                                                "type"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "quotedMessage": {
+                                        "type": "null"
+                                    },
+                                    "replace": {
+                                        "type": "string"
+                                    },
+                                    "responseTo": {
+                                        "type": "string"
+                                    },
+                                    "rtl": {
+                                        "type": "boolean"
+                                    },
+                                    "seen": {
+                                        "type": "boolean"
+                                    },
+                                    "text": {
+                                        "type": "string"
+                                    },
+                                    "timestamp": {
+                                        "type": "integer"
+                                    },
+                                    "whisperTimestamp": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "alias",
+                                    "chatId",
+                                    "clock",
+                                    "compressedKey",
+                                    "contentType",
+                                    "deletedForMe",
+                                    "displayName",
+                                    "emojiHash",
+                                    "ensName",
+                                    "from",
+                                    "gapParameters",
+                                    "id",
+                                    "identicon",
+                                    "lineCount",
+                                    "localChatId",
+                                    "messageType",
+                                    "outgoingStatus",
+                                    "parsedText",
+                                    "quotedMessage",
+                                    "replace",
+                                    "responseTo",
+                                    "rtl",
+                                    "seen",
+                                    "text",
+                                    "timestamp",
+                                    "whisperTimestamp"
+                                ],
+                                "type": "object"
+                            },
+                            "members": {
+                                "type": "null"
+                            },
+                            "membershipUpdateEvents": {
+                                "type": "null"
+                            },
+                            "muteTill": {
+                                "type": "string"
+                            },
+                            "muted": {
+                                "type": "boolean"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "syncedFrom": {
+                                "type": "integer"
+                            },
+                            "syncedTo": {
+                                "type": "integer"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "unviewedMentionsCount": {
+                                "type": "integer"
+                            },
+                            "unviewedMessagesCount": {
+                                "type": "integer"
+                            },
+                            "viewersCanPostReactions": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "ReadMessagesAtClockValue",
+                            "active",
+                            "alias",
+                            "chatType",
+                            "color",
+                            "deletedAtClockValue",
+                            "description",
+                            "emoji",
+                            "highlight",
+                            "id",
+                            "identicon",
+                            "joined",
+                            "lastClockValue",
+                            "lastMessage",
+                            "members",
+                            "membershipUpdateEvents",
+                            "muteTill",
+                            "muted",
+                            "name",
+                            "syncedFrom",
+                            "syncedTo",
+                            "timestamp",
+                            "unviewedMentionsCount",
+                            "unviewedMessagesCount",
+                            "viewersCanPostReactions"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "discordOldestMessageTimestamp": {
+                    "type": "integer"
+                },
+                "messages": {
+                    "items": {
+                        "properties": {
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatId": {
+                                "type": "string"
+                            },
+                            "clock": {
+                                "type": "integer"
+                            },
+                            "compressedKey": {
+                                "type": "string"
+                            },
+                            "contentType": {
+                                "type": "integer"
+                            },
+                            "deletedForMe": {
+                                "type": "boolean"
+                            },
+                            "displayName": {
+                                "type": "string"
+                            },
+                            "emojiHash": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "ensName": {
+                                "type": "string"
+                            },
+                            "from": {
+                                "type": "string"
+                            },
+                            "gapParameters": {
+                                "type": "object"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "lineCount": {
+                                "type": "integer"
+                            },
+                            "localChatId": {
+                                "type": "string"
+                            },
+                            "messageType": {
+                                "type": "integer"
+                            },
+                            "outgoingStatus": {
+                                "type": "string"
+                            },
+                            "parsedText": {
+                                "items": {
+                                    "properties": {
+                                        "children": {
+                                            "items": {
+                                                "properties": {
+                                                    "literal": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "literal"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "children",
+                                        "type"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "quotedMessage": {
+                                "type": "null"
+                            },
+                            "replace": {
+                                "type": "string"
+                            },
+                            "responseTo": {
+                                "type": "string"
+                            },
+                            "rtl": {
+                                "type": "boolean"
+                            },
+                            "seen": {
+                                "type": "boolean"
+                            },
+                            "text": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "whisperTimestamp": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "alias",
+                            "chatId",
+                            "clock",
+                            "compressedKey",
+                            "contentType",
+                            "deletedForMe",
+                            "displayName",
+                            "emojiHash",
+                            "ensName",
+                            "from",
+                            "gapParameters",
+                            "id",
+                            "identicon",
+                            "lineCount",
+                            "localChatId",
+                            "messageType",
+                            "outgoingStatus",
+                            "parsedText",
+                            "quotedMessage",
+                            "replace",
+                            "responseTo",
+                            "rtl",
+                            "seen",
+                            "text",
+                            "timestamp",
+                            "whisperTimestamp"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "notifications": {
+                    "type": "null"
+                }
+            },
+            "required": [
+                "chats",
+                "discordOldestMessageTimestamp",
+                "messages",
+                "notifications"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/schemas/wakuext_deleteMessagesByChatID
+++ b/tests-functional/schemas/wakuext_deleteMessagesByChatID
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "type": "null"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/schemas/wakuext_editMessage
+++ b/tests-functional/schemas/wakuext_editMessage
@@ -1,0 +1,424 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "properties": {
+                "chats": {
+                    "items": {
+                        "properties": {
+                            "ReadMessagesAtClockValue": {
+                                "type": "integer"
+                            },
+                            "active": {
+                                "type": "boolean"
+                            },
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatType": {
+                                "type": "integer"
+                            },
+                            "color": {
+                                "type": "string"
+                            },
+                            "deletedAtClockValue": {
+                                "type": "integer"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "emoji": {
+                                "type": "string"
+                            },
+                            "highlight": {
+                                "type": "boolean"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "joined": {
+                                "type": "integer"
+                            },
+                            "lastClockValue": {
+                                "type": "integer"
+                            },
+                            "lastMessage": {
+                                "properties": {
+                                    "alias": {
+                                        "type": "string"
+                                    },
+                                    "chatId": {
+                                        "type": "string"
+                                    },
+                                    "clock": {
+                                        "type": "integer"
+                                    },
+                                    "compressedKey": {
+                                        "type": "string"
+                                    },
+                                    "contentType": {
+                                        "type": "integer"
+                                    },
+                                    "displayName": {
+                                        "type": "string"
+                                    },
+                                    "editedAt": {
+                                        "type": "integer"
+                                    },
+                                    "emojiHash": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "ensName": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "gapParameters": {
+                                        "type": "object"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "identicon": {
+                                        "type": "string"
+                                    },
+                                    "lineCount": {
+                                        "type": "integer"
+                                    },
+                                    "localChatId": {
+                                        "type": "string"
+                                    },
+                                    "messageType": {
+                                        "type": "integer"
+                                    },
+                                    "outgoingStatus": {
+                                        "type": "string"
+                                    },
+                                    "parsedText": {
+                                        "items": {
+                                            "properties": {
+                                                "children": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "literal": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "literal"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "children",
+                                                "type"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "quotedMessage": {
+                                        "type": "null"
+                                    },
+                                    "replace": {
+                                        "type": "string"
+                                    },
+                                    "responseTo": {
+                                        "type": "string"
+                                    },
+                                    "rtl": {
+                                        "type": "boolean"
+                                    },
+                                    "seen": {
+                                        "type": "boolean"
+                                    },
+                                    "text": {
+                                        "type": "string"
+                                    },
+                                    "timestamp": {
+                                        "type": "integer"
+                                    },
+                                    "whisperTimestamp": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "alias",
+                                    "chatId",
+                                    "clock",
+                                    "compressedKey",
+                                    "contentType",
+                                    "displayName",
+                                    "editedAt",
+                                    "emojiHash",
+                                    "ensName",
+                                    "from",
+                                    "gapParameters",
+                                    "id",
+                                    "identicon",
+                                    "lineCount",
+                                    "localChatId",
+                                    "messageType",
+                                    "outgoingStatus",
+                                    "parsedText",
+                                    "quotedMessage",
+                                    "replace",
+                                    "responseTo",
+                                    "rtl",
+                                    "seen",
+                                    "text",
+                                    "timestamp",
+                                    "whisperTimestamp"
+                                ],
+                                "type": "object"
+                            },
+                            "members": {
+                                "type": "null"
+                            },
+                            "membershipUpdateEvents": {
+                                "type": "null"
+                            },
+                            "muteTill": {
+                                "type": "string"
+                            },
+                            "muted": {
+                                "type": "boolean"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "syncedFrom": {
+                                "type": "integer"
+                            },
+                            "syncedTo": {
+                                "type": "integer"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "unviewedMentionsCount": {
+                                "type": "integer"
+                            },
+                            "unviewedMessagesCount": {
+                                "type": "integer"
+                            },
+                            "viewersCanPostReactions": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "ReadMessagesAtClockValue",
+                            "active",
+                            "alias",
+                            "chatType",
+                            "color",
+                            "deletedAtClockValue",
+                            "description",
+                            "emoji",
+                            "highlight",
+                            "id",
+                            "identicon",
+                            "joined",
+                            "lastClockValue",
+                            "lastMessage",
+                            "members",
+                            "membershipUpdateEvents",
+                            "muteTill",
+                            "muted",
+                            "name",
+                            "syncedFrom",
+                            "syncedTo",
+                            "timestamp",
+                            "unviewedMentionsCount",
+                            "unviewedMessagesCount",
+                            "viewersCanPostReactions"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "discordOldestMessageTimestamp": {
+                    "type": "integer"
+                },
+                "messages": {
+                    "items": {
+                        "properties": {
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatId": {
+                                "type": "string"
+                            },
+                            "clock": {
+                                "type": "integer"
+                            },
+                            "compressedKey": {
+                                "type": "string"
+                            },
+                            "contentType": {
+                                "type": "integer"
+                            },
+                            "displayName": {
+                                "type": "string"
+                            },
+                            "editedAt": {
+                                "type": "integer"
+                            },
+                            "emojiHash": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "ensName": {
+                                "type": "string"
+                            },
+                            "from": {
+                                "type": "string"
+                            },
+                            "gapParameters": {
+                                "type": "object"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "lineCount": {
+                                "type": "integer"
+                            },
+                            "localChatId": {
+                                "type": "string"
+                            },
+                            "messageType": {
+                                "type": "integer"
+                            },
+                            "outgoingStatus": {
+                                "type": "string"
+                            },
+                            "parsedText": {
+                                "items": {
+                                    "properties": {
+                                        "children": {
+                                            "items": {
+                                                "properties": {
+                                                    "literal": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "literal"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "children",
+                                        "type"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "quotedMessage": {
+                                "type": "null"
+                            },
+                            "replace": {
+                                "type": "string"
+                            },
+                            "responseTo": {
+                                "type": "string"
+                            },
+                            "rtl": {
+                                "type": "boolean"
+                            },
+                            "seen": {
+                                "type": "boolean"
+                            },
+                            "text": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "whisperTimestamp": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "alias",
+                            "chatId",
+                            "clock",
+                            "compressedKey",
+                            "contentType",
+                            "displayName",
+                            "editedAt",
+                            "emojiHash",
+                            "ensName",
+                            "from",
+                            "gapParameters",
+                            "id",
+                            "identicon",
+                            "lineCount",
+                            "localChatId",
+                            "messageType",
+                            "outgoingStatus",
+                            "parsedText",
+                            "quotedMessage",
+                            "replace",
+                            "responseTo",
+                            "rtl",
+                            "seen",
+                            "text",
+                            "timestamp",
+                            "whisperTimestamp"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "notifications": {
+                    "type": "null"
+                }
+            },
+            "required": [
+                "chats",
+                "discordOldestMessageTimestamp",
+                "messages",
+                "notifications"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/schemas/wakuext_firstUnseenMessageID
+++ b/tests-functional/schemas/wakuext_firstUnseenMessageID
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/schemas/wakuext_markMessageAsUnread
+++ b/tests-functional/schemas/wakuext_markMessageAsUnread
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "properties": {
+                "discordOldestMessageTimestamp": {
+                    "type": "integer"
+                },
+                "notifications": {
+                    "type": "null"
+                },
+                "seenAndUnseenMessages": {
+                    "items": {
+                        "properties": {
+                            "chatId": {
+                                "type": "string"
+                            },
+                            "count": {
+                                "type": "integer"
+                            },
+                            "countWithMentions": {
+                                "type": "integer"
+                            },
+                            "seen": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "chatId",
+                            "count",
+                            "countWithMentions",
+                            "seen"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "discordOldestMessageTimestamp",
+                "notifications",
+                "seenAndUnseenMessages"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -134,6 +134,22 @@ class TestChatMessages(MessengerTestCase):
         assert pinned_messages_page2[1].get("message", {}).get("text", "") == sent_texts[0]
         assert cursor2 == ""
 
+    def test_edit_message(self):
+        sent_texts, responses = self.send_multiple_one_to_one_messages(1)
+        messageId = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
+
+        response = self.sender.wakuext_service.message_by_message_id(messageId)
+        actual_text = response.get("result", {}).get("text", "")
+        assert actual_text == sent_texts[0]
+
+        new_text = "test_message_edited"
+        response = self.sender.wakuext_service.edit_message(messageId, new_text)
+        self.sender.verify_json_schema(response, method="wakuext_editMessage")
+
+        response = self.sender.wakuext_service.message_by_message_id(messageId)
+        actual_text = response.get("result", {}).get("text", "")
+        assert actual_text == new_text
+
     def test_delete_message(self):
         _, responses = self.send_multiple_one_to_one_messages(1)
 

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -51,8 +51,8 @@ class TestChatMessages(MessengerTestCase):
     def test_message_by_message_id(self):
         sent_texts, responses = self.send_multiple_one_to_one_messages(1)
 
-        messageId = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
-        response = self.sender.wakuext_service.message_by_message_id(messageId)
+        message_id = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
+        response = self.sender.wakuext_service.message_by_message_id(message_id)
 
         self.sender.verify_json_schema(response, method="wakuext_messageByMessageID")
 
@@ -145,35 +145,53 @@ class TestChatMessages(MessengerTestCase):
 
     def test_edit_message(self):
         sent_texts, responses = self.send_multiple_one_to_one_messages(1)
-        messageId = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
+        message_id = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
 
-        response = self.sender.wakuext_service.message_by_message_id(messageId)
+        response = self.sender.wakuext_service.message_by_message_id(message_id)
         actual_text = response.get("result", {}).get("text", "")
         assert actual_text == sent_texts[0]
 
         new_text = "test_message_edited"
-        response = self.sender.wakuext_service.edit_message(messageId, new_text)
+        response = self.sender.wakuext_service.edit_message(message_id, new_text)
         self.sender.verify_json_schema(response, method="wakuext_editMessage")
 
-        response = self.sender.wakuext_service.message_by_message_id(messageId)
+        response = self.sender.wakuext_service.message_by_message_id(message_id)
         actual_text = response.get("result", {}).get("text", "")
         assert actual_text == new_text
 
     def test_delete_message(self):
         _, responses = self.send_multiple_one_to_one_messages(1)
 
-        messageId = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
-        response = self.sender.wakuext_service.message_by_message_id(messageId)
+        message_id = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
+        response = self.sender.wakuext_service.message_by_message_id(message_id)
         assert response.get("result", {}) != {}
 
-        response = self.sender.wakuext_service.delete_message(messageId)
+        response = self.sender.wakuext_service.delete_message(message_id)
         self.sender.verify_json_schema(response, method="wakuext_deleteMessage")
 
-        response = self.sender.rpc_request("wakuext_messageByMessageID", [messageId])
+        response = self.sender.rpc_request("wakuext_messageByMessageID", [message_id])
         error_code = response.json().get("error", {}).get("code", 0)
         error_message = response.json().get("error", {}).get("message", "")
         assert error_code == -32000
         assert error_message == "record not found"
+
+    def test_delete_message_and_send(self):
+        _, responses = self.send_multiple_one_to_one_messages(1)
+
+        message_id = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
+        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        assert response.get("result", {}) != {}
+
+        response = self.sender.wakuext_service.delete_message_and_send(message_id)
+        self.sender.verify_json_schema(response, method="wakuext_deleteMessageAndSend")
+        removed_messages = response.get("result", {}).get("removedMessages", [])
+        assert len(removed_messages) == 1
+        assert removed_messages[0].get("messageId") == message_id
+
+        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        message = response.get("result", {})
+        assert message.get("id", "") == message_id
+        assert message.get("deleted", None) is True
 
     def test_delete_messages_by_chat_id(self):
         _, _ = self.send_multiple_one_to_one_messages(3)
@@ -193,16 +211,16 @@ class TestChatMessages(MessengerTestCase):
     def test_first_unseen_message(self):
         _, responses = self.send_multiple_one_to_one_messages(1)
         sender_chat_id = self.receiver.public_key
-        messageId = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
+        message_id = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
 
-        response = self.sender.wakuext_service.mark_message_as_unread(sender_chat_id, messageId)
+        response = self.sender.wakuext_service.mark_message_as_unread(sender_chat_id, message_id)
         self.sender.verify_json_schema(response, method="wakuext_markMessageAsUnread")
 
         response = self.sender.wakuext_service.first_unseen_message_id(sender_chat_id)
         self.sender.verify_json_schema(response, method="wakuext_firstUnseenMessageID")
 
         result = response.get("result", "")
-        assert result == messageId
+        assert result == message_id
 
 
 @pytest.mark.usefixtures("setup_two_unprivileged_nodes")

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -208,6 +208,24 @@ class TestChatMessages(MessengerTestCase):
         messages = response.get("result", {}).get("messages", [])
         assert messages is None
 
+    def test_delete_message_for_me_and_sync(self):
+        _, responses = self.send_multiple_one_to_one_messages(1)
+
+        message_id = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
+        local_chat_id = responses[0].get("result", {}).get("messages", [])[0].get("localChatId", "")
+        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        assert response.get("result", {}) != {}
+
+        response = self.sender.wakuext_service.delete_message_for_me_and_sync(local_chat_id, message_id)
+        self.sender.verify_json_schema(response, method="wakuext_deleteMessageForMeAndSync")
+
+        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        message = response.get("result", {})
+        assert message.get("id", "") == message_id
+        assert message.get("deletedForMe", None) is True
+
+        # TODO: assert sync action
+
     def test_first_unseen_message(self):
         _, responses = self.send_multiple_one_to_one_messages(1)
         sender_chat_id = self.receiver.public_key

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -190,6 +190,20 @@ class TestChatMessages(MessengerTestCase):
         messages = response.get("result", {}).get("messages", [])
         assert messages is None
 
+    def test_first_unseen_message(self):
+        _, responses = self.send_multiple_one_to_one_messages(1)
+        sender_chat_id = self.receiver.public_key
+        messageId = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
+
+        response = self.sender.wakuext_service.mark_message_as_unread(sender_chat_id, messageId)
+        self.sender.verify_json_schema(response, method="wakuext_markMessageAsUnread")
+
+        response = self.sender.wakuext_service.first_unseen_message_id(sender_chat_id)
+        self.sender.verify_json_schema(response, method="wakuext_firstUnseenMessageID")
+
+        result = response.get("result", "")
+        assert result == messageId
+
 
 @pytest.mark.usefixtures("setup_two_unprivileged_nodes")
 @pytest.mark.rpc

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -134,6 +134,37 @@ class TestChatMessages(MessengerTestCase):
         assert pinned_messages_page2[1].get("message", {}).get("text", "") == sent_texts[0]
         assert cursor2 == ""
 
+    def test_delete_message(self):
+        _, responses = self.send_multiple_one_to_one_messages(1)
+
+        messageId = responses[0].get("result", {}).get("messages", [])[0].get("id", "")
+        response = self.sender.wakuext_service.message_by_message_id(messageId)
+        assert response.get("result", {}) != {}
+
+        response = self.sender.wakuext_service.delete_message(messageId)
+        self.sender.verify_json_schema(response, method="wakuext_deleteMessage")
+
+        response = self.sender.rpc_request("wakuext_messageByMessageID", [messageId])
+        error_code = response.json().get("error", {}).get("code", 0)
+        error_message = response.json().get("error", {}).get("message", "")
+        assert error_code == -32000
+        assert error_message == "record not found"
+
+    def test_delete_messages_by_chat_id(self):
+        _, _ = self.send_multiple_one_to_one_messages(3)
+        sender_chat_id = self.receiver.public_key
+
+        response = self.sender.wakuext_service.chat_messages(sender_chat_id)
+        messages = response.get("result", {}).get("messages", [])
+        assert len(messages) == 3
+
+        response = self.sender.wakuext_service.delete_messages_by_chat_id(sender_chat_id)
+        self.sender.verify_json_schema(response, method="wakuext_deleteMessagesByChatID")
+
+        response = self.sender.wakuext_service.chat_messages(sender_chat_id)
+        messages = response.get("result", {}).get("messages", [])
+        assert messages is None
+
 
 @pytest.mark.usefixtures("setup_two_unprivileged_nodes")
 @pytest.mark.rpc

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -81,6 +81,7 @@ class TestChatMessages(MessengerTestCase):
     def test_pinned_messages(self):
         sent_texts, responses = self.send_multiple_one_to_one_messages(1)
 
+        # pin
         message = responses[0].get("result", {}).get("messages", [])[0]
         pin_message_payload: SendPinMessagePayload = {
             "chat_id": message.get("chatId", ""),
@@ -99,6 +100,14 @@ class TestChatMessages(MessengerTestCase):
         assert len(pinned_messages) == 1
         actual_text = pinned_messages[0].get("message", {}).get("text", "")
         assert actual_text == sent_texts[0]
+
+        # unpin
+        pin_message_payload["pinned"] = False
+        self.sender.wakuext_service.send_pin_message(pin_message_payload)
+        response = self.sender.wakuext_service.chat_pinned_messages(sender_chat_id)
+
+        pinned_messages = response.get("result", {}).get("pinnedMessages", [])
+        assert pinned_messages is None
 
     def test_pinned_messages_with_pagination(self):
         sent_texts, responses = self.send_multiple_one_to_one_messages(5)

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -169,9 +169,9 @@ class TestChatMessages(MessengerTestCase):
         response = self.sender.wakuext_service.delete_message(message_id)
         self.sender.verify_json_schema(response, method="wakuext_deleteMessage")
 
-        response = self.sender.rpc_request("wakuext_messageByMessageID", [message_id])
-        error_code = response.json().get("error", {}).get("code", 0)
-        error_message = response.json().get("error", {}).get("message", "")
+        response = self.sender.wakuext_service.message_by_message_id(message_id, skip_validation=True)
+        error_code = response.get("error", {}).get("code", 0)
+        error_message = response.get("error", {}).get("message", "")
         assert error_code == -32000
         assert error_message == "record not found"
 

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -1,4 +1,5 @@
 import pytest
+from uuid import uuid4
 
 from tests.test_cases import MessengerTestCase
 
@@ -15,6 +16,8 @@ class TestChatMessages(MessengerTestCase):
 
         sender_chat_id = self.receiver.public_key
         response = self.sender.wakuext_service.chat_messages(sender_chat_id)
+
+        self.sender.verify_json_schema(response, method="wakuext_chatMessages")
 
         self.sender.verify_json_schema(response, method="wakuext_chatMessages")
 

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -19,8 +19,6 @@ class TestChatMessages(MessengerTestCase):
 
         self.sender.verify_json_schema(response, method="wakuext_chatMessages")
 
-        self.sender.verify_json_schema(response, method="wakuext_chatMessages")
-
         messages = response.get("result", {}).get("messages", [])
         assert len(messages) == 1
         actual_text = messages[0].get("text", "")

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -1,5 +1,4 @@
 import pytest
-from uuid import uuid4
 
 from tests.test_cases import MessengerTestCase
 
@@ -16,8 +15,6 @@ class TestChatMessages(MessengerTestCase):
 
         sender_chat_id = self.receiver.public_key
         response = self.sender.wakuext_service.chat_messages(sender_chat_id)
-
-        self.sender.verify_json_schema(response, method="wakuext_chatMessages")
 
         self.sender.verify_json_schema(response, method="wakuext_chatMessages")
 

--- a/tests-functional/tests/test_wakuext_messages.py
+++ b/tests-functional/tests/test_wakuext_messages.py
@@ -1,5 +1,4 @@
 import pytest
-from uuid import uuid4
 
 from tests.test_cases import MessengerTestCase
 


### PR DESCRIPTION
Functional tests for `wakuext` messages methods: https://github.com/status-im/status-go/issues/6084

Important changes:
- [x] `wakuext_editMessage`
- [x] `wakuext_deleteMessage`
- [x] `wakuext_deleteMessagesByChatID`
- [x] `wakuext_deleteMessageAndSend`
- [x] `wakuext_deleteMessageForMeAndSync`
- [x] `wakuext_markMessageAsUnread`
- [x] `wakuext_firstUnseenMessageID`
