### PR TITLE
ci: migration check GitHub action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,3 +65,20 @@ jobs:
       - name: lint-panics
         run: |
           make lint-panics
+
+  migration-check:
+    name: SQL migrations check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run migration check
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+        run: |
+          bash _assets/scripts/migration_check.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,7 +67,7 @@ jobs:
           make lint-panics
 
   migration-check:
-    name: SQL migrations check
+    name: Check SQL migrations order
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -119,15 +119,6 @@ pipeline {
       } }
     }
 
-    stage('Migration') {
-      when { // https://github.com/status-im/status-go/issues/4993#issuecomment-2022685544
-        expression { isPRJob() }
-      }
-      steps { script {
-        nix.develop('make migration-check', pure: false)
-      } }
-    }
-
     stage('Unit Tests') {
       environment {
         TEST_POSTGRES_PORT = "${env.DB_PORT}"

--- a/_assets/scripts/migration_check.sh
+++ b/_assets/scripts/migration_check.sh
@@ -4,15 +4,37 @@ set -euo pipefail
 
 source _assets/scripts/colors.sh
 
+# Track whether any validation failed to report all issues before exiting
+FAILED=0
+
+# Verify filename starts with exactly 10 digits before the first underscore
+validate_filename_regex() {
+  local fname="$1"
+  local base
+  base=$(basename "$fname")
+
+  if [[ ! "$base" =~ ^[0-9]{10}_ ]]; then
+    echo -e "${YLW}Error:${RST} migration '${base}' must start with a seconds-precision timestamp followed by an underscore."
+    return 1
+  fi
+  return 0
+}
+
 check_migration_order() {
   local prev_migration=""
+
   for file in "$@"; do
+    [[ -z "$file" ]] && continue
+    local current_migration
     current_migration=$(basename "$file")
 
-    if [[ ! -z "$prev_migration" && "$current_migration" < "$prev_migration" ]]; then
-      echo -e "${YLW}migration ${RST}${current_migration} ${YLW}is not in order with ${RST}${prev_migration}"
-      echo -e "${YLW}Error: Migration files are out of order. Please ensure migrations are added in chronological order."
-      exit 1
+    # String-based order check (filenames sorted lexicographically)
+    if [[ -n "$prev_migration" && "$current_migration" < "$prev_migration" ]]; then
+      echo -e "${YLW}Error:${RST}migration ${current_migration} ${YLW}is not in chronological order with ${RST}${prev_migration}"
+      # GitHub annotation on the problematic current file
+      echo "::error file=${file},line=1,col=1::Migration order incorrect: '${current_migration}' should come after '${prev_migration}'."
+      FAILED=1
+      # continue checking other files
     fi
 
     prev_migration="$current_migration"
@@ -29,18 +51,39 @@ MIGRATION_DIRS=( \
   "walletdatabase/migrations/sql" \
 )
 
+# Update base ref locally to ensure comparisons are accurate
+echo -e "${GRN}Checking out${RST} ${BASE_COMMIT} to verify against ${BASE_BRANCH}"
 git checkout ${BASE_COMMIT}
 git pull origin ${BASE_BRANCH}
 git checkout -
 
-for MIGRATION_DIR in ${MIGRATION_DIRS[@]}; do
+for MIGRATION_DIR in "${MIGRATION_DIRS[@]}"; do
   echo -e "${GRN}Checking migrations:${RST} ${MIGRATION_DIR}"
 
+  # Collect files from base and from current diff
   base_files=$(git ls-tree -r --name-only ${BASE_COMMIT} ${MIGRATION_DIR}/*.sql | sort)
-  new_files=$(git diff --name-only ${BASE_COMMIT} ${MIGRATION_DIR}/*.sql | sort)
+  new_files=$(git diff --name-only ${BASE_COMMIT} -- ${MIGRATION_DIR}/*.sql | sort || true)
   all_files=$(echo -e "$base_files\n$new_files")
 
+  # Regex validation: ONLY verify newly added/changed files match ^[0-9]{10}_ prefix
+  if [[ -n "$new_files" ]]; then
+    while IFS= read -r nf; do
+      [[ -z "$nf" ]] && continue
+      if ! validate_filename_regex "$(basename "$nf")"; then
+        # Provide GitHub annotation with the file path
+        echo "::error file=${nf},line=1,col=1::Migration filename must start with exactly 10 digits (Unix seconds) followed by an underscore. Example: '1725978456_my_migration.up.sql'"
+        FAILED=1
+        # continue checking others
+      fi
+    done <<< "$new_files"
+  fi
+
+  # Iterate in filename order and ensure lexicographic ordering
   check_migration_order $all_files
 done
 
+# Exit with failure if any issues were detected (so the job fails and annotations show up)
+if [[ "$FAILED" -ne 0 ]]; then
+  exit 1
+fi
 exit 0

--- a/_assets/scripts/migration_check.sh
+++ b/_assets/scripts/migration_check.sh
@@ -24,7 +24,6 @@ check_migration_order() {
   local prev_migration=""
 
   for file in "$@"; do
-    [[ -z "$file" ]] && continue
     local current_migration
     current_migration=$(basename "$file")
 
@@ -62,7 +61,7 @@ for MIGRATION_DIR in "${MIGRATION_DIRS[@]}"; do
 
   # Collect files from base and from current diff
   base_files=$(git ls-tree -r --name-only ${BASE_COMMIT} ${MIGRATION_DIR}/*.sql | sort)
-  new_files=$(git diff --name-only ${BASE_COMMIT} -- ${MIGRATION_DIR}/*.sql | sort || true)
+  new_files=$(git diff --name-only ${BASE_COMMIT} ${MIGRATION_DIR}/*.sql | sort)
   all_files=$(echo -e "$base_files\n$new_files")
 
   # Regex validation: ONLY verify newly added/changed files match ^[0-9]{10}_ prefix


### PR DESCRIPTION
# Description

1. Move migration check from Jenkins to Github Actions
    - Allows to monitor the check independently from tests run
    - Allows to simply publish annotations to the PR

2. Improve the migration check script
    - Verify that all new migrations start with a 10-digit number, which matches seconds-precision timestamp
    - Verify all files and print errors, and only exit in the end

# How it looks

<img width="1239" height="312" alt="Screenshot 2025-09-10 at 17 50 17" src="https://github.com/user-attachments/assets/bea5a6d4-44a5-4a22-ab31-58ce79a78574" />

<img width="1235" height="286" alt="Screenshot 2025-09-10 at 17 50 14" src="https://github.com/user-attachments/assets/e943499e-9aa4-40f9-a00b-e5a384a0a989" />
