### PR TITLE
chore(wallet)_: removed an option for breaking down entered amount to more txs with smaller amounts

### DIFF
--- a/services/connector/commands/send_transaction_test.go
+++ b/services/connector/commands/send_transaction_test.go
@@ -84,7 +84,7 @@ func TestSendTransactionWithSignalTimout(t *testing.T) {
 	mockedChainClient := mock_client.NewMockClientInterface(state.mockCtrl)
 	feeHistory := &fees.FeeHistory{}
 	percentiles := []int{fees.RewardPercentiles1, fees.RewardPercentiles2, fees.RewardPercentiles3}
-	state.rpcClient.EXPECT().Call(feeHistory, uint64(1), "eth_feeHistory", uint64(300), "latest", percentiles).Times(1).Return(nil)
+	state.rpcClient.EXPECT().Call(feeHistory, uint64(1), "eth_feeHistory", uint64(10), "latest", percentiles).Times(1).Return(nil)
 	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(1).Return(mockedChainClient, nil)
 	mockedChainClient.EXPECT().SuggestGasPrice(state.ctx).Times(1).Return(big.NewInt(1), nil)
 	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(1).Return(mockedChainClient, nil)
@@ -131,7 +131,7 @@ func TestSendTransactionWithSignalAccepted(t *testing.T) {
 	mockedChainClient := mock_client.NewMockClientInterface(state.mockCtrl)
 	feeHistory := &fees.FeeHistory{}
 	percentiles := []int{fees.RewardPercentiles1, fees.RewardPercentiles2, fees.RewardPercentiles3}
-	state.rpcClient.EXPECT().Call(feeHistory, uint64(1), "eth_feeHistory", uint64(300), "latest", percentiles).Times(1).Return(nil)
+	state.rpcClient.EXPECT().Call(feeHistory, uint64(1), "eth_feeHistory", uint64(10), "latest", percentiles).Times(1).Return(nil)
 	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(1).Return(mockedChainClient, nil)
 	mockedChainClient.EXPECT().SuggestGasPrice(state.ctx).Times(1).Return(big.NewInt(1), nil)
 	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(1).Return(mockedChainClient, nil)
@@ -175,7 +175,7 @@ func TestSendTransactionWithSignalRejected(t *testing.T) {
 	mockedChainClient := mock_client.NewMockClientInterface(state.mockCtrl)
 	feeHistory := &fees.FeeHistory{}
 	percentiles := []int{fees.RewardPercentiles1, fees.RewardPercentiles2, fees.RewardPercentiles3}
-	state.rpcClient.EXPECT().Call(feeHistory, uint64(1), "eth_feeHistory", uint64(300), "latest", percentiles).Times(1).Return(nil)
+	state.rpcClient.EXPECT().Call(feeHistory, uint64(1), "eth_feeHistory", uint64(10), "latest", percentiles).Times(1).Return(nil)
 	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(1).Return(mockedChainClient, nil)
 	mockedChainClient.EXPECT().SuggestGasPrice(state.ctx).Times(1).Return(big.NewInt(1), nil)
 	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(1).Return(mockedChainClient, nil)

--- a/services/connector/connector_flows_test.go
+++ b/services/connector/connector_flows_test.go
@@ -106,7 +106,7 @@ func TestRequestAccountsSwitchChainAndSendTransactionFlow(t *testing.T) {
 	mockedChainClient := mock_client.NewMockClientInterface(state.mockCtrl)
 	feeHistory := &fees.FeeHistory{}
 	percentiles := []int{fees.RewardPercentiles1, fees.RewardPercentiles2, fees.RewardPercentiles3}
-	state.rpcClient.EXPECT().Call(feeHistory, uint64(1), "eth_feeHistory", uint64(300), "latest", percentiles).Times(1).Return(nil)
+	state.rpcClient.EXPECT().Call(feeHistory, uint64(1), "eth_feeHistory", uint64(10), "latest", percentiles).Times(1).Return(nil)
 	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(1).Return(mockedChainClient, nil)
 	mockedChainClient.EXPECT().SuggestGasPrice(state.ctx).Times(1).Return(big.NewInt(1), nil)
 	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(1).Return(mockedChainClient, nil)

--- a/services/wallet/routeexecution/manager.go
+++ b/services/wallet/routeexecution/manager.go
@@ -88,7 +88,7 @@ func (m *Manager) BuildTransactionsFromRoute(ctx context.Context, buildInputPara
 
 		// re-use path processor input params structure to pass extra params to transaction manager
 		var extraParams pathprocessor.ProcessorInputParams
-		extraParams, err = m.router.CreateProcessorInputParams(&routeInputParams, nil, nil, nil, nil, nil, buildInputParams.SlippagePercentage, 0)
+		extraParams, err = m.router.CreateProcessorInputParams(&routeInputParams, nil, nil, nil, nil, buildInputParams.SlippagePercentage, 0)
 		if err != nil {
 			return
 		}

--- a/services/wallet/router/router_test.go
+++ b/services/wallet/router/router_test.go
@@ -19,46 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func amountOptionEqual(a, b amountOption) bool {
-	return a.amount.Cmp(b.amount) == 0 && a.locked == b.locked
-}
-
-func contains(slice []amountOption, val amountOption) bool {
-	for _, item := range slice {
-		if amountOptionEqual(item, val) {
-			return true
-		}
-	}
-	return false
-}
-
-func amountOptionsMapsEqual(map1, map2 map[uint64][]amountOption) bool {
-	if len(map1) != len(map2) {
-		return false
-	}
-
-	for key, slice1 := range map1 {
-		slice2, ok := map2[key]
-		if !ok || len(slice1) != len(slice2) {
-			return false
-		}
-
-		for _, val1 := range slice1 {
-			if !contains(slice2, val1) {
-				return false
-			}
-		}
-
-		for _, val2 := range slice2 {
-			if !contains(slice1, val2) {
-				return false
-			}
-		}
-	}
-
-	return true
-}
-
 func assertPathsEqual(t *testing.T, expected, actual routes.Route) {
 	assert.Equal(t, len(expected), len(actual))
 	if len(expected) == 0 {
@@ -258,28 +218,6 @@ func TestNoBalanceForTheBestRouteRouter(t *testing.T) {
 			case <-time.After(10 * time.Second):
 				t.FailNow()
 			}
-		})
-	}
-}
-
-func TestAmountOptions(t *testing.T) {
-	router, cleanTmpDb := setupRouter(t)
-	defer cleanTmpDb()
-
-	tests := getAmountOptionsTestParamsList()
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			selectedFromChains, _, err := router.getSelectedChains(tt.input)
-			assert.NoError(t, err)
-
-			router.SetTestBalanceMap(tt.input.TestParams.BalanceMap)
-			amountOptions, err := router.findOptionsForSendingAmount(tt.input, selectedFromChains)
-			assert.NoError(t, err)
-
-			assert.Equal(t, len(tt.expectedAmountOptions), len(amountOptions))
-			assert.True(t, amountOptionsMapsEqual(tt.expectedAmountOptions, amountOptions))
 		})
 	}
 }

--- a/services/wallet/router/router_test_data.go
+++ b/services/wallet/router/router_test_data.go
@@ -978,9 +978,6 @@ func getNormalTestParamsList() []normalTestParams {
 				AddrTo:      common.HexToAddress("0x2"),
 				AmountIn:    (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 				TokenID:     walletCommon.EthSymbol,
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.EthereumMainnet: (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)),
-				},
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
@@ -1004,112 +1001,112 @@ func getNormalTestParamsList() []normalTestParams {
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &mainnet,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &optimism,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &arbitrum,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &base,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point8ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 			},
@@ -1125,11 +1122,6 @@ func getNormalTestParamsList() []normalTestParams {
 				AmountIn:           (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 				TokenID:            walletCommon.EthSymbol,
 				DisabledToChainIDs: []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet, walletCommon.BaseMainnet},
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.EthereumMainnet: (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)),
-					walletCommon.ArbitrumMainnet: (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
-					walletCommon.BaseMainnet:     (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
-				},
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
@@ -1153,28 +1145,28 @@ func getNormalTestParamsList() []normalTestParams {
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &optimism,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testAmount0Point2ETHInWei - testAmount0Point3ETHInWei - testAmount0Point3ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)), //(*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)), //(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)), //(*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)), //(*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 			},
@@ -1189,11 +1181,6 @@ func getNormalTestParamsList() []normalTestParams {
 				AddrTo:      common.HexToAddress("0x2"),
 				AmountIn:    (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 				TokenID:     walletCommon.EthSymbol,
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.EthereumMainnet: (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)),
-					walletCommon.OptimismMainnet: (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
-					walletCommon.BaseMainnet:     (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
-				},
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
@@ -1217,112 +1204,112 @@ func getNormalTestParamsList() []normalTestParams {
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &mainnet,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &optimism,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &arbitrum,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &base,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 			},
@@ -1337,12 +1324,6 @@ func getNormalTestParamsList() []normalTestParams {
 				AddrTo:      common.HexToAddress("0x2"),
 				AmountIn:    (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 				TokenID:     walletCommon.EthSymbol,
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.EthereumMainnet: (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)),
-					walletCommon.OptimismMainnet: (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
-					walletCommon.ArbitrumMainnet: (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
-					walletCommon.BaseMainnet:     (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)),
-				},
 
 				TestsMode: true,
 				TestParams: &requests.RouterTestParams{
@@ -1366,112 +1347,112 @@ func getNormalTestParamsList() []normalTestParams {
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &mainnet,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &optimism,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &arbitrum,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
 					FromChain:        &base,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point3ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount0Point2ETHInWei - testBonderFeeETH)),
+					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount1ETHInWei - testBonderFeeETH)),
 					ApprovalRequired: false,
 				},
 			},
@@ -2221,6 +2202,10 @@ func getNormalTestParamsList() []normalTestParams {
 					ApprovalL1Fee:         testApprovalL1Fee,
 				},
 			},
+			expectedError: &errors.ErrorResponse{
+				Code:    ErrNotEnoughTokenBalance.Code,
+				Details: fmt.Sprintf(ErrNotEnoughTokenBalance.Details, walletCommon.UsdcSymbol, walletCommon.OptimismMainnet),
+			},
 			expectedCandidates: routes.Route{
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
@@ -2230,24 +2215,10 @@ func getNormalTestParamsList() []normalTestParams {
 					ApprovalRequired: false,
 				},
 				{
-					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
-					FromChain:        &mainnet,
-					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC)),
-					ApprovalRequired: false,
-				},
-				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
 					ToChain:          &optimism,
 					AmountOut:        (*hexutil.Big)(big.NewInt(3.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &mainnet,
-					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
 					ApprovalRequired: true,
 				},
 				{
@@ -2260,22 +2231,8 @@ func getNormalTestParamsList() []normalTestParams {
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &mainnet,
-					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &mainnet,
 					ToChain:          &base,
 					AmountOut:        (*hexutil.Big)(big.NewInt(3.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &mainnet,
-					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
 					ApprovalRequired: true,
 				},
 				{
@@ -2286,13 +2243,6 @@ func getNormalTestParamsList() []normalTestParams {
 					ApprovalRequired: false,
 				},
 				{
-					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
-					FromChain:        &optimism,
-					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC)),
-					ApprovalRequired: false,
-				},
-				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
 					ToChain:          &mainnet,
@@ -2302,22 +2252,8 @@ func getNormalTestParamsList() []normalTestParams {
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &optimism,
-					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &optimism,
 					ToChain:          &arbitrum,
 					AmountOut:        (*hexutil.Big)(big.NewInt(3.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &optimism,
-					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
 					ApprovalRequired: true,
 				},
 				{
@@ -2326,27 +2262,6 @@ func getNormalTestParamsList() []normalTestParams {
 					ToChain:          &base,
 					AmountOut:        (*hexutil.Big)(big.NewInt(3.5*testAmount100USDC - testBonderFeeUSDC)),
 					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &optimism,
-					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
-					FromChain:        &arbitrum,
-					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(0.5 * testAmount100USDC)),
-					ApprovalRequired: false,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
-					FromChain:        &arbitrum,
-					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC)),
-					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
@@ -2359,35 +2274,7 @@ func getNormalTestParamsList() []normalTestParams {
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(0.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &arbitrum,
-					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &arbitrum,
-					ToChain:          &mainnet,
 					AmountOut:        (*hexutil.Big)(big.NewInt(3.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &arbitrum,
-					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(0.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &arbitrum,
-					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
 					ApprovalRequired: true,
 				},
 				{
@@ -2401,36 +2288,8 @@ func getNormalTestParamsList() []normalTestParams {
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &arbitrum,
 					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(0.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &arbitrum,
-					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &arbitrum,
-					ToChain:          &base,
 					AmountOut:        (*hexutil.Big)(big.NewInt(3.5*testAmount100USDC - testBonderFeeUSDC)),
 					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
-					FromChain:        &base,
-					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(0.5 * testAmount100USDC)),
-					ApprovalRequired: false,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
-					FromChain:        &base,
-					ToChain:          &base,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC)),
-					ApprovalRequired: false,
 				},
 				{
 					ProcessorName:    pathProcessorCommon.ProcessorTransferName,
@@ -2443,20 +2302,6 @@ func getNormalTestParamsList() []normalTestParams {
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(0.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &base,
-					ToChain:          &mainnet,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &base,
-					ToChain:          &mainnet,
 					AmountOut:        (*hexutil.Big)(big.NewInt(3.5*testAmount100USDC - testBonderFeeUSDC)),
 					ApprovalRequired: true,
 				},
@@ -2464,35 +2309,7 @@ func getNormalTestParamsList() []normalTestParams {
 					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
 					FromChain:        &base,
 					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(0.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &base,
-					ToChain:          &optimism,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &base,
-					ToChain:          &optimism,
 					AmountOut:        (*hexutil.Big)(big.NewInt(3.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &base,
-					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(0.5*testAmount100USDC - testBonderFeeUSDC)),
-					ApprovalRequired: true,
-				},
-				{
-					ProcessorName:    pathProcessorCommon.ProcessorBridgeHopName,
-					FromChain:        &base,
-					ToChain:          &arbitrum,
-					AmountOut:        (*hexutil.Big)(big.NewInt(testAmount100USDC - testBonderFeeUSDC)),
 					ApprovalRequired: true,
 				},
 				{
@@ -3509,479 +3326,6 @@ func getNoBalanceTestParamsList() []noBalanceTestParams {
 					FromChain:        &arbitrum,
 					ToChain:          &optimism,
 					ApprovalRequired: true,
-				},
-			},
-		},
-	}
-}
-
-type amountOptionsTestParams struct {
-	name                  string
-	input                 *requests.RouteInputParams
-	expectedAmountOptions map[uint64][]amountOption
-}
-
-func getAmountOptionsTestParamsList() []amountOptionsTestParams {
-	return []amountOptionsTestParams{
-		{
-			name: "Transfer - Single From Chain - No Locked Amount",
-			input: &requests.RouteInputParams{
-				TestnetMode:          false,
-				Uuid:                 uuid.NewString(),
-				SendType:             sendtype.Transfer,
-				AmountIn:             (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-				TokenID:              walletCommon.EthSymbol,
-				DisabledFromChainIDs: []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet, walletCommon.BaseMainnet},
-
-				TestsMode: true,
-				TestParams: &requests.RouterTestParams{
-					TokenFrom: &tokenTypes.Token{
-						ChainID:  1,
-						Symbol:   walletCommon.EthSymbol,
-						Decimals: 18,
-					},
-					BalanceMap: map[string]*big.Int{},
-				},
-			},
-			expectedAmountOptions: map[uint64][]amountOption{
-				walletCommon.OptimismMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: false,
-					},
-				},
-			},
-		},
-		{
-			name: "Transfer - Single From Chain - Locked Amount To Single Chain Equal Total Amount",
-			input: &requests.RouteInputParams{
-				TestnetMode:          false,
-				Uuid:                 uuid.NewString(),
-				SendType:             sendtype.Transfer,
-				AmountIn:             (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-				TokenID:              walletCommon.EthSymbol,
-				DisabledFromChainIDs: []uint64{walletCommon.EthereumMainnet, walletCommon.ArbitrumMainnet},
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.OptimismMainnet: (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-				},
-
-				TestsMode: true,
-				TestParams: &requests.RouterTestParams{
-					TokenFrom: &tokenTypes.Token{
-						ChainID:  1,
-						Symbol:   walletCommon.EthSymbol,
-						Decimals: 18,
-					},
-					BalanceMap: map[string]*big.Int{},
-				},
-			},
-			expectedAmountOptions: map[uint64][]amountOption{
-				walletCommon.OptimismMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: true,
-					},
-				},
-			},
-		},
-		{
-			name: "Transfer - Multiple From Chains - Locked Amount To Single Chain Is Less Than Total Amount",
-			input: &requests.RouteInputParams{
-				TestnetMode:          false,
-				Uuid:                 uuid.NewString(),
-				SendType:             sendtype.Transfer,
-				AmountIn:             (*hexutil.Big)(big.NewInt(testAmount2ETHInWei)),
-				TokenID:              walletCommon.EthSymbol,
-				DisabledFromChainIDs: []uint64{walletCommon.EthereumMainnet, walletCommon.BaseMainnet},
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.OptimismMainnet: (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-				},
-
-				TestsMode: true,
-				TestParams: &requests.RouterTestParams{
-					TokenFrom: &tokenTypes.Token{
-						ChainID:  1,
-						Symbol:   walletCommon.EthSymbol,
-						Decimals: 18,
-					},
-					BalanceMap: map[string]*big.Int{},
-				},
-			},
-			expectedAmountOptions: map[uint64][]amountOption{
-				walletCommon.OptimismMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: true,
-					},
-				},
-				walletCommon.ArbitrumMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: false,
-					},
-				},
-			},
-		},
-		{
-			name: "Transfer - Multiple From Chains - Locked Amount To Multiple Chains",
-			input: &requests.RouteInputParams{
-				TestnetMode:          false,
-				Uuid:                 uuid.NewString(),
-				SendType:             sendtype.Transfer,
-				AmountIn:             (*hexutil.Big)(big.NewInt(testAmount2ETHInWei)),
-				TokenID:              walletCommon.EthSymbol,
-				DisabledFromChainIDs: []uint64{walletCommon.EthereumMainnet},
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.OptimismMainnet: (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-					walletCommon.ArbitrumMainnet: (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-				},
-
-				TestsMode: true,
-				TestParams: &requests.RouterTestParams{
-					TokenFrom: &tokenTypes.Token{
-						ChainID:  1,
-						Symbol:   walletCommon.EthSymbol,
-						Decimals: 18,
-					},
-					BalanceMap: map[string]*big.Int{},
-				},
-			},
-			expectedAmountOptions: map[uint64][]amountOption{
-				walletCommon.OptimismMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: true,
-					},
-				},
-				walletCommon.ArbitrumMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: true,
-					},
-				},
-			},
-		},
-		{
-			name: "Transfer - All From Chains - Locked Amount To Multiple Chains Equal Total Amount",
-			input: &requests.RouteInputParams{
-				TestnetMode: false,
-				Uuid:        uuid.NewString(),
-				SendType:    sendtype.Transfer,
-				AmountIn:    (*hexutil.Big)(big.NewInt(testAmount2ETHInWei)),
-				TokenID:     walletCommon.EthSymbol,
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.OptimismMainnet: (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-					walletCommon.ArbitrumMainnet: (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-				},
-
-				TestsMode: true,
-				TestParams: &requests.RouterTestParams{
-					TokenFrom: &tokenTypes.Token{
-						ChainID:  1,
-						Symbol:   walletCommon.EthSymbol,
-						Decimals: 18,
-					},
-					BalanceMap: map[string]*big.Int{},
-				},
-			},
-			expectedAmountOptions: map[uint64][]amountOption{
-				walletCommon.OptimismMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: true,
-					},
-				},
-				walletCommon.ArbitrumMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: true,
-					},
-				},
-			},
-		},
-		{
-			name: "Transfer - All From Chains - Locked Amount To Multiple Chains Is Less Than Total Amount",
-			input: &requests.RouteInputParams{
-				TestnetMode: false,
-				Uuid:        uuid.NewString(),
-				SendType:    sendtype.Transfer,
-				AmountIn:    (*hexutil.Big)(big.NewInt(testAmount5ETHInWei)),
-				TokenID:     walletCommon.EthSymbol,
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.OptimismMainnet: (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-					walletCommon.ArbitrumMainnet: (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-				},
-
-				TestsMode: true,
-				TestParams: &requests.RouterTestParams{
-					TokenFrom: &tokenTypes.Token{
-						ChainID:  1,
-						Symbol:   walletCommon.EthSymbol,
-						Decimals: 18,
-					},
-					BalanceMap: map[string]*big.Int{},
-				},
-			},
-			expectedAmountOptions: map[uint64][]amountOption{
-				walletCommon.OptimismMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: true,
-					},
-				},
-				walletCommon.ArbitrumMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: true,
-					},
-				},
-				walletCommon.EthereumMainnet: {
-					{
-						amount: big.NewInt(testAmount3ETHInWei),
-						locked: false,
-					},
-				},
-				walletCommon.BaseMainnet: {
-					{
-						amount: big.NewInt(testAmount3ETHInWei),
-						locked: false,
-					},
-				},
-			},
-		},
-		{
-			name: "Transfer - All From Chain - No Locked Amount - Enough Token Balance If All Chains Are Used",
-			input: &requests.RouteInputParams{
-				TestnetMode: false,
-				Uuid:        uuid.NewString(),
-				SendType:    sendtype.Transfer,
-				AmountIn:    (*hexutil.Big)(big.NewInt(testAmount3ETHInWei + testAmount1ETHInWei)),
-				TokenID:     walletCommon.EthSymbol,
-
-				TestsMode: true,
-				TestParams: &requests.RouterTestParams{
-					TokenFrom: &tokenTypes.Token{
-						ChainID:  1,
-						Symbol:   walletCommon.EthSymbol,
-						Decimals: 18,
-					},
-					BalanceMap: map[string]*big.Int{
-						makeBalanceKey(walletCommon.EthereumMainnet, walletCommon.EthSymbol): big.NewInt(testAmount1ETHInWei),
-						makeBalanceKey(walletCommon.OptimismMainnet, walletCommon.EthSymbol): big.NewInt(testAmount1ETHInWei),
-						makeBalanceKey(walletCommon.ArbitrumMainnet, walletCommon.EthSymbol): big.NewInt(testAmount1ETHInWei),
-						makeBalanceKey(walletCommon.BaseMainnet, walletCommon.EthSymbol):     big.NewInt(testAmount1ETHInWei),
-					},
-				},
-			},
-			expectedAmountOptions: map[uint64][]amountOption{
-				walletCommon.OptimismMainnet: {
-					{
-						amount: big.NewInt(testAmount3ETHInWei + testAmount1ETHInWei),
-						locked: false,
-					},
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: false,
-					},
-				},
-				walletCommon.ArbitrumMainnet: {
-					{
-						amount: big.NewInt(testAmount3ETHInWei + testAmount1ETHInWei),
-						locked: false,
-					},
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: false,
-					},
-				},
-				walletCommon.EthereumMainnet: {
-					{
-						amount: big.NewInt(testAmount3ETHInWei + testAmount1ETHInWei),
-						locked: false,
-					},
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: false,
-					},
-				},
-				walletCommon.BaseMainnet: {
-					{
-						amount: big.NewInt(testAmount3ETHInWei + testAmount1ETHInWei),
-						locked: false,
-					},
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: false,
-					},
-				},
-			},
-		},
-		{
-			name: "Transfer - All From Chain - Locked Amount To Single Chain - Enough Token Balance If All Chains Are Used",
-			input: &requests.RouteInputParams{
-				TestnetMode: false,
-				Uuid:        uuid.NewString(),
-				SendType:    sendtype.Transfer,
-				AmountIn:    (*hexutil.Big)(big.NewInt(testAmount3ETHInWei)),
-				TokenID:     walletCommon.EthSymbol,
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.OptimismMainnet: (*hexutil.Big)(big.NewInt(testAmount0Point5ETHInWei)),
-				},
-
-				TestsMode: true,
-				TestParams: &requests.RouterTestParams{
-					TokenFrom: &tokenTypes.Token{
-						ChainID:  1,
-						Symbol:   walletCommon.EthSymbol,
-						Decimals: 18,
-					},
-					BalanceMap: map[string]*big.Int{
-						makeBalanceKey(walletCommon.EthereumMainnet, walletCommon.EthSymbol): big.NewInt(testAmount2ETHInWei),
-						makeBalanceKey(walletCommon.OptimismMainnet, walletCommon.EthSymbol): big.NewInt(testAmount1ETHInWei),
-						makeBalanceKey(walletCommon.ArbitrumMainnet, walletCommon.EthSymbol): big.NewInt(testAmount3ETHInWei),
-						makeBalanceKey(walletCommon.BaseMainnet, walletCommon.EthSymbol):     big.NewInt(testAmount3ETHInWei),
-					},
-				},
-			},
-			expectedAmountOptions: map[uint64][]amountOption{
-				walletCommon.OptimismMainnet: {
-					{
-						amount: big.NewInt(testAmount0Point5ETHInWei),
-						locked: true,
-					},
-				},
-				walletCommon.ArbitrumMainnet: {
-					{
-						amount: big.NewInt(testAmount2ETHInWei + testAmount0Point5ETHInWei),
-						locked: false,
-					},
-				},
-				walletCommon.EthereumMainnet: {
-					{
-						amount: big.NewInt(testAmount2ETHInWei + testAmount0Point5ETHInWei),
-						locked: false,
-					},
-					{
-						amount: big.NewInt(testAmount2ETHInWei),
-						locked: false,
-					},
-				},
-				walletCommon.BaseMainnet: {
-					{
-						amount: big.NewInt(testAmount0Point5ETHInWei),
-						locked: false,
-					},
-					{
-						amount: big.NewInt(testAmount2ETHInWei + testAmount0Point5ETHInWei),
-						locked: false,
-					},
-				},
-			},
-		},
-		{
-			name: "Transfer - All From Chain - Locked Amount To Multiple Chains - Enough Token Balance If All Chains Are Used",
-			input: &requests.RouteInputParams{
-				TestnetMode: false,
-				Uuid:        uuid.NewString(),
-				SendType:    sendtype.Transfer,
-				AmountIn:    (*hexutil.Big)(big.NewInt(testAmount3ETHInWei)),
-				TokenID:     walletCommon.EthSymbol,
-				FromLockedAmount: map[uint64]*hexutil.Big{
-					walletCommon.OptimismMainnet: (*hexutil.Big)(big.NewInt(testAmount0Point5ETHInWei)),
-					walletCommon.BaseMainnet:     (*hexutil.Big)(big.NewInt(testAmount0Point5ETHInWei)),
-					walletCommon.EthereumMainnet: (*hexutil.Big)(big.NewInt(testAmount1ETHInWei)),
-				},
-
-				TestsMode: true,
-				TestParams: &requests.RouterTestParams{
-					TokenFrom: &tokenTypes.Token{
-						ChainID:  1,
-						Symbol:   walletCommon.EthSymbol,
-						Decimals: 18,
-					},
-					BalanceMap: map[string]*big.Int{
-						makeBalanceKey(walletCommon.EthereumMainnet, walletCommon.EthSymbol): big.NewInt(testAmount2ETHInWei),
-						makeBalanceKey(walletCommon.OptimismMainnet, walletCommon.EthSymbol): big.NewInt(testAmount1ETHInWei),
-						makeBalanceKey(walletCommon.ArbitrumMainnet, walletCommon.EthSymbol): big.NewInt(testAmount3ETHInWei),
-						makeBalanceKey(walletCommon.BaseMainnet, walletCommon.EthSymbol):     big.NewInt(testAmount3ETHInWei),
-					},
-				},
-			},
-			expectedAmountOptions: map[uint64][]amountOption{
-				walletCommon.OptimismMainnet: {
-					{
-						amount: big.NewInt(testAmount0Point5ETHInWei),
-						locked: true,
-					},
-				},
-				walletCommon.BaseMainnet: {
-					{
-						amount: big.NewInt(testAmount0Point5ETHInWei),
-						locked: true,
-					},
-				},
-				walletCommon.ArbitrumMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: false,
-					},
-				},
-				walletCommon.EthereumMainnet: {
-					{
-						amount: big.NewInt(testAmount1ETHInWei),
-						locked: true,
-					},
-				},
-			},
-		},
-		{
-			name: "Transfer - All From Chain - No Locked Amount - Not Enough Token Balance",
-			input: &requests.RouteInputParams{
-				TestnetMode: false,
-				Uuid:        uuid.NewString(),
-				SendType:    sendtype.Transfer,
-				AmountIn:    (*hexutil.Big)(big.NewInt(testAmount5ETHInWei)),
-				TokenID:     walletCommon.EthSymbol,
-
-				TestsMode: true,
-				TestParams: &requests.RouterTestParams{
-					TokenFrom: &tokenTypes.Token{
-						ChainID:  1,
-						Symbol:   walletCommon.EthSymbol,
-						Decimals: 18,
-					},
-					BalanceMap: map[string]*big.Int{
-						makeBalanceKey(walletCommon.EthereumMainnet, walletCommon.EthSymbol): big.NewInt(testAmount1ETHInWei),
-						makeBalanceKey(walletCommon.OptimismMainnet, walletCommon.EthSymbol): big.NewInt(testAmount1ETHInWei),
-						makeBalanceKey(walletCommon.ArbitrumMainnet, walletCommon.EthSymbol): big.NewInt(testAmount1ETHInWei),
-						makeBalanceKey(walletCommon.BaseMainnet, walletCommon.EthSymbol):     big.NewInt(testAmount1ETHInWei),
-					},
-				},
-			},
-			expectedAmountOptions: map[uint64][]amountOption{
-				walletCommon.OptimismMainnet: {
-					{
-						amount: big.NewInt(testAmount5ETHInWei),
-						locked: false,
-					},
-				},
-				walletCommon.ArbitrumMainnet: {
-					{
-						amount: big.NewInt(testAmount5ETHInWei),
-						locked: false,
-					},
-				},
-				walletCommon.BaseMainnet: {
-					{
-						amount: big.NewInt(testAmount5ETHInWei),
-						locked: false,
-					},
-				},
-				walletCommon.EthereumMainnet: {
-					{
-						amount: big.NewInt(testAmount5ETHInWei),
-						locked: false,
-					},
 				},
 			},
 		},


### PR DESCRIPTION
The initial request for multi-tx was if the user enters an amount higher than the balance on each chain individually, the router algorithm should transparently send smaller amounts from different chains and transfer the entered amount. 

That's not a request anymore, since we're operating in a single-chain environment, there is no need for some additional calculations and an increase of time necessary for finding the best route by iterating over the list of frictional amounts. This PR removes that unnecessary loop from the resolving candidates process.