### PR TITLE
fix(health-manager)_: fix nil healthmanager in copied rpc client

### DIFF
--- a/healthmanager/providers_health_manager.go
+++ b/healthmanager/providers_health_manager.go
@@ -29,13 +29,13 @@ func NewProvidersHealthManager(chainID uint64) *ProvidersHealthManager {
 }
 
 // Update processes a batch of provider call statuses, updates the aggregated status, and emits chain status changes if necessary.
-func (p *ProvidersHealthManager) Update(ctx context.Context, callStatuses []rpcstatus.RpcProviderCallStatus) {
+func (p *ProvidersHealthManager) doUpdate(callStatuses []rpcstatus.RpcProviderCallStatus) (shouldEmit bool, newStatus rpcstatus.ProviderStatus) {
 	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	// Check if aggregator is nil
 	if p.aggregator == nil {
-		p.mu.Unlock()
-		return
+		return false, rpcstatus.ProviderStatus{}
 	}
 
 	// Update the aggregator with the new provider statuses
@@ -44,16 +44,20 @@ func (p *ProvidersHealthManager) Update(ctx context.Context, callStatuses []rpcs
 		p.aggregator.Update(providerStatus)
 	}
 
-	newStatus := p.aggregator.GetAggregatedStatus()
+	newStatus = p.aggregator.GetAggregatedStatus()
+	shouldEmit = p.lastStatus == nil || p.lastStatus.Status != newStatus.Status
+	return
+}
 
-	shouldEmit := p.lastStatus == nil || p.lastStatus.Status != newStatus.Status
-	p.mu.Unlock()
-
+// Update processes a batch of provider call statuses, updates the aggregated status, and emits chain status changes if necessary.
+func (p *ProvidersHealthManager) Update(ctx context.Context, callStatuses []rpcstatus.RpcProviderCallStatus) {
+	shouldEmit, newStatus := p.doUpdate(callStatuses)
 	if !shouldEmit {
 		return
 	}
 
 	p.emitChainStatus(ctx)
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.lastStatus = &newStatus

--- a/healthmanager/providers_health_manager.go
+++ b/healthmanager/providers_health_manager.go
@@ -32,6 +32,12 @@ func NewProvidersHealthManager(chainID uint64) *ProvidersHealthManager {
 func (p *ProvidersHealthManager) Update(ctx context.Context, callStatuses []rpcstatus.RpcProviderCallStatus) {
 	p.mu.Lock()
 
+	// Check if aggregator is nil
+	if p.aggregator == nil {
+		p.mu.Unlock()
+		return
+	}
+
 	// Update the aggregator with the new provider statuses
 	for _, rpcCallStatus := range callStatuses {
 		providerStatus := rpcstatus.NewRpcProviderStatus(rpcCallStatus)
@@ -74,7 +80,9 @@ func (p *ProvidersHealthManager) Unsubscribe(ch chan struct{}) {
 func (p *ProvidersHealthManager) Reset() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.aggregator = aggregator.NewAggregator(fmt.Sprintf("%d", p.chainID))
+	newAgg := aggregator.NewAggregator(fmt.Sprintf("%d", p.chainID))
+	p.aggregator = newAgg
+	p.lastStatus = nil
 }
 
 // Status returns the current aggregated status.
@@ -91,5 +99,8 @@ func (p *ProvidersHealthManager) ChainID() uint64 {
 
 // emitChainStatus sends a notification to all subscribers.
 func (p *ProvidersHealthManager) emitChainStatus(ctx context.Context) {
+	if p.subscriptionManager == nil {
+		return
+	}
 	p.subscriptionManager.Emit(ctx)
 }

--- a/healthmanager/providers_health_manager_test.go
+++ b/healthmanager/providers_health_manager_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/healthmanager/aggregator"
 	"github.com/status-im/status-go/healthmanager/rpcstatus"
 )
 
@@ -182,6 +183,43 @@ func (s *ProvidersHealthManagerSuite) TestConcurrency() {
 
 	chainStatus := s.phm.Status().Status
 	s.Equal(chainStatus, rpcstatus.StatusUp, "Expected chain status to be either Up or Down")
+}
+
+// TestPanicWithNilAggregator tests that Update handles nil aggregator without panicking
+// (refs https://github.com/status-im/status-go/issues/6462)
+func (s *ProvidersHealthManagerSuite) TestPanicWithNilAggregator() {
+	// Create ProvidersHealthManager with nil aggregator for testing
+	phm := &ProvidersHealthManager{
+		chainID:             1,
+		aggregator:          nil, // Explicitly set to nil
+		subscriptionManager: NewSubscriptionManager(),
+	}
+
+	// Test data
+	callStatuses := []rpcstatus.RpcProviderCallStatus{
+		{Name: "Provider1", Timestamp: time.Now(), Err: nil},
+	}
+
+	// Call should not panic due to our nil check
+	s.NotPanics(func() {
+		phm.Update(context.Background(), callStatuses)
+	}, "Update should not panic with nil aggregator thanks to nil check")
+}
+
+// TestPanicWithNilSubscriptionManager tests that emitChainStatus handles nil subscriptionManager without panicking
+// (refs https://github.com/status-im/status-go/issues/6462)
+func (s *ProvidersHealthManagerSuite) TestPanicWithNilSubscriptionManager() {
+	// Create ProvidersHealthManager with nil subscriptionManager for testing
+	phm := &ProvidersHealthManager{
+		chainID:             1,
+		aggregator:          aggregator.NewAggregator("1"),
+		subscriptionManager: nil, // Explicitly set to nil
+	}
+
+	// Call should not panic due to our nil check
+	s.NotPanics(func() {
+		phm.emitChainStatus(context.Background())
+	}, "emitChainStatus should not panic with nil subscriptionManager thanks to nil check")
 }
 
 func TestProvidersHealthManagerSuite(t *testing.T) {

--- a/healthmanager/providers_health_manager_test.go
+++ b/healthmanager/providers_health_manager_test.go
@@ -222,6 +222,46 @@ func (s *ProvidersHealthManagerSuite) TestPanicWithNilSubscriptionManager() {
 	}, "emitChainStatus should not panic with nil subscriptionManager thanks to nil check")
 }
 
+// TestReset verifies that Reset sets lastStatus to nil and creates a new aggregator
+func (s *ProvidersHealthManagerSuite) TestReset() {
+	// First, update the providers to establish a known state
+	ch := s.phm.Subscribe()
+	defer s.phm.Unsubscribe(ch)
+
+	// Update provider to Up and wait for notification
+	upStatuses := []rpcstatus.RpcProviderCallStatus{
+		{Name: "Provider1", Timestamp: time.Now(), Err: nil},
+	}
+	s.updateAndWait(ch, upStatuses, rpcstatus.StatusUp, time.Second)
+
+	// Verify providers are in statuses
+	statusesBeforeReset := s.phm.GetStatuses()
+	s.Len(statusesBeforeReset, 1, "Expected 1 provider status before reset")
+	s.Contains(statusesBeforeReset, "Provider1", "Expected Provider1 in statuses before reset")
+
+	// Capture the aggregator and lastStatus references before reset
+	originalAggregator := s.phm.aggregator
+
+	// Access the lastStatus field directly
+	s.NotNil(s.phm.lastStatus, "lastStatus should not be nil before reset")
+
+	// Reset the providers health manager
+	s.phm.Reset()
+
+	// Verify lastStatus is nil
+	s.Nil(s.phm.lastStatus, "lastStatus should be nil after reset")
+
+	// Verify aggregator was recreated (different instance)
+	s.NotSame(originalAggregator, s.phm.aggregator, "Aggregator should be a new instance after reset")
+
+	// Verify statuses are cleared
+	statusesAfterReset := s.phm.GetStatuses()
+	s.Empty(statusesAfterReset, "Expected no provider statuses after reset")
+
+	// Verify chain ID remains the same
+	s.Equal(uint64(1), s.phm.ChainID(), "Chain ID should remain unchanged after reset")
+}
+
 func TestProvidersHealthManagerSuite(t *testing.T) {
 	suite.Run(t, new(ProvidersHealthManagerSuite))
 }

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -84,15 +84,16 @@ type ClientWithFallback struct {
 
 func (c *ClientWithFallback) Copy() interface{} {
 	return &ClientWithFallback{
-		ChainID:        c.ChainID,
-		ethClients:     c.ethClients,
-		commonLimiter:  c.commonLimiter,
-		circuitbreaker: c.circuitbreaker,
-		WalletNotifier: c.WalletNotifier,
-		isConnected:    c.isConnected,
-		LastCheckedAt:  c.LastCheckedAt,
-		tag:            c.tag,
-		groupTag:       c.groupTag,
+		ChainID:                c.ChainID,
+		ethClients:             c.ethClients,
+		commonLimiter:          c.commonLimiter,
+		circuitbreaker:         c.circuitbreaker,
+		providersHealthManager: c.providersHealthManager,
+		WalletNotifier:         c.WalletNotifier,
+		isConnected:            c.isConnected,
+		LastCheckedAt:          c.LastCheckedAt,
+		tag:                    c.tag,
+		groupTag:               c.groupTag,
 	}
 }
 


### PR DESCRIPTION
Issue from Sentry: https://sentry.infra.status.im/organizations/sentry/issues/161/events/3db6b31551c5474ea45d2b9069c61a19/?project=7


The identified root cause of the panics was likely related to improper copying in the ClientWithFallback implementation. The Copy() method was not properly copying the providersHealthManager field:

* Fixes Copy method in ClientWithFallback to properly include the providersHealthManager field
* Updates tests to verify nil handling rather than expecting panics

Closes #6462