### PR TITLE
feat(cmd)_: generate json schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,3 +447,6 @@ codecov-validate:
 pytest-lint:
 	$(MAKE) -C tests-functional lint
 
+
+generate-json-schemas: build/bin/generate-json-schemas
+	./build/bin/generate-json-schemas -out-dir tests-functional/schemas

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ status-go-deps:
 	go install go.uber.org/mock/mockgen@v0.4.0
 	go install github.com/kevinburke/go-bindata/v4/...@v4.0.2
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
+	go install github.com/goware/modvendor@v0.5.0
 
 statusgo-android: generate
 statusgo-android: ##@cross-compile Build status-go for Android

--- a/cmd/generate-json-schemas/main.go
+++ b/cmd/generate-json-schemas/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"reflect"
+
+	"github.com/invopop/jsonschema"
+	"github.com/pkg/errors"
+
+	"github.com/status-im/status-go/protocol"
+	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/services/ens"
+	"github.com/status-im/status-go/services/personal"
+)
+
+var types = []any{
+	protocol.MessengerResponse{},
+	[]*ens.UsernameDetail{},
+	[]*communities.RequestToJoin{},
+	[]personal.SignParams{},
+}
+
+var (
+	outDir = flag.String("out-dir", ".", "output directory for JSON schema files")
+)
+
+func process(t any, path string) error {
+	schema := jsonschema.Reflect(t)
+	json, err := schema.MarshalJSON()
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal schema")
+	}
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return errors.Wrap(err, "failed to open file")
+	}
+	defer file.Close()
+
+	_, err = file.Write(json)
+	if err != nil {
+		return errors.Wrap(err, "failed to write file")
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	for _, t := range types {
+		typeString := reflect.TypeOf(t)
+		filename := fmt.Sprintf("%s.json", typeString)
+		filepath := path.Join(*outDir, filename)
+
+		err := process(t, filepath)
+		if err != nil {
+			log.Printf("Failed to process type '%v' - %v", typeString, err)
+			continue
+		}
+
+		log.Printf("Generated schema for type '%v': %s", typeString, filepath)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	github.com/getsentry/sentry-go v0.29.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/gorilla/websocket v1.5.3
+	github.com/invopop/jsonschema v0.13.0
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/jmoiron/sqlx v1.3.5
@@ -97,7 +98,7 @@ require (
 	github.com/status-im/extkeys v1.1.0
 	github.com/waku-org/go-waku v0.8.1-0.20250411145637-900b98812a91
 	github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d
-	github.com/wk8/go-ordered-map/v2 v2.1.7
+	github.com/wk8/go-ordered-map/v2 v2.1.8
 	github.com/yeqown/go-qrcode/v2 v2.2.1
 	github.com/yeqown/go-qrcode/writer/standard v1.2.1
 	go.lsp.dev/jsonrpc2 v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1182,6 +1182,8 @@ github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bS
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
+github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
+github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=
 github.com/ipfs/go-cid v0.4.1/go.mod h1:uQHwDeX4c6CtyrFwdqyhpNcxVewur1M7l7fNU7LKwZk=
@@ -2185,8 +2187,8 @@ github.com/willf/bloom v0.0.0-20170505221640-54e3b963ee16/go.mod h1:MmAltL9pDMNT
 github.com/willf/bloom v2.0.3+incompatible/go.mod h1:MmAltL9pDMNTrvUkxdg0k0q5I0suxmuwp3KbyrZLOZ8=
 github.com/wk8/go-ordered-map v1.0.0 h1:BV7z+2PaK8LTSd/mWgY12HyMAo5CEgkHqbkVq2thqr8=
 github.com/wk8/go-ordered-map v1.0.0/go.mod h1:9ZIbRunKbuvfPKyBP1SIKLcXNlv74YCOZ3t3VTS6gRk=
-github.com/wk8/go-ordered-map/v2 v2.1.7 h1:aUZ1xBMdbvY8wnNt77qqo4nyT3y0pX4Usat48Vm+hik=
-github.com/wk8/go-ordered-map/v2 v2.1.7/go.mod h1:9Xvgm2mV2kSq2SAm0Y608tBmu8akTzI7c2bz7/G7ZN4=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/wlynxg/anet v0.0.3/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
 github.com/wlynxg/anet v0.0.4 h1:0de1OFQxnNqAu+x2FAKKCVIrnfGKQbs7FQz++tB0+Uw=
 github.com/wlynxg/anet v0.0.4/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=

--- a/vendor/github.com/invopop/jsonschema/.gitignore
+++ b/vendor/github.com/invopop/jsonschema/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+.idea/

--- a/vendor/github.com/invopop/jsonschema/.golangci.yml
+++ b/vendor/github.com/invopop/jsonschema/.golangci.yml
@@ -1,0 +1,69 @@
+run:
+  tests: true
+  max-same-issues: 50
+
+output:
+  print-issued-lines: false
+
+linters:
+  enable:
+    - gocyclo
+    - gocritic
+    - goconst
+    - dupl
+    - unconvert
+    - goimports
+    - unused
+    - govet
+    - nakedret
+    - errcheck
+    - revive
+    - ineffassign
+    - goconst
+    - unparam
+    - gofmt
+
+linters-settings:
+  vet:
+    check-shadowing: true
+    use-installed-packages: true
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 8
+    min-occurrences: 3
+  gocyclo:
+    min-complexity: 20
+  gocritic:
+    disabled-checks:
+      - ifElseChain
+  gofmt:
+    rewrite-rules:
+      - pattern: "interface{}"
+        replacement: "any"
+      - pattern: "a[b:len(a)]"
+        replacement: "a[b:]"
+
+issues:
+  max-per-linter: 0
+  max-same: 0
+  exclude-dirs:
+    - resources
+    - old
+  exclude-files:
+    - cmd/protopkg/main.go
+  exclude-use-default: false
+  exclude:
+    # Captured by errcheck.
+    - "^(G104|G204):"
+    # Very commonly not checked.
+    - 'Error return value of .(.*\.Help|.*\.MarkFlagRequired|(os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*Print(f|ln|)|os\.(Un)?Setenv). is not checked'
+    # Weird error only seen on Kochiku...
+    - "internal error: no range for"
+    - 'exported method `.*\.(MarshalJSON|UnmarshalJSON|URN|Payload|GoString|Close|Provides|Requires|ExcludeFromHash|MarshalText|UnmarshalText|Description|Check|Poll|Severity)` should have comment or be unexported'
+    - "composite literal uses unkeyed fields"
+    - 'declaration of "err" shadows declaration'
+    - "by other packages, and that stutters"
+    - "Potential file inclusion via variable"
+    - "at least one file in a package should have a package comment"
+    - "bad syntax for struct tag pair"

--- a/vendor/github.com/invopop/jsonschema/COPYING
+++ b/vendor/github.com/invopop/jsonschema/COPYING
@@ -1,0 +1,19 @@
+Copyright (C) 2014 Alec Thomas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/invopop/jsonschema/README.md
+++ b/vendor/github.com/invopop/jsonschema/README.md
@@ -1,0 +1,374 @@
+# Go JSON Schema Reflection
+
+[![Lint](https://github.com/invopop/jsonschema/actions/workflows/lint.yaml/badge.svg)](https://github.com/invopop/jsonschema/actions/workflows/lint.yaml)
+[![Test Go](https://github.com/invopop/jsonschema/actions/workflows/test.yaml/badge.svg)](https://github.com/invopop/jsonschema/actions/workflows/test.yaml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/invopop/jsonschema)](https://goreportcard.com/report/github.com/invopop/jsonschema)
+[![GoDoc](https://godoc.org/github.com/invopop/jsonschema?status.svg)](https://godoc.org/github.com/invopop/jsonschema)
+[![codecov](https://codecov.io/gh/invopop/jsonschema/graph/badge.svg?token=JMEB8W8GNZ)](https://codecov.io/gh/invopop/jsonschema)
+![Latest Tag](https://img.shields.io/github/v/tag/invopop/jsonschema)
+
+This package can be used to generate [JSON Schemas](http://json-schema.org/latest/json-schema-validation.html) from Go types through reflection.
+
+- Supports arbitrarily complex types, including `interface{}`, maps, slices, etc.
+- Supports json-schema features such as minLength, maxLength, pattern, format, etc.
+- Supports simple string and numeric enums.
+- Supports custom property fields via the `jsonschema_extras` struct tag.
+
+This repository is a fork of the original [jsonschema](https://github.com/alecthomas/jsonschema) by [@alecthomas](https://github.com/alecthomas). At [Invopop](https://invopop.com) we use jsonschema as a cornerstone in our [GOBL library](https://github.com/invopop/gobl), and wanted to be able to continue building and adding features without taking up Alec's time. There have been a few significant changes that probably mean this version is a not compatible with with Alec's:
+
+- The original was stuck on the draft-04 version of JSON Schema, we've now moved to the latest JSON Schema Draft 2020-12.
+- Schema IDs are added automatically from the current Go package's URL in order to be unique, and can be disabled with the `Anonymous` option.
+- Support for the `FullyQualifyTypeName` option has been removed. If you have conflicts, you should use multiple schema files with different IDs, set the `DoNotReference` option to true to hide definitions completely, or add your own naming strategy using the `Namer` property.
+- Support for `yaml` tags and related options has been dropped for the sake of simplification. There were a [few inconsistencies](https://github.com/invopop/jsonschema/pull/21) around this that have now been fixed.
+
+## Versions
+
+This project is still under v0 scheme, as per Go convention, breaking changes are likely. Please pin go modules to version tags or branches, and reach out if you think something can be improved.
+
+Go version >= 1.18 is required as generics are now being used.
+
+## Example
+
+The following Go type:
+
+```go
+type TestUser struct {
+  ID            int                    `json:"id"`
+  Name          string                 `json:"name" jsonschema:"title=the name,description=The name of a friend,example=joe,example=lucy,default=alex"`
+  Friends       []int                  `json:"friends,omitempty" jsonschema_description:"The list of IDs, omitted when empty"`
+  Tags          map[string]interface{} `json:"tags,omitempty" jsonschema_extras:"a=b,foo=bar,foo=bar1"`
+  BirthDate     time.Time              `json:"birth_date,omitempty" jsonschema:"oneof_required=date"`
+  YearOfBirth   string                 `json:"year_of_birth,omitempty" jsonschema:"oneof_required=year"`
+  Metadata      interface{}            `json:"metadata,omitempty" jsonschema:"oneof_type=string;array"`
+  FavColor      string                 `json:"fav_color,omitempty" jsonschema:"enum=red,enum=green,enum=blue"`
+}
+```
+
+Results in following JSON Schema:
+
+```go
+jsonschema.Reflect(&TestUser{})
+```
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/invopop/jsonschema_test/test-user",
+  "$ref": "#/$defs/TestUser",
+  "$defs": {
+    "TestUser": {
+      "oneOf": [
+        {
+          "required": ["birth_date"],
+          "title": "date"
+        },
+        {
+          "required": ["year_of_birth"],
+          "title": "year"
+        }
+      ],
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string",
+          "title": "the name",
+          "description": "The name of a friend",
+          "default": "alex",
+          "examples": ["joe", "lucy"]
+        },
+        "friends": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array",
+          "description": "The list of IDs, omitted when empty"
+        },
+        "tags": {
+          "type": "object",
+          "a": "b",
+          "foo": ["bar", "bar1"]
+        },
+        "birth_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "year_of_birth": {
+          "type": "string"
+        },
+        "metadata": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
+        "fav_color": {
+          "type": "string",
+          "enum": ["red", "green", "blue"]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": ["id", "name"]
+    }
+  }
+}
+```
+
+## YAML
+
+Support for `yaml` tags has now been removed. If you feel very strongly about this, we've opened a discussion to hear your comments: https://github.com/invopop/jsonschema/discussions/28
+
+The recommended approach if you need to deal with YAML data is to first convert to JSON. The [invopop/yaml](https://github.com/invopop/yaml) library will make this trivial.
+
+## Configurable behaviour
+
+The behaviour of the schema generator can be altered with parameters when a `jsonschema.Reflector`
+instance is created.
+
+### ExpandedStruct
+
+If set to `true`, makes the top level struct not to reference itself in the definitions. But type passed should be a struct type.
+
+eg.
+
+```go
+type GrandfatherType struct {
+	FamilyName string `json:"family_name" jsonschema:"required"`
+}
+
+type SomeBaseType struct {
+	SomeBaseProperty int `json:"some_base_property"`
+	// The jsonschema required tag is nonsensical for private and ignored properties.
+	// Their presence here tests that the fields *will not* be required in the output
+	// schema, even if they are tagged required.
+	somePrivateBaseProperty            string `json:"i_am_private" jsonschema:"required"`
+	SomeIgnoredBaseProperty            string `json:"-" jsonschema:"required"`
+	SomeSchemaIgnoredProperty          string `jsonschema:"-,required"`
+	SomeUntaggedBaseProperty           bool   `jsonschema:"required"`
+	someUnexportedUntaggedBaseProperty bool
+	Grandfather                        GrandfatherType `json:"grand"`
+}
+```
+
+will output:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "required": ["some_base_property", "grand", "SomeUntaggedBaseProperty"],
+  "properties": {
+    "SomeUntaggedBaseProperty": {
+      "type": "boolean"
+    },
+    "grand": {
+      "$schema": "http://json-schema.org/draft/2020-12/schema",
+      "$ref": "#/definitions/GrandfatherType"
+    },
+    "some_base_property": {
+      "type": "integer"
+    }
+  },
+  "type": "object",
+  "$defs": {
+    "GrandfatherType": {
+      "required": ["family_name"],
+      "properties": {
+        "family_name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}
+```
+
+### Using Go Comments
+
+Writing a good schema with descriptions inside tags can become cumbersome and tedious, especially if you already have some Go comments around your types and field definitions. If you'd like to take advantage of these existing comments, you can use the `AddGoComments(base, path string)` method that forms part of the reflector to parse your go files and automatically generate a dictionary of Go import paths, types, and fields, to individual comments. These will then be used automatically as description fields, and can be overridden with a manual definition if needed.
+
+Take a simplified example of a User struct which for the sake of simplicity we assume is defined inside this package:
+
+```go
+package main
+
+// User is used as a base to provide tests for comments.
+type User struct {
+	// Unique sequential identifier.
+	ID int `json:"id" jsonschema:"required"`
+	// Name of the user
+	Name string `json:"name"`
+}
+```
+
+To get the comments provided into your JSON schema, use a regular `Reflector` and add the go code using an import module URL and path. Fully qualified go module paths cannot be determined reliably by the `go/parser` library, so we need to introduce this manually:
+
+```go
+r := new(Reflector)
+if err := r.AddGoComments("github.com/invopop/jsonschema", "./"); err != nil {
+  // deal with error
+}
+s := r.Reflect(&User{})
+// output
+```
+
+Expect the results to be similar to:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/$defs/User",
+  "$defs": {
+    "User": {
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Unique sequential identifier."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the user"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "User is used as a base to provide tests for comments."
+    }
+  }
+}
+```
+
+### Custom Key Naming
+
+In some situations, the keys actually used to write files are different from Go structs'.
+
+This is often the case when writing a configuration file to YAML or JSON from a Go struct, or when returning a JSON response for a Web API: APIs typically use snake_case, while Go uses PascalCase.
+
+You can pass a `func(string) string` function to `Reflector`'s `KeyNamer` option to map Go field names to JSON key names and reflect the aforementioned transformations, without having to specify `json:"..."` on every struct field.
+
+For example, consider the following struct
+
+```go
+type User struct {
+  GivenName       string
+  PasswordSalted  []byte `json:"salted_password"`
+}
+```
+
+We can transform field names to snake_case in the generated JSON schema:
+
+```go
+r := new(jsonschema.Reflector)
+r.KeyNamer = strcase.SnakeCase // from package github.com/stoewer/go-strcase
+
+r.Reflect(&User{})
+```
+
+Will yield
+
+```diff
+  {
+    "$schema": "http://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/$defs/User",
+    "$defs": {
+      "User": {
+        "properties": {
+-         "GivenName": {
++         "given_name": {
+            "type": "string"
+          },
+          "salted_password": {
+            "type": "string",
+            "contentEncoding": "base64"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+-       "required": ["GivenName", "salted_password"]
++       "required": ["given_name", "salted_password"]
+      }
+    }
+  }
+```
+
+As you can see, if a field name has a `json:""` tag set, the `key` argument to `KeyNamer` will have the value of that tag.
+
+### Custom Type Definitions
+
+Sometimes it can be useful to have custom JSON Marshal and Unmarshal methods in your structs that automatically convert for example a string into an object.
+
+This library will recognize and attempt to call four different methods that help you adjust schemas to your specific needs:
+
+- `JSONSchema() *Schema` - will prevent auto-generation of the schema so that you can provide your own definition.
+- `JSONSchemaExtend(schema *jsonschema.Schema)` - will be called _after_ the schema has been generated, allowing you to add or manipulate the fields easily.
+- `JSONSchemaAlias() any` - is called when reflecting the type of object and allows for an alternative to be used instead.
+- `JSONSchemaProperty(prop string) any` - will be called for every property inside a struct giving you the chance to provide an alternative object to convert into a schema.
+
+Note that all of these methods **must** be defined on a non-pointer object for them to be called.
+
+Take the following simplified example of a `CompactDate` that only includes the Year and Month:
+
+```go
+type CompactDate struct {
+	Year  int
+	Month int
+}
+
+func (d *CompactDate) UnmarshalJSON(data []byte) error {
+  if len(data) != 9 {
+    return errors.New("invalid compact date length")
+  }
+  var err error
+  d.Year, err = strconv.Atoi(string(data[1:5]))
+  if err != nil {
+    return err
+  }
+  d.Month, err = strconv.Atoi(string(data[7:8]))
+  if err != nil {
+    return err
+  }
+  return nil
+}
+
+func (d *CompactDate) MarshalJSON() ([]byte, error) {
+  buf := new(bytes.Buffer)
+  buf.WriteByte('"')
+  buf.WriteString(fmt.Sprintf("%d-%02d", d.Year, d.Month))
+  buf.WriteByte('"')
+  return buf.Bytes(), nil
+}
+
+func (CompactDate) JSONSchema() *Schema {
+	return &Schema{
+		Type:        "string",
+		Title:       "Compact Date",
+		Description: "Short date that only includes year and month",
+		Pattern:     "^[0-9]{4}-[0-1][0-9]$",
+	}
+}
+```
+
+The resulting schema generated for this struct would look like:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/$defs/CompactDate",
+  "$defs": {
+    "CompactDate": {
+      "pattern": "^[0-9]{4}-[0-1][0-9]$",
+      "type": "string",
+      "title": "Compact Date",
+      "description": "Short date that only includes year and month"
+    }
+  }
+}
+```

--- a/vendor/github.com/invopop/jsonschema/id.go
+++ b/vendor/github.com/invopop/jsonschema/id.go
@@ -1,0 +1,76 @@
+package jsonschema
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ID represents a Schema ID type which should always be a URI.
+// See draft-bhutton-json-schema-00 section 8.2.1
+type ID string
+
+// EmptyID is used to explicitly define an ID with no value.
+const EmptyID ID = ""
+
+// Validate is used to check if the ID looks like a proper schema.
+// This is done by parsing the ID as a URL and checking it has all the
+// relevant parts.
+func (id ID) Validate() error {
+	u, err := url.Parse(id.String())
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Hostname() == "" {
+		return errors.New("missing hostname")
+	}
+	if !strings.Contains(u.Hostname(), ".") {
+		return errors.New("hostname does not look valid")
+	}
+	if u.Path == "" {
+		return errors.New("path is expected")
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return errors.New("unexpected schema")
+	}
+	return nil
+}
+
+// Anchor sets the anchor part of the schema URI.
+func (id ID) Anchor(name string) ID {
+	b := id.Base()
+	return ID(b.String() + "#" + name)
+}
+
+// Def adds or replaces a definition identifier.
+func (id ID) Def(name string) ID {
+	b := id.Base()
+	return ID(b.String() + "#/$defs/" + name)
+}
+
+// Add appends the provided path to the id, and removes any
+// anchor data that might be there.
+func (id ID) Add(path string) ID {
+	b := id.Base()
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return ID(b.String() + path)
+}
+
+// Base removes any anchor information from the schema
+func (id ID) Base() ID {
+	s := id.String()
+	i := strings.LastIndex(s, "#")
+	if i != -1 {
+		s = s[0:i]
+	}
+	s = strings.TrimRight(s, "/")
+	return ID(s)
+}
+
+// String provides string version of ID
+func (id ID) String() string {
+	return string(id)
+}

--- a/vendor/github.com/invopop/jsonschema/reflect.go
+++ b/vendor/github.com/invopop/jsonschema/reflect.go
@@ -1,0 +1,1148 @@
+// Package jsonschema uses reflection to generate JSON Schemas from Go types [1].
+//
+// If json tags are present on struct fields, they will be used to infer
+// property names and if a property is required (omitempty is present).
+//
+// [1] http://json-schema.org/latest/json-schema-validation.html
+package jsonschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// customSchemaImpl is used to detect if the type provides it's own
+// custom Schema Type definition to use instead. Very useful for situations
+// where there are custom JSON Marshal and Unmarshal methods.
+type customSchemaImpl interface {
+	JSONSchema() *Schema
+}
+
+// Function to be run after the schema has been generated.
+// this will let you modify a schema afterwards
+type extendSchemaImpl interface {
+	JSONSchemaExtend(*Schema)
+}
+
+// If the object to be reflected defines a `JSONSchemaAlias` method, its type will
+// be used instead of the original type.
+type aliasSchemaImpl interface {
+	JSONSchemaAlias() any
+}
+
+// If an object to be reflected defines a `JSONSchemaPropertyAlias` method,
+// it will be called for each property to determine if another object
+// should be used for the contents.
+type propertyAliasSchemaImpl interface {
+	JSONSchemaProperty(prop string) any
+}
+
+var customAliasSchema = reflect.TypeOf((*aliasSchemaImpl)(nil)).Elem()
+var customPropertyAliasSchema = reflect.TypeOf((*propertyAliasSchemaImpl)(nil)).Elem()
+
+var customType = reflect.TypeOf((*customSchemaImpl)(nil)).Elem()
+var extendType = reflect.TypeOf((*extendSchemaImpl)(nil)).Elem()
+
+// customSchemaGetFieldDocString
+type customSchemaGetFieldDocString interface {
+	GetFieldDocString(fieldName string) string
+}
+
+type customGetFieldDocString func(fieldName string) string
+
+var customStructGetFieldDocString = reflect.TypeOf((*customSchemaGetFieldDocString)(nil)).Elem()
+
+// Reflect reflects to Schema from a value using the default Reflector
+func Reflect(v any) *Schema {
+	return ReflectFromType(reflect.TypeOf(v))
+}
+
+// ReflectFromType generates root schema using the default Reflector
+func ReflectFromType(t reflect.Type) *Schema {
+	r := &Reflector{}
+	return r.ReflectFromType(t)
+}
+
+// A Reflector reflects values into a Schema.
+type Reflector struct {
+	// BaseSchemaID defines the URI that will be used as a base to determine Schema
+	// IDs for models. For example, a base Schema ID of `https://invopop.com/schemas`
+	// when defined with a struct called `User{}`, will result in a schema with an
+	// ID set to `https://invopop.com/schemas/user`.
+	//
+	// If no `BaseSchemaID` is provided, we'll take the type's complete package path
+	// and use that as a base instead. Set `Anonymous` to try if you do not want to
+	// include a schema ID.
+	BaseSchemaID ID
+
+	// Anonymous when true will hide the auto-generated Schema ID and provide what is
+	// known as an "anonymous schema". As a rule, this is not recommended.
+	Anonymous bool
+
+	// AssignAnchor when true will use the original struct's name as an anchor inside
+	// every definition, including the root schema. These can be useful for having a
+	// reference to the original struct's name in CamelCase instead of the snake-case used
+	// by default for URI compatibility.
+	//
+	// Anchors do not appear to be widely used out in the wild, so at this time the
+	// anchors themselves will not be used inside generated schema.
+	AssignAnchor bool
+
+	// AllowAdditionalProperties will cause the Reflector to generate a schema
+	// without additionalProperties set to 'false' for all struct types. This means
+	// the presence of additional keys in JSON objects will not cause validation
+	// to fail. Note said additional keys will simply be dropped when the
+	// validated JSON is unmarshaled.
+	AllowAdditionalProperties bool
+
+	// RequiredFromJSONSchemaTags will cause the Reflector to generate a schema
+	// that requires any key tagged with `jsonschema:required`, overriding the
+	// default of requiring any key *not* tagged with `json:,omitempty`.
+	RequiredFromJSONSchemaTags bool
+
+	// Do not reference definitions. This will remove the top-level $defs map and
+	// instead cause the entire structure of types to be output in one tree. The
+	// list of type definitions (`$defs`) will not be included.
+	DoNotReference bool
+
+	// ExpandedStruct when true will include the reflected type's definition in the
+	// root as opposed to a definition with a reference.
+	ExpandedStruct bool
+
+	// FieldNameTag will change the tag used to get field names. json tags are used by default.
+	FieldNameTag string
+
+	// IgnoredTypes defines a slice of types that should be ignored in the schema,
+	// switching to just allowing additional properties instead.
+	IgnoredTypes []any
+
+	// Lookup allows a function to be defined that will provide a custom mapping of
+	// types to Schema IDs. This allows existing schema documents to be referenced
+	// by their ID instead of being embedded into the current schema definitions.
+	// Reflected types will never be pointers, only underlying elements.
+	Lookup func(reflect.Type) ID
+
+	// Mapper is a function that can be used to map custom Go types to jsonschema schemas.
+	Mapper func(reflect.Type) *Schema
+
+	// Namer allows customizing of type names. The default is to use the type's name
+	// provided by the reflect package.
+	Namer func(reflect.Type) string
+
+	// KeyNamer allows customizing of key names.
+	// The default is to use the key's name as is, or the json tag if present.
+	// If a json tag is present, KeyNamer will receive the tag's name as an argument, not the original key name.
+	KeyNamer func(string) string
+
+	// AdditionalFields allows adding structfields for a given type
+	AdditionalFields func(reflect.Type) []reflect.StructField
+
+	// LookupComment allows customizing comment lookup. Given a reflect.Type and optionally
+	// a field name, it should return the comment string associated with this type or field.
+	//
+	// If the field name is empty, it should return the type's comment; otherwise, the field's
+	// comment should be returned. If no comment is found, an empty string should be returned.
+	//
+	// When set, this function is called before the below CommentMap lookup mechanism. However,
+	// if it returns an empty string, the CommentMap is still consulted.
+	LookupComment func(reflect.Type, string) string
+
+	// CommentMap is a dictionary of fully qualified go types and fields to comment
+	// strings that will be used if a description has not already been provided in
+	// the tags. Types and fields are added to the package path using "." as a
+	// separator.
+	//
+	// Type descriptions should be defined like:
+	//
+	//   map[string]string{"github.com/invopop/jsonschema.Reflector": "A Reflector reflects values into a Schema."}
+	//
+	// And Fields defined as:
+	//
+	//   map[string]string{"github.com/invopop/jsonschema.Reflector.DoNotReference": "Do not reference definitions."}
+	//
+	// See also: AddGoComments, LookupComment
+	CommentMap map[string]string
+}
+
+// Reflect reflects to Schema from a value.
+func (r *Reflector) Reflect(v any) *Schema {
+	return r.ReflectFromType(reflect.TypeOf(v))
+}
+
+// ReflectFromType generates root schema
+func (r *Reflector) ReflectFromType(t reflect.Type) *Schema {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem() // re-assign from pointer
+	}
+
+	name := r.typeName(t)
+
+	s := new(Schema)
+	definitions := Definitions{}
+	s.Definitions = definitions
+	bs := r.reflectTypeToSchemaWithID(definitions, t)
+	if r.ExpandedStruct {
+		*s = *definitions[name]
+		delete(definitions, name)
+	} else {
+		*s = *bs
+	}
+
+	// Attempt to set the schema ID
+	if !r.Anonymous && s.ID == EmptyID {
+		baseSchemaID := r.BaseSchemaID
+		if baseSchemaID == EmptyID {
+			id := ID("https://" + t.PkgPath())
+			if err := id.Validate(); err == nil {
+				// it's okay to silently ignore URL errors
+				baseSchemaID = id
+			}
+		}
+		if baseSchemaID != EmptyID {
+			s.ID = baseSchemaID.Add(ToSnakeCase(name))
+		}
+	}
+
+	s.Version = Version
+	if !r.DoNotReference {
+		s.Definitions = definitions
+	}
+
+	return s
+}
+
+// Available Go defined types for JSON Schema Validation.
+// RFC draft-wright-json-schema-validation-00, section 7.3
+var (
+	timeType = reflect.TypeOf(time.Time{}) // date-time RFC section 7.3.1
+	ipType   = reflect.TypeOf(net.IP{})    // ipv4 and ipv6 RFC section 7.3.4, 7.3.5
+	uriType  = reflect.TypeOf(url.URL{})   // uri RFC section 7.3.6
+)
+
+// Byte slices will be encoded as base64
+var byteSliceType = reflect.TypeOf([]byte(nil))
+
+// Except for json.RawMessage
+var rawMessageType = reflect.TypeOf(json.RawMessage{})
+
+// Go code generated from protobuf enum types should fulfil this interface.
+type protoEnum interface {
+	EnumDescriptor() ([]byte, []int)
+}
+
+var protoEnumType = reflect.TypeOf((*protoEnum)(nil)).Elem()
+
+// SetBaseSchemaID is a helper use to be able to set the reflectors base
+// schema ID from a string as opposed to then ID instance.
+func (r *Reflector) SetBaseSchemaID(id string) {
+	r.BaseSchemaID = ID(id)
+}
+
+func (r *Reflector) refOrReflectTypeToSchema(definitions Definitions, t reflect.Type) *Schema {
+	id := r.lookupID(t)
+	if id != EmptyID {
+		return &Schema{
+			Ref: id.String(),
+		}
+	}
+
+	// Already added to definitions?
+	if def := r.refDefinition(definitions, t); def != nil {
+		return def
+	}
+
+	return r.reflectTypeToSchemaWithID(definitions, t)
+}
+
+func (r *Reflector) reflectTypeToSchemaWithID(defs Definitions, t reflect.Type) *Schema {
+	s := r.reflectTypeToSchema(defs, t)
+	if s != nil {
+		if r.Lookup != nil {
+			id := r.Lookup(t)
+			if id != EmptyID {
+				s.ID = id
+			}
+		}
+	}
+	return s
+}
+
+func (r *Reflector) reflectTypeToSchema(definitions Definitions, t reflect.Type) *Schema {
+	// only try to reflect non-pointers
+	if t.Kind() == reflect.Ptr {
+		return r.refOrReflectTypeToSchema(definitions, t.Elem())
+	}
+
+	// Check if the there is an alias method that provides an object
+	// that we should use instead of this one.
+	if t.Implements(customAliasSchema) {
+		v := reflect.New(t)
+		o := v.Interface().(aliasSchemaImpl)
+		t = reflect.TypeOf(o.JSONSchemaAlias())
+		return r.refOrReflectTypeToSchema(definitions, t)
+	}
+
+	// Do any pre-definitions exist?
+	if r.Mapper != nil {
+		if t := r.Mapper(t); t != nil {
+			return t
+		}
+	}
+	if rt := r.reflectCustomSchema(definitions, t); rt != nil {
+		return rt
+	}
+
+	// Prepare a base to which details can be added
+	st := new(Schema)
+
+	// jsonpb will marshal protobuf enum options as either strings or integers.
+	// It will unmarshal either.
+	if t.Implements(protoEnumType) {
+		st.OneOf = []*Schema{
+			{Type: "string"},
+			{Type: "integer"},
+		}
+		return st
+	}
+
+	// Defined format types for JSON Schema Validation
+	// RFC draft-wright-json-schema-validation-00, section 7.3
+	// TODO email RFC section 7.3.2, hostname RFC section 7.3.3, uriref RFC section 7.3.7
+	if t == ipType {
+		// TODO differentiate ipv4 and ipv6 RFC section 7.3.4, 7.3.5
+		st.Type = "string"
+		st.Format = "ipv4"
+		return st
+	}
+
+	switch t.Kind() {
+	case reflect.Struct:
+		r.reflectStruct(definitions, t, st)
+
+	case reflect.Slice, reflect.Array:
+		r.reflectSliceOrArray(definitions, t, st)
+
+	case reflect.Map:
+		r.reflectMap(definitions, t, st)
+
+	case reflect.Interface:
+		// empty
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		st.Type = "integer"
+
+	case reflect.Float32, reflect.Float64:
+		st.Type = "number"
+
+	case reflect.Bool:
+		st.Type = "boolean"
+
+	case reflect.String:
+		st.Type = "string"
+
+	default:
+		panic("unsupported type " + t.String())
+	}
+
+	r.reflectSchemaExtend(definitions, t, st)
+
+	// Always try to reference the definition which may have just been created
+	if def := r.refDefinition(definitions, t); def != nil {
+		return def
+	}
+
+	return st
+}
+
+func (r *Reflector) reflectCustomSchema(definitions Definitions, t reflect.Type) *Schema {
+	if t.Kind() == reflect.Ptr {
+		return r.reflectCustomSchema(definitions, t.Elem())
+	}
+
+	if t.Implements(customType) {
+		v := reflect.New(t)
+		o := v.Interface().(customSchemaImpl)
+		st := o.JSONSchema()
+		r.addDefinition(definitions, t, st)
+		if ref := r.refDefinition(definitions, t); ref != nil {
+			return ref
+		}
+		return st
+	}
+
+	return nil
+}
+
+func (r *Reflector) reflectSchemaExtend(definitions Definitions, t reflect.Type, s *Schema) *Schema {
+	if t.Implements(extendType) {
+		v := reflect.New(t)
+		o := v.Interface().(extendSchemaImpl)
+		o.JSONSchemaExtend(s)
+		if ref := r.refDefinition(definitions, t); ref != nil {
+			return ref
+		}
+	}
+
+	return s
+}
+
+func (r *Reflector) reflectSliceOrArray(definitions Definitions, t reflect.Type, st *Schema) {
+	if t == rawMessageType {
+		return
+	}
+
+	r.addDefinition(definitions, t, st)
+
+	if st.Description == "" {
+		st.Description = r.lookupComment(t, "")
+	}
+
+	if t.Kind() == reflect.Array {
+		l := uint64(t.Len())
+		st.MinItems = &l
+		st.MaxItems = &l
+	}
+	if t.Kind() == reflect.Slice && t.Elem() == byteSliceType.Elem() {
+		st.Type = "string"
+		// NOTE: ContentMediaType is not set here
+		st.ContentEncoding = "base64"
+	} else {
+		st.Type = "array"
+		st.Items = r.refOrReflectTypeToSchema(definitions, t.Elem())
+	}
+}
+
+func (r *Reflector) reflectMap(definitions Definitions, t reflect.Type, st *Schema) {
+	r.addDefinition(definitions, t, st)
+
+	st.Type = "object"
+	if st.Description == "" {
+		st.Description = r.lookupComment(t, "")
+	}
+
+	switch t.Key().Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		st.PatternProperties = map[string]*Schema{
+			"^[0-9]+$": r.refOrReflectTypeToSchema(definitions, t.Elem()),
+		}
+		st.AdditionalProperties = FalseSchema
+		return
+	}
+	if t.Elem().Kind() != reflect.Interface {
+		st.AdditionalProperties = r.refOrReflectTypeToSchema(definitions, t.Elem())
+	}
+}
+
+// Reflects a struct to a JSON Schema type.
+func (r *Reflector) reflectStruct(definitions Definitions, t reflect.Type, s *Schema) {
+	// Handle special types
+	switch t {
+	case timeType: // date-time RFC section 7.3.1
+		s.Type = "string"
+		s.Format = "date-time"
+		return
+	case uriType: // uri RFC section 7.3.6
+		s.Type = "string"
+		s.Format = "uri"
+		return
+	}
+
+	r.addDefinition(definitions, t, s)
+	s.Type = "object"
+	s.Properties = NewProperties()
+	s.Description = r.lookupComment(t, "")
+	if r.AssignAnchor {
+		s.Anchor = t.Name()
+	}
+	if !r.AllowAdditionalProperties && s.AdditionalProperties == nil {
+		s.AdditionalProperties = FalseSchema
+	}
+
+	ignored := false
+	for _, it := range r.IgnoredTypes {
+		if reflect.TypeOf(it) == t {
+			ignored = true
+			break
+		}
+	}
+	if !ignored {
+		r.reflectStructFields(s, definitions, t)
+	}
+}
+
+func (r *Reflector) reflectStructFields(st *Schema, definitions Definitions, t reflect.Type) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return
+	}
+
+	var getFieldDocString customGetFieldDocString
+	if t.Implements(customStructGetFieldDocString) {
+		v := reflect.New(t)
+		o := v.Interface().(customSchemaGetFieldDocString)
+		getFieldDocString = o.GetFieldDocString
+	}
+
+	customPropertyMethod := func(string) any {
+		return nil
+	}
+	if t.Implements(customPropertyAliasSchema) {
+		v := reflect.New(t)
+		o := v.Interface().(propertyAliasSchemaImpl)
+		customPropertyMethod = o.JSONSchemaProperty
+	}
+
+	handleField := func(f reflect.StructField) {
+		name, shouldEmbed, required, nullable := r.reflectFieldName(f)
+		// if anonymous and exported type should be processed recursively
+		// current type should inherit properties of anonymous one
+		if name == "" {
+			if shouldEmbed {
+				r.reflectStructFields(st, definitions, f.Type)
+			}
+			return
+		}
+
+		// If a JSONSchemaAlias(prop string) method is defined, attempt to use
+		// the provided object's type instead of the field's type.
+		var property *Schema
+		if alias := customPropertyMethod(name); alias != nil {
+			property = r.refOrReflectTypeToSchema(definitions, reflect.TypeOf(alias))
+		} else {
+			property = r.refOrReflectTypeToSchema(definitions, f.Type)
+		}
+
+		property.structKeywordsFromTags(f, st, name)
+		if property.Description == "" {
+			property.Description = r.lookupComment(t, f.Name)
+		}
+		if getFieldDocString != nil {
+			property.Description = getFieldDocString(f.Name)
+		}
+
+		if nullable {
+			property = &Schema{
+				OneOf: []*Schema{
+					property,
+					{
+						Type: "null",
+					},
+				},
+			}
+		}
+
+		st.Properties.Set(name, property)
+		if required {
+			st.Required = appendUniqueString(st.Required, name)
+		}
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		handleField(f)
+	}
+	if r.AdditionalFields != nil {
+		if af := r.AdditionalFields(t); af != nil {
+			for _, sf := range af {
+				handleField(sf)
+			}
+		}
+	}
+}
+
+func appendUniqueString(base []string, value string) []string {
+	for _, v := range base {
+		if v == value {
+			return base
+		}
+	}
+	return append(base, value)
+}
+
+// addDefinition will append the provided schema. If needed, an ID and anchor will also be added.
+func (r *Reflector) addDefinition(definitions Definitions, t reflect.Type, s *Schema) {
+	name := r.typeName(t)
+	if name == "" {
+		return
+	}
+	definitions[name] = s
+}
+
+// refDefinition will provide a schema with a reference to an existing definition.
+func (r *Reflector) refDefinition(definitions Definitions, t reflect.Type) *Schema {
+	if r.DoNotReference {
+		return nil
+	}
+	name := r.typeName(t)
+	if name == "" {
+		return nil
+	}
+	if _, ok := definitions[name]; !ok {
+		return nil
+	}
+	return &Schema{
+		Ref: "#/$defs/" + name,
+	}
+}
+
+func (r *Reflector) lookupID(t reflect.Type) ID {
+	if r.Lookup != nil {
+		if t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+		return r.Lookup(t)
+
+	}
+	return EmptyID
+}
+
+func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, propertyName string) {
+	t.Description = f.Tag.Get("jsonschema_description")
+
+	tags := splitOnUnescapedCommas(f.Tag.Get("jsonschema"))
+	tags = t.genericKeywords(tags, parent, propertyName)
+
+	switch t.Type {
+	case "string":
+		t.stringKeywords(tags)
+	case "number":
+		t.numericalKeywords(tags)
+	case "integer":
+		t.numericalKeywords(tags)
+	case "array":
+		t.arrayKeywords(tags)
+	case "boolean":
+		t.booleanKeywords(tags)
+	}
+	extras := strings.Split(f.Tag.Get("jsonschema_extras"), ",")
+	t.extraKeywords(extras)
+}
+
+// read struct tags for generic keywords
+func (t *Schema) genericKeywords(tags []string, parent *Schema, propertyName string) []string { //nolint:gocyclo
+	unprocessed := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		nameValue := strings.SplitN(tag, "=", 2)
+		if len(nameValue) == 2 {
+			name, val := nameValue[0], nameValue[1]
+			switch name {
+			case "title":
+				t.Title = val
+			case "description":
+				t.Description = val
+			case "type":
+				t.Type = val
+			case "anchor":
+				t.Anchor = val
+			case "oneof_required":
+				var typeFound *Schema
+				for i := range parent.OneOf {
+					if parent.OneOf[i].Title == nameValue[1] {
+						typeFound = parent.OneOf[i]
+					}
+				}
+				if typeFound == nil {
+					typeFound = &Schema{
+						Title:    nameValue[1],
+						Required: []string{},
+					}
+					parent.OneOf = append(parent.OneOf, typeFound)
+				}
+				typeFound.Required = append(typeFound.Required, propertyName)
+			case "anyof_required":
+				var typeFound *Schema
+				for i := range parent.AnyOf {
+					if parent.AnyOf[i].Title == nameValue[1] {
+						typeFound = parent.AnyOf[i]
+					}
+				}
+				if typeFound == nil {
+					typeFound = &Schema{
+						Title:    nameValue[1],
+						Required: []string{},
+					}
+					parent.AnyOf = append(parent.AnyOf, typeFound)
+				}
+				typeFound.Required = append(typeFound.Required, propertyName)
+			case "oneof_ref":
+				subSchema := t
+				if t.Items != nil {
+					subSchema = t.Items
+				}
+				if subSchema.OneOf == nil {
+					subSchema.OneOf = make([]*Schema, 0, 1)
+				}
+				subSchema.Ref = ""
+				refs := strings.Split(nameValue[1], ";")
+				for _, r := range refs {
+					subSchema.OneOf = append(subSchema.OneOf, &Schema{
+						Ref: r,
+					})
+				}
+			case "oneof_type":
+				if t.OneOf == nil {
+					t.OneOf = make([]*Schema, 0, 1)
+				}
+				t.Type = ""
+				types := strings.Split(nameValue[1], ";")
+				for _, ty := range types {
+					t.OneOf = append(t.OneOf, &Schema{
+						Type: ty,
+					})
+				}
+			case "anyof_ref":
+				subSchema := t
+				if t.Items != nil {
+					subSchema = t.Items
+				}
+				if subSchema.AnyOf == nil {
+					subSchema.AnyOf = make([]*Schema, 0, 1)
+				}
+				subSchema.Ref = ""
+				refs := strings.Split(nameValue[1], ";")
+				for _, r := range refs {
+					subSchema.AnyOf = append(subSchema.AnyOf, &Schema{
+						Ref: r,
+					})
+				}
+			case "anyof_type":
+				if t.AnyOf == nil {
+					t.AnyOf = make([]*Schema, 0, 1)
+				}
+				t.Type = ""
+				types := strings.Split(nameValue[1], ";")
+				for _, ty := range types {
+					t.AnyOf = append(t.AnyOf, &Schema{
+						Type: ty,
+					})
+				}
+			default:
+				unprocessed = append(unprocessed, tag)
+			}
+		}
+	}
+	return unprocessed
+}
+
+// read struct tags for boolean type keywords
+func (t *Schema) booleanKeywords(tags []string) {
+	for _, tag := range tags {
+		nameValue := strings.Split(tag, "=")
+		if len(nameValue) != 2 {
+			continue
+		}
+		name, val := nameValue[0], nameValue[1]
+		if name == "default" {
+			if val == "true" {
+				t.Default = true
+			} else if val == "false" {
+				t.Default = false
+			}
+		}
+	}
+}
+
+// read struct tags for string type keywords
+func (t *Schema) stringKeywords(tags []string) {
+	for _, tag := range tags {
+		nameValue := strings.SplitN(tag, "=", 2)
+		if len(nameValue) == 2 {
+			name, val := nameValue[0], nameValue[1]
+			switch name {
+			case "minLength":
+				t.MinLength = parseUint(val)
+			case "maxLength":
+				t.MaxLength = parseUint(val)
+			case "pattern":
+				t.Pattern = val
+			case "format":
+				t.Format = val
+			case "readOnly":
+				i, _ := strconv.ParseBool(val)
+				t.ReadOnly = i
+			case "writeOnly":
+				i, _ := strconv.ParseBool(val)
+				t.WriteOnly = i
+			case "default":
+				t.Default = val
+			case "example":
+				t.Examples = append(t.Examples, val)
+			case "enum":
+				t.Enum = append(t.Enum, val)
+			}
+		}
+	}
+}
+
+// read struct tags for numerical type keywords
+func (t *Schema) numericalKeywords(tags []string) {
+	for _, tag := range tags {
+		nameValue := strings.Split(tag, "=")
+		if len(nameValue) == 2 {
+			name, val := nameValue[0], nameValue[1]
+			switch name {
+			case "multipleOf":
+				t.MultipleOf, _ = toJSONNumber(val)
+			case "minimum":
+				t.Minimum, _ = toJSONNumber(val)
+			case "maximum":
+				t.Maximum, _ = toJSONNumber(val)
+			case "exclusiveMaximum":
+				t.ExclusiveMaximum, _ = toJSONNumber(val)
+			case "exclusiveMinimum":
+				t.ExclusiveMinimum, _ = toJSONNumber(val)
+			case "default":
+				if num, ok := toJSONNumber(val); ok {
+					t.Default = num
+				}
+			case "example":
+				if num, ok := toJSONNumber(val); ok {
+					t.Examples = append(t.Examples, num)
+				}
+			case "enum":
+				if num, ok := toJSONNumber(val); ok {
+					t.Enum = append(t.Enum, num)
+				}
+			}
+		}
+	}
+}
+
+// read struct tags for object type keywords
+// func (t *Type) objectKeywords(tags []string) {
+//     for _, tag := range tags{
+//         nameValue := strings.Split(tag, "=")
+//         name, val := nameValue[0], nameValue[1]
+//         switch name{
+//             case "dependencies":
+//                 t.Dependencies = val
+//                 break;
+//             case "patternProperties":
+//                 t.PatternProperties = val
+//                 break;
+//         }
+//     }
+// }
+
+// read struct tags for array type keywords
+func (t *Schema) arrayKeywords(tags []string) {
+	var defaultValues []any
+
+	unprocessed := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		nameValue := strings.Split(tag, "=")
+		if len(nameValue) == 2 {
+			name, val := nameValue[0], nameValue[1]
+			switch name {
+			case "minItems":
+				t.MinItems = parseUint(val)
+			case "maxItems":
+				t.MaxItems = parseUint(val)
+			case "uniqueItems":
+				t.UniqueItems = true
+			case "default":
+				defaultValues = append(defaultValues, val)
+			case "format":
+				t.Items.Format = val
+			case "pattern":
+				t.Items.Pattern = val
+			default:
+				unprocessed = append(unprocessed, tag) // left for further processing by underlying type
+			}
+		}
+	}
+	if len(defaultValues) > 0 {
+		t.Default = defaultValues
+	}
+
+	if len(unprocessed) == 0 {
+		// we don't have anything else to process
+		return
+	}
+
+	switch t.Items.Type {
+	case "string":
+		t.Items.stringKeywords(unprocessed)
+	case "number":
+		t.Items.numericalKeywords(unprocessed)
+	case "integer":
+		t.Items.numericalKeywords(unprocessed)
+	case "array":
+		// explicitly don't support traversal for the [][]..., as it's unclear where the array tags belong
+	case "boolean":
+		t.Items.booleanKeywords(unprocessed)
+	}
+}
+
+func (t *Schema) extraKeywords(tags []string) {
+	for _, tag := range tags {
+		nameValue := strings.SplitN(tag, "=", 2)
+		if len(nameValue) == 2 {
+			t.setExtra(nameValue[0], nameValue[1])
+		}
+	}
+}
+
+func (t *Schema) setExtra(key, val string) {
+	if t.Extras == nil {
+		t.Extras = map[string]any{}
+	}
+	if existingVal, ok := t.Extras[key]; ok {
+		switch existingVal := existingVal.(type) {
+		case string:
+			t.Extras[key] = []string{existingVal, val}
+		case []string:
+			t.Extras[key] = append(existingVal, val)
+		case int:
+			t.Extras[key], _ = strconv.Atoi(val)
+		case bool:
+			t.Extras[key] = (val == "true" || val == "t")
+		}
+	} else {
+		switch key {
+		case "minimum":
+			t.Extras[key], _ = strconv.Atoi(val)
+		default:
+			var x any
+			if val == "true" {
+				x = true
+			} else if val == "false" {
+				x = false
+			} else {
+				x = val
+			}
+			t.Extras[key] = x
+		}
+	}
+}
+
+func requiredFromJSONTags(tags []string, val *bool) {
+	if ignoredByJSONTags(tags) {
+		return
+	}
+
+	for _, tag := range tags[1:] {
+		if tag == "omitempty" {
+			*val = false
+			return
+		}
+	}
+	*val = true
+}
+
+func requiredFromJSONSchemaTags(tags []string, val *bool) {
+	if ignoredByJSONSchemaTags(tags) {
+		return
+	}
+	for _, tag := range tags {
+		if tag == "required" {
+			*val = true
+		}
+	}
+}
+
+func nullableFromJSONSchemaTags(tags []string) bool {
+	if ignoredByJSONSchemaTags(tags) {
+		return false
+	}
+	for _, tag := range tags {
+		if tag == "nullable" {
+			return true
+		}
+	}
+	return false
+}
+
+func ignoredByJSONTags(tags []string) bool {
+	return tags[0] == "-"
+}
+
+func ignoredByJSONSchemaTags(tags []string) bool {
+	return tags[0] == "-"
+}
+
+func inlinedByJSONTags(tags []string) bool {
+	for _, tag := range tags[1:] {
+		if tag == "inline" {
+			return true
+		}
+	}
+	return false
+}
+
+// toJSONNumber converts string to *json.Number.
+// It'll aso return whether the number is valid.
+func toJSONNumber(s string) (json.Number, bool) {
+	num := json.Number(s)
+	if _, err := num.Int64(); err == nil {
+		return num, true
+	}
+	if _, err := num.Float64(); err == nil {
+		return num, true
+	}
+	return json.Number(""), false
+}
+
+func parseUint(num string) *uint64 {
+	val, err := strconv.ParseUint(num, 10, 64)
+	if err != nil {
+		return nil
+	}
+	return &val
+}
+
+func (r *Reflector) fieldNameTag() string {
+	if r.FieldNameTag != "" {
+		return r.FieldNameTag
+	}
+	return "json"
+}
+
+func (r *Reflector) reflectFieldName(f reflect.StructField) (string, bool, bool, bool) {
+	jsonTagString := f.Tag.Get(r.fieldNameTag())
+	jsonTags := strings.Split(jsonTagString, ",")
+
+	if ignoredByJSONTags(jsonTags) {
+		return "", false, false, false
+	}
+
+	schemaTags := strings.Split(f.Tag.Get("jsonschema"), ",")
+	if ignoredByJSONSchemaTags(schemaTags) {
+		return "", false, false, false
+	}
+
+	var required bool
+	if !r.RequiredFromJSONSchemaTags {
+		requiredFromJSONTags(jsonTags, &required)
+	}
+	requiredFromJSONSchemaTags(schemaTags, &required)
+
+	nullable := nullableFromJSONSchemaTags(schemaTags)
+
+	if f.Anonymous && jsonTags[0] == "" {
+		// As per JSON Marshal rules, anonymous structs are inherited
+		if f.Type.Kind() == reflect.Struct {
+			return "", true, false, false
+		}
+
+		// As per JSON Marshal rules, anonymous pointer to structs are inherited
+		if f.Type.Kind() == reflect.Ptr && f.Type.Elem().Kind() == reflect.Struct {
+			return "", true, false, false
+		}
+	}
+
+	// As per JSON Marshal rules, inline nested structs that have `inline` tag.
+	if inlinedByJSONTags(jsonTags) {
+		return "", true, false, false
+	}
+
+	// Try to determine the name from the different combos
+	name := f.Name
+	if jsonTags[0] != "" {
+		name = jsonTags[0]
+	}
+	if !f.Anonymous && f.PkgPath != "" {
+		// field not anonymous and not export has no export name
+		name = ""
+	} else if r.KeyNamer != nil {
+		name = r.KeyNamer(name)
+	}
+
+	return name, false, required, nullable
+}
+
+// UnmarshalJSON is used to parse a schema object or boolean.
+func (t *Schema) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte("true")) {
+		*t = *TrueSchema
+		return nil
+	} else if bytes.Equal(data, []byte("false")) {
+		*t = *FalseSchema
+		return nil
+	}
+	type SchemaAlt Schema
+	aux := &struct {
+		*SchemaAlt
+	}{
+		SchemaAlt: (*SchemaAlt)(t),
+	}
+	return json.Unmarshal(data, aux)
+}
+
+// MarshalJSON is used to serialize a schema object or boolean.
+func (t *Schema) MarshalJSON() ([]byte, error) {
+	if t.boolean != nil {
+		if *t.boolean {
+			return []byte("true"), nil
+		}
+		return []byte("false"), nil
+	}
+	if reflect.DeepEqual(&Schema{}, t) {
+		// Don't bother returning empty schemas
+		return []byte("true"), nil
+	}
+	type SchemaAlt Schema
+	b, err := json.Marshal((*SchemaAlt)(t))
+	if err != nil {
+		return nil, err
+	}
+	if len(t.Extras) == 0 {
+		return b, nil
+	}
+	m, err := json.Marshal(t.Extras)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 2 {
+		return m, nil
+	}
+	b[len(b)-1] = ','
+	return append(b, m[1:]...), nil
+}
+
+func (r *Reflector) typeName(t reflect.Type) string {
+	if r.Namer != nil {
+		if name := r.Namer(t); name != "" {
+			return name
+		}
+	}
+	return t.Name()
+}
+
+// Split on commas that are not preceded by `\`.
+// This way, we prevent splitting regexes
+func splitOnUnescapedCommas(tagString string) []string {
+	ret := make([]string, 0)
+	separated := strings.Split(tagString, ",")
+	ret = append(ret, separated[0])
+	i := 0
+	for _, nextTag := range separated[1:] {
+		if len(ret[i]) == 0 {
+			ret = append(ret, nextTag)
+			i++
+			continue
+		}
+
+		if ret[i][len(ret[i])-1] == '\\' {
+			ret[i] = ret[i][:len(ret[i])-1] + "," + nextTag
+		} else {
+			ret = append(ret, nextTag)
+			i++
+		}
+	}
+
+	return ret
+}
+
+func fullyQualifiedTypeName(t reflect.Type) string {
+	return t.PkgPath() + "." + t.Name()
+}

--- a/vendor/github.com/invopop/jsonschema/reflect_comments.go
+++ b/vendor/github.com/invopop/jsonschema/reflect_comments.go
@@ -1,0 +1,146 @@
+package jsonschema
+
+import (
+	"fmt"
+	"io/fs"
+	gopath "path"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+)
+
+type commentOptions struct {
+	fullObjectText bool // use the first sentence only?
+}
+
+// CommentOption allows for special configuration options when preparing Go
+// source files for comment extraction.
+type CommentOption func(*commentOptions)
+
+// WithFullComment will configure the comment extraction to process to use an
+// object type's full comment text instead of just the synopsis.
+func WithFullComment() CommentOption {
+	return func(o *commentOptions) {
+		o.fullObjectText = true
+	}
+}
+
+// AddGoComments will update the reflectors comment map with all the comments
+// found in the provided source directories including sub-directories, in order to
+// generate a dictionary of comments associated with Types and Fields. The results
+// will be added to the `Reflect.CommentMap` ready to use with Schema "description"
+// fields.
+//
+// The `go/parser` library is used to extract all the comments and unfortunately doesn't
+// have a built-in way to determine the fully qualified name of a package. The `base`
+// parameter, the URL used to import that package, is thus required to be able to match
+// reflected types.
+//
+// When parsing type comments, by default we use the `go/doc`'s Synopsis method to extract
+// the first phrase only. Field comments, which tend to be much shorter, will include everything.
+// This behavior can be changed by using the `WithFullComment` option.
+func (r *Reflector) AddGoComments(base, path string, opts ...CommentOption) error {
+	if r.CommentMap == nil {
+		r.CommentMap = make(map[string]string)
+	}
+	co := new(commentOptions)
+	for _, opt := range opts {
+		opt(co)
+	}
+
+	return r.extractGoComments(base, path, r.CommentMap, co)
+}
+
+func (r *Reflector) extractGoComments(base, path string, commentMap map[string]string, opts *commentOptions) error {
+	fset := token.NewFileSet()
+	dict := make(map[string][]*ast.Package)
+	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			d, err := parser.ParseDir(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				return err
+			}
+			for _, v := range d {
+				// paths may have multiple packages, like for tests
+				k := gopath.Join(base, path)
+				dict[k] = append(dict[k], v)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for pkg, p := range dict {
+		for _, f := range p {
+			gtxt := ""
+			typ := ""
+			ast.Inspect(f, func(n ast.Node) bool {
+				switch x := n.(type) {
+				case *ast.TypeSpec:
+					typ = x.Name.String()
+					if !ast.IsExported(typ) {
+						typ = ""
+					} else {
+						txt := x.Doc.Text()
+						if txt == "" && gtxt != "" {
+							txt = gtxt
+							gtxt = ""
+						}
+						if !opts.fullObjectText {
+							txt = doc.Synopsis(txt)
+						}
+						commentMap[fmt.Sprintf("%s.%s", pkg, typ)] = strings.TrimSpace(txt)
+					}
+				case *ast.Field:
+					txt := x.Doc.Text()
+					if txt == "" {
+						txt = x.Comment.Text()
+					}
+					if typ != "" && txt != "" {
+						for _, n := range x.Names {
+							if ast.IsExported(n.String()) {
+								k := fmt.Sprintf("%s.%s.%s", pkg, typ, n)
+								commentMap[k] = strings.TrimSpace(txt)
+							}
+						}
+					}
+				case *ast.GenDecl:
+					// remember for the next type
+					gtxt = x.Doc.Text()
+				}
+				return true
+			})
+		}
+	}
+
+	return nil
+}
+
+func (r *Reflector) lookupComment(t reflect.Type, name string) string {
+	if r.LookupComment != nil {
+		if comment := r.LookupComment(t, name); comment != "" {
+			return comment
+		}
+	}
+
+	if r.CommentMap == nil {
+		return ""
+	}
+
+	n := fullyQualifiedTypeName(t)
+	if name != "" {
+		n = n + "." + name
+	}
+
+	return r.CommentMap[n]
+}

--- a/vendor/github.com/invopop/jsonschema/schema.go
+++ b/vendor/github.com/invopop/jsonschema/schema.go
@@ -1,0 +1,94 @@
+package jsonschema
+
+import (
+	"encoding/json"
+
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+// Version is the JSON Schema version.
+var Version = "https://json-schema.org/draft/2020-12/schema"
+
+// Schema represents a JSON Schema object type.
+// RFC draft-bhutton-json-schema-00 section 4.3
+type Schema struct {
+	// RFC draft-bhutton-json-schema-00
+	Version     string      `json:"$schema,omitempty"`     // section 8.1.1
+	ID          ID          `json:"$id,omitempty"`         // section 8.2.1
+	Anchor      string      `json:"$anchor,omitempty"`     // section 8.2.2
+	Ref         string      `json:"$ref,omitempty"`        // section 8.2.3.1
+	DynamicRef  string      `json:"$dynamicRef,omitempty"` // section 8.2.3.2
+	Definitions Definitions `json:"$defs,omitempty"`       // section 8.2.4
+	Comments    string      `json:"$comment,omitempty"`    // section 8.3
+	// RFC draft-bhutton-json-schema-00 section 10.2.1 (Sub-schemas with logic)
+	AllOf []*Schema `json:"allOf,omitempty"` // section 10.2.1.1
+	AnyOf []*Schema `json:"anyOf,omitempty"` // section 10.2.1.2
+	OneOf []*Schema `json:"oneOf,omitempty"` // section 10.2.1.3
+	Not   *Schema   `json:"not,omitempty"`   // section 10.2.1.4
+	// RFC draft-bhutton-json-schema-00 section 10.2.2 (Apply sub-schemas conditionally)
+	If               *Schema            `json:"if,omitempty"`               // section 10.2.2.1
+	Then             *Schema            `json:"then,omitempty"`             // section 10.2.2.2
+	Else             *Schema            `json:"else,omitempty"`             // section 10.2.2.3
+	DependentSchemas map[string]*Schema `json:"dependentSchemas,omitempty"` // section 10.2.2.4
+	// RFC draft-bhutton-json-schema-00 section 10.3.1 (arrays)
+	PrefixItems []*Schema `json:"prefixItems,omitempty"` // section 10.3.1.1
+	Items       *Schema   `json:"items,omitempty"`       // section 10.3.1.2  (replaces additionalItems)
+	Contains    *Schema   `json:"contains,omitempty"`    // section 10.3.1.3
+	// RFC draft-bhutton-json-schema-00 section 10.3.2 (sub-schemas)
+	Properties           *orderedmap.OrderedMap[string, *Schema] `json:"properties,omitempty"`           // section 10.3.2.1
+	PatternProperties    map[string]*Schema                      `json:"patternProperties,omitempty"`    // section 10.3.2.2
+	AdditionalProperties *Schema                                 `json:"additionalProperties,omitempty"` // section 10.3.2.3
+	PropertyNames        *Schema                                 `json:"propertyNames,omitempty"`        // section 10.3.2.4
+	// RFC draft-bhutton-json-schema-validation-00, section 6
+	Type              string              `json:"type,omitempty"`              // section 6.1.1
+	Enum              []any               `json:"enum,omitempty"`              // section 6.1.2
+	Const             any                 `json:"const,omitempty"`             // section 6.1.3
+	MultipleOf        json.Number         `json:"multipleOf,omitempty"`        // section 6.2.1
+	Maximum           json.Number         `json:"maximum,omitempty"`           // section 6.2.2
+	ExclusiveMaximum  json.Number         `json:"exclusiveMaximum,omitempty"`  // section 6.2.3
+	Minimum           json.Number         `json:"minimum,omitempty"`           // section 6.2.4
+	ExclusiveMinimum  json.Number         `json:"exclusiveMinimum,omitempty"`  // section 6.2.5
+	MaxLength         *uint64             `json:"maxLength,omitempty"`         // section 6.3.1
+	MinLength         *uint64             `json:"minLength,omitempty"`         // section 6.3.2
+	Pattern           string              `json:"pattern,omitempty"`           // section 6.3.3
+	MaxItems          *uint64             `json:"maxItems,omitempty"`          // section 6.4.1
+	MinItems          *uint64             `json:"minItems,omitempty"`          // section 6.4.2
+	UniqueItems       bool                `json:"uniqueItems,omitempty"`       // section 6.4.3
+	MaxContains       *uint64             `json:"maxContains,omitempty"`       // section 6.4.4
+	MinContains       *uint64             `json:"minContains,omitempty"`       // section 6.4.5
+	MaxProperties     *uint64             `json:"maxProperties,omitempty"`     // section 6.5.1
+	MinProperties     *uint64             `json:"minProperties,omitempty"`     // section 6.5.2
+	Required          []string            `json:"required,omitempty"`          // section 6.5.3
+	DependentRequired map[string][]string `json:"dependentRequired,omitempty"` // section 6.5.4
+	// RFC draft-bhutton-json-schema-validation-00, section 7
+	Format string `json:"format,omitempty"`
+	// RFC draft-bhutton-json-schema-validation-00, section 8
+	ContentEncoding  string  `json:"contentEncoding,omitempty"`  // section 8.3
+	ContentMediaType string  `json:"contentMediaType,omitempty"` // section 8.4
+	ContentSchema    *Schema `json:"contentSchema,omitempty"`    // section 8.5
+	// RFC draft-bhutton-json-schema-validation-00, section 9
+	Title       string `json:"title,omitempty"`       // section 9.1
+	Description string `json:"description,omitempty"` // section 9.1
+	Default     any    `json:"default,omitempty"`     // section 9.2
+	Deprecated  bool   `json:"deprecated,omitempty"`  // section 9.3
+	ReadOnly    bool   `json:"readOnly,omitempty"`    // section 9.4
+	WriteOnly   bool   `json:"writeOnly,omitempty"`   // section 9.4
+	Examples    []any  `json:"examples,omitempty"`    // section 9.5
+
+	Extras map[string]any `json:"-"`
+
+	// Special boolean representation of the Schema - section 4.3.2
+	boolean *bool
+}
+
+var (
+	// TrueSchema defines a schema with a true value
+	TrueSchema = &Schema{boolean: &[]bool{true}[0]}
+	// FalseSchema defines a schema with a false value
+	FalseSchema = &Schema{boolean: &[]bool{false}[0]}
+)
+
+// Definitions hold schema definitions.
+// http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.26
+// RFC draft-wright-json-schema-validation-00, section 5.26
+type Definitions map[string]*Schema

--- a/vendor/github.com/invopop/jsonschema/utils.go
+++ b/vendor/github.com/invopop/jsonschema/utils.go
@@ -1,0 +1,26 @@
+package jsonschema
+
+import (
+	"regexp"
+	"strings"
+
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+)
+
+var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+
+// ToSnakeCase converts the provided string into snake case using dashes.
+// This is useful for Schema IDs and definitions to be coherent with
+// common JSON Schema examples.
+func ToSnakeCase(str string) string {
+	snake := matchFirstCap.ReplaceAllString(str, "${1}-${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}-${2}")
+	return strings.ToLower(snake)
+}
+
+// NewProperties is a helper method to instantiate a new properties ordered
+// map.
+func NewProperties() *orderedmap.OrderedMap[string, *Schema] {
+	return orderedmap.New[string, *Schema]()
+}

--- a/vendor/github.com/wk8/go-ordered-map/v2/CHANGELOG.md
+++ b/vendor/github.com/wk8/go-ordered-map/v2/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [comment]: # (Changes since last release go here)
 
+## 2.1.8 - Jun 27th 2023
+
+* Added support for YAML serialization/deserialization
+
 ## 2.1.7 - Apr 13th 2023
 
 * Renamed test_utils.go to utils_test.go

--- a/vendor/github.com/wk8/go-ordered-map/v2/Makefile
+++ b/vendor/github.com/wk8/go-ordered-map/v2/Makefile
@@ -16,9 +16,13 @@ bench:
 
 FUZZ_TIME ?= 10s
 
+# see https://github.com/golang/go/issues/46312
+# and https://stackoverflow.com/a/72673487/4867444
+# if we end up having more fuzz tests
 .PHONY: test_with_fuzz
 test_with_fuzz:
-	$(TEST_COMMAND) -fuzz=. -fuzztime=$(FUZZ_TIME)
+	$(TEST_COMMAND) -fuzz=FuzzRoundTripJSON -fuzztime=$(FUZZ_TIME)
+	$(TEST_COMMAND) -fuzz=FuzzRoundTripYAML -fuzztime=$(FUZZ_TIME)
 
 .PHONY: fuzz
 fuzz: test_with_fuzz

--- a/vendor/github.com/wk8/go-ordered-map/v2/README.md
+++ b/vendor/github.com/wk8/go-ordered-map/v2/README.md
@@ -11,6 +11,7 @@ It offers the following features:
 * allows iterating from newest or oldest keys indifferently, without memory copy, allowing to `break` the iteration, and in time linear to the number of keys iterated over rather than the total length of the ordered map
 * supports any generic types for both keys and values. If you're running go < 1.18, you can use [version 1](https://github.com/wk8/go-ordered-map/tree/v1) that takes and returns generic `interface{}`s instead of using generics
 * idiomatic API, akin to that of [`container/list`](https://golang.org/pkg/container/list)
+* support for JSON and YAML marshalling
 
 ## Documentation
 
@@ -128,6 +129,19 @@ data, err := json.Marshal(om)
 // deserialization
 om := orderedmap.New[string, string]() // or orderedmap.New[int, any](), or any type you expect
 err := json.Unmarshal(data, &om)
+...
+```
+
+Similarly, it also supports YAML serialization/deserialization using the yaml.v3 package, which also preserves order:
+
+```go
+// serialization
+data, err := yaml.Marshal(om)
+...
+
+// deserialization
+om := orderedmap.New[string, string]() // or orderedmap.New[int, any](), or any type you expect
+err := yaml.Unmarshal(data, &om)
 ...
 ```
 

--- a/vendor/github.com/wk8/go-ordered-map/v2/yaml.go
+++ b/vendor/github.com/wk8/go-ordered-map/v2/yaml.go
@@ -1,0 +1,71 @@
+package orderedmap
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	_ yaml.Marshaler   = &OrderedMap[int, any]{}
+	_ yaml.Unmarshaler = &OrderedMap[int, any]{}
+)
+
+// MarshalYAML implements the yaml.Marshaler interface.
+func (om *OrderedMap[K, V]) MarshalYAML() (interface{}, error) {
+	if om == nil {
+		return []byte("null"), nil
+	}
+
+	node := yaml.Node{
+		Kind: yaml.MappingNode,
+	}
+
+	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+		key, value := pair.Key, pair.Value
+
+		keyNode := &yaml.Node{}
+
+		// serialize key to yaml, then deserialize it back into the node
+		// this is a hack to get the correct tag for the key
+		if err := keyNode.Encode(key); err != nil {
+			return nil, err
+		}
+
+		valueNode := &yaml.Node{}
+		if err := valueNode.Encode(value); err != nil {
+			return nil, err
+		}
+
+		node.Content = append(node.Content, keyNode, valueNode)
+	}
+
+	return &node, nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (om *OrderedMap[K, V]) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("pipeline must contain YAML mapping, has %v", value.Kind)
+	}
+
+	if om.list == nil {
+		om.initialize(0)
+	}
+
+	for index := 0; index < len(value.Content); index += 2 {
+		var key K
+		var val V
+
+		if err := value.Content[index].Decode(&key); err != nil {
+			return err
+		}
+		if err := value.Content[index+1].Decode(&val); err != nil {
+			return err
+		}
+
+		om.Set(key, val)
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -428,6 +428,9 @@ github.com/huin/goupnp/ssdp
 # github.com/imdario/mergo v0.3.12
 ## explicit; go 1.13
 github.com/imdario/mergo
+# github.com/invopop/jsonschema v0.13.0
+## explicit; go 1.18
+github.com/invopop/jsonschema
 # github.com/ipfs/go-cid v0.4.1
 ## explicit; go 1.19
 github.com/ipfs/go-cid
@@ -1141,7 +1144,7 @@ github.com/wealdtech/go-multicodec
 # github.com/wk8/go-ordered-map v1.0.0
 ## explicit; go 1.14
 github.com/wk8/go-ordered-map
-# github.com/wk8/go-ordered-map/v2 v2.1.7
+# github.com/wk8/go-ordered-map/v2 v2.1.8
 ## explicit; go 1.18
 github.com/wk8/go-ordered-map/v2
 # github.com/wlynxg/anet v0.0.4


### PR DESCRIPTION
This PR shows how we could generate JSON schemas for Go types to be used in functional tests.

But while working on it, I though it doesn't make any sense to verify schemas in our case. 
We have no API specification as a contract between server and client. Instead, the server is the specification. And the schemas generated from the implementation will _always_ match the implementation.