### PR TITLE
feat(news)_: hook News settings to the newsFeedManager and its polling

### DIFF
--- a/appdatabase/migrations/sql/1744905192_add_news_rss_setting.up.sql
+++ b/appdatabase/migrations/sql/1744905192_add_news_rss_setting.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings ADD COLUMN news_rss_enabled BOOLEAN DEFAULT TRUE;

--- a/internal/newsfeed/new_feed_manager_test.go
+++ b/internal/newsfeed/new_feed_manager_test.go
@@ -149,13 +149,15 @@ func (s *NewsFeedManagerSuite) TestStartAndStopFetching() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	newsFeedManager.StartFetching(ctx)
+	newsFeedManager.StartPolling(ctx)
 
 	time.Sleep(1 * time.Millisecond) // Leave time for the go routine to run and process
 
 	// The start fetching does an initial fetch immediately
 	s.Require().Len(captured, 1)
 	s.Require().Equal("New Item", captured[0].Title)
+	s.Require().True(newsFeedManager.IsPolling())
 
-	newsFeedManager.StopFetching()
+	newsFeedManager.StopPolling()
+	s.Require().False(newsFeedManager.IsPolling())
 }

--- a/multiaccounts/settings/columns.go
+++ b/multiaccounts/settings/columns.go
@@ -242,6 +242,11 @@ var (
 		dBColumnName:   "news_notifications_enabled",
 		valueHandler:   BoolHandler,
 	}
+	NewsRSSEnabled = SettingField{
+		reactFieldName: "news-rss-enabled?",
+		dBColumnName:   "news_rss_enabled",
+		valueHandler:   BoolHandler,
+	}
 	NodeConfig = SettingField{
 		reactFieldName: "node-config",
 		dBColumnName:   "node_config",
@@ -582,6 +587,7 @@ var (
 		NewsFeedEnabled,
 		NewsFeedLastFetchedTimestamp,
 		NewsNotificationsEnabled,
+		NewsRSSEnabled,
 		MessengerNotificationsEnabled,
 		NodeConfig,
 		NotificationsEnabled,

--- a/multiaccounts/settings/database.go
+++ b/multiaccounts/settings/database.go
@@ -396,7 +396,7 @@ func (db *Database) GetSettings() (Settings, error) {
 		test_networks_enabled, mutual_contact_enabled, profile_migration_needed, wallet_token_preferences_group_by_community, url_unfurling_mode,
 		mnemonic_was_not_shown, wallet_show_community_asset_when_sending_tokens, wallet_display_assets_below_balance,
 		wallet_display_assets_below_balance_threshold, wallet_collectible_preferences_group_by_collection, wallet_collectible_preferences_group_by_community,
-		peer_syncing_enabled, auto_refresh_tokens_enabled, last_tokens_update, news_feed_enabled, news_feed_last_fetched_timestamp
+		peer_syncing_enabled, auto_refresh_tokens_enabled, last_tokens_update, news_feed_enabled, news_feed_last_fetched_timestamp, news_rss_enabled
 	FROM
 		settings
 	WHERE
@@ -485,6 +485,7 @@ func (db *Database) GetSettings() (Settings, error) {
 		&lastTokensUpdate,
 		&s.NewsFeedEnabled,
 		&newsFeedLastFetchedTimestamp,
+		&s.NewsRSSEnabled,
 	)
 
 	if err != nil {
@@ -901,4 +902,28 @@ func (db *Database) NewsFeedLastFetchedTimestamp() (result time.Time, err error)
 		result = newsFeedLastFetchedTimestamp.Time
 	}
 	return
+}
+
+func (db *Database) NewsFeedEnabled() (result bool, err error) {
+	err = db.makeSelectRow(NewsFeedEnabled).Scan(&result)
+	if err == sql.ErrNoRows {
+		return result, nil
+	}
+	return result, err
+}
+
+func (db *Database) NewsNotificationsEnabled() (result bool, err error) {
+	err = db.makeSelectRow(NewsNotificationsEnabled).Scan(&result)
+	if err == sql.ErrNoRows {
+		return result, nil
+	}
+	return result, err
+}
+
+func (db *Database) NewsRSSEnabled() (result bool, err error) {
+	err = db.makeSelectRow(NewsRSSEnabled).Scan(&result)
+	if err == sql.ErrNoRows {
+		return result, nil
+	}
+	return result, err
 }

--- a/multiaccounts/settings/database_settings_manager.go
+++ b/multiaccounts/settings/database_settings_manager.go
@@ -84,4 +84,7 @@ type DatabaseSettingsManager interface {
 	AutoRefreshTokensEnabled() (result bool, err error)
 	LastTokensUpdate() (result time.Time, err error)
 	NewsFeedLastFetchedTimestamp() (result time.Time, err error)
+	NewsFeedEnabled() (result bool, err error)
+	NewsNotificationsEnabled() (result bool, err error)
+	NewsRSSEnabled() (result bool, err error)
 }

--- a/multiaccounts/settings/database_test.go
+++ b/multiaccounts/settings/database_test.go
@@ -50,6 +50,7 @@ var (
 		DisplayAssetsBelowBalance:           false,
 		ShowCommunityAssetWhenSendingTokens: true,
 		NewsFeedEnabled:                     true,
+		NewsRSSEnabled:                      true,
 	}
 )
 
@@ -208,9 +209,9 @@ func TestDatabase_NewsNotificationsEnabled(t *testing.T) {
 
 	require.NoError(t, db.CreateSettings(settings, config))
 
-	settings, err := db.GetSettings()
+	enabled, err := db.NewsNotificationsEnabled()
 	require.NoError(t, err)
-	require.Equal(t, false, settings.NewsNotificationsEnabled)
+	require.Equal(t, false, enabled)
 
 	err = db.SaveSetting(NewsNotificationsEnabled.GetReactName(), true)
 	require.NoError(t, err)
@@ -244,10 +245,10 @@ func TestDatabase_NewsFeedEnabled(t *testing.T) {
 
 	require.NoError(t, db.CreateSettings(settings, config))
 
-	settings, err := db.GetSettings()
+	enabled, err := db.NewsFeedEnabled()
 	require.NoError(t, err)
 
-	require.Equal(t, true, settings.NewsFeedEnabled)
+	require.Equal(t, true, enabled)
 
 	err = db.SaveSetting(NewsFeedEnabled.GetReactName(), false)
 	require.NoError(t, err)
@@ -263,11 +264,11 @@ func TestDatabase_NewsFeedLastFetchedTimestamp(t *testing.T) {
 
 	require.NoError(t, db.CreateSettings(settings, config))
 
-	settings, err := db.GetSettings()
+	timestamp, err := db.NewsFeedLastFetchedTimestamp()
 	require.NoError(t, err)
 
 	// Using GreaterOrEqual because the timestamp is set during CreateSettings and there is a tiny chance that the second changes between
-	require.GreaterOrEqual(t, time.Now().UTC().Second(), settings.NewsFeedLastFetchedTimestamp.UTC().Second())
+	require.GreaterOrEqual(t, time.Now().UTC().Second(), timestamp.UTC().Second())
 
 	dateNow := time.Now()
 	err = db.SaveSetting(NewsFeedLastFetchedTimestamp.GetReactName(), dateNow)
@@ -276,4 +277,22 @@ func TestDatabase_NewsFeedLastFetchedTimestamp(t *testing.T) {
 	settings, err = db.GetSettings()
 	require.NoError(t, err)
 	require.Equal(t, dateNow.UTC().Second(), settings.NewsFeedLastFetchedTimestamp.UTC().Second())
+}
+
+func TestDatabase_NewsRSSEnabled(t *testing.T) {
+	db, stop := setupTestDB(t)
+	defer stop()
+
+	require.NoError(t, db.CreateSettings(settings, config))
+
+	enabled, err := db.NewsRSSEnabled()
+	require.NoError(t, err)
+	require.Equal(t, true, enabled)
+
+	err = db.SaveSetting(NewsRSSEnabled.GetReactName(), false)
+	require.NoError(t, err)
+
+	settings, err = db.GetSettings()
+	require.NoError(t, err)
+	require.Equal(t, false, settings.NewsRSSEnabled)
 }

--- a/multiaccounts/settings/structs.go
+++ b/multiaccounts/settings/structs.go
@@ -161,6 +161,7 @@ type Settings struct {
 	NewsFeedEnabled              bool             `json:"news-feed-enabled?,omitempty"`
 	NewsFeedLastFetchedTimestamp time.Time        `json:"news-feed-last-fetched-timestamp,omitempty"`
 	NewsNotificationsEnabled     bool             `json:"news-notifications-enabled?,omitempty"`
+	NewsRSSEnabled               bool             `json:"news-rss-enabled?,omitempty"`
 	PhotoPath                    string           `json:"photo-path"`
 	PinnedMailserver             *json.RawMessage `json:"pinned-mailservers,omitempty"`
 	// PreferredName represents the user's preferred Ethereum Name Service (ENS) name.

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -912,8 +912,13 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 			newsfeed.WithFetchFrom(lastFetched),
 		)
 
-		// TODO only start if the setting is enabled
-		m.newsFeedManager.StartFetching(m.ctx)
+		newsFeedEnabled, err := m.IsNewsFeedEnabled()
+		if err != nil {
+			return nil, err
+		}
+		if newsFeedEnabled {
+			m.newsFeedManager.StartPolling(m.ctx)
+		}
 	}
 
 	return response, nil

--- a/services/accounts/settings.go
+++ b/services/accounts/settings.go
@@ -50,6 +50,19 @@ func (api *SettingsAPI) SaveNodeConfig(ctx context.Context, n *params.NodeConfig
 	return nodecfg.SaveNodeConfig(api.db.DB(), n)
 }
 
+// News Settings
+func (api *SettingsAPI) NewsFeedEnabled() (bool, error) {
+	return api.db.NewsFeedEnabled()
+}
+
+func (api *SettingsAPI) NewsNotificationsEnabled() (bool, error) {
+	return api.db.NewsNotificationsEnabled()
+}
+
+func (api *SettingsAPI) NewsRSSEnabled() (bool, error) {
+	return api.db.NewsRSSEnabled()
+}
+
 // Notifications Settings
 func (api *SettingsAPI) NotificationsGetAllowNotifications() (bool, error) {
 	return api.db.GetAllowNotifications()

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1362,6 +1362,16 @@ func (api *PublicAPI) FetchNewsMessages() (*protocol.MessengerResponse, error) {
 	return m.FetchNewsMessages()
 }
 
+func (api *PublicAPI) ToggleNewsFeedEnabled(value bool) error {
+	m := api.service.messenger
+	return m.ToggleNewsFeedEnabled(value)
+}
+
+func (api *PublicAPI) ToggleNewsRSSEnabled(value bool) error {
+	m := api.service.messenger
+	return m.ToggleNewsRSSEnabled(value)
+}
+
 func (api *PublicAPI) RequestAllHistoricMessages(forceFetchingBackup bool) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.RequestAllHistoricMessages(forceFetchingBackup, false)
 }


### PR DESCRIPTION
Fixes #6533
Needed for https://github.com/status-im/status-desktop/issues/17811
Base on top of https://github.com/status-im/status-go/pull/6534

Adds the NewsRSSEnabled setting that is going to be used in the Privacy settings of the clients.

Adds API methods to toggle the NewsFeedEnabled  and NewsRSSEnabled settings.
By doing so, it will trigger the NewsFeedManager polling if both settings are set to true.
Conversely, if one of them is disabled, it stops the polling.