### PR TITLE
fix_: add unit tests for message signing and recovery in personal api

### DIFF
--- a/services/personal/service.go
+++ b/services/personal/service.go
@@ -85,7 +85,10 @@ func (s *Service) Sign(rpcParams SignParams, verifiedAccount *accounttypes.Selec
 	var dBytes []byte
 	switch d := rpcParams.Data.(type) {
 	case string:
-		dBytes = []byte(d)
+		dBytes, err = hexutil.Decode(rpcParams.Data.(string))
+		if err != nil {
+			return types.HexBytes{}, err
+		}
 	case []byte:
 		dBytes = d
 	case byte:

--- a/services/personal/service_test.go
+++ b/services/personal/service_test.go
@@ -1,0 +1,94 @@
+package personal
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/status-im/status-go/account/types"
+	"github.com/status-im/status-go/eth-node/crypto"
+	ethtypes "github.com/status-im/status-go/eth-node/types"
+
+	"github.com/status-im/extkeys"
+
+	"github.com/stretchr/testify/require"
+)
+
+func generateMessageToSign(t *testing.T) string {
+	requestID := "0x240235eb861041795bc84ebe837569f08f8306a23f3f377a2977bc18eba76326"
+	requestIDBytes, err := hexutil.Decode(requestID)
+	require.NoError(t, err)
+
+	communityID := "0x02abc53deca7213ef265487b63715d226f3f31853e08636f822d74b9ebaddefb47"
+	communityIDBytes, err := hexutil.Decode(communityID)
+	require.NoError(t, err)
+
+	identityPublicKeyCompressed := "0x03c8eec7e5b7ad01693376529387ae1f097c9967f161d745bf99318b321b3e7800"
+	identityPublicKeyCompressedBytes, err := hexutil.Decode(identityPublicKeyCompressed)
+	require.NoError(t, err)
+
+	return ethtypes.EncodeHex(crypto.Keccak256(identityPublicKeyCompressedBytes, communityIDBytes, requestIDBytes))
+}
+
+func generateAccountForSigning(t *testing.T) *types.SelectedExtKey {
+	seedPhrase := "inch describe nothing prepare salon foster market fabric bottom type trial glooom"
+	mnemonic := extkeys.NewMnemonic()
+	seed := mnemonic.MnemonicSeed(seedPhrase, "")
+
+	masterKey, err := extkeys.NewMaster(seed)
+	require.NoError(t, err)
+
+	extendedKey, err := masterKey.ChildForPurpose(extkeys.KeyPurposeWallet, 0)
+	require.NoError(t, err)
+
+	privateKeyECDSA := extendedKey.ToECDSA()
+	address := crypto.PubkeyToAddress(privateKeyECDSA.PublicKey)
+
+	return &types.SelectedExtKey{
+		AccountKey: &ethtypes.Key{PrivateKey: privateKeyECDSA},
+		Address:    address,
+	}
+}
+
+func TestSignAndRecover(t *testing.T) {
+	expectedMessageToSign := "0x32a4ed227797845663dce42d5f595ab26aab43bb5bb98fca2c4599b4c255d18b"
+
+	generatedMessageToSign := generateMessageToSign(t)
+	require.Equal(t, expectedMessageToSign, generatedMessageToSign)
+
+	accountForSigning := generateAccountForSigning(t)
+
+	personalService := New()
+
+	// Sign the message as string
+	signature, err := personalService.Sign(SignParams{
+		Data: generatedMessageToSign,
+	}, accountForSigning)
+	require.NoError(t, err)
+
+	// Recover the address from the signed string message
+	recoveredAddress, err := personalService.Recover(RecoverParams{
+		Message:   generatedMessageToSign,
+		Signature: hexutil.Encode(signature),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, accountForSigning.Address.Hex(), recoveredAddress.Hex())
+
+	// Sign the message as bytes
+	generatedMessageToSignBytes, err := hexutil.Decode(generatedMessageToSign)
+	require.NoError(t, err)
+
+	signature, err = personalService.Sign(SignParams{
+		Data: generatedMessageToSignBytes,
+	}, accountForSigning)
+	require.NoError(t, err)
+
+	// Recover the address from the signed bytes message
+	recoveredAddress, err = personalService.Recover(RecoverParams{
+		Message:   generatedMessageToSign,
+		Signature: hexutil.Encode(signature),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, accountForSigning.Address.Hex(), recoveredAddress.Hex())
+}


### PR DESCRIPTION
- Updated the `Sign` method in `api.go` to handle string data decoding properly.
- Introduced a new test file `api_test.go` for the personal API.