### PR TITLE
fix_: ensure we unregister Waku metrics service during messenger shutdown

### DIFF
--- a/metrics/wakumetrics/client_test.go
+++ b/metrics/wakumetrics/client_test.go
@@ -73,7 +73,7 @@ func getGaugeVecValue(metric *prometheus.GaugeVec, labels ...string) float64 {
 	return pb.Gauge.GetValue()
 }
 
-func TestClient_DoubleRegsiter(t *testing.T) {
+func TestClient_DoubleRegister(t *testing.T) {
 	client := createTestClient(t)
 	require.Error(t, client.RegisterWithRegistry())
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -590,6 +590,7 @@ func NewMessenger(
 			communitiesManager.Stop,
 			archiveManager.Stop,
 			encryptionProtocol.Stop,
+			wakumetrics.UnregisterMetrics,
 			func() error {
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 				defer cancel()


### PR DESCRIPTION
fixes #6430 

## Summary

* This PR is meant to resolve an issue with the Status mobile client not being able to login to the app after logging out because of an existing metrics service already running (registered) from the previous login.
  * This PR attempts to resolve the Status mobile login issue by adding a shutdown task to the Status messenger for unregistering the Waku metrics service during the shutdown phase.
