### PR TITLE
feat(wallet)_: ensure empty token lists are initialized to avoid nil references

### DIFF
--- a/services/wallet/token/token-lists/builder.go
+++ b/services/wallet/token/token-lists/builder.go
@@ -42,7 +42,19 @@ func (t *TokenLists) rebuildTokensMap(fetchedLists []fetcher.FetchedTokenList) e
 	// temporary soltion to avoid token collisions
 	t.solveCollision()
 
+	t.ensureEmptyTokenListsAreNotNil()
+
 	return nil
+}
+
+func (t *TokenLists) ensureEmptyTokenListsAreNotNil() {
+	t.tokensListsMu.RLock()
+	defer t.tokensListsMu.RUnlock()
+	for _, list := range t.tokensLists {
+		if len(list.Tokens) == 0 {
+			list.Tokens = make([]*tokenTypes.Token, 0)
+		}
+	}
 }
 
 func getDefaultTokensLists() []fetcher.FetchedTokenList {


### PR DESCRIPTION
Added a new method to ensure that empty token lists are not nil by initializing them to an empty slice. This ensures having tokens list in the json representation as an empty array `[]` rather than `null` value.