### PR TITLE
chore(wallet)_: removed unnecessary check for optimism and base when evaluating the nonce

### DIFF
--- a/transactions/pendingtxtracker.go
+++ b/transactions/pendingtxtracker.go
@@ -588,23 +588,6 @@ func (tm *PendingTxTracker) GetPendingEntry(chainID common.ChainID, hash eth.Has
 	return trs[0], nil
 }
 
-func (tm *PendingTxTracker) CountPendingTxsFromNonce(chainID common.ChainID, address eth.Address, nonce uint64) (pendingTx uint64, err error) {
-	err = tm.db.QueryRow(`
-		SELECT
-			COUNT(nonce)
-		FROM
-			pending_transactions
-		WHERE
-			network_id = ?
-		AND
-			from_address = ?
-		AND
-			nonce >= ?`,
-		chainID, address, nonce).
-		Scan(&pendingTx)
-	return
-}
-
 // StoreAndTrackPendingTx store the details of a pending transaction and track it until it is mined
 func (tm *PendingTxTracker) StoreAndTrackPendingTx(transaction *PendingTransaction) error {
 	err := tm.addPendingAndNotify(transaction)

--- a/transactions/transactor.go
+++ b/transactions/transactor.go
@@ -104,27 +104,7 @@ func (t *Transactor) SetRPC(rpcClient *rpc.Client, timeout time.Duration) {
 
 func (t *Transactor) NextNonce(ctx context.Context, rpcClient rpc.ClientInterface, chainID uint64, from types.Address) (uint64, error) {
 	wrapper := newRPCWrapper(rpcClient, chainID)
-	nonce, err := wrapper.PendingNonceAt(ctx, common.Address(from))
-	if err != nil {
-		return 0, err
-	}
-
-	// We need to take into consideration all pending transactions in case of networks based on the Optimism stack, cause the network returns always
-	// the nonce of last executed tx + 1 for the next nonce value.
-	if chainID == wallet_common.OptimismMainnet ||
-		chainID == wallet_common.OptimismSepolia ||
-		chainID == wallet_common.BaseMainnet ||
-		chainID == wallet_common.BaseSepolia {
-		if t.pendingTracker != nil {
-			countOfPendingTXs, err := t.pendingTracker.CountPendingTxsFromNonce(wallet_common.ChainID(chainID), common.Address(from), nonce)
-			if err != nil {
-				return 0, err
-			}
-			return nonce + countOfPendingTXs, nil
-		}
-	}
-
-	return nonce, err
+	return wrapper.PendingNonceAt(ctx, common.Address(from))
 }
 
 func (t *Transactor) EstimateGas(network *params.Network, from common.Address, to common.Address, value *big.Int, input []byte) (uint64, error) {


### PR DESCRIPTION
should fix https://github.com/status-im/status-mobile/issues/22341

Adding the number of pending transactions to the Nonce resolved by the provider dates from when we were struggling with the Grove, which was very often out of sync. Now, since the providers the app is using are more reliable, we don't need this because it may just create a mess and more pending TXs.

Was discussed here https://github.com/status-im/status-go/pull/6228#discussion_r1912764727