### PR TITLE
chore(analytics)_: Add UserID field to MetricsInfo

### DIFF
--- a/centralizedmetrics/metrics.go
+++ b/centralizedmetrics/metrics.go
@@ -15,8 +15,9 @@ import (
 const defaultPollInterval = 10 * time.Second
 
 type MetricsInfo struct {
-	Enabled       bool `json:"enabled"`
-	UserConfirmed bool `json:"userConfirmed"`
+	Enabled       bool   `json:"enabled"`
+	UserConfirmed bool   `json:"userConfirmed"`
+	UserID        string `json:"userID"`
 }
 
 type MetricRepository interface {

--- a/centralizedmetrics/sqlite_persistence.go
+++ b/centralizedmetrics/sqlite_persistence.go
@@ -189,7 +189,7 @@ func (r *SQLiteMetricRepository) ToggleEnabled(enabled bool) error {
 
 func (r *SQLiteMetricRepository) Info() (*MetricsInfo, error) {
 	info := MetricsInfo{}
-	err := r.db.QueryRow("SELECT enabled,user_confirmed FROM centralizedmetrics_uuid LIMIT 1").Scan(&info.Enabled, &info.UserConfirmed)
+	err := r.db.QueryRow("SELECT enabled,user_confirmed,uuid FROM centralizedmetrics_uuid LIMIT 1").Scan(&info.Enabled, &info.UserConfirmed, &info.UserID)
 	if err == sql.ErrNoRows {
 		return &info, nil
 	}

--- a/centralizedmetrics/sqlite_persistence_test.go
+++ b/centralizedmetrics/sqlite_persistence_test.go
@@ -204,3 +204,28 @@ func TestSQLiteMetricRepository_EnabledDelete(t *testing.T) {
 	require.False(t, info.Enabled)
 	require.True(t, info.UserConfirmed)
 }
+
+func TestSQLiteMetricRepository_Info(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	repo := NewSQLiteMetricRepository(db)
+
+	// Verify default behavior ignores sql.ErrNoRows.
+	info, err := repo.Info()
+	require.NoError(t, err)
+	require.False(t, info.Enabled)
+	require.False(t, info.UserConfirmed)
+	require.Empty(t, info.UserID)
+
+	// Call UserID() because on first usage it will insert a new UUID.
+	userID, err := repo.UserID(nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, userID)
+
+	info, err = repo.Info()
+	require.NoError(t, err)
+	require.False(t, info.Enabled)
+	require.False(t, info.UserConfirmed)
+	require.Equal(t, userID, info.UserID)
+}


### PR DESCRIPTION
## Summary

This PR adds a new field to `MetricsInfo` so that clients can access the MixPanel `User ID` value from `mobile/status.go#InitializeApplicationResponse` and allow devs/QAs to easily copy MixPanel `User ID` in PR builds.

For a better explanation on the problem and solution, please refer to the mobile PR https://github.com/status-im/status-mobile/pull/22235 and its associated issue https://github.com/status-im/status-mobile/issues/21680.
