### PR TITLE
test_: pass pytest.ini as config file for pytest run

### DIFF
--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -54,7 +54,7 @@ pip install --upgrade pip
 pip install -r "${root_path}/requirements.txt"
 
 # Run functional tests
-pytest --reruns 2 -m rpc -n 12 --dist loadgroup --docker_project_name=${project_name} --codecov_dir=${binary_coverage_reports_path} --junitxml=${test_results_path}/report.xml
+pytest --reruns 2 -m rpc -c "${root_path}/pytest.ini" -n 12 --dist loadgroup --docker_project_name=${project_name} --codecov_dir=${binary_coverage_reports_path} --junitxml=${test_results_path}/report.xml
 exit_code=$?
 
 # Stop containers


### PR DESCRIPTION
**Now**: pytest output contains a lot of PytestUnknownMarkWarning for RPC Tests run on Jenkins. This is due to no config file found. 

**After this PR**: config pytest.ini is found and warnings on PytestUnknownMarkWarning not shown. How it's done: pytest run with -c option that specifies pytest.ini location. 

### How it was:
[2025-05-13T12:39:50.335Z] ============================= test session starts ==============================

[2025-05-13T12:39:50.335Z] platform linux -- Python 3.10.12, pytest-7.0.1, pluggy-1.5.0
[2025-05-13T12:39:50.335Z] waku fleets config file: /static/configs/wakufleetconfig.json
[2025-05-13T12:39:50.335Z] waku fleet: status-go.test
[2025-05-13T12:39:50.335Z] rootdir: /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552
[2025-05-13T12:39:50.335Z] plugins: dependency-0.6.0, rerunfailures-13.0, xdist-3.6.1
[2025-05-13T12:39:50.335Z] created: 12/12 workers
[2025-05-13T12:39:50.335Z] 12 workers [156 items]

.....

[2025-05-13T12:46:20.421Z] =============================== warnings summary ===============================

[2025-05-13T12:46:20.421Z] tests-functional/tests/test_accounts.py:9: 12 warnings

[2025-05-13T12:46:20.421Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_accounts.py:9: PytestUnknownMarkWarning: Unknown pytest.mark.accounts - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.421Z]     @pytest.mark.accounts

[2025-05-13T12:46:20.421Z] 

[2025-05-13T12:46:20.421Z] tests-functional/tests/test_accounts.py:10: 12 warnings

[2025-05-13T12:46:20.421Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_accounts.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.421Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.421Z] 

[2025-05-13T12:46:20.421Z] tests-functional/tests/test_activity_center_notifications.py:19: 12 warnings

[2025-05-13T12:46:20.421Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_activity_center_notifications.py:19: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.421Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.421Z] 

[2025-05-13T12:46:20.421Z] tests-functional/tests/test_app_general.py:8: 12 warnings

[2025-05-13T12:46:20.421Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_app_general.py:8: PytestUnknownMarkWarning: Unknown pytest.mark.accounts - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.421Z]     @pytest.mark.accounts

[2025-05-13T12:46:20.421Z] 

[2025-05-13T12:46:20.421Z] tests-functional/tests/test_app_general.py:9: 12 warnings

[2025-05-13T12:46:20.422Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_app_general.py:9: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.422Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.422Z] 

[2025-05-13T12:46:20.422Z] tests-functional/tests/test_eth_api.py:27: 12 warnings

[2025-05-13T12:46:20.422Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_eth_api.py:27: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.422Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.422Z] 

[2025-05-13T12:46:20.422Z] tests-functional/tests/test_eth_api.py:28: 12 warnings

[2025-05-13T12:46:20.422Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_eth_api.py:28: PytestUnknownMarkWarning: Unknown pytest.mark.ethclient - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.422Z]     @pytest.mark.ethclient

[2025-05-13T12:46:20.422Z] 

[2025-05-13T12:46:20.422Z] tests-functional/tests/test_init_status_app.py:7: 12 warnings

[2025-05-13T12:46:20.422Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_init_status_app.py:7: PytestUnknownMarkWarning: Unknown pytest.mark.create_account - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.422Z]     @pytest.mark.create_account

[2025-05-13T12:46:20.422Z] 

[2025-05-13T12:46:20.422Z] tests-functional/tests/test_init_status_app.py:8: 12 warnings

[2025-05-13T12:46:20.422Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_init_status_app.py:8: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.422Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.422Z] 

[2025-05-13T12:46:20.422Z] tests-functional/tests/test_init_status_app.py:11: 12 warnings

[2025-05-13T12:46:20.423Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_init_status_app.py:11: PytestUnknownMarkWarning: Unknown pytest.mark.init - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.423Z]     @pytest.mark.init

[2025-05-13T12:46:20.423Z] 

[2025-05-13T12:46:20.423Z] tests-functional/tests/test_init_status_app.py:55: 12 warnings

[2025-05-13T12:46:20.423Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_init_status_app.py:55: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.423Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.423Z] 

[2025-05-13T12:46:20.423Z] tests-functional/tests/test_init_status_app.py:56: 12 warnings

[2025-05-13T12:46:20.423Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_init_status_app.py:56: PytestUnknownMarkWarning: Unknown pytest.mark.init - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.423Z]     @pytest.mark.init

[2025-05-13T12:46:20.423Z] 

[2025-05-13T12:46:20.423Z] tests-functional/tests/test_logging.py:7: 12 warnings

[2025-05-13T12:46:20.423Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_logging.py:7: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.423Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.423Z] 

[2025-05-13T12:46:20.424Z] tests-functional/tests/test_logging.py:10: 12 warnings

[2025-05-13T12:46:20.424Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_logging.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.init - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.424Z]     @pytest.mark.init

[2025-05-13T12:46:20.424Z] 

[2025-05-13T12:46:20.424Z] tests-functional/tests/test_router.py:12: 12 warnings

[2025-05-13T12:46:20.424Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_router.py:12: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.424Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.424Z] 

[2025-05-13T12:46:20.424Z] tests-functional/tests/test_router.py:13: 12 warnings

[2025-05-13T12:46:20.424Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_router.py:13: PytestUnknownMarkWarning: Unknown pytest.mark.transaction - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.424Z]     @pytest.mark.transaction

[2025-05-13T12:46:20.424Z] 

[2025-05-13T12:46:20.424Z] tests-functional/tests/test_router.py:14: 12 warnings

[2025-05-13T12:46:20.424Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_router.py:14: PytestUnknownMarkWarning: Unknown pytest.mark.wallet - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.424Z]     @pytest.mark.wallet

[2025-05-13T12:46:20.424Z] 

[2025-05-13T12:46:20.424Z] tests-functional/tests/test_wakuext_chats.py:9: 12 warnings

[2025-05-13T12:46:20.425Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_chats.py:9: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.425Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.425Z] 

[2025-05-13T12:46:20.425Z] tests-functional/tests/test_wakuext_contact_requests.py:7: 12 warnings

[2025-05-13T12:46:20.425Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_contact_requests.py:7: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.425Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.425Z] 

[2025-05-13T12:46:20.425Z] tests-functional/tests/test_wakuext_message_reactions.py:11: 12 warnings

[2025-05-13T12:46:20.425Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_message_reactions.py:11: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.425Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.425Z] 

[2025-05-13T12:46:20.425Z] tests-functional/tests/test_wakuext_messages_fetching.py:7: 12 warnings

[2025-05-13T12:46:20.425Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_messages_fetching.py:7: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.425Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.425Z] 

[2025-05-13T12:46:20.425Z] tests-functional/tests/test_wakuext_messages_interacting.py:9: 12 warnings

[2025-05-13T12:46:20.425Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_messages_interacting.py:9: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.425Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.425Z] 

[2025-05-13T12:46:20.425Z] tests-functional/tests/test_wakuext_messages_light_client.py:5: 12 warnings

[2025-05-13T12:46:20.426Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_messages_light_client.py:5: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.426Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.426Z] 

[2025-05-13T12:46:20.426Z] tests-functional/tests/test_wakuext_messages_sending.py:11: 12 warnings

[2025-05-13T12:46:20.426Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_messages_sending.py:11: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.426Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.426Z] 

[2025-05-13T12:46:20.426Z] tests-functional/tests/test_wakuext_messages_transactions.py:10: 12 warnings

[2025-05-13T12:46:20.426Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_messages_transactions.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.426Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.426Z] 

[2025-05-13T12:46:20.426Z] tests-functional/tests/test_wakuext_profile.py:133: 12 warnings

[2025-05-13T12:46:20.426Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_profile.py:133: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.426Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.426Z] 

[2025-05-13T12:46:20.426Z] tests-functional/tests/test_wakuext_savedAddress.py:7: 12 warnings

[2025-05-13T12:46:20.426Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_savedAddress.py:7: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.426Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.426Z] 

[2025-05-13T12:46:20.426Z] tests-functional/tests/test_wakuext_savedAddress.py:8: 12 warnings

[2025-05-13T12:46:20.427Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wakuext_savedAddress.py:8: PytestUnknownMarkWarning: Unknown pytest.mark.wallet - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.427Z]     @pytest.mark.wallet

[2025-05-13T12:46:20.427Z] 

[2025-05-13T12:46:20.427Z] tests-functional/tests/test_wallet_activity_session.py:21: 12 warnings

[2025-05-13T12:46:20.427Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wallet_activity_session.py:21: PytestUnknownMarkWarning: Unknown pytest.mark.wallet - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.427Z]     @pytest.mark.wallet

[2025-05-13T12:46:20.427Z] 

[2025-05-13T12:46:20.427Z] tests-functional/tests/test_wallet_activity_session.py:22: 12 warnings

[2025-05-13T12:46:20.427Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wallet_activity_session.py:22: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.427Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.427Z] 

[2025-05-13T12:46:20.427Z] tests-functional/tests/test_wallet_activity_session.py:23: 12 warnings

[2025-05-13T12:46:20.427Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wallet_activity_session.py:23: PytestUnknownMarkWarning: Unknown pytest.mark.activity - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.427Z]     @pytest.mark.activity

[2025-05-13T12:46:20.427Z] 

[2025-05-13T12:46:20.427Z] tests-functional/tests/test_wallet_rpc.py:8: 12 warnings

[2025-05-13T12:46:20.427Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wallet_rpc.py:8: PytestUnknownMarkWarning: Unknown pytest.mark.wallet - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.427Z]     @pytest.mark.wallet

[2025-05-13T12:46:20.427Z] 

[2025-05-13T12:46:20.427Z] tests-functional/tests/test_wallet_rpc.py:9: 12 warnings

[2025-05-13T12:46:20.428Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wallet_rpc.py:9: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.428Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.428Z] 

[2025-05-13T12:46:20.428Z] tests-functional/tests/test_wallet_signals.py:10: 12 warnings

[2025-05-13T12:46:20.428Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wallet_signals.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.wallet - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.428Z]     @pytest.mark.wallet

[2025-05-13T12:46:20.428Z] 

[2025-05-13T12:46:20.428Z] tests-functional/tests/test_wallet_signals.py:11: 12 warnings

[2025-05-13T12:46:20.428Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/test_wallet_signals.py:11: PytestUnknownMarkWarning: Unknown pytest.mark.rpc - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.428Z]     @pytest.mark.rpc

[2025-05-13T12:46:20.428Z] 

[2025-05-13T12:46:20.428Z] tests-functional/tests/reliability/test_community_messages.py:10: 12 warnings

[2025-05-13T12:46:20.428Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/reliability/test_community_messages.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.reliability - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.428Z]     @pytest.mark.reliability

[2025-05-13T12:46:20.428Z] 

[2025-05-13T12:46:20.428Z] tests-functional/tests/reliability/test_contact_request.py:10: 12 warnings

[2025-05-13T12:46:20.429Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/reliability/test_contact_request.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.reliability - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.429Z]     @pytest.mark.reliability

[2025-05-13T12:46:20.429Z] 

[2025-05-13T12:46:20.429Z] tests-functional/tests/reliability/test_create_private_groups.py:10: 12 warnings

[2025-05-13T12:46:20.429Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/reliability/test_create_private_groups.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.reliability - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.429Z]     @pytest.mark.reliability

[2025-05-13T12:46:20.429Z] 

[2025-05-13T12:46:20.429Z] tests-functional/tests/reliability/test_join_leave_community.py:7: 12 warnings

[2025-05-13T12:46:20.430Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/reliability/test_join_leave_community.py:7: PytestUnknownMarkWarning: Unknown pytest.mark.reliability - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.430Z]     @pytest.mark.reliability

[2025-05-13T12:46:20.430Z] 

[2025-05-13T12:46:20.430Z] tests-functional/tests/reliability/test_light_client_rate_limiting.py:10: 12 warnings

[2025-05-13T12:46:20.430Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/reliability/test_light_client_rate_limiting.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.reliability - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.430Z]     @pytest.mark.reliability

[2025-05-13T12:46:20.430Z] 

[2025-05-13T12:46:20.430Z] tests-functional/tests/reliability/test_one_to_one_messages.py:10: 12 warnings

[2025-05-13T12:46:20.430Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/reliability/test_one_to_one_messages.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.reliability - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.430Z]     @pytest.mark.reliability

[2025-05-13T12:46:20.430Z] 

[2025-05-13T12:46:20.430Z] tests-functional/tests/reliability/test_private_groups_messages.py:10: 12 warnings

[2025-05-13T12:46:20.430Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/tests/reliability/test_private_groups_messages.py:10: PytestUnknownMarkWarning: Unknown pytest.mark.reliability - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html

[2025-05-13T12:46:20.430Z]     @pytest.mark.reliability

[2025-05-13T12:46:20.430Z] 

[2025-05-13T12:46:20.430Z] tests-functional/tests/test_accounts.py: 2 warnings

[2025-05-13T12:46:20.430Z] tests-functional/tests/test_app_general.py: 1 warning

[2025-05-13T12:46:20.430Z] tests-functional/tests/test_activity_center_notifications.py: 13 warnings

[2025-05-13T12:46:20.430Z] tests-functional/tests/test_wakuext_chats.py: 18 warnings

[2025-05-13T12:46:20.430Z] tests-functional/tests/test_wakuext_contact_requests.py: 20 warnings

[2025-05-13T12:46:20.430Z] tests-functional/tests/test_wakuext_messages_fetching.py: 14 warnings

[2025-05-13T12:46:20.430Z] tests-functional/tests/test_wakuext_message_reactions.py: 14 warnings

[2025-05-13T12:46:20.431Z] tests-functional/tests/test_wakuext_messages_interacting.py: 16 warnings

[2025-05-13T12:46:20.431Z] tests-functional/tests/test_wakuext_messages_sending.py: 8 warnings

[2025-05-13T12:46:20.431Z] tests-functional/tests/test_wakuext_savedAddress.py: 6 warnings

[2025-05-13T12:46:20.431Z] tests-functional/tests/test_wakuext_messages_transactions.py: 14 warnings

[2025-05-13T12:46:20.431Z] tests-functional/tests/test_wallet_rpc.py: 3 warnings

[2025-05-13T12:46:20.431Z] tests-functional/tests/test_wakuext_profile.py: 8 warnings

[2025-05-13T12:46:20.431Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6552/tests-functional/.venv/lib/python3.10/site-packages/jsonschema/validators.py:928: DeprecationWarning: The metaschema specified by $schema was not found. Using the latest draft to validate, but this will raise an error in the future.

[2025-05-13T12:46:20.431Z]     cls = validator_for(schema)

### How it will be:


[2025-05-08T12:58:00.626Z] ============================= test session starts ==============================

[2025-05-08T12:58:00.626Z] platform linux -- Python 3.10.12, pytest-7.0.1, pluggy-1.5.0 -- /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6566/tests-functional/.venv/bin/python3
[2025-05-08T12:58:00.626Z] cachedir: .pytest_cache
[2025-05-08T12:58:00.626Z] waku fleets config file: /static/configs/wakufleetconfig.json
[2025-05-08T12:58:00.626Z] waku fleet: status-go.test
[2025-05-08T12:58:00.626Z] rootdir: /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6566/tests-functional, configfile: pytest.ini
[2025-05-08T12:58:00.626Z] plugins: xdist-3.6.1, rerunfailures-13.0, dependency-0.6.0
[2025-05-08T12:58:00.626Z] created: 12/12 workers
[2025-05-08T12:58:00.626Z] 12 workers [156 items]
......

[2025-05-08T13:03:32.212Z] =============================== warnings summary ===============================

[2025-05-08T13:03:32.212Z] tests/test_accounts.py: 2 warnings

[2025-05-08T13:03:32.212Z] tests/test_activity_center_notifications.py: 13 warnings

[2025-05-08T13:03:32.212Z] tests/test_app_general.py: 1 warning

[2025-05-08T13:03:32.212Z] tests/test_wakuext_chats.py: 18 warnings

[2025-05-08T13:03:32.212Z] tests/test_wakuext_contact_requests.py: 20 warnings

[2025-05-08T13:03:32.212Z] tests/test_wakuext_messages_fetching.py: 14 warnings

[2025-05-08T13:03:32.212Z] tests/test_wakuext_messages_interacting.py: 16 warnings

[2025-05-08T13:03:32.212Z] tests/test_wakuext_message_reactions.py: 16 warnings

[2025-05-08T13:03:32.212Z] tests/test_wakuext_messages_sending.py: 8 warnings

[2025-05-08T13:03:32.213Z] tests/test_wakuext_messages_transactions.py: 14 warnings

[2025-05-08T13:03:32.213Z] tests/test_wakuext_savedAddress.py: 6 warnings

[2025-05-08T13:03:32.213Z] tests/test_wallet_rpc.py: 3 warnings

[2025-05-08T13:03:32.213Z] tests/test_wakuext_profile.py: 8 warnings

[2025-05-08T13:03:32.213Z]   /home/jenkins/workspace/status-go_prs_tests-rpc_PR-6566/tests-functional/.venv/lib/python3.10/site-packages/jsonschema/validators.py:928: DeprecationWarning: The metaschema specified by $schema was not found. Using the latest draft to validate, but this will raise an error in the future.

[2025-05-08T13:03:32.213Z]     cls = validator_for(schema)

