### PR TITLE
chore: tidy up injection of token manager dependency into communities…

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -2349,7 +2349,9 @@ func (b *GethStatusBackend) initProtocol() error {
 		AccountsPublisher:      b.statusNode.AccountsPublisher(),
 		TimeSource:             b.statusNode.TimeSource(),
 		MetricsEnabled:         b.prometheusMetrics != nil,
-		TokenManager:           b.statusNode.TokenManager(),
+		TokenManager:           NewCommunitiesTokenManager(b.statusNode.TokenManager()),
+		TokenBalanceManager:    NewCommunitiesTokenBalanceManager(b.statusNode.TokenManager()),
+		NetworkManager:         NewCommunitiesNetworkManager(b.statusNode.RPCClient().GetNetworkManager()),
 	}
 	err = st.InitProtocol(params)
 	if err != nil {

--- a/api/protocol_adaptors.go
+++ b/api/protocol_adaptors.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"context"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/protocol/communities"
+	"github.com/status-im/status-go/rpc/network"
+	"github.com/status-im/status-go/services/wallet/token"
+	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
+)
+
+var _ communities.NetworkManager = (*CommunitiesNetworkManager)(nil)
+var _ communities.TokenManager = (*CommunitiesTokenManager)(nil)
+var _ communities.TokenBalanceManager = (*CommunitiesTokenBalanceManager)(nil)
+
+type CommunitiesNetworkManager struct {
+	networkManager *network.Manager
+}
+
+func NewCommunitiesNetworkManager(nm *network.Manager) *CommunitiesNetworkManager {
+	return &CommunitiesNetworkManager{networkManager: nm}
+}
+
+func (m *CommunitiesNetworkManager) GetAllChainIDs() ([]uint64, error) {
+	networks, err := m.networkManager.GetActiveNetworks()
+	if err != nil {
+		return nil, err
+	}
+
+	chainIDs := make([]uint64, 0)
+	for _, network := range networks {
+		chainIDs = append(chainIDs, network.ChainID)
+	}
+	return chainIDs, nil
+}
+
+type CommunitiesTokenManager struct {
+	tokenManager *token.Manager
+}
+
+func NewCommunitiesTokenManager(tm *token.Manager) *CommunitiesTokenManager {
+	return &CommunitiesTokenManager{tokenManager: tm}
+}
+
+func (m *CommunitiesTokenManager) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token {
+	return m.tokenManager.FindOrCreateTokenByAddress(ctx, chainID, address)
+}
+
+type CommunitiesTokenBalanceManager struct {
+	tokenManager *token.Manager
+}
+
+func NewCommunitiesTokenBalanceManager(tm *token.Manager) *CommunitiesTokenBalanceManager {
+	return &CommunitiesTokenBalanceManager{tokenManager: tm}
+}
+
+func (m *CommunitiesTokenBalanceManager) GetBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (communities.BalancesByChain, error) {
+	chainClients, err := m.tokenManager.RPCClient.EthClients(chainIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := m.tokenManager.GetBalancesByChain(context.Background(), chainClients, accounts, tokenAddresses)
+	return resp, err
+}
+
+func (m *CommunitiesTokenBalanceManager) GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (communities.BalancesByChain, error) {
+	resp, err := m.tokenManager.GetCachedBalancesByChain(accounts, tokenAddresses, chainIDs)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -1,5 +1,7 @@
 package communities
 
+//go:generate go tool mockgen -package=mock_communities -source=manager.go -destination=mock/communities/manager.go
+
 import (
 	"bytes"
 	"context"
@@ -41,13 +43,11 @@ import (
 	"github.com/status-im/status-go/protocol/ens"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
-	"github.com/status-im/status-go/rpc/network"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/personal"
 	"github.com/status-im/status-go/services/wallet/bigint"
 	walletcommon "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
-	"github.com/status-im/status-go/services/wallet/token"
 	tokenTypes "github.com/status-im/status-go/services/wallet/token/types"
 	"github.com/status-im/status-go/signal"
 )
@@ -104,7 +104,9 @@ type Manager struct {
 	identity                 *ecdsa.PrivateKey
 	installationID           string
 	accountsManager          *accsmanagement.AccountsManager
+	networkManager           NetworkManager
 	tokenManager             TokenManager
+	tokenBalanceManager      TokenBalanceManager
 	collectiblesManager      CollectiblesManager
 	logger                   *zap.Logger
 	signer                   MessageSigner
@@ -245,7 +247,9 @@ type membersReevaluationTask struct {
 
 type managerOptions struct {
 	accountsManager        *accsmanagement.AccountsManager
+	networkManager         NetworkManager
 	tokenManager           TokenManager
+	tokenBalanceManager    TokenBalanceManager
 	collectiblesManager    CollectiblesManager
 	communityTokensService CommunityTokensServiceInterface
 	permissionChecker      PermissionChecker
@@ -256,11 +260,16 @@ type managerOptions struct {
 	allowForcingCommunityMembersReevaluation bool
 }
 
-type TokenManager interface {
-	GetBalancesByChain(ctx context.Context, accounts, tokens []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error)
-	GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error)
-	FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token
+type NetworkManager interface {
 	GetAllChainIDs() ([]uint64, error)
+}
+type TokenManager interface {
+	FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token
+}
+
+type TokenBalanceManager interface {
+	GetBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error)
+	GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error)
 }
 
 type CollectibleContractData struct {
@@ -283,65 +292,13 @@ type CommunityTokensServiceInterface interface {
 	ProcessCommunityTokenAction(message *protobuf.CommunityTokenAction) error
 }
 
-type DefaultTokenManager struct {
-	tokenManager   *token.Manager
-	networkManager network.ManagerInterface
-}
-
-func NewDefaultTokenManager(tm *token.Manager, nm network.ManagerInterface) *DefaultTokenManager {
-	return &DefaultTokenManager{tokenManager: tm, networkManager: nm}
-}
-
 type BalancesByChain = map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big
-
-func (m *DefaultTokenManager) GetAllChainIDs() ([]uint64, error) {
-	networks, err := m.networkManager.GetAll()
-	if err != nil {
-		return nil, err
-	}
-
-	areTestNetworksEnabled, err := m.networkManager.GetTestNetworksEnabled()
-	if err != nil {
-		return nil, err
-	}
-
-	chainIDs := make([]uint64, 0)
-	for _, network := range networks {
-		if areTestNetworksEnabled == network.IsTest {
-			chainIDs = append(chainIDs, network.ChainID)
-		}
-	}
-	return chainIDs, nil
-}
 
 type CollectiblesManager interface {
 	FetchBalancesByOwnerAndContractAddress(ctx context.Context, chainID walletcommon.ChainID, ownerAddress gethcommon.Address, contractAddresses []gethcommon.Address) (thirdparty.TokenBalancesPerContractAddress, error)
 	FetchCachedBalancesByOwnerAndContractAddress(ctx context.Context, chainID walletcommon.ChainID, ownerAddress gethcommon.Address, contractAddresses []gethcommon.Address) (thirdparty.TokenBalancesPerContractAddress, error)
 	GetCollectibleOwnership(id thirdparty.CollectibleUniqueID) ([]thirdparty.AccountBalance, error)
 	FetchCollectibleOwnersByContractAddress(ctx context.Context, chainID walletcommon.ChainID, contractAddress gethcommon.Address) (*thirdparty.CollectibleContractOwnership, error)
-}
-
-func (m *DefaultTokenManager) GetBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error) {
-	clients, err := m.tokenManager.RPCClient.EthClients(chainIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := m.tokenManager.GetBalancesByChain(context.Background(), clients, accounts, tokenAddresses)
-	return resp, err
-}
-
-func (m *DefaultTokenManager) GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error) {
-	resp, err := m.tokenManager.GetCachedBalancesByChain(accounts, tokenAddresses, chainIDs)
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, nil
-}
-
-func (m *DefaultTokenManager) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token {
-	return m.tokenManager.FindOrCreateTokenByAddress(ctx, chainID, address)
 }
 
 type ManagerOption func(*managerOptions)
@@ -364,9 +321,21 @@ func WithCollectiblesManager(collectiblesManager CollectiblesManager) ManagerOpt
 	}
 }
 
+func WithNetworkManager(networkManager NetworkManager) ManagerOption {
+	return func(opts *managerOptions) {
+		opts.networkManager = networkManager
+	}
+}
+
 func WithTokenManager(tokenManager TokenManager) ManagerOption {
 	return func(opts *managerOptions) {
 		opts.tokenManager = tokenManager
+	}
+}
+
+func WithTokenBalanceManager(tokenBalanceManager TokenBalanceManager) ManagerOption {
+	return func(opts *managerOptions) {
+		opts.tokenBalanceManager = tokenBalanceManager
 	}
 }
 
@@ -455,6 +424,14 @@ func NewManager(
 		manager.tokenManager = managerConfig.tokenManager
 	}
 
+	if managerConfig.tokenBalanceManager != nil {
+		manager.tokenBalanceManager = managerConfig.tokenBalanceManager
+	}
+
+	if managerConfig.networkManager != nil {
+		manager.networkManager = managerConfig.networkManager
+	}
+
 	if managerConfig.communityTokensService != nil {
 		manager.communityTokensService = managerConfig.communityTokensService
 	}
@@ -469,7 +446,8 @@ func NewManager(
 		manager.PermissionChecker = managerConfig.permissionChecker
 	} else {
 		manager.PermissionChecker = &DefaultPermissionChecker{
-			tokenManager:        manager.tokenManager,
+			networkManager:      manager.networkManager,
+			tokenBalanceManager: manager.tokenBalanceManager,
 			collectiblesManager: manager.collectiblesManager,
 			logger:              logger,
 			ensVerifier:         ensverifier,
@@ -3356,7 +3334,7 @@ func (m *Manager) CheckChannelPermissions(communityID types.HexBytes, chatID str
 	viewOnlyPreParsedPermissions := preParsedCommunityPermissionsData(viewOnlyPermissions)
 	viewAndPostPreParsedPermissions := preParsedCommunityPermissionsData(viewAndPostPermissions)
 
-	allChainIDs, err := m.tokenManager.GetAllChainIDs()
+	allChainIDs, err := m.networkManager.GetAllChainIDs()
 	if err != nil {
 		return nil, err
 	}
@@ -3465,7 +3443,7 @@ func (m *Manager) CheckAllChannelsPermissions(communityID types.HexBytes, addres
 	}
 	channels := community.Chats()
 
-	allChainIDs, err := m.tokenManager.GetAllChainIDs()
+	allChainIDs, err := m.networkManager.GetAllChainIDs()
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -166,11 +166,11 @@ func (m *testCollectiblesManager) FetchCachedBalancesByOwnerAndContractAddress(c
 	return m.response[uint64(chainID)][ownerAddress], nil
 }
 
-type testTokenManager struct {
+type testTokenBalanceManager struct {
 	response map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big
 }
 
-func (m *testTokenManager) setResponse(chainID uint64, walletAddress, tokenAddress gethcommon.Address, balance int64) {
+func (m *testTokenBalanceManager) setResponse(chainID uint64, walletAddress, tokenAddress gethcommon.Address, balance int64) {
 
 	if m.response == nil {
 		m.response = make(map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big)
@@ -188,23 +188,29 @@ func (m *testTokenManager) setResponse(chainID uint64, walletAddress, tokenAddre
 
 }
 
-func (m *testTokenManager) GetAllChainIDs() ([]uint64, error) {
+type testNetworkManager struct {
+}
+
+func (m *testNetworkManager) GetAllChainIDs() ([]uint64, error) {
 	return []uint64{5}, nil
 }
 
-func (m *testTokenManager) GetBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big, error) {
+func (m *testTokenBalanceManager) GetBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big, error) {
 	return m.response, nil
 }
 
-func (m *testTokenManager) GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error) {
+func (m *testTokenBalanceManager) GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (BalancesByChain, error) {
 	return m.response, nil
+}
+
+type testTokenManager struct {
 }
 
 func (m *testTokenManager) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token {
 	return nil
 }
 
-func (s *ManagerSuite) setupManagerForTokenPermissions() (*Manager, *testCollectiblesManager, *testTokenManager) {
+func (s *ManagerSuite) setupManagerForTokenPermissions() (*Manager, *testCollectiblesManager, *testTokenBalanceManager) {
 	db, err := helpers.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
 	s.NoError(err, "creating sqlite db instance")
 	err = sqlite.Migrate(db)
@@ -216,17 +222,21 @@ func (s *ManagerSuite) setupManagerForTokenPermissions() (*Manager, *testCollect
 
 	cm := &testCollectiblesManager{}
 	tm := &testTokenManager{}
+	tbm := &testTokenBalanceManager{}
+	nm := &testNetworkManager{}
 
 	options := []ManagerOption{
 		WithCollectiblesManager(cm),
 		WithTokenManager(tm),
+		WithTokenBalanceManager(tbm),
+		WithNetworkManager(nm),
 	}
 
 	m, err := NewManager(key, "", db, nil, nil, nil, nil, &TimeSourceStub{}, nil, nil, options...)
 	s.Require().NoError(err)
 	s.Require().NoError(m.Start())
 
-	return m, cm, tm
+	return m, cm, tbm
 }
 
 func (s *ManagerSuite) TestRetrieveTokens() {

--- a/protocol/communities/permission_checker.go
+++ b/protocol/communities/permission_checker.go
@@ -27,7 +27,8 @@ type PermissionChecker interface {
 }
 
 type DefaultPermissionChecker struct {
-	tokenManager        TokenManager
+	networkManager      NetworkManager
+	tokenBalanceManager TokenBalanceManager
 	collectiblesManager CollectiblesManager
 	ensVerifier         *ens.Verifier
 
@@ -158,7 +159,7 @@ func (p *DefaultPermissionChecker) CheckPermissionToJoin(community *Community, a
 
 	adminOrTokenMasterPermissionsToJoin := append(becomeAdminPermissions, becomeTokenMasterPermissions...)
 
-	allChainIDs, err := p.tokenManager.GetAllChainIDs()
+	allChainIDs, err := p.networkManager.GetAllChainIDs()
 	if err != nil {
 		return nil, err
 	}
@@ -492,14 +493,14 @@ func (p *DefaultPermissionChecker) handlePermissionsCheck(permissionsParsedData 
 }
 
 func (p *DefaultPermissionChecker) CheckCachedPermissions(permissionsParsedData *PreParsedCommunityPermissionsData, accountsAndChainIDs []*AccountChainIDsCombination, shortcircuit bool) (*CheckPermissionsResponse, error) {
-	return p.handlePermissionsCheck(permissionsParsedData, accountsAndChainIDs, shortcircuit, p.collectiblesManager.FetchCachedBalancesByOwnerAndContractAddress, p.tokenManager.GetCachedBalancesByChain)
+	return p.handlePermissionsCheck(permissionsParsedData, accountsAndChainIDs, shortcircuit, p.collectiblesManager.FetchCachedBalancesByOwnerAndContractAddress, p.tokenBalanceManager.GetCachedBalancesByChain)
 }
 
 // CheckPermissions will retrieve balances and check whether the user has
 // permission to join the community, if shortcircuit is true, it will stop as soon
 // as we know the answer
 func (p *DefaultPermissionChecker) CheckPermissions(permissionsParsedData *PreParsedCommunityPermissionsData, accountsAndChainIDs []*AccountChainIDsCombination, shortcircuit bool) (*CheckPermissionsResponse, error) {
-	return p.handlePermissionsCheck(permissionsParsedData, accountsAndChainIDs, shortcircuit, p.collectiblesManager.FetchBalancesByOwnerAndContractAddress, p.tokenManager.GetBalancesByChain)
+	return p.handlePermissionsCheck(permissionsParsedData, accountsAndChainIDs, shortcircuit, p.collectiblesManager.FetchBalancesByOwnerAndContractAddress, p.tokenBalanceManager.GetBalancesByChain)
 }
 
 type CollectiblesOwners = map[walletcommon.ChainID]map[gethcommon.Address]*thirdparty.CollectibleContractOwnership
@@ -535,7 +536,7 @@ func (p *DefaultPermissionChecker) CheckPermissionsWithPreFetchedData(permission
 		return p.getOwnedERC721Tokens(walletAddresses, tokenRequirements, chainIDs, getCollectiblesBalances)
 	}
 
-	return p.checkPermissions(permissionsParsedData, accountsAndChainIDs, shortcircuit, getOwnedERC721Tokens, p.tokenManager.GetBalancesByChain)
+	return p.checkPermissions(permissionsParsedData, accountsAndChainIDs, shortcircuit, getOwnedERC721Tokens, p.tokenBalanceManager.GetBalancesByChain)
 }
 
 func preParsedPermissionsData(permissions []*CommunityTokenPermission) *PreParsedPermissionsData {

--- a/protocol/communities/permissioned_balances.go
+++ b/protocol/communities/permissioned_balances.go
@@ -235,7 +235,7 @@ func (m *Manager) GetPermissionedBalances(
 
 	tokenPermissions := keepRoleTokenPermissions(community.TokenPermissions())
 
-	allChainIDs, err := m.tokenManager.GetAllChainIDs()
+	allChainIDs, err := m.networkManager.GetAllChainIDs()
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (m *Manager) GetPermissionedBalances(
 	erc20ChainIDs := calculateChainIDsSet(accountsAndChainIDs, erc20ChainIDsSet)
 	erc721ChainIDs := calculateChainIDsSet(accountsAndChainIDs, erc721ChainIDsSet)
 
-	erc20Balances, err := m.tokenManager.GetBalancesByChain(ctx, accounts, erc20TokenAddresses, erc20ChainIDs)
+	erc20Balances, err := m.tokenBalanceManager.GetBalancesByChain(ctx, accounts, erc20TokenAddresses, erc20ChainIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
+	mock_communities "github.com/status-im/status-go/protocol/communities/mock/communities"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
@@ -37,26 +38,22 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-type TokenManagerMock struct {
-	Balances *communities.BalancesByChain
-}
-
-func (m *TokenManagerMock) GetAllChainIDs() ([]uint64, error) {
-	chainIDs := make([]uint64, 0, len(*m.Balances))
-	for key := range *m.Balances {
+func getAllChainIDs(balances communities.BalancesByChain) []uint64 {
+	chainIDs := make([]uint64, 0, len(balances))
+	for key := range balances {
 		chainIDs = append(chainIDs, key)
 	}
-	return chainIDs, nil
+	return chainIDs
 }
 
-func (m *TokenManagerMock) getBalanceBasedOnParams(accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big {
+func getBalanceBasedOnParams(balances communities.BalancesByChain, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big {
 	retBalances := make(map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big)
 
 	for _, chainId := range chainIDs {
 		if _, exists := retBalances[chainId]; !exists {
 			retBalances[chainId] = make(map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big)
 		}
-		if storedAccounts, exists := (*m.Balances)[chainId]; exists {
+		if storedAccounts, exists := balances[chainId]; exists {
 			for _, account := range accounts {
 				if _, exists := retBalances[chainId][account]; !exists {
 					retBalances[chainId][account] = make(map[gethcommon.Address]*hexutil.Big)
@@ -77,21 +74,6 @@ func (m *TokenManagerMock) getBalanceBasedOnParams(accounts, tokenAddresses []ge
 	}
 
 	return retBalances
-}
-
-func (m *TokenManagerMock) GetBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big, error) {
-	time.Sleep(100 * time.Millisecond) // simulate response time
-	return m.getBalanceBasedOnParams(accounts, tokenAddresses, chainIDs), nil
-}
-
-func (m *TokenManagerMock) GetCachedBalancesByChain(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big, error) {
-	time.Sleep(100 * time.Millisecond) // simulate response time
-	return m.getBalanceBasedOnParams(accounts, tokenAddresses, chainIDs), nil
-}
-
-func (m *TokenManagerMock) FindOrCreateTokenByAddress(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token {
-	time.Sleep(100 * time.Millisecond) // simulate response time
-	return nil
 }
 
 type CollectiblesManagerMock struct {
@@ -307,13 +289,37 @@ func newTestCommunitiesMessenger(s *suite.Suite, messagingEnv *messaging.TestMes
 	accountsManagerMock.EXPECT().GetVerifiedWalletAccount(gomock.Any(), gomock.Any()).
 		Return(generator.NewAccount(nil, nil), nil).AnyTimes()
 
-	tokenManagerMock := &TokenManagerMock{
-		Balances: config.mockedBalances,
-	}
+	tokenManagerMock := mock_communities.NewMockTokenManager(ctrl)
+	tokenManagerMock.EXPECT().FindOrCreateTokenByAddress(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, chainID uint64, address gethcommon.Address) *tokenTypes.Token {
+			time.Sleep(100 * time.Millisecond) // simulate response time
+			return nil
+		}).AnyTimes()
+
+	tokenBalanceManagerMock := mock_communities.NewMockTokenBalanceManager(ctrl)
+	tokenBalanceManagerMock.EXPECT().GetBalancesByChain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big, error) {
+			time.Sleep(100 * time.Millisecond) // simulate response time
+			return getBalanceBasedOnParams(*config.mockedBalances, accounts, tokenAddresses, chainIDs), nil
+		}).AnyTimes()
+	tokenBalanceManagerMock.EXPECT().GetCachedBalancesByChain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, accounts, tokenAddresses []gethcommon.Address, chainIDs []uint64) (map[uint64]map[gethcommon.Address]map[gethcommon.Address]*hexutil.Big, error) {
+			time.Sleep(100 * time.Millisecond) // simulate response time
+			return getBalanceBasedOnParams(*config.mockedBalances, accounts, tokenAddresses, chainIDs), nil
+		}).AnyTimes()
+
+	networkManagerMock := mock_communities.NewMockNetworkManager(ctrl)
+	networkManagerMock.EXPECT().GetAllChainIDs().
+		DoAndReturn(func() ([]uint64, error) {
+			time.Sleep(100 * time.Millisecond) // simulate response time
+			return getAllChainIDs(*config.mockedBalances), nil
+		}).AnyTimes()
 
 	options := []Option{
 		WithAccountsManager(accountsManagerMock),
-		WithCommunityTokenManager(tokenManagerMock),
+		WithTokenManager(tokenManagerMock),
+		WithTokenBalanceManager(tokenBalanceManagerMock),
+		WithNetworkManager(networkManagerMock),
 		WithMessageSigner(NewSignerStub()),
 		WithCollectiblesManager(config.collectiblesManager),
 		WithCommunityTokensService(config.collectiblesService),

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -330,11 +330,16 @@ func NewMessenger(
 		managerOptions = append(managerOptions, communities.WithCollectiblesManager(c.collectiblesManager))
 	}
 
-	if c.communityTokenManager != nil {
-		managerOptions = append(managerOptions, communities.WithTokenManager(c.communityTokenManager))
-	} else if c.rpcClient != nil && c.tokenManager != nil {
-		managerOptions = append(managerOptions, communities.WithTokenManager(
-			communities.NewDefaultTokenManager(c.tokenManager, c.rpcClient.GetNetworkManager())))
+	if c.tokenManager != nil {
+		managerOptions = append(managerOptions, communities.WithTokenManager(c.tokenManager))
+	}
+
+	if c.tokenBalanceManager != nil {
+		managerOptions = append(managerOptions, communities.WithTokenBalanceManager(c.tokenBalanceManager))
+	}
+
+	if c.networkManager != nil {
+		managerOptions = append(managerOptions, communities.WithNetworkManager(c.networkManager))
 	}
 
 	if c.communityTokensService != nil {

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -9,7 +9,6 @@ import (
 	"github.com/status-im/status-go/rpc"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/browsers"
-	"github.com/status-im/status-go/services/wallet/token"
 
 	"go.uber.org/zap"
 
@@ -84,8 +83,9 @@ type config struct {
 	communityTokensService communities.CommunityTokensServiceInterface
 	httpServer             *server.MediaServer
 	rpcClient              *rpc.Client
-	tokenManager           *token.Manager
-	communityTokenManager  communities.TokenManager
+	tokenManager           communities.TokenManager
+	tokenBalanceManager    communities.TokenBalanceManager
+	networkManager         communities.NetworkManager
 	collectiblesManager    communities.CollectiblesManager
 	accountsManager        AccountsManager
 	signer                 communities.MessageSigner
@@ -296,16 +296,23 @@ func WithCommunityTokensService(s communities.CommunityTokensServiceInterface) O
 	}
 }
 
-func WithCommunityTokenManager(tokenManager communities.TokenManager) Option {
+func WithTokenManager(tokenManager communities.TokenManager) Option {
 	return func(c *config) error {
-		c.communityTokenManager = tokenManager
+		c.tokenManager = tokenManager
 		return nil
 	}
 }
 
-func WithTokenManager(tokenManager *token.Manager) Option {
+func WithTokenBalanceManager(tokenBalanceManager communities.TokenBalanceManager) Option {
 	return func(c *config) error {
-		c.tokenManager = tokenManager
+		c.tokenBalanceManager = tokenBalanceManager
+		return nil
+	}
+}
+
+func WithNetworkManager(networkManager communities.NetworkManager) Option {
+	return func(c *config) error {
+		c.networkManager = networkManager
 		return nil
 	}
 }

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -54,7 +54,6 @@ import (
 	"github.com/status-im/status-go/services/wallet/collectibles"
 	w_common "github.com/status-im/status-go/services/wallet/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
-	"github.com/status-im/status-go/services/wallet/token"
 	"github.com/status-im/status-go/signal"
 )
 
@@ -112,7 +111,9 @@ type InitProtocolParams struct {
 	AccountsPublisher      *pubsub.Publisher
 	TimeSource             timesource.TimeSource
 	MetricsEnabled         bool
-	TokenManager           *token.Manager
+	TokenManager           communities.TokenManager
+	TokenBalanceManager    communities.TokenBalanceManager
+	NetworkManager         communities.NetworkManager
 }
 
 func (s *Service) InitProtocol(params InitProtocolParams) error {
@@ -198,7 +199,7 @@ func (s *Service) InitProtocol(params InitProtocolParams) error {
 	options, err := buildMessengerOptions(s.config, params.Identity, params.AppDB, params.WalletDB, params.HTTPServer,
 		s.rpcClient, s.multiAccountsDB, params.Account, envelopeEventsConfig, s.accountsDB, params.WalletService,
 		params.CommunityTokensService, s.logger, &MessengerSignalsHandler{}, params.AccountsManager, params.AccountsPublisher,
-		ensVerifier, params.TokenManager)
+		ensVerifier, params.TokenManager, params.TokenBalanceManager, params.NetworkManager)
 	if err != nil {
 		return err
 	}
@@ -435,7 +436,9 @@ func buildMessengerOptions(
 	accountsManager *accsmanagement.AccountsManager,
 	accountsPublisher *pubsub.Publisher,
 	ensVerifier *ens.Verifier,
-	tokenManager *token.Manager,
+	tokenManager communities.TokenManager,
+	tokenBalanceManager communities.TokenBalanceManager,
+	networkManager communities.NetworkManager,
 ) ([]protocol.Option, error) {
 	personalService := personal.New()
 	options := []protocol.Option{
@@ -462,6 +465,8 @@ func buildMessengerOptions(
 		protocol.WithNewsFeed(),
 		protocol.WithMessageSigner(personalService),
 		protocol.WithTokenManager(tokenManager),
+		protocol.WithTokenBalanceManager(tokenBalanceManager),
+		protocol.WithNetworkManager(networkManager),
 	}
 
 	if config.ShhextConfig.DataSyncEnabled {


### PR DESCRIPTION
… manager

Cleaner use of adapter pattern to inject the Wallet's Token Manager into the Communities manager

Creation of the adaptor objects is now in charge of the class that instantiates everything. Before it was inside the communities package, which meant communities had to import the wallet's packages even though it's only really interested in the interfaces it defines.

Split token list interface from token balance interface in preparation for future refactors.
