### PR TITLE
perf_: Release the contact image data after generating the contact image URL

### DIFF
--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -781,6 +781,7 @@ func (m *Messenger) updateContactImagesURL(contact *Contact) error {
 				return err
 			}
 			v.LocalURL = m.httpServer.MakeContactImageURL(common.PubkeyToHex(publicKey), k, v.Clock)
+			v.Payload = nil
 			contact.Images[k] = v
 		}
 	}


### PR DESCRIPTION
Releasing the contact image data after URL generation.

Iterates: https://github.com/status-im/status-desktop/issues/18150
