### PR TITLE
fix_: retryDnsDiscoveryWithBackoff nil pointer dereference

### DIFF
--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -420,8 +420,11 @@ func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string, 
 				defer gocommon.LogOnPanic()
 				defer wg.Done()
 				if err := w.dnsDiscover(ctx, addr, retrieveENR, useOnlyDnsDiscCache); err != nil {
+					// prevent w.ctx in retryDnsDiscoveryWithBackoff from set to nil when w.Stop() is called
+					w.wg.Add(1)
 					go func() {
 						defer gocommon.LogOnPanic()
+						defer w.wg.Done()
 						w.retryDnsDiscoveryWithBackoff(ctx, addr, w.dnsDiscAsyncRetrievedSignal)
 					}()
 				}
@@ -514,13 +517,8 @@ func (w *Waku) retryDnsDiscoveryWithBackoff(ctx context.Context, addr string, su
 		}
 
 		t := time.NewTimer(backoff)
-		c := w.ctx
-		// c might be nil when w.Stop is invoked while this goroutine is running
-		if c == nil {
-			return
-		}
 		select {
-		case <-c.Done():
+		case <-w.ctx.Done():
 			t.Stop()
 			return
 		case <-t.C:

--- a/wakuv2/waku.go
+++ b/wakuv2/waku.go
@@ -514,8 +514,13 @@ func (w *Waku) retryDnsDiscoveryWithBackoff(ctx context.Context, addr string, su
 		}
 
 		t := time.NewTimer(backoff)
+		c := w.ctx
+		// c might be nil when w.Stop is invoked while this goroutine is running
+		if c == nil {
+			return
+		}
 		select {
-		case <-w.ctx.Done():
+		case <-c.Done():
 			t.Stop()
 			return
 		case <-t.C:


### PR DESCRIPTION
This issue is a bit hidden and might impact logout XP, it depends on `dnsDiscover` return err, sometimes the same `addr` `enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im`  works fine, sometimes it returns DNSError i/o timeout. So the addr is not that stable which also caused another test issue before like `test timed out after 5m0s`

Reproduce steps:
- update code to make [dnsDiscover](https://github.com/status-im/status-go/blob/1e1df751c12a91177a88d6f963cc2f9e03af0380/wakuv2waku.go#L422) return err to invoke [retryDnsDiscoveryWithBackoff](https://github.com/status-im/status-go/blob/1e1df751c12a91177a88d6f963cc2f9e03af0380/wakuv2/waku.go#L425)  
- make [dnsDiscover](https://github.com/status-im/status-go/blob/1e1df751c12a91177a88d6f963cc2f9e03af0380/wakuv2/waku.go#L500) return err so that the `for` loop won't break
- add a line `time.Sleep(3*time.Seconds)` before [NewTimer](https://github.com/status-im/status-go/blob/1e1df751c12a91177a88d6f963cc2f9e03af0380/wakuv2/waku.go#L516)
- run test that will invoke `logout` e.g. `TestPairDeclineContactRequest` multi times

Closes #6366