### PR TITLE
feat(router)_: check balance when setting custom tx details

### DIFF
--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -188,8 +188,9 @@ func (r *Router) setCustomTxDetails(ctx context.Context, pathTxIdentity *request
 		if err != nil {
 			return err
 		}
+		_, err = r.checkBalancesForTheBestRoute(ctx, r.activeRoutes.Best)
 		// inform the client about the changes
-		sendRouterResult(pathTxIdentity.RouterInputParamsUuid, r.activeRoutes, nil)
+		sendRouterResult(pathTxIdentity.RouterInputParamsUuid, r.activeRoutes, err)
 
 		return nil
 	}

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -169,12 +169,11 @@ func (r *Router) setCustomTxDetails(ctx context.Context, pathTxIdentity *request
 		return err
 	}
 
-	pathFound := false
 	for _, path := range r.activeRoutes.Best {
 		if path.PathIdentity() != pathTxIdentity.PathIdentity() {
 			continue
 		}
-		pathFound = true
+
 		// update the custom params
 		r.lastInputParamsMutex.Lock()
 		if r.lastInputParams.PathTxCustomParams == nil {
@@ -189,17 +188,13 @@ func (r *Router) setCustomTxDetails(ctx context.Context, pathTxIdentity *request
 		if err != nil {
 			return err
 		}
+		// inform the client about the changes
+		sendRouterResult(pathTxIdentity.RouterInputParamsUuid, r.activeRoutes, nil)
+
+		return nil
 	}
 
-	if !pathFound {
-		return ErrCannotFindPathForProvidedIdentity
-	}
-
-	_, err = r.checkBalancesForTheBestRoute(ctx, r.activeRoutes.Best)
-
-	// inform the client about the changes
-	sendRouterResult(pathTxIdentity.RouterInputParamsUuid, r.activeRoutes, err)
-	return nil
+	return ErrCannotFindPathForProvidedIdentity
 }
 
 func (r *Router) SetFeeMode(ctx context.Context, pathTxIdentity *requests.PathTxIdentity, feeMode fees.GasFeeMode) error {

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -169,11 +169,12 @@ func (r *Router) setCustomTxDetails(ctx context.Context, pathTxIdentity *request
 		return err
 	}
 
+	pathFound := false
 	for _, path := range r.activeRoutes.Best {
 		if path.PathIdentity() != pathTxIdentity.PathIdentity() {
 			continue
 		}
-
+		pathFound = true
 		// update the custom params
 		r.lastInputParamsMutex.Lock()
 		if r.lastInputParams.PathTxCustomParams == nil {
@@ -188,13 +189,17 @@ func (r *Router) setCustomTxDetails(ctx context.Context, pathTxIdentity *request
 		if err != nil {
 			return err
 		}
-		// inform the client about the changes
-		sendRouterResult(pathTxIdentity.RouterInputParamsUuid, r.activeRoutes, nil)
-
-		return nil
 	}
 
-	return ErrCannotFindPathForProvidedIdentity
+	if !pathFound {
+		return ErrCannotFindPathForProvidedIdentity
+	}
+
+	_, err = r.checkBalancesForTheBestRoute(ctx, r.activeRoutes.Best)
+
+	// inform the client about the changes
+	sendRouterResult(pathTxIdentity.RouterInputParamsUuid, r.activeRoutes, err)
+	return nil
 }
 
 func (r *Router) SetFeeMode(ctx context.Context, pathTxIdentity *requests.PathTxIdentity, feeMode fees.GasFeeMode) error {


### PR DESCRIPTION
Checking balance when sending routes after setting custom tx details.

Currently, we're checking the account balance and sending the appropriate error message when sending the suggested routes signals, but when calling `SetFeeMode` or `SetCustomTxDetails`, the balance errors are not sent with the updated route signal. This PR adds the balance check before sending the route signal after changing tx details.

The issue was found [here](https://github.com/status-im/status-mobile/pull/22232#issuecomment-2710828029) during QA. 