### PR TITLE
perf(envelopes)_: only cache the hash and Processed status instead of whole envelope

### DIFF
--- a/wakuv2/common/message.go
+++ b/wakuv2/common/message.go
@@ -3,7 +3,6 @@ package common
 import (
 	"crypto/ecdsa"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -59,8 +58,6 @@ type ReceivedMessage struct {
 	SymKeyHash common.Hash // The Keccak256Hash of the key
 
 	hash common.Hash
-
-	Processed atomic.Bool
 }
 
 // EnvelopeError code and optional description of the error.


### PR DESCRIPTION
Fixes #6523

Changes the envelopeCache to store a bool instead of a full envelope. That bool represents whether the envelope has been Processed. This is sufficient info for the code to process envelopes the same way as before. Only one test was affected by this. Other tests were just cleaned up and made simpler by that change, but still test as much.
