### PR TITLE
test_: Tests for wakuext messages 6

### DIFF
--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -206,3 +206,8 @@ class WakuextService(Service):
         params = [message_id, new_status]
         response = self.rpc_request("updateMessageOutgoingStatus", params)
         return response.json()
+
+    def request_transaction(self, chat_id: str, value: str, contract: str, address: str):
+        params = [chat_id, value, contract, address]
+        response = self.rpc_request("requestTransaction", params)
+        return response.json()

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -216,3 +216,13 @@ class WakuextService(Service):
         params = [message_id]
         response = self.rpc_request("declineRequestTransaction", params)
         return response.json()
+
+    def request_address_for_transaction(self, chat_id: str, address_from: str, value: str, contract: str):
+        params = [chat_id, address_from, value, contract]
+        response = self.rpc_request("requestAddressForTransaction", params)
+        return response.json()
+
+    def decline_request_address_for_transaction(self, message_id: str):
+        params = [message_id]
+        response = self.rpc_request("declineRequestAddressForTransaction", params)
+        return response.json()

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -217,6 +217,11 @@ class WakuextService(Service):
         response = self.rpc_request("declineRequestTransaction", params)
         return response.json()
 
+    def accept_request_transaction(self, transactionHash: str, message_id: str, signature: str):
+        params = [transactionHash, message_id, signature]
+        response = self.rpc_request("acceptRequestTransaction", params)
+        return response.json()
+
     def request_address_for_transaction(self, chat_id: str, address_from: str, value: str, contract: str):
         params = [chat_id, address_from, value, contract]
         response = self.rpc_request("requestAddressForTransaction", params)
@@ -225,4 +230,9 @@ class WakuextService(Service):
     def decline_request_address_for_transaction(self, message_id: str):
         params = [message_id]
         response = self.rpc_request("declineRequestAddressForTransaction", params)
+        return response.json()
+
+    def send_transaction(self, chat_id: str, value: str, contract: str, transactionHash: str, signature: str):
+        params = [chat_id, value, contract, transactionHash, signature]
+        response = self.rpc_request("sendTransaction", params)
         return response.json()

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -211,3 +211,8 @@ class WakuextService(Service):
         params = [chat_id, value, contract, address]
         response = self.rpc_request("requestTransaction", params)
         return response.json()
+
+    def decline_request_transaction(self, message_id: str):
+        params = [message_id]
+        response = self.rpc_request("declineRequestTransaction", params)
+        return response.json()

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -232,6 +232,11 @@ class WakuextService(Service):
         response = self.rpc_request("declineRequestAddressForTransaction", params)
         return response.json()
 
+    def accept_request_address_for_transaction(self, message_id: str, address: str):
+        params = [message_id, address]
+        response = self.rpc_request("acceptRequestAddressForTransaction", params)
+        return response.json()
+
     def send_transaction(self, chat_id: str, value: str, contract: str, transactionHash: str, signature: str):
         params = [chat_id, value, contract, transactionHash, signature]
         response = self.rpc_request("sendTransaction", params)

--- a/tests-functional/schemas/wakuext_acceptRequestTransaction
+++ b/tests-functional/schemas/wakuext_acceptRequestTransaction
@@ -1,0 +1,488 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "properties": {
+                "chats": {
+                    "items": {
+                        "properties": {
+                            "ReadMessagesAtClockValue": {
+                                "type": "integer"
+                            },
+                            "active": {
+                                "type": "boolean"
+                            },
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatType": {
+                                "type": "integer"
+                            },
+                            "color": {
+                                "type": "string"
+                            },
+                            "deletedAtClockValue": {
+                                "type": "integer"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "emoji": {
+                                "type": "string"
+                            },
+                            "highlight": {
+                                "type": "boolean"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "joined": {
+                                "type": "integer"
+                            },
+                            "lastClockValue": {
+                                "type": "integer"
+                            },
+                            "lastMessage": {
+                                "properties": {
+                                    "alias": {
+                                        "type": "string"
+                                    },
+                                    "chatId": {
+                                        "type": "string"
+                                    },
+                                    "clock": {
+                                        "type": "integer"
+                                    },
+                                    "commandParameters": {
+                                        "properties": {
+                                            "address": {
+                                                "type": "string"
+                                            },
+                                            "commandState": {
+                                                "type": "integer"
+                                            },
+                                            "contract": {
+                                                "type": "string"
+                                            },
+                                            "from": {
+                                                "type": "string"
+                                            },
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "signature": {
+                                                "type": "string"
+                                            },
+                                            "transactionHash": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "address",
+                                            "commandState",
+                                            "contract",
+                                            "from",
+                                            "id",
+                                            "signature",
+                                            "transactionHash",
+                                            "value"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "compressedKey": {
+                                        "type": "string"
+                                    },
+                                    "contentType": {
+                                        "type": "integer"
+                                    },
+                                    "displayName": {
+                                        "type": "string"
+                                    },
+                                    "emojiHash": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "ensName": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "gapParameters": {
+                                        "type": "object"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "identicon": {
+                                        "type": "string"
+                                    },
+                                    "lineCount": {
+                                        "type": "integer"
+                                    },
+                                    "localChatId": {
+                                        "type": "string"
+                                    },
+                                    "messageType": {
+                                        "type": "integer"
+                                    },
+                                    "outgoingStatus": {
+                                        "type": "string"
+                                    },
+                                    "parsedText": {
+                                        "items": {
+                                            "properties": {
+                                                "children": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "literal": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "literal"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "children",
+                                                "type"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "quotedMessage": {
+                                        "type": "null"
+                                    },
+                                    "replace": {
+                                        "type": "string"
+                                    },
+                                    "responseTo": {
+                                        "type": "string"
+                                    },
+                                    "rtl": {
+                                        "type": "boolean"
+                                    },
+                                    "seen": {
+                                        "type": "boolean"
+                                    },
+                                    "text": {
+                                        "type": "string"
+                                    },
+                                    "timestamp": {
+                                        "type": "integer"
+                                    },
+                                    "whisperTimestamp": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "alias",
+                                    "chatId",
+                                    "clock",
+                                    "commandParameters",
+                                    "compressedKey",
+                                    "contentType",
+                                    "displayName",
+                                    "emojiHash",
+                                    "ensName",
+                                    "from",
+                                    "gapParameters",
+                                    "id",
+                                    "identicon",
+                                    "lineCount",
+                                    "localChatId",
+                                    "messageType",
+                                    "outgoingStatus",
+                                    "parsedText",
+                                    "quotedMessage",
+                                    "replace",
+                                    "responseTo",
+                                    "rtl",
+                                    "seen",
+                                    "text",
+                                    "timestamp",
+                                    "whisperTimestamp"
+                                ],
+                                "type": "object"
+                            },
+                            "members": {
+                                "type": "null"
+                            },
+                            "membershipUpdateEvents": {
+                                "type": "null"
+                            },
+                            "muteTill": {
+                                "type": "string"
+                            },
+                            "muted": {
+                                "type": "boolean"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "unviewedMentionsCount": {
+                                "type": "integer"
+                            },
+                            "unviewedMessagesCount": {
+                                "type": "integer"
+                            },
+                            "viewersCanPostReactions": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "ReadMessagesAtClockValue",
+                            "active",
+                            "alias",
+                            "chatType",
+                            "color",
+                            "deletedAtClockValue",
+                            "description",
+                            "emoji",
+                            "highlight",
+                            "id",
+                            "identicon",
+                            "joined",
+                            "lastClockValue",
+                            "lastMessage",
+                            "members",
+                            "membershipUpdateEvents",
+                            "muteTill",
+                            "muted",
+                            "name",
+                            "timestamp",
+                            "unviewedMentionsCount",
+                            "unviewedMessagesCount",
+                            "viewersCanPostReactions"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "discordOldestMessageTimestamp": {
+                    "type": "integer"
+                },
+                "messages": {
+                    "items": {
+                        "properties": {
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatId": {
+                                "type": "string"
+                            },
+                            "clock": {
+                                "type": "integer"
+                            },
+                            "commandParameters": {
+                                "properties": {
+                                    "address": {
+                                        "type": "string"
+                                    },
+                                    "commandState": {
+                                        "type": "integer"
+                                    },
+                                    "contract": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "signature": {
+                                        "type": "string"
+                                    },
+                                    "transactionHash": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "address",
+                                    "commandState",
+                                    "contract",
+                                    "from",
+                                    "id",
+                                    "signature",
+                                    "transactionHash",
+                                    "value"
+                                ],
+                                "type": "object"
+                            },
+                            "compressedKey": {
+                                "type": "string"
+                            },
+                            "contentType": {
+                                "type": "integer"
+                            },
+                            "displayName": {
+                                "type": "string"
+                            },
+                            "emojiHash": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "ensName": {
+                                "type": "string"
+                            },
+                            "from": {
+                                "type": "string"
+                            },
+                            "gapParameters": {
+                                "type": "object"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "lineCount": {
+                                "type": "integer"
+                            },
+                            "localChatId": {
+                                "type": "string"
+                            },
+                            "messageType": {
+                                "type": "integer"
+                            },
+                            "outgoingStatus": {
+                                "type": "string"
+                            },
+                            "parsedText": {
+                                "items": {
+                                    "properties": {
+                                        "children": {
+                                            "items": {
+                                                "properties": {
+                                                    "literal": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "literal"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "children",
+                                        "type"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "quotedMessage": {
+                                "type": "null"
+                            },
+                            "replace": {
+                                "type": "string"
+                            },
+                            "responseTo": {
+                                "type": "string"
+                            },
+                            "rtl": {
+                                "type": "boolean"
+                            },
+                            "seen": {
+                                "type": "boolean"
+                            },
+                            "text": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "whisperTimestamp": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "alias",
+                            "chatId",
+                            "clock",
+                            "commandParameters",
+                            "compressedKey",
+                            "contentType",
+                            "displayName",
+                            "emojiHash",
+                            "ensName",
+                            "from",
+                            "gapParameters",
+                            "id",
+                            "identicon",
+                            "lineCount",
+                            "localChatId",
+                            "messageType",
+                            "outgoingStatus",
+                            "parsedText",
+                            "quotedMessage",
+                            "replace",
+                            "responseTo",
+                            "rtl",
+                            "seen",
+                            "text",
+                            "timestamp",
+                            "whisperTimestamp"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "notifications": {
+                    "type": "null"
+                }
+            },
+            "required": [
+                "chats",
+                "discordOldestMessageTimestamp",
+                "messages",
+                "notifications"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/schemas/wakuext_requestTransaction
+++ b/tests-functional/schemas/wakuext_requestTransaction
@@ -1,0 +1,480 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "properties": {
+                "chats": {
+                    "items": {
+                        "properties": {
+                            "ReadMessagesAtClockValue": {
+                                "type": "integer"
+                            },
+                            "active": {
+                                "type": "boolean"
+                            },
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatType": {
+                                "type": "integer"
+                            },
+                            "color": {
+                                "type": "string"
+                            },
+                            "deletedAtClockValue": {
+                                "type": "integer"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "emoji": {
+                                "type": "string"
+                            },
+                            "highlight": {
+                                "type": "boolean"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "joined": {
+                                "type": "integer"
+                            },
+                            "lastClockValue": {
+                                "type": "integer"
+                            },
+                            "lastMessage": {
+                                "properties": {
+                                    "alias": {
+                                        "type": "string"
+                                    },
+                                    "chatId": {
+                                        "type": "string"
+                                    },
+                                    "clock": {
+                                        "type": "integer"
+                                    },
+                                    "commandParameters": {
+                                        "properties": {
+                                            "address": {
+                                                "type": "string"
+                                            },
+                                            "commandState": {
+                                                "type": "integer"
+                                            },
+                                            "contract": {
+                                                "type": "string"
+                                            },
+                                            "from": {
+                                                "type": "string"
+                                            },
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "signature": {
+                                                "type": "null"
+                                            },
+                                            "transactionHash": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "address",
+                                            "commandState",
+                                            "contract",
+                                            "from",
+                                            "id",
+                                            "signature",
+                                            "transactionHash",
+                                            "value"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "compressedKey": {
+                                        "type": "string"
+                                    },
+                                    "contentType": {
+                                        "type": "integer"
+                                    },
+                                    "displayName": {
+                                        "type": "string"
+                                    },
+                                    "emojiHash": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "ensName": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "identicon": {
+                                        "type": "string"
+                                    },
+                                    "lineCount": {
+                                        "type": "integer"
+                                    },
+                                    "localChatId": {
+                                        "type": "string"
+                                    },
+                                    "messageType": {
+                                        "type": "integer"
+                                    },
+                                    "outgoingStatus": {
+                                        "type": "string"
+                                    },
+                                    "parsedText": {
+                                        "items": {
+                                            "properties": {
+                                                "children": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "literal": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "literal"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "children",
+                                                "type"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "quotedMessage": {
+                                        "type": "null"
+                                    },
+                                    "replace": {
+                                        "type": "string"
+                                    },
+                                    "responseTo": {
+                                        "type": "string"
+                                    },
+                                    "rtl": {
+                                        "type": "boolean"
+                                    },
+                                    "seen": {
+                                        "type": "boolean"
+                                    },
+                                    "text": {
+                                        "type": "string"
+                                    },
+                                    "timestamp": {
+                                        "type": "integer"
+                                    },
+                                    "whisperTimestamp": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "alias",
+                                    "chatId",
+                                    "clock",
+                                    "commandParameters",
+                                    "compressedKey",
+                                    "contentType",
+                                    "displayName",
+                                    "emojiHash",
+                                    "ensName",
+                                    "from",
+                                    "id",
+                                    "identicon",
+                                    "lineCount",
+                                    "localChatId",
+                                    "messageType",
+                                    "outgoingStatus",
+                                    "parsedText",
+                                    "quotedMessage",
+                                    "replace",
+                                    "responseTo",
+                                    "rtl",
+                                    "seen",
+                                    "text",
+                                    "timestamp",
+                                    "whisperTimestamp"
+                                ],
+                                "type": "object"
+                            },
+                            "members": {
+                                "type": "null"
+                            },
+                            "membershipUpdateEvents": {
+                                "type": "null"
+                            },
+                            "muteTill": {
+                                "type": "string"
+                            },
+                            "muted": {
+                                "type": "boolean"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "unviewedMentionsCount": {
+                                "type": "integer"
+                            },
+                            "unviewedMessagesCount": {
+                                "type": "integer"
+                            },
+                            "viewersCanPostReactions": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "ReadMessagesAtClockValue",
+                            "active",
+                            "alias",
+                            "chatType",
+                            "color",
+                            "deletedAtClockValue",
+                            "description",
+                            "emoji",
+                            "highlight",
+                            "id",
+                            "identicon",
+                            "joined",
+                            "lastClockValue",
+                            "lastMessage",
+                            "members",
+                            "membershipUpdateEvents",
+                            "muteTill",
+                            "muted",
+                            "name",
+                            "timestamp",
+                            "unviewedMentionsCount",
+                            "unviewedMessagesCount",
+                            "viewersCanPostReactions"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "discordOldestMessageTimestamp": {
+                    "type": "integer"
+                },
+                "messages": {
+                    "items": {
+                        "properties": {
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatId": {
+                                "type": "string"
+                            },
+                            "clock": {
+                                "type": "integer"
+                            },
+                            "commandParameters": {
+                                "properties": {
+                                    "address": {
+                                        "type": "string"
+                                    },
+                                    "commandState": {
+                                        "type": "integer"
+                                    },
+                                    "contract": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "signature": {
+                                        "type": "null"
+                                    },
+                                    "transactionHash": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "address",
+                                    "commandState",
+                                    "contract",
+                                    "from",
+                                    "id",
+                                    "signature",
+                                    "transactionHash",
+                                    "value"
+                                ],
+                                "type": "object"
+                            },
+                            "compressedKey": {
+                                "type": "string"
+                            },
+                            "contentType": {
+                                "type": "integer"
+                            },
+                            "displayName": {
+                                "type": "string"
+                            },
+                            "emojiHash": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "ensName": {
+                                "type": "string"
+                            },
+                            "from": {
+                                "type": "string"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "lineCount": {
+                                "type": "integer"
+                            },
+                            "localChatId": {
+                                "type": "string"
+                            },
+                            "messageType": {
+                                "type": "integer"
+                            },
+                            "outgoingStatus": {
+                                "type": "string"
+                            },
+                            "parsedText": {
+                                "items": {
+                                    "properties": {
+                                        "children": {
+                                            "items": {
+                                                "properties": {
+                                                    "literal": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "literal"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "children",
+                                        "type"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "quotedMessage": {
+                                "type": "null"
+                            },
+                            "replace": {
+                                "type": "string"
+                            },
+                            "responseTo": {
+                                "type": "string"
+                            },
+                            "rtl": {
+                                "type": "boolean"
+                            },
+                            "seen": {
+                                "type": "boolean"
+                            },
+                            "text": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "whisperTimestamp": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "alias",
+                            "chatId",
+                            "clock",
+                            "commandParameters",
+                            "compressedKey",
+                            "contentType",
+                            "displayName",
+                            "emojiHash",
+                            "ensName",
+                            "from",
+                            "id",
+                            "identicon",
+                            "lineCount",
+                            "localChatId",
+                            "messageType",
+                            "outgoingStatus",
+                            "parsedText",
+                            "quotedMessage",
+                            "replace",
+                            "responseTo",
+                            "rtl",
+                            "seen",
+                            "text",
+                            "timestamp",
+                            "whisperTimestamp"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "notifications": {
+                    "type": "null"
+                }
+            },
+            "required": [
+                "chats",
+                "discordOldestMessageTimestamp",
+                "messages",
+                "notifications"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/schemas/wakuext_sendTransaction
+++ b/tests-functional/schemas/wakuext_sendTransaction
@@ -1,0 +1,480 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "id": {
+            "type": "integer"
+        },
+        "jsonrpc": {
+            "type": "string"
+        },
+        "result": {
+            "properties": {
+                "chats": {
+                    "items": {
+                        "properties": {
+                            "ReadMessagesAtClockValue": {
+                                "type": "integer"
+                            },
+                            "active": {
+                                "type": "boolean"
+                            },
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatType": {
+                                "type": "integer"
+                            },
+                            "color": {
+                                "type": "string"
+                            },
+                            "deletedAtClockValue": {
+                                "type": "integer"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "emoji": {
+                                "type": "string"
+                            },
+                            "highlight": {
+                                "type": "boolean"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "joined": {
+                                "type": "integer"
+                            },
+                            "lastClockValue": {
+                                "type": "integer"
+                            },
+                            "lastMessage": {
+                                "properties": {
+                                    "alias": {
+                                        "type": "string"
+                                    },
+                                    "chatId": {
+                                        "type": "string"
+                                    },
+                                    "clock": {
+                                        "type": "integer"
+                                    },
+                                    "commandParameters": {
+                                        "properties": {
+                                            "address": {
+                                                "type": "string"
+                                            },
+                                            "commandState": {
+                                                "type": "integer"
+                                            },
+                                            "contract": {
+                                                "type": "string"
+                                            },
+                                            "from": {
+                                                "type": "string"
+                                            },
+                                            "id": {
+                                                "type": "string"
+                                            },
+                                            "signature": {
+                                                "type": "string"
+                                            },
+                                            "transactionHash": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "address",
+                                            "commandState",
+                                            "contract",
+                                            "from",
+                                            "id",
+                                            "signature",
+                                            "transactionHash",
+                                            "value"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "compressedKey": {
+                                        "type": "string"
+                                    },
+                                    "contentType": {
+                                        "type": "integer"
+                                    },
+                                    "displayName": {
+                                        "type": "string"
+                                    },
+                                    "emojiHash": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "ensName": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "identicon": {
+                                        "type": "string"
+                                    },
+                                    "lineCount": {
+                                        "type": "integer"
+                                    },
+                                    "localChatId": {
+                                        "type": "string"
+                                    },
+                                    "messageType": {
+                                        "type": "integer"
+                                    },
+                                    "outgoingStatus": {
+                                        "type": "string"
+                                    },
+                                    "parsedText": {
+                                        "items": {
+                                            "properties": {
+                                                "children": {
+                                                    "items": {
+                                                        "properties": {
+                                                            "literal": {
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "literal"
+                                                        ],
+                                                        "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "children",
+                                                "type"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "quotedMessage": {
+                                        "type": "null"
+                                    },
+                                    "replace": {
+                                        "type": "string"
+                                    },
+                                    "responseTo": {
+                                        "type": "string"
+                                    },
+                                    "rtl": {
+                                        "type": "boolean"
+                                    },
+                                    "seen": {
+                                        "type": "boolean"
+                                    },
+                                    "text": {
+                                        "type": "string"
+                                    },
+                                    "timestamp": {
+                                        "type": "integer"
+                                    },
+                                    "whisperTimestamp": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "alias",
+                                    "chatId",
+                                    "clock",
+                                    "commandParameters",
+                                    "compressedKey",
+                                    "contentType",
+                                    "displayName",
+                                    "emojiHash",
+                                    "ensName",
+                                    "from",
+                                    "id",
+                                    "identicon",
+                                    "lineCount",
+                                    "localChatId",
+                                    "messageType",
+                                    "outgoingStatus",
+                                    "parsedText",
+                                    "quotedMessage",
+                                    "replace",
+                                    "responseTo",
+                                    "rtl",
+                                    "seen",
+                                    "text",
+                                    "timestamp",
+                                    "whisperTimestamp"
+                                ],
+                                "type": "object"
+                            },
+                            "members": {
+                                "type": "null"
+                            },
+                            "membershipUpdateEvents": {
+                                "type": "null"
+                            },
+                            "muteTill": {
+                                "type": "string"
+                            },
+                            "muted": {
+                                "type": "boolean"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "unviewedMentionsCount": {
+                                "type": "integer"
+                            },
+                            "unviewedMessagesCount": {
+                                "type": "integer"
+                            },
+                            "viewersCanPostReactions": {
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "ReadMessagesAtClockValue",
+                            "active",
+                            "alias",
+                            "chatType",
+                            "color",
+                            "deletedAtClockValue",
+                            "description",
+                            "emoji",
+                            "highlight",
+                            "id",
+                            "identicon",
+                            "joined",
+                            "lastClockValue",
+                            "lastMessage",
+                            "members",
+                            "membershipUpdateEvents",
+                            "muteTill",
+                            "muted",
+                            "name",
+                            "timestamp",
+                            "unviewedMentionsCount",
+                            "unviewedMessagesCount",
+                            "viewersCanPostReactions"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "discordOldestMessageTimestamp": {
+                    "type": "integer"
+                },
+                "messages": {
+                    "items": {
+                        "properties": {
+                            "alias": {
+                                "type": "string"
+                            },
+                            "chatId": {
+                                "type": "string"
+                            },
+                            "clock": {
+                                "type": "integer"
+                            },
+                            "commandParameters": {
+                                "properties": {
+                                    "address": {
+                                        "type": "string"
+                                    },
+                                    "commandState": {
+                                        "type": "integer"
+                                    },
+                                    "contract": {
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "type": "string"
+                                    },
+                                    "signature": {
+                                        "type": "string"
+                                    },
+                                    "transactionHash": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "address",
+                                    "commandState",
+                                    "contract",
+                                    "from",
+                                    "id",
+                                    "signature",
+                                    "transactionHash",
+                                    "value"
+                                ],
+                                "type": "object"
+                            },
+                            "compressedKey": {
+                                "type": "string"
+                            },
+                            "contentType": {
+                                "type": "integer"
+                            },
+                            "displayName": {
+                                "type": "string"
+                            },
+                            "emojiHash": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "ensName": {
+                                "type": "string"
+                            },
+                            "from": {
+                                "type": "string"
+                            },
+                            "id": {
+                                "type": "string"
+                            },
+                            "identicon": {
+                                "type": "string"
+                            },
+                            "lineCount": {
+                                "type": "integer"
+                            },
+                            "localChatId": {
+                                "type": "string"
+                            },
+                            "messageType": {
+                                "type": "integer"
+                            },
+                            "outgoingStatus": {
+                                "type": "string"
+                            },
+                            "parsedText": {
+                                "items": {
+                                    "properties": {
+                                        "children": {
+                                            "items": {
+                                                "properties": {
+                                                    "literal": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "literal"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "children",
+                                        "type"
+                                    ],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "quotedMessage": {
+                                "type": "null"
+                            },
+                            "replace": {
+                                "type": "string"
+                            },
+                            "responseTo": {
+                                "type": "string"
+                            },
+                            "rtl": {
+                                "type": "boolean"
+                            },
+                            "seen": {
+                                "type": "boolean"
+                            },
+                            "text": {
+                                "type": "string"
+                            },
+                            "timestamp": {
+                                "type": "integer"
+                            },
+                            "whisperTimestamp": {
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "alias",
+                            "chatId",
+                            "clock",
+                            "commandParameters",
+                            "compressedKey",
+                            "contentType",
+                            "displayName",
+                            "emojiHash",
+                            "ensName",
+                            "from",
+                            "id",
+                            "identicon",
+                            "lineCount",
+                            "localChatId",
+                            "messageType",
+                            "outgoingStatus",
+                            "parsedText",
+                            "quotedMessage",
+                            "replace",
+                            "responseTo",
+                            "rtl",
+                            "seen",
+                            "text",
+                            "timestamp",
+                            "whisperTimestamp"
+                        ],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "notifications": {
+                    "type": "null"
+                }
+            },
+            "required": [
+                "chats",
+                "discordOldestMessageTimestamp",
+                "messages",
+                "notifications"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "id",
+        "jsonrpc",
+        "result"
+    ],
+    "type": "object"
+}

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -100,6 +100,20 @@ class MessengerSteps(NetworkConditionsSteps):
         else:
             raise ValueError(f"Failed to find a message with contentType '{content_type}' in response")
 
+    def get_message_id(self, response, index=0):
+        return response.get("result", {}).get("messages", [])[index].get("id", "")
+
+    def get_message_by_message_id(self, response, message_id: str):
+        messages = response.get("result", {}).get("messages", [])
+        matched_message = None
+        for message in messages:
+            if message.get("id", "") == message_id:
+                matched_message = message
+                break
+        if matched_message is None:
+            raise ValueError(f"Failed to find a message with message id '{message_id}' in response")
+        return matched_message
+
     def join_private_group(self):
         private_group_name = f"private_group_{uuid4()}"
         response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], private_group_name)

--- a/tests-functional/tests/test_wakuext_messages_transactions.py
+++ b/tests-functional/tests/test_wakuext_messages_transactions.py
@@ -2,6 +2,7 @@ import base64
 import pytest
 
 from clients.signals import SignalType
+from resources.enums import MessageContentType
 from steps.messenger import MessengerSteps
 
 
@@ -36,6 +37,7 @@ class TestTransactionsChatMessages(MessengerSteps):
         message_id = self.get_message_id(response)
         message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.REQUEST_TRANSACTION_TEXT
+        assert message.get("contentType", -1) == MessageContentType.TRANSACTION_COMMAND.value
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == transaction_data["value"]
         assert command_parameters.get("contract", "") == transaction_data["contract"]
@@ -57,6 +59,7 @@ class TestTransactionsChatMessages(MessengerSteps):
         message_id = self.get_message_id(response)
         message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.REQUEST_TRANSACTION_DECLINED_TEXT
+        assert message.get("contentType", -1) == MessageContentType.TRANSACTION_COMMAND.value
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == transaction_data["value"]
         assert command_parameters.get("contract", "") == transaction_data["contract"]
@@ -78,6 +81,7 @@ class TestTransactionsChatMessages(MessengerSteps):
         message_id = self.get_message_id(response)
         message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.TRANSACTION_SENT_TEXT
+        assert message.get("contentType", -1) == MessageContentType.TRANSACTION_COMMAND.value
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == transaction_data["value"]
         assert command_parameters.get("contract", "") == transaction_data["contract"]
@@ -95,6 +99,7 @@ class TestTransactionsChatMessages(MessengerSteps):
         message_id = self.get_message_id(response)
         message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_TEXT
+        assert message.get("contentType", -1) == MessageContentType.TRANSACTION_COMMAND.value
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("from", "") == transaction_data["from"]
         assert command_parameters.get("value", "") == transaction_data["value"]
@@ -118,6 +123,7 @@ class TestTransactionsChatMessages(MessengerSteps):
         message_id = self.get_message_id(response)
         message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_DECLINED_TEXT
+        assert message.get("contentType", -1) == MessageContentType.TRANSACTION_COMMAND.value
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == transaction_data["value"]
         assert command_parameters.get("contract", "") == transaction_data["contract"]
@@ -140,6 +146,7 @@ class TestTransactionsChatMessages(MessengerSteps):
         message_id = self.get_message_id(response)
         message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_ACCEPTED_TEXT
+        assert message.get("contentType", -1) == MessageContentType.TRANSACTION_COMMAND.value
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("address", "") == transaction_data["address"]
         assert command_parameters.get("value", "") == transaction_data["value"]
@@ -156,6 +163,7 @@ class TestTransactionsChatMessages(MessengerSteps):
         message_id = self.get_message_id(response)
         message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.TRANSACTION_SENT_TEXT
+        assert message.get("contentType", -1) == MessageContentType.TRANSACTION_COMMAND.value
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == transaction_data["value"]
         assert command_parameters.get("contract", "") == transaction_data["contract"]

--- a/tests-functional/tests/test_wakuext_messages_transactions.py
+++ b/tests-functional/tests/test_wakuext_messages_transactions.py
@@ -1,3 +1,4 @@
+import base64
 import pytest
 
 from clients.signals import SignalType
@@ -12,32 +13,39 @@ class TestTransactionsChatMessages(MessengerSteps):
     REQUEST_TRANSACTION_DECLINED_TEXT = "Transaction request declined"
     REQUEST_ADDRESS_FOR_TRANSACTION_TEXT = "Request address for transaction"
     REQUEST_ADDRESS_FOR_TRANSACTION_DECLINED_TEXT = "Request address for transaction declined"
+    TRANSACTION_SENT_TEXT = "Transaction sent"
 
-    def test_request_transaction(self):
+    @pytest.fixture
+    def transaction_data(self):
+        return {
+            "value": "10000000",
+            "contract": "0x0000000000000000000000000000000000000000",
+            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+            "from": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+            "tx_hash": "0x1adeaa0e672d7e67bf01d8431b6238bdef15e19ae7e8ceb16886c",
+            "signature": "0xa123",
+        }
+
+    def test_request_transaction(self, transaction_data):
         self.make_contacts()
-        value = "1"
-        contract = "TEST_CONTRACT"
-        address = "TEST_ADDRESS"
-        response = self.sender.wakuext_service.request_transaction(self.receiver.public_key, value, contract, address)
+        response = self.sender.wakuext_service.request_transaction(
+            self.receiver.public_key, transaction_data["value"], transaction_data["contract"], transaction_data["address"]
+        )
         self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")
 
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_TRANSACTION_TEXT, timeout=5)
-
-        response = self.receiver.wakuext_service.chat_messages(self.sender.public_key)
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
         assert message.get("text", "") == self.REQUEST_TRANSACTION_TEXT
         command_parameters = message.get("commandParameters", {})
-        assert command_parameters.get("value", "") == value
-        assert command_parameters.get("contract", "") == contract
-        assert command_parameters.get("address", "") == address
+        assert command_parameters.get("value", "") == transaction_data["value"]
+        assert command_parameters.get("contract", "") == transaction_data["contract"]
+        assert command_parameters.get("address", "") == transaction_data["address"]
 
-    def test_decline_request_transaction(self):
+    def test_decline_request_transaction(self, transaction_data):
         self.make_contacts()
         sender_chat_id = self.receiver.public_key
-        value = "1"
-        contract = "TEST_CONTRACT"
-        address = "TEST_ADDRESS"
-        response = self.sender.wakuext_service.request_transaction(sender_chat_id, value, contract, address)
+        response = self.sender.wakuext_service.request_transaction(
+            sender_chat_id, transaction_data["value"], transaction_data["contract"], transaction_data["address"]
+        )
         message_id = response.get("result", {}).get("messages", [])[0].get("id", "")
 
         self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_TRANSACTION_TEXT, timeout=5)
@@ -45,43 +53,55 @@ class TestTransactionsChatMessages(MessengerSteps):
         response = self.receiver.wakuext_service.decline_request_transaction(message_id)
         self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
 
-        self.sender.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_TRANSACTION_DECLINED_TEXT, timeout=5)
-
-        response = self.sender.wakuext_service.chat_messages(sender_chat_id)
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
         assert message.get("text", "") == self.REQUEST_TRANSACTION_DECLINED_TEXT
         command_parameters = message.get("commandParameters", {})
-        assert command_parameters.get("value", "") == value
-        assert command_parameters.get("contract", "") == contract
-        assert command_parameters.get("address", "") == address
+        assert command_parameters.get("value", "") == transaction_data["value"]
+        assert command_parameters.get("contract", "") == transaction_data["contract"]
+        assert command_parameters.get("address", "") == transaction_data["address"]
 
-    def test_request_address_for_transaction(self):
+    def test_accept_request_transaction(self, transaction_data):
         self.make_contacts()
-        value = "1"
-        contract = "TEST_CONTRACT"
-        address_from = "TEST_ADDRESS_FROM"
-        response = self.sender.wakuext_service.request_address_for_transaction(self.receiver.public_key, address_from, value, contract)
+        sender_chat_id = self.receiver.public_key
+        response = self.sender.wakuext_service.request_transaction(
+            sender_chat_id, transaction_data["value"], transaction_data["contract"], transaction_data["address"]
+        )
+        message_id = response.get("result", {}).get("messages", [])[0].get("id", "")
+
+        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_TRANSACTION_TEXT, timeout=5)
+
+        response = self.receiver.wakuext_service.accept_request_transaction(transaction_data["tx_hash"], message_id, transaction_data["signature"])
+        self.receiver.verify_json_schema(response, method="wakuext_acceptRequestTransaction")
+
+        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        assert message.get("text", "") == self.TRANSACTION_SENT_TEXT
+        command_parameters = message.get("commandParameters", {})
+        assert command_parameters.get("value", "") == transaction_data["value"]
+        assert command_parameters.get("contract", "") == transaction_data["contract"]
+        assert command_parameters.get("address", "") == transaction_data["address"]
+        assert command_parameters.get("transactionHash", "") == transaction_data["tx_hash"]
+        assert command_parameters.get("signature", "") == base64.b64encode(bytes.fromhex(transaction_data["signature"].replace("0x", ""))).decode()
+
+    def test_request_address_for_transaction(self, transaction_data):
+        self.make_contacts()
+        response = self.sender.wakuext_service.request_address_for_transaction(
+            self.receiver.public_key, transaction_data["from"], transaction_data["value"], transaction_data["contract"]
+        )
         self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
 
-        self.receiver.find_signal_containing_pattern(
-            SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_ADDRESS_FOR_TRANSACTION_TEXT, timeout=5
-        )
-
-        response = self.receiver.wakuext_service.chat_messages(self.sender.public_key)
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
         assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_TEXT
         command_parameters = message.get("commandParameters", {})
-        # assert command_parameters.get("from", "") == address_from
-        assert command_parameters.get("value", "") == value
-        assert command_parameters.get("contract", "") == contract
+        assert command_parameters.get("from", "") == transaction_data["from"]
+        assert command_parameters.get("value", "") == transaction_data["value"]
+        assert command_parameters.get("contract", "") == transaction_data["contract"]
 
-    def test_decline_request_address_for_transaction(self):
+    def test_decline_request_address_for_transaction(self, transaction_data):
         self.make_contacts()
         sender_chat_id = self.receiver.public_key
-        value = "1"
-        contract = "TEST_CONTRACT"
-        address_from = "TEST_ADDRESS_FROM"
-        response = self.sender.wakuext_service.request_address_for_transaction(self.receiver.public_key, address_from, value, contract)
+        response = self.sender.wakuext_service.request_address_for_transaction(
+            sender_chat_id, transaction_data["from"], transaction_data["value"], transaction_data["contract"]
+        )
         message_id = response.get("result", {}).get("messages", [])[0].get("id", "")
 
         self.receiver.find_signal_containing_pattern(
@@ -91,14 +111,23 @@ class TestTransactionsChatMessages(MessengerSteps):
         response = self.receiver.wakuext_service.decline_request_address_for_transaction(message_id)
         self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
 
-        self.sender.find_signal_containing_pattern(
-            SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_ADDRESS_FOR_TRANSACTION_DECLINED_TEXT, timeout=5
-        )
-
-        response = self.sender.wakuext_service.chat_messages(sender_chat_id)
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
         assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_DECLINED_TEXT
         command_parameters = message.get("commandParameters", {})
-        assert command_parameters.get("from", "") == address_from
-        assert command_parameters.get("value", "") == value
-        assert command_parameters.get("contract", "") == contract
+        assert command_parameters.get("value", "") == transaction_data["value"]
+        assert command_parameters.get("contract", "") == transaction_data["contract"]
+
+    def test_send_transaction(self, transaction_data):
+        self.make_contacts()
+        sender_chat_id = self.receiver.public_key
+        response = self.sender.wakuext_service.send_transaction(
+            sender_chat_id, transaction_data["value"], transaction_data["contract"], transaction_data["tx_hash"], transaction_data["signature"]
+        )
+
+        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        assert message.get("text", "") == self.TRANSACTION_SENT_TEXT
+        command_parameters = message.get("commandParameters", {})
+        assert command_parameters.get("value", "") == transaction_data["value"]
+        assert command_parameters.get("contract", "") == transaction_data["contract"]
+        assert command_parameters.get("transactionHash", "") == transaction_data["tx_hash"]
+        assert command_parameters.get("signature", "") == base64.b64encode(bytes.fromhex(transaction_data["signature"].replace("0x", ""))).decode()

--- a/tests-functional/tests/test_wakuext_messages_transactions.py
+++ b/tests-functional/tests/test_wakuext_messages_transactions.py
@@ -13,6 +13,7 @@ class TestTransactionsChatMessages(MessengerSteps):
     REQUEST_TRANSACTION_DECLINED_TEXT = "Transaction request declined"
     REQUEST_ADDRESS_FOR_TRANSACTION_TEXT = "Request address for transaction"
     REQUEST_ADDRESS_FOR_TRANSACTION_DECLINED_TEXT = "Request address for transaction declined"
+    REQUEST_ADDRESS_FOR_TRANSACTION_ACCEPTED_TEXT = "Request address for transaction accepted"
     TRANSACTION_SENT_TEXT = "Transaction sent"
 
     @pytest.fixture
@@ -117,12 +118,35 @@ class TestTransactionsChatMessages(MessengerSteps):
         assert command_parameters.get("value", "") == transaction_data["value"]
         assert command_parameters.get("contract", "") == transaction_data["contract"]
 
+    def test_accept_request_address_for_transaction(self, transaction_data):
+        self.make_contacts()
+        sender_chat_id = self.receiver.public_key
+        response = self.sender.wakuext_service.request_address_for_transaction(
+            sender_chat_id, transaction_data["from"], transaction_data["value"], transaction_data["contract"]
+        )
+        message_id = response.get("result", {}).get("messages", [])[0].get("id", "")
+
+        self.receiver.find_signal_containing_pattern(
+            SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_ADDRESS_FOR_TRANSACTION_TEXT, timeout=5
+        )
+
+        response = self.receiver.wakuext_service.accept_request_address_for_transaction(message_id, transaction_data["address"])
+        self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
+
+        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_ACCEPTED_TEXT
+        command_parameters = message.get("commandParameters", {})
+        assert command_parameters.get("address", "") == transaction_data["address"]
+        assert command_parameters.get("value", "") == transaction_data["value"]
+        assert command_parameters.get("contract", "") == transaction_data["contract"]
+
     def test_send_transaction(self, transaction_data):
         self.make_contacts()
         sender_chat_id = self.receiver.public_key
         response = self.sender.wakuext_service.send_transaction(
             sender_chat_id, transaction_data["value"], transaction_data["contract"], transaction_data["tx_hash"], transaction_data["signature"]
         )
+        self.receiver.verify_json_schema(response, method="wakuext_sendTransaction")
 
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
         assert message.get("text", "") == self.TRANSACTION_SENT_TEXT

--- a/tests-functional/tests/test_wakuext_messages_transactions.py
+++ b/tests-functional/tests/test_wakuext_messages_transactions.py
@@ -2,7 +2,6 @@ import base64
 import pytest
 
 from clients.signals import SignalType
-from resources.enums import MessageContentType
 from steps.messenger import MessengerSteps
 
 
@@ -20,10 +19,10 @@ class TestTransactionsChatMessages(MessengerSteps):
     def transaction_data(self):
         return {
             "value": "10000000",
-            "contract": "0x0000000000000000000000000000000000000000",
-            "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-            "from": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
-            "tx_hash": "0x1adeaa0e672d7e67bf01d8431b6238bdef15e19ae7e8ceb16886c",
+            "contract": "0xCONTRACT",
+            "address": "0xADDRESS",
+            "from": "0xFROM",
+            "tx_hash": "0xTXHASH",
             "signature": "0xa123",
         }
 
@@ -34,7 +33,8 @@ class TestTransactionsChatMessages(MessengerSteps):
         )
         self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")
 
-        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        message_id = self.get_message_id(response)
+        message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.REQUEST_TRANSACTION_TEXT
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == transaction_data["value"]
@@ -47,14 +47,15 @@ class TestTransactionsChatMessages(MessengerSteps):
         response = self.sender.wakuext_service.request_transaction(
             sender_chat_id, transaction_data["value"], transaction_data["contract"], transaction_data["address"]
         )
-        message_id = response.get("result", {}).get("messages", [])[0].get("id", "")
+        message_id = self.get_message_id(response)
 
         self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_TRANSACTION_TEXT, timeout=5)
 
         response = self.receiver.wakuext_service.decline_request_transaction(message_id)
         self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
 
-        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        message_id = self.get_message_id(response)
+        message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.REQUEST_TRANSACTION_DECLINED_TEXT
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == transaction_data["value"]
@@ -67,14 +68,15 @@ class TestTransactionsChatMessages(MessengerSteps):
         response = self.sender.wakuext_service.request_transaction(
             sender_chat_id, transaction_data["value"], transaction_data["contract"], transaction_data["address"]
         )
-        message_id = response.get("result", {}).get("messages", [])[0].get("id", "")
+        message_id = self.get_message_id(response)
 
         self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_TRANSACTION_TEXT, timeout=5)
 
         response = self.receiver.wakuext_service.accept_request_transaction(transaction_data["tx_hash"], message_id, transaction_data["signature"])
         self.receiver.verify_json_schema(response, method="wakuext_acceptRequestTransaction")
 
-        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        message_id = self.get_message_id(response)
+        message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.TRANSACTION_SENT_TEXT
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == transaction_data["value"]
@@ -90,7 +92,8 @@ class TestTransactionsChatMessages(MessengerSteps):
         )
         self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
 
-        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        message_id = self.get_message_id(response)
+        message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_TEXT
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("from", "") == transaction_data["from"]
@@ -103,7 +106,7 @@ class TestTransactionsChatMessages(MessengerSteps):
         response = self.sender.wakuext_service.request_address_for_transaction(
             sender_chat_id, transaction_data["from"], transaction_data["value"], transaction_data["contract"]
         )
-        message_id = response.get("result", {}).get("messages", [])[0].get("id", "")
+        message_id = self.get_message_id(response)
 
         self.receiver.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_ADDRESS_FOR_TRANSACTION_TEXT, timeout=5
@@ -112,7 +115,8 @@ class TestTransactionsChatMessages(MessengerSteps):
         response = self.receiver.wakuext_service.decline_request_address_for_transaction(message_id)
         self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
 
-        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        message_id = self.get_message_id(response)
+        message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_DECLINED_TEXT
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == transaction_data["value"]
@@ -124,7 +128,7 @@ class TestTransactionsChatMessages(MessengerSteps):
         response = self.sender.wakuext_service.request_address_for_transaction(
             sender_chat_id, transaction_data["from"], transaction_data["value"], transaction_data["contract"]
         )
-        message_id = response.get("result", {}).get("messages", [])[0].get("id", "")
+        message_id = self.get_message_id(response)
 
         self.receiver.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_ADDRESS_FOR_TRANSACTION_TEXT, timeout=5
@@ -133,7 +137,8 @@ class TestTransactionsChatMessages(MessengerSteps):
         response = self.receiver.wakuext_service.accept_request_address_for_transaction(message_id, transaction_data["address"])
         self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
 
-        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        message_id = self.get_message_id(response)
+        message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_ACCEPTED_TEXT
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("address", "") == transaction_data["address"]
@@ -148,7 +153,8 @@ class TestTransactionsChatMessages(MessengerSteps):
         )
         self.receiver.verify_json_schema(response, method="wakuext_sendTransaction")
 
-        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        message_id = self.get_message_id(response)
+        message = self.get_message_by_message_id(response, message_id)
         assert message.get("text", "") == self.TRANSACTION_SENT_TEXT
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == transaction_data["value"]

--- a/tests-functional/tests/test_wakuext_messages_transactions.py
+++ b/tests-functional/tests/test_wakuext_messages_transactions.py
@@ -10,6 +10,8 @@ from steps.messenger import MessengerSteps
 class TestTransactionsChatMessages(MessengerSteps):
     REQUEST_TRANSACTION_TEXT = "Request transaction"
     REQUEST_TRANSACTION_DECLINED_TEXT = "Transaction request declined"
+    REQUEST_ADDRESS_FOR_TRANSACTION_TEXT = "Request address for transaction"
+    REQUEST_ADDRESS_FOR_TRANSACTION_DECLINED_TEXT = "Request address for transaction declined"
 
     def test_request_transaction(self):
         self.make_contacts()
@@ -52,3 +54,51 @@ class TestTransactionsChatMessages(MessengerSteps):
         assert command_parameters.get("value", "") == value
         assert command_parameters.get("contract", "") == contract
         assert command_parameters.get("address", "") == address
+
+    def test_request_address_for_transaction(self):
+        self.make_contacts()
+        value = "1"
+        contract = "TEST_CONTRACT"
+        address_from = "TEST_ADDRESS_FROM"
+        response = self.sender.wakuext_service.request_address_for_transaction(self.receiver.public_key, address_from, value, contract)
+        self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
+
+        self.receiver.find_signal_containing_pattern(
+            SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_ADDRESS_FOR_TRANSACTION_TEXT, timeout=5
+        )
+
+        response = self.receiver.wakuext_service.chat_messages(self.sender.public_key)
+        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_TEXT
+        command_parameters = message.get("commandParameters", {})
+        # assert command_parameters.get("from", "") == address_from
+        assert command_parameters.get("value", "") == value
+        assert command_parameters.get("contract", "") == contract
+
+    def test_decline_request_address_for_transaction(self):
+        self.make_contacts()
+        sender_chat_id = self.receiver.public_key
+        value = "1"
+        contract = "TEST_CONTRACT"
+        address_from = "TEST_ADDRESS_FROM"
+        response = self.sender.wakuext_service.request_address_for_transaction(self.receiver.public_key, address_from, value, contract)
+        message_id = response.get("result", {}).get("messages", [])[0].get("id", "")
+
+        self.receiver.find_signal_containing_pattern(
+            SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_ADDRESS_FOR_TRANSACTION_TEXT, timeout=5
+        )
+
+        response = self.receiver.wakuext_service.decline_request_address_for_transaction(message_id)
+        self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
+
+        self.sender.find_signal_containing_pattern(
+            SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_ADDRESS_FOR_TRANSACTION_DECLINED_TEXT, timeout=5
+        )
+
+        response = self.sender.wakuext_service.chat_messages(sender_chat_id)
+        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        assert message.get("text", "") == self.REQUEST_ADDRESS_FOR_TRANSACTION_DECLINED_TEXT
+        command_parameters = message.get("commandParameters", {})
+        assert command_parameters.get("from", "") == address_from
+        assert command_parameters.get("value", "") == value
+        assert command_parameters.get("contract", "") == contract

--- a/tests-functional/tests/test_wakuext_messages_transactions.py
+++ b/tests-functional/tests/test_wakuext_messages_transactions.py
@@ -1,0 +1,28 @@
+import pytest
+
+from clients.signals import SignalType
+from resources.enums import MessageContentType
+from steps.messenger import MessengerSteps
+
+
+@pytest.mark.usefixtures("setup_two_unprivileged_nodes")
+@pytest.mark.rpc
+class TestTransactionsChatMessages(MessengerSteps):
+    def test_request_transaction(self):
+        self.make_contacts()
+        sender_chat_id = self.receiver.public_key
+        value = "1"
+        contract = "TEST_CONTRACT"
+        address = "TEST_ADDRESS"
+        response = self.sender.wakuext_service.request_transaction(sender_chat_id, value, contract, address)
+        self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")
+
+        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern="Request transaction", timeout=5)
+        receiver_chat_id = self.sender.public_key
+        response = self.receiver.wakuext_service.chat_messages(receiver_chat_id)
+
+        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        command_parameters = message.get("commandParameters", {})
+        assert command_parameters.get("value", "") == value
+        assert command_parameters.get("contract", "") == contract
+        assert command_parameters.get("address", "") == address

--- a/tests-functional/tests/test_wakuext_messages_transactions.py
+++ b/tests-functional/tests/test_wakuext_messages_transactions.py
@@ -8,20 +8,46 @@ from steps.messenger import MessengerSteps
 @pytest.mark.usefixtures("setup_two_unprivileged_nodes")
 @pytest.mark.rpc
 class TestTransactionsChatMessages(MessengerSteps):
+    REQUEST_TRANSACTION_TEXT = "Request transaction"
+    REQUEST_TRANSACTION_DECLINED_TEXT = "Transaction request declined"
+
     def test_request_transaction(self):
+        self.make_contacts()
+        value = "1"
+        contract = "TEST_CONTRACT"
+        address = "TEST_ADDRESS"
+        response = self.sender.wakuext_service.request_transaction(self.receiver.public_key, value, contract, address)
+        self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")
+
+        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_TRANSACTION_TEXT, timeout=5)
+
+        response = self.receiver.wakuext_service.chat_messages(self.sender.public_key)
+        message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        assert message.get("text", "") == self.REQUEST_TRANSACTION_TEXT
+        command_parameters = message.get("commandParameters", {})
+        assert command_parameters.get("value", "") == value
+        assert command_parameters.get("contract", "") == contract
+        assert command_parameters.get("address", "") == address
+
+    def test_decline_request_transaction(self):
         self.make_contacts()
         sender_chat_id = self.receiver.public_key
         value = "1"
         contract = "TEST_CONTRACT"
         address = "TEST_ADDRESS"
         response = self.sender.wakuext_service.request_transaction(sender_chat_id, value, contract, address)
-        self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")
+        message_id = response.get("result", {}).get("messages", [])[0].get("id", "")
 
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern="Request transaction", timeout=5)
-        receiver_chat_id = self.sender.public_key
-        response = self.receiver.wakuext_service.chat_messages(receiver_chat_id)
+        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_TRANSACTION_TEXT, timeout=5)
 
+        response = self.receiver.wakuext_service.decline_request_transaction(message_id)
+        self.receiver.verify_json_schema(response, method="wakuext_requestTransaction")  # same schema
+
+        self.sender.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=self.REQUEST_TRANSACTION_DECLINED_TEXT, timeout=5)
+
+        response = self.sender.wakuext_service.chat_messages(sender_chat_id)
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TRANSACTION_COMMAND.value)[0]
+        assert message.get("text", "") == self.REQUEST_TRANSACTION_DECLINED_TEXT
         command_parameters = message.get("commandParameters", {})
         assert command_parameters.get("value", "") == value
         assert command_parameters.get("contract", "") == contract


### PR DESCRIPTION
Functional tests for `wakuext` messages methods: https://github.com/status-im/status-go/issues/6084

Important changes:
- [x] `wakuext_requestTransaction `
- [x] `wakuext_declineRequestTransaction `
- [x] `wakuext_acceptRequestTransaction `
- [x] `wakuext_requestAddressForTransaction `
- [x] `wakuext_declineRequestAddressForTransaction `
- [x] `wakuext_acceptRequestAddressForTransaction `
- [x] `wakuext_sendTransaction `