### PR TITLE
perf!: implement account local urls and remove unused identicon property

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -318,6 +318,9 @@ func (b *GethStatusBackend) getAccountByKeyUID(keyUID string) (*multiaccounts.Ac
 	}
 	for _, acc := range as {
 		if acc.KeyUID == keyUID {
+			for k, v := range acc.Images {
+				acc.Images[k].LocalURL = b.statusNode.HTTPServer().MakeAccountImageURL(acc.KeyUID, v.Name, v.Clock)
+			}
 			return &acc, nil
 		}
 	}

--- a/images/identity.go
+++ b/images/identity.go
@@ -46,7 +46,7 @@ func (i IdentityImage) MarshalJSON() ([]byte, error) {
 	temp := struct {
 		KeyUID       string `json:"keyUid"`
 		Name         string `json:"type"`
-		URI          string `json:"uri"`
+		URI          string `json:"uri"` // Deprecated, use LocalURL instead
 		Width        int    `json:"width"`
 		Height       int    `json:"height"`
 		FileSize     int    `json:"fileSize"`

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -151,6 +151,12 @@ func initializeApplication(requestJSON string) string {
 		}
 	}
 
+	for i, acc := range accs {
+		for j, images := range acc.Images {
+			accs[i].Images[j].LocalURL = statusBackend.StatusNode().HTTPServer().MakeAccountImageURL(acc.KeyUID, images.Name, images.Clock)
+		}
+	}
+
 	response := &InitializeApplicationResponse{
 		Accounts:               accs,
 		CentralizedMetricsInfo: metricsInfo,

--- a/protocol/common/message.go
+++ b/protocol/common/message.go
@@ -140,8 +140,6 @@ type Message struct {
 	From string `json:"from"`
 	// Random 3 words name
 	Alias string `json:"alias"`
-	// Identicon of the author
-	Identicon string `json:"identicon"`
 	// The chat id to be stored locally
 	LocalChatID string `json:"localChatId"`
 	// Seen set to true when user have read this message already
@@ -242,7 +240,6 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		WhisperTimestamp         uint64                           `json:"whisperTimestamp"`
 		From                     string                           `json:"from"`
 		Alias                    string                           `json:"alias"`
-		Identicon                string                           `json:"identicon"`
 		Seen                     bool                             `json:"seen"`
 		OutgoingStatus           string                           `json:"outgoingStatus,omitempty"`
 		QuotedMessage            *QuotedMessage                   `json:"quotedMessage"`
@@ -294,7 +291,6 @@ func (m *Message) MarshalJSON() ([]byte, error) {
 		WhisperTimestamp:         m.WhisperTimestamp,
 		From:                     m.From,
 		Alias:                    m.Alias,
-		Identicon:                m.Identicon,
 		Seen:                     m.Seen,
 		OutgoingStatus:           m.OutgoingStatus,
 		QuotedMessage:            m.QuotedMessage,

--- a/protocol/common/pin_message.go
+++ b/protocol/common/pin_message.go
@@ -27,8 +27,6 @@ type PinMessage struct {
 	// The chat id to be stored locally
 	LocalChatID string           `json:"localChatId"`
 	SigPubKey   *ecdsa.PublicKey `json:"-"`
-	// Identicon of the author
-	Identicon string `json:"identicon"`
 	// Random 3 words name
 	Alias string `json:"alias"`
 

--- a/protocol/message_builder.go
+++ b/protocol/message_builder.go
@@ -7,7 +7,6 @@ import (
 	"github.com/status-im/status-go/eth-node/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/identity/alias"
-	"github.com/status-im/status-go/protocol/identity/identicon"
 )
 
 func extendMessageFromChat(message *common.Message, chat *Chat, key *ecdsa.PublicKey, timesource common.TimeSource) error {
@@ -21,13 +20,6 @@ func extendMessageFromChat(message *common.Message, chat *Chat, key *ecdsa.Publi
 	message.WhisperTimestamp = timestamp
 	message.Seen = true
 	message.OutgoingStatus = common.OutgoingStatusSending
-
-	identicon, err := identicon.GenerateBase64(message.From)
-	if err != nil {
-		return err
-	}
-
-	message.Identicon = identicon
 
 	alias, err := alias.GenerateFromPublicKeyString(message.From)
 	if err != nil {
@@ -47,13 +39,6 @@ func extendPinMessageFromChat(message *common.PinMessage, chat *Chat, key *ecdsa
 	message.From = types.EncodeHex(crypto.FromECDSAPub(key))
 	message.SigPubKey = key
 	message.WhisperTimestamp = timestamp
-
-	identicon, err := identicon.GenerateBase64(message.From)
-	if err != nil {
-		return err
-	}
-
-	message.Identicon = identicon
 
 	alias, err := alias.GenerateFromPublicKeyString(message.From)
 	if err != nil {

--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -205,7 +205,6 @@ func (db sqlitePersistence) tableUserMessagesAllFieldsJoin() string {
         m2.deleted,
         m2.deleted_for_me,
 		c.alias,
-		c.identicon,
     COALESCE(m2.discord_message_id, ""),
 		COALESCE(m2_dm_author.name, ""),
 		COALESCE(m2_dm_author.nickname, ""),
@@ -251,7 +250,6 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 	var serializedUnfurledStatusLinks []byte
 	var serializedPaymentRequests []byte
 	var alias sql.NullString
-	var identicon sql.NullString
 	var communityID sql.NullString
 	var gapFrom sql.NullInt64
 	var gapTo sql.NullInt64
@@ -364,7 +362,6 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 		&quotedDeleted,
 		&quotedDeletedForMe,
 		&alias,
-		&identicon,
 		&quotedDiscordMessage.Id,
 		&quotedDiscordMessage.Author.Name,
 		&quotedDiscordMessage.Author.Nickname,
@@ -444,7 +441,6 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 		}
 	}
 	message.Alias = alias.String
-	message.Identicon = identicon.String
 
 	if gapFrom.Valid && gapTo.Valid {
 		message.GapParameters = &common.GapParameters{

--- a/protocol/messenger_contact_verification.go
+++ b/protocol/messenger_contact_verification.go
@@ -1150,7 +1150,6 @@ func (m *Messenger) createContactVerificationMessage(challenge string, chat *Cha
 	chatMessage.From = state.CurrentMessageState.Contact.ID
 	chatMessage.Alias = state.CurrentMessageState.Contact.Alias
 	chatMessage.SigPubKey = state.CurrentMessageState.PublicKey
-	chatMessage.Identicon = state.CurrentMessageState.Contact.Identicon
 	chatMessage.WhisperTimestamp = state.CurrentMessageState.WhisperTimestamp
 
 	chatMessage.ChatId = chat.ID

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -394,7 +394,6 @@ func (m *Messenger) handleCommandMessage(state *ReceivedMessageState, message *c
 	message.From = state.CurrentMessageState.Contact.ID
 	message.Alias = state.CurrentMessageState.Contact.Alias
 	message.SigPubKey = state.CurrentMessageState.PublicKey
-	message.Identicon = state.CurrentMessageState.Contact.Identicon
 	message.WhisperTimestamp = state.CurrentMessageState.WhisperTimestamp
 
 	if err := message.PrepareContent(common.PubkeyToHex(&m.identity.PublicKey)); err != nil {
@@ -891,7 +890,6 @@ func (m *Messenger) handlePinMessage(pinner *Contact, whisperTimestamp uint64, r
 		WhisperTimestamp: whisperTimestamp,
 		From:             pinner.ID,
 		SigPubKey:        publicKey,
-		Identicon:        pinner.Identicon,
 		Alias:            pinner.Alias,
 	}
 
@@ -2147,7 +2145,6 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 		From:             state.CurrentMessageState.Contact.ID,
 		Alias:            state.CurrentMessageState.Contact.Alias,
 		SigPubKey:        state.CurrentMessageState.PublicKey,
-		Identicon:        state.CurrentMessageState.Contact.Identicon,
 		WhisperTimestamp: state.CurrentMessageState.WhisperTimestamp,
 	}
 

--- a/server/server_media.go
+++ b/server/server_media.go
@@ -238,6 +238,14 @@ func (s *MediaServer) MakeContactImageURL(publicKey string, imageType string, im
 	return u.String()
 }
 
+func (s *MediaServer) MakeAccountImageURL(keyUid string, imageType string, imageClock uint64) string {
+	u := s.MakeBaseURL()
+	u.Path = accountImagesPath
+	u.RawQuery = url.Values{"keyUid": {keyUid}, "imageName": {imageType}, "clock": {fmt.Sprint(imageClock)}}.Encode()
+
+	return u.String()
+}
+
 func (s *MediaServer) MakeCommunityTokenImagesURL(communityID string, chainID uint64, symbol string) string {
 	u := s.MakeBaseURL()
 	u.Path = communityTokenImagesPath

--- a/services/accounts/multiaccounts.go
+++ b/services/accounts/multiaccounts.go
@@ -45,14 +45,47 @@ func (api *MultiAccountsAPI) UpdateAccount(account multiaccounts.Account) error 
 // Profile Images
 //
 
+func (api *MultiAccountsAPI) setLocalURLOnImage(keyUID string, image *images.IdentityImage) {
+	image.LocalURL = api.mediaServer.MakeAccountImageURL(keyUID, image.Name, image.Clock)
+}
+
+func (api *MultiAccountsAPI) setLocalURLOnImages(keyUID string, iis []*images.IdentityImage) {
+	for k := range iis {
+		if iis[k] == nil {
+			continue
+		}
+		api.setLocalURLOnImage(keyUID, iis[k])
+	}
+}
+
+func (api *MultiAccountsAPI) setLocalURLOnImages2(keyUID string, iis []images.IdentityImage) {
+	for k := range iis {
+		api.setLocalURLOnImage(keyUID, &iis[k])
+	}
+}
+
 // GetIdentityImages returns an array of json marshalled IdentityImages assigned to the user's identity
 func (api *MultiAccountsAPI) GetIdentityImages(keyUID string) ([]*images.IdentityImage, error) {
-	return api.db.GetIdentityImages(keyUID)
+	images, err := api.db.GetIdentityImages(keyUID)
+	if err != nil {
+		return nil, err
+	}
+	api.setLocalURLOnImages(keyUID, images)
+	return images, nil
 }
 
 // GetIdentityImage returns a json object representing the image with the given name
 func (api *MultiAccountsAPI) GetIdentityImage(keyUID, name string) (*images.IdentityImage, error) {
-	return api.db.GetIdentityImage(keyUID, name)
+	image, err := api.db.GetIdentityImage(keyUID, name)
+
+	if err != nil {
+		return nil, err
+	}
+	if image == nil {
+		return nil, nil
+	}
+	api.setLocalURLOnImage(keyUID, image)
+	return image, nil
 }
 
 // StoreIdentityImage takes the filepath of an image, crops it as per the rect coords and finally resizes the image.
@@ -70,7 +103,9 @@ func (api *MultiAccountsAPI) StoreIdentityImage(keyUID, filepath string, aX, aY,
 		return nil, err
 	}
 
-	return iis, err
+	api.setLocalURLOnImages2(keyUID, iis)
+
+	return iis, nil
 }
 
 func (api *MultiAccountsAPI) StoreIdentityImageFromURL(keyUID, url string) ([]images.IdentityImage, error) {
@@ -84,7 +119,9 @@ func (api *MultiAccountsAPI) StoreIdentityImageFromURL(keyUID, url string) ([]im
 		return nil, err
 	}
 
-	return iis, err
+	api.setLocalURLOnImages2(keyUID, iis)
+
+	return iis, nil
 }
 
 // DeleteIdentityImage deletes an IdentityImage from the db with the given name

--- a/tests-functional/schemas/wakuext_acceptActivityCenterNotifications
+++ b/tests-functional/schemas/wakuext_acceptActivityCenterNotifications
@@ -185,7 +185,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",

--- a/tests-functional/schemas/wakuext_acceptContactRequest
+++ b/tests-functional/schemas/wakuext_acceptContactRequest
@@ -80,9 +80,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -161,7 +158,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -220,9 +216,6 @@
                                         "type": "object"
                                     },
                                     "id": {
-                                        "type": "string"
-                                    },
-                                    "identicon": {
                                         "type": "string"
                                     },
                                     "lineCount": {
@@ -301,7 +294,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -460,9 +452,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -541,7 +530,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -785,9 +773,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -862,7 +847,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_acceptLatestContactRequestForContact
+++ b/tests-functional/schemas/wakuext_acceptLatestContactRequestForContact
@@ -80,9 +80,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -161,7 +158,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -220,9 +216,6 @@
                                         "type": "object"
                                     },
                                     "id": {
-                                        "type": "string"
-                                    },
-                                    "identicon": {
                                         "type": "string"
                                     },
                                     "lineCount": {
@@ -301,7 +294,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -460,9 +452,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -541,7 +530,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -785,9 +773,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -862,7 +847,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_acceptRequestTransaction
+++ b/tests-functional/schemas/wakuext_acceptRequestTransaction
@@ -128,9 +128,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -210,7 +207,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -365,9 +361,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -447,7 +440,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_activityCenterNotifications
+++ b/tests-functional/schemas/wakuext_activityCenterNotifications
@@ -83,9 +83,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -163,7 +160,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -217,9 +213,6 @@
                                         "type": "string"
                                     },
                                     "id": {
-                                        "type": "string"
-                                    },
-                                    "identicon": {
                                         "type": "string"
                                     },
                                     "lineCount": {
@@ -297,7 +290,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",

--- a/tests-functional/schemas/wakuext_addContact
+++ b/tests-functional/schemas/wakuext_addContact
@@ -86,9 +86,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -167,7 +164,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -327,9 +323,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -408,7 +401,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -656,9 +648,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -736,7 +725,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_addMembersToGroupChat
+++ b/tests-functional/schemas/wakuext_addMembersToGroupChat
@@ -212,9 +212,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -298,7 +295,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "mentions",

--- a/tests-functional/schemas/wakuext_allMessagesFromChatWhichMatchTerm
+++ b/tests-functional/schemas/wakuext_allMessagesFromChatWhichMatchTerm
@@ -51,9 +51,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -132,7 +129,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_allMessagesFromChatsAndCommunitiesWhichMatchTerm
+++ b/tests-functional/schemas/wakuext_allMessagesFromChatsAndCommunitiesWhichMatchTerm
@@ -51,9 +51,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -132,7 +129,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_changeGroupChatName
+++ b/tests-functional/schemas/wakuext_changeGroupChatName
@@ -212,9 +212,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -298,7 +295,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "mentions",

--- a/tests-functional/schemas/wakuext_chat
+++ b/tests-functional/schemas/wakuext_chat
@@ -83,9 +83,6 @@
                         "id": {
                             "type": "string"
                         },
-                        "identicon": {
-                            "type": "string"
-                        },
                         "lineCount": {
                             "type": "integer"
                         },
@@ -163,7 +160,6 @@
                         "ensName",
                         "from",
                         "id",
-                        "identicon",
                         "lineCount",
                         "localChatId",
                         "messageType",

--- a/tests-functional/schemas/wakuext_chatMessages
+++ b/tests-functional/schemas/wakuext_chatMessages
@@ -51,9 +51,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -132,7 +129,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_chatPinnedMessages
+++ b/tests-functional/schemas/wakuext_chatPinnedMessages
@@ -53,9 +53,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -137,7 +134,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",

--- a/tests-functional/schemas/wakuext_chats
+++ b/tests-functional/schemas/wakuext_chats
@@ -89,9 +89,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -169,7 +166,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",

--- a/tests-functional/schemas/wakuext_createGroupChatWithMembers
+++ b/tests-functional/schemas/wakuext_createGroupChatWithMembers
@@ -212,9 +212,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -298,7 +295,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "mentions",

--- a/tests-functional/schemas/wakuext_deactivateChat
+++ b/tests-functional/schemas/wakuext_deactivateChat
@@ -88,9 +88,6 @@
                                             "id": {
                                                 "type": "string"
                                             },
-                                            "identicon": {
-                                                "type": "string"
-                                            },
                                             "lineCount": {
                                                 "type": "integer"
                                             },
@@ -168,7 +165,6 @@
                                             "ensName",
                                             "from",
                                             "id",
-                                            "identicon",
                                             "lineCount",
                                             "localChatId",
                                             "messageType",

--- a/tests-functional/schemas/wakuext_declineContactRequest
+++ b/tests-functional/schemas/wakuext_declineContactRequest
@@ -80,9 +80,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -161,7 +158,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -220,9 +216,6 @@
                                         "type": "object"
                                     },
                                     "id": {
-                                        "type": "string"
-                                    },
-                                    "identicon": {
                                         "type": "string"
                                     },
                                     "lineCount": {
@@ -301,7 +294,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -550,9 +542,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -629,7 +618,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_deleteMessageAndSend
+++ b/tests-functional/schemas/wakuext_deleteMessageAndSend
@@ -92,9 +92,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -174,7 +171,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",

--- a/tests-functional/schemas/wakuext_deleteMessageForMeAndSync
+++ b/tests-functional/schemas/wakuext_deleteMessageForMeAndSync
@@ -92,9 +92,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -174,7 +171,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -301,9 +297,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -383,7 +376,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_dismissLatestContactRequestForContact
+++ b/tests-functional/schemas/wakuext_dismissLatestContactRequestForContact
@@ -80,9 +80,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -161,7 +158,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -220,9 +216,6 @@
                                         "type": "object"
                                     },
                                     "id": {
-                                        "type": "string"
-                                    },
-                                    "identicon": {
                                         "type": "string"
                                     },
                                     "lineCount": {
@@ -301,7 +294,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -550,9 +542,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -629,7 +618,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_editMessage
+++ b/tests-functional/schemas/wakuext_editMessage
@@ -92,9 +92,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -174,7 +171,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -301,9 +297,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -383,7 +376,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_getLatestContactRequestForContact
+++ b/tests-functional/schemas/wakuext_getLatestContactRequestForContact
@@ -54,9 +54,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -133,7 +130,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_leaveGroupChat
+++ b/tests-functional/schemas/wakuext_leaveGroupChat
@@ -212,9 +212,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -298,7 +295,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "mentions",

--- a/tests-functional/schemas/wakuext_markActivityCenterNotificationsRead
+++ b/tests-functional/schemas/wakuext_markActivityCenterNotificationsRead
@@ -77,9 +77,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -125,7 +122,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -182,9 +178,6 @@
                                         "type": "object"
                                     },
                                     "id": {
-                                        "type": "string"
-                                    },
-                                    "identicon": {
                                         "type": "string"
                                     },
                                     "lineCount": {
@@ -266,7 +259,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",

--- a/tests-functional/schemas/wakuext_markActivityCenterNotificationsUnread
+++ b/tests-functional/schemas/wakuext_markActivityCenterNotificationsUnread
@@ -89,9 +89,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -171,7 +168,6 @@
                                     "from",
                                     "gapParameters",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",

--- a/tests-functional/schemas/wakuext_markAllActivityCenterNotificationsRead
+++ b/tests-functional/schemas/wakuext_markAllActivityCenterNotificationsRead
@@ -85,9 +85,6 @@
                                             "id": {
                                                 "type": "string"
                                             },
-                                            "identicon": {
-                                                "type": "string"
-                                            },
                                             "lineCount": {
                                                 "type": "integer"
                                             },
@@ -166,7 +163,6 @@
                                             "ensName",
                                             "from",
                                             "id",
-                                            "identicon",
                                             "lineCount",
                                             "localChatId",
                                             "messageType",
@@ -229,9 +225,6 @@
                                                 "type": "string"
                                             },
                                             "id": {
-                                                "type": "string"
-                                            },
-                                            "identicon": {
                                                 "type": "string"
                                             },
                                             "lineCount": {
@@ -309,7 +302,6 @@
                                             "ensName",
                                             "from",
                                             "id",
-                                            "identicon",
                                             "lineCount",
                                             "localChatId",
                                             "messageType",

--- a/tests-functional/schemas/wakuext_messageByMessageID
+++ b/tests-functional/schemas/wakuext_messageByMessageID
@@ -45,9 +45,6 @@
                 "id": {
                     "type": "string"
                 },
-                "identicon": {
-                    "type": "string"
-                },
                 "lineCount": {
                     "type": "integer"
                 },
@@ -126,7 +123,6 @@
                 "from",
                 "gapParameters",
                 "id",
-                "identicon",
                 "lineCount",
                 "localChatId",
                 "messageType",

--- a/tests-functional/schemas/wakuext_removeContact
+++ b/tests-functional/schemas/wakuext_removeContact
@@ -86,9 +86,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -134,7 +131,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -370,9 +366,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -418,7 +411,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_removeMemberFromGroupChat
+++ b/tests-functional/schemas/wakuext_removeMemberFromGroupChat
@@ -212,9 +212,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -298,7 +295,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "mentions",

--- a/tests-functional/schemas/wakuext_removeMembersFromGroupChat
+++ b/tests-functional/schemas/wakuext_removeMembersFromGroupChat
@@ -212,9 +212,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -298,7 +295,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "mentions",

--- a/tests-functional/schemas/wakuext_requestTransaction
+++ b/tests-functional/schemas/wakuext_requestTransaction
@@ -125,9 +125,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -206,7 +203,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -358,9 +354,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -439,7 +432,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_retractContactRequest
+++ b/tests-functional/schemas/wakuext_retractContactRequest
@@ -86,9 +86,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -134,7 +131,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -370,9 +366,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -418,7 +411,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_sendChatMessage
+++ b/tests-functional/schemas/wakuext_sendChatMessage
@@ -86,9 +86,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -166,7 +163,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -182,7 +178,6 @@
                                     "whisperTimestamp"
                                 ],
                                 "type": "object"
-
                             },
                             "members": {
                                 "items": {
@@ -213,12 +208,6 @@
                             },
                             "name": {
                                 "type": "string"
-                            },
-                            "syncedFrom": {
-                                "type": "integer"
-                            },
-                            "syncedTo": {
-                                "type": "integer"
                             },
                             "timestamp": {
                                 "type": "integer"
@@ -549,8 +538,8 @@
                                 "type": "object"
                             },
                             "chatsModified": {
-                                "patternProperties": {
-                                    "^[a-zA-Z0-9-]+$": {
+                                "properties": {
+                                    "66dbc222-c960-4857-bb68-3d06527eac65": {
                                         "properties": {
                                             "CategoryModified": {
                                                 "type": "string"
@@ -967,9 +956,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -1048,7 +1034,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_sendContactRequest
+++ b/tests-functional/schemas/wakuext_sendContactRequest
@@ -86,9 +86,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -167,7 +164,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -327,9 +323,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -408,7 +401,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -652,9 +644,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -732,7 +721,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_sendEmojiReaction
+++ b/tests-functional/schemas/wakuext_sendEmojiReaction
@@ -65,6 +65,9 @@
                                     "compressedKey": {
                                         "type": "string"
                                     },
+                                    "contactRequestState": {
+                                        "type": "integer"
+                                    },
                                     "contentType": {
                                         "type": "integer"
                                     },
@@ -84,9 +87,6 @@
                                         "type": "string"
                                     },
                                     "id": {
-                                        "type": "string"
-                                    },
-                                    "identicon": {
                                         "type": "string"
                                     },
                                     "lineCount": {
@@ -167,7 +167,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",

--- a/tests-functional/schemas/wakuext_sendEmojiReactionRetraction
+++ b/tests-functional/schemas/wakuext_sendEmojiReactionRetraction
@@ -89,9 +89,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -163,13 +160,13 @@
                                     "chatId",
                                     "clock",
                                     "compressedKey",
+                                    "contactRequestState",
                                     "contentType",
                                     "displayName",
                                     "emojiHash",
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",

--- a/tests-functional/schemas/wakuext_sendGroupChatMessage
+++ b/tests-functional/schemas/wakuext_sendGroupChatMessage
@@ -83,9 +83,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -163,7 +160,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -344,9 +340,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -425,7 +418,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_sendOneToOneMessage
+++ b/tests-functional/schemas/wakuext_sendOneToOneMessage
@@ -86,9 +86,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -166,7 +163,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -290,9 +286,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -371,7 +364,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/schemas/wakuext_sendPinMessage
+++ b/tests-functional/schemas/wakuext_sendPinMessage
@@ -86,9 +86,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -166,7 +163,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -288,9 +284,6 @@
                                 "type": "object"
                             },
                             "id": {
-                                "type": "string"
-                            },
-                            "identicon": {
                                 "type": "string"
                             },
                             "lineCount": {
@@ -435,7 +428,6 @@
                             "from",
                             "gapParameters",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",
@@ -473,9 +465,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "localChatId": {
                                 "type": "string"
                             },
@@ -501,7 +490,6 @@
                             "clock",
                             "from",
                             "id",
-                            "identicon",
                             "localChatId",
                             "message_id",
                             "message_type",

--- a/tests-functional/schemas/wakuext_sendTransaction
+++ b/tests-functional/schemas/wakuext_sendTransaction
@@ -125,9 +125,6 @@
                                     "id": {
                                         "type": "string"
                                     },
-                                    "identicon": {
-                                        "type": "string"
-                                    },
                                     "lineCount": {
                                         "type": "integer"
                                     },
@@ -206,7 +203,6 @@
                                     "ensName",
                                     "from",
                                     "id",
-                                    "identicon",
                                     "lineCount",
                                     "localChatId",
                                     "messageType",
@@ -358,9 +354,6 @@
                             "id": {
                                 "type": "string"
                             },
-                            "identicon": {
-                                "type": "string"
-                            },
                             "lineCount": {
                                 "type": "integer"
                             },
@@ -439,7 +432,6 @@
                             "ensName",
                             "from",
                             "id",
-                            "identicon",
                             "lineCount",
                             "localChatId",
                             "messageType",

--- a/tests-functional/tests/test_accounts.py
+++ b/tests-functional/tests/test_accounts.py
@@ -1,3 +1,4 @@
+import os
 import random
 import pytest
 from resources.constants import user_1
@@ -27,3 +28,26 @@ class TestAccounts:
 
         response = self.rpc_client.rpc_valid_request(method, params, _id)
         self.rpc_client.verify_json_schema(response.json(), method)
+
+    def test_store_identity_image(self):
+        self.rpc_client.import_data(
+            os.path.abspath(os.path.join(os.path.dirname(__file__), "../resources/images/test-image-200x200.jpg")), "/tmp/images/"
+        )
+        response = self.rpc_client.rpc_valid_request(
+            "multiaccounts_storeIdentityImage", [self.rpc_client.key_uid, "/tmp/images/test-image-200x200.jpg", 0, 0, 200, 200]
+        )
+
+        jsonResponse = response.json()
+        result = jsonResponse.get("result", {})
+        assert result is not None, "Identity images were not stored (no result)"
+        assert len(result) == 2, "Identity images were not stored (wrong count)"
+        assert result[0]["localUrl"] is not None, "Local URL for identity image 1 is not set"
+        assert result[1]["localUrl"] is not None, "Local URL for identity image 2 is not set"
+
+        response = self.rpc_client.rpc_valid_request("multiaccounts_getIdentityImages", [self.rpc_client.key_uid])
+        jsonResponse = response.json()
+        result = jsonResponse.get("result", {})
+        assert result is not None, "Identity images were not retrieved (no result)"
+        assert len(result) == 2, "Identity images were not retrieved (wrong count)"
+        assert result[0]["localUrl"] is not None, "Local URL for identity image 1 is not set"
+        assert result[1]["localUrl"] is not None, "Local URL for identity image 2 is not set"


### PR DESCRIPTION
Same thing as https://github.com/status-im/status-go/pull/6776 but without the breaking change of removing the URI for IdentityImages, because mobile still uses that one.

The other breaking change of removing the identicon from the Message json is fine, because no client uses it.