### PR TITLE
chore_: increase timeout for rpc tests to the same we have for golang…

### DIFF
--- a/_assets/ci/Jenkinsfile.tests-rpc
+++ b/_assets/ci/Jenkinsfile.tests-rpc
@@ -20,7 +20,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 30, unit: 'MINUTES')
+    timeout(time: 50, unit: 'MINUTES')
     disableConcurrentBuilds()
     /* manage how many builds we keep */
     buildDiscarder(logRotator(


### PR DESCRIPTION
… tests

The run time for rpc tests seems to have increased. Previous runtimes were in the 20-25 min range, and now we're in the 30~ min range. 30 min is the current limit, causing the job to be sometimes cancelled.

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/f915920e-0056-4446-bbea-d46e47eff0fe" />

The most likely culprit is the introduction of https://github.com/status-im/status-go/pull/6168/commits/d4a116ef4ef0fd9babcfb39b820ac8632eeeddfc which makes some changes to how the contracts are deployed to Anvil.

I'll look for a way to reduce the run time again, but in the meantime I'm increasing the timeout to what the unit tests use, since the rpc tests job is still shorter than the unit tests job (~40 min) anyway so it's not the limiting factor.

<img width="1313" alt="image" src="https://github.com/user-attachments/assets/4b7abd5a-30df-4e33-84c4-d4d0bddd168f" />

