### PR TITLE
chore!: use single alchemy api key for all chains

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/status-im/status-go/services/typeddata"
 	"github.com/status-im/status-go/services/wallet"
 	walletservice "github.com/status-im/status-go/services/wallet"
-	"github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/signal"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/t/utils"
@@ -1258,14 +1257,7 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 
 	poktToken := fakeToken()
 	infuraToken := fakeToken()
-	alchemyEthereumMainnetToken := fakeToken()
-	alchemyEthereumSepoliaToken := fakeToken()
-	alchemyArbitrumMainnetToken := fakeToken()
-	alchemyArbitrumSepoliaToken := fakeToken()
-	alchemyOptimismMainnetToken := fakeToken()
-	alchemyOptimismSepoliaToken := fakeToken()
-	alchemyBaseMainnetToken := fakeToken()
-	alchemyBaseSepoliaToken := fakeToken()
+	alchemyAPIKey := fakeToken()
 	raribleMainnetAPIKey := fakeToken()
 	raribleTestnetAPIKey := fakeToken()
 
@@ -1295,18 +1287,11 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 		KeyUID:   newAccount.KeyUID,
 		Password: testPassword,
 		WalletSecretsConfig: requests.WalletSecretsConfig{
-			PoktToken:                   poktToken,
-			InfuraToken:                 infuraToken,
-			AlchemyEthereumMainnetToken: alchemyEthereumMainnetToken,
-			AlchemyEthereumSepoliaToken: alchemyEthereumSepoliaToken,
-			AlchemyArbitrumMainnetToken: alchemyArbitrumMainnetToken,
-			AlchemyArbitrumSepoliaToken: alchemyArbitrumSepoliaToken,
-			AlchemyOptimismMainnetToken: alchemyOptimismMainnetToken,
-			AlchemyOptimismSepoliaToken: alchemyOptimismSepoliaToken,
-			AlchemyBaseMainnetToken:     alchemyBaseMainnetToken,
-			AlchemyBaseSepoliaToken:     alchemyBaseSepoliaToken,
-			RaribleMainnetAPIKey:        raribleMainnetAPIKey,
-			RaribleTestnetAPIKey:        raribleTestnetAPIKey,
+			PoktToken:            poktToken,
+			InfuraToken:          infuraToken,
+			AlchemyAPIKey:        alchemyAPIKey,
+			RaribleMainnetAPIKey: raribleMainnetAPIKey,
+			RaribleTestnetAPIKey: raribleTestnetAPIKey,
 		},
 	}
 
@@ -1322,14 +1307,7 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 
 	walletConfig := testContext.backend.config.WalletConfig
 	require.Equal(t, walletConfig.InfuraAPIKey, infuraToken)
-	require.Equal(t, walletConfig.AlchemyAPIKeys[common.EthereumMainnet], alchemyEthereumMainnetToken)
-	require.Equal(t, walletConfig.AlchemyAPIKeys[common.EthereumSepolia], alchemyEthereumSepoliaToken)
-	require.Equal(t, walletConfig.AlchemyAPIKeys[common.ArbitrumMainnet], alchemyArbitrumMainnetToken)
-	require.Equal(t, walletConfig.AlchemyAPIKeys[common.ArbitrumSepolia], alchemyArbitrumSepoliaToken)
-	require.Equal(t, walletConfig.AlchemyAPIKeys[common.OptimismMainnet], alchemyOptimismMainnetToken)
-	require.Equal(t, walletConfig.AlchemyAPIKeys[common.OptimismSepolia], alchemyOptimismSepoliaToken)
-	require.Equal(t, walletConfig.AlchemyAPIKeys[common.BaseMainnet], alchemyBaseMainnetToken)
-	require.Equal(t, walletConfig.AlchemyAPIKeys[common.BaseSepolia], alchemyBaseSepoliaToken)
+	require.Equal(t, walletConfig.AlchemyAPIKey, alchemyAPIKey)
 	require.Equal(t, walletConfig.RaribleMainnetAPIKey, raribleMainnetAPIKey)
 	require.Equal(t, walletConfig.RaribleTestnetAPIKey, raribleTestnetAPIKey)
 

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -14,7 +14,6 @@ import (
 	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/protocol"
 	"github.com/status-im/status-go/protocol/identity/alias"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -153,7 +152,6 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 	walletConfig := params.WalletConfig{
 		Enabled:                true,
 		EnableMercuryoProvider: true,
-		AlchemyAPIKeys:         make(map[uint64]security.SensitiveString),
 
 		TokensListsAutoRefreshCheckInterval: walletRequest.TokensListsAutoRefreshCheckInterval,
 		TokensListsAutoRefreshInterval:      walletRequest.TokensListsAutoRefreshInterval,
@@ -183,30 +181,10 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 		walletConfig.InfuraAPIKeySecret = request.InfuraSecret
 	}
 
-	if !request.AlchemyEthereumMainnetToken.Empty() {
-		walletConfig.AlchemyAPIKeys[walletcommon.EthereumMainnet] = request.AlchemyEthereumMainnetToken
+	if !request.AlchemyAPIKey.Empty() {
+		walletConfig.AlchemyAPIKey = request.AlchemyAPIKey
 	}
-	if !request.AlchemyEthereumSepoliaToken.Empty() {
-		walletConfig.AlchemyAPIKeys[walletcommon.EthereumSepolia] = request.AlchemyEthereumSepoliaToken
-	}
-	if !request.AlchemyArbitrumMainnetToken.Empty() {
-		walletConfig.AlchemyAPIKeys[walletcommon.ArbitrumMainnet] = request.AlchemyArbitrumMainnetToken
-	}
-	if !request.AlchemyArbitrumSepoliaToken.Empty() {
-		walletConfig.AlchemyAPIKeys[walletcommon.ArbitrumSepolia] = request.AlchemyArbitrumSepoliaToken
-	}
-	if !request.AlchemyOptimismMainnetToken.Empty() {
-		walletConfig.AlchemyAPIKeys[walletcommon.OptimismMainnet] = request.AlchemyOptimismMainnetToken
-	}
-	if !request.AlchemyOptimismSepoliaToken.Empty() {
-		walletConfig.AlchemyAPIKeys[walletcommon.OptimismSepolia] = request.AlchemyOptimismSepoliaToken
-	}
-	if !request.AlchemyBaseMainnetToken.Empty() {
-		walletConfig.AlchemyAPIKeys[walletcommon.BaseMainnet] = request.AlchemyBaseMainnetToken
-	}
-	if !request.AlchemyBaseSepoliaToken.Empty() {
-		walletConfig.AlchemyAPIKeys[walletcommon.BaseSepolia] = request.AlchemyBaseSepoliaToken
-	}
+
 	if !request.StatusProxyMarketUser.Empty() {
 		walletConfig.StatusProxyMarketUser = request.StatusProxyMarketUser
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -215,15 +215,15 @@ type NodeConfig struct {
 // WalletConfig extra configuration for wallet.Service.
 type WalletConfig struct {
 	Enabled                   bool
-	OpenseaAPIKey             security.SensitiveString            `json:"OpenseaAPIKey"`
-	RaribleMainnetAPIKey      security.SensitiveString            `json:"RaribleMainnetAPIKey"`
-	RaribleTestnetAPIKey      security.SensitiveString            `json:"RaribleTestnetAPIKey"`
-	AlchemyAPIKeys            map[uint64]security.SensitiveString `json:"AlchemyAPIKeys"`
-	InfuraAPIKey              security.SensitiveString            `json:"InfuraAPIKey"`
-	InfuraAPIKeySecret        security.SensitiveString            `json:"InfuraAPIKeySecret"`
-	StatusProxyMarketUser     security.SensitiveString            `json:"StatusProxyMarketUser"`
-	StatusProxyMarketPassword security.SensitiveString            `json:"StatusProxyMarketPassword"`
-	MarketDataProxyConfig     MarketDataProxyConfig               `json:"MarketDataProxyConfig"`
+	OpenseaAPIKey             security.SensitiveString `json:"OpenseaAPIKey"`
+	RaribleMainnetAPIKey      security.SensitiveString `json:"RaribleMainnetAPIKey"`
+	RaribleTestnetAPIKey      security.SensitiveString `json:"RaribleTestnetAPIKey"`
+	AlchemyAPIKey             security.SensitiveString `json:"AlchemyAPIKey"`
+	InfuraAPIKey              security.SensitiveString `json:"InfuraAPIKey"`
+	InfuraAPIKeySecret        security.SensitiveString `json:"InfuraAPIKeySecret"`
+	StatusProxyMarketUser     security.SensitiveString `json:"StatusProxyMarketUser"`
+	StatusProxyMarketPassword security.SensitiveString `json:"StatusProxyMarketPassword"`
+	MarketDataProxyConfig     MarketDataProxyConfig    `json:"MarketDataProxyConfig"`
 	// FIXME: remove when EthRpcProxy* is integrated
 	StatusProxyBlockchainUser     security.SensitiveString `json:"StatusProxyBlockchainUser"`
 	StatusProxyBlockchainPassword security.SensitiveString `json:"StatusProxyBlockchainPassword"`

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -102,15 +102,7 @@ type WalletSecretsConfig struct {
 	OpenseaAPIKey        security.SensitiveString `json:"openseaApiKey"`
 	RaribleMainnetAPIKey security.SensitiveString `json:"raribleMainnetApiKey"`
 	RaribleTestnetAPIKey security.SensitiveString `json:"raribleTestnetApiKey"`
-
-	AlchemyEthereumMainnetToken security.SensitiveString `json:"alchemyEthereumMainnetToken"`
-	AlchemyEthereumSepoliaToken security.SensitiveString `json:"alchemyEthereumSepoliaToken"`
-	AlchemyArbitrumMainnetToken security.SensitiveString `json:"alchemyArbitrumMainnetToken"`
-	AlchemyArbitrumSepoliaToken security.SensitiveString `json:"alchemyArbitrumSepoliaToken"`
-	AlchemyOptimismMainnetToken security.SensitiveString `json:"alchemyOptimismMainnetToken"`
-	AlchemyOptimismSepoliaToken security.SensitiveString `json:"alchemyOptimismSepoliaToken"`
-	AlchemyBaseMainnetToken     security.SensitiveString `json:"alchemyBaseMainnetToken"`
-	AlchemyBaseSepoliaToken     security.SensitiveString `json:"alchemyBaseSepoliaToken"`
+	AlchemyAPIKey        security.SensitiveString `json:"alchemyApiKey"`
 
 	StatusProxyStageName      string                   `json:"statusProxyStageName"`
 	StatusProxyMarketUser     security.SensitiveString `json:"statusProxyMarketUser"`

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -142,7 +142,7 @@ func NewService(
 	openseaHTTPClient := opensea.NewHTTPClient()
 	openseaV2Client := opensea.NewClientV2(config.WalletConfig.OpenseaAPIKey, openseaHTTPClient)
 	raribleClient := rarible.NewClient(config.WalletConfig.RaribleMainnetAPIKey, config.WalletConfig.RaribleTestnetAPIKey)
-	alchemyClient := alchemy.NewClient(config.WalletConfig.AlchemyAPIKeys)
+	alchemyClient := alchemy.NewClient(config.WalletConfig.AlchemyAPIKey)
 
 	// Collectible providers in priority order (i.e. provider N+1 will be tried only if provider N fails)
 	contractOwnershipProviders := []thirdparty.CollectibleContractOwnershipProvider{

--- a/services/wallet/thirdparty/collectibles/alchemy/client.go
+++ b/services/wallet/thirdparty/collectibles/alchemy/client.go
@@ -81,21 +81,18 @@ func getNFTBaseURL(chainID walletCommon.ChainID, apiKey security.SensitiveString
 type Client struct {
 	thirdparty.CollectibleContractOwnershipProvider
 	client           *http.Client
-	apiKeys          map[uint64]security.SensitiveString
+	apiKey           security.SensitiveString
 	connectionStatus *connection.Status
 }
 
-func NewClient(apiKeys map[uint64]security.SensitiveString) *Client {
-	for _, chainID := range walletCommon.AllChainIDs() {
-		key := apiKeys[uint64(chainID)]
-		if key.Empty() {
-			logutils.ZapLogger().Warn("Alchemy API key not available for", zap.Stringer("chainID", chainID))
-		}
+func NewClient(apiKey security.SensitiveString) *Client {
+	if apiKey.Empty() {
+		logutils.ZapLogger().Warn("Alchemy API key not available")
 	}
 
 	return &Client{
 		client:           &http.Client{Timeout: time.Minute},
-		apiKeys:          apiKeys,
+		apiKey:           apiKey,
 		connectionStatus: connection.NewStatus(),
 	}
 }
@@ -175,7 +172,7 @@ func (o *Client) FetchCollectibleOwnersByContractAddress(ctx context.Context, ch
 		"withTokenBalances": {"true"},
 	}
 
-	baseURL, err := getNFTBaseURL(chainID, o.apiKeys[uint64(chainID)])
+	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
 
 	if err != nil {
 		return nil, err
@@ -246,7 +243,7 @@ func (o *Client) fetchOwnedAssets(ctx context.Context, chainID walletCommon.Chai
 	}
 	assets.Provider = o.ID()
 
-	baseURL, err := getNFTBaseURL(chainID, o.apiKeys[uint64(chainID)])
+	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
 
 	if err != nil {
 		return nil, err
@@ -328,7 +325,7 @@ func getCollectibleUniqueIDBatches(ids []thirdparty.CollectibleUniqueID) []Batch
 }
 
 func (o *Client) fetchAssetsByBatchTokenIDs(ctx context.Context, chainID walletCommon.ChainID, batchIDs BatchTokenIDs) ([]thirdparty.FullCollectibleData, error) {
-	baseURL, err := getNFTBaseURL(chainID, o.apiKeys[uint64(chainID)])
+	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +416,7 @@ func getContractAddressBatches(ids []thirdparty.ContractID) []BatchContractAddre
 }
 
 func (o *Client) fetchCollectionsDataByBatchContractAddresses(ctx context.Context, chainID walletCommon.ChainID, batchAddresses BatchContractAddresses) ([]thirdparty.CollectionData, error) {
-	baseURL, err := getNFTBaseURL(chainID, o.apiKeys[uint64(chainID)])
+	baseURL, err := getNFTBaseURL(chainID, o.apiKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
status-desktop PR: https://github.com/status-im/status-desktop/pull/18345
Blocked by: https://github.com/status-im/status-desktop/issues/18346

Replace multiple API keys for Alchemy (one per chain) with a single one, according to https://www.alchemy.com/blog/the-future-is-multichain