### PR TITLE
refactor: DataDir removed from NodeConfig cause RootDataDir already has an absolute path to data dir

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -706,14 +706,13 @@ func TestRuntimeLogLevelIsNotWrittenToDatabase(t *testing.T) {
 
 	json := `{
 		"NetworkId": 3,
-		"DataDir": "` + testContext.config.DataDir + `",
-		"KeycardPairingDataFile": "` + path.Join(testContext.config.DataDir, "keycard/pairings.json") + `",
+		"KeycardPairingDataFile": "` + path.Join(testContext.config.RootDataDir, "keycard/pairings.json") + `",
 		"NoDiscovery": true,
 		"TorrentConfig": {
 			"Port": 9025,
 			"Enabled": false,
-			"DataDir": "` + testContext.config.DataDir + `/archivedata",
-			"TorrentDir": "` + testContext.config.DataDir + `/torrents"
+			"DataDir": "` + testContext.config.RootDataDir + `/archivedata",
+			"TorrentDir": "` + testContext.config.RootDataDir + `/torrents"
 		},
 		"RuntimeLogLevel": "INFO",
 		"LogLevel": "DEBUG"
@@ -730,7 +729,7 @@ func TestRuntimeLogLevelIsNotWrittenToDatabase(t *testing.T) {
 	require.NoError(t, err)
 
 	request := &requests.CreateAccount{
-		RootDataDir:   testContext.config.DataDir,
+		RootDataDir:   testContext.config.RootDataDir,
 		Password:      testPassword,
 		KdfIterations: 1,
 	}
@@ -771,8 +770,8 @@ func TestLoginAccount(t *testing.T) {
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
 		Password:           testPassword,
-		RootDataDir:        testContext.config.DataDir,
-		LogFilePath:        testContext.config.DataDir + "/log",
+		RootDataDir:        testContext.config.RootDataDir,
+		LogFilePath:        testContext.config.RootDataDir + "/log",
 		WakuV2Nameserver:   &nameserver,
 		WakuV2Fleet:        "status.staging",
 	}
@@ -804,7 +803,7 @@ func TestLoginAccount(t *testing.T) {
 	require.NoError(t, testContext.backend.Logout())
 	require.NoError(t, testContext.backend.StopNode())
 
-	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
+	testContext.backend.UpdateRootDataDir(testContext.config.RootDataDir)
 
 	accounts, err := testContext.backend.GetAccounts()
 	require.NoError(t, err)
@@ -830,7 +829,7 @@ func TestVerifyDatabasePassword(t *testing.T) {
 	testContext := setupTestContext(t, testPassword, false, false, false)
 
 	request := &requests.CreateAccount{
-		RootDataDir:   testContext.config.DataDir,
+		RootDataDir:   testContext.config.RootDataDir,
 		Password:      testPassword,
 		KdfIterations: 1,
 	}
@@ -854,7 +853,7 @@ func TestConvertAccount(t *testing.T) {
 	testContext := setupTestContext(t, testPassword, false, false, true)
 
 	request := &requests.CreateAccount{
-		RootDataDir:   testContext.config.DataDir,
+		RootDataDir:   testContext.config.RootDataDir,
 		Password:      testPassword,
 		KdfIterations: 1,
 	}
@@ -1016,7 +1015,7 @@ func loginDesktopUser(t *testing.T, conf *params.NodeConfig, keyUID string) {
 
 	b := NewGethStatusBackend(tt.MustCreateTestLogger())
 
-	b.UpdateRootDataDir(conf.DataDir)
+	b.UpdateRootDataDir(conf.RootDataDir)
 
 	require.NoError(t, b.OpenAccounts())
 
@@ -1107,7 +1106,7 @@ func TestChangeDatabasePassword(t *testing.T) {
 	err = testContext.backend.ChangeDatabasePassword(testContext.profileKeypair.KeyUID, testPassword, newPassword)
 	require.NoError(t, err)
 
-	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
+	testContext.backend.UpdateRootDataDir(testContext.config.RootDataDir)
 
 	// Test that keystore can be decrypted with the new password
 	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(masterAddress, newPassword)
@@ -1132,8 +1131,8 @@ func TestCreateWallet(t *testing.T) {
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
 		Password:           testPassword,
-		RootDataDir:        testContext.config.DataDir,
-		LogFilePath:        testContext.config.DataDir + "/log",
+		RootDataDir:        testContext.config.RootDataDir,
+		LogFilePath:        testContext.config.RootDataDir + "/log",
 	}
 
 	c := make(chan interface{}, 10)
@@ -1194,8 +1193,8 @@ func TestSetFleet(t *testing.T) {
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
 		Password:           testPassword,
-		RootDataDir:        testContext.config.DataDir,
-		LogFilePath:        testContext.config.DataDir + "/log",
+		RootDataDir:        testContext.config.RootDataDir,
+		LogFilePath:        testContext.config.RootDataDir + "/log",
 	}
 
 	c := make(chan interface{}, 10)
@@ -1227,7 +1226,7 @@ func TestSetFleet(t *testing.T) {
 
 	require.NoError(t, testContext.backend.Logout())
 
-	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
+	testContext.backend.UpdateRootDataDir(testContext.config.RootDataDir)
 
 	loginAccountRequest := &requests.Login{
 		KeyUID:   newAccount.KeyUID,
@@ -1265,8 +1264,8 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
 		Password:           testPassword,
-		RootDataDir:        testContext.config.DataDir,
-		LogFilePath:        testContext.config.DataDir + "/log",
+		RootDataDir:        testContext.config.RootDataDir,
+		LogFilePath:        testContext.config.RootDataDir + "/log",
 	}
 	c := make(chan interface{}, 10)
 	signal.SetMobileSignalHandler(func(data []byte) {
@@ -1295,7 +1294,7 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 		},
 	}
 
-	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
+	testContext.backend.UpdateRootDataDir(testContext.config.RootDataDir)
 
 	require.NoError(t, testContext.backend.LoginAccount(loginAccountRequest))
 	select {
@@ -1422,7 +1421,7 @@ func TestAcceptTerms(t *testing.T) {
 	conf, err := params.NewNodeConfig(tmpdir, 1777)
 	require.NoError(t, err)
 
-	b.UpdateRootDataDir(conf.DataDir)
+	b.UpdateRootDataDir(conf.RootDataDir)
 	require.NoError(t, b.OpenAccounts())
 	nameserver := "8.8.8.8"
 	createAccountRequest := &requests.CreateAccount{
@@ -1572,7 +1571,7 @@ func TestRestoreKeycardAccountAndLogin(t *testing.T) {
 			"torrentConfigEnabled":   false,
 			"torrentConfigPort":      0,
 			"keycardInstanceUID":     "a84599394887b742eed9a99d3834a797",
-			"keycardPairingDataFile": path.Join(tmpdir, DefaultKeycardPairingDataFile),
+			"keycardPairingDataFile": path.Join(tmpdir, DefaultKeycardPairingDataFileRelativePath),
 		},
 	}
 
@@ -1585,7 +1584,7 @@ func TestRestoreKeycardAccountAndLogin(t *testing.T) {
 	backend := NewGethStatusBackend(tt.MustCreateTestLogger())
 	require.NoError(t, err)
 
-	backend.UpdateRootDataDir(conf.DataDir)
+	backend.UpdateRootDataDir(conf.RootDataDir)
 
 	require.NoError(t, backend.OpenAccounts())
 

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -25,10 +25,9 @@ const (
 	defaultMnemonicLength    = 12
 	walletAccountDefaultName = "Account 1"
 
-	DefaultKeystoreRelativePath   = "keystore"
-	DefaultKeycardPairingDataFile = "/ethereum/mainnet_rpc/keycard/pairings.json"
-	DefaultDataDir                = "/ethereum/mainnet_rpc"
-	DefaultAPILogFile             = "api.log"
+	DefaultKeystoreRelativePath               = "keystore"
+	DefaultKeycardPairingDataFileRelativePath = "/keycard/pairings.json"
+	DefaultAPILogFile                         = "api.log"
 
 	DefaultLogLevel                 = "ERROR"
 	DefaultVerifyTransactionChainID = 1
@@ -270,8 +269,7 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 	nodeConfig.LogFile = gocommon.TruncateWithDot(keyUID) + ".log"
 	nodeConfig.LogDir = request.LogFilePath
 	nodeConfig.LogLevel = DefaultLogLevel
-	nodeConfig.DataDir = DefaultDataDir
-	nodeConfig.KeycardPairingDataFile = DefaultKeycardPairingDataFile
+	nodeConfig.KeycardPairingDataFile = filepath.Join(nodeConfig.RootDataDir, DefaultKeycardPairingDataFileRelativePath)
 	if request.KeycardPairingDataFile != nil {
 		nodeConfig.KeycardPairingDataFile = *request.KeycardPairingDataFile
 	}

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -584,7 +584,6 @@ func (b *GethStatusBackend) workaroundToFixBadMigration(request *requests.Login)
 
 	// check if we saved a empty node config because of node config migration failed
 	if currentConf.NetworkID == 0 &&
-		currentConf.DataDir == "" &&
 		currentConf.NodeKey == "" {
 		// check if exist old node config
 		oldNodeConf := &params.NodeConfig{}
@@ -630,7 +629,6 @@ func (b *GethStatusBackend) overridePartialWithOldNodeConfig(conf *params.NodeCo
 	conf.LogFile = oldNodeConf.LogFile
 	conf.LogDir = oldNodeConf.LogDir
 	conf.LogLevel = oldNodeConf.LogLevel
-	conf.DataDir = oldNodeConf.DataDir
 	conf.NodeKey = oldNodeConf.NodeKey
 }
 
@@ -700,7 +698,7 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 
 	defaultCfg := &params.NodeConfig{
 		// why we need this? relate PR: https://github.com/status-im/status-go/pull/4014
-		KeycardPairingDataFile: DefaultKeycardPairingDataFile,
+		KeycardPairingDataFile: filepath.Join(b.rootDataDir, DefaultKeycardPairingDataFileRelativePath),
 	}
 
 	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletConfig, &request.WalletSecretsConfig)
@@ -1885,7 +1883,6 @@ func (b *GethStatusBackend) loadNodeConfig(inputNodeCfg *params.NodeConfig) erro
 	}
 
 	conf.RootDataDir = b.rootDataDir
-	conf.DataDir = filepath.Join(b.rootDataDir, conf.DataDir)
 
 	if _, err = os.Stat(conf.RootDataDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(conf.RootDataDir, os.ModePerm); err != nil {

--- a/api/test_helpers.go
+++ b/api/test_helpers.go
@@ -105,11 +105,10 @@ func setupTestContext(t *testing.T, password string, storeProfile bool, storeMul
 		})
 		require.NoError(t, err)
 		data.config.RootDataDir = tmpdir
-		data.config.DataDir = tmpdir
 	} else {
 		json := `{
 		"NetworkId": 3,
-		"DataDir": "` + tmpdir + `",
+		"RootDataDir": "` + tmpdir + `",
 		"KeycardPairingDataFile": "` + path.Join(tmpdir, "keycard/pairings.json") + `",
 		"NoDiscovery": true,
 		"TorrentConfig": {

--- a/appdatabase/node_config_test.go
+++ b/appdatabase/node_config_test.go
@@ -27,7 +27,6 @@ func setupTestDB(t *testing.T) *sql.DB {
 func randomNodeConfig() *params.NodeConfig {
 	return &params.NodeConfig{
 		NetworkID:          uint64(int64(randomInt(math.MaxInt64))),
-		DataDir:            randomString(),
 		NodeKey:            randomString(),
 		APIModules:         randomString(),
 		WalletConfig:       params.WalletConfig{Enabled: randomBool()},

--- a/multiaccounts/settings/database_test.go
+++ b/multiaccounts/settings/database_test.go
@@ -22,7 +22,6 @@ import (
 var (
 	config = params.NodeConfig{
 		NetworkID: 10,
-		DataDir:   "test",
 	}
 
 	networks = json.RawMessage("{}")

--- a/multiaccounts/settings_wallet/database_test.go
+++ b/multiaccounts/settings_wallet/database_test.go
@@ -14,8 +14,8 @@ import (
 
 var (
 	config = params.NodeConfig{
-		NetworkID: 10,
-		DataDir:   "test",
+		NetworkID:   10,
+		RootDataDir: "test",
 	}
 	networks    = json.RawMessage("{}")
 	settingsObj = settings.Settings{

--- a/node/geth_node.go
+++ b/node/geth_node.go
@@ -26,9 +26,9 @@ var (
 func MakeNode(config *params.NodeConfig) (*node.Node, error) {
 	// If DataDir is empty, it means we want to create an ephemeral node
 	// keeping data only in memory.
-	if config.DataDir != "" {
+	if config.RootDataDir != "" {
 		// make sure data directory exists
-		if err := os.MkdirAll(filepath.Clean(config.DataDir), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Clean(config.RootDataDir), os.ModePerm); err != nil {
 			return nil, fmt.Errorf("make node: make data directory: %v", err)
 		}
 
@@ -50,7 +50,7 @@ func MakeNode(config *params.NodeConfig) (*node.Node, error) {
 // newGethNodeConfig returns default stack configuration for mobile client node
 func newGethNodeConfig(config *params.NodeConfig) (*node.Config, error) {
 	nc := &node.Config{
-		DataDir:           config.DataDir,
+		DataDir:           config.RootDataDir,
 		UseLightweightKDF: true,
 		NoUSB:             true,
 		P2P: p2p.Config{

--- a/node/geth_status_node_test.go
+++ b/node/geth_status_node_test.go
@@ -68,7 +68,7 @@ func TestStatusNodeWithDataDir(t *testing.T) {
 	require.NoError(t, err)
 
 	config := params.NodeConfig{
-		DataDir: dir,
+		RootDataDir: dir,
 	}
 
 	n, stop1, stop2, err := createStatusNode()

--- a/nodecfg/node_config.go
+++ b/nodecfg/node_config.go
@@ -29,7 +29,7 @@ func insertNodeConfigBase(tx *sql.Tx, c *params.NodeConfig, includeConnector boo
 		browser_enabled, permissions_enabled`
 
 	args := []any{
-		c.NetworkID, c.DataDir, "", c.NodeKey, c.APIModules, true,
+		c.NetworkID, "", "", c.NodeKey, c.APIModules, true,
 		c.WalletConfig.Enabled, c.BrowsersConfig.Enabled,
 		c.PermissionsConfig.Enabled,
 	}
@@ -94,7 +94,7 @@ func insertShhExtConfig(tx *sql.Tx, c *params.NodeConfig) error {
 	_, err := tx.Exec(`
 	INSERT OR REPLACE INTO shhext_config (
 		pfs_enabled, installation_id, mailserver_confirmations,
-		verify_transaction_url, 
+		verify_transaction_url,
 		verify_ens_url, verify_ens_contract_address, verify_transaction_chain_id, bandwidth_stats_enabled, synthetic_id
 	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'id')`,
 		c.ShhextConfig.PFSEnabled, c.ShhextConfig.InstallationID, c.ShhextConfig.MailServerConfirmations,
@@ -248,12 +248,12 @@ func loadNodeConfig(tx *sql.Tx) (*params.NodeConfig, error) {
 
 	err := tx.QueryRow(`
 	SELECT
-		network_id, data_dir, node_key, api_modules,
+		network_id, node_key, api_modules,
 		wallet_enabled, browser_enabled, permissions_enabled,
 		connector_enabled FROM node_config
 		WHERE synthetic_id = 'id'
 	`).Scan(
-		&nodecfg.NetworkID, &nodecfg.DataDir, &nodecfg.NodeKey, &nodecfg.APIModules,
+		&nodecfg.NetworkID, &nodecfg.NodeKey, &nodecfg.APIModules,
 		&nodecfg.WalletConfig.Enabled, &nodecfg.BrowsersConfig.Enabled, &nodecfg.PermissionsConfig.Enabled,
 		&nodecfg.ConnectorConfig.Enabled,
 	)
@@ -295,7 +295,7 @@ func loadNodeConfig(tx *sql.Tx) (*params.NodeConfig, error) {
 	err = tx.QueryRow(`
 	SELECT pfs_enabled, installation_id, mailserver_confirmations,
 	verify_transaction_url,
-	verify_ens_url, verify_ens_contract_address, verify_transaction_chain_id, 
+	verify_ens_url, verify_ens_contract_address, verify_transaction_chain_id,
 	bandwidth_stats_enabled FROM shhext_config WHERE synthetic_id = 'id'
 	`).Scan(
 		&nodecfg.ShhextConfig.PFSEnabled, &nodecfg.ShhextConfig.InstallationID, &nodecfg.ShhextConfig.MailServerConfirmations,

--- a/params/config.go
+++ b/params/config.go
@@ -102,9 +102,6 @@ type NodeConfig struct {
 
 	RootDataDir string `json:",omitempty"`
 
-	// DataDir is the file system folder the node should use for any data storage needs.
-	DataDir string `validate:"required"`
-
 	// KeycardPairingDataFile is the file where we keep keycard pairings data.
 	// It's specified by clients (and not in status-go) when creating a new account,
 	// because this file is initialized by status-keycard-go and we need to use it before initializing the node.
@@ -383,7 +380,6 @@ func NewNodeConfig(dataDir string, networkID uint64) (*NodeConfig, error) {
 	config := &NodeConfig{
 		NetworkID:              networkID,
 		RootDataDir:            dataDir,
-		DataDir:                dataDir,
 		KeycardPairingDataFile: keycardPairingDataFile,
 		HTTPHost:               "localhost",
 		HTTPPort:               8545,

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/status-im/status-go/api"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/security"
 )
@@ -20,8 +21,8 @@ func TestNewConfigFromJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 	json := `{
 		"NetworkId": 3,
-		"DataDir": "` + tmpDir + `",
-		"KeycardPairingDataFile": "` + path.Join(tmpDir, "keycard/pairings.json") + `",
+		"RootDataDir": "` + tmpDir + `",
+		"KeycardPairingDataFile": "` + path.Join(tmpDir, api.DefaultKeycardPairingDataFileRelativePath) + `",
 		"TorrentConfig": {
 			"Port": 9025,
 			"Enabled": false,
@@ -33,7 +34,7 @@ func TestNewConfigFromJSON(t *testing.T) {
 	c, err := params.NewConfigFromJSON(json)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), c.NetworkID)
-	require.Equal(t, tmpDir, c.DataDir)
+	require.Equal(t, tmpDir, c.RootDataDir)
 	require.Equal(t, false, c.TorrentConfig.Enabled)
 	require.Equal(t, 9025, c.TorrentConfig.Port)
 	require.Equal(t, tmpDir+"/archivedata", c.TorrentConfig.DataDir)
@@ -55,7 +56,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"RootDataDir": "/tmp/data",
-				"DataDir": "/tmp/data",
 				"KeycardPairingDataFile": "/tmp/data/keycard/pairings.json"
 			}`,
 		},
@@ -74,7 +74,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{}`,
 			FieldErrors: map[string]string{
 				"NetworkID":              "required",
-				"DataDir":                "required",
 				"KeycardPairingDataFile": "required",
 			},
 		},
@@ -82,7 +81,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Validate that NodeKey is checked for validity",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"NodeKey": "foo"
 			}`,
@@ -92,7 +91,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Validate that UpstreamConfig.URL is not validated if UpstreamConfig is disabled",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"UpstreamConfig": {
 					"Enabled": false,
@@ -104,7 +103,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Validate that UpstreamConfig.URL validation passes if UpstreamConfig.URL is valid",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"UpstreamConfig": {
 					"Enabled": true,
@@ -116,7 +115,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Validate that PFSEnabled & InstallationID are checked for validity",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"ShhextConfig": {
 					"PFSEnabled": true
@@ -140,7 +139,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Set HTTP virtual hosts and CORS",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"HTTPVirtualHosts": ["my.domain.com"],
 				"HTTPCors": ["http://my.domain.com:8080"]
@@ -160,7 +159,7 @@ func TestNodeConfigValidate(t *testing.T) {
 		},
 		{
 			Name:   "Missing APIModules",
-			Config: `{"NetworkId": 1, "DataDir": "/tmp/data", "KeycardPairingDataFile": "/tmp/data/keycard/pairings.json", "APIModules" :""}`,
+			Config: `{"NetworkId": 1, "RootDataDir": "/tmp/data", "KeycardPairingDataFile": "/tmp/data/keycard/pairings.json", "APIModules" :""}`,
 			FieldErrors: map[string]string{
 				"APIModules": "required",
 			},
@@ -169,7 +168,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Validate that TorrentConfig.DataDir and TorrentConfig.TorrentDir can't be empty strings",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
         "TorrentConfig": {
           "Enabled": true,

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -272,7 +272,6 @@ func (tcmc *testCommunitiesMessengerConfig) complete() error {
 func defaultTestCommunitiesMessengerNodeConfig() *params.NodeConfig {
 	return &params.NodeConfig{
 		NetworkID: 10,
-		DataDir:   "test",
 	}
 }
 func defaultTestCommunitiesMessengerSettings() *settings.Settings {

--- a/services/connector/test_helpers.go
+++ b/services/connector/test_helpers.go
@@ -58,7 +58,6 @@ func setupTests(t *testing.T) (state testState, close func()) {
 
 	config := params.NodeConfig{
 		NetworkID: 10,
-		DataDir:   "test",
 	}
 	networks := json.RawMessage("{}")
 	settingsObj := settings.Settings{

--- a/services/gif/gif_test.go
+++ b/services/gif/gif_test.go
@@ -25,7 +25,6 @@ func setupTestDB(t *testing.T, db *sql.DB) (*accounts.Database, func()) {
 	require.NoError(t, err)
 	config := params.NodeConfig{
 		NetworkID: 10,
-		DataDir:   "test",
 	}
 	networks := json.RawMessage("{}")
 	settingsObj := settings.Settings{

--- a/services/wallet/market/market_test.go
+++ b/services/wallet/market/market_test.go
@@ -38,7 +38,6 @@ func setupTokenManager(t *testing.T) (*token.Manager, func()) {
 	require.NoError(t, err)
 	config := params.NodeConfig{
 		NetworkID: 10,
-		DataDir:   "test",
 	}
 	networks := json.RawMessage("{}")
 	settingsObj := settings.Settings{

--- a/services/wallet/token/token-lists/token_lists_test.go
+++ b/services/wallet/token/token-lists/token_lists_test.go
@@ -32,7 +32,6 @@ func initSettings(appDb *sql.DB, autoRefreshEnabled bool) (*settings.Database, e
 	var (
 		config = params.NodeConfig{
 			NetworkID: 10,
-			DataDir:   "test",
 		}
 		networks    = json.RawMessage("{}")
 		settingsObj = settings.Settings{

--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -143,7 +143,6 @@ func MakeTestNodeConfig(networkID int) (*params.NodeConfig, error) {
 		"Name": "test",
 		"NetworkId": ` + strconv.Itoa(networkID) + `,
 		"RootDataDir": "` + testDir + `",
-		"DataDir": "` + testDir + `",
 		"KeycardPairingDataFile": "` + path.Join(testDir, "keycard/pairings.json") + `",
 		"HTTPPort": ` + strconv.Itoa(TestConfig.Node.HTTPPort) + `,
 		"WSPort": ` + strconv.Itoa(TestConfig.Node.WSPort) + `,


### PR DESCRIPTION
In some parts of the code, DataDir was an absolute, but in other parts a relative path to the data dir, while RootDataDir is always an absolute path to the data dir. Since no need for such redundancy, DataDir is removed.

This should fix https://github.com/status-im/status-desktop/issues/18764