### PR TITLE
fix(makefile)_: lint with build_tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,11 +339,12 @@ test-functional: export FUNCTIONAL_TESTS_REPORT_CODECOV ?= false
 test-functional:
 	@./_assets/scripts/run_functional_tests.sh
 
+lint-panics: export GOFLAGS ?= -tags='$(BUILD_TAGS)'
 lint-panics: generate
 	go run ./cmd/lint-panics -root="$(call sh, pwd)" -skip=./cmd -test=false ./...
 
 lint: generate lint-panics
-	golangci-lint run ./...
+	golangci-lint --build-tags '$(BUILD_TAGS)' run ./...
 
 ci: generate lint test-unit test-e2e ##@tests Run all linters and tests at once
 


### PR DESCRIPTION
# Description

Added `BUILD_TAGS` to linters.

Somehow it was working on CI. Also it works randomly works locally for me. I couldn't figure out why. 
But this change seem to make sense anyway.