### PR TITLE
chore(news)_: hardcode the Status test RSS feeds and use the right one

### DIFF
--- a/internal/newsfeed/news_feed_manager.go
+++ b/internal/newsfeed/news_feed_manager.go
@@ -10,8 +10,8 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 )
 
-// TODO replace with the real Status feed URL
-const STATUS_FEED_URL = "https://hnrss.org/frontpage"
+const STATUS_DESKTOP_FEED_URL = "https://status-website-git-add-rss-status-im-web.vercel.app/desktop-news/rss?_vercel_share=IySrfv1xyphlMgEp3rAfrCnzT19yjzG9&x-vercel-protection-bypass=I4euHZRiK3TEnAE5Kw73tQxhmxjBThSS"
+const STATUS_MOBILE_FEED_URL = "https://status-website-git-add-rss-status-im-web.vercel.app/mobile-news/rss?_vercel_share=IySrfv1xyphlMgEp3rAfrCnzT19yjzG9&x-vercel-protection-bypass=I4euHZRiK3TEnAE5Kw73tQxhmxjBThSS"
 
 type FeedParser interface {
 	ParseURL(url string) (*gofeed.Feed, error)

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -903,8 +903,14 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 		if err != nil {
 			return nil, err
 		}
+		var feedUrl string
+		if gocommon.IsMobilePlatform() {
+			feedUrl = newsfeed.STATUS_MOBILE_FEED_URL
+		} else {
+			feedUrl = newsfeed.STATUS_DESKTOP_FEED_URL
+		}
 		m.newsFeedManager = newsfeed.NewNewsFeedManager(
-			newsfeed.WithURL(newsfeed.STATUS_FEED_URL),
+			newsfeed.WithURL(feedUrl),
 			newsfeed.WithParser(gofeed.NewParser()),
 			newsfeed.WithHandler(m),
 			newsfeed.WithLogger(m.logger),

--- a/protocol/messenger_news_feed_test.go
+++ b/protocol/messenger_news_feed_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mmcdole/gofeed"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/status-im/status-go/internal/newsfeed"
+	"github.com/status-im/status-go/eth-node/crypto"
 )
 
 type MessengerNewsFeedSuite struct {
@@ -19,15 +19,13 @@ type MessengerNewsFeedSuite struct {
 func (s *MessengerNewsFeedSuite) SetupTest() {
 	s.MessengerBaseTestSuite.SetupTest()
 
-	s.m = s.newMessenger()
-	s.m.newsFeedManager = newsfeed.NewNewsFeedManager(
-		newsfeed.WithURL(newsfeed.STATUS_FEED_URL),
-		newsfeed.WithParser(gofeed.NewParser()),
-		newsfeed.WithHandler(s.m),
-		newsfeed.WithLogger(s.m.logger),
-		newsfeed.WithPollingInterval(30*time.Minute),
-		newsfeed.WithFetchFrom(time.Now().Add(-1*time.Hour)),
-	)
+	privateKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+
+	messenger, err := newMessengerWithKey(s.shh, privateKey, s.logger, []Option{WithNewsFeed()})
+	s.Require().NoError(err)
+
+	s.m = messenger
 }
 
 func TestMessengerNewsFeedSuite(t *testing.T) {


### PR DESCRIPTION
Fixes #6563

Hardcodes the two RSS feed URLs and uses the right one depending on the platform
