### PR TITLE
fix(wallet)_: ensure contract type is present when refreshing collecti…

### DIFF
--- a/services/wallet/collectibles/commands.go
+++ b/services/wallet/collectibles/commands.go
@@ -63,7 +63,7 @@ type periodicRefreshOwnedCollectiblesCommand struct {
 	chainID                   walletCommon.ChainID
 	account                   common.Address
 	manager                   *Manager
-	ownershipDB               *OwnershipDB
+	ownershipDB               OwnershipStorage
 	walletFeed                *event.Feed
 	ownedCollectiblesChangeCb OwnedCollectiblesChangeCb
 
@@ -73,7 +73,7 @@ type periodicRefreshOwnedCollectiblesCommand struct {
 
 func newPeriodicRefreshOwnedCollectiblesCommand(
 	manager *Manager,
-	ownershipDB *OwnershipDB,
+	ownershipDB OwnershipStorage,
 	walletFeed *event.Feed,
 	chainID walletCommon.ChainID,
 	account common.Address,
@@ -161,7 +161,7 @@ type loadOwnedCollectiblesCommand struct {
 	chainID                   walletCommon.ChainID
 	account                   common.Address
 	manager                   *Manager
-	ownershipDB               *OwnershipDB
+	ownershipDB               OwnershipStorage
 	walletFeed                *event.Feed
 	ownedCollectiblesChangeCh chan<- OwnedCollectiblesChange
 
@@ -172,7 +172,7 @@ type loadOwnedCollectiblesCommand struct {
 
 func newLoadOwnedCollectiblesCommand(
 	manager *Manager,
-	ownershipDB *OwnershipDB,
+	ownershipDB OwnershipStorage,
 	walletFeed *event.Feed,
 	chainID walletCommon.ChainID,
 	account common.Address,

--- a/services/wallet/collectibles/controller.go
+++ b/services/wallet/collectibles/controller.go
@@ -36,7 +36,7 @@ type timerPerAddressAndChainID = map[common.Address]timerPerChainID
 
 type Controller struct {
 	manager      *Manager
-	ownershipDB  *OwnershipDB
+	ownershipDB  OwnershipStorage
 	walletFeed   *event.Feed
 	accountsDB   *accounts.Database
 	accountsFeed *event.Feed

--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -63,8 +63,8 @@ type Manager struct {
 
 	collectiblesDataDB CollectibleDataStorage
 	collectionsDataDB  CollectionDataStorage
-	communityManager   *community.Manager
-	ownershipDB        *OwnershipDB
+	communityManager   community.CommunityManagerInterface
+	ownershipDB        OwnershipStorage
 
 	mediaServer *server.MediaServer
 
@@ -77,12 +77,12 @@ type Manager struct {
 func NewManager(
 	db *sql.DB,
 	rpcClient rpc.ClientInterface,
-	communityManager *community.Manager,
+	communityManager community.CommunityManagerInterface,
 	providers thirdparty.CollectibleProviders,
 	mediaServer *server.MediaServer,
 	feed *event.Feed) *Manager {
 
-	var ownershipDB *OwnershipDB
+	var ownershipDB OwnershipStorage
 	var statuses *sync.Map
 	var statusNotifier *connection.StatusNotifier
 	if db != nil {
@@ -1222,7 +1222,7 @@ func (o *Manager) updateStatusNotifier() {
 	o.statusNotifier = createStatusNotifier(o.statuses, o.feed)
 }
 
-func initStatuses(ownershipDB *OwnershipDB) *sync.Map {
+func initStatuses(ownershipDB OwnershipStorage) *sync.Map {
 	statuses := &sync.Map{}
 	for _, chainID := range walletCommon.AllChainIDs() {
 		status := connection.NewStatus()

--- a/services/wallet/collectibles/manager_test.go
+++ b/services/wallet/collectibles/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/bigint"
 	mock_collectibles "github.com/status-im/status-go/services/wallet/collectibles/mock"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
+	mock_community "github.com/status-im/status-go/services/wallet/community/mock"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	mock_thirdparty "github.com/status-im/status-go/services/wallet/thirdparty/mock"
 )
@@ -101,11 +102,42 @@ func TestManager_FetchAllAssetsByOwner(t *testing.T) {
 	manager.statuses = &sync.Map{}
 	collectiblesDataDB := mock_collectibles.NewMockCollectibleDataStorage(mockCtrl)
 	collectiblesDataDB.EXPECT().SetData(gomock.Any(), gomock.Any()).Return(nil)
+	collectiblesDataDB.EXPECT().GetData(gomock.Any()).DoAndReturn(func(ids []thirdparty.CollectibleUniqueID) (map[string]thirdparty.CollectibleData, error) {
+		ret := make(map[string]thirdparty.CollectibleData)
+		for _, id := range ids {
+			ret[id.HashKey()] = thirdparty.CollectibleData{
+				ID: id,
+			}
+		}
+		return ret, nil
+	})
+	collectiblesDataDB.EXPECT().GetCommunityInfo(gomock.Any()).Return(&thirdparty.CollectibleCommunityInfo{}, nil).AnyTimes()
+
 	collectionsDataDB := mock_collectibles.NewMockCollectionDataStorage(mockCtrl)
 	collectionsDataDB.EXPECT().SetData(gomock.Any(), gomock.Any()).Return(nil)
+	collectionsDataDB.EXPECT().GetData(gomock.Any()).DoAndReturn(func(ids []thirdparty.ContractID) (map[string]thirdparty.CollectionData, error) {
+		ret := make(map[string]thirdparty.CollectionData)
+		for _, id := range ids {
+			ret[id.HashKey()] = thirdparty.CollectionData{
+				ID: id,
+			}
+		}
+		return ret, nil
+	})
+
+	communityManager := mock_community.NewMockCommunityManagerInterface(mockCtrl)
+	communityManager.EXPECT().GetCommunityID(gomock.Any()).Return(providerID).AnyTimes()
+	communityManager.EXPECT().FillCollectiblesMetadata(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+	communityManager.EXPECT().GetCommunityInfo(gomock.Any()).Return(&thirdparty.CommunityInfo{}, nil, nil).AnyTimes()
+
+	ownershipDB := mock_collectibles.NewMockOwnershipStorage(mockCtrl)
+	ownershipDB.EXPECT().GetLatestOwnershipUpdateTimestamp(gomock.Any()).Return(int64(0), nil).AnyTimes()
+	ownershipDB.EXPECT().GetOwnership(gomock.Any()).Return([]thirdparty.AccountBalance{}, nil).AnyTimes()
+
 	manager.collectiblesDataDB = collectiblesDataDB
 	manager.collectionsDataDB = collectionsDataDB
-
+	manager.communityManager = communityManager
+	manager.ownershipDB = ownershipDB
 	assetContainer, err := manager.FetchAllAssetsByOwner(ctx, chainID, owner, cursor, limit, providerID)
 
 	assert.NoError(t, err)

--- a/services/wallet/collectibles/ownership_db.go
+++ b/services/wallet/collectibles/ownership_db.go
@@ -1,5 +1,7 @@
 package collectibles
 
+//go:generate mockgen -package=mock_collectibles -source=ownership_db.go -destination=mock/ownership_db.go
+
 import (
 	"database/sql"
 	"fmt"
@@ -17,6 +19,21 @@ import (
 )
 
 const InvalidTimestamp = int64(-1)
+
+type OwnershipStorage interface {
+	GetOwnership(id thirdparty.CollectibleUniqueID) ([]thirdparty.AccountBalance, error)
+	Update(chainID w_common.ChainID, ownerAddress common.Address, balances thirdparty.TokenBalancesPerContractAddress, timestamp int64) (removedIDs, updatedIDs, insertedIDs []thirdparty.CollectibleUniqueID, err error)
+	SetTransferID(ownerAddress common.Address, id thirdparty.CollectibleUniqueID, transferID common.Hash) (bool, error)
+	GetTransferID(ownerAddress common.Address, id thirdparty.CollectibleUniqueID) (*common.Hash, error)
+	GetCollectiblesWithNoTransferID(account common.Address, chainID w_common.ChainID) ([]thirdparty.CollectibleUniqueID, error)
+	GetLatestOwnershipUpdateTimestamp(chainID w_common.ChainID) (int64, error)
+	GetOwnedCollectibles(chainIDs []w_common.ChainID, ownerAddresses []common.Address, offset int, limit int) ([]thirdparty.CollectibleUniqueID, error)
+	FetchCachedCollectibleOwnersByContractAddress(chainID w_common.ChainID, contractAddress common.Address) (*thirdparty.CollectibleContractOwnership, error)
+	GetOwnedCollectible(chainID w_common.ChainID, ownerAddresses common.Address, contractAddress common.Address, tokenID *big.Int) (*thirdparty.CollectibleUniqueID, error)
+	GetIsFirstOfCollection(onwerAddress common.Address, newIDs []thirdparty.CollectibleUniqueID) (map[thirdparty.CollectibleUniqueID]bool, error)
+	GetIDsNotInDB(ownerAddress common.Address, newIDs []thirdparty.CollectibleUniqueID) ([]thirdparty.CollectibleUniqueID, error)
+	GetOwnershipUpdateTimestamp(owner common.Address, chainID w_common.ChainID) (int64, error)
+}
 
 type OwnershipDB struct {
 	db *sql.DB

--- a/services/wallet/collectibles/service.go
+++ b/services/wallet/collectibles/service.go
@@ -94,7 +94,7 @@ type Service struct {
 	manager          *Manager
 	controller       *Controller
 	db               *sql.DB
-	ownershipDB      *OwnershipDB
+	ownershipDB      OwnershipStorage
 	transferDB       *transfer.Database
 	communityManager *community.Manager
 	walletFeed       *event.Feed

--- a/services/wallet/community/manager.go
+++ b/services/wallet/community/manager.go
@@ -1,5 +1,7 @@
 package community
 
+//go:generate mockgen -package=mock_community -source=manager.go -destination=mock/manager.go
+
 import (
 	"database/sql"
 	"encoding/json"
@@ -13,6 +15,13 @@ import (
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/services/wallet/walletevent"
 )
+
+type CommunityManagerInterface interface {
+	FetchCommunityInfo(communityID string) (*thirdparty.CommunityInfo, error)
+	GetCommunityInfo(id string) (*thirdparty.CommunityInfo, *InfoState, error)
+	GetCommunityID(tokenURI string) string
+	FillCollectiblesMetadata(communityID string, cs []*thirdparty.FullCollectibleData) (bool, error)
+}
 
 // These events are used to notify the UI of state changes
 const (


### PR DESCRIPTION
…ble balances

Fixes https://github.com/status-im/status-desktop/issues/17474

We got a bad condition in cases where:
- Contract type is not provided by collectibles provider
- Contract type is already present in the db (by having fetched collection metadata before)
- We want to refresh assets balances for ERC1155 collectibles

In this condition, we were getting contract type value `Unknown` even though the proper contract type was present in the DB. This PR ensures we get that value after processing the collectibles metadata.

A short summary which serves as a squashed-commit message.

A description to understand introduced changes without reading the code.

Important changes:
- [x] Something worth noting for reviewers.

Closes #
