### PR TITLE
fix(reactions): limit reactions to 20 per message

### DIFF
--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -1846,6 +1846,52 @@ func (db sqlitePersistence) EmojiReactionsByChatIDMessageID(chatID string, messa
 	return result, nil
 }
 
+// EmojiReactionCountByChatIDMessageID returns the count of different emoji types on a message.
+func (db sqlitePersistence) EmojiReactionCountByChatIDMessageID(chatID string, messageID string) (int, error) {
+	args := []interface{}{chatID, messageID}
+	query := `SELECT
+			    COUNT(DISTINCT e.emoji)
+			FROM
+				emoji_reactions e
+			WHERE NOT(e.retracted)
+			AND
+			e.local_chat_id = ?
+			AND
+			e.message_id = ?`
+
+	var count int
+	err := db.db.QueryRow(query, args...).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}
+
+// EmojiReactionExistsOnMessage checks if a particular emoji type has already been added to a specific message.
+func (db sqlitePersistence) EmojiReactionExistsOnMessage(chatID string, messageID string, emoji string) (bool, error) {
+	args := []interface{}{chatID, messageID, emoji}
+	query := `SELECT
+			    COUNT(*)
+			FROM
+				emoji_reactions e
+			WHERE NOT(e.retracted)
+			AND
+			e.local_chat_id = ?
+			AND
+			e.message_id = ?
+			AND
+			e.emoji = ?`
+
+	var count int
+	err := db.db.QueryRow(query, args...).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}
+
 // EmojiReactionsByChatIDs returns the emoji reactions for the queried messages, up to a maximum of 100, as it's a potentially unbound number.
 // NOTE: This is not completely accurate, as the messages in the database might have change since the last call to `MessageByChatID`.
 func (db sqlitePersistence) EmojiReactionsByChatIDs(chatIDs []string, currCursor string, limit int) ([]*EmojiReaction, error) {

--- a/protocol/messenger_emoji_reactions.go
+++ b/protocol/messenger_emoji_reactions.go
@@ -11,6 +11,10 @@ import (
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
+var ErrTooManyEmojiReactionsForMessage = errors.New("too many emoji reactions for message")
+
+const maxEmojiReactionsPerMessage = 20
+
 func ConvertEmojiIDToString(emojiID protobuf.EmojiReaction_Type) string {
 	switch emojiID {
 	case protobuf.EmojiReaction_LOVE:
@@ -29,6 +33,27 @@ func ConvertEmojiIDToString(emojiID protobuf.EmojiReaction_Type) string {
 
 	return ""
 
+}
+
+func (m *Messenger) CheckMaxNumberOfEmojiReactionsPerMessage(chatID string, messageID string, emoji string) error {
+	// Limit the amount of emoji reactions per message to avoid spam
+	numberOfEmojis, err := m.persistence.EmojiReactionCountByChatIDMessageID(chatID, messageID)
+	if err != nil {
+		return err
+	}
+
+	if numberOfEmojis < maxEmojiReactionsPerMessage {
+		return nil
+	}
+	// We need to check if it's an emoji that was already applied. If not, then we throw an error
+	exists, err := m.persistence.EmojiReactionExistsOnMessage(chatID, messageID, emoji)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return ErrTooManyEmojiReactionsForMessage
+	}
+	return nil
 }
 
 // TODO remove emojiID once the client supports sending custom emojis
@@ -51,6 +76,11 @@ func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID str
 	// Validate that the emoji is valid
 	if !emojiRegex.MatchString(emoji) {
 		return nil, errors.New("invalid emoji")
+	}
+
+	err := m.CheckMaxNumberOfEmojiReactionsPerMessage(chatID, messageID, emoji)
+	if err != nil {
+		return nil, err
 	}
 
 	emojiR := &EmojiReaction{

--- a/protocol/messenger_emoji_test.go
+++ b/protocol/messenger_emoji_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
+	messagingtypes "github.com/status-im/status-go/messaging/types"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -179,4 +180,95 @@ func (s *MessengerEmojiSuite) TestCompressedKeyReturnedWithEmoji() {
 	// Check that compressedKey and emojiHash exists
 	s.Require().True(strings.Contains(string(encodedReaction), "compressedKey\":\"zQ"))
 	s.Require().True(strings.Contains(string(encodedReaction), "emojiHash"))
+}
+
+func (s *MessengerEmojiSuite) TestMaxEmojiReactionsPerMessage() {
+	alice := s.m
+	alice.account = &multiaccounts.Account{KeyUID: "0xdeadbeef"}
+
+	bob := s.newMessenger()
+	defer TearDownMessenger(&s.Suite, bob)
+
+	chatID := statusChatID
+
+	chat := CreatePublicChat(chatID, alice.getTimesource())
+
+	err := alice.SaveChat(chat)
+	s.Require().NoError(err)
+
+	_, err = alice.Join(chat)
+	s.Require().NoError(err)
+
+	err = bob.SaveChat(chat)
+	s.Require().NoError(err)
+
+	_, err = bob.Join(chat)
+	s.Require().NoError(err)
+
+	// Send chat message from alice to bob
+
+	message := buildTestMessage(*chat)
+	_, err = alice.SendChatMessage(context.Background(), message)
+	s.NoError(err)
+
+	// Wait for message to arrive to bob
+	response, err := WaitOnMessengerResponse(
+		bob,
+		func(r *MessengerResponse) bool { return len(r.Messages()) > 0 },
+		"no messages",
+	)
+	s.Require().NoError(err)
+
+	s.Require().Len(response.Messages(), 1)
+
+	messageID := response.Messages()[0].ID
+
+	// Respond with the max amount of emojis
+	emojis := []string{"😀", "🤓", "😄", "😁", "😆", "😅", "🤣", "😂", "🥹", "🙂", "🙃", "😉", "😊", "😇", "🥰", "😍", "🤩", "😘", "😗", "☺️"}
+	for _, emoji := range emojis {
+		response, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, emoji)
+		s.Require().NoError(err)
+		s.Require().Len(response.EmojiReactions(), 1)
+	}
+
+	// Try sending one more (should fail)
+	_, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "😋")
+	s.Require().Error(err)
+	s.Require().Equal(ErrTooManyEmojiReactionsForMessage, err)
+
+	messageState := bob.buildMessageState()
+	messageState.CurrentMessageState = &CurrentMessageState{
+		Contact: &Contact{
+			ID: common.PubkeyToHex(&alice.identity.PublicKey),
+		},
+	}
+
+	// Try handling a new emoji (like if it was sent by Alice) (should fail)
+	err = bob.HandleEmojiReaction(
+		messageState,
+		&protobuf.EmojiReaction{
+			MessageId:   messageID,
+			ChatId:      chat.ID,
+			Emoji:       "😋",
+			Type:        protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE,
+			Clock:       123,
+			MessageType: protobuf.MessageType_PUBLIC_GROUP,
+		},
+		&messagingtypes.Message{},
+	)
+	s.Require().Error(err)
+	s.Require().Equal(ErrTooManyEmojiReactionsForMessage, err)
+
+	// Sending an existing emoji should work
+	response, err = alice.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "😀")
+	s.Require().NoError(err)
+	s.Require().Len(response.EmojiReactions(), 1)
+
+	_, err = WaitOnMessengerResponse(
+		bob,
+		func(r *MessengerResponse) bool { return len(r.EmojiReactions()) == 1 },
+		"no emoji",
+	)
+	s.Require().NoError(err)
+
 }

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2927,6 +2927,11 @@ func (m *Messenger) HandleEmojiReaction(state *ReceivedMessageState, pbEmojiR *p
 		return nil
 	}
 
+	err = m.CheckMaxNumberOfEmojiReactionsPerMessage(emojiReaction.ChatId, emojiReaction.MessageId, pbEmojiR.Emoji)
+	if err != nil {
+		return err
+	}
+
 	chat, err := m.matchChatEntity(emojiReaction, protobuf.ApplicationMetadataMessage_EMOJI_REACTION)
 	if err != nil {
 		return err // matchChatEntity returns a descriptive error message

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -510,3 +510,13 @@ class WakuextService(Service):
         params = []
         response = self.rpc_request("peerID", params)
         return response
+
+    def send_emoji_reaction(self, chat_id: str, message_id: str, emoji: str):
+        params = [chat_id, message_id, emoji]
+        response = self.rpc_request(method="sendEmojiReactionV2", params=params)
+        return response
+
+    def send_emoji_reaction_retraction(self, last_emoji_id: str):
+        params = [last_emoji_id]
+        response = self.rpc_request(method="sendEmojiReactionRetraction", params=params)
+        return response

--- a/tests-functional/tests/test_wakuext_message_reactions.py
+++ b/tests-functional/tests/test_wakuext_message_reactions.py
@@ -1,8 +1,9 @@
+import re
 import time
-
 import pytest
 
 from clients.signals import SignalType
+from clients.api import ApiResponseError
 from resources.enums import MessageContentType
 from steps.messenger import MessengerSteps
 
@@ -69,9 +70,8 @@ class TestMessageReactions(MessengerSteps):
         response = self.sender.wakuext_service.send_one_to_one_message(self.receiver.public_key, "test_message 1")
         message_1 = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         # Send emoji reaction (V2)
-        emoji_1_id = self.receiver.wakuext_service.rpc_request(method="sendEmojiReactionV2", params=[receiver_chat_id, message_1["id"], "🙂"])[
-            "emojiReactions"
-        ][0]["id"]
+        response = self.receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_1["id"], "🙂")
+        emoji_1_id = response["emojiReactions"][0]["id"]
         self.sender.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,
             event_pattern=emoji_1_id,
@@ -80,9 +80,8 @@ class TestMessageReactions(MessengerSteps):
 
         response = self.receiver.wakuext_service.send_one_to_one_message(self.sender.public_key, "test_message 2")
         message_2 = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
-        emoji_2_id = self.sender.wakuext_service.rpc_request(method="sendEmojiReactionV2", params=[sender_chat_id, message_2["id"], "🙁"])[
-            "emojiReactions"
-        ][0]["id"]
+        response = self.sender.wakuext_service.send_emoji_reaction(sender_chat_id, message_2["id"], "🙁")
+        emoji_2_id = response["emojiReactions"][0]["id"]
         self.receiver.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,
             event_pattern=emoji_2_id,
@@ -106,3 +105,53 @@ class TestMessageReactions(MessengerSteps):
                     item["emoji"] == "🙂",
                 )
             )
+
+    @pytest.mark.parametrize("waku_light_client", [False], indirect=True, ids=["wakuV2LightClient_False"])
+    def test_limit_of_20_reactions(self, backend_new_profile, waku_light_client):
+        """Test that you cannot send more than 20 message reactions on a single message"""
+        # Initialize two backends (sender and receiver) for this test
+        sender = backend_new_profile("sender", waku_light_client=waku_light_client)
+        receiver = backend_new_profile("receiver", waku_light_client=waku_light_client)
+
+        self.make_contacts(sender, receiver)
+        response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, "test_message")
+        message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
+        message_id, sender_chat_id = message["id"], message["chatId"]
+        receiver_chat_id = receiver.wakuext_service.rpc_request(method="chats")[0]["id"]
+
+        # Send 20 emojis
+        emojis = ["😀", "🤓", "😄", "😁", "😆", "😅", "🤣", "😂", "🥹", "🙂", "🙃", "😉", "😊", "😇", "🥰", "😍", "🤩", "😘", "😗", "☺️"]
+        last_emoji_id = None
+        for emoji in emojis:
+            response = sender.wakuext_service.send_emoji_reaction(sender_chat_id, message_id, emoji)
+            assert response["emojiReactions"][0]["emoji"] == emoji
+            last_emoji_id = response["emojiReactions"][0]["id"]
+
+        # The 21st emoji sent should fail
+        with pytest.raises(ApiResponseError, match=re.escape("too many emoji reactions for message")):
+            _ = sender.wakuext_service.send_emoji_reaction(sender_chat_id, message_id, "😋")
+
+        # Test retract the 20th emoji and adding a new one
+        response = sender.wakuext_service.send_emoji_reaction_retraction(last_emoji_id)
+
+        response = sender.wakuext_service.send_emoji_reaction(sender_chat_id, message_id, "⚓️")
+        assert response["emojiReactions"][0]["emoji"] == "⚓️"
+        new_emoji_id = response["emojiReactions"][0]["id"]
+
+        # Wait for receiver to get the reaction
+        receiver.find_signal_containing_pattern(
+            SignalType.MESSAGES_NEW.value,
+            event_pattern=new_emoji_id,
+            timeout=60,
+        )
+
+        # Test receiver sending the SAME type of a previous reaction (should be allowed)
+        response = receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_id, "⚓️")
+        emoji_2_id = response["emojiReactions"][0]["id"]
+        assert response["emojiReactions"][0]["emoji"] == "⚓️"
+
+        sender.find_signal_containing_pattern(
+            SignalType.MESSAGES_NEW.value,
+            event_pattern=emoji_2_id,
+            timeout=60,
+        )


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/18843

Blocks sending or receiving more than 20 different types of reactions on a single message.

Adds a functional test testing it all

I'll work on the frontend validation too before closing the issue
