### PR TITLE
fix(wallet)_: don't ignore error coming from the hop api when estimate bonder fee

### DIFF
--- a/services/wallet/router/pathprocessor/processor_bridge_hop.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_hop.go
@@ -65,6 +65,13 @@ type BonderFee struct {
 }
 
 func (bf *BonderFee) UnmarshalJSON(data []byte) error {
+	var errorResponse struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(data, &errorResponse); err == nil && errorResponse.Error != "" {
+		return createBridgeHopErrorResponse(fmt.Errorf(errorResponse.Error))
+	}
+
 	type Alias BonderFee
 	aux := &struct {
 		AmountIn                string  `json:"amountIn"`


### PR DESCRIPTION
Noticed when bridging a very low amount from Base to Optimism.
The error which is part of the response returned by the Hop API (that is coming from the contract) simply was just ignored. This PR notifies client about the error.

Fixes the issue https://github.com/status-im/status-desktop/issues/17961

Screenshot from the desktop app now:
![image](https://github.com/user-attachments/assets/c28096fe-ad2d-4e6f-9115-201d33149a13)


Screenshot from the hop exchange:
![image](https://github.com/user-attachments/assets/082d9d87-3505-44dc-9735-285ddb673988)

![image](https://github.com/user-attachments/assets/2ec5514d-c29d-4694-a9a0-1021e656446a)

