### PR TITLE
chore(market)_: Diagnostic information about rpc/market API calls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,4 @@ shell.nix             @status-im/devops
 /cmd/status-backend   @igor-sirotin
 /internal/sentry      @igor-sirotin
 /healthmanager	      @friofry
+/rpc/network          @friofry

--- a/healthmanager/provider_errors/provider_errors.go
+++ b/healthmanager/provider_errors/provider_errors.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/afex/hystrix-go/hystrix"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -193,6 +195,17 @@ func IsServiceUnavailableError(err error) bool {
 		return statusCode == 503
 	}
 	return false
+}
+
+// IsTimeoutErr checks if the error is a timeout error.
+func IsTimeoutErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, hystrix.ErrTimeout) ||
+		strings.Contains(err.Error(), "timeout") ||
+		strings.Contains(err.Error(), "deadline exceeded")
 }
 
 // determineProviderErrorType determines the ProviderErrorType based on the error.

--- a/healthmanager/provider_errors/rpc_provider_errors.go
+++ b/healthmanager/provider_errors/rpc_provider_errors.go
@@ -74,7 +74,7 @@ func determineRpcErrorType(err error) RpcProviderErrorType {
 	return RpcErrorTypeRPCOther
 }
 
-// IsCriticalRpcError determines if the RPC error is critical.
+// IsNonCriticalRpcError determines if the RPC error is critical.
 func IsNonCriticalRpcError(err error) bool {
 	errorType := determineRpcErrorType(err)
 

--- a/healthmanager/rpcstatus/provider_status_test.go
+++ b/healthmanager/rpcstatus/provider_status_test.go
@@ -5,10 +5,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/status-im/status-go/healthmanager/provider_errors"
 	"github.com/status-im/status-go/rpc/chain/rpclimiter"
 )
 
 func TestNewRpcProviderStatus(t *testing.T) {
+	now := time.Now()
+	duration := 100 * time.Millisecond
+
 	tests := []struct {
 		name          string
 		res           RpcProviderCallStatus
@@ -19,8 +25,9 @@ func TestNewRpcProviderStatus(t *testing.T) {
 			name: "No error, should be up",
 			res: RpcProviderCallStatus{
 				Name:      "Provider1",
-				Timestamp: time.Now(),
+				Timestamp: now,
 				Err:       nil,
+				StartTime: now.Add(-duration),
 			},
 			expectSuccess: true,
 		},
@@ -28,8 +35,9 @@ func TestNewRpcProviderStatus(t *testing.T) {
 			name: "Critical RPC error, should be down",
 			res: RpcProviderCallStatus{
 				Name:      "Provider1",
-				Timestamp: time.Now(),
+				Timestamp: now,
 				Err:       errors.New("Some critical RPC error"),
+				StartTime: now.Add(-duration),
 			},
 			expectSuccess: false,
 			expectedError: errors.New("Some critical RPC error"),
@@ -38,20 +46,35 @@ func TestNewRpcProviderStatus(t *testing.T) {
 			name: "Non-critical RPC error, should be up",
 			res: RpcProviderCallStatus{
 				Name:      "Provider2",
-				Timestamp: time.Now(),
+				Timestamp: now,
 				Err:       rpclimiter.ErrRequestsOverLimit,
+				StartTime: now.Add(-duration),
 			},
 			expectSuccess: true,
+		},
+		{
+			name: "Timeout error, should be down but tracked",
+			res: RpcProviderCallStatus{
+				Name:      "Provider3",
+				Timestamp: now,
+				Err:       errors.New("context deadline exceeded"),
+				StartTime: now.Add(-duration),
+			},
+			expectSuccess: false,
+			expectedError: errors.New("context deadline exceeded"),
 		},
 	}
 
 	for _, tt := range tests {
 		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
+			status := NewRpcProviderStatus(tt.res)
+
 			if tt.expectSuccess {
 				if tt.res.Err != nil && tt.res.Err != rpclimiter.ErrRequestsOverLimit {
 					t.Errorf("expected success but got error: %v", tt.res.Err)
 				}
+				assert.Equal(t, StatusUp, status.Status, "Status should be up")
 			} else {
 				if tt.res.Err == nil {
 					t.Error("expected error but got success")
@@ -59,6 +82,18 @@ func TestNewRpcProviderStatus(t *testing.T) {
 				if tt.expectedError != nil && tt.res.Err.Error() != tt.expectedError.Error() {
 					t.Errorf("expected error %v, got %v", tt.expectedError, tt.res.Err)
 				}
+				assert.Equal(t, StatusDown, status.Status, "Status should be down")
+			}
+
+			// Verify the new fields are correctly transferred
+			expectedDuration := tt.res.Timestamp.Sub(tt.res.StartTime)
+			assert.Equal(t, expectedDuration, status.TotalDuration, "Duration should be calculated as Timestamp - StartTime")
+			assert.Equal(t, int64(1), status.TotalRequests, "TotalRequests should be initialized to 1")
+
+			if provider_errors.IsTimeoutErr(tt.res.Err) {
+				assert.Equal(t, int64(1), status.TotalTimeoutCount, "TotalTimeoutCount should be 1 for timeout errors")
+			} else {
+				assert.Equal(t, int64(0), status.TotalTimeoutCount, "TotalTimeoutCount should be 0 for non-timeout errors")
 			}
 		})
 	}

--- a/metrics/wakumetrics/client.go
+++ b/metrics/wakumetrics/client.go
@@ -8,10 +8,11 @@ import (
 	wakutypes "github.com/status-im/status-go/waku/types"
 	"github.com/status-im/status-go/wakuv2"
 
-	v1protocol "github.com/status-im/status-go/protocol/v1"
-	v2common "github.com/status-im/status-go/wakuv2/common"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
+
+	v1protocol "github.com/status-im/status-go/protocol/v1"
+	v2common "github.com/status-im/status-go/wakuv2/common"
 )
 
 type ReceivedMessages struct {

--- a/metrics/wakumetrics/client_test.go
+++ b/metrics/wakumetrics/client_test.go
@@ -9,14 +9,15 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 
-	"github.com/status-im/status-go/protocol/transport"
-	v1protocol "github.com/status-im/status-go/protocol/v1"
-	wakutypes "github.com/status-im/status-go/waku/types"
-	"github.com/status-im/status-go/wakuv2"
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+
+	"github.com/status-im/status-go/protocol/transport"
+	v1protocol "github.com/status-im/status-go/protocol/v1"
+	wakutypes "github.com/status-im/status-go/waku/types"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 var (

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -793,7 +793,9 @@ func convertFunctorCallStatuses(statuses []circuitbreaker.FunctorCallStatus, met
 			Name:      f.Name,
 			Method:    methodName,
 			Timestamp: f.Timestamp,
-			Err:       f.Err})
+			Err:       f.Err,
+			StartTime: f.StartTime,
+		})
 	}
 	return
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -226,6 +226,10 @@ func (c *Client) monitorHealth(ctx context.Context, statusCh chan struct{}) {
 	}
 }
 
+func (c *Client) GetHealthManagerFullStatus() healthmanager.BlockchainFullStatus {
+	return c.healthMgr.GetFullStatus()
+}
+
 func (c *Client) GetNetworkManager() *network.Manager {
 	return c.NetworkManager
 }

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -22,6 +22,7 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/healthmanager"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/rpc/network"
@@ -518,6 +519,12 @@ func (api *API) StopSuggestedRoutesAsyncCalculation(ctx context.Context) {
 	logutils.ZapLogger().Debug("call to StopSuggestedRoutesAsyncCalculation")
 
 	api.s.router.StopSuggestedRoutesAsyncCalculation()
+}
+
+// GetBlockchainHealthStatus returns the status of rpc clients
+func (api *API) GetBlockchainHealthStatus(ctx context.Context) healthmanager.BlockchainFullStatus {
+	logutils.ZapLogger().Debug("call to GetBlockchainHealthStatus")
+	return api.s.GetRPCClient().GetHealthManagerFullStatus()
 }
 
 func (api *API) StopSuggestedRoutesCalculation(ctx context.Context) {

--- a/services/wallet/thirdparty/http_client.go
+++ b/services/wallet/thirdparty/http_client.go
@@ -9,6 +9,10 @@ import (
 	"net/http"
 	netUrl "net/url"
 	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/logutils"
 )
 
 const requestTimeout = 5 * time.Second
@@ -25,9 +29,13 @@ type HTTPClient struct {
 }
 
 func NewHTTPClient() *HTTPClient {
+	return NewHTTPClientWithTimeout(requestTimeout)
+}
+
+func NewHTTPClientWithTimeout(timeout time.Duration) *HTTPClient {
 	return &HTTPClient{
 		client: &http.Client{
-			Timeout: requestTimeout,
+			Timeout: timeout,
 		},
 		maxRetries: maxNumOfRequestRetries,
 	}
@@ -65,6 +73,7 @@ func NewHTTPClientWithDetailedTimeouts(
 // If etag is not empty, it will add an If-None-Match header to the request
 // If the server responds with a 304 status code (`http.StatusNotModified`), it will return an empty body and the same etag
 func (c *HTTPClient) doGetRequest(ctx context.Context, url string, params netUrl.Values, creds *BasicCreds, etag string) (body []byte, newEtag string, err error) {
+	startTime := time.Now()
 	if len(params) > 0 {
 		url = url + "?" + params.Encode()
 	}
@@ -72,6 +81,9 @@ func (c *HTTPClient) doGetRequest(ctx context.Context, url string, params netUrl
 	var req *http.Request
 	req, err = http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
+		logutils.ZapLogger().Debug("Failed to create GET request",
+			zap.String("url", url),
+			zap.Error(err))
 		return
 	}
 
@@ -87,18 +99,28 @@ func (c *HTTPClient) doGetRequest(ctx context.Context, url string, params netUrl
 
 	var resp *http.Response
 	maxRetries := c.maxRetries
-	if maxRetries <= 0 {
+	if maxRetries < 0 {
 		maxRetries = maxNumOfRequestRetries // Use default if not set
 	}
 
+	var retryCount int
 	for i := 0; i < maxRetries; i++ {
+		retryCount = i
 		resp, err = c.client.Do(req)
 		if err == nil || i == maxRetries-1 {
 			break
 		}
+		logutils.ZapLogger().Debug("Retrying GET request after error",
+			zap.String("url", url),
+			zap.Int("retry", i+1),
+			zap.Error(err))
 		time.Sleep(200 * time.Millisecond)
 	}
 	if err != nil {
+		logutils.ZapLogger().Debug("GET request failed after retries",
+			zap.String("url", url),
+			zap.Int("retries", retryCount),
+			zap.Error(err))
 		return
 	}
 	defer resp.Body.Close()
@@ -111,8 +133,19 @@ func (c *HTTPClient) doGetRequest(ctx context.Context, url string, params netUrl
 
 	body, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
+		logutils.ZapLogger().Debug("Failed to read GET response body",
+			zap.String("url", url),
+			zap.Error(err))
 		return
 	}
+
+	duration := time.Since(startTime)
+	logutils.ZapLogger().Debug("GET request completed",
+		zap.String("url", url),
+		zap.Int("status", resp.StatusCode),
+		zap.Int("retries", retryCount),
+		zap.Int("bodySize", len(body)),
+		zap.Duration("duration", duration))
 
 	return
 }
@@ -122,7 +155,6 @@ func (c *HTTPClient) DoGetRequest(ctx context.Context, url string, params netUrl
 	body, _, err = c.doGetRequest(ctx, url, params, nil, "")
 	return
 }
-
 // DoGetRequestWithCredentials performs a GET request with the given URL and parameters
 // If creds is not nil, it will add basic auth to the request
 func (c *HTTPClient) DoGetRequestWithCredentials(ctx context.Context, url string, params netUrl.Values, creds *BasicCreds) (body []byte, err error) {
@@ -136,7 +168,6 @@ func (c *HTTPClient) DoGetRequestWithCredentials(ctx context.Context, url string
 func (c *HTTPClient) DoGetRequestWithEtag(ctx context.Context, url string, params netUrl.Values, etag string) (body []byte, newEtag string, err error) {
 	return c.doGetRequest(ctx, url, params, nil, etag)
 }
-
 func (c *HTTPClient) DoPostRequest(ctx context.Context, url string, params map[string]interface{}, creds *BasicCreds) ([]byte, error) {
 	jsonData, err := json.Marshal(params)
 	if err != nil {

--- a/services/wallet/thirdparty/http_client.go
+++ b/services/wallet/thirdparty/http_client.go
@@ -15,57 +15,71 @@ import (
 	"github.com/status-im/status-go/logutils"
 )
 
-const requestTimeout = 5 * time.Second
-const maxNumOfRequestRetries = 5
+const (
+	defaultRequestTimeout  = 5 * time.Second
+	defaultMaxRetries      = 5
+	defaultIdleConnTimeout = 90 * time.Second
+)
 
 type BasicCreds struct {
 	User     string
 	Password string
 }
 
+// HTTPClient represents an HTTP client with configurable options
 type HTTPClient struct {
 	client     *http.Client
 	maxRetries int
 }
 
-func NewHTTPClient() *HTTPClient {
-	return NewHTTPClientWithTimeout(requestTimeout)
-}
+// Option defines a function type for configuring HTTPClient
+type Option func(*HTTPClient)
 
-func NewHTTPClientWithTimeout(timeout time.Duration) *HTTPClient {
-	return &HTTPClient{
-		client: &http.Client{
-			Timeout: timeout,
-		},
-		maxRetries: maxNumOfRequestRetries,
+// WithTimeout sets the overall request timeout
+func WithTimeout(timeout time.Duration) Option {
+	return func(c *HTTPClient) {
+		c.client.Timeout = timeout
 	}
 }
 
-// NewHTTPClientWithDetailedTimeouts creates a new HTTPClient with separate timeouts for
-// connection establishment and data transfer
-func NewHTTPClientWithDetailedTimeouts(
-	dialTimeout time.Duration,
-	tlsHandshakeTimeout time.Duration,
-	responseHeaderTimeout time.Duration,
-	requestTimeout time.Duration,
-	maxRetries int,
-) *HTTPClient {
-	transport := &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout: dialTimeout, // Timeout for establishing a connection
-		}).DialContext,
-		TLSHandshakeTimeout:   tlsHandshakeTimeout,   // Timeout for TLS handshake
-		ResponseHeaderTimeout: responseHeaderTimeout, // Timeout for receiving response headers
-		IdleConnTimeout:       90 * time.Second,      // How long to keep idle connections
+// WithMaxRetries sets the maximum number of retries for failed requests
+func WithMaxRetries(maxRetries int) Option {
+	return func(c *HTTPClient) {
+		c.maxRetries = maxRetries
+	}
+}
+
+// WithDetailedTimeouts sets detailed timeouts for different connection phases
+func WithDetailedTimeouts(dialTimeout, tlsHandshakeTimeout, responseHeaderTimeout, requestTimeout time.Duration) Option {
+	return func(c *HTTPClient) {
+		transport := &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: dialTimeout,
+			}).DialContext,
+			TLSHandshakeTimeout:   tlsHandshakeTimeout,
+			ResponseHeaderTimeout: responseHeaderTimeout,
+			IdleConnTimeout:       defaultIdleConnTimeout,
+		}
+		c.client.Transport = transport
+		c.client.Timeout = requestTimeout
+	}
+}
+
+// NewHTTPClient creates a new HTTPClient with the provided options
+func NewHTTPClient(opts ...Option) *HTTPClient {
+	client := &HTTPClient{
+		client: &http.Client{
+			Timeout: defaultRequestTimeout,
+		},
+		maxRetries: defaultMaxRetries,
 	}
 
-	return &HTTPClient{
-		client: &http.Client{
-			Transport: transport,
-			Timeout:   requestTimeout, // Overall request timeout
-		},
-		maxRetries: maxRetries,
+	// Apply all provided options
+	for _, opt := range opts {
+		opt(client)
 	}
+
+	return client
 }
 
 // doGetRequest performs a GET request with the given URL and parameters
@@ -100,7 +114,7 @@ func (c *HTTPClient) doGetRequest(ctx context.Context, url string, params netUrl
 	var resp *http.Response
 	maxRetries := c.maxRetries
 	if maxRetries < 0 {
-		maxRetries = maxNumOfRequestRetries // Use default if not set
+		maxRetries = defaultMaxRetries // Use default if not set
 	}
 
 	var retryCount int
@@ -155,6 +169,7 @@ func (c *HTTPClient) DoGetRequest(ctx context.Context, url string, params netUrl
 	body, _, err = c.doGetRequest(ctx, url, params, nil, "")
 	return
 }
+
 // DoGetRequestWithCredentials performs a GET request with the given URL and parameters
 // If creds is not nil, it will add basic auth to the request
 func (c *HTTPClient) DoGetRequestWithCredentials(ctx context.Context, url string, params netUrl.Values, creds *BasicCreds) (body []byte, err error) {

--- a/services/wallet/thirdparty/market/coingecko/client.go
+++ b/services/wallet/thirdparty/market/coingecko/client.go
@@ -68,14 +68,14 @@ func NewClient() *Client {
 	// Configure HTTP client with detailed timeouts:
 	// - 5 seconds for connection establishment (dialTimeout)
 	// - 5 seconds for TLS handshake (tlsHandshakeTimeout)
-	// - 10 seconds for receiving response headers (responseHeaderTimeout)
-	// - 30 seconds for overall request timeout (requestTimeout)
+	// - 5 seconds for receiving response headers (responseHeaderTimeout)
+	// - 20 seconds for overall request timeout (requestTimeout)
 	httpClient := thirdparty.NewHTTPClientWithDetailedTimeouts(
 		5*time.Second,  // dialTimeout
 		5*time.Second,  // tlsHandshakeTimeout
 		5*time.Second,  // responseHeaderTimeout
 		20*time.Second, // requestTimeout
-		5,              // retries
+		5,              // maxRetries
 	)
 
 	return &Client{

--- a/services/wallet/thirdparty/market/coingecko/client.go
+++ b/services/wallet/thirdparty/market/coingecko/client.go
@@ -70,12 +70,14 @@ func NewClient() *Client {
 	// - 5 seconds for TLS handshake (tlsHandshakeTimeout)
 	// - 5 seconds for receiving response headers (responseHeaderTimeout)
 	// - 20 seconds for overall request timeout (requestTimeout)
-	httpClient := thirdparty.NewHTTPClientWithDetailedTimeouts(
-		5*time.Second,  // dialTimeout
-		5*time.Second,  // tlsHandshakeTimeout
-		5*time.Second,  // responseHeaderTimeout
-		20*time.Second, // requestTimeout
-		5,              // maxRetries
+	httpClient := thirdparty.NewHTTPClient(
+		thirdparty.WithDetailedTimeouts(
+			5*time.Second,
+			5*time.Second,
+			5*time.Second,
+			20*time.Second,
+		),
+		thirdparty.WithMaxRetries(5),
 	)
 
 	return &Client{

--- a/services/wallet/thirdparty/market/cryptocompare/client.go
+++ b/services/wallet/thirdparty/market/cryptocompare/client.go
@@ -74,12 +74,24 @@ func NewClientWithParams(params Params) *Client {
 		5,              // retries
 	)
 
+	// Ensure baseURL doesn't end with a slash
+	baseURL := strings.TrimSuffix(params.URL, "/")
+
 	return &Client{
 		id:         params.ID,
 		httpClient: httpClient,
-		baseURL:    params.URL,
+		baseURL:    baseURL,
 		creds:      creds,
 	}
+}
+
+// buildURL creates a URL by joining the base URL with the given path
+// ensuring there are no double slashes
+func (c *Client) buildURL(path string) string {
+	baseURL := strings.TrimRight(c.baseURL, "/")
+	trimmedPath := strings.TrimLeft(path, "/")
+
+	return baseURL + "/" + trimmedPath
 }
 
 func (c *Client) FetchPrices(symbols []string, currencies []string) (map[string]map[string]float64, error) {
@@ -103,7 +115,7 @@ func (c *Client) FetchPrices(symbols []string, currencies []string) (map[string]
 		params.Add("relaxedValidation", "true")
 		params.Add("extraParams", extraParamStatus)
 
-		url := fmt.Sprintf("%s/data/pricemulti", c.baseURL)
+		url := c.buildURL("data/pricemulti")
 		response, err := c.httpClient.DoGetRequestWithCredentials(context.Background(), url, params, c.creds)
 		if err != nil {
 			return nil, err
@@ -126,7 +138,7 @@ func (c *Client) FetchPrices(symbols []string, currencies []string) (map[string]
 }
 
 func (c *Client) FetchTokenDetails(symbols []string) (map[string]thirdparty.TokenDetails, error) {
-	url := fmt.Sprintf("%s/data/all/coinlist", c.baseURL)
+	url := c.buildURL("data/all/coinlist")
 	response, err := c.httpClient.DoGetRequestWithCredentials(context.Background(), url, nil, c.creds)
 	if err != nil {
 		return nil, err
@@ -168,7 +180,7 @@ func (c *Client) FetchTokenMarketValues(symbols []string, currency string) (map[
 		params.Add("relaxedValidation", "true")
 		params.Add("extraParams", extraParamStatus)
 
-		url := fmt.Sprintf("%s/data/pricemultifull", c.baseURL)
+		url := c.buildURL("data/pricemultifull")
 		response, err := c.httpClient.DoGetRequestWithCredentials(context.Background(), url, params, c.creds)
 		if err != nil {
 			return nil, err
@@ -201,7 +213,7 @@ func (c *Client) FetchHistoricalHourlyPrices(symbol string, currency string, lim
 	params.Add("limit", fmt.Sprintf("%d", limit))
 	params.Add("extraParams", extraParamStatus)
 
-	url := fmt.Sprintf("%s/data/v2/histohour", c.baseURL)
+	url := c.buildURL("data/v2/histohour")
 	response, err := c.httpClient.DoGetRequestWithCredentials(context.Background(), url, params, c.creds)
 	if err != nil {
 		return item, err
@@ -229,7 +241,7 @@ func (c *Client) FetchHistoricalDailyPrices(symbol string, currency string, limi
 	params.Add("allData", fmt.Sprintf("%v", allData))
 	params.Add("extraParams", extraParamStatus)
 
-	url := fmt.Sprintf("%s/data/v2/histoday", c.baseURL)
+	url := c.buildURL("data/v2/histoday")
 	response, err := c.httpClient.DoGetRequestWithCredentials(context.Background(), url, params, c.creds)
 	if err != nil {
 		return item, err

--- a/services/wallet/thirdparty/market/cryptocompare/client.go
+++ b/services/wallet/thirdparty/market/cryptocompare/client.go
@@ -65,13 +65,15 @@ func NewClientWithParams(params Params) *Client {
 		}
 	}
 
-	// Configure HTTP client with detailed timeouts:
-	httpClient := thirdparty.NewHTTPClientWithDetailedTimeouts(
-		5*time.Second,  // dialTimeout
-		5*time.Second,  // tlsHandshakeTimeout
-		5*time.Second,  // responseHeaderTimeout
-		20*time.Second, // requestTimeout
-		5,              // retries
+	// Configure HTTP client with detailed timeouts
+	httpClient := thirdparty.NewHTTPClient(
+		thirdparty.WithDetailedTimeouts(
+			5*time.Second,  // dialTimeout
+			5*time.Second,  // tlsHandshakeTimeout
+			5*time.Second,  // responseHeaderTimeout
+			20*time.Second, // requestTimeout
+		),
+		thirdparty.WithMaxRetries(5),
 	)
 
 	// Ensure baseURL doesn't end with a slash

--- a/services/wallet/thirdparty/market/cryptocompare/client_test.go
+++ b/services/wallet/thirdparty/market/cryptocompare/client_test.go
@@ -1,6 +1,7 @@
 package cryptocompare
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,4 +15,67 @@ func TestIDs(t *testing.T) {
 		ID: "testID",
 	})
 	require.Equal(t, "testID", clientWithParams.ID())
+}
+
+func TestBuildURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseURL  string
+		path     string
+		expected string
+	}{
+		{
+			name:     "base URL without trailing slash, path without leading slash",
+			baseURL:  "https://example.com",
+			path:     "api/v1/endpoint",
+			expected: "https://example.com/api/v1/endpoint",
+		},
+		{
+			name:     "base URL with trailing slash, path without leading slash",
+			baseURL:  "https://example.com/",
+			path:     "api/v1/endpoint",
+			expected: "https://example.com/api/v1/endpoint",
+		},
+		{
+			name:     "base URL without trailing slash, path with leading slash",
+			baseURL:  "https://example.com",
+			path:     "/api/v1/endpoint",
+			expected: "https://example.com/api/v1/endpoint",
+		},
+		{
+			name:     "base URL with trailing slash, path with leading slash",
+			baseURL:  "https://example.com/",
+			path:     "/api/v1/endpoint",
+			expected: "https://example.com/api/v1/endpoint",
+		},
+		{
+			name:     "base URL with multiple trailing slashes",
+			baseURL:  "https://example.com///",
+			path:     "api/v1/endpoint",
+			expected: "https://example.com/api/v1/endpoint",
+		},
+		{
+			name:     "path with multiple leading slashes",
+			baseURL:  "https://example.com",
+			path:     "///api/v1/endpoint",
+			expected: "https://example.com/api/v1/endpoint",
+		},
+		{
+			name:     "empty path",
+			baseURL:  "https://example.com",
+			path:     "",
+			expected: "https://example.com/",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Simulate the NewClientWithParams behavior which trims trailing slashes
+			baseURL := strings.TrimSuffix(tc.baseURL, "/")
+			client := &Client{baseURL: baseURL}
+
+			result := client.buildURL(tc.path)
+			require.Equal(t, tc.expected, result)
+		})
+	}
 }

--- a/services/wallet/token/token-lists/fetcher/fetcher.go
+++ b/services/wallet/token/token-lists/fetcher/fetcher.go
@@ -42,8 +42,16 @@ type TokenListsFetcher struct {
 // NewTokenListsFetcher creates a new instance of TokenListsFetcher.
 func NewTokenListsFetcher(walletDb *sql.DB) *TokenListsFetcher {
 	return &TokenListsFetcher{
-		walletDb:   walletDb,
-		httpClient: thirdparty.NewHTTPClientWithDetailedTimeouts(dialTimeout, tlsHandshakeTimeout, responseHeaderTimeout, requestTimeout, retries),
+		walletDb: walletDb,
+		httpClient: thirdparty.NewHTTPClient(
+			thirdparty.WithDetailedTimeouts(
+				dialTimeout,
+				tlsHandshakeTimeout,
+				responseHeaderTimeout,
+				requestTimeout,
+			),
+			thirdparty.WithMaxRetries(retries),
+		),
 	}
 }
 


### PR DESCRIPTION
Main changes:
* `market.go` - increased timeout for a market request (see details https://github.com/status-im/status-mobile/issues/22203#issuecomment-2690498346)
* `wallet/thirdparty/http_client.go` - increase timeout from 5 seconds total to (5-5-5-60)

Added more diagnostic information:
* `circuit_breaker.go` - log additional responseSize (if any), duration, timeout cancellation
* Not market related: additional information in blockchain_health status

+ tests

Fixes status-im/status-mobile#22203