### PR TITLE
feat_: API to use a custom Waku fleet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ tests-functional/*.log
 # generated files
 mock
 mock.go
+*_mock_test.go
 *.pb.go
 bindata.go
 migrations.go

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -155,7 +155,7 @@ func SetFleet(fleet string, nodeConfig *params.NodeConfig) error {
 	}
 
 	nodeConfig.ClusterConfig = params.DefaultClusterConfig(fleet)
-    
+
 	return nil
 }
 

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"path/filepath"
 
@@ -149,8 +150,12 @@ func SetFleet(fleet string, nodeConfig *params.NodeConfig) error {
 		Nameserver:                             specifiedWakuV2Config.Nameserver,
 	}
 
-	nodeConfig.ClusterConfig = params.DefaultClusterConfig(fleet)
+	if !params.IsFleetSupported(fleet) {
+		return fmt.Errorf("unknown fleet %s", fleet)
+	}
 
+	nodeConfig.ClusterConfig = params.DefaultClusterConfig(fleet)
+    
 	return nil
 }
 

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -12,12 +12,14 @@ import (
 	"unsafe"
 
 	"go.uber.org/zap"
-	validator "gopkg.in/go-playground/validator.v9"
+	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 
 	"github.com/status-im/zxcvbn-go"
 	"github.com/status-im/zxcvbn-go/scoring"
+
+	"github.com/status-im/status-go/extkeys"
 
 	abi_spec "github.com/status-im/status-go/abi-spec"
 	"github.com/status-im/status-go/account"
@@ -29,7 +31,6 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/exportlogs"
-	"github.com/status-im/status-go/extkeys"
 	"github.com/status-im/status-go/images"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/logutils/callog"
@@ -131,6 +132,13 @@ func initializeApplication(requestJSON string) string {
 	statusBackend.SetSentryDSN(request.SentryDSN)
 	if metricsInfo.Enabled {
 		err = statusBackend.EnablePanicReporting()
+		if err != nil {
+			return makeJSONResponse(err)
+		}
+	}
+
+	if request.WakuFleetsConfigFilePath != "" {
+		err = params.LoadFleetsFromFile(request.WakuFleetsConfigFilePath)
 		if err != nil {
 			return makeJSONResponse(err)
 		}

--- a/params/cluster.go
+++ b/params/cluster.go
@@ -1,6 +1,12 @@
 package params
 
 import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	pkgerrors "github.com/pkg/errors"
+
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
 
@@ -186,6 +192,40 @@ var defaultPushNotificationServers = []string{
 	"401ba5eda402678dc78a0a40fd0795f4ea8b1e34972c4d15cf33ac01292341c89f0cbc637fa9f7a3ffe0b9dfe90e9cdae7a14925500ab01b6a91c67bae42a97a",
 	"181141b1d111908aaf05f4788e6778ec07073a1d4e1ce43c73815c40ee4e7345a1cbf5a90a45f601bf3763f12be63b01624ba1f36eeb9572455e7034b8f9f2c4",
 	"5ffc34d5ffda180d94cd3974d9ed2bb082ede68f342babdbe801ceffb7da902087d43f9aa961c7b85029358874c08ef04ecad9f1d95a1f0e448cbdd5d04350c7",
+}
+
+func loadFleetsFromFile(filepath string) (FleetsMap, error) {
+	// Read the JSON file to populate the supportedFleets map
+	file, err := os.Open(filepath)
+	if err != nil {
+		err = pkgerrors.Wrap(err, "failed to open fleets json file")
+		return nil, err
+	}
+
+	defer func() {
+		err = errors.Join(err, file.Close())
+	}()
+
+	var overrideFleets FleetsMap
+	decoder := json.NewDecoder(file)
+
+	err = decoder.Decode(&overrideFleets)
+	if err != nil {
+		err = pkgerrors.Wrap(err, "failed to decode fleets json file")
+		return nil, err
+	}
+
+	return overrideFleets, nil
+}
+
+func LoadFleetsFromFile(filepath string) error {
+	fleetsMap, err := loadFleetsFromFile(filepath)
+	if err != nil {
+		return err
+	}
+
+	supportedFleets = fleetsMap
+	return nil
 }
 
 func DefaultWakuNodes(fleet string) []string {

--- a/params/cluster.go
+++ b/params/cluster.go
@@ -2,7 +2,6 @@ package params
 
 import (
 	"encoding/json"
-	"errors"
 	"os"
 
 	pkgerrors "github.com/pkg/errors"
@@ -202,9 +201,7 @@ func loadFleetsFromFile(filepath string) (FleetsMap, error) {
 		return nil, err
 	}
 
-	defer func() {
-		err = errors.Join(err, file.Close())
-	}()
+	defer file.Close()
 
 	var overrideFleets FleetsMap
 	decoder := json.NewDecoder(file)

--- a/params/cluster_test.go
+++ b/params/cluster_test.go
@@ -1,0 +1,72 @@
+package params
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadFleetsFromFile tests the loadFleetsFromFile function.
+func TestLoadFleetsFromFile(t *testing.T) {
+	t.Run("valid file", func(t *testing.T) {
+		// Arrange: Create a temporary valid JSON file.
+		tempFile, err := os.CreateTemp("", "fleets*.json")
+		require.NoError(t, err)
+		defer os.Remove(tempFile.Name())
+
+		// Write valid JSON data into the temp file.
+		fleetName := gofakeit.LetterN(10)
+		validFleets := FleetsMap{
+			fleetName: {
+				ClusterID: 123,
+				WakuNodes: []string{"test.node"},
+			},
+		}
+		err = json.NewEncoder(tempFile).Encode(validFleets)
+		require.NoError(t, err)
+		err = tempFile.Close()
+		require.NoError(t, err)
+
+		// Act: Call the function.
+		result, err := loadFleetsFromFile(tempFile.Name())
+
+		// Assert: Check the error.
+		require.NoError(t, err)
+		assert.Equal(t, validFleets, result)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		// Arrange: Use a non-existent file path.
+		nonExistentFile := filepath.Join(os.TempDir(), "non_existent_file.json")
+
+		// Act: Call the function.
+		_, err := loadFleetsFromFile(nonExistentFile)
+
+		// Assert: Check the error.
+		require.Error(t, err)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		// Arrange: Create a temporary file with invalid JSON.
+		tempFile, err := os.CreateTemp("", "malformed*.json")
+		require.NoError(t, err)
+		defer os.Remove(tempFile.Name())
+
+		_, err = tempFile.WriteString("{ invalid json }")
+		require.NoError(t, err)
+		tempFile.Close()
+
+		// Act: Call the function.
+		_, err = loadFleetsFromFile(tempFile.Name())
+
+		// Assert: Check the error.
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid character") // Match JSON parsing error.
+	})
+}

--- a/params/config.go
+++ b/params/config.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	validator "gopkg.in/go-playground/validator.v9"
+	"gopkg.in/go-playground/validator.v9"
 
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/ethereum/go-ethereum/params"

--- a/protocol/requests/initialize_application.go
+++ b/protocol/requests/initialize_application.go
@@ -26,6 +26,11 @@ type InitializeApplication struct {
 
 	MetricsEnabled bool   `json:"metricsEnabled"`
 	MetricsAddress string `json:"metricsAddress"`
+
+	// WakuFleetsConfigFilePath specifies the file path for configuring fleets supported by the app.
+	// File structure must be as params.FleetsMap.
+	// When successfully loaded, overrides all hard-coded fleets with file contents.
+	WakuFleetsConfigFilePath string `json:"wakuFleetsConfigFilePath"`
 }
 
 func (i *InitializeApplication) Validate() error {

--- a/waku/types/mailserver_test.go
+++ b/waku/types/mailserver_test.go
@@ -1,0 +1,28 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/waku/types"
+)
+
+func TestMailserver_UnmarshalJSON(t *testing.T) {
+	fleets := params.GetSupportedFleets()
+
+	for _, fleet := range fleets {
+		for _, mailserver := range fleet.StoreNodes {
+			jsonData, err := json.Marshal(mailserver)
+			require.NoError(t, err)
+
+			var unmarshalled types.Mailserver
+			err = json.Unmarshal(jsonData, &unmarshalled)
+			require.NoError(t, err)
+
+			require.Equal(t, mailserver, unmarshalled)
+		}
+	}
+}

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -36,6 +36,8 @@ import (
 	"testing"
 	"time"
 
+	pkgerrors "github.com/pkg/errors"
+
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
@@ -88,7 +90,7 @@ import (
 
 	"github.com/status-im/status-go/waku/types"
 
-	node "github.com/waku-org/go-waku/waku/v2/node"
+	"github.com/waku-org/go-waku/waku/v2/node"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 )
 
@@ -531,7 +533,21 @@ func (w *Waku) retryDnsDiscoveryWithBackoff(ctx context.Context, addr string, su
 	}
 }
 
+type peerAddressHandler interface {
+	discoverAndConnect(addr string)
+	connect(peerInfo peer.AddrInfo, node *enode.Node, origin wps.Origin)
+}
+
 func (w *Waku) discoverAndConnectPeers() {
+	for _, addrString := range w.cfg.WakuNodes {
+		err := handlePeerAddress(addrString, w)
+		if err != nil {
+			w.logger.Warn("failed to handle peer address", zap.String("addr", addrString), zap.Error(err))
+		}
+	}
+}
+
+func (w *Waku) discoverAndConnect(address string) {
 	fnApply := func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {
 		defer wg.Done()
 		if len(d.PeerInfo.Addrs) != 0 {
@@ -539,60 +555,53 @@ func (w *Waku) discoverAndConnectPeers() {
 		}
 	}
 
-	for _, addrString := range w.cfg.WakuNodes {
-		if strings.HasPrefix(addrString, "enrtree://") {
-			// Use DNS Discovery
-			go func() {
-				defer gocommon.LogOnPanic()
-				if err := w.dnsDiscover(w.ctx, addrString, fnApply, false); err != nil {
-					w.logger.Error("could not obtain dns discovery peers for ClusterConfig.WakuNodes", zap.Error(err), zap.String("dnsDiscURL", addrString))
-				}
-			}()
-			continue
+	go func() {
+		defer gocommon.LogOnPanic()
+		if err := w.dnsDiscover(w.ctx, address, fnApply, false); err != nil {
+			w.logger.Error("dns discovery failed",
+				zap.String("dnsDiscURL", address),
+				zap.Error(err))
 		}
+	}()
+}
 
-		if addr, err := multiaddr.NewMultiaddr(addrString); err == nil {
-			// It is a normal multiaddress
-			peerInfo, err := peer.AddrInfoFromP2pAddr(addr)
-			if err != nil {
-				w.logger.Warn("invalid peer multiaddress", zap.Stringer("addr", addr), zap.Error(err))
-				continue
-			}
-
-			go w.connect(*peerInfo, nil, wps.Static)
-			continue
-		}
-
-		if strings.HasPrefix(addrString, "enr:") {
-			// Parse as ENR
-			node, err := enode.Parse(enode.ValidSchemes, addrString)
-			if err != nil {
-				w.logger.Warn("invalid ENR", zap.String("addr", addrString), zap.Error(err))
-				continue
-			}
-
-			id, addrs, err := enr.Multiaddress(node)
-			if err != nil {
-				w.logger.Warn("invalid peer ID", zap.Error(err))
-				continue
-			}
-
-			peerInfo := peer.AddrInfo{
-				ID:    id,
-				Addrs: addrs,
-			}
-			go w.connect(peerInfo, node, wps.Static)
-			continue
-		}
-
-		w.logger.Warn("unknown format of waku node address", zap.String("addr", addrString))
+func handlePeerAddress(addr string, handler peerAddressHandler) error {
+	if strings.HasPrefix(addr, "enrtree://") {
+		handler.discoverAndConnect(addr)
+		return nil
 	}
+
+	if node, err := enode.Parse(enode.ValidSchemes, addr); err == nil {
+		id, addrs, err := enr.Multiaddress(node)
+		if err != nil {
+			return pkgerrors.Wrap(err, "invalid enr contents")
+		}
+
+		peerInfo := peer.AddrInfo{
+			ID:    id,
+			Addrs: addrs,
+		}
+		handler.connect(peerInfo, node, wps.Static)
+		return nil
+	}
+
+	if maddr, err := multiaddr.NewMultiaddr(addr); err == nil {
+		peerInfo, err := peer.AddrInfoFromP2pAddr(maddr)
+		if err != nil {
+			return pkgerrors.Wrap(err, "invalid peer multiaddress")
+		}
+
+		handler.connect(*peerInfo, nil, wps.Static)
+		return nil
+	}
+
+	return errors.New("unknown format of waku node address")
 }
 
 func (w *Waku) connect(peerInfo peer.AddrInfo, enr *enode.Node, origin wps.Origin) {
 	defer gocommon.LogOnPanic()
 	// Connection will be prunned eventually by the connection manager if needed
-	// The peer connector in go-waku uses Connect, so it will execute identify as part of its
+	// The peer connector in go-waku uses connect, so it will execute identify as part of its
 	w.node.AddDiscoveredPeer(peerInfo.ID, peerInfo.Addrs, origin, w.cfg.DefaultShardedPubsubTopics, enr, true)
 }
 

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -41,7 +41,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/waku-org/go-waku/waku/v2/protocol/enr"
 	"google.golang.org/protobuf/proto"
 
 	"go.uber.org/zap"
@@ -71,6 +70,7 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/peermanager"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
+	"github.com/waku-org/go-waku/waku/v2/protocol/enr"
 	"github.com/waku-org/go-waku/waku/v2/protocol/filter"
 	"github.com/waku-org/go-waku/waku/v2/protocol/lightpush"
 	"github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange"

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -41,6 +41,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/waku-org/go-waku/waku/v2/protocol/enr"
 	"google.golang.org/protobuf/proto"
 
 	"go.uber.org/zap"
@@ -539,7 +540,6 @@ func (w *Waku) discoverAndConnectPeers() {
 	}
 
 	for _, addrString := range w.cfg.WakuNodes {
-		addrString := addrString
 		if strings.HasPrefix(addrString, "enrtree://") {
 			// Use DNS Discovery
 			go func() {
@@ -548,14 +548,11 @@ func (w *Waku) discoverAndConnectPeers() {
 					w.logger.Error("could not obtain dns discovery peers for ClusterConfig.WakuNodes", zap.Error(err), zap.String("dnsDiscURL", addrString))
 				}
 			}()
-		} else {
-			// It is a normal multiaddress
-			addr, err := multiaddr.NewMultiaddr(addrString)
-			if err != nil {
-				w.logger.Warn("invalid peer multiaddress", zap.String("ma", addrString), zap.Error(err))
-				continue
-			}
+			continue
+		}
 
+		if addr, err := multiaddr.NewMultiaddr(addrString); err == nil {
+			// It is a normal multiaddress
 			peerInfo, err := peer.AddrInfoFromP2pAddr(addr)
 			if err != nil {
 				w.logger.Warn("invalid peer multiaddress", zap.Stringer("addr", addr), zap.Error(err))
@@ -563,7 +560,32 @@ func (w *Waku) discoverAndConnectPeers() {
 			}
 
 			go w.connect(*peerInfo, nil, wps.Static)
+			continue
 		}
+
+		if strings.HasPrefix(addrString, "enr:") {
+			// Parse as ENR
+			node, err := enode.Parse(enode.ValidSchemes, addrString)
+			if err != nil {
+				w.logger.Warn("invalid ENR", zap.String("addr", addrString), zap.Error(err))
+				continue
+			}
+
+			id, addrs, err := enr.Multiaddress(node)
+			if err != nil {
+				w.logger.Warn("invalid peer ID", zap.Error(err))
+				continue
+			}
+
+			peerInfo := peer.AddrInfo{
+				ID:    id,
+				Addrs: addrs,
+			}
+			go w.connect(peerInfo, node, wps.Static)
+			continue
+		}
+
+		w.logger.Warn("unknown format of waku node address", zap.String("addr", addrString))
 	}
 }
 

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -21,6 +21,10 @@
 
 package wakuv2
 
+// Generate a mock for peerAddressHandler. Keep it in same dir and package, as it's a private type.
+// Yet we name the file _test.go to keep it only available in testing environment.
+//go:generate mockgen -source=gowaku.go -destination=gowaku_mock_test.go -package=wakuv2
+
 import (
 	"context"
 	"crypto/ecdsa"

--- a/wakuv2/gowaku_test.go
+++ b/wakuv2/gowaku_test.go
@@ -1,0 +1,156 @@
+package wakuv2
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
+	"github.com/waku-org/go-waku/waku/v2/utils"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandlePeerAddress(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Mocks
+	mockHandler := NewMockpeerAddressHandler(ctrl)
+
+	t.Run("valid enrtree", func(t *testing.T) {
+		addr := "enrtree:// " + gofakeit.LetterN(10)
+
+		// Setup discover mock expectation.
+		mockHandler.EXPECT().
+			discoverAndConnect(addr).
+			Times(1)
+
+		// Setup connect expectation (not called for enrtree resolution).
+		mockHandler.EXPECT().
+			connect(gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+
+		// Call the tested function
+		err := handlePeerAddress(addr, mockHandler)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid multiaddr", func(t *testing.T) {
+		// Use a multiaddr with no p2p peerID
+		addr := fmt.Sprintf("/ip4/%s/tcp/%d/", gofakeit.IPv4Address(), gofakeit.Uint16())
+
+		// Setup discover mock expectation (no call expected).
+		mockHandler.EXPECT().
+			discoverAndConnect(gomock.Any()).
+			Times(0)
+
+		// Setup connect mock expectation (no call expected).
+		mockHandler.EXPECT().
+			connect(gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+
+		// Call the tested function
+		err := handlePeerAddress(addr, mockHandler)
+		assert.ErrorContains(t, err, "invalid peer multiaddress")
+	})
+
+	t.Run("valid multiaddr", func(t *testing.T) {
+		// Generate peer ID
+		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		publicKey := utils.EcdsaPubKeyToSecp256k1PublicKey(&privateKey.PublicKey)
+		peerID, err := peer.IDFromPublicKey(publicKey)
+		require.NoError(t, err)
+
+		// Generate multiaddr
+		ip4Addr := gofakeit.IPv4Address()
+		port := gofakeit.Number(1024, 65535)
+		addr := fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", ip4Addr, port, peerID.String())
+		maddr, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip4Addr, port))
+		require.NoError(t, err)
+
+		// Setup expectations
+		expectedPeerInfo := peer.AddrInfo{
+			ID:    peerID,
+			Addrs: []multiaddr.Multiaddr{maddr},
+		}
+		mockHandler.EXPECT().
+			discoverAndConnect(gomock.Any()).
+			Times(0)
+		mockHandler.EXPECT().
+			connect(gomock.Eq(expectedPeerInfo), gomock.Nil(), gomock.Eq(wps.Static)).
+			//connect(gomock.Eq(expectedPeerInfo), gomock.Nil(), gomock.Eq(wps.Static)).
+			Times(1)
+
+		// Call the tested function
+		err = handlePeerAddress(addr, mockHandler)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid enr", func(t *testing.T) {
+		const enr = "enr:-QEQuEBuiQgFlJNcv255042zwyl4pOBOivakX8N30Dr9vaaEU2q8-7N4GVY4Hk87iEKELjlIXTpE9Wj6EQq1lrBuc7ayAYJpZIJ2NIJpcISPxvrpim11bHRpYWRkcnO4YAAtNihib290LTAxLmRvLWFtczMuc3RhdHVzLnN0YWdpbmcuc3RhdHVzLmltBnZfAC82KGJvb3QtMDEuZG8tYW1zMy5zdGF0dXMuc3RhZ2luZy5zdGF0dXMuaW0GAbveA4Jyc40AEAUAAQAgAEAAgAEAiXNlY3AyNTZrMaEDq-yGgpuoUG6NKkbIDRmrMiT-bEVzFlpWLEK_rF3yKUaDdGNwgnZfg3VkcIIjKIV3YWt1Mg0"
+		expectedAddrs := []string{
+			"/ip4/143.198.250.233/tcp/30303/p2p/16Uiu2HAmQE7FXQc6iZHdBzYfw3qCSDa9dLc1wsBJKoP4aZvztq2d",
+			"/dns4/boot-01.do-ams3.status.staging.status.im/tcp/30303/p2p/16Uiu2HAmQE7FXQc6iZHdBzYfw3qCSDa9dLc1wsBJKoP4aZvztq2d",
+			"/dns4/boot-01.do-ams3.status.staging.status.im/tcp/443/wss/p2p/16Uiu2HAmQE7FXQc6iZHdBzYfw3qCSDa9dLc1wsBJKoP4aZvztq2d",
+		}
+		expectedPeerID, err := peer.Decode("16Uiu2HAmQE7FXQc6iZHdBzYfw3qCSDa9dLc1wsBJKoP4aZvztq2d")
+		require.NoError(t, err)
+
+		node, err := enode.Parse(enode.ValidSchemes, enr)
+		require.NoError(t, err)
+
+		//maddr, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip, port))
+		//require.NoError(t, err)
+
+		// Setup discover mock expectation.
+		mockHandler.EXPECT().
+			discoverAndConnect(gomock.Any()).
+			Times(0)
+
+		// Setup connect expectation (not called due to ENR resolution failure).
+		expectedPeerInfo := peer.AddrInfo{
+			ID:    expectedPeerID,
+			Addrs: []multiaddr.Multiaddr{},
+		}
+		for _, m := range expectedAddrs {
+			maddr, err := multiaddr.NewMultiaddr(m)
+			require.NoError(t, err)
+			expectedPeerInfo.Addrs = append(expectedPeerInfo.Addrs, maddr)
+		}
+		mockHandler.EXPECT().
+			connect(gomock.Eq(expectedPeerInfo), gomock.Eq(node), gomock.Eq(wps.Static)).
+			Times(1)
+
+		// Call the tested function
+		err = handlePeerAddress(enr, mockHandler)
+		require.NoError(t, err)
+	})
+
+	t.Run("unknown address format", func(t *testing.T) {
+		addr := gofakeit.LetterN(10)
+
+		// Setup discover mock expectation (no call expected).
+		mockHandler.EXPECT().
+			discoverAndConnect(gomock.Any()).
+			Times(0)
+
+		// Setup connect mock expectation (also no call expected).
+		mockHandler.EXPECT().
+			connect(gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(0)
+
+		// Call the tested function
+		err := handlePeerAddress(addr, mockHandler)
+		assert.ErrorContains(t, err, "unknown format of waku")
+	})
+}

--- a/wakuv2/gowaku_test.go
+++ b/wakuv2/gowaku_test.go
@@ -8,15 +8,19 @@ import (
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
-	"github.com/ethereum/go-ethereum/p2p/enode"
+
 	"github.com/libp2p/go-libp2p/core/peer"
+
 	"github.com/multiformats/go-multiaddr"
-	"github.com/stretchr/testify/require"
-	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
-	"github.com/waku-org/go-waku/waku/v2/utils"
+
 	"go.uber.org/mock/gomock"
 
-	"github.com/stretchr/testify/assert"
+	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
+	"github.com/waku-org/go-waku/waku/v2/utils"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandlePeerAddress(t *testing.T) {
@@ -41,7 +45,7 @@ func TestHandlePeerAddress(t *testing.T) {
 
 		// Call the tested function
 		err := handlePeerAddress(addr, mockHandler)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("invalid multiaddr", func(t *testing.T) {
@@ -60,7 +64,7 @@ func TestHandlePeerAddress(t *testing.T) {
 
 		// Call the tested function
 		err := handlePeerAddress(addr, mockHandler)
-		assert.ErrorContains(t, err, "invalid peer multiaddress")
+		require.ErrorContains(t, err, "invalid peer multiaddress")
 	})
 
 	t.Run("valid multiaddr", func(t *testing.T) {
@@ -93,7 +97,7 @@ func TestHandlePeerAddress(t *testing.T) {
 
 		// Call the tested function
 		err = handlePeerAddress(addr, mockHandler)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("valid enr", func(t *testing.T) {
@@ -151,6 +155,6 @@ func TestHandlePeerAddress(t *testing.T) {
 
 		// Call the tested function
 		err := handlePeerAddress(addr, mockHandler)
-		assert.ErrorContains(t, err, "unknown format of waku")
+		require.ErrorContains(t, err, "unknown format of waku")
 	})
 }


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/6260

# Description

1. Added `InitializeApplication.WakuFleetsConfigFilePath` parameter
  When set, looks for a local file by given path and replaces `supportedFleets` with its contents.
  
2. Added a custom `UnmarshalJSON` for `Mailserver`.
    To parse `enr` and `addr` fields as strings.

3. When selecting a fleet, check if such fleet is known

4. When parsing static `WakuNode`, support ENRs.
    This way we immediately get the protocols/topics information about each peer.