### PR TITLE
test_: enhance support for running functional tests with local `status-backend`

### DIFF
--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -39,7 +39,7 @@ Functional tests for status-go
     * Status-im contracts will be deployed to the network
 
 * In `./tests-functional/tests` directory run `pytest -m rpc`
-* To run tests against binary run `pytest -m <your mark> --url=http:<binary_url>:<binary_port> --user_dir=/<path>`
+* To run tests against binary run `pytest -m <your mark> --status_backend_url=http://<binary_url>:<binary_port>`
 
 ### Prerequisites for Mac OSx users
 If you see errors at attempt to run tests, try to run in terminal:

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -30,15 +30,15 @@ class StatusBackend(RpcClient, SignalClient):
 
     container = None
 
-    def __init__(self, await_signals=[], privileged=False, ipv6=USE_IPV6, status_backend_url=""):
+    def __init__(self, await_signals=[], privileged=False, ipv6=USE_IPV6):
         self.ipv6 = True if ipv6 == "Yes" else False
         logging.debug(f"Flag USE_IPV6 is: {self.ipv6}")
         self.docker_project_name = option.docker_project_name
         self.network_name = f"{self.docker_project_name}_default"
+
         if option.status_backend_url:
-            url = option.status_backend_url
-        elif status_backend_url != "":
-            url = status_backend_url
+            url = next(option.status_backend_urls)
+            assert url != "", "not enough status-backend urls provided"
         else:
             self.docker_client = docker.from_env()
             retries = 5

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -84,8 +84,7 @@ class StatusBackend(RpcClient, SignalClient):
             self.temp_dir.cleanup()
 
     def _start_container(self, host_port, privileged):
-        identifier = os.environ.get("BUILD_ID") if os.environ.get("CI") else os.popen(
-            "git rev-parse --short HEAD").read().strip()
+        identifier = os.environ.get("BUILD_ID") if os.environ.get("CI") else os.popen("git rev-parse --short HEAD").read().strip()
         image_name = f"{self.docker_project_name}-status-backend:latest"
         container_name = f"{self.docker_project_name}-{identifier}-status-backend-{host_port}"
 
@@ -338,8 +337,7 @@ class StatusBackend(RpcClient, SignalClient):
         try:
             exec_result = self.container.exec_run(cmd=["sh", "-c", command], stdout=True, stderr=True, tty=False)
             if exec_result.exit_code != 0:
-                raise RuntimeError(
-                    f"Failed to execute command in container {self.container.id}:\n" f"OUTPUT: {exec_result.output.decode().strip()}")
+                raise RuntimeError(f"Failed to execute command in container {self.container.id}:\n" f"OUTPUT: {exec_result.output.decode().strip()}")
             return exec_result.output.decode().strip()
         except APIError as e:
             raise RuntimeError(f"API error during container execution: {str(e)}") from e
@@ -403,8 +401,7 @@ class StatusBackend(RpcClient, SignalClient):
             if not self.ipv6 and current_ipv4 == updated_ipv4:
                 raise RuntimeError("IPV4 is the same after network reconnect")
 
-            logging.info(
-                f"Changed container {self.container.name} IPs - New IPv4: {updated_ipv4}, New IPv6: {updated_ipv6}")
+            logging.info(f"Changed container {self.container.name} IPs - New IPv4: {updated_ipv4}, New IPv6: {updated_ipv6}")
 
         except Exception as e:
             raise RuntimeError(f"Failed to change container IP: {e}")

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -20,14 +20,13 @@ from clients.services.settings import SettingsService
 from clients.signals import SignalClient
 from clients.rpc import RpcClient
 from conftest import option
-from resources.constants import USE_IPV6, user_1, USER_DIR, ANVIL_NETWORK_ID
+from resources.constants import USE_IPV6, user_1, ANVIL_NETWORK_ID
 from docker.errors import APIError
 
 NANOSECONDS_PER_SECOND = 1_000_000_000
 
 
 class StatusBackend(RpcClient, SignalClient):
-
     container = None
 
     def __init__(self, await_signals=[], privileged=False, ipv6=USE_IPV6):
@@ -39,7 +38,10 @@ class StatusBackend(RpcClient, SignalClient):
         if option.status_backend_url:
             url = next(option.status_backend_urls)
             assert url != "", "not enough status-backend urls provided"
+            self.temp_dir = tempfile.TemporaryDirectory()
+            self.data_dir = self.temp_dir.name
         else:
+            self.data_dir = "/usr/status-user"
             self.docker_client = docker.from_env()
             retries = 5
             ports_tried = []
@@ -56,6 +58,7 @@ class StatusBackend(RpcClient, SignalClient):
             else:
                 raise RuntimeError(f"Failed to start container on ports: {ports_tried}")
 
+        assert self.data_dir != ""
         self.base_url = url
         self.api_url = f"{url}/statusgo"
         self.ws_url = f"{url}".replace("http", "ws")
@@ -76,8 +79,13 @@ class StatusBackend(RpcClient, SignalClient):
         self.accounts_service = AccountService(self)
         self.settings_service = SettingsService(self)
 
+    def __del__(self):
+        if self.temp_dir is not None:
+            self.temp_dir.cleanup()
+
     def _start_container(self, host_port, privileged):
-        identifier = os.environ.get("BUILD_ID") if os.environ.get("CI") else os.popen("git rev-parse --short HEAD").read().strip()
+        identifier = os.environ.get("BUILD_ID") if os.environ.get("CI") else os.popen(
+            "git rev-parse --short HEAD").read().strip()
         image_name = f"{self.docker_project_name}-status-backend:latest"
         container_name = f"{self.docker_project_name}-{identifier}-status-backend-{host_port}"
 
@@ -167,7 +175,7 @@ class StatusBackend(RpcClient, SignalClient):
         self.verify_is_valid_api_response(response)
         return response
 
-    def init_status_backend(self, data_dir=USER_DIR):
+    def init_status_backend(self):
         if option.logout:
             logging.warning("automatically logging out before InitializeApplication")
             try:
@@ -179,7 +187,7 @@ class StatusBackend(RpcClient, SignalClient):
 
         method = "InitializeApplication"
         data = {
-            "dataDir": data_dir,
+            "dataDir": self.data_dir,
             "logEnabled": True,
             "logLevel": "DEBUG",
             "apiLogging": True,
@@ -268,9 +276,9 @@ class StatusBackend(RpcClient, SignalClient):
             f"DISP_NAME_{''.join(random.choices(string.ascii_letters + string.digits + '_-', k=10))}",
         )
 
-    def _create_account_request(self, data_dir, user, **kwargs):
+    def _create_account_request(self, user, **kwargs):
         data = {
-            "rootDataDir": data_dir,
+            "rootDataDir": self.data_dir,
             "kdfIterations": 256000,
             # Profile config
             "displayName": self.display_name,
@@ -285,16 +293,16 @@ class StatusBackend(RpcClient, SignalClient):
         data = self._set_proxy_credentials(data)
         return data
 
-    def create_account_and_login(self, data_dir=USER_DIR, user=user_1, **kwargs):
+    def create_account_and_login(self, user=user_1, **kwargs):
         self._set_display_name(**kwargs)
         method = "CreateAccountAndLogin"
-        data = self._create_account_request(data_dir, user, **kwargs)
+        data = self._create_account_request(user, **kwargs)
         return self.api_valid_request(method, data)
 
-    def restore_account_and_login(self, data_dir=USER_DIR, user=user_1, **kwargs):
+    def restore_account_and_login(self, user=user_1, **kwargs):
         self._set_display_name(**kwargs)
         method = "RestoreAccountAndLogin"
-        data = self._create_account_request(data_dir, user, **kwargs)
+        data = self._create_account_request(user, **kwargs)
         data["mnemonic"] = user.passphrase
         return self.api_valid_request(method, data)
 
@@ -330,7 +338,8 @@ class StatusBackend(RpcClient, SignalClient):
         try:
             exec_result = self.container.exec_run(cmd=["sh", "-c", command], stdout=True, stderr=True, tty=False)
             if exec_result.exit_code != 0:
-                raise RuntimeError(f"Failed to execute command in container {self.container.id}:\n" f"OUTPUT: {exec_result.output.decode().strip()}")
+                raise RuntimeError(
+                    f"Failed to execute command in container {self.container.id}:\n" f"OUTPUT: {exec_result.output.decode().strip()}")
             return exec_result.output.decode().strip()
         except APIError as e:
             raise RuntimeError(f"API error during container execution: {str(e)}") from e
@@ -394,7 +403,8 @@ class StatusBackend(RpcClient, SignalClient):
             if not self.ipv6 and current_ipv4 == updated_ipv4:
                 raise RuntimeError("IPV4 is the same after network reconnect")
 
-            logging.info(f"Changed container {self.container.name} IPs - New IPv4: {updated_ipv4}, New IPv6: {updated_ipv6}")
+            logging.info(
+                f"Changed container {self.container.name} IPs - New IPv4: {updated_ipv4}, New IPv6: {updated_ipv6}")
 
         except Exception as e:
             raise RuntimeError(f"Failed to change container IP: {e}")

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -36,12 +36,6 @@ def pytest_addoption(parser):
         default=None,
     )
     parser.addoption(
-        "--user_dir",
-        action="store",
-        help="",
-        default=None,
-    )
-    parser.addoption(
         "--logout",
         action="store_true",
         help="When set, will automatically call Logout() before InitializeApplication()",
@@ -90,7 +84,7 @@ def pytest_configure(config):
     option.status_backend_port_range = list(range(start_port, end_port))
     option.status_backend_containers = []
 
-    option.base_dir = os.path.dirname(os.path.abspath(__file__))
+    option.base_dir = os.path.dirname(os.path.abspath(__file__))  # schemas directory
     option.status_backend_urls = status_backend_url_generator()
 
 

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -54,8 +54,8 @@ option = Option()
 
 
 def status_backend_url_generator(config):
-    if hasattr(option, "status_backend_url") and config.status_backend_url is not None:
-        urls = config.status_backend_url
+    if hasattr(option, "status_backend_url") and config.option.status_backend_url is not None:
+        urls = config.option.status_backend_url
     else:
         print("status_backend_url option not found or is None")
         return

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -53,9 +53,9 @@ class Option:
 option = Option()
 
 
-def status_backend_url_generator():
-    if hasattr(option, "status_backend_url") and option.status_backend_url is not None:
-        urls = option.status_backend_url
+def status_backend_url_generator(config):
+    if hasattr(option, "status_backend_url") and config.status_backend_url is not None:
+        urls = config.status_backend_url
     else:
         print("status_backend_url option not found or is None")
         return
@@ -85,7 +85,7 @@ def pytest_configure(config):
     option.status_backend_containers = []
 
     option.base_dir = os.path.dirname(os.path.abspath(__file__))  # schemas directory
-    option.status_backend_urls = status_backend_url_generator()
+    option.status_backend_urls = status_backend_url_generator(config)
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -7,7 +7,7 @@ import pytest
 def pytest_addoption(parser):
     parser.addoption(
         "--status_backend_url",
-        action="store",
+        action="append",
         help="",
         default=None,
     )
@@ -59,6 +59,17 @@ class Option:
 option = Option()
 
 
+def status_backend_url_generator():
+    if hasattr(option, "status_backend_url") and option.status_backend_url is not None:
+        urls = option.status_backend_url
+    else:
+        print("status_backend_url option not found or is None")
+        return
+
+    for url in urls:
+        yield url
+
+
 def pytest_configure(config):
     global option
     option = config.option
@@ -80,6 +91,7 @@ def pytest_configure(config):
     option.status_backend_containers = []
 
     option.base_dir = os.path.dirname(os.path.abspath(__file__))
+    option.status_backend_urls = status_backend_url_generator()
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests-functional/resources/constants.py
+++ b/tests-functional/resources/constants.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from conftest import option
 import os
 
 

--- a/tests-functional/resources/constants.py
+++ b/tests-functional/resources/constants.py
@@ -30,7 +30,6 @@ FORGE_OUTPUT_DIR = os.path.join(PROJECT_ROOT, "forge_output")
 DEPLOYER_ACCOUNT = user_1
 LOG_SIGNALS_TO_FILE = False  # used for debugging purposes
 USE_IPV6 = os.getenv("USE_IPV6", "No")
-USER_DIR = option.user_dir if option.user_dir else "/usr/status-user"
 
 gas_fee_mode_low = 0
 gas_fee_mode_medium = 1

--- a/tests-functional/tests/test_init_status_app.py
+++ b/tests-functional/tests/test_init_status_app.py
@@ -1,4 +1,3 @@
-from resources.constants import USER_DIR
 from clients.status_backend import StatusBackend
 import pytest
 from clients.signals import SignalType
@@ -57,10 +56,11 @@ def assert_file_first_line(path, pattern: str, expected: bool):
 @pytest.mark.init
 @pytest.mark.parametrize("log_enabled,api_logging_enabled", [(True, True), (False, False)])
 def test_check_logs(log_enabled: bool, api_logging_enabled: bool):
-    data_dir = os.path.join(USER_DIR, "data")
-    logs_dir = os.path.join(USER_DIR, "logs")
-
     backend = StatusBackend()
+
+    data_dir = os.path.join(backend.data_dir, "data")
+    logs_dir = os.path.join(backend.data_dir, "logs")
+
     backend.api_valid_request(
         "InitializeApplication",
         {

--- a/tests-functional/tests/test_logging.py
+++ b/tests-functional/tests/test_logging.py
@@ -1,4 +1,3 @@
-from resources.constants import USER_DIR
 import re
 from clients.status_backend import StatusBackend
 import pytest
@@ -40,21 +39,23 @@ class TestLogging:
             r"ERROR\s+test1\.test2\.test3\s+",
         ]
 
+        log_path = os.path.join(backend_client.data_dir, "geth.log")
+
         # Ensure changes take effect at runtime
         backend_client.rpc_valid_request("wakuext_logTest")
-        geth_log = backend_client.extract_data(os.path.join(USER_DIR, "geth.log"))
+        geth_log = backend_client.extract_data(log_path)
         self.expect_logs(geth_log, "test message", log_pattern, count=1)
 
         # Disable logging
         backend_client.api_valid_request("SetLogEnabled", {"enabled": False})
         backend_client.rpc_valid_request("wakuext_logTest")
-        geth_log = backend_client.extract_data(os.path.join(USER_DIR, "geth.log"))
+        geth_log = backend_client.extract_data(log_path)
         self.expect_logs(geth_log, "test message", log_pattern, count=1)
 
         # Enable logging
         backend_client.api_valid_request("SetLogEnabled", {"enabled": True})
         backend_client.rpc_valid_request("wakuext_logTest")
-        geth_log = backend_client.extract_data(os.path.join(USER_DIR, "geth.log"))
+        geth_log = backend_client.extract_data(log_path)
         self.expect_logs(geth_log, "test message", log_pattern, count=2)
 
         # Ensure changes are persisted after re-login
@@ -62,7 +63,7 @@ class TestLogging:
         backend_client.login(str(backend_client.find_key_uid()))
         backend_client.wait_for_login()
         backend_client.rpc_valid_request("wakuext_logTest")
-        geth_log = backend_client.extract_data(os.path.join(USER_DIR, "geth.log"))
+        geth_log = backend_client.extract_data(log_path)
         self.expect_logs(geth_log, "test message", log_pattern, count=3)
 
     def expect_logs(self, log_file, filter_keyword, expected_logs, count):


### PR DESCRIPTION
# Description

1. Pass multiple `--status_backend_url` CLI options to run a test with multiple local status backends.
    - Each backend is used only once, asserts when not enough urls were provided

2. When `--status_backend_url` is set, profile is created in a temporary directory
    - The directory is clean up on destruction of `StatusBackend`
    - `--user_dir` option is removed

