### PR TITLE
feat_: push fleets config parameter

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -138,7 +138,14 @@ func initializeApplication(requestJSON string) string {
 	}
 
 	if request.WakuFleetsConfigFilePath != "" {
-		err = params.LoadFleetsFromFile(request.WakuFleetsConfigFilePath)
+		err = params.LoadWakuFleetsFromFile(request.WakuFleetsConfigFilePath)
+		if err != nil {
+			return makeJSONResponse(err)
+		}
+	}
+
+	if request.PushFleetsConfigFilePath != "" {
+		err = params.LoadPushFleetsFromFile(request.PushFleetsConfigFilePath)
 		if err != nil {
 			return makeJSONResponse(err)
 		}

--- a/params/cluster.go
+++ b/params/cluster.go
@@ -28,7 +28,7 @@ type FleetInfo struct {
 type FleetsMap map[string]FleetInfo
 
 // DefaultWakuNodes is a list of "supported" fleets. This list is populated to clients UI settings.
-var supportedFleets = FleetsMap{
+var supportedWakuFleets = FleetsMap{
 	FleetStatusStaging: {
 		ClusterID: 16,
 		WakuNodes: []string{
@@ -193,8 +193,8 @@ var defaultPushNotificationServers = []string{
 	"5ffc34d5ffda180d94cd3974d9ed2bb082ede68f342babdbe801ceffb7da902087d43f9aa961c7b85029358874c08ef04ecad9f1d95a1f0e448cbdd5d04350c7",
 }
 
-func loadFleetsFromFile(filepath string) (FleetsMap, error) {
-	// Read the JSON file to populate the supportedFleets map
+func loadWakuFleetsFromFile(filepath string) (FleetsMap, error) {
+	// Read the JSON file to populate the supportedWakuFleets map
 	file, err := os.Open(filepath)
 	if err != nil {
 		err = pkgerrors.Wrap(err, "failed to open fleets json file")
@@ -215,39 +215,69 @@ func loadFleetsFromFile(filepath string) (FleetsMap, error) {
 	return overrideFleets, nil
 }
 
-func LoadFleetsFromFile(filepath string) error {
-	fleetsMap, err := loadFleetsFromFile(filepath)
+func LoadWakuFleetsFromFile(filepath string) error {
+	fleetsMap, err := loadWakuFleetsFromFile(filepath)
 	if err != nil {
 		return err
 	}
 
-	supportedFleets = fleetsMap
+	supportedWakuFleets = fleetsMap
+	return nil
+}
+
+func loadPushFleetsFromFile(filepath string) ([]string, error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		err = pkgerrors.Wrap(err, "failed to open push notifications json file")
+		return nil, err
+	}
+
+	defer file.Close()
+
+	var overridePushNotificationsServers []string
+	decoder := json.NewDecoder(file)
+
+	err = decoder.Decode(&overridePushNotificationsServers)
+	if err != nil {
+		err = pkgerrors.Wrap(err, "failed to decode push notifications json file")
+		return nil, err
+	}
+
+	return overridePushNotificationsServers, err
+}
+
+func LoadPushFleetsFromFile(filepath string) error {
+	pushNotifications, err := loadPushFleetsFromFile(filepath)
+	if err != nil {
+		return err
+	}
+	defaultPushNotificationServers = pushNotifications
 	return nil
 }
 
 func DefaultWakuNodes(fleet string) []string {
-	return supportedFleets[fleet].WakuNodes
+	return supportedWakuFleets[fleet].WakuNodes
 }
 
 func DefaultDiscV5Nodes(fleet string) []string {
-	return supportedFleets[fleet].DiscV5BootstrapNodes
+	return supportedWakuFleets[fleet].DiscV5BootstrapNodes
 }
 
 func DefaultClusterID(fleet string) uint16 {
-	return supportedFleets[fleet].ClusterID
+	return supportedWakuFleets[fleet].ClusterID
 }
 
 func IsFleetSupported(fleet string) bool {
-	_, ok := supportedFleets[fleet]
+	_, ok := supportedWakuFleets[fleet]
 	return ok
 }
 
 func GetSupportedFleets() FleetsMap {
-	return supportedFleets
+	return supportedWakuFleets
 }
 
 func DefaultStoreNodes(fleet string) []wakutypes.Mailserver {
-	return supportedFleets[fleet].StoreNodes
+	return supportedWakuFleets[fleet].StoreNodes
 }
 
 func DefaultPushNotificationServers() []string {

--- a/params/cluster_test.go
+++ b/params/cluster_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLoadFleetsFromFile tests the loadFleetsFromFile function.
+// TestLoadFleetsFromFile tests the loadWakuFleetsFromFile function.
 func TestLoadFleetsFromFile(t *testing.T) {
 	t.Run("valid file", func(t *testing.T) {
 		// Arrange: Create a temporary valid JSON file.
@@ -33,7 +33,7 @@ func TestLoadFleetsFromFile(t *testing.T) {
 		require.NoError(t, err)
 
 		// Act: Call the function.
-		result, err := loadFleetsFromFile(tempFile.Name())
+		result, err := loadWakuFleetsFromFile(tempFile.Name())
 
 		// Assert: Check the error.
 		require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestLoadFleetsFromFile(t *testing.T) {
 		nonExistentFile := filepath.Join(os.TempDir(), "non_existent_file.json")
 
 		// Act: Call the function.
-		_, err := loadFleetsFromFile(nonExistentFile)
+		_, err := loadWakuFleetsFromFile(nonExistentFile)
 
 		// Assert: Check the error.
 		require.Error(t, err)
@@ -63,7 +63,7 @@ func TestLoadFleetsFromFile(t *testing.T) {
 		tempFile.Close()
 
 		// Act: Call the function.
-		_, err = loadFleetsFromFile(tempFile.Name())
+		_, err = loadWakuFleetsFromFile(tempFile.Name())
 
 		// Assert: Check the error.
 		require.Error(t, err)

--- a/params/cluster_test.go
+++ b/params/cluster_test.go
@@ -70,3 +70,62 @@ func TestLoadFleetsFromFile(t *testing.T) {
 		require.ErrorContains(t, err, "invalid character") // Match JSON parsing error.
 	})
 }
+
+// TestLoadPushFleetsFromFile tests the loadPushFleetsFromFile function.
+func TestLoadPushFleetsFromFile(t *testing.T) {
+	t.Run("valid file", func(t *testing.T) {
+		// Arrange: Create a temporary valid JSON file.
+		tempFile, err := os.CreateTemp("", "fleets*.json")
+		require.NoError(t, err)
+		defer os.Remove(tempFile.Name())
+
+		// Write valid JSON data into the temp file.
+		validFleets := []string{
+			// There's no public key validation at this stage, so we can use any string.
+			gofakeit.LetterN(5),
+			gofakeit.LetterN(5),
+			gofakeit.LetterN(5),
+		}
+		err = json.NewEncoder(tempFile).Encode(validFleets)
+		require.NoError(t, err)
+		err = tempFile.Close()
+		require.NoError(t, err)
+
+		// Act: Call the function.
+		result, err := loadPushFleetsFromFile(tempFile.Name())
+
+		// Assert: Check the error.
+		require.NoError(t, err)
+		assert.Equal(t, validFleets, result)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		// Arrange: Use a non-existent file path.
+		nonExistentFile := filepath.Join(os.TempDir(), "non_existent_file.json")
+
+		// Act: Call the function.
+		_, err := loadPushFleetsFromFile(nonExistentFile)
+
+		// Assert: Check the error.
+		require.Error(t, err)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		// Arrange: Create a temporary file with invalid JSON.
+		tempFile, err := os.CreateTemp("", "malformed*.json")
+		require.NoError(t, err)
+		defer os.Remove(tempFile.Name())
+
+		_, err = tempFile.WriteString("{ invalid json }")
+		require.NoError(t, err)
+		tempFile.Close()
+
+		// Act: Call the function.
+		_, err = loadPushFleetsFromFile(tempFile.Name())
+
+		// Assert: Check the error.
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid character") // Match JSON parsing error.
+	})
+}

--- a/protocol/pushnotificationclient/client.go
+++ b/protocol/pushnotificationclient/client.go
@@ -1569,7 +1569,7 @@ func (c *Client) registrationLoop() error {
 			return err
 		}
 		if len(servers) == 0 {
-			c.config.Logger.Debug("nothing to do, quitting registration loop")
+			c.config.Logger.Debug("no push notification servers found, quitting registration loop")
 			return nil
 		}
 

--- a/protocol/pushnotificationserver/server.go
+++ b/protocol/pushnotificationserver/server.go
@@ -19,7 +19,7 @@ import (
 )
 
 const encryptedPayloadKeyLength = 16
-const defaultGorushURL = "https://gorush.infra.status.im/"
+const DefaultGorushURL = "https://gorush.infra.status.im/"
 
 var errUnhandledPushNotificationType = errors.New("unhandled push notification type")
 
@@ -43,7 +43,7 @@ type Server struct {
 
 func New(config *Config, persistence Persistence, messageSender *common.MessageSender) *Server {
 	if len(config.GorushURL) == 0 {
-		config.GorushURL = defaultGorushURL
+		config.GorushURL = DefaultGorushURL
 
 	}
 	return &Server{persistence: persistence, config: config, messageSender: messageSender}

--- a/protocol/pushnotificationserver/server.go
+++ b/protocol/pushnotificationserver/server.go
@@ -167,7 +167,7 @@ func (s *Server) HandlePushNotificationRequest(publicKey *ecdsa.PublicKey,
 	}
 	err = s.sendPushNotification(requestsAndRegistrations)
 	if err != nil {
-		s.config.Logger.Error("failed to send go rush notification", zap.Error(err))
+		s.config.Logger.Error("failed to send gorush notification", zap.Error(err))
 		return err
 	}
 	encodedMessage, err := proto.Marshal(response)

--- a/protocol/requests/initialize_application.go
+++ b/protocol/requests/initialize_application.go
@@ -35,6 +35,10 @@ type InitializeApplication struct {
 	// File structure must be as params.FleetsMap.
 	// When successfully loaded, overrides all hard-coded fleets with file contents.
 	WakuFleetsConfigFilePath string `json:"wakuFleetsConfigFilePath"`
+
+	// PushNotificationsConfigFilePath specifies the file path for configuring push notifications servers.
+	// File structure must be as params.PushNotificationsFleet.
+	PushFleetsConfigFilePath string `json:"pushFleetsConfigFilePath"`
 }
 
 func (i *InitializeApplication) Validate() error {

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -192,8 +192,10 @@ class StatusBackend(RpcClient, SignalClient):
             "logEnabled": True,
             "logLevel": "DEBUG",
             "apiLogging": True,
+            "wakuFleetsConfigFilePath": option.waku_fleets_config,
+            "pushFleetsConfigFilePath": option.push_fleets_config,
         }
-        data["wakuFleetsConfigFilePath"] = option.waku_fleets_config
+
         return self.api_valid_request(method, data)
 
     def _set_networks(self, data, **kwargs):

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -53,6 +53,12 @@ def pytest_addoption(parser):
         help="Waku fleet to be used. Default: --waku-fleet=status-go.test",
         default="status-go.test",
     )
+    parser.addoption(
+        "--push-fleets-config",
+        action="store",
+        help="Path to a local JSON file with Push Notifications fleets configuration. Default value is a path to config in Docker to run 1 pn-server",
+        default="",
+    )
 
 
 @dataclass


### PR DESCRIPTION
Required for:
- https://github.com/status-im/status-go/issues/6503

# Description

1. Added ability to override push notification servers list.
Implemented in the same way as to override waku fleets.

2. Also exported `DefaultGorushURL`. 
Not related to the PR itself, but required for https://github.com/status-im/status-go/issues/6503

3. Minor log messages improvements