### PR TITLE
ci_: upgrade codecov cli

### DIFF
--- a/_assets/scripts/codecov.sh
+++ b/_assets/scripts/codecov.sh
@@ -16,6 +16,9 @@ report_to_codecov() {
     report_files_args+="--file ${file} "
   done
 
+  # Print codecov version
+  codecov --version
+
   # Don't upload test results to Codecov while we re-run tests on failure.
   # This results in having both failure and success results in the same report, which Codecov treats as a failure
   # and doesn't report coverage to Github. More details here: https://github.com/status-im/status-go/issues/5963

--- a/nix/pkgs/codecov-cli/default.nix
+++ b/nix/pkgs/codecov-cli/default.nix
@@ -10,15 +10,15 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "codecov";
-  version = "0.7.4";
+  version = "11.1.0";
 
   src = fetchurl {
     url = "https://cli.codecov.io/v${version}/${platform}/codecov";
     hash = lib.getAttr system {
-      aarch64-darwin = "sha256-CB1D8/zYF23Jes9sd6rJiadDg7nwwee9xWSYqSByAlU=";
-      x86_64-darwin = "sha256-CB1D8/zYF23Jes9sd6rJiadDg7nwwee9xWSYqSByAlU=";
-      x86_64-linux = "sha256-65AgCcuAD977zikcE1eVP4Dik4L0PHqYzOO1fStNjOw=";
-      aarch64-linux = "sha256-hALtVSXY40uTIaAtwWr7EXh7zclhK63r7a341Tn+q/g=";
+      aarch64-darwin = "sha256-Arm/CUJ/QdGwVhA5WWt0xgB2hsGogn+epeAVKQZ+maQ=";
+      x86_64-darwin = "sha256-Arm/CUJ/QdGwVhA5WWt0xgB2hsGogn+epeAVKQZ+maQ=";
+      x86_64-linux = "sha256-XMiVGIZOquSfOBnkK6NT+aPGdpEtRHI1HTGXBkPxpJo=";
+      aarch64-linux = "sha256-e4hqsXUMxL+AyADIv1CunhDHeohuSKTRXtxaCWXj2qg=";
     };
    };
 


### PR DESCRIPTION
# Descirption

Attempting to fix the issue when codecov status checks are missing in PRs:
<img width="584" height="158" alt="image" src="https://github.com/user-attachments/assets/3d6b3452-7559-421c-99d7-e96031e1221e" />
although the tests have passed:
<img width="522" height="86" alt="image" src="https://github.com/user-attachments/assets/585cad4f-a1d6-4454-b139-f3dd97153437" />

---

Although `codecov-cli` was successfully uploading the reports in such cases, this is the simplest thing to try at the moment. Because otherwise the issue is somewhere on Codecov end.