### PR TITLE
chore_: add emit-time timestamp to signal event

### DIFF
--- a/signal/signals.go
+++ b/signal/signals.go
@@ -10,6 +10,7 @@ extern void SetEventCallback(void *cb);
 import "C"
 import (
 	"encoding/json"
+	"time"
 	"unsafe"
 
 	"sync"
@@ -32,15 +33,17 @@ var logger = logutils.ZapLogger().Named("signal")
 
 // Envelope is a general signal sent upward from node to RN app
 type Envelope struct {
-	Type  string      `json:"type"`
-	Event interface{} `json:"event"`
+	Type      string      `json:"type"`
+	Event     interface{} `json:"event"`
+	Timestamp int64       `json:"timestamp"`
 }
 
 // NewEnvelope creates new envlope of given type and event payload.
 func NewEnvelope(typ string, event interface{}) *Envelope {
 	return &Envelope{
-		Type:  typ,
-		Event: event,
+		Type:      typ,
+		Event:     event,
+		Timestamp: time.Now().Unix(),
 	}
 }
 

--- a/tests-functional/schemas/signal_mediaserver_started
+++ b/tests-functional/schemas/signal_mediaserver_started
@@ -15,10 +15,19 @@
           "maximum": 65535
         }
       },
-      "required": ["port"],
+      "required": [
+        "port"
+      ],
       "additionalProperties": false
+    },
+    "timestamp": {
+      "type": "integer",
+      "description": "Unix timestamp of event emit-time"
     }
   },
-  "required": ["type", "event"],
+  "required": [
+    "type",
+    "event"
+  ],
   "additionalProperties": false
 }

--- a/tests-functional/schemas/signal_node_login
+++ b/tests-functional/schemas/signal_node_login
@@ -12,105 +12,265 @@
         "settings": {
           "type": "object",
           "properties": {
-            "address": { "type": "string" },
-            "currency": { "type": "string" },
-            "networks/current-network": { "type": "string" },
-            "dapps-address": { "type": "string" },
-            "device-name": { "type": "string" },
-            "display-name": { "type": "string" },
-            "eip1581-address": { "type": "string" },
-            "installation-id": { "type": "string" },
-            "key-uid": { "type": "string" },
-            "latest-derived-path": { "type": "integer" },
-            "link-preview-request-enabled": { "type": "boolean" },
-            "messages-from-contacts-only": { "type": "boolean" },
-            "mnemonic": { "type": "string" },
-            "mutual-contact-enabled?": { "type": "boolean" },
-            "name": { "type": "string" },
-            "networks/networks": { "type": "array" },
-            "photo-path": { "type": "string" },
-            "preview-privacy?": { "type": "boolean" },
-            "public-key": { "type": "string" },
-            "signing-phrase": { "type": "string" },
-            "default-sync-period": { "type": "integer" },
-            "send-push-notifications?": { "type": "boolean" },
-            "appearance": { "type": "integer" },
-            "profile-pictures-show-to": { "type": "integer" },
-            "profile-pictures-visibility": { "type": "integer" },
-            "use-mailservers?": { "type": "boolean" },
-            "wallet-root-address": { "type": "string" },
-            "send-status-updates?": { "type": "boolean" },
+            "address": {
+              "type": "string"
+            },
+            "currency": {
+              "type": "string"
+            },
+            "networks/current-network": {
+              "type": "string"
+            },
+            "dapps-address": {
+              "type": "string"
+            },
+            "device-name": {
+              "type": "string"
+            },
+            "display-name": {
+              "type": "string"
+            },
+            "eip1581-address": {
+              "type": "string"
+            },
+            "installation-id": {
+              "type": "string"
+            },
+            "key-uid": {
+              "type": "string"
+            },
+            "latest-derived-path": {
+              "type": "integer"
+            },
+            "link-preview-request-enabled": {
+              "type": "boolean"
+            },
+            "messages-from-contacts-only": {
+              "type": "boolean"
+            },
+            "mnemonic": {
+              "type": "string"
+            },
+            "mutual-contact-enabled?": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "networks/networks": {
+              "type": "array"
+            },
+            "photo-path": {
+              "type": "string"
+            },
+            "preview-privacy?": {
+              "type": "boolean"
+            },
+            "public-key": {
+              "type": "string"
+            },
+            "signing-phrase": {
+              "type": "string"
+            },
+            "default-sync-period": {
+              "type": "integer"
+            },
+            "send-push-notifications?": {
+              "type": "boolean"
+            },
+            "appearance": {
+              "type": "integer"
+            },
+            "profile-pictures-show-to": {
+              "type": "integer"
+            },
+            "profile-pictures-visibility": {
+              "type": "integer"
+            },
+            "use-mailservers?": {
+              "type": "boolean"
+            },
+            "wallet-root-address": {
+              "type": "string"
+            },
+            "send-status-updates?": {
+              "type": "boolean"
+            },
             "current-user-status": {
               "type": "object",
               "properties": {
-                "publicKey": { "type": "string" },
-                "statusType": { "type": "integer" },
-                "clock": { "type": "integer" },
-                "text": { "type": "string" }
+                "publicKey": {
+                  "type": "string"
+                },
+                "statusType": {
+                  "type": "integer"
+                },
+                "clock": {
+                  "type": "integer"
+                },
+                "text": {
+                  "type": "string"
+                }
               },
-              "required": ["publicKey", "statusType", "clock", "text"]
+              "required": [
+                "publicKey",
+                "statusType",
+                "clock",
+                "text"
+              ]
             },
-            "gifs/recent-gifs": { "type": ["null", "array"] },
-            "gifs/favorite-gifs": { "type": ["null", "array"] },
-            "last-backup": { "type": "integer" },
-            "backup-enabled?": { "type": "boolean" },
-            "gifs/api-key": { "type": "string" },
-            "show-community-asset-when-sending-tokens?": { "type": "boolean" },
-            "display-assets-below-balance-threshold": { "type": "integer" },
-            "url-unfurling-mode": { "type": "integer" },
-            "compressedKey": { "type": "string" },
+            "gifs/recent-gifs": {
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "gifs/favorite-gifs": {
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "last-backup": {
+              "type": "integer"
+            },
+            "backup-enabled?": {
+              "type": "boolean"
+            },
+            "gifs/api-key": {
+              "type": "string"
+            },
+            "show-community-asset-when-sending-tokens?": {
+              "type": "boolean"
+            },
+            "display-assets-below-balance-threshold": {
+              "type": "integer"
+            },
+            "url-unfurling-mode": {
+              "type": "integer"
+            },
+            "compressedKey": {
+              "type": "string"
+            },
             "emojiHash": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             }
           },
           "required": [
-            "address", "currency", "networks/current-network", "dapps-address",
-            "device-name", "display-name", "eip1581-address", "installation-id",
-            "key-uid", "latest-derived-path", "link-preview-request-enabled",
-            "messages-from-contacts-only", "mutual-contact-enabled?",
-            "name", "networks/networks", "photo-path", "preview-privacy?",
-            "public-key", "signing-phrase", "default-sync-period",
-            "send-push-notifications?", "appearance", "profile-pictures-show-to",
-            "profile-pictures-visibility", "use-mailservers?", "wallet-root-address",
-            "send-status-updates?", "current-user-status", "gifs/recent-gifs",
-            "gifs/favorite-gifs", "last-backup", "backup-enabled?", "gifs/api-key",
+            "address",
+            "currency",
+            "networks/current-network",
+            "dapps-address",
+            "device-name",
+            "display-name",
+            "eip1581-address",
+            "installation-id",
+            "key-uid",
+            "latest-derived-path",
+            "link-preview-request-enabled",
+            "messages-from-contacts-only",
+            "mutual-contact-enabled?",
+            "name",
+            "networks/networks",
+            "photo-path",
+            "preview-privacy?",
+            "public-key",
+            "signing-phrase",
+            "default-sync-period",
+            "send-push-notifications?",
+            "appearance",
+            "profile-pictures-show-to",
+            "profile-pictures-visibility",
+            "use-mailservers?",
+            "wallet-root-address",
+            "send-status-updates?",
+            "current-user-status",
+            "gifs/recent-gifs",
+            "gifs/favorite-gifs",
+            "last-backup",
+            "backup-enabled?",
+            "gifs/api-key",
             "show-community-asset-when-sending-tokens?",
-            "display-assets-below-balance-threshold", "url-unfurling-mode",
-            "compressedKey", "emojiHash"
+            "display-assets-below-balance-threshold",
+            "url-unfurling-mode",
+            "compressedKey",
+            "emojiHash"
           ]
         },
         "account": {
           "type": "object",
           "properties": {
-            "name": { "type": "string" },
-            "timestamp": { "type": "integer" },
-            "identicon": { "type": "string" },
+            "name": {
+              "type": "string"
+            },
+            "timestamp": {
+              "type": "integer"
+            },
+            "identicon": {
+              "type": "string"
+            },
             "colorHash": {
               "type": "array",
               "items": {
                 "type": "array",
-                "items": { "type": "integer" },
+                "items": {
+                  "type": "integer"
+                },
                 "minItems": 2,
                 "maxItems": 2
               }
             },
-            "colorId": { "type": "integer" },
-            "customizationColor": { "type": "string" },
-            "keycard-pairing": { "type": "string" },
-            "key-uid": { "type": "string" },
-            "images": { "type": ["null", "array"] },
-            "kdfIterations": { "type": "integer" }
+            "colorId": {
+              "type": "integer"
+            },
+            "customizationColor": {
+              "type": "string"
+            },
+            "keycard-pairing": {
+              "type": "string"
+            },
+            "key-uid": {
+              "type": "string"
+            },
+            "images": {
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "kdfIterations": {
+              "type": "integer"
+            }
           },
           "required": [
-            "name", "timestamp", "identicon", "colorHash", "colorId",
-            "customizationColor", "keycard-pairing", "key-uid", "images",
+            "name",
+            "timestamp",
+            "identicon",
+            "colorHash",
+            "colorId",
+            "customizationColor",
+            "keycard-pairing",
+            "key-uid",
+            "images",
             "kdfIterations"
           ]
         }
       },
-      "required": ["settings", "account"]
+      "required": [
+        "settings",
+        "account"
+      ]
+    },
+    "timestamp": {
+      "type": "integer",
+      "description": "Unix timestamp of event emit-time"
     }
   },
-  "required": ["type", "event"]
+  "required": [
+    "type",
+    "event"
+  ]
 }

--- a/tests-functional/schemas/signal_node_ready
+++ b/tests-functional/schemas/signal_node_ready
@@ -1,5 +1,5 @@
 {
-   "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "type": "object",
     "properties": {
         "type": {
@@ -8,8 +8,15 @@
         },
         "event": {
             "type": "null"
+        },
+        "timestamp": {
+            "type": "integer",
+            "description": "Unix timestamp of event emit-time"
         }
     },
-    "required": ["type", "event"],
+    "required": [
+        "type",
+        "event"
+    ],
     "additionalProperties": false
 }

--- a/tests-functional/schemas/signal_node_started
+++ b/tests-functional/schemas/signal_node_started
@@ -8,8 +8,15 @@
         },
         "event": {
             "type": "null"
+        },
+        "timestamp": {
+            "type": "integer",
+            "description": "Unix timestamp of event emit-time"
         }
     },
-    "required": ["type", "event"],
+    "required": [
+        "type",
+        "event"
+    ],
     "additionalProperties": false
 }


### PR DESCRIPTION
Required for DST chat protocol benchmarks. There might be delays between when a signal is emitted and when it is received by the test instance due to network conditions. Adding the timestamp at emit time addresses this.
