### PR TITLE
fix_: properly setting peerId for store queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/siphiuel/lc-proxy-wrapper v0.0.0-20230516150924-246507cee8c7
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/waku-org/go-waku v0.8.1-0.20250313161544-e68fcdb554f9
+	github.com/waku-org/go-waku v0.8.1-0.20250320134751-fdf03de179a7
 	github.com/waku-org/waku-go-bindings v0.0.0-20250313132258-6f95d51df46c
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -2150,8 +2150,8 @@ github.com/waku-org/go-libp2p-pubsub v0.12.0-gowaku.0.20240823143342-b0f2429ca27
 github.com/waku-org/go-libp2p-pubsub v0.12.0-gowaku.0.20240823143342-b0f2429ca27f/go.mod h1:Oi0zw9aw8/Y5GC99zt+Ef2gYAl+0nZlwdJonDyOz/sE=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0 h1:R4YYx2QamhBRl/moIxkDCNW+OP7AHbyWLBygDc/xIMo=
 github.com/waku-org/go-libp2p-rendezvous v0.0.0-20240110193335-a67d1cc760a0/go.mod h1:EhZP9fee0DYjKH/IOQvoNSy1tSHp2iZadsHGphcAJgY=
-github.com/waku-org/go-waku v0.8.1-0.20250313161544-e68fcdb554f9 h1:gHN9uJYzJuRgKwFBOrLbsisE97e+0P7Qbx32qGFdRu4=
-github.com/waku-org/go-waku v0.8.1-0.20250313161544-e68fcdb554f9/go.mod h1:zYhLgqwBE3sGP2vP+aNiM5moOKlf/uSoIv36puAj9WI=
+github.com/waku-org/go-waku v0.8.1-0.20250320134751-fdf03de179a7 h1:SxJt0AXNUWaqFnPOB3BBK7GKf+y7eVjToq4D5ngz0gw=
+github.com/waku-org/go-waku v0.8.1-0.20250320134751-fdf03de179a7/go.mod h1:zYhLgqwBE3sGP2vP+aNiM5moOKlf/uSoIv36puAj9WI=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59 h1:jisj+OCI6QydLtFq3Pyhu49wl9ytPN7oAHjMfepHDrA=
 github.com/waku-org/go-zerokit-rln v0.1.14-0.20240102145250-fa738c0bdf59/go.mod h1:1PdBdPzyTaKt3VnpAHk3zj+r9dXPFOr3IHZP9nFle6E=
 github.com/waku-org/go-zerokit-rln-apple v0.0.0-20230916172309-ee0ee61dde2b h1:KgZVhsLkxsj5gb/FfndSCQu6VYwALrCOgYI3poR95yE=

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
@@ -203,8 +203,8 @@ func (s *WakuStore) RequestRaw(ctx context.Context, peerInfo peer.AddrInfo, stor
 	}
 
 	var params Parameters
-	params.peerAddr = peerInfo.Addrs
-	if len(params.peerAddr) == 0 {
+	params.selectedPeer = peerInfo.ID
+	if params.selectedPeer == "" {
 		return nil, ErrMustSelectPeer
 	}
 

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
@@ -205,22 +205,12 @@ func (s *WakuStore) RequestRaw(ctx context.Context, peerInfo peer.AddrInfo, stor
 
 	var params Parameters
 	params.peerAddr = peerInfo.Addrs
-	if len(params.peerAddr) == 0 {
+	params.selectedPeer = peerInfo.ID
+	if len(params.peerAddr) == 0 || params.selectedPeer == "" {
 		return nil, ErrMustSelectPeer
 	}
 
-	//Add Peer to peerstore.
-	if s.pm != nil && params.peerAddr != nil {
-		infoArr, err := peer.AddrInfosFromP2pAddrs(params.peerAddr...)
-		if err != nil {
-			return nil, err
-		}
-		for _, info := range infoArr {
-			s.h.Peerstore().AddAddrs(info.ID, info.Addrs, libp2pPeerstore.AddressTTL)
-
-		}
-		params.selectedPeer = infoArr[0].ID
-	}
+	s.h.Peerstore().AddAddrs(peerInfo.ID, peerInfo.Addrs, libp2pPeerstore.AddressTTL)
 
 	response, err := s.queryFrom(ctx, storeRequest, &params)
 	if err != nil {

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
+	libp2pPeerstore "github.com/libp2p/go-libp2p/core/peerstore"
 	libp2pProtocol "github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-msgio/pbio"
 	"github.com/waku-org/go-waku/logging"
@@ -203,9 +204,22 @@ func (s *WakuStore) RequestRaw(ctx context.Context, peerInfo peer.AddrInfo, stor
 	}
 
 	var params Parameters
-	params.selectedPeer = peerInfo.ID
-	if params.selectedPeer == "" {
+	params.peerAddr = peerInfo.Addrs
+	if len(params.peerAddr) == 0 {
 		return nil, ErrMustSelectPeer
+	}
+
+	//Add Peer to peerstore.
+	if s.pm != nil && params.peerAddr != nil {
+		infoArr, err := peer.AddrInfosFromP2pAddrs(params.peerAddr...)
+		if err != nil {
+			return nil, err
+		}
+		for _, info := range infoArr {
+			s.h.Peerstore().AddAddrs(info.ID, info.Addrs, libp2pPeerstore.AddressTTL)
+
+		}
+		params.selectedPeer = infoArr[0].ID
 	}
 
 	response, err := s.queryFrom(ctx, storeRequest, &params)

--- a/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
+++ b/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go
@@ -210,6 +210,7 @@ func (s *WakuStore) RequestRaw(ctx context.Context, peerInfo peer.AddrInfo, stor
 		return nil, ErrMustSelectPeer
 	}
 
+	//Add Peer to peerstore.
 	s.h.Peerstore().AddAddrs(peerInfo.ID, peerInfo.Addrs, libp2pPeerstore.AddressTTL)
 
 	response, err := s.queryFrom(ctx, storeRequest, &params)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1041,7 +1041,7 @@ github.com/waku-org/go-discover/discover/v5wire
 github.com/waku-org/go-libp2p-rendezvous
 github.com/waku-org/go-libp2p-rendezvous/db
 github.com/waku-org/go-libp2p-rendezvous/pb
-# github.com/waku-org/go-waku v0.8.1-0.20250313161544-e68fcdb554f9
+# github.com/waku-org/go-waku v0.8.1-0.20250320134751-fdf03de179a7
 ## explicit; go 1.21
 github.com/waku-org/go-waku/logging
 github.com/waku-org/go-waku/tests


### PR DESCRIPTION
Updating `go-waku` to properly set the peerId in store queries 

Closes https://github.com/status-im/status-go/issues/6439 and https://github.com/status-im/status-mobile/issues/22343
