### PR TITLE
fix(wallet)_: appropriately update the gas amount if "non-custom" option is chosen after a "custom" one

### DIFF
--- a/services/wallet/router/router_helper.go
+++ b/services/wallet/router/router_helper.go
@@ -189,13 +189,17 @@ func (r *Router) applyCustomFields(ctx context.Context, path *routes.Path, fetch
 		}
 	}
 
+	// set appropriate gas amount and update later in this function if custom gas amount is provided
+	path.TxGasAmount = path.SuggestedTxGasAmount
+	path.ApprovalGasAmount = path.SuggestedApprovalGasAmount
+
 	// set appropriate nonce/s, and update later in this function if custom nonce/s are provided
 	err := r.resolveNonceForPath(ctx, path, r.lastInputParams.AddrFrom, usedNonces)
 	if err != nil {
 		return err
 	}
 
-	if r.lastInputParams.PathTxCustomParams == nil || len(r.lastInputParams.PathTxCustomParams) == 0 {
+	if len(r.lastInputParams.PathTxCustomParams) == 0 {
 		// if no custom params are provided, use the initial fee mode
 		maxFeesPerGas, priorityFee, estimatedTime, err := fetchedFees.FeeFor(r.lastInputParams.GasFeeMode)
 		if err != nil {


### PR DESCRIPTION
Closes #6490

To the mobile team: 
Whoever takes handling this one on the client side should use `suggestedApprovalGasAmount` and `suggestedTxGasAmount` for normal, fast, urgent fee calculation instead of `approvalGasAmount` and `txGasAmount`.

The desktop PR with attached recording with these changes included is here:
- https://github.com/status-im/status-desktop/pull/17702