### PR TITLE
chore_: add test_pairing_server_as_receiver functional test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git
 .ethereumtest
 .github
+**/*.vscode
 build/bin
 statusd-data
 wnode-data

--- a/mobile/requests/input_connection_string_for_bootstrapping.go
+++ b/mobile/requests/input_connection_string_for_bootstrapping.go
@@ -1,8 +1,6 @@
 package requests
 
 import (
-	"gopkg.in/go-playground/validator.v9"
-
 	"github.com/status-im/status-go/server/pairing"
 )
 
@@ -12,5 +10,5 @@ type InputConnectionStringForBootstrapping struct {
 }
 
 func (r *InputConnectionStringForBootstrapping) Validate() error {
-	return validator.New().Struct(r)
+	return pairing.ValidateStruct(r)
 }

--- a/mobile/requests/input_connection_string_for_bootstrapping_another_device.go
+++ b/mobile/requests/input_connection_string_for_bootstrapping_another_device.go
@@ -1,8 +1,6 @@
 package requests
 
 import (
-	"gopkg.in/go-playground/validator.v9"
-
 	"github.com/status-im/status-go/server/pairing"
 )
 
@@ -12,5 +10,5 @@ type InputConnectionStringForBootstrappingAnotherDevice struct {
 }
 
 func (r *InputConnectionStringForBootstrappingAnotherDevice) Validate() error {
-	return validator.New().Struct(r)
+	return pairing.ValidateStruct(r)
 }

--- a/mobile/requests/input_connection_string_for_importing_keypairs_keystores.go
+++ b/mobile/requests/input_connection_string_for_importing_keypairs_keystores.go
@@ -1,8 +1,6 @@
 package requests
 
 import (
-	"gopkg.in/go-playground/validator.v9"
-
 	"github.com/status-im/status-go/server/pairing"
 )
 
@@ -12,5 +10,5 @@ type InputConnectionStringForImportingKeypairsKeystores struct {
 }
 
 func (r *InputConnectionStringForImportingKeypairsKeystores) Validate() error {
-	return validator.New().Struct(r)
+	return pairing.ValidateStruct(r)
 }

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1767,6 +1767,7 @@ func GetConnectionStringForBeingBootstrapped(configJSON string) string {
 // and the device has no camera to read a QR code with
 //
 // Example: A desktop device (device without camera) receiving account data from mobile (device with camera)
+// Note: Once the bootstrapping is complete, the device will be in a logged-in state.
 func getConnectionStringForBeingBootstrapped(configJSON string) string {
 	if configJSON == "" {
 		return makeJSONResponse(fmt.Errorf("no config given, PayloadSourceConfig is expected"))
@@ -1778,11 +1779,6 @@ func getConnectionStringForBeingBootstrapped(configJSON string) string {
 	}()
 
 	cs, err := pairing.StartUpReceiverServer(statusBackend, configJSON)
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-
-	err = statusBackend.Logout()
 	if err != nil {
 		return makeJSONResponse(err)
 	}

--- a/server/pairing/common.go
+++ b/server/pairing/common.go
@@ -87,7 +87,7 @@ func loadKeys(keys map[string][]byte, keyStorePath string) error {
 	return nil
 }
 
-func validate(s interface{}) error {
+func ValidateStruct(s interface{}) error {
 	v, err := newValidate()
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func validate(s interface{}) error {
 }
 
 func validateAndVerifyPassword(s interface{}, senderConfig *SenderConfig) error {
-	err := validate(s)
+	err := ValidateStruct(s)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func validateAndVerifyPassword(s interface{}, senderConfig *SenderConfig) error 
 }
 
 func validateReceiverConfig(s interface{}, receiverConfig *ReceiverConfig) error {
-	err := validate(s)
+	err := ValidateStruct(s)
 	if err != nil {
 		return err
 	}

--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -31,11 +31,11 @@ Functional tests for status-go
 1. Functional tests will spawn `status-go` containers as needed, using the docker image name provided in `--docker-image`.
     Run this command to build a docker image for local runs:
     ```sh
-    # Note we tag the image with the commit hash. Functional tests will refer to the same when `--docker-image` is empty.   
-    docker build _assets/build/Dockerfile . --tag "statusgo-$(git rev-parse --short HEAD)"
+    # Note we tag the image with the commit hash. Functional tests will refer to the same when `--docker-image` is empty.
+    docker build --file _assets/build/Dockerfile . --tag "statusgo-$(git rev-parse --short HEAD)"
     ```
 2. Functional tests rely on local instances of Waku and Anvil.
-   Run this command to start all environment dependencies: 
+   Run this command to start all environment dependencies:
     ```sh
     docker compose -f tests-functional/docker-compose.anvil.yml -f tests-functional/docker-compose.waku.yml up --build --remove-orphans
     ```
@@ -68,7 +68,7 @@ NOTE:
 2. URLs are not reused
 3. URLs are not reusedURLs are selected in the provided order
 4. Most tests do not call `Logout` in the end of the test, so make sure to restart `status-backend` in between test runs.
-   You can also use `--logout` flag to automatically `Logout` before each `InitializeApplication` call, but it is 
+   You can also use `--logout` flag to automatically `Logout` before each `InitializeApplication` call, but it is
    recommended to restart `status-backend` for a full clean test.
 
 ### Options
@@ -80,7 +80,7 @@ NOTE:
 - Use `--waku-fleets-config` to override the hard-coded list of supported fleets. \
     The value will be passed to `InitializeApplication.wakuFleetsConfigFilePath` parameter. By default, it's set to JSON config for a local waku fleet. To run with a fleet from the hard-coded list use `--waku-fleets-config=""` and corresponding `--waku-fleet` value, e.g. `--waku-fleet=status.prod`
 - Use `--waku-fleet` to select a Waku fleet to be used by `status-go`. \
-    Default is `status-go.test` that will use local waku nodes for functional tests run. 
+    Default is `status-go.test` that will use local waku nodes for functional tests run.
     The value will be passed to all of these parameters:
     - `CreateAccount.wakuV2Fleet`
     - `RestoreAccount.wakuV2Fleet`
@@ -117,7 +117,7 @@ sudo ln -s $HOME/.docker/run/docker.sock /var/run/docker.sock
 
 ## Import issues
 
-If you see some import issues, make sure that you have all requirements installed from `requirements.txt` 
+If you see some import issues, make sure that you have all requirements installed from `requirements.txt`
 
 ### For PyCharm users
 

--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -126,6 +126,18 @@ class SignalClient:
             return self.received_signals[signal_type]["received"][-1]
         return self.received_signals[signal_type]["received"][-delta_count:]
 
+    def wait_for_signal_predicate(self, signal_type, predicate=lambda signal: True, timeout=20):
+        start_time = time.time()
+        while True:
+            elapsed_time = time.time() - start_time
+            if elapsed_time >= timeout:
+                break
+            remaining_time = int(timeout - elapsed_time)
+            signal = self.wait_for_signal(signal_type, remaining_time)
+            if predicate(signal):
+                return signal
+        raise TimeoutError(f"Signal {signal_type} satisfying the predicate is not received in {timeout} seconds")
+
     def wait_for_logout(self):
         signal = self.wait_for_signal(SignalType.NODE_LOGOUT.value)
         return signal

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -341,3 +341,41 @@ class StatusBackend(RpcClient, SignalClient):
         }
         response = self.api_valid_request(method, data)
         return json.loads(response.content)
+
+    def get_connection_string_for_being_bootstrapped(self):
+        method = "GetConnectionStringForBeingBootstrapped"
+        user = Account(
+            address="",
+            private_key="",
+            password="",
+            passphrase="",
+        )
+        data = {
+            "receiverConfig": {
+                "createAccount": self._create_account_request(user),
+                "deviceType": "macos",
+            },
+            "serverConfig": {
+                "timeout": 5 * 60 * 1000,
+            },
+        }
+        response = self.api_request(method, data)
+        return response.content.decode()
+
+    def input_connection_string_for_bootstrapping_another_device(self, connection_string):
+        method = "InputConnectionStringForBootstrappingAnotherDeviceV2"
+        data = {
+            "connectionString": connection_string,
+            "senderClientConfig": {
+                "senderConfig": {
+                    "keystorePath": os.path.join(self.data_dir, "keystore", self.key_uid),
+                    "deviceType": "macos",
+                    "keyUID": self.key_uid,
+                    "password": self.password,
+                    "chatKey": "",
+                },
+                "clientConfig": {},
+            },
+        }
+        response = self.api_valid_request(method, data)
+        return json.loads(response.content)

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -6,7 +6,7 @@ from resources.constants import Account
 from steps.messenger import MessengerSteps
 
 
-def check_sender_events(events):
+def check_server_sender_events(events):
     assert len(events) == 8
 
     assert events[0]["action"] == events[1]["action"] == LocalPairingEventAction.ACTION_PAIRING_ACCOUNT.value
@@ -33,7 +33,28 @@ def check_sender_events(events):
         assert "error" not in event or not event["error"]
 
 
-def check_receiver_events(events):
+def check_client_sender_events(events):
+    assert len(events) == 6
+
+    assert events[0]["action"] == LocalPairingEventAction.ACTION_CONNECT.value
+    assert events[0]["type"] == LocalPairingEventType.EVENT_CONNECTION_SUCCESS.value
+
+    assert events[1]["action"] == LocalPairingEventAction.ACTION_PAIRING_ACCOUNT.value
+    assert events[1]["type"] == LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
+
+    assert events[2]["action"] == LocalPairingEventAction.ACTION_SYNC_DEVICE.value
+    assert events[2]["type"] == LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
+
+    assert events[3]["action"] == events[4]["action"] == events[5]["action"] == LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value
+    assert events[3]["type"] == LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
+    assert events[4]["type"] == LocalPairingEventType.EVENT_RECEIVED_INSTALLATION.value
+    assert events[5]["type"] == LocalPairingEventType.EVENT_PROCESS_SUCCESS.value
+
+    for event in events:
+        assert "error" not in event or not event["error"]
+
+
+def check_client_receiver_events(events):
     assert len(events) == 8
 
     assert events[0]["action"] == LocalPairingEventAction.ACTION_CONNECT.value
@@ -57,6 +78,42 @@ def check_receiver_events(events):
 
     for event in events:
         assert "error" not in event or not event["error"]
+
+
+def check_server_receiver_events(events):
+    assert len(events) == 10
+
+    assert (
+        events[0]["action"]
+        == events[1]["action"]
+        == events[2]["action"]
+        == events[3]["action"]
+        == LocalPairingEventAction.ACTION_PAIRING_ACCOUNT.value
+    )
+    assert events[0]["type"] == LocalPairingEventType.EVENT_CONNECTION_SUCCESS.value
+    assert events[1]["type"] == LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
+    assert events[2]["type"] == LocalPairingEventType.EVENT_RECEIVED_ACCOUNT.value
+    assert events[3]["type"] == LocalPairingEventType.EVENT_PROCESS_SUCCESS.value
+
+    assert events[4]["action"] == events[5]["action"] == events[7]["action"] == LocalPairingEventAction.ACTION_SYNC_DEVICE.value
+    assert events[4]["type"] == LocalPairingEventType.EVENT_CONNECTION_SUCCESS.value
+    assert events[5]["type"] == LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
+    assert events[7]["type"] == LocalPairingEventType.EVENT_PROCESS_SUCCESS.value
+
+    assert events[6]["action"] == events[8]["action"] == events[9]["action"] == LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value
+    assert events[6]["type"] == LocalPairingEventType.EVENT_RECEIVED_INSTALLATION.value
+    assert events[8]["type"] == LocalPairingEventType.EVENT_CONNECTION_SUCCESS.value
+    assert events[9]["type"] == LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
+
+    for event in events:
+        assert "error" not in event or not event["error"]
+
+
+def wait_for_action_of_type(backend: StatusBackend, action, type):
+    backend.wait_for_signal_predicate(
+        SignalType.LOCAL_PAIRING.value,
+        lambda signal: signal.get("event", {}).get("action") == action and signal.get("event", {}).get("type") == type,
+    )
 
 
 @pytest.mark.rpc
@@ -87,13 +144,20 @@ class TestLocalPairing(MessengerSteps):
         assert response["error"] is None
         assert response["keyUID"] == self.receiver.key_uid
 
+        wait_for_action_of_type(
+            self.receiver, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_PROCESS_SUCCESS.value
+        )
+        wait_for_action_of_type(
+            receiver_second_device, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
+        )
+
         # Check sender signals
         events = self.receiver.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
-        check_sender_events(events)
+        check_server_sender_events(events)
 
         # Check receiver signals
         events = receiver_second_device.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
-        check_receiver_events(events)
+        check_client_receiver_events(events)
 
         # Login on the second device
         user = Account(
@@ -106,6 +170,45 @@ class TestLocalPairing(MessengerSteps):
         receiver_second_device.login(self.receiver.key_uid, user)
         receiver_second_device.wait_for_login()
         receiver_second_device.wakuext_service.start_messenger()
+
+        # Check that contact is synced
+        response = receiver_second_device.wakuext_service.get_contacts()
+        assert "error" not in response
+
+        contacts = response["result"]
+        assert len(contacts) == 1
+        assert contacts[0]["id"] == self.sender.public_key
+
+    def test_pairing_server_as_receiver(self):
+        # Create users
+        self.sender = self.initialize_backend(self.await_signals, False)
+        self.receiver = self.initialize_backend(self.await_signals, False)
+
+        # Make contacts before local pairing
+        self.make_contacts()
+
+        # Local pairing
+        receiver_second_device = StatusBackend(self.await_signals)
+        receiver_second_device.init_status_backend()
+
+        connection_string = receiver_second_device.get_connection_string_for_being_bootstrapped()
+        response = self.receiver.input_connection_string_for_bootstrapping_another_device(connection_string)
+        assert response.get("error") in (None, "")
+
+        wait_for_action_of_type(
+            self.receiver, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_PROCESS_SUCCESS.value
+        )
+        wait_for_action_of_type(
+            receiver_second_device, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
+        )
+
+        # Check sender signals
+        events = self.receiver.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
+        check_client_sender_events(events)
+
+        # Check receiver signals
+        events = receiver_second_device.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
+        check_server_receiver_events(events)
 
         # Check that contact is synced
         response = receiver_second_device.wakuext_service.get_contacts()


### PR DESCRIPTION
Adds `test_pairing_server_as_receiver` and fixes issues with 
`GetConnectionStringForBeingBootstrapped` endpoint.

iterates: https://github.com/status-im/status-go/issues/6689