### PR TITLE
refactor(service)_: use slices.Sort where appropriate

### DIFF
--- a/services/typeddata/hash.go
+++ b/services/typeddata/hash.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"sort"
+	"slices"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -55,9 +55,7 @@ func deps(target string, types Types) []string {
 		visited = visited[1:]
 		deps = append(deps, current)
 	}
-	sort.Slice(deps[1:], func(i, j int) bool {
-		return deps[1:][i] < deps[1:][j]
-	})
+	slices.Sort(deps[1:])
 	return deps
 }
 

--- a/services/wallet/testutils/helpers.go
+++ b/services/wallet/testutils/helpers.go
@@ -100,8 +100,8 @@ func (m *Uint64SliceMatcher) Matches(x interface{}) bool {
 	copy(expectedCopy, m.expected)
 	copy(actualCopy, actual)
 
-	sort.Slice(expectedCopy, func(i, j int) bool { return expectedCopy[i] < expectedCopy[j] })
-	sort.Slice(actualCopy, func(i, j int) bool { return actualCopy[i] < actualCopy[j] })
+	slices.Sort(expectedCopy)
+	slices.Sort(actualCopy)
 
 	return slices.Equal(expectedCopy, actualCopy)
 }


### PR DESCRIPTION
Replace older sort functions with slices.Sort to simplify code

Important changes:
- [x] Something worth noting for reviewers.

Closes #
