### PR TITLE
fix_: fetch curated communities sequentially

### DIFF
--- a/protocol/messenger_curated_communities.go
+++ b/protocol/messenger_curated_communities.go
@@ -45,6 +45,7 @@ func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
 				// Immediate execution on first run, then set to regular interval
 				interval = curatedCommunitiesUpdateInterval
 
+				logger.Debug("updating curated communities")
 				curatedCommunities, err := m.getCuratedCommunitiesFromContract()
 				if err != nil {
 					interval = communitiesUpdateFailureInterval
@@ -144,7 +145,17 @@ func (m *Messenger) fetchCuratedCommunities(curatedCommunities *communities.Cura
 
 	go func() {
 		defer gocommon.LogOnPanic()
-		_ = m.fetchCommunities(unknownCommunities)
+		m.logger.Debug("fetching unknown curated communities")
+
+		for _, community := range unknownCommunities {
+			_, _, err := m.storeNodeRequestsManager.FetchCommunity(m.ctx, community, nil)
+			if err != nil {
+				m.logger.Error("failed to fetch curated community",
+					zap.String("communityID", community.CommunityID),
+					zap.Error(err),
+				)
+			}
+		}
 	}()
 
 	return response, nil

--- a/protocol/messenger_curated_communities.go
+++ b/protocol/messenger_curated_communities.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/communities"
@@ -143,8 +144,11 @@ func (m *Messenger) fetchCuratedCommunities(curatedCommunities *communities.Cura
 		})
 	}
 
+	m.shutdownWaitGroup.Add(1)
+
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		m.logger.Debug("fetching unknown curated communities")
 
 		for _, community := range unknownCommunities {


### PR DESCRIPTION
Iterates:
- https://github.com/status-im/status-desktop/issues/18063

Develop branch fix here:
- https://github.com/status-im/status-go/pull/6649

# Description

Replaced parallel communities fetching with sequential.

Fetching many communities in parallel unnecessarily overloads the backend when creating a new account. Fetching them one by one is absolutely acceptable. 