### PR TITLE
chore_: remove useless retry ports

### DIFF
--- a/_assets/ci/Jenkinsfile.tests-rpc
+++ b/_assets/ci/Jenkinsfile.tests-rpc
@@ -15,6 +15,11 @@ pipeline {
       defaultValue: true,
       description: 'Should the job report test coverage to Codecov?'
     )
+    choice(
+      name: 'FUNCTIONAL_TESTS_LOG_LEVEL',
+      choices: ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+      description: 'pytest log level'
+    )
   }
 
   options {
@@ -35,8 +40,9 @@ pipeline {
     PKG_URL = "${currentBuild.absoluteUrl}/consoleText"
 
     /* Hack-fix for params not being set in env on first job run. */
-    BRANCH =                           "${params.BRANCH}"
+    BRANCH =                          "${params.BRANCH}"
     FUNCTIONAL_TESTS_REPORT_CODECOV = "${params.FUNCTIONAL_TESTS_REPORT_CODECOV}"
+    FUNCTIONAL_TESTS_LOG_LEVEL =      "${params.FUNCTIONAL_TESTS_LOG_LEVEL}"
   }
 
   stages {

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -54,7 +54,12 @@ pip install --upgrade pip
 pip install -r "${root_path}/requirements.txt"
 
 # Run functional tests
-pytest --reruns 2 -m rpc -c "${root_path}/pytest.ini" -n 12 --dist loadgroup --docker_project_name=${project_name} --codecov_dir=${binary_coverage_reports_path} --junitxml=${test_results_path}/report.xml
+pytest --reruns 2 -m rpc -c "${root_path}/pytest.ini" -n 12 \
+  --dist loadgroup\
+  --log-cli-level="${FUNCTIONAL_TESTS_LOG_LEVEL}" \
+  --docker_project_name="${project_name}" \
+  --codecov_dir="${binary_coverage_reports_path}" \
+  --junitxml="${test_results_path}/report.xml"
 exit_code=$?
 
 # Stop containers

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -45,20 +45,12 @@ class StatusBackend(RpcClient, SignalClient):
             self.temp_dir = None
             self.data_dir = "/usr/status-user"
             self.docker_client = docker.from_env()
-            retries = 5
-            ports_tried = []
-            for _ in range(retries):
-                try:
-                    host_port = random.choice(option.status_backend_port_range)
-                    ports_tried.append(host_port)
-                    self.container = self._start_container(host_port, privileged)
-                    url = f"http://{'[::1]' if self.ipv6 else '127.0.0.1'}:{host_port}"
-                    option.status_backend_port_range.remove(host_port)
-                    break
-                except Exception as ex:
-                    logging.error(f"Error in starting the container: {str(ex)}")
-            else:
-                raise RuntimeError(f"Failed to start container on ports: {ports_tried}")
+
+            host_port = random.choice(option.status_backend_port_range)
+            option.status_backend_port_range.remove(host_port)
+
+            self.container = self._start_container(host_port, privileged)
+            url = f"http://{'[::1]' if self.ipv6 else '127.0.0.1'}:{host_port}"
 
         assert self.data_dir != ""
         self.base_url = url


### PR DESCRIPTION
# Description

1. Removed a retry loop for container ports.
    It was added here: https://github.com/status-im/status-go/pull/6259
    I am refactoring this place a bit and this thing didn't make sense to me 🤔 

2. Added CI `FUNCTIONAL_TESTS_LOG_LEVEL` parameter