### PR TITLE
chore: Remove legacy mobile v1 migration workaround

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -558,68 +558,6 @@ func (b *GethStatusBackend) LoginAccount(request *requests.Login) error {
 	return nil
 }
 
-// This is a workaround to make user be able to login again, the root cause is where the node config migration
-// failed caused by adding new columns to the node config table, it's been fixed in PR: https://github.com/status-im/status-go/pull/6248.
-// Details for the issue: it prevent user from login, it happens when old mobile user ignore upgrade the app to the version which introduced the node config migration
-// and choose to upgrade a higher version instead, after upgrading, user first attempt to login will fail because the node config migration will fail.
-// and second attempt to login will cause an empty node config saved in the db.
-func (b *GethStatusBackend) workaroundToFixBadMigration(request *requests.Login) (err error) {
-	if !gocommon.IsMobilePlatform() { // this issue only happens on mobile platform
-		return nil
-	}
-
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	var (
-		currentConf     *params.NodeConfig
-		defaultNodeConf *params.NodeConfig
-	)
-	currentConf, err = nodecfg.GetNodeConfigFromDB(b.appDB)
-	if err != nil {
-		return err
-	}
-
-	// check if we saved a empty node config because of node config migration failed
-	if currentConf.NetworkID == 0 &&
-		currentConf.NodeKey == "" {
-		// check if exist old node config
-		oldNodeConf := &params.NodeConfig{}
-		err = b.appDB.QueryRow("SELECT node_config FROM settings WHERE synthetic_id = 'id'").Scan(&sqlite.JSONBlob{Data: oldNodeConf})
-		if err != nil && err != sql.ErrNoRows {
-			return err
-		}
-		if err == sql.ErrNoRows {
-			return errors.New("failed to migrate node config as there's no data in settings")
-		}
-
-		// the createAccount contains all the fields that are needed to create the default node config
-		createAccount := b.convertLoginRequestToAccountRequest(request)
-		defaultNodeConf, err = DefaultNodeConfig(oldNodeConf.ShhextConfig.InstallationID, request.KeyUID, createAccount)
-		if err != nil {
-			return err
-		}
-
-		b.overridePartialWithOldNodeConfig(defaultNodeConf, oldNodeConf)
-		var tx *sql.Tx
-		tx, err = b.appDB.BeginTx(context.Background(), &sql.TxOptions{})
-		if err != nil {
-			return err
-		}
-		defer func() {
-			if err == nil {
-				err = tx.Commit()
-				return
-			}
-			// don't shadow original error
-			_ = tx.Rollback()
-		}()
-		err = nodecfg.SaveConfigWithTx(tx, defaultNodeConf)
-	}
-
-	return nil
-}
-
 func (b *GethStatusBackend) overridePartialWithOldNodeConfig(conf *params.NodeConfig, oldNodeConf *params.NodeConfig) {
 	// rootDataDir should be set by InitializeApplication or UpdateRootDataDir already
 	conf.RootDataDir = b.rootDataDir
@@ -684,11 +622,6 @@ func (b *GethStatusBackend) loginAccount(request *requests.Login) error {
 	err := b.ensureDBsOpened(acc, request.Password)
 	if err != nil {
 		return errors.Wrap(err, "failed to open database")
-	}
-
-	//relate PR: https://github.com/status-im/status-go/pull/6248
-	if err := b.workaroundToFixBadMigration(request); err != nil {
-		return errors.Wrap(err, "failed to workaround bad migration")
 	}
 
 	defaultCfg := &params.NodeConfig{

--- a/api/old_mobile_v1_user_login_test.go
+++ b/api/old_mobile_v1_user_login_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
-	"github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/t/utils"
 )
@@ -50,28 +49,4 @@ func (s *OldMobileV1_10_UserLoginTest) TestLoginWithSuccessNodeConfigMigration()
 	}
 	s.Require().NoError(b.LoginAccount(loginRequest))
 	s.Require().NoError(b.Logout())
-}
-
-// without workaroundToFixBadMigration, this test would login fail
-func (s *OldMobileV1_10_UserLoginTest) TestLoginWithFailNodeConfigMigration() {
-	bkFunc := common.IsMobilePlatform
-	common.IsMobilePlatform = func() bool {
-		return true
-	}
-	defer func() {
-		common.IsMobilePlatform = bkFunc
-	}()
-
-	s.tmpdir = s.T().TempDir()
-	copyDir(v1_10_AfterUpgradeFolder, s.tmpdir, s.T())
-
-	b := NewGethStatusBackend(s.logger)
-	b.UpdateRootDataDir(s.tmpdir)
-	s.Require().NoError(b.OpenAccounts(true))
-	loginRequest := &requests.Login{
-		KeyUID:   v1_10_keyUID,
-		Password: v1_10_passwd,
-	}
-	err := b.LoginAccount(loginRequest)
-	s.Require().NoError(err)
 }


### PR DESCRIPTION
It seems to affect the new mobile app. Cannot login on failed sync because this workaround fails.