### PR TITLE
fix(wallet)_: error parsing best route fixed

### DIFF
--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -513,7 +513,10 @@ func (h *HopBridgeProcessor) CalculateFees(params ProcessorInputParams) (*big.In
 	// Remove token fee from bonder fee as said here:
 	// https://docs.hop.exchange/v/developer-docs/api/api#get-v1-quote
 	// `bonderFee` - The suggested bonder fee for the amount in. The bonder fee also includes the cost of the destination transaction fee.
-	tokenFee := new(big.Int).Sub(bonderFee.AmountIn.Int, bonderFee.EstimatedRecieved.Int)
+	tokenFee := new(big.Int).SetUint64(0)
+	if (bonderFee.AmountIn.Int).Cmp(bonderFee.EstimatedRecieved.Int) > 0 {
+		tokenFee = new(big.Int).Sub(bonderFee.AmountIn.Int, bonderFee.EstimatedRecieved.Int)
+	}
 
 	return bonderFee.BonderFee.Int, tokenFee, nil
 }


### PR DESCRIPTION
In some cases when the provider wants to incentivise some token bridging the user may get more on the destination chain that the sent amount is.

An example of a quote where estimatedRecieved > amountIn:
```
{
    "amountIn": "1000000000000000000",
    "slippage": 0.5,
    "amountOutMin": "995289507266749095",
    "destinationAmountOutMin": null,
    "bonderFee": "0",
    "estimatedRecieved": "1000290962077134769",
    "deadline": 1742305300,
    "destinationDeadline": null
}
```

A short summary which serves as a squashed-commit message.

A description to understand introduced changes without reading the code.

Important changes:
- [x] Something worth noting for reviewers.

Closes #
