### PR TITLE
fix_: disable mercuryo on-ramp provider

### DIFF
--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -128,14 +128,6 @@ func NewService(
 		featureFlags.EnableCelerBridge = true
 	}
 
-	if config.WalletConfig.EnableMercuryoProvider {
-		featureFlags.EnableMercuryoProvider = true
-	}
-
-	if featureFlags.EnableMercuryoProvider {
-		cryptoOnRampProviders = append(cryptoOnRampProviders, onramp.NewMercuryoProvider(tokenManager))
-	}
-
 	cryptoOnRampManager := onramp.NewManager(cryptoOnRampProviders)
 
 	savedAddressesManager := &SavedAddressesManager{db: db}


### PR DESCRIPTION
## Description

This PR disables Mercuryo on-ramp for next old mobile release to prevent user dissatisfaction that Mecuryo doesn't work now. And to prevent any possible security issues.

### Reviewer notes
Mobile takes the list of on-ramp providers from `status-go` and displays them in a list, this is why it is not disabled in mobile only.
