### PR TITLE
chore_: moving shard module to wakuv2

### DIFF
--- a/cmd/ping-community/main.go
+++ b/cmd/ping-community/main.go
@@ -30,10 +30,10 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/identity/alias"
 	"github.com/status-im/status-go/protocol/protobuf"
 	wakuextn "github.com/status-im/status-go/services/wakuv2ext"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 const (
@@ -49,8 +49,8 @@ var (
 	seedPhrase       = flag.String("seed-phrase", "", "Seed phrase")
 	version          = flag.Bool("version", false, "Print version and dump configuration")
 	communityID      = flag.String("community-id", "", "The id of the community")
-	shardCluster     = flag.Int("shard-cluster", shard.MainStatusShardCluster, "The shard cluster in which the of the community is published")
-	shardIndex       = flag.Int("shard-index", shard.DefaultShardIndex, "The shard index in which the community is published")
+	shardCluster     = flag.Int("shard-cluster", wakuv2.MainStatusShardCluster, "The shard cluster in which the of the community is published")
+	shardIndex       = flag.Int("shard-index", wakuv2.DefaultShardIndex, "The shard index in which the community is published")
 	chatID           = flag.String("chat-id", "", "The id of the chat")
 
 	dataDir   = flag.String("dir", getDefaultDataDir(), "Directory used by node to store data")
@@ -152,9 +152,9 @@ func main() {
 
 	messenger := wakuextservice.Messenger()
 
-	var s *shard.Shard = nil
+	var s *wakuv2.Shard = nil
 	if shardCluster != nil && shardIndex != nil {
-		s = &shard.Shard{
+		s = &wakuv2.Shard{
 			Cluster: uint16(*shardCluster),
 			Index:   uint16(*shardIndex),
 		}

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -12,10 +12,10 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/signal"
 	"github.com/status-im/status-go/transactions"
+	"github.com/status-im/status-go/wakuv2"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/event"
@@ -60,7 +60,6 @@ import (
 	"github.com/status-im/status-go/services/wallet/transfer"
 	"github.com/status-im/status-go/services/web3provider"
 	"github.com/status-im/status-go/timesource"
-	"github.com/status-im/status-go/wakuv2"
 	wakuv2common "github.com/status-im/status-go/wakuv2/common"
 )
 
@@ -244,7 +243,7 @@ func (b *StatusNode) wakuV2Service(nodeConfig *params.NodeConfig) (*wakuv2.Waku,
 			Nameserver:                             nodeConfig.WakuV2Config.Nameserver,
 			UDPPort:                                nodeConfig.WakuV2Config.UDPPort,
 			AutoUpdate:                             nodeConfig.WakuV2Config.AutoUpdate,
-			DefaultShardPubsubTopic:                shard.DefaultShardPubsubTopic(),
+			DefaultShardPubsubTopic:                wakuv2.DefaultShardPubsubTopic(),
 			TelemetryServerURL:                     nodeConfig.WakuV2Config.TelemetryServerURL,
 			ClusterID:                              nodeConfig.ClusterConfig.ClusterID,
 			EnableMissingMessageVerification:       nodeConfig.WakuV2Config.EnableMissingMessageVerification,

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -23,12 +23,12 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	community_token "github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/protocol/v1"
 	"github.com/status-im/status-go/server"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 const signatureLength = 65
@@ -55,7 +55,7 @@ type Config struct {
 	RequestsToJoin                      []*RequestToJoin
 	MemberIdentity                      *ecdsa.PrivateKey
 	EventsData                          *EventsData
-	Shard                               *shard.Shard
+	Shard                               *wakuv2.Shard
 	PubsubTopicPrivateKey               *ecdsa.PrivateKey
 	LastOpenedAt                        int64
 }
@@ -172,7 +172,7 @@ func (o *Community) MarshalPublicAPIJSON() ([]byte, error) {
 		ActiveMembersCount      uint64                               `json:"activeMembersCount"`
 		PubsubTopic             string                               `json:"pubsubTopic"`
 		PubsubTopicKey          string                               `json:"pubsubTopicKey"`
-		Shard                   *shard.Shard                         `json:"shard"`
+		Shard                   *wakuv2.Shard                        `json:"shard"`
 	}{
 		ID:             o.ID(),
 		Verified:       o.config.Verified,
@@ -308,7 +308,7 @@ func (o *Community) MarshalJSON() ([]byte, error) {
 		ActiveMembersCount          uint64                               `json:"activeMembersCount"`
 		PubsubTopic                 string                               `json:"pubsubTopic"`
 		PubsubTopicKey              string                               `json:"pubsubTopicKey"`
-		Shard                       *shard.Shard                         `json:"shard"`
+		Shard                       *wakuv2.Shard                        `json:"shard"`
 		LastOpenedAt                int64                                `json:"lastOpenedAt"`
 		Clock                       uint64                               `json:"clock"`
 	}{
@@ -461,7 +461,7 @@ func (o *Community) DescriptionText() string {
 	return ""
 }
 
-func (o *Community) Shard() *shard.Shard {
+func (o *Community) Shard() *wakuv2.Shard {
 	if o != nil && o.config != nil {
 		return o.config.Shard
 	}

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -31,7 +31,6 @@ import (
 	multiaccountscommon "github.com/status-im/status-go/multiaccounts/common"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	community_token "github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/encryption"
 	"github.com/status-im/status-go/protocol/ens"
@@ -47,6 +46,7 @@ import (
 	"github.com/status-im/status-go/signal"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 type Publisher interface {
@@ -768,8 +768,8 @@ func (m *Manager) All() ([]*Community, error) {
 }
 
 type CommunityShard struct {
-	CommunityID string       `json:"communityID"`
-	Shard       *shard.Shard `json:"shard"`
+	CommunityID string        `json:"communityID"`
+	Shard       *wakuv2.Shard `json:"shard"`
 }
 
 type CuratedCommunities struct {
@@ -1577,7 +1577,7 @@ func (m *Manager) DeleteCommunity(id types.HexBytes) error {
 	return m.persistence.DeleteCommunitySettings(id)
 }
 
-func (m *Manager) updateShard(community *Community, shard *shard.Shard, clock uint64) error {
+func (m *Manager) updateShard(community *Community, shard *wakuv2.Shard, clock uint64) error {
 	community.config.Shard = shard
 	if shard == nil {
 		return m.persistence.DeleteCommunityShard(community.ID())
@@ -1586,7 +1586,7 @@ func (m *Manager) updateShard(community *Community, shard *shard.Shard, clock ui
 	return m.persistence.SaveCommunityShard(community.ID(), shard, clock)
 }
 
-func (m *Manager) UpdateShard(community *Community, shard *shard.Shard, clock uint64) error {
+func (m *Manager) UpdateShard(community *Community, shard *wakuv2.Shard, clock uint64) error {
 	m.communityLock.Lock(community.ID())
 	defer m.communityLock.Unlock(community.ID())
 
@@ -1594,7 +1594,7 @@ func (m *Manager) UpdateShard(community *Community, shard *shard.Shard, clock ui
 }
 
 // SetShard assigns a shard to a community
-func (m *Manager) SetShard(communityID types.HexBytes, shard *shard.Shard) (*Community, error) {
+func (m *Manager) SetShard(communityID types.HexBytes, shard *wakuv2.Shard) (*Community, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 
@@ -2207,11 +2207,11 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 		if err != nil {
 			return nil, err
 		}
-		var cShard *shard.Shard
+		var cShard *wakuv2.Shard
 		if communityShard == nil {
-			cShard = &shard.Shard{Cluster: shard.MainStatusShardCluster, Index: shard.DefaultShardIndex}
+			cShard = &wakuv2.Shard{Cluster: wakuv2.MainStatusShardCluster, Index: wakuv2.DefaultShardIndex}
 		} else {
-			cShard = shard.FromProtobuff(communityShard)
+			cShard = wakuv2.FromProtobuff(communityShard)
 		}
 		config := Config{
 			CommunityDescription:                processedDescription,
@@ -3996,11 +3996,11 @@ func (m *Manager) GetByIDString(idString string) (*Community, error) {
 	return m.GetByID(id)
 }
 
-func (m *Manager) GetCommunityShard(communityID types.HexBytes) (*shard.Shard, error) {
+func (m *Manager) GetCommunityShard(communityID types.HexBytes) (*wakuv2.Shard, error) {
 	return m.persistence.GetCommunityShard(communityID)
 }
 
-func (m *Manager) SaveCommunityShard(communityID types.HexBytes, shard *shard.Shard, clock uint64) error {
+func (m *Manager) SaveCommunityShard(communityID types.HexBytes, shard *wakuv2.Shard, clock uint64) error {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)
 

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -16,11 +16,11 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/encryption"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/services/wallet/bigint"
+	"github.com/status-im/status-go/wakuv2"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
@@ -1768,7 +1768,7 @@ func (p *Persistence) AllNonApprovedCommunitiesRequestsToJoin() ([]*RequestToJoi
 	return nonApprovedRequestsToJoin, nil
 }
 
-func (p *Persistence) SaveCommunityShard(communityID types.HexBytes, shard *shard.Shard, clock uint64) error {
+func (p *Persistence) SaveCommunityShard(communityID types.HexBytes, shard *wakuv2.Shard, clock uint64) error {
 	var cluster, index *uint16
 
 	if shard != nil {
@@ -1803,7 +1803,7 @@ func (p *Persistence) SaveCommunityShard(communityID types.HexBytes, shard *shar
 }
 
 // if data will not be found, will return sql.ErrNoRows. Must be handled on the caller side
-func (p *Persistence) GetCommunityShard(communityID types.HexBytes) (*shard.Shard, error) {
+func (p *Persistence) GetCommunityShard(communityID types.HexBytes) (*wakuv2.Shard, error) {
 	var cluster sql.NullInt64
 	var index sql.NullInt64
 	err := p.db.QueryRow(`SELECT shard_cluster, shard_index FROM communities_shards WHERE community_id = ?`,
@@ -1817,7 +1817,7 @@ func (p *Persistence) GetCommunityShard(communityID types.HexBytes) (*shard.Shar
 		return nil, nil
 	}
 
-	return &shard.Shard{
+	return &wakuv2.Shard{
 		Cluster: uint16(cluster.Int64),
 		Index:   uint16(index.Int64),
 	}, nil

--- a/protocol/communities/persistence_mapping.go
+++ b/protocol/communities/persistence_mapping.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/server"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 func communityToRecord(community *Community) (*CommunityRecord, error) {
@@ -118,9 +118,9 @@ func recordBundleToCommunity(
 		}
 	}
 
-	var s *shard.Shard = nil
+	var s *wakuv2.Shard = nil
 	if r.community.shardCluster != nil && r.community.shardIndex != nil {
-		s = &shard.Shard{
+		s = &wakuv2.Shard{
 			Cluster: uint16(*r.community.shardCluster),
 			Index:   uint16(*r.community.shardIndex),
 		}

--- a/protocol/communities/persistence_test.go
+++ b/protocol/communities/persistence_test.go
@@ -15,13 +15,13 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/encryption"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/sqlite"
 	"github.com/status-im/status-go/services/wallet/bigint"
 	"github.com/status-im/status-go/t/helpers"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 func TestPersistenceSuite(t *testing.T) {
@@ -787,7 +787,7 @@ func (s *PersistenceSuite) TestSaveShardInfo() {
 	s.Require().Nil(resultShard)
 
 	// not nil shard
-	expectedShard := &shard.Shard{
+	expectedShard := &wakuv2.Shard{
 		Cluster: 1,
 		Index:   2,
 	}

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -24,13 +24,13 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/protocol/transport"
 	"github.com/status-im/status-go/protocol/tt"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
+	"github.com/status-im/status-go/wakuv2"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
@@ -489,7 +489,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestBecomeMemberPermissions(
 	cfg := testWakuV2Config{
 		logger:      s.logger.Named("store-node-waku"),
 		enableStore: false,
-		clusterID:   shard.MainStatusShardCluster,
+		clusterID:   wakuv2.MainStatusShardCluster,
 	}
 	wakuStoreNode := NewTestWakuV2(&s.Suite, cfg)
 

--- a/protocol/linkpreview_unfurler_status.go
+++ b/protocol/linkpreview_unfurler_status.go
@@ -9,8 +9,8 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 type StatusUnfurler struct {
@@ -84,7 +84,7 @@ func (u *StatusUnfurler) buildContactData(publicKey string) (*common.StatusConta
 	return c, nil
 }
 
-func (u *StatusUnfurler) buildCommunityData(communityID string, shard *shard.Shard) (*communities.Community, *common.StatusCommunityLinkPreview, error) {
+func (u *StatusUnfurler) buildCommunityData(communityID string, shard *wakuv2.Shard) (*communities.Community, *common.StatusCommunityLinkPreview, error) {
 	// This automatically checks the database
 	community, err := u.m.FetchCommunity(&FetchCommunityRequest{
 		CommunityKey:    communityID,
@@ -109,7 +109,7 @@ func (u *StatusUnfurler) buildCommunityData(communityID string, shard *shard.Sha
 	return community, statusCommunityLinkPreviews, nil
 }
 
-func (u *StatusUnfurler) buildChannelData(channelUUID string, communityID string, communityShard *shard.Shard) (*common.StatusCommunityChannelLinkPreview, error) {
+func (u *StatusUnfurler) buildChannelData(channelUUID string, communityID string, communityShard *wakuv2.Shard) (*common.StatusCommunityChannelLinkPreview, error) {
 	community, communityData, err := u.buildCommunityData(communityID, communityShard)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build channel community data: %w", err)

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -34,7 +34,6 @@ import (
 	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/discord"
@@ -47,6 +46,7 @@ import (
 	localnotifications "github.com/status-im/status-go/services/local-notifications"
 	"github.com/status-im/status-go/services/wallet/bigint"
 	"github.com/status-im/status-go/signal"
+	"github.com/status-im/status-go/wakuv2"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
@@ -91,10 +91,10 @@ const (
 
 type FetchCommunityRequest struct {
 	// CommunityKey should be either a public or a private community key
-	CommunityKey    string       `json:"communityKey"`
-	Shard           *shard.Shard `json:"shard"`
-	TryDatabase     bool         `json:"tryDatabase"`
-	WaitForResponse bool         `json:"waitForResponse"`
+	CommunityKey    string        `json:"communityKey"`
+	Shard           *wakuv2.Shard `json:"shard"`
+	TryDatabase     bool          `json:"tryDatabase"`
+	WaitForResponse bool          `json:"waitForResponse"`
 }
 
 func (r *FetchCommunityRequest) Validate() error {
@@ -348,7 +348,7 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 					Sender:              community.PrivateKey(),
 					SkipEncryptionLayer: true,
 					MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_USER_KICKED,
-					PubsubTopic:         shard.DefaultNonProtectedPubsubTopic(),
+					PubsubTopic:         wakuv2.DefaultNonProtectedPubsubTopic(),
 				}
 
 				_, err = m.sender.SendPrivate(context.Background(), pk, rawMessage)
@@ -683,7 +683,7 @@ func (m *Messenger) handleCommunitySharedAddressesRequest(state *ReceivedMessage
 		CommunityID:         community.ID(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_SHARED_ADDRESSES_RESPONSE,
-		PubsubTopic:         shard.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         wakuv2.DefaultNonProtectedPubsubTopic(),
 		ResendType:          common.ResendTypeRawMessage,
 		ResendMethod:        common.ResendMethodSendPrivate,
 		Recipients:          []*ecdsa.PublicKey{signer},
@@ -1046,7 +1046,7 @@ func (m *Messenger) JoinCommunity(ctx context.Context, communityID types.HexByte
 	return mr, nil
 }
 
-func (m *Messenger) subscribeToCommunityShard(communityID []byte, shard *shard.Shard) error {
+func (m *Messenger) subscribeToCommunityShard(communityID []byte, shard *wakuv2.Shard) error {
 	if m.transport.WakuVersion() != 2 {
 		return nil
 	}
@@ -1067,7 +1067,7 @@ func (m *Messenger) subscribeToCommunityShard(communityID []byte, shard *shard.S
 	return m.transport.SubscribeToPubsubTopic(pubsubTopic, pubK)
 }
 
-func (m *Messenger) unsubscribeFromShard(shard *shard.Shard) error {
+func (m *Messenger) unsubscribeFromShard(shard *wakuv2.Shard) error {
 	if m.transport.WakuVersion() != 2 {
 		return nil
 	}
@@ -1496,7 +1496,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 		ResendType:          common.ResendTypeRawMessage,
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN,
-		PubsubTopic:         shard.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         wakuv2.DefaultNonProtectedPubsubTopic(),
 		Priority:            &common.HighPriority,
 	}
 
@@ -1874,7 +1874,7 @@ func (m *Messenger) CancelRequestToJoinCommunity(ctx context.Context, request *r
 		CommunityID:         community.ID(),
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_CANCEL_REQUEST_TO_JOIN,
-		PubsubTopic:         shard.DefaultNonProtectedPubsubTopic(),
+		PubsubTopic:         wakuv2.DefaultNonProtectedPubsubTopic(),
 		ResendType:          common.ResendTypeRawMessage,
 		Priority:            &common.HighPriority,
 	}
@@ -2030,7 +2030,7 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 			CommunityID:         community.ID(),
 			SkipEncryptionLayer: true,
 			MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_REQUEST_TO_JOIN_RESPONSE,
-			PubsubTopic:         shard.DefaultNonProtectedPubsubTopic(),
+			PubsubTopic:         wakuv2.DefaultNonProtectedPubsubTopic(),
 			ResendType:          common.ResendTypeRawMessage,
 			ResendMethod:        common.ResendMethodSendPrivate,
 			Recipients:          []*ecdsa.PublicKey{pk},
@@ -2505,7 +2505,7 @@ func (m *Messenger) DefaultFilters(o *communities.Community) []transport.Filters
 		{ChatID: updatesChannelID, PubsubTopic: communityPubsubTopic},
 		{ChatID: mlChannelID, PubsubTopic: communityPubsubTopic},
 		{ChatID: memberUpdateChannelID, PubsubTopic: communityPubsubTopic},
-		{ChatID: uncompressedPubKey, PubsubTopic: shard.DefaultNonProtectedPubsubTopic()},
+		{ChatID: uncompressedPubKey, PubsubTopic: wakuv2.DefaultNonProtectedPubsubTopic()},
 	}
 
 	return filters
@@ -3569,7 +3569,7 @@ func (m *Messenger) HandleCommunityShardKey(state *ReceivedMessageState, message
 }
 
 func (m *Messenger) handleCommunityShardAndFiltersFromProto(community *communities.Community, message *protobuf.CommunityShardKey) error {
-	err := m.communitiesManager.UpdateShard(community, shard.FromProtobuff(message.Shard), message.Clock)
+	err := m.communitiesManager.UpdateShard(community, wakuv2.FromProtobuff(message.Shard), message.Clock)
 	if err != nil {
 		return err
 	}
@@ -3591,7 +3591,7 @@ func (m *Messenger) handleCommunityShardAndFiltersFromProto(community *communiti
 	}
 
 	// Unsubscribing from existing shard
-	if community.Shard() != nil && community.Shard() != shard.FromProtobuff(message.GetShard()) {
+	if community.Shard() != nil && community.Shard() != wakuv2.FromProtobuff(message.GetShard()) {
 		err := m.unsubscribeFromShard(community.Shard())
 		if err != nil {
 			return err
@@ -3605,7 +3605,7 @@ func (m *Messenger) handleCommunityShardAndFiltersFromProto(community *communiti
 		return err
 	}
 	// Update community filters in case of change of shard
-	if community.Shard() != shard.FromProtobuff(message.GetShard()) {
+	if community.Shard() != wakuv2.FromProtobuff(message.GetShard()) {
 		err = m.UpdateCommunityFilters(community)
 		if err != nil {
 			return err

--- a/protocol/messenger_communities_sharding_test.go
+++ b/protocol/messenger_communities_sharding_test.go
@@ -10,11 +10,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/protocol/tt"
+	"github.com/status-im/status-go/wakuv2"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
@@ -108,7 +108,7 @@ func (s *MessengerCommunitiesShardingSuite) TearDownTest() {
 	_ = s.logger.Sync()
 }
 
-func (s *MessengerCommunitiesShardingSuite) testPostToCommunityChat(shard *shard.Shard, community *communities.Community, chat *Chat) {
+func (s *MessengerCommunitiesShardingSuite) testPostToCommunityChat(shard *wakuv2.Shard, community *communities.Community, chat *Chat) {
 	_, err := s.owner.SetCommunityShard(&requests.SetCommunityShard{
 		CommunityID: community.ID(),
 		Shard:       shard,
@@ -144,8 +144,8 @@ func (s *MessengerCommunitiesShardingSuite) TestPostToCommunityChat() {
 
 	// Members should be able to receive messages in a community with sharding enabled.
 	{
-		shard := &shard.Shard{
-			Cluster: shard.MainStatusShardCluster,
+		shard := &wakuv2.Shard{
+			Cluster: wakuv2.MainStatusShardCluster,
 			Index:   128,
 		}
 		s.testPostToCommunityChat(shard, community, chat)
@@ -153,8 +153,8 @@ func (s *MessengerCommunitiesShardingSuite) TestPostToCommunityChat() {
 
 	// Members should be able to receive messages in a community where the sharding configuration has been edited.
 	{
-		shard := &shard.Shard{
-			Cluster: shard.MainStatusShardCluster,
+		shard := &wakuv2.Shard{
+			Cluster: wakuv2.MainStatusShardCluster,
 			Index:   256,
 		}
 		s.testPostToCommunityChat(shard, community, chat)
@@ -162,8 +162,8 @@ func (s *MessengerCommunitiesShardingSuite) TestPostToCommunityChat() {
 
 	// Members should continue to receive messages in a community if it is moved back to default shard.
 	{
-		shard := &shard.Shard{
-			Cluster: shard.MainStatusShardCluster,
+		shard := &wakuv2.Shard{
+			Cluster: wakuv2.MainStatusShardCluster,
 			Index:   32,
 		}
 		s.testPostToCommunityChat(shard, community, chat)
@@ -176,8 +176,8 @@ func (s *MessengerCommunitiesShardingSuite) TestIgnoreOutdatedShardKey() {
 	advertiseCommunityToUserOldWay(&s.Suite, community, s.owner, s.alice)
 	joinCommunity(&s.Suite, community.ID(), s.owner, s.alice, alicePassword, []string{aliceAddress1})
 
-	shard := &shard.Shard{
-		Cluster: shard.MainStatusShardCluster,
+	shard := &wakuv2.Shard{
+		Cluster: wakuv2.MainStatusShardCluster,
 		Index:   128,
 	}
 

--- a/protocol/messenger_community_shard.go
+++ b/protocol/messenger_community_shard.go
@@ -13,11 +13,11 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/transport"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 func (m *Messenger) sendPublicCommunityShardInfo(community *communities.Community) error {
@@ -58,7 +58,7 @@ func (m *Messenger) sendPublicCommunityShardInfo(community *communities.Communit
 		// we don't want to wrap in an encryption layer message
 		SkipEncryptionLayer: true,
 		MessageType:         protobuf.ApplicationMetadataMessage_COMMUNITY_PUBLIC_SHARD_INFO,
-		PubsubTopic:         shard.DefaultNonProtectedPubsubTopic(), // it must be sent always to default shard pubsub topic
+		PubsubTopic:         wakuv2.DefaultNonProtectedPubsubTopic(), // it must be sent always to default shard pubsub topic
 		Priority:            &common.HighPriority,
 	}
 
@@ -90,7 +90,7 @@ func (m *Messenger) HandleCommunityPublicShardInfo(state *ReceivedMessageState, 
 		return err
 	}
 
-	err = m.communitiesManager.SaveCommunityShard(publicShardInfo.CommunityId, shard.FromProtobuff(publicShardInfo.Shard), publicShardInfo.Clock)
+	err = m.communitiesManager.SaveCommunityShard(publicShardInfo.CommunityId, wakuv2.FromProtobuff(publicShardInfo.Shard), publicShardInfo.Clock)
 	if err != nil && err != communities.ErrOldShardInfo {
 		logError(err)
 		return err

--- a/protocol/messenger_filter_init.go
+++ b/protocol/messenger_filter_init.go
@@ -12,9 +12,9 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/deprecation"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/transport"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 // InitFilters analyzes chats and contacts in order to setup filters
@@ -24,7 +24,7 @@ func (m *Messenger) InitFilters() error {
 	rand.Seed(time.Now().Unix())
 
 	// Community requests will arrive in this pubsub topic
-	if err := m.SubscribeToPubsubTopic(shard.DefaultNonProtectedPubsubTopic(), nil); err != nil {
+	if err := m.SubscribeToPubsubTopic(wakuv2.DefaultNonProtectedPubsubTopic(), nil); err != nil {
 		return err
 	}
 

--- a/protocol/messenger_share_urls.go
+++ b/protocol/messenger_share_urls.go
@@ -16,11 +16,11 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/services/utils"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 type CommunityURLData struct {
@@ -50,7 +50,7 @@ type URLDataResponse struct {
 	Community *CommunityURLData        `json:"community"`
 	Channel   *CommunityChannelURLData `json:"channel"`
 	Contact   *ContactURLData          `json:"contact"`
-	Shard     *shard.Shard             `json:"shard,omitempty"`
+	Shard     *wakuv2.Shard            `json:"shard,omitempty"`
 }
 
 const baseShareURL = "https://status.app"
@@ -205,7 +205,7 @@ func parseCommunityURLWithData(data string, chatKey string) (*URLDataResponse, e
 			TagIndices:   tagIndices,
 			CommunityID:  types.EncodeHex(communityID),
 		},
-		Shard: shard.FromProtobuff(urlDataProto.Shard),
+		Shard: wakuv2.FromProtobuff(urlDataProto.Shard),
 	}, nil
 }
 
@@ -381,7 +381,7 @@ func parseCommunityChannelURLWithData(data string, chatKey string) (*URLDataResp
 			Color:       channelProto.Color,
 			ChannelUUID: channelProto.Uuid,
 		},
-		Shard: shard.FromProtobuff(urlDataProto.Shard),
+		Shard: wakuv2.FromProtobuff(urlDataProto.Shard),
 	}, nil
 }
 

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -12,7 +12,7 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/eth-node/crypto"
-	"github.com/status-im/status-go/protocol/common/shard"
+	"github.com/status-im/status-go/wakuv2"
 
 	"go.uber.org/zap"
 
@@ -86,7 +86,7 @@ func (m *StoreNodeRequestManager) FetchCommunity(ctx context.Context, community 
 		zap.Any("community", community),
 		zap.Any("config", cfg))
 
-	requestCommunity := func(communityID string, shard *shard.Shard) (*communities.Community, StoreNodeRequestStats, error) {
+	requestCommunity := func(communityID string, shard *wakuv2.Shard) (*communities.Community, StoreNodeRequestStats, error) {
 		channel, err := m.subscribeToRequest(ctx, storeNodeCommunityRequest, communityID, shard, cfg)
 		if err != nil {
 			return nil, StoreNodeRequestStats{}, fmt.Errorf("failed to create a request for community: %w", err)
@@ -104,7 +104,7 @@ func (m *StoreNodeRequestManager) FetchCommunity(ctx context.Context, community 
 	communityShard := community.Shard
 	if communityShard == nil {
 		id := transport.CommunityShardInfoTopic(community.CommunityID)
-		fetchedShard, err := m.subscribeToRequest(ctx, storeNodeShardRequest, id, shard.DefaultNonProtectedShard(), cfg)
+		fetchedShard, err := m.subscribeToRequest(ctx, storeNodeShardRequest, id, wakuv2.DefaultNonProtectedShard(), cfg)
 		if err != nil {
 			return nil, StoreNodeRequestStats{}, fmt.Errorf("failed to create a shard info request: %w", err)
 		}
@@ -182,7 +182,7 @@ func (m *StoreNodeRequestManager) FetchContact(ctx context.Context, contactID st
 // subscribeToRequest checks if a request for given community/contact is already in progress, creates and installs
 // a new one if not found, and returns a subscription to the result of the found/started request.
 // The subscription can then be used to get the result of the request, this could be either a community/contact or an error.
-func (m *StoreNodeRequestManager) subscribeToRequest(ctx context.Context, requestType storeNodeRequestType, dataID string, shard *shard.Shard, cfg StoreNodeRequestConfig) (storeNodeResponseSubscription, error) {
+func (m *StoreNodeRequestManager) subscribeToRequest(ctx context.Context, requestType storeNodeRequestType, dataID string, shard *wakuv2.Shard, cfg StoreNodeRequestConfig) (storeNodeResponseSubscription, error) {
 	// It's important to unlock only after getting the subscription channel.
 	// We also lock `activeRequestsLock` during finalizing the requests. This ensures that the subscription
 	// created in this function will get the result even if the requests proceeds faster than this function ends.
@@ -237,7 +237,7 @@ func (m *StoreNodeRequestManager) newStoreNodeRequest(ctx context.Context) *stor
 
 // getFilter checks if a filter for a given community is already created and creates one of not found.
 // Returns the found/created filter, a flag if the filter was created by the function and an error.
-func (m *StoreNodeRequestManager) getFilter(requestType storeNodeRequestType, dataID string, shard *shard.Shard) (*transport.Filter, bool, error) {
+func (m *StoreNodeRequestManager) getFilter(requestType storeNodeRequestType, dataID string, shard *wakuv2.Shard) (*transport.Filter, bool, error) {
 	// First check if such filter already exists.
 	filter := m.messenger.transport.FilterByChatID(dataID)
 	if filter != nil {
@@ -340,7 +340,7 @@ type storeNodeRequestResult struct {
 	// One of data fields (community or contact) will be present depending on request type
 	community *communities.Community
 	contact   *Contact
-	shard     *shard.Shard
+	shard     *wakuv2.Shard
 }
 
 type storeNodeResponseSubscription = chan storeNodeRequestResult

--- a/protocol/messenger_storenode_comunity_test.go
+++ b/protocol/messenger_storenode_comunity_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/status-im/status-go/protocol/storenodes"
 
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/tt"
+	"github.com/status-im/status-go/wakuv2"
 
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
@@ -92,7 +92,7 @@ func (s *MessengerStoreNodeCommunitySuite) createStore(name string) (*waku2.Waku
 	cfg := testWakuV2Config{
 		logger:      s.logger.Named(name),
 		enableStore: true,
-		clusterID:   shard.MainStatusShardCluster,
+		clusterID:   wakuv2.MainStatusShardCluster,
 	}
 
 	storeNode := NewTestWakuV2(&s.Suite, cfg)
@@ -110,7 +110,7 @@ func (s *MessengerStoreNodeCommunitySuite) newMessenger(name string, storenodeAd
 	cfg := testWakuV2Config{
 		logger:      logger,
 		enableStore: false,
-		clusterID:   shard.MainStatusShardCluster,
+		clusterID:   wakuv2.MainStatusShardCluster,
 	}
 	wakuV2 := NewTestWakuV2(&s.Suite, cfg)
 

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -33,6 +32,7 @@ import (
 	mailserversDB "github.com/status-im/status-go/services/mailservers"
 	"github.com/status-im/status-go/services/wallet/bigint"
 	"github.com/status-im/status-go/t/helpers"
+	"github.com/status-im/status-go/wakuv2"
 	waku2 "github.com/status-im/status-go/wakuv2"
 	wakuV2common "github.com/status-im/status-go/wakuv2/common"
 
@@ -161,7 +161,7 @@ func (s *MessengerStoreNodeRequestSuite) createStore() {
 	cfg := testWakuV2Config{
 		logger:      s.logger.Named("store-waku"),
 		enableStore: true,
-		clusterID:   shard.MainStatusShardCluster,
+		clusterID:   wakuv2.MainStatusShardCluster,
 	}
 
 	s.wakuStoreNode = NewTestWakuV2(&s.Suite, cfg)
@@ -179,7 +179,7 @@ func (s *MessengerStoreNodeRequestSuite) createOwner() {
 	cfg := testWakuV2Config{
 		logger:      s.logger.Named("owner-waku"),
 		enableStore: false,
-		clusterID:   shard.MainStatusShardCluster,
+		clusterID:   wakuv2.MainStatusShardCluster,
 	}
 
 	s.ownerWaku = NewTestWakuV2(&s.Suite, cfg)
@@ -199,7 +199,7 @@ func (s *MessengerStoreNodeRequestSuite) createBob() {
 	cfg := testWakuV2Config{
 		logger:      s.logger.Named("bob-waku"),
 		enableStore: false,
-		clusterID:   shard.MainStatusShardCluster,
+		clusterID:   wakuv2.MainStatusShardCluster,
 	}
 	s.bobWaku = NewTestWakuV2(&s.Suite, cfg)
 
@@ -698,8 +698,8 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestShardAndCommunityInfo() {
 	topicPrivKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 
-	expectedShard := &shard.Shard{
-		Cluster: shard.MainStatusShardCluster,
+	expectedShard := &wakuv2.Shard{
+		Cluster: wakuv2.MainStatusShardCluster,
 		Index:   23,
 	}
 
@@ -843,8 +843,8 @@ type testFetchRealCommunityExampleTokenInfo struct {
 
 var testFetchRealCommunityExample = []struct {
 	CommunityID          string
-	CommunityURL         string       // If set, takes precedence over CommunityID
-	CommunityShard       *shard.Shard // WARNING: I didn't test a sharded community
+	CommunityURL         string        // If set, takes precedence over CommunityID
+	CommunityShard       *wakuv2.Shard // WARNING: I didn't test a sharded community
 	Fleet                string
 	ClusterID            uint16
 	UserPrivateKeyString string // When empty a new user will be created
@@ -865,14 +865,14 @@ var testFetchRealCommunityExample = []struct {
 		CommunityID:    "0x03073514d4c14a7d10ae9fc9b0f05abc904d84166a6ac80add58bf6a3542a4e50a",
 		CommunityShard: nil,
 		Fleet:          params.FleetStatusProd,
-		ClusterID:      shard.MainStatusShardCluster,
+		ClusterID:      wakuv2.MainStatusShardCluster,
 	},
 	{
 		// Example 3,
 		// https://status.app/c/CxiACi8KFGFwIHJlcSAxIHN0dCBiZWMgbWVtEgdkc2Fkc2FkGAMiByM0MzYwREYqAxkrHAM=#zQ3shwDYZHtrLE7NqoTGjTWzWUu6hom5D4qxfskLZfgfyGRyL
 		CommunityID: "0x03f64be95ed5c925022265f9250f538f65ed3dcf6e4ef6c139803dc02a3487ae7b",
 		Fleet:       params.FleetStatusProd,
-		ClusterID:   shard.MainStatusShardCluster,
+		ClusterID:   wakuv2.MainStatusShardCluster,
 
 		CheckExpectedEnvelopes: true,
 		ExpectedShardEnvelopes: []string{
@@ -975,7 +975,7 @@ var testFetchRealCommunityExample = []struct {
 		//Example 1,
 		CommunityID:            "0x02471dd922756a3a50b623e59cf3b99355d6587e43d5c517eb55f9aea9d3fe9fe9",
 		Fleet:                  params.FleetStatusProd,
-		ClusterID:              shard.MainStatusShardCluster,
+		ClusterID:              wakuv2.MainStatusShardCluster,
 		CheckExpectedEnvelopes: true,
 		ExpectedShardEnvelopes: []string{
 			"0xc3e68e838d09e0117b3f3fd27aabe5f5a509d13e9045263c78e6890953d43547",
@@ -1015,7 +1015,7 @@ var testFetchRealCommunityExample = []struct {
 				ContractAddress: "0x21F6F5Cb75E81e5104D890D750270eD6538C50cb",
 			},
 		},
-		ClusterID:              shard.MainStatusShardCluster,
+		ClusterID:              wakuv2.MainStatusShardCluster,
 		CheckExpectedEnvelopes: false,
 		CustomOptions: []StoreNodeRequestOption{
 			WithInitialPageSize(1),

--- a/protocol/requests/set_community_shard.go
+++ b/protocol/requests/set_community_shard.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 
 	"github.com/status-im/status-go/eth-node/types"
-	"github.com/status-im/status-go/protocol/common/shard"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 type SetCommunityShard struct {
 	CommunityID types.HexBytes  `json:"communityId"`
-	Shard       *shard.Shard    `json:"shard,omitempty"`
+	Shard       *wakuv2.Shard   `json:"shard,omitempty"`
 	PrivateKey  *types.HexBytes `json:"privateKey,omitempty"`
 }
 
@@ -19,7 +19,7 @@ func (s *SetCommunityShard) Validate() error {
 	}
 	if s.Shard != nil {
 		// TODO: for now only MainStatusShard(16) is accepted
-		if s.Shard.Cluster != shard.MainStatusShardCluster {
+		if s.Shard.Cluster != wakuv2.MainStatusShardCluster {
 			return errors.New("invalid shard cluster")
 		}
 		if s.Shard.Index > 1023 {

--- a/protocol/transport/filters_manager.go
+++ b/protocol/transport/filters_manager.go
@@ -14,7 +14,7 @@ import (
 
 	wakutypes "github.com/status-im/status-go/waku/types"
 
-	"github.com/status-im/status-go/protocol/common/shard"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 const (
@@ -144,7 +144,7 @@ func (f *FiltersManager) InitPublicFilters(publicFiltersToInit []FiltersToInitia
 }
 
 type CommunityFilterToInitialize struct {
-	Shard   *shard.Shard
+	Shard   *wakuv2.Shard
 	PrivKey *ecdsa.PrivateKey
 }
 
@@ -161,7 +161,7 @@ func (f *FiltersManager) InitCommunityFilters(communityFiltersToInitialize []Com
 		}
 
 		topics := make([]string, 0)
-		topics = append(topics, shard.DefaultNonProtectedPubsubTopic())
+		topics = append(topics, wakuv2.DefaultNonProtectedPubsubTopic())
 		topics = append(topics, communityFilter.Shard.PubsubTopic())
 
 		for _, pubsubTopic := range topics {

--- a/protocol/waku_builder_test.go
+++ b/protocol/waku_builder_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/status-im/status-go/appdatabase"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/t/helpers"
+	"github.com/status-im/status-go/wakuv2"
 	waku2 "github.com/status-im/status-go/wakuv2"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
@@ -62,7 +62,7 @@ func NewTestWakuV2(s *suite.Suite, cfg testWakuV2Config) *waku2.Waku {
 
 	err = wakuNode.Start()
 	if cfg.enableStore {
-		err := wakuNode.SubscribeToPubsubTopic(shard.DefaultNonProtectedPubsubTopic(), nil)
+		err := wakuNode.SubscribeToPubsubTopic(wakuv2.DefaultNonProtectedPubsubTopic(), nil)
 		s.Require().NoError(err)
 	}
 	s.Require().NoError(err)
@@ -77,7 +77,7 @@ func CreateWakuV2Network(s *suite.Suite, parentLogger *zap.Logger, nodeNames []s
 		nodes[i] = NewTestWakuV2(s, testWakuV2Config{
 			logger:      parentLogger.Named("waku-" + name),
 			enableStore: false,
-			clusterID:   shard.MainStatusShardCluster,
+			clusterID:   wakuv2.MainStatusShardCluster,
 		})
 	}
 

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
@@ -83,7 +82,7 @@ func (s *SyncDeviceSuite) SetupTest() {
 		EnableDiscV5:                           true,
 		EnablePeerExchangeServer:               true,
 		ClusterID:                              16,
-		DefaultShardPubsubTopic:                shard.DefaultShardPubsubTopic(),
+		DefaultShardPubsubTopic:                wakuv2.DefaultShardPubsubTopic(),
 		EnableStoreConfirmationForMessagesSent: false,
 	}
 	var err error

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -30,7 +30,6 @@ import (
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol"
 	"github.com/status-im/status-go/protocol/common"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/discord"
@@ -42,6 +41,7 @@ import (
 	"github.com/status-im/status-go/protocol/transport"
 	"github.com/status-im/status-go/protocol/verification"
 	"github.com/status-im/status-go/services/ext/mailservers"
+	"github.com/status-im/status-go/wakuv2"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
@@ -1278,7 +1278,7 @@ func (api *PublicAPI) RequestCommunityInfoFromMailserver(communityID string) (*c
 
 // Deprecated: RequestCommunityInfoFromMailserverWithShard is deprecated in favor of
 // configurable FetchCommunity.
-func (api *PublicAPI) RequestCommunityInfoFromMailserverWithShard(communityID string, shard *shard.Shard) (*communities.Community, error) {
+func (api *PublicAPI) RequestCommunityInfoFromMailserverWithShard(communityID string, shard *wakuv2.Shard) (*communities.Community, error) {
 	request := &protocol.FetchCommunityRequest{
 		CommunityKey:    communityID,
 		Shard:           shard,
@@ -1303,7 +1303,7 @@ func (api *PublicAPI) RequestCommunityInfoFromMailserverAsync(communityID string
 
 // Deprecated: RequestCommunityInfoFromMailserverAsyncWithShard is deprecated in favor of
 // configurable FetchCommunity.
-func (api *PublicAPI) RequestCommunityInfoFromMailserverAsyncWithShard(communityID string, shard *shard.Shard) error {
+func (api *PublicAPI) RequestCommunityInfoFromMailserverAsyncWithShard(communityID string, shard *wakuv2.Shard) error {
 	request := &protocol.FetchCommunityRequest{
 		CommunityKey:    communityID,
 		Shard:           shard,

--- a/services/mailservers/api_test.go
+++ b/services/mailservers/api_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/appdatabase"
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/protocol/sqlite"
 	"github.com/status-im/status-go/protocol/transport"
 	"github.com/status-im/status-go/t/helpers"
 	wakutypes "github.com/status-im/status-go/waku/types"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 func setupTestDB(t *testing.T) (*Database, func()) {
@@ -62,9 +62,9 @@ func TestTopic(t *testing.T) {
 	defer close()
 	topicA := "0x61000000"
 	topicD := "0x64000000"
-	topic1 := MailserverTopic{PubsubTopic: shard.DefaultShardPubsubTopic(), ContentTopic: topicA, LastRequest: 1}
-	topic2 := MailserverTopic{PubsubTopic: shard.DefaultShardPubsubTopic(), ContentTopic: "0x6200000", LastRequest: 2}
-	topic3 := MailserverTopic{PubsubTopic: shard.DefaultShardPubsubTopic(), ContentTopic: "0x6300000", LastRequest: 3}
+	topic1 := MailserverTopic{PubsubTopic: wakuv2.DefaultShardPubsubTopic(), ContentTopic: topicA, LastRequest: 1}
+	topic2 := MailserverTopic{PubsubTopic: wakuv2.DefaultShardPubsubTopic(), ContentTopic: "0x6200000", LastRequest: 2}
+	topic3 := MailserverTopic{PubsubTopic: wakuv2.DefaultShardPubsubTopic(), ContentTopic: "0x6300000", LastRequest: 3}
 
 	require.NoError(t, db.AddTopic(topic1))
 	require.NoError(t, db.AddTopic(topic2))
@@ -77,14 +77,14 @@ func TestTopic(t *testing.T) {
 	filters := []*transport.Filter{
 		// Existing topic, is not updated
 		{
-			PubsubTopic:  shard.DefaultShardPubsubTopic(),
+			PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
 			ContentTopic: wakutypes.BytesToTopic([]byte{0x61}),
 		},
 		// Non existing topic is not inserted
 		{
 			Discovery:    true,
 			Negotiated:   true,
-			PubsubTopic:  shard.DefaultShardPubsubTopic(),
+			PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
 			ContentTopic: wakutypes.BytesToTopic([]byte{0x64}),
 		},
 	}
@@ -160,7 +160,7 @@ func TestAddGetDeleteMailserverTopics(t *testing.T) {
 	defer close()
 	api := &API{db: db}
 	testTopic := MailserverTopic{
-		PubsubTopic:  shard.DefaultShardPubsubTopic(),
+		PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),
 		ContentTopic: "topic-001",
 		ChatIDs:      []string{"chatID01", "chatID02"},
 		LastRequest:  10,
@@ -173,14 +173,14 @@ func TestAddGetDeleteMailserverTopics(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, []MailserverTopic{testTopic}, topics)
 
-	err = api.DeleteMailserverTopic(context.Background(), shard.DefaultShardPubsubTopic(), testTopic.ContentTopic)
+	err = api.DeleteMailserverTopic(context.Background(), wakuv2.DefaultShardPubsubTopic(), testTopic.ContentTopic)
 	require.NoError(t, err)
 	topics, err = api.GetMailserverTopics(context.Background())
 	require.NoError(t, err)
 	require.EqualValues(t, ([]MailserverTopic)(nil), topics)
 
 	// Delete non-existing topic.
-	err = api.DeleteMailserverTopic(context.Background(), shard.DefaultShardPubsubTopic(), "non-existing-topic")
+	err = api.DeleteMailserverTopic(context.Background(), wakuv2.DefaultShardPubsubTopic(), "non-existing-topic")
 	require.NoError(t, err)
 }
 

--- a/services/status/service.go
+++ b/services/status/service.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol"
-	"github.com/status-im/status-go/protocol/common/shard"
+	"github.com/status-im/status-go/wakuv2"
 )
 
 // Make sure that Service implements node.Lifecycle interface.
@@ -70,7 +70,7 @@ type PublicAPI struct {
 	service *Service
 }
 
-func (p *PublicAPI) CommunityInfo(communityID types.HexBytes, shard *shard.Shard) (json.RawMessage, error) {
+func (p *PublicAPI) CommunityInfo(communityID types.HexBytes, shard *wakuv2.Shard) (json.RawMessage, error) {
 	if p.service.messenger == nil {
 		return nil, ErrNotInitialized
 	}

--- a/wakuv2/api_test.go
+++ b/wakuv2/api_test.go
@@ -24,7 +24,6 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	"github.com/status-im/status-go/protocol/common/shard"
 	"github.com/status-im/status-go/waku/types"
 	"github.com/status-im/status-go/wakuv2/common"
 )
@@ -58,7 +57,7 @@ func TestMultipleTopicCopyInNewMessageFilter(t *testing.T) {
 	}
 
 	found := false
-	candidates := w.filters.GetWatchersByTopic(shard.DefaultShardPubsubTopic(), t1)
+	candidates := w.filters.GetWatchersByTopic(DefaultShardPubsubTopic(), t1)
 	for _, f := range candidates {
 		if maps.Equal(f.ContentTopics, common.NewTopicSet([]common.TopicType{t1, t2})) {
 			found = true

--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -23,8 +23,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/status-im/status-go/protocol/common/shard"
-
 	ethdisc "github.com/ethereum/go-ethereum/p2p/dnsdisc"
 
 	"github.com/status-im/status-go/wakuv2/common"
@@ -117,10 +115,10 @@ func setDefaults(cfg *Config) *Config {
 	}
 
 	if cfg.DefaultShardPubsubTopic == "" {
-		cfg.DefaultShardPubsubTopic = shard.DefaultShardPubsubTopic()
+		cfg.DefaultShardPubsubTopic = DefaultShardPubsubTopic()
 		//For now populating with both used shards, but this can be populated from user subscribed communities etc once community sharding is implemented
-		cfg.DefaultShardedPubsubTopics = append(cfg.DefaultShardedPubsubTopics, shard.DefaultShardPubsubTopic())
-		cfg.DefaultShardedPubsubTopics = append(cfg.DefaultShardedPubsubTopics, shard.DefaultNonProtectedPubsubTopic())
+		cfg.DefaultShardedPubsubTopics = append(cfg.DefaultShardedPubsubTopics, DefaultShardPubsubTopic())
+		cfg.DefaultShardedPubsubTopics = append(cfg.DefaultShardedPubsubTopics, DefaultNonProtectedPubsubTopic())
 	}
 
 	return cfg

--- a/wakuv2/shard.go
+++ b/wakuv2/shard.go
@@ -1,4 +1,4 @@
-package shard
+package wakuv2
 
 import (
 	wakuproto "github.com/waku-org/go-waku/waku/v2/protocol"


### PR DESCRIPTION
Moving `shard.go` to the `wakuv2` package. The sharding logic belongs to Waku usage and moving it allows us avoiding circular dependencies.

Important changes:
- [x] moving `shard.go` to `wakuv2` package
- [x] updating imports 

Issue: https://github.com/waku-org/nwaku/issues/3076
