### PR TITLE
chore_: introduce imports check

### DIFF
--- a/.github/workflows/import-check.yml
+++ b/.github/workflows/import-check.yml
@@ -1,0 +1,34 @@
+name: "Import Check"
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  check_messaging_imports:
+    name: Ensure no messaging/* imports outside messaging directory
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run messaging import check
+        run: |
+          echo "Finding all Go files outside the messaging and vendor directories..."
+          files=$(find . -type f -name '*.go' ! -path './messaging/*' ! -path './vendor/*')
+
+          echo "Checking for invalid imports of github.com/status-im/status-go/messaging/*..."
+          for file in $files; do
+            if grep -qE '"github.com/status-im/status-go/messaging/.+"' "$file"; then
+              echo "Error: File $file imports github.com/status-im/status-go/messaging/* which is not allowed."
+              exit 1
+            fi
+          done
+
+          echo "No invalid github.com/status-im/status-go/messaging/* imports found."


### PR DESCRIPTION
Prevents access to the transport layer from the app layer by limiting `messaging/*` imports.

Tested in: https://github.com/status-im/status-go/pull/6571, details: https://github.com/status-im/status-go/actions/runs/14913687698/job/41893990360?pr=6571
```
Finding all Go files outside the messaging and vendor directories...
Checking for invalid imports of github.com/status-im/status-go/messaging/*...
Error: File ./protocol/messenger.go imports github.com/status-im/status-go/messaging/* which is not allowed.
Error: Process completed with exit code 1.
```
