### PR TITLE
fix_: cancel ongoing requests when closing the ClientWithFallback

### DIFF
--- a/circuitbreaker/circuit_breaker_test.go
+++ b/circuitbreaker/circuit_breaker_test.go
@@ -660,41 +660,5 @@ func TestCircuitBreaker_NilPointerPanic(t *testing.T) {
 	}()
 
 	// Attempt to call addCallStatus on nil pointer, which should cause the panic
-	result.addCallStatus("test-circuit", nil)
-}
-
-func TestCircuitBreaker_DeinitializedPanic(t *testing.T) {
-	// Create a circuit breaker
-	cb := NewCircuitBreaker(Config{})
-
-	// Create a command that will be executed
-	cmd := NewCommand(context.Background(), nil)
-	cmd.Add(NewFunctor(func() ([]any, error) {
-		return nil, nil
-	}, "test-circuit", ""))
-
-	// Create a channel to coordinate the test
-	done := make(chan struct{})
-
-	// Start executing the command in a goroutine
-	go func() {
-		defer close(done)
-
-		// Execute will try to use the circuit breaker after we nil it
-		result := cb.Execute(cmd)
-
-		// This line should never be reached due to panic
-		t.Error("Expected panic but got result:", result)
-	}()
-
-	// Set circuit breaker to nil to simulate deinitialization
-	cb = nil
-
-	// Wait for goroutine to finish or timeout
-	select {
-	case <-done:
-		t.Error("Expected panic but goroutine completed normally")
-	case <-time.After(time.Second):
-		// Test passes if we timeout, as this means the goroutine panicked
-	}
+	result.addCallStatus("test-circuit", nil, time.Now())
 }

--- a/circuitbreaker/circuit_breaker_test.go
+++ b/circuitbreaker/circuit_breaker_test.go
@@ -647,18 +647,3 @@ func TestCircuitBreaker_ErrorLogging(t *testing.T) {
 		assert.True(t, duration >= 0)
 	})
 }
-
-func TestCircuitBreaker_NilPointerPanic(t *testing.T) {
-	// Create a nil pointer to CommandResult
-	var result *CommandResult
-
-	// This should panic with nil pointer dereference
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("Expected panic but got none")
-		}
-	}()
-
-	// Attempt to call addCallStatus on nil pointer, which should cause the panic
-	result.addCallStatus("test-circuit", nil, time.Now())
-}

--- a/circuitbreaker/circuit_breaker_test.go
+++ b/circuitbreaker/circuit_breaker_test.go
@@ -647,3 +647,54 @@ func TestCircuitBreaker_ErrorLogging(t *testing.T) {
 		assert.True(t, duration >= 0)
 	})
 }
+
+func TestCircuitBreaker_NilPointerPanic(t *testing.T) {
+	// Create a nil pointer to CommandResult
+	var result *CommandResult
+
+	// This should panic with nil pointer dereference
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic but got none")
+		}
+	}()
+
+	// Attempt to call addCallStatus on nil pointer, which should cause the panic
+	result.addCallStatus("test-circuit", nil)
+}
+
+func TestCircuitBreaker_DeinitializedPanic(t *testing.T) {
+	// Create a circuit breaker
+	cb := NewCircuitBreaker(Config{})
+
+	// Create a command that will be executed
+	cmd := NewCommand(context.Background(), nil)
+	cmd.Add(NewFunctor(func() ([]any, error) {
+		return nil, nil
+	}, "test-circuit", ""))
+
+	// Create a channel to coordinate the test
+	done := make(chan struct{})
+
+	// Start executing the command in a goroutine
+	go func() {
+		defer close(done)
+
+		// Execute will try to use the circuit breaker after we nil it
+		result := cb.Execute(cmd)
+
+		// This line should never be reached due to panic
+		t.Error("Expected panic but got result:", result)
+	}()
+
+	// Set circuit breaker to nil to simulate deinitialization
+	cb = nil
+
+	// Wait for goroutine to finish or timeout
+	select {
+	case <-done:
+		t.Error("Expected panic but goroutine completed normally")
+	case <-time.After(time.Second):
+		// Test passes if we timeout, as this means the goroutine panicked
+	}
+}

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/status-im/status-go/circuitbreaker"
+	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/healthmanager"
 	"github.com/status-im/status-go/healthmanager/rpcstatus"
 	"github.com/status-im/status-go/logutils"
@@ -211,12 +212,14 @@ func (c *ClientWithFallback) makeCall(ctx context.Context, f MakeCallFunctor) (i
 
 	// Start a goroutine to watch for client closure
 	go func() {
+		defer gocommon.LogOnPanic()
 		select {
 		case <-c.done:
 			cancel()
 		case <-ctx.Done():
 		}
 	}()
+
 	if c.commonLimiter != nil {
 		if allow, err := c.commonLimiter.Allow(c.tag); !allow {
 			return nil, fmt.Errorf("tag=%s, %w", c.tag, err)
@@ -235,6 +238,9 @@ func (c *ClientWithFallback) makeCall(ctx context.Context, f MakeCallFunctor) (i
 	for _, ethProviderClient := range c.ethClients {
 		ethProviderClient := ethProviderClient
 		cmd.Add(circuitbreaker.NewFunctor(func() ([]interface{}, error) {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			res, err := ethProviderClient.ExecuteWithRPSLimit(f.Func)
 			if err != nil && (isVMError(err) || errors.Is(err, context.Canceled)) {
 				cmd.Cancel()

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -87,20 +87,25 @@ type ClientWithFallback struct {
 }
 
 func (c *ClientWithFallback) Copy() interface{} {
-	return &ClientWithFallback{
+	// Create a new ClientWithFallback with copied values
+	clientCopy := &ClientWithFallback{
 		ChainID:                c.ChainID,
 		ethClients:             c.ethClients,
 		commonLimiter:          c.commonLimiter,
 		circuitbreaker:         c.circuitbreaker,
 		providersHealthManager: c.providersHealthManager,
 		WalletNotifier:         c.WalletNotifier,
-		isConnected:            c.isConnected,
+		isConnected:            c.isConnected, // Use the same isConnected pointer
 		LastCheckedAt:          c.LastCheckedAt,
 		tag:                    c.tag,
 		groupTag:               c.groupTag,
-		done:                   c.done,
-		closed:                 c.closed,
+		done:                   make(chan struct{}),
 	}
+
+	// Copy the closed value
+	clientCopy.closed.Store(c.closed.Load())
+
+	return clientCopy
 }
 
 // Don't mark connection as failed if we get one of these errors
@@ -803,8 +808,24 @@ func (c *ClientWithFallback) SetGroupTag(tag string) {
 }
 
 func (c *ClientWithFallback) DeepCopyTag() tagger.Tagger {
-	clientCopy := *c
-	return &clientCopy
+	// Create a new ClientWithFallback with copied values
+	clientCopy := &ClientWithFallback{
+		ChainID:                c.ChainID,
+		ethClients:             c.ethClients,
+		commonLimiter:          c.commonLimiter,
+		circuitbreaker:         c.circuitbreaker,
+		providersHealthManager: c.providersHealthManager,
+		WalletNotifier:         c.WalletNotifier,
+		isConnected:            c.isConnected,
+		LastCheckedAt:          c.LastCheckedAt,
+		tag:                    c.tag,
+		groupTag:               c.groupTag,
+		done:                   make(chan struct{}),
+	}
+
+	clientCopy.closed.Store(c.closed.Load())
+
+	return clientCopy
 }
 
 func (c *ClientWithFallback) GetLimiter() rpclimiter.RequestLimiter {

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -82,11 +83,17 @@ type ClientWithFallback struct {
 	tag      string // tag for the limiter
 	groupTag string // tag for the limiter group
 
-	done   chan struct{} // channel to signal client closure
-	closed atomic.Bool   // flag to track if client is closed
+	done   chan struct{}  // channel to signal client closure
+	wg     sync.WaitGroup // wait group to track active operations
+	closed atomic.Bool    // flag to track if client is closed
 }
 
 func (c *ClientWithFallback) Copy() interface{} {
+	clientCopy := c.createCopy()
+	return clientCopy
+}
+
+func (c *ClientWithFallback) createCopy() *ClientWithFallback {
 	// Create a new ClientWithFallback with copied values
 	clientCopy := &ClientWithFallback{
 		ChainID:                c.ChainID,
@@ -95,7 +102,7 @@ func (c *ClientWithFallback) Copy() interface{} {
 		circuitbreaker:         c.circuitbreaker,
 		providersHealthManager: c.providersHealthManager,
 		WalletNotifier:         c.WalletNotifier,
-		isConnected:            c.isConnected, // Use the same isConnected pointer
+		isConnected:            c.isConnected,
 		LastCheckedAt:          c.LastCheckedAt,
 		tag:                    c.tag,
 		groupTag:               c.groupTag,
@@ -157,6 +164,9 @@ func (c *ClientWithFallback) Close() {
 
 	close(c.done) // signal all ongoing operations to stop
 
+	// Wait for all operations to complete
+	c.wg.Wait()
+
 	// Close all eth clients
 	for _, client := range c.ethClients {
 		client.Close()
@@ -210,6 +220,10 @@ func (c *ClientWithFallback) makeCall(ctx context.Context, f MakeCallFunctor) (i
 	if c.closed.Load() {
 		return nil, errors.New("client is closed")
 	}
+
+	// Add the operation to the wait group
+	c.wg.Add(1)
+	defer c.wg.Done()
 
 	// Create a context that will be cancelled when either the parent context is done or the client is closed
 	ctx, cancel := context.WithCancel(ctx)
@@ -808,24 +822,7 @@ func (c *ClientWithFallback) SetGroupTag(tag string) {
 }
 
 func (c *ClientWithFallback) DeepCopyTag() tagger.Tagger {
-	// Create a new ClientWithFallback with copied values
-	clientCopy := &ClientWithFallback{
-		ChainID:                c.ChainID,
-		ethClients:             c.ethClients,
-		commonLimiter:          c.commonLimiter,
-		circuitbreaker:         c.circuitbreaker,
-		providersHealthManager: c.providersHealthManager,
-		WalletNotifier:         c.WalletNotifier,
-		isConnected:            c.isConnected,
-		LastCheckedAt:          c.LastCheckedAt,
-		tag:                    c.tag,
-		groupTag:               c.groupTag,
-		done:                   make(chan struct{}),
-	}
-
-	clientCopy.closed.Store(c.closed.Load())
-
-	return clientCopy
+	return c.createCopy()
 }
 
 func (c *ClientWithFallback) GetLimiter() rpclimiter.RequestLimiter {

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -80,6 +80,9 @@ type ClientWithFallback struct {
 
 	tag      string // tag for the limiter
 	groupTag string // tag for the limiter group
+
+	done   chan struct{} // channel to signal client closure
+	closed atomic.Bool   // flag to track if client is closed
 }
 
 func (c *ClientWithFallback) Copy() interface{} {
@@ -94,6 +97,8 @@ func (c *ClientWithFallback) Copy() interface{} {
 		LastCheckedAt:          c.LastCheckedAt,
 		tag:                    c.tag,
 		groupTag:               c.groupTag,
+		done:                   c.done,
+		closed:                 c.closed,
 	}
 }
 
@@ -135,10 +140,18 @@ func NewClient(ethClients []ethclient.RPSLimitedEthClientInterface, chainID uint
 		LastCheckedAt:          time.Now().Unix(),
 		circuitbreaker:         circuitbreaker.NewCircuitBreaker(cbConfig),
 		providersHealthManager: providersHealthManager,
+		done:                   make(chan struct{}),
 	}
 }
 
 func (c *ClientWithFallback) Close() {
+	if !c.closed.CompareAndSwap(false, true) {
+		return // already closed
+	}
+
+	close(c.done) // signal all ongoing operations to stop
+
+	// Close all eth clients
 	for _, client := range c.ethClients {
 		client.Close()
 	}
@@ -188,6 +201,22 @@ func (c *ClientWithFallback) IsConnected() bool {
 }
 
 func (c *ClientWithFallback) makeCall(ctx context.Context, f MakeCallFunctor) (interface{}, error) {
+	if c.closed.Load() {
+		return nil, errors.New("client is closed")
+	}
+
+	// Create a context that will be cancelled when either the parent context is done or the client is closed
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Start a goroutine to watch for client closure
+	go func() {
+		select {
+		case <-c.done:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
 	if c.commonLimiter != nil {
 		if allow, err := c.commonLimiter.Allow(c.tag); !allow {
 			return nil, fmt.Errorf("tag=%s, %w", c.tag, err)

--- a/rpc/chain/client_health_test.go
+++ b/rpc/chain/client_health_test.go
@@ -132,8 +132,6 @@ func (s *ClientWithFallbackSuite) TestContextCanceledDoesNotMarkChainDown() {
 	hash := common.HexToHash("0x1234")
 
 	// WHEN
-	s.mockEthClients[0].EXPECT().BlockByHash(ctx, hash).Return(nil, context.Canceled).Times(1)
-
 	_, err := s.client.BlockByHash(ctx, hash)
 	require.Error(s.T(), err)
 	require.True(s.T(), errors.Is(err, context.Canceled))

--- a/rpc/chain/client_test.go
+++ b/rpc/chain/client_test.go
@@ -3,7 +3,9 @@ package chain
 import (
 	"context"
 	"errors"
+	"math/big"
 	"reflect"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -135,4 +137,64 @@ func getFuncPtr(f func(uint64, string)) uintptr {
 		return 0
 	}
 	return reflect.ValueOf(f).Pointer()
+}
+
+// TestClientWithFallback_NilClientPanic tests that a nil pointer panic occurs
+// when the client's internal state is nullified during operation
+func TestClientWithFallback_NilClientPanic(t *testing.T) {
+	client, ethClients, cleanup := setupClientTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	addr := common.HexToAddress("0x1234")
+
+	// Create channels to coordinate the test
+	done := make(chan struct{})
+	operationStarted := make(chan struct{})
+	stateNulled := make(chan struct{})
+
+	// Set up the first client to block for a short time
+	ethClients[0].EXPECT().CodeAt(ctx, addr, nil).DoAndReturn(
+		func(ctx context.Context, addr common.Address, blockNumber *big.Int) ([]byte, error) {
+			close(operationStarted) // Signal that operation has started
+			<-stateNulled           // Wait until state is nulled
+			return nil, errors.New("timeout")
+		}).Times(1)
+
+	// Set up expectations for other clients
+	ethClients[1].EXPECT().CodeAt(ctx, addr, nil).Return(nil, errors.New("error")).Times(1)
+	ethClients[2].EXPECT().CodeAt(ctx, addr, nil).Return(nil, errors.New("error")).Times(1)
+
+	// Start the operation in a goroutine
+	go func() {
+		defer close(done)
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Expected panic but got none")
+			} else {
+				// Verify it's the expected nil pointer panic
+				if _, ok := r.(runtime.Error); !ok {
+					t.Errorf("Expected runtime error, got: %v", r)
+				}
+			}
+		}()
+
+		// Start the operation that should trigger the panic
+		_, _ = client.CodeAt(ctx, addr, nil)
+		t.Error("Expected panic, but operation completed successfully")
+	}()
+
+	// Wait for operation to start
+	<-operationStarted
+
+	// Nullify the client's internal state while operation is running
+	client.ethClients = nil
+	client.circuitbreaker = nil
+	client.commonLimiter = nil
+	client.providersHealthManager = nil
+	client.isConnected = nil
+	close(stateNulled)
+
+	// Wait for the operation to complete
+	<-done
 }

--- a/rpc/chain/client_test.go
+++ b/rpc/chain/client_test.go
@@ -198,3 +198,59 @@ func TestClientWithFallback_NilClientPanic(t *testing.T) {
 	// Wait for the operation to complete
 	<-done
 }
+
+// TestClientWithFallback_CloseStopsOperations tests that closing the client
+// properly stops all ongoing operations
+func TestClientWithFallback_CloseStopsOperations(t *testing.T) {
+	client, ethClients, cleanup := setupClientTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	addr := common.HexToAddress("0x1234")
+
+	// Create channels to coordinate the test
+	done := make(chan struct{})
+	operationStarted := make(chan struct{})
+
+	// Set up the first client to block for a short time
+	ethClients[0].EXPECT().CodeAt(ctx, addr, nil).DoAndReturn(
+		func(ctx context.Context, addr common.Address, blockNumber *big.Int) ([]byte, error) {
+			close(operationStarted) // Signal that operation has started
+
+			// Wait for context cancellation
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).Times(1)
+
+	// Set up expectations for other clients - they should not be called
+	// because the operation should be cancelled after the first client
+	ethClients[1].EXPECT().CodeAt(ctx, addr, nil).Times(0)
+	ethClients[2].EXPECT().CodeAt(ctx, addr, nil).Times(0)
+
+	// Set up expectations for Close on all clients
+	for _, ethClient := range ethClients {
+		ethClient.EXPECT().Close().Times(1)
+	}
+
+	// Start the operation in a goroutine
+	go func() {
+		defer close(done)
+		_, err := client.CodeAt(ctx, addr, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context canceled")
+	}()
+
+	// Wait for operation to start
+	<-operationStarted
+
+	// Close the client while operation is running
+	client.Close()
+
+	// Wait for the operation to complete
+	<-done
+
+	// Verify that subsequent calls fail immediately
+	_, err := client.CodeAt(ctx, addr, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "client is closed")
+}

--- a/rpc/chain/client_test.go
+++ b/rpc/chain/client_test.go
@@ -278,58 +278,44 @@ func TestClientWithFallback_CloseStopsMultipleOperations(t *testing.T) {
 
 	allOperationsStarted := make(chan struct{})
 
-	// Set up the mock responses for operation 1
-	ethClients[0].EXPECT().CodeAt(ctx, addr1, nil).DoAndReturn(
-		func(ctx context.Context, addr common.Address, blockNumber *big.Int) ([]byte, error) {
-			close(operation1Started)
+	// Helper function to create operation handlers with common logic
+	createOperationHandler := func(operationStarted chan struct{}) func(context.Context) error {
+		return func(ctx context.Context) error {
+			close(operationStarted)
 
 			// Wait for all operations to start or context to be cancelled
 			select {
 			case <-allOperationsStarted:
 				// Continue with normal processing
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return ctx.Err()
 			}
 
 			// Now wait for context cancellation
 			<-ctx.Done()
-			return nil, ctx.Err()
+			return ctx.Err()
+		}
+	}
+
+	// Set up the mock responses for operation 1
+	ethClients[0].EXPECT().CodeAt(ctx, addr1, nil).DoAndReturn(
+		func(ctx context.Context, addr common.Address, blockNumber *big.Int) ([]byte, error) {
+			err := createOperationHandler(operation1Started)(ctx)
+			return nil, err
 		}).Times(1)
 
 	// Set up the mock responses for operation 2
 	ethClients[0].EXPECT().BalanceAt(ctx, addr2, blockNumber).DoAndReturn(
 		func(ctx context.Context, addr common.Address, blockNumber *big.Int) (*big.Int, error) {
-			close(operation2Started)
-
-			// Wait for all operations to start or context to be cancelled
-			select {
-			case <-allOperationsStarted:
-				// Continue with normal processing
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
-
-			// Now wait for context cancellation
-			<-ctx.Done()
-			return nil, ctx.Err()
+			err := createOperationHandler(operation2Started)(ctx)
+			return nil, err
 		}).Times(1)
 
 	// Set up the mock responses for operation 3
 	ethClients[0].EXPECT().BlockByHash(ctx, hash).DoAndReturn(
 		func(ctx context.Context, hash common.Hash) (*types.Block, error) {
-			close(operation3Started)
-
-			// Wait for all operations to start or context to be cancelled
-			select {
-			case <-allOperationsStarted:
-				// Continue with normal processing
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
-
-			// Now wait for context cancellation
-			<-ctx.Done()
-			return nil, ctx.Err()
+			err := createOperationHandler(operation3Started)(ctx)
+			return nil, err
 		}).Times(1)
 
 	// Set up expectations for Close on all clients

--- a/rpc/chain/client_test.go
+++ b/rpc/chain/client_test.go
@@ -254,3 +254,129 @@ func TestClientWithFallback_CloseStopsOperations(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "client is closed")
 }
+
+// TestClientWithFallback_CloseStopsMultipleOperations tests that closing the client
+// properly stops multiple concurrent operations
+func TestClientWithFallback_CloseStopsMultipleOperations(t *testing.T) {
+	client, ethClients, cleanup := setupClientTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	addr1 := common.HexToAddress("0x1234")
+	addr2 := common.HexToAddress("0x5678")
+	hash := common.HexToHash("0xabcd")
+	blockNumber := big.NewInt(100)
+
+	// Create channels to coordinate the test
+	operation1Started := make(chan struct{})
+	operation2Started := make(chan struct{})
+	operation3Started := make(chan struct{})
+
+	operation1Done := make(chan struct{})
+	operation2Done := make(chan struct{})
+	operation3Done := make(chan struct{})
+
+	allOperationsStarted := make(chan struct{})
+
+	// Set up the mock responses for operation 1
+	ethClients[0].EXPECT().CodeAt(ctx, addr1, nil).DoAndReturn(
+		func(ctx context.Context, addr common.Address, blockNumber *big.Int) ([]byte, error) {
+			close(operation1Started)
+
+			// Wait for all operations to start or context to be cancelled
+			select {
+			case <-allOperationsStarted:
+				// Continue with normal processing
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+
+			// Now wait for context cancellation
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).Times(1)
+
+	// Set up the mock responses for operation 2
+	ethClients[0].EXPECT().BalanceAt(ctx, addr2, blockNumber).DoAndReturn(
+		func(ctx context.Context, addr common.Address, blockNumber *big.Int) (*big.Int, error) {
+			close(operation2Started)
+
+			// Wait for all operations to start or context to be cancelled
+			select {
+			case <-allOperationsStarted:
+				// Continue with normal processing
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+
+			// Now wait for context cancellation
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).Times(1)
+
+	// Set up the mock responses for operation 3
+	ethClients[0].EXPECT().BlockByHash(ctx, hash).DoAndReturn(
+		func(ctx context.Context, hash common.Hash) (*types.Block, error) {
+			close(operation3Started)
+
+			// Wait for all operations to start or context to be cancelled
+			select {
+			case <-allOperationsStarted:
+				// Continue with normal processing
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+
+			// Now wait for context cancellation
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}).Times(1)
+
+	// Set up expectations for Close on all clients
+	for _, ethClient := range ethClients {
+		ethClient.EXPECT().Close().Times(1)
+	}
+
+	// Start operation 1 in a goroutine
+	go func() {
+		defer close(operation1Done)
+		_, err := client.CodeAt(ctx, addr1, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context canceled")
+	}()
+
+	// Start operation 2 in a goroutine
+	go func() {
+		defer close(operation2Done)
+		_, err := client.BalanceAt(ctx, addr2, blockNumber)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context canceled")
+	}()
+
+	// Start operation 3 in a goroutine
+	go func() {
+		defer close(operation3Done)
+		_, err := client.BlockByHash(ctx, hash)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context canceled")
+	}()
+
+	// Wait for all operations to start
+	<-operation1Started
+	<-operation2Started
+	<-operation3Started
+
+	// Signal all operations that they can proceed past their initial state
+	close(allOperationsStarted)
+
+	// Wait a small amount of time for operations to reach the waiting state
+	runtime.Gosched()
+
+	// Close the client while operations are running
+	client.Close()
+
+	// All operations should complete with cancellation errors
+	<-operation1Done
+	<-operation2Done
+	<-operation3Done
+}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -188,6 +188,12 @@ func (c *Client) Start(ctx context.Context) {
 func (c *Client) Stop() {
 	c.NetworkManager.Stop()
 
+	c.rpcClientsMutex.Lock()
+	for _, client := range c.rpcClients {
+		client.Close()
+	}
+	c.rpcClientsMutex.Unlock()
+
 	c.healthMgr.Stop()
 	if c.stopMonitoringFunc == nil {
 		return


### PR DESCRIPTION
* reproduce the issue when Client is closed, but requests are still going through
* fix the issue 

The code uses three mechanisms to manage client closure:

* Atomic flag: The `closed` provides immediate rejection of new requests once the client is marked as closed. It ensures that `Close()` is called only once
* Signal channel (`done`): When Close() is called, it closes the done channel which signals all ongoing operations to stop gracefully. This context cancellation approach ensures operations that are already in progress terminate properly.
* Wait group (`wg`): The wait group tracks all active operations, allowing `Close()` to wait for them to complete before finalizing the shutdown process.

Closes #6525
Closes https://github.com/status-im/status-go/issues/6576
Closes https://github.com/status-im/status-go/issues/6462