### PR TITLE
test_: remove contactRequestState from required list

### DIFF
--- a/tests-functional/schemas/wakuext_sendEmojiReactionRetraction
+++ b/tests-functional/schemas/wakuext_sendEmojiReactionRetraction
@@ -163,7 +163,6 @@
                                     "chatId",
                                     "clock",
                                     "compressedKey",
-                                    "contactRequestState",
                                     "contentType",
                                     "displayName",
                                     "emojiHash",


### PR DESCRIPTION
Test `test_one_to_one_message_reactions` is flucky because schema `/schemas/wakuext_sendEmojiReactionRetraction` used for validation contains property `contactRequestState` as required while it should not be required. This PR removes the property from the required list.
