### PR TITLE
chore_: add SetLogEnabled endpoint for runtime log configuration

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -3005,3 +3005,16 @@ func (b *GethStatusBackend) SetLogNamespaces(namespaces string) error {
 
 	return logutils.OverrideRootLoggerWithConfig(b.config.DefaultLogSettings())
 }
+
+func (b *GethStatusBackend) SetLogEnabled(enabled bool) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	err := nodecfg.SetLogEnabled(b.appDB, enabled)
+	if err != nil {
+		return err
+	}
+	b.config.LogEnabled = enabled
+
+	return logutils.OverrideRootLoggerWithConfig(b.config.DefaultLogSettings())
+}

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -2361,6 +2361,20 @@ func setLogNamespaces(requestJSON string) string {
 	return makeJSONResponse(statusBackend.SetLogNamespaces(request.LogNamespaces))
 }
 
+func SetLogEnabled(requestJSON string) string {
+	return callWithResponse(setLogEnabled, requestJSON)
+}
+
+func setLogEnabled(requestJSON string) string {
+	var request requests.SetLogEnabled
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	return makeJSONResponse(statusBackend.SetLogEnabled(request.Enabled))
+}
+
 func IntendedPanic(message string) string {
 	type intendedPanic struct {
 		error

--- a/protocol/messenger_settings.go
+++ b/protocol/messenger_settings.go
@@ -48,6 +48,7 @@ func (m *Messenger) SetLogNamespaces(request *requests.SetLogNamespaces) error {
 	return nodecfg.SetLogNamespaces(m.database, request.LogNamespaces)
 }
 
+// Deprecated: Use SetLogEnabled from status.go instead.
 func (m *Messenger) SetLogEnabled(enabled bool) error {
 	return nodecfg.SetLogEnabled(m.database, enabled)
 }

--- a/protocol/requests/set_log_enabled.go
+++ b/protocol/requests/set_log_enabled.go
@@ -1,0 +1,5 @@
+package requests
+
+type SetLogEnabled struct {
+	Enabled bool `json:"enabled"`
+}

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1788,14 +1788,17 @@ func (api *PublicAPI) SetStoreConfirmationForMessagesSent(request *requests.SetS
 	return api.service.messenger.SetStoreConfirmationForMessagesSent(request)
 }
 
+// Deprecated: Use SetLogLevel from status.go instead. BTW, mobile don't use this anymore.
 func (api *PublicAPI) SetLogLevel(request *requests.SetLogLevel) error {
 	return api.service.messenger.SetLogLevel(request)
 }
 
+// Deprecated: Use SetLogNamespaces from status.go instead. BTW, mobile don't use this anymore.
 func (api *PublicAPI) SetLogNamespaces(request *requests.SetLogNamespaces) error {
 	return api.service.messenger.SetLogNamespaces(request)
 }
 
+// Deprecated: Use SetLogEnabled from status.go instead. BTW, mobile don't use this anymore.
 func (api *PublicAPI) SetLogEnabled(enabled bool) error {
 	return api.service.messenger.SetLogEnabled(enabled)
 }

--- a/tests-functional/tests/test_logging.py
+++ b/tests-functional/tests/test_logging.py
@@ -44,13 +44,25 @@ class TestLogging:
         geth_log = backend_client.extract_data(os.path.join(USER_DIR, "geth.log"))
         self.expect_logs(geth_log, "test message", log_pattern, count=1)
 
+        # Disable logging
+        backend_client.api_valid_request("SetLogEnabled", {"enabled": False})
+        backend_client.rpc_valid_request("wakuext_logTest")
+        geth_log = backend_client.extract_data(os.path.join(USER_DIR, "geth.log"))
+        self.expect_logs(geth_log, "test message", log_pattern, count=1)
+
+        # Enable logging
+        backend_client.api_valid_request("SetLogEnabled", {"enabled": True})
+        backend_client.rpc_valid_request("wakuext_logTest")
+        geth_log = backend_client.extract_data(os.path.join(USER_DIR, "geth.log"))
+        self.expect_logs(geth_log, "test message", log_pattern, count=2)
+
         # Ensure changes are persisted after re-login
         backend_client.logout()
         backend_client.login(str(backend_client.find_key_uid()))
         backend_client.wait_for_login()
         backend_client.rpc_valid_request("wakuext_logTest")
         geth_log = backend_client.extract_data(os.path.join(USER_DIR, "geth.log"))
-        self.expect_logs(geth_log, "test message", log_pattern, count=2)
+        self.expect_logs(geth_log, "test message", log_pattern, count=3)
 
     def expect_logs(self, log_file, filter_keyword, expected_logs, count):
         with open(log_file, "r") as f:


### PR DESCRIPTION
This PR is based on branch `chore/setup-logging-at-runtime` , relate [PR](https://github.com/status-im/status-go/pull/6210).

With the help of PR, mobile can set log level without logout.

relate mobile [PR](https://github.com/status-im/status-mobile/pull/22275)