### PR TITLE
ci_: upgrade foundry to 1.3.0

### DIFF
--- a/tests-functional/Dockerfile
+++ b/tests-functional/Dockerfile
@@ -1,14 +1,8 @@
-FROM ghcr.io/foundry-rs/foundry:v0.3.0
-
-RUN apk update && \
-    apk add git bash
+FROM ghcr.io/foundry-rs/foundry:v1.3.0
 
 WORKDIR /app
 
-COPY clone_and_run.sh /app
-RUN chmod +x /app/clone_and_run.sh
-
-COPY entrypoint.sh /app
-RUN chmod +x /app/entrypoint.sh
+COPY --chmod=0755 clone_and_run.sh /app
+COPY --chmod=0755 entrypoint.sh /app
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]


### PR DESCRIPTION
Since today I have issues building with `0.3.0` locally for some reason:
```
[+] Building 0.5s (2/2) FINISHED                                                                                                                                      docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                  0.0s
 => => transferring dockerfile: 290B                                                                                                                                                  0.0s
 => ERROR [internal] load metadata for ghcr.io/foundry-rs/foundry:v0.3.0                                                                                                              0.5s
------
 > [internal] load metadata for ghcr.io/foundry-rs/foundry:v0.3.0:
------
Dockerfile:1
--------------------
   1 | >>> FROM ghcr.io/foundry-rs/foundry:v0.3.0
   2 |     
   3 |     RUN apk update && \
--------------------
ERROR: failed to build: failed to solve: ghcr.io/foundry-rs/foundry:v0.3.0: failed to resolve source metadata for ghcr.io/foundry-rs/foundry:v0.3.0: no match for platform in manifest: not found
```

The upgrade fixes the issue.