### PR TITLE
refactor_: replace golang.org/x/exp with stdlib

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -8,15 +8,14 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
-	slices "golang.org/x/exp/slices"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-
 	"github.com/status-im/status-go/api/multiformat"
 	utils "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/eth-node/crypto"

--- a/protocol/communities/community_changes.go
+++ b/protocol/communities/community_changes.go
@@ -3,8 +3,7 @@ package communities
 import (
 	"bytes"
 	"crypto/ecdsa"
-
-	slices "golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/status-im/status-go/protocol/protobuf"
 )

--- a/protocol/communities/permission_checker.go
+++ b/protocol/communities/permission_checker.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
+	"slices"
 	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
-
-	maps "golang.org/x/exp/maps"
-	slices "golang.org/x/exp/slices"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"

--- a/protocol/communities/roles_authorization.go
+++ b/protocol/communities/roles_authorization.go
@@ -1,7 +1,7 @@
 package communities
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/status-im/status-go/protocol/protobuf"
 )

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -7,32 +7,27 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"
-	"golang.org/x/time/rate"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-
-	"go.uber.org/zap"
-
 	gocommon "github.com/status-im/status-go/common"
 	utils "github.com/status-im/status-go/common"
-	messagingtypes "github.com/status-im/status-go/messaging/types"
-
-	multiaccountscommon "github.com/status-im/status-go/multiaccounts/common"
-
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/images"
+	messagingtypes "github.com/status-im/status-go/messaging/types"
 	"github.com/status-im/status-go/multiaccounts/accounts"
+	multiaccountscommon "github.com/status-im/status-go/multiaccounts/common"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/communities/token"

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -5,23 +5,17 @@ import (
 	"database/sql"
 	"fmt"
 	"math/big"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/status-im/status-go/contracts"
-	"github.com/status-im/status-go/services/wallet/blockchainstate"
-	"github.com/status-im/status-go/services/wallet/token/token-lists/fetcher"
-	"github.com/status-im/status-go/t/utils"
-
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
-	"go.uber.org/mock/gomock"
-	"golang.org/x/exp/slices" // since 1.21, this is in the standard library
-
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -30,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/contracts"
 	"github.com/status-im/status-go/contracts/balancechecker"
 	"github.com/status-im/status-go/contracts/ethscan"
 	"github.com/status-im/status-go/contracts/ierc20"
@@ -46,10 +41,13 @@ import (
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/wallet/async"
 	"github.com/status-im/status-go/services/wallet/balance"
+	"github.com/status-im/status-go/services/wallet/blockchainstate"
 	walletcommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/community"
 	"github.com/status-im/status-go/services/wallet/token"
+	"github.com/status-im/status-go/services/wallet/token/token-lists/fetcher"
 	"github.com/status-im/status-go/t/helpers"
+	"github.com/status-im/status-go/t/utils"
 	"github.com/status-im/status-go/transactions"
 	"github.com/status-im/status-go/walletdatabase"
 )

--- a/services/wallet/transfer/controller.go
+++ b/services/wallet/transfer/controller.go
@@ -3,9 +3,9 @@ package transfer
 import (
 	"context"
 	"database/sql"
+	"slices"
 
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices" // since 1.21, this is in the standard library
 
 	"github.com/ethereum/go-ethereum/common"
 	gocommon "github.com/status-im/status-go/common"

--- a/services/wallet/transfer/downloader.go
+++ b/services/wallet/transfer/downloader.go
@@ -4,16 +4,15 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"slices"
 	"time"
 
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices" // since 1.21, this is in the standard library
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/rpc/chain"
 	w_common "github.com/status-im/status-go/services/wallet/common"

--- a/wakuv2/api_test.go
+++ b/wakuv2/api_test.go
@@ -19,10 +19,9 @@
 package wakuv2
 
 import (
+	"maps"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/status-im/status-go/waku/types"
 	"github.com/status-im/status-go/wakuv2/common"

--- a/wakuv2/common/filter.go
+++ b/wakuv2/common/filter.go
@@ -21,10 +21,10 @@ package common
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"maps"
 	"sync"
 
 	"go.uber.org/zap"
-	"golang.org/x/exp/maps"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"


### PR DESCRIPTION
Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library.
Also done `goimports` operation




Important changes:
- [x] Something worth noting for reviewers.

Closes #
