### PR TITLE
fix: Crash on uninitialized filterManager

### DIFF
--- a/messaging/waku/gowaku.go
+++ b/messaging/waku/gowaku.go
@@ -968,6 +968,9 @@ func (w *Waku) subscribe(f *common.Filter) (string, error) {
 	}
 
 	if w.cfg.LightClient {
+		if w.filterManager == nil {
+			return id, nil
+		}
 		cf := protocol.NewContentFilter(f.PubsubTopic, f.ContentTopics.ContentTopics()...)
 		w.filterManager.SubscribeFilter(id, cf)
 	}
@@ -983,6 +986,9 @@ func (w *Waku) Unsubscribe(ctx context.Context, id string) error {
 	}
 
 	if w.cfg.LightClient {
+		if w.filterManager == nil {
+			return nil
+		}
 		w.filterManager.UnsubscribeFilter(id)
 	}
 


### PR DESCRIPTION
An attempt to get over this crash https://github.com/status-im/status-go/issues/7009. This is based on a superficial investigation to unblock other tasks and I'll merge it only if it's good enough. It's fixing the crash, the synced app seems fine.


Not sure if this will only hide the root cause because the proper flow on pairing is unknown to me. But from what I've seen Waku is only started after login. While `subscribe` and `unsubscribe` is used in the pairing flow as well.
