### PR TITLE
fix_: misc collectibles fixes

### DIFF
--- a/services/wallet/collectibles/commands.go
+++ b/services/wallet/collectibles/commands.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	fetchLimit                          = 50 // Limit number of collectibles we fetch per provider call
-	accountOwnershipUpdateInterval      = 60 * time.Minute
-	accountOwnershipUpdateDelayInterval = 30 * time.Second
+	fetchLimit                               = 50 // Limit number of collectibles we fetch per provider call
+	accountOwnershipUpdateInterval           = 60 * time.Minute
+	accountOwnershipUpdateShortDelayInterval = 10 * time.Second // Delay used to "debounce" fetches triggered by settings changes
+	accountOwnershipUpdateDelayInterval      = 30 * time.Second // Delay used to "debounce" fetches triggered by different detected transfers
 )
 
 type OwnershipState = int
@@ -132,15 +133,23 @@ func (c *periodicRefreshOwnedCollectiblesCommand) loadOwnedCollectibles(ctx cont
 
 	c.state.Store(OwnershipStateUpdating)
 	defer func() {
-		if command.err != nil {
+		if command.err != nil && !errors.Is(command.err, context.Canceled) {
 			c.state.Store(OwnershipStateError)
 		} else {
 			c.state.Store(OwnershipStateIdle)
 		}
 	}()
 
-	c.group.Add(command.Command())
+	delayTimer := time.NewTicker(accountOwnershipUpdateShortDelayInterval)
+	defer delayTimer.Stop()
+	select {
+	case <-delayTimer.C:
+		break
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 
+	c.group.Add(command.Command())
 	select {
 	case ownedCollectiblesChange := <-ownedCollectiblesChangeCh:
 		if c.ownedCollectiblesChangeCb != nil {

--- a/services/wallet/collectibles/ownership_db.go
+++ b/services/wallet/collectibles/ownership_db.go
@@ -58,31 +58,32 @@ func insertTmpOwnership(
 	chainID w_common.ChainID,
 	ownerAddress common.Address,
 	balancesPerContractAdddress thirdparty.TokenBalancesPerContractAddress,
+	uuid string,
 ) error {
 	// Put old/new ownership data into temp tables
 	// NOTE: Temp table CREATE doesn't work with prepared statements,
 	// so we have to use Exec directly
-	_, err := db.Exec(`
-		DROP TABLE IF EXISTS temp.old_collectibles_ownership_cache; 
-		CREATE TABLE temp.old_collectibles_ownership_cache(
+	_, err := db.Exec(fmt.Sprintf(`
+		DROP TABLE IF EXISTS temp.old_collectibles_ownership_cache_%[1]s; 
+		CREATE TABLE temp.old_collectibles_ownership_cache_%[1]s(
 			contract_address VARCHAR NOT NULL,
 			token_id BLOB NOT NULL,
 			balance BLOB NOT NULL
 		);
-		DROP TABLE IF EXISTS temp.new_collectibles_ownership_cache; 
-		CREATE TABLE temp.new_collectibles_ownership_cache(
+		DROP TABLE IF EXISTS temp.new_collectibles_ownership_cache_%[1]s; 
+		CREATE TABLE temp.new_collectibles_ownership_cache_%[1]s(
 			contract_address VARCHAR NOT NULL,
 			token_id BLOB NOT NULL,
 			balance BLOB NOT NULL
-		);`)
+		);`, uuid))
 	if err != nil {
 		return err
 	}
 
-	insertTmpOldOwnership, err := db.Prepare(`
-			INSERT INTO temp.old_collectibles_ownership_cache
+	insertTmpOldOwnership, err := db.Prepare(fmt.Sprintf(`
+			INSERT INTO temp.old_collectibles_ownership_cache_%[1]s
 			SELECT contract_address, token_id, balance FROM collectibles_ownership_cache
-			WHERE chain_id = ? AND owner_address = ?`)
+			WHERE chain_id = ? AND owner_address = ?`, uuid))
 	if err != nil {
 		return err
 	}
@@ -93,9 +94,9 @@ func insertTmpOwnership(
 		return err
 	}
 
-	insertTmpNewOwnership, err := db.Prepare(`
-			INSERT INTO temp.new_collectibles_ownership_cache (contract_address, token_id, balance) 
-			VALUES (?, ?, ?)`)
+	insertTmpNewOwnership, err := db.Prepare(fmt.Sprintf(`
+			INSERT INTO temp.new_collectibles_ownership_cache_%[1]s (contract_address, token_id, balance) 
+			VALUES (?, ?, ?)`, uuid))
 	if err != nil {
 		return err
 	}
@@ -121,16 +122,17 @@ func removeOldAddressOwnership(
 	creator sqlite.StatementCreator,
 	chainID w_common.ChainID,
 	ownerAddress common.Address,
+	uuid string,
 ) ([]thirdparty.CollectibleUniqueID, error) {
 	// Find collectibles in the DB that are not in the temp table
 	removedQuery, err := creator.Prepare(fmt.Sprintf(`
-	SELECT %d, tOld.contract_address, tOld.token_id 
-		FROM temp.old_collectibles_ownership_cache tOld
-		LEFT JOIN temp.new_collectibles_ownership_cache tNew ON
+	SELECT %[2]d, tOld.contract_address, tOld.token_id 
+		FROM temp.old_collectibles_ownership_cache_%[1]s tOld
+		LEFT JOIN temp.new_collectibles_ownership_cache_%[1]s tNew ON
 			tOld.contract_address = tNew.contract_address AND tOld.token_id = tNew.token_id
 		WHERE 
 			tNew.contract_address IS NULL
-	`, chainID))
+	`, uuid, chainID))
 	if err != nil {
 		return nil, err
 	}
@@ -172,16 +174,17 @@ func updateChangedAddressOwnership(
 	creator sqlite.StatementCreator,
 	chainID w_common.ChainID,
 	ownerAddress common.Address,
+	uuid string,
 ) ([]thirdparty.CollectibleUniqueID, error) {
 	// Find collectibles in the temp table that are in the DB and have a different balance
 	updatedQuery, err := creator.Prepare(fmt.Sprintf(`
-		SELECT %d, tNew.contract_address, tNew.token_id 
-		FROM temp.new_collectibles_ownership_cache tNew
-		LEFT JOIN temp.old_collectibles_ownership_cache tOld ON
+		SELECT %[2]d, tNew.contract_address, tNew.token_id 
+		FROM temp.new_collectibles_ownership_cache_%[1]s tNew
+		LEFT JOIN temp.old_collectibles_ownership_cache_%[1]s tOld ON
 			tOld.contract_address = tNew.contract_address AND tOld.token_id = tNew.token_id
 		WHERE 
 			tOld.contract_address IS NOT NULL AND tOld.balance != tNew.balance
-	`, chainID))
+	`, uuid, chainID))
 	if err != nil {
 		return nil, err
 	}
@@ -198,13 +201,13 @@ func updateChangedAddressOwnership(
 		return nil, err
 	}
 
-	updateOwnership, err := creator.Prepare(`
+	updateOwnership, err := creator.Prepare(fmt.Sprintf(`
 		UPDATE collectibles_ownership_cache
 		SET balance = (SELECT tNew.balance
-			FROM temp.new_collectibles_ownership_cache tNew
+			FROM temp.new_collectibles_ownership_cache_%[1]s tNew
 			WHERE tNew.contract_address = collectibles_ownership_cache.contract_address AND tNew.token_id = collectibles_ownership_cache.token_id)
 		WHERE chain_id = ? AND owner_address = ? AND contract_address = ? AND token_id = ?
-	`)
+	`, uuid))
 	if err != nil {
 		return nil, err
 	}
@@ -228,16 +231,17 @@ func insertNewAddressOwnership(
 	creator sqlite.StatementCreator,
 	chainID w_common.ChainID,
 	ownerAddress common.Address,
+	uuid string,
 ) ([]thirdparty.CollectibleUniqueID, error) {
 	// Find collectibles in the temp table that are not in the DB
 	insertedQuery, err := creator.Prepare(fmt.Sprintf(`
-		SELECT %d, tNew.contract_address, tNew.token_id 
-		FROM temp.new_collectibles_ownership_cache tNew
-		LEFT JOIN temp.old_collectibles_ownership_cache tOld ON
+		SELECT %[2]d, tNew.contract_address, tNew.token_id 
+		FROM temp.new_collectibles_ownership_cache_%[1]s tNew
+		LEFT JOIN temp.old_collectibles_ownership_cache_%[1]s tOld ON
 			tOld.contract_address = tNew.contract_address AND tOld.token_id = tNew.token_id
 		WHERE 
 			tOld.contract_address IS NULL
-	`, chainID))
+	`, uuid, chainID))
 	if err != nil {
 		return nil, err
 	}
@@ -257,11 +261,11 @@ func insertNewAddressOwnership(
 	insertOwnership, err := creator.Prepare(fmt.Sprintf(`
 		INSERT INTO collectibles_ownership_cache
 		SELECT
-			%d, tNew.contract_address, tNew.token_id, X'%s', tNew.balance, NULL
-		FROM temp.new_collectibles_ownership_cache tNew
+			%[2]d, tNew.contract_address, tNew.token_id, X'%[3]s', tNew.balance, NULL
+		FROM temp.new_collectibles_ownership_cache_%[1]s tNew
 		WHERE
 			tNew.contract_address = ? AND tNew.token_id = ?
-	`, chainID, ownerAddress.Hex()[2:]))
+	`, uuid, chainID, ownerAddress.Hex()[2:]))
 	if err != nil {
 		return nil, err
 	}
@@ -283,18 +287,19 @@ func updateAddressOwnership(
 	tx sqlite.StatementCreator,
 	chainID w_common.ChainID,
 	ownerAddress common.Address,
+	uuid string,
 ) (removedIDs, updatedIDs, insertedIDs []thirdparty.CollectibleUniqueID, err error) {
-	removedIDs, err = removeOldAddressOwnership(tx, chainID, ownerAddress)
+	removedIDs, err = removeOldAddressOwnership(tx, chainID, ownerAddress, uuid)
 	if err != nil {
 		return
 	}
 
-	updatedIDs, err = updateChangedAddressOwnership(tx, chainID, ownerAddress)
+	updatedIDs, err = updateChangedAddressOwnership(tx, chainID, ownerAddress, uuid)
 	if err != nil {
 		return
 	}
 
-	insertedIDs, err = insertNewAddressOwnership(tx, chainID, ownerAddress)
+	insertedIDs, err = insertNewAddressOwnership(tx, chainID, ownerAddress, uuid)
 	if err != nil {
 		return
 	}
@@ -380,7 +385,9 @@ func (o *OwnershipDB) Update(chainID w_common.ChainID, ownerAddress common.Addre
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	err = insertTmpOwnership(o.db, chainID, ownerAddress, balances)
+	uuid := fmt.Sprintf("%d_%s", chainID, ownerAddress.Hex())
+
+	err = insertTmpOwnership(o.db, chainID, ownerAddress, balances, uuid)
 	if err != nil {
 		return
 	}
@@ -401,7 +408,7 @@ func (o *OwnershipDB) Update(chainID w_common.ChainID, ownerAddress common.Addre
 	}()
 
 	// Compare tmp and current ownership tables and update the current one
-	removedIDs, updatedIDs, insertedIDs, err = updateAddressOwnership(tx, chainID, ownerAddress)
+	removedIDs, updatedIDs, insertedIDs, err = updateAddressOwnership(tx, chainID, ownerAddress, uuid)
 	if err != nil {
 		return
 	}

--- a/services/wallet/thirdparty/collectibles/rarible/client_int_test.go
+++ b/services/wallet/thirdparty/collectibles/rarible/client_int_test.go
@@ -47,6 +47,36 @@ func (s *RaribleClientIntegrationSuite) TestAPIKeysAvailable() {
 	assert.NotEmpty(s.T(), s.client.testnetAPIKey)
 }
 
+func (s *RaribleClientIntegrationSuite) TestGetOwnedCollectibles() {
+	// TODO #13953: Enable for nightly runs
+	s.T().Skip("integration test")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	collectibles, err := s.client.FetchAllAssetsByOwner(
+		ctx,
+		walletCommon.ChainID(walletCommon.EthereumMainnet),
+		common.HexToAddress("0x06012c8cf97BEaD5deAe237070F9587f8E7A266d"), // CryptoKitties contract address
+		thirdparty.FetchFromStartCursor,
+		10,
+	)
+	s.Require().NoError(err)
+	s.Require().NotNil(collectibles)
+	s.Require().NotEmpty(collectibles.Items)
+
+	collectibles, err = s.client.FetchAllAssetsByOwner(
+		ctx,
+		walletCommon.ChainID(walletCommon.EthereumMainnet),
+		common.HexToAddress("0x06012c8cf97BEaD5deAe237070F9587f8E7A266d"), // CryptoKitties contract address
+		collectibles.NextCursor,
+		10,
+	)
+	s.Require().NoError(err)
+	s.Require().NotNil(collectibles)
+	s.Require().NotEmpty(collectibles.Items)
+}
+
 func (s *RaribleClientIntegrationSuite) TestSearchCollections() {
 	// TODO #13953: Enable for nightly runs
 	s.T().Skip("integration test")


### PR DESCRIPTION
status-dekstop PR: https://github.com/status-im/status-go/pull/6627/files

Couple of fixes/improvements for the collectibles service:

- Fix concurrent ownership db updates (temporary table used to detect changes is now created using a unique ID for every chainID+address)
- Add small 10s debouncer before triggering fetch from the provider to prevent multiple quick calls when settings change (network configuration, testnet mode change, accounts list change, etc)
