### PR TITLE
feat(wallet)!: support for calculating/setting fees for non eip1559 compliant transactions

### DIFF
--- a/params/network_config.go
+++ b/params/network_config.go
@@ -94,6 +94,7 @@ type Network struct {
 	RelatedChainID         uint64          `json:"relatedChainId" validate:"omitempty"`
 	IsActive               bool            `json:"isActive"`
 	IsDeactivatable        bool            `json:"isDeactivatable"`
+	EIP1559Enabled         bool            `json:"eip1559Enabled"`
 }
 
 func (n *Network) DeepCopy() Network {

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -95,6 +95,8 @@ type Network struct {
 	IsActive               bool            `json:"isActive"`
 	IsDeactivatable        bool            `json:"isDeactivatable"`
 	EIP1559Enabled         bool            `json:"eip1559Enabled"`
+	NoBaseFee              bool            `json:"noBaseFee"`
+	NoPriorityFee          bool            `json:"noPriorityFee"`
 }
 
 func (n *Network) DeepCopy() Network {

--- a/services/connector/connector_flows_test.go
+++ b/services/connector/connector_flows_test.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	gethTrie "github.com/ethereum/go-ethereum/trie"
 	"github.com/status-im/status-go/eth-node/types"
 	mock_client "github.com/status-im/status-go/rpc/chain/mock/client"
 	"github.com/status-im/status-go/services/connector/chainutils"
@@ -103,11 +106,39 @@ func TestRequestAccountsSwitchChainAndSendTransactionFlow(t *testing.T) {
 	assert.Equal(t, commands.FormatAccountAddressToResponse(accountAddress), response)
 
 	// Send transaction
+	blockToReturn := gethTypes.NewBlock(&gethTypes.Header{
+		Number: big.NewInt(10),
+		Time:   uint64(time.Now().Unix()),
+	},
+		[]*gethTypes.Transaction{
+			gethTypes.NewTransaction(0, common.HexToAddress(""), big.NewInt(1), 100000, big.NewInt(1), nil),
+			gethTypes.NewTransaction(0, common.HexToAddress(""), big.NewInt(1), 100000, big.NewInt(2), nil),
+			gethTypes.NewTransaction(0, common.HexToAddress(""), big.NewInt(1), 100000, big.NewInt(3), nil),
+			gethTypes.NewTransaction(0, common.HexToAddress(""), big.NewInt(1), 100000, big.NewInt(4), nil),
+			gethTypes.NewTransaction(0, common.HexToAddress(""), big.NewInt(1), 100000, big.NewInt(5), nil),
+			gethTypes.NewTransaction(0, common.HexToAddress(""), big.NewInt(1), 100000, big.NewInt(6), nil),
+			gethTypes.NewTransaction(0, common.HexToAddress(""), big.NewInt(1), 100000, big.NewInt(7), nil),
+			gethTypes.NewTransaction(0, common.HexToAddress(""), big.NewInt(1), 100000, big.NewInt(8), nil),
+			gethTypes.NewTransaction(0, common.HexToAddress(""), big.NewInt(1), 100000, big.NewInt(9), nil),
+			gethTypes.NewTransaction(0, common.HexToAddress(""), big.NewInt(1), 100000, big.NewInt(10), nil),
+		},
+		nil,
+		nil,
+		gethTrie.NewStackTrie(nil),
+	)
+
 	mockedChainClient := mock_client.NewMockClientInterface(state.mockCtrl)
+	const blocksToCheck = 5
+	blockNumber := uint64(10)
 	feeHistory := &fees.FeeHistory{}
 	percentiles := []int{fees.RewardPercentiles1, fees.RewardPercentiles2, fees.RewardPercentiles3}
 	state.rpcClient.EXPECT().Call(feeHistory, uint64(1), "eth_feeHistory", uint64(10), "latest", percentiles).Times(1).Return(nil)
-	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(1).Return(mockedChainClient, nil)
+	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(2).Return(mockedChainClient, nil)
+	mockedChainClient.EXPECT().BlockNumber(state.ctx).Times(1).Return(blockNumber, nil)
+	for i := uint64(0); i < uint64(blocksToCheck); i++ {
+		blockNum := big.NewInt(0).SetUint64(blockNumber - i)
+		mockedChainClient.EXPECT().BlockByNumber(state.ctx, blockNum).Times(1).Return(blockToReturn, nil)
+	}
 	mockedChainClient.EXPECT().SuggestGasPrice(state.ctx).Times(1).Return(big.NewInt(1), nil)
 	state.rpcClient.EXPECT().EthClient(uint64(1)).Times(1).Return(mockedChainClient, nil)
 	mockedChainClient.EXPECT().PendingNonceAt(state.ctx, common.Address(accountAddress)).Times(1).Return(uint64(10), nil)

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -421,8 +421,15 @@ func (api *API) GetTransactionEstimatedTime(ctx context.Context, chainID uint64,
 	return api.s.router.GetFeesManager().TransactionEstimatedTime(ctx, chainID, gweiToWei(maxFeePerGas)), nil
 }
 
-func (api *API) GetTransactionEstimatedTimeV2(ctx context.Context, chainID uint64, maxFeePerGas *hexutil.Big, maxPriorityFeePerGas *hexutil.Big) (uint, error) {
+func (api *API) GetTransactionEstimatedTimeV2(ctx context.Context, chainID uint64, gasPrice *hexutil.Big, maxFeePerGas *hexutil.Big, maxPriorityFeePerGas *hexutil.Big) (uint, error) {
 	logutils.ZapLogger().Debug("call to getTransactionEstimatedTimeV2")
+	isEIP1559Enabled, err := api.s.router.GetFeesManager().IsEIP1559Enabled(ctx, chainID)
+	if err != nil {
+		return 0, err
+	}
+	if !isEIP1559Enabled {
+		return api.s.router.GetFeesManager().TransactionEstimatedTimeV2Legacy(ctx, chainID, gasPrice.ToInt()), nil
+	}
 	return api.s.router.GetFeesManager().TransactionEstimatedTimeV2(ctx, chainID, maxFeePerGas.ToInt(), maxPriorityFeePerGas.ToInt()), nil
 }
 

--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -125,10 +125,11 @@ func AllChainIDs() []ChainID {
 }
 
 var AverageBlockDurationForChain = map[ChainID]time.Duration{
-	ChainID(UnknownChainID):  time.Duration(12000) * time.Millisecond,
-	ChainID(EthereumMainnet): time.Duration(12000) * time.Millisecond,
-	ChainID(OptimismMainnet): time.Duration(2000) * time.Millisecond,
-	ChainID(ArbitrumMainnet): time.Duration(250) * time.Millisecond,
-	ChainID(BaseMainnet):     time.Duration(2000) * time.Millisecond,
-	ChainID(BSCMainnet):      time.Duration(3000) * time.Millisecond,
+	ChainID(UnknownChainID):       time.Duration(12000) * time.Millisecond,
+	ChainID(EthereumMainnet):      time.Duration(12000) * time.Millisecond,
+	ChainID(OptimismMainnet):      time.Duration(2000) * time.Millisecond,
+	ChainID(ArbitrumMainnet):      time.Duration(250) * time.Millisecond,
+	ChainID(BaseMainnet):          time.Duration(2000) * time.Millisecond,
+	ChainID(BSCMainnet):           time.Duration(3000) * time.Millisecond,
+	ChainID(StatusNetworkSepolia): time.Duration(2000) * time.Millisecond,
 }

--- a/services/wallet/common/utils.go
+++ b/services/wallet/common/utils.go
@@ -84,3 +84,20 @@ func GetBlockCreationTimeForChain(chainID uint64) time.Duration {
 	}
 	return blockDuration
 }
+
+// Special functions to hardcode the nature of some special chains (eg. Status Network), where we cannot deduce EIP-1559 compatibility in a generic way
+
+// IsGaslessChainAndEIP1559Compatible returns true if the chain is gasless and EIP-1559 compatible
+func IsGaslessChainAndEIP1559Compatible(chainID uint64) bool {
+	return chainID == StatusNetworkSepolia
+}
+
+// HasNoBaseFee returns true if the chain has no base fee (eg. Status Network is (will be fully) gasless chain, but EIP-1559 compatible, but at the moment its base fee is 0)
+func HasNoBaseFee(chainID uint64) bool {
+	return chainID == StatusNetworkSepolia
+}
+
+// HasNoPriorityFee returns true if the chain has no priority fee (eg. Status Network is (will be fully) gasless chain, but EIP-1559 compatible, but at the moment it has priority fee greater than 0)
+func HasNoPriorityFee(chainID uint64) bool {
+	return false // At this moment Status Network has priority fee, but it will be 0 after the upgrade
+}

--- a/services/wallet/market/market_test.go
+++ b/services/wallet/market/market_test.go
@@ -260,7 +260,12 @@ func TestGetOrFetchTokenMarketValues(t *testing.T) {
 			}
 
 			if tc.fetchTokenMarketValues != nil || tc.fetchErr != nil {
-				provider.EXPECT().FetchTokenMarketValues(tc.wantFetchSymbols, requestCurrency).Return(tc.fetchTokenMarketValues, tc.fetchErr)
+				provider.EXPECT().FetchTokenMarketValues(gomock.Any(), requestCurrency).DoAndReturn(
+					func(symbols []string, currency string) (map[string]thirdparty.TokenMarketValues, error) {
+						require.ElementsMatch(t, tc.wantFetchSymbols, symbols)
+						return tc.fetchTokenMarketValues, tc.fetchErr
+					},
+				)
 			}
 
 			gotValues, gotErr := manager.GetOrFetchTokenMarketValues(requestSymbols, requestCurrency, tc.requestMaxCachedAgeSeconds)

--- a/services/wallet/requests/tx_custom_params.go
+++ b/services/wallet/requests/tx_custom_params.go
@@ -21,6 +21,7 @@ type PathTxCustomParams struct {
 	GasAmount     uint64          `json:"gasAmount"`
 	MaxFeesPerGas *hexutil.Big    `json:"maxFeesPerGas"`
 	PriorityFee   *hexutil.Big    `json:"priorityFee"`
+	GasPrice      *hexutil.Big    `json:"gasPrice"` // used for non-EIP1559 chains
 }
 
 func gasFeeModeValid(fl validator.FieldLevel) bool {
@@ -65,6 +66,9 @@ func (p *PathTxCustomParams) Validate() error {
 		return err
 	}
 	if p.GasFeeMode != fees.GasFeeCustom {
+		return nil
+	}
+	if p.GasPrice != nil { // used for non-EIP1559 chains
 		return nil
 	}
 	if p.MaxFeesPerGas == nil {

--- a/services/wallet/router/fees/estimated_time_test.go
+++ b/services/wallet/router/fees/estimated_time_test.go
@@ -229,12 +229,12 @@ func TestEstimatedTimeCalculation(t *testing.T) {
 		{
 			maxFee:       big.NewInt(32760456719),
 			priorityFee:  big.NewInt(1000000001),
-			expectedTime: 25,
+			expectedTime: 15,
 		},
 		{
 			maxFee:       big.NewInt(32067456719),
 			priorityFee:  big.NewInt(1000000001),
-			expectedTime: 50,
+			expectedTime: 25,
 		},
 	}
 
@@ -247,7 +247,7 @@ func TestEstimatedTimeCalculation(t *testing.T) {
 	for i, test := range tests {
 
 		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
-			estimatedTime := estimatedTimeV2(feeHistory, test.maxFee, test.priorityFee, 1)
+			estimatedTime := estimatedTimeV2(feeHistory, test.maxFee, test.priorityFee, 1, 0)
 			assert.Equal(t, test.expectedTime, estimatedTime)
 		})
 	}

--- a/services/wallet/router/fees/fees_history.go
+++ b/services/wallet/router/fees/fees_history.go
@@ -15,7 +15,12 @@ type FeeHistory struct {
 	Reward        [][]string `json:"reward,omitempty"`
 }
 
-func (fh *FeeHistory) isEIP1559Compatible() bool {
+func (fh *FeeHistory) isEIP1559Compatible(chainID uint64) bool {
+	// Since the Status Network is gasless chain, but EIP-1559 compatible, we should not rely on checking the BaseFeePerGas, that's why we have this special case.
+	if common.IsGaslessChainAndEIP1559Compatible(chainID) {
+		return true
+	}
+
 	if len(fh.BaseFeePerGas) == 0 {
 		return false
 	}

--- a/services/wallet/router/fees/suggested_priority.go
+++ b/services/wallet/router/fees/suggested_priority.go
@@ -16,6 +16,8 @@ const (
 
 	priorityWeight = 0.7
 	gasUsedWeight  = 0.3
+
+	blocksToCheck = 5 // Number of blocks to check for estimating time in case of non-EIP1559 chains
 )
 
 func hexStringToBigInt(value string) (*big.Int, error) {
@@ -51,18 +53,14 @@ func (f *FeeManager) getNonEIP1559SuggestedFees(ctx context.Context, chainID uin
 	if err != nil {
 		return nil, err
 	}
+
+	estimatedTime := f.TransactionEstimatedTimeV2Legacy(ctx, chainID, gasPrice)
+
 	return &SuggestedFees{
-		GasPrice:             gasPrice,
-		BaseFee:              big.NewInt(0),
-		MaxPriorityFeePerGas: big.NewInt(0),
-		MaxPriorityFeeSuggestedBounds: &MaxPriorityFeesSuggestedBounds{
-			Lower: big.NewInt(0),
-			Upper: big.NewInt(0),
-		},
-		MaxFeesLevels: &MaxFeesLevels{
-			Low:    (*hexutil.Big)(gasPrice),
-			Medium: (*hexutil.Big)(gasPrice),
-			High:   (*hexutil.Big)(gasPrice),
+		GasPrice: gasPrice,
+		NonEIP1559Fees: &NonEIP1559Fees{
+			GasPrice:      (*hexutil.Big)(gasPrice),
+			EstimatedTime: estimatedTime,
 		},
 		EIP1559Enabled: false,
 	}, nil

--- a/services/wallet/router/fees/suggested_priority.go
+++ b/services/wallet/router/fees/suggested_priority.go
@@ -68,8 +68,8 @@ func (f *FeeManager) getNonEIP1559SuggestedFees(ctx context.Context, chainID uin
 
 // getEIP1559SuggestedFees returns suggested fees for EIP-1559 compatible chains
 // source https://github.com/brave/brave-core/blob/master/components/brave_wallet/browser/eth_gas_utils.cc
-func getEIP1559SuggestedFees(feeHistory *FeeHistory) (lowPriorityFee, avgPriorityFee, highPriorityFee, suggestedBaseFee *big.Int, err error) {
-	if feeHistory == nil || !feeHistory.isEIP1559Compatible() {
+func getEIP1559SuggestedFees(chainID uint64, feeHistory *FeeHistory) (lowPriorityFee, avgPriorityFee, highPriorityFee, suggestedBaseFee *big.Int, err error) {
+	if feeHistory == nil || !feeHistory.isEIP1559Compatible(chainID) {
 		return nil, nil, nil, nil, ErrEIP1559IncompaibleChain
 	}
 

--- a/services/wallet/router/router_helper.go
+++ b/services/wallet/router/router_helper.go
@@ -387,10 +387,16 @@ func (r *Router) applyCustomTxFeeMode(ctx context.Context, path *routes.Path, fe
 	return nil
 }
 
+func (r *Router) updatePathFields(path *routes.Path, fetchedFees *fees.SuggestedFees) {
+	path.FromChain.EIP1559Enabled = fetchedFees.EIP1559Enabled
+	path.FromChain.NoBaseFee = walletCommon.HasNoBaseFee(path.FromChain.ChainID)
+	path.FromChain.NoPriorityFee = walletCommon.HasNoPriorityFee(path.FromChain.ChainID)
+}
+
 func (r *Router) evaluateAndUpdatePathDetails(ctx context.Context, path *routes.Path, fetchedFees *fees.SuggestedFees,
 	usedNonces map[uint64]uint64, testsMode bool, testApprovalL1Fee uint64) (err error) {
 
-	path.FromChain.EIP1559Enabled = fetchedFees.EIP1559Enabled
+	r.updatePathFields(path, fetchedFees)
 
 	l1TxFeeWei := big.NewInt(0)
 	l1ApprovalFeeWei := big.NewInt(0)

--- a/services/wallet/router/router_test_data.go
+++ b/services/wallet/router/router_test_data.go
@@ -90,7 +90,7 @@ var (
 			Medium: (*hexutil.Big)(big.NewInt(testPriorityFeeMedium)),
 			High:   (*hexutil.Big)(big.NewInt(testPriorityFeeHigh)),
 		},
-		EIP1559Enabled: false,
+		EIP1559Enabled: true,
 	}
 
 	testBalanceMapPerChain = map[string]*big.Int{
@@ -128,6 +128,7 @@ var mainnet = params.Network{
 	Layer:                  1,
 	Enabled:                true,
 	RelatedChainID:         walletCommon.EthereumMainnet,
+	EIP1559Enabled:         true,
 }
 
 var optimism = params.Network{
@@ -151,6 +152,7 @@ var optimism = params.Network{
 	Layer:                  2,
 	Enabled:                true,
 	RelatedChainID:         walletCommon.OptimismMainnet,
+	EIP1559Enabled:         true,
 }
 
 var arbitrum = params.Network{
@@ -174,6 +176,7 @@ var arbitrum = params.Network{
 	Layer:                  2,
 	Enabled:                true,
 	RelatedChainID:         walletCommon.ArbitrumMainnet,
+	EIP1559Enabled:         true,
 }
 
 var base = params.Network{
@@ -197,6 +200,7 @@ var base = params.Network{
 	Layer:                  2,
 	Enabled:                true,
 	RelatedChainID:         walletCommon.BaseMainnet,
+	EIP1559Enabled:         true,
 }
 
 var bsc = params.Network{
@@ -217,6 +221,7 @@ var bsc = params.Network{
 	Layer:                  1,
 	Enabled:                true,
 	RelatedChainID:         walletCommon.BSCMainnet,
+	EIP1559Enabled:         true,
 }
 
 var defaultNetworks = []params.Network{

--- a/services/wallet/router/router_test_data.go
+++ b/services/wallet/router/router_test_data.go
@@ -129,6 +129,8 @@ var mainnet = params.Network{
 	Enabled:                true,
 	RelatedChainID:         walletCommon.EthereumMainnet,
 	EIP1559Enabled:         true,
+	NoBaseFee:              false,
+	NoPriorityFee:          false,
 }
 
 var optimism = params.Network{
@@ -153,6 +155,8 @@ var optimism = params.Network{
 	Enabled:                true,
 	RelatedChainID:         walletCommon.OptimismMainnet,
 	EIP1559Enabled:         true,
+	NoBaseFee:              false,
+	NoPriorityFee:          false,
 }
 
 var arbitrum = params.Network{
@@ -177,6 +181,8 @@ var arbitrum = params.Network{
 	Enabled:                true,
 	RelatedChainID:         walletCommon.ArbitrumMainnet,
 	EIP1559Enabled:         true,
+	NoBaseFee:              false,
+	NoPriorityFee:          false,
 }
 
 var base = params.Network{
@@ -201,6 +207,8 @@ var base = params.Network{
 	Enabled:                true,
 	RelatedChainID:         walletCommon.BaseMainnet,
 	EIP1559Enabled:         true,
+	NoBaseFee:              false,
+	NoPriorityFee:          false,
 }
 
 var bsc = params.Network{
@@ -222,6 +230,8 @@ var bsc = params.Network{
 	Enabled:                true,
 	RelatedChainID:         walletCommon.BSCMainnet,
 	EIP1559Enabled:         true,
+	NoBaseFee:              false,
+	NoPriorityFee:          false,
 }
 
 var defaultNetworks = []params.Network{

--- a/services/wallet/router/routes/router_path.go
+++ b/services/wallet/router/routes/router_path.go
@@ -22,49 +22,52 @@ type Path struct {
 	AmountIn              *hexutil.Big      // Amount that will be sent from the source chain
 	AmountOut             *hexutil.Big      // Amount that will be received on the destination chain
 
-	SuggestedLevelsForMaxFeesPerGas *fees.MaxFeesLevels // Suggested max fees by the network (in ETH WEI)
-	SuggestedMinPriorityFee         *hexutil.Big        // Suggested min priority fee by the network (in ETH WEI)
-	SuggestedMaxPriorityFee         *hexutil.Big        // Suggested max priority fee by the network (in ETH WEI)
-	SuggestedTxNonce                *hexutil.Uint64     // Suggested nonce for the transaction
-	SuggestedTxGasAmount            uint64              // Suggested gas amount for the transaction
-	SuggestedApprovalTxNonce        *hexutil.Uint64     // Suggested nonce for the approval transaction
-	SuggestedApprovalGasAmount      uint64              // Suggested gas amount for the approval transaction
-	CurrentBaseFee                  *hexutil.Big        // Current network base fee (in ETH WEI)
-	UsedContractAddress             *common.Address     // Address of the contract that will be used for the transaction
+	SuggestedNonEIP1559Fees         *fees.NonEIP1559Fees // Suggested fees for non EIP-1559 compatible chains
+	SuggestedLevelsForMaxFeesPerGas *fees.MaxFeesLevels  // Suggested max fees by the network (in base unit of the chain eg. WEI for ETH or BNB)
+	SuggestedMinPriorityFee         *hexutil.Big         // Suggested min priority fee by the network (in base unit of the chain eg. WEI for ETH or BNB)
+	SuggestedMaxPriorityFee         *hexutil.Big         // Suggested max priority fee by the network (in base unit of the chain eg. WEI for ETH or BNB)
+	SuggestedTxNonce                *hexutil.Uint64      // Suggested nonce for the transaction
+	SuggestedTxGasAmount            uint64               // Suggested gas amount for the transaction
+	SuggestedApprovalTxNonce        *hexutil.Uint64      // Suggested nonce for the approval transaction
+	SuggestedApprovalGasAmount      uint64               // Suggested gas amount for the approval transaction
+	CurrentBaseFee                  *hexutil.Big         // Current network base fee (in base unit of the chain eg. WEI for ETH or BNB)
+	UsedContractAddress             *common.Address      // Address of the contract that will be used for the transaction
 
 	TxPackedData    []byte          // Packed data for the transaction
 	TxNonce         *hexutil.Uint64 // Nonce for the transaction
+	TxGasPrice      *hexutil.Big    // Gas price for the transaction (in base unit of the chain eg. WEI for ETH or BNB)
 	TxGasFeeMode    fees.GasFeeMode // Gas fee mode for the transaction
-	TxMaxFeesPerGas *hexutil.Big    // Max fees per gas (determined by client via GasFeeMode, in ETH WEI)
-	TxBaseFee       *hexutil.Big    // Base fee for the transaction (in ETH WEI)
-	TxPriorityFee   *hexutil.Big    // Priority fee for the transaction (in ETH WEI)
+	TxMaxFeesPerGas *hexutil.Big    // Max fees per gas (determined by client via GasFeeMode, in base unit of the chain eg. WEI for ETH or BNB)
+	TxBaseFee       *hexutil.Big    // Base fee for the transaction (in base unit of the chain eg. WEI for ETH or BNB)
+	TxPriorityFee   *hexutil.Big    // Priority fee for the transaction (in base unit of the chain eg. WEI for ETH or BNB)
 	TxGasAmount     uint64          // Gas used for the transaction
 	TxBonderFees    *hexutil.Big    // Bonder fees for the transaction - used for Hop bridge (in selected token)
 	TxTokenFees     *hexutil.Big    // Token fees for the transaction - used for bridges (represent the difference between the amount in and the amount out, in selected token)
 	TxEstimatedTime uint            // Estimated time for the transaction in seconds
 
-	TxFee   *hexutil.Big // fee for the transaction (includes tx fee only, doesn't include approval fees, l1 fees, l1 approval fees, token fees or bonders fees, in ETH WEI)
-	TxL1Fee *hexutil.Big // L1 fee for the transaction - used for for transactions placed on L2 chains (in ETH WEI)
+	TxFee   *hexutil.Big // fee for the transaction (includes tx fee only, doesn't include approval fees, l1 fees, l1 approval fees, token fees or bonders fees, in base unit of the chain eg. WEI for ETH or BNB)
+	TxL1Fee *hexutil.Big // L1 fee for the transaction - used for for transactions placed on L2 chains (in base unit of the chain eg. WEI for ETH or BNB)
 
 	ApprovalRequired        bool            // Is approval required for the transaction
 	ApprovalAmountRequired  *hexutil.Big    // Amount required for the approval transaction
 	ApprovalContractAddress *common.Address // Address of the contract that will be used for the approval transaction, the same as UsedContractAddress. We can remove this field and use UsedContractAddress instead.
 	ApprovalPackedData      []byte          // Packed data for the approval transaction
 	ApprovalTxNonce         *hexutil.Uint64 // Nonce for the transaction
+	ApprovalGasPrice        *hexutil.Big    // Gas price for the approval transaction (in base unit of the chain eg. WEI for ETH or BNB)
 	ApprovalGasFeeMode      fees.GasFeeMode // Gas fee mode for the approval transaction
-	ApprovalMaxFeesPerGas   *hexutil.Big    // Max fees per gas (determined by client via GasFeeMode, in ETH WEI)
-	ApprovalBaseFee         *hexutil.Big    // Base fee for the approval transaction (in ETH WEI)
-	ApprovalPriorityFee     *hexutil.Big    // Priority fee for the approval transaction (in ETH WEI)
+	ApprovalMaxFeesPerGas   *hexutil.Big    // Max fees per gas (determined by client via GasFeeMode, in base unit of the chain eg. WEI for ETH or BNB)
+	ApprovalBaseFee         *hexutil.Big    // Base fee for the approval transaction (in base unit of the chain eg. WEI for ETH or BNB)
+	ApprovalPriorityFee     *hexutil.Big    // Priority fee for the approval transaction (in base unit of the chain eg. WEI for ETH or BNB)
 	ApprovalGasAmount       uint64          // Gas used for the approval transaction
 	ApprovalEstimatedTime   uint            // Estimated time for the approval transaction in seconds
 
-	ApprovalFee   *hexutil.Big // Total fee for the approval transaction (includes approval tx fees only, doesn't include approval l1 fees, in ETH WEI)
-	ApprovalL1Fee *hexutil.Big // L1 fee for the approval transaction - used for for transactions placed on L2 chains (in ETH WEI)
+	ApprovalFee   *hexutil.Big // Total fee for the approval transaction (includes approval tx fees only, doesn't include approval l1 fees, in base unit of the chain eg. WEI for ETH or BNB)
+	ApprovalL1Fee *hexutil.Big // L1 fee for the approval transaction - used for for transactions placed on L2 chains (in base unit of the chain eg. WEI for ETH or BNB)
 
-	TxTotalFee *hexutil.Big // Total fee for the transaction (includes tx fees, approval fees, l1 fees, l1 approval fees, in ETH WEI)
+	TxTotalFee *hexutil.Big // Total fee for the transaction (includes tx fees, approval fees, l1 fees, l1 approval fees, in base unit of the chain eg. WEI for ETH or BNB)
 
 	RequiredTokenBalance  *big.Int // (in selected token)
-	RequiredNativeBalance *big.Int // (in ETH WEI)
+	RequiredNativeBalance *big.Int // (in base unit of the chain eg. WEI for ETH or BNB)
 	SubtractFees          bool
 
 	// used internally
@@ -139,6 +142,14 @@ func (p *Path) Copy() *Path {
 		newPath.AmountOut = (*hexutil.Big)(big.NewInt(0).Set(p.AmountOut.ToInt()))
 	}
 
+	if p.SuggestedNonEIP1559Fees != nil {
+		newPath.SuggestedNonEIP1559Fees = &fees.NonEIP1559Fees{}
+		if p.SuggestedNonEIP1559Fees.GasPrice != nil {
+			newPath.SuggestedNonEIP1559Fees.GasPrice = (*hexutil.Big)(big.NewInt(0).Set(p.SuggestedNonEIP1559Fees.GasPrice.ToInt()))
+		}
+		newPath.SuggestedNonEIP1559Fees.EstimatedTime = p.SuggestedNonEIP1559Fees.EstimatedTime
+	}
+
 	if p.SuggestedLevelsForMaxFeesPerGas != nil {
 		newPath.SuggestedLevelsForMaxFeesPerGas = &fees.MaxFeesLevels{}
 		if p.SuggestedLevelsForMaxFeesPerGas.Low != nil {
@@ -196,6 +207,10 @@ func (p *Path) Copy() *Path {
 		newPath.TxNonce = &txNonce
 	}
 
+	if p.TxGasPrice != nil {
+		newPath.TxGasPrice = (*hexutil.Big)(big.NewInt(0).Set(p.TxGasPrice.ToInt()))
+	}
+
 	if p.TxMaxFeesPerGas != nil {
 		newPath.TxMaxFeesPerGas = (*hexutil.Big)(big.NewInt(0).Set(p.TxMaxFeesPerGas.ToInt()))
 	}
@@ -246,6 +261,10 @@ func (p *Path) Copy() *Path {
 	if p.ApprovalTxNonce != nil {
 		approvalTxNonce := *p.ApprovalTxNonce
 		newPath.ApprovalTxNonce = &approvalTxNonce
+	}
+
+	if p.ApprovalGasPrice != nil {
+		newPath.ApprovalGasPrice = (*hexutil.Big)(big.NewInt(0).Set(p.ApprovalGasPrice.ToInt()))
 	}
 
 	if p.ApprovalMaxFeesPerGas != nil {


### PR DESCRIPTION
What's changed:
- Introduced `EIP1559Enabled` field in the Network struct, which will be set forthe  chain in the path response
- Introduced `GasPrice` field in `PathTxCustomParams` that will be used for setting custom fees for non-EIP-1559 chains
- Updated Router methods to handle suggested fees and gas prices based on EIP-1559 flag
- Refactored fee estimation logic to accommodate both EIP-1559 and non-EIP-1559 fee structures
- Improved path handling to ensure correct fee application for transactions and approvals

Clients need to:
- check `EIP1559Enabled` field of the `FromChain` field for each path from the Best router that is being processed
- based on that the client needs to either use values from `SuggestedNonEIP1559Fees` or `SuggestedLevelsForMaxFeesPerGas` when preparing estimated time or suggested fee values
- `ApprovalGasPrice` and `TxGasPrice` are added to the `Path` and they represent the value that will be used for the tx execution
- Custom gas price can be set via `GasPrice` field of `PathTxCustomParams` via `SetCustomTxDetails` API endpoint
- API endpoint `GetTransactionEstimatedTimeV2` extended with `gasPrice` parameter, now it's able to estimate time for EIP1559 compliant and non-compliant chains