### PR TITLE
test_: use common create_account request for create and restore RPCs

### DIFF
--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -106,6 +106,7 @@ class SignalClient:
         if "error" in signal["event"]:
             error_details = signal["event"]["error"]
             assert not error_details, f"Unexpected error during login: {error_details}"
+        self.node_login_event = signal
         return signal
 
     def wait_for_logout(self):

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -61,6 +61,7 @@ class StatusBackend(RpcClient, SignalClient):
         self.ws_url = f"{url}".replace("http", "ws")
         self.rpc_url = f"{url}/statusgo/CallRPC"
         self.public_key = ""
+        self.node_login_event = None
 
         RpcClient.__init__(self, self.rpc_url)
         SignalClient.__init__(self, self.ws_url, await_signals)
@@ -186,6 +187,38 @@ class StatusBackend(RpcClient, SignalClient):
         }
         return self.api_valid_request(method, data)
 
+    def _set_networks(self, data, **kwargs):
+        network_id = kwargs.get("network_id", ANVIL_NETWORK_ID)
+        anvil_network = {
+            "chainID": network_id,
+            "chainName": "Anvil",
+            "rpcProviders": [
+                {
+                    "chainId": network_id,
+                    "name": "Anvil Direct",
+                    "url": "http://anvil:8545",
+                    "enableRpsLimiter": False,
+                    "type": "embedded-direct",
+                    "enabled": True,
+                    "authType": "no-auth",
+                }
+            ],
+            "shortName": "eth",
+            "nativeCurrencyName": "Ether",
+            "nativeCurrencySymbol": "ETH",
+            "nativeCurrencyDecimals": 18,
+            "isTest": False,
+            "layer": 1,
+            "enabled": True,
+            "isActive": True,
+            "isDeactivatable": False,
+        }
+        anvil_network = self._set_token_overrides(anvil_network, kwargs.get("token_overrides", []))
+
+        data["testNetworksEnabled"] = False
+        data["networkId"] = network_id
+        data["networksOverride"] = [anvil_network]
+
     def _set_proxy_credentials(self, data):
         if "STATUS_BUILD_PROXY_USER" not in os.environ:
             return data
@@ -230,78 +263,47 @@ class StatusBackend(RpcClient, SignalClient):
 
         return temp_dir
 
-    def create_account_and_login(self, data_dir=USER_DIR, **kwargs):
+    def _set_display_name(self, **kwargs):
         self.display_name = kwargs.get(
             "display_name",
             f"DISP_NAME_{''.join(random.choices(string.ascii_letters + string.digits + '_-', k=10))}",
         )
-        method = "CreateAccountAndLogin"
+
+    def _create_account_request(self,
+                                data_dir,
+                                user,
+                                **kwargs):
         data = {
             "rootDataDir": data_dir,
             "kdfIterations": 256000,
+            # Profile config
             "displayName": self.display_name,
-            "password": kwargs.get("password", user_1.password),
-            "customizationColor": "primary",
+            "password": kwargs.get("password", user.password),
+            "customizationColor": kwargs.get("customizationColor", "primary"),
+            # Logs config
             "logEnabled": True,
             "logLevel": "DEBUG",
             "wakuV2LightClient": kwargs.get("wakuV2LightClient", False),
         }
-
+        self._set_networks(data, **kwargs)
         data = self._set_proxy_credentials(data)
+        return data
+
+    def create_account_and_login(self, data_dir=USER_DIR, user=user_1, **kwargs):
+        self._set_display_name(**kwargs)
+        method = "CreateAccountAndLogin"
+        data = self._create_account_request(data_dir, user, **kwargs)
         resp = self.api_valid_request(method, data)
         self.node_login_event = self.wait_for_login()
         return resp
 
-    def restore_account_and_login(
-        self,
-        data_dir=USER_DIR,
-        display_name=DEFAULT_DISPLAY_NAME,
-        user=user_1,
-        network_id=ANVIL_NETWORK_ID,
-        **kwargs,
-    ):
+    def restore_account_and_login(self, data_dir=USER_DIR, user=user_1, **kwargs):
         method = "RestoreAccountAndLogin"
-        anvil_network = {
-            "chainID": network_id,
-            "chainName": "Anvil",
-            "rpcProviders": [
-                {
-                    "chainId": network_id,
-                    "name": "Anvil Direct",
-                    "url": "http://anvil:8545",
-                    "enableRpsLimiter": False,
-                    "type": "embedded-direct",
-                    "enabled": True,
-                    "authType": "no-auth",
-                }
-            ],
-            "shortName": "eth",
-            "nativeCurrencyName": "Ether",
-            "nativeCurrencySymbol": "ETH",
-            "nativeCurrencyDecimals": 18,
-            "isTest": False,
-            "layer": 1,
-            "enabled": True,
-            "isActive": True,
-            "isDeactivatable": False,
-        }
-        anvil_network = self._set_token_overrides(anvil_network, kwargs.get("token_overrides", []))
-
-        data = {
-            "rootDataDir": data_dir,
-            "kdfIterations": 256000,
-            "displayName": display_name,
-            "password": user.password,
-            "mnemonic": user.passphrase,
-            "customizationColor": "blue",
-            "logEnabled": True,
-            "logLevel": "DEBUG",
-            "testNetworksEnabled": False,
-            "networkId": network_id,
-            "networksOverride": [anvil_network],
-        }
-        data = self._set_proxy_credentials(data)
-        return self.api_valid_request(method, data)
+        data = self._create_account_request(data_dir, user, **kwargs)
+        data["mnemonic"] = user.passphrase
+        resp = self.api_valid_request(method, data)
+        self.node_login_event = self.wait_for_login()
+        return resp
 
     def login(self, keyUid, user=user_1):
         method = "LoginAccount"
@@ -316,18 +318,6 @@ class StatusBackend(RpcClient, SignalClient):
     def logout(self):
         method = "Logout"
         return self.api_valid_request(method, {})
-
-    def restore_account_and_wait_for_rpc_client_to_start(self, timeout=60):
-        self.restore_account_and_login()
-        start_time = time.time()
-        # ToDo: change this part for waiting for `node.login` signal when websockets are migrated to StatusBackend
-        while time.time() - start_time <= timeout:
-            try:
-                self.accounts_service.get_account_keypairs()
-                return
-            except AssertionError:
-                time.sleep(3)
-        raise TimeoutError(f"RPC client was not started after {timeout} seconds")
 
     def container_pause(self):
         if not self.container:

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -294,6 +294,7 @@ class StatusBackend(RpcClient, SignalClient):
         return resp
 
     def restore_account_and_login(self, data_dir=USER_DIR, user=user_1, **kwargs):
+        self._set_display_name(**kwargs)
         method = "RestoreAccountAndLogin"
         data = self._create_account_request(data_dir, user, **kwargs)
         data["mnemonic"] = user.passphrase

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -289,18 +289,14 @@ class StatusBackend(RpcClient, SignalClient):
         self._set_display_name(**kwargs)
         method = "CreateAccountAndLogin"
         data = self._create_account_request(data_dir, user, **kwargs)
-        resp = self.api_valid_request(method, data)
-        self.node_login_event = self.wait_for_login()
-        return resp
+        return self.api_valid_request(method, data)
 
     def restore_account_and_login(self, data_dir=USER_DIR, user=user_1, **kwargs):
         self._set_display_name(**kwargs)
         method = "RestoreAccountAndLogin"
         data = self._create_account_request(data_dir, user, **kwargs)
         data["mnemonic"] = user.passphrase
-        resp = self.api_valid_request(method, data)
-        self.node_login_event = self.wait_for_login()
-        return resp
+        return self.api_valid_request(method, data)
 
     def login(self, keyUid, user=user_1):
         method = "LoginAccount"

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -20,7 +20,7 @@ from clients.services.settings import SettingsService
 from clients.signals import SignalClient
 from clients.rpc import RpcClient
 from conftest import option
-from resources.constants import USE_IPV6, user_1, DEFAULT_DISPLAY_NAME, USER_DIR, ANVIL_NETWORK_ID
+from resources.constants import USE_IPV6, user_1, USER_DIR, ANVIL_NETWORK_ID
 from docker.errors import APIError
 
 NANOSECONDS_PER_SECOND = 1_000_000_000
@@ -61,7 +61,6 @@ class StatusBackend(RpcClient, SignalClient):
         self.ws_url = f"{url}".replace("http", "ws")
         self.rpc_url = f"{url}/statusgo/CallRPC"
         self.public_key = ""
-        self.node_login_event = None
 
         RpcClient.__init__(self, self.rpc_url)
         SignalClient.__init__(self, self.ws_url, await_signals)
@@ -269,10 +268,7 @@ class StatusBackend(RpcClient, SignalClient):
             f"DISP_NAME_{''.join(random.choices(string.ascii_letters + string.digits + '_-', k=10))}",
         )
 
-    def _create_account_request(self,
-                                data_dir,
-                                user,
-                                **kwargs):
+    def _create_account_request(self, data_dir, user, **kwargs):
         data = {
             "rootDataDir": data_dir,
             "kdfIterations": 256000,

--- a/tests-functional/resources/constants.py
+++ b/tests-functional/resources/constants.py
@@ -23,7 +23,6 @@ user_2 = Account(
     password="Strong12345",
     passphrase="test test test test test test test test test test nest junk",
 )
-DEFAULT_DISPLAY_NAME = "Mr_Meeseeks"
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
 TESTS_DIR = os.path.join(PROJECT_ROOT, "tests-functional")
 SIGNALS_DIR = os.path.join(TESTS_DIR, "signals")

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -35,6 +35,7 @@ class MessengerSteps(NetworkConditionsSteps):
         backend = StatusBackend(await_signals, privileged=privileged, ipv6=ipv6)
         backend.init_status_backend()
         backend.create_account_and_login(**kwargs)
+        backend.wait_for_login()
         backend.find_public_key()
         backend.wakuext_service.start_messenger()
         return backend

--- a/tests-functional/tests/test_logging.py
+++ b/tests-functional/tests/test_logging.py
@@ -23,6 +23,7 @@ class TestLogging:
         # Init and login
         backend_client.init_status_backend()
         backend_client.create_account_and_login()
+        backend_client.wait_for_login()
 
         # Configure logging
         backend_client.api_valid_request("SetLogLevel", {"logLevel": "ERROR"})


### PR DESCRIPTION
# Description

In status-go, `RestoreAccount` requests composes `CreateAccount` request, and only adds a few more properties:
https://github.com/status-im/status-go/blob/49eaabaca5100368c5b39fb8c107aad2535371e5/protocol/requests/restore_account.go#L12-L22

I extracted the common part to `_create_account_request`, and reused it in both RPCs.

Also now we pass the networks to `create_account_request` call now 🙌 