### PR TITLE
fix: disable mercuryo on-ramp provider

### DIFF
--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -102,10 +102,6 @@ func NewService(
 
 	featureFlags := &protocolCommon.FeatureFlags{}
 
-	if config.WalletConfig.EnableMercuryoProvider {
-		featureFlags.EnableMercuryoProvider = true
-	}
-
 	savedAddressesManager := &SavedAddressesManager{db: db}
 	transactionManager := transfer.NewTransactionManager(gethManager, transactor, config, accountsDB, pendingTxManager, feed)
 	blockChainState := blockchainstate.NewBlockChainState(rpcClient)
@@ -122,15 +118,6 @@ func NewService(
 
 		cryptoOnRampProviders = []onramp.Provider{
 			onramp.NewMoonPayProvider(),
-		}
-
-		if featureFlags.EnableMercuryoProvider {
-			params := onramp.MercuryoParams{
-				SignURL:      fmt.Sprintf("https://%s.api.status.im/mercuryo/sign/", statusProxyStageName),
-				SignUser:     config.WalletConfig.StatusProxyUser,
-				SignPassword: config.WalletConfig.StatusProxyPassword,
-			}
-			cryptoOnRampProviders = append(cryptoOnRampProviders, onramp.NewMercuryoProvider(tokenManager, params))
 		}
 
 		cryptoCompare := cryptocompare.NewClient()


### PR DESCRIPTION
## Description

This PR disables Mercuryo on-ramp for next old mobile release to prevent user dissatisfaction that Mecuryo doesn't work now. And to prevent any possible security issues.

### Reviewer notes
Mobile takes the list of on-ramp providers from `status-go` and displays them in a list, this is why it is not disabled in mobile only.
