### PR TITLE
feat(pairing): add config to let users enable message syncing

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -157,6 +157,7 @@ func (b *GethStatusBackend) initialize() (err error) {
 	b.statusNode.SetMultiaccountsDB(b.multiaccountsDB)
 	b.LocalPairingStateManager = new(statecontrol.ProcessStateManager)
 	b.LocalPairingStateManager.SetPairing(false)
+	b.LocalPairingStateManager.SetMessageSyncEnabled(false)
 
 	return
 }

--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -131,7 +131,7 @@ func (db sqlitePersistence) tableUserMessagesProtobufFields() string {
     		m1.text,
     		m1.source,
 			m1.response_to,
-    		m1.chat_id,
+    		m1.local_chat_id,
     		m1.message_type,
     		m1.content_type,
 

--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -128,6 +128,7 @@ func (db sqlitePersistence) tableUserMessagesProtobufFields() string {
 	return `
 			m1.id,
     		m1.whisper_timestamp,
+			m1.clock_value,
     		m1.text,
     		m1.source,
 			m1.response_to,
@@ -569,6 +570,7 @@ func (db sqlitePersistence) tableUserMessagesScanProtobufFields(row scanner, mes
 	args := []interface{}{
 		&message.Id,
 		&message.Timestamp,
+		&message.Clock,
 		&message.Text,
 		&message.From, // source in table
 		&message.ResponseTo,

--- a/protocol/messenger_group_chat_test.go
+++ b/protocol/messenger_group_chat_test.go
@@ -60,7 +60,9 @@ func makeMutualContact(origin *Messenger, contactPubkey *ecdsa.PublicKey) error 
 		return err
 	}
 	contact.ContactRequestLocalState = ContactRequestStateSent
+	contact.ContactRequestLocalClock = 1
 	contact.ContactRequestRemoteState = ContactRequestStateReceived
+	contact.ContactRequestRemoteClock = 1
 	origin.allContacts.Store(contact.ID, contact)
 
 	return nil

--- a/protocol/messenger_installations_test.go
+++ b/protocol/messenger_installations_test.go
@@ -264,7 +264,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 	s.Require().NoError(err)
 
 	// sync
-	err = s.m.SyncDevices(context.Background(), "ens-name", "profile-image", nil)
+	err = s.m.SyncDevices(context.Background(), "ens-name", "profile-image", false, nil)
 	s.Require().NoError(err)
 
 	var allChats []*Chat

--- a/protocol/messenger_local_backup_test.go
+++ b/protocol/messenger_local_backup_test.go
@@ -24,6 +24,13 @@ type MessengerLocalBackupSuite struct {
 	MessengerBaseTestSuite
 }
 
+func makeMutualContacts(lhs *Messenger, rhs *Messenger) error {
+	if err := makeMutualContact(lhs, &rhs.identity.PublicKey); err != nil {
+		return err
+	}
+	return makeMutualContact(rhs, &lhs.identity.PublicKey)
+}
+
 func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	// Create bob1
 	bob1 := s.anotherMessenger()
@@ -59,23 +66,6 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	s.Require().NoError(err)
 
 	s.Require().Len(bob1.Contacts(), 2)
-
-	// Validate contacts on bob1
-	actualContacts := bob1.Contacts()
-	if actualContacts[0].ID == contactID1 {
-		s.Require().Equal(actualContacts[0].ID, contactID1)
-		s.Require().Equal(actualContacts[1].ID, contactID2)
-	} else {
-		s.Require().Equal(actualContacts[0].ID, contactID2)
-		s.Require().Equal(actualContacts[1].ID, contactID1)
-	}
-	s.Require().Equal(ContactRequestStateSent, actualContacts[0].ContactRequestLocalState)
-	s.Require().Equal(ContactRequestStateSent, actualContacts[1].ContactRequestLocalState)
-	s.Require().True(actualContacts[0].added())
-	s.Require().True(actualContacts[1].added())
-
-	// Check that bob2 has no contacts
-	s.Require().Len(bob2.Contacts(), 0)
 
 	//-------------------- COMMUNITIES --------------------
 	// Create a community
@@ -211,8 +201,18 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	alice := s.newMessenger()
 	defer TearDownMessenger(&s.Suite, alice)
 
+	makeMutualContacts(bob1, alice)
+
+	aliceContact := bob1.GetContactByID(alice.selfContact.ID)
+	err = bob1.persistence.SaveContact(aliceContact, nil)
+	s.Require().NoError(err)
+
 	ourOneOneChat := CreateOneToOneChat("Our 1TO1", &alice.identity.PublicKey, alice.getTimesource())
 	err = bob1.SaveChat(ourOneOneChat)
+	s.Require().NoError(err)
+
+	theirChat := CreateOneToOneChat("Their 1TO1", &bob1.identity.PublicKey, bob1.getTimesource())
+	err = alice.SaveChat(theirChat)
 	s.Require().NoError(err)
 
 	// Send transaction command to Alice
@@ -222,6 +222,53 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	transactionMessage.Text = "some transaction"
 	_, err = bob1.SendChatMessage(ctx, transactionMessage)
 	s.Require().NoError(err)
+
+	// Alice sends a message to bob1
+	inputMessage = buildTestMessage(*theirChat)
+	inputMessage.Text = "some text from alice"
+	sendResponse, err = alice.SendChatMessage(context.Background(), inputMessage)
+	s.NoError(err)
+	s.Require().Len(sendResponse.Messages(), 1)
+
+	response, err = WaitOnMessengerResponse(
+		bob1,
+		func(r *MessengerResponse) bool {
+			return len(r.messages) > 0 && r.Messages()[0].Text == "some text from alice"
+		},
+		"no messages",
+	)
+	s.Require().NoError(err)
+	s.Require().Len(response.Chats(), 1)
+	s.Require().Len(response.Messages(), 1)
+
+	// Validate contacts on bob1
+	contact1Found := false
+	contact2Found := false
+	aliceFound := false
+	for _, c := range bob1.Contacts() {
+		switch c.ID {
+		case contactID1:
+			contact1Found = true
+			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
+			s.Require().Equal(ContactRequestStateNone, c.ContactRequestRemoteState)
+			s.Require().True(c.added())
+		case contactID2:
+			contact2Found = true
+			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
+			s.Require().Equal(ContactRequestStateNone, c.ContactRequestRemoteState)
+			s.Require().True(c.added())
+		case alice.selfContact.ID:
+			aliceFound = true
+			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
+			s.Require().Equal(ContactRequestStateReceived, c.ContactRequestRemoteState)
+			s.Require().True(c.added())
+		}
+	}
+	s.Require().True(contact1Found)
+	s.Require().True(contact2Found)
+	s.Require().True(aliceFound)
+	// Check that bob2 has no contacts
+	s.Require().Len(bob2.Contacts(), 0)
 
 	// -------------------- BACKUP --------------------
 	// Backup
@@ -234,7 +281,31 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 
 	// -------------------- VALIDATE BACKUP --------------------
 	// Validate contacts on bob2
-	s.Require().Len(bob2.Contacts(), 2)
+	contact1Found = false
+	contact2Found = false
+	aliceFound = false
+	for _, c := range bob2.Contacts() {
+		switch c.ID {
+		case contactID1:
+			contact1Found = true
+			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
+			s.Require().Equal(ContactRequestStateNone, c.ContactRequestRemoteState)
+			s.Require().True(c.added())
+		case contactID2:
+			contact2Found = true
+			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
+			s.Require().Equal(ContactRequestStateNone, c.ContactRequestRemoteState)
+			s.Require().True(c.added())
+		case alice.selfContact.ID:
+			aliceFound = true
+			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
+			s.Require().Equal(ContactRequestStateReceived, c.ContactRequestRemoteState)
+			s.Require().True(c.added())
+		}
+	}
+	s.Require().True(contact1Found)
+	s.Require().True(contact2Found)
+	s.Require().True(aliceFound)
 
 	// Validate communities on bob2
 	communities, err = bob2.JoinedCommunities()
@@ -257,7 +328,7 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	s.Require().NoError(err)
 	messages, err := bob2.persistence.AllMessagesForBackup()
 	s.Require().NoError(err)
-	s.Require().Len(messages, 14)
+	s.Require().Len(messages, 15)
 
 	textMessageFound := false
 	mdMessageFound := false
@@ -266,6 +337,7 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	emojiMessageFound := false
 	txMessageFound := false
 	pinnedSystemMessageFound := false
+	messageFromAliceFound := false
 	for _, msg := range messages {
 		if msg.ContentType == int64(protobuf.ChatMessage_TEXT_PLAIN) && msg.Text == "some text" {
 			textMessageFound = true
@@ -282,6 +354,8 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 			txMessageFound = true
 		} else if msg.ContentType == int64(protobuf.ChatMessage_SYSTEM_MESSAGE_PINNED_MESSAGE) && msg.Text == "" {
 			pinnedSystemMessageFound = true
+		} else if msg.ContentType == int64(protobuf.ChatMessage_TEXT_PLAIN) && msg.Text == "some text from alice" {
+			messageFromAliceFound = true
 		}
 	}
 	s.Require().True(textMessageFound)
@@ -291,6 +365,7 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	s.Require().True(emojiMessageFound)
 	s.Require().True(txMessageFound)
 	s.Require().True(pinnedSystemMessageFound)
+	s.Require().True(messageFromAliceFound)
 
 	// Validate pinned messages
 	pinnedMessages, _, err := bob2.PinnedMessageByChatID(chatID, "", 10)

--- a/protocol/messenger_local_backup_test.go
+++ b/protocol/messenger_local_backup_test.go
@@ -242,31 +242,24 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	s.Require().Len(response.Messages(), 1)
 
 	// Validate contacts on bob1
-	contact1Found := false
-	contact2Found := false
-	aliceFound := false
-	for _, c := range bob1.Contacts() {
-		switch c.ID {
-		case contactID1:
-			contact1Found = true
-			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
-			s.Require().Equal(ContactRequestStateNone, c.ContactRequestRemoteState)
-			s.Require().True(c.added())
-		case contactID2:
-			contact2Found = true
-			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
-			s.Require().Equal(ContactRequestStateNone, c.ContactRequestRemoteState)
-			s.Require().True(c.added())
-		case alice.selfContact.ID:
-			aliceFound = true
-			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
-			s.Require().Equal(ContactRequestStateReceived, c.ContactRequestRemoteState)
-			s.Require().True(c.added())
-		}
-	}
-	s.Require().True(contact1Found)
-	s.Require().True(contact2Found)
-	s.Require().True(aliceFound)
+	contact1 := bob1.GetContactByID(contactID1)
+	s.Require().NotNil(contact1)
+	s.Require().Equal(ContactRequestStateSent, contact1.ContactRequestLocalState)
+	s.Require().Equal(ContactRequestStateNone, contact1.ContactRequestRemoteState)
+	s.Require().True(contact1.added())
+
+	contact2 := bob1.GetContactByID(contactID2)
+	s.Require().NotNil(contact2)
+	s.Require().Equal(ContactRequestStateSent, contact2.ContactRequestLocalState)
+	s.Require().Equal(ContactRequestStateNone, contact2.ContactRequestRemoteState)
+	s.Require().True(contact2.added())
+
+	aliceContact = bob1.GetContactByID(alice.selfContact.ID)
+	s.Require().NotNil(aliceContact)
+	s.Require().Equal(ContactRequestStateSent, aliceContact.ContactRequestLocalState)
+	s.Require().Equal(ContactRequestStateReceived, aliceContact.ContactRequestRemoteState)
+	s.Require().True(aliceContact.added())
+
 	// Check that bob2 has no contacts
 	s.Require().Len(bob2.Contacts(), 0)
 
@@ -281,31 +274,23 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 
 	// -------------------- VALIDATE BACKUP --------------------
 	// Validate contacts on bob2
-	contact1Found = false
-	contact2Found = false
-	aliceFound = false
-	for _, c := range bob2.Contacts() {
-		switch c.ID {
-		case contactID1:
-			contact1Found = true
-			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
-			s.Require().Equal(ContactRequestStateNone, c.ContactRequestRemoteState)
-			s.Require().True(c.added())
-		case contactID2:
-			contact2Found = true
-			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
-			s.Require().Equal(ContactRequestStateNone, c.ContactRequestRemoteState)
-			s.Require().True(c.added())
-		case alice.selfContact.ID:
-			aliceFound = true
-			s.Require().Equal(ContactRequestStateSent, c.ContactRequestLocalState)
-			s.Require().Equal(ContactRequestStateReceived, c.ContactRequestRemoteState)
-			s.Require().True(c.added())
-		}
-	}
-	s.Require().True(contact1Found)
-	s.Require().True(contact2Found)
-	s.Require().True(aliceFound)
+	contact1 = bob2.GetContactByID(contactID1)
+	s.Require().NotNil(contact1)
+	s.Require().Equal(ContactRequestStateSent, contact1.ContactRequestLocalState)
+	s.Require().Equal(ContactRequestStateNone, contact1.ContactRequestRemoteState)
+	s.Require().True(contact1.added())
+
+	contact2 = bob2.GetContactByID(contactID2)
+	s.Require().NotNil(contact2)
+	s.Require().Equal(ContactRequestStateSent, contact2.ContactRequestLocalState)
+	s.Require().Equal(ContactRequestStateNone, contact2.ContactRequestRemoteState)
+	s.Require().True(contact2.added())
+
+	aliceContact = bob2.GetContactByID(alice.selfContact.ID)
+	s.Require().NotNil(aliceContact)
+	s.Require().Equal(ContactRequestStateSent, aliceContact.ContactRequestLocalState)
+	s.Require().Equal(ContactRequestStateReceived, aliceContact.ContactRequestRemoteState)
+	s.Require().True(aliceContact.added())
 
 	// Validate communities on bob2
 	communities, err = bob2.JoinedCommunities()
@@ -325,47 +310,54 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	s.Require().Equal("", chat.Name)
 
 	// Validate messages
-	s.Require().NoError(err)
 	messages, err := bob2.persistence.AllMessagesForBackup()
 	s.Require().NoError(err)
 	s.Require().Len(messages, 15)
 
-	textMessageFound := false
-	mdMessageFound := false
-	imageMessageFound := false
-	stickerMessageFound := false
-	emojiMessageFound := false
-	txMessageFound := false
-	pinnedSystemMessageFound := false
-	messageFromAliceFound := false
+	// Build a map for easier assertions
+	messageMap := make(map[string]*protobuf.BackedUpMessage)
 	for _, msg := range messages {
-		if msg.ContentType == int64(protobuf.ChatMessage_TEXT_PLAIN) && msg.Text == "some text" {
-			textMessageFound = true
-			s.Require().True(msg.PinnedBy == bob2.selfContact.ID)
-		} else if msg.ContentType == int64(protobuf.ChatMessage_TEXT_PLAIN) && msg.Text == "some *markdown* text" {
-			mdMessageFound = true
-		} else if msg.ContentType == int64(protobuf.ChatMessage_IMAGE) && msg.Text == "some image" {
-			imageMessageFound = true
-		} else if msg.ContentType == int64(protobuf.ChatMessage_STICKER) && msg.Text == "some sticker" {
-			stickerMessageFound = true
-		} else if msg.ContentType == int64(protobuf.ChatMessage_EMOJI) && msg.Text == ":+1:" {
-			emojiMessageFound = true
-		} else if msg.ContentType == int64(protobuf.ChatMessage_TRANSACTION_COMMAND) && msg.Text == "some transaction" {
-			txMessageFound = true
-		} else if msg.ContentType == int64(protobuf.ChatMessage_SYSTEM_MESSAGE_PINNED_MESSAGE) && msg.Text == "" {
-			pinnedSystemMessageFound = true
-		} else if msg.ContentType == int64(protobuf.ChatMessage_TEXT_PLAIN) && msg.Text == "some text from alice" {
-			messageFromAliceFound = true
+		if msg.ContentType == int64(protobuf.ChatMessage_SYSTEM_MESSAGE_PINNED_MESSAGE) && msg.Text == "" {
+			// For system pinned message, Text is empty so we use a custom key
+			messageMap["systemPin"] = msg
+			continue
 		}
+		messageMap[msg.Text] = msg
 	}
-	s.Require().True(textMessageFound)
-	s.Require().True(mdMessageFound)
-	s.Require().True(imageMessageFound)
-	s.Require().True(stickerMessageFound)
-	s.Require().True(emojiMessageFound)
-	s.Require().True(txMessageFound)
-	s.Require().True(pinnedSystemMessageFound)
-	s.Require().True(messageFromAliceFound)
+
+	// Assert each message type exists and has expected properties
+	textMsg, ok := messageMap["some text"]
+	s.Require().True(ok)
+	s.Require().Equal(int64(protobuf.ChatMessage_TEXT_PLAIN), textMsg.ContentType)
+	s.Require().Equal(bob2.selfContact.ID, textMsg.PinnedBy)
+
+	mdMsg, ok := messageMap["some *markdown* text"]
+	s.Require().True(ok)
+	s.Require().Equal(int64(protobuf.ChatMessage_TEXT_PLAIN), mdMsg.ContentType)
+
+	imageMsg, ok := messageMap["some image"]
+	s.Require().True(ok)
+	s.Require().Equal(int64(protobuf.ChatMessage_IMAGE), imageMsg.ContentType)
+
+	stickerMsg, ok := messageMap["some sticker"]
+	s.Require().True(ok)
+	s.Require().Equal(int64(protobuf.ChatMessage_STICKER), stickerMsg.ContentType)
+
+	emojiMsg, ok := messageMap[":+1:"]
+	s.Require().True(ok)
+	s.Require().Equal(int64(protobuf.ChatMessage_EMOJI), emojiMsg.ContentType)
+
+	txMsg, ok := messageMap["some transaction"]
+	s.Require().True(ok)
+	s.Require().Equal(int64(protobuf.ChatMessage_TRANSACTION_COMMAND), txMsg.ContentType)
+
+	aliceMsg, ok := messageMap["some text from alice"]
+	s.Require().True(ok)
+	s.Require().Equal(int64(protobuf.ChatMessage_TEXT_PLAIN), aliceMsg.ContentType)
+
+	systemPinMsg, ok := messageMap["systemPin"]
+	s.Require().True(ok)
+	s.Require().Equal("", systemPinMsg.Text)
 
 	// Validate pinned messages
 	pinnedMessages, _, err := bob2.PinnedMessageByChatID(chatID, "", 10)

--- a/protocol/messenger_pairing_and_syncing.go
+++ b/protocol/messenger_pairing_and_syncing.go
@@ -22,9 +22,6 @@ type InstallationIDProvider interface {
 	Validate() error
 }
 
-// TODO use a setting or an API param instead
-const syncMessages = false
-
 func (m *Messenger) EnableInstallationAndSync(request *requests.EnableInstallationAndSync) (*MessengerResponse, error) {
 	if err := request.Validate(); err != nil {
 		return nil, err
@@ -43,7 +40,7 @@ func (m *Messenger) EnableInstallationAndSync(request *requests.EnableInstallati
 		return nil, err
 	}
 
-	if err = m.SyncDevices(context.Background(), "", "", nil); err != nil {
+	if err = m.SyncDevices(context.Background(), "", "", false, nil); err != nil {
 		return nil, err
 	}
 
@@ -160,8 +157,9 @@ func (m *Messenger) SendPairInstallation(ctx context.Context, targetInstallation
 }
 
 // SyncDevices sends all public chats and contacts to paired devices
+// Also sends all messages if enabled
 // TODO remove use of photoPath in contacts
-func (m *Messenger) SyncDevices(ctx context.Context, ensName, photoPath string, rawMessageHandler RawMessageHandler) (err error) {
+func (m *Messenger) SyncDevices(ctx context.Context, ensName, photoPath string, messageSyncEnabled bool, rawMessageHandler RawMessageHandler) (err error) {
 	isLocalPairing := true
 	if rawMessageHandler == nil {
 		isLocalPairing = false
@@ -317,7 +315,7 @@ func (m *Messenger) SyncDevices(ctx context.Context, ensName, photoPath string, 
 
 	// Only sync messages when enabled by the user and on local pairing
 	// This is to avoid as much as possible the possibility of breaching user privacy
-	if syncMessages && isLocalPairing {
+	if messageSyncEnabled && isLocalPairing {
 		err = m.syncMessages(ctx, rawMessageHandler)
 		if err != nil {
 			return err

--- a/protocol/messenger_sync_keycards_state_test.go
+++ b/protocol/messenger_sync_keycards_state_test.go
@@ -125,7 +125,7 @@ func (s *MessengerSyncKeycardsStateSuite) TestSyncKeycardsIfReceiverHasNoKeycard
 	s.Require().NoError(err)
 
 	// Trigger's a sync between devices
-	err = s.main.SyncDevices(context.Background(), "ens-name", "profile-image", nil)
+	err = s.main.SyncDevices(context.Background(), "ens-name", "profile-image", false, nil)
 	s.Require().NoError(err)
 
 	// Wait for the response
@@ -189,7 +189,7 @@ func (s *MessengerSyncKeycardsStateSuite) TestSyncKeycardsIfKeycardsWereDeletedO
 	s.Require().NoError(err)
 
 	// Trigger's a sync between devices
-	err = s.main.SyncDevices(context.Background(), "ens-name", "profile-image", nil)
+	err = s.main.SyncDevices(context.Background(), "ens-name", "profile-image", false, nil)
 	s.Require().NoError(err)
 
 	// Wait for the response
@@ -245,7 +245,7 @@ func (s *MessengerSyncKeycardsStateSuite) TestSyncKeycardsIfReceiverAndSenderHas
 	s.Require().NoError(err)
 
 	// Trigger's a sync between devices
-	err = s.main.SyncDevices(context.Background(), "ens-name", "profile-image", nil)
+	err = s.main.SyncDevices(context.Background(), "ens-name", "profile-image", false, nil)
 	s.Require().NoError(err)
 
 	// Wait for the response

--- a/protocol/messenger_sync_wallets_test.go
+++ b/protocol/messenger_sync_wallets_test.go
@@ -174,7 +174,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWallets() {
 	s.Require().Equal(len(profileKp.Accounts)+len(seedPhraseKp.Accounts)+len(privKeyKp.Accounts)+len(woAccounts), len(dbAccounts1))
 
 	// Trigger's a sync between devices
-	err = s.m.SyncDevices(context.Background(), "ens-name", "profile-image", nil)
+	err = s.m.SyncDevices(context.Background(), "ens-name", "profile-image", false, nil)
 	s.Require().NoError(err)
 
 	err = tt.RetryWithBackOff(func() error {
@@ -567,7 +567,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 	s.Require().NoError(err)
 
 	// Trigger's a sync between devices
-	err = s.m.SyncDevices(context.Background(), "ens-name", "profile-image", nil)
+	err = s.m.SyncDevices(context.Background(), "ens-name", "profile-image", false, nil)
 	s.Require().NoError(err)
 
 	err = tt.RetryWithBackOff(func() error {

--- a/server/pairing/config.go
+++ b/server/pairing/config.go
@@ -20,6 +20,8 @@ type SenderConfig struct {
 	Password string `json:"password" validate:"required"`
 	ChatKey  string `json:"chatKey"` // set only in case of a Keycard user, otherwise empty
 
+	MessageSyncingEnabled bool `json:"messageSyncingEnabled"`
+
 	DB *multiaccounts.Database `json:"-"`
 }
 

--- a/server/pairing/raw_message_handler.go
+++ b/server/pairing/raw_message_handler.go
@@ -55,12 +55,14 @@ func (s *SyncRawMessageHandler) PrepareRawMessage(keyUID, deviceType string) (rm
 		return nil, nil, nil, fmt.Errorf("keyUID not equal")
 	}
 
+	messageSyncEnabled := s.backend.LocalPairingStateManager.IsMessageSyncEnabled()
+
 	messenger.SetLocalPairing(true)
 	defer func() {
 		messenger.SetLocalPairing(false)
 	}()
 	rawMessageCollector := new(RawMessageCollector)
-	err = messenger.SyncDevices(context.TODO(), currentAccount.Name, currentAccount.Identicon, rawMessageCollector.dispatchMessage)
+	err = messenger.SyncDevices(context.TODO(), currentAccount.Name, currentAccount.Identicon, messageSyncEnabled, rawMessageCollector.dispatchMessage)
 	if err != nil {
 		return
 	}

--- a/server/pairing/server.go
+++ b/server/pairing/server.go
@@ -196,6 +196,8 @@ func StartUpSenderServer(backend *api.GethStatusBackend, configJSON string) (str
 		}
 	}
 
+	backend.LocalPairingStateManager.SetMessageSyncEnabled(conf.SenderConfig.MessageSyncingEnabled)
+
 	ps, err := MakeFullSenderServer(backend, conf)
 	if err != nil {
 		return "", err

--- a/server/pairing/statecontrol/state_management.go
+++ b/server/pairing/statecontrol/state_management.go
@@ -19,6 +19,9 @@ type ProcessStateManager struct {
 	pairing     bool
 	pairingLock sync.Mutex
 
+	messageSyncEnabled bool
+	messageSyncLock    sync.Mutex
+
 	// sessions represents a map[string]bool:
 	// where string is a ConnectionParams string and bool is the transfer success state of that connection string
 	sessions sync.Map
@@ -36,6 +39,20 @@ func (psm *ProcessStateManager) SetPairing(state bool) {
 	psm.pairingLock.Lock()
 	defer psm.pairingLock.Unlock()
 	psm.pairing = state
+}
+
+// IsMessageSyncEnabled returns if syncing messages is enabled by the User
+func (psm *ProcessStateManager) IsMessageSyncEnabled() bool {
+	psm.messageSyncLock.Lock()
+	defer psm.messageSyncLock.Unlock()
+	return psm.messageSyncEnabled
+}
+
+// SetMessageSyncEnabled sets the ProcessStateManager message sync state
+func (psm *ProcessStateManager) SetMessageSyncEnabled(state bool) {
+	psm.messageSyncLock.Lock()
+	defer psm.messageSyncLock.Unlock()
+	psm.messageSyncEnabled = state
 }
 
 // RegisterSession stores a sessionName with the default false value.

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -848,7 +848,7 @@ func (api *PublicAPI) SendPairInstallation(ctx context.Context) (*protocol.Messe
 }
 
 func (api *PublicAPI) SyncDevices(ctx context.Context, name, picture string) error {
-	return api.service.messenger.SyncDevices(ctx, name, picture, nil)
+	return api.service.messenger.SyncDevices(ctx, name, picture, false, nil)
 }
 
 // Deprecated: Use EnableInstallationAndSync instead

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -356,7 +356,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
             return
         raise TimeoutError(f"StatusBackend was not online after {timeout} seconds")
 
-    def get_connection_string_for_bootstrapping_another_device(self):
+    def get_connection_string_for_bootstrapping_another_device(self, message_sync_enabled=False):
         method = "GetConnectionStringForBootstrappingAnotherDevice"
         data = {
             "senderConfig": {
@@ -365,6 +365,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
                 "keyUID": self.key_uid,
                 "password": self.password,
                 "chatKey": "",
+                "messageSyncingEnabled": message_sync_enabled,
             },
             "serverConfig": {
                 "timeout": 5 * 60 * 1000,

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -208,18 +208,14 @@ class TestLocalPairing(MessengerSteps):
 
         # Check that bob has the messages before pairing
         messages = bob.wakuext_service.chat_messages(alice.public_key, limit=10)["messages"]
-        assert messages is not None, "No messages found on paired device"
-        message_found1 = False
-        message_found2 = False
-        for message in messages:
-            if message["id"] == message_id1 and message["text"] == "hello alice":
-                message_found1 = True
-                continue
-            if message["id"] == message_id2 and message["text"] == "hello bob":
-                message_found2 = True
-                continue
-        assert message_found1, "Message 1 not found on original device"
-        assert message_found2, "Message 2 not found on original device"
+        assert messages is not None, "No messages found on original device"
+        messages_map = {message["id"]: message for message in messages}
+
+        assert message_id1 in messages_map, "Message 1 not found on original device"
+        assert messages_map[message_id1]["text"] == "hello alice"
+
+        assert message_id2 in messages_map, "Message 2 not found on original device"
+        assert messages_map[message_id2]["text"] == "hello bob"
 
         # Local pairing WITH message syncing
         pair_server_as_sender(bob, bob_second_device, True)
@@ -249,19 +245,15 @@ class TestLocalPairing(MessengerSteps):
         # Check that the messages are synced
         messages = bob_second_device.wakuext_service.chat_messages(sender_chat_id, limit=10)["messages"]
         assert messages is not None, "No messages found on paired device"
-        message_found1 = False
-        message_found2 = False
-        for message in messages:
-            if message["id"] == message_id1 and message["text"] == "hello alice":
-                message_found1 = True
-                assert message["clock"] == clock_1, "Message 1 clock is not right on paired device"
-                continue
-            if message["id"] == message_id2 and message["text"] == "hello bob":
-                message_found2 = True
-                assert message["clock"] == clock_2, "Message 2 clock is not right on paired device"
-                continue
-        assert message_found1, "Message 1 sent before pairing not found on paired device"
-        assert message_found2, "Message 2 sent before pairing not found on paired device"
+        messages_map = {message["id"]: message for message in messages}
+
+        assert message_id1 in messages_map, "Message 1 sent before pairing not found on paired device"
+        assert messages_map[message_id1]["text"] == "hello alice"
+        assert messages_map[message_id1]["clock"] == clock_1, "Message 1 clock is not right on paired device"
+
+        assert message_id2 in messages_map, "Message 2 sent before pairing not found on paired device"
+        assert messages_map[message_id2]["text"] == "hello bob"
+        assert messages_map[message_id2]["clock"] == clock_2, "Message 2 clock is not right on paired device"
 
     def test_pairing_server_as_receiver(self):
         # Create users

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -191,13 +191,13 @@ class TestLocalPairing(MessengerSteps):
         # Send a message to Alice before local pairing
         response = bob.wakuext_service.send_one_to_one_message(alice.public_key, "hello alice")
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
-        message_id1, sender_chat_id = message["id"], message["chatId"]
+        message_id1, sender_chat_id, clock_1 = message["id"], message["chatId"], message["clock"]
 
         # Send a message to Bob before local pairing
         response = alice.wakuext_service.send_one_to_one_message(bob.public_key, "hello bob")
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
-        message_id2 = message["id"]
+        message_id2, clock_2 = message["id"], message["clock"]
 
         # Wait for the message to be delivered
         bob.find_signal_containing_pattern(
@@ -254,9 +254,11 @@ class TestLocalPairing(MessengerSteps):
         for message in messages:
             if message["id"] == message_id1 and message["text"] == "hello alice":
                 message_found1 = True
+                assert message["clock"] == clock_1, "Message 1 clock is not right on paired device"
                 continue
             if message["id"] == message_id2 and message["text"] == "hello bob":
                 message_found2 = True
+                assert message["clock"] == clock_2, "Message 2 clock is not right on paired device"
                 continue
         assert message_found1, "Message 1 sent before pairing not found on paired device"
         assert message_found2, "Message 2 sent before pairing not found on paired device"

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -189,9 +189,37 @@ class TestLocalPairing(MessengerSteps):
         self.create_community(bob)
 
         # Send a message to Alice before local pairing
-        response = bob.wakuext_service.send_one_to_one_message(alice.public_key, "test_message")
+        response = bob.wakuext_service.send_one_to_one_message(alice.public_key, "hello alice")
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
-        message_id, sender_chat_id = message["id"], message["chatId"]
+        message_id1, sender_chat_id = message["id"], message["chatId"]
+
+        # Send a message to Bob before local pairing
+        response = alice.wakuext_service.send_one_to_one_message(bob.public_key, "hello bob")
+        message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
+        self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
+        message_id2 = message["id"]
+
+        # Wait for the message to be delivered
+        bob.find_signal_containing_pattern(
+            SignalType.MESSAGES_NEW.value,
+            event_pattern=message_id2,
+            timeout=60,
+        )
+
+        # Check that bob has the messages before pairing
+        messages = bob.wakuext_service.chat_messages(alice.public_key, limit=10)["messages"]
+        assert messages is not None, "No messages found on paired device"
+        message_found1 = False
+        message_found2 = False
+        for message in messages:
+            if message["id"] == message_id1 and message["text"] == "hello alice":
+                message_found1 = True
+                continue
+            if message["id"] == message_id2 and message["text"] == "hello bob":
+                message_found2 = True
+                continue
+        assert message_found1, "Message 1 not found on original device"
+        assert message_found2, "Message 2 not found on original device"
 
         # Local pairing WITH message syncing
         pair_server_as_sender(bob, bob_second_device, True)
@@ -221,12 +249,17 @@ class TestLocalPairing(MessengerSteps):
         # Check that the messages are synced
         messages = bob_second_device.wakuext_service.chat_messages(sender_chat_id, limit=10)["messages"]
         assert messages is not None, "No messages found on paired device"
-        message_found = False
+        message_found1 = False
+        message_found2 = False
         for message in messages:
-            if message["id"] == message_id and message["text"] == "test_message":
-                message_found = True
-                break
-        assert message_found, "Message sent before pairing not found on paired device"
+            if message["id"] == message_id1 and message["text"] == "hello alice":
+                message_found1 = True
+                continue
+            if message["id"] == message_id2 and message["text"] == "hello bob":
+                message_found2 = True
+                continue
+        assert message_found1, "Message 1 sent before pairing not found on paired device"
+        assert message_found2, "Message 2 sent before pairing not found on paired device"
 
     def test_pairing_server_as_receiver(self):
         # Create users

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -119,8 +119,8 @@ def wait_for_action_of_type(backend: StatusBackend, action, type):
     )
 
 
-def pair_server_as_sender(sender, receiver):
-    connection_string = sender.get_connection_string_for_bootstrapping_another_device()
+def pair_server_as_sender(sender, receiver, message_sync_enabled=False):
+    connection_string = sender.get_connection_string_for_bootstrapping_another_device(message_sync_enabled)
     response = receiver.input_connection_string_for_bootstrapping(connection_string)
     assert response["error"] is None
     assert response["keyUID"] == sender.key_uid
@@ -193,8 +193,8 @@ class TestLocalPairing(MessengerSteps):
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         message_id, sender_chat_id = message["id"], message["chatId"]
 
-        # Local pairing
-        pair_server_as_sender(bob, bob_second_device)
+        # Local pairing WITH message syncing
+        pair_server_as_sender(bob, bob_second_device, True)
 
         # Check sender signals
         events = bob.get_all_events(signal_type=SignalType.LOCAL_PAIRING.value)
@@ -219,17 +219,14 @@ class TestLocalPairing(MessengerSteps):
         assert bob_response is True
 
         # Check that the messages are synced
-        # TODO uncomment this when message sync is enabled (syncMessages = true)
-        # those asserts are just to avoid unused variable warnings for now
-        assert message_id is not None
-        assert sender_chat_id is not None
-        # messages = bob_second_device.wakuext_service.chat_messages(sender_chat_id, limit=10)["messages"]
-        # message_found = False
-        # for message in messages:
-        #     if message["id"] == message_id and message["text"] == "test_message":
-        #         message_found = True
-        #         break
-        # assert message_found, "Message sent before pairing not found on paired device"
+        messages = bob_second_device.wakuext_service.chat_messages(sender_chat_id, limit=10)["messages"]
+        assert messages is not None, "No messages found on paired device"
+        message_found = False
+        for message in messages:
+            if message["id"] == message_id and message["text"] == "test_message":
+                message_found = True
+                break
+        assert message_found, "Message sent before pairing not found on paired device"
 
     def test_pairing_server_as_receiver(self):
         # Create users
@@ -244,7 +241,12 @@ class TestLocalPairing(MessengerSteps):
         # Create community before local pairing
         self.create_community(bob)
 
-        # Local pairing
+        # Send a message to Alice before local pairing
+        response = bob.wakuext_service.send_one_to_one_message(alice.public_key, "test_message")
+        message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
+        _, sender_chat_id = message["id"], message["chatId"]
+
+        # Local pairing WITHOUT message syncing
         pair_server_as_receiver(bob, bob_second_device)
 
         # Check sender signals
@@ -265,6 +267,10 @@ class TestLocalPairing(MessengerSteps):
         assert alice_response is False
         bob_response = bob.accounts_service.has_paired_devices()
         assert bob_response is True
+
+        # Check that the messages are synced
+        messages = bob_second_device.wakuext_service.chat_messages(sender_chat_id, limit=10)["messages"]
+        assert messages is None, "Messages found on paired device wrongly"
 
     def test_pairing_three_devices(self):
         # Create users


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/18894

Based on top of https://github.com/status-im/status-go/pull/6948
I will merge this one into the base once it's reviewed. It will enable the the tests to run and the coverage to go up on the base.

Adds a param for users to enable message syncing during local pairing.

Updates the test to use that param

Based on top of https://github.com/status-im/status-go/pull/6948
I will merge this one into the base once it's reviewed. It will enable the the tests to run and the coverage to go up on the base.
