### PR TITLE
fix(tag_version)_: stop bumping MAJOR 

### DIFF
--- a/_assets/scripts/tag_version.sh
+++ b/_assets/scripts/tag_version.sh
@@ -16,15 +16,8 @@ bump_version() {
     local is_breaking_change=$2
     IFS='v.' read -r _ major minor patch <<< "$tag"
 
-    # Bump the version based on the type of change
-    if [[ "$is_breaking_change" = true ]]; then
-        ((major++))
-        ((minor=0))
-        ((patch=0))
-    else
-        ((minor++))
-        ((patch=0))
-    fi
+    ((minor++))
+    ((patch=0))
 
     new_version="$major.$minor.$patch"
     echo "v$new_version"


### PR DESCRIPTION
Iterates https://github.com/status-im/status-go/issues/6049

# Description

> [!WARNING]
> This does not fix the original issue


But while I didn't get there to properly think about this, I thought that we could __stop increasing MAJOR__.

Not sure what will be the actual solution, but the MAJOR will probably remain fixed forever. 
Currently it is `10` and I believe **it's a good number to fix**.

Basically, we won't be able to determine difference between a breaking and non-breaking change.