### PR TITLE
test_: added local fleet to README

### DIFF
--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -33,7 +33,7 @@ Functional tests for status-go
     * Status-im contracts will be deployed to the network
 
 ### Run tests
-- In `./tests-functional` run `docker compose -f docker-compose.anvil.yml -f docker-compose.test.status-go.yml -f docker-compose.status-go.local.yml up --build --remove-orphans`, as result:
+- In `./tests-functional` run `docker compose -f docker-compose.anvil.yml -f docker-compose.test.status-go.yml -f docker-compose.status-go.local.yml -f docker-compose.waku.yml up --build --remove-orphans`, as result:
     * a container with [status-backend](https://github.com/status-im/status-go/pull/5847) will be created with endpoint exposed on `0.0.0.0:3333`
     * status-go will use [anvil](https://book.getfoundry.sh/reference/anvil/) as RPCURL with ChainID 31337 
     * Status-im contracts will be deployed to the network


### PR DESCRIPTION
This pull request updates the instructions for running functional tests in the `tests-functional/README.MD` file to include an additional Docker Compose file for Waku.

Documentation updates:

* [`tests-functional/README.MD`](diffhunk://#diff-0c72386e4a3b3ea1d542132185048ff26343afbba080746e48e52fd002ae1ac4L36-R36): Updated the command to include the `docker-compose.waku.yml` file when running Docker Compose for functional tests. This ensures that the Waku service is included in the test environment setup.