### PR TITLE
test: community chats

### DIFF
--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -694,3 +694,48 @@ class WakuextService(Service):
     def log_test(self):
         response = self.rpc_request("logTest")
         return response
+
+    def create_community_chat(self, community_id: str, c: dict):
+        params = [community_id, c]
+        response = self.rpc_request("createCommunityChat", params)
+        return response
+
+    def edit_community_chat(self, community_id: str, chat_id: str, c: dict):
+        params = [community_id, chat_id, c]
+        response = self.rpc_request("editCommunityChat", params)
+        return response
+
+    def delete_community_chat(self, community_id: str, chat_id: str):
+        params = [community_id, chat_id]
+        response = self.rpc_request("deleteCommunityChat", params)
+        return response
+
+    def reorder_community_chat(self, community_id: str, chat_id: str, position: int):
+        params = [{"communityId": community_id, "chatId": chat_id, "position": position}]
+        response = self.rpc_request("reorderCommunityChat", params)
+        return response
+
+    def share_community_channel_url_with_chat_key(self, community_id: str, channel_id: str):
+        params = [{"communityId": community_id, "channelId": channel_id}]
+        response = self.rpc_request("shareCommunityChannelURLWithChatKey", params)
+        return response
+
+    def share_community_url_with_chat_key(self, community_id: str):
+        params = [community_id]
+        response = self.rpc_request("shareCommunityURLWithChatKey", params)
+        return response
+
+    def parse_shared_url(self, url: str):
+        params = [url]
+        response = self.rpc_request("parseSharedURL", params)
+        return response
+
+    def mute_community_chats(self, community_id: str, muted_type):
+        params = [{"communityId": community_id, "mutedType": muted_type}]
+        response = self.rpc_request("muteCommunityChats", params)
+        return response
+
+    def un_mute_community_chats(self, community_id: str):
+        params = [community_id]
+        response = self.rpc_request("unMuteCommunityChats", params)
+        return response

--- a/tests-functional/tests/test_wakuext_chats.py
+++ b/tests-functional/tests/test_wakuext_chats.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -92,8 +92,6 @@ class TestChatActions(MessengerSteps):
         assert chat.get("muted", False) is True
         assert chat.get("muteTill", "") == result
 
-    @pytest.mark.skip(reason="Skipping mute chat tests due to failing on local build")
-    # TODO: check in nightly build locally
     @pytest.mark.parametrize(
         "mute_type, time_delta",
         [
@@ -113,11 +111,11 @@ class TestChatActions(MessengerSteps):
         chat_id = self.receiver.public_key
 
         result = self.sender.wakuext_service.mute_chat_v2(chat_id, mute_type)
-        actual = datetime.strptime(result, "%Y-%m-%dT%H:%M:%SZ")
+        actual = datetime.fromisoformat(result.replace("Z", "+00:00"))
 
-        expected = datetime.now() + time_delta
+        expected = datetime.now(timezone.utc) + time_delta
         diff = expected - actual
-        assert diff.total_seconds() < 2  # 2sec margin
+        assert abs(diff.total_seconds()) < 2  # 2 sec margin
 
         chat = self.sender.wakuext_service.chat(chat_id)
         assert chat.get("muted", False) is True

--- a/tests-functional/tests/test_wakuext_community_chats.py
+++ b/tests-functional/tests/test_wakuext_community_chats.py
@@ -1,0 +1,263 @@
+from enum import Enum
+from uuid import uuid4
+from datetime import datetime, timezone, timedelta
+import pytest
+
+from steps.messenger import MessengerSteps
+from clients.services.wakuext import ActivityCenterNotificationType
+from clients.signals import SignalType
+
+
+class MutedType(Enum):
+    MuteFor15Min = 1
+    MuteFor1Hr = 2
+    MuteFor8Hr = 3
+    MuteFor1Week = 4
+    MuteTillUnmuted = 5
+    MuteTill1Min = 6
+    Unmuted = 7
+    MuteFor24Hr = 8
+
+
+@pytest.mark.rpc
+class TestCommunityChats(MessengerSteps):
+    @pytest.fixture(autouse=True)
+    def setup_backends(self, backend_new_profile):
+        """Initialize two backends (creator and requester) for each test function"""
+        self.creator = backend_new_profile("creator")
+        self.member = backend_new_profile("member")
+        self.fake_address = "0x" + str(uuid4())[:8]
+        self.community_id = self.create_community(self.creator)
+        self.join_community(member=self.member, admin=self.creator)
+        self.display_name = "chat_" + str(uuid4())
+        self.chat_payload = {
+            "identity": {
+                "displayName": self.display_name,
+                "emoji": "😀",
+                "color": "#1f2c75",
+                "description": self.display_name,
+            },
+            "viewersCanPostReactions": False,
+            "hideIfPermissionsNotMet": False,
+            "permissions": {"access": 1},
+        }
+
+    def test_create_edit_delete_community_chat(self):
+        create_resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+        chats = create_resp.get("chats")
+        communities = create_resp.get("communities")
+        assert len(chats) == 1
+        assert len(communities) == 1
+        community_chats = communities[0].get("chats")
+
+        # assert chats[0].get("displayName") == self.chat_payload["identity"]["displayName"] #  https://github.com/status-im/status-go/issues/6985
+        assert chats[0].get("color") == self.chat_payload["identity"]["color"]
+        assert chats[0].get("emoji") == self.chat_payload["identity"]["emoji"]
+        assert chats[0].get("description") == self.chat_payload["identity"]["description"]
+        assert chats[0].get("viewersCanPostReactions") == self.chat_payload["viewersCanPostReactions"]
+
+        # build a dict keyed by position
+        chats_by_position = {chat["position"]: chat for chat in community_chats.values()}
+        # position 1 should be the default chat
+        assert chats_by_position[0].get("name") == "general"
+        # assert chats_by_position[1].get("name") == self.chat_payload["identity"]["displayName"] # https://github.com/status-im/status-go/issues/6985
+        assert chats_by_position[1].get("hideIfPermissionsNotMet") == self.chat_payload["hideIfPermissionsNotMet"]
+        assert chats_by_position[1].get("permissions") == self.chat_payload["permissions"]
+        added_chat_id = chats_by_position[1].get("id")
+
+        comm_before_delete = self.fetch_community(self.creator, self.community_id)
+        assert added_chat_id in comm_before_delete.get("chats")
+
+        edit_payload = {
+            "identity": {
+                "displayName": "edited_" + str(uuid4()),
+                "emoji": "🔑",
+                "color": "#212331",
+                "description": "edited_" + str(uuid4()),
+            }
+        }
+        edit_resp = self.creator.wakuext_service.edit_community_chat(self.community_id, added_chat_id, edit_payload)
+        assert edit_resp.get("chats")[0].get("color") == edit_payload["identity"]["color"]
+        assert edit_resp.get("chats")[0].get("emoji") == edit_payload["identity"]["emoji"]
+        assert edit_resp.get("chats")[0].get("description") == edit_payload["identity"]["description"]
+
+        del_resp = self.creator.wakuext_service.delete_community_chat(self.community_id, added_chat_id)
+        assert del_resp.get("removedChats")[0] == added_chat_id
+        assert added_chat_id not in del_resp.get("communities")[0].get("chats")
+
+        comm_after_delete = self.fetch_community(self.creator, self.community_id)
+        assert added_chat_id not in comm_after_delete.get("chats")
+
+    def test_reorder_community_chat(self):
+        resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+
+        # sort chats by position
+        chats_before = sorted(resp.get("communities")[0].get("chats").values(), key=lambda c: c["position"])
+
+        first_chat = next(c for c in chats_before if c["position"] == 0)
+        second_chat = next(c for c in chats_before if c["position"] == 1)
+
+        # reorder: move the new chat to position 0
+        reorder_resp = self.creator.wakuext_service.reorder_community_chat(self.community_id, second_chat["id"], 0)
+
+        # fetch reordered chats and sort them again by position
+        chats_after = sorted(reorder_resp["communities"][0]["chats"].values(), key=lambda c: c["position"])
+
+        # assertions: positions must be swapped
+        assert chats_after[0]["id"] == second_chat["id"]
+        assert chats_after[0]["position"] == 0
+        assert chats_after[1]["id"] == first_chat["id"]
+        assert chats_after[1]["position"] == 1
+
+    def test_create_and_share_community_channel_url(self):
+        self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+
+        channel_id = str(uuid4())
+        share_resp = self.creator.wakuext_service.share_community_channel_url_with_chat_key(self.community_id, channel_id)
+        assert share_resp is not None
+        assert f"https://status.app/cc/{channel_id}" in share_resp
+
+        parsed = self.creator.wakuext_service.parse_shared_url(share_resp)
+        assert parsed["channel"].get("channelUuid") == channel_id
+        assert parsed["community"].get("communityId") == self.community_id
+
+        share_comm_resp = self.creator.wakuext_service.share_community_url_with_chat_key(self.community_id)
+        assert "https://status.app/c" in share_comm_resp
+        parsed_comm = self.creator.wakuext_service.parse_shared_url(share_comm_resp)
+        assert parsed_comm["community"].get("communityId") == self.community_id
+
+    def test_mute_and_unmute_community_chats(self):
+        self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+
+        community_before = self.creator.wakuext_service.fetch_community(self.community_id)
+        assert community_before.get("muted") is False
+
+        mute_resp = self.creator.wakuext_service.mute_community_chats(self.community_id, MutedType.MuteFor15Min.value)
+        assert mute_resp is not None
+
+        community_after_mute = self.creator.wakuext_service.fetch_community(self.community_id)
+        assert community_after_mute.get("muted") is True
+        assert community_after_mute.get("muteTill") == mute_resp
+
+        unmute_resp = self.creator.wakuext_service.un_mute_community_chats(self.community_id)
+        assert unmute_resp is not None
+
+        community_after_unmute = self.creator.wakuext_service.fetch_community(self.community_id)
+        assert community_after_unmute.get("muted") is False
+        assert community_after_unmute.get("muteTill") == "0001-01-01T00:00:00Z"
+
+    @pytest.mark.parametrize("muted_type", [mt.value for mt in MutedType])
+    def test_mute_types_are_applied(self, muted_type):
+        create_resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+        chat_id = create_resp.get("chats")[0].get("id")
+        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=chat_id, timeout=10)
+
+        mute_resp = self.member.wakuext_service.mute_community_chats(self.community_id, muted_type)
+        community_after_mute = self.member.wakuext_service.fetch_community(self.community_id)
+        muted_flag = community_after_mute.get("muted")
+        comm_mute_till = community_after_mute.get("muteTill")
+
+        if muted_type == MutedType.Unmuted.value:
+            assert muted_flag is False
+        else:
+            assert muted_flag is True
+
+        assert comm_mute_till is not None
+        assert str(comm_mute_till) == str(mute_resp)
+
+        parsed_mute_till = datetime.fromisoformat(comm_mute_till.replace("Z", "+00:00"))
+
+        now = datetime.now(timezone.utc)
+        # time remaining until mute expires
+        remaining = parsed_mute_till - now
+
+        # map expected durations
+        expected_map = {
+            MutedType.MuteFor15Min.value: timedelta(minutes=15),
+            MutedType.MuteFor1Hr.value: timedelta(hours=1),
+            MutedType.MuteFor8Hr.value: timedelta(hours=8),
+            MutedType.MuteFor24Hr.value: timedelta(hours=24),
+            MutedType.MuteFor1Week.value: timedelta(days=7),
+            MutedType.MuteTill1Min.value: timedelta(minutes=1),
+        }
+
+        # allow some tolerance for clocks and propagation delays
+        tolerance = timedelta(seconds=30)
+
+        if muted_type in expected_map:
+            expected = expected_map[muted_type]
+            # remaining should be roughly equal to expected (allow +/- tolerance)
+            assert abs(remaining - expected) <= tolerance, f"mute remaining {remaining}, expected ~{expected}"
+        else:
+            assert comm_mute_till == "0001-01-01T00:00:00Z"
+
+    def test_send_community_chat_message_with_mention(self):
+        create_resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+        chat_id = create_resp.get("chats")[0].get("id")
+        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=chat_id, timeout=10)
+
+        text = f"Hi @{self.member.public_key}"
+        # creator sends a chat message with a mention to trigger a notification
+        send_resp = self.creator.wakuext_service.send_chat_message(chat_id, text)
+        assert send_resp.get("chats")[0].get("lastMessage").get("text") == text
+        message_id = send_resp.get("messages", [])[0].get("id", "")
+
+        # member receives that message even if chat is muted
+        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=10)
+        member_msgs_resp = self.member.wakuext_service.chat_messages(chat_id)
+        assert member_msgs_resp.get("messages")[0].get("text") == text
+        assert member_msgs_resp.get("messages")[0].get("mentioned") is True
+
+        # member will receive the mention notification
+        resp = self.member.wakuext_service.get_activity_center_notifications([activity for activity in ActivityCenterNotificationType])
+        notifications = resp.get("notifications")
+        assert len(notifications) == 2
+        assert notifications[0].get("communityId") == self.community_id
+        assert notifications[0].get("chatId") == chat_id
+        assert notifications[0].get("message").get("text") == text
+
+    def test_send_community_chat_message_while_chat_is_muted_and_then_unmuted(self):
+        create_resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+        chat_id = create_resp.get("chats")[0].get("id")
+        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=chat_id, timeout=10)
+
+        # muting the community chats
+        self.member.wakuext_service.mute_community_chats(self.community_id, MutedType.MuteFor15Min.value)
+
+        text = f"Hi @{self.member.public_key}"
+        # creator sends a chat message with a mention to trigger a notification
+        send_resp = self.creator.wakuext_service.send_chat_message(chat_id, text)
+        assert send_resp.get("chats")[0].get("lastMessage").get("text") == text
+        message_id = send_resp.get("messages", [])[0].get("id", "")
+
+        # member receives that message even if chat is muted
+        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=10)
+        member_msgs_resp = self.member.wakuext_service.chat_messages(chat_id)
+        assert member_msgs_resp.get("messages")[0].get("text") == text
+        assert member_msgs_resp.get("messages")[0].get("mentioned") is True
+
+        # member doesn't received the mention notification because the chat was muted
+        resp = self.member.wakuext_service.get_activity_center_notifications([activity for activity in ActivityCenterNotificationType])
+        notifications = resp.get("notifications")
+        assert len(notifications) == 1
+        assert notifications[0].get("chatId") == ""
+
+        self.member.wakuext_service.un_mute_community_chats(self.community_id)
+
+        send_resp = self.creator.wakuext_service.send_chat_message(chat_id, text)
+        assert send_resp.get("chats")[0].get("lastMessage").get("text") == text
+        message_id = send_resp.get("messages", [])[0].get("id", "")
+
+        # member receives that message even if chat is muted
+        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=10)
+        member_msgs_resp = self.member.wakuext_service.chat_messages(chat_id)
+        assert member_msgs_resp.get("messages")[0].get("text") == text
+        assert member_msgs_resp.get("messages")[0].get("mentioned") is True
+
+        # member receives again the mention notification because the chat was unmuted
+        resp = self.member.wakuext_service.get_activity_center_notifications([activity for activity in ActivityCenterNotificationType])
+        notifications = resp.get("notifications")
+        assert len(notifications) == 2
+        assert notifications[0].get("communityId") == self.community_id
+        assert notifications[0].get("chatId") == chat_id
+        assert notifications[0].get("message").get("text") == text

--- a/tests-functional/tests/test_wakuext_community_chats.py
+++ b/tests-functional/tests/test_wakuext_community_chats.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from uuid import uuid4
 from datetime import datetime, timezone, timedelta
 import pytest
@@ -6,17 +5,7 @@ import pytest
 from steps.messenger import MessengerSteps
 from clients.services.wakuext import ActivityCenterNotificationType
 from clients.signals import SignalType
-
-
-class MutedType(Enum):
-    MuteFor15Min = 1
-    MuteFor1Hr = 2
-    MuteFor8Hr = 3
-    MuteFor1Week = 4
-    MuteTillUnmuted = 5
-    MuteTill1Min = 6
-    Unmuted = 7
-    MuteFor24Hr = 8
+from resources.enums import MuteType
 
 
 @pytest.mark.rpc
@@ -132,7 +121,7 @@ class TestCommunityChats(MessengerSteps):
         community_before = self.creator.wakuext_service.fetch_community(self.community_id)
         assert community_before.get("muted") is False
 
-        mute_resp = self.creator.wakuext_service.mute_community_chats(self.community_id, MutedType.MuteFor15Min.value)
+        mute_resp = self.creator.wakuext_service.mute_community_chats(self.community_id, MuteType.MUTE_FOR15_MIN.value)
         assert mute_resp is not None
 
         community_after_mute = self.creator.wakuext_service.fetch_community(self.community_id)
@@ -146,7 +135,7 @@ class TestCommunityChats(MessengerSteps):
         assert community_after_unmute.get("muted") is False
         assert community_after_unmute.get("muteTill") == "0001-01-01T00:00:00Z"
 
-    @pytest.mark.parametrize("muted_type", [mt.value for mt in MutedType])
+    @pytest.mark.parametrize("muted_type", [mt.value for mt in MuteType])
     def test_mute_types_are_applied(self, muted_type):
         create_resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
         chat_id = create_resp.get("chats")[0].get("id")
@@ -157,7 +146,7 @@ class TestCommunityChats(MessengerSteps):
         muted_flag = community_after_mute.get("muted")
         comm_mute_till = community_after_mute.get("muteTill")
 
-        if muted_type == MutedType.Unmuted.value:
+        if muted_type == MuteType.UNMUTED.value:
             assert muted_flag is False
         else:
             assert muted_flag is True
@@ -173,12 +162,12 @@ class TestCommunityChats(MessengerSteps):
 
         # map expected durations
         expected_map = {
-            MutedType.MuteFor15Min.value: timedelta(minutes=15),
-            MutedType.MuteFor1Hr.value: timedelta(hours=1),
-            MutedType.MuteFor8Hr.value: timedelta(hours=8),
-            MutedType.MuteFor24Hr.value: timedelta(hours=24),
-            MutedType.MuteFor1Week.value: timedelta(days=7),
-            MutedType.MuteTill1Min.value: timedelta(minutes=1),
+            MuteType.MUTE_FOR15_MIN.value: timedelta(minutes=15),
+            MuteType.MUTE_FOR1_HR.value: timedelta(hours=1),
+            MuteType.MUTE_FOR8_HR.value: timedelta(hours=8),
+            MuteType.MUTE_FOR24_HR.value: timedelta(hours=24),
+            MuteType.MUTE_FOR1_WEEK.value: timedelta(days=7),
+            MuteType.MUTE_TILL1_MIN.value: timedelta(minutes=1),
         }
 
         # allow some tolerance for clocks and propagation delays
@@ -222,7 +211,7 @@ class TestCommunityChats(MessengerSteps):
         self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=chat_id, timeout=10)
 
         # muting the community chats
-        self.member.wakuext_service.mute_community_chats(self.community_id, MutedType.MuteFor15Min.value)
+        self.member.wakuext_service.mute_community_chats(self.community_id, MuteType.MUTE_FOR15_MIN.value)
 
         text = f"Hi @{self.member.public_key}"
         # creator sends a chat message with a mention to trigger a notification


### PR DESCRIPTION
Reported https://github.com/status-im/status-go/issues/6985

New methods covered:
- createCommunityChat
- editCommunityChat
- deleteCommunityChat
- reorderCommunityChat
- shareCommunityChannelURLWithChatKey
- shareCommunityURLWithChatKey
- parseSharedURL
- muteCommunityChats
- unMuteCommunityChats
