### PR TITLE
refactor(accounts-management)!: make password mandatory when deleting account/keypair

### DIFF
--- a/accounts-management/core/errors.go
+++ b/accounts-management/core/errors.go
@@ -39,6 +39,7 @@ const (
 	ErrCodeKeycardDoesNotHaveAnyAccounts
 	ErrCodeKeycardDoesNotRelateToAnyKeypair
 	ErrCodeCannotRemoveProfileKeypair
+	ErrCodeNoPasswordProvided
 )
 
 var (
@@ -67,6 +68,7 @@ var (
 	ErrKeypairIsNotKeycard                             = errors.NewError(ErrCodeKeypairIsNotKeycard, "keypair is not a keycard keypair", getErrorCategory)
 	ErrKeycardDoesNotHaveAnyAccounts                   = errors.NewError(ErrCodeKeycardDoesNotHaveAnyAccounts, "keycard does not have any accounts", getErrorCategory)
 	ErrCannotRemoveProfileKeypair                      = errors.NewError(ErrCodeCannotRemoveProfileKeypair, "cannot remove profile keypair", getErrorCategory)
+	ErrNoPasswordProvided                              = errors.NewError(ErrCodeNoPasswordProvided, "no password provided", getErrorCategory)
 )
 
 func ErrKeystoreDirectoryError(err error) *errors.AccountsError {
@@ -93,7 +95,7 @@ func getErrorCategory(code errors.ErrorCode) errors.ErrorCategory {
 		ErrCodeKeypairAlreadyAdded, ErrCodeAccountAlreadyAdded, ErrCodeChatAccountNotFoundInDerivedAccounts,
 		ErrCodeKeypairMustHaveAtLeastOneWalletAccount, ErrCodeCannotAddAccountsToKeypairImportedViaPrivateKey,
 		ErrCodeCannotMigrateProfileKeypair, ErrCodeKeypairIsNotKeycard, ErrCodeWrongPasswordProvided, ErrCodeKeycardDoesNotHaveAnyAccounts,
-		ErrCodeKeycardDoesNotRelateToAnyKeypair:
+		ErrCodeKeycardDoesNotRelateToAnyKeypair, ErrCodeNoPasswordProvided:
 		return ErrorCategoryValidation
 	case ErrCodeCannotAddDefaultWalletAccount, ErrCodeCannotAddDefaultChatAccount, ErrCodeCannotRemoveDefaultWalletAccount,
 		ErrCodeCannotRemoveDefaultChatAccount, ErrCodeCannotRemoveProfileKeypair:

--- a/accounts-management/core/keystore_operations.go
+++ b/accounts-management/core/keystore_operations.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,8 +118,8 @@ func (m *AccountsManager) storeToKeystore(acc *generator.Account, password strin
 
 func (m *AccountsManager) createKeystore(keyUID string) (keystore.KeyStore, error) {
 	// prepare keystore path
-	const DefaultKeystoreRelativePath = "keystore"
-	relativePath := filepath.Join(DefaultKeystoreRelativePath, keyUID)
+	const defaultKeystoreRelativePath = "keystore"
+	relativePath := filepath.Join(defaultKeystoreRelativePath, keyUID)
 	absoluteKeystorePath := filepath.Join(m.rootDataDir, relativePath)
 
 	if _, err := os.Stat(absoluteKeystorePath); os.IsNotExist(err) {
@@ -130,30 +131,27 @@ func (m *AccountsManager) createKeystore(keyUID string) (keystore.KeyStore, erro
 	return geth.NewGethKeystoreAdapter(absoluteKeystorePath)
 }
 
-// deleteAccountFromKeystore deletes an account from the keystore
-func (m *AccountsManager) deleteAccountFromKeystore(address cryptotypes.Address) error {
+// deleteAccountFromKeystoreIfExists deletes an account from the keystore if it exists, if not returns no error
+func (m *AccountsManager) deleteAccountFromKeystoreIfExists(address cryptotypes.Address, password string) error {
 	if m.keystore == nil {
 		m.logger.Error("cannot delete account, keystore is missing", zap.String("address", address.Hex()))
 		return ErrKeystoreMissing
 	}
 	m.logger.Info("deleting account", zap.String("address", address.Hex()))
-	return m.keystore.Delete(address)
+	err := m.keystore.Delete(address, password)
+	if errors.Is(err, keystore.ErrNoMatch) {
+		return nil
+	}
+	return err
 }
 
-// DeleteKeystoreFileForAccount deletes the keystore file for an account
+// deleteKeystoreFileForAccountIfExists deletes the keystore file for an account if it exists
+// if the account is a watch only account, it does nothing
 // if the account is non-operable or partially operable, it does nothing
-// if the account is a watch account, it does nothing
-// if the account is a key account, it deletes the keystore file for the account
-// if the account is a key account and it is the last account of the keypair, it deletes the master account keystore file
-// trying to delete a non-existent keystore file for an account does not result in an error
-func (m *AccountsManager) DeleteKeystoreFileForAccount(address cryptotypes.Address) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	return m.deleteKeystoreFileForAccountInternally(address)
-}
-
-func (m *AccountsManager) deleteKeystoreFileForAccountInternally(address cryptotypes.Address) error {
+// if the account belongs to regular, not keycard migrated keypair:
+// - it deletes the keystore file for the account if the keystore file exists
+// - if it is the last account of the keypair, it deletes the master account keystore file
+func (m *AccountsManager) deleteKeystoreFileForAccountInternally(address cryptotypes.Address, password string) error {
 	if m.persistence == nil {
 		return ErrPersistenceMissing
 	}
@@ -168,13 +166,17 @@ func (m *AccountsManager) deleteKeystoreFileForAccountInternally(address cryptot
 	}
 
 	if acc.Type != types.AccountTypeWatch {
+		if password == "" {
+			return ErrNoPasswordProvided
+		}
+
 		kp, err := m.persistence.GetKeypairByKeyUID(acc.KeyUID)
 		if err != nil {
 			return err
 		}
 
 		if !kp.MigratedToKeycard() {
-			err = m.deleteAccountFromKeystore(address)
+			err = m.deleteAccountFromKeystoreIfExists(address, password)
 			if err != nil {
 				return err
 			}
@@ -182,7 +184,7 @@ func (m *AccountsManager) deleteKeystoreFileForAccountInternally(address cryptot
 			if acc.Type != types.AccountTypeKey {
 				lastAcccountOfKeypairWithTheSameKey := len(kp.Accounts) == 1
 				if lastAcccountOfKeypairWithTheSameKey {
-					err = m.deleteAccountFromKeystore(cryptotypes.HexToAddress(kp.DerivedFrom))
+					err = m.deleteAccountFromKeystoreIfExists(cryptotypes.HexToAddress(kp.DerivedFrom), password)
 					if err != nil {
 						return err
 					}
@@ -194,17 +196,14 @@ func (m *AccountsManager) deleteKeystoreFileForAccountInternally(address cryptot
 	return nil
 }
 
-// DeleteKeystoreFilesForKeypair deletes the keystore files for a keypair
+// deleteKeystoreFilesForKeypairInternally deletes the keystore files for a keypair
 // if the keypair is already migrated to keycard, it does nothing
 // trying to delete a non-existent keystore file does not result in an error
-func (m *AccountsManager) DeleteKeystoreFilesForKeypair(keypair *types.Keypair) (err error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+func (m *AccountsManager) deleteKeystoreFilesForKeypairInternally(keypair *types.Keypair, password string) (err error) {
+	if password == "" {
+		return ErrNoPasswordProvided
+	}
 
-	return m.deleteKeystoreFilesForKeypairInternally(keypair)
-}
-
-func (m *AccountsManager) deleteKeystoreFilesForKeypairInternally(keypair *types.Keypair) (err error) {
 	if keypair == nil {
 		return ErrKeypairIsNil
 	}
@@ -228,20 +227,72 @@ func (m *AccountsManager) deleteKeystoreFilesForKeypairInternally(keypair *types
 		if acc.Operable == types.AccountPartiallyOperable {
 			continue
 		}
-		err = m.deleteAccountFromKeystore(acc.Address)
+		err = m.deleteAccountFromKeystoreIfExists(acc.Address, password)
 		if err != nil {
 			return err
 		}
 	}
 
 	if anyAccountFullyOrPartiallyOperable && keypair.Type != types.KeypairTypeKey {
-		err = m.deleteAccountFromKeystore(cryptotypes.HexToAddress(keypair.DerivedFrom))
+		err = m.deleteAccountFromKeystoreIfExists(cryptotypes.HexToAddress(keypair.DerivedFrom), password)
 		if err != nil {
 			return err
 		}
 	}
 
 	return
+}
+
+// CleanKeystoreFiles cleans the keystore files for all keypairs
+// if the keypair is already migrated to keycard or removed, it cleans all accounts of the keypair, including the master account
+// if the keypair is not migrated to keycard and not removed, it cleans the keystore files for removed accounts of the keypair,
+// the master account is not cleaned if the keypair is not removed/migrated to keycard
+func (m *AccountsManager) CleanKeystoreFiles(password string) error {
+	if password == "" {
+		return ErrNoPasswordProvided
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.persistence == nil {
+		return ErrPersistenceMissing
+	}
+
+	keypairs, err := m.persistence.GetAllKeypairs()
+	if err != nil {
+		return err
+	}
+
+	for _, kp := range keypairs {
+		if kp.MigratedToKeycard() || kp.Removed {
+			for _, acc := range kp.Accounts {
+				err = m.deleteAccountFromKeystoreIfExists(acc.Address, password)
+				if err != nil {
+					return err
+				}
+			}
+
+			err = m.deleteAccountFromKeystoreIfExists(cryptotypes.HexToAddress(kp.DerivedFrom), password)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		for _, acc := range kp.Accounts {
+			if !acc.Removed {
+				continue
+			}
+
+			err = m.deleteAccountFromKeystoreIfExists(acc.Address, password)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // MigrateKeyStoreDir migrates the keystore directory from the current location to the provided new location

--- a/accounts-management/core/manager_test.go
+++ b/accounts-management/core/manager_test.go
@@ -515,3 +515,154 @@ func (s *ManagerTestSuite) TestReEncryptKeyStoreDir() {
 		s.Require().NotNil(account)
 	}
 }
+
+func (s *ManagerTestSuite) TestDeleteAccount() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	walletAccount := keypair.Accounts[1]
+	walletAccount.Wallet = false
+
+	// check if keystore file exists
+	account, err := s.accManager.LoadAccount(walletAccount.Address, testPassword)
+	s.Require().NoError(err)
+	s.Require().NotNil(account)
+
+	s.persistence.EXPECT().GetAccountByAddress(s.walletAddress).Return(
+		walletAccount,
+		nil,
+	).Times(2)
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(walletAccount.KeyUID).Return(
+		keypair,
+		nil,
+	).Times(1)
+
+	s.persistence.EXPECT().RemoveAccount(walletAccount.Address, uint64(0)).Return(nil).Times(1)
+
+	acc, err := s.accManager.DeleteAccount(s.walletAddress, s.password, 0)
+	s.Require().NoError(err)
+	s.Require().NotNil(acc)
+	s.Require().Equal(walletAccount.Address.Hex(), acc.Address.Hex())
+
+	// check if keystore file exists
+	account, err = s.accManager.LoadAccount(walletAccount.Address, testPassword)
+	s.Require().Error(err)
+	s.Require().Nil(account)
+
+	files, _ := os.ReadDir(s.getKeyDir())
+	s.Equal(2, len(files))
+}
+
+func (s *ManagerTestSuite) TestDeleteKeypair() {
+	keypair := s.createAndStoreProfileKeypair()
+
+	keypair.Type = types.KeypairTypeSeed
+
+	s.persistence.EXPECT().GetKeypairByKeyUID(keypair.KeyUID).Return(
+		keypair,
+		nil,
+	).Times(1)
+
+	s.persistence.EXPECT().RemoveKeypair(keypair.KeyUID, uint64(0)).Return(nil).Times(1)
+
+	deletedKp, err := s.accManager.DeleteKeypair(keypair.KeyUID, s.password, 0)
+	s.Require().NoError(err)
+	s.Require().NotNil(deletedKp)
+	s.Require().Equal(keypair.KeyUID, deletedKp.KeyUID)
+
+	files, _ := os.ReadDir(s.getKeyDir())
+	s.Equal(0, len(files))
+}
+
+func (s *ManagerTestSuite) TestCleanKeystoreFiles() {
+	testCases := []struct {
+		name                     string
+		keypairRemoved           bool
+		keypairMigratedToKeycard bool
+		oneAccountRemoved        bool
+		allAccountsRemoved       bool
+	}{
+		{
+			"clean keystore files for removed keypair",
+			true,
+			false,
+			false,
+			false,
+		},
+		{
+			"clean keystore files for migrated to keycard keypair",
+			false,
+			true,
+			false,
+			false,
+		},
+		{
+			"clean keystore files for not removed keypair but one account removed",
+			false,
+			false,
+			true,
+			false,
+		},
+		{
+			"clean keystore files for not removed keypair but all accounts removed",
+			false,
+			false,
+			false,
+			true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		s.Run(testCase.name, func() {
+
+			keypair := s.createAndStoreProfileKeypair()
+
+			files, _ := os.ReadDir(s.getKeyDir())
+			s.Equal(3, len(files))
+
+			keypair.Type = types.KeypairTypeSeed
+			keypair.Removed = testCase.keypairRemoved
+
+			if testCase.keypairMigratedToKeycard {
+				keypair.Keycards = []*types.Keycard{
+					{
+						KeyUID:        keypair.KeyUID,
+						KeycardUID:    "keycard-uid",
+						KeycardName:   "keycard-name",
+						KeycardLocked: false,
+						AccountsAddresses: []cryptotypes.Address{
+							keypair.Accounts[0].Address,
+							keypair.Accounts[1].Address,
+						},
+					},
+				}
+			}
+
+			if testCase.oneAccountRemoved {
+				keypair.Accounts[0].Removed = true
+			}
+
+			if testCase.allAccountsRemoved {
+				keypair.Accounts[0].Removed = true
+				keypair.Accounts[1].Removed = true
+			}
+
+			s.persistence.EXPECT().GetAllKeypairs().Return(
+				[]*types.Keypair{keypair},
+				nil,
+			).Times(1)
+
+			err := s.accManager.CleanKeystoreFiles(s.password)
+			s.Require().NoError(err)
+
+			files, _ = os.ReadDir(s.getKeyDir())
+			if testCase.keypairRemoved || testCase.keypairMigratedToKeycard {
+				s.Equal(0, len(files))
+			} else if testCase.oneAccountRemoved {
+				s.Equal(2, len(files))
+			} else if testCase.allAccountsRemoved {
+				s.Equal(1, len(files)) // only the master account is left
+			}
+		})
+	}
+}

--- a/accounts-management/core/persistence_operations.go
+++ b/accounts-management/core/persistence_operations.go
@@ -349,6 +349,10 @@ func (m *AccountsManager) MakePrivateKeyKeypairFullyOperable(privateKey string, 
 }
 
 func (m *AccountsManager) MakePartiallyOperableAccoutsFullyOperable(password string) (addresses []cryptotypes.Address, err error) {
+	if password == "" {
+		return nil, ErrNoPasswordProvided
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -454,32 +458,6 @@ func (m *AccountsManager) AddAccounts(keyUID string, accounts []*types.Account, 
 	return nil
 }
 
-func (m *AccountsManager) RemoveAccounts(keyUID string, accounts []*types.Account) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if m.persistence == nil {
-		return ErrPersistenceMissing
-	}
-
-	kp, err := m.persistence.GetKeypairByKeyUID(keyUID)
-	if err != nil {
-		return err
-	}
-
-	if !kp.MigratedToKeycard() {
-		for _, acc := range accounts {
-			err = m.deleteAccountFromKeystore(acc.Address)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return m.persistence.SaveOrUpdateAccounts(accounts, true)
-
-}
-
 func (m *AccountsManager) MigrateNonProfileKeycardKeypairToApp(mnemonic string, password string, clock uint64) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -532,9 +510,8 @@ func (m *AccountsManager) MigrateNonProfileKeycardKeypairToApp(mnemonic string, 
 }
 
 // SaveOrUpdateKeycard saves or updates a keycard and its accounts
-// If `removeKeystoreFiles` is true, then corresponding keystore files will be deleted if keypair is not already migrated.
 // In case of migration to a keycard, corresponding keystore files need to be deleted if the keypair being migrated is not already migrated.
-func (m *AccountsManager) SaveOrUpdateKeycard(keycard *types.Keycard, clock uint64, removeKeystoreFiles bool) error {
+func (m *AccountsManager) SaveOrUpdateKeycard(keycard *types.Keycard, password string, clock uint64) error {
 	if len(keycard.AccountsAddresses) == 0 {
 		return ErrKeycardDoesNotHaveAnyAccounts
 	}
@@ -556,25 +533,10 @@ func (m *AccountsManager) SaveOrUpdateKeycard(keycard *types.Keycard, clock uint
 		return err
 	}
 
-	if removeKeystoreFiles {
-		// Once we migrate a keypair, corresponding keystore files need to be deleted
-		// if the keypair being migrated is not already migrated (in case user is creating a copy of an existing Keycard)
-		// and if keypair operability is different from non operable (otherwise there are not keystore files to be deleted).
-		if !kpDb.MigratedToKeycard() && kpDb.Operability() != types.AccountNonOperable {
-			for _, acc := range kpDb.Accounts {
-				if acc.Operable != types.AccountFullyOperable {
-					continue
-				}
-				err = m.deleteAccountFromKeystore(acc.Address)
-				if err != nil {
-					return err
-				}
-			}
-
-			err = m.deleteAccountFromKeystore(cryptotypes.HexToAddress(kpDb.DerivedFrom))
-			if err != nil {
-				return err
-			}
+	if !kpDb.MigratedToKeycard() && password != "" {
+		err = m.deleteKeystoreFilesForKeypairInternally(kpDb, password)
+		if err != nil {
+			return err
 		}
 
 		err = m.persistence.MarkKeypairFullyOperable(keycard.KeyUID, clock, true)
@@ -586,7 +548,7 @@ func (m *AccountsManager) SaveOrUpdateKeycard(keycard *types.Keycard, clock uint
 	return nil
 }
 
-func (m *AccountsManager) DeleteAccount(address cryptotypes.Address, clock uint64) (account *types.Account, err error) {
+func (m *AccountsManager) DeleteAccount(address cryptotypes.Address, password string, clock uint64) (account *types.Account, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -609,7 +571,7 @@ func (m *AccountsManager) DeleteAccount(address cryptotypes.Address, clock uint6
 		return
 	}
 
-	err = m.deleteKeystoreFileForAccountInternally(address)
+	err = m.deleteKeystoreFileForAccountInternally(address, password)
 	if err != nil {
 		return
 	}
@@ -618,7 +580,11 @@ func (m *AccountsManager) DeleteAccount(address cryptotypes.Address, clock uint6
 	return
 }
 
-func (m *AccountsManager) DeleteKeypair(keyUID string, clock uint64) (keypair *types.Keypair, err error) {
+func (m *AccountsManager) DeleteKeypair(keyUID string, password string, clock uint64) (keypair *types.Keypair, err error) {
+	if password == "" {
+		return nil, ErrNoPasswordProvided
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -636,7 +602,7 @@ func (m *AccountsManager) DeleteKeypair(keyUID string, clock uint64) (keypair *t
 		return
 	}
 
-	err = m.deleteKeystoreFilesForKeypairInternally(keypair)
+	err = m.deleteKeystoreFilesForKeypairInternally(keypair, password)
 	if err != nil {
 		return
 	}

--- a/accounts-management/keystore/geth/adapter.go
+++ b/accounts-management/keystore/geth/adapter.go
@@ -117,7 +117,7 @@ func (a *Adapter) AccountDecryptedKey(address cryptotypes.Address, passphrase st
 	return
 }
 
-func (a *Adapter) Delete(address cryptotypes.Address) (err error) {
+func (a *Adapter) Delete(address cryptotypes.Address, passphrase string) (err error) {
 	defer func() {
 		err = mapToKeystoreError(err)
 	}()
@@ -128,9 +128,7 @@ func (a *Adapter) Delete(address cryptotypes.Address) (err error) {
 		return
 	}
 
-	// TODO: think about how to use `Delete` method from `keystore` package, not from our fork
-	// this is the only that depends on our fork for the account management part of the app.
-	err = a.keystore.Delete(gethAccount)
+	err = a.keystore.Delete(gethAccount, passphrase)
 	return
 }
 

--- a/accounts-management/keystore/interface.go
+++ b/accounts-management/keystore/interface.go
@@ -27,7 +27,7 @@ type KeyStore interface {
 	AccountDecryptedKey(address cryptoypes.Address, passphrase string) (types.KeystoreAccount, *ecdsa.PrivateKey, *extkeys.ExtendedKey, error)
 	// Delete deletes the key matched by account.
 	// If the account contains no filename, the address must match a unique key.
-	Delete(address cryptoypes.Address) error
+	Delete(address cryptoypes.Address, passphrase string) error
 	// Find returns the account matched by address
 	Find(address cryptoypes.Address) (types.KeystoreAccount, error)
 	// Accounts returns all accounts in the keystore

--- a/accounts-management/persistence/interface.go
+++ b/accounts-management/persistence/interface.go
@@ -20,6 +20,8 @@ type Persistence interface {
 	GetKeypairByKeyUID(keyUID string) (*types.Keypair, error)
 	// GetActiveKeypairs returns all active keypairs
 	GetActiveKeypairs() ([]*types.Keypair, error)
+	// GetAllKeypairs returns all keypairs
+	GetAllKeypairs() ([]*types.Keypair, error)
 	// SaveOrUpdateKeypair saves or updates a keypair and its accounts
 	SaveOrUpdateKeypair(keypair *types.Keypair) error
 	// SaveOrUpdateAccounts saves or updates accounts

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -1264,7 +1264,7 @@ func (b *GethStatusBackend) ConvertToKeycardAccount(account multiaccounts.Accoun
 	for _, acc := range keypair.Accounts {
 		kc.AccountsAddresses = append(kc.AccountsAddresses, acc.Address)
 	}
-	err = messenger.SaveOrUpdateKeycard(context.Background(), &kc, true)
+	err = messenger.SaveOrUpdateKeycard(context.Background(), &kc, oldPassword)
 	if err != nil {
 		return err
 	}

--- a/api/old_mobile_user_upgrading_from_v1_to_v2_test.go
+++ b/api/old_mobile_user_upgrading_from_v1_to_v2_test.go
@@ -242,7 +242,7 @@ func (s *OldMobileUserUpgradingFromV1ToV2Test) TestAddWalletAccountAfterUpgradin
 	s.Require().NoError(err)
 	// need retry since there's a possible of getting "no key for given address or file" error
 	err = tt.RetryWithBackOff(func() error {
-		return accountsAPI.DeleteAccount(context.Background(), derivedAddress)
+		return accountsAPI.DeleteAccount(context.Background(), derivedAddress, oldMobileUserPasswd)
 	})
 	s.Require().NoError(err)
 	s.Require().NoError(b.Logout())

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/status-im/status-go
 
 go 1.23
 
-replace github.com/ethereum/go-ethereum v1.10.26 => github.com/status-im/go-ethereum v1.10.25-status.21
+replace github.com/ethereum/go-ethereum v1.10.26 => github.com/status-im/go-ethereum v1.10.25-status.22
 
 replace github.com/rjeczalik/notify => github.com/status-im/notify v1.0.2-status
 

--- a/go.sum
+++ b/go.sum
@@ -2031,8 +2031,8 @@ github.com/status-im/doubleratchet v3.0.0+incompatible h1:aJ1ejcSERpSzmWZBgtfYti
 github.com/status-im/doubleratchet v3.0.0+incompatible/go.mod h1:1sqR0+yhiM/bd+wrdX79AOt2csZuJOni0nUDzKNuqOU=
 github.com/status-im/extkeys v1.2.0 h1:ecFMiiESmjza+GNaS4m20okxJAsYEsPfkZof555ubBw=
 github.com/status-im/extkeys v1.2.0/go.mod h1:D6WDVwhax0M/x1hRcQTm7gMgV33/SYSnsV/+4IIfZfA=
-github.com/status-im/go-ethereum v1.10.25-status.21 h1:LSoG0BeQkXPgYLP1KMfYIdWQsBum0PUrW2JQIgGyIdk=
-github.com/status-im/go-ethereum v1.10.25-status.21/go.mod h1:qSfF4zz2PhIy4t8RNBYCUewQiTzyJApK1+lk3ORbDa0=
+github.com/status-im/go-ethereum v1.10.25-status.22 h1:c9Cy2LfJmNVf5BkdHM+4a6OBZv+ZCQsuRabQm2USUt4=
+github.com/status-im/go-ethereum v1.10.25-status.22/go.mod h1:qSfF4zz2PhIy4t8RNBYCUewQiTzyJApK1+lk3ORbDa0=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3 h1:/73h1w1hUfb3wVyTlNrUIwahZxatgesCHa6lwO57C2M=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4 h1:CtobZoiNdHpx+xurFxnuJ1xsGm3oKMfcZkB3vmomJmA=

--- a/multiaccounts/accounts/accounts_manager_adapter.go
+++ b/multiaccounts/accounts/accounts_manager_adapter.go
@@ -56,6 +56,14 @@ func (a *AccountsManagerPersistenceAdapter) GetActiveKeypairs() ([]*types.Keypai
 	return KeypairsToAccountsManagerKeypairs(dbKeypairs), nil
 }
 
+func (a *AccountsManagerPersistenceAdapter) GetAllKeypairs() ([]*types.Keypair, error) {
+	dbKeypairs, err := a.db.GetAllKeypairs()
+	if err != nil {
+		return nil, err
+	}
+	return KeypairsToAccountsManagerKeypairs(dbKeypairs), nil
+}
+
 func (a *AccountsManagerPersistenceAdapter) SaveOrUpdateKeypair(keypair *types.Keypair) error {
 	dbKeypair := AccountsManagerKeypairToKeypair(keypair)
 	return a.db.SaveOrUpdateKeypair(dbKeypair)

--- a/protocol/accounts_manager_interface.go
+++ b/protocol/accounts_manager_interface.go
@@ -11,13 +11,11 @@ import (
 // AccountsManager interface for mocking purposes
 type AccountsManager interface {
 	GetVerifiedWalletAccount(address cryptotypes.Address, password string) (*generator.Account, error)
-	DeleteAccount(address cryptotypes.Address, clock uint64) (account *types.Account, err error)
-	DeleteKeypair(keyUID string, clock uint64) (keypair *types.Keypair, err error)
-	DeleteKeystoreFileForAccount(address cryptotypes.Address) error
-	DeleteKeystoreFilesForKeypair(keypair *types.Keypair) (err error)
+	DeleteAccount(address cryptotypes.Address, password string, clock uint64) (account *types.Account, err error)
+	DeleteKeypair(keyUID string, password string, clock uint64) (keypair *types.Keypair, err error)
 	MakeSeedPhraseKeypairFullyOperable(mnemonic string, password string, clock uint64) (string, error)
 	MakePrivateKeyKeypairFullyOperable(privateKey string, password string, clock uint64) (string, error)
-	SaveOrUpdateKeycard(keycard *types.Keycard, clock uint64, removeKeystoreFiles bool) error
+	SaveOrUpdateKeycard(keycard *types.Keycard, password string, clock uint64) error
 	AddAccounts(keyUID string, accounts []*types.Account, password string) error
 	CreateKeypairFromMnemonicAndStore(mnemonic string, password string, keypairName string,
 		walletAccount *types.AccountCreationDetails, profile bool, clock uint64) (keypair *types.Keypair, err error)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -3632,37 +3632,14 @@ func (m *Messenger) handleSyncKeypair(message *protobuf.SyncKeypair, fromLocalPa
 		kp.Accounts = append(kp.Accounts, acc)
 	}
 
-	if !fromLocalPairing && !recoveringFromWakuInitiatedByKeycard {
-		if kp.Removed ||
-			dbKeypair != nil && !dbKeypair.MigratedToKeycard() && syncKpMigratedToKeycard {
-			// delete all keystore files
-			err = m.accountsManager.DeleteKeystoreFilesForKeypair(accounts.KeypairToAccountsManagerKeypair(dbKeypair))
-			if err != nil {
-				return nil, err
-			}
-
-			if syncKpMigratedToKeycard {
-				err = m.settings.MarkKeypairFullyOperable(dbKeypair.KeyUID, 0, false)
-				if err != nil {
-					return nil, err
-				}
-			}
-		} else if dbKeypair != nil {
-			for _, dbAcc := range dbKeypair.Accounts {
-				removeAcc := false
-				for _, acc := range kp.Accounts {
-					if dbAcc.Address == acc.Address && acc.Removed && !dbAcc.Removed {
-						removeAcc = true
-						break
-					}
-				}
-				if removeAcc {
-					err = m.accountsManager.DeleteKeystoreFileForAccount(dbAcc.Address)
-					if err != nil {
-						return nil, err
-					}
-				}
-			}
+	if !fromLocalPairing &&
+		!recoveringFromWakuInitiatedByKeycard &&
+		dbKeypair != nil &&
+		!dbKeypair.MigratedToKeycard() &&
+		syncKpMigratedToKeycard {
+		err = m.settings.MarkKeypairFullyOperable(dbKeypair.KeyUID, 0, false)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/protocol/messenger_keycard.go
+++ b/protocol/messenger_keycard.go
@@ -46,7 +46,7 @@ func (m *Messenger) dispatchKeycardActivity(keyUID string, keycardUID string, ne
 // Keycard position is fully maintained by the backend.
 // If keycard is already stored, this function updates `KeycardName` and adds accounts which are not already added, in this case
 // `KeycardLocked` and `Position` remains as they were, they won't be changed.
-func (m *Messenger) SaveOrUpdateKeycard(ctx context.Context, keycard *accounts.Keycard, removeKeystoreFiles bool) (err error) {
+func (m *Messenger) SaveOrUpdateKeycard(ctx context.Context, keycard *accounts.Keycard, password string) (err error) {
 	dbKeycard, err := m.settings.GetKeycardByKeycardUID(keycard.KeycardUID)
 	if err != nil && err != accounts.ErrNoKeycardForPassedKeycardUID {
 		return err
@@ -65,7 +65,7 @@ func (m *Messenger) SaveOrUpdateKeycard(ctx context.Context, keycard *accounts.K
 	}
 
 	return m.dispatchKeycardActivity(keycard.KeyUID, "", "", []types.Address{}, func(clock uint64) error {
-		return m.accountsManager.SaveOrUpdateKeycard(accounts.KeycardToAccountsManagerKeycard(keycard), clock, removeKeystoreFiles)
+		return m.accountsManager.SaveOrUpdateKeycard(accounts.KeycardToAccountsManagerKeycard(keycard), password, clock)
 	})
 }
 

--- a/protocol/messenger_sync_keycard_change_test.go
+++ b/protocol/messenger_sync_keycard_change_test.go
@@ -110,21 +110,15 @@ func (s *MessengerSyncKeycardChangeSuite) TestAddingNewKeycards() {
 	keycard2 := accounts.GetKeycardForSeedImportedKeypair1ForTest()
 
 	s.accountsManagerMock.EXPECT().SaveOrUpdateKeycard(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(keycard *types.Keycard, clock uint64, removeKeystoreFiles bool) error {
+		Do(func(keycard *types.Keycard, password string, clock uint64) error {
 			kc := accounts.AccountsManagerKeycardToKeycard(keycard)
-			err := s.m.settings.SaveOrUpdateKeycard(*kc, clock, removeKeystoreFiles)
-			if err != nil {
-				return err
-			}
-			return nil
+			return s.m.settings.SaveOrUpdateKeycard(*kc, clock, true)
 		}).Times(2)
 
-	err := s.main.SaveOrUpdateKeycard(context.Background(), keycard1, false)
+	err := s.main.SaveOrUpdateKeycard(context.Background(), keycard1, "")
 	s.Require().NoError(err)
-	err = s.main.SaveOrUpdateKeycard(context.Background(), keycard2, false)
+	err = s.main.SaveOrUpdateKeycard(context.Background(), keycard2, "")
 	s.Require().NoError(err)
-
-	s.accountsManagerOtherMock.EXPECT().DeleteKeystoreFilesForKeypair(gomock.Any()).Return(nil).Times(2)
 
 	// Wait for the response
 	_, err = WaitOnMessengerResponse(
@@ -161,25 +155,29 @@ func (s *MessengerSyncKeycardChangeSuite) TestAddingAccountsToKeycard() {
 	err := senderDb.SaveOrUpdateKeycard(*keycard1, 0, false)
 	s.Require().NoError(err)
 
+	senderKeycards, err := senderDb.GetAllKnownKeycards()
+	s.Require().NoError(err)
+	s.Require().Equal(1, len(senderKeycards))
+	s.Require().True(contains(senderKeycards, keycard1, accounts.SameKeycards))
+
 	// Add the same keycard on receiver
 	err = dbOnReceiver.SaveOrUpdateKeycard(*keycard1, 0, false)
 	s.Require().NoError(err)
 
+	syncedKeycards, err := dbOnReceiver.GetAllKnownKeycards()
+	s.Require().NoError(err)
+	s.Require().Equal(1, len(syncedKeycards))
+	s.Require().True(contains(syncedKeycards, keycard1, accounts.SameKeycards))
+
 	s.accountsManagerMock.EXPECT().SaveOrUpdateKeycard(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(keycard *types.Keycard, clock uint64, removeKeystoreFiles bool) error {
+		Do(func(keycard *types.Keycard, password string, clock uint64) error {
 			kc := accounts.AccountsManagerKeycardToKeycard(keycard)
-			err := s.m.settings.SaveOrUpdateKeycard(*kc, clock, removeKeystoreFiles)
-			if err != nil {
-				return err
-			}
-			return nil
+			return s.m.settings.SaveOrUpdateKeycard(*kc, clock, true)
 		}).Times(1)
 
 	// Add additional accounts to sender
-	err = s.main.SaveOrUpdateKeycard(context.Background(), keycard2, false)
+	err = s.main.SaveOrUpdateKeycard(context.Background(), keycard2, "")
 	s.Require().NoError(err)
-
-	s.accountsManagerOtherMock.EXPECT().DeleteKeystoreFilesForKeypair(gomock.Any()).Return(nil).Times(1)
 
 	// Wait for the response
 	_, err = WaitOnMessengerResponse(
@@ -191,13 +189,13 @@ func (s *MessengerSyncKeycardChangeSuite) TestAddingAccountsToKeycard() {
 	)
 	s.Require().NoError(err)
 
-	senderKeycards, err := senderDb.GetAllKnownKeycards()
+	senderKeycards, err = senderDb.GetAllKnownKeycards()
 	s.Require().NoError(err)
 	s.Require().Equal(2, len(senderKeycards))
 	s.Require().True(contains(senderKeycards, keycard1, accounts.SameKeycards))
 	s.Require().True(contains(senderKeycards, keycard2, accounts.SameKeycards))
 
-	syncedKeycards, err := dbOnReceiver.GetAllKnownKeycards()
+	syncedKeycards, err = dbOnReceiver.GetAllKnownKeycards()
 	s.Require().NoError(err)
 	s.Require().Equal(2, len(syncedKeycards))
 	s.Require().True(contains(syncedKeycards, keycard1, accounts.SameKeycards))

--- a/protocol/messenger_sync_keycards_state_test.go
+++ b/protocol/messenger_sync_keycards_state_test.go
@@ -128,8 +128,6 @@ func (s *MessengerSyncKeycardsStateSuite) TestSyncKeycardsIfReceiverHasNoKeycard
 	err = s.main.SyncDevices(context.Background(), "ens-name", "profile-image", nil)
 	s.Require().NoError(err)
 
-	s.accountsManagerOtherMock.EXPECT().DeleteKeystoreFilesForKeypair(gomock.Any()).Return(nil).AnyTimes()
-
 	// Wait for the response
 	_, err = WaitOnMessengerResponse(
 		s.other,
@@ -249,8 +247,6 @@ func (s *MessengerSyncKeycardsStateSuite) TestSyncKeycardsIfReceiverAndSenderHas
 	// Trigger's a sync between devices
 	err = s.main.SyncDevices(context.Background(), "ens-name", "profile-image", nil)
 	s.Require().NoError(err)
-
-	s.accountsManagerOtherMock.EXPECT().DeleteKeystoreFilesForKeypair(gomock.Any()).Return(nil).AnyTimes()
 
 	// Wait for the response
 	_, err = WaitOnMessengerResponse(

--- a/protocol/messenger_sync_wallets_test.go
+++ b/protocol/messenger_sync_wallets_test.go
@@ -594,8 +594,8 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 	// Delete keypair related account on alice's primary device
 	accToDelete := seedPhraseKp.Accounts[1]
 
-	s.accountsManagerMock.EXPECT().DeleteAccount(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(address types.Address, clock uint64) (*accsmanagementtypes.Account, error) {
+	s.accountsManagerMock.EXPECT().DeleteAccount(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(address types.Address, password string, clock uint64) (*accsmanagementtypes.Account, error) {
 			err := s.m.settings.RemoveAccount(address, clock)
 			if err != nil {
 				return nil, err
@@ -603,7 +603,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 			return accounts.AccountToAccountsManagerAccount(accToDelete), nil
 		}).Times(1)
 
-	err = s.m.DeleteAccount(accToDelete.Address)
+	err = s.m.DeleteAccount(accToDelete.Address, "")
 	s.Require().NoError(err, "delete account on alice primary device")
 
 	totalNumOfAccounts-- //one acc less
@@ -611,8 +611,6 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 	dbAccounts1, err = s.m.settings.GetActiveAccounts()
 	s.Require().NoError(err)
 	s.Require().Equal(totalNumOfAccounts, len(dbAccounts1))
-
-	accountsManagerAnotherMock.EXPECT().DeleteKeystoreFileForAccount(accToDelete.Address).Return(nil).Times(1)
 
 	err = tt.RetryWithBackOff(func() error {
 		response, err := alicesOtherDevice.RetrieveAll()
@@ -636,8 +634,8 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 	// Delete watch only account on alice's primary device
 	accToDelete = woAccounts[1]
 
-	s.accountsManagerMock.EXPECT().DeleteAccount(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(address types.Address, clock uint64) (*accsmanagementtypes.Account, error) {
+	s.accountsManagerMock.EXPECT().DeleteAccount(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(address types.Address, password string, clock uint64) (*accsmanagementtypes.Account, error) {
 			err := s.m.settings.RemoveAccount(address, clock)
 			if err != nil {
 				return nil, err
@@ -645,7 +643,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 			return accounts.AccountToAccountsManagerAccount(accToDelete), nil
 		}).Times(1)
 
-	err = s.m.DeleteAccount(accToDelete.Address)
+	err = s.m.DeleteAccount(accToDelete.Address, "")
 	s.Require().NoError(err, "delete account on alice primary device")
 
 	totalNumOfAccounts-- //one acc less

--- a/protocol/messenger_wallet.go
+++ b/protocol/messenger_wallet.go
@@ -304,9 +304,9 @@ func (m *Messenger) MakePrivateKeyKeypairFullyOperable(privateKey string, passwo
 	return m.resolveAndSyncKeypairOrJustWalletAccount(keyUID, types.Address{}, clock, m.dispatchMessage)
 }
 
-func (m *Messenger) DeleteAccount(address types.Address) error {
+func (m *Messenger) DeleteAccount(address types.Address, password string) error {
 	clock, _ := m.getLastClockWithRelatedChat()
-	acc, err := m.accountsManager.DeleteAccount(address, clock)
+	acc, err := m.accountsManager.DeleteAccount(address, password, clock)
 	if err != nil {
 		return err
 	}
@@ -332,9 +332,9 @@ func (m *Messenger) DeleteAccount(address types.Address) error {
 	return m.DeleteProfileShowcaseWalletAccount(accounts.AccountsManagerAccountToAccount(acc))
 }
 
-func (m *Messenger) DeleteKeypair(keyUID string) error {
+func (m *Messenger) DeleteKeypair(keyUID string, password string) error {
 	clock, _ := m.getLastClockWithRelatedChat()
-	kp, err := m.accountsManager.DeleteKeypair(keyUID, clock)
+	kp, err := m.accountsManager.DeleteKeypair(keyUID, password, clock)
 	if err != nil {
 		return err
 	}

--- a/server/pairing/sync_device_test.go
+++ b/server/pairing/sync_device_test.go
@@ -170,8 +170,23 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFiles() {
 
 	accountsManager := clientBackend.AccountsManager()
 	// need to delete keystore files for keypair in order to simulate the case where the keypair was restored and keystore files were not created yet
-	err = accountsManager.DeleteKeystoreFilesForKeypair(accounts.KeypairToAccountsManagerKeypair(clientSeedPhraseKp))
+	clientKeystoreDir := filepath.Join(clientTmpDir, "keystore", clientActiveAccount.KeyUID)
+	files, err := os.ReadDir(clientKeystoreDir)
 	require.NoError(s.T(), err)
+
+	for _, file := range files {
+		if strings.Contains(strings.ToLower(file.Name()), strings.ToLower(clientSeedPhraseKp.DerivedFrom[2:])) {
+			require.NoError(s.T(), os.RemoveAll(filepath.Join(clientKeystoreDir, file.Name())))
+			continue
+		}
+
+		for _, acc := range clientSeedPhraseKp.Accounts {
+			if !strings.Contains(strings.ToLower(file.Name()), strings.ToLower(acc.Address.String()[2:])) {
+				continue
+			}
+			require.NoError(s.T(), os.RemoveAll(filepath.Join(clientKeystoreDir, file.Name())))
+		}
+	}
 
 	// check client - client should not contain keystore files for imported seed phrase
 	clientKeystorePath := filepath.Join(clientTmpDir, api.DefaultKeystoreRelativePath, clientActiveAccount.KeyUID)
@@ -387,7 +402,7 @@ func (s *SyncDeviceSuite) TestTransferringKeystoreFilesAfterStopUisngKeycard() {
 		KeycardName:       "new-keycard",
 		KeyUID:            serverKp.KeyUID,
 		AccountsAddresses: []types.Address{serverKp.Accounts[0].Address, serverKp.Accounts[1].Address},
-	}, false)
+	}, s.password)
 	s.Require().NoError(err)
 
 	// Wait for sync messages to be received on client

--- a/services/accounts/accounts.go
+++ b/services/accounts/accounts.go
@@ -183,8 +183,8 @@ func (api *API) GetKeypairByKeyUID(ctx context.Context, keyUID string) (*account
 	return api.db.GetKeypairByKeyUID(keyUID)
 }
 
-func (api *API) DeleteAccount(ctx context.Context, address types.Address) error {
-	err := (*api.messenger).DeleteAccount(address)
+func (api *API) DeleteAccount(ctx context.Context, address types.Address, password string) error {
+	err := (*api.messenger).DeleteAccount(address, password)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func (api *API) DeleteAccount(ctx context.Context, address types.Address) error 
 	return nil
 }
 
-func (api *API) DeleteKeypair(ctx context.Context, keyUID string) error {
+func (api *API) DeleteKeypair(ctx context.Context, keyUID string, password string) error {
 	keypair, err := api.db.GetKeypairByKeyUID(keyUID)
 	if err != nil {
 		return err
@@ -204,7 +204,7 @@ func (api *API) DeleteKeypair(ctx context.Context, keyUID string) error {
 		return accounts.ErrCannotRemoveProfileKeypair
 	}
 
-	err = (*api.messenger).DeleteKeypair(keyUID)
+	err = (*api.messenger).DeleteKeypair(keyUID, password)
 	if err != nil {
 		return err
 	}
@@ -232,6 +232,14 @@ func (api *API) RemainingWatchOnlyAccountCapacity(ctx context.Context) (int, err
 // Creates all keystore files for a keypair and mark it in db as fully operable.
 func (api *API) MakePrivateKeyKeypairFullyOperable(ctx context.Context, privateKey string, password string) error {
 	return (*api.messenger).MakePrivateKeyKeypairFullyOperable(privateKey, password)
+}
+
+// CleanKeystoreFiles cleans the keystore files for all keypairs
+// if the keypair is already migrated to keycard or removed, it cleans all accounts of the keypair, including the master account
+// if the keypair is not migrated to keycard and not removed, it cleans the keystore files for removed accounts of the keypair,
+// the master account is not cleaned if the keypair is not removed/migrated to keycard
+func (api *API) CleanKeystoreFiles(ctx context.Context, password string) error {
+	return api.manager.CleanKeystoreFiles(password)
 }
 
 func (api *API) MakePartiallyOperableAccoutsFullyOperable(ctx context.Context, password string) (addresses []types.Address, err error) {
@@ -269,11 +277,10 @@ func (api *API) MigrateNonProfileKeycardKeypairToApp(ctx context.Context, mnemon
 	return (*api.messenger).MigrateNonProfileKeycardKeypairToApp(ctx, mnemonicNoExtraSpaces, password)
 }
 
-// If keypair is migrated from keycard to app, then `accountsComingFromKeycard` should be set to true, otherwise false.
 // If keycard is new `Position` will be determined and set by the backend and `KeycardLocked` will be set to false.
 // If keycard is already added, `Position` and `KeycardLocked` will be unchanged.
-func (api *API) SaveOrUpdateKeycard(ctx context.Context, keycard *accounts.Keycard, accountsComingFromKeycard bool) error {
-	return (*api.messenger).SaveOrUpdateKeycard(ctx, keycard, !accountsComingFromKeycard)
+func (api *API) SaveOrUpdateKeycard(ctx context.Context, keycard *accounts.Keycard, password string) error {
+	return (*api.messenger).SaveOrUpdateKeycard(ctx, keycard, password)
 }
 
 func (api *API) GetAllKnownKeycards(ctx context.Context) ([]*accounts.Keycard, error) {

--- a/tests-functional/clients/services/accounts.py
+++ b/tests-functional/clients/services/accounts.py
@@ -19,8 +19,8 @@ class AccountService(Service):
         response = self.rpc_request("addAccount", params)
         return response.json()
 
-    def delete_account(self, account_address):
-        params = [account_address]
+    def delete_account(self, account_address, password):
+        params = [account_address, password]
         response = self.rpc_request("deleteAccount", params)
         return response.json()
 

--- a/tests-functional/tests/test_delete_account.py
+++ b/tests-functional/tests/test_delete_account.py
@@ -13,12 +13,12 @@ class TestDeleteAccount:
 
     def test_delete_watch_account(self):
         self.account_data["type"] = "watch"
-        self.account.accounts_service.add_account(self.account.password, self.account_data)
+        self.account.accounts_service.add_account("", self.account_data)
 
         accounts_response = self.account.accounts_service.get_accounts()
         assert len(accounts_response.get("result", [])) == 3
 
-        resp = self.account.accounts_service.delete_account(self.account_data["address"])
+        resp = self.account.accounts_service.delete_account(self.account_data["address"], "")
         assert resp["result"] is None
 
         accounts_response = self.account.accounts_service.get_accounts()
@@ -28,7 +28,7 @@ class TestDeleteAccount:
         accounts_response = self.account.accounts_service.get_accounts()
         assert len(accounts_response.get("result", [])) == 2
 
-        resp = self.account.accounts_service.delete_account(accounts_response.get("result")[0].get("address"))
+        resp = self.account.accounts_service.delete_account(accounts_response.get("result")[0].get("address"), self.account.password)
         assert resp.get("error").get("message") == "[database] cannot remove default chat account"
 
         accounts_response = self.account.accounts_service.get_accounts()
@@ -38,12 +38,12 @@ class TestDeleteAccount:
         accounts_response = self.account.accounts_service.get_accounts()
         assert len(accounts_response.get("result", [])) == 2
 
-        resp = self.account.accounts_service.delete_account(accounts_response.get("result")[1].get("address"))
+        resp = self.account.accounts_service.delete_account(accounts_response.get("result")[1].get("address"), self.account.password)
         assert resp.get("error").get("message") == "[database] cannot remove default wallet account"
 
         accounts_response = self.account.accounts_service.get_accounts()
         assert len(accounts_response.get("result", [])) == 2
 
     def test_delete_nonexistent_account(self):
-        resp = self.account.accounts_service.delete_account("0x0000000000000000000000000000000000000001")
+        resp = self.account.accounts_service.delete_account("0x0000000000000000000000000000000000000001", self.account.password)
         assert resp.get("error").get("message") == "accounts: account is not found"

--- a/vendor/github.com/ethereum/go-ethereum/accounts/keystore/keystore.go
+++ b/vendor/github.com/ethereum/go-ethereum/accounts/keystore/keystore.go
@@ -241,17 +241,22 @@ func (ks *KeyStore) AccountDecryptedKey(a accounts.Account, auth string) (accoun
 	return ks.getDecryptedKey(a, auth)
 }
 
-// Delete deletes the key matched by account.
+// Delete deletes the key matched by account if the passphrase is correct.
 // If the account contains no filename, the address must match a unique key.
-func (ks *KeyStore) Delete(a accounts.Account) error {
-	// The order is crucial here. The key is dropped from the
-	// cache after the file is gone so that a reload happening in
-	// between won't insert it into the cache again.
-	a, err := ks.Find(a)
+func (ks *KeyStore) Delete(a accounts.Account, passphrase string) error {
+	// Decrypting the key isn't really necessary, but we do
+	// it anyway to check the password and zero out the key
+	// immediately afterwards.
+	a, key, err := ks.getDecryptedKey(a, passphrase)
+	if key != nil {
+		zeroKey(key.PrivateKey)
+	}
 	if err != nil {
 		return err
 	}
-
+	// The order is crucial here. The key is dropped from the
+	// cache after the file is gone so that a reload happening in
+	// between won't insert it into the cache again.
 	err = os.Remove(a.URL.Path)
 	if err == nil {
 		ks.cache.delete(a)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -220,7 +220,7 @@ github.com/edsrzf/mmap-go
 ## explicit; go 1.14
 github.com/elastic/gosigar
 github.com/elastic/gosigar/sys/windows
-# github.com/ethereum/go-ethereum v1.10.26 => github.com/status-im/go-ethereum v1.10.25-status.21
+# github.com/ethereum/go-ethereum v1.10.26 => github.com/status-im/go-ethereum v1.10.25-status.22
 ## explicit; go 1.21
 github.com/ethereum/go-ethereum
 github.com/ethereum/go-ethereum/accounts


### PR DESCRIPTION
Corresponding PR to our `go-ethereum` fork:
- https://github.com/status-im/go-ethereum/pull/112

- Updated the `DeleteAccount` and `DeleteKeypair` methods to require a password in order to align with what's expected by the go-ethereum.
- Refactored the keystore file deletion logic to ensure proper handling of accounts and keypairs deletion.
- Introduced a new `CleanKeystoreFiles` method to streamline the cleanup of keystore files for removed or migrated keypairs via paired devices.
- Adjusted the keystore interface to accommodate the new password parameter in the `Delete` method.