### PR TITLE
fix(ci)_: clean workspace for benchmark CI

### DIFF
--- a/_assets/ci/Jenkinsfile.tests-benchmark
+++ b/_assets/ci/Jenkinsfile.tests-benchmark
@@ -63,8 +63,8 @@ pipeline {
       script {
         sh '''
           docker ps -a --filter "name=status-go-func-tests-${BUILD_ID}" -q | xargs -r docker rm -f
-          make git-clean
         '''
+        cleanWs(disableDeferredWipeout: true, deleteDirs: true)
       }
     }
   } // post

--- a/_assets/scripts/run_benchmark.sh
+++ b/_assets/scripts/run_benchmark.sh
@@ -16,6 +16,8 @@ rm -rf "${benchmark_results_path}"
 
 mkdir -p "${test_results_path}"
 mkdir -p "${benchmark_results_path}"
+# Create coverage directory as jenkins user
+mkdir -p "${GIT_ROOT}/coverage/binary"
 
 all_compose_files="-f ${root_path}/docker-compose.anvil.yml -f ${root_path}/docker-compose.waku.yml"
 identifier=${BUILD_ID:-$(git rev-parse --short HEAD)}


### PR DESCRIPTION
The coverage directory was being created by Docker containers with `dockremap:dockremap` ownership due to Docker's user namespace remapping, which prevented Jenkins `cleanWs()` from deleting it.

## Root Cause

Unlike functional tests, the benchmark script didn't pre-create the coverage directory.

## Solution

Pre-create the coverage directory as jenkins user before pytest runs, even though coverage collection is not used for benchmarks:

```bash
mkdir -p "${GIT_ROOT}/coverage/binary"