### PR TITLE
test_:  enhance pytest logging - filter noise, show debug logs on failure

### DIFF
--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -29,7 +29,7 @@ Functional tests for status-go
 ## How to Run
 
 1. Functional tests will spawn `status-go` containers as needed, using the docker image name provided in `--docker-image`.
-    Run this command to build a docker image for local runs:
+    Run this command to build a docker image for local runs in root dir `status-go`:
     ```sh
     # Note we tag the image with the commit hash. Functional tests will refer to the same when `--docker-image` is empty.
     docker build --file _assets/build/Dockerfile . --tag "statusgo-$(git rev-parse --short HEAD)"

--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -164,10 +164,10 @@ class SignalClient:
         logging.error(f"Error: {error}")
 
     def _on_close(self, ws, close_status_code, close_msg):
-        logging.info(f"Connection closed: {close_status_code}, {close_msg}")
+        logging.debug(f"Connection closed: {close_status_code}, {close_msg}")
 
     def _on_open(self, ws):
-        logging.info("Connection opened")
+        logging.debug("Connection opened")
 
     def _connect(self):
         ws = websocket.WebSocketApp(

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -83,10 +83,10 @@ class StatusBackend(RpcClient, SignalClient):
         while time.time() - start_time <= timeout:
             try:
                 self.health(enable_logging=True)
-                logging.info(f"StatusBackend is healthy after {time.time() - start_time} seconds")
+                logging.debug(f"StatusBackend is healthy after {time.time() - start_time} seconds")
                 return
             except Exception as ex:
-                logging.error(ex)
+                logging.debug(f"StatusBackend error: {ex}")
                 time.sleep(0.1)
         raise TimeoutError(f"StatusBackend was not healthy after {timeout} seconds")
 

--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -38,7 +38,7 @@ class StatusGoContainer:
         coverage_path = option.codecov_dir if option.codecov_dir else os.path.abspath("./coverage/binary")
 
         # Run the container
-        logging.info(f"Creating status-go container from image '{image_name}'")
+        logging.debug(f"Creating status-go container from image '{image_name}'")
 
         container_args = {
             "image": image_name,
@@ -76,7 +76,7 @@ class StatusGoContainer:
         self.container = self.docker_client.containers.run(**container_args)
         option.statusgo_containers.append(self)
 
-        logging.info(f"Container {self.container.name} created. ID = {self.container.id}")
+        logging.debug(f"Container {self.container.name} created. ID = {self.container.id}")
 
         network = self.docker_client.networks.get(self.network_name)
         network.connect(self.container)
@@ -131,7 +131,7 @@ class StatusGoContainer:
         if self.container:
             logging.debug(f"Stopping container {self.container.name}...")
             self.container.stop(timeout=10)
-            logging.info(f"Container {self.container.name} stopped.")
+            logging.debug(f"Container {self.container.name} stopped.")
 
     def remove(self):
         """Remove the container"""
@@ -140,7 +140,7 @@ class StatusGoContainer:
             logging.debug(f"Removing container {name}...")
             self.container.remove()
             self.container = None
-            logging.info(f"Container {name} removed.")
+            logging.debug(f"Container {name} removed.")
 
     def pause(self):
         if not self.container:
@@ -190,7 +190,7 @@ class StatusGoContainer:
         if not self.container:
             raise RuntimeError("Container is not initialized.")
         if option.logs_dir == "":
-            logging.warning("Save container logs skipped")
+            logging.debug("Save container logs skipped")
             return
 
         id_short = self.container.id[:12]

--- a/tests-functional/pytest.ini
+++ b/tests-functional/pytest.ini
@@ -1,10 +1,13 @@
 [pytest]
-addopts = -s -v --tb=short
+addopts = -v --show-capture=all
 
 log_cli=true
-log_level=INFO
+log_level=DEBUG
+log_cli_level=DEBUG
 log_cli_format = %(asctime)s.%(msecs)03d %(levelname)s %(message)s
 log_cli_date_format = %Y-%m-%d %H:%M:%S
+
+junit_logging = all
 
 markers =
     rpc

--- a/tests-functional/tests/test_recover_mnemonic.py
+++ b/tests-functional/tests/test_recover_mnemonic.py
@@ -1,7 +1,6 @@
 from clients.status_backend import StatusBackend
 import pytest
 from clients.signals import SignalType
-import logging
 
 from resources.constants import user_mnemonic_12, user_mnemonic_15, user_mnemonic_24
 from resources.utils import assert_response_attributes
@@ -23,15 +22,15 @@ class TestRecoverMnemonic:
             SignalType.NODE_LOGIN.value,
         ]
 
-        logging.info("Step: Initialize backend client and restore account using user_mnemonic.")
+        # Initialize backend client and restore account using user_mnemonic.
         backend_client = StatusBackend(await_signals)
         backend_client.init_status_backend()
         backend_client.restore_account_and_login(user=user_mnemonic)
 
-        logging.info("Step: request getAccounts and check recovered accounts attributes.")
+        # Request getAccounts and check recovered accounts attributes.
         response = backend_client.rpc_valid_request("accounts_getAccounts", [])
         assert_response_attributes(response.json()["result"], user_mnemonic.accounts)
 
-        logging.info("Step: request getSettings and check recovered profile data attributes.")
+        # Request getSettings and check recovered profile data attributes.
         response = backend_client.rpc_valid_request("settings_getSettings", [])
         assert_response_attributes(response.json()["result"], user_mnemonic.profile_data)

--- a/tests-functional/tests/test_router.py
+++ b/tests-functional/tests/test_router.py
@@ -1,7 +1,6 @@
 import uuid as uuid_lib
 
 import pytest
-import logging
 import resources.constants as constants
 
 from steps.status_backend import StatusBackendSteps
@@ -77,24 +76,24 @@ class TestRouter(StatusBackendSteps):
             "gasFeeMode": gas_fee_mode,
         }
 
-        logging.info("Step: getting the best route")
+        # Step: getting the best route
         routes = wallet_utils.get_suggested_routes(self.rpc_client, **router_input_params)
         assert len(routes["Best"]) > 0
         wallet_utils.check_fees_for_path(constants.processor_name_transfer, gas_fee_mode, routes["Best"][0]["ApprovalRequired"], routes["Best"])
 
-        logging.info("Step: update gas fee mode without providing path tx identity params via wallet_setFeeMode endpoint")
+        # Step: update gas fee mode without providing path tx identity params via wallet_setFeeMode endpoint
         method = "wallet_setFeeMode"
         response = self.rpc_client.rpc_request(method, [None, gas_fee_mode])
         self.rpc_client.verify_is_json_rpc_error(response)
 
-        logging.info("Step: update gas fee mode with incomplete details for path tx identity params via wallet_setFeeMode endpoint")
+        # Step: update gas fee mode with incomplete details for path tx identity params via wallet_setFeeMode endpoint
         tx_identity_params = {
             "routerInputParamsUuid": uuid,
         }
         response = self.rpc_client.rpc_request(method, [tx_identity_params, gas_fee_mode])
         self.rpc_client.verify_is_json_rpc_error(response)
 
-        logging.info("Step: update gas fee mode to low")
+        # Step: update gas fee mode to low
         gas_fee_mode = constants.gas_fee_mode_low
         tx_identity_params = {
             "routerInputParamsUuid": uuid,
@@ -109,7 +108,7 @@ class TestRouter(StatusBackendSteps):
         assert len(routes["Best"]) > 0
         wallet_utils.check_fees_for_path(constants.processor_name_transfer, gas_fee_mode, routes["Best"][0]["ApprovalRequired"], routes["Best"])
 
-        logging.info("Step: update gas fee mode to high")
+        # Step: update gas fee mode to high
         gas_fee_mode = constants.gas_fee_mode_high
         self.rpc_client.prepare_wait_for_signal("wallet.suggested.routes", 1)
         _ = self.rpc_client.rpc_valid_request(method, [tx_identity_params, gas_fee_mode])
@@ -118,7 +117,7 @@ class TestRouter(StatusBackendSteps):
         assert len(routes["Best"]) > 0
         wallet_utils.check_fees_for_path(constants.processor_name_transfer, gas_fee_mode, routes["Best"][0]["ApprovalRequired"], routes["Best"])
 
-        logging.info("Step: try to set custom gas fee mode via wallet_setFeeMode endpoint")
+        # Step: try to set custom gas fee mode via wallet_setFeeMode endpoint
         gas_fee_mode = constants.gas_fee_mode_custom
         response = self.rpc_client.rpc_request(method, [tx_identity_params, gas_fee_mode])
         self.rpc_client.verify_is_json_rpc_error(response)
@@ -144,24 +143,24 @@ class TestRouter(StatusBackendSteps):
             "gasFeeMode": gas_fee_mode,
         }
 
-        logging.info("Step: getting the best route")
+        # Step: getting the best route
         routes = wallet_utils.get_suggested_routes(self.rpc_client, **router_input_params)
         assert len(routes["Best"]) > 0
         wallet_utils.check_fees_for_path(constants.processor_name_transfer, gas_fee_mode, routes["Best"][0]["ApprovalRequired"], routes["Best"])
 
-        logging.info("Step: try to set custom tx details with empty params via wallet_setCustomTxDetails endpoint")
+        # Step: try to set custom tx details with empty params via wallet_setCustomTxDetails endpoint
         method = "wallet_setCustomTxDetails"
         response = self.rpc_client.rpc_request(method, [None, None])
         self.rpc_client.verify_is_json_rpc_error(response)
 
-        logging.info("Step: try to set custom tx details with incomplete details for path tx identity params via wallet_setCustomTxDetails endpoint")
+        # Step: try to set custom tx details with incomplete details for path tx identity params via wallet_setCustomTxDetails endpoint
         tx_identity_params = {
             "routerInputParamsUuid": uuid,
         }
         response = self.rpc_client.rpc_request(method, [tx_identity_params, None])
         self.rpc_client.verify_is_json_rpc_error(response)
 
-        logging.info("Step: try to set custom tx details providing other than the custom gas fee mode via wallet_setCustomTxDetails endpoint")
+        # Step: try to set custom tx details providing other than the custom gas fee mode via wallet_setCustomTxDetails endpoint
         tx_identity_params = {
             "routerInputParamsUuid": uuid,
             "pathName": routes["Best"][0]["ProcessorName"],
@@ -174,14 +173,14 @@ class TestRouter(StatusBackendSteps):
         response = self.rpc_client.rpc_request(method, [tx_identity_params, tx_custom_params])
         self.rpc_client.verify_is_json_rpc_error(response)
 
-        logging.info("Step: try to set custom tx details without providing maxFeesPerGas via wallet_setCustomTxDetails endpoint")
+        # Step: try to set custom tx details without providing maxFeesPerGas via wallet_setCustomTxDetails endpoint
         tx_custom_params = {
             "gasFeeMode": gas_fee_mode,
         }
         response = self.rpc_client.rpc_request(method, [tx_identity_params, tx_custom_params])
         self.rpc_client.verify_is_json_rpc_error(response)
 
-        logging.info("Step: try to set custom tx details without providing PriorityFee via wallet_setCustomTxDetails endpoint")
+        # Step: try to set custom tx details without providing PriorityFee via wallet_setCustomTxDetails endpoint
         tx_custom_params = {
             "gasFeeMode": gas_fee_mode,
             "maxFeesPerGas": "0x77359400",
@@ -189,7 +188,7 @@ class TestRouter(StatusBackendSteps):
         response = self.rpc_client.rpc_request(method, [tx_identity_params, tx_custom_params])
         self.rpc_client.verify_is_json_rpc_error(response)
 
-        logging.info("Step: try to set custom tx details via wallet_setCustomTxDetails endpoint")
+        # Step: try to set custom tx details via wallet_setCustomTxDetails endpoint
         gas_fee_mode = constants.gas_fee_mode_custom
         tx_nonce = 4
         tx_gas_amount = 30000

--- a/tests-functional/tests/test_wakuext_savedAddress.py
+++ b/tests-functional/tests/test_wakuext_savedAddress.py
@@ -1,5 +1,4 @@
 import pytest
-import logging
 
 from steps.status_backend import StatusBackendSteps
 
@@ -55,22 +54,22 @@ class TestSavedAddresses(StatusBackendSteps):
     def test_add_saved_address(self, method, params):
         """Test adding saved addresses and verifying their presence in the lists."""
 
-        logging.info("Step: Adding item in mainnet mode")
+        # Step: Adding item in mainnet mode
         self.rpc_client.rpc_valid_request(method, params)
         response = self.rpc_client.rpc_valid_request("wakuext_getSavedAddresses", [])
 
-        logging.info("Step: Verifying the item is in the saved addresses list")
+        # Step: Verifying the item is in the saved addresses list
         self.rpc_client.verify_json_schema(response.json(), "wakuext_getSavedAddresses")
         assert any(params[0].items() <= item.items() for item in response.json()["result"]), f"{params[0]['name']} not found in getSavedAddresses"
 
-        logging.info("Step: Checking if the item is listed under mainnet saved addresses")
+        # Step: Checking if the item is listed under mainnet saved addresses
         response = self.rpc_client.rpc_valid_request("wakuext_getSavedAddressesPerMode", [False])
         self.rpc_client.verify_json_schema(response.json(), "wakuext_getSavedAddressesPerMode")
         assert any(
             params[0].items() <= item.items() for item in response.json()["result"]
         ), f"{params[0]['name']} not found in getSavedAddressesPerMode"
 
-        logging.info("Step: Ensuring the item is NOT in the testnet saved addresses list")
+        # Step: Ensuring the item is NOT in the testnet saved addresses list
         response = self.rpc_client.rpc_valid_request("wakuext_getSavedAddressesPerMode", [True])
         assert response.json()["result"] is None, "wakuext_getSavedAddressesPerMode for test mode is not empty"
 
@@ -87,16 +86,16 @@ class TestSavedAddresses(StatusBackendSteps):
             }
         ]
 
-        logging.info("Step: Adding item in testnet mode")
+        # Step: Adding item in testnet mode
         self.rpc_client.rpc_valid_request("wakuext_upsertSavedAddress", params)
 
-        logging.info("Step: Verifying the item exists in testnet saved addresses")
+        # Step: Verifying the item exists in testnet saved addresses
         response = self.rpc_client.rpc_valid_request("wakuext_getSavedAddressesPerMode", [is_test])
         assert any(
             params[0].items() <= item.items() for item in response.json()["result"]
         ), f"{params[0]['name']} not found in getSavedAddressesPerMode"
 
-        logging.info("Step: Deleting the item and verifying removal")
+        # Step: Deleting the item and verifying removal
         self.rpc_client.rpc_valid_request("wakuext_deleteSavedAddress", [address, is_test])
         response = self.rpc_client.rpc_valid_request("wakuext_getSavedAddressesPerMode", [is_test])
         assert response.json()["result"] is None, "getSavedAddressesPerMode for test mode is not empty"
@@ -127,15 +126,15 @@ class TestSavedAddresses(StatusBackendSteps):
             "0x09B69c2F46E7F63131C54BAfae242EEc2C600762",
         ]
 
-        logging.info("Step: Checking remaining capacity")
+        # Step: Checking remaining capacity
         response = self.rpc_client.rpc_valid_request("wakuext_remainingCapacityForSavedAddresses", [is_test])
         remaining_capacity = response.json()["result"]
 
-        logging.info("Step: adding  addresses to fill capacity")
+        # Step: adding  addresses to fill capacity
         for i in range(remaining_capacity):
             self.rpc_client.rpc_valid_request("wakuext_upsertSavedAddress", [{"address": addresses[i], "name": f"test{i}", "isTest": is_test}])
 
-        logging.info("Step: Verifying that capacity is now 0")
+        # Step: Verifying that capacity is now 0
         response = self.rpc_client.rpc_request("wakuext_remainingCapacityForSavedAddresses", [is_test])
         self.rpc_client.verify_is_json_rpc_error(response)
         assert response.json()["error"]["message"] == "no more save addresses can be added"


### PR DESCRIPTION
This pull request focuses on improving logging practices, enhancing test reliability, and introducing better log handling for debugging purposes. The most significant changes include replacing `logging.info` with `logging.debug` for less verbose logging, implementing a buffering log handler for capturing logs during test failures, and cleaning up unnecessary logging imports.

### Logging improvements:

* Replaced `logging.info` with `logging.debug` in several methods across `statusgo_container.py`, `signals.py`, and `status_backend.py` to reduce log verbosity. [[1]](diffhunk://#diff-7d24a49a4966311c574bf860c2ea62e0666f67e9d7de7e858c761d6f738cebf7L155-R158) [[2]](diffhunk://#diff-58cf519bd057448f7af1e6e24ff7bc7bdd2857c3e6dffdec19da7830cf3d0f73L41-R41) [[3]](diffhunk://#diff-58cf519bd057448f7af1e6e24ff7bc7bdd2857c3e6dffdec19da7830cf3d0f73L79-R79) [[4]](diffhunk://#diff-58cf519bd057448f7af1e6e24ff7bc7bdd2857c3e6dffdec19da7830cf3d0f73L134-R134) [[5]](diffhunk://#diff-58cf519bd057448f7af1e6e24ff7bc7bdd2857c3e6dffdec19da7830cf3d0f73L143-R143) [[6]](diffhunk://#diff-58cf519bd057448f7af1e6e24ff7bc7bdd2857c3e6dffdec19da7830cf3d0f73L193-R193) [[7]](diffhunk://#diff-1ccba497efc20425a9bea622554ac1b738a2c3d0479946eba85401b269a28b65L86-R88)

### Enhanced log handling for test failures:

* Added a `BufferingHandler` to capture DUBUG logs during test execution and attach them to test reports in case of failures. This includes appending logs to error messages and Jenkins test result details. [[1]](diffhunk://#diff-13bc94fc8fc4813ebeb7aa5e514c68b266a2e3133b9079bed796b9f7f7899ec0R5-R6) [[2]](diffhunk://#diff-13bc94fc8fc4813ebeb7aa5e514c68b266a2e3133b9079bed796b9f7f7899ec0R135-R191)

### Test code cleanup:

* Removed redundant `logging` imports from test files where they were no longer used. [[1]](diffhunk://#diff-42e34eb96e6bc17e49c704a13f842cc9971eaf08ce20bba5c25bb030035bdca4L4) [[2]](diffhunk://#diff-c514b1ec83d2a64900d309b814e0d86b98d3e2b0aa23fa3273c8301faec14b73L4) [[3]](diffhunk://#diff-a0246f501705ee973a622062aac54f844a9b53cb8d34050783567e6175ad263bL2)
* Replaced inline logging statements in test steps with comments to simplify the code. [[1]](diffhunk://#diff-42e34eb96e6bc17e49c704a13f842cc9971eaf08ce20bba5c25bb030035bdca4L26-R34) [[2]](diffhunk://#diff-c514b1ec83d2a64900d309b814e0d86b98d3e2b0aa23fa3273c8301faec14b73L80-R96) [[3]](diffhunk://#diff-c514b1ec83d2a64900d309b814e0d86b98d3e2b0aa23fa3273c8301faec14b73L112-R111) [[4]](diffhunk://#diff-c514b1ec83d2a64900d309b814e0d86b98d3e2b0aa23fa3273c8301faec14b73L121-R120) [[5]](diffhunk://#diff-c514b1ec83d2a64900d309b814e0d86b98d3e2b0aa23fa3273c8301faec14b73L147-R163) [[6]](diffhunk://#diff-c514b1ec83d2a64900d309b814e0d86b98d3e2b0aa23fa3273c8301faec14b73L177-R191) [[7]](diffhunk://#diff-a0246f501705ee973a622062aac54f844a9b53cb8d34050783567e6175ad263bL58-R72) [[8]](diffhunk://#diff-a0246f501705ee973a622062aac54f844a9b53cb8d34050783567e6175ad263bL90-R98)

### Documentation update:

* Clarified instructions in the `tests-functional/README.MD` for building Docker images by specifying the root directory.



## SUMMARY
1) Currently in stack trace of failed report you can see all debug logs from the current phase, check out [before](https://ci.status.im/job/status-go/job/prs/job/tests-rpc/job/PR-6697/8/testReport/tests.test_recover_mnemonic/TestRecoverMnemonic/test_recover_app_different_mnemonic_mnemonic_24_/) and [now](https://ci.status.im/job/status-go/job/prs/job/tests-rpc/job/PR-6697/9/testReport/tests.test_recover_mnemonic/TestRecoverMnemonic/test_recover_app_different_mnemonic_mnemonic_24_/)

All verbose info is available just in ErrorReport in Jenkins test report, which makes debugging easier.
 How test report looks in console now:
 
![image](https://github.com/user-attachments/assets/95a8211e-6068-4ea1-ace0-639749a38b00)


2) Set all custom logs to DEBUG level, as they anyway will be captured on test failure with `BufferingHandler`

3) There are still several noisy logs in setup/teardown, but not sure it makes sense to filter them manually

```
-------------------------------- live log call ---------------------------------
2025-06-26 11:31:43.451 WARNING websocket connected
FAILED
------------------------------ live log teardown -------------------------------
2025-06-26 11:31:47.632 ERROR Connection to remote host was lost. - goodbye
2025-06-26 11:31:47.633 ERROR Error: Connection to remote host was lost.
```
