### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/accounts-management/errors/errors.go
+++ b/accounts-management/errors/errors.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"errors"
 	"fmt"
+	"maps"
 )
 
 type ErrorCode int
@@ -48,9 +49,7 @@ func (e *AccountsError) Copy() *AccountsError {
 	var ctx map[string]interface{}
 	if e.Context != nil {
 		ctx = make(map[string]interface{}, len(e.Context))
-		for k, v := range e.Context {
-			ctx[k] = v
-		}
+		maps.Copy(ctx, e.Context)
 	}
 
 	return &AccountsError{

--- a/centralizedmetrics/providers/mixpanel.go
+++ b/centralizedmetrics/providers/mixpanel.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -148,9 +149,7 @@ func (p mixpanelMetricProperties) MarshalJSON() ([]byte, error) {
 	}
 
 	// Merge AdditionalProperties into the map
-	for key, value := range p.AdditionalProperties {
-		mmpMap[key] = value
-	}
+	maps.Copy(mmpMap, p.AdditionalProperties)
 
 	// Marshal the merged map back to JSON
 	marshaled, err := json.Marshal(mmpMap)

--- a/services/wallet/thirdparty/utils/chunk_fetcher.go
+++ b/services/wallet/thirdparty/utils/chunk_fetcher.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 )
@@ -58,9 +59,7 @@ func ChunkMapFetcher[T any](
 
 	result := make(map[string]T)
 	for _, chunkResult := range chunkResults {
-		for k, v := range chunkResult {
-			result[k] = v
-		}
+		maps.Copy(result, chunkResult)
 	}
 
 	return result, nil


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

Important changes:
- [x] Something worth noting for reviewers.

Closes #
