### PR TITLE
feat: introduce transferdetector package

### DIFF
--- a/services/wallet/transferdetector/README.md
+++ b/services/wallet/transferdetector/README.md
@@ -1,0 +1,125 @@
+# Transfer Detector
+
+A service for detecting and monitoring cryptocurrency transfers across multiple token standards (ERC-20, ERC-721, ERC-1155) on various blockchain networks.
+
+## Overview
+
+This package provides a unified interface for:
+- **Transfer Detection**: Efficiently detect transfers using event filtering
+- **Multi-Standard Support**: ERC-20, ERC-721, and ERC-1155 token transfers
+- **Multi-Chain Support**: Works across different blockchain networks
+- **Block Range Management**: Tracks last fetched blocks to avoid duplicates
+- **Event-Driven**: Publishes events for transfer detection operations
+
+## Key Components
+
+### Controller
+The main orchestrator that manages transfer detection operations:
+- Monitors account and network changes
+- Debounces fetch requests (10s debounce, 10min fetch period)
+- Coordinates between fetcher and providers
+- Manages block number tracking to prevent duplicate detection
+
+### Fetcher
+Handles the actual transfer filtering using event logs:
+- Uses `eventfilter.FilterTransfers` for efficient event detection
+- Supports all transfer types (ERC-20, ERC-721, ERC-1155)
+- Works with any Ethereum-compatible chain
+- Returns structured event log data
+
+```go
+// Create a fetcher
+fetcher := transferdetector.NewFetcher(ethClientGetter)
+```
+
+### Providers
+Required interfaces for integration:
+- **AccountsProvider**: Provides wallet addresses to monitor
+- **NetworksProvider**: Provides active blockchain networks
+- **LastBlockProvider**: Provides latest block numbers for each chain
+- **FilterProvider**: Handles the actual transfer filtering
+
+## Usage
+
+```go
+// Create a new controller with default configuration
+controller := transferdetector.NewController(
+    transferdetector.DefaultControllerConfig(),
+    fetcher,
+    accountsProvider,
+    accountsPublisher,
+    networksProvider,
+    lastBlockProvider,
+    logger,
+)
+
+// Or with custom configuration
+config := transferdetector.ControllerConfig{
+    FetchDebounceTime: 5 * time.Second,
+    FetchPeriod:       5 * time.Minute,
+}
+controller := transferdetector.NewController(
+    config,
+    fetcher,
+    accountsProvider,
+    accountsPublisher,
+    networksProvider,
+    lastBlockProvider,
+    logger,
+)
+
+// Start the controller
+controller.Start()
+
+// Trigger transfer detection
+controller.TriggerFetch()
+
+// Listen for events
+publisher := controller.GetPublisher()
+// Subscribe to transfer detection events...
+```
+
+## Events
+
+- `EventTransferDetectionStarted`: Transfer detection initiated
+- `EventTransferDetectionFinished`: Successful detection completion with found events
+- `EventTransferDetectionError`: Detection errors
+
+Each event contains:
+- **ChainID**: The blockchain network ID
+- **Accounts**: List of monitored wallet addresses
+- **FromBlock/ToBlock**: Block range that was scanned
+- **Events**: (Finished only) Array of detected transfer events
+- **Error**: (Error only) Error details
+
+## Configuration
+
+### Controller Configuration
+- **FetchDebounceTime**: 10 seconds (default) - debounce time for detection requests
+- **FetchPeriod**: 10 minutes (default) - minimum time between detections
+
+The controller automatically tracks the last fetched block number for each chain to ensure no transfers are missed and no duplicates are detected.
+
+## Transfer Types
+
+The detector supports all major token standards:
+- **ERC-20**: Fungible token transfers
+- **ERC-721**: NFT transfers (single token)
+- **ERC-1155**: Multi-token transfers (batch operations)
+
+## Event Data Structure
+
+Detected transfers include:
+- **ContractKey**: The contract address where the transfer occurred
+- **EventKey**: The event name (e.g., "Transfer")
+- **Unpacked**: Structured data containing transfer details (from, to, value, tokenId, etc.)
+
+## Integration
+
+The transfer detector integrates with:
+- **Account Management**: Monitors specified wallet addresses
+- **Network Management**: Works across multiple blockchain networks
+- **Block Tracking**: Maintains state of last scanned blocks
+- **Event Publishing**: Notifies other services of detected transfers
+
+This makes it ideal for building comprehensive wallet applications that need to track all user activity across multiple chains and token standards.

--- a/services/wallet/transferdetector/controller.go
+++ b/services/wallet/transferdetector/controller.go
@@ -1,0 +1,333 @@
+package transferdetector
+
+//go:generate go tool mockgen -package=mock_transferdetector -source=controller.go -destination=mock/controller.go
+
+import (
+	"context"
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/bep/debounce"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/status-im/go-wallet-sdk/pkg/eventfilter"
+	"github.com/status-im/go-wallet-sdk/pkg/eventlog"
+
+	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/crypto/types"
+	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/pkg/pubsub"
+	"github.com/status-im/status-go/rpc/network"
+	"github.com/status-im/status-go/services/accounts/accountsevent"
+
+	"go.uber.org/zap"
+)
+
+type AccountsProvider interface {
+	GetWalletAddresses() ([]types.Address, error)
+}
+
+type NetworksProvider interface {
+	GetActiveNetworks() ([]*params.Network, error)
+	GetPublisher() *pubsub.Publisher
+}
+
+type LastBlockProvider interface {
+	GetEstimatedLatestBlockNumber(ctx context.Context, chainID uint64) (uint64, error)
+}
+
+type FilterProvider interface {
+	FilterTransfers(ctx context.Context, chainID uint64, config eventfilter.TransferQueryConfig) ([]eventlog.Event, error)
+}
+
+type ControllerConfig struct {
+	FetchDebounceTime time.Duration
+	FetchPeriod       time.Duration
+}
+
+func DefaultControllerConfig() ControllerConfig {
+	return ControllerConfig{
+		FetchDebounceTime: 10 * time.Second,
+		FetchPeriod:       10 * time.Minute,
+	}
+}
+
+type Controller struct {
+	config  ControllerConfig
+	fetcher FilterProvider
+
+	mu                     sync.RWMutex
+	lastFetchedBlockNumber map[uint64]uint64 // map[chainID]blockNumber
+
+	accountsProvider  AccountsProvider
+	accountsPublisher *pubsub.Publisher
+	networksProvider  NetworksProvider
+	lastBlockProvider LastBlockProvider
+
+	publisher *pubsub.Publisher
+
+	stopCh          chan struct{}
+	triggerFetchCh  chan struct{}
+	fetchDebounceFn func(f func())
+
+	logger *zap.Logger
+}
+
+func NewController(
+	config ControllerConfig,
+	fetcher FilterProvider,
+	accountsProvider AccountsProvider,
+	accountsPublisher *pubsub.Publisher,
+	networksProvider NetworksProvider,
+	lastBlockProvider LastBlockProvider,
+	logger *zap.Logger,
+) *Controller {
+	return &Controller{
+		config:                 config,
+		fetcher:                fetcher,
+		accountsProvider:       accountsProvider,
+		accountsPublisher:      accountsPublisher,
+		networksProvider:       networksProvider,
+		lastBlockProvider:      lastBlockProvider,
+		publisher:              pubsub.NewPublisher(),
+		fetchDebounceFn:        debounce.New(config.FetchDebounceTime),
+		triggerFetchCh:         make(chan struct{}),
+		logger:                 logger,
+		lastFetchedBlockNumber: make(map[uint64]uint64),
+	}
+}
+
+func (c *Controller) Start() {
+	if c.stopCh != nil {
+		return
+	}
+	c.stopCh = make(chan struct{})
+
+	c.startAccountsWatcher()
+	c.startNetworksWatcher()
+	c.startFetcher()
+}
+
+func (c *Controller) Stop() {
+	if c.stopCh != nil {
+		close(c.stopCh)
+		c.stopCh = nil
+	}
+}
+
+func (c *Controller) GetPublisher() *pubsub.Publisher {
+	return c.publisher
+}
+
+func (c *Controller) startAccountsWatcher() {
+	if c.accountsPublisher == nil {
+		return
+	}
+
+	removedCh, removedUnsubFn := pubsub.Subscribe[accountsevent.AccountsRemovedEvent](c.accountsPublisher, 10)
+	addedCh, addedUnsubFn := pubsub.Subscribe[accountsevent.AccountsAddedEvent](c.accountsPublisher, 10)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer removedUnsubFn()
+		defer addedUnsubFn()
+		for {
+			select {
+			case <-c.stopCh:
+				return
+			case _, ok := <-removedCh:
+				if !ok {
+					return
+				}
+				c.run()
+			case _, ok := <-addedCh:
+				if !ok {
+					return
+				}
+				c.run()
+			}
+		}
+	}()
+}
+
+func (c *Controller) startNetworksWatcher() {
+	if c.networksProvider == nil {
+		return
+	}
+
+	ch, unsubFn := pubsub.Subscribe[network.EventActiveNetworksChanged](c.networksProvider.GetPublisher(), 10)
+
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer unsubFn()
+		for {
+			select {
+			case <-c.stopCh:
+				return
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				c.run()
+			}
+		}
+	}()
+}
+
+func (c *Controller) startFetcher() {
+	ticker := time.NewTicker(c.config.FetchPeriod)
+	go func() {
+		defer gocommon.LogOnPanic()
+		defer ticker.Stop()
+		for {
+			select {
+			case <-c.stopCh:
+				return
+			case <-ticker.C:
+				c.run()
+			case <-c.triggerFetchCh:
+				ticker.Reset(c.config.FetchPeriod)
+				c.run()
+			}
+		}
+	}()
+	// Trigger initial fetch
+	c.run()
+}
+
+func (c *Controller) TriggerFetch() {
+	select {
+	case c.triggerFetchCh <- struct{}{}:
+	default:
+	}
+}
+
+func (c *Controller) run() {
+	c.fetchDebounceFn(func() {
+		go func() {
+			defer gocommon.LogOnPanic()
+			c.runNow()
+		}()
+	})
+}
+
+func (c *Controller) getAllAccounts() ([]common.Address, error) {
+	accounts, err := c.accountsProvider.GetWalletAddresses()
+	if err != nil {
+		return nil, err
+	}
+	gethAccounts := make([]common.Address, len(accounts))
+	for i, account := range accounts {
+		gethAccounts[i] = common.BytesToAddress(account.Bytes())
+	}
+	return gethAccounts, nil
+}
+
+func (c *Controller) getAllNetworks() ([]uint64, error) {
+	networks, err := c.networksProvider.GetActiveNetworks()
+	if err != nil {
+		return nil, err
+	}
+	chains := make([]uint64, len(networks))
+	for i, network := range networks {
+		chains[i] = network.ChainID
+	}
+	return chains, nil
+}
+
+func (c *Controller) runNow() {
+	accounts, err := c.getAllAccounts()
+	if err != nil {
+		c.logger.Error("failed to get all accounts", zap.Error(err))
+		return
+	}
+	networks, err := c.getAllNetworks()
+	if err != nil {
+		c.logger.Error("failed to get all networks", zap.Error(err))
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wg := sync.WaitGroup{}
+	for _, network := range networks {
+		wg.Add(1)
+		go func(chainID uint64) {
+			defer gocommon.LogOnPanic()
+			defer wg.Done()
+
+			c.fetchTransfers(ctx, chainID, accounts)
+		}(network)
+	}
+
+	go func() {
+		defer gocommon.LogOnPanic()
+		select {
+		case <-c.stopCh:
+			cancel()
+			return
+		case <-ctx.Done():
+			return
+		}
+	}()
+	wg.Wait()
+}
+
+func (c *Controller) fetchTransfers(ctx context.Context, chainID uint64, accounts []common.Address) {
+	latestBlockNumber, err := c.lastBlockProvider.GetEstimatedLatestBlockNumber(ctx, chainID)
+	if err != nil {
+		c.logger.Error("failed to get estimated latest block number", zap.Uint64("chainID", chainID), zap.Error(err))
+		return
+	}
+
+	lastFetchedBlockNumber := c.getLastFetchedBlockNumber(chainID)
+	if lastFetchedBlockNumber == 0 {
+		c.logger.Debug("setting initial block for the chain", zap.Uint64("chainID", chainID), zap.Uint64("latestBlockNumber", latestBlockNumber))
+		c.updateLastFetchedBlockNumber(chainID, latestBlockNumber)
+		return
+	}
+
+	if lastFetchedBlockNumber >= latestBlockNumber {
+		c.logger.Debug("latest block number is already fetched", zap.Uint64("chainID", chainID), zap.Uint64("latestBlockNumber", latestBlockNumber), zap.Uint64("lastFetchedBlockNumber", lastFetchedBlockNumber))
+		return
+	}
+
+	fromBlock := lastFetchedBlockNumber + 1
+	toBlock := latestBlockNumber
+
+	c.sendEventTransferDetectionStarted(chainID, accounts, fromBlock, toBlock)
+	events, err := c.fetcher.FilterTransfers(ctx, chainID, eventfilter.TransferQueryConfig{
+		FromBlock: big.NewInt(int64(fromBlock)),
+		ToBlock:   big.NewInt(int64(toBlock)),
+		Accounts:  accounts,
+		TransferTypes: []eventfilter.TransferType{
+			eventfilter.TransferTypeERC20,
+			eventfilter.TransferTypeERC721,
+			eventfilter.TransferTypeERC1155,
+		},
+		Direction: eventfilter.Both,
+	})
+	if err != nil {
+		c.logger.Error("failed to filter transfers", zap.Uint64("chainID", chainID), zap.Error(err))
+		c.sendEventTransferDetectionError(chainID, accounts, fromBlock, toBlock, err)
+		return
+	}
+
+	c.logger.Debug("filtered transfers", zap.Uint64("chainID", chainID), zap.Int64("fromBlock", int64(fromBlock)), zap.Int64("toBlock", int64(toBlock)), zap.Int("events", len(events)))
+	c.sendEventTransferDetectionFinished(chainID, accounts, fromBlock, toBlock, events)
+	c.updateLastFetchedBlockNumber(chainID, toBlock)
+}
+
+func (c *Controller) getLastFetchedBlockNumber(chainID uint64) uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.lastFetchedBlockNumber[chainID]
+}
+
+func (c *Controller) updateLastFetchedBlockNumber(chainID uint64, blockNumber uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lastFetchedBlockNumber[chainID] = blockNumber
+}

--- a/services/wallet/transferdetector/controller_events.go
+++ b/services/wallet/transferdetector/controller_events.go
@@ -1,0 +1,38 @@
+package transferdetector
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/status-im/go-wallet-sdk/pkg/eventlog"
+
+	"github.com/status-im/status-go/pkg/pubsub"
+)
+
+func (c *Controller) sendEventTransferDetectionStarted(chainID uint64, accounts []common.Address, fromBlock uint64, toBlock uint64) {
+	pubsub.Publish(c.publisher, EventTransferDetectionStarted{
+		ChainID:   chainID,
+		Accounts:  accounts,
+		FromBlock: fromBlock,
+		ToBlock:   toBlock,
+	})
+}
+
+func (c *Controller) sendEventTransferDetectionFinished(chainID uint64, accounts []common.Address, fromBlock uint64, toBlock uint64, events []eventlog.Event) {
+	pubsub.Publish(c.publisher, EventTransferDetectionFinished{
+		ChainID:   chainID,
+		Accounts:  accounts,
+		FromBlock: fromBlock,
+		ToBlock:   toBlock,
+		Events:    events,
+	})
+}
+
+func (c *Controller) sendEventTransferDetectionError(chainID uint64, accounts []common.Address, fromBlock uint64, toBlock uint64, err error) {
+	pubsub.Publish(c.publisher, EventTransferDetectionError{
+		ChainID:   chainID,
+		Accounts:  accounts,
+		FromBlock: fromBlock,
+		ToBlock:   toBlock,
+		Error:     err,
+	})
+}

--- a/services/wallet/transferdetector/events.go
+++ b/services/wallet/transferdetector/events.go
@@ -1,0 +1,30 @@
+package transferdetector
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/status-im/go-wallet-sdk/pkg/eventlog"
+)
+
+type EventTransferDetectionStarted struct {
+	ChainID   uint64
+	Accounts  []common.Address
+	FromBlock uint64
+	ToBlock   uint64
+}
+
+type EventTransferDetectionFinished struct {
+	ChainID   uint64
+	Accounts  []common.Address
+	FromBlock uint64
+	ToBlock   uint64
+	Events    []eventlog.Event
+}
+
+type EventTransferDetectionError struct {
+	ChainID   uint64
+	Accounts  []common.Address
+	FromBlock uint64
+	ToBlock   uint64
+	Error     error
+}

--- a/services/wallet/transferdetector/fetcher.go
+++ b/services/wallet/transferdetector/fetcher.go
@@ -1,0 +1,35 @@
+package transferdetector
+
+//go:generate go tool mockgen -package=mock_transferdetector -source=fetcher.go -destination=mock/fetcher.go
+
+import (
+	"context"
+
+	"github.com/status-im/go-wallet-sdk/pkg/eventfilter"
+	"github.com/status-im/go-wallet-sdk/pkg/eventlog"
+
+	"github.com/status-im/status-go/rpc/chain"
+)
+
+type EthClientGetter interface {
+	EthClient(chainID uint64) (chain.ClientInterface, error)
+}
+
+type Fetcher struct {
+	ethClientGetter EthClientGetter
+}
+
+func NewFetcher(ethClientGetter EthClientGetter) *Fetcher {
+	return &Fetcher{
+		ethClientGetter: ethClientGetter,
+	}
+}
+
+func (f *Fetcher) FilterTransfers(ctx context.Context, chainID uint64, config eventfilter.TransferQueryConfig) ([]eventlog.Event, error) {
+	ethClient, err := f.ethClientGetter.EthClient(chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	return eventfilter.FilterTransfers(ctx, ethClient, config)
+}

--- a/services/wallet/transferdetector/test/controller_test.go
+++ b/services/wallet/transferdetector/test/controller_test.go
@@ -1,0 +1,602 @@
+package transferdetector_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/status-im/go-wallet-sdk/pkg/eventfilter"
+	"github.com/status-im/go-wallet-sdk/pkg/eventlog"
+
+	"github.com/status-im/status-go/crypto/types"
+	"github.com/status-im/status-go/params"
+	"github.com/status-im/status-go/pkg/pubsub"
+	"github.com/status-im/status-go/services/wallet/transferdetector"
+	mock_transferdetector "github.com/status-im/status-go/services/wallet/transferdetector/mock"
+
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/atomic"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+)
+
+func TestController_DebounceTiming(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fetcher := mock_transferdetector.NewMockFilterProvider(ctrl)
+	accountsProvider := mock_transferdetector.NewMockAccountsProvider(ctrl)
+	accountsPublisher := pubsub.NewPublisher()
+	networksProvider := mock_transferdetector.NewMockNetworksProvider(ctrl)
+	lastBlockProvider := mock_transferdetector.NewMockLastBlockProvider(ctrl)
+	logger := zap.NewNop()
+
+	// Mock accounts and networks
+	address1 := types.Address{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}
+	network1 := &params.Network{ChainID: 1}
+
+	accountsProvider.EXPECT().GetWalletAddresses().Return([]types.Address{address1}, nil).AnyTimes()
+	networksProvider.EXPECT().GetActiveNetworks().Return([]*params.Network{network1}, nil).AnyTimes()
+	networksProvider.EXPECT().GetPublisher().Return(pubsub.NewPublisher()).AnyTimes()
+	lastReturnedBlockNumber := atomic.NewUint64(100)
+	lastBlockProvider.EXPECT().GetEstimatedLatestBlockNumber(gomock.Any(), uint64(1)).DoAndReturn(func(ctx context.Context, chainID uint64) (uint64, error) {
+		lastReturnedBlockNumber.Add(100)
+		return lastReturnedBlockNumber.Load(), nil
+	}).AnyTimes()
+
+	// Track fetch calls
+	var fetchCalls int
+	var fetchMutex sync.Mutex
+	fetcher.EXPECT().FilterTransfers(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, chainID uint64, config eventfilter.TransferQueryConfig) ([]eventlog.Event, error) {
+		fetchMutex.Lock()
+		fetchCalls++
+		fetchMutex.Unlock()
+		return []eventlog.Event{}, nil
+	}).AnyTimes()
+
+	getFetchCalls := func() int {
+		fetchMutex.Lock()
+		defer fetchMutex.Unlock()
+		return fetchCalls
+	}
+
+	resetFetchCalls := func() {
+		fetchMutex.Lock()
+		fetchCalls = 0
+		fetchMutex.Unlock()
+	}
+
+	// Create controller with short debounce time for testing
+	config := transferdetector.ControllerConfig{
+		FetchDebounceTime: 100 * time.Millisecond,
+		FetchPeriod:       1 * time.Hour, // Long period to avoid interference
+	}
+
+	controller := transferdetector.NewController(
+		config,
+		fetcher,
+		accountsProvider,
+		accountsPublisher,
+		networksProvider,
+		lastBlockProvider,
+		logger,
+	)
+
+	resetFetchCalls()
+
+	controller.Start()
+	defer controller.Stop()
+
+	// After calling Start, the initial block should be set but no actual fetch should occur
+	// since lastFetchedBlockNumber starts at 0
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 0, getFetchCalls(), "Expected no fetch calls after Start (initial block setting only)")
+	resetFetchCalls()
+
+	// Test debounce behavior - multiple rapid calls should only result in one fetch
+	// The block difference is already set up above (100 -> 150)
+
+	controller.TriggerFetch()
+	controller.TriggerFetch()
+	controller.TriggerFetch()
+
+	// Wait for debounce time (100ms)
+	time.Sleep(200 * time.Millisecond)
+	require.Equal(t, 1, getFetchCalls(), "Expected 1 fetch call after multiple consecutive TriggerFetch calls")
+	resetFetchCalls()
+
+	// Test that another call after debounce time works
+	controller.TriggerFetch()
+	// Wait for debounce time
+	time.Sleep(200 * time.Millisecond)
+	require.Equal(t, 1, getFetchCalls(), "Expected 1 fetch call after TriggerFetch")
+	resetFetchCalls()
+}
+
+func TestController_FetchPeriod(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fetcher := mock_transferdetector.NewMockFilterProvider(ctrl)
+	accountsProvider := mock_transferdetector.NewMockAccountsProvider(ctrl)
+	accountsPublisher := pubsub.NewPublisher()
+	networksProvider := mock_transferdetector.NewMockNetworksProvider(ctrl)
+	lastBlockProvider := mock_transferdetector.NewMockLastBlockProvider(ctrl)
+	logger := zap.NewNop()
+
+	// Mock accounts and networks
+	address1 := types.Address{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}
+	network1 := &params.Network{ChainID: 1}
+
+	accountsProvider.EXPECT().GetWalletAddresses().Return([]types.Address{address1}, nil).AnyTimes()
+	networksProvider.EXPECT().GetActiveNetworks().Return([]*params.Network{network1}, nil).AnyTimes()
+	networksProvider.EXPECT().GetPublisher().Return(pubsub.NewPublisher()).AnyTimes()
+	lastReturnedBlockNumber := atomic.NewUint64(100)
+	lastBlockProvider.EXPECT().GetEstimatedLatestBlockNumber(gomock.Any(), uint64(1)).DoAndReturn(func(ctx context.Context, chainID uint64) (uint64, error) {
+		lastReturnedBlockNumber.Add(100)
+		return lastReturnedBlockNumber.Load(), nil
+	}).AnyTimes()
+
+	// Track fetch calls
+	var fetchCalls int
+	var fetchMutex sync.Mutex
+	fetcher.EXPECT().FilterTransfers(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, chainID uint64, config eventfilter.TransferQueryConfig) ([]eventlog.Event, error) {
+		fetchMutex.Lock()
+		fetchCalls++
+		fetchMutex.Unlock()
+		return []eventlog.Event{}, nil
+	}).AnyTimes()
+
+	getFetchCalls := func() int {
+		fetchMutex.Lock()
+		defer fetchMutex.Unlock()
+		return fetchCalls
+	}
+
+	resetFetchCalls := func() {
+		fetchMutex.Lock()
+		fetchCalls = 0
+		fetchMutex.Unlock()
+	}
+
+	// Create controller with short times for testing
+	config := transferdetector.ControllerConfig{
+		FetchDebounceTime: 0 * time.Millisecond,   // No debounce for this test
+		FetchPeriod:       500 * time.Millisecond, // Short period for testing
+	}
+
+	controller := transferdetector.NewController(
+		config,
+		fetcher,
+		accountsProvider,
+		accountsPublisher,
+		networksProvider,
+		lastBlockProvider,
+		logger,
+	)
+
+	resetFetchCalls()
+
+	controller.Start()
+	defer controller.Stop()
+
+	// After calling Start, the initial block should be set but no actual fetch should occur
+	// since lastFetchedBlockNumber starts at 0
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 0, getFetchCalls(), "Expected no fetch calls after Start (initial block setting only)")
+	resetFetchCalls()
+
+	// Set up a block difference to trigger fetching
+	lastBlockProvider.EXPECT().GetEstimatedLatestBlockNumber(gomock.Any(), uint64(1)).Return(uint64(150), nil).AnyTimes()
+
+	// Wait for period time (500ms)
+	time.Sleep(600 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return getFetchCalls() == 1
+	}, 200*time.Millisecond, 50*time.Millisecond, "Expected 1 fetch call after fetch period")
+	resetFetchCalls()
+
+	// Trigger fetch manually
+	controller.TriggerFetch()
+	require.Eventually(t, func() bool {
+		return getFetchCalls() == 1
+	}, 200*time.Millisecond, 50*time.Millisecond, "Expected 1 fetch call after TriggerFetch")
+	resetFetchCalls()
+
+	// Periodic ticker should've been reset, so no extra calls until the next period
+	time.Sleep(600 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return getFetchCalls() == 1
+	}, 200*time.Millisecond, 50*time.Millisecond, "Expected 1 fetch call after next period")
+	resetFetchCalls()
+}
+
+func TestController_TransferDetection(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fetcher := mock_transferdetector.NewMockFilterProvider(ctrl)
+	accountsProvider := mock_transferdetector.NewMockAccountsProvider(ctrl)
+	accountsPublisher := pubsub.NewPublisher()
+	networksProvider := mock_transferdetector.NewMockNetworksProvider(ctrl)
+	lastBlockProvider := mock_transferdetector.NewMockLastBlockProvider(ctrl)
+	logger := zap.NewNop()
+
+	// Mock accounts and networks
+	address1 := types.Address{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}
+	address2 := types.Address{0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22}
+	network1 := &params.Network{ChainID: 1}
+	network2 := &params.Network{ChainID: 2}
+
+	accountsProvider.EXPECT().GetWalletAddresses().Return([]types.Address{address1, address2}, nil).AnyTimes()
+	networksProvider.EXPECT().GetActiveNetworks().Return([]*params.Network{network1, network2}, nil).AnyTimes()
+	networksProvider.EXPECT().GetPublisher().Return(pubsub.NewPublisher()).AnyTimes()
+	lastReturnedBlockNumber1 := atomic.NewUint64(100)
+	lastReturnedBlockNumber2 := atomic.NewUint64(200)
+
+	lastBlockProvider.EXPECT().GetEstimatedLatestBlockNumber(gomock.Any(), uint64(1)).DoAndReturn(func(ctx context.Context, chainID uint64) (uint64, error) {
+		lastReturnedBlockNumber1.Add(100)
+		return lastReturnedBlockNumber1.Load(), nil
+	}).AnyTimes()
+	lastBlockProvider.EXPECT().GetEstimatedLatestBlockNumber(gomock.Any(), uint64(2)).DoAndReturn(func(ctx context.Context, chainID uint64) (uint64, error) {
+		lastReturnedBlockNumber2.Add(100)
+		return lastReturnedBlockNumber2.Load(), nil
+	}).AnyTimes()
+
+	// Mock transfer events
+	mockEvents := []eventlog.Event{
+		{
+			ContractKey: "0x1234567890123456789012345678901234567890",
+			EventKey:    "Transfer",
+			Unpacked: map[string]interface{}{
+				"from":  common.BytesToAddress(address1.Bytes()),
+				"to":    common.BytesToAddress(address2.Bytes()),
+				"value": "1000000000000000000", // 1 ETH
+			},
+		},
+	}
+
+	// Track fetch calls and verify config
+	var fetchCalls []struct {
+		ChainID uint64
+		Config  eventfilter.TransferQueryConfig
+	}
+	var fetchMutex sync.Mutex
+	fetcher.EXPECT().FilterTransfers(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, chainID uint64, config eventfilter.TransferQueryConfig) ([]eventlog.Event, error) {
+		fetchMutex.Lock()
+		fetchCalls = append(fetchCalls, struct {
+			ChainID uint64
+			Config  eventfilter.TransferQueryConfig
+		}{ChainID: chainID, Config: config})
+		fetchMutex.Unlock()
+		return mockEvents, nil
+	}).AnyTimes()
+
+	getFetchCalls := func() []struct {
+		ChainID uint64
+		Config  eventfilter.TransferQueryConfig
+	} {
+		fetchMutex.Lock()
+		defer fetchMutex.Unlock()
+		result := make([]struct {
+			ChainID uint64
+			Config  eventfilter.TransferQueryConfig
+		}, len(fetchCalls))
+		copy(result, fetchCalls)
+		return result
+	}
+
+	resetFetchCalls := func() {
+		fetchMutex.Lock()
+		fetchCalls = nil
+		fetchMutex.Unlock()
+	}
+
+	// Create controller with short debounce time for testing
+	config := transferdetector.ControllerConfig{
+		FetchDebounceTime: 100 * time.Millisecond,
+		FetchPeriod:       1 * time.Hour, // Long period to avoid interference
+	}
+
+	controller := transferdetector.NewController(
+		config,
+		fetcher,
+		accountsProvider,
+		accountsPublisher,
+		networksProvider,
+		lastBlockProvider,
+		logger,
+	)
+
+	startedCh, startedUnsubFn := pubsub.Subscribe[transferdetector.EventTransferDetectionStarted](controller.GetPublisher(), 10)
+	defer startedUnsubFn()
+
+	finishedCh, finishedUnsubFn := pubsub.Subscribe[transferdetector.EventTransferDetectionFinished](controller.GetPublisher(), 10)
+	defer finishedUnsubFn()
+
+	errorCh, errorUnsubFn := pubsub.Subscribe[transferdetector.EventTransferDetectionError](controller.GetPublisher(), 10)
+	defer errorUnsubFn()
+
+	resetFetchCalls()
+
+	controller.Start()
+	defer controller.Stop()
+
+	// After calling Start, the initial blocks should be set but no actual fetch should occur
+	// since lastFetchedBlockNumber starts at 0
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 0, len(getFetchCalls()), "Expected no fetch calls after Start (initial block setting only)")
+
+	// Now trigger a fetch to test the actual functionality
+	controller.TriggerFetch()
+
+	// Wait for the fetch to complete
+	require.Eventually(t, func() bool {
+		calls := getFetchCalls()
+		return len(calls) == 2 // Should fetch both chains
+	}, 2*time.Second, 50*time.Millisecond, "Expected 2 fetch calls after TriggerFetch")
+
+	// Verify that both chains were fetched
+	actualCalls := getFetchCalls()
+	require.Len(t, actualCalls, 2, "Expected 2 fetch calls to be made")
+
+	// Verify the configs contain the expected accounts
+	chain1Call := actualCalls[0]
+	chain2Call := actualCalls[1]
+
+	// One of the calls should be for chain 1, the other for chain 2
+	chainIDs := []uint64{chain1Call.ChainID, chain2Call.ChainID}
+	require.Contains(t, chainIDs, uint64(1), "Expected chain 1 to be fetched")
+	require.Contains(t, chainIDs, uint64(2), "Expected chain 2 to be fetched")
+
+	// Verify that both accounts are included in the config
+	for _, call := range actualCalls {
+		require.Len(t, call.Config.Accounts, 2, "Expected 2 accounts in config")
+		require.Contains(t, call.Config.Accounts, common.BytesToAddress(address1.Bytes()), "Expected address1 in config")
+		require.Contains(t, call.Config.Accounts, common.BytesToAddress(address2.Bytes()), "Expected address2 in config")
+
+		// Verify transfer types
+		expectedTypes := []eventfilter.TransferType{
+			eventfilter.TransferTypeERC20,
+			eventfilter.TransferTypeERC721,
+			eventfilter.TransferTypeERC1155,
+		}
+		require.Equal(t, expectedTypes, call.Config.TransferTypes, "Expected correct transfer types")
+		require.Equal(t, eventfilter.Both, call.Config.Direction, "Expected Both direction")
+	}
+
+	// Verify events are published with correct values
+	// Collect events
+	var startedEvents []transferdetector.EventTransferDetectionStarted
+	var finishedEvents []transferdetector.EventTransferDetectionFinished
+	var errorEvents []transferdetector.EventTransferDetectionError
+	var eventsMutex sync.Mutex
+
+	// Collect started events
+	go func() {
+		for ev := range startedCh {
+			eventsMutex.Lock()
+			startedEvents = append(startedEvents, ev)
+			eventsMutex.Unlock()
+		}
+	}()
+
+	// Collect finished events
+	go func() {
+		for ev := range finishedCh {
+			eventsMutex.Lock()
+			finishedEvents = append(finishedEvents, ev)
+			eventsMutex.Unlock()
+		}
+	}()
+
+	// Collect error events
+	go func() {
+		for ev := range errorCh {
+			eventsMutex.Lock()
+			errorEvents = append(errorEvents, ev)
+			eventsMutex.Unlock()
+		}
+	}()
+
+	// Wait for events to be collected
+	require.Eventually(t, func() bool {
+		eventsMutex.Lock()
+		defer eventsMutex.Unlock()
+		return len(startedEvents) >= 2 && len(finishedEvents) >= 2
+	}, 2*time.Second, 50*time.Millisecond, "Expected started and finished events")
+
+	// Verify started events
+	eventsMutex.Lock()
+	require.Len(t, startedEvents, 2, "Expected 2 started events (one per chain)")
+	require.Len(t, errorEvents, 0, "Expected no error events")
+
+	// Verify started events contain correct values
+	startedChainIDs := make(map[uint64]bool)
+	for _, ev := range startedEvents {
+		startedChainIDs[ev.ChainID] = true
+		require.Contains(t, []uint64{1, 2}, ev.ChainID, "Started event should be for chain 1 or 2")
+		require.Len(t, ev.Accounts, 2, "Started event should contain 2 accounts")
+		require.Contains(t, ev.Accounts, common.BytesToAddress(address1.Bytes()), "Started event should contain address1")
+		require.Contains(t, ev.Accounts, common.BytesToAddress(address2.Bytes()), "Started event should contain address2")
+		require.True(t, ev.FromBlock > 0, "FromBlock should be positive")
+		require.True(t, ev.ToBlock > ev.FromBlock, "ToBlock should be greater than FromBlock")
+	}
+	require.True(t, startedChainIDs[1], "Expected started event for chain 1")
+	require.True(t, startedChainIDs[2], "Expected started event for chain 2")
+
+	// Verify finished events contain correct values
+	require.Len(t, finishedEvents, 2, "Expected 2 finished events (one per chain)")
+	finishedChainIDs := make(map[uint64]bool)
+	for _, ev := range finishedEvents {
+		finishedChainIDs[ev.ChainID] = true
+		require.Contains(t, []uint64{1, 2}, ev.ChainID, "Finished event should be for chain 1 or 2")
+		require.Len(t, ev.Accounts, 2, "Finished event should contain 2 accounts")
+		require.Contains(t, ev.Accounts, common.BytesToAddress(address1.Bytes()), "Finished event should contain address1")
+		require.Contains(t, ev.Accounts, common.BytesToAddress(address2.Bytes()), "Finished event should contain address2")
+		require.True(t, ev.FromBlock > 0, "FromBlock should be positive")
+		require.True(t, ev.ToBlock > ev.FromBlock, "ToBlock should be greater than FromBlock")
+		require.Len(t, ev.Events, 1, "Finished event should contain 1 mock event")
+
+		// Verify the mock event content
+		if len(ev.Events) > 0 {
+			event := ev.Events[0]
+			require.Equal(t, eventlog.ContractKey("0x1234567890123456789012345678901234567890"), event.ContractKey, "Event should have correct contract key")
+			require.Equal(t, eventlog.EventKey("Transfer"), event.EventKey, "Event should have correct event key")
+			require.NotNil(t, event.Unpacked, "Event should have unpacked data")
+
+			// Verify unpacked data
+			unpacked, ok := event.Unpacked.(map[string]interface{})
+			require.True(t, ok, "Unpacked data should be a map")
+			require.Equal(t, common.BytesToAddress(address1.Bytes()), unpacked["from"], "Event 'from' should be address1")
+			require.Equal(t, common.BytesToAddress(address2.Bytes()), unpacked["to"], "Event 'to' should be address2")
+			require.Equal(t, "1000000000000000000", unpacked["value"], "Event 'value' should be 1 ETH")
+		}
+	}
+	require.True(t, finishedChainIDs[1], "Expected finished event for chain 1")
+	require.True(t, finishedChainIDs[2], "Expected finished event for chain 2")
+	eventsMutex.Unlock()
+}
+
+func TestController_BlockNumberTracking(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	fetcher := mock_transferdetector.NewMockFilterProvider(ctrl)
+	accountsProvider := mock_transferdetector.NewMockAccountsProvider(ctrl)
+	accountsPublisher := pubsub.NewPublisher()
+	networksProvider := mock_transferdetector.NewMockNetworksProvider(ctrl)
+	lastBlockProvider := mock_transferdetector.NewMockLastBlockProvider(ctrl)
+	logger := zap.NewNop()
+
+	// Mock accounts and networks
+	address1 := types.Address{0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}
+	network1 := &params.Network{ChainID: 1}
+
+	accountsProvider.EXPECT().GetWalletAddresses().Return([]types.Address{address1}, nil).AnyTimes()
+	networksProvider.EXPECT().GetActiveNetworks().Return([]*params.Network{network1}, nil).AnyTimes()
+	networksProvider.EXPECT().GetPublisher().Return(pubsub.NewPublisher()).AnyTimes()
+
+	// Track fetch calls and verify block ranges
+	var fetchCalls []struct {
+		ChainID   uint64
+		FromBlock uint64
+		ToBlock   uint64
+	}
+	var fetchMutex sync.Mutex
+	fetcher.EXPECT().FilterTransfers(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, chainID uint64, config eventfilter.TransferQueryConfig) ([]eventlog.Event, error) {
+		fetchMutex.Lock()
+		fetchCalls = append(fetchCalls, struct {
+			ChainID   uint64
+			FromBlock uint64
+			ToBlock   uint64
+		}{
+			ChainID:   chainID,
+			FromBlock: config.FromBlock.Uint64(),
+			ToBlock:   config.ToBlock.Uint64(),
+		})
+		fetchMutex.Unlock()
+		return []eventlog.Event{}, nil
+	}).AnyTimes()
+
+	getFetchCalls := func() []struct {
+		ChainID   uint64
+		FromBlock uint64
+		ToBlock   uint64
+	} {
+		fetchMutex.Lock()
+		defer fetchMutex.Unlock()
+		result := make([]struct {
+			ChainID   uint64
+			FromBlock uint64
+			ToBlock   uint64
+		}, len(fetchCalls))
+		copy(result, fetchCalls)
+		return result
+	}
+
+	resetFetchCalls := func() {
+		fetchMutex.Lock()
+		fetchCalls = nil
+		fetchMutex.Unlock()
+	}
+
+	// Create controller with short debounce time for testing
+	config := transferdetector.ControllerConfig{
+		FetchDebounceTime: 100 * time.Millisecond,
+		FetchPeriod:       1 * time.Hour, // Long period to avoid interference
+	}
+
+	controller := transferdetector.NewController(
+		config,
+		fetcher,
+		accountsProvider,
+		accountsPublisher,
+		networksProvider,
+		lastBlockProvider,
+		logger,
+	)
+
+	// Test initial fetch - should set initial block number
+	lastBlockProvider.EXPECT().GetEstimatedLatestBlockNumber(gomock.Any(), uint64(1)).Return(uint64(100), nil).Times(1)
+
+	resetFetchCalls()
+	controller.Start()
+	defer controller.Stop()
+
+	// Wait for initial setup (no actual fetch should occur since lastFetchedBlockNumber is 0)
+	time.Sleep(100 * time.Millisecond)
+	initialCalls := getFetchCalls()
+	require.Len(t, initialCalls, 0, "Expected no initial fetch call (just sets initial block)")
+
+	// Test subsequent fetch - should filter from last fetched block + 1
+	resetFetchCalls()
+	lastBlockProvider.EXPECT().GetEstimatedLatestBlockNumber(gomock.Any(), uint64(1)).Return(uint64(150), nil).Times(1)
+
+	controller.TriggerFetch()
+
+	// Wait for fetch
+	require.Eventually(t, func() bool {
+		calls := getFetchCalls()
+		return len(calls) == 1
+	}, 2*time.Second, 50*time.Millisecond, "Expected 1 fetch call after TriggerFetch")
+
+	// Verify the block range is correct
+	subsequentCalls := getFetchCalls()
+	require.Len(t, subsequentCalls, 1, "Expected 1 subsequent fetch call")
+
+	call := subsequentCalls[0]
+	require.Equal(t, uint64(1), call.ChainID, "Expected chain ID 1")
+	require.Equal(t, uint64(101), call.FromBlock, "Expected from block to be 101 (last fetched + 1)")
+	require.Equal(t, uint64(150), call.ToBlock, "Expected to block to be 150 (latest block)")
+
+	// Test that if latest block is same as last fetched, no filtering occurs
+	resetFetchCalls()
+	lastBlockProvider.EXPECT().GetEstimatedLatestBlockNumber(gomock.Any(), uint64(1)).Return(uint64(150), nil).Times(1)
+
+	controller.TriggerFetch()
+
+	// Wait a bit to ensure no fetch occurs
+	time.Sleep(200 * time.Millisecond)
+
+	// Should not have any new fetch calls since latest block equals last fetched
+	noNewCalls := getFetchCalls()
+	require.Len(t, noNewCalls, 0, "Expected no new fetch calls when latest block equals last fetched")
+
+	// Test that if latest block is less than last fetched, no filtering occurs
+	resetFetchCalls()
+	lastBlockProvider.EXPECT().GetEstimatedLatestBlockNumber(gomock.Any(), uint64(1)).Return(uint64(140), nil).Times(1)
+
+	controller.TriggerFetch()
+
+	// Wait a bit to ensure no fetch occurs
+	time.Sleep(200 * time.Millisecond)
+
+	// Should not have any new fetch calls since latest block is less than last fetched
+	noNewCalls2 := getFetchCalls()
+	require.Len(t, noNewCalls2, 0, "Expected no new fetch calls when latest block is less than last fetched")
+}

--- a/vendor/github.com/status-im/go-wallet-sdk/pkg/eventfilter/README.md
+++ b/vendor/github.com/status-im/go-wallet-sdk/pkg/eventfilter/README.md
@@ -1,0 +1,183 @@
+# EventFilter
+
+Efficient filtering for Ethereum transfer events across ERC20, ERC721, and ERC1155 tokens. Minimizes `eth_getLogs` API calls while capturing all relevant transfers involving specified addresses with concurrent processing capabilities.
+
+## Features
+
+- **Multi-Token Support**: ERC20, ERC721, and ERC1155 transfers
+- **Direction Filtering**: Send, receive, or both directions
+- **Concurrent Processing**: Parallel execution of multiple filter queries for improved performance
+- **Optimized Queries**: Uses FilterQuery OR operations to minimize API calls
+- **Address-Based Filtering**: Capture transfers involving any specified addresses
+- **Contract Filtering**: Optional filtering by specific contract addresses
+- **Clean API**: Simple switch-based implementation for easy maintenance
+
+## Usage
+
+### Basic Usage with FilterTransfers
+
+```go
+import (
+    "context"
+    "math/big"
+    "github.com/ethereum/go-ethereum/common"
+    "github.com/status-im/go-wallet-sdk/pkg/eventfilter"
+)
+
+// Create filter configuration
+config := eventfilter.TransferQueryConfig{
+    FromBlock:     big.NewInt(18000000),
+    ToBlock:       big.NewInt(18001000),
+    Accounts:      []common.Address{common.HexToAddress("0x1234...")},
+    TransferTypes: []eventfilter.TransferType{
+        eventfilter.TransferTypeERC20,
+        eventfilter.TransferTypeERC721,
+        eventfilter.TransferTypeERC1155,
+    },
+    Direction: eventfilter.Both, // Send, Receive, or Both
+}
+
+// Filter and parse events with concurrent processing
+events, err := eventfilter.FilterTransfers(ctx, client, config)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Process events...
+for _, event := range events {
+    // Access parsed event data via event.Unpacked
+}
+```
+
+### Manual Query Generation
+
+```go
+// Generate optimized filter queries manually
+queries := config.ToFilterQueries()
+
+// Execute queries manually
+for _, query := range queries {
+    logs, err := client.FilterLogs(ctx, query)
+    // Process logs...
+}
+```
+
+## Configuration Options
+
+### TransferQueryConfig
+
+```go
+type TransferQueryConfig struct {
+    FromBlock         *big.Int           // Start block number
+    ToBlock           *big.Int           // End block number  
+    ContractAddresses []common.Address   // Optional contract addresses to filter
+    Accounts          []common.Address   // Addresses to filter for
+    TransferTypes     []TransferType     // Token types to include
+    Direction         Direction          // Transfer direction filter
+}
+```
+
+### Direction
+- **`Send`**: Only transfers where specified addresses are the sender
+- **`Receive`**: Only transfers where specified addresses are the recipient  
+- **`Both`**: Transfers in both directions
+
+### Transfer Types
+- **`TransferTypeERC20`**: ERC20 token transfers
+- **`TransferTypeERC721`**: ERC721 NFT transfers
+- **`TransferTypeERC1155`**: ERC1155 multi-token transfers
+
+### Contract Filtering
+- **`ContractAddresses`**: Optional slice of contract addresses to filter by
+- If empty, searches all contracts
+- If specified, only events from these contracts are returned
+
+## Query Efficiency
+
+The package minimizes API calls through intelligent query merging:
+
+### Single Transfer Types
+- **ERC20/ERC721 only**: 1-2 queries (Send + Receive)
+- **ERC1155 only**: 1-2 queries (Send + Receive)
+
+### Mixed Transfer Types
+- **ERC20 + ERC721**: 1-2 queries (shared event signature)
+- **ERC20/ERC721 + ERC1155**: 2-3 queries (optimized with merging)
+- **All types**: 2-3 queries maximum
+
+### Optimization Techniques
+- **Event Signature Merging**: Multiple event types in single query using OR operations
+- **Topic Structure Optimization**: Merges compatible queries by omitting empty trailing topics
+- **Smart Grouping**: ERC20/ERC721 Receive + ERC1155 Send merged when Direction = Both
+
+## Query Structure Examples
+
+### Send Direction
+- **ERC20/ERC721**: `[eventSignature, address]` (2 topics)
+- **ERC1155**: `[eventSignature, {}, address]` (3 topics)
+
+### Receive Direction  
+- **ERC20/ERC721**: `[eventSignature, {}, address]` (3 topics)
+- **ERC1155**: `[eventSignature, {}, {}, address]` (4 topics)
+
+### Both Direction (Optimized)
+- **ERC20/ERC721 Send**: `[eventSignature, address]` (2 topics)
+- **Merged Receive**: `[eventSignature, {}, address]` (3 topics) - combines ERC20/ERC721 Receive + ERC1155 Send
+- **ERC1155 Receive**: `[eventSignature, {}, {}, address]` (4 topics)
+
+## Integration
+
+### With go-ethereum client
+
+```go
+import (
+    "github.com/ethereum/go-ethereum/ethclient"
+    "github.com/status-im/go-wallet-sdk/pkg/eventfilter"
+)
+
+// Create client
+client, _ := ethclient.Dial("https://mainnet.infura.io/v3/YOUR_KEY")
+
+// Use FilterTransfers for concurrent processing
+events, err := eventfilter.FilterTransfers(ctx, client, config)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Process events
+for _, event := range events {
+    // Access parsed event data via event.Unpacked
+}
+```
+
+### Manual query execution
+
+```go
+// Generate queries manually
+queries := config.ToFilterQueries()
+
+// Execute queries sequentially
+for _, query := range queries {
+    logs, err := client.FilterLogs(context.Background(), query)
+    // Process logs...
+}
+```
+
+## Event Signatures
+
+Uses standardized signatures from the `eventlog` package:
+- **ERC20/ERC721 Transfer**: `0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef`
+- **ERC1155 TransferSingle**: `0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62`
+- **ERC1155 TransferBatch**: `0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb`
+
+## Testing
+
+Comprehensive test suite ensures correct query generation:
+- Query count validation for all configurations
+- Topic structure verification
+- Merged query functionality testing
+
+Run tests with:
+```bash
+go test ./pkg/transfereventfilter
+```

--- a/vendor/github.com/status-im/go-wallet-sdk/pkg/eventfilter/filter.go
+++ b/vendor/github.com/status-im/go-wallet-sdk/pkg/eventfilter/filter.go
@@ -1,0 +1,62 @@
+package eventfilter
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/status-im/go-wallet-sdk/pkg/eventlog"
+)
+
+type FilterClient interface {
+	FilterLogs(context.Context, ethereum.FilterQuery) ([]types.Log, error)
+}
+
+func FilterTransfers(ctx context.Context, client FilterClient, config TransferQueryConfig) ([]eventlog.Event, error) {
+	queries := config.ToFilterQueries()
+
+	queryEventsCh := make(chan []eventlog.Event, len(queries))
+	queryErrorsCh := make(chan error, len(queries))
+
+	wg := sync.WaitGroup{}
+	for _, query := range queries {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			logs, err := client.FilterLogs(ctx, query)
+			if err != nil {
+				queryErrorsCh <- err
+				return
+			}
+			queryEvents := make([]eventlog.Event, 0)
+			for _, log := range logs {
+				event := eventlog.ParseLog(log)
+				queryEvents = append(queryEvents, event...)
+			}
+			queryEventsCh <- queryEvents
+		}()
+	}
+	wg.Wait()
+
+	close(queryEventsCh)
+	close(queryErrorsCh)
+
+	queryErrors := make([]error, 0, len(queries))
+	for queryError := range queryErrorsCh {
+		if queryError != nil {
+			queryErrors = append(queryErrors, queryError)
+		}
+	}
+	if len(queryErrors) > 0 {
+		return nil, errors.Join(queryErrors...)
+	}
+
+	events := make([]eventlog.Event, 0)
+	for queryEvents := range queryEventsCh {
+		events = append(events, queryEvents...)
+	}
+	return events, nil
+}

--- a/vendor/github.com/status-im/go-wallet-sdk/pkg/eventfilter/query.go
+++ b/vendor/github.com/status-im/go-wallet-sdk/pkg/eventfilter/query.go
@@ -1,0 +1,206 @@
+package eventfilter
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/status-im/go-wallet-sdk/pkg/eventlog"
+)
+
+type TransferType string
+
+const (
+	TransferTypeERC20   TransferType = "erc20"
+	TransferTypeERC721  TransferType = "erc721"
+	TransferTypeERC1155 TransferType = "erc1155"
+)
+
+type Direction string
+
+const (
+	Send    Direction = "send"
+	Receive Direction = "receive"
+	Both    Direction = "both"
+)
+
+type TransferQueryConfig struct {
+	FromBlock         *big.Int
+	ToBlock           *big.Int
+	ContractAddresses []common.Address
+	Accounts          []common.Address
+	TransferTypes     []TransferType
+	Direction         Direction
+}
+
+func (c *TransferQueryConfig) ToFilterQueries() []ethereum.FilterQuery {
+	// FilterQuery should match Transfer events of the given types, with
+	// any of the given addresses in the from/to fields
+
+	// Transfer types need to be specified
+	if len(c.TransferTypes) == 0 {
+		return nil
+	}
+
+	// If both are specified, FromBlock must not be greater than ToBlock
+	if c.FromBlock != nil && c.ToBlock != nil && c.FromBlock.Cmp(c.ToBlock) > 0 {
+		return nil
+	}
+
+	// Convert addresses to topic format (32-byte padded)
+	var addressTopics []common.Hash
+	for _, addr := range c.Accounts {
+		addressTopics = append(addressTopics, common.BytesToHash(addr.Bytes()))
+	}
+
+	// Create optimized queries based on transfer types and direction
+	var topicsList []topics
+	switch c.Direction {
+	case Send:
+		topicsList = buildSendTopicsList(addressTopics, c.TransferTypes)
+	case Receive:
+		topicsList = buildReceiveTopicsList(addressTopics, c.TransferTypes)
+	case Both:
+		topicsList = buildBothTopicsList(addressTopics, c.TransferTypes)
+	}
+
+	queries := make([]ethereum.FilterQuery, 0, len(topicsList))
+	for _, topics := range topicsList {
+		queries = append(queries, buildFilterQuery(c.FromBlock, c.ToBlock, c.ContractAddresses, topics))
+	}
+
+	return queries
+}
+
+func buildFilterQuery(fromBlock *big.Int, toBlock *big.Int, contractAddresses []common.Address, topics topics) ethereum.FilterQuery {
+	query := ethereum.FilterQuery{
+		FromBlock: fromBlock,
+		ToBlock:   toBlock,
+		Topics:    topics,
+	}
+	if len(contractAddresses) > 0 {
+		query.Addresses = contractAddresses
+	}
+	return query
+}
+
+func unpackTransferTypes(transferTypes []TransferType) (hasERC20 bool, hasERC721 bool, hasERC1155 bool) {
+	for _, transferType := range transferTypes {
+		switch transferType {
+		case TransferTypeERC20:
+			hasERC20 = true
+		case TransferTypeERC721:
+			hasERC721 = true
+		case TransferTypeERC1155:
+			hasERC1155 = true
+		}
+	}
+	return
+}
+
+type topics [][]common.Hash
+
+func buildSendTopicsList(addressTopics []common.Hash, transferTypes []TransferType) []topics {
+	var topicsList []topics
+
+	// Send direction: separate queries for each transfer type
+	// - ERC20/ERC721: [eventSignature, address] (2 topics)
+	// - ERC1155: [eventSignature, {}, address] (3 topics, omitting empty last topic)
+
+	hasERC20, hasERC721, hasERC1155 := unpackTransferTypes(transferTypes)
+
+	if hasERC20 || hasERC721 {
+		topicsList = append(topicsList, topics{
+			{eventlog.ERC20TransferID}, // Match Transfer event signature (same for ERC20 and ERC721)
+			addressTopics,              // Match any of our addresses in 'from' field
+		})
+	}
+
+	if hasERC1155 {
+		topicsList = append(topicsList, topics{
+			{eventlog.ERC1155TransferSingleID, eventlog.ERC1155TransferBatchID}, // Match either TransferSingle OR TransferBatch
+			{},            // Any operator
+			addressTopics, // Match any of our addresses in 'from' field
+		})
+	}
+
+	return topicsList
+}
+
+func buildReceiveTopicsList(addressTopics []common.Hash, transferTypes []TransferType) []topics {
+	var topicsList []topics
+
+	// Receive direction: separate queries for each transfer type
+	// - ERC20/ERC721: [eventSignature, {}, address] (3 topics)
+	// - ERC1155: [eventSignature, {}, {}, address] (4 topics)
+
+	hasERC20, hasERC721, hasERC1155 := unpackTransferTypes(transferTypes)
+
+	if hasERC20 || hasERC721 {
+		topicsList = append(topicsList, topics{
+			{eventlog.ERC20TransferID}, // Match Transfer event signature (same for ERC20 and ERC721)
+			{},                         // Any 'from' address
+			addressTopics,              // Match any of our addresses in 'to' field
+		})
+	}
+
+	if hasERC1155 {
+		topicsList = append(topicsList, topics{
+			{eventlog.ERC1155TransferSingleID, eventlog.ERC1155TransferBatchID}, // Match either TransferSingle OR TransferBatch
+			{},            // Any operator
+			{},            // Any 'from' address
+			addressTopics, // Match any of our addresses in 'to' field
+		})
+	}
+
+	return topicsList
+}
+
+func buildBothTopicsList(addressTopics []common.Hash, transferTypes []TransferType) []topics {
+	var topicsList []topics
+
+	// Both direction: optimized with merging where possible
+	// - ERC20/ERC721 Send: [eventSignature, address] (2 topics)
+	// - Merged ERC20/ERC721 Receive + ERC1155 Send: [eventSignature, {}, address] (3 topics)
+	// - ERC1155 Receive: [eventSignature, {}, {}, address] (4 topics)
+
+	hasERC20, hasERC721, hasERC1155 := unpackTransferTypes(transferTypes)
+
+	// ERC20/ERC721 Send query
+	if hasERC20 || hasERC721 {
+		topicsList = append(topicsList, topics{
+			{eventlog.ERC20TransferID}, // Match Transfer event signature (same for ERC20 and ERC721)
+			addressTopics,              // Match any of our addresses in 'from' field
+		})
+	}
+
+	// Merged ERC20/ERC721 Receive + ERC1155 Send query (only if we have both)
+	{
+		var eventSignatures []common.Hash
+		if hasERC20 || hasERC721 {
+			eventSignatures = append(eventSignatures, eventlog.ERC20TransferID) // Transfer event signature (same for ERC20 and ERC721)
+		}
+		if hasERC1155 {
+			eventSignatures = append(eventSignatures, eventlog.ERC1155TransferSingleID, eventlog.ERC1155TransferBatchID)
+		}
+
+		topicsList = append(topicsList, topics{
+			eventSignatures, // Match any of the event signatures
+			{},              // Any 'from' address (or operator for ERC1155)
+			addressTopics,   // Match any of our addresses in 'to' field
+		})
+	}
+
+	// ERC1155 Receive query
+	if hasERC1155 {
+		topicsList = append(topicsList, topics{
+			{eventlog.ERC1155TransferSingleID, eventlog.ERC1155TransferBatchID}, // Match either TransferSingle OR TransferBatch
+			{},            // Any operator
+			{},            // Any 'from' address
+			addressTopics, // Match any of our addresses in 'to' field
+		})
+	}
+
+	return topicsList
+}

--- a/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/README.md
+++ b/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/README.md
@@ -1,0 +1,87 @@
+# EventLog
+
+Ethereum event log parser for ERC20, ERC721, and ERC1155 events. Automatically detects and parses token events with type-safe access to event data.
+
+## Supported Events
+
+- **ERC20**: Transfer, Approval
+- **ERC721**: Transfer, Approval, ApprovalForAll  
+- **ERC1155**: TransferSingle, TransferBatch, ApprovalForAll, URI
+
+## Usage
+
+```go
+import (
+    "github.com/ethereum/go-ethereum/core/types"
+    "github.com/status-im/go-wallet-sdk/pkg/eventlog"
+)
+
+// Parse events from a log
+log := types.Log{...}
+events := eventlog.ParseLog(log)
+
+// Handle each event
+for _, event := range events {
+    switch event.EventKey {
+    case eventlog.ERC20Transfer:
+        transfer := event.Unpacked.(erc20.Erc20Transfer)
+        fmt.Printf("Transfer: %s -> %s, Amount: %s\n", 
+            transfer.From.Hex(), transfer.To.Hex(), transfer.Value.String())
+    case eventlog.ERC721Transfer:
+        transfer := event.Unpacked.(erc721.Erc721Transfer)
+        fmt.Printf("NFT Transfer: %s -> %s, TokenID: %s\n",
+            transfer.From.Hex(), transfer.To.Hex(), transfer.TokenId.String())
+    case eventlog.ERC1155TransferSingle:
+        transfer := event.Unpacked.(erc1155.Erc1155TransferSingle)
+        fmt.Printf("ERC1155: %s -> %s, ID: %s, Value: %s\n",
+            transfer.From.Hex(), transfer.To.Hex(), transfer.Id.String(), transfer.Value.String())
+    }
+}
+```
+
+## Event Structure
+
+```go
+type Event struct {
+    ContractKey ContractKey  // "erc20", "erc721", or "erc1155"
+    ContractABI *abi.ABI     // Full contract ABI
+    EventKey    EventKey     // Specific event type
+    ABIEvent    *abi.Event   // ABI event definition
+    Unpacked    any          // Type-safe parsed event data
+}
+```
+
+## Integration with EventFilter
+
+```go
+import (
+    "github.com/status-im/go-wallet-sdk/pkg/eventfilter"
+    "github.com/status-im/go-wallet-sdk/pkg/eventlog"
+)
+
+// Filter and parse events
+events, err := eventfilter.FilterTransfers(client, config)
+if err != nil {
+    log.Fatal(err)
+}
+
+for _, event := range events {
+    parsedEvents := eventlog.ParseLog(event.Raw)
+    for _, parsedEvent := range parsedEvents {
+        // Process parsed event data
+        handleEvent(parsedEvent)
+    }
+}
+```
+
+## Error Handling
+
+Returns empty slice for unknown events or malformed data. Safe to use with any log data.
+
+## Testing
+
+```bash
+go test -v ./pkg/eventlog/...
+```
+
+See `examples/eventfilter-example` for complete usage example.

--- a/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/common.go
+++ b/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/common.go
@@ -1,0 +1,48 @@
+package eventlog
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+var (
+	errNoEventSignature       = errors.New("no event signature")
+	errEventSignatureMismatch = errors.New("event signature mismatch")
+)
+
+type logParser func(log types.Log) *Event
+
+var parsersMap map[ContractKey]logParser = make(map[ContractKey]logParser)
+
+func getABI(meta *bind.MetaData) *abi.ABI {
+	abi, err := meta.GetAbi()
+	if err != nil {
+		panic(err)
+	}
+	return abi
+}
+
+func unpackLog(contractAbi *abi.ABI, out any, event string, log types.Log) error {
+	// Anonymous events are not supported.
+	if len(log.Topics) == 0 {
+		return errNoEventSignature
+	}
+	if log.Topics[0] != contractAbi.Events[event].ID {
+		return errEventSignatureMismatch
+	}
+	if len(log.Data) > 0 {
+		if err := contractAbi.UnpackIntoInterface(out, event, log.Data); err != nil {
+			return err
+		}
+	}
+	var indexed abi.Arguments
+	for _, arg := range contractAbi.Events[event].Inputs {
+		if arg.Indexed {
+			indexed = append(indexed, arg)
+		}
+	}
+	return abi.ParseTopics(out, indexed, log.Topics[1:])
+}

--- a/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/erc1155.go
+++ b/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/erc1155.go
@@ -1,0 +1,82 @@
+package eventlog
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/status-im/go-wallet-sdk/pkg/contracts/erc1155"
+)
+
+const (
+	ERC1155               ContractKey = "erc1155"
+	ERC1155TransferSingle EventKey    = "erc1155transfersingle"
+	ERC1155TransferBatch  EventKey    = "erc1155transferbatch"
+	ERC1155ApprovalForAll EventKey    = "erc1155approvalforall"
+	ERC1155URI            EventKey    = "erc1155uri"
+)
+
+var ERC1155TransferSingleID common.Hash = common.HexToHash("0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62")
+var ERC1155TransferBatchID common.Hash = common.HexToHash("0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb")
+var ERC1155ApprovalForAllID common.Hash = common.HexToHash("0x17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31")
+var ERC1155URIID common.Hash = common.HexToHash("0x6bb7ff708619ba0610cba295a58592e0451dee2622938c8755667688daf3529b")
+
+func init() {
+	parsersMap[ERC1155] = ParseLogERC1155
+}
+
+func ParseLogERC1155(log types.Log) *Event {
+	abi := getABI(erc1155.Erc1155MetaData)
+	event, _ := abi.EventByID(log.Topics[0])
+	if event == nil {
+		return nil
+	}
+
+	ret := &Event{
+		ContractKey: ERC1155,
+		ContractABI: abi,
+		ABIEvent:    event,
+	}
+
+	switch event.ID {
+	case ERC1155TransferSingleID:
+		unpacked := new(erc1155.Erc1155TransferSingle)
+		err := unpackLog(abi, unpacked, event.Name, log)
+		if err != nil {
+			return nil
+		}
+		unpacked.Raw = log
+		ret.Unpacked = *unpacked
+		ret.EventKey = ERC1155TransferSingle
+	case ERC1155TransferBatchID:
+		unpacked := new(erc1155.Erc1155TransferBatch)
+		err := unpackLog(abi, unpacked, event.Name, log)
+		if err != nil {
+			return nil
+		}
+		unpacked.Raw = log
+		ret.Unpacked = *unpacked
+		ret.EventKey = ERC1155TransferBatch
+	case ERC1155ApprovalForAllID:
+		unpacked := new(erc1155.Erc1155ApprovalForAll)
+		err := unpackLog(abi, unpacked, event.Name, log)
+		if err != nil {
+			return nil
+		}
+		unpacked.Raw = log
+		ret.Unpacked = *unpacked
+		ret.EventKey = ERC1155ApprovalForAll
+	case ERC1155URIID:
+		unpacked := new(erc1155.Erc1155URI)
+		err := unpackLog(abi, unpacked, event.Name, log)
+		if err != nil {
+			return nil
+		}
+		unpacked.Raw = log
+		ret.Unpacked = *unpacked
+		ret.EventKey = ERC1155URI
+	default:
+		return nil
+	}
+
+	return ret
+}

--- a/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/erc20.go
+++ b/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/erc20.go
@@ -1,0 +1,60 @@
+package eventlog
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/status-im/go-wallet-sdk/pkg/contracts/erc20"
+)
+
+const (
+	ERC20         ContractKey = "erc20"
+	ERC20Approval EventKey    = "erc20approval"
+	ERC20Transfer EventKey    = "erc20transfer"
+)
+
+var ERC20ApprovalID common.Hash = common.HexToHash("0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925")
+var ERC20TransferID common.Hash = common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
+
+func init() {
+	parsersMap[ERC20] = ParseLogERC20
+}
+
+func ParseLogERC20(log types.Log) *Event {
+	abi := getABI(erc20.Erc20MetaData)
+	event, _ := abi.EventByID(log.Topics[0])
+	if event == nil {
+		return nil
+	}
+
+	ret := &Event{
+		ContractKey: ERC20,
+		ContractABI: abi,
+		ABIEvent:    event,
+	}
+
+	switch event.ID {
+	case ERC20ApprovalID:
+		unpacked := new(erc20.Erc20Approval)
+		err := unpackLog(abi, unpacked, event.Name, log)
+		if err != nil {
+			return nil
+		}
+		unpacked.Raw = log
+		ret.Unpacked = *unpacked
+		ret.EventKey = ERC20Approval
+	case ERC20TransferID:
+		unpacked := new(erc20.Erc20Transfer)
+		err := unpackLog(abi, unpacked, event.Name, log)
+		if err != nil {
+			return nil
+		}
+		unpacked.Raw = log
+		ret.Unpacked = *unpacked
+		ret.EventKey = ERC20Transfer
+	default:
+		return nil
+	}
+
+	return ret
+}

--- a/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/erc721.go
+++ b/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/erc721.go
@@ -1,0 +1,71 @@
+package eventlog
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/status-im/go-wallet-sdk/pkg/contracts/erc721"
+)
+
+const (
+	ERC721               ContractKey = "erc721"
+	ERC721Approval       EventKey    = "erc721approval"
+	ERC721ApprovalForAll EventKey    = "erc721approvalforall"
+	ERC721Transfer       EventKey    = "erc721transfer"
+)
+
+var ERC721ApprovalID common.Hash = common.HexToHash("0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925")
+var ERC721ApprovalForAllID common.Hash = common.HexToHash("0x17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31")
+var ERC721TransferID common.Hash = common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
+
+func init() {
+	parsersMap[ERC721] = ParseLogERC721
+}
+
+func ParseLogERC721(log types.Log) *Event {
+	abi := getABI(erc721.Erc721MetaData)
+	event, _ := abi.EventByID(log.Topics[0])
+	if event == nil {
+		return nil
+	}
+
+	ret := &Event{
+		ContractKey: ERC721,
+		ContractABI: abi,
+		ABIEvent:    event,
+	}
+
+	switch event.ID {
+	case ERC721ApprovalID:
+		unpacked := new(erc721.Erc721Approval)
+		err := unpackLog(abi, unpacked, event.Name, log)
+		if err != nil {
+			return nil
+		}
+		unpacked.Raw = log
+		ret.Unpacked = *unpacked
+		ret.EventKey = ERC721Approval
+	case ERC721ApprovalForAllID:
+		unpacked := new(erc721.Erc721ApprovalForAll)
+		err := unpackLog(abi, unpacked, event.Name, log)
+		if err != nil {
+			return nil
+		}
+		unpacked.Raw = log
+		ret.Unpacked = *unpacked
+		ret.EventKey = ERC721ApprovalForAll
+	case ERC721TransferID:
+		unpacked := new(erc721.Erc721Transfer)
+		err := unpackLog(abi, unpacked, event.Name, log)
+		if err != nil {
+			return nil
+		}
+		unpacked.Raw = log
+		ret.Unpacked = *unpacked
+		ret.EventKey = ERC721Transfer
+	default:
+		return nil
+	}
+
+	return ret
+}

--- a/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/parser.go
+++ b/vendor/github.com/status-im/go-wallet-sdk/pkg/eventlog/parser.go
@@ -1,0 +1,31 @@
+package eventlog
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type ContractKey string
+type EventKey string
+
+type Event struct {
+	ContractKey ContractKey
+	ContractABI *abi.ABI
+	EventKey    EventKey
+	ABIEvent    *abi.Event
+	Unpacked    any
+}
+
+func ParseLog(log types.Log) []Event {
+	ret := make([]Event, 0)
+
+	for _, parser := range parsersMap {
+		event := parser(log)
+		if event == nil {
+			continue
+		}
+		ret = append(ret, *event)
+
+	}
+	return ret
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1037,6 +1037,8 @@ github.com/status-im/go-wallet-sdk/pkg/contracts/erc20
 github.com/status-im/go-wallet-sdk/pkg/contracts/erc721
 github.com/status-im/go-wallet-sdk/pkg/contracts/multicall3
 github.com/status-im/go-wallet-sdk/pkg/ethclient
+github.com/status-im/go-wallet-sdk/pkg/eventfilter
+github.com/status-im/go-wallet-sdk/pkg/eventlog
 github.com/status-im/go-wallet-sdk/pkg/multicall
 # github.com/status-im/markdown v0.0.0-20250825083641-55c1df9bc05d
 ## explicit; go 1.12


### PR DESCRIPTION
This PR introduces the`transferdetector` package. It uses`eventfilter` to efficiently filter event logs for transfers of multiple token standards (erc20, erc721, erc1155) for all accounts in as few RPC calls as possible.
It's intended to replace the event filtering section of the old transfer detection algorithm (https://github.com/status-im/status-go/blob/develop/services/wallet/transfer/downloader.go#L291):

It runs at the same interval (every 10 minutes) by default.
Other than that, the underlying implementation is pretty much the same.
