### PR TITLE
test_: auto-logout and logs with time

### DIFF
--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -170,7 +170,12 @@ class StatusBackend(RpcClient, SignalClient):
     def init_status_backend(self, data_dir=USER_DIR):
         if option.logout:
             logging.warning("automatically logging out before InitializeApplication")
-            self.logout()
+            try:
+                self.logout()
+                logging.debug("successfully logged out")
+            except Exception:
+                logging.debug("failed to log out")
+                pass
 
         method = "InitializeApplication"
         data = {

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -168,6 +168,10 @@ class StatusBackend(RpcClient, SignalClient):
         return response
 
     def init_status_backend(self, data_dir=USER_DIR):
+        if option.logout:
+            logging.warning("automatically logging out before InitializeApplication")
+            self.logout()
+
         method = "InitializeApplication"
         data = {
             "dataDir": data_dir,
@@ -304,7 +308,7 @@ class StatusBackend(RpcClient, SignalClient):
         data = self._set_proxy_credentials(data)
         return self.api_valid_request(method, data)
 
-    def logout(self, user=user_1):
+    def logout(self):
         method = "Logout"
         return self.api_valid_request(method, {})
 

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -41,6 +41,12 @@ def pytest_addoption(parser):
         help="",
         default=None,
     )
+    parser.addoption(
+        "--logout",
+        action="store_true",
+        help="When set, will automatically call Logout() before InitializeApplication()",
+        default=False,
+    )
 
 
 @dataclass

--- a/tests-functional/pytest.ini
+++ b/tests-functional/pytest.ini
@@ -3,6 +3,8 @@ addopts = -s -v --tb=short
 
 log_cli=true
 log_level=INFO
+log_cli_format = %(asctime)s.%(msecs)03d %(levelname)s %(message)s
+log_cli_date_format = %Y-%m-%d %H:%M:%S
 
 markers =
     rpc


### PR DESCRIPTION
# Description

1. Added `--logout` option. 
    When True, it automatically calls `Logout()` before initializing status-backend. 
    This is handy when modifying tests with locally running instance of `status-backend`.

2. Added time to logs format

3. Removed unused `user` arg from `logout` method