### PR TITLE
ci_: upgrade nixpkgs to 24.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727956061,
-        "narHash": "sha256-VvwJWij/D6Coc7hiHbW2/dvkeNS1GhB6nuqsfmaNey0=",
+        "lastModified": 1749558169,
+        "narHash": "sha256-EYKHBAqslKF4MQyT8HCfRDqtF1YIw5B6wNp3OWKJIKY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "df27247e6f3e636c119e2610bf12d38b5e98cc79",
+        "rev": "3939f5f357444b182817a65b86019dbcb16bdb65",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "df27247e6f3e636c119e2610bf12d38b5e98cc79",
+        "rev": "3939f5f357444b182817a65b86019dbcb16bdb65",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,8 @@
 
   inputs = {
     # We are pinning the commit because ultimately we want to use same commit across different projects.
-    nixpkgs.url = "github:NixOS/nixpkgs/df27247e6f3e636c119e2610bf12d38b5e98cc79";
+    # A commit from nixpkgs 24.11 release : https://github.com/NixOS/nixpkgs/tree/release-24.11
+    nixpkgs.url = "github:NixOS/nixpkgs/3939f5f357444b182817a65b86019dbcb16bdb65";
     # We cannot do follows since the nim-unwrapped-2_0 doesn't exist in this nixpkgs version above
     nwaku.url = "git+https://github.com/waku-org/nwaku?submodules=1&rev=e755fd834f5f3d6fba216b09469316f0328b3b6f";
   };

--- a/nix/pkgs/gomobile/default.nix
+++ b/nix/pkgs/gomobile/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchgit,
-  fetchurl,
   buildGo122Module,
   zlib,
   makeWrapper,
@@ -17,6 +16,7 @@
     }
   ),
 }:
+
 buildGo122Module {
   pname = "gomobile";
   version = "0-unstable-2024-12-13";
@@ -31,6 +31,15 @@ buildGo122Module {
   vendorHash = "sha256-6ycxEDEE0/i6Lxo0gb8wq3U2U7Q49AJj+PdzSl57wwI=";
 
   CGO_ENABLED = "1";
+
+  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # to fix : error: unable to find sdk: 'iphoneos'
+    export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer";
+    export SDKROOT="$(/usr/bin/xcrun --sdk macosx --show-sdk-path)";
+    if ! xcrun --sdk iphoneos --show-sdk-path >/dev/null 2>&1; then
+      echo "iOS SDK not found. Ensure Xcode is installed: sudo xcode-select --switch /Applications/Xcode.app"
+    fi
+  '';
 
   subPackages = [
     "bind"
@@ -64,11 +73,17 @@ buildGo122Module {
     ln -s $src $out/src/golang.org/x/mobile
   '';
 
+  # to fix : error: unable to find sdk: 'iphoneos'
   postFixup = ''
     for prog in gomobile gobind; do
       wrapProgram $out/bin/$prog \
         --suffix GOPATH : $out \
         --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ zlib ]}" \
+        ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+          --set DEVELOPER_DIR "/Applications/Xcode.app/Contents/Developer" \
+          --prefix PATH : "/usr/bin" \
+          --run 'export SDKROOT="$(/usr/bin/xcrun --sdk macosx --show-sdk-path)"' \
+        ''} \
         ${lib.optionalString withAndroidPkgs ''
           --prefix PATH : "${androidPkgs.androidsdk}/bin" \
           --set-default ANDROID_HOME "${androidPkgs.androidsdk}/libexec/android-sdk"

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -23,7 +23,7 @@ in pkgs.buildGoPackage {
       go-bindata
       mockgen
       protoc-gen-go
-      protobuf3_20
+      protobuf3_24
       fakeGit
   ];
 

--- a/nix/pkgs/status-go/mobile/build.nix
+++ b/nix/pkgs/status-go/mobile/build.nix
@@ -37,7 +37,7 @@ in pkgs.buildGoPackage rec {
       go-bindata
       mockgen
       protoc-gen-go
-      protobuf3_20
+      protobuf3_24
       fakeGit
   ] ++ optional isAndroid pkgs.openjdk_headless
     ++ optional isAndroid pkgs.nwaku.libwaku-android-arm64

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -28,7 +28,7 @@ in mkShell {
   buildInputs = with pkgs; [
     git jq which
     go golangci-lint go-junit-report gopls go-bindata gomobileMod codecov-cli go-generate-fast
-    mockgen protobuf3_20 protoc-gen-go gotestsum go-modvendor openjdk openssl
+    mockgen protobuf3_24 protoc-gen-go gotestsum go-modvendor openjdk openssl
    ] ++ lib.optionals (stdenv.isDarwin) [ xcodeWrapper ];
 
    shellHook = lib.optionalString (!isMacM1) ''


### PR DESCRIPTION
## Summary

- point `nixpkgs` to commit from `release-24.11`
- bump `protobuf` to `3_24`
- fix `gomobile` issue with : `error: unable to find sdk: 'iphoneos'`
