### PR TITLE
feat: remove uri from Identity image and add local url to accounts

### DIFF
--- a/images/identity.go
+++ b/images/identity.go
@@ -38,15 +38,9 @@ func (i IdentityImage) GetDataURI() (string, error) {
 }
 
 func (i IdentityImage) MarshalJSON() ([]byte, error) {
-	uri, err := i.GetDataURI()
-	if err != nil {
-		return nil, err
-	}
-
 	temp := struct {
 		KeyUID       string `json:"keyUid"`
 		Name         string `json:"type"`
-		URI          string `json:"uri"` // Deprecated, use LocalURL instead
 		Width        int    `json:"width"`
 		Height       int    `json:"height"`
 		FileSize     int    `json:"fileSize"`
@@ -56,7 +50,6 @@ func (i IdentityImage) MarshalJSON() ([]byte, error) {
 	}{
 		KeyUID:       i.KeyUID,
 		Name:         i.Name,
-		URI:          uri,
 		Width:        i.Width,
 		Height:       i.Height,
 		FileSize:     i.FileSize,

--- a/images/identity_test.go
+++ b/images/identity_test.go
@@ -63,7 +63,7 @@ func TestIdentityImage_MarshalJSON(t *testing.T) {
 		FileSize:     256,
 		ResizeTarget: 80,
 	}
-	expected := `{"keyUid":"","type":"thumbnail","uri":"data:image/jpeg;base64,/9j/2wCEAFA3PEY8MlA=","width":80,"height":80,"fileSize":256,"resizeTarget":80,"clock":0}`
+	expected := `{"keyUid":"","type":"thumbnail","width":80,"height":80,"fileSize":256,"resizeTarget":80,"clock":0}`
 
 	js, err := json.Marshal(ii)
 	require.NoError(t, err)

--- a/multiaccounts/database_test.go
+++ b/multiaccounts/database_test.go
@@ -139,7 +139,7 @@ func TestDatabase_GetIdentityImages(t *testing.T) {
 	defer stop()
 	seedTestDBWithIdentityImages(t, db, keyUID)
 
-	expected := `[{"keyUid":"0xdeadbeef","type":"large","uri":"data:image/png;base64,iVBORw0KGgoAAAANSUg=","width":240,"height":300,"fileSize":1024,"resizeTarget":240,"clock":0},{"keyUid":"0xdeadbeef","type":"thumbnail","uri":"data:image/jpeg;base64,/9j/2wCEAFA3PEY8MlA=","width":80,"height":80,"fileSize":256,"resizeTarget":80,"clock":0}]`
+	expected := `[{"keyUid":"0xdeadbeef","type":"large","width":240,"height":300,"fileSize":1024,"resizeTarget":240,"clock":0},{"keyUid":"0xdeadbeef","type":"thumbnail","width":80,"height":80,"fileSize":256,"resizeTarget":80,"clock":0}]`
 
 	oiis, err := db.GetIdentityImages(keyUID)
 	require.NoError(t, err)
@@ -167,12 +167,12 @@ func TestDatabase_GetIdentityImage(t *testing.T) {
 		{
 			keyUID,
 			images.SmallDimName,
-			`{"keyUid":"0xdeadbeef","type":"thumbnail","uri":"data:image/jpeg;base64,/9j/2wCEAFA3PEY8MlA=","width":80,"height":80,"fileSize":256,"resizeTarget":80,"clock":0}`,
+			`{"keyUid":"0xdeadbeef","type":"thumbnail","width":80,"height":80,"fileSize":256,"resizeTarget":80,"clock":0}`,
 		},
 		{
 			keyUID,
 			images.LargeDimName,
-			`{"keyUid":"0xdeadbeef","type":"large","uri":"data:image/png;base64,iVBORw0KGgoAAAANSUg=","width":240,"height":300,"fileSize":1024,"resizeTarget":240,"clock":0}`,
+			`{"keyUid":"0xdeadbeef","type":"large","width":240,"height":300,"fileSize":1024,"resizeTarget":240,"clock":0}`,
 		},
 		{
 			keyUID2,
@@ -253,7 +253,6 @@ func TestDatabase_GetAccountsWithIdentityImages(t *testing.T) {
 			{
 				"keyUid": "0xdeadbeef",
 				"type": "large",
-				"uri": "data:image/png;base64,iVBORw0KGgoAAAANSUg=",
 				"width": 240,
 				"height": 300,
 				"fileSize": 1024,
@@ -263,7 +262,6 @@ func TestDatabase_GetAccountsWithIdentityImages(t *testing.T) {
 			{
 				"keyUid": "0xdeadbeef",
 				"type": "thumbnail",
-				"uri": "data:image/jpeg;base64,/9j/2wCEAFA3PEY8MlA=",
 				"width": 80,
 				"height": 80,
 				"fileSize": 256,
@@ -310,7 +308,6 @@ func TestDatabase_GetAccountsWithIdentityImages(t *testing.T) {
 			{
 				"keyUid": "0x1337beef3",
 				"type": "large",
-				"uri": "data:image/png;base64,iVBORw0KGgoAAAANSUg=",
 				"width": 240,
 				"height": 300,
 				"fileSize": 1024,
@@ -320,7 +317,6 @@ func TestDatabase_GetAccountsWithIdentityImages(t *testing.T) {
 			{
 				"keyUid": "0x1337beef3",
 				"type": "thumbnail",
-				"uri": "data:image/jpeg;base64,/9j/2wCEAFA3PEY8MlA=",
 				"width": 80,
 				"height": 80,
 				"fileSize": 256,


### PR DESCRIPTION
Same as this PR https://github.com/status-im/status-go/pull/6776

I had closed it and reopened because I thought we avoided breaking changes for the mobile client, but turns out we're no longer updating the status-go version already, so here the breaking change again.

Desktop already supports the localURL format and no longer uses the uri one.

[remval-of-image-uris.webm](https://github.com/user-attachments/assets/06d0237f-082f-4a47-8403-f3709067d40c)
