### PR TITLE
fix(wallet)_: refresh balances on sent transaction state change

### DIFF
--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -4,6 +4,7 @@ package wallet
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"math/big"
 	"sync"
@@ -23,6 +24,7 @@ import (
 	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/services/wallet/transfer"
 	"github.com/status-im/status-go/services/wallet/walletevent"
+	"github.com/status-im/status-go/transactions"
 )
 
 // WalletTickReload emitted every 15mn to reload the wallet balance and history
@@ -185,10 +187,25 @@ func (r *Reader) startWalletEventsWatcher() {
 		return
 	}
 
-	// Respond to ETH/Token transfers
+	// Respond to ETH/Token transfers or any sent transaction
 	walletEventCb := func(event walletevent.Event) {
-		if event.Type != transfer.EventInternalETHTransferDetected &&
-			event.Type != transfer.EventInternalERC20TransferDetected {
+		delayed := true
+		switch event.Type {
+		case transfer.EventInternalETHTransferDetected, transfer.EventInternalERC20TransferDetected:
+			// Delayed refresh
+		case transactions.EventPendingTransactionUpdate:
+			var p transactions.PendingTxUpdatePayload
+			err := json.Unmarshal([]byte(event.Message), &p)
+			if err != nil {
+				return
+			}
+			if p.Deleted {
+				// Immediate refresh
+				delayed = false
+			}
+			// Delayed refresh
+		default:
+			// Unrelated event, do not trigger a reload
 			return
 		}
 
@@ -200,8 +217,12 @@ func (r *Reader) startWalletEventsWatcher() {
 			}
 
 			if !ok || event.At > timecheck {
-				r.triggerDelayedWalletReload()
 				r.invalidateBalanceCache()
+				if delayed {
+					r.triggerDelayedWalletReload()
+				} else {
+					r.triggerWalletReload()
+				}
 				break
 			}
 		}

--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -32,6 +32,7 @@ class WalletEventType(Enum):
     WALLET_ACTIVITY_SESSION_UPDATED = "wallet-activity-session-updated"
     TRANSACTIONS_PENDING_TRANSACTION_UPDATE = "pending-transaction-update"
     TRANSACTIONS_PENDING_TRANSACTION_STATUS_CHANGED = "pending-transaction-status-changed"
+    WALLET_TICK_RELOAD = "wallet-tick-reload"
 
 
 class LocalPairingEventType(Enum):

--- a/tests-functional/pytest.ini
+++ b/tests-functional/pytest.ini
@@ -20,3 +20,4 @@ markers =
     create_account
     reliability
     activity
+    assets

--- a/tests-functional/tests/test_wallet_assets.py
+++ b/tests-functional/tests/test_wallet_assets.py
@@ -1,0 +1,80 @@
+import uuid as uuid_lib
+import json
+import pytest
+import resources.constants as constants
+
+from steps.status_backend import StatusBackendSteps
+from clients.signals import SignalType, WalletEventType
+from utils import wallet_utils
+
+
+@pytest.mark.rpc
+@pytest.mark.assets
+@pytest.mark.wallet
+class TestWalletAssets(StatusBackendSteps):
+    await_signals = [
+        SignalType.NODE_LOGIN.value,
+        SignalType.WALLET.value,
+        SignalType.WALLET_SUGGESTED_ROUTES.value,
+        SignalType.WALLET_ROUTER_SIGN_TRANSACTIONS.value,
+        SignalType.WALLET_ROUTER_SENDING_TRANSACTIONS_STARTED.value,
+        SignalType.WALLET_ROUTER_TRANSACTIONS_SENT.value,
+    ]
+
+    @classmethod
+    def setup_class(cls, skip_login=False):
+        super().setup_class(skip_login)
+        cls.wallet_service.start_wallet()
+
+    @pytest.mark.skip("cryptocompare limit reached")
+    def test_balance_refresh_ticker_after_sending_transaction(self):
+        uuid = str(uuid_lib.uuid4())
+        amount_in = "0xde0b6b3a7640000"
+
+        input_params = {
+            "uuid": uuid,
+            "sendType": 0,
+            "addrFrom": constants.user_1.address,
+            "addrTo": constants.user_2.address,
+            "amountIn": amount_in,
+            "amountOut": "0x0",
+            "tokenID": "ETH",
+            "tokenIDIsOwnerToken": False,
+            "toTokenID": "",
+            "fromChainID": 31337,
+            "toChainID": 31337,
+            "gasFeeMode": 1,
+            # params for building tx from route
+            "slippagePercentage": 0,
+        }
+
+        # Prepare to send tx
+        routes = wallet_utils.get_suggested_routes(self.rpc_client, **input_params)
+        assert "Route" in routes, f"No route found: {routes}"
+        build_tx = wallet_utils.build_transactions_from_route(self.rpc_client, input_params.get("uuid"))
+        tx_signatures = wallet_utils.sign_messages(self.rpc_client, build_tx["signingDetails"]["hashes"], input_params.get("addrFrom"))
+
+        # Send tx, listen to reload tick signal
+        method = "wallet_sendRouterTransactionsWithSignatures"
+        params = [{"uuid": uuid, "Signatures": tx_signatures}]
+
+        def accept_fn(signal):
+            match signal["event"]["type"]:
+                case WalletEventType.TRANSACTIONS_PENDING_TRANSACTION_STATUS_CHANGED.value:
+                    tx_status = json.loads(signal["event"]["message"].replace("'", '"'))
+                    return tx_status["status"] == "Success"
+                case WalletEventType.WALLET_TICK_RELOAD.value:
+                    return True
+                case _:
+                    return False
+
+        self.rpc_client.prepare_wait_for_signal(
+            SignalType.WALLET.value,
+            2,
+            accept_fn,
+        )
+        _ = self.rpc_client.rpc_valid_request(method, params)
+        signals = self.rpc_client.wait_for_signal(SignalType.WALLET.value)
+
+        # Verify
+        assert len(signals) == 2


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/18322
We were only refreshing balances on externally detected eth/erc20 transfers, we've now added a generic refresh after any sent transaction succeeds/fails. Moreover, this refresh is immediate and not delayed.

Functional test added, tried locally, ignored for CI runs until the market providers are sorted out.
