### PR TITLE
chore_: improve backend instances naming in context of test_local_pairing

### DIFF
--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -41,26 +41,35 @@ class MessengerSteps(NetworkConditionsSteps):
         backend.wakuext_service.start_messenger()
         return backend
 
-    def send_contact_request_and_wait_for_signal_to_be_received(self):
-        response = self.sender.wakuext_service.send_contact_request(self.receiver.public_key, "contact_request")
+    def send_contact_request_and_wait_for_signal_to_be_received(self, sender=None, receiver=None):
+        sender = sender or self.sender
+        receiver = receiver or self.receiver
+
+        response = sender.wakuext_service.send_contact_request(receiver.public_key, "contact_request")
         expected_message = self.get_message_by_content_type(response, content_type=MessageContentType.CONTACT_REQUEST.value)[0]
         message_id = expected_message.get("id")
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id)
+        receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id)
         return message_id
 
-    def accept_contact_request_and_wait_for_signal_to_be_received(self, message_id):
-        self.receiver.wakuext_service.accept_contact_request(message_id)
-        accepted_signal = f"@{self.receiver.public_key} accepted your contact request"
-        self.sender.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=accepted_signal)
+    def accept_contact_request_and_wait_for_signal_to_be_received(self, message_id, sender=None, receiver=None):
+        sender = sender or self.sender
+        receiver = receiver or self.receiver
 
-    def make_contacts(self):
-        existing_contacts = self.receiver.wakuext_service.get_contacts()
+        receiver.wakuext_service.accept_contact_request(message_id)
+        accepted_signal = f"@{receiver.public_key} accepted your contact request"
+        sender.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=accepted_signal)
 
-        if self.sender.public_key in str(existing_contacts):
+    def make_contacts(self, sender=None, receiver=None):
+        sender = sender or self.sender
+        receiver = receiver or self.receiver
+
+        existing_contacts = receiver.wakuext_service.get_contacts()
+
+        if sender.public_key in str(existing_contacts):
             return
 
-        message_id = self.send_contact_request_and_wait_for_signal_to_be_received()
-        self.accept_contact_request_and_wait_for_signal_to_be_received(message_id)
+        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        self.accept_contact_request_and_wait_for_signal_to_be_received(message_id, sender, receiver)
         return message_id
 
     def validate_signal_event_against_response(self, signal_event, fields_to_validate, expected_message):

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -129,91 +129,87 @@ class TestLocalPairing(MessengerSteps):
 
     def test_pairing_server_as_sender(self):
         # Create users
-        self.sender = self.initialize_backend(self.await_signals, False)
-        self.receiver = self.initialize_backend(self.await_signals, False)
+        alice = self.initialize_backend(self.await_signals, False)
+        bob = self.initialize_backend(self.await_signals, False)
 
         # Make contacts before local pairing
-        self.make_contacts()
+        self.make_contacts(alice, bob)
 
         # Local pairing
-        receiver_second_device = StatusBackend(self.await_signals)
-        receiver_second_device.init_status_backend()
+        bob_second_device = StatusBackend(self.await_signals)
+        bob_second_device.init_status_backend()
 
-        connection_string = self.receiver.get_connection_string_for_bootstrapping_another_device()
-        response = receiver_second_device.input_connection_string_for_bootstrapping(connection_string)
+        connection_string = bob.get_connection_string_for_bootstrapping_another_device()
+        response = bob_second_device.input_connection_string_for_bootstrapping(connection_string)
         assert response["error"] is None
-        assert response["keyUID"] == self.receiver.key_uid
+        assert response["keyUID"] == bob.key_uid
 
+        wait_for_action_of_type(bob, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_PROCESS_SUCCESS.value)
         wait_for_action_of_type(
-            self.receiver, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_PROCESS_SUCCESS.value
-        )
-        wait_for_action_of_type(
-            receiver_second_device, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
+            bob_second_device, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
         )
 
         # Check sender signals
-        events = self.receiver.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
+        events = bob.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
         check_server_sender_events(events)
 
         # Check receiver signals
-        events = receiver_second_device.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
+        events = bob_second_device.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
         check_client_receiver_events(events)
 
         # Login on the second device
         user = Account(
-            password=self.receiver.password,
+            password=bob.password,
             address="",
             private_key="",
             passphrase="",
         )
-        receiver_second_device.init_status_backend()
-        receiver_second_device.login(self.receiver.key_uid, user)
-        receiver_second_device.wait_for_login()
-        receiver_second_device.wakuext_service.start_messenger()
+        bob_second_device.init_status_backend()
+        bob_second_device.login(bob.key_uid, user)
+        bob_second_device.wait_for_login()
+        bob_second_device.wakuext_service.start_messenger()
 
         # Check that contact is synced
-        response = receiver_second_device.wakuext_service.get_contacts()
+        response = bob_second_device.wakuext_service.get_contacts()
         assert "error" not in response
 
         contacts = response["result"]
         assert len(contacts) == 1
-        assert contacts[0]["id"] == self.sender.public_key
+        assert contacts[0]["id"] == alice.public_key
 
     def test_pairing_server_as_receiver(self):
         # Create users
-        self.sender = self.initialize_backend(self.await_signals, False)
-        self.receiver = self.initialize_backend(self.await_signals, False)
+        alice = self.initialize_backend(self.await_signals, False)
+        bob = self.initialize_backend(self.await_signals, False)
 
         # Make contacts before local pairing
-        self.make_contacts()
+        self.make_contacts(alice, bob)
 
         # Local pairing
-        receiver_second_device = StatusBackend(self.await_signals)
-        receiver_second_device.init_status_backend()
+        bob_second_device = StatusBackend(self.await_signals)
+        bob_second_device.init_status_backend()
 
-        connection_string = receiver_second_device.get_connection_string_for_being_bootstrapped()
-        response = self.receiver.input_connection_string_for_bootstrapping_another_device(connection_string)
+        connection_string = bob_second_device.get_connection_string_for_being_bootstrapped()
+        response = bob.input_connection_string_for_bootstrapping_another_device(connection_string)
         assert response.get("error") in (None, "")
 
+        wait_for_action_of_type(bob, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_PROCESS_SUCCESS.value)
         wait_for_action_of_type(
-            self.receiver, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_PROCESS_SUCCESS.value
-        )
-        wait_for_action_of_type(
-            receiver_second_device, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
+            bob_second_device, LocalPairingEventAction.ACTION_PAIRING_INSTALLATION.value, LocalPairingEventType.EVENT_TRANSFER_SUCCESS.value
         )
 
         # Check sender signals
-        events = self.receiver.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
+        events = bob.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
         check_client_sender_events(events)
 
         # Check receiver signals
-        events = receiver_second_device.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
+        events = bob_second_device.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
         check_server_receiver_events(events)
 
         # Check that contact is synced
-        response = receiver_second_device.wakuext_service.get_contacts()
+        response = bob_second_device.wakuext_service.get_contacts()
         assert "error" not in response
 
         contacts = response["result"]
         assert len(contacts) == 1
-        assert contacts[0]["id"] == self.sender.public_key
+        assert contacts[0]["id"] == alice.public_key


### PR DESCRIPTION
The terms "sender" and "receiver" are keywords for local pairing, which conflicted with the enforced `self.sender` and `self.receiver` pattern.

Now, `make_contacts()` can accept arguments to handle such cases more flexibly.
