### PR TITLE
perf_: Reduce golang idle memory on mobile platforms

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -131,6 +132,10 @@ func NewGethStatusBackend(logger *zap.Logger) *GethStatusBackend {
 		zap.String("backend geth version", version.Version()),
 		zap.String("commit", version.GitCommit()),
 		zap.String("IpfsGatewayURL", params.IpfsGatewayURL))
+
+	if gocommon.IsMobilePlatform() {
+		debug.SetMemoryLimit(1024 * 1024 * 150) // 150MB
+	}
 
 	return backend
 }


### PR DESCRIPTION
Setting the soft mem limit to 150Mb for mobile platforms. The golang idle memory tends to accumulate and it's slow to release the memory back to the OS. I've tested this setting with a large account and I've always 50+ Mb of idle memory for the allocator to use. I think that's enough for normal app usage.

Rationale: Reduce memory footprint

Iterates: https://github.com/status-im/status-desktop/issues/18150


<p style="margin: 0.0px 0.0px 0.0px 0.0px; font: 13.0px 'Helvetica Neue'">Mem limit with Status desktop</p>
Note: Couldn't observe increased CPU pressure

Account type | With mem limit | Without men limit
-- | -- | --
Old account - status member | 1.17GB | 1.30GB
New account with Status | 560Mb | 580Mb


<br class="Apple-interchange-newline">