### PR TITLE
feat(leaderboard)_: add getMarketProxyHost function for market proxy …

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,4 +19,4 @@ shell.nix             @status-im/devops
 /healthmanager        @friofry
 /rpc/network          @friofry
 
-/services/wallet/leaderboard @cuteivist @friofry
+/services/wallet/leaderboard @friofry

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ shell.nix             @status-im/devops
 
 # Custom ownership for specific folders
 # Feel free to add yourself for any new packages you implement.
-/_docs/policies       @status-im/status-go-guild @jrainville @alaibe @shivekkhurana @ilmotta @plopezlpz
+/_docs/policies       @status-im/status-go-guild @jrainville @alaibe @plopezlpz
 /cmd/status-backend   @igor-sirotin
 /internal/sentry      @igor-sirotin
 /healthmanager        @friofry

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -224,14 +224,17 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 	if !request.StatusProxyMarketPassword.Empty() {
 		walletConfig.StatusProxyMarketPassword = request.StatusProxyMarketPassword
 	}
-	if request.MarketDataProxyUser != "" {
+	if !request.MarketDataProxyUser.Empty() {
 		walletConfig.MarketDataProxyConfig.User = request.MarketDataProxyUser
 	}
-	if request.MarketDataProxyPassword != "" {
+	if !request.MarketDataProxyPassword.Empty() {
 		walletConfig.MarketDataProxyConfig.Password = request.MarketDataProxyPassword
 	}
-	if request.MarketDataProxyUrl != "" {
-		walletConfig.MarketDataProxyConfig.Url = request.MarketDataProxyUrl
+	if !request.MarketDataProxyUrl.Empty() {
+		walletConfig.MarketDataProxyConfig.UrlOverride = request.MarketDataProxyUrl
+	}
+	if request.StatusProxyStageName != "" {
+		walletConfig.MarketDataProxyConfig.StageName = request.StatusProxyStageName
 	}
 	if walletRequest.MarketDataFullDataRefreshInterval != 0 {
 		walletConfig.MarketDataProxyConfig.FullDataRefreshInterval = walletRequest.MarketDataFullDataRefreshInterval

--- a/params/config.go
+++ b/params/config.go
@@ -447,11 +447,12 @@ type WalletConfig struct {
 }
 
 type MarketDataProxyConfig struct {
-	Url                     string `json:"Url"`
-	User                    string `json:"User"`
-	Password                string `json:"Password"`
-	FullDataRefreshInterval int    `json:"FullDataRefreshInterval"`
-	PriceRefreshInterval    int    `json:"PriceRefreshInterval"`
+	UrlOverride             security.SensitiveString `json:"UrlOverride"`
+	StageName               string                   `json:"StageName"`
+	User                    security.SensitiveString `json:"User"`
+	Password                security.SensitiveString `json:"Password"`
+	FullDataRefreshInterval int                      `json:"FullDataRefreshInterval"`
+	PriceRefreshInterval    int                      `json:"PriceRefreshInterval"`
 }
 
 // MarshalJSON custom marshalling to avoid exposing sensitive data in log,

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -117,9 +117,9 @@ type WalletSecretsConfig struct {
 	StatusProxyMarketUser     security.SensitiveString `json:"statusProxyMarketUser"`
 	StatusProxyMarketPassword security.SensitiveString `json:"statusProxyMarketPassword"`
 
-	MarketDataProxyUrl      string `json:"marketDataProxyUrl"`
-	MarketDataProxyUser     string `json:"marketDataProxyUser"`
-	MarketDataProxyPassword string `json:"marketDataProxyPassword"`
+	MarketDataProxyUrl      security.SensitiveString `json:"marketDataProxyUrl"`
+	MarketDataProxyUser     security.SensitiveString `json:"marketDataProxyUser"`
+	MarketDataProxyPassword security.SensitiveString `json:"marketDataProxyPassword"`
 	// FIXME: remove when EthRpcProxy* is integrated
 	StatusProxyBlockchainUser     security.SensitiveString `json:"statusProxyBlockchainUser"`
 	StatusProxyBlockchainPassword security.SensitiveString `json:"statusProxyBlockchainPassword"`

--- a/services/wallet/leaderboard/config.go
+++ b/services/wallet/leaderboard/config.go
@@ -3,6 +3,8 @@ package leaderboard
 import (
 	"time"
 
+	"github.com/status-im/status-go/pkg/security"
+
 	"github.com/status-im/status-go/params"
 )
 
@@ -14,9 +16,10 @@ const (
 // ServiceConfig defines the configuration for the market data service
 type ServiceConfig struct {
 	// API connection settings
-	ProxyURL string
-	User     string
-	Password string
+	UrlOverride security.SensitiveString
+	User        security.SensitiveString
+	Password    security.SensitiveString
+	StageName   string
 
 	// Refresh intervals (in seconds)
 	FullDataInterval    time.Duration
@@ -42,9 +45,10 @@ func (c *ServiceConfig) setDefaults() {
 func NewLeaderbordConfig(config params.MarketDataProxyConfig) ServiceConfig {
 	// Create a new ServiceConfig instance with default values
 	serviceConfig := ServiceConfig{
-		ProxyURL:            config.Url,
+		UrlOverride:         config.UrlOverride,
 		User:                config.User,
 		Password:            config.Password,
+		StageName:           config.StageName,
 		FullDataInterval:    time.Duration(config.FullDataRefreshInterval) * time.Second,
 		PriceUpdateInterval: time.Duration(config.PriceRefreshInterval) * time.Second,
 		AllowGzip:           true,

--- a/services/wallet/leaderboard/config.go
+++ b/services/wallet/leaderboard/config.go
@@ -42,7 +42,7 @@ func (c *ServiceConfig) setDefaults() {
 	}
 }
 
-func NewLeaderbordConfig(config params.MarketDataProxyConfig) ServiceConfig {
+func NewLeaderboardConfig(config params.MarketDataProxyConfig) ServiceConfig {
 	// Create a new ServiceConfig instance with default values
 	serviceConfig := ServiceConfig{
 		UrlOverride:         config.UrlOverride,

--- a/services/wallet/leaderboard/config_test.go
+++ b/services/wallet/leaderboard/config_test.go
@@ -7,24 +7,25 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/pkg/security"
 )
 
 func TestServiceConfigValidate(t *testing.T) {
 	{
 		// Zero intervals
 		config := NewLeaderbordConfig(params.MarketDataProxyConfig{
-			Url:                     "https://example.com",
-			User:                    "user",
-			Password:                "pass",
+			UrlOverride:             security.NewSensitiveString("https://example.com"),
+			User:                    security.NewSensitiveString("user"),
+			Password:                security.NewSensitiveString("pass"),
 			FullDataRefreshInterval: 0,
 			PriceRefreshInterval:    0,
 		})
 
 		require.Equal(t, defaultFullDataInterval, config.FullDataInterval)
 		require.Equal(t, defaultPriceUpdateInterval, config.PriceUpdateInterval)
-		require.Equal(t, "https://example.com", config.ProxyURL)
-		require.Equal(t, "user", config.User)
-		require.Equal(t, "pass", config.Password)
+		require.Equal(t, "https://example.com", config.UrlOverride.Reveal())
+		require.Equal(t, "user", config.User.Reveal())
+		require.Equal(t, "pass", config.Password.Reveal())
 		require.Equal(t, true, config.AllowGzip)
 		require.Equal(t, true, config.AllowETag)
 	}
@@ -32,18 +33,18 @@ func TestServiceConfigValidate(t *testing.T) {
 	{
 		// Negative intervals
 		config := NewLeaderbordConfig(params.MarketDataProxyConfig{
-			Url:                     "https://example.com",
-			User:                    "user",
-			Password:                "pass",
+			UrlOverride:             security.NewSensitiveString("https://example.com"),
+			User:                    security.NewSensitiveString("user"),
+			Password:                security.NewSensitiveString("pass"),
 			FullDataRefreshInterval: -5,
 			PriceRefreshInterval:    -5,
 		})
 
 		require.Equal(t, defaultFullDataInterval, config.FullDataInterval)
 		require.Equal(t, defaultPriceUpdateInterval, config.PriceUpdateInterval)
-		require.Equal(t, "https://example.com", config.ProxyURL)
-		require.Equal(t, "user", config.User)
-		require.Equal(t, "pass", config.Password)
+		require.Equal(t, "https://example.com", config.UrlOverride.Reveal())
+		require.Equal(t, "user", config.User.Reveal())
+		require.Equal(t, "pass", config.Password.Reveal())
 		require.Equal(t, true, config.AllowGzip)
 		require.Equal(t, true, config.AllowETag)
 	}
@@ -51,18 +52,18 @@ func TestServiceConfigValidate(t *testing.T) {
 	{
 		// Custom intervals
 		config := NewLeaderbordConfig(params.MarketDataProxyConfig{
-			Url:                     "https://example.com",
-			User:                    "user",
-			Password:                "pass",
+			UrlOverride:             security.NewSensitiveString("https://example.com"),
+			User:                    security.NewSensitiveString("user"),
+			Password:                security.NewSensitiveString("pass"),
 			FullDataRefreshInterval: 50,
 			PriceRefreshInterval:    65,
 		})
 
 		require.Equal(t, 50*time.Second, config.FullDataInterval)
 		require.Equal(t, 65*time.Second, config.PriceUpdateInterval)
-		require.Equal(t, "https://example.com", config.ProxyURL)
-		require.Equal(t, "user", config.User)
-		require.Equal(t, "pass", config.Password)
+		require.Equal(t, "https://example.com", config.UrlOverride.Reveal())
+		require.Equal(t, "user", config.User.Reveal())
+		require.Equal(t, "pass", config.Password.Reveal())
 		require.Equal(t, true, config.AllowGzip)
 		require.Equal(t, true, config.AllowETag)
 	}

--- a/services/wallet/leaderboard/config_test.go
+++ b/services/wallet/leaderboard/config_test.go
@@ -13,7 +13,7 @@ import (
 func TestServiceConfigValidate(t *testing.T) {
 	{
 		// Zero intervals
-		config := NewLeaderbordConfig(params.MarketDataProxyConfig{
+		config := NewLeaderboardConfig(params.MarketDataProxyConfig{
 			UrlOverride:             security.NewSensitiveString("https://example.com"),
 			User:                    security.NewSensitiveString("user"),
 			Password:                security.NewSensitiveString("pass"),
@@ -32,7 +32,7 @@ func TestServiceConfigValidate(t *testing.T) {
 
 	{
 		// Negative intervals
-		config := NewLeaderbordConfig(params.MarketDataProxyConfig{
+		config := NewLeaderboardConfig(params.MarketDataProxyConfig{
 			UrlOverride:             security.NewSensitiveString("https://example.com"),
 			User:                    security.NewSensitiveString("user"),
 			Password:                security.NewSensitiveString("pass"),
@@ -51,7 +51,7 @@ func TestServiceConfigValidate(t *testing.T) {
 
 	{
 		// Custom intervals
-		config := NewLeaderbordConfig(params.MarketDataProxyConfig{
+		config := NewLeaderboardConfig(params.MarketDataProxyConfig{
 			UrlOverride:             security.NewSensitiveString("https://example.com"),
 			User:                    security.NewSensitiveString("user"),
 			Password:                security.NewSensitiveString("pass"),

--- a/services/wallet/leaderboard/proxy_host_test.go
+++ b/services/wallet/leaderboard/proxy_host_test.go
@@ -1,0 +1,72 @@
+package leaderboard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMarketProxyHost(t *testing.T) {
+	tests := []struct {
+		name        string
+		customUrl   string
+		stageName   string
+		expectedUrl string
+	}{
+		{
+			name:        "Empty custom URL with test stage",
+			customUrl:   "",
+			stageName:   "test",
+			expectedUrl: "https://test.market.status.im",
+		},
+		{
+			name:        "Empty custom URL with prod stage - should still use test",
+			customUrl:   "",
+			stageName:   "prod",
+			expectedUrl: "https://test.market.status.im",
+		},
+		{
+			name:        "Empty custom URL with random stage - should still use test",
+			customUrl:   "",
+			stageName:   "staging",
+			expectedUrl: "https://test.market.status.im",
+		},
+		{
+			name:        "Custom URL provided - should use custom URL",
+			customUrl:   "https://custom-market.example.com",
+			stageName:   "test",
+			expectedUrl: "https://custom-market.example.com",
+		},
+		{
+			name:        "Custom URL with trailing slash - should trim",
+			customUrl:   "https://custom-market.example.com/",
+			stageName:   "test",
+			expectedUrl: "https://custom-market.example.com",
+		},
+		{
+			name:        "Custom URL with multiple trailing slashes - should trim all",
+			customUrl:   "https://custom-market.example.com///",
+			stageName:   "test",
+			expectedUrl: "https://custom-market.example.com",
+		},
+		{
+			name:        "Custom localhost URL",
+			customUrl:   "http://localhost:8080",
+			stageName:   "dev",
+			expectedUrl: "http://localhost:8080",
+		},
+		{
+			name:        "Empty stage name with empty custom URL",
+			customUrl:   "",
+			stageName:   "",
+			expectedUrl: "https://test.market.status.im",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getMarketProxyHost(tt.customUrl, tt.stageName)
+			require.Equal(t, tt.expectedUrl, result)
+		})
+	}
+}

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -209,7 +209,7 @@ func NewService(
 
 	routeExecutionManager := routeexecution.NewManager(db, feed, router, transactionManager, transferController)
 
-	leaderboardConfig := leaderboard.NewLeaderbordConfig(config.WalletConfig.MarketDataProxyConfig)
+	leaderboardConfig := leaderboard.NewLeaderboardConfig(config.WalletConfig.MarketDataProxyConfig)
 	leaderboardService := leaderboard.NewMarketDataService(leaderboardConfig, db, feed)
 
 	return &Service{


### PR DESCRIPTION
This PR adds a new function `getMarketProxyHost` for generating market proxy URLs, similar to the existing `getProxyHost` function in `api/default_networks.go`.

- Tests
- Always use "test" subdomain (prod commented out for future deployment)
- Fix config_test.go to use security.SensitiveString properly

fixes #6599

