### PR TITLE
chore_: updating go-waku

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20250103101727-4ef460cb951a
+	github.com/waku-org/go-waku v0.8.1-0.20250313161544-e68fcdb554f9
 	github.com/waku-org/waku-go-bindings v0.0.0-20250313132258-6f95d51df46c
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -2150,8 +2150,8 @@ github.com/waku-org/go-libp2p-pubsub v0.12.0-gowaku.0.20240823143342-b0f2429ca27
 github.com/waku-org/go-libp2p-pubsub v0.12.0-gowaku.0.20240823143342-b0f2429ca27f/go.mod h1:Oi0zw9aw8/Y5GC99zt+Ef2gYAl+0nZlwdJonDyOz/sE=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20250103101727-4ef460cb951a h1:20W3RwuJvLWEtXxXZ7RWwoVfTQJtJrjde3qQETP9QMs=
-github.com/waku-org/go-waku v0.8.1-0.20250103101727-4ef460cb951a/go.mod h1:zYhLgqwBE3sGP2vP+aNiM5moOKlf/uSoIv36puAj9WI=
+github.com/waku-org/go-waku v0.8.1-0.20250313161544-e68fcdb554f9 h1:gHN9uJYzJuRgKwFBOrLbsisE97e+0P7Qbx32qGFdRu4=
+github.com/waku-org/go-waku v0.8.1-0.20250313161544-e68fcdb554f9/go.mod h1:zYhLgqwBE3sGP2vP+aNiM5moOKlf/uSoIv36puAj9WI=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/protocol/common/message_sender_test.go
+++ b/protocol/common/message_sender_test.go
@@ -77,7 +77,7 @@ func (s *MessageSenderSuite) SetupTest() {
 		s.logger,
 		database,
 		nil,
-		func([]byte, peer.ID, error) {},
+		func([]byte, peer.AddrInfo, error) {},
 		nil,
 	)
 	s.Require().NoError(err)

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -92,7 +92,7 @@ func newTestWakuNode(logger *zap.Logger) (wakutypes.Waku, error) {
 		logger,
 		nil,
 		nil,
-		func([]byte, peer.ID, error) {},
+		func([]byte, peer.AddrInfo, error) {},
 		nil,
 	)
 }

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -5173,9 +5173,9 @@ func (m *Messenger) startRequestMissingCommunityChannelsHRKeysLoop() {
 
 // getCommunityStorenode returns the active mailserver if a communityID is present then it'll return the mailserver
 // for that community if it has a mailserver setup otherwise it'll return the global mailserver
-func (m *Messenger) getCommunityStorenode(communityID ...string) peer.ID {
+func (m *Messenger) getCommunityStorenode(communityID ...string) peer.AddrInfo {
 	if m.transport.WakuVersion() != 2 {
-		return ""
+		return peer.AddrInfo{}
 	}
 
 	if len(communityID) == 0 || communityID[0] == "" {
@@ -5191,11 +5191,11 @@ func (m *Messenger) getCommunityStorenode(communityID ...string) peer.ID {
 		return m.transport.GetActiveStorenode()
 	}
 
-	peerID, err := ms.PeerID()
+	peerInfo, err := ms.PeerInfo()
 	if err != nil {
 		m.logger.Error("getting storenode for community, using global", zap.String("communityID", gocommon.TruncateWithDot(communityID[0])), zap.Error(err))
 		return m.transport.GetActiveStorenode()
 	}
 
-	return peerID
+	return peerInfo
 }

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -45,7 +45,7 @@ func (m *Messenger) shouldSync() (bool, error) {
 	}
 
 	// TODO (pablo) support community store node as well
-	if m.transport.GetActiveStorenode() == "" || !m.Online() {
+	if m.transport.GetActiveStorenode().ID() == "" || !m.Online() {
 		return false, nil
 	}
 
@@ -71,9 +71,9 @@ func (m *Messenger) scheduleSyncChat(chat *Chat) (bool, error) {
 
 	go func() {
 		defer gocommon.LogOnPanic()
-		peerID := m.getCommunityStorenode(chat.CommunityID)
+		peerInfo := m.getCommunityStorenode(chat.CommunityID)
 		_, err = m.performStorenodeTask(func() (*MessengerResponse, error) {
-			response, err := m.syncChatWithFilters(peerID, chat.ID)
+			response, err := m.syncChatWithFilters(peerInfo, chat.ID)
 
 			if err != nil {
 				m.logger.Error("failed to sync chat", zap.Error(err))
@@ -84,7 +84,7 @@ func (m *Messenger) scheduleSyncChat(chat *Chat) (bool, error) {
 				m.config.messengerSignalsHandler.MessengerResponse(response)
 			}
 			return response, nil
-		}, history.WithPeerID(peerID))
+		}, history.WithPeerID(peerInfo.ID))
 		if err != nil {
 			m.logger.Error("failed to perform mailserver request", zap.Error(err))
 		}
@@ -135,9 +135,9 @@ func (m *Messenger) scheduleSyncFilters(filters []*transport.Filter) (bool, erro
 		// split filters by community store node so we can request the filters to the correct mailserver
 		filtersByMs := m.SplitFiltersByStoreNode(filters)
 		for communityID, filtersForMs := range filtersByMs {
-			peerID := m.getCommunityStorenode(communityID)
+			peerInfo := m.getCommunityStorenode(communityID)
 			_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
-				response, err := m.syncFilters(peerID, filtersForMs)
+				response, err := m.syncFilters(peerInfo, filtersForMs)
 
 				if err != nil {
 					m.logger.Error("failed to sync filter", zap.Error(err))
@@ -148,7 +148,7 @@ func (m *Messenger) scheduleSyncFilters(filters []*transport.Filter) (bool, erro
 					m.config.messengerSignalsHandler.MessengerResponse(response)
 				}
 				return response, nil
-			}, history.WithPeerID(peerID))
+			}, history.WithPeerID(peerInfo.ID))
 			if err != nil {
 				m.logger.Error("failed to perform mailserver request", zap.Error(err))
 			}
@@ -216,13 +216,13 @@ func (m *Messenger) topicsForChat(chatID string) (string, []wakutypes.TopicType,
 	return filters[0].PubsubTopic, contentTopics, nil
 }
 
-func (m *Messenger) syncChatWithFilters(peerID peer.ID, chatID string) (*MessengerResponse, error) {
+func (m *Messenger) syncChatWithFilters(peerInfo peer.AddrInfo, chatID string) (*MessengerResponse, error) {
 	filters, err := m.filtersForChat(chatID)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.syncFilters(peerID, filters)
+	return m.syncFilters(peerInfo, filters)
 }
 
 func (m *Messenger) syncBackup() error {
@@ -343,11 +343,11 @@ func (m *Messenger) RequestAllHistoricMessages(forceFetchingBackup, withRetries 
 
 	filtersByMs := m.SplitFiltersByStoreNode(filters)
 	for communityID, filtersForMs := range filtersByMs {
-		peerID := m.getCommunityStorenode(communityID)
+		peerInfo := m.getCommunityStorenode(communityID)
 		if withRetries {
 			response, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
-				return m.syncFilters(peerID, filtersForMs)
-			}, history.WithPeerID(peerID))
+				return m.syncFilters(peerInfo, filtersForMs)
+			}, history.WithPeerID(peerInfo.ID))
 			if err != nil {
 				return nil, err
 			}
@@ -357,7 +357,7 @@ func (m *Messenger) RequestAllHistoricMessages(forceFetchingBackup, withRetries 
 			}
 			continue
 		}
-		response, err := m.syncFilters(peerID, filtersForMs)
+		response, err := m.syncFilters(peerInfo, filtersForMs)
 		if err != nil {
 			return nil, err
 		}
@@ -398,12 +398,12 @@ func (m *Messenger) checkForMissingMessagesLoop() {
 		filters := m.transport.Filters()
 		filtersByMs := m.SplitFiltersByStoreNode(filters)
 		for communityID, filtersForMs := range filtersByMs {
-			peerID := m.getCommunityStorenode(communityID)
-			if peerID == "" {
+			peerInfo := m.getCommunityStorenode(communityID)
+			if peerInfo.ID == "" {
 				continue
 			}
 
-			m.transport.SetCriteriaForMissingMessageVerification(peerID, filtersForMs)
+			m.transport.SetCriteriaForMissingMessageVerification(peerInfo, filtersForMs)
 		}
 	}
 }
@@ -412,7 +412,7 @@ func getPrioritizedBatches() []int {
 	return []int{1, 5, 10}
 }
 
-func (m *Messenger) syncFiltersFrom(peerID peer.ID, filters []*transport.Filter, lastRequest uint32) (*MessengerResponse, error) {
+func (m *Messenger) syncFiltersFrom(peerInfo peer.AddrInfo, filters []*transport.Filter, lastRequest uint32) (*MessengerResponse, error) {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return nil, err
@@ -551,7 +551,7 @@ func (m *Messenger) syncFiltersFrom(peerID peer.ID, filters []*transport.Filter,
 		batchKeys := maps.Keys(batches[pubsubTopic])
 		sort.Ints(batchKeys)
 		for _, k := range batchKeys {
-			err := m.processMailserverBatch(peerID, batches[pubsubTopic][k])
+			err := m.processMailserverBatch(peerInfo, batches[pubsubTopic][k])
 			if err != nil {
 				m.logger.Error("error syncing topics", zap.Error(err))
 				return nil, err
@@ -610,8 +610,8 @@ func (m *Messenger) syncFiltersFrom(peerID peer.ID, filters []*transport.Filter,
 	return response, nil
 }
 
-func (m *Messenger) syncFilters(peerID peer.ID, filters []*transport.Filter) (*MessengerResponse, error) {
-	return m.syncFiltersFrom(peerID, filters, 0)
+func (m *Messenger) syncFilters(peerInfo peer.AddrInfo, filters []*transport.Filter) (*MessengerResponse, error) {
+	return m.syncFiltersFrom(peerInfo, filters, 0)
 }
 
 func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Message, error) {
@@ -665,7 +665,7 @@ func (m *Messenger) DisableStoreNodes() {
 	m.featureFlags.StoreNodesDisabled = true
 }
 
-func (m *Messenger) processMailserverBatch(peerID peer.ID, batch wakutypes.MailserverBatch) error {
+func (m *Messenger) processMailserverBatch(peerInfo peer.AddrInfo, batch wakutypes.MailserverBatch) error {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return err
@@ -674,10 +674,10 @@ func (m *Messenger) processMailserverBatch(peerID peer.ID, batch wakutypes.Mails
 		return nil
 	}
 
-	return m.transport.ProcessMailserverBatch(m.ctx, batch, peerID, defaultStoreNodeRequestPageSize, nil, false)
+	return m.transport.ProcessMailserverBatch(m.ctx, batch, peerInfo, defaultStoreNodeRequestPageSize, nil, false)
 }
 
-func (m *Messenger) processMailserverBatchWithOptions(peerID peer.ID, batch wakutypes.MailserverBatch, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {
+func (m *Messenger) processMailserverBatchWithOptions(peerInfo peer.AddrInfo, batch wakutypes.MailserverBatch, pageLimit uint64, shouldProcessNextPage func(int) (bool, uint64), processEnvelopes bool) error {
 	canSync, err := m.canSyncWithStoreNodes()
 	if err != nil {
 		return err
@@ -686,7 +686,7 @@ func (m *Messenger) processMailserverBatchWithOptions(peerID peer.ID, batch waku
 		return nil
 	}
 
-	return m.transport.ProcessMailserverBatch(m.ctx, batch, peerID, pageLimit, shouldProcessNextPage, processEnvelopes)
+	return m.transport.ProcessMailserverBatch(m.ctx, batch, peerInfo, pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
 func (m *Messenger) SyncChatFromSyncedFrom(chatID string) (uint32, error) {
@@ -695,7 +695,7 @@ func (m *Messenger) SyncChatFromSyncedFrom(chatID string) (uint32, error) {
 		return 0, ErrChatNotFound
 	}
 
-	peerID := m.getCommunityStorenode(chat.CommunityID)
+	peerInfo := m.getCommunityStorenode(chat.CommunityID)
 	var from uint32
 	_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
 		canSync, err := m.canSyncWithStoreNodes()
@@ -727,7 +727,7 @@ func (m *Messenger) SyncChatFromSyncedFrom(chatID string) (uint32, error) {
 			m.config.messengerSignalsHandler.HistoryRequestStarted(1)
 		}
 
-		err = m.processMailserverBatch(peerID, batch)
+		err = m.processMailserverBatch(peerInfo, batch)
 		if err != nil {
 			return nil, err
 		}
@@ -744,7 +744,7 @@ func (m *Messenger) SyncChatFromSyncedFrom(chatID string) (uint32, error) {
 		err = m.persistence.SetSyncTimestamps(uint32(batch.From.Unix()), chat.SyncedTo, chat.ID)
 		from = uint32(batch.From.Unix())
 		return nil, err
-	}, history.WithPeerID(peerID))
+	}, history.WithPeerID(peerInfo.ID))
 	if err != nil {
 		return 0, err
 	}
@@ -863,7 +863,7 @@ func (m *Messenger) fetchMessages(chatID string, duration time.Duration) (uint32
 		return 0, ErrChatNotFound
 	}
 
-	peerID := m.getCommunityStorenode(chat.CommunityID)
+	peerInfo := m.getCommunityStorenode(chat.CommunityID)
 	_, err := m.performStorenodeTask(func() (*MessengerResponse, error) {
 		canSync, err := m.canSyncWithStoreNodes()
 		if err != nil {
@@ -873,7 +873,7 @@ func (m *Messenger) fetchMessages(chatID string, duration time.Duration) (uint32
 			return nil, nil
 		}
 
-		m.logger.Debug("fetching messages", zap.String("chatID", chatID), zap.Stringer("peerID", peerID))
+		m.logger.Debug("fetching messages", zap.String("chatID", chatID), zap.Stringer("peerID", peerInfo.ID))
 		pubsubTopic, topics, err := m.topicsForChat(chatID)
 		if err != nil {
 			return nil, nil
@@ -890,7 +890,7 @@ func (m *Messenger) fetchMessages(chatID string, duration time.Duration) (uint32
 			m.config.messengerSignalsHandler.HistoryRequestStarted(1)
 		}
 
-		err = m.processMailserverBatch(peerID, batch)
+		err = m.processMailserverBatch(peerInfo, batch)
 		if err != nil {
 			return nil, err
 		}
@@ -907,7 +907,7 @@ func (m *Messenger) fetchMessages(chatID string, duration time.Duration) (uint32
 		err = m.persistence.SetSyncTimestamps(uint32(batch.From.Unix()), chat.SyncedTo, chat.ID)
 		from = batch.From
 		return nil, err
-	}, history.WithPeerID(peerID))
+	}, history.WithPeerID(peerInfo.ID))
 	if err != nil {
 		return 0, err
 	}

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -45,7 +45,7 @@ func (m *Messenger) shouldSync() (bool, error) {
 	}
 
 	// TODO (pablo) support community store node as well
-	if m.transport.GetActiveStorenode().ID() == "" || !m.Online() {
+	if m.transport.GetActiveStorenode().ID == "" || !m.Online() {
 		return false, nil
 	}
 

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -564,7 +564,7 @@ func (r *storeNodeRequest) routine() {
 		}
 
 		return nil, r.manager.messenger.processMailserverBatchWithOptions(storeNode, batch, r.config.InitialPageSize, r.shouldFetchNextPage, true)
-	}, history.WithPeerID(storeNode))
+	}, history.WithPeerID(storeNode.ID))
 
 	r.result.err = err
 }

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -191,7 +191,9 @@ func (s *MessengerStoreNodeRequestSuite) createOwner() {
 	WaitForPeersConnected(&s.Suite, s.ownerWaku, func() peer.IDSlice {
 		err := s.owner.DialPeer(s.storeNodeAddress)
 		s.Require().NoError(err)
-		return peer.IDSlice{s.wakuStoreNode.PeerID()}
+		peerID, err := s.wakuStoreNode.PeerID()
+		s.Require().NoError(err)
+		return peer.IDSlice{peerID}
 	})
 }
 
@@ -1236,7 +1238,8 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchingCommunityWithOwnerToken() {
 
 func (s *MessengerStoreNodeRequestSuite) TestFetchingHistoryWhenOnline() {
 	storeAddress := s.storeNodeAddress
-	storePeerID := s.wakuStoreNode.PeerID()
+	storePeerID, err := s.wakuStoreNode.PeerID()
+	s.Require().NoError(err)
 
 	// Create messengers
 	s.createOwner()

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -191,7 +191,7 @@ func (s *MessengerStoreNodeRequestSuite) createOwner() {
 	WaitForPeersConnected(&s.Suite, s.ownerWaku, func() peer.IDSlice {
 		err := s.owner.DialPeer(s.storeNodeAddress)
 		s.Require().NoError(err)
-		peerID, err := s.wakuStoreNode.PeerID()
+		peerID := s.wakuStoreNode.PeerID()
 		s.Require().NoError(err)
 		return peer.IDSlice{peerID}
 	})
@@ -1238,8 +1238,7 @@ func (s *MessengerStoreNodeRequestSuite) TestFetchingCommunityWithOwnerToken() {
 
 func (s *MessengerStoreNodeRequestSuite) TestFetchingHistoryWhenOnline() {
 	storeAddress := s.storeNodeAddress
-	storePeerID, err := s.wakuStoreNode.PeerID()
-	s.Require().NoError(err)
+	storePeerID := s.wakuStoreNode.PeerID()
 
 	// Create messengers
 	s.createOwner()

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -192,7 +192,6 @@ func (s *MessengerStoreNodeRequestSuite) createOwner() {
 		err := s.owner.DialPeer(s.storeNodeAddress)
 		s.Require().NoError(err)
 		peerID := s.wakuStoreNode.PeerID()
-		s.Require().NoError(err)
 		return peer.IDSlice{peerID}
 	})
 }

--- a/protocol/transport/filters_manager_test.go
+++ b/protocol/transport/filters_manager_test.go
@@ -98,7 +98,7 @@ func (s *FiltersManagerSuite) SetupTest() {
 		s.logger,
 		nil,
 		nil,
-		func([]byte, peer.ID, error) {},
+		func([]byte, peer.AddrInfo, error) {},
 		nil,
 	)
 	s.Require().NoError(err)

--- a/protocol/transport/transport.go
+++ b/protocol/transport/transport.go
@@ -596,7 +596,7 @@ func (t *Transport) ConfirmMessageDelivered(messageID string) {
 	t.waku.ConfirmMessageDelivered(commHashes)
 }
 
-func (t *Transport) SetCriteriaForMissingMessageVerification(peerID peer.ID, filters []*Filter) {
+func (t *Transport) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, filters []*Filter) {
 	if t.waku.Version() != 2 {
 		return
 	}
@@ -617,11 +617,11 @@ func (t *Transport) SetCriteriaForMissingMessageVerification(peerID peer.ID, fil
 
 	for pubsubTopic, contentTopics := range topicMap {
 		ctList := maps.Keys(contentTopics)
-		err := t.waku.SetCriteriaForMissingMessageVerification(peerID, pubsubTopic, ctList)
+		err := t.waku.SetCriteriaForMissingMessageVerification(peerInfo, pubsubTopic, ctList)
 		if err != nil {
 			t.logger.Error("could not check for missing messages",
 				zap.Error(err),
-				zap.Stringer("peerID", peerID),
+				zap.Stringer("peerID", peerInfo.ID),
 				zap.String("pubsubTopic", pubsubTopic),
 				zap.Stringers("contentTopics", ctList))
 			return
@@ -629,7 +629,7 @@ func (t *Transport) SetCriteriaForMissingMessageVerification(peerID peer.ID, fil
 	}
 }
 
-func (t *Transport) GetActiveStorenode() peer.ID {
+func (t *Transport) GetActiveStorenode() peer.AddrInfo {
 	return t.waku.GetActiveStorenode()
 }
 
@@ -664,12 +664,12 @@ func (t *Transport) PerformStorenodeTask(fn func() error, opts ...history.Storen
 func (t *Transport) ProcessMailserverBatch(
 	ctx context.Context,
 	batch wakutypes.MailserverBatch,
-	storenodeID peer.ID,
+	storenode peer.AddrInfo,
 	pageLimit uint64,
 	shouldProcessNextPage func(int) (bool, uint64),
 	processEnvelopes bool,
 ) error {
-	return t.waku.ProcessMailserverBatch(ctx, batch, storenodeID, pageLimit, shouldProcessNextPage, processEnvelopes)
+	return t.waku.ProcessMailserverBatch(ctx, batch, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
 }
 
 func (t *Transport) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {

--- a/signal/events_shhext.go
+++ b/signal/events_shhext.go
@@ -155,8 +155,8 @@ func SendHistoricMessagesRequestStarted(numBatches int) {
 	send(EventHistoryRequestStarted, HistoryMessagesSignal{NumBatches: numBatches})
 }
 
-func SendHistoricMessagesRequestFailed(requestID []byte, peerID peer.ID, err error) {
-	send(EventHistoryRequestFailed, HistoryMessagesSignal{RequestID: hex.EncodeToString(requestID), PeerID: peerID.String(), ErrorMsg: err.Error()})
+func SendHistoricMessagesRequestFailed(requestID []byte, peerInfo peer.AddrInfo, err error) {
+	send(EventHistoryRequestFailed, HistoryMessagesSignal{RequestID: hex.EncodeToString(requestID), PeerID: peerInfo.ID.String(), ErrorMsg: err.Error()})
 }
 
 func SendHistoricMessagesRequestCompleted() {

--- a/vendor/github.com/waku-org/go-waku/waku/v2/api/common/storenode_requestor.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/api/common/storenode_requestor.go
@@ -8,5 +8,5 @@ import (
 )
 
 type StorenodeRequestor interface {
-	Query(ctx context.Context, peerID peer.ID, query *pb.StoreQueryRequest) (StoreRequestResult, error)
+	Query(ctx context.Context, peerInfo peer.AddrInfo, query *pb.StoreQueryRequest) (StoreRequestResult, error)
 }

--- a/vendor/github.com/waku-org/go-waku/waku/v2/api/filter/filter_manager.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/api/filter/filter_manager.go
@@ -111,8 +111,6 @@ func (mgr *FilterManager) startFilterSubLoop() {
 				mgr.incompleteFilterBatch = make(map[string]filterConfig)
 				mgr.Unlock()
 			}
-			subs := mgr.node.Subscriptions()
-			mgr.logger.Debug("filter stats", zap.Int("agg filters count", len(mgr.filterSubscriptions)), zap.Int("filter subs count", len(subs)))
 		}
 	}
 }

--- a/vendor/github.com/waku-org/go-waku/waku/v2/api/missing/criteria_interest.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/api/missing/criteria_interest.go
@@ -10,7 +10,7 @@ import (
 )
 
 type criteriaInterest struct {
-	peerID        peer.ID
+	peerInfo      peer.AddrInfo
 	contentFilter protocol.ContentFilter
 	lastChecked   time.Time
 
@@ -19,7 +19,7 @@ type criteriaInterest struct {
 }
 
 func (c criteriaInterest) equals(other criteriaInterest) bool {
-	if c.peerID != other.peerID {
+	if c.peerInfo.ID != other.peerInfo.ID {
 		return false
 	}
 

--- a/vendor/github.com/waku-org/go-waku/waku/v2/api/missing/default_requestor.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/api/missing/default_requestor.go
@@ -20,10 +20,10 @@ type defaultStorenodeRequestor struct {
 	store *store.WakuStore
 }
 
-func (d *defaultStorenodeRequestor) GetMessagesByHash(ctx context.Context, peerID peer.ID, pageSize uint64, messageHashes []pb.MessageHash) (common.StoreRequestResult, error) {
-	return d.store.QueryByHash(ctx, messageHashes, store.WithPeer(peerID), store.WithPaging(false, pageSize))
+func (d *defaultStorenodeRequestor) GetMessagesByHash(ctx context.Context, peerInfo peer.AddrInfo, pageSize uint64, messageHashes []pb.MessageHash) (common.StoreRequestResult, error) {
+	return d.store.QueryByHash(ctx, messageHashes, store.WithPeerAddr(peerInfo.Addrs...), store.WithPaging(false, pageSize))
 }
 
-func (d *defaultStorenodeRequestor) Query(ctx context.Context, peerID peer.ID, storeQueryRequest *storepb.StoreQueryRequest) (common.StoreRequestResult, error) {
-	return d.store.RequestRaw(ctx, peerID, storeQueryRequest)
+func (d *defaultStorenodeRequestor) Query(ctx context.Context, peerInfo peer.AddrInfo, storeQueryRequest *storepb.StoreQueryRequest) (common.StoreRequestResult, error) {
+	return d.store.RequestRaw(ctx, peerInfo, storeQueryRequest)
 }

--- a/vendor/github.com/waku-org/go-waku/waku/v2/api/publish/default_verifier.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/api/publish/default_verifier.go
@@ -18,10 +18,10 @@ type defaultStorenodeMessageVerifier struct {
 	store *store.WakuStore
 }
 
-func (d *defaultStorenodeMessageVerifier) MessageHashesExist(ctx context.Context, requestID []byte, peerID peer.ID, pageSize uint64, messageHashes []pb.MessageHash) ([]pb.MessageHash, error) {
+func (d *defaultStorenodeMessageVerifier) MessageHashesExist(ctx context.Context, requestID []byte, peerID peer.AddrInfo, pageSize uint64, messageHashes []pb.MessageHash) ([]pb.MessageHash, error) {
 	var opts []store.RequestOption
 	opts = append(opts, store.WithRequestID(requestID))
-	opts = append(opts, store.WithPeer(peerID))
+	opts = append(opts, store.WithPeerAddr(peerID.Addrs...))
 	opts = append(opts, store.WithPaging(false, pageSize))
 	opts = append(opts, store.IncludeData(false))
 

--- a/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/node/wakunode2.go
@@ -703,8 +703,8 @@ func (w *WakuNode) startStore(ctx context.Context, sub *relay.Subscription) erro
 
 // AddPeer is used to add a peer and the protocols it support to the node peerstore
 // TODO: Need to update this for autosharding, to only take contentTopics and optional pubSubTopics or provide an alternate API only for contentTopics.
-func (w *WakuNode) AddPeer(address ma.Multiaddr, origin wps.Origin, pubSubTopics []string, protocols ...protocol.ID) (peer.ID, error) {
-	pData, err := w.peermanager.AddPeer(address, origin, pubSubTopics, protocols...)
+func (w *WakuNode) AddPeer(addresses []ma.Multiaddr, origin wps.Origin, pubSubTopics []string, protocols ...protocol.ID) (peer.ID, error) {
+	pData, err := w.peermanager.AddPeer(addresses, origin, pubSubTopics, protocols...)
 	if err != nil {
 		return "", err
 	}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/client.go
@@ -17,6 +17,7 @@ import (
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	"github.com/libp2p/go-msgio/pbio"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/waku-org/go-waku/logging"
 	"github.com/waku-org/go-waku/waku/v2/onlinechecker"
@@ -348,7 +349,7 @@ func (wf *WakuFilterLightNode) handleFilterSubscribeOptions(ctx context.Context,
 
 	//Add Peer to peerstore.
 	if params.pm != nil && params.peerAddr != nil {
-		pData, err := wf.pm.AddPeer(params.peerAddr, peerstore.Static, maps.Keys(pubSubTopicMap), FilterSubscribeID_v20beta1)
+		pData, err := wf.pm.AddPeer([]multiaddr.Multiaddr{params.peerAddr}, peerstore.Static, maps.Keys(pubSubTopicMap), FilterSubscribeID_v20beta1)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/filter_health_check.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/filter_health_check.go
@@ -25,7 +25,7 @@ func (wf *WakuFilterLightNode) PingPeer(peer peer.ID) {
 	defer cancel()
 	err := wf.Ping(ctxWithTimeout, peer)
 	if err != nil && wf.onlineChecker.IsOnline() {
-		wf.log.Warn("Filter ping failed towards peer", zap.Stringer("peer", peer), zap.Error(err))
+		wf.log.Info("Filter ping failed towards peer", zap.Stringer("peer", peer), zap.Error(err))
 		//quickly retry ping again before marking subscription as failure
 		//Note that PingTimeout is a fraction of PingInterval so this shouldn't cause parallel pings being sent.
 		ctxWithTimeout, cancel := context.WithTimeout(wf.CommonService.Context(), PingTimeout)

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/test_utils.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/filter/test_utils.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/suite"
 	"github.com/waku-org/go-waku/tests"
@@ -102,7 +103,7 @@ func (s *FilterTestSuite) TearDownTest() {
 
 func (s *FilterTestSuite) ConnectToFullNode(h1 *WakuFilterLightNode, h2 *WakuFilterFullNode) {
 	mAddr := tests.GetAddr(h2.h)
-	_, err := h1.pm.AddPeer(mAddr, wps.Static, []string{s.TestTopic}, FilterSubscribeID_v20beta1)
+	_, err := h1.pm.AddPeer([]multiaddr.Multiaddr{mAddr}, wps.Static, []string{s.TestTopic}, FilterSubscribeID_v20beta1)
 	s.Log.Info("add peer", zap.Stringer("mAddr", mAddr))
 	s.Require().NoError(err)
 }

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/legacy_store/waku_store_client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/legacy_store/waku_store_client.go
@@ -310,7 +310,7 @@ func (store *WakuStore) Query(ctx context.Context, query Query, opts ...HistoryR
 
 		//Add Peer to peerstore.
 		if store.pm != nil && params.peerAddr != nil {
-			pData, err := store.pm.AddPeer(params.peerAddr, peerstore.Static, pubsubTopics, StoreID_v20beta4)
+			pData, err := store.pm.AddPeer([]multiaddr.Multiaddr{params.peerAddr}, peerstore.Static, pubsubTopics, StoreID_v20beta4)
 			if err != nil {
 				return nil, err
 			}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -15,6 +15,7 @@ import (
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	"github.com/libp2p/go-msgio/pbio"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/waku-org/go-waku/logging"
 	"github.com/waku-org/go-waku/waku/v2/peermanager"
@@ -278,7 +279,7 @@ func (wakuLP *WakuLightPush) handleOpts(ctx context.Context, message *wpb.WakuMe
 	}
 
 	if params.pm != nil && params.peerAddr != nil {
-		pData, err := wakuLP.pm.AddPeer(params.peerAddr, peerstore.Static, []string{params.pubsubTopic}, LightPushID_v20beta1)
+		pData, err := wakuLP.pm.AddPeer([]multiaddr.Multiaddr{params.peerAddr}, peerstore.Static, []string{params.pubsubTopic}, LightPushID_v20beta1)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/peer_exchange/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-msgio/pbio"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/waku-org/go-waku/waku/v2/peermanager"
 	"github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
@@ -36,7 +37,7 @@ func (wakuPX *WakuPeerExchange) Request(ctx context.Context, numPeers int, opts 
 	}
 
 	if params.pm != nil && params.peerAddr != nil {
-		pData, err := wakuPX.pm.AddPeer(params.peerAddr, peerstore.Static, []string{}, PeerExchangeID_v20alpha1)
+		pData, err := wakuPX.pm.AddPeer([]multiaddr.Multiaddr{params.peerAddr}, peerstore.Static, []string{}, PeerExchangeID_v20alpha1)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
@@ -196,15 +196,15 @@ func (s *WakuStore) Request(ctx context.Context, criteria Criteria, opts ...Requ
 	return result, nil
 }
 
-func (s *WakuStore) RequestRaw(ctx context.Context, peerID peer.ID, storeRequest *pb.StoreQueryRequest) (Result, error) {
+func (s *WakuStore) RequestRaw(ctx context.Context, peerInfo peer.AddrInfo, storeRequest *pb.StoreQueryRequest) (Result, error) {
 	err := storeRequest.Validate()
 	if err != nil {
 		return nil, err
 	}
 
 	var params Parameters
-	params.selectedPeer = peerID
-	if params.selectedPeer == "" {
+	params.peerAddr = peerInfo.Addrs
+	if len(params.peerAddr) == 0 {
 		return nil, ErrMustSelectPeer
 	}
 

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/options.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/options.go
@@ -11,7 +11,7 @@ import (
 
 type Parameters struct {
 	selectedPeer      peer.ID
-	peerAddr          multiaddr.Multiaddr
+	peerAddr          []multiaddr.Multiaddr
 	peerSelectionType peermanager.PeerSelection
 	preferredPeers    peer.IDSlice
 	requestID         []byte
@@ -33,7 +33,7 @@ type RequestOption func(*Parameters) error
 func WithPeer(p peer.ID) RequestOption {
 	return func(params *Parameters) error {
 		params.selectedPeer = p
-		if params.peerAddr != nil {
+		if len(params.peerAddr) != 0 {
 			return errors.New("WithPeer and WithPeerAddr options are mutually exclusive")
 		}
 		return nil
@@ -43,7 +43,7 @@ func WithPeer(p peer.ID) RequestOption {
 // WithPeerAddr is an option used to specify a peerAddress to request the message history.
 // This new peer will be added to peerStore.
 // Note that this option is mutually exclusive to WithPeerAddr, only one of them can be used.
-func WithPeerAddr(pAddr multiaddr.Multiaddr) RequestOption {
+func WithPeerAddr(pAddr ...multiaddr.Multiaddr) RequestOption {
 	return func(params *Parameters) error {
 		params.peerAddr = pAddr
 		if params.selectedPeer != "" {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1041,7 +1041,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20250103101727-4ef460cb951a
+# github.com/waku-org/go-waku v0.8.1-0.20250313161544-e68fcdb554f9
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests

--- a/waku/types/waku.go
+++ b/waku/types/waku.go
@@ -147,7 +147,7 @@ type Waku interface {
 
 	SubscribeToConnStatusChanges() (*ConnStatusSubscription, error)
 
-	SetCriteriaForMissingMessageVerification(peerID peer.ID, pubsubTopic string, contentTopics []TopicType) error
+	SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []TopicType) error
 
 	// MinPow returns the PoW value required by this node.
 	MinPow() float64
@@ -200,8 +200,8 @@ type Waku interface {
 	// PeerID returns node's PeerID
 	PeerID() peer.ID
 
-	// GetActiveStorenode returns the peer ID of the currently active storenode. It will be empty if no storenode is active
-	GetActiveStorenode() peer.ID
+	// GetActiveStorenode returns the peer AddrInfo of the currently active storenode. It will be empty if no storenode is active
+	GetActiveStorenode() peer.AddrInfo
 
 	// OnStorenodeChanged is triggered when a new storenode is promoted to become the active storenode or when the active storenode is removed
 	OnStorenodeChanged() <-chan peer.ID
@@ -222,7 +222,7 @@ type Waku interface {
 	ProcessMailserverBatch(
 		ctx context.Context,
 		batch MailserverBatch,
-		storenodeID peer.ID,
+		storenode peer.AddrInfo,
 		pageLimit uint64,
 		shouldProcessNextPage func(int) (bool, uint64),
 		processEnvelopes bool,

--- a/wakuv2/history_processor_wrapper.go
+++ b/wakuv2/history_processor_wrapper.go
@@ -21,6 +21,6 @@ func (hr *HistoryProcessorWrapper) OnEnvelope(env *protocol.Envelope, processEnv
 	return hr.waku.OnNewEnvelopes(env, common.StoreMessageType, processEnvelopes)
 }
 
-func (hr *HistoryProcessorWrapper) OnRequestFailed(requestID []byte, peerID peer.ID, err error) {
-	hr.waku.onHistoricMessagesRequestFailed(requestID, peerID, err)
+func (hr *HistoryProcessorWrapper) OnRequestFailed(requestID []byte, peerInfo peer.AddrInfo, err error) {
+	hr.waku.onHistoricMessagesRequestFailed(requestID, peerInfo, err)
 }

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -545,9 +545,9 @@ func TestWakuV2Store(t *testing.T) {
 	}()
 
 	// Connect the two nodes directly
-	peer2Addr := w2.node.ListenAddresses()[0].String()
-	err = w1.node.DialPeer(context.Background(), peer2Addr)
+	peer2Addr, err := w2.ListenAddresses()
 	require.NoError(t, err)
+	err = w1.node.DialPeer(context.Background(), peer2Addr[0].String())
 
 	waitForPeerConnection(t, w2.node.Host().ID(), w1PeersCh)
 
@@ -720,7 +720,10 @@ func TestLightpushRateLimit(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	//Connect the relay peer and full node
-	err = w1.node.DialPeer(ctx, w0.node.ListenAddresses()[0].String())
+	peerAddr, err := w0.ListenAddresses()
+
+	require.NoError(t, err)
+	err = w1.node.DialPeer(ctx, peerAddr[0].String())
 	require.NoError(t, err)
 
 	err = tt.RetryWithBackOff(func() error {
@@ -747,7 +750,11 @@ func TestLightpushRateLimit(t *testing.T) {
 	}()
 
 	//Use this instead of DialPeer to make sure the peer is added to PeerStore and can be selected for Lighpush
-	w2.node.AddDiscoveredPeer(w1.PeerID(), w1.node.ListenAddresses(), wps.Static, w1.cfg.DefaultShardedPubsubTopics, w1.node.ENR(), true)
+	addresses, err := w1.ListenAddresses()
+	require.NoError(t, err)
+	peerID, err := w1.PeerID()
+	require.NoError(t, err)
+	w2.node.AddDiscoveredPeer(peerID, addresses, wps.Static, w1.cfg.DefaultShardedPubsubTopics, w1.node.ENR(), true)
 
 	waitForPeerConnectionWithTimeout(t, w2.node.Host().ID(), w1PeersCh, 5*time.Second)
 

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -548,6 +548,7 @@ func TestWakuV2Store(t *testing.T) {
 	peer2Addr, err := w2.ListenAddresses()
 	require.NoError(t, err)
 	err = w1.node.DialPeer(context.Background(), peer2Addr[0].String())
+	require.NoError(t, err)
 
 	waitForPeerConnection(t, w2.node.Host().ID(), w1PeersCh)
 
@@ -752,8 +753,7 @@ func TestLightpushRateLimit(t *testing.T) {
 	//Use this instead of DialPeer to make sure the peer is added to PeerStore and can be selected for Lighpush
 	addresses, err := w1.ListenAddresses()
 	require.NoError(t, err)
-	peerID, err := w1.PeerID()
-	require.NoError(t, err)
+	peerID := w1.PeerID()
 	w2.node.AddDiscoveredPeer(peerID, addresses, wps.Static, w1.cfg.DefaultShardedPubsubTopics, w1.node.ENR(), true)
 
 	waitForPeerConnectionWithTimeout(t, w2.node.Host().ID(), w1PeersCh, 5*time.Second)


### PR DESCRIPTION
Updating `go-waku`, which makes us use peerInfo and multiaddresses more widely instead of peerId.
This is necessary as using only the peerId requires us having access to the peer store, and when integrating with nwaku we don't have direct access to it.

More in https://github.com/waku-org/go-waku/pull/1269 

Important changes:
- [x] updating `go-waku`
- [x] adapt code to use peerInfo and multiaddresses more widely instead of peerId 

Issue: https://github.com/waku-org/nwaku/issues/3076
