### PR TITLE
refactor(services)_: use slices.Equal to simplify code

### DIFF
--- a/services/wallet/testutils/helpers.go
+++ b/services/wallet/testutils/helpers.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"reflect"
+	"slices"
 	"sort"
 
 	"go.uber.org/mock/gomock"
@@ -67,13 +68,7 @@ func (m *AddressSliceMatcher) Matches(x interface{}) bool {
 	sort.Slice(expectedCopy, func(i, j int) bool { return expectedCopy[i].Hex() < expectedCopy[j].Hex() })
 	sort.Slice(actualCopy, func(i, j int) bool { return actualCopy[i].Hex() < actualCopy[j].Hex() })
 
-	for i := range expectedCopy {
-		if expectedCopy[i] != actualCopy[i] {
-			return false
-		}
-	}
-
-	return true
+	return slices.Equal(expectedCopy, actualCopy)
 }
 
 func (m *AddressSliceMatcher) String() string {
@@ -108,13 +103,7 @@ func (m *Uint64SliceMatcher) Matches(x interface{}) bool {
 	sort.Slice(expectedCopy, func(i, j int) bool { return expectedCopy[i] < expectedCopy[j] })
 	sort.Slice(actualCopy, func(i, j int) bool { return actualCopy[i] < actualCopy[j] })
 
-	for i := range expectedCopy {
-		if expectedCopy[i] != actualCopy[i] {
-			return false
-		}
-	}
-
-	return true
+	return slices.Equal(expectedCopy, actualCopy)
 }
 
 func (m *Uint64SliceMatcher) String() string {


### PR DESCRIPTION
In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).



Important changes:
- [x] Something worth noting for reviewers.

Closes #
