### PR TITLE
fix(wallet)_: fixing swap and bridge release issues

### DIFF
--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -278,7 +278,7 @@ func (h *HopBridgeProcessor) EstimateGas(params ProcessorInputParams, input []by
 			// TODO: this is a temporary solution until we find a better way to estimate the gas
 			// hardcoding the estimation for other than ETH, cause we cannot get a proper estimation without having an approval placed first
 			// this is an error we're facing otherwise: `execution reverted: ERC20: transfer amount exceeds allowance`
-			estimation = 350000
+			estimation = 600000 // temporary increase for the release, an issue for addressing this is https://github.com/status-im/status-desktop/issues/17551
 		} else {
 			return 0, createBridgeHopErrorResponse(err)
 		}

--- a/services/wallet/router/pathprocessor/processor_swap_paraswap.go
+++ b/services/wallet/router/pathprocessor/processor_swap_paraswap.go
@@ -167,6 +167,14 @@ func (s *SwapParaswapProcessor) EstimateGas(params ProcessorInputParams, input [
 		swapSide = paraswap.BuySide
 	}
 
+	// TODO: this is an extra check, we should remove it once we set the proper address for the native (ETH) token
+	if params.FromToken.IsNative() {
+		params.FromToken.Address = common.HexToAddress("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") // ETH address across all chains that we support
+	}
+	if params.ToToken.IsNative() {
+		params.ToToken.Address = common.HexToAddress("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee") // ETH address across all chains that we support
+	}
+
 	priceRoute, err := s.paraswapClient.FetchPriceRoute(context.Background(), params.FromToken.Address, params.FromToken.Decimals,
 		params.ToToken.Address, params.ToToken.Decimals, params.AmountIn, params.FromAddr, params.ToAddr, swapSide)
 	if err != nil {

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -695,6 +695,9 @@ func (tm *Manager) GetCustoms(onlyCommunityCustoms bool) ([]*Token, error) {
 
 func (tm *Manager) ToToken(network *params.Network) *Token {
 	return &Token{
+		// TODO: we need to change the address for the native token to the correct one, we cannot to that right now cause will affect other parts of the code
+		// The following line is the right fix for `{"error":"Validation failed: \"srcToken\" contains an invalid value"}` error for Swap
+		// Address:  common.HexToAddress("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"), // for all the chains we support this is the address of the native (ETH) token
 		Address:  common.HexToAddress("0x"),
 		Name:     network.NativeCurrencyName,
 		Symbol:   network.NativeCurrencySymbol,


### PR DESCRIPTION
This PR contains 2 commits, both are temporary fix for the release.

----
### Swap issue
**fix(wallet)_: swap route calculation fixed**
- https://github.com/status-im/status-mobile/issues/22277

Recently, based on what's said here https://developers.paraswap.network/api/get-tokens-list
```
ParaSwap's API is not limited to the tokens that are listed on the tokens endpoint. Tokens endpoint is merely a list of tokens curated by ParaSwap. This list is not actively maintained and will soon be deprecated. To use a more up-to-date list of tokens it is suggested to use token-lists.
```

We've decided to rely on tokens' addresses which are available in the Status app, but it turned out
that it works well for all but the ETH (native) token, cause the address for the native token was
hardcodded to `0x0000000000000000000000000000000000000000`.

Changes from this commit fix the issue in resolving route for swap. This should be handled as mentioned in the `token.go` file.

----
### Bridge issue
**fix(wallet)_: ensuring higher estimated gas for erc20 tokens in order to avoid failed bridge txs**
- based on this comment https://github.com/status-im/status-desktop/issues/17551#issuecomment-2714821398

This is a temporary fix for the release, but a proper handling of this issue will be addressed via https://github.com/status-im/status-desktop/issues/17551
