### PR TITLE
refactor(accounts-management)_: simplify MigrateKeyStoreDir logic

### DIFF
--- a/accounts-management/README.md
+++ b/accounts-management/README.md
@@ -103,7 +103,7 @@ childAccounts, err := manager.DeriveChildrenAccountsForPathsAndStore(
 #### Keystore Operations
 ```go
 // Migrate keystore to new directory
-err := manager.MigrateKeyStoreDir(newDir, addresses)
+err := manager.MigrateKeyStoreDir(newDir)
 
 // Re-encrypt keystore with new password
 err := manager.ReEncryptKeyStoreDir(oldPassword, newPassword)

--- a/accounts-management/accounts.go
+++ b/accounts-management/accounts.go
@@ -237,15 +237,15 @@ func (m *AccountsManager) Accounts() ([]ethtypes.Address, error) {
 	return addresses, nil
 }
 
-func (m *AccountsManager) MigrateKeyStoreDir(newDir string, addresses []string) error {
+func (m *AccountsManager) MigrateKeyStoreDir(newDir string) error {
 	m.keystoreMu.RLock()
 	defer m.keystoreMu.RUnlock()
 
 	if m.keystore == nil {
 		return ErrAccountKeyStoreMissing
 	}
-	m.logger.Info("migrating keystore directory", zap.String("new location", newDir), zap.Strings("addresses", addresses))
-	return m.keystore.MigrateKeyStoreDir(newDir, addresses)
+	m.logger.Info("migrating keystore directory", zap.String("new location", newDir))
+	return m.keystore.MigrateKeyStoreDir(newDir)
 }
 
 func (m *AccountsManager) ReEncryptKeyStoreDir(oldPass, newPass string) error {

--- a/accounts-management/accounts_test.go
+++ b/accounts-management/accounts_test.go
@@ -301,9 +301,7 @@ func (s *ManagerTestSuite) TestMigrateKeyStoreDir() {
 	files, _ := os.ReadDir(newKeyDir)
 	s.Equal(0, len(files))
 
-	address := ethtypes.HexToAddress(s.walletAddress).Hex()
-	addresses := []string{address}
-	err = s.accManager.MigrateKeyStoreDir(newKeyDir, addresses)
+	err = s.accManager.MigrateKeyStoreDir(newKeyDir)
 	s.Require().NoError(err)
 
 	files, _ = os.ReadDir(newKeyDir)

--- a/accounts-management/keystore.go
+++ b/accounts-management/keystore.go
@@ -29,5 +29,5 @@ type KeyStore interface {
 	// ReEncryptKeyStoreDir re-encrypts all keys in the keystore directory.
 	ReEncryptKeyStoreDir(oldPass, newPass string) error
 	// MigrateKeyStoreDir migrates the keystore directory from one location to another.
-	MigrateKeyStoreDir(newDir string, addresses []string) error
+	MigrateKeyStoreDir(newDir string) error
 }

--- a/accounts-management/keystore/geth/adapter.go
+++ b/accounts-management/keystore/geth/adapter.go
@@ -114,8 +114,14 @@ func (a *Adapter) ReEncryptKeyStoreDir(oldPass, newPass string) error {
 	return reEncryptKeyStoreDir(a.keystoreDir, oldPass, newPass)
 }
 
-func (a *Adapter) MigrateKeyStoreDir(newDir string, addresses []string) error {
-	err := migrateKeyStoreDir(a.keystoreDir, newDir, addresses)
+func (a *Adapter) MigrateKeyStoreDir(newDir string) error {
+	addresses := a.Accounts()
+	addressesStr := make([]string, len(addresses))
+	for i, address := range addresses {
+		addressesStr[i] = address.Address.Hex()
+	}
+
+	err := migrateKeyStoreDir(a.keystoreDir, newDir, addressesStr)
 	if err != nil {
 		return err
 	}

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -985,36 +985,6 @@ func (b *GethStatusBackend) GetEnsUsernames() ([]*ens.UsernameDetail, error) {
 	return db.GetEnsUsernames(&removed)
 }
 
-func (b *GethStatusBackend) MigrateKeyStoreDir(acc multiaccounts.Account, password, newDir string) error {
-	err := b.ensureDBsOpened(acc, password)
-	if err != nil {
-		return err
-	}
-
-	accountDB, err := accounts.NewDB(b.appDB)
-	if err != nil {
-		return err
-	}
-	accounts, err := accountDB.GetActiveAccounts()
-	if err != nil {
-		return err
-	}
-	settings, err := accountDB.GetSettings()
-	if err != nil {
-		return err
-	}
-	addresses := []string{settings.EIP1581Address.Hex(), settings.WalletRootAddress.Hex()}
-	for _, account := range accounts {
-		addresses = append(addresses, account.Address.Hex())
-	}
-	err = b.accountManager.MigrateKeyStoreDir(newDir, addresses)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (b *GethStatusBackend) Login(keyUID, password string) error {
 	return b.startNodeWithAccount(multiaccounts.Account{KeyUID: keyUID}, password, nil, nil)
 }

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -464,24 +464,18 @@ func migrateKeyStoreDirV2(requestJSON string) string {
 		return makeJSONResponse(err)
 	}
 
-	err = statusBackend.MigrateKeyStoreDir(request.Account, request.Password, request.NewDir)
+	err = statusBackend.AccountManager().MigrateKeyStoreDir(request.NewDir)
 	return makeJSONResponse(err)
 }
 
 // Deprecated: Use MigrateKeyStoreDirV2 instead
 func MigrateKeyStoreDir(accountData, password, oldDir, newDir string) string {
-	return migrateKeyStoreDir(accountData, password, newDir)
+	return migrateKeyStoreDir(newDir)
 }
 
 // migrateKeyStoreDir migrates key files to a new directory
-func migrateKeyStoreDir(accountData, password, newDir string) string {
-	var account multiaccounts.Account
-	err := json.Unmarshal([]byte(accountData), &account)
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-
-	err = statusBackend.MigrateKeyStoreDir(account, password, newDir)
+func migrateKeyStoreDir(newDir string) string {
+	err := statusBackend.AccountManager().MigrateKeyStoreDir(newDir)
 	return makeJSONResponse(err)
 }
 


### PR DESCRIPTION
There is no need for the addresses to be provided from outside, the migration should migrate all the files that are in the keystore dir to another location.

- Removed the addresses parameter from the MigrateKeyStoreDir method in AccountsManager and related interfaces.
- Updated all references and usages of MigrateKeyStoreDir across the codebase to reflect the new signature.
- Adjusted tests and documentation accordingly to ensure consistency and clarity.