### PR TITLE
feat(backup)_: poc for local user data backups

### DIFF
--- a/api/defaults.go
+++ b/api/defaults.go
@@ -416,6 +416,10 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 		overrideApiConfig(nodeConfig, request.APIConfig)
 	}
 
+	nodeConfig.BackupConfig = params.BackupConfig{
+		DataDir: filepath.Join(nodeConfig.RootDataDir, params.BackupsRelativePath),
+	}
+
 	for _, opt := range opts {
 		if err := opt(nodeConfig); err != nil {
 			return nil, err

--- a/params/config.go
+++ b/params/config.go
@@ -395,6 +395,8 @@ type NodeConfig struct {
 
 	TorrentConfig TorrentConfig
 
+	BackupConfig BackupConfig
+
 	// RegisterTopics a list of specific topics where the peer wants to be
 	// discoverable.
 	RegisterTopics []discv5.Topic `json:"RegisterTopics"`
@@ -595,6 +597,12 @@ type TorrentConfig struct {
 	TorrentDir string
 }
 
+// BackupConfig provides configuration for the local backups
+type BackupConfig struct {
+	// DataDir is the file system folder Status should use for storing local backups.
+	DataDir string
+}
+
 // Validate validates the ShhextConfig struct and returns an error if inconsistent values are found
 func (c *ShhextConfig) Validate(validate *validator.Validate) error {
 	if err := validate.Struct(c); err != nil {
@@ -733,6 +741,10 @@ func (c *NodeConfig) UpdateWithDefaults() error {
 		if c.TorrentConfig.TorrentDir == "" {
 			c.TorrentConfig.TorrentDir = filepath.Join(c.RootDataDir, TorrentTorrentsRelativePath)
 		}
+	}
+
+	c.BackupConfig = BackupConfig{
+		DataDir: filepath.Join(c.RootDataDir, BackupsRelativePath),
 	}
 
 	return c.setDefaultPushNotificationsServers()

--- a/params/defaults.go
+++ b/params/defaults.go
@@ -8,6 +8,7 @@ const (
 
 	ArchivesRelativePath        = "data/archivedata"
 	TorrentTorrentsRelativePath = "data/torrents"
+	BackupsRelativePath         = "backups"
 
 	// SendTransactionMethodName https://docs.walletconnect.com/advanced/rpc-reference/ethereum-rpc#eth_sendtransaction
 	SendTransactionMethodName = "eth_sendTransaction"

--- a/protocol/common/feature_flags.go
+++ b/protocol/common/feature_flags.go
@@ -35,4 +35,7 @@ type FeatureFlags struct {
 
 	// EnableNewsFeed indicates whether we should enable the News Feed polling (this is not the user setting)
 	EnableNewsFeed bool
+
+	// EnableLocalBackup indicates whether we should also back up user data locally
+	EnableLocalBackup bool
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -3515,6 +3515,13 @@ func (m *Messenger) saveDataAndPrepareResponse(messageState *ReceivedMessageStat
 		if ok {
 			contactsToSave = append(contactsToSave, contact)
 			messageState.Response.AddContact(contact)
+
+			_, ok := m.allContacts.Load(id)
+			if !ok {
+				// If the contact is not in the allContacts map, it means it's a new contact
+				// and we need to add it to the allContacts map.
+				m.allContacts.Store(id, contact)
+			}
 		}
 		return true
 	})

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -775,6 +775,9 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	if !m.config.featureFlags.DisableCheckingForBackup {
 		m.startBackupLoop()
 	}
+	if m.config.featureFlags.EnableLocalBackup {
+		m.startLocalBackupLoop()
+	}
 	if !m.config.featureFlags.DisableAutoMessageLoop {
 		err = m.startAutoMessageLoop()
 		if err != nil {

--- a/protocol/messenger_backup.go
+++ b/protocol/messenger_backup.go
@@ -2,6 +2,8 @@ package protocol
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -13,7 +15,9 @@ import (
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/protocol/encryption"
 	"github.com/status-im/status-go/protocol/protobuf"
+	v1protocol "github.com/status-im/status-go/protocol/v1"
 )
 
 const (
@@ -136,7 +140,7 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 			},
 			ProfileDetails: &protobuf.FetchingBackedUpDataDetails{
 				DataNumber:  uint32(0),
-				TotalNumber: uint32(len(profileToBackup)),
+				TotalNumber: uint32(1), // Profile is always one
 			},
 			SettingsDetails: &protobuf.FetchingBackedUpDataDetails{
 				DataNumber:  uint32(0),
@@ -153,11 +157,14 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		}
 	}
 
+	fullBackup := &protobuf.Backup{}
+
 	// Update contacts messages encode and dispatch
 	for i, d := range contactsToBackup {
 		pb := backupDetailsOnly()
 		pb.ContactsDetails.DataNumber = uint32(i + 1)
 		pb.Contacts = d.Contacts
+		fullBackup.Contacts = append(fullBackup.Contacts, d.Contacts...)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
 			return 0, err
@@ -169,6 +176,7 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		pb := backupDetailsOnly()
 		pb.CommunitiesDetails.DataNumber = uint32(i + 1)
 		pb.Communities = d.Communities
+		fullBackup.Communities = append(fullBackup.Communities, d.Communities...)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
 			return 0, err
@@ -176,14 +184,13 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 	}
 
 	// Update profile messages encode and dispatch
-	for i, d := range profileToBackup {
-		pb := backupDetailsOnly()
-		pb.ProfileDetails.DataNumber = uint32(i + 1)
-		pb.Profile = d.Profile
-		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
-		if err != nil {
-			return 0, err
-		}
+	pb := backupDetailsOnly()
+	pb.ProfileDetails.DataNumber = uint32(1)
+	pb.Profile = profileToBackup.Profile
+	fullBackup.Profile = profileToBackup.Profile
+	err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
+	if err != nil {
+		return 0, err
 	}
 
 	// Update chats encode and dispatch
@@ -191,6 +198,7 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		pb := backupDetailsOnly()
 		pb.ChatsDetails.DataNumber = uint32(i + 1)
 		pb.Chats = d.Chats
+		fullBackup.Chats = append(fullBackup.Chats, d.Chats...)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
 			return 0, err
@@ -202,6 +210,8 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		pb := backupDetailsOnly()
 		pb.SettingsDetails.DataNumber = uint32(i + 1)
 		pb.Setting = d
+		// TODO find a way to get all settings
+		// fullBackup.Setting = append(fullBackup.Setting, d)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
 			return 0, err
@@ -213,6 +223,8 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		pb := backupDetailsOnly()
 		pb.KeypairDetails.DataNumber = uint32(i + 1)
 		pb.Keypair = d.Keypair
+		// TODO find a way to get all settings
+		// fullBackup.Keypair = append(fullBackup.Keypair, d.Keypair)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
 			return 0, err
@@ -224,8 +236,45 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		pb := backupDetailsOnly()
 		pb.WatchOnlyAccountDetails.DataNumber = uint32(i + 1)
 		pb.WatchOnlyAccount = d.WatchOnlyAccount
+		// TODO find a way to get all settings
+		// fullBackup.WatchOnlyAccount = append(fullBackup.WatchOnlyAccount, d.Keypair)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
+			return 0, err
+		}
+	}
+
+	if m.config.featureFlags.EnableLocalBackup {
+		// TODO put file in a constant
+		path := filepath.Join(m.config.backupConfig.DataDir, "user_data.bkp")
+
+		if err := os.MkdirAll(m.config.backupConfig.DataDir, 0700); err != nil {
+			return 0, err
+		}
+
+		file, err := os.Create(path)
+		if err != nil {
+			return 0, err
+		}
+		defer file.Close()
+
+		mashalledMessage, err := proto.Marshal(fullBackup)
+		if err != nil {
+			return 0, err
+		}
+
+		messageSpec, err := m.encryptor.BuildDHMessage(m.identity, &m.identity.PublicKey, mashalledMessage)
+		if err != nil {
+			return 0, err
+		}
+
+		encryptedMessage, err := proto.Marshal(messageSpec.Message)
+		if err != nil {
+			return 0, err
+		}
+		err = os.WriteFile(path, encryptedMessage, 0600)
+		if err != nil {
+			m.logger.Error("failed to write backup message to file", zap.Error(err), zap.String("path", path))
 			return 0, err
 		}
 	}
@@ -246,6 +295,62 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 	}
 
 	return clockInSeconds, nil
+}
+
+func (m *Messenger) importLocalBackupFile(filePath string) (*MessengerResponse, error) {
+	if !m.config.featureFlags.EnableLocalBackup {
+		return nil, nil
+	}
+
+	// Make sure the backup file exists
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decrypt the backup file
+	// Unmarshal the content to get the message spec
+	var messageSpec encryption.ProtocolMessage
+	err = proto.Unmarshal(content, &messageSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decrypt the payload
+	var defaultMessageID = []byte("default")
+	decryptedPayload1, err := m.encryptor.HandleMessage(m.identity, &m.identity.PublicKey, &messageSpec, defaultMessageID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the decrypted payload to get the backup message
+	var backupMessage protobuf.Backup
+	err = proto.Unmarshal(decryptedPayload1.DecryptedMessage, &backupMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle the backup
+	state := ReceivedMessageState{
+		Response: &MessengerResponse{},
+		AllChats: &chatMap{},
+		AllContacts: &contactMap{
+			me: m.selfContact,
+		},
+		Timesource:            m.getTimesource(),
+		ModifiedContacts:      &stringBoolMap{},
+		ModifiedInstallations: &stringBoolMap{},
+	}
+	err = m.HandleBackup(
+		&state,
+		&backupMessage,
+		&v1protocol.StatusMessage{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.saveDataAndPrepareResponse(&state)
 }
 
 func (m *Messenger) encodeAndDispatchBackupMessage(ctx context.Context, message *protobuf.Backup, chatID string) error {
@@ -447,7 +552,7 @@ func (m *Messenger) buildSyncContactMessage(contact *Contact) *protobuf.SyncInst
 	}
 }
 
-func (m *Messenger) backupProfile(ctx context.Context, clock uint64) ([]*protobuf.Backup, error) {
+func (m *Messenger) backupProfile(ctx context.Context, clock uint64) (*protobuf.Backup, error) {
 	displayName, err := m.settings.DisplayName()
 	if err != nil {
 		return nil, err
@@ -515,9 +620,7 @@ func (m *Messenger) backupProfile(ctx context.Context, clock uint64) ([]*protobu
 		},
 	}
 
-	backupMessages := []*protobuf.Backup{backupMessage}
-
-	return backupMessages, nil
+	return backupMessage, nil
 }
 
 func (m *Messenger) backupKeypairs() ([]*protobuf.Backup, error) {

--- a/protocol/messenger_backup.go
+++ b/protocol/messenger_backup.go
@@ -2,8 +2,6 @@ package protocol
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -15,9 +13,7 @@ import (
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
-	"github.com/status-im/status-go/protocol/encryption"
 	"github.com/status-im/status-go/protocol/protobuf"
-	v1protocol "github.com/status-im/status-go/protocol/v1"
 )
 
 const (
@@ -157,14 +153,11 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		}
 	}
 
-	fullBackup := &protobuf.Backup{}
-
 	// Update contacts messages encode and dispatch
 	for i, d := range contactsToBackup {
 		pb := backupDetailsOnly()
 		pb.ContactsDetails.DataNumber = uint32(i + 1)
 		pb.Contacts = d.Contacts
-		fullBackup.Contacts = append(fullBackup.Contacts, d.Contacts...)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
 			return 0, err
@@ -176,7 +169,6 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		pb := backupDetailsOnly()
 		pb.CommunitiesDetails.DataNumber = uint32(i + 1)
 		pb.Communities = d.Communities
-		fullBackup.Communities = append(fullBackup.Communities, d.Communities...)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
 			return 0, err
@@ -187,7 +179,6 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 	pb := backupDetailsOnly()
 	pb.ProfileDetails.DataNumber = uint32(1)
 	pb.Profile = profileToBackup.Profile
-	fullBackup.Profile = profileToBackup.Profile
 	err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 	if err != nil {
 		return 0, err
@@ -198,7 +189,6 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		pb := backupDetailsOnly()
 		pb.ChatsDetails.DataNumber = uint32(i + 1)
 		pb.Chats = d.Chats
-		fullBackup.Chats = append(fullBackup.Chats, d.Chats...)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
 			return 0, err
@@ -210,8 +200,6 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		pb := backupDetailsOnly()
 		pb.SettingsDetails.DataNumber = uint32(i + 1)
 		pb.Setting = d
-		// TODO find a way to get all settings
-		// fullBackup.Setting = append(fullBackup.Setting, d)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
 			return 0, err
@@ -223,8 +211,6 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		pb := backupDetailsOnly()
 		pb.KeypairDetails.DataNumber = uint32(i + 1)
 		pb.Keypair = d.Keypair
-		// TODO find a way to get all settings
-		// fullBackup.Keypair = append(fullBackup.Keypair, d.Keypair)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
 			return 0, err
@@ -236,45 +222,8 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 		pb := backupDetailsOnly()
 		pb.WatchOnlyAccountDetails.DataNumber = uint32(i + 1)
 		pb.WatchOnlyAccount = d.WatchOnlyAccount
-		// TODO find a way to get all settings
-		// fullBackup.WatchOnlyAccount = append(fullBackup.WatchOnlyAccount, d.Keypair)
 		err = m.encodeAndDispatchBackupMessage(ctx, pb, chat.ID)
 		if err != nil {
-			return 0, err
-		}
-	}
-
-	if m.config.featureFlags.EnableLocalBackup {
-		// TODO put file in a constant
-		path := filepath.Join(m.config.backupConfig.DataDir, "user_data.bkp")
-
-		if err := os.MkdirAll(m.config.backupConfig.DataDir, 0700); err != nil {
-			return 0, err
-		}
-
-		file, err := os.Create(path)
-		if err != nil {
-			return 0, err
-		}
-		defer file.Close()
-
-		mashalledMessage, err := proto.Marshal(fullBackup)
-		if err != nil {
-			return 0, err
-		}
-
-		messageSpec, err := m.encryptor.BuildDHMessage(m.identity, &m.identity.PublicKey, mashalledMessage)
-		if err != nil {
-			return 0, err
-		}
-
-		encryptedMessage, err := proto.Marshal(messageSpec.Message)
-		if err != nil {
-			return 0, err
-		}
-		err = os.WriteFile(path, encryptedMessage, 0600)
-		if err != nil {
-			m.logger.Error("failed to write backup message to file", zap.Error(err), zap.String("path", path))
 			return 0, err
 		}
 	}
@@ -295,62 +244,6 @@ func (m *Messenger) BackupData(ctx context.Context) (uint64, error) {
 	}
 
 	return clockInSeconds, nil
-}
-
-func (m *Messenger) importLocalBackupFile(filePath string) (*MessengerResponse, error) {
-	if !m.config.featureFlags.EnableLocalBackup {
-		return nil, nil
-	}
-
-	// Make sure the backup file exists
-	content, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	// Decrypt the backup file
-	// Unmarshal the content to get the message spec
-	var messageSpec encryption.ProtocolMessage
-	err = proto.Unmarshal(content, &messageSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	// Decrypt the payload
-	var defaultMessageID = []byte("default")
-	decryptedPayload1, err := m.encryptor.HandleMessage(m.identity, &m.identity.PublicKey, &messageSpec, defaultMessageID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Unmarshal the decrypted payload to get the backup message
-	var backupMessage protobuf.Backup
-	err = proto.Unmarshal(decryptedPayload1.DecryptedMessage, &backupMessage)
-	if err != nil {
-		return nil, err
-	}
-
-	// Handle the backup
-	state := ReceivedMessageState{
-		Response: &MessengerResponse{},
-		AllChats: &chatMap{},
-		AllContacts: &contactMap{
-			me: m.selfContact,
-		},
-		Timesource:            m.getTimesource(),
-		ModifiedContacts:      &stringBoolMap{},
-		ModifiedInstallations: &stringBoolMap{},
-	}
-	err = m.HandleBackup(
-		&state,
-		&backupMessage,
-		&v1protocol.StatusMessage{},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return m.saveDataAndPrepareResponse(&state)
 }
 
 func (m *Messenger) encodeAndDispatchBackupMessage(ctx context.Context, message *protobuf.Backup, chatID string) error {

--- a/protocol/messenger_backup_test.go
+++ b/protocol/messenger_backup_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 
+	"github.com/status-im/status-go/params"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 	"github.com/status-im/status-go/protocol/wakusync"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
@@ -108,6 +111,76 @@ func (s *MessengerBackupSuite) TestBackupContacts() {
 	s.Require().NoError(err)
 	s.Require().NotEmpty(lastBackup)
 	s.Require().Equal(clock, lastBackup)
+}
+
+func (s *MessengerBackupSuite) TestBackupContactsLocally() {
+	backupOptions := []Option{
+		WithLocalBackup(&params.BackupConfig{
+			DataDir: filepath.Join(s.tmpdir, params.BackupsRelativePath),
+		}),
+	}
+
+	// Create bob1
+	privateKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	bob1, err := newMessengerWithKey(s.shh, privateKey, s.logger, backupOptions)
+	s.Require().NoError(err)
+	defer TearDownMessenger(&s.Suite, bob1)
+
+	// Create bob2
+	bob2, err := newMessengerWithKey(s.shh, bob1.identity, s.logger, backupOptions)
+	s.Require().NoError(err)
+	defer TearDownMessenger(&s.Suite, bob2)
+
+	// Make sure there is no backup at first
+	backupFile := filepath.Join(bob1.config.backupConfig.DataDir, "user_data.bkp")
+	err = os.RemoveAll(backupFile)
+	s.Require().NoError(err)
+
+	// Create 2 contacts
+	contact1Key, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	contactID1 := types.EncodeHex(crypto.FromECDSAPub(&contact1Key.PublicKey))
+
+	_, err = bob1.AddContact(context.Background(), &requests.AddContact{ID: contactID1})
+	s.Require().NoError(err)
+
+	contact2Key, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	contactID2 := types.EncodeHex(crypto.FromECDSAPub(&contact2Key.PublicKey))
+
+	_, err = bob1.AddContact(context.Background(), &requests.AddContact{ID: contactID2})
+	s.Require().NoError(err)
+
+	s.Require().Len(bob1.Contacts(), 2)
+
+	actualContacts := bob1.Contacts()
+	if actualContacts[0].ID == contactID1 {
+		s.Require().Equal(actualContacts[0].ID, contactID1)
+		s.Require().Equal(actualContacts[1].ID, contactID2)
+	} else {
+		s.Require().Equal(actualContacts[0].ID, contactID2)
+		s.Require().Equal(actualContacts[1].ID, contactID1)
+	}
+
+	s.Require().Equal(ContactRequestStateSent, actualContacts[0].ContactRequestLocalState)
+	s.Require().Equal(ContactRequestStateSent, actualContacts[1].ContactRequestLocalState)
+	s.Require().True(actualContacts[0].added())
+	s.Require().True(actualContacts[1].added())
+
+	// Backup
+	_, err = bob1.BackupData(context.Background())
+	s.Require().NoError(err)
+
+	// Safety check
+	s.Require().Len(bob2.Contacts(), 0)
+
+	// Import the backup file and process it
+	response, err := bob2.importLocalBackupFile(backupFile)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+	s.Require().Len(response.Contacts, 2)
+	s.Require().Len(bob2.Contacts(), 2)
 }
 
 func (s *MessengerBackupSuite) TestBackupProfile() {

--- a/protocol/messenger_backup_test.go
+++ b/protocol/messenger_backup_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -15,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 
-	"github.com/status-im/status-go/params"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 	"github.com/status-im/status-go/protocol/wakusync"
 	"github.com/status-im/status-go/services/accounts/accountsevent"
@@ -111,76 +108,6 @@ func (s *MessengerBackupSuite) TestBackupContacts() {
 	s.Require().NoError(err)
 	s.Require().NotEmpty(lastBackup)
 	s.Require().Equal(clock, lastBackup)
-}
-
-func (s *MessengerBackupSuite) TestBackupContactsLocally() {
-	backupOptions := []Option{
-		WithLocalBackup(&params.BackupConfig{
-			DataDir: filepath.Join(s.tmpdir, params.BackupsRelativePath),
-		}),
-	}
-
-	// Create bob1
-	privateKey, err := crypto.GenerateKey()
-	s.Require().NoError(err)
-	bob1, err := newMessengerWithKey(s.shh, privateKey, s.logger, backupOptions)
-	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, bob1)
-
-	// Create bob2
-	bob2, err := newMessengerWithKey(s.shh, bob1.identity, s.logger, backupOptions)
-	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, bob2)
-
-	// Make sure there is no backup at first
-	backupFile := filepath.Join(bob1.config.backupConfig.DataDir, "user_data.bkp")
-	err = os.RemoveAll(backupFile)
-	s.Require().NoError(err)
-
-	// Create 2 contacts
-	contact1Key, err := crypto.GenerateKey()
-	s.Require().NoError(err)
-	contactID1 := types.EncodeHex(crypto.FromECDSAPub(&contact1Key.PublicKey))
-
-	_, err = bob1.AddContact(context.Background(), &requests.AddContact{ID: contactID1})
-	s.Require().NoError(err)
-
-	contact2Key, err := crypto.GenerateKey()
-	s.Require().NoError(err)
-	contactID2 := types.EncodeHex(crypto.FromECDSAPub(&contact2Key.PublicKey))
-
-	_, err = bob1.AddContact(context.Background(), &requests.AddContact{ID: contactID2})
-	s.Require().NoError(err)
-
-	s.Require().Len(bob1.Contacts(), 2)
-
-	actualContacts := bob1.Contacts()
-	if actualContacts[0].ID == contactID1 {
-		s.Require().Equal(actualContacts[0].ID, contactID1)
-		s.Require().Equal(actualContacts[1].ID, contactID2)
-	} else {
-		s.Require().Equal(actualContacts[0].ID, contactID2)
-		s.Require().Equal(actualContacts[1].ID, contactID1)
-	}
-
-	s.Require().Equal(ContactRequestStateSent, actualContacts[0].ContactRequestLocalState)
-	s.Require().Equal(ContactRequestStateSent, actualContacts[1].ContactRequestLocalState)
-	s.Require().True(actualContacts[0].added())
-	s.Require().True(actualContacts[1].added())
-
-	// Backup
-	_, err = bob1.BackupData(context.Background())
-	s.Require().NoError(err)
-
-	// Safety check
-	s.Require().Len(bob2.Contacts(), 0)
-
-	// Import the backup file and process it
-	response, err := bob2.importLocalBackupFile(backupFile)
-	s.Require().NoError(err)
-	s.Require().NotNil(response)
-	s.Require().Len(response.Contacts, 2)
-	s.Require().Len(bob2.Contacts(), 2)
 }
 
 func (s *MessengerBackupSuite) TestBackupProfile() {

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -19,6 +19,7 @@ import (
 const DefaultProfileDisplayName = ""
 
 func (s *MessengerBaseTestSuite) SetupTest() {
+	s.tmpdir = s.T().TempDir()
 	s.logger = tt.MustCreateTestLogger()
 	shh, err := newTestWakuNode(s.logger)
 	s.Require().NoError(err)
@@ -51,6 +52,7 @@ type MessengerBaseTestSuite struct {
 	// a single waku service should be shared.
 	shh    wakutypes.Waku
 	logger *zap.Logger
+	tmpdir string
 }
 
 func newMessengerWithKey(shh wakutypes.Waku, privateKey *ecdsa.PrivateKey, logger *zap.Logger, extraOptions []Option) (*Messenger, error) {

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -19,7 +19,6 @@ import (
 const DefaultProfileDisplayName = ""
 
 func (s *MessengerBaseTestSuite) SetupTest() {
-	s.tmpdir = s.T().TempDir()
 	s.logger = tt.MustCreateTestLogger()
 	shh, err := newTestWakuNode(s.logger)
 	s.Require().NoError(err)

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -94,6 +94,7 @@ type config struct {
 	clusterConfig          params.ClusterConfig
 	browserDatabase        *browsers.Database
 	torrentConfig          *params.TorrentConfig
+	backupConfig           *params.BackupConfig
 	walletService          *wallet.Service
 	communityTokensService communities.CommunityTokensServiceInterface
 	httpServer             *server.MediaServer
@@ -427,6 +428,14 @@ func WithAccountsFeed(feed *event.Feed) Option {
 func WithNewsFeed() func(c *config) error {
 	return func(c *config) error {
 		c.featureFlags.EnableNewsFeed = true
+		return nil
+	}
+}
+
+func WithLocalBackup(bc *params.BackupConfig) func(c *config) error {
+	return func(c *config) error {
+		c.featureFlags.EnableLocalBackup = true
+		c.backupConfig = bc
 		return nil
 	}
 }

--- a/protocol/messenger_local_backup.go
+++ b/protocol/messenger_local_backup.go
@@ -17,12 +17,15 @@ import (
 )
 
 // localBackupInterval is the duration we should allow between backups
-var localBackupInterval = 1800 * time.Second // 30 minutes
+var localBackupInterval = 30 * time.Minute
 
 func (m *Messenger) startLocalBackupLoop() {
 	ticker := time.NewTicker(localBackupInterval)
+	defer ticker.Stop()
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case <-ticker.C:
@@ -38,7 +41,7 @@ func (m *Messenger) startLocalBackupLoop() {
 
 				m.logger.Debug("backing up data")
 
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				ctx, cancel := context.WithTimeout(m.ctx, 5*time.Minute)
 				defer cancel()
 				err = m.BackupDataLocally(ctx)
 				if err != nil {

--- a/protocol/messenger_local_backup.go
+++ b/protocol/messenger_local_backup.go
@@ -1,0 +1,196 @@
+package protocol
+
+import (
+	"context"
+	crand "crypto/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"go.uber.org/zap"
+
+	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/protocol/protobuf"
+	v1protocol "github.com/status-im/status-go/protocol/v1"
+)
+
+// localBackupInterval is the duration we should allow between backups
+var localBackupInterval = 1800 * time.Second // 30 minutes
+
+func (m *Messenger) startLocalBackupLoop() {
+	ticker := time.NewTicker(localBackupInterval)
+	go func() {
+		defer gocommon.LogOnPanic()
+		for {
+			select {
+			case <-ticker.C:
+				enabled, err := m.backupEnabled()
+				if err != nil {
+					m.logger.Error("failed to fetch backup enabled")
+					continue
+				}
+				if !enabled || !m.config.featureFlags.EnableLocalBackup {
+					m.logger.Debug("backup not enabled, skipping")
+					continue
+				}
+
+				m.logger.Debug("backing up data")
+
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer cancel()
+				err = m.BackupDataLocally(ctx)
+				if err != nil {
+					m.logger.Error("failed to backup data", zap.Error(err))
+				}
+			case <-m.quit:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (m *Messenger) BackupDataLocally(ctx context.Context) error {
+	if !m.config.featureFlags.EnableLocalBackup {
+		return nil
+	}
+
+	clock, chat := m.getLastClockWithRelatedChat()
+	contactsToBackup := m.backupContacts(ctx)
+	communitiesToBackup, err := m.backupCommunities(ctx, clock)
+	if err != nil {
+		return err
+	}
+	chatsToBackup := m.backupChats(ctx, clock)
+	if err != nil {
+		return err
+	}
+	profileToBackup, err := m.backupProfile(ctx, clock)
+	if err != nil {
+		return err
+	}
+	// _, settings, errors := m.prepareSyncSettingsMessages(clock, true)
+	// if len(errors) != 0 {
+	// 	// return just the first error, the others have been logged
+	// 	return errors[0]
+	// }
+	// woAccountsToBackup, err := m.backupWatchOnlyAccounts()
+	// if err != nil {
+	// 	return 0, err
+	// }
+
+	fullBackup := &protobuf.Backup{}
+
+	for _, d := range contactsToBackup {
+		fullBackup.Contacts = append(fullBackup.Contacts, d.Contacts...)
+	}
+	for _, d := range communitiesToBackup {
+		fullBackup.Communities = append(fullBackup.Communities, d.Communities...)
+	}
+	fullBackup.Profile = profileToBackup.Profile
+	for _, d := range chatsToBackup {
+		fullBackup.Chats = append(fullBackup.Chats, d.Chats...)
+	}
+	// for i, d := range settings {
+	// 	// TODO find a way to get all settings
+	// 	fullBackup.Setting = append(fullBackup.Setting, d)
+	// }
+	// for i, d := range woAccountsToBackup {
+	// 	// TODO find a way to get all watchonlyaccounts
+	// 	fullBackup.WatchOnlyAccount = append(fullBackup.WatchOnlyAccount, d.Keypair)
+	// }
+
+	// TODO put file in a constant
+	path := filepath.Join(m.config.backupConfig.DataDir, "user_data.bkp")
+
+	if err := os.MkdirAll(m.config.backupConfig.DataDir, 0700); err != nil {
+		return err
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	mashalledMessage, err := proto.Marshal(fullBackup)
+	if err != nil {
+		return err
+	}
+
+	key, err := common.MakeECDHSharedKey(m.identity, &m.identity.PublicKey)
+	if err != nil {
+		return err
+	}
+	encryptedMessage, err := common.Encrypt(mashalledMessage, key, crand.Reader)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(path, encryptedMessage, 0600)
+	if err != nil {
+		m.logger.Error("failed to write backup message to file", zap.Error(err), zap.String("path", path))
+		return err
+	}
+
+	chat.LastClockValue = clock
+	err = m.saveChat(chat)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Messenger) importLocalBackupFile(filePath string) (*MessengerResponse, error) {
+	if !m.config.featureFlags.EnableLocalBackup {
+		return nil, nil
+	}
+
+	// Make sure the backup file exists
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decrypt the backup file
+	key, err := common.MakeECDHSharedKey(m.identity, &m.identity.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	decryptedPayload, err := common.Decrypt(content, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the decrypted payload to get the backup message
+	var backupMessage protobuf.Backup
+	err = proto.Unmarshal(decryptedPayload, &backupMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle the backup
+	state := ReceivedMessageState{
+		Response: &MessengerResponse{},
+		AllChats: &chatMap{},
+		AllContacts: &contactMap{
+			me: m.selfContact,
+		},
+		Timesource:            m.getTimesource(),
+		ModifiedContacts:      &stringBoolMap{},
+		ModifiedInstallations: &stringBoolMap{},
+	}
+	err = m.HandleBackup(
+		&state,
+		&backupMessage,
+		&v1protocol.StatusMessage{},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.saveDataAndPrepareResponse(&state)
+}

--- a/protocol/messenger_local_backup_test.go
+++ b/protocol/messenger_local_backup_test.go
@@ -1,0 +1,94 @@
+package protocol
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/status-im/status-go/params"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/status-im/status-go/eth-node/crypto"
+	"github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/protocol/requests"
+)
+
+func TestMessengerLocalBackupSuite(t *testing.T) {
+	suite.Run(t, new(MessengerBackupSuite))
+}
+
+type MessengerLocalBackupSuite struct {
+	MessengerBaseTestSuite
+}
+
+func (s *MessengerBackupSuite) TestBackupContactsLocally() {
+	backupOptions := []Option{
+		WithLocalBackup(&params.BackupConfig{
+			DataDir: filepath.Join(s.tmpdir, params.BackupsRelativePath),
+		}),
+	}
+
+	// Create bob1
+	privateKey, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	bob1, err := newMessengerWithKey(s.shh, privateKey, s.logger, backupOptions)
+	s.Require().NoError(err)
+	defer TearDownMessenger(&s.Suite, bob1)
+
+	// Create bob2
+	bob2, err := newMessengerWithKey(s.shh, bob1.identity, s.logger, backupOptions)
+	s.Require().NoError(err)
+	defer TearDownMessenger(&s.Suite, bob2)
+
+	// Make sure there is no backup at first
+	backupFile := filepath.Join(bob1.config.backupConfig.DataDir, "user_data.bkp")
+	err = os.RemoveAll(backupFile)
+	s.Require().NoError(err)
+
+	// Create 2 contacts
+	contact1Key, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	contactID1 := types.EncodeHex(crypto.FromECDSAPub(&contact1Key.PublicKey))
+
+	_, err = bob1.AddContact(context.Background(), &requests.AddContact{ID: contactID1})
+	s.Require().NoError(err)
+
+	contact2Key, err := crypto.GenerateKey()
+	s.Require().NoError(err)
+	contactID2 := types.EncodeHex(crypto.FromECDSAPub(&contact2Key.PublicKey))
+
+	_, err = bob1.AddContact(context.Background(), &requests.AddContact{ID: contactID2})
+	s.Require().NoError(err)
+
+	s.Require().Len(bob1.Contacts(), 2)
+
+	actualContacts := bob1.Contacts()
+	if actualContacts[0].ID == contactID1 {
+		s.Require().Equal(actualContacts[0].ID, contactID1)
+		s.Require().Equal(actualContacts[1].ID, contactID2)
+	} else {
+		s.Require().Equal(actualContacts[0].ID, contactID2)
+		s.Require().Equal(actualContacts[1].ID, contactID1)
+	}
+
+	s.Require().Equal(ContactRequestStateSent, actualContacts[0].ContactRequestLocalState)
+	s.Require().Equal(ContactRequestStateSent, actualContacts[1].ContactRequestLocalState)
+	s.Require().True(actualContacts[0].added())
+	s.Require().True(actualContacts[1].added())
+
+	// Backup
+	err = bob1.BackupDataLocally(context.Background())
+	s.Require().NoError(err)
+
+	// Safety check
+	s.Require().Len(bob2.Contacts(), 0)
+
+	// Import the backup file and process it
+	response, err := bob2.importLocalBackupFile(backupFile)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+	s.Require().Len(response.Contacts, 2)
+	s.Require().Len(bob2.Contacts(), 2)
+}

--- a/protocol/messenger_local_backup_test.go
+++ b/protocol/messenger_local_backup_test.go
@@ -24,6 +24,7 @@ type MessengerLocalBackupSuite struct {
 }
 
 func (s *MessengerBackupSuite) TestBackupContactsLocally() {
+	s.tmpdir = s.T().TempDir()
 	backupOptions := []Option{
 		WithLocalBackup(&params.BackupConfig{
 			DataDir: filepath.Join(s.tmpdir, params.BackupsRelativePath),

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -396,6 +396,7 @@ func buildMessengerOptions(
 		protocol.WithAccountsFeed(accountsFeed),
 		protocol.WithNewsFeed(),
 		protocol.WithMessageSigner(personalService),
+		protocol.WithLocalBackup(&config.BackupConfig),
 	}
 
 	if config.ShhextConfig.DataSyncEnabled {

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -396,7 +396,7 @@ func buildMessengerOptions(
 		protocol.WithAccountsFeed(accountsFeed),
 		protocol.WithNewsFeed(),
 		protocol.WithMessageSigner(personalService),
-		protocol.WithLocalBackup(&config.BackupConfig),
+		// protocol.WithLocalBackup(&config.BackupConfig),
 	}
 
 	if config.ShhextConfig.DataSyncEnabled {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/18107

Creates a proof of concept of the local user data backups. When a back up is done, if the feature flag is active, a local file will be created with (almost) all the same backup data. Then, that file can be passed to the import function and it will import that data. A test case was added to test the flow using contacts and it works.

----

This is ofc just a POC/SPIKE and not meant to be used. The feature flag makes sure that the normal flow is not affected.

I will add issues to the Epic to complete the work on the backend and add the UI for users to actually use it.