### PR TITLE
fix(Dockerfile): no need to download go dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN mkdir -p /go/src/github.com/status-im/status-go
 WORKDIR /go/src/github.com/status-im/status-go
 
 ADD go.mod go.sum ./
-RUN go mod download -x
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
 
 ADD . .


### PR DESCRIPTION
We vendor the dependencies, there's no need to download them every time 