### PR TITLE
feat(Dockerfile)_: bookworm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,9 +143,9 @@ $(GO_CMD_BUILDS): generate
 $(GO_CMD_BUILDS): ##@build Build any Go project from cmd folder
 	go build -mod=vendor -v \
 		-tags '$(BUILD_TAGS)' $(BUILD_FLAGS) \
-		-o ./$@ ./cmd/$(notdir $@) ;\
-	echo "Compilation done." ;\
-	echo "Run \"build/bin/$(notdir $@) -h\" to view available commands."
+		-o ./$@ ./cmd/$(notdir $@)
+	@echo "Compilation done."
+	@echo "Run \"build/bin/$(notdir $@) -h\" to view available commands."
 
 LIBWAKU := $(CURDIR)/vendor/github.com/waku-org/waku-go-bindings/third_party/nwaku/build/libwaku.$(LIBWAKU_EXT)
 $(LIBWAKU):

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -1,11 +1,16 @@
 # Build status-go in a Go builder container
-FROM golang:1.22-alpine3.18 as builder
+FROM golang:1.22.12-bookworm AS builder
 
 # Set environment variables to use Clang
 ENV CC=clang
 ENV CXX=clang++
 
 RUN apk add --no-cache git bash make llvm clang musl-dev linux-headers protobuf-dev~3.21
+RUN apt-get update && apt-get install -y \
+    git bash make llvm clang protobuf-compiler \
+    build-essential pkg-config && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ARG build_tags='gowaku_no_rln'
 ARG build_flags=''
@@ -33,13 +38,17 @@ RUN --mount=type=cache,target="/root/.cache/go-build",id=statusgo-build-$cache_i
       GO_GENERATE_FAST_DIR="/root/.cache/go-generate-fast"
 
 # Copy binaries to the second image
-FROM alpine:3.18
+FROM debian:bookworm-slim
 
 LABEL maintainer="support@status.im"
 LABEL source="https://github.com/status-im/status-go"
 LABEL description="status-go is an underlying part of Status - a browser, messenger, and gateway to a decentralized world."
 
-RUN apk add --no-cache ca-certificates bash libgcc libstdc++ curl
+RUN apt-get update && apt-get install -y \
+    ca-certificates bash curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /usr/status-user && chmod -R 777 /usr/status-user
 RUN mkdir -p /static/keys
 RUN mkdir -p /static/configs

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -5,16 +5,10 @@ FROM golang:1.22.12-bookworm AS builder
 ENV CC=clang
 ENV CXX=clang++
 
-# Set version information environment variables
-ENV VERSION=unknown
-ENV GIT_COMMIT=unknown
-
-RUN apk add --no-cache git bash make llvm clang musl-dev linux-headers protobuf-dev~3.21
-RUN apt-get update && apt-get install -y \
-    git bash make llvm clang protobuf-compiler \
-    build-essential pkg-config && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y git bash make llvm clang protobuf-compiler build-essential pkg-config \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG build_tags='gowaku_no_rln'
 ARG build_flags=''
@@ -33,22 +27,12 @@ ADD . .
 ARG cache_id='local'
 ARG enable_go_cache=true
 
-# Update version information from git if available
-# Usually the version is built-in using go:generate and go:embed in `pkg/version.go`,
-# but this approach does not work when there is no access to .git directory.
-# And we do not want to copy the whole .git directory to the image.
-RUN VERSION=$(git describe --tags --dirty='-dirty' 2>/dev/null || echo "unknown") && \
-    GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown") && \
-    export VERSION GIT_COMMIT && \
-    echo "Building with VERSION=$VERSION GIT_COMMIT=$GIT_COMMIT"
-
 RUN if [ "$enable_go_cache" = "true" ]; then \
       go env -w GOCACHE=/root/.cache/go-build; \
     fi
 RUN --mount=type=cache,target="/root/.cache/go-build",id=statusgo-build-$cache_id \
     --mount=type=cache,target="/root/.cache/go-generate-fast",id=statusgo-build-$cache_id \
-    make $build_target BUILD_TAGS="$build_tags" \
-      BUILD_FLAGS="$build_flags -ldflags \"-X github.com/status-im/status-go/pkg/version.version=$VERSION -X github.com/status-im/status-go/pkg/version.gitCommit=$GIT_COMMIT\"" \
+    make $build_target BUILD_TAGS="$build_tags" BUILD_FLAGS="$build_flags" \
       GO_GENERATE_FAST_RECACHE=$([ "$enable_go_cache" = "true" ] && echo false || echo true) \
       GO_GENERATE_FAST_DIR="/root/.cache/go-generate-fast"
 
@@ -59,10 +43,10 @@ LABEL maintainer="support@status.im"
 LABEL source="https://github.com/status-im/status-go"
 LABEL description="status-go is an underlying part of Status - a browser, messenger, and gateway to a decentralized world."
 
-RUN apt-get update && apt-get install -y \
-    ca-certificates bash curl && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -y ca-certificates bash curl \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/status-user && chmod -R 777 /usr/status-user
 RUN mkdir -p /static/keys

--- a/_assets/build/Dockerfile
+++ b/_assets/build/Dockerfile
@@ -5,6 +5,10 @@ FROM golang:1.22.12-bookworm AS builder
 ENV CC=clang
 ENV CXX=clang++
 
+# Set version information environment variables
+ENV VERSION=unknown
+ENV GIT_COMMIT=unknown
+
 RUN apk add --no-cache git bash make llvm clang musl-dev linux-headers protobuf-dev~3.21
 RUN apt-get update && apt-get install -y \
     git bash make llvm clang protobuf-compiler \
@@ -28,12 +32,23 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
 ADD . .
 ARG cache_id='local'
 ARG enable_go_cache=true
+
+# Update version information from git if available
+# Usually the version is built-in using go:generate and go:embed in `pkg/version.go`,
+# but this approach does not work when there is no access to .git directory.
+# And we do not want to copy the whole .git directory to the image.
+RUN VERSION=$(git describe --tags --dirty='-dirty' 2>/dev/null || echo "unknown") && \
+    GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown") && \
+    export VERSION GIT_COMMIT && \
+    echo "Building with VERSION=$VERSION GIT_COMMIT=$GIT_COMMIT"
+
 RUN if [ "$enable_go_cache" = "true" ]; then \
       go env -w GOCACHE=/root/.cache/go-build; \
     fi
 RUN --mount=type=cache,target="/root/.cache/go-build",id=statusgo-build-$cache_id \
     --mount=type=cache,target="/root/.cache/go-generate-fast",id=statusgo-build-$cache_id \
-    make $build_target BUILD_TAGS="$build_tags" BUILD_FLAGS="$build_flags" \
+    make $build_target BUILD_TAGS="$build_tags" \
+      BUILD_FLAGS="$build_flags -ldflags \"-X github.com/status-im/status-go/pkg/version.version=$VERSION -X github.com/status-im/status-go/pkg/version.gitCommit=$GIT_COMMIT\"" \
       GO_GENERATE_FAST_RECACHE=$([ "$enable_go_cache" = "true" ] && echo false || echo true) \
       GO_GENERATE_FAST_DIR="/root/.cache/go-generate-fast"
 

--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -32,7 +32,7 @@ Functional tests for status-go
     Run this command to build a docker image for local runs in root dir `status-go`:
     ```sh
     # Note we tag the image with the commit hash. Functional tests will refer to the same when `--docker-image` is empty.
-    docker build --file _assets/build/Dockerfile . --tag "statusgo-$(git rev-parse --short HEAD)"
+    docker build --file _assets/build/Dockerfile --tag "statusgo-$(git rev-parse --short HEAD)" .
     ```
 2. Functional tests rely on local instances of Waku and Anvil.
    Run this command to start all environment dependencies:


### PR DESCRIPTION
There are 3 commits:

1. Use `debian:bookworm` as a base image to prevent `sqlite` compile issues 
    as described in https://github.com/status-im/status-go/pull/6678#issuecomment-3019094152

2. Fix Makefile `GO_CMD_BUILDS` target to properly fail if `go build` failed

3. Add specific `go build` linker flags in Dockerfile to preserve versioning information in the binary