### PR TITLE
chore_: remove unused fields from waku's `NewMessage`

### DIFF
--- a/protocol/common/message_segmentation.go
+++ b/protocol/common/message_segmentation.go
@@ -58,7 +58,6 @@ func replicateMessageWithNewPayload(message *wakutypes.NewMessage, payload []byt
 	}
 
 	copy.Payload = payload
-	copy.PowTarget = calculatePoW(payload)
 	return copy, nil
 }
 

--- a/protocol/common/message_sender_test.go
+++ b/protocol/common/message_sender_test.go
@@ -178,13 +178,6 @@ func (s *MessageSenderSuite) TestHandleDecodedMessagesDatasync() {
 	s.Require().Equal(protobuf.ApplicationMetadataMessage_CHAT_MESSAGE, decodedMessages[0].ApplicationLayer.Type)
 }
 
-func (s *MessageSenderSuite) CalculatePoWTest() {
-	largeSizePayload := make([]byte, largeSizeInBytes)
-	s.Require().Equal(whisperLargeSizePoW, calculatePoW(largeSizePayload))
-	normalSizePayload := make([]byte, largeSizeInBytes-1)
-	s.Require().Equal(whisperDefaultPoW, calculatePoW(normalSizePayload))
-
-}
 func (s *MessageSenderSuite) TestHandleDecodedMessagesDatasyncEncrypted() {
 	relayerKey, err := crypto.GenerateKey()
 	s.Require().NoError(err)

--- a/waku/types/rpc.go
+++ b/waku/types/rpc.go
@@ -11,14 +11,9 @@ type NewMessage struct {
 	SymKeyID    string    `json:"symKeyID"`
 	PublicKey   []byte    `json:"pubKey"`
 	SigID       string    `json:"sig"`
-	TTL         uint32    `json:"ttl"`
 	PubsubTopic string    `json:"pubsubTopic"`
 	Topic       TopicType `json:"topic"`
 	Payload     []byte    `json:"payload"`
-	Padding     []byte    `json:"padding"`
-	PowTime     uint32    `json:"powTime"`
-	PowTarget   float64   `json:"powTarget"`
-	TargetPeer  string    `json:"targetPeer"`
 	Ephemeral   bool      `json:"ephemeral"`
 	Priority    *int      `json:"priority"`
 }


### PR DESCRIPTION
Remove fields that are no longer used due to the removal of Waku v1.







