### PR TITLE
ci: set XDG_CACHE_HOME to workspace tmp

### DIFF
--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -62,6 +62,9 @@ pipeline {
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     /* Ensure env var is set on first run. */
     USE_NWAKU = "${params.USE_NWAKU}"
+
+    /* fixes nim cache collision */
+    XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
   }
 
   stages {

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -82,6 +82,9 @@ pipeline {
 
     /* prevent sharing cache dir across different jobs */
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
+
+    /* fixes nim cache collision */
+    XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
   }
 
   stages {


### PR DESCRIPTION
## Summary

In CI jobs where nwaku or nim is used, its safer to set `XDG_CACHE_HOME` to a temp directory to avoid cache collisions in CI.

we could use `--nimflags` but `XDG_CACHE_HOME` is also a safe bet : https://nim-lang.org/docs/nimc.html#compiler-usage-generated-c-code-directory