### PR TITLE
chore_: rename params test package

### DIFF
--- a/params/network_config_test.go
+++ b/params/network_config_test.go
@@ -1,25 +1,23 @@
-package params_test
+package params
 
 import (
 	"testing"
-
-	"github.com/status-im/status-go/params"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRpcProvider_GetHost(t *testing.T) {
-	provider := params.RpcProvider{URL: "https://api.example.com/path"}
+	provider := RpcProvider{URL: "https://api.example.com/path"}
 	expectedHost := "api.example.com"
 	assert.Equal(t, expectedHost, provider.GetHost())
 }
 
 func TestRpcProvider_GetFullURL(t *testing.T) {
-	provider := params.RpcProvider{URL: "https://api.example.com", AuthType: params.TokenAuth, AuthToken: "mytoken"}
+	provider := RpcProvider{URL: "https://api.example.com", AuthType: TokenAuth, AuthToken: "mytoken"}
 	expectedFullURL := "https://api.example.com/mytoken"
 	assert.Equal(t, expectedFullURL, provider.GetFullURL())
 
-	provider.AuthType = params.NoAuth
+	provider.AuthType = NoAuth
 	expectedFullURL = "https://api.example.com"
 	assert.Equal(t, expectedFullURL, provider.GetFullURL())
 }


### PR DESCRIPTION
It's not needed to call the package `params_test`, as it's testing the `params` package.