### PR TITLE
docs_: code owners policy

### DIFF
--- a/_docs/policies/codeowners.md
+++ b/_docs/policies/codeowners.md
@@ -21,7 +21,8 @@ reviewing and maintaining code in the `status-go` repository.
   - Any CC MAY nominate themselves as a code owner for any part of the existing code.
   - Nominations SHOULD be discussed and agreed upon with other CCs if there are overlaps or concerns.
 - For **new** code:
-  - When introducing a new file/module, CCs SHOULD assign themselves or another CC as a code owner for this file/module. 
+  - When introducing a new module or substantial new component, CCs SHOULD assign ownership.
+  - File-level ownership MAY be used where appropriate but is not required.
 
 ### Pull Request Reviews
 

--- a/_docs/policies/codeowners.md
+++ b/_docs/policies/codeowners.md
@@ -1,0 +1,28 @@
+# Code Owners Policy
+
+### Purpose
+
+This policy outlines how code ownership is assigned and ensures that core contributors (CCs) are accountable for 
+reviewing and maintaining code in the `status-go` repository.
+
+### Code Owners File
+
+- Code owners MUST be stored in the `.github/CODEOWNERS` file, as per GitHub's [CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+
+### Assigning Code Ownership
+
+1. Eligibility
+ 
+- Only CCs MAY be code owners. External contributors are not eligible to be code owners.
+
+2. Nomination
+ 
+- For **existing** code:
+  - Any CC MAY nominate themselves as a code owner for any part of the existing code.
+  - Nominations SHOULD be discussed and agreed upon with other CCs if there are overlaps or concerns.
+- For **new** code:
+  - When introducing a new file/module, CCs SHOULD assign themselves or another CC as a code owner for this file/module. 
+
+### Pull Request Reviews
+
+- At least one of the code owners for the affected files MUST review a PR for it to be eligible for merging.

--- a/_docs/policies/codeowners.md
+++ b/_docs/policies/codeowners.md
@@ -19,7 +19,7 @@ reviewing and maintaining code in the `status-go` repository.
  
 - For **existing** code:
   - Any CC MAY nominate themselves as a code owner for any part of the existing code.
-  - Nominations SHOULD be discussed and agreed upon with other CCs if there are overlaps or concerns.
+  - Nominations SHOULD be discussed and agreed upon with other CCs to prevent and address overlaps or concerns.
 - For **new** code:
   - When introducing a new module or substantial new component, CCs SHOULD assign ownership.
   - File-level ownership MAY be used where appropriate but is not required.
@@ -27,5 +27,5 @@ reviewing and maintaining code in the `status-go` repository.
 ### Pull Request Reviews
 
 - At least one of the code owners for the affected files MUST review a PR for it to be eligible for merging.
-- If a code owner is unresponsive within a reasonable timeframe, another CC from the relevant area MAY approve 
+- If a code owner is unresponsive within a reasonable timeframe, another CC from the relevant area may approve 
 the PR in their place.

--- a/_docs/policies/codeowners.md
+++ b/_docs/policies/codeowners.md
@@ -27,3 +27,5 @@ reviewing and maintaining code in the `status-go` repository.
 ### Pull Request Reviews
 
 - At least one of the code owners for the affected files MUST review a PR for it to be eligible for merging.
+- If a code owner is unresponsive within a reasonable timeframe, another CC from the relevant area MAY approve 
+the PR in their place.


### PR DESCRIPTION
# Description

Added a simple code owners policy.
It's quite simple, as in general we should follow common practices.

# TLDR;

1. REQUIRE code owners review on PR level.
2. Any CC may nominate somebody for code owners. 

Let's spread this practice.