### PR TITLE
chore_: cleaning the accounts manager

### DIFF
--- a/account/accounts_geth.go
+++ b/account/accounts_geth.go
@@ -1,14 +1,11 @@
 package account
 
 import (
-	"time"
-
 	"go.uber.org/zap"
 
 	"github.com/ethereum/go-ethereum/accounts"
 
 	"github.com/status-im/status-go/account/generator"
-	"github.com/status-im/status-go/rpc"
 )
 
 // GethManager represents account manager interface.
@@ -26,11 +23,6 @@ func NewGethManager(logger *zap.Logger) *GethManager {
 		logger:            logger,
 	}
 	return m
-}
-
-func (m *GethManager) SetRPCClient(rpcClient *rpc.Client, rpcTimeout time.Duration) {
-	m.DefaultManager.rpcClient = rpcClient
-	m.DefaultManager.rpcTimeout = rpcTimeout
 }
 
 // InitKeystore sets key manager and key store.

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -273,7 +273,7 @@ func TestBackendGettersConcurrently(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		assert.NotNil(t, backend.personalAPI)
+		assert.NotNil(t, backend.signer)
 		wg.Done()
 	}()
 

--- a/cmd/statusd/main.go
+++ b/cmd/statusd/main.go
@@ -261,6 +261,7 @@ func main() {
 			protocol.WithTorrentConfig(&config.TorrentConfig),
 			protocol.WithWalletConfig(&config.WalletConfig),
 			protocol.WithAccountManager(backend.AccountManager()),
+			protocol.WithMessageSigner(backend.MessageSigner()),
 		}
 
 		messenger, err := protocol.NewMessenger(
@@ -331,6 +332,7 @@ func main() {
 				protocol.WithTorrentConfig(&config.TorrentConfig),
 				protocol.WithWalletConfig(&config.WalletConfig),
 				protocol.WithAccountManager(backend.AccountManager()),
+				protocol.WithMessageSigner(backend.MessageSigner()),
 			}
 
 			messenger, err := protocol.NewMessenger(

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -105,6 +105,7 @@ var messageCacheIntervalMs uint64 = 1000 * 60 * 60 * 48
 type Messenger struct {
 	config                    *config
 	identity                  *ecdsa.PrivateKey
+	signer                    communities.MessageSigner
 	messaging                 *messaging.API
 	persistence               *sqlitePersistence
 	encryptor                 *encryption.Protocol
@@ -413,7 +414,7 @@ func NewMessenger(
 	pushNotificationClient := pushnotificationclient.New(pushNotificationClientPersistence, pushNotificationClientConfig, sender, sqlitePersistence)
 
 	managerOptions := []communities.ManagerOption{
-		communities.WithAccountManager(c.accountsManager),
+		communities.WithMessageSigner(c.signer),
 	}
 
 	var walletAPI *wallet.API
@@ -532,6 +533,7 @@ func NewMessenger(
 		archiveManager:             archiveManager,
 		accountsManager:            c.accountsManager,
 		ensVerifier:                c.ensVerifier,
+		signer:                     c.signer,
 		featureFlags:               c.featureFlags,
 		systemMessagesTranslations: c.systemMessagesTranslations,
 		allChats:                   new(chatMap),

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/tt"
+	"github.com/status-im/status-go/services/personal"
 	"github.com/status-im/status-go/wakuv2"
 
 	wakutypes "github.com/status-im/status-go/waku/types"
@@ -55,6 +56,8 @@ type MessengerBaseTestSuite struct {
 }
 
 func newMessengerWithKey(shh wakutypes.Waku, privateKey *ecdsa.PrivateKey, logger *zap.Logger, extraOptions []Option) (*Messenger, error) {
+	personalAPI := personal.NewMockedAPI()
+
 	options := []Option{
 		WithAppSettings(settings.Settings{
 			DisplayName:               DefaultProfileDisplayName,
@@ -62,6 +65,7 @@ func newMessengerWithKey(shh wakutypes.Waku, privateKey *ecdsa.PrivateKey, logge
 			ProfilePicturesVisibility: 1,
 			URLUnfurlingMode:          settings.URLUnfurlingAlwaysAsk,
 		}, params.NodeConfig{}),
+		WithMessageSigner(personalAPI),
 	}
 	options = append(options, extraOptions...)
 

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/tt"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
+	"github.com/status-im/status-go/services/personal"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/walletdatabase"
 
@@ -84,6 +85,8 @@ func newTestMessenger(waku wakutypes.Waku, config testMessengerConfig) (*Messeng
 		"",
 	)
 
+	personalAPI := personal.NewMockedAPI()
+
 	options := []Option{
 		WithCustomLogger(config.logger),
 		WithDatabase(appDb),
@@ -96,6 +99,7 @@ func newTestMessenger(waku wakutypes.Waku, config testMessengerConfig) (*Messeng
 		WithCuratedCommunitiesUpdateLoop(false),
 		WithStubOnlineChecker(),
 		WithENSVerifier(ensVerifier),
+		WithMessageSigner(personalAPI),
 	}
 	options = append(options, config.extraOptions...)
 

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -97,6 +97,7 @@ type config struct {
 	tokenManager           communities.TokenManager
 	collectiblesManager    communities.CollectiblesManager
 	accountsManager        account.Manager
+	signer                 communities.MessageSigner
 
 	verifyTransactionClient EthClient
 	ensVerifier             *ens.Verifier
@@ -408,6 +409,13 @@ func WithCollectiblesManager(collectiblesManager communities.CollectiblesManager
 func WithAccountManager(accountManager account.Manager) Option {
 	return func(c *config) error {
 		c.accountsManager = accountManager
+		return nil
+	}
+}
+
+func WithMessageSigner(signer communities.MessageSigner) Option {
+	return func(c *config) error {
+		c.signer = signer
 		return nil
 	}
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -11,9 +11,9 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"go.uber.org/zap"
 
-	"github.com/status-im/status-go/account"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/services/browsers"
+	"github.com/status-im/status-go/services/personal"
 	"github.com/status-im/status-go/services/wallet"
 	"github.com/status-im/status-go/services/wallet/bigint"
 
@@ -599,21 +599,21 @@ func (api *PublicAPI) AllNonApprovedCommunitiesRequestsToJoin() ([]*communities.
 // Generates a single hash for each address that needs to be revealed to a community.
 // Each hash needs to be signed.
 // The order of retuned hashes corresponds to the order of addresses in addressesToReveal.
-func (api *PublicAPI) GenerateJoiningCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]account.SignParams, error) {
+func (api *PublicAPI) GenerateJoiningCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
 	return api.service.messenger.GenerateJoiningCommunityRequestsForSigning(memberPubKey, communityID, addressesToReveal)
 }
 
 // Generates a single hash for each address that needs to be revealed to a community.
 // Each hash needs to be signed.
 // The order of retuned hashes corresponds to the order of addresses in addressesToReveal.
-func (api *PublicAPI) GenerateEditCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]account.SignParams, error) {
+func (api *PublicAPI) GenerateEditCommunityRequestsForSigning(memberPubKey string, communityID types.HexBytes, addressesToReveal []string) ([]personal.SignParams, error) {
 	return api.service.messenger.GenerateEditCommunityRequestsForSigning(memberPubKey, communityID, addressesToReveal)
 }
 
 // Signs the provided messages with the provided accounts and password.
 // Provided accounts must not belong to a keypair that is migrated to a keycard.
 // Otherwise, the signing will fail, cause such accounts should be signed with a keycard.
-func (api *PublicAPI) SignData(signParams []account.SignParams) ([]string, error) {
+func (api *PublicAPI) SignData(signParams []personal.SignParams) ([]string, error) {
 	return api.service.messenger.SignData(signParams)
 }
 

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -49,6 +49,7 @@ import (
 	"github.com/status-im/status-go/services/browsers"
 	"github.com/status-im/status-go/services/communitytokens"
 	mailserversDB "github.com/status-im/status-go/services/mailservers"
+	"github.com/status-im/status-go/services/personal"
 	"github.com/status-im/status-go/services/wallet"
 	"github.com/status-im/status-go/services/wallet/collectibles"
 	w_common "github.com/status-im/status-go/services/wallet/common"
@@ -371,6 +372,7 @@ func buildMessengerOptions(
 	accountsFeed *event.Feed,
 	ensVerifier *ens.Verifier,
 ) ([]protocol.Option, error) {
+	personalAPI := personal.NewAPI()
 	options := []protocol.Option{
 		protocol.WithCustomLogger(logger),
 		protocol.WithPushNotifications(),
@@ -395,6 +397,7 @@ func buildMessengerOptions(
 		protocol.WithAccountManager(accountManager),
 		protocol.WithAccountsFeed(accountsFeed),
 		protocol.WithNewsFeed(),
+		protocol.WithMessageSigner(personalAPI),
 	}
 
 	if config.ShhextConfig.DataSyncEnabled {

--- a/services/personal/api.go
+++ b/services/personal/api.go
@@ -1,91 +1,82 @@
 package personal
 
 import (
-	"context"
 	"errors"
-	"strings"
-	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-
 	"github.com/status-im/status-go/account"
+	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
-	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/rpc"
 )
 
 var (
-	// ErrInvalidPersonalSignAccount is returned when the account passed to
-	// personal_sign isn't equal to the currently selected account.
-	ErrInvalidPersonalSignAccount = errors.New("invalid account as only the selected one can generate a signature")
+	ErrInvalidSignatureLength = errors.New("invalid signature, must be 65 bytes long")
+	ErrInvalidSignatureV      = errors.New("invalid Ethereum signature (V is not 27 or 28)")
 )
-
-// SignParams required to sign messages
-type SignParams struct {
-	Data     interface{} `json:"data"`
-	Address  string      `json:"account"`
-	Password string      `json:"password"`
-}
-
-// RecoverParams are for calling `personal_ecRecover`
-type RecoverParams struct {
-	Message   string `json:"message"`
-	Signature string `json:"signature"`
-}
 
 // PublicAPI represents a set of APIs from the `web3.personal` namespace.
 type PublicAPI struct {
-	rpcClient  *rpc.Client
-	rpcTimeout time.Duration
 }
 
 // NewAPI creates an instance of the personal API.
 func NewAPI() *PublicAPI {
-	return &PublicAPI{
-		rpcTimeout: 300 * time.Second,
-	}
-}
-
-// SetRPC sets RPC params (client and timeout) for the API calls.
-func (api *PublicAPI) SetRPC(rpcClient *rpc.Client, timeout time.Duration) {
-	api.rpcClient = rpcClient
-	api.rpcTimeout = timeout
+	return &PublicAPI{}
 }
 
 // Recover is an implementation of `personal_ecRecover` or `web3.personal.ecRecover` API
 func (api *PublicAPI) Recover(rpcParams RecoverParams) (addr types.Address, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), api.rpcTimeout)
-	defer cancel()
-	var gethAddr common.Address
-	err = api.rpcClient.CallContextIgnoringLocalHandlers(
-		ctx,
-		&gethAddr,
-		api.rpcClient.UpstreamChainID,
-		params.PersonalRecoverMethodName,
-		rpcParams.Message, rpcParams.Signature)
-	addr = types.Address(gethAddr)
+	message, err := hexutil.Decode(rpcParams.Message)
+	if err != nil {
+		return types.Address{}, err
+	}
+	sig, err := hexutil.Decode(rpcParams.Signature)
+	if err != nil {
+		return types.Address{}, err
+	}
 
-	return
+	if len(sig) != 65 {
+		return types.Address{}, ErrInvalidSignatureLength
+	}
+	if sig[64] != 27 && sig[64] != 28 {
+		return types.Address{}, ErrInvalidSignatureV
+	}
+	sig[64] -= 27 // Transform yellow paper V from 27/28 to 0/1
+	hash := crypto.TextHash(message)
+	rpk, err := crypto.SigToPub(hash, sig)
+	if err != nil {
+		return types.Address{}, err
+	}
+	return crypto.PubkeyToAddress(*rpk), nil
+}
+
+// CanRecover is an implementation of `personal_ecRecover` or `web3.personal.ecRecover` API
+func (api *PublicAPI) CanRecover(rpcParams RecoverParams, revealedAddress types.Address) (bool, error) {
+	recovered, err := api.Recover(rpcParams)
+	if err != nil {
+		return false, err
+	}
+	return recovered == revealedAddress, nil
 }
 
 // Sign is an implementation of `personal_sign` or `web3.personal.sign` API
 func (api *PublicAPI) Sign(rpcParams SignParams, verifiedAccount *account.SelectedExtKey) (result types.HexBytes, err error) {
-	if !strings.EqualFold(rpcParams.Address, verifiedAccount.Address.Hex()) {
-		err = ErrInvalidPersonalSignAccount
-		return
+	var dBytes []byte
+	switch d := rpcParams.Data.(type) {
+	case string:
+		dBytes = []byte(d)
+	case []byte:
+		dBytes = d
+	case byte:
+		dBytes = []byte{d}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), api.rpcTimeout)
-	defer cancel()
-	var gethResult hexutil.Bytes
-	err = api.rpcClient.CallContextIgnoringLocalHandlers(
-		ctx,
-		&gethResult,
-		api.rpcClient.UpstreamChainID,
-		params.PersonalSignMethodName,
-		rpcParams.Data, rpcParams.Address, rpcParams.Password)
-	result = types.HexBytes(gethResult)
+	hash := crypto.TextHash(dBytes)
 
-	return
+	sig, err := crypto.Sign(hash, verifiedAccount.AccountKey.PrivateKey)
+	if err != nil {
+		return types.HexBytes{}, err
+	}
+	sig[64] += 27 // Transform V from 0/1 to 27/28 according to the yellow paper
+
+	return types.HexBytes(sig), err
 }

--- a/services/personal/mocked_api.go
+++ b/services/personal/mocked_api.go
@@ -1,0 +1,43 @@
+package personal
+
+import (
+	"github.com/status-im/status-go/account"
+	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/protocol/common"
+)
+
+type MockedPersonalAPI struct {
+}
+
+func NewMockedAPI() *MockedPersonalAPI {
+	return &MockedPersonalAPI{}
+}
+
+func (api *MockedPersonalAPI) Recover(rpcParams RecoverParams) (addr types.Address, err error) {
+	sig := types.HexBytes(rpcParams.Signature)
+	if len(sig) != 65 {
+		return types.Address{}, ErrInvalidSignatureLength
+	}
+	if sig[64] != 27 && sig[64] != 28 {
+		return types.Address{}, ErrInvalidSignatureV
+	}
+	sig[64] -= 27 // Transform yellow paper V from 27/28 to 0/1
+	hash := crypto.TextHash(types.HexBytes(rpcParams.Message))
+	rpk, err := crypto.SigToPub(hash, sig)
+	if err != nil {
+		return types.Address{}, err
+	}
+	return crypto.PubkeyToAddress(*rpk), nil
+}
+
+func (api *MockedPersonalAPI) CanRecover(rpcParams RecoverParams, revealedAddress types.Address) (bool, error) {
+	return true, nil
+}
+
+func (api *MockedPersonalAPI) Sign(rpcParams SignParams, verifiedAccount *account.SelectedExtKey) (result types.HexBytes, err error) {
+	bytesArray := []byte(rpcParams.Address)
+	bytesArray = append(bytesArray, []byte(rpcParams.Password)...)
+	bytesArray = common.Shake256(bytesArray)
+	return append([]byte{0}, bytesArray...), nil
+}

--- a/services/personal/types.go
+++ b/services/personal/types.go
@@ -1,0 +1,36 @@
+package personal
+
+import (
+	"errors"
+
+	"github.com/status-im/status-go/eth-node/types"
+)
+
+// SignParams required to sign messages
+type SignParams struct {
+	Data     interface{} `json:"data"`
+	Address  string      `json:"account"`
+	Password string      `json:"password"`
+}
+
+func (sp *SignParams) Validate(checkPassword bool) error {
+	if len(sp.Address) != 2*types.AddressLength+2 {
+		return errors.New("address has to be provided")
+	}
+
+	if sp.Data == "" {
+		return errors.New("data has to be provided")
+	}
+
+	if checkPassword && sp.Password == "" {
+		return errors.New("password has to be provided")
+	}
+
+	return nil
+}
+
+// RecoverParams are for calling `personal_ecRecover`
+type RecoverParams struct {
+	Message   string `json:"message"`
+	Signature string `json:"signature"`
+}


### PR DESCRIPTION
The following functions have been removed from the account package:
- `Recover`
- `CanRecover`
- `Sign`

and the rest of the code updates to use the same functions from the personal api package,
where we already have those functions.

`MockedPersonalAPI` within the personal package was added as the easiest way of fixing tests (basically it does what was done in the `AccountManagerMock`, cause any other approach requires a lot of changes in communities/messenger tests.