### PR TITLE
fix_: more dapp fixes

### DIFF
--- a/services/wallet/common/utils.go
+++ b/services/wallet/common/utils.go
@@ -65,10 +65,16 @@ func CopyMapGeneric(original interface{}, deepCopyValueFn func(interface{}) inte
 }
 
 func GweiToEth(val *big.Float) *big.Float {
+	if val == nil {
+		return nil
+	}
 	return new(big.Float).Quo(val, big.NewFloat(1000000000))
 }
 
 func WeiToGwei(val *big.Int) *big.Float {
+	if val == nil {
+		return nil
+	}
 	result := new(big.Float)
 	result.SetInt(val)
 

--- a/services/wallet/router/fees/estimated_time.go
+++ b/services/wallet/router/fees/estimated_time.go
@@ -36,7 +36,7 @@ const (
 )
 
 func (f *FeeManager) TransactionEstimatedTime(ctx context.Context, chainID uint64, maxFeePerGas *big.Int) TransactionEstimation {
-	feeHistory, err := f.getFeeHistory(ctx, chainID, "latest", nil)
+	feeHistory, err := f.getFeeHistory(ctx, chainID, getFeeHistoryBlockCount(chainID), "latest", nil)
 	if err != nil {
 		return Unknown
 	}
@@ -167,7 +167,7 @@ func getBaseFeePercentileIndex(sortedBaseFees []*big.Int, percentile float64, ne
 
 // TransactionEstimatedTimeV2 returns the estimated time in seconds for a transaction to be included in a block
 func (f *FeeManager) TransactionEstimatedTimeV2(ctx context.Context, chainID uint64, maxFeePerGas *big.Int, priorityFee *big.Int) uint {
-	feeHistory, err := f.getFeeHistory(ctx, chainID, "latest", []int{RewardPercentiles2})
+	feeHistory, err := f.getFeeHistory(ctx, chainID, getFeeHistoryBlockCount(chainID), "latest", []int{RewardPercentiles2})
 	if err != nil {
 		return 0
 	}

--- a/services/wallet/router/fees/fees.go
+++ b/services/wallet/router/fees/fees.go
@@ -129,7 +129,8 @@ func (f *FeeManager) IsEIP1559Enabled(ctx context.Context, chainID uint64) (bool
 }
 
 func (f *FeeManager) SuggestedFees(ctx context.Context, chainID uint64, address ethCommon.Address) (suggestedFees *SuggestedFees, noBaseFee bool, noPriorityFee bool, err error) {
-	feeHistory, err := f.getFeeHistory(ctx, chainID, "latest", []int{RewardPercentiles1, RewardPercentiles2, RewardPercentiles3})
+	blockCount := getFeeHistoryBlockCount(chainID)
+	feeHistory, err := f.getFeeHistory(ctx, chainID, blockCount, "latest", []int{RewardPercentiles1, RewardPercentiles2, RewardPercentiles3})
 	if err != nil {
 		suggestedFees, err = f.getNonEIP1559SuggestedFees(ctx, chainID)
 		return
@@ -155,7 +156,7 @@ func (f *FeeManager) SuggestedFees(ctx context.Context, chainID uint64, address 
 		noPriorityFee = lowPriorityFeePerGasLowerBound == nil || lowPriorityFeePerGasLowerBound.Cmp(common.ZeroBigIntValue()) == 0
 	} else {
 		lowPriorityFeePerGasLowerBound, mediumPriorityFeePerGas, maxPriorityFeePerGasUpperBound, baseFee, err = getEIP1559SuggestedFees(chainID, feeHistory)
-		if err != nil {
+		if err != nil || len(feeHistory.Reward) < int(blockCount) {
 			suggestedFees, err = f.getNonEIP1559SuggestedFees(ctx, chainID)
 			return
 		}

--- a/services/wallet/router/fees/fees.go
+++ b/services/wallet/router/fees/fees.go
@@ -220,13 +220,19 @@ func (f *FeeManager) SuggestedFeesGwei(ctx context.Context, chainID uint64) (*Su
 	if err != nil {
 		return nil, err
 	}
-	return &SuggestedFeesGwei{
-		GasPrice:             common.WeiToGwei(fees.GasPrice),
-		BaseFee:              common.WeiToGwei(fees.BaseFee),
-		MaxPriorityFeePerGas: common.WeiToGwei(fees.MaxPriorityFeePerGas),
-		MaxFeePerGasLow:      common.WeiToGwei(fees.MaxFeesLevels.Low.ToInt()),
-		MaxFeePerGasMedium:   common.WeiToGwei(fees.MaxFeesLevels.Medium.ToInt()),
-		MaxFeePerGasHigh:     common.WeiToGwei(fees.MaxFeesLevels.High.ToInt()),
-		EIP1559Enabled:       fees.EIP1559Enabled,
-	}, nil
+	feesGwei := &SuggestedFeesGwei{
+		EIP1559Enabled: fees.EIP1559Enabled,
+	}
+	if feesGwei.EIP1559Enabled {
+		feesGwei.GasPrice = common.WeiToGwei(fees.GasPrice)
+		feesGwei.BaseFee = common.WeiToGwei(fees.BaseFee)
+		feesGwei.MaxPriorityFeePerGas = common.WeiToGwei(fees.MaxPriorityFeePerGas)
+		feesGwei.MaxFeePerGasLow = common.WeiToGwei(fees.MaxFeesLevels.Low.ToInt())
+		feesGwei.MaxFeePerGasMedium = common.WeiToGwei(fees.MaxFeesLevels.Medium.ToInt())
+		feesGwei.MaxFeePerGasHigh = common.WeiToGwei(fees.MaxFeesLevels.High.ToInt())
+	} else {
+		feesGwei.GasPrice = common.WeiToGwei(fees.NonEIP1559Fees.GasPrice.ToInt())
+	}
+
+	return feesGwei, nil
 }

--- a/services/wallet/router/fees/fees_history.go
+++ b/services/wallet/router/fees/fees_history.go
@@ -18,14 +18,14 @@ type FeeHistory struct {
 	Reward        [][]string `json:"reward,omitempty"`
 }
 
-func (f *FeeManager) getFeeHistory(ctx context.Context, chainID uint64, newestBlock string, rewardPercentiles []int) (*FeeHistory, error) {
-	blockCount := uint64(10) // use the last 10 blocks for L1 chains
-	if chainID != walletCommon.EthereumMainnet &&
-		chainID != walletCommon.EthereumSepolia &&
-		chainID != walletCommon.AnvilMainnet {
-		blockCount = 50 // use the last 50 blocks for L2 chains
+func getFeeHistoryBlockCount(chainID uint64) uint64 {
+	if chainID == walletCommon.EthereumMainnet || chainID == walletCommon.EthereumSepolia || chainID == walletCommon.AnvilMainnet {
+		return 10 // use the last 10 blocks for L1 chains
 	}
+	return 50 // use the last 50 blocks for L2 chains
+}
 
+func (f *FeeManager) getFeeHistory(ctx context.Context, chainID uint64, blockCount uint64, newestBlock string, rewardPercentiles []int) (*FeeHistory, error) {
 	feeHistory := &FeeHistory{}
 	err := f.RPCClient.Call(feeHistory, chainID, "eth_feeHistory", blockCount, newestBlock, rewardPercentiles)
 	return feeHistory, err

--- a/services/wallet/router/fees/fees_history.go
+++ b/services/wallet/router/fees/fees_history.go
@@ -18,26 +18,6 @@ type FeeHistory struct {
 	Reward        [][]string `json:"reward,omitempty"`
 }
 
-func (fh *FeeHistory) isEIP1559Compatible(chainID uint64) bool {
-	// Since the Status Network is gasless chain, but EIP-1559 compatible, we should not rely on checking the BaseFeePerGas, that's why we have this special case.
-	eip1559Enabled, err := walletCommon.IsPartiallyOrFullyGaslessChainEIP1559Compatible(chainID)
-	if err == nil {
-		return eip1559Enabled
-	}
-
-	if len(fh.BaseFeePerGas) == 0 {
-		return false
-	}
-
-	for _, fee := range fh.BaseFeePerGas {
-		if fee != "0x0" {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (f *FeeManager) getFeeHistory(ctx context.Context, chainID uint64, newestBlock string, rewardPercentiles []int) (*FeeHistory, error) {
 	blockCount := uint64(10) // use the last 10 blocks for L1 chains
 	if chainID != walletCommon.EthereumMainnet &&

--- a/services/wallet/router/fees/suggested_priority.go
+++ b/services/wallet/router/fees/suggested_priority.go
@@ -69,7 +69,7 @@ func (f *FeeManager) getNonEIP1559SuggestedFees(ctx context.Context, chainID uin
 // getEIP1559SuggestedFees returns suggested fees for EIP-1559 compatible chains
 // source https://github.com/brave/brave-core/blob/master/components/brave_wallet/browser/eth_gas_utils.cc
 func getEIP1559SuggestedFees(chainID uint64, feeHistory *FeeHistory) (lowPriorityFee, avgPriorityFee, highPriorityFee, suggestedBaseFee *big.Int, err error) {
-	if feeHistory == nil || !feeHistory.isEIP1559Compatible(chainID) {
+	if feeHistory == nil {
 		return nil, nil, nil, nil, ErrEIP1559IncompaibleChain
 	}
 


### PR DESCRIPTION
EIP1559 support check didn't work properly since the base fee is fixed at 0 on that chain. Removing the check since the chains we support are all EIP1559-enabled anyway.
Also we got some wrong fee suggestions when `eth_feeHistory` returns info for fewer blocks than what we ask for. Falling back to legacy fees in that case.