### PR TITLE
feat(backup): implement messages backup poc

### DIFF
--- a/appdatabase/migrations/sql/1757511667_add_messages-backup_enabled.up.sql
+++ b/appdatabase/migrations/sql/1757511667_add_messages-backup_enabled.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settings ADD COLUMN messages_backup_enabled BOOLEAN DEFAULT FALSE;

--- a/multiaccounts/settings/columns.go
+++ b/multiaccounts/settings/columns.go
@@ -166,6 +166,11 @@ var (
 		reactFieldName: "log-level",
 		dBColumnName:   "log_level",
 	}
+	MessagesBackupEnabled = SettingField{
+		reactFieldName: "messages-backup-enabled",
+		dBColumnName:   "messages_backup_enabled",
+		valueHandler:   BoolHandler,
+	}
 	MessagesFromContactsOnly = SettingField{
 		reactFieldName: "messages-from-contacts-only",
 		dBColumnName:   "messages_from_contacts_only",
@@ -560,6 +565,7 @@ var (
 		LinkPreviewRequestEnabled,
 		LinkPreviewsEnabledSites,
 		LogLevel,
+		MessagesBackupEnabled,
 		MessagesFromContactsOnly,
 		Mnemonic,
 		MnemonicRemoved,

--- a/multiaccounts/settings/database.go
+++ b/multiaccounts/settings/database.go
@@ -410,7 +410,7 @@ func (db *Database) GetSettings() (Settings, error) {
 		mnemonic_was_not_shown, wallet_show_community_asset_when_sending_tokens, wallet_display_assets_below_balance,
 		wallet_display_assets_below_balance_threshold, wallet_collectible_preferences_group_by_collection, wallet_collectible_preferences_group_by_community,
 		peer_syncing_enabled, auto_refresh_tokens_enabled, last_tokens_update, news_feed_enabled, news_feed_last_fetched_timestamp, news_rss_enabled, backup_path,
-		thirdparty_services_enabled
+		thirdparty_services_enabled, messages_backup_enabled
 	FROM
 		settings
 	WHERE
@@ -497,6 +497,7 @@ func (db *Database) GetSettings() (Settings, error) {
 		&s.NewsRSSEnabled,
 		&s.BackupPath,
 		&s.ThirdpartyServicesEnabled,
+		&s.MessagesBackupEnabled,
 	)
 
 	if err != nil {
@@ -919,6 +920,14 @@ func (db *Database) ThirdpartyServicesEnabled() (result bool, err error) {
 	err = db.makeSelectRow(ThirdpartyServicesEnabled).Scan(&result)
 	if err == sql.ErrNoRows {
 		return true, nil
+	}
+	return result, err
+}
+
+func (db *Database) MessagesBackupEnabled() (result bool, err error) {
+	err = db.makeSelectRow(MessagesBackupEnabled).Scan(&result)
+	if err == sql.ErrNoRows {
+		return result, nil
 	}
 	return result, err
 }

--- a/multiaccounts/settings/database_settings_manager.go
+++ b/multiaccounts/settings/database_settings_manager.go
@@ -60,6 +60,7 @@ type DatabaseSettingsManager interface {
 	CanSyncOnMobileNetwork() (result bool, err error)
 	ShouldBroadcastUserStatus() (result bool, err error)
 	BackupPath() (result string, err error)
+	MessagesBackupEnabled() (result bool, err error)
 	AutoMessageEnabled() (result bool, err error)
 	ENSName() (string, error)
 	DeviceName() (string, error)

--- a/multiaccounts/settings/database_test.go
+++ b/multiaccounts/settings/database_test.go
@@ -347,3 +347,21 @@ func TestDatabase_ThirdpartyServicesEnabled(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, settings.ThirdpartyServicesEnabled, "expected ThirdpartyServicesEnabled to be true after enabling")
 }
+
+func TestDatabase_MessagesBackupEnabled(t *testing.T) {
+	db, stop := setupTestDB(t)
+	defer stop()
+
+	require.NoError(t, db.CreateSettings(settings, config))
+
+	enabled, err := db.MessagesBackupEnabled()
+	require.NoError(t, err)
+	require.Equal(t, false, enabled)
+
+	err = db.SaveSetting(MessagesBackupEnabled.GetReactName(), true)
+	require.NoError(t, err)
+
+	settings, err = db.GetSettings()
+	require.NoError(t, err)
+	require.Equal(t, true, settings.MessagesBackupEnabled)
+}

--- a/multiaccounts/settings/structs.go
+++ b/multiaccounts/settings/structs.go
@@ -210,6 +210,7 @@ type Settings struct {
 	GifFavorites                        *json.RawMessage              `json:"gifs/favorite-gifs"`
 	OpenseaEnabled                      bool                          `json:"opensea-enabled?,omitempty"`
 	BackupPath                          string                        `json:"backup-path,omitempty"`
+	MessagesBackupEnabled               bool                          `json:"messages-backup-enabled?,omitempty"`
 	AutoMessageEnabled                  bool                          `json:"auto-message-enabled?,omitempty"`
 	GifAPIKey                           string                        `json:"gifs/api-key"`
 	TestNetworksEnabled                 bool                          `json:"test-networks-enabled?,omitempty"`

--- a/protocol/common/message_test.go
+++ b/protocol/common/message_test.go
@@ -3,7 +3,7 @@ package common
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -22,7 +22,7 @@ func TestPrepareContentImage(t *testing.T) {
 	require.NoError(t, err)
 	defer file.Close()
 
-	payload, err := ioutil.ReadAll(file)
+	payload, err := io.ReadAll(file)
 	require.NoError(t, err)
 
 	message := NewMessage()
@@ -42,7 +42,7 @@ func TestPrepareContentAudio(t *testing.T) {
 	require.NoError(t, err)
 	defer file.Close()
 
-	payload, err := ioutil.ReadAll(file)
+	payload, err := io.ReadAll(file)
 	require.NoError(t, err)
 
 	message := NewMessage()

--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -12,6 +12,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/lib/pq"
 
+	"github.com/status-im/markdown"
+
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -120,6 +122,37 @@ func (db sqlitePersistence) tableUserMessagesAllFields() string {
 		replied,
     	discord_message_id,
 		payment_requests`
+}
+
+func (db sqlitePersistence) tableUserMessagesProtobufFields() string {
+	return `
+			m1.id,
+    		m1.whisper_timestamp,
+    		m1.text,
+    		m1.source,
+			m1.response_to,
+    		m1.chat_id,
+    		m1.message_type,
+    		m1.content_type,
+
+			m1.sticker_pack,
+			m1.sticker_hash,
+
+			m1.image_payload,
+			m1.image_type,
+
+			COALESCE(m1.album_id, ""),
+			COALESCE(m1.album_images_count, 0),
+			COALESCE(m1.image_width, 0),
+			COALESCE(m1.image_height, 0),
+
+			m1.links,
+			m1.unfurled_links,
+			m1.unfurled_status_links,
+
+			m1.payment_requests,
+
+			pm.pinned_by`
 }
 
 // keep the same order as in tableUserMessagesScanAllFields
@@ -517,6 +550,91 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 		message.Payload = &protobuf.ChatMessage_BridgeMessage{
 			BridgeMessage: bridgeMessage,
 		}
+	}
+
+	return nil
+}
+
+// keep the same order as in tableUserMessagesProtobufFields
+func (db sqlitePersistence) tableUserMessagesScanProtobufFields(row scanner, message *protobuf.BackedUpMessage, others ...interface{}) error {
+
+	sticker := &protobuf.StickerMessage{}
+	image := &protobuf.ImageMessage{}
+	var serializedLinks []byte
+	var serializedUnfurledLinks []byte
+	var serializedPaymentRequests []byte
+	var serializedUnfurledStatusLinks []byte
+	var pinnedBy sql.NullString
+
+	args := []interface{}{
+		&message.Id,
+		&message.Timestamp,
+		&message.Text,
+		&message.From, // source in table
+		&message.ResponseTo,
+		&message.ChatId,
+		&message.MessageType,
+		&message.ContentType,
+
+		&sticker.Pack,
+		&sticker.Hash,
+
+		&image.Payload,
+		&image.Format,
+
+		&image.AlbumId,
+		&image.AlbumImagesCount,
+		&image.Width,
+		&image.Height,
+
+		&serializedLinks,
+		&serializedUnfurledLinks,
+		&serializedUnfurledStatusLinks,
+
+		&serializedPaymentRequests,
+
+		&pinnedBy,
+	}
+	err := row.Scan(append(args, others...)...)
+	if err != nil {
+		return err
+	}
+
+	if serializedUnfurledLinks != nil {
+		err = json.Unmarshal(serializedUnfurledLinks, &message.UnfurledLinks)
+		if err != nil {
+			return err
+		}
+	}
+
+	if serializedUnfurledStatusLinks != nil {
+		// use proto.Marshal, because json.Marshal doesn't support `oneof` fields
+		var links protobuf.UnfurledStatusLinks
+		err = proto.Unmarshal(serializedUnfurledStatusLinks, &links)
+		if err != nil {
+			return err
+		}
+		message.UnfurledStatusLinks = &links
+	}
+
+	if serializedPaymentRequests != nil {
+		err := json.Unmarshal(serializedPaymentRequests, &message.PaymentRequests)
+		if err != nil {
+			return err
+		}
+	}
+
+	if pinnedBy.Valid {
+		message.PinnedBy = pinnedBy.String
+	}
+
+	switch message.ContentType {
+	case int64(protobuf.ChatMessage_STICKER):
+		message.Payload = &protobuf.BackedUpMessage_Sticker{Sticker: sticker}
+
+	case int64(protobuf.ChatMessage_IMAGE):
+		message.Payload = &protobuf.BackedUpMessage_Image{Image: image}
+
 	}
 
 	return nil
@@ -1329,6 +1447,229 @@ func (db sqlitePersistence) MessageByChatIDs(chatIDs []string, currCursor string
 		result = result[:limit]
 	}
 	return result, newCursor, nil
+}
+
+func (db sqlitePersistence) AllMessagesForBackup() ([]*protobuf.BackedUpMessage, error) {
+	where := "WHERE NOT(m1.hide)"
+	fields := db.tableUserMessagesProtobufFields()
+	selectQuery := `SELECT    %s
+				FROM      user_messages m1
+				LEFT JOIN pin_messages pm
+				ON 	      m1.id = pm.message_id AND pm.pinned = 1`
+	query := fmt.Sprintf(selectQuery, fields) + " " + where
+	rows, err := db.db.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var messages []*protobuf.BackedUpMessage
+	for rows.Next() {
+		message := &protobuf.BackedUpMessage{}
+		if err := db.tableUserMessagesScanProtobufFields(rows, message); err != nil {
+			return nil, err
+		}
+
+		messages = append(messages, message)
+	}
+
+	return messages, nil
+}
+
+func (db sqlitePersistence) saveBackedUpMessages(messages []*protobuf.BackedUpMessage) error {
+	if len(messages) == 0 {
+		return nil
+	}
+
+	tx, err := db.db.BeginTx(context.Background(), &sql.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+			return
+		}
+		// don't shadow original error
+		_ = tx.Rollback()
+	}()
+
+	allFields := db.tableUserMessagesAllFields()
+	valuesVector := strings.Repeat("?, ", db.tableUserMessagesAllFieldsCount()-1) + "?"
+	query := "INSERT OR REPLACE INTO user_messages(" + allFields + ") VALUES (" + valuesVector + ")" //nolint: gosec
+	stmt, err := tx.Prepare(query)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, msg := range messages {
+		allValues, err := db.backedUpMessageToUserMessageValues(msg)
+		if err != nil {
+			return err
+		}
+
+		_, err = stmt.Exec(allValues...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (db sqlitePersistence) saveBackedUpPinMessages(messages []*protobuf.BackedUpMessage) error {
+	pinMessages := make([]*common.PinMessage, 0)
+
+	for _, msg := range messages {
+		if msg.PinnedBy == "" {
+			continue
+		}
+
+		pinMessage := protobuf.PinMessage{
+			Clock:       msg.Timestamp,
+			MessageId:   msg.Id,
+			ChatId:      msg.ChatId,
+			MessageType: msg.MessageType,
+			Pinned:      true,
+		}
+		pinMessages = append(pinMessages, &common.PinMessage{
+			ID:               msg.Id, // TODO do we need a special ID?
+			From:             msg.PinnedBy,
+			PinMessage:       &pinMessage,
+			WhisperTimestamp: msg.Timestamp,
+		})
+	}
+
+	if len(pinMessages) == 0 {
+		return nil
+	}
+
+	return db.SavePinMessages(pinMessages)
+}
+
+func (db sqlitePersistence) SaveBackedUpMessages(messages []*protobuf.BackedUpMessage) error {
+	if len(messages) == 0 {
+		return nil
+	}
+
+	err := db.saveBackedUpMessages(messages)
+	if err != nil {
+		return err
+	}
+
+	err = db.saveBackedUpPinMessages(messages)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (db sqlitePersistence) backedUpMessageToUserMessageValues(message *protobuf.BackedUpMessage) ([]interface{}, error) {
+	parsedText := markdown.Parse([]byte(message.Text), nil)
+	jsonParsedText, err := json.Marshal(parsedText)
+	if err != nil {
+		return nil, err
+	}
+
+	sticker := message.GetSticker()
+	if sticker == nil {
+		sticker = &protobuf.StickerMessage{}
+	}
+
+	image := message.GetImage()
+	if image == nil {
+		image = &protobuf.ImageMessage{}
+	}
+
+	var serializedUnfurledLinks []byte
+	if links := message.GetUnfurledLinks(); len(links) > 0 {
+		serializedUnfurledLinks, err = json.Marshal(links)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var serializedUnfurledStatusLinks []byte
+	if links := message.GetUnfurledStatusLinks(); links != nil {
+		// use proto.Marshal, because json.Marshal doesn't support `oneof` fields
+		serializedUnfurledStatusLinks, err = proto.Marshal(links)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var serializedPaymentRequests []byte
+	if paymentRequests := message.GetPaymentRequests(); len(paymentRequests) > 0 {
+		serializedPaymentRequests, err = json.Marshal(paymentRequests)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Convert protobuf MessageType to the expected format
+	messageType := message.MessageType
+
+	return []interface{}{
+		message.GetId(),               // id
+		message.GetTimestamp(),        // whisper_timestamp
+		message.GetFrom(),             // source
+		message.GetText(),             // text
+		message.GetContentType(),      // content_type
+		"",                            // username (alias) - not available in BackedUpMessage
+		message.GetTimestamp(),        // timestamp
+		message.GetChatId(),           // chat_id
+		message.GetChatId(),           // local_chat_id (same as chat_id) // TODO this should be adapated if 1-1
+		messageType,                   // message_type
+		message.GetClock(),            // clock_value
+		false,                         // seen
+		"",                            // outgoing_status
+		jsonParsedText,                // parsed_text
+		sticker.GetPack(),             // sticker_pack
+		sticker.GetHash(),             // sticker_hash
+		image.GetPayload(),            // image_payload
+		int64(image.GetFormat()),      // image_type
+		image.GetAlbumId(),            // album_id
+		nil,                           // album_images
+		image.GetAlbumImagesCount(),   // album_images_count
+		image.GetWidth(),              // image_width
+		image.GetHeight(),             // image_height
+		"",                            // image_base64
+		nil,                           // audio_payload
+		0,                             // audio_type
+		0,                             // audio_duration_ms
+		"",                            // audio_base64
+		"",                            // community_id
+		nil,                           // mentions
+		nil,                           // links
+		serializedUnfurledLinks,       // unfurled_links
+		serializedUnfurledStatusLinks, // unfurled_status_links
+		"",                            // command_id
+		"",                            // command_value
+		"",                            // command_from
+		"",                            // command_address
+		"",                            // command_contract
+		"",                            // command_transaction_hash
+		0,                             // command_state
+		nil,                           // command_signature
+		"",                            // replace
+		int64(0),                      // edited_at
+		false,                         // deleted
+		"",                            // deleted_by
+		false,                         // deleted_for_me
+		false,                         // rtl
+		0,                             // line_count
+		message.GetResponseTo(),       // response_to
+		uint32(0),                     // gap_from
+		uint32(0),                     // gap_to
+		0,                             // contact_request_state
+		0,                             // contact_verification_state
+		false,                         // mentioned
+		false,                         // replied
+		"",                            // discord_message_id
+		serializedPaymentRequests,     // payment_requests
+	}, nil
 }
 
 func (db sqlitePersistence) OldestMessageWhisperTimestampByChatIDs(chatIDs []string) (map[string]uint64, error) {

--- a/protocol/messenger_backup_handler.go
+++ b/protocol/messenger_backup_handler.go
@@ -27,29 +27,36 @@ const (
 	SyncWakuSectionKeyWatchOnlyAccounts = "watchOnlyAccounts"
 )
 
-func (m *Messenger) handleLocalBackup(state *ReceivedMessageState, message *protobuf.MessengerLocalBackup) []error {
+func (m *Messenger) handleLocalBackup(state *ReceivedMessageState, backup *protobuf.MessengerLocalBackup) []error {
 	var errors []error
 
-	err := m.handleBackedUpProfile(message.Profile, message.Clock)
+	err := m.handleBackedUpProfile(backup.Profile, backup.Clock)
 	if err != nil {
 		errors = append(errors, err)
 	}
 
-	for _, contact := range message.Contacts {
+	for _, contact := range backup.Contacts {
 		err = m.HandleSyncInstallationContactV2(state, contact, nil)
 		if err != nil {
 			errors = append(errors, err)
 		}
 	}
 
-	err = m.handleSyncChats(state, message.Chats)
+	err = m.handleSyncChats(state, backup.Chats)
 	if err != nil {
 		errors = append(errors, err)
 	}
 
-	communityErrors := m.handleLocalBackupCommunities(state, message.Communities)
+	communityErrors := m.handleLocalBackupCommunities(state, backup.Communities)
 	if len(communityErrors) > 0 {
 		errors = append(errors, communityErrors...)
+	}
+
+	if len(backup.Messages) > 0 {
+		err := m.persistence.SaveBackedUpMessages(backup.Messages)
+		if err != nil {
+			errors = append(errors, err)
+		}
 	}
 
 	return errors
@@ -231,7 +238,7 @@ func (m *Messenger) handleLocalBackupCommunities(state *ReceivedMessageState, co
 			errors = append(errors, err)
 		}
 
-		err = m.requestCommunityKeysAndSharedAddresses(state, syncCommunity)
+		err = m.requestCommunityKeysAndSharedAddresses(syncCommunity)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -240,7 +247,7 @@ func (m *Messenger) handleLocalBackupCommunities(state *ReceivedMessageState, co
 	return errors
 }
 
-func (m *Messenger) requestCommunityKeysAndSharedAddresses(state *ReceivedMessageState, syncCommunity *protobuf.SyncInstallationCommunity) error {
+func (m *Messenger) requestCommunityKeysAndSharedAddresses(syncCommunity *protobuf.SyncInstallationCommunity) error {
 	if !syncCommunity.Joined {
 		return nil
 	}

--- a/protocol/messenger_local_backup.go
+++ b/protocol/messenger_local_backup.go
@@ -233,6 +233,19 @@ func (m *Messenger) backupProfile(clock uint64) (*protobuf.Backup, error) {
 	return backupMessage, nil
 }
 
+func (m *Messenger) backupMessages() ([]*protobuf.BackedUpMessage, error) {
+	messagesBackupEnabled, err := m.settings.MessagesBackupEnabled()
+	if err != nil {
+		return nil, err
+	}
+
+	if !messagesBackupEnabled {
+		return nil, nil
+	}
+
+	return m.persistence.AllMessagesForBackup()
+}
+
 func (m *Messenger) ExportBackup() ([]byte, error) {
 	backup := &protobuf.MessengerLocalBackup{}
 
@@ -258,6 +271,13 @@ func (m *Messenger) ExportBackup() ([]byte, error) {
 	for _, d := range chatsToBackup {
 		backup.Chats = append(backup.Chats, d.Chats...)
 	}
+
+	backupMessages, err := m.backupMessages()
+	if err != nil {
+		return nil, err
+	}
+	backup.Messages = backupMessages
+
 	return proto.Marshal(backup)
 }
 

--- a/protocol/messenger_local_backup_test.go
+++ b/protocol/messenger_local_backup_test.go
@@ -2,12 +2,16 @@ package protocol
 
 import (
 	"context"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
+	"github.com/status-im/status-go/multiaccounts/settings"
+	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 )
@@ -28,6 +32,15 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	// Create bob2
 	bob2 := s.anotherMessenger()
 	defer TearDownMessenger(&s.Suite, bob2)
+
+	// Enable message backup on both accounts
+	err := bob1.settings.SaveSetting(settings.MessagesBackupEnabled.GetReactName(), true)
+	s.Require().NoError(err)
+
+	err = bob2.settings.SaveSetting(settings.MessagesBackupEnabled.GetReactName(), true)
+	s.Require().NoError(err)
+
+	ctx := context.Background()
 
 	// -------------------- CONTACTS --------------------
 	// Create 2 contacts
@@ -76,6 +89,81 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
 	s.Require().Len(response.Communities(), 1)
+
+	// Send message on community
+	chatID := response.Chats()[0].ID
+	inputMessage := common.NewMessage()
+	inputMessage.ChatId = chatID
+	inputMessage.ContentType = protobuf.ChatMessage_TEXT_PLAIN
+	inputMessage.Text = "some text"
+
+	_, err = bob1.SendChatMessage(ctx, inputMessage)
+	s.Require().NoError(err)
+
+	// Pin message
+	pinMessage := common.NewPinMessage()
+	pinMessage.ChatId = chatID
+	pinMessage.MessageId = inputMessage.ID
+	pinMessage.Pinned = true
+	sendResponse, err := bob1.SendPinMessage(ctx, pinMessage)
+	s.Require().NoError(err)
+	s.Require().Len(sendResponse.PinMessages(), 1)
+
+	// Send markdown message
+	mdMessage := common.NewMessage()
+	mdMessage.ChatId = chatID
+	mdMessage.ContentType = protobuf.ChatMessage_TEXT_PLAIN
+	mdMessage.Text = "some *markdown* text"
+
+	_, err = bob1.SendChatMessage(ctx, mdMessage)
+	s.Require().NoError(err)
+
+	// Send image on community
+	file, err := os.Open("../_assets/tests/test.jpg")
+	s.Require().NoError(err)
+	defer file.Close()
+
+	payload, err := io.ReadAll(file)
+	s.Require().NoError(err)
+
+	imageMessage := common.NewMessage()
+	imageMessage.ChatId = chatID
+	imageMessage.ContentType = protobuf.ChatMessage_IMAGE
+
+	image := protobuf.ImageMessage{
+		Payload: payload,
+		Format:  protobuf.ImageFormat_JPEG,
+		Width:   1200,
+		Height:  1000,
+		AlbumId: "",
+	}
+	imageMessage.Payload = &protobuf.ChatMessage_Image{Image: &image}
+	imageMessage.Text = "some image"
+
+	_, err = bob1.SendChatMessage(ctx, imageMessage)
+	s.Require().NoError(err)
+
+	// Send sticker on community
+	stickerMessage := common.NewMessage()
+	stickerMessage.ChatId = chatID
+	stickerMessage.ContentType = protobuf.ChatMessage_STICKER
+	stickerMessage.Text = "some sticker"
+	stickerMessage.Payload = &protobuf.ChatMessage_Sticker{
+		Sticker: &protobuf.StickerMessage{
+			Pack: 1,
+			Hash: "some-hash",
+		},
+	}
+	_, err = bob1.SendChatMessage(ctx, stickerMessage)
+	s.Require().NoError(err)
+
+	// Send emoji on community
+	emojiMessage := common.NewMessage()
+	emojiMessage.ChatId = chatID
+	emojiMessage.ContentType = protobuf.ChatMessage_EMOJI
+	emojiMessage.Text = ":+1:"
+	_, err = bob1.SendChatMessage(ctx, emojiMessage)
+	s.Require().NoError(err)
 
 	// Check bob2
 	communities, err := bob2.Communities()
@@ -127,6 +215,14 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	err = bob1.SaveChat(ourOneOneChat)
 	s.Require().NoError(err)
 
+	// Send transaction command to Alice
+	transactionMessage := common.NewMessage()
+	transactionMessage.ChatId = ourOneOneChat.ID
+	transactionMessage.ContentType = protobuf.ChatMessage_TRANSACTION_COMMAND
+	transactionMessage.Text = "some transaction"
+	_, err = bob1.SendChatMessage(ctx, transactionMessage)
+	s.Require().NoError(err)
+
 	// -------------------- BACKUP --------------------
 	// Backup
 	marshalledBackup, err := bob1.ExportBackup()
@@ -156,4 +252,50 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	s.Require().True(ok)
 	s.Require().True(chat.Active)
 	s.Require().Equal("", chat.Name)
+
+	// Validate messages
+	s.Require().NoError(err)
+	messages, err := bob2.persistence.AllMessagesForBackup()
+	s.Require().NoError(err)
+	s.Require().Len(messages, 14)
+
+	textMessageFound := false
+	mdMessageFound := false
+	imageMessageFound := false
+	stickerMessageFound := false
+	emojiMessageFound := false
+	txMessageFound := false
+	pinnedSystemMessageFound := false
+	for _, msg := range messages {
+		if msg.ContentType == int64(protobuf.ChatMessage_TEXT_PLAIN) && msg.Text == "some text" {
+			textMessageFound = true
+			s.Require().True(msg.PinnedBy == bob2.selfContact.ID)
+		} else if msg.ContentType == int64(protobuf.ChatMessage_TEXT_PLAIN) && msg.Text == "some *markdown* text" {
+			mdMessageFound = true
+		} else if msg.ContentType == int64(protobuf.ChatMessage_IMAGE) && msg.Text == "some image" {
+			imageMessageFound = true
+		} else if msg.ContentType == int64(protobuf.ChatMessage_STICKER) && msg.Text == "some sticker" {
+			stickerMessageFound = true
+		} else if msg.ContentType == int64(protobuf.ChatMessage_EMOJI) && msg.Text == ":+1:" {
+			emojiMessageFound = true
+		} else if msg.ContentType == int64(protobuf.ChatMessage_TRANSACTION_COMMAND) && msg.Text == "some transaction" {
+			txMessageFound = true
+		} else if msg.ContentType == int64(protobuf.ChatMessage_SYSTEM_MESSAGE_PINNED_MESSAGE) && msg.Text == "" {
+			pinnedSystemMessageFound = true
+		}
+	}
+	s.Require().True(textMessageFound)
+	s.Require().True(mdMessageFound)
+	s.Require().True(imageMessageFound)
+	s.Require().True(stickerMessageFound)
+	s.Require().True(emojiMessageFound)
+	s.Require().True(txMessageFound)
+	s.Require().True(pinnedSystemMessageFound)
+
+	// Validate pinned messages
+	pinnedMessages, _, err := bob2.PinnedMessageByChatID(chatID, "", 10)
+	s.Require().NoError(err)
+	s.Require().Len(pinnedMessages, 1)
+	s.Require().Equal(bob2.selfContact.ID, pinnedMessages[0].PinnedBy)
+
 }

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -2414,13 +2414,13 @@ func (s *MessengerSuite) TestResendExpiredEmojis() {
 
 func buildImageWithAlbumIDMessage(chat Chat, albumID string) (*common.Message, error) {
 	file, err := os.Open("../_assets/tests/test.jpg")
-	if err != err {
+	if err != nil {
 		return nil, err
 	}
 	defer file.Close()
 
 	payload, err := io.ReadAll(file)
-	if err != err {
+	if err != nil {
 		return nil, err
 	}
 

--- a/protocol/protobuf/messenger_local_backup.proto
+++ b/protocol/protobuf/messenger_local_backup.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 
 import "pairing.proto";
+import "chat_message.proto";
+import "enums.proto";
 
 option go_package = "./;protobuf";
 package protobuf;
@@ -13,4 +15,47 @@ message MessengerLocalBackup {
   repeated SyncInstallationCommunity communities = 3;
   repeated SyncChat chats = 4;
   BackedUpProfile profile = 5;
+  repeated BackedUpMessage messages = 6;
+}
+
+message BackedUpMessage {
+  // Lamport timestamp of the chat message
+  uint64 clock = 1;
+
+  // ID generated from the sender's public key and the message payload
+  string id = 2;
+  // The public key of the sender of the message
+  string from = 3;
+
+  // Unix timestamps in milliseconds, currently not used as we use whisper as
+  // more reliable, but here so that we don't rely on it
+  uint64 timestamp = 4;
+  // Text of the message
+  string text = 5;
+  // Id of the message that we are replying to
+  string response_to = 6;
+  // Chat id, this field is symmetric for public-chats and private group chats,
+  // but asymmetric in case of one-to-ones, as the sender will use the chat-id
+  // of the received, while the receiver will use the chat-id of the sender.
+  // Probably should be the concatenation of sender-pk & receiver-pk in
+  // alphabetical order
+  string chat_id = 7;
+
+  // The type of message (public/one-to-one/private-group-chat)
+  MessageType message_type = 8;
+  // The type of the content of the message
+  int64 content_type = 9;
+
+  oneof payload {
+    StickerMessage sticker = 10;
+    ImageMessage image = 11;
+  }
+
+  repeated UnfurledLink unfurled_links = 12;
+
+  UnfurledStatusLinks unfurled_status_links = 13;
+
+  repeated PaymentRequest payment_requests = 14;
+
+  string pinned_by = 15;
 }

--- a/services/accounts/settings.go
+++ b/services/accounts/settings.go
@@ -66,6 +66,10 @@ func (api *SettingsAPI) BackupPath() (string, error) {
 	return api.db.BackupPath()
 }
 
+func (api *SettingsAPI) MessagesBackupEnabled() (bool, error) {
+	return api.db.MessagesBackupEnabled()
+}
+
 // Notifications Settings
 func (api *SettingsAPI) NotificationsGetAllowNotifications() (bool, error) {
 	return api.db.GetAllowNotifications()


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/18529

Implements a rough but functional proof of concept for message backup and import.

It is guarded by a new setting so that you need to opt-in to have it, thus not breaking PFS by default.

It works for text messages, contacts requests, images, emojis, transaction commands and stickers.

The only missing part is pinned messages. I am able to export the PinnedBy value, but when I try import and recreated the PinnedMessage, it crashes. I'll need to figure it out

### Screencapture

I improved the test to test the new behavior and tested in desktop. Both worked. 

Here is what it looks like in the imported account:

[imported-messages.webm](https://github.com/user-attachments/assets/7ba788a0-0c3b-41d5-8833-f6f5f5e961ef)


### How to test

To test, you'll need to enable the setting, either by hardcoding it or updating the client to be able to change it

### Next steps

- Fix the pinned message crash
- test the new message backup in the functional test too
- Integrate it in Desktop
- Clean up