### PR TITLE
test_: save container logs artifacts

### DIFF
--- a/_assets/ci/Jenkinsfile.tests-rpc
+++ b/_assets/ci/Jenkinsfile.tests-rpc
@@ -69,7 +69,7 @@ pipeline {
     always {
       script {
         archiveArtifacts(
-          artifacts: 'tests-functional/reports/*.xml, tests-functional/*.log, tests-functional/coverage/coverage.html',
+          artifacts: 'tests-functional/reports/*.xml, tests-functional/logs/*.log, tests-functional/coverage/coverage.html',
           allowEmptyArchive: true,
         )
         junit(

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -16,15 +16,18 @@ coverage_reports_path="${root_path}/coverage"
 binary_coverage_reports_path="${coverage_reports_path}/binary"
 merged_coverage_reports_path="${coverage_reports_path}/merged"
 test_results_path="${root_path}/reports"
+logs_path="${root_path}/logs"
 
 # Cleanup any previous coverage reports
 rm -rf "${coverage_reports_path}"
 rm -rf "${test_results_path}"
+rm -rf "${logs_path}"
 
 # Create directories
 mkdir -p "${binary_coverage_reports_path}"
 mkdir -p "${merged_coverage_reports_path}"
 mkdir -p "${test_results_path}"
+mkdir -p "${logs_path}"
 
 all_compose_files="-f ${root_path}/docker-compose.anvil.yml -f ${root_path}/docker-compose.waku.yml"
 identifier=${BUILD_ID:-$(git rev-parse --short HEAD)}
@@ -71,6 +74,7 @@ pytest --reruns 2 -m rpc -c "${root_path}/pytest.ini" -n 12 \
   --docker_project_name="${project_name}" \
   --docker-image=${image_name} \
   --codecov_dir="${binary_coverage_reports_path}" \
+  --logs-dir="${logs_path}" \
   --junitxml="${test_results_path}/report.xml"
 exit_code=$?
 

--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -176,6 +176,22 @@ class StatusGoContainer:
         return temp_dir
 
 
+    def save_logs(self):
+        if not self.container:
+            raise RuntimeError("Container is not initialized.")
+        if option.logs_dir == "":
+            logging.warning("Save container logs skipped")
+            return
+
+        id_short = self.container.id[:12]
+        file_path = os.path.join(option.logs_dir, f"container_{id_short}.log")
+        logging.info(f"Saving logs to {file_path}")
+
+        with open(file_path, "wb") as f:
+            logs = self.container.logs()
+            f.write(logs)
+
+
 class PushNotificationServerContainer(StatusGoContainer):
     def __init__(self, identity, gorush_port):
         entrypoint = [

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -42,6 +42,12 @@ def pytest_addoption(parser):
         default=None,
     )
     parser.addoption(
+        "--logs-dir",
+        action="store",
+        help="Path to a directory where containers logs will be saved",
+        default="",
+    )
+    parser.addoption(
         "--logout",
         action="store_true",
         help="When set, will automatically call Logout() before InitializeApplication()",
@@ -126,5 +132,7 @@ def close_status_backend_containers(request):
         return
     for container in option.statusgo_containers:
         container.stop()  # pyright: ignore[reportAttributeAccessIssue]
+        container.save_logs() # pyright: ignore[reportAttributeAccessIssue]
         container.remove()  # pyright: ignore[reportAttributeAccessIssue]
+        
     option.statusgo_containers = []


### PR DESCRIPTION
# Description

Save all status-go containers logs to CI artifacts.

This is quite useless for now, because `status-backend` logs are written to a file. But:
1. It will be useful after https://github.com/status-im/status-go/issues/6473
2. And it's already useful for me in https://github.com/status-im/status-go/pull/6675