### PR TITLE
chore_: removing unnecessary store functions

### DIFF
--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -824,17 +824,10 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	}
 	response := &MessengerResponse{}
 
-	storenodes, err := m.AllMailservers()
+	response.Mailservers, err = m.AllMailservers()
 	if err != nil {
 		return nil, err
 	}
-
-	err = m.setupStorenodes(storenodes)
-	if err != nil {
-		return nil, err
-	}
-
-	response.Mailservers = storenodes
 
 	m.transport.SetStorenodeConfigProvider(m)
 

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -4,8 +4,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
 
-	"github.com/waku-org/go-waku/waku/v2/utils"
-
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/services/mailservers"
@@ -37,28 +35,6 @@ func (m *Messenger) AllMailservers() ([]mailservers.Mailserver, error) {
 	}
 
 	return allMailservers, nil
-}
-
-func (m *Messenger) setupStorenodes(storenodes []mailservers.Mailserver) error {
-	if m.transport.WakuVersion() != 2 {
-		return nil
-	}
-
-	for _, storenode := range storenodes {
-
-		peerInfo, err := storenode.PeerInfo()
-		if err != nil {
-			return err
-		}
-
-		for _, addr := range utils.EncapsulatePeerID(peerInfo.ID, peerInfo.Addrs...) {
-			_, err := m.transport.AddStorePeer(addr)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func (m *Messenger) getFleet() (string, error) {

--- a/protocol/messenger_peers.go
+++ b/protocol/messenger_peers.go
@@ -11,10 +11,6 @@ import (
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
 
-func (m *Messenger) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
-	return m.transport.AddStorePeer(address)
-}
-
 func (m *Messenger) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return m.transport.AddRelayPeer(address)
 }

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -518,10 +518,6 @@ func (t *Transport) ENR() (*enode.Node, error) {
 	return t.waku.ENR()
 }
 
-func (t *Transport) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
-	return t.waku.AddStorePeer(address)
-}
-
 func (t *Transport) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
 	return t.waku.AddRelayPeer(address)
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1447,14 +1447,6 @@ func (api *PublicAPI) StorePubsubTopicKey(topic string, privKey string) error {
 	return api.service.messenger.StorePubsubTopicKey(topic, p)
 }
 
-func (api *PublicAPI) AddStorePeer(address string) (peer.ID, error) {
-	maddr, err := multiaddr.NewMultiaddr(address)
-	if err != nil {
-		return "", err
-	}
-	return api.service.messenger.AddStorePeer(maddr)
-}
-
 func (api *PublicAPI) AddRelayPeer(address string) (peer.ID, error) {
 	maddr, err := multiaddr.NewMultiaddr(address)
 	if err != nil {

--- a/waku/types/waku.go
+++ b/waku/types/waku.go
@@ -137,8 +137,6 @@ type Waku interface {
 
 	RemovePubsubTopicKey(topic string) error
 
-	AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error)
-
 	AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error)
 
 	DialPeer(address multiaddr.Multiaddr) error

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -1923,14 +1923,6 @@ func (w *Waku) restartDiscV5(useOnlyDNSDiscCache bool) error {
 	return w.node.SetDiscV5Bootnodes(bootnodes)
 }
 
-func (w *Waku) AddStorePeer(address multiaddr.Multiaddr) (peer.ID, error) {
-	peerID, err := w.node.AddPeer(address, wps.Static, w.cfg.DefaultShardedPubsubTopics, store.StoreQueryID_v300)
-	if err != nil {
-		return "", err
-	}
-	return peerID, nil
-}
-
 func (w *Waku) timestamp() int64 {
 	return w.timesource.Now().UnixNano()
 }


### PR DESCRIPTION
`status-go` shouldn't add directly Store nodes to waku's peer store, as `status-go` has its own list of Store nodes saved, which are selected in its store node cycle. 

Therefore, removing the functions related to adding a store node to waku's peer store as they don't add anything in practice.

Important changes:
- [x] removing functions to add store nodes directly to waku's peer store

Issue: https://github.com/waku-org/nwaku/issues/3076
