### PR TITLE
chore(wallet)_: token related types moved from the token to tokentypes package

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -43,6 +43,7 @@ import (
 	walletcommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/signal"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
@@ -251,7 +252,7 @@ type managerOptions struct {
 type TokenManager interface {
 	GetBalancesByChain(ctx context.Context, accounts, tokens []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error)
 	GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error)
-	FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *token.Token
+	FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token
 	GetAllChainIDs() ([]uint64, error)
 }
 
@@ -332,7 +333,7 @@ func (m *DefaultTokenManager) GetCachedBalancesByChain(ctx context.Context, acco
 	return resp, nil
 }
 
-func (m *DefaultTokenManager) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *token.Token {
+func (m *DefaultTokenManager) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token {
 	return m.tokenManager.FindOrCreateTokenByAddress(ctx, chainID, address)
 }
 

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/bigint"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/t/helpers"
 	wakutypes "github.com/status-im/status-go/waku/types"
 
@@ -201,7 +201,7 @@ func (m *testTokenManager) GetCachedBalancesByChain(ctx context.Context, account
 	return m.response, nil
 }
 
-func (m *testTokenManager) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *token.Token {
+func (m *testTokenManager) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token {
 	return nil
 }
 

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/bigint"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
-	walletToken "github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
@@ -112,7 +112,7 @@ func (m *TokenManagerMock) GetCachedBalancesByChain(ctx context.Context, account
 	return m.getBalanceBasedOnParams(accounts, tokenAddresses, chainIDs), nil
 }
 
-func (m *TokenManagerMock) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *walletToken.Token {
+func (m *TokenManagerMock) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token {
 	time.Sleep(100 * time.Millisecond) // simulate response time
 	return nil
 }

--- a/services/wallet/activity/activity_v2.go
+++ b/services/wallet/activity/activity_v2.go
@@ -18,7 +18,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/requests"
 	pathProcessorCommon "github.com/status-im/status-go/services/wallet/router/pathprocessor/common"
 	"github.com/status-im/status-go/services/wallet/router/routes"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/services/wallet/transfer"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 	"github.com/status-im/status-go/sqlite"
@@ -46,18 +46,18 @@ func getActivityEntriesV2(ctx context.Context, deps FilterDependencies, addresse
 		tt.timestamp
 		`).Distinct()
 	q = q.From("sent_transactions st").
-		LeftJoin(`route_path_transactions rpt ON 
-			st.chain_id = rpt.chain_id AND 
+		LeftJoin(`route_path_transactions rpt ON
+			st.chain_id = rpt.chain_id AND
 			st.tx_hash = rpt.tx_hash`).
-		LeftJoin(`tracked_transactions tt ON 
-			st.chain_id = tt.chain_id AND 
+		LeftJoin(`tracked_transactions tt ON
+			st.chain_id = tt.chain_id AND
 			st.tx_hash = tt.tx_hash`).
-		LeftJoin(`route_paths rp ON 
-			rpt.uuid = rp.uuid AND 
+		LeftJoin(`route_paths rp ON
+			rpt.uuid = rp.uuid AND
 			rpt.path_idx = rp.path_idx`).
-		LeftJoin(`route_build_tx_parameters rbtp ON 
+		LeftJoin(`route_build_tx_parameters rbtp ON
 			rpt.uuid = rbtp.uuid`).
-		LeftJoin(`route_input_parameters rip ON 
+		LeftJoin(`route_input_parameters rip ON
 			rpt.uuid = rip.uuid`)
 	q = q.OrderBy("tt.timestamp DESC", "rpt.is_approval ASC")
 
@@ -273,7 +273,7 @@ func getFinalizationPeriod(chainID wCommon.ChainID) int64 {
 	return L2FinalizationDuration
 }
 
-func getTransferType(fromToken *token.Token, processorName string) *TransferType {
+func getTransferType(fromToken *tokenTypes.Token, processorName string) *TransferType {
 	ret := new(TransferType)
 
 	switch processorName {
@@ -294,7 +294,7 @@ func getTransferType(fromToken *token.Token, processorName string) *TransferType
 	return ret
 }
 
-func getToken(token *token.Token, processorName string) *Token {
+func getToken(token *tokenTypes.Token, processorName string) *Token {
 	if token == nil {
 		return nil
 	}

--- a/services/wallet/activity/service_test.go
+++ b/services/wallet/activity/service_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/status-im/status-go/services/wallet/bigint"
 	"github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
-	"github.com/status-im/status-go/services/wallet/token"
 	mock_token "github.com/status-im/status-go/services/wallet/token/mock/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/services/wallet/transfer"
 	"github.com/status-im/status-go/services/wallet/walletevent"
 	"github.com/status-im/status-go/t/helpers"
@@ -149,7 +149,7 @@ func TestService_UpdateCollectibleInfo(t *testing.T) {
 
 	// Expect one call for the fungible token
 	state.tokenMock.EXPECT().LookupTokenIdentity(uint64(5), eth.HexToAddress("0x3d6afaa395c31fcd391fe3d562e75fe9e8ec7e6a"), false).Return(
-		&token.Token{
+		&tokenTypes.Token{
 			ChainID: 5,
 			Address: eth.HexToAddress("0x3d6afaa395c31fcd391fe3d562e75fe9e8ec7e6a"),
 			Symbol:  "STT",
@@ -311,7 +311,7 @@ func setupTransactions(t *testing.T, state testState, txCount int, testTxs []tra
 	allAddresses = append(append(allAddresses, fromTrs...), toTrs...)
 
 	state.tokenMock.EXPECT().LookupTokenIdentity(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&token.Token{
+		&tokenTypes.Token{
 			ChainID: 5,
 			Address: eth.Address{},
 			Symbol:  "ETH",
@@ -319,7 +319,7 @@ func setupTransactions(t *testing.T, state testState, txCount int, testTxs []tra
 	).AnyTimes()
 
 	state.tokenMock.EXPECT().LookupToken(gomock.Any(), gomock.Any()).Return(
-		&token.Token{
+		&tokenTypes.Token{
 			ChainID: 5,
 			Address: eth.Address{},
 			Symbol:  "ETH",

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -38,6 +38,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/router/pathprocessor"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/services/wallet/transfer"
 	"github.com/status-im/status-go/services/wallet/walletconnect"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
@@ -85,7 +86,7 @@ func (api *API) GetBalancesByChain(ctx context.Context, chainIDs []uint64, addre
 	return api.s.tokenManager.GetBalancesByChain(ctx, clients, addresses, tokens)
 }
 
-func (api *API) FetchOrGetCachedWalletBalances(ctx context.Context, addresses []common.Address, forceRefresh bool) (map[common.Address][]token.StorageToken, error) {
+func (api *API) FetchOrGetCachedWalletBalances(ctx context.Context, addresses []common.Address, forceRefresh bool) (map[common.Address][]tokenTypes.StorageToken, error) {
 	activeNetworks, err := api.s.rpcClient.NetworkManager.GetActiveNetworks()
 	if err != nil {
 		return nil, err
@@ -214,13 +215,13 @@ func (api *API) GetTokenList(ctx context.Context) (*token.ListWrapper, error) {
 	return rst, nil
 }
 
-func (api *API) GetTokensAvailableForBridgeOnChain(ctx context.Context, chainID uint64) []*token.Token {
+func (api *API) GetTokensAvailableForBridgeOnChain(ctx context.Context, chainID uint64) []*tokenTypes.Token {
 	logutils.ZapLogger().Debug("call to get tokens available for bridge on chain")
 	return api.s.router.GetTokensAvailableForBridgeOnChain(chainID)
 }
 
 // @deprecated
-func (api *API) GetTokens(ctx context.Context, chainID uint64) ([]*token.Token, error) {
+func (api *API) GetTokens(ctx context.Context, chainID uint64) ([]*tokenTypes.Token, error) {
 	logutils.ZapLogger().Debug("call to get tokens")
 	rst, err := api.s.tokenManager.GetTokens(chainID)
 	logutils.ZapLogger().Debug("result from token store", zap.Int("len", len(rst)))
@@ -228,20 +229,20 @@ func (api *API) GetTokens(ctx context.Context, chainID uint64) ([]*token.Token, 
 }
 
 // @deprecated
-func (api *API) GetCustomTokens(ctx context.Context) ([]*token.Token, error) {
+func (api *API) GetCustomTokens(ctx context.Context) ([]*tokenTypes.Token, error) {
 	logutils.ZapLogger().Debug("call to get custom tokens")
 	rst, err := api.s.tokenManager.GetCustoms(true)
 	logutils.ZapLogger().Debug("result from database for custom tokens", zap.Int("len", len(rst)))
 	return rst, err
 }
 
-func (api *API) DiscoverToken(ctx context.Context, chainID uint64, address common.Address) (*token.Token, error) {
+func (api *API) DiscoverToken(ctx context.Context, chainID uint64, address common.Address) (*tokenTypes.Token, error) {
 	logutils.ZapLogger().Debug("call to get discover token")
 	token, err := api.s.tokenManager.DiscoverToken(ctx, chainID, address)
 	return token, err
 }
 
-func (api *API) AddCustomToken(ctx context.Context, token token.Token) error {
+func (api *API) AddCustomToken(ctx context.Context, token tokenTypes.Token) error {
 	logutils.ZapLogger().Debug("call to create or edit custom token")
 	if token.ChainID == 0 {
 		token.ChainID = api.s.rpcClient.UpstreamChainID

--- a/services/wallet/api_test.go
+++ b/services/wallet/api_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/onramp"
 	mock_onramp "github.com/status-im/status-go/services/wallet/onramp/mock"
 	"github.com/status-im/status-go/services/wallet/requests"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/services/wallet/walletconnect"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/walletdatabase"
@@ -252,13 +252,13 @@ func TestAPI_FetchOrGetCachedWalletBalances(t *testing.T) {
 
 	testTokenAddress1 := common.Address{0x34}
 	testAccAddress1 := common.Address{0x12}
-	storageToken := token.StorageToken{
-		Token: token.Token{
+	storageToken := tokenTypes.StorageToken{
+		Token: tokenTypes.Token{
 			Name:     "USD Tether",
 			Symbol:   "USDT",
 			Decimals: 18,
 		},
-		BalancesPerChain: map[uint64]token.ChainBalance{
+		BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 			1: {
 				RawBalance: "1000000000000000000",
 				Balance:    nil,
@@ -268,7 +268,7 @@ func TestAPI_FetchOrGetCachedWalletBalances(t *testing.T) {
 			},
 		},
 	}
-	expectedTokens := map[common.Address][]token.StorageToken{
+	expectedTokens := map[common.Address][]tokenTypes.StorageToken{
 		testAccAddress1: {storageToken},
 	}
 

--- a/services/wallet/onramp/provider_mercuryo.go
+++ b/services/wallet/onramp/provider_mercuryo.go
@@ -14,6 +14,7 @@ import (
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty/mercuryo"
 	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 const mercuryoID = "mercuryo"
@@ -21,7 +22,7 @@ const mercuryioNoFeesBaseURL = "https://exchange.mercuryo.io/?type=buy&networks=
 const supportedAssetsUpdateInterval = 24 * time.Hour
 
 type MercuryoProvider struct {
-	supportedTokens          []*token.Token
+	supportedTokens          []*tokenTypes.Token
 	supportedTokensTimestamp time.Time
 	supportedTokensLock      sync.RWMutex
 	httpClient               *mercuryo.Client
@@ -64,7 +65,7 @@ func (p *MercuryoProvider) GetCryptoOnRamp(ctx context.Context) (CryptoOnRamp, e
 	return provider, err
 }
 
-func (p *MercuryoProvider) getSupportedCurrencies(ctx context.Context) ([]*token.Token, error) {
+func (p *MercuryoProvider) getSupportedCurrencies(ctx context.Context) ([]*tokenTypes.Token, error) {
 	p.supportedTokensLock.Lock()
 	defer p.supportedTokensLock.Unlock()
 
@@ -77,7 +78,7 @@ func (p *MercuryoProvider) getSupportedCurrencies(ctx context.Context) ([]*token
 		return p.supportedTokens, err
 	}
 
-	newSupportedTokens := make([]*token.Token, 0, len(newSupportedCurrencies))
+	newSupportedTokens := make([]*tokenTypes.Token, 0, len(newSupportedCurrencies))
 	for _, currency := range newSupportedCurrencies {
 		chainID := mercuryo.NetworkToCommonChainID(currency.Network)
 		if chainID == walletCommon.UnknownChainID {

--- a/services/wallet/onramp/types.go
+++ b/services/wallet/onramp/types.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 type Provider interface {
@@ -24,17 +24,17 @@ type Parameters struct {
 }
 
 type CryptoOnRamp struct {
-	ID                        string         `json:"id"`
-	Name                      string         `json:"name"`
-	Description               string         `json:"description"`
-	Fees                      string         `json:"fees"`
-	LogoURL                   string         `json:"logoUrl"`
-	Hostname                  string         `json:"hostname"`
-	SupportsSinglePurchase    bool           `json:"supportsSinglePurchase"`
-	SupportsRecurrentPurchase bool           `json:"supportsRecurrentPurchase"`
-	SupportedChainIDs         []uint64       `json:"supportedChainIds"`
-	SupportedTokens           []*token.Token `json:"supportedTokens"`    // Empty array means supported assets are not specified
-	URLsNeedParameters        bool           `json:"urlsNeedParameters"` // True means Parameters are required for URL generation
+	ID                        string              `json:"id"`
+	Name                      string              `json:"name"`
+	Description               string              `json:"description"`
+	Fees                      string              `json:"fees"`
+	LogoURL                   string              `json:"logoUrl"`
+	Hostname                  string              `json:"hostname"`
+	SupportsSinglePurchase    bool                `json:"supportsSinglePurchase"`
+	SupportsRecurrentPurchase bool                `json:"supportsRecurrentPurchase"`
+	SupportedChainIDs         []uint64            `json:"supportedChainIds"`
+	SupportedTokens           []*tokenTypes.Token `json:"supportedTokens"`    // Empty array means supported assets are not specified
+	URLsNeedParameters        bool                `json:"urlsNeedParameters"` // True means Parameters are required for URL generation
 	// Deprecated fields below, only used by mobile
 	Params           map[string]string `json:"params"`
 	SiteURL          string            `json:"siteUrl"`          // Replaced by call to GetURL

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -20,6 +20,7 @@ import (
 	"github.com/status-im/status-go/rpc/chain"
 	"github.com/status-im/status-go/services/wallet/market"
 	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/services/wallet/transfer"
 	"github.com/status-im/status-go/services/wallet/walletevent"
 )
@@ -48,9 +49,9 @@ type ReaderInterface interface {
 	Start() error
 	Stop()
 	Restart() error
-	FetchOrGetCachedWalletBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address, forceRefresh bool) (map[common.Address][]token.StorageToken, error)
-	FetchBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address) (map[common.Address][]token.StorageToken, error)
-	GetCachedBalances(clients map[uint64]chain.ClientInterface, addresses []common.Address) (map[common.Address][]token.StorageToken, error)
+	FetchOrGetCachedWalletBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address, forceRefresh bool) (map[common.Address][]tokenTypes.StorageToken, error)
+	FetchBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address) (map[common.Address][]tokenTypes.StorageToken, error)
+	GetCachedBalances(clients map[uint64]chain.ClientInterface, addresses []common.Address) (map[common.Address][]tokenTypes.StorageToken, error)
 	GetLastTokenUpdateTimestamps() map[common.Address]int64
 }
 
@@ -77,9 +78,9 @@ type Reader struct {
 	rw                             sync.RWMutex
 }
 
-func splitVerifiedTokens(tokens []*token.Token) ([]*token.Token, []*token.Token) {
-	verified := make([]*token.Token, 0)
-	unverified := make([]*token.Token, 0)
+func splitVerifiedTokens(tokens []*tokenTypes.Token) ([]*tokenTypes.Token, []*tokenTypes.Token) {
+	verified := make([]*tokenTypes.Token, 0)
+	unverified := make([]*tokenTypes.Token, 0)
 
 	for _, t := range tokens {
 		if t.Verified {
@@ -92,12 +93,12 @@ func splitVerifiedTokens(tokens []*token.Token) ([]*token.Token, []*token.Token)
 	return verified, unverified
 }
 
-func getTokenBySymbols(tokens []*token.Token) map[string][]*token.Token {
-	res := make(map[string][]*token.Token)
+func getTokenBySymbols(tokens []*tokenTypes.Token) map[string][]*tokenTypes.Token {
+	res := make(map[string][]*tokenTypes.Token)
 
 	for _, t := range tokens {
 		if _, ok := res[t.Symbol]; !ok {
-			res[t.Symbol] = make([]*token.Token, 0)
+			res[t.Symbol] = make([]*tokenTypes.Token, 0)
 		}
 
 		res[t.Symbol] = append(res[t.Symbol], t)
@@ -106,7 +107,7 @@ func getTokenBySymbols(tokens []*token.Token) map[string][]*token.Token {
 	return res
 }
 
-func getTokenAddresses(tokens []*token.Token) []common.Address {
+func getTokenAddresses(tokens []*tokenTypes.Token) []common.Address {
 	set := make(map[common.Address]bool)
 	for _, token := range tokens {
 		set[token.Address] = true
@@ -270,7 +271,7 @@ func (r *Reader) invalidateBalanceCache() {
 	r.refreshBalanceCache = true
 }
 
-func (r *Reader) FetchOrGetCachedWalletBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address, forceRefresh bool) (map[common.Address][]token.StorageToken, error) {
+func (r *Reader) FetchOrGetCachedWalletBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address, forceRefresh bool) (map[common.Address][]tokenTypes.StorageToken, error) {
 	needFetch := forceRefresh || !r.isBalanceCacheValid(addresses) || r.isBalanceUpdateNeededAnyway(clients, addresses)
 
 	if needFetch {
@@ -317,7 +318,7 @@ func (r *Reader) isBalanceUpdateNeededAnyway(clients map[uint64]chain.ClientInte
 	return updateAnyway
 }
 
-func tokensToBalancesPerChain(cachedTokens map[common.Address][]token.StorageToken) map[uint64]map[common.Address]map[common.Address]*hexutil.Big {
+func tokensToBalancesPerChain(cachedTokens map[common.Address][]tokenTypes.StorageToken) map[uint64]map[common.Address]map[common.Address]*hexutil.Big {
 	cachedBalancesPerChain := map[uint64]map[common.Address]map[common.Address]*hexutil.Big{}
 	for address, tokens := range cachedTokens {
 		for _, token := range tokens {
@@ -350,13 +351,13 @@ func (r *Reader) fetchBalances(ctx context.Context, clients map[uint64]chain.Cli
 
 func toChainBalance(
 	balances map[uint64]map[common.Address]map[common.Address]*hexutil.Big,
-	tok *token.Token,
+	tok *tokenTypes.Token,
 	address common.Address,
 	decimals uint,
-	cachedTokens map[common.Address][]token.StorageToken,
+	cachedTokens map[common.Address][]tokenTypes.StorageToken,
 	hasError bool,
 	isMandatoryToken bool,
-) *token.ChainBalance {
+) *tokenTypes.ChainBalance {
 	hexBalance := &big.Int{}
 	if balances != nil {
 		hexBalance = balances[tok.ChainID][address][tok.Address].ToInt()
@@ -375,7 +376,7 @@ func toChainBalance(
 		return nil
 	}
 
-	return &token.ChainBalance{
+	return &tokenTypes.ChainBalance{
 		RawBalance:     hexBalance.String(),
 		Balance:        balance,
 		Balance1DayAgo: "0",
@@ -385,7 +386,7 @@ func toChainBalance(
 	}
 }
 
-func (r *Reader) getBalance1DayAgo(balance *token.ChainBalance, dayAgoTimestamp int64, symbol string, address common.Address) (*big.Int, error) {
+func (r *Reader) getBalance1DayAgo(balance *tokenTypes.ChainBalance, dayAgoTimestamp int64, symbol string, address common.Address) (*big.Int, error) {
 	balance1DayAgo, err := r.tokenManager.GetTokenHistoricalBalance(address, balance.ChainID, symbol, dayAgoTimestamp)
 	if err != nil {
 		logutils.ZapLogger().Error("tokenManager.GetTokenHistoricalBalance error", zap.Error(err))
@@ -395,22 +396,22 @@ func (r *Reader) getBalance1DayAgo(balance *token.ChainBalance, dayAgoTimestamp 
 	return balance1DayAgo, nil
 }
 
-func (r *Reader) balancesToTokensByAddress(connectedPerChain map[uint64]bool, addresses []common.Address, allTokens []*token.Token, balances map[uint64]map[common.Address]map[common.Address]*hexutil.Big, cachedTokens map[common.Address][]token.StorageToken) map[common.Address][]token.StorageToken {
+func (r *Reader) balancesToTokensByAddress(connectedPerChain map[uint64]bool, addresses []common.Address, allTokens []*tokenTypes.Token, balances map[uint64]map[common.Address]map[common.Address]*hexutil.Big, cachedTokens map[common.Address][]tokenTypes.StorageToken) map[common.Address][]tokenTypes.StorageToken {
 	verifiedTokens, unverifiedTokens := splitVerifiedTokens(allTokens)
 
-	result := make(map[common.Address][]token.StorageToken)
+	result := make(map[common.Address][]tokenTypes.StorageToken)
 	dayAgoTimestamp := time.Now().Add(-24 * time.Hour).Unix()
 
 	for _, address := range addresses {
-		for _, tokenList := range [][]*token.Token{verifiedTokens, unverifiedTokens} {
+		for _, tokenList := range [][]*tokenTypes.Token{verifiedTokens, unverifiedTokens} {
 			for symbol, tokens := range getTokenBySymbols(tokenList) {
 				balancesPerChain := r.createBalancePerChainPerSymbol(address, balances, tokens, cachedTokens, connectedPerChain, dayAgoTimestamp)
 				if balancesPerChain == nil {
 					continue
 				}
 
-				walletToken := token.StorageToken{
-					Token: token.Token{
+				walletToken := tokenTypes.StorageToken{
+					Token: tokenTypes.Token{
 						Name:          tokens[0].Name,
 						Symbol:        symbol,
 						Decimals:      tokens[0].Decimals,
@@ -433,12 +434,12 @@ func (r *Reader) balancesToTokensByAddress(connectedPerChain map[uint64]bool, ad
 func (r *Reader) createBalancePerChainPerSymbol(
 	address common.Address,
 	balances map[uint64]map[common.Address]map[common.Address]*hexutil.Big,
-	tokens []*token.Token,
-	cachedTokens map[common.Address][]token.StorageToken,
+	tokens []*tokenTypes.Token,
+	cachedTokens map[common.Address][]tokenTypes.StorageToken,
 	clientConnectionPerChain map[uint64]bool,
 	dayAgoTimestamp int64,
-) map[uint64]token.ChainBalance {
-	var balancesPerChain map[uint64]token.ChainBalance
+) map[uint64]tokenTypes.ChainBalance {
+	var balancesPerChain map[uint64]tokenTypes.ChainBalance
 	decimals := tokens[0].Decimals
 	isMandatoryToken := belongsToMandatoryTokens(tokens[0].Symbol) // we expect all tokens in the list to have the same symbol
 	for _, tok := range tokens {
@@ -460,7 +461,7 @@ func (r *Reader) createBalancePerChainPerSymbol(
 			}
 
 			if balancesPerChain == nil {
-				balancesPerChain = make(map[uint64]token.ChainBalance)
+				balancesPerChain = make(map[uint64]tokenTypes.ChainBalance)
 			}
 			balancesPerChain[tok.ChainID] = *balance
 		}
@@ -485,7 +486,7 @@ func (r *Reader) GetLastTokenUpdateTimestamps() map[common.Address]int64 {
 	return result
 }
 
-func isCachedToken(cachedTokens map[common.Address][]token.StorageToken, address common.Address, symbol string, chainID uint64) bool {
+func isCachedToken(cachedTokens map[common.Address][]tokenTypes.StorageToken, address common.Address, symbol string, chainID uint64) bool {
 	if tokens, ok := cachedTokens[address]; ok {
 		for _, t := range tokens {
 			if t.Symbol != symbol {
@@ -502,7 +503,7 @@ func isCachedToken(cachedTokens map[common.Address][]token.StorageToken, address
 
 // getCachedWalletTokensWithoutMarketData returns the latest fetched balances, minus
 // price information
-func (r *Reader) getCachedWalletTokensWithoutMarketData() (map[common.Address][]token.StorageToken, error) {
+func (r *Reader) getCachedWalletTokensWithoutMarketData() (map[common.Address][]tokenTypes.StorageToken, error) {
 	return r.persistence.GetTokens()
 }
 
@@ -512,7 +513,7 @@ func (r *Reader) updateTokenUpdateTimestamp(addresses []common.Address) {
 	}
 }
 
-func (r *Reader) FetchBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address) (map[common.Address][]token.StorageToken, error) {
+func (r *Reader) FetchBalances(ctx context.Context, clients map[uint64]chain.ClientInterface, addresses []common.Address) (map[common.Address][]tokenTypes.StorageToken, error) {
 	cachedTokens, err := r.getCachedWalletTokensWithoutMarketData()
 	if err != nil {
 		return nil, err
@@ -549,7 +550,7 @@ func (r *Reader) FetchBalances(ctx context.Context, clients map[uint64]chain.Cli
 	return tokens, err
 }
 
-func (r *Reader) GetCachedBalances(clients map[uint64]chain.ClientInterface, addresses []common.Address) (map[common.Address][]token.StorageToken, error) {
+func (r *Reader) GetCachedBalances(clients map[uint64]chain.ClientInterface, addresses []common.Address) (map[common.Address][]tokenTypes.StorageToken, error) {
 	cachedTokens, err := r.getCachedWalletTokensWithoutMarketData()
 	if err != nil {
 		return nil, err

--- a/services/wallet/reader_test.go
+++ b/services/wallet/reader_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/status-im/status-go/rpc/chain"
 	mock_client "github.com/status-im/status-go/rpc/chain/mock/client"
 	"github.com/status-im/status-go/services/wallet/testutils"
-	"github.com/status-im/status-go/services/wallet/token"
 	mock_balance_persistence "github.com/status-im/status-go/services/wallet/token/mock/balance_persistence"
 	mock_token "github.com/status-im/status-go/services/wallet/token/mock/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 var (
@@ -31,10 +31,10 @@ var (
 	testAccAddress1 = common.Address{0x12}
 	testAccAddress2 = common.Address{0x45}
 
-	expectedTokens = map[common.Address][]token.StorageToken{
-		testAccAddress1: []token.StorageToken{
+	expectedTokens = map[common.Address][]tokenTypes.StorageToken{
+		testAccAddress1: []tokenTypes.StorageToken{
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  testTokenAddress1,
 					Name:     "Token 1",
 					Symbol:   "T1",
@@ -43,15 +43,15 @@ var (
 				BalancesPerChain: nil,
 			},
 		},
-		testAccAddress2: []token.StorageToken{
+		testAccAddress2: []tokenTypes.StorageToken{
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  testTokenAddress2,
 					Name:     "Token 2",
 					Symbol:   "T2",
 					Decimals: 18,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					1: {
 						RawBalance: "1000000000000000000",
 						Balance:    big.NewFloat(1),
@@ -65,13 +65,13 @@ var (
 	}
 )
 
-// This matcher is used to compare the expected and actual map[common.Address][]token.StorageToken in parameters to SaveTokens
+// This matcher is used to compare the expected and actual map[common.Address][]tokenTypes.StorageToken in parameters to SaveTokens
 type mapTokenWithBalanceMatcher struct {
 	expected []interface{}
 }
 
 func (m mapTokenWithBalanceMatcher) Matches(x interface{}) bool {
-	actual, ok := x.(map[common.Address][]token.StorageToken)
+	actual, ok := x.(map[common.Address][]tokenTypes.StorageToken)
 	if !ok {
 		return false
 	}
@@ -80,7 +80,7 @@ func (m mapTokenWithBalanceMatcher) Matches(x interface{}) bool {
 		return false
 	}
 
-	expected := m.expected[0].(map[common.Address][]token.StorageToken)
+	expected := m.expected[0].(map[common.Address][]tokenTypes.StorageToken)
 
 	for address, expectedTokens := range expected {
 		actualTokens, ok := actual[address]
@@ -144,7 +144,7 @@ func newMapTokenWithBalanceMatcher(expected []interface{}) gomock.Matcher {
 		expected: expected,
 	}
 }
-func testChainBalancesEqual(t *testing.T, expected, actual token.ChainBalance) {
+func testChainBalancesEqual(t *testing.T, expected, actual tokenTypes.ChainBalance) {
 	assert.Equal(t, expected.RawBalance, actual.RawBalance)
 	assert.Equal(t, 0, expected.Balance.Cmp(actual.Balance))
 	assert.Equal(t, expected.Address, actual.Address)
@@ -153,7 +153,7 @@ func testChainBalancesEqual(t *testing.T, expected, actual token.ChainBalance) {
 	assert.Equal(t, expected.Balance1DayAgo, actual.Balance1DayAgo)
 }
 
-func testBalancePerChainEqual(t *testing.T, expected, actual map[uint64]token.ChainBalance) {
+func testBalancePerChainEqual(t *testing.T, expected, actual map[uint64]tokenTypes.ChainBalance) {
 	assert.Len(t, actual, len(expected))
 	for chainID, expectedBalance := range expected {
 		actualBalance, ok := actual[chainID]
@@ -207,7 +207,7 @@ func TestIsBalanceCacheValid(t *testing.T) {
 
 	// Make cached tokens not contain all the addresses
 	reader.balanceRefreshed()
-	cachedTokens := map[common.Address][]token.StorageToken{
+	cachedTokens := map[common.Address][]tokenTypes.StorageToken{
 		testAccAddress1: expectedTokens[testAccAddress1],
 	}
 	tokenPersistence.EXPECT().GetTokens().Return(cachedTokens, nil)
@@ -230,7 +230,7 @@ func TestTokensCachedForAddresses(t *testing.T) {
 	addresses := []common.Address{testAccAddress1, testAccAddress2}
 
 	// Test when the cached tokens do not contain all the addresses
-	cachedTokens := map[common.Address][]token.StorageToken{
+	cachedTokens := map[common.Address][]tokenTypes.StorageToken{
 		testAccAddress1: expectedTokens[testAccAddress1],
 	}
 	persistence.EXPECT().GetTokens().Return(cachedTokens, nil)
@@ -276,16 +276,16 @@ func TestFetchBalancesInternal(t *testing.T) {
 }
 
 func TestTokensToBalancesPerChain(t *testing.T) {
-	cachedTokens := map[common.Address][]token.StorageToken{
-		testAccAddress1: []token.StorageToken{
+	cachedTokens := map[common.Address][]tokenTypes.StorageToken{
+		testAccAddress1: []tokenTypes.StorageToken{
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  testTokenAddress1,
 					Name:     "Token 1",
 					Symbol:   "T1",
 					Decimals: 18,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					1: {
 						RawBalance: "1000000000000000000",
 						Balance:    big.NewFloat(1),
@@ -296,7 +296,7 @@ func TestTokensToBalancesPerChain(t *testing.T) {
 				},
 			},
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  testTokenAddress2,
 					Name:     "Token 2",
 					Symbol:   "T2",
@@ -305,15 +305,15 @@ func TestTokensToBalancesPerChain(t *testing.T) {
 				BalancesPerChain: nil, // Skip this token
 			},
 		},
-		testAccAddress2: []token.StorageToken{
+		testAccAddress2: []tokenTypes.StorageToken{
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  testTokenAddress2,
 					Name:     "Token 2",
 					Symbol:   "T2",
 					Decimals: 18,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					1: {
 						RawBalance: "2000000000000000000",
 						Balance:    big.NewFloat(2),
@@ -367,7 +367,7 @@ func TestGetBalance1DayAgo(t *testing.T) {
 	expectedBalance := big.NewInt(1000000000000000000)
 	tokenManager.EXPECT().GetTokenHistoricalBalance(address, chainID, symbol, dayAgoTimestamp).Return(expectedBalance, nil)
 
-	balance1DayAgo, err := reader.getBalance1DayAgo(&token.ChainBalance{
+	balance1DayAgo, err := reader.getBalance1DayAgo(&tokenTypes.ChainBalance{
 		ChainID: chainID,
 		Address: address,
 	}, dayAgoTimestamp, symbol, address)
@@ -377,7 +377,7 @@ func TestGetBalance1DayAgo(t *testing.T) {
 
 	// Test error
 	tokenManager.EXPECT().GetTokenHistoricalBalance(address, chainID, symbol, dayAgoTimestamp).Return(nil, errors.New("error"))
-	balance1DayAgo, err = reader.getBalance1DayAgo(&token.ChainBalance{
+	balance1DayAgo, err = reader.getBalance1DayAgo(&tokenTypes.ChainBalance{
 		ChainID: chainID,
 		Address: address,
 	}, dayAgoTimestamp, symbol, address)
@@ -394,7 +394,7 @@ func TestToChainBalance(t *testing.T) {
 			},
 		},
 	}
-	tok := &token.Token{
+	tok := &tokenTypes.Token{
 		ChainID:  1,
 		Address:  common.Address{0x34},
 		Symbol:   "T1",
@@ -402,10 +402,10 @@ func TestToChainBalance(t *testing.T) {
 	}
 	address := common.Address{0x12}
 	decimals := uint(18)
-	cachedTokens := map[common.Address][]token.StorageToken{
+	cachedTokens := map[common.Address][]tokenTypes.StorageToken{
 		common.Address{0x12}: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  common.Address{0x34},
 					Name:     "Token 1",
 					Symbol:   "T1",
@@ -418,7 +418,7 @@ func TestToChainBalance(t *testing.T) {
 
 	expectedBalance := big.NewFloat(1)
 	hasError := false
-	expectedChainBalance := &token.ChainBalance{
+	expectedChainBalance := &tokenTypes.ChainBalance{
 		RawBalance:     "1000000000000000000",
 		Balance:        expectedBalance,
 		Balance1DayAgo: "0",
@@ -431,7 +431,7 @@ func TestToChainBalance(t *testing.T) {
 	testChainBalancesEqual(t, *expectedChainBalance, *chainBalance)
 
 	// Test when the token is not visible
-	emptyCachedTokens := map[common.Address][]token.StorageToken{}
+	emptyCachedTokens := map[common.Address][]tokenTypes.StorageToken{}
 	isMandatory := false
 	noBalances := map[uint64]map[common.Address]map[common.Address]*hexutil.Big{
 		tok.ChainID: {
@@ -445,16 +445,16 @@ func TestToChainBalance(t *testing.T) {
 }
 
 func TestIsCachedToken(t *testing.T) {
-	cachedTokens := map[common.Address][]token.StorageToken{
+	cachedTokens := map[common.Address][]tokenTypes.StorageToken{
 		common.Address{0x12}: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  common.Address{0x34},
 					Name:     "Token 1",
 					Symbol:   "T1",
 					Decimals: 18,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					1: {
 						RawBalance: "1000000000000000000",
 						Balance:    big.NewFloat(1),
@@ -501,7 +501,7 @@ func TestCreateBalancePerChainPerSymbol(t *testing.T) {
 		},
 	}
 
-	tokens := []*token.Token{
+	tokens := []*tokenTypes.Token{
 		{
 			Name:     "Token 1 mainnet",
 			ChainID:  1,
@@ -518,16 +518,16 @@ func TestCreateBalancePerChainPerSymbol(t *testing.T) {
 		},
 	}
 	// Let cached tokens not have the token for chain 2, it still should be calculated because of positive balance
-	cachedTokens := map[common.Address][]token.StorageToken{
+	cachedTokens := map[common.Address][]tokenTypes.StorageToken{
 		address: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  common.Address{0x34},
 					Name:     "Token 1",
 					Symbol:   "T1",
 					Decimals: 18,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					1: {
 						RawBalance: "1000000000000000000",
 						Balance:    big.NewFloat(1),
@@ -546,7 +546,7 @@ func TestCreateBalancePerChainPerSymbol(t *testing.T) {
 	}
 	dayAgoTimestamp := time.Now().Add(-24 * time.Hour).Unix()
 
-	expectedBalancesPerChain := map[uint64]token.ChainBalance{
+	expectedBalancesPerChain := map[uint64]tokenTypes.ChainBalance{
 		1: {
 			RawBalance:     "1000000000000000000",
 			Balance:        big.NewFloat(1),
@@ -577,7 +577,7 @@ func TestCreateBalancePerChainPerSymbol(t *testing.T) {
 
 func TestCreateBalancePerChainPerSymbolWithMissingBalance(t *testing.T) {
 	address := common.Address{0x12}
-	tokens := []*token.Token{
+	tokens := []*tokenTypes.Token{
 		{
 			Name:     "Token 1 mainnet",
 			ChainID:  1,
@@ -600,7 +600,7 @@ func TestCreateBalancePerChainPerSymbolWithMissingBalance(t *testing.T) {
 	}
 
 	dayAgoTimestamp := time.Now().Add(-24 * time.Hour).Unix()
-	emptyCachedTokens := map[common.Address][]token.StorageToken{}
+	emptyCachedTokens := map[common.Address][]tokenTypes.StorageToken{}
 	oneBalanceMissing := map[uint64]map[common.Address]map[common.Address]*hexutil.Big{
 		1: {
 			address: {
@@ -615,7 +615,7 @@ func TestCreateBalancePerChainPerSymbolWithMissingBalance(t *testing.T) {
 		},
 	}
 
-	expectedBalancesPerChain := map[uint64]token.ChainBalance{
+	expectedBalancesPerChain := map[uint64]tokenTypes.ChainBalance{
 		2: {
 			RawBalance:     "1000000000000000000",
 			Balance:        big.NewFloat(1),
@@ -646,7 +646,7 @@ func TestBalancesToTokensByAddress(t *testing.T) {
 		common.HexToAddress("0x456"),
 	}
 
-	allTokens := []*token.Token{
+	allTokens := []*tokenTypes.Token{
 		{
 			Name:     "Token 1",
 			Symbol:   "T1",
@@ -689,10 +689,10 @@ func TestBalancesToTokensByAddress(t *testing.T) {
 		},
 	}
 
-	cachedTokens := map[common.Address][]token.StorageToken{
+	cachedTokens := map[common.Address][]tokenTypes.StorageToken{
 		addresses[0]: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Name:     "Token 1",
 					Symbol:   "T1",
 					Decimals: 18,
@@ -700,7 +700,7 @@ func TestBalancesToTokensByAddress(t *testing.T) {
 					Address:  common.HexToAddress("0x789"),
 					ChainID:  1,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					1: {
 						RawBalance: "1000000000000000000",
 						Balance:    big.NewFloat(1),
@@ -713,16 +713,16 @@ func TestBalancesToTokensByAddress(t *testing.T) {
 		},
 	}
 
-	expectedTokensPerAddress := map[common.Address][]token.StorageToken{
+	expectedTokensPerAddress := map[common.Address][]tokenTypes.StorageToken{
 		addresses[0]: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Name:     "Token 1",
 					Symbol:   "T1",
 					Decimals: 18,
 					Verified: true,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					1: {
 						RawBalance:     "1000000000000000000",
 						Balance:        big.NewFloat(1),
@@ -736,13 +736,13 @@ func TestBalancesToTokensByAddress(t *testing.T) {
 		},
 		addresses[1]: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Name:     "Token 2",
 					Symbol:   "T2",
 					Decimals: 18,
 					Verified: true,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					1: {
 						RawBalance:     "2000000000000000000",
 						Balance:        big.NewFloat(2),
@@ -798,7 +798,7 @@ func TestGetCachedBalances(t *testing.T) {
 		2: mockClientIface2,
 	}
 
-	allTokens := []*token.Token{
+	allTokens := []*tokenTypes.Token{
 		{
 			Address:  common.HexToAddress("0xabc"),
 			Name:     "Token 1",
@@ -822,10 +822,10 @@ func TestGetCachedBalances(t *testing.T) {
 		},
 	}
 
-	cachedTokens := map[common.Address][]token.StorageToken{
+	cachedTokens := map[common.Address][]tokenTypes.StorageToken{
 		addresses[0]: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  common.HexToAddress("0xabc"),
 					Name:     "Token 1",
 					Symbol:   "T1",
@@ -837,14 +837,14 @@ func TestGetCachedBalances(t *testing.T) {
 		},
 		addresses[1]: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  common.HexToAddress("0xdef"),
 					Name:     "Token 2",
 					Symbol:   "T2",
 					Decimals: 18,
 					ChainID:  2,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					2: {
 						RawBalance:     "1000000000000000000",
 						Balance:        big.NewFloat(1),
@@ -858,15 +858,15 @@ func TestGetCachedBalances(t *testing.T) {
 		},
 	}
 
-	expectedTokens := map[common.Address][]token.StorageToken{
+	expectedTokens := map[common.Address][]tokenTypes.StorageToken{
 		addresses[1]: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Name:     "Token 2",
 					Symbol:   "T2",
 					Decimals: 18,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					2: {
 						RawBalance:     "1000000000000000000",
 						Balance:        big.NewFloat(1),
@@ -913,7 +913,7 @@ func TestFetchBalances(t *testing.T) {
 		2: mockClientIface2,
 	}
 
-	allTokens := []*token.Token{
+	allTokens := []*tokenTypes.Token{
 		{
 			Address:  common.HexToAddress("0xabc"),
 			Name:     "Token 1",
@@ -937,10 +937,10 @@ func TestFetchBalances(t *testing.T) {
 		},
 	}
 
-	cachedTokens := map[common.Address][]token.StorageToken{
+	cachedTokens := map[common.Address][]tokenTypes.StorageToken{
 		addresses[0]: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  common.HexToAddress("0xabc"),
 					Name:     "Token 1",
 					Symbol:   "T1",
@@ -952,14 +952,14 @@ func TestFetchBalances(t *testing.T) {
 		},
 		addresses[1]: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Address:  common.HexToAddress("0xdef"),
 					Name:     "Token 2",
 					Symbol:   "T2",
 					Decimals: 18,
 					ChainID:  2,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					2: {
 						RawBalance:     "1000000000000000000",
 						Balance:        big.NewFloat(1),
@@ -973,15 +973,15 @@ func TestFetchBalances(t *testing.T) {
 		},
 	}
 
-	expectedTokens := map[common.Address][]token.StorageToken{
+	expectedTokens := map[common.Address][]tokenTypes.StorageToken{
 		addresses[1]: {
 			{
-				Token: token.Token{
+				Token: tokenTypes.Token{
 					Name:     "Token 2",
 					Symbol:   "T2",
 					Decimals: 18,
 				},
-				BalancesPerChain: map[uint64]token.ChainBalance{
+				BalancesPerChain: map[uint64]tokenTypes.ChainBalance{
 					2: {
 						RawBalance:     "2000000000000000000",
 						Balance:        big.NewFloat(2),

--- a/services/wallet/requests/router_input_params.go
+++ b/services/wallet/requests/router_input_params.go
@@ -11,7 +11,7 @@ import (
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/router/fees"
 	"github.com/status-im/status-go/services/wallet/router/sendtype"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 var (
@@ -74,7 +74,7 @@ type RouteInputParams struct {
 }
 
 type RouterTestParams struct {
-	TokenFrom             *token.Token
+	TokenFrom             *tokenTypes.Token
 	TokenPrices           map[string]float64
 	EstimationMap         map[string]Estimation // [processor-name, estimation]
 	BonderFeeMap          map[string]*big.Int   // [token-symbol, bonder-fee]

--- a/services/wallet/router/pathprocessor/processor.go
+++ b/services/wallet/router/pathprocessor/processor.go
@@ -12,7 +12,7 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/wallet/requests"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 )
 
@@ -60,8 +60,8 @@ type ProcessorInputParams struct {
 	ToChain   *params.Network
 	FromAddr  common.Address
 	ToAddr    common.Address
-	FromToken *token.Token
-	ToToken   *token.Token
+	FromToken *tokenTypes.Token
+	ToToken   *tokenTypes.Token
 	AmountIn  *big.Int
 	AmountOut *big.Int
 

--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -38,6 +38,7 @@ import (
 	pathProcessorCommon "github.com/status-im/status-go/services/wallet/router/pathprocessor/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 	"github.com/status-im/status-go/transactions"
 )
@@ -165,7 +166,7 @@ func (h *HopBridgeProcessor) AvailableFor(params ProcessorInputParams) (bool, er
 	return err == nil, err
 }
 
-func (c *HopBridgeProcessor) getAppropriateABI(contractType string, chainID uint64, token *token.Token) (abi.ABI, error) {
+func (c *HopBridgeProcessor) getAppropriateABI(contractType string, chainID uint64, token *tokenTypes.Token) (abi.ABI, error) {
 	switch contractType {
 	case hop.CctpL1Bridge:
 		return abi.JSON(strings.NewReader(hopL1CctpImplementation.HopL1CctpImplementationABI))
@@ -569,7 +570,7 @@ func (h *HopBridgeProcessor) packL1BridgeTx(abi abi.ABI, toChainID uint64, to co
 }
 
 func (h *HopBridgeProcessor) sendL1BridgeTx(contractAddress common.Address, ethClient chain.ClientInterface, toChainID uint64,
-	to common.Address, txOpts *bind.TransactOpts, token *token.Token, bonderFee *BonderFee) (tx *ethTypes.Transaction, err error) {
+	to common.Address, txOpts *bind.TransactOpts, token *tokenTypes.Token, bonderFee *BonderFee) (tx *ethTypes.Transaction, err error) {
 	if token.IsNative() {
 		contractInstance, err := hopL1EthBridge.NewHopL1EthBridge(
 			contractAddress,

--- a/services/wallet/router/pathprocessor/processor_erc721.go
+++ b/services/wallet/router/pathprocessor/processor_erc721.go
@@ -20,7 +20,7 @@ import (
 	"github.com/status-im/status-go/services/utils"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	pathProcessorCommon "github.com/status-im/status-go/services/wallet/router/pathprocessor/common"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 	"github.com/status-im/status-go/transactions"
 )
@@ -155,7 +155,7 @@ func (s *ERC721Processor) sendOrBuild(sendArgs *MultipathProcessorTxArgs, signer
 		},
 		FromAddr: from,
 		ToAddr:   sendArgs.ERC721TransferTx.Recipient,
-		FromToken: &token.Token{
+		FromToken: &tokenTypes.Token{
 			Symbol:  sendArgs.ERC721TransferTx.TokenID.String(),
 			Address: common.Address(*sendArgs.ERC721TransferTx.To),
 		},

--- a/services/wallet/router/pathprocessor/processor_swap_paraswap_test.go
+++ b/services/wallet/router/pathprocessor/processor_swap_paraswap_test.go
@@ -15,7 +15,7 @@ import (
 	pathProcessorCommon "github.com/status-im/status-go/services/wallet/router/pathprocessor/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty/paraswap"
 	mock_paraswap "github.com/status-im/status-go/services/wallet/thirdparty/paraswap/mock"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,10 +37,10 @@ func TestParaswapWithPartnerFee(t *testing.T) {
 
 	processor := NewSwapParaswapProcessor(nil, nil, nil)
 
-	fromToken := token.Token{
+	fromToken := tokenTypes.Token{
 		Symbol: walletCommon.EthSymbol,
 	}
-	toToken := token.Token{
+	toToken := tokenTypes.Token{
 		Symbol: walletCommon.UsdcSymbol,
 	}
 	chainIDs := []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet, walletCommon.OptimismMainnet, walletCommon.UnknownChainID}
@@ -108,10 +108,10 @@ func TestParaswapErrors(t *testing.T) {
 	processor := NewSwapParaswapProcessor(nil, nil, nil)
 	processor.paraswapClient = client
 
-	fromToken := token.Token{
+	fromToken := tokenTypes.Token{
 		Symbol: walletCommon.EthSymbol,
 	}
-	toToken := token.Token{
+	toToken := tokenTypes.Token{
 		Symbol: walletCommon.UsdcSymbol,
 	}
 	chainID := walletCommon.EthereumMainnet

--- a/services/wallet/router/pathprocessor/processor_test.go
+++ b/services/wallet/router/pathprocessor/processor_test.go
@@ -8,7 +8,7 @@ import (
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/requests"
 	pathProcessorCommon "github.com/status-im/status-go/services/wallet/router/pathprocessor/common"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -128,7 +128,7 @@ func TestPathProcessors(t *testing.T) {
 				TestsMode: true,
 				FromChain: &mainnet,
 				ToChain:   &mainnet,
-				FromToken: &token.Token{
+				FromToken: &tokenTypes.Token{
 					Symbol: walletCommon.EthSymbol,
 				},
 				TestEstimationMap: testEstimationMap,
@@ -154,10 +154,10 @@ func TestPathProcessors(t *testing.T) {
 				TestsMode: true,
 				FromChain: &mainnet,
 				ToChain:   &mainnet,
-				FromToken: &token.Token{
+				FromToken: &tokenTypes.Token{
 					Symbol: walletCommon.EthSymbol,
 				},
-				ToToken: &token.Token{
+				ToToken: &tokenTypes.Token{
 					Symbol: walletCommon.EthSymbol,
 				},
 				TestEstimationMap: testEstimationMap,
@@ -183,10 +183,10 @@ func TestPathProcessors(t *testing.T) {
 				TestsMode: true,
 				FromChain: &mainnet,
 				ToChain:   &mainnet,
-				FromToken: &token.Token{
+				FromToken: &tokenTypes.Token{
 					Symbol: walletCommon.EthSymbol,
 				},
-				ToToken: &token.Token{
+				ToToken: &tokenTypes.Token{
 					Symbol: walletCommon.UsdcSymbol,
 				},
 				TestEstimationMap: testEstimationMap,
@@ -235,7 +235,7 @@ func TestPathProcessors(t *testing.T) {
 				TestsMode: true,
 				FromChain: &mainnet,
 				ToChain:   &optimism,
-				FromToken: &token.Token{
+				FromToken: &tokenTypes.Token{
 					Symbol: walletCommon.EthSymbol,
 				},
 				TestEstimationMap: testEstimationMap,
@@ -261,10 +261,10 @@ func TestPathProcessors(t *testing.T) {
 				TestsMode: true,
 				FromChain: &mainnet,
 				ToChain:   &optimism,
-				FromToken: &token.Token{
+				FromToken: &tokenTypes.Token{
 					Symbol: walletCommon.EthSymbol,
 				},
-				ToToken: &token.Token{
+				ToToken: &tokenTypes.Token{
 					Symbol: walletCommon.EthSymbol,
 				},
 				TestEstimationMap: testEstimationMap,
@@ -290,7 +290,7 @@ func TestPathProcessors(t *testing.T) {
 				TestsMode: true,
 				FromChain: &optimism,
 				ToChain:   &base,
-				FromToken: &token.Token{
+				FromToken: &tokenTypes.Token{
 					Symbol: walletCommon.DaiSymbol,
 				},
 				TestEstimationMap: testEstimationMap,
@@ -316,10 +316,10 @@ func TestPathProcessors(t *testing.T) {
 				TestsMode: true,
 				FromChain: &mainnet,
 				ToChain:   &optimism,
-				FromToken: &token.Token{
+				FromToken: &tokenTypes.Token{
 					Symbol: walletCommon.EthSymbol,
 				},
-				ToToken: &token.Token{
+				ToToken: &tokenTypes.Token{
 					Symbol: walletCommon.UsdcSymbol,
 				},
 				TestEstimationMap: testEstimationMap,

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -28,7 +28,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/router/routes"
 	"github.com/status-im/status-go/services/wallet/router/sendtype"
 	"github.com/status-im/status-go/services/wallet/token"
-	walletToken "github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/signal"
 	"github.com/status-im/status-go/transactions"
 )
@@ -659,7 +659,7 @@ func (r *Router) getSelectedChains(input *requests.RouteInputParams) (selectedFr
 }
 
 func (r *Router) CreateProcessorInputParams(input *requests.RouteInputParams, fromNetwork *params.Network, toNetwork *params.Network,
-	fromToken *token.Token, toToken *token.Token, amountIn *big.Int, slippagePercentage float32,
+	fromToken *tokenTypes.Token, toToken *tokenTypes.Token, amountIn *big.Int, slippagePercentage float32,
 	useCommunityTokenTransferDetailsAtIndex int) (pathprocessor.ProcessorInputParams, error) {
 	var err error
 	processorInputParams := pathprocessor.ProcessorInputParams{
@@ -721,7 +721,7 @@ func (r *Router) CreateProcessorInputParams(input *requests.RouteInputParams, fr
 	return processorInputParams, err
 }
 
-func (r *Router) findFromAndToTokens(testsMode bool, input *requests.RouteInputParams, network *params.Network) (fromToken *walletToken.Token, toToken *walletToken.Token) {
+func (r *Router) findFromAndToTokens(testsMode bool, input *requests.RouteInputParams, network *params.Network) (fromToken *tokenTypes.Token, toToken *tokenTypes.Token) {
 	if testsMode {
 		fromToken = input.TestParams.TokenFrom
 	} else {
@@ -873,7 +873,7 @@ func (r *Router) resolveCandidates(ctx context.Context, input *requests.RouteInp
 }
 
 func (r *Router) buildPath(ctx context.Context, input *requests.RouteInputParams, fromNetwork *params.Network,
-	toNetwork *params.Network, fromToken *token.Token, toToken *token.Token, amountOption amountOption,
+	toNetwork *params.Network, fromToken *tokenTypes.Token, toToken *tokenTypes.Token, amountOption amountOption,
 	pathProcessor pathprocessor.PathProcessor, fetchedFees *fees.SuggestedFees, usedNonces map[uint64]uint64,
 	useCommunityTokenTransferDetailsAtIndex int) (*routes.Path, error) {
 	if !input.SendType.IsAvailableFor(fromNetwork) {

--- a/services/wallet/router/router_helper.go
+++ b/services/wallet/router/router_helper.go
@@ -26,6 +26,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/router/routes"
 	"github.com/status-im/status-go/services/wallet/router/sendtype"
 	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 func (r *Router) requireApproval(ctx context.Context, sendType sendtype.SendType, approvalContractAddress *common.Address, params pathprocessor.ProcessorInputParams) (
@@ -110,7 +111,7 @@ func CalculateL1Fee(chainID uint64, data []byte, ethClient chain.ClientInterface
 	return proxyContract.GetL1Fee(callOpt, data)
 }
 
-func (r *Router) getERC1155Balance(ctx context.Context, network *params.Network, token *token.Token, account common.Address) (*big.Int, error) {
+func (r *Router) getERC1155Balance(ctx context.Context, network *params.Network, token *tokenTypes.Token, account common.Address) (*big.Int, error) {
 	tokenID, success := new(big.Int).SetString(token.Symbol, 10)
 	if !success {
 		return nil, errors.New("failed to convert token symbol to big.Int")
@@ -134,7 +135,7 @@ func (r *Router) getERC1155Balance(ctx context.Context, network *params.Network,
 	return balances[0].Int, nil
 }
 
-func (r *Router) getBalance(ctx context.Context, chainID uint64, token *token.Token, account common.Address) (*big.Int, error) {
+func (r *Router) getBalance(ctx context.Context, chainID uint64, token *tokenTypes.Token, account common.Address) (*big.Int, error) {
 	client, err := r.rpcClient.EthClient(chainID)
 	if err != nil {
 		return nil, err
@@ -358,7 +359,7 @@ func ParseCollectibleID(ID string) (contractAddress common.Address, tokenID *big
 	return
 }
 
-func findToken(sendType sendtype.SendType, tokenManager *token.Manager, collectibles *collectibles.Service, account common.Address, network *params.Network, tokenID string) *token.Token {
+func findToken(sendType sendtype.SendType, tokenManager *token.Manager, collectibles *collectibles.Service, account common.Address, network *params.Network, tokenID string) *tokenTypes.Token {
 	if !sendType.IsCollectiblesTransfer() {
 		return tokenManager.FindToken(network, tokenID)
 	}
@@ -377,7 +378,7 @@ func findToken(sendType sendtype.SendType, tokenManager *token.Manager, collecti
 		return nil
 	}
 
-	return &token.Token{
+	return &tokenTypes.Token{
 		Address:  contractAddress,
 		Symbol:   collectibleTokenID.String(),
 		Decimals: 0,
@@ -411,10 +412,10 @@ func fetchPrices(sendType sendtype.SendType, marketManager *market.Manager, toke
 	return prices, nil
 }
 
-func (r *Router) GetTokensAvailableForBridgeOnChain(chainID uint64) []*token.Token {
+func (r *Router) GetTokensAvailableForBridgeOnChain(chainID uint64) []*tokenTypes.Token {
 	symbols := hop.GetSymbolsAvailableOnChain(chainID)
 
-	tokens := make([]*token.Token, 0)
+	tokens := make([]*tokenTypes.Token, 0)
 	for _, symbol := range symbols {
 		t, _ := r.tokenManager.LookupToken(&chainID, symbol)
 		if t == nil {

--- a/services/wallet/router/router_test_data.go
+++ b/services/wallet/router/router_test_data.go
@@ -17,7 +17,7 @@ import (
 	pathProcessorCommon "github.com/status-im/status-go/services/wallet/router/pathprocessor/common"
 	"github.com/status-im/status-go/services/wallet/router/routes"
 	"github.com/status-im/status-go/services/wallet/router/sendtype"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 const (
@@ -220,7 +220,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -258,7 +258,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -311,7 +311,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -438,7 +438,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -494,7 +494,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -574,7 +574,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -631,7 +631,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -736,7 +736,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -775,7 +775,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -814,7 +814,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -853,7 +853,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -910,7 +910,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -949,7 +949,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -984,7 +984,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -1133,7 +1133,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -1197,7 +1197,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -1346,7 +1346,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -1495,7 +1495,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -1530,7 +1530,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -1561,7 +1561,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -1689,7 +1689,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -1745,7 +1745,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -1825,7 +1825,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -1881,7 +1881,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -1962,7 +1962,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2001,7 +2001,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2040,7 +2040,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2079,7 +2079,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2136,7 +2136,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2175,7 +2175,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2206,7 +2206,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2517,7 +2517,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2621,7 +2621,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2671,7 +2671,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2757,7 +2757,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2807,7 +2807,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2894,7 +2894,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2927,7 +2927,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2966,7 +2966,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -2999,7 +2999,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -3068,7 +3068,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -3107,7 +3107,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -3140,7 +3140,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -3182,7 +3182,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -3224,7 +3224,7 @@ func getNormalTestParamsList() []normalTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -3277,7 +3277,7 @@ func getNoBalanceTestParamsList() []noBalanceTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -3310,7 +3310,7 @@ func getNoBalanceTestParamsList() []noBalanceTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -3356,7 +3356,7 @@ func getNoBalanceTestParamsList() []noBalanceTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -3396,7 +3396,7 @@ func getNoBalanceTestParamsList() []noBalanceTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -3458,7 +3458,7 @@ func getNoBalanceTestParamsList() []noBalanceTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.UsdcSymbol,
 						Decimals: 6,
@@ -3535,7 +3535,7 @@ func getAmountOptionsTestParamsList() []amountOptionsTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -3567,7 +3567,7 @@ func getAmountOptionsTestParamsList() []amountOptionsTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -3599,7 +3599,7 @@ func getAmountOptionsTestParamsList() []amountOptionsTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -3638,7 +3638,7 @@ func getAmountOptionsTestParamsList() []amountOptionsTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -3676,7 +3676,7 @@ func getAmountOptionsTestParamsList() []amountOptionsTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -3714,7 +3714,7 @@ func getAmountOptionsTestParamsList() []amountOptionsTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -3760,7 +3760,7 @@ func getAmountOptionsTestParamsList() []amountOptionsTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -3830,7 +3830,7 @@ func getAmountOptionsTestParamsList() []amountOptionsTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -3894,7 +3894,7 @@ func getAmountOptionsTestParamsList() []amountOptionsTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,
@@ -3945,7 +3945,7 @@ func getAmountOptionsTestParamsList() []amountOptionsTestParams {
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
-					TokenFrom: &token.Token{
+					TokenFrom: &tokenTypes.Token{
 						ChainID:  1,
 						Symbol:   walletCommon.EthSymbol,
 						Decimals: 18,

--- a/services/wallet/router/routes/router_path.go
+++ b/services/wallet/router/routes/router_path.go
@@ -9,19 +9,19 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/wallet/requests"
 	"github.com/status-im/status-go/services/wallet/router/fees"
-	walletToken "github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 type Path struct {
 	RouterInputParamsUuid string
 	ProcessorName         string
-	FromChain             *params.Network    // Source chain
-	ToChain               *params.Network    // Destination chain
-	FromToken             *walletToken.Token // Source token
-	ToToken               *walletToken.Token // Destination token, set if applicable
-	AmountIn              *hexutil.Big       // Amount that will be sent from the source chain
-	AmountInLocked        bool               // Is the amount locked
-	AmountOut             *hexutil.Big       // Amount that will be received on the destination chain
+	FromChain             *params.Network   // Source chain
+	ToChain               *params.Network   // Destination chain
+	FromToken             *tokenTypes.Token // Source token
+	ToToken               *tokenTypes.Token // Destination token, set if applicable
+	AmountIn              *hexutil.Big      // Amount that will be sent from the source chain
+	AmountInLocked        bool              // Is the amount locked
+	AmountOut             *hexutil.Big      // Amount that will be received on the destination chain
 
 	SuggestedLevelsForMaxFeesPerGas *fees.MaxFeesLevels // Suggested max fees by the network (in ETH WEI)
 	SuggestedMinPriorityFee         *hexutil.Big        // Suggested min priority fee by the network (in ETH WEI)
@@ -124,12 +124,12 @@ func (p *Path) Copy() *Path {
 	}
 
 	if p.FromToken != nil {
-		newPath.FromToken = &walletToken.Token{}
+		newPath.FromToken = &tokenTypes.Token{}
 		*newPath.FromToken = *p.FromToken
 	}
 
 	if p.ToToken != nil {
-		newPath.ToToken = &walletToken.Token{}
+		newPath.ToToken = &tokenTypes.Token{}
 		*newPath.ToToken = *p.ToToken
 	}
 

--- a/services/wallet/router/routes/router_path_test.go
+++ b/services/wallet/router/routes/router_path_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/wallet/router/fees"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 func TestCopyPath(t *testing.T) {
@@ -20,8 +20,8 @@ func TestCopyPath(t *testing.T) {
 		ProcessorName:  "test",
 		FromChain:      &params.Network{ChainID: 1},
 		ToChain:        &params.Network{ChainID: 2},
-		FromToken:      &token.Token{Symbol: "symbol1"},
-		ToToken:        &token.Token{Symbol: "symbol2"},
+		FromToken:      &tokenTypes.Token{Symbol: "symbol1"},
+		ToToken:        &tokenTypes.Token{Symbol: "symbol2"},
 		AmountIn:       (*hexutil.Big)(big.NewInt(100)),
 		AmountInLocked: true,
 		AmountOut:      (*hexutil.Big)(big.NewInt(200)),

--- a/services/wallet/token/aave.go
+++ b/services/wallet/token/aave.go
@@ -2,13 +2,14 @@ package token
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 var aaveVersion = "3.0.85"
 
 var aaveTimestamp = int64(1739626918)
 
-var aaveTokens = []*Token{
+var aaveTokens = []*tokenTypes.Token{
 
 	{
 		Address:   common.HexToAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),

--- a/services/wallet/token/aave_tokenstore.go
+++ b/services/wallet/token/aave_tokenstore.go
@@ -1,5 +1,7 @@
 package token
 
+import tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
+
 type aaveStore struct {
 }
 
@@ -7,7 +9,7 @@ func NewAaveStore() *aaveStore {
 	return &aaveStore{}
 }
 
-func (s *aaveStore) GetTokens() []*Token {
+func (s *aaveStore) GetTokens() []*tokenTypes.Token {
 	return aaveTokens
 }
 

--- a/services/wallet/token/analyzer/main.go
+++ b/services/wallet/token/analyzer/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	token "github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 func main() {
@@ -21,17 +22,17 @@ func main() {
 	}
 
 	fmt.Println("")
-	tokensPerStore := make(map[string]map[string]*token.Token) // map[store][tokenID]*token.Token
+	tokensPerStore := make(map[string]map[string]*tokenTypes.Token) // map[store][tokenID]*tokenTypes.Token
 	for storeName, store := range storePerName {
 		fmt.Printf("Analizying store: %s\n", storeName)
 		tokens := store.GetTokens()
 		fmt.Printf("Total number of tokens: %d\n", len(tokens))
 
-		tokensPerStore[storeName] = make(map[string]*token.Token)
-		tokensPerChainID := make(map[uint64][]*token.Token) // map[chainID]*token.Token
+		tokensPerStore[storeName] = make(map[string]*tokenTypes.Token)
+		tokensPerChainID := make(map[uint64][]*tokenTypes.Token) // map[chainID]*tokenTypes.Token
 		for _, chainToken := range tokens {
 			if _, ok := tokensPerChainID[chainToken.ChainID]; !ok {
-				tokensPerChainID[chainToken.ChainID] = make([]*token.Token, 0, len(tokens))
+				tokensPerChainID[chainToken.ChainID] = make([]*tokenTypes.Token, 0, len(tokens))
 			}
 			tokensPerChainID[chainToken.ChainID] = append(tokensPerChainID[chainToken.ChainID], chainToken)
 
@@ -68,6 +69,6 @@ func main() {
 	}
 }
 
-func getTokenID(token *token.Token) string {
+func getTokenID(token *tokenTypes.Token) string {
 	return fmt.Sprintf("%d - %s", token.ChainID, token.Address.Hex())
 }

--- a/services/wallet/token/balance_persistence.go
+++ b/services/wallet/token/balance_persistence.go
@@ -8,41 +8,12 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
-type TokenMarketValues struct {
-	MarketCap       float64 `json:"marketCap"`
-	HighDay         float64 `json:"highDay"`
-	LowDay          float64 `json:"lowDay"`
-	ChangePctHour   float64 `json:"changePctHour"`
-	ChangePctDay    float64 `json:"changePctDay"`
-	ChangePct24hour float64 `json:"changePct24hour"`
-	Change24hour    float64 `json:"change24hour"`
-	Price           float64 `json:"price"`
-	HasError        bool    `json:"hasError"`
-}
-
-type StorageToken struct {
-	Token
-	BalancesPerChain        map[uint64]ChainBalance      `json:"balancesPerChain"`
-	Description             string                       `json:"description"`
-	AssetWebsiteURL         string                       `json:"assetWebsiteUrl"`
-	BuiltOn                 string                       `json:"builtOn"`
-	MarketValuesPerCurrency map[string]TokenMarketValues `json:"marketValuesPerCurrency"`
-}
-
-type ChainBalance struct {
-	RawBalance     string         `json:"rawBalance"`
-	Balance        *big.Float     `json:"balance"`
-	Balance1DayAgo string         `json:"balance1DayAgo"`
-	Address        common.Address `json:"address"`
-	ChainID        uint64         `json:"chainId"`
-	HasError       bool           `json:"hasError"`
-}
-
 type TokenBalancesStorage interface {
-	SaveTokens(tokens map[common.Address][]StorageToken) error
-	GetTokens() (map[common.Address][]StorageToken, error)
+	SaveTokens(tokens map[common.Address][]tokenTypes.StorageToken) error
+	GetTokens() (map[common.Address][]tokenTypes.StorageToken, error)
 }
 
 type Persistence struct {
@@ -53,7 +24,7 @@ func NewPersistence(db *sql.DB) *Persistence {
 	return &Persistence{db: db}
 }
 
-func (p *Persistence) SaveTokens(tokens map[common.Address][]StorageToken) (err error) {
+func (p *Persistence) SaveTokens(tokens map[common.Address][]tokenTypes.StorageToken) (err error) {
 	tx, err := p.db.BeginTx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		return
@@ -85,7 +56,7 @@ func (p *Persistence) SaveTokens(tokens map[common.Address][]StorageToken) (err 
 	return nil
 }
 
-func (p *Persistence) GetTokens() (map[common.Address][]StorageToken, error) {
+func (p *Persistence) GetTokens() (map[common.Address][]tokenTypes.StorageToken, error) {
 	rows, err := p.db.Query(`SELECT user_address, token_name, token_symbol, token_address, token_decimals, token_description, token_url, balance, raw_balance, chain_id FROM token_balances `)
 	if err != nil {
 		return nil, err
@@ -93,11 +64,11 @@ func (p *Persistence) GetTokens() (map[common.Address][]StorageToken, error) {
 
 	defer rows.Close()
 
-	acc := make(map[common.Address]map[string]StorageToken)
+	acc := make(map[common.Address]map[string]tokenTypes.StorageToken)
 
 	for rows.Next() {
 		var addressStr, balance, rawBalance, tokenAddress string
-		token := StorageToken{}
+		token := tokenTypes.StorageToken{}
 		var chainID uint64
 
 		err := rows.Scan(&addressStr, &token.Name, &token.Symbol, &tokenAddress, &token.Decimals, &token.Description, &token.AssetWebsiteURL, &balance, &rawBalance, &chainID)
@@ -110,11 +81,11 @@ func (p *Persistence) GetTokens() (map[common.Address][]StorageToken, error) {
 		address := common.HexToAddress(addressStr)
 
 		if acc[address] == nil {
-			acc[address] = make(map[string]StorageToken)
+			acc[address] = make(map[string]tokenTypes.StorageToken)
 		}
 
 		if acc[address][token.Name].Name == "" {
-			token.BalancesPerChain = make(map[uint64]ChainBalance)
+			token.BalancesPerChain = make(map[uint64]tokenTypes.ChainBalance)
 			acc[address][token.Name] = token
 		}
 
@@ -126,7 +97,7 @@ func (p *Persistence) GetTokens() (map[common.Address][]StorageToken, error) {
 			return nil, err
 		}
 
-		tokenAcc.BalancesPerChain[chainID] = ChainBalance{
+		tokenAcc.BalancesPerChain[chainID] = tokenTypes.ChainBalance{
 			RawBalance: rawBalance,
 			Balance:    balanceFloat,
 			Address:    common.HexToAddress(tokenAddress),
@@ -134,7 +105,7 @@ func (p *Persistence) GetTokens() (map[common.Address][]StorageToken, error) {
 		}
 	}
 
-	result := make(map[common.Address][]StorageToken)
+	result := make(map[common.Address][]tokenTypes.StorageToken)
 
 	for address, tks := range acc {
 		for _, t := range tks {

--- a/services/wallet/token/balance_persistence_test.go
+++ b/services/wallet/token/balance_persistence_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/status-im/status-go/rpc/network"
 	"github.com/status-im/status-go/services/wallet/community"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/walletdatabase"
 
@@ -23,7 +24,7 @@ func TestSaveTokens(t *testing.T) {
 	persistence := NewPersistence(db)
 	require.NotNil(t, persistence)
 
-	tokens := make(map[common.Address][]StorageToken)
+	tokens := make(map[common.Address][]tokenTypes.StorageToken)
 	address1 := common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
 	address2 := common.HexToAddress("0x5e4e65926ba27467555eb562121fac00d24e9dd2")
 
@@ -33,70 +34,70 @@ func TestSaveTokens(t *testing.T) {
 	var chain1 uint64 = 1
 	var chain2 uint64 = 2
 
-	token1 := StorageToken{
-		Token: Token{
+	token1 := tokenTypes.StorageToken{
+		Token: tokenTypes.Token{
 			Name:     "token-1",
 			Symbol:   "TT1",
 			Decimals: 10,
 		},
-		BalancesPerChain: make(map[uint64]ChainBalance),
+		BalancesPerChain: make(map[uint64]tokenTypes.ChainBalance),
 		Description:      "description-1",
 		AssetWebsiteURL:  "url-1",
 	}
 
-	token1.BalancesPerChain[chain1] = ChainBalance{
+	token1.BalancesPerChain[chain1] = tokenTypes.ChainBalance{
 		RawBalance: "1",
 		Balance:    big.NewFloat(0.1),
 		Address:    tokenAddress1,
 		ChainID:    chain1,
 	}
 
-	token1.BalancesPerChain[chain2] = ChainBalance{
+	token1.BalancesPerChain[chain2] = tokenTypes.ChainBalance{
 		RawBalance: "2",
 		Balance:    big.NewFloat(0.2),
 		Address:    tokenAddress2,
 		ChainID:    chain2,
 	}
 
-	token2 := StorageToken{
-		Token: Token{
+	token2 := tokenTypes.StorageToken{
+		Token: tokenTypes.Token{
 			Name:     "token-2",
 			Symbol:   "TT2",
 			Decimals: 11,
 		},
-		BalancesPerChain: make(map[uint64]ChainBalance),
+		BalancesPerChain: make(map[uint64]tokenTypes.ChainBalance),
 		Description:      "description-2",
 		AssetWebsiteURL:  "url-2",
 	}
 
-	token2.BalancesPerChain[chain1] = ChainBalance{
+	token2.BalancesPerChain[chain1] = tokenTypes.ChainBalance{
 		RawBalance: "3",
 		Balance:    big.NewFloat(0.3),
 		Address:    tokenAddress1,
 		ChainID:    chain1,
 	}
 
-	token3 := StorageToken{
-		Token: Token{
+	token3 := tokenTypes.StorageToken{
+		Token: tokenTypes.Token{
 			Name:     "token-3",
 			Symbol:   "TT3",
 			Decimals: 11,
 		},
-		BalancesPerChain: make(map[uint64]ChainBalance),
+		BalancesPerChain: make(map[uint64]tokenTypes.ChainBalance),
 		Description:      "description-3",
 		AssetWebsiteURL:  "url-3",
 	}
 
-	token3.BalancesPerChain[chain1] = ChainBalance{
+	token3.BalancesPerChain[chain1] = tokenTypes.ChainBalance{
 		RawBalance: "4",
 		Balance:    big.NewFloat(0.4),
 		Address:    tokenAddress1,
 		ChainID:    chain1,
 	}
 
-	tokens[address1] = []StorageToken{token1, token2}
+	tokens[address1] = []tokenTypes.StorageToken{token1, token2}
 
-	tokens[address2] = []StorageToken{token3}
+	tokens[address2] = []tokenTypes.StorageToken{token3}
 
 	require.NoError(t, persistence.SaveTokens(tokens))
 
@@ -106,7 +107,7 @@ func TestSaveTokens(t *testing.T) {
 	require.NotNil(t, actualTokens[address1])
 	require.Len(t, actualTokens[address1], 2)
 
-	var actualToken1, actualToken2, actualToken3 StorageToken
+	var actualToken1, actualToken2, actualToken3 tokenTypes.StorageToken
 	if actualTokens[address1][0].Name == "token-1" {
 		actualToken1 = actualTokens[address1][0]
 		actualToken2 = actualTokens[address1][1]
@@ -173,7 +174,7 @@ func TestGetCachedBalancesByChain(t *testing.T) {
 	persistence := NewPersistence(db)
 	require.NotNil(t, persistence)
 
-	tokens := make(map[common.Address][]StorageToken)
+	tokens := make(map[common.Address][]tokenTypes.StorageToken)
 	address1 := common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
 	address2 := common.HexToAddress("0x5e4e65926ba27467555eb562121fac00d24e9dd2")
 
@@ -183,18 +184,18 @@ func TestGetCachedBalancesByChain(t *testing.T) {
 	var chain1 uint64 = 1
 	var chain2 uint64 = 2
 
-	token1 := StorageToken{
-		Token: Token{
+	token1 := tokenTypes.StorageToken{
+		Token: tokenTypes.Token{
 			Name:     "token-1",
 			Symbol:   "TT1",
 			Decimals: 18,
 		},
-		BalancesPerChain: make(map[uint64]ChainBalance),
+		BalancesPerChain: make(map[uint64]tokenTypes.ChainBalance),
 		Description:      "description-1",
 		AssetWebsiteURL:  "url-1",
 	}
 
-	token1.BalancesPerChain[chain1] = ChainBalance{
+	token1.BalancesPerChain[chain1] = tokenTypes.ChainBalance{
 		RawBalance: "1",
 		// min eth number (not zero)
 		Balance: big.NewFloat(0.000000000000000001),
@@ -202,26 +203,26 @@ func TestGetCachedBalancesByChain(t *testing.T) {
 		ChainID: chain1,
 	}
 
-	token2 := StorageToken{
-		Token: Token{
+	token2 := tokenTypes.StorageToken{
+		Token: tokenTypes.Token{
 			Name:     "token-2",
 			Symbol:   "TT2",
 			Decimals: 10,
 		},
-		BalancesPerChain: make(map[uint64]ChainBalance),
+		BalancesPerChain: make(map[uint64]tokenTypes.ChainBalance),
 		Description:      "description-2",
 		AssetWebsiteURL:  "url-2",
 	}
 
-	token2.BalancesPerChain[chain2] = ChainBalance{
+	token2.BalancesPerChain[chain2] = tokenTypes.ChainBalance{
 		RawBalance: "1000000000000000000",
 		Balance:    big.NewFloat(1),
 		Address:    tokenAddress2,
 		ChainID:    chain1,
 	}
 
-	tokens[address1] = []StorageToken{token1}
-	tokens[address2] = []StorageToken{token2}
+	tokens[address1] = []tokenTypes.StorageToken{token1}
+	tokens[address2] = []tokenTypes.StorageToken{token2}
 
 	require.NoError(t, persistence.SaveTokens(tokens))
 

--- a/services/wallet/token/downloader/main.go
+++ b/services/wallet/token/downloader/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -19,13 +20,14 @@ const templateText = `package token
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 var {{ .VersionName }} = "{{ .Version }}"
 
 var {{ .TimestampName }} = int64({{ .Timestamp }})
 
-var {{ .AllTokensName }} = []*Token{
+var {{ .AllTokensName }} = []*tokenTypes.Token{
 {{ range $token := .Tokens }}
 	{
 		Address:   common.HexToAddress("{{ $token.Address }}"),
@@ -44,7 +46,7 @@ type templateData struct {
 	TimestampName string
 	Version       string
 	Timestamp     uint64
-	Tokens        []*token.Token
+	Tokens        []*tokenTypes.Token
 }
 
 type version struct {
@@ -73,13 +75,13 @@ func validateDocument(doc string, schemaURL string) (bool, error) {
 	return true, nil
 }
 
-func bytesToTokens(tokenListData []byte) ([]*token.Token, error) {
+func bytesToTokens(tokenListData []byte) ([]*tokenTypes.Token, error) {
 	var objmap map[string]json.RawMessage
 	err := json.Unmarshal(tokenListData, &objmap)
 	if err != nil {
 		return nil, err
 	}
-	var tokens []*token.Token
+	var tokens []*tokenTypes.Token
 	err = json.Unmarshal(objmap["tokens"], &tokens)
 	if err != nil {
 		return nil, err

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/bigint"
 	"github.com/status-im/status-go/services/wallet/community"
 
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/t/utils"
 	"github.com/status-im/status-go/transactions/fake"
@@ -49,7 +50,7 @@ func setupTestTokenDB(t *testing.T) (*Manager, func()) {
 		}
 }
 
-func upsertCommunityToken(t *testing.T, token *Token, manager *Manager) {
+func upsertCommunityToken(t *testing.T, token *tokenTypes.Token, manager *Manager) {
 	require.NotNil(t, token.CommunityData)
 
 	err := manager.UpsertCustom(*token)
@@ -68,7 +69,7 @@ func TestCustoms(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, rst)
 
-	token := Token{
+	token := tokenTypes.Token{
 		Address:  common.Address{1},
 		Name:     "Zilliqa",
 		Symbol:   "ZIL",
@@ -100,7 +101,7 @@ func TestCommunityTokens(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, rst)
 
-	token := Token{
+	token := tokenTypes.Token{
 		Address:  common.Address{1},
 		Name:     "Zilliqa",
 		Symbol:   "ZIL",
@@ -111,7 +112,7 @@ func TestCommunityTokens(t *testing.T) {
 	err = manager.UpsertCustom(token)
 	require.NoError(t, err)
 
-	communityToken := Token{
+	communityToken := tokenTypes.Token{
 		Address:  common.Address{2},
 		Name:     "Communitia",
 		Symbol:   "COM",
@@ -136,7 +137,7 @@ func TestCommunityTokens(t *testing.T) {
 	require.Equal(t, communityToken, *rst[0])
 }
 
-func toTokenMap(tokens []*Token) storeMap {
+func toTokenMap(tokens []*tokenTypes.Token) storeMap {
 	tokenMap := storeMap{}
 
 	for _, token := range tokens {
@@ -175,23 +176,23 @@ func TestTokenOverride(t *testing.T) {
 		},
 	}
 
-	tokenList := []*Token{
-		&Token{
+	tokenList := []*tokenTypes.Token{
+		&tokenTypes.Token{
 			Address: common.Address{1},
 			Symbol:  "SNT",
 			ChainID: 1,
 		},
-		&Token{
+		&tokenTypes.Token{
 			Address: common.Address{2},
 			Symbol:  "TNT",
 			ChainID: 1,
 		},
-		&Token{
+		&tokenTypes.Token{
 			Address: common.Address{3},
 			Symbol:  "STT",
 			ChainID: 2,
 		},
-		&Token{
+		&tokenTypes.Token{
 			Address: common.Address{4},
 			Symbol:  "TTT",
 			ChainID: 2,
@@ -219,7 +220,7 @@ func TestMarkAsPreviouslyOwnedToken(t *testing.T) {
 	defer stop()
 
 	owner := common.HexToAddress("0x1234567890abcdef")
-	token := &Token{
+	token := &tokenTypes.Token{
 		Address:  common.HexToAddress("0xabcdef1234567890"),
 		Name:     "TestToken",
 		Symbol:   "TT",
@@ -349,7 +350,7 @@ func Test_removeTokenBalanceOnEventAccountRemoved(t *testing.T) {
 	manager := NewTokenManager(walletDB, rpcClient, nil, nm, appDB, mediaServer, nil, &accountFeed, accountsDB, NewPersistence(walletDB))
 
 	// Insert balances for address
-	marked, err := manager.MarkAsPreviouslyOwnedToken(&Token{
+	marked, err := manager.MarkAsPreviouslyOwnedToken(&tokenTypes.Token{
 		Address:  common.HexToAddress("0x1234"),
 		Symbol:   "Dummy",
 		Decimals: 18,
@@ -416,7 +417,7 @@ func Test_tokensListsValidity(t *testing.T) {
 	allLists := tokensListWrapper.Data
 	require.Greater(t, len(allLists), 0)
 
-	tmpMap := make(map[string][]*Token)
+	tmpMap := make(map[string][]*tokenTypes.Token)
 	for _, list := range allLists {
 		for _, token := range list.Tokens {
 			key := fmt.Sprintf("%d-%s", token.ChainID, token.Address)
@@ -431,7 +432,7 @@ func Test_tokensListsValidity(t *testing.T) {
 
 				require.True(t, found, "Token %s not found in list %s", token.Symbol, list.Name)
 			} else {
-				tmpMap[key] = []*Token{token}
+				tmpMap[key] = []*tokenTypes.Token{token}
 			}
 		}
 	}

--- a/services/wallet/token/tokenstore.go
+++ b/services/wallet/token/tokenstore.go
@@ -2,10 +2,11 @@ package token
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 type Store interface {
-	GetTokens() []*Token
+	GetTokens() []*tokenTypes.Token
 	GetVersion() string
 	GetSource() string
 	GetName() string
@@ -36,7 +37,7 @@ func GetTokenPegSymbol(symbol string) string {
 }
 
 type DefaultStore struct {
-	TokenListID []*Token
+	TokenListID []*tokenTypes.Token
 }
 
 func (s *DefaultStore) GetName() string {
@@ -57,1100 +58,1100 @@ func (s *DefaultStore) GetSource() string {
 
 func NewDefaultStore() *DefaultStore {
 	return &DefaultStore{
-		TokenListID: []*Token{
-			&Token{
+		TokenListID: []*tokenTypes.Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359"),
 				Name:     "Sai Stablecoin v1.0",
 				Symbol:   "SAI",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0"),
 				Name:     "EOS",
 				Symbol:   "EOS",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xd4fa1460f537bb9085d22c7bccb5dd450ef28e3a"),
 				Name:     "Populous Platform",
 				Symbol:   "PPT",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xb97048628db6b661d4c2aa833e95dbe1a905b280"),
 				Name:     "TenX Pay Token",
 				Symbol:   "PAY",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x92e78dae1315067a8819efd6dca432de9dcde2e9"),
 				Name:     "Veros",
 				Symbol:   "VRS",
 				Decimals: 6,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xa74476443119a942de498590fe1f2454d7d4ac0d"),
 				Name:     "Golem Network Token",
 				Symbol:   "GNT",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x4156d3342d5c385a87d264f90653733592000581"),
 				Name:     "Salt",
 				Symbol:   "SALT",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xb8c77482e45f1f44de1745f52c74426c631bdd52"),
 				Name:     "BNB",
 				Symbol:   "BNB",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xb683D83a532e2Cb7DFa5275eED3698436371cc9f"),
 				Name:     "BTU Protocol",
 				Symbol:   "BTU",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xe0b7927c4af23765cb51314a0e0521a9645f0e2a"),
 				Name:     "Digix DAO",
 				Symbol:   "DGD",
 				Decimals: 9,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x5ca9a71b1d01849c0a95490cc00559717fcf0d1d"),
 				Name:     "Aeternity",
 				Symbol:   "AE",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xf230b790e05390fc8295f4d3f60332c93bed42e2"),
 				Name:     "Tronix",
 				Symbol:   "TRX",
 				Decimals: 6,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6"),
 				Name:     "Raiden Token",
 				Symbol:   "RDN",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xaec2e87e0a235266d9c5adc9deb4b2e29b54d009"),
 				Name:     "SingularDTV",
 				Symbol:   "SNGLS",
 				Decimals: 0,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x419d0d8bdd9af5e606ae2232ed285aff190e711b"),
 				Name:     "FunFair",
 				Symbol:   "FUN",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x888666ca69e0f178ded6d75b5726cee99a87d698"),
 				Name:     "ICONOMI",
 				Symbol:   "ICN",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xb7cb1c96db6b22b0d3d9536e0108d062bd488f74"),
 				Name:     "Walton Token",
 				Symbol:   "WTC",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xcb97e65f07da24d46bcdd078ebebd7c6e6e3d750"),
 				Name:     "Bytom",
 				Symbol:   "BTM",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xc42209accc14029c1012fb5680d95fbd6036e2a0"),
 				Name:     "PayPie",
 				Symbol:   "PPP",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x818fc6c2ec5986bc6e2cbf00939d90556ab12ce5"),
 				Name:     "Kin",
 				Symbol:   "KIN",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x40395044ac3c0c57051906da938b54bd6557f212"),
 				Name:     "MobileGo Token",
 				Symbol:   "MGO",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xb63b606ac810a52cca15e44bb630fd42d8d1d83d"),
 				Name:     "Monaco",
 				Symbol:   "MCO",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x7a41e0517a5eca4fdbc7fbeba4d4c47b9ff6dc63"),
 				Name:     "Zeus Shield Coin",
 				Symbol:   "ZSC",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x0cf0ee63788a0849fe5297f3407f701e122cc023"),
 				Name:     "Streamr (old)",
 				Symbol:   "XDATA",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xf970b8e36e23f7fc3fd752eea86f8be8d83375a6"),
 				Name:     "Ripio Credit Network Token",
 				Symbol:   "RCN",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x667088b212ce3d06a1b553a7221e1fd19000d9af"),
 				Name:     "WINGS",
 				Symbol:   "WINGS",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x08711d3b02c8758f2fb3ab4e80228418a7f8e39c"),
 				Name:     "Edgeless",
 				Symbol:   "EDG",
 				Decimals: 0,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x51db5ad35c671a87207d88fc11d593ac0c8415bd"),
 				Name:     "Moeda Loyalty Points",
 				Symbol:   "MDA",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xe3818504c1b32bf1557b16c238b2e01fd3149c17"),
 				Name:     "PILLAR",
 				Symbol:   "PLR",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x697beac28b09e122c4332d163985e8a73121b97f"),
 				Name:     "QRL",
 				Symbol:   "QRL",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x957c30ab0426e0c93cd8241e2c60392d08c6ac8e"),
 				Name:     "Modum Token",
 				Symbol:   "MOD",
 				Decimals: 0,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xe7775a6e9bcf904eb39da2b68c5efb4f9360e08c"),
 				Name:     "Token-as-a-Service",
 				Symbol:   "TAAS",
 				Decimals: 6,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd"),
 				Name:     "GRID Token",
 				Symbol:   "GRID",
 				Decimals: 12,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098"),
 				Name:     "SANtiment network token",
 				Symbol:   "SAN",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x983f6d60db79ea8ca4eb9968c6aff8cfa04b3c63"),
 				Name:     "SONM Token",
 				Symbol:   "SNM",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x12480e24eb5bec1a9d4369cab6a80cad3c0a377a"),
 				Name:     "Substratum",
 				Symbol:   "SUB",
 				Decimals: 2,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x48f775efbe4f5ece6e0df2f7b5932df56823b990"),
 				Name:     "R token",
 				Symbol:   "R",
 				Decimals: 0,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xaf30d2a7e90d7dc361c8c4585e9bb7d2f6f15bc7"),
 				Name:     "FirstBlood Token",
 				Symbol:   "1ST",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x12fef5e57bf45873cd9b62e9dbd7bfb99e32d73e"),
 				Name:     "Cofoundit",
 				Symbol:   "CFI",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xf0ee6b27b759c9893ce4f094b49ad28fd15a23e4"),
 				Name:     "Enigma",
 				Symbol:   "ENG",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x4dc3643dbc642b72c158e7f3d2ff232df61cb6ce"),
 				Name:     "Amber Token",
 				Symbol:   "AMB",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x90528aeb3a2b736b780fd1b6c478bb7e1d643170"),
 				Name:     "XPlay Token",
 				Symbol:   "XPA",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x881ef48211982d01e2cb7092c915e647cd40d85c"),
 				Name:     "Open Trading Network",
 				Symbol:   "OTN",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xcb94be6f13a1182e4a4b6140cb7bf2025d28e41b"),
 				Name:     "Trustcoin",
 				Symbol:   "TRST",
 				Decimals: 6,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xaaaf91d9b90df800df4f55c205fd6989c977e73a"),
 				Name:     "Monolith TKN",
 				Symbol:   "TKN",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x168296bb09e24a88805cb9c33356536b980d3fc5"),
 				Name:     "RHOC",
 				Symbol:   "RHOC",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xac3da587eac229c9896d919abc235ca4fd7f72c1"),
 				Name:     "Target Coin",
 				Symbol:   "TGT",
 				Decimals: 1,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xf3db5fa2c66b7af3eb0c0b782510816cbe4813b8"),
 				Name:     "Everex",
 				Symbol:   "EVX",
 				Decimals: 4,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x014b50466590340d41307cc54dcee990c8d58aa8"),
 				Name:     "ICOS",
 				Symbol:   "ICOS",
 				Decimals: 6,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x08d32b0da63e2c3bcf8019c9c5d849d7a9d791e6"),
 				Name:     "Dentacoin",
 				Symbol:   "DCN",
 				Decimals: 0,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xced4e93198734ddaff8492d525bd258d49eb388e"),
 				Name:     "Eidoo Token",
 				Symbol:   "EDO",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x29d75277ac7f0335b2165d0895e8725cbf658d73"),
 				Name:     "BitDice",
 				Symbol:   "CSNO",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xb2f7eb1f2c37645be61d73953035360e768d81e6"),
 				Name:     "Cobinhood Token",
 				Symbol:   "COB",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xd4c435f5b09f855c3317c8524cb1f586e42795fa"),
 				Name:     "Cindicator Token",
 				Symbol:   "CND",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x4df812f6064def1e5e029f1ca858777cc98d2d81"),
 				Name:     "Xaurum",
 				Symbol:   "XAUR",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x2c974b2d0ba1716e644c1fc59982a89ddd2ff724"),
 				Name:     "Vibe",
 				Symbol:   "VIB",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x7728dfef5abd468669eb7f9b48a7f70a501ed29d"),
 				Name:     "PRG",
 				Symbol:   "PRG",
 				Decimals: 6,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x6c2adc2073994fb2ccc5032cc2906fa221e9b391"),
 				Name:     "Delphy Token",
 				Symbol:   "DPY",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x2fe6ab85ebbf7776fee46d191ee4cea322cecf51"),
 				Name:     "CoinDash Token",
 				Symbol:   "CDT",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x08f5a9235b08173b7569f83645d2c7fb55e8ccd8"),
 				Name:     "Tierion Network Token",
 				Symbol:   "TNT",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x9af4f26941677c706cfecf6d3379ff01bb85d5ab"),
 				Name:     "DomRaiderToken",
 				Symbol:   "DRT",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x42d6622dece394b54999fbd73d108123806f6a18"),
 				Name:     "SPANK",
 				Symbol:   "SPANK",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x80046305aaab08f6033b56a360c184391165dc2d"),
 				Name:     "Berlin Coin",
 				Symbol:   "BRLN",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x2c4e8f2d746113d0696ce89b35f0d8bf88e0aeca"),
 				Name:     "Simple Token",
 				Symbol:   "ST",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x107c4504cd79c5d2696ea0030a8dd4e92601b82e"),
 				Name:     "Bloom Token",
 				Symbol:   "BLT",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x96a65609a7b84e8842732deb08f56c3e21ac6f8a"),
 				Name:     "Centra token",
 				Symbol:   "Centra",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x2e071d2966aa7d8decb1005885ba1977d6038a65"),
 				Name:     "DICE",
 				Symbol:   "ROL",
 				Decimals: 16,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x9b11efcaaa1890f6ee52c6bb7cf8153ac5d74139"),
 				Name:     "Attention Token of Media",
 				Symbol:   "ATM",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x80fB784B7eD66730e8b1DBd9820aFD29931aab03"),
 				Name:     "EthLend Token",
 				Symbol:   "LEND",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xA15C7Ebe1f07CaF6bFF097D8a589fb8AC49Ae5B3"),
 				Name:     "Pundi X Token",
 				Symbol:   "NPXS",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x0e0989b1f9B8A38983c2BA8053269Ca62Ec9B195"),
 				Name:     "Po.et",
 				Symbol:   "POE",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xFA1a856Cfa3409CFa145Fa4e20Eb270dF3EB21ab"),
 				Name:     "IOSToken",
 				Symbol:   "IOST",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xEA26c4aC16D4a5A106820BC8AEE85fd0b7b2b664"),
 				Name:     "QuarkChain Token",
 				Symbol:   "QKC",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x865ec58b06bF6305B886793AA20A2da31D034E68"),
 				Name:     "Moss Coin",
 				Symbol:   "MOC",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x8400D94A5cb0fa0D041a3788e395285d61c9ee5e"),
 				Name:     "UniBright",
 				Symbol:   "UBT",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x4f3AfEC4E5a3F2A6a1A411DEF7D7dFe50eE057bF"),
 				Name:     "Digix Gold Token",
 				Symbol:   "DGX",
 				Decimals: 9,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xEA38eAa3C86c8F9B751533Ba2E562deb9acDED40"),
 				Name:     "Fuel Token",
 				Symbol:   "FUEL",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x00000100F2A2bd000715001920eB70D229700085"),
 				Name:     "TrueCAD",
 				Symbol:   "TCAD",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x6710c63432A2De02954fc0f851db07146a6c0312"),
 				Name:     "SyncFab Smart Manufacturing Blockchain",
 				Symbol:   "MFG",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x543Ff227F64Aa17eA132Bf9886cAb5DB55DCAddf"),
 				Name:     "DAOstack",
 				Symbol:   "GEN",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x0E8d6b471e332F140e7d9dbB99E5E3822F728DA6"),
 				Name:     "ABYSS",
 				Symbol:   "ABYSS",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xB62132e35a6c13ee1EE0f84dC5d40bad8d815206"),
 				Name:     "Nexo",
 				Symbol:   "NEXO",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x0000000000085d4780B73119b644AE5ecd22b376"),
 				Name:     "TrueUSD",
 				Symbol:   "TUSD",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xD0a4b8946Cb52f0661273bfbC6fD0E0C75Fc6433"),
 				Name:     "Storm Token",
 				Symbol:   "STORM",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xaF4DcE16Da2877f8c9e00544c93B62Ac40631F16"),
 				Name:     "Monetha",
 				Symbol:   "MTH",
 				Decimals: 5,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x00000000441378008EA67F4284A57932B1c000a5"),
 				Name:     "TrueGBP",
 				Symbol:   "TGBP",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xbf2179859fc6D5BEE9Bf9158632Dc51678a4100e"),
 				Name:     "ELF Token",
 				Symbol:   "ELF",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x20F7A3DdF244dc9299975b4Da1C39F8D5D75f05A"),
 				Name:     "Sapien Network",
 				Symbol:   "SPN",
 				Decimals: 6,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x1a7a8BD9106F2B8D977E08582DC7d24c723ab0DB"),
 				Name:     "AppCoins",
 				Symbol:   "APPC",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xa3d58c4E56fedCae3a7c43A725aeE9A71F0ece4e"),
 				Name:     "Metronome",
 				Symbol:   "MET",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x6f259637dcD74C767781E37Bc6133cd6A68aa161"),
 				Name:     "HuobiToken",
 				Symbol:   "HT",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x8f3470A7388c05eE4e7AF3d01D8C722b0FF52374"),
 				Name:     "Veritaseum",
 				Symbol:   "VERI",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x00006100F7090010005F1bd7aE6122c3C2CF0090"),
 				Name:     "TrueAUD",
 				Symbol:   "TAUD",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x66497A283E0a007bA3974e837784C6AE323447de"),
 				Name:     "PornToken",
 				Symbol:   "PT",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xB24754bE79281553dc1adC160ddF5Cd9b74361a4"),
 				Name:     "RIALTO",
 				Symbol:   "XRL",
 				Decimals: 9,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x07e3c70653548B04f0A75970C1F81B4CBbFB606f"),
 				Name:     "Delta",
 				Symbol:   "DLT",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x554C20B7c486beeE439277b4540A434566dC4C02"),
 				Name:     "Decision Token",
 				Symbol:   "HST",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x286BDA1413a2Df81731D4930ce2F862a35A609fE"),
 				Name:     "WaBi",
 				Symbol:   "WaBi",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xE5a3229CCb22b6484594973A03a3851dCd948756"),
 				Name:     "RAE Token",
 				Symbol:   "RAE",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x24692791Bc444c5Cd0b81e3CBCaba4b04Acd1F3B"),
 				Name:     "UnikoinGold",
 				Symbol:   "UKG",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xD46bA6D942050d489DBd938a2C909A5d5039A161"),
 				Name:     "Ampleforth",
 				Symbol:   "AMPL",
 				Decimals: 9,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xA4Bdb11dc0a2bEC88d24A3aa1E6Bb17201112eBe"),
 				Name:     "Stably USD Classic",
 				Symbol:   "USDSC",
 				Decimals: 6,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x81c9151de0C8bafCd325a57E3dB5a5dF1CEBf79c"),
 				Name:     "Datum Token",
 				Symbol:   "DAT",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xa6a840E50bCaa50dA017b91A0D86B8b2d41156EE"),
 				Name:     "EchoLink",
 				Symbol:   "EKO",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x4a57E687b9126435a9B19E4A802113e266AdeBde"),
 				Name:     "Flexacoin",
 				Symbol:   "FXC",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xC86D054809623432210c107af2e3F619DcFbf652"),
 				Name:     "SENTINEL PROTOCOL",
 				Symbol:   "UPP",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x69b148395ce0015c13e36bffbad63f49ef874e03"),
 				Name:     "Data Token",
 				Symbol:   "DTA",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643"),
 				Name:     "Compound Dai",
 				Symbol:   "cDAI",
 				Decimals: 8,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xa7fc5d2453e3f68af0cc1b78bcfee94a1b293650"),
 				Name:     "Spiking",
 				Symbol:   "SPIKE",
 				Decimals: 10,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7"),
 				Name:     "Akropolis",
 				Symbol:   "AKRO",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x9ba00d6856a4edf4665bca2c2309936572473b7e"),
 				Name:     "Aave Interest bearing USDC",
 				Symbol:   "aUSDC",
 				Decimals: 6,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xEEF9f339514298C6A857EfCfC1A762aF84438dEE"),
 				Name:     "Hermez Network Token",
 				Symbol:   "HEZ",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd"),
 				Name:     "ETH 2x Flexible Leverage Index",
 				Symbol:   "ETH2x-FLI",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xDd1Ad9A21Ce722C151A836373baBe42c868cE9a4"),
 				Name:     "Universal Basic Income",
 				Symbol:   "UBI",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xae78736cd615f374d3085123a210448e74fc6393"),
 				Name:     "Rocket Pool",
 				Symbol:   "rETH",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xb0c7a3ba49c7a6eaba6cd4a96c55a1391070ac9a"),
 				Name:     "Magic Proxy",
 				Symbol:   "MAGIC",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"),
 				Name:     "Hop",
 				Symbol:   "HOP",
 				Decimals: 18,
 				ChainID:  1,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xc55cf4b03948d7ebc8b9e8bad92643703811d162"),
 				Name:     "Status Test Token",
 				Symbol:   "STT",
 				Decimals: 18,
 				ChainID:  3,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xdee43a267e8726efd60c2e7d5b81552dcd4fa35c"),
 				Name:     "Handy Test Token",
 				Symbol:   "HND",
 				Decimals: 0,
 				ChainID:  3,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x703d7dc0bc8e314d65436adf985dda51e09ad43b"),
 				Name:     "Lucky Test Token",
 				Symbol:   "LXS",
 				Decimals: 2,
 				ChainID:  3,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xe639e24346d646e927f323558e6e0031bfc93581"),
 				Name:     "Adi Test Token",
 				Symbol:   "ADI",
 				Decimals: 7,
 				ChainID:  3,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x2e7cd05f437eb256f363417fd8f920e2efa77540"),
 				Name:     "Wagner Test Token",
 				Symbol:   "WGN",
 				Decimals: 10,
 				ChainID:  3,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x57cc9b83730e6d22b224e9dc3e370967b44a2de0"),
 				Name:     "Modest Test Token",
 				Symbol:   "MDS",
 				Decimals: 18,
 				ChainID:  3,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x6ba7dc8dd10880ab83041e60c4ede52bb607864b"),
 				Name:     "Moksha Coin",
 				Symbol:   "MOKSHA",
 				Decimals: 18,
 				ChainID:  4,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x7d4ccf6af2f0fdad48ee7958bcc28bdef7b732c7"),
 				Name:     "WIBB",
 				Symbol:   "WIBB",
 				Decimals: 18,
 				ChainID:  4,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x43d5adc3b49130a575ae6e4b00dfa4bc55c71621"),
 				Name:     "Status Test Token",
 				Symbol:   "STT",
 				Decimals: 18,
 				ChainID:  4,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x3d6afaa395c31fcd391fe3d562e75fe9e8ec7e6a"),
 				Name:     "Status Test Token",
 				Symbol:   "STT",
 				Decimals: 18,
 				ChainID:  5,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x98339d8c260052b7ad81c28c16c0b98420f2b46a"),
 				Name:     "USD Coin",
 				Symbol:   "USDC",
 				Decimals: 6,
 				ChainID:  5,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x022e292b44b5a146f2e8ee36ff44d3dd863c915c"),
 				Name:     "Xeenus 💪",
 				Symbol:   "XEENUS",
 				Decimals: 18,
 				ChainID:  5,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xc6fde3fd2cc2b173aec24cc3f267cb3cd78a26b7"),
 				Name:     "Yeenus 💪",
 				Symbol:   "YEENUS",
 				Decimals: 8,
 				ChainID:  5,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x1f9061b953bba0e36bf50f21876132dcf276fc6e"),
 				Name:     "Zeenus 💪",
 				Symbol:   "ZEENUS",
 				Decimals: 0,
 				ChainID:  5,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xf4B2cbc3bA04c478F0dC824f4806aC39982Dce73"),
 				Name:     "Tether USD",
 				Symbol:   "USDT",
 				Decimals: 6,
 				ChainID:  5,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xf2edF1c091f683E3fb452497d9a98A49cBA84666"),
 				Name:     "DAI Stablecoin",
 				Symbol:   "DAI",
 				Decimals: 18,
 				ChainID:  5,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"),
 				Name:     "Hop",
 				Symbol:   "HOP",
 				Decimals: 18,
 				ChainID:  10,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x9Bcef72be871e61ED4fBbc7630889beE758eb81D"),
 				Name:     "Rocket Pool",
 				Symbol:   "rETH",
 				Decimals: 18,
 				ChainID:  10,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x3e50bf6703fc132a94e4baff068db2055655f11b"),
 				Name:     "buffiDai",
 				Symbol:   "BUFF",
 				Decimals: 18,
 				ChainID:  100,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xcb4ceefce514b2d910d3ac529076d18e3add3775"),
 				Name:     "USD Coin",
 				Symbol:   "USDC",
 				Decimals: 6,
 				ChainID:  420,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x4d15a3a2286d883af0aa1b3f21367843fac63e07"),
 				Name:     "True USD",
 				Symbol:   "TUSD",
 				Decimals: 18,
 				ChainID:  42161,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x680447595e8b7b3aa1b43beb9f6098c79ac2ab3f"),
 				Name:     "Decentralized USD",
 				Symbol:   "USDD",
 				Decimals: 18,
 				ChainID:  42161,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xc5102fe9359fd9a28f877a67e36b0f050d81a3cc"),
 				Name:     "Hop",
 				Symbol:   "HOP",
 				Decimals: 18,
 				ChainID:  42161,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8"),
 				Name:     "Rocket Pool",
 				Symbol:   "rETH",
 				Decimals: 18,
 				ChainID:  42161,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x17078F231AA8dc256557b49a8f2F72814A71f633"),
 				Name:     "USD Coin",
 				Symbol:   "USDC",
 				Decimals: 6,
 				ChainID:  421613,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x265B25e22bcd7f10a5bD6E6410F10537Cc7567e8"),
 				Name:     "Tether USD",
 				Symbol:   "USDT",
 				Decimals: 6,
 				ChainID:  421613,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xE452027cdEF746c7Cd3DB31CB700428b16cD8E51"),
 				Name:     "Status Test Token",
 				Symbol:   "STT",
 				Decimals: 18,
 				ChainID:  11155111,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xfDB3b57944943a7724fCc0520eE2B10659969a06"),
 				Name:     "Status Test Token",
 				Symbol:   "STT",
 				Decimals: 18,
 				ChainID:  84532,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x3e622317f8c93f7328350cf0b56d9ed4c620c5d6"),
 				Name:     "Dai Stablecoin",
 				Symbol:   "DAI",
 				Decimals: 18,
 				ChainID:  11155111,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x7439E9Bb6D8a84dd3A23fe621A30F95403F87fB9"),
 				Name:     "WEENUS Token",
 				Symbol:   "WEENUS",
 				Decimals: 18,
 				ChainID:  11155111,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xc21d97673B9E0B3AA53a06439F71fDc1facE393B"),
 				Name:     "XEENUS Token",
 				Symbol:   "XEENUS",
 				Decimals: 18,
 				ChainID:  11155111,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x93fCA4c6E2525C09c95269055B46f16b1459BF9d"),
 				Name:     "YEENUS Token",
 				Symbol:   "YEENUS",
 				Decimals: 8,
 				ChainID:  11155111,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0xe9EF74A6568E9f0e42a587C9363C9BcC582dcC6c"),
 				Name:     "ZEENUS Token",
 				Symbol:   "ZEENUS",
 				Decimals: 0,
 				ChainID:  11155111,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x07391dbE03e7a0DEa0fce6699500da081537B6c3"),
 				Name:     "WETH9 Token",
 				Symbol:   "WETH9",
 				Decimals: 18,
 				ChainID:  11155111,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x08210F9170F89Ab7658F0B5E3fF39b0E03C594D4"),
 				Name:     "Euro Coin",
 				Symbol:   "EURC",
 				Decimals: 6,
 				ChainID:  11155111,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x808456652fdb597867f38412077A9182bf77359F"),
 				Name:     "Euro Coin",
 				Symbol:   "EURC",
 				Decimals: 6,
 				ChainID:  84532,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"),
 				Name:     "USD Coin",
 				Symbol:   "USDC",
 				Decimals: 6,
 				ChainID:  11155111,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d"),
 				Name:     "USD Coin",
 				Symbol:   "USDC",
 				Decimals: 6,
 				ChainID:  421614,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x5fd84259d66Cd46123540766Be93DFE6D43130D7"),
 				Name:     "USD Coin",
 				Symbol:   "USDC",
 				Decimals: 6,
 				ChainID:  11155420,
 			},
-			&Token{
+			&tokenTypes.Token{
 				Address:  common.HexToAddress("0x036CbD53842c5426634e7929541eC2318f3dCF7e"),
 				Name:     "USD Coin",
 				Symbol:   "USDC",
@@ -1161,6 +1162,6 @@ func NewDefaultStore() *DefaultStore {
 	}
 }
 
-func (s *DefaultStore) GetTokens() []*Token {
+func (s *DefaultStore) GetTokens() []*tokenTypes.Token {
 	return s.TokenListID
 }

--- a/services/wallet/token/types/balance.go
+++ b/services/wallet/token/types/balance.go
@@ -1,0 +1,28 @@
+package tokentypes
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type TokenMarketValues struct {
+	MarketCap       float64 `json:"marketCap"`
+	HighDay         float64 `json:"highDay"`
+	LowDay          float64 `json:"lowDay"`
+	ChangePctHour   float64 `json:"changePctHour"`
+	ChangePctDay    float64 `json:"changePctDay"`
+	ChangePct24hour float64 `json:"changePct24hour"`
+	Change24hour    float64 `json:"change24hour"`
+	Price           float64 `json:"price"`
+	HasError        bool    `json:"hasError"`
+}
+
+type ChainBalance struct {
+	RawBalance     string         `json:"rawBalance"`
+	Balance        *big.Float     `json:"balance"`
+	Balance1DayAgo string         `json:"balance1DayAgo"`
+	Address        common.Address `json:"address"`
+	ChainID        uint64         `json:"chainId"`
+	HasError       bool           `json:"hasError"`
+}

--- a/services/wallet/token/types/token.go
+++ b/services/wallet/token/types/token.go
@@ -1,0 +1,40 @@
+package tokentypes
+
+import (
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/services/wallet/community"
+)
+
+type Token struct {
+	Address common.Address `json:"address"`
+	Name    string         `json:"name"`
+	Symbol  string         `json:"symbol"`
+	// Decimals defines how divisible the token is. For example, 0 would be
+	// indivisible, whereas 18 would allow very small amounts of the token
+	// to be traded.
+	Decimals uint   `json:"decimals"`
+	ChainID  uint64 `json:"chainId"`
+	// PegSymbol indicates that the token is pegged to some fiat currency, using the
+	// ISO 4217 alphabetic code. For example, an empty string means it is not
+	// pegged, while "USD" means it's pegged to the United States Dollar.
+	PegSymbol string `json:"pegSymbol"`
+	Image     string `json:"image,omitempty"`
+
+	CommunityData *community.Data `json:"community_data,omitempty"`
+	Verified      bool            `json:"verified"`
+}
+
+type StorageToken struct {
+	Token
+	BalancesPerChain        map[uint64]ChainBalance      `json:"balancesPerChain"`
+	Description             string                       `json:"description"`
+	AssetWebsiteURL         string                       `json:"assetWebsiteUrl"`
+	BuiltOn                 string                       `json:"builtOn"`
+	MarketValuesPerCurrency map[string]TokenMarketValues `json:"marketValuesPerCurrency"`
+}
+
+func (t *Token) IsNative() bool {
+	return strings.EqualFold(t.Symbol, "ETH")
+}

--- a/services/wallet/token/uniswap.go
+++ b/services/wallet/token/uniswap.go
@@ -2,13 +2,14 @@ package token
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 var uniswapVersion = "13.11.0"
 
 var uniswapTimestamp = int64(1740787797)
 
-var uniswapTokens = []*Token{
+var uniswapTokens = []*tokenTypes.Token{
 
 	{
 		Address:   common.HexToAddress("0x111111111117dC0aa78b770fA6A738034120C302"),

--- a/services/wallet/token/uniswap_tokenstore.go
+++ b/services/wallet/token/uniswap_tokenstore.go
@@ -1,5 +1,7 @@
 package token
 
+import tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
+
 type uniswapStore struct {
 }
 
@@ -7,7 +9,7 @@ func NewUniswapStore() *uniswapStore {
 	return &uniswapStore{}
 }
 
-func (s *uniswapStore) GetTokens() []*Token {
+func (s *uniswapStore) GetTokens() []*tokenTypes.Token {
 	return uniswapTokens
 }
 

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/status-im/status-go/contracts"
 	"github.com/status-im/status-go/services/wallet/blockchainstate"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/t/utils"
 
 	"github.com/pkg/errors"
@@ -1092,7 +1093,7 @@ func setupFindBlocksCommand(t *testing.T, accountAddress common.Address, fromBlo
 
 	client.SetClient(tc.NetworkID(), tc)
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb, nil, nil, nil), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
-	tokenManager.SetTokens([]*token.Token{
+	tokenManager.SetTokens([]*tokenTypes.Token{
 		{
 			Address:  tokenTXXAddress,
 			Symbol:   "TXX",
@@ -1363,7 +1364,7 @@ func TestFetchTransfersForLoadedBlocks(t *testing.T) {
 	client.SetClient(tc.NetworkID(), tc)
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb, nil, nil, nil), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
-	tokenManager.SetTokens([]*token.Token{
+	tokenManager.SetTokens([]*tokenTypes.Token{
 		{
 			Address:  tokenTXXAddress,
 			Symbol:   "TXX",
@@ -1494,7 +1495,7 @@ func TestFetchNewBlocksCommand_findBlocksWithEthTransfers(t *testing.T) {
 		client.SetClient(tc.NetworkID(), tc)
 		tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb, nil, nil, nil), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
-		tokenManager.SetTokens([]*token.Token{
+		tokenManager.SetTokens([]*tokenTypes.Token{
 			{
 				Address:  tokenTXXAddress,
 				Symbol:   "TXX",
@@ -1705,7 +1706,7 @@ func TestFetchNewBlocksCommand(t *testing.T) {
 
 	tokenManager := token.NewTokenManager(db, client, community.NewManager(appdb, nil, nil), network.NewManager(appdb, nil, nil, nil), appdb, mediaServer, nil, nil, nil, token.NewPersistence(db))
 
-	tokenManager.SetTokens([]*token.Token{
+	tokenManager.SetTokens([]*tokenTypes.Token{
 		{
 			Address:  tokenTXXAddress,
 			Symbol:   "TXX",

--- a/services/wallet/transfer/testutils.go
+++ b/services/wallet/transfer/testutils.go
@@ -13,7 +13,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/bigint"
 	"github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/testutils"
-	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +34,7 @@ type TestTransfer struct {
 	TestTransaction
 	To    eth_common.Address // [address]
 	Value int64
-	Token *token.Token
+	Token *tokenTypes.Token
 }
 
 type TestCollectibleTransfer struct {
@@ -42,12 +42,12 @@ type TestCollectibleTransfer struct {
 	TestCollectible
 }
 
-func SeedToToken(seed int) *token.Token {
+func SeedToToken(seed int) *tokenTypes.Token {
 	tokenIndex := seed % len(TestTokens)
 	return TestTokens[tokenIndex]
 }
 
-func TestTrToToken(t *testing.T, tt *TestTransaction) (token *token.Token, isNative bool) {
+func TestTrToToken(t *testing.T, tt *TestTransaction) (token *tokenTypes.Token, isNative bool) {
 	// Sanity check that none of the markers changed and they should be equal to seed
 	require.Equal(t, tt.Timestamp, tt.BlkNumber)
 
@@ -94,7 +94,7 @@ func generateTestCollectibleTransfer(seed int) TestCollectibleTransfer {
 			TestTransaction: generateTestTransaction(seed),
 			To:              eth_common.HexToAddress(fmt.Sprintf("0x3%d", seed)),
 			Value:           int64(seed),
-			Token: &token.Token{
+			Token: &tokenTypes.Token{
 				Address: collectible.TokenAddress,
 				Name:    "Collectible",
 				ChainID: uint64(collectible.ChainID),
@@ -208,35 +208,35 @@ var TestCollectibles = []TestCollectible{
 	},
 }
 
-var EthMainnet = token.Token{
+var EthMainnet = tokenTypes.Token{
 	Address: eth_common.HexToAddress("0x"),
 	Name:    "Ether",
 	Symbol:  "ETH",
 	ChainID: 1,
 }
 
-var EthSepolia = token.Token{
+var EthSepolia = tokenTypes.Token{
 	Address: eth_common.HexToAddress("0x"),
 	Name:    "Ether",
 	Symbol:  "ETH",
 	ChainID: 11155111,
 }
 
-var EthOptimism = token.Token{
+var EthOptimism = tokenTypes.Token{
 	Address: eth_common.HexToAddress("0x"),
 	Name:    "Ether",
 	Symbol:  "ETH",
 	ChainID: 10,
 }
 
-var UsdcMainnet = token.Token{
+var UsdcMainnet = tokenTypes.Token{
 	Address: eth_common.HexToAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"),
 	Name:    "USD Coin",
 	Symbol:  "USDC",
 	ChainID: 1,
 }
 
-var UsdcSepolia = token.Token{
+var UsdcSepolia = tokenTypes.Token{
 	Address:  eth_common.HexToAddress("0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238"),
 	Name:     "USD Coin",
 	Symbol:   "USDC",
@@ -244,28 +244,28 @@ var UsdcSepolia = token.Token{
 	ChainID:  11155111,
 }
 
-var UsdcOptimism = token.Token{
+var UsdcOptimism = tokenTypes.Token{
 	Address: eth_common.HexToAddress("0x7f5c764cbc14f9669b88837ca1490cca17c31607"),
 	Name:    "USD Coin",
 	Symbol:  "USDC",
 	ChainID: 10,
 }
 
-var SntMainnet = token.Token{
+var SntMainnet = tokenTypes.Token{
 	Address: eth_common.HexToAddress("0x744d70fdbe2ba4cf95131626614a1763df805b9e"),
 	Name:    "Status Network Token",
 	Symbol:  "SNT",
 	ChainID: 1,
 }
 
-var DaiMainnet = token.Token{
+var DaiMainnet = tokenTypes.Token{
 	Address: eth_common.HexToAddress("0xf2edF1c091f683E3fb452497d9a98A49cBA84666"),
 	Name:    "DAI Stablecoin",
 	Symbol:  "DAI",
 	ChainID: 5,
 }
 
-var DaiSepolia = token.Token{
+var DaiSepolia = tokenTypes.Token{
 	Address:  eth_common.HexToAddress("0x3e622317f8c93f7328350cf0b56d9ed4c620c5d6"),
 	Name:     "DAI Stablecoin",
 	Symbol:   "DAI",
@@ -274,11 +274,11 @@ var DaiSepolia = token.Token{
 }
 
 // TestTokens contains ETH/Mainnet, ETH/Sepolia, ETH/Optimism, USDC/Mainnet, USDC/Sepolia, USDC/Optimism, SNT/Mainnet, DAI/Mainnet, DAI/Sepolia
-var TestTokens = []*token.Token{
+var TestTokens = []*tokenTypes.Token{
 	&EthMainnet, &EthSepolia, &EthOptimism, &UsdcMainnet, &UsdcSepolia, &UsdcOptimism, &SntMainnet, &DaiMainnet, &DaiSepolia,
 }
 
-func LookupTokenIdentity(chainID uint64, address eth_common.Address, native bool) *token.Token {
+func LookupTokenIdentity(chainID uint64, address eth_common.Address, native bool) *tokenTypes.Token {
 	for _, token := range TestTokens {
 		if token.ChainID == chainID && token.Address == address && token.IsNative() == native {
 			return token


### PR DESCRIPTION
This change is needed for the upcoming PR, which will auto-refresh token lists.

The following types are moved from `services/wallet/token` to `services/wallet/token/types` location:
- `Token`
- `StorageToken`
- `TokenMarketValues`
- `ChainBalance`

Need for the follow-up PR:
- https://github.com/status-im/status-go/pull/6398
- https://github.com/status-im/status-go/pull/6399
