### PR TITLE
chore_: unskip TestTokenMasterAcceptsRequestToJoinAfter

### DIFF
--- a/protocol/communities_events_token_master_test.go
+++ b/protocol/communities_events_token_master_test.go
@@ -219,8 +219,6 @@ func (s *TokenMasterCommunityEventsSuite) TestReceiveRequestsToJoinWithRevealedA
 }
 
 func (s *TokenMasterCommunityEventsSuite) TestTokenMasterAcceptsRequestToJoinAfterMemberLeave() {
-	s.T().Skip("flaky test")
-
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{})
 
 	// set up additional user that will send request to join


### PR DESCRIPTION
Flaky tests should not be skipped. A retry mechanism is in place that prevents CI test jobs from failing unless a test fails three times in a row.
