### PR TITLE
feat(news)_: add NewsFeedLastFetchedTimestamp setting and hook it

### DIFF
--- a/appdatabase/migrations/sql/1744737285_add_settings_news_feed_last_fetched_timestamp.up.sql
+++ b/appdatabase/migrations/sql/1744737285_add_settings_news_feed_last_fetched_timestamp.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE settings ADD COLUMN news_feed_last_fetched_timestamp TIMESTAMP;
+UPDATE settings SET news_feed_last_fetched_timestamp = CURRENT_TIMESTAMP WHERE news_feed_last_fetched_timestamp IS NULL;

--- a/internal/newsfeed/news_feed_manager.go
+++ b/internal/newsfeed/news_feed_manager.go
@@ -96,8 +96,10 @@ func (n *NewsFeedManager) FetchRSS() ([]*gofeed.Item, error) {
 		}
 	}
 
-	// Update fetchFrom to now
-	n.fetchFrom = time.Now()
+	if len(filteredItems) > 0 {
+		// Update fetchFrom to now since we have new items
+		n.fetchFrom = time.Now()
+	}
 
 	return filteredItems, nil
 }

--- a/multiaccounts/settings/columns.go
+++ b/multiaccounts/settings/columns.go
@@ -227,6 +227,21 @@ var (
 		dBColumnName:   "networks",
 		valueHandler:   JSONBlobHandler,
 	}
+	NewsFeedEnabled = SettingField{
+		reactFieldName: "news-feed-enabled?",
+		dBColumnName:   "news_feed_enabled",
+		valueHandler:   BoolHandler,
+	}
+	NewsFeedLastFetchedTimestamp = SettingField{
+		reactFieldName: "news-feed-last-fetched-timestamp",
+		dBColumnName:   "news_feed_last_fetched_timestamp",
+		valueHandler:   TimeHandler,
+	}
+	NewsNotificationsEnabled = SettingField{
+		reactFieldName: "news-notifications-enabled?",
+		dBColumnName:   "news_notifications_enabled",
+		valueHandler:   BoolHandler,
+	}
 	NodeConfig = SettingField{
 		reactFieldName: "node-config",
 		dBColumnName:   "node_config",
@@ -322,11 +337,6 @@ var (
 	RemotePushNotificationsEnabled = SettingField{
 		reactFieldName: "remote-push-notifications-enabled?",
 		dBColumnName:   "remote_push_notifications_enabled",
-		valueHandler:   BoolHandler,
-	}
-	NewsNotificationsEnabled = SettingField{
-		reactFieldName: "news-notifications-enabled?",
-		dBColumnName:   "news_notifications_enabled",
 		valueHandler:   BoolHandler,
 	}
 	MessengerNotificationsEnabled = SettingField{
@@ -527,11 +537,6 @@ var (
 		dBColumnName:   "last_tokens_update",
 		valueHandler:   TimeHandler,
 	}
-	NewsFeedEnabled = SettingField{
-		reactFieldName: "news-feed-enabled?",
-		dBColumnName:   "news_feed_enabled",
-		valueHandler:   BoolHandler,
-	}
 	SettingFieldRegister = []SettingField{
 		AnonMetricsShouldSend,
 		Appearance,
@@ -574,6 +579,8 @@ var (
 		Name,
 		NetworksCurrentNetwork,
 		NetworksNetworks,
+		NewsFeedEnabled,
+		NewsFeedLastFetchedTimestamp,
 		NewsNotificationsEnabled,
 		MessengerNotificationsEnabled,
 		NodeConfig,
@@ -612,7 +619,6 @@ var (
 		WebviewAllowPermissionRequests,
 		AutoRefreshTokensEnabled,
 		LastTokensUpdate,
-		NewsFeedEnabled,
 	}
 )
 

--- a/multiaccounts/settings/database_settings_manager.go
+++ b/multiaccounts/settings/database_settings_manager.go
@@ -83,4 +83,5 @@ type DatabaseSettingsManager interface {
 	GetPeerSyncingEnabled() (result bool, err error)
 	AutoRefreshTokensEnabled() (result bool, err error)
 	LastTokensUpdate() (result time.Time, err error)
+	NewsFeedLastFetchedTimestamp() (result time.Time, err error)
 }

--- a/multiaccounts/settings/structs.go
+++ b/multiaccounts/settings/structs.go
@@ -157,9 +157,12 @@ type Settings struct {
 	Name                 string           `json:"name,omitempty"`
 	Networks             *json.RawMessage `json:"networks/networks"`
 	// NotificationsEnabled indicates whether local notifications should be enabled (android only)
-	NotificationsEnabled bool             `json:"notifications-enabled?,omitempty"`
-	PhotoPath            string           `json:"photo-path"`
-	PinnedMailserver     *json.RawMessage `json:"pinned-mailservers,omitempty"`
+	NotificationsEnabled         bool             `json:"notifications-enabled?,omitempty"`
+	NewsFeedEnabled              bool             `json:"news-feed-enabled?,omitempty"`
+	NewsFeedLastFetchedTimestamp time.Time        `json:"news-feed-last-fetched-timestamp,omitempty"`
+	NewsNotificationsEnabled     bool             `json:"news-notifications-enabled?,omitempty"`
+	PhotoPath                    string           `json:"photo-path"`
+	PinnedMailserver             *json.RawMessage `json:"pinned-mailservers,omitempty"`
 	// PreferredName represents the user's preferred Ethereum Name Service (ENS) name.
 	// If a user has multiple ENS names, they can select one as the PreferredName.
 	// When PreferredName is set, it takes precedence over the DisplayName for displaying the user's name.
@@ -181,7 +184,6 @@ type Settings struct {
 	RememberSyncingChoice          bool `json:"remember-syncing-choice?,omitempty"`
 	// RemotePushNotificationsEnabled indicates whether we should be using remote notifications (ios only for now)
 	RemotePushNotificationsEnabled bool             `json:"remote-push-notifications-enabled?,omitempty"`
-	NewsNotificationsEnabled       bool             `json:"news-notifications-enabled?,omitempty"`
 	MessengerNotificationsEnabled  bool             `json:"messenger-notifications-enabled?,omitempty"`
 	SigningPhrase                  string           `json:"signing-phrase"`
 	StickerPacksInstalled          *json.RawMessage `json:"stickers/packs-installed,omitempty"`
@@ -227,7 +229,6 @@ type Settings struct {
 	PeerSyncingEnabled                  bool                          `json:"peer-syncing-enabled?,omitempty"`
 	AutoRefreshTokensEnabled            bool                          `json:"auto-refresh-tokens-enabled,omitempty"`
 	LastTokensUpdate                    time.Time                     `json:"last-tokens-update,omitempty"`
-	NewsFeedEnabled                     bool                          `json:"news-feed-enabled?,omitempty"`
 }
 
 func (s Settings) MarshalJSON() ([]byte, error) {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -902,15 +902,17 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	}
 
 	if m.config.featureFlags.EnableNewsFeed {
-		// TODO get the last time we opened the app
-		twoHoursAgo := time.Now().Add(-2 * time.Hour)
+		lastFetched, err := m.settings.NewsFeedLastFetchedTimestamp()
+		if err != nil {
+			return nil, err
+		}
 		m.newsFeedManager = newsfeed.NewNewsFeedManager(
 			newsfeed.WithURL(newsfeed.STATUS_FEED_URL),
 			newsfeed.WithParser(gofeed.NewParser()),
 			newsfeed.WithHandler(m),
 			newsfeed.WithLogger(m.logger),
 			newsfeed.WithPollingInterval(30*time.Minute),
-			newsfeed.WithFetchFrom(twoHoursAgo),
+			newsfeed.WithFetchFrom(lastFetched),
 		)
 
 		// TODO only start if the setting is enabled

--- a/protocol/messenger_news_feed.go
+++ b/protocol/messenger_news_feed.go
@@ -1,11 +1,14 @@
 package protocol
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/mmcdole/gofeed"
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/signal"
 )
 
@@ -43,6 +46,13 @@ func (m *Messenger) HandleFeedItem(feedItem *gofeed.Item) (*MessengerResponse, e
 	err = m.addActivityCenterNotification(response, notification, nil)
 	if err != nil {
 		m.logger.Error("HandleFeedItem: failed to save notification", zap.Error(err))
+		return nil, err
+	}
+
+	// Update the lastFetch time to the current time
+	err = m.settings.SaveSetting(settings.NewsFeedLastFetchedTimestamp.GetReactName(), time.Now())
+	if err != nil {
+		m.logger.Error("HandleFeedItem: failed to save last fetch time", zap.Error(err))
 		return nil, err
 	}
 

--- a/protocol/messenger_news_feed_test.go
+++ b/protocol/messenger_news_feed_test.go
@@ -43,6 +43,12 @@ func (s *MessengerNewsFeedSuite) TestHandleNewsFeedItem() {
 	err := s.m.HandleFeedItemAndSend(&item)
 	s.Require().NoError(err)
 
+	// Check that the lastFetched timestamp is updated
+	lastFetched, err := s.m.settings.NewsFeedLastFetchedTimestamp()
+	s.Require().NoError(err)
+	s.Require().GreaterOrEqual(time.Now().UTC().Second(), lastFetched.UTC().Second())
+
+	// Check that the notification is saved in the database
 	_, notifications, err := s.m.persistence.ActivityCenterNotifications("", 10, []ActivityCenterType{ActivityCenterNotificationTypeNews}, ActivityCenterQueryParamsReadAll, true)
 	s.Require().NoError(err)
 	s.Require().NotNil(notifications)


### PR DESCRIPTION
Fixes #6496

Adds the NewsFeedLastFetchedTimestamp to the settings Table. Defaults it to `Date.now()` for new users or `CURRENT_TIMESTAMP` for old users using the migration. That way, we will never fetch old news.

Hooks that new setting to the NewsFeedManager. With it, it makes sure that we never fetch the same News twice.
When reopening the app after some sleep, the fetch happens from the last one that succeeded, so that you don't miss anything.

I tested it in Desktop on the HackerNews RSS and it worked like a charm. After waiting for an hour, one News appeared. I restarted after and it didn't handle it again.

![image](https://github.com/user-attachments/assets/f2dd3598-daa0-4846-9e31-656613f4f96f)
