### PR TITLE
refactor(accounts-management)!: enhance account management functionality

### DIFF
--- a/accounts-management/README.md
+++ b/accounts-management/README.md
@@ -8,7 +8,7 @@ This package is responsible for:
 - Creating and managing Ethereum accounts
 - Secure storage and retrieval of private keys
 - Account derivation from mnemonics and private keys
-- Keystore operations (encryption, decryption, migration)
+- **Automatic keystore management based on selected chat account and root data directory**
 - Account selection and authentication
 
 ## Package Structure
@@ -35,6 +35,7 @@ The main interface for account management operations. It provides methods for:
 - **Account Loading**: Load and decrypt accounts from the keystore
 - **Account Selection**: Select and manage the currently active account
 - **Account Derivation**: Derive child accounts from existing accounts
+- **Keystore Management**: Keystore is managed internally and switched automatically based on the selected chat account and root data directory
 
 #### Constructor
 ```go
@@ -45,14 +46,16 @@ manager, err := NewAccountsManager(logger)
 The constructor requires:
 - `logger`: A zap.Logger instance for logging operations
 
-After creation, you need to set up the persistence and keystore:
+After creation, you need to set up the persistence and root data directory:
 ```go
 // Set the persistence layer for account data storage
 manager.SetPersistence(persistence)
 
-// Set the keystore for secure key storage
-manager.SetKeystore(keystore)
+// Set the root data directory for keystore management
+manager.SetRootDataDir(rootDataDir)
 ```
+
+> **Note:** The keystore is now managed internally. You do not set it directly. It is created and switched automatically based on the selected chat account and the root data directory.
 
 ### Key Features
 
@@ -62,7 +65,8 @@ manager.SetKeystore(keystore)
 account, mnemonic, err := manager.CreateAndStoreAccount(password)
 
 // Create account from existing mnemonic
-account, err := manager.CreateFromMnemonicAndStoreAccount(mnemonic, password)
+account, err := manager.CreateFromMnemonicAndStoreAccount(mnemonic, password, profile)
+// profile: if true, creates a profile keypair and sets the keystore to the new one
 
 // Create account from private key
 account, err := manager.CreateFromPrivateKeyAndStoreAccount(privateKeyHex, password)
@@ -76,8 +80,12 @@ account, err := manager.LoadAccount(address, password)
 // Verify account password
 valid, err := manager.VerifyAccountPassword(address, password)
 
-// Sets chat account for use
-err := manager.SetChatAccount(chatAddress, password)
+// Set chat account for use (and switch keystore automatically) via chat address and password
+err := manager.SetChatAccount(chatAddress, password, nil)
+// Or Set chat account for use (and switch keystore automatically) via private key, the address doesn't need to be provided
+// since it will be evaluated from the provided private key
+err := manager.SetChatAccount(chatAddress, "", privateKey)
+
 
 // Get currently selected chat account
 account, err := manager.SelectedChatAccount()
@@ -140,9 +148,8 @@ func main() {
     // Set the persistence layer for account data storage
     manager.SetPersistence(persistence)
 
-    // Set up keystore instance aligning with `KeyStore` interface
-    keystore := yourKeystoreImplementation()
-    manager.SetKeystore(keystore)
+    // Set the root data directory for keystore management
+    manager.SetRootDataDir("/path/to/root/data/dir")
 
     // Create a new account
     account, mnemonic, err := manager.CreateAndStoreAccount("my-password")
@@ -153,8 +160,8 @@ func main() {
     log.Printf("Created account: %s", account.Address().Hex())
     log.Printf("Mnemonic: %s", mnemonic)
 
-    // Select the account
-    err = manager.SetChatAccount(account.Address(), "my-password")
+    // Select the account (this will also switch the keystore internally)
+    err = manager.SetChatAccount(account.Address(), "my-password", nil)
     if err != nil {
         log.Fatal(err)
     }
@@ -169,12 +176,21 @@ func main() {
 }
 ```
 
+## Persistence Interface Requirements
+
+Your `Persistence` implementation must provide:
+- `AddressExists(address ethtypes.Address) (bool, error)`
+- `GetProfileKeypair() (*accounts.Keypair, error)`
+- `GetWalletRootAddress() (ethtypes.Address, error)`
+- `GetPath(address ethtypes.Address) (string, error)`
+
 ## Security Considerations
 
 - **Password Protection**: All private keys are encrypted using the provided password
 - **Secure Storage**: Keys are stored in a Geth-compatible keystore format
 - **Memory Management**: Private keys are cleared from memory when not in use
 - **Account Isolation**: Each account is stored separately with its own encryption
+- **Keystore Isolation**: Keystore is managed per profile/account and switched automatically
 
 ## Error Handling
 
@@ -183,6 +199,7 @@ The package defines several custom errors:
 - `ErrNoAccountSelected`: No account has been selected (login required)
 - `ErrAccountKeyStoreMissing`: Keystore is not properly initialized
 - `ErrCannotLocateKeyFile`: Account file cannot be found for the given address
+- `ErrAddressAndPasswordOrPrivateKeyRequired`: Both address and password or a private key are required for SetChatAccount
 
 ## Dependencies
 
@@ -191,6 +208,7 @@ The package defines several custom errors:
 - `github.com/status-im/status-go/multiaccounts`: Multi-account support
 - `Persistence` interface: Required for account data storage operations
 - `KeyStore` interface: Required for secure cryptographic key storage, encryption/decryption, and keystore management operations
+- **Root data directory**: Required for keystore management
 
 ## Testing
 

--- a/accounts-management/accounts.go
+++ b/accounts-management/accounts.go
@@ -4,11 +4,14 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
 	"go.uber.org/zap"
 
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/status-im/status-go/accounts-management/common"
 	"github.com/status-im/status-go/accounts-management/generator"
 	"github.com/status-im/status-go/accounts-management/keystore/geth"
@@ -26,12 +29,12 @@ func (e ErrCannotLocateKeyFile) Error() string {
 
 // AccountsManager represents the default account manager implementation
 type AccountsManager struct {
-	keystoreMu  sync.RWMutex
+	mu          sync.RWMutex
 	keystore    KeyStore
 	persistence Persistence
 
-	selectedChatAccountMutex sync.RWMutex
-	selectedChatAccount      *generator.Account
+	rootDataDir         string
+	selectedChatAccount *generator.Account
 
 	logger *zap.Logger
 }
@@ -48,15 +51,41 @@ func NewAccountsManager(logger *zap.Logger) (*AccountsManager, error) {
 }
 
 func (m *AccountsManager) SetPersistence(persistence Persistence) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.persistence = persistence
 }
 
-func (m *AccountsManager) SetKeystore(keystore KeyStore) {
-	m.keystoreMu.Lock()
-	defer m.keystoreMu.Unlock()
+func (m *AccountsManager) SetRootDataDir(rootDataDir string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
+	m.rootDataDir = rootDataDir
+}
+
+func (m *AccountsManager) setKeystore(keystore KeyStore) {
 	m.keystore = keystore
-	m.logger.Info("new keystore set")
+}
+
+func (m *AccountsManager) setChatAccount(account *generator.Account) {
+	m.selectedChatAccount = account
+}
+
+func (m *AccountsManager) isChatAccountSet(address ethtypes.Address) bool {
+	return m.selectedChatAccount != nil && m.selectedChatAccount.Address() == address
+}
+
+func (m *AccountsManager) ReloadKeystore() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	keystore, err := m.createKeystore()
+	if err != nil {
+		return err
+	}
+	m.setKeystore(keystore)
+	return nil
 }
 
 // CreateAndStoreAccount creates an internal geth account and stores it in the keystore
@@ -66,16 +95,28 @@ func (m *AccountsManager) CreateAndStoreAccount(password string) (genAccount *ge
 		return
 	}
 
-	genAccount, err = m.CreateFromMnemonicAndStoreAccount(mnemonic, password)
+	genAccount, err = m.CreateFromMnemonicAndStoreAccount(mnemonic, password, false)
 
 	return
 }
 
 // CreateFromMnemonicAndStoreAccount creates an internal geth account from a mnemonic and stores it in the keystore
-func (m *AccountsManager) CreateFromMnemonicAndStoreAccount(mnemonic string, password string) (genAccount *generator.Account, err error) {
+// if profile is true means that a profile keypair is being created, and the keystore is set to the new one
+func (m *AccountsManager) CreateFromMnemonicAndStoreAccount(mnemonic string, password string, profile bool) (genAccount *generator.Account, err error) {
 	genAccount, err = generator.CreateAccountFromMnemonic(mnemonic, "")
 	if err != nil {
 		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if profile {
+		keystore, err := m.createKeystore()
+		if err != nil {
+			return nil, err
+		}
+		m.setKeystore(keystore)
 	}
 
 	err = m.storeToKeystore(genAccount, password)
@@ -92,6 +133,9 @@ func (m *AccountsManager) CreateFromPrivateKeyAndStoreAccount(privateKey string,
 	if err != nil {
 		return
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	err = m.storeToKeystore(acc, password)
 	if err != nil {
@@ -119,9 +163,13 @@ func (m *AccountsManager) VerifyAccountPassword(address ethtypes.Address, passwo
 // LoadAccount loads an account key from the keystore for a given address and password.
 // If either address or password is incorrect, an error is returned.
 func (m *AccountsManager) LoadAccount(address ethtypes.Address, password string) (*generator.Account, error) {
-	m.keystoreMu.RLock()
-	defer m.keystoreMu.RUnlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
+	return m.loadAccountInternally(address, password)
+}
+
+func (m *AccountsManager) loadAccountInternally(address ethtypes.Address, password string) (*generator.Account, error) {
 	if m.keystore == nil {
 		return nil, ErrAccountKeyStoreMissing
 	}
@@ -146,9 +194,6 @@ func (m *AccountsManager) LoadAccount(address ethtypes.Address, password string)
 }
 
 func (m *AccountsManager) storeToKeystore(acc *generator.Account, password string) (err error) {
-	m.keystoreMu.Lock()
-	defer m.keystoreMu.Unlock()
-
 	if m.keystore == nil {
 		return ErrAccountKeyStoreMissing
 	}
@@ -168,23 +213,58 @@ func (m *AccountsManager) storeToKeystore(acc *generator.Account, password strin
 	return
 }
 
-func (m *AccountsManager) setChatAccount(account *generator.Account) {
-	m.selectedChatAccountMutex.Lock()
-	defer m.selectedChatAccountMutex.Unlock()
-
-	m.selectedChatAccount = account
-	if account != nil {
-		m.logger.Info("chat account set", zap.String("address", account.Address().Hex()))
-	} else {
-		m.logger.Info("chat account cleared")
+func (m *AccountsManager) createKeystore() (KeyStore, error) {
+	if m.persistence == nil {
+		return nil, ErrPersistenceIsMissing
 	}
+
+	profileKeypair, err := m.persistence.GetProfileKeypair()
+	if err != nil {
+		return nil, err
+	}
+
+	// prepare keystore path
+	const DefaultKeystoreRelativePath = "keystore"
+	relativePath := filepath.Join(DefaultKeystoreRelativePath, profileKeypair.KeyUID)
+	absoluteKeystorePath := filepath.Join(m.rootDataDir, relativePath)
+
+	if _, err := os.Stat(absoluteKeystorePath); os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Clean(absoluteKeystorePath), os.ModePerm); err != nil {
+			return nil, fmt.Errorf("make keystore directory: %v", err)
+		}
+	}
+
+	return geth.NewGethKeystoreAdapter(absoluteKeystorePath, keystore.LightScryptN, keystore.LightScryptP)
 }
 
-// SetChatAccount sets the chat account with the given address and password
-func (m *AccountsManager) SetChatAccount(chatAddress ethtypes.Address, password string) error {
-	selectedChatAccount, err := m.LoadAccount(chatAddress, password)
+// SetChatAccount sets the chat account and keystore either by address and password or by private key
+func (m *AccountsManager) SetChatAccount(address ethtypes.Address, password string, privateKey *ecdsa.PrivateKey) error {
+	if address == ethtypes.ZeroAddress() && privateKey == nil {
+		return ErrAddressAndPasswordOrPrivateKeyRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.isChatAccountSet(address) {
+		m.logger.Info("chat account already set", zap.String("address", address.Hex()))
+		return nil
+	}
+
+	keystore, err := m.createKeystore()
 	if err != nil {
 		return err
+	}
+	m.setKeystore(keystore)
+
+	var selectedChatAccount *generator.Account
+	if privateKey != nil {
+		selectedChatAccount = generator.NewAccount(privateKey, nil)
+	} else {
+		selectedChatAccount, err = m.loadAccountInternally(address, password)
+		if err != nil {
+			return err
+		}
 	}
 
 	m.setChatAccount(selectedChatAccount)
@@ -192,19 +272,10 @@ func (m *AccountsManager) SetChatAccount(chatAddress ethtypes.Address, password 
 	return nil
 }
 
-// SetChatAccountWithPrivateKey sets the chat account with the given private key
-func (m *AccountsManager) SetChatAccountWithPrivateKey(privKey *ecdsa.PrivateKey) error {
-	account := generator.NewAccount(privKey, nil)
-
-	m.setChatAccount(account)
-
-	return nil
-}
-
 // SelectedChatAccount returns currently selected chat account
 func (m *AccountsManager) SelectedChatAccount() (*generator.Account, error) {
-	m.selectedChatAccountMutex.RLock()
-	defer m.selectedChatAccountMutex.RUnlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	if m.selectedChatAccount == nil {
 		return nil, ErrNoAccountSelected
@@ -214,15 +285,20 @@ func (m *AccountsManager) SelectedChatAccount() (*generator.Account, error) {
 
 // Logout clears everything.
 func (m *AccountsManager) Logout() {
-	m.setChatAccount(nil)
-	m.SetKeystore(nil)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.keystore = nil
+	m.persistence = nil
+	m.rootDataDir = ""
+	m.selectedChatAccount = nil
 	m.logger.Info("logout")
 }
 
 // Accounts returns list of addresses for selected account, including subaccounts.
 func (m *AccountsManager) Accounts() ([]ethtypes.Address, error) {
-	m.keystoreMu.RLock()
-	defer m.keystoreMu.RUnlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	if m.keystore == nil {
 		return nil, ErrAccountKeyStoreMissing
@@ -238,8 +314,8 @@ func (m *AccountsManager) Accounts() ([]ethtypes.Address, error) {
 }
 
 func (m *AccountsManager) MigrateKeyStoreDir(newDir string) error {
-	m.keystoreMu.RLock()
-	defer m.keystoreMu.RUnlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	if m.keystore == nil {
 		return ErrAccountKeyStoreMissing
@@ -249,8 +325,8 @@ func (m *AccountsManager) MigrateKeyStoreDir(newDir string) error {
 }
 
 func (m *AccountsManager) ReEncryptKeyStoreDir(oldPass, newPass string) error {
-	m.keystoreMu.RLock()
-	defer m.keystoreMu.RUnlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	if m.keystore == nil {
 		return ErrAccountKeyStoreMissing
@@ -260,8 +336,8 @@ func (m *AccountsManager) ReEncryptKeyStoreDir(oldPass, newPass string) error {
 }
 
 func (m *AccountsManager) DeleteAccount(address ethtypes.Address) error {
-	m.keystoreMu.RLock()
-	defer m.keystoreMu.RUnlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	if m.keystore == nil {
 		m.logger.Error("cannot delete account, keystore is missing", zap.String("address", address.Hex()))
@@ -272,6 +348,9 @@ func (m *AccountsManager) DeleteAccount(address ethtypes.Address) error {
 }
 
 func (m *AccountsManager) GetVerifiedWalletAccount(address ethtypes.Address, password string) (*generator.Account, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	if m.persistence == nil {
 		return nil, ErrPersistenceIsMissing
 	}
@@ -285,7 +364,7 @@ func (m *AccountsManager) GetVerifiedWalletAccount(address ethtypes.Address, pas
 		return nil, ErrAccountDoesNotExist
 	}
 
-	account, err := m.LoadAccount(address, password)
+	account, err := m.loadAccountInternally(address, password)
 	if errors.Is(err, geth.ErrNoMatch) {
 		account, err = m.generatePartialAccountKey(address, password)
 		if err != nil {
@@ -316,11 +395,18 @@ func (m *AccountsManager) generatePartialAccountKey(address ethtypes.Address, pa
 	}
 	path := "m/" + dbPath[strings.LastIndex(dbPath, "/")+1:]
 
-	return m.DeriveChildAccountForPathAndStore(rootAddress, path, password)
+	return m.deriveChildAccountForPathAndStoreInternally(rootAddress, path, password)
 }
 
 func (m *AccountsManager) DeriveChildAccountForPathAndStore(deriveFrom ethtypes.Address, path string, password string) (*generator.Account, error) {
-	account, err := m.LoadAccount(deriveFrom, password)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.deriveChildAccountForPathAndStoreInternally(deriveFrom, path, password)
+}
+
+func (m *AccountsManager) deriveChildAccountForPathAndStoreInternally(deriveFrom ethtypes.Address, path string, password string) (*generator.Account, error) {
+	account, err := m.loadAccountInternally(deriveFrom, password)
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +425,10 @@ func (m *AccountsManager) DeriveChildAccountForPathAndStore(deriveFrom ethtypes.
 }
 
 func (m *AccountsManager) DeriveChildrenAccountsForPathsAndStore(deriveFrom ethtypes.Address, paths []string, password string) (map[string]*generator.Account, error) {
-	account, err := m.LoadAccount(deriveFrom, password)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	account, err := m.loadAccountInternally(deriveFrom, password)
 	if err != nil {
 		return nil, err
 	}

--- a/accounts-management/accounts_test.go
+++ b/accounts-management/accounts_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/status-im/status-go/accounts-management/common"
 	"github.com/status-im/status-go/accounts-management/generator"
@@ -25,7 +24,6 @@ import (
 
 const testPassword = "test-password"
 const newTestPassword = "new-test-password"
-const keystoreReloadDelay = 2 * time.Second
 
 func TestVerifyAccountPassword(t *testing.T) {
 	accManager, err := NewAccountsManager(tt.MustCreateTestLogger())
@@ -111,12 +109,21 @@ func TestVerifyAccountPassword(t *testing.T) {
 		if testCase.importToLocation {
 			err = utils.ImportTestAccount(keystore.KeystorePath(), utils.GetAccount1PKFile())
 			require.NoError(t, err)
+
+			persistence.EXPECT().GetProfileKeypair().Return(
+				&accounts.Keypair{
+					KeyUID: testCase.keyUID,
+				},
+				nil,
+			)
+
+			// now we need to re-create the keystore in order to make the get-keystore aware of the copied account
+			keystore, err = accManager.createKeystore()
+			require.NoError(t, err)
 		}
 
 		if testCase.keystoreSet {
 			accManager.setKeystore(keystore)
-
-			time.Sleep(keystoreReloadDelay)
 		} else {
 			accManager.setKeystore(nil)
 		}
@@ -155,17 +162,19 @@ func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {
 			KeyUID: utils.TestConfig.Account3.KeyUID,
 		},
 		nil,
-	)
+	).Times(2)
 
 	accManager.SetRootDataDir(rootDataDir)
+
 	keystore, err := accManager.createKeystore()
 	require.NoError(t, err)
 
 	err = utils.ImportTestAccount(keystore.KeystorePath(), "test-account3-before-eip55.pk") // Import keys and make sure one was created before EIP55 introduction.
 	require.NoError(t, err)
 
-	accManager.setKeystore(keystore)
-	time.Sleep(keystoreReloadDelay)
+	// now we need to reload the keystore (re-create it) in order to make the get-keystore aware of the copied account
+	err = accManager.ReloadKeystore()
+	require.NoError(t, err)
 
 	address := ethtypes.HexToAddress(utils.TestConfig.Account3.WalletAddress)
 	ok, err := accManager.VerifyAccountPassword(address, utils.TestConfig.Account3.Password)

--- a/accounts-management/accounts_test.go
+++ b/accounts-management/accounts_test.go
@@ -6,13 +6,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/status-im/status-go/accounts-management/common"
+	"github.com/status-im/status-go/accounts-management/generator"
 	"github.com/status-im/status-go/accounts-management/keystore/geth"
 	mock_persistence "github.com/status-im/status-go/accounts-management/mock"
 	"github.com/status-im/status-go/eth-node/crypto"
 	ethtypes "github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/protocol/tt"
 	"github.com/status-im/status-go/t/utils"
 
@@ -23,80 +25,101 @@ import (
 
 const testPassword = "test-password"
 const newTestPassword = "new-test-password"
-
-func setKeystore(accManager *AccountsManager, keyStoreDir string) error {
-	keystoreAdapter, err := geth.NewGethKeystoreAdapter(keyStoreDir, keystore.LightScryptN, keystore.LightScryptP)
-	if err != nil {
-		return err
-	}
-	accManager.SetKeystore(keystoreAdapter)
-	return nil
-}
+const keystoreReloadDelay = 2 * time.Second
 
 func TestVerifyAccountPassword(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	accManager, err := NewAccountsManager(tt.MustCreateTestLogger())
 	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
 	persistence := mock_persistence.NewMockPersistence(ctrl)
 	accManager.SetPersistence(persistence)
 
-	keyStoreDir := t.TempDir()
-	emptyKeyStoreDir := t.TempDir()
-
-	// import account keys
-	utils.Init()
-	require.NoError(t, utils.ImportTestAccount(keyStoreDir, utils.GetAccount1PKFile()))
-	require.NoError(t, utils.ImportTestAccount(keyStoreDir, utils.GetAccount2PKFile()))
+	utils.Init() // initialize the test config
 
 	testCases := []struct {
-		name          string
-		keyPath       string
-		address       string
-		password      string
-		expectedError error
+		name             string
+		keyUID           string
+		address          string
+		password         string
+		keystoreSet      bool
+		importToLocation bool
+		expectedError    error
 	}{
 		{
 			"correct address, correct password (decrypt should succeed)",
-			keyStoreDir,
+			utils.TestConfig.Account1.KeyUID,
 			utils.TestConfig.Account1.WalletAddress,
 			utils.TestConfig.Account1.Password,
+			true,
+			true,
 			nil,
 		},
 		{
 			"correct address, correct password, non-existent key store",
-			filepath.Join(keyStoreDir, "non-existent-folder"),
+			utils.TestConfig.Account1.KeyUID,
 			utils.TestConfig.Account1.WalletAddress,
 			utils.TestConfig.Account1.Password,
-			fmt.Errorf("no key for given address or file"),
+			false,
+			false,
+			ErrAccountKeyStoreMissing,
 		},
 		{
 			"correct address, correct password, empty key store (pk is not there)",
-			emptyKeyStoreDir,
+			utils.TestConfig.Account1.KeyUID,
 			utils.TestConfig.Account1.WalletAddress,
 			utils.TestConfig.Account1.Password,
+			true,
+			false,
 			fmt.Errorf("no key for given address or file"),
 		},
 		{
 			"wrong address, correct password",
-			keyStoreDir,
+			utils.TestConfig.Account1.KeyUID,
 			"0x79791d3e8f2daa1f7fec29649d152c0ada3cc535",
 			utils.TestConfig.Account1.Password,
+			true,
+			true,
 			fmt.Errorf("no key for given address or file"),
 		},
 		{
 			"correct address, wrong password",
-			keyStoreDir,
+			utils.TestConfig.Account1.KeyUID,
 			utils.TestConfig.Account1.WalletAddress,
 			"wrong password", // wrong password
+			true,
+			true,
 			geth.ErrDecrypt,
 		},
 	}
 	for _, testCase := range testCases {
-		err := setKeystore(accManager, testCase.keyPath)
+
+		persistence.EXPECT().GetProfileKeypair().Return(
+			&accounts.Keypair{
+				KeyUID: testCase.keyUID,
+			},
+			nil,
+		)
+
+		rootDataDir := t.TempDir()
+		accManager.SetRootDataDir(rootDataDir)
+		keystore, err := accManager.createKeystore()
 		require.NoError(t, err)
+
+		if testCase.importToLocation {
+			err = utils.ImportTestAccount(keystore.KeystorePath(), utils.GetAccount1PKFile())
+			require.NoError(t, err)
+		}
+
+		if testCase.keystoreSet {
+			accManager.setKeystore(keystore)
+
+			time.Sleep(keystoreReloadDelay)
+		} else {
+			accManager.setKeystore(nil)
+		}
 
 		ok, err := accManager.VerifyAccountPassword(ethtypes.HexToAddress(testCase.address), testCase.password)
 		if testCase.expectedError != nil && err != nil && testCase.expectedError.Error() != err.Error() ||
@@ -114,12 +137,9 @@ func TestVerifyAccountPassword(t *testing.T) {
 // TestVerifyAccountPasswordWithAccountBeforeEIP55 verifies if VerifyAccountPassword
 // can handle accounts before introduction of EIP55.
 func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {
-	keyStoreDir := t.TempDir()
+	rootDataDir := t.TempDir()
 
-	// Import keys and make sure one was created before EIP55 introduction.
-	utils.Init()
-	err := utils.ImportTestAccount(keyStoreDir, "test-account3-before-eip55.pk")
-	require.NoError(t, err)
+	utils.Init() // initialize the test config
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -130,8 +150,22 @@ func TestVerifyAccountPasswordWithAccountBeforeEIP55(t *testing.T) {
 	persistence := mock_persistence.NewMockPersistence(ctrl)
 	accManager.SetPersistence(persistence)
 
-	err = setKeystore(accManager, keyStoreDir)
+	persistence.EXPECT().GetProfileKeypair().Return(
+		&accounts.Keypair{
+			KeyUID: utils.TestConfig.Account3.KeyUID,
+		},
+		nil,
+	)
+
+	accManager.SetRootDataDir(rootDataDir)
+	keystore, err := accManager.createKeystore()
 	require.NoError(t, err)
+
+	err = utils.ImportTestAccount(keystore.KeystorePath(), "test-account3-before-eip55.pk") // Import keys and make sure one was created before EIP55 introduction.
+	require.NoError(t, err)
+
+	accManager.setKeystore(keystore)
+	time.Sleep(keystoreReloadDelay)
 
 	address := ethtypes.HexToAddress(utils.TestConfig.Account3.WalletAddress)
 	ok, err := accManager.VerifyAccountPassword(address, utils.TestConfig.Account3.Password)
@@ -172,19 +206,34 @@ func (s *ManagerTestSuite) SetupTest() {
 	persistence := mock_persistence.NewMockPersistence(ctrl)
 	s.accManager.SetPersistence(persistence)
 
-	keyStoreDir := s.T().TempDir()
-	err = setKeystore(s.accManager, keyStoreDir)
-	s.Require().NoError(err)
-	s.keydir = keyStoreDir
+	rootDataDir := s.T().TempDir()
+	s.accManager.SetRootDataDir(rootDataDir)
 
 	// Initial test - create test account
-	genAccount, mnemonic, err := s.accManager.CreateAndStoreAccount(testPassword)
+	mnemonic, err := common.CreateRandomMnemonicWithDefaultLength()
+	s.Require().NoError(err)
+
+	genAcc, err := generator.CreateAccountFromMnemonic(mnemonic, "")
+	s.Require().NoError(err)
+
+	persistence.EXPECT().GetProfileKeypair().Return(
+		&accounts.Keypair{
+			KeyUID: genAcc.KeyUID(),
+		},
+		nil,
+	).AnyTimes()
+
+	genAccount, err := s.accManager.CreateFromMnemonicAndStoreAccount(mnemonic, testPassword, true)
 	s.Require().NoError(err)
 	s.Require().NotEmpty(mnemonic)
+	s.Require().NotNil(genAccount)
+	s.Require().Equal(genAcc.KeyUID(), genAccount.KeyUID())
 	s.Require().NotNil(genAccount.PrivateKey())
 	s.Require().NotNil(genAccount.ExtendedKey())
 
 	accountInfo := genAccount.ToAccountInfo()
+
+	s.keydir = s.accManager.keystore.KeystorePath()
 
 	s.testAccount = testAccount{
 		testPassword,
@@ -197,7 +246,7 @@ func (s *ManagerTestSuite) SetupTest() {
 }
 
 func (s *ManagerTestSuite) TestRecoverAccount() {
-	genAccount, err := s.accManager.CreateFromMnemonicAndStoreAccount(s.mnemonic, s.password)
+	genAccount, err := s.accManager.CreateFromMnemonicAndStoreAccount(s.mnemonic, s.password, false)
 	s.NoError(err)
 	accountInfo := genAccount.ToAccountInfo()
 	s.Equal(s.walletAddress, accountInfo.Address)
@@ -219,7 +268,7 @@ func (s *ManagerTestSuite) TestSetChatAccountWrongPassword() {
 }
 
 func (s *ManagerTestSuite) testSetChatAccount(chat, wallet ethtypes.Address, password string, expErr error) {
-	err := s.accManager.SetChatAccount(chat, password)
+	err := s.accManager.SetChatAccount(chat, password, nil)
 	s.Require().Equal(expErr, err)
 
 	selectedChatAccount, chatErr := s.accManager.SelectedChatAccount()
@@ -227,6 +276,8 @@ func (s *ManagerTestSuite) testSetChatAccount(chat, wallet ethtypes.Address, pas
 	if expErr == nil {
 		s.Require().NoError(chatErr)
 		s.Equal(chat, crypto.PubkeyToAddress(selectedChatAccount.PrivateKey().PublicKey))
+		s.Require().NotNil(s.accManager.keystore)
+		s.Equal(s.keydir, s.accManager.keystore.KeystorePath())
 	} else {
 		s.Nil(selectedChatAccount)
 		s.Equal(chatErr, ErrNoAccountSelected)
@@ -235,38 +286,37 @@ func (s *ManagerTestSuite) testSetChatAccount(chat, wallet ethtypes.Address, pas
 	s.accManager.Logout()
 }
 
-func (s *ManagerTestSuite) TestSetChatAccount() {
-	s.accManager.Logout()
-
-	privKey, err := crypto.GenerateKey()
+func (s *ManagerTestSuite) TestSetChatAccountForExistingProfile() {
+	genAcc, err := generator.CreateAccountFromMnemonic(s.mnemonic, "")
 	s.Require().NoError(err)
 
-	address := crypto.PubkeyToAddress(privKey.PublicKey)
-
-	s.Require().NoError(s.accManager.SetChatAccountWithPrivateKey(privKey))
+	s.Require().NoError(s.accManager.SetChatAccount(genAcc.Address(), s.password, nil))
 	selectedChatAccount, err := s.accManager.SelectedChatAccount()
 	s.Require().NoError(err)
 	s.Require().NotNil(selectedChatAccount)
-	s.Equal(privKey, selectedChatAccount.PrivateKey())
-	s.Equal(address, selectedChatAccount.Address())
+	s.Equal(genAcc.PrivateKeyHex(), selectedChatAccount.PrivateKeyHex())
+	s.Equal(genAcc.Address(), selectedChatAccount.Address())
 }
 
 func (s *ManagerTestSuite) TestLogout() {
 	s.accManager.Logout()
 	s.Nil(s.accManager.selectedChatAccount)
 	s.Nil(s.accManager.keystore)
+	s.Nil(s.accManager.persistence)
+	s.Empty(s.accManager.rootDataDir)
 }
 
 // TestAccounts tests cases for (*Manager).Accounts.
 func (s *ManagerTestSuite) TestAccounts() {
 	// Select the test account
-	err := s.accManager.SetChatAccount(ethtypes.HexToAddress(s.chatAddress), s.password)
+	err := s.accManager.SetChatAccount(ethtypes.HexToAddress(s.chatAddress), s.password, nil)
 	s.NoError(err)
 
 	// Success
 	accs, err := s.accManager.Accounts()
 	s.NoError(err)
-	s.NotNil(accs)
+	s.Len(accs, 1)
+	s.Equal(ethtypes.HexToAddress(s.chatAddress), accs[0])
 }
 
 func (s *ManagerTestSuite) TestAddressToAccountSuccess() {

--- a/accounts-management/common/const.go
+++ b/accounts-management/common/const.go
@@ -6,6 +6,8 @@ const AddressBytesLength = 20
 // AddressHexLength is the expected length of the address in hex (with 0x prefix)
 const AddressHexLength = 2*AddressBytesLength + 2
 
+const PathMaster = "m"
+
 const PathEIP1581Root = "m/43'/60'/1581'"
 const PathEIP1581Chat = PathEIP1581Root + "/0'/0"
 const PathEIP1581Encryption = PathEIP1581Root + "/1'/0"

--- a/accounts-management/errors.go
+++ b/accounts-management/errors.go
@@ -5,10 +5,11 @@ import (
 )
 
 var (
-	ErrPersistenceIsMissing   = errors.New("persistence is not set")
-	ErrLoggerIsMissing        = errors.New("logger is not set")
-	ErrAccountDoesNotExist    = errors.New("account doesn't exist")
-	ErrNoAccountSelected      = errors.New("no account has been selected, please login")
-	ErrAccountKeyStoreMissing = errors.New("account key store is not set")
-	ErrAccountIsNil           = errors.New("account is nil")
+	ErrPersistenceIsMissing                   = errors.New("persistence is not set")
+	ErrLoggerIsMissing                        = errors.New("logger is not set")
+	ErrAccountDoesNotExist                    = errors.New("account doesn't exist")
+	ErrNoAccountSelected                      = errors.New("no account has been selected, please login")
+	ErrAccountKeyStoreMissing                 = errors.New("account key store is not set")
+	ErrAccountIsNil                           = errors.New("account is nil")
+	ErrAddressAndPasswordOrPrivateKeyRequired = errors.New("address and password or private key are required")
 )

--- a/accounts-management/keystore.go
+++ b/accounts-management/keystore.go
@@ -30,4 +30,6 @@ type KeyStore interface {
 	ReEncryptKeyStoreDir(oldPass, newPass string) error
 	// MigrateKeyStoreDir migrates the keystore directory from one location to another.
 	MigrateKeyStoreDir(newDir string) error
+	// KeystorePath returns the path to the keystore directory
+	KeystorePath() string
 }

--- a/accounts-management/keystore/geth/adapter.go
+++ b/accounts-management/keystore/geth/adapter.go
@@ -128,3 +128,7 @@ func (a *Adapter) MigrateKeyStoreDir(newDir string) error {
 	a.keystoreDir = newDir
 	return nil
 }
+
+func (a *Adapter) KeystorePath() string {
+	return a.keystoreDir
+}

--- a/accounts-management/persistence.go
+++ b/accounts-management/persistence.go
@@ -4,11 +4,14 @@ package accountsmanagement
 
 import (
 	ethtypes "github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/multiaccounts/accounts"
 )
 
 type Persistence interface {
 	// AddressExists checks if the address exists in the persistence
 	AddressExists(address ethtypes.Address) (bool, error)
+	// GetProfileKeypair returns the profile keypair
+	GetProfileKeypair() (*accounts.Keypair, error)
 	// GetWalletRootAddress returns the root address of the wallet
 	GetWalletRootAddress() (ethtypes.Address, error)
 	// GetPath returns the derivation path of the address

--- a/api/backend.go
+++ b/api/backend.go
@@ -20,18 +20,18 @@ type StatusBackend interface {
 	StartNode(config *params.NodeConfig) error // NOTE: Only used in canary
 	StartNodeWithKey(acc multiaccounts.Account, password string, keyHex string, conf *params.NodeConfig) error
 	StartNodeWithAccount(acc multiaccounts.Account, password string, conf *params.NodeConfig, chatKey *ecdsa.PrivateKey) error
-	StartNodeWithAccountAndInitialConfig(account multiaccounts.Account, password string, settings settings.Settings, conf *params.NodeConfig, subaccs []*accounts.Account, chatKey *ecdsa.PrivateKey) error
+	StartNodeWithAccountAndInitialConfig(mnemonic string, account multiaccounts.Account, password string, settings settings.Settings,
+		conf *params.NodeConfig, keypair *accounts.Keypair, chatKey *ecdsa.PrivateKey) error
 	StopNode() error
 
 	GetNodeConfig() (*params.NodeConfig, error)
 	UpdateRootDataDir(datadir string)
 
-	SelectAccount(loginParams LoginParams) error
+	SelectAccount(loginParams LoginParams, privateKey *ecdsa.PrivateKey) error
 	OpenAccounts() error
 	GetAccounts() ([]multiaccounts.Account, error)
 	LocalPairingStarted() error
 	SaveAccount(account multiaccounts.Account) error
-	SaveAccountAndStartNodeWithKey(acc multiaccounts.Account, password string, settings settings.Settings, conf *params.NodeConfig, subaccs []*accounts.Account, keyHex string) error
 	Recover(rpcParams personal.RecoverParams) (types.Address, error)
 	Logout() error
 

--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -23,11 +21,6 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
-
-	accsmanagement "github.com/status-im/status-go/accounts-management"
-	accscommon "github.com/status-im/status-go/accounts-management/common"
-	"github.com/status-im/status-go/accounts-management/generator"
 	"github.com/status-im/status-go/accounts-management/keystore/geth"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/connection"
@@ -48,30 +41,9 @@ import (
 	"github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
 	"github.com/status-im/status-go/signal"
-	"github.com/status-im/status-go/sqlite"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/t/utils"
 	"github.com/status-im/status-go/walletdatabase"
-)
-
-var (
-	networks     = json.RawMessage("{}")
-	testSettings = settings.Settings{
-		Address:           types.HexToAddress("0xeC540f3745Ff2964AFC1171a5A0DD726d1F6B472"),
-		DisplayName:       "UserDisplayName",
-		CurrentNetwork:    "mainnet_rpc",
-		DappsAddress:      types.HexToAddress("0xe1300f99fDF7346986CbC766903245087394ecd0"),
-		EIP1581Address:    types.HexToAddress("0xe1DDDE9235a541d1344550d969715CF43982de9f"),
-		InstallationID:    "d3efcff6-cffa-560e-a547-21d3858cbc51",
-		KeyUID:            "0x4e8129f3edfc004875be17bf468a784098a9f69b53c095be1f52deff286935ab",
-		LatestDerivedPath: 0,
-		Name:              "Jittery Cornflowerblue Kingbird",
-		Networks:          &networks,
-		PhotoPath:         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAjklEQVR4nOzXwQmFMBAAUZXUYh32ZB32ZB02sxYQQSZGsod55/91WFgSS0RM+SyjA56ZRZhFmEWYRRT6h+M6G16zrxv6fdJpmUWYRbxsYr13dKfanpN0WmYRZhGzXz6AWYRZRIfbaX26fT9Jk07LLMIsosPt9I/dTDotswizCG+nhFmEWYRZhFnEHQAA///z1CFkYamgfQAAAABJRU5ErkJggg==",
-		PreviewPrivacy:    false,
-		PublicKey:         "0x04211fe0f69772ecf7eb0b5bfc7678672508a9fb01f2d699096f0d59ef7fe1a0cb1e648a80190db1c0f5f088872444d846f2956d0bd84069f3f9f69335af852ac0",
-		SigningPhrase:     "yurt joey vibe",
-		WalletRootAddress: types.HexToAddress("0xeB591fd819F86D0A6a2EF2Bcb94f77807a7De1a6")}
 )
 
 func setupTestDB() (*sql.DB, func() error, error) {
@@ -126,15 +98,6 @@ func setupGethStatusBackend() (*GethStatusBackend, func() error, func() error, f
 	return backend, stop1, stop2, stop3, err
 }
 
-func setKeystore(accManager *accsmanagement.AccountsManager, keyStoreDir string) error {
-	keystoreAdapter, err := geth.NewGethKeystoreAdapter(keyStoreDir, keystore.LightScryptN, keystore.LightScryptP)
-	if err != nil {
-		return err
-	}
-	accManager.SetKeystore(keystoreAdapter)
-	return nil
-}
-
 func handleError(t *testing.T, err error) {
 	if err != nil {
 		t.Logf("deferred function error: '%s'", err)
@@ -166,8 +129,6 @@ func TestBackendStartNodeConcurrently(t *testing.T) {
 	require.NoError(t, err)
 
 	config, err := utils.MakeTestNodeConfig(params.StatusChainNetworkID)
-	require.NoError(t, err)
-	err = setKeystore(backend.AccountsManager(), config.KeyStoreDir)
 	require.NoError(t, err)
 
 	count := 2
@@ -224,9 +185,8 @@ func TestBackendRestartNodeConcurrently(t *testing.T) {
 
 	config, err := utils.MakeTestNodeConfig(params.StatusChainNetworkID)
 	require.NoError(t, err)
-	count := 3
-	err = setKeystore(backend.AccountsManager(), config.KeyStoreDir)
-	require.NoError(t, err)
+	const count = 3
+
 	require.NoError(t, backend.StartNode(config))
 	defer func() {
 		require.NoError(t, backend.StopNode())
@@ -273,8 +233,7 @@ func TestBackendGettersConcurrently(t *testing.T) {
 
 	config, err := utils.MakeTestNodeConfig(params.StatusChainNetworkID)
 	require.NoError(t, err)
-	err = setKeystore(backend.AccountsManager(), config.KeyStoreDir)
-	require.NoError(t, err)
+
 	err = backend.StartNode(config)
 	require.NoError(t, err)
 	defer func() {
@@ -381,9 +340,6 @@ func TestBackendCallRPCConcurrently(t *testing.T) {
 
 	config, err := utils.MakeTestNodeConfig(params.StatusChainNetworkID)
 	require.NoError(t, err)
-	err = setKeystore(backend.AccountsManager(), config.KeyStoreDir)
-	require.NoError(t, err)
-	count := 3
 
 	err = backend.StartNode(config)
 	require.NoError(t, err)
@@ -393,6 +349,7 @@ func TestBackendCallRPCConcurrently(t *testing.T) {
 
 	var wg sync.WaitGroup
 
+	const count = 3
 	for i := 0; i < count; i++ {
 		wg.Add(1)
 		go func(idx int) {
@@ -478,8 +435,7 @@ func TestBlockedRPCMethods(t *testing.T) {
 
 	config, err := utils.MakeTestNodeConfig(params.StatusChainNetworkID)
 	require.NoError(t, err)
-	err = setKeystore(backend.AccountsManager(), config.KeyStoreDir)
-	require.NoError(t, err)
+
 	err = backend.StartNode(config)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, backend.StopNode()) }()
@@ -539,8 +495,7 @@ func TestStartStopMultipleTimes(t *testing.T) {
 
 	config, err := utils.MakeTestNodeConfig(params.StatusChainNetworkID)
 	require.NoError(t, err)
-	err = setKeystore(backend.AccountsManager(), config.KeyStoreDir)
-	require.NoError(t, err)
+
 	config.NoDiscovery = false
 	// doesn't have to be running. just any valid enode to bypass validation.
 	config.ClusterConfig.BootNodes = []string{
@@ -579,8 +534,7 @@ func TestHashTypedData(t *testing.T) {
 
 	config, err := utils.MakeTestNodeConfig(params.StatusChainNetworkID)
 	require.NoError(t, err)
-	err = setKeystore(backend.AccountsManager(), config.KeyStoreDir)
-	require.NoError(t, err)
+
 	err = backend.StartNode(config)
 	require.NoError(t, err)
 	defer func() {
@@ -625,16 +579,20 @@ func TestHashTypedData(t *testing.T) {
 func TestBackendGetVerifiedAccount(t *testing.T) {
 	utils.Init()
 
-	password := "test"
-	backend, defers, err := setupWalletTest(t, password)
+	testContext := setupTestContext(t, testPassword, true, true, false)
+
+	err := testContext.backend.StartNode(testContext.config)
 	require.NoError(t, err)
-	defer defers()
+
+	defer func() {
+		require.NoError(t, testContext.backend.StopNode())
+	}()
 
 	t.Run("AccountDoesntExist", func(t *testing.T) {
 		pkey, err := gethcrypto.GenerateKey()
 		require.NoError(t, err)
 		address := gethcrypto.PubkeyToAddress(pkey.PublicKey)
-		key, err := backend.getVerifiedWalletAccount(address.String(), password)
+		key, err := testContext.backend.getVerifiedWalletAccount(address.String(), testPassword)
 		require.EqualError(t, err, wallettypes.ErrAccountDoesntExist.Error())
 		require.Nil(t, key)
 	})
@@ -647,10 +605,10 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 		keyUIDHex := sha256.Sum256(gethcrypto.FromECDSAPub(&pkey.PublicKey))
 		keyUID := types.EncodeHex(keyUIDHex[:])
 
-		db, err := accounts.NewDB(backend.appDB)
+		db, err := accounts.NewDB(testContext.backend.appDB)
 		require.NoError(t, err)
 
-		_, err = backend.AccountsManager().CreateFromPrivateKeyAndStoreAccount(privateKeyHex, password)
+		_, err = testContext.backend.AccountsManager().CreateFromPrivateKeyAndStoreAccount(privateKeyHex, testPassword)
 		require.NoError(t, err)
 
 		require.NoError(t, db.SaveOrUpdateKeypair(&accounts.Keypair{
@@ -664,25 +622,25 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 				},
 			},
 		}))
-		key, err := backend.getVerifiedWalletAccount(address.String(), "wrong-password")
+		key, err := testContext.backend.getVerifiedWalletAccount(address.String(), "wrong-password")
 		require.EqualError(t, err, geth.ErrDecrypt.Error())
 		require.Nil(t, key)
 	})
 
 	t.Run("PartialAccount", func(t *testing.T) {
 		// Create a derived wallet account without storing the keys
-		db, err := accounts.NewDB(backend.appDB)
+		db, err := accounts.NewDB(testContext.backend.appDB)
 		require.NoError(t, err)
 		newPath := "m/0"
 		walletRootAddress, err := db.GetWalletRootAddress()
 		require.NoError(t, err)
 
-		genAcc, err := backend.AccountsManager().LoadAccount(walletRootAddress, password)
+		genAcc, err := testContext.backend.AccountsManager().LoadAccount(walletRootAddress, testPassword)
 		require.NoError(t, err)
 
 		walletInfo := genAcc.ToIdentifiedAccountInfo()
 
-		derivedAcc, err := backend.AccountsManager().DeriveChildAccountForPathAndStore(walletRootAddress, newPath, password)
+		derivedAcc, err := testContext.backend.AccountsManager().DeriveChildAccountForPathAndStore(walletRootAddress, newPath, testPassword)
 		require.NoError(t, err)
 
 		derivedInfo := derivedAcc.ToAccountInfo()
@@ -706,7 +664,7 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 		require.NoError(t, db.SaveOrUpdateKeypair(keypair))
 
 		// With partial account we need to dynamically generate private key
-		acc, err := backend.getVerifiedWalletAccount(keypair.Accounts[0].Address.Hex(), password)
+		acc, err := testContext.backend.getVerifiedWalletAccount(keypair.Accounts[0].Address.Hex(), testPassword)
 		require.NoError(t, err)
 		require.Equal(t, keypair.Accounts[0].Address, acc.Address())
 	})
@@ -719,13 +677,13 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 		keyUIDHex := sha256.Sum256(gethcrypto.FromECDSAPub(&pkey.PublicKey))
 		keyUID := types.EncodeHex(keyUIDHex[:])
 
-		db, err := accounts.NewDB(backend.appDB)
+		db, err := accounts.NewDB(testContext.backend.appDB)
 		require.NoError(t, err)
 		defer func() {
 			handleError(t, db.Close())
 		}()
 
-		_, err = backend.AccountsManager().CreateFromPrivateKeyAndStoreAccount(privateKeyHex, password)
+		_, err = testContext.backend.AccountsManager().CreateFromPrivateKeyAndStoreAccount(privateKeyHex, testPassword)
 		require.NoError(t, err)
 
 		require.NoError(t, db.SaveOrUpdateKeypair(&accounts.Keypair{
@@ -739,7 +697,7 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 				},
 			},
 		}))
-		acc, err := backend.getVerifiedWalletAccount(address.String(), password)
+		acc, err := testContext.backend.getVerifiedWalletAccount(address.String(), testPassword)
 		require.NoError(t, err)
 		require.Equal(t, address, acc.Address())
 	})
@@ -748,148 +706,68 @@ func TestBackendGetVerifiedAccount(t *testing.T) {
 func TestRuntimeLogLevelIsNotWrittenToDatabase(t *testing.T) {
 	utils.Init()
 
-	b := NewGethStatusBackend(tt.MustCreateTestLogger())
+	testContext := setupTestContext(t, testPassword, false, false, false)
 
-	chatKey, err := gethcrypto.GenerateKey()
-	require.NoError(t, err)
-	walletKey, err := gethcrypto.GenerateKey()
-	require.NoError(t, err)
-	keyUIDHex := sha256.Sum256(gethcrypto.FromECDSAPub(&chatKey.PublicKey))
-	keyUID := types.EncodeHex(keyUIDHex[:])
-	main := multiaccounts.Account{
-		KeyUID: keyUID,
-	}
-
-	tmpdir := t.TempDir()
-
-	config := `{
+	json := `{
 		"NetworkId": 3,
-		"DataDir": "` + tmpdir + `",
-		"KeyStoreDir": "` + tmpdir + `",
-		"KeycardPairingDataFile": "` + path.Join(tmpdir, "keycard/pairings.json") + `",
+		"DataDir": "` + testContext.config.DataDir + `",
+		"KeycardPairingDataFile": "` + path.Join(testContext.config.DataDir, "keycard/pairings.json") + `",
 		"NoDiscovery": true,
 		"TorrentConfig": {
 			"Port": 9025,
 			"Enabled": false,
-			"DataDir": "` + tmpdir + `/archivedata",
-			"TorrentDir": "` + tmpdir + `/torrents"
+			"DataDir": "` + testContext.config.DataDir + `/archivedata",
+			"TorrentDir": "` + testContext.config.DataDir + `/torrents"
 		},
 		"RuntimeLogLevel": "INFO",
 		"LogLevel": "DEBUG"
 	}`
 
-	conf, err := params.NewConfigFromJSON(config)
+	newConf, err := params.NewConfigFromJSON(json)
 	require.NoError(t, err)
-	require.Equal(t, "INFO", conf.RuntimeLogLevel)
-	keyhex := hex.EncodeToString(gethcrypto.FromECDSA(chatKey))
+	require.Equal(t, "INFO", newConf.RuntimeLogLevel)
 
-	err = setKeystore(b.AccountsManager(), conf.KeyStoreDir)
+	require.NoError(t, testContext.backend.OpenAccounts())
+	require.NotNil(t, testContext.backend.statusNode.HTTPServer())
+
+	err = testContext.backend.ensureDBsOpened(*testContext.multiAcc, testPassword)
 	require.NoError(t, err)
-	b.UpdateRootDataDir(conf.DataDir)
-	require.NoError(t, b.OpenAccounts())
-	require.NotNil(t, b.statusNode.HTTPServer())
 
-	address := crypto.PubkeyToAddress(walletKey.PublicKey)
+	require.NoError(t, testContext.backend.StartNodeWithAccountAndInitialConfig(testContext.mnemonic, *testContext.multiAcc, testPassword, testContext.settings, newConf, testContext.profileKeypair, nil))
+	require.NoError(t, testContext.backend.Logout())
+	require.NoError(t, testContext.backend.StopNode())
 
-	s := testSettings
-	s.KeyUID = keyUID
-	s.Address = crypto.PubkeyToAddress(walletKey.PublicKey)
+	chatPrivKey := strings.TrimPrefix(testContext.chatPrivateKey, "0x")
+	require.NoError(t, testContext.backend.StartNodeWithKey(*testContext.multiAcc, testPassword, chatPrivKey, newConf))
 
-	chatPubKey := crypto.FromECDSAPub(&chatKey.PublicKey)
-	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", s, conf,
-		[]*accounts.Account{
-			{Address: address, KeyUID: keyUID, Wallet: true},
-			{Address: crypto.PubkeyToAddress(chatKey.PublicKey), KeyUID: keyUID, Chat: true, PublicKey: chatPubKey}}, keyhex))
-	require.NoError(t, b.Logout())
-	require.NoError(t, b.StopNode())
-
-	require.NoError(t, b.StartNodeWithKey(main, "test-pass", keyhex, conf))
 	defer func() {
-		assert.NoError(t, b.Logout())
-		assert.NoError(t, b.StopNode())
+		assert.NoError(t, testContext.backend.Logout())
+		assert.NoError(t, testContext.backend.StopNode())
 	}()
 
-	c, err := b.GetNodeConfig()
+	c, err := testContext.backend.GetNodeConfig()
 	require.NoError(t, err)
 	require.Equal(t, "", c.RuntimeLogLevel)
 	require.Equal(t, "DEBUG", c.LogLevel)
 }
 
-func TestLoginWithKey(t *testing.T) {
-	utils.Init()
-
-	b := NewGethStatusBackend(tt.MustCreateTestLogger())
-
-	chatKey, err := gethcrypto.GenerateKey()
-	require.NoError(t, err)
-	walletKey, err := gethcrypto.GenerateKey()
-	require.NoError(t, err)
-	keyUIDHex := sha256.Sum256(gethcrypto.FromECDSAPub(&chatKey.PublicKey))
-	keyUID := types.EncodeHex(keyUIDHex[:])
-	main := multiaccounts.Account{
-		KeyUID: keyUID,
-	}
-	tmpdir := t.TempDir()
-	conf, err := params.NewNodeConfig(tmpdir, 1777)
-	require.NoError(t, err)
-	keyhex := hex.EncodeToString(gethcrypto.FromECDSA(chatKey))
-
-	err = setKeystore(b.AccountsManager(), conf.KeyStoreDir)
-	require.NoError(t, err)
-	b.UpdateRootDataDir(conf.DataDir)
-	require.NoError(t, b.OpenAccounts())
-	require.NotNil(t, b.statusNode.HTTPServer())
-
-	address := crypto.PubkeyToAddress(walletKey.PublicKey)
-
-	s := testSettings
-	s.KeyUID = keyUID
-	s.Address = crypto.PubkeyToAddress(walletKey.PublicKey)
-
-	chatPubKey := crypto.FromECDSAPub(&chatKey.PublicKey)
-	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", s, conf,
-		[]*accounts.Account{
-			{Address: address, KeyUID: keyUID, Wallet: true},
-			{Address: crypto.PubkeyToAddress(chatKey.PublicKey), KeyUID: keyUID, Chat: true, PublicKey: chatPubKey}}, keyhex))
-	require.NoError(t, b.Logout())
-	require.NoError(t, b.StopNode())
-
-	err = setKeystore(b.AccountsManager(), conf.KeyStoreDir)
-	require.NoError(t, err)
-	b.UpdateRootDataDir(conf.DataDir)
-	require.NoError(t, b.OpenAccounts())
-
-	require.NoError(t, b.StartNodeWithKey(main, "test-pass", keyhex, conf))
-	defer func() {
-		assert.NoError(t, b.Logout())
-		assert.NoError(t, b.StopNode())
-	}()
-	acc, err := b.AccountsManager().SelectedChatAccount()
-	require.NoError(t, err)
-	require.Equal(t, crypto.PubkeyToAddress(chatKey.PublicKey), acc.Address())
-
-	activeAccount, err := b.GetActiveAccount()
-	require.NoError(t, err)
-	require.NotNil(t, activeAccount.ColorHash)
-}
-
 func TestLoginAccount(t *testing.T) {
 	utils.Init()
-	password := "some-password"
-	tmpdir := t.TempDir()
-	nameserver := "8.8.8.8"
 
-	b := NewGethStatusBackend(tt.MustCreateTestLogger())
+	testContext := setupTestContext(t, testPassword, false, false, false)
+
+	nameserver := "8.8.8.8"
 
 	createAccountRequest := &requests.CreateAccount{
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
-		Password:           password,
-		RootDataDir:        tmpdir,
-		LogFilePath:        tmpdir + "/log",
+		Password:           testPassword,
+		RootDataDir:        testContext.config.DataDir,
+		LogFilePath:        testContext.config.DataDir + "/log",
 		WakuV2Nameserver:   &nameserver,
 		WakuV2Fleet:        "status.staging",
 	}
+
 	c := make(chan interface{}, 10)
 	signal.SetMobileSignalHandler(func(data []byte) {
 		if strings.Contains(string(data), signal.EventLoggedIn) {
@@ -907,11 +785,11 @@ func TestLoginAccount(t *testing.T) {
 		}
 	}
 
-	acc, err := b.CreateAccountAndLogin(createAccountRequest)
+	acc, err := testContext.backend.CreateAccountAndLogin(createAccountRequest)
 	require.NoError(t, err)
-	require.Equal(t, nameserver, b.config.WakuV2Config.Nameserver)
+	require.Equal(t, nameserver, testContext.backend.config.WakuV2Config.Nameserver)
 
-	accountsDB, err := b.accountsDB()
+	accountsDB, err := testContext.backend.accountsDB()
 	require.NoError(t, err)
 	backupFecthed, err := accountsDB.BackupFetched()
 	require.NoError(t, err)
@@ -920,309 +798,82 @@ func TestLoginAccount(t *testing.T) {
 	require.True(t, acc.HasAcceptedTerms)
 
 	waitForLogin(c)
-	require.NoError(t, b.Logout())
-	require.NoError(t, b.StopNode())
+	require.NoError(t, testContext.backend.Logout())
+	require.NoError(t, testContext.backend.StopNode())
 
-	accs, err := b.GetAccounts()
+	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
+
+	accounts, err := testContext.backend.GetAccounts()
 	require.NoError(t, err)
-	require.Len(t, accs, 1)
+	require.Len(t, accounts, 1)
 
-	require.NotEmpty(t, accs[0].KeyUID)
-	require.Equal(t, acc.KeyUID, accs[0].KeyUID)
+	require.NotEmpty(t, accounts[0].KeyUID)
+	require.Equal(t, acc.KeyUID, accounts[0].KeyUID)
 
 	loginAccountRequest := &requests.Login{
-		KeyUID:           accs[0].KeyUID,
-		Password:         password,
+		KeyUID:           accounts[0].KeyUID,
+		Password:         testPassword,
 		WakuV2Nameserver: nameserver,
 	}
-	err = b.LoginAccount(loginAccountRequest)
+	err = testContext.backend.LoginAccount(loginAccountRequest)
 	require.NoError(t, err)
 	waitForLogin(c)
-
-	require.Equal(t, nameserver, b.config.WakuV2Config.Nameserver)
+	require.Equal(t, nameserver, testContext.backend.config.WakuV2Config.Nameserver)
 }
 
 func TestVerifyDatabasePassword(t *testing.T) {
 	utils.Init()
 
-	b := NewGethStatusBackend(tt.MustCreateTestLogger())
+	testContext := setupTestContext(t, testPassword, false, false, false)
 
-	chatKey, err := gethcrypto.GenerateKey()
-	require.NoError(t, err)
-	walletKey, err := gethcrypto.GenerateKey()
-	require.NoError(t, err)
-	keyUIDHex := sha256.Sum256(gethcrypto.FromECDSAPub(&chatKey.PublicKey))
-	keyUID := types.EncodeHex(keyUIDHex[:])
-	main := multiaccounts.Account{
-		KeyUID: keyUID,
-	}
-	tmpdir := t.TempDir()
-	conf, err := params.NewNodeConfig(tmpdir, 1777)
-	require.NoError(t, err)
-	keyhex := hex.EncodeToString(gethcrypto.FromECDSA(chatKey))
+	require.NoError(t, testContext.backend.StartNodeWithAccountAndInitialConfig(testContext.mnemonic, *testContext.multiAcc, testPassword,
+		testContext.settings, testContext.config, testContext.profileKeypair, nil))
+	require.NoError(t, testContext.backend.Logout())
+	require.NoError(t, testContext.backend.StopNode())
 
-	err = setKeystore(b.AccountsManager(), conf.KeyStoreDir)
-	require.NoError(t, err)
-	b.UpdateRootDataDir(conf.DataDir)
-	require.NoError(t, b.OpenAccounts())
-
-	address := crypto.PubkeyToAddress(walletKey.PublicKey)
-
-	s := testSettings
-	s.KeyUID = keyUID
-	s.Address = crypto.PubkeyToAddress(walletKey.PublicKey)
-
-	chatPubKey := crypto.FromECDSAPub(&chatKey.PublicKey)
-
-	require.NoError(t, b.SaveAccountAndStartNodeWithKey(main, "test-pass", s, conf, []*accounts.Account{
-		{Address: address, KeyUID: keyUID, Wallet: true},
-		{Address: crypto.PubkeyToAddress(chatKey.PublicKey), KeyUID: keyUID, Chat: true, PublicKey: chatPubKey}}, keyhex))
-	require.NoError(t, b.Logout())
-	require.NoError(t, b.StopNode())
-
-	require.Error(t, b.VerifyDatabasePassword(main.KeyUID, "wrong-pass"))
-	require.NoError(t, b.VerifyDatabasePassword(main.KeyUID, "test-pass"))
-}
-
-func TestDeleteMultiaccount(t *testing.T) {
-	backend := NewGethStatusBackend(tt.MustCreateTestLogger())
-
-	rootDataDir := t.TempDir()
-
-	keyStoreDir := filepath.Join(rootDataDir, "keystore")
-
-	backend.rootDataDir = rootDataDir
-
-	err := setKeystore(backend.AccountsManager(), keyStoreDir)
-	require.NoError(t, err)
-
-	const password = "123123"
-	genAccount, _, err := backend.AccountsManager().CreateAndStoreAccount(password)
-	if err != nil {
-		return
-	}
-
-	genAccInfo := genAccount.ToIdentifiedAccountInfo()
-
-	derivedAcc, err := backend.AccountsManager().DeriveChildAccountForPathAndStore(types.HexToAddress(genAccInfo.Address), accscommon.PathWalletRoot, password)
-	if err != nil {
-		return
-	}
-
-	walletRootAddress := derivedAcc.Address()
-	derivedInfo := derivedAcc.ToAccountInfo()
-
-	account := multiaccounts.Account{
-		Name:           "foo",
-		Timestamp:      1,
-		KeycardPairing: "pairing",
-		KeyUID:         genAccInfo.KeyUID,
-	}
-
-	err = backend.ensureAppDBOpened(account, "123123")
-	require.NoError(t, err)
-
-	s := settings.Settings{
-		Address:           walletRootAddress,
-		CurrentNetwork:    "mainnet_rpc",
-		DappsAddress:      walletRootAddress,
-		EIP1581Address:    walletRootAddress,
-		InstallationID:    "d3efcff6-cffa-560e-a547-21d3858cbc51",
-		KeyUID:            account.KeyUID,
-		LatestDerivedPath: 0,
-		Name:              "Jittery Cornflowerblue Kingbird",
-		Networks:          &networks,
-		PhotoPath:         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAjklEQVR4nOzXwQmFMBAAUZXUYh32ZB32ZB02sxYQQSZGsod55/91WFgSS0RM+SyjA56ZRZhFmEWYRRT6h+M6G16zrxv6fdJpmUWYRbxsYr13dKfanpN0WmYRZhGzXz6AWYRZRIfbaX26fT9Jk07LLMIsosPt9I/dTDotswizCG+nhFmEWYRZhFnEHQAA///z1CFkYamgfQAAAABJRU5ErkJggg==",
-		PreviewPrivacy:    false,
-		PublicKey:         derivedInfo.PublicKey,
-		SigningPhrase:     "yurt joey vibe",
-		WalletRootAddress: walletRootAddress,
-	}
-
-	err = backend.saveAccountsAndSettings(
-		s,
-		&params.NodeConfig{},
-		nil)
-	require.Error(t, err)
-	require.True(t, err == accounts.ErrKeypairWithoutAccounts)
-
-	err = backend.OpenAccounts()
-	require.NoError(t, err)
-
-	err = backend.SaveAccount(account)
-	require.NoError(t, err)
-
-	files, err := os.ReadDir(rootDataDir)
-	require.NoError(t, err)
-	require.NotEqual(t, 3, len(files))
-
-	err = backend.DeleteMultiaccount(account.KeyUID, keyStoreDir)
-	require.NoError(t, err)
-
-	files, err = os.ReadDir(rootDataDir)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(files))
+	require.Error(t, testContext.backend.VerifyDatabasePassword(testContext.profileKeypair.KeyUID, "wrong-pass"))
+	require.NoError(t, testContext.backend.VerifyDatabasePassword(testContext.profileKeypair.KeyUID, testPassword))
 }
 
 func TestConvertAccount(t *testing.T) {
-	const mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-	const password = "111111"        // represents password for a regular user
-	const keycardPassword = "222222" // represents password for a keycard user
-	const keycardUID = "1234"
-	var allGeneratedPaths []string
-	allGeneratedPaths = append(allGeneratedPaths, accscommon.PathEIP1581Root, accscommon.PathEIP1581Chat, accscommon.PathWalletRoot, accscommon.PathDefaultWalletAccount, accscommon.CustomWalletPath1, accscommon.CustomWalletPath2)
+	testContext := setupTestContext(t, testPassword, false, false, true)
 
-	var err error
-
-	keystoreContainsFileForAccount := func(keyStoreDir string, hexAddress string) bool {
-		addrWithoutPrefix := strings.ToLower(hexAddress[2:])
-		found := false
-		err = filepath.Walk(keyStoreDir, func(path string, fileInfo os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			if !fileInfo.IsDir() && strings.Contains(strings.ToUpper(path), strings.ToUpper(addrWithoutPrefix)) {
-				found = true
-			}
-			return nil
-		})
-		return found
-	}
-
-	rootDataDir := t.TempDir()
-
-	keyStoreDirPath := filepath.Join(rootDataDir, "keystore")
-
-	utils.Init()
-
-	backend, stop1, stop2, stopWallet, err := setupGethStatusBackend()
-	defer func() {
-		err := stop1()
-		if err != nil {
-			require.NoError(t, backend.StopNode())
-		}
-	}()
-	defer func() {
-		err := stop2()
-		if err != nil {
-			require.NoError(t, backend.StopNode())
-		}
-	}()
-	defer func() {
-		err := stopWallet()
-		if err != nil {
-			require.NoError(t, backend.StopNode())
-		}
-	}()
+	err := testContext.backend.StartNodeWithAccountAndInitialConfig(testContext.mnemonic, *testContext.multiAcc, testPassword,
+		testContext.settings, testContext.config, testContext.profileKeypair, nil)
 	require.NoError(t, err)
 
-	backend.rootDataDir = rootDataDir
-	err = setKeystore(backend.AccountsManager(), keyStoreDirPath)
+	multiaccounts, err := testContext.backend.GetAccounts()
 	require.NoError(t, err)
-
-	err = backend.OpenAccounts()
-	require.NoError(t, err)
-
-	genAcc, err := backend.AccountsManager().CreateFromMnemonicAndStoreAccount(mnemonic, password)
-	assert.NoError(t, err)
-
-	genAccInfo := genAcc.ToIdentifiedAccountInfo()
-	masterAddress := genAccInfo.Address
-
-	found := keystoreContainsFileForAccount(keyStoreDirPath, genAccInfo.Address)
-	require.True(t, found)
-
-	derivedAccounts, err := backend.AccountsManager().DeriveChildrenAccountsForPathsAndStore(types.HexToAddress(genAccInfo.Address), allGeneratedPaths, password)
-	assert.NoError(t, err)
-
-	chatAcc := derivedAccounts[accscommon.PathEIP1581Chat]
-	chatInfo := chatAcc.ToAccountInfo()
-
-	for _, acc := range derivedAccounts {
-		found := keystoreContainsFileForAccount(keyStoreDirPath, acc.Address().Hex())
-		require.True(t, found)
-	}
-
-	derivedAccountsInfo := make(map[string]generator.AccountInfo, 0)
-	for path, acc := range derivedAccounts {
-		derivedAccountsInfo[path] = acc.ToAccountInfo()
-	}
-
-	defaultSettings, err := defaultSettings(genAccInfo.KeyUID, genAccInfo.Address, derivedAccountsInfo)
-	require.NoError(t, err)
-	nodeConfig, err := DefaultNodeConfig(defaultSettings.InstallationID, genAccInfo.KeyUID, &requests.CreateAccount{
-		LogLevel: defaultSettings.LogLevel,
-	})
-	require.NoError(t, err)
-	nodeConfig.DataDir = rootDataDir
-	nodeConfig.KeyStoreDir = keyStoreDirPath
-
-	profileKeypair := &accounts.Keypair{
-		KeyUID:      genAccInfo.KeyUID,
-		Name:        "Profile Name",
-		Type:        accounts.KeypairTypeProfile,
-		DerivedFrom: masterAddress,
-	}
-
-	profileKeypair.Accounts = append(profileKeypair.Accounts, &accounts.Account{
-		Address:   types.HexToAddress(chatInfo.Address),
-		KeyUID:    profileKeypair.KeyUID,
-		Type:      accounts.AccountTypeGenerated,
-		PublicKey: types.Hex2Bytes(genAccInfo.PublicKey),
-		Path:      accscommon.PathEIP1581Chat,
-		Wallet:    false,
-		Chat:      true,
-		Name:      "GeneratedAccount",
-	})
-
-	for p, dAccInfo := range derivedAccountsInfo {
-		found = keystoreContainsFileForAccount(keyStoreDirPath, dAccInfo.Address)
-		require.NoError(t, err)
-		require.True(t, found)
-
-		if p == accscommon.PathDefaultWalletAccount ||
-			p == accscommon.CustomWalletPath1 ||
-			p == accscommon.CustomWalletPath2 {
-			wAcc := &accounts.Account{
-				Address: types.HexToAddress(dAccInfo.Address),
-				KeyUID:  profileKeypair.KeyUID,
-				Wallet:  false,
-				Chat:    false,
-				Type:    accounts.AccountTypeGenerated,
-				Path:    p,
-				Name:    "derivacc" + p,
-				Hidden:  false,
-				Removed: false,
-			}
-			if p == accscommon.PathDefaultWalletAccount {
-				wAcc.Wallet = true
-			}
-			profileKeypair.Accounts = append(profileKeypair.Accounts, wAcc)
-		}
-	}
-
-	account := multiaccounts.Account{
-		Name:      profileKeypair.Name,
-		Timestamp: 1,
-		KeyUID:    profileKeypair.KeyUID,
-	}
-
-	err = backend.ensureAppDBOpened(account, password)
-	require.NoError(t, err)
-
-	err = backend.StartNodeWithAccountAndInitialConfig(account, password, *defaultSettings, nodeConfig, profileKeypair.Accounts, nil)
-	require.NoError(t, err)
-	multiaccs, err := backend.GetAccounts()
-	require.NoError(t, err)
-	require.NotEmpty(t, multiaccs[0].ColorHash)
-	serverMessenger := backend.Messenger()
+	require.NotEmpty(t, multiaccounts[0].ColorHash)
+	serverMessenger := testContext.backend.Messenger()
 	require.NotNil(t, serverMessenger)
 
-	files, err := os.ReadDir(rootDataDir)
+	// Ensure all created accounts are in the keystore and can be loaded
+	masterAddress := types.HexToAddress(testContext.profileKeypair.DerivedFrom)
+	ok, err := testContext.backend.AccountsManager().VerifyAccountPassword(masterAddress, testPassword)
 	require.NoError(t, err)
-	require.NotEqual(t, 3, len(files))
+	require.True(t, ok)
 
-	keycardAccount := account
+	for _, acc := range testContext.profileKeypair.Accounts {
+		ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(acc.Address, testPassword)
+		require.NoError(t, err)
+		require.True(t, ok)
+	}
+
+	// Ensure we're able to open the DB
+	err = testContext.backend.ensureAppDBOpened(*testContext.multiAcc, testPassword)
+	require.NoError(t, err)
+
+	// db creation
+	db, err := accounts.NewDB(testContext.backend.appDB)
+	require.NoError(t, err)
+
+	// Check that there is no registered keycards
+	keycards, err := db.GetKeycardsWithSameKeyUID(testContext.profileKeypair.KeyUID)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(keycards))
+
+	keycardAccount := *testContext.multiAcc
 	keycardAccount.KeycardPairing = "pairing"
 
 	keycardSettings := settings.Settings{
@@ -1231,87 +882,73 @@ func TestConvertAccount(t *testing.T) {
 		KeycardPairing:     "pairing",
 	}
 
-	// Ensure we're able to open the DB
-	err = backend.ensureAppDBOpened(keycardAccount, keycardPassword)
-	require.NoError(t, err)
-
-	// db creation
-	db, err := accounts.NewDB(backend.appDB)
-	require.NoError(t, err)
-
-	// Check that there is no registered keycards
-	keycards, err := db.GetKeycardsWithSameKeyUID(genAccInfo.KeyUID)
-	require.NoError(t, err)
-	require.Equal(t, 0, len(keycards))
-
 	// Converting to a keycard account
-	err = backend.ConvertToKeycardAccount(keycardAccount, keycardSettings, keycardUID, password, keycardPassword)
+	const keycardPassword = "222222" // represents password for a keycard user
+	err = testContext.backend.ConvertToKeycardAccount(keycardAccount, keycardSettings, testContext.profileKeypair.KeyUID, testPassword, keycardPassword)
 	require.NoError(t, err)
 
 	// Validating results of converting to a keycard account.
 	// All keystore files for the account which is migrated need to be removed.
-	found = keystoreContainsFileForAccount(keyStoreDirPath, masterAddress)
-	require.False(t, found)
+	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(masterAddress, testPassword)
+	require.Error(t, err)
+	require.False(t, ok)
 
-	for _, dAccInfo := range derivedAccountsInfo {
-		found = keystoreContainsFileForAccount(keyStoreDirPath, dAccInfo.Address)
-		require.False(t, found)
+	for _, acc := range testContext.profileKeypair.Accounts {
+		ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(acc.Address, testPassword)
+		require.Error(t, err)
+		require.False(t, ok)
 	}
 
-	require.NoError(t, backend.Logout())
-	require.NoError(t, backend.StopNode())
+	require.NoError(t, testContext.backend.Logout())
+	require.NoError(t, testContext.backend.StopNode())
 
-	err = setKeystore(backend.AccountsManager(), keyStoreDirPath)
-	require.NoError(t, err)
+	chatPrivKey := strings.TrimPrefix(testContext.chatPrivateKey, "0x")
+	require.NoError(t, testContext.backend.StartNodeWithKey(*testContext.multiAcc, keycardPassword, chatPrivKey, testContext.config))
 
-	require.NoError(t, backend.OpenAccounts())
-
-	require.NoError(t, backend.StartNodeWithKey(account, keycardPassword, strings.TrimPrefix(chatInfo.PrivateKey, "0x"), nodeConfig))
 	defer func() {
-		assert.NoError(t, backend.Logout())
-		assert.NoError(t, backend.StopNode())
+		assert.NoError(t, testContext.backend.Logout())
+		assert.NoError(t, testContext.backend.StopNode())
 	}()
 
 	// Ensure we're able to open the DB
-	err = backend.ensureAppDBOpened(keycardAccount, keycardPassword)
+	err = testContext.backend.ensureAppDBOpened(keycardAccount, keycardPassword)
 	require.NoError(t, err)
 
 	// db creation after re-encryption
-	db1, err := accounts.NewDB(backend.appDB)
+	db1, err := accounts.NewDB(testContext.backend.appDB)
 	require.NoError(t, err)
 
 	// Check that there is a registered keycard
-	keycards, err = db1.GetKeycardsWithSameKeyUID(genAccInfo.KeyUID)
+	keycards, err = db1.GetKeycardsWithSameKeyUID(testContext.profileKeypair.KeyUID)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(keycards))
 
 	// Converting to a regular account
-	err = backend.ConvertToRegularAccount(mnemonic, keycardPassword, password)
+	err = testContext.backend.ConvertToRegularAccount(testContext.mnemonic, keycardPassword, testPassword)
 	require.NoError(t, err)
 
 	// Validating results of converting to a regular account.
 	// All keystore files for need to be created.
-	found = keystoreContainsFileForAccount(keyStoreDirPath, genAccInfo.Address)
-	require.True(t, found)
+	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(masterAddress, testPassword)
+	require.NoError(t, err)
+	require.True(t, ok)
 
-	for _, dAccInfo := range derivedAccountsInfo {
-		found = keystoreContainsFileForAccount(keyStoreDirPath, dAccInfo.Address)
-		require.True(t, found)
+	for _, acc := range testContext.profileKeypair.Accounts {
+		ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(acc.Address, testPassword)
+		require.NoError(t, err)
+		require.True(t, ok)
 	}
 
-	found = keystoreContainsFileForAccount(keyStoreDirPath, masterAddress)
-	require.True(t, found)
-
 	// Ensure we're able to open the DB
-	err = backend.ensureAppDBOpened(keycardAccount, password)
+	err = testContext.backend.ensureAppDBOpened(keycardAccount, testPassword)
 	require.NoError(t, err)
 
 	// db creation after re-encryption
-	db2, err := accounts.NewDB(backend.appDB)
+	db2, err := accounts.NewDB(testContext.backend.appDB)
 	require.NoError(t, err)
 
 	// Check that there is no registered keycards
-	keycards, err = db2.GetKeycardsWithSameKeyUID(genAccInfo.KeyUID)
+	keycards, err = db2.GetKeycardsWithSameKeyUID(testContext.profileKeypair.KeyUID)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(keycards))
 }
@@ -1344,19 +981,15 @@ func copyDir(srcFolder string, dstFolder string, t *testing.T) {
 	}
 }
 
-func loginDesktopUser(t *testing.T, conf *params.NodeConfig) {
+func loginDesktopUser(t *testing.T, conf *params.NodeConfig, keyUID string) {
 	// The following passwords and DB used in this test unit are only
 	// used to determine if login process works correctly after a migration
 
 	// Expected account data:
-	keyUID := "0x7c46c8f6f059ab72d524f2a6d356904db30bb0392636172ab3929a6bd2220f84" // #nosec G101
 	username := "TestUser"
 	passwd := "0xC888C9CE9E098D5864D3DED6EBCC140A12142263BACE3A23A36F9905F12BD64A" // #nosec G101
 
 	b := NewGethStatusBackend(tt.MustCreateTestLogger())
-
-	err := setKeystore(b.AccountsManager(), conf.KeyStoreDir)
-	require.NoError(t, err)
 
 	b.UpdateRootDataDir(conf.DataDir)
 
@@ -1387,172 +1020,97 @@ func loginDesktopUser(t *testing.T, conf *params.NodeConfig) {
 func TestLoginAndMigrationsStillWorkWithExistingDesktopUser(t *testing.T) {
 	utils.Init()
 
+	keyUID := "0x7c46c8f6f059ab72d524f2a6d356904db30bb0392636172ab3929a6bd2220f84" // #nosec G101
+
 	srcFolder := "../static/test-0.132.0-account/"
 
 	tmpdir := t.TempDir()
-
 	copyDir(srcFolder, tmpdir, t)
+
+	keystoreDir := path.Join(tmpdir, "keystore", keyUID)
+	err := os.MkdirAll(keystoreDir, 0700)
+	require.NoError(t, err)
+
+	srcKeystoreFolder := "../static/test-0.132.0-account/keystore/"
+	copyDir(srcKeystoreFolder, keystoreDir, t)
 
 	conf, err := params.NewNodeConfig(tmpdir, 1777)
 	require.NoError(t, err)
 
-	loginDesktopUser(t, conf)
-	loginDesktopUser(t, conf) // Login twice to catch weird errors that only appear after logout
+	loginDesktopUser(t, conf, keyUID)
+	loginDesktopUser(t, conf, keyUID) // Login twice to catch weird errors that only appear after logout
 }
 
 func TestChangeDatabasePassword(t *testing.T) {
 	utils.Init()
 
-	backend, stop1, stop2, stop3, err := setupGethStatusBackend()
+	testContext := setupTestContext(t, testPassword, true, true, false)
+
+	err := testContext.backend.StartNode(testContext.config)
+	require.NoError(t, err)
+
 	defer func() {
-		err := stop1()
-		if err != nil {
-			require.NoError(t, backend.StopNode())
-		}
+		require.NoError(t, testContext.backend.StopNode())
 	}()
-	defer func() {
-		err := stop2()
-		if err != nil {
-			require.NoError(t, backend.StopNode())
-		}
-	}()
-	defer func() {
-		err := stop3()
-		if err != nil {
-			require.NoError(t, backend.StopNode())
-		}
-	}()
-	require.NoError(t, err)
 
-	tempDir := t.TempDir()
-	backend.UpdateRootDataDir(tempDir)
-
-	config, err := utils.MakeTestNodeConfig(params.StatusChainNetworkID)
-	require.NoError(t, err)
-
-	config.RootDataDir = tempDir
-	config.KeyStoreDir = path.Join(tempDir, "keystore")
-
-	err = backend.StartNode(config)
-	require.NoError(t, err)
-
-	oldPassword := "password"
-	newPassword := "newPassword"
-
-	genAccount, _, err := backend.AccountsManager().CreateAndStoreAccount(oldPassword)
-	require.NoError(t, err)
-
-	paths := []string{accscommon.PathEIP1581Chat, accscommon.PathDefaultWalletAccount}
-
-	genChatAccounts, err := backend.AccountsManager().DeriveChildrenAccountsForPathsAndStore(genAccount.Address(), paths, oldPassword)
-	require.NoError(t, err)
-
-	ok, err := backend.AccountsManager().VerifyAccountPassword(genChatAccounts[accscommon.PathEIP1581Chat].Address(), oldPassword)
+	masterAddress := types.HexToAddress(testContext.profileKeypair.DerivedFrom)
+	ok, err := testContext.backend.AccountsManager().VerifyAccountPassword(masterAddress, testPassword)
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	ok, err = backend.AccountsManager().VerifyAccountPassword(genChatAccounts[accscommon.PathDefaultWalletAccount].Address(), oldPassword)
+	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(testContext.profileKeypair.Accounts[0].Address, testPassword)
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	account := multiaccounts.Account{
-		Name:          "TestAccount",
-		Timestamp:     1,
-		KeyUID:        genAccount.KeyUID(),
-		KDFIterations: 1,
-	}
-
-	// Initialize accounts DB
-	err = backend.OpenAccounts()
+	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(testContext.profileKeypair.Accounts[1].Address, testPassword)
 	require.NoError(t, err)
-	err = backend.SaveAccount(account)
+	require.True(t, ok)
+
+	db, err := testContext.backend.accountsDB()
 	require.NoError(t, err)
 
-	// Created DBs with old password
-	err = backend.ensureDBsOpened(account, oldPassword)
+	acc, err := db.GetAccountByAddress(testContext.profileKeypair.Accounts[0].Address)
 	require.NoError(t, err)
+	require.Equal(t, testContext.profileKeypair.Accounts[0].Address, acc.Address)
 
-	db, err := accounts.NewDB(backend.appDB)
+	acc, err = db.GetAccountByAddress(testContext.profileKeypair.Accounts[1].Address)
 	require.NoError(t, err)
-
-	err = db.SaveOrUpdateKeypair(&accounts.Keypair{
-		KeyUID: account.KeyUID,
-		Name:   "private key keypair",
-		Type:   accounts.KeypairTypeSeed,
-		Accounts: []*accounts.Account{
-			{
-				Chat:      true,
-				Wallet:    false,
-				Address:   genChatAccounts[accscommon.PathEIP1581Chat].Address(),
-				KeyUID:    account.KeyUID,
-				PublicKey: types.Hex2Bytes(genChatAccounts[accscommon.PathEIP1581Chat].PublicKeyHex()),
-			},
-			{
-				Chat:      false,
-				Wallet:    true,
-				Address:   genChatAccounts[accscommon.PathDefaultWalletAccount].Address(),
-				KeyUID:    account.KeyUID,
-				PublicKey: types.Hex2Bytes(genChatAccounts[accscommon.PathDefaultWalletAccount].PublicKeyHex()),
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	chatAcc, err := db.GetAccountByAddress(genChatAccounts[accscommon.PathEIP1581Chat].Address())
-	require.NoError(t, err)
-	require.Equal(t, genChatAccounts[accscommon.PathEIP1581Chat].Address(), chatAcc.Address)
-
-	walletAcc, err := db.GetAccountByAddress(genChatAccounts[accscommon.PathDefaultWalletAccount].Address())
-	require.NoError(t, err)
-	require.Equal(t, genChatAccounts[accscommon.PathDefaultWalletAccount].Address(), walletAcc.Address)
+	require.Equal(t, testContext.profileKeypair.Accounts[1].Address, acc.Address)
 
 	// Change password
-	err = backend.ChangeDatabasePassword(account.KeyUID, oldPassword, newPassword)
+	const newPassword = "newPassword"
+	err = testContext.backend.ChangeDatabasePassword(testContext.profileKeypair.KeyUID, testPassword, newPassword)
 	require.NoError(t, err)
 
-	// Test that DBs can be opened with new password
-	appDbPath, err := backend.getAppDBPath(account.KeyUID)
-	require.NoError(t, err)
-	appDb, err := sqlite.OpenDB(appDbPath, newPassword, account.KDFIterations)
-	require.NoError(t, err)
-	defer func() {
-		handleError(t, appDb.Close())
-	}()
-
-	walletDbPath, err := backend.getWalletDBPath(account.KeyUID)
-	require.NoError(t, err)
-	walletDb, err := sqlite.OpenDB(walletDbPath, newPassword, account.KDFIterations)
-	require.NoError(t, err)
-	defer func() {
-		handleError(t, walletDb.Close())
-	}()
+	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
 
 	// Test that keystore can be decrypted with the new password
-	acc, err := backend.AccountsManager().LoadAccount(genAccount.Address(), newPassword)
+	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(masterAddress, newPassword)
 	require.NoError(t, err)
-	require.NotNil(t, acc)
+	require.True(t, ok)
 
-	accInfo := acc.ToAccountInfo()
-	require.Equal(t, accInfo.Address, genAccount.Address().Hex())
+	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(testContext.profileKeypair.Accounts[0].Address, newPassword)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(testContext.profileKeypair.Accounts[1].Address, newPassword)
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 func TestCreateWallet(t *testing.T) {
 	utils.Init()
-	password := "some-password2" // nolint: goconst
-	tmpdir := t.TempDir()
 
-	b := NewGethStatusBackend(tt.MustCreateTestLogger())
-	defer func() {
-		require.NoError(t, b.StopNode())
-	}()
+	testContext := setupTestContext(t, testPassword, false, false, true)
 
 	createAccountRequest := &requests.CreateAccount{
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
-		Password:           password,
-		RootDataDir:        tmpdir,
-		LogFilePath:        tmpdir + "/log",
+		Password:           testPassword,
+		RootDataDir:        testContext.config.DataDir,
+		LogFilePath:        testContext.config.DataDir + "/log",
 	}
+
 	c := make(chan interface{}, 10)
 	signal.SetMobileSignalHandler(func(data []byte) {
 		if strings.Contains(string(data), "node.login") {
@@ -1561,9 +1119,9 @@ func TestCreateWallet(t *testing.T) {
 	})
 	t.Cleanup(signal.ResetMobileSignalHandler)
 
-	account, err := b.CreateAccountAndLogin(createAccountRequest)
+	account, err := testContext.backend.CreateAccountAndLogin(createAccountRequest)
 	require.NoError(t, err)
-	statusNode := b.statusNode
+	statusNode := testContext.backend.statusNode
 	require.NotNil(t, statusNode)
 
 	walletService := statusNode.WalletService()
@@ -1572,16 +1130,16 @@ func TestCreateWallet(t *testing.T) {
 
 	paths := []string{"m/44'/60'/0'/0/1"}
 
-	db, err := accounts.NewDB(b.appDB)
+	db, err := accounts.NewDB(testContext.backend.appDB)
 	require.NoError(t, err)
-	walletRootAddress, err := db.GetWalletRootAddress()
+	masterAddress, err := db.GetMasterAddress()
 	require.NoError(t, err)
 
 	mnemonic, err := db.Mnemonic()
 	require.NoError(t, err)
 	require.NotEmpty(t, mnemonic)
 
-	derivedAddress, err := walletAPI.GetDerivedAddresses(context.Background(), password, walletRootAddress.String(), paths)
+	derivedAddress, err := walletAPI.GetDerivedAddresses(context.Background(), testPassword, masterAddress.String(), paths)
 	require.NoError(t, err)
 	require.Len(t, derivedAddress, 1)
 
@@ -1589,7 +1147,7 @@ func TestCreateWallet(t *testing.T) {
 	require.NotNil(t, accountsService)
 	accountsAPI := accountsService.AccountsAPI()
 
-	err = accountsAPI.AddAccount(context.Background(), password, &accounts.Account{
+	err = accountsAPI.AddAccount(context.Background(), testPassword, &accounts.Account{
 		KeyUID:    account.KeyUID,
 		Type:      accounts.AccountTypeGenerated,
 		PublicKey: derivedAddress[0].PublicKey,
@@ -1603,17 +1161,17 @@ func TestCreateWallet(t *testing.T) {
 
 func TestSetFleet(t *testing.T) {
 	utils.Init()
-	password := "some-password2" // nolint: goconst
-	tmpdir := t.TempDir()
 
-	b := NewGethStatusBackend(tt.MustCreateTestLogger())
+	testContext := setupTestContext(t, testPassword, false, false, true)
+
 	createAccountRequest := &requests.CreateAccount{
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
-		Password:           password,
-		RootDataDir:        tmpdir,
-		LogFilePath:        tmpdir + "/log",
+		Password:           testPassword,
+		RootDataDir:        testContext.config.DataDir,
+		LogFilePath:        testContext.config.DataDir + "/log",
 	}
+
 	c := make(chan interface{}, 10)
 	signal.SetMobileSignalHandler(func(data []byte) {
 		if strings.Contains(string(data), "node.login") {
@@ -1622,32 +1180,34 @@ func TestSetFleet(t *testing.T) {
 	})
 	t.Cleanup(signal.ResetMobileSignalHandler)
 
-	newAccount, err := b.CreateAccountAndLogin(createAccountRequest)
+	newAccount, err := testContext.backend.CreateAccountAndLogin(createAccountRequest)
 	require.NoError(t, err)
-	statusNode := b.statusNode
+	statusNode := testContext.backend.statusNode
 	require.NotNil(t, statusNode)
 
-	savedSettings, err := b.GetSettings()
+	savedSettings, err := testContext.backend.GetSettings()
 	require.NoError(t, err)
 	require.Empty(t, savedSettings.Fleet)
 
-	accountsDB, err := b.accountsDB()
+	accountsDB, err := testContext.backend.accountsDB()
 	require.NoError(t, err)
 	err = accountsDB.SaveSettingField(settings.Fleet, params.FleetStatusProd)
 	require.NoError(t, err)
 
-	savedSettings, err = b.GetSettings()
+	savedSettings, err = testContext.backend.GetSettings()
 	require.NoError(t, err)
 	require.NotEmpty(t, savedSettings.Fleet)
 	require.Equal(t, params.FleetStatusProd, *savedSettings.Fleet)
 
-	require.NoError(t, b.Logout())
+	require.NoError(t, testContext.backend.Logout())
+
+	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
 
 	loginAccountRequest := &requests.Login{
 		KeyUID:   newAccount.KeyUID,
-		Password: password,
+		Password: testPassword,
 	}
-	require.NoError(t, b.LoginAccount(loginAccountRequest))
+	require.NoError(t, testContext.backend.LoginAccount(loginAccountRequest))
 	select {
 	case <-c:
 		break
@@ -1655,9 +1215,9 @@ func TestSetFleet(t *testing.T) {
 		t.FailNow()
 	}
 	// Check is using the right fleet
-	require.Equal(t, b.config.ClusterConfig.WakuNodes, params.DefaultWakuNodes(params.FleetStatusProd))
+	require.Equal(t, testContext.backend.config.ClusterConfig.WakuNodes, params.DefaultWakuNodes(params.FleetStatusProd))
 
-	require.NoError(t, b.Logout())
+	require.NoError(t, testContext.backend.Logout())
 }
 
 func fakeToken() security.SensitiveString {
@@ -1666,8 +1226,9 @@ func fakeToken() security.SensitiveString {
 
 func TestWalletConfigOnLoginAccount(t *testing.T) {
 	utils.Init()
-	password := "some-password2"
-	tmpdir := t.TempDir()
+
+	testContext := setupTestContext(t, testPassword, false, false, true)
+
 	poktToken := fakeToken()
 	infuraToken := fakeToken()
 	alchemyEthereumMainnetToken := fakeToken()
@@ -1681,13 +1242,12 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 	raribleMainnetAPIKey := fakeToken()
 	raribleTestnetAPIKey := fakeToken()
 
-	b := NewGethStatusBackend(tt.MustCreateTestLogger())
 	createAccountRequest := &requests.CreateAccount{
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
-		Password:           password,
-		RootDataDir:        tmpdir,
-		LogFilePath:        tmpdir + "/log",
+		Password:           testPassword,
+		RootDataDir:        testContext.config.DataDir,
+		LogFilePath:        testContext.config.DataDir + "/log",
 	}
 	c := make(chan interface{}, 10)
 	signal.SetMobileSignalHandler(func(data []byte) {
@@ -1697,16 +1257,16 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 	})
 	t.Cleanup(signal.ResetMobileSignalHandler)
 
-	newAccount, err := b.CreateAccountAndLogin(createAccountRequest)
+	newAccount, err := testContext.backend.CreateAccountAndLogin(createAccountRequest)
 	require.NoError(t, err)
-	statusNode := b.statusNode
+	statusNode := testContext.backend.statusNode
 	require.NotNil(t, statusNode)
 
-	require.NoError(t, b.Logout())
+	require.NoError(t, testContext.backend.Logout())
 
 	loginAccountRequest := &requests.Login{
 		KeyUID:   newAccount.KeyUID,
-		Password: password,
+		Password: testPassword,
 		WalletSecretsConfig: requests.WalletSecretsConfig{
 			PoktToken:                   poktToken,
 			InfuraToken:                 infuraToken,
@@ -1723,7 +1283,9 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, b.LoginAccount(loginAccountRequest))
+	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
+
+	require.NoError(t, testContext.backend.LoginAccount(loginAccountRequest))
 	select {
 	case <-c:
 		break
@@ -1731,19 +1293,20 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 		t.FailNow()
 	}
 
-	require.Equal(t, b.config.WalletConfig.InfuraAPIKey, infuraToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.EthereumMainnet], alchemyEthereumMainnetToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.EthereumSepolia], alchemyEthereumSepoliaToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.ArbitrumMainnet], alchemyArbitrumMainnetToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.ArbitrumSepolia], alchemyArbitrumSepoliaToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.OptimismMainnet], alchemyOptimismMainnetToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.OptimismSepolia], alchemyOptimismSepoliaToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.BaseMainnet], alchemyBaseMainnetToken)
-	require.Equal(t, b.config.WalletConfig.AlchemyAPIKeys[common.BaseSepolia], alchemyBaseSepoliaToken)
-	require.Equal(t, b.config.WalletConfig.RaribleMainnetAPIKey, raribleMainnetAPIKey)
-	require.Equal(t, b.config.WalletConfig.RaribleTestnetAPIKey, raribleTestnetAPIKey)
+	walletConfig := testContext.backend.config.WalletConfig
+	require.Equal(t, walletConfig.InfuraAPIKey, infuraToken)
+	require.Equal(t, walletConfig.AlchemyAPIKeys[common.EthereumMainnet], alchemyEthereumMainnetToken)
+	require.Equal(t, walletConfig.AlchemyAPIKeys[common.EthereumSepolia], alchemyEthereumSepoliaToken)
+	require.Equal(t, walletConfig.AlchemyAPIKeys[common.ArbitrumMainnet], alchemyArbitrumMainnetToken)
+	require.Equal(t, walletConfig.AlchemyAPIKeys[common.ArbitrumSepolia], alchemyArbitrumSepoliaToken)
+	require.Equal(t, walletConfig.AlchemyAPIKeys[common.OptimismMainnet], alchemyOptimismMainnetToken)
+	require.Equal(t, walletConfig.AlchemyAPIKeys[common.OptimismSepolia], alchemyOptimismSepoliaToken)
+	require.Equal(t, walletConfig.AlchemyAPIKeys[common.BaseMainnet], alchemyBaseMainnetToken)
+	require.Equal(t, walletConfig.AlchemyAPIKeys[common.BaseSepolia], alchemyBaseSepoliaToken)
+	require.Equal(t, walletConfig.RaribleMainnetAPIKey, raribleMainnetAPIKey)
+	require.Equal(t, walletConfig.RaribleTestnetAPIKey, raribleTestnetAPIKey)
 
-	require.NoError(t, b.Logout())
+	require.NoError(t, testContext.backend.Logout())
 }
 
 func TestTestnetEnabledSettingOnCreateAccount(t *testing.T) {
@@ -1855,8 +1418,7 @@ func TestAcceptTerms(t *testing.T) {
 	b := NewGethStatusBackend(tt.MustCreateTestLogger())
 	conf, err := params.NewNodeConfig(tmpdir, 1777)
 	require.NoError(t, err)
-	err = setKeystore(b.AccountsManager(), conf.KeyStoreDir)
-	require.NoError(t, err)
+
 	b.UpdateRootDataDir(conf.DataDir)
 	require.NoError(t, b.OpenAccounts())
 	nameserver := "8.8.8.8"
@@ -2021,8 +1583,6 @@ func TestRestoreKeycardAccountAndLogin(t *testing.T) {
 	backend := NewGethStatusBackend(tt.MustCreateTestLogger())
 	require.NoError(t, err)
 
-	err = setKeystore(backend.AccountsManager(), conf.KeyStoreDir)
-	require.NoError(t, err)
 	backend.UpdateRootDataDir(conf.DataDir)
 
 	require.NoError(t, backend.OpenAccounts())

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -290,7 +290,7 @@ func getMainnetRPCURL(networks []params.Network) string {
 	return ""
 }
 
-func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAccount, opts ...params.Option) (*params.NodeConfig, error) {
+func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAccount) (*params.NodeConfig, error) {
 	// Set mainnet
 	nodeConfig := &params.NodeConfig{}
 	nodeConfig.RootDataDir = request.RootDataDir
@@ -413,12 +413,6 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 		overrideApiConfig(nodeConfig, request.APIConfig)
 	}
 
-	for _, opt := range opts {
-		if err := opt(nodeConfig); err != nil {
-			return nil, err
-		}
-	}
-
 	return nodeConfig, nil
 }
 
@@ -444,28 +438,4 @@ func buildSigningPhrase() (string, error) {
 	}
 
 	return dictionary[a.Int64()] + " " + dictionary[b.Int64()] + " " + dictionary[c.Int64()], nil
-}
-
-func randomWalletEmoji() (string, error) {
-	count := big.NewInt(int64(len(animalsAndNatureEmojis)))
-	index, err := rand.Int(rand.Reader, count)
-	if err != nil {
-		return "", err
-	}
-	return animalsAndNatureEmojis[index.Int64()], nil
-}
-
-var animalsAndNatureEmojis = []string{
-	"🐵", "🐒", "🦍", "🦧", "🦣", "🦏", "🦛", "🐪", "🐫", "🦙",
-	"🐃", "🐂", "🐄", "🐎", "🦄", "🦓", "🦌", "🐐", "🐏", "🐑",
-	"🦙", "🐘", "🦣", "🦛", "🦏", "🦒", "🐁", "🐀", "🐹", "🐰",
-	"🐇", "🐿️", "🦔", "🦇", "🐻", "🐻‍❄️", "🐨", "🐼", "🦥", "🦦",
-	"🦨", "🦘", "🦡", "🐾", "🐉", "🐲", "🌵", "🎄", "🌲", "🌳",
-	"🌴", "🌱", "🌿", "☘️", "🍀", "🎍", "🎋", "🍃", "🍂", "🍁",
-	"🍄", "🐚", "🪨", "🌾", "💐", "🌷", "🌹", "🥀", "🌺", "🌸",
-	"🌼", "🌻", "🌞", "🌝", "🌛", "🌜", "🌚", "🌕", "🌖", "🌗",
-	"🌘", "🌑", "🌒", "🌓", "🌔", "🌙", "🌎", "🌍", "🌏", "🪐",
-	"💫", "⭐", "🌟", "✨", "⚡", "☄️", "💥", "🔥", "🌪️", "🌈",
-	"☀️", "🌤️", "⛅", "🌥️", "☁️", "🌦️", "🌧️", "⛈️", "🌩️", "🌨️",
-	"❄️", "☃️", "⛄", "🌬️", "💨", "💧", "💦", "🌊",
 }

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -26,12 +26,9 @@ import (
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	signercore "github.com/ethereum/go-ethereum/signer/core/apitypes"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
-
 	accsmanagement "github.com/status-im/status-go/accounts-management"
 	accscommon "github.com/status-im/status-go/accounts-management/common"
 	"github.com/status-im/status-go/accounts-management/generator"
-	"github.com/status-im/status-go/accounts-management/keystore/geth"
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/centralizedmetrics"
 	centralizedmetricscommon "github.com/status-im/status-go/centralizedmetrics/common"
@@ -206,6 +203,7 @@ func (b *GethStatusBackend) UpdateRootDataDir(datadir string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.rootDataDir = datadir
+	b.accountsManager.SetRootDataDir(datadir)
 }
 
 func (b *GethStatusBackend) GetMultiaccountDB() *multiaccounts.Database {
@@ -328,59 +326,6 @@ func (b *GethStatusBackend) SaveAccount(account multiaccounts.Account) error {
 		return errors.New("accounts db wasn't initialized")
 	}
 	return b.multiaccountsDB.SaveAccount(account)
-}
-
-func (b *GethStatusBackend) DeleteMultiaccount(keyUID string, keyStoreDir string) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.multiaccountsDB == nil {
-		return errors.New("accounts db wasn't initialized")
-	}
-
-	err := b.multiaccountsDB.DeleteAccount(keyUID)
-	if err != nil {
-		return err
-	}
-
-	appDbPath, err := b.getAppDBPath(keyUID)
-	if err != nil {
-		return err
-	}
-
-	walletDbPath, err := b.getWalletDBPath(keyUID)
-	if err != nil {
-		return err
-	}
-
-	dbFiles := []string{
-		filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql", keyUID)),
-		filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql-shm", keyUID)),
-		filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql-wal", keyUID)),
-		filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db", keyUID)),
-		filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db-shm", keyUID)),
-		filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db-wal", keyUID)),
-		appDbPath,
-		appDbPath + "-shm",
-		appDbPath + "-wal",
-		walletDbPath,
-		walletDbPath + "-shm",
-		walletDbPath + "-wal",
-	}
-	for _, path := range dbFiles {
-		if _, err := os.Stat(path); err == nil {
-			err = os.Remove(path)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	if b.account != nil && b.account.KeyUID == keyUID {
-		// reset active account
-		b.account = nil
-	}
-
-	return os.RemoveAll(keyStoreDir)
 }
 
 func (b *GethStatusBackend) runDBFileMigrations(account multiaccounts.Account, password string) (string, error) {
@@ -571,11 +516,11 @@ func (b *GethStatusBackend) updateAccountColorHashAndColorID(keyUID string, acco
 		if err != nil {
 			return nil, err
 		}
-		publicKey := keypair.GetChatPublicKey()
-		if publicKey == nil {
-			return nil, errors.New("chat public key not found")
+		chatAcc := keypair.GetChatAccount()
+		if chatAcc == nil {
+			return nil, errors.New("chat account not found")
 		}
-		if err = enrichMultiAccountByPublicKey(multiAccount, publicKey); err != nil {
+		if err = enrichMultiAccountByPublicKey(multiAccount, chatAcc.PublicKey); err != nil {
 			return nil, err
 		}
 		if err = b.multiaccountsDB.UpdateAccount(*multiAccount); err != nil {
@@ -630,7 +575,6 @@ func (b *GethStatusBackend) workaroundToFixBadMigration(request *requests.Login)
 
 	// check if we saved a empty node config because of node config migration failed
 	if currentConf.NetworkID == 0 &&
-		currentConf.KeyStoreDir == "" &&
 		currentConf.DataDir == "" &&
 		currentConf.NodeKey == "" {
 		// check if exist old node config
@@ -678,7 +622,6 @@ func (b *GethStatusBackend) overridePartialWithOldNodeConfig(conf *params.NodeCo
 	conf.LogDir = oldNodeConf.LogDir
 	conf.LogLevel = oldNodeConf.LogLevel
 	conf.DataDir = oldNodeConf.DataDir
-	conf.KeyStoreDir = oldNodeConf.KeyStoreDir
 	conf.NodeKey = oldNodeConf.NodeKey
 	conf.RegisterTopics = oldNodeConf.RegisterTopics
 	conf.RequireTopics = oldNodeConf.RequireTopics
@@ -736,6 +679,8 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 		}
 	}
 
+	b.UpdateRootDataDir(b.rootDataDir)
+
 	err := b.ensureDBsOpened(acc, request.Password)
 	if err != nil {
 		return errors.Wrap(err, "failed to open database")
@@ -790,6 +735,12 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 	}
 	b.account = multiAccount
 
+	err = b.StartNode(b.config)
+	if err != nil {
+		b.logger.Info("failed to start node")
+		return errors.Wrap(err, "failed to start node")
+	}
+
 	chatAddr, err := accountsDB.GetChatAddress()
 	if err != nil {
 		return errors.Wrap(err, "failed to get chat address")
@@ -804,35 +755,9 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 		MainAccount: walletAddr,
 	}
 
-	err = b.StartNode(b.config)
+	err = b.SelectAccount(login, request.ChatPrivateKey())
 	if err != nil {
-		b.logger.Info("failed to start node")
-		return errors.Wrap(err, "failed to start node")
-	}
-
-	if chatKey := request.ChatPrivateKey(); chatKey == nil {
-		err = b.SelectAccount(login)
-		if err != nil {
-			return errors.Wrap(err, "failed to select account")
-		}
-	} else {
-		// In case of keycard, we don't have a keystore, instead we have private key loaded from the keycard
-		if err := b.accountsManager.SetChatAccountWithPrivateKey(chatKey); err != nil {
-			return errors.Wrap(err, "failed to set chat account")
-		}
-		_, err = b.accountsManager.SelectedChatAccount()
-		if err != nil {
-			return errors.Wrap(err, "failed to get selected chat account")
-		}
-
-		err = b.initProtocol()
-		if err != nil {
-			return errors.Wrap(err, "failed to init protocol")
-		}
-	}
-
-	if err = b.statusNode.StartLocalBackup(); err != nil {
-		return err
+		return errors.Wrap(err, "failed to select account")
 	}
 
 	err = b.multiaccountsDB.UpdateAccountTimestamp(acc.KeyUID, time.Now().Unix())
@@ -881,6 +806,8 @@ func (b *GethStatusBackend) UpdateNodeConfigFleet(acc multiaccounts.Account, pas
 
 // Deprecated: Use loginAccount instead
 func (b *GethStatusBackend) startNodeWithAccount(acc multiaccounts.Account, password string, inputNodeCfg *params.NodeConfig, chatKey *ecdsa.PrivateKey) error {
+	b.UpdateRootDataDir(b.rootDataDir)
+
 	err := b.ensureDBsOpened(acc, password)
 	if err != nil {
 		return err
@@ -906,6 +833,12 @@ func (b *GethStatusBackend) startNodeWithAccount(acc multiaccounts.Account, pass
 
 	b.account = &acc
 
+	err = b.StartNode(b.config)
+	if err != nil {
+		b.logger.Info("failed to start node", zap.Error(err))
+		return err
+	}
+
 	chatAddr, err := accountsDB.GetChatAddress()
 	if err != nil {
 		return err
@@ -914,41 +847,15 @@ func (b *GethStatusBackend) startNodeWithAccount(acc multiaccounts.Account, pass
 	if err != nil {
 		return err
 	}
+
 	login := LoginParams{
 		Password:    password,
 		ChatAddress: chatAddr,
 		MainAccount: walletAddr,
 	}
 
-	err = b.StartNode(b.config)
+	err = b.SelectAccount(login, chatKey)
 	if err != nil {
-		b.logger.Info("failed to start node", zap.Error(err))
-		return err
-	}
-
-	if chatKey == nil {
-		// Load account from keystore
-		err = b.SelectAccount(login)
-		if err != nil {
-			return err
-		}
-	} else {
-		// In case of keycard, we don't have keystore, but we directly have the private key
-		if err := b.accountsManager.SetChatAccountWithPrivateKey(chatKey); err != nil {
-			return err
-		}
-		_, err = b.accountsManager.SelectedChatAccount()
-		if err != nil {
-			return err
-		}
-
-		err = b.initProtocol()
-		if err != nil {
-			return err
-		}
-	}
-
-	if err = b.statusNode.StartLocalBackup(); err != nil {
 		return err
 	}
 
@@ -1405,37 +1312,38 @@ func (b *GethStatusBackend) ConvertToKeycardAccount(account multiaccounts.Accoun
 
 	err = b.accountsManager.DeleteAccount(eip1581Address)
 	if err != nil {
-		return err
+		// Don't return error here, because those addresses are not required for the profile/account, may be here for all keypairs.
+		b.logger.Error("failed to delete eip1581 address or doesn't exist", zap.Error(err))
 	}
 
 	err = b.accountsManager.DeleteAccount(walletRootAddress)
 	if err != nil {
-		return err
+		// Don't return error here, because those addresses are not required for the profile/account, may be here for all keypairs.
+		b.logger.Error("failed to delete wallet root address or doesn't exist", zap.Error(err))
 	}
 
 	return nil
 }
 
-func (b *GethStatusBackend) RestoreAccountAndLogin(request *requests.RestoreAccount, opts ...params.Option) (*multiaccounts.Account, error) {
-
+func (b *GethStatusBackend) RestoreAccountAndLogin(request *requests.RestoreAccount) (*multiaccounts.Account, error) {
 	if err := request.Validate(); err != nil {
 		return nil, err
 	}
 
-	response, err := b.generateOrImportAccount(request.Mnemonic, 0, request.FetchBackup, &request.CreateAccount, opts...)
+	response, err := b.generateOrImportAccount(request.Mnemonic, 0, request.FetchBackup, &request.CreateAccount)
 	if err != nil {
 		return nil, err
 	}
 
 	err = b.StartNodeWithAccountAndInitialConfig(
+		response.mnemonic,
 		*response.account,
 		request.Password,
 		*response.settings,
 		response.nodeConfig,
-		response.subAccounts,
+		response.keypair,
 		response.chatPrivateKey,
 	)
-
 	if err != nil {
 		b.logger.Error("start node", zap.Error(err))
 		return nil, err
@@ -1449,10 +1357,7 @@ func (b *GethStatusBackend) RestoreKeycardAccountAndLogin(request *requests.Rest
 		return nil, err
 	}
 
-	keyStoreDir, err := b.InitKeyStoreDirWithAccount(request.RootDataDir, request.Keycard.KeyUID)
-	if err != nil {
-		return nil, err
-	}
+	b.UpdateRootDataDir(request.RootDataDir)
 
 	derivedAddresses := map[string]generator.AccountInfo{
 		accscommon.PathEIP1581Chat: {
@@ -1460,30 +1365,20 @@ func (b *GethStatusBackend) RestoreKeycardAccountAndLogin(request *requests.Rest
 			PublicKey:  request.Keycard.WhisperPublicKey,
 			PrivateKey: request.Keycard.WhisperPrivateKey,
 		},
-		accscommon.PathWalletRoot: {
-			Address: request.Keycard.WalletRootAddress,
-		},
 		accscommon.PathDefaultWalletAccount: {
 			Address:   request.Keycard.WalletAddress,
 			PublicKey: request.Keycard.WalletPublicKey,
-		},
-		accscommon.PathEIP1581Root: {
-			Address: request.Keycard.Eip1581Address,
-		},
-		accscommon.PathEIP1581Encryption: {
-			PublicKey: request.Keycard.EncryptionPublicKey,
 		},
 	}
 
 	input := &prepareAccountInput{
 		customizationColorClock: 0,
 		keyUID:                  request.Keycard.KeyUID,
-		address:                 request.Keycard.Address,
+		masterAddress:           request.Keycard.Address,
 		mnemonic:                "",
 		restoringAccount:        true,
 		derivedAddresses:        derivedAddresses,
 		fetchBackup:             request.FetchBackup, // WARNING: Ensure this value is correct
-		keyStoreDir:             keyStoreDir,
 	}
 
 	response, err := b.prepareNodeAccount(&request.CreateAccount, input)
@@ -1492,14 +1387,14 @@ func (b *GethStatusBackend) RestoreKeycardAccountAndLogin(request *requests.Rest
 	}
 
 	err = b.StartNodeWithAccountAndInitialConfig(
+		response.mnemonic,
 		*response.account,
 		request.Password,
 		*response.settings,
 		response.nodeConfig,
-		response.subAccounts,
+		response.keypair,
 		response.chatPrivateKey, //request.WhisperPrivateKey,
 	)
-
 	if err != nil {
 		b.logger.Error("start node", zap.Error(err))
 		return nil, errors.Wrap(err, "failed to start node")
@@ -1522,30 +1417,27 @@ func (b *GethStatusBackend) GetKeyUIDByMnemonic(mnemonic string) (string, error)
 type prepareAccountInput struct {
 	customizationColorClock uint64
 	keyUID                  string
-	address                 string
+	masterAddress           string
 	mnemonic                string
 	restoringAccount        bool
 	derivedAddresses        map[string]generator.AccountInfo
 	fetchBackup             bool
-	keyStoreDir             string
-	opts                    []params.Option
 }
 
 type accountBundle struct {
+	mnemonic       string
 	account        *multiaccounts.Account
+	keypair        *accounts.Keypair
 	settings       *settings.Settings
 	nodeConfig     *params.NodeConfig
-	subAccounts    []*accounts.Account
 	chatPrivateKey *ecdsa.PrivateKey
 }
 
-func (b *GethStatusBackend) generateOrImportAccount(mnemonic string, customizationColorClock uint64, fetchBackup bool, request *requests.CreateAccount, opts ...params.Option) (*accountBundle, error) {
-	generatedAccount, generatedAccountInfo, err := b.generateAccount(mnemonic)
-	if err != nil {
-		return nil, err
-	}
+// if provided mnemonic is empty, it will generate a new random mnemonic and return it in the response
+func (b *GethStatusBackend) generateOrImportAccount(mnemonic string, customizationColorClock uint64, fetchBackup bool, request *requests.CreateAccount) (*accountBundle, error) {
+	b.UpdateRootDataDir(request.RootDataDir)
 
-	keyStoreDir, err := b.InitKeyStoreDirWithAccount(request.RootDataDir, generatedAccountInfo.KeyUID)
+	generatedAccount, generatedAccountInfo, err := b.generateAccount(mnemonic)
 	if err != nil {
 		return nil, err
 	}
@@ -1558,13 +1450,11 @@ func (b *GethStatusBackend) generateOrImportAccount(mnemonic string, customizati
 	input := &prepareAccountInput{
 		customizationColorClock: customizationColorClock,
 		keyUID:                  generatedAccountInfo.KeyUID,
-		address:                 generatedAccountInfo.Address,
+		masterAddress:           generatedAccountInfo.Address,
 		mnemonic:                generatedAccountInfo.Mnemonic,
 		restoringAccount:        mnemonic != "",
 		derivedAddresses:        generatedDerivedAccountsInfo,
 		fetchBackup:             fetchBackup,
-		keyStoreDir:             keyStoreDir,
-		opts:                    opts,
 	}
 
 	return b.prepareNodeAccount(request, input)
@@ -1572,21 +1462,12 @@ func (b *GethStatusBackend) generateOrImportAccount(mnemonic string, customizati
 
 func (b *GethStatusBackend) prepareNodeAccount(request *requests.CreateAccount, input *prepareAccountInput) (*accountBundle, error) {
 	var err error
-	response := &accountBundle{}
+	response := &accountBundle{
+		mnemonic: input.mnemonic,
+	}
 
 	if request.KeycardInstanceUID != "" {
 		request.Password = input.derivedAddresses[accscommon.PathEIP1581Encryption].PublicKey
-	}
-
-	// NOTE: I intentionally left this condition separately and not an `else` branch. Technically it's an `else`,
-	// 		 but the statements inside are not the opposite statement of the first statement. It's just kinda like this:
-	// 		 - replace password when we're using keycard
-	// 		 - store account when we're not using keycard
-	if request.KeycardInstanceUID == "" {
-		_, _, err = b.StoreAccount(input.mnemonic, request.Password, paths)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	response.account, err = b.buildAccount(request, input)
@@ -1608,9 +1489,9 @@ func (b *GethStatusBackend) prepareNodeAccount(request *requests.CreateAccount, 
 		return nil, errors.Wrap(err, "failed to prepare node config")
 	}
 
-	response.subAccounts, err = b.prepareSubAccounts(request, input)
+	response.keypair, err = b.prepareKeypair(request, input)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to prepare sub accounts")
+		return nil, errors.Wrap(err, "failed to prepare keypair")
 	}
 
 	response, err = b.prepareForKeycard(request, input, response)
@@ -1619,19 +1500,6 @@ func (b *GethStatusBackend) prepareNodeAccount(request *requests.CreateAccount, 
 	}
 
 	return response, nil
-}
-
-func (b *GethStatusBackend) InitKeyStoreDirWithAccount(rootDataDir, keyUID string) (string, error) {
-	b.UpdateRootDataDir(rootDataDir)
-	_, keystoreAbsolutePath := DefaultKeystorePath(rootDataDir, keyUID)
-
-	keystoreAdapter, err := geth.NewGethKeystoreAdapter(keystoreAbsolutePath, keystore.LightScryptN, keystore.LightScryptP)
-	if err != nil {
-		return "", err
-	}
-	b.accountsManager.SetKeystore(keystoreAdapter)
-
-	return keystoreAbsolutePath, nil
 }
 
 func (b *GethStatusBackend) generateAccount(mnemonic string) (genAcc *generator.Account, accInfo generator.GeneratedAccountInfo, err error) {
@@ -1666,9 +1534,10 @@ func (b *GethStatusBackend) generateDerivedAddresses(genAcc *generator.Account, 
 	return
 }
 
-func (b *GethStatusBackend) StoreAccount(mnemonic string, password string, paths []string) (accInfo generator.IdentifiedAccountInfo, derivedAccsInfo map[string]generator.AccountInfo, err error) {
+// TODO: account manager should take care of saving keypairs/accounts to db and the keystore
+func (b *GethStatusBackend) StoreAccount(mnemonic string, password string, paths []string, profile bool) (accInfo generator.IdentifiedAccountInfo, derivedAccsInfo map[string]generator.AccountInfo, err error) {
 	var genAcc *generator.Account
-	genAcc, err = b.accountsManager.CreateFromMnemonicAndStoreAccount(mnemonic, password)
+	genAcc, err = b.accountsManager.CreateFromMnemonicAndStoreAccount(mnemonic, password, profile)
 	if err != nil {
 		return
 	}
@@ -1684,6 +1553,13 @@ func (b *GethStatusBackend) StoreAccount(mnemonic string, password string, paths
 	derivedAccsInfo = make(map[string]generator.AccountInfo, 0)
 	for path, acc := range genDerivedAccs {
 		derivedAccsInfo[path] = acc.ToAccountInfo()
+	}
+
+	chatAcc := derivedAccsInfo[accscommon.PathEIP1581Chat]
+	chatAccAddress := types.HexToAddress(chatAcc.Address)
+	err = b.accountsManager.SetChatAccount(chatAccAddress, password, nil)
+	if err != nil {
+		return
 	}
 
 	return accInfo, derivedAccsInfo, nil
@@ -1741,7 +1617,7 @@ func (b *GethStatusBackend) buildAccount(request *requests.CreateAccount, input 
 }
 
 func (b *GethStatusBackend) prepareSettings(request *requests.CreateAccount, input *prepareAccountInput) (*settings.Settings, error) {
-	s, err := defaultSettings(input.keyUID, input.address, input.derivedAddresses)
+	s, err := defaultSettings(input.keyUID, input.masterAddress, input.derivedAddresses)
 	if err != nil {
 		return nil, err
 	}
@@ -1772,49 +1648,52 @@ func (b *GethStatusBackend) prepareSettings(request *requests.CreateAccount, inp
 }
 
 func (b *GethStatusBackend) prepareConfig(request *requests.CreateAccount, input *prepareAccountInput, installationID string) (*params.NodeConfig, error) {
-	nodeConfig, err := DefaultNodeConfig(installationID, input.keyUID, request, input.opts...)
+	nodeConfig, err := DefaultNodeConfig(installationID, input.keyUID, request)
 	if err != nil {
 		return nil, err
 	}
 	nodeConfig.ProcessBackedupMessages = input.fetchBackup
 
-	// when we set nodeConfig.KeyStoreDir, value of nodeConfig.KeyStoreDir should not contain the rootDataDir
-	// loadNodeConfig will add rootDataDir to nodeConfig.KeyStoreDir
-	nodeConfig.KeyStoreDir = input.keyStoreDir
-
 	return nodeConfig, nil
 }
-
-func (b *GethStatusBackend) prepareSubAccounts(request *requests.CreateAccount, input *prepareAccountInput) ([]*accounts.Account, error) {
-	emoji, err := randomWalletEmoji()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate random emoji")
+func (b *GethStatusBackend) prepareKeypair(request *requests.CreateAccount, input *prepareAccountInput) (keypair *accounts.Keypair, err error) {
+	// set up keypair
+	keypair = &accounts.Keypair{
+		Name:                    request.DisplayName,
+		KeyUID:                  input.keyUID,
+		Type:                    accounts.KeypairTypeProfile,
+		DerivedFrom:             input.masterAddress,
+		LastUsedDerivationIndex: 0,
 	}
 
+	// add chat account
+	chatDerivedAccount := input.derivedAddresses[accscommon.PathEIP1581Chat]
+	keypair.Accounts = append(keypair.Accounts, &accounts.Account{
+		PublicKey: types.Hex2Bytes(chatDerivedAccount.PublicKey),
+		KeyUID:    keypair.KeyUID,
+		Address:   types.HexToAddress(chatDerivedAccount.Address),
+		Chat:      true,
+		Path:      accscommon.PathEIP1581Chat,
+		Position:  -1, // When creating a new account, the chat account should have position -1, cause it doesn't participate
+		Operable:  accounts.AccountFullyOperable,
+	})
+
+	// add wallet account
 	walletDerivedAccount := input.derivedAddresses[accscommon.PathDefaultWalletAccount]
-	walletAccount := &accounts.Account{
+	keypair.Accounts = append(keypair.Accounts, &accounts.Account{
 		PublicKey:          types.Hex2Bytes(walletDerivedAccount.PublicKey),
-		KeyUID:             input.keyUID,
+		KeyUID:             keypair.KeyUID,
 		Address:            types.HexToAddress(walletDerivedAccount.Address),
 		ColorID:            multiacccommon.CustomizationColor(request.CustomizationColor),
-		Emoji:              emoji,
 		Wallet:             true,
 		Path:               accscommon.PathDefaultWalletAccount,
 		Name:               walletAccountDefaultName,
 		AddressWasNotShown: !input.restoringAccount,
-	}
+		Position:           0, // When creating a new account, the wallet account should have position 0, cause it's the default wallet account
+		Operable:           accounts.AccountFullyOperable,
+	})
 
-	chatDerivedAccount := input.derivedAddresses[accscommon.PathEIP1581Chat]
-	chatAccount := &accounts.Account{
-		PublicKey: types.Hex2Bytes(chatDerivedAccount.PublicKey),
-		KeyUID:    input.keyUID,
-		Address:   types.HexToAddress(chatDerivedAccount.Address),
-		Name:      request.DisplayName,
-		Chat:      true,
-		Path:      accscommon.PathEIP1581Chat,
-	}
-
-	return []*accounts.Account{walletAccount, chatAccount}, nil
+	return
 }
 
 func (b *GethStatusBackend) prepareForKeycard(request *requests.CreateAccount, input *prepareAccountInput, response *accountBundle) (*accountBundle, error) {
@@ -1859,7 +1738,7 @@ func (b *GethStatusBackend) prepareForKeycard(request *requests.CreateAccount, i
 
 // CreateAccountAndLogin creates a new account and logs in with it.
 // NOTE: requests.CreateAccount is used for public, params.Option maybe used for internal usage.
-func (b *GethStatusBackend) CreateAccountAndLogin(request *requests.CreateAccount, opts ...params.Option) (*multiaccounts.Account, error) {
+func (b *GethStatusBackend) CreateAccountAndLogin(request *requests.CreateAccount) (*multiaccounts.Account, error) {
 	validation := &requests.CreateAccountValidation{
 		AllowEmptyDisplayName: true,
 	}
@@ -1867,20 +1746,20 @@ func (b *GethStatusBackend) CreateAccountAndLogin(request *requests.CreateAccoun
 		return nil, err
 	}
 
-	response, err := b.generateOrImportAccount("", 1, false, request, opts...)
+	response, err := b.generateOrImportAccount("", 1, false, request)
 	if err != nil {
 		return nil, err
 	}
 
 	err = b.StartNodeWithAccountAndInitialConfig(
+		response.mnemonic,
 		*response.account,
 		request.Password,
 		*response.settings,
 		response.nodeConfig,
-		response.subAccounts,
+		response.keypair,
 		response.chatPrivateKey,
 	)
-
 	if err != nil {
 		b.logger.Error("start node", zap.Error(err))
 		return nil, err
@@ -1930,7 +1809,7 @@ func (b *GethStatusBackend) ConvertToRegularAccount(mnemonic string, currPasswor
 		}
 	}
 
-	_, _, err = b.StoreAccount(mnemonicNoExtraSpaces, currPassword, paths)
+	_, _, err = b.StoreAccount(mnemonicNoExtraSpaces, currPassword, paths, false)
 	if err != nil {
 		return err
 	}
@@ -2001,8 +1880,7 @@ func enrichMultiAccountBySubAccounts(account *multiaccounts.Account, subaccs []*
 		return nil
 	}
 
-	for i, acc := range subaccs {
-		subaccs[i].KeyUID = account.KeyUID
+	for _, acc := range subaccs {
 		if acc.Chat {
 			pk := string(acc.PublicKey.Bytes())
 			colorHash, err := colorhash.GenerateFor(pk)
@@ -2041,47 +1919,20 @@ func enrichMultiAccountByPublicKey(account *multiaccounts.Account, publicKey typ
 	return nil
 }
 
-// Deprecated: Use CreateAccountAndLogin instead
-func (b *GethStatusBackend) SaveAccountAndStartNodeWithKey(
-	account multiaccounts.Account,
-	password string,
-	settings settings.Settings,
-	nodecfg *params.NodeConfig,
-	subaccs []*accounts.Account,
-	keyHex string,
-) error {
-	err := enrichMultiAccountBySubAccounts(&account, subaccs)
-	if err != nil {
-		return err
-	}
-	err = b.SaveAccount(account)
-	if err != nil {
-		return err
-	}
-	err = b.ensureDBsOpened(account, password)
-	if err != nil {
-		return err
-	}
-	err = b.saveAccountsAndSettings(settings, nodecfg, subaccs)
-	if err != nil {
-		return err
-	}
-	return b.StartNodeWithKey(account, password, keyHex, nodecfg)
-}
-
 // StartNodeWithAccountAndInitialConfig is used after account and config was generated.
 // In current setup account name and config is generated on the client side. Once/if it will be generated on
 // status-go side this flow can be simplified.
 // TODO: Consider passing accountBundle here directly
 func (b *GethStatusBackend) StartNodeWithAccountAndInitialConfig(
+	mnemonic string,
 	account multiaccounts.Account,
 	password string,
 	settings settings.Settings,
 	nodecfg *params.NodeConfig,
-	subaccs []*accounts.Account,
+	keypair *accounts.Keypair,
 	chatKey *ecdsa.PrivateKey,
 ) error {
-	err := enrichMultiAccountBySubAccounts(&account, subaccs)
+	err := enrichMultiAccountBySubAccounts(&account, keypair.Accounts)
 	if err != nil {
 		return err
 	}
@@ -2093,15 +1944,26 @@ func (b *GethStatusBackend) StartNodeWithAccountAndInitialConfig(
 	if err != nil {
 		return err
 	}
-	err = b.saveAccountsAndSettings(settings, nodecfg, subaccs)
+	err = b.saveKeypairAndSettings(settings, nodecfg, keypair)
 	if err != nil {
 		return err
+	}
+
+	isPairing := b.LocalPairingStateManager.IsPairing()
+	if settings.KeycardInstanceUID == "" && !isPairing {
+		keypairPaths := []string{accscommon.PathMaster}
+		for _, acc := range keypair.Accounts {
+			keypairPaths = append(keypairPaths, acc.Path)
+		}
+		_, _, err = b.StoreAccount(mnemonic, password, keypairPaths, true)
+		if err != nil {
+			return err
+		}
 	}
 	return b.StartNodeWithAccount(account, password, nodecfg, chatKey)
 }
 
-// TODO: change in `saveAccountsAndSettings` function param `subaccs []*accounts.Account` parameter to `profileKeypair *accounts.Keypair` parameter
-func (b *GethStatusBackend) saveAccountsAndSettings(settings settings.Settings, nodecfg *params.NodeConfig, subaccs []*accounts.Account) error {
+func (b *GethStatusBackend) saveKeypairAndSettings(settings settings.Settings, nodecfg *params.NodeConfig, keypair *accounts.Keypair) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	accdb, err := accounts.NewDB(b.appDB)
@@ -2120,27 +1982,6 @@ func (b *GethStatusBackend) saveAccountsAndSettings(settings settings.Settings, 
 	err = accdb.SetLastBackup(uint64(now))
 	if err != nil {
 		return err
-	}
-
-	keypair := &accounts.Keypair{
-		KeyUID:                  settings.KeyUID,
-		Name:                    settings.DisplayName,
-		Type:                    accounts.KeypairTypeProfile,
-		DerivedFrom:             settings.Address.String(),
-		LastUsedDerivationIndex: 0,
-	}
-
-	// When creating a new account, the chat account should have position -1, because it doesn't participate
-	// in the wallet view and default wallet account should be at position 0.
-	for _, acc := range subaccs {
-		if acc.Chat {
-			acc.Position = -1
-		}
-		if acc.Wallet {
-			acc.Position = 0
-		}
-		acc.Operable = accounts.AccountFullyOperable
-		keypair.Accounts = append(keypair.Accounts, acc)
 	}
 
 	return accdb.SaveOrUpdateKeypair(keypair)
@@ -2175,11 +2016,6 @@ func (b *GethStatusBackend) loadNodeConfig(inputNodeCfg *params.NodeConfig) erro
 	conf.Version = version.Version()
 	conf.RootDataDir = b.rootDataDir
 	conf.DataDir = filepath.Join(b.rootDataDir, conf.DataDir)
-	if strings.Contains(conf.KeyStoreDir, "keystore") &&
-		(strings.HasPrefix(conf.KeyStoreDir, "keystore") ||
-			strings.HasPrefix(conf.KeyStoreDir, "/keystore")) {
-		conf.KeyStoreDir = filepath.Join(b.rootDataDir, conf.KeyStoreDir)
-	}
 
 	if _, err = os.Stat(conf.RootDataDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(conf.RootDataDir, os.ModePerm); err != nil {
@@ -2250,16 +2086,6 @@ func (b *GethStatusBackend) startNode(config *params.NodeConfig) (err error) {
 		return
 	}
 	b.logger.Info("Handlers registered")
-
-	// Handle a case when a node is stopped and resumed.
-	// If there is no account selected, an error is returned.
-	if _, err := b.accountsManager.SelectedChatAccount(); err == nil {
-		if err := b.initProtocol(); err != nil {
-			return err
-		}
-	} else if err != accsmanagement.ErrNoAccountSelected {
-		return err
-	}
 
 	if b.statusNode.WalletService() != nil {
 		b.statusNode.WalletService().KeycardPairings().SetKeycardPairingsFile(config.KeycardPairingDataFile)
@@ -2655,11 +2481,11 @@ func (b *GethStatusBackend) closeWalletDB() error {
 // SelectAccount selects current wallet and chat accounts, by verifying that each address has corresponding account which can be decrypted
 // using provided password. Once verification is done, the decrypted chat key is injected into Whisper (as a single identity,
 // all previous identities are removed).
-func (b *GethStatusBackend) SelectAccount(loginParams LoginParams) error {
+func (b *GethStatusBackend) SelectAccount(loginParams LoginParams, privateKey *ecdsa.PrivateKey) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	err := b.accountsManager.SetChatAccount(loginParams.ChatAddress, loginParams.Password)
+	err := b.accountsManager.SetChatAccount(loginParams.ChatAddress, loginParams.Password, privateKey)
 	if err != nil {
 		return err
 	}
@@ -2669,6 +2495,10 @@ func (b *GethStatusBackend) SelectAccount(loginParams LoginParams) error {
 	}
 
 	if err := b.initProtocol(); err != nil {
+		return err
+	}
+
+	if err = b.statusNode.StartLocalBackup(); err != nil {
 		return err
 	}
 

--- a/api/test_helpers.go
+++ b/api/test_helpers.go
@@ -2,98 +2,167 @@ package api
 
 import (
 	"encoding/json"
-	"path/filepath"
+	"path"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
-	"github.com/status-im/status-go/accounts-management/keystore/geth"
+	"github.com/status-im/status-go/accounts-management/common"
+	accscommon "github.com/status-im/status-go/accounts-management/common"
+	"github.com/status-im/status-go/accounts-management/generator"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/protocol/encryption/multidevice"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/protocol/tt"
 
 	"github.com/stretchr/testify/require"
 )
 
-func setupWalletTest(t *testing.T, password string) (backend *GethStatusBackend, defersFunc func(), err error) {
+const (
+	testPassword = "test-password"
+)
+
+var (
+	networks = json.RawMessage("{}")
+)
+
+type setupContext struct {
+	backend        *GethStatusBackend
+	mnemonic       string
+	settings       settings.Settings
+	config         *params.NodeConfig
+	multiAcc       *multiaccounts.Account
+	profileKeypair *accounts.Keypair
+	chatPrivateKey string
+}
+
+func setupTestContext(t *testing.T, password string, storeProfile bool, storeMultiAcc bool, useDefaultSettings bool) (data *setupContext) {
 	tmpdir := t.TempDir()
 
-	defers := make([]func(), 0)
-	defersFunc = func() {
-		for _, f := range defers {
-			f()
-		}
+	data = &setupContext{}
+
+	var err error
+	data.mnemonic, err = common.CreateRandomMnemonicWithDefaultLength()
+	require.NoError(t, err)
+
+	genMasterAcc, err := generator.CreateAccountFromMnemonic(data.mnemonic, "")
+	require.NoError(t, err)
+
+	accountsPaths := []string{accscommon.PathWalletRoot, accscommon.PathEIP1581Chat, accscommon.PathDefaultWalletAccount}
+	derivedAccs, err := generator.DeriveChildrenFromAccount(genMasterAcc, append([]string{accscommon.PathWalletRoot}, accountsPaths...))
+	require.NoError(t, err)
+
+	data.profileKeypair = &accounts.Keypair{
+		KeyUID:      genMasterAcc.KeyUID(),
+		Name:        "Test Keypair",
+		Type:        accounts.KeypairTypeProfile,
+		DerivedFrom: genMasterAcc.Address().Hex(),
 	}
 
-	backend = NewGethStatusBackend(tt.MustCreateTestLogger())
-	backend.UpdateRootDataDir(tmpdir)
+	data.chatPrivateKey = derivedAccs[accscommon.PathEIP1581Chat].PrivateKeyHex()
 
-	keystoreDir := filepath.Join(tmpdir, "keystore")
-	keystoreAdapter, err := geth.NewGethKeystoreAdapter(keystoreDir, keystore.LightScryptN, keystore.LightScryptP)
-	if err != nil {
-		return
-	}
-	backend.AccountsManager().SetKeystore(keystoreAdapter)
-
-	genAccount, _, err := backend.AccountsManager().CreateAndStoreAccount(password)
-	if err != nil {
-		return
+	for path, acc := range derivedAccs {
+		data.profileKeypair.Accounts = append(data.profileKeypair.Accounts, &accounts.Account{
+			Address:   acc.Address(),
+			KeyUID:    genMasterAcc.KeyUID(),
+			Path:      path,
+			PublicKey: types.Hex2Bytes(acc.PublicKeyHex()),
+			Wallet:    path == accscommon.PathDefaultWalletAccount,
+			Chat:      path == accscommon.PathEIP1581Chat,
+		})
 	}
 
-	masterAccInfo := genAccount.ToIdentifiedAccountInfo()
-
-	const pathWalletRoot = "m/44'/60'/0'/0"
-	derivedAccount, err := backend.AccountsManager().DeriveChildAccountForPathAndStore(types.HexToAddress(masterAccInfo.Address), pathWalletRoot, password)
-	if err != nil {
-		return
-	}
-
-	account := multiaccounts.Account{
+	data.multiAcc = &multiaccounts.Account{
 		Name:           "foo",
 		Timestamp:      1,
 		KeycardPairing: "pairing",
-		KeyUID:         masterAccInfo.KeyUID,
+		KeyUID:         genMasterAcc.KeyUID(),
+		KDFIterations:  1,
 	}
 
-	err = backend.ensureDBsOpened(account, password)
+	if useDefaultSettings {
+		derivedAddresses := make(map[string]generator.AccountInfo)
+		for path, acc := range derivedAccs {
+			derivedAddresses[path] = generator.AccountInfo{
+				Address:   acc.Address().Hex(),
+				PublicKey: acc.PublicKeyHex(),
+			}
+		}
+
+		defSettings, err := defaultSettings(genMasterAcc.KeyUID(), genMasterAcc.Address().Hex(), derivedAddresses)
+		require.NoError(t, err)
+
+		data.settings = *defSettings
+
+		data.config, err = DefaultNodeConfig(data.settings.InstallationID, genMasterAcc.KeyUID(), &requests.CreateAccount{
+			LogLevel: data.settings.LogLevel,
+		})
+		require.NoError(t, err)
+		data.config.RootDataDir = tmpdir
+		data.config.DataDir = tmpdir
+	} else {
+		json := `{
+		"NetworkId": 3,
+		"DataDir": "` + tmpdir + `",
+		"KeycardPairingDataFile": "` + path.Join(tmpdir, "keycard/pairings.json") + `",
+		"NoDiscovery": true,
+		"TorrentConfig": {
+			"Port": 9025,
+			"Enabled": false,
+			"DataDir": "` + tmpdir + `/archivedata",
+			"TorrentDir": "` + tmpdir + `/torrents"
+		},
+		"RuntimeLogLevel": "INFO",
+		"LogLevel": "DEBUG"
+	}`
+
+		data.config, err = params.NewConfigFromJSON(json)
+		require.NoError(t, err)
+
+		data.config, err = params.NewNodeConfig(tmpdir, 178733)
+		require.NoError(t, err)
+
+		data.settings = settings.Settings{
+			KeyUID:            genMasterAcc.KeyUID(),
+			Address:           genMasterAcc.Address(),
+			DisplayName:       "UserDisplayName",
+			CurrentNetwork:    "mainnet_rpc",
+			DappsAddress:      derivedAccs[accscommon.PathDefaultWalletAccount].Address(),
+			InstallationID:    multidevice.GenerateInstallationID(),
+			LatestDerivedPath: 0,
+			Name:              "Jittery Cornflowerblue Kingbird",
+			Networks:          &networks,
+			PhotoPath:         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAjklEQVR4nOzXwQmFMBAAUZXUYh32ZB32ZB02sxYQQSZGsod55/91WFgSS0RM+SyjA56ZRZhFmEWYRRT6h+M6G16zrxv6fdJpmUWYRbxsYr13dKfanpN0WmYRZhGzXz6AWYRZRIfbaX26fT9Jk07LLMIsosPt9I/dTDotswizCG+nhFmEWYRZhFnEHQAA///z1CFkYamgfQAAAABJRU5ErkJggg==",
+			PreviewPrivacy:    false,
+			PublicKey:         genMasterAcc.PublicKeyHex(),
+			SigningPhrase:     "yurt joey vibe",
+			WalletRootAddress: derivedAccs[accscommon.PathWalletRoot].Address(),
+		}
+	}
+
+	data.backend = NewGethStatusBackend(tt.MustCreateTestLogger())
+	data.backend.UpdateRootDataDir(tmpdir)
+
+	err = data.backend.OpenAccounts()
 	require.NoError(t, err)
 
-	walletRootAddress := derivedAccount.Address().Hex()
+	if storeMultiAcc {
+		err = data.backend.SaveAccount(*data.multiAcc)
+		require.NoError(t, err)
+	}
 
-	config, err := params.NewNodeConfig(tmpdir, 178733)
-	require.NoError(t, err)
-	networks := json.RawMessage("{}")
-	s := settings.Settings{
-		Address:           types.HexToAddress(walletRootAddress),
-		DisplayName:       "UserDisplayName",
-		CurrentNetwork:    "mainnet_rpc",
-		DappsAddress:      types.HexToAddress(walletRootAddress),
-		EIP1581Address:    types.HexToAddress(walletRootAddress),
-		InstallationID:    "d3efcff6-cffa-560e-a547-21d3858cbc51",
-		KeyUID:            account.KeyUID,
-		LatestDerivedPath: 0,
-		Name:              "Jittery Cornflowerblue Kingbird",
-		Networks:          &networks,
-		PhotoPath:         "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAjklEQVR4nOzXwQmFMBAAUZXUYh32ZB32ZB02sxYQQSZGsod55/91WFgSS0RM+SyjA56ZRZhFmEWYRRT6h+M6G16zrxv6fdJpmUWYRbxsYr13dKfanpN0WmYRZhGzXz6AWYRZRIfbaX26fT9Jk07LLMIsosPt9I/dTDotswizCG+nhFmEWYRZhFnEHQAA///z1CFkYamgfQAAAABJRU5ErkJggg==",
-		PreviewPrivacy:    false,
-		PublicKey:         masterAccInfo.PublicKey,
-		SigningPhrase:     "yurt joey vibe",
-		WalletRootAddress: types.HexToAddress(walletRootAddress)}
+	if storeProfile {
+		err = data.backend.ensureDBsOpened(*data.multiAcc, password)
+		require.NoError(t, err)
 
-	err = backend.saveAccountsAndSettings(s, config, nil)
-	require.Error(t, err)
-	require.True(t, err == accounts.ErrKeypairWithoutAccounts)
+		err = data.backend.saveKeypairAndSettings(data.settings, data.config, data.profileKeypair)
+		require.NoError(t, err)
 
-	// this is for StatusNode().Config() call inside of the getVerifiedWalletAccount
-	err = backend.StartNode(config)
-	require.NoError(t, err)
-
-	defers = append(defers, func() {
-		require.NoError(t, backend.StopNode())
-	})
+		_, _, err = data.backend.StoreAccount(data.mnemonic, password, accountsPaths, true)
+		require.NoError(t, err)
+	}
 
 	return
 }

--- a/appdatabase/node_config_test.go
+++ b/appdatabase/node_config_test.go
@@ -118,7 +118,6 @@ func randomNodeConfig() *params.NodeConfig {
 	return &params.NodeConfig{
 		NetworkID:                 uint64(int64(randomInt(math.MaxInt64))),
 		DataDir:                   randomString(),
-		KeyStoreDir:               randomString(),
 		NodeKey:                   randomString(),
 		NoDiscovery:               randomBool(),
 		ListenAddr:                randomString(),

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -21,10 +21,8 @@ import (
 
 	"github.com/status-im/extkeys"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	abi_spec "github.com/status-im/status-go/abi-spec"
 	accscommon "github.com/status-im/status-go/accounts-management/common"
-	"github.com/status-im/status-go/accounts-management/keystore/geth"
 	"github.com/status-im/status-go/api"
 	"github.com/status-im/status-go/api/multiformat"
 	"github.com/status-im/status-go/centralizedmetrics"
@@ -388,12 +386,12 @@ func callPrivateRPC(inputJSON string) string {
 }
 
 // Deprecated: Use VerifyAccountPasswordV2 instead
-func VerifyAccountPassword(keyStoreDir, address, password string) string {
-	return verifyAccountPassword(keyStoreDir, address, password)
+func VerifyAccountPassword(address, password string) string {
+	return verifyAccountPassword(address, password)
 }
 
 // verifyAccountPassword verifies account password.
-func verifyAccountPassword(keyStoreDir, address, password string) string {
+func verifyAccountPassword(address, password string) string {
 	_, err := statusBackend.AccountsManager().LoadAccount(types.HexToAddress(address), password)
 	return makeJSONResponse(err)
 }
@@ -675,97 +673,22 @@ func SaveAccountAndLogin(accountData, password, settingsJSON, configJSON, subacc
 		return makeJSONResponse(err)
 	}
 
+	keypair := &accounts.Keypair{
+		KeyUID: account.KeyUID,
+		Name:   settings.DisplayName,
+		Type:   accounts.KeypairTypeProfile,
+	}
+	keypair.Accounts = subaccs
+
 	api.RunAsync(func() error {
 		logutils.ZapLogger().Debug("starting a node, and saving account with configuration", zap.String("key-uid", account.KeyUID))
-		err := statusBackend.StartNodeWithAccountAndInitialConfig(account, password, settings, &conf, subaccs, nil)
+		err := statusBackend.StartNodeWithAccountAndInitialConfig("", account, password, settings, &conf, keypair, nil)
 		if err != nil {
 			logutils.ZapLogger().Error("failed to start node and save account", zap.String("key-uid", gocommon.TruncateWithDot(account.KeyUID)), zap.Error(err))
 			return err
 		}
 		logutils.ZapLogger().Debug("started a node, and saved account", zap.String("key-uid", account.KeyUID))
 		return statusBackend.SetupLogSettings()
-	})
-	return makeJSONResponse(nil)
-}
-
-// Deprecated: Use DeleteMultiaccountV2 instead
-func DeleteMultiaccount(keyUID, keyStoreDir string) string {
-	return callWithResponse(deleteMultiaccount, keyUID, keyStoreDir)
-}
-
-// deleteMultiaccount
-func deleteMultiaccount(keyUID, keyStoreDir string) string {
-	err := statusBackend.DeleteMultiaccount(keyUID, keyStoreDir)
-	return makeJSONResponse(err)
-}
-
-func DeleteMultiaccountV2(requestJSON string) string {
-	return callWithResponse(deleteMultiaccountV2, requestJSON)
-}
-
-func deleteMultiaccountV2(requestJSON string) string {
-	var request requests.DeleteMultiaccount
-	err := json.Unmarshal([]byte(requestJSON), &request)
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-
-	err = request.Validate()
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-
-	err = statusBackend.DeleteMultiaccount(request.KeyUID, request.KeyStoreDir)
-	return makeJSONResponse(err)
-}
-
-func InitKeystore(keydir string) string {
-	return callWithResponse(initKeystore, keydir)
-}
-
-// initKeystore initialize keystore before doing any operations with keys.
-func initKeystore(keydir string) string {
-	keystoreAdapter, err := geth.NewGethKeystoreAdapter(keydir, keystore.LightScryptN, keystore.LightScryptP)
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-	statusBackend.AccountsManager().SetKeystore(keystoreAdapter)
-	return makeJSONResponse(nil)
-}
-
-// SaveAccountAndLoginWithKeycard saves account in status-go database.
-// Deprecated: Use CreateAndAccountAndLogin with required keycard properties.
-func SaveAccountAndLoginWithKeycard(accountData, password, settingsJSON, configJSON, subaccountData string, keyHex string) string {
-	var account multiaccounts.Account
-	err := json.Unmarshal([]byte(accountData), &account)
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-	var settings settings.Settings
-	err = json.Unmarshal([]byte(settingsJSON), &settings)
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-	var conf params.NodeConfig
-	err = json.Unmarshal([]byte(configJSON), &conf)
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-	var subaccs []*accounts.Account
-	err = json.Unmarshal([]byte(subaccountData), &subaccs)
-	if err != nil {
-		return makeJSONResponse(err)
-	}
-
-	api.RunAsync(func() error {
-		logutils.ZapLogger().Debug("starting a node, and saving account with configuration", zap.String("key-uid", account.KeyUID))
-		err := statusBackend.SaveAccountAndStartNodeWithKey(account, password, settings, &conf, subaccs, keyHex)
-		if err != nil {
-			logutils.ZapLogger().Error("failed to start node and save account", zap.String("key-uid", gocommon.TruncateWithDot(account.KeyUID)), zap.Error(err))
-			return err
-		}
-		logutils.ZapLogger().Debug("started a node, and saved account", zap.String("key-uid", account.KeyUID))
-		return nil
 	})
 	return makeJSONResponse(nil)
 }

--- a/multiaccounts/accounts/database.go
+++ b/multiaccounts/accounts/database.go
@@ -41,6 +41,7 @@ var (
 	ErrNotTheSameNumberOdAccountsToApplyReordering = errors.New("accounts: there is different number of accounts between received sync message and db accounts")
 	ErrNotTheSameAccountsToApplyReordering         = errors.New("accounts: there are differences between accounts in received sync message and db accounts")
 	ErrMovingAccountToWrongPosition                = errors.New("accounts: trying to move account to a wrong position")
+	ErrKeypairIsNil                                = errors.New("cannot store nil keypair")
 	ErrKeypairDifferentAccountsKeyUID              = errors.New("cannot store keypair with different accounts' key uid than keypair's key uid")
 	ErrKeypairWithoutAccounts                      = errors.New("cannot store keypair without accounts")
 )
@@ -253,13 +254,12 @@ func (a *Keypair) CopyKeypair() *Keypair {
 	return kp
 }
 
-func (a *Keypair) GetChatPublicKey() types.HexBytes {
+func (a *Keypair) GetChatAccount() *Account {
 	for _, acc := range a.Accounts {
 		if acc.Chat {
-			return acc.PublicKey
+			return acc
 		}
 	}
-
 	return nil
 }
 
@@ -1120,7 +1120,7 @@ func (db *Database) SaveOrUpdateAccounts(accounts []*Account, updateKeypairClock
 // are set or not.
 func (db *Database) SaveOrUpdateKeypair(keypair *Keypair) error {
 	if keypair == nil {
-		return errDbPassedParameterIsNil
+		return ErrKeypairIsNil
 	}
 
 	tx, err := db.db.Begin()

--- a/node/geth_node.go
+++ b/node/geth_node.go
@@ -32,10 +32,6 @@ func MakeNode(config *params.NodeConfig) (*node.Node, error) {
 			return nil, fmt.Errorf("make node: make data directory: %v", err)
 		}
 
-		// make sure keys directory exists
-		if err := os.MkdirAll(filepath.Clean(config.KeyStoreDir), os.ModePerm); err != nil {
-			return nil, fmt.Errorf("make node: make keys directory: %v", err)
-		}
 	}
 
 	stackConfig, err := newGethNodeConfig(config)
@@ -55,7 +51,6 @@ func MakeNode(config *params.NodeConfig) (*node.Node, error) {
 func newGethNodeConfig(config *params.NodeConfig) (*node.Config, error) {
 	nc := &node.Config{
 		DataDir:           config.DataDir,
-		KeyStoreDir:       config.KeyStoreDir,
 		UseLightweightKDF: true,
 		NoUSB:             true,
 		Name:              config.Name,

--- a/node/geth_status_node_test.go
+++ b/node/geth_status_node_test.go
@@ -68,8 +68,7 @@ func TestStatusNodeWithDataDir(t *testing.T) {
 	require.NoError(t, err)
 
 	config := params.NodeConfig{
-		DataDir:     dir,
-		KeyStoreDir: keyStoreDir,
+		DataDir: dir,
 	}
 
 	n, stop1, stop2, err := createStatusNode()

--- a/nodecfg/node_config.go
+++ b/nodecfg/node_config.go
@@ -44,7 +44,7 @@ func insertNodeConfigBase(tx *sql.Tx, c *params.NodeConfig, includeConnector boo
 		 swarm_enabled, mailserver_registry_address`
 
 	args := []any{
-		c.NetworkID, c.DataDir, c.KeyStoreDir, c.NodeKey, c.NoDiscovery,
+		c.NetworkID, c.DataDir, "", c.NodeKey, c.NoDiscovery,
 		c.ListenAddr, c.AdvertiseAddr, c.Name, c.Version, c.APIModules,
 		c.TLSEnabled, c.MaxPeers, c.MaxPendingPeers,
 		c.EnableStatusService, true,
@@ -418,6 +418,7 @@ func migrateNodeConfig(tx *sql.Tx) error {
 func loadNodeConfig(tx *sql.Tx) (*params.NodeConfig, error) {
 	nodecfg := &params.NodeConfig{}
 
+	keystoreDir := "" // TODO: remove this from db
 	err := tx.QueryRow(`
 	SELECT
 		network_id, data_dir, keystore_dir, node_key, no_discovery,
@@ -427,7 +428,7 @@ func loadNodeConfig(tx *sql.Tx) (*params.NodeConfig, error) {
 		mailserver_registry_address, connector_enabled FROM node_config
 		WHERE synthetic_id = 'id'
 	`).Scan(
-		&nodecfg.NetworkID, &nodecfg.DataDir, &nodecfg.KeyStoreDir, &nodecfg.NodeKey, &nodecfg.NoDiscovery,
+		&nodecfg.NetworkID, &nodecfg.DataDir, &keystoreDir, &nodecfg.NodeKey, &nodecfg.NoDiscovery,
 		&nodecfg.ListenAddr, &nodecfg.AdvertiseAddr, &nodecfg.Name, &nodecfg.Version, &nodecfg.APIModules, &nodecfg.TLSEnabled, &nodecfg.MaxPeers, &nodecfg.MaxPendingPeers,
 		&nodecfg.EnableStatusService, &nodecfg.BridgeConfig.Enabled, &nodecfg.WalletConfig.Enabled, &nodecfg.LocalNotificationsConfig.Enabled,
 		&nodecfg.BrowsersConfig.Enabled, &nodecfg.PermissionsConfig.Enabled, &nodecfg.MailserversConfig.Enabled, &nodecfg.SwarmConfig.Enabled,

--- a/params/config.go
+++ b/params/config.go
@@ -229,9 +229,6 @@ type NodeConfig struct {
 	// DataDir is the file system folder the node should use for any data storage needs.
 	DataDir string `validate:"required"`
 
-	// KeyStoreDir is the file system folder that contains private keys.
-	KeyStoreDir string `validate:"required"`
-
 	// KeycardPairingDataFile is the file where we keep keycard pairings data.
 	// It's specified by clients (and not in status-go) when creating a new account,
 	// because this file is initialized by status-keycard-go and we need to use it before initializing the node.
@@ -774,10 +771,9 @@ func (c *NodeConfig) updatePeerLimits() {
 // NewNodeConfig creates new node configuration object with bare-minimum defaults.
 // Important: the returned config is not validated.
 func NewNodeConfig(dataDir string, networkID uint64) (*NodeConfig, error) {
-	var keyStoreDir, keycardPairingDataFile, wakuV2Dir string
+	var keycardPairingDataFile, wakuV2Dir string
 
 	if dataDir != "" {
-		keyStoreDir = filepath.Join(dataDir, "keystore")
 		keycardPairingDataFile = filepath.Join(dataDir, "keycard", "pairings.json")
 
 		wakuV2Dir = filepath.Join(dataDir, "wakuv2")
@@ -787,7 +783,6 @@ func NewNodeConfig(dataDir string, networkID uint64) (*NodeConfig, error) {
 		NetworkID:              networkID,
 		RootDataDir:            dataDir,
 		DataDir:                dataDir,
-		KeyStoreDir:            keyStoreDir,
 		KeycardPairingDataFile: keycardPairingDataFile,
 		Version:                version.Version(),
 		HTTPHost:               "localhost",

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -30,7 +30,6 @@ func TestNewNodeConfigWithDefaults(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "/some/data/path", c.DataDir)
-	assert.Equal(t, "/some/data/path/keystore", c.KeyStoreDir)
 	// assert Whisper
 	assert.Equal(t, true, c.WakuV2Config.Enabled)
 	assert.Equal(t, "/some/data/path/wakuv2", c.WakuV2Config.DataDir)
@@ -62,7 +61,6 @@ func TestNewConfigFromJSON(t *testing.T) {
 	json := `{
 		"NetworkId": 3,
 		"DataDir": "` + tmpDir + `",
-		"KeyStoreDir": "` + tmpDir + `",
 		"KeycardPairingDataFile": "` + path.Join(tmpDir, "keycard/pairings.json") + `",
 		"NoDiscovery": true,
 		"TorrentConfig": {
@@ -77,7 +75,6 @@ func TestNewConfigFromJSON(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), c.NetworkID)
 	require.Equal(t, tmpDir, c.DataDir)
-	require.Equal(t, tmpDir, c.KeyStoreDir)
 	require.Equal(t, false, c.TorrentConfig.Enabled)
 	require.Equal(t, 9025, c.TorrentConfig.Port)
 	require.Equal(t, tmpDir+"/archivedata", c.TorrentConfig.DataDir)
@@ -116,7 +113,6 @@ func TestNodeConfigValidate(t *testing.T) {
 				"NetworkId": 1,
 				"RootDataDir": "/tmp/data",
 				"DataDir": "/tmp/data",
-				"KeyStoreDir": "/tmp/data",
 				"KeycardPairingDataFile": "/tmp/data/keycard/pairings.json",
 				"NoDiscovery": true
 			}`,
@@ -137,7 +133,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			FieldErrors: map[string]string{
 				"NetworkID":              "required",
 				"DataDir":                "required",
-				"KeyStoreDir":            "required",
 				"KeycardPairingDataFile": "required",
 			},
 		},
@@ -146,7 +141,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"Name": "invalid/name"
 			}`,
@@ -159,7 +153,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"NoDiscovery": true,
 				"NodeKey": "foo"
@@ -171,7 +164,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"NoDiscovery": true,
 				"UpstreamConfig": {
@@ -185,7 +177,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"NoDiscovery": true,
 				"UpstreamConfig": {
@@ -199,7 +190,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"NoDiscovery": false
 			}`,
@@ -210,7 +200,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"NoDiscovery": true,
 				"ShhextConfig": {
@@ -224,7 +213,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json"
 			}`,
 			CheckFunc: func(t *testing.T, config *params.NodeConfig) {
@@ -237,7 +225,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"HTTPVirtualHosts": ["my.domain.com"],
 				"HTTPCors": ["http://my.domain.com:8080"]
@@ -252,13 +239,12 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json"
 			}`,
 		},
 		{
 			Name:   "Missing APIModules",
-			Config: `{"NetworkId": 1, "DataDir": "/tmp/data", "KeyStoreDir": "/tmp/data", "KeycardPairingDataFile": "/tmp/data/keycard/pairings.json", "APIModules" :""}`,
+			Config: `{"NetworkId": 1, "DataDir": "/tmp/data", "KeycardPairingDataFile": "/tmp/data/keycard/pairings.json", "APIModules" :""}`,
 			FieldErrors: map[string]string{
 				"APIModules": "required",
 			},
@@ -268,7 +254,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"DataDir": "/some/dir",
-				"KeyStoreDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
         "TorrentConfig": {
           "Enabled": true,

--- a/protocol/requests/delete_multiaccount.go
+++ b/protocol/requests/delete_multiaccount.go
@@ -8,9 +8,6 @@ import (
 type DeleteMultiaccount struct {
 	// KeyUID is the unique identifier for the key.
 	KeyUID string `json:"keyUID" validate:"required"`
-
-	// KeyStoreDir is the directory where the keystore files are located.
-	KeyStoreDir string `json:"keyStoreDir" validate:"required"`
 }
 
 // Validate checks the validity of the DeleteMultiaccount request.

--- a/protocol/requests/verify_account_password.go
+++ b/protocol/requests/verify_account_password.go
@@ -6,9 +6,6 @@ import (
 
 // VerifyAccountPassword represents a request to verify an account password.
 type VerifyAccountPassword struct {
-	// KeyStoreDir is the directory where the keystore files are located.
-	KeyStoreDir string `json:"keyStoreDir" validate:"required"`
-
 	// Address is the Ethereum address for the account.
 	Address string `json:"address" validate:"required"`
 

--- a/server/pairing/raw_message_handler.go
+++ b/server/pairing/raw_message_handler.go
@@ -136,12 +136,7 @@ func (s *SyncRawMessageHandler) login(accountPayload *AccountPayload, createAcco
 		return err
 	}
 
-	keystoreRelativePath, err := s.backend.InitKeyStoreDirWithAccount(nodeConfig.RootDataDir, account.KeyUID)
-	nodeConfig.KeyStoreDir = keystoreRelativePath
-
-	if err != nil {
-		return err
-	}
+	s.backend.UpdateRootDataDir(nodeConfig.RootDataDir)
 
 	var chatKey *ecdsa.PrivateKey
 	if accountPayload.chatKey != "" {
@@ -162,11 +157,12 @@ func (s *SyncRawMessageHandler) login(accountPayload *AccountPayload, createAcco
 	rmp.setting.CurrentNetwork = api.DefaultCurrentNetwork
 
 	return s.backend.StartNodeWithAccountAndInitialConfig(
+		"",
 		*account,
 		accountPayload.password,
 		*rmp.setting,
 		nodeConfig,
-		rmp.profileKeypair.Accounts,
+		rmp.profileKeypair,
 		chatKey,
 	)
 }

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -15,10 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
-	accsmanagement "github.com/status-im/status-go/accounts-management"
 	"github.com/status-im/status-go/accounts-management/generator"
-	"github.com/status-im/status-go/accounts-management/keystore/geth"
 	"github.com/status-im/status-go/api"
 	"github.com/status-im/status-go/common/dbsetup"
 	"github.com/status-im/status-go/eth-node/types"
@@ -67,16 +64,10 @@ func (s *SyncDeviceSuite) SetupTest() {
 	s.tmpdir = s.T().TempDir()
 }
 
-func setKeystore(accManager *accsmanagement.AccountsManager, keyStoreDir string) error {
-	keystoreAdapter, err := geth.NewGethKeystoreAdapter(keyStoreDir, keystore.LightScryptN, keystore.LightScryptP)
-	if err != nil {
-		return err
-	}
-	accManager.SetKeystore(keystoreAdapter)
-	return nil
-}
-
 func (s *SyncDeviceSuite) prepareBackendWithAccount(mnemonic, tmpdir string) *api.GethStatusBackend {
+	err := os.MkdirAll(tmpdir, 0755) // making sure the dir is created
+	s.Require().NoError(err)
+
 	backend := s.prepareBackendWithoutAccount(tmpdir)
 
 	displayName, err := common.RandomAlphabeticalString(8)
@@ -261,8 +252,7 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFiles() {
 		require.True(s.T(), containsKeystoreFile(clientKeystorePath, acc.Address.String()[2:]))
 	}
 
-	// reinit keystore on client
-	err = setKeystore(accountsManager, clientKeystorePath)
+	err = accountsManager.ReloadKeystore()
 	require.NoError(s.T(), err)
 
 	// check keystore on client

--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -437,7 +437,7 @@ func (api *API) ImportMnemonic(ctx context.Context, mnemonic string, password st
 		return errors.New("provided mnemonic was already imported, to add new account use `AddAccount` endpoint")
 	}
 
-	_, err = api.manager.CreateFromMnemonicAndStoreAccount(mnemonic, password)
+	_, err = api.manager.CreateFromMnemonicAndStoreAccount(mnemonic, password, false)
 	return err
 }
 
@@ -461,7 +461,7 @@ func (api *API) MakeSeedPhraseKeypairFullyOperable(ctx context.Context, mnemonic
 		return errors.New("keypair for the provided seed phrase is not known")
 	}
 
-	_, err = api.manager.CreateFromMnemonicAndStoreAccount(mnemonicNoExtraSpaces, password)
+	_, err = api.manager.CreateFromMnemonicAndStoreAccount(mnemonicNoExtraSpaces, password, false)
 	if err != nil {
 		return err
 	}
@@ -529,7 +529,7 @@ func (api *API) MigrateNonProfileKeycardKeypairToApp(ctx context.Context, mnemon
 		return errors.New("wrong password provided")
 	}
 
-	_, err = api.manager.CreateFromMnemonicAndStoreAccount(mnemonicNoExtraSpaces, password)
+	_, err = api.manager.CreateFromMnemonicAndStoreAccount(mnemonicNoExtraSpaces, password, false)
 	if err != nil {
 		return err
 	}

--- a/services/accounts/service.go
+++ b/services/accounts/service.go
@@ -4,13 +4,11 @@ import (
 	"errors"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/rpc"
 
 	"github.com/golang/protobuf/proto"
 
 	accsmanagement "github.com/status-im/status-go/accounts-management"
-	"github.com/status-im/status-go/accounts-management/keystore/geth"
 	"github.com/status-im/status-go/eth-node/crypto"
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/multiaccounts"
@@ -62,11 +60,6 @@ func (s *Service) Init(messenger *protocol.Messenger) {
 
 // Start a service.
 func (s *Service) Start() error {
-	keystoreAdapter, err := geth.NewGethKeystoreAdapter(s.config.KeyStoreDir, keystore.LightScryptN, keystore.LightScryptP)
-	if err != nil {
-		return err
-	}
-	s.manager.SetKeystore(keystoreAdapter)
 	return nil
 }
 

--- a/services/stickers/api.go
+++ b/services/stickers/api.go
@@ -45,9 +45,8 @@ type API struct {
 	accountsDB      *accounts.Database
 	pendingTracker  *transactions.PendingTxTracker
 
-	keyStoreDir string
-	downloader  *ipfs.Downloader
-	httpServer  *server.MediaServer
+	downloader *ipfs.Downloader
+	httpServer *server.MediaServer
 
 	ctx context.Context
 }
@@ -89,7 +88,7 @@ type ednStickerPackInfo struct {
 }
 
 func NewAPI(ctx context.Context, acc *accounts.Database, rpcClient *rpc.Client, accountsManager *accsmanagement.AccountsManager,
-	pendingTracker *transactions.PendingTxTracker, keyStoreDir string, downloader *ipfs.Downloader, httpServer *server.MediaServer) *API {
+	pendingTracker *transactions.PendingTxTracker, downloader *ipfs.Downloader, httpServer *server.MediaServer) *API {
 	result := &API{
 		contractMaker: &contracts.ContractMaker{
 			RPCClient: rpcClient,
@@ -97,7 +96,6 @@ func NewAPI(ctx context.Context, acc *accounts.Database, rpcClient *rpc.Client, 
 		accountsManager: accountsManager,
 		accountsDB:      acc,
 		pendingTracker:  pendingTracker,
-		keyStoreDir:     keyStoreDir,
 		downloader:      downloader,
 		ctx:             ctx,
 		httpServer:      httpServer,

--- a/services/stickers/recent_test.go
+++ b/services/stickers/recent_test.go
@@ -27,7 +27,7 @@ func SetupAPI(t *testing.T) (*API, *mock_settings.MockDatabaseSettingsManager) {
 		DatabaseSettingsManager: mockDB,
 	}
 
-	api := NewAPI(context.Background(), accountDatabase, nil, nil, nil, "test-store-dir", nil, nil)
+	api := NewAPI(context.Background(), accountDatabase, nil, nil, nil, nil, nil)
 	require.NotNil(t, api)
 
 	return api, mockDB

--- a/services/stickers/service.go
+++ b/services/stickers/service.go
@@ -22,12 +22,11 @@ func NewService(acc *accounts.Database, rpcClient *rpc.Client, accountsManager *
 		accountsDB:      acc,
 		rpcClient:       rpcClient,
 		accountsManager: accountsManager,
-		keyStoreDir:     config.KeyStoreDir,
 		downloader:      downloader,
 		httpServer:      httpServer,
 		ctx:             ctx,
 		cancel:          cancel,
-		api:             NewAPI(ctx, acc, rpcClient, accountsManager, pendingTracker, config.KeyStoreDir, downloader, httpServer),
+		api:             NewAPI(ctx, acc, rpcClient, accountsManager, pendingTracker, downloader, httpServer),
 	}
 }
 
@@ -37,7 +36,6 @@ type Service struct {
 	rpcClient       *rpc.Client
 	accountsManager *accsmanagement.AccountsManager
 	downloader      *ipfs.Downloader
-	keyStoreDir     string
 	httpServer      *server.MediaServer
 	ctx             context.Context
 	cancel          context.CancelFunc

--- a/t/config/status-chain-accounts.json
+++ b/t/config/status-chain-accounts.json
@@ -1,15 +1,18 @@
 {
   "Account1": {
+    "KeyUID": "0x0000000000000000000000000000000000000000000000000000000000000001",
     "WalletAddress": "0xbF164ca341326a03b547c05B343b2E21eFAe24b9",
     "ChatAddress": "0xbF164ca341326a03b547c05B343b2E21eFAe24b9",
     "Password": "password"
   },
   "Account2": {
+    "KeyUID": "0x0000000000000000000000000000000000000000000000000000000000000002",
     "WalletAddress": "0x205a5d0E72ff65079FCaBB4A63E33d28aA6Def2C",
     "ChatAddress": "0x205a5d0E72ff65079FCaBB4A63E33d28aA6Def2C",
     "Password": "password"
   },
   "Account3": {
+    "KeyUID": "0x0000000000000000000000000000000000000000000000000000000000000003",
     "WalletAddress": "0x3ad34e698d4806afd08b359b920f5c6b62b68ee4",
     "ChatAddress": "0x3ad34e698d4806afd08b359b920f5c6b62b68ee4",
     "Password": "password"

--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -242,7 +242,6 @@ func MakeTestNodeConfig(networkID int) (*params.NodeConfig, error) {
 		"NetworkId": ` + strconv.Itoa(networkID) + `,
 		"RootDataDir": "` + testDir + `",
 		"DataDir": "` + testDir + `",
-		"KeyStoreDir": "` + path.Join(testDir, "keystore") + `",
 		"KeycardPairingDataFile": "` + path.Join(testDir, "keycard/pairings.json") + `",
 		"HTTPPort": ` + strconv.Itoa(TestConfig.Node.HTTPPort) + `,
 		"WSPort": ` + strconv.Itoa(TestConfig.Node.WSPort) + `,
@@ -276,9 +275,6 @@ func MakeTestNodeConfigWithDataDir(name, dataDir string, networkID uint64) (*par
 	}
 	cfg.NoDiscovery = true
 	cfg.LightEthConfig.Enabled = false
-	if dataDir != "" {
-		cfg.KeyStoreDir = path.Join(dataDir, "keystore")
-	}
 
 	// Only attempt to validate if a dataDir is specified, we only support in-memory DB for tests
 	if dataDir != "" {
@@ -291,6 +287,7 @@ func MakeTestNodeConfigWithDataDir(name, dataDir string, networkID uint64) (*par
 }
 
 type account struct {
+	KeyUID        string
 	WalletAddress string
 	ChatAddress   string
 	Password      string


### PR DESCRIPTION
The main goal of this change is to internally (for the account manager) change the keystore based on the selected chat account. That simplifies the usage of the account manager across the app. Main changes are made in `AccountsManager` and all other changes reflect changes made there.

- Updated `AccountsManager` to support setting a root data directory.
- Refactored methods to let the client deal with the keystore transparently.
- Adjusted tests to reflect changes in account creation and password verification processes.
- Removed unnecessary keystore directory references from various components.
- Unused functions/endpoints removed:
  - `SaveAccountAndStartNodeWithKey`
  - `InitKeystore`
  - `DeleteMultiaccount`
  - `DeleteMultiaccountV2`
  - `SaveAccountAndLoginWithKeycard`