### PR TITLE
fix_: fetch curated communities sequentially

### DIFF
--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -3248,12 +3248,6 @@ func (m *Messenger) FetchCommunity(request *FetchCommunityRequest) (*communities
 	return community, err
 }
 
-// fetchCommunities installs filter for community and requests its details from store node.
-// When response received it will be passed through signals handler.
-func (m *Messenger) fetchCommunities(communities []communities.CommunityShard) error {
-	return m.storeNodeRequestsManager.FetchCommunities(m.ctx, communities, []StoreNodeRequestOption{})
-}
-
 // passStoredCommunityInfoToSignalHandler calls signal handler with community info
 func (m *Messenger) passStoredCommunityInfoToSignalHandler(community *communities.Community) {
 	if m.config.messengerSignalsHandler == nil {

--- a/protocol/messenger_curated_communities.go
+++ b/protocol/messenger_curated_communities.go
@@ -45,6 +45,7 @@ func (m *Messenger) startCuratedCommunitiesUpdateLoop() {
 				// Immediate execution on first run, then set to regular interval
 				interval = curatedCommunitiesUpdateInterval
 
+				logger.Debug("updating curated communities")
 				curatedCommunities, err := m.getCuratedCommunitiesFromContract()
 				if err != nil {
 					interval = communitiesUpdateFailureInterval
@@ -144,7 +145,17 @@ func (m *Messenger) fetchCuratedCommunities(curatedCommunities *communities.Cura
 
 	go func() {
 		defer gocommon.LogOnPanic()
-		_ = m.fetchCommunities(unknownCommunities)
+		m.logger.Debug("fetching unknown curated communities")
+
+		for _, community := range unknownCommunities {
+			_, _, err := m.storeNodeRequestsManager.FetchCommunity(m.ctx, community, nil)
+			if err != nil {
+				m.logger.Error("failed to fetch curated community",
+					zap.String("communityID", community.CommunityID),
+					zap.Error(err),
+				)
+			}
+		}
 	}()
 
 	return response, nil

--- a/protocol/messenger_curated_communities.go
+++ b/protocol/messenger_curated_communities.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/communities"
@@ -143,8 +144,11 @@ func (m *Messenger) fetchCuratedCommunities(curatedCommunities *communities.Cura
 		})
 	}
 
+	m.shutdownWaitGroup.Add(1)
+
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		m.logger.Debug("fetching unknown curated communities")
 
 		for _, community := range unknownCommunities {

--- a/protocol/messenger_store_node_request_manager.go
+++ b/protocol/messenger_store_node_request_manager.go
@@ -127,34 +127,6 @@ func (m *StoreNodeRequestManager) FetchCommunity(ctx context.Context, community 
 	return requestCommunity(community.CommunityID, communityShard)
 }
 
-// FetchCommunities makes a FetchCommunity for each element in given `communities` list.
-// For each successfully fetched community, a `CommunityFound` event will be emitted. Ability to subscribe
-// to results is not provided, because it's not needed and would complicate the code. `FetchCommunity` can
-// be called directly if such functionality is needed.
-//
-// This function intentionally doesn't fetch multiple content topics in a single store node request. For now
-// FetchCommunities is only used for regular (once in 2 minutes) fetching of curated communities. If one of
-// those content topics is spammed with to many envelopes, then on each iteration we will have to fetch all
-// of this spam first to get the envelopes in other content topics. To avoid this we keep independent requests
-// for each content topic.
-func (m *StoreNodeRequestManager) FetchCommunities(ctx context.Context, communities []communities.CommunityShard, opts []StoreNodeRequestOption) error {
-	m.logger.Info("requesting communities from store node", zap.Any("communities", communities))
-
-	// when fetching multiple communities we don't wait for the response
-	opts = append(opts, WithWaitForResponseOption(false))
-
-	var outErr error
-
-	for _, community := range communities {
-		_, _, err := m.FetchCommunity(ctx, community, opts)
-		if err != nil {
-			outErr = fmt.Errorf("%sfailed to create a request for community %s: %w", outErr, gocommon.TruncateWithDot(community.CommunityID), err)
-		}
-	}
-
-	return outErr
-}
-
 // FetchContact - similar to FetchCommunity
 // If a `nil` contact and a `nil` error are returned, it means that the contact wasn't found at the store node.
 func (m *StoreNodeRequestManager) FetchContact(ctx context.Context, contactID string, opts []StoreNodeRequestOption) (*Contact, StoreNodeRequestStats, error) {

--- a/protocol/messenger_storenode_request_test.go
+++ b/protocol/messenger_storenode_request_test.go
@@ -493,37 +493,6 @@ func (s *MessengerStoreNodeRequestSuite) TestRequestCommunityWithSameContentTopi
 	s.fetchCommunity(s.bob, community1.CommunityShard(), community1)
 }
 
-func (s *MessengerStoreNodeRequestSuite) TestRequestMultipleCommunities() {
-	s.createOwner()
-	s.createBob()
-
-	// Create 2 communities
-	community1 := s.createCommunity(s.owner)
-	community2 := s.createCommunity(s.owner)
-
-	fetchedCommunities := map[string]*communities.Community{}
-
-	err := WaitOnSignaledCommunityFound(s.bob,
-		func() {
-			err := s.bob.fetchCommunities([]communities.CommunityShard{
-				community1.CommunityShard(),
-				community2.CommunityShard(),
-			})
-			s.Require().NoError(err)
-		},
-		func(community *communities.Community) bool {
-			fetchedCommunities[community.IDString()] = community
-			return len(fetchedCommunities) == 2
-		},
-		1*time.Second,
-		"communities were not signalled in time",
-	)
-
-	s.Require().NoError(err)
-	s.Require().Contains(fetchedCommunities, community1.IDString())
-	s.Require().Contains(fetchedCommunities, community2.IDString())
-}
-
 func (s *MessengerStoreNodeRequestSuite) TestRequestWithoutWaitingResponse() {
 	s.createOwner()
 	s.createBob()


### PR DESCRIPTION
# Description

1. Replaced parallel communities fetching with sequential. Fetching many communities in parallel unneccesarily overloads the backend when creating a new account. Fetching them one by one is absolutely acceptable.
2. Removed the now unused `FetchCommunities` function.