### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/multiaccounts/accounts/database.go
+++ b/multiaccounts/accounts/database.go
@@ -1696,10 +1696,7 @@ func (db *Database) resolveNumOfAddressesToGenerate(keypair *Keypair) uint64 {
 	}
 
 	final := numOfGeneratedAddressesKeycardKeypair + keypair.LastUsedDerivationIndex
-	if final < maxNumOfGeneratedAddresses {
-		return final
-	}
-	return maxNumOfGeneratedAddresses
+	return min(maxNumOfGeneratedAddresses, final)
 }
 
 func (db *Database) GetNumOfAddressesToGenerateForKeypair(keyUID string) (uint64, error) {

--- a/protocol/communities/community_bloom_filter.go
+++ b/protocol/communities/community_bloom_filter.go
@@ -44,13 +44,6 @@ func nextPowerOfTwo(x int) uint {
 	return 1 << bits.Len(uint(x))
 }
 
-func max(x, y uint) uint {
-	if x > y {
-		return x
-	}
-	return y
-}
-
 func generateBloomFilter(members map[string]*protobuf.CommunityMember, privateKey *ecdsa.PrivateKey, channelID string, clock uint64) (*bloom.BloomFilter, error) {
 	membersCount := len(members)
 	if membersCount == 0 {


### PR DESCRIPTION
Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max