### PR TITLE
refactor_: DataDir removed from NodeConfig cause RootDataDir already has an absolute path to data dir (cherry-pick)

### DIFF
--- a/api/backend_test.go
+++ b/api/backend_test.go
@@ -707,14 +707,13 @@ func TestRuntimeLogLevelIsNotWrittenToDatabase(t *testing.T) {
 
 	json := `{
 		"NetworkId": 3,
-		"DataDir": "` + testContext.config.DataDir + `",
-		"KeycardPairingDataFile": "` + path.Join(testContext.config.DataDir, "keycard/pairings.json") + `",
+		"KeycardPairingDataFile": "` + path.Join(testContext.config.RootDataDir, "keycard/pairings.json") + `",
 		"NoDiscovery": true,
 		"TorrentConfig": {
 			"Port": 9025,
 			"Enabled": false,
-			"DataDir": "` + testContext.config.DataDir + `/archivedata",
-			"TorrentDir": "` + testContext.config.DataDir + `/torrents"
+			"DataDir": "` + testContext.config.RootDataDir + `/archivedata",
+			"TorrentDir": "` + testContext.config.RootDataDir + `/torrents"
 		},
 		"RuntimeLogLevel": "INFO",
 		"LogLevel": "DEBUG"
@@ -759,8 +758,8 @@ func TestLoginAccount(t *testing.T) {
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
 		Password:           testPassword,
-		RootDataDir:        testContext.config.DataDir,
-		LogFilePath:        testContext.config.DataDir + "/log",
+		RootDataDir:        testContext.config.RootDataDir,
+		LogFilePath:        testContext.config.RootDataDir + "/log",
 		WakuV2Nameserver:   &nameserver,
 		WakuV2Fleet:        "status.staging",
 	}
@@ -798,7 +797,7 @@ func TestLoginAccount(t *testing.T) {
 	require.NoError(t, testContext.backend.Logout())
 	require.NoError(t, testContext.backend.StopNode())
 
-	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
+	testContext.backend.UpdateRootDataDir(testContext.config.RootDataDir)
 
 	accounts, err := testContext.backend.GetAccounts()
 	require.NoError(t, err)
@@ -988,7 +987,7 @@ func loginDesktopUser(t *testing.T, conf *params.NodeConfig, keyUID string) {
 
 	b := NewGethStatusBackend(tt.MustCreateTestLogger())
 
-	b.UpdateRootDataDir(conf.DataDir)
+	b.UpdateRootDataDir(conf.RootDataDir)
 
 	require.NoError(t, b.OpenAccounts())
 
@@ -1079,7 +1078,7 @@ func TestChangeDatabasePassword(t *testing.T) {
 	err = testContext.backend.ChangeDatabasePassword(testContext.profileKeypair.KeyUID, testPassword, newPassword)
 	require.NoError(t, err)
 
-	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
+	testContext.backend.UpdateRootDataDir(testContext.config.RootDataDir)
 
 	// Test that keystore can be decrypted with the new password
 	ok, err = testContext.backend.AccountsManager().VerifyAccountPassword(masterAddress, newPassword)
@@ -1104,8 +1103,8 @@ func TestCreateWallet(t *testing.T) {
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
 		Password:           testPassword,
-		RootDataDir:        testContext.config.DataDir,
-		LogFilePath:        testContext.config.DataDir + "/log",
+		RootDataDir:        testContext.config.RootDataDir,
+		LogFilePath:        testContext.config.RootDataDir + "/log",
 	}
 
 	c := make(chan interface{}, 10)
@@ -1165,8 +1164,8 @@ func TestSetFleet(t *testing.T) {
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
 		Password:           testPassword,
-		RootDataDir:        testContext.config.DataDir,
-		LogFilePath:        testContext.config.DataDir + "/log",
+		RootDataDir:        testContext.config.RootDataDir,
+		LogFilePath:        testContext.config.RootDataDir + "/log",
 	}
 
 	c := make(chan interface{}, 10)
@@ -1198,7 +1197,7 @@ func TestSetFleet(t *testing.T) {
 
 	require.NoError(t, testContext.backend.Logout())
 
-	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
+	testContext.backend.UpdateRootDataDir(testContext.config.RootDataDir)
 
 	loginAccountRequest := &requests.Login{
 		KeyUID:   newAccount.KeyUID,
@@ -1243,8 +1242,8 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 		DisplayName:        "some-display-name",
 		CustomizationColor: "#ffffff",
 		Password:           testPassword,
-		RootDataDir:        testContext.config.DataDir,
-		LogFilePath:        testContext.config.DataDir + "/log",
+		RootDataDir:        testContext.config.RootDataDir,
+		LogFilePath:        testContext.config.RootDataDir + "/log",
 	}
 	c := make(chan interface{}, 10)
 	signal.SetMobileSignalHandler(func(data []byte) {
@@ -1280,7 +1279,7 @@ func TestWalletConfigOnLoginAccount(t *testing.T) {
 		},
 	}
 
-	testContext.backend.UpdateRootDataDir(testContext.config.DataDir)
+	testContext.backend.UpdateRootDataDir(testContext.config.RootDataDir)
 
 	require.NoError(t, testContext.backend.LoginAccount(loginAccountRequest))
 	select {
@@ -1416,7 +1415,7 @@ func TestAcceptTerms(t *testing.T) {
 	conf, err := params.NewNodeConfig(tmpdir, 1777)
 	require.NoError(t, err)
 
-	b.UpdateRootDataDir(conf.DataDir)
+	b.UpdateRootDataDir(conf.RootDataDir)
 	require.NoError(t, b.OpenAccounts())
 	nameserver := "8.8.8.8"
 	createAccountRequest := &requests.CreateAccount{
@@ -1567,7 +1566,7 @@ func TestRestoreKeycardAccountAndLogin(t *testing.T) {
 			"torrentConfigEnabled":   false,
 			"torrentConfigPort":      0,
 			"keycardInstanceUID":     "a84599394887b742eed9a99d3834a797",
-			"keycardPairingDataFile": path.Join(tmpdir, DefaultKeycardPairingDataFile),
+			"keycardPairingDataFile": path.Join(tmpdir, DefaultKeycardPairingDataFileRelativePath),
 		},
 	}
 
@@ -1580,7 +1579,7 @@ func TestRestoreKeycardAccountAndLogin(t *testing.T) {
 	backend := NewGethStatusBackend(tt.MustCreateTestLogger())
 	require.NoError(t, err)
 
-	backend.UpdateRootDataDir(conf.DataDir)
+	backend.UpdateRootDataDir(conf.RootDataDir)
 
 	require.NoError(t, backend.OpenAccounts())
 

--- a/api/defaults.go
+++ b/api/defaults.go
@@ -26,10 +26,9 @@ const (
 	defaultMnemonicLength    = 12
 	walletAccountDefaultName = "Account 1"
 
-	DefaultKeystoreRelativePath   = "keystore"
-	DefaultKeycardPairingDataFile = "/ethereum/mainnet_rpc/keycard/pairings.json"
-	DefaultDataDir                = "/ethereum/mainnet_rpc"
-	DefaultAPILogFile             = "api.log"
+	DefaultKeystoreRelativePath               = "keystore"
+	DefaultKeycardPairingDataFileRelativePath = "/keycard/pairings.json"
+	DefaultAPILogFile                         = "api.log"
 
 	DefaultLogLevel                   = "ERROR"
 	DefaultMaxMessageDeliveryAttempts = 3
@@ -295,9 +294,8 @@ func DefaultNodeConfig(installationID, keyUID string, request *requests.CreateAc
 	nodeConfig.LogFile = gocommon.TruncateWithDot(keyUID) + ".log"
 	nodeConfig.LogDir = request.LogFilePath
 	nodeConfig.LogLevel = DefaultLogLevel
-	nodeConfig.DataDir = DefaultDataDir
 	nodeConfig.ProcessBackedupMessages = false
-	nodeConfig.KeycardPairingDataFile = DefaultKeycardPairingDataFile
+	nodeConfig.KeycardPairingDataFile = filepath.Join(nodeConfig.RootDataDir, DefaultKeycardPairingDataFileRelativePath)
 	if request.KeycardPairingDataFile != nil {
 		nodeConfig.KeycardPairingDataFile = *request.KeycardPairingDataFile
 	}

--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -583,7 +583,6 @@ func (b *GethStatusBackend) workaroundToFixBadMigration(request *requests.Login)
 
 	// check if we saved a empty node config because of node config migration failed
 	if currentConf.NetworkID == 0 &&
-		currentConf.DataDir == "" &&
 		currentConf.NodeKey == "" {
 		// check if exist old node config
 		oldNodeConf := &params.NodeConfig{}
@@ -629,7 +628,6 @@ func (b *GethStatusBackend) overridePartialWithOldNodeConfig(conf *params.NodeCo
 	conf.LogFile = oldNodeConf.LogFile
 	conf.LogDir = oldNodeConf.LogDir
 	conf.LogLevel = oldNodeConf.LogLevel
-	conf.DataDir = oldNodeConf.DataDir
 	conf.NodeKey = oldNodeConf.NodeKey
 }
 
@@ -699,7 +697,7 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 
 	defaultCfg := &params.NodeConfig{
 		// why we need this? relate PR: https://github.com/status-im/status-go/pull/4014
-		KeycardPairingDataFile: DefaultKeycardPairingDataFile,
+		KeycardPairingDataFile: filepath.Join(b.rootDataDir, DefaultKeycardPairingDataFileRelativePath),
 	}
 
 	defaultCfg.WalletConfig = buildWalletConfig(&request.WalletConfig, &request.WalletSecretsConfig)
@@ -2020,7 +2018,6 @@ func (b *GethStatusBackend) loadNodeConfig(inputNodeCfg *params.NodeConfig) erro
 	// TODO: Consider removing the Enabled field from the config as WakuV1 has been removed.
 	conf.WakuV2Config.Enabled = true
 	conf.RootDataDir = b.rootDataDir
-	conf.DataDir = filepath.Join(b.rootDataDir, conf.DataDir)
 
 	if _, err = os.Stat(conf.RootDataDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(conf.RootDataDir, os.ModePerm); err != nil {

--- a/api/test_helpers.go
+++ b/api/test_helpers.go
@@ -101,11 +101,10 @@ func setupTestContext(t *testing.T, password string, storeProfile bool, storeMul
 		})
 		require.NoError(t, err)
 		data.config.RootDataDir = tmpdir
-		data.config.DataDir = tmpdir
 	} else {
 		json := `{
 		"NetworkId": 3,
-		"DataDir": "` + tmpdir + `",
+		"RootDataDir": "` + tmpdir + `",
 		"KeycardPairingDataFile": "` + path.Join(tmpdir, "keycard/pairings.json") + `",
 		"NoDiscovery": true,
 		"TorrentConfig": {

--- a/appdatabase/node_config_test.go
+++ b/appdatabase/node_config_test.go
@@ -117,7 +117,6 @@ func randomCustomNodes() map[string]string {
 func randomNodeConfig() *params.NodeConfig {
 	return &params.NodeConfig{
 		NetworkID:          uint64(int64(randomInt(math.MaxInt64))),
-		DataDir:            randomString(),
 		NodeKey:            randomString(),
 		APIModules:         randomString(),
 		WalletConfig:       params.WalletConfig{Enabled: randomBool()},

--- a/multiaccounts/settings/database_test.go
+++ b/multiaccounts/settings/database_test.go
@@ -22,7 +22,6 @@ import (
 var (
 	config = params.NodeConfig{
 		NetworkID: 10,
-		DataDir:   "test",
 	}
 
 	networks = json.RawMessage("{}")

--- a/multiaccounts/settings_wallet/database_test.go
+++ b/multiaccounts/settings_wallet/database_test.go
@@ -14,8 +14,8 @@ import (
 
 var (
 	config = params.NodeConfig{
-		NetworkID: 10,
-		DataDir:   "test",
+		NetworkID:   10,
+		RootDataDir: "test",
 	}
 	networks    = json.RawMessage("{}")
 	settingsObj = settings.Settings{

--- a/node/geth_node.go
+++ b/node/geth_node.go
@@ -26,9 +26,9 @@ var (
 func MakeNode(config *params.NodeConfig) (*node.Node, error) {
 	// If DataDir is empty, it means we want to create an ephemeral node
 	// keeping data only in memory.
-	if config.DataDir != "" {
+	if config.RootDataDir != "" {
 		// make sure data directory exists
-		if err := os.MkdirAll(filepath.Clean(config.DataDir), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Clean(config.RootDataDir), os.ModePerm); err != nil {
 			return nil, fmt.Errorf("make node: make data directory: %v", err)
 		}
 
@@ -50,7 +50,7 @@ func MakeNode(config *params.NodeConfig) (*node.Node, error) {
 // newGethNodeConfig returns default stack configuration for mobile client node
 func newGethNodeConfig(config *params.NodeConfig) (*node.Config, error) {
 	nc := &node.Config{
-		DataDir:           config.DataDir,
+		DataDir:           config.RootDataDir,
 		UseLightweightKDF: true,
 		NoUSB:             true,
 		P2P: p2p.Config{

--- a/node/geth_status_node_test.go
+++ b/node/geth_status_node_test.go
@@ -68,7 +68,7 @@ func TestStatusNodeWithDataDir(t *testing.T) {
 	require.NoError(t, err)
 
 	config := params.NodeConfig{
-		DataDir: dir,
+		RootDataDir: dir,
 	}
 
 	n, stop1, stop2, err := createStatusNode()

--- a/nodecfg/node_config.go
+++ b/nodecfg/node_config.go
@@ -40,7 +40,7 @@ func insertNodeConfigBase(tx *sql.Tx, c *params.NodeConfig, includeConnector boo
 		browser_enabled, permissions_enabled, mailservers_enabled`
 
 	args := []any{
-		c.NetworkID, c.DataDir, "", c.NodeKey, c.APIModules, true,
+		c.NetworkID, "", "", c.NodeKey, c.APIModules, true,
 		c.WalletConfig.Enabled, c.BrowsersConfig.Enabled,
 		c.PermissionsConfig.Enabled, c.MailserversConfig.Enabled,
 	}
@@ -358,12 +358,12 @@ func loadNodeConfig(tx *sql.Tx) (*params.NodeConfig, error) {
 	keystoreDir := "" // TODO: remove this from db
 	err := tx.QueryRow(`
 	SELECT
-		network_id, data_dir, keystore_dir, node_key, api_modules,
+		network_id, keystore_dir, node_key, api_modules,
 		wallet_enabled, browser_enabled, permissions_enabled,
 		mailservers_enabled, connector_enabled FROM node_config
 		WHERE synthetic_id = 'id'
 	`).Scan(
-		&nodecfg.NetworkID, &nodecfg.DataDir, &keystoreDir, &nodecfg.NodeKey, &nodecfg.APIModules,
+		&nodecfg.NetworkID, &keystoreDir, &nodecfg.NodeKey, &nodecfg.APIModules,
 		&nodecfg.WalletConfig.Enabled, &nodecfg.BrowsersConfig.Enabled, &nodecfg.PermissionsConfig.Enabled,
 		&nodecfg.MailserversConfig.Enabled, &nodecfg.ConnectorConfig.Enabled,
 	)

--- a/params/config.go
+++ b/params/config.go
@@ -168,9 +168,6 @@ type NodeConfig struct {
 
 	RootDataDir string `json:",omitempty"`
 
-	// DataDir is the file system folder the node should use for any data storage needs.
-	DataDir string `validate:"required"`
-
 	// KeycardPairingDataFile is the file where we keep keycard pairings data.
 	// It's specified by clients (and not in status-go) when creating a new account,
 	// because this file is initialized by status-keycard-go and we need to use it before initializing the node.
@@ -639,7 +636,6 @@ func NewNodeConfig(dataDir string, networkID uint64) (*NodeConfig, error) {
 	config := &NodeConfig{
 		NetworkID:              networkID,
 		RootDataDir:            dataDir,
-		DataDir:                dataDir,
 		KeycardPairingDataFile: keycardPairingDataFile,
 		HTTPHost:               "localhost",
 		HTTPPort:               8545,
@@ -804,11 +800,11 @@ func (c *NodeConfig) Save() error {
 		return err
 	}
 
-	if err := os.MkdirAll(c.DataDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(c.RootDataDir, os.ModePerm); err != nil {
 		return err
 	}
 
-	configFilePath := filepath.Join(c.DataDir, "config.json")
+	configFilePath := filepath.Join(c.RootDataDir, "config.json")
 	//nolint:gosec
 	if err := ioutil.WriteFile(configFilePath, data, os.ModePerm); err != nil {
 		return err

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/status-im/status-go/api"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/t/utils"
@@ -29,7 +30,7 @@ func TestNewNodeConfigWithDefaults(t *testing.T) {
 		params.WithMailserver(),
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "/some/data/path", c.DataDir)
+	assert.Equal(t, "/some/data/path", c.RootDataDir)
 	// assert Whisper
 	assert.Equal(t, true, c.WakuV2Config.Enabled)
 	assert.Equal(t, "/some/data/path/wakuv2", c.WakuV2Config.DataDir)
@@ -57,8 +58,8 @@ func TestNewConfigFromJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 	json := `{
 		"NetworkId": 3,
-		"DataDir": "` + tmpDir + `",
-		"KeycardPairingDataFile": "` + path.Join(tmpDir, "keycard/pairings.json") + `",
+		"RootDataDir": "` + tmpDir + `",
+		"KeycardPairingDataFile": "` + path.Join(tmpDir, api.DefaultKeycardPairingDataFileRelativePath) + `",
 		"TorrentConfig": {
 			"Port": 9025,
 			"Enabled": false,
@@ -70,7 +71,7 @@ func TestNewConfigFromJSON(t *testing.T) {
 	c, err := params.NewConfigFromJSON(json)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), c.NetworkID)
-	require.Equal(t, tmpDir, c.DataDir)
+	require.Equal(t, tmpDir, c.RootDataDir)
 	require.Equal(t, false, c.TorrentConfig.Enabled)
 	require.Equal(t, 9025, c.TorrentConfig.Port)
 	require.Equal(t, tmpDir+"/archivedata", c.TorrentConfig.DataDir)
@@ -87,11 +88,11 @@ func TestConfigWriteRead(t *testing.T) {
 	err = nodeConfig.Save()
 	require.Nil(t, err, "cannot persist configuration")
 
-	loadedConfigData, err := ioutil.ReadFile(filepath.Join(nodeConfig.DataDir, "config.json"))
+	loadedConfigData, err := ioutil.ReadFile(filepath.Join(nodeConfig.RootDataDir, "config.json"))
 	require.Nil(t, err, "cannot read configuration from disk")
 	loadedConfig := string(loadedConfigData)
 	require.Contains(t, loadedConfig, fmt.Sprintf(`"NetworkId": %d`, params.SepoliaNetworkID))
-	require.Contains(t, loadedConfig, fmt.Sprintf(`"DataDir": "%s"`, tmpDir))
+	require.Contains(t, loadedConfig, fmt.Sprintf(`"RootDataDir": "%s"`, tmpDir))
 }
 
 // TestNodeConfigValidate checks validation of individual fields.
@@ -108,7 +109,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{
 				"NetworkId": 1,
 				"RootDataDir": "/tmp/data",
-				"DataDir": "/tmp/data",
 				"KeycardPairingDataFile": "/tmp/data/keycard/pairings.json"
 			}`,
 		},
@@ -127,7 +127,6 @@ func TestNodeConfigValidate(t *testing.T) {
 			Config: `{}`,
 			FieldErrors: map[string]string{
 				"NetworkID":              "required",
-				"DataDir":                "required",
 				"KeycardPairingDataFile": "required",
 			},
 		},
@@ -135,7 +134,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Validate that NodeKey is checked for validity",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"NodeKey": "foo"
 			}`,
@@ -145,7 +144,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Validate that UpstreamConfig.URL is not validated if UpstreamConfig is disabled",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"UpstreamConfig": {
 					"Enabled": false,
@@ -157,7 +156,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Validate that UpstreamConfig.URL validation passes if UpstreamConfig.URL is valid",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"UpstreamConfig": {
 					"Enabled": true,
@@ -169,7 +168,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Validate that PFSEnabled & InstallationID are checked for validity",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"ShhextConfig": {
 					"PFSEnabled": true
@@ -193,7 +192,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Set HTTP virtual hosts and CORS",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
 				"HTTPVirtualHosts": ["my.domain.com"],
 				"HTTPCors": ["http://my.domain.com:8080"]
@@ -213,7 +212,7 @@ func TestNodeConfigValidate(t *testing.T) {
 		},
 		{
 			Name:   "Missing APIModules",
-			Config: `{"NetworkId": 1, "DataDir": "/tmp/data", "KeycardPairingDataFile": "/tmp/data/keycard/pairings.json", "APIModules" :""}`,
+			Config: `{"NetworkId": 1, "RootDataDir": "/tmp/data", "KeycardPairingDataFile": "/tmp/data/keycard/pairings.json", "APIModules" :""}`,
 			FieldErrors: map[string]string{
 				"APIModules": "required",
 			},
@@ -222,7 +221,7 @@ func TestNodeConfigValidate(t *testing.T) {
 			Name: "Validate that TorrentConfig.DataDir and TorrentConfig.TorrentDir can't be empty strings",
 			Config: `{
 				"NetworkId": 1,
-				"DataDir": "/some/dir",
+				"RootDataDir": "/some/dir",
 				"KeycardPairingDataFile": "/some/dir/keycard/pairings.json",
         "TorrentConfig": {
           "Enabled": true,

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -281,7 +281,6 @@ func (tcmc *testCommunitiesMessengerConfig) complete() error {
 func defaultTestCommunitiesMessengerNodeConfig() *params.NodeConfig {
 	return &params.NodeConfig{
 		NetworkID: 10,
-		DataDir:   "test",
 	}
 }
 func defaultTestCommunitiesMessengerSettings() *settings.Settings {

--- a/services/connector/test_helpers.go
+++ b/services/connector/test_helpers.go
@@ -58,7 +58,6 @@ func setupTests(t *testing.T) (state testState, close func()) {
 
 	config := params.NodeConfig{
 		NetworkID: 10,
-		DataDir:   "test",
 	}
 	networks := json.RawMessage("{}")
 	settingsObj := settings.Settings{

--- a/services/gif/gif_test.go
+++ b/services/gif/gif_test.go
@@ -25,7 +25,6 @@ func setupTestDB(t *testing.T, db *sql.DB) (*accounts.Database, func()) {
 	require.NoError(t, err)
 	config := params.NodeConfig{
 		NetworkID: 10,
-		DataDir:   "test",
 	}
 	networks := json.RawMessage("{}")
 	settingsObj := settings.Settings{

--- a/services/wallet/market/market_test.go
+++ b/services/wallet/market/market_test.go
@@ -38,7 +38,6 @@ func setupTokenManager(t *testing.T) (*token.Manager, func()) {
 	require.NoError(t, err)
 	config := params.NodeConfig{
 		NetworkID: 10,
-		DataDir:   "test",
 	}
 	networks := json.RawMessage("{}")
 	settingsObj := settings.Settings{

--- a/services/wallet/router/fees/fees_test.go
+++ b/services/wallet/router/fees/fees_test.go
@@ -235,6 +235,9 @@ func TestSuggestedFeesForEIP1559CompatibleChains(t *testing.T) {
 			"0x134180d5a",
 			"0x134e32c33",
 			"0x137da8d22",
+			"0x12f0e070b",
+			"0x13f10da8b",
+			"0x126c30d5e",
 		},
 		GasUsedRatio: []float64{
 			0.7113286209349903,
@@ -244,6 +247,9 @@ func TestSuggestedFeesForEIP1559CompatibleChains(t *testing.T) {
 			0.5103012666666666,
 			0.538413,
 			0.16543626666666666,
+			0.7113286209349903,
+			0.19531163333333335,
+			0.7189235666666667,
 		},
 		OldestBlock: "0x1497d4b",
 		Reward: [][]string{
@@ -282,6 +288,21 @@ func TestSuggestedFeesForEIP1559CompatibleChains(t *testing.T) {
 				"0x39d10680",
 				"0x41d0a8d6",
 			},
+			{
+				"0x2faf080",
+				"0x39d10680",
+				"0x722d7ef5",
+			},
+			{
+				"0x5f5e100",
+				"0x3b9aca00",
+				"0x59682f00",
+			},
+			{
+				"0x342e4a2",
+				"0x39d10680",
+				"0x77359400",
+			},
 		},
 	}
 
@@ -308,13 +329,13 @@ func TestSuggestedFeesForEIP1559CompatibleChains(t *testing.T) {
 	assert.Equal(t, variadicFee1, variadicFee2)
 
 	assert.Equal(t, big.NewInt(0), suggestedFees.GasPrice)
-	assert.Equal(t, big.NewInt(5362838082), suggestedFees.BaseFee)
-	assert.Equal(t, big.NewInt(5362838082), suggestedFees.CurrentBaseFee)
-	assert.Equal(t, big.NewInt(5462838082), suggestedFees.MaxFeesLevels.Low.ToInt())
+	assert.Equal(t, big.NewInt(5068916557), suggestedFees.BaseFee)
+	assert.Equal(t, big.NewInt(5068916557), suggestedFees.CurrentBaseFee)
+	assert.Equal(t, big.NewInt(5168916557), suggestedFees.MaxFeesLevels.Low.ToInt())
 	assert.Equal(t, big.NewInt(100000000), suggestedFees.MaxFeesLevels.LowPriority.ToInt())
-	assert.Equal(t, big.NewInt(7795989313), suggestedFees.MaxFeesLevels.Medium.ToInt())
+	assert.Equal(t, big.NewInt(7451651202), suggestedFees.MaxFeesLevels.Medium.ToInt())
 	assert.Equal(t, big.NewInt(970000000), suggestedFees.MaxFeesLevels.MediumPriority.ToInt())
-	assert.Equal(t, big.NewInt(14104411640), suggestedFees.MaxFeesLevels.High.ToInt())
+	assert.Equal(t, big.NewInt(13466152004), suggestedFees.MaxFeesLevels.High.ToInt())
 	assert.Equal(t, big.NewInt(1915584245), suggestedFees.MaxFeesLevels.HighPriority.ToInt())
 	assert.Equal(t, suggestedFees.MaxFeesLevels.MediumPriority.ToInt(), suggestedFees.MaxPriorityFeePerGas)
 	assert.Equal(t, big.NewInt(100000000), suggestedFees.MaxPriorityFeeSuggestedBounds.Lower)

--- a/services/wallet/router/fees/suggested_priority.go
+++ b/services/wallet/router/fees/suggested_priority.go
@@ -69,7 +69,7 @@ func (f *FeeManager) getNonEIP1559SuggestedFees(ctx context.Context, chainID uin
 // getEIP1559SuggestedFees returns suggested fees for EIP-1559 compatible chains
 // source https://github.com/brave/brave-core/blob/master/components/brave_wallet/browser/eth_gas_utils.cc
 func getEIP1559SuggestedFees(chainID uint64, feeHistory *FeeHistory) (lowPriorityFee, avgPriorityFee, highPriorityFee, suggestedBaseFee *big.Int, err error) {
-	if feeHistory == nil {
+	if feeHistory == nil || len(feeHistory.BaseFeePerGas) == 0 {
 		return nil, nil, nil, nil, ErrEIP1559IncompaibleChain
 	}
 

--- a/services/wallet/token/token-lists/token_lists_test.go
+++ b/services/wallet/token/token-lists/token_lists_test.go
@@ -32,7 +32,6 @@ func initSettings(appDb *sql.DB, autoRefreshEnabled bool) (*settings.Database, e
 	var (
 		config = params.NodeConfig{
 			NetworkID: 10,
-			DataDir:   "test",
 		}
 		networks    = json.RawMessage("{}")
 		settingsObj = settings.Settings{

--- a/t/utils/utils.go
+++ b/t/utils/utils.go
@@ -241,7 +241,6 @@ func MakeTestNodeConfig(networkID int) (*params.NodeConfig, error) {
 		"Name": "test",
 		"NetworkId": ` + strconv.Itoa(networkID) + `,
 		"RootDataDir": "` + testDir + `",
-		"DataDir": "` + testDir + `",
 		"KeycardPairingDataFile": "` + path.Join(testDir, "keycard/pairings.json") + `",
 		"HTTPPort": ` + strconv.Itoa(TestConfig.Node.HTTPPort) + `,
 		"WSPort": ` + strconv.Itoa(TestConfig.Node.WSPort) + `,

--- a/transactions/pendingtxtracker_test.go
+++ b/transactions/pendingtxtracker_test.go
@@ -447,8 +447,9 @@ func TestPendingTxTracker_Watch_StatusChangeIncrementally(t *testing.T) {
 	chainClient.SetAvailableClients([]common.ChainID{txs[0].ChainID})
 	cl := chainClient.Clients[txs[0].ChainID]
 
+	firstCall := true
 	cl.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
-		if len(cl.Calls) == 0 {
+		if firstCall {
 			res := len(b) > 0 && b[0].Method == GetTransactionReceiptRPCName && b[0].Args[0] == txs[0].Hash
 			// If the first processing call picked up the second validate this case also
 			if len(b) == 2 {
@@ -460,7 +461,7 @@ func TestPendingTxTracker_Watch_StatusChangeIncrementally(t *testing.T) {
 		return len(b) == 1 && (b[0].Method == GetTransactionReceiptRPCName && b[0].Args[0] == txs[1].Hash)
 	})).Return(nil).Twice().Run(func(args mock.Arguments) {
 		elems := args.Get(1).([]rpc.BatchElem)
-		if len(cl.Calls) == 2 {
+		if !firstCall {
 			firsDoneWG.Wait()
 		}
 		// Only first item is processed, second is left pending
@@ -469,6 +470,7 @@ func TestPendingTxTracker_Watch_StatusChangeIncrementally(t *testing.T) {
 			BlockNumber: new(big.Int).SetUint64(1),
 			Status:      1,
 		}
+		firstCall = false
 	})
 
 	eventChan := make(chan walletevent.Event, 6)
@@ -517,16 +519,19 @@ func TestPendingTxTracker_Watch_StatusChangeIncrementally(t *testing.T) {
 		statusEventCount++
 	}
 
-	for j := 0; j < 6; j++ {
+	timeout := time.After(5 * time.Second)
+	eventCount := 0
+	for eventCount < 6 {
 		select {
 		case we := <-eventChan:
+			eventCount++
 			if EventPendingTransactionUpdate == we.Type {
 				storeEventCount++
 			} else if EventPendingTransactionStatusChanged == we.Type {
 				validateStatusChange(&we)
 			}
-		case <-time.After(1 * time.Second):
-			t.Fatal("timeout waiting for the status update event")
+		case <-timeout:
+			t.Fatalf("timeout waiting for events (received %d events, expected 6, storeEventCount=%d, statusEventCount=%d)", eventCount, storeEventCount, statusEventCount)
 		}
 	}
 


### PR DESCRIPTION
Cherry-picked:
- https://github.com/status-im/status-go/pull/6898