### PR TITLE
feat(metrics)_: monitor the metrics for different message types.

### DIFF
--- a/metrics/wakumetrics/client.go
+++ b/metrics/wakumetrics/client.go
@@ -162,6 +162,11 @@ func (c *Client) PushSentMessageTotal(messageSize uint32, publishMethod string) 
 	metrics.MessagesSentTotal.WithLabelValues(publishMethod).Inc()
 }
 
+func (c *Client) PushRawMessageByType(pubsubTopic string, contentTopic string, messageType string, messageSize uint32) {
+	metrics.RawMessagesSizeBytes.WithLabelValues(messageType, pubsubTopic, contentTopic).Add(float64(messageSize))
+	metrics.RawMessagesSentTotal.WithLabelValues(messageType, pubsubTopic, contentTopic).Inc()
+}
+
 func getOriginString(origin wps.Origin) string {
 	switch origin {
 	case wps.Unknown:

--- a/metrics/wakumetrics/client_test.go
+++ b/metrics/wakumetrics/client_test.go
@@ -180,3 +180,18 @@ func TestClient_PushErrorSendingEnvelope(t *testing.T) {
 	)
 	require.Equal(t, float64(1), value)
 }
+
+func TestClient_PushRawMessageByType(t *testing.T) {
+	client := createTestClient(t)
+
+	pubsubTopic := "test-pubsub-topic"
+	contentTopic := "test-content-topic"
+	messageType := "test-message-type"
+	client.PushRawMessageByType(pubsubTopic, contentTopic, messageType, 10)
+
+	value := getCounterValue(metrics.RawMessagesSentTotal, messageType, pubsubTopic, contentTopic)
+	require.Equal(t, float64(1), value)
+
+	valueBytes := getCounterValue(metrics.RawMessagesSizeBytes, messageType, pubsubTopic, contentTopic)
+	require.Equal(t, float64(10), valueBytes)
+}

--- a/metrics/wakumetrics/metrics.go
+++ b/metrics/wakumetrics/metrics.go
@@ -20,6 +20,8 @@ type MetricsCollection struct {
 	ConnectedPeers               prometheus.Gauge
 	PeersByOrigin                *prometheus.GaugeVec
 	PeersByShard                 *prometheus.GaugeVec
+	RawMessagesSizeBytes         *prometheus.CounterVec
+	RawMessagesSentTotal         *prometheus.CounterVec
 }
 
 var metrics = MetricsCollection{
@@ -137,6 +139,22 @@ var metrics = MetricsCollection{
 		},
 		[]string{"peer_id"},
 	),
+
+	RawMessagesSizeBytes: prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "statusgo_waku_raw_message_size_bytes",
+			Help: "Size of each raw message in bytes sent by this node",
+		},
+		[]string{"message_type", "pubsub_topic", "content_topic"},
+	),
+
+	RawMessagesSentTotal: prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "statusgo_waku_raw_message_sent_total",
+			Help: "Total number of raw messages sent by this node",
+		},
+		[]string{"message_type", "pubsub_topic", "content_topic"},
+	),
 }
 
 var collectors = []prometheus.Collector{
@@ -154,6 +172,8 @@ var collectors = []prometheus.Collector{
 	metrics.StoreQueryFailures,
 	metrics.MissedMessages,
 	metrics.NodePeerId,
+	metrics.RawMessagesSizeBytes,
+	metrics.RawMessagesSentTotal,
 }
 
 // RegisterMetrics registers all metrics with the provided registry

--- a/metrics/wakumetrics/metrics.go
+++ b/metrics/wakumetrics/metrics.go
@@ -27,7 +27,7 @@ type MetricsCollection struct {
 var metrics = MetricsCollection{
 	MessagesSentTotal: prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_messages_sent_total",
+			Name: "waku_messages_sent_total",
 			Help: "Frequency of Waku messages sent by this node",
 		},
 		[]string{"publish_method"},
@@ -35,7 +35,7 @@ var metrics = MetricsCollection{
 
 	EnvelopeSentTotal: prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_envelope_sent_total",
+			Name: "waku_envelope_sent_total",
 			Help: "Total number of envelopes sent by this node",
 		},
 		[]string{"pubsub_topic", "content_topic", "publish_method"},
@@ -43,7 +43,7 @@ var metrics = MetricsCollection{
 
 	MessagesReceivedTotal: prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_messages_received_total",
+			Name: "waku_messages_received_total",
 			Help: "Frequency of Status messages received",
 		},
 		[]string{"pubsub_topic", "content_topic", "chat_id"},
@@ -51,7 +51,7 @@ var metrics = MetricsCollection{
 
 	WakuMessagesSizeBytes: prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_message_size_bytes",
+			Name: "waku_message_size_bytes",
 			Help: "Size of each Waku message in bytes sent by this node",
 		},
 		[]string{"publish_method"},
@@ -59,7 +59,7 @@ var metrics = MetricsCollection{
 
 	EnvelopeSentErrors: prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_envelope_sent_errors_total",
+			Name: "waku_envelope_sent_errors_total",
 			Help: "Frequency of errors occurred when sending an envelope",
 		},
 		[]string{"pubsub_topic", "content_topic"},
@@ -67,21 +67,21 @@ var metrics = MetricsCollection{
 
 	MessageDeliveryConfirmations: prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_message_delivery_confirmations_total",
+			Name: "waku_message_delivery_confirmations_total",
 			Help: "Frequency of message delivery confirmations",
 		},
 	),
 
 	ConnectedPeers: prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "statusgo_waku_connected_peers",
+			Name: "waku_connected_peers",
 			Help: "Current number of peers connected",
 		},
 	),
 
 	PeersByOrigin: prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "statusgo_waku_peers_by_origin",
+			Name: "waku_peers_by_origin",
 			Help: "Number of peers by discovery origin",
 		},
 		[]string{"origin"},
@@ -89,7 +89,7 @@ var metrics = MetricsCollection{
 
 	PeersByShard: prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "statusgo_waku_peers_by_shard",
+			Name: "waku_peers_by_shard",
 			Help: "Number of peers by shard",
 		},
 		[]string{"shard"},
@@ -97,14 +97,14 @@ var metrics = MetricsCollection{
 
 	PeerConnectionFailures: prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_peer_connection_failures_total",
+			Name: "waku_peer_connection_failures_total",
 			Help: "Total number of peer connection failures",
 		},
 	),
 
 	PeerDialFailures: prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_peer_dial_failures_total",
+			Name: "waku_peer_dial_failures_total",
 			Help: "Total number of peer dial failures by error type",
 		},
 		[]string{"error_type", "protocols"},
@@ -112,21 +112,21 @@ var metrics = MetricsCollection{
 
 	StoreQuerySuccesses: prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_store_query_successes_total",
+			Name: "waku_store_query_successes_total",
 			Help: "Frequency of successful store confirmation queries",
 		},
 	),
 
 	StoreQueryFailures: prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_store_query_failures_total",
+			Name: "waku_store_query_failures_total",
 			Help: "Frequency of failed store confirmation queries",
 		},
 	),
 
 	MissedMessages: prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_missed_messages_total",
+			Name: "waku_missed_messages_total",
 			Help: "Frequency of missed messages detected by store query",
 		},
 		[]string{"pubsub_topic", "content_topic"},
@@ -134,7 +134,7 @@ var metrics = MetricsCollection{
 
 	NodePeerId: prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "statusgo_waku_peer_id",
+			Name: "waku_peer_id",
 			Help: "Peer ID",
 		},
 		[]string{"peer_id"},
@@ -142,7 +142,7 @@ var metrics = MetricsCollection{
 
 	RawMessagesSizeBytes: prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_raw_message_size_bytes",
+			Name: "waku_raw_message_size_bytes",
 			Help: "Size of each raw message in bytes sent by this node",
 		},
 		[]string{"message_type", "pubsub_topic", "content_topic"},
@@ -150,7 +150,7 @@ var metrics = MetricsCollection{
 
 	RawMessagesSentTotal: prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "statusgo_waku_raw_message_sent_total",
+			Name: "waku_raw_message_sent_total",
 			Help: "Total number of raw messages sent by this node",
 		},
 		[]string{"message_type", "pubsub_topic", "content_topic"},

--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -26,6 +26,7 @@ import (
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
+	wakuv2 "github.com/status-im/status-go/wakuv2"
 )
 
 // Whisper message properties.
@@ -85,6 +86,8 @@ type MessageSender struct {
 
 	// handleSharedSecrets is a callback that is called every time a new shared secret is negotiated
 	handleSharedSecrets func([]*sharedsecret.Secret) error
+
+	metricsHandler wakuv2.IMetricsHandler
 }
 
 func NewMessageSender(
@@ -430,6 +433,7 @@ func (s *MessageSender) sendCommunity(
 		zap.Any("contentType", rawMessage.MessageType),
 		zap.Strings("hashes", types.EncodeHexes(hashes)))
 	s.transport.Track(messageID, hashes, newMessages)
+	s.sendBandwidthMetrics(rawMessage)
 
 	return messageID, nil
 }
@@ -476,6 +480,7 @@ func (s *MessageSender) sendPrivate(
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to send message with datasync")
 		}
+		s.sendBandwidthMetrics(rawMessage)
 		// We don't need to receive confirmations from our own devices
 		if !IsPubKeyEqual(recipient, &s.identity.PublicKey) {
 			confirmation := &RawMessageConfirmation{
@@ -525,6 +530,7 @@ func (s *MessageSender) sendPrivate(
 			zap.Any("contentType", rawMessage.MessageType),
 			zap.Strings("hashes", types.EncodeHexes(hashes)))
 		s.transport.Track(messageID, hashes, newMessages)
+		s.sendBandwidthMetrics(rawMessage)
 
 	} else {
 		messageSpec, err := s.protocol.BuildEncryptedMessage(rawMessage.Sender, recipient, wrappedMessage)
@@ -545,6 +551,7 @@ func (s *MessageSender) sendPrivate(
 			zap.String("messageType", "private"),
 			zap.Strings("hashes", types.EncodeHexes(hashes)))
 		s.transport.Track(messageID, hashes, newMessages)
+		s.sendBandwidthMetrics(rawMessage)
 	}
 
 	return messageID, nil
@@ -576,6 +583,7 @@ func (s *MessageSender) SendPairInstallation(
 	}
 
 	s.transport.Track(messageID, hashes, newMessages)
+	s.sendBandwidthMetrics(&rawMessage)
 
 	return messageID, nil
 }
@@ -800,6 +808,7 @@ func (s *MessageSender) SendPublic(
 		zap.String("messageType", "public"),
 		zap.Strings("hashes", types.EncodeHexes(hashes)))
 	s.transport.Track(messageID, hashes, newMessages)
+	s.sendBandwidthMetrics(&rawMessage)
 
 	return messageID, nil
 }
@@ -1310,6 +1319,12 @@ func (s *MessageSender) GetEphemeralKey() (*ecdsa.PrivateKey, error) {
 	}
 
 	return privateKey, nil
+}
+
+func (s *MessageSender) sendBandwidthMetrics(rawMessage *RawMessage) {
+	if s.metricsHandler != nil {
+		s.metricsHandler.PushRawMessageByType(rawMessage.PubsubTopic, rawMessage.ContentTopic, rawMessage.MessageType.String(), uint32(len(rawMessage.Payload)))
+	}
 }
 
 func MessageSpecToWhisper(spec *encryption.ProtocolMessageSpec) (*wakutypes.NewMessage, error) {

--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -128,6 +128,10 @@ func (s *MessageSender) SetHandleSharedSecrets(handler func([]*sharedsecret.Secr
 	s.handleSharedSecrets = handler
 }
 
+func (s *MessageSender) SetMetricsHandler(handler wakuv2.IMetricsHandler) {
+	s.metricsHandler = handler
+}
+
 func (s *MessageSender) StartDatasync(statusChangeEvent chan datasyncnode.PeerStatusChangeEvent, handler func(peer state.PeerID, payload *datasyncproto.Payload) error) error {
 	if !s.datasyncEnabled {
 		return nil
@@ -480,7 +484,6 @@ func (s *MessageSender) sendPrivate(
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to send message with datasync")
 		}
-		s.sendBandwidthMetrics(rawMessage)
 		// We don't need to receive confirmations from our own devices
 		if !IsPubKeyEqual(recipient, &s.identity.PublicKey) {
 			confirmation := &RawMessageConfirmation{
@@ -530,7 +533,6 @@ func (s *MessageSender) sendPrivate(
 			zap.Any("contentType", rawMessage.MessageType),
 			zap.Strings("hashes", types.EncodeHexes(hashes)))
 		s.transport.Track(messageID, hashes, newMessages)
-		s.sendBandwidthMetrics(rawMessage)
 
 	} else {
 		messageSpec, err := s.protocol.BuildEncryptedMessage(rawMessage.Sender, recipient, wrappedMessage)
@@ -551,8 +553,9 @@ func (s *MessageSender) sendPrivate(
 			zap.String("messageType", "private"),
 			zap.Strings("hashes", types.EncodeHexes(hashes)))
 		s.transport.Track(messageID, hashes, newMessages)
-		s.sendBandwidthMetrics(rawMessage)
 	}
+
+	s.sendBandwidthMetrics(rawMessage)
 
 	return messageID, nil
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -522,6 +522,7 @@ func NewMessenger(
 		if c.wakuService != nil {
 			c.wakuService.SetMetricsHandler(wakuMetricsHandler)
 		}
+		sender.SetMetricsHandler(wakuMetricsHandler)
 		err = wakuMetricsHandler.RegisterWithRegistry()
 		if err != nil {
 			return nil, err

--- a/protocol/messenger_peersyncing.go
+++ b/protocol/messenger_peersyncing.go
@@ -416,6 +416,11 @@ func (m *Messenger) sendDataSync(receiver state.PeerID, payload *datasyncproto.P
 
 	m.logger.Debug("sent private messages", zap.Any("messageIDs", hexMessageIDs), zap.Strings("hashes", types.EncodeHexes(hashes)))
 	m.transport.TrackMany(messageIDs, hashes, newMessages)
+	if m.wakuMetricsHandler != nil {
+		for _, message := range newMessages {
+			m.wakuMetricsHandler.PushRawMessageByType(message.PubsubTopic, message.Topic.String(), "DATASYNC", uint32(len(message.Payload)))
+		}
+	}
 
 	return nil
 }

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -126,6 +126,7 @@ type IMetricsHandler interface {
 	PushMissedRelevantMessage(message *common.ReceivedMessage)
 	PushMessageDeliveryConfirmed()
 	PushSentMessageTotal(messageSize uint32, publishMethod string)
+	PushRawMessageByType(pubsubTopic string, contentTopic string, messageType string, messageSize uint32)
 }
 
 // Waku represents a dark communication interface through the Ethereum


### PR DESCRIPTION
Monitor the bandwidth usage for different message types when sending messages.

Add waku metrics based on message type, pubsub and content topic and trigger such metrics when different messages were sent.

Check out the grafana dashboard screenshot [here](https://github.com/waku-org/status-metrics/pull/7)
