### PR TITLE
fix(identity)_: no need to double-check ENS and it should return an error

### DIFF
--- a/protocol/messenger_identity.go
+++ b/protocol/messenger_identity.go
@@ -26,7 +26,7 @@ func (m *Messenger) SetDisplayName(displayName string) error {
 		return err
 	}
 
-	if utils.IsENSName(displayName) || currDisplayName == displayName {
+	if currDisplayName == displayName {
 		return nil // Do nothing
 	}
 

--- a/protocol/messenger_identity_display_name_test.go
+++ b/protocol/messenger_identity_display_name_test.go
@@ -50,6 +50,10 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestDisplayNameChange() {
 	err = s.m.SetDisplayName(testDisplayName)
 	s.Require().NoError(err)
 
+	// set the same display name (should do nothing)
+	err = s.m.SetDisplayName(testDisplayName)
+	s.Require().NoError(err)
+
 	// check display name after change - mutliaccount
 	multiAcc, err := s.m.multiAccounts.GetAccount(s.m.account.KeyUID)
 	s.Require().NoError(err)
@@ -219,14 +223,23 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestDisplayNameRestrictions() 
 	s.Require().Equal("name with space", displayName)
 }
 
-func (s *MessengerProfileDisplayNameHandlerSuite) TestUpdateImageWhenEnsNameIsSet() {
-	err := s.m.settings.SaveSetting("preferred-name", "kounkou.stateofus.eth")
+func (s *MessengerProfileDisplayNameHandlerSuite) TestSaveAccountWhenEnsNameIsSet() {
+	// try to manually set display name to ens name (will fail)
+	err := s.m.SetDisplayName("godfrain.stateofus.eth")
+	s.Require().Error(err)
+
+	displayName, err := s.m.settings.DisplayName()
+	s.Require().NoError(err)
+	s.Require().NotEqual("godfrain.stateofus.eth", displayName)
+
+	// Set the preffered name to ens name (will work)
+	err = s.m.settings.SaveSetting("preferred-name", "godfrain.stateofus.eth")
 	s.Require().NoError(err)
 
-	// check display name for the created instance
-	displayName, err := s.m.settings.GetPreferredUsername()
+	// check preffered name for the created instance
+	displayName, err = s.m.settings.GetPreferredUsername()
 	s.Require().NoError(err)
-	s.Require().Equal("kounkou.stateofus.eth", displayName)
+	s.Require().Equal("godfrain.stateofus.eth", displayName)
 
 	// add profile keypair
 	profileKp := accounts.GetProfileKeypairForTest(true, false, false)
@@ -244,9 +257,5 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestUpdateImageWhenEnsNameIsSe
 
 	// save account will create the account
 	err = s.m.multiAccounts.SaveAccount(*s.m.account)
-	s.Require().NoError(err)
-
-	// set new description
-	err = s.m.SetDisplayName("godfrain.stateofus.eth")
 	s.Require().NoError(err)
 }


### PR DESCRIPTION
Potentially fixes https://github.com/status-im/status-desktop/issues/16224

This condition is already being checked by `ValidateDisplayName` just below. The fact that we check it early and return without an error when we try to set an ENS can lead to an false state where the settings get modified from the client by accident.

In theory, this shouldn't affect anything, but we have this code block in Desktop:
```nim
proc setDisplayName*(self: Service, displayName: string): bool =
    try:
      let response = status_accounts.setDisplayName(displayName)
      if not response.error.isNil:
        error "could not set display name"
        return false
      if not self.settingsService.saveDisplayName(displayName):
        error "could not save display name to the settings"
        return false
      return true
    except Exception as e:
      error "error: ", procName="setDisplayName", errName = e.name, errDesription = e.msg
      return false
```

In this code, we try to change the DisplayName, and if there is no error, we change the setting. This is where the problem can happen. The setting should **not** be changed if it is an ENS name. The first call didn't update the display name, but it also didn't return an error, so the setting would be changed still.

I'm still unsure if that's exactly why the bug happens, but it does seem like a culprit. In theory, the UI side validation should have caught it, but we need to rely on all the validation we can.