### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/services/wallet/common/utils.go
+++ b/services/wallet/common/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"slices"
 	"time"
 
 	ethereum "github.com/ethereum/go-ethereum"
@@ -33,12 +34,7 @@ func NetworksToChainIDs(networks []*params.Network) []uint64 {
 }
 
 func ArrayContainsElement[T comparable](el T, arr []T) bool {
-	for _, e := range arr {
-		if e == el {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(arr, el)
 }
 
 func IsSingleChainOperation(fromChain *params.Network, toChain *params.Network) bool {

--- a/services/wallet/testutils/helpers.go
+++ b/services/wallet/testutils/helpers.go
@@ -15,12 +15,7 @@ const SntSymbol = "SNT"
 const DaiSymbol = "DAI"
 
 func SliceContains[T comparable](slice []T, value T) bool {
-	for _, v := range slice {
-		if v == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, value)
 }
 func StructExistsInSlice[T any](target T, slice []T) bool {
 	for _, item := range slice {

--- a/services/wallet/thirdparty/http_client_test.go
+++ b/services/wallet/thirdparty/http_client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -252,13 +253,7 @@ func TestFetchDataCompression(t *testing.T) {
 			// Create test server
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				// Check if client requested gzip
-				acceptsGzip := false
-				for _, encoding := range r.Header["Accept-Encoding"] {
-					if encoding == "gzip" {
-						acceptsGzip = true
-						break
-					}
-				}
+				acceptsGzip := slices.Contains(r.Header["Accept-Encoding"], "gzip")
 
 				// Verify auth
 				username, password, ok := r.BasicAuth()


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.