### PR TITLE
test_: option to use custom waku fleet

### DIFF
--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -41,6 +41,21 @@ Functional tests for status-go
 * In `./tests-functional/tests` directory run `pytest -m rpc`
 * To run tests against binary run `pytest -m <your mark> --status_backend_url=http://<binary_url>:<binary_port>`
 
+### Options
+
+#### Running with a custom Waku fleet
+
+By default, `status-backend` will use a hard-coded list of supported fleets, and select `status.prod` by default. Functional tests provide 2 options to ask status-go to use a different Waku fleet.
+
+- Use `--waku-fleets-config` to override the list of supported fleets. \
+    The value will be passed to `InitializeApplication.wakuFleetsConfigFilePath` parameter. 
+- Use `--waku-fleet` to select a Waku fleet to be used by `status-go`. \
+    The value will be passed to all of these parameters:
+    - `CreateAccount.wakuV2Fleet`
+    - `RestoreAccount.wakuV2Fleet`
+
+Please refer to the description of these parameters in `stauts-go` for details.
+
 ### Prerequisites for Mac OSx users
 If you see errors at attempt to run tests, try to run in terminal:
 ```shell

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -190,6 +190,7 @@ class StatusBackend(RpcClient, SignalClient):
             "logEnabled": True,
             "logLevel": "DEBUG",
             "apiLogging": True,
+            "wakuFleetsConfigFilePath": option.waku_fleets_config,
         }
         return self.api_valid_request(method, data)
 
@@ -286,7 +287,9 @@ class StatusBackend(RpcClient, SignalClient):
             # Logs config
             "logEnabled": True,
             "logLevel": "DEBUG",
+            # Waku config
             "wakuV2LightClient": kwargs.get("wakuV2LightClient", False),
+            "wakuV2Fleet": option.waku_fleet,
         }
         self._set_networks(data, **kwargs)
         data = self._set_proxy_credentials(data)

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -41,6 +41,18 @@ def pytest_addoption(parser):
         help="When set, will automatically call Logout() before InitializeApplication()",
         default=False,
     )
+    parser.addoption(
+        "--waku-fleets-config",
+        action="store",
+        help="Path to a local JSON file with Waku fleets configuration",
+        default=None,
+    )
+    parser.addoption(
+        "--waku-fleet",
+        action="store",
+        help="Waku fleet to be used",
+        default=None,
+    )
 
 
 @dataclass
@@ -86,6 +98,13 @@ def pytest_configure(config):
 
     option.base_dir = os.path.dirname(os.path.abspath(__file__))  # schemas directory
     option.status_backend_urls = status_backend_url_generator(config)
+
+
+def pytest_report_header(config):
+    return [
+        f"waku fleets config file: {option.waku_fleets_config}",
+        f"waku fleet: {option.waku_fleet}",
+    ]
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -102,8 +102,8 @@ def pytest_configure(config):
 
 def pytest_report_header(config):
     return [
-        f"waku fleets config file: {option.waku_fleets_config}",
-        f"waku fleet: {option.waku_fleet}",
+        f"waku fleets config file: {config.option.waku_fleets_config}",
+        f"waku fleet: {config.option.waku_fleet}",
     ]
 
 


### PR DESCRIPTION
Requires https://github.com/status-im/status-go/pull/6414

# Description

Adds options to run _functional tests_ with certain Waku fleet and ability to instruct status-go to use custom fleets:
- https://github.com/status-im/status-go/blob/2f0a6239959e864151fe46e8277b50861cda27c7/tests-functional/conftest.py#L45-L47 
- https://github.com/status-im/status-go/blob/2f0a6239959e864151fe46e8277b50861cda27c7/tests-functional/conftest.py#L51-L53