### PR TITLE
test_: add dockerignore for test-functional build context

### DIFF
--- a/tests-functional/.dockerignore
+++ b/tests-functional/.dockerignore
@@ -1,0 +1,6 @@
+coverage/
+reports/
+__pycache__/
+*.pyc
+*.pyo
+*.log


### PR DESCRIPTION
This pull request adds new entries to the `.dockerignore` file in the `tests-functional` directory to optimize Docker builds by excluding unnecessary files and directories.
