### PR TITLE
chore(swap)_: swap fees calculation improved

### DIFF
--- a/services/wallet/thirdparty/paraswap/request_price_route.go
+++ b/services/wallet/thirdparty/paraswap/request_price_route.go
@@ -29,6 +29,35 @@ type Route struct {
 	TokenTransferProxy common.Address  `json:"tokenTransferProxy"`
 }
 
+func (r *Route) Copy() *Route {
+	gasCost := new(bigint.BigInt)
+	if r.GasCost != nil {
+		gasCost.Int = big.NewInt(r.GasCost.Int64())
+	}
+	srcAmount := new(bigint.BigInt)
+	if r.SrcAmount != nil {
+		srcAmount.Int = big.NewInt(r.SrcAmount.Int64())
+	}
+	destAmount := new(bigint.BigInt)
+	if r.DestAmount != nil {
+		destAmount.Int = big.NewInt(r.DestAmount.Int64())
+	}
+
+	return &Route{
+		GasCost:            gasCost,
+		SrcAmount:          srcAmount,
+		SrcTokenAddress:    r.SrcTokenAddress,
+		SrcTokenDecimals:   r.SrcTokenDecimals,
+		DestAmount:         destAmount,
+		DestTokenAddress:   r.DestTokenAddress,
+		DestTokenDecimals:  r.DestTokenDecimals,
+		RawPriceRoute:      r.RawPriceRoute,
+		Side:               r.Side,
+		ContractAddress:    r.ContractAddress,
+		TokenTransferProxy: r.TokenTransferProxy,
+	}
+}
+
 type PriceRouteResponse struct {
 	PriceRoute json.RawMessage `json:"priceRoute"`
 	Error      string          `json:"error"`


### PR DESCRIPTION
The fees for the swap tx were calculated based on the response received by the paraswap prices request, but not calculated based on the real tx that is being placed for the swap. It was, most likely, done that way because of not building the tx on the statusgo side, but relaying to paraswap API for building it, since no other way. That's corrected now.

For this tx:
- https://etherscan.io/tx/0xce8b98ac3c7664b8ca4556494ee9a1bd1a81ba864d788939cd8d2e9bf767408c

The displayed "normal" fee was `0.49$`