### PR TITLE
feat(cmd)_: empty db generation utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,3 +447,6 @@ codecov-validate:
 pytest-lint:
 	$(MAKE) -C tests-functional lint
 
+generate-db: build/bin/generate-db
+generate-db: ##@build Generate fake sqlite DBs in ./build directory for IDE SQL inspections
+	./build/bin/generate-db -out-dir build/db

--- a/cmd/generate-db/README.md
+++ b/cmd/generate-db/README.md
@@ -1,0 +1,30 @@
+# generate-db
+
+A tiny utility to generate empty, up-to-date SQLite databases used by Status. 
+
+It initializes the databases using the same initializers and migrations as the app, 
+so the resulting files match the current schema. This is handy for IDE SQL inspections, 
+schema exploration, or tooling that expects a real database file.
+
+## What it creates
+
+- `app.db` — initialized via `appdatabase.DbInitializer`
+- `wallet.db` — initialized via `walletdatabase.DbInitializer`
+- `accounts.db` — initialized via `multiaccounts.InitializeDB`
+
+By design, these databases are empty (no user data) but fully migrated to the latest schema.
+
+## Build and run
+
+```bash
+make generate-db
+```
+This builds the tool and generates databases under `build/db` by default.
+
+## Notes
+
+- Schemas are produced by the current codebase.  
+  If you update migrations, rerun this tool to regenerate the files.
+- The tool uses an empty password and 0 KDF iterations during initialization.  
+  These files are strictly for local development, inspection, and tooling.
+- Existing files at the target location are removed before re-creation. 

--- a/cmd/generate-db/main.go
+++ b/cmd/generate-db/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/multiaccounts"
+	"github.com/status-im/status-go/walletdatabase"
+)
+
+const (
+	password            = ""
+	kdfIterationsNumber = 0
+)
+
+func main() {
+	outDir := flag.String("out-dir", "build", "Output directory for generated DB files")
+	flag.Parse()
+
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		log.Fatalf("failed to create output directory %s: %v", *outDir, err)
+	}
+
+	if err := generateAppDB(*outDir); err != nil {
+		log.Fatalf("failed to generate app DB: %v", err)
+	}
+	fmt.Println("Generated app DB")
+
+	if err := generateWalletDB(*outDir); err != nil {
+		log.Fatalf("failed to generate wallet DB: %v", err)
+	}
+	fmt.Println("Generated wallet DB")
+
+	if err := generateAccountsDB(*outDir); err != nil {
+		log.Fatalf("failed to generate accounts DB: %v", err)
+	}
+	fmt.Println("Generated accounts DB")
+
+	fmt.Printf("All DBs are generated under %s\n", *outDir)
+}
+
+func recreate(path string) error {
+	_ = os.Remove(path)
+	_ = os.Remove(path + "-wal")
+	_ = os.Remove(path + "-shm")
+	return nil
+}
+
+func generateAppDB(outDir string) error {
+	path := filepath.Join(outDir, "app.db")
+	if err := recreate(path); err != nil {
+		return err
+	}
+
+	// Use the same initializer the app uses
+	var init appdatabase.DbInitializer
+	_, err := init.Initialize(path, password, kdfIterationsNumber)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func generateWalletDB(outDir string) error {
+	path := filepath.Join(outDir, "wallet.db")
+	if err := recreate(path); err != nil {
+		return err
+	}
+
+	// Use the same initializer the app uses
+	var init walletdatabase.DbInitializer
+	_, err := init.Initialize(path, password, kdfIterationsNumber)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func generateAccountsDB(outDir string) error {
+	path := filepath.Join(outDir, "accounts.db")
+	if err := recreate(path); err != nil {
+		return err
+	}
+
+	// Accounts DB uses its own initializer returning a wrapper type
+	db, err := multiaccounts.InitializeDB(path)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	return nil
+}


### PR DESCRIPTION
# Description

A simple utility that generates 3 empty unencrypted databases (accounts, app, wallet).

This is useful for:
1. Debugging purposes, easy to check DB schemas
2. IDE integration

    E.g. in GoLand there's a [Data Sources](https://www.jetbrains.com/help/idea/managing-data-sources.html#share-data-sources) feature that analyze the SQL queries in our code agains the DB schemas:
    <img width="578" height="133" alt="image" src="https://github.com/user-attachments/assets/07cc782d-a309-4f85-98f3-0d66e13938ed" />

# Usage

```
> make generate-db
...

> ls build/db  
.rw-r--r-- sirotin staff  36 KB Mon Aug 11 16:40:52 2025 accounts.db
.rw-r--r-- sirotin staff 452 KB Mon Aug 11 16:40:52 2025 app.db
.rw-r--r-- sirotin staff  32 KB Mon Aug 11 16:40:52 2025 app.db-shm
.rw-r--r-- sirotin staff 3.9 MB Mon Aug 11 16:40:52 2025 app.db-wal
.rw-r--r-- sirotin staff 4.0 KB Mon Aug 11 16:40:52 2025 wallet.db
.rw-r--r-- sirotin staff  32 KB Mon Aug 11 16:40:52 2025 wallet.db-shm
.rw-r--r-- sirotin staff 1.5 MB Mon Aug 11 16:40:52 2025 wallet.db-wal
```