### PR TITLE
feat_: support configuring pre-login log

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -1090,7 +1090,7 @@ func TestConvertAccount(t *testing.T) {
 
 	defaultSettings, err := defaultSettings(genAccInfo.KeyUID, genAccInfo.Address, derivedAccounts)
 	require.NoError(t, err)
-	nodeConfig, err := DefaultNodeConfig(defaultSettings.InstallationID, &requests.CreateAccount{
+	nodeConfig, err := DefaultNodeConfig(defaultSettings.InstallationID, genAccInfo.KeyUID, &requests.CreateAccount{
 		LogLevel: defaultSettings.LogLevel,
 	})
 	require.NoError(t, err)

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -275,12 +275,12 @@ func getMainnetRPCURL(networks []params.Network) string {
 	return ""
 }
 
-func DefaultNodeConfig(installationID,keyUID string, request *requests.CreateAccount, opts ...params.Option) (*params.NodeConfig, error) {
+func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAccount, opts ...params.Option) (*params.NodeConfig, error) {
 	// Set mainnet
 	nodeConfig := &params.NodeConfig{}
 	nodeConfig.RootDataDir = request.RootDataDir
 	nodeConfig.LogEnabled = request.LogEnabled
-	nodeConfig.LogFile = gocommon.TruncateWithDot(keyUID)+".log"
+	nodeConfig.LogFile = gocommon.TruncateWithDot(keyUID) + ".log"
 	nodeConfig.LogDir = request.LogFilePath
 	nodeConfig.LogLevel = DefaultLogLevel
 	nodeConfig.DataDir = DefaultDataDir

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/status-im/status-go/account/generator"
 	"github.com/status-im/status-go/api/common"
+	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
@@ -32,7 +33,6 @@ const (
 	DefaultKeycardPairingDataFile = "/ethereum/mainnet_rpc/keycard/pairings.json"
 	DefaultDataDir                = "/ethereum/mainnet_rpc"
 	DefaultNodeName               = "StatusIM"
-	DefaultLogFile                = "geth.log"
 	DefaultAPILogFile             = "api.log"
 
 	DefaultLogLevel                   = "ERROR"
@@ -275,12 +275,12 @@ func getMainnetRPCURL(networks []params.Network) string {
 	return ""
 }
 
-func DefaultNodeConfig(installationID string, request *requests.CreateAccount, opts ...params.Option) (*params.NodeConfig, error) {
+func DefaultNodeConfig(installationID,keyUID string, request *requests.CreateAccount, opts ...params.Option) (*params.NodeConfig, error) {
 	// Set mainnet
 	nodeConfig := &params.NodeConfig{}
 	nodeConfig.RootDataDir = request.RootDataDir
 	nodeConfig.LogEnabled = request.LogEnabled
-	nodeConfig.LogFile = DefaultLogFile
+	nodeConfig.LogFile = gocommon.TruncateWithDot(keyUID)+".log"
 	nodeConfig.LogDir = request.LogFilePath
 	nodeConfig.LogLevel = DefaultLogLevel
 	nodeConfig.DataDir = DefaultDataDir

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -108,16 +108,16 @@ type GethStatusBackend struct {
 	prometheusMetrics        *metrics.Server
 	sentryDSN                string
 
-	logger      *zap.Logger
-	preLoginLog *logutils.PreLoginLog
+	logger            *zap.Logger
+	preLoginLogConfig *logutils.PreLoginLogConfig
 }
 
 // NewGethStatusBackend create a new GethStatusBackend instance
 func NewGethStatusBackend(logger *zap.Logger) *GethStatusBackend {
 	logger = logger.Named("GethStatusBackend")
 	backend := &GethStatusBackend{
-		logger:      logger,
-		preLoginLog: logutils.NewPreLoginLog(),
+		logger:            logger,
+		preLoginLogConfig: logutils.NewPreLoginLogConfig(),
 	}
 	backend.initialize()
 
@@ -129,8 +129,8 @@ func NewGethStatusBackend(logger *zap.Logger) *GethStatusBackend {
 	return backend
 }
 
-func (b *GethStatusBackend) PreLoginLog() *logutils.PreLoginLog {
-	return b.preLoginLog
+func (b *GethStatusBackend) PreLoginLog() *logutils.PreLoginLogConfig {
+	return b.preLoginLogConfig
 }
 
 func (b *GethStatusBackend) initialize() {
@@ -2712,7 +2712,7 @@ func (b *GethStatusBackend) switchToPreLoginLog() error {
 	if err != nil {
 		return err
 	}
-	return logutils.OverrideRootLoggerWithConfig(b.preLoginLog.Settings())
+	return logutils.OverrideRootLoggerWithConfig(b.preLoginLogConfig.ConvertToLogSettings())
 }
 
 // cleanupServices stops parts of services that doesn't managed by a node and removes injected data from services.
@@ -3028,15 +3028,15 @@ func (b *GethStatusBackend) SetProfileLogEnabled(enabled bool) error {
 func (b *GethStatusBackend) SetPreLoginLogEnabled(enabled bool) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.preLoginLog.SetEnabled(enabled)
-	return logutils.OverrideRootLoggerWithConfig(b.preLoginLog.Settings())
+	b.preLoginLogConfig.SetEnabled(enabled)
+	return logutils.OverrideRootLoggerWithConfig(b.preLoginLogConfig.ConvertToLogSettings())
 }
 
 func (b *GethStatusBackend) SetPreLoginLogLevel(level string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if err := b.preLoginLog.SetLevel(level); err != nil {
+	if err := b.preLoginLogConfig.SetLevel(level); err != nil {
 		return err
 	}
-	return logutils.OverrideRootLoggerWithConfig(b.preLoginLog.Settings())
+	return logutils.OverrideRootLoggerWithConfig(b.preLoginLogConfig.ConvertToLogSettings())
 }

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -109,6 +109,7 @@ type GethStatusBackend struct {
 	sentryDSN                string
 
 	logger *zap.Logger
+	preLoginLog *logutils.PreLoginLog
 }
 
 // NewGethStatusBackend create a new GethStatusBackend instance
@@ -116,6 +117,7 @@ func NewGethStatusBackend(logger *zap.Logger) *GethStatusBackend {
 	logger = logger.Named("GethStatusBackend")
 	backend := &GethStatusBackend{
 		logger: logger,
+		preLoginLog: logutils.NewPreLoginLog(),
 	}
 	backend.initialize()
 
@@ -125,6 +127,10 @@ func NewGethStatusBackend(logger *zap.Logger) *GethStatusBackend {
 		zap.String("IpfsGatewayURL", params.IpfsGatewayURL))
 
 	return backend
+}
+
+func (b *GethStatusBackend) PreLoginLog() *logutils.PreLoginLog {
+	return b.preLoginLog
 }
 
 func (b *GethStatusBackend) initialize() {
@@ -509,7 +515,7 @@ func (b *GethStatusBackend) SetupLogSettings() error {
 	if err := logutils.ZapLogger().Sync(); err != nil {
 		return errors.Wrap(err, "failed to sync logger")
 	}
-	logSettings := b.config.DefaultLogSettings()
+	logSettings := b.config.ProfileLogSettings()
 	return logutils.OverrideRootLoggerWithConfig(logSettings)
 }
 
@@ -639,7 +645,7 @@ func (b *GethStatusBackend) workaroundToFixBadMigration(request *requests.Login)
 
 		// the createAccount contains all the fields that are needed to create the default node config
 		createAccount := b.convertLoginRequestToAccountRequest(request)
-		defaultNodeConf, err = DefaultNodeConfig(oldNodeConf.ShhextConfig.InstallationID, createAccount)
+		defaultNodeConf, err = DefaultNodeConfig(oldNodeConf.ShhextConfig.InstallationID, request.KeyUID, createAccount)
 		if err != nil {
 			return err
 		}
@@ -1775,7 +1781,7 @@ func (b *GethStatusBackend) prepareSettings(request *requests.CreateAccount, inp
 }
 
 func (b *GethStatusBackend) prepareConfig(request *requests.CreateAccount, input *prepareAccountInput, installationID string) (*params.NodeConfig, error) {
-	nodeConfig, err := DefaultNodeConfig(installationID, request, input.opts...)
+	nodeConfig, err := DefaultNodeConfig(installationID, input.keyUID, request, input.opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2706,7 +2712,7 @@ func (b *GethStatusBackend) switchToPreLoginLog() error {
 	if err != nil {
 		return err
 	}
-	return logutils.OverrideRootLoggerWithConfig(b.config.PreLoginLogSettings())
+	return logutils.OverrideRootLoggerWithConfig(b.preLoginLog.Settings())
 }
 
 // cleanupServices stops parts of services that doesn't managed by a node and removes injected data from services.
@@ -2980,7 +2986,7 @@ func (b *GethStatusBackend) TogglePanicReporting(enabled bool) error {
 	return b.DisablePanicReporting()
 }
 
-func (b *GethStatusBackend) SetLogLevel(level string) error {
+func (b *GethStatusBackend) SetProfileLogLevel(level string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -2990,7 +2996,7 @@ func (b *GethStatusBackend) SetLogLevel(level string) error {
 	}
 	b.config.LogLevel = level
 
-	return logutils.OverrideRootLoggerWithConfig(b.config.DefaultLogSettings())
+	return logutils.OverrideRootLoggerWithConfig(b.config.ProfileLogSettings())
 }
 
 func (b *GethStatusBackend) SetLogNamespaces(namespaces string) error {
@@ -3003,10 +3009,10 @@ func (b *GethStatusBackend) SetLogNamespaces(namespaces string) error {
 	}
 	b.config.LogNamespaces = namespaces
 
-	return logutils.OverrideRootLoggerWithConfig(b.config.DefaultLogSettings())
+	return logutils.OverrideRootLoggerWithConfig(b.config.ProfileLogSettings())
 }
 
-func (b *GethStatusBackend) SetLogEnabled(enabled bool) error {
+func (b *GethStatusBackend) SetProfileLogEnabled(enabled bool) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -3016,5 +3022,21 @@ func (b *GethStatusBackend) SetLogEnabled(enabled bool) error {
 	}
 	b.config.LogEnabled = enabled
 
-	return logutils.OverrideRootLoggerWithConfig(b.config.DefaultLogSettings())
+	return logutils.OverrideRootLoggerWithConfig(b.config.ProfileLogSettings())
+}
+
+func (b *GethStatusBackend) SetPreLoginLogEnabled(enabled bool) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.preLoginLog.SetEnabled(enabled)
+	return logutils.OverrideRootLoggerWithConfig(b.preLoginLog.Settings())
+}
+
+func (b *GethStatusBackend) SetPreLoginLogLevel(level string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err := b.preLoginLog.SetLevel(level); err != nil {
+		return err
+	}
+	return logutils.OverrideRootLoggerWithConfig(b.preLoginLog.Settings())
 }

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -108,7 +108,7 @@ type GethStatusBackend struct {
 	prometheusMetrics        *metrics.Server
 	sentryDSN                string
 
-	logger *zap.Logger
+	logger      *zap.Logger
 	preLoginLog *logutils.PreLoginLog
 }
 
@@ -116,7 +116,7 @@ type GethStatusBackend struct {
 func NewGethStatusBackend(logger *zap.Logger) *GethStatusBackend {
 	logger = logger.Named("GethStatusBackend")
 	backend := &GethStatusBackend{
-		logger: logger,
+		logger:      logger,
 		preLoginLog: logutils.NewPreLoginLog(),
 	}
 	backend.initialize()

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -15,7 +15,7 @@ func SetupLogging(logLevel *string, logWithoutColors *bool, config *params.NodeC
 		config.LogLevel = *logLevel
 	}
 
-	logSettings := config.DefaultLogSettings()
+	logSettings := config.ProfileLogSettings()
 	logSettings.Colorized = !(*logWithoutColors) && terminal.IsTerminal(int(os.Stdin.Fd()))
 	if err := logutils.OverrideRootLoggerWithConfig(logSettings); err != nil {
 		stdlog.Fatalf("Error initializing logger: %v", err)

--- a/common/utils.go
+++ b/common/utils.go
@@ -142,10 +142,6 @@ func TruncateWithDot(s string) string {
 	return TruncateWithDotN(s, DefaultTruncateLength)
 }
 
-func StrPtr(s string) *string {
-	return &s
-}
-
-func BoolPtr(b bool) *bool {
-	return &b
+func Ptr[T any](v T) *T {
+	return &v
 }

--- a/common/utils.go
+++ b/common/utils.go
@@ -141,3 +141,11 @@ func TruncateWithDotN(s string, n int) string {
 func TruncateWithDot(s string) string {
 	return TruncateWithDotN(s, DefaultTruncateLength)
 }
+
+func StrPtr(s string) *string {
+	return &s
+}
+
+func BoolPtr(b bool) *bool {
+	return &b
+}

--- a/logutils/geth_adapter.go
+++ b/logutils/geth_adapter.go
@@ -14,7 +14,7 @@ import (
 // Logs are forwarded raw as if geth were printing them.
 func gethAdapter(logger *zap.Logger) log.Handler {
 	return log.FuncHandler(func(r *log.Record) error {
-		level, err := lvlFromString(r.Lvl.String())
+		level, err := LvlFromString(r.Lvl.String())
 		if err != nil {
 			return err
 		}
@@ -30,8 +30,8 @@ func gethAdapter(logger *zap.Logger) log.Handler {
 
 const traceLevel = zapcore.DebugLevel - 1
 
-// lvlFromString returns the appropriate zapcore.Level from a string.
-func lvlFromString(lvlString string) (zapcore.Level, error) {
+// LvlFromString returns the appropriate zapcore.Level from a string.
+func LvlFromString(lvlString string) (zapcore.Level, error) {
 	switch strings.ToLower(lvlString) {
 	case "trace", "trce":
 		return traceLevel, nil // zap does not have a trace level, use custom

--- a/logutils/namespaces_tree.go
+++ b/logutils/namespaces_tree.go
@@ -103,7 +103,7 @@ func (t *namespacesTree) Rebuild(namespaces string) error {
 			return errInvalidNamespacesFormat
 		}
 
-		lvl, err := lvlFromString(parts[1])
+		lvl, err := LvlFromString(parts[1])
 		if err != nil {
 			return err
 		}

--- a/logutils/override.go
+++ b/logutils/override.go
@@ -35,7 +35,7 @@ func overrideCoreWithConfig(filteringCore *namespaceFilteringCore, settings LogS
 	if settings.Level == "" {
 		settings.Level = "info"
 	}
-	level, err := lvlFromString(settings.Level)
+	level, err := LvlFromString(settings.Level)
 	if err != nil {
 		return err
 	}

--- a/logutils/pre_login_log.go
+++ b/logutils/pre_login_log.go
@@ -1,13 +1,12 @@
 package logutils
 
 import (
-	"errors"
 	"path/filepath"
 )
 
-const(
-	defaultPreLoginLogFile  = "pre_login.log"
-	defaultPreLoginLogLevel = "ERROR"
+const (
+	defaultPreLoginLogFile    = "pre_login.log"
+	defaultPreLoginLogLevel   = "ERROR"
 	defaultPreLoginLogEnabled = true
 )
 
@@ -30,13 +29,11 @@ func (l *PreLoginLog) SetEnabled(enabled bool) {
 }
 
 func (l *PreLoginLog) SetLevel(level string) error {
-	switch level {
-	case "ERROR", "WARN", "INFO", "DEBUG", "TRACE":
-		l.level = level
-		return nil
-	default:
-		return errors.New("invalid log level")
+	if _, err := LvlFromString(level); err != nil {
+		return err
 	}
+	l.level = level
+	return nil
 }
 
 func (l *PreLoginLog) SetLogDir(dir string) {
@@ -46,8 +43,8 @@ func (l *PreLoginLog) SetLogDir(dir string) {
 func (l *PreLoginLog) Settings() LogSettings {
 	logFile := filepath.Join(l.logDir, defaultPreLoginLogFile)
 	return LogSettings{
-		Enabled:         l.enabled,
-		Level:           l.level,
-		File:            logFile,
+		Enabled: l.enabled,
+		Level:   l.level,
+		File:    logFile,
 	}
 }

--- a/logutils/pre_login_log.go
+++ b/logutils/pre_login_log.go
@@ -1,0 +1,53 @@
+package logutils
+
+import (
+	"errors"
+	"path/filepath"
+)
+
+const(
+	defaultPreLoginLogFile  = "pre_login.log"
+	defaultPreLoginLogLevel = "ERROR"
+	defaultPreLoginLogEnabled = true
+)
+
+type PreLoginLog struct {
+	enabled bool
+	level   string
+	// absolute path to the log directory, it should be the same as node config's logDir
+	logDir string
+}
+
+func NewPreLoginLog() *PreLoginLog {
+	return &PreLoginLog{
+		enabled: defaultPreLoginLogEnabled,
+		level:   defaultPreLoginLogLevel,
+	}
+}
+
+func (l *PreLoginLog) SetEnabled(enabled bool) {
+	l.enabled = enabled
+}
+
+func (l *PreLoginLog) SetLevel(level string) error {
+	switch level {
+	case "ERROR", "WARN", "INFO", "DEBUG", "TRACE":
+		l.level = level
+		return nil
+	default:
+		return errors.New("invalid log level")
+	}
+}
+
+func (l *PreLoginLog) SetLogDir(dir string) {
+	l.logDir = dir
+}
+
+func (l *PreLoginLog) Settings() LogSettings {
+	logFile := filepath.Join(l.logDir, defaultPreLoginLogFile)
+	return LogSettings{
+		Enabled:         l.enabled,
+		Level:           l.level,
+		File:            logFile,
+	}
+}

--- a/logutils/pre_login_log.go
+++ b/logutils/pre_login_log.go
@@ -10,25 +10,25 @@ const (
 	defaultPreLoginLogEnabled = true
 )
 
-type PreLoginLog struct {
+type PreLoginLogConfig struct {
 	enabled bool
 	level   string
 	// absolute path to the log directory, it should be the same as node config's logDir
 	logDir string
 }
 
-func NewPreLoginLog() *PreLoginLog {
-	return &PreLoginLog{
+func NewPreLoginLogConfig() *PreLoginLogConfig {
+	return &PreLoginLogConfig{
 		enabled: defaultPreLoginLogEnabled,
 		level:   defaultPreLoginLogLevel,
 	}
 }
 
-func (l *PreLoginLog) SetEnabled(enabled bool) {
+func (l *PreLoginLogConfig) SetEnabled(enabled bool) {
 	l.enabled = enabled
 }
 
-func (l *PreLoginLog) SetLevel(level string) error {
+func (l *PreLoginLogConfig) SetLevel(level string) error {
 	if _, err := LvlFromString(level); err != nil {
 		return err
 	}
@@ -36,11 +36,11 @@ func (l *PreLoginLog) SetLevel(level string) error {
 	return nil
 }
 
-func (l *PreLoginLog) SetLogDir(dir string) {
+func (l *PreLoginLogConfig) SetLogDir(dir string) {
 	l.logDir = dir
 }
 
-func (l *PreLoginLog) Settings() LogSettings {
+func (l *PreLoginLogConfig) ConvertToLogSettings() LogSettings {
 	logFile := filepath.Join(l.logDir, defaultPreLoginLogFile)
 	return LogSettings{
 		Enabled: l.enabled,

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -174,7 +174,7 @@ func initializeLogging(request *requests.InitializeApplication) error {
 
 	preLoginLog.SetLogDir(request.LogDir)
 
-	logSettings := preLoginLog.Settings()
+	logSettings := preLoginLog.ConvertToLogSettings()
 	err = logutils.OverrideRootLoggerWithConfig(logSettings)
 	if err != nil {
 		return err

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -181,7 +181,7 @@ func initializeLogging(request *requests.InitializeApplication) error {
 	}
 
 	logutils.ZapLogger().Info("logging initialised",
-		zap.Any("pre-login logSettings", logSettings),
+		zap.Any("logSettings", logSettings),
 		zap.Bool("APILoggingEnabled", request.APILoggingEnabled),
 	)
 

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -160,14 +160,11 @@ func initializeLogging(request *requests.InitializeApplication) error {
 		request.LogDir = request.DataDir
 	}
 
-	if request.LogLevel == "" {
-		request.LogLevel = params.DefaultPreLoginLogLevel
-	}
-
-	logSettings := logutils.LogSettings{
-		Enabled: true, // always enable pre-login logging
-		Level:   request.LogLevel,
-		File:    path.Join(request.LogDir, params.DefaultPreLoginLogFile),
+	preLoginLog := statusBackend.PreLoginLog()
+	preLoginLog.SetEnabled(request.LogEnabled)
+	if request.LogLevel != "" {
+		// ignore the error since it's already validated
+		_ = preLoginLog.SetLevel(request.LogLevel)
 	}
 
 	err := os.MkdirAll(request.LogDir, 0700)
@@ -175,13 +172,16 @@ func initializeLogging(request *requests.InitializeApplication) error {
 		return err
 	}
 
+	preLoginLog.SetLogDir(request.LogDir)
+
+	logSettings := preLoginLog.Settings()
 	err = logutils.OverrideRootLoggerWithConfig(logSettings)
 	if err != nil {
 		return err
 	}
 
 	logutils.ZapLogger().Info("logging initialised",
-		zap.Any("logSettings", logSettings),
+		zap.Any("pre-login logSettings", logSettings),
 		zap.Bool("APILoggingEnabled", request.APILoggingEnabled),
 	)
 
@@ -2337,11 +2337,16 @@ func addCentralizedMetric(requestJSON string) string {
 	return metric.ID
 }
 
+// Deprecated: Use SetProfileLogLevel instead.
 func SetLogLevel(requestJSON string) string {
-	return callWithResponse(setLogLevel, requestJSON)
+	return callWithResponse(setProfileLogLevel, requestJSON)
 }
 
-func setLogLevel(requestJSON string) string {
+func SetProfileLogLevel(requestJSON string) string {
+	return callWithResponse(setProfileLogLevel, requestJSON)
+}
+
+func setProfileLogLevel(requestJSON string) string {
 	var request requests.SetLogLevel
 	err := json.Unmarshal([]byte(requestJSON), &request)
 	if err != nil {
@@ -2353,7 +2358,7 @@ func setLogLevel(requestJSON string) string {
 		return makeJSONResponse(err)
 	}
 
-	return makeJSONResponse(statusBackend.SetLogLevel(request.LogLevel))
+	return makeJSONResponse(statusBackend.SetProfileLogLevel(request.LogLevel))
 }
 
 func SetLogNamespaces(requestJSON string) string {
@@ -2375,18 +2380,54 @@ func setLogNamespaces(requestJSON string) string {
 	return makeJSONResponse(statusBackend.SetLogNamespaces(request.LogNamespaces))
 }
 
+// Deprecated: Use SetProfileLogEnabled instead.
 func SetLogEnabled(requestJSON string) string {
-	return callWithResponse(setLogEnabled, requestJSON)
+	return callWithResponse(setProfileLogEnabled, requestJSON)
 }
 
-func setLogEnabled(requestJSON string) string {
+func SetProfileLogEnabled(requestJSON string) string {
+	return callWithResponse(setProfileLogEnabled, requestJSON)
+}
+
+func setProfileLogEnabled(requestJSON string) string {
 	var request requests.SetLogEnabled
 	err := json.Unmarshal([]byte(requestJSON), &request)
 	if err != nil {
 		return makeJSONResponse(err)
 	}
+	return makeJSONResponse(statusBackend.SetProfileLogEnabled(request.Enabled))
+}
 
-	return makeJSONResponse(statusBackend.SetLogEnabled(request.Enabled))
+func SetPreLoginLogEnabled(requestJSON string) string {
+	return callWithResponse(setPreLoginLogEnabled, requestJSON)
+}
+
+func setPreLoginLogEnabled(requestJSON string) string {
+	var request requests.SetLogEnabled
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+	return makeJSONResponse(statusBackend.SetPreLoginLogEnabled(request.Enabled))
+}
+
+func SetPreLoginLogLevel(requestJSON string) string {
+	return callWithResponse(setPreLoginLogLevel, requestJSON)
+}
+
+func setPreLoginLogLevel(requestJSON string) string {
+	var request requests.SetLogLevel
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = request.Validate()
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	return makeJSONResponse(statusBackend.SetPreLoginLogLevel(request.LogLevel))
 }
 
 func IntendedPanic(message string) string {

--- a/params/config.go
+++ b/params/config.go
@@ -1060,28 +1060,12 @@ func (c *NodeConfig) LogFilePath() string {
 	return filepath.Join(c.LogDir, c.LogFile)
 }
 
-func (c *NodeConfig) DefaultLogSettings() logutils.LogSettings {
+func (c *NodeConfig) ProfileLogSettings() logutils.LogSettings {
 	return logutils.LogSettings{
 		Enabled:         c.LogEnabled,
 		Level:           c.LogLevel,
 		Namespaces:      c.LogNamespaces,
 		File:            c.LogFilePath(),
-		MaxSize:         c.LogMaxSize,
-		MaxBackups:      c.LogMaxBackups,
-		CompressRotated: c.LogCompressRotated,
-	}
-}
-
-func (c *NodeConfig) PreLoginLogSettings() logutils.LogSettings {
-	logFile := filepath.Join(c.LogDir, DefaultPreLoginLogFile)
-	if c.LogLevel == "" {
-		c.LogLevel = DefaultPreLoginLogLevel
-	}
-	return logutils.LogSettings{
-		Enabled:         true,
-		Level:           c.LogLevel,
-		Namespaces:      c.LogNamespaces,
-		File:            logFile,
 		MaxSize:         c.LogMaxSize,
 		MaxBackups:      c.LogMaxBackups,
 		CompressRotated: c.LogCompressRotated,

--- a/params/defaults.go
+++ b/params/defaults.go
@@ -83,9 +83,6 @@ const (
 
 	// IpfsGatewayURL is the Gateway URL to use for IPFS
 	IpfsGatewayURL = "https://ipfs.status.im/"
-
-	DefaultPreLoginLogFile  = "pre_login.log"
-	DefaultPreLoginLogLevel = "ERROR"
 )
 
 var (

--- a/protocol/requests/initialize_application.go
+++ b/protocol/requests/initialize_application.go
@@ -2,6 +2,7 @@ package requests
 
 import (
 	"errors"
+
 	"github.com/status-im/status-go/logutils"
 )
 
@@ -41,7 +42,7 @@ func (i *InitializeApplication) Validate() error {
 		return ErrInitializeApplicationInvalidDataDir
 	}
 	if i.LogLevel != "" {
-		if _,err := logutils.LvlFromString(i.LogLevel); err != nil {
+		if _, err := logutils.LvlFromString(i.LogLevel); err != nil {
 			return err
 		}
 	}

--- a/protocol/requests/initialize_application.go
+++ b/protocol/requests/initialize_application.go
@@ -2,6 +2,8 @@ package requests
 
 import (
 	"errors"
+
+	"gopkg.in/go-playground/validator.v9"
 )
 
 var (
@@ -20,8 +22,10 @@ type InitializeApplication struct {
 	// If empty, logs are stored in the `DataDir`.
 	LogDir string `json:"logDir"`
 
-	LogEnabled        bool   `json:"logEnabled"`
-	LogLevel          string `json:"logLevel"`
+	// Specify if enable Pre-Login Log
+	LogEnabled bool `json:"logEnabled"`
+	// Specify the Pre-Login log level
+	LogLevel          string `json:"logLevel" validate:"omitempty,eq=ERROR|eq=WARN|eq=INFO|eq=DEBUG|eq=TRACE"`
 	APILoggingEnabled bool   `json:"apiLoggingEnabled"`
 
 	MetricsEnabled bool   `json:"metricsEnabled"`
@@ -37,5 +41,5 @@ func (i *InitializeApplication) Validate() error {
 	if len(i.DataDir) == 0 {
 		return ErrInitializeApplicationInvalidDataDir
 	}
-	return nil
+	return validator.New().Struct(i)
 }

--- a/protocol/requests/initialize_application.go
+++ b/protocol/requests/initialize_application.go
@@ -2,8 +2,7 @@ package requests
 
 import (
 	"errors"
-
-	"gopkg.in/go-playground/validator.v9"
+	"github.com/status-im/status-go/logutils"
 )
 
 var (
@@ -25,7 +24,7 @@ type InitializeApplication struct {
 	// Specify if enable Pre-Login Log
 	LogEnabled bool `json:"logEnabled"`
 	// Specify the Pre-Login log level
-	LogLevel          string `json:"logLevel" validate:"omitempty,eq=ERROR|eq=WARN|eq=INFO|eq=DEBUG|eq=TRACE"`
+	LogLevel          string `json:"logLevel"`
 	APILoggingEnabled bool   `json:"apiLoggingEnabled"`
 
 	MetricsEnabled bool   `json:"metricsEnabled"`
@@ -41,5 +40,10 @@ func (i *InitializeApplication) Validate() error {
 	if len(i.DataDir) == 0 {
 		return ErrInitializeApplicationInvalidDataDir
 	}
-	return validator.New().Struct(i)
+	if i.LogLevel != "" {
+		if _,err := logutils.LvlFromString(i.LogLevel); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/protocol/requests/initialize_application_test.go
+++ b/protocol/requests/initialize_application_test.go
@@ -1,8 +1,9 @@
 package requests
 
 import (
-	"github.com/status-im/status-go/common"
 	"testing"
+
+	"github.com/status-im/status-go/common"
 )
 
 func TestInitializeApplication_Validate(t *testing.T) {
@@ -76,8 +77,8 @@ func TestInitializeApplication_Validate(t *testing.T) {
 		{
 			name: "All valid log levels",
 			app: InitializeApplication{
-				DataDir:          "/valid/path",
-				LogLevel:         "ERROR",
+				DataDir:  "/valid/path",
+				LogLevel: "ERROR",
 			},
 			wantErr: false,
 		},
@@ -87,7 +88,7 @@ func TestInitializeApplication_Validate(t *testing.T) {
 				DataDir:              "/valid/path",
 				MixpanelAppID:        "app-id",
 				MixpanelToken:        "token",
-				MediaServerEnableTLS: common.BoolPtr(true),
+				MediaServerEnableTLS: common.Ptr(true),
 				SentryDSN:            "sentry-dsn",
 				LogDir:               "/logs/path",
 				LogEnabled:           true,

--- a/protocol/requests/initialize_application_test.go
+++ b/protocol/requests/initialize_application_test.go
@@ -1,0 +1,117 @@
+package requests
+
+import (
+	"github.com/status-im/status-go/common"
+	"testing"
+)
+
+func TestInitializeApplication_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		app     InitializeApplication
+		wantErr bool
+		errType error
+	}{
+		{
+			name: "Valid with minimum required fields",
+			app: InitializeApplication{
+				DataDir: "/valid/path",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Missing DataDir",
+			app:     InitializeApplication{},
+			wantErr: true,
+			errType: ErrInitializeApplicationInvalidDataDir,
+		},
+		{
+			name: "Invalid LogLevel",
+			app: InitializeApplication{
+				DataDir:  "/valid/path",
+				LogLevel: "INVALID",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Valid LogLevel - ERROR",
+			app: InitializeApplication{
+				DataDir:  "/valid/path",
+				LogLevel: "ERROR",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid LogLevel - WARN",
+			app: InitializeApplication{
+				DataDir:  "/valid/path",
+				LogLevel: "WARN",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid LogLevel - INFO",
+			app: InitializeApplication{
+				DataDir:  "/valid/path",
+				LogLevel: "INFO",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid LogLevel - DEBUG",
+			app: InitializeApplication{
+				DataDir:  "/valid/path",
+				LogLevel: "DEBUG",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid LogLevel - TRACE",
+			app: InitializeApplication{
+				DataDir:  "/valid/path",
+				LogLevel: "TRACE",
+			},
+			wantErr: false,
+		},
+		{
+			name: "All valid log levels",
+			app: InitializeApplication{
+				DataDir:          "/valid/path",
+				LogLevel:         "ERROR",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Full configuration with valid values",
+			app: InitializeApplication{
+				DataDir:              "/valid/path",
+				MixpanelAppID:        "app-id",
+				MixpanelToken:        "token",
+				MediaServerEnableTLS: common.BoolPtr(true),
+				SentryDSN:            "sentry-dsn",
+				LogDir:               "/logs/path",
+				LogEnabled:           true,
+				LogLevel:             "INFO",
+				APILoggingEnabled:    true,
+				MetricsEnabled:       true,
+				MetricsAddress:       "localhost:8545",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.app.Validate()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.errType != nil && err != tt.errType {
+				t.Errorf("Validate() error type = %v, want %v", err, tt.errType)
+			}
+		})
+	}
+}

--- a/protocol/requests/set_log_level.go
+++ b/protocol/requests/set_log_level.go
@@ -9,7 +9,7 @@ type SetLogLevel struct {
 }
 
 func (c *SetLogLevel) Validate() error {
-	if _,err := logutils.LvlFromString(c.LogLevel); err != nil {
+	if _, err := logutils.LvlFromString(c.LogLevel); err != nil {
 		return err
 	}
 	return nil

--- a/protocol/requests/set_log_level.go
+++ b/protocol/requests/set_log_level.go
@@ -1,28 +1,16 @@
 package requests
 
 import (
-	"errors"
+	"github.com/status-im/status-go/logutils"
 )
-
-const (
-	ErrorLogLevel = "ERROR"
-	WarnLogLevel  = "WARN"
-	InfoLogLevel  = "INFO"
-	DebugLogLevel = "DEBUG"
-	TraceLogLevel = "TRACE"
-)
-
-var ErrSetLogLevelInvalidLogLevel = errors.New("set-log-level: invalid log level")
 
 type SetLogLevel struct {
 	LogLevel string `json:"logLevel"`
 }
 
 func (c *SetLogLevel) Validate() error {
-	switch c.LogLevel {
-	case ErrorLogLevel, WarnLogLevel, InfoLogLevel, DebugLogLevel, TraceLogLevel:
-		return nil
+	if _,err := logutils.LvlFromString(c.LogLevel); err != nil {
+		return err
 	}
-
-	return ErrSetLogLevelInvalidLogLevel
+	return nil
 }

--- a/server/pairing/raw_message_handler.go
+++ b/server/pairing/raw_message_handler.go
@@ -131,7 +131,7 @@ func (s *SyncRawMessageHandler) HandleRawMessage(
 func (s *SyncRawMessageHandler) login(accountPayload *AccountPayload, createAccountRequest *requests.CreateAccount, rmp *RawMessagesPayload) error {
 	account := accountPayload.multiaccount
 	installationID := multidevice.GenerateInstallationID()
-	nodeConfig, err := api.DefaultNodeConfig(installationID, createAccountRequest)
+	nodeConfig, err := api.DefaultNodeConfig(installationID, account.KeyUID, createAccountRequest)
 	if err != nil {
 		return err
 	}

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -251,7 +251,9 @@ class StatusBackend(RpcClient, SignalClient):
 
     def extract_data(self, path: str):
         if not self.container:
-            return path
+            if os.path.exists(path):
+                return path
+            return None
 
         try:
             stream, _ = self.container.get_archive(path)

--- a/tests-functional/tests/test_init_status_app.py
+++ b/tests-functional/tests/test_init_status_app.py
@@ -54,7 +54,7 @@ def assert_file_first_line(path, pattern: str, expected: bool):
 
 @pytest.mark.rpc
 @pytest.mark.init
-@pytest.mark.parametrize("log_enabled,api_logging_enabled", [(True, True), (False, False)])
+@pytest.mark.parametrize("log_enabled,api_logging_enabled", [(False, False), (True, True)])
 def test_check_logs(log_enabled: bool, api_logging_enabled: bool):
     backend = StatusBackend()
 
@@ -75,7 +75,7 @@ def test_check_logs(log_enabled: bool, api_logging_enabled: bool):
     pre_login_log = backend.extract_data(os.path.join(logs_dir, "pre_login.log"))
     local_api_log = backend.extract_data(os.path.join(logs_dir, "api.log"))
 
-    assert_file_first_line(path=pre_login_log, pattern="logging initialised", expected=True)
+    assert_file_first_line(path=pre_login_log, pattern="logging initialised", expected=log_enabled)
 
     assert_file_first_line(
         path=local_api_log,

--- a/tests-functional/tests/test_logging.py
+++ b/tests-functional/tests/test_logging.py
@@ -1,3 +1,4 @@
+from resources.constants import USER_DIR
 import re
 from clients.status_backend import StatusBackend
 import pytest
@@ -39,32 +40,34 @@ class TestLogging:
             r"ERROR\s+test1\.test2\.test3\s+",
         ]
 
-        log_path = os.path.join(backend_client.data_dir, "geth.log")
-
+        key_uid = str(backend_client.find_key_uid())
+        formatted_key_uid = f"{key_uid[:4]}..{key_uid[-4:]}"
+        profile_log_file_name = f"{formatted_key_uid}.log"
+        log_path = os.path.join(backend_client.data_dir, profile_log_file_name)
         # Ensure changes take effect at runtime
         backend_client.rpc_valid_request("wakuext_logTest")
-        geth_log = backend_client.extract_data(log_path)
-        self.expect_logs(geth_log, "test message", log_pattern, count=1)
+        profile_log = backend_client.extract_data(log_path)
+        self.expect_logs(profile_log, "test message", log_pattern, count=1)
 
         # Disable logging
         backend_client.api_valid_request("SetLogEnabled", {"enabled": False})
         backend_client.rpc_valid_request("wakuext_logTest")
-        geth_log = backend_client.extract_data(log_path)
-        self.expect_logs(geth_log, "test message", log_pattern, count=1)
+        profile_log = backend_client.extract_data(log_path)
+        self.expect_logs(profile_log, "test message", log_pattern, count=1)
 
         # Enable logging
         backend_client.api_valid_request("SetLogEnabled", {"enabled": True})
         backend_client.rpc_valid_request("wakuext_logTest")
-        geth_log = backend_client.extract_data(log_path)
+        profile_log = backend_client.extract_data(log_path)
         self.expect_logs(geth_log, "test message", log_pattern, count=2)
 
         # Ensure changes are persisted after re-login
         backend_client.logout()
-        backend_client.login(str(backend_client.find_key_uid()))
+        backend_client.login(key_uid)
         backend_client.wait_for_login()
         backend_client.rpc_valid_request("wakuext_logTest")
-        geth_log = backend_client.extract_data(log_path)
-        self.expect_logs(geth_log, "test message", log_pattern, count=3)
+        profile_log = backend_client.extract_data(log_path)
+        self.expect_logs(profile_log, "test message", log_pattern, count=3)
 
     def expect_logs(self, log_file, filter_keyword, expected_logs, count):
         with open(log_file, "r") as f:

--- a/tests-functional/tests/test_logging.py
+++ b/tests-functional/tests/test_logging.py
@@ -1,4 +1,3 @@
-from resources.constants import USER_DIR
 import re
 from clients.status_backend import StatusBackend
 import pytest
@@ -59,7 +58,7 @@ class TestLogging:
         backend_client.api_valid_request("SetLogEnabled", {"enabled": True})
         backend_client.rpc_valid_request("wakuext_logTest")
         profile_log = backend_client.extract_data(log_path)
-        self.expect_logs(geth_log, "test message", log_pattern, count=2)
+        self.expect_logs(profile_log, "test message", log_pattern, count=2)
 
         # Ensure changes are persisted after re-login
         backend_client.logout()


### PR DESCRIPTION
Major changes:
- add endpoints that support configuring pre-login log
- implemented log per profile

this PR could help solving [mobile issue](https://github.com/status-im/status-mobile/issues/22321)

frontend have to handle persistence of saving pre-login log setting themself. For mobile, maybe we can use `async-storage`? @ilmotta 

the profile log file name will be like `truncate(keyUID)`+".log", pls see the screenshot that shows the new profile log file name.
<img width="658" alt="image" src="https://github.com/user-attachments/assets/0d944605-b316-471e-a019-e235a105399a" />

to avoid making the changes as breaking change for mobile, I've draft a mobile [PR](https://github.com/status-im/status-mobile/pull/22342) , the mobile PR has to be merged before this PR. I'm not sure if it's a break change for desktop, could you help check? thanks in advance! @igor-sirotin 

status: ready to review.