### PR TITLE
fix(keypair): fix crash when when updating display name twice

### DIFF
--- a/multiaccounts/accounts/keycard_database.go
+++ b/multiaccounts/accounts/keycard_database.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/status-im/status-go/crypto/types"
@@ -53,15 +54,6 @@ func (kp *Keycard) FromSyncKeycard(kc *protobuf.SyncKeycard) {
 	}
 }
 
-func containsAddress(addresses []types.Address, address types.Address) bool {
-	for _, addr := range addresses {
-		if addr == address {
-			return true
-		}
-	}
-	return false
-}
-
 func (db *Database) processResult(rows *sql.Rows) ([]*Keycard, error) {
 	keycards := []*Keycard{}
 	for rows.Next() {
@@ -89,7 +81,7 @@ func (db *Database) processResult(rows *sql.Rows) ([]*Keycard, error) {
 			keycard.AccountsAddresses = append(keycard.AccountsAddresses, addr)
 			keycards = append(keycards, keycard)
 		} else {
-			if containsAddress(keycards[foundAtIndex].AccountsAddresses, addr) {
+			if slices.Contains(keycards[foundAtIndex].AccountsAddresses, addr) {
 				continue
 			}
 			keycards[foundAtIndex].AccountsAddresses = append(keycards[foundAtIndex].AccountsAddresses, addr)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -3308,13 +3308,13 @@ func mapSyncAccountToAccount(message *protobuf.SyncAccount, accountOperability a
 	}
 }
 
-func (m *Messenger) resolveAccountOperability(syncAcc *protobuf.SyncAccount, recoverinrecoveringFromWakuInitiatedByKeycard bool,
+func (m *Messenger) resolveAccountOperability(syncAcc *protobuf.SyncAccount, recoveringFromWakuInitiatedByKeycard bool,
 	syncKpMigratedToKeycard bool, dbKpMigratedToKeycard bool, accountReceivedFromLocalPairing bool) (accounts.AccountOperable, error) {
 	if accountReceivedFromLocalPairing {
 		return accounts.AccountOperable(syncAcc.Operable), nil
 	}
 
-	if syncKpMigratedToKeycard || recoverinrecoveringFromWakuInitiatedByKeycard && m.account.KeyUID == syncAcc.KeyUid {
+	if syncKpMigratedToKeycard || recoveringFromWakuInitiatedByKeycard && m.account.KeyUID == syncAcc.KeyUid {
 		return accounts.AccountFullyOperable, nil
 	}
 
@@ -3593,6 +3593,8 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 		Removed:                 message.Removed,
 	}
 
+	oldAddresses := make(map[types.Address]bool)
+
 	if dbKeypair != nil {
 		if dbKeypair.Clock >= kp.Clock {
 			return nil, ErrTryingToStoreOldKeypair
@@ -3604,6 +3606,9 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 		if dbKeypair.SyncedFrom != accounts.SyncedFromBackup {
 			kp.SyncedFrom = dbKeypair.SyncedFrom
 		}
+		for _, acc := range dbKeypair.Accounts {
+			oldAddresses[acc.Address] = !acc.Removed
+		}
 	}
 
 	syncKpMigratedToKeycard := len(message.Keycards) > 0
@@ -3613,10 +3618,10 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 	if err != nil {
 		return nil, err
 	}
-	recoverinrecoveringFromWakuInitiatedByKeycard := recoveringFromWaku && multiAcc != nil && multiAcc.RefersToKeycard()
+	recoveringFromWakuInitiatedByKeycard := recoveringFromWaku && multiAcc != nil && multiAcc.RefersToKeycard()
 	for _, sAcc := range message.Accounts {
 		accountOperability, err := m.resolveAccountOperability(sAcc,
-			recoverinrecoveringFromWakuInitiatedByKeycard,
+			recoveringFromWakuInitiatedByKeycard,
 			syncKpMigratedToKeycard,
 			dbKeypair != nil && dbKeypair.MigratedToKeycard(),
 			fromLocalPairing)
@@ -3628,7 +3633,7 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 		kp.Accounts = append(kp.Accounts, acc)
 	}
 
-	if !fromLocalPairing && !recoverinrecoveringFromWakuInitiatedByKeycard {
+	if !fromLocalPairing && !recoveringFromWakuInitiatedByKeycard {
 		if kp.Removed ||
 			dbKeypair != nil && !dbKeypair.MigratedToKeycard() && syncKpMigratedToKeycard {
 			// delete all keystore files
@@ -3731,24 +3736,27 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 				if acc.Chat {
 					continue
 				}
-				if acc.Removed {
+				// We call the signals only if there is a change in the account list
+				// i.e. an account is unknown (not part of the Accounts list before)
+				// or an account was removed and is now back (Removed flag changed)
+				stillPresent, ok := oldAddresses[acc.Address]
+				if acc.Removed && (!ok || stillPresent) {
 					removedAddresses = append(removedAddresses, gethcommon.Address(acc.Address))
-				} else {
+				} else if !ok || !stillPresent {
 					addedAddresses = append(addedAddresses, gethcommon.Address(acc.Address))
 				}
 			}
 		}
-		if m.config.accountsPublisher != nil {
-			if len(addedAddresses) > 0 {
-				pubsub.Publish(m.config.accountsPublisher, accountsevent.AccountsAddedEvent{
-					Accounts: addedAddresses,
-				})
-			}
-			if len(removedAddresses) > 0 {
-				pubsub.Publish(m.config.accountsPublisher, accountsevent.AccountsRemovedEvent{
-					Accounts: removedAddresses,
-				})
-			}
+
+		if len(addedAddresses) > 0 {
+			pubsub.Publish(m.config.accountsPublisher, accountsevent.AccountsAddedEvent{
+				Accounts: addedAddresses,
+			})
+		}
+		if len(removedAddresses) > 0 {
+			pubsub.Publish(m.config.accountsPublisher, accountsevent.AccountsRemovedEvent{
+				Accounts: removedAddresses,
+			})
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/18503

I'm not sure if I fixed the root cause, but what was happening is that each time the display name was update, the keypairs were also sent with it and it caused a signal to be sent that "keypairs were added", which is not true. That signal triggered a refetch of collectibles, which in turn caused the crash. This is where I'm a bit lost. I don't know why it would crash exactly. I assume it's because it was calling the fetches in too rapid a succession so the previous one was not over, hence deleting the previous one in the middle of it and crashing.

[display-name-change.webm](https://github.com/user-attachments/assets/012c1f16-4be1-4471-b022-4168ad72e954)
