### PR TITLE
feat: bump waku go bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ pkg/sentry/SENTRY_PRODUCTION
 # Don't ignore generated files in the vendor/ directory
 !vendor/**/*.pb.go
 !vendor/**/migrations.go
+
+go.work
+go.work.sum

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,11 @@ GO_CMD_BUILDS := $(addprefix build/bin/, $(GO_CMD_NAMES))
 # Location of symlinks to derivations that should not be garbage collected
 export _NIX_GCROOTS = ./.nix-gcroots
 
+# Location of waku-go-bindings and nwaku
+WAKU_GO_BINDINGS_DIR := $(shell go list -m -f '{{.Dir}}' github.com/waku-org/waku-go-bindings)
+NWAKU_DIR := $(WAKU_GO_BINDINGS_DIR)/third_party/nwaku
+LIBWAKU := $(NWAKU_DIR)/libwaku.$(LIBWAKU_EXT)
+
 #----------------
 # Nix targets
 #----------------
@@ -163,7 +168,7 @@ nix-purge: ##@nix Completely remove Nix setup, including /nix directory
 all: $(GO_CMD_NAMES)
 
 .PHONY: $(GO_CMD_NAMES) $(GO_CMD_PATHS) $(GO_CMD_BUILDS)
-$(GO_CMD_BUILDS): generate
+$(GO_CMD_BUILDS): generate $(LIBWAKU)
 $(GO_CMD_BUILDS): ##@build Build any Go project from cmd folder
 	go build -mod=vendor -v \
 		-tags '$(BUILD_TAGS)' $(BUILD_FLAGS) \
@@ -171,11 +176,10 @@ $(GO_CMD_BUILDS): ##@build Build any Go project from cmd folder
 	@echo "Compilation done."
 	@echo "Run \"build/bin/$(notdir $@) -h\" to view available commands."
 
-LIBWAKU := $(CURDIR)/vendor/github.com/waku-org/waku-go-bindings/third_party/nwaku/build/libwaku.$(LIBWAKU_EXT)
 $(LIBWAKU):
 ifeq ($(USE_NWAKU),true)
-	@echo "Building libwaku"
-	$(MAKE) -C $(CURDIR)/vendor/github.com/waku-org/waku-go-bindings/waku SHELL=/bin/bash
+	@echo "Building libwaku in $(NWAKU_DIR)"
+	$(MAKE) -C "$(WAKU_GO_BINDINGS_DIR)/waku"
 endif
 
 statusgo: ##@build Build status-go as status-backend server

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/status-im/extkeys v1.4.0
 	github.com/status-im/go-wallet-sdk v0.0.0-20250912130226-d334ec9bff18
 	github.com/waku-org/go-waku v0.8.1-0.20250825172353-0c3d6dc0a8cc
-	github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d
+	github.com/waku-org/waku-go-bindings v0.0.0-20250929211451-e3bf2dd864e3
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.lsp.dev/jsonrpc2 v0.10.0
 	go.lsp.dev/protocol v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -2189,14 +2189,6 @@ github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065 h1:Sd7
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065/go.mod h1:7cSGUoGVIla1IpnChrLbkVjkYgdOcr7rcifEfh4ReR4=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:4HSdWMFMufpRo3ECTX6BrvA+VzKhXZf7mS0rTa5cCWU=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
-github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d h1:k22pZ7dnQ5vTplQ7ZwTfkaZgEUl9IwO9NlbwzRsg73M=
-github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
-github.com/waku-org/waku-go-bindings v0.0.0-20250929101637-e5d92ec09b1c h1:8QPbhfQEoc6ja53Tc+UtBJc+uTaN5JfjO5KvmL5yLJg=
-github.com/waku-org/waku-go-bindings v0.0.0-20250929101637-e5d92ec09b1c/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
-github.com/waku-org/waku-go-bindings v0.0.0-20250929210314-a9642ccf7502 h1:+TxsuQ4umSFSS+qVz50smLrYGxOj+RXLTQUpW2ruCjk=
-github.com/waku-org/waku-go-bindings v0.0.0-20250929210314-a9642ccf7502/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
-github.com/waku-org/waku-go-bindings v0.0.0-20250929211050-b76489a36217 h1:8jSkDl3NaTIx2QYXqbU+dfb33UgXmC+J3sXH+JFyEaM=
-github.com/waku-org/waku-go-bindings v0.0.0-20250929211050-b76489a36217/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/waku-org/waku-go-bindings v0.0.0-20250929211451-e3bf2dd864e3 h1:CV8iZ3NItF0UbJIgN89HgsJn8YwBcpZeE/GZnkVLjZc=
 github.com/waku-org/waku-go-bindings v0.0.0-20250929211451-e3bf2dd864e3/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.5.0 h1:Huc9GxBgiGweCOGTYomvsg07K2QggAqZpZ5SuiZdC8o=

--- a/go.sum
+++ b/go.sum
@@ -2191,6 +2191,14 @@ github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
 github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d h1:k22pZ7dnQ5vTplQ7ZwTfkaZgEUl9IwO9NlbwzRsg73M=
 github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20250929101637-e5d92ec09b1c h1:8QPbhfQEoc6ja53Tc+UtBJc+uTaN5JfjO5KvmL5yLJg=
+github.com/waku-org/waku-go-bindings v0.0.0-20250929101637-e5d92ec09b1c/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20250929210314-a9642ccf7502 h1:+TxsuQ4umSFSS+qVz50smLrYGxOj+RXLTQUpW2ruCjk=
+github.com/waku-org/waku-go-bindings v0.0.0-20250929210314-a9642ccf7502/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20250929211050-b76489a36217 h1:8jSkDl3NaTIx2QYXqbU+dfb33UgXmC+J3sXH+JFyEaM=
+github.com/waku-org/waku-go-bindings v0.0.0-20250929211050-b76489a36217/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20250929211451-e3bf2dd864e3 h1:CV8iZ3NItF0UbJIgN89HgsJn8YwBcpZeE/GZnkVLjZc=
+github.com/waku-org/waku-go-bindings v0.0.0-20250929211451-e3bf2dd864e3/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.5.0 h1:Huc9GxBgiGweCOGTYomvsg07K2QggAqZpZ5SuiZdC8o=
 github.com/wealdtech/go-ens/v3 v3.5.0/go.mod h1:bVuYoWYEEeEu7Zy95rIMjPR34QFJarxt8p84ywSo0YM=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/Makefile
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/Makefile
@@ -1,42 +1,49 @@
 # Makefile for Waku Go Bindings
 
-# Directories
-THIRD_PARTY_DIR := ../third_party
+# Determine OS and set library extension
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	EXT := so
+else ifeq ($(UNAME_S),Darwin)
+	EXT := so
+else ifeq ($(OS),Windows_NT)
+	EXT := dll
+else
+	$(error Unsupported OS: $(UNAME_S))
+endif
+
+THIRD_PARTY_DIR := $(shell pwd)/../third_party
 NWAKU_REPO := https://github.com/waku-org/nwaku
 NWAKU_DIR := $(THIRD_PARTY_DIR)/nwaku
+LIBWAKU_HEADER := $(NWAKU_DIR)/libwaku.h
+LIBWAKU := $(NWAKU_DIR)/libwaku.${EXT}
 
-.PHONY: all clean prepare build-libwaku build
+.PHONY: all clean build libwaku
 
 # Default target
 all: build
 
 # Prepare third_party directory and clone nwaku
-prepare:
-	@echo "Creating third_party directory..."
-	@mkdir -p $(THIRD_PARTY_DIR)
+# NOTE: Currently we download a library release.
+# 		In the future we should get nwaku from Nimble package manager.
+$(LIBWAKU) $(LIBWAKU_HEADER):
+	@chmod +x ../scripts/download_nwaku.sh
+	@../scripts/download_nwaku.sh
 
-	@echo "Cloning nwaku repository..."
-	@if [ ! -d "$(NWAKU_DIR)" ]; then \
-		cd $(THIRD_PARTY_DIR) && \
-		git clone $(NWAKU_REPO) && \
-		cd $(NWAKU_DIR) && \
-		make update; \
-	else \
-		echo "nwaku repository already exists."; \
-	fi
+libwaku: $(LIBWAKU) $(LIBWAKU_HEADER)
 
 # Build libwaku
-build-libwaku: prepare
+build-libwaku:
 	@echo "Building libwaku..."
 	@cd $(NWAKU_DIR) && make libwaku
 
 # Build Waku Go Bindings
-build: build-libwaku
+build: libwaku
 	@echo "Building Waku Go Bindings..."
 	go build ./...
 
 # Clean up generated files
 clean:
 	@echo "Cleaning up..."
-	@rm -rf $(THIRD_PARTY_DIR)
+	@rm -f $(LIBWAKU_HEADER) $(LIBWAKU)
 	@rm -f waku-go-bindings

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
@@ -1,10 +1,10 @@
 package waku
 
 /*
-	#cgo LDFLAGS: -L../third_party/nwaku/build/ -lwaku
-	#cgo LDFLAGS: -L../third_party/nwaku -Wl,-rpath,../third_party/nwaku/build/
+	#cgo LDFLAGS: -L../third_party/nwaku -lwaku
+	#cgo LDFLAGS: -L../third_party/nwaku -Wl,-rpath,../third_party/nwaku
 
-	#include "../third_party/nwaku/library/libwaku.h"
+	#include "../third_party/nwaku/libwaku.h"
 	#include <stdio.h>
 	#include <stdlib.h>
 
@@ -348,6 +348,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/utils"
+
 	"github.com/waku-org/waku-go-bindings/waku/common"
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1185,7 +1185,7 @@ github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-pc-windows-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-musl
 github.com/waku-org/go-zerokit-rln-x86_64/rln
-# github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d
+# github.com/waku-org/waku-go-bindings v0.0.0-20250929211451-e3bf2dd864e3
 ## explicit; go 1.21
 github.com/waku-org/waku-go-bindings/utils
 github.com/waku-org/waku-go-bindings/waku


### PR DESCRIPTION
# Description

Upgrade to the `waku-go-bindings` version with nwaku included binaries.
- https://github.com/waku-org/waku-go-bindings/pull/92

Required for:
- https://github.com/status-im/status-go/pull/6951