### PR TITLE
chore(backup)_: enable local backup flag and final fix

### DIFF
--- a/node/backup/core.go
+++ b/node/backup/core.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"bytes"
 	"encoding/gob"
+	"errors"
 	"fmt"
 
 	"github.com/status-im/status-go/eth-node/crypto"
@@ -78,17 +79,18 @@ func (b *core) exportBackup() (map[string][]byte, error) {
 }
 
 func (b *core) importBackup(data map[string][]byte) error {
+	var errs []error
 	for name, provider := range b.backupProviders {
 		raw, ok := data[name]
 		if !ok {
 			continue
 		}
 		if err := provider.ImportBackup(raw); err != nil {
-			return fmt.Errorf("importBackup %q failed: %w", name, err)
+			errs = append(errs, fmt.Errorf("importBackup %q failed: %w", name, err))
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func marshal(data map[string][]byte) ([]byte, error) {

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -228,9 +228,8 @@ func (n *StatusNode) StartLocalBackup() error {
 	n.localBackup, err = backup.NewController(backup.BackupConfig{
 		PrivateKey:     crypto.Keccak256(crypto.FromECDSA(privateKey)),
 		FileNameGetter: filenameGetter,
-		// TODO set to true to enable the local backup
-		BackupEnabled: false,
-		Interval:      time.Minute * 30,
+		BackupEnabled:  true,
+		Interval:       time.Minute * 30,
 	}, n.logger.Named("LocalBackup"))
 	if err != nil {
 		return err

--- a/protocol/messenger_backup.go
+++ b/protocol/messenger_backup.go
@@ -390,6 +390,7 @@ func (m *Messenger) backupChats(ctx context.Context, clock uint64) []*protobuf.B
 					From:       membershipUpdate.From,
 					RawPayload: membershipUpdate.RawPayload,
 					Color:      membershipUpdate.Color,
+					Image:      membershipUpdate.Image,
 				}
 			}
 		}

--- a/protocol/messenger_backup.go
+++ b/protocol/messenger_backup.go
@@ -25,7 +25,7 @@ var backupTickerInterval = 120 * time.Second
 
 // backupIntervalSeconds is the amount of seconds we should allow between
 // backups
-var backupIntervalSeconds uint64 = 28800
+var backupIntervalSeconds uint64 = 57600
 
 type CommunitySet struct {
 	Joined  []*communities.Community

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -537,7 +537,8 @@ func (s *Service) handleSyncWatchOnlyAccount(message *protobuf.SyncAccount) (*ac
 
 	if dbAccount != nil {
 		if message.Clock <= dbAccount.Clock {
-			return nil, ErrTryingToStoreOldWalletAccount
+			// ignore this old message
+			return nil, nil
 		}
 
 		if message.Removed {


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/18400

First commit fixes an issue where if something was already imported before, it would throw an error and mess up the rest of the imports.
Instead, we only return the error for real error, like not being able to unmarshall. Otherwise, we just ignore in between errors, because they usually just mean that the clock of the imported backup is older than what is already saved.

Second commit is the enabling of the local backup save loop.

Third commit is doubling the waku backup so that we slowly deprecate it, but it will still work