### PR TITLE
test: only connect to the docker compose network

### DIFF
--- a/messaging/waku/gowaku.go
+++ b/messaging/waku/gowaku.go
@@ -197,9 +197,6 @@ type Waku struct {
 	// goingOnline is channel that notifies when connectivity has changed from offline to online
 	goingOnline chan struct{}
 
-	// discV5BootstrapNodes is the ENR to be used to fetch bootstrap nodes for discovery
-	discV5BootstrapNodes []string
-
 	onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error)
 	onPeerStats                     func(types.ConnStatus)
 
@@ -266,7 +263,6 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, appDB *sql.
 		timesource:                      ts,
 		storeMsgIDsMu:                   sync.RWMutex{},
 		logger:                          logger,
-		discV5BootstrapNodes:            cfg.DiscV5BootstrapNodes,
 		onHistoricMessagesRequestFailed: onHistoricMessagesRequestFailed,
 		onPeerStats:                     onPeerStats,
 		onlineChecker:                   onlinechecker.NewDefaultOnlineChecker(false).(*onlinechecker.DefaultOnlineChecker),
@@ -308,7 +304,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, appDB *sql.
 	}
 
 	if cfg.EnableDiscV5 {
-		bootnodes, err := waku.getDiscV5BootstrapNodes(waku.ctx, cfg.DiscV5BootstrapNodes, false)
+		bootnodes, err := waku.getDiscV5BootstrapNodes(waku.ctx, false)
 		if err != nil {
 			logger.Error("failed to get bootstrap nodes", zap.Error(err))
 			return nil, err
@@ -397,7 +393,7 @@ func (w *Waku) GetNodeENRString() (string, error) {
 	return w.node.ENR().String(), nil
 }
 
-func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string, useOnlyDnsDiscCache bool) ([]*enode.Node, error) {
+func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, useOnlyDnsDiscCache bool) ([]*enode.Node, error) {
 	wg := sync.WaitGroup{}
 	mu := sync.Mutex{}
 	var result []*enode.Node
@@ -413,7 +409,7 @@ func (w *Waku) getDiscV5BootstrapNodes(ctx context.Context, addresses []string, 
 		}
 	}
 
-	for _, addrString := range addresses {
+	for _, addrString := range w.cfg.DiscV5BootstrapNodes {
 		if addrString == "" {
 			continue
 		}
@@ -1867,7 +1863,7 @@ func (w *Waku) seedBootnodesForDiscV5() {
 func (w *Waku) restartDiscV5(useOnlyDNSDiscCache bool) error {
 	ctx, cancel := context.WithTimeout(w.ctx, 30*time.Second)
 	defer cancel()
-	bootnodes, err := w.getDiscV5BootstrapNodes(ctx, w.discV5BootstrapNodes, useOnlyDNSDiscCache)
+	bootnodes, err := w.getDiscV5BootstrapNodes(ctx, useOnlyDNSDiscCache)
 	if err != nil {
 		return err
 	}

--- a/messaging/waku/waku_test.go
+++ b/messaging/waku/waku_test.go
@@ -104,7 +104,7 @@ func TestRestartDiscoveryV5(t *testing.T) {
 
 	require.Error(t, err)
 
-	w.discV5BootstrapNodes = []string{testStoreENRBootstrap}
+	w.cfg.DiscV5BootstrapNodes = []string{testStoreENRBootstrap}
 
 	options = func(b *backoff.ExponentialBackOff) {
 		b.MaxElapsedTime = 90 * time.Second

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -453,4 +453,4 @@ class WakuextService(Service):
     def peer_id(self):
         params = []
         response = self.rpc_request("peerID", params)
-        return response.json()["result"]
+        return response["result"]

--- a/tests-functional/tests/test_discovery.py
+++ b/tests-functional/tests/test_discovery.py
@@ -1,0 +1,74 @@
+import logging
+import time
+import pytest
+import threading
+
+from clients.status_backend import StatusBackend
+
+DISCOVERY_TIMEOUT_SEC = 10
+
+
+def _all_nodes_discovered(nodes: dict[str, StatusBackend], known_peers: dict[str, str]) -> bool:
+    """Check if all nodes discovered each other"""
+    for peer_id, node in nodes.items():
+        if node is None:
+            return False
+        response = node.wakuext_service.peers(enable_logging=False)
+        peers = response["result"]
+
+        # Use shorter names for logging
+        peer_names = [known_peers.get(peer, peer[-5:]) for peer in peers]
+        logging.info(f"Node {known_peers[peer_id]} peers: {peer_names}")
+
+        for known_node in known_peers.keys():
+            if known_node == peer_id:
+                continue
+            if known_node not in peers:
+                return False
+    return True
+
+
+@pytest.mark.rpc
+class TestDiscovery:
+
+    def test_discovery(self, backend_new_profile):
+        nodes_count = 3
+        nodes: dict[str, StatusBackend] = {}
+
+        known_nodes = {
+            "16Uiu2HAm3vFYHkGRURyJ6F7bwDyzMLtPEuCg4DU89T7km2u8Fjyb": "boot-1",
+            "16Uiu2HAmCDqxtfF1DwBqs7UJ4TgSnjoh6j1RtE1hhQxLLao84jLi": "store",
+        }
+
+        def create_node(node_index: int):
+            """Function to run in each thread - waits for wakuv2.peerstats signal"""
+            backend = backend_new_profile(f"node_{node_index}")
+            peer_id = backend.wakuext_service.peer_id()
+            known_nodes[peer_id] = f"backend_{node_index}"
+            nodes[peer_id] = backend
+            logging.info(f"Backend {node_index} ready. Peer ID: {peer_id}")
+
+        # Run threads, each waiting for wakuv2.peerstats signal
+        logging.info("Starting threads to wait for wakuv2.peerstats signals...")
+        threads = []
+
+        for i in range(nodes_count):
+            thread = threading.Thread(target=create_node, args=(i,))
+            thread.daemon = True
+            thread.start()
+            threads.append(thread)
+
+        for thread in threads:
+            thread.join()
+
+        for peer_id, node in nodes.items():
+            assert node is not None, f"Node {peer_id} is None"
+
+        # Wait for all nodes to discover each other
+        start_time = time.time()
+        while time.time() - start_time < DISCOVERY_TIMEOUT_SEC:
+            if _all_nodes_discovered(nodes, known_nodes):
+                break
+            time.sleep(0.5)
+        else:
+            pytest.fail(f"Nodes failed to discover each other within {DISCOVERY_TIMEOUT_SEC} seconds")

--- a/tests-functional/tests/test_discovery.py
+++ b/tests-functional/tests/test_discovery.py
@@ -13,7 +13,7 @@ def _all_nodes_discovered(nodes: dict[str, StatusBackend], known_peers: dict[str
     for peer_id, node in nodes.items():
         if node is None:
             return False
-        response = node.wakuext_service.peers(enable_logging=False)
+        response = node.wakuext_service.peers()
         peers = response["result"]
 
         # Use shorter names for logging
@@ -61,7 +61,7 @@ class TestDiscovery:
         for thread in threads:
             thread.join()
 
-        assert len(nodes) == nodes_count, "Not all nodes created"
+        assert len(nodes.keys()) == nodes_count, "Not all nodes created"
 
         # Wait for all nodes to discover each other
         start_time = time.time()

--- a/tests-functional/tests/test_discovery.py
+++ b/tests-functional/tests/test_discovery.py
@@ -61,14 +61,13 @@ class TestDiscovery:
         for thread in threads:
             thread.join()
 
-        for peer_id, node in nodes.items():
-            assert node is not None, f"Node {peer_id} is None"
+        assert len(nodes) == nodes_count, "Not all nodes created"
 
         # Wait for all nodes to discover each other
         start_time = time.time()
         while time.time() - start_time < DISCOVERY_TIMEOUT_SEC:
             if _all_nodes_discovered(nodes, known_nodes):
-                break
+                return
             time.sleep(0.5)
-        else:
-            pytest.fail(f"Nodes failed to discover each other within {DISCOVERY_TIMEOUT_SEC} seconds")
+
+        assert False, f"Nodes failed to discover each other within {DISCOVERY_TIMEOUT_SEC} seconds"


### PR DESCRIPTION
Fixes https://github.com/status-im/status-go/issues/6886
Requires https://github.com/status-im/status-go/pull/6902

# Description

1. Instead of adding the docker compose network, we set it in `container_args`.
This way we ensure that `StatusBackend` container is only connected to our docker compose network, and not connected to the bridge.

    UPD: I've had to move this part to https://github.com/status-im/status-go/pull/6902. WIll probably merge these 2 PRs together.

2. Implemented `test_discovery` that starts 3 backends and checks that they connect to each other within 10 seconds.

3. Removed redundant `Waku.discV5BootstrapNodes` property