### PR TITLE
perf_: Don't store community members for public chats

### DIFF
--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -520,7 +520,7 @@ func CreateOneToOneChat(name string, publicKey *ecdsa.PublicKey, timesource comm
 	}
 }
 
-func CreateCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, timesource common.TimeSource) *Chat {
+func createCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, timesource common.TimeSource) *Chat {
 	color := orgChat.Identity.Color
 	if color == "" {
 		color = chatColors[rand.Intn(len(chatColors))] // nolint: gosec
@@ -556,6 +556,16 @@ func CreateCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, 
 		FirstMessageTimestamp:    orgChat.Identity.FirstMessageTimestamp,
 		ViewersCanPostReactions:  orgChat.ViewersCanPostReactions,
 	}
+}
+
+func CreateCommunityChat(org *communities.Community, orgChat *protobuf.CommunityChat, chatID string, timesource common.TimeSource) *Chat {
+	orgID := org.IDString()
+	chat := createCommunityChat(orgID, chatID, orgChat, timesource)
+	// No need for members in public channels
+	if !org.ChannelEncrypted(chatID) {
+		chat.Members = []ChatMember{}
+	}
+	return chat
 }
 
 func (c *Chat) CommunityChannelID() string {
@@ -595,10 +605,9 @@ func (c *Chat) DeepLink() string {
 
 func CreateCommunityChats(org *communities.Community, timesource common.TimeSource) []*Chat {
 	var chats []*Chat
-	orgID := org.IDString()
-
 	for chatID, chat := range org.Chats() {
-		chats = append(chats, CreateCommunityChat(orgID, chatID, chat, timesource))
+		chat := CreateCommunityChat(org, chat, chatID, timesource)
+		chats = append(chats, chat)
 	}
 	return chats
 }

--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -563,7 +563,7 @@ func createCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, 
 
 func CreateCommunityChat(org *communities.Community, orgChat *protobuf.CommunityChat, chatID string, timesource common.TimeSource) *Chat {
 	orgID := org.IDString()
-	populateMembers := org.ChannelEncrypted(chatID)
+	populateMembers := org.ChannelHasPermissions(chatID)
 	chat := createCommunityChat(orgID, chatID, orgChat, timesource, populateMembers)
 
 	return chat

--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -520,7 +520,7 @@ func CreateOneToOneChat(name string, publicKey *ecdsa.PublicKey, timesource comm
 	}
 }
 
-func createCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, timesource common.TimeSource) *Chat {
+func createCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, timesource common.TimeSource, populateMembers bool) *Chat {
 	color := orgChat.Identity.Color
 	if color == "" {
 		color = chatColors[rand.Intn(len(chatColors))] // nolint: gosec
@@ -530,12 +530,15 @@ func createCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, 
 
 	// Populate community _channel_ members to _chat_ members
 	chatMembers := []ChatMember{}
-	for pubKey := range orgChat.Members {
-		chatMember := ChatMember{
-			ID:    pubKey,
-			Admin: false,
+	if populateMembers {
+		// Populate chat members from orgChat members
+		for pubKey := range orgChat.Members {
+			chatMember := ChatMember{
+				ID:    pubKey,
+				Admin: false,
+			}
+			chatMembers = append(chatMembers, chatMember)
 		}
-		chatMembers = append(chatMembers, chatMember)
 	}
 
 	return &Chat{
@@ -560,11 +563,9 @@ func createCommunityChat(orgID, chatID string, orgChat *protobuf.CommunityChat, 
 
 func CreateCommunityChat(org *communities.Community, orgChat *protobuf.CommunityChat, chatID string, timesource common.TimeSource) *Chat {
 	orgID := org.IDString()
-	chat := createCommunityChat(orgID, chatID, orgChat, timesource)
-	// No need for members in public channels
-	if !org.ChannelEncrypted(chatID) {
-		chat.Members = []ChatMember{}
-	}
+	populateMembers := org.ChannelEncrypted(chatID)
+	chat := createCommunityChat(orgID, chatID, orgChat, timesource, populateMembers)
+
 	return chat
 }
 

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -713,7 +713,7 @@ func (o *Community) getChatMember(pk *ecdsa.PublicKey, chatID string) *protobuf.
 	key := common.PubkeyToHex(pk)
 	member := chat.Members[key]
 
-	if member == nil && !channelEncrypted(o.ChatID(chatID), o.config.CommunityDescription.TokenPermissions) {
+	if member == nil && !channelHasPermissions(o.ChatID(chatID), o.config.CommunityDescription.TokenPermissions) {
 		// User is a member of the community, but not in the chat. The chat is public, so we return the community member.
 		return o.getMember(pk)
 	}
@@ -1697,18 +1697,6 @@ func dehydrateChannelsMembers(description *protobuf.CommunityDescription) {
 	for channelID, channel := range description.Chats {
 		if !channelHasPermissions(ChatID(description.ID, channelID), description.TokenPermissions) {
 			channel.Members = map[string]*protobuf.CommunityMember{} // clean members
-		} else if !channelEncrypted(ChatID(description.ID, channelID), description.TokenPermissions) {
-			// Has some permissions, but not encrypted. Everyone can view, only members can post.
-			membersToKeep := make(map[string]*protobuf.CommunityMember)
-			for id, member := range channel.Members {
-				isViewer := member.GetChannelRole() == protobuf.CommunityMember_CHANNEL_ROLE_VIEWER
-				if !isViewer {
-					// If the member is a viewer, we can remove them from the channel members
-					// as they are not allowed to post anyway.
-					membersToKeep[id] = member
-				}
-			}
-			channel.Members = membersToKeep // keep only members that can post
 		}
 	}
 }
@@ -2153,7 +2141,7 @@ func (o *Community) CanView(pk *ecdsa.PublicKey, chatID string) bool {
 		return false
 	}
 
-	if !channelEncrypted(o.ChatID(chatID), o.config.CommunityDescription.TokenPermissions) {
+	if !channelHasPermissions(o.ChatID(chatID), o.config.CommunityDescription.TokenPermissions) {
 		return true
 	}
 

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -711,7 +711,14 @@ func (o *Community) getChatMember(pk *ecdsa.PublicKey, chatID string) *protobuf.
 	}
 
 	key := common.PubkeyToHex(pk)
-	return chat.Members[key]
+	member := chat.Members[key]
+
+	if member == nil && !channelEncrypted(o.ChatID(chatID), o.config.CommunityDescription.TokenPermissions) {
+		// User is a member of the community, but not in the chat. The chat is public, so we return the community member.
+		return o.getMember(pk)
+	}
+
+	return member
 }
 
 func (o *Community) hasMember(pk *ecdsa.PublicKey) bool {
@@ -1690,17 +1697,18 @@ func dehydrateChannelsMembers(description *protobuf.CommunityDescription) {
 	for channelID, channel := range description.Chats {
 		if !channelHasPermissions(ChatID(description.ID, channelID), description.TokenPermissions) {
 			channel.Members = map[string]*protobuf.CommunityMember{} // clean members
-		}
-	}
-}
-
-func hydrateChannelsMembers(description *protobuf.CommunityDescription) {
-	for channelID, channel := range description.Chats {
-		if !channelHasPermissions(ChatID(description.ID, channelID), description.TokenPermissions) {
-			channel.Members = make(map[string]*protobuf.CommunityMember)
-			for pubKey, member := range description.Members {
-				channel.Members[pubKey] = member
+		} else if !channelEncrypted(ChatID(description.ID, channelID), description.TokenPermissions) {
+			// Has some permissions, but not encrypted. Everyone can view, only members can post.
+			membersToKeep := make(map[string]*protobuf.CommunityMember)
+			for id, member := range channel.Members {
+				isViewer := member.GetChannelRole() == protobuf.CommunityMember_CHANNEL_ROLE_VIEWER
+				if !isViewer {
+					// If the member is a viewer, we can remove them from the channel members
+					// as they are not allowed to post anyway.
+					membersToKeep[id] = member
+				}
 			}
+			channel.Members = membersToKeep // keep only members that can post
 		}
 	}
 }
@@ -1927,6 +1935,12 @@ func channelEncrypted(chatID string, permissions map[string]*protobuf.CommunityT
 	return hasPermission && !viewableByEveryone
 }
 
+func (o *Community) ChannelHasPermissions(channelID string) bool {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	return channelHasPermissions(o.ChatID(channelID), o.config.CommunityDescription.TokenPermissions)
+}
+
 func (o *Community) channelEncrypted(channelID string) bool {
 	return channelEncrypted(o.ChatID(channelID), o.config.CommunityDescription.TokenPermissions)
 }
@@ -2118,7 +2132,7 @@ func (o *Community) CanView(pk *ecdsa.PublicKey, chatID string) bool {
 	}
 
 	// community creator can always post, return immediately
-	if common.IsPubKeyEqual(pk, o.ControlNode()) {
+	if common.IsPubKeyEqual(pk, o.ControlNode()) || o.IsPrivilegedMember(pk) {
 		return true
 	}
 
@@ -2139,6 +2153,10 @@ func (o *Community) CanView(pk *ecdsa.PublicKey, chatID string) bool {
 		return false
 	}
 
+	if !channelEncrypted(o.ChatID(chatID), o.config.CommunityDescription.TokenPermissions) {
+		return true
+	}
+
 	if chat.Members == nil {
 		o.config.Logger.Debug("Community.CanView: no members in chat", zap.String("chat-id", chatID))
 		return false
@@ -2154,8 +2172,18 @@ func (o *Community) CanPost(pk *ecdsa.PublicKey, chatID string, messageType prot
 		return false, nil
 	}
 
+	if o.IsPrivilegedMember(pk) || common.IsPubKeyEqual(pk, o.ControlNode()) {
+		// If the user is a privileged member, they can post in any chat
+		return true, nil
+	}
+
 	chat := o.config.CommunityDescription.Chats[chatID]
 	member := chat.Members[common.PubkeyToHex(pk)]
+
+	// Channels with permissions require the member to be present
+	if member == nil && channelHasPermissions(o.ChatID(chatID), o.config.CommunityDescription.TokenPermissions) {
+		return false, nil
+	}
 
 	switch messageType {
 	case protobuf.ApplicationMetadataMessage_PIN_MESSAGE:
@@ -2369,49 +2397,6 @@ func (o *Community) AddMemberToChat(chatID string, publicKey *ecdsa.PublicKey,
 	return changes, nil
 }
 
-func (o *Community) PopulateChannelsWithAllMembers() {
-	members := o.Members()
-	for _, channel := range o.Chats() {
-		channel.Members = members
-	}
-	o.increaseClock()
-}
-
-func (o *Community) PopulateChatWithAllMembers(chatID string) (*CommunityChanges, error) {
-	o.mutex.Lock()
-	defer o.mutex.Unlock()
-
-	if !o.IsControlNode() {
-		return o.emptyCommunityChanges(), ErrNotControlNode
-	}
-
-	return o.populateChatWithAllMembers(chatID)
-}
-
-func (o *Community) populateChatWithAllMembers(chatID string) (*CommunityChanges, error) {
-	result := o.emptyCommunityChanges()
-
-	chat, exists := o.chats()[chatID]
-	if !exists {
-		return result, ErrChatNotFound
-	}
-
-	membersAdded := make(map[string]*protobuf.CommunityMember)
-	for pubKey, member := range o.Members() {
-		if chat.Members[pubKey] == nil {
-			membersAdded[pubKey] = member
-		}
-	}
-	result.ChatsModified[chatID] = &CommunityChatChanges{
-		MembersAdded: membersAdded,
-	}
-
-	chat.Members = o.Members()
-	o.increaseClock()
-
-	return result, nil
-}
-
 func ChatID(communityID, channelID string) string {
 	return communityID + channelID
 }
@@ -2601,11 +2586,6 @@ func (o *Community) createChat(chatID string, chat *protobuf.CommunityChat) erro
 		if c.CategoryId == chat.CategoryId {
 			chat.Position++
 		}
-	}
-
-	chat.Members = make(map[string]*protobuf.CommunityMember)
-	for pubKey, member := range o.config.CommunityDescription.Members {
-		chat.Members[pubKey] = member
 	}
 
 	o.config.CommunityDescription.Chats[chatID] = chat

--- a/protocol/communities/community_encryption_key_action.go
+++ b/protocol/communities/community_encryption_key_action.go
@@ -86,11 +86,17 @@ func evaluateChannelLevelEncryptionKeyActions(origin, modified *Community, chang
 			membersRemoved = chatChanges.MembersRemoved
 		}
 
+		// Channel with 0 members is considered open
+		allMembers := modified.config.CommunityDescription.Chats[channelID].Members
+		if len(allMembers) == 0 {
+			allMembers = modified.config.CommunityDescription.Members
+		}
+
 		result[channelID] = *evaluateEncryptionKeyAction(
 			origin.ChannelEncrypted(channelID),
 			modified.ChannelEncrypted(channelID),
 			changes.ControlNodeChanged != nil,
-			modified.config.CommunityDescription.Chats[channelID].Members,
+			allMembers,
 			membersAdded,
 			membersRemoved,
 		)

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1320,7 +1320,6 @@ func (m *Manager) reevaluateMemberChannelsPermissions(community *Community, memb
 
 		// ensure member is added if channel has no permissions
 		if !hasChannelPermission {
-			addToChannels[channelID] = protobuf.CommunityMember_CHANNEL_ROLE_POSTER
 			continue
 		}
 
@@ -2307,9 +2306,6 @@ func (m *Manager) preprocessDescription(id types.HexBytes, description *protobuf
 	}
 
 	upgradeTokenPermissions(description)
-
-	// Workaround for https://github.com/status-im/status-desktop/issues/12188
-	hydrateChannelsMembers(description)
 
 	return response, description, m.persistence.SaveDecryptedCommunityDescription(id, response, description)
 }

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1318,7 +1318,7 @@ func (m *Manager) reevaluateMemberChannelsPermissions(community *Community, memb
 	for channelID := range community.Chats() {
 		channelPermissionsCheckResult, hasChannelPermission := channelPermissionsCheckResult[community.ChatID(channelID)]
 
-		// ensure member is added if channel has no permissions
+		// Permissionless channels are public - no need to check permissions
 		if !hasChannelPermission {
 			continue
 		}

--- a/protocol/communities_messenger_signers_test.go
+++ b/protocol/communities_messenger_signers_test.go
@@ -863,7 +863,8 @@ func (s *MessengerCommunitiesSignersSuite) TestControlNodeDeviceChanged() {
 	s.Require().NoError(err)
 	s.Require().Len(community.Members(), 2)
 	for _, chat := range community.Chats() {
-		s.Require().Len(chat.Members, 2)
+		// All chats are public, so no members
+		s.Require().Len(chat.Members, 0)
 	}
 
 	// Bob will receive request to share RevealedAddresses and send request to join to the control node

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -4548,9 +4548,9 @@ func (s *MessengerCommunitiesSuite) TestOpenAndNotJoinedCommunityNewChannelIsNot
 	s.Require().Len(response.CommunityChanges[0].ChatsAdded, 1)
 	s.Require().Len(response.Communities(), 1)
 	s.Require().Len(response.Chats(), 1)
-	s.Require().Len(response.Chats()[0].Members, 2)
+	s.Require().Len(response.Chats()[0].Members, 0)
 	for _, chat := range response.Communities()[0].Chats() {
-		s.Require().Len(chat.Members, 2)
+		s.Require().Len(chat.Members, 0)
 	}
 
 	// Check Alice gets the correct member list for a new channel
@@ -4559,16 +4559,16 @@ func (s *MessengerCommunitiesSuite) TestOpenAndNotJoinedCommunityNewChannelIsNot
 		func(r *MessengerResponse) bool {
 			if len(r.Chats()) == 1 && len(r.Communities()) > 0 {
 				for _, chat := range r.Chats() {
-					s.Require().Len(chat.Members, 2)
+					s.Require().Len(chat.Members, 0)
 				}
 				for _, chat := range r.Communities()[0].Chats() {
-					s.Require().Len(chat.Members, 2)
+					s.Require().Len(chat.Members, 0)
 				}
 				return true
 			}
 			return false
 		},
-		"no commiunity message for Alice",
+		"no community message for Alice",
 	)
 	s.Require().NoError(err)
 
@@ -4576,7 +4576,7 @@ func (s *MessengerCommunitiesSuite) TestOpenAndNotJoinedCommunityNewChannelIsNot
 	s.Require().NoError(err)
 	s.Require().Len(aliceCommunity.Chats(), 2)
 	for _, chat := range aliceCommunity.Chats() {
-		s.Require().Len(chat.Members, 2)
+		s.Require().Len(chat.Members, 0)
 	}
 }
 

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -1017,17 +1017,13 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestAnnouncementsChannelPerm
 			if channel == nil || len(channel.Members) != 0 {
 				return false
 			}
-			return c.IsMemberLikelyInChat(chat.CommunityChatID())
+			return c.IsMemberInChat(s.bob.IdentityPublicKey(), chat.CommunityChatID()) &&
+				c.IsMemberLikelyInChat(chat.CommunityChatID())
 		},
 		"no community that satisfies criteria",
 	)
 
 	s.Require().NoError(err)
-
-	// bob should be in the bloom filter list
-	community, err = s.bob.communitiesManager.GetByID(community.ID())
-	s.Require().NoError(err)
-	s.Require().True(community.IsMemberLikelyInChat(chat.CommunityChatID()))
 
 	// bob can't post
 	msg := &common.Message{
@@ -1881,7 +1877,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestResendEncryptionKeyOnBac
 
 	waitOnChannelKeyToBeDistributedToBob := s.waitOnKeyDistribution(func(sub *CommunityAndKeyActions) bool {
 		action, ok := sub.keyActions.ChannelKeysActions[chat.CommunityChatID()]
-		if !ok || action.ActionType != communities.EncryptionKeySendToMembers {
+		if !ok || action.ActionType != communities.EncryptionKeyAdd {
 			return false
 		}
 
@@ -1893,7 +1889,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestResendEncryptionKeyOnBac
 	s.Require().NoError(err)
 
 	// bob receives community changes
-	// channel members should not be empty,
+	// channel members should be empty,
 	// this info is available only to channel members with encryption key
 	_, err = WaitOnMessengerResponse(
 		s.bob,
@@ -2165,7 +2161,8 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestImportDecryptedArchiveMe
 		if !ok || action.ActionType != communities.EncryptionKeyAdd {
 			return false
 		}
-		return true
+		_, ok = action.Members[common.PubkeyToHex(&s.owner.identity.PublicKey)]
+		return ok
 	})
 
 	waitOnCommunityPermissionCreated := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -1012,9 +1012,9 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestAnnouncementsChannelPerm
 				return false
 			}
 			channel := c.Chats()[chat.CommunityChatID()]
-			// The channel is not encrypted. Should have no members
+			// The channel is not encrypted. Should have one member
 			// and bob should be a viewer
-			if channel == nil || len(channel.Members) != 0 {
+			if channel == nil || len(channel.Members) != 1 {
 				return false
 			}
 			return c.IsMemberInChat(s.bob.IdentityPublicKey(), chat.CommunityChatID()) &&
@@ -1038,6 +1038,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestAnnouncementsChannelPerm
 	s.Require().Error(err)
 	s.Require().Contains(err.Error(), "can't post")
 
+	// owner can post
 	msg = s.sendChatMessage(s.owner, chat.ID, "hello on announcements channel")
 	// bob can read the message
 	response, err = WaitOnMessengerResponse(
@@ -1096,11 +1097,16 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestAnnouncementsChannelPerm
 				return false
 			}
 			channel := c.Chats()[chat.CommunityChatID()]
-			// The channel is not encrypted. Should have no members
-			// and alice should be a poster
-			if channel == nil || len(channel.Members) == 0 {
+			// The channel is not encrypted, but has permissions. Should have 2 members
+			// Alice - poster, bob - viewer
+			if channel == nil || len(channel.Members) != 2 {
 				return false
 			}
+
+			if channel.Members[s.alice.IdentityPublicKeyString()].ChannelRole != protobuf.CommunityMember_CHANNEL_ROLE_POSTER {
+				return false
+			}
+
 			return c.IsMemberLikelyInChat(chat.CommunityChatID())
 		},
 		"no community that satisfies criteria",
@@ -1110,7 +1116,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestAnnouncementsChannelPerm
 	s.Require().NoError(err)
 	chatID := strings.TrimPrefix(chat.ID, community.IDString())
 	members := community.Chats()[chatID].Members
-	s.Require().Len(members, 1)
+	s.Require().Len(members, 2)
 	// confirm that member is a viewer and not a poster
 	s.Require().Equal(protobuf.CommunityMember_CHANNEL_ROLE_POSTER, members[s.alice.IdentityPublicKeyString()].ChannelRole)
 

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -812,7 +812,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testViewChannelPermissions(v
 
 	waitOnBobToBeKickedFromChannel := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
 		channel, ok := sub.Community.Chats()[chat.CommunityChatID()]
-		return ok && len(channel.Members) == 1
+		return ok && len(channel.Members) == 0
 	})
 	waitOnChannelToBeRekeyedOnceBobIsKicked := s.waitOnKeyDistribution(func(sub *CommunityAndKeyActions) bool {
 		action, ok := sub.keyActions.ChannelKeysActions[chat.CommunityChatID()]
@@ -839,6 +839,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testViewChannelPermissions(v
 	s.Require().NoError(err)
 	s.Require().Len(response.Communities(), 1)
 	s.Require().True(s.owner.communitiesManager.IsChannelEncrypted(community.IDString(), chat.ID))
+	s.Require().True(response.Communities()[0].ChannelHasPermissions(chat.CommunityChatID()))
 
 	err = <-waitOnBobToBeKickedFromChannel
 	s.Require().NoError(err)
@@ -859,6 +860,9 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testViewChannelPermissions(v
 			if c == nil {
 				return false
 			}
+			if !c.ChannelEncrypted(chat.CommunityChatID()) {
+				return false
+			}
 			channel := c.Chats()[chat.CommunityChatID()]
 			return channel != nil && len(channel.Members) == 0
 		},
@@ -868,6 +872,8 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testViewChannelPermissions(v
 
 	// bob should not be in the bloom filter list
 	community, err = s.bob.communitiesManager.GetByID(community.ID())
+	s.Require().True(s.bob.communitiesManager.IsChannelEncrypted(community.IDString(), chat.ID))
+	s.Require().True(community.ChannelHasPermissions(chat.CommunityChatID()))
 	s.Require().NoError(err)
 	s.Require().False(community.IsMemberLikelyInChat(chat.CommunityChatID()))
 
@@ -981,6 +987,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestAnnouncementsChannelPerm
 	response, err := s.owner.CreateCommunityTokenPermission(&channelPermissionRequest)
 	s.Require().NoError(err)
 	s.Require().Len(response.Communities(), 1)
+	s.Require().True(response.Communities()[0].ChannelHasPermissions(chat.CommunityChatID()))
 	s.Require().False(s.owner.communitiesManager.IsChannelEncrypted(community.IDString(), chat.ID))
 
 	// bob should be in the bloom filter list since everyone has access to readonly channels
@@ -997,23 +1004,24 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestAnnouncementsChannelPerm
 	_, err = WaitOnMessengerResponse(
 		s.bob,
 		func(r *MessengerResponse) bool {
-			c, err := s.bob.GetCommunityByID(community.ID())
-			if err != nil {
+			if len(r.Communities()) == 0 || !r.Communities()[0].ChannelHasPermissions(chat.CommunityChatID()) {
 				return false
 			}
+			c := r.Communities()[0]
 			if c == nil {
 				return false
 			}
 			channel := c.Chats()[chat.CommunityChatID()]
-
-			if channel == nil || len(channel.Members) != 2 {
+			// The channel is not encrypted. Should have no members
+			// and bob should be a viewer
+			if channel == nil || len(channel.Members) != 0 {
 				return false
 			}
-			member := channel.Members[s.bob.IdentityPublicKeyString()]
-			return member != nil && member.ChannelRole == protobuf.CommunityMember_CHANNEL_ROLE_VIEWER
+			return c.IsMemberLikelyInChat(chat.CommunityChatID())
 		},
 		"no community that satisfies criteria",
 	)
+
 	s.Require().NoError(err)
 
 	// bob should be in the bloom filter list
@@ -1033,6 +1041,133 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestAnnouncementsChannelPerm
 	_, err = s.bob.SendChatMessage(context.Background(), msg)
 	s.Require().Error(err)
 	s.Require().Contains(err.Error(), "can't post")
+
+	msg = s.sendChatMessage(s.owner, chat.ID, "hello on announcements channel")
+	// bob can read the message
+	response, err = WaitOnMessengerResponse(
+		s.bob,
+		func(r *MessengerResponse) bool {
+			_, ok := r.messages[msg.ID]
+			return ok
+		},
+		"no messages",
+	)
+	s.Require().NoError(err)
+	s.Require().Len(response.Messages(), 1)
+	s.Require().Equal(msg.Text, response.Messages()[0].Text)
+
+	// alice joins the community
+	s.advertiseCommunityTo(community, s.alice)
+	s.joinCommunity(community, s.alice)
+
+	// setup view and post channel permission
+	channelPermissionRequest = requests.CreateCommunityTokenPermission{
+		CommunityID: community.ID(),
+		Type:        protobuf.CommunityTokenPermission_CAN_VIEW_AND_POST_CHANNEL,
+		ChatIds:     []string{chat.ID},
+		TokenCriteria: []*protobuf.TokenCriteria{
+			{
+				Type:              protobuf.CommunityTokenType_ERC20,
+				ContractAddresses: map[uint64]string{testChainID1: "0x124"},
+				Symbol:            "TEST2",
+				AmountInWei:       "200000000000000000000",
+				Decimals:          uint64(18),
+			},
+		},
+	}
+
+	response, err = s.owner.CreateCommunityTokenPermission(&channelPermissionRequest)
+	s.Require().NoError(err)
+	s.Require().Len(response.Communities(), 1)
+	s.Require().True(response.Communities()[0].ChannelHasPermissions(chat.CommunityChatID()))
+	s.Require().False(s.owner.communitiesManager.IsChannelEncrypted(community.IDString(), chat.ID))
+
+	// make alice satisfy channel criteria
+	s.makeAddressSatisfyTheCriteria(testChainID1, aliceAddress1, channelPermissionRequest.TokenCriteria[0])
+	// force owner to reevaluate channel members
+	// in production it will happen automatically, by periodic check
+	err = s.owner.communitiesManager.ForceMembersReevaluation(community.ID())
+
+	// alice receives community changes
+	_, err = WaitOnMessengerResponse(
+		s.alice,
+		func(r *MessengerResponse) bool {
+			if len(r.Communities()) == 0 || !r.Communities()[0].ChannelHasPermissions(chat.CommunityChatID()) {
+				return false
+			}
+			c := r.Communities()[0]
+			if c == nil {
+				return false
+			}
+			channel := c.Chats()[chat.CommunityChatID()]
+			// The channel is not encrypted. Should have no members
+			// and alice should be a poster
+			if channel == nil || len(channel.Members) == 0 {
+				return false
+			}
+			return c.IsMemberLikelyInChat(chat.CommunityChatID())
+		},
+		"no community that satisfies criteria",
+	)
+
+	community, err = s.alice.communitiesManager.GetByID(community.ID())
+	s.Require().NoError(err)
+	chatID := strings.TrimPrefix(chat.ID, community.IDString())
+	members := community.Chats()[chatID].Members
+	s.Require().Len(members, 1)
+	// confirm that member is a viewer and not a poster
+	s.Require().Equal(protobuf.CommunityMember_CHANNEL_ROLE_POSTER, members[s.alice.IdentityPublicKeyString()].ChannelRole)
+
+	// bob can't post
+	msg = &common.Message{
+		ChatMessage: &protobuf.ChatMessage{
+			ChatId:      chat.ID,
+			ContentType: protobuf.ChatMessage_TEXT_PLAIN,
+			Text:        "I can't post on read-only channel",
+		},
+	}
+
+	_, err = s.bob.SendChatMessage(context.Background(), msg)
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), "can't post")
+
+	// alice can post
+	msg = &common.Message{
+		ChatMessage: &protobuf.ChatMessage{
+			ChatId:      chat.ID,
+			ContentType: protobuf.ChatMessage_TEXT_PLAIN,
+			Text:        "I can post on read-only channel",
+		},
+	}
+
+	_, err = s.alice.SendChatMessage(context.Background(), msg)
+	s.Require().NoError(err)
+
+	// owner can read the message
+	response, err = WaitOnMessengerResponse(
+		s.owner,
+		func(r *MessengerResponse) bool {
+			_, ok := r.messages[msg.ID]
+			return ok
+		},
+		"no messages",
+	)
+	s.Require().NoError(err)
+	s.Require().Len(response.Messages(), 1)
+	s.Require().Equal(msg.Text, response.Messages()[0].Text)
+
+	// bob can read the message
+	response, err = WaitOnMessengerResponse(
+		s.bob,
+		func(r *MessengerResponse) bool {
+			_, ok := r.messages[msg.ID]
+			return ok
+		},
+		"no messages",
+	)
+	s.Require().NoError(err)
+	s.Require().Len(response.Messages(), 1)
+	s.Require().Equal(msg.Text, response.Messages()[0].Text)
 }
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) TestSearchMessageinPermissionedChannel() {
@@ -1099,7 +1234,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestSearchMessageinPermissio
 
 	waitOnBobToBeKickedFromChannel := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
 		channel, ok := sub.Community.Chats()[chat.CommunityChatID()]
-		return ok && len(channel.Members) == 1
+		return ok && len(channel.Members) == 0
 	})
 	waitOnChannelToBeRekeyedOnceBobIsKicked := s.waitOnKeyDistribution(func(sub *CommunityAndKeyActions) bool {
 		action, ok := sub.keyActions.ChannelKeysActions[chat.CommunityChatID()]
@@ -1144,6 +1279,9 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestSearchMessageinPermissio
 				return false
 			}
 			if c == nil {
+				return false
+			}
+			if !c.ChannelEncrypted(chat.CommunityChatID()) {
 				return false
 			}
 			channel := c.Chats()[chat.CommunityChatID()]
@@ -1188,9 +1326,15 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestMemberRoleGetUpdatedWhen
 	s.Require().Len(response.Messages(), 1)
 	s.Require().Equal(msg.Text, response.Messages()[0].Text)
 
+	community, err = s.bob.communitiesManager.GetByID(community.ID())
+	s.Require().NoError(err)
+	s.Require().Len(community.Chats(), 1)
+	s.Require().Len(community.Chats()[chat.CommunityChatID()].Members, 0)
+	s.Require().True(community.IsMemberInChat(community.MemberIdentity(), chat.CommunityChatID()))
+
 	waitOnBobToBeKickedFromChannel := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {
 		channel, ok := sub.Community.Chats()[chat.CommunityChatID()]
-		return ok && len(channel.Members) == 1
+		return ok && len(channel.Members) == 0 && !sub.Community.IsMemberInChat(community.MemberIdentity(), chat.CommunityChatID())
 	})
 	waitOnChannelToBeRekeyedOnceBobIsKicked := s.waitOnKeyDistribution(func(sub *CommunityAndKeyActions) bool {
 		action, ok := sub.keyActions.ChannelKeysActions[chat.CommunityChatID()]
@@ -1218,6 +1362,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestMemberRoleGetUpdatedWhen
 	s.Require().Len(response.Communities(), 1)
 	s.Require().Len(response.CommunityChanges[0].TokenPermissionsAdded, 1)
 	s.Require().True(s.owner.communitiesManager.IsChannelEncrypted(community.IDString(), chat.ID))
+	s.Require().True(response.Communities()[0].ChannelHasPermissions(chat.CommunityChatID()))
 
 	err = <-waitOnBobToBeKickedFromChannel
 	s.Require().NoError(err)
@@ -1239,7 +1384,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestMemberRoleGetUpdatedWhen
 				return false
 			}
 			channel := c.Chats()[chat.CommunityChatID()]
-			return channel != nil && len(channel.Members) == 0
+			return channel != nil && len(channel.Members) == 0 && !c.IsMemberInChat(c.MemberIdentity(), chat.CommunityChatID())
 		},
 		"no community that satisfies criteria",
 	)
@@ -1270,7 +1415,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestMemberRoleGetUpdatedWhen
 	s.Require().NoError(err)
 	chatID := strings.TrimPrefix(chat.ID, community.IDString())
 	members := community.Chats()[chatID].Members
-	s.Require().Len(members, 2)
+	s.Require().Len(members, 1)
 	// confirm that member is a viewer and not a poster
 	s.Require().Equal(protobuf.CommunityMember_CHANNEL_ROLE_VIEWER, members[s.bob.IdentityPublicKeyString()].ChannelRole)
 
@@ -1333,7 +1478,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestMemberRoleGetUpdatedWhen
 	s.Require().NoError(err)
 
 	members = community.Chats()[chatID].Members
-	s.Require().Len(members, 2)
+	s.Require().Len(members, 1)
 	// confirm that member is now a poster
 	s.Require().Equal(protobuf.CommunityMember_CHANNEL_ROLE_POSTER, members[s.bob.IdentityPublicKeyString()].ChannelRole)
 
@@ -1354,7 +1499,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestMemberRoleGetUpdatedWhen
 				return false
 			}
 			members = chats[chat.ID].Members
-			return len(members) == 2 && members[s.bob.myHexIdentity()] != nil && members[s.bob.myHexIdentity()].ChannelRole == protobuf.CommunityMember_CHANNEL_ROLE_POSTER
+			return len(members) == 1 && members[s.bob.myHexIdentity()] != nil && members[s.bob.myHexIdentity()].ChannelRole == protobuf.CommunityMember_CHANNEL_ROLE_POSTER
 		},
 		"bob never got post permissions",
 	)
@@ -1736,7 +1881,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestResendEncryptionKeyOnBac
 
 	waitOnChannelKeyToBeDistributedToBob := s.waitOnKeyDistribution(func(sub *CommunityAndKeyActions) bool {
 		action, ok := sub.keyActions.ChannelKeysActions[chat.CommunityChatID()]
-		if !ok || action.ActionType != communities.EncryptionKeyAdd {
+		if !ok || action.ActionType != communities.EncryptionKeySendToMembers {
 			return false
 		}
 
@@ -1760,8 +1905,13 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestResendEncryptionKeyOnBac
 			if c == nil {
 				return false
 			}
+
+			if !c.ChannelEncrypted(chat.CommunityChatID()) {
+				return false
+			}
+
 			channel := c.Chats()[chat.CommunityChatID()]
-			if channel != nil && len(channel.Members) < 2 {
+			if channel != nil && len(channel.Members) == 0 {
 				return false
 			}
 
@@ -2015,8 +2165,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestImportDecryptedArchiveMe
 		if !ok || action.ActionType != communities.EncryptionKeyAdd {
 			return false
 		}
-		_, ok = action.Members[common.PubkeyToHex(&s.owner.identity.PublicKey)]
-		return ok
+		return true
 	})
 
 	waitOnCommunityPermissionCreated := waitOnCommunitiesEvent(s.owner, func(sub *communities.Subscription) bool {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -2385,7 +2385,7 @@ func (m *Messenger) CreateCommunityChat(communityID types.HexBytes, c *protobuf.
 
 	var chats []*Chat
 	for chatID, chat := range changes.ChatsAdded {
-		c := CreateCommunityChat(changes.Community.IDString(), chatID, chat, m.getTimesource())
+		c := CreateCommunityChat(changes.Community, chat, chatID, m.getTimesource())
 		chats = append(chats, c)
 		response.AddChat(c)
 	}
@@ -2414,7 +2414,7 @@ func (m *Messenger) EditCommunityChat(communityID types.HexBytes, chatID string,
 
 	var chats []*Chat
 	for chatID, change := range changes.ChatsModified {
-		c := CreateCommunityChat(community.IDString(), chatID, change.ChatModified, m.getTimesource())
+		c := CreateCommunityChat(community, change.ChatModified, chatID, m.getTimesource())
 		chats = append(chats, c)
 		response.AddChat(c)
 	}

--- a/protocol/messenger_communities_import_discord.go
+++ b/protocol/messenger_communities_import_discord.go
@@ -643,7 +643,7 @@ func (m *Messenger) RequestImportDiscordChannel(request *requests.ImportDiscordC
 
 				community = changes.Community
 				for chatID, chat := range changes.ChatsAdded {
-					newChat = CreateCommunityChat(request.CommunityID.String(), chatID, chat, m.getTimesource())
+					newChat = CreateCommunityChat(community, chat, chatID, m.getTimesource())
 				}
 
 				progressValue = float32(1.0)
@@ -1242,7 +1242,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 				// as we iterate over `ChatsAdded`, however at this point we
 				// know there was only a single such change (and it's a map)
 				for chatID, chat := range changes.ChatsAdded {
-					c := CreateCommunityChat(communityID, chatID, chat, m.getTimesource())
+					c := CreateCommunityChat(discordCommunity, chat, chatID, m.getTimesource())
 					createdChats[c.ID] = c
 					chatsToSave = append(chatsToSave, c)
 					processedChannelIds[channel.Channel.ID] = c.ID

--- a/protocol/messenger_community_chat_test.go
+++ b/protocol/messenger_community_chat_test.go
@@ -76,6 +76,7 @@ func (s *MessengerCommunityChatsUnitSuite) TestEditCommunityChat_GlobalCommunity
 	communityResponse, err := s.m.CreateCommunity(description, false)
 	s.Require().NoError(err)
 	community := communityResponse.Communities()[0]
+	s.Require().Len(community.Members(), 1, "Community should have one member initially")
 
 	// Verify that the global community content topic filter is set
 	universalChatFilter := s.m.messaging.ChatFilterByChatID(community.UniversalChatID())
@@ -98,6 +99,7 @@ func (s *MessengerCommunityChatsUnitSuite) TestEditCommunityChat_GlobalCommunity
 
 	createdChat := createResponse.Chats()[0]
 	chatID := createdChat.CommunityChatID()
+	s.Require().Len(createdChat.Members, 0, "Created chat should have no members initially")
 
 	// Edit the chat
 	editedChat := &protobuf.CommunityChat{

--- a/protocol/messenger_filter_init.go
+++ b/protocol/messenger_filter_init.go
@@ -228,6 +228,11 @@ func (m *Messenger) processCommunityChat(chat *Chat, communityInfo map[string]*c
 		}
 	}
 
+	// Members could be populated in the DB from previous inserts
+	if !community.ChannelHasPermissions(chat.CommunityChatID()) {
+		chat.Members = []ChatMember{}
+	}
+
 	return nil
 }
 

--- a/protocol/persistence_test.go
+++ b/protocol/persistence_test.go
@@ -1559,21 +1559,37 @@ func TestSaveCommunityChat(t *testing.T) {
 	require.NoError(t, err)
 	p := newSQLitePersistence(db)
 
-	identity := &protobuf.ChatIdentity{
-		DisplayName:           "community-chat-name",
-		Description:           "community-chat-name-description",
-		FirstMessageTimestamp: 1,
-	}
-	permissions := &protobuf.CommunityPermissions{
-		Access: protobuf.CommunityPermissions_AUTO_ACCEPT,
+	chat := &Chat{
+		ID:          "test-community-chat-id",
+		Name:        "test-community-chat-name",
+		Description: "test-community-chat-description",
+		Color:       "#000000",
+		Emoji:       "test-emoji",
+		Active:      true,
+		Timestamp:   1,
+		// LastClockValue:        1,
+		DeletedAtClockValue:      0,
+		ReadMessagesAtClockValue: 0,
+		UnviewedMessagesCount:    0,
+		UnviewedMentionsCount:    0,
+		LastMessage:              nil,
+		Members:                  []ChatMember{},
+		MembershipUpdates:        nil,
+		Muted:                    false,
+		MuteTill:                 time.Time{},
+		InvitationAdmin:          "",
+		ReceivedInvitationAdmin:  "",
+		Profile:                  "",
+		CommunityID:              "test-community-id",
+		Joined:                   0,
+		SyncedTo:                 0,
+		SyncedFrom:               0,
+		FirstMessageTimestamp:    0,
+		Highlight:                false,
+		Base64Image:              "",
+		HideIfPermissionsNotMet:  false,
 	}
 
-	communityChat := &protobuf.CommunityChat{
-		Identity:    identity,
-		Permissions: permissions,
-	}
-
-	chat := CreateCommunityChat("test-or-gid", "test-chat-id", communityChat, &testTimeSource{})
 	chat.LastMessage = common.NewMessage()
 	err = p.SaveChat(*chat)
 	require.NoError(t, err)


### PR DESCRIPTION
Avoid duplicating community members in public chats
Rationale: reduce memory footprint

<p style="margin: 0.0px 0.0px 0.0px 0.0px; font: 13.0px 'Helvetica Neue'"><br>
Startup memory footprint for status-desktop</p>

Account type | With public chat members | Without public chat members
-- | -- | --
Old account - status member | 1.30GB | 1.1GB
New account with Status | 580Mb | 550Mb
New account loading Status | 1.30 GB | 740Mb


<br class="Apple-interchange-newline">

Iterates https://github.com/status-im/status-desktop/issues/18150