### PR TITLE
feat(ci)_: implement nightly benchmark runs on CI

### DIFF
--- a/_assets/ci/Jenkinsfile.tests-benchmark
+++ b/_assets/ci/Jenkinsfile.tests-benchmark
@@ -1,0 +1,71 @@
+#!/usr/bin/env groovy
+library 'status-jenkins-lib@v1.9.24'
+
+pipeline {
+  agent { label 'benchmark' }
+
+  triggers {
+    // Nightly at 2am
+    cron 'H 2 * * *'
+  }
+
+  parameters {
+    string(
+      name: 'BRANCH',
+      defaultValue: 'develop',
+      description: 'Name of branch to build.'
+    )
+  }
+
+  options {
+    timestamps()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 50, unit: 'MINUTES')
+    disableConcurrentBuilds()
+    disableRestartFromStage()
+    /* manage how many builds we keep */
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
+      artifactNumToKeepStr: '1',
+    ))
+  }
+
+  stages {
+    stage('Benchmark Tests') {
+      steps {
+        script {
+          nix.develop('make benchmark', pure: false)
+       }
+     }
+   }
+    stage('Push Results') {
+      steps {
+        sshagent(credentials: ['status-go-benchmarks-deploy-key']) {
+          sh './_assets/scripts/push_benchmark.sh'
+        }
+      }
+    }
+  } // stages
+
+  post {
+    always {
+      script {
+        junit(
+          testResults: 'tests-functional/.results/reports/*.xml',
+          skipOldReports: true,
+          skipPublishingChecks: true,
+          skipMarkingBuildUnstable: true,
+        )
+      }
+    }
+    cleanup {
+      script {
+        sh '''
+          docker ps -a --filter "name=status-go-func-tests-${BUILD_ID}" -q | xargs -r docker rm -f
+          make git-clean
+        '''
+      }
+    }
+  } // post
+} // pipeline

--- a/_assets/scripts/push_benchmark.sh
+++ b/_assets/scripts/push_benchmark.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -o nounset
+set -o errexit
+set -o pipefail
+
+REPO_URL="git@github.com:status-im/status-go-benchmarks.git"
+
+GIT_ROOT=$(cd "${BASH_SOURCE%/*}" && git rev-parse --show-toplevel)
+source "${GIT_ROOT}/_assets/scripts/colors.sh"
+
+echo -e "${GRN}Pushing benchmark results${RST}"
+
+cd "${GIT_ROOT}"
+# Get the commit SHA from the status-go repo BEFORE cloning bench-repo
+commit_sha=$(git rev-parse --short HEAD)
+
+git clone "${REPO_URL}" benchmarks-repo
+cd benchmarks-repo
+
+timestamp=$(date -u '+%Y%m%dT%H%M%S')
+benchmark_dir="${timestamp}_${commit_sha}"
+
+echo -e "${GRN}Creating benchmark directory${RST}"
+mkdir -p "benchmarks/${benchmark_dir}"
+
+echo -e "${GRN}Copying benchmark results${RST}"
+cp -r "${GIT_ROOT}/tests-functional/.results/benchmarks"/* "benchmarks/${benchmark_dir}/"
+
+echo -e "${GRN}Creating virtual environment${RST}"
+python3 -m venv .venv
+source .venv/bin/activate
+
+echo -e "${GRN}Installing dependencies${RST}"
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo -e "${GRN}Updating README${RST}"
+python ./scripts/update_readme.py
+
+echo -e "${GRN}Committing changes${RST}"
+git add .
+git commit -m "Add benchmark results ${benchmark_dir}"
+
+echo -e "${GRN}Pushing changes${RST}"
+git push "${REPO_URL}"
+
+echo -e "${GRN}Push finished${RST}"


### PR DESCRIPTION
- runs nightly at 2am
- runs on dedicated ci host labaled as `benchmark`
- uses `deploy-key` for pushing to:
  - https://github.com/status-im/status-go-benchmarks

Refs.:
- https://github.com/status-im/status-go-benchmarks/issues/1 
- https://github.com/status-im/status-go/pull/6786
