### PR TITLE
test_: increase waiting for push registration to 10 seconds

### DIFF
--- a/tests-functional/tests/test_push_notification_server.py
+++ b/tests-functional/tests/test_push_notification_server.py
@@ -74,7 +74,7 @@ class TestPushNotificationServer(MessengerSteps):
         assert "error" not in response
 
         # There is currently no way to reliably check if the devices have been registered, so we just wait a few seconds
-        time.sleep(5)
+        time.sleep(10)
 
         # Make contacts, this should force delivery of a push notification
         self.make_contacts(alice, bob)


### PR DESCRIPTION
The test seem to be flaky on CI: 
https://ci.status.im/blue/organizations/jenkins/status-go%2Fprs%2Ftests-rpc/detail/PR-6711/14/tests/

We need a proper solution to track push registrations, perhaps we could reuse `pns` metrics in tests. 
We need to implement them first though 😄 