### PR TITLE
test: attach logs to reliability tests

### DIFF
--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -75,6 +75,7 @@ jobs:
         use-actions-summary: 'true'
 
     - uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: status-backend-logs
-        path: tests-functional/logs
+        path: tests-functional/log

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -63,7 +63,7 @@ jobs:
           --tb=short \
           --docker-image="statusgo-local" \
           --waku-fleet=status.staging \
-          --waku-fleets-config=""
+          --waku-fleets-config="" \
           --logs-dir=tests-functional/log
 
     - name: Test Report

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -64,6 +64,7 @@ jobs:
           --docker-image="statusgo-local" \
           --waku-fleet=status.staging \
           --waku-fleets-config=""
+          --logs-dir=tests-functional/log
 
     - name: Test Report
       if: always()

--- a/.github/workflows/test-reliability.yml
+++ b/.github/workflows/test-reliability.yml
@@ -78,5 +78,5 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: status-backend-logs
+        name: status-backend-logs_${{ matrix.config.name }}
         path: tests-functional/log

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -88,6 +88,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         self.settings_service = SettingsService(self)
         self.connector_service = ConnectorService(self)
         self.expvar_client = ExpvarClient(self.base_url)
+        self.test_name = kwargs.get("test_name", str(uuid.uuid4()))
 
     def __del__(self):
         self.shutdown()
@@ -96,7 +97,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         SignalClient.disconnect(self)
 
         if self.container:
-            self.container.shutdown()
+            self.container.shutdown(self.test_name)
 
         if self.temp_dir is not None:
             self.temp_dir.cleanup()

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -88,16 +88,15 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         self.settings_service = SettingsService(self)
         self.connector_service = ConnectorService(self)
         self.expvar_client = ExpvarClient(self.base_url)
-        self.test_name = kwargs.get("test_name", str(uuid.uuid4()))
 
     def __del__(self):
         self.shutdown()
 
-    def shutdown(self):
+    def shutdown(self, log_sufix=""):
         SignalClient.disconnect(self)
 
         if self.container:
-            self.container.shutdown(self.test_name)
+            self.container.shutdown(log_sufix)
 
         if self.temp_dir is not None:
             self.temp_dir.cleanup()

--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -199,19 +199,18 @@ class StatusGoContainer:
         if self.health_monitor.is_alive():
             logging.warning("Health monitoring thread didn't stop gracefully")
 
-    def shutdown(self):
+    def shutdown(self, log_sufix=None):
         """
         Stops, saves logs, and removes a container with error handling.
         Args:
-            container: The container object (should have stop, save_logs, remove methods)
-            log_prefix: Optional string for logging context
+            log_sufix: Optional string for logging context
         """
         if not self.container:
             return
 
         container_id = self.short_id()
         self.stop()
-        self.save_logs()
+        self.save_logs(log_sufix)
         self.remove()
         logging.debug(f"Container '{container_id}' shutdown finished")
 
@@ -310,14 +309,16 @@ class StatusGoContainer:
     def get_name(self):
         return self.container.name if self.container else None
 
-    def save_logs(self):
+    def save_logs(self, log_sufix=None):
+        if not log_sufix:
+            log_sufix = self.short_id()
         if not self.container:
             raise RuntimeError("Container is not initialized.")
         if Config.logs_dir == "":
             logging.debug("Save container logs skipped")
             return
 
-        file_path = os.path.join(Config.logs_dir, f"container_{self.short_id()}.log")
+        file_path = os.path.join(Config.logs_dir, f"container_{log_sufix}.log")
         logging.info(f"Saving logs to {file_path}")
 
         with open(file_path, "wb") as f:

--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -316,6 +316,8 @@ class StatusGoContainer:
             logging.debug("Save container logs skipped")
             return
 
+        os.makedirs(Config.logs_dir, exist_ok=True)
+
         file_path = os.path.join(Config.logs_dir, f"container_{log_sufix}_{self.short_id()}.log")
         logging.info(f"Saving logs to {file_path}")
 

--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -199,7 +199,7 @@ class StatusGoContainer:
         if self.health_monitor.is_alive():
             logging.warning("Health monitoring thread didn't stop gracefully")
 
-    def shutdown(self, log_sufix=None):
+    def shutdown(self, log_sufix=""):
         """
         Stops, saves logs, and removes a container with error handling.
         Args:
@@ -309,16 +309,14 @@ class StatusGoContainer:
     def get_name(self):
         return self.container.name if self.container else None
 
-    def save_logs(self, log_sufix=None):
-        if not log_sufix:
-            log_sufix = self.short_id()
+    def save_logs(self, log_sufix="test"):
         if not self.container:
             raise RuntimeError("Container is not initialized.")
         if Config.logs_dir == "":
             logging.debug("Save container logs skipped")
             return
 
-        file_path = os.path.join(Config.logs_dir, f"container_{log_sufix}.log")
+        file_path = os.path.join(Config.logs_dir, f"container_{log_sufix}_{self.short_id()}.log")
         logging.info(f"Saving logs to {file_path}")
 
         with open(file_path, "wb") as f:

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -39,6 +39,8 @@ def backend_factory(request):
     # Store created backends for cleanup
     created_backends: list[StatusBackend] = []
 
+    test_name = request.node.name if hasattr(request, "cls") else str(uuid4)
+
     def factory(name, **kwargs) -> StatusBackend:
         """
         Create a single backend with the given name.
@@ -50,13 +52,12 @@ def backend_factory(request):
         Returns:
             StatusBackend: Created backend instance
         """
-        test_name = request.node.name if hasattr(request, "cls") else str(uuid4)
         logging.debug(f"🔧 [SETUP] Creating {name} backend for {request.cls.__name__}")
         logging.debug(f"🔧 [SETUP] Creating {name} backend for {test_name}")
         logging.debug(f"📋 [SETUP] Parameters: privileged={privileged}, ipv6={ipv6}")
 
         # Create backend
-        backend = StatusBackend(await_signals=await_signals, privileged=privileged, ipv6=ipv6, test_name=test_name, **kwargs)
+        backend = StatusBackend(await_signals=await_signals, privileged=privileged, ipv6=ipv6, **kwargs)
         created_backends.append(backend)
         logging.debug(f"✅ [SETUP] {name.capitalize()} backend created")
 
@@ -69,7 +70,7 @@ def backend_factory(request):
 
     for i, backend in enumerate(reversed(created_backends)):
         logging.debug(f"🧹 [TEARDOWN] Cleaning up backend {len(created_backends) - i}...")
-        backend.shutdown(log_sufix=request.node.name)
+        backend.shutdown(log_sufix=test_name)
 
 
 @pytest.fixture(scope="function", autouse=False)

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -69,7 +69,7 @@ def backend_factory(request):
 
     for i, backend in enumerate(reversed(created_backends)):
         logging.debug(f"🧹 [TEARDOWN] Cleaning up backend {len(created_backends) - i}...")
-        backend.shutdown()
+        backend.shutdown(log_sufix=request.node.name)
 
 
 @pytest.fixture(scope="function", autouse=False)
@@ -160,7 +160,7 @@ def close_status_backend_containers(request):
     yield
     for container in StatusGoContainer.all_containers:
         try:
-            container.shutdown(request.node.name)  # pyright: ignore[reportAttributeAccessIssue]
+            container.shutdown(log_sufix=request.node.name)  # pyright: ignore[reportAttributeAccessIssue]
         except Exception as e:
             logging.error(f"Error cleaning up container: {e}")
     StatusGoContainer.all_containers = []

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+from uuid import uuid4
 import pytest
 
 from resources.constants import USE_IPV6
@@ -49,13 +50,13 @@ def backend_factory(request):
         Returns:
             StatusBackend: Created backend instance
         """
-        test_name = request.cls.__name__ if hasattr(request, "cls") else "test"
+        test_name = request.node.name if hasattr(request, "cls") else str(uuid4)
         logging.debug(f"🔧 [SETUP] Creating {name} backend for {request.cls.__name__}")
         logging.debug(f"🔧 [SETUP] Creating {name} backend for {test_name}")
         logging.debug(f"📋 [SETUP] Parameters: privileged={privileged}, ipv6={ipv6}")
 
         # Create backend
-        backend = StatusBackend(await_signals=await_signals, privileged=privileged, ipv6=ipv6, **kwargs)
+        backend = StatusBackend(await_signals=await_signals, privileged=privileged, ipv6=ipv6, test_name=test_name, **kwargs)
         created_backends.append(backend)
         logging.debug(f"✅ [SETUP] {name.capitalize()} backend created")
 
@@ -159,7 +160,7 @@ def close_status_backend_containers(request):
     yield
     for container in StatusGoContainer.all_containers:
         try:
-            container.shutdown()  # pyright: ignore[reportAttributeAccessIssue]
+            container.shutdown(request.node.name)  # pyright: ignore[reportAttributeAccessIssue]
         except Exception as e:
             logging.error(f"Error cleaning up container: {e}")
     StatusGoContainer.all_containers = []


### PR DESCRIPTION
Attaching status-backend logs to reliability tests
Added test name in status-backend logs for test traceability
Example of run with logs: https://github.com/status-im/status-go/actions/runs/17591104771
<img width="2142" height="301" alt="image" src="https://github.com/user-attachments/assets/81f43bf3-1a83-4d10-a500-26f2f7ffd3b8" />

