### PR TITLE
feat(emoji): add string emoji property to reactions - DB and protocol

### DIFF
--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -919,7 +919,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testViewChannelPermissions(v
 	s.Require().True(community.IsMemberLikelyInChat(chat.CommunityChatID()))
 
 	// bob can/can't post reactions
-	response, err = s.bob.SendEmojiReaction(context.Background(), chat.ID, msg.ID, protobuf.EmojiReaction_THUMBS_UP)
+	response, err = s.bob.SendEmojiReaction(context.Background(), chat.ID, msg.ID, protobuf.EmojiReaction_THUMBS_UP, "")
 	if !viewersCanAddReactions {
 		s.Require().Error(err)
 	} else {

--- a/protocol/emoji_reaction.go
+++ b/protocol/emoji_reaction.go
@@ -70,6 +70,7 @@ func (e *EmojiReaction) MarshalJSON() ([]byte, error) {
 		MessageType protobuf.MessageType        `json:"messageType,omitempty"`
 		Retracted   bool                        `json:"retracted,omitempty"`
 		EmojiID     protobuf.EmojiReaction_Type `json:"emojiId,omitempty"`
+		Emoji       string                      `json:"emoji,omitempty"`
 	}{
 
 		ID:          e.ID(),
@@ -81,6 +82,7 @@ func (e *EmojiReaction) MarshalJSON() ([]byte, error) {
 		MessageType: e.MessageType,
 		Retracted:   e.Retracted,
 		EmojiID:     e.Type,
+		Emoji:       e.Emoji,
 	}
 
 	ext, err := common.ExtendStructWithPubKeyData(item.From, item)

--- a/protocol/emoji_reaction.go
+++ b/protocol/emoji_reaction.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/golang/protobuf/proto"
 
@@ -12,6 +13,10 @@ import (
 	"github.com/status-im/status-go/crypto/types"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
+
+// There is no foolproof way to validate emojis, but this regex should cover all standard emojis
+// it will also allow some non-emoji unicode characters, but that's not a big issue
+var emojiRegex = regexp.MustCompile("(?:\u00A9|\u00AE|[\u2000-\u3300]|[\U0001F000-\U0001FBFF])")
 
 // EmojiReaction represents an emoji reaction from a user in the application layer, used for persistence, querying and
 // signaling
@@ -35,10 +40,13 @@ func NewEmojiReaction() *EmojiReaction {
 // ID is the Keccak256() contatenation of From-MessageID-Emoji
 func (e *EmojiReaction) ID() string {
 	// Backwards compatibility: old versions will not have the string Emoji, use Type instead
+	var data string
 	if e.Emoji == "" {
-		return types.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s%s%d", e.From, e.MessageId, e.Type))))
+		data = fmt.Sprintf("%s%s%d", e.From, e.MessageId, e.Type)
+	} else {
+		data = fmt.Sprintf("%s%s%s", e.From, e.MessageId, e.Emoji)
 	}
-	return types.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s%s%s", e.From, e.MessageId, e.Emoji))))
+	return types.EncodeHex(crypto.Keccak256([]byte(data)))
 }
 
 // GetSigPubKey returns an ecdsa encoded public key

--- a/protocol/emoji_reaction.go
+++ b/protocol/emoji_reaction.go
@@ -32,9 +32,13 @@ func NewEmojiReaction() *EmojiReaction {
 	return &EmojiReaction{EmojiReaction: &protobuf.EmojiReaction{}}
 }
 
-// ID is the Keccak256() contatenation of From-MessageID-EmojiType
+// ID is the Keccak256() contatenation of From-MessageID-Emoji
 func (e *EmojiReaction) ID() string {
-	return types.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s%s%d", e.From, e.MessageId, e.Type))))
+	// Backwards compatibility: old versions will not have the string Emoji, use Type instead
+	if e.Emoji == "" {
+		return types.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s%s%d", e.From, e.MessageId, e.Type))))
+	}
+	return types.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s%s%s", e.From, e.MessageId, e.Emoji))))
 }
 
 // GetSigPubKey returns an ecdsa encoded public key

--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -1407,7 +1407,8 @@ func (db sqlitePersistence) EmojiReactionsByChatID(chatID string, currCursor str
 			    e.message_id,
 			    e.chat_id,
 			    e.local_chat_id,
-			    e.retracted
+			    e.retracted,
+				e.emoji
 			FROM
 				emoji_reactions e
 			WHERE NOT(e.retracted)
@@ -1438,7 +1439,9 @@ func (db sqlitePersistence) EmojiReactionsByChatID(chatID string, currCursor str
 			&emojiReaction.MessageId,
 			&emojiReaction.ChatId,
 			&emojiReaction.LocalChatID,
-			&emojiReaction.Retracted)
+			&emojiReaction.Retracted,
+			&emojiReaction.Emoji,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1460,7 +1463,8 @@ func (db sqlitePersistence) EmojiReactionsByChatIDMessageID(chatID string, messa
 			    e.message_id,
 			    e.chat_id,
 			    e.local_chat_id,
-			    e.retracted
+			    e.retracted,
+				e.emoji
 			FROM
 				emoji_reactions e
 			WHERE NOT(e.retracted)
@@ -1488,7 +1492,9 @@ func (db sqlitePersistence) EmojiReactionsByChatIDMessageID(chatID string, messa
 			&emojiReaction.MessageId,
 			&emojiReaction.ChatId,
 			&emojiReaction.LocalChatID,
-			&emojiReaction.Retracted)
+			&emojiReaction.Retracted,
+			&emojiReaction.Emoji,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -1537,7 +1543,8 @@ func (db sqlitePersistence) EmojiReactionsByChatIDs(chatIDs []string, currCursor
 			    e.message_id,
 			    e.chat_id,
 			    e.local_chat_id,
-			    e.retracted
+			    e.retracted,
+				e.emoji
 			FROM
 				emoji_reactions e
 			WHERE NOT(e.retracted)
@@ -1568,7 +1575,9 @@ func (db sqlitePersistence) EmojiReactionsByChatIDs(chatIDs []string, currCursor
 			&emojiReaction.MessageId,
 			&emojiReaction.ChatId,
 			&emojiReaction.LocalChatID,
-			&emojiReaction.Retracted)
+			&emojiReaction.Retracted,
+			&emojiReaction.Emoji,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -2470,7 +2479,7 @@ func (db sqlitePersistence) SaveDiscordMessageAttachments(attachments []*protobu
 }
 
 func (db sqlitePersistence) SaveEmojiReaction(emojiReaction *EmojiReaction) (err error) {
-	query := "INSERT INTO emoji_reactions(id,clock_value,source,emoji_id,message_id,chat_id,local_chat_id,retracted) VALUES (?,?,?,?,?,?,?,?)"
+	query := "INSERT INTO emoji_reactions(id,clock_value,source,emoji_id,message_id,chat_id,local_chat_id,retracted,emoji) VALUES (?,?,?,?,?,?,?,?,?)"
 	stmt, err := db.db.Prepare(query)
 	if err != nil {
 		return
@@ -2485,6 +2494,7 @@ func (db sqlitePersistence) SaveEmojiReaction(emojiReaction *EmojiReaction) (err
 		emojiReaction.ChatId,
 		emojiReaction.LocalChatID,
 		emojiReaction.Retracted,
+		emojiReaction.Emoji,
 	)
 
 	return
@@ -2499,7 +2509,8 @@ func (db sqlitePersistence) EmojiReactionByID(id string) (*EmojiReaction, error)
 			    message_id,
 			    chat_id,
 			    local_chat_id,
-			    retracted
+			    retracted,
+				emoji
 			FROM
 				emoji_reactions
 			WHERE
@@ -2514,6 +2525,7 @@ func (db sqlitePersistence) EmojiReactionByID(id string) (*EmojiReaction, error)
 		&emojiReaction.ChatId,
 		&emojiReaction.LocalChatID,
 		&emojiReaction.Retracted,
+		&emojiReaction.Emoji,
 	)
 
 	switch err {

--- a/protocol/messenger_emoji_reactions.go
+++ b/protocol/messenger_emoji_reactions.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"context"
-	"regexp"
 
 	"github.com/pkg/errors"
 
@@ -50,9 +49,6 @@ func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID str
 	}
 
 	// Validate that the emoji is valid
-	// There is no foolproof way to validate emojis, but this regex should cover all standard emojis
-	// it will also allow some non-emoji unicode characters, but that's not a big issue
-	emojiRegex := regexp.MustCompile("(?:\u00A9|\u00AE|[\u2000-\u3300]|[\U0001F000-\U0001FBFF])")
 	if !emojiRegex.MatchString(emoji) {
 		return nil, errors.New("invalid emoji")
 	}

--- a/protocol/messenger_emoji_reactions.go
+++ b/protocol/messenger_emoji_reactions.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"context"
+	"regexp"
 
 	"github.com/pkg/errors"
 
@@ -31,7 +32,8 @@ func ConvertEmojiIDToString(emojiID protobuf.EmojiReaction_Type) string {
 
 }
 
-func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID string, emojiID protobuf.EmojiReaction_Type) (*MessengerResponse, error) {
+// TODO remove emojiID once the client supports sending custom emojis
+func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID string, emojiID protobuf.EmojiReaction_Type, emoji string) (*MessengerResponse, error) {
 	var response MessengerResponse
 
 	chat, ok := m.allChats.Load(chatID)
@@ -40,14 +42,28 @@ func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID str
 	}
 	clock, _ := chat.NextClockAndTimestamp(m.getTimesource())
 
+	if emoji == "" {
+		emoji = ConvertEmojiIDToString(emojiID)
+		if emoji == "" {
+			return nil, errors.New("invalid emojiID")
+		}
+	}
+
+	// Validate that the emoji is valid
+	// There is no foolproof way to validate emojis, but this regex should cover all standard emojis
+	// it will also allow some non-emoji unicode characters, but that's not a big issue
+	emojiRegex := regexp.MustCompile("(?:\u00A9|\u00AE|[\u2000-\u3300]|[\U0001F000-\U0001FBFF])")
+	if !emojiRegex.MatchString(emoji) {
+		return nil, errors.New("invalid emoji")
+	}
+
 	emojiR := &EmojiReaction{
 		EmojiReaction: &protobuf.EmojiReaction{
 			Clock:     clock,
 			MessageId: messageID,
 			ChatId:    chatID,
 			Type:      emojiID,
-			// TODO remove this conversion once the client supports sending custom emojis
-			Emoji: ConvertEmojiIDToString(emojiID),
+			Emoji:     emoji,
 		},
 		LocalChatID: chatID,
 		From:        types.EncodeHex(crypto.FromECDSAPub(&m.identity.PublicKey)),

--- a/protocol/messenger_emoji_reactions.go
+++ b/protocol/messenger_emoji_reactions.go
@@ -11,6 +11,26 @@ import (
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
+func ConvertEmojiIDToString(emojiID protobuf.EmojiReaction_Type) string {
+	switch emojiID {
+	case protobuf.EmojiReaction_LOVE:
+		return "❤️"
+	case protobuf.EmojiReaction_THUMBS_UP:
+		return "👍"
+	case protobuf.EmojiReaction_THUMBS_DOWN:
+		return "👎"
+	case protobuf.EmojiReaction_LAUGH:
+		return "😂"
+	case protobuf.EmojiReaction_SAD:
+		return "😢"
+	case protobuf.EmojiReaction_ANGRY:
+		return "😠"
+	}
+
+	return ""
+
+}
+
 func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID string, emojiID protobuf.EmojiReaction_Type) (*MessengerResponse, error) {
 	var response MessengerResponse
 
@@ -26,6 +46,8 @@ func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID str
 			MessageId: messageID,
 			ChatId:    chatID,
 			Type:      emojiID,
+			// TODO remove this conversion once the client supports sending custom emojis
+			Emoji: ConvertEmojiIDToString(emojiID),
 		},
 		LocalChatID: chatID,
 		From:        types.EncodeHex(crypto.FromECDSAPub(&m.identity.PublicKey)),

--- a/protocol/messenger_emoji_test.go
+++ b/protocol/messenger_emoji_test.go
@@ -64,8 +64,7 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 
 	messageID := response.Messages()[0].ID
 
-	// Respond with an emoji, donald trump style
-
+	// Respond with an emoji
 	response, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_SAD)
 	s.Require().NoError(err)
 	s.Require().Len(response.EmojiReactions(), 1)
@@ -83,6 +82,7 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 	s.Require().Len(response.EmojiReactions(), 1)
 	s.Require().Equal(response.EmojiReactions()[0].ID(), emojiID)
 	s.Require().Equal(response.EmojiReactions()[0].Type, protobuf.EmojiReaction_SAD)
+	s.Require().Equal(response.EmojiReactions()[0].Emoji, "😢")
 
 	// Retract the emoji
 	response, err = bob.SendEmojiReactionRetraction(context.Background(), emojiID)

--- a/protocol/messenger_emoji_test.go
+++ b/protocol/messenger_emoji_test.go
@@ -65,11 +65,15 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 	messageID := response.Messages()[0].ID
 
 	// Respond with an emoji
-	response, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_SAD)
+	response, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_SAD, "")
 	s.Require().NoError(err)
 	s.Require().Len(response.EmojiReactions(), 1)
 
 	emojiID := response.EmojiReactions()[0].ID()
+
+	// Try sending a non-emoji reaction
+	_, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "haha")
+	s.Require().Error(err)
 
 	// Wait for the emoji to arrive to alice
 	response, err = WaitOnMessengerResponse(
@@ -150,7 +154,7 @@ func (s *MessengerEmojiSuite) TestEmojiPrivateGroup() {
 	s.Require().NoError(err)
 	messageID := response.Messages()[0].ID
 
-	_, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_SAD)
+	_, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_SAD, "")
 	s.Require().NoError(err)
 
 	// Wait for the message to reach its destination

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2906,6 +2906,11 @@ func (m *Messenger) HandleEmojiReaction(state *ReceivedMessageState, pbEmojiR *p
 		pbEmojiR.Emoji = ConvertEmojiIDToString(pbEmojiR.Type)
 	}
 
+	// Validate that the emoji is valid
+	if !emojiRegex.MatchString(pbEmojiR.Emoji) {
+		return errors.New("invalid emoji")
+	}
+
 	emojiReaction := &EmojiReaction{
 		EmojiReaction: pbEmojiR,
 		From:          from,

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2901,6 +2901,11 @@ func (m *Messenger) HandleEmojiReaction(state *ReceivedMessageState, pbEmojiR *p
 
 	from := state.CurrentMessageState.Contact.ID
 
+	// Backwards compatibility: old versions will not have the string Emoji, convert it
+	if pbEmojiR.Emoji == "" {
+		pbEmojiR.Emoji = ConvertEmojiIDToString(pbEmojiR.Type)
+	}
+
 	emojiReaction := &EmojiReaction{
 		EmojiReaction: pbEmojiR,
 		From:          from,

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -2387,7 +2387,7 @@ func (s *MessengerSuite) TestResendExpiredEmojis() {
 	s.NoError(err)
 
 	//create emoji
-	_, err = s.m.SendEmojiReaction(context.Background(), chat.ID, inputMessage.ID, protobuf.EmojiReaction_SAD)
+	_, err = s.m.SendEmojiReaction(context.Background(), chat.ID, inputMessage.ID, protobuf.EmojiReaction_SAD, "")
 	s.Require().NoError(err)
 
 	ids, err := s.m.persistence.RawMessagesIDsByType(protobuf.ApplicationMetadataMessage_EMOJI_REACTION)

--- a/protocol/migrations/sqlite/1757438321_add_reactions_emoji.up.sql
+++ b/protocol/migrations/sqlite/1757438321_add_reactions_emoji.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE emoji_reactions ADD COLUMN emoji VARCHAR DEFAULT "";

--- a/protocol/persistence_test.go
+++ b/protocol/persistence_test.go
@@ -876,9 +876,38 @@ func TestPersistenceEmojiReactions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Insert normal emoji reaction
-	require.NoError(t, p.SaveEmojiReaction(&EmojiReaction{
+	reaction := &EmojiReaction{
 		EmojiReaction: &protobuf.EmojiReaction{
 			Clock:     1,
+			MessageId: id3,
+			ChatId:    chatID,
+			Emoji:     "😀",
+		},
+		LocalChatID: chatID,
+		From:        from1,
+	}
+	require.NoError(t, p.SaveEmojiReaction(reaction))
+
+	// Retract emoji reaction
+	retractedReaction := &EmojiReaction{
+		EmojiReaction: &protobuf.EmojiReaction{
+			Clock:     2,
+			MessageId: id3,
+			ChatId:    chatID,
+			Emoji:     "😀",
+			Retracted: true,
+		},
+		LocalChatID: chatID,
+		From:        from1,
+	}
+	require.NoError(t, p.SaveEmojiReaction(retractedReaction))
+
+	require.Equal(t, reaction.ID(), retractedReaction.ID())
+
+	// Insert old emoji reaction (with only type)
+	require.NoError(t, p.SaveEmojiReaction(&EmojiReaction{
+		EmojiReaction: &protobuf.EmojiReaction{
+			Clock:     2,
 			MessageId: id3,
 			ChatId:    chatID,
 			Type:      protobuf.EmojiReaction_SAD,
@@ -890,7 +919,7 @@ func TestPersistenceEmojiReactions(t *testing.T) {
 	// Insert retracted emoji reaction
 	require.NoError(t, p.SaveEmojiReaction(&EmojiReaction{
 		EmojiReaction: &protobuf.EmojiReaction{
-			Clock:     1,
+			Clock:     2,
 			MessageId: id3,
 			ChatId:    chatID,
 			Type:      protobuf.EmojiReaction_SAD,

--- a/protocol/protobuf/emoji_reaction.proto
+++ b/protocol/protobuf/emoji_reaction.proto
@@ -23,6 +23,7 @@ message EmojiReaction {
   Type type = 5 [deprecated = true];
 
   enum Type {
+    option deprecated = true;
     UNKNOWN_EMOJI_REACTION_TYPE = 0;
     LOVE = 1;
     THUMBS_UP = 2;

--- a/protocol/protobuf/emoji_reaction.proto
+++ b/protocol/protobuf/emoji_reaction.proto
@@ -20,7 +20,7 @@ message EmojiReaction {
   MessageType message_type = 4;
 
   // type the ID of the emoji the user wishes to react with
-  Type type = 5;
+  Type type = 5 [deprecated = true];
 
   enum Type {
     UNKNOWN_EMOJI_REACTION_TYPE = 0;
@@ -37,4 +37,6 @@ message EmojiReaction {
 
   // Grant for organisation chat messages
   bytes grant = 7 [deprecated = true];
+
+  string emoji = 8;
 }

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1020,7 +1020,12 @@ func (api *PublicAPI) RegisteredForPushNotifications() (bool, error) {
 // Emoji
 
 func (api *PublicAPI) SendEmojiReaction(ctx context.Context, chatID, messageID string, emojiID protobuf.EmojiReaction_Type) (*protocol.MessengerResponse, error) {
-	return api.service.messenger.SendEmojiReaction(ctx, chatID, messageID, emojiID)
+	return api.service.messenger.SendEmojiReaction(ctx, chatID, messageID, emojiID, "")
+}
+
+// TODO remove SendEmojiReaction and remove the 2 when the client supports sending custom emojis
+func (api *PublicAPI) SendEmojiReaction2(ctx context.Context, chatID, messageID string, emoji string) (*protocol.MessengerResponse, error) {
+	return api.service.messenger.SendEmojiReaction(ctx, chatID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, emoji)
 }
 
 func (api *PublicAPI) SendEmojiReactionRetraction(ctx context.Context, emojiReactionID string) (*protocol.MessengerResponse, error) {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -1023,8 +1023,8 @@ func (api *PublicAPI) SendEmojiReaction(ctx context.Context, chatID, messageID s
 	return api.service.messenger.SendEmojiReaction(ctx, chatID, messageID, emojiID, "")
 }
 
-// TODO remove SendEmojiReaction and remove the 2 when the client supports sending custom emojis
-func (api *PublicAPI) SendEmojiReaction2(ctx context.Context, chatID, messageID string, emoji string) (*protocol.MessengerResponse, error) {
+// TODO remove SendEmojiReaction and remove the V2 when the client supports sending custom emojis
+func (api *PublicAPI) SendEmojiReactionV2(ctx context.Context, chatID, messageID string, emoji string) (*protocol.MessengerResponse, error) {
 	return api.service.messenger.SendEmojiReaction(ctx, chatID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, emoji)
 }
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/18801

Adds a string field called `emoji` in the emoji_reactions table and in the protobuf that enable sending and receiving any emoji reaction.

Modifies the tests to show that it works and that it's backwards compatible

edit: added a second commit with the API changes too, since they are pretty small
