### PR TITLE
refactor: replace customized bit sizer with bit.Uintsize

### DIFF
--- a/eth-node/types/json.go
+++ b/eth-node/types/json.go
@@ -6,13 +6,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/bits"
 	"reflect"
 	"strconv"
 )
 
 const (
 	badNibble = ^uint64(0)
-	uintBits  = 32 << (uint64(^uint(0)) >> 63)
 )
 
 // Errors
@@ -24,7 +24,7 @@ var (
 	ErrEmptyNumber   = &decError{"hex string \"0x\""}
 	ErrLeadingZero   = &decError{"hex number with leading zero digits"}
 	ErrUint64Range   = &decError{"hex number > 64 bits"}
-	ErrUintRange     = &decError{fmt.Sprintf("hex number > %d bits", uintBits)}
+	ErrUintRange     = &decError{fmt.Sprintf("hex number > %d bits", bits.UintSize)}
 	ErrBig256Range   = &decError{"hex number > 256 bits"}
 )
 


### PR DESCRIPTION
 replace customized bit sizer with bit.Uintsize

Inspired by https://github.com/ethereum/go-ethereum/pulls?q=bit.Uintsize

