### PR TITLE
fix(share_urls)_: fix profile URLs containing no data for new accounts

### DIFF
--- a/protocol/messenger_share_urls.go
+++ b/protocol/messenger_share_urls.go
@@ -446,6 +446,10 @@ func (m *Messenger) prepareEncodedUserData(contact *Contact) (string, string, er
 		return "", "", err
 	}
 
+	if contact.DisplayName == "" && contact.Bio == "" {
+		return "", shortKey, nil
+	}
+
 	userProto := &protobuf.User{
 		DisplayName: contact.DisplayName,
 		Description: contact.Bio,
@@ -488,6 +492,15 @@ func (m *Messenger) ShareUserURLWithData(contactID string) (string, error) {
 }
 
 func parseUserURLWithData(data string, chatKey string) (*URLDataResponse, error) {
+	if data == "" {
+		return &URLDataResponse{
+			Contact: &ContactURLData{
+				DisplayName: "",
+				Description: "",
+				PublicKey:   chatKey,
+			},
+		}, nil
+	}
 	urlData, err := decodeDataURL(data)
 	if err != nil {
 		return nil, err

--- a/protocol/messenger_share_urls_test.go
+++ b/protocol/messenger_share_urls_test.go
@@ -482,6 +482,19 @@ func (s *MessengerShareUrlsSuite) TestShareUserURLWithData() {
 	s.Require().Equal(expectedURL, url)
 }
 
+func (s *MessengerShareUrlsSuite) TestPrepareEncodedUserDataWithEmptyAccount() {
+	_, contact := s.createContact()
+
+	contact.DisplayName = ""
+	contact.Bio = ""
+
+	userData, chatKey, err := s.m.prepareEncodedUserData(contact)
+	s.Require().NoError(err)
+	// The data should be empty if no display name or bio is set
+	s.Require().Empty(userData)
+	s.Require().NotEmpty(chatKey)
+}
+
 func (s *MessengerShareUrlsSuite) TestShareAndParseUserURLWithData() {
 	_, contact := s.createContact()
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/18416

The problem is that new accounts now don't have any Display names, so it encodes an empty protobuf and adds that to the URL. 

First, it's useless, it contains nothing. Also, it makes the website unable to decode it. So we just skip the encoded data if there is nothing to decode. The result is a basic URL with just the compressed key.

It still won't find the user on the Website since there is literally no data associated with the user, but at least it's gonna be possible to share it with someone

[fix-share-url.webm](https://github.com/user-attachments/assets/07c7f916-d9dc-4d52-8a91-fe2fdf2572b0)
