### PR TITLE
chore_: isolate transport layer

### DIFF
--- a/cmd/generate_handlers/generate_handlers_template.txt
+++ b/cmd/generate_handlers/generate_handlers_template.txt
@@ -12,11 +12,11 @@ import (
 
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 )
 
-func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter, fromArchive bool) error {
+func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter messaging.ChatFilter, fromArchive bool) error {
 	switch msg.ApplicationLayer.Type {
 	{{ range .}}
            case protobuf.ApplicationMetadataMessage_{{.EnumValue}}:
@@ -28,7 +28,7 @@ func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoB
 }
 
 {{ range . }}
-func (m *Messenger) {{.MethodName}}(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter transport.Filter{{ if .FromArchiveArg }}, fromArchive bool{{ end }}) error {
+func (m *Messenger) {{.MethodName}}(messageState *ReceivedMessageState, protoBytes []byte, msg *v1protocol.StatusMessage, filter messaging.ChatFilter{{ if .FromArchiveArg }}, fromArchive bool{{ end }}) error {
 	m.logger.Info("handling {{ .ProtobufName}}")
 	{{ if .SyncMessage }}
 	if !common.IsPubKeyEqual(messageState.CurrentMessageState.PublicKey, &m.identity.PublicKey) {

--- a/cmd/status-cli/message.go
+++ b/cmd/status-cli/message.go
@@ -73,7 +73,7 @@ func (cli *StatusCLI) sendDirectMessage(ctx context.Context, text string, option
 	chat := cli.messenger.Chat(cli.messenger.MutualContacts()[0].ID)
 	cli.logger.Info("will send message to contact: ", chat.ID)
 
-	clock, timestamp := chat.NextClockAndTimestamp(cli.messenger.GetTransport())
+	clock, timestamp := chat.NextClockAndTimestamp(cli.messenger.GetTimesource())
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID
 	inputMessage.LocalChatID = chat.ID

--- a/messaging/api.go
+++ b/messaging/api.go
@@ -1,0 +1,330 @@
+package messaging
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/status-im/status-go/connection"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/messaging/transport"
+	wakutypes "github.com/status-im/status-go/waku/types"
+	"github.com/waku-org/go-waku/waku/v2/api/history"
+)
+
+type API struct {
+	transport *transport.Transport
+}
+
+func NewAPI(transport *transport.Transport) *API {
+	return &API{
+		transport: transport,
+	}
+}
+
+func (a *API) InitChats(chats ChatsToInitialize, publicKeys []*ecdsa.PublicKey) error {
+	_, err := a.transport.InitFilters(chats.toFilters(), publicKeys)
+	return err
+}
+
+func (a *API) InitPublicChats(chats ChatsToInitialize) (ChatFilters, error) {
+	filters, err := a.transport.InitPublicFilters(chats.toFilters())
+	return fromTransportFilters(filters), err
+}
+
+func (a *API) InitCommunities(communities CommunitiesToInitialize) (ChatFilters, error) {
+	filters, err := a.transport.InitCommunityFilters(communities.toFilters())
+	return fromTransportFilters(filters), err
+}
+
+func (a *API) ChatFilters() ChatFilters {
+	return fromTransportFilters(a.transport.Filters())
+}
+
+func (a *API) ChatFilterByChatID(chatID string) *ChatFilter {
+	return fromTransportFilter(a.transport.FilterByChatID(chatID))
+}
+
+func (a *API) ChatFilterByTopic(topic []byte) *ChatFilter {
+	return fromTransportFilter(a.transport.FilterByTopic(topic))
+}
+
+func (a *API) ChatFiltersByIdentities(identities []string) ChatFilters {
+	return fromTransportFilters(a.transport.FiltersByIdentities(identities))
+}
+
+func (a *API) RemoveFilters(filters ChatFilters) error {
+	return a.transport.RemoveFilters(filters.toTransportFilters())
+}
+
+func (a *API) RemoveFilterByChatID(chatID string) (*ChatFilter, error) {
+	filter, err := a.transport.RemoveFilterByChatID(chatID)
+	if err != nil {
+		return nil, err
+	}
+	return fromTransportFilter(filter), nil
+}
+
+func (a *API) ResetChatFilters(ctx context.Context) error {
+	return a.transport.ResetFilters(ctx)
+}
+
+func (a *API) ProcessNegotiatedSecret(secret types.NegotiatedSecret) (*ChatFilter, error) {
+	filter, err := a.transport.ProcessNegotiatedSecret(secret)
+	if err != nil {
+		return nil, err
+	}
+	return fromTransportFilter(filter), nil
+}
+
+func (a *API) JoinPublicChat(chatID string) (*ChatFilter, error) {
+	filter, err := a.transport.JoinPublic(chatID)
+	if err != nil {
+		return nil, err
+	}
+	return fromTransportFilter(filter), nil
+}
+
+func (a *API) JoinPrivateChat(publicKey *ecdsa.PublicKey) (*ChatFilter, error) {
+	filter, err := a.transport.JoinPrivate(publicKey)
+	if err != nil {
+		return nil, err
+	}
+	return fromTransportFilter(filter), nil
+}
+
+func (a *API) JoinGroupChat(publicKeys []*ecdsa.PublicKey) (ChatFilters, error) {
+	filters, err := a.transport.JoinGroup(publicKeys)
+	if err != nil {
+		return nil, err
+	}
+	return fromTransportFilters(filters), nil
+}
+
+func (a *API) GetStats() wakutypes.StatsSummary {
+	return a.transport.GetStats()
+}
+
+func (a *API) RetrieveRawAll() (map[ChatFilter][]*wakutypes.Message, error) {
+	filters, err := a.transport.RetrieveRawAll()
+	if err != nil {
+		return nil, err
+	}
+	chatFilters := make(map[ChatFilter][]*wakutypes.Message)
+	for k, v := range filters {
+		chatFilters[*fromTransportFilter(&k)] = v
+	}
+	return chatFilters, nil
+}
+
+func (a *API) SendPublic(ctx context.Context, newMessage *wakutypes.NewMessage, chatName string) ([]byte, error) {
+	return a.transport.SendPublic(ctx, newMessage, chatName)
+}
+
+func (a *API) SendPrivateWithSharedSecret(ctx context.Context, newMessage *wakutypes.NewMessage, publicKey *ecdsa.PublicKey, secret []byte) ([]byte, error) {
+	return a.transport.SendPrivateWithSharedSecret(ctx, newMessage, publicKey, secret)
+}
+
+func (a *API) SendPrivateWithPartitioned(ctx context.Context, newMessage *wakutypes.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
+	return a.transport.SendPrivateWithPartitioned(ctx, newMessage, publicKey)
+}
+
+func (a *API) SendPrivateOnPersonalTopic(ctx context.Context, newMessage *wakutypes.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
+	return a.transport.SendPrivateOnPersonalTopic(ctx, newMessage, publicKey)
+}
+
+func (a *API) PersonalTopicFilter() *ChatFilter {
+	return fromTransportFilter(a.transport.PersonalTopicFilter())
+}
+
+func (a *API) LoadKeyFilters(key *ecdsa.PrivateKey) (*ChatFilter, error) {
+	filter, err := a.transport.LoadKeyFilters(key)
+	if err != nil {
+		return nil, err
+	}
+	return fromTransportFilter(filter), nil
+}
+
+func (a *API) SendCommunityMessage(ctx context.Context, newMessage *wakutypes.NewMessage, publicKey *ecdsa.PublicKey) ([]byte, error) {
+	return a.transport.SendCommunityMessage(ctx, newMessage, publicKey)
+}
+
+func (a *API) Track(identifier []byte, hashes [][]byte, newMessages []*wakutypes.NewMessage) {
+	a.transport.Track(identifier, hashes, newMessages)
+}
+
+func (a *API) TrackMany(identifiers [][]byte, hashes [][]byte, newMessages []*wakutypes.NewMessage) {
+	a.transport.TrackMany(identifiers, hashes, newMessages)
+}
+
+func (a *API) GetCurrentTime() uint64 {
+	return a.transport.GetCurrentTime()
+}
+
+func (a *API) MaxMessageSize() uint32 {
+	return a.transport.MaxMessageSize()
+}
+
+func (a *API) Stop() error {
+	return a.transport.Stop()
+}
+
+func (a *API) PeerCount() int {
+	return a.transport.PeerCount()
+}
+
+func (a *API) Peers() wakutypes.PeerStats {
+	return a.transport.Peers()
+}
+
+func (a *API) ConfirmMessagesProcessed(ids []string, timestamp uint64) error {
+	return a.transport.ConfirmMessagesProcessed(ids, timestamp)
+}
+
+func (a *API) CleanMessagesProcessed(timestamp uint64) error {
+	return a.transport.CleanMessagesProcessed(timestamp)
+}
+
+func (a *API) SetEnvelopeEventsHandler(handler EnvelopeEventsHandler) error {
+	return a.transport.SetEnvelopeEventsHandler(handler)
+}
+
+func (a *API) ClearProcessedMessageIDsCache() error {
+	return a.transport.ClearProcessedMessageIDsCache()
+}
+
+func (a *API) ListenAddresses() ([]multiaddr.Multiaddr, error) {
+	return a.transport.ListenAddresses()
+}
+
+func (a *API) RelayPeersByTopic(topic string) (*wakutypes.PeerList, error) {
+	return a.transport.RelayPeersByTopic(topic)
+}
+
+func (a *API) ENR() (*enode.Node, error) {
+	return a.transport.ENR()
+}
+
+func (a *API) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
+	return a.transport.AddRelayPeer(address)
+}
+
+func (a *API) DialPeer(address multiaddr.Multiaddr) error {
+	return a.transport.DialPeer(address)
+}
+
+func (a *API) DialPeerByID(peerID peer.ID) error {
+	return a.transport.DialPeerByID(peerID)
+}
+
+func (a *API) DropPeer(peerID peer.ID) error {
+	return a.transport.DropPeer(peerID)
+}
+
+func (a *API) MarkP2PMessageAsProcessed(hash common.Hash) {
+	a.transport.MarkP2PMessageAsProcessed(hash)
+}
+
+func (a *API) ConnectionChanged(state connection.State) {
+	a.transport.ConnectionChanged(state)
+}
+
+func (a *API) SubscribeToPubsubTopic(topic string, optPublicKey *ecdsa.PublicKey) error {
+	return a.transport.SubscribeToPubsubTopic(topic, optPublicKey)
+}
+
+func (a *API) UnsubscribeFromPubsubTopic(topic string) error {
+	return a.transport.UnsubscribeFromPubsubTopic(topic)
+}
+
+func (a *API) StorePubsubTopicKey(topic string, privKey *ecdsa.PrivateKey) error {
+	return a.transport.StorePubsubTopicKey(topic, privKey)
+}
+
+func (a *API) RetrievePubsubTopicKey(topic string) (*ecdsa.PrivateKey, error) {
+	return a.transport.RetrievePubsubTopicKey(topic)
+}
+
+func (a *API) RemovePubsubTopicKey(topic string) error {
+	return a.transport.RemovePubsubTopicKey(topic)
+}
+
+func (a *API) ConfirmMessageDelivered(messageID string) {
+	a.transport.ConfirmMessageDelivered(messageID)
+}
+
+func (a *API) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, filters ChatFilters) {
+	a.transport.SetCriteriaForMissingMessageVerification(peerInfo, filters.toTransportFilters())
+}
+
+func (a *API) GetActiveStorenode() peer.AddrInfo {
+	return a.transport.GetActiveStorenode()
+}
+
+func (a *API) DisconnectActiveStorenode(ctx context.Context, backoffReason time.Duration, shouldCycle bool) {
+	a.transport.DisconnectActiveStorenode(ctx, backoffReason, shouldCycle)
+}
+
+func (a *API) OnStorenodeChanged() <-chan peer.ID {
+	return a.transport.OnStorenodeChanged()
+}
+
+func (a *API) OnStorenodeNotWorking() <-chan struct{} {
+	return a.transport.OnStorenodeNotWorking()
+}
+
+func (a *API) OnStorenodeAvailable() <-chan peer.ID {
+	return a.transport.OnStorenodeAvailable()
+}
+
+func (a *API) WaitForAvailableStoreNode(ctx context.Context) bool {
+	return a.transport.WaitForAvailableStoreNode(ctx)
+}
+
+func (a *API) IsStorenodeAvailable(peerID peer.ID) bool {
+	return a.transport.IsStorenodeAvailable(peerID)
+}
+
+func (a *API) PerformStorenodeTask(fn func() error, opts ...history.StorenodeTaskOption) error {
+	return a.transport.PerformStorenodeTask(fn, opts...)
+}
+
+func (a *API) ProcessMailserverBatch(
+	ctx context.Context,
+	batch wakutypes.MailserverBatch,
+	storenode peer.AddrInfo,
+	pageLimit uint64,
+	shouldProcessNextPage func(int) (bool, uint64),
+	processEnvelopes bool,
+) error {
+	return a.transport.ProcessMailserverBatch(ctx, batch, storenode, pageLimit, shouldProcessNextPage, processEnvelopes)
+}
+
+func (a *API) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
+	a.transport.SetStorenodeConfigProvider(c)
+}
+
+func ToContentTopic(s string) []byte {
+	return transport.ToTopic(s)
+}
+
+func PartitionedTopic(publicKey *ecdsa.PublicKey) string {
+	return transport.PartitionedTopic(publicKey)
+}
+
+func ContactCodeTopic(publicKey *ecdsa.PublicKey) string {
+	return transport.ContactCodeTopic(publicKey)
+}
+
+func CommunityShardInfoTopic(communityID string) string {
+	return transport.CommunityShardInfoTopic(communityID)
+}
+
+func CommunityShardInfoTopicPrefix() string {
+	return transport.CommunityShardInfoTopicPrefix()
+}

--- a/messaging/core.go
+++ b/messaging/core.go
@@ -1,0 +1,73 @@
+package messaging
+
+import (
+	"crypto/ecdsa"
+	"database/sql"
+
+	"go.uber.org/zap"
+
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/messaging/transport"
+	wakutypes "github.com/status-im/status-go/waku/types"
+)
+
+type Core struct {
+	transport              *transport.Transport
+	envelopesMonitorConfig *transport.EnvelopesMonitorConfig
+	logger                 *zap.Logger
+}
+
+func NewCore(waku wakutypes.Waku, identity *ecdsa.PrivateKey, db *sql.DB, options ...Options) (*Core, error) {
+	core := &Core{
+		envelopesMonitorConfig: &transport.EnvelopesMonitorConfig{
+			IsMailserver: func(types.EnodeID) bool { return false },
+		},
+	}
+
+	for _, option := range options {
+		option(core)
+	}
+
+	if core.logger == nil {
+		core.logger = zap.NewNop()
+	}
+	core.envelopesMonitorConfig.Logger = core.logger
+
+	var err error
+	core.transport, err = transport.NewTransport(
+		waku,
+		identity,
+		db,
+		"wakuv2_keys",
+		nil,
+		core.envelopesMonitorConfig,
+		core.logger,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return core, nil
+}
+
+func (m *Core) API() *API {
+	return NewAPI(m.transport)
+}
+
+type Options func(*Core)
+
+func WithLogger(logger *zap.Logger) Options {
+	return func(c *Core) {
+		c.logger = logger
+	}
+}
+
+func WithEnvelopeEventsConfig(config *EnvelopeEventsConfig) Options {
+	return func(c *Core) {
+		if config != nil {
+			c.envelopesMonitorConfig.EnvelopeEventsHandler = config.EnvelopeEventsHandler
+			c.envelopesMonitorConfig.MaxAttempts = config.MaxMessageDeliveryAttempts
+			c.envelopesMonitorConfig.AwaitOnlyMailServerConfirmations = config.MailServerConfirmations
+		}
+	}
+}

--- a/messaging/transport/envelopes_monitor_test.go
+++ b/messaging/transport/envelopes_monitor_test.go
@@ -263,6 +263,3 @@ func (m *mockWakuAPI) NewMessageFilter(req wakutypes.Criteria) (string, error) {
 func (m *mockWakuAPI) GetFilterMessages(id string) ([]*wakutypes.Message, error) {
 	return nil, nil
 }
-func (m *mockWakuAPI) BloomFilter() []byte {
-	return nil
-}

--- a/messaging/transport/filters_manager_test.go
+++ b/messaging/transport/filters_manager_test.go
@@ -116,10 +116,6 @@ func (s *FiltersManagerSuite) TestPartitionedTopicWithDiscoveryDisabled() {
 	s.Require().NoError(err)
 
 	s.Require().Equal(3, len(s.chats.filters), "It creates three filters")
-
-	discoveryFilter := s.chats.filters[discoveryTopic]
-	s.Require().Nil(discoveryFilter, "It does not add the discovery filter")
-
 	s.assertRequiredFilters()
 }
 

--- a/messaging/transport/topic.go
+++ b/messaging/transport/topic.go
@@ -10,8 +10,6 @@ import (
 	"github.com/status-im/status-go/waku/types"
 )
 
-const discoveryTopic = "contact-discovery"
-
 var (
 	// The number of partitions.
 	nPartitions = big.NewInt(5000)
@@ -44,10 +42,6 @@ func ContactCodeTopic(publicKey *ecdsa.PublicKey) string {
 
 func NegotiatedTopic(publicKey *ecdsa.PublicKey) string {
 	return "0x" + PublicKeyToStr(publicKey) + "-negotiated"
-}
-
-func DiscoveryTopic() string {
-	return discoveryTopic
 }
 
 func CommunityShardInfoTopic(communityID string) string {

--- a/messaging/transport/transport.go
+++ b/messaging/transport/transport.go
@@ -192,14 +192,6 @@ func (t *Transport) JoinPublic(chatID string) (*Filter, error) {
 	return t.filters.LoadPublic(chatID, "")
 }
 
-func (t *Transport) LeavePublic(chatID string) error {
-	chat := t.filters.Filter(chatID)
-	if chat != nil {
-		return nil
-	}
-	return t.filters.Remove(context.Background(), chat)
-}
-
 func (t *Transport) JoinPrivate(publicKey *ecdsa.PublicKey) (*Filter, error) {
 	return t.filters.LoadContactCode(publicKey)
 }
@@ -448,10 +440,6 @@ func (t *Transport) cleanFiltersLoop() {
 	}()
 }
 
-func (t *Transport) WakuVersion() uint {
-	return t.waku.Version()
-}
-
 func (t *Transport) PeerCount() int {
 	return t.waku.PeerCount()
 }
@@ -486,20 +474,8 @@ func (t *Transport) ClearProcessedMessageIDsCache() error {
 	return t.cache.Clear()
 }
 
-func (t *Transport) BloomFilter() []byte {
-	return t.api.BloomFilter()
-}
-
 func PubkeyToHex(key *ecdsa.PublicKey) string {
 	return types.EncodeHex(crypto.FromECDSAPub(key))
-}
-
-func (t *Transport) StartDiscV5() error {
-	return t.waku.StartDiscV5()
-}
-
-func (t *Transport) StopDiscV5() error {
-	return t.waku.StopDiscV5()
 }
 
 func (t *Transport) ListenAddresses() ([]multiaddr.Multiaddr, error) {
@@ -530,16 +506,8 @@ func (t *Transport) DropPeer(peerID peer.ID) error {
 	return t.waku.DropPeer(peerID)
 }
 
-func (t *Transport) ProcessingP2PMessages() bool {
-	return t.waku.ProcessingP2PMessages()
-}
-
 func (t *Transport) MarkP2PMessageAsProcessed(hash common.Hash) {
 	t.waku.MarkP2PMessageAsProcessed(hash)
-}
-
-func (t *Transport) SubscribeToConnStatusChanges() (*wakutypes.ConnStatusSubscription, error) {
-	return t.waku.SubscribeToConnStatusChanges()
 }
 
 func (t *Transport) ConnectionChanged(state connection.State) {
@@ -548,18 +516,12 @@ func (t *Transport) ConnectionChanged(state connection.State) {
 
 // Subscribe to a pubsub topic, passing an optional public key if the pubsub topic is protected
 func (t *Transport) SubscribeToPubsubTopic(topic string, optPublicKey *ecdsa.PublicKey) error {
-	if t.waku.Version() == 2 {
-		return t.waku.SubscribeToPubsubTopic(topic, optPublicKey)
-	}
-	return nil
+	return t.waku.SubscribeToPubsubTopic(topic, optPublicKey)
 }
 
 // Unsubscribe from a pubsub topic
 func (t *Transport) UnsubscribeFromPubsubTopic(topic string) error {
-	if t.waku.Version() == 2 {
-		return t.waku.UnsubscribeFromPubsubTopic(topic)
-	}
-	return nil
+	return t.waku.UnsubscribeFromPubsubTopic(topic)
 }
 
 func (t *Transport) StorePubsubTopicKey(topic string, privKey *ecdsa.PrivateKey) error {
@@ -571,10 +533,7 @@ func (t *Transport) RetrievePubsubTopicKey(topic string) (*ecdsa.PrivateKey, err
 }
 
 func (t *Transport) RemovePubsubTopicKey(topic string) error {
-	if t.waku.Version() == 2 {
-		return t.waku.RemovePubsubTopicKey(topic)
-	}
-	return nil
+	return t.waku.RemovePubsubTopicKey(topic)
 }
 
 func (t *Transport) ConfirmMessageDelivered(messageID string) {
@@ -593,10 +552,6 @@ func (t *Transport) ConfirmMessageDelivered(messageID string) {
 }
 
 func (t *Transport) SetCriteriaForMissingMessageVerification(peerInfo peer.AddrInfo, filters []*Filter) {
-	if t.waku.Version() != 2 {
-		return
-	}
-
 	topicMap := make(map[string]map[wakutypes.TopicType]struct{})
 	for _, f := range filters {
 		if !f.Listen || f.Ephemeral {
@@ -669,7 +624,5 @@ func (t *Transport) ProcessMailserverBatch(
 }
 
 func (t *Transport) SetStorenodeConfigProvider(c history.StorenodeConfigProvider) {
-	if t.WakuVersion() == 2 {
-		t.waku.SetStorenodeConfigProvider(c)
-	}
+	t.waku.SetStorenodeConfigProvider(c)
 }

--- a/messaging/types.go
+++ b/messaging/types.go
@@ -1,0 +1,127 @@
+package messaging
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/messaging/transport"
+	wakutypes "github.com/status-im/status-go/waku/types"
+	"github.com/status-im/status-go/wakuv2"
+)
+
+type ChatToInitialize struct {
+	ChatID      string
+	PubsubTopic string
+}
+
+type ChatsToInitialize []*ChatToInitialize
+
+func (c ChatsToInitialize) toFilters() []transport.FiltersToInitialize {
+	filters := make([]transport.FiltersToInitialize, len(c))
+	for i, chat := range c {
+		filters[i] = transport.FiltersToInitialize{
+			ChatID:      chat.ChatID,
+			PubsubTopic: chat.PubsubTopic,
+		}
+	}
+	return filters
+}
+
+type ChatFilter struct {
+	ChatID       string              `json:"chatId"`
+	FilterID     string              `json:"filterId"`
+	Identity     string              `json:"identity"`
+	PubsubTopic  string              `json:"pubsubTopic"`
+	ContentTopic wakutypes.TopicType `json:"topic"`
+	Discovery    bool                `json:"discovery"`
+	Negotiated   bool                `json:"negotiated"`
+	Listen       bool                `json:"listen"`
+	Ephemeral    bool                `json:"ephemeral"`
+	Priority     uint64
+}
+
+type ChatFilters []*ChatFilter
+
+func fromTransportFilter(filter *transport.Filter) *ChatFilter {
+	if filter == nil {
+		return nil
+	}
+	return &ChatFilter{
+		ChatID:       filter.ChatID,
+		FilterID:     filter.FilterID,
+		Identity:     filter.Identity,
+		PubsubTopic:  filter.PubsubTopic,
+		ContentTopic: filter.ContentTopic,
+		Discovery:    filter.Discovery,
+		Negotiated:   filter.Negotiated,
+		Listen:       filter.Listen,
+		Ephemeral:    filter.Ephemeral,
+		Priority:     filter.Priority,
+	}
+}
+
+func fromTransportFilters(filters []*transport.Filter) ChatFilters {
+	chatFilters := make([]*ChatFilter, len(filters))
+	for i, filter := range filters {
+		chatFilters[i] = fromTransportFilter(filter)
+	}
+	return chatFilters
+}
+
+func (c *ChatFilter) toTransportFilter() *transport.Filter {
+	return &transport.Filter{
+		ChatID:       c.ChatID,
+		FilterID:     c.FilterID,
+		Identity:     c.Identity,
+		PubsubTopic:  c.PubsubTopic,
+		ContentTopic: c.ContentTopic,
+		Discovery:    c.Discovery,
+		Negotiated:   c.Negotiated,
+		Listen:       c.Listen,
+		Ephemeral:    c.Ephemeral,
+		Priority:     c.Priority,
+	}
+}
+
+func (c ChatFilters) toTransportFilters() []*transport.Filter {
+	transportFilters := make([]*transport.Filter, len(c))
+	for i, filter := range c {
+		transportFilters[i] = filter.toTransportFilter()
+	}
+	return transportFilters
+}
+
+type CommunityToInitialize struct {
+	Shard   *wakuv2.Shard
+	PrivKey *ecdsa.PrivateKey
+}
+
+type CommunitiesToInitialize []*CommunityToInitialize
+
+func (c *CommunityToInitialize) toFilter() *transport.CommunityFilterToInitialize {
+	return &transport.CommunityFilterToInitialize{
+		Shard:   c.Shard,
+		PrivKey: c.PrivKey,
+	}
+}
+
+func (c CommunitiesToInitialize) toFilters() []transport.CommunityFilterToInitialize {
+	communityFilters := make([]transport.CommunityFilterToInitialize, len(c))
+	for i, filter := range c {
+		communityFilters[i] = *filter.toFilter()
+	}
+	return communityFilters
+}
+
+type EnvelopeEventsHandler interface {
+	EnvelopeSent([][]byte)
+	EnvelopeExpired([][]byte, error)
+	MailServerRequestCompleted(types.Hash, types.Hash, []byte, error)
+	MailServerRequestExpired(types.Hash)
+}
+
+type EnvelopeEventsConfig struct {
+	EnvelopeEventsHandler      EnvelopeEventsHandler
+	MaxMessageDeliveryAttempts int
+	MailServerConfirmations    bool
+}

--- a/metrics/wakumetrics/client.go
+++ b/metrics/wakumetrics/client.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	wakutypes "github.com/status-im/status-go/waku/types"
 	"github.com/status-im/status-go/wakuv2"
 
@@ -16,7 +16,7 @@ import (
 )
 
 type ReceivedMessages struct {
-	Filter     transport.Filter
+	Filter     messaging.ChatFilter
 	SHHMessage *wakutypes.Message
 	Messages   []*v1protocol.StatusMessage
 }

--- a/metrics/wakumetrics/client_test.go
+++ b/metrics/wakumetrics/client_test.go
@@ -14,7 +14,7 @@ import (
 	v2protocol "github.com/waku-org/go-waku/waku/v2/protocol"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 	wakutypes "github.com/status-im/status-go/waku/types"
 	"github.com/status-im/status-go/wakuv2"
@@ -73,7 +73,7 @@ func TestClient_DoubleRegister(t *testing.T) {
 func TestClient_PushReceivedMessages(t *testing.T) {
 	client := createTestClient(t)
 
-	filter := transport.Filter{
+	filter := messaging.ChatFilter{
 		PubsubTopic:  "test-pubsub",
 		ContentTopic: wakutypes.StringToTopic("test-content"),
 		ChatID:       "test-chat",

--- a/protocol/common/message_segmentation.go
+++ b/protocol/common/message_segmentation.go
@@ -45,7 +45,7 @@ func (s *SegmentMessage) IsParityMessage() bool {
 func (s *MessageSender) segmentMessage(newMessage *wakutypes.NewMessage) ([]*wakutypes.NewMessage, error) {
 	// We set the max message size to 3/4 of the allowed message size, to leave
 	// room for segment message metadata.
-	newMessages, err := segmentMessage(newMessage, int(s.transport.MaxMessageSize()/4*3))
+	newMessages, err := segmentMessage(newMessage, int(s.messaging.MaxMessageSize()/4*3))
 	s.logger.Debug("message segmented", zap.Int("segments", len(newMessages)))
 	return newMessages, err
 }

--- a/protocol/common/message_sender_test.go
+++ b/protocol/common/message_sender_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	transport2 "github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/t/helpers"
 	wakutypes "github.com/status-im/status-go/waku/types"
 	"github.com/status-im/status-go/wakuv2"
@@ -82,22 +82,19 @@ func (s *MessageSenderSuite) SetupTest() {
 	s.Require().NoError(err)
 	s.Require().NoError(shh.Start())
 
-	whisperTransport, err := transport2.NewTransport(
+	messaging, err := messaging.NewCore(
 		shh,
 		identity,
 		database,
-		"waku_keys",
-		nil,
-		nil,
-		s.logger,
+		messaging.WithLogger(s.logger),
 	)
 	s.Require().NoError(err)
 
 	s.sender, err = NewMessageSender(
 		identity,
 		database,
+		messaging.API(),
 		encryptionProtocol,
-		whisperTransport,
 		s.logger,
 		FeatureFlags{
 			Datasync: true,

--- a/protocol/communities/manager_archive_nop.go
+++ b/protocol/communities/manager_archive_nop.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/status-im/status-go/eth-node/types"
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/params"
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
@@ -42,7 +42,7 @@ func (tmm *ArchiveManagerNop) IsReady() bool {
 	return false
 }
 
-func (tmm *ArchiveManagerNop) GetCommunityChatsFilters(communityID types.HexBytes) ([]*transport.Filter, error) {
+func (tmm *ArchiveManagerNop) GetCommunityChatsFilters(communityID types.HexBytes) (messaging.ChatFilters, error) {
 	return nil, nil
 }
 

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/eth-node/crypto"
 	userimages "github.com/status-im/status-go/images"
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/common"
 	community_token "github.com/status-im/status-go/protocol/communities/token"
@@ -68,7 +68,7 @@ func (s *ManagerSuite) buildManagers(ownerVerifier OwnerVerifier) (*Manager, *Ar
 		TorrentConfig: buildTorrentConfig(),
 		Logger:        logger,
 		Persistence:   m.GetPersistence(),
-		Transport:     nil,
+		Messaging:     nil,
 		Identity:      key,
 		Encryptor:     nil,
 		Publisher:     m,
@@ -560,7 +560,7 @@ func (s *ManagerSuite) TestCreateHistoryArchiveTorrent_WithoutMessages() {
 	community, chatID, err := s.buildCommunityWithChat()
 	s.Require().NoError(err)
 
-	topic := wakutypes.BytesToTopic(transport.ToTopic(chatID))
+	topic := wakutypes.BytesToTopic(messaging.ToContentTopic(chatID))
 	topics := []wakutypes.TopicType{topic}
 
 	// Time range of 7 days
@@ -586,7 +586,7 @@ func (s *ManagerSuite) TestCreateHistoryArchiveTorrent_ShouldCreateArchive() {
 	community, chatID, err := s.buildCommunityWithChat()
 	s.Require().NoError(err)
 
-	topic := wakutypes.BytesToTopic(transport.ToTopic(chatID))
+	topic := wakutypes.BytesToTopic(messaging.ToContentTopic(chatID))
 	topics := []wakutypes.TopicType{topic}
 
 	// Time range of 7 days
@@ -640,7 +640,7 @@ func (s *ManagerSuite) TestCreateHistoryArchiveTorrent_ShouldCreateMultipleArchi
 	community, chatID, err := s.buildCommunityWithChat()
 	s.Require().NoError(err)
 
-	topic := wakutypes.BytesToTopic(transport.ToTopic(chatID))
+	topic := wakutypes.BytesToTopic(messaging.ToContentTopic(chatID))
 	topics := []wakutypes.TopicType{topic}
 
 	// Time range of 3 weeks
@@ -699,7 +699,7 @@ func (s *ManagerSuite) TestCreateHistoryArchiveTorrent_ShouldAppendArchives() {
 	community, chatID, err := s.buildCommunityWithChat()
 	s.Require().NoError(err)
 
-	topic := wakutypes.BytesToTopic(transport.ToTopic(chatID))
+	topic := wakutypes.BytesToTopic(messaging.ToContentTopic(chatID))
 	topics := []wakutypes.TopicType{topic}
 
 	// Time range of 1 week
@@ -739,7 +739,7 @@ func (s *ManagerSuite) TestCreateHistoryArchiveTorrentFromMessages() {
 	community, chatID, err := s.buildCommunityWithChat()
 	s.Require().NoError(err)
 
-	topic := wakutypes.BytesToTopic(transport.ToTopic(chatID))
+	topic := wakutypes.BytesToTopic(messaging.ToContentTopic(chatID))
 	topics := []wakutypes.TopicType{topic}
 
 	// Time range of 7 days
@@ -786,7 +786,7 @@ func (s *ManagerSuite) TestCreateHistoryArchiveTorrentFromMessages_ShouldCreateM
 	community, chatID, err := s.buildCommunityWithChat()
 	s.Require().NoError(err)
 
-	topic := wakutypes.BytesToTopic(transport.ToTopic(chatID))
+	topic := wakutypes.BytesToTopic(messaging.ToContentTopic(chatID))
 	topics := []wakutypes.TopicType{topic}
 
 	// Time range of 3 weeks
@@ -836,7 +836,7 @@ func (s *ManagerSuite) TestCreateHistoryArchiveTorrentFromMessages_ShouldAppendA
 	community, chatID, err := s.buildCommunityWithChat()
 	s.Require().NoError(err)
 
-	topic := wakutypes.BytesToTopic(transport.ToTopic(chatID))
+	topic := wakutypes.BytesToTopic(messaging.ToContentTopic(chatID))
 	topics := []wakutypes.TopicType{topic}
 
 	// Time range of 1 week
@@ -876,7 +876,7 @@ func (s *ManagerSuite) TestSeedHistoryArchiveTorrent() {
 	community, chatID, err := s.buildCommunityWithChat()
 	s.Require().NoError(err)
 
-	topic := wakutypes.BytesToTopic(transport.ToTopic(chatID))
+	topic := wakutypes.BytesToTopic(messaging.ToContentTopic(chatID))
 	topics := []wakutypes.TopicType{topic}
 
 	startDate := time.Date(2020, 1, 1, 00, 00, 00, 0, time.UTC)
@@ -910,7 +910,7 @@ func (s *ManagerSuite) TestUnseedHistoryArchiveTorrent() {
 	community, chatID, err := s.buildCommunityWithChat()
 	s.Require().NoError(err)
 
-	topic := wakutypes.BytesToTopic(transport.ToTopic(chatID))
+	topic := wakutypes.BytesToTopic(messaging.ToContentTopic(chatID))
 	topics := []wakutypes.TopicType{topic}
 
 	startDate := time.Date(2020, 1, 1, 00, 00, 00, 0, time.UTC)

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1044,7 +1044,7 @@ func testCreateEditDeleteBecomeMemberPermission(base CommunityEventsTestsInterfa
 // To be removed in https://github.com/status-im/status-go/issues/4437
 func advertiseCommunityToUserOldWay(s *suite.Suite, community *communities.Community, owner *Messenger, user *Messenger) {
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&user.identity.PublicKey), &user.identity.PublicKey, user.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&user.identity.PublicKey), &user.identity.PublicKey, user.getTimesource())
 
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID

--- a/protocol/communities_messenger_signers_test.go
+++ b/protocol/communities_messenger_signers_test.go
@@ -488,7 +488,7 @@ func (s *MessengerCommunitiesSignersSuite) TestNewOwnerAcceptRequestToJoin() {
 	s.Require().NoError(err)
 
 	// Alice advertises community to Bob
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.bob.identity.PublicKey), &s.bob.identity.PublicKey, s.bob.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.bob.identity.PublicKey), &s.bob.identity.PublicKey, s.bob.getTimesource())
 
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/images"
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	multiaccountscommon "github.com/status-im/status-go/multiaccounts/common"
 	"github.com/status-im/status-go/protocol/common"
@@ -151,7 +151,7 @@ func (s *MessengerCommunitiesSuite) TestRetrieveCommunity() {
 	s.Require().Equal(communitySettings.HistoryArchiveSupportEnabled, false)
 
 	// Send a community message
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID
@@ -206,7 +206,7 @@ func (s *MessengerCommunitiesSuite) TestJoiningOpenCommunityReturnsChatsResponse
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -349,7 +349,7 @@ func (s *MessengerCommunitiesSuite) TestJoinCommunity() {
 	s.Require().Len(chats, 2)
 
 	// Send a community message
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.bob.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.bob.getTimesource())
 
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID
@@ -801,7 +801,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccess() {
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -1008,7 +1008,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccess() {
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -1199,7 +1199,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccessWithDeclinedSt
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -1451,7 +1451,7 @@ func (s *MessengerCommunitiesSuite) TestCancelRequestAccess() {
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -1892,7 +1892,7 @@ func (s *MessengerCommunitiesSuite) TestDeclineAccess() {
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -2768,7 +2768,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_RequestToJoin() {
 	s.Len(tcs1, 0, "Must have 0 communities")
 
 	// Bob the admin opens up a 1-1 chat with alice
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 	s.Require().NoError(s.bob.SaveChat(chat))
 
 	// Bob the admin shares with Alice, via public chat, an invite link to the new community
@@ -2996,7 +2996,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_Leave() {
 	s.Len(tcs1, 0, "Must have 0 communities")
 
 	// Bob the admin opens up a 1-1 chat with alice
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 	s.Require().NoError(s.bob.SaveChat(chat))
 
 	// Bob the admin shares with Alice, via public chat, an invite link to the new community
@@ -3641,8 +3641,8 @@ func (s *MessengerCommunitiesSuite) TestHandleImport() {
 	message.Sig = crypto.FromECDSAPub(&s.owner.identity.PublicKey)
 	message.Payload = wrappedPayload
 
-	filter := s.alice.transport.FilterByChatID(chat.ID)
-	importedMessages := make(map[transport.Filter][]*wakutypes.Message, 0)
+	filter := s.alice.messaging.ChatFilterByChatID(chat.ID)
+	importedMessages := make(map[messaging.ChatFilter][]*wakutypes.Message, 0)
 
 	importedMessages[*filter] = append(importedMessages[*filter], message)
 
@@ -4687,10 +4687,8 @@ func (s *MessengerCommunitiesSuite) TestAliceDidNotProcessOutdatedCommunityReque
 	s.Require().NoError(err)
 
 	var key *ecdsa.PrivateKey
-	if s.owner.transport.WakuVersion() == 2 {
-		key, err = s.owner.transport.RetrievePubsubTopicKey(community.PubsubTopic())
-		s.Require().NoError(err)
-	}
+	key, err = s.owner.messaging.RetrievePubsubTopicKey(community.PubsubTopic())
+	s.Require().NoError(err)
 
 	descriptionMessage, err := community.ToProtocolMessageBytes()
 	s.Require().NoError(err)

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -22,7 +22,7 @@ import (
 	hexutil "github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
@@ -2153,8 +2153,8 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestImportDecryptedArchiveMe
 	messageDate := time.UnixMilli(int64(message1.Timestamp))
 	startDate := messageDate.Add(-time.Minute)
 	endDate := messageDate.Add(time.Minute)
-	topic := wakutypes.BytesToTopic(transport.ToTopic(chat.ID))
-	communityCommonTopic := wakutypes.BytesToTopic(transport.ToTopic(community.UniversalChatID()))
+	topic := wakutypes.BytesToTopic(messaging.ToContentTopic(chat.ID))
+	communityCommonTopic := wakutypes.BytesToTopic(messaging.ToContentTopic(community.UniversalChatID()))
 	topics := []wakutypes.TopicType{topic, communityCommonTopic}
 
 	torrentConfig := params.TorrentConfig{

--- a/protocol/messages_iterator.go
+++ b/protocol/messages_iterator.go
@@ -3,22 +3,22 @@ package protocol
 import (
 	"golang.org/x/exp/maps"
 
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
 
 type MessagesIterator interface {
 	HasNext() bool
-	Next() (transport.Filter, []*wakutypes.Message)
+	Next() (messaging.ChatFilter, []*wakutypes.Message)
 }
 
 type DefaultMessagesIterator struct {
-	chatWithMessages map[transport.Filter][]*wakutypes.Message
-	keys             []transport.Filter
+	chatWithMessages map[messaging.ChatFilter][]*wakutypes.Message
+	keys             []messaging.ChatFilter
 	currentIndex     int
 }
 
-func NewDefaultMessagesIterator(chatWithMessages map[transport.Filter][]*wakutypes.Message) MessagesIterator {
+func NewDefaultMessagesIterator(chatWithMessages map[messaging.ChatFilter][]*wakutypes.Message) MessagesIterator {
 	return &DefaultMessagesIterator{
 		chatWithMessages: chatWithMessages,
 		keys:             maps.Keys(chatWithMessages),
@@ -30,11 +30,11 @@ func (it *DefaultMessagesIterator) HasNext() bool {
 	return it.currentIndex < len(it.keys)
 }
 
-func (it *DefaultMessagesIterator) Next() (transport.Filter, []*wakutypes.Message) {
+func (it *DefaultMessagesIterator) Next() (messaging.ChatFilter, []*wakutypes.Message) {
 	if it.HasNext() {
 		key := it.keys[it.currentIndex]
 		it.currentIndex++
 		return key, it.chatWithMessages[key]
 	}
-	return transport.Filter{}, nil
+	return messaging.ChatFilter{}, nil
 }

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -54,7 +54,7 @@ func (s *MessengerActivityCenterMessageSuite) TestDeleteOneToOneChat() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 

--- a/protocol/messenger_backup_test.go
+++ b/protocol/messenger_backup_test.go
@@ -1074,7 +1074,7 @@ func (s *MessengerBackupSuite) TestBackupChats() {
 	alice := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, alice)
 
-	ourOneOneChat := CreateOneToOneChat("Our 1TO1", &alice.identity.PublicKey, alice.transport)
+	ourOneOneChat := CreateOneToOneChat("Our 1TO1", &alice.identity.PublicKey, alice.getTimesource())
 	err = bob1.SaveChat(ourOneOneChat)
 	s.Require().NoError(err)
 

--- a/protocol/messenger_bridge_message_test.go
+++ b/protocol/messenger_bridge_message_test.go
@@ -31,7 +31,7 @@ func (s *BridgeMessageSuite) TestSendBridgeMessage() {
 
 	chatID := statusChatID
 
-	chat := CreatePublicChat(chatID, alice.transport)
+	chat := CreatePublicChat(chatID, alice.getTimesource())
 
 	err = alice.SaveChat(chat)
 	s.Require().NoError(err)
@@ -103,7 +103,7 @@ func (s *BridgeMessageSuite) TestSendBridgeMessage() {
 
 func (s *BridgeMessageSuite) TestSearchForDiscordMessages() {
 	//send bridged message
-	chat := CreatePublicChat("test-chat", s.m.transport)
+	chat := CreatePublicChat("test-chat", s.m.getTimesource())
 	err := s.m.SaveChat(chat)
 	s.NoError(err)
 

--- a/protocol/messenger_chat_context_test.go
+++ b/protocol/messenger_chat_context_test.go
@@ -54,7 +54,7 @@ func (s *MessengerSuite) TestTwoImagesAreAddedToChatIdentityForPrivateChat() {
 
 	bobPkString := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
-	chat := CreateOneToOneChat(bobPkString, &bob.identity.PublicKey, alice.transport)
+	chat := CreateOneToOneChat(bobPkString, &bob.identity.PublicKey, alice.getTimesource())
 	s.Require().Equal(privateChat, GetChatContextFromChatType(chat.ChatType))
 
 	imgs := s.retrieveIdentityImages(alice, bob, chat)

--- a/protocol/messenger_communities_import_discord.go
+++ b/protocol/messenger_communities_import_discord.go
@@ -17,7 +17,7 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/images"
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/discord"
@@ -931,7 +931,7 @@ func (m *Messenger) RequestImportDiscordChannel(request *requests.ImportDiscordC
 				importProgress.UpdateTaskProgress(discord.DownloadAssetsTask, progressValue)
 			}
 
-			_, err := m.transport.JoinPublic(newChat.ID)
+			_, err := m.messaging.JoinPublicChat(newChat.ID)
 			if err != nil {
 				m.logger.Error("failed to load filter for chat", zap.Error(err))
 				continue
@@ -1703,7 +1703,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 				importProgress.UpdateTaskProgress(discord.DownloadAssetsTask, progressValue)
 			}
 
-			_, err := m.transport.JoinPublic(processedChannelIds[channel.Channel.ID])
+			_, err := m.messaging.JoinPublicChat(processedChannelIds[channel.Channel.ID])
 			if err != nil {
 				m.logger.Error("failed to load filter for chat", zap.Error(err))
 				continue
@@ -1794,7 +1794,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 		}
 
 		// Init the community filter so we can receive messages on the community
-		_, err = m.InitCommunityFilters([]transport.CommunityFilterToInitialize{{
+		_, err = m.InitCommunityFilters(messaging.CommunitiesToInitialize{{
 			Shard:   discordCommunity.Shard(),
 			PrivKey: discordCommunity.PrivateKey(),
 		}})
@@ -1815,7 +1815,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 			return
 		}
 
-		_, err = m.transport.InitPublicFilters(m.DefaultFilters(discordCommunity))
+		_, err = m.messaging.InitPublicChats(m.DefaultFilters(discordCommunity))
 		if err != nil {
 			m.cleanUpImport(communityID)
 			importProgress.AddTaskError(discord.InitCommunityTask, discord.Error(err.Error()))
@@ -1834,7 +1834,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 			return
 		}
 
-		filters := m.transport.Filters()
+		filters := m.messaging.ChatFilters()
 		_, err = m.scheduleSyncFilters(filters)
 		if err != nil {
 			m.cleanUpImport(communityID)

--- a/protocol/messenger_community_shard.go
+++ b/protocol/messenger_community_shard.go
@@ -12,7 +12,7 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -62,7 +62,7 @@ func (m *Messenger) sendPublicCommunityShardInfo(community *communities.Communit
 		Priority:            &common.HighPriority,
 	}
 
-	chatName := transport.CommunityShardInfoTopic(community.IDString())
+	chatName := messaging.CommunityShardInfoTopic(community.IDString())
 	messageID, err := m.sender.SendPublic(context.Background(), chatName, rawMessage)
 	if err == nil {
 		m.logger.Debug("published public community shard info",

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 
 	"github.com/status-im/status-go/account"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/browsers"
@@ -16,7 +17,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/appdatabase/migrations"
-	"github.com/status-im/status-go/messaging/transport"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/multiaccounts/settings"
@@ -74,8 +74,7 @@ type MessengerSignalsHandler interface {
 type config struct {
 	// systemMessagesTranslations holds translations for system-messages
 	systemMessagesTranslations *systemMessageTranslationsMap
-	// Config for the envelopes monitor
-	envelopesMonitorConfig *transport.EnvelopesMonitorConfig
+	envelopeEventsConfig       *messaging.EnvelopeEventsConfig
 
 	featureFlags     common.FeatureFlags
 	codeControlFlags common.CodeControlFlags
@@ -315,9 +314,9 @@ func WithAutoMessageDisabled() func(c *config) error {
 	}
 }
 
-func WithEnvelopesMonitorConfig(emc *transport.EnvelopesMonitorConfig) Option {
+func WithEnvelopeEventsConfig(emc *messaging.EnvelopeEventsConfig) Option {
 	return func(c *config) error {
-		c.envelopesMonitorConfig = emc
+		c.envelopeEventsConfig = emc
 		return nil
 	}
 }

--- a/protocol/messenger_delete_message_for_me_test.go
+++ b/protocol/messenger_delete_message_for_me_test.go
@@ -216,11 +216,11 @@ func (s *MessengerDeleteMessageForMeSuite) TestDeleteImageMessageFromReceiverSid
 	bob := s.otherNewMessenger()
 	defer TearDownMessenger(&s.Suite, bob)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, alice.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, alice.getTimesource())
 	err := alice.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &alice.identity.PublicKey, alice.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &alice.identity.PublicKey, alice.getTimesource())
 	err = bob.SaveChat(ourChat)
 	s.Require().NoError(err)
 

--- a/protocol/messenger_discv5.go
+++ b/protocol/messenger_discv5.go
@@ -1,9 +1,0 @@
-package protocol
-
-func (m *Messenger) StartDiscV5() error {
-	return m.transport.StartDiscV5()
-}
-
-func (m *Messenger) StopDiscV5() error {
-	return m.transport.StopDiscV5()
-}

--- a/protocol/messenger_edit_message_test.go
+++ b/protocol/messenger_edit_message_test.go
@@ -25,11 +25,11 @@ func (s *MessengerEditMessageSuite) TestEditMessage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -94,11 +94,11 @@ func (s *MessengerEditMessageSuite) TestEditImageMessage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -176,11 +176,11 @@ func (s *MessengerEditMessageSuite) TestEditBridgeMessage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -249,11 +249,11 @@ func (s *MessengerEditMessageSuite) TestEditMessageEdgeCases() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -350,14 +350,14 @@ func (s *MessengerEditMessageSuite) TestEditMessageFirstEditsThenMessage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
 	contact, err := BuildContactFromPublicKey(&theirMessenger.identity.PublicKey)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 	messageID := "message-id"
@@ -490,11 +490,11 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -595,11 +595,11 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithLinkPreviews() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 

--- a/protocol/messenger_emoji_test.go
+++ b/protocol/messenger_emoji_test.go
@@ -35,7 +35,7 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 
 	chatID := statusChatID
 
-	chat := CreatePublicChat(chatID, alice.transport)
+	chat := CreatePublicChat(chatID, alice.getTimesource())
 
 	err = alice.SaveChat(chat)
 	s.Require().NoError(err)

--- a/protocol/messenger_handler_test.go
+++ b/protocol/messenger_handler_test.go
@@ -142,7 +142,7 @@ func (s *EventToSystemMessageSuite) TestHandleMembershipUpdate() {
 
 	state := &ReceivedMessageState{
 		Response:            &MessengerResponse{},
-		Timesource:          s.m.transport,
+		Timesource:          s.m.getTimesource(),
 		CurrentMessageState: currentMessageState,
 		ExistingMessagesMap: map[string]bool{},
 		AllChats:            s.m.allChats,

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -214,7 +214,7 @@ func (s *MessengerProfilePictureHandlerSuite) TestPictureInPrivateChatOneSided()
 	err = s.alice.settings.SaveSettingField(settings.ProfilePicturesVisibility, settings.ProfilePicturesShowToEveryone)
 	s.Require().NoError(err)
 
-	bChat := CreateOneToOneChat(s.alice.IdentityPublicKeyString(), s.alice.IdentityPublicKey(), s.alice.transport)
+	bChat := CreateOneToOneChat(s.alice.IdentityPublicKeyString(), s.alice.IdentityPublicKey(), s.alice.getTimesource())
 	err = s.bob.SaveChat(bChat)
 	s.Require().NoError(err)
 
@@ -336,14 +336,14 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 	switch args.chatContext {
 	case publicChat:
 		// Bob opens up the public chat and joins it
-		bChat := CreatePublicChat("status", alice.transport)
+		bChat := CreatePublicChat("status", alice.getTimesource())
 		err = bob.SaveChat(bChat)
 		s.Require().NoError(err)
 
 		_, err = bob.Join(bChat)
 		s.Require().NoError(err)
 	case privateChat:
-		bChat := CreateOneToOneChat(alice.IdentityPublicKeyString(), alice.IdentityPublicKey(), alice.transport)
+		bChat := CreateOneToOneChat(alice.IdentityPublicKeyString(), alice.IdentityPublicKey(), alice.getTimesource())
 		err = bob.SaveChat(bChat)
 		s.Require().NoError(err)
 
@@ -369,7 +369,7 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 	switch args.chatContext {
 	case publicChat:
 		// Alice opens creates a public chat
-		aChat = CreatePublicChat("status", alice.transport)
+		aChat = CreatePublicChat("status", alice.getTimesource())
 		err = alice.SaveChat(aChat)
 		s.Require().NoError(err)
 
@@ -381,7 +381,7 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 		s.Require().Len(response.messages, 1)
 
 	case privateChat:
-		aChat = CreateOneToOneChat(bob.IdentityPublicKeyString(), bob.IdentityPublicKey(), bob.transport)
+		aChat = CreateOneToOneChat(bob.IdentityPublicKeyString(), bob.IdentityPublicKey(), bob.getTimesource())
 		err = alice.SaveChat(aChat)
 		s.Require().NoError(err)
 

--- a/protocol/messenger_installations_test.go
+++ b/protocol/messenger_installations_test.go
@@ -115,7 +115,7 @@ func (s *MessengerInstallationSuite) TestReceiveInstallation() {
 	)
 	s.Require().NoError(err)
 
-	chat := CreatePublicChat(statusChatID, s.m.transport)
+	chat := CreatePublicChat(statusChatID, s.m.getTimesource())
 	err = s.m.SaveChat(chat)
 	s.Require().NoError(err)
 
@@ -162,7 +162,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 	s.Require().NoError(err)
 
 	// add chat
-	chat := CreatePublicChat(statusChatID, s.m.transport)
+	chat := CreatePublicChat(statusChatID, s.m.getTimesource())
 	err = s.m.SaveChat(chat)
 	s.Require().NoError(err)
 
@@ -219,12 +219,12 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 	defer TearDownMessenger(&s.Suite, alice)
 
 	// Create 1-1 chat
-	ourOneOneChat := CreateOneToOneChat("Our 1TO1", &alice.identity.PublicKey, alice.transport)
+	ourOneOneChat := CreateOneToOneChat("Our 1TO1", &alice.identity.PublicKey, alice.getTimesource())
 	err = s.m.SaveChat(ourOneOneChat)
 	s.Require().NoError(err)
 
 	// add and deactivate chat
-	chat2 := CreatePublicChat(removedChatID, s.m.transport)
+	chat2 := CreatePublicChat(removedChatID, s.m.getTimesource())
 	chat2.DeletedAtClockValue = 1
 	err = s.m.SaveChat(chat2)
 	s.Require().NoError(err)
@@ -388,7 +388,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallationNewMessages() {
 	// send a message from bob1 to alice, it should be received on both bob1 and bob2
 
 	alicePkString := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
-	chat := CreateOneToOneChat(alicePkString, &alice.identity.PublicKey, bob1.transport)
+	chat := CreateOneToOneChat(alicePkString, &alice.identity.PublicKey, bob1.getTimesource())
 	s.Require().NoError(bob1.SaveChat(chat))
 
 	inputMessage := buildTestMessage(*chat)

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -58,7 +58,7 @@ func (m *Messenger) getFleet() (string, error) {
 }
 
 func (m *Messenger) asyncRequestAllHistoricMessages() {
-	if !m.config.codeControlFlags.AutoRequestHistoricMessages || m.transport.WakuVersion() == 1 {
+	if !m.config.codeControlFlags.AutoRequestHistoricMessages {
 		return
 	}
 
@@ -129,13 +129,9 @@ func (m *Messenger) Storenodes() ([]peer.AddrInfo, error) {
 func (m *Messenger) checkForStorenodeCycleSignals() {
 	defer gocommon.LogOnPanic()
 
-	if m.transport.WakuVersion() != 2 {
-		return
-	}
-
-	changed := m.transport.OnStorenodeChanged()
-	notWorking := m.transport.OnStorenodeNotWorking()
-	available := m.transport.OnStorenodeAvailable()
+	changed := m.messaging.OnStorenodeChanged()
+	notWorking := m.messaging.OnStorenodeNotWorking()
+	available := m.messaging.OnStorenodeAvailable()
 
 	allMailservers, err := m.AllMailservers()
 	if err != nil {

--- a/protocol/messenger_messages_order_controller_test.go
+++ b/protocol/messenger_messages_order_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
 )
@@ -59,7 +59,7 @@ func (m *MessagesOrderController) Stop() {
 	})
 }
 
-func (m *MessagesOrderController) newMessagesIterator(chatWithMessages map[transport.Filter][]*wakutypes.Message) MessagesIterator {
+func (m *MessagesOrderController) newMessagesIterator(chatWithMessages map[messaging.ChatFilter][]*wakutypes.Message) MessagesIterator {
 	switch m.order {
 	case messagesOrderAsPosted, messagesOrderReversed:
 		return &messagesIterator{chatWithMessages: m.sort(chatWithMessages, m.order)}
@@ -77,7 +77,7 @@ func buildIndexMap(messages [][]byte) map[string]int {
 	return indexMap
 }
 
-func (m *MessagesOrderController) sort(chatWithMessages map[transport.Filter][]*wakutypes.Message, order messagesOrderType) []*chatWithMessage {
+func (m *MessagesOrderController) sort(chatWithMessages map[messaging.ChatFilter][]*wakutypes.Message, order messagesOrderType) []*chatWithMessage {
 	allMessages := make([]*chatWithMessage, 0)
 	for chat, messages := range chatWithMessages {
 		for _, message := range messages {
@@ -107,7 +107,7 @@ func (m *MessagesOrderController) sort(chatWithMessages map[transport.Filter][]*
 }
 
 type chatWithMessage struct {
-	chat    transport.Filter
+	chat    messaging.ChatFilter
 	message *wakutypes.Message
 }
 
@@ -120,12 +120,12 @@ func (it *messagesIterator) HasNext() bool {
 	return it.currentIndex < len(it.chatWithMessages)
 }
 
-func (it *messagesIterator) Next() (transport.Filter, []*wakutypes.Message) {
+func (it *messagesIterator) Next() (messaging.ChatFilter, []*wakutypes.Message) {
 	if it.HasNext() {
 		m := it.chatWithMessages[it.currentIndex]
 		it.currentIndex++
 		return m.chat, []*wakutypes.Message{m.message}
 	}
 
-	return transport.Filter{}, nil
+	return messaging.ChatFilter{}, nil
 }

--- a/protocol/messenger_mute_test.go
+++ b/protocol/messenger_mute_test.go
@@ -29,7 +29,7 @@ func (s *MessengerMuteSuite) TestSetMute() {
 
 	chatID := publicChatName
 
-	chat := CreatePublicChat(chatID, s.m.transport)
+	chat := CreatePublicChat(chatID, s.m.getTimesource())
 
 	err = s.m.SaveChat(chat)
 	s.Require().NoError(err)
@@ -82,7 +82,7 @@ func (s *MessengerMuteSuite) TestSetMuteForDuration() {
 
 	chatID := publicChatName
 
-	chat := CreatePublicChat(chatID, s.m.transport)
+	chat := CreatePublicChat(chatID, s.m.getTimesource())
 
 	err = s.m.SaveChat(chat)
 	s.Require().NoError(err)

--- a/protocol/messenger_peers.go
+++ b/protocol/messenger_peers.go
@@ -12,42 +12,42 @@ import (
 )
 
 func (m *Messenger) AddRelayPeer(address multiaddr.Multiaddr) (peer.ID, error) {
-	return m.transport.AddRelayPeer(address)
+	return m.messaging.AddRelayPeer(address)
 }
 
 func (m *Messenger) DialPeer(address multiaddr.Multiaddr) error {
-	return m.transport.DialPeer(address)
+	return m.messaging.DialPeer(address)
 }
 
 func (m *Messenger) DialPeerByID(peerID peer.ID) error {
-	return m.transport.DialPeerByID(peerID)
+	return m.messaging.DialPeerByID(peerID)
 }
 
 func (m *Messenger) DropPeer(peerID peer.ID) error {
-	return m.transport.DropPeer(peerID)
+	return m.messaging.DropPeer(peerID)
 }
 
 func (m *Messenger) Peers() wakutypes.PeerStats {
-	return m.transport.Peers()
+	return m.messaging.Peers()
 }
 
 func (m *Messenger) RelayPeersByTopic(topic string) (*wakutypes.PeerList, error) {
-	return m.transport.RelayPeersByTopic(topic)
+	return m.messaging.RelayPeersByTopic(topic)
 }
 
 func (m *Messenger) ListenAddresses() ([]multiaddr.Multiaddr, error) {
-	return m.transport.ListenAddresses()
+	return m.messaging.ListenAddresses()
 }
 
 func (m *Messenger) ENR() (*enode.Node, error) {
-	return m.transport.ENR()
+	return m.messaging.ENR()
 }
 
 // Subscribe to a pubsub topic, passing an optional public key if the pubsub topic is protected
 func (m *Messenger) SubscribeToPubsubTopic(topic string, optPublicKey *ecdsa.PublicKey) error {
-	return m.transport.SubscribeToPubsubTopic(topic, optPublicKey)
+	return m.messaging.SubscribeToPubsubTopic(topic, optPublicKey)
 }
 
 func (m *Messenger) StorePubsubTopicKey(topic string, privKey *ecdsa.PrivateKey) error {
-	return m.transport.StorePubsubTopicKey(topic, privKey)
+	return m.messaging.StorePubsubTopicKey(topic, privKey)
 }

--- a/protocol/messenger_peersyncing.go
+++ b/protocol/messenger_peersyncing.go
@@ -51,7 +51,7 @@ func (m *Messenger) markDeliveredMessages(acks [][]byte) {
 			m.logger.Debug("can't set raw message as sent", zap.Error(err))
 		}
 
-		m.transport.ConfirmMessageDelivered(messageID)
+		m.messaging.ConfirmMessageDelivered(messageID)
 
 		//send signal to client that message status updated
 		if m.config.messengerSignalsHandler != nil {
@@ -415,7 +415,7 @@ func (m *Messenger) sendDataSync(receiver state.PeerID, payload *datasyncproto.P
 	}
 
 	m.logger.Debug("sent private messages", zap.Any("messageIDs", hexMessageIDs), zap.Strings("hashes", types.EncodeHexes(hashes)))
-	m.transport.TrackMany(messageIDs, hashes, newMessages)
+	m.messaging.TrackMany(messageIDs, hashes, newMessages)
 	if m.wakuMetricsHandler != nil {
 		for _, message := range newMessages {
 			m.wakuMetricsHandler.PushRawMessageByType(message.PubsubTopic, message.Topic.String(), "DATASYNC", uint32(len(message.Payload)))

--- a/protocol/messenger_peersyncing_test.go
+++ b/protocol/messenger_peersyncing_test.go
@@ -279,7 +279,7 @@ func (s *MessengerPeersyncingSuite) TestSyncOneToOne() {
 	s.owner.featureFlags.Peersyncing = true
 
 	pkString := hex.EncodeToString(crypto.FromECDSAPub(&s.alice.identity.PublicKey))
-	chat := CreateOneToOneChat(pkString, &s.alice.identity.PublicKey, s.owner.transport)
+	chat := CreateOneToOneChat(pkString, &s.alice.identity.PublicKey, s.owner.getTimesource())
 
 	chat.LastClockValue = uint64(100000000000000)
 	err := s.owner.SaveChat(chat)
@@ -342,7 +342,7 @@ func (s *MessengerPeersyncingSuite) TestCanSyncOneToOneMessageWith() {
 	s.owner.featureFlags.Peersyncing = true
 
 	pkString := hex.EncodeToString(crypto.FromECDSAPub(&s.alice.identity.PublicKey))
-	chat := CreateOneToOneChat(pkString, &s.alice.identity.PublicKey, s.owner.transport)
+	chat := CreateOneToOneChat(pkString, &s.alice.identity.PublicKey, s.owner.getTimesource())
 
 	chat.LastClockValue = uint64(100000000000000)
 	err := s.owner.SaveChat(chat)

--- a/protocol/messenger_pin_message_test.go
+++ b/protocol/messenger_pin_message_test.go
@@ -22,11 +22,11 @@ func (s *MessengerPinMessageSuite) TestPinMessage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -91,11 +91,11 @@ func (s *MessengerPinMessageSuite) TestPinMessageOutOfOrder() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 

--- a/protocol/messenger_remove_message_test.go
+++ b/protocol/messenger_remove_message_test.go
@@ -23,11 +23,11 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -72,11 +72,11 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessagePreviousLastMessage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -121,11 +121,11 @@ func (s *MessengerRemoveMessageSuite) TestDeleteWrongMessageType() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -148,14 +148,14 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageFirstThenMessage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
 	contact, err := BuildContactFromPublicKey(&theirMessenger.identity.PublicKey)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 	messageID := "message-id"
@@ -201,11 +201,11 @@ func (s *MessengerRemoveMessageSuite) TestDeleteImageMessage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -275,14 +275,14 @@ func (s *MessengerRemoveMessageSuite) TestDeleteImageMessageFirstThenMessage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
 	contact, err := BuildContactFromPublicKey(&theirMessenger.identity.PublicKey)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 	messageID1 := "message-id1"
@@ -353,11 +353,11 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageWithAMention() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -413,11 +413,11 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageAndChatIsAlreadyRead() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -472,11 +472,11 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageReplyToImage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -525,11 +525,11 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageForMeReplyToImage() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 

--- a/protocol/messenger_reply_test.go
+++ b/protocol/messenger_reply_test.go
@@ -29,7 +29,7 @@ func (s *MessengerReplySuite) TestReceiveReply() {
 
 	chatID := statusChatID
 
-	chat := CreatePublicChat(chatID, alice.transport)
+	chat := CreatePublicChat(chatID, alice.getTimesource())
 
 	err = alice.SaveChat(chat)
 	s.Require().NoError(err)

--- a/protocol/messenger_send_images_album_test.go
+++ b/protocol/messenger_send_images_album_test.go
@@ -48,11 +48,11 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesSend() {
 	s.Require().NoError(err)
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -109,11 +109,11 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesWithMentionSend() 
 	s.Require().NoError(err)
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 
@@ -213,11 +213,11 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageEditText() {
 	s.Require().NoError(err)
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err = theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 

--- a/protocol/messenger_share_image_test.go
+++ b/protocol/messenger_share_image_test.go
@@ -57,11 +57,11 @@ func (s *MessengerShareMessageSuite) TestImageMessageSharing() {
 	theirMessenger := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, theirMessenger)
 
-	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.transport)
+	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
-	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.transport)
+	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
 	err = s.m.SaveChat(ourChat)
 	s.Require().NoError(err)
 

--- a/protocol/messenger_status_updates.go
+++ b/protocol/messenger_status_updates.go
@@ -11,9 +11,9 @@ import (
 	datasyncnode "github.com/status-im/mvds/node"
 
 	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/messaging"
 	datasyncpeer "github.com/status-im/status-go/protocol/datasync/peer"
 
-	"github.com/status-im/status-go/messaging/transport"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
@@ -67,7 +67,7 @@ func (m *Messenger) sendUserStatus(ctx context.Context, status UserStatus) error
 		return err
 	}
 
-	contactCodeTopic := transport.ContactCodeTopic(&m.identity.PublicKey)
+	contactCodeTopic := messaging.ContactCodeTopic(&m.identity.PublicKey)
 
 	rawMessage := common.RawMessage{
 		LocalChatID: contactCodeTopic,

--- a/protocol/messenger_storenode_comunity_test.go
+++ b/protocol/messenger_storenode_comunity_test.go
@@ -352,10 +352,10 @@ func (s *MessengerStoreNodeCommunitySuite) TestToggleUseMailservers() {
 	// Enable use of mailservers
 	err := s.owner.ToggleUseMailservers(true)
 	s.Require().NoError(err)
-	s.Require().NotNil(s.owner.transport.GetActiveStorenode())
+	s.Require().NotNil(s.owner.messaging.GetActiveStorenode())
 
 	// Disable use of mailservers
 	err = s.owner.ToggleUseMailservers(false)
 	s.Require().NoError(err)
-	s.Require().Nil(s.owner.transport.GetActiveStorenode())
+	s.Require().Nil(s.owner.messaging.GetActiveStorenode())
 }

--- a/protocol/messenger_sync_chat_test.go
+++ b/protocol/messenger_sync_chat_test.go
@@ -105,11 +105,11 @@ func (s *MessengerSyncChatSuite) Pair() {
 }
 
 func (s *MessengerSyncChatSuite) TestRemovePubChat() {
-	chat := CreatePublicChat(publicChatName, s.alice1.transport)
+	chat := CreatePublicChat(publicChatName, s.alice1.getTimesource())
 	err := s.alice1.SaveChat(chat)
 	s.Require().NoError(err)
 
-	chat = CreatePublicChat(publicChatName, s.alice2.transport)
+	chat = CreatePublicChat(publicChatName, s.alice2.getTimesource())
 	err = s.alice2.SaveChat(chat)
 	s.Require().NoError(err)
 

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -368,7 +368,7 @@ func SetIdentityImagesAndWaitForChange(s *suite.Suite, messenger *Messenger, tim
 func WaitForAvailableStoreNode(s *suite.Suite, m *Messenger, ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	available := m.transport.WaitForAvailableStoreNode(ctx)
+	available := m.messaging.WaitForAvailableStoreNode(ctx)
 	s.Require().True(available)
 }
 

--- a/protocol/messenger_unread_test.go
+++ b/protocol/messenger_unread_test.go
@@ -39,7 +39,7 @@ func (s *MessengerSuite) retrieveAllWithRetry(errorMessage string) (*MessengerRe
 }
 
 func (s *MessengerSuite) TestMarkMessageAsUnreadWhenMessageListContainsSingleMessage() {
-	chat := CreatePublicChat("test-chat-1", s.m.transport)
+	chat := CreatePublicChat("test-chat-1", s.m.getTimesource())
 
 	chat.UnviewedMessagesCount = 2
 	chat.UnviewedMentionsCount = 2
@@ -89,7 +89,7 @@ func (s *MessengerSuite) TestMarkMessageAsUnreadWhenMessageListContainsSingleMes
 }
 
 func (s *MessengerSuite) TestMarkMessageAsUnreadWhenMessageListContainsSeveralMessages() {
-	chat := CreatePublicChat("test-chat-2", s.m.transport)
+	chat := CreatePublicChat("test-chat-2", s.m.getTimesource())
 
 	chat.UnviewedMessagesCount = 0
 	chat.UnviewedMentionsCount = 0
@@ -169,7 +169,7 @@ func (s *MessengerSuite) TestMarkMessageAsUnreadWhenMessageListContainsSeveralMe
 }
 
 func (s *MessengerSuite) TestMarkMessageAsUnreadWhenMessageIsAlreadyInUnreadState() {
-	chat := CreatePublicChat("test-chat-3", s.m.transport)
+	chat := CreatePublicChat("test-chat-3", s.m.getTimesource())
 
 	chat.UnviewedMessagesCount = 1
 	chat.UnviewedMentionsCount = 0
@@ -214,11 +214,11 @@ func (s *MessengerSuite) TestMarkMessageAsUnreadWhenMessageIsAlreadyInUnreadStat
 }
 
 func (s *MessengerSuite) TestMarkMessageAsUnreadInOneChatDoesNotImpactOtherChats() {
-	chat1 := CreatePublicChat("test-chat-1", s.m.transport)
+	chat1 := CreatePublicChat("test-chat-1", s.m.getTimesource())
 	err := s.m.SaveChat(chat1)
 	s.Require().NoError(err)
 
-	chat2 := CreatePublicChat("test-chat-2", s.m.transport)
+	chat2 := CreatePublicChat("test-chat-2", s.m.getTimesource())
 	err = s.m.SaveChat(chat2)
 	s.Require().NoError(err)
 

--- a/protocol/persistence_quoted_message_test.go
+++ b/protocol/persistence_quoted_message_test.go
@@ -29,7 +29,7 @@ func (s *TestMessengerPrepareMessageSuite) SetupTest() {
 }
 
 func (s *TestMessengerPrepareMessageSuite) setUpTestDatabase() (string, *sqlitePersistence) {
-	chat := CreatePublicChat("test-chat", s.m.transport)
+	chat := CreatePublicChat("test-chat", s.m.getTimesource())
 	err := s.m.SaveChat(chat)
 	s.NoError(err)
 

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -183,7 +183,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotification() {
 
 	// Create one to one chat & send message
 	pkString := hex.EncodeToString(crypto.FromECDSAPub(&s.m.identity.PublicKey))
-	chat := CreateOneToOneChat(pkString, &s.m.identity.PublicKey, alice.transport)
+	chat := CreateOneToOneChat(pkString, &s.m.identity.PublicKey, alice.getTimesource())
 	s.Require().NoError(alice.SaveChat(chat))
 	inputMessage := buildTestMessage(*chat)
 	response, err := alice.SendChatMessage(context.Background(), inputMessage)
@@ -338,7 +338,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationFromContactO
 
 	// Create one to one chat & send message
 	pkString := hex.EncodeToString(crypto.FromECDSAPub(&s.m.identity.PublicKey))
-	chat := CreateOneToOneChat(pkString, &s.m.identity.PublicKey, alice.transport)
+	chat := CreateOneToOneChat(pkString, &s.m.identity.PublicKey, alice.getTimesource())
 	s.Require().NoError(alice.SaveChat(chat))
 	inputMessage := buildTestMessage(*chat)
 	response, err := alice.SendChatMessage(context.Background(), inputMessage)
@@ -491,7 +491,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
 
 	// Create one to one chat & send message
 	pkString := hex.EncodeToString(crypto.FromECDSAPub(&s.m.identity.PublicKey))
-	chat := CreateOneToOneChat(pkString, &s.m.identity.PublicKey, alice.transport)
+	chat := CreateOneToOneChat(pkString, &s.m.identity.PublicKey, alice.getTimesource())
 	s.Require().NoError(alice.SaveChat(chat))
 	inputMessage := buildTestMessage(*chat)
 	_, err = alice.SendChatMessage(context.Background(), inputMessage)
@@ -706,7 +706,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
 	bobInstallationIDs := []string{bob.installationID}
 
 	// Create public chat and join for both alice and bob
-	chat := CreatePublicChat("status", s.m.transport)
+	chat := CreatePublicChat("status", s.m.getTimesource())
 	err = bob.SaveChat(chat)
 	s.Require().NoError(err)
 
@@ -897,7 +897,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	community := response.Communities()[0]
 
 	// Send a community message
-	chat := CreateOneToOneChat(common.PubkeyToHex(&alice.identity.PublicKey), &alice.identity.PublicKey, alice.transport)
+	chat := CreateOneToOneChat(common.PubkeyToHex(&alice.identity.PublicKey), &alice.identity.PublicKey, alice.getTimesource())
 
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID
@@ -1059,7 +1059,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevice
 
 	// Create one to one chat & send message
 	pkString := hex.EncodeToString(crypto.FromECDSAPub(&s.m.identity.PublicKey))
-	chat := CreateOneToOneChat(pkString, &s.m.identity.PublicKey, alice.transport)
+	chat := CreateOneToOneChat(pkString, &s.m.identity.PublicKey, alice.getTimesource())
 	s.Require().NoError(alice.SaveChat(chat))
 	inputMessage := buildTestMessage(*chat)
 	response, err := alice.SendChatMessage(context.Background(), inputMessage)
@@ -1160,7 +1160,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationReply() {
 	bobInstallationIDs := []string{bob.installationID}
 
 	// Create public chat and join for both alice and bob
-	chat := CreatePublicChat("status", s.m.transport)
+	chat := CreatePublicChat("status", s.m.getTimesource())
 	err = bob.SaveChat(chat)
 	s.Require().NoError(err)
 

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/logutils"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/services/browsers"
 	"github.com/status-im/status-go/services/wallet"
 	"github.com/status-im/status-go/services/wallet/bigint"
@@ -26,7 +27,6 @@ import (
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/images"
-	"github.com/status-im/status-go/messaging/transport"
 	multiaccountscommon "github.com/status-im/status-go/multiaccounts/common"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol"
@@ -345,7 +345,7 @@ func (api *PublicAPI) RequestContactInfoFromMailserver(pubkey string) (*protocol
 	return api.service.messenger.FetchContact(pubkey, true)
 }
 
-func (api *PublicAPI) RemoveFilters(parent context.Context, chats []*transport.Filter) error {
+func (api *PublicAPI) RemoveFilters(parent context.Context, chats messaging.ChatFilters) error {
 	return api.service.messenger.RemoveFilters(chats)
 }
 
@@ -1381,19 +1381,6 @@ func (api *PublicAPI) FillGaps(chatID string, messageIDs []string) error {
 
 func (api *PublicAPI) SyncChatFromSyncedFrom(chatID string) (uint32, error) {
 	return api.service.messenger.SyncChatFromSyncedFrom(chatID)
-}
-
-// BloomFilter returns the current bloom filter bytes
-func (api *PublicAPI) BloomFilter() string {
-	return hexutil.Encode(api.service.messenger.BloomFilter())
-}
-
-func (api *PublicAPI) StartDiscV5() error {
-	return api.service.messenger.StartDiscV5()
-}
-
-func (api *PublicAPI) StopDiscV5() error {
-	return api.service.messenger.StopDiscV5()
 }
 
 func (api *PublicAPI) GetCommunitiesSettings() ([]communities.CommunitySettings, error) {

--- a/services/mailservers/api_test.go
+++ b/services/mailservers/api_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/appdatabase"
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/protocol/sqlite"
 	"github.com/status-im/status-go/t/helpers"
 	wakutypes "github.com/status-im/status-go/waku/types"
@@ -74,7 +74,7 @@ func TestTopic(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, topics, 3)
 
-	filters := []*transport.Filter{
+	filters := messaging.ChatFilters{
 		// Existing topic, is not updated
 		{
 			PubsubTopic:  wakuv2.DefaultShardPubsubTopic(),

--- a/services/mailservers/database.go
+++ b/services/mailservers/database.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/multiformats/go-multiaddr"
 
-	"github.com/status-im/status-go/messaging/transport"
+	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/waku/types"
 )
 
@@ -318,7 +318,7 @@ func (d *Database) DeleteTopic(pubsubTopic, contentTopic string) error {
 
 // SetTopics deletes all topics excepts the one set, or upsert those if
 // missing
-func (d *Database) SetTopics(filters []*transport.Filter) (err error) {
+func (d *Database) SetTopics(filters messaging.ChatFilters) (err error) {
 	var tx *sql.Tx
 	tx, err = d.db.Begin()
 	if err != nil {

--- a/waku/types/rpc.go
+++ b/waku/types/rpc.go
@@ -65,6 +65,4 @@ type PublicWakuAPI interface {
 	// GetFilterMessages returns the messages that match the filter criteria and
 	// are received between the last poll and now.
 	GetFilterMessages(id string) ([]*Message, error)
-
-	BloomFilter() []byte
 }

--- a/waku/types/waku.go
+++ b/waku/types/waku.go
@@ -182,9 +182,6 @@ type Waku interface {
 	Unsubscribe(ctx context.Context, id string) error
 	UnsubscribeMany(ids []string) error
 
-	// ProcessingP2PMessages indicates whether there are in-flight p2p messages
-	ProcessingP2PMessages() bool
-
 	// MarkP2PMessageAsProcessed tells the waku layer that a P2P message has been processed
 	MarkP2PMessageAsProcessed(common.Hash)
 

--- a/wakuv2/api.go
+++ b/wakuv2/api.go
@@ -173,10 +173,6 @@ func (api *PublicWakuAPI) DeleteSymKey(ctx context.Context, id string) bool {
 	return api.w.DeleteSymKey(id)
 }
 
-func (api *PublicWakuAPI) BloomFilter() []byte {
-	return nil
-}
-
 // Post posts a message on the Waku network.
 // returns the hash of the message in case of success.
 func (api *PublicWakuAPI) Post(ctx context.Context, req types.NewMessage) ([]byte, error) {

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -1978,12 +1978,6 @@ func (w *Waku) DropPeer(peerID peer.ID) error {
 	return w.node.ClosePeerById(peerID)
 }
 
-func (w *Waku) ProcessingP2PMessages() bool {
-	w.storeMsgIDsMu.Lock()
-	defer w.storeMsgIDsMu.Unlock()
-	return len(w.storeMsgIDs) != 0
-}
-
 func (w *Waku) MarkP2PMessageAsProcessed(hash gethcommon.Hash) {
 	w.storeMsgIDsMu.Lock()
 	defer w.storeMsgIDsMu.Unlock()


### PR DESCRIPTION
Encapsulate `transport` usage behind the messaging API facade. This is first step toward extracting the messaging stack.

Before:
```cmd
$ grep -rI --exclude-dir=vendor -o "messaging/transport" . | cut -d: -f1 | uniq -c | awk '{print $2, $1}'

./cmd/generate_handlers/generate_handlers_template.txt 1
./metrics/wakumetrics/client.go 1
./metrics/wakumetrics/client_test.go 1
./protocol/common/message_sender.go 1
./protocol/common/message_sender_test.go 1
./protocol/communities/manager.go 1
./protocol/communities/manager_archive.go 1
./protocol/communities/manager_archive_nop.go 1
./protocol/communities/manager_test.go 1
./protocol/sqlite/prepare_migrations.go 1
./protocol/communities_messenger_test.go 1
./protocol/communities_messenger_token_permissions_test.go 1
./protocol/messages_iterator.go 1
./protocol/messenger.go 1
./protocol/messenger_chats.go 1
./protocol/messenger_communities.go 1
./protocol/messenger_communities_import_discord.go 1
./protocol/messenger_community_shard.go 1
./protocol/messenger_config.go 1
./protocol/messenger_contacts.go 1
./protocol/messenger_filter_init.go 1
./protocol/messenger_handler.go 1
./protocol/messenger_mailserver.go 1
./protocol/messenger_messages_order_controller_test.go 1
./protocol/messenger_messages_tracking_test.go 1
./protocol/messenger_status_updates.go 1
./protocol/messenger_store_node_request_manager.go 1
./protocol/messenger_storenode_request_test.go 1
./services/ext/api.go 1
./services/ext/service.go 1
./services/mailservers/api_test.go 1
./services/mailservers/database.go 1
./services/shhext/api_nimbus.go 1
```

After:
```
$ grep -rI --exclude-dir=vendor -o "messaging/transport" . | cut -d: -f1 | uniq -c | awk '{print $2, $1}'

./protocol/sqlite/prepare_migrations.go 1
./messaging/api.go 1
./messaging/core.go 1
./messaging/types.go 1
```