### PR TITLE
feat_: Add fetch data event and some improvements

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -927,7 +927,7 @@ func (api *API) RestartWalletReloadTimer(ctx context.Context) error {
 
 func (api *API) IsChecksumValidForAddress(address string) (bool, error) {
 	logutils.ZapLogger().Debug("wallet.api.isChecksumValidForAddress", zap.String("address", address))
-	return abi_spec.CheckAddressChecksum(address)	 
+	return abi_spec.CheckAddressChecksum(address)
 }
 
 // GetLeaderboardData returns cryptocurrency data with updated price information

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -927,7 +927,7 @@ func (api *API) RestartWalletReloadTimer(ctx context.Context) error {
 
 func (api *API) IsChecksumValidForAddress(address string) (bool, error) {
 	logutils.ZapLogger().Debug("wallet.api.isChecksumValidForAddress", zap.String("address", address))
-	return abi_spec.CheckAddressChecksum(address)
+	return abi_spec.CheckAddressChecksum(address)	 
 }
 
 // GetLeaderboardData returns cryptocurrency data with updated price information
@@ -939,9 +939,10 @@ func (api *API) GetLeaderboardData(ctx context.Context) ([]leaderboard.Cryptocur
 	return api.s.leaderboardService.GetCombinedData(), nil
 }
 
-func (api *API) FetchMarketTokenPageAsync(ctx context.Context, page, pageSize, sortOrder int, currency string) {
+func (api *API) FetchMarketTokenPageAsync(ctx context.Context, page, pageSize, sortOrder int, currency string) error {
 	logutils.ZapLogger().Debug("call to GetMarketTokenPageAsync", zap.Int("page", page), zap.Int("pageSize", pageSize), zap.Int("sortOrder", sortOrder), zap.String("currency", currency))
 	api.s.leaderboardService.FetchLeaderboardPageAsync(page, pageSize, sortOrder, currency)
+	return nil
 }
 
 func (api *API) UnsubscribeFromLeaderboard() error {

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -939,9 +939,9 @@ func (api *API) GetLeaderboardData(ctx context.Context) ([]leaderboard.Cryptocur
 	return api.s.leaderboardService.GetCombinedData(), nil
 }
 
-func (api *API) GetMarketTokenPageAsync(ctx context.Context, page, pageSize, sortOrder int) {
-	logutils.ZapLogger().Debug("call to GetMarketTokenPageAsync", zap.Int("page", page), zap.Int("pageSize", pageSize), zap.Int("sortOrder", sortOrder))
-	api.s.leaderboardService.GetLeaderboardPageAsync(page, pageSize, sortOrder)
+func (api *API) FetchMarketTokenPageAsync(ctx context.Context, page, pageSize, sortOrder int, currency string) {
+	logutils.ZapLogger().Debug("call to GetMarketTokenPageAsync", zap.Int("page", page), zap.Int("pageSize", pageSize), zap.Int("sortOrder", sortOrder), zap.String("currency", currency))
+	api.s.leaderboardService.FetchLeaderboardPageAsync(page, pageSize, sortOrder, currency)
 }
 
 func (api *API) UnsubscribeFromLeaderboard() error {

--- a/services/wallet/leaderboard/cache.go
+++ b/services/wallet/leaderboard/cache.go
@@ -34,4 +34,5 @@ func (c *PageCache) UpdateLastPage(page *LeaderboardPage) {
 	c.lastPage.Page = page.Page
 	c.lastPage.PageSize = page.PageSize
 	c.lastPage.SortOrder = page.SortOrder
+	c.lastPage.Currency = page.Currency
 }

--- a/services/wallet/leaderboard/cache.go
+++ b/services/wallet/leaderboard/cache.go
@@ -35,4 +35,5 @@ func (c *PageCache) UpdateLastPage(page *LeaderboardPage) {
 	c.lastPage.PageSize = page.PageSize
 	c.lastPage.SortOrder = page.SortOrder
 	c.lastPage.Currency = page.Currency
+
 }

--- a/services/wallet/leaderboard/config.go
+++ b/services/wallet/leaderboard/config.go
@@ -26,7 +26,7 @@ type ServiceConfig struct {
 }
 
 // Validate checks if the configuration is valid
-func (c *ServiceConfig) validate() {
+func (c *ServiceConfig) Validate() {
 	// Set default refresh intervals if not provided
 	if c.FullDataInterval <= 0 {
 		c.FullDataInterval = defaultFullDataInterval
@@ -50,7 +50,7 @@ func NewLeaderbordConfig(config params.MarketDataProxyConfig) ServiceConfig {
 	}
 
 	// Validate the configuration
-	serviceConfig.validate()
+	serviceConfig.Validate()
 
 	return serviceConfig
 }

--- a/services/wallet/leaderboard/fetcher.go
+++ b/services/wallet/leaderboard/fetcher.go
@@ -1,0 +1,195 @@
+package leaderboard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/logutils"
+)
+
+// DataFetcher defines the interface for fetching market and price data
+type DataFetcher interface {
+	// FetchMarkets fetches the full market data
+	FetchMarkets(ctx context.Context) error
+	// FetchPrices fetches the latest price data
+	FetchPrices(ctx context.Context) error
+	// Start begins the data refresh loops
+	Start(ctx context.Context)
+	// Stop halts all data refresh operations
+	Stop()
+}
+
+// ProxyFetcher implements DataFetcher interface using HTTP proxy
+type ProxyFetcher struct {
+	requestHandler *RequestHandler
+	storage        *DataStorage
+	config         ServiceConfig
+
+	// Background polling state
+	isRunning      bool
+	isRunningMutex sync.Mutex
+	cancelFunc     context.CancelFunc
+}
+
+// NewProxyFetcher creates a new proxy data fetcher
+func NewProxyFetcher(config ServiceConfig, storage *DataStorage) DataFetcher {
+	client := &http.Client{Timeout: 10 * time.Second}
+	return &ProxyFetcher{
+		requestHandler: NewRequestHandler(config, client),
+		storage:        storage,
+		config:         config,
+	}
+}
+
+// Start begins the data refresh loops
+func (f *ProxyFetcher) Start(ctx context.Context) {
+	if f.startRefreshLoops() {
+		// Stop everything when the top-level context is cancelled
+		go func() {
+			defer common.LogOnPanic()
+			<-ctx.Done()
+			f.Stop() // gracefully stop if running
+		}()
+	}
+}
+
+// Stop halts all data refresh operations
+func (f *ProxyFetcher) Stop() {
+	f.isRunningMutex.Lock()
+	defer f.isRunningMutex.Unlock()
+
+	if !f.isRunning {
+		return // Not running
+	}
+
+	// Cancel the context to stop all loops
+	if f.cancelFunc != nil {
+		f.cancelFunc()
+		f.cancelFunc = nil
+	}
+
+	f.isRunning = false
+}
+
+func (f *ProxyFetcher) startRefreshLoops() bool {
+	f.isRunningMutex.Lock()
+	defer f.isRunningMutex.Unlock()
+
+	if f.isRunning {
+		return false // Already running
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	f.cancelFunc = cancel
+	f.isRunning = true
+
+	// Start crypto data refresh loop
+	go func() {
+		defer common.LogOnPanic()
+		f.cryptoRefreshLoop(ctx)
+	}()
+
+	// Start price data refresh loop
+	go func() {
+		defer common.LogOnPanic()
+		f.priceRefreshLoop(ctx)
+	}()
+	return true
+}
+
+// cryptoRefreshLoop periodically fetches the full cryptocurrency data
+func (f *ProxyFetcher) cryptoRefreshLoop(ctx context.Context) {
+	// Initial fetch
+	if err := f.FetchMarkets(ctx); err != nil {
+		logutils.ZapLogger().Error("Error in initial crypto data fetch", zap.Error(err))
+	}
+
+	// Set up ticker for periodic updates
+	ticker := time.NewTicker(time.Duration(f.config.FullDataInterval) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return // Context cancelled, stop the loop
+		case <-ticker.C:
+			if err := f.FetchMarkets(ctx); err != nil {
+				logutils.ZapLogger().Error("Error fetching crypto data", zap.Error(err))
+			}
+		}
+	}
+}
+
+// priceRefreshLoop periodically fetches price updates
+func (f *ProxyFetcher) priceRefreshLoop(ctx context.Context) {
+	// Wait a short time before starting price updates
+	time.Sleep(1 * time.Second)
+
+	// Initial fetch
+	if err := f.FetchPrices(ctx); err != nil {
+		logutils.ZapLogger().Error("Error in initial price data fetch", zap.Error(err))
+	}
+
+	// Set up ticker for periodic updates
+	ticker := time.NewTicker(time.Duration(f.config.PriceUpdateInterval) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return // Context cancelled, stop the loop
+		case <-ticker.C:
+			if err := f.FetchPrices(ctx); err != nil {
+				logutils.ZapLogger().Error("Error fetching price data", zap.Error(err))
+			}
+		}
+	}
+}
+
+// FetchMarkets fetches the full market data
+func (f *ProxyFetcher) FetchMarkets(ctx context.Context) error {
+	endpoint := "/v1/leaderboard/markets"
+	etag := f.storage.GetCryptoEtag()
+
+	body, updated := f.requestHandler.FetchData(ctx, endpoint, &etag)
+	if !updated {
+		return nil
+	}
+
+	var data CryptoResponse
+	if err := json.Unmarshal(body, &data); err != nil {
+		return err
+	}
+
+	// Store data and etag atomically
+	f.storage.UpdateCryptoDataWithEtag(data.Data, etag)
+
+	return nil
+}
+
+// FetchPrices fetches the latest price data
+func (f *ProxyFetcher) FetchPrices(ctx context.Context) error {
+	endpoint := "/v1/leaderboard/prices"
+	etag := f.storage.GetPriceEtag()
+
+	body, updated := f.requestHandler.FetchData(ctx, endpoint, &etag)
+	if !updated {
+		return nil
+	}
+
+	var priceData PriceMap
+	if err := json.Unmarshal(body, &priceData); err != nil {
+		return err
+	}
+
+	// Store data and etag atomically
+	f.storage.UpdatePriceDataWithEtag(priceData, etag)
+
+	return nil
+}

--- a/services/wallet/leaderboard/models.go
+++ b/services/wallet/leaderboard/models.go
@@ -37,6 +37,7 @@ type LeaderboardPagePrices struct {
 	Page      int         `json:"page"`
 	PageSize  int         `json:"page_size"`
 	SortOrder int         `json:"sorting"`
+	Currency  string      `json:"currency"`
 	Data      []PriceData `json:"prices"`
 }
 

--- a/services/wallet/leaderboard/models.go
+++ b/services/wallet/leaderboard/models.go
@@ -29,6 +29,7 @@ type LeaderboardPage struct {
 	Page       int              `json:"page"`
 	PageSize   int              `json:"page_size"`
 	SortOrder  int              `json:"sorting"`
+	Currency   string           `json:"currency"`
 	Data       []Cryptocurrency `json:"cryptocurrencies"`
 }
 

--- a/services/wallet/leaderboard/requests.go
+++ b/services/wallet/leaderboard/requests.go
@@ -23,8 +23,8 @@ func NewRequestHandler(config ServiceConfig, client *http.Client) *RequestHandle
 }
 
 // FetchData performs an HTTP request and processes the response
-// Returns the response body, a success flag, and update statistics
-func (h *RequestHandler) FetchData(ctx context.Context, endpoint string, etag *string, stats *Stats) ([]byte, bool) {
+// Returns the response body and a success flag
+func (h *RequestHandler) FetchData(ctx context.Context, endpoint string, etag *string) ([]byte, bool) {
 	// Create request
 	req, err := h.createRequest(ctx, endpoint, etag)
 	if err != nil {
@@ -38,13 +38,8 @@ func (h *RequestHandler) FetchData(ctx context.Context, endpoint string, etag *s
 	}
 	defer resp.Body.Close()
 
-	// Update statistics
-	stats.TotalRequests++
-	h.updateCacheStats(stats, resp)
-
 	// Check for 304 Not Modified
 	if resp.StatusCode == http.StatusNotModified {
-		stats.NotModifiedCount++
 		return nil, false // No data update
 	}
 
@@ -54,7 +49,7 @@ func (h *RequestHandler) FetchData(ctx context.Context, endpoint string, etag *s
 	}
 
 	// Process response body
-	body, updated := h.processResponseBody(stats, resp, etag)
+	body, updated := h.processResponseBody(resp, etag)
 	if !updated {
 		return nil, false
 	}
@@ -96,22 +91,12 @@ func (h *RequestHandler) createRequest(ctx context.Context, endpoint string, eta
 	return req, nil
 }
 
-// updateCacheStats updates cache-related statistics based on response headers
-func (h *RequestHandler) updateCacheStats(stats *Stats, resp *http.Response) {
-	if cacheStatus := resp.Header.Get("X-Proxy-Cache"); cacheStatus == "HIT" {
-		stats.CacheHits++
-	} else {
-		stats.CacheMisses++
-	}
-}
-
 // processResponseBody handles the response body, including gzip decompression
 // Returns the body and a success flag
-func (h *RequestHandler) processResponseBody(stats *Stats, resp *http.Response, etag *string) ([]byte, bool) {
+func (h *RequestHandler) processResponseBody(resp *http.Response, etag *string) ([]byte, bool) {
 	// Set up appropriate reader based on content encoding
 	var reader io.ReadCloser = resp.Body
 	if h.config.AllowGzip && resp.Header.Get("Content-Encoding") == "gzip" {
-		stats.GzipResponseCount++
 		var gzipErr error
 		reader, gzipErr = gzip.NewReader(resp.Body)
 		if gzipErr != nil {
@@ -130,9 +115,6 @@ func (h *RequestHandler) processResponseBody(stats *Stats, resp *http.Response, 
 	if err != nil {
 		return nil, false
 	}
-
-	// Update total response size
-	stats.TotalResponseSize += int64(len(body))
 
 	return body, true
 }

--- a/services/wallet/leaderboard/requests_test.go
+++ b/services/wallet/leaderboard/requests_test.go
@@ -172,19 +172,11 @@ func TestFetchDataCompression(t *testing.T) {
 			}, server.Client())
 
 			// Make request
-			stats := &Stats{}
-			body, ok := handler.FetchData(context.Background(), "/test", new(string), stats)
+			body, ok := handler.FetchData(context.Background(), "/test", new(string))
 
 			// Verify response
 			require.True(t, ok)
 			require.Equal(t, tt.responseBody, string(body))
-
-			// Verify stats
-			expectedStats := &Stats{}
-			if tt.useGzip && tt.enableGzip {
-				expectedStats.GzipResponseCount = 1
-			}
-			require.Equal(t, expectedStats.GzipResponseCount, stats.GzipResponseCount, "GzipResponseCount mismatch")
 		})
 	}
 }

--- a/services/wallet/leaderboard/service.go
+++ b/services/wallet/leaderboard/service.go
@@ -18,10 +18,16 @@ import (
 )
 
 const (
-	// EventGetLeaderboardPageDone contains a LeaderboardPage payload
-	EventGetLeaderboardPageDone walletevent.EventType = "wallet-leaderboard-get-page-done"
-	// EventLeaderboardPagePricesUpdated contains a EventLeaderboardPagePricesUpdate payload
+	// Contains a LeaderboardPage payload
+	EventFetchLeaderboardPageDone walletevent.EventType = "wallet-leaderboard-fetch-page-done"
+	// Contains a LeaderboardPage payload
+	EvenLeaderboardPageDone walletevent.EventType = "wallet-leaderboard-page-updated"
+	// Contains a EventLeaderboardPagePricesUpdate payload
 	EventLeaderboardPagePricesUpdated walletevent.EventType = "wallet-leaderboard-page-prices-updated"
+
+	// Signal source
+	TickerFullDataUpdateSource int = 0
+	TickerPriceUpdateSource    int = 1
 )
 
 var (
@@ -47,7 +53,7 @@ type MarketDataService struct {
 
 	// Subscription management
 	subscriptionManager    *SubscriptionManager
-	pageUpdateSubscription chan struct{}
+	pageUpdateSubscription chan Signal
 
 	// Context management
 	cancelFunc     context.CancelFunc
@@ -93,6 +99,7 @@ func (s *MarketDataService) Start(ctx context.Context) {
 		return // Already running
 	}
 
+	// TODO_ES optimize to stop fetching data when not needed
 	// Create a cancellable context that can stop all data operations
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancelFunc = cancel
@@ -138,39 +145,8 @@ func (s *MarketDataService) IsRunning() bool {
 	return s.isRunning
 }
 
-// Subscribe creates a subscription to data updates
-func (s *MarketDataService) Subscribe() chan struct{} {
-	return s.subscriptionManager.Subscribe()
-}
-
-// Unsubscribe removes a subscription
-func (s *MarketDataService) Unsubscribe(ch chan struct{}) {
-	s.subscriptionManager.Unsubscribe(ch)
-}
-
-// GetCryptoData returns the latest cryptocurrency data
-func (s *MarketDataService) GetCryptoData() []Cryptocurrency {
-	return s.storage.GetCryptoData()
-}
-
-// GetPriceData returns the latest price data
-func (s *MarketDataService) GetPriceData() PriceMap {
-	return s.storage.GetPriceData()
-}
-
-// GetCombinedData returns cryptocurrency data with updated price information
-func (s *MarketDataService) GetCombinedData() []Cryptocurrency {
-	return s.storage.GetCombinedData()
-}
-
-// GetCryptoStats returns statistics for crypto data requests
-func (s *MarketDataService) GetCryptoStats() Stats {
-	return s.storage.GetCryptoStats()
-}
-
-// GetPriceStats returns statistics for price data requests
-func (s *MarketDataService) GetPriceStats() Stats {
-	return s.storage.GetPriceStats()
+func (s *MarketDataService) isSubscribed() bool {
+	return s.pageUpdateSubscription != nil
 }
 
 // cryptoRefreshLoop periodically fetches the full cryptocurrency data
@@ -179,7 +155,7 @@ func (s *MarketDataService) cryptoRefreshLoop(ctx context.Context) {
 	s.fetchCryptoData(ctx)
 
 	// Notify subscribers of the initial data
-	s.subscriptionManager.Emit(ctx)
+	s.subscriptionManager.Emit(ctx, TickerFullDataUpdateSource)
 
 	// Set up ticker for periodic updates
 	ticker := time.NewTicker(time.Duration(s.config.FullDataInterval) * time.Second)
@@ -192,7 +168,7 @@ func (s *MarketDataService) cryptoRefreshLoop(ctx context.Context) {
 		case <-ticker.C:
 			if s.fetchCryptoData(ctx) {
 				// Only notify if data was actually updated
-				s.subscriptionManager.Emit(ctx)
+				s.subscriptionManager.Emit(ctx, TickerFullDataUpdateSource)
 			}
 		}
 	}
@@ -207,7 +183,7 @@ func (s *MarketDataService) priceRefreshLoop(ctx context.Context) {
 	s.fetchPriceData(ctx)
 
 	// Notify subscribers of the initial data
-	s.subscriptionManager.Emit(ctx)
+	s.subscriptionManager.Emit(ctx, TickerPriceUpdateSource)
 
 	// Set up ticker for periodic updates
 	ticker := time.NewTicker(time.Duration(s.config.PriceUpdateInterval) * time.Second)
@@ -220,7 +196,7 @@ func (s *MarketDataService) priceRefreshLoop(ctx context.Context) {
 		case <-ticker.C:
 			if s.fetchPriceData(ctx) {
 				// Only notify if data was actually updated
-				s.subscriptionManager.Emit(ctx)
+				s.subscriptionManager.Emit(ctx, TickerPriceUpdateSource)
 			}
 		}
 	}
@@ -279,7 +255,7 @@ func (s *MarketDataService) fetchPriceData(ctx context.Context) bool {
 }
 
 func (s *MarketDataService) sendLeaderboardPagePricesUpdate() {
-	if s.pageUpdateSubscription == nil {
+	if !s.isSubscribed() {
 		return
 	}
 
@@ -300,9 +276,32 @@ func (s *MarketDataService) sendLeaderboardPagePricesUpdate() {
 	s.feed.Send(event)
 }
 
-func (s *MarketDataService) GetLeaderboardPageAsync(page, pageSize int, sortOrder int) {
+func (s *MarketDataService) sendLeaderboardPageUpdate() {
+	if !s.isSubscribed() {
+		return
+	}
+
+	lastPage := s.cache.GetLastPage()
+	result, err := s.storage.GetLeaderboardPage(lastPage.Page, lastPage.PageSize, lastPage.SortOrder, lastPage.Currency)
+	if err != nil {
+		logutils.ZapLogger().Error("Error fetching leaderboard page", zap.Error(err))
+		return
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		logutils.ZapLogger().Error("Error marshalling leaderboard page", zap.Error(err))
+	}
+
+	event := walletevent.Event{
+		Type:    EvenLeaderboardPageDone,
+		Message: string(payload),
+	}
+	s.feed.Send(event)
+}
+
+func (s *MarketDataService) FetchLeaderboardPageAsync(page, pageSize, sortOrder int, currency string) {
 	s.scheduler.Enqueue(fetchLeaderboardPageTask, func(ctx context.Context) (interface{}, error) {
-		result, err := s.storage.GetLeaderboardPage(page, pageSize, sortOrder)
+		result, err := s.storage.GetLeaderboardPage(page, pageSize, sortOrder, currency)
 		s.cache.UpdateLastPage(result)
 		return result, err
 	}, func(result interface{}, taskType async.TaskType, resErr error) {
@@ -311,27 +310,41 @@ func (s *MarketDataService) GetLeaderboardPageAsync(page, pageSize int, sortOrde
 			logutils.ZapLogger().Error("Error marshalling leaderboard page", zap.Error(err))
 		}
 		event := walletevent.Event{
-			Type:    EventGetLeaderboardPageDone,
+			Type:    EventFetchLeaderboardPageDone,
 			Message: string(payload),
 		}
-		if s.pageUpdateSubscription == nil {
-			s.pageUpdateSubscription = s.subscriptionManager.Subscribe()
-			go func() {
-				defer common.LogOnPanic()
-				for range s.pageUpdateSubscription {
-					s.sendLeaderboardPagePricesUpdate()
-				}
-			}()
-		}
+		s.subscribeToLeaderboard()
 		s.feed.Send(event)
 	})
 }
 
+func (s *MarketDataService) subscribeToLeaderboard() {
+	if s.isSubscribed() {
+		return
+	}
+
+	s.pageUpdateSubscription = s.subscriptionManager.Subscribe()
+	go func() {
+		defer common.LogOnPanic()
+		for {
+			select {
+			case sig := <-s.pageUpdateSubscription:
+				switch sig.Source() {
+				case TickerFullDataUpdateSource:
+					s.sendLeaderboardPageUpdate()
+				case TickerPriceUpdateSource:
+					s.sendLeaderboardPagePricesUpdate()
+				}
+			}
+		}
+	}()
+}
+
 func (s *MarketDataService) UnsubscribeFromLeaderboard() error {
-	if s.pageUpdateSubscription == nil {
+	if !s.isSubscribed() {
 		return fmt.Errorf("No subscription found")
 	}
-	s.Unsubscribe(s.pageUpdateSubscription)
+	s.subscriptionManager.Unsubscribe(s.pageUpdateSubscription)
 	s.pageUpdateSubscription = nil
 	s.cache.Clear()
 	return nil

--- a/services/wallet/leaderboard/service.go
+++ b/services/wallet/leaderboard/service.go
@@ -3,6 +3,7 @@ package leaderboard
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -17,6 +18,8 @@ import (
 	"github.com/status-im/status-go/services/wallet/walletevent"
 )
 
+type ErrorCode = int
+
 const (
 	// Contains a LeaderboardPage payload
 	EventFetchLeaderboardPageDone walletevent.EventType = "wallet-leaderboard-fetch-page-done"
@@ -28,6 +31,11 @@ const (
 	// Signal source
 	TickerFullDataUpdateSource int = 0
 	TickerPriceUpdateSource    int = 1
+
+	// Error codes
+	ErrorCodeSuccess      ErrorCode = 1
+	ErrorCodeTaskCanceled           = 2
+	ErrorCodeFailed                 = 3
 )
 
 var (
@@ -69,6 +77,11 @@ type Stats struct {
 	TotalResponseSize int64
 	NotModifiedCount  int
 	GzipResponseCount int
+}
+
+type GetLeaderboardPageResponse struct {
+	LeaderboardPage
+	ErrorCode ErrorCode `json:"error_code"`
 }
 
 // NewMarketDataService creates a new market data service with the given configuration
@@ -312,18 +325,32 @@ func (s *MarketDataService) sendLeaderboardPageUpdate() {
 func (s *MarketDataService) FetchLeaderboardPageAsync(page, pageSize, sortOrder int, currency string) {
 	s.scheduler.Enqueue(fetchLeaderboardPageTask, func(ctx context.Context) (interface{}, error) {
 		result, err := s.storage.GetLeaderboardPage(page, pageSize, sortOrder, currency)
+		if err != nil {
+			logutils.ZapLogger().Error("Error fetching leaderboard page", zap.Error(err))
+			return nil, err
+		}
 		s.cache.UpdateLastPage(result)
 		return result, err
 	}, func(result interface{}, taskType async.TaskType, resErr error) {
-		payload, err := json.Marshal(result.(*LeaderboardPage))
+		res := GetLeaderboardPageResponse{
+			ErrorCode: ErrorCodeFailed,
+		}
+		if errors.Is(resErr, context.Canceled) || errors.Is(resErr, async.ErrTaskOverwritten) {
+			res.ErrorCode = ErrorCodeTaskCanceled
+		} else if resErr == nil {
+			res.ErrorCode = ErrorCodeSuccess
+			res.LeaderboardPage = *(result.(*LeaderboardPage))
+			s.subscribeToLeaderboard()
+		}
+
+		payload, err := json.Marshal(res)
 		if err != nil {
-			logutils.ZapLogger().Error("Error marshalling leaderboard page", zap.Error(err))
+			logutils.ZapLogger().Error("Error marshalling leaderboard page response", zap.Error(err))
 		}
 		event := walletevent.Event{
 			Type:    EventFetchLeaderboardPageDone,
 			Message: string(payload),
 		}
-		s.subscribeToLeaderboard()
 		s.feed.Send(event)
 	})
 }

--- a/services/wallet/leaderboard/service.go
+++ b/services/wallet/leaderboard/service.go
@@ -22,9 +22,9 @@ type ErrorCode = int
 
 const (
 	// Contains a LeaderboardPage payload
-	EventFetchLeaderboardPageDone walletevent.EventType = "wallet-leaderboard-fetch-page-done"
+	EventFetchLeaderboardPageDone walletevent.EventType = "wallet-fetch-leaderboard-page-done"
 	// Contains a LeaderboardPage payload
-	EvenLeaderboardPageDone walletevent.EventType = "wallet-leaderboard-page-updated"
+	EventLeaderboardPageDataUpdated walletevent.EventType = "wallet-leaderboard-page-data-updated"
 	// Contains a EventLeaderboardPagePricesUpdate payload
 	EventLeaderboardPagePricesUpdated walletevent.EventType = "wallet-leaderboard-page-prices-updated"
 
@@ -316,7 +316,7 @@ func (s *MarketDataService) sendLeaderboardPageUpdate() {
 	}
 
 	event := walletevent.Event{
-		Type:    EvenLeaderboardPageDone,
+		Type:    EventLeaderboardPageDataUpdated,
 		Message: string(payload),
 	}
 	s.feed.Send(event)

--- a/services/wallet/leaderboard/service.go
+++ b/services/wallet/leaderboard/service.go
@@ -75,14 +75,13 @@ type Stats struct {
 func NewMarketDataService(config ServiceConfig, feed *event.Feed) *MarketDataService {
 	// Set default values for intervals if not provided
 	client := &http.Client{Timeout: 10 * time.Second}
-	storage := NewDataStorage()
 
 	return &MarketDataService{
 		config:                 config,
 		client:                 client,
 		feed:                   feed,
 		requestHandler:         NewRequestHandler(config, client),
-		storage:                storage,
+		storage:                NewDataStorage(),
 		subscriptionManager:    NewSubscriptionManager(),
 		scheduler:              async.NewScheduler(),
 		pageUpdateSubscription: nil,
@@ -92,16 +91,36 @@ func NewMarketDataService(config ServiceConfig, feed *event.Feed) *MarketDataSer
 
 // Start begins the data refresh loops
 func (s *MarketDataService) Start(ctx context.Context) {
+	if s.startRefreshLoops() {
+		// Stop everything when the top-level context is cancelled
+		go func() {
+			defer common.LogOnPanic()
+			<-ctx.Done()
+			s.stopRefreshLoops() // gracefully stop if running
+		}()
+	}
+}
+
+// Stop halts all data refresh operations
+func (s *MarketDataService) Stop() {
+	s.stopRefreshLoops()
+	s.UnsubscribeFromLeaderboard() //nolint:errcheck
+}
+
+// GetCombinedData returns cryptocurrency data with updated price information
+func (s *MarketDataService) GetCombinedData() []Cryptocurrency {
+	return s.storage.GetCombinedData()
+}
+
+func (s *MarketDataService) startRefreshLoops() bool {
 	s.isRunningMutex.Lock()
 	defer s.isRunningMutex.Unlock()
 
 	if s.isRunning {
-		return // Already running
+		return false // Already running
 	}
 
-	// TODO_ES optimize to stop fetching data when not needed
-	// Create a cancellable context that can stop all data operations
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
 	s.cancelFunc = cancel
 	s.isRunning = true
 
@@ -116,10 +135,10 @@ func (s *MarketDataService) Start(ctx context.Context) {
 		defer common.LogOnPanic()
 		s.priceRefreshLoop(ctx)
 	}()
+	return true
 }
 
-// Stop halts all data refresh operations
-func (s *MarketDataService) Stop() {
+func (s *MarketDataService) stopRefreshLoops() {
 	s.isRunningMutex.Lock()
 	defer s.isRunningMutex.Unlock()
 
@@ -133,16 +152,7 @@ func (s *MarketDataService) Stop() {
 		s.cancelFunc = nil
 	}
 
-	s.UnsubscribeFromLeaderboard() //nolint:errcheck
-
 	s.isRunning = false
-}
-
-// IsRunning returns whether the service is currently running
-func (s *MarketDataService) IsRunning() bool {
-	s.isRunningMutex.Lock()
-	defer s.isRunningMutex.Unlock()
-	return s.isRunning
 }
 
 func (s *MarketDataService) isSubscribed() bool {
@@ -323,24 +333,24 @@ func (s *MarketDataService) subscribeToLeaderboard() {
 		return
 	}
 
+	s.startRefreshLoops()
+
 	s.pageUpdateSubscription = s.subscriptionManager.Subscribe()
 	go func() {
 		defer common.LogOnPanic()
-		for {
-			select {
-			case sig := <-s.pageUpdateSubscription:
-				switch sig.Source() {
-				case TickerFullDataUpdateSource:
-					s.sendLeaderboardPageUpdate()
-				case TickerPriceUpdateSource:
-					s.sendLeaderboardPagePricesUpdate()
-				}
+		for sig := range s.pageUpdateSubscription {
+			switch sig.Source() {
+			case TickerFullDataUpdateSource:
+				s.sendLeaderboardPageUpdate()
+			case TickerPriceUpdateSource:
+				s.sendLeaderboardPagePricesUpdate()
 			}
 		}
 	}()
 }
 
 func (s *MarketDataService) UnsubscribeFromLeaderboard() error {
+	s.stopRefreshLoops()
 	if !s.isSubscribed() {
 		return fmt.Errorf("No subscription found")
 	}

--- a/services/wallet/leaderboard/service.go
+++ b/services/wallet/leaderboard/service.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -34,8 +33,8 @@ const (
 
 	// Error codes
 	ErrorCodeSuccess      ErrorCode = 1
-	ErrorCodeTaskCanceled           = 2
-	ErrorCodeFailed                 = 3
+	ErrorCodeTaskCanceled ErrorCode = 2
+	ErrorCodeFailed       ErrorCode = 3
 )
 
 var (
@@ -48,7 +47,7 @@ var (
 // MarketDataService manages market data fetching and provides access to the latest data
 type MarketDataService struct {
 	config    ServiceConfig
-	client    *http.Client
+	fetcher   DataFetcher
 	scheduler *async.Scheduler
 	feed      *event.Feed
 
@@ -62,21 +61,6 @@ type MarketDataService struct {
 	// Subscription management
 	subscriptionManager    *SubscriptionManager
 	pageUpdateSubscription chan Signal
-
-	// Context management
-	cancelFunc     context.CancelFunc
-	isRunning      bool
-	isRunningMutex sync.Mutex
-}
-
-// Stats tracks API request statistics
-type Stats struct {
-	TotalRequests     int
-	CacheHits         int
-	CacheMisses       int
-	TotalResponseSize int64
-	NotModifiedCount  int
-	GzipResponseCount int
 }
 
 type GetLeaderboardPageResponse struct {
@@ -86,37 +70,27 @@ type GetLeaderboardPageResponse struct {
 
 // NewMarketDataService creates a new market data service with the given configuration
 func NewMarketDataService(config ServiceConfig, feed *event.Feed) *MarketDataService {
-	// Set default values for intervals if not provided
-	client := &http.Client{Timeout: 10 * time.Second}
-
+	storage := NewDataStorage()
 	return &MarketDataService{
-		config:                 config,
-		client:                 client,
-		feed:                   feed,
-		requestHandler:         NewRequestHandler(config, client),
-		storage:                NewDataStorage(),
-		subscriptionManager:    NewSubscriptionManager(),
-		scheduler:              async.NewScheduler(),
-		pageUpdateSubscription: nil,
-		cache:                  NewPageCache(),
+		config:              config,
+		fetcher:             NewProxyFetcher(config, storage),
+		feed:                feed,
+		requestHandler:      NewRequestHandler(config, &http.Client{Timeout: 10 * time.Second}),
+		storage:             storage,
+		subscriptionManager: NewSubscriptionManager(),
+		scheduler:           async.NewScheduler(),
+		cache:               NewPageCache(),
 	}
 }
 
 // Start begins the data refresh loops
 func (s *MarketDataService) Start(ctx context.Context) {
-	if s.startRefreshLoops() {
-		// Stop everything when the top-level context is cancelled
-		go func() {
-			defer common.LogOnPanic()
-			<-ctx.Done()
-			s.stopRefreshLoops() // gracefully stop if running
-		}()
-	}
+	s.fetcher.Start(ctx)
 }
 
 // Stop halts all data refresh operations
 func (s *MarketDataService) Stop() {
-	s.stopRefreshLoops()
+	s.fetcher.Stop()
 	s.UnsubscribeFromLeaderboard() //nolint:errcheck
 }
 
@@ -125,156 +99,8 @@ func (s *MarketDataService) GetCombinedData() []Cryptocurrency {
 	return s.storage.GetCombinedData()
 }
 
-func (s *MarketDataService) startRefreshLoops() bool {
-	s.isRunningMutex.Lock()
-	defer s.isRunningMutex.Unlock()
-
-	if s.isRunning {
-		return false // Already running
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	s.cancelFunc = cancel
-	s.isRunning = true
-
-	// Start crypto data refresh loop
-	go func() {
-		defer common.LogOnPanic()
-		s.cryptoRefreshLoop(ctx)
-	}()
-
-	// Start price data refresh loop
-	go func() {
-		defer common.LogOnPanic()
-		s.priceRefreshLoop(ctx)
-	}()
-	return true
-}
-
-func (s *MarketDataService) stopRefreshLoops() {
-	s.isRunningMutex.Lock()
-	defer s.isRunningMutex.Unlock()
-
-	if !s.isRunning {
-		return // Not running
-	}
-
-	// Cancel the context to stop all loops
-	if s.cancelFunc != nil {
-		s.cancelFunc()
-		s.cancelFunc = nil
-	}
-
-	s.isRunning = false
-}
-
 func (s *MarketDataService) isSubscribed() bool {
 	return s.pageUpdateSubscription != nil
-}
-
-// cryptoRefreshLoop periodically fetches the full cryptocurrency data
-func (s *MarketDataService) cryptoRefreshLoop(ctx context.Context) {
-	// Initial fetch
-	s.fetchCryptoData(ctx)
-
-	// Notify subscribers of the initial data
-	s.subscriptionManager.Emit(ctx, TickerFullDataUpdateSource)
-
-	// Set up ticker for periodic updates
-	ticker := time.NewTicker(time.Duration(s.config.FullDataInterval) * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return // Context cancelled, stop the loop
-		case <-ticker.C:
-			if s.fetchCryptoData(ctx) {
-				// Only notify if data was actually updated
-				s.subscriptionManager.Emit(ctx, TickerFullDataUpdateSource)
-			}
-		}
-	}
-}
-
-// priceRefreshLoop periodically fetches price updates
-func (s *MarketDataService) priceRefreshLoop(ctx context.Context) {
-	// Wait a short time before starting price updates
-	time.Sleep(1 * time.Second)
-
-	// Initial fetch
-	s.fetchPriceData(ctx)
-
-	// Notify subscribers of the initial data
-	s.subscriptionManager.Emit(ctx, TickerPriceUpdateSource)
-
-	// Set up ticker for periodic updates
-	ticker := time.NewTicker(time.Duration(s.config.PriceUpdateInterval) * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return // Context cancelled, stop the loop
-		case <-ticker.C:
-			if s.fetchPriceData(ctx) {
-				// Only notify if data was actually updated
-				s.subscriptionManager.Emit(ctx, TickerPriceUpdateSource)
-			}
-		}
-	}
-}
-
-// fetchCryptoData fetches the latest cryptocurrency data
-// Returns true if data was updated, false if using cached data (304)
-func (s *MarketDataService) fetchCryptoData(ctx context.Context) bool {
-	// Get current etag
-	cryptoEtag := s.storage.GetCryptoEtag()
-
-	// Fetch data using the request handler
-	endpoint := "/v1/leaderboard/markets"
-	body, updated := s.requestHandler.FetchData(ctx, endpoint, &cryptoEtag, s.storage.GetCryptoStatsRef())
-	if !updated {
-		return false
-	}
-
-	// Update etag if changed
-	s.storage.SetCryptoEtag(cryptoEtag)
-
-	// Parse the response
-	var cryptoResp CryptoResponse
-	if err := json.Unmarshal(body, &cryptoResp); err != nil {
-		return false
-	}
-
-	// Update the data
-	return s.storage.UpdateCryptoData(cryptoResp.Data)
-}
-
-// fetchPriceData fetches the latest price data
-// Returns true if data was updated, false if using cached data (304)
-func (s *MarketDataService) fetchPriceData(ctx context.Context) bool {
-	// Get current etag
-	priceEtag := s.storage.GetPriceEtag()
-
-	// Fetch data using the request handler
-	endpoint := "/v1/leaderboard/prices"
-	body, updated := s.requestHandler.FetchData(ctx, endpoint, &priceEtag, s.storage.GetPriceStatsRef())
-	if !updated {
-		return false
-	}
-
-	// Update etag if changed
-	s.storage.SetPriceEtag(priceEtag)
-
-	// Parse the response
-	var priceData PriceMap
-	if err := json.Unmarshal(body, &priceData); err != nil {
-		return false
-	}
-
-	// Update the data
-	return s.storage.UpdatePriceData(priceData)
 }
 
 func (s *MarketDataService) sendLeaderboardPagePricesUpdate() {
@@ -360,7 +186,7 @@ func (s *MarketDataService) subscribeToLeaderboard() {
 		return
 	}
 
-	s.startRefreshLoops()
+	s.fetcher.Start(context.Background())
 
 	s.pageUpdateSubscription = s.subscriptionManager.Subscribe()
 	go func() {
@@ -377,7 +203,7 @@ func (s *MarketDataService) subscribeToLeaderboard() {
 }
 
 func (s *MarketDataService) UnsubscribeFromLeaderboard() error {
-	s.stopRefreshLoops()
+	s.fetcher.Stop()
 	if !s.isSubscribed() {
 		return fmt.Errorf("No subscription found")
 	}

--- a/services/wallet/leaderboard/service_test.go
+++ b/services/wallet/leaderboard/service_test.go
@@ -2,16 +2,58 @@ package leaderboard
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/event"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/status-im/status-go/services/wallet/async"
 )
+
+// MockFetcher implements DataFetcher interface for testing
+type MockFetcher struct {
+	storage *DataStorage
+}
+
+func NewMockFetcher(storage *DataStorage) *MockFetcher {
+	f := &MockFetcher{
+		storage: storage,
+	}
+	// Initialize data
+	f.storage.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	f.storage.UpdatePriceDataWithEtag(mockPriceData, "test-etag")
+	return f
+}
+
+func (f *MockFetcher) FetchMarkets(ctx context.Context) error {
+	f.storage.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	return nil
+}
+
+func (f *MockFetcher) FetchPrices(ctx context.Context) error {
+	f.storage.UpdatePriceDataWithEtag(mockPriceData, "test-etag")
+	return nil
+}
+
+func (f *MockFetcher) Start(ctx context.Context) {}
+func (f *MockFetcher) Stop()                     {}
 
 func setupMarketDatadService(t *testing.T, config ServiceConfig) *MarketDataService {
 	config.Validate()
-	return NewMarketDataService(config, &event.Feed{})
+	storage := NewDataStorage()
+	service := &MarketDataService{
+		config:              config,
+		feed:                &event.Feed{},
+		requestHandler:      NewRequestHandler(config, &http.Client{Timeout: 10 * time.Second}),
+		storage:             storage,
+		subscriptionManager: NewSubscriptionManager(),
+		scheduler:           async.NewScheduler(),
+		cache:               NewPageCache(),
+	}
+	service.fetcher = NewMockFetcher(storage)
+	return service
 }
 
 func TestServiceStartStop(t *testing.T) {
@@ -29,8 +71,7 @@ func TestUnsubscribeWhenNotSubscribed(t *testing.T) {
 	service := setupMarketDatadService(t, config)
 
 	// Unsubscribe should not panic or error
-	err := service.UnsubscribeFromLeaderboard()
-	require.Error(t, err)
+	_ = service.UnsubscribeFromLeaderboard()
 }
 
 func TestSubsribe(t *testing.T) {
@@ -44,5 +85,5 @@ func TestSubsribe(t *testing.T) {
 
 	// TODO check for sent events
 
-	service.UnsubscribeFromLeaderboard() // Unsubscribe after the test
+	_ = service.UnsubscribeFromLeaderboard() // Unsubscribe after the test
 }

--- a/services/wallet/leaderboard/service_test.go
+++ b/services/wallet/leaderboard/service_test.go
@@ -1,0 +1,48 @@
+package leaderboard
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/stretchr/testify/require"
+)
+
+func setupMarketDatadService(t *testing.T, config ServiceConfig) *MarketDataService {
+	config.Validate()
+	return NewMarketDataService(config, &event.Feed{})
+}
+
+func TestServiceStartStop(t *testing.T) {
+	config := ServiceConfig{}
+
+	service := setupMarketDatadService(t, config)
+	require.NotNil(t, service)
+
+	service.Start(context.Background())
+	service.Stop()
+}
+
+func TestUnsubscribeWhenNotSubscribed(t *testing.T) {
+	config := ServiceConfig{}
+	service := setupMarketDatadService(t, config)
+
+	// Unsubscribe should not panic or error
+	err := service.UnsubscribeFromLeaderboard()
+	require.Error(t, err)
+}
+
+func TestSubsribe(t *testing.T) {
+	config := ServiceConfig{}
+	service := setupMarketDatadService(t, config)
+
+	// Subscribe should not panic or error
+	service.FetchLeaderboardPageAsync(0, 0, 0, "usd")
+
+	time.Sleep(3 * time.Second) // Wait for the async operation to complete and events to be sent
+
+	// TODO check for sent events
+
+	service.UnsubscribeFromLeaderboard() // Unsubscribe after the test
+}

--- a/services/wallet/leaderboard/storage.go
+++ b/services/wallet/leaderboard/storage.go
@@ -224,7 +224,7 @@ func (s *DataStorage) GetLeaderboardPagePrices(page LeaderboardPage) *Leaderboar
 	return result
 }
 
-func (s *DataStorage) GetLeaderboardPage(page, pageSize int, sortOrder int) (*LeaderboardPage, error) {
+func (s *DataStorage) GetLeaderboardPage(page, pageSize, sortOrder int, currency string) (*LeaderboardPage, error) {
 	if pageSize <= 0 {
 		return nil, fmt.Errorf("Invalid page size")
 	}
@@ -244,6 +244,7 @@ func (s *DataStorage) GetLeaderboardPage(page, pageSize int, sortOrder int) (*Le
 		Page:       page,
 		PageSize:   pageSize,
 		SortOrder:  sortOrder,
+		Currency:   currency,
 		Data:       s.GetCryptoDataForPage(page, pageSize),
 	}
 	return result, nil

--- a/services/wallet/leaderboard/storage.go
+++ b/services/wallet/leaderboard/storage.go
@@ -164,6 +164,7 @@ func (s *DataStorage) GetLeaderboardPagePrices(page LeaderboardPage) *Leaderboar
 		Page:      page.Page,
 		PageSize:  page.PageSize,
 		SortOrder: page.SortOrder,
+		Currency:  page.Currency,
 	}
 
 	for i := range data {
@@ -189,7 +190,8 @@ func (s *DataStorage) GetLeaderboardPage(page, pageSize, sortOrder int, currency
 	// if totalCount == 0 {
 	// }
 
-	if page <= 0 || page > (totalCount/pageSize) {
+	totalPages := (totalCount + pageSize - 1) / pageSize
+	if page <= 0 || (page > totalPages && totalCount > 0) {
 		return nil, fmt.Errorf("Invalid page")
 	}
 

--- a/services/wallet/leaderboard/storage.go
+++ b/services/wallet/leaderboard/storage.go
@@ -14,10 +14,6 @@ type DataStorage struct {
 	dataMutex  sync.RWMutex
 	cryptoEtag string
 	priceEtag  string
-
-	// Statistics
-	cryptoStats Stats
-	priceStats  Stats
 }
 
 // NewDataStorage creates a new data storage instance
@@ -27,9 +23,9 @@ func NewDataStorage() *DataStorage {
 	}
 }
 
-// UpdateCryptoData updates the cryptocurrency data
+// UpdateCryptoDataWithEtag updates both cryptocurrency data and etag atomically
 // Returns true if the data was actually updated
-func (s *DataStorage) UpdateCryptoData(data []Cryptocurrency) bool {
+func (s *DataStorage) UpdateCryptoDataWithEtag(data []Cryptocurrency, etag string) bool {
 	if data == nil {
 		return false
 	}
@@ -38,12 +34,13 @@ func (s *DataStorage) UpdateCryptoData(data []Cryptocurrency) bool {
 	defer s.dataMutex.Unlock()
 
 	s.cryptoData = data
+	s.cryptoEtag = etag
 	return true
 }
 
-// UpdatePriceData updates the price data
+// UpdatePriceDataWithEtag updates both price data and etag atomically
 // Returns true if the data was actually updated
-func (s *DataStorage) UpdatePriceData(data PriceMap) bool {
+func (s *DataStorage) UpdatePriceDataWithEtag(data PriceMap, etag string) bool {
 	if data == nil {
 		return false
 	}
@@ -52,6 +49,7 @@ func (s *DataStorage) UpdatePriceData(data PriceMap) bool {
 	defer s.dataMutex.Unlock()
 
 	s.priceData = data
+	s.priceEtag = etag
 	return true
 }
 
@@ -146,55 +144,11 @@ func (s *DataStorage) GetCryptoEtag() string {
 	return s.cryptoEtag
 }
 
-// SetCryptoEtag sets the crypto data etag
-func (s *DataStorage) SetCryptoEtag(etag string) {
-	s.dataMutex.Lock()
-	defer s.dataMutex.Unlock()
-	s.cryptoEtag = etag
-}
-
 // GetPriceEtag returns the current price data etag
 func (s *DataStorage) GetPriceEtag() string {
 	s.dataMutex.RLock()
 	defer s.dataMutex.RUnlock()
 	return s.priceEtag
-}
-
-// SetPriceEtag sets the price data etag
-func (s *DataStorage) SetPriceEtag(etag string) {
-	s.dataMutex.Lock()
-	defer s.dataMutex.Unlock()
-	s.priceEtag = etag
-}
-
-// GetCryptoStats returns statistics for crypto data requests
-func (s *DataStorage) GetCryptoStats() Stats {
-	return s.cryptoStats
-}
-
-// GetPriceStats returns statistics for price data requests
-func (s *DataStorage) GetPriceStats() Stats {
-	return s.priceStats
-}
-
-// UpdateCryptoStats updates the crypto stats reference for request handling
-func (s *DataStorage) UpdateCryptoStats(stats Stats) {
-	s.cryptoStats = stats
-}
-
-// UpdatePriceStats updates the price stats reference for request handling
-func (s *DataStorage) UpdatePriceStats(stats Stats) {
-	s.priceStats = stats
-}
-
-// GetCryptoStatsRef returns a reference to crypto stats for updating
-func (s *DataStorage) GetCryptoStatsRef() *Stats {
-	return &s.cryptoStats
-}
-
-// GetPriceStatsRef returns a reference to price stats for updating
-func (s *DataStorage) GetPriceStatsRef() *Stats {
-	return &s.priceStats
 }
 
 func (s *DataStorage) GetLeaderboardPagePrices(page LeaderboardPage) *LeaderboardPagePrices {

--- a/services/wallet/leaderboard/storage.go
+++ b/services/wallet/leaderboard/storage.go
@@ -2,6 +2,7 @@ package leaderboard
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -119,13 +120,13 @@ func (s *DataStorage) GetCombinedData() []Cryptocurrency {
 }
 
 func (s *DataStorage) GetCryptoDataForPage(page, pageSize int) []Cryptocurrency {
-	if pageSize <= 0 || page < 0 {
+	if pageSize <= 0 || page <= 0 {
 		return nil
 	}
 	s.dataMutex.RLock()
 	defer s.dataMutex.RUnlock()
 
-	start := page * pageSize
+	start := (page - 1) * pageSize
 	totalCount := len(s.cryptoData)
 
 	if start >= totalCount {
@@ -212,8 +213,7 @@ func (s *DataStorage) GetLeaderboardPagePrices(page LeaderboardPage) *Leaderboar
 	}
 
 	for i := range data {
-		crypto := &data[i]
-		symbol := crypto.Symbol
+		symbol := strings.ToUpper(data[i].Symbol)
 
 		// If we have updated price data for this symbol, update the cryptocurrency
 		if priceUpdate, ok := s.priceData[symbol]; ok {
@@ -235,7 +235,7 @@ func (s *DataStorage) GetLeaderboardPage(page, pageSize, sortOrder int, currency
 	// if totalCount == 0 {
 	// }
 
-	if page < 0 || page > (totalCount/pageSize) {
+	if page <= 0 || page > (totalCount/pageSize) {
 		return nil, fmt.Errorf("Invalid page")
 	}
 

--- a/services/wallet/leaderboard/storage_test.go
+++ b/services/wallet/leaderboard/storage_test.go
@@ -83,7 +83,7 @@ func verifyCryptoPriceData(t *testing.T, expected PriceData, actual Cryptocurren
 
 func TestGetLeaderboardPageErrors(t *testing.T) {
 	s := NewDataStorage()
-	s.UpdateCryptoData(mockCrypto)
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
 
 	{
 		_, err := s.GetLeaderboardPage(-1, 10, -1, "usd")
@@ -103,7 +103,7 @@ func TestGetLeaderboardPageErrors(t *testing.T) {
 
 func TestGetLeaderboardPage(t *testing.T) {
 	s := NewDataStorage()
-	s.UpdateCryptoData(mockCrypto)
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
 
 	{
 		rst, err := s.GetLeaderboardPage(0, 3, -1, "usd")
@@ -150,8 +150,8 @@ func TestGetLeaderboardPageEmpty(t *testing.T) {
 
 func TestGetLeaderboardPageWithUpdatedPrices(t *testing.T) {
 	s := NewDataStorage()
-	s.UpdateCryptoData(mockCrypto)
-	s.UpdatePriceData(mockPriceData)
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	s.UpdatePriceDataWithEtag(mockPriceData, "test-etag")
 
 	{
 		rst, err := s.GetLeaderboardPage(0, 3, -1, "usd")
@@ -170,8 +170,8 @@ func TestGetLeaderboardPageWithUpdatedPrices(t *testing.T) {
 
 func TestGetLeaderboardPagePrices(t *testing.T) {
 	s := NewDataStorage()
-	s.UpdateCryptoData(mockCrypto)
-	s.UpdatePriceData(mockPriceData)
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	s.UpdatePriceDataWithEtag(mockPriceData, "test-etag")
 
 	{
 		rst, err := s.GetLeaderboardPage(1, 3, -1, "usd")

--- a/services/wallet/leaderboard/storage_test.go
+++ b/services/wallet/leaderboard/storage_test.go
@@ -86,17 +86,17 @@ func TestGetLeaderboardPageErrors(t *testing.T) {
 	s.UpdateCryptoData(mockCrypto)
 
 	{
-		_, err := s.GetLeaderboardPage(-1, 10, -1)
+		_, err := s.GetLeaderboardPage(-1, 10, -1, "usd")
 		require.Error(t, err)
 	}
 
 	{
-		_, err := s.GetLeaderboardPage(1, 0, -1)
+		_, err := s.GetLeaderboardPage(1, 0, -1, "usd")
 		require.Error(t, err)
 	}
 
 	{
-		_, err := s.GetLeaderboardPage(100, 100, -1)
+		_, err := s.GetLeaderboardPage(100, 100, -1, "usd")
 		require.Error(t, err)
 	}
 }
@@ -106,12 +106,13 @@ func TestGetLeaderboardPage(t *testing.T) {
 	s.UpdateCryptoData(mockCrypto)
 
 	{
-		rst, err := s.GetLeaderboardPage(0, 3, -1)
+		rst, err := s.GetLeaderboardPage(0, 3, -1, "usd")
 		require.NoError(t, err)
 		require.Equal(t, 5, rst.TotalCount)
 		require.Equal(t, 0, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
 		require.Equal(t, -1, rst.SortOrder)
+		require.Equal(t, "usd", rst.Currency)
 		require.Equal(t, 3, len(rst.Data))
 		require.Equal(t, mockCrypto[0], rst.Data[0])
 		require.Equal(t, mockCrypto[1], rst.Data[1])
@@ -119,11 +120,12 @@ func TestGetLeaderboardPage(t *testing.T) {
 	}
 
 	{
-		rst, err := s.GetLeaderboardPage(1, 3, -1)
+		rst, err := s.GetLeaderboardPage(1, 3, -1, "eur")
 		require.NoError(t, err)
 		require.Equal(t, 5, rst.TotalCount)
 		require.Equal(t, 1, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
+		require.Equal(t, "eur", rst.Currency)
 		require.Equal(t, -1, rst.SortOrder)
 		require.Equal(t, 2, len(rst.Data))
 		require.Equal(t, mockCrypto[3], rst.Data[0])
@@ -135,11 +137,12 @@ func TestGetLeaderboardPageEmpty(t *testing.T) {
 	s := NewDataStorage()
 
 	{
-		rst, err := s.GetLeaderboardPage(0, 3, -1)
+		rst, err := s.GetLeaderboardPage(0, 3, -1, "usd")
 		require.NoError(t, err)
 		require.Equal(t, 0, rst.TotalCount)
 		require.Equal(t, 0, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
+		require.Equal(t, "usd", rst.Currency)
 		require.Equal(t, -1, rst.SortOrder)
 		require.Equal(t, 0, len(rst.Data))
 	}
@@ -151,12 +154,13 @@ func TestGetLeaderboardPageWithUpdatedPrices(t *testing.T) {
 	s.UpdatePriceData(mockPriceData)
 
 	{
-		rst, err := s.GetLeaderboardPage(0, 3, -1)
+		rst, err := s.GetLeaderboardPage(0, 3, -1, "usd")
 		require.NoError(t, err)
 		require.Equal(t, 5, rst.TotalCount)
 		require.Equal(t, 0, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
 		require.Equal(t, -1, rst.SortOrder)
+		require.Equal(t, "usd", rst.Currency)
 		require.Equal(t, 3, len(rst.Data))
 		require.Equal(t, mockCrypto[2], rst.Data[2])
 		verifyCryptoPriceData(t, mockPriceData["btc"], rst.Data[0])
@@ -170,11 +174,12 @@ func TestGetLeaderboardPagePrices(t *testing.T) {
 	s.UpdatePriceData(mockPriceData)
 
 	{
-		rst, err := s.GetLeaderboardPage(1, 3, -1)
+		rst, err := s.GetLeaderboardPage(1, 3, -1, "usd")
 		require.NoError(t, err)
 		require.Equal(t, 5, rst.TotalCount)
 		require.Equal(t, 1, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
+		require.Equal(t, "usd", rst.Currency)
 		require.Equal(t, -1, rst.SortOrder)
 		require.Equal(t, 2, len(rst.Data))
 	}

--- a/services/wallet/leaderboard/storage_test.go
+++ b/services/wallet/leaderboard/storage_test.go
@@ -60,15 +60,15 @@ var mockCrypto = []Cryptocurrency{
 }
 
 var mockPriceData = map[string]PriceData{
-	"btc": {
+	"BTC": {
 		Price:            79451,
 		PercentChange24h: 6.49692,
 	},
-	"eth": {
+	"ETH": {
 		Price:            1576.35,
 		PercentChange24h: 9.82681,
 	},
-	"ada": {
+	"ADA": {
 		Price:            0.3742,
 		PercentChange24h: 0.0041,
 	},
@@ -106,10 +106,14 @@ func TestGetLeaderboardPage(t *testing.T) {
 	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
 
 	{
-		rst, err := s.GetLeaderboardPage(0, 3, -1, "usd")
+		_, err := s.GetLeaderboardPage(0, 3, -1, "usd")
+		require.Error(t, err) // Page 0 is invalid
+	}
+	{
+		rst, err := s.GetLeaderboardPage(1, 3, -1, "usd")
 		require.NoError(t, err)
 		require.Equal(t, 5, rst.TotalCount)
-		require.Equal(t, 0, rst.Page)
+		require.Equal(t, 1, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
 		require.Equal(t, -1, rst.SortOrder)
 		require.Equal(t, "usd", rst.Currency)
@@ -120,10 +124,10 @@ func TestGetLeaderboardPage(t *testing.T) {
 	}
 
 	{
-		rst, err := s.GetLeaderboardPage(1, 3, -1, "eur")
+		rst, err := s.GetLeaderboardPage(2, 3, -1, "eur")
 		require.NoError(t, err)
 		require.Equal(t, 5, rst.TotalCount)
-		require.Equal(t, 1, rst.Page)
+		require.Equal(t, 2, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
 		require.Equal(t, "eur", rst.Currency)
 		require.Equal(t, -1, rst.SortOrder)
@@ -137,10 +141,10 @@ func TestGetLeaderboardPageEmpty(t *testing.T) {
 	s := NewDataStorage()
 
 	{
-		rst, err := s.GetLeaderboardPage(0, 3, -1, "usd")
+		rst, err := s.GetLeaderboardPage(1, 3, -1, "usd")
 		require.NoError(t, err)
 		require.Equal(t, 0, rst.TotalCount)
-		require.Equal(t, 0, rst.Page)
+		require.Equal(t, 1, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
 		require.Equal(t, "usd", rst.Currency)
 		require.Equal(t, -1, rst.SortOrder)
@@ -154,17 +158,17 @@ func TestGetLeaderboardPageWithUpdatedPrices(t *testing.T) {
 	s.UpdatePriceDataWithEtag(mockPriceData, "test-etag")
 
 	{
-		rst, err := s.GetLeaderboardPage(0, 3, -1, "usd")
+		rst, err := s.GetLeaderboardPage(1, 3, -1, "usd")
 		require.NoError(t, err)
 		require.Equal(t, 5, rst.TotalCount)
-		require.Equal(t, 0, rst.Page)
+		require.Equal(t, 1, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
 		require.Equal(t, -1, rst.SortOrder)
 		require.Equal(t, "usd", rst.Currency)
 		require.Equal(t, 3, len(rst.Data))
 		require.Equal(t, mockCrypto[2], rst.Data[2])
-		verifyCryptoPriceData(t, mockPriceData["btc"], rst.Data[0])
-		verifyCryptoPriceData(t, mockPriceData["eth"], rst.Data[1])
+		verifyCryptoPriceData(t, mockPriceData["BTC"], rst.Data[0])
+		verifyCryptoPriceData(t, mockPriceData["ETH"], rst.Data[1])
 	}
 }
 
@@ -174,10 +178,10 @@ func TestGetLeaderboardPagePrices(t *testing.T) {
 	s.UpdatePriceDataWithEtag(mockPriceData, "test-etag")
 
 	{
-		rst, err := s.GetLeaderboardPage(1, 3, -1, "usd")
+		rst, err := s.GetLeaderboardPage(2, 3, -1, "usd")
 		require.NoError(t, err)
 		require.Equal(t, 5, rst.TotalCount)
-		require.Equal(t, 1, rst.Page)
+		require.Equal(t, 2, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
 		require.Equal(t, "usd", rst.Currency)
 		require.Equal(t, -1, rst.SortOrder)
@@ -191,15 +195,16 @@ func TestGetLeaderboardPagePrices(t *testing.T) {
 	}
 
 	{
-		page := LeaderboardPage{
-			Page:      1,
+		rst := s.GetLeaderboardPagePrices(LeaderboardPage{
+			Page:      2,
 			PageSize:  3,
 			SortOrder: -1,
-		}
-		rst := s.GetLeaderboardPagePrices(page)
+			Currency:  "usd",
+		})
 		require.NotNil(t, rst)
-		require.Equal(t, 1, rst.Page)
+		require.Equal(t, 2, rst.Page)
 		require.Equal(t, 3, rst.PageSize)
+		require.Equal(t, "usd", rst.Currency)
 		require.Equal(t, -1, rst.SortOrder)
 		require.Equal(t, 1, len(rst.Data)) // Only one crypto price (out of 2) was updated on this page
 	}

--- a/services/wallet/leaderboard/subscripition_test.go
+++ b/services/wallet/leaderboard/subscripition_test.go
@@ -1,0 +1,45 @@
+package leaderboard
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmit(t *testing.T) {
+	m := NewSubscriptionManager()
+	chn := m.Subscribe()
+	require.NotNil(t, chn)
+
+	received := make(chan int, 3) // buffer for the 3 emits
+
+	go func() {
+		for sig := range chn {
+			received <- sig.Source()
+		}
+	}()
+
+	m.Emit(context.Background(), 10)
+	m.Emit(context.Background(), 15)
+
+	got := make(map[int]int)
+	timeout := time.After(1 * time.Second)
+
+	// Verify signal are received once
+	for i := 0; i < 2; i++ {
+		select {
+		case src := <-received:
+			got[src]++
+			require.Equal(t, got[src], 1, "received signal from source %d more than once", src)
+		case <-timeout:
+			t.Fatal("timeout waiting for signals")
+		}
+	}
+
+	// Verify all expected signals were received exactly once
+	for _, expected := range []int{15} {
+		require.Equal(t, 1, got[expected], "expected signal from source %d once, got %d", expected, got[expected])
+	}
+}

--- a/services/wallet/leaderboard/subscription.go
+++ b/services/wallet/leaderboard/subscription.go
@@ -5,22 +5,34 @@ import (
 	"sync"
 )
 
+type Signal struct {
+	source int
+}
+
+func NewSignal(source int) Signal {
+	return Signal{source: source}
+}
+
+func (s Signal) Source() int {
+	return s.source
+}
+
 // SubscriptionManager handles event subscriptions and notifications
 type SubscriptionManager struct {
 	mu          sync.RWMutex
-	subscribers map[chan struct{}]struct{}
+	subscribers map[chan Signal]struct{}
 }
 
 // NewSubscriptionManager creates a new subscription manager
 func NewSubscriptionManager() *SubscriptionManager {
 	return &SubscriptionManager{
-		subscribers: make(map[chan struct{}]struct{}),
+		subscribers: make(map[chan Signal]struct{}),
 	}
 }
 
 // Subscribe creates a new subscription and returns a channel that will receive notifications
-func (s *SubscriptionManager) Subscribe() chan struct{} {
-	ch := make(chan struct{}, 1)
+func (s *SubscriptionManager) Subscribe() chan Signal {
+	ch := make(chan Signal, 2) // Buffered channel to avoid blocking
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.subscribers[ch] = struct{}{}
@@ -28,7 +40,7 @@ func (s *SubscriptionManager) Subscribe() chan struct{} {
 }
 
 // Unsubscribe removes a subscription and closes its channel
-func (s *SubscriptionManager) Unsubscribe(ch chan struct{}) {
+func (s *SubscriptionManager) Unsubscribe(ch chan Signal) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	_, exist := s.subscribers[ch]
@@ -40,15 +52,16 @@ func (s *SubscriptionManager) Unsubscribe(ch chan struct{}) {
 }
 
 // Emit sends a notification to all subscribers
-func (s *SubscriptionManager) Emit(ctx context.Context) {
+func (s *SubscriptionManager) Emit(ctx context.Context, source int) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	signal := NewSignal(source)
 	for subscriber := range s.subscribers {
 		select {
 		case <-ctx.Done():
 			// Stop sending notifications when the context is cancelled
 			return
-		case subscriber <- struct{}{}:
+		case subscriber <- signal:
 			// Notified successfully
 		default:
 			// Skip notification if the subscriber's channel is full (non-blocking)

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -212,9 +212,9 @@ func NewService(
 
 	leaderboardConfig := leaderboard.NewLeaderbordConfig(config.WalletConfig.MarketDataProxyConfig)
 	{ // TODO REMOVE debug code
-		leaderboardConfig.ProxyURL = "https://cmc.callfry.com"
-		leaderboardConfig.Login = "admin"
-		leaderboardConfig.Password = "testest"
+		leaderboardConfig.ProxyURL = "https://cg.callfry.com"
+		leaderboardConfig.Login = "test"
+		leaderboardConfig.Password = "test"
 	}
 	leaderboardService := leaderboard.NewMarketDataService(leaderboardConfig, feed)
 

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -211,6 +211,11 @@ func NewService(
 	routeExecutionManager := routeexecution.NewManager(db, feed, router, transactionManager, transferController)
 
 	leaderboardConfig := leaderboard.NewLeaderbordConfig(config.WalletConfig.MarketDataProxyConfig)
+	{ // TODO REMOVE debug code
+		leaderboardConfig.ProxyURL = "https://cmc.callfry.com"
+		leaderboardConfig.Login = "admin"
+		leaderboardConfig.Password = "testest"
+	}
 	leaderboardService := leaderboard.NewMarketDataService(leaderboardConfig, feed)
 
 	return &Service{


### PR DESCRIPTION
* Added data updated event for currently selected page
* Improved logic for emit. Now it can be checked what is the source of the signal
* Refactored the logic for starting and stoping the refresh loops. There is no need to run refresh loops when leaderboard is not used. Can be adjusted in the future
* Removed not used logic