### PR TITLE
test_: fix flucky test_one_to_one_message_reactions

### DIFF
--- a/tests-functional/schemas/wakuext_sendEmojiReactionRetraction
+++ b/tests-functional/schemas/wakuext_sendEmojiReactionRetraction
@@ -163,7 +163,6 @@
                                     "chatId",
                                     "clock",
                                     "compressedKey",
-                                    "contactRequestState",
                                     "contentType",
                                     "displayName",
                                     "emojiHash",


### PR DESCRIPTION
Fixed flucky `test_one_to_one_message_reactions` by removing property `contactRequestState` from required list in wakuext_sendEmojiReactionRetraction schema

