### PR TITLE
ci_: run jobs by go label

### DIFF
--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -3,7 +3,7 @@ library 'status-jenkins-lib@v1.9.20'
 
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
-  agent { label "${params.AGENT_LABEL}" }
+  agent { label "${params.AGENT_LABEL} && go-1.22" }
 
   parameters {
     string(


### PR DESCRIPTION
## Summary

Add label to only run CI jobs on host that match the go version.
This way I can avoid all jobs to run on host that have newer go version when status-go is still using older go.
