### PR TITLE
chore(ci): get rid of dirty flag

### DIFF
--- a/_assets/scripts/version.sh
+++ b/_assets/scripts/version.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-git describe --tags --dirty="-dirty"
+git describe --tags

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,7 +8,7 @@ import (
 // Use go:generate script to get the version and git commit.
 // VERSION and GIT_COMMIT files are used in further `go:embed` commands to load values to the variables.
 // Suppress errors, assuming files have already been properly generated. Required for Docker builds.
-//go:generate sh -c "git describe --tags --dirty='-dirty' > VERSION || true"
+//go:generate sh -c "git describe --tags > VERSION || true"
 //go:generate sh -c "git rev-parse --short HEAD > GIT_COMMIT || true"
 
 var (


### PR DESCRIPTION
## Summary

I found few instances of `--dirty` in status-go as well, 
Now that we don't have this versioning in status-desktop it would be consistent if we removed it from here as well.
