### PR TITLE
fix_: remove duplicated waku metric for peer count

### DIFF
--- a/metrics/wakumetrics/client.go
+++ b/metrics/wakumetrics/client.go
@@ -97,7 +97,7 @@ func (c *Client) PushErrorSendingEnvelope(errorSendingEnvelope wakuv2.ErrorSendi
 }
 
 func (c *Client) PushPeerCount(peerCount int) {
-	metrics.ConnectedPeers.Set(float64(peerCount))
+	metrics.ConnectedPeerCount.Set(float64(peerCount))
 }
 
 func (c *Client) PushPeerConnFailures(peerConnFailures map[string]int) {

--- a/metrics/wakumetrics/client.go
+++ b/metrics/wakumetrics/client.go
@@ -96,10 +96,6 @@ func (c *Client) PushErrorSendingEnvelope(errorSendingEnvelope wakuv2.ErrorSendi
 	).Inc()
 }
 
-func (c *Client) PushPeerCount(peerCount int) {
-	metrics.ConnectedPeerCount.Set(float64(peerCount))
-}
-
 func (c *Client) PushPeerConnFailures(peerConnFailures map[string]int) {
 	for peerID, failures := range peerConnFailures {
 		if lastFailures, exists := c.lastPeerConnFailures[peerID]; exists {

--- a/metrics/wakumetrics/client_test.go
+++ b/metrics/wakumetrics/client_test.go
@@ -107,14 +107,6 @@ func TestClient_PushReceivedMessages(t *testing.T) {
 	require.Equal(t, float64(1), value)
 }
 
-func TestClient_PushPeerCount(t *testing.T) {
-	client := createTestClient(t)
-
-	client.PushPeerCount(5)
-	value := getGaugeValue(metrics.ConnectedPeerCount)
-	require.Equal(t, float64(5), value)
-}
-
 func TestClient_PushPeerCountByOrigin(t *testing.T) {
 	client := createTestClient(t)
 

--- a/metrics/wakumetrics/client_test.go
+++ b/metrics/wakumetrics/client_test.go
@@ -111,7 +111,7 @@ func TestClient_PushPeerCount(t *testing.T) {
 	client := createTestClient(t)
 
 	client.PushPeerCount(5)
-	value := getGaugeValue(metrics.ConnectedPeers)
+	value := getGaugeValue(metrics.ConnectedPeerCount)
 	require.Equal(t, float64(5), value)
 }
 

--- a/metrics/wakumetrics/client_test.go
+++ b/metrics/wakumetrics/client_test.go
@@ -55,15 +55,6 @@ func getCounterValue(metric *prometheus.CounterVec, labels ...string) float64 {
 	return pb.Counter.GetValue()
 }
 
-func getGaugeValue(metric prometheus.Gauge) float64 {
-	pb := &dto.Metric{}
-	err := metric.(prometheus.Metric).Write(pb)
-	if err != nil {
-		return 0
-	}
-	return pb.Gauge.GetValue()
-}
-
 func getGaugeVecValue(metric *prometheus.GaugeVec, labels ...string) float64 {
 	m := metric.WithLabelValues(labels...)
 	pb := &dto.Metric{}

--- a/metrics/wakumetrics/metrics.go
+++ b/metrics/wakumetrics/metrics.go
@@ -17,7 +17,7 @@ type MetricsCollection struct {
 	PeerConnectionFailures       prometheus.Counter
 	StoreQuerySuccesses          prometheus.Counter
 	StoreQueryFailures           prometheus.Counter
-	ConnectedPeers               prometheus.Gauge
+	ConnectedPeerCount           prometheus.Gauge
 	PeersByOrigin                *prometheus.GaugeVec
 	PeersByShard                 *prometheus.GaugeVec
 	RawMessagesSizeBytes         *prometheus.CounterVec
@@ -72,9 +72,9 @@ var metrics = MetricsCollection{
 		},
 	),
 
-	ConnectedPeers: prometheus.NewGauge(
+	ConnectedPeerCount: prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "waku_connected_peers",
+			Name: "waku_connected_peer_count",
 			Help: "Current number of peers connected",
 		},
 	),
@@ -163,7 +163,7 @@ var collectors = []prometheus.Collector{
 	metrics.WakuMessagesSizeBytes,
 	metrics.EnvelopeSentErrors,
 	metrics.MessageDeliveryConfirmations,
-	metrics.ConnectedPeers,
+	metrics.ConnectedPeerCount,
 	metrics.PeersByOrigin,
 	metrics.PeersByShard,
 	metrics.PeerConnectionFailures,

--- a/metrics/wakumetrics/metrics.go
+++ b/metrics/wakumetrics/metrics.go
@@ -17,7 +17,6 @@ type MetricsCollection struct {
 	PeerConnectionFailures       prometheus.Counter
 	StoreQuerySuccesses          prometheus.Counter
 	StoreQueryFailures           prometheus.Counter
-	ConnectedPeerCount           prometheus.Gauge
 	PeersByOrigin                *prometheus.GaugeVec
 	PeersByShard                 *prometheus.GaugeVec
 	RawMessagesSizeBytes         *prometheus.CounterVec
@@ -69,13 +68,6 @@ var metrics = MetricsCollection{
 		prometheus.CounterOpts{
 			Name: "waku_message_delivery_confirmations_total",
 			Help: "Frequency of message delivery confirmations",
-		},
-	),
-
-	ConnectedPeerCount: prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "waku_connected_peer_count",
-			Help: "Current number of peers connected",
 		},
 	),
 
@@ -163,7 +155,6 @@ var collectors = []prometheus.Collector{
 	metrics.WakuMessagesSizeBytes,
 	metrics.EnvelopeSentErrors,
 	metrics.MessageDeliveryConfirmations,
-	metrics.ConnectedPeerCount,
 	metrics.PeersByOrigin,
 	metrics.PeersByShard,
 	metrics.PeerConnectionFailures,

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -121,7 +121,6 @@ type IMetricsHandler interface {
 	SetDeviceType(deviceType string)
 	PushSentEnvelope(sentEnvelope SentEnvelope)
 	PushErrorSendingEnvelope(errorSendingEnvelope ErrorSendingEnvelope)
-	PushPeerCount(peerCount int)
 	PushPeerConnFailures(peerConnFailures map[string]int)
 	PushMessageCheckSuccess()
 	PushMessageCheckFailure()
@@ -1329,7 +1328,6 @@ func (w *Waku) checkForConnectionChanges() {
 func (w *Waku) reportPeerMetrics() {
 	if w.metricsHandler != nil {
 		connFailures := FormatPeerConnFailures(w.node)
-		w.metricsHandler.PushPeerCount(w.PeerCount())
 		w.metricsHandler.PushPeerConnFailures(connFailures)
 
 		peerCountByOrigin := make(map[wps.Origin]uint)


### PR DESCRIPTION

Remove duplicated waku metric for peer count.

Closes https://github.com/status-im/status-desktop/issues/17734
