### PR TITLE
chore_: integrate status market proxy

### DIFF
--- a/services/wallet/leaderboard/fetcher.go
+++ b/services/wallet/leaderboard/fetcher.go
@@ -3,8 +3,6 @@ package leaderboard
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -18,23 +16,7 @@ import (
 const (
 	MARKETS_ENDPOINT = "/v1/leaderboard/markets"
 	PRICES_ENDPOINT  = "/v1/leaderboard/prices"
-
-	// Host suffix for market proxy
-	MarketProxyHostSuffix = "market.status.im"
 )
-
-// getMarketProxyHost creates market proxy URL based on stage name
-// Similar to getProxyHost in api/default_networks.go but for market proxy
-func getMarketProxyHost(customUrl, stageName string) string {
-	if customUrl != "" {
-		return strings.TrimRight(customUrl, "/")
-	}
-	// Use stageName if provided, otherwise default to "test"
-	if stageName == "" {
-		stageName = "test"
-	}
-	return fmt.Sprintf("https://%s.%s", stageName, MarketProxyHostSuffix)
-}
 
 // DataFetcher defines the interface for fetching market and price data
 type DataFetcher interface {
@@ -221,7 +203,7 @@ func (f *ProxyFetcher) FetchPrices(ctx context.Context) error {
 }
 
 func (f *ProxyFetcher) fetchData(ctx context.Context, endpoint string, etag string) ([]byte, string, bool) {
-	baseUrl := getMarketProxyHost(f.config.UrlOverride.Reveal(), f.config.StageName)
+	baseUrl := GetMarketProxyHost(f.config.UrlOverride.Reveal(), f.config.StageName)
 	url := f.client.BuildURL(baseUrl, endpoint)
 
 	options := []thirdparty.RequestOption{}

--- a/services/wallet/leaderboard/proxy_host_test.go
+++ b/services/wallet/leaderboard/proxy_host_test.go
@@ -71,7 +71,7 @@ func TestGetMarketProxyHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := getMarketProxyHost(tt.customUrl, tt.stageName)
+			result := GetMarketProxyHost(tt.customUrl, tt.stageName)
 			require.Equal(t, tt.expectedUrl, result)
 		})
 	}

--- a/services/wallet/leaderboard/utils.go
+++ b/services/wallet/leaderboard/utils.go
@@ -1,0 +1,27 @@
+package leaderboard
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	MarketProxyHostSuffix = "market.status.im"
+)
+
+// GetMarketProxyHost creates market proxy base URL based on stage name
+func GetMarketProxyHost(customUrl, stageName string) string {
+	if customUrl != "" {
+		return strings.TrimRight(customUrl, "/")
+	}
+	if stageName == "" {
+		stageName = "test"
+	}
+	return fmt.Sprintf("https://%s.%s", stageName, MarketProxyHostSuffix)
+}
+
+// GetMarketProxyUrl creates market proxy URL based on stage name with /v1 suffix
+func GetMarketProxyUrl(customUrl, stageName string) string {
+	baseUrl := GetMarketProxyHost(customUrl, stageName)
+	return baseUrl + "/v1"
+}

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/status-im/status-go/services/wallet/thirdparty/market/cryptocompare"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
@@ -39,7 +41,6 @@ import (
 	"github.com/status-im/status-go/services/wallet/thirdparty/collectibles/opensea"
 	"github.com/status-im/status-go/services/wallet/thirdparty/collectibles/rarible"
 	"github.com/status-im/status-go/services/wallet/thirdparty/market/coingecko"
-	"github.com/status-im/status-go/services/wallet/thirdparty/market/cryptocompare"
 	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/services/wallet/transfer"
 	"github.com/status-im/status-go/services/wallet/walletevent"
@@ -52,6 +53,16 @@ const (
 	defaultAutoRefreshInterval      = 30 * time.Minute // interval after which we should fetch the token lists from the remote source (or use the default one if remote source is not set)
 	defaultAutoRefreshCheckInterval = 3 * time.Minute  // interval after which we should check if we should trigger the auto-refresh
 )
+
+func createCoingeckoProxyClient(config params.MarketDataProxyConfig) *coingecko.Client {
+	baseURL := leaderboard.GetMarketProxyUrl(config.UrlOverride.Reveal(), config.StageName)
+
+	return coingecko.NewClientWithParams(coingecko.Params{
+		URL:      baseURL,
+		User:     config.User,
+		Password: config.Password,
+	})
+}
 
 // NewService initializes service instance.
 func NewService(
@@ -133,14 +144,15 @@ func NewService(
 	transferController := transfer.NewTransferController(db, accountsDB, rpcClient, accountsPublisher, transactionManager, blockChainState)
 
 	cryptoCompare := cryptocompare.NewClient()
-	coingecko := coingecko.NewClient()
+	coingeckoClient := coingecko.NewClient()
+	coingeckoProxy := createCoingeckoProxyClient(config.WalletConfig.MarketDataProxyConfig)
 	cryptoCompareProxy := cryptocompare.NewClientWithParams(cryptocompare.Params{
 		ID:       fmt.Sprintf("%s-proxy", cryptoCompare.ID()),
 		URL:      fmt.Sprintf("https://%s.api.status.im/cryptocompare/", statusProxyStageName),
 		User:     config.WalletConfig.StatusProxyMarketUser,
 		Password: config.WalletConfig.StatusProxyMarketPassword,
 	})
-	marketManager := market.NewManager([]thirdparty.MarketDataProvider{cryptoCompare, coingecko, cryptoCompareProxy}, tokenManager, feed)
+	marketManager := market.NewManager([]thirdparty.MarketDataProvider{coingeckoProxy, coingeckoClient, cryptoCompare, cryptoCompareProxy}, tokenManager, feed)
 	reader := NewReader(tokenManager, marketManager, token.NewPersistence(db), feed)
 	history := history.NewService(db, accountsDB, accountsPublisher, feed, rpcClient, tokenManager, marketManager, balanceCacher.Cache())
 	currency := currency.NewService(db, feed, tokenManager, marketManager)

--- a/services/wallet/thirdparty/market/coingecko/client.go
+++ b/services/wallet/thirdparty/market/coingecko/client.go
@@ -3,17 +3,25 @@ package coingecko
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
 
 	"golang.org/x/exp/maps"
 
+	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/services/wallet/thirdparty/utils"
 )
 
 const baseURL = "https://api.coingecko.com/api/v3"
+
+const (
+	requestDelay     = 500 * time.Millisecond
+	pricesChunkLimit = 500
+	tokensChunkLimit = 250
+)
 
 var coinGeckoMapping = map[string]string{
 	"STT":   "status",
@@ -61,29 +69,54 @@ type Client struct {
 	httpClient       *thirdparty.HTTPClient
 	tokens           map[string][]GeckoToken
 	baseURL          string
+	creds            *thirdparty.BasicCreds
 	fetchTokensMutex sync.Mutex
 }
 
+type Params struct {
+	URL      string
+	User     security.SensitiveString
+	Password security.SensitiveString
+}
+
 func NewClient() *Client {
-	// Configure HTTP client with detailed timeouts:
-	// - 5 seconds for connection establishment (dialTimeout)
-	// - 5 seconds for TLS handshake (tlsHandshakeTimeout)
-	// - 5 seconds for receiving response headers (responseHeaderTimeout)
-	// - 20 seconds for overall request timeout (requestTimeout)
+	return NewClientWithParams(Params{
+		URL:      baseURL,
+		User:     security.SensitiveString{},
+		Password: security.SensitiveString{},
+	})
+}
+
+func NewClientWithParams(params Params) *Client {
+	var creds *thirdparty.BasicCreds
+	if !params.User.Empty() {
+		creds = &thirdparty.BasicCreds{
+			User:     params.User,
+			Password: params.Password,
+		}
+	}
+
 	httpClient := thirdparty.NewHTTPClient(
 		thirdparty.WithDetailedTimeouts(
-			5*time.Second,
-			5*time.Second,
-			5*time.Second,
-			20*time.Second,
+			5*time.Second,  // dialTimeout
+			5*time.Second,  // tlsHandshakeTimeout
+			5*time.Second,  // responseHeaderTimeout
+			20*time.Second, // requestTimeout
 		),
 		thirdparty.WithMaxRetries(5),
 	)
 
+	// Ensure baseURL doesn't end with a slash
+	clientBaseURL := strings.TrimSuffix(params.URL, "/")
+	if clientBaseURL == "" {
+		clientBaseURL = baseURL
+	}
+
 	return &Client{
 		httpClient: httpClient,
 		tokens:     make(map[string][]GeckoToken),
-		baseURL:    baseURL,
+		baseURL:    clientBaseURL,
+		creds:      creds,
 	}
 }
 
@@ -166,7 +199,15 @@ func (c *Client) FetchPrices(symbols []string, currencies []string) (map[string]
 		return nil, err
 	}
 
-	simplePrices, err := c.FetchSimplePrice(context.Background(), maps.Values(mappedSymbols), currencies)
+	simplePrices, err := utils.ChunkMapFetcher[CurrencyPriceMap](
+		context.Background(),
+		maps.Values(mappedSymbols),
+		pricesChunkLimit,
+		requestDelay,
+		func(ctx context.Context, chunkIds []string) (map[string]CurrencyPriceMap, error) {
+			return c.FetchSimplePrice(ctx, chunkIds, currencies)
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +255,15 @@ func (c *Client) FetchTokenMarketValues(symbols []string, currency string) (map[
 		return nil, err
 	}
 
-	marketValues, err := c.FetchCoinsMarkets(context.Background(), maps.Values(mappedSymbols), currency)
+	marketValues, err := utils.ChunkArrayFetcher[GeckoMarketValues](
+		context.Background(),
+		maps.Values(mappedSymbols),
+		tokensChunkLimit,
+		requestDelay,
+		func(ctx context.Context, chunkIds []string) ([]GeckoMarketValues, error) {
+			return c.FetchCoinsMarkets(ctx, chunkIds, currency)
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +295,15 @@ func (c *Client) FetchTokenMarketValues(symbols []string, currency string) (map[
 }
 
 func (c *Client) FetchHistoricalHourlyPrices(symbol string, currency string, limit int, aggregate int) ([]thirdparty.HistoricalPrice, error) {
-	return []thirdparty.HistoricalPrice{}, nil
+	days := (limit + 23) / 24 // round up
+	if days == 0 {
+		days = 1 // minimum 1 day
+	}
+	if days > 90 {
+		days = 90 // maximum 90 days
+	}
+
+	return c.FetchHistoricalDailyPrices(symbol, currency, days, false, aggregate)
 }
 
 func (c *Client) FetchHistoricalDailyPrices(symbol string, currency string, limit int, allData bool, aggregate int) ([]thirdparty.HistoricalPrice, error) {
@@ -260,7 +317,14 @@ func (c *Client) FetchHistoricalDailyPrices(symbol string, currency string, limi
 		return nil, err
 	}
 
-	container, err := c.FetchHistoryMarketData(context.Background(), id, currency)
+	var days string
+	if allData {
+		days = "max"
+	} else {
+		days = fmt.Sprintf("%d", limit)
+	}
+
+	container, err := c.FetchHistoryMarketData(context.Background(), id, currency, days)
 	if err != nil {
 		return nil, err
 	}
@@ -274,4 +338,12 @@ func (c *Client) FetchHistoricalDailyPrices(symbol string, currency string, limi
 	}
 
 	return result, nil
+}
+
+// doGetRequestWithOptionalAuth performs a GET request, using credentials if they are available
+func (c *Client) doGetRequestWithOptionalAuth(ctx context.Context, url string, params url.Values) ([]byte, error) {
+	if c.creds != nil {
+		return c.httpClient.DoGetRequestWithCredentials(ctx, url, params, c.creds)
+	}
+	return c.httpClient.DoGetRequest(ctx, url, params)
 }

--- a/services/wallet/thirdparty/market/coingecko/request_asset_platforms.go
+++ b/services/wallet/thirdparty/market/coingecko/request_asset_platforms.go
@@ -20,7 +20,7 @@ func (c *Client) FetchPlatforms(ctx context.Context) ([]Chain, error) {
 
 	params := netUrl.Values{}
 	url := fmt.Sprintf(platformsURL, c.baseURL)
-	response, err := c.httpClient.DoGetRequest(ctx, url, params)
+	response, err := c.doGetRequestWithOptionalAuth(ctx, url, params)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/thirdparty/market/coingecko/request_coin_market_chart.go
+++ b/services/wallet/thirdparty/market/coingecko/request_coin_market_chart.go
@@ -13,13 +13,16 @@ type HistoricalPriceContainer struct {
 	Prices [][]float64 `json:"prices"`
 }
 
-func (c *Client) FetchHistoryMarketData(ctx context.Context, id string, currency string) (HistoricalPriceContainer, error) {
+func (c *Client) FetchHistoryMarketData(ctx context.Context, id string, currency string, days string) (HistoricalPriceContainer, error) {
+	if days == "" {
+		days = "30"
+	}
 
 	params := netUrl.Values{}
 	params.Add("vs_currency", currency)
-	params.Add("days", "30")
+	params.Add("days", days)
 	url := fmt.Sprintf(coinMarketChartURL, c.baseURL, id)
-	response, err := c.httpClient.DoGetRequest(ctx, url, params)
+	response, err := c.doGetRequestWithOptionalAuth(ctx, url, params)
 	if err != nil {
 		return HistoricalPriceContainer{}, err
 	}

--- a/services/wallet/thirdparty/market/coingecko/request_coin_market_chart_test.go
+++ b/services/wallet/thirdparty/market/coingecko/request_coin_market_chart_test.go
@@ -34,7 +34,7 @@ func TestFetchHistoryMarketData(t *testing.T) {
 		baseURL:    srv.URL,
 	}
 
-	received, err := geckoClient.FetchHistoryMarketData(context.Background(), "status", "usd")
+	received, err := geckoClient.FetchHistoryMarketData(context.Background(), "status", "usd", "30")
 	require.NoError(t, err)
 	require.True(t, reflect.DeepEqual(expectedData, received))
 }
@@ -48,7 +48,7 @@ func TestErrorWhenFetchingHistoryMarketData(t *testing.T) {
 		baseURL:    srv.URL,
 	}
 
-	received, err := geckoClient.FetchHistoryMarketData(context.Background(), "status", "usd")
+	received, err := geckoClient.FetchHistoryMarketData(context.Background(), "status", "usd", "30")
 	require.Error(t, err)
 	require.Len(t, received.Prices, 0)
 }

--- a/services/wallet/thirdparty/market/coingecko/request_coins_list.go
+++ b/services/wallet/thirdparty/market/coingecko/request_coins_list.go
@@ -52,7 +52,7 @@ func (c *Client) FetchTokens(ctx context.Context) ([]GeckoToken, error) {
 	params := netUrl.Values{}
 	params.Add("include_platform", "true")
 	url := fmt.Sprintf(coinsListURL, c.baseURL)
-	response, err := c.httpClient.DoGetRequest(ctx, url, params)
+	response, err := c.doGetRequestWithOptionalAuth(ctx, url, params)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/thirdparty/market/coingecko/request_coins_markets.go
+++ b/services/wallet/thirdparty/market/coingecko/request_coins_markets.go
@@ -33,7 +33,7 @@ func (c *Client) FetchCoinsMarkets(ctx context.Context, ids []string, currency s
 	params.Add("sparkline", "false")
 	params.Add("price_change_percentage", "1h,24h")
 	url := fmt.Sprintf(coinsMarketsURL, c.baseURL)
-	response, err := c.httpClient.DoGetRequest(ctx, url, params)
+	response, err := c.doGetRequestWithOptionalAuth(ctx, url, params)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/thirdparty/market/coingecko/request_simple_price.go
+++ b/services/wallet/thirdparty/market/coingecko/request_simple_price.go
@@ -10,8 +10,10 @@ import (
 
 const simplePriceURL = "%s/simple/price"
 
+type CurrencyPriceMap map[string]float64
+
 // SymbolPriceMap represents a map of symbols with price per currency for each.
-type SymbolPriceMap map[string]map[string]float64
+type SymbolPriceMap map[string]CurrencyPriceMap
 
 func (c *Client) FetchSimplePrice(ctx context.Context, ids []string, currencies []string) (SymbolPriceMap, error) {
 
@@ -19,7 +21,7 @@ func (c *Client) FetchSimplePrice(ctx context.Context, ids []string, currencies 
 	params.Add("ids", strings.Join(ids, ","))
 	params.Add("vs_currencies", strings.Join(currencies, ","))
 	url := fmt.Sprintf(simplePriceURL, c.baseURL)
-	response, err := c.httpClient.DoGetRequest(ctx, url, params)
+	response, err := c.doGetRequestWithOptionalAuth(ctx, url, params)
 	if err != nil {
 		return nil, err
 	}

--- a/services/wallet/thirdparty/utils/chunk_fetcher.go
+++ b/services/wallet/thirdparty/utils/chunk_fetcher.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+)
+
+const PerChunkLimit = 100
+
+func processInChunks[T any](
+	ctx context.Context,
+	items []string,
+	chunkLimit int,
+	delay time.Duration,
+	fetchFunc func(context.Context, []string) (T, error),
+) ([]T, error) {
+	if len(items) == 0 || chunkLimit <= 0 {
+		return make([]T, 0), nil
+	}
+
+	var results []T
+	isFirst := true
+
+	for chunk := range slices.Chunk(items, chunkLimit) {
+		if delay > 0 && !isFirst {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		isFirst = false
+
+		chunkResult, err := fetchFunc(ctx, chunk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch chunk: %w", err)
+		}
+
+		results = append(results, chunkResult)
+	}
+
+	return results, nil
+}
+
+func ChunkMapFetcher[T any](
+	ctx context.Context,
+	items []string,
+	chunkLimit int,
+	delay time.Duration,
+	fetchFunc func(context.Context, []string) (map[string]T, error),
+) (map[string]T, error) {
+	chunkResults, err := processInChunks(ctx, items, chunkLimit, delay, fetchFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]T)
+	for _, chunkResult := range chunkResults {
+		for k, v := range chunkResult {
+			result[k] = v
+		}
+	}
+
+	return result, nil
+}
+
+func ChunkArrayFetcher[T any](
+	ctx context.Context,
+	items []string,
+	chunkLimit int,
+	delay time.Duration,
+	fetchFunc func(context.Context, []string) ([]T, error),
+) ([]T, error) {
+	chunkResults, err := processInChunks(ctx, items, chunkLimit, delay, fetchFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []T
+	for _, chunkResult := range chunkResults {
+		result = append(result, chunkResult...)
+	}
+
+	return result, nil
+}

--- a/services/wallet/thirdparty/utils/chunk_fetcher_test.go
+++ b/services/wallet/thirdparty/utils/chunk_fetcher_test.go
@@ -1,0 +1,207 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestChunkMapFetcher(t *testing.T) {
+	tests := []struct {
+		name        string
+		items       []string
+		chunkLimit  int
+		fetchFunc   func(context.Context, []string) (map[string]int, error)
+		expected    map[string]int
+		expectedErr bool
+	}{
+		{
+			name:       "empty items",
+			items:      []string{},
+			chunkLimit: 2,
+			fetchFunc: func(ctx context.Context, chunk []string) (map[string]int, error) {
+				result := make(map[string]int)
+				for i, item := range chunk {
+					result[item] = i
+				}
+				return result, nil
+			},
+			expected:    map[string]int{},
+			expectedErr: false,
+		},
+		{
+			name:       "single chunk",
+			items:      []string{"a", "b"},
+			chunkLimit: 5,
+			fetchFunc: func(ctx context.Context, chunk []string) (map[string]int, error) {
+				result := make(map[string]int)
+				for i, item := range chunk {
+					result[item] = i
+				}
+				return result, nil
+			},
+			expected:    map[string]int{"a": 0, "b": 1},
+			expectedErr: false,
+		},
+		{
+			name:       "multiple chunks",
+			items:      []string{"a", "b", "c", "d", "e"},
+			chunkLimit: 2,
+			fetchFunc: func(ctx context.Context, chunk []string) (map[string]int, error) {
+				result := make(map[string]int)
+				for _, item := range chunk {
+					result[item] = len(item)
+				}
+				return result, nil
+			},
+			expected:    map[string]int{"a": 1, "b": 1, "c": 1, "d": 1, "e": 1},
+			expectedErr: false,
+		},
+		{
+			name:       "error in fetch function",
+			items:      []string{"a", "b", "c"},
+			chunkLimit: 2,
+			fetchFunc: func(ctx context.Context, chunk []string) (map[string]int, error) {
+				return nil, errors.New("fetch error")
+			},
+			expected:    nil,
+			expectedErr: true,
+		},
+		{
+			name:       "zero chunk limit returns empty",
+			items:      []string{"a", "b"},
+			chunkLimit: 0,
+			fetchFunc: func(ctx context.Context, chunk []string) (map[string]int, error) {
+				result := make(map[string]int)
+				for i, item := range chunk {
+					result[item] = i
+				}
+				return result, nil
+			},
+			expected:    map[string]int{},
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ChunkMapFetcher[int](
+				context.Background(),
+				tt.items,
+				tt.chunkLimit,
+				0,
+				tt.fetchFunc,
+			)
+
+			if tt.expectedErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestChunkArrayFetcher(t *testing.T) {
+	tests := []struct {
+		name        string
+		items       []string
+		chunkLimit  int
+		fetchFunc   func(context.Context, []string) ([]string, error)
+		expected    []string
+		expectedErr bool
+	}{
+		{
+			name:       "empty items",
+			items:      []string{},
+			chunkLimit: 2,
+			fetchFunc: func(ctx context.Context, chunk []string) ([]string, error) {
+				return chunk, nil
+			},
+			expected:    []string{},
+			expectedErr: false,
+		},
+		{
+			name:       "single chunk",
+			items:      []string{"a", "b"},
+			chunkLimit: 5,
+			fetchFunc: func(ctx context.Context, chunk []string) ([]string, error) {
+				result := make([]string, len(chunk))
+				for i, item := range chunk {
+					result[i] = fmt.Sprintf("%s_processed", item)
+				}
+				return result, nil
+			},
+			expected:    []string{"a_processed", "b_processed"},
+			expectedErr: false,
+		},
+		{
+			name:       "multiple chunks",
+			items:      []string{"a", "b", "c", "d", "e"},
+			chunkLimit: 2,
+			fetchFunc: func(ctx context.Context, chunk []string) ([]string, error) {
+				result := make([]string, 0, len(chunk)*2)
+				for _, item := range chunk {
+					result = append(result, item, item+"_copy")
+				}
+				return result, nil
+			},
+			expected:    []string{"a", "a_copy", "b", "b_copy", "c", "c_copy", "d", "d_copy", "e", "e_copy"},
+			expectedErr: false,
+		},
+		{
+			name:       "error in fetch function",
+			items:      []string{"a", "b", "c"},
+			chunkLimit: 2,
+			fetchFunc: func(ctx context.Context, chunk []string) ([]string, error) {
+				return nil, errors.New("fetch error")
+			},
+			expected:    nil,
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ChunkArrayFetcher[string](
+				context.Background(),
+				tt.items,
+				tt.chunkLimit,
+				0,
+				tt.fetchFunc,
+			)
+
+			if tt.expectedErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(tt.expected) == 0 && len(result) == 0 {
+				return
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/tests-functional/tests/test_router.py
+++ b/tests-functional/tests/test_router.py
@@ -21,7 +21,6 @@ class TestRouter(StatusBackendSteps):
         SignalType.WALLET_ROUTER_TRANSACTIONS_SENT.value,
     ]
 
-    @pytest.mark.skip("cryptocompare limit reached")
     def test_tx_from_route(self):
         uuid = str(uuid_lib.uuid4())
         amount_in = "0xde0b6b3a7640000"
@@ -55,7 +54,6 @@ class TestRouter(StatusBackendSteps):
         tx_status = wallet_utils.send_router_transactions_with_signatures(self.rpc_client, uuid, tx_signatures)
         wallet_utils.check_tx_details(self.rpc_client, tx_status["hash"], self.network_id, constants.user_2.address, amount_in)
 
-    @pytest.mark.skip("cryptocompare limit reached")
     def test_setting_different_fee_modes(self):
         uuid = str(uuid_lib.uuid4())
         gas_fee_mode = constants.gas_fee_mode_medium
@@ -122,7 +120,6 @@ class TestRouter(StatusBackendSteps):
         response = self.rpc_client.rpc_request(method, [tx_identity_params, gas_fee_mode])
         self.rpc_client.verify_is_json_rpc_error(response)
 
-    @pytest.mark.skip("cryptocompare limit reached")
     def test_setting_custom_fee_mode(self):
         uuid = str(uuid_lib.uuid4())
         gas_fee_mode = constants.gas_fee_mode_medium

--- a/tests-functional/tests/test_wallet_activity_session.py
+++ b/tests-functional/tests/test_wallet_activity_session.py
@@ -36,7 +36,6 @@ class TestWalletActivitySession(WalletSteps):
         self.request_id = str(random.randint(1, 8888))
         self.mint_snt(user_1.address, 1000000000000000000000000)
 
-    @pytest.mark.skip("cryptocompare limit reached")
     def test_wallet_start_activity_filter_session(self):
         uuid = str(uuid_lib.uuid4())
         amount_in = "0xde0b6b3a7640000"

--- a/tests-functional/tests/test_wallet_assets.py
+++ b/tests-functional/tests/test_wallet_assets.py
@@ -26,7 +26,6 @@ class TestWalletAssets(StatusBackendSteps):
         super().setup_class(skip_login)
         cls.wallet_service.start_wallet()
 
-    @pytest.mark.skip("cryptocompare limit reached")
     def test_balance_refresh_ticker_after_sending_transaction(self):
         uuid = str(uuid_lib.uuid4())
         amount_in = "0xde0b6b3a7640000"


### PR DESCRIPTION
fixes #6740

Add the market.status.im market data provider.

* Use the same method to get the market URL as in the leaderboard package.
* Fix the `allData`, `limit` flags.
* Fix `FetchHistoricalHourlyPrices` method.
* Providers order: `cryptoCompare, coingeckoClient, coingeckoProxy, cryptoCompareProxy`.
* Add `chunk_fetcher` to split the requests for simple/price and tokens details into chunks (500 and 250)