### PR TITLE
ci: skip intel MacOS hosts

### DIFF
--- a/_assets/ci/Jenkinsfile.desktop
+++ b/_assets/ci/Jenkinsfile.desktop
@@ -62,7 +62,7 @@ pipeline {
     GO_GENERATE_FAST_DIR = "${env.WORKSPACE_TMP}/go-generate-fast"
     /* Ensure env var is set on first run. */
     USE_NWAKU = "${params.USE_NWAKU}"
-
+    AGENT_LABEL = "${params.AGENT_LABEL}"
     /* fixes nim cache collision */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
   }


### PR DESCRIPTION
## Summary

Desktop PR jobs will now skip Intel MacOS hosts due to the change in label logic.
Intel MacOS hosts are only required for Nimbus builds, we could skip building status-go on that host.
