### PR TITLE
chore_: add `test_pairing_receiver_must_be_logged_out` functional test

### DIFF
--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -377,5 +377,5 @@ class StatusBackend(RpcClient, SignalClient):
                 "clientConfig": {},
             },
         }
-        response = self.api_valid_request(method, data)
+        response = self.api_request(method, data)
         return json.loads(response.content)

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -278,3 +278,17 @@ class TestLocalPairing(MessengerSteps):
             assert user_declined_notification["read"] is True
             assert user_declined_notification["accepted"] is False
             assert user_declined_notification["dismissed"] is True
+
+    def test_pairing_receiver_must_be_logged_out(self):
+        sender = self.initialize_backend(self.await_signals, False)
+        receiver = self.initialize_backend(self.await_signals, False)
+
+        # Client receiver must be logged out
+        connection_string = sender.get_connection_string_for_bootstrapping_another_device()
+        response = receiver.input_connection_string_for_bootstrapping(connection_string)
+        assert response["error"] is not None
+
+        # Server receiver must be logged out
+        connection_string = receiver.get_connection_string_for_being_bootstrapped()
+        response = sender.input_connection_string_for_bootstrapping_another_device(connection_string)
+        assert response["error"] is not None


### PR DESCRIPTION
closes: #6689
