### PR TITLE
feat(wallet)_: set tokens lists auto update interval from client side

### DIFF
--- a/api/defaults.go
+++ b/api/defaults.go
@@ -170,7 +170,7 @@ func SetFleet(fleet string, nodeConfig *params.NodeConfig) error {
 	return nil
 }
 
-func buildWalletConfig(request *requests.WalletSecretsConfig, statusProxyEnabled bool) params.WalletConfig {
+func buildWalletConfig(request *requests.WalletSecretsConfig) params.WalletConfig {
 	walletConfig := params.WalletConfig{
 		Enabled:                true,
 		EnableMercuryoProvider: true,
@@ -250,8 +250,6 @@ func buildWalletConfig(request *requests.WalletSecretsConfig, statusProxyEnabled
 		walletConfig.EthRpcProxyPassword = request.EthRpcProxyPassword
 	}
 
-	walletConfig.StatusProxyEnabled = statusProxyEnabled
-
 	return walletConfig
 }
 
@@ -324,7 +322,7 @@ func DefaultNodeConfig(installationID string, request *requests.CreateAccount, o
 	nodeConfig.MaxPeers = DefaultMaxPeers
 	nodeConfig.MaxPendingPeers = DefaultMaxPendingPeers
 
-	nodeConfig.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig, request.StatusProxyEnabled)
+	nodeConfig.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig)
 
 	nodeConfig.LocalNotificationsConfig = params.LocalNotificationsConfig{Enabled: true}
 	nodeConfig.BrowsersConfig = params.BrowsersConfig{Enabled: true}

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -170,11 +170,14 @@ func SetFleet(fleet string, nodeConfig *params.NodeConfig) error {
 	return nil
 }
 
-func buildWalletConfig(request *requests.WalletSecretsConfig) params.WalletConfig {
+func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.WalletSecretsConfig) params.WalletConfig {
 	walletConfig := params.WalletConfig{
 		Enabled:                true,
 		EnableMercuryoProvider: true,
 		AlchemyAPIKeys:         make(map[uint64]string),
+
+		TokensListsAutoRefreshCheckInterval: walletRequest.TokensListsAutoRefreshCheckInterval,
+		TokensListsAutoRefreshInterval:      walletRequest.TokensListsAutoRefreshInterval,
 	}
 
 	if request.StatusProxyStageName != "" {
@@ -322,7 +325,7 @@ func DefaultNodeConfig(installationID string, request *requests.CreateAccount, o
 	nodeConfig.MaxPeers = DefaultMaxPeers
 	nodeConfig.MaxPendingPeers = DefaultMaxPendingPeers
 
-	nodeConfig.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig)
+	nodeConfig.WalletConfig = buildWalletConfig(&request.WalletConfig, &request.WalletSecretsConfig)
 
 	nodeConfig.LocalNotificationsConfig = params.LocalNotificationsConfig{Enabled: true}
 	nodeConfig.BrowsersConfig = params.BrowsersConfig{Enabled: true}

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -680,6 +680,7 @@ func (b *GethStatusBackend) overridePartialWithOldNodeConfig(conf *params.NodeCo
 
 func (b *GethStatusBackend) convertLoginRequestToAccountRequest(loginRequest *requests.Login) *requests.CreateAccount {
 	createAccount := &requests.CreateAccount{}
+	createAccount.WalletConfig = loginRequest.WalletConfig
 	createAccount.WalletSecretsConfig = loginRequest.WalletSecretsConfig
 	createAccount.WakuV2Nameserver = &loginRequest.WakuV2Nameserver
 	createAccount.WakuV2LightClient = loginRequest.WakuV2LightClient
@@ -745,7 +746,7 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 		KeycardPairingDataFile: DefaultKeycardPairingDataFile,
 	}
 
-	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig)
+	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletConfig, &request.WalletSecretsConfig)
 
 	err = b.UpdateNodeConfigFleet(acc, request.Password, defaultCfg)
 	if err != nil {

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -681,7 +681,6 @@ func (b *GethStatusBackend) overridePartialWithOldNodeConfig(conf *params.NodeCo
 func (b *GethStatusBackend) convertLoginRequestToAccountRequest(loginRequest *requests.Login) *requests.CreateAccount {
 	createAccount := &requests.CreateAccount{}
 	createAccount.WalletSecretsConfig = loginRequest.WalletSecretsConfig
-	createAccount.StatusProxyEnabled = loginRequest.StatusProxyEnabled
 	createAccount.WakuV2Nameserver = &loginRequest.WakuV2Nameserver
 	createAccount.WakuV2LightClient = loginRequest.WakuV2LightClient
 	createAccount.WakuV2EnableMissingMessageVerification = loginRequest.WakuV2EnableMissingMessageVerification
@@ -746,7 +745,7 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 		KeycardPairingDataFile: DefaultKeycardPairingDataFile,
 	}
 
-	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig, request.StatusProxyEnabled)
+	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletSecretsConfig)
 
 	err = b.UpdateNodeConfigFleet(acc, request.Password, defaultCfg)
 	if err != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -428,7 +428,6 @@ type WalletConfig struct {
 	StatusProxyBlockchainUser     string `json:"StatusProxyBlockchainUser"`
 	StatusProxyBlockchainPassword string `json:"StatusProxyBlockchainPassword"`
 
-	StatusProxyEnabled     bool   `json:"StatusProxyEnabled"`
 	StatusProxyStageName   string `json:"StatusProxyStageName"`
 	EnableCelerBridge      bool   `json:"EnableCelerBridge"`
 	EnableMercuryoProvider bool   `json:"EnableMercuryoProvider"`
@@ -442,12 +441,10 @@ type WalletConfig struct {
 func (wc WalletConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Enabled                bool `json:"Enabled"`
-		StatusProxyEnabled     bool `json:"StatusProxyEnabled"`
 		EnableCelerBridge      bool `json:"EnableCelerBridge"`
 		EnableMercuryoProvider bool `json:"EnableMercuryoProvider"`
 	}{
 		Enabled:                wc.Enabled,
-		StatusProxyEnabled:     wc.StatusProxyEnabled,
 		EnableCelerBridge:      wc.EnableCelerBridge,
 		EnableMercuryoProvider: wc.EnableMercuryoProvider,
 	})

--- a/params/config.go
+++ b/params/config.go
@@ -434,19 +434,26 @@ type WalletConfig struct {
 	EthRpcProxyUrl         string `json:"EthRpcProxyUrl"`
 	EthRpcProxyUser        string `json:"EthRpcProxyUser"`
 	EthRpcProxyPassword    string `json:"EthRpcProxyPassword"`
+
+	TokensListsAutoRefreshInterval      int `json:"TokensListsAutoRefreshInterval"`      // in seconds
+	TokensListsAutoRefreshCheckInterval int `json:"TokensListsAutoRefreshCheckInterval"` // in seconds
 }
 
 // MarshalJSON custom marshalling to avoid exposing sensitive data in log,
 // there's a function called `startNode` will log NodeConfig which include WalletConfig
 func (wc WalletConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Enabled                bool `json:"Enabled"`
-		EnableCelerBridge      bool `json:"EnableCelerBridge"`
-		EnableMercuryoProvider bool `json:"EnableMercuryoProvider"`
+		Enabled                             bool `json:"Enabled"`
+		EnableCelerBridge                   bool `json:"EnableCelerBridge"`
+		EnableMercuryoProvider              bool `json:"EnableMercuryoProvider"`
+		TokensListsAutoRefreshInterval      int  `json:"TokensListsAutoRefreshInterval"`
+		TokensListsAutoRefreshCheckInterval int  `json:"TokensListsAutoRefreshCheckInterval"`
 	}{
-		Enabled:                wc.Enabled,
-		EnableCelerBridge:      wc.EnableCelerBridge,
-		EnableMercuryoProvider: wc.EnableMercuryoProvider,
+		Enabled:                             wc.Enabled,
+		EnableCelerBridge:                   wc.EnableCelerBridge,
+		EnableMercuryoProvider:              wc.EnableMercuryoProvider,
+		TokensListsAutoRefreshInterval:      wc.TokensListsAutoRefreshInterval,
+		TokensListsAutoRefreshCheckInterval: wc.TokensListsAutoRefreshCheckInterval,
 	})
 }
 

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -316,12 +316,10 @@ func TestMarshalWalletConfigJSON(t *testing.T) {
 	require.NoError(t, err)
 	// check if sensitive fields are not present
 	require.NotContains(t, string(bytes), "OpenseaAPIKey")
-	require.Contains(t, string(bytes), "StatusProxyEnabled")
 
 	// check if deserializing are still working with sensitive fields
 	walletConfig = params.WalletConfig{}
-	err = json.Unmarshal([]byte(`{"OpenseaAPIKey":"some-key", "StatusProxyEnabled":true}`), &walletConfig)
+	err = json.Unmarshal([]byte(`{"OpenseaAPIKey":"some-key"}`), &walletConfig)
 	require.NoError(t, err)
 	require.Equal(t, "some-key", walletConfig.OpenseaAPIKey)
-	require.True(t, walletConfig.StatusProxyEnabled)
 }

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -72,6 +72,7 @@ type CreateAccount struct {
 
 	AutoRefreshTokensEnabled bool `json:"autoRefreshTokensEnabled"`
 
+	WalletConfig
 	WalletSecretsConfig
 
 	TorrentConfigEnabled *bool
@@ -88,7 +89,10 @@ type CreateAccount struct {
 	KeycardPairingKey      string  `json:"keycardPairingKey"`
 	KeycardPairingDataFile *string `json:"keycardPairingDataFile"`
 }
-
+type WalletConfig struct {
+	TokensListsAutoRefreshInterval      int `json:"tokensListsAutoRefreshInterval"`      // in seconds
+	TokensListsAutoRefreshCheckInterval int `json:"tokensListsAutoRefreshCheckInterval"` // in seconds
+}
 type WalletSecretsConfig struct {
 	PoktToken            string `json:"poktToken"`
 	InfuraToken          string `json:"infuraToken"`

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -87,7 +87,6 @@ type CreateAccount struct {
 	// for recovering account
 	KeycardPairingKey      string  `json:"keycardPairingKey"`
 	KeycardPairingDataFile *string `json:"keycardPairingDataFile"`
-	StatusProxyEnabled     bool    `json:"statusProxyEnabled"`
 }
 
 type WalletSecretsConfig struct {

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -36,6 +36,7 @@ type Login struct {
 	// - KeyUID is ignored and replaced with hash of the master public key
 	Mnemonic string `json:"mnemonic"`
 
+	WalletConfig
 	WalletSecretsConfig
 
 	APIConfig *APIConfig `json:"apiConfig"`

--- a/protocol/requests/login.go
+++ b/protocol/requests/login.go
@@ -38,8 +38,7 @@ type Login struct {
 
 	WalletSecretsConfig
 
-	APIConfig          *APIConfig `json:"apiConfig"`
-	StatusProxyEnabled bool       `json:"statusProxyEnabled"`
+	APIConfig *APIConfig `json:"apiConfig"`
 
 	// Following fields are used for migration from old node config to new one
 	WakuV2LightClient                            bool    `json:"wakuV2LightClient"`

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -132,12 +132,9 @@ func NewTokenManager(
 	}
 }
 
-func (tm *Manager) Start(ctx context.Context) {
+func (tm *Manager) Start(ctx context.Context, autoRefreshInterval time.Duration, autoRefreshCheckInterval time.Duration) {
 	tm.startAccountsWatcher()
 
-	// TODO: make `autoRefreshInterval` configurable from the client
-	autoRefreshInterval := 30 * time.Minute     // interval after which we should fetch the token lists from the remote source (or use the default one if remote source is not set)
-	autoRefreshCheckInterval := 3 * time.Minute // interval after which we should check if we should trigger the auto-refresh
 	// For now we don't have the list of tokens lists remotely set so we're uisng the harcoded default lists. Once we have it
 	//we will just need to update the empty string with the correct URL.
 	tm.tokenLists.Start(ctx, "", autoRefreshInterval, autoRefreshCheckInterval)

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -1146,7 +1146,7 @@ func setupFindBlocksCommand(t *testing.T, accountAddress common.Address, fromBlo
 	err = tokenListsFetcher.StoreTokenList("sequential-commands-tests-list", "abcd", sequentialCommandsTestsListJsonData)
 	require.NoError(t, err)
 
-	tokenManager.Start(context.Background())
+	tokenManager.Start(context.Background(), time.Hour, time.Hour)
 
 	accDB, err := accounts.NewDB(appDb)
 	require.NoError(t, err)


### PR DESCRIPTION
The first commit removes `statusProxyEnabled` flag since it's not in use anywhere.

The second commit allows setting tokens lists auto-update interval from the client side.

Added flags:
- `tokensListsAutoRefreshInterval`
- `tokensListsAutoRefreshCheckInterval`

to `CreateAccount` and `Login` type. That way the client can set custom intervals for auto-refresh token lists. If intervals are not provided, the default values of 30 minutes for auto refresh-interval and 3 minutes for check interval will be used.