### PR TITLE
chore(stickers)!: cleaning up stickers service

### DIFF
--- a/services/stickers/pending.go
+++ b/services/stickers/pending.go
@@ -2,37 +2,7 @@ package stickers
 
 import (
 	"encoding/json"
-	"errors"
-	"math/big"
-
-	"github.com/status-im/status-go/multiaccounts/settings"
-	"github.com/status-im/status-go/services/wallet/bigint"
 )
-
-func (api *API) AddPending(chainID uint64, packID *bigint.BigInt) error {
-	pendingPacks, err := api.pendingStickerPacks()
-	if err != nil {
-		return err
-	}
-
-	if _, exists := pendingPacks[uint(packID.Uint64())]; exists {
-		return errors.New("sticker pack is already pending")
-	}
-
-	stickerType, err := api.contractMaker.NewStickerType(chainID)
-	if err != nil {
-		return err
-	}
-
-	stickerPack, err := api.fetchPackData(stickerType, packID.Int, false)
-	if err != nil {
-		return err
-	}
-
-	pendingPacks[uint(packID.Uint64())] = *stickerPack
-
-	return api.accountsDB.SaveSettingField(settings.StickersPacksPending, pendingPacks)
-}
 
 func (api *API) pendingStickerPacks() (StickerPackCollection, error) {
 	stickerPacks := make(StickerPackCollection)
@@ -72,62 +42,4 @@ func (api *API) Pending() (StickerPackCollection, error) {
 	}
 
 	return stickerPacks, nil
-}
-
-func (api *API) ProcessPending(chainID uint64) (pendingChanged StickerPackCollection, err error) {
-	pendingStickerPacks, err := api.pendingStickerPacks()
-	if err != nil {
-		return nil, err
-	}
-
-	accs, err := api.accountsDB.GetActiveAccounts()
-	if err != nil {
-		return nil, err
-	}
-
-	purchasedPacks := make(map[uint]struct{})
-	purchasedPackChan := make(chan *big.Int)
-	errChan := make(chan error)
-	doneChan := make(chan struct{}, 1)
-	go api.getAccountsPurchasedPack(chainID, accs, purchasedPackChan, errChan, doneChan)
-	for {
-		select {
-		case err := <-errChan:
-			if err != nil {
-				return nil, err
-			}
-		case packID := <-purchasedPackChan:
-			if packID != nil {
-				purchasedPacks[uint(packID.Uint64())] = struct{}{}
-			}
-		case <-doneChan:
-			result := make(StickerPackCollection)
-			for _, stickerPack := range pendingStickerPacks {
-				packID := uint(stickerPack.ID.Uint64())
-				if _, exists := purchasedPacks[packID]; !exists {
-					continue
-				}
-				delete(pendingStickerPacks, packID)
-				stickerPack.Status = statusPurchased
-				result[packID] = stickerPack
-			}
-			err = api.accountsDB.SaveSettingField(settings.StickersPacksPending, pendingStickerPacks)
-			return result, err
-		}
-	}
-}
-
-func (api *API) RemovePending(packID *bigint.BigInt) error {
-	pendingPacks, err := api.pendingStickerPacks()
-	if err != nil {
-		return err
-	}
-
-	if _, exists := pendingPacks[uint(packID.Uint64())]; !exists {
-		return nil
-	}
-
-	delete(pendingPacks, uint(packID.Uint64()))
-
-	return api.accountsDB.SaveSettingField(settings.StickersPacksPending, pendingPacks)
 }

--- a/services/stickers/transactions.go
+++ b/services/stickers/transactions.go
@@ -2,114 +2,11 @@ package stickers
 
 import (
 	"context"
-	"math/big"
-	"strings"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
-
-	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/status-im/status-go/contracts/snt"
 	"github.com/status-im/status-go/contracts/stickers"
-	"github.com/status-im/status-go/eth-node/types"
-	"github.com/status-im/status-go/services/wallet/bigint"
 )
-
-func (api *API) BuyPrepareTxCallMsg(chainID uint64, from types.Address, packID *bigint.BigInt) (ethereum.CallMsg, error) {
-	callOpts := &bind.CallOpts{Context: api.ctx, Pending: false}
-
-	stickerType, err := api.contractMaker.NewStickerType(chainID)
-	if err != nil {
-		return ethereum.CallMsg{}, err
-	}
-
-	packInfo, err := stickerType.GetPackData(callOpts, packID.Int)
-	if err != nil {
-		return ethereum.CallMsg{}, err
-	}
-
-	stickerMarketABI, err := abi.JSON(strings.NewReader(stickers.StickerMarketABI))
-	if err != nil {
-		return ethereum.CallMsg{}, err
-	}
-
-	extraData, err := stickerMarketABI.Pack("buyToken", packID.Int, from, packInfo.Price)
-	if err != nil {
-		return ethereum.CallMsg{}, err
-	}
-
-	sntABI, err := abi.JSON(strings.NewReader(snt.SNTABI))
-	if err != nil {
-		return ethereum.CallMsg{}, err
-	}
-
-	stickerMarketAddress, err := stickers.StickerMarketContractAddress(chainID)
-	if err != nil {
-		return ethereum.CallMsg{}, err
-	}
-
-	data, err := sntABI.Pack("approveAndCall", stickerMarketAddress, packInfo.Price, extraData)
-	if err != nil {
-		return ethereum.CallMsg{}, err
-	}
-
-	sntAddress, err := snt.ContractAddress(chainID)
-	if err != nil {
-		return ethereum.CallMsg{}, err
-	}
-
-	return ethereum.CallMsg{
-		From:  common.Address(from),
-		To:    &sntAddress,
-		Value: big.NewInt(0),
-		Data:  data,
-	}, nil
-}
-
-func (api *API) BuyPrepareTx(ctx context.Context, chainID uint64, from types.Address, packID *bigint.BigInt) (interface{}, error) {
-	callMsg, err := api.BuyPrepareTxCallMsg(chainID, from, packID)
-	if err != nil {
-		return nil, err
-	}
-
-	return toCallArg(callMsg), nil
-}
-
-func (api *API) BuyEstimate(ctx context.Context, chainID uint64, from types.Address, packID *bigint.BigInt) (uint64, error) {
-	callMsg, err := api.BuyPrepareTxCallMsg(chainID, from, packID)
-	if err != nil {
-		return 0, err
-	}
-	ethClient, err := api.contractMaker.RPCClient.EthClient(chainID)
-	if err != nil {
-		return 0, err
-	}
-
-	return ethClient.EstimateGas(ctx, callMsg)
-}
 
 func (api *API) StickerMarketAddress(ctx context.Context, chainID uint64) (common.Address, error) {
 	return stickers.StickerMarketContractAddress(chainID)
-}
-
-func toCallArg(msg ethereum.CallMsg) interface{} {
-	arg := map[string]interface{}{
-		"from": msg.From,
-		"to":   msg.To,
-	}
-	if len(msg.Data) > 0 {
-		arg["data"] = hexutil.Bytes(msg.Data)
-	}
-	if msg.Value != nil {
-		arg["value"] = (*hexutil.Big)(msg.Value)
-	}
-	if msg.Gas != 0 {
-		arg["gas"] = hexutil.Uint64(msg.Gas)
-	}
-	if msg.GasPrice != nil {
-		arg["gasPrice"] = (*hexutil.Big)(msg.GasPrice)
-	}
-	return arg
 }


### PR DESCRIPTION
The following unused endpoints of the stickers service are removed:
- stickers_addPending
- stickers_processPending
- stickers_removePending
- stickers_BuyPrepareTxCallMsg
- stickers_buyPrepareTx
- stickers_buyEstimate

@shivekkhurana even though you confirmed here https://discord.com/channels/1210237582470807632/1270072144067563520/1343991446319140884 please ensure that none of those endpoints is used by the mobile app.

Buying stickers is fully covered some time ago through the wallet router.