### PR TITLE
feat_: status backend pprof

### DIFF
--- a/cmd/status-backend/main.go
+++ b/cmd/status-backend/main.go
@@ -19,8 +19,9 @@ import (
 )
 
 var (
-	address = flag.String("address", "127.0.0.1:0", "host:port to listen")
-	logger  = log.New("package", "status-go/cmd/status-backend")
+	address      = flag.String("address", "127.0.0.1:0", "host:port to listen")
+	pprofEnabled = flag.Bool("pprof", false, "enable pprof")
+	logger       = log.New("package", "status-go/cmd/status-backend")
 )
 
 func init() {
@@ -44,7 +45,9 @@ func main() {
 	flag.Parse()
 	go handleInterrupts()
 
-	srv := server.NewServer()
+	srv := server.NewServer(
+		server.WithProfiling(*pprofEnabled),
+	)
 	srv.Setup()
 
 	err := srv.Listen(*address)

--- a/cmd/status-backend/server/options.go
+++ b/cmd/status-backend/server/options.go
@@ -1,0 +1,19 @@
+package server
+
+type Config struct {
+	profilingEnabled bool
+}
+
+func defaultConfig() *Config {
+	return &Config{
+		profilingEnabled: false,
+	}
+}
+
+type Option func(*Config)
+
+func WithProfiling(enabled bool) func(*Config) {
+	return func(c *Config) {
+		c.profilingEnabled = enabled
+	}
+}

--- a/cmd/status-backend/server/server.go
+++ b/cmd/status-backend/server/server.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"strconv"
 	"sync"
 	"time"
@@ -26,11 +27,17 @@ type Server struct {
 	lock        sync.Mutex
 	connections map[*websocket.Conn]struct{}
 	address     string
+	config      *Config
 }
 
-func NewServer() *Server {
+func NewServer(options ...Option) *Server {
+	config := defaultConfig()
+	for _, option := range options {
+		option(config)
+	}
 	return &Server{
 		connections: make(map[*websocket.Conn]struct{}, 1),
+		config:      config,
 	}
 }
 
@@ -78,7 +85,7 @@ func (s *Server) signalHandler(data []byte) {
 	}
 }
 
-func (s *Server) Listen(address string) error {
+func (s *Server) Listen(address string, ) error {
 	if s.server != nil {
 		return errors.New("server already started")
 	}
@@ -97,6 +104,15 @@ func (s *Server) Listen(address string) error {
 	s.mux.HandleFunc("/health", api.Health)
 	s.mux.HandleFunc("/signals", s.signals)
 	s.server.Handler = s.mux
+
+	// Register pprof handlers
+	if s.config.profilingEnabled {
+		s.mux.HandleFunc("/debug/pprof/", pprof.Index)
+		s.mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		s.mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		s.mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		s.mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
 
 	s.listener, err = net.Listen("tcp", address)
 	if err != nil {

--- a/cmd/status-backend/server/server.go
+++ b/cmd/status-backend/server/server.go
@@ -86,7 +86,7 @@ func (s *Server) signalHandler(data []byte) {
 	}
 }
 
-func (s *Server) Listen(address string, ) error {
+func (s *Server) Listen(address string) error {
 	if s.server != nil {
 		return errors.New("server already started")
 	}

--- a/cmd/status-backend/server/server.go
+++ b/cmd/status-backend/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -107,6 +108,7 @@ func (s *Server) Listen(address string, ) error {
 
 	// Register pprof handlers
 	if s.config.profilingEnabled {
+		runtime.SetMutexProfileFraction(1)
 		s.mux.HandleFunc("/debug/pprof/", pprof.Index)
 		s.mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 		s.mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)


### PR DESCRIPTION
# Description

Added `--pprof` flag to enable profiling with `status-backend`.
The server is available at the same port at `/debug/pprof` endpoint