### PR TITLE
test: community membership requests

### DIFF
--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -276,9 +276,74 @@ class WakuextService(Service):
         response = self.rpc_request("requestToJoinCommunity", params)
         return response
 
-    def accept_request_to_join_community(self, request_to_join_id):
+    def accept_request_to_join_community(self, request_to_join_id: str):
         params = [{"id": request_to_join_id}]
         response = self.rpc_request("acceptRequestToJoinCommunity", params)
+        return response
+
+    def cancel_request_to_join_community(self, request_to_join_id: str):
+        params = [{"id": request_to_join_id}]
+        response = self.rpc_request("cancelRequestToJoinCommunity", params)
+        return response
+
+    def decline_request_to_join_community(self, request_to_join_id: str):
+        params = [{"id": request_to_join_id}]
+        response = self.rpc_request("declineRequestToJoinCommunity", params)
+        return response
+
+    def canceled_requests_to_join_for_community(self, community_id: str):
+        params = [community_id]
+        response = self.rpc_request("canceledRequestsToJoinForCommunity", params)
+        return response
+
+    def pending_requests_to_join_for_community(self, community_id: str):
+        params = [community_id]
+        response = self.rpc_request("pendingRequestsToJoinForCommunity", params)
+        return response
+
+    def declined_requests_to_join_for_community(self, community_id: str):
+        params = [community_id]
+        response = self.rpc_request("declinedRequestsToJoinForCommunity", params)
+        return response
+
+    def latest_request_to_join_for_community(self, community_id: str):
+        params = [community_id]
+        response = self.rpc_request("latestRequestToJoinForCommunity", params)
+        return response
+
+    def my_pending_requests_to_join(self):
+        params = []
+        response = self.rpc_request("myPendingRequestsToJoin", params)
+        return response
+
+    def my_canceled_requests_to_join(self):
+        params = []
+        response = self.rpc_request("myCanceledRequestsToJoin", params)
+        return response
+
+    def check_and_delete_pending_request_to_join_community(self):
+        params = []
+        response = self.rpc_request("checkAndDeletePendingRequestToJoinCommunity", params)
+        return response
+
+    def all_non_approved_communities_requests_to_join(self):
+        params = []
+        response = self.rpc_request("allNonApprovedCommunitiesRequestsToJoin", params)
+        return response
+
+    def check_permissions_to_join_community(self, community_id: str):
+        params = [{"communityId": community_id}]
+        response = self.rpc_request("checkPermissionsToJoinCommunity", params)
+        return response
+
+    def generate_joining_community_requests_for_signing(self, member_pub_key: str, community_id: str, addresses_to_reveal: list):
+        params = [member_pub_key, community_id, addresses_to_reveal]
+        response = self.rpc_request("generateJoiningCommunityRequestsForSigning", params)
+        return response
+
+    def generate_edit_community_requests_for_signing(self, member_pub_key: str, community_id: str, addresses_to_reveal: list):
+        params = [member_pub_key, community_id, addresses_to_reveal]
+        response = self.rpc_request("generateEditCommunityRequestsForSigning", params)
         return response
 
     def send_chat_message(self, chat_id, message, content_type=MessageContentType.TEXT_PLAIN.value):

--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -144,8 +144,12 @@ class SignalClient:
                 break
             remaining_time = int(timeout - elapsed_time)
             signal = self.wait_for_signal(signal_type, remaining_time)
-            if predicate(signal):
-                return signal
+            try:
+                if predicate(signal):
+                    return signal
+            except Exception as ex:
+                logging.warning(f"Could not filter signal by predicate because of error: {str(ex)}")
+                continue
         raise TimeoutError(f"Signal {signal_type} satisfying the predicate is not received in {timeout} seconds")
 
     def wait_for_logout(self):

--- a/tests-functional/resources/enums.py
+++ b/tests-functional/resources/enums.py
@@ -47,3 +47,10 @@ class MuteType(Enum):
 class ChatPreviewFilterType(Enum):
     Community = 0
     NonCommunity = 1
+
+
+class RequestToJoinState(Enum):
+    RequestToJoinStatePending = 1
+    RequestToJoinStateDeclined = 2
+    RequestToJoinStateAccepted = 3
+    RequestToJoinStateCanceled = 4

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -1,6 +1,5 @@
 # pyright: reportOptionalMemberAccess=false
 # pyright: reportAttributeAccessIssue=false
-import logging
 import time
 from uuid import uuid4
 
@@ -11,6 +10,7 @@ from clients.signals import SignalType
 from resources.enums import MessageContentType
 from steps.network_conditions import NetworkConditionsSteps
 from utils import fake
+from utils.retry_utils import retry_call
 
 
 class MessengerSteps(NetworkConditionsSteps):
@@ -161,20 +161,7 @@ class MessengerSteps(NetworkConditionsSteps):
         response_to_join = member.wakuext_service.request_to_join_community(self.community_id)
         join_id = response_to_join.get("requestsToJoinCommunity", [{}])[0].get("id")
 
-        # I couldn't find any signal related to the requestToJoinCommunity request in the peer node.
-        # That's why I need this retry logic for accepting the request to join the community.
-        max_retries = 40
-        retry_interval = 0.5
-        for attempt in range(max_retries):
-            try:
-                response = admin.wakuext_service.accept_request_to_join_community(join_id)
-                if response:
-                    break
-            except Exception as e:
-                logging.error(f"Attempt {attempt + 1}/{max_retries}: Unexpected error: {e}")
-                time.sleep(retry_interval)
-        else:
-            raise Exception(f"Failed to accept request to join community in {max_retries * retry_interval} seconds.")
+        response = retry_call(admin.wakuext_service.accept_request_to_join_community, join_id)
 
         chats = response.get("communities", [{}])[0].get("chats", {})
         chat_id = list(chats.keys())[0] if chats else None

--- a/tests-functional/tests/test_wakuext_community_membership_requests.py
+++ b/tests-functional/tests/test_wakuext_community_membership_requests.py
@@ -145,12 +145,6 @@ class TestCommunityMembershipRequests(MessengerSteps):
         decline_resp = self.creator.wakuext_service.decline_request_to_join_community(latest.get("id"))
         assert decline_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStateDeclined.value
 
-        self.requester.wait_for_signal_predicate(
-            SignalType.MESSAGES_NEW.value,
-            lambda signal: signal.get("event", {}).get("requestsToJoinCommunity")[0].get("state")
-            == RequestToJoinState.RequestToJoinStateDeclined.value,
-        )
-
         canceled = self.creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
         assert canceled is None
 

--- a/tests-functional/tests/test_wakuext_community_membership_requests.py
+++ b/tests-functional/tests/test_wakuext_community_membership_requests.py
@@ -1,0 +1,182 @@
+from time import sleep
+from uuid import uuid4
+import pytest
+
+from steps.messenger import MessengerSteps
+
+
+@pytest.mark.rpc
+class TestCommunityMembershipRequests(MessengerSteps):
+    @pytest.fixture(autouse=True)
+    def setup_backends(self, backend_new_profile):
+        """Initialize two backends (creator and requester) for each test function"""
+        self.creator = backend_new_profile("creator")
+        self.requester = backend_new_profile("requester")
+        self.fake_address = "0x" + str(uuid4())[:8]
+        self.community_id = self.create_community(self.creator)
+        self.fetch_community(self.requester)
+
+    def test_pending_request_to_join_community_and_cancel(self):
+        req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
+        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == 1
+        req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
+
+        sleep(2)  # small sleep is needed for community requests to sync across nodes
+
+        # Requester checks his pending requests
+        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        assert my_pending[0].get("id") == req_id
+        assert my_pending[0].get("communityId") == self.community_id
+
+        # Creator fetches pending requests for community and expects at least one entry
+        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        assert pending[0].get("id") == req_id
+        assert pending[0].get("communityId") == self.community_id
+
+        latest = self.requester.wakuext_service.latest_request_to_join_for_community(self.community_id)
+        assert latest.get("communityId") == self.community_id
+        assert latest.get("id") == req_id
+
+        # Requester decides to cancel the request to join the community
+        cancel_resp = self.requester.wakuext_service.cancel_request_to_join_community(latest.get("id"))
+        assert cancel_resp.get("requestsToJoinCommunity")[0].get("state") == 4
+
+        sleep(2)  # small sleep is needed for community requests to sync across nodes
+
+        canceled = self.creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
+        assert canceled[0].get("communityId") == self.community_id
+        assert canceled[0].get("id") == req_id
+
+        my_canceled = self.requester.wakuext_service.my_canceled_requests_to_join()
+        assert my_canceled[0].get("communityId") == self.community_id
+        assert my_canceled[0].get("id") == req_id
+
+        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        assert my_pending is None
+
+        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        assert pending is None
+
+    def test_pending_request_to_join_community_and_accept(self):
+        req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
+        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == 1
+        req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
+
+        sleep(2)  # small sleep is needed for community requests to sync across nodes
+
+        # Requester checks his pending requests
+        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        assert my_pending[0].get("id") == req_id
+        assert my_pending[0].get("communityId") == self.community_id
+
+        # Creator fetches pending requests for community and expects at least one entry
+        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        assert pending[0].get("id") == req_id
+        assert pending[0].get("communityId") == self.community_id
+
+        latest = self.requester.wakuext_service.latest_request_to_join_for_community(self.community_id)
+        assert latest.get("communityId") == self.community_id
+        assert latest.get("id") == req_id
+
+        all_non_approved = self.creator.wakuext_service.all_non_approved_communities_requests_to_join()
+        assert all_non_approved[0].get("communityId") == self.community_id
+        assert all_non_approved[0].get("id") == req_id
+
+        # Creator accepts the request from the requester to join the community
+        cancel_resp = self.creator.wakuext_service.accept_request_to_join_community(latest.get("id"))
+        assert cancel_resp.get("requestsToJoinCommunity")[0].get("state") == 3
+
+        sleep(2)  # small sleep is needed for community requests to sync across nodes
+
+        canceled = self.creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
+        assert canceled is None
+
+        my_canceled = self.requester.wakuext_service.my_canceled_requests_to_join()
+        assert my_canceled is None
+
+        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        assert my_pending is None
+
+        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        assert pending is None
+
+        all_non_approved = self.creator.wakuext_service.all_non_approved_communities_requests_to_join()
+        assert all_non_approved == []
+
+    def test_pending_request_to_join_community_and_decline(self):
+        req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
+        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == 1
+        req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
+
+        sleep(2)  # small sleep is needed for community requests to sync across nodes
+
+        # Requester checks his pending requests
+        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        assert my_pending[0].get("id") == req_id
+        assert my_pending[0].get("communityId") == self.community_id
+
+        # Creator fetches pending requests for community and expects at least one entry
+        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        assert pending[0].get("id") == req_id
+        assert pending[0].get("communityId") == self.community_id
+
+        latest = self.requester.wakuext_service.latest_request_to_join_for_community(self.community_id)
+        assert latest.get("communityId") == self.community_id
+        assert latest.get("id") == req_id
+
+        # Creator declines the request from the requester to join the community
+        cancel_resp = self.creator.wakuext_service.decline_request_to_join_community(latest.get("id"))
+        assert cancel_resp.get("requestsToJoinCommunity")[0].get("state") == 2
+
+        sleep(2)  # small sleep is needed for community requests to sync across nodes
+
+        canceled = self.creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
+        assert canceled is None
+
+        declined = self.creator.wakuext_service.declined_requests_to_join_for_community(self.community_id)
+        assert declined[0].get("communityId") == self.community_id
+        assert declined[0].get("id") == req_id
+
+        my_canceled = self.requester.wakuext_service.my_canceled_requests_to_join()
+        assert my_canceled is None
+
+        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        # assert my_pending is None # bug reported here https://github.com/status-im/status-go/issues/6975
+
+        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        assert pending is None
+
+    def test_check_and_delete_pending_request_to_join_community(self):
+        req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
+        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == 1
+        req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
+
+        sleep(2)  # small sleep is needed for community requests to sync across nodes
+
+        # Requester checks his pending requests
+        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        assert my_pending[0].get("id") == req_id
+        assert my_pending[0].get("communityId") == self.community_id
+
+        self.requester.wakuext_service.check_and_delete_pending_request_to_join_community()
+        self.creator.wakuext_service.check_and_delete_pending_request_to_join_community()
+
+        sleep(2)  # small sleep is needed for community requests to sync across nodes
+
+        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        # assert my_pending is None # bug reported here https://github.com/status-im/status-go/issues/6976
+        self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        # assert pending is None # bug reported here https://github.com/status-im/status-go/issues/6976
+
+    def test_check_permissions_and_generate_community_requests(self):
+        perm_resp = self.requester.wakuext_service.check_permissions_to_join_community(self.community_id)
+        assert perm_resp.get("satisfied") is True
+        assert perm_resp.get("roles")[0].get("type") == 2
+
+        member_pub_key = self.requester.public_key
+
+        gen_join_resp = self.requester.wakuext_service.generate_joining_community_requests_for_signing(member_pub_key, self.community_id, [])
+        assert gen_join_resp[0].get("account").lower() == perm_resp.get("validCombinations")[0].get("address").lower()
+
+        gen_edit_resp = self.requester.wakuext_service.generate_edit_community_requests_for_signing(member_pub_key, self.community_id, [])
+        assert gen_edit_resp[0].get("account").lower() == perm_resp.get("validCombinations")[0].get("address").lower()

--- a/tests-functional/tests/test_wakuext_community_membership_requests.py
+++ b/tests-functional/tests/test_wakuext_community_membership_requests.py
@@ -1,8 +1,9 @@
-from time import sleep
 from uuid import uuid4
 import pytest
-
+from clients.signals import SignalType
 from steps.messenger import MessengerSteps
+from resources.enums import RequestToJoinState
+from utils.retry_utils import retry_call
 
 
 @pytest.mark.rpc
@@ -18,18 +19,19 @@ class TestCommunityMembershipRequests(MessengerSteps):
 
     def test_pending_request_to_join_community_and_cancel(self):
         req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
-        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == 1
+        assert len(req_resp.get("requestsToJoinCommunity")) == 1
+        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStatePending.value
         req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
-
-        sleep(2)  # small sleep is needed for community requests to sync across nodes
 
         # Requester checks his pending requests
         my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        assert len(my_pending) == 1
         assert my_pending[0].get("id") == req_id
         assert my_pending[0].get("communityId") == self.community_id
 
         # Creator fetches pending requests for community and expects at least one entry
-        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        pending = retry_call(self.creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
+        assert len(pending) == 1
         assert pending[0].get("id") == req_id
         assert pending[0].get("communityId") == self.community_id
 
@@ -39,15 +41,22 @@ class TestCommunityMembershipRequests(MessengerSteps):
 
         # Requester decides to cancel the request to join the community
         cancel_resp = self.requester.wakuext_service.cancel_request_to_join_community(latest.get("id"))
-        assert cancel_resp.get("requestsToJoinCommunity")[0].get("state") == 4
+        assert len(cancel_resp.get("requestsToJoinCommunity")) == 1
+        assert cancel_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStateCanceled.value
 
-        sleep(2)  # small sleep is needed for community requests to sync across nodes
+        self.creator.wait_for_signal_predicate(
+            SignalType.MESSAGES_NEW.value,
+            lambda signal: signal.get("event", {}).get("requestsToJoinCommunity")[0].get("state")
+            == RequestToJoinState.RequestToJoinStateCanceled.value,
+        )
 
         canceled = self.creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
+        assert len(canceled) == 1
         assert canceled[0].get("communityId") == self.community_id
         assert canceled[0].get("id") == req_id
 
         my_canceled = self.requester.wakuext_service.my_canceled_requests_to_join()
+        assert len(my_canceled) == 1
         assert my_canceled[0].get("communityId") == self.community_id
         assert my_canceled[0].get("id") == req_id
 
@@ -59,18 +68,19 @@ class TestCommunityMembershipRequests(MessengerSteps):
 
     def test_pending_request_to_join_community_and_accept(self):
         req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
-        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == 1
+        assert len(req_resp.get("requestsToJoinCommunity")) == 1
+        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStatePending.value
         req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
-
-        sleep(2)  # small sleep is needed for community requests to sync across nodes
 
         # Requester checks his pending requests
         my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        assert len(my_pending) == 1
         assert my_pending[0].get("id") == req_id
         assert my_pending[0].get("communityId") == self.community_id
 
         # Creator fetches pending requests for community and expects at least one entry
-        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        pending = retry_call(self.creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
+        assert len(pending) == 1
         assert pending[0].get("id") == req_id
         assert pending[0].get("communityId") == self.community_id
 
@@ -79,14 +89,20 @@ class TestCommunityMembershipRequests(MessengerSteps):
         assert latest.get("id") == req_id
 
         all_non_approved = self.creator.wakuext_service.all_non_approved_communities_requests_to_join()
+        assert len(all_non_approved) == 1
         assert all_non_approved[0].get("communityId") == self.community_id
         assert all_non_approved[0].get("id") == req_id
 
         # Creator accepts the request from the requester to join the community
-        cancel_resp = self.creator.wakuext_service.accept_request_to_join_community(latest.get("id"))
-        assert cancel_resp.get("requestsToJoinCommunity")[0].get("state") == 3
+        accept_resp = self.creator.wakuext_service.accept_request_to_join_community(latest.get("id"))
+        assert len(accept_resp.get("requestsToJoinCommunity")) == 1
+        assert accept_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStateAccepted.value
 
-        sleep(2)  # small sleep is needed for community requests to sync across nodes
+        self.requester.wait_for_signal_predicate(
+            SignalType.MESSAGES_NEW.value,
+            lambda signal: signal.get("event", {}).get("requestsToJoinCommunity")[0].get("state")
+            == RequestToJoinState.RequestToJoinStateAccepted.value,
+        )
 
         canceled = self.creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
         assert canceled is None
@@ -105,18 +121,19 @@ class TestCommunityMembershipRequests(MessengerSteps):
 
     def test_pending_request_to_join_community_and_decline(self):
         req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
-        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == 1
+        assert len(req_resp.get("requestsToJoinCommunity")) == 1
+        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStatePending.value
         req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
-
-        sleep(2)  # small sleep is needed for community requests to sync across nodes
 
         # Requester checks his pending requests
         my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        assert len(my_pending) == 1
         assert my_pending[0].get("id") == req_id
         assert my_pending[0].get("communityId") == self.community_id
 
         # Creator fetches pending requests for community and expects at least one entry
-        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        pending = retry_call(self.creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
+        assert len(pending) == 1
         assert pending[0].get("id") == req_id
         assert pending[0].get("communityId") == self.community_id
 
@@ -125,15 +142,20 @@ class TestCommunityMembershipRequests(MessengerSteps):
         assert latest.get("id") == req_id
 
         # Creator declines the request from the requester to join the community
-        cancel_resp = self.creator.wakuext_service.decline_request_to_join_community(latest.get("id"))
-        assert cancel_resp.get("requestsToJoinCommunity")[0].get("state") == 2
+        decline_resp = self.creator.wakuext_service.decline_request_to_join_community(latest.get("id"))
+        assert decline_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStateDeclined.value
 
-        sleep(2)  # small sleep is needed for community requests to sync across nodes
+        self.requester.wait_for_signal_predicate(
+            SignalType.MESSAGES_NEW.value,
+            lambda signal: signal.get("event", {}).get("requestsToJoinCommunity")[0].get("state")
+            == RequestToJoinState.RequestToJoinStateDeclined.value,
+        )
 
         canceled = self.creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
         assert canceled is None
 
         declined = self.creator.wakuext_service.declined_requests_to_join_for_community(self.community_id)
+        assert len(declined) == 1
         assert declined[0].get("communityId") == self.community_id
         assert declined[0].get("id") == req_id
 
@@ -148,20 +170,19 @@ class TestCommunityMembershipRequests(MessengerSteps):
 
     def test_check_and_delete_pending_request_to_join_community(self):
         req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
-        assert req_resp.get("requestsToJoinCommunity")[0].get("state") == 1
+        assert len(req_resp.get("requestsToJoinCommunity")) == 1
         req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
-
-        sleep(2)  # small sleep is needed for community requests to sync across nodes
 
         # Requester checks his pending requests
         my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        assert len(my_pending) == 1
         assert my_pending[0].get("id") == req_id
         assert my_pending[0].get("communityId") == self.community_id
 
+        retry_call(self.creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
+
         self.requester.wakuext_service.check_and_delete_pending_request_to_join_community()
         self.creator.wakuext_service.check_and_delete_pending_request_to_join_community()
-
-        sleep(2)  # small sleep is needed for community requests to sync across nodes
 
         my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
         # assert my_pending is None # bug reported here https://github.com/status-im/status-go/issues/6976
@@ -171,12 +192,15 @@ class TestCommunityMembershipRequests(MessengerSteps):
     def test_check_permissions_and_generate_community_requests(self):
         perm_resp = self.requester.wakuext_service.check_permissions_to_join_community(self.community_id)
         assert perm_resp.get("satisfied") is True
+        assert len(perm_resp.get("roles")) == 1
         assert perm_resp.get("roles")[0].get("type") == 2
 
         member_pub_key = self.requester.public_key
 
         gen_join_resp = self.requester.wakuext_service.generate_joining_community_requests_for_signing(member_pub_key, self.community_id, [])
+        assert len(gen_join_resp) == 1
         assert gen_join_resp[0].get("account").lower() == perm_resp.get("validCombinations")[0].get("address").lower()
 
         gen_edit_resp = self.requester.wakuext_service.generate_edit_community_requests_for_signing(member_pub_key, self.community_id, [])
+        assert len(gen_edit_resp) == 1
         assert gen_edit_resp[0].get("account").lower() == perm_resp.get("validCombinations")[0].get("address").lower()

--- a/tests-functional/utils/retry_utils.py
+++ b/tests-functional/utils/retry_utils.py
@@ -1,0 +1,15 @@
+import logging
+from time import sleep
+
+
+# To be used when signals related to RPC requests are not present in the peer ndoe, ex for: requestToJoinCommunity.
+def retry_call(func, *args, max_retries=40, retry_interval=0.5, **kwargs):
+    for attempt in range(max_retries):
+        try:
+            response = func(*args, **kwargs)
+            if response:
+                return response
+        except Exception as e:
+            logging.error(f"Attempt {attempt + 1}/{max_retries}: Unexpected error: {e}")
+        sleep(retry_interval)
+    raise Exception(f"Failed to execute {func.__name__} in {max_retries * retry_interval} seconds.")


### PR DESCRIPTION
Reported 2 potential bugs:
- [bug: MyPendingRequestsToJoin still return request after the request has been declined](https://github.com/status-im/status-go/issues/6975)
- [bug: checkAndDeletePendingRequestToJoinCommunity doesn't clear pending requests](https://github.com/status-im/status-go/issues/6976)

Covered the following methods that were not covered by functional tests:

- cancelRequestToJoinCommunity
- declineRequestToJoinCommunity
- canceledRequestsToJoinForCommunity
- pendingRequestsToJoinForCommunity
- declinedRequestsToJoinForCommunity
- latestRequestToJoinForCommunity
- myPendingRequestsToJoin
- myCanceledRequestsToJoin
- checkAndDeletePendingRequestToJoinCommunity
- allNonApprovedCommunitiesRequestsToJoin
- checkPermissionsToJoinCommunity
- generateJoiningCommunityRequestsForSigning
- generateEditCommunityRequestsForSigning