### PR TITLE
feat(rss)_: implement a basic RSS fetching and polling manager

### DIFF
--- a/internal/newsfeed/new_feed_manager_test.go
+++ b/internal/newsfeed/new_feed_manager_test.go
@@ -1,0 +1,110 @@
+package newsfeed
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mmcdole/gofeed"
+	"github.com/stretchr/testify/suite"
+)
+
+type NewsFeedManagerSuite struct {
+	suite.Suite
+}
+
+type MockParser struct {
+	Feed *gofeed.Feed
+	Err  error
+}
+
+func (mp *MockParser) ParseURL(url string) (*gofeed.Feed, error) {
+	return mp.Feed, mp.Err
+}
+
+type MockHandler struct {
+	callback func(item *gofeed.Item)
+}
+
+func (mh *MockHandler) HandleFeed(item *gofeed.Item) {
+	mh.callback(item)
+}
+
+func TestNewsFeedManagerSuite(t *testing.T) {
+	suite.Run(t, new(NewsFeedManagerSuite))
+}
+
+func ptrTime(t time.Time) *time.Time {
+	return &t
+}
+
+func (s *NewsFeedManagerSuite) TestFetchOnlyItemNewerThanTwoHours() {
+	now := time.Now()
+	items := []*gofeed.Item{
+		{Title: "Old Item", PublishedParsed: ptrTime(now.Add(-48 * time.Hour))},
+		{Title: "New Item", PublishedParsed: ptrTime(now.Add(-1 * time.Hour))},
+	}
+	mockFeed := &gofeed.Feed{
+		Title: "Test Feed",
+		Items: items,
+	}
+	captured := []*gofeed.Item{}
+
+	myCallback := func(item *gofeed.Item) {
+		captured = append(captured, item)
+	}
+
+	twoHoursAgo := now.Add(-2 * time.Hour)
+
+	newsFeedManager := NewNewsFeedManager(
+		WithURL("mock-url"),
+		WithParser(&MockParser{Feed: mockFeed}),
+		WithHandler(&MockHandler{callback: myCallback}),
+		WithPollingInterval(60*time.Second),
+		WithFetchFrom(twoHoursAgo),
+	)
+
+	err := newsFeedManager.fetchRSS()
+	s.Require().NoError(err)
+
+	s.Require().Len(captured, 1)
+	s.Require().Equal("New Item", captured[0].Title)
+}
+
+func (s *NewsFeedManagerSuite) TestStartAndStopFetching() {
+	now := time.Now()
+	items := []*gofeed.Item{
+		{Title: "Old Item", PublishedParsed: ptrTime(now.Add(-48 * time.Hour))},
+		{Title: "New Item", PublishedParsed: ptrTime(now.Add(-1 * time.Hour))},
+	}
+	mockFeed := &gofeed.Feed{
+		Title: "Test Feed",
+		Items: items,
+	}
+	captured := []*gofeed.Item{}
+
+	myCallback := func(item *gofeed.Item) {
+		captured = append(captured, item)
+	}
+
+	twoHoursAgo := now.Add(-2 * time.Hour)
+
+	newsFeedManager := NewNewsFeedManager(
+		WithURL("mock-url"),
+		WithParser(&MockParser{Feed: mockFeed}),
+		WithHandler(&MockHandler{callback: myCallback}),
+		WithPollingInterval(60*time.Second),
+		WithFetchFrom(twoHoursAgo),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	newsFeedManager.StartFetching(ctx)
+
+	// The start fetching does an initial fetch immediately
+	s.Require().Len(captured, 1)
+	s.Require().Equal("New Item", captured[0].Title)
+
+	newsFeedManager.StopFetching()
+}

--- a/internal/newsfeed/news_feed_manager.go
+++ b/internal/newsfeed/news_feed_manager.go
@@ -1,0 +1,127 @@
+package newsfeed
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/mmcdole/gofeed"
+
+	gocommon "github.com/status-im/status-go/common"
+)
+
+// TODO replace with the real Status feed URL
+const STATUS_FEED_URL = "https://hnrss.org/frontpage"
+
+type FeedParser interface {
+	ParseURL(url string) (*gofeed.Feed, error)
+}
+
+type FeedHandler interface {
+	HandleFeed(item *gofeed.Item)
+}
+
+type NewsFeedManager struct {
+	url             string
+	parser          FeedParser
+	handler         FeedHandler
+	fetchFrom       time.Time
+	pollingInterval time.Duration
+	cancel          context.CancelFunc
+}
+
+type Option func(*NewsFeedManager)
+
+func WithURL(url string) Option {
+	return func(nfm *NewsFeedManager) {
+		nfm.url = url
+	}
+}
+
+func WithParser(parser FeedParser) Option {
+	return func(nfm *NewsFeedManager) {
+		nfm.parser = parser
+	}
+}
+
+func WithHandler(handler FeedHandler) Option {
+	return func(nfm *NewsFeedManager) {
+		nfm.handler = handler
+	}
+}
+
+func WithPollingInterval(interval time.Duration) Option {
+	return func(nfm *NewsFeedManager) {
+		nfm.pollingInterval = interval
+	}
+}
+
+func WithFetchFrom(t time.Time) Option {
+	return func(nfm *NewsFeedManager) {
+		nfm.fetchFrom = t
+	}
+}
+
+func NewNewsFeedManager(opts ...Option) *NewsFeedManager {
+	nfm := &NewsFeedManager{
+		pollingInterval: time.Minute * 30,
+		fetchFrom:       time.Now(),
+	}
+
+	for _, opt := range opts {
+		opt(nfm)
+	}
+
+	return nfm
+}
+
+func (n *NewsFeedManager) fetchRSS() error {
+	feed, err := n.parser.ParseURL(n.url)
+	if err != nil {
+		fmt.Println("Error fetching feed:", err)
+		return err
+	}
+
+	fmt.Println("Feed Title:", feed.Title)
+	for _, item := range feed.Items {
+		if item.PublishedParsed != nil && item.PublishedParsed.After(n.fetchFrom) {
+			fmt.Printf("NEW ITEM:\n  Title: %s\n  Link: %s\n  Published: %s\n\n",
+				item.Title, item.Link, item.PublishedParsed)
+			n.handler.HandleFeed(item)
+		}
+	}
+
+	// Update fetchFrom to now
+	n.fetchFrom = time.Now()
+
+	return nil
+}
+
+func (n *NewsFeedManager) StartFetching(ctx context.Context) {
+	// Derive the given context, save the CancelFunc
+	ctx, n.cancel = context.WithCancel(ctx)
+
+	// Initial fetch
+	_ = n.fetchRSS()
+
+	ticker := time.NewTicker(n.pollingInterval)
+
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				_ = n.fetchRSS()
+			case <-ctx.Done():
+				// TODO use logger
+				fmt.Println("Polling stopped for:", n.url)
+				return
+			}
+		}
+	}()
+}
+
+func (n *NewsFeedManager) StopFetching() {
+	n.cancel()
+}

--- a/protocol/common/feature_flags.go
+++ b/protocol/common/feature_flags.go
@@ -32,4 +32,7 @@ type FeatureFlags struct {
 
 	// EnableMercuryoProvider indicates whether we should enable the Mercuryo provider in the Wallet
 	EnableMercuryoProvider bool
+
+	// EnableNewsFeed indicates whether we should enable the News Feed polling (this is not the user setting)
+	EnableNewsFeed bool
 }

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -427,3 +427,10 @@ func WithAccountsFeed(feed *event.Feed) Option {
 		return nil
 	}
 }
+
+func WithNewsFeed() func(c *config) error {
+	return func(c *config) error {
+		c.featureFlags.EnableNewsFeed = true
+		return nil
+	}
+}

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -433,6 +433,8 @@ func buildMessengerOptions(
 		protocol.WithWakuService(wakuService),
 		protocol.WithAccountManager(accountManager),
 		protocol.WithAccountsFeed(accountsFeed),
+		// TODO uncomment this to enable the news feed in dev
+		// protocol.WithNewsFeed(),
 	}
 
 	if config.ShhextConfig.DataSyncEnabled {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-go/issues/6479 and https://github.com/status-im/status-go/issues/6478

Implements a basic manager for getting an RSS feed. It fetches and polls it.

~~I still need to pass it a callback so that we can generate AC notifications.~~
~~I also want to mock the RSS feed in the tests before merging.~~
Done.

Otherwise, the remaining TODOs will be fixed in other PRs/issues (see the Epic).

~~I had to install `gofeed` and it somehow modified a lot of files, I'm not sure if it's normal, please let me know. Also, you should probably review by commit~~

edit: I created a new PR just for the go-feed install as @igor-sirotin suggested. You can find it here: https://github.com/status-im/status-go/pull/6501
It should be easier to review now