### PR TITLE
chore_: improving timesource

### DIFF
--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -583,7 +583,10 @@ func (b *StatusNode) timeSource() *timesource.NTPTimeSource {
 		b.timeSourceSrvc = timesource.Default()
 		go func() {
 			defer common.LogOnPanic()
-			b.timeSourceSrvc.Start(context.Background())
+			err := b.timeSourceSrvc.Start(context.Background())
+			if err != nil {
+				panic("could not obtain timesource: " + err.Error())
+			}
 		}()
 	}
 	return b.timeSourceSrvc

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"database/sql"
 	"encoding/json"
@@ -582,7 +583,7 @@ func (b *StatusNode) timeSource() *timesource.NTPTimeSource {
 		b.timeSourceSrvc = timesource.Default()
 		go func() {
 			defer common.LogOnPanic()
-			b.timeSourceSrvc.Start()
+			b.timeSourceSrvc.Start(context.Background())
 		}()
 	}
 	return b.timeSourceSrvc

--- a/timesource/timesource.go
+++ b/timesource/timesource.go
@@ -283,7 +283,7 @@ func (s *NTPTimeSource) Stop() {
 func (s *NTPTimeSource) GetCurrentTime() time.Time {
 	err := s.Start(context.Background())
 	if err != nil {
-		panic("could not obtain timesource")
+		panic("could not obtain timesource: " + err.Error())
 	}
 	return s.Now()
 }
@@ -296,7 +296,7 @@ func GetCurrentTime() time.Time {
 	ts := Default()
 	err := ts.Start(context.Background())
 	if err != nil {
-		panic("could not obtain timesource")
+		panic("could not obtain timesource: " + err.Error())
 	}
 	return ts.Now()
 }

--- a/timesource/timesource.go
+++ b/timesource/timesource.go
@@ -2,6 +2,7 @@ package timesource
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"sort"
 	"sync"
@@ -148,9 +149,8 @@ type NTPTimeSource struct {
 	timeQuery         ntpQuery // for ease of testing
 	now               func() time.Time
 
-	quit chan struct{}
-
 	stateMu sync.Mutex
+	cancel  context.CancelFunc
 	started bool
 
 	timeDataMu    sync.RWMutex
@@ -215,7 +215,7 @@ func (s *NTPTimeSource) updateOffset() error {
 
 // runPeriodically runs periodically the given function based on NTPTimeSource
 // synchronization limits (fastNTPSyncPeriod / slowNTPSyncPeriod)
-func (s *NTPTimeSource) runPeriodically(fn func() error, starWithSlowSyncPeriod bool) {
+func (s *NTPTimeSource) runPeriodically(ctx context.Context, fn func() error, starWithSlowSyncPeriod bool) {
 	if s.started {
 		return
 	}
@@ -224,7 +224,6 @@ func (s *NTPTimeSource) runPeriodically(fn func() error, starWithSlowSyncPeriod 
 	if starWithSlowSyncPeriod {
 		period = s.slowNTPSyncPeriod
 	}
-	s.quit = make(chan struct{})
 	go func() {
 		defer common.LogOnPanic()
 		for {
@@ -236,7 +235,7 @@ func (s *NTPTimeSource) runPeriodically(fn func() error, starWithSlowSyncPeriod 
 					period = s.fastNTPSyncPeriod
 				}
 
-			case <-s.quit:
+			case <-ctx.Done():
 				return
 			}
 		}
@@ -244,16 +243,17 @@ func (s *NTPTimeSource) runPeriodically(fn func() error, starWithSlowSyncPeriod 
 }
 
 // Start initializes the local offset and starts a goroutine that periodically updates the local offset.
-func (s *NTPTimeSource) Start() {
+func (s *NTPTimeSource) Start(ctx context.Context) error {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 	if s.started {
-		return
+		return nil
 	}
 
 	// Initialize time tracking fields immediately
 	currentTime := s.now()
 	s.lastMonotonic = currentTime
+	ctx, cancel := context.WithCancel(ctx)
 
 	// Attempt to update the offset synchronously so that user can have reliable messages right away
 	err := s.updateOffset()
@@ -263,23 +263,28 @@ func (s *NTPTimeSource) Start() {
 		logutils.ZapLogger().Error("failed to update offset", zap.Error(err))
 	}
 
-	s.runPeriodically(s.updateOffset, err == nil)
+	s.runPeriodically(ctx, s.updateOffset, err == nil)
 
 	s.started = true
-}
+	s.cancel = cancel
 
-// Stop goroutine that updates time source.
-func (s *NTPTimeSource) Stop() error {
-	if s.quit == nil {
-		return nil
-	}
-	close(s.quit)
-	s.started = false
 	return nil
 }
 
+// Stop goroutine that updates time source.
+func (s *NTPTimeSource) Stop() {
+	if s.cancel == nil {
+		return
+	}
+	s.cancel()
+	s.started = false
+}
+
 func (s *NTPTimeSource) GetCurrentTime() time.Time {
-	s.Start()
+	err := s.Start(context.Background())
+	if err != nil {
+		panic("could not obtain timesource")
+	}
 	return s.Now()
 }
 
@@ -289,7 +294,10 @@ func (s *NTPTimeSource) GetCurrentTimeInMillis() uint64 {
 
 func GetCurrentTime() time.Time {
 	ts := Default()
-	ts.Start()
+	err := ts.Start(context.Background())
+	if err != nil {
+		panic("could not obtain timesource")
+	}
 	return ts.Now()
 }
 

--- a/timesource/timesource_test.go
+++ b/timesource/timesource_test.go
@@ -1,6 +1,7 @@
 package timesource
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -214,7 +215,7 @@ func TestRunningPeriodically(t *testing.T) {
 		// on NTPTimeSource specified periods (fastNTPSyncPeriod & slowNTPSyncPeriod)
 		wg := sync.WaitGroup{}
 		wg.Add(1)
-		source.runPeriodically(func() error {
+		source.runPeriodically(context.TODO(), func() error {
 			mu.Lock()
 			periods = append(periods, time.Since(lastCall))
 			mu.Unlock()
@@ -278,14 +279,12 @@ func TestGetCurrentTimeInMillis(t *testing.T) {
 	// test repeat invoke GetCurrentTimeInMillis
 	n = ts.GetCurrentTimeInMillis()
 	require.Equal(t, expectedTime, n)
-	e := ts.Stop()
-	require.NoError(t, e)
+	ts.Stop()
 
 	// test invoke after stop
 	n = ts.GetCurrentTimeInMillis()
 	require.Equal(t, expectedTime, n)
-	e = ts.Stop()
-	require.NoError(t, e)
+	ts.Stop()
 }
 
 func TestGetCurrentTimeOffline(t *testing.T) {

--- a/timesource/timesource_test.go
+++ b/timesource/timesource_test.go
@@ -328,7 +328,6 @@ func TestSystemTimeChangeDetection(t *testing.T) {
 		fastNTPSyncPeriod: 1 * time.Hour,
 		slowNTPSyncPeriod: 1 * time.Hour,
 		now:               mockTimeNow,
-		quit:              make(chan struct{}),
 	}
 
 	// Set up the timeQuery function to track calls
@@ -446,18 +445,17 @@ func TestTimeTrackingInitialization(t *testing.T) {
 		slowNTPSyncPeriod: 1 * time.Hour,
 		timeQuery:         mockQuery,
 		now:               mockTimeNow,
-		quit:              make(chan struct{}),
 	}
 
 	// Verify that time tracking fields are initially zero
 	assert.True(t, ts.lastMonotonic.IsZero(), "lastMonotonic should be zero before Start()")
 
 	// Start the time source
-	ts.Start()
+	err := ts.Start(context.TODO())
+	assert.NoError(t, err, "Start should not return an error")
 
 	defer func() {
-		err := ts.Stop()
-		assert.NoError(t, err, "Stop should not return an error")
+		ts.Stop()
 	}()
 
 	// Verify that time tracking fields are initialized


### PR DESCRIPTION
Improving `timesource` to use a more modern approach with `ctx` instead of a `quit` channel, so the `timesource` can be used by the message verifier instead of go-waku's one

Important changes:
- [x] small improvements of `timesource`

Issue: https://github.com/waku-org/nwaku/issues/3076