### PR TITLE
test_: use local waku fleet for functional tests

### DIFF
--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -37,6 +37,7 @@ RUN mkdir -p /static/configs
 COPY --from=builder /go/src/github.com/status-im/status-go/build/bin/$build_target /usr/local/bin/
 COPY --from=builder /go/src/github.com/status-im/status-go/static/keys/* /static/keys/
 COPY --from=builder /go/src/github.com/status-im/status-go/tests-functional/config.json /static/configs/
+COPY --from=builder /go/src/github.com/status-im/status-go/tests-functional/waku_configs/* /static/configs/
 
 RUN ln -s /usr/local/bin/$build_target /usr/local/bin/entrypoint
 

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -23,7 +23,7 @@ mkdir -p "${binary_coverage_reports_path}"
 mkdir -p "${merged_coverage_reports_path}"
 mkdir -p "${test_results_path}"
 
-all_compose_files="-f ${root_path}/docker-compose.anvil.yml -f ${root_path}/docker-compose.test.status-go.yml"
+all_compose_files="-f ${root_path}/docker-compose.anvil.yml -f ${root_path}/docker-compose.test.status-go.yml -f ${root_path}/docker-compose.waku.yml"
 identifier=${BUILD_ID:-$(git rev-parse --short HEAD)}
 project_name="status-go-func-tests-${identifier}"
 

--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -48,13 +48,14 @@ Functional tests for status-go
 By default, `status-backend` will use a hard-coded list of supported fleets, and select `status.prod` by default. Functional tests provide 2 options to ask status-go to use a different Waku fleet.
 
 - Use `--waku-fleets-config` to override the list of supported fleets. \
-    The value will be passed to `InitializeApplication.wakuFleetsConfigFilePath` parameter. 
+    The value will be passed to `InitializeApplication.wakuFleetsConfigFilePath` parameter. By default, it's set to JSON config for local waku fleet.
 - Use `--waku-fleet` to select a Waku fleet to be used by `status-go`. \
+    E.g. `--waku-fleet=status-go.test` to run the functional tests with a local waku fleet. If not set then prod fleet is used.
     The value will be passed to all of these parameters:
     - `CreateAccount.wakuV2Fleet`
     - `RestoreAccount.wakuV2Fleet`
 
-Please refer to the description of these parameters in `stauts-go` for details.
+Please refer to the description of these parameters in `status-go` for details.
 
 ### Prerequisites for Mac OSx users
 If you see errors at attempt to run tests, try to run in terminal:

--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -45,12 +45,12 @@ Functional tests for status-go
 
 #### Running with a custom Waku fleet
 
-By default, `status-backend` will use a hard-coded list of supported fleets, and select `status.prod` by default. Functional tests provide 2 options to ask status-go to use a different Waku fleet.
+`status-backend` can use a hard-coded list of supported Waku fleets or fleets specified in a config file. Functional tests provide 2 options to specify which Waku fleet to use.
 
-- Use `--waku-fleets-config` to override the list of supported fleets. \
-    The value will be passed to `InitializeApplication.wakuFleetsConfigFilePath` parameter. By default, it's set to JSON config for local waku fleet.
+- Use `--waku-fleets-config` to override the hard-coded list of supported fleets. \
+    The value will be passed to `InitializeApplication.wakuFleetsConfigFilePath` parameter. By default, it's set to JSON config for a local waku fleet. To run with a fleet from the hard-coded list use `--waku-fleets-config=""` and corresponding `--waku-fleet` value, e.g. `--waku-fleet=status.prod`
 - Use `--waku-fleet` to select a Waku fleet to be used by `status-go`. \
-    E.g. `--waku-fleet=status-go.test` to run the functional tests with a local waku fleet. If not set then prod fleet is used.
+    Default is `status-go.test` that will use local waku nodes for functional tests run. 
     The value will be passed to all of these parameters:
     - `CreateAccount.wakuV2Fleet`
     - `RestoreAccount.wakuV2Fleet`

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -191,10 +191,7 @@ class StatusBackend(RpcClient, SignalClient):
             "logLevel": "DEBUG",
             "apiLogging": True,
         }
-
-        if option.waku_fleets_config and option.waku_fleet:
-            data["wakuFleetsConfigFilePath"] = option.waku_fleets_config
-
+        data["wakuFleetsConfigFilePath"] = option.waku_fleets_config
         return self.api_valid_request(method, data)
 
     def _set_networks(self, data, **kwargs):

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -192,8 +192,8 @@ class StatusBackend(RpcClient, SignalClient):
             "apiLogging": True,
         }
 
-        if option.waku_fleet:
-            data["wakuFleetsConfigFilePath"] = f"/static/configs/{option.waku_fleets_config}"
+        if option.waku_fleets_config and option.waku_fleet:
+            data["wakuFleetsConfigFilePath"] = option.waku_fleets_config
 
         return self.api_valid_request(method, data)
 

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -189,7 +189,7 @@ class StatusBackend(RpcClient, SignalClient):
             "dataDir": self.data_dir,
             "logEnabled": True,
             "logLevel": "DEBUG",
-            "apiLogging": True
+            "apiLogging": True,
         }
 
         if option.waku_fleet:

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -189,9 +189,12 @@ class StatusBackend(RpcClient, SignalClient):
             "dataDir": self.data_dir,
             "logEnabled": True,
             "logLevel": "DEBUG",
-            "apiLogging": True,
-            "wakuFleetsConfigFilePath": option.waku_fleets_config,
+            "apiLogging": True
         }
+
+        if option.waku_fleet:
+            data["wakuFleetsConfigFilePath"] = f"/static/configs/{option.waku_fleets_config}"
+
         return self.api_valid_request(method, data)
 
     def _set_networks(self, data, **kwargs):

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -45,7 +45,7 @@ def pytest_addoption(parser):
         "--waku-fleets-config",
         action="store",
         help="Path to a local JSON file with Waku fleets configuration",
-        default=None,
+        default="wakufleetconfig.json",
     )
     parser.addoption(
         "--waku-fleet",

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -44,13 +44,13 @@ def pytest_addoption(parser):
     parser.addoption(
         "--waku-fleets-config",
         action="store",
-        help="Path to a local JSON file with Waku fleets configuration",
-        default="wakufleetconfig.json",
+        help="Path to a local JSON file with Waku fleets configuration. Default value is a path to config in Docker to run 2 local waku nodes",
+        default="/static/configs/wakufleetconfig.json",
     )
     parser.addoption(
         "--waku-fleet",
         action="store",
-        help="Waku fleet to be used",
+        help="Waku fleet to be used. Example: --waku-fleet=status-go.test",
         default=None,
     )
 

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -50,8 +50,8 @@ def pytest_addoption(parser):
     parser.addoption(
         "--waku-fleet",
         action="store",
-        help="Waku fleet to be used. Example: --waku-fleet=status-go.test",
-        default=None,
+        help="Waku fleet to be used. Default: --waku-fleet=status-go.test",
+        default="status-go.test",
     )
 
 

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   boot-1:
     image: wakuorg/nwaku:v0.34.0
@@ -15,7 +13,7 @@ services:
       "--filter=true",
       "--keep-alive=true",
       "--lightpush=true",
-      "--log-level=DEBUG",
+      "--log-level=INFO",
       "--max-connections=18000",
       "--nodekey=03ce9122016be1f80a23df36525103bed1c7c4b9a0ff7605d97553ed8ed96bcf",
       "--peer-exchange=true",
@@ -46,7 +44,7 @@ services:
       "--dns-addrs-name-server=127.0.0.11",
       "--dns4-domain-name=store",
       "--keep-alive=true",
-      "--log-level=DEBUG",
+      "--log-level=INFO",
       "--max-connections=18000",
       "--nodekey=3190bc9b55b18dbc171997a7a67abcd5bbf0c81002ad9617b1cb67f2f15daa64",
       "--peer-exchange=false",

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -1,0 +1,68 @@
+version: '3.8'
+
+services:
+  boot-1:
+    image: wakuorg/nwaku:v0.35.0
+    entrypoint: [
+      "/usr/bin/wakunode",
+      "--peer-exchange=true",
+      "--rest-address=0.0.0.0",
+      "--rest-admin",
+      "--keep-alive=true",
+      "--max-connections=18000",
+      "--discv5-discovery=true",
+      "--discv5-enr-auto-update=True",
+      "--cluster-id=16",
+      "--shard=32",
+      "--shard=64",
+      "--tcp-port=60001",
+      "--discv5-udp-port=9000",
+      "--log-level=DEBUG",
+      "--nodekey=03ce9122016be1f80a23df36525103bed1c7c4b9a0ff7605d97553ed8ed96bcf",
+      # Docker DNS server
+      "--dns-addrs-name-server=127.0.0.11",
+      "--dns4-domain-name=boot-1",
+      "--relay=true",
+      "--filter=true",
+      "--lightpush=true",
+      "--staticnode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi",
+      "--storenode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi"
+      # "--dns-addrs=true"
+    ]
+    depends_on:
+      - store
+
+    healthcheck:
+      test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
+
+  store:
+    image: wakuorg/nwaku:v0.35.0
+    entrypoint: [
+      "/usr/bin/wakunode",
+      "--peer-exchange=true",
+      "--rest-address=0.0.0.0",
+      "--rest-admin",
+      "--keep-alive=true",
+      "--max-connections=18000",
+      "--discv5-discovery=true",
+      "--discv5-enr-auto-update=True",
+      "--cluster-id=16",
+      "--shard=32",
+      "--shard=64",
+      "--tcp-port=60002",
+      "--discv5-udp-port=9000",
+      "--log-level=DEBUG",
+      "--nodekey=3190bc9b55b18dbc171997a7a67abcd5bbf0c81002ad9617b1cb67f2f15daa64",
+      # Docker DNS server
+      "--dns-addrs-name-server=127.0.0.11",
+      #"--dns-addrs=true"
+      "--dns4-domain-name=store",
+      "--relay=true",
+      "--store=true"
+    ]
+    # --staticnode="/dns4/boot-1/tcp/60002/p2p/16Uiu2HAm3vFYHkGRURyJ6F7bwDyzMLtPEuCg4DU89T7km2u8Fjyb"
+    command: >
+
+    healthcheck:
+      test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
+

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -2,32 +2,31 @@ version: '3.8'
 
 services:
   boot-1:
-    image: wakuorg/nwaku:v0.35.0
+    image: wakuorg/nwaku:v0.34.0
     entrypoint: [
       "/usr/bin/wakunode",
-      "--peer-exchange=true",
-      "--rest-address=0.0.0.0",
-      "--rest-admin",
-      "--keep-alive=true",
-      "--max-connections=18000",
       "--discv5-discovery=true",
       "--discv5-enr-auto-update=True",
-      "--cluster-id=16",
-      "--shard=32",
-      "--shard=64",
-      "--tcp-port=60001",
       "--discv5-udp-port=9000",
-      "--log-level=DEBUG",
-      "--nodekey=03ce9122016be1f80a23df36525103bed1c7c4b9a0ff7605d97553ed8ed96bcf",
+      "--cluster-id=16",
       # Docker DNS server
       "--dns-addrs-name-server=127.0.0.11",
       "--dns4-domain-name=boot-1",
-      "--relay=true",
       "--filter=true",
+      "--keep-alive=true",
       "--lightpush=true",
+      "--log-level=DEBUG",
+      "--max-connections=18000",
+      "--nodekey=03ce9122016be1f80a23df36525103bed1c7c4b9a0ff7605d97553ed8ed96bcf",
+      "--peer-exchange=true",
+      "--relay=true",
+      "--rest-address=0.0.0.0",
+      "--rest-admin",
+      "--shard=32",
+      "--shard=64",
       "--staticnode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi",
-      "--storenode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi"
-      # "--dns-addrs=true"
+      "--storenode=/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi",
+      "--tcp-port=60001"
     ]
     depends_on:
       - store
@@ -36,33 +35,30 @@ services:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
 
   store:
-    image: wakuorg/nwaku:v0.35.0
+    image: wakuorg/nwaku:v0.34.0
     entrypoint: [
       "/usr/bin/wakunode",
-      "--peer-exchange=true",
-      "--rest-address=0.0.0.0",
-      "--rest-admin",
-      "--keep-alive=true",
-      "--max-connections=18000",
       "--discv5-discovery=true",
       "--discv5-enr-auto-update=True",
-      "--cluster-id=16",
-      "--shard=32",
-      "--shard=64",
-      "--tcp-port=60002",
       "--discv5-udp-port=9000",
-      "--log-level=DEBUG",
-      "--nodekey=3190bc9b55b18dbc171997a7a67abcd5bbf0c81002ad9617b1cb67f2f15daa64",
+      "--cluster-id=16",
       # Docker DNS server
       "--dns-addrs-name-server=127.0.0.11",
-      #"--dns-addrs=true"
       "--dns4-domain-name=store",
+      "--keep-alive=true",
+      "--log-level=DEBUG",
+      "--max-connections=18000",
+      "--nodekey=3190bc9b55b18dbc171997a7a67abcd5bbf0c81002ad9617b1cb67f2f15daa64",
+      "--peer-exchange=false",
       "--relay=true",
-      "--store=true"
+      "--rest-address=0.0.0.0",
+      "--rest-admin",
+      "--shard=32",
+      "--shard=64",
+      "--staticnode=/dns4/boot-1/tcp/60001/p2p/16Uiu2HAm3vFYHkGRURyJ6F7bwDyzMLtPEuCg4DU89T7km2u8Fjyb",
+      "--store=true",
+      "--tcp-port=60002"
     ]
-    # --staticnode="/dns4/boot-1/tcp/60002/p2p/16Uiu2HAm3vFYHkGRURyJ6F7bwDyzMLtPEuCg4DU89T7km2u8Fjyb"
-    command: >
-
     healthcheck:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
 

--- a/tests-functional/waku_configs/wakufleetconfig.json
+++ b/tests-functional/waku_configs/wakufleetconfig.json
@@ -1,0 +1,17 @@
+{
+    "status-go.test": {
+      "clusterId": 16,
+      "wakuNodes": [
+        "enr:-La4QNqv0XQy7XuM0YHun6vTp9sxXoq4IT-rh3nDDOtaUP_BeFkoo-5JHtHFjM6p3hqTvOHmj3RvXedil9042MpTtlkBgmlkgnY0gmlwhKwSAAOKbXVsdGlhZGRyc40ACzYGYm9vdC0xBuphgnJzhwAQAgAgAECJc2VjcDI1NmsxoQJ-L7RtImvRuvgn_pQnJsag8tbaqPZ7mBM4Z1scEreWGoN0Y3CC6mGDdWRwgiMohXdha3UyDQ"
+      ],
+      "discV5BootstrapNodes": [],
+      "storeNodes": [
+        {
+          "id": "store-1",
+          "enr": "enr:-LW4QK-uN7FmYgWHd7w8vbUbqBljJPpfZUqSCftH_YmmfGxmP4HmDDcDj-FGO7fbr7kBrKRnPQC5Ma3RnxTj4wUvAP0EgmlkgnY0gmlwhKwSAAKKbXVsdGlhZGRyc4wACjYFc3RvcmUG6mKCcnOHABACACAAQIlzZWNwMjU2azGhAvmO_1uGYSBbONMOibc2Q7Caq36O7fOVUNsMhMwTxHPHg3RjcILqYoN1ZHCCIyiFd2FrdTID",
+          "addr": "/dns4/store/tcp/60002/p2p/16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi",
+          "fleet": "status-go.test"
+        }
+      ]
+    }
+  }


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/6485

Set up 2 local waku nodes (boot and store) running in Docker containers for functonal tests run. By default, functional test run is using now these local waku nodes instead of Waku prod fleet.

To run functional tests with local waku fleet: `pytest -m rpc` 
To run functional test with prod fleet: `pytest -m rpc --waku-fleet=status.prod --waku-fleets-config=""`