### PR TITLE
chore: pull token manager out of services and pass it

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -2341,6 +2341,7 @@ func (b *GethStatusBackend) initProtocol() error {
 		AccountsPublisher:      b.statusNode.AccountsPublisher(),
 		TimeSource:             b.statusNode.TimeSource(),
 		MetricsEnabled:         b.prometheusMetrics != nil,
+		TokenManager:           b.statusNode.TokenManager(),
 	}
 	err = st.InitProtocol(params)
 	if err != nil {

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -15,9 +15,8 @@ import (
 
 	"go.uber.org/zap"
 
-	gethrpc "github.com/ethereum/go-ethereum/rpc"
-
 	"github.com/ethereum/go-ethereum/event"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
 
 	accsmanagement "github.com/status-im/status-go/accounts-management"
 	common2 "github.com/status-im/status-go/common"
@@ -25,6 +24,7 @@ import (
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/ipfs"
 	"github.com/status-im/status-go/multiaccounts"
+	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/node/backup"
 	rpc2 "github.com/status-im/status-go/node/rpc"
 	"github.com/status-im/status-go/params"
@@ -50,6 +50,8 @@ import (
 	"github.com/status-im/status-go/services/updates"
 	"github.com/status-im/status-go/services/wakuv2ext"
 	"github.com/status-im/status-go/services/wallet"
+	"github.com/status-im/status-go/services/wallet/community"
+	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/timesource"
 	"github.com/status-im/status-go/transactions"
 )
@@ -81,6 +83,8 @@ type StatusNode struct {
 
 	mediaServerEnableTLS *bool
 	httpServer           *server.MediaServer
+
+	tokenManager *token.Manager
 
 	logger *zap.Logger
 
@@ -291,6 +295,10 @@ func (n *StatusNode) startWithDB(config *params.NodeConfig) error {
 		return err
 	}
 
+	if err := n.createAndStartTokenManager(); err != nil {
+		return err
+	}
+
 	if err := n.initServices(config, n.httpServer); err != nil {
 		return err
 	}
@@ -322,6 +330,34 @@ func (n *StatusNode) startWithDB(config *params.NodeConfig) error {
 		}
 	}
 
+	return nil
+}
+
+func (n *StatusNode) createAndStartTokenManager() error {
+	accDB, err := accounts.NewDB(n.appDB)
+	if err != nil {
+		return err
+	}
+
+	n.tokenManager = token.NewTokenManager(n.walletDB, n.rpcClient, community.NewManager(n.appDB, n.httpServer, nil),
+		n.rpcClient.GetNetworkManager(), n.appDB, n.httpServer, &n.walletFeed, n.accountsPublisher, accDB,
+		token.NewPersistence(n.walletDB))
+
+	const (
+		defaultAutoRefreshInterval      = 30 * time.Minute // interval after which we should fetch the token lists from the remote source (or use the default one if remote source is not set)
+		defaultAutoRefreshCheckInterval = 3 * time.Minute  // interval after which we should check if we should trigger the auto-refresh
+	)
+
+	autoRefreshInterval := defaultAutoRefreshInterval
+	autoRefreshCheckInterval := defaultAutoRefreshCheckInterval
+	if n.config.WalletConfig.TokensListsAutoRefreshInterval > 0 &&
+		n.config.WalletConfig.TokensListsAutoRefreshCheckInterval > 0 &&
+		n.config.WalletConfig.TokensListsAutoRefreshInterval > n.config.WalletConfig.TokensListsAutoRefreshCheckInterval {
+		autoRefreshInterval = time.Duration(n.config.WalletConfig.TokensListsAutoRefreshInterval) * time.Second
+		autoRefreshCheckInterval = time.Duration(n.config.WalletConfig.TokensListsAutoRefreshCheckInterval) * time.Second
+	}
+
+	n.tokenManager.Start(context.Background(), autoRefreshInterval, autoRefreshCheckInterval)
 	return nil
 }
 
@@ -442,4 +478,8 @@ func (n *StatusNode) SetWalletDB(db *sql.DB) {
 
 func (n *StatusNode) GetWalletDB() *sql.DB {
 	return n.walletDB
+}
+
+func (n *StatusNode) TokenManager() *token.Manager {
+	return n.tokenManager
 }

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -291,6 +291,7 @@ func (b *StatusNode) walletService(accountsDB *accounts.Database, appDB *sql.DB,
 			b.pendingTracker,
 			walletFeed,
 			b.httpServer,
+			b.tokenManager,
 			statusProxyStageName,
 		)
 	}

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -313,7 +313,7 @@ func newTestCommunitiesMessenger(s *suite.Suite, messagingEnv *messaging.TestMes
 
 	options := []Option{
 		WithAccountsManager(accountsManagerMock),
-		WithTokenManager(tokenManagerMock),
+		WithCommunityTokenManager(tokenManagerMock),
 		WithMessageSigner(NewSignerStub()),
 		WithCollectiblesManager(config.collectiblesManager),
 		WithCommunityTokensService(config.collectiblesService),

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -55,8 +55,6 @@ import (
 	localnotifications "github.com/status-im/status-go/services/local-notifications"
 	mailserversDB "github.com/status-im/status-go/services/mailservers"
 	"github.com/status-im/status-go/services/wallet"
-	"github.com/status-im/status-go/services/wallet/community"
-	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/signal"
 
 	_ "github.com/mmcdole/gofeed"
@@ -332,11 +330,11 @@ func NewMessenger(
 		managerOptions = append(managerOptions, communities.WithCollectiblesManager(c.collectiblesManager))
 	}
 
-	if c.tokenManager != nil {
-		managerOptions = append(managerOptions, communities.WithTokenManager(c.tokenManager))
-	} else if c.rpcClient != nil {
-		tokenManager := token.NewTokenManager(c.walletDb, c.rpcClient, community.NewManager(database, c.httpServer, nil), c.rpcClient.GetNetworkManager(), database, c.httpServer, nil, nil, nil, token.NewPersistence(c.walletDb))
-		managerOptions = append(managerOptions, communities.WithTokenManager(communities.NewDefaultTokenManager(tokenManager, c.rpcClient.GetNetworkManager())))
+	if c.communityTokenManager != nil {
+		managerOptions = append(managerOptions, communities.WithTokenManager(c.communityTokenManager))
+	} else if c.rpcClient != nil && c.tokenManager != nil {
+		managerOptions = append(managerOptions, communities.WithTokenManager(
+			communities.NewDefaultTokenManager(c.tokenManager, c.rpcClient.GetNetworkManager())))
 	}
 
 	if c.communityTokensService != nil {

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/sqlite"
 	"github.com/status-im/status-go/protocol/tt"
+	"github.com/status-im/status-go/rpc/network"
 	"github.com/status-im/status-go/services/browsers"
+	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/t/helpers"
 	"github.com/status-im/status-go/walletdatabase"
 )
@@ -144,6 +146,8 @@ func newTestMessenger(messagingEnv *messaging.TestMessagingEnvironment, config t
 		"",
 	)
 
+	tokenManager := token.NewTokenManager(walletDb, nil, nil, network.NewManager(appDb, nil), appDb, nil, nil, nil, nil, token.NewPersistence(walletDb))
+
 	options := []Option{
 		WithCustomLogger(config.logger),
 		WithDatabase(appDb),
@@ -156,6 +160,7 @@ func newTestMessenger(messagingEnv *messaging.TestMessagingEnvironment, config t
 		WithStubOnlineChecker(),
 		WithENSVerifier(ensVerifier),
 		WithMessageSigner(NewSignerStub()),
+		WithTokenManager(tokenManager),
 	}
 	options = append(options, config.extraOptions...)
 

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/browsers"
+	"github.com/status-im/status-go/services/wallet/token"
 
 	"go.uber.org/zap"
 
@@ -83,7 +84,8 @@ type config struct {
 	communityTokensService communities.CommunityTokensServiceInterface
 	httpServer             *server.MediaServer
 	rpcClient              *rpc.Client
-	tokenManager           communities.TokenManager
+	tokenManager           *token.Manager
+	communityTokenManager  communities.TokenManager
 	collectiblesManager    communities.CollectiblesManager
 	accountsManager        AccountsManager
 	signer                 communities.MessageSigner
@@ -294,7 +296,14 @@ func WithCommunityTokensService(s communities.CommunityTokensServiceInterface) O
 	}
 }
 
-func WithTokenManager(tokenManager communities.TokenManager) Option {
+func WithCommunityTokenManager(tokenManager communities.TokenManager) Option {
+	return func(c *config) error {
+		c.communityTokenManager = tokenManager
+		return nil
+	}
+}
+
+func WithTokenManager(tokenManager *token.Manager) Option {
 	return func(c *config) error {
 		c.tokenManager = tokenManager
 		return nil

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -39,7 +39,7 @@ import (
 	"github.com/status-im/status-go/protocol"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
-	"github.com/status-im/status-go/protocol/communities/token"
+	communitiestoken "github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/ens"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/pushnotificationclient"
@@ -54,6 +54,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/collectibles"
 	w_common "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
+	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/signal"
 )
 
@@ -111,6 +112,7 @@ type InitProtocolParams struct {
 	AccountsPublisher      *pubsub.Publisher
 	TimeSource             timesource.TimeSource
 	MetricsEnabled         bool
+	TokenManager           *token.Manager
 }
 
 func (s *Service) InitProtocol(params InitProtocolParams) error {
@@ -193,7 +195,10 @@ func (s *Service) InitProtocol(params InitProtocolParams) error {
 		s.config.ShhextConfig.VerifyENSContractAddress,
 	)
 
-	options, err := buildMessengerOptions(s.config, params.Identity, params.AppDB, params.WalletDB, params.HTTPServer, s.rpcClient, s.multiAccountsDB, params.Account, envelopeEventsConfig, s.accountsDB, params.WalletService, params.CommunityTokensService, s.logger, &MessengerSignalsHandler{}, params.AccountsManager, params.AccountsPublisher, ensVerifier)
+	options, err := buildMessengerOptions(s.config, params.Identity, params.AppDB, params.WalletDB, params.HTTPServer,
+		s.rpcClient, s.multiAccountsDB, params.Account, envelopeEventsConfig, s.accountsDB, params.WalletService,
+		params.CommunityTokensService, s.logger, &MessengerSignalsHandler{}, params.AccountsManager, params.AccountsPublisher,
+		ensVerifier, params.TokenManager)
 	if err != nil {
 		return err
 	}
@@ -430,6 +435,7 @@ func buildMessengerOptions(
 	accountsManager *accsmanagement.AccountsManager,
 	accountsPublisher *pubsub.Publisher,
 	ensVerifier *ens.Verifier,
+	tokenManager *token.Manager,
 ) ([]protocol.Option, error) {
 	personalService := personal.New()
 	options := []protocol.Option{
@@ -455,6 +461,7 @@ func buildMessengerOptions(
 		protocol.WithAccountsPublisher(accountsPublisher),
 		protocol.WithNewsFeed(),
 		protocol.WithMessageSigner(personalService),
+		protocol.WithTokenManager(tokenManager),
 	}
 
 	if config.ShhextConfig.DataSyncEnabled {
@@ -586,7 +593,7 @@ func (s *Service) FillCollectibleMetadata(community *communities.Community, coll
 
 	permission := fetchCommunityCollectiblePermission(community, id)
 
-	privilegesLevel := token.CommunityLevel
+	privilegesLevel := communitiestoken.CommunityLevel
 	if permission != nil {
 		privilegesLevel = permissionTypeToPrivilegesLevel(permission.GetType())
 	}
@@ -621,14 +628,14 @@ func (s *Service) FillCollectibleMetadata(community *communities.Community, coll
 	return nil
 }
 
-func permissionTypeToPrivilegesLevel(permissionType protobuf.CommunityTokenPermission_Type) token.PrivilegesLevel {
+func permissionTypeToPrivilegesLevel(permissionType protobuf.CommunityTokenPermission_Type) communitiestoken.PrivilegesLevel {
 	switch permissionType {
 	case protobuf.CommunityTokenPermission_BECOME_TOKEN_OWNER:
-		return token.OwnerLevel
+		return communitiestoken.OwnerLevel
 	case protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER:
-		return token.MasterLevel
+		return communitiestoken.MasterLevel
 	default:
-		return token.CommunityLevel
+		return communitiestoken.CommunityLevel
 	}
 }
 
@@ -720,7 +727,7 @@ func (s *Service) fetchCommunityInfoForCollectibles(communityID string, ids []th
 	return community, nil
 }
 
-func (s *Service) fetchCommunityToken(communityID string, contractID thirdparty.ContractID) (*token.CommunityToken, error) {
+func (s *Service) fetchCommunityToken(communityID string, contractID thirdparty.ContractID) (*communitiestoken.CommunityToken, error) {
 	if s.messenger == nil {
 		return nil, fmt.Errorf("messenger not ready")
 	}
@@ -826,7 +833,7 @@ func boolToString(value bool) string {
 	return "No"
 }
 
-func getCollectibleCommunityTraits(token *token.CommunityToken) []thirdparty.CollectibleTrait {
+func getCollectibleCommunityTraits(token *communitiestoken.CommunityToken) []thirdparty.CollectibleTrait {
 	if token == nil {
 		return make([]thirdparty.CollectibleTrait, 0)
 	}

--- a/services/wallet/api_test.go
+++ b/services/wallet/api_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/services/wallet/onramp"
 	"github.com/status-im/status-go/services/wallet/requests"
+	"github.com/status-im/status-go/services/wallet/token"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/services/wallet/walletconnect"
 	"github.com/status-im/status-go/t/helpers"
@@ -156,7 +157,9 @@ func TestAPI_GetAddressDetails(t *testing.T) {
 	c, err := rpc.NewClient(config)
 	require.NoError(t, err)
 
-	service := NewService(db, accountsDb, appDB, c, accountsPublisher, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
+	tokenManager := token.NewTokenManager(db, c, nil, nil, appDB, nil, nil, nil, accountsDb, token.NewPersistence(db))
+
+	service := NewService(db, accountsDb, appDB, c, accountsPublisher, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, tokenManager, "")
 
 	api := &API{
 		s: service,

--- a/services/wallet/keycard_pairings_test.go
+++ b/services/wallet/keycard_pairings_test.go
@@ -32,7 +32,8 @@ func TestKeycardPairingsFile(t *testing.T) {
 		AccountsPublisher: accountsPublisher,
 	})
 	require.NoError(t, err)
-	service := NewService(db, accountsDb, appDB, rpcClient, accountsPublisher, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, "")
+
+	service := NewService(db, accountsDb, appDB, rpcClient, accountsPublisher, nil, nil, &params.NodeConfig{}, nil, nil, nil, nil, nil, "")
 
 	data, err := service.KeycardPairings().GetPairingsJSONFileContent()
 	require.NoError(t, err)

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -52,11 +52,6 @@ import (
 	"github.com/status-im/status-go/transactions"
 )
 
-const (
-	defaultAutoRefreshInterval      = 30 * time.Minute // interval after which we should fetch the token lists from the remote source (or use the default one if remote source is not set)
-	defaultAutoRefreshCheckInterval = 3 * time.Minute  // interval after which we should check if we should trigger the auto-refresh
-)
-
 // TODO this is duplicated
 var (
 	ErrNotWatchOnlyAccount           = errors.New("an account is not a watch only account")
@@ -91,6 +86,7 @@ func NewService(
 	pendingTxManager *transactions.PendingTxTracker,
 	feed *event.Feed,
 	mediaServer *server.MediaServer,
+	tokenManager *token.Manager,
 	statusProxyStageName string,
 ) *Service {
 	signals := &walletevent.SignalsTransmitter{
@@ -98,7 +94,6 @@ func NewService(
 	}
 	communityManager := community.NewManager(db, mediaServer, feed)
 	balanceCacher := balance.NewCacherWithTTL(5 * time.Minute)
-	tokenManager := token.NewTokenManager(db, rpcClient, communityManager, rpcClient.GetNetworkManager(), appDB, mediaServer, feed, accountsPublisher, accountsDB, token.NewPersistence(db))
 
 	cryptoOnRampProviders := []onramp.Provider{
 		onramp.NewMoonPayProvider(),
@@ -339,16 +334,6 @@ func (s *Service) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancelWalletServiceCtx = cancel
 
-	autoRefreshInterval := defaultAutoRefreshInterval
-	autoRefreshCheckInterval := defaultAutoRefreshCheckInterval
-	if s.config.WalletConfig.TokensListsAutoRefreshInterval > 0 &&
-		s.config.WalletConfig.TokensListsAutoRefreshCheckInterval > 0 &&
-		s.config.WalletConfig.TokensListsAutoRefreshInterval > s.config.WalletConfig.TokensListsAutoRefreshCheckInterval {
-		autoRefreshInterval = time.Duration(s.config.WalletConfig.TokensListsAutoRefreshInterval) * time.Second
-		autoRefreshCheckInterval = time.Duration(s.config.WalletConfig.TokensListsAutoRefreshCheckInterval) * time.Second
-	}
-
-	s.tokenManager.Start(ctx, autoRefreshInterval, autoRefreshCheckInterval)
 	s.transferController.Start(ctx)
 	s.currency.Start(ctx)
 	err := s.signals.Start(ctx)


### PR DESCRIPTION
The token manager is instantiated and started by the status node, and passed to services and other types that need it.