### PR TITLE
test_: option to run with real networks

### DIFF
--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -246,6 +246,15 @@ class StatusBackend(RpcClient, SignalClient):
         data["StatusProxyStageName"] = "test"
         return data
 
+    def _set_wallet_secrets(self, data):
+        if "STATUS_BUILD_INFURA_TOKEN" in os.environ:
+            data["infuraToken"] = os.environ["STATUS_BUILD_INFURA_TOKEN"]
+        if "STATUS_BUILD_INFURA_SECRET" in os.environ:
+            data["infuraSecret"] = os.environ["STATUS_BUILD_INFURA_SECRET"]
+        if "STATUS_BUILD_POKT_TOKEN" in os.environ:
+            data["poktToken"] = os.environ["STATUS_BUILD_POKT_TOKEN"]
+        return data
+
     def _set_token_overrides(self, network, token_overrides):
         if not token_overrides:
             return network
@@ -299,7 +308,9 @@ class StatusBackend(RpcClient, SignalClient):
         }
         if not option.disable_override_networks:
             self._set_networks(data, **kwargs)
+
         data = self._set_proxy_credentials(data)
+        data = self._set_wallet_secrets(data)
         return data
 
     def create_account_and_login(self, user=user_1, **kwargs):
@@ -323,6 +334,7 @@ class StatusBackend(RpcClient, SignalClient):
             "kdfIterations": 256000,
         }
         data = self._set_proxy_credentials(data)
+        data = self._set_wallet_secrets(data)
         return self.api_valid_request(method, data)
 
     def logout(self):

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -297,7 +297,8 @@ class StatusBackend(RpcClient, SignalClient):
             "wakuV2LightClient": kwargs.get("wakuV2LightClient", False),
             "wakuV2Fleet": option.waku_fleet,
         }
-        self._set_networks(data, **kwargs)
+        if not option.disable_override_networks:
+            self._set_networks(data, **kwargs)
         data = self._set_proxy_credentials(data)
         return data
 

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -62,7 +62,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--disable-override-networks",
         action="store_true",
-        help="When set, will override the networks to use Anvil. Disable to use real networks.",
+        help="When set, will disable overriding the networks to use Anvil and use default status-backend networks",
         default=False,
     )
 

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -59,6 +59,12 @@ def pytest_addoption(parser):
         help="Path to a local JSON file with Push Notifications fleets configuration. Default value is a path to config in Docker to run 1 pn-server",
         default="",
     )
+    parser.addoption(
+        "--disable-override-networks",
+        action="store_true",
+        help="When set, will override the networks to use Anvil. Disable to use real networks.",
+        default=False,
+    )
 
 
 @dataclass

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -116,6 +116,8 @@ def pytest_report_header(config):
     return [
         f"waku fleets config file: {config.option.waku_fleets_config}",
         f"waku fleet: {config.option.waku_fleet}",
+        f"push fleets config file: {config.option.push_fleets_config}",
+        f"disable override networks: {config.option.disable_override_networks}",
     ]
 
 


### PR DESCRIPTION
1. Added `--disable-networks-override` to use real networks instead of Anvil
2. Tests check these env vars for infura/grove secrets