### PR TITLE
chore_: dockerfile caching

### DIFF
--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -46,7 +46,7 @@ jobs:
       run: pip install -r tests-functional/requirements.txt
 
     - name: Build status-backend
-      run: docker build --file _assets/build/Dockerfile . --tag "statusgo-local"
+      run: docker build --file _assets/build/Dockerfile . --tag "statusgo-local" --build-arg "cache_id=${GITHUB_RUN_ID}"
 
     - name: Run environment
       run: docker compose -f tests-functional/docker-compose.anvil.yml -f ${{ matrix.config.docker_compose_file }} up --build --remove-orphans -d

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -13,12 +13,19 @@ ARG build_target='status-backend'
 
 RUN mkdir -p /go/src/github.com/status-im/status-go
 WORKDIR /go/src/github.com/status-im/status-go
-ADD . .
 
+ADD go.mod go.sum ./
+RUN go mod download -x
 RUN go install go.uber.org/mock/mockgen@v0.4.0
 RUN go install github.com/kevinburke/go-bindata/v4/...@v4.0.2
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
-RUN make $build_target BUILD_TAGS="$build_tags" BUILD_FLAGS="$build_flags"
+
+ADD . .
+RUN go env -w GOCACHE=/root/.cache/go-build
+RUN --mount=type=cache,target="/root/.cache/go-build" \
+    --mount=type=cache,target="/root/.cache/go-generate-fast" \
+    make $build_target BUILD_TAGS="$build_tags" BUILD_FLAGS="$build_flags" \
+      GO_GENERATE_FAST_RECACHE=false GO_GENERATE_FAST_DIR="/root/.cache/go-generate-fast"
 
 # Copy binaries to the second image
 FROM alpine:3.18

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache git bash make llvm clang musl-dev linux-headers protobuf-
 ARG build_tags='gowaku_no_rln'
 ARG build_flags=''
 ARG build_target='status-backend'
+ARG cache_id='local'
 
 RUN mkdir -p /go/src/github.com/status-im/status-go
 WORKDIR /go/src/github.com/status-im/status-go
@@ -22,8 +23,8 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
 
 ADD . .
 RUN go env -w GOCACHE=/root/.cache/go-build
-RUN --mount=type=cache,target="/root/.cache/go-build" \
-    --mount=type=cache,target="/root/.cache/go-generate-fast" \
+RUN --mount=type=cache,target="/root/.cache/go-build",id=statusgo-build-$cache_id \
+    --mount=type=cache,target="/root/.cache/go-generate-fast",id=statusgo-build-$cache_id \
     make $build_target BUILD_TAGS="$build_tags" BUILD_FLAGS="$build_flags" \
       GO_GENERATE_FAST_RECACHE=false GO_GENERATE_FAST_DIR="/root/.cache/go-generate-fast"
 

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -10,7 +10,6 @@ RUN apk add --no-cache git bash make llvm clang musl-dev linux-headers protobuf-
 ARG build_tags='gowaku_no_rln'
 ARG build_flags=''
 ARG build_target='status-backend'
-ARG cache_id='local'
 
 RUN mkdir -p /go/src/github.com/status-im/status-go
 WORKDIR /go/src/github.com/status-im/status-go
@@ -22,11 +21,16 @@ RUN go install github.com/kevinburke/go-bindata/v4/...@v4.0.2
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
 
 ADD . .
-RUN go env -w GOCACHE=/root/.cache/go-build
+ARG cache_id='local'
+ARG enable_go_cache=true
+RUN if [ "$enable_go_cache" = "true" ]; then \
+      go env -w GOCACHE=/root/.cache/go-build; \
+    fi
 RUN --mount=type=cache,target="/root/.cache/go-build",id=statusgo-build-$cache_id \
     --mount=type=cache,target="/root/.cache/go-generate-fast",id=statusgo-build-$cache_id \
     make $build_target BUILD_TAGS="$build_tags" BUILD_FLAGS="$build_flags" \
-      GO_GENERATE_FAST_RECACHE=false GO_GENERATE_FAST_DIR="/root/.cache/go-generate-fast"
+      GO_GENERATE_FAST_RECACHE=$([ "$enable_go_cache" = "true" ] && echo false || echo true) \
+      GO_GENERATE_FAST_DIR="/root/.cache/go-generate-fast"
 
 # Copy binaries to the second image
 FROM alpine:3.18

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -43,7 +43,7 @@ echo -e "${GRN}Building status-go${RST}"
 docker build --file ./_assets/build/Dockerfile . \
   --build-arg "build_flags=-cover" \
   --build-arg "build_tags='gowaku_no_rln,enable_private_api'" \
-  --build-arg "cache_id=${BUILD_ID}" \
+  --build-arg "enable_go_cache=false" \
   --tag "${image_name}"
 
 # Run docker

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -43,6 +43,7 @@ echo -e "${GRN}Building status-go${RST}"
 docker build --file ./_assets/build/Dockerfile . \
   --build-arg "build_flags=-cover" \
   --build-arg "build_tags='gowaku_no_rln,enable_private_api'" \
+  --build-arg "cache_id=${BUILD_ID}" \
   --tag "${image_name}"
 
 # Run docker


### PR DESCRIPTION
# Descirption

1. Avoid fetching Go dependencies each time by using Docker layers caching.
By copying only `go.mod` and `go.sum` we can track if dependencies have changed. And if they didn't, we will start building from `ADD . .`

2. Mount Go cache directory

3. Mount `go-generate-fast` cache directory

# Benefits

1. Not fetching Go dependencies saves ~40 seconds
2. Using Go and go-generate-fast caches allows to only rebuild changed code, also saves ~1 minute

3. A _pure re-run_ on CI shows ~3 minutes save:
    <img width="658" alt="image" src="https://github.com/user-attachments/assets/10264133-0f23-4161-861b-83b01ff8a96a" />
