### PR TITLE
fix(backup)_: do not show the backup notifi backup during normal fetch

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -865,6 +865,13 @@ func TestLoginAccount(t *testing.T) {
 	acc, err := b.CreateAccountAndLogin(createAccountRequest)
 	require.NoError(t, err)
 	require.Equal(t, nameserver, b.config.WakuV2Config.Nameserver)
+
+	accountsDB, err := b.accountsDB()
+	require.NoError(t, err)
+	backupFecthed, err := accountsDB.BackupFetched()
+	require.NoError(t, err)
+	require.True(t, backupFecthed)
+
 	require.True(t, acc.HasAcceptedTerms)
 
 	waitForLogin(c)

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1773,6 +1773,11 @@ func (b *GethStatusBackend) prepareSettings(request *requests.CreateAccount, inp
 		//settings.MnemonicWasNotShown = true
 	}
 
+	if !input.fetchBackup {
+		// This is a an account created from scratch, we can mark the BackupFetched as true
+		settings.BackupFetched = true
+	}
+
 	if request.WakuV2Fleet != "" {
 		settings.Fleet = &request.WakuV2Fleet
 	}

--- a/multiaccounts/settings/database.go
+++ b/multiaccounts/settings/database.go
@@ -148,10 +148,11 @@ INSERT INTO settings (
   test_networks_enabled,
   fleet,
   auto_refresh_tokens_enabled,
-  news_feed_last_fetched_timestamp
+  news_feed_last_fetched_timestamp,
+  backup_fetched
 ) VALUES (
 ?,?,?,?,?,?,?,?,?,?,?,?,?,?,
-?,?,?,?,?,?,?,?,?,'id',?,?,?,?,?,?,?,?,?,?,?,?)`,
+?,?,?,?,?,?,?,?,?,'id',?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		s.Address,
 		s.Currency,
 		s.CurrentNetwork,
@@ -188,6 +189,7 @@ INSERT INTO settings (
 		s.AutoRefreshTokensEnabled,
 		// Default the news feed last fetched timestamp to now
 		time.Now().Unix(),
+		s.BackupFetched,
 	)
 	if err != nil {
 		return err

--- a/multiaccounts/settings/structs.go
+++ b/multiaccounts/settings/structs.go
@@ -216,6 +216,7 @@ type Settings struct {
 	TelemetrySendPeriodMs               int                           `json:"telemetry-send-period-ms,omitempty"`
 	LastBackup                          uint64                        `json:"last-backup,omitempty"`
 	BackupEnabled                       bool                          `json:"backup-enabled?,omitempty"`
+	BackupFetched                       bool                          `json:"backup-fetched?,omitempty"`
 	AutoMessageEnabled                  bool                          `json:"auto-message-enabled?,omitempty"`
 	GifAPIKey                           string                        `json:"gifs/api-key"`
 	TestNetworksEnabled                 bool                          `json:"test-networks-enabled?,omitempty"`

--- a/protocol/messenger_backup_handler.go
+++ b/protocol/messenger_backup_handler.go
@@ -127,6 +127,10 @@ func (m *Messenger) handleBackup(state *ReceivedMessageState, message *protobuf.
 }
 
 func (m *Messenger) updateBackupFetchProgress(message *protobuf.Backup, response *wakusync.WakuBackedUpDataResponse, state *ReceivedMessageState) error {
+	if m.backedUpFetchingStatus == nil {
+		return nil
+	}
+
 	m.backedUpFetchingStatus.fetchingCompletedMutex.Lock()
 	defer m.backedUpFetchingStatus.fetchingCompletedMutex.Unlock()
 

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -320,11 +320,6 @@ func (m *Messenger) RequestAllHistoricMessages(forceFetchingBackup, withRetries 
 
 	allResponses := &MessengerResponse{}
 	if forceFetchingBackup || !backupFetched {
-		err = m.startBackupFetchingTracking(allResponses)
-		if err != nil {
-			return nil, err
-		}
-
 		m.logger.Info("fetching backup")
 		err := m.syncBackup()
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/17555

We were adding the Notification of the back ups by accident when creating a normal account (not restored), because I added the code to create the notification in the `RequestAllHistoricMessages` function as well, even though the Messenger already does it. So for normal restores, it probably tried to add it twice, though they have the same ID, so it wasn't noticed
