### PR TITLE
test: add more connector service tests

### DIFF
--- a/tests-functional/clients/connector.py
+++ b/tests-functional/clients/connector.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import requests
+from typing import Any, Dict, List
 import websocket
 from websocket import WebSocket
 from websocket import create_connection
@@ -38,16 +39,43 @@ class ConnectorClient:
         if self.ws_conn is not None:
             self.ws_conn.close()
 
-    def accounts(self):
-        self._send("eth_accounts")
-
-    def chain_id(self):
+    def eth_chain_id(self):
         self._send("eth_chainId")
 
-    def block_number(self):
+    def eth_accounts(self):
+        self._send("eth_accounts")
+
+    def eth_request_accounts(self):
+        self._send("eth_requestAccounts")
+
+    def eth_block_number(self):
         self._send("eth_blockNumber")
 
-    def revoke_permissions(self):
+    def eth_get_balance(self, address: str):
+        self._send("eth_getBalance", [address, "latest"])
+
+    def eth_get_transaction_count(self, address: str):
+        self._send("eth_getTransactionCount", [address, "latest"])
+
+    def eth_call(self, call_object: Dict[str, Any]):
+        params: List[Any] = [call_object, "latest"]
+        self._send("eth_call", params)
+
+    def eth_estimate_gas(self, tx_object: Dict[str, Any]):
+        params: List[Any] = [tx_object]
+        self._send("eth_estimateGas", params)
+
+    def eth_get_transaction_receipt(self, tx_hash: str):
+        self._send("eth_getTransactionReceipt", [tx_hash])
+
+    def eth_send_transaction(self, tx_object: Dict[str, Any]):
+        self._send("eth_sendTransaction", [tx_object])
+
+    def wallet_switch_ethereum_chain(self, chain_id: int):
+        hex_chain_id = hex(chain_id)
+        self._send("wallet_switchEthereumChain", [{"chainId": hex_chain_id}])
+
+    def wallet_revoke_permissions(self):
         self._send("wallet_revokePermissions")
 
     def _send(self, method, params=None):

--- a/tests-functional/clients/connector.py
+++ b/tests-functional/clients/connector.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import requests
-from typing import Any, Dict, List
+from typing import Any, Dict
 import websocket
 from websocket import WebSocket
 from websocket import create_connection
@@ -58,12 +58,10 @@ class ConnectorClient:
         self._send("eth_getTransactionCount", [address, "latest"])
 
     def eth_call(self, call_object: Dict[str, Any]):
-        params: List[Any] = [call_object, "latest"]
-        self._send("eth_call", params)
+        self._send("eth_call", [call_object, "latest"])
 
     def eth_estimate_gas(self, tx_object: Dict[str, Any]):
-        params: List[Any] = [tx_object]
-        self._send("eth_estimateGas", params)
+        self._send("eth_estimateGas", [tx_object])
 
     def eth_get_transaction_receipt(self, tx_hash: str):
         self._send("eth_getTransactionReceipt", [tx_hash])
@@ -72,8 +70,7 @@ class ConnectorClient:
         self._send("eth_sendTransaction", [tx_object])
 
     def wallet_switch_ethereum_chain(self, chain_id: int):
-        hex_chain_id = hex(chain_id)
-        self._send("wallet_switchEthereumChain", [{"chainId": hex_chain_id}])
+        self._send("wallet_switchEthereumChain", [{"chainId": hex(chain_id)}])
 
     def wallet_revoke_permissions(self):
         self._send("wallet_revokePermissions")

--- a/tests-functional/clients/connector.py
+++ b/tests-functional/clients/connector.py
@@ -38,13 +38,13 @@ class ConnectorClient:
         if self.ws_conn is not None:
             self.ws_conn.close()
 
-    def get_accounts(self):
+    def accounts(self):
         self._send("eth_accounts")
 
-    def get_chain_id(self):
+    def chain_id(self):
         self._send("eth_chainId")
 
-    def get_block_number(self):
+    def block_number(self):
         self._send("eth_blockNumber")
 
     def revoke_permissions(self):

--- a/tests-functional/clients/connector.py
+++ b/tests-functional/clients/connector.py
@@ -10,9 +10,14 @@ class ConnectorClient:
     def __init__(self, url: str):
         self.url = url
         self.ws_conn: WebSocket | None = None
-        self.request_id = 0
+        self._request_id = 0
         self.wrapped_request_id = 0
         self.name = ""
+
+    @property
+    def request_id(self) -> int:
+        self._request_id += 1
+        return self._request_id
 
     def connect(self):
         http_url = self.url.replace("ws", "http")
@@ -34,26 +39,45 @@ class ConnectorClient:
             self.ws_conn.close()
 
     def get_accounts(self):
+        self._send("eth_accounts")
+
+    def get_chain_id(self):
+        self._send("eth_chainId")
+
+    def get_block_number(self):
+        self._send("eth_blockNumber")
+
+    def revoke_permissions(self):
+        self._send("wallet_revokePermissions")
+
+    def _send(self, method, params=None):
         assert self.ws_conn is not None
 
-        self.request_id += 1
-
+        request_id = self.request_id
         request = {
             "jsonrpc": "2.0",
-            "id": self.request_id,
+            "id": request_id,
             "name": self.name,
             "url": "http://localhost/",
-            "method": "eth_accounts",
+            "method": method,
         }
+        if params is not None:
+            request["params"] = params
+
         wrapped_request = {
             "jsonrpc": "2.0",
-            "id": self.request_id,
+            "id": request_id,
             "method": "connector_callRPC",
             "params": [json.dumps(request)],
         }
 
+        logging.debug(f"Sending Connector request with data: {json.dumps(wrapped_request, sort_keys=True)}")
         self.ws_conn.send(json.dumps(wrapped_request), websocket.ABNF.OPCODE_TEXT)
 
     def receive(self):
         assert self.ws_conn is not None
-        return self.ws_conn.recv()
+
+        response = self.ws_conn.recv()
+        logging.debug(f"Got Connector response: {json.dumps(response, sort_keys=True)}")
+
+        return json.loads(response)

--- a/tests-functional/clients/services/connector.py
+++ b/tests-functional/clients/services/connector.py
@@ -14,3 +14,11 @@ class ConnectorService(Service):
         }
         response = self.rpc_request("requestAccountsAccepted", [params])
         return response.json()
+
+    def send_transaction_accepted(self, request_id: str, tx_hash: str):
+        params = {
+            "requestId": request_id,
+            "hash": tx_hash,
+        }
+        response = self.rpc_request("sendTransactionAccepted", [params])
+        return response.json()

--- a/tests-functional/tests/test_status_connector.py
+++ b/tests-functional/tests/test_status_connector.py
@@ -4,6 +4,27 @@ from clients.connector import ConnectorClient
 from clients.signals import SignalType
 
 
+def wait_event(backend, signal_type):
+    signal = backend.wait_for_signal(signal_type)
+    return signal.get("event")
+
+
+def accept_connector(backend, connector, wallet_acc):
+    # Expect SEND_REQUEST_ACCOUNTS signal, check dApp name
+    event = wait_event(backend, SignalType.CONNECTOR_SEND_REQUEST_ACCOUNTS.value)
+    assert event.get("name") == connector.name
+
+    # Accept request
+    response = backend.connector_service.request_accounts_accepted(event.get("requestId"), wallet_acc, backend.network_id)
+    assert response.get("error") is None
+
+    # Expect DAPP_PERMISSION_GRANTED signal, check dApp name, shared account and chain ID
+    event = wait_event(backend, SignalType.CONNECTOR_DAPP_PERMISSION_GRANTED.value)
+    assert event.get("name") == connector.name
+    assert event.get("sharedAccount") == wallet_acc
+    assert len(event.get("chains")) == 1 and event.get("chains")[0] == backend.network_id
+
+
 @pytest.mark.rpc
 @pytest.mark.connector
 class TestStatusConnector:
@@ -29,70 +50,59 @@ class TestStatusConnector:
         yield client
         client.disconnect()
 
-    def test_get_chain_id_resolved_before_connection(self, backend, connector):
-        connector.get_chain_id()
+    @pytest.fixture
+    def wallet_account(self, backend):
+        # Load actual wallet account directly from backend
+        accs = backend.accounts_service.get_accounts()["result"]
+        wallet_acc = next((acc.get("address") for acc in accs if acc.get("wallet") is True), None)
+        assert wallet_acc is not None
+        return wallet_acc
+
+    def test_chain_id_resolved_before_connection(self, backend, connector):
+        connector.chain_id()
 
         message = connector.receive()
         chain_id = int(message.get("result"), 16)
         assert chain_id == backend.network_id
 
     def test_other_methods_not_resolved_before_connection(self, connector):
-        connector.get_block_number()
+        connector.block_number()
 
         message = connector.receive()
         assert message.get("error").get("message") == "dApp is not permitted by user"
 
-    def test_connect_and_get_accounts(self, backend, connector):
-        # Load actual directly from backend
-        wallet_acc = self._get_wallet_account(backend)
-        assert wallet_acc is not None
-
+    def test_connect_and_accounts(self, backend, connector, wallet_account):
         # Request accounts through connector
-        connector.get_accounts()
-
-        # Expect SEND_REQUEST_ACCOUNTS signal, check dApp name
-        event = self._get_event(backend, SignalType.CONNECTOR_SEND_REQUEST_ACCOUNTS.value)
-        assert event.get("name") == connector.name
-        request_id = event.get("requestId")
-
-        # Accept request
-        response = backend.connector_service.request_accounts_accepted(request_id, wallet_acc, backend.network_id)
-        assert response.get("error") is None
-
-        # Expect DAPP_PERMISSION_GRANTED signal, check dApp name, shared account and chain ID
-        event = self._get_event(backend, SignalType.CONNECTOR_DAPP_PERMISSION_GRANTED.value)
-        assert event.get("name") == connector.name
-        assert event.get("sharedAccount") == wallet_acc
-        assert len(event.get("chains")) == 1 and event.get("chains")[0] == backend.network_id
+        # And accept connection request
+        connector.accounts()
+        accept_connector(backend, connector, wallet_account)
 
         # Receive accounts on connector
         message = connector.receive()
         assert message.get("result") is not None
         accounts = message.get("result")
         assert len(accounts) == 1
-        assert accounts[0] == wallet_acc
+        assert accounts[0] == wallet_account
 
-    def test_other_methods_resolved_after_connection(self, backend, connector):
-        # Request accounts through connector and connect
-        wallet_acc = self._get_wallet_account(backend)
-        connector.get_accounts()
-        request_id = self._get_event(backend, SignalType.CONNECTOR_SEND_REQUEST_ACCOUNTS.value).get("requestId")
-        backend.connector_service.request_accounts_accepted(request_id, wallet_acc, backend.network_id)
+    def test_block_number_resolved_after_connection(self, backend, connector, wallet_account):
+        # Request accounts through connector
+        # And accept connection request
+        connector.accounts()
+        accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
 
-        # Other methods are resolved after connection
-        connector.get_block_number()
+        # Block Number is resolved after connection
+        connector.block_number()
 
         message = connector.receive()
         assert message.get("result") is not None
 
-    def test_revoke_permissions_on_disconnect(self, backend, connector):
-        # Request accounts through connector and connect
-        wallet_acc = self._get_wallet_account(backend)
-        connector.get_accounts()
-        request_id = self._get_event(backend, SignalType.CONNECTOR_SEND_REQUEST_ACCOUNTS.value).get("requestId")
-        backend.connector_service.request_accounts_accepted(request_id, wallet_acc, backend.network_id)
+    def test_revoke_permissions_on_disconnect(self, backend, connector, wallet_account):
+        # Request accounts through connector
+        # And accept connection request
+        connector.accounts()
+        accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
 
@@ -103,15 +113,5 @@ class TestStatusConnector:
         assert message.get("error") is None
 
         # Expect DAPP_PERMISSION_REVOKED signal, check dApp name
-        event = self._get_event(backend, SignalType.CONNECTOR_DAPP_PERMISSION_REVOKED.value)
+        event = wait_event(backend, SignalType.CONNECTOR_DAPP_PERMISSION_REVOKED.value)
         assert event.get("name") == connector.name
-
-    def _get_wallet_account(self, backend):
-        accs = backend.accounts_service.get_accounts()["result"]
-        wallet_acc = next((acc.get("address") for acc in accs if acc.get("wallet") is True), None)
-        return wallet_acc
-
-    def _get_event(self, backend, signal_type):
-        signal = backend.wait_for_signal(signal_type)
-        event = signal.get("event")
-        return event

--- a/tests-functional/tests/test_status_connector.py
+++ b/tests-functional/tests/test_status_connector.py
@@ -59,22 +59,15 @@ class TestStatusConnector:
         return wallet_acc
 
     def test_chain_id_resolved_before_connection(self, backend, connector):
-        connector.chain_id()
+        connector.eth_chain_id()
 
         message = connector.receive()
-        chain_id = int(message.get("result"), 16)
-        assert chain_id == backend.network_id
-
-    def test_other_methods_not_resolved_before_connection(self, connector):
-        connector.block_number()
-
-        message = connector.receive()
-        assert message.get("error").get("message") == "dApp is not permitted by user"
+        assert message.get("result") == hex(backend.network_id)
 
     def test_connect_and_accounts(self, backend, connector, wallet_account):
         # Request accounts through connector
+        connector.eth_accounts()
         # And accept connection request
-        connector.accounts()
         accept_connector(backend, connector, wallet_account)
 
         # Receive accounts on connector
@@ -84,30 +77,197 @@ class TestStatusConnector:
         assert len(accounts) == 1
         assert accounts[0] == wallet_account
 
-    def test_block_number_resolved_after_connection(self, backend, connector, wallet_account):
-        # Request accounts through connector
-        # And accept connection request
-        connector.accounts()
+    def test_connect_and_request_accounts(self, backend, connector, wallet_account):
+        # Request accounts through connector using eth_requestAccounts
+        connector.eth_request_accounts()
+        # Accept connection request
+        accept_connector(backend, connector, wallet_account)
+
+        # Receive accounts on connector
+        message = connector.receive()
+        assert message.get("result") is not None
+        accounts = message.get("result")
+        assert len(accounts) == 1
+        assert accounts[0] == wallet_account
+
+    def test_block_number(self, backend, connector, wallet_account):
+        # Block Number not resolved before connection
+        connector.eth_block_number()
+        message = connector.receive()
+        assert message.get("error").get("message") == "dApp is not permitted by user"
+
+        # Establish connection
+        connector.eth_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
 
         # Block Number is resolved after connection
-        connector.block_number()
+        connector.eth_block_number()
 
         message = connector.receive()
+        result = message.get("result")
+        assert int(result, 16) >= 0
+
+    def test_get_balance(self, backend, connector, wallet_account):
+        # Get balance not resolved before connection
+        connector.eth_get_balance(wallet_account)
+        message = connector.receive()
+        assert message.get("error").get("message") == "dApp is not permitted by user"
+
+        # Establish connection
+        connector.eth_accounts()
+        accept_connector(backend, connector, wallet_account)
+        message = connector.receive()
         assert message.get("result") is not None
+
+        # Get balance is resolved after connection
+        connector.eth_get_balance(wallet_account)
+        message = connector.receive()
+        result = message.get("result")
+        assert result.startswith("0x")
+        assert int(result, 16) >= 0
+
+    def test_get_transaction_count(self, backend, connector, wallet_account):
+        # Get transaction count not resolved before connection
+        connector.eth_get_transaction_count(wallet_account)
+        message = connector.receive()
+        assert message.get("error").get("message") == "dApp is not permitted by user"
+
+        # Establish connection
+        connector.eth_accounts()
+        accept_connector(backend, connector, wallet_account)
+        message = connector.receive()
+        assert message.get("result") is not None
+
+        # Get transaction count is resolved after connection
+        connector.eth_get_transaction_count(wallet_account)
+        message = connector.receive()
+        result = message.get("result")
+        assert result.startswith("0x")
+        assert int(result, 16) >= 0
+
+    def test_eth_call(self, backend, connector, wallet_account):
+        # eth_call not resolved before connection
+        call_object = {"to": "0x0000000000000000000000000000000000000000", "data": "0x"}
+        connector.eth_call(call_object)
+        message = connector.receive()
+        assert message.get("error").get("message") == "dApp is not permitted by user"
+
+        # Establish connection
+        connector.eth_accounts()
+        accept_connector(backend, connector, wallet_account)
+        message = connector.receive()
+        assert message.get("result") is not None
+
+        # eth_call is resolved after connection
+        connector.eth_call(call_object)
+        message = connector.receive()
+        result = message.get("result")
+        assert result == "0x"
+
+    def test_estimate_gas_resolved(self, backend, connector, wallet_account):
+        # Estimate gas not resolved before connection
+        # Simple 0-value transfer to self
+        tx = {"from": wallet_account, "to": wallet_account, "value": "0x0"}
+        connector.eth_estimate_gas(tx)
+        message = connector.receive()
+        assert message.get("error").get("message") == "dApp is not permitted by user"
+
+        # Establish connection
+        connector.eth_accounts()
+        accept_connector(backend, connector, wallet_account)
+        message = connector.receive()
+        assert message.get("result") is not None
+
+        # Estimate gas is resolved after connection
+        connector.eth_estimate_gas(tx)
+        message = connector.receive()
+        result = message.get("result")
+        assert result.startswith("0x")
+        assert int(result, 16) == 21000  # minimum gas limit
+
+    def test_get_transaction_receipt(self, backend, connector, wallet_account):
+        # Get transaction receipt not resolved before connection
+        fake_tx = "0x" + "0" * 64
+        connector.eth_get_transaction_receipt(fake_tx)
+        message = connector.receive()
+        assert message.get("error").get("message") == "dApp is not permitted by user"
+
+        # Establish connection
+        connector.eth_accounts()
+        accept_connector(backend, connector, wallet_account)
+        message = connector.receive()
+        assert message.get("result") is not None
+
+        # Query a non-existent tx receipt should return null result
+        connector.eth_get_transaction_receipt(fake_tx)
+        message = connector.receive()
+        assert message.get("error") is None
+
+    def test_send_transaction_flow(self, backend, connector, wallet_account):
+        # Send transaction not resolved before connection
+        tx = {
+            "from": wallet_account,
+            "to": wallet_account,
+            "value": "0x0",
+        }
+        connector.eth_send_transaction(tx)
+        message = connector.receive()
+        assert message.get("error").get("message") == "dApp is not permitted by user"
+
+        # Establish connection
+        connector.eth_accounts()
+        accept_connector(backend, connector, wallet_account)
+        message = connector.receive()
+        assert message.get("result") is not None
+
+        # Initiate send transaction
+        connector.eth_send_transaction(tx)
+
+        # Wait for signal and approve with a dummy tx hash
+        event = wait_event(backend, SignalType.CONNECTOR_SEND_TRANSACTION.value)
+        request_id = event.get("requestId")
+        fake_hash = "0x" + "1" * 64
+        response = backend.connector_service.send_transaction_accepted(request_id, fake_hash)
+        assert response.get("error") is None
+
+        # Connector should now receive the tx hash as result
+        message = connector.receive()
+        assert message.get("error") is None
+        assert message.get("result") == fake_hash
+
+    def test_wallet_switch_ethereum_chain(self, backend, connector, wallet_account):
+        # Switch chain not resolved before connection
+        connector.wallet_switch_ethereum_chain(backend.network_id)
+        message = connector.receive()
+        assert message.get("error").get("message") == "dApp is not permitted by user"
+
+        # Establish connection
+        connector.eth_accounts()
+        accept_connector(backend, connector, wallet_account)
+        message = connector.receive()
+        assert message.get("result") is not None
+
+        # Switch to the same chain ID
+        connector.wallet_switch_ethereum_chain(backend.network_id)
+        message = connector.receive()
+        assert message.get("error") is None
+
+        # Expect CHAIN_ID_SWITCHED signal, verify chain ID
+        event = wait_event(backend, SignalType.CONNECTOR_DAPP_CHAIN_ID_SWITCHED.value)
+        assert event.get("chainId") == hex(backend.network_id)
 
     def test_revoke_permissions_on_disconnect(self, backend, connector, wallet_account):
         # Request accounts through connector
         # And accept connection request
-        connector.accounts()
+        connector.eth_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
 
         # Handle Revoke Permissions before disconnect
-        connector.revoke_permissions()
+        connector.wallet_revoke_permissions()
 
         message = connector.receive()
         assert message.get("error") is None

--- a/tests-functional/tests/test_status_connector.py
+++ b/tests-functional/tests/test_status_connector.py
@@ -237,7 +237,7 @@ class TestStatusConnector:
         assert message.get("error") is None
         assert message.get("result") == fake_hash
 
-    def test_wallet_switch_ethereum_chain(self, backend, connector, wallet_account):
+    def test_switch_ethereum_chain(self, backend, connector, wallet_account):
         # Switch chain not resolved before connection
         connector.wallet_switch_ethereum_chain(backend.network_id)
         message = connector.receive()

--- a/tests-functional/tests/test_status_connector.py
+++ b/tests-functional/tests/test_status_connector.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 
 from clients.connector import ConnectorClient
@@ -30,35 +29,89 @@ class TestStatusConnector:
         yield client
         client.disconnect()
 
-    def test_get_accounts(self, backend, connector):
+    def test_get_chain_id_resolved_before_connection(self, backend, connector):
+        connector.get_chain_id()
+
+        message = connector.receive()
+        chain_id = int(message.get("result"), 16)
+        assert chain_id == backend.network_id
+
+    def test_other_methods_not_resolved_before_connection(self, connector):
+        connector.get_block_number()
+
+        message = connector.receive()
+        assert message.get("error").get("message") == "dApp is not permitted by user"
+
+    def test_connect_and_get_accounts(self, backend, connector):
         # Load actual directly from backend
-        accs = backend.accounts_service.get_accounts()["result"]
-        wallet_acc = next((acc.get("address") for acc in accs if acc.get("wallet") is True), None)
+        wallet_acc = self._get_wallet_account(backend)
         assert wallet_acc is not None
 
         # Request accounts through connector
         connector.get_accounts()
 
         # Expect SEND_REQUEST_ACCOUNTS signal, check dApp name
-        signal = backend.wait_for_signal(SignalType.CONNECTOR_SEND_REQUEST_ACCOUNTS.value)
-        event = signal.get("event")
+        event = self._get_event(backend, SignalType.CONNECTOR_SEND_REQUEST_ACCOUNTS.value)
         assert event.get("name") == connector.name
+        request_id = event.get("requestId")
 
         # Accept request
-        response = backend.connector_service.request_accounts_accepted(event.get("requestId"), wallet_acc, backend.network_id)
+        response = backend.connector_service.request_accounts_accepted(request_id, wallet_acc, backend.network_id)
         assert response.get("error") is None
 
         # Expect DAPP_PERMISSION_GRANTED signal, check dApp name, shared account and chain ID
-        signal = backend.wait_for_signal(SignalType.CONNECTOR_DAPP_PERMISSION_GRANTED.value)
-        event = signal.get("event")
+        event = self._get_event(backend, SignalType.CONNECTOR_DAPP_PERMISSION_GRANTED.value)
         assert event.get("name") == connector.name
         assert event.get("sharedAccount") == wallet_acc
         assert len(event.get("chains")) == 1 and event.get("chains")[0] == backend.network_id
 
         # Receive accounts on connector
         message = connector.receive()
-        message = json.loads(message)
         assert message.get("result") is not None
         accounts = message.get("result")
         assert len(accounts) == 1
         assert accounts[0] == wallet_acc
+
+    def test_other_methods_resolved_after_connection(self, backend, connector):
+        # Request accounts through connector and connect
+        wallet_acc = self._get_wallet_account(backend)
+        connector.get_accounts()
+        request_id = self._get_event(backend, SignalType.CONNECTOR_SEND_REQUEST_ACCOUNTS.value).get("requestId")
+        backend.connector_service.request_accounts_accepted(request_id, wallet_acc, backend.network_id)
+        message = connector.receive()
+        assert message.get("result") is not None
+
+        # Other methods are resolved after connection
+        connector.get_block_number()
+
+        message = connector.receive()
+        assert message.get("result") is not None
+
+    def test_revoke_permissions_on_disconnect(self, backend, connector):
+        # Request accounts through connector and connect
+        wallet_acc = self._get_wallet_account(backend)
+        connector.get_accounts()
+        request_id = self._get_event(backend, SignalType.CONNECTOR_SEND_REQUEST_ACCOUNTS.value).get("requestId")
+        backend.connector_service.request_accounts_accepted(request_id, wallet_acc, backend.network_id)
+        message = connector.receive()
+        assert message.get("result") is not None
+
+        # Handle Revoke Permissions before disconnect
+        connector.revoke_permissions()
+
+        message = connector.receive()
+        assert message.get("error") is None
+
+        # Expect DAPP_PERMISSION_REVOKED signal, check dApp name
+        event = self._get_event(backend, SignalType.CONNECTOR_DAPP_PERMISSION_REVOKED.value)
+        assert event.get("name") == connector.name
+
+    def _get_wallet_account(self, backend):
+        accs = backend.accounts_service.get_accounts()["result"]
+        wallet_acc = next((acc.get("address") for acc in accs if acc.get("wallet") is True), None)
+        return wallet_acc
+
+    def _get_event(self, backend, signal_type):
+        signal = backend.wait_for_signal(signal_type)
+        event = signal.get("event")
+        return event


### PR DESCRIPTION
Closes [6889](https://github.com/status-im/status-go/issues/6889)

Changes:
- add more tests for `connector` service:
  - `test_chain_id_resolved_before_connection`
  - `test_connect_and_accounts`
  - `test_connect_and_request_accounts`
  - `test_block_number`
  - `test_get_balance`
  - `test_get_transaction_count`
  - `test_eth_call`
  - `test_estimate_gas_resolved`
  - `test_get_transaction_receipt`
  - `test_send_transaction_flow`
  - `test_switch_ethereum_chain`
  - `test_revoke_permissions_on_disconnect`
