### PR TITLE
fix(logging)_: revert buffering of `os.Stderr`

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -494,12 +494,8 @@ func (b *GethStatusBackend) ensureWalletDBOpened(account multiaccounts.Account, 
 }
 
 func (b *GethStatusBackend) SetupLogSettings() error {
-	// sync pre_login.log
-	if err := logutils.ZapLogger().Sync(); err != nil {
-		return errors.Wrap(err, "failed to sync logger")
-	}
-	logSettings := b.config.ProfileLogSettings()
-	return logutils.OverrideRootLoggerWithConfig(logSettings)
+	_ = logutils.ZapLogger().Sync()
+	return logutils.OverrideRootLoggerWithConfig(b.config.ProfileLogSettings())
 }
 
 // Deprecated: Use StartNodeWithAccount instead.
@@ -2681,10 +2677,7 @@ func (b *GethStatusBackend) Logout() error {
 // including in release builds, to help diagnose login issues.
 // related issue: https://github.com/status-im/status-mobile/issues/21501
 func (b *GethStatusBackend) switchToPreLoginLog() error {
-	err := logutils.ZapLogger().Sync()
-	if err != nil {
-		return err
-	}
+	_ = logutils.ZapLogger().Sync()
 	return logutils.OverrideRootLoggerWithConfig(b.preLoginLogConfig.ConvertToLogSettings())
 }
 

--- a/logutils/override.go
+++ b/logutils/override.go
@@ -1,7 +1,6 @@
 package logutils
 
 import (
-	"bufio"
 	"io"
 	"os"
 
@@ -59,10 +58,7 @@ func overrideCoreWithConfig(filteringCore *namespaceFilteringCore, settings LogS
 			Compress:   settings.CompressRotated,
 		}))
 	} else {
-		// run TestLoginWithKey will get error: sync /dev/stdout: bad file descriptor
-		// use bufio.NewWriter to wrap os.Stderr to fix it
-		writer := bufio.NewWriter(os.Stderr)
-		core.UpdateSyncer(zapcore.Lock(zapcore.AddSync(writer)))
+		core.UpdateSyncer(zapcore.Lock(zapcore.AddSync(os.Stderr)))
 	}
 
 	// FIXME: remove go-libp2p logging altogether


### PR DESCRIPTION
The regression was introduced in 58ed6e5, where `os.Stderr` was wrapped with `bufio.NewWriter`.

This approach doesn't work as expected because `bufio.NewWriter` requires an explicit flush unless the buffer fills up. The correct fix for the original issue is to ignore `Sync()` errors, which occur on stdout/stderr and are safe to ignore, as noted in
https://github.com/uber-go/zap/issues/328.
