### PR TITLE
fix(docker)_: update build target to cmd for push notification server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ endif
 	@ls -la build/bin/libstatus.*
 
 docker-image: SHELL := /bin/sh
-docker-image: BUILD_TARGET ?= statusd
+docker-image: BUILD_TARGET ?= cmd
 docker-image: ##@docker Build docker image (use DOCKER_IMAGE_NAME to set the image name)
 	@echo "Building docker image..."
 	docker build --file _assets/build/Dockerfile . \

--- a/_assets/ci/Jenkinsfile.docker
+++ b/_assets/ci/Jenkinsfile.docker
@@ -46,6 +46,7 @@ pipeline {
     /* Makefile parameters */
     DOCKER_IMAGE_NAME = 'statusteam/status-go'
     DOCKER_IMAGE_CUSTOM_TAG = "ci-build-${git.commit()}"
+    SENTRY_PRODUCTION = '1'
   }
 
   stages {


### PR DESCRIPTION
Updates docker-image BUILD_TARGET from `statusd` to `cmd` to align with Dockerfile changes that expect both `status-backend` and `push-notification-server` binaries to be built and copied.

Refs.:
- https://github.com/status-im/status-go/commit/7258e73d18f5858d22d4bdd497c9a5b50448c58
- https://github.com/status-im/status-go/pull/6520
- https://github.com/status-im/infra-push-notify/issues/11

Built and tested:
```sh
docker run --rm --entrypoint=push-notification-server statusteam/status-go:vv10.29.0-83-g65174d0a1-65174d0a1c63d71631df80766a2ca1d95dff12e3 --help
Usage of push-notification-server:
  -data-dir string
    	data directory
  -gorush-url string
    	gorush server URL (default "https://gorush.infra.status.im/")
  -identity string
    	Hex-encoded private key to use. When empty, an ephemeral key will be used
  -log-level string
    	Log level, one of: "ERROR", "WARN", "INFO", "DEBUG" (default "INFO")
  -log-no-color
    	Disables log colors
  -sentry
    	Enable sentry panic reporting
  -testify.m string
    	regular expression to select tests of the testify suite to run
  -waku-fleet string
    	Waku fleet to use (default "status.prod")
  -waku-fleet-config string
    	path to Waku fleet config file
    	```