### PR TITLE
test: run functional tests with nwaku 0.36

### DIFF
--- a/messaging/waku/nwaku_test.go
+++ b/messaging/waku/nwaku_test.go
@@ -163,7 +163,7 @@ func newTestStorenodeConfigProvider(storenode peer.AddrInfo) history.StorenodeCo
 //
 //	IP_ADDRESS=$(hostname -I | awk '{print $1}');
 // 	docker run \
-// 	-p 61000:61000/tcp -p 8000:8000/udp -p 8646:8646/tcp harbor.status.im/wakuorg/nwaku:v0.33.0 \
+// 	-p 61000:61000/tcp -p 8000:8000/udp -p 8646:8646/tcp harbor.status.im/wakuorg/nwaku:v0.36.0 \
 // 	--discv5-discovery=true --cluster-id=16 --log-level=DEBUG --shard=64 --tcp-port=61000 \
 // 	--nat=extip:${IP_ADDRESS} --discv5-udp-port=8000 --rest-address=0.0.0.0 --store --rest-port=8646 \
 

--- a/messaging/waku/waku_test.go
+++ b/messaging/waku/waku_test.go
@@ -163,7 +163,7 @@ func parseNodes(rec []string) []*enode.Node {
 //
 //	IP_ADDRESS=$(hostname -I | awk '{print $1}');
 //	docker run \
-//	 -p 60000:60000/tcp -p 9000:9000/udp -p 8645:8645/tcp harbor.status.im/wakuorg/nwaku:v0.31.0 \
+//	 -p 60000:60000/tcp -p 9000:9000/udp -p 8645:8645/tcp harbor.status.im/wakuorg/nwaku:v0.36.0 \
 //	 --tcp-port=60000 --discv5-discovery=true --cluster-id=16 --pubsub-topic=/waku/2/rs/16/32 --pubsub-topic=/waku/2/rs/16/64 \
 //	 --nat=extip:${IP_ADDRESS} --discv5-discovery --discv5-udp-port=9000 --rest-address=0.0.0.0 --store
 

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -1,6 +1,6 @@
 services:
   boot-1:
-    image: wakuorg/nwaku:v0.34.0
+    image: wakuorg/nwaku:v0.36.0
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
@@ -33,7 +33,7 @@ services:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
 
   store:
-    image: wakuorg/nwaku:v0.34.0
+    image: wakuorg/nwaku:v0.36.0
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",


### PR DESCRIPTION
Run functional tests with nwaku 0.36, as this is the version used in `status.prod` fleet