### PR TITLE
test_: critical flow RecoverAndLogin with 12,15,24 words mnemonic

### DIFF
--- a/tests-functional/resources/constants.py
+++ b/tests-functional/resources/constants.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import os
+from typing import Optional
 
 
 @dataclass
@@ -8,6 +9,8 @@ class Account:
     private_key: str
     password: str
     passphrase: str
+    accounts: Optional[list] = None  # Optional list of accounts
+    profile_data: Optional[dict] = None  # Optional profile data
 
 
 user_1 = Account(
@@ -22,6 +25,150 @@ user_2 = Account(
     password="Strong12345",
     passphrase="test test test test test test test test test test nest junk",
 )
+
+user_mnemonic_12 = Account(
+    address="0xC43f4Ab94eC965a3EE9815C5Df07383057d261A8",
+    private_key="",
+    password="Strong12345",
+    passphrase="exhibit soldier miracle series edge atom daring alter absorb decide orphan addict",
+    accounts=[
+        {
+            "address": "0xb01a7dbaaacc92581558a4d178289be7471ba0f4",
+            "public-key": "0x047fd6e4384b764cb7782bf747ad3fb51e8c54c2b3c2be7029c72d85d16b07f4be6a8703cf0a1d97be4c8712ad"
+            "52cd6a519efdc723faae4935bbaba5c320dde02b",
+            "path": "m/43'/60'/1581'/0'/0",
+            "prodPreferredChainIds": "1:10:42161:8453",
+            "operable": "fully",
+            "position": -1,
+        },
+        {
+            "address": "0xc43f4ab94ec965a3ee9815c5df07383057d261a8",
+            "public-key": "0x041d8f6ebfa662c506d3d11cd407373f8ff2eb4c9ddc61a834864150a908172efbaa37f0de7dbeeea51f02272"
+            "74e6ccd78fa5a07de55716094dbba475ac9e9ab44",
+            "path": "m/44'/60'/0'/0/0",
+            "name": "Account 1",
+            "colorId": "primary",
+            "hidden": False,
+            "prodPreferredChainIds": "1:10:42161:8453",
+            "position": 0,
+        },
+    ],
+    profile_data={
+        "address": "0x5f8e02f9f52709b29c82bd893d9af0f83273a6e4",
+        "currency": "usd",
+        "networks/current-network": "",
+        "dapps-address": "0xc43f4ab94ec965a3ee9815c5df07383057d261a8",
+        "eip1581-address": "0x803102f704324d4a4f2ddb1c47f6ab31339d0f70",
+        "key-uid": "0x3231d92c94548d14f097173765a50bebe28fbad8f2267c9e08cc4433a6f219a4",
+        "latest-derived-path": 0,
+        "link-preview-request-enabled": True,
+        "messages-from-contacts-only": False,
+        "mutual-contact-enabled?": False,
+        "name": "Anchored Open Wirehair",
+        "networks/networks": [],
+        "news-feed-enabled?": True,
+        "news-rss-enabled?": True,
+        "photo-path": "",
+        "preview-privacy?": False,
+        "public-key": "0x047fd6e4384b764cb7782bf747ad3fb51e8c54c2b3c2be7029c72d85d16b07f4be6a8703cf0a1d97be4c8712ad52cd"
+        "6a519efdc723faae4935bbaba5c320dde02b",
+        "default-sync-period": 777600,
+        "appearance": 0,
+        "profile-pictures-show-to": 2,
+        "profile-pictures-visibility": 2,
+        "use-mailservers?": True,
+        "wallet-root-address": "0x1846a7930d0ab03e5a120ebdd46eff3fe0365824",
+        "send-status-updates?": True,
+        "backup-enabled?": True,
+        "show-community-asset-when-sending-tokens?": True,
+        "display-assets-below-balance-threshold": 100000000,
+        "url-unfurling-mode": 1,
+        "compressedKey": "zQ3shoF8xQNaT44MWQxztUXK6DK9UU63PRgJhn1Zd7oYWXJ5K",
+        "emojiHash": ["🔢", "🤞🏽", "🖍️", "🙇🏽‍♀️", "🙋🏼‍♀️", "🙌", "💎", "🎞️", "😊", "🦸🏼", "😤", "👵🏿", "🧑🏿‍🔧", "🤶🏿"],
+    },
+)
+
+user_mnemonic_15 = Account(
+    address="0x685d7ec8e08769ca7020a6b65709887e38e68e6d",
+    private_key="",
+    password="Strong12345",
+    passphrase="category two chapter fame hunt horse huge rotate inner monkey affair champion mixed tail final",
+    accounts=[
+        {
+            "address": "0x245b7438961de05444645898f9215e5cf0786891",
+            "public-key": "0x04c898c7763afd577f10efdd9e5d607caafd6d708e6cad8cee1b6d822d6ab148eb4e76d1c8266c8b73c8ce1d76"
+            "699e072ac5844a9a6934abb565044bf619336302",
+            "path": "m/43'/60'/1581'/0'/0",
+            "prodPreferredChainIds": "1:10:42161:8453",
+            "operable": "fully",
+            "position": -1,
+        },
+        {
+            "address": "0x685d7ec8e08769ca7020a6b65709887e38e68e6d",
+            "public-key": "0x0480acddfad1e73c3e70e8e50f82eb1566e3df125736e9fe9042c4df5022c825afe6234021ad8bbb43e0ab0196"
+            "878c2d9e3c8b5a8f266aca72b0e23d1f84464c72",
+            "path": "m/44'/60'/0'/0/0",
+            "name": "Account 1",
+            "colorId": "primary",
+            "hidden": False,
+            "prodPreferredChainIds": "1:10:42161:8453",
+            "position": 0,
+        },
+    ],
+    profile_data={
+        "address": "0x3644a8cc3860606fdee3b95c8825e17933a91647",
+        "dapps-address": "0x685d7ec8e08769ca7020a6b65709887e38e68e6d",
+        "eip1581-address": "0xe98734898ff58ac33a1a9c28f732696ec3e6b580",
+        "key-uid": "0x944c1ce03f83dd1750acee591745d6ef14da90723af86f97b2df7d7282e8dd97",
+        "name": "Overcooked Lost Grayreefshark",
+        "public-key": "0x04c898c7763afd577f10efdd9e5d607caafd6d708e6cad8cee1b6d822d6ab148eb4e76d1c8266c8b73c8ce1d76699e"
+        "072ac5844a9a6934abb565044bf619336302",
+        "wallet-root-address": "0xe89675c9be641ceeca9f250345dc58528c3de93b",
+        "emojiHash": ["🏄🏾", "👒", "👨🏽‍🎓", "🅰️", "👩🏾‍🍳", "🪀", "📩", "🐄", "⏳", "👸🏻", "🚣🏾‍♂️", "👩🏽‍🤝‍👩🏻", "📀", "🌒"],
+    },
+)
+
+user_mnemonic_24 = Account(
+    address="0xf2d58ae5aa880f7c3f65d769296b1061c61e0955",
+    private_key="",
+    password="Strong12345",
+    passphrase="border cabbage grape stage return enable bamboo main only voyage glad race patient stool drum sort "
+    "army abandon elegant grit cinnamon endless rail drink",
+    accounts=[
+        {
+            "address": "0x8a6d1f3b9f158f7274ca4be1a3f0056c86e2ccdb",
+            "public-key": "0x04c25b359fab7fc8989d6325128b06dd9734b38d207dc2ab652e130a5d59852910fd6414694e1f5ce3a9cdd5c1"
+            "f6bec9a425a57bae10c98ff4337adba3bf8c18bb",
+            "path": "m/43'/60'/1581'/0'/0",
+            "prodPreferredChainIds": "1:10:42161:8453",
+            "operable": "fully",
+            "position": -1,
+        },
+        {
+            "address": "0xf2d58ae5aa880f7c3f65d769296b1061c61e0955",
+            "public-key": "0x04218096ceb5420c9b4cfa9d0187a057099540edff0aa5882b0a16b76fc8f0056d1a01930db4981f8885d00137"
+            "c535740c04eec7ebe8bae7ef9fd98338fba31e04",
+            "path": "m/44'/60'/0'/0/0",
+            "name": "Account 1",
+            "colorId": "primary",
+            "hidden": False,
+            "prodPreferredChainIds": "1:10:42161:8453",
+            "position": 0,
+        },
+    ],
+    profile_data={
+        "address": "0xb47386b0074a9ddfd979540f134915d1df8dc3d0",
+        "dapps-address": "0xf2d58ae5aa880f7c3f65d769296b1061c61e0955",
+        "eip1581-address": "0xf203f9c33afd10e2d3888289ad2cad81c4b017c4",
+        "key-uid": "0xcf119f28496e4123dd6d5a4936c5f595ee1a873b11ead5f275098456eb8777c4",
+        "name": "Selfassured Pesky Mayfly",
+        "public-key": "0x04c25b359fab7fc8989d6325128b06dd9734b38d207dc2ab652e130a5d59852910fd6414694e1f5ce3a9cdd5c1f6be"
+        "c9a425a57bae10c98ff4337adba3bf8c18bb",
+        "wallet-root-address": "0x0410bd5715fdd8ccadede1d3131a9180a96e502c",
+        "emojiHash": ["👦🏻", "🕔", "🧜", "👩🏽‍🤝‍👨🏼", "👩🏿‍🔧", "🉐", "🧝🏿‍♂️", "🚣🏾‍♀️", "🫀", "🏄🏿", "🌘", "🤵🏼‍♀️", "🏄🏿‍♀️", "🎴"],
+    },
+)
+
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))
 TESTS_DIR = os.path.join(PROJECT_ROOT, "tests-functional")
 SIGNALS_DIR = os.path.join(TESTS_DIR, "signals")

--- a/tests-functional/resources/constants.py
+++ b/tests-functional/resources/constants.py
@@ -1,6 +1,8 @@
+# Main constants file for tests
 from dataclasses import dataclass
 import os
-from typing import Optional
+from typing import Optional, List, Dict, Any
+from resources.test_data import mnemonic_12, mnemonic_15, mnemonic_24
 
 
 @dataclass
@@ -9,8 +11,8 @@ class Account:
     private_key: str
     password: str
     passphrase: str
-    accounts: Optional[list] = None  # Optional list of accounts
-    profile_data: Optional[dict] = None  # Optional profile data
+    accounts: Optional[List[Dict[str, Any]]] = None  # Optional list of accounts
+    profile_data: Optional[Dict[str, Any]] = None  # Optional profile data
 
 
 user_1 = Account(
@@ -31,61 +33,8 @@ user_mnemonic_12 = Account(
     private_key="",
     password="Strong12345",
     passphrase="exhibit soldier miracle series edge atom daring alter absorb decide orphan addict",
-    accounts=[
-        {
-            "address": "0xb01a7dbaaacc92581558a4d178289be7471ba0f4",
-            "public-key": "0x047fd6e4384b764cb7782bf747ad3fb51e8c54c2b3c2be7029c72d85d16b07f4be6a8703cf0a1d97be4c8712ad"
-            "52cd6a519efdc723faae4935bbaba5c320dde02b",
-            "path": "m/43'/60'/1581'/0'/0",
-            "prodPreferredChainIds": "1:10:42161:8453",
-            "operable": "fully",
-            "position": -1,
-        },
-        {
-            "address": "0xc43f4ab94ec965a3ee9815c5df07383057d261a8",
-            "public-key": "0x041d8f6ebfa662c506d3d11cd407373f8ff2eb4c9ddc61a834864150a908172efbaa37f0de7dbeeea51f02272"
-            "74e6ccd78fa5a07de55716094dbba475ac9e9ab44",
-            "path": "m/44'/60'/0'/0/0",
-            "name": "Account 1",
-            "colorId": "primary",
-            "hidden": False,
-            "prodPreferredChainIds": "1:10:42161:8453",
-            "position": 0,
-        },
-    ],
-    profile_data={
-        "address": "0x5f8e02f9f52709b29c82bd893d9af0f83273a6e4",
-        "currency": "usd",
-        "networks/current-network": "",
-        "dapps-address": "0xc43f4ab94ec965a3ee9815c5df07383057d261a8",
-        "eip1581-address": "0x803102f704324d4a4f2ddb1c47f6ab31339d0f70",
-        "key-uid": "0x3231d92c94548d14f097173765a50bebe28fbad8f2267c9e08cc4433a6f219a4",
-        "latest-derived-path": 0,
-        "link-preview-request-enabled": True,
-        "messages-from-contacts-only": False,
-        "mutual-contact-enabled?": False,
-        "name": "Anchored Open Wirehair",
-        "networks/networks": [],
-        "news-feed-enabled?": True,
-        "news-rss-enabled?": True,
-        "photo-path": "",
-        "preview-privacy?": False,
-        "public-key": "0x047fd6e4384b764cb7782bf747ad3fb51e8c54c2b3c2be7029c72d85d16b07f4be6a8703cf0a1d97be4c8712ad52cd"
-        "6a519efdc723faae4935bbaba5c320dde02b",
-        "default-sync-period": 777600,
-        "appearance": 0,
-        "profile-pictures-show-to": 2,
-        "profile-pictures-visibility": 2,
-        "use-mailservers?": True,
-        "wallet-root-address": "0x1846a7930d0ab03e5a120ebdd46eff3fe0365824",
-        "send-status-updates?": True,
-        "backup-enabled?": True,
-        "show-community-asset-when-sending-tokens?": True,
-        "display-assets-below-balance-threshold": 100000000,
-        "url-unfurling-mode": 1,
-        "compressedKey": "zQ3shoF8xQNaT44MWQxztUXK6DK9UU63PRgJhn1Zd7oYWXJ5K",
-        "emojiHash": ["🔢", "🤞🏽", "🖍️", "🙇🏽‍♀️", "🙋🏼‍♀️", "🙌", "💎", "🎞️", "😊", "🦸🏼", "😤", "👵🏿", "🧑🏿‍🔧", "🤶🏿"],
-    },
+    accounts=mnemonic_12.accounts,
+    profile_data=mnemonic_12.profile_data,
 )
 
 user_mnemonic_15 = Account(
@@ -93,80 +42,20 @@ user_mnemonic_15 = Account(
     private_key="",
     password="Strong12345",
     passphrase="category two chapter fame hunt horse huge rotate inner monkey affair champion mixed tail final",
-    accounts=[
-        {
-            "address": "0x245b7438961de05444645898f9215e5cf0786891",
-            "public-key": "0x04c898c7763afd577f10efdd9e5d607caafd6d708e6cad8cee1b6d822d6ab148eb4e76d1c8266c8b73c8ce1d76"
-            "699e072ac5844a9a6934abb565044bf619336302",
-            "path": "m/43'/60'/1581'/0'/0",
-            "prodPreferredChainIds": "1:10:42161:8453",
-            "operable": "fully",
-            "position": -1,
-        },
-        {
-            "address": "0x685d7ec8e08769ca7020a6b65709887e38e68e6d",
-            "public-key": "0x0480acddfad1e73c3e70e8e50f82eb1566e3df125736e9fe9042c4df5022c825afe6234021ad8bbb43e0ab0196"
-            "878c2d9e3c8b5a8f266aca72b0e23d1f84464c72",
-            "path": "m/44'/60'/0'/0/0",
-            "name": "Account 1",
-            "colorId": "primary",
-            "hidden": False,
-            "prodPreferredChainIds": "1:10:42161:8453",
-            "position": 0,
-        },
-    ],
-    profile_data={
-        "address": "0x3644a8cc3860606fdee3b95c8825e17933a91647",
-        "dapps-address": "0x685d7ec8e08769ca7020a6b65709887e38e68e6d",
-        "eip1581-address": "0xe98734898ff58ac33a1a9c28f732696ec3e6b580",
-        "key-uid": "0x944c1ce03f83dd1750acee591745d6ef14da90723af86f97b2df7d7282e8dd97",
-        "name": "Overcooked Lost Grayreefshark",
-        "public-key": "0x04c898c7763afd577f10efdd9e5d607caafd6d708e6cad8cee1b6d822d6ab148eb4e76d1c8266c8b73c8ce1d76699e"
-        "072ac5844a9a6934abb565044bf619336302",
-        "wallet-root-address": "0xe89675c9be641ceeca9f250345dc58528c3de93b",
-        "emojiHash": ["🏄🏾", "👒", "👨🏽‍🎓", "🅰️", "👩🏾‍🍳", "🪀", "📩", "🐄", "⏳", "👸🏻", "🚣🏾‍♂️", "👩🏽‍🤝‍👩🏻", "📀", "🌒"],
-    },
+    accounts=mnemonic_15.accounts,
+    profile_data=mnemonic_15.profile_data,
 )
 
 user_mnemonic_24 = Account(
     address="0xf2d58ae5aa880f7c3f65d769296b1061c61e0955",
     private_key="",
     password="Strong12345",
-    passphrase="border cabbage grape stage return enable bamboo main only voyage glad race patient stool drum sort "
-    "army abandon elegant grit cinnamon endless rail drink",
-    accounts=[
-        {
-            "address": "0x8a6d1f3b9f158f7274ca4be1a3f0056c86e2ccdb",
-            "public-key": "0x04c25b359fab7fc8989d6325128b06dd9734b38d207dc2ab652e130a5d59852910fd6414694e1f5ce3a9cdd5c1"
-            "f6bec9a425a57bae10c98ff4337adba3bf8c18bb",
-            "path": "m/43'/60'/1581'/0'/0",
-            "prodPreferredChainIds": "1:10:42161:8453",
-            "operable": "fully",
-            "position": -1,
-        },
-        {
-            "address": "0xf2d58ae5aa880f7c3f65d769296b1061c61e0955",
-            "public-key": "0x04218096ceb5420c9b4cfa9d0187a057099540edff0aa5882b0a16b76fc8f0056d1a01930db4981f8885d00137"
-            "c535740c04eec7ebe8bae7ef9fd98338fba31e04",
-            "path": "m/44'/60'/0'/0/0",
-            "name": "Account 1",
-            "colorId": "primary",
-            "hidden": False,
-            "prodPreferredChainIds": "1:10:42161:8453",
-            "position": 0,
-        },
-    ],
-    profile_data={
-        "address": "0xb47386b0074a9ddfd979540f134915d1df8dc3d0",
-        "dapps-address": "0xf2d58ae5aa880f7c3f65d769296b1061c61e0955",
-        "eip1581-address": "0xf203f9c33afd10e2d3888289ad2cad81c4b017c4",
-        "key-uid": "0xcf119f28496e4123dd6d5a4936c5f595ee1a873b11ead5f275098456eb8777c4",
-        "name": "Selfassured Pesky Mayfly",
-        "public-key": "0x04c25b359fab7fc8989d6325128b06dd9734b38d207dc2ab652e130a5d59852910fd6414694e1f5ce3a9cdd5c1f6be"
-        "c9a425a57bae10c98ff4337adba3bf8c18bb",
-        "wallet-root-address": "0x0410bd5715fdd8ccadede1d3131a9180a96e502c",
-        "emojiHash": ["👦🏻", "🕔", "🧜", "👩🏽‍🤝‍👨🏼", "👩🏿‍🔧", "🉐", "🧝🏿‍♂️", "🚣🏾‍♀️", "🫀", "🏄🏿", "🌘", "🤵🏼‍♀️", "🏄🏿‍♀️", "🎴"],
-    },
+    passphrase=(
+        "border cabbage grape stage return enable bamboo main only voyage glad race patient stool drum sort "
+        "army abandon elegant grit cinnamon endless rail drink"
+    ),
+    accounts=mnemonic_24.accounts,
+    profile_data=mnemonic_24.profile_data,
 )
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))

--- a/tests-functional/resources/test_data/__init__.py
+++ b/tests-functional/resources/test_data/__init__.py
@@ -1,0 +1,1 @@
+# Make test_data a proper Python package

--- a/tests-functional/resources/test_data/mnemonic_12.py
+++ b/tests-functional/resources/test_data/mnemonic_12.py
@@ -1,0 +1,61 @@
+# Account data for mnemonic with 12 words
+
+accounts = [
+    {
+        "address": "0xb01a7dbaaacc92581558a4d178289be7471ba0f4",
+        "public-key": (
+            "0x047fd6e4384b764cb7782bf747ad3fb51e8c54c2b3c2be7029c72d85d16b07f4be6a8703cf0a1d97be4c8712ad" "52cd6a519efdc723faae4935bbaba5c320dde02b"
+        ),
+        "path": "m/43'/60'/1581'/0'/0",
+        "prodPreferredChainIds": "1:10:42161:8453",
+        "operable": "fully",
+        "position": -1,
+    },
+    {
+        "address": "0xc43f4ab94ec965a3ee9815c5df07383057d261a8",
+        "public-key": (
+            "0x041d8f6ebfa662c506d3d11cd407373f8ff2eb4c9ddc61a834864150a908172efbaa37f0de7dbeeea51f02272" "74e6ccd78fa5a07de55716094dbba475ac9e9ab44"
+        ),
+        "path": "m/44'/60'/0'/0/0",
+        "name": "Account 1",
+        "colorId": "primary",
+        "hidden": False,
+        "prodPreferredChainIds": "1:10:42161:8453",
+        "position": 0,
+    },
+]
+
+profile_data = {
+    "address": "0x5f8e02f9f52709b29c82bd893d9af0f83273a6e4",
+    "currency": "usd",
+    "networks/current-network": "",
+    "dapps-address": "0xc43f4ab94ec965a3ee9815c5df07383057d261a8",
+    "eip1581-address": "0x803102f704324d4a4f2ddb1c47f6ab31339d0f70",
+    "key-uid": "0x3231d92c94548d14f097173765a50bebe28fbad8f2267c9e08cc4433a6f219a4",
+    "latest-derived-path": 0,
+    "link-preview-request-enabled": True,
+    "messages-from-contacts-only": False,
+    "mutual-contact-enabled?": False,
+    "name": "Anchored Open Wirehair",
+    "networks/networks": [],
+    "news-feed-enabled?": True,
+    "news-rss-enabled?": True,
+    "photo-path": "",
+    "preview-privacy?": False,
+    "public-key": (
+        "0x047fd6e4384b764cb7782bf747ad3fb51e8c54c2b3c2be7029c72d85d16b07f4be6a8703cf0a1d97be4c8712ad52cd" "6a519efdc723faae4935bbaba5c320dde02b"
+    ),
+    "default-sync-period": 777600,
+    "appearance": 0,
+    "profile-pictures-show-to": 2,
+    "profile-pictures-visibility": 2,
+    "use-mailservers?": True,
+    "wallet-root-address": "0x1846a7930d0ab03e5a120ebdd46eff3fe0365824",
+    "send-status-updates?": True,
+    "backup-enabled?": True,
+    "show-community-asset-when-sending-tokens?": True,
+    "display-assets-below-balance-threshold": 100000000,
+    "url-unfurling-mode": 1,
+    "compressedKey": "zQ3shoF8xQNaT44MWQxztUXK6DK9UU63PRgJhn1Zd7oYWXJ5K",
+    "emojiHash": ["🔢", "🤞🏽", "🖍️", "🙇🏽‍♀️", "🙋🏼‍♀️", "🙌", "💎", "🎞️", "😊", "🦸🏼", "😤", "👵🏿", "🧑🏿‍🔧", "🤶🏿"],
+}

--- a/tests-functional/resources/test_data/mnemonic_15.py
+++ b/tests-functional/resources/test_data/mnemonic_15.py
@@ -1,0 +1,39 @@
+# Account data for mnemonic with 15 words
+
+accounts = [
+    {
+        "address": "0x245b7438961de05444645898f9215e5cf0786891",
+        "public-key": (
+            "0x04c898c7763afd577f10efdd9e5d607caafd6d708e6cad8cee1b6d822d6ab148eb4e76d1c8266c8b73c8ce1d76" "699e072ac5844a9a6934abb565044bf619336302"
+        ),
+        "path": "m/43'/60'/1581'/0'/0",
+        "prodPreferredChainIds": "1:10:42161:8453",
+        "operable": "fully",
+        "position": -1,
+    },
+    {
+        "address": "0x685d7ec8e08769ca7020a6b65709887e38e68e6d",
+        "public-key": (
+            "0x0480acddfad1e73c3e70e8e50f82eb1566e3df125736e9fe9042c4df5022c825afe6234021ad8bbb43e0ab0196" "878c2d9e3c8b5a8f266aca72b0e23d1f84464c72"
+        ),
+        "path": "m/44'/60'/0'/0/0",
+        "name": "Account 1",
+        "colorId": "primary",
+        "hidden": False,
+        "prodPreferredChainIds": "1:10:42161:8453",
+        "position": 0,
+    },
+]
+
+profile_data = {
+    "address": "0x3644a8cc3860606fdee3b95c8825e17933a91647",
+    "dapps-address": "0x685d7ec8e08769ca7020a6b65709887e38e68e6d",
+    "eip1581-address": "0xe98734898ff58ac33a1a9c28f732696ec3e6b580",
+    "key-uid": "0x944c1ce03f83dd1750acee591745d6ef14da90723af86f97b2df7d7282e8dd97",
+    "name": "Overcooked Lost Grayreefshark",
+    "public-key": (
+        "0x04c898c7763afd577f10efdd9e5d607caafd6d708e6cad8cee1b6d822d6ab148eb4e76d1c8266c8b73c8ce1d76699e" "072ac5844a9a6934abb565044bf619336302"
+    ),
+    "wallet-root-address": "0xe89675c9be641ceeca9f250345dc58528c3de93b",
+    "emojiHash": ["🏄🏾", "👒", "👨🏽‍🎓", "🅰️", "👩🏾‍🍳", "🪀", "📩", "🐄", "⏳", "👸🏻", "🚣🏾‍♂️", "👩🏽‍🤝‍👩🏻", "📀", "🌒"],
+}

--- a/tests-functional/resources/test_data/mnemonic_24.py
+++ b/tests-functional/resources/test_data/mnemonic_24.py
@@ -1,0 +1,39 @@
+# Account data for mnemonic with 24 words
+
+accounts = [
+    {
+        "address": "0x8a6d1f3b9f158f7274ca4be1a3f0056c86e2ccdb",
+        "public-key": (
+            "0x04c25b359fab7fc8989d6325128b06dd9734b38d207dc2ab652e130a5d59852910fd6414694e1f5ce3a9cdd5c1" "f6bec9a425a57bae10c98ff4337adba3bf8c18bb"
+        ),
+        "path": "m/43'/60'/1581'/0'/0",
+        "prodPreferredChainIds": "1:10:42161:8453",
+        "operable": "fully",
+        "position": -1,
+    },
+    {
+        "address": "0xf2d58ae5aa880f7c3f65d769296b1061c61e0955",
+        "public-key": (
+            "0x04218096ceb5420c9b4cfa9d0187a057099540edff0aa5882b0a16b76fc8f0056d1a01930db4981f8885d00137" "c535740c04eec7ebe8bae7ef9fd98338fba31e04"
+        ),
+        "path": "m/44'/60'/0'/0/0",
+        "name": "Account 1",
+        "colorId": "primary",
+        "hidden": False,
+        "prodPreferredChainIds": "1:10:42161:8453",
+        "position": 0,
+    },
+]
+
+profile_data = {
+    "address": "0xb47386b0074a9ddfd979540f134915d1df8dc3d0",
+    "dapps-address": "0xf2d58ae5aa880f7c3f65d769296b1061c61e0955",
+    "eip1581-address": "0xf203f9c33afd10e2d3888289ad2cad81c4b017c4",
+    "key-uid": "0xcf119f28496e4123dd6d5a4936c5f595ee1a873b11ead5f275098456eb8777c4",
+    "name": "Selfassured Pesky Mayfly",
+    "public-key": (
+        "0x04c25b359fab7fc8989d6325128b06dd9734b38d207dc2ab652e130a5d59852910fd6414694e1f5ce3a9cdd5c1f6be" "c9a425a57bae10c98ff4337adba3bf8c18bb"
+    ),
+    "wallet-root-address": "0x0410bd5715fdd8ccadede1d3131a9180a96e502c",
+    "emojiHash": ["👦🏻", "🕔", "🧜", "👩🏽‍🤝‍👨🏼", "👩🏿‍🔧", "🉐", "🧝🏿‍♂️", "🚣🏾‍♀️", "🫀", "🏄🏿", "🌘", "🤵🏼‍♀️", "🏄🏿‍♀️", "🎴"],
+}

--- a/tests-functional/resources/utils.py
+++ b/tests-functional/resources/utils.py
@@ -1,0 +1,20 @@
+def assert_account_attributes(actual, expected, keys=None):
+    """
+    Assert that all keys in expected (or in keys) match in actual.
+    Handles both list-of-dicts and dict.
+    """
+    if isinstance(expected, list):
+        assert isinstance(actual, list), "Expected a list for actual"
+        assert len(actual) == len(expected), "Length mismatch"
+        for idx, exp in enumerate(expected):
+            act = actual[idx]
+            check_keys = keys or exp.keys()
+            for key in check_keys:
+                assert act[key] == exp[key], f"Mismatch for key '{key}': {act[key]} != {exp[key]}"
+    elif isinstance(expected, dict):
+        assert isinstance(actual, dict), "Expected a dict for actual"
+        check_keys = keys or expected.keys()
+        for key in check_keys:
+            assert actual[key] == expected[key], f"Mismatch for key '{key}': {actual.get(key)} != {expected[key]}"
+    else:
+        raise TypeError("Expected must be a list or dict")

--- a/tests-functional/resources/utils.py
+++ b/tests-functional/resources/utils.py
@@ -1,4 +1,4 @@
-def assert_account_attributes(actual, expected, keys=None):
+def assert_response_attributes(actual, expected, keys=None):
     """
     Assert that all keys in expected (or in keys) match in actual.
     Handles both list-of-dicts and dict.

--- a/tests-functional/tests/test_recover_mnemonic.py
+++ b/tests-functional/tests/test_recover_mnemonic.py
@@ -4,7 +4,7 @@ from clients.signals import SignalType
 import logging
 
 from resources.constants import user_mnemonic_12, user_mnemonic_15, user_mnemonic_24
-from resources.utils import assert_account_attributes
+from resources.utils import assert_response_attributes
 
 
 @pytest.mark.create_account
@@ -30,8 +30,8 @@ class TestRecoverMnemonic:
 
         logging.info("Step: request getAccounts and check recovered accounts attributes.")
         response = backend_client.rpc_valid_request("accounts_getAccounts", [])
-        assert_account_attributes(response.json()["result"], user_mnemonic.accounts)
+        assert_response_attributes(response.json()["result"], user_mnemonic.accounts)
 
         logging.info("Step: request getSettings and check recovered profile data attributes.")
         response = backend_client.rpc_valid_request("settings_getSettings", [])
-        assert_account_attributes(response.json()["result"], user_mnemonic.profile_data)
+        assert_response_attributes(response.json()["result"], user_mnemonic.profile_data)

--- a/tests-functional/tests/test_recover_mnemonic.py
+++ b/tests-functional/tests/test_recover_mnemonic.py
@@ -1,0 +1,37 @@
+from clients.status_backend import StatusBackend
+import pytest
+from clients.signals import SignalType
+import logging
+
+from resources.constants import user_mnemonic_12, user_mnemonic_15, user_mnemonic_24
+from resources.utils import assert_account_attributes
+
+
+@pytest.mark.create_account
+@pytest.mark.rpc
+class TestRecoverMnemonic:
+    @pytest.mark.parametrize(
+        "user_mnemonic",
+        [user_mnemonic_24, user_mnemonic_15, user_mnemonic_12],
+        ids=["mnemonic_24", "mnemonic_15", "mnemonic_12"],
+    )
+    def test_recover_app_different_mnemonic(self, user_mnemonic):
+        await_signals = [
+            SignalType.MEDIASERVER_STARTED.value,
+            SignalType.NODE_STARTED.value,
+            SignalType.NODE_READY.value,
+            SignalType.NODE_LOGIN.value,
+        ]
+
+        logging.info("Step: Initialize backend client and restore account using user_mnemonic.")
+        backend_client = StatusBackend(await_signals)
+        backend_client.init_status_backend()
+        backend_client.restore_account_and_login(user=user_mnemonic)
+
+        logging.info("Step: request getAccounts and check recovered accounts attributes.")
+        response = backend_client.rpc_valid_request("accounts_getAccounts", [])
+        assert_account_attributes(response.json()["result"], user_mnemonic.accounts)
+
+        logging.info("Step: request getSettings and check recovered profile data attributes.")
+        response = backend_client.rpc_valid_request("settings_getSettings", [])
+        assert_account_attributes(response.json()["result"], user_mnemonic.profile_data)


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/6681

This pull request introduces enhancements to the functional testing framework by adding new account configurations, utility functions, and test cases for recovering accounts using different mnemonics. The changes improve test coverage and validation for account recovery scenarios (12,15,24 words mnemonic)

### Enhancements to account configurations:
* Added optional fields `accounts` and `profile_data` to the `Account` dataclass in `tests-functional/resources/constants.py` to support storing additional account-related data.
* Introduced three new account configurations (`user_mnemonic_12`, `user_mnemonic_15`, and `user_mnemonic_24`) with detailed account and profile data for testing mnemonic recovery.

### Utility function for validation:
* Added a new function `assert_account_attributes` in `tests-functional/resources/utils.py` to validate that account attributes match expected values, supporting both dictionaries and lists of dictionaries.

### New test case for mnemonic recovery:
* Created a parameterized test case `test_recover_app_different_mnemonic` in `tests-functional/tests/test_recover_mnemonic.py` to verify account recovery using mnemonics with 12, 15, and 24 words. This includes validating account attributes and profile data using the new utility function.