### PR TITLE
fix(news)_: make sure we do not fetch old news when the user re-enables

### DIFF
--- a/internal/newsfeed/news_feed_manager.go
+++ b/internal/newsfeed/news_feed_manager.go
@@ -73,7 +73,7 @@ func WithFetchFrom(t time.Time) Option {
 func NewNewsFeedManager(opts ...Option) *NewsFeedManager {
 	nfm := &NewsFeedManager{
 		pollingInterval: time.Minute * 30,
-		fetchFrom:       time.Now(),
+		fetchFrom:       time.Now().UTC(),
 		polling:         false,
 	}
 
@@ -100,7 +100,7 @@ func (n *NewsFeedManager) FetchRSS() ([]*gofeed.Item, error) {
 
 	if len(filteredItems) > 0 {
 		// Update fetchFrom to now since we have new items
-		n.fetchFrom = time.Now()
+		n.SetFetchFrom(time.Now().UTC())
 	}
 
 	return filteredItems, nil
@@ -122,6 +122,14 @@ func (n *NewsFeedManager) fetchRSSAndHandle() error {
 	}
 
 	return nil
+}
+
+func (n *NewsFeedManager) GetFetchFrom() time.Time {
+	return n.fetchFrom
+}
+
+func (n *NewsFeedManager) SetFetchFrom(fetchFrom time.Time) {
+	n.fetchFrom = fetchFrom
 }
 
 func (n *NewsFeedManager) IsPolling() bool {

--- a/protocol/messenger_news_feed_test.go
+++ b/protocol/messenger_news_feed_test.go
@@ -68,6 +68,8 @@ func (s *MessengerNewsFeedSuite) TestToggleSettings() {
 	s.Require().NoError(err)
 	s.Require().True(s.m.newsFeedManager.IsPolling())
 
+	oldFetchFrom := s.m.newsFeedManager.GetFetchFrom()
+
 	// Polling is off as soon as one setting is off
 	err = s.m.ToggleNewsFeedEnabled(false)
 	s.Require().NoError(err)
@@ -86,6 +88,10 @@ func (s *MessengerNewsFeedSuite) TestToggleSettings() {
 	err = s.m.ToggleNewsFeedEnabled(true)
 	s.Require().NoError(err)
 	s.Require().True(s.m.newsFeedManager.IsPolling())
+
+	// Check that the fetchFrom timestamp is updated
+	newFetchFrom := s.m.newsFeedManager.GetFetchFrom()
+	s.Require().Greater(newFetchFrom, oldFetchFrom)
 
 	s.m.newsFeedManager.StopPolling()
 	s.Require().False(s.m.newsFeedManager.IsPolling())


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/17926

Fixes the issue by reseting the the `fetchFrom` time to the current time when the user re-enables the setting. That way, the news posted in between the time it was disabled and then re-enabled will be ignored.