### PR TITLE
fix_: prevent logutils.TestCore flakiness

### DIFF
--- a/logutils/core_test.go
+++ b/logutils/core_test.go
@@ -17,8 +17,11 @@ func TestCore(t *testing.T) {
 	buffer1 := bytes.NewBuffer(nil)
 	buffer2 := bytes.NewBuffer(nil)
 
+	cfg := zap.NewDevelopmentEncoderConfig()
+	cfg.TimeKey = ""
+
 	core := NewCore(
-		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+		zapcore.NewConsoleEncoder(cfg),
 		zapcore.AddSync(buffer1),
 		level,
 	)


### PR DESCRIPTION
Output was not deterministic due to timestamp being printed.
