### PR TITLE
fix_: TestBasicWakuV2

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -142,7 +142,7 @@ pipeline {
           "--env=POSTGRES_HOST_AUTH_METHOD=trust",
           "--publish=${DB_PORT}:${DB_PORT}",
         ].join(' '), "-p ${DB_PORT}") { c ->
-          nwaku = docker.image('harbor.status.im/wakuorg/nwaku:v0.35.1').withRun([
+          nwaku = docker.image('harbor.status.im/wakuorg/nwaku:latest').withRun([
             "--name=${NWAKU_CONT}",
             "--publish=${NWAKU_TCP_PORT}:${NWAKU_TCP_PORT}/tcp",
             "--publish=${NWAKU_UDP_PORT}:${NWAKU_UDP_PORT}/udp",

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -151,6 +151,7 @@ pipeline {
             "--tcp-port=${NWAKU_TCP_PORT}",
             "--discv5-discovery=true",
             "--cluster-id=16",
+            "--num-shards-in-network=0",
             "--shard=32",
             "--shard=64",
             "--nat=extip:${ipAddress}",

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -142,7 +142,7 @@ pipeline {
           "--env=POSTGRES_HOST_AUTH_METHOD=trust",
           "--publish=${DB_PORT}:${DB_PORT}",
         ].join(' '), "-p ${DB_PORT}") { c ->
-          nwaku = docker.image('harbor.status.im/wakuorg/nwaku:latest').withRun([
+          nwaku = docker.image('wakuorg/nwaku:v0.36.0').withRun([
             "--name=${NWAKU_CONT}",
             "--publish=${NWAKU_TCP_PORT}:${NWAKU_TCP_PORT}/tcp",
             "--publish=${NWAKU_UDP_PORT}:${NWAKU_UDP_PORT}/udp",
@@ -151,7 +151,7 @@ pipeline {
             "--tcp-port=${NWAKU_TCP_PORT}",
             "--discv5-discovery=true",
             "--cluster-id=16",
-            "--num-shards-in-network=0",
+         // "--num-shards-in-network=0", // uncomment when switching to nwaku:v0.37.0
             "--shard=32",
             "--shard=64",
             "--nat=extip:${ipAddress}",


### PR DESCRIPTION
Using the latest nwaku release (`v0.36.0`) for the unit tests

In addition to that, commenting a fix to an issue we saw recently that broke the CI in `TestBasicWakuV2`, which came from a breaking change that will enter release `v0.37.0`

When upgrading to `v0.37.0`, uncomment that line in order not to experience that same issue.


Important changes:
- [x] setting nwaku image to `v0.36.0`
- [x] commenting fix needed to migrate to release `v0.37.0` 
