### PR TITLE
refactor(accounts-management)_: enhance AccountsManager with persistence interface

### DIFF
--- a/accounts-management/README.md
+++ b/accounts-management/README.md
@@ -103,7 +103,7 @@ childAccounts, err := manager.DeriveChildrenAccountsForPathsAndStore(
 #### Keystore Operations
 ```go
 // Migrate keystore to new directory
-err := manager.MigrateKeyStoreDir(newDir, addresses)
+err := manager.MigrateKeyStoreDir(newDir)
 
 // Re-encrypt keystore with new password
 err := manager.ReEncryptKeyStoreDir(oldPassword, newPassword)

--- a/accounts-management/README.md
+++ b/accounts-management/README.md
@@ -36,6 +36,24 @@ The main interface for account management operations. It provides methods for:
 - **Account Selection**: Select and manage the currently active account
 - **Account Derivation**: Derive child accounts from existing accounts
 
+#### Constructor
+```go
+// Create a new AccountsManager instance
+manager, err := NewAccountsManager(logger)
+```
+
+The constructor requires:
+- `logger`: A zap.Logger instance for logging operations
+
+After creation, you need to set up the persistence and keystore:
+```go
+// Set the persistence layer for account data storage
+manager.SetPersistence(persistence)
+
+// Set the keystore for secure key storage
+manager.SetKeystore(keystore)
+```
+
 ### Key Features
 
 #### Account Creation
@@ -110,11 +128,21 @@ func main() {
     // Initialize logger
     logger, _ := zap.NewDevelopment()
 
-    // Create account manager
-    manager := accountsmanagement.NewAccountsManager(logger)
+    // Create persistence instance aligning with `Persistence` interface
+    persistence := yourPersistenceImplementation()
 
-    // Set up keystore (implementation depends on your setup)
-    // manager.SetKeystore(keystore)
+    // Create account manager with persistence and logger
+    manager, err := accountsmanagement.NewAccountsManager(logger)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // Set the persistence layer for account data storage
+    manager.SetPersistence(persistence)
+
+    // Set up keystore instance aligning with `KeyStore` interface
+    keystore := yourKeystoreImplementation()
+    manager.SetKeystore(keystore)
 
     // Create a new account
     account, mnemonic, err := manager.CreateAndStoreAccount("my-password")
@@ -161,6 +189,8 @@ The package defines several custom errors:
 - `go.uber.org/zap`: Logging
 - `github.com/status-im/status-go/eth-node/types`: Ethereum types
 - `github.com/status-im/status-go/multiaccounts`: Multi-account support
+- `Persistence` interface: Required for account data storage operations
+- `KeyStore` interface: Required for secure cryptographic key storage, encryption/decryption, and keystore management operations
 
 ## Testing
 

--- a/accounts-management/accounts.go
+++ b/accounts-management/accounts.go
@@ -12,7 +12,6 @@ import (
 	"github.com/status-im/status-go/accounts-management/common"
 	"github.com/status-im/status-go/accounts-management/generator"
 	"github.com/status-im/status-go/accounts-management/keystore/geth"
-	"github.com/status-im/status-go/accounts-management/types"
 	gocommon "github.com/status-im/status-go/common"
 	ethtypes "github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts/accounts"
@@ -29,7 +28,7 @@ func (e ErrCannotLocateKeyFile) Error() string {
 // AccountsManager represents the default account manager implementation
 type AccountsManager struct {
 	keystoreMu sync.RWMutex
-	keystore   types.KeyStore
+	keystore   KeyStore
 
 	selectedChatAccountMutex sync.RWMutex
 	selectedChatAccount      *generator.Account
@@ -43,7 +42,7 @@ func NewAccountsManager(logger *zap.Logger) *AccountsManager {
 	}
 }
 
-func (m *AccountsManager) SetKeystore(keystore types.KeyStore) {
+func (m *AccountsManager) SetKeystore(keystore KeyStore) {
 	m.keystoreMu.Lock()
 	defer m.keystoreMu.Unlock()
 

--- a/accounts-management/accounts.go
+++ b/accounts-management/accounts.go
@@ -237,15 +237,15 @@ func (m *AccountsManager) Accounts() ([]ethtypes.Address, error) {
 	return addresses, nil
 }
 
-func (m *AccountsManager) MigrateKeyStoreDir(newDir string, addresses []string) error {
+func (m *AccountsManager) MigrateKeyStoreDir(newDir string) error {
 	m.keystoreMu.RLock()
 	defer m.keystoreMu.RUnlock()
 
 	if m.keystore == nil {
 		return ErrAccountKeyStoreMissing
 	}
-	m.logger.Info("migrating keystore directory", zap.String("new location", newDir), zap.Strings("addresses", addresses))
-	return m.keystore.MigrateKeyStoreDir(newDir, addresses)
+	m.logger.Info("migrating keystore directory", zap.String("new location", newDir))
+	return m.keystore.MigrateKeyStoreDir(newDir)
 }
 
 func (m *AccountsManager) ReEncryptKeyStoreDir(oldPass, newPass string) error {

--- a/accounts-management/accounts.go
+++ b/accounts-management/accounts.go
@@ -14,7 +14,6 @@ import (
 	"github.com/status-im/status-go/accounts-management/keystore/geth"
 	gocommon "github.com/status-im/status-go/common"
 	ethtypes "github.com/status-im/status-go/eth-node/types"
-	"github.com/status-im/status-go/multiaccounts/accounts"
 )
 
 type ErrCannotLocateKeyFile struct {
@@ -27,8 +26,9 @@ func (e ErrCannotLocateKeyFile) Error() string {
 
 // AccountsManager represents the default account manager implementation
 type AccountsManager struct {
-	keystoreMu sync.RWMutex
-	keystore   KeyStore
+	keystoreMu  sync.RWMutex
+	keystore    KeyStore
+	persistence Persistence
 
 	selectedChatAccountMutex sync.RWMutex
 	selectedChatAccount      *generator.Account
@@ -36,10 +36,19 @@ type AccountsManager struct {
 	logger *zap.Logger
 }
 
-func NewAccountsManager(logger *zap.Logger) *AccountsManager {
+func NewAccountsManager(logger *zap.Logger) (*AccountsManager, error) {
+	if logger == nil {
+		return nil, ErrLoggerIsMissing
+	}
+
+	logger.Info("accounts manager created")
 	return &AccountsManager{
 		logger: logger,
-	}
+	}, nil
+}
+
+func (m *AccountsManager) SetPersistence(persistence Persistence) {
+	m.persistence = persistence
 }
 
 func (m *AccountsManager) SetKeystore(keystore KeyStore) {
@@ -47,6 +56,7 @@ func (m *AccountsManager) SetKeystore(keystore KeyStore) {
 	defer m.keystoreMu.Unlock()
 
 	m.keystore = keystore
+	m.logger.Info("new keystore set")
 }
 
 // CreateAndStoreAccount creates an internal geth account and stores it in the keystore
@@ -69,6 +79,10 @@ func (m *AccountsManager) CreateFromMnemonicAndStoreAccount(mnemonic string, pas
 	}
 
 	err = m.storeToKeystore(genAccount, password)
+	if err != nil {
+		return
+	}
+	m.logger.Info("account created and stored (mnemonic)", zap.String("address", genAccount.Address().Hex()))
 
 	return
 }
@@ -80,6 +94,10 @@ func (m *AccountsManager) CreateFromPrivateKeyAndStoreAccount(privateKey string,
 	}
 
 	err = m.storeToKeystore(acc, password)
+	if err != nil {
+		return
+	}
+	m.logger.Info("account created and stored (private key)", zap.String("address", acc.Address().Hex()))
 
 	return
 }
@@ -110,6 +128,7 @@ func (m *AccountsManager) LoadAccount(address ethtypes.Address, password string)
 
 	_, privateKey, extendedKey, err := m.keystore.AccountDecryptedKey(address, password)
 	if err != nil {
+		m.logger.Error("error loading account", zap.String("address", address.Hex()), zap.Error(err))
 		if errors.Is(err, geth.ErrNoMatch) {
 			return nil, &ErrCannotLocateKeyFile{fmt.Sprintf("cannot locate account for address: %s", address.Hex())}
 		}
@@ -118,9 +137,11 @@ func (m *AccountsManager) LoadAccount(address ethtypes.Address, password string)
 
 	account := generator.NewAccount(privateKey, extendedKey)
 	if err := account.ValidateExtendedKey(); err != nil {
+		m.logger.Error("error validating account", zap.String("address", address.Hex()), zap.Error(err))
 		return nil, err
 	}
 
+	m.logger.Info("account loaded", zap.String("address", address.Hex()))
 	return account, nil
 }
 
@@ -131,6 +152,12 @@ func (m *AccountsManager) storeToKeystore(acc *generator.Account, password strin
 	if m.keystore == nil {
 		return ErrAccountKeyStoreMissing
 	}
+
+	if acc == nil {
+		return ErrAccountIsNil
+	}
+
+	m.logger.Info("storing account to keystore", zap.String("address", acc.Address().Hex()))
 
 	if acc.HasExtendedKey() {
 		_, err = m.keystore.ImportSingleExtendedKey(acc.ExtendedKey(), password)
@@ -146,6 +173,11 @@ func (m *AccountsManager) setChatAccount(account *generator.Account) {
 	defer m.selectedChatAccountMutex.Unlock()
 
 	m.selectedChatAccount = account
+	if account != nil {
+		m.logger.Info("chat account set", zap.String("address", account.Address().Hex()))
+	} else {
+		m.logger.Info("chat account cleared")
+	}
 }
 
 // SetChatAccount sets the chat account with the given address and password
@@ -184,6 +216,7 @@ func (m *AccountsManager) SelectedChatAccount() (*generator.Account, error) {
 func (m *AccountsManager) Logout() {
 	m.setChatAccount(nil)
 	m.SetKeystore(nil)
+	m.logger.Info("logout")
 }
 
 // Accounts returns list of addresses for selected account, including subaccounts.
@@ -211,6 +244,7 @@ func (m *AccountsManager) MigrateKeyStoreDir(newDir string, addresses []string) 
 	if m.keystore == nil {
 		return ErrAccountKeyStoreMissing
 	}
+	m.logger.Info("migrating keystore directory", zap.String("new location", newDir), zap.Strings("addresses", addresses))
 	return m.keystore.MigrateKeyStoreDir(newDir, addresses)
 }
 
@@ -221,6 +255,7 @@ func (m *AccountsManager) ReEncryptKeyStoreDir(oldPass, newPass string) error {
 	if m.keystore == nil {
 		return ErrAccountKeyStoreMissing
 	}
+	m.logger.Info("re-encrypting keystore directory")
 	return m.keystore.ReEncryptKeyStoreDir(oldPass, newPass)
 }
 
@@ -229,24 +264,30 @@ func (m *AccountsManager) DeleteAccount(address ethtypes.Address) error {
 	defer m.keystoreMu.RUnlock()
 
 	if m.keystore == nil {
+		m.logger.Error("cannot delete account, keystore is missing", zap.String("address", address.Hex()))
 		return ErrAccountKeyStoreMissing
 	}
+	m.logger.Info("deleting account", zap.String("address", address.Hex()))
 	return m.keystore.Delete(address)
 }
 
-func (m *AccountsManager) GetVerifiedWalletAccount(db *accounts.Database, address ethtypes.Address, password string) (*generator.Account, error) {
-	exists, err := db.AddressExists(address)
+func (m *AccountsManager) GetVerifiedWalletAccount(address ethtypes.Address, password string) (*generator.Account, error) {
+	if m.persistence == nil {
+		return nil, ErrPersistenceIsMissing
+	}
+
+	exists, err := m.persistence.AddressExists(address)
 	if err != nil {
 		return nil, err
 	}
 
 	if !exists {
-		return nil, errors.New("account doesn't exist")
+		return nil, ErrAccountDoesNotExist
 	}
 
 	account, err := m.LoadAccount(address, password)
 	if errors.Is(err, geth.ErrNoMatch) {
-		account, err = m.generatePartialAccountKey(db, address, password)
+		account, err = m.generatePartialAccountKey(address, password)
 		if err != nil {
 			return nil, err
 		}
@@ -259,17 +300,21 @@ func (m *AccountsManager) GetVerifiedWalletAccount(db *accounts.Database, addres
 	return account, nil
 }
 
-func (m *AccountsManager) generatePartialAccountKey(db *accounts.Database, address ethtypes.Address, password string) (*generator.Account, error) {
-	rootAddress, err := db.GetWalletRootAddress()
+func (m *AccountsManager) generatePartialAccountKey(address ethtypes.Address, password string) (*generator.Account, error) {
+	if m.persistence == nil {
+		return nil, ErrPersistenceIsMissing
+	}
+
+	rootAddress, err := m.persistence.GetWalletRootAddress()
 	if err != nil {
 		return nil, err
 	}
 
-	dbPath, err := db.GetPath(address)
-	path := "m/" + dbPath[strings.LastIndex(dbPath, "/")+1:]
+	dbPath, err := m.persistence.GetPath(address)
 	if err != nil {
 		return nil, err
 	}
+	path := "m/" + dbPath[strings.LastIndex(dbPath, "/")+1:]
 
 	return m.DeriveChildAccountForPathAndStore(rootAddress, path, password)
 }

--- a/accounts-management/accounts_test.go
+++ b/accounts-management/accounts_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/status-im/status-go/accounts-management/common"
 	"github.com/status-im/status-go/accounts-management/keystore/geth"
+	mock_persistence "github.com/status-im/status-go/accounts-management/mock"
 	"github.com/status-im/status-go/eth-node/crypto"
 	ethtypes "github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/tt"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	gomock "go.uber.org/mock/gomock"
 )
 
 const testPassword = "test-password"
@@ -32,7 +34,15 @@ func setKeystore(accManager *AccountsManager, keyStoreDir string) error {
 }
 
 func TestVerifyAccountPassword(t *testing.T) {
-	accManager := NewAccountsManager(tt.MustCreateTestLogger())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	accManager, err := NewAccountsManager(tt.MustCreateTestLogger())
+	require.NoError(t, err)
+
+	persistence := mock_persistence.NewMockPersistence(ctrl)
+	accManager.SetPersistence(persistence)
+
 	keyStoreDir := t.TempDir()
 	emptyKeyStoreDir := t.TempDir()
 
@@ -111,7 +121,14 @@ func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {
 	err := utils.ImportTestAccount(keyStoreDir, "test-account3-before-eip55.pk")
 	require.NoError(t, err)
 
-	accManager := NewAccountsManager(tt.MustCreateTestLogger())
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	accManager, err := NewAccountsManager(tt.MustCreateTestLogger())
+	require.NoError(t, err)
+
+	persistence := mock_persistence.NewMockPersistence(ctrl)
+	accManager.SetPersistence(persistence)
 
 	err = setKeystore(accManager, keyStoreDir)
 	require.NoError(t, err)
@@ -145,10 +162,18 @@ type testAccount struct {
 // SetupTest is used here for reinitializing the mock before every
 // test function to avoid faulty execution.
 func (s *ManagerTestSuite) SetupTest() {
-	s.accManager = NewAccountsManager(tt.MustCreateTestLogger())
+	ctrl := gomock.NewController(s.T())
+	defer ctrl.Finish()
+
+	var err error
+	s.accManager, err = NewAccountsManager(tt.MustCreateTestLogger())
+	s.Require().NoError(err)
+
+	persistence := mock_persistence.NewMockPersistence(ctrl)
+	s.accManager.SetPersistence(persistence)
 
 	keyStoreDir := s.T().TempDir()
-	err := setKeystore(s.accManager, keyStoreDir)
+	err = setKeystore(s.accManager, keyStoreDir)
 	s.Require().NoError(err)
 	s.keydir = keyStoreDir
 

--- a/accounts-management/accounts_test.go
+++ b/accounts-management/accounts_test.go
@@ -301,9 +301,7 @@ func (s *ManagerTestSuite) TestMigrateKeyStoreDir() {
 	files, _ := os.ReadDir(newKeyDir)
 	s.Equal(0, len(files))
 
-	address := ethtypes.HexToAddress(s.walletAddress).Hex()
-	addresses := []string{address}
-	err = s.accManager.MigrateKeyStoreDir(newKeyDir, addresses)
+	err = s.accManager.MigrateKeyStoreDir(newKeyDir)
 	s.Require().NoError(err)
 
 	files, _ = os.ReadDir(newKeyDir)

--- a/accounts-management/errors.go
+++ b/accounts-management/errors.go
@@ -5,6 +5,10 @@ import (
 )
 
 var (
+	ErrPersistenceIsMissing   = errors.New("persistence is not set")
+	ErrLoggerIsMissing        = errors.New("logger is not set")
+	ErrAccountDoesNotExist    = errors.New("account doesn't exist")
 	ErrNoAccountSelected      = errors.New("no account has been selected, please login")
 	ErrAccountKeyStoreMissing = errors.New("account key store is not set")
+	ErrAccountIsNil           = errors.New("account is nil")
 )

--- a/accounts-management/keystore.go
+++ b/accounts-management/keystore.go
@@ -29,5 +29,5 @@ type KeyStore interface {
 	// ReEncryptKeyStoreDir re-encrypts all keys in the keystore directory.
 	ReEncryptKeyStoreDir(oldPass, newPass string) error
 	// MigrateKeyStoreDir migrates the keystore directory from one location to another.
-	MigrateKeyStoreDir(newDir string, addresses []string) error
+	MigrateKeyStoreDir(newDir string) error
 }

--- a/accounts-management/keystore.go
+++ b/accounts-management/keystore.go
@@ -1,30 +1,31 @@
-package types
+package accountsmanagement
 
 import (
 	"crypto/ecdsa"
 
 	"github.com/status-im/extkeys"
 
+	"github.com/status-im/status-go/accounts-management/types"
 	ethtypes "github.com/status-im/status-go/eth-node/types"
 )
 
 type KeyStore interface {
 	// ImportECDSA imports a private key into the keystore
-	ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (Account, error)
+	ImportECDSA(priv *ecdsa.PrivateKey, passphrase string) (types.Account, error)
 	// ImportSingleExtendedKey imports an extended key setting it in both the PrivateKey and ExtendedKey fields
 	// of the Key struct.
 	// ImportExtendedKey is used in older version of Status where PrivateKey is set to be the BIP44 key at index 0,
 	// and ExtendedKey is the extended key of the BIP44 key at index 1.
-	ImportSingleExtendedKey(extKey *extkeys.ExtendedKey, passphrase string) (Account, error)
+	ImportSingleExtendedKey(extKey *extkeys.ExtendedKey, passphrase string) (types.Account, error)
 	// AccountDecryptedKey returns decrypted key for account (provided that password is correct).
-	AccountDecryptedKey(address ethtypes.Address, passphrase string) (Account, *ecdsa.PrivateKey, *extkeys.ExtendedKey, error)
+	AccountDecryptedKey(address ethtypes.Address, passphrase string) (types.Account, *ecdsa.PrivateKey, *extkeys.ExtendedKey, error)
 	// Delete deletes the key matched by account.
 	// If the account contains no filename, the address must match a unique key.
 	Delete(address ethtypes.Address) error
 	// Find returns the account matched by address
-	Find(address ethtypes.Address) (Account, error)
+	Find(address ethtypes.Address) (types.Account, error)
 	// Accounts returns all accounts in the keystore
-	Accounts() []Account
+	Accounts() []types.Account
 	// ReEncryptKeyStoreDir re-encrypts all keys in the keystore directory.
 	ReEncryptKeyStoreDir(oldPass, newPass string) error
 	// MigrateKeyStoreDir migrates the keystore directory from one location to another.

--- a/accounts-management/keystore/geth/adapter.go
+++ b/accounts-management/keystore/geth/adapter.go
@@ -114,8 +114,14 @@ func (a *Adapter) ReEncryptKeyStoreDir(oldPass, newPass string) error {
 	return reEncryptKeyStoreDir(a.keystoreDir, oldPass, newPass)
 }
 
-func (a *Adapter) MigrateKeyStoreDir(newDir string, addresses []string) error {
-	err := migrateKeyStoreDir(a.keystoreDir, newDir, addresses)
+func (a *Adapter) MigrateKeyStoreDir(newDir string) error {
+	addresses := a.Accounts()
+	addressesStr := make([]string, len(addresses))
+	for i, address := range addresses {
+		addressesStr[i] = address.Address.Hex()
+	}
+
+	err := migrateKeyStoreDir(a.keystoreDir, newDir, addressesStr)
 	if err != nil {
 		return err
 	}

--- a/accounts-management/persistence.go
+++ b/accounts-management/persistence.go
@@ -1,0 +1,16 @@
+package accountsmanagement
+
+//go:generate mockgen -package=mock_persistence -source=persistence.go -destination=mock/persistence.go
+
+import (
+	ethtypes "github.com/status-im/status-go/eth-node/types"
+)
+
+type Persistence interface {
+	// AddressExists checks if the address exists in the persistence
+	AddressExists(address ethtypes.Address) (bool, error)
+	// GetWalletRootAddress returns the root address of the wallet
+	GetWalletRootAddress() (ethtypes.Address, error)
+	// GetPath returns the derivation path of the address
+	GetPath(address ethtypes.Address) (string, error)
+}

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -985,36 +985,6 @@ func (b *GethStatusBackend) GetEnsUsernames() ([]*ens.UsernameDetail, error) {
 	return db.GetEnsUsernames(&removed)
 }
 
-func (b *GethStatusBackend) MigrateKeyStoreDir(acc multiaccounts.Account, password, newDir string) error {
-	err := b.ensureDBsOpened(acc, password)
-	if err != nil {
-		return err
-	}
-
-	accountDB, err := accounts.NewDB(b.appDB)
-	if err != nil {
-		return err
-	}
-	accounts, err := accountDB.GetActiveAccounts()
-	if err != nil {
-		return err
-	}
-	settings, err := accountDB.GetSettings()
-	if err != nil {
-		return err
-	}
-	addresses := []string{settings.EIP1581Address.Hex(), settings.WalletRootAddress.Hex()}
-	for _, account := range accounts {
-		addresses = append(addresses, account.Address.Hex())
-	}
-	err = b.accountManager.MigrateKeyStoreDir(newDir, addresses)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (b *GethStatusBackend) Login(keyUID, password string) error {
 	return b.startNodeWithAccount(multiaccounts.Account{KeyUID: keyUID}, password, nil, nil)
 }

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -130,7 +130,10 @@ func NewGethStatusBackend(logger *zap.Logger) *GethStatusBackend {
 		logger:            logger,
 		preLoginLogConfig: logutils.NewPreLoginLogConfig(),
 	}
-	backend.initialize()
+	if err := backend.initialize(); err != nil {
+		logger.Error("failed to initialize backend", zap.Error(err))
+		panic(err)
+	}
 
 	logger.Info("Status backend initialized",
 		zap.String("backend geth version", version.Version()),
@@ -144,8 +147,13 @@ func (b *GethStatusBackend) PreLoginLog() *logutils.PreLoginLogConfig {
 	return b.preLoginLogConfig
 }
 
-func (b *GethStatusBackend) initialize() {
-	accountManager := accsmanagement.NewAccountsManager(b.logger)
+func (b *GethStatusBackend) initialize() (err error) {
+	accountManager, err := accsmanagement.NewAccountsManager(b.logger)
+	if err != nil {
+		b.logger.Error("failed to create new *AccountsManager instance", zap.Error(err))
+		return
+	}
+
 	transactor := transactions.NewTransactor()
 	personalService := personal.New()
 	statusNode := node.New(transactor, accountManager, b.logger)
@@ -157,6 +165,8 @@ func (b *GethStatusBackend) initialize() {
 	b.statusNode.SetMultiaccountsDB(b.multiaccountsDB)
 	b.LocalPairingStateManager = new(statecontrol.ProcessStateManager)
 	b.LocalPairingStateManager.SetPairing(false)
+
+	return
 }
 
 // StatusNode returns reference to node manager
@@ -451,7 +461,16 @@ func (b *GethStatusBackend) ensureAppDBOpened(account multiaccounts.Account, pas
 		b.logger.Error("failed to initialize db", zap.Error(err))
 		return err
 	}
+
 	b.statusNode.SetAppDB(b.appDB)
+
+	accountsDB, err := accounts.NewDB(b.appDB)
+	if err != nil {
+		b.logger.Error("failed to create new *Database instance", zap.Error(err))
+		return
+	}
+	b.accountManager.SetPersistence(accountsDB)
+
 	return nil
 }
 
@@ -2449,13 +2468,7 @@ func (b *GethStatusBackend) HashTypedDataV4(typed signercore.TypedData) (types.H
 }
 
 func (b *GethStatusBackend) getVerifiedWalletAccount(address, password string) (*generator.Account, error) {
-	db, err := accounts.NewDB(b.appDB)
-	if err != nil {
-		b.logger.Error("failed to create new *Database instance", zap.Error(err))
-		return nil, err
-	}
-
-	return b.accountManager.GetVerifiedWalletAccount(db, types.HexToAddress(address), password)
+	return b.accountManager.GetVerifiedWalletAccount(types.HexToAddress(address), password)
 }
 
 // registerHandlers attaches Status callback handlers to running node
@@ -2605,7 +2618,9 @@ func (b *GethStatusBackend) Logout() error {
 	}
 
 	// re-initialize the node, at some point we should better manage the lifecycle
-	b.initialize()
+	if err = b.initialize(); err != nil {
+		return err
+	}
 
 	err = b.statusNode.StartMediaServerWithoutDB()
 	if err != nil {

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -464,24 +464,18 @@ func migrateKeyStoreDirV2(requestJSON string) string {
 		return makeJSONResponse(err)
 	}
 
-	err = statusBackend.MigrateKeyStoreDir(request.Account, request.Password, request.NewDir)
+	err = statusBackend.AccountManager().MigrateKeyStoreDir(request.NewDir)
 	return makeJSONResponse(err)
 }
 
 // Deprecated: Use MigrateKeyStoreDirV2 instead
 func MigrateKeyStoreDir(accountData, password, oldDir, newDir string) string {
-	return migrateKeyStoreDir(accountData, password, newDir)
+	return migrateKeyStoreDir(newDir)
 }
 
 // migrateKeyStoreDir migrates key files to a new directory
-func migrateKeyStoreDir(accountData, password, newDir string) string {
-	var account multiaccounts.Account
-	err := json.Unmarshal([]byte(accountData), &account)
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-
-	err = statusBackend.MigrateKeyStoreDir(account, password, newDir)
+func migrateKeyStoreDir(newDir string) string {
+	err := statusBackend.AccountManager().MigrateKeyStoreDir(newDir)
 	return makeJSONResponse(err)
 }
 

--- a/node/status_node_rpc_client_test.go
+++ b/node/status_node_rpc_client_test.go
@@ -15,6 +15,7 @@ import (
 	accsmanagement "github.com/status-im/status-go/accounts-management"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/multiaccounts"
+	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/tt"
 	"github.com/status-im/status-go/t/helpers"
@@ -69,19 +70,27 @@ func setupTestMultiDB() (*multiaccounts.Database, func() error, error) {
 }
 
 func createAndStartStatusNode(config *params.NodeConfig) (*StatusNode, error) {
-	accountManager := accsmanagement.NewAccountsManager(tt.MustCreateTestLogger())
-	statusNode := New(nil, accountManager, tt.MustCreateTestLogger())
-
 	appDB, walletDB, stop, err := setupTestDBs()
 	defer func() {
-		err := stop()
-		if err != nil {
-			statusNode.logger.Error("stopping db", zap.Error(err))
-		}
+		err = stop()
 	}()
 	if err != nil {
 		return nil, err
 	}
+
+	accsDB, err := accounts.NewDB(appDB)
+	if err != nil {
+		return nil, err
+	}
+
+	accountManager, err := accsmanagement.NewAccountsManager(tt.MustCreateTestLogger())
+	if err != nil {
+		return nil, err
+	}
+	accountManager.SetPersistence(accsDB)
+
+	statusNode := New(nil, accountManager, tt.MustCreateTestLogger())
+
 	statusNode.appDB = appDB
 	statusNode.walletDB = walletDB
 
@@ -110,7 +119,18 @@ func createStatusNode() (*StatusNode, func() error, func() error, error) {
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	accountManager := accsmanagement.NewAccountsManager(tt.MustCreateTestLogger())
+
+	accsDB, err := accounts.NewDB(appDB)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	accountManager, err := accsmanagement.NewAccountsManager(tt.MustCreateTestLogger())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	accountManager.SetPersistence(accsDB)
+
 	statusNode := New(nil, accountManager, tt.MustCreateTestLogger())
 	statusNode.SetAppDB(appDB)
 	statusNode.SetWalletDB(walletDB)

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -39,7 +39,7 @@ type AccountsManagerMock struct {
 	AccountsMap map[string]string
 }
 
-func (m *AccountsManagerMock) GetVerifiedWalletAccount(db *accounts.Database, address ethtypes.Address, password string) (*generator.Account, error) {
+func (m *AccountsManagerMock) GetVerifiedWalletAccount(address ethtypes.Address, password string) (*generator.Account, error) {
 	return generator.NewAccount(nil, nil), nil
 }
 

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1383,7 +1383,7 @@ func (m *Messenger) SignData(signParams []personal.SignParams) ([]string, error)
 			return nil, errors.New(ErrSigningJoinRequestForKeycardAccounts)
 		}
 
-		verifiedAccount, err := m.accountsManager.GetVerifiedWalletAccount(m.settings, types.HexToAddress(param.Address), param.Password)
+		verifiedAccount, err := m.accountsManager.GetVerifiedWalletAccount(types.HexToAddress(param.Address), param.Password)
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -74,7 +74,7 @@ type MessengerSignalsHandler interface {
 }
 
 type AccountsManager interface {
-	GetVerifiedWalletAccount(db *accounts.Database, address ethtypes.Address, password string) (*generator.Account, error)
+	GetVerifiedWalletAccount(address ethtypes.Address, password string) (*generator.Account, error)
 	DeleteAccount(address ethtypes.Address) error
 }
 

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -868,7 +868,7 @@ func (api *API) SignTypedDataV4(typedJson string, address string, password strin
 		zap.Int("len(password)", len(password)),
 	)
 
-	account, err := api.s.gethManager.GetVerifiedWalletAccount(api.s.accountsDB, types.HexToAddress(address), password)
+	account, err := api.s.gethManager.GetVerifiedWalletAccount(types.HexToAddress(address), password)
 	if err != nil {
 		return types.HexBytes{}, err
 	}
@@ -901,7 +901,7 @@ func (api *API) SafeSignTypedDataForDApps(typedJson string, address string, pass
 		zap.Bool("legacy", legacy),
 	)
 
-	account, err := api.s.gethManager.GetVerifiedWalletAccount(api.s.accountsDB, types.HexToAddress(address), password)
+	account, err := api.s.gethManager.GetVerifiedWalletAccount(types.HexToAddress(address), password)
 	if err != nil {
 		return types.HexBytes{}, err
 	}


### PR DESCRIPTION
- Introduced a new `Persistence` interface to manage account data storage and retrieval.
- Updated `AccountsManager` to require a `Persistence` instance during initialization.
- Refactored related methods to utilize the new persistence layer, improving separation of concerns.
- Updated tests to mock the persistence layer for better isolation and reliability.
- Added error handling for missing persistence and logger instances.

----
Reference to other accounts-management refactor PRs:
- https://github.com/status-im/status-go/pull/6605
- https://github.com/status-im/status-go/pull/6612
- https://github.com/status-im/status-go/pull/6640
- https://github.com/status-im/status-go/pull/6660
- https://github.com/status-im/status-go/pull/6668
- https://github.com/status-im/status-go/pull/6673
- https://github.com/status-im/status-go/pull/6686
- https://github.com/status-im/status-go/pull/6687
- https://github.com/status-im/status-go/pull/6692