### PR TITLE
fix(health-manager)_: handle nil wrapped in an error type

### DIFF
--- a/healthmanager/provider_errors/rpc_provider_errors.go
+++ b/healthmanager/provider_errors/rpc_provider_errors.go
@@ -2,6 +2,7 @@ package provider_errors
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 
 	"github.com/ethereum/go-ethereum"
@@ -20,31 +21,52 @@ const (
 	RpcErrorTypeRPCOther       RpcProviderErrorType = "rpc_other"
 )
 
+// safeRPCError safely extracts an RPC error and its error code.
+// Returns nil, 0, false if:
+// - err is nil
+// - err is not an RPC error
+// - err is a nil RPC error pointer
+func safeRPCError(err error) (rpc.Error, int, bool) {
+	var rpcErr rpc.Error
+	if !errors.As(err, &rpcErr) {
+		return nil, 0, false
+	}
+
+	// If it's a nil pointer but wrapped, we still want to handle it as an RPC error
+	if v := reflect.ValueOf(rpcErr); v.Kind() == reflect.Ptr && v.IsNil() {
+		return nil, 0, true
+	}
+
+	return rpcErr, rpcErr.ErrorCode(), true
+}
+
 // Not found should not be cancelling the requests, as that's returned
 // when we are hitting a non archival node for example, it should continue the
 // chain as the next provider might have archival support.
 func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
 	return strings.Contains(err.Error(), ethereum.NotFound.Error())
 }
 
 func IsRPCError(err error) (rpc.Error, bool) {
-	var rpcErr rpc.Error
-	if errors.As(err, &rpcErr) {
-		return rpcErr, true
-	}
-	return nil, false
+	rpcErr, _, ok := safeRPCError(err)
+	return rpcErr, ok
 }
 
 func IsMethodNotFoundError(err error) bool {
-	if rpcErr, ok := IsRPCError(err); ok {
-		return rpcErr.ErrorCode() == -32601
-	}
-	return false
+	_, code, ok := safeRPCError(err)
+	return ok && code == -32601
 }
 
 func IsVMError(err error) bool {
-	if rpcErr, ok := IsRPCError(err); ok {
-		return rpcErr.ErrorCode() == -32015 // Код ошибки VM execution error
+	_, code, ok := safeRPCError(err)
+	if ok && code == -32015 { // VM execution error code
+		return true
+	}
+	if err == nil {
+		return false
 	}
 	if strings.Contains(err.Error(), core.ErrInsufficientFunds.Error()) {
 		return true
@@ -62,14 +84,15 @@ func determineRpcErrorType(err error) RpcProviderErrorType {
 	if err == nil {
 		return RpcErrorTypeNone
 	}
-	//if IsRpsLimitError(err) {
-	//	return RpcErrorTypeRPSLimit
-	//}
+
 	if IsMethodNotFoundError(err) || IsNotFoundError(err) {
 		return RpcErrorTypeMethodNotFound
 	}
 	if IsVMError(err) {
 		return RpcErrorTypeVMError
+	}
+	if _, ok := IsRPCError(err); ok {
+		return RpcErrorTypeRPCOther
 	}
 	return RpcErrorTypeRPCOther
 }

--- a/healthmanager/provider_errors/rpc_provider_errors_test.go
+++ b/healthmanager/provider_errors/rpc_provider_errors_test.go
@@ -2,7 +2,11 @@ package provider_errors
 
 import (
 	"errors"
+	"fmt"
+	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestIsRpsLimitError tests the IsRpsLimitError function.
@@ -43,8 +47,112 @@ func TestIsRpsLimitError(t *testing.T) {
 		tt := tt // capture the variable
 		t.Run(tt.name, func(t *testing.T) {
 			got := IsRateLimitError(tt.err)
-			if got != tt.wantResult {
-				t.Errorf("IsRpsLimitError(%v) = %v; want %v", tt.err, got, tt.wantResult)
+			require.Equal(t, tt.wantResult, got)
+		})
+	}
+}
+
+// mockRPCError implements the rpc.Error interface for testing
+type mockRPCError struct {
+	code    int
+	message string
+}
+
+func (e *mockRPCError) Error() string {
+	return e.message
+}
+
+func (e *mockRPCError) ErrorCode() int {
+	return e.code
+}
+
+// TestNilRPCErrorHandling tests handling of nil RPC errors in various wrapping scenarios
+func TestNilRPCErrorHandling(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantType RpcProviderErrorType
+	}{
+		{
+			name: "direct nil RPC error in url.Error",
+			err: &url.Error{
+				Op:  "Post",
+				URL: "http://localhost:8545",
+				Err: (*mockRPCError)(nil),
+			},
+			wantType: RpcErrorTypeRPCOther,
+		},
+		{
+			name: "wrapped nil RPC error in url.Error",
+			err: fmt.Errorf("outer error: %w",
+				&url.Error{
+					Op:  "Post",
+					URL: "http://localhost:8545",
+					Err: (*mockRPCError)(nil),
+				}),
+			wantType: RpcErrorTypeRPCOther,
+		},
+		{
+			name: "double wrapped nil RPC error",
+			err: fmt.Errorf("outer error: %w",
+				fmt.Errorf("inner error: %w",
+					&url.Error{
+						Op:  "Post",
+						URL: "http://localhost:8545",
+						Err: (*mockRPCError)(nil),
+					})),
+			wantType: RpcErrorTypeRPCOther,
+		},
+		{
+			name: "direct nil error in url.Error",
+			err: &url.Error{
+				Op:  "Post",
+				URL: "http://localhost:8545",
+				Err: nil,
+			},
+			wantType: RpcErrorTypeRPCOther,
+		},
+		{
+			name:     "direct nil error",
+			err:      nil,
+			wantType: RpcErrorTypeNone,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// Test for panics in all error handling functions
+			testFuncs := []struct {
+				name string
+				fn   func(error)
+			}{
+				{"IsRPCError", func(err error) { _, _ = IsRPCError(err) }},
+				{"IsMethodNotFoundError", func(err error) { _ = IsMethodNotFoundError(err) }},
+				{"determineRpcErrorType", func(err error) { _ = determineRpcErrorType(err) }},
+				{"IsNonCriticalRpcError", func(err error) { _ = IsNonCriticalRpcError(err) }},
+			}
+
+			// Verify no panics
+			for _, tf := range testFuncs {
+				tf := tf
+				require.NotPanics(t, func() { tf.fn(tt.err) })
+			}
+
+			// Test error type determination
+			errType := determineRpcErrorType(tt.err)
+			require.Equal(t, tt.wantType, errType)
+
+			if tt.err != nil {
+				// Check IsMethodNotFoundError behavior
+				require.False(t, IsMethodNotFoundError(tt.err),
+					"IsMethodNotFoundError() should return false for nil RPC error")
+
+				// Check IsNonCriticalRpcError behavior
+				if tt.wantType == RpcErrorTypeRPCOther {
+					require.False(t, IsNonCriticalRpcError(tt.err),
+						"IsNonCriticalRpcError() should return false for RpcErrorTypeRPCOther")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
- Add safeRPCError function to safely handle nil RPC errors
- Add tests

fixes: https://sentry.infra.status.im/organizations/sentry/issues/160/ 

Closes #6457 
