### PR TITLE
test_: functional tests framework improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,8 @@ Session.vim
 .undodir/*
 /.idea/
 /.vscode/
+/tests-functional/.idea/
+/tests-functional/.vscode/
 /cmd/*/.ethereum/
 *.iml
 

--- a/tests-functional/clients/rpc.py
+++ b/tests-functional/clients/rpc.py
@@ -12,6 +12,7 @@ class RpcClient:
     def __init__(self, rpc_url, client=requests.Session()):
         self.client = client
         self.rpc_url = rpc_url
+        self.request_counter = 0
 
     def _check_decode_and_key_errors_in_response(self, response, key):
         try:
@@ -45,7 +46,8 @@ class RpcClient:
     @retry(stop=stop_after_delay(10), wait=wait_fixed(0.5), reraise=True)
     def rpc_request(self, method, params=None, request_id=None, url=None, enable_logging=True):
         if not request_id:
-            request_id = 13
+            request_id = self.request_counter
+            self.request_counter += 1
         if params is None:
             params = []
         url = url if url else self.rpc_url

--- a/tests-functional/clients/rpc.py
+++ b/tests-functional/clients/rpc.py
@@ -69,7 +69,7 @@ class RpcClient:
         return response
 
     def rpc_valid_request(self, method, params=None, _id=None, url=None, skip_validation=False, enable_logging=True):
-        response = self.rpc_request(method, params, _id, url, enable_logging=enable_loggin)
+        response = self.rpc_request(method, params, _id, url, enable_logging=enable_logging)
         self.verify_is_valid_json_rpc_response(response, _id, skip_validation=skip_validation)
         return response
 

--- a/tests-functional/clients/rpc.py
+++ b/tests-functional/clients/rpc.py
@@ -43,7 +43,7 @@ class RpcClient:
         self._check_decode_and_key_errors_in_response(response, "error")
 
     @retry(stop=stop_after_delay(10), wait=wait_fixed(0.5), reraise=True)
-    def rpc_request(self, method, params=None, request_id=None, url=None):
+    def rpc_request(self, method, params=None, request_id=None, url=None, enable_logging=True):
         if not request_id:
             request_id = 13
         if params is None:
@@ -52,19 +52,22 @@ class RpcClient:
         data = {"jsonrpc": "2.0", "method": method, "id": request_id}
         if params:
             data["params"] = params
-        logging.info(f"Sending POST request to url {url} with data: {json.dumps(data, sort_keys=True, indent=4)}")
+        if enable_logging:
+            logging.info(f"Sending POST request to url {url} with data: {json.dumps(data, sort_keys=True, indent=4)}")
         response = self.client.post(url, json=data)
         try:
             resp_json = response.json()
-            logging.info(f"Got response: {json.dumps(resp_json, sort_keys=True, indent=4)}")
+            if enable_logging:
+                logging.info(f"Got response: {json.dumps(resp_json, sort_keys=True, indent=4)}")
             if resp_json.get("error"):
                 assert "JSON-RPC client is unavailable" != resp_json["error"]
         except JSONDecodeError:
-            logging.info(f"Got response: {response.content}")
+            if enable_logging:
+                logging.info(f"Got response: {response.content}")
         return response
 
-    def rpc_valid_request(self, method, params=None, _id=None, url=None, skip_validation=False):
-        response = self.rpc_request(method, params, _id, url)
+    def rpc_valid_request(self, method, params=None, _id=None, url=None, skip_validation=False, enable_logging=True):
+        response = self.rpc_request(method, params, _id, url, enable_logging=enable_loggin)
         self.verify_is_valid_json_rpc_response(response, _id, skip_validation=skip_validation)
         return response
 

--- a/tests-functional/clients/services/service.py
+++ b/tests-functional/clients/services/service.py
@@ -7,6 +7,6 @@ class Service:
         self.rpc_client = client
         self.name = name
 
-    def rpc_request(self, method: str, params=None, skip_validation=False):
+    def rpc_request(self, method: str, params=None, skip_validation=False, enable_logging=True):
         full_method_name = f"{self.name}_{method}"
-        return self.rpc_client.rpc_valid_request(full_method_name, params, skip_validation=skip_validation)
+        return self.rpc_client.rpc_valid_request(full_method_name, params, skip_validation=skip_validation, enable_logging=enable_logging)

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -87,9 +87,9 @@ class WakuextService(Service):
         response = self.rpc_request("setLightClient", params)
         return response.json()
 
-    def peers(self):
+    def peers(self, enable_logging=True):
         params = []
-        response = self.rpc_request("peers", params)
+        response = self.rpc_request("peers", params, enable_logging=enable_logging)
         return response.json()
 
     def chat_messages(self, chat_id: str, cursor="", limit=10):

--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -96,7 +96,8 @@ class SignalClient:
     def wait_for_login(self):
         signal = self.wait_for_signal(SignalType.NODE_LOGIN.value)
         if "error" in signal["event"]:
-            assert not signal["event"]["error"]
+            error_details = signal["event"]["error"]
+            assert not error_details, f"Unexpected error during login: {error_details}"
         return signal
 
     def wait_for_logout(self):

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -17,7 +17,7 @@ from clients.services.wallet import WalletService
 from clients.services.wakuext import WakuextService
 from clients.services.accounts import AccountService
 from clients.services.settings import SettingsService
-from clients.signals import SignalClient, SignalType
+from clients.signals import SignalClient
 from clients.rpc import RpcClient
 from conftest import option
 from resources.constants import USE_IPV6, user_1, DEFAULT_DISPLAY_NAME, USER_DIR

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -30,13 +30,15 @@ class StatusBackend(RpcClient, SignalClient):
 
     container = None
 
-    def __init__(self, await_signals=[], privileged=False, ipv6=USE_IPV6):
+    def __init__(self, await_signals=[], privileged=False, ipv6=USE_IPV6, status_backend_url=""):
         self.ipv6 = True if ipv6 == "Yes" else False
         logging.info(f"Flag USE_IPV6 is: {self.ipv6}")
         self.docker_project_name = option.docker_project_name
         self.network_name = f"{self.docker_project_name}_default"
         if option.status_backend_url:
             url = option.status_backend_url
+        elif status_backend_url != "":
+            url = status_backend_url
         else:
             self.docker_client = docker.from_env()
             retries = 5

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -234,7 +234,6 @@ class StatusBackend(RpcClient, SignalClient):
         data = self._set_proxy_credentials(data)
         resp = self.api_valid_request(method, data)
         self.node_login_event = self.wait_for_login()
-        # self.node_login_event = self.find_signal_containing_pattern(SignalType.NODE_LOGIN.value, event_pattern=self.display_name)
         return resp
 
     def restore_account_and_login(

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -233,7 +233,8 @@ class StatusBackend(RpcClient, SignalClient):
 
         data = self._set_proxy_credentials(data)
         resp = self.api_valid_request(method, data)
-        self.node_login_event = self.find_signal_containing_pattern(SignalType.NODE_LOGIN.value, event_pattern=self.display_name)
+        self.node_login_event = self.wait_for_login()
+        # self.node_login_event = self.find_signal_containing_pattern(SignalType.NODE_LOGIN.value, event_pattern=self.display_name)
         return resp
 
     def restore_account_and_login(

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -393,3 +393,14 @@ class StatusBackend(RpcClient, SignalClient):
 
         except Exception as e:
             raise RuntimeError(f"Failed to change container IP: {e}")
+
+    def wait_for_online(self, timeout=10):
+        start_time = time.time()
+        while time.time() - start_time <= timeout:
+            response = self.wakuext_service.peers(enable_logging=False)
+            if len(response["result"].keys()) == 0:
+                time.sleep(0.5)
+                continue
+            logging.info(f"StatusBackend is online after {time.time() - start_time} seconds")
+            return
+        raise TimeoutError(f"StatusBackend was not online after {timeout} seconds")

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -33,7 +33,7 @@ class MessengerSteps(NetworkConditionsSteps):
 
     def initialize_backend(self, await_signals, privileged=True, ipv6=USE_IPV6, **kwargs):
         backend = StatusBackend(await_signals, privileged=privileged, ipv6=ipv6)
-        backend.init_status_backend()
+        backend.init_status_backend(data_dir)
         backend.create_account_and_login(**kwargs)
         backend.find_public_key()
         backend.wakuext_service.start_messenger()

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -33,7 +33,7 @@ class MessengerSteps(NetworkConditionsSteps):
 
     def initialize_backend(self, await_signals, privileged=True, ipv6=USE_IPV6, **kwargs):
         backend = StatusBackend(await_signals, privileged=privileged, ipv6=ipv6)
-        backend.init_status_backend(data_dir)
+        backend.init_status_backend()
         backend.create_account_and_login(**kwargs)
         backend.find_public_key()
         backend.wakuext_service.start_messenger()


### PR DESCRIPTION
Required for https://github.com/status-im/status-go/pull/6414/

Just some minor improvements and features:

- 5b4e41ea8 - wait_for_online,
- 44b2289a9 - use `wait_for_login` instead of explicit search for signal
- 2d2ade3a0 - properly pass `data_dir` arg in `initialize_backend`
- fe4c07e75 - ability to create `StatusBackend` with custom status-backend URL (useful for local debugging)
- 8b4342ad7 - print error details on login error
- 120fd1c48 - increment RPC request ID (instead of always using `13`)
- d0267829c - added `enable_logging` arg for `rpc_request`, to silent logging of some looped calls like `peers()`.
