### PR TITLE
use global communities shards

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2510,6 +2510,10 @@ func (m *Messenger) DefaultFilters(o *communities.Community) []transport.Filters
 		{ChatID: mlChannelID, PubsubTopic: communityPubsubTopic},
 		{ChatID: memberUpdateChannelID, PubsubTopic: communityPubsubTopic},
 		{ChatID: uncompressedPubKey, PubsubTopic: wakuv2.DefaultNonProtectedPubsubTopic()},
+		// TODO only filter if interested in communities
+		{ChatID: uncompressedPubKey, PubsubTopic: wakuv2.GlobalCommunityControlPubsubTopic()},
+		// TODO only filter if interested in communities
+		{ChatID: uncompressedPubKey, PubsubTopic: wakuv2.GlobalCommunityContentPubsubTopic()},
 	}
 
 	return filters

--- a/protocol/messenger_filter_init.go
+++ b/protocol/messenger_filter_init.go
@@ -28,6 +28,18 @@ func (m *Messenger) InitFilters() error {
 		return err
 	}
 
+	// TODO only subscribe if interested in communities
+	// TODO will need to start sending the communities' control messages to this pubsub topic
+	if err := m.SubscribeToPubsubTopic(wakuv2.GlobalCommunityControlPubsubTopic(), nil); err != nil {
+		return err
+	}
+
+	// TODO only subscribe if interested in communities
+	// TODO will need to start sending the communities' content messages to this pubsub topic
+	if err := m.SubscribeToPubsubTopic(wakuv2.GlobalCommunityContentPubsubTopic(), nil); err != nil {
+		return err
+	}
+
 	filters, publicKeys, err := m.collectFiltersAndKeys()
 	if err != nil {
 		return err

--- a/wakuv2/shard.go
+++ b/wakuv2/shard.go
@@ -57,3 +57,17 @@ func DefaultNonProtectedShard() *Shard {
 func DefaultNonProtectedPubsubTopic() string {
 	return DefaultNonProtectedShard().PubsubTopic()
 }
+
+// GlobalCommunityControlPubsubTopic returns the pubsub topic for the global community control
+//
+// Specs: https://github.com/vacp2p/rfc-index/blob/8ee2a6d6b232838d83374c35e2413f84436ecf64/status/56/communities.md?plain=1#L329
+func GlobalCommunityControlPubsubTopic() string {
+	return wakuproto.NewStaticShardingPubsubTopic(MainStatusShardCluster, 128).String()
+}
+
+// GlobalCommunityContentPubsubTopic returns the pubsub topic for the global community content
+//
+// Specs: https://github.com/vacp2p/rfc-index/blob/8ee2a6d6b232838d83374c35e2413f84436ecf64/status/56/communities.md?plain=1#L330
+func GlobalCommunityContentPubsubTopic() string {
+	return wakuproto.NewStaticShardingPubsubTopic(MainStatusShardCluster, 256).String()
+}


### PR DESCRIPTION
Stage 1 on migration to global communities shards (128 & 256)

Moving to different shards the traffic from global communiteis will entail multiple steps:

1. Subscribe and filter on those shards (128 & 256)
2. Review store queries and hash queries 
3. Review Lightpush
4. Start publishing traffic belonging to global communities on those shards
5. Remove filters to other used shards for communities if any 