### PR TITLE
fix(metrics): cleanup old metrics so that new ones can be processed

### DIFF
--- a/centralizedmetrics/metrics.go
+++ b/centralizedmetrics/metrics.go
@@ -23,6 +23,7 @@ type MetricsInfo struct {
 type MetricRepository interface {
 	Poll() ([]common.Metric, error)
 	Delete(metrics []common.Metric) error
+	CleanupOldMetrics() error
 	Add(metric common.Metric) error
 	Info() (*MetricsInfo, error)
 	ToggleEnabled(isEnabled bool) error
@@ -60,6 +61,13 @@ func (s *MetricService) Start() {
 	if s.started {
 		return
 	}
+
+	err := s.repository.CleanupOldMetrics()
+	if err != nil {
+		// No need to return
+		s.logger.Error("error cleaning up old metrics", zap.Error(err))
+	}
+
 	s.ticker = time.NewTicker(s.interval)
 	s.wg.Add(1)
 	s.started = true

--- a/centralizedmetrics/metrics_test.go
+++ b/centralizedmetrics/metrics_test.go
@@ -74,6 +74,10 @@ func (r *TestMetricRepository) Info() (*MetricsInfo, error) {
 	return &MetricsInfo{Enabled: r.enabled, UserConfirmed: r.userConfirmed}, nil
 }
 
+func (r *TestMetricRepository) CleanupOldMetrics() error {
+	return nil
+}
+
 func (r *TestMetricRepository) Delete(metrics []common.Metric) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()

--- a/centralizedmetrics/sqlite_persistence.go
+++ b/centralizedmetrics/sqlite_persistence.go
@@ -98,6 +98,26 @@ func (r *SQLiteMetricRepository) Delete(metrics []common.Metric) error {
 	return tx.Commit()
 }
 
+func (r *SQLiteMetricRepository) CleanupOldMetrics() error {
+	tx, err := r.db.BeginTx(context.Background(), &sql.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+		// don't shadow original error
+		_ = tx.Rollback()
+	}()
+
+	const cleanupThreshold = 5 * 24 * time.Hour // 5 days is the MixPanel limit
+
+	_, err = tx.Exec("DELETE FROM centralizedmetrics_metrics WHERE timestamp < ?", time.Now().Add(-cleanupThreshold).UnixNano()/int64(time.Millisecond))
+	return err
+}
+
 func (r *SQLiteMetricRepository) Add(metric common.Metric) error {
 	eventValue, err := json.Marshal(metric.EventValue)
 	if err != nil {

--- a/centralizedmetrics/sqlite_persistence_test.go
+++ b/centralizedmetrics/sqlite_persistence_test.go
@@ -2,7 +2,9 @@ package centralizedmetrics
 
 import (
 	"database/sql"
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -115,6 +117,57 @@ func TestSQLiteMetricRepository_Delete(t *testing.T) {
 	err = db.QueryRow("SELECT COUNT(*) FROM centralizedmetrics_metrics WHERE id = ?", metric.ID).Scan(&count)
 	require.NoError(t, err)
 	require.Equal(t, 0, count)
+}
+
+func TestSQLiteMetricRepository_CleanupOldMetrics(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	repo := NewSQLiteMetricRepository(db)
+
+	// Insert a normal metric
+	metric := common.Metric{
+		ID:        "id",
+		EventName: "purchase",
+		EventValue: map[string]interface{}{
+			"amount": 99.99,
+		},
+	}
+
+	err := repo.Add(metric)
+	require.NoError(t, err)
+
+	// Cleanup should do nothing
+	err = repo.CleanupOldMetrics()
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM centralizedmetrics_metrics").Scan(&count)
+	require.NoError(t, err)
+	// There will be one because the added metric will be from Now
+	require.Equal(t, 1, count)
+
+	// Insert an old metric
+	eventValue, err := json.Marshal(metric.EventValue)
+	require.NoError(t, err)
+	metric.ID = "old_id"
+	_, err = db.Exec("INSERT INTO centralizedmetrics_metrics (id, event_name, event_value, platform, app_version, timestamp) VALUES (?, ?, ?, ?, ?, ?)",
+		metric.ID, metric.EventName, string(eventValue), metric.Platform, metric.AppVersion, time.Now().Add(-6*24*time.Hour).UnixNano()/int64(time.Millisecond))
+	require.NoError(t, err)
+
+	err = db.QueryRow("SELECT COUNT(*) FROM centralizedmetrics_metrics").Scan(&count)
+	require.NoError(t, err)
+	// Now there are 2 metrics
+	require.Equal(t, 2, count)
+
+	// Cleanup will do something now
+	err = repo.CleanupOldMetrics()
+	require.NoError(t, err)
+
+	err = db.QueryRow("SELECT COUNT(*) FROM centralizedmetrics_metrics").Scan(&count)
+	require.NoError(t, err)
+	// Back to one metric
+	require.Equal(t, 1, count)
 }
 
 func TestSQLiteMetricRepository_UserID(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-go/pull/6863

Fixes #6860

The solution is to cleanup metrics older than five days at the start of the metrics module. That way, we start pilling, we only process valid metrics

