### PR TITLE
refactor: minor improvements in functional tests

### DIFF
--- a/tests-functional/clients/api.py
+++ b/tests-functional/clients/api.py
@@ -1,7 +1,8 @@
 import json
 import logging
-import requests
 from json import JSONDecodeError
+
+import requests
 
 
 class ApiError(Exception):
@@ -30,12 +31,12 @@ class ApiClient:
         self.client = client
         self.api_url = api_url
 
-    def api_request(self, method, data, url=None, quiet=False):
+    def api_request(self, method, data, url=None, quiet=False, **kwargs):
         url = url if url else self.api_url
         url = f"{url}/{method}" if method else url
         if not quiet:
             logging.debug(f"Sending POST request to url {url} with data: {json.dumps(data, sort_keys=True)}")
-        response = self.client.post(url, json=data)
+        response = self.client.post(url, json=data, **kwargs)
 
         if response.status_code != 200:
             raise ApiHTTPError(
@@ -52,8 +53,8 @@ class ApiClient:
             logging.debug(f"Got response: {response.content}")
         return response
 
-    def api_request_json(self, method, data):
-        response = self.api_request(method, data)
+    def api_request_json(self, method, data, **kwargs):
+        response = self.api_request(method, data, **kwargs)
         try:
             json_response = response.json()
         except JSONDecodeError:

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -6,7 +6,7 @@ import time
 import uuid
 
 import requests
-from tenacity import retry, stop_after_delay, wait_fixed
+from tenacity import retry, stop_after_delay, wait_fixed, wait_exponential, retry_if_exception_type
 
 import resources.constants as constants
 from clients.api import ApiClient
@@ -103,19 +103,17 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         if self.temp_dir is not None:
             self.temp_dir.cleanup()
 
-    def wait_for_healthy(self, timeout=10):
-        start_time = time.time()
-        while time.time() - start_time <= timeout:
-            try:
-                response = self.health()
-                response = json.loads(response.content)
-                self.version = response.get("version", "unknown")
-                logging.debug(f"StatusBackend is healthy after {time.time() - start_time} seconds")
-                return
-            except Exception as ex:
-                logging.debug(f"StatusBackend error: {ex}")
-                time.sleep(0.1)
-        raise TimeoutError(f"StatusBackend was not healthy after {timeout} seconds")
+    @retry(
+        stop=stop_after_delay(10),
+        wait=wait_exponential(multiplier=1, min=0.1, max=5),
+        retry=retry_if_exception_type((ConnectionError, requests.RequestException)),
+        reraise=True,
+    )
+    def wait_for_healthy(self):
+        response = self.health()
+        response = json.loads(response.content)
+        self.version = response.get("version", "unknown")
+        logging.debug("StatusBackend is healthy")
 
     def health(self):
         return self.api_request("health", data=[], url=self.base_url, quiet=True)
@@ -298,9 +296,9 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         data = self._set_wallet_secrets(data)
         return self.api_request_json(method, data)
 
-    def logout(self):
+    def logout(self, **kwargs):
         method = "Logout"
-        return self.api_request_json(method, {})
+        return self.api_request_json(method, {}, **kwargs)
 
     def wait_for_login(self):
         signal = self.wait_for_signal(SignalType.NODE_LOGIN.value)

--- a/tests-functional/pytest.ini
+++ b/tests-functional/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -v --show-capture=all
+addopts = -v --show-capture=all --color=yes
 
 log_cli=true
 log_level=DEBUG

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -1,10 +1,11 @@
 import logging
 from uuid import uuid4
 import pytest
+from requests import ReadTimeout
 
-from resources.constants import USE_IPV6
 from clients.status_backend import StatusBackend
 from clients.statusgo_container import StatusGoContainer
+from resources.constants import USE_IPV6
 
 
 @pytest.fixture(scope="function", autouse=False)
@@ -96,7 +97,10 @@ def backend_new_profile(request, backend_factory):
     yield _backend_new_profile
 
     for backend in backends:
-        backend.logout()
+        try:
+            backend.logout(timeout=10)
+        except ReadTimeout as e:
+            logging.warning(f"Failed to logout during shutdown: {e}")
 
 
 @pytest.fixture(scope="function", autouse=False)

--- a/tests-functional/tests/test_wakuext_chats.py
+++ b/tests-functional/tests/test_wakuext_chats.py
@@ -1,6 +1,7 @@
+from datetime import datetime, timedelta
+
 import pytest
 
-from datetime import datetime, timedelta
 from resources.enums import ChatType, ChatPreviewFilterType, MuteType
 from steps.messenger import MessengerSteps
 
@@ -24,8 +25,14 @@ class TestChatActions(MessengerSteps):
 
         chats = self.sender.wakuext_service.chats()
         assert len(chats) == 2
-        assert chats[0].get("chatType", 0) == ChatType.ONE_TO_ONE.value
-        assert chats[1].get("chatType", 0) == ChatType.PRIVATE_GROUP_CHAT.value
+
+        private_group_chat = next((chat for chat in chats if chat.get("id") == private_group_id), None)
+        assert private_group_chat is not None
+        assert private_group_chat.get("chatType", "") == ChatType.PRIVATE_GROUP_CHAT.value
+
+        one_to_one_chat = next((chat for chat in chats if chat.get("id") == self.receiver.public_key), None)
+        assert one_to_one_chat is not None
+        assert one_to_one_chat.get("chatType", "") == ChatType.ONE_TO_ONE.value
 
     def test_chat_by_chat_id(self):
         sent_texts, _ = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
@@ -56,8 +63,7 @@ class TestChatActions(MessengerSteps):
 
         chats_previews = self.sender.wakuext_service.chats_preview(ChatPreviewFilterType.NonCommunity.value)
         assert len(chats_previews) == 2
-        assert chats_previews[0].get("id", "") == one_to_one_chat_id
-        assert chats_previews[1].get("id", "") == private_group_chat_id
+        assert {chat.get("id", "") for chat in chats_previews} == {one_to_one_chat_id, private_group_chat_id}
 
     def test_active_chats(self):
         self.make_contacts(self.sender, self.receiver)

--- a/tests-functional/utils/fake.py
+++ b/tests-functional/utils/fake.py
@@ -1,3 +1,5 @@
+import random
+
 from faker import Faker
 
 # Use a single English locale to minimize provider loading
@@ -14,7 +16,8 @@ def community_description() -> str:
 
 
 def profile_name() -> str:
-    return _faker.user_name()
+    length = random.randint(5, 24)
+    return _faker.pystr(min_chars=length, max_chars=length)
 
 
 def profile_password(length: int = 8) -> str:


### PR DESCRIPTION
# Description

1. Use `@retry` decorator on `wait_for_healthy`
2. Add timeout to `logout()` on shutdown
3. Set `--color=yes` to have some beauty in PyCharm test runs
4. Fix 2 flaky tests. We should not expect elements in response lists to be ordered.
5. Limit `fake.profile_name()` to return 5-24 characters.