### PR TITLE
chore(ci)_: use xcode 16.2

### DIFF
--- a/_assets/ci/Jenkinsfile.ios
+++ b/_assets/ci/Jenkinsfile.ios
@@ -2,7 +2,7 @@
 library 'status-jenkins-lib@v1.9.20'
 
 pipeline {
-  agent { label 'macos && aarch64 && xcode-15.1 && nix-2.24' }
+  agent { label 'macos && aarch64 && xcode-16.2 && nix-2.24' }
 
   parameters {
     string(


### PR DESCRIPTION
## Summary

I've upgraded CI hosts to Xcode 16.

![Screenshot 2025-03-15 at 6 39 06 PM](https://github.com/user-attachments/assets/27eaebe7-5a70-4fd9-af77-9a8b7dc2b1b0)
