### PR TITLE
feat_: initial nwaku integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: statusgo all test clean help
 .PHONY: statusgo-android statusgo-ios
+.PHONY: build-libwaku test-libwaku clean-libwaku rebuild-libwaku
 
 # Clear any GOROOT set outside of the Nix shell
 export GOROOT=
@@ -40,7 +41,7 @@ else
 endif
 
 ifeq ($(detected_OS),Darwin)
- GOBIN_SHARED_LIB_EXT := dylib
+ GOBIN_SHARED_LIB_EXT := so
  GOBIN_SHARED_LIB_CFLAGS := CGO_ENABLED=1 GOOS=darwin
 else ifeq ($(detected_OS),Windows)
  GOBIN_SHARED_LIB_EXT := dll
@@ -59,6 +60,10 @@ GIT_AUTHOR ?= $(shell git config user.email || echo $$USER)
 
 ENABLE_METRICS ?= true
 BUILD_TAGS ?= gowaku_no_rln
+
+ifeq ($(USE_NWAKU), true)
+BUILD_TAGS += use_nwaku
+endif
 
 BUILD_FLAGS ?= -ldflags="-X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=$(ENABLE_METRICS)"
 BUILD_FLAGS_MOBILE ?=
@@ -141,6 +146,13 @@ $(GO_CMD_BUILDS): ##@build Build any Go project from cmd folder
 	echo "Compilation done." ;\
 	echo "Run \"build/bin/$(notdir $@) -h\" to view available commands."
 
+LIBWAKU := $(CURDIR)/vendor/github.com/waku-org/waku-go-bindings/third_party/nwaku/build/libwaku.$(GOBIN_SHARED_LIB_EXT)
+$(LIBWAKU):
+ifeq ($(USE_NWAKU),true)
+	@echo "Building libwaku"
+	$(MAKE) -C $(CURDIR)/vendor/github.com/waku-org/waku-go-bindings/waku SHELL=/bin/bash
+endif
+
 statusgo: ##@build Build status-go as statusd server
 statusgo: build/bin/statusd
 statusd: statusgo
@@ -193,7 +205,7 @@ statusgo-ios: ##@cross-compile Build status-go for iOS
 	@echo "iOS framework cross compilation done in build/bin/Statusgo.xcframework"
 
 statusgo-library: generate
-statusgo-library: ##@cross-compile Build status-go as static library for current platform
+statusgo-library: $(LIBWAKU) ##@cross-compile Build status-go as static library for current platform
 	## cmd/library/README.md explains the magic incantation behind this
 	mkdir -p build/bin/statusgo-lib
 	go run cmd/library/*.go > build/bin/statusgo-lib/main.go
@@ -207,8 +219,10 @@ statusgo-library: ##@cross-compile Build status-go as static library for current
 	@echo "Static library built:"
 	@ls -la build/bin/libstatus.*
 
+build-libwaku: $(LIBWAKU)
+
 statusgo-shared-library: generate
-statusgo-shared-library: ##@cross-compile Build status-go as shared library for current platform
+statusgo-shared-library: $(LIBWAKU) ##@cross-compile Build status-go as shared library for current platform
 	## cmd/library/README.md explains the magic incantation behind this
 	mkdir -p build/bin/statusgo-lib
 	go run cmd/library/*.go > build/bin/statusgo-lib/main.go
@@ -295,6 +309,15 @@ lint-fix:
 
 docker-test: ##@tests Run tests in a docker container with golang.
 	docker run --privileged --rm -it -v "$(PWD):$(DOCKER_TEST_WORKDIR)" -w "$(DOCKER_TEST_WORKDIR)" $(DOCKER_TEST_IMAGE) go test ${ARGS}
+
+test-libwaku: | $(LIBWAKU)
+	go test -tags '$(BUILD_TAGS) use_nwaku' -run TestDial ./wakuv2/... -count 1 -v -json | jq -r '.Output'
+
+clean-libwaku:
+	@echo "Removing libwaku"
+	rm $(LIBWAKU)
+
+rebuild-libwaku: | clean-libwaku $(LIBWAKU)
 
 test: test-unit ##@tests Run basic, short tests during development
 

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,16 @@ else
 endif
 
 ifeq ($(detected_OS),Darwin)
- GOBIN_SHARED_LIB_EXT := so
+ GOBIN_SHARED_LIB_EXT := dylib
+ LIBWAKU_EXT := so
  GOBIN_SHARED_LIB_CFLAGS := CGO_ENABLED=1 GOOS=darwin
 else ifeq ($(detected_OS),Windows)
  GOBIN_SHARED_LIB_EXT := dll
+ LIBWAKU_EXT := dll
  GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS=""
 else
  GOBIN_SHARED_LIB_EXT := so
+ LIBWAKU_EXT := so
  GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS="-Wl,-soname,libstatus.so.0"
 endif
 
@@ -146,7 +149,7 @@ $(GO_CMD_BUILDS): ##@build Build any Go project from cmd folder
 	echo "Compilation done." ;\
 	echo "Run \"build/bin/$(notdir $@) -h\" to view available commands."
 
-LIBWAKU := $(CURDIR)/vendor/github.com/waku-org/waku-go-bindings/third_party/nwaku/build/libwaku.$(GOBIN_SHARED_LIB_EXT)
+LIBWAKU := $(CURDIR)/vendor/github.com/waku-org/waku-go-bindings/third_party/nwaku/build/libwaku.$(LIBWAKU_EXT)
 $(LIBWAKU):
 ifeq ($(USE_NWAKU),true)
 	@echo "Building libwaku"

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,8 @@ statusgo-cross: statusgo-android statusgo-ios
 	@ls -ld build/bin/statusgo-*
 
 status-go-deps:
+	go clean -cache
+	go clean -modcache
 	go install go.uber.org/mock/mockgen@v0.4.0
 	go install github.com/kevinburke/go-bindata/v4/...@v4.0.2
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1

--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -93,9 +93,9 @@ pipeline {
         steps {
             script {
                 shell('make statusgo-shared-library')
+                }
             }
         }
-    }
 
     stage('Archive') {
         steps {

--- a/_assets/ci/Jenkinsfile.nwaku
+++ b/_assets/ci/Jenkinsfile.nwaku
@@ -151,7 +151,7 @@ def shell(cmd) {
     if (env.PLATFORM == 'windows') {
         sh "${cmd} SHELL=/bin/sh"
     } else {
-        nix.shell(cmd, pure: false) // Use nix.shell for Linux/macOS
+        nix.develop(cmd, pure: false) // Use nix.develop for Linux/macOS
     }
 }
 

--- a/_assets/ci/Jenkinsfile.nwaku
+++ b/_assets/ci/Jenkinsfile.nwaku
@@ -89,10 +89,12 @@ pipeline {
             }
         }
 
-    stage('Build Shared Lib') {
+     stage('Build Shared Lib with nwaku') {
         steps {
             script {
-                shell('make statusgo-shared-library')
+              if (env.PLATFORM == 'linux') {
+                shell('USE_NWAKU=true make statusgo-shared-library')
+              }
             }
         }
     }
@@ -149,7 +151,7 @@ def shell(cmd) {
     if (env.PLATFORM == 'windows') {
         sh "${cmd} SHELL=/bin/sh"
     } else {
-        nix.develop(cmd, pure: false) // Use nix.develop for Linux/macOS
+        nix.shell(cmd, pure: false) // Use nix.shell for Linux/macOS
     }
 }
 

--- a/_assets/ci/Jenkinsfile.nwaku
+++ b/_assets/ci/Jenkinsfile.nwaku
@@ -27,7 +27,7 @@ pipeline {
     timestamps()
     ansiColor('xterm')
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 15, unit: 'MINUTES')
+    timeout(time: 30, unit: 'MINUTES')
     disableConcurrentBuilds()
     /* manage how many builds we keep */
     buildDiscarder(logRotator(

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/status-im/extkeys v1.1.0
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/waku-org/go-waku v0.8.1-0.20250411145637-900b98812a91
-	github.com/waku-org/waku-go-bindings v0.0.0-20250411112228-442f6baabd20
+	github.com/waku-org/waku-go-bindings v0.0.0-20250527143900-e37fbd26d67a
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/status-im/extkeys v1.1.0
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/waku-org/go-waku v0.8.1-0.20250411145637-900b98812a91
-	github.com/waku-org/waku-go-bindings v0.0.0-20250313132258-6f95d51df46c
+	github.com/waku-org/waku-go-bindings v0.0.0-20250411112228-442f6baabd20
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/status-im/extkeys v1.1.0
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/waku-org/go-waku v0.8.1-0.20250411145637-900b98812a91
-	github.com/waku-org/waku-go-bindings v0.0.0-20250527143900-e37fbd26d67a
+	github.com/waku-org/waku-go-bindings v0.0.0-20250528131356-4af668737057
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -2169,8 +2169,8 @@ github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065 h1:Sd7
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065/go.mod h1:7cSGUoGVIla1IpnChrLbkVjkYgdOcr7rcifEfh4ReR4=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:4HSdWMFMufpRo3ECTX6BrvA+VzKhXZf7mS0rTa5cCWU=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
-github.com/waku-org/waku-go-bindings v0.0.0-20250404151507-e8588762f446 h1:qPB2umbWzyeXfLRPTvux9AVwDfB5XDLtMbE5RvTo2S0=
-github.com/waku-org/waku-go-bindings v0.0.0-20250404151507-e8588762f446/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20250411112228-442f6baabd20 h1:lRjB/Ff1hw8PqxyO8LkWqK1FUOIhD2a3IyiA6ZzfG5w=
+github.com/waku-org/waku-go-bindings v0.0.0-20250411112228-442f6baabd20/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.5.0 h1:Huc9GxBgiGweCOGTYomvsg07K2QggAqZpZ5SuiZdC8o=
 github.com/wealdtech/go-ens/v3 v3.5.0/go.mod h1:bVuYoWYEEeEu7Zy95rIMjPR34QFJarxt8p84ywSo0YM=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/go.sum
+++ b/go.sum
@@ -2169,8 +2169,8 @@ github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065 h1:Sd7
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065/go.mod h1:7cSGUoGVIla1IpnChrLbkVjkYgdOcr7rcifEfh4ReR4=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:4HSdWMFMufpRo3ECTX6BrvA+VzKhXZf7mS0rTa5cCWU=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
-github.com/waku-org/waku-go-bindings v0.0.0-20250313132258-6f95d51df46c h1:3tr0wlG2tco4HKT6H6j53PZSpJVLE+wjCaxpr4XPRhI=
-github.com/waku-org/waku-go-bindings v0.0.0-20250313132258-6f95d51df46c/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20250404151507-e8588762f446 h1:qPB2umbWzyeXfLRPTvux9AVwDfB5XDLtMbE5RvTo2S0=
+github.com/waku-org/waku-go-bindings v0.0.0-20250404151507-e8588762f446/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.5.0 h1:Huc9GxBgiGweCOGTYomvsg07K2QggAqZpZ5SuiZdC8o=
 github.com/wealdtech/go-ens/v3 v3.5.0/go.mod h1:bVuYoWYEEeEu7Zy95rIMjPR34QFJarxt8p84ywSo0YM=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/go.sum
+++ b/go.sum
@@ -2169,8 +2169,8 @@ github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065 h1:Sd7
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065/go.mod h1:7cSGUoGVIla1IpnChrLbkVjkYgdOcr7rcifEfh4ReR4=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:4HSdWMFMufpRo3ECTX6BrvA+VzKhXZf7mS0rTa5cCWU=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
-github.com/waku-org/waku-go-bindings v0.0.0-20250411112228-442f6baabd20 h1:lRjB/Ff1hw8PqxyO8LkWqK1FUOIhD2a3IyiA6ZzfG5w=
-github.com/waku-org/waku-go-bindings v0.0.0-20250411112228-442f6baabd20/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20250527143900-e37fbd26d67a h1:Pjm+ylFCah4LR5e4HMot7QmbZKsxm3jsZ0YRaRnXvpY=
+github.com/waku-org/waku-go-bindings v0.0.0-20250527143900-e37fbd26d67a/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.5.0 h1:Huc9GxBgiGweCOGTYomvsg07K2QggAqZpZ5SuiZdC8o=
 github.com/wealdtech/go-ens/v3 v3.5.0/go.mod h1:bVuYoWYEEeEu7Zy95rIMjPR34QFJarxt8p84ywSo0YM=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/go.sum
+++ b/go.sum
@@ -2169,8 +2169,8 @@ github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065 h1:Sd7
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065/go.mod h1:7cSGUoGVIla1IpnChrLbkVjkYgdOcr7rcifEfh4ReR4=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:4HSdWMFMufpRo3ECTX6BrvA+VzKhXZf7mS0rTa5cCWU=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
-github.com/waku-org/waku-go-bindings v0.0.0-20250527143900-e37fbd26d67a h1:Pjm+ylFCah4LR5e4HMot7QmbZKsxm3jsZ0YRaRnXvpY=
-github.com/waku-org/waku-go-bindings v0.0.0-20250527143900-e37fbd26d67a/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20250528131356-4af668737057 h1:9ZsIVx4VQc75gIVTwB6TySQs/r/bcpMUNg/p85iI5js=
+github.com/waku-org/waku-go-bindings v0.0.0-20250528131356-4af668737057/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.5.0 h1:Huc9GxBgiGweCOGTYomvsg07K2QggAqZpZ5SuiZdC8o=
 github.com/wealdtech/go-ens/v3 v3.5.0/go.mod h1:bVuYoWYEEeEu7Zy95rIMjPR34QFJarxt8p84ywSo0YM=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -28,7 +28,7 @@ in mkShell {
   buildInputs = with pkgs; [
     git jq which
     go golangci-lint go-junit-report gopls go-bindata gomobileMod codecov-cli go-generate-fast
-    mockgen protobuf3_20 protoc-gen-go gotestsum go-modvendor openjdk
+    mockgen protobuf3_20 protoc-gen-go gotestsum go-modvendor openjdk openssl
    ] ++ lib.optionals (stdenv.isDarwin) [ xcodeWrapper ];
 
    shellHook = lib.optionalString (!isMacM1) ''

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,6 +22,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/event"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
+
+	bindings "github.com/waku-org/waku-go-bindings/waku/common"
 
 	"github.com/status-im/status-go/appmetrics"
 	"github.com/status-im/status-go/common"
@@ -271,6 +274,15 @@ func (b *StatusNode) wakuV2Service(nodeConfig *params.NodeConfig) (*wakuv2.Waku,
 					return nil, fmt.Errorf("could not convert nodekey into a valid private key: %v", err)
 				}
 			}
+		}
+
+		cfg.NwakuConfig = &bindings.WakuConfig{
+			Nodekey:   hex.EncodeToString(crypto.FromECDSA(nodeKey)),
+			Host:      nodeConfig.WakuV2Config.Host,
+			TcpPort:   nodeConfig.WakuV2Config.Port,
+			LogLevel:  "DEBUG", // TODO-nwaku ?
+			ClusterID: nodeConfig.ClusterConfig.ClusterID,
+			Shards:    []uint16{wakuv2.DefaultShardIndex, wakuv2.NonProtectedShardIndex},
 		}
 
 		w, err := wakuv2.New(nodeKey, cfg, logutils.ZapLogger(), b.appDB, b.timeSource(), signal.SendHistoricMessagesRequestFailed, signal.SendPeerStats)

--- a/protocol/waku_builder_test.go
+++ b/protocol/waku_builder_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/status-im/status-go/wakuv2"
 	waku2 "github.com/status-im/status-go/wakuv2"
 
+	"github.com/waku-org/waku-go-bindings/waku/common"
+
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
 
@@ -31,6 +33,15 @@ func NewTestWakuV2(s *suite.Suite, cfg testWakuV2Config) *waku2.Waku {
 		EnablePeerExchangeServer: true,
 		EnablePeerExchangeClient: false,
 		EnableDiscV5:             false,
+	}
+
+	wakuConfig.NwakuConfig = &common.WakuConfig{
+		Relay:         true,
+		LogLevel:      "DEBUG",
+		ClusterID:     cfg.clusterID,
+		Shards:        []uint16{wakuv2.DefaultShardIndex},
+		Discv5UdpPort: 0,
+		TcpPort:       0,
 	}
 
 	var nodeKey *ecdsa.PrivateKey

--- a/vendor/github.com/waku-org/waku-go-bindings/utils/utils.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/utils/utils.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	testName  string
+	iteration int
+	phase     string
+	mu        sync.Mutex
+)
+
+func RecordMemoryMetricsCSV(testName string, iter int, phase string, heapKB, rssKB uint64) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	f, err := os.OpenFile("memory_metrics.csv", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w := csv.NewWriter(f)
+	defer w.Flush()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if stat.Size() == 0 {
+		header := []string{"TestName", "Iteration", "Phase", "HeapAlloc(KB)", "RSS(KB)", "Timestamp"}
+		if err := w.Write(header); err != nil {
+			return err
+		}
+	}
+
+	row := []string{
+		testName,
+		strconv.Itoa(iter),
+		phase,
+		strconv.FormatUint(heapKB, 10),
+		strconv.FormatUint(rssKB, 10),
+		time.Now().Format(time.RFC3339),
+	}
+
+	return w.Write(row)
+}
+
+func GetRSSKB() (uint64, error) {
+	f, err := os.Open("/proc/self/statm")
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return 0, err
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) < 2 {
+		return 0, fmt.Errorf("unexpected /proc/self/statm format")
+	}
+	rssPages, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	pageSize := os.Getpagesize()
+	return (rssPages * uint64(pageSize)) / 1024, nil
+}
+

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/common/envelope.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/common/envelope.go
@@ -15,7 +15,7 @@ type Envelope struct {
 	hash  MessageHash
 }
 
-type tmpWakuMessageJson struct {
+type wakuMessage struct {
 	Payload        []byte  `json:"payload,omitempty"`
 	ContentTopic   string  `json:"contentTopic,omitempty"`
 	Version        *uint32 `json:"version,omitempty"`
@@ -25,32 +25,32 @@ type tmpWakuMessageJson struct {
 	RateLimitProof []byte  `json:"proof,omitempty"`
 }
 
-type tmpEnvelopeStruct struct {
-	WakuMessage tmpWakuMessageJson `json:"wakuMessage"`
-	PubsubTopic string             `json:"pubsubTopic"`
-	MessageHash MessageHash        `json:"messageHash"`
+type wakuEnvelope struct {
+	WakuMessage wakuMessage `json:"wakuMessage"`
+	PubsubTopic string      `json:"pubsubTopic"`
+	MessageHash MessageHash `json:"messageHash"`
 }
 
 // NewEnvelope creates a new Envelope from a json string generated in nwaku
 func NewEnvelope(jsonEventStr string) (*Envelope, error) {
-	tmpEnvelopeStruct := tmpEnvelopeStruct{}
-	err := json.Unmarshal([]byte(jsonEventStr), &tmpEnvelopeStruct)
+	wakuEnvelope := wakuEnvelope{}
+	err := json.Unmarshal([]byte(jsonEventStr), &wakuEnvelope)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Envelope{
 		msg: &pb.WakuMessage{
-			Payload:        tmpEnvelopeStruct.WakuMessage.Payload,
-			ContentTopic:   tmpEnvelopeStruct.WakuMessage.ContentTopic,
-			Version:        tmpEnvelopeStruct.WakuMessage.Version,
-			Timestamp:      tmpEnvelopeStruct.WakuMessage.Timestamp,
-			Meta:           tmpEnvelopeStruct.WakuMessage.Meta,
-			Ephemeral:      tmpEnvelopeStruct.WakuMessage.Ephemeral,
-			RateLimitProof: tmpEnvelopeStruct.WakuMessage.RateLimitProof,
+			Payload:        wakuEnvelope.WakuMessage.Payload,
+			ContentTopic:   wakuEnvelope.WakuMessage.ContentTopic,
+			Version:        wakuEnvelope.WakuMessage.Version,
+			Timestamp:      wakuEnvelope.WakuMessage.Timestamp,
+			Meta:           wakuEnvelope.WakuMessage.Meta,
+			Ephemeral:      wakuEnvelope.WakuMessage.Ephemeral,
+			RateLimitProof: wakuEnvelope.WakuMessage.RateLimitProof,
 		},
-		topic: tmpEnvelopeStruct.PubsubTopic,
-		hash:  tmpEnvelopeStruct.MessageHash,
+		topic: wakuEnvelope.PubsubTopic,
+		hash:  wakuEnvelope.MessageHash,
 	}, nil
 }
 

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/common/envelope.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/common/envelope.go
@@ -9,13 +9,7 @@ import (
 // Envelope contains information about the pubsub topic of a WakuMessage
 // and a hash used to identify a message based on the bytes of a WakuMessage
 // protobuffer
-type Envelope interface {
-	Message() *pb.WakuMessage
-	PubsubTopic() string
-	Hash() MessageHash
-}
-
-type envelopeImpl struct {
+type Envelope struct {
 	msg   *pb.WakuMessage
 	topic string
 	hash  MessageHash
@@ -38,18 +32,14 @@ type tmpEnvelopeStruct struct {
 }
 
 // NewEnvelope creates a new Envelope from a json string generated in nwaku
-func NewEnvelope(jsonEventStr string) (Envelope, error) {
+func NewEnvelope(jsonEventStr string) (*Envelope, error) {
 	tmpEnvelopeStruct := tmpEnvelopeStruct{}
 	err := json.Unmarshal([]byte(jsonEventStr), &tmpEnvelopeStruct)
 	if err != nil {
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
-	return &envelopeImpl{
+	return &Envelope{
 		msg: &pb.WakuMessage{
 			Payload:        tmpEnvelopeStruct.WakuMessage.Payload,
 			ContentTopic:   tmpEnvelopeStruct.WakuMessage.ContentTopic,
@@ -64,14 +54,14 @@ func NewEnvelope(jsonEventStr string) (Envelope, error) {
 	}, nil
 }
 
-func (e *envelopeImpl) Message() *pb.WakuMessage {
+func (e *Envelope) Message() *pb.WakuMessage {
 	return e.msg
 }
 
-func (e *envelopeImpl) PubsubTopic() string {
+func (e *Envelope) PubsubTopic() string {
 	return e.topic
 }
 
-func (e *envelopeImpl) Hash() MessageHash {
+func (e *Envelope) Hash() MessageHash {
 	return e.hash
 }

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/common/envelope.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/common/envelope.go
@@ -31,27 +31,27 @@ type wakuEnvelope struct {
 	MessageHash MessageHash `json:"messageHash"`
 }
 
-// NewEnvelope creates a new Envelope from a json string generated in nwaku
-func NewEnvelope(jsonEventStr string) (*Envelope, error) {
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (e *Envelope) UnmarshalJSON(input []byte) error {
 	wakuEnvelope := wakuEnvelope{}
-	err := json.Unmarshal([]byte(jsonEventStr), &wakuEnvelope)
+	err := json.Unmarshal(input, &wakuEnvelope)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &Envelope{
-		msg: &pb.WakuMessage{
-			Payload:        wakuEnvelope.WakuMessage.Payload,
-			ContentTopic:   wakuEnvelope.WakuMessage.ContentTopic,
-			Version:        wakuEnvelope.WakuMessage.Version,
-			Timestamp:      wakuEnvelope.WakuMessage.Timestamp,
-			Meta:           wakuEnvelope.WakuMessage.Meta,
-			Ephemeral:      wakuEnvelope.WakuMessage.Ephemeral,
-			RateLimitProof: wakuEnvelope.WakuMessage.RateLimitProof,
-		},
-		topic: wakuEnvelope.PubsubTopic,
-		hash:  wakuEnvelope.MessageHash,
-	}, nil
+	e.msg = &pb.WakuMessage{
+		Payload:        wakuEnvelope.WakuMessage.Payload,
+		ContentTopic:   wakuEnvelope.WakuMessage.ContentTopic,
+		Version:        wakuEnvelope.WakuMessage.Version,
+		Timestamp:      wakuEnvelope.WakuMessage.Timestamp,
+		Meta:           wakuEnvelope.WakuMessage.Meta,
+		Ephemeral:      wakuEnvelope.WakuMessage.Ephemeral,
+		RateLimitProof: wakuEnvelope.WakuMessage.RateLimitProof,
+	}
+	e.topic = wakuEnvelope.PubsubTopic
+	e.hash = wakuEnvelope.MessageHash
+
+	return nil
 }
 
 func (e *Envelope) Message() *pb.WakuMessage {

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/common/peers.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/common/peers.go
@@ -1,0 +1,97 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/multiformats/go-multiaddr"
+)
+
+type PeersData map[peer.ID]PeerInfo
+type PeerInfo struct {
+	Protocols []protocol.ID         `json:"protocols"`
+	Addresses []multiaddr.Multiaddr `json:"addresses"`
+}
+
+func ParsePeerInfoFromJSON(jsonStr string) (PeersData, error) {
+	/*
+		We expect a JSON string with the format:
+
+			{
+				<peerId1>: {
+				  "protocols": [
+					"protocol1",
+					"protocol2",
+					 ...
+				  ],
+				  "addresses": [
+					"address1",
+					"address2",
+					...
+				  ]
+				},
+				<peerId2>: ...
+			}
+	*/
+	// Create a temporary map to unmarshal the JSON data
+	var rawMap map[string]struct {
+		Protocols []string `json:"protocols"`
+		Addresses []string `json:"addresses"`
+	}
+
+	// Unmarshal the JSON string to our temporary map
+	if err := json.Unmarshal([]byte(jsonStr), &rawMap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	// Create the result map
+	result := make(PeersData)
+
+	// Process each peer entry
+	for peerIDStr, rawPeer := range rawMap {
+		// Parse the peer ID
+		peerID, err := peer.Decode(peerIDStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode peer ID %s: %w", peerIDStr, err)
+		}
+
+		// Convert protocols to libp2pproto.ID
+		protocols := make([]protocol.ID, len(rawPeer.Protocols))
+		for i, protoStr := range rawPeer.Protocols {
+			protocols[i] = protocol.ID(protoStr)
+		}
+
+		// Convert addresses to multiaddr.Multiaddr
+		addresses := make([]multiaddr.Multiaddr, 0, len(rawPeer.Addresses))
+		for _, addrStr := range rawPeer.Addresses {
+			addr, err := multiaddr.NewMultiaddr(addrStr)
+			if err != nil {
+				// Log the error but continue with other addresses
+				log.Printf("failed to parse multiaddress %s: %v", addrStr, err)
+				continue
+			}
+			addresses = append(addresses, addr)
+		}
+
+		// Add the peer to the result map
+		result[peerID] = PeerInfo{
+			Protocols: protocols,
+			Addresses: addresses,
+		}
+	}
+
+	return result, nil
+}
+
+// EncapsulatePeerID takes a peer.ID and adds a p2p component to all multiaddresses it receives
+func EncapsulatePeerID(peerID peer.ID, addrs ...multiaddr.Multiaddr) []multiaddr.Multiaddr {
+	hostInfo, _ := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", peerID.String()))
+	var result []multiaddr.Multiaddr
+	for _, addr := range addrs {
+		result = append(result, addr.Encapsulate(hostInfo))
+	}
+	return result
+}

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/common/store.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/common/store.go
@@ -1,22 +1,22 @@
 package common
 
 type StoreQueryRequest struct {
-	RequestId         string         `json:"request_id"`
-	IncludeData       bool           `json:"include_data"`
-	PubsubTopic       string         `json:"pubsub_topic,omitempty"`
-	ContentTopics     *[]string      `json:"content_topics,omitempty"`
-	TimeStart         *int64         `json:"time_start,omitempty"`
-	TimeEnd           *int64         `json:"time_end,omitempty"`
-	MessageHashes     *[]MessageHash `json:"message_hashes,omitempty"`
-	PaginationCursor  *MessageHash   `json:"pagination_cursor,omitempty"`
-	PaginationForward bool           `json:"pagination_forward"`
-	PaginationLimit   *uint64        `json:"pagination_limit,omitempty"`
+	RequestId         string         `json:"requestId"`
+	IncludeData       bool           `json:"includeData"`
+	PubsubTopic       string         `json:"pubsubTopic,omitempty"`
+	ContentTopics     *[]string      `json:"contentTopics,omitempty"`
+	TimeStart         *int64         `json:"timeStart,omitempty"`
+	TimeEnd           *int64         `json:"timeEnd,omitempty"`
+	MessageHashes     *[]MessageHash `json:"messageHashes,omitempty"`
+	PaginationCursor  *MessageHash   `json:"paginationCursor,omitempty"`
+	PaginationForward bool           `json:"paginationForward"`
+	PaginationLimit   *uint64        `json:"paginationLimit,omitempty"`
 }
 
 type StoreMessageResponse struct {
-	WakuMessage *tmpWakuMessageJson `json:"message"`
-	PubsubTopic string              `json:"pubsubTopic"`
-	MessageHash MessageHash         `json:"messageHash"`
+	WakuMessage *wakuMessage `json:"message"`
+	PubsubTopic string       `json:"pubsubTopic"`
+	MessageHash MessageHash  `json:"messageHash"`
 }
 
 type StoreQueryResponse struct {

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/common/store.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/common/store.go
@@ -1,15 +1,15 @@
 package common
 
 type StoreQueryRequest struct {
-	RequestId         string         `json:"requestId"`
-	IncludeData       bool           `json:"includeData"`
+	RequestId         string         `json:"request_id"`
+	IncludeData       bool           `json:"include_data"`
 	PubsubTopic       string         `json:"pubsubTopic,omitempty"`
 	ContentTopics     *[]string      `json:"contentTopics,omitempty"`
 	TimeStart         *int64         `json:"timeStart,omitempty"`
 	TimeEnd           *int64         `json:"timeEnd,omitempty"`
 	MessageHashes     *[]MessageHash `json:"messageHashes,omitempty"`
 	PaginationCursor  *MessageHash   `json:"paginationCursor,omitempty"`
-	PaginationForward bool           `json:"paginationForward"`
+	PaginationForward bool           `json:"pagination_forward"`
 	PaginationLimit   *uint64        `json:"paginationLimit,omitempty"`
 }
 

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/common/store.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/common/store.go
@@ -1,15 +1,15 @@
 package common
 
 type StoreQueryRequest struct {
-	RequestId         string         `json:"request_id"`
-	IncludeData       bool           `json:"include_data"`
+	RequestId         string         `json:"requestId"`
+	IncludeData       bool           `json:"includeData"`
 	PubsubTopic       string         `json:"pubsubTopic,omitempty"`
 	ContentTopics     *[]string      `json:"contentTopics,omitempty"`
 	TimeStart         *int64         `json:"timeStart,omitempty"`
 	TimeEnd           *int64         `json:"timeEnd,omitempty"`
 	MessageHashes     *[]MessageHash `json:"messageHashes,omitempty"`
 	PaginationCursor  *MessageHash   `json:"paginationCursor,omitempty"`
-	PaginationForward bool           `json:"pagination_forward"`
+	PaginationForward bool           `json:"paginationForward"`
 	PaginationLimit   *uint64        `json:"paginationLimit,omitempty"`
 }
 

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/logging.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/logging.go
@@ -13,9 +13,8 @@ var (
 
 func _getLogger() *zap.SugaredLogger {
 	once.Do(func() {
+
 		config := zap.NewDevelopmentConfig()
-		config.DisableCaller = true
-		config.EncoderConfig.CallerKey = ""
 		l, err := config.Build()
 		if err != nil {
 			panic(err)

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
@@ -484,7 +484,11 @@ func (n *WakuNode) parseMessageEvent(eventStr string) {
 	if err != nil {
 		Error("could not parse message %v", err)
 	}
-	n.MsgChan <- *envelope
+	select {
+	case n.MsgChan <- *envelope:
+	default:
+		Warn("Can't deliver message to subscription, MsgChan is full")
+	}
 }
 
 func (n *WakuNode) parseTopicHealthChangeEvent(eventStr string) {
@@ -494,7 +498,12 @@ func (n *WakuNode) parseTopicHealthChangeEvent(eventStr string) {
 	if err != nil {
 		Error("could not parse topic health change %v", err)
 	}
-	n.TopicHealthChan <- topicHealth
+
+	select {
+	case n.TopicHealthChan <- topicHealth:
+	default:
+		Warn("Can't deliver topic health event, TopicHealthChan is full")
+	}
 }
 
 func (n *WakuNode) parseConnectionChangeEvent(eventStr string) {
@@ -504,7 +513,12 @@ func (n *WakuNode) parseConnectionChangeEvent(eventStr string) {
 	if err != nil {
 		Error("could not parse connection change %v", err)
 	}
-	n.ConnectionChangeChan <- connectionChange
+
+	select {
+	case n.ConnectionChangeChan <- connectionChange:
+	default:
+		Warn("Can't deliver connection change event, ConnectionChangeChan is full")
+	}
 }
 
 func (n *WakuNode) GetNumConnectedRelayPeers(optPubsubTopic ...string) (int, error) {

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
@@ -480,12 +480,14 @@ func (n *WakuNode) OnEvent(eventStr string) {
 }
 
 func (n *WakuNode) parseMessageEvent(eventStr string) {
-	envelope, err := common.NewEnvelope(eventStr)
+	var envelope common.Envelope
+	err := json.Unmarshal([]byte(eventStr), &envelope)
 	if err != nil {
 		Error("could not parse message %v", err)
+		return
 	}
 	select {
-	case n.MsgChan <- *envelope:
+	case n.MsgChan <- envelope:
 	default:
 		Warn("Can't deliver message to subscription, MsgChan is full")
 	}

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
@@ -223,6 +223,10 @@ package waku
 		waku_ping_peer(ctx, peerAddr, timeoutMs, (WakuCallBack) GoCallback, resp);
 	}
 
+	static void cGoWakuGetPeersInMesh(void* ctx, char* pubSubTopic, void* resp) {
+		waku_relay_get_peers_in_mesh(ctx, pubSubTopic, (WakuCallBack) GoCallback, resp);
+	}
+
 	static void cGoWakuGetNumPeersInMesh(void* ctx, char* pubSubTopic, void* resp) {
 		waku_relay_get_num_peers_in_mesh(ctx, pubSubTopic, (WakuCallBack) GoCallback, resp);
 	}
@@ -231,12 +235,20 @@ package waku
 		waku_relay_get_num_connected_peers(ctx, pubSubTopic, (WakuCallBack) GoCallback, resp);
 	}
 
+	static void cGoWakuGetConnectedRelayPeers(void* ctx, char* pubSubTopic, void* resp) {
+		waku_relay_get_connected_peers(ctx, pubSubTopic, (WakuCallBack) GoCallback, resp);
+	}
+
 	static void cGoWakuGetConnectedPeers(void* wakuCtx, void* resp) {
 		waku_get_connected_peers(wakuCtx, (WakuCallBack) GoCallback, resp);
 	}
 
 	static void cGoWakuGetPeerIdsFromPeerStore(void* wakuCtx, void* resp) {
 		waku_get_peerids_from_peerstore(wakuCtx, (WakuCallBack) GoCallback, resp);
+	}
+
+	static void cGoWakuGetConnectedPeersInfo(void* wakuCtx, void* resp) {
+		waku_get_connected_peers_info(wakuCtx, (WakuCallBack) GoCallback, resp);
 	}
 
 	static void cGoWakuLightpushPublish(void* wakuCtx,
@@ -472,7 +484,7 @@ func (n *WakuNode) parseMessageEvent(eventStr string) {
 	if err != nil {
 		Error("could not parse message %v", err)
 	}
-	n.MsgChan <- envelope
+	n.MsgChan <- *envelope
 }
 
 func (n *WakuNode) parseTopicHealthChangeEvent(eventStr string) {
@@ -529,6 +541,60 @@ func (n *WakuNode) GetNumConnectedRelayPeers(optPubsubTopic ...string) (int, err
 	Error("Failed to get number of connected relay peers for %s: %s", n.nodeName, errMsg)
 
 	return 0, errors.New(errMsg)
+}
+
+func (n *WakuNode) GetConnectedRelayPeers(optPubsubTopic ...string) (peer.IDSlice, error) {
+
+	pubsubTopic := ""
+	if len(optPubsubTopic) > 0 {
+		pubsubTopic = optPubsubTopic[0]
+	}
+
+	if n == nil {
+		err := errors.New("waku node is nil")
+		Error("Failed to get connected relay peers: %v", err)
+		return nil, err
+	}
+
+	Debug("Fetching connected relay peers for pubsubTopic: %v, node: %v", pubsubTopic, n.nodeName)
+
+	wg := sync.WaitGroup{}
+	var resp = C.allocResp(unsafe.Pointer(&wg))
+	defer C.freeResp(resp)
+
+	var cPubsubTopic = C.CString(pubsubTopic)
+	defer C.free(unsafe.Pointer(cPubsubTopic))
+
+	wg.Add(1)
+	C.cGoWakuGetConnectedRelayPeers(n.wakuCtx, cPubsubTopic, resp)
+	wg.Wait()
+
+	if C.getRet(resp) == C.RET_OK {
+		peersStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+		if peersStr == "" {
+			Debug("No connected relay peers found for pubsubTopic: %v, node: %v", pubsubTopic, n.nodeName)
+			return nil, nil
+		}
+
+		peerIDs := strings.Split(peersStr, ",")
+		var peers peer.IDSlice
+		for _, peerID := range peerIDs {
+			id, err := peer.Decode(peerID)
+			if err != nil {
+				Error("Failed to decode peer ID for %v: %v", n.nodeName, err)
+				return nil, err
+			}
+			peers = append(peers, id)
+		}
+
+		Debug("Successfully fetched connected relay peers for pubsubTopic: %v, node: %v count: %v", pubsubTopic, n.nodeName, len(peers))
+		return peers, nil
+	}
+
+	errMsg := "error GetConnectedRelayPeers: " + C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+	Error("Failed to get connected relay peers for pubsubTopic: %v:, node: %v. %v", pubsubTopic, n.nodeName, errMsg)
+
+	return nil, errors.New(errMsg)
 }
 
 func (n *WakuNode) DisconnectPeerByID(peerID peer.ID) error {
@@ -591,6 +657,54 @@ func (n *WakuNode) GetConnectedPeers() (peer.IDSlice, error) {
 
 	errMsg := "error GetConnectedPeers: " + C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
 	Error("Failed to get connected peers for %v: %v", n.nodeName, errMsg)
+
+	return nil, errors.New(errMsg)
+}
+
+func (n *WakuNode) GetPeersInMesh(pubsubTopic string) (peer.IDSlice, error) {
+	if n == nil {
+		err := errors.New("waku node is nil")
+		Error("Failed to get peers in mesh: %v", err)
+		return nil, err
+	}
+
+	Debug("Fetching peers in mesh peers for pubsubTopic: %v, node: %v", pubsubTopic, n.nodeName)
+
+	wg := sync.WaitGroup{}
+	var resp = C.allocResp(unsafe.Pointer(&wg))
+	defer C.freeResp(resp)
+
+	var cPubsubTopic = C.CString(pubsubTopic)
+	defer C.free(unsafe.Pointer(cPubsubTopic))
+
+	wg.Add(1)
+	C.cGoWakuGetPeersInMesh(n.wakuCtx, cPubsubTopic, resp)
+	wg.Wait()
+
+	if C.getRet(resp) == C.RET_OK {
+		peersStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+		if peersStr == "" {
+			Debug("No peers in mesh found for pubsubTopic: %v, node: %v", pubsubTopic, n.nodeName)
+			return nil, nil
+		}
+
+		peerIDs := strings.Split(peersStr, ",")
+		var peers peer.IDSlice
+		for _, peerID := range peerIDs {
+			id, err := peer.Decode(peerID)
+			if err != nil {
+				Error("Failed to decode peer ID for %v: %v", n.nodeName, err)
+				return nil, err
+			}
+			peers = append(peers, id)
+		}
+
+		Debug("Successfully fetched mesh peers for pubsubTopic: %v, node: %v count: %v", pubsubTopic, n.nodeName, len(peers))
+		return peers, nil
+	}
+
+	errMsg := "error GetPeersInMesh: " + C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+	Error("Failed to get peers in mesh for pubsubTopic: %v:, node: %v. %v", pubsubTopic, n.nodeName, errMsg)
 
 	return nil, errors.New(errMsg)
 }
@@ -1176,6 +1290,33 @@ func (n *WakuNode) GetPeerIDsFromPeerStore() (peer.IDSlice, error) {
 	return nil, fmt.Errorf("GetPeerIdsFromPeerStore: %s", errMsg)
 }
 
+func (n *WakuNode) GetConnectedPeersInfo() (common.PeersData, error) {
+	wg := sync.WaitGroup{}
+
+	var resp = C.allocResp(unsafe.Pointer(&wg))
+	defer C.freeResp(resp)
+
+	wg.Add(1)
+	C.cGoWakuGetConnectedPeersInfo(n.wakuCtx, resp)
+	wg.Wait()
+	if C.getRet(resp) == C.RET_OK {
+		jsonStr := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+		if jsonStr == "" {
+			return nil, nil
+		}
+
+		peerData, err := common.ParsePeerInfoFromJSON(jsonStr)
+
+		if err != nil {
+			return nil, fmt.Errorf("GetConnectedPeersInfo - failed parsing JSON: %w", err)
+		}
+
+		return peerData, nil
+	}
+	errMsg := C.GoStringN(C.getMyCharPtr(resp), C.int(C.getMyCharLen(resp)))
+	return nil, fmt.Errorf("GetConnectedPeersInfo: %s", errMsg)
+}
+
 func (n *WakuNode) GetPeerIDsByProtocol(protocol libp2pproto.ID) (peer.IDSlice, error) {
 	wg := sync.WaitGroup{}
 
@@ -1242,7 +1383,7 @@ func (n *WakuNode) GetNumConnectedPeers() (int, error) {
 
 	peers, err := n.GetConnectedPeers()
 	if err != nil {
-		Error("Failed to fetch connected peers for %v %v ", n.nodeName, err)
+		Error("Failed to fetch connected peers for %v: %v ", n.nodeName, err)
 		return 0, err
 	}
 

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku_test_utils.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku_test_utils.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/cenkalti/backoff/v3"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+	"github.com/waku-org/waku-go-bindings/utils"
 	"github.com/waku-org/waku-go-bindings/waku/common"
 	"google.golang.org/protobuf/proto"
 )
@@ -287,4 +289,16 @@ func recordMemoryMetricsPX(testName, phase string, heapAllocKB, rssKB uint64) er
 		time.Now().Format(time.RFC3339),
 	}
 	return writer.Write(row)
+}
+
+func captureMemory(testName, phase string) {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	heapKB := ms.HeapAlloc / 1024
+	rssKB, _ := utils.GetRSSKB() 
+
+	Debug("[%s] Memory usage  (%s): %d KB (RSS %d KB)", testName, phase, heapKB, rssKB)
+
+	_ = recordMemoryMetricsPX(testName, phase, heapKB, rssKB)
 }

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku_test_utils.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku_test_utils.go
@@ -2,6 +2,7 @@ package waku
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v3"
@@ -153,10 +155,6 @@ func (n *WakuNode) VerifyMessageReceived(expectedMessage *pb.WakuMessage, expect
 
 	select {
 	case envelope := <-n.MsgChan:
-		if envelope == nil {
-			Error("Received envelope is nil on node %s", n.nodeName)
-			return errors.New("received envelope is nil")
-		}
 		if string(expectedMessage.Payload) != string(envelope.Message().Payload) {
 			Error("Payload does not match on node %s", n.nodeName)
 			return errors.New("payload does not match")
@@ -254,4 +252,39 @@ func (n *WakuNode) GetStoredMessages(storeNode *WakuNode, storeRequest *common.S
 
 	Debug("Store query successful, retrieved %d messages", len(*res.Messages))
 	return res, nil
+}
+
+func recordMemoryMetricsPX(testName, phase string, heapAllocKB, rssKB uint64) error {
+	staticMu := sync.Mutex{}
+	staticMu.Lock()
+	defer staticMu.Unlock()
+
+	file, err := os.OpenFile("px_load_metrics.csv", os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if stat.Size() == 0 {
+		header := []string{"TestName", "Phase", "HeapAlloc(KB)", "RSS(KB)", "Timestamp"}
+		if err := writer.Write(header); err != nil {
+			return err
+		}
+	}
+
+	row := []string{
+		testName,
+		phase,
+		strconv.FormatUint(heapAllocKB, 10),
+		strconv.FormatUint(rssKB, 10),
+		time.Now().Format(time.RFC3339),
+	}
+	return writer.Write(row)
 }

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/test_data.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/test_data.go
@@ -10,7 +10,7 @@ import (
 
 var DefaultWakuConfig common.WakuConfig
 var DefaultStoreQueryRequest common.StoreQueryRequest
-var DEFAULT_CLUSTER_ID = 16
+var DEFAULT_CLUSTER_ID = uint16(16)
 
 func init() {
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1133,8 +1133,9 @@ github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-pc-windows-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-musl
 github.com/waku-org/go-zerokit-rln-x86_64/rln
-# github.com/waku-org/waku-go-bindings v0.0.0-20250411112228-442f6baabd20
+# github.com/waku-org/waku-go-bindings v0.0.0-20250527143900-e37fbd26d67a
 ## explicit; go 1.21
+github.com/waku-org/waku-go-bindings/utils
 github.com/waku-org/waku-go-bindings/waku
 github.com/waku-org/waku-go-bindings/waku/common
 # github.com/wealdtech/go-ens/v3 v3.5.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1133,7 +1133,7 @@ github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-pc-windows-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-musl
 github.com/waku-org/go-zerokit-rln-x86_64/rln
-# github.com/waku-org/waku-go-bindings v0.0.0-20250527143900-e37fbd26d67a
+# github.com/waku-org/waku-go-bindings v0.0.0-20250528131356-4af668737057
 ## explicit; go 1.21
 github.com/waku-org/waku-go-bindings/utils
 github.com/waku-org/waku-go-bindings/waku

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1133,7 +1133,7 @@ github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-pc-windows-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-musl
 github.com/waku-org/go-zerokit-rln-x86_64/rln
-# github.com/waku-org/waku-go-bindings v0.0.0-20250404151507-e8588762f446
+# github.com/waku-org/waku-go-bindings v0.0.0-20250411112228-442f6baabd20
 ## explicit; go 1.21
 github.com/waku-org/waku-go-bindings/waku
 github.com/waku-org/waku-go-bindings/waku/common

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1133,7 +1133,7 @@ github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-pc-windows-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-musl
 github.com/waku-org/go-zerokit-rln-x86_64/rln
-# github.com/waku-org/waku-go-bindings v0.0.0-20250313132258-6f95d51df46c
+# github.com/waku-org/waku-go-bindings v0.0.0-20250404151507-e8588762f446
 ## explicit; go 1.21
 github.com/waku-org/waku-go-bindings/waku
 github.com/waku-org/waku-go-bindings/waku/common

--- a/wakuv2/common/envelope.go
+++ b/wakuv2/common/envelope.go
@@ -1,0 +1,79 @@
+package common
+
+import (
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+)
+
+// Envelope contains information about the pubsub topic of a WakuMessage
+// and a hash used to identify a message based on the bytes of a WakuMessage
+// protobuffer
+type Envelope interface {
+	Message() *pb.WakuMessage
+	PubsubTopic() string
+	Hash() pb.MessageHash
+}
+
+type envelopeImpl struct {
+	msg   *pb.WakuMessage
+	topic string
+	hash  pb.MessageHash
+}
+
+type tmpWakuMessageJson struct {
+	Payload        []byte  `json:"payload,omitempty"`
+	ContentTopic   string  `json:"contentTopic,omitempty"`
+	Version        *uint32 `json:"version,omitempty"`
+	Timestamp      *int64  `json:"timestamp,omitempty"`
+	Meta           []byte  `json:"meta,omitempty"`
+	Ephemeral      *bool   `json:"ephemeral,omitempty"`
+	RateLimitProof []byte  `json:"proof,omitempty"`
+}
+
+type tmpEnvelopeStruct struct {
+	WakuMessage tmpWakuMessageJson `json:"wakuMessage"`
+	PubsubTopic string             `json:"pubsubTopic"`
+	MessageHash string             `json:"messageHash"`
+}
+
+// NewEnvelope creates a new Envelope from a json string generated in nwaku
+func NewEnvelope(jsonEventStr string) (Envelope, error) {
+	tmpEnvelopeStruct := tmpEnvelopeStruct{}
+	err := json.Unmarshal([]byte(jsonEventStr), &tmpEnvelopeStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	hash, err := hexutil.Decode(tmpEnvelopeStruct.MessageHash)
+	if err != nil {
+		return nil, err
+	}
+
+	return &envelopeImpl{
+		msg: &pb.WakuMessage{
+			Payload:        tmpEnvelopeStruct.WakuMessage.Payload,
+			ContentTopic:   tmpEnvelopeStruct.WakuMessage.ContentTopic,
+			Version:        tmpEnvelopeStruct.WakuMessage.Version,
+			Timestamp:      tmpEnvelopeStruct.WakuMessage.Timestamp,
+			Meta:           tmpEnvelopeStruct.WakuMessage.Meta,
+			Ephemeral:      tmpEnvelopeStruct.WakuMessage.Ephemeral,
+			RateLimitProof: tmpEnvelopeStruct.WakuMessage.RateLimitProof,
+		},
+		topic: tmpEnvelopeStruct.PubsubTopic,
+		hash:  pb.ToMessageHash(hash),
+	}, nil
+}
+
+func (e *envelopeImpl) Message() *pb.WakuMessage {
+	return e.msg
+}
+
+func (e *envelopeImpl) PubsubTopic() string {
+	return e.topic
+}
+
+func (e *envelopeImpl) Hash() pb.MessageHash {
+	return e.hash
+}

--- a/wakuv2/common/envelope.go
+++ b/wakuv2/common/envelope.go
@@ -32,7 +32,7 @@ type tmpWakuMessageJson struct {
 	RateLimitProof []byte  `json:"proof,omitempty"`
 }
 
-type tmpEnvelopeStruct struct {
+type nwakuEnvelope struct {
 	WakuMessage tmpWakuMessageJson `json:"wakuMessage"`
 	PubsubTopic string             `json:"pubsubTopic"`
 	MessageHash string             `json:"messageHash"`
@@ -49,28 +49,28 @@ func NewWakuEnvelope(msg *pb.WakuMessage, topic string, hash pb.MessageHash) *Wa
 
 // NewEnvelope creates a new Envelope from a json string generated in nwaku
 func NewEnvelope(jsonEventStr string) (Envelope, error) {
-	tmpEnvelopeStruct := tmpEnvelopeStruct{}
-	err := json.Unmarshal([]byte(jsonEventStr), &tmpEnvelopeStruct)
+	nwakuEnvelope := nwakuEnvelope{}
+	err := json.Unmarshal([]byte(jsonEventStr), &nwakuEnvelope)
 	if err != nil {
 		return nil, err
 	}
 
-	hash, err := hexutil.Decode(tmpEnvelopeStruct.MessageHash)
+	hash, err := hexutil.Decode(nwakuEnvelope.MessageHash)
 	if err != nil {
 		return nil, err
 	}
 
 	return &WakuEnvelope{
 		msg: &pb.WakuMessage{
-			Payload:        tmpEnvelopeStruct.WakuMessage.Payload,
-			ContentTopic:   tmpEnvelopeStruct.WakuMessage.ContentTopic,
-			Version:        tmpEnvelopeStruct.WakuMessage.Version,
-			Timestamp:      tmpEnvelopeStruct.WakuMessage.Timestamp,
-			Meta:           tmpEnvelopeStruct.WakuMessage.Meta,
-			Ephemeral:      tmpEnvelopeStruct.WakuMessage.Ephemeral,
-			RateLimitProof: tmpEnvelopeStruct.WakuMessage.RateLimitProof,
+			Payload:        nwakuEnvelope.WakuMessage.Payload,
+			ContentTopic:   nwakuEnvelope.WakuMessage.ContentTopic,
+			Version:        nwakuEnvelope.WakuMessage.Version,
+			Timestamp:      nwakuEnvelope.WakuMessage.Timestamp,
+			Meta:           nwakuEnvelope.WakuMessage.Meta,
+			Ephemeral:      nwakuEnvelope.WakuMessage.Ephemeral,
+			RateLimitProof: nwakuEnvelope.WakuMessage.RateLimitProof,
 		},
-		topic: tmpEnvelopeStruct.PubsubTopic,
+		topic: nwakuEnvelope.PubsubTopic,
 		hash:  pb.ToMessageHash(hash),
 	}, nil
 }

--- a/wakuv2/common/envelope.go
+++ b/wakuv2/common/envelope.go
@@ -22,7 +22,7 @@ type WakuEnvelope struct {
 	hash  pb.MessageHash
 }
 
-type tmpWakuMessageJson struct {
+type nwakuMessage struct {
 	Payload        []byte  `json:"payload,omitempty"`
 	ContentTopic   string  `json:"contentTopic,omitempty"`
 	Version        *uint32 `json:"version,omitempty"`
@@ -33,9 +33,9 @@ type tmpWakuMessageJson struct {
 }
 
 type nwakuEnvelope struct {
-	WakuMessage tmpWakuMessageJson `json:"wakuMessage"`
-	PubsubTopic string             `json:"pubsubTopic"`
-	MessageHash string             `json:"messageHash"`
+	WakuMessage nwakuMessage `json:"wakuMessage"`
+	PubsubTopic string       `json:"pubsubTopic"`
+	MessageHash string       `json:"messageHash"`
 }
 
 func NewWakuEnvelope(msg *pb.WakuMessage, topic string, hash pb.MessageHash) *WakuEnvelope {

--- a/wakuv2/common/envelope.go
+++ b/wakuv2/common/envelope.go
@@ -16,7 +16,7 @@ type Envelope interface {
 	Hash() pb.MessageHash
 }
 
-type envelopeImpl struct {
+type WakuEnvelope struct {
 	msg   *pb.WakuMessage
 	topic string
 	hash  pb.MessageHash
@@ -38,6 +38,15 @@ type tmpEnvelopeStruct struct {
 	MessageHash string             `json:"messageHash"`
 }
 
+func NewWakuEnvelope(msg *pb.WakuMessage, topic string, hash pb.MessageHash) *WakuEnvelope {
+	return &WakuEnvelope{
+		msg:   msg,
+		topic: topic,
+		hash:  hash,
+	}
+
+}
+
 // NewEnvelope creates a new Envelope from a json string generated in nwaku
 func NewEnvelope(jsonEventStr string) (Envelope, error) {
 	tmpEnvelopeStruct := tmpEnvelopeStruct{}
@@ -51,7 +60,7 @@ func NewEnvelope(jsonEventStr string) (Envelope, error) {
 		return nil, err
 	}
 
-	return &envelopeImpl{
+	return &WakuEnvelope{
 		msg: &pb.WakuMessage{
 			Payload:        tmpEnvelopeStruct.WakuMessage.Payload,
 			ContentTopic:   tmpEnvelopeStruct.WakuMessage.ContentTopic,
@@ -66,14 +75,14 @@ func NewEnvelope(jsonEventStr string) (Envelope, error) {
 	}, nil
 }
 
-func (e *envelopeImpl) Message() *pb.WakuMessage {
+func (e *WakuEnvelope) Message() *pb.WakuMessage {
 	return e.msg
 }
 
-func (e *envelopeImpl) PubsubTopic() string {
+func (e *WakuEnvelope) PubsubTopic() string {
 	return e.topic
 }
 
-func (e *envelopeImpl) Hash() pb.MessageHash {
+func (e *WakuEnvelope) Hash() pb.MessageHash {
 	return e.hash
 }

--- a/wakuv2/common/envelope.go
+++ b/wakuv2/common/envelope.go
@@ -48,31 +48,32 @@ func NewWakuEnvelope(msg *pb.WakuMessage, topic string, hash pb.MessageHash) *Wa
 }
 
 // NewEnvelope creates a new Envelope from a json string generated in nwaku
-func NewEnvelope(jsonEventStr string) (Envelope, error) {
+func (e *WakuEnvelope) UnmarshalJSON(input []byte) error {
 	nwakuEnvelope := nwakuEnvelope{}
-	err := json.Unmarshal([]byte(jsonEventStr), &nwakuEnvelope)
+	err := json.Unmarshal(input, &nwakuEnvelope)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	hash, err := hexutil.Decode(nwakuEnvelope.MessageHash)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &WakuEnvelope{
-		msg: &pb.WakuMessage{
-			Payload:        nwakuEnvelope.WakuMessage.Payload,
-			ContentTopic:   nwakuEnvelope.WakuMessage.ContentTopic,
-			Version:        nwakuEnvelope.WakuMessage.Version,
-			Timestamp:      nwakuEnvelope.WakuMessage.Timestamp,
-			Meta:           nwakuEnvelope.WakuMessage.Meta,
-			Ephemeral:      nwakuEnvelope.WakuMessage.Ephemeral,
-			RateLimitProof: nwakuEnvelope.WakuMessage.RateLimitProof,
-		},
-		topic: nwakuEnvelope.PubsubTopic,
-		hash:  pb.ToMessageHash(hash),
-	}, nil
+	// Modify the receiver instead of returning a new instance
+	e.msg = &pb.WakuMessage{
+		Payload:        nwakuEnvelope.WakuMessage.Payload,
+		ContentTopic:   nwakuEnvelope.WakuMessage.ContentTopic,
+		Version:        nwakuEnvelope.WakuMessage.Version,
+		Timestamp:      nwakuEnvelope.WakuMessage.Timestamp,
+		Meta:           nwakuEnvelope.WakuMessage.Meta,
+		Ephemeral:      nwakuEnvelope.WakuMessage.Ephemeral,
+		RateLimitProof: nwakuEnvelope.WakuMessage.RateLimitProof,
+	}
+	e.topic = nwakuEnvelope.PubsubTopic
+	e.hash = pb.ToMessageHash(hash)
+
+	return nil
 }
 
 func (e *WakuEnvelope) Message() *pb.WakuMessage {

--- a/wakuv2/common/envelope_test.go
+++ b/wakuv2/common/envelope_test.go
@@ -3,8 +3,9 @@ package common
 import (
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 )
 

--- a/wakuv2/common/envelope_test.go
+++ b/wakuv2/common/envelope_test.go
@@ -44,4 +44,10 @@ func TestNewEnvelope(t *testing.T) {
 	assert.Equal(t, ephemeral, *msg.Ephemeral)
 	assert.Equal(t, "test-pubsub", env.PubsubTopic())
 	assert.Equal(t, pb.ToMessageHash(hashBytes), env.Hash())
+
+	// Test NewWakuEnvelope constructor
+	newEnv := NewWakuEnvelope(msg, "new-topic", pb.ToMessageHash([]byte{0xaa, 0xbb}))
+	assert.Equal(t, msg, newEnv.Message())
+	assert.Equal(t, "new-topic", newEnv.PubsubTopic())
+	assert.Equal(t, pb.ToMessageHash([]byte{0xaa, 0xbb}), newEnv.Hash())
 }

--- a/wakuv2/common/envelope_test.go
+++ b/wakuv2/common/envelope_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,9 +31,10 @@ func TestNewEnvelope(t *testing.T) {
 		"messageHash": "` + hashStr + `"
 	}`
 
-	env, err := NewEnvelope(jsonStr)
+	// Create a WakuEnvelope instance and unmarshal into it
+	var env WakuEnvelope
+	err := json.Unmarshal([]byte(jsonStr), &env)
 	assert.NoError(t, err)
-	assert.NotNil(t, env)
 
 	msg := env.Message()
 	assert.NotNil(t, msg)

--- a/wakuv2/common/envelope_test.go
+++ b/wakuv2/common/envelope_test.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+)
+
+func TestNewEnvelope(t *testing.T) {
+	version := uint32(1)
+	timestamp := int64(1234567890)
+	ephemeral := true
+	hashBytes := []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0}
+	hashStr := hexutil.Encode(hashBytes)
+
+	jsonStr := `{
+		"wakuMessage": {
+			"payload": "aGVsbG8=",
+			"contentTopic": "test-topic",
+			"version": 1,
+			"timestamp": 1234567890,
+			"meta": "bWV0YQ==",
+			"ephemeral": true,
+			"proof": "cHJvb2Y="
+		},
+		"pubsubTopic": "test-pubsub",
+		"messageHash": "` + hashStr + `"
+	}`
+
+	env, err := NewEnvelope(jsonStr)
+	assert.NoError(t, err)
+	assert.NotNil(t, env)
+
+	msg := env.Message()
+	assert.NotNil(t, msg)
+	assert.Equal(t, "test-topic", msg.ContentTopic)
+	assert.Equal(t, &version, msg.Version)
+	assert.Equal(t, &timestamp, msg.Timestamp)
+	assert.Equal(t, ephemeral, *msg.Ephemeral)
+	assert.Equal(t, "test-pubsub", env.PubsubTopic())
+	assert.Equal(t, pb.ToMessageHash(hashBytes), env.Hash())
+}

--- a/wakuv2/common/message.go
+++ b/wakuv2/common/message.go
@@ -8,7 +8,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/waku-org/go-waku/waku/v2/payload"
-	"github.com/waku-org/go-waku/waku/v2/protocol"
 
 	"github.com/status-im/status-go/logutils"
 
@@ -40,7 +39,7 @@ type MessageParams struct {
 // ReceivedMessage represents a data packet to be received through the
 // WakuV2 protocol and successfully decrypted.
 type ReceivedMessage struct {
-	Envelope *protocol.Envelope // Wrapped Waku Message
+	Envelope Envelope // Wrapped Waku Message
 
 	MsgType MessageType
 
@@ -102,7 +101,7 @@ type MemoryMessageStore struct {
 	messages map[common.Hash]*ReceivedMessage
 }
 
-func NewReceivedMessage(env *protocol.Envelope, msgType MessageType) *ReceivedMessage {
+func NewReceivedMessage(env Envelope, msgType MessageType) *ReceivedMessage {
 	ct, err := ExtractTopicFromContentTopic(env.Message().ContentTopic)
 	if err != nil {
 		logutils.ZapLogger().Debug("failed to extract content topic from message",

--- a/wakuv2/config.go
+++ b/wakuv2/config.go
@@ -25,6 +25,8 @@ import (
 
 	ethdisc "github.com/ethereum/go-ethereum/p2p/dnsdisc"
 
+	bindingscommon "github.com/waku-org/waku-go-bindings/waku/common"
+
 	"github.com/status-im/status-go/wakuv2/common"
 )
 
@@ -35,36 +37,37 @@ var (
 
 // Config represents the configuration state of a waku node.
 type Config struct {
-	MaxMessageSize                         uint32           `toml:",omitempty"` // Maximal message length allowed by the waku node
-	Host                                   string           `toml:",omitempty"`
-	Port                                   int              `toml:",omitempty"`
-	EnablePeerExchangeServer               bool             `toml:",omitempty"` // PeerExchange server makes sense only when discv5 is running locally as it will have a cache of peers that it can respond to in case a PeerExchange request comes from the PeerExchangeClient
-	EnablePeerExchangeClient               bool             `toml:",omitempty"`
-	MinPeersForRelay                       int              `toml:",omitempty"` // Indicates the minimum number of peers required for using Relay Protocol
-	MinPeersForFilter                      int              `toml:",omitempty"` // Indicates the minimum number of peers required for using Filter Protocol
-	LightClient                            bool             `toml:",omitempty"` // Indicates if the node is a light client
-	WakuNodes                              []string         `toml:",omitempty"`
-	DiscV5BootstrapNodes                   []string         `toml:",omitempty"`
-	Nameserver                             string           `toml:",omitempty"` // Optional nameserver to use for dns discovery
-	Resolver                               ethdisc.Resolver `toml:",omitempty"` // Optional resolver to use for dns discovery
-	EnableDiscV5                           bool             `toml:",omitempty"` // Indicates whether discv5 is enabled or not
-	DiscoveryLimit                         int              `toml:",omitempty"` // Indicates the number of nodes to discover with peer exchange client
-	AutoUpdate                             bool             `toml:",omitempty"`
-	UDPPort                                int              `toml:",omitempty"`
-	EnableStore                            bool             `toml:",omitempty"`
-	StoreCapacity                          int              `toml:",omitempty"`
-	StoreSeconds                           int              `toml:",omitempty"`
-	TelemetryServerURL                     string           `toml:",omitempty"`
-	TelemetrySendPeriodMs                  int              `toml:",omitempty"` // Number of milliseconds to wait between sending requests to telemetry service
-	TelemetryPeerCountSendPeriod           int              `toml:",omitempty"` // Number of milliseconds to wait between checking peer count
-	DefaultShardPubsubTopic                string           `toml:",omitempty"` // Pubsub topic to be used by default for messages that do not have a topic assigned (depending whether sharding is used or not)
-	DefaultShardedPubsubTopics             []string         `toml:", omitempty"`
-	ClusterID                              uint16           `toml:",omitempty"`
-	EnableConfirmations                    bool             `toml:",omitempty"` // Enable sending message confirmations
-	SkipPublishToTopic                     bool             `toml:",omitempty"` // Used in testing
-	EnableMissingMessageVerification       bool             `toml:",omitempty"`
-	EnableStoreConfirmationForMessagesSent bool             `toml:",omitempty"` //Flag that enables checking with store node for sent message confimration
-	UseThrottledPublish                    bool             `toml:",omitempty"` // Flag that indicates whether a rate limited priority queue will be used to send messages or not
+	MaxMessageSize                         uint32                     `toml:",omitempty"` // Maximal message length allowed by the waku node
+	Host                                   string                     `toml:",omitempty"`
+	Port                                   int                        `toml:",omitempty"`
+	EnablePeerExchangeServer               bool                       `toml:",omitempty"` // PeerExchange server makes sense only when discv5 is running locally as it will have a cache of peers that it can respond to in case a PeerExchange request comes from the PeerExchangeClient
+	EnablePeerExchangeClient               bool                       `toml:",omitempty"`
+	MinPeersForRelay                       int                        `toml:",omitempty"` // Indicates the minimum number of peers required for using Relay Protocol
+	MinPeersForFilter                      int                        `toml:",omitempty"` // Indicates the minimum number of peers required for using Filter Protocol
+	LightClient                            bool                       `toml:",omitempty"` // Indicates if the node is a light client
+	WakuNodes                              []string                   `toml:",omitempty"`
+	DiscV5BootstrapNodes                   []string                   `toml:",omitempty"`
+	Nameserver                             string                     `toml:",omitempty"` // Optional nameserver to use for dns discovery
+	Resolver                               ethdisc.Resolver           `toml:",omitempty"` // Optional resolver to use for dns discovery
+	EnableDiscV5                           bool                       `toml:",omitempty"` // Indicates whether discv5 is enabled or not
+	DiscoveryLimit                         int                        `toml:",omitempty"` // Indicates the number of nodes to discover with peer exchange client
+	AutoUpdate                             bool                       `toml:",omitempty"`
+	UDPPort                                int                        `toml:",omitempty"`
+	EnableStore                            bool                       `toml:",omitempty"`
+	StoreCapacity                          int                        `toml:",omitempty"`
+	StoreSeconds                           int                        `toml:",omitempty"`
+	TelemetryServerURL                     string                     `toml:",omitempty"`
+	TelemetrySendPeriodMs                  int                        `toml:",omitempty"` // Number of milliseconds to wait between sending requests to telemetry service
+	TelemetryPeerCountSendPeriod           int                        `toml:",omitempty"` // Number of milliseconds to wait between checking peer count
+	DefaultShardPubsubTopic                string                     `toml:",omitempty"` // Pubsub topic to be used by default for messages that do not have a topic assigned (depending whether sharding is used or not)
+	DefaultShardedPubsubTopics             []string                   `toml:", omitempty"`
+	ClusterID                              uint16                     `toml:",omitempty"`
+	EnableConfirmations                    bool                       `toml:",omitempty"` // Enable sending message confirmations
+	SkipPublishToTopic                     bool                       `toml:",omitempty"` // Used in testing
+	EnableMissingMessageVerification       bool                       `toml:",omitempty"`
+	EnableStoreConfirmationForMessagesSent bool                       `toml:",omitempty"` //Flag that enables checking with store node for sent message confimration
+	UseThrottledPublish                    bool                       `toml:",omitempty"` // Flag that indicates whether a rate limited priority queue will be used to send messages or not
+	NwakuConfig                            *bindingscommon.WakuConfig `toml:",omitempty"` // Config for nwaku node
 }
 
 func (c *Config) Validate(logger *zap.Logger) error {

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -3,6 +3,2334 @@
 
 package wakuv2
 
+import "C"
+
 import (
-	_ "github.com/waku-org/waku-go-bindings/waku"
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/protobuf/proto"
+
+	"go.uber.org/zap"
+
+	"golang.org/x/crypto/pbkdf2"
+	"golang.org/x/time/rate"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/libp2p/go-libp2p/core/metrics"
+
+	filterapi "github.com/waku-org/go-waku/waku/v2/api/filter"
+	"github.com/waku-org/go-waku/waku/v2/api/history"
+	"github.com/waku-org/go-waku/waku/v2/api/missing"
+	"github.com/waku-org/go-waku/waku/v2/api/publish"
+	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
+	"github.com/waku-org/go-waku/waku/v2/onlinechecker"
+	"github.com/waku-org/go-waku/waku/v2/peermanager"
+	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+
+	"github.com/waku-org/go-waku/waku/v2/protocol/legacy_store"
+	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
+	"github.com/waku-org/go-waku/waku/v2/protocol/store"
+	"github.com/waku-org/go-waku/waku/v2/utils"
+
+	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/connection"
+	"github.com/status-im/status-go/logutils"
+	"github.com/status-im/status-go/timesource"
+	"github.com/status-im/status-go/waku/types"
+	"github.com/status-im/status-go/wakuv2/common"
+	"github.com/status-im/status-go/wakuv2/persistence"
+
+	"github.com/waku-org/waku-go-bindings/waku"
+	bindingscommon "github.com/waku-org/waku-go-bindings/waku/common"
+
+	node "github.com/waku-org/go-waku/waku/v2/node"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 )
+
+const messageQueueLimit = 1024
+const requestTimeout = 30 * time.Second
+const bootnodesQueryBackoffMs = 200
+const bootnodesMaxRetries = 7
+const cacheTTL = 20 * time.Minute
+const maxRelayPeers = 300
+const randomPeersKeepAliveInterval = 5 * time.Second
+const allPeersKeepAliveInterval = 5 * time.Minute
+
+type SentEnvelope struct {
+	Envelope      common.Envelope
+	PublishMethod publish.PublishMethod
+}
+
+type ErrorSendingEnvelope struct {
+	Error        error
+	SentEnvelope SentEnvelope
+}
+
+type IMetricsHandler interface {
+	SetDeviceType(deviceType string)
+	PushSentEnvelope(sentEnvelope SentEnvelope)
+	PushErrorSendingEnvelope(errorSendingEnvelope ErrorSendingEnvelope)
+	PushPeerCount(peerCount int)
+	PushPeerConnFailures(peerConnFailures map[string]int)
+	PushMessageCheckSuccess()
+	PushMessageCheckFailure()
+	PushPeerCountByShard(peerCountByShard map[uint16]uint)
+	PushPeerCountByOrigin(peerCountByOrigin map[wps.Origin]uint)
+	PushDialFailure(dialFailure common.DialError)
+	PushMissedMessage(envelope *protocol.Envelope)
+	PushMissedRelevantMessage(message *common.ReceivedMessage)
+	PushMessageDeliveryConfirmed()
+	PushSentMessageTotal(messageSize uint32, publishMethod string)
+}
+
+// Waku represents a dark communication interface through the Ethereum
+// network, using its very own P2P communication layer.
+type Waku struct {
+	node *waku.WakuNode
+
+	appDB *sql.DB
+
+	dnsAddressCache             map[string][]dnsdisc.DiscoveredNode // Map to store the multiaddresses returned by dns discovery
+	dnsAddressCacheLock         *sync.RWMutex                       // lock to handle access to the map
+	dnsDiscAsyncRetrievedSignal chan struct{}
+
+	// Filter-related
+	filters       *common.Filters // Message filters installed with Subscribe function
+	filterManager *filterapi.FilterManager
+
+	privateKeys map[string]*ecdsa.PrivateKey // Private key storage
+	symKeys     map[string][]byte            // Symmetric key storage
+	keyMu       sync.RWMutex                 // Mutex associated with key stores
+
+	envelopeCache *ttlcache.Cache[gethcommon.Hash, *common.ReceivedMessage] // Pool of envelopes currently tracked by this node
+	poolMu        sync.RWMutex                                              // Mutex to sync the message and expiration pools
+
+	bandwidthCounter *metrics.BandwidthCounter
+
+	protectedTopicStore *persistence.ProtectedTopicsStore
+
+	sendQueue *publish.MessageQueue
+
+	missingMsgVerifier *missing.MissingMessageVerifier
+
+	msgQueue chan *common.ReceivedMessage // Message queue for waku messages that havent been decoded
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	cfg *Config
+
+	options []node.WakuNodeOption
+
+	envelopeFeed event.Feed
+
+	storeMsgIDs   map[gethcommon.Hash]bool // Map of the currently processing ids
+	storeMsgIDsMu sync.RWMutex
+
+	messageSender *publish.MessageSender
+
+	topicHealthStatusChan   chan peermanager.TopicHealthStatus
+	connectionNotifChan     chan node.PeerConnection
+	connStatusSubscriptions map[string]*types.ConnStatusSubscription
+	connStatusMu            sync.Mutex
+	onlineChecker           *onlinechecker.DefaultOnlineChecker
+	state                   connection.State
+
+	StorenodeCycle   *history.StorenodeCycle
+	HistoryRetriever *history.HistoryRetriever
+
+	logger *zap.Logger
+
+	// NTP Synced timesource
+	timesource *timesource.NTPTimeSource
+
+	// seededBootnodesForDiscV5 indicates whether we manage to retrieve discovery
+	// bootnodes successfully
+	seededBootnodesForDiscV5 bool
+
+	// goingOnline is channel that notifies when connectivity has changed from offline to online
+	goingOnline chan struct{}
+
+	// discV5BootstrapNodes is the ENR to be used to fetch bootstrap nodes for discovery
+	discV5BootstrapNodes []string
+
+	onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error)
+	onPeerStats                     func(types.ConnStatus)
+
+	metricsHandler IMetricsHandler
+
+	defaultShardInfo protocol.RelayShards
+}
+
+func (w *Waku) SetMetricsHandler(client IMetricsHandler) {
+	w.metricsHandler = client
+}
+
+func newTTLCache() *ttlcache.Cache[gethcommon.Hash, *common.ReceivedMessage] {
+	cache := ttlcache.New[gethcommon.Hash, *common.ReceivedMessage](ttlcache.WithTTL[gethcommon.Hash, *common.ReceivedMessage](cacheTTL))
+	go func() {
+		defer gocommon.LogOnPanic()
+		cache.Start()
+	}()
+	return cache
+}
+
+// New creates a WakuV2 client ready to communicate through the LibP2P network.
+func New(nodeKey *ecdsa.PrivateKey, fleet string, cfg *Config, logger *zap.Logger, appDB *sql.DB, ts *timesource.NTPTimeSource, onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
+	node, err := wakuNew(nodeKey,
+		fleet,
+		cfg,
+		logger, appDB, ts, onHistoricMessagesRequestFailed,
+		onPeerStats)
+	if err != nil {
+		return nil, err
+	}
+
+	return node, nil
+
+	// TODO-nwaku
+	/*
+		cfg = setDefaults(cfg)
+		if err = cfg.Validate(logger); err != nil {
+			return nil, err
+		}
+
+		logger.Info("starting wakuv2 with config", zap.Any("config", cfg))
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		waku := &Waku{
+			appDB:                           appDB,
+			cfg:                             cfg,
+			privateKeys:                     make(map[string]*ecdsa.PrivateKey),
+			symKeys:                         make(map[string][]byte),
+			envelopeCache:                   newTTLCache(),
+			msgQueue:                        make(chan *common.ReceivedMessage, messageQueueLimit),
+			topicHealthStatusChan:           make(chan peermanager.TopicHealthStatus, 100),
+			connectionNotifChan:             make(chan node.PeerConnection, 20),
+			connStatusSubscriptions:         make(map[string]*types.ConnStatusSubscription),
+			ctx:                             ctx,
+			cancel:                          cancel,
+			wg:                              sync.WaitGroup{},
+			dnsAddressCache:                 make(map[string][]dnsdisc.DiscoveredNode),
+			dnsAddressCacheLock:             &sync.RWMutex{},
+			dnsDiscAsyncRetrievedSignal:     make(chan struct{}),
+			storeMsgIDs:                     make(map[gethcommon.Hash]bool),
+			timesource:                      ts,
+			storeMsgIDsMu:                   sync.RWMutex{},
+			logger:                          logger,
+			discV5BootstrapNodes:            cfg.DiscV5BootstrapNodes,
+			onHistoricMessagesRequestFailed: onHistoricMessagesRequestFailed,
+			onPeerStats:                     onPeerStats,
+			onlineChecker:                   onlinechecker.NewDefaultOnlineChecker(false).(*onlinechecker.DefaultOnlineChecker),
+			sendQueue:                       publish.NewMessageQueue(1000, cfg.UseThrottledPublish),
+		}
+
+		waku.bandwidthCounter = metrics.NewBandwidthCounter()
+
+		libp2pOpts := node.DefaultLibP2POptions
+		libp2pOpts = append(libp2pOpts, libp2p.BandwidthReporter(waku.bandwidthCounter))
+		libp2pOpts = append(libp2pOpts, libp2p.NATPortMap())
+
+		opts := []node.WakuNodeOption{
+			node.WithLibP2POptions(libp2pOpts...),
+			node.WithPrivateKey(nodeKey),
+			node.WithHostAddress(hostAddr),
+			node.WithConnectionNotification(waku.connectionNotifChan),
+			node.WithTopicHealthStatusChannel(waku.topicHealthStatusChan),
+			node.WithKeepAlive(randomPeersKeepAliveInterval, allPeersKeepAliveInterval),
+			node.WithLogger(logger),
+			node.WithLogLevel(logger.Level()),
+			node.WithClusterID(cfg.ClusterID),
+			node.WithMaxMsgSize(1024 * 1024),
+			node.WithPrometheusRegisterer(prometheus.DefaultRegisterer),
+		}
+
+		if cfg.EnableDiscV5 {
+			bootnodes, err := waku.getDiscV5BootstrapNodes(waku.ctx, cfg.DiscV5BootstrapNodes, false)
+			if err != nil {
+				logger.Error("failed to get bootstrap nodes", zap.Error(err))
+				return nil, err
+			}
+			opts = append(opts, node.WithDiscoveryV5(uint(cfg.UDPPort), bootnodes, cfg.AutoUpdate))
+		}
+		shards, err := protocol.TopicsToRelayShards(cfg.DefaultShardPubsubTopic)
+		if err != nil {
+			logger.Error("FATAL ERROR: failed to parse relay shards", zap.Error(err))
+			return nil, errors.New("failed to parse relay shard, invalid pubsubTopic configuration")
+		}
+		if len(shards) == 0 { //Hack so that tests don't fail. TODO: Need to remove this once tests are changed to use proper cluster and shard.
+			shardInfo := protocol.RelayShards{ClusterID: 0, ShardIDs: []uint16{0}}
+			shards = append(shards, shardInfo)
+		}
+		waku.defaultShardInfo = shards[0]
+		if cfg.LightClient {
+			opts = append(opts, node.WithWakuFilterLightNode())
+			waku.defaultShardInfo = shards[0]
+			opts = append(opts, node.WithMaxPeerConnections(cfg.DiscoveryLimit))
+			cfg.EnableStoreConfirmationForMessagesSent = false
+			//TODO: temporary work-around to improve lightClient connectivity, need to be removed once community sharding is implemented
+			opts = append(opts, node.WithShards(waku.defaultShardInfo.ShardIDs))
+		} else {
+			relayOpts := []pubsub.Option{
+				pubsub.WithMaxMessageSize(int(waku.cfg.MaxMessageSize)),
+			}
+
+			if testing.Testing() {
+				relayOpts = append(relayOpts, pubsub.WithEventTracer(waku))
+			}
+
+			opts = append(opts, node.WithWakuRelayAndMinPeers(waku.cfg.MinPeersForRelay, relayOpts...))
+			opts = append(opts, node.WithMaxPeerConnections(maxRelayPeers))
+			cfg.EnablePeerExchangeClient = true //Enabling this until discv5 issues are resolved. This will enable more peers to be connected for relay mesh.
+			cfg.EnableStoreConfirmationForMessagesSent = true
+		}
+
+		if cfg.EnableStore {
+			if appDB == nil {
+				return nil, errors.New("appDB is required for store")
+			}
+			opts = append(opts, node.WithWakuStore())
+			dbStore, err := persistence.NewDBStore(logger, persistence.WithDB(appDB), persistence.WithRetentionPolicy(cfg.StoreCapacity, time.Duration(cfg.StoreSeconds)*time.Second))
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, node.WithMessageProvider(dbStore))
+		}
+
+		waku.options = opts
+
+		waku.logger.Info("setup the go-waku node successfully")
+
+		return waku, nil*/
+}
+
+func (w *Waku) SubscribeToConnStatusChanges() (*types.ConnStatusSubscription, error) {
+	w.connStatusMu.Lock()
+	defer w.connStatusMu.Unlock()
+	subscription := types.NewConnStatusSubscription()
+	w.connStatusSubscriptions[subscription.ID] = subscription
+	return subscription, nil
+}
+
+/* TODO-nwaku
+func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string, useOnlyDnsDiscCache bool) ([]*enode.Node, error) {
+	wg := sync.WaitGroup{}
+	mu := sync.Mutex{}
+	var result []*enode.Node
+
+	w.seededBootnodesForDiscV5 = true
+
+	retrieveENR := func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {
+		mu.Lock()
+		defer mu.Unlock()
+		defer wg.Done()
+		if d.ENR != nil {
+			result = append(result, d.ENR)
+		}
+	}
+
+	for _, addrString := range addresses {
+		if addrString == "" {
+			continue
+		}
+
+		if strings.HasPrefix(addrString, "enrtree://") {
+			// Use DNS Discovery
+			wg.Add(1)
+			go func(addr string) {
+				defer gocommon.LogOnPanic()
+				defer wg.Done()
+				if err := w.dnsDiscover(ctx, addr, retrieveENR, useOnlyDnsDiscCache); err != nil {
+					go func() {
+						defer gocommon.LogOnPanic()
+						w.retryDnsDiscoveryWithBackoff(ctx, addr, w.dnsDiscAsyncRetrievedSignal)
+					}()
+				}
+			}(addrString)
+		} else {
+			// It's a normal enr
+			bootnode, err := enode.Parse(enode.ValidSchemes, addrString)
+			if err != nil {
+				return nil, err
+			}
+			mu.Lock()
+			result = append(result, bootnode)
+			mu.Unlock()
+		}
+	}
+	wg.Wait()
+
+	if len(result) == 0 {
+		w.seededBootnodesForDiscV5 = false
+	}
+
+	return result, nil
+}
+
+type fnApplyToEachPeer func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup)
+
+func (w *Waku) dnsDiscover(ctx context.Context, enrtreeAddress string, apply fnApplyToEachPeer, useOnlyCache bool) error {
+	w.logger.Info("retrieving nodes", zap.String("enr", enrtreeAddress))
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	w.dnsAddressCacheLock.Lock()
+	defer w.dnsAddressCacheLock.Unlock()
+
+	discNodes, ok := w.dnsAddressCache[enrtreeAddress]
+	if !ok && !useOnlyCache {
+		nameserver := w.cfg.Nameserver
+		resolver := w.cfg.Resolver
+
+		var opts []dnsdisc.DNSDiscoveryOption
+		if nameserver != "" {
+			opts = append(opts, dnsdisc.WithNameserver(nameserver))
+		}
+		if resolver != nil {
+			opts = append(opts, dnsdisc.WithResolver(resolver))
+		}
+
+		discoveredNodes, err := dnsdisc.RetrieveNodes(ctx, enrtreeAddress, opts...)
+		if err != nil {
+			w.logger.Warn("dns discovery error ", zap.Error(err))
+			return err
+		}
+
+		if len(discoveredNodes) != 0 {
+			w.dnsAddressCache[enrtreeAddress] = append(w.dnsAddressCache[enrtreeAddress], discoveredNodes...)
+			discNodes = w.dnsAddressCache[enrtreeAddress]
+		}
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(len(discNodes))
+	for _, d := range discNodes {
+		apply(d, wg)
+	}
+	wg.Wait()
+
+	return nil
+}
+
+func (w *Waku) retryDnsDiscoveryWithBackoff(ctx context.Context, addr string, successChan chan<- struct{}) {
+	retries := 0
+	for {
+		err := w.dnsDiscover(ctx, addr, func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {}, false)
+		if err == nil {
+			select {
+			case successChan <- struct{}{}:
+			default:
+			}
+
+			break
+		}
+
+		retries++
+		backoff := time.Second * time.Duration(math.Exp2(float64(retries)))
+		if backoff > time.Minute {
+			backoff = time.Minute
+		}
+
+		t := time.NewTimer(backoff)
+		select {
+		case <-w.ctx.Done():
+			t.Stop()
+			return
+		case <-t.C:
+			t.Stop()
+		}
+	}
+}
+*/
+
+func (w *Waku) discoverAndConnectPeers() {
+	var addrsToConnect []multiaddr.Multiaddr
+	nameserver := w.cfg.Nameserver
+	if nameserver == "" {
+		nameserver = "8.8.8.8"
+	}
+
+	for _, addrString := range w.cfg.WakuNodes {
+		addrString := addrString
+		if strings.HasPrefix(addrString, "enrtree://") {
+
+			// Use DNS Discovery
+			ctx, cancel := context.WithTimeout(w.ctx, requestTimeout)
+			res, err := w.node.DnsDiscovery(ctx, addrString, nameserver)
+			cancel()
+			if err != nil {
+				w.logger.Error("could not obtain dns discovery peers for ClusterConfig.WakuNodes", zap.Error(err), zap.String("dnsDiscURL", addrString))
+				continue
+			}
+			addrsToConnect = append(addrsToConnect, res...)
+		} else {
+			// It is a normal multiaddress
+			addr, err := multiaddr.NewMultiaddr(addrString)
+			if err != nil {
+				w.logger.Warn("invalid peer multiaddress", zap.String("ma", addrString), zap.Error(err))
+				continue
+			}
+			addrsToConnect = append(addrsToConnect, addr)
+		}
+	}
+	// Now connect to all the Multiaddresses
+	for _, ma := range addrsToConnect {
+		ctx, cancel := context.WithTimeout(w.ctx, requestTimeout)
+		err := w.node.Connect(ctx, ma)
+		if err != nil {
+			w.logger.Error("could not connect", zap.Error(err), zap.Stringer("ma", ma))
+		}
+		cancel()
+	}
+}
+
+func (w *Waku) connect(peerInfo peer.AddrInfo, enr *enode.Node, origin wps.Origin) {
+	defer gocommon.LogOnPanic()
+	// Connection will be prunned eventually by the connection manager if needed
+	// The peer connector in go-waku uses Connect, so it will execute identify as part of its
+
+	// TODO-nwaku
+	// TODO: is enr and origin required?
+	// TODO: this function is meant to add a node to a peer store so it can be picked up by the peer manager
+	//       so probably we shouldn't connect directly but expose an AddPeer function in libwaku
+
+	ctx, cancel := context.WithTimeout(w.ctx, requestTimeout)
+	defer cancel()
+
+	addr := peerInfo.Addrs[0]
+	err := w.node.Connect(ctx, addr)
+	if err != nil {
+		w.logger.Error("couldn't connect to peer", zap.Error(err), zap.Stringer("peerID", peerInfo.ID))
+	}
+}
+
+/* TODO-nwaku
+func (w *Waku) telemetryBandwidthStats(telemetryServerURL string) {
+	defer gocommon.LogOnPanic()
+	defer w.wg.Done()
+
+	if telemetryServerURL == "" {
+		return
+	}
+
+	telemetry := NewBandwidthTelemetryClient(w.logger, telemetryServerURL)
+
+	ticker := time.NewTicker(time.Second * 20)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case <-ticker.C:
+			bandwidthPerProtocol := w.bandwidthCounter.GetBandwidthByProtocol()
+			w.bandwidthCounter.Reset()
+			go telemetry.PushProtocolStats(bandwidthPerProtocol)
+		}
+	}
+}
+*/
+
+func (w *Waku) StartDiscV5() error {
+	return w.node.StartDiscV5()
+}
+
+func (w *Waku) StopDiscV5() error {
+	return w.node.StopDiscV5()
+}
+
+func (w *Waku) GetStats() types.StatsSummary {
+	return types.StatsSummary{
+		UploadRate:   uint64(1),
+		DownloadRate: uint64(1),
+	}
+	/* TODO-nwaku
+	stats := w.bandwidthCounter.GetBandwidthTotals()
+	return types.StatsSummary{
+		UploadRate:   uint64(stats.RateOut),
+		DownloadRate: uint64(stats.RateIn),
+	} */
+}
+
+/* TODO-nwaku
+func (w *Waku) runPeerExchangeLoop() {
+	defer gocommon.LogOnPanic()
+	defer w.wg.Done()
+
+	if !w.cfg.EnablePeerExchangeClient {
+		// Currently peer exchange client is only used for light nodes
+		return
+	}
+
+	ticker := time.NewTicker(time.Second * 5)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			w.logger.Debug("Peer exchange loop stopped")
+			return
+		case <-ticker.C:
+			w.logger.Info("Running peer exchange loop")
+
+			// We select only the nodes discovered via DNS Discovery that support peer exchange
+			// We assume that those peers are running peer exchange according to infra config,
+			// If not, the peer selection process in go-waku will filter them out anyway
+			w.dnsAddressCacheLock.RLock()
+			var peers peer.IDSlice
+			for _, record := range w.dnsAddressCache {
+				for _, discoveredNode := range record {
+					if len(discoveredNode.PeerInfo.Addrs) == 0 {
+						continue
+					}
+					// Attempt to connect to the peers.
+					// Peers will be added to the libp2p peer store thanks to identify
+					go w.connect(discoveredNode.PeerInfo, discoveredNode.ENR, wps.DNSDiscovery)
+					peers = append(peers, discoveredNode.PeerID)
+				}
+			}
+			w.dnsAddressCacheLock.RUnlock()
+
+			if len(peers) != 0 {
+				err := w.node.PeerExchange().Request(w.ctx, w.cfg.DiscoveryLimit, peer_exchange.WithAutomaticPeerSelection(peers...),
+					peer_exchange.FilterByShard(int(w.defaultShardInfo.ClusterID), int(w.defaultShardInfo.ShardIDs[0])))
+				if err != nil {
+					w.logger.Error("couldnt request peers via peer exchange", zap.Error(err))
+				}
+			}
+		}
+	}
+}
+*/
+
+func (w *Waku) GetPubsubTopic(topic string) string {
+	if topic == "" {
+		topic = w.cfg.DefaultShardPubsubTopic
+	}
+
+	return topic
+}
+
+func (w *Waku) unsubscribeFromPubsubTopicWithWakuRelay(topic string) error {
+	topic = w.GetPubsubTopic(topic)
+	return w.node.RelayUnsubscribe(topic)
+}
+
+func (w *Waku) subscribeToPubsubTopicWithWakuRelay(topic string, pubkey *ecdsa.PublicKey) error {
+	if w.cfg.LightClient {
+		return errors.New("only available for full nodes")
+	}
+
+	topic = w.GetPubsubTopic(topic)
+
+	rs, err := protocol.TopicsToRelayShards(topic)
+	if err != nil {
+		return err
+	}
+
+	if len(rs) == 0 {
+		w.logger.Warn("could not obtain shards from topic", zap.String("topic", topic))
+		return nil
+	}
+
+	if pubkey != nil {
+		err := w.node.RelayAddProtectedShard(rs[0].ClusterID, rs[0].ShardIDs[0], pubkey)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = w.node.RelaySubscribe(topic)
+	if err != nil {
+		return err
+	}
+
+	w.wg.Add(1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer w.wg.Done()
+		for {
+			select {
+			case <-w.ctx.Done():
+				err := w.node.RelayUnsubscribe(topic)
+				if err != nil && !errors.Is(err, context.Canceled) {
+					w.logger.Error("could not unsubscribe", zap.Error(err))
+				}
+				return
+
+			case bindingsEnv := <-w.node.MsgChan:
+				env, err := BindingsToCommonEnvelope(bindingsEnv)
+				if err != nil {
+					w.logger.Error("BindingsToCommonEnvelope error", zap.Error(err))
+					return
+				}
+
+				err = w.OnNewEnvelopes(env, common.RelayedMessageType, false)
+				if err != nil {
+					w.logger.Error("OnNewEnvelopes error", zap.Error(err))
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// MaxMessageSize returns the maximum accepted message size.
+func (w *Waku) MaxMessageSize() uint32 {
+	return w.cfg.MaxMessageSize
+}
+
+// CurrentTime returns current time.
+func (w *Waku) CurrentTime() time.Time {
+	return w.timesource.Now()
+}
+
+// APIs returns the RPC descriptors the Waku implementation offers
+func (w *Waku) APIs() []rpc.API {
+	return []rpc.API{
+		{
+			Namespace: Name,
+			Version:   VersionStr,
+			Service:   NewPublicWakuAPI(w),
+			Public:    false,
+		},
+	}
+}
+
+// Protocols returns the waku sub-protocols ran by this particular client.
+func (w *Waku) Protocols() []p2p.Protocol {
+	return []p2p.Protocol{}
+}
+
+func (w *Waku) SendEnvelopeEvent(event common.EnvelopeEvent) int {
+	return w.envelopeFeed.Send(event)
+}
+
+// SubscribeEnvelopeEvents subscribes to envelopes feed.
+// In order to prevent blocking waku producers events must be amply buffered.
+
+func (w *Waku) subscribeEnvelopeEvents(events chan<- common.EnvelopeEvent) event.Subscription {
+	return w.envelopeFeed.Subscribe(events)
+}
+
+func (w *Waku) SubscribeEnvelopeEvents(eventsProxy chan<- types.EnvelopeEvent) types.Subscription {
+	events := make(chan common.EnvelopeEvent, 100) // must be buffered to prevent blocking whisper
+	go func() {
+		defer gocommon.LogOnPanic()
+		for e := range events {
+			eventsProxy <- *NewWakuV2EnvelopeEventWrapper(&e)
+		}
+	}()
+
+	return NewGethSubscriptionWrapper(w.subscribeEnvelopeEvents(events))
+}
+
+// NewKeyPair generates a new cryptographic identity for the client, and injects
+// it into the known identities for message decryption. Returns ID of the new key pair.
+func (w *Waku) NewKeyPair() (string, error) {
+	key, err := crypto.GenerateKey()
+	if err != nil || !validatePrivateKey(key) {
+		key, err = crypto.GenerateKey() // retry once
+	}
+	if err != nil {
+		return "", err
+	}
+	if !validatePrivateKey(key) {
+		return "", fmt.Errorf("failed to generate valid key")
+	}
+
+	id, err := toDeterministicID(hexutil.Encode(crypto.FromECDSAPub(&key.PublicKey)), common.KeyIDSize)
+	if err != nil {
+		return "", err
+	}
+
+	w.keyMu.Lock()
+	defer w.keyMu.Unlock()
+
+	if w.privateKeys[id] != nil {
+		return "", fmt.Errorf("failed to generate unique ID")
+	}
+	w.privateKeys[id] = key
+	return id, nil
+}
+
+// DeleteKeyPair deletes the specified key if it exists.
+func (w *Waku) DeleteKeyPair(key string) bool {
+	deterministicID, err := toDeterministicID(key, common.KeyIDSize)
+	if err != nil {
+		return false
+	}
+
+	w.keyMu.Lock()
+	defer w.keyMu.Unlock()
+
+	if w.privateKeys[deterministicID] != nil {
+		delete(w.privateKeys, deterministicID)
+		return true
+	}
+	return false
+}
+
+// AddKeyPair imports a asymmetric private key and returns it identifier.
+func (w *Waku) AddKeyPair(key *ecdsa.PrivateKey) (string, error) {
+	id, err := makeDeterministicID(hexutil.Encode(crypto.FromECDSAPub(&key.PublicKey)), common.KeyIDSize)
+	if err != nil {
+		return "", err
+	}
+	if w.HasKeyPair(id) {
+		return id, nil // no need to re-inject
+	}
+
+	w.keyMu.Lock()
+	w.privateKeys[id] = key
+	w.keyMu.Unlock()
+
+	return id, nil
+}
+
+// SelectKeyPair adds cryptographic identity, and makes sure
+// that it is the only private key known to the node.
+func (w *Waku) SelectKeyPair(key *ecdsa.PrivateKey) error {
+	id, err := makeDeterministicID(hexutil.Encode(crypto.FromECDSAPub(&key.PublicKey)), common.KeyIDSize)
+	if err != nil {
+		return err
+	}
+
+	w.keyMu.Lock()
+	defer w.keyMu.Unlock()
+
+	w.privateKeys = make(map[string]*ecdsa.PrivateKey) // reset key store
+	w.privateKeys[id] = key
+
+	return nil
+}
+
+// DeleteKeyPairs removes all cryptographic identities known to the node
+func (w *Waku) DeleteKeyPairs() error {
+	w.keyMu.Lock()
+	defer w.keyMu.Unlock()
+
+	w.privateKeys = make(map[string]*ecdsa.PrivateKey)
+
+	return nil
+}
+
+// HasKeyPair checks if the waku node is configured with the private key
+// of the specified public pair.
+func (w *Waku) HasKeyPair(id string) bool {
+	deterministicID, err := toDeterministicID(id, common.KeyIDSize)
+	if err != nil {
+		return false
+	}
+
+	w.keyMu.RLock()
+	defer w.keyMu.RUnlock()
+	return w.privateKeys[deterministicID] != nil
+}
+
+// GetPrivateKey retrieves the private key of the specified identity.
+func (w *Waku) GetPrivateKey(id string) (*ecdsa.PrivateKey, error) {
+	deterministicID, err := toDeterministicID(id, common.KeyIDSize)
+	if err != nil {
+		return nil, err
+	}
+
+	w.keyMu.RLock()
+	defer w.keyMu.RUnlock()
+	key := w.privateKeys[deterministicID]
+	if key == nil {
+		return nil, fmt.Errorf("invalid id")
+	}
+	return key, nil
+}
+
+// GenerateSymKey generates a random symmetric key and stores it under id,
+// which is then returned. Will be used in the future for session key exchange.
+func (w *Waku) GenerateSymKey() (string, error) {
+	key, err := common.GenerateSecureRandomData(common.AESKeyLength)
+	if err != nil {
+		return "", err
+	} else if !common.ValidateDataIntegrity(key, common.AESKeyLength) {
+		return "", fmt.Errorf("error in GenerateSymKey: crypto/rand failed to generate random data")
+	}
+
+	id, err := common.GenerateRandomID()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate ID: %s", err)
+	}
+
+	w.keyMu.Lock()
+	defer w.keyMu.Unlock()
+
+	if w.symKeys[id] != nil {
+		return "", fmt.Errorf("failed to generate unique ID")
+	}
+	w.symKeys[id] = key
+	return id, nil
+}
+
+// AddSymKey stores the key with a given id.
+func (w *Waku) AddSymKey(id string, key []byte) (string, error) {
+	deterministicID, err := toDeterministicID(id, common.KeyIDSize)
+	if err != nil {
+		return "", err
+	}
+
+	w.keyMu.Lock()
+	defer w.keyMu.Unlock()
+
+	if w.symKeys[deterministicID] != nil {
+		return "", fmt.Errorf("key already exists: %v", id)
+	}
+	w.symKeys[deterministicID] = key
+	return deterministicID, nil
+}
+
+// AddSymKeyDirect stores the key, and returns its id.
+func (w *Waku) AddSymKeyDirect(key []byte) (string, error) {
+	if len(key) != common.AESKeyLength {
+		return "", fmt.Errorf("wrong key size: %d", len(key))
+	}
+
+	id, err := common.GenerateRandomID()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate ID: %s", err)
+	}
+
+	w.keyMu.Lock()
+	defer w.keyMu.Unlock()
+
+	if w.symKeys[id] != nil {
+		return "", fmt.Errorf("failed to generate unique ID")
+	}
+	w.symKeys[id] = key
+	return id, nil
+}
+
+// AddSymKeyFromPassword generates the key from password, stores it, and returns its id.
+func (w *Waku) AddSymKeyFromPassword(password string) (string, error) {
+	id, err := common.GenerateRandomID()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate ID: %s", err)
+	}
+	if w.HasSymKey(id) {
+		return "", fmt.Errorf("failed to generate unique ID")
+	}
+
+	// kdf should run no less than 0.1 seconds on an average computer,
+	// because it's an once in a session experience
+	derived := pbkdf2.Key([]byte(password), nil, 65356, common.AESKeyLength, sha256.New)
+
+	w.keyMu.Lock()
+	defer w.keyMu.Unlock()
+
+	// double check is necessary, because deriveKeyMaterial() is very slow
+	if w.symKeys[id] != nil {
+		return "", fmt.Errorf("critical error: failed to generate unique ID")
+	}
+	w.symKeys[id] = derived
+	return id, nil
+}
+
+// HasSymKey returns true if there is a key associated with the given id.
+// Otherwise returns false.
+func (w *Waku) HasSymKey(id string) bool {
+	w.keyMu.RLock()
+	defer w.keyMu.RUnlock()
+	return w.symKeys[id] != nil
+}
+
+// DeleteSymKey deletes the key associated with the name string if it exists.
+func (w *Waku) DeleteSymKey(id string) bool {
+	w.keyMu.Lock()
+	defer w.keyMu.Unlock()
+	if w.symKeys[id] != nil {
+		delete(w.symKeys, id)
+		return true
+	}
+	return false
+}
+
+// GetSymKey returns the symmetric key associated with the given id.
+func (w *Waku) GetSymKey(id string) ([]byte, error) {
+	w.keyMu.RLock()
+	defer w.keyMu.RUnlock()
+	if w.symKeys[id] != nil {
+		return w.symKeys[id], nil
+	}
+	return nil, fmt.Errorf("non-existent key ID")
+}
+
+// Subscribe installs a new message handler used for filtering, decrypting
+// and subsequent storing of incoming messages.
+func (w *Waku) subscribe(f *common.Filter) (string, error) {
+	f.PubsubTopic = w.GetPubsubTopic(f.PubsubTopic)
+	id, err := w.filters.Install(f)
+	if err != nil {
+		return id, err
+	}
+
+	if w.cfg.LightClient {
+		cf := protocol.NewContentFilter(f.PubsubTopic, f.ContentTopics.ContentTopics()...)
+		w.filterManager.SubscribeFilter(id, cf)
+	}
+
+	return id, nil
+}
+
+func (w *Waku) Subscribe(opts *types.SubscriptionOptions) (string, error) {
+	var (
+		err     error
+		keyAsym *ecdsa.PrivateKey
+		keySym  []byte
+	)
+
+	if opts.SymKeyID != "" {
+		keySym, err = w.GetSymKey(opts.SymKeyID)
+		if err != nil {
+			return "", err
+		}
+	}
+	if opts.PrivateKeyID != "" {
+		keyAsym, err = w.GetPrivateKey(opts.PrivateKeyID)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	f := &common.Filter{
+		KeyAsym:       keyAsym,
+		KeySym:        keySym,
+		ContentTopics: common.NewTopicSetFromBytes(opts.Topics),
+		PubsubTopic:   opts.PubsubTopic,
+		Messages:      common.NewMemoryMessageStore(),
+	}
+
+	return w.subscribe(f)
+}
+
+// Unsubscribe removes an installed message handler.
+func (w *Waku) Unsubscribe(ctx context.Context, id string) error {
+	ok := w.filters.Uninstall(id)
+	if !ok {
+		return fmt.Errorf("failed to unsubscribe: invalid ID '%s'", id)
+	}
+
+	if w.cfg.LightClient {
+		w.filterManager.UnsubscribeFilter(id)
+	}
+
+	return nil
+}
+
+// GetFilter returns the filter by id.
+func (w *Waku) getFilter(id string) *common.Filter {
+	return w.filters.Get(id)
+}
+
+func (w *Waku) GetFilter(id string) types.Filter {
+	return w.getFilter(id)
+}
+
+// Unsubscribe removes an installed message handler.
+func (w *Waku) UnsubscribeMany(ids []string) error {
+	for _, id := range ids {
+		w.logger.Info("cleaning up filter", zap.String("id", id))
+		ok := w.filters.Uninstall(id)
+		if !ok {
+			w.logger.Warn("could not remove filter with id", zap.String("id", id))
+		}
+	}
+	return nil
+}
+
+func (w *Waku) SkipPublishToTopic(value bool) {
+	w.cfg.SkipPublishToTopic = value
+}
+
+func (w *Waku) ConfirmMessageDelivered(hashes []gethcommon.Hash) {
+	w.messageSender.MessagesDelivered(hashes)
+	/* TODO-nwaku
+	if w.metricsHandler != nil {
+		w.metricsHandler.PushMessageDeliveryConfirmed()
+	}
+	*/
+}
+
+// OnNewEnvelope is an interface from Waku FilterManager API that gets invoked when any new message is received by Filter.
+func (w *Waku) OnNewEnvelope(env common.Envelope) error {
+	return w.OnNewEnvelopes(env, common.RelayedMessageType, false)
+}
+
+// Start implements node.Service, starting the background data propagation thread
+// of the Waku protocol.
+func (w *Waku) Start() error {
+	err := w.node.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start nwaku node: %v", err)
+	}
+
+	if w.ctx == nil {
+		w.ctx, w.cancel = context.WithCancel(context.Background())
+	}
+
+	/* TODO-nwaku
+	w.goingOnline = make(chan struct{})
+	*/
+	w.StorenodeCycle = history.NewStorenodeCycle(w.logger, newPinger(w.node))
+	w.HistoryRetriever = history.NewHistoryRetriever(newStorenodeRequestor(w.node, w.logger), NewHistoryProcessorWrapper(w), w.logger)
+	w.StorenodeCycle.Start(w.ctx)
+
+	peerID, err := w.node.PeerID()
+	if err != nil {
+		return err
+	}
+
+	w.logger.Info("WakuV2 PeerID", zap.Stringer("id", peerID))
+
+	/* TODO-nwaku
+	w.discoverAndConnectPeers()
+
+	if w.cfg.EnableDiscV5 {
+		err := w.node.DiscV5().Start(w.ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	w.wg.Add(1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer w.wg.Done()
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-w.ctx.Done():
+				return
+			case <-ticker.C:
+				w.checkForConnectionChanges()
+			case <-w.topicHealthStatusChan:
+				// TODO: https://github.com/status-im/status-go/issues/4628
+			case <-w.connectionNotifChan:
+				w.checkForConnectionChanges()
+			}
+		}
+	}()
+
+	if w.cfg.TelemetryServerURL != "" {
+		w.wg.Add(1)
+		go func() {
+			defer gocommon.LogOnPanic()
+			defer w.wg.Done()
+			peerTelemetryTickerInterval := time.Duration(w.cfg.TelemetryPeerCountSendPeriod) * time.Millisecond
+			if peerTelemetryTickerInterval == 0 {
+				peerTelemetryTickerInterval = 10 * time.Second
+			}
+			peerTelemetryTicker := time.NewTicker(peerTelemetryTickerInterval)
+			defer peerTelemetryTicker.Stop()
+
+			dialErrSub, err := w.node.Host().EventBus().Subscribe(new(utils.DialError))
+			if err != nil {
+				w.logger.Error("failed to subscribe to dial errors", zap.Error(err))
+				return
+			}
+			defer dialErrSub.Close()
+
+			messageSentSub, err := w.node.Host().EventBus().Subscribe(new(publish.MessageSent))
+			if err != nil {
+				w.logger.Error("failed to subscribe to message sent events", zap.Error(err))
+				return
+			}
+
+			publishMethod := "relay"
+			if w.cfg.LightClient {
+				publishMethod = "lightpush"
+			}
+
+			for {
+				select {
+				case <-w.ctx.Done():
+					return
+				case <-peerTelemetryTicker.C:
+					w.reportPeerMetrics()
+				case dialErr := <-dialErrSub.Out():
+					errors := common.ParseDialErrors(dialErr.(utils.DialError).Err.Error())
+					for _, dialError := range errors {
+						w.metricsHandler.PushDialFailure(common.DialError{ErrType: dialError.ErrType, ErrMsg: dialError.ErrMsg, Protocols: dialError.Protocols})
+					}
+				case messageSent := <-messageSentSub.Out():
+					w.metricsHandler.PushSentMessageTotal(messageSent.(publish.MessageSent).Size, publishMethod)
+				}
+			}
+		}()
+	}
+
+	w.wg.Add(1)
+	go w.telemetryBandwidthStats(w.cfg.TelemetryServerURL)
+	//TODO: commenting for now so that only fleet nodes are used.
+	//Need to uncomment once filter peer scoring etc is implemented.
+
+	w.wg.Add(1)
+	go w.runPeerExchangeLoop()
+	*/
+
+	if w.cfg.EnableMissingMessageVerification {
+		w.missingMsgVerifier = missing.NewMissingMessageVerifier(
+			newStorenodeRequestor(w.node, w.logger),
+			w,
+			w.timesource,
+			w.logger)
+
+		w.missingMsgVerifier.Start(w.ctx)
+		w.logger.Info("Started missing message verifier")
+
+		w.wg.Add(1)
+		go func() {
+			defer gocommon.LogOnPanic()
+			w.wg.Done()
+			for {
+				select {
+				case <-w.ctx.Done():
+					return
+				case envelope := <-w.missingMsgVerifier.C:
+					err = w.OnNewEnvelopes(envelope, common.MissingMessageType, false)
+					if err != nil {
+						w.logger.Error("OnNewEnvelopes error", zap.Error(err))
+					}
+				}
+			}
+		}()
+	}
+
+	/* TODO: nwaku
+	if w.cfg.LightClient {
+		// Create FilterManager that will main peer connectivity
+		// for installed filters
+		w.filterManager = filterapi.NewFilterManager(
+			w.ctx,
+			w.logger,
+			w.cfg.MinPeersForFilter,
+			w,
+			w.node.FilterLightnode(),
+			filterapi.WithBatchInterval(300*time.Millisecond))
+	}
+	*/
+	err = w.setupRelaySubscriptions()
+	if err != nil {
+		return err
+	}
+
+	numCPU := runtime.NumCPU()
+	for i := 0; i < numCPU; i++ {
+		w.wg.Add(1)
+		go w.processQueueLoop()
+	}
+
+	w.wg.Add(1)
+	go w.broadcast()
+
+	go func() {
+		defer gocommon.LogOnPanic()
+		w.sendQueue.Start(w.ctx)
+	}()
+
+	err = w.startMessageSender()
+	if err != nil {
+		return err
+	}
+
+	/* TODO-nwaku
+	// we should wait `seedBootnodesForDiscV5` shutdown smoothly before set w.ctx to nil within `w.Stop()`
+	w.wg.Add(1)
+	go w.seedBootnodesForDiscV5()
+	*/
+
+	return nil
+}
+
+func (w *Waku) checkForConnectionChanges() {
+
+	/* TODO-nwaku
+	isOnline := len(w.node.Host().Network().Peers()) > 0
+
+	w.connStatusMu.Lock()
+
+	latestConnStatus := types.ConnStatus{
+		IsOnline: isOnline,
+		Peers:    FormatPeerStats(w.node),
+	}
+
+	w.logger.Debug("peer stats",
+		zap.Int("peersCount", len(latestConnStatus.Peers)),
+		zap.Any("stats", latestConnStatus))
+	for k, subs := range w.connStatusSubscriptions {
+		if !subs.Send(latestConnStatus) {
+			delete(w.connStatusSubscriptions, k)
+		}
+	}
+
+	w.connStatusMu.Unlock()
+
+	if w.onPeerStats != nil {
+		w.onPeerStats(latestConnStatus)
+	}
+
+	w.ConnectionChanged(connection.State{
+		Type:    w.state.Type, //setting state type as previous one since there won't be a change here
+		Offline: !latestConnStatus.IsOnline,
+	}) */
+}
+
+/* TODO: nwaku
+func (w *Waku) reportPeerMetrics() {
+	if w.metricsHandler != nil {
+		connFailures := FormatPeerConnFailures(w.node)
+		w.metricsHandler.PushPeerCount(w.PeerCount())
+		w.metricsHandler.PushPeerConnFailures(connFailures)
+
+		peerCountByOrigin := make(map[wps.Origin]uint)
+		peerCountByShard := make(map[uint16]uint)
+		wakuPeerStore := w.node.Host().Peerstore().(wps.WakuPeerstore)
+
+		for _, peerID := range w.node.Host().Network().Peers() {
+			origin, err := wakuPeerStore.Origin(peerID)
+			if err != nil {
+				origin = wps.Unknown
+			}
+
+			peerCountByOrigin[origin]++
+			pubsubTopics, err := wakuPeerStore.PubSubTopics(peerID)
+			if err != nil {
+				continue
+			}
+
+			keys := make([]string, 0, len(pubsubTopics))
+			for k := range pubsubTopics {
+				keys = append(keys, k)
+			}
+			relayShards, err := protocol.TopicsToRelayShards(keys...)
+			if err != nil {
+				continue
+			}
+
+			for _, shards := range relayShards {
+				for _, shard := range shards.ShardIDs {
+					peerCountByShard[shard]++
+				}
+			}
+		}
+		w.metricsHandler.PushPeerCountByShard(peerCountByShard)
+		w.metricsHandler.PushPeerCountByOrigin(peerCountByOrigin)
+	}
+}
+*/
+
+func (w *Waku) startMessageSender() error {
+	publishMethod := publish.Relay
+	/* TODO-nwaku
+	if w.cfg.LightClient {
+		publishMethod = publish.LightPush
+	}*/
+
+	sender, err := publish.NewMessageSender(publishMethod, newPublisher(w.node), nil, w.logger)
+	if err != nil {
+		w.logger.Error("failed to create message sender", zap.Error(err))
+		return err
+	}
+
+	/* TODO-nwaku
+	if w.cfg.TelemetryServerURL != "" {
+		sender.WithMessageSentEmitter(w.node.Host())
+	}*/
+
+	if w.cfg.EnableStoreConfirmationForMessagesSent {
+		msgStoredChan := make(chan gethcommon.Hash, 1000)
+		msgExpiredChan := make(chan gethcommon.Hash, 1000)
+		messageSentCheck := publish.NewMessageSentCheck(w.ctx, newStorenodeMessageVerifier(w.node), w.StorenodeCycle, w.timesource, msgStoredChan, msgExpiredChan, w.logger)
+		sender.WithMessageSentCheck(messageSentCheck)
+
+		w.wg.Add(1)
+		go func() {
+			defer gocommon.LogOnPanic()
+			defer w.wg.Done()
+			for {
+				select {
+				case <-w.ctx.Done():
+					return
+				case hash := <-msgStoredChan:
+					w.SendEnvelopeEvent(common.EnvelopeEvent{
+						Hash:  hash,
+						Event: common.EventEnvelopeSent,
+					})
+
+					if w.metricsHandler != nil {
+						w.metricsHandler.PushMessageCheckSuccess()
+					}
+				case hash := <-msgExpiredChan:
+					w.SendEnvelopeEvent(common.EnvelopeEvent{
+						Hash:  hash,
+						Event: common.EventEnvelopeExpired,
+					})
+
+					if w.metricsHandler != nil {
+						w.metricsHandler.PushMessageCheckFailure()
+					}
+				}
+			}
+		}()
+	}
+
+	if !w.cfg.UseThrottledPublish || testing.Testing() {
+		// To avoid delaying the tests, or for when we dont want to rate limit, we set up an infinite rate limiter,
+		// basically disabling the rate limit functionality
+		limiter := publish.NewDefaultRateLimiter(rate.Inf, 1)
+		sender.WithRateLimiting(limiter)
+	}
+
+	w.messageSender = sender
+	w.messageSender.Start()
+
+	return nil
+}
+
+func (w *Waku) MessageExists(mh pb.MessageHash) (bool, error) {
+	w.poolMu.Lock()
+	defer w.poolMu.Unlock()
+	return w.envelopeCache.Has(gethcommon.Hash(mh)), nil
+}
+
+func (w *Waku) SetTopicsToVerifyForMissingMessages(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []string) {
+	if !w.cfg.EnableMissingMessageVerification {
+		return
+	}
+
+	w.missingMsgVerifier.SetCriteriaInterest(peerInfo, protocol.NewContentFilter(pubsubTopic, contentTopics...))
+}
+
+func (w *Waku) setupRelaySubscriptions() error {
+	if w.cfg.LightClient {
+		return nil
+	}
+
+	if w.protectedTopicStore != nil {
+		protectedTopics, err := w.protectedTopicStore.ProtectedTopics()
+		if err != nil {
+			return err
+		}
+
+		for _, pt := range protectedTopics {
+			// Adding subscription to protected topics
+			err = w.subscribeToPubsubTopicWithWakuRelay(pt.Topic, pt.PubKey)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	err := w.subscribeToPubsubTopicWithWakuRelay(w.cfg.DefaultShardPubsubTopic, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Stop implements node.Service, stopping the background data propagation thread
+// of the Waku protocol.
+func (w *Waku) Stop() error {
+	w.cancel()
+
+	w.envelopeCache.Stop()
+
+	err := w.node.Stop()
+	if err != nil {
+		return err
+	}
+
+	if w.protectedTopicStore != nil {
+		err := w.protectedTopicStore.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	/* TODO-nwaku
+	close(w.goingOnline)*/
+
+	w.wg.Wait()
+
+	w.ctx = nil
+	w.cancel = nil
+
+	return nil
+}
+
+func (w *Waku) OnNewEnvelopes(envelope common.Envelope, msgType common.MessageType, processImmediately bool) error {
+	if envelope == nil {
+		return nil
+	}
+
+	recvMessage := common.NewReceivedMessage(envelope, msgType)
+	if recvMessage == nil {
+		return nil
+	}
+
+	/* TODO-nwaku
+	if w.metricsHandler != nil {
+		if msgType == common.MissingMessageType {
+			w.metricsHandler.PushMissedMessage(envelope)
+		}
+	} */
+
+	logger := w.logger.With(
+		zap.String("messageType", msgType),
+		zap.Stringer("envelopeHash", envelope.Hash()),
+		zap.String("pubsubTopic", envelope.PubsubTopic()),
+		zap.String("contentTopic", envelope.Message().ContentTopic),
+		logutils.WakuMessageTimestamp("timestamp", envelope.Message().Timestamp),
+	)
+
+	logger.Debug("received new envelope")
+	trouble := false
+
+	_, err := w.add(recvMessage, processImmediately)
+	if err != nil {
+		logger.Info("invalid envelope received", zap.Error(err))
+		trouble = true
+	}
+
+	common.EnvelopesValidatedCounter.With(prometheus.Labels{"pubsubTopic": envelope.PubsubTopic(), "type": msgType}).Inc()
+
+	if trouble {
+		return errors.New("received invalid envelope")
+	}
+
+	return nil
+}
+
+// addEnvelope adds an envelope to the envelope map, used for sending
+func (w *Waku) addEnvelope(envelope *common.ReceivedMessage) {
+	w.poolMu.Lock()
+	w.envelopeCache.Set(envelope.Hash(), envelope, ttlcache.DefaultTTL)
+	w.poolMu.Unlock()
+}
+
+func (w *Waku) add(recvMessage *common.ReceivedMessage, processImmediately bool) (bool, error) {
+	common.EnvelopesReceivedCounter.Inc()
+
+	w.poolMu.Lock()
+	envelope := w.envelopeCache.Get(recvMessage.Hash())
+	alreadyCached := envelope != nil
+	w.poolMu.Unlock()
+
+	if !alreadyCached {
+		recvMessage.Processed.Store(false)
+		w.addEnvelope(recvMessage)
+	}
+
+	logger := w.logger.With(zap.String("envelopeHash", recvMessage.Hash().Hex()))
+
+	if alreadyCached {
+		logger.Debug("w envelope already cached")
+		common.EnvelopesCachedCounter.WithLabelValues("hit").Inc()
+	} else {
+		logger.Debug("cached w envelope")
+		common.EnvelopesCachedCounter.WithLabelValues("miss").Inc()
+		common.EnvelopesSizeMeter.Observe(float64(len(recvMessage.Envelope.Message().Payload)))
+	}
+
+	if !alreadyCached || !envelope.Value().Processed.Load() {
+		if processImmediately {
+			logger.Debug("immediately processing envelope")
+			w.processMessage(recvMessage)
+		} else {
+			logger.Debug("posting event")
+			w.postEvent(recvMessage) // notify the local node about the new message
+		}
+	}
+
+	return true, nil
+}
+
+// postEvent queues the message for further processing.
+func (w *Waku) postEvent(envelope *common.ReceivedMessage) {
+	w.msgQueue <- envelope
+}
+
+// processQueueLoop delivers the messages to the watchers during the lifetime of the waku node.
+func (w *Waku) processQueueLoop() {
+	defer gocommon.LogOnPanic()
+	defer w.wg.Done()
+	if w.ctx == nil {
+		return
+	}
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case e := <-w.msgQueue:
+			w.processMessage(e)
+		}
+	}
+}
+
+func (w *Waku) processMessage(e *common.ReceivedMessage) {
+	logger := w.logger.With(
+		zap.Stringer("envelopeHash", e.Envelope.Hash()),
+		zap.String("pubsubTopic", e.PubsubTopic),
+		zap.String("contentTopic", e.ContentTopic.ContentTopic()),
+		zap.Int64("timestamp", e.Envelope.Message().GetTimestamp()),
+	)
+
+	if e.MsgType == common.StoreMessageType {
+		// We need to insert it first, and then remove it if not matched,
+		// as messages are processed asynchronously
+		w.storeMsgIDsMu.Lock()
+		w.storeMsgIDs[e.Hash()] = true
+		w.storeMsgIDsMu.Unlock()
+	}
+
+	matched := w.filters.NotifyWatchers(e)
+
+	// If not matched we remove it
+	if !matched {
+		logger.Debug("filters did not match")
+		w.storeMsgIDsMu.Lock()
+		delete(w.storeMsgIDs, e.Hash())
+		w.storeMsgIDsMu.Unlock()
+	} else {
+		logger.Debug("filters did match")
+		/* TODO-nwaku
+		if w.metricsHandler != nil && e.MsgType == common.MissingMessageType {
+			w.metricsHandler.PushMissedRelevantMessage(e)
+		}
+		*/
+		e.Processed.Store(true)
+	}
+
+	w.envelopeFeed.Send(common.EnvelopeEvent{
+		Topic: e.ContentTopic,
+		Hash:  e.Hash(),
+		Event: common.EventEnvelopeAvailable,
+	})
+}
+
+// GetEnvelope retrieves an envelope from the message queue by its hash.
+// It returns nil if the envelope can not be found.
+func (w *Waku) GetEnvelope(hash gethcommon.Hash) *common.ReceivedMessage {
+	w.poolMu.RLock()
+	defer w.poolMu.RUnlock()
+
+	envelope := w.envelopeCache.Get(hash)
+	if envelope == nil {
+		return nil
+	}
+
+	return envelope.Value()
+}
+
+// isEnvelopeCached checks if envelope with specific hash has already been received and cached.
+func (w *Waku) IsEnvelopeCached(hash gethcommon.Hash) bool {
+	w.poolMu.Lock()
+	defer w.poolMu.Unlock()
+
+	return w.envelopeCache.Has(hash)
+}
+
+func (w *Waku) ClearEnvelopesCache() {
+	w.poolMu.Lock()
+	defer w.poolMu.Unlock()
+
+	w.envelopeCache.Stop()
+	w.envelopeCache = newTTLCache()
+}
+
+func (w *Waku) PeerCount() int {
+	numPeers, err := w.node.GetNumConnectedPeers()
+	if err != nil {
+		panic(err)
+	}
+	return numPeers
+}
+
+// TODO-nwaku
+func (w *Waku) Peers() types.PeerStats {
+	return nil
+	// return FormatPeerStats(w.node)
+}
+
+func (w *Waku) RelayPeersByTopic(topic string) (*types.PeerList, error) {
+	/* TODO-nwaku
+		return nil, errors.New("only available in relay mode")
+	}
+
+	return &types.PeerList{
+		FullMeshPeers: w.node.Relay().PubSub().MeshPeers(topic),
+		AllPeers:      w.node.Relay().PubSub().ListPeers(topic),
+	}, nil
+	*/
+	return &types.PeerList{}, nil
+}
+
+func (w *Waku) ENR() (*enode.Node, error) {
+	return w.node.ENR()
+}
+
+func (w *Waku) SubscribeToPubsubTopic(topic string, pubkey *ecdsa.PublicKey) error {
+	topic = w.GetPubsubTopic(topic)
+
+	if !w.cfg.LightClient {
+		err := w.subscribeToPubsubTopicWithWakuRelay(topic, pubkey)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *Waku) UnsubscribeFromPubsubTopic(topic string) error {
+	topic = w.GetPubsubTopic(topic)
+
+	if !w.cfg.LightClient {
+		err := w.unsubscribeFromPubsubTopicWithWakuRelay(topic)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *Waku) RetrievePubsubTopicKey(topic string) (*ecdsa.PrivateKey, error) {
+	topic = w.GetPubsubTopic(topic)
+	if w.protectedTopicStore == nil {
+		return nil, nil
+	}
+
+	return w.protectedTopicStore.FetchPrivateKey(topic)
+}
+
+func (w *Waku) StorePubsubTopicKey(topic string, privKey *ecdsa.PrivateKey) error {
+	topic = w.GetPubsubTopic(topic)
+	if w.protectedTopicStore == nil {
+		return nil
+	}
+
+	return w.protectedTopicStore.Insert(topic, privKey, &privKey.PublicKey)
+}
+
+func (w *Waku) RemovePubsubTopicKey(topic string) error {
+	topic = w.GetPubsubTopic(topic)
+	if w.protectedTopicStore == nil {
+		return nil
+	}
+
+	return w.protectedTopicStore.Delete(topic)
+}
+
+func (w *Waku) ListenAddresses() ([]multiaddr.Multiaddr, error) {
+	return w.node.ListenAddresses()
+}
+
+func (w *Waku) DisconnectActiveStorenode(ctx context.Context, backoff time.Duration, shouldCycle bool) {
+	// TODO-nwaku
+	return
+}
+
+func (w *Waku) GetActiveStorenode() peer.AddrInfo {
+	// TODO-nwaku
+	return peer.AddrInfo{}
+}
+
+// GetCurrentTime returns current time.
+func (w *Waku) GetCurrentTime() time.Time {
+	return w.CurrentTime()
+}
+
+func (w *Waku) IsStorenodeAvailable(peerID peer.ID) bool {
+	return w.StorenodeCycle.IsStorenodeAvailable(peerID)
+}
+
+func (w *Waku) OnStorenodeAvailable() <-chan peer.ID {
+	return w.StorenodeCycle.StorenodeAvailableEmitter.Subscribe()
+}
+
+func (w *Waku) OnStorenodeChanged() <-chan peer.ID {
+	return w.StorenodeCycle.StorenodeChangedEmitter.Subscribe()
+}
+
+func (w *Waku) OnStorenodeNotWorking() <-chan struct{} {
+	return w.StorenodeCycle.StorenodeNotWorkingEmitter.Subscribe()
+}
+
+func (w *Waku) PerformStorenodeTask(fn func() error, opts ...history.StorenodeTaskOption) error {
+	return w.StorenodeCycle.PerformStorenodeTask(fn, opts...)
+}
+
+func (w *Waku) ProcessMailserverBatch(
+	ctx context.Context,
+	batch types.MailserverBatch,
+	storenode peer.AddrInfo,
+	pageLimit uint64,
+	shouldProcessNextPage func(int) (bool, uint64),
+	processEnvelopes bool,
+) error {
+	pubsubTopic := w.GetPubsubTopic(batch.PubsubTopic)
+	contentTopics := []string{}
+	for _, topic := range batch.Topics {
+		contentTopics = append(contentTopics, common.BytesToTopic(topic.Bytes()).ContentTopic())
+	}
+
+	criteria := store.FilterCriteria{
+		TimeStart:     proto.Int64(batch.From.UnixNano()),
+		TimeEnd:       proto.Int64(batch.To.UnixNano()),
+		ContentFilter: protocol.NewContentFilter(pubsubTopic, contentTopics...),
+	}
+
+	return w.HistoryRetriever.Query(ctx, criteria, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
+}
+
+func (w *Waku) PublicWakuAPI() types.PublicWakuAPI {
+	return NewPublicWakuAPI(w)
+}
+
+func (w *Waku) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []types.TopicType) error {
+	var cTopics []string
+	for _, ct := range contentTopics {
+		cTopics = append(cTopics, common.BytesToTopic(ct.Bytes()).ContentTopic())
+	}
+	pubsubTopic = w.GetPubsubTopic(pubsubTopic)
+	w.SetTopicsToVerifyForMissingMessages(peerInfo, pubsubTopic, cTopics)
+
+	return nil
+}
+
+func (w *Waku) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
+	w.StorenodeCycle.SetStorenodeConfigProvider(c)
+}
+
+func (w *Waku) Version() uint {
+	return 2
+}
+
+func (w *Waku) WaitForAvailableStoreNode(ctx context.Context) bool {
+	return w.StorenodeCycle.WaitForAvailableStoreNode(ctx)
+}
+
+func (w *Waku) handleNetworkChangeFromApp(state connection.State) {
+	// TODO-nwaku
+	/*
+		//If connection state is reported by something other than peerCount becoming 0 e.g from mobile app, disconnect all peers
+		if (state.Offline && len(w.node.Host().Network().Peers()) > 0) ||
+			(w.state.Type != state.Type && !w.state.Offline && !state.Offline) { // network switched between wifi and cellular
+			w.logger.Info("connection switched or offline detected via mobile, disconnecting all peers")
+			w.node.DisconnectAllPeers()
+			if w.cfg.LightClient {
+				w.filterManager.NetworkChange()
+			}
+		}
+	*/
+}
+
+/* TODO-nwaku
+func (w *Waku) isGoingOnline(state connection.State) bool {
+	return !state.Offline && !w.onlineChecker.IsOnline()
+}
+
+func (w *Waku) isGoingOffline(state connection.State) bool {
+	return state.Offline && w.onlineChecker.IsOnline()
+}
+*/
+
+func (w *Waku) ConnectionChanged(state connection.State) {
+	/* TODO-nwaku
+	if w.isGoingOnline(state) {
+		w.discoverAndConnectPeers()
+		if w.cfg.EnableMissingMessageVerification {
+			w.missingMsgVerifier.Start(w.ctx)
+		}
+	}
+
+	if w.isGoingOffline(state) && w.cfg.EnableMissingMessageVerification {
+		w.missingMsgVerifier.Stop()
+	}
+
+	isOnline := !state.Offline
+	if w.cfg.LightClient {
+		//TODO: Update this as per  https://github.com/waku-org/go-waku/issues/1114
+		go func() {
+			defer gocommon.LogOnPanic()
+			w.filterManager.OnConnectionStatusChange("", isOnline, byte(state.Type))
+		}()
+		w.handleNetworkChangeFromApp(state)
+	} else {
+		// for lightClient state update and onlineChange is handled in filterManager.
+		if w.isGoingOnline(state) {
+			select {
+			case w.goingOnline <- struct{}{}:
+			default:
+				w.logger.Warn("could not write on connection changed channel")
+			}
+		}
+	}
+	// update state
+	w.onlineChecker.SetOnline(isOnline)
+	w.state = state
+	*/
+}
+
+/* TODO-nwaku
+// seedBootnodesForDiscV5 tries to fetch bootnodes
+// from an ENR periodically.
+// It backs off exponentially until maxRetries, at which point it restarts from 0
+// It also restarts if there's a connection change signalled from the client
+func (w *Waku) seedBootnodesForDiscV5() {
+	defer gocommon.LogOnPanic()
+	defer w.wg.Done()
+
+	if !w.cfg.EnableDiscV5 || w.node.DiscV5() == nil {
+		return
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	var retries = 0
+
+	now := func() int64 {
+		return time.Now().UnixNano() / int64(time.Millisecond)
+
+	}
+
+	var lastTry = now()
+
+	canQuery := func() bool {
+		backoff := bootnodesQueryBackoffMs * int64(math.Exp2(float64(retries)))
+
+		return lastTry+backoff < now()
+	}
+
+	for {
+		select {
+		case <-w.dnsDiscAsyncRetrievedSignal:
+			if !canQuery() {
+				continue
+			}
+
+			err := w.restartDiscV5(true)
+			if err != nil {
+				w.logger.Warn("failed to restart discv5", zap.Error(err))
+			}
+			retries = 0
+			lastTry = now()
+		case <-ticker.C:
+			if w.seededBootnodesForDiscV5 && len(w.node.Host().Network().Peers()) > 3 {
+				w.logger.Debug("not querying bootnodes", zap.Bool("seeded", w.seededBootnodesForDiscV5), zap.Int("peer-count", len(w.node.Host().Network().Peers())))
+				continue
+			}
+
+			if !canQuery() {
+				w.logger.Info("can't query bootnodes",
+					zap.Int("peer-count", len(w.node.Host().Network().Peers())),
+					zap.Int64("lastTry", lastTry), zap.Int64("now", now()),
+					zap.Int64("backoff", bootnodesQueryBackoffMs*int64(math.Exp2(float64(retries)))),
+					zap.Int("retries", retries),
+				)
+				continue
+			}
+
+			w.logger.Info("querying bootnodes to restore connectivity", zap.Int("peer-count", len(w.node.Host().Network().Peers())))
+			err := w.restartDiscV5(false)
+			if err != nil {
+				w.logger.Warn("failed to restart discv5", zap.Error(err))
+			}
+
+			lastTry = now()
+			retries++
+			// We reset the retries after a while and restart
+			if retries > bootnodesMaxRetries {
+				retries = 0
+			}
+
+		// If we go online, trigger immediately
+		case <-w.goingOnline:
+			if !canQuery() {
+				continue
+			}
+
+			err := w.restartDiscV5(false)
+			if err != nil {
+				w.logger.Warn("failed to restart discv5", zap.Error(err))
+			}
+			retries = 0
+			lastTry = now()
+
+		case <-w.ctx.Done():
+			w.logger.Debug("bootnode seeding stopped")
+			return
+		}
+	}
+}
+
+// Restart discv5, re-retrieving bootstrap nodes
+func (w *Waku) restartDiscV5(useOnlyDNSDiscCache bool) error {
+	ctx, cancel := context.WithTimeout(w.ctx, 30*time.Second)
+	defer cancel()
+	bootnodes, err := w.getDiscV5BootstrapNodes(ctx, w.discV5BootstrapNodes, useOnlyDNSDiscCache)
+	if err != nil {
+		return err
+	}
+	if len(bootnodes) == 0 {
+		return errors.New("failed to fetch bootnodes")
+	}
+
+	if w.node.DiscV5().ErrOnNotRunning() != nil {
+		w.logger.Info("is not started restarting")
+		err := w.node.DiscV5().Start(w.ctx)
+		if err != nil {
+			w.logger.Error("Could not start DiscV5", zap.Error(err))
+		}
+	} else {
+		w.node.DiscV5().Stop()
+		w.logger.Info("is started restarting")
+
+		select {
+		case <-w.ctx.Done(): // Don't start discv5 if we are stopping waku
+			return nil
+		default:
+		}
+
+		err := w.node.DiscV5().Start(w.ctx)
+		if err != nil {
+			w.logger.Error("Could not start DiscV5", zap.Error(err))
+		}
+	}
+
+	w.logger.Info("restarting discv5 with nodes", zap.Any("nodes", bootnodes))
+	return w.node.SetDiscV5Bootnodes(bootnodes)
+}
+*/
+
+func (w *Waku) timestamp() int64 {
+	return w.timesource.Now().UnixNano()
+}
+
+func (w *Waku) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
+	// TODO-nwaku
+	/*
+		peerID, err := w.node.AddPeer(address, wps.Static, w.cfg.DefaultShardedPubsubTopics, relay.WakuRelayID_v200)
+		if err != nil {
+			return "", err
+		}
+		return peerID, nil
+	*/
+	return "", nil
+}
+
+func (w *Waku) DialPeer(address multiaddr.Multiaddr) error {
+	// Using WakuConnect so it matches the go-waku's behavior and terminology
+	ctx, cancel := context.WithTimeout(w.ctx, requestTimeout)
+	defer cancel()
+	return w.node.Connect(ctx, address)
+}
+
+func (w *Waku) DialPeerByID(peerID peer.ID) error {
+	ctx, cancel := context.WithTimeout(w.ctx, requestTimeout)
+	defer cancel()
+	return w.node.DialPeerByID(ctx, peerID, relay.WakuRelayID_v200)
+}
+
+func (w *Waku) DropPeer(peerID peer.ID) error {
+	return w.node.DisconnectPeerByID(peerID)
+}
+
+func (w *Waku) ProcessingP2PMessages() bool {
+	w.storeMsgIDsMu.Lock()
+	defer w.storeMsgIDsMu.Unlock()
+	return len(w.storeMsgIDs) != 0
+}
+
+func (w *Waku) MarkP2PMessageAsProcessed(hash gethcommon.Hash) {
+	w.storeMsgIDsMu.Lock()
+	defer w.storeMsgIDsMu.Unlock()
+	delete(w.storeMsgIDs, hash)
+}
+
+func (w *Waku) Clean() error {
+	w.msgQueue = make(chan *common.ReceivedMessage, messageQueueLimit)
+
+	for _, f := range w.filters.All() {
+		f.Messages = common.NewMemoryMessageStore()
+	}
+
+	return nil
+}
+
+func (w *Waku) PeerID() peer.ID {
+	peerId, err := w.node.PeerID()
+	if err != nil {
+		panic(err)
+	}
+	return peerId
+}
+
+// validatePrivateKey checks the format of the given private key.
+func validatePrivateKey(k *ecdsa.PrivateKey) bool {
+	if k == nil || k.D == nil || k.D.Sign() == 0 {
+		return false
+	}
+	return common.ValidatePublicKey(&k.PublicKey)
+}
+
+// makeDeterministicID generates a deterministic ID, based on a given input
+func makeDeterministicID(input string, keyLen int) (id string, err error) {
+	buf := pbkdf2.Key([]byte(input), nil, 4096, keyLen, sha256.New)
+	if !common.ValidateDataIntegrity(buf, common.KeyIDSize) {
+		return "", fmt.Errorf("error in GenerateDeterministicID: failed to generate key")
+	}
+	id = gethcommon.Bytes2Hex(buf)
+	return id, err
+}
+
+// toDeterministicID reviews incoming id, and transforms it to format
+// expected internally be private key store. Originally, public keys
+// were used as keys, now random keys are being used. And in order to
+// make it easier to consume, we now allow both random IDs and public
+// keys to be passed.
+func toDeterministicID(id string, expectedLen int) (string, error) {
+	if len(id) != (expectedLen * 2) { // we received hex key, so number of chars in id is doubled
+		var err error
+		id, err = makeDeterministicID(id, expectedLen)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return id, nil
+}
+
+func FormatPeerStats(wakuNode *node.WakuNode) types.PeerStats {
+	p := make(types.PeerStats)
+	for k, v := range wakuNode.PeerStats() {
+		p[k] = types.WakuV2Peer{
+			Addresses: utils.EncapsulatePeerID(k, wakuNode.Host().Peerstore().PeerInfo(k).Addrs...),
+			Protocols: v,
+		}
+	}
+	return p
+}
+
+// TODO-nwaku
+func (w *Waku) StoreNode() *store.WakuStore {
+	// return w.node.Store()
+	return nil
+}
+
+func FormatPeerConnFailures(wakuNode *node.WakuNode) map[string]int {
+	p := make(map[string]int)
+	for _, peerID := range wakuNode.Host().Network().Peers() {
+		peerInfo := wakuNode.Host().Peerstore().PeerInfo(peerID)
+		connFailures := wakuNode.Host().Peerstore().(wps.WakuPeerstore).ConnFailures(peerInfo.ID)
+		if connFailures > 0 {
+			p[peerID.String()] = connFailures
+		}
+	}
+	return p
+}
+
+// TODO-nwaku
+func (w *Waku) LegacyStoreNode() legacy_store.Store {
+	// return w.node.LegacyStore()
+	return nil
+}
+
+func printStackTrace() {
+	// Create a buffer to hold the stack trace
+	buf := make([]byte, 102400)
+	// Capture the stack trace into the buffer
+	n := runtime.Stack(buf, false)
+	// Print the stack trace
+	fmt.Printf("Current stack trace:\n%s\n", buf[:n])
+}
+
+func wakuNew(nodeKey *ecdsa.PrivateKey,
+	fleet string,
+	cfg *Config,
+	logger *zap.Logger,
+	appDB *sql.DB,
+	ts *timesource.NTPTimeSource,
+	onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
+
+	var err error
+	if logger == nil {
+		logger, err = zap.NewDevelopment()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if ts == nil {
+		ts = timesource.Default()
+	}
+
+	if nodeKey == nil {
+		// No nodekey is provided, create an ephemeral key
+		nodeKey, err = crypto.GenerateKey()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate a random private key: %v", err)
+		}
+	}
+
+	nwakuCfg := cfg.NwakuConfig
+	nwakuCfg.Nodekey = hex.EncodeToString(crypto.FromECDSA(nodeKey))
+
+	nwakuCfg.TcpPort, nwakuCfg.Discv5UdpPort, err = getFreePortIfNeeded(nwakuCfg.TcpPort, nwakuCfg.Discv5UdpPort, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO-nwaku
+	// TODO: merge Config and WakuConfig
+	cfg = setDefaults(cfg)
+	if err = cfg.Validate(logger); err != nil {
+		return nil, err
+	}
+	logger.Info("starting wakuv2 with config", zap.Any("nwakuCfg", nwakuCfg), zap.Any("wakuCfg", cfg))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if !cfg.LightClient {
+		nwakuCfg.Discv5Discovery = true
+		nwakuCfg.Relay = true
+		nwakuCfg.Filter = true
+		nwakuCfg.FilterMaxPeersToServe = 20
+		nwakuCfg.Lightpush = true
+		nwakuCfg.RateLimits.Filter = &bindingscommon.RateLimit{Volume: 100, Period: 1, TimeUnit: bindingscommon.Second}
+		nwakuCfg.RateLimits.Lightpush = &bindingscommon.RateLimit{Volume: 5, Period: 1, TimeUnit: bindingscommon.Second}
+	}
+
+	if cfg.EnablePeerExchangeServer {
+		nwakuCfg.PeerExchange = true
+		nwakuCfg.RateLimits.PeerExchange = &bindingscommon.RateLimit{Volume: 5, Period: 1, TimeUnit: bindingscommon.Second}
+	}
+
+	wakunode, err := waku.NewWakuNode(nwakuCfg, "nwaku")
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	var protectedTopicStore *persistence.ProtectedTopicsStore
+	if appDB != nil {
+		protectedTopicStore, err = persistence.NewProtectedTopicsStore(logger, appDB)
+		if err != nil {
+			cancel()
+			return nil, err
+		}
+	}
+
+	// Notice that the events for self node are handled by the 'MyEventCallback' method
+
+	return &Waku{
+		node:                            wakunode,
+		cfg:                             cfg,
+		privateKeys:                     make(map[string]*ecdsa.PrivateKey),
+		symKeys:                         make(map[string][]byte),
+		envelopeCache:                   newTTLCache(),
+		msgQueue:                        make(chan *common.ReceivedMessage, messageQueueLimit),
+		topicHealthStatusChan:           make(chan peermanager.TopicHealthStatus, 100),
+		connectionNotifChan:             make(chan node.PeerConnection, 20),
+		connStatusSubscriptions:         make(map[string]*types.ConnStatusSubscription),
+		ctx:                             ctx,
+		cancel:                          cancel,
+		wg:                              sync.WaitGroup{},
+		dnsAddressCache:                 make(map[string][]dnsdisc.DiscoveredNode),
+		dnsAddressCacheLock:             &sync.RWMutex{},
+		dnsDiscAsyncRetrievedSignal:     make(chan struct{}),
+		storeMsgIDs:                     make(map[gethcommon.Hash]bool),
+		timesource:                      ts,
+		storeMsgIDsMu:                   sync.RWMutex{},
+		logger:                          logger,
+		discV5BootstrapNodes:            nwakuCfg.Discv5BootstrapNodes,
+		onHistoricMessagesRequestFailed: onHistoricMessagesRequestFailed,
+		onPeerStats:                     onPeerStats,
+		onlineChecker:                   onlinechecker.NewDefaultOnlineChecker(false).(*onlinechecker.DefaultOnlineChecker),
+		sendQueue:                       publish.NewMessageQueue(1000, cfg.UseThrottledPublish),
+		filters:                         common.NewFilters(cfg.DefaultShardPubsubTopic, logger),
+		protectedTopicStore:             protectedTopicStore,
+	}, nil
+
+}
+
+func getFreePortIfNeeded(tcpPort int, discV5UDPPort int, logger *zap.Logger) (int, int, error) {
+	if tcpPort == 0 {
+		for i := 0; i < 10; i++ {
+			tcpAddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort("localhost", "0"))
+			if err != nil {
+				logger.Warn("unable to resolve tcp addr: %v", zap.Error(err))
+				continue
+			}
+			tcpListener, err := net.ListenTCP("tcp", tcpAddr)
+			if err != nil {
+				logger.Warn("unable to listen on addr", zap.Stringer("addr", tcpAddr), zap.Error(err))
+				continue
+			}
+			tcpPort = tcpListener.Addr().(*net.TCPAddr).Port
+			tcpListener.Close()
+			break
+		}
+		if tcpPort == 0 {
+			return -1, -1, errors.New("could not obtain a free TCP port")
+		}
+	}
+
+	if discV5UDPPort == 0 {
+		for i := 0; i < 10; i++ {
+			udpAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort("localhost", "0"))
+			if err != nil {
+				logger.Warn("unable to resolve udp addr: %v", zap.Error(err))
+				continue
+			}
+
+			udpListener, err := net.ListenUDP("udp", udpAddr)
+			if err != nil {
+				logger.Warn("unable to listen on addr", zap.Stringer("addr", udpAddr), zap.Error(err))
+				continue
+			}
+
+			discV5UDPPort = udpListener.LocalAddr().(*net.UDPAddr).Port
+			udpListener.Close()
+			break
+		}
+		if discV5UDPPort == 0 {
+			return -1, -1, errors.New("could not obtain a free UDP port")
+		}
+	}
+
+	return tcpPort, discV5UDPPort, nil
+}

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -35,7 +35,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
 
@@ -736,11 +735,6 @@ func (w *Waku) APIs() []rpc.API {
 			Public:    false,
 		},
 	}
-}
-
-// Protocols returns the waku sub-protocols ran by this particular client.
-func (w *Waku) Protocols() []p2p.Protocol {
-	return []p2p.Protocol{}
 }
 
 func (w *Waku) SendEnvelopeEvent(event common.EnvelopeEvent) int {
@@ -1965,12 +1959,6 @@ func (w *Waku) DropPeer(peerID peer.ID) error {
 	return w.node.DisconnectPeerByID(peerID)
 }
 
-func (w *Waku) ProcessingP2PMessages() bool {
-	w.storeMsgIDsMu.Lock()
-	defer w.storeMsgIDsMu.Unlock()
-	return len(w.storeMsgIDs) != 0
-}
-
 func (w *Waku) MarkP2PMessageAsProcessed(hash gethcommon.Hash) {
 	w.storeMsgIDsMu.Lock()
 	defer w.storeMsgIDsMu.Unlock()
@@ -2066,8 +2054,9 @@ func (w *Waku) LegacyStoreNode() legacy_store.Store {
 }
 
 // GetCurrentTime returns current time.
-func (w *Waku) GetCurrentTime() time.Time {
-	return w.CurrentTime()
+// Implements protocol/common.TimeSource
+func (w *Waku) GetCurrentTime() uint64 {
+	return uint64(w.CurrentTime().UnixNano() / int64(time.Millisecond))
 }
 
 func (w *Waku) GetActiveStorenode() peer.AddrInfo {

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -105,6 +105,7 @@ type IMetricsHandler interface {
 	PushMissedRelevantMessage(message *common.ReceivedMessage)
 	PushMessageDeliveryConfirmed()
 	PushSentMessageTotal(messageSize uint32, publishMethod string)
+	PushRawMessageByType(pubsubTopic string, contentTopic string, messageType string, messageSize uint32)
 }
 
 // Waku represents a dark communication interface through the Ethereum

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -188,6 +188,8 @@ type Waku struct {
 	defaultShardInfo protocol.RelayShards
 }
 
+var _ types.Waku = (*Waku)(nil)
+
 func (w *Waku) SetMetricsHandler(client IMetricsHandler) {
 	w.metricsHandler = client
 }
@@ -338,7 +340,21 @@ func (w *Waku) SubscribeToConnStatusChanges() (*types.ConnStatusSubscription, er
 	return subscription, nil
 }
 
-/* TODO-nwaku
+func (w *Waku) GetNodeENRString() (string, error) {
+	if w.node == nil {
+		return "", errors.New("node not initialized")
+	}
+
+	enr, err := w.node.ENR()
+	if err != nil {
+		w.logger.Error("failed retrieving node's enr", zap.Error(err))
+		return "", err
+	}
+
+	return enr.String(), nil
+}
+
+/* TODO-nwaku* (this logic should be directly in nwaku?)
 func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string, useOnlyDnsDiscCache bool) ([]*enode.Node, error) {
 	wg := sync.WaitGroup{}
 	mu := sync.Mutex{}
@@ -367,8 +383,11 @@ func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string, 
 				defer gocommon.LogOnPanic()
 				defer wg.Done()
 				if err := w.dnsDiscover(ctx, addr, retrieveENR, useOnlyDnsDiscCache); err != nil {
+					// prevent w.ctx in retryDnsDiscoveryWithBackoff from set to nil when w.Stop() is called
+					w.wg.Add(1)
 					go func() {
 						defer gocommon.LogOnPanic()
+						defer w.wg.Done()
 						w.retryDnsDiscoveryWithBackoff(ctx, addr, w.dnsDiscAsyncRetrievedSignal)
 					}()
 				}
@@ -440,8 +459,11 @@ func (w *Waku) dnsDiscover(ctx context.Context, enrtreeAddress string, apply fnA
 
 func (w *Waku) retryDnsDiscoveryWithBackoff(ctx context.Context, addr string, successChan chan<- struct{}) {
 	retries := 0
+	applyFn := func(_ dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {
+		wg.Done()
+	}
 	for {
-		err := w.dnsDiscover(ctx, addr, func(d dnsdisc.DiscoveredNode, wg *sync.WaitGroup) {}, false)
+		err := w.dnsDiscover(ctx, addr, applyFn, false)
 		if err == nil {
 			select {
 			case successChan <- struct{}{}:
@@ -530,7 +552,7 @@ func (w *Waku) connect(peerInfo peer.AddrInfo, enr *enode.Node, origin wps.Origi
 	}
 }
 
-/* TODO-nwaku
+/* TODO-nwaku - implement when metrics are supported
 func (w *Waku) telemetryBandwidthStats(telemetryServerURL string) {
 	defer gocommon.LogOnPanic()
 	defer w.wg.Done()
@@ -557,14 +579,7 @@ func (w *Waku) telemetryBandwidthStats(telemetryServerURL string) {
 }
 */
 
-func (w *Waku) StartDiscV5() error {
-	return w.node.StartDiscV5()
-}
-
-func (w *Waku) StopDiscV5() error {
-	return w.node.StopDiscV5()
-}
-
+// TODO-nwaku - implement when metrics are supported
 func (w *Waku) GetStats() types.StatsSummary {
 	return types.StatsSummary{
 		UploadRate:   uint64(1),
@@ -578,7 +593,7 @@ func (w *Waku) GetStats() types.StatsSummary {
 	} */
 }
 
-/* TODO-nwaku
+/* TODO-nwaku* (this logic should be directly in nwaku?)
 func (w *Waku) runPeerExchangeLoop() {
 	defer gocommon.LogOnPanic()
 	defer w.wg.Done()
@@ -1005,37 +1020,6 @@ func (w *Waku) subscribe(f *common.Filter) (string, error) {
 	return id, nil
 }
 
-func (w *Waku) Subscribe(opts *types.SubscriptionOptions) (string, error) {
-	var (
-		err     error
-		keyAsym *ecdsa.PrivateKey
-		keySym  []byte
-	)
-
-	if opts.SymKeyID != "" {
-		keySym, err = w.GetSymKey(opts.SymKeyID)
-		if err != nil {
-			return "", err
-		}
-	}
-	if opts.PrivateKeyID != "" {
-		keyAsym, err = w.GetPrivateKey(opts.PrivateKeyID)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	f := &common.Filter{
-		KeyAsym:       keyAsym,
-		KeySym:        keySym,
-		ContentTopics: common.NewTopicSetFromBytes(opts.Topics),
-		PubsubTopic:   opts.PubsubTopic,
-		Messages:      common.NewMemoryMessageStore(),
-	}
-
-	return w.subscribe(f)
-}
-
 // Unsubscribe removes an installed message handler.
 func (w *Waku) Unsubscribe(ctx context.Context, id string) error {
 	ok := w.filters.Uninstall(id)
@@ -1077,11 +1061,9 @@ func (w *Waku) SkipPublishToTopic(value bool) {
 
 func (w *Waku) ConfirmMessageDelivered(hashes []gethcommon.Hash) {
 	w.messageSender.MessagesDelivered(hashes)
-	/* TODO-nwaku
 	if w.metricsHandler != nil {
 		w.metricsHandler.PushMessageDeliveryConfirmed()
 	}
-	*/
 }
 
 // OnNewEnvelope is an interface from Waku FilterManager API that gets invoked when any new message is received by Filter.
@@ -1309,7 +1291,7 @@ func (w *Waku) checkForConnectionChanges() {
 	}) */
 }
 
-/* TODO: nwaku
+/* TODO-nwaku - implement when metrics are supported
 func (w *Waku) reportPeerMetrics() {
 	if w.metricsHandler != nil {
 		connFailures := FormatPeerConnFailures(w.node)
@@ -1355,10 +1337,9 @@ func (w *Waku) reportPeerMetrics() {
 
 func (w *Waku) startMessageSender() error {
 	publishMethod := publish.Relay
-	/* TODO-nwaku
 	if w.cfg.LightClient {
 		publishMethod = publish.LightPush
-	}*/
+	}
 
 	sender, err := publish.NewMessageSender(publishMethod, newPublisher(w.node), nil, w.logger)
 	if err != nil {
@@ -1366,10 +1347,10 @@ func (w *Waku) startMessageSender() error {
 		return err
 	}
 
-	/* TODO-nwaku
+	/* TODO-nwaku - check what WithMessageSentEmitter does
 	if w.cfg.TelemetryServerURL != "" {
 		sender.WithMessageSentEmitter(w.node.Host())
-	}*/
+	} */
 
 	if w.cfg.EnableStoreConfirmationForMessagesSent {
 		msgStoredChan := make(chan gethcommon.Hash, 1000)
@@ -1390,7 +1371,6 @@ func (w *Waku) startMessageSender() error {
 						Hash:  hash,
 						Event: common.EventEnvelopeSent,
 					})
-
 					if w.metricsHandler != nil {
 						w.metricsHandler.PushMessageCheckSuccess()
 					}
@@ -1399,7 +1379,6 @@ func (w *Waku) startMessageSender() error {
 						Hash:  hash,
 						Event: common.EventEnvelopeExpired,
 					})
-
 					if w.metricsHandler != nil {
 						w.metricsHandler.PushMessageCheckFailure()
 					}
@@ -1503,12 +1482,13 @@ func (w *Waku) OnNewEnvelopes(envelope common.Envelope, msgType common.MessageTy
 		return nil
 	}
 
-	/* TODO-nwaku
+	/* TODO-nwaku - implement when metrics are supported
 	if w.metricsHandler != nil {
 		if msgType == common.MissingMessageType {
 			w.metricsHandler.PushMissedMessage(envelope)
 		}
-	} */
+	}
+	*/
 
 	logger := w.logger.With(
 		zap.String("messageType", msgType),
@@ -1628,11 +1608,9 @@ func (w *Waku) processMessage(e *common.ReceivedMessage) {
 		w.storeMsgIDsMu.Unlock()
 	} else {
 		logger.Debug("filters did match")
-		/* TODO-nwaku
 		if w.metricsHandler != nil && e.MsgType == common.MissingMessageType {
 			w.metricsHandler.PushMissedRelevantMessage(e)
 		}
-		*/
 		e.Processed.Store(true)
 	}
 
@@ -1755,93 +1733,12 @@ func (w *Waku) RemovePubsubTopicKey(topic string) error {
 	return w.protectedTopicStore.Delete(topic)
 }
 
-func (w *Waku) ListenAddresses() ([]multiaddr.Multiaddr, error) {
-	return w.node.ListenAddresses()
+func (w *Waku) StartDiscV5() error {
+	return w.node.StartDiscV5()
 }
 
-func (w *Waku) DisconnectActiveStorenode(ctx context.Context, backoff time.Duration, shouldCycle bool) {
-	// TODO-nwaku
-	return
-}
-
-func (w *Waku) GetActiveStorenode() peer.AddrInfo {
-	// TODO-nwaku
-	return peer.AddrInfo{}
-}
-
-// GetCurrentTime returns current time.
-func (w *Waku) GetCurrentTime() time.Time {
-	return w.CurrentTime()
-}
-
-func (w *Waku) IsStorenodeAvailable(peerID peer.ID) bool {
-	return w.StorenodeCycle.IsStorenodeAvailable(peerID)
-}
-
-func (w *Waku) OnStorenodeAvailable() <-chan peer.ID {
-	return w.StorenodeCycle.StorenodeAvailableEmitter.Subscribe()
-}
-
-func (w *Waku) OnStorenodeChanged() <-chan peer.ID {
-	return w.StorenodeCycle.StorenodeChangedEmitter.Subscribe()
-}
-
-func (w *Waku) OnStorenodeNotWorking() <-chan struct{} {
-	return w.StorenodeCycle.StorenodeNotWorkingEmitter.Subscribe()
-}
-
-func (w *Waku) PerformStorenodeTask(fn func() error, opts ...history.StorenodeTaskOption) error {
-	return w.StorenodeCycle.PerformStorenodeTask(fn, opts...)
-}
-
-func (w *Waku) ProcessMailserverBatch(
-	ctx context.Context,
-	batch types.MailserverBatch,
-	storenode peer.AddrInfo,
-	pageLimit uint64,
-	shouldProcessNextPage func(int) (bool, uint64),
-	processEnvelopes bool,
-) error {
-	pubsubTopic := w.GetPubsubTopic(batch.PubsubTopic)
-	contentTopics := []string{}
-	for _, topic := range batch.Topics {
-		contentTopics = append(contentTopics, common.BytesToTopic(topic.Bytes()).ContentTopic())
-	}
-
-	criteria := store.FilterCriteria{
-		TimeStart:     proto.Int64(batch.From.UnixNano()),
-		TimeEnd:       proto.Int64(batch.To.UnixNano()),
-		ContentFilter: protocol.NewContentFilter(pubsubTopic, contentTopics...),
-	}
-
-	return w.HistoryRetriever.Query(ctx, criteria, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
-}
-
-func (w *Waku) PublicWakuAPI() types.PublicWakuAPI {
-	return NewPublicWakuAPI(w)
-}
-
-func (w *Waku) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []types.TopicType) error {
-	var cTopics []string
-	for _, ct := range contentTopics {
-		cTopics = append(cTopics, common.BytesToTopic(ct.Bytes()).ContentTopic())
-	}
-	pubsubTopic = w.GetPubsubTopic(pubsubTopic)
-	w.SetTopicsToVerifyForMissingMessages(peerInfo, pubsubTopic, cTopics)
-
-	return nil
-}
-
-func (w *Waku) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
-	w.StorenodeCycle.SetStorenodeConfigProvider(c)
-}
-
-func (w *Waku) Version() uint {
-	return 2
-}
-
-func (w *Waku) WaitForAvailableStoreNode(ctx context.Context) bool {
-	return w.StorenodeCycle.WaitForAvailableStoreNode(ctx)
+func (w *Waku) StopDiscV5() error {
+	return w.node.StopDiscV5()
 }
 
 func (w *Waku) handleNetworkChangeFromApp(state connection.State) {
@@ -2168,6 +2065,126 @@ func FormatPeerConnFailures(wakuNode *node.WakuNode) map[string]int {
 func (w *Waku) LegacyStoreNode() legacy_store.Store {
 	// return w.node.LegacyStore()
 	return nil
+}
+
+// GetCurrentTime returns current time.
+func (w *Waku) GetCurrentTime() time.Time {
+	return w.CurrentTime()
+}
+
+func (w *Waku) GetActiveStorenode() peer.AddrInfo {
+	// TODO-nwaku
+	return peer.AddrInfo{}
+}
+
+func (w *Waku) OnStorenodeChanged() <-chan peer.ID {
+	return w.StorenodeCycle.StorenodeChangedEmitter.Subscribe()
+}
+
+func (w *Waku) OnStorenodeNotWorking() <-chan struct{} {
+	return w.StorenodeCycle.StorenodeNotWorkingEmitter.Subscribe()
+}
+
+func (w *Waku) OnStorenodeAvailable() <-chan peer.ID {
+	return w.StorenodeCycle.StorenodeAvailableEmitter.Subscribe()
+}
+
+func (w *Waku) WaitForAvailableStoreNode(ctx context.Context) bool {
+	return w.StorenodeCycle.WaitForAvailableStoreNode(ctx)
+}
+
+func (w *Waku) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
+	w.StorenodeCycle.SetStorenodeConfigProvider(c)
+}
+
+func (w *Waku) ProcessMailserverBatch(
+	ctx context.Context,
+	batch types.MailserverBatch,
+	storenode peer.AddrInfo,
+	pageLimit uint64,
+	shouldProcessNextPage func(int) (bool, uint64),
+	processEnvelopes bool,
+) error {
+	pubsubTopic := w.GetPubsubTopic(batch.PubsubTopic)
+	contentTopics := []string{}
+	for _, topic := range batch.Topics {
+		contentTopics = append(contentTopics, common.BytesToTopic(topic.Bytes()).ContentTopic())
+	}
+
+	criteria := store.FilterCriteria{
+		TimeStart:     proto.Int64(batch.From.UnixNano()),
+		TimeEnd:       proto.Int64(batch.To.UnixNano()),
+		ContentFilter: protocol.NewContentFilter(pubsubTopic, contentTopics...),
+	}
+
+	return w.HistoryRetriever.Query(ctx, criteria, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
+}
+
+func (w *Waku) IsStorenodeAvailable(peerID peer.ID) bool {
+	return w.StorenodeCycle.IsStorenodeAvailable(peerID)
+}
+
+func (w *Waku) PerformStorenodeTask(fn func() error, opts ...history.StorenodeTaskOption) error {
+	return w.StorenodeCycle.PerformStorenodeTask(fn, opts...)
+}
+
+func (w *Waku) DisconnectActiveStorenode(ctx context.Context, backoff time.Duration, shouldCycle bool) {
+	// TODO-nwaku
+	return
+}
+
+func (w *Waku) PublicWakuAPI() types.PublicWakuAPI {
+	return NewPublicWakuAPI(w)
+}
+
+func (w *Waku) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, pubsubTopic string, contentTopics []types.TopicType) error {
+	var cTopics []string
+	for _, ct := range contentTopics {
+		cTopics = append(cTopics, common.BytesToTopic(ct.Bytes()).ContentTopic())
+	}
+	pubsubTopic = w.GetPubsubTopic(pubsubTopic)
+	w.SetTopicsToVerifyForMissingMessages(peerInfo, pubsubTopic, cTopics)
+
+	return nil
+}
+
+func (w *Waku) Subscribe(opts *types.SubscriptionOptions) (string, error) {
+	var (
+		err     error
+		keyAsym *ecdsa.PrivateKey
+		keySym  []byte
+	)
+
+	if opts.SymKeyID != "" {
+		keySym, err = w.GetSymKey(opts.SymKeyID)
+		if err != nil {
+			return "", err
+		}
+	}
+	if opts.PrivateKeyID != "" {
+		keyAsym, err = w.GetPrivateKey(opts.PrivateKeyID)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	f := &common.Filter{
+		KeyAsym:       keyAsym,
+		KeySym:        keySym,
+		ContentTopics: common.NewTopicSetFromBytes(opts.Topics),
+		PubsubTopic:   opts.PubsubTopic,
+		Messages:      common.NewMemoryMessageStore(),
+	}
+
+	return w.subscribe(f)
+}
+
+func (w *Waku) Version() uint {
+	return 2
+}
+
+func (w *Waku) ListenAddresses() ([]multiaddr.Multiaddr, error) {
+	return w.node.ListenAddresses()
 }
 
 func printStackTrace() {

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -94,7 +94,6 @@ type IMetricsHandler interface {
 	SetDeviceType(deviceType string)
 	PushSentEnvelope(sentEnvelope SentEnvelope)
 	PushErrorSendingEnvelope(errorSendingEnvelope ErrorSendingEnvelope)
-	PushPeerCount(peerCount int)
 	PushPeerConnFailures(peerConnFailures map[string]int)
 	PushMessageCheckSuccess()
 	PushMessageCheckFailure()
@@ -1295,7 +1294,6 @@ func (w *Waku) checkForConnectionChanges() {
 func (w *Waku) reportPeerMetrics() {
 	if w.metricsHandler != nil {
 		connFailures := FormatPeerConnFailures(w.node)
-		w.metricsHandler.PushPeerCount(w.PeerCount())
 		w.metricsHandler.PushPeerConnFailures(connFailures)
 
 		peerCountByOrigin := make(map[wps.Origin]uint)

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -57,6 +57,7 @@ import (
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/connection"
+	ethtypes "github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/timesource"
 	"github.com/status-im/status-go/waku/types"
@@ -125,8 +126,8 @@ type Waku struct {
 	symKeys     map[string][]byte            // Symmetric key storage
 	keyMu       sync.RWMutex                 // Mutex associated with key stores
 
-	envelopeCache *ttlcache.Cache[gethcommon.Hash, *common.ReceivedMessage] // Pool of envelopes currently tracked by this node
-	poolMu        sync.RWMutex                                              // Mutex to sync the message and expiration pools
+	envelopeCache *ttlcache.Cache[gethcommon.Hash, bool] // [Hash of envelope -> Processed] cache
+	poolMu        sync.RWMutex                           // Mutex to sync the message and expiration pools
 
 	bandwidthCounter *metrics.BandwidthCounter
 
@@ -192,8 +193,8 @@ func (w *Waku) SetMetricsHandler(client IMetricsHandler) {
 	w.metricsHandler = client
 }
 
-func newTTLCache() *ttlcache.Cache[gethcommon.Hash, *common.ReceivedMessage] {
-	cache := ttlcache.New[gethcommon.Hash, *common.ReceivedMessage](ttlcache.WithTTL[gethcommon.Hash, *common.ReceivedMessage](cacheTTL))
+func newTTLCache() *ttlcache.Cache[gethcommon.Hash, bool] {
+	cache := ttlcache.New(ttlcache.WithTTL[gethcommon.Hash, bool](cacheTTL))
 	go func() {
 		defer gocommon.LogOnPanic()
 		cache.Start()
@@ -1511,7 +1512,8 @@ func (w *Waku) OnNewEnvelopes(envelope common.Envelope, msgType common.MessageTy
 // addEnvelope adds an envelope to the envelope map, used for sending
 func (w *Waku) addEnvelope(envelope *common.ReceivedMessage) {
 	w.poolMu.Lock()
-	w.envelopeCache.Set(envelope.Hash(), envelope, ttlcache.DefaultTTL)
+	// Add the envelope to the cache with Processed set to false
+	w.envelopeCache.Set(envelope.Hash(), false, ttlcache.DefaultTTL)
 	w.poolMu.Unlock()
 }
 
@@ -1519,13 +1521,14 @@ func (w *Waku) add(recvMessage *common.ReceivedMessage, processImmediately bool)
 	common.EnvelopesReceivedCounter.Inc()
 
 	w.poolMu.Lock()
-	envelope := w.envelopeCache.Get(recvMessage.Hash())
-	alreadyCached := envelope != nil
+	alreadyCached := w.envelopeCache.Has(recvMessage.Hash())
+	envelopeProcessed := false
 	w.poolMu.Unlock()
 
 	if !alreadyCached {
-		recvMessage.Processed.Store(false)
 		w.addEnvelope(recvMessage)
+	} else {
+		envelopeProcessed = w.envelopeCache.Get(recvMessage.Hash()).Value()
 	}
 
 	logger := w.logger.With(zap.String("envelopeHash", recvMessage.Hash().Hex()))
@@ -1539,7 +1542,7 @@ func (w *Waku) add(recvMessage *common.ReceivedMessage, processImmediately bool)
 		common.EnvelopesSizeMeter.Observe(float64(len(recvMessage.Envelope.Message().Payload)))
 	}
 
-	if !alreadyCached || !envelope.Value().Processed.Load() {
+	if !envelopeProcessed {
 		if processImmediately {
 			logger.Debug("immediately processing envelope")
 			w.processMessage(recvMessage)
@@ -1603,7 +1606,7 @@ func (w *Waku) processMessage(e *common.ReceivedMessage) {
 		if w.metricsHandler != nil && e.MsgType == common.MissingMessageType {
 			w.metricsHandler.PushMissedRelevantMessage(e)
 		}
-		e.Processed.Store(true)
+		w.envelopeCache.Set(e.Hash(), true, ttlcache.DefaultTTL)
 	}
 
 	w.envelopeFeed.Send(common.EnvelopeEvent{
@@ -1613,18 +1616,12 @@ func (w *Waku) processMessage(e *common.ReceivedMessage) {
 	})
 }
 
-// GetEnvelope retrieves an envelope from the message queue by its hash.
-// It returns nil if the envelope can not be found.
-func (w *Waku) GetEnvelope(hash gethcommon.Hash) *common.ReceivedMessage {
+// HasEnvelope returns true if the envelope with the given hash is present in the cache.
+func (w *Waku) HasEnvelope(hash ethtypes.Hash) bool {
 	w.poolMu.RLock()
 	defer w.poolMu.RUnlock()
 
-	envelope := w.envelopeCache.Get(hash)
-	if envelope == nil {
-		return nil
-	}
-
-	return envelope.Value()
+	return w.envelopeCache.Has(gethcommon.Hash(hash))
 }
 
 // isEnvelopeCached checks if envelope with specific hash has already been received and cached.

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -201,9 +201,8 @@ func newTTLCache() *ttlcache.Cache[gethcommon.Hash, *common.ReceivedMessage] {
 }
 
 // New creates a WakuV2 client ready to communicate through the LibP2P network.
-func New(nodeKey *ecdsa.PrivateKey, fleet string, cfg *Config, logger *zap.Logger, appDB *sql.DB, ts *timesource.NTPTimeSource, onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
+func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, appDB *sql.DB, ts *timesource.NTPTimeSource, onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
 	node, err := wakuNew(nodeKey,
-		fleet,
 		cfg,
 		logger, appDB, ts, onHistoricMessagesRequestFailed,
 		onPeerStats)
@@ -2180,7 +2179,6 @@ func printStackTrace() {
 }
 
 func wakuNew(nodeKey *ecdsa.PrivateKey,
-	fleet string,
 	cfg *Config,
 	logger *zap.Logger,
 	appDB *sql.DB,

--- a/wakuv2/nwaku_test.go
+++ b/wakuv2/nwaku_test.go
@@ -1,53 +1,33 @@
-//go:build !use_nwaku
-// +build !use_nwaku
+//go:build use_nwaku
+// +build use_nwaku
 
 package wakuv2
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/json"
 	"errors"
-	"math/big"
-	"os"
-	"sync"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v3"
-	"github.com/libp2p/go-libp2p/core/metrics"
 	"github.com/libp2p/go-libp2p/core/peer"
-	libp2pprotocol "github.com/libp2p/go-libp2p/core/protocol"
+	"go.uber.org/zap"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto"
-	ethdnsdisc "github.com/ethereum/go-ethereum/p2p/dnsdisc"
-	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/waku-org/waku-go-bindings/waku"
 
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
-	"google.golang.org/protobuf/proto"
-
-	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
-	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
-	"github.com/waku-org/go-waku/waku/v2/protocol"
-	"github.com/waku-org/go-waku/waku/v2/protocol/filter"
-	"github.com/waku-org/go-waku/waku/v2/protocol/legacy_store"
-	"github.com/waku-org/go-waku/waku/v2/protocol/lightpush"
-	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
-	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
+	"github.com/waku-org/go-waku/waku/v2/api/history"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
 
-	"github.com/status-im/status-go/appdatabase"
-	"github.com/status-im/status-go/connection"
+	"github.com/stretchr/testify/require"
+
 	"github.com/status-im/status-go/protocol/tt"
-	"github.com/status-im/status-go/t/helpers"
-	"github.com/status-im/status-go/wakuv2/common"
 )
 
-var testStoreENRBootstrap = "enrtree://AI4W5N5IFEUIHF5LESUAOSMV6TKWF2MB6GU2YK7PU4TYUGUNOCEPW@store.staging.status.nodes.status.im"
-var testBootENRBootstrap = "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.staging.status.nodes.status.im"
+// var testStoreENRBootstrap = "enrtree://AI4W5N5IFEUIHF5LESUAOSMV6TKWF2MB6GU2YK7PU4TYUGUNOCEPW@store.staging.status.nodes.status.im"
+// var testBootENRBootstrap = "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.staging.status.nodes.status.im"
 
+/*
 func setDefaultConfig(config *Config, lightMode bool) {
 	config.ClusterID = 16
 
@@ -61,31 +41,29 @@ func setDefaultConfig(config *Config, lightMode bool) {
 		config.LightClient = false
 		config.EnablePeerExchangeClient = false
 	}
-}
+}*/
 
+/*
 func TestDiscoveryV5(t *testing.T) {
 	config := &Config{}
 	setDefaultConfig(config, false)
 	config.DiscV5BootstrapNodes = []string{testStoreENRBootstrap}
 	config.DiscoveryLimit = 20
-	w, err := New(nil, config, nil, nil, nil, nil, nil)
+	w, err := New(nil, "shards.staging", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-
 	require.NoError(t, w.Start())
-
 	err = tt.RetryWithBackOff(func() error {
 		if len(w.Peers()) == 0 {
 			return errors.New("no peers discovered")
 		}
 		return nil
 	})
-
 	require.NoError(t, err)
-
 	require.NotEqual(t, 0, len(w.Peers()))
 	require.NoError(t, w.Stop())
 }
-
+*/
+/*
 func TestRestartDiscoveryV5(t *testing.T) {
 	config := &Config{}
 	setDefaultConfig(config, false)
@@ -94,16 +72,13 @@ func TestRestartDiscoveryV5(t *testing.T) {
 	config.DiscoveryLimit = 20
 	config.UDPPort = 10002
 	config.ClusterID = 16
-	w, err := New(nil, config, nil, nil, nil, nil, nil)
+	w, err := New(nil, "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-
 	require.NoError(t, w.Start())
 	require.False(t, w.seededBootnodesForDiscV5)
-
 	options := func(b *backoff.ExponentialBackOff) {
 		b.MaxElapsedTime = 2 * time.Second
 	}
-
 	// Sanity check, not great, but it's probably helpful
 	err = tt.RetryWithBackOff(func() error {
 		if len(w.Peers()) == 0 {
@@ -111,15 +86,11 @@ func TestRestartDiscoveryV5(t *testing.T) {
 		}
 		return nil
 	}, options)
-
 	require.Error(t, err)
-
 	w.discV5BootstrapNodes = []string{testStoreENRBootstrap}
-
 	options = func(b *backoff.ExponentialBackOff) {
 		b.MaxElapsedTime = 90 * time.Second
 	}
-
 	err = tt.RetryWithBackOff(func() error {
 		if len(w.Peers()) == 0 {
 			return errors.New("no peers discovered")
@@ -127,28 +98,25 @@ func TestRestartDiscoveryV5(t *testing.T) {
 		return nil
 	}, options)
 	require.NoError(t, err)
-
 	require.True(t, w.seededBootnodesForDiscV5)
 	require.NotEqual(t, 0, len(w.Peers()))
 	require.NoError(t, w.Stop())
 }
-
 func TestRelayPeers(t *testing.T) {
 	config := &Config{
 		EnableMissingMessageVerification: true,
 	}
 	setDefaultConfig(config, false)
-	w, err := New(nil, config, nil, nil, nil, nil, nil)
+	w, err := New(nil, "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 	_, err = w.RelayPeersByTopic(config.DefaultShardPubsubTopic)
 	require.NoError(t, err)
-
 	// Ensure function returns an error for lightclient
 	config = &Config{}
 	config.ClusterID = 16
 	config.LightClient = true
-	w, err = New(nil, config, nil, nil, nil, nil, nil)
+	w, err = New(nil, "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 	_, err = w.RelayPeersByTopic(config.DefaultShardPubsubTopic)
@@ -166,56 +134,71 @@ func parseNodes(rec []string) []*enode.Node {
 	}
 	return ns
 }
+*/
+type testStorenodeConfigProvider struct {
+	storenode peer.AddrInfo
+}
+
+func (t *testStorenodeConfigProvider) UseStorenodes() (bool, error) {
+	return true, nil
+}
+
+func (t *testStorenodeConfigProvider) GetPinnedStorenode() (peer.AddrInfo, error) {
+	return peer.AddrInfo{}, nil
+}
+
+func (t *testStorenodeConfigProvider) Storenodes() ([]peer.AddrInfo, error) {
+	return []peer.AddrInfo{t.storenode}, nil
+}
+
+func newTestStorenodeConfigProvider(storenode peer.AddrInfo) history.StorenodeConfigProvider {
+	return &testStorenodeConfigProvider{
+		storenode: storenode,
+	}
+}
 
 // In order to run these tests, you must run an nwaku node
 //
 // Using Docker:
 //
 //	IP_ADDRESS=$(hostname -I | awk '{print $1}');
-//	docker run \
-//	 -p 60000:60000/tcp -p 9000:9000/udp -p 8645:8645/tcp harbor.status.im/wakuorg/nwaku:v0.31.0 \
-//	 --tcp-port=60000 --discv5-discovery=true --cluster-id=16 --pubsub-topic=/waku/2/rs/16/32 --pubsub-topic=/waku/2/rs/16/64 \
-//	 --nat=extip:${IP_ADDRESS} --discv5-discovery --discv5-udp-port=9000 --rest-address=0.0.0.0 --store
+// 	docker run \
+// 	-p 61000:61000/tcp -p 8000:8000/udp -p 8646:8646/tcp harbor.status.im/wakuorg/nwaku:v0.33.0 \
+// 	--discv5-discovery=true --cluster-id=16 --log-level=DEBUG --shard=64 --tcp-port=61000 \
+// 	--nat=extip:${IP_ADDRESS} --discv5-udp-port=8000 --rest-address=0.0.0.0 --store --rest-port=8646 \
 
 func TestBasicWakuV2(t *testing.T) {
-	nwakuInfo, err := GetNwakuInfo(nil, nil)
+	extNodeRestPort := 8646
+	storeNodeInfo, err := GetNwakuInfo(nil, &extNodeRestPort)
 	require.NoError(t, err)
 
-	// Creating a fake DNS Discovery ENRTree
-	tree, url := makeTestTree("n", parseNodes([]string{nwakuInfo.EnrUri}), nil)
-	enrTreeAddress := url
-	envEnrTreeAddress := os.Getenv("ENRTREE_ADDRESS")
-	if envEnrTreeAddress != "" {
-		enrTreeAddress = envEnrTreeAddress
+	ctx := context.Background()
+
+	wakuConfig := Config{
+		UseThrottledPublish: true,
+		ClusterID:           16,
 	}
 
-	config := &Config{}
-	setDefaultConfig(config, false)
-	config.Port = 0
-	config.Resolver = mapResolver(tree.ToTXT("n"))
-	config.DiscV5BootstrapNodes = []string{enrTreeAddress}
-	config.DiscoveryLimit = 20
-	config.WakuNodes = []string{enrTreeAddress}
-	w, err := New(nil, config, nil, nil, nil, nil, nil)
+	nwakuConfig := waku.WakuConfig{
+		TcpPort:         30303,
+		Nodekey:         "11d0dcea28e86f81937a3bd1163473c7fbc0a0db54fd72914849bc47bdf78710",
+		Relay:           true,
+		LogLevel:        "DEBUG",
+		DnsDiscoveryUrl: "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im",
+		DnsDiscovery:    true,
+		Discv5Discovery: true,
+		Staticnodes:     []string{storeNodeInfo.ListenAddresses[0]},
+		ClusterID:       16,
+		Shards:          []uint16{64},
+	}
+
+	w, err := New(nil, "", &wakuConfig, &nwakuConfig, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
 
-	enr, err := w.ENR()
+	enr, err := w.node.ENR()
 	require.NoError(t, err)
 	require.NotNil(t, enr)
-
-	// DNSDiscovery
-	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
-	defer cancel()
-
-	discoveredNodes, err := dnsdisc.RetrieveNodes(ctx, enrTreeAddress, dnsdisc.WithResolver(config.Resolver))
-	require.NoError(t, err)
-
-	// Peer used for retrieving history
-	r, err := rand.Int(rand.Reader, big.NewInt(int64(len(discoveredNodes))))
-	require.NoError(t, err)
-
-	storeNode := discoveredNodes[int(r.Int64())]
 
 	options := func(b *backoff.ExponentialBackOff) {
 		b.MaxElapsedTime = 30 * time.Second
@@ -223,36 +206,58 @@ func TestBasicWakuV2(t *testing.T) {
 
 	// Sanity check, not great, but it's probably helpful
 	err = tt.RetryWithBackOff(func() error {
-		if len(w.Peers()) < 1 {
-			return errors.New("no peers discovered")
+		numConnected, err := w.node.GetNumConnectedPeers()
+		if err != nil {
+			return err
 		}
-		return nil
+		// Have to be connected to at least 3 nodes: the static node, the bootstrap node, and one discovered node
+		if numConnected > 2 {
+			return nil
+		}
+		return errors.New("no peers discovered")
 	}, options)
 	require.NoError(t, err)
 
-	// Dropping Peer
-	err = w.DropPeer(storeNode.PeerID)
+	// Get local store node address
+	storeNode, err := peer.AddrInfoFromString(storeNodeInfo.ListenAddresses[0])
 	require.NoError(t, err)
 
-	// Dialing with peerID
-	err = w.DialPeerByID(storeNode.PeerID)
+	err = w.node.DialPeer(ctx, storeNode.Addrs[0], "")
 	require.NoError(t, err)
 
-	err = tt.RetryWithBackOff(func() error {
-		if len(w.Peers()) < 1 {
-			return errors.New("no peers discovered")
-		}
-		return nil
-	}, options)
+	w.StorenodeCycle.SetStorenodeConfigProvider(newTestStorenodeConfigProvider(*storeNode))
+
+	// Check that we are indeed connected to the store node
+	connectedStoreNodes, err := w.node.GetPeerIDsByProtocol(store.StoreQueryID_v300)
+	require.NoError(t, err)
+	require.True(t, slices.Contains(connectedStoreNodes, storeNode.ID), "nwaku should be connected to the store node")
+
+	// Disconnect from the store node
+	err = w.node.DisconnectPeerByID(storeNode.ID)
 	require.NoError(t, err)
 
-	filter := &common.Filter{
-		PubsubTopic:   config.DefaultShardPubsubTopic,
+	// Check that we are indeed disconnected
+	connectedStoreNodes, err = w.node.GetPeerIDsByProtocol(store.StoreQueryID_v300)
+	require.NoError(t, err)
+	isDisconnected := !slices.Contains(connectedStoreNodes, storeNode.ID)
+	require.True(t, isDisconnected, "nwaku should be disconnected from the store node")
+
+	// Re-connect
+	err = w.DialPeerByID(storeNode.ID)
+	require.NoError(t, err)
+
+	// Check that we are connected again
+	connectedStoreNodes, err = w.node.GetPeerIDsByProtocol(store.StoreQueryID_v300)
+	require.NoError(t, err)
+	require.True(t, slices.Contains(connectedStoreNodes, storeNode.ID), "nwaku should be connected to the store node")
+
+	/* filter := &common.Filter{
+		PubsubTopic:   w.cfg.DefaultShardPubsubTopic,
 		Messages:      common.NewMemoryMessageStore(),
 		ContentTopics: common.NewTopicSetFromBytes([][]byte{{1, 2, 3, 4}}),
 	}
 
-	_, err = w.subscribe(filter)
+	_, err = w.Subscribe(filter)
 	require.NoError(t, err)
 
 	msgTimestamp := w.timestamp()
@@ -260,7 +265,7 @@ func TestBasicWakuV2(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	_, err = w.Send(config.DefaultShardPubsubTopic, &pb.WakuMessage{
+	msgID, err := w.Send(w.cfg.DefaultShardPubsubTopic, &pb.WakuMessage{
 		Payload:      []byte{1, 2, 3, 4, 5},
 		ContentTopic: contentTopic.ContentTopic(),
 		Version:      proto.Uint32(0),
@@ -268,6 +273,7 @@ func TestBasicWakuV2(t *testing.T) {
 	}, nil)
 
 	require.NoError(t, err)
+	require.NotEqual(t, msgID, "1")
 
 	time.Sleep(1 * time.Second)
 
@@ -282,16 +288,22 @@ func TestBasicWakuV2(t *testing.T) {
 		b.InitialInterval = 500 * time.Millisecond
 	}
 	err = tt.RetryWithBackOff(func() error {
-		result, err := w.node.Store().Query(
+		err := w.HistoryRetriever.Query(
 			context.Background(),
 			store.FilterCriteria{
-				ContentFilter: protocol.NewContentFilter(config.DefaultShardPubsubTopic, contentTopic.ContentTopic()),
+				ContentFilter: protocol.NewContentFilter(w.cfg.DefaultShardPubsubTopic, contentTopic.ContentTopic()),
 				TimeStart:     proto.Int64((timestampInSeconds - int64(marginInSeconds)) * int64(time.Second)),
 				TimeEnd:       proto.Int64((timestampInSeconds + int64(marginInSeconds)) * int64(time.Second)),
 			},
-			store.WithPeer(storeNode.PeerID),
+			*storeNode,
+			10,
+			nil, false,
 		)
-		if err != nil || len(result.Messages()) == 0 {
+
+		return err
+
+		// TODO-nwaku
+		/*if err != nil || envelopeCount == 0 {
 			// in case of failure extend timestamp margin up to 40secs
 			if marginInSeconds < 40 {
 				marginInSeconds += 5
@@ -299,12 +311,16 @@ func TestBasicWakuV2(t *testing.T) {
 			return errors.New("no messages received from store node")
 		}
 		return nil
+
 	}, options)
 	require.NoError(t, err)
+
+	time.Sleep(10 * time.Second) */
 
 	require.NoError(t, w.Stop())
 }
 
+/*
 type mapResolver map[string]string
 
 func (mr mapResolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
@@ -327,51 +343,190 @@ func makeTestTree(domain string, nodes []*enode.Node, links []string) (*ethdnsdi
 	}
 	return tree, url
 }
+*/
 
 func TestPeerExchange(t *testing.T) {
-	logger := tt.MustCreateTestLogger()
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	discV5NodeConfig := Config{
+		UseThrottledPublish: true,
+		ClusterID:           16,
+	}
+
+	// start node that will be discovered by PeerExchange
+	discV5NodeWakuConfig := waku.WakuConfig{
+		Relay:           true,
+		LogLevel:        "DEBUG",
+		Discv5Discovery: true,
+		ClusterID:       16,
+		Shards:          []uint16{64},
+		PeerExchange:    false,
+		Discv5UdpPort:   9001,
+		TcpPort:         60010,
+	}
+
+	discV5Node, err := New(nil, "", &discV5NodeConfig, &discV5NodeWakuConfig, logger.Named("discV5Node"), nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, discV5Node.Start())
+
+	time.Sleep(1 * time.Second)
+
+	discV5NodePeerId, err := discV5Node.node.PeerID()
+	require.NoError(t, err)
+
+	discv5NodeEnr, err := discV5Node.node.ENR()
+	require.NoError(t, err)
+
+	pxServerConfig := Config{
+		UseThrottledPublish: true,
+		ClusterID:           16,
+	}
+
+	// start node which serves as PeerExchange server
+	pxServerWakuConfig := waku.WakuConfig{
+		Relay:                true,
+		LogLevel:             "DEBUG",
+		Discv5Discovery:      true,
+		ClusterID:            16,
+		Shards:               []uint16{64},
+		PeerExchange:         true,
+		Discv5UdpPort:        9000,
+		Discv5BootstrapNodes: []string{discv5NodeEnr.String()},
+		TcpPort:              60011,
+	}
+
+	pxServerNode, err := New(nil, "", &pxServerConfig, &pxServerWakuConfig, logger.Named("pxServerNode"), nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, pxServerNode.Start())
+
+	// Adding an extra second to make sure PX cache is not empty
+	time.Sleep(2 * time.Second)
+
+	serverNodeMa, err := pxServerNode.node.ListenAddresses()
+	require.NoError(t, err)
+	require.NotNil(t, serverNodeMa)
+
+	// Sanity check, not great, but it's probably helpful
+	options := func(b *backoff.ExponentialBackOff) {
+		b.MaxElapsedTime = 30 * time.Second
+	}
+
+	// Check that pxServerNode has discV5Node in its Peer Store
+	err = tt.RetryWithBackOff(func() error {
+		peers, err := pxServerNode.node.GetPeerIDsFromPeerStore()
+
+		if err != nil {
+			return err
+		}
+
+		if slices.Contains(peers, discV5NodePeerId) {
+			return nil
+		}
+
+		return errors.New("pxServer is missing the discv5 node in its peer store")
+	}, options)
+	require.NoError(t, err)
+
+	pxClientConfig := Config{
+		UseThrottledPublish: true,
+		ClusterID:           16,
+	}
+
+	// start light node which uses PeerExchange to discover peers
+	pxClientWakuConfig := waku.WakuConfig{
+		Relay:            false,
+		LogLevel:         "DEBUG",
+		Discv5Discovery:  false,
+		ClusterID:        16,
+		Shards:           []uint16{64},
+		PeerExchange:     true,
+		Discv5UdpPort:    9002,
+		TcpPort:          60012,
+		PeerExchangeNode: serverNodeMa[0].String(),
+	}
+
+	lightNode, err := New(nil, "", &pxClientConfig, &pxClientWakuConfig, logger.Named("lightNode"), nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, lightNode.Start())
+
+	time.Sleep(1 * time.Second)
+
+	pxServerPeerId, err := pxServerNode.node.PeerID()
+	require.NoError(t, err)
+
+	// Check that the light node discovered the discV5Node and has both nodes in its peer store
+	err = tt.RetryWithBackOff(func() error {
+		peers, err := lightNode.node.GetPeerIDsFromPeerStore()
+		if err != nil {
+			return err
+		}
+
+		if slices.Contains(peers, discV5NodePeerId) && slices.Contains(peers, pxServerPeerId) {
+			return nil
+		}
+		return errors.New("lightnode is missing peers")
+	}, options)
+	require.NoError(t, err)
+
+	// Now perform the PX request manually to see if it also works
+	err = tt.RetryWithBackOff(func() error {
+		numPeersReceived, err := lightNode.node.PeerExchangeRequest(1)
+		if err != nil {
+			return err
+		}
+
+		if numPeersReceived == 1 {
+			return nil
+		}
+		return errors.New("Peer Exchange is not returning peers")
+	}, options)
+	require.NoError(t, err)
+
+	// Stop nodes
+	require.NoError(t, lightNode.Stop())
+	require.NoError(t, pxServerNode.Stop())
+	require.NoError(t, discV5Node.Stop())
+
+	/* logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
 	// start node which serve as PeerExchange server
 	config := &Config{}
 	config.ClusterID = 16
 	config.EnableDiscV5 = true
 	config.EnablePeerExchangeServer = true
 	config.EnablePeerExchangeClient = false
-	pxServerNode, err := New(nil, config, logger.Named("pxServerNode"), nil, nil, nil, nil)
+	pxServerNode, err := New(nil, "", config, logger.Named("pxServerNode"), nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, pxServerNode.Start())
-
 	time.Sleep(1 * time.Second)
-
 	// start node that will be discovered by PeerExchange
 	config = &Config{}
 	config.ClusterID = 16
 	config.EnableDiscV5 = true
 	config.EnablePeerExchangeServer = false
 	config.EnablePeerExchangeClient = false
-	config.DiscV5BootstrapNodes = []string{pxServerNode.node.ENR().String()}
-	discV5Node, err := New(nil, config, logger.Named("discV5Node"), nil, nil, nil, nil)
+	enr, err := pxServerNode.ENR()
+	require.NoError(t, err)
+	config.DiscV5BootstrapNodes = []string{enr.String()}
+	discV5Node, err := New(nil, "", config, logger.Named("discV5Node"), nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, discV5Node.Start())
-
 	time.Sleep(1 * time.Second)
-
 	// start light node which use PeerExchange to discover peers
-	enrNodes := []*enode.Node{pxServerNode.node.ENR()}
+	enrNodes := []*enode.Node{enr}
 	tree, url := makeTestTree("n", enrNodes, nil)
 	resolver := mapResolver(tree.ToTXT("n"))
-
 	config = &Config{}
 	config.ClusterID = 16
 	config.EnablePeerExchangeServer = false
 	config.EnablePeerExchangeClient = true
 	config.LightClient = true
 	config.Resolver = resolver
-
 	config.WakuNodes = []string{url}
-	lightNode, err := New(nil, config, logger.Named("lightNode"), nil, nil, nil, nil)
+	lightNode, err := New(nil, "", config, logger.Named("lightNode"), nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, lightNode.Start())
-
 	// Sanity check, not great, but it's probably helpful
 	options := func(b *backoff.ExponentialBackOff) {
 		b.MaxElapsedTime = 30 * time.Second
@@ -381,26 +536,126 @@ func TestPeerExchange(t *testing.T) {
 		// in light client mode,the peer will be closed via `w.node.Host().Network().ClosePeer(peerInfo.ID)`
 		// after invoking identifyAndConnect, instead, we should check the peerStore, peers from peerStore
 		// won't get deleted especially if they are statically added.
-		if len(lightNode.node.Host().Peerstore().Peers()) == 2 {
+		numConnected, err := lightNode.GetNumConnectedPeers()
+		if err != nil {
+			return err
+		}
+		if numConnected == 2 {
 			return nil
 		}
 		return errors.New("no peers discovered")
 	}, options)
 	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(context.Background())
+	_, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	require.NoError(t, discV5Node.node.PeerExchange().Request(ctx, 1))
-	require.Error(t, discV5Node.node.PeerExchange().Request(ctx, 1)) //should fail due to rate limit
-
+	_, err = discV5Node.WakuPeerExchangeRequest(1)
+	require.NoError(t, err)
+	_, err = discV5Node.WakuPeerExchangeRequest(1)
+	require.Error(t, err) //should fail due to rate limit
 	require.NoError(t, lightNode.Stop())
 	require.NoError(t, pxServerNode.Stop())
-	require.NoError(t, discV5Node.Stop())
+	require.NoError(t, discV5Node.Stop()) */
 }
 
+func TestDnsDiscover(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	nodeConfig := Config{
+		UseThrottledPublish: true,
+		ClusterID:           16,
+		Nameserver:          "8.8.8.8",
+	}
+	nodeWakuConfig := waku.WakuConfig{
+		Relay:         true,
+		LogLevel:      "DEBUG",
+		ClusterID:     16,
+		Shards:        []uint16{64},
+		Discv5UdpPort: 9040,
+		TcpPort:       60040,
+	}
+	node, err := New(nil, "", &nodeConfig, &nodeWakuConfig, logger.Named("node"), nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, node.Start())
+	time.Sleep(1 * time.Second)
+	sampleEnrTree := "enrtree://AMOJVZX4V6EXP7NTJPMAYJYST2QP6AJXYW76IU6VGJS7UVSNDYZG4@boot.prod.status.nodes.status.im"
+
+	ctx, cancel := context.WithTimeout(context.TODO(), requestTimeout)
+	defer cancel()
+	res, err := node.node.DnsDiscovery(ctx, sampleEnrTree, nodeConfig.Nameserver)
+	require.NoError(t, err)
+	require.True(t, len(res) > 1, "multiple nodes should be returned from the DNS Discovery query")
+	// Stop nodes
+	require.NoError(t, node.Stop())
+}
+
+func TestDial(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	dialerNodeConfig := Config{
+		UseThrottledPublish: true,
+		ClusterID:           16,
+	}
+	// start node that will initiate the dial
+	dialerNodeWakuConfig := waku.WakuConfig{
+		Relay:           true,
+		LogLevel:        "DEBUG",
+		Discv5Discovery: false,
+		ClusterID:       16,
+		Shards:          []uint16{64},
+		Discv5UdpPort:   9020,
+		TcpPort:         60020,
+	}
+	dialerNode, err := New(nil, "", &dialerNodeConfig, &dialerNodeWakuConfig, logger.Named("dialerNode"), nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, dialerNode.Start())
+	time.Sleep(1 * time.Second)
+	receiverNodeConfig := Config{
+		UseThrottledPublish: true,
+		ClusterID:           16,
+	}
+	// start node that will receive the dial
+	receiverNodeWakuConfig := waku.WakuConfig{
+		Relay:           true,
+		LogLevel:        "DEBUG",
+		Discv5Discovery: false,
+		ClusterID:       16,
+		Shards:          []uint16{64},
+		Discv5UdpPort:   9021,
+		TcpPort:         60021,
+	}
+	receiverNode, err := New(nil, "", &receiverNodeConfig, &receiverNodeWakuConfig, logger.Named("receiverNode"), nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, receiverNode.Start())
+	time.Sleep(1 * time.Second)
+	receiverMultiaddr, err := receiverNode.node.ListenAddresses()
+	require.NoError(t, err)
+	require.NotNil(t, receiverMultiaddr)
+	// Check that both nodes start with no connected peers
+	dialerPeerCount := dialerNode.PeerCount()
+	require.NoError(t, err)
+	require.True(t, dialerPeerCount == 0, "Dialer node should have no connected peers")
+	receiverPeerCount := receiverNode.PeerCount()
+	require.NoError(t, err)
+	require.True(t, receiverPeerCount == 0, "Receiver node should have no connected peers")
+	// Dial
+	err = dialerNode.DialPeer(receiverMultiaddr[0])
+	require.NoError(t, err)
+	time.Sleep(1 * time.Second)
+	// Check that both nodes now have one connected peer
+	dialerPeerCount = dialerNode.PeerCount()
+	require.NoError(t, err)
+	require.True(t, dialerPeerCount == 1, "Dialer node should have 1 peer")
+	receiverPeerCount = receiverNode.PeerCount()
+	require.NoError(t, err)
+	require.True(t, receiverPeerCount == 1, "Receiver node should have 1 peer")
+	// Stop nodes
+	require.NoError(t, dialerNode.Stop())
+	require.NoError(t, receiverNode.Stop())
+}
+
+/*
 func TestWakuV2Filter(t *testing.T) {
 	t.Skip("flaky test")
-
 	enrTreeAddress := testBootENRBootstrap
 	envEnrTreeAddress := os.Getenv("ENRTREE_ADDRESS")
 	if envEnrTreeAddress != "" {
@@ -411,22 +666,19 @@ func TestWakuV2Filter(t *testing.T) {
 	config.EnablePeerExchangeClient = false
 	config.Port = 0
 	config.MinPeersForFilter = 2
-
 	config.DiscV5BootstrapNodes = []string{enrTreeAddress}
 	config.DiscoveryLimit = 20
 	config.WakuNodes = []string{enrTreeAddress}
-	w, err := New(nil, config, nil, nil, nil, nil, nil)
+	w, err := New(nil, "", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w.Start())
-
 	options := func(b *backoff.ExponentialBackOff) {
 		b.MaxElapsedTime = 10 * time.Second
 	}
 	time.Sleep(10 * time.Second) //TODO: Check if we can remove this sleep.
-
 	// Sanity check, not great, but it's probably helpful
 	err = tt.RetryWithBackOff(func() error {
-		peers, err := w.node.PeerManager().FilterPeersByProto(nil, nil, filter.FilterSubscribeID_v20beta1)
+		peers, err := w.GetPeerIdsByProtocol(string(filter.FilterSubscribeID_v20beta1))
 		if err != nil {
 			return err
 		}
@@ -445,13 +697,10 @@ func TestWakuV2Filter(t *testing.T) {
 		PubsubTopic:   testPubsubTopic,
 		ContentTopics: common.NewTopicSetFromBytes([][]byte{contentTopicBytes}),
 	}
-
-	fID, err := w.subscribe(filter)
+	fID, err := w.Subscribe(filter)
 	require.NoError(t, err)
-
 	msgTimestamp := w.timestamp()
 	contentTopic := maps.Keys(filter.ContentTopics)[0]
-
 	_, err = w.Send(testPubsubTopic, &pb.WakuMessage{
 		Payload:      []byte{1, 2, 3, 4, 5},
 		ContentTopic: contentTopic.ContentTopic(),
@@ -460,24 +709,18 @@ func TestWakuV2Filter(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	time.Sleep(5 * time.Second)
-
 	// Ensure there is at least 1 active filter subscription
-	subscriptions := w.node.FilterLightnode().Subscriptions()
+	subscriptions := w.FilterLightnode().Subscriptions()
 	require.Greater(t, len(subscriptions), 0)
-
 	messages := filter.Retrieve()
 	require.Len(t, messages, 1)
-
 	// Mock peers going down
-	_, err = w.node.FilterLightnode().UnsubscribeWithSubscription(w.ctx, subscriptions[0])
+	_, err = w.FilterLightnode().UnsubscribeWithSubscription(w.ctx, subscriptions[0])
 	require.NoError(t, err)
-
 	time.Sleep(10 * time.Second)
-
 	// Ensure there is at least 1 active filter subscription
-	subscriptions = w.node.FilterLightnode().Subscriptions()
+	subscriptions = w.FilterLightnode().Subscriptions()
 	require.Greater(t, len(subscriptions), 0)
-
 	// Ensure that messages are retrieved with a fresh sub
 	_, err = w.Send(testPubsubTopic, &pb.WakuMessage{
 		Payload:      []byte{1, 2, 3, 4, 5, 6},
@@ -487,17 +730,14 @@ func TestWakuV2Filter(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	time.Sleep(10 * time.Second)
-
 	messages = filter.Retrieve()
 	require.Len(t, messages, 1)
 	err = w.Unsubscribe(context.Background(), fID)
 	require.NoError(t, err)
 	require.NoError(t, w.Stop())
 }
-
 func TestWakuV2Store(t *testing.T) {
 	t.Skip("deprecated. Storenode must use nwaku")
-
 	// Configuration for the first Waku node
 	config1 := &Config{
 		Port:                             0,
@@ -510,9 +750,8 @@ func TestWakuV2Store(t *testing.T) {
 		EnableMissingMessageVerification: true,
 	}
 	w1PeersCh := make(chan peer.IDSlice, 100) // buffered not to block on the send side
-
 	// Start the first Waku node
-	w1, err := New(nil, config1, nil, nil, nil, nil, func(cs wakutypes.ConnStatus) {
+	w1, err := New(nil, "", config1, nil, nil, nil, nil, func(cs types.ConnStatus) {
 		w1PeersCh <- maps.Keys(cs.Peers)
 	})
 	require.NoError(t, err)
@@ -521,7 +760,6 @@ func TestWakuV2Store(t *testing.T) {
 		require.NoError(t, w1.Stop())
 		close(w1PeersCh)
 	}()
-
 	// Configuration for the second Waku node
 	sql2, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
 	require.NoError(t, err)
@@ -534,38 +772,30 @@ func TestWakuV2Store(t *testing.T) {
 		StoreCapacity:  100,
 		StoreSeconds:   3600,
 	}
-
 	// Start the second Waku node
-	w2, err := New(nil, config2, nil, sql2, nil, nil, nil)
+	w2, err := New(nil, "", config2, nil, sql2, nil, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, w2.Start())
 	w2EnvelopeCh := make(chan common.EnvelopeEvent, 100)
-	w2.subscribeEnvelopeEvents(w2EnvelopeCh)
+	w2.SubscribeEnvelopeEvents(w2EnvelopeCh)
 	defer func() {
 		require.NoError(t, w2.Stop())
 		close(w2EnvelopeCh)
 	}()
-
 	// Connect the two nodes directly
 	peer2Addr, err := w2.ListenAddresses()
 	require.NoError(t, err)
-	err = w1.node.DialPeer(context.Background(), peer2Addr[0].String())
+	err = w1.DialPeer(peer2Addr[0])
 	require.NoError(t, err)
-
-	waitForPeerConnection(t, w2.node.Host().ID(), w1PeersCh)
-
 	// Create a filter for the second node to catch messages
 	filter := &common.Filter{
 		Messages:      common.NewMemoryMessageStore(),
 		PubsubTopic:   config2.DefaultShardPubsubTopic,
 		ContentTopics: common.NewTopicSetFromBytes([][]byte{{1, 2, 3, 4}}),
 	}
-
-	_, err = w2.subscribe(filter)
+	_, err = w2.Subscribe(filter)
 	require.NoError(t, err)
-
 	time.Sleep(2 * time.Second)
-
 	// Send a message from the first node
 	msgTimestamp := w1.CurrentTime().UnixNano()
 	contentTopic := maps.Keys(filter.ContentTopics)[0]
@@ -576,33 +806,31 @@ func TestWakuV2Store(t *testing.T) {
 		Timestamp:    &msgTimestamp,
 	}, nil)
 	require.NoError(t, err)
-
 	waitForEnvelope(t, contentTopic.ContentTopic(), w2EnvelopeCh)
-
 	// Retrieve the message from the second node's filter
 	messages := filter.Retrieve()
 	require.Len(t, messages, 1)
-
 	timestampInSeconds := msgTimestamp / int64(time.Second)
 	marginInSeconds := 5
 	// Query the second node's store for the message
-	result, err := w1.node.Store().Query(
+	_, envelopeCount, err := w1.Query(
 		context.Background(),
+		w2.Host().ID(),
 		store.FilterCriteria{
 			TimeStart:     proto.Int64((timestampInSeconds - int64(marginInSeconds)) * int64(time.Second)),
 			TimeEnd:       proto.Int64((timestampInSeconds + int64(marginInSeconds)) * int64(time.Second)),
 			ContentFilter: protocol.NewContentFilter(config1.DefaultShardPubsubTopic, contentTopic.ContentTopic()),
 		},
-		store.WithPeer(w2.node.Host().ID()),
+		nil,
+		nil,
+		false,
 	)
 	require.NoError(t, err)
-	require.True(t, len(result.Messages()) > 0, "no messages received from store node")
+	require.True(t, envelopeCount > 0, "no messages received from store node")
 }
-
 func waitForPeerConnection(t *testing.T, peerID peer.ID, peerCh chan peer.IDSlice) {
 	waitForPeerConnectionWithTimeout(t, peerID, peerCh, 3*time.Second)
 }
-
 func waitForPeerConnectionWithTimeout(t *testing.T, peerID peer.ID, peerCh chan peer.IDSlice, timeout time.Duration) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -620,7 +848,6 @@ func waitForPeerConnectionWithTimeout(t *testing.T, peerID peer.ID, peerCh chan 
 		}
 	}
 }
-
 func waitForEnvelope(t *testing.T, contentTopic string, envCh chan common.EnvelopeEvent) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -636,17 +863,13 @@ func waitForEnvelope(t *testing.T, contentTopic string, envCh chan common.Envelo
 		}
 	}
 }
-
 func TestOnlineChecker(t *testing.T) {
-	w, err := New(nil, nil, nil, nil, nil, nil, nil)
+	w, err := New(nil, "shards.staging", nil, nil, nil, nil, nil, nil)
 	require.NoError(t, w.Start())
-
 	require.NoError(t, err)
 	require.False(t, w.onlineChecker.IsOnline())
-
 	w.ConnectionChanged(connection.State{Offline: false})
 	require.True(t, w.onlineChecker.IsOnline())
-
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -654,38 +877,29 @@ func TestOnlineChecker(t *testing.T) {
 		<-w.goingOnline
 		require.True(t, true)
 	}()
-
 	time.Sleep(100 * time.Millisecond)
-
 	w.ConnectionChanged(connection.State{Offline: true})
 	require.False(t, w.onlineChecker.IsOnline())
-
 	// Test lightnode online checker
 	config := &Config{}
 	config.ClusterID = 16
 	config.LightClient = true
-	lightNode, err := New(nil, config, nil, nil, nil, nil, nil)
+	lightNode, err := New(nil, "shards.staging", config, nil, nil, nil, nil, nil)
 	require.NoError(t, err)
-
 	err = lightNode.Start()
 	require.NoError(t, err)
-
 	require.False(t, lightNode.onlineChecker.IsOnline())
 	f := &common.Filter{}
 	lightNode.filterManager.SubscribeFilter("test", protocol.NewContentFilter(f.PubsubTopic, f.ContentTopics.ContentTopics()...))
-
 }
-
 func TestLightpushRateLimit(t *testing.T) {
-	t.Skip("flaky as it is hard to simulate rate-limits as execution time varies in environments")
-	logger := tt.MustCreateTestLogger()
-
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
 	config0 := &Config{}
 	setDefaultConfig(config0, false)
 	w0PeersCh := make(chan peer.IDSlice, 5) // buffered not to block on the send side
-
 	// Start the relayu node
-	w0, err := New(nil, config0, logger.Named("relayNode"), nil, nil, nil, func(cs wakutypes.ConnStatus) {
+	w0, err := New(nil, "", config0, logger.Named("relayNode"), nil, nil, nil, func(cs types.ConnStatus) {
 		w0PeersCh <- maps.Keys(cs.Peers)
 	})
 	require.NoError(t, err)
@@ -694,23 +908,19 @@ func TestLightpushRateLimit(t *testing.T) {
 		require.NoError(t, w0.Stop())
 		close(w0PeersCh)
 	}()
-
 	contentTopics := common.NewTopicSetFromBytes([][]byte{{1, 2, 3, 4}})
 	filter := &common.Filter{
 		PubsubTopic:   config0.DefaultShardPubsubTopic,
 		Messages:      common.NewMemoryMessageStore(),
 		ContentTopics: contentTopics,
 	}
-
-	_, err = w0.subscribe(filter)
+	_, err = w0.Subscribe(filter)
 	require.NoError(t, err)
-
 	config1 := &Config{}
 	setDefaultConfig(config1, false)
 	w1PeersCh := make(chan peer.IDSlice, 5) // buffered not to block on the send side
-
 	// Start the full node
-	w1, err := New(nil, config1, logger.Named("fullNode"), nil, nil, nil, func(cs wakutypes.ConnStatus) {
+	w1, err := New(nil, "", config1, logger.Named("fullNode"), nil, nil, nil, func(cs types.ConnStatus) {
 		w1PeersCh <- maps.Keys(cs.Peers)
 	})
 	require.NoError(t, err)
@@ -719,16 +929,11 @@ func TestLightpushRateLimit(t *testing.T) {
 		require.NoError(t, w1.Stop())
 		close(w1PeersCh)
 	}()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	//Connect the relay peer and full node
-	peerAddr, err := w0.ListenAddresses()
-
+	err = w1.DialPeer(ctx, w0.ListenAddresses()[0].String())
 	require.NoError(t, err)
-	err = w1.node.DialPeer(ctx, peerAddr[0].String())
-	require.NoError(t, err)
-
 	err = tt.RetryWithBackOff(func() error {
 		if len(w1.Peers()) == 0 {
 			return errors.New("no peers discovered")
@@ -736,13 +941,11 @@ func TestLightpushRateLimit(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-
 	config2 := &Config{}
 	setDefaultConfig(config2, true)
 	w2PeersCh := make(chan peer.IDSlice, 5) // buffered not to block on the send side
-
 	// Start the light node
-	w2, err := New(nil, config2, logger.Named("lightNode"), nil, nil, nil, func(cs wakutypes.ConnStatus) {
+	w2, err := New(nil, "", config2, logger.Named("lightNode"), nil, nil, nil, func(cs types.ConnStatus) {
 		w2PeersCh <- maps.Keys(cs.Peers)
 	})
 	require.NoError(t, err)
@@ -751,19 +954,12 @@ func TestLightpushRateLimit(t *testing.T) {
 		require.NoError(t, w2.Stop())
 		close(w2PeersCh)
 	}()
-
 	//Use this instead of DialPeer to make sure the peer is added to PeerStore and can be selected for Lighpush
-	addresses, err := w1.ListenAddresses()
-	require.NoError(t, err)
-	peerID := w1.PeerID()
-	w2.node.AddDiscoveredPeer(peerID, addresses, wps.Static, w1.cfg.DefaultShardedPubsubTopics, w1.node.ENR(), true)
-
-	waitForPeerConnectionWithTimeout(t, w2.node.Host().ID(), w1PeersCh, 5*time.Second)
-
+	w2.AddDiscoveredPeer(w1.PeerID(), w1.ListenAddresses(), wps.Static, w1.cfg.DefaultShardedPubsubTopics, w1.node.ENR(), true)
+	waitForPeerConnectionWithTimeout(t, w2.Host().ID(), w1PeersCh, 5*time.Second)
 	event := make(chan common.EnvelopeEvent, 10)
-	w2.subscribeEnvelopeEvents(event)
-
-	for i := range [15]int{} {
+	w2.SubscribeEnvelopeEvents(event)
+	for i := range [4]int{} {
 		msgTimestamp := w2.timestamp()
 		_, err := w2.Send(config2.DefaultShardPubsubTopic, &pb.WakuMessage{
 			Payload:      []byte{1, 2, 3, 4, 5, 6, byte(i)},
@@ -771,36 +967,30 @@ func TestLightpushRateLimit(t *testing.T) {
 			Version:      proto.Uint32(0),
 			Timestamp:    &msgTimestamp,
 		}, nil)
-
 		require.NoError(t, err)
-
-		time.Sleep(20 * time.Millisecond)
-
+		time.Sleep(550 * time.Millisecond)
 	}
-
 	messages := filter.Retrieve()
-	require.Len(t, messages, 10)
-
+	require.Len(t, messages, 2)
 }
-
 func TestTelemetryFormat(t *testing.T) {
-	tc := NewBandwidthTelemetryClient(tt.MustCreateTestLogger(), "#")
-
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	tc := NewBandwidthTelemetryClient(logger, "#")
 	s := metrics.Stats{
 		TotalIn:  10,
 		TotalOut: 20,
 		RateIn:   30,
 		RateOut:  40,
 	}
-
 	m := make(map[libp2pprotocol.ID]metrics.Stats)
 	m[relay.WakuRelayID_v200] = s
 	m[filter.FilterPushID_v20beta1] = s
 	m[filter.FilterSubscribeID_v20beta1] = s
 	m[legacy_store.StoreID_v20beta4] = s
 	m[lightpush.LightPushID_v20beta1] = s
-
 	requestBody := tc.getTelemetryRequestBody(m)
-	_, err := json.Marshal(requestBody)
+	_, err = json.Marshal(requestBody)
 	require.NoError(t, err)
 }
+*/

--- a/wakuv2/nwaku_utils.go
+++ b/wakuv2/nwaku_utils.go
@@ -1,0 +1,160 @@
+//go:build use_nwaku
+// +build use_nwaku
+
+package wakuv2
+
+// TODO-nwaku remove this entire file once go-waku is removed from status-go
+import (
+	bindings "github.com/waku-org/waku-go-bindings/waku/common"
+
+	"github.com/status-im/status-go/wakuv2/common"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
+)
+
+type envelopeImpl struct {
+	msg   *pb.WakuMessage
+	topic string
+	hash  pb.MessageHash
+}
+
+func (e *envelopeImpl) Message() *pb.WakuMessage {
+	return e.msg
+}
+
+func (e *envelopeImpl) PubsubTopic() string {
+	return e.topic
+}
+
+func (e *envelopeImpl) Hash() pb.MessageHash {
+	return e.hash
+}
+
+func HexToPbHash(hexHash bindings.MessageHash) (pb.MessageHash, error) {
+	bytesHash, err := hexHash.Bytes()
+	if err != nil {
+		return pb.MessageHash{}, err
+	}
+
+	pbHash := pb.ToMessageHash(bytesHash)
+	return pbHash, nil
+}
+
+func PbToHexHash(pbHash pb.MessageHash) (bindings.MessageHash, error) {
+	return bindings.ToMessageHash(pbHash.String())
+}
+
+func PbToBindingsStoreRequest(pbStoreRequest *storepb.StoreQueryRequest) (*bindings.StoreQueryRequest, error) {
+
+	bindingsQueryRequest := bindings.StoreQueryRequest{
+		RequestId:         pbStoreRequest.RequestId,
+		IncludeData:       pbStoreRequest.IncludeData,
+		PubsubTopic:       *pbStoreRequest.PubsubTopic,
+		ContentTopics:     &pbStoreRequest.ContentTopics,
+		TimeStart:         pbStoreRequest.TimeStart,
+		MessageHashes:     nil,
+		TimeEnd:           pbStoreRequest.TimeEnd,
+		PaginationCursor:  nil,
+		PaginationForward: pbStoreRequest.PaginationForward,
+		PaginationLimit:   pbStoreRequest.PaginationLimit,
+	}
+
+	if len(pbStoreRequest.MessageHashes) > 0 {
+		var messageHashes []bindings.MessageHash
+		for _, hash := range pbStoreRequest.MessageHashes {
+			hexHash, err := PbToHexHash(pb.ToMessageHash(hash))
+			if err != nil {
+				return nil, err
+			}
+			messageHashes = append(messageHashes, hexHash)
+		}
+
+		bindingsQueryRequest.MessageHashes = &messageHashes
+	}
+
+	if len(pbStoreRequest.PaginationCursor) > 0 {
+		paginationCursor, err := PbToHexHash(pb.ToMessageHash(pbStoreRequest.PaginationCursor))
+		if err != nil {
+			return nil, err
+		}
+		bindingsQueryRequest.PaginationCursor = &paginationCursor
+	}
+
+	return &bindingsQueryRequest, nil
+}
+
+func BindingsToPbStoreResponse(bindingsStoreResponse *bindings.StoreQueryResponse) (*storepb.StoreQueryResponse, error) {
+
+	paginationCursor, err := bindingsStoreResponse.PaginationCursor.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	pbQueryResponse := storepb.StoreQueryResponse{
+		RequestId:        bindingsStoreResponse.RequestId,
+		StatusCode:       bindingsStoreResponse.StatusCode,
+		StatusDesc:       &bindingsStoreResponse.StatusDesc,
+		PaginationCursor: paginationCursor,
+	}
+
+	if bindingsStoreResponse.Messages == nil {
+		return &pbQueryResponse, nil
+	}
+
+	var messages []*storepb.WakuMessageKeyValue
+
+	for _, message := range *bindingsStoreResponse.Messages {
+
+		msgHash, err := message.MessageHash.Bytes()
+
+		if err != nil {
+			return nil, err
+		}
+
+		var pbMessage storepb.WakuMessageKeyValue
+		if message.WakuMessage == nil {
+			pbMessage = storepb.WakuMessageKeyValue{
+				MessageHash: msgHash,
+				PubsubTopic: &message.PubsubTopic,
+				Message:     nil,
+			}
+		} else {
+			wakuMessage := pb.WakuMessage{
+				Payload:        message.WakuMessage.Payload,
+				ContentTopic:   message.WakuMessage.ContentTopic,
+				Version:        message.WakuMessage.Version,
+				Timestamp:      message.WakuMessage.Timestamp,
+				Meta:           message.WakuMessage.Meta,
+				Ephemeral:      message.WakuMessage.Ephemeral,
+				RateLimitProof: message.WakuMessage.RateLimitProof,
+			}
+
+			pbMessage = storepb.WakuMessageKeyValue{
+				MessageHash: msgHash,
+				PubsubTopic: &message.PubsubTopic,
+				Message:     &wakuMessage,
+			}
+
+		}
+
+		messages = append(messages, &pbMessage)
+	}
+
+	pbQueryResponse.Messages = messages
+
+	return &pbQueryResponse, nil
+
+}
+
+func BindingsToCommonEnvelope(bindingsEnv bindings.Envelope) (common.Envelope, error) {
+
+	hash, err := HexToPbHash(bindingsEnv.Hash())
+
+	if err != nil {
+		return nil, err
+	}
+
+	env := envelopeImpl{topic: bindingsEnv.PubsubTopic(), msg: bindingsEnv.Message(), hash: hash}
+
+	return &env, nil
+}

--- a/wakuv2/nwaku_utils.go
+++ b/wakuv2/nwaku_utils.go
@@ -12,24 +12,6 @@ import (
 	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
 )
 
-type envelopeImpl struct {
-	msg   *pb.WakuMessage
-	topic string
-	hash  pb.MessageHash
-}
-
-func (e *envelopeImpl) Message() *pb.WakuMessage {
-	return e.msg
-}
-
-func (e *envelopeImpl) PubsubTopic() string {
-	return e.topic
-}
-
-func (e *envelopeImpl) Hash() pb.MessageHash {
-	return e.hash
-}
-
 func HexToPbHash(hexHash bindings.MessageHash) (pb.MessageHash, error) {
 	bytesHash, err := hexHash.Bytes()
 	if err != nil {
@@ -154,7 +136,7 @@ func BindingsToCommonEnvelope(bindingsEnv bindings.Envelope) (common.Envelope, e
 		return nil, err
 	}
 
-	env := envelopeImpl{topic: bindingsEnv.PubsubTopic(), msg: bindingsEnv.Message(), hash: hash}
+	env := common.NewWakuEnvelope(bindingsEnv.Message(), bindingsEnv.PubsubTopic(), hash)
 
-	return &env, nil
+	return env, nil
 }

--- a/wakuv2/pinger.go
+++ b/wakuv2/pinger.go
@@ -1,0 +1,29 @@
+//go:build use_nwaku
+// +build use_nwaku
+
+package wakuv2
+
+import (
+	"context"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/waku-org/waku-go-bindings/waku"
+
+	commonapi "github.com/waku-org/go-waku/waku/v2/api/common"
+)
+
+type pinger struct {
+	node *waku.WakuNode
+}
+
+func newPinger(node *waku.WakuNode) commonapi.Pinger {
+	return &pinger{
+		node: node,
+	}
+}
+
+func (p *pinger) PingPeer(ctx context.Context, peerInfo peer.AddrInfo) (time.Duration, error) {
+	return p.node.PingPeer(ctx, peerInfo)
+}

--- a/wakuv2/publisher.go
+++ b/wakuv2/publisher.go
@@ -1,0 +1,46 @@
+//go:build use_nwaku
+// +build use_nwaku
+
+package wakuv2
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/waku-org/waku-go-bindings/waku"
+
+	"github.com/waku-org/go-waku/waku/v2/api/publish"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+)
+
+type nwakuPublisher struct {
+	node *waku.WakuNode
+}
+
+func newPublisher(node *waku.WakuNode) publish.Publisher {
+	return &nwakuPublisher{
+		node: node,
+	}
+}
+
+func (p *nwakuPublisher) RelayListPeers(pubsubTopic string) ([]peer.ID, error) {
+	// TODO-nwaku
+	return nil, nil
+}
+
+func (p *nwakuPublisher) RelayPublish(ctx context.Context, message *pb.WakuMessage, pubsubTopic string) (pb.MessageHash, error) {
+	// TODO-nwaku improve this workaround to use the pb definition of the hash
+	hexHash, err := p.node.RelayPublish(ctx, message, pubsubTopic)
+	if err != nil {
+		return pb.MessageHash{}, err
+	}
+
+	return HexToPbHash(hexHash)
+}
+
+// LightpushPublish publishes a message via WakuLightPush
+func (p *nwakuPublisher) LightpushPublish(ctx context.Context, message *pb.WakuMessage, pubsubTopic string, maxPeers int) (pb.MessageHash, error) {
+	// TODO-nwaku
+	return pb.MessageHash{}, nil
+}

--- a/wakuv2/result.go
+++ b/wakuv2/result.go
@@ -1,0 +1,88 @@
+//go:build use_nwaku
+// +build use_nwaku
+
+package wakuv2
+
+import (
+	"context"
+	"encoding/hex"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/waku-org/waku-go-bindings/waku"
+
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	"github.com/waku-org/go-waku/waku/v2/protocol/store"
+	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
+)
+
+type storeResultImpl struct {
+	done bool
+
+	node          *waku.WakuNode
+	storeRequest  *storepb.StoreQueryRequest
+	storeResponse *storepb.StoreQueryResponse
+	peerInfo      peer.AddrInfo
+}
+
+func newStoreResultImpl(node *waku.WakuNode, peerInfo peer.AddrInfo, storeRequest *storepb.StoreQueryRequest, storeResponse *storepb.StoreQueryResponse) *storeResultImpl {
+	return &storeResultImpl{
+		node:          node,
+		storeRequest:  storeRequest,
+		storeResponse: storeResponse,
+		peerInfo:      peerInfo,
+	}
+}
+
+func (r *storeResultImpl) Cursor() []byte {
+	return r.storeResponse.GetPaginationCursor()
+}
+
+func (r *storeResultImpl) IsComplete() bool {
+	return r.done
+}
+
+func (r *storeResultImpl) PeerID() peer.ID {
+	return r.peerInfo.ID
+}
+
+func (r *storeResultImpl) Query() *storepb.StoreQueryRequest {
+	return r.storeRequest
+}
+
+func (r *storeResultImpl) Response() *storepb.StoreQueryResponse {
+	return r.storeResponse
+}
+
+func (r *storeResultImpl) Next(ctx context.Context, opts ...store.RequestOption) error {
+	// TODO: opts is being ignored. Will require some changes in go-waku. For now using this
+	// is not necessary
+
+	if r.storeResponse.GetPaginationCursor() == nil {
+		r.done = true
+		return nil
+	}
+
+	r.storeRequest.RequestId = hex.EncodeToString(protocol.GenerateRequestID())
+	r.storeRequest.PaginationCursor = r.storeResponse.PaginationCursor
+
+	bindingsStoreRequest, err := PbToBindingsStoreRequest(r.storeRequest)
+
+	if err != nil {
+		return err
+	}
+
+	bindingsStoreResponse, err := r.node.StoreQuery(ctx, bindingsStoreRequest, r.peerInfo)
+	if err != nil {
+		return err
+	}
+
+	storeResponse := storepb.StoreQueryResponse{RequestId: bindingsStoreResponse.RequestId}
+
+	r.storeResponse = &storeResponse
+	return nil
+}
+
+func (r *storeResultImpl) Messages() []*storepb.WakuMessageKeyValue {
+	return r.storeResponse.GetMessages()
+}

--- a/wakuv2/store_message_verifier.go
+++ b/wakuv2/store_message_verifier.go
@@ -1,0 +1,71 @@
+//go:build use_nwaku
+// +build use_nwaku
+
+package wakuv2
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/waku-org/waku-go-bindings/waku"
+	"github.com/waku-org/waku-go-bindings/waku/common"
+
+	"github.com/waku-org/go-waku/waku/v2/api/publish"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+)
+
+type storenodeMessageVerifier struct {
+	node *waku.WakuNode
+}
+
+func newStorenodeMessageVerifier(node *waku.WakuNode) publish.StorenodeMessageVerifier {
+	return &storenodeMessageVerifier{
+		node: node,
+	}
+}
+
+func (d *storenodeMessageVerifier) MessageHashesExist(ctx context.Context, requestID []byte, peerInfo peer.AddrInfo, pageSize uint64, messageHashes []pb.MessageHash) ([]pb.MessageHash, error) {
+	requestIDStr := hex.EncodeToString(requestID)
+
+	hexHashes := make([]common.MessageHash, len(messageHashes))
+
+	storeRequest := &common.StoreQueryRequest{
+		RequestId:         requestIDStr,
+		MessageHashes:     &hexHashes,
+		IncludeData:       false,
+		PaginationCursor:  nil,
+		PaginationForward: false,
+		PaginationLimit:   proto.Uint64(pageSize),
+	}
+
+	for i, mhash := range messageHashes {
+		(*storeRequest.MessageHashes)[i] = common.MessageHash(mhash.String())
+	}
+
+	bindingsResponse, err := d.node.StoreQuery(ctx, storeRequest, peerInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := BindingsToPbStoreResponse(bindingsResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if response.GetStatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("could not query storenode: %s %d %s", requestIDStr, response.GetStatusCode(), response.GetStatusDesc())
+	}
+
+	result := make([]pb.MessageHash, len(response.Messages))
+	for i, msg := range response.Messages {
+		result[i] = pb.ToMessageHash(msg.GetMessageHash())
+	}
+
+	return result, nil
+}

--- a/wakuv2/storenode_requestor.go
+++ b/wakuv2/storenode_requestor.go
@@ -1,0 +1,105 @@
+//go:build use_nwaku
+// +build use_nwaku
+
+package wakuv2
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/zap"
+
+	"github.com/waku-org/waku-go-bindings/waku"
+
+	commonapi "github.com/waku-org/go-waku/waku/v2/api/common"
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+	storepb "github.com/waku-org/go-waku/waku/v2/protocol/store/pb"
+)
+
+type storenodeRequestor struct {
+	node   *waku.WakuNode
+	logger *zap.Logger
+}
+
+func newStorenodeRequestor(node *waku.WakuNode, logger *zap.Logger) commonapi.StorenodeRequestor {
+	return &storenodeRequestor{
+		node:   node,
+		logger: logger.Named("storenodeRequestor"),
+	}
+}
+
+func (s *storenodeRequestor) GetMessagesByHash(ctx context.Context, peerInfo peer.AddrInfo, pageSize uint64, messageHashes []pb.MessageHash) (commonapi.StoreRequestResult, error) {
+	requestIDStr := hex.EncodeToString(protocol.GenerateRequestID())
+
+	logger := s.logger.With(zap.Stringer("peerID", peerInfo.ID), zap.String("requestID", requestIDStr))
+
+	logger.Debug("sending store request")
+
+	storeRequest := &storepb.StoreQueryRequest{
+		RequestId:         requestIDStr,
+		MessageHashes:     make([][]byte, len(messageHashes)),
+		IncludeData:       true,
+		PaginationCursor:  nil,
+		PaginationForward: false,
+		PaginationLimit:   proto.Uint64(pageSize),
+	}
+
+	for i, mhash := range messageHashes {
+		storeRequest.MessageHashes[i] = mhash.Bytes()
+	}
+
+	bindingsStoreRequest, err := PbToBindingsStoreRequest(storeRequest)
+
+	if err != nil {
+		return nil, err
+	}
+
+	bindingsResponse, err := s.node.StoreQuery(ctx, bindingsStoreRequest, peerInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	storeResponse, err := BindingsToPbStoreResponse(bindingsResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if storeResponse.GetStatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("could not query storenode: %s %d %s", requestIDStr, storeResponse.GetStatusCode(), storeResponse.GetStatusDesc())
+	}
+
+	return newStoreResultImpl(s.node, peerInfo, storeRequest, storeResponse), nil
+}
+
+func (s *storenodeRequestor) Query(ctx context.Context, peerInfo peer.AddrInfo, storeRequest *storepb.StoreQueryRequest) (commonapi.StoreRequestResult, error) {
+
+	bindingsStoreRequest, err := PbToBindingsStoreRequest(storeRequest)
+
+	if err != nil {
+		return nil, err
+	}
+
+	bindingsResponse, err := s.node.StoreQuery(ctx, bindingsStoreRequest, peerInfo)
+
+	if err != nil {
+		return nil, err
+	}
+
+	storeResponse, err := BindingsToPbStoreResponse(bindingsResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if storeResponse.GetStatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("could not query storenode: %s %d %s", storeRequest.RequestId, storeResponse.GetStatusCode(), storeResponse.GetStatusDesc())
+	}
+
+	return newStoreResultImpl(s.node, peerInfo, storeRequest, storeResponse), nil
+}

--- a/wakuv2/waku_test.go
+++ b/wakuv2/waku_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/status-im/status-go/connection"
 	"github.com/status-im/status-go/protocol/tt"
 	"github.com/status-im/status-go/t/helpers"
+	wakutypes "github.com/status-im/status-go/waku/types"
 	"github.com/status-im/status-go/wakuv2/common"
 )
 


### PR DESCRIPTION
Integrating nwaku under the `use_nwaku` build tag and added a CI pipeline compiling `status-go` with nwaku.

Everything in files with the `use_nwaku` on top are not production ready and have lots of missing features, commented blocks of code and TODOs. That will be taken care of in the following weeks.
Merging it now so we can make sure that we don't break the nwaku build or diverge too much.

For `go-waku`, the changes are the following:
- [x] adding `NwakuConfig` to the `Config` struct as we use the same struct for `nwaku` and `go-waku` nodes
- [x] moving the Envelope definition outside of `go-waku` to `wakuv2/common/envelope.go`
- [x] adding libwaku target to makefile, which triggers a libwaku build in case we compile with the `USE_NWAKU=true` env variable
- [x] including `openssl` to nix packages
- [x] added CI pipeline compiling `statusgo-shared-library` using nwaku in linux 

Rest of the changes are disabled under the `use_nwaku` tag

Issue: https://github.com/waku-org/nwaku/issues/3076
