### PR TITLE
test_: move cli config to utils

### DIFF
--- a/tests-functional/clients/anvil.py
+++ b/tests-functional/clients/anvil.py
@@ -2,7 +2,7 @@ import logging
 import time
 import docker
 
-from conftest import option
+from utils.config import Config
 from tenacity import retry, wait_fixed, stop_after_attempt
 from web3 import Web3
 
@@ -11,7 +11,7 @@ class Anvil(Web3):
 
     def __init__(self):
         self.docker_client = docker.from_env()
-        self.docker_project_name = option.docker_project_name
+        self.docker_project_name = Config.docker_project_name
         self.network_name = f"{self.docker_project_name}_default"
 
         container_name_prefix = f"{self.docker_project_name}-anvil"

--- a/tests-functional/clients/rpc.py
+++ b/tests-functional/clients/rpc.py
@@ -3,7 +3,7 @@ import logging
 import jsonschema
 import requests
 from tenacity import retry, stop_after_delay, wait_fixed
-from conftest import option
+from utils.config import Config
 from json import JSONDecodeError
 
 
@@ -74,5 +74,5 @@ class RpcClient:
         return response
 
     def verify_json_schema(self, response, method):
-        with open(f"{option.base_dir}/schemas/{method}", "r") as schema:
+        with open(f"{Config.base_dir}/schemas/{method}", "r") as schema:
             jsonschema.validate(instance=response, schema=json.load(schema))

--- a/tests-functional/clients/smart_contract_runner.py
+++ b/tests-functional/clients/smart_contract_runner.py
@@ -8,7 +8,7 @@ import docker
 import docker.errors
 import os
 
-from conftest import option
+from utils.config import Config
 from resources.constants import user_1, ANVIL_NETWORK_ID
 from tenacity import retry, wait_fixed, stop_after_attempt
 
@@ -19,7 +19,7 @@ class SmartContractRunner:
 
     def __init__(self):
         self.docker_client = docker.from_env()
-        self.docker_project_name = option.docker_project_name
+        self.docker_project_name = Config.docker_project_name
         self.network_name = f"{self.docker_project_name}_default"
 
         container_name_prefix = f"{self.docker_project_name}-foundry"

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -6,7 +6,6 @@ import time
 import random
 import threading
 import uuid
-
 import requests
 import os
 
@@ -18,7 +17,7 @@ from clients.services.settings import SettingsService
 from clients.signals import SignalClient, SignalType
 from clients.rpc import RpcClient
 from clients.statusgo_container import StatusBackendContainer
-from conftest import option
+from utils.config import Config
 from resources.constants import USE_IPV6, user_1, ANVIL_NETWORK_ID, Account
 from utils import keys
 
@@ -33,14 +32,18 @@ class StatusBackend(RpcClient, SignalClient):
         self.ipv6 = True if ipv6 == "Yes" else False
         logging.debug(f"Flag USE_IPV6 is: {self.ipv6}")
 
-        if option.status_backend_url:
-            url = next(option.status_backend_urls)
+        if Config.status_backend_urls:
+            try:
+                url = next(Config.status_backend_urls)
+            except StopIteration:
+                raise Exception("--status-backend-url is found, but not enough backends provided")
+
             assert url != "", "not enough status-backend urls provided"
             self.temp_dir = tempfile.TemporaryDirectory()
             self.data_dir = self.temp_dir.name
         else:
-            host_port = random.choice(option.status_backend_port_range)
-            option.status_backend_port_range.remove(host_port)
+            host_port = random.choice(Config.status_backend_port_range)
+            Config.status_backend_port_range.remove(host_port)
 
             self.container = StatusBackendContainer(host_port, privileged, self.ipv6)
             self.temp_dir = None
@@ -122,7 +125,7 @@ class StatusBackend(RpcClient, SignalClient):
         return response
 
     def init_status_backend(self):
-        if option.logout:
+        if Config.logout:
             logging.warning("automatically logging out before InitializeApplication")
             try:
                 self.logout()
@@ -137,8 +140,8 @@ class StatusBackend(RpcClient, SignalClient):
             "logEnabled": True,
             "logLevel": "DEBUG",
             "apiLoggingEnabled": True,
-            "wakuFleetsConfigFilePath": option.waku_fleets_config,
-            "pushFleetsConfigFilePath": option.push_fleets_config,
+            "wakuFleetsConfigFilePath": Config.waku_fleets_config,
+            "pushFleetsConfigFilePath": Config.push_fleets_config,
         }
 
         return self.api_valid_request(method, data)
@@ -254,9 +257,9 @@ class StatusBackend(RpcClient, SignalClient):
             "logLevel": "DEBUG",
             # Waku config
             "wakuV2LightClient": kwargs.get("wakuV2LightClient", False),
-            "wakuV2Fleet": option.waku_fleet,
+            "wakuV2Fleet": Config.waku_fleet,
         }
-        if not option.disable_override_networks:
+        if not Config.disable_override_networks:
             self._set_networks(data, **kwargs)
 
         data = self._set_proxy_credentials(data)

--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -10,12 +10,13 @@ import docker
 import docker.errors
 from docker.errors import APIError
 
-from conftest import option
+from utils.config import Config
 
 DATA_DIR = "/usr/status-user"
 
 
 class StatusGoContainer:
+    all_containers = []
     container = None
 
     def __init__(self, entrypoint, ports=None, privileged=False, container_name_suffix=""):
@@ -29,13 +30,13 @@ class StatusGoContainer:
         # Prepare image and container name
         # NOTE: This part needs some love.
         #       There's magic with `docker_project_name`, `docker_image` and `identifier` variables.
-        docker_project_name = option.docker_project_name
+        docker_project_name = Config.docker_project_name
         self.network_name = f"{docker_project_name}_default"
         git_commit = os.popen("git rev-parse --short HEAD").read().strip()
         identifier = os.environ.get("BUILD_ID") if os.environ.get("CI") else git_commit
-        image_name = option.docker_image or f"statusgo-{identifier}:latest"
+        image_name = Config.docker_image or f"statusgo-{identifier}:latest"
         self.container_name = f"{docker_project_name}-{identifier}{container_name_suffix}"
-        coverage_path = option.codecov_dir if option.codecov_dir else os.path.abspath("./coverage/binary")
+        coverage_path = Config.codecov_dir if Config.codecov_dir else os.path.abspath("./coverage/binary")
 
         # Run the container
         logging.debug(f"Creating status-go container from image '{image_name}'")
@@ -74,7 +75,7 @@ class StatusGoContainer:
             raise RuntimeError(f"Docker image '{image_name}' not found")
 
         self.container = self.docker_client.containers.run(**container_args)
-        option.statusgo_containers.append(self)
+        StatusGoContainer.all_containers.append(self)
 
         logging.debug(f"Container {self.container.name} created. ID = {self.container.id}")
 
@@ -221,12 +222,12 @@ class StatusGoContainer:
     def save_logs(self):
         if not self.container:
             raise RuntimeError("Container is not initialized.")
-        if option.logs_dir == "":
+        if Config.logs_dir == "":
             logging.debug("Save container logs skipped")
             return
 
         id_short = self.container.id[:12]
-        file_path = os.path.join(option.logs_dir, f"container_{id_short}.log")
+        file_path = os.path.join(Config.logs_dir, f"container_{id_short}.log")
         logging.info(f"Saving logs to {file_path}")
 
         with open(file_path, "wb") as f:
@@ -247,9 +248,9 @@ class PushNotificationServerContainer(StatusGoContainer):
             "--log-level",
             "DEBUG",
             "--waku-fleet-config",
-            option.waku_fleets_config,
+            Config.waku_fleets_config,
             "--waku-fleet",
-            option.waku_fleet,
+            Config.waku_fleet,
         ]
         super().__init__(entrypoint, container_name_suffix=f"-push-notification-server-{gorush_port}")
 

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 import logging
-from typing import Generator
+from typing import Iterator
 
 from resources.constants import ANVIL_NETWORK_ID
 from clients.statusgo_container import StatusGoContainer
@@ -77,7 +77,7 @@ def pytest_addoption(parser):
     )
 
 
-def _status_backend_url_generator(urls) -> Generator[str]:
+def _status_backend_url_generator(urls) -> Iterator[str]:
     for url in urls:
         yield url
 

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -1,9 +1,11 @@
 import os
-from dataclasses import dataclass, field
-from typing import List, Any
 import pytest
 import logging
+from typing import Generator
+
 from resources.constants import ANVIL_NETWORK_ID
+from clients.statusgo_container import StatusGoContainer
+from utils.config import Config
 
 
 def pytest_addoption(parser):
@@ -12,12 +14,6 @@ def pytest_addoption(parser):
         action="append",
         help="",
         default=None,
-    )
-    parser.addoption(
-        "--anvil_url",
-        action="store",
-        help="",
-        default="http://0.0.0.0:8545",
     )
     parser.addoption(
         "--password",
@@ -81,31 +77,12 @@ def pytest_addoption(parser):
     )
 
 
-@dataclass
-class Option:
-    status_backend_port_range: List[int] = field(default_factory=list)
-    statusgo_containers: List[Any] = field(default_factory=list)
-    base_dir: str = ""
-
-
-option = Option()
-
-
-def status_backend_url_generator(config):
-    if hasattr(option, "status_backend_url") and config.option.status_backend_url is not None:
-        urls = config.option.status_backend_url
-    else:
-        print("status_backend_url option not found or is None")
-        return
-
+def _status_backend_url_generator(urls) -> Generator[str]:
     for url in urls:
         yield url
 
 
-def pytest_configure(config):
-    global option
-    option = config.option
-
+def _calculate_port_range():
     executor_number = int(os.getenv("EXECUTOR_NUMBER", 5))
     base_port = 7000
     range_size = 100
@@ -119,11 +96,24 @@ def pytest_configure(config):
     if start_port < min_port or end_port > max_port:
         raise ValueError(f"Generated port range ({start_port}-{end_port}) is outside the allowed range ({min_port}-{max_port}).")
 
-    option.status_backend_port_range = list(range(start_port, end_port))
-    option.statusgo_containers = []
+    return list(range(start_port, end_port))
 
-    option.base_dir = os.path.dirname(os.path.abspath(__file__))  # schemas directory
-    option.status_backend_urls = status_backend_url_generator(config)
+
+def pytest_configure(config):
+    status_backend_urls = config.getoption("--status_backend_url")
+    Config.status_backend_urls = _status_backend_url_generator(status_backend_urls) if status_backend_urls else None
+    Config.password = config.getoption("--password")
+    Config.docker_project_name = config.getoption("--docker_project_name")
+    Config.docker_image = config.getoption("--docker-image")
+    Config.codecov_dir = config.getoption("--codecov_dir")
+    Config.logs_dir = config.getoption("--logs-dir")
+    Config.logout = config.getoption("--logout")
+    Config.waku_fleets_config = config.getoption("--waku-fleets-config")
+    Config.waku_fleet = config.getoption("--waku-fleet")
+    Config.push_fleets_config = config.getoption("--push-fleets-config")
+    Config.disable_override_networks = config.getoption("--disable-override-networks")
+    Config.status_backend_port_range = _calculate_port_range()
+    Config.base_dir = os.path.dirname(os.path.abspath(__file__))  # schemas directory
 
 
 def pytest_report_header(config):
@@ -203,12 +193,12 @@ def close_status_backend_containers(request):
     yield
     if hasattr(request.node.instance, "reuse_container"):
         return
-    for container in option.statusgo_containers:
+    for container in StatusGoContainer.all_containers:
         try:
             teardown_container(container, log_prefix="[close_status_backend_containers] ")
         except Exception as e:
             logging.error(f"Error cleaning up container: {e}")
-    option.statusgo_containers = []
+    StatusGoContainer.all_containers = []
 
 
 @pytest.fixture(scope="function", autouse=False)

--- a/tests-functional/utils/config.py
+++ b/tests-functional/utils/config.py
@@ -1,0 +1,19 @@
+from typing import List, Generator
+from dataclasses import field
+
+
+class Config:
+    status_backend_port_range: List[int] = field(default_factory=list)
+    base_dir: str = ""
+
+    status_backend_urls: Generator[str] | None = None
+    password: str = ""  # FIXME: remove
+    docker_project_name: str = ""
+    docker_image: str = ""
+    codecov_dir: str = ""
+    logs_dir: str = ""
+    logout: bool = False
+    waku_fleets_config: str = ""
+    waku_fleet: str = ""
+    push_fleets_config: str = ""
+    disable_override_networks: bool = False

--- a/tests-functional/utils/config.py
+++ b/tests-functional/utils/config.py
@@ -1,4 +1,4 @@
-from typing import List, Generator
+from typing import List, Iterator
 from dataclasses import field
 
 
@@ -6,7 +6,7 @@ class Config:
     status_backend_port_range: List[int] = field(default_factory=list)
     base_dir: str = ""
 
-    status_backend_urls: Generator[str] | None = None
+    status_backend_urls: Iterator[str] | None = None
     password: str = ""  # FIXME: remove
     docker_project_name: str = ""
     docker_image: str = ""

--- a/tests-functional/utils/schema_builder.py
+++ b/tests-functional/utils/schema_builder.py
@@ -3,14 +3,14 @@ import os
 
 from genson import SchemaBuilder
 
-from conftest import option
+from utils.config import Config
 
 
 class CustomSchemaBuilder(SchemaBuilder):
 
     def __init__(self, schema_name):
         super().__init__()
-        self.path = f"{option.base_dir}/schemas/{schema_name}"
+        self.path = f"{Config.base_dir}/schemas/{schema_name}"
 
     def create_schema(self, response_json):
         builder = SchemaBuilder()

--- a/tests-functional/utils/wallet_utils.py
+++ b/tests-functional/utils/wallet_utils.py
@@ -4,11 +4,11 @@ import jsonschema
 import resources.constants as constants
 from clients.signals import SignalType, WalletEventType
 
-from conftest import option
+from utils.config import Config
 
 
 def verify_json_schema(response, method):
-    with open(f"{option.base_dir}/schemas/{method}", "r") as schema:
+    with open(f"{Config.base_dir}/schemas/{method}", "r") as schema:
         jsonschema.validate(instance=response, schema=json.load(schema))
 
 
@@ -61,7 +61,7 @@ def sign_messages(rpc_client, hashes, address):
     for hash in hashes:
 
         method = "wallet_signMessage"
-        params = [hash, address, option.password]
+        params = [hash, address, Config.password]
 
         response = rpc_client.rpc_valid_request(method, params)
 


### PR DESCRIPTION
Required for https://github.com/status-im/status-go/pull/6779

# Description

Moved CLI configuration to `/utils` module:
- for clarity
- for better autocompletion in IDEs
- to prevent import loops in fixtures

### Details

- Moved CLI configuration (`Option`) from `conftest.py` to `utils/config.py` to centralize configuration handling. 
- Added exception handling for `Option.status_backend_urls` in `status_backend.py` to make the error more obvious
- Removed unused pytest option `--anvil_url` from `conftest.py`
- Moved `option.statusgo_containers` to `StatusGoContainer.all_containers`