### PR TITLE
fix(communities)_: avoid retaining `response` in `watchCommunitiesToUnmute`

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -822,6 +822,10 @@ func (m *Manager) Spectated() ([]*Community, error) {
 	return m.persistence.SpectatedCommunities(&m.identity.PublicKey)
 }
 
+func (m *Manager) JoinedOrSpectated() ([]*Community, error) {
+	return m.persistence.JoinedOrSpectatedCommunities(&m.identity.PublicKey)
+}
+
 func (m *Manager) CommunityUpdateLastOpenedAt(communityID types.HexBytes, timestamp int64) (*Community, error) {
 	m.communityLock.Lock(communityID)
 	defer m.communityLock.Unlock(communityID)

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -296,6 +296,11 @@ func (p *Persistence) SpectatedCommunities(memberIdentity *ecdsa.PublicKey) ([]*
 	return p.queryCommunities(memberIdentity, query)
 }
 
+func (p *Persistence) JoinedOrSpectatedCommunities(memberIdentity *ecdsa.PublicKey) ([]*Community, error) {
+	query := communitiesBaseQuery + ` WHERE c.joined OR c.spectated`
+	return p.queryCommunities(memberIdentity, query)
+}
+
 func (p *Persistence) rowsToCommunityRecords(rows *sql.Rows) (result []*CommunityRecordBundle, err error) {
 	defer func() {
 		if err != nil {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1621,26 +1621,29 @@ func (m *Messenger) watchChatsToUnmute() {
 
 // watchCommunitiesToUnmute checks every minute to identify and unmute communities that should no longer be muted.
 func (m *Messenger) watchCommunitiesToUnmute() {
-	m.logger.Debug("Checking for communities to unmute every minute")
+	logger := m.logger.Named("watchCommunitiesToUnmute")
+	logger.Debug("starting")
+
+	check := func() {
+		response, err := m.CheckCommunitiesToUnmute()
+		if err != nil {
+			logger.Warn("couldn't check communities to unmute", zap.Error(err))
+		} else if !response.IsEmpty() {
+			signal.SendNewMessages(response)
+		}
+	}
+
 	go func() {
 		defer gocommon.LogOnPanic()
+		check()
+
+		ticker := time.NewTicker(time.Minute)
+		defer ticker.Stop()
+
 		for {
-			// Execute the check immediately upon starting
-			response, err := m.CheckCommunitiesToUnmute()
-			if err != nil {
-				m.logger.Warn("watchCommunitiesToUnmute error", zap.Any("Couldn't unmute communities", err))
-			} else if !response.IsEmpty() {
-				signal.SendNewMessages(response)
-			}
-
-			// Calculate the time until the next whole minute
-			now := time.Now()
-			waitDuration := time.Until(now.Truncate(time.Minute).Add(time.Minute))
-
-			// Wait until the next minute
 			select {
-			case <-time.After(waitDuration):
-				// Continue to next iteration
+			case <-ticker.C:
+				check()
 			case <-m.quit:
 				return
 			}

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -844,9 +844,8 @@ func (m *Messenger) schedulePublishGrantsForControlledCommunities() {
 }
 
 func (m *Messenger) CheckCommunitiesToUnmute() (*MessengerResponse, error) {
-	m.logger.Debug("watching communities to unmute")
 	response := &MessengerResponse{}
-	communities, err := m.communitiesManager.All()
+	communities, err := m.communitiesManager.JoinedOrSpectated()
 	currTime := time.Now()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get all communities: %v", err)


### PR DESCRIPTION
Previously, the loop retained a reference to `response` object, preventing it from being garbage collected. This led to unnecessary memory retention, as the object included all communities and could grow large. Additionally, the logic scanned all communities, whereas the unmute operation should only consider joined or spectated ones.


Issue found during investigation of https://github.com/status-im/status-mobile/issues/22463
![image](https://github.com/user-attachments/assets/1966f23f-d071-4618-86e0-ef17bba930e2)
