### PR TITLE
fix(wallet)_: reevaluating tx fields from the router path based on the provided path tx identity

### DIFF
--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -707,6 +707,12 @@ func (api *API) SendRouterTransactionsWithSignatures(ctx context.Context, sendIn
 	api.s.routeExecutionManager.SendRouterTransactionsWithSignatures(ctx, sendInputParams)
 }
 
+// ReevaluateRouterPath reevaluates the tx-fields from the router path that matches the provided pathTxIdentity and sends signal.SuggestedRoutes.
+func (api *API) ReevaluateRouterPath(ctx context.Context, pathTxIdentity *requests.PathTxIdentity) error {
+	logutils.ZapLogger().Debug("wallet.api.ReevaluateRouterPath")
+	return api.s.routeExecutionManager.ReevaluateRouterPath(ctx, pathTxIdentity)
+}
+
 func (api *API) GetMultiTransactions(ctx context.Context, transactionIDs []wcommon.MultiTransactionIDType) ([]*transfer.MultiTransaction, error) {
 	logutils.ZapLogger().Debug("wallet.api.GetMultiTransactions", zap.Int("IDs.len", len(transactionIDs)))
 	return api.s.transactionManager.GetMultiTransactions(ctx, transactionIDs)

--- a/services/wallet/routeexecution/manager.go
+++ b/services/wallet/routeexecution/manager.go
@@ -53,6 +53,10 @@ func (m *Manager) ClearLocalRouteData() {
 	m.transactionManager.ClearLocalRouterTransactionsData()
 }
 
+func (m *Manager) ReevaluateRouterPath(ctx context.Context, pathTxIdentity *requests.PathTxIdentity) error {
+	return m.router.ReevaluateRouterPath(ctx, pathTxIdentity)
+}
+
 func (m *Manager) BuildTransactionsFromRoute(ctx context.Context, uuid string) {
 	go func() {
 		defer status_common.LogOnPanic()

--- a/services/wallet/router/errors.go
+++ b/services/wallet/router/errors.go
@@ -6,21 +6,22 @@ import (
 
 // Abbreviation `WR` for the error code stands for Wallet Router
 var (
-	ErrNotEnoughTokenBalance                 = &errors.ErrorResponse{Code: errors.ErrorCode("WR-001"), Details: "not enough token balance, token: %s, chainId: %d"}
-	ErrNotEnoughNativeBalance                = &errors.ErrorResponse{Code: errors.ErrorCode("WR-002"), Details: "not enough native balance, token: %s, chainId: %d"}
-	ErrNativeTokenNotFound                   = &errors.ErrorResponse{Code: errors.ErrorCode("WR-003"), Details: "native token not found"}
-	ErrTokenNotFound                         = &errors.ErrorResponse{Code: errors.ErrorCode("WR-004"), Details: "token not found"}
-	ErrNoBestRouteFound                      = &errors.ErrorResponse{Code: errors.ErrorCode("WR-005"), Details: "no best route found"}
-	ErrCannotCheckBalance                    = &errors.ErrorResponse{Code: errors.ErrorCode("WR-006"), Details: "cannot check balance"}
-	ErrLowAmountInForHopBridge               = &errors.ErrorResponse{Code: errors.ErrorCode("WR-007"), Details: "bonder fee greater than estimated received, a higher amount is needed to cover fees"}
-	ErrNoPositiveBalance                     = &errors.ErrorResponse{Code: errors.ErrorCode("WR-008"), Details: "no positive balance"}
-	ErrCustomFeeModeCannotBeSetThisWay       = &errors.ErrorResponse{Code: errors.ErrorCode("WR-009"), Details: "custom fee mode cannot be set this way"}
-	ErrOnlyCustomFeeModeCanBeSetThisWay      = &errors.ErrorResponse{Code: errors.ErrorCode("WR-010"), Details: "only custom fee mode can be set this way"}
-	ErrTxIdentityNotProvided                 = &errors.ErrorResponse{Code: errors.ErrorCode("WR-011"), Details: "transaction identity not provided"}
-	ErrTxCustomParamsNotProvided             = &errors.ErrorResponse{Code: errors.ErrorCode("WR-012"), Details: "transaction custom params not provided"}
-	ErrCannotCustomizeIfNoRoute              = &errors.ErrorResponse{Code: errors.ErrorCode("WR-013"), Details: "cannot customize params if no route"}
-	ErrCannotFindPathForProvidedIdentity     = &errors.ErrorResponse{Code: errors.ErrorCode("WR-014"), Details: "cannot find path for provided identity"}
-	ErrPathNotSupportedForProvidedChain      = &errors.ErrorResponse{Code: errors.ErrorCode("WR-015"), Details: "path not supported for provided chain"}
-	ErrPathNotSupportedBetweenProvidedChains = &errors.ErrorResponse{Code: errors.ErrorCode("WR-016"), Details: "path not supported between provided chains"}
-	ErrPathNotAvaliableForProvidedParameters = &errors.ErrorResponse{Code: errors.ErrorCode("WR-017"), Details: "path not available for provided parameters"}
+	ErrNotEnoughTokenBalance                      = &errors.ErrorResponse{Code: errors.ErrorCode("WR-001"), Details: "not enough token balance, token: %s, chainId: %d"}
+	ErrNotEnoughNativeBalance                     = &errors.ErrorResponse{Code: errors.ErrorCode("WR-002"), Details: "not enough native balance, token: %s, chainId: %d"}
+	ErrNativeTokenNotFound                        = &errors.ErrorResponse{Code: errors.ErrorCode("WR-003"), Details: "native token not found"}
+	ErrTokenNotFound                              = &errors.ErrorResponse{Code: errors.ErrorCode("WR-004"), Details: "token not found"}
+	ErrNoBestRouteFound                           = &errors.ErrorResponse{Code: errors.ErrorCode("WR-005"), Details: "no best route found"}
+	ErrCannotCheckBalance                         = &errors.ErrorResponse{Code: errors.ErrorCode("WR-006"), Details: "cannot check balance"}
+	ErrLowAmountInForHopBridge                    = &errors.ErrorResponse{Code: errors.ErrorCode("WR-007"), Details: "bonder fee greater than estimated received, a higher amount is needed to cover fees"}
+	ErrNoPositiveBalance                          = &errors.ErrorResponse{Code: errors.ErrorCode("WR-008"), Details: "no positive balance"}
+	ErrCustomFeeModeCannotBeSetThisWay            = &errors.ErrorResponse{Code: errors.ErrorCode("WR-009"), Details: "custom fee mode cannot be set this way"}
+	ErrOnlyCustomFeeModeCanBeSetThisWay           = &errors.ErrorResponse{Code: errors.ErrorCode("WR-010"), Details: "only custom fee mode can be set this way"}
+	ErrTxIdentityNotProvided                      = &errors.ErrorResponse{Code: errors.ErrorCode("WR-011"), Details: "transaction identity not provided"}
+	ErrTxCustomParamsNotProvided                  = &errors.ErrorResponse{Code: errors.ErrorCode("WR-012"), Details: "transaction custom params not provided"}
+	ErrCannotCustomizeIfNoRoute                   = &errors.ErrorResponse{Code: errors.ErrorCode("WR-013"), Details: "cannot customize params if no route"}
+	ErrCannotFindPathForProvidedIdentity          = &errors.ErrorResponse{Code: errors.ErrorCode("WR-014"), Details: "cannot find path for provided identity"}
+	ErrPathNotSupportedForProvidedChain           = &errors.ErrorResponse{Code: errors.ErrorCode("WR-015"), Details: "path not supported for provided chain"}
+	ErrPathNotSupportedBetweenProvidedChains      = &errors.ErrorResponse{Code: errors.ErrorCode("WR-016"), Details: "path not supported between provided chains"}
+	ErrPathNotAvaliableForProvidedParameters      = &errors.ErrorResponse{Code: errors.ErrorCode("WR-017"), Details: "path not available for provided parameters"}
+	ErrCannotFindPathProcessorForProvidedIdentity = &errors.ErrorResponse{Code: errors.ErrorCode("WR-018"), Details: "cannot find path processor for provided identity"}
 )

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -207,6 +207,75 @@ func (r *Router) SetCustomTxDetails(ctx context.Context, pathTxIdentity *request
 	return r.setCustomTxDetails(ctx, pathTxIdentity, pathTxCustomParams)
 }
 
+// ReevaluateRouterPath reevaluates the tx-fields from the router path that matches the provided pathTxIdentity and sends signal.SuggestedRoutes.
+func (r *Router) ReevaluateRouterPath(ctx context.Context, pathTxIdentity *requests.PathTxIdentity) error {
+	if pathTxIdentity == nil {
+		return ErrTxIdentityNotProvided
+	}
+	err := pathTxIdentity.Validate()
+	if err != nil {
+		return err
+	}
+
+	r.activeRoutesMutex.Lock()
+	defer r.activeRoutesMutex.Unlock()
+	if r.activeRoutes == nil || len(r.activeRoutes.Best) == 0 {
+		return ErrNoBestRouteFound
+	}
+
+	fetchedFees, err := r.feesManager.SuggestedFees(ctx, pathTxIdentity.ChainID)
+	if err != nil {
+		return err
+	}
+
+	for _, path := range r.activeRoutes.Best {
+		if path.PathIdentity() != pathTxIdentity.PathIdentity() {
+			continue
+		}
+
+		for _, pProcessor := range r.pathProcessors {
+			if pProcessor.Name() != path.ProcessorName {
+				continue
+			}
+
+			processorInputParams, err := r.CreateProcessorInputParams(r.lastInputParams, path.FromChain, path.ToChain, path.FromToken, path.ToToken, 0)
+			if err != nil {
+				return err
+			}
+
+			txPackedData, err := pProcessor.PackTxInputData(processorInputParams)
+			if err != nil {
+				return err
+			}
+
+			gasLimit, err := pProcessor.EstimateGas(processorInputParams, txPackedData)
+			if err != nil {
+				return err
+			}
+
+			path.SuggestedTxGasAmount = gasLimit
+			path.TxGasAmount = gasLimit
+			path.TxPackedData = txPackedData
+
+			// update the path details
+			usedNonces := make(map[uint64]uint64)
+			err = r.evaluateAndUpdatePathDetails(ctx, path, fetchedFees, usedNonces, false, 0)
+			if err != nil {
+				return err
+			}
+
+			// inform the client about the changes
+			sendRouterResult(pathTxIdentity.RouterInputParamsUuid, r.activeRoutes, err)
+
+			return nil
+		}
+
+		return ErrCannotFindPathProcessorForProvidedIdentity
+	}
+
+	return ErrCannotFindPathForProvidedIdentity
+}
+
 func newSuggestedRoutes(
 	input *requests.RouteInputParams,
 	candidates routes.Route,


### PR DESCRIPTION
This PR should help in displaying the correct fees for swap.

Since we're using paraswap API to make a swap, there is no way to display the total correctly calculated fees in advance if an approval is needed (that's not the case if the amount the user is trying to swap is pre-approved).

If an approval is needed for a swap, the `TxTotalFee` should not be used, but instead, `ApprovalFee` + `ApprovalL1Fee` should be used for the total approval fee, and `TxFee` + `TxL1Fee` should be used for the total swap fee.

Now another problem appears, when the client asks for the swap route that includes approval, `TxFee` field will be empty. That's why this PR introduces a new API endpoint `ReevaluateRouterPath` which will re-evaluate the tx related field of the initially received router's path. 

The client should call `ReevaluateRouterPath` after receiving a signal (`pending-transaction-status-changed`) that the approval tx is successfully completed.