### PR TITLE
refactor!: update network name from "Mainnet" to "Ethereum"

### DIFF
--- a/api/default_networks.go
+++ b/api/default_networks.go
@@ -70,7 +70,7 @@ func mainnet(proxyHost, stageName string) params.Network {
 
 	return params.Network{
 		ChainID:                chainID,
-		ChainName:              "Mainnet",
+		ChainName:              "Ethereum",
 		RpcProviders:           rpcProviders,
 		BlockExplorerURL:       "https://etherscan.io/",
 		IconURL:                "network/Network=Ethereum",

--- a/cmd/ping-community/main.go
+++ b/cmd/ping-community/main.go
@@ -58,7 +58,7 @@ var (
 		"network-id",
 		params.SepoliaNetworkID,
 		fmt.Sprintf(
-			"A network ID: %d (Mainnet), %d (Sepolia)",
+			"A network ID: %d (Ethereum), %d (Sepolia)",
 			params.MainNetworkID, params.SepoliaNetworkID,
 		),
 	)

--- a/cmd/populate-db/main.go
+++ b/cmd/populate-db/main.go
@@ -67,7 +67,7 @@ var (
 		"network-id",
 		params.SepoliaNetworkID,
 		fmt.Sprintf(
-			"A network ID: %d (Mainnet), %d (Sepolia)",
+			"A network ID: %d (Ethereum), %d (Sepolia)",
 			params.MainNetworkID, params.SepoliaNetworkID,
 		),
 	)

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -63,7 +63,7 @@ var (
 		"network-id",
 		params.SepoliaNetworkID,
 		fmt.Sprintf(
-			"A network ID: %d (Mainnet), %d (Sepolia)",
+			"A network ID: %d (Ethereum), %d (Sepolia)",
 			params.MainNetworkID, params.SepoliaNetworkID,
 		),
 	)

--- a/services/wallet/router/pathprocessor/processor_test.go
+++ b/services/wallet/router/pathprocessor/processor_test.go
@@ -15,7 +15,7 @@ import (
 
 var mainnet = params.Network{
 	ChainID:                walletCommon.EthereumMainnet,
-	ChainName:              "Mainnet",
+	ChainName:              "Ethereum",
 	BlockExplorerURL:       "https://etherscan.io/",
 	IconURL:                "network/Network=Ethereum",
 	ChainColor:             "#627EEA",

--- a/services/wallet/router/router_test_data.go
+++ b/services/wallet/router/router_test_data.go
@@ -99,7 +99,7 @@ var (
 
 var mainnet = params.Network{
 	ChainID:   walletCommon.EthereumMainnet,
-	ChainName: "Mainnet",
+	ChainName: "Ethereum",
 	RpcProviders: []params.RpcProvider{
 		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyNodefleet, fmt.Sprintf("https://%s.api.status.im/nodefleet/ethereum/mainnet/", stageName), false),
 		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyInfura, fmt.Sprintf("https://%s.api.status.im/infura/ethereum/mainnet/", stageName), false),

--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -50,7 +50,7 @@ var (
 
 	// TestNetworkNames network ID to name mapping
 	TestNetworkNames = map[int]string{
-		params.MainNetworkID:        "Mainnet",
+		params.MainNetworkID:        "Ethereum",
 		params.StatusChainNetworkID: "StatusChain",
 		params.SepoliaNetworkID:     "Sepolia",
 	}


### PR DESCRIPTION
The goal of this PR is to show the term Ethereum instead of Mainnet to make the network identification more user-friendly.

The desktop client might also need some adjustments. A global find and replace should suffice. 

Issue: https://github.com/status-im/status-mobile/issues/22459
Mobile PR: https://github.com/status-im/status-mobile/pull/22460