### PR TITLE
perf!: remove data images from json sent to clients

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -315,6 +315,9 @@ func (b *GethStatusBackend) getAccountByKeyUID(keyUID string) (*multiaccounts.Ac
 	}
 	for _, acc := range as {
 		if acc.KeyUID == keyUID {
+			for k, v := range acc.Images {
+				acc.Images[k].LocalURL = b.statusNode.HTTPServer().MakeAccountImageURL(acc.KeyUID, v.Name, v.Clock)
+			}
 			return &acc, nil
 		}
 	}

--- a/images/identity.go
+++ b/images/identity.go
@@ -38,15 +38,9 @@ func (i IdentityImage) GetDataURI() (string, error) {
 }
 
 func (i IdentityImage) MarshalJSON() ([]byte, error) {
-	uri, err := i.GetDataURI()
-	if err != nil {
-		return nil, err
-	}
-
 	temp := struct {
 		KeyUID       string `json:"keyUid"`
 		Name         string `json:"type"`
-		URI          string `json:"uri"`
 		Width        int    `json:"width"`
 		Height       int    `json:"height"`
 		FileSize     int    `json:"fileSize"`
@@ -56,7 +50,6 @@ func (i IdentityImage) MarshalJSON() ([]byte, error) {
 	}{
 		KeyUID:       i.KeyUID,
 		Name:         i.Name,
-		URI:          uri,
 		Width:        i.Width,
 		Height:       i.Height,
 		FileSize:     i.FileSize,

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -153,6 +153,12 @@ func initializeApplication(requestJSON string) string {
 		}
 	}
 
+	for i, acc := range accs {
+		for j, images := range acc.Images {
+			accs[i].Images[j].LocalURL = statusBackend.StatusNode().HTTPServer().MakeAccountImageURL(acc.KeyUID, images.Name, images.Clock)
+		}
+	}
+
 	response := &InitializeApplicationResponse{
 		Accounts:               accs,
 		CentralizedMetricsInfo: metricsInfo,

--- a/protocol/common/message.go
+++ b/protocol/common/message.go
@@ -140,8 +140,6 @@ type Message struct {
 	From string `json:"from"`
 	// Random 3 words name
 	Alias string `json:"alias"`
-	// Identicon of the author
-	Identicon string `json:"identicon"`
 	// The chat id to be stored locally
 	LocalChatID string `json:"localChatId"`
 	// Seen set to true when user have read this message already
@@ -242,7 +240,6 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		WhisperTimestamp         uint64                           `json:"whisperTimestamp"`
 		From                     string                           `json:"from"`
 		Alias                    string                           `json:"alias"`
-		Identicon                string                           `json:"identicon"`
 		Seen                     bool                             `json:"seen"`
 		OutgoingStatus           string                           `json:"outgoingStatus,omitempty"`
 		QuotedMessage            *QuotedMessage                   `json:"quotedMessage"`
@@ -294,7 +291,6 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		WhisperTimestamp:         m.WhisperTimestamp,
 		From:                     m.From,
 		Alias:                    m.Alias,
-		Identicon:                m.Identicon,
 		Seen:                     m.Seen,
 		OutgoingStatus:           m.OutgoingStatus,
 		QuotedMessage:            m.QuotedMessage,

--- a/protocol/common/pin_message.go
+++ b/protocol/common/pin_message.go
@@ -27,8 +27,6 @@ type PinMessage struct {
 	// The chat id to be stored locally
 	LocalChatID string           `json:"localChatId"`
 	SigPubKey   *ecdsa.PublicKey `json:"-"`
-	// Identicon of the author
-	Identicon string `json:"identicon"`
 	// Random 3 words name
 	Alias string `json:"alias"`
 

--- a/protocol/message_builder.go
+++ b/protocol/message_builder.go
@@ -7,7 +7,6 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/identity/alias"
-	"github.com/status-im/status-go/protocol/identity/identicon"
 )
 
 func extendMessageFromChat(message *common.Message, chat *Chat, key *ecdsa.PublicKey, timesource common.TimeSource) error {
@@ -21,13 +20,6 @@ func extendMessageFromChat(message *common.Message, chat *Chat, key *ecdsa.Publi
 	message.WhisperTimestamp = timestamp
 	message.Seen = true
 	message.OutgoingStatus = common.OutgoingStatusSending
-
-	identicon, err := identicon.GenerateBase64(message.From)
-	if err != nil {
-		return err
-	}
-
-	message.Identicon = identicon
 
 	alias, err := alias.GenerateFromPublicKeyString(message.From)
 	if err != nil {
@@ -47,13 +39,6 @@ func extendPinMessageFromChat(message *common.PinMessage, chat *Chat, key *ecdsa
 	message.From = types.EncodeHex(crypto.FromECDSAPub(key))
 	message.SigPubKey = key
 	message.WhisperTimestamp = timestamp
-
-	identicon, err := identicon.GenerateBase64(message.From)
-	if err != nil {
-		return err
-	}
-
-	message.Identicon = identicon
 
 	alias, err := alias.GenerateFromPublicKeyString(message.From)
 	if err != nil {

--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -205,7 +205,6 @@ func (db sqlitePersistence) tableUserMessagesAllFieldsJoin() string {
         m2.deleted,
         m2.deleted_for_me,
 		c.alias,
-		c.identicon,
     COALESCE(m2.discord_message_id, ""),
 		COALESCE(m2_dm_author.name, ""),
 		COALESCE(m2_dm_author.nickname, ""),
@@ -251,7 +250,6 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 	var serializedUnfurledStatusLinks []byte
 	var serializedPaymentRequests []byte
 	var alias sql.NullString
-	var identicon sql.NullString
 	var communityID sql.NullString
 	var gapFrom sql.NullInt64
 	var gapTo sql.NullInt64
@@ -364,7 +362,6 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 		&quotedDeleted,
 		&quotedDeletedForMe,
 		&alias,
-		&identicon,
 		&quotedDiscordMessage.Id,
 		&quotedDiscordMessage.Author.Name,
 		&quotedDiscordMessage.Author.Nickname,
@@ -444,7 +441,6 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 		}
 	}
 	message.Alias = alias.String
-	message.Identicon = identicon.String
 
 	if gapFrom.Valid && gapTo.Valid {
 		message.GapParameters = &common.GapParameters{

--- a/protocol/messenger_contact_verification.go
+++ b/protocol/messenger_contact_verification.go
@@ -1150,7 +1150,6 @@ func (m *Messenger) createContactVerificationMessage(challenge string, chat *Cha
 	chatMessage.From = state.CurrentMessageState.Contact.ID
 	chatMessage.Alias = state.CurrentMessageState.Contact.Alias
 	chatMessage.SigPubKey = state.CurrentMessageState.PublicKey
-	chatMessage.Identicon = state.CurrentMessageState.Contact.Identicon
 	chatMessage.WhisperTimestamp = state.CurrentMessageState.WhisperTimestamp
 
 	chatMessage.ChatId = chat.ID

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -394,7 +394,6 @@ func (m *Messenger) handleCommandMessage(state *ReceivedMessageState, message *c
 	message.From = state.CurrentMessageState.Contact.ID
 	message.Alias = state.CurrentMessageState.Contact.Alias
 	message.SigPubKey = state.CurrentMessageState.PublicKey
-	message.Identicon = state.CurrentMessageState.Contact.Identicon
 	message.WhisperTimestamp = state.CurrentMessageState.WhisperTimestamp
 
 	if err := message.PrepareContent(common.PubkeyToHex(&m.identity.PublicKey)); err != nil {
@@ -890,7 +889,6 @@ func (m *Messenger) handlePinMessage(pinner *Contact, whisperTimestamp uint64, r
 		WhisperTimestamp: whisperTimestamp,
 		From:             pinner.ID,
 		SigPubKey:        publicKey,
-		Identicon:        pinner.Identicon,
 		Alias:            pinner.Alias,
 	}
 
@@ -2146,7 +2144,6 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 		From:             state.CurrentMessageState.Contact.ID,
 		Alias:            state.CurrentMessageState.Contact.Alias,
 		SigPubKey:        state.CurrentMessageState.PublicKey,
-		Identicon:        state.CurrentMessageState.Contact.Identicon,
 		WhisperTimestamp: state.CurrentMessageState.WhisperTimestamp,
 	}
 

--- a/server/server_media.go
+++ b/server/server_media.go
@@ -238,6 +238,14 @@ func (s *MediaServer) MakeContactImageURL(publicKey string, imageType string, im
 	return u.String()
 }
 
+func (s *MediaServer) MakeAccountImageURL(keyUid string, imageType string, imageClock uint64) string {
+	u := s.MakeBaseURL()
+	u.Path = accountImagesPath
+	u.RawQuery = url.Values{"keyUid": {keyUid}, "imageName": {imageType}, "clock": {fmt.Sprint(imageClock)}}.Encode()
+
+	return u.String()
+}
+
 func (s *MediaServer) MakeCommunityTokenImagesURL(communityID string, chainID uint64, symbol string) string {
 	u := s.MakeBaseURL()
 	u.Path = communityTokenImagesPath

--- a/services/accounts/multiaccounts.go
+++ b/services/accounts/multiaccounts.go
@@ -70,6 +70,10 @@ func (api *MultiAccountsAPI) StoreIdentityImage(keyUID, filepath string, aX, aY,
 		return nil, err
 	}
 
+	for k, v := range iis {
+		iis[k].LocalURL = api.mediaServer.MakeAccountImageURL(keyUID, v.Name, v.Clock)
+	}
+
 	return iis, err
 }
 


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/18428

I found that IdentityImage (used by Contacts and Accounts) still sent a full base64 image in its json data even if it wasn't used for contacts.

I implemented the local server images for the Account images, because those actually still used the data URI.

This is a breaking change because the data URI will no longer be available. That's fixed on the QT app. However, I think I might have to revert it if we can't update the clojure app too.

I also removed the `identicon` property from Message, as that was not used anywhere (Clojure or QT apps). It was also a base 64 image, so taking space for no reason.