### PR TITLE
fix(backup)_: use pubkey suffix instead of prefix

### DIFF
--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -198,6 +199,24 @@ func (n *StatusNode) Start(config *params.NodeConfig) error {
 func (n *StatusNode) StartLocalBackup() error {
 	if n.localBackup != nil {
 		return errors.New("local backup already started")
+	}
+
+	backupPath, err := n.accountsSrvc.GetBackupPath()
+	if err != nil {
+		return err
+	}
+	if backupPath == "" {
+		// No path set yet, set it to the user's config directory
+		dir, err := os.UserConfigDir()
+		// We do not return the error as it's not a major issue
+		if err != nil {
+			n.logger.Error("failed to get user config dir", zap.Error(err))
+		} else {
+			err = n.accountsSrvc.SetBackupPath(filepath.Join(dir, "Status", "backups"))
+			if err != nil {
+				n.logger.Error("failed to set backup path", zap.Error(err))
+			}
+		}
 	}
 
 	filenameGetter := func() (string, error) {

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -23,7 +23,6 @@ import (
 	"github.com/status-im/status-go/node/backup"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/pubsub"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/server"
 	accountssvc "github.com/status-im/status-go/services/accounts"
@@ -201,14 +200,11 @@ func (n *StatusNode) StartLocalBackup() error {
 		return errors.New("local backup already started")
 	}
 
-	chatAccount, err := n.gethAccountsManager.SelectedChatAccount()
-	if err != nil {
-		return err
-	}
-
-	privateKey := chatAccount.PrivateKey()
 	filenameGetter := func() (string, error) {
-		accountIdentifier := common.PubkeyToHex(&privateKey.PublicKey)
+		profileKeypair, err := n.accountsSrvc.GetProfileKeypair()
+		if err != nil {
+			return "", err
+		}
 
 		backupPath, err := n.accountsSrvc.GetBackupPath()
 		if err != nil {
@@ -220,9 +216,16 @@ func (n *StatusNode) StartLocalBackup() error {
 		} else {
 			backupDir = filepath.Join(n.config.RootDataDir, "backups")
 		}
-		fullPath := filepath.Join(backupDir, fmt.Sprintf("%x_user_data.bkp", accountIdentifier[:4]))
+		fullPath := filepath.Join(backupDir, fmt.Sprintf("%x_user_data.bkp", profileKeypair.KeyUID[len(profileKeypair.KeyUID)-4:]))
 		return fullPath, nil
 	}
+
+	chatAccount, err := n.gethAccountsManager.SelectedChatAccount()
+	if err != nil {
+		return err
+	}
+
+	privateKey := chatAccount.PrivateKey()
 
 	n.localBackup, err = backup.NewController(backup.BackupConfig{
 		PrivateKey:     crypto.Keccak256(crypto.FromECDSA(privateKey)),

--- a/services/accounts/service.go
+++ b/services/accounts/service.go
@@ -110,6 +110,10 @@ func (s *Service) GetBackupPath() (string, error) {
 	return s.db.BackupPath()
 }
 
+func (s *Service) SetBackupPath(path string) error {
+	return s.db.SaveSettingField(settings.BackupPath, path)
+}
+
 func (s *Service) GetMessenger() *protocol.Messenger {
 	return s.messenger
 }

--- a/services/accounts/service.go
+++ b/services/accounts/service.go
@@ -93,6 +93,10 @@ func (s *Service) AccountsAPI() *API {
 	return NewAccountsAPI(s.manager, s.config, s.db, &s.messenger, s.publisher)
 }
 
+func (s *Service) GetProfileKeypair() (*accounts.Keypair, error) {
+	return s.db.GetProfileKeypair()
+}
+
 func (s *Service) GetKeypairByKeyUID(keyUID string) (*accounts.Keypair, error) {
 
 	return s.db.GetKeypairByKeyUID(keyUID)

--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -50,6 +50,11 @@ Functional tests for status-go
     pytest -m rpc
    ```
 
+   You can run a single test with the `-k` argument. Eg:
+   ```sh
+   pytest -k test_logging
+   ```
+
 ### Running against a `status-backend` binary
 
 By default, tests will spawn containers with `status-backend` when and as needed.

--- a/tests-functional/tests/test_local_backup.py
+++ b/tests-functional/tests/test_local_backup.py
@@ -246,6 +246,9 @@ class TestLocalBackup:
         assert group_chat_recovered, "Group chat was not restored correctly"
         assert one_on_one_chat_recovered, "One-to-one chat was not restored correctly"
 
+        # Change the backup path (Docker restricts access to a lot of folders)
+        backend_client.rpc_valid_request("settings_saveSetting", ["backup-path", "/usr/status-user/backups"])
+
         # Perform the backup
         response = backend_client.api_valid_request("PerformLocalBackup", "")
         jsonResponse = response.json()


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/18731

Turns out our pubkeys all start with the same prefix, and I chose exactly the length of the prefix in the previous version, so all files had the same name. Using the suffix solves this
