### PR TITLE
fix(services)_: fix imported and not used error

### DIFF
--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"database/sql"
-	"errors"
 	"fmt"
 	"math/big"
 	"os"

--- a/wakuv2/gowaku.go
+++ b/wakuv2/gowaku.go
@@ -1172,7 +1172,7 @@ func (w *Waku) Start() error {
 		w.missingMsgVerifier = missing.NewMissingMessageVerifier(
 			missing.NewDefaultStorenodeRequestor(w.node.Store()),
 			w,
-			w.node.Timesource(),
+			w.timesource.(timesource.TimeSource),
 			w.logger)
 
 		w.missingMsgVerifier.Start(w.ctx)
@@ -1331,7 +1331,7 @@ func (w *Waku) startMessageSender() error {
 	if w.cfg.EnableStoreConfirmationForMessagesSent {
 		msgStoredChan := make(chan gethcommon.Hash, 1000)
 		msgExpiredChan := make(chan gethcommon.Hash, 1000)
-		messageSentCheck := publish.NewMessageSentCheck(w.ctx, publish.NewDefaultStorenodeMessageVerifier(w.node.Store()), w.StorenodeCycle, w.node.Timesource(), msgStoredChan, msgExpiredChan, w.logger)
+		messageSentCheck := publish.NewMessageSentCheck(w.ctx, publish.NewDefaultStorenodeMessageVerifier(w.node.Store()), w.StorenodeCycle, w.timesource.(timesource.TimeSource), msgStoredChan, msgExpiredChan, w.logger)
 		sender.WithMessageSentCheck(messageSentCheck)
 
 		w.wg.Add(1)

--- a/wakuv2/nwaku.go
+++ b/wakuv2/nwaku.go
@@ -57,8 +57,9 @@ import (
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/connection"
 	cryptotypes "github.com/status-im/status-go/crypto/types"
+	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/logutils"
-	"github.com/status-im/status-go/timesource"
+	ntptimesource "github.com/status-im/status-go/timesource"
 	"github.com/status-im/status-go/waku/types"
 	"github.com/status-im/status-go/wakuv2/common"
 	"github.com/status-im/status-go/wakuv2/persistence"
@@ -162,7 +163,7 @@ type Waku struct {
 	logger *zap.Logger
 
 	// NTP Synced timesource
-	timesource *timesource.NTPTimeSource
+	timesource timesource.TimeSource
 
 	// seededBootnodesForDiscV5 indicates whether we manage to retrieve discovery
 	// bootnodes successfully
@@ -198,7 +199,7 @@ func newTTLCache() *ttlcache.Cache[gethcommon.Hash, bool] {
 }
 
 // New creates a WakuV2 client ready to communicate through the LibP2P network.
-func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, appDB *sql.DB, ts *timesource.NTPTimeSource, onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
+func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, appDB *sql.DB, ts timesource.TimeSource, onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
 	var err error
 	if logger == nil {
 		logger, err = zap.NewDevelopment()
@@ -208,7 +209,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, appDB *sql.
 	}
 
 	if ts == nil {
-		ts = timesource.Default()
+		ts = ntptimesource.Default()
 	}
 
 	cfg = setDefaults(cfg)
@@ -840,7 +841,7 @@ func (w *Waku) Start() error {
 		w.missingMsgVerifier = missing.NewMissingMessageVerifier(
 			newStorenodeRequestor(w.node, w.logger),
 			w,
-			w.timesource,
+			w.node.Timesource(),
 			w.logger)
 
 		w.missingMsgVerifier.Start(w.ctx)
@@ -961,7 +962,7 @@ func (w *Waku) startMessageSender() error {
 	if w.cfg.EnableStoreConfirmationForMessagesSent {
 		msgStoredChan := make(chan gethcommon.Hash, 1000)
 		msgExpiredChan := make(chan gethcommon.Hash, 1000)
-		messageSentCheck := publish.NewMessageSentCheck(w.ctx, newStorenodeMessageVerifier(w.node), w.StorenodeCycle, w.timesource, msgStoredChan, msgExpiredChan, w.logger)
+		messageSentCheck := publish.NewMessageSentCheck(w.ctx, newStorenodeMessageVerifier(w.node), w.StorenodeCycle, w.node.Timesource(), msgStoredChan, msgExpiredChan, w.logger)
 		sender.WithMessageSentCheck(messageSentCheck)
 
 		w.wg.Add(1)


### PR DESCRIPTION
Fixes:
```
services/ext/service.go:7:2: "errors" imported and not used
```
And fixes errors like this:
```
messaging/core.go:421:3: cannot use params.timeSource
(variable of type "github.com/status-im/status-go/internal/timesource".TimeSource)
as *"github.com/status-im/status-go/timesource".NTPTimeSource value in argument to wakuv2.New: need type assertion
```
Issues introduced in:
- https://github.com/status-im/status-go/pull/6829