### PR TITLE
fix_: cache read-only communities to reduce memory pressure

### DIFF
--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -73,6 +73,13 @@ type Community struct {
 	mediaServer server.MediaServerInterface
 }
 
+type ReadonlyCommunity interface {
+	ID() types.HexBytes
+	IsControlNode() bool
+	CanPost(pk *ecdsa.PublicKey, chatID string, messageType protobuf.ApplicationMetadataMessage_Type) (bool, error)
+	IsBanned(pk *ecdsa.PublicKey) bool
+}
+
 func New(config Config, timesource common.TimeSource, encryptor DescriptionEncryptor, mediaServer server.MediaServerInterface) (*Community, error) {
 	if config.MemberIdentity == nil {
 		return nil, errors.New("no member identity")

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -2344,7 +2344,7 @@ func (m *Messenger) updateChatFirstMessageTimestamp(chat *Chat, timestamp uint32
 		return nil
 	}
 
-	community, err := m.communitiesManager.GetByIDString(chat.CommunityID)
+	community, err := m.communitiesManager.GetByIDStringReadonly(chat.CommunityID)
 	if err != nil {
 		return err
 	}

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2198,7 +2198,7 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 			return err
 		}
 
-		community, err := m.GetCommunityByID(communityID)
+		community, err := m.communitiesManager.GetByIDReadonly(communityID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Full database reads, especially on message receipt, caused repeated allocations and high RAM usage due to unmarshaling full community objects. This change introduces a lightweight cache (up to 5 entries, 1-minute TTL) to avoid redundant DB access and deserialization for commonly used communities.

Issue found during investigation of https://github.com/status-im/status-mobile/issues/22463

CPU and Memory are a bit better.
![cache_fix_metrics](https://github.com/user-attachments/assets/b2ff5c6c-9e86-47e8-9828-a0a4f22ed85d)

Total memory allocation (not to be confused with memory in use) during a 4-minute app run dropped from 10 GB to less than 2 GB.
![cache_fix_mem_allocation](https://github.com/user-attachments/assets/b81a4070-b7d1-4283-8b65-15639689d2f7)

Interestingly, the Go runtime is quite greedy and reluctant to return unused memory to the operating system. See below:
```
HeapAlloc: 177 MB
HeapSys:   337 MB
HeapInuse: 199 MB
HeapIdle: 137 MB
HeapReleased: 12 MB
HeapToReturnToOS: 125 MB
StackInuse: 6 MB
```
