### PR TITLE
test_: properly logout and disconnect from StatusBackend

### DIFF
--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import threading
 import time
 
 import websocket
@@ -162,23 +163,31 @@ class SignalClient:
         return [signal.get("event") for signal in signals]
 
     def _on_error(self, ws, error):
-        logging.error(f"SignalClient websocket error: {error}")
+        logging.error(f"SignalClient [{self.url}]: websocket error: {error}")
 
     def _on_close(self, ws, close_status_code, close_msg):
-        logging.debug(f"SignalClient websocket connection closed to {self.url}: {close_status_code}, {close_msg}")
+        logging.debug(f"SignalClient [{self.url}]: websocket connection closed: {close_status_code}, {close_msg}")
 
     def _on_open(self, ws):
-        logging.debug(f"SignalClient websocket connection opened to {self.url}")
+        logging.debug(f"SignalClient [{self.url}]: websocket connection opened")
 
     def _connect(self):
-        ws = websocket.WebSocketApp(
+        self.wsapp = websocket.WebSocketApp(
             url=self.url,
             on_message=self.on_message,
             on_error=self._on_error,
             on_open=self._on_open,
             on_close=self._on_close,
         )
-        ws.run_forever()
+        self.wsapp.run_forever()
+
+    def connect(self):
+        websocket_thread = threading.Thread(target=self._connect)
+        websocket_thread.daemon = True
+        websocket_thread.start()
+
+    def disconnect(self):
+        self.wsapp.close()
 
     def write_signal_to_file(self, signal_data):
         with open(self.signal_file_path, "a+") as file:

--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -162,22 +162,22 @@ class SignalClient:
         return [signal.get("event") for signal in signals]
 
     def _on_error(self, ws, error):
-        logging.error(f"Error: {error}")
+        logging.error(f"SignalClient websocket error: {error}")
 
     def _on_close(self, ws, close_status_code, close_msg):
-        logging.debug(f"Connection closed: {close_status_code}, {close_msg}")
+        logging.debug(f"SignalClient websocket connection closed to {self.url}: {close_status_code}, {close_msg}")
 
     def _on_open(self, ws):
-        logging.debug("Connection opened")
+        logging.debug(f"SignalClient websocket connection opened to {self.url}")
 
     def _connect(self):
         ws = websocket.WebSocketApp(
-            self.url,
+            url=self.url,
             on_message=self.on_message,
             on_error=self._on_error,
+            on_open=self._on_open,
             on_close=self._on_close,
         )
-        ws.on_open = self._on_open
         ws.run_forever()
 
     def write_signal_to_file(self, signal_data):

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -4,7 +4,6 @@ import string
 import tempfile
 import time
 import random
-import threading
 import uuid
 import requests
 import os
@@ -72,9 +71,7 @@ class StatusBackend(RpcClient, SignalClient):
 
         self.wait_for_healthy()
 
-        websocket_thread = threading.Thread(target=self._connect)
-        websocket_thread.daemon = True
-        websocket_thread.start()
+        SignalClient.connect(self)
 
         self.wallet_service = WalletService(self)
         self.wakuext_service = WakuextService(self)
@@ -82,6 +79,14 @@ class StatusBackend(RpcClient, SignalClient):
         self.settings_service = SettingsService(self)
 
     def __del__(self):
+        self.shutdown()
+
+    def shutdown(self):
+        SignalClient.disconnect(self)
+
+        if self.container:
+            self.container.shutdown()
+
         if self.temp_dir is not None:
             self.temp_dir.cleanup()
 

--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -181,6 +181,23 @@ class StatusGoContainer:
         if self.health_monitor.is_alive():
             logging.warning("Health monitoring thread didn't stop gracefully")
 
+    def shutdown(self):
+        """
+        Stops, saves logs, and removes a container with error handling.
+        Args:
+            container: The container object (should have stop, save_logs, remove methods)
+            log_prefix: Optional string for logging context
+        """
+        if not self.container:
+            logging.debug("No container to shutdown")
+            return
+
+        container_id = self.short_id()
+        self.stop()
+        self.save_logs()
+        self.remove()
+        logging.debug(f"Container '{container_id}' shutdown finished")
+
     def stop(self):
         """Stop the container and monitoring"""
         self.stop_health_monitoring()  # Stop health monitoring first
@@ -283,8 +300,7 @@ class StatusGoContainer:
             logging.debug("Save container logs skipped")
             return
 
-        id_short = self.container.id[:12]
-        file_path = os.path.join(Config.logs_dir, f"container_{id_short}.log")
+        file_path = os.path.join(Config.logs_dir, f"container_{self.short_id()}.log")
         logging.info(f"Saving logs to {file_path}")
 
         with open(file_path, "wb") as f:

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -174,3 +174,5 @@ class SecretRedactingFilter(logging.Filter):
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 logger.addFilter(SecretRedactingFilter())
+
+logging.getLogger("websocket").setLevel(logging.ERROR)

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -36,7 +36,7 @@ def backend_factory(request):
     ipv6 = params.get("ipv6", USE_IPV6)
 
     # Store created backends for cleanup
-    created_backends = []
+    created_backends: list[StatusBackend] = []
 
     def factory(name, *, start_messenger=True) -> StatusBackend:
         """
@@ -68,11 +68,7 @@ def backend_factory(request):
 
     for i, backend in enumerate(reversed(created_backends)):
         logging.debug(f"🧹 [TEARDOWN] Cleaning up backend {len(created_backends) - i}...")
-
-        if hasattr(backend, "container") and backend.container:
-            teardown_container(backend.container, log_prefix=f"🧹 [TEARDOWN] Cleaning up backend {len(created_backends) - i} container...")
-        else:
-            logging.debug(f"ℹ️ [TEARDOWN] Backend {len(created_backends) - i} has no container to cleanup")
+        backend.shutdown()
 
 
 @pytest.fixture(scope="function", autouse=False)
@@ -82,9 +78,13 @@ def waku_light_client(request) -> bool:
 
 @pytest.fixture(scope="function", autouse=False)
 def backend_new_profile(request, backend_factory):
+    backends: list[StatusBackend] = []
+
     def _backend_new_profile(name: str, waku_light_client: bool = False) -> StatusBackend:
         logging.debug(f"📋 [SETUP] backend_new_profile parameters: wakuV2LightClient={waku_light_client}")
         backend = backend_factory(name)
+        backends.append(backend)
+
         backend.init_status_backend()
         backend.create_account_and_login(waku_light_client=waku_light_client)
         backend.wait_for_login()
@@ -92,14 +92,20 @@ def backend_new_profile(request, backend_factory):
         return backend
 
     yield _backend_new_profile
-    # backend.logout()
+
+    for backend in backends:
+        backend.logout()
 
 
 @pytest.fixture(scope="function", autouse=False)
 def backend_recovered_profile(request, backend_factory):
+    backends: list[StatusBackend] = []
+
     def _backend_recovered_profile(name: str, user: object, waku_light_client: bool = False, **kwargs) -> StatusBackend:
         logging.debug(f"📋 [SETUP] backend_recovered_profile parameters: wakuV2LightClient={waku_light_client}")
         backend = backend_factory(name)
+        backends.append(backend)
+
         backend.init_status_backend()
         backend.restore_account_and_login(user=user, waku_light_client=waku_light_client, **kwargs)
         backend.wait_for_login()
@@ -107,29 +113,9 @@ def backend_recovered_profile(request, backend_factory):
         return backend
 
     yield _backend_recovered_profile
-    # backend.logout()
 
-
-def teardown_container(container, log_prefix=""):
-    """
-    Stops, saves logs, and removes a container with error handling.
-    Args:
-        container: The container object (should have stop, save_logs, remove methods)
-        log_prefix: Optional string for logging context
-    """
-    if not hasattr(container, "container") or not container.container:
-        logging.debug(f"{log_prefix}No container to cleanup.")
-        return
-    container.stop()  # pyright: ignore[reportAttributeAccessIssue]
-    try:
-        container.save_logs()  # pyright: ignore[reportAttributeAccessIssue]
-    except RuntimeError as e:
-        if "Container is not initialized" in str(e):
-            logging.warning(f"{log_prefix}Container already stopped, skipping log save: {e}")
-        else:
-            raise
-    container.remove()  # pyright: ignore[reportAttributeAccessIssue]
-    logging.debug(f"{log_prefix}Container stopped and removed.")
+    for backend in backends:
+        backend.logout()
 
 
 @pytest.fixture(scope="function", autouse=False)
@@ -173,7 +159,7 @@ def close_status_backend_containers(request):
     yield
     for container in StatusGoContainer.all_containers:
         try:
-            teardown_container(container, log_prefix="[close_status_backend_containers] ")
+            container.shutdown()  # pyright: ignore[reportAttributeAccessIssue]
         except Exception as e:
             logging.error(f"Error cleaning up container: {e}")
     StatusGoContainer.all_containers = []


### PR DESCRIPTION
# Description

1. Automatically disconnect the WebSocket client before shutting down the container.
    This is just right to do, but also fixes websocket errors in the log.
2. `Logout` before shutting down `StatusBackend`
3. Moved `teardown_container` to `container.shutdown`
4. Set `websocket` logging to `ERROR` to remove useless warnings about connected/disconnected