### PR TITLE
fix(docs)_:Added instruction if not using Nix shell while building

### DIFF
--- a/_docs/how-to-build.md
+++ b/_docs/how-to-build.md
@@ -8,10 +8,10 @@ status-go is an underlying part of Status. It heavily depends on [go-ethereum](h
 
 ### 1. Requirements
 
-* Nix (Installed automatically)
 * Docker (only if cross-compiling).
 
-> go is provided by Nix
+> go is provided by Nix, if Nix shell is used else go has to be
+  downloaded and installed (https://go.dev/doc/install).
 
 ### 2. Clone the repository
 
@@ -27,6 +27,13 @@ You can enter the development shell by using either of two:
 ```bash
 make shell
 nix develop
+```
+		OR
+
+If not using nix shell, go dependency packages have to be installed by using the following make command:
+
+```
+make status-go-deps
 ```
 
 ### 4. Build the status-backend


### PR DESCRIPTION
## Summary 

Nix is no longer installed automatically since the [commit ba6f0a1](https://github.com/status-im/status-go/commit/ba6f0a10ed9e3a9bf5e653f4a109ca796e1711fd)

Hence the following two instructions need to be added to the `how_to_build.md`
* `go` has to be downloaded and installed if Nix shell is not used.
* `go` deps need to be downloaded indicated by the `make status-go-deps` command.

I was facing an issue with the path of the dynamic linker `ld-linux-x86-64.so.2` while creating a docker image including the `status-backend` binary. The nix path is not portable as seen below.

<img width="1735" height="277" alt="Screenshot from 2025-07-26 18-29-00" src="https://github.com/user-attachments/assets/2a897208-fbaa-4705-9565-24fa08679e86" />


