### PR TITLE
chore!: remove deprecated networks connection status

### DIFF
--- a/healthmanager/aggregator/aggregator.go
+++ b/healthmanager/aggregator/aggregator.go
@@ -9,16 +9,19 @@ import (
 
 // Aggregator manages and aggregates the statuses of multiple providers.
 type Aggregator struct {
-	mu               sync.RWMutex
-	name             string
-	providerStatuses map[string]*rpcstatus.ProviderStatus
+	mu                          sync.RWMutex
+	name                        string
+	providerStatuses            map[string]*rpcstatus.ProviderStatus
+	lastAggregatedStatus        rpcstatus.ProviderStatus
+	isLastAggregatedStatusDirty bool
 }
 
 // NewAggregator creates a new instance of Aggregator with the given name.
 func NewAggregator(name string) *Aggregator {
 	return &Aggregator{
-		name:             name,
-		providerStatuses: make(map[string]*rpcstatus.ProviderStatus),
+		name:                        name,
+		providerStatuses:            make(map[string]*rpcstatus.ProviderStatus),
+		isLastAggregatedStatusDirty: true,
 	}
 }
 
@@ -37,6 +40,7 @@ func (a *Aggregator) RegisterProvider(providerName string) {
 			TotalErrorCount:   0,
 		}
 	}
+	a.isLastAggregatedStatusDirty = true
 }
 
 // Update modifies the status of a specific provider.
@@ -73,6 +77,7 @@ func (a *Aggregator) Update(providerStatus rpcstatus.ProviderStatus) {
 			TotalErrorCount:   providerStatus.TotalErrorCount,
 		}
 	}
+	a.isLastAggregatedStatusDirty = true
 }
 
 // UpdateBatch processes a batch of provider statuses.
@@ -90,6 +95,10 @@ func (a *Aggregator) UpdateBatch(statuses []rpcstatus.ProviderStatus) {
 func (a *Aggregator) ComputeAggregatedStatus() rpcstatus.ProviderStatus {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
+
+	if !a.isLastAggregatedStatusDirty {
+		return a.lastAggregatedStatus
+	}
 
 	var lastSuccessAt, lastErrorAt time.Time
 	var lastError error
@@ -142,6 +151,9 @@ func (a *Aggregator) ComputeAggregatedStatus() rpcstatus.ProviderStatus {
 	} else {
 		aggregatedStatus.Status = rpcstatus.StatusDown
 	}
+
+	a.lastAggregatedStatus = aggregatedStatus
+	a.isLastAggregatedStatusDirty = false
 
 	return aggregatedStatus
 }

--- a/healthmanager/rpcstatus/provider_status.go
+++ b/healthmanager/rpcstatus/provider_status.go
@@ -19,8 +19,8 @@ const (
 // ProviderStatus holds the status information for a single provider.
 type ProviderStatus struct {
 	Name              string        `json:"name"`
-	LastSuccessAt     time.Time     `json:"last_success_at"`
-	LastErrorAt       time.Time     `json:"last_error_at"`
+	LastSuccessAt     time.Time     `json:"-"` // ignore this field during standard marshaling
+	LastErrorAt       time.Time     `json:"-"` // ignore this field during standard marshaling
 	LastError         error         `json:"-"` // ignore this field during standard marshaling
 	Status            StatusType    `json:"status"`
 	TotalDuration     time.Duration `json:"-"` // ignore this field during standard marshaling
@@ -36,10 +36,14 @@ func (ps ProviderStatus) MarshalJSON() ([]byte, error) {
 	// Create a new struct for JSON marshaling
 	return json.Marshal(&struct {
 		Alias
+		LastSuccessAt   int64  `json:"last_success_at"`
+		LastErrorAt     int64  `json:"last_error_at"`
 		LastError       string `json:"last_error,omitempty"`
 		TotalDurationMs int64  `json:"total_duration_ms"` // Include duration as milliseconds
 	}{
-		Alias: Alias(ps),
+		Alias:         Alias(ps),
+		LastSuccessAt: ps.LastSuccessAt.Unix(),
+		LastErrorAt:   ps.LastErrorAt.Unix(),
 		LastError: func() string {
 			if ps.LastError != nil {
 				return ps.LastError.Error()

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -256,7 +256,6 @@ func (n *StatusNode) setupRPCClient() (err error) {
 		Networks:          n.config.Networks,
 		DB:                n.appDB,
 		AccountsPublisher: n.accountsPublisher,
-		WalletFeed:        &n.walletFeed,
 	}
 	n.rpcClient, err = rpc.NewClient(config)
 	if err != nil {

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -187,7 +187,7 @@ func (b *StatusNode) WakuV2ExtService() *wakuv2ext.Service {
 
 func (b *StatusNode) connectorService() *connector.Service {
 	if b.connectorSrvc == nil {
-		b.connectorSrvc = connector.NewService(b.walletDB, b.rpcClient, b.rpcClient.NetworkManager)
+		b.connectorSrvc = connector.NewService(b.walletDB, b.rpcClient, b.rpcClient.GetNetworkManager())
 	}
 	return b.connectorSrvc
 }

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -424,8 +424,8 @@ func NewMessenger(
 	if c.tokenManager != nil {
 		managerOptions = append(managerOptions, communities.WithTokenManager(c.tokenManager))
 	} else if c.rpcClient != nil {
-		tokenManager := token.NewTokenManager(c.walletDb, c.rpcClient, community.NewManager(database, c.httpServer, nil), c.rpcClient.NetworkManager, database, c.httpServer, nil, nil, nil, token.NewPersistence(c.walletDb))
-		managerOptions = append(managerOptions, communities.WithTokenManager(communities.NewDefaultTokenManager(tokenManager, c.rpcClient.NetworkManager)))
+		tokenManager := token.NewTokenManager(c.walletDb, c.rpcClient, community.NewManager(database, c.httpServer, nil), c.rpcClient.GetNetworkManager(), database, c.httpServer, nil, nil, nil, token.NewPersistence(c.walletDb))
+		managerOptions = append(managerOptions, communities.WithTokenManager(communities.NewDefaultTokenManager(tokenManager, c.rpcClient.GetNetworkManager())))
 	}
 
 	if c.communityTokensService != nil {

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -10,9 +10,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
-
-	"go.uber.org/zap"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -26,7 +23,6 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/healthmanager"
 	"github.com/status-im/status-go/healthmanager/rpcstatus"
-	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/rpc/chain/ethclient"
 	"github.com/status-im/status-go/rpc/chain/rpclimiter"
 	"github.com/status-im/status-go/rpc/chain/tagger"
@@ -39,8 +35,6 @@ type ClientInterface interface {
 	ethclient.EthClientInterface
 	NetworkID() uint64
 	ToBigInt() *big.Int
-	GetWalletNotifier() func(chainId uint64, message string)
-	SetWalletNotifier(notifier func(chainId uint64, message string))
 	connection.Connectable
 	GetLimiter() rpclimiter.RequestLimiter
 	SetLimiter(rpclimiter.RequestLimiter)
@@ -77,11 +71,6 @@ type ClientWithFallback struct {
 	circuitbreaker         *circuitbreaker.CircuitBreaker
 	providersHealthManager *healthmanager.ProvidersHealthManager
 
-	WalletNotifier func(chainId uint64, message string)
-
-	isConnected   *atomic.Bool
-	LastCheckedAt int64
-
 	tag      string // tag for the limiter
 	groupTag string // tag for the limiter group
 
@@ -103,9 +92,6 @@ func (c *ClientWithFallback) createCopy() *ClientWithFallback {
 		commonLimiter:          c.commonLimiter,
 		circuitbreaker:         c.circuitbreaker,
 		providersHealthManager: c.providersHealthManager,
-		WalletNotifier:         c.WalletNotifier,
-		isConnected:            c.isConnected,
-		LastCheckedAt:          c.LastCheckedAt,
 		tag:                    c.tag,
 		groupTag:               c.groupTag,
 		done:                   make(chan struct{}),
@@ -145,14 +131,9 @@ func NewClient(ethClients []ethclient.RPSLimitedEthClientInterface, chainID uint
 		ErrorPercentThreshold: 25,
 	}
 
-	isConnected := &atomic.Bool{}
-	isConnected.Store(true)
-
 	return &ClientWithFallback{
 		ChainID:                chainID,
 		ethClients:             ethClients,
-		isConnected:            isConnected,
-		LastCheckedAt:          time.Now().Unix(),
 		circuitbreaker:         circuitbreaker.NewCircuitBreaker(cbConfig),
 		providersHealthManager: providersHealthManager,
 		done:                   make(chan struct{}),
@@ -175,13 +156,6 @@ func (c *ClientWithFallback) Close() {
 	}
 }
 
-// Not found should not be cancelling the requests, as that's returned
-// when we are hitting a non-archival node for example, it should continue the
-// chain as the next provider might have archival support.
-func isNotFoundError(err error) bool {
-	return strings.Contains(err.Error(), ethereum.NotFound.Error())
-}
-
 func isVMError(err error) bool {
 	if strings.Contains(err.Error(), core.ErrInsufficientFunds.Error()) {
 		return true
@@ -194,31 +168,12 @@ func isVMError(err error) bool {
 	return false
 }
 
-func (c *ClientWithFallback) SetIsConnected(value bool) {
-	c.LastCheckedAt = time.Now().Unix()
-	if !value {
-		if c.isConnected.Load() {
-			if c.WalletNotifier != nil {
-				c.WalletNotifier(c.ChainID, "down")
-			}
-			c.isConnected.Store(false)
-		}
-
-	} else {
-		if !c.isConnected.Load() {
-			c.isConnected.Store(true)
-			if c.WalletNotifier != nil {
-				c.WalletNotifier(c.ChainID, "up")
-			}
-		}
-	}
-}
-
 func (c *ClientWithFallback) IsConnected() bool {
-	return c.isConnected.Load()
+	return c.providersHealthManager.Status().Status == rpcstatus.StatusUp
 }
 
 func (c *ClientWithFallback) makeCall(ctx context.Context, f MakeCallFunctor) (interface{}, error) {
+	rpcstats.CountCall(f.MethodName)
 	if c.closed.Load() {
 		return nil, errors.New("client is closed")
 	}
@@ -250,8 +205,6 @@ func (c *ClientWithFallback) makeCall(ctx context.Context, f MakeCallFunctor) (i
 			return nil, fmt.Errorf("groupTag=%s, %w", c.groupTag, err)
 		}
 	}
-
-	c.LastCheckedAt = time.Now().Unix()
 
 	cmd := circuitbreaker.NewCommand(ctx, nil)
 	// Try making requests with each RPC provider.
@@ -287,15 +240,8 @@ type MakeCallFunctor struct {
 	Func       func(client ethclient.EthClientInterface) (interface{}, error)
 }
 
-func (c *ClientWithFallback) makeCallAndToggleConnectionState(ctx context.Context, f MakeCallFunctor) (interface{}, error) {
-	rpcstats.CountCall(f.MethodName)
-	res, err := c.makeCall(ctx, f)
-	c.toggleConnectionState(err)
-	return res, err
-}
-
 func (c *ClientWithFallback) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_BlockByHash",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -311,7 +257,7 @@ func (c *ClientWithFallback) BlockByHash(ctx context.Context, hash common.Hash) 
 }
 
 func (c *ClientWithFallback) BlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_BlockByNumber",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -327,7 +273,7 @@ func (c *ClientWithFallback) BlockByNumber(ctx context.Context, number *big.Int)
 }
 
 func (c *ClientWithFallback) BlockNumber(ctx context.Context) (uint64, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_BlockNumber",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -343,7 +289,7 @@ func (c *ClientWithFallback) BlockNumber(ctx context.Context) (uint64, error) {
 }
 
 func (c *ClientWithFallback) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_HeaderByHash",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -359,7 +305,7 @@ func (c *ClientWithFallback) HeaderByHash(ctx context.Context, hash common.Hash)
 }
 
 func (c *ClientWithFallback) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_HeaderByNumber",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -375,7 +321,7 @@ func (c *ClientWithFallback) HeaderByNumber(ctx context.Context, number *big.Int
 }
 
 func (c *ClientWithFallback) TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_TransactionByHash",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -393,7 +339,7 @@ func (c *ClientWithFallback) TransactionByHash(ctx context.Context, hash common.
 }
 
 func (c *ClientWithFallback) TransactionSender(ctx context.Context, tx *types.Transaction, block common.Hash, index uint) (common.Address, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_TransactionSender",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -409,7 +355,7 @@ func (c *ClientWithFallback) TransactionSender(ctx context.Context, tx *types.Tr
 }
 
 func (c *ClientWithFallback) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_TransactionReceipt",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -425,7 +371,7 @@ func (c *ClientWithFallback) TransactionReceipt(ctx context.Context, txHash comm
 }
 
 func (c *ClientWithFallback) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_SyncProgress",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -445,7 +391,7 @@ func (c *ClientWithFallback) NetworkID() uint64 {
 }
 
 func (c *ClientWithFallback) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_BalanceAt",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -461,7 +407,7 @@ func (c *ClientWithFallback) BalanceAt(ctx context.Context, account common.Addre
 }
 
 func (c *ClientWithFallback) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_StorageAt",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -477,7 +423,7 @@ func (c *ClientWithFallback) StorageAt(ctx context.Context, account common.Addre
 }
 
 func (c *ClientWithFallback) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_CodeAt",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -493,7 +439,7 @@ func (c *ClientWithFallback) CodeAt(ctx context.Context, account common.Address,
 }
 
 func (c *ClientWithFallback) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_NonceAt",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -515,7 +461,7 @@ func (c *ClientWithFallback) FilterLogs(ctx context.Context, q ethereum.FilterQu
 		ethClients[i] = client.CopyWithCircuitName(client.GetCircuitName() + "_FilterLogs")
 	}
 
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_FilterLogs",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -535,7 +481,7 @@ func (c *ClientWithFallback) FilterLogs(ctx context.Context, q ethereum.FilterQu
 }
 
 func (c *ClientWithFallback) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_SubscribeFilterLogs",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -551,7 +497,7 @@ func (c *ClientWithFallback) SubscribeFilterLogs(ctx context.Context, q ethereum
 }
 
 func (c *ClientWithFallback) PendingBalanceAt(ctx context.Context, account common.Address) (*big.Int, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_PendingBalanceAt",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -567,7 +513,7 @@ func (c *ClientWithFallback) PendingBalanceAt(ctx context.Context, account commo
 }
 
 func (c *ClientWithFallback) PendingStorageAt(ctx context.Context, account common.Address, key common.Hash) ([]byte, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_PendingStorageAt",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -583,7 +529,7 @@ func (c *ClientWithFallback) PendingStorageAt(ctx context.Context, account commo
 }
 
 func (c *ClientWithFallback) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_PendingCodeAt",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -599,7 +545,7 @@ func (c *ClientWithFallback) PendingCodeAt(ctx context.Context, account common.A
 }
 
 func (c *ClientWithFallback) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_PendingNonceAt",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -615,7 +561,7 @@ func (c *ClientWithFallback) PendingNonceAt(ctx context.Context, account common.
 }
 
 func (c *ClientWithFallback) PendingTransactionCount(ctx context.Context) (uint, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_PendingTransactionCount",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -631,7 +577,7 @@ func (c *ClientWithFallback) PendingTransactionCount(ctx context.Context) (uint,
 }
 
 func (c *ClientWithFallback) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_CallContract",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -647,7 +593,7 @@ func (c *ClientWithFallback) CallContract(ctx context.Context, msg ethereum.Call
 }
 
 func (c *ClientWithFallback) PendingCallContract(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_PendingCallContract",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -663,7 +609,7 @@ func (c *ClientWithFallback) PendingCallContract(ctx context.Context, msg ethere
 }
 
 func (c *ClientWithFallback) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_SuggestGasPrice",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -679,7 +625,7 @@ func (c *ClientWithFallback) SuggestGasPrice(ctx context.Context) (*big.Int, err
 }
 
 func (c *ClientWithFallback) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_SuggestGasTipCap",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -695,7 +641,7 @@ func (c *ClientWithFallback) SuggestGasTipCap(ctx context.Context) (*big.Int, er
 }
 
 func (c *ClientWithFallback) FeeHistory(ctx context.Context, blockCount uint64, lastBlock *big.Int, rewardPercentiles []float64) (*ethereum.FeeHistory, error) {
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_FeeHistory",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -715,7 +661,7 @@ func (c *ClientWithFallback) EstimateGas(ctx context.Context, msg ethereum.CallM
 		return c.LineaEstimateGas(ctx, msg)
 	}
 
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_EstimateGas",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -736,7 +682,7 @@ func (c *ClientWithFallback) LineaEstimateGas(ctx context.Context, msg ethereum.
 	}
 
 	const method = "linea_estimateGas"
-	res, err := c.makeCallAndToggleConnectionState(
+	res, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: method,
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -759,7 +705,7 @@ func (c *ClientWithFallback) LineaEstimateGas(ctx context.Context, msg ethereum.
 }
 
 func (c *ClientWithFallback) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-	_, err := c.makeCallAndToggleConnectionState(
+	_, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_SendTransaction",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -771,7 +717,7 @@ func (c *ClientWithFallback) SendTransaction(ctx context.Context, tx *types.Tran
 }
 
 func (c *ClientWithFallback) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
-	_, err := c.makeCallAndToggleConnectionState(
+	_, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_CallContext",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -783,7 +729,7 @@ func (c *ClientWithFallback) CallContext(ctx context.Context, result interface{}
 }
 
 func (c *ClientWithFallback) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
-	_, err := c.makeCallAndToggleConnectionState(
+	_, err := c.makeCall(
 		ctx, MakeCallFunctor{
 			MethodName: "eth_BatchCallContext",
 			Func: func(client ethclient.EthClientInterface) (interface{}, error) {
@@ -816,27 +762,6 @@ func (c *ClientWithFallback) GetBaseFeeFromBlock(ctx context.Context, blockNumbe
 	}
 
 	return baseGasFee, err
-}
-
-func (c *ClientWithFallback) GetWalletNotifier() func(chainId uint64, message string) {
-	return c.WalletNotifier
-}
-
-func (c *ClientWithFallback) SetWalletNotifier(notifier func(chainId uint64, message string)) {
-	c.WalletNotifier = notifier
-}
-
-func (c *ClientWithFallback) toggleConnectionState(err error) {
-	connected := true
-	if err != nil {
-		if !isNotFoundError(err) && !isVMError(err) && !errors.Is(err, rpclimiter.ErrRequestsOverLimit) && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			logutils.ZapLogger().Warn("Error not in chain call", zap.Uint64("chain", c.ChainID), zap.Error(err))
-			connected = false
-		} else {
-			logutils.ZapLogger().Warn("Error in chain call", zap.Error(err))
-		}
-	}
-	c.SetIsConnected(connected)
 }
 
 func (c *ClientWithFallback) Tag() string {

--- a/rpc/chain/client.go
+++ b/rpc/chain/client.go
@@ -28,14 +28,13 @@ import (
 	"github.com/status-im/status-go/rpc/chain/tagger"
 	"github.com/status-im/status-go/services/rpcstats"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
-	"github.com/status-im/status-go/services/wallet/connection"
 )
 
 type ClientInterface interface {
 	ethclient.EthClientInterface
 	NetworkID() uint64
 	ToBigInt() *big.Int
-	connection.Connectable
+	GetConnectionStatus() rpcstatus.StatusType
 	GetLimiter() rpclimiter.RequestLimiter
 	SetLimiter(rpclimiter.RequestLimiter)
 }
@@ -168,8 +167,8 @@ func isVMError(err error) bool {
 	return false
 }
 
-func (c *ClientWithFallback) IsConnected() bool {
-	return c.providersHealthManager.Status().Status == rpcstatus.StatusUp
+func (c *ClientWithFallback) GetConnectionStatus() rpcstatus.StatusType {
+	return c.providersHealthManager.Status().Status
 }
 
 func (c *ClientWithFallback) makeCall(ctx context.Context, f MakeCallFunctor) (interface{}, error) {

--- a/rpc/chain/client_test.go
+++ b/rpc/chain/client_test.go
@@ -92,12 +92,10 @@ func TestClientWithFallback_Copy(t *testing.T) {
 	// Setup test values
 	testTag := "test-tag"
 	testGroupTag := "test-group-tag"
-	testNotifier := func(chainId uint64, message string) {}
 
 	// Set values on the original client
 	client.tag = testTag
 	client.groupTag = testGroupTag
-	client.WalletNotifier = testNotifier
 
 	// Copy the client
 	clientCopy := client.Copy().(*ClientWithFallback)
@@ -106,7 +104,6 @@ func TestClientWithFallback_Copy(t *testing.T) {
 	require.Equal(t, client.ChainID, clientCopy.ChainID)
 	require.Equal(t, client.tag, clientCopy.tag)
 	require.Equal(t, client.groupTag, clientCopy.groupTag)
-	require.Equal(t, client.LastCheckedAt, clientCopy.LastCheckedAt)
 
 	// Verify that both clients have the same ethClients slice
 	require.Equal(t, len(client.ethClients), len(clientCopy.ethClients))
@@ -115,14 +112,8 @@ func TestClientWithFallback_Copy(t *testing.T) {
 	}
 
 	// Check that pointer values are the same (shallow copy)
-	require.Same(t, client.isConnected, clientCopy.isConnected)
 	require.Same(t, client.circuitbreaker, clientCopy.circuitbreaker)
 	require.Same(t, client.providersHealthManager, clientCopy.providersHealthManager)
-
-	// Verify that function references are the same
-	clientFuncPtr := getFuncPtr(client.WalletNotifier)
-	copyFuncPtr := getFuncPtr(clientCopy.WalletNotifier)
-	require.Equal(t, clientFuncPtr, copyFuncPtr)
 
 	// Modify the copy, ensure it doesn't affect the original
 	clientCopy.tag = "new-tag"
@@ -137,66 +128,6 @@ func getFuncPtr(f func(uint64, string)) uintptr {
 		return 0
 	}
 	return reflect.ValueOf(f).Pointer()
-}
-
-// TestClientWithFallback_NilClientPanic tests that a nil pointer panic occurs
-// when the client's internal state is nullified during operation
-func TestClientWithFallback_NilClientPanic(t *testing.T) {
-	client, ethClients, cleanup := setupClientTest(t)
-	defer cleanup()
-
-	ctx := context.Background()
-	addr := common.HexToAddress("0x1234")
-
-	// Create channels to coordinate the test
-	done := make(chan struct{})
-	operationStarted := make(chan struct{})
-	stateNulled := make(chan struct{})
-
-	// Set up the first client to block for a short time
-	ethClients[0].EXPECT().CodeAt(ctx, addr, nil).DoAndReturn(
-		func(ctx context.Context, addr common.Address, blockNumber *big.Int) ([]byte, error) {
-			close(operationStarted) // Signal that operation has started
-			<-stateNulled           // Wait until state is nulled
-			return nil, errors.New("timeout")
-		}).Times(1)
-
-	// Set up expectations for other clients
-	ethClients[1].EXPECT().CodeAt(ctx, addr, nil).Return(nil, errors.New("error")).Times(1)
-	ethClients[2].EXPECT().CodeAt(ctx, addr, nil).Return(nil, errors.New("error")).Times(1)
-
-	// Start the operation in a goroutine
-	go func() {
-		defer close(done)
-		defer func() {
-			if r := recover(); r == nil {
-				t.Error("Expected panic but got none")
-			} else {
-				// Verify it's the expected nil pointer panic
-				if _, ok := r.(runtime.Error); !ok {
-					t.Errorf("Expected runtime error, got: %v", r)
-				}
-			}
-		}()
-
-		// Start the operation that should trigger the panic
-		_, _ = client.CodeAt(ctx, addr, nil)
-		t.Error("Expected panic, but operation completed successfully")
-	}()
-
-	// Wait for operation to start
-	<-operationStarted
-
-	// Nullify the client's internal state while operation is running
-	client.ethClients = nil
-	client.circuitbreaker = nil
-	client.commonLimiter = nil
-	client.providersHealthManager = nil
-	client.isConnected = nil
-	close(stateNulled)
-
-	// Wait for the operation to complete
-	<-done
 }
 
 // TestClientWithFallback_CloseStopsOperations tests that closing the client

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -159,7 +159,9 @@ func NewClient(config ClientConfig) (*Client, error) {
 }
 
 func (c *Client) Start(ctx context.Context) {
-	c.signalsTransmitter.Start()
+	if err := c.signalsTransmitter.Start(); err != nil {
+		c.logger.Error("Failed to start signals transmitter", zap.Error(err))
+	}
 	c.networkManager.Start()
 
 	if c.stopMonitoringFunc != nil {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -100,7 +100,7 @@ type Client struct {
 	limiterPerProvider map[string]*rpclimiter.RPCRpsLimiter
 
 	router         *router
-	NetworkManager *network.Manager
+	networkManager *network.Manager
 
 	healthMgr          *healthmanager.BlockchainHealthManager
 	stopMonitoringFunc context.CancelFunc
@@ -146,7 +146,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 
 	c := Client{
 		local:              config.Client,
-		NetworkManager:     networkManager,
+		networkManager:     networkManager,
 		handlers:           make(map[string]Handler),
 		rpcClients:         make(map[uint64]chain.ClientInterface),
 		limiterPerProvider: make(map[string]*rpclimiter.RPCRpsLimiter),
@@ -167,7 +167,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 }
 
 func (c *Client) Start(ctx context.Context) {
-	c.NetworkManager.Start()
+	c.networkManager.Start()
 
 	if c.stopMonitoringFunc != nil {
 		c.logger.Warn("Blockchain health manager already started")
@@ -181,7 +181,7 @@ func (c *Client) Start(ctx context.Context) {
 }
 
 func (c *Client) Stop() {
-	c.NetworkManager.Stop()
+	c.networkManager.Stop()
 
 	c.rpcClientsMutex.Lock()
 	for _, client := range c.rpcClients {
@@ -233,7 +233,7 @@ func (c *Client) GetHealthManagerFullStatus() healthmanager.BlockchainFullStatus
 }
 
 func (c *Client) GetNetworkManager() *network.Manager {
-	return c.NetworkManager
+	return c.networkManager
 }
 
 func (c *Client) SetWalletNotifier(notifier func(chainID uint64, message string)) {
@@ -250,7 +250,7 @@ func (c *Client) getClientUsingCache(chainID uint64) (chain.ClientInterface, err
 		return rpcClient, nil
 	}
 
-	network := c.NetworkManager.Find(chainID)
+	network := c.networkManager.Find(chainID)
 	if network == nil {
 		return nil, fmt.Errorf("could not find network: %d", chainID)
 	}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -16,8 +16,6 @@ import (
 
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/ethereum/go-ethereum/event"
-
 	appCommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/healthmanager"
 	"github.com/status-im/status-go/logutils"
@@ -30,7 +28,6 @@ import (
 	"github.com/status-im/status-go/rpc/network"
 	"github.com/status-im/status-go/services/rpcstats"
 	"github.com/status-im/status-go/services/wallet/common"
-	"github.com/status-im/status-go/services/wallet/walletevent"
 )
 
 const (
@@ -47,8 +44,6 @@ const (
 	// rpcUserAgentUpstreamFormat a separate user agent format for upstream, because we should not be using upstream
 	// if we see this user agent in the logs that means parts of the application are using a malconfigured http client
 	rpcUserAgentUpstreamFormat = "procuratee-%s-upstream/%s"
-
-	EventBlockchainHealthChanged walletevent.EventType = "wallet-blockchain-health-changed" // Full status of the blockchain (including provider statuses)
 )
 
 // List of RPC client errors.
@@ -105,13 +100,11 @@ type Client struct {
 	healthMgr          *healthmanager.BlockchainHealthManager
 	stopMonitoringFunc context.CancelFunc
 	accountsPublisher  *pubsub.Publisher
-	walletFeed         *event.Feed
+	signalsTransmitter *SignalsTransmitter
 
 	handlersMx sync.RWMutex       // mx guards handlers
 	handlers   map[string]Handler // locally registered handlers
 	logger     *zap.Logger
-
-	walletNotifier func(chainID uint64, message string)
 }
 
 // Is initialized in a build-tag-dependent module
@@ -124,7 +117,6 @@ type ClientConfig struct {
 	Networks          []params.Network
 	DB                *sql.DB
 	AccountsPublisher *pubsub.Publisher
-	WalletFeed        *event.Feed
 }
 
 // NewClient initializes Client
@@ -153,7 +145,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 		logger:             logger,
 		healthMgr:          healthmanager.NewBlockchainHealthManager(),
 		accountsPublisher:  config.AccountsPublisher,
-		walletFeed:         config.WalletFeed,
+		signalsTransmitter: NewSignalsTransmitter(networkManager.GetPublisher()),
 	}
 
 	c.UpstreamChainID = config.UpstreamChainID
@@ -167,6 +159,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 }
 
 func (c *Client) Start(ctx context.Context) {
+	c.signalsTransmitter.Start()
 	c.networkManager.Start()
 
 	if c.stopMonitoringFunc != nil {
@@ -177,10 +170,14 @@ func (c *Client) Start(ctx context.Context) {
 	cancelableCtx, cancel := context.WithCancel(ctx)
 	c.stopMonitoringFunc = cancel
 	statusCh := c.healthMgr.Subscribe()
-	go c.monitorHealth(cancelableCtx, statusCh)
+	go func() {
+		defer appCommon.LogOnPanic()
+		c.monitorHealth(cancelableCtx, statusCh)
+	}()
 }
 
 func (c *Client) Stop() {
+	c.signalsTransmitter.Stop()
 	c.networkManager.Stop()
 
 	c.rpcClientsMutex.Lock()
@@ -198,23 +195,13 @@ func (c *Client) Stop() {
 }
 
 func (c *Client) monitorHealth(ctx context.Context, statusCh chan struct{}) {
-	defer appCommon.LogOnPanic()
 	sendFullStatusEventFunc := func() {
-		blockchainStatus := c.healthMgr.GetFullStatus()
-		encodedMessage, err := json.Marshal(blockchainStatus)
-		if err != nil {
-			c.logger.Warn("could not marshal full blockchain status", zap.Error(err))
+		publisher := c.GetNetworksPublisher()
+		if publisher == nil {
 			return
 		}
-		if c.walletFeed == nil {
-			return
-		}
-		// FIXME: remove these excessive logs in future release (2.31+)
-		c.logger.Debug("Sending blockchain health status event", zap.String("status", string(encodedMessage)))
-		c.walletFeed.Send(walletevent.Event{
-			Type:    EventBlockchainHealthChanged,
-			Message: string(encodedMessage),
-			At:      time.Now().Unix(),
+		pubsub.Publish(publisher, EventBlockchainHealthChanged{
+			FullStatus: c.healthMgr.GetFullStatus(),
 		})
 	}
 
@@ -236,17 +223,17 @@ func (c *Client) GetNetworkManager() *network.Manager {
 	return c.networkManager
 }
 
-func (c *Client) SetWalletNotifier(notifier func(chainID uint64, message string)) {
-	c.walletNotifier = notifier
+func (c *Client) GetNetworksPublisher() *pubsub.Publisher {
+	if c.networkManager == nil {
+		return nil
+	}
+	return c.networkManager.GetPublisher()
 }
 
 func (c *Client) getClientUsingCache(chainID uint64) (chain.ClientInterface, error) {
 	c.rpcClientsMutex.Lock()
 	defer c.rpcClientsMutex.Unlock()
 	if rpcClient, ok := c.rpcClients[chainID]; ok {
-		if rpcClient.GetWalletNotifier() == nil {
-			rpcClient.SetWalletNotifier(c.walletNotifier)
-		}
 		return rpcClient, nil
 	}
 
@@ -267,7 +254,6 @@ func (c *Client) getClientUsingCache(chainID uint64) (chain.ClientInterface, err
 	}
 
 	client := chain.NewClient(ethClients, chainID, phm)
-	client.SetWalletNotifier(c.walletNotifier)
 	c.rpcClients[chainID] = client
 	return client, nil
 }

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -53,7 +53,6 @@ func TestBlockedRoutesCall(t *testing.T) {
 		UpstreamChainID: 1,
 		Networks:        []params.Network{},
 		DB:              db,
-		WalletFeed:      nil,
 	}
 	c, err := NewClient(config)
 	require.NoError(t, err)
@@ -99,7 +98,6 @@ func TestBlockedRoutesRawCall(t *testing.T) {
 		UpstreamChainID: 1,
 		Networks:        []params.Network{},
 		DB:              db,
-		WalletFeed:      nil,
 	}
 	c, err := NewClient(config)
 	require.NoError(t, err)
@@ -185,7 +183,6 @@ func TestGetClientsUsingCache(t *testing.T) {
 		UpstreamChainID: 1,
 		Networks:        networks,
 		DB:              db,
-		WalletFeed:      nil,
 	}
 
 	c, err := NewClient(config)

--- a/rpc/events.go
+++ b/rpc/events.go
@@ -1,0 +1,9 @@
+package rpc
+
+import (
+	"github.com/status-im/status-go/healthmanager"
+)
+
+type EventBlockchainHealthChanged struct {
+	FullStatus healthmanager.BlockchainFullStatus
+}

--- a/rpc/signals_transmitter.go
+++ b/rpc/signals_transmitter.go
@@ -1,0 +1,52 @@
+package rpc
+
+import (
+	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/pkg/pubsub"
+	"github.com/status-im/status-go/signal"
+)
+
+type SignalsTransmitter struct {
+	publisher *pubsub.Publisher
+
+	quit chan struct{}
+}
+
+func NewSignalsTransmitter(publisher *pubsub.Publisher) *SignalsTransmitter {
+	return &SignalsTransmitter{
+		publisher: publisher,
+	}
+}
+
+func (tmr *SignalsTransmitter) Start() error {
+	if tmr.quit != nil {
+		// already running, nothing to do
+		return nil
+	}
+	tmr.quit = make(chan struct{})
+	ch, unsubFn := pubsub.Subscribe[EventBlockchainHealthChanged](tmr.publisher, 10)
+
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer unsubFn()
+		for {
+			select {
+			case <-tmr.quit:
+				return
+			case event, ok := <-ch:
+				if !ok {
+					return
+				}
+				signal.SendNetworksBlockchainHealthChanged(event.FullStatus)
+			}
+		}
+	}()
+	return nil
+}
+
+func (tmr *SignalsTransmitter) Stop() {
+	if tmr.quit != nil {
+		close(tmr.quit)
+		tmr.quit = nil
+	}
+}

--- a/rpc/verif_proxy_test.go
+++ b/rpc/verif_proxy_test.go
@@ -54,7 +54,6 @@ func (s *ProxySuite) startRpcClient(infuraURL string) *Client {
 		UpstreamChainID: 1,
 		Networks:        []params.Network{},
 		DB:              db,
-		WalletFeed:      nil,
 	}
 	c, err := NewClient(config)
 	require.NoError(s.T(), err)

--- a/services/ens/api_test.go
+++ b/services/ens/api_test.go
@@ -38,7 +38,6 @@ func setupTestAPI(t *testing.T) (*API, func()) {
 		UpstreamChainID: 1,
 		Networks:        nil,
 		DB:              db,
-		WalletFeed:      nil,
 	}
 	rpcClient, err := statusRPC.NewClient(config)
 	require.NoError(t, err)

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -87,7 +87,7 @@ func (api *API) GetBalancesByChain(ctx context.Context, chainIDs []uint64, addre
 }
 
 func (api *API) FetchOrGetCachedWalletBalances(ctx context.Context, addresses []common.Address, forceRefresh bool) (map[common.Address][]tokenTypes.StorageToken, error) {
-	activeNetworks, err := api.s.rpcClient.NetworkManager.GetActiveNetworks()
+	activeNetworks, err := api.s.rpcClient.GetNetworkManager().GetActiveNetworks()
 	if err != nil {
 		return nil, err
 	}
@@ -337,42 +337,42 @@ func (api *API) SearchCollections(ctx context.Context, chainID wcommon.ChainID, 
 // @deprecated: Custom networks not currently supported. Change settings using specific API functions.
 func (api *API) AddEthereumChain(ctx context.Context, network params.Network) error {
 	logutils.ZapLogger().Debug("call to AddEthereumChain")
-	return api.s.rpcClient.NetworkManager.Upsert(&network)
+	return api.s.rpcClient.GetNetworkManager().Upsert(&network)
 }
 
 // @deprecated: Custom networks not currently supported. Change settings using specific API functions.
 func (api *API) DeleteEthereumChain(ctx context.Context, chainID uint64) error {
 	logutils.ZapLogger().Debug("call to DeleteEthereumChain")
-	return api.s.rpcClient.NetworkManager.Delete(chainID)
+	return api.s.rpcClient.GetNetworkManager().Delete(chainID)
 }
 
 func (api *API) SetChainUserRpcProviders(ctx context.Context, chainID uint64, rpcProviders []params.RpcProvider) error {
 	logutils.ZapLogger().Debug("call to SetChainUserRpcProviders")
-	return api.s.rpcClient.NetworkManager.SetUserRpcProviders(chainID, rpcProviders)
+	return api.s.rpcClient.GetNetworkManager().SetUserRpcProviders(chainID, rpcProviders)
 }
 
 // Active chains are the ones that are available for selection across the whole application
 // Providers are expected to be accessed only for active chains.
 func (api *API) SetChainActive(ctx context.Context, chainID uint64, active bool) error {
 	logutils.ZapLogger().Debug("call to SetChainActive")
-	return api.s.rpcClient.NetworkManager.SetActive(chainID, active)
+	return api.s.rpcClient.GetNetworkManager().SetActive(chainID, active)
 }
 
 // Enabled chains are the ones taken into account when displaying balances, collectibles, activity, etc.
 func (api *API) SetChainEnabled(ctx context.Context, chainID uint64, enabled bool) error {
 	logutils.ZapLogger().Debug("call to SetChainEnabled")
-	return api.s.rpcClient.NetworkManager.SetEnabled(chainID, enabled)
+	return api.s.rpcClient.GetNetworkManager().SetEnabled(chainID, enabled)
 }
 
 // @deprecated: Combined networks are not used anymore, use GetFlatEthereumChains instead
 func (api *API) GetEthereumChains(ctx context.Context) ([]*network.CombinedNetwork, error) {
 	logutils.ZapLogger().Debug("call to GetEthereumChains")
-	return api.s.rpcClient.NetworkManager.GetCombinedNetworks()
+	return api.s.rpcClient.GetNetworkManager().GetCombinedNetworks()
 }
 
 func (api *API) GetFlatEthereumChains(ctx context.Context) ([]*params.Network, error) {
 	logutils.ZapLogger().Debug("call to GetFlatEthereumChains")
-	return api.s.rpcClient.NetworkManager.GetAll()
+	return api.s.rpcClient.GetNetworkManager().GetAll()
 }
 
 // @deprecated
@@ -568,7 +568,7 @@ func (api *API) AddressDetails(ctx context.Context, params *requests.AddressDeta
 
 	chainIDs := params.ChainIDs
 	if len(chainIDs) == 0 {
-		activeNetworks, err := api.s.rpcClient.NetworkManager.GetActiveNetworks()
+		activeNetworks, err := api.s.rpcClient.GetNetworkManager().GetActiveNetworks()
 		if err != nil {
 			return nil, err
 		}

--- a/services/wallet/api_test.go
+++ b/services/wallet/api_test.go
@@ -153,15 +153,9 @@ func TestAPI_GetAddressDetails(t *testing.T) {
 		UpstreamChainID: chainID,
 		Networks:        networks,
 		DB:              appDB,
-		WalletFeed:      nil,
 	}
 	c, err := rpc.NewClient(config)
 	require.NoError(t, err)
-
-	chainClient, err := c.EthClient(chainID)
-	require.NoError(t, err)
-	chainClient.SetWalletNotifier(func(chainID uint64, message string) {})
-	c.SetWalletNotifier(func(chainID uint64, message string) {})
 
 	service := NewService(db, accountsDb, appDB, c, accountsPublisher, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
 
@@ -247,7 +241,6 @@ func TestAPI_FetchOrGetCachedWalletBalances(t *testing.T) {
 		UpstreamChainID: chainID,
 		Networks:        networks,
 		DB:              appDB,
-		WalletFeed:      nil,
 	}
 	c, err := rpc.NewClient(config)
 	require.NoError(t, err)

--- a/services/wallet/connection/status.go
+++ b/services/wallet/connection/status.go
@@ -6,7 +6,6 @@ import (
 )
 
 type Connectable interface {
-	SetIsConnected(bool)
 	IsConnected() bool
 }
 

--- a/services/wallet/history/service.go
+++ b/services/wallet/history/service.go
@@ -79,7 +79,7 @@ func NewService(db *sql.DB, accountsDB *accounts.Database, accountsPublisher *pu
 		accountsPublisher: accountsPublisher,
 		eventFeed:         eventFeed,
 		rpcClient:         rpcClient,
-		networkManager:    rpcClient.NetworkManager,
+		networkManager:    rpcClient.GetNetworkManager(),
 		tokenManager:      tokenManager,
 		exchange:          NewExchange(marketManager),
 		balanceCache:      balanceCache,

--- a/services/wallet/history/service_test.go
+++ b/services/wallet/history/service_test.go
@@ -412,7 +412,6 @@ func Test_removeBalanceHistoryOnEventAccountRemoved(t *testing.T) {
 		UpstreamChainID: chainID,
 		Networks:        nil,
 		DB:              appDB,
-		WalletFeed:      nil,
 	}
 	rpcClient, _ := rpc.NewClient(config)
 	rpcClient.UpstreamChainID = chainID

--- a/services/wallet/keycard_pairings_test.go
+++ b/services/wallet/keycard_pairings_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/rpc"
-	"github.com/status-im/status-go/rpc/network"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/walletdatabase"
 )
@@ -28,7 +27,12 @@ func TestKeycardPairingsFile(t *testing.T) {
 
 	accountsPublisher := pubsub.NewPublisher()
 
-	service := NewService(db, accountsDb, appDB, &rpc.Client{NetworkManager: network.NewManager(db, nil)}, accountsPublisher, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
+	rpcClient, err := rpc.NewClient(rpc.ClientConfig{
+		DB:                db,
+		AccountsPublisher: accountsPublisher,
+	})
+	require.NoError(t, err)
+	service := NewService(db, accountsDb, appDB, rpcClient, accountsPublisher, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
 
 	data, err := service.KeycardPairings().GetPairingsJSONFileContent()
 	require.NoError(t, err)

--- a/services/wallet/reader.go
+++ b/services/wallet/reader.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/event"
 	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/healthmanager/rpcstatus"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/rpc/chain"
 	"github.com/status-im/status-go/services/wallet/market"
@@ -558,7 +559,8 @@ func (r *Reader) FetchBalances(ctx context.Context, clients map[uint64]chain.Cli
 
 	connectedPerChain := map[uint64]bool{}
 	for chainID, client := range clients {
-		connectedPerChain[chainID] = client.IsConnected()
+		// Checked post-request, it should either be Up or Down
+		connectedPerChain[chainID] = client.GetConnectionStatus() == rpcstatus.StatusUp
 	}
 
 	tokens := r.balancesToTokensByAddress(connectedPerChain, addresses, allTokens, balances, cachedTokens)
@@ -588,7 +590,8 @@ func (r *Reader) GetCachedBalances(clients map[uint64]chain.ClientInterface, add
 
 	connectedPerChain := map[uint64]bool{}
 	for chainID, client := range clients {
-		connectedPerChain[chainID] = client.IsConnected()
+		// Checked post-request, it should either be Up or Down
+		connectedPerChain[chainID] = client.GetConnectionStatus() == rpcstatus.StatusUp
 	}
 
 	balances, err := tokensToBalancesPerChain(cachedTokens)

--- a/services/wallet/reader_test.go
+++ b/services/wallet/reader_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/status-im/status-go/healthmanager/rpcstatus"
 	"github.com/status-im/status-go/rpc/chain"
 	mock_client "github.com/status-im/status-go/rpc/chain/mock/client"
 	"github.com/status-im/status-go/services/wallet/testutils"
@@ -885,8 +886,8 @@ func TestGetCachedBalances(t *testing.T) {
 	expectedChains := []uint64{1, 2}
 	tokenManager.EXPECT().GetTokensByChainIDs(testutils.NewUint64SliceMatcher(expectedChains)).Return(allTokens, nil)
 	tokenManager.EXPECT().GetTokenHistoricalBalance(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-	mockClientIface1.EXPECT().IsConnected().Return(true)
-	mockClientIface2.EXPECT().IsConnected().Return(true)
+	mockClientIface1.EXPECT().GetConnectionStatus().Return(rpcstatus.StatusUp)
+	mockClientIface2.EXPECT().GetConnectionStatus().Return(rpcstatus.StatusUp)
 	tokens, err := reader.GetCachedBalances(clients, addresses)
 	require.NoError(t, err)
 
@@ -1012,8 +1013,8 @@ func TestFetchBalances(t *testing.T) {
 
 	tokenAddresses := getTokenAddresses(allTokens)
 	tokenManager.EXPECT().GetBalancesByChain(context.TODO(), clients, addresses, testutils.NewAddressSliceMatcher(tokenAddresses)).Return(expectedBalances, nil)
-	mockClientIface1.EXPECT().IsConnected().Return(true)
-	mockClientIface2.EXPECT().IsConnected().Return(true)
+	mockClientIface1.EXPECT().GetConnectionStatus().Return(rpcstatus.StatusUp)
+	mockClientIface2.EXPECT().GetConnectionStatus().Return(rpcstatus.StatusUp)
 	tokens, err := reader.FetchBalances(context.TODO(), clients, addresses)
 	require.NoError(t, err)
 

--- a/services/wallet/router/pathprocessor/processor_bridge_celar.go
+++ b/services/wallet/router/pathprocessor/processor_bridge_celar.go
@@ -303,7 +303,7 @@ func (s *CelerBridgeProcessor) GetContractAddress(params ProcessorInputParams) (
 
 // TODO: remove this struct once mobile switches to the new approach
 func (s *CelerBridgeProcessor) sendOrBuild(sendArgs *MultipathProcessorTxArgs, signerFn bind.SignerFn, lastUsedNonce int64) (*ethTypes.Transaction, error) {
-	fromChain := s.rpcClient.NetworkManager.Find(sendArgs.ChainID)
+	fromChain := s.rpcClient.GetNetworkManager().Find(sendArgs.ChainID)
 	if fromChain == nil {
 		return nil, ErrNetworkNotFound
 	}
@@ -365,7 +365,7 @@ func (s *CelerBridgeProcessor) sendOrBuild(sendArgs *MultipathProcessorTxArgs, s
 }
 
 func (s *CelerBridgeProcessor) sendOrBuildV2(sendArgs *wallettypes.SendTxArgs, signerFn bind.SignerFn, lastUsedNonce int64) (*ethTypes.Transaction, error) {
-	fromChain := s.rpcClient.NetworkManager.Find(sendArgs.FromChainID)
+	fromChain := s.rpcClient.GetNetworkManager().Find(sendArgs.FromChainID)
 	if fromChain == nil {
 		return nil, ErrNetworkNotFound
 	}

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -375,7 +375,7 @@ func (r *Router) SuggestedRoutes(ctx context.Context, input *requests.RouteInput
 		r.routeCanceledMutex.Unlock()
 	}()
 
-	testnetMode, err := r.rpcClient.NetworkManager.GetTestNetworksEnabled()
+	testnetMode, err := r.rpcClient.GetNetworkManager().GetTestNetworksEnabled()
 	if err != nil {
 		return nil, errors.CreateErrorResponseFromError(err)
 	}
@@ -387,12 +387,12 @@ func (r *Router) SuggestedRoutes(ctx context.Context, input *requests.RouteInput
 		return nil, errors.CreateErrorResponseFromError(err)
 	}
 
-	fromChain := r.rpcClient.NetworkManager.Find(input.FromChainID)
+	fromChain := r.rpcClient.GetNetworkManager().Find(input.FromChainID)
 	if fromChain == nil {
 		return nil, errors.CreateErrorResponseFromError(fmt.Errorf("from chain %d not found", input.FromChainID))
 	}
 
-	toChain := r.rpcClient.NetworkManager.Find(input.ToChainID)
+	toChain := r.rpcClient.GetNetworkManager().Find(input.ToChainID)
 	if toChain == nil {
 		return nil, errors.CreateErrorResponseFromError(fmt.Errorf("to chain %d not found", input.ToChainID))
 	}

--- a/services/wallet/router/router_test.go
+++ b/services/wallet/router/router_test.go
@@ -56,7 +56,6 @@ func setupRouter(t *testing.T) (*Router, func()) {
 		UpstreamChainID: 1,
 		Networks:        defaultNetworks,
 		DB:              db,
-		WalletFeed:      nil,
 	}
 	client, _ := rpc.NewClient(config)
 

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -3,14 +3,11 @@ package wallet
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/status-im/status-go/services/wallet/thirdparty/market/cryptocompare"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 
@@ -48,8 +45,6 @@ import (
 )
 
 const (
-	EventBlockchainStatusChanged walletevent.EventType = "wallet-blockchain-status-changed"
-
 	defaultAutoRefreshInterval      = 30 * time.Minute // interval after which we should fetch the token lists from the remote source (or use the default one if remote source is not set)
 	defaultAutoRefreshCheckInterval = 3 * time.Minute  // interval after which we should check if we should trigger the auto-refresh
 )
@@ -83,38 +78,6 @@ func NewService(
 	signals := &walletevent.SignalsTransmitter{
 		Publisher: feed,
 	}
-	blockchainStatus := make(map[uint64]string)
-	mutex := sync.Mutex{}
-	rpcClient.SetWalletNotifier(func(chainID uint64, message string) {
-		mutex.Lock()
-		defer mutex.Unlock()
-
-		if len(blockchainStatus) == 0 {
-			networks, err := rpcClient.GetNetworkManager().Get(false)
-			if err != nil {
-				return
-			}
-
-			for _, network := range networks {
-				blockchainStatus[network.ChainID] = "up"
-			}
-		}
-
-		blockchainStatus[chainID] = message
-		encodedmessage, err := json.Marshal(blockchainStatus)
-		if err != nil {
-			return
-		}
-
-		feed.Send(walletevent.Event{
-			Type:     EventBlockchainStatusChanged,
-			Accounts: []common.Address{},
-			Message:  string(encodedmessage),
-			At:       time.Now().Unix(),
-			ChainID:  chainID,
-		})
-	})
-
 	communityManager := community.NewManager(db, mediaServer, feed)
 	balanceCacher := balance.NewCacherWithTTL(5 * time.Minute)
 	tokenManager := token.NewTokenManager(db, rpcClient, communityManager, rpcClient.GetNetworkManager(), appDB, mediaServer, feed, accountsPublisher, accountsDB, token.NewPersistence(db))

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -90,7 +90,7 @@ func NewService(
 		defer mutex.Unlock()
 
 		if len(blockchainStatus) == 0 {
-			networks, err := rpcClient.NetworkManager.Get(false)
+			networks, err := rpcClient.GetNetworkManager().Get(false)
 			if err != nil {
 				return
 			}
@@ -117,7 +117,7 @@ func NewService(
 
 	communityManager := community.NewManager(db, mediaServer, feed)
 	balanceCacher := balance.NewCacherWithTTL(5 * time.Minute)
-	tokenManager := token.NewTokenManager(db, rpcClient, communityManager, rpcClient.NetworkManager, appDB, mediaServer, feed, accountsPublisher, accountsDB, token.NewPersistence(db))
+	tokenManager := token.NewTokenManager(db, rpcClient, communityManager, rpcClient.GetNetworkManager(), appDB, mediaServer, feed, accountsPublisher, accountsDB, token.NewPersistence(db))
 
 	cryptoOnRampProviders := []onramp.Provider{
 		onramp.NewMoonPayProvider(),
@@ -206,7 +206,7 @@ func NewService(
 		mediaServer,
 		feed,
 	)
-	collectibles := collectibles.NewService(db, feed, accountsDB, accountsPublisher, communityManager, rpcClient.NetworkManager, collectiblesManager)
+	collectibles := collectibles.NewService(db, feed, accountsDB, accountsPublisher, communityManager, rpcClient.GetNetworkManager(), collectiblesManager)
 
 	activity := activity.NewService(db, accountsDB, tokenManager, collectiblesManager, feed)
 
@@ -274,7 +274,7 @@ func buildPathProcessors(
 	erc1155Transfer := pathprocessor.NewERC1155Processor(rpcClient, transactor)
 	ret = append(ret, erc1155Transfer)
 
-	hop := pathprocessor.NewHopBridgeProcessor(rpcClient, transactor, tokenManager, rpcClient.NetworkManager)
+	hop := pathprocessor.NewHopBridgeProcessor(rpcClient, transactor, tokenManager, rpcClient.GetNetworkManager())
 	ret = append(ret, hop)
 
 	if featureFlags.EnableCelerBridge {

--- a/services/wallet/token/token_test.go
+++ b/services/wallet/token/token_test.go
@@ -343,7 +343,6 @@ func Test_removeTokenBalanceOnEventAccountRemoved(t *testing.T) {
 		UpstreamChainID: chainID,
 		Networks:        nil,
 		DB:              appDB,
-		WalletFeed:      nil,
 	}
 	rpcClient, _ := rpc.NewClient(config)
 

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -585,19 +585,6 @@ func (tc *TestClient) CallContext(ctx context.Context, result interface{}, metho
 	return err
 }
 
-func (tc *TestClient) GetWalletNotifier() func(chainId uint64, message string) {
-	if tc.traceAPICalls {
-		tc.t.Log("GetWalletNotifier")
-	}
-	return nil
-}
-
-func (tc *TestClient) SetWalletNotifier(notifier func(chainId uint64, message string)) {
-	if tc.traceAPICalls {
-		tc.t.Log("SetWalletNotifier")
-	}
-}
-
 func (tc *TestClient) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
 	err = tc.countAndlog("EstimateGas")
 	return 0, err
@@ -1132,7 +1119,6 @@ func setupFindBlocksCommand(t *testing.T, accountAddress common.Address, fromBlo
 		UpstreamChainID: 1,
 		Networks:        []params.Network{},
 		DB:              appDb,
-		WalletFeed:      nil,
 	}
 	client, err := statusRpc.NewClient(config)
 	require.NoError(t, err)
@@ -1392,7 +1378,6 @@ func TestFetchTransfersForLoadedBlocks(t *testing.T) {
 		UpstreamChainID: 1,
 		Networks:        []params.Network{},
 		DB:              appdb,
-		WalletFeed:      nil,
 	}
 	client, _ := statusRpc.NewClient(config)
 
@@ -1504,7 +1489,6 @@ func TestFetchNewBlocksCommand_findBlocksWithEthTransfers(t *testing.T) {
 			UpstreamChainID: 1,
 			Networks:        []params.Network{},
 			DB:              appdb,
-			WalletFeed:      nil,
 		}
 		client, _ := statusRpc.NewClient(config)
 
@@ -1573,7 +1557,6 @@ func TestFetchNewBlocksCommand_nonceDetection(t *testing.T) {
 		UpstreamChainID: 1,
 		Networks:        []params.Network{},
 		DB:              appdb,
-		WalletFeed:      nil,
 	}
 	client, _ := statusRpc.NewClient(config)
 
@@ -1695,7 +1678,6 @@ func TestFetchNewBlocksCommand(t *testing.T) {
 		UpstreamChainID: 1,
 		Networks:        []params.Network{},
 		DB:              appdb,
-		WalletFeed:      nil,
 	}
 	client, _ := statusRpc.NewClient(config)
 
@@ -1823,7 +1805,6 @@ func TestLoadBlocksAndTransfersCommand_FiniteFinishedInfiniteRunning(t *testing.
 		UpstreamChainID: 1,
 		Networks:        []params.Network{},
 		DB:              appdb,
-		WalletFeed:      nil,
 	}
 	client, _ := statusRpc.NewClient(config)
 

--- a/services/wallet/transfer/commands_sequential_test.go
+++ b/services/wallet/transfer/commands_sequential_test.go
@@ -23,12 +23,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rpc"
+
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/contracts"
 	"github.com/status-im/status-go/contracts/balancechecker"
 	"github.com/status-im/status-go/contracts/ethscan"
 	"github.com/status-im/status-go/contracts/ierc20"
 	ethtypes "github.com/status-im/status-go/eth-node/types"
+	"github.com/status-im/status-go/healthmanager/rpcstatus"
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	multicommon "github.com/status-im/status-go/multiaccounts/common"
 	"github.com/status-im/status-go/params"
@@ -703,12 +705,12 @@ func (tc *TestClient) SetIsConnected(value bool) {
 	}
 }
 
-func (tc *TestClient) IsConnected() bool {
+func (tc *TestClient) GetConnectionStatus() rpcstatus.StatusType {
 	if tc.traceAPICalls {
-		tc.t.Log("GetIsConnected")
+		tc.t.Log("GetConnectionStatus")
 	}
 
-	return true
+	return rpcstatus.StatusUp
 }
 
 func (tc *TestClient) GetLimiter() rpclimiter.RequestLimiter {

--- a/services/wallet/transfer/controller.go
+++ b/services/wallet/transfer/controller.go
@@ -110,29 +110,31 @@ func (c *Controller) startAccountWatcher() {
 }
 
 func (c *Controller) startNetworksWatcher() {
-	if c.rpcClient != nil && c.rpcClient.GetNetworkManager() != nil {
-		networksPublisher := c.rpcClient.GetNetworkManager().GetPublisher()
-		if networksPublisher == nil {
-			return
-		}
-
-		ch, unsubFn := pubsub.Subscribe[network.EventActiveNetworksChanged](networksPublisher, 10)
-		go func() {
-			defer gocommon.LogOnPanic()
-			defer unsubFn()
-			for {
-				select {
-				case <-c.stopCh:
-					return
-				case _, ok := <-ch:
-					if !ok {
-						return
-					}
-					c.restartReactor()
-				}
-			}
-		}()
+	if c.rpcClient == nil {
+		return
 	}
+
+	networksPublisher := c.rpcClient.GetNetworksPublisher()
+	if networksPublisher == nil {
+		return
+	}
+
+	ch, unsubFn := pubsub.Subscribe[network.EventActiveNetworksChanged](networksPublisher, 10)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer unsubFn()
+		for {
+			select {
+			case <-c.stopCh:
+				return
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				c.restartReactor()
+			}
+		}
+	}()
 }
 
 func (c *Controller) restartReactor() {

--- a/services/wallet/transfer/controller.go
+++ b/services/wallet/transfer/controller.go
@@ -110,8 +110,8 @@ func (c *Controller) startAccountWatcher() {
 }
 
 func (c *Controller) startNetworksWatcher() {
-	if c.rpcClient != nil && c.rpcClient.NetworkManager != nil {
-		networksPublisher := c.rpcClient.NetworkManager.GetPublisher()
+	if c.rpcClient != nil && c.rpcClient.GetNetworkManager() != nil {
+		networksPublisher := c.rpcClient.GetNetworkManager().GetPublisher()
 		if networksPublisher == nil {
 			return
 		}
@@ -155,7 +155,7 @@ func (c *Controller) restartReactor() {
 
 	logutils.ZapLogger().Debug("list of accounts was changed from a previous version. reactor will be restarted", zap.Stringers("new", currentAddresses))
 
-	currentNetworks, err := c.rpcClient.NetworkManager.Get(false)
+	currentNetworks, err := c.rpcClient.GetNetworkManager().Get(false)
 	if err != nil {
 		logutils.ZapLogger().Error("failed getting active networks", zap.Error(err))
 		return

--- a/signal/events_networks.go
+++ b/signal/events_networks.go
@@ -1,0 +1,16 @@
+package signal
+
+import (
+	"github.com/status-im/status-go/healthmanager"
+)
+
+const (
+	EventNetworksBlockchainHealthChanged = "networks.blockchainHealthChanged"
+)
+
+// BlockchainHealthChangedSignal is triggered when the rpc client for some blockchain goes up/down.
+type BlockchainHealthChangedSignal healthmanager.BlockchainFullStatus
+
+func SendNetworksBlockchainHealthChanged(status healthmanager.BlockchainFullStatus) {
+	send(EventNetworksBlockchainHealthChanged, BlockchainHealthChangedSignal(status))
+}

--- a/transactions/transactor_test.go
+++ b/transactions/transactor_test.go
@@ -70,7 +70,6 @@ func (s *TransactorSuite) SetupTest() {
 		UpstreamChainID: chainID,
 		Networks:        nil,
 		DB:              db,
-		WalletFeed:      nil,
 	}
 	rpcClient, _ := statusRpc.NewClient(config)
 


### PR DESCRIPTION
Replace use of the deprecated connection/status module with the healthmanager.
Events are now transmitted to the client as a separate signal instead of a wallet.Event.

Part of #https://github.com/status-im/status-go/issues/6744
