### PR TITLE
refactor: move pubkeys utils from protocol to crypto package

### DIFF
--- a/cmd/generate_handlers/generate_handlers_template.txt
+++ b/cmd/generate_handlers/generate_handlers_template.txt
@@ -10,7 +10,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
 
-	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/protocol/protobuf"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
 )
@@ -30,7 +30,7 @@ func (m *Messenger) dispatchToHandler(messageState *ReceivedMessageState, protoB
 func (m *Messenger) {{.MethodName}}(messageState *ReceivedMessageState, protoBytes []byte, msg *messagingtypes.Message, filter messagingtypes.ChatFilter{{ if .FromArchiveArg }}, fromArchive bool{{ end }}) error {
 	m.logger.Info("handling {{ .ProtobufName}}")
 	{{ if .SyncMessage }}
-	if !common.IsPubKeyEqual(messageState.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
+	if !crypto.IsPubKeyEqual(messageState.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
 		m.logger.Warn("not coming from us, ignoring")
 		return nil
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -132,6 +132,36 @@ func DecodePubkeyString(pubkey string) (*ecdsa.PublicKey, error) {
 	return key, nil
 }
 
+// IsPubKeyEqual checks that two public keys are equal
+func IsPubKeyEqual(a, b *ecdsa.PublicKey) bool {
+	// the curve is always the same, just compare the points
+	return a.X.Cmp(b.X) == 0 && a.Y.Cmp(b.Y) == 0
+}
+
+func PubkeysToHex(keys []*ecdsa.PublicKey) []string {
+	var result []string
+	for _, k := range keys {
+		result = append(result, PubkeyToHex(k))
+	}
+	return result
+}
+
+func PubkeyToHex(key *ecdsa.PublicKey) string {
+	return types.EncodeHex(FromECDSAPub(key))
+}
+
+func PubkeyToHexBytes(key *ecdsa.PublicKey) types.HexBytes {
+	return FromECDSAPub(key)
+}
+
+func HexToPubkey(pk string) (*ecdsa.PublicKey, error) {
+	bytes, err := types.DecodeHex(pk)
+	if err != nil {
+		return nil, err
+	}
+	return UnmarshalPubkey(bytes)
+}
+
 func MustDecodePubkeyString(pubkey string) *ecdsa.PublicKey {
 	pk, err := DecodePubkeyString(pubkey)
 	if err != nil {

--- a/messaging/common/message_sender.go
+++ b/messaging/common/message_sender.go
@@ -29,7 +29,6 @@ import (
 	messagingtypes "github.com/status-im/status-go/messaging/types"
 	wakutypes "github.com/status-im/status-go/messaging/waku/types"
 	"github.com/status-im/status-go/pkg/pubsub"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 )
@@ -398,7 +397,7 @@ func (s *MessageSender) sendCommunity(
 	}
 
 	s.logger.Debug("sent-message: community ",
-		zap.Strings("recipient", common.PubkeysToHex(rawMessage.Recipients)),
+		zap.Strings("recipient", crypto.PubkeysToHex(rawMessage.Recipients)),
 		zap.String("messageID", messageID.String()),
 		zap.String("messageType", "community"),
 		zap.Any("contentType", rawMessage.MessageType),
@@ -452,7 +451,7 @@ func (s *MessageSender) sendPrivate(
 			return nil, errors.Wrap(err, "failed to send message with datasync")
 		}
 		// We don't need to receive confirmations from our own devices
-		if !common.IsPubKeyEqual(recipient, &s.identity.PublicKey) {
+		if !crypto.IsPubKeyEqual(recipient, &s.identity.PublicKey) {
 			confirmation := &messagingtypes.RawMessageConfirmation{
 				DataSyncID: datasyncID,
 				MessageID:  messageID,
@@ -494,7 +493,7 @@ func (s *MessageSender) sendPrivate(
 		}
 
 		s.logger.Debug("sent-message: private skipProtocolLayer",
-			zap.String("recipient", common.PubkeyToHex(recipient)),
+			zap.String("recipient", crypto.PubkeyToHex(recipient)),
 			zap.String("messageID", messageID.String()),
 			zap.String("messageType", "private"),
 			zap.Any("contentType", rawMessage.MessageType),
@@ -514,7 +513,7 @@ func (s *MessageSender) sendPrivate(
 		}
 
 		s.logger.Debug("sent-message: private without datasync",
-			zap.String("recipient", common.PubkeyToHex(recipient)),
+			zap.String("recipient", crypto.PubkeyToHex(recipient)),
 			zap.String("messageID", messageID.String()),
 			zap.Any("contentType", rawMessage.MessageType),
 			zap.String("messageType", "private"),
@@ -772,7 +771,7 @@ func (s *MessageSender) SendPublic(
 	s.notifyOnSentMessage(sentMessage)
 
 	s.logger.Debug("sent-message: public message",
-		zap.Strings("recipient", common.PubkeysToHex(rawMessage.Recipients)),
+		zap.Strings("recipient", crypto.PubkeysToHex(rawMessage.Recipients)),
 		zap.String("messageID", messageID.String()),
 		zap.Any("contentType", rawMessage.MessageType),
 		zap.String("messageType", "public"),

--- a/messaging/common/message_sender_test.go
+++ b/messaging/common/message_sender_test.go
@@ -4,31 +4,26 @@ import (
 	"math"
 	"testing"
 
-	"github.com/status-im/status-go/messaging/adapters"
-	"github.com/status-im/status-go/messaging/layers/transport"
-	messagingtypes "github.com/status-im/status-go/messaging/types"
-	wakuv2 "github.com/status-im/status-go/messaging/waku"
-	wakutypes "github.com/status-im/status-go/messaging/waku/types"
-	"github.com/status-im/status-go/t/helpers"
-
-	"github.com/libp2p/go-libp2p/core/peer"
-
 	"github.com/golang/protobuf/proto"
-
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
 	datasyncproto "github.com/status-im/mvds/protobuf"
 
+	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/crypto"
+	"github.com/status-im/status-go/messaging/adapters"
 	"github.com/status-im/status-go/messaging/datasync"
 	"github.com/status-im/status-go/messaging/layers/encryption"
-	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/messaging/layers/transport"
+	messagingtypes "github.com/status-im/status-go/messaging/types"
+	wakuv2 "github.com/status-im/status-go/messaging/waku"
+	wakutypes "github.com/status-im/status-go/messaging/waku/types"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/sqlite"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
-
-	"github.com/status-im/status-go/appdatabase"
+	"github.com/status-im/status-go/t/helpers"
 )
 
 func TestMessageSenderSuite(t *testing.T) {
@@ -370,7 +365,7 @@ func (s *MessageSenderSuite) TestGetEphemeralKey() {
 		key, err := s.sender.GetEphemeralKey()
 		s.Require().NoError(err)
 		s.Require().NotNil(key)
-		keyMap[common.PubkeyToHex(&key.PublicKey)] = true
+		keyMap[crypto.PubkeyToHex(&key.PublicKey)] = true
 	}
 	s.Require().Len(keyMap, maxMessageSenderEphemeralKeys)
 	// Add one more
@@ -378,5 +373,5 @@ func (s *MessageSenderSuite) TestGetEphemeralKey() {
 	s.Require().NoError(err)
 	s.Require().NotNil(key)
 
-	s.Require().True(keyMap[common.PubkeyToHex(&key.PublicKey)])
+	s.Require().True(keyMap[crypto.PubkeyToHex(&key.PublicKey)])
 }

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -40,7 +40,6 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/profiling"
 	"github.com/status-im/status-go/protocol"
-	"github.com/status-im/status-go/protocol/common"
 	identityUtils "github.com/status-im/status-go/protocol/identity"
 	"github.com/status-im/status-go/protocol/identity/alias"
 	"github.com/status-im/status-go/protocol/identity/colorhash"
@@ -1089,7 +1088,7 @@ func CompressPublicKey(key string) string {
 
 // compressPublicKey compresses uncompressed 65-byte format to 33-byte compressed format.
 func compressPublicKey(key string) string {
-	pubKey, err := common.HexToPubkey(key)
+	pubKey, err := crypto.HexToPubkey(key)
 	if err != nil {
 		return makeJSONResponse(err)
 	}

--- a/protocol/activity_center.go
+++ b/protocol/activity_center.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/verification"
@@ -168,7 +169,7 @@ func showMentionOrReplyActivityCenterNotification(publicKey ecdsa.PublicKey, mes
 		return true, ActivityCenterNotificationTypeMention
 	}
 
-	publicKeyString := common.PubkeyToHex(&publicKey)
+	publicKeyString := crypto.PubkeyToHex(&publicKey)
 	if responseTo != nil && responseTo.From == publicKeyString {
 		return true, ActivityCenterNotificationTypeReply
 	}

--- a/protocol/chat.go
+++ b/protocol/chat.go
@@ -261,7 +261,7 @@ func (c *Chat) PublicKey() (*ecdsa.PublicKey, error) {
 	if c.ChatType != ChatTypeOneToOne {
 		return nil, nil
 	}
-	return common.HexToPubkey(c.ID)
+	return crypto.HexToPubkey(c.ID)
 }
 
 func (c *Chat) Public() bool {
@@ -492,7 +492,7 @@ type ChatMember struct {
 }
 
 func (c ChatMember) PublicKey() (*ecdsa.PublicKey, error) {
-	return common.HexToPubkey(c.ID)
+	return crypto.HexToPubkey(c.ID)
 }
 
 func oneToOneChatID(publicKey *ecdsa.PublicKey) string {
@@ -692,7 +692,7 @@ func stringSliceToPublicKeys(slice []string) ([]*ecdsa.PublicKey, error) {
 	result := make([]*ecdsa.PublicKey, len(slice))
 	for idx, item := range slice {
 		var err error
-		result[idx], err = common.HexToPubkey(item)
+		result[idx], err = crypto.HexToPubkey(item)
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/common/crypto.go
+++ b/protocol/common/crypto.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 
 	"github.com/status-im/status-go/crypto"
-	"github.com/status-im/status-go/crypto/types"
 )
 
 const (
@@ -77,36 +76,6 @@ func Shake256(buf []byte) []byte {
 	h := make([]byte, 64)
 	sha3.ShakeSum256(h, buf)
 	return h
-}
-
-// IsPubKeyEqual checks that two public keys are equal
-func IsPubKeyEqual(a, b *ecdsa.PublicKey) bool {
-	// the curve is always the same, just compare the points
-	return a.X.Cmp(b.X) == 0 && a.Y.Cmp(b.Y) == 0
-}
-
-func PubkeysToHex(keys []*ecdsa.PublicKey) []string {
-	var result []string
-	for _, k := range keys {
-		result = append(result, PubkeyToHex(k))
-	}
-	return result
-}
-
-func PubkeyToHex(key *ecdsa.PublicKey) string {
-	return types.EncodeHex(crypto.FromECDSAPub(key))
-}
-
-func PubkeyToHexBytes(key *ecdsa.PublicKey) types.HexBytes {
-	return crypto.FromECDSAPub(key)
-}
-
-func HexToPubkey(pk string) (*ecdsa.PublicKey, error) {
-	bytes, err := types.DecodeHex(pk)
-	if err != nil {
-		return nil, err
-	}
-	return crypto.UnmarshalPubkey(bytes)
 }
 
 func MakeECDHSharedKey(yourPrivateKey *ecdsa.PrivateKey, theirPubKey *ecdsa.PublicKey) ([]byte, error) {

--- a/protocol/communities/community.go
+++ b/protocol/communities/community.go
@@ -582,7 +582,7 @@ func (o *Community) GetMemberPubkeys() []*ecdsa.PublicKey {
 		pubkeys := make([]*ecdsa.PublicKey, len(o.config.CommunityDescription.Members))
 		i := 0
 		for hex := range o.config.CommunityDescription.Members {
-			pubkeys[i], _ = common.HexToPubkey(hex)
+			pubkeys[i], _ = crypto.HexToPubkey(hex)
 			i++
 		}
 		return pubkeys
@@ -682,7 +682,7 @@ func (o *Community) DeleteChat(chatID string) (*CommunityChanges, error) {
 
 func (o *Community) getMember(pk *ecdsa.PublicKey) *protobuf.CommunityMember {
 
-	key := common.PubkeyToHex(pk)
+	key := crypto.PubkeyToHex(pk)
 	member := o.config.CommunityDescription.Members[key]
 	return member
 }
@@ -710,7 +710,7 @@ func (o *Community) getChatMember(pk *ecdsa.PublicKey, chatID string) *protobuf.
 		return nil
 	}
 
-	key := common.PubkeyToHex(pk)
+	key := crypto.PubkeyToHex(pk)
 	member := chat.Members[key]
 
 	if member == nil && !channelHasPermissions(o.ChatID(chatID), o.config.CommunityDescription.TokenPermissions) {
@@ -735,7 +735,7 @@ func (o *Community) IsBanned(pk *ecdsa.PublicKey) bool {
 
 func (o *Community) isBanned(pk *ecdsa.PublicKey) bool {
 
-	key := common.PubkeyToHex(pk)
+	key := crypto.PubkeyToHex(pk)
 
 	banned := slices.Contains(o.config.CommunityDescription.BanList, key)
 
@@ -837,7 +837,7 @@ func (o *Community) RemoveUserFromChat(pk *ecdsa.PublicKey, chatID string) (*pro
 		return o.config.CommunityDescription, nil
 	}
 
-	key := common.PubkeyToHex(pk)
+	key := crypto.PubkeyToHex(pk)
 	delete(chat.Members, key)
 
 	if o.IsControlNode() {
@@ -850,7 +850,7 @@ func (o *Community) RemoveUserFromChat(pk *ecdsa.PublicKey, chatID string) (*pro
 func (o *Community) RemoveOurselvesFromOrg(pk *ecdsa.PublicKey) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
-	_ = o.RemoveMembersFromOrg([]string{common.PubkeyToHex(pk)})
+	_ = o.RemoveMembersFromOrg([]string{crypto.PubkeyToHex(pk)})
 	o.increaseClock()
 }
 
@@ -866,13 +866,13 @@ func (o *Community) RemoveUserFromOrg(pk *ecdsa.PublicKey) (*protobuf.CommunityD
 		return nil, ErrCannotRemoveOwnerOrAdmin
 	}
 
-	pkStr := common.PubkeyToHex(pk)
+	pkStr := crypto.PubkeyToHex(pk)
 
 	if o.IsControlNode() {
 		_ = o.RemoveMembersFromOrg([]string{pkStr})
 		o.increaseClock()
 	} else {
-		err := o.addNewCommunityEvent(o.ToKickCommunityMemberCommunityEvent(common.PubkeyToHex(pk)))
+		err := o.addNewCommunityEvent(o.ToKickCommunityMemberCommunityEvent(crypto.PubkeyToHex(pk)))
 		if err != nil {
 			return nil, err
 		}
@@ -922,7 +922,7 @@ func (o *Community) RemoveMembersFromOrg(membersToRemove []string) *CommunityCha
 func (o *Community) RemoveAllUsersFromOrg() *CommunityChanges {
 	o.increaseClock()
 
-	myPublicKey := common.PubkeyToHex(o.MemberIdentity())
+	myPublicKey := crypto.PubkeyToHex(o.MemberIdentity())
 	member := o.config.CommunityDescription.Members[myPublicKey]
 
 	membersToRemove := o.config.CommunityDescription.Members
@@ -1002,7 +1002,7 @@ func (o *Community) UnbanUserFromCommunity(pk *ecdsa.PublicKey) (*protobuf.Commu
 		o.unbanUserFromCommunity(pk)
 		o.increaseClock()
 	} else {
-		err := o.addNewCommunityEvent(o.ToUnbanCommunityMemberCommunityEvent(common.PubkeyToHex(pk)))
+		err := o.addNewCommunityEvent(o.ToUnbanCommunityMemberCommunityEvent(crypto.PubkeyToHex(pk)))
 		if err != nil {
 			return nil, err
 		}
@@ -1027,7 +1027,7 @@ func (o *Community) BanUserFromCommunity(pk *ecdsa.PublicKey, communityBanInfo *
 		o.banUserFromCommunity(pk, communityBanInfo)
 		o.increaseClock()
 	} else {
-		pkStr := common.PubkeyToHex(pk)
+		pkStr := crypto.PubkeyToHex(pk)
 		err := o.addNewCommunityEvent(o.ToBanCommunityMemberCommunityEvent(pkStr))
 		if err != nil {
 			return nil, err
@@ -1395,8 +1395,8 @@ func (o *Community) GetFilteredPrivilegedMembers(skipMembers map[string]struct{}
 	members := o.GetMemberPubkeys()
 	for _, member := range members {
 		if len(skipMembers) > 0 {
-			if _, exist := skipMembers[common.PubkeyToHex(member)]; exist {
-				delete(skipMembers, common.PubkeyToHex(member))
+			if _, exist := skipMembers[crypto.PubkeyToHex(member)]; exist {
+				delete(skipMembers, crypto.PubkeyToHex(member))
 				continue
 			}
 		}
@@ -2103,7 +2103,7 @@ func (o *Community) VerifyGrantSignature(data []byte) (*protobuf.Grant, error) {
 		return nil, err
 	}
 
-	if !common.IsPubKeyEqual(o.ControlNode(), extractedPublicKey) {
+	if !crypto.IsPubKeyEqual(o.ControlNode(), extractedPublicKey) {
 		return nil, ErrInvalidGrant
 	}
 
@@ -2123,7 +2123,7 @@ func (o *Community) CanView(pk *ecdsa.PublicKey, chatID string) bool {
 	}
 
 	// community creator can always post, return immediately
-	if common.IsPubKeyEqual(pk, o.ControlNode()) || o.IsPrivilegedMember(pk) {
+	if crypto.IsPubKeyEqual(pk, o.ControlNode()) || o.IsPrivilegedMember(pk) {
 		return true
 	}
 
@@ -2138,7 +2138,7 @@ func (o *Community) CanView(pk *ecdsa.PublicKey, chatID string) bool {
 	}
 
 	// If community member, also check chat membership next
-	_, ok = o.config.CommunityDescription.Members[common.PubkeyToHex(pk)]
+	_, ok = o.config.CommunityDescription.Members[crypto.PubkeyToHex(pk)]
 	if !ok {
 		o.config.Logger.Debug("Community.CanView: not a community member", zap.String("chat-id", chatID))
 		return false
@@ -2153,7 +2153,7 @@ func (o *Community) CanView(pk *ecdsa.PublicKey, chatID string) bool {
 		return false
 	}
 
-	_, isChatMember := chat.Members[common.PubkeyToHex(pk)]
+	_, isChatMember := chat.Members[crypto.PubkeyToHex(pk)]
 	return isChatMember
 }
 
@@ -2163,13 +2163,13 @@ func (o *Community) CanPost(pk *ecdsa.PublicKey, chatID string, messageType prot
 		return false, nil
 	}
 
-	if o.IsPrivilegedMember(pk) || common.IsPubKeyEqual(pk, o.ControlNode()) {
+	if o.IsPrivilegedMember(pk) || crypto.IsPubKeyEqual(pk, o.ControlNode()) {
 		// If the user is a privileged member, they can post in any chat
 		return true, nil
 	}
 
 	chat := o.config.CommunityDescription.Chats[chatID]
-	member := chat.Members[common.PubkeyToHex(pk)]
+	member := chat.Members[crypto.PubkeyToHex(pk)]
 
 	// Channels with permissions require the member to be present
 	if member == nil && channelHasPermissions(o.ChatID(chatID), o.config.CommunityDescription.TokenPermissions) {
@@ -2307,7 +2307,7 @@ func (o *Community) CanManageUsersPublicKeys() ([]*ecdsa.PublicKey, error) {
 	roles := manageCommunityRoles()
 	for pkString, member := range o.config.CommunityDescription.Members {
 		if o.memberHasRoles(member, roles) {
-			pk, err := common.HexToPubkey(pkString)
+			pk, err := crypto.HexToPubkey(pkString)
 			if err != nil {
 				return nil, err
 			}
@@ -2332,7 +2332,7 @@ func (o *Community) AddMember(publicKey *ecdsa.PublicKey, roles []protobuf.Commu
 		return nil, ErrNotControlNode
 	}
 
-	memberKey := common.PubkeyToHex(publicKey)
+	memberKey := crypto.PubkeyToHex(publicKey)
 	changes := o.emptyCommunityChanges()
 
 	if o.config.CommunityDescription.Members == nil {
@@ -2359,7 +2359,7 @@ func (o *Community) AddMemberToChat(chatID string, publicKey *ecdsa.PublicKey,
 		return nil, ErrNotControlNode
 	}
 
-	memberKey := common.PubkeyToHex(publicKey)
+	memberKey := crypto.PubkeyToHex(publicKey)
 	changes := o.emptyCommunityChanges()
 
 	chat, ok := o.config.CommunityDescription.Chats[chatID]
@@ -2476,7 +2476,7 @@ func (d sortSlice) Less(i, j int) bool {
 }
 
 func (o *Community) unbanUserFromCommunity(pk *ecdsa.PublicKey) {
-	key := common.PubkeyToHex(pk)
+	key := crypto.PubkeyToHex(pk)
 	for i, v := range o.config.CommunityDescription.BanList {
 		if v == key {
 			o.config.CommunityDescription.BanList =
@@ -2491,7 +2491,7 @@ func (o *Community) unbanUserFromCommunity(pk *ecdsa.PublicKey) {
 }
 
 func (o *Community) banUserFromCommunity(pk *ecdsa.PublicKey, communityBanInfo *protobuf.CommunityBanInfo) {
-	key := common.PubkeyToHex(pk)
+	key := crypto.PubkeyToHex(pk)
 	if o.hasMember(pk) {
 		// Remove from org
 		delete(o.config.CommunityDescription.Members, key)
@@ -2520,7 +2520,7 @@ func (o *Community) banUserFromCommunity(pk *ecdsa.PublicKey, communityBanInfo *
 }
 
 func (o *Community) deleteBannedMemberAllMessages(pk *ecdsa.PublicKey) error {
-	key := common.PubkeyToHex(pk)
+	key := crypto.PubkeyToHex(pk)
 
 	if o.config.CommunityDescription.BannedMembers == nil {
 		return ErrBannedMemberNotFound
@@ -2670,7 +2670,7 @@ func (o *Community) validateEvent(event *CommunityEvent, signer *ecdsa.PublicKey
 	}
 
 	eventTargetRoles := []protobuf.CommunityMember_Roles{}
-	eventTargetPk, err := common.HexToPubkey(event.MemberToAction)
+	eventTargetPk, err := crypto.HexToPubkey(event.MemberToAction)
 	if err == nil {
 		eventTarget := o.getMember(eventTargetPk)
 		if eventTarget != nil {

--- a/protocol/communities/community_bloom_filter.go
+++ b/protocol/communities/community_bloom_filter.go
@@ -9,7 +9,6 @@ import (
 	"github.com/bits-and-blooms/bloom/v3"
 
 	"github.com/status-im/status-go/crypto"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -61,7 +60,7 @@ func generateBloomFilter(members map[string]*protobuf.CommunityMember, privateKe
 	filter := bloom.NewWithEstimates(numberOfItems, falsePositiveRate)
 
 	for pk := range members {
-		publicKey, err := common.HexToPubkey(pk)
+		publicKey, err := crypto.HexToPubkey(pk)
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/communities/community_bloom_filter_test.go
+++ b/protocol/communities/community_bloom_filter_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/crypto"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -38,12 +37,12 @@ func (s *CommunityBloomFilterSuite) TestBasic() {
 		Chats: map[string]*protobuf.CommunityChat{
 			encryptedChannelID: {
 				Members: map[string]*protobuf.CommunityMember{
-					common.PubkeyToHex(&memberIdentity.PublicKey): {},
+					crypto.PubkeyToHex(&memberIdentity.PublicKey): {},
 				},
 			},
 			nonEncryptedChannelID: {
 				Members: map[string]*protobuf.CommunityMember{
-					common.PubkeyToHex(&memberIdentity.PublicKey): {},
+					crypto.PubkeyToHex(&memberIdentity.PublicKey): {},
 				},
 			},
 		},

--- a/protocol/communities/community_encryption_key_action_test.go
+++ b/protocol/communities/community_encryption_key_action_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -74,9 +73,9 @@ func (s *CommunityEncryptionKeyActionSuite) SetupTest() {
 	s.Require().NoError(err)
 	s.member3 = member3
 
-	s.member1Key = common.PubkeyToHex(&s.member1.PublicKey)
-	s.member2Key = common.PubkeyToHex(&s.member2.PublicKey)
-	s.member3Key = common.PubkeyToHex(&s.member3.PublicKey)
+	s.member1Key = crypto.PubkeyToHex(&s.member1.PublicKey)
+	s.member2Key = crypto.PubkeyToHex(&s.member2.PublicKey)
+	s.member3Key = crypto.PubkeyToHex(&s.member3.PublicKey)
 }
 
 func (s *CommunityEncryptionKeyActionSuite) TestEncryptionKeyNone() {

--- a/protocol/communities/community_events_processing.go
+++ b/protocol/communities/community_events_processing.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
 
-	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -241,7 +241,7 @@ func (o *Community) applyEvent(communityEvent CommunityEvent) error {
 		}
 	case protobuf.CommunityEvent_COMMUNITY_MEMBER_BAN:
 		if o.IsControlNode() {
-			pk, err := common.HexToPubkey(communityEvent.MemberToAction)
+			pk, err := crypto.HexToPubkey(communityEvent.MemberToAction)
 			if err != nil {
 				return err
 			}
@@ -249,7 +249,7 @@ func (o *Community) applyEvent(communityEvent CommunityEvent) error {
 		}
 	case protobuf.CommunityEvent_COMMUNITY_MEMBER_UNBAN:
 		if o.IsControlNode() {
-			pk, err := common.HexToPubkey(communityEvent.MemberToAction)
+			pk, err := crypto.HexToPubkey(communityEvent.MemberToAction)
 			if err != nil {
 				return err
 			}
@@ -259,7 +259,7 @@ func (o *Community) applyEvent(communityEvent CommunityEvent) error {
 		o.config.CommunityDescription.CommunityTokensMetadata = append(o.config.CommunityDescription.CommunityTokensMetadata, communityEvent.TokenMetadata)
 	case protobuf.CommunityEvent_COMMUNITY_DELETE_BANNED_MEMBER_MESSAGES:
 		if o.IsControlNode() {
-			pk, err := common.HexToPubkey(communityEvent.MemberToAction)
+			pk, err := crypto.HexToPubkey(communityEvent.MemberToAction)
 			if err != nil {
 				return err
 			}

--- a/protocol/communities/community_test.go
+++ b/protocol/communities/community_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/images"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -65,9 +64,9 @@ func (s *CommunitySuite) SetupTest() {
 	s.Require().NoError(err)
 	s.member3 = member3
 
-	s.member1Key = common.PubkeyToHex(&s.member1.PublicKey)
-	s.member2Key = common.PubkeyToHex(&s.member2.PublicKey)
-	s.member3Key = common.PubkeyToHex(&s.member3.PublicKey)
+	s.member1Key = crypto.PubkeyToHex(&s.member1.PublicKey)
+	s.member2Key = crypto.PubkeyToHex(&s.member2.PublicKey)
+	s.member3Key = crypto.PubkeyToHex(&s.member3.PublicKey)
 
 }
 
@@ -92,8 +91,8 @@ func (s *CommunitySuite) TestHasPermission() {
 
 	communityDescription := &protobuf.CommunityDescription{}
 	communityDescription.Members = make(map[string]*protobuf.CommunityMember)
-	communityDescription.Members[common.PubkeyToHex(&ownerKey.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_OWNER}}
-	communityDescription.Members[common.PubkeyToHex(&memberKey.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_ADMIN}}
+	communityDescription.Members[crypto.PubkeyToHex(&ownerKey.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_OWNER}}
+	communityDescription.Members[crypto.PubkeyToHex(&memberKey.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_ADMIN}}
 
 	community.config = &Config{ID: &ownerKey.PublicKey, CommunityDescription: communityDescription}
 
@@ -267,11 +266,11 @@ func (s *CommunitySuite) TestRemoveUserFromChat() {
 	s.Require().True(org.HasMember(&s.member1.PublicKey))
 
 	// Check member has not been removed from org
-	_, ok := actualCommunity.Members[common.PubkeyToHex(&s.member1.PublicKey)]
+	_, ok := actualCommunity.Members[crypto.PubkeyToHex(&s.member1.PublicKey)]
 	s.Require().True(ok)
 
 	// Check member has been removed from chat
-	_, ok = actualCommunity.Chats[testChatID1].Members[common.PubkeyToHex(&s.member1.PublicKey)]
+	_, ok = actualCommunity.Chats[testChatID1].Members[crypto.PubkeyToHex(&s.member1.PublicKey)]
 	s.Require().False(ok)
 }
 
@@ -295,11 +294,11 @@ func (s *CommunitySuite) TestRemoveUserFormOrg() {
 	s.Require().False(org.HasMember(&s.member1.PublicKey))
 
 	// Check member has been removed from org
-	_, ok := actualCommunity.Members[common.PubkeyToHex(&s.member1.PublicKey)]
+	_, ok := actualCommunity.Members[crypto.PubkeyToHex(&s.member1.PublicKey)]
 	s.Require().False(ok)
 
 	// Check member has been removed from chat
-	_, ok = actualCommunity.Chats[testChatID1].Members[common.PubkeyToHex(&s.member1.PublicKey)]
+	_, ok = actualCommunity.Chats[testChatID1].Members[crypto.PubkeyToHex(&s.member1.PublicKey)]
 	s.Require().False(ok)
 }
 
@@ -315,7 +314,7 @@ func (s *CommunitySuite) TestRemoveOurselvesFormOrg() {
 	s.Require().False(org.HasMember(&s.member1.PublicKey))
 
 	// Check member has been removed from chat
-	_, ok := org.config.CommunityDescription.Chats[testChatID1].Members[common.PubkeyToHex(&s.member1.PublicKey)]
+	_, ok := org.config.CommunityDescription.Chats[testChatID1].Members[crypto.PubkeyToHex(&s.member1.PublicKey)]
 	s.Require().False(ok)
 }
 
@@ -464,7 +463,7 @@ func (s *CommunitySuite) TestValidateRequestToJoin() {
 
 func (s *CommunitySuite) TestCanPostCanView() {
 	chatID := "chat-id"
-	memberKey := common.PubkeyToHex(&s.member1.PublicKey)
+	memberKey := crypto.PubkeyToHex(&s.member1.PublicKey)
 	// Member has no channel role
 	description := &protobuf.CommunityDescription{
 		Members: map[string]*protobuf.CommunityMember{
@@ -827,8 +826,8 @@ func (s *CommunitySuite) emptyCommunityDescriptionWithChat() *protobuf.Community
 
 	desc.Categories[testCategoryID1] = &protobuf.CommunityCategory{CategoryId: testCategoryID1, Name: testCategoryName1, Position: 0}
 	desc.Chats[testChatID1] = &protobuf.CommunityChat{Position: 0, Permissions: &protobuf.CommunityPermissions{}, Members: make(map[string]*protobuf.CommunityMember)}
-	desc.Members[common.PubkeyToHex(&s.member1.PublicKey)] = &protobuf.CommunityMember{}
-	desc.Chats[testChatID1].Members[common.PubkeyToHex(&s.member1.PublicKey)] = &protobuf.CommunityMember{}
+	desc.Members[crypto.PubkeyToHex(&s.member1.PublicKey)] = &protobuf.CommunityMember{}
+	desc.Chats[testChatID1].Members[crypto.PubkeyToHex(&s.member1.PublicKey)] = &protobuf.CommunityMember{}
 
 	return desc
 
@@ -1057,10 +1056,10 @@ func (s *CommunitySuite) TestMarshalJSON() {
 	// returns true if the user is the owner
 
 	communityDescription.Members = make(map[string]*protobuf.CommunityMember)
-	communityDescription.Members[common.PubkeyToHex(&ownerKey.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_OWNER}}
-	communityDescription.Members[common.PubkeyToHex(&memberKey.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_ADMIN}}
+	communityDescription.Members[crypto.PubkeyToHex(&ownerKey.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_OWNER}}
+	communityDescription.Members[crypto.PubkeyToHex(&memberKey.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_ADMIN}}
 	communityDescription.Chats[testChatID1] = &protobuf.CommunityChat{Members: make(map[string]*protobuf.CommunityMember), Identity: &protobuf.ChatIdentity{}}
-	communityDescription.Chats[testChatID1].Members[common.PubkeyToHex(&ownerKey.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_OWNER}}
+	communityDescription.Chats[testChatID1].Members[crypto.PubkeyToHex(&ownerKey.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_OWNER}}
 
 	// Test token gated community
 	s.Require().True(community.ChannelEncrypted(testChatID1))
@@ -1083,7 +1082,7 @@ func (s *CommunitySuite) TestMarshalJSON() {
 		"emoji":                   "",
 		"hideIfPermissionsNotMet": false,
 		"members": map[string]interface{}{
-			common.PubkeyToHex(&ownerKey.PublicKey): map[string]interface{}{
+			crypto.PubkeyToHex(&ownerKey.PublicKey): map[string]interface{}{
 				"roles": []interface{}{float64(1)},
 			},
 		},

--- a/protocol/communities/communnity_privileged_member_sync_msg.go
+++ b/protocol/communities/communnity_privileged_member_sync_msg.go
@@ -7,10 +7,10 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/status-im/status-go/crypto"
 	multiaccountscommon "github.com/status-im/status-go/multiaccounts/common"
 
 	"github.com/status-im/status-go/crypto/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -30,7 +30,7 @@ func (m *Manager) HandleRequestToJoinPrivilegedUserSyncMessage(message *protobuf
 		state = RequestToJoinStateDeclined
 	}
 
-	myPk := common.PubkeyToHex(&m.identity.PublicKey)
+	myPk := crypto.PubkeyToHex(&m.identity.PublicKey)
 
 	requestsToJoin := make([]*RequestToJoin, 0)
 	for signer, requestToJoinProto := range message.RequestToJoin {
@@ -67,7 +67,7 @@ func (m *Manager) HandleRequestToJoinPrivilegedUserSyncMessage(message *protobuf
 
 func (m *Manager) HandleSyncAllRequestToJoinForNewPrivilegedMember(message *protobuf.CommunityPrivilegedUserSyncMessage, community *Community) ([]*RequestToJoin, error) {
 	nonAcceptedRequestsToJoin := []*RequestToJoin{}
-	myPk := common.PubkeyToHex(&m.identity.PublicKey)
+	myPk := crypto.PubkeyToHex(&m.identity.PublicKey)
 
 	for _, syncRequestToJoin := range message.SyncRequestsToJoin {
 		if syncRequestToJoin.PublicKey == myPk {

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -677,7 +677,7 @@ func (m *Manager) validateCommunity(communityToValidateData []communityToValidat
 			continue
 		}
 
-		m.logger.Info("validating community", zap.String("id", types.EncodeHex(community.id)), zap.String("signer", common.PubkeyToHex(signer)))
+		m.logger.Info("validating community", zap.String("id", types.EncodeHex(community.id)), zap.String("signer", crypto.PubkeyToHex(signer)))
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 		defer cancel()
@@ -688,7 +688,7 @@ func (m *Manager) validateCommunity(communityToValidateData []communityToValidat
 			continue
 		}
 
-		ownerPK, err := common.HexToPubkey(owner)
+		ownerPK, err := crypto.HexToPubkey(owner)
 		if err != nil {
 			m.logger.Error("failed to convert pk string to ecdsa", zap.Error(err))
 			continue
@@ -707,7 +707,7 @@ func (m *Manager) validateCommunity(communityToValidateData []communityToValidat
 
 		if response != nil {
 
-			m.logger.Info("community validated", zap.String("id", types.EncodeHex(community.id)), zap.String("signer", common.PubkeyToHex(signer)))
+			m.logger.Info("community validated", zap.String("id", types.EncodeHex(community.id)), zap.String("signer", crypto.PubkeyToHex(signer)))
 			m.publish(&Subscription{TokenCommunityValidated: response})
 			err := m.persistence.DeleteCommunitiesToValidateByCommunityID(community.id)
 			if err != nil {
@@ -855,7 +855,7 @@ func (m *Manager) CreateCommunity(request *requests.CreateCommunity, publish boo
 	}
 
 	description.Members = make(map[string]*protobuf.CommunityMember)
-	description.Members[common.PubkeyToHex(&m.identity.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_OWNER}}
+	description.Members[crypto.PubkeyToHex(&m.identity.PublicKey)] = &protobuf.CommunityMember{Roles: []protobuf.CommunityMember_Roles{protobuf.CommunityMember_ROLE_OWNER}}
 
 	err = ValidateCommunityDescription(description)
 	if err != nil {
@@ -1018,7 +1018,7 @@ func (rmr *reevaluateMembersResult) newPrivilegedRoles() (map[protobuf.Community
 
 	for memberKey, roles := range rmr.membersRoles {
 		if roles.hasChangedToPrivileged() || roles.hasChangedPrivilegedRole() {
-			memberPubKey, err := common.HexToPubkey(memberKey)
+			memberPubKey, err := crypto.HexToPubkey(memberKey)
 			if err != nil {
 				return nil, err
 			}
@@ -1097,12 +1097,12 @@ func (m *Manager) reevaluateMembers(communityID types.HexBytes) (*Community, map
 	}
 
 	for memberKey := range community.Members() {
-		memberPubKey, err := common.HexToPubkey(memberKey)
+		memberPubKey, err := crypto.HexToPubkey(memberKey)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		if memberKey == common.PubkeyToHex(&m.identity.PublicKey) || community.IsMemberOwner(memberPubKey) {
+		if memberKey == crypto.PubkeyToHex(&m.identity.PublicKey) || community.IsMemberOwner(memberPubKey) {
 			continue
 		}
 
@@ -1199,7 +1199,7 @@ func (m *Manager) applyReevaluateMembersResult(communityID types.HexBytes, resul
 
 	// Remove members.
 	for memberKey := range result.membersToRemove {
-		memberPubKey, err := common.HexToPubkey(memberKey)
+		memberPubKey, err := crypto.HexToPubkey(memberKey)
 		if err != nil {
 			return nil, err
 		}
@@ -1211,7 +1211,7 @@ func (m *Manager) applyReevaluateMembersResult(communityID types.HexBytes, resul
 
 	// Ensure members have proper roles.
 	for memberKey, roles := range result.membersRoles {
-		memberPubKey, err := common.HexToPubkey(memberKey)
+		memberPubKey, err := crypto.HexToPubkey(memberKey)
 		if err != nil {
 			return nil, err
 		}
@@ -1238,7 +1238,7 @@ func (m *Manager) applyReevaluateMembersResult(communityID types.HexBytes, resul
 
 	// Remove members from channels.
 	for memberKey, channels := range result.membersToRemoveFromChannels {
-		memberPubKey, err := common.HexToPubkey(memberKey)
+		memberPubKey, err := crypto.HexToPubkey(memberKey)
 		if err != nil {
 			return nil, err
 		}
@@ -1253,7 +1253,7 @@ func (m *Manager) applyReevaluateMembersResult(communityID types.HexBytes, resul
 
 	// Add unprivileged members to channels.
 	for memberKey, channels := range result.membersToAddToChannels {
-		memberPubKey, err := common.HexToPubkey(memberKey)
+		memberPubKey, err := crypto.HexToPubkey(memberKey)
 		if err != nil {
 			return nil, err
 		}
@@ -2118,7 +2118,7 @@ func (m *Manager) GenerateRequestsToJoinForAutoApprovalOnNewOwnership(communityI
 
 func (m *Manager) Queue(signer *ecdsa.PublicKey, community *Community, clock uint64, payload []byte) error {
 
-	m.logger.Info("queuing community", zap.String("id", community.IDString()), zap.String("signer", common.PubkeyToHex(signer)))
+	m.logger.Info("queuing community", zap.String("id", community.IDString()), zap.String("signer", crypto.PubkeyToHex(signer)))
 
 	communityToValidate := communityToValidate{
 		id:         community.ID(),
@@ -2214,7 +2214,7 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 	} else {
 		// only queue if already known control node is different than the signer
 		// and if the clock is greater
-		shouldQueue = shouldQueue && !common.IsPubKeyEqual(community.ControlNode(), signer) &&
+		shouldQueue = shouldQueue && !crypto.IsPubKeyEqual(community.ControlNode(), signer) &&
 			community.config.CommunityDescription.Clock < processedDescription.Clock
 		if shouldQueue {
 			return nil, m.Queue(signer, community, processedDescription.Clock, payload)
@@ -2225,21 +2225,21 @@ func (m *Manager) HandleCommunityDescriptionMessage(signer *ecdsa.PublicKey, des
 		// Override verified owner
 		m.logger.Info("updating verified owner",
 			zap.String("communityID", community.IDString()),
-			zap.String("verifiedOwner", common.PubkeyToHex(verifiedOwner)),
-			zap.String("signer", common.PubkeyToHex(signer)),
-			zap.String("controlNode", common.PubkeyToHex(community.ControlNode())),
+			zap.String("verifiedOwner", crypto.PubkeyToHex(verifiedOwner)),
+			zap.String("signer", crypto.PubkeyToHex(signer)),
+			zap.String("controlNode", crypto.PubkeyToHex(community.ControlNode())),
 		)
 
 		// If we are not the verified owner anymore, drop the private key
-		if !common.IsPubKeyEqual(verifiedOwner, &m.identity.PublicKey) {
+		if !crypto.IsPubKeyEqual(verifiedOwner, &m.identity.PublicKey) {
 			community.config.PrivateKey = nil
 		}
 
 		// new control node will be set in the 'UpdateCommunityDescription'
-		if !common.IsPubKeyEqual(verifiedOwner, signer) {
+		if !crypto.IsPubKeyEqual(verifiedOwner, signer) {
 			return nil, ErrNotAuthorized
 		}
-	} else if !common.IsPubKeyEqual(community.ControlNode(), signer) {
+	} else if !crypto.IsPubKeyEqual(community.ControlNode(), signer) {
 		return nil, ErrNotAuthorized
 	}
 
@@ -2318,7 +2318,7 @@ func (m *Manager) handleCommunityDescriptionMessageCommon(community *Community, 
 		}
 	}
 
-	pkString := common.PubkeyToHex(&m.identity.PublicKey)
+	pkString := crypto.PubkeyToHex(&m.identity.PublicKey)
 	if m.tokenManager != nil && description.CommunityTokensMetadata != nil && len(description.CommunityTokensMetadata) > 0 {
 		for _, tokenMetadata := range description.CommunityTokensMetadata {
 			if tokenMetadata.TokenType != protobuf.CommunityTokenType_ERC20 {
@@ -2543,11 +2543,11 @@ func (m *Manager) saveOrUpdateRequestToJoin(communityID types.HexBytes, requestT
 		// node already knows about this request to join, so let's compare clocks
 		// and update it if necessary
 		if existingRequestToJoin.Clock <= requestToJoin.Clock {
-			pk, err := common.HexToPubkey(existingRequestToJoin.PublicKey)
+			pk, err := crypto.HexToPubkey(existingRequestToJoin.PublicKey)
 			if err != nil {
 				return updated, err
 			}
-			err = m.persistence.SetRequestToJoinState(common.PubkeyToHex(pk), communityID, requestToJoin.State)
+			err = m.persistence.SetRequestToJoinState(crypto.PubkeyToHex(pk), communityID, requestToJoin.State)
 			if err != nil {
 				return updated, err
 			}
@@ -2668,17 +2668,17 @@ func (m *Manager) handleCommunityEventRequestRejected(community *Community, comm
 // if we are members
 func (m *Manager) markRequestToJoinAsAccepted(pk *ecdsa.PublicKey, community *Community) error {
 	if community.HasMember(pk) {
-		return m.persistence.SetRequestToJoinState(common.PubkeyToHex(pk), community.ID(), RequestToJoinStateAccepted)
+		return m.persistence.SetRequestToJoinState(crypto.PubkeyToHex(pk), community.ID(), RequestToJoinStateAccepted)
 	}
 	return nil
 }
 
 func (m *Manager) markRequestToJoinAsCanceled(pk *ecdsa.PublicKey, community *Community) error {
-	return m.persistence.SetRequestToJoinState(common.PubkeyToHex(pk), community.ID(), RequestToJoinStateCanceled)
+	return m.persistence.SetRequestToJoinState(crypto.PubkeyToHex(pk), community.ID(), RequestToJoinStateCanceled)
 }
 
 func (m *Manager) markRequestToJoinAsAcceptedPending(pk *ecdsa.PublicKey, community *Community) error {
-	return m.persistence.SetRequestToJoinState(common.PubkeyToHex(pk), community.ID(), RequestToJoinStateAcceptedPending)
+	return m.persistence.SetRequestToJoinState(crypto.PubkeyToHex(pk), community.ID(), RequestToJoinStateAcceptedPending)
 }
 
 func (m *Manager) DeletePendingRequestToJoin(request *RequestToJoin) error {
@@ -2733,7 +2733,7 @@ func (m *Manager) CancelRequestToJoin(request *requests.CancelRequestToJoinCommu
 		return nil, nil, err
 	}
 
-	pk, err := common.HexToPubkey(dbRequest.PublicKey)
+	pk, err := crypto.HexToPubkey(dbRequest.PublicKey)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2833,7 +2833,7 @@ func (m *Manager) AcceptRequestToJoin(dbRequest *RequestToJoin) (*Community, err
 	m.communityLock.Lock(dbRequest.CommunityID)
 	defer m.communityLock.Unlock(dbRequest.CommunityID)
 
-	pk, err := common.HexToPubkey(dbRequest.PublicKey)
+	pk, err := crypto.HexToPubkey(dbRequest.PublicKey)
 	if err != nil {
 		return nil, err
 	}
@@ -2972,7 +2972,7 @@ func (m *Manager) DeclineRequestToJoin(dbRequest *RequestToJoin) (*Community, er
 }
 
 func (m *Manager) shouldUserRetainDeclined(signer *ecdsa.PublicKey, community *Community, requestClock uint64) (bool, error) {
-	requestID := CalculateRequestID(common.PubkeyToHex(signer), types.HexBytes(community.IDString()))
+	requestID := CalculateRequestID(crypto.PubkeyToHex(signer), types.HexBytes(community.IDString()))
 	request, err := m.persistence.GetRequestToJoin(requestID)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -3015,7 +3015,7 @@ func (m *Manager) HandleCommunityCancelRequestToJoin(signer *ecdsa.PublicKey, re
 		return nil, err
 	}
 
-	requestToJoin, err := m.persistence.GetRequestToJoinByPk(common.PubkeyToHex(signer), community.ID(), RequestToJoinStateCanceled)
+	requestToJoin, err := m.persistence.GetRequestToJoinByPk(crypto.PubkeyToHex(signer), community.ID(), RequestToJoinStateCanceled)
 	if err != nil {
 		return nil, err
 	}
@@ -3055,7 +3055,7 @@ func (m *Manager) HandleCommunityRequestToJoin(signer *ecdsa.PublicKey, receiver
 	}
 
 	requestToJoin := &RequestToJoin{
-		PublicKey:          common.PubkeyToHex(signer),
+		PublicKey:          crypto.PubkeyToHex(signer),
 		Clock:              request.Clock,
 		ENSName:            request.EnsName,
 		CommunityID:        request.CommunityId,
@@ -3183,7 +3183,7 @@ func (m *Manager) HandleCommunityEditSharedAddresses(signer *ecdsa.PublicKey, re
 		return ErrNotOwner
 	}
 
-	publicKey := common.PubkeyToHex(signer)
+	publicKey := crypto.PubkeyToHex(signer)
 
 	if err := community.ValidateEditSharedAddresses(publicKey, request); err != nil {
 		return err
@@ -3227,7 +3227,7 @@ func (m *Manager) HandleCommunityEditSharedAddresses(signer *ecdsa.PublicKey, re
 			Type:        protobuf.CommunityPrivilegedUserSyncMessage_CONTROL_NODE_MEMBER_EDIT_SHARED_ADDRESSES,
 			CommunityId: community.ID(),
 			SyncEditSharedAddresses: &protobuf.SyncCommunityEditSharedAddresses{
-				PublicKey:         common.PubkeyToHex(signer),
+				PublicKey:         crypto.PubkeyToHex(signer),
 				EditSharedAddress: request,
 			},
 		},
@@ -3532,7 +3532,7 @@ func (m *Manager) HandleCommunityRequestToJoinResponse(signer *ecdsa.PublicKey, 
 	m.communityLock.Lock(request.CommunityId)
 	defer m.communityLock.Unlock(request.CommunityId)
 
-	pkString := common.PubkeyToHex(&m.identity.PublicKey)
+	pkString := crypto.PubkeyToHex(&m.identity.PublicKey)
 
 	community, err := m.GetByID(request.CommunityId)
 	if err != nil {
@@ -3562,7 +3562,7 @@ func (m *Manager) HandleCommunityRequestToJoinResponse(signer *ecdsa.PublicKey, 
 }
 
 func (m *Manager) HandleCommunityRequestToLeave(signer *ecdsa.PublicKey, proto *protobuf.CommunityRequestToLeave) error {
-	requestToLeave := NewRequestToLeave(common.PubkeyToHex(signer), proto)
+	requestToLeave := NewRequestToLeave(crypto.PubkeyToHex(signer), proto)
 	if err := m.persistence.SaveRequestToLeave(requestToLeave); err != nil {
 		return err
 	}
@@ -3649,7 +3649,7 @@ func (m *Manager) GetCommunityRequestToJoinClock(pk *ecdsa.PublicKey, communityI
 		return 0, err
 	}
 
-	joinClock, err := m.persistence.GetRequestToJoinClockByPkAndCommunityID(common.PubkeyToHex(pk), communityIDBytes)
+	joinClock, err := m.persistence.GetRequestToJoinClockByPkAndCommunityID(crypto.PubkeyToHex(pk), communityIDBytes)
 
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
@@ -3661,7 +3661,7 @@ func (m *Manager) GetCommunityRequestToJoinClock(pk *ecdsa.PublicKey, communityI
 }
 
 func (m *Manager) GetRequestToJoinByPkAndCommunityID(pk *ecdsa.PublicKey, communityID []byte) (*RequestToJoin, error) {
-	return m.persistence.GetRequestToJoinByPkAndCommunityID(common.PubkeyToHex(pk), communityID)
+	return m.persistence.GetRequestToJoinByPkAndCommunityID(crypto.PubkeyToHex(pk), communityID)
 }
 
 func (m *Manager) UpdateCommunityDescriptionMagnetlinkMessageClock(communityID types.HexBytes, clock uint64) error {
@@ -3785,7 +3785,7 @@ func (m *Manager) UnbanUserFromCommunity(request *requests.UnbanUserFromCommunit
 	defer m.communityLock.Unlock(request.CommunityID)
 
 	id := request.CommunityID
-	publicKey, err := common.HexToPubkey(request.User.String())
+	publicKey, err := crypto.HexToPubkey(request.User.String())
 	if err != nil {
 		return nil, err
 	}
@@ -3813,7 +3813,7 @@ func (m *Manager) AddRoleToMember(request *requests.AddRoleToMember) (*Community
 	defer m.communityLock.Unlock(request.CommunityID)
 
 	id := request.CommunityID
-	publicKey, err := common.HexToPubkey(request.User.String())
+	publicKey, err := crypto.HexToPubkey(request.User.String())
 	if err != nil {
 		return nil, err
 	}
@@ -3847,7 +3847,7 @@ func (m *Manager) RemoveRoleFromMember(request *requests.RemoveRoleFromMember) (
 	defer m.communityLock.Unlock(request.CommunityID)
 
 	id := request.CommunityID
-	publicKey, err := common.HexToPubkey(request.User.String())
+	publicKey, err := crypto.HexToPubkey(request.User.String())
 	if err != nil {
 		return nil, err
 	}
@@ -3882,7 +3882,7 @@ func (m *Manager) BanUserFromCommunity(request *requests.BanUserFromCommunity) (
 
 	id := request.CommunityID
 
-	publicKey, err := common.HexToPubkey(request.User.String())
+	publicKey, err := crypto.HexToPubkey(request.User.String())
 	if err != nil {
 		return nil, err
 	}
@@ -4035,7 +4035,7 @@ func (m *Manager) SaveRequestToJoinAndCommunity(requestToJoin *RequestToJoin, co
 func (m *Manager) CreateRequestToJoin(request *requests.RequestToJoinCommunity, customizationColor multiaccountscommon.CustomizationColor) *RequestToJoin {
 	clock := uint64(time.Now().Unix())
 	requestToJoin := &RequestToJoin{
-		PublicKey:            common.PubkeyToHex(&m.identity.PublicKey),
+		PublicKey:            crypto.PubkeyToHex(&m.identity.PublicKey),
 		Clock:                clock,
 		ENSName:              request.ENSName,
 		CommunityID:          request.CommunityID,
@@ -4070,7 +4070,7 @@ func (m *Manager) SaveRequestToJoin(request *RequestToJoin) error {
 }
 
 func (m *Manager) CanceledRequestsToJoinForUser(pk *ecdsa.PublicKey) ([]*RequestToJoin, error) {
-	return m.persistence.CanceledRequestsToJoinForUser(common.PubkeyToHex(pk))
+	return m.persistence.CanceledRequestsToJoinForUser(crypto.PubkeyToHex(pk))
 }
 
 func (m *Manager) PendingRequestsToJoin() ([]*RequestToJoin, error) {
@@ -4078,7 +4078,7 @@ func (m *Manager) PendingRequestsToJoin() ([]*RequestToJoin, error) {
 }
 
 func (m *Manager) PendingRequestsToJoinForUser(pk *ecdsa.PublicKey) ([]*RequestToJoin, error) {
-	return m.persistence.RequestsToJoinForUserByState(common.PubkeyToHex(pk), RequestToJoinStatePending)
+	return m.persistence.RequestsToJoinForUserByState(crypto.PubkeyToHex(pk), RequestToJoinStatePending)
 }
 
 func (m *Manager) PendingRequestsToJoinForCommunity(id types.HexBytes) ([]*RequestToJoin, error) {
@@ -4748,7 +4748,7 @@ func (m *Manager) RemoveUsersWithoutRevealedAccounts(community *Community, clock
 		return nil, err
 	}
 
-	myPk := common.PubkeyToHex(&m.identity.PublicKey)
+	myPk := crypto.PubkeyToHex(&m.identity.PublicKey)
 	membersToRemove := []string{}
 	for pk := range community.Members() {
 		if myPk == pk {
@@ -4964,7 +4964,7 @@ func (m *Manager) ShareRequestsToJoinWithPrivilegedMembers(community *Community,
 }
 
 func (m *Manager) shareAcceptedRequestToJoinWithPrivilegedMembers(community *Community, requestToJoin *RequestToJoin) error {
-	pk, err := common.HexToPubkey(requestToJoin.PublicKey)
+	pk, err := crypto.HexToPubkey(requestToJoin.PublicKey)
 	if err != nil {
 		return err
 	}
@@ -4994,8 +4994,8 @@ func (m *Manager) shareAcceptedRequestToJoinWithPrivilegedMembers(community *Com
 
 	// do not sent to ourself and to the accepted user
 	skipMembers := make(map[string]struct{})
-	skipMembers[common.PubkeyToHex(&m.identity.PublicKey)] = struct{}{}
-	skipMembers[common.PubkeyToHex(pk)] = struct{}{}
+	skipMembers[crypto.PubkeyToHex(&m.identity.PublicKey)] = struct{}{}
+	skipMembers[crypto.PubkeyToHex(pk)] = struct{}{}
 
 	subscriptionMsg := &CommunityPrivilegedMemberSyncMessage{}
 

--- a/protocol/communities/manager_archive_file.go
+++ b/protocol/communities/manager_archive_file.go
@@ -20,7 +20,6 @@ import (
 	"github.com/status-im/status-go/messaging"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/signal"
 
@@ -265,7 +264,7 @@ func (m *ArchiveFileManager) createHistoryArchiveTorrent(communityID types.HexBy
 			AnnounceList: defaultAnnounceList,
 		}
 		metaInfo.SetDefaults()
-		metaInfo.CreatedBy = common.PubkeyToHex(&m.identity.PublicKey)
+		metaInfo.CreatedBy = crypto.PubkeyToHex(&m.identity.PublicKey)
 
 		info := metainfo.Info{
 			PieceLength: int64(pieceLength),

--- a/protocol/communities/manager_test.go
+++ b/protocol/communities/manager_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/status-im/status-go/messaging"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
 	"github.com/status-im/status-go/params"
-	"github.com/status-im/status-go/protocol/common"
 	community_token "github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
@@ -1712,7 +1711,7 @@ func (s *ManagerSuite) TestCommunityQueue() {
 
 	// set verifier public key
 	verifier.ownersMap = make(map[string]string)
-	verifier.ownersMap[community.IDString()] = common.PubkeyToHex(&owner.PublicKey)
+	verifier.ownersMap[community.IDString()] = crypto.PubkeyToHex(&owner.PublicKey)
 
 	description := community.config.CommunityDescription
 
@@ -1803,7 +1802,7 @@ func (s *ManagerSuite) TestCommunityQueueMultipleDifferentSigners() {
 
 	// set verifier public key
 	verifier.ownersMap = make(map[string]string)
-	verifier.ownersMap[community.IDString()] = common.PubkeyToHex(&newOwner.PublicKey)
+	verifier.ownersMap[community.IDString()] = crypto.PubkeyToHex(&newOwner.PublicKey)
 
 	description := community.config.CommunityDescription
 
@@ -1932,7 +1931,7 @@ func (s *ManagerSuite) TestCommunityQueueMultipleDifferentSignersIgnoreIfNotRetu
 
 	// set verifier public key
 	verifier.ownersMap = make(map[string]string)
-	verifier.ownersMap[community.IDString()] = common.PubkeyToHex(&oldOwner.PublicKey)
+	verifier.ownersMap[community.IDString()] = crypto.PubkeyToHex(&oldOwner.PublicKey)
 
 	description := community.config.CommunityDescription
 
@@ -2089,7 +2088,7 @@ func (s *ManagerSuite) TestDetermineChannelsForHRKeysRequest() {
 
 	channel := &protobuf.CommunityChat{
 		Members: map[string]*protobuf.CommunityMember{
-			common.PubkeyToHex(&s.manager.identity.PublicKey): {},
+			crypto.PubkeyToHex(&s.manager.identity.PublicKey): {},
 		},
 	}
 

--- a/protocol/communities/persistence.go
+++ b/protocol/communities/persistence.go
@@ -16,7 +16,6 @@ import (
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/services/wallet/bigint"
@@ -266,7 +265,7 @@ func (p *Persistence) ShouldHandleSyncCommunity(community *protobuf.SyncInstalla
 }
 
 func (p *Persistence) queryCommunities(memberIdentity *ecdsa.PublicKey, query string) (response []*Community, err error) {
-	rows, err := p.db.Query(query, common.PubkeyToHex(memberIdentity))
+	rows, err := p.db.Query(query, crypto.PubkeyToHex(memberIdentity))
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +340,7 @@ func (p *Persistence) rowsToCommunities(rows *sql.Rows) (comms []*Community, err
 func (p *Persistence) JoinedAndPendingCommunitiesWithRequests(memberIdentity *ecdsa.PublicKey) (comms []*Community, err error) {
 	query := communitiesBaseQuery + ` WHERE c.Joined OR r.state = ?`
 
-	rows, err := p.db.Query(query, common.PubkeyToHex(memberIdentity), RequestToJoinStatePending)
+	rows, err := p.db.Query(query, crypto.PubkeyToHex(memberIdentity), RequestToJoinStatePending)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +351,7 @@ func (p *Persistence) JoinedAndPendingCommunitiesWithRequests(memberIdentity *ec
 func (p *Persistence) DeletedCommunities(memberIdentity *ecdsa.PublicKey) (comms []*Community, err error) {
 	query := communitiesBaseQuery + ` WHERE NOT c.Joined AND r.state != ?`
 
-	rows, err := p.db.Query(query, common.PubkeyToHex(memberIdentity), RequestToJoinStatePending)
+	rows, err := p.db.Query(query, crypto.PubkeyToHex(memberIdentity), RequestToJoinStatePending)
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +365,7 @@ func (p *Persistence) CommunitiesWithPrivateKey(memberIdentity *ecdsa.PublicKey)
 }
 
 func (p *Persistence) getByID(id []byte, memberIdentity *ecdsa.PublicKey) (*CommunityRecordBundle, error) {
-	r, err := scanCommunity(p.db.QueryRow(communitiesBaseQuery+` WHERE c.id = ?`, common.PubkeyToHex(memberIdentity), id).Scan)
+	r, err := scanCommunity(p.db.QueryRow(communitiesBaseQuery+` WHERE c.id = ?`, crypto.PubkeyToHex(memberIdentity), id).Scan)
 	return r, err
 }
 

--- a/protocol/communities/persistence_test.go
+++ b/protocol/communities/persistence_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/sqlite"
@@ -236,7 +235,7 @@ func (s *PersistenceSuite) TestJoinedAndPendingCommunitiesWithRequests() {
 
 	rtj := &RequestToJoin{
 		ID:          types.HexBytes{1, 2, 3, 4, 5, 6, 7, 8},
-		PublicKey:   common.PubkeyToHex(&s.identity.PublicKey),
+		PublicKey:   crypto.PubkeyToHex(&s.identity.PublicKey),
 		Clock:       clock,
 		CommunityID: com2.ID(),
 		State:       RequestToJoinStatePending,
@@ -558,7 +557,7 @@ func (s *PersistenceSuite) TestGetCommunityRequestsToJoinWithRevealedAddresses()
 	// RTJ with 2 revealed Addresses
 	expectedRtj1 := &RequestToJoin{
 		ID:          types.HexBytes{1, 2, 3, 4, 5, 6, 7, 8},
-		PublicKey:   common.PubkeyToHex(&s.identity.PublicKey),
+		PublicKey:   crypto.PubkeyToHex(&s.identity.PublicKey),
 		Clock:       clock,
 		CommunityID: communityID,
 		State:       RequestToJoinStateAccepted,
@@ -594,7 +593,7 @@ func (s *PersistenceSuite) TestGetCommunityRequestsToJoinWithRevealedAddresses()
 	signature := []byte("test")
 	expectedRtj2 := &RequestToJoin{
 		ID:          types.HexBytes{8, 7, 6, 5, 4, 3, 2, 1},
-		PublicKey:   common.PubkeyToHex(&s.identity.PublicKey),
+		PublicKey:   crypto.PubkeyToHex(&s.identity.PublicKey),
 		Clock:       clock,
 		CommunityID: communityID,
 		State:       RequestToJoinStateAccepted,
@@ -626,7 +625,7 @@ func (s *PersistenceSuite) TestGetCommunityRequestsToJoinWithRevealedAddresses()
 	// RTJ without RevealedAccounts
 	expectedRtjWithoutRevealedAccounts := &RequestToJoin{
 		ID:          types.HexBytes{1, 6, 6, 6, 6, 6, 6, 6},
-		PublicKey:   common.PubkeyToHex(&s.identity.PublicKey),
+		PublicKey:   crypto.PubkeyToHex(&s.identity.PublicKey),
 		Clock:       clock,
 		CommunityID: communityID,
 		State:       RequestToJoinStateAccepted,
@@ -643,7 +642,7 @@ func (s *PersistenceSuite) TestGetCommunityRequestsToJoinWithRevealedAddresses()
 	// RTJ with RevealedAccount but with empty Address
 	expectedRtjWithEmptyAddress := &RequestToJoin{
 		ID:          types.HexBytes{2, 6, 6, 6, 6, 6, 6, 6},
-		PublicKey:   common.PubkeyToHex(&s.identity.PublicKey),
+		PublicKey:   crypto.PubkeyToHex(&s.identity.PublicKey),
 		Clock:       clock,
 		CommunityID: communityID,
 		State:       RequestToJoinStateAccepted,
@@ -698,7 +697,7 @@ func (s *PersistenceSuite) TestGetCommunityRequestToJoinWithRevealedAddresses() 
 	communityID := types.HexBytes{7, 7, 7, 7, 7, 7, 7, 7}
 	revealedAddresses := []string{"address1", "address2", "address3"}
 	chainIds := []uint64{1, 2}
-	publicKey := common.PubkeyToHex(&s.identity.PublicKey)
+	publicKey := crypto.PubkeyToHex(&s.identity.PublicKey)
 	signature := []byte("test")
 
 	// No data in database
@@ -775,7 +774,7 @@ func (s *PersistenceSuite) TestAllNonApprovedCommunitiesRequestsToJoin() {
 
 		rtj := &RequestToJoin{
 			ID:          types.HexBytes{1, 2, 3, 4, 5, 6, 7, byte(i)},
-			PublicKey:   common.PubkeyToHex(&identity.PublicKey),
+			PublicKey:   crypto.PubkeyToHex(&identity.PublicKey),
 			Clock:       clock,
 			CommunityID: community.ID(),
 			State:       allStates[i],
@@ -981,7 +980,7 @@ func (s *PersistenceSuite) TestGetCommunityRequestsToJoinRevealedAddresses() {
 	communityID := types.HexBytes{7, 7, 7, 7, 7, 7, 7, 7}
 	revealedAddress := "address1"
 	chainIds := []uint64{1, 2}
-	publicKey := common.PubkeyToHex(&s.identity.PublicKey)
+	publicKey := crypto.PubkeyToHex(&s.identity.PublicKey)
 	signature := []byte("test")
 
 	// No data in database

--- a/protocol/communities_events_owner_without_community_key_test.go
+++ b/protocol/communities_events_owner_without_community_key_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -120,7 +120,7 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerKickControlNode(
 
 func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerKickMember() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_OWNER)
-	kickMember(s, community.ID(), common.PubkeyToHex(&s.alice.identity.PublicKey))
+	kickMember(s, community.ID(), crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 }
 
 func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerBanOwnerWithoutCommunityKey() {

--- a/protocol/communities_events_token_master_test.go
+++ b/protocol/communities_events_token_master_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/status-im/status-go/protocol/common"
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -139,7 +139,7 @@ func (s *TokenMasterCommunityEventsSuite) TestTokenMasterKickControlNode() {
 
 func (s *TokenMasterCommunityEventsSuite) TestTokenMasterKickMember() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER)
-	kickMember(s, community.ID(), common.PubkeyToHex(&s.alice.identity.PublicKey))
+	kickMember(s, community.ID(), crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 }
 
 func (s *TokenMasterCommunityEventsSuite) TestTokenMasterBanOwnerWithoutCommunityKey() {

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -11,6 +11,7 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	hexutil "github.com/ethereum/go-ethereum/common/hexutil"
 
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
@@ -788,7 +789,7 @@ func banMember(base CommunityEventsTestsInterface, banRequest *requests.BanUserF
 }
 
 func unbanMember(base CommunityEventsTestsInterface, unbanRequest *requests.UnbanUserFromCommunity) {
-	pubkey := common.PubkeyToHex(&base.GetMember().identity.PublicKey)
+	pubkey := crypto.PubkeyToHex(&base.GetMember().identity.PublicKey)
 
 	checkUnbanned := func(response *MessengerResponse) error {
 		modifiedCommmunity, err := getModifiedCommunity(response, types.EncodeHex(unbanRequest.CommunityID))
@@ -1044,7 +1045,7 @@ func testCreateEditDeleteBecomeMemberPermission(base CommunityEventsTestsInterfa
 // To be removed in https://github.com/status-im/status-go/issues/4437
 func advertiseCommunityToUserOldWay(s *suite.Suite, community *communities.Community, owner *Messenger, user *Messenger) {
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&user.identity.PublicKey), &user.identity.PublicKey, user.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&user.identity.PublicKey), &user.identity.PublicKey, user.getTimesource())
 
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID
@@ -1117,7 +1118,7 @@ func testAcceptMemberRequestToJoin(base CommunityEventsTestsInterface, community
 	acceptedRequestsPending, err := base.GetEventSender().AcceptedPendingRequestsToJoinForCommunity(community.ID())
 	s.Require().NoError(err)
 	s.Require().Len(acceptedRequestsPending, 1)
-	s.Require().Equal(acceptedRequestsPending[0].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(acceptedRequestsPending[0].PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 
 	// control node receives community event with accepted membership request
 	_, err = WaitOnMessengerResponse(
@@ -1134,7 +1135,7 @@ func testAcceptMemberRequestToJoin(base CommunityEventsTestsInterface, community
 	s.Require().NoError(err)
 	// we expect 3 here (1 event senders, 1 member + 1 from user)
 	s.Require().Len(acceptedRequests, 3)
-	s.Require().Equal(acceptedRequests[2].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(acceptedRequests[2].PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 
 	// user receives updated community
 	_, err = WaitOnMessengerResponse(
@@ -1161,7 +1162,7 @@ func testAcceptMemberRequestToJoin(base CommunityEventsTestsInterface, community
 		base.GetEventSender(),
 		func(r *MessengerResponse) bool {
 			acceptedRequests, err := base.GetEventSender().AcceptedRequestsToJoinForCommunity(community.ID())
-			return err == nil && len(acceptedRequests) == 2 && (acceptedRequests[1].PublicKey == common.PubkeyToHex(&user.identity.PublicKey))
+			return err == nil && len(acceptedRequests) == 2 && (acceptedRequests[1].PublicKey == crypto.PubkeyToHex(&user.identity.PublicKey))
 		},
 		"no updates from control node",
 	)
@@ -1226,7 +1227,7 @@ func testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(base Commu
 	acceptedPendingRequests, err := additionalEventSender.AcceptedPendingRequestsToJoinForCommunity(community.ID())
 	s.Require().NoError(err)
 	s.Require().Len(acceptedPendingRequests, 1)
-	s.Require().Equal(acceptedPendingRequests[0].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(acceptedPendingRequests[0].PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 
 	// event sender 1 changes its mind and rejects the request
 	rejectRequestToJoin := &requests.DeclineRequestToJoinCommunity{ID: requestID}
@@ -1246,7 +1247,7 @@ func testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(base Commu
 	rejectedPendingRequests, err := additionalEventSender.DeclinedPendingRequestsToJoinForCommunity(community.ID())
 	s.Require().NoError(err)
 	s.Require().Len(rejectedPendingRequests, 1)
-	s.Require().Equal(rejectedPendingRequests[0].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(rejectedPendingRequests[0].PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 }
 
 func testRejectMemberRequestToJoinResponseSharedWithOtherEventSenders(base CommunityEventsTestsInterface, community *communities.Community, user *Messenger, additionalEventSender *Messenger) {
@@ -1301,7 +1302,7 @@ func testRejectMemberRequestToJoinResponseSharedWithOtherEventSenders(base Commu
 	rejectedPendingRequests, err := additionalEventSender.DeclinedPendingRequestsToJoinForCommunity(community.ID())
 	s.Require().NoError(err)
 	s.Require().Len(rejectedPendingRequests, 1)
-	s.Require().Equal(rejectedPendingRequests[0].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(rejectedPendingRequests[0].PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 
 	// event sender 1 changes its mind and accepts the request
 	acceptRequestToJoin := &requests.AcceptRequestToJoinCommunity{ID: requestID}
@@ -1322,7 +1323,7 @@ func testRejectMemberRequestToJoinResponseSharedWithOtherEventSenders(base Commu
 	acceptedPendingRequests, err := additionalEventSender.AcceptedPendingRequestsToJoinForCommunity(community.ID())
 	s.Require().NoError(err)
 	s.Require().Len(acceptedPendingRequests, 1)
-	s.Require().Equal(acceptedPendingRequests[0].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(acceptedPendingRequests[0].PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 }
 
 func testRejectMemberRequestToJoin(base CommunityEventsTestsInterface, community *communities.Community, user *Messenger) {
@@ -1468,7 +1469,7 @@ func testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(base Commun
 			return errors.New("rejected requests should be 1")
 		}
 
-		if rejectedRequests[0].PublicKey != common.PubkeyToHex(&user.identity.PublicKey) {
+		if rejectedRequests[0].PublicKey != crypto.PubkeyToHex(&user.identity.PublicKey) {
 			return errors.New("public key of rejected request not matching")
 		}
 
@@ -1504,7 +1505,7 @@ func testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(base Commun
 			return errors.New("rejected requests should be 1")
 		}
 		// we expect user's request to join still to be rejected
-		if rejectedRequests[0].PublicKey != common.PubkeyToHex(&user.identity.PublicKey) {
+		if rejectedRequests[0].PublicKey != crypto.PubkeyToHex(&user.identity.PublicKey) {
 			return errors.New("public key of rejected request not matching")
 		}
 		return nil
@@ -1581,7 +1582,7 @@ func testEventSenderKickTheSameRole(base CommunityEventsTestsInterface, communit
 	// event sender tries to kick the member with the same role
 	_, err := base.GetEventSender().RemoveUserFromCommunity(
 		community.ID(),
-		common.PubkeyToHex(&base.GetEventSender().identity.PublicKey),
+		crypto.PubkeyToHex(&base.GetEventSender().identity.PublicKey),
 	)
 
 	s := base.GetSuite()
@@ -1593,7 +1594,7 @@ func testEventSenderKickControlNode(base CommunityEventsTestsInterface, communit
 	// event sender tries to kick the control node
 	_, err := base.GetEventSender().RemoveUserFromCommunity(
 		community.ID(),
-		common.PubkeyToHex(&base.GetControlNode().identity.PublicKey),
+		crypto.PubkeyToHex(&base.GetControlNode().identity.PublicKey),
 	)
 
 	s := base.GetSuite()
@@ -1606,7 +1607,7 @@ func testOwnerBanTheSameRole(base CommunityEventsTestsInterface, community *comm
 		context.Background(),
 		&requests.BanUserFromCommunity{
 			CommunityID: community.ID(),
-			User:        common.PubkeyToHexBytes(&base.GetEventSender().identity.PublicKey),
+			User:        crypto.PubkeyToHexBytes(&base.GetEventSender().identity.PublicKey),
 		},
 	)
 
@@ -1620,7 +1621,7 @@ func testOwnerBanControlNode(base CommunityEventsTestsInterface, community *comm
 		context.Background(),
 		&requests.BanUserFromCommunity{
 			CommunityID: community.ID(),
-			User:        common.PubkeyToHexBytes(&base.GetControlNode().identity.PublicKey),
+			User:        crypto.PubkeyToHexBytes(&base.GetControlNode().identity.PublicKey),
 		},
 	)
 
@@ -1635,7 +1636,7 @@ func testBanUnbanMember(base CommunityEventsTestsInterface, community *communiti
 		context.Background(),
 		&requests.BanUserFromCommunity{
 			CommunityID: community.ID(),
-			User:        common.PubkeyToHexBytes(&base.GetControlNode().identity.PublicKey),
+			User:        crypto.PubkeyToHexBytes(&base.GetControlNode().identity.PublicKey),
 		},
 	)
 	s := base.GetSuite()
@@ -1643,14 +1644,14 @@ func testBanUnbanMember(base CommunityEventsTestsInterface, community *communiti
 
 	banRequest := &requests.BanUserFromCommunity{
 		CommunityID: community.ID(),
-		User:        common.PubkeyToHexBytes(&base.GetMember().identity.PublicKey),
+		User:        crypto.PubkeyToHexBytes(&base.GetMember().identity.PublicKey),
 	}
 
 	banMember(base, banRequest)
 
 	unbanRequest := &requests.UnbanUserFromCommunity{
 		CommunityID: community.ID(),
-		User:        common.PubkeyToHexBytes(&base.GetMember().identity.PublicKey),
+		User:        crypto.PubkeyToHexBytes(&base.GetMember().identity.PublicKey),
 	}
 
 	unbanMember(base, unbanRequest)
@@ -2160,7 +2161,7 @@ func waitAndCheckRequestsToJoin(s *suite.Suite, user *Messenger, expectedLength 
 			}
 
 			for _, request := range requestsToJoin {
-				if request.PublicKey == common.PubkeyToHex(&user.identity.PublicKey) {
+				if request.PublicKey == crypto.PubkeyToHex(&user.identity.PublicKey) {
 					if len(request.RevealedAccounts) != 1 {
 						s.T().Log("our own requests to join must always have accounts revealed")
 						return false
@@ -2241,7 +2242,7 @@ func testPrivilegedMemberAcceptsRequestToJoinAfterMemberLeave(base CommunityEven
 	acceptedRequestsPending, err := base.GetEventSender().AcceptedPendingRequestsToJoinForCommunity(community.ID())
 	s.Require().NoError(err)
 	s.Require().Len(acceptedRequestsPending, 1)
-	s.Require().Equal(acceptedRequestsPending[0].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(acceptedRequestsPending[0].PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 
 	// control node receives community event with accepted membership request
 	_, err = WaitOnMessengerResponse(
@@ -2258,7 +2259,7 @@ func testPrivilegedMemberAcceptsRequestToJoinAfterMemberLeave(base CommunityEven
 	s.Require().NoError(err)
 	// we expect 3 here (1 event senders, 1 member + 1 from user)
 	s.Require().Len(acceptedRequests, 3)
-	s.Require().Equal(acceptedRequests[2].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(acceptedRequests[2].PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 
 	// user receives updated community
 	_, err = WaitOnMessengerResponse(
@@ -2285,7 +2286,7 @@ func testPrivilegedMemberAcceptsRequestToJoinAfterMemberLeave(base CommunityEven
 		base.GetEventSender(),
 		func(r *MessengerResponse) bool {
 			acceptedRequests, err := base.GetEventSender().AcceptedRequestsToJoinForCommunity(community.ID())
-			return err == nil && len(acceptedRequests) == 2 && (acceptedRequests[1].PublicKey == common.PubkeyToHex(&user.identity.PublicKey))
+			return err == nil && len(acceptedRequests) == 2 && (acceptedRequests[1].PublicKey == crypto.PubkeyToHex(&user.identity.PublicKey))
 		},
 		"no updates from control node",
 	)
@@ -2357,7 +2358,7 @@ func testPrivilegedMemberAcceptsRequestToJoinAfterMemberLeave(base CommunityEven
 	acceptedRequestsPending, err = base.GetEventSender().AcceptedPendingRequestsToJoinForCommunity(community.ID())
 	s.Require().NoError(err)
 	s.Require().Len(acceptedRequestsPending, 1)
-	s.Require().Equal(acceptedRequestsPending[0].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(acceptedRequestsPending[0].PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 
 	// control node receives community event with accepted membership request
 	_, err = WaitOnMessengerResponse(
@@ -2374,7 +2375,7 @@ func testPrivilegedMemberAcceptsRequestToJoinAfterMemberLeave(base CommunityEven
 	s.Require().NoError(err)
 	// we expect 3 here (1 event senders, 1 member + 1 from user)
 	s.Require().Len(acceptedRequests, 3)
-	s.Require().Equal(acceptedRequests[2].PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(acceptedRequests[2].PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 
 	// user receives updated community
 	_, err = WaitOnMessengerResponse(
@@ -2401,7 +2402,7 @@ func testPrivilegedMemberAcceptsRequestToJoinAfterMemberLeave(base CommunityEven
 		base.GetEventSender(),
 		func(r *MessengerResponse) bool {
 			acceptedRequests, err := base.GetEventSender().AcceptedRequestsToJoinForCommunity(community.ID())
-			return err == nil && len(acceptedRequests) == 2 && (acceptedRequests[1].PublicKey == common.PubkeyToHex(&user.identity.PublicKey))
+			return err == nil && len(acceptedRequests) == 2 && (acceptedRequests[1].PublicKey == crypto.PubkeyToHex(&user.identity.PublicKey))
 		},
 		"no updates from control node",
 	)
@@ -2417,7 +2418,7 @@ func testBanMemberWithDeletingAllMessages(base CommunityEventsTestsInterface, co
 	// verify that event sender can't ban a control node and delete his messages
 	banRequest := &requests.BanUserFromCommunity{
 		CommunityID:       community.ID(),
-		User:              common.PubkeyToHexBytes(&base.GetControlNode().identity.PublicKey),
+		User:              crypto.PubkeyToHexBytes(&base.GetControlNode().identity.PublicKey),
 		DeleteAllMessages: true,
 	}
 
@@ -2458,7 +2459,7 @@ func testBanMemberWithDeletingAllMessages(base CommunityEventsTestsInterface, co
 
 	waitOnMessengerResponse(s, checkMsgDelivered, base.GetEventSender())
 
-	banRequest.User = common.PubkeyToHexBytes(&base.GetMember().identity.PublicKey)
+	banRequest.User = crypto.PubkeyToHexBytes(&base.GetMember().identity.PublicKey)
 
 	banMember(base, banRequest)
 }

--- a/protocol/communities_key_distributor.go
+++ b/protocol/communities_key_distributor.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"crypto/ecdsa"
 
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/messaging"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -57,7 +57,7 @@ func (ckd *CommunitiesKeyDistributorImpl) distributeKey(community *communities.C
 	pubkeys := make([]*ecdsa.PublicKey, len(keyAction.Members))
 	i := 0
 	for hex := range keyAction.Members {
-		pubkeys[i], _ = common.HexToPubkey(hex)
+		pubkeys[i], _ = crypto.HexToPubkey(hex)
 		i++
 	}
 

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/status-im/status-go/crypto"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -233,7 +232,7 @@ func (s *AdminCommunityEventsSuite) TestOwnerKickControlNode() {
 
 func (s *AdminCommunityEventsSuite) TestAdminKickMember() {
 	community := setUpCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN)
-	kickMember(s, community.ID(), common.PubkeyToHex(&s.alice.identity.PublicKey))
+	kickMember(s, community.ID(), crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 }
 
 func (s *AdminCommunityEventsSuite) TestAdminBanAdmin() {

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/status-im/status-go/accounts-management/generator"
 	accsmanagementtypes "github.com/status-im/status-go/accounts-management/types"
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
 	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/multiaccounts/accounts"
@@ -467,7 +468,7 @@ func createRequestToJoinCommunity(s *suite.Suite, communityID types.HexBytes, us
 		AirdropAddress:    airdropAddress}
 
 	if password != "" {
-		signingParams, err := user.GenerateJoiningCommunityRequestsForSigning(common.PubkeyToHex(&user.identity.PublicKey), communityID, request.AddressesToReveal)
+		signingParams, err := user.GenerateJoiningCommunityRequestsForSigning(crypto.PubkeyToHex(&user.identity.PublicKey), communityID, request.AddressesToReveal)
 		s.Require().NoError(err)
 
 		for i := range signingParams {
@@ -527,7 +528,7 @@ func requestToJoinCommunity(s *suite.Suite, controlNode *Messenger, user *Messen
 	s.Require().Len(response.RequestsToJoinCommunity(), 1)
 
 	requestToJoin := response.RequestsToJoinCommunity()[0]
-	s.Require().Equal(requestToJoin.PublicKey, common.PubkeyToHex(&user.identity.PublicKey))
+	s.Require().Equal(requestToJoin.PublicKey, crypto.PubkeyToHex(&user.identity.PublicKey))
 
 	_, err = WaitOnMessengerResponse(
 		controlNode,
@@ -601,7 +602,7 @@ func sendChatMessage(s *suite.Suite, sender *Messenger, chatID string, text stri
 func grantPermission(s *suite.Suite, community *communities.Community, controlNode *Messenger, target *Messenger, role protobuf.CommunityMember_Roles) {
 	responseAddRole, err := controlNode.AddRoleToMember(&requests.AddRoleToMember{
 		CommunityID: community.ID(),
-		User:        common.PubkeyToHexBytes(target.IdentityPublicKey()),
+		User:        crypto.PubkeyToHexBytes(target.IdentityPublicKey()),
 		Role:        role,
 	})
 	s.Require().NoError(err)

--- a/protocol/communities_messenger_shared_member_address_test.go
+++ b/protocol/communities_messenger_shared_member_address_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
@@ -122,7 +121,7 @@ func createTokenMasterTokenCriteria() *protobuf.TokenCriteria {
 func (s *MessengerCommunitiesSharedMemberAddressSuite) createEditSharedAddressesRequest(communityID types.HexBytes) *requests.EditSharedAddresses {
 	request := &requests.EditSharedAddresses{CommunityID: communityID, AddressesToReveal: []string{aliceAddress2}, AirdropAddress: aliceAddress2}
 
-	signingParams, err := s.alice.GenerateJoiningCommunityRequestsForSigning(common.PubkeyToHex(&s.alice.identity.PublicKey), communityID, request.AddressesToReveal)
+	signingParams, err := s.alice.GenerateJoiningCommunityRequestsForSigning(crypto.PubkeyToHex(&s.alice.identity.PublicKey), communityID, request.AddressesToReveal)
 	s.Require().NoError(err)
 
 	passwdHash := types.EncodeHex(crypto.Keccak256([]byte(alicePassword)))
@@ -215,16 +214,16 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) TestJoinedCommunityMember
 
 	// Check owner's DB for revealed accounts
 	for pubKey := range community.Members() {
-		if pubKey != common.PubkeyToHex(&s.owner.identity.PublicKey) {
+		if pubKey != crypto.PubkeyToHex(&s.owner.identity.PublicKey) {
 			revealedAccounts, err := s.owner.communitiesManager.GetRevealedAddresses(community.ID(), pubKey)
 			s.Require().NoError(err)
 			switch pubKey {
-			case common.PubkeyToHex(&s.alice.identity.PublicKey):
+			case crypto.PubkeyToHex(&s.alice.identity.PublicKey):
 				s.Require().Len(revealedAccounts, 2)
 				s.Require().Equal(revealedAccounts[0].Address, aliceAddress1)
 				s.Require().Equal(revealedAccounts[1].Address, aliceAddress2)
 				s.Require().Equal(true, revealedAccounts[0].IsAirdropAddress)
-			case common.PubkeyToHex(&s.bob.identity.PublicKey):
+			case crypto.PubkeyToHex(&s.bob.identity.PublicKey):
 				s.Require().Len(revealedAccounts, 1)
 				s.Require().Equal(revealedAccounts[0].Address, bobAddress)
 				s.Require().Equal(true, revealedAccounts[0].IsAirdropAddress)
@@ -235,14 +234,14 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) TestJoinedCommunityMember
 	}
 
 	// Check Bob's DB for revealed accounts
-	revealedAccountsInBobsDB, err := s.bob.communitiesManager.GetRevealedAddresses(community.ID(), common.PubkeyToHex(&s.bob.identity.PublicKey))
+	revealedAccountsInBobsDB, err := s.bob.communitiesManager.GetRevealedAddresses(community.ID(), crypto.PubkeyToHex(&s.bob.identity.PublicKey))
 	s.Require().NoError(err)
 	s.Require().Len(revealedAccountsInBobsDB, 1)
 	s.Require().Equal(revealedAccountsInBobsDB[0].Address, bobAddress)
 	s.Require().Equal(true, revealedAccountsInBobsDB[0].IsAirdropAddress)
 
 	// Check Alices's DB for revealed accounts
-	revealedAccountsInAlicesDB, err := s.alice.communitiesManager.GetRevealedAddresses(community.ID(), common.PubkeyToHex(&s.alice.identity.PublicKey))
+	revealedAccountsInAlicesDB, err := s.alice.communitiesManager.GetRevealedAddresses(community.ID(), crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().NoError(err)
 	s.Require().Len(revealedAccountsInAlicesDB, 2)
 	s.Require().Equal(revealedAccountsInAlicesDB[0].Address, aliceAddress1)
@@ -261,7 +260,7 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) TestJoinedCommunityMember
 
 	s.Require().Equal(2, community.MembersCount())
 
-	alicePubkey := common.PubkeyToHex(&s.alice.identity.PublicKey)
+	alicePubkey := crypto.PubkeyToHex(&s.alice.identity.PublicKey)
 
 	// Check Alice's DB for revealed accounts
 	revealedAccountsInAlicesDB, err := s.alice.communitiesManager.GetRevealedAddresses(community.ID(), alicePubkey)
@@ -285,7 +284,7 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) TestJoinedCommunityMember
 
 	s.Require().Equal(2, community.MembersCount())
 
-	alicePubkey := common.PubkeyToHex(&s.alice.identity.PublicKey)
+	alicePubkey := crypto.PubkeyToHex(&s.alice.identity.PublicKey)
 
 	// Check Alice's DB for revealed accounts
 	revealedAccountsInAlicesDB, err := s.alice.communitiesManager.GetRevealedAddresses(community.ID(), alicePubkey)
@@ -301,7 +300,7 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) TestJoinedCommunityMember
 
 func (s *MessengerCommunitiesSharedMemberAddressSuite) TestEditSharedAddresses() {
 	community, _ := createCommunity(&s.Suite, s.owner)
-	alicePubkey := common.PubkeyToHex(&s.alice.identity.PublicKey)
+	alicePubkey := crypto.PubkeyToHex(&s.alice.identity.PublicKey)
 
 	advertiseCommunityTo(&s.Suite, community, s.owner, s.alice)
 	s.joinCommunity(community, s.alice, alicePassword, []string{aliceAddress1})
@@ -438,7 +437,7 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) TestSharedAddressesReturn
 
 	s.joinCommunity(community, s.alice, alicePassword, []string{})
 
-	revealedAccounts, err := s.alice.GetRevealedAccounts(community.ID(), common.PubkeyToHex(&s.alice.identity.PublicKey))
+	revealedAccounts, err := s.alice.GetRevealedAccounts(community.ID(), crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().NoError(err)
 
 	revealedAddressesMap := make(map[string]struct{}, len(revealedAccounts))

--- a/protocol/communities_messenger_signers_test.go
+++ b/protocol/communities_messenger_signers_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	utils "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/crypto"
 
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
@@ -112,7 +113,7 @@ func (s *MessengerCommunitiesSignersSuite) TestControlNodeUpdateSigner() {
 	s.Require().NoError(err)
 
 	// update mock - the signer for the community returned by the contracts should be john
-	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), common.PubkeyToHex(&s.john.identity.PublicKey))
+	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), crypto.PubkeyToHex(&s.john.identity.PublicKey))
 	s.collectiblesServiceMock.SetMockCollectibleContractData(chainID, tokenAddress,
 		&communities.CollectibleContractData{TotalSupply: &bigint.BigInt{}})
 
@@ -139,7 +140,7 @@ func (s *MessengerCommunitiesSignersSuite) TestControlNodeUpdateSigner() {
 	// Ownership token will be transferred to Alice and she will kick all members
 	// and request kicked members to rejoin
 	// the signer for the community returned by the contracts should be alice
-	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 
 	response, err := s.alice.PromoteSelfToControlNode(community.ID())
 	s.Require().NoError(err)
@@ -148,7 +149,7 @@ func (s *MessengerCommunitiesSignersSuite) TestControlNodeUpdateSigner() {
 	community, err = s.alice.communitiesManager.GetByID(community.ID())
 	s.Require().NoError(err)
 	s.Require().True(community.IsControlNode())
-	s.Require().True(common.IsPubKeyEqual(community.ControlNode(), &s.alice.identity.PublicKey))
+	s.Require().True(crypto.IsPubKeyEqual(community.ControlNode(), &s.alice.identity.PublicKey))
 	s.Require().True(community.IsOwner())
 
 	// check that Bob received kick event, also he will receive
@@ -197,7 +198,7 @@ func (s *MessengerCommunitiesSignersSuite) TestControlNodeUpdateSigner() {
 	validateResults := func(messenger *Messenger) *communities.Community {
 		community, err = messenger.communitiesManager.GetByID(community.ID())
 		s.Require().NoError(err)
-		s.Require().True(common.IsPubKeyEqual(community.ControlNode(), &s.alice.identity.PublicKey))
+		s.Require().True(crypto.IsPubKeyEqual(community.ControlNode(), &s.alice.identity.PublicKey))
 		s.Require().Len(community.Members(), 2)
 		s.Require().True(community.HasMember(&messenger.identity.PublicKey))
 
@@ -307,7 +308,7 @@ func (s *MessengerCommunitiesSignersSuite) TestAutoAcceptOnOwnershipChangeReques
 	s.Require().NoError(err)
 
 	// set john as contract owner
-	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), common.PubkeyToHex(&s.john.identity.PublicKey))
+	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), crypto.PubkeyToHex(&s.john.identity.PublicKey))
 	s.collectiblesServiceMock.SetMockCollectibleContractData(chainID, tokenAddress,
 		&communities.CollectibleContractData{TotalSupply: &bigint.BigInt{}})
 
@@ -332,7 +333,7 @@ func (s *MessengerCommunitiesSignersSuite) TestAutoAcceptOnOwnershipChangeReques
 	s.Require().NoError(err)
 
 	// simulate Alice received owner token
-	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 
 	// after receiving owner token - set up control node, set up owner role, kick all members
 	// and request kicked members to rejoin
@@ -342,7 +343,7 @@ func (s *MessengerCommunitiesSignersSuite) TestAutoAcceptOnOwnershipChangeReques
 	community, err = s.alice.communitiesManager.GetByID(community.ID())
 	s.Require().NoError(err)
 	s.Require().True(community.IsControlNode())
-	s.Require().True(common.IsPubKeyEqual(community.ControlNode(), &s.alice.identity.PublicKey))
+	s.Require().True(crypto.IsPubKeyEqual(community.ControlNode(), &s.alice.identity.PublicKey))
 	s.Require().True(community.IsOwner())
 
 	// check that client received kick event
@@ -388,7 +389,7 @@ func (s *MessengerCommunitiesSignersSuite) TestAutoAcceptOnOwnershipChangeReques
 	validateResults := func(messenger *Messenger) *communities.Community {
 		community, err = messenger.communitiesManager.GetByID(community.ID())
 		s.Require().NoError(err)
-		s.Require().True(common.IsPubKeyEqual(community.ControlNode(), &s.alice.identity.PublicKey))
+		s.Require().True(crypto.IsPubKeyEqual(community.ControlNode(), &s.alice.identity.PublicKey))
 		s.Require().Len(community.Members(), 2)
 		s.Require().True(community.HasMember(&messenger.identity.PublicKey))
 
@@ -445,7 +446,7 @@ func (s *MessengerCommunitiesSignersSuite) TestNewOwnerAcceptRequestToJoin() {
 	s.Require().NoError(err)
 
 	// update mock - the signer for the community returned by the contracts should be john
-	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), common.PubkeyToHex(&s.john.identity.PublicKey))
+	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), crypto.PubkeyToHex(&s.john.identity.PublicKey))
 	s.collectiblesServiceMock.SetMockCollectibleContractData(chainID, tokenAddress,
 		&communities.CollectibleContractData{TotalSupply: &bigint.BigInt{}})
 
@@ -462,7 +463,7 @@ func (s *MessengerCommunitiesSignersSuite) TestNewOwnerAcceptRequestToJoin() {
 	// Ownership token will be transferred to Alice and she will kick all members
 	// and request kicked members to rejoin
 	// the signer for the community returned by the contracts should be alice
-	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 
 	response, err := s.alice.PromoteSelfToControlNode(community.ID())
 	s.Require().NoError(err)
@@ -471,7 +472,7 @@ func (s *MessengerCommunitiesSignersSuite) TestNewOwnerAcceptRequestToJoin() {
 	community, err = s.alice.communitiesManager.GetByID(community.ID())
 	s.Require().NoError(err)
 	s.Require().True(community.IsControlNode())
-	s.Require().True(common.IsPubKeyEqual(community.ControlNode(), &s.alice.identity.PublicKey))
+	s.Require().True(crypto.IsPubKeyEqual(community.ControlNode(), &s.alice.identity.PublicKey))
 	s.Require().True(community.IsOwner())
 
 	// check that John received kick event, also he will receive
@@ -486,7 +487,7 @@ func (s *MessengerCommunitiesSignersSuite) TestNewOwnerAcceptRequestToJoin() {
 	s.Require().NoError(err)
 
 	// Alice advertises community to Bob
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.bob.identity.PublicKey), &s.bob.identity.PublicKey, s.bob.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.bob.identity.PublicKey), &s.bob.identity.PublicKey, s.bob.getTimesource())
 
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID
@@ -580,7 +581,7 @@ func (s *MessengerCommunitiesSignersSuite) testSyncCommunity(mintOwnerToken bool
 		s.Require().NoError(err)
 
 		// update mock - the signer for the community returned by the contracts should be john
-		s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), common.PubkeyToHex(&s.john.identity.PublicKey))
+		s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), crypto.PubkeyToHex(&s.john.identity.PublicKey))
 		s.collectiblesServiceMock.SetMockCommunityTokenData(communityToken)
 
 		// alice accepts community update
@@ -639,7 +640,7 @@ func (s *MessengerCommunitiesSignersSuite) testSyncCommunity(mintOwnerToken bool
 
 	responseCommunity := messageState.Response.Communities()[0]
 	s.Require().Equal(community.IDString(), responseCommunity.IDString())
-	s.Require().True(common.IsPubKeyEqual(expectedControlNode, responseCommunity.ControlNode()))
+	s.Require().True(crypto.IsPubKeyEqual(expectedControlNode, responseCommunity.ControlNode()))
 }
 
 func (s *MessengerCommunitiesSignersSuite) TestSyncTokenGatedCommunity() {
@@ -688,7 +689,7 @@ func (s *MessengerCommunitiesSignersSuite) TestWithMintedOwnerTokenApplyCommunit
 	s.Require().NoError(err)
 
 	// Make sure there is no control node
-	s.Require().False(common.IsPubKeyEqual(community.ControlNode(), &s.john.identity.PublicKey))
+	s.Require().False(crypto.IsPubKeyEqual(community.ControlNode(), &s.john.identity.PublicKey))
 
 	// Trick. We need to remove the community private key otherwise the events
 	// will be signed and Events will be approved instead of being in Pending State.
@@ -749,7 +750,7 @@ func (s *MessengerCommunitiesSignersSuite) TestWithoutMintedOwnerTokenMakingDevi
 	community := s.createCommunity(s.john)
 
 	// Make sure there is no control node
-	s.Require().False(common.IsPubKeyEqual(community.ControlNode(), &s.john.identity.PublicKey))
+	s.Require().False(crypto.IsPubKeyEqual(community.ControlNode(), &s.john.identity.PublicKey))
 
 	response, err := s.john.PromoteSelfToControlNode(community.ID())
 	s.Require().Nil(response)
@@ -797,7 +798,7 @@ func (s *MessengerCommunitiesSignersSuite) TestControlNodeDeviceChanged() {
 	s.Require().NoError(err)
 
 	// set john as contract owner
-	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), common.PubkeyToHex(&s.john.identity.PublicKey))
+	s.collectiblesServiceMock.SetSignerPubkeyForCommunity(community.ID(), crypto.PubkeyToHex(&s.john.identity.PublicKey))
 	s.collectiblesServiceMock.SetMockCollectibleContractData(testChainID1, ownerTokenAddress,
 		&communities.CollectibleContractData{TotalSupply: &bigint.BigInt{}})
 	s.collectiblesServiceMock.SetMockCollectibleContractData(testChainID1, tokenMasterTokenAddress,
@@ -805,7 +806,7 @@ func (s *MessengerCommunitiesSignersSuite) TestControlNodeDeviceChanged() {
 
 	community, err = s.john.communitiesManager.GetByID(community.ID())
 	s.Require().NoError(err)
-	s.Require().True(common.IsPubKeyEqual(community.ControlNode(), &s.john.identity.PublicKey))
+	s.Require().True(crypto.IsPubKeyEqual(community.ControlNode(), &s.john.identity.PublicKey))
 
 	var tokenMasterTokenCriteria *protobuf.TokenCriteria
 	for _, permission := range community.TokenPermissions() {

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -150,7 +150,7 @@ func (s *MessengerCommunitiesSuite) TestRetrieveCommunity() {
 	s.Require().Equal(communitySettings.HistoryArchiveSupportEnabled, false)
 
 	// Send a community message
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID
@@ -205,7 +205,7 @@ func (s *MessengerCommunitiesSuite) TestJoiningOpenCommunityReturnsChatsResponse
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -241,7 +241,7 @@ func (s *MessengerCommunitiesSuite) TestJoiningOpenCommunityReturnsChatsResponse
 	s.Require().Equal(community.ID(), requestToJoin.CommunityID)
 	s.Require().NotEmpty(requestToJoin.ID)
 	s.Require().NotEmpty(requestToJoin.Clock)
-	s.Require().Equal(requestToJoin.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Len(response.Communities(), 1)
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin.State)
 
@@ -348,7 +348,7 @@ func (s *MessengerCommunitiesSuite) TestJoinCommunity() {
 	s.Require().Len(chats, 2)
 
 	// Send a community message
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.bob.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.bob.getTimesource())
 
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID
@@ -801,7 +801,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccess() {
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -850,7 +850,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccess() {
 	s.Require().True(requestToJoin1.Our)
 	s.Require().NotEmpty(requestToJoin1.ID)
 	s.Require().NotEmpty(requestToJoin1.Clock)
-	s.Require().Equal(requestToJoin1.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin1.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(requestToJoin1.CustomizationColor, s.alice.account.GetCustomizationColor())
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin1.State)
 
@@ -899,7 +899,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccess() {
 	s.Require().False(requestToJoin2.Our)
 	s.Require().NotEmpty(requestToJoin2.ID)
 	s.Require().NotEmpty(requestToJoin2.Clock)
-	s.Require().Equal(requestToJoin2.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin2.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(requestToJoin2.CustomizationColor, s.alice.account.GetCustomizationColor())
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin2.State)
 
@@ -1008,7 +1008,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccess() {
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -1046,7 +1046,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccess() {
 	s.Require().Equal(community.ID(), requestToJoin.CommunityID)
 	s.Require().NotEmpty(requestToJoin.ID)
 	s.Require().NotEmpty(requestToJoin.Clock)
-	s.Require().Equal(requestToJoin.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin.State)
 
 	s.Require().Len(response.Communities(), 1)
@@ -1199,7 +1199,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccessWithDeclinedSt
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -1245,7 +1245,7 @@ func (s *MessengerCommunitiesSuite) TestDeletePendingRequestAccessWithDeclinedSt
 	s.Require().Equal(community.ID(), requestToJoin.CommunityID)
 	s.Require().NotEmpty(requestToJoin.ID)
 	s.Require().NotEmpty(requestToJoin.Clock)
-	s.Require().Equal(requestToJoin.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin.State)
 
 	s.Require().Len(response.Communities(), 1)
@@ -1451,7 +1451,7 @@ func (s *MessengerCommunitiesSuite) TestCancelRequestAccess() {
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -1490,7 +1490,7 @@ func (s *MessengerCommunitiesSuite) TestCancelRequestAccess() {
 	s.Require().True(requestToJoin1.Our)
 	s.Require().NotEmpty(requestToJoin1.ID)
 	s.Require().NotEmpty(requestToJoin1.Clock)
-	s.Require().Equal(requestToJoin1.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin1.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(requestToJoin1.CustomizationColor, s.alice.account.GetCustomizationColor())
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin1.State)
 
@@ -1542,7 +1542,7 @@ func (s *MessengerCommunitiesSuite) TestCancelRequestAccess() {
 	s.Require().False(requestToJoin2.Our)
 	s.Require().NotEmpty(requestToJoin2.ID)
 	s.Require().NotEmpty(requestToJoin2.Clock)
-	s.Require().Equal(requestToJoin2.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin2.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(requestToJoin2.CustomizationColor, s.alice.account.GetCustomizationColor())
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin2.State)
 
@@ -1603,7 +1603,7 @@ func (s *MessengerCommunitiesSuite) TestCancelRequestAccess() {
 	s.Require().False(cancelRequestToJoin2.Our)
 	s.Require().NotEmpty(cancelRequestToJoin2.ID)
 	s.Require().NotEmpty(cancelRequestToJoin2.Clock)
-	s.Require().Equal(cancelRequestToJoin2.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(cancelRequestToJoin2.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(cancelRequestToJoin2.CustomizationColor, s.alice.account.GetCustomizationColor())
 	s.Require().Equal(communities.RequestToJoinStateCanceled, cancelRequestToJoin2.State)
 }
@@ -1649,7 +1649,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 	s.Require().True(requestToJoin1.Our)
 	s.Require().NotEmpty(requestToJoin1.ID)
 	s.Require().NotEmpty(requestToJoin1.Clock)
-	s.Require().Equal(requestToJoin1.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin1.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin1.State)
 
 	// Make sure clock is not empty
@@ -1697,7 +1697,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 	s.Require().False(requestToJoin2.Our)
 	s.Require().NotEmpty(requestToJoin2.ID)
 	s.Require().NotEmpty(requestToJoin2.Clock)
-	s.Require().Equal(requestToJoin2.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin2.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin2.State)
 
 	s.Require().Equal(requestToJoin1.ID, requestToJoin2.ID)
@@ -1776,7 +1776,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 	// We kick the member
 	response, err = s.bob.RemoveUserFromCommunity(
 		community.ID(),
-		common.PubkeyToHex(&s.alice.identity.PublicKey),
+		crypto.PubkeyToHex(&s.alice.identity.PublicKey),
 	)
 	s.Require().NoError(err)
 	s.Require().NotNil(response)
@@ -1838,7 +1838,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 	s.Require().True(requestToJoin3.Our)
 	s.Require().NotEmpty(requestToJoin3.ID)
 	s.Require().NotEmpty(requestToJoin3.Clock)
-	s.Require().Equal(requestToJoin3.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin3.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin3.State)
 
 	s.Require().Len(response.Communities(), 1)
@@ -1868,7 +1868,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAccessAgain() {
 	s.Require().False(requestToJoin4.Our)
 	s.Require().NotEmpty(requestToJoin4.ID)
 	s.Require().NotEmpty(requestToJoin4.Clock)
-	s.Require().Equal(requestToJoin4.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin4.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin4.State)
 
 	s.Require().Equal(requestToJoin3.ID, requestToJoin4.ID)
@@ -1892,7 +1892,7 @@ func (s *MessengerCommunitiesSuite) TestDeclineAccess() {
 
 	community := response.Communities()[0]
 
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 
 	s.Require().NoError(s.bob.SaveChat(chat))
 
@@ -1931,7 +1931,7 @@ func (s *MessengerCommunitiesSuite) TestDeclineAccess() {
 	s.Require().True(requestToJoin1.Our)
 	s.Require().NotEmpty(requestToJoin1.ID)
 	s.Require().NotEmpty(requestToJoin1.Clock)
-	s.Require().Equal(requestToJoin1.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin1.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin1.State)
 
 	s.Require().Len(response.ActivityCenterNotifications(), 1)
@@ -1988,7 +1988,7 @@ func (s *MessengerCommunitiesSuite) TestDeclineAccess() {
 	s.Require().False(requestToJoin2.Our)
 	s.Require().NotEmpty(requestToJoin2.ID)
 	s.Require().NotEmpty(requestToJoin2.Clock)
-	s.Require().Equal(requestToJoin2.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin2.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin2.State)
 
 	s.Require().Equal(requestToJoin1.ID, requestToJoin2.ID)
@@ -2213,7 +2213,7 @@ func (s *MessengerCommunitiesSuite) TestShareCommunity() {
 	// Alice shares community with Bob
 	response, err = s.owner.ShareCommunity(&requests.ShareCommunity{
 		CommunityID:   community.ID(),
-		Users:         []types.HexBytes{common.PubkeyToHexBytes(&s.alice.identity.PublicKey)},
+		Users:         []types.HexBytes{crypto.PubkeyToHexBytes(&s.alice.identity.PublicKey)},
 		InviteMessage: inputMessageText,
 	})
 
@@ -2278,7 +2278,7 @@ func (s *MessengerCommunitiesSuite) TestShareCommunityWithPreviousMember() {
 	advertiseCommunityToUserOldWay(&s.Suite, community, s.bob, s.alice)
 
 	// Add bob to contacts so it does not go on activity center
-	bobPk := common.PubkeyToHex(&s.bob.identity.PublicKey)
+	bobPk := crypto.PubkeyToHex(&s.bob.identity.PublicKey)
 	request := &requests.AddContact{ID: bobPk}
 	_, err = s.alice.AddContact(context.Background(), request)
 	s.Require().NoError(err)
@@ -2316,7 +2316,7 @@ func (s *MessengerCommunitiesSuite) TestBanUser() {
 		context.Background(),
 		&requests.BanUserFromCommunity{
 			CommunityID: community.ID(),
-			User:        common.PubkeyToHexBytes(&s.alice.identity.PublicKey),
+			User:        crypto.PubkeyToHexBytes(&s.alice.identity.PublicKey),
 		},
 	)
 	s.Require().NoError(err)
@@ -2363,7 +2363,7 @@ func (s *MessengerCommunitiesSuite) TestBanUser() {
 	response, err = s.owner.UnbanUserFromCommunity(
 		&requests.UnbanUserFromCommunity{
 			CommunityID: community.ID(),
-			User:        common.PubkeyToHexBytes(&s.alice.identity.PublicKey),
+			User:        crypto.PubkeyToHexBytes(&s.alice.identity.PublicKey),
 		},
 	)
 	s.Require().NoError(err)
@@ -2782,7 +2782,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_RequestToJoin() {
 	s.Len(tcs1, 0, "Must have 0 communities")
 
 	// Bob the admin opens up a 1-1 chat with alice
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 	s.Require().NoError(s.bob.SaveChat(chat))
 
 	// Bob the admin shares with Alice, via public chat, an invite link to the new community
@@ -2833,7 +2833,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_RequestToJoin() {
 	s.True(aRtj.Our)
 	s.Require().NotEmpty(aRtj.ID)
 	s.Require().NotEmpty(aRtj.Clock)
-	s.Equal(aRtj.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Equal(aRtj.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Equal(aRtj.CustomizationColor, s.alice.account.GetCustomizationColor())
 	s.Equal(communities.RequestToJoinStatePending, aRtj.State)
 
@@ -2924,7 +2924,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_RequestToJoin() {
 	s.False(bobRtj.Our)
 	s.Require().NotEmpty(bobRtj.ID)
 	s.Require().NotEmpty(bobRtj.Clock)
-	s.Equal(bobRtj.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Equal(bobRtj.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Equal(bobRtj.CustomizationColor, s.alice.account.GetCustomizationColor())
 	s.Equal(communities.RequestToJoinStatePending, bobRtj.State)
 
@@ -3010,7 +3010,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_Leave() {
 	s.Len(tcs1, 0, "Must have 0 communities")
 
 	// Bob the admin opens up a 1-1 chat with alice
-	chat := CreateOneToOneChat(common.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&s.alice.identity.PublicKey), &s.alice.identity.PublicKey, s.alice.getTimesource())
 	s.Require().NoError(s.bob.SaveChat(chat))
 
 	// Bob the admin shares with Alice, via public chat, an invite link to the new community
@@ -3534,7 +3534,7 @@ func (s *MessengerCommunitiesSuite) TestCommunityBanUserRequestToJoin() {
 		context.Background(),
 		&requests.BanUserFromCommunity{
 			CommunityID: community.ID(),
-			User:        common.PubkeyToHexBytes(&s.alice.identity.PublicKey),
+			User:        crypto.PubkeyToHexBytes(&s.alice.identity.PublicKey),
 		},
 	)
 	s.Require().NoError(err)
@@ -3849,7 +3849,7 @@ func (s *MessengerCommunitiesSuite) TestCommunityRekeyAfterBan() {
 
 	response, err = s.owner.BanUserFromCommunity(context.Background(), &requests.BanUserFromCommunity{
 		CommunityID: c.ID(),
-		User:        common.PubkeyToHexBytes(&s.bob.identity.PublicKey),
+		User:        crypto.PubkeyToHexBytes(&s.bob.identity.PublicKey),
 	})
 	s.Require().NoError(err)
 	s.Require().Len(response.Communities(), 1)
@@ -3952,7 +3952,7 @@ func (s *MessengerCommunitiesSuite) TestCommunityRekeyAfterBanDisableCompatibili
 
 	response, err = s.owner.BanUserFromCommunity(context.Background(), &requests.BanUserFromCommunity{
 		CommunityID: c.ID(),
-		User:        common.PubkeyToHexBytes(&s.bob.identity.PublicKey),
+		User:        crypto.PubkeyToHexBytes(&s.bob.identity.PublicKey),
 	})
 	s.Require().NoError(err)
 	s.Require().Len(response.Communities(), 1)
@@ -4045,7 +4045,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAndCancelCommunityAdminOffline() 
 	s.Require().True(requestToJoin1.Our)
 	s.Require().NotEmpty(requestToJoin1.ID)
 	s.Require().NotEmpty(requestToJoin1.Clock)
-	s.Require().Equal(requestToJoin1.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin1.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin1.State)
 
 	messageState := s.alice.buildMessageState()
@@ -4098,7 +4098,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAndCancelCommunityAdminOffline() 
 	s.Require().Equal(community.ID(), requestToJoin2.CommunityID)
 	s.Require().NotEmpty(requestToJoin2.ID)
 	s.Require().NotEmpty(requestToJoin2.Clock)
-	s.Require().Equal(requestToJoin2.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin2.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin2.State)
 
 	s.Require().Equal(requestToJoin1.ID, requestToJoin2.ID)
@@ -4182,7 +4182,7 @@ func (s *MessengerCommunitiesSuite) TestRequestAndCancelCommunityAdminOffline() 
 	s.Require().False(cancelRequestToJoin2.Our)
 	s.Require().NotEmpty(cancelRequestToJoin2.ID)
 	s.Require().NotEmpty(cancelRequestToJoin2.Clock)
-	s.Require().Equal(cancelRequestToJoin2.PublicKey, common.PubkeyToHex(&s.alice.identity.PublicKey))
+	s.Require().Equal(cancelRequestToJoin2.PublicKey, crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 }
 
 func (s *MessengerCommunitiesSuite) TestCommunityLastOpenedAt() {
@@ -4264,7 +4264,7 @@ func (s *MessengerCommunitiesSuite) TestBanUserAndDeleteAllUserMessages() {
 		context.Background(),
 		&requests.BanUserFromCommunity{
 			CommunityID:       community.ID(),
-			User:              common.PubkeyToHexBytes(&s.alice.identity.PublicKey),
+			User:              crypto.PubkeyToHexBytes(&s.alice.identity.PublicKey),
 			DeleteAllMessages: true,
 		},
 	)

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -615,7 +615,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestJoinCommunityWithAdminPe
 	s.joinCommunity(community, s.bob)
 
 	// Verify that we have Bob's revealed account
-	revealedAccounts, err := s.owner.GetRevealedAccounts(community.ID(), common.PubkeyToHex(&s.bob.identity.PublicKey))
+	revealedAccounts, err := s.owner.GetRevealedAccounts(community.ID(), crypto.PubkeyToHex(&s.bob.identity.PublicKey))
 	s.Require().NoError(err)
 	s.Require().Len(revealedAccounts, 1)
 	s.Require().Equal(bobAddress, revealedAccounts[0].Address)
@@ -685,7 +685,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestJoinCommunityAsMemberWit
 	s.joinCommunity(community, s.bob)
 
 	// Verify that we have Bob's revealed account
-	revealedAccounts, err := s.owner.GetRevealedAccounts(community.ID(), common.PubkeyToHex(&s.bob.identity.PublicKey))
+	revealedAccounts, err := s.owner.GetRevealedAccounts(community.ID(), crypto.PubkeyToHex(&s.bob.identity.PublicKey))
 	s.Require().NoError(err)
 	s.Require().Len(revealedAccounts, 1)
 	s.Require().Equal(bobAddress, revealedAccounts[0].Address)
@@ -763,7 +763,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestJoinCommunityAsAdminWith
 	s.joinCommunity(community, s.bob)
 
 	// Verify that we have Bob's revealed account
-	revealedAccounts, err := s.owner.GetRevealedAccounts(community.ID(), common.PubkeyToHex(&s.bob.identity.PublicKey))
+	revealedAccounts, err := s.owner.GetRevealedAccounts(community.ID(), crypto.PubkeyToHex(&s.bob.identity.PublicKey))
 	s.Require().NoError(err)
 	s.Require().Len(revealedAccounts, 1)
 	s.Require().Equal(bobAddress, revealedAccounts[0].Address)
@@ -885,7 +885,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testViewChannelPermissions(v
 		if !ok || action.ActionType != communities.EncryptionKeySendToMembers {
 			return false
 		}
-		_, ok = action.Members[common.PubkeyToHex(&s.bob.identity.PublicKey)]
+		_, ok = action.Members[crypto.PubkeyToHex(&s.bob.identity.PublicKey)]
 		return ok
 	})
 
@@ -1400,7 +1400,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestMemberRoleGetUpdatedWhen
 		if !ok || action.ActionType != communities.EncryptionKeySendToMembers {
 			return false
 		}
-		_, ok = action.Members[common.PubkeyToHex(&s.bob.identity.PublicKey)]
+		_, ok = action.Members[crypto.PubkeyToHex(&s.bob.identity.PublicKey)]
 		return ok
 	})
 
@@ -1886,7 +1886,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestResendEncryptionKeyOnBac
 			return false
 		}
 
-		_, ok = action.Members[common.PubkeyToHex(&s.bob.identity.PublicKey)]
+		_, ok = action.Members[crypto.PubkeyToHex(&s.bob.identity.PublicKey)]
 		return ok
 	})
 
@@ -1976,7 +1976,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestResendEncryptionKeyOnBac
 			return false
 		}
 
-		_, ok = action.Members[common.PubkeyToHex(&s.bob.identity.PublicKey)]
+		_, ok = action.Members[crypto.PubkeyToHex(&s.bob.identity.PublicKey)]
 		return ok
 	}
 
@@ -2047,7 +2047,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestReevaluateMemberPermissi
 		privateKey, err := crypto.GenerateKey()
 		s.Require().NoError(err)
 
-		memberPubKeyStr := common.PubkeyToHex(&privateKey.PublicKey)
+		memberPubKeyStr := crypto.PubkeyToHex(&privateKey.PublicKey)
 		requestId := communities.CalculateRequestID(memberPubKeyStr, community.ID())
 		requestToJoin.ID = requestId
 		requestToJoin.PublicKey = memberPubKeyStr
@@ -2166,7 +2166,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestImportDecryptedArchiveMe
 		if !ok || action.ActionType != communities.EncryptionKeyAdd {
 			return false
 		}
-		_, ok = action.Members[common.PubkeyToHex(&s.owner.identity.PublicKey)]
+		_, ok = action.Members[crypto.PubkeyToHex(&s.owner.identity.PublicKey)]
 		return ok
 	})
 
@@ -2297,7 +2297,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) TestImportDecryptedArchiveMe
 		if !ok || action.ActionType != communities.EncryptionKeySendToMembers {
 			return false
 		}
-		_, ok = action.Members[common.PubkeyToHex(&s.bob.identity.PublicKey)]
+		_, ok = action.Members[crypto.PubkeyToHex(&s.bob.identity.PublicKey)]
 		return ok
 	})
 

--- a/protocol/contact.go
+++ b/protocol/contact.go
@@ -14,7 +14,6 @@ import (
 	"github.com/status-im/status-go/multiaccounts/accounts"
 	multiaccountscommon "github.com/status-im/status-go/multiaccounts/common"
 	"github.com/status-im/status-go/multiaccounts/settings"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/verification"
 )
@@ -359,7 +358,7 @@ func buildContactFromPkString(pkString string) (*Contact, error) {
 }
 
 func BuildContactFromPublicKey(publicKey *ecdsa.PublicKey) (*Contact, error) {
-	id := common.PubkeyToHex(publicKey)
+	id := crypto.PubkeyToHex(publicKey)
 	return buildContact(id, publicKey)
 }
 
@@ -376,7 +375,7 @@ func getShortenedCompressedKey(publicKey string) string {
 }
 
 func buildContact(publicKeyString string, publicKey *ecdsa.PublicKey) (*Contact, error) {
-	compressedKey, err := multiformat.SerializeLegacyKey(common.PubkeyToHex(publicKey))
+	compressedKey, err := multiformat.SerializeLegacyKey(crypto.PubkeyToHex(publicKey))
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +432,7 @@ func contactIDFromPublicKey(key *ecdsa.PublicKey) string {
 }
 
 func contactIDFromPublicKeyString(key string) (string, error) {
-	pubKey, err := common.HexToPubkey(key)
+	pubKey, err := crypto.HexToPubkey(key)
 	if err != nil {
 		return "", err
 	}

--- a/protocol/contact_test.go
+++ b/protocol/contact_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/status-im/status-go/crypto"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -557,7 +556,7 @@ func TestMarshalContactJSON(t *testing.T) {
 	}
 	id, err := crypto.GenerateKey()
 	require.NoError(t, err)
-	contact.ID = common.PubkeyToHex(&id.PublicKey)
+	contact.ID = crypto.PubkeyToHex(&id.PublicKey)
 
 	encodedContact, err := json.Marshal(contact)
 

--- a/protocol/local_notifications.go
+++ b/protocol/local_notifications.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
@@ -32,7 +33,7 @@ func showMessageNotification(publicKey ecdsa.PublicKey, message *common.Message,
 	}
 
 	if responseTo != nil {
-		publicKeyString := common.PubkeyToHex(&publicKey)
+		publicKeyString := crypto.PubkeyToHex(&publicKey)
 		return responseTo.From == publicKeyString
 	}
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -1763,7 +1763,7 @@ func (m *Messenger) dispatchMessage(ctx context.Context, rawMessage messagingtyp
 		//SendPrivate will alter message identity and possibly datasyncid, so we save an unchanged
 		//message for sending to paired devices later
 		specCopyForPairedDevices := rawMessage
-		if !common.IsPubKeyEqual(publicKey, &m.identity.PublicKey) || rawMessage.SkipEncryptionLayer {
+		if !crypto.IsPubKeyEqual(publicKey, &m.identity.PublicKey) || rawMessage.SkipEncryptionLayer {
 			id, err = m.messaging.SendPrivate(ctx, publicKey, &rawMessage)
 
 			if err != nil {
@@ -1856,7 +1856,7 @@ func (m *Messenger) dispatchMessage(ctx context.Context, rawMessage messagingtyp
 			// Filter out my key from the recipients
 			n := 0
 			for _, recipient := range rawMessage.Recipients {
-				if !common.IsPubKeyEqual(recipient, &m.identity.PublicKey) {
+				if !crypto.IsPubKeyEqual(recipient, &m.identity.PublicKey) {
 					rawMessage.Recipients[n] = recipient
 					n++
 				}
@@ -2047,7 +2047,7 @@ func (m *Messenger) sendChatMessage(ctx context.Context, message *common.Message
 			message.OutgoingStatus = common.OutgoingStatusSent
 		}
 		message.ID = rawMessage.ID
-		err = message.PrepareContent(common.PubkeyToHex(&m.identity.PublicKey))
+		err = message.PrepareContent(crypto.PubkeyToHex(&m.identity.PublicKey))
 		if err != nil {
 			return err
 		}
@@ -4061,7 +4061,7 @@ func (m *Messenger) MuteChat(request *requests.MuteChat) (time.Time, error) {
 	chat, ok := m.allChats.Load(request.ChatID)
 	if !ok {
 		// Only one to one chan be muted when it's not in the database
-		publicKey, err := common.HexToPubkey(request.ChatID)
+		publicKey, err := crypto.HexToPubkey(request.ChatID)
 		if err != nil {
 			return time.Time{}, err
 		}
@@ -4564,7 +4564,7 @@ func (m *Messenger) ImageServerURL() string {
 }
 
 func (m *Messenger) myHexIdentity() string {
-	return common.PubkeyToHex(&m.identity.PublicKey)
+	return crypto.PubkeyToHex(&m.identity.PublicKey)
 }
 
 func (m *Messenger) GetMentionsManager() *MentionManager {

--- a/protocol/messenger_chats.go
+++ b/protocol/messenger_chats.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/deprecation"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 )
@@ -249,7 +249,7 @@ func (m *Messenger) CreateProfileChat(request *requests.CreateProfileChat) (*Mes
 		return nil, err
 	}
 
-	publicKey, err := common.HexToPubkey(request.ID)
+	publicKey, err := crypto.HexToPubkey(request.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (m *Messenger) CreateOneToOneChat(request *requests.CreateOneToOneChat) (*M
 	}
 
 	chatID := request.ID.String()
-	pk, err := common.HexToPubkey(chatID)
+	pk, err := crypto.HexToPubkey(chatID)
 	if err != nil {
 		return nil, err
 	}
@@ -599,7 +599,7 @@ func (m *Messenger) ensureMyOwnProfileChat() error {
 		return errors.New("profile chats are deprecated")
 	}
 
-	chatID := common.PubkeyToHex(&m.identity.PublicKey)
+	chatID := crypto.PubkeyToHex(&m.identity.PublicKey)
 	_, ok := m.allChats.Load(chatID)
 	if ok {
 		return nil

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -161,7 +161,7 @@ func (m *Messenger) publishOrg(org *communities.Community, shouldRekey bool) err
 }
 
 func (m *Messenger) publishCommunityEvents(community *communities.Community, msg *communities.CommunityEventsMessage) error {
-	m.logger.Debug("publishing community events", zap.String("admin-id", common.PubkeyToHex(&m.identity.PublicKey)), zap.Any("event", msg))
+	m.logger.Debug("publishing community events", zap.String("admin-id", crypto.PubkeyToHex(&m.identity.PublicKey)), zap.Any("event", msg))
 
 	payload, err := msg.Marshal()
 	if err != nil {
@@ -322,7 +322,7 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 			}
 
 			for pkString := range encryptionKeyActions.CommunityKeyAction.RemovedMembers {
-				pk, err := common.HexToPubkey(pkString)
+				pk, err := crypto.HexToPubkey(pkString)
 				if err != nil {
 					m.logger.Error("failed to decode public key", zap.Error(err), zap.String("pk", gocommon.TruncateWithDot(pkString)))
 				}
@@ -603,7 +603,7 @@ func (m *Messenger) handleCommunityEncryptionKeysRequest(community *communities.
 		ChannelKeysActions: map[string]communities.EncryptionKeyAction{},
 	}
 
-	pkStr := common.PubkeyToHex(signer)
+	pkStr := crypto.PubkeyToHex(signer)
 	members := make(map[string]*protobuf.CommunityMember)
 	members[pkStr] = community.GetMember(signer)
 
@@ -649,7 +649,7 @@ func (m *Messenger) handleCommunitySharedAddressesRequest(state *ReceivedMessage
 		return communities.ErrMemberNotFound
 	}
 
-	pkStr := common.PubkeyToHex(signer)
+	pkStr := crypto.PubkeyToHex(signer)
 
 	revealedAccounts, err := m.communitiesManager.GetRevealedAddresses(community.ID(), pkStr)
 	if err != nil {
@@ -696,12 +696,12 @@ func (m *Messenger) handleCommunitySharedAddressesRequest(state *ReceivedMessage
 }
 
 func (m *Messenger) handleCommunitySharedAddressesResponse(state *ReceivedMessageState, community *communities.Community, signer *ecdsa.PublicKey, revealedAccounts []*protobuf.RevealedAccount) error {
-	isControlNodeMsg := common.IsPubKeyEqual(community.ControlNode(), signer)
+	isControlNodeMsg := crypto.IsPubKeyEqual(community.ControlNode(), signer)
 	if !isControlNodeMsg {
 		return errors.New(ErrSyncMessagesSentByNonControlNode)
 	}
 
-	requestID := communities.CalculateRequestID(common.PubkeyToHex(&m.identity.PublicKey), community.ID())
+	requestID := communities.CalculateRequestID(crypto.PubkeyToHex(&m.identity.PublicKey), community.ID())
 	err := m.communitiesManager.SaveRequestToJoinRevealedAddresses(requestID, revealedAccounts)
 	if err != nil {
 		return nil
@@ -792,7 +792,7 @@ func (m *Messenger) updateGrantsForControlledCommunities() {
 					m.logger.Error("error handling grant for controlled community", zap.Error(err))
 				}
 			} else {
-				memberPubKey, err := common.HexToPubkey(memberKey)
+				memberPubKey, err := crypto.HexToPubkey(memberKey)
 				if err != nil {
 					m.logger.Error("Pubkey decode ", zap.Error(err))
 				}
@@ -1105,7 +1105,7 @@ func (m *Messenger) joinCommunity(ctx context.Context, communityID types.HexByte
 		response.AddNotification(joinedNotification)
 
 		// Activity Center notification
-		requestID := communities.CalculateRequestID(common.PubkeyToHex(&m.identity.PublicKey), communityID)
+		requestID := communities.CalculateRequestID(crypto.PubkeyToHex(&m.identity.PublicKey), communityID)
 		notification, err := m.persistence.GetActivityCenterNotificationByID(requestID)
 		if err != nil {
 			return nil, err
@@ -1525,7 +1525,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 				return
 			}
 			for _, publicKey := range pks {
-				pkString := common.PubkeyToHex(publicKey)
+				pkString := crypto.PubkeyToHex(publicKey)
 				_, err = m.pushNotificationClient.SendNotification(publicKey, nil, requestToJoin.ID, pkString, protobuf.PushNotification_REQUEST_TO_JOIN_COMMUNITY)
 				if err != nil {
 					m.logger.Error("error sending notification", zap.Error(err))
@@ -1614,7 +1614,7 @@ func (m *Messenger) EditSharedAddressesForCommunity(request *requests.EditShared
 		requestToEditRevealedAccountsProto.RevealedAccounts = append(requestToEditRevealedAccountsProto.RevealedAccounts, revealedAcc)
 	}
 
-	requestID := communities.CalculateRequestID(common.PubkeyToHex(&m.identity.PublicKey), request.CommunityID)
+	requestID := communities.CalculateRequestID(crypto.PubkeyToHex(&m.identity.PublicKey), request.CommunityID)
 	err = m.communitiesManager.RemoveRequestToJoinRevealedAddresses(requestID)
 	if err != nil {
 		return nil, err
@@ -1681,7 +1681,7 @@ func (m *Messenger) PublishTokenActionToPrivilegedMembers(communityID []byte, ch
 	}
 
 	skipMembers := make(map[string]struct{})
-	skipMembers[common.PubkeyToHex(&m.identity.PublicKey)] = struct{}{}
+	skipMembers[crypto.PubkeyToHex(&m.identity.PublicKey)] = struct{}{}
 	privilegedMembers := community.GetFilteredPrivilegedMembers(skipMembers)
 
 	allRecipients := privilegedMembers[protobuf.CommunityMember_ROLE_OWNER]
@@ -1715,7 +1715,7 @@ func (m *Messenger) GetRevealedAccountsForAllMembers(communityID types.HexBytes)
 	}
 	membersRevealedAccounts := map[string][]*protobuf.RevealedAccount{}
 	for _, memberPubKey := range community.GetMemberPubkeys() {
-		memberPubKeyStr := common.PubkeyToHex(memberPubKey)
+		memberPubKeyStr := crypto.PubkeyToHex(memberPubKey)
 		accounts, err := m.communitiesManager.GetRevealedAddresses(communityID, memberPubKeyStr)
 		if err != nil {
 			return nil, err
@@ -1938,7 +1938,7 @@ func (m *Messenger) acceptRequestToJoinCommunity(requestToJoin *communities.Requ
 
 	if community.IsControlNode() {
 		// If we are the control node, we send the response to the user
-		pk, err := common.HexToPubkey(requestToJoin.PublicKey)
+		pk, err := crypto.HexToPubkey(requestToJoin.PublicKey)
 		if err != nil {
 			return nil, err
 		}
@@ -2434,7 +2434,7 @@ func (m *Messenger) InitCommunityFilters(c messagingtypes.CommunitiesToInitializ
 
 func (m *Messenger) DefaultFilters(o *communities.Community) messagingtypes.ChatsToInitialize {
 	cID := o.IDString()
-	uncompressedPubKey := common.PubkeyToHex(o.PublicKey())[2:]
+	uncompressedPubKey := crypto.PubkeyToHex(o.PublicKey())[2:]
 	memberUpdateChannelID := o.MemberUpdateChannelID()
 
 	communityPubsubTopic := o.PubsubTopic()
@@ -3006,7 +3006,7 @@ func (m *Messenger) AllNonApprovedCommunitiesRequestsToJoin() ([]*communities.Re
 }
 
 func (m *Messenger) RemoveUserFromCommunity(id types.HexBytes, pkString string) (*MessengerResponse, error) {
-	publicKey, err := common.HexToPubkey(pkString)
+	publicKey, err := crypto.HexToPubkey(pkString)
 	if err != nil {
 		return nil, err
 	}
@@ -3265,7 +3265,7 @@ func (m *Messenger) handleCommunityResponse(state *ReceivedMessageState, communi
 
 	// Check if we have been removed from a chat (ie no longer have access)
 	for channelID, changes := range communityResponse.Changes.ChatsModified {
-		if _, ok := changes.MembersRemoved[common.PubkeyToHex(&m.identity.PublicKey)]; ok {
+		if _, ok := changes.MembersRemoved[crypto.PubkeyToHex(&m.identity.PublicKey)]; ok {
 			chatID := community.ChatID(channelID)
 
 			if chat, ok := state.AllChats.Load(chatID); ok {
@@ -3482,7 +3482,7 @@ func (m *Messenger) handleCommunityPrivilegedUserSyncMessage(state *ReceivedMess
 	// Currently this type of msg coming from the control node.
 	// If it will change in the future, check that events types starting from
 	// CONTROL_NODE were sent by a control node
-	isControlNodeMsg := common.IsPubKeyEqual(community.ControlNode(), signer)
+	isControlNodeMsg := crypto.IsPubKeyEqual(community.ControlNode(), signer)
 	if !isControlNodeMsg {
 		return errors.New(ErrSyncMessagesSentByNonControlNode)
 	}
@@ -3534,7 +3534,7 @@ func (m *Messenger) sendSharedAddressToControlNode(receiver *ecdsa.PublicKey, co
 
 	m.logger.Info("share address to the new owner ", zap.String("community id", community.IDString()))
 
-	pk := common.PubkeyToHex(&m.identity.PublicKey)
+	pk := crypto.PubkeyToHex(&m.identity.PublicKey)
 
 	requestToJoin, err := m.communitiesManager.GetCommunityRequestToJoinWithRevealedAddresses(pk, community.ID())
 	if err != nil {
@@ -4430,7 +4430,7 @@ func (m *Messenger) getSharedAddresses(communityID types.HexBytes, requestAddres
 	}
 
 	if len(requestAddresses) == 0 {
-		sharedAddresses, err := m.GetRevealedAccounts(communityID, common.PubkeyToHex(&m.identity.PublicKey))
+		sharedAddresses, err := m.GetRevealedAccounts(communityID, crypto.PubkeyToHex(&m.identity.PublicKey))
 		if err != nil {
 			return nil, err
 		}
@@ -4624,7 +4624,7 @@ func (m *Messenger) GetCommunityMembersForWalletAddresses(communityID types.HexB
 	membersForAddresses := map[string]*Contact{}
 
 	for _, memberPubKey := range community.GetMemberPubkeys() {
-		memberPubKeyStr := common.PubkeyToHex(memberPubKey)
+		memberPubKeyStr := crypto.PubkeyToHex(memberPubKey)
 		revealedAccounts, err := m.communitiesManager.GetRevealedAddresses(communityID, memberPubKeyStr)
 		if err != nil {
 			return nil, err
@@ -4648,7 +4648,7 @@ func (m *Messenger) GetCommunityMembersForWalletAddresses(communityID types.HexB
 
 func (m *Messenger) processCommunityChanges(messageState *ReceivedMessageState) {
 	// Process any community changes
-	pkString := common.PubkeyToHex(&m.identity.PublicKey)
+	pkString := crypto.PubkeyToHex(&m.identity.PublicKey)
 	for _, changes := range messageState.Response.CommunityChanges {
 		if changes.ShouldMemberJoin {
 			response, err := m.joinCommunity(context.TODO(), changes.Community.ID(), false)
@@ -4877,7 +4877,7 @@ func (m *Messenger) DeleteCommunityMemberMessages(request *requests.DeleteCommun
 		return nil, communities.ErrNotEnoughPermissions
 	}
 
-	memberPubKey, err := common.HexToPubkey(request.MemberPubKey)
+	memberPubKey, err := crypto.HexToPubkey(request.MemberPubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_communities_import_discord.go
+++ b/protocol/messenger_communities_import_discord.go
@@ -297,7 +297,7 @@ func (m *Messenger) processDiscordMessages(discordChannel *discord.ExportedData,
 			ChatMessage:      &chatMessage,
 		}
 
-		err = messageToSave.PrepareContent(common.PubkeyToHex(&m.identity.PublicKey))
+		err = messageToSave.PrepareContent(crypto.PubkeyToHex(&m.identity.PublicKey))
 		if err != nil {
 			m.logger.Error("failed to prepare message content", zap.Error(err))
 			importProgress.AddTaskError(discord.ImportMessagesTask, discord.Error(err.Error()))
@@ -1350,7 +1350,7 @@ func (m *Messenger) RequestImportDiscordCommunity(request *requests.ImportDiscor
 					ChatMessage:      &chatMessage,
 				}
 
-				err = messageToSave.PrepareContent(common.PubkeyToHex(&m.identity.PublicKey))
+				err = messageToSave.PrepareContent(crypto.PubkeyToHex(&m.identity.PublicKey))
 				if err != nil {
 					m.logger.Error("failed to prepare message content", zap.Error(err))
 					importProgress.AddTaskError(discord.ImportMessagesTask, discord.Error(err.Error()))

--- a/protocol/messenger_community_metrics_test.go
+++ b/protocol/messenger_community_metrics_test.go
@@ -102,13 +102,13 @@ func (s *MessengerCommunityMetricsSuite) generateMessages(chatID string, communi
 				Timestamp: timestamp,
 			},
 			WhisperTimestamp: timestamp,
-			From:             common.PubkeyToHex(&s.m.identity.PublicKey),
+			From:             crypto.PubkeyToHex(&s.m.identity.PublicKey),
 			LocalChatID:      chatID,
 			CommunityID:      communityID,
 			ID:               types.EncodeHex(crypto.Keccak256([]byte(fmt.Sprintf("%s%s%d", chatID, communityID, timestamp)))),
 		}
 
-		err := message.PrepareContent(common.PubkeyToHex(&s.m.identity.PublicKey))
+		err := message.PrepareContent(crypto.PubkeyToHex(&s.m.identity.PublicKey))
 		s.Require().NoError(err)
 
 		messages = append(messages, message)

--- a/protocol/messenger_community_shard.go
+++ b/protocol/messenger_community_shard.go
@@ -14,7 +14,6 @@ import (
 	"github.com/status-im/status-go/crypto/types"
 	"github.com/status-im/status-go/messaging"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
@@ -105,7 +104,7 @@ func (m *Messenger) verifyCommunitySignature(payload, signature, communityID []b
 	if err != nil {
 		return err
 	}
-	pubKeyStr := common.PubkeyToHex(pubKey)
+	pubKeyStr := crypto.PubkeyToHex(pubKey)
 
 	var ownerPublicKey string
 	if chainID > 0 {
@@ -119,7 +118,7 @@ func (m *Messenger) verifyCommunitySignature(payload, signature, communityID []b
 		if err != nil {
 			return err
 		}
-		ownerPublicKey = common.PubkeyToHex(communityPubkey)
+		ownerPublicKey = crypto.PubkeyToHex(communityPubkey)
 	}
 
 	if pubKeyStr != ownerPublicKey {

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -1270,7 +1270,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 		Clock:       4,
 		Timestamp:   1,
 		Text:        "some text",
-		ChatId:      common.PubkeyToHex(&s.m.identity.PublicKey),
+		ChatId:      crypto.PubkeyToHex(&s.m.identity.PublicKey),
 		MessageType: protobuf.MessageType_ONE_TO_ONE,
 		ContentType: protobuf.ChatMessage_CONTACT_REQUEST,
 	}

--- a/protocol/messenger_contact_verification.go
+++ b/protocol/messenger_contact_verification.go
@@ -39,7 +39,7 @@ func (m *Messenger) SendContactVerificationRequest(ctx context.Context, contactI
 	}
 
 	verifRequest := &verification.Request{
-		From:          common.PubkeyToHex(&m.identity.PublicKey),
+		From:          crypto.PubkeyToHex(&m.identity.PublicKey),
 		To:            contact.ID,
 		Challenge:     challenge,
 		RequestStatus: verification.RequestStatusPENDING,
@@ -164,7 +164,7 @@ func (m *Messenger) CancelVerificationRequest(ctx context.Context, id string) (*
 		return nil, verification.ErrVerificationRequestNotFound
 	}
 
-	if verifRequest.From != common.PubkeyToHex(&m.identity.PublicKey) {
+	if verifRequest.From != crypto.PubkeyToHex(&m.identity.PublicKey) {
 		return nil, errors.New("Can cancel only outgoing contact request")
 	}
 
@@ -786,7 +786,7 @@ func (m *Messenger) HandleRequestContactVerification(state *ReceivedMessageState
 
 	id := state.CurrentMessageState.MessageID
 
-	if common.IsPubKeyEqual(state.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
+	if crypto.IsPubKeyEqual(state.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
 		return nil // Is ours, do nothing
 	}
 
@@ -877,7 +877,7 @@ func (m *Messenger) HandleAcceptContactVerification(state *ReceivedMessageState,
 		return err
 	}
 
-	if common.IsPubKeyEqual(state.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
+	if crypto.IsPubKeyEqual(state.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
 		return nil // Is ours, do nothing
 	}
 
@@ -966,7 +966,7 @@ func (m *Messenger) HandleAcceptContactVerification(state *ReceivedMessageState,
 }
 
 func (m *Messenger) HandleDeclineContactVerification(state *ReceivedMessageState, request *protobuf.DeclineContactVerification, statusMessage *messagingtypes.Message) error {
-	if common.IsPubKeyEqual(state.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
+	if crypto.IsPubKeyEqual(state.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
 		return nil // Is ours, do nothing
 	}
 
@@ -1157,7 +1157,7 @@ func (m *Messenger) createContactVerificationMessage(challenge string, chat *Cha
 	chatMessage.ContentType = protobuf.ChatMessage_IDENTITY_VERIFICATION
 	chatMessage.ContactVerificationState = verificationStatus
 
-	err := chatMessage.PrepareContent(common.PubkeyToHex(&m.identity.PublicKey))
+	err := chatMessage.PrepareContent(crypto.PubkeyToHex(&m.identity.PublicKey))
 	if err != nil {
 		return nil, err
 	}
@@ -1182,7 +1182,7 @@ func (m *Messenger) createLocalContactVerificationMessage(challenge string, chat
 		return nil, err
 	}
 
-	err = chatMessage.PrepareContent(common.PubkeyToHex(&m.identity.PublicKey))
+	err = chatMessage.PrepareContent(crypto.PubkeyToHex(&m.identity.PublicKey))
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -125,7 +125,7 @@ func (m *Messenger) acceptContactRequest(ctx context.Context, requestID string, 
 	// Force activate chat
 	chat, ok := m.allChats.Load(contactRequest.From)
 	if !ok {
-		publicKey, err := common.HexToPubkey(contactRequest.From)
+		publicKey, err := crypto.HexToPubkey(contactRequest.From)
 		if err != nil {
 			return nil, err
 		}
@@ -620,7 +620,7 @@ func (m *Messenger) generateContactRequest(clock uint64, timestamp uint64, conta
 	} else {
 		contactRequest.ContactRequestState = common.ContactRequestStatePending
 	}
-	err := contactRequest.PrepareContent(common.PubkeyToHex(&m.identity.PublicKey))
+	err := contactRequest.PrepareContent(crypto.PubkeyToHex(&m.identity.PublicKey))
 	return contactRequest, err
 }
 
@@ -780,7 +780,7 @@ func (m *Messenger) updateContactImagesURL(contact *Contact) error {
 			if err != nil {
 				return err
 			}
-			v.LocalURL = m.httpServer.MakeContactImageURL(common.PubkeyToHex(publicKey), k, v.Clock)
+			v.LocalURL = m.httpServer.MakeContactImageURL(crypto.PubkeyToHex(publicKey), k, v.Clock)
 			v.Payload = nil
 			contact.Images[k] = v
 		}

--- a/protocol/messenger_delete_message_for_everyone_test.go
+++ b/protocol/messenger_delete_message_for_everyone_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -90,7 +91,7 @@ func (s *MessengerDeleteMessageForEveryoneSuite) TestDeleteMessageForEveryone() 
 
 	response, err := s.admin.AddRoleToMember(&requests.AddRoleToMember{
 		CommunityID: community.ID(),
-		User:        common.PubkeyToHexBytes(s.moderator.IdentityPublicKey()),
+		User:        crypto.PubkeyToHexBytes(s.moderator.IdentityPublicKey()),
 		Role:        protobuf.CommunityMember_ROLE_ADMIN,
 	})
 	s.Require().NoError(err)

--- a/protocol/messenger_edit_message_test.go
+++ b/protocol/messenger_edit_message_test.go
@@ -372,7 +372,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageFirstEditsThenMessage() {
 			MessageId:   messageID,
 			ChatId:      theirChat.ID,
 		},
-		From: common.PubkeyToHex(&theirMessenger.identity.PublicKey),
+		From: crypto.PubkeyToHex(&theirMessenger.identity.PublicKey),
 	}
 	state := &ReceivedMessageState{
 		Response: &MessengerResponse{},
@@ -418,7 +418,7 @@ func (s *MessengerEditMessageSuite) TestEditGroupChatMessage() {
 
 	s.Require().NoError(makeMutualContact(s.m, &theirMessenger.identity.PublicKey))
 
-	members := []string{common.PubkeyToHex(&theirMessenger.identity.PublicKey)}
+	members := []string{crypto.PubkeyToHex(&theirMessenger.identity.PublicKey)}
 	_, err = s.m.AddMembersToGroupChat(context.Background(), ourChat.ID, members)
 	s.NoError(err)
 
@@ -523,7 +523,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 	s.Require().NoError(err)
 
 	// Edit the message and add a mention
-	editedText := "edited text @" + common.PubkeyToHex(&s.privateKey.PublicKey)
+	editedText := "edited text @" + crypto.PubkeyToHex(&s.privateKey.PublicKey)
 	editedMessage := &requests.EditMessage{
 		ID:   messageID,
 		Text: editedText,

--- a/protocol/messenger_emoji_test.go
+++ b/protocol/messenger_emoji_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/status-im/status-go/crypto/types"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
 	"github.com/status-im/status-go/multiaccounts"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -172,7 +171,7 @@ func (s *MessengerEmojiSuite) TestCompressedKeyReturnedWithEmoji() {
 	id, err := crypto.GenerateKey()
 	s.Require().NoError(err)
 
-	emojiReaction.From = common.PubkeyToHex(&id.PublicKey)
+	emojiReaction.From = crypto.PubkeyToHex(&id.PublicKey)
 	emojiReaction.LocalChatID = testPublicChatID
 	encodedReaction, err := json.Marshal(emojiReaction)
 	s.Require().NoError(err)
@@ -239,7 +238,7 @@ func (s *MessengerEmojiSuite) TestMaxEmojiReactionsPerMessage() {
 	messageState := bob.buildMessageState()
 	messageState.CurrentMessageState = &CurrentMessageState{
 		Contact: &Contact{
-			ID: common.PubkeyToHex(&alice.identity.PublicKey),
+			ID: crypto.PubkeyToHex(&alice.identity.PublicKey),
 		},
 	}
 

--- a/protocol/messenger_group_chat.go
+++ b/protocol/messenger_group_chat.go
@@ -725,10 +725,10 @@ func (m *Messenger) leaveGroupChat(ctx context.Context, response *MessengerRespo
 		return nil, ErrChatNotFound
 	}
 
-	amIMember := chat.HasMember(common.PubkeyToHex(&m.identity.PublicKey))
+	amIMember := chat.HasMember(crypto.PubkeyToHex(&m.identity.PublicKey))
 
 	if amIMember {
-		chat.RemoveMember(common.PubkeyToHex(&m.identity.PublicKey))
+		chat.RemoveMember(crypto.PubkeyToHex(&m.identity.PublicKey))
 
 		group, err := newProtocolGroupFromChat(chat)
 		if err != nil {

--- a/protocol/messenger_group_chat_test.go
+++ b/protocol/messenger_group_chat_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/crypto"
 	userimage "github.com/status-im/status-go/images"
 	multiaccountscommon "github.com/status-im/status-go/multiaccounts/common"
 
 	"github.com/status-im/status-go/multiaccounts/settings"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -120,7 +120,7 @@ func (s *MessengerGroupChatSuite) TestGroupChatCreation() {
 		defer TearDownMessenger(&s.Suite, creator)
 		defer TearDownMessenger(&s.Suite, member)
 
-		members := []string{common.PubkeyToHex(&member.identity.PublicKey)}
+		members := []string{crypto.PubkeyToHex(&member.identity.PublicKey)}
 
 		if testCase.creatorAddedMemberAsContact {
 			s.makeContact(creator, member)
@@ -183,7 +183,7 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersAddition() {
 		defer TearDownMessenger(&s.Suite, inviter)
 		defer TearDownMessenger(&s.Suite, member)
 
-		members := []string{common.PubkeyToHex(&member.identity.PublicKey)}
+		members := []string{crypto.PubkeyToHex(&member.identity.PublicKey)}
 
 		if testCase.inviterAddedMemberAsContact {
 			s.makeContact(inviter, member)
@@ -198,7 +198,7 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersAddition() {
 				groupChat = s.createEmptyGroupChat(inviter, fmt.Sprintf("test_group_chat_%d_%d", i, j))
 			} else {
 				s.makeContact(admin, inviter)
-				groupChat = s.createGroupChat(admin, fmt.Sprintf("test_group_chat_%d_%d", i, j), []string{common.PubkeyToHex(&inviter.identity.PublicKey)})
+				groupChat = s.createGroupChat(admin, fmt.Sprintf("test_group_chat_%d_%d", i, j), []string{crypto.PubkeyToHex(&inviter.identity.PublicKey)})
 				err := inviter.SaveChat(groupChat)
 				s.Require().NoError(err)
 			}
@@ -221,8 +221,8 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersRemoval() {
 	defer TearDownMessenger(&s.Suite, memberB)
 	defer TearDownMessenger(&s.Suite, memberC)
 
-	members := []string{common.PubkeyToHex(&memberA.identity.PublicKey), common.PubkeyToHex(&memberB.identity.PublicKey),
-		common.PubkeyToHex(&memberC.identity.PublicKey)}
+	members := []string{crypto.PubkeyToHex(&memberA.identity.PublicKey), crypto.PubkeyToHex(&memberB.identity.PublicKey),
+		crypto.PubkeyToHex(&memberC.identity.PublicKey)}
 
 	s.makeMutualContacts(admin, memberA)
 	s.makeMutualContacts(admin, memberB)
@@ -233,13 +233,13 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersRemoval() {
 	s.verifyGroupChatCreated(memberB, true)
 	s.verifyGroupChatCreated(memberC, true)
 
-	_, err := memberA.RemoveMembersFromGroupChat(context.Background(), groupChat.ID, []string{common.PubkeyToHex(&memberB.identity.PublicKey),
-		common.PubkeyToHex(&memberC.identity.PublicKey)})
+	_, err := memberA.RemoveMembersFromGroupChat(context.Background(), groupChat.ID, []string{crypto.PubkeyToHex(&memberB.identity.PublicKey),
+		crypto.PubkeyToHex(&memberC.identity.PublicKey)})
 	s.Require().Error(err)
 
 	// only admin can remove members from the group
-	_, err = admin.RemoveMembersFromGroupChat(context.Background(), groupChat.ID, []string{common.PubkeyToHex(&memberB.identity.PublicKey),
-		common.PubkeyToHex(&memberC.identity.PublicKey)})
+	_, err = admin.RemoveMembersFromGroupChat(context.Background(), groupChat.ID, []string{crypto.PubkeyToHex(&memberB.identity.PublicKey),
+		crypto.PubkeyToHex(&memberC.identity.PublicKey)})
 	s.Require().NoError(err)
 
 	// ensure removal is propagated to other members
@@ -261,7 +261,7 @@ func (s *MessengerGroupChatSuite) TestGroupChatEdit() {
 
 	s.makeMutualContacts(admin, member)
 
-	groupChat := s.createGroupChat(admin, "test_group_chat", []string{common.PubkeyToHex(&member.identity.PublicKey)})
+	groupChat := s.createGroupChat(admin, "test_group_chat", []string{crypto.PubkeyToHex(&member.identity.PublicKey)})
 	s.verifyGroupChatCreated(member, true)
 
 	response, err := admin.EditGroupChat(context.Background(), groupChat.ID, "test_admin_group", "#FF00FF", userimage.CroppedImage{})
@@ -331,7 +331,7 @@ func (s *MessengerGroupChatSuite) TestGroupChatDeleteMemberMessage() {
 
 	s.makeMutualContacts(admin, member)
 
-	groupChat := s.createGroupChat(admin, "test_group_chat", []string{common.PubkeyToHex(&member.identity.PublicKey)})
+	groupChat := s.createGroupChat(admin, "test_group_chat", []string{crypto.PubkeyToHex(&member.identity.PublicKey)})
 	s.verifyGroupChatCreated(member, true)
 
 	ctx := context.Background()
@@ -369,7 +369,7 @@ func (s *MessengerGroupChatSuite) TestGroupChatHandleDeleteMemberMessage() {
 
 	s.makeMutualContacts(admin, member)
 
-	groupChat := s.createGroupChat(admin, "test_group_chat", []string{common.PubkeyToHex(&member.identity.PublicKey)})
+	groupChat := s.createGroupChat(admin, "test_group_chat", []string{crypto.PubkeyToHex(&member.identity.PublicKey)})
 	s.verifyGroupChatCreated(member, true)
 
 	ctx := context.Background()
@@ -393,7 +393,7 @@ func (s *MessengerGroupChatSuite) TestGroupChatHandleDeleteMemberMessage() {
 			MessageId:   inputMessage.ID,
 			ChatId:      groupChat.ID,
 		},
-		From: common.PubkeyToHex(&admin.identity.PublicKey),
+		From: crypto.PubkeyToHex(&admin.identity.PublicKey),
 	}
 
 	state := &ReceivedMessageState{
@@ -413,13 +413,13 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersRemovalOutOfOrder() {
 	defer TearDownMessenger(&s.Suite, admin)
 	defer TearDownMessenger(&s.Suite, memberA)
 
-	members := []string{common.PubkeyToHex(&memberA.identity.PublicKey)}
+	members := []string{crypto.PubkeyToHex(&memberA.identity.PublicKey)}
 
 	s.makeMutualContacts(admin, memberA)
 
 	groupChat := s.createGroupChat(admin, "test_group_chat", members)
 
-	removeMembersResponse, err := admin.removeMembersFromGroupChat(context.Background(), groupChat, []string{common.PubkeyToHex(&memberA.identity.PublicKey)})
+	removeMembersResponse, err := admin.removeMembersFromGroupChat(context.Background(), groupChat, []string{crypto.PubkeyToHex(&memberA.identity.PublicKey)})
 	s.Require().NoError(err)
 
 	encodedMessage := removeMembersResponse.encodedProtobuf
@@ -463,7 +463,7 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersInfoSync() {
 	s.Require().NoError(memberA.settings.SaveSettingField(settings.DisplayName, "memberA"))
 	s.Require().NoError(memberB.settings.SaveSettingField(settings.DisplayName, "memberB"))
 
-	members := []string{common.PubkeyToHex(&memberA.identity.PublicKey), common.PubkeyToHex(&memberB.identity.PublicKey)}
+	members := []string{crypto.PubkeyToHex(&memberA.identity.PublicKey), crypto.PubkeyToHex(&memberB.identity.PublicKey)}
 
 	s.makeMutualContacts(admin, memberA)
 	s.makeMutualContacts(admin, memberB)
@@ -490,7 +490,7 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersInfoSync() {
 			if err != nil {
 				return false
 			}
-			contact, ok := memberA.allContacts.Load(common.PubkeyToHex(&memberB.identity.PublicKey))
+			contact, ok := memberA.allContacts.Load(crypto.PubkeyToHex(&memberB.identity.PublicKey))
 			return ok && contact.DisplayName == "memberB" && contact.CustomizationColor == memberB.account.GetCustomizationColor()
 		},
 		"DisplayName is not the same",

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -502,7 +502,7 @@ func (m *Messenger) HandleSyncInstallationContactV2(state *ReceivedMessageState,
 	removed := message.Removed && !message.Blocked
 	chat, ok := state.AllChats.Load(message.Id)
 	if !ok && (message.Added || message.HasAddedUs || message.Muted) && !removed {
-		pubKey, err := common.HexToPubkey(message.Id)
+		pubKey, err := crypto.HexToPubkey(message.Id)
 		if err != nil {
 			return err
 		}
@@ -611,7 +611,7 @@ func (m *Messenger) HandleSyncInstallationContactV2(state *ReceivedMessageState,
 				return err
 			}
 
-			err = m.ENSVerified(common.PubkeyToHex(publicKey), message.EnsName)
+			err = m.ENSVerified(crypto.PubkeyToHex(publicKey), message.EnsName)
 			if err != nil {
 				contact.ENSVerified = false
 			}
@@ -1117,7 +1117,7 @@ func (m *Messenger) HandleRetractContactRequest(state *ReceivedMessageState, mes
 func (m *Messenger) HandleContactUpdate(state *ReceivedMessageState, message *protobuf.ContactUpdate, statusMessage *messagingtypes.Message) error {
 
 	logger := m.logger.With(zap.String("site", "HandleContactUpdate"))
-	if common.IsPubKeyEqual(state.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
+	if crypto.IsPubKeyEqual(state.CurrentMessageState.PublicKey, &m.identity.PublicKey) {
 		logger.Warn("coming from us, ignoring")
 		return nil
 	}
@@ -1698,7 +1698,7 @@ func (m *Messenger) HandleCommunityRequestToLeave(state *ReceivedMessageState, r
 		return err
 	}
 
-	response, err := m.RemoveUserFromCommunity(requestToLeaveProto.CommunityId, common.PubkeyToHex(signer))
+	response, err := m.RemoveUserFromCommunity(requestToLeaveProto.CommunityId, crypto.PubkeyToHex(signer))
 	if err != nil {
 		return err
 	}
@@ -1842,7 +1842,7 @@ func (m *Messenger) handleDeleteMessage(state *ReceivedMessageState, deleteMessa
 
 	var canDeleteMessageForEveryone = false
 	if originalMessage.From != deleteMessage.From {
-		fromPublicKey, err := common.HexToPubkey(deleteMessage.From)
+		fromPublicKey, err := crypto.HexToPubkey(deleteMessage.From)
 		if err != nil {
 			return err
 		}
@@ -2058,7 +2058,7 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 	}
 
 	// is the message coming from us?
-	isSyncMessage := common.IsPubKeyEqual(receivedMessage.SigPubKey, &m.identity.PublicKey)
+	isSyncMessage := crypto.IsPubKeyEqual(receivedMessage.SigPubKey, &m.identity.PublicKey)
 
 	if forceSeen || isSyncMessage {
 		receivedMessage.Seen = true
@@ -2118,7 +2118,7 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 			return communities.ErrOrgNotFound
 		}
 
-		pk, err := common.HexToPubkey(state.CurrentMessageState.Contact.ID)
+		pk, err := crypto.HexToPubkey(state.CurrentMessageState.Contact.ID)
 		if err != nil {
 			return err
 		}
@@ -2480,7 +2480,7 @@ func (m *Messenger) matchChatEntity(chatEntity messagingtypes.ChatEntity, messag
 			return nil, ErrMessageForWrongChatType
 		}
 		return chat, nil
-	case chatEntity.GetMessageType() == protobuf.MessageType_ONE_TO_ONE && common.IsPubKeyEqual(chatEntity.GetSigPubKey(), &m.identity.PublicKey):
+	case chatEntity.GetMessageType() == protobuf.MessageType_ONE_TO_ONE && crypto.IsPubKeyEqual(chatEntity.GetSigPubKey(), &m.identity.PublicKey):
 		// It's a private message coming from us so we rely on Message.ChatID
 		// If chat does not exist, it should be created to support multidevice synchronization.
 		chatID := chatEntity.GetChatId()

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -169,7 +169,7 @@ func (m *Messenger) filtersForChat(chatID string) (messagingtypes.ChatFilters, e
 
 	if chat.OneToOne() {
 		// We sync our own topic and any eventual negotiated
-		publicKeys := []string{common.PubkeyToHex(&m.identity.PublicKey), chatID}
+		publicKeys := []string{crypto.PubkeyToHex(&m.identity.PublicKey), chatID}
 
 		filters = m.messaging.ChatFiltersByIdentities(publicKeys)
 
@@ -578,7 +578,7 @@ func (m *Messenger) calculateGapForChat(chat *Chat, from uint32) (*common.Messag
 			From: chat.SyncedTo,
 			To:   from,
 		},
-		From:             common.PubkeyToHex(&m.identity.PublicKey),
+		From:             crypto.PubkeyToHex(&m.identity.PublicKey),
 		WhisperTimestamp: timestamp,
 		LocalChatID:      chat.ID,
 		Seen:             true,

--- a/protocol/messenger_mention.go
+++ b/protocol/messenger_mention.go
@@ -14,10 +14,10 @@ import (
 	"go.uber.org/zap"
 
 	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/logutils"
 
 	"github.com/status-im/status-go/api/multiformat"
-	"github.com/status-im/status-go/protocol/common"
 )
 
 const (
@@ -248,7 +248,7 @@ func (m *MentionManager) getMentionableUsers(chatID string) (map[string]*Mention
 			return nil, err
 		}
 		for _, pk := range community.GetMemberPubkeys() {
-			publicKeys = append(publicKeys, common.PubkeyToHex(pk))
+			publicKeys = append(publicKeys, crypto.PubkeyToHex(pk))
 		}
 	case chat.Public():
 		m.allContacts.Range(func(pk string, _ *Contact) bool {

--- a/protocol/messenger_messages.go
+++ b/protocol/messenger_messages.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/crypto"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -31,7 +32,7 @@ func (m *Messenger) EditMessage(ctx context.Context, request *requests.EditMessa
 		return nil, err
 	}
 
-	if message.From != common.PubkeyToHex(&m.identity.PublicKey) {
+	if message.From != crypto.PubkeyToHex(&m.identity.PublicKey) {
 		return nil, ErrInvalidEditOrDeleteAuthor
 	}
 
@@ -161,7 +162,7 @@ func (m *Messenger) CanDeleteMessageForEveryoneInPrivateGroupChat(chat *Chat, pu
 		return false
 	}
 	admins := group.Admins()
-	return stringSliceContains(admins, common.PubkeyToHex(publicKey))
+	return stringSliceContains(admins, crypto.PubkeyToHex(publicKey))
 }
 
 func (m *Messenger) DeleteMessageAndSend(ctx context.Context, messageID string) (*MessengerResponse, error) {
@@ -178,7 +179,7 @@ func (m *Messenger) DeleteMessageAndSend(ctx context.Context, messageID string) 
 
 	var canDeleteMessageForEveryone = false
 	var deletedBy string
-	if message.From != common.PubkeyToHex(&m.identity.PublicKey) {
+	if message.From != crypto.PubkeyToHex(&m.identity.PublicKey) {
 		if message.MessageType == protobuf.MessageType_COMMUNITY_CHAT {
 			communityID := chat.CommunityID
 			canDeleteMessageForEveryone = m.CanDeleteMessageForEveryoneInCommunity(communityID, &m.identity.PublicKey)
@@ -407,7 +408,7 @@ func (m *Messenger) applyEditMessage(editMessage *protobuf.EditMessage, message 
 		}
 	}
 
-	err := message.PrepareContent(common.PubkeyToHex(&m.identity.PublicKey))
+	err := message.PrepareContent(crypto.PubkeyToHex(&m.identity.PublicKey))
 	if err != nil {
 		return err
 	}
@@ -423,7 +424,7 @@ func (m *Messenger) applyDeleteMessage(messageDeletes []*DeleteMessage, message 
 	message.Deleted = true
 	message.DeletedBy = messageDeletes[0].DeletedBy
 
-	err := message.PrepareContent(common.PubkeyToHex(&m.identity.PublicKey))
+	err := message.PrepareContent(crypto.PubkeyToHex(&m.identity.PublicKey))
 	if err != nil {
 		return err
 	}
@@ -483,7 +484,7 @@ func (m *Messenger) SendOneToOneMessage(request *requests.SendOneToOneMessage) (
 	_, ok := m.allChats.Load(chatID)
 	if !ok {
 		// Only one to one chan be muted when it's not in the database
-		publicKey, err := common.HexToPubkey(chatID)
+		publicKey, err := crypto.HexToPubkey(chatID)
 		if err != nil {
 			return nil, err
 		}

--- a/protocol/messenger_peersyncing.go
+++ b/protocol/messenger_peersyncing.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
 	"github.com/status-im/status-go/protocol/common"
@@ -230,7 +231,7 @@ func (m *Messenger) OnDatasyncOffer(response *messagingtypes.HandleMessageRespon
 		return nil
 	}
 
-	if common.PubkeyToHex(sender) == m.myHexIdentity() {
+	if crypto.PubkeyToHex(sender) == m.myHexIdentity() {
 		return nil
 	}
 
@@ -264,7 +265,7 @@ func (m *Messenger) OnDatasyncOffer(response *messagingtypes.HandleMessageRespon
 		return err
 	}
 	rawMessage := messagingtypes.RawMessage{
-		LocalChatID:         common.PubkeyToHex(sender),
+		LocalChatID:         crypto.PubkeyToHex(sender),
 		Payload:             payload,
 		Ephemeral:           true,
 		SkipApplicationWrap: true,
@@ -313,7 +314,7 @@ func (m *Messenger) canSyncCommunityMessageWith(chat *Chat, community *communiti
 }
 
 func (m *Messenger) canSyncOneToOneMessageWith(chat *Chat, peer *ecdsa.PublicKey) (bool, error) {
-	return chat.HasMember(common.PubkeyToHex(peer)), nil
+	return chat.HasMember(crypto.PubkeyToHex(peer)), nil
 }
 
 func (m *Messenger) OnDatasyncRequests(requester *ecdsa.PublicKey, messageIDs [][]byte) error {
@@ -333,7 +334,7 @@ func (m *Messenger) OnDatasyncRequests(requester *ecdsa.PublicKey, messageIDs []
 		if !canSync {
 			continue
 		}
-		idString := common.PubkeyToHex(requester) + types.Bytes2Hex(msg.ID)
+		idString := crypto.PubkeyToHex(requester) + types.Bytes2Hex(msg.ID)
 		lastRequested := m.peersyncingRequests[idString]
 		timeNow := m.GetCurrentTimeInMillis() / 1000
 		if lastRequested+30 < timeNow {
@@ -341,7 +342,7 @@ func (m *Messenger) OnDatasyncRequests(requester *ecdsa.PublicKey, messageIDs []
 
 			// Check permissions
 			rawMessage := messagingtypes.RawMessage{
-				LocalChatID:         common.PubkeyToHex(requester),
+				LocalChatID:         crypto.PubkeyToHex(requester),
 				Payload:             msg.Payload,
 				Ephemeral:           true,
 				SkipApplicationWrap: true,

--- a/protocol/messenger_profile_showcase.go
+++ b/protocol/messenger_profile_showcase.go
@@ -423,7 +423,7 @@ func (m *Messenger) GetProfileShowcaseForContact(contactID string, validate bool
 		return profileShowcase, nil
 	}
 
-	contactPubKey, err := common.HexToPubkey(contactID)
+	contactPubKey, err := crypto.HexToPubkey(contactID)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_raw_message_resend.go
+++ b/protocol/messenger_raw_message_resend.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/crypto"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
 	"github.com/status-im/status-go/protocol/protobuf"
 
@@ -106,7 +107,7 @@ func (m *Messenger) handleSendPrivateMessage(rawMessage *messagingtypes.RawMessa
 	for _, r := range rawMessage.Recipients {
 		_, err = m.messaging.SendPrivate(context.TODO(), r, rawMessage)
 		if err != nil {
-			err = errors.Wrap(err, fmt.Sprintf("Can't resend message with SendPrivate to %s", common.PubkeyToHex(r)))
+			err = errors.Wrap(err, fmt.Sprintf("Can't resend message with SendPrivate to %s", crypto.PubkeyToHex(r)))
 		}
 	}
 

--- a/protocol/messenger_remove_message_test.go
+++ b/protocol/messenger_remove_message_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/server"
@@ -169,7 +170,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageFirstThenMessage() {
 			MessageId:   messageID,
 			ChatId:      theirChat.ID,
 		},
-		From: common.PubkeyToHex(&theirMessenger.identity.PublicKey),
+		From: crypto.PubkeyToHex(&theirMessenger.identity.PublicKey),
 	}
 
 	state := &ReceivedMessageState{
@@ -305,7 +306,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteImageMessageFirstThenMessage() {
 			MessageId:   messageID1,
 			ChatId:      theirChat.ID,
 		},
-		From: common.PubkeyToHex(&theirMessenger.identity.PublicKey),
+		From: crypto.PubkeyToHex(&theirMessenger.identity.PublicKey),
 	}
 
 	state := &ReceivedMessageState{
@@ -362,7 +363,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageWithAMention() {
 	s.Require().NoError(err)
 
 	inputMessage := buildTestMessage(*theirChat)
-	inputMessage.Text = "text with a mention @" + common.PubkeyToHex(&s.privateKey.PublicKey)
+	inputMessage.Text = "text with a mention @" + crypto.PubkeyToHex(&s.privateKey.PublicKey)
 	sendResponse, err := theirMessenger.SendChatMessage(context.Background(), inputMessage)
 	s.NoError(err)
 	s.Require().Len(sendResponse.Messages(), 1)
@@ -389,7 +390,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageWithAMention() {
 			MessageId:   messageID,
 			ChatId:      theirChat.ID,
 		},
-		From: common.PubkeyToHex(&theirMessenger.identity.PublicKey),
+		From: crypto.PubkeyToHex(&theirMessenger.identity.PublicKey),
 	}
 
 	state := &ReceivedMessageState{
@@ -451,7 +452,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageAndChatIsAlreadyRead() {
 			MessageId:   ogMessage.ID,
 			ChatId:      theirChat.ID,
 		},
-		From: common.PubkeyToHex(&theirMessenger.identity.PublicKey),
+		From: crypto.PubkeyToHex(&theirMessenger.identity.PublicKey),
 	}
 
 	state := &ReceivedMessageState{

--- a/protocol/messenger_send_images_album_test.go
+++ b/protocol/messenger_send_images_album_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
@@ -124,7 +125,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesWithMentionSend() 
 		outgoingMessage, err := buildImageWithoutAlbumIDMessage(*ourChat)
 		s.NoError(err)
 		outgoingMessage.Mentioned = true
-		outgoingMessage.Text = "hey @" + common.PubkeyToHex(&theirMessenger.identity.PublicKey)
+		outgoingMessage.Text = "hey @" + crypto.PubkeyToHex(&theirMessenger.identity.PublicKey)
 		album = append(album, outgoingMessage)
 	}
 
@@ -175,7 +176,7 @@ func (s *MessengerSendImagesAlbumSuite) TestSingleImageMessageWithMentionInCommu
 		outgoingMessage, err := buildImageWithoutAlbumIDMessage(*chat)
 		s.NoError(err)
 		outgoingMessage.Mentioned = true
-		outgoingMessage.Text = "hey @" + common.PubkeyToHex(&theirMessenger.identity.PublicKey)
+		outgoingMessage.Text = "hey @" + crypto.PubkeyToHex(&theirMessenger.identity.PublicKey)
 		album = append(album, outgoingMessage)
 	}
 
@@ -310,7 +311,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImagesMessageWithMentionInCommu
 		outgoingMessage, err := buildImageWithoutAlbumIDMessage(*chat)
 		s.NoError(err)
 		outgoingMessage.Mentioned = true
-		outgoingMessage.Text = "hey @" + common.PubkeyToHex(&theirMessenger.identity.PublicKey)
+		outgoingMessage.Text = "hey @" + crypto.PubkeyToHex(&theirMessenger.identity.PublicKey)
 		album = append(album, outgoingMessage)
 	}
 

--- a/protocol/messenger_share_image_test.go
+++ b/protocol/messenger_share_image_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
@@ -93,7 +94,7 @@ func (s *MessengerShareMessageSuite) TestImageMessageSharing() {
 	shareResponse, err := s.m.ShareImageMessage(
 		&requests.ShareImageMessage{
 			MessageID: MessageID,
-			Users:     []types.HexBytes{common.PubkeyToHexBytes(&theirMessenger.identity.PublicKey)},
+			Users:     []types.HexBytes{crypto.PubkeyToHexBytes(&theirMessenger.identity.PublicKey)},
 		},
 	)
 

--- a/protocol/messenger_share_urls.go
+++ b/protocol/messenger_share_urls.go
@@ -16,7 +16,6 @@ import (
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
@@ -76,7 +75,7 @@ func decodeCommunityID(serialisedPublicKey string) (string, error) {
 		return "", err
 	}
 
-	communityID, err := common.HexToPubkey(deserializedCommunityID)
+	communityID, err := crypto.HexToPubkey(deserializedCommunityID)
 	if err != nil {
 		return "", err
 	}
@@ -386,7 +385,7 @@ func parseCommunityChannelURLWithData(data string, chatKey string) (*URLDataResp
 }
 
 func (m *Messenger) ShareUserURLWithChatKey(contactID string) (string, error) {
-	publicKey, err := common.HexToPubkey(contactID)
+	publicKey, err := crypto.HexToPubkey(contactID)
 	if err != nil {
 		return "", err
 	}
@@ -410,7 +409,7 @@ func parseUserURLWithChatKey(urlData string) (*URLDataResponse, error) {
 		return nil, err
 	}
 
-	serializedPublicKey, err := multiformat.SerializeLegacyKey(common.PubkeyToHex(pubKey))
+	serializedPublicKey, err := multiformat.SerializeLegacyKey(crypto.PubkeyToHex(pubKey))
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_status_updates.go
+++ b/protocol/messenger_status_updates.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/messaging"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
 
@@ -247,7 +248,7 @@ func (m *Messenger) HandleStatusUpdate(state *ReceivedMessageState, message *pro
 		return err
 	}
 
-	if common.IsPubKeyEqual(state.CurrentMessageState.PublicKey, &m.identity.PublicKey) { // Status message is ours
+	if crypto.IsPubKeyEqual(state.CurrentMessageState.PublicKey, &m.identity.PublicKey) { // Status message is ours
 		currentStatus, err := m.GetCurrentUserStatus()
 		if err != nil {
 			m.logger.Debug("Error obtaining latest status", zap.Error(err))

--- a/protocol/messenger_sync_activity_center_test.go
+++ b/protocol/messenger_sync_activity_center_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 
@@ -170,7 +170,7 @@ func (s *MessengerSyncActivityCenterSuite) createClosedCommunity() types.HexByte
 }
 
 func (s *MessengerSyncActivityCenterSuite) addContactAndShareCommunity(userB *Messenger, communityID types.HexBytes) {
-	request := &requests.AddContact{ID: common.PubkeyToHex(&s.m2.identity.PublicKey)}
+	request := &requests.AddContact{ID: crypto.PubkeyToHex(&s.m2.identity.PublicKey)}
 	response, err := userB.AddContact(context.Background(), request)
 	s.Require().NoError(err)
 	s.Require().Len(response.Messages(), 2)

--- a/protocol/messenger_sync_contact_request_decision_test.go
+++ b/protocol/messenger_sync_contact_request_decision_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/requests"
 )
@@ -53,7 +53,7 @@ func (s *MessengerSyncContactRequestDecisionSuite) TestSyncAcceptContactRequest(
 		}
 	}
 	// send contact request to m/m2, m and m2 are paired
-	request := &requests.AddContact{ID: common.PubkeyToHex(&s.m2.identity.PublicKey)}
+	request := &requests.AddContact{ID: crypto.PubkeyToHex(&s.m2.identity.PublicKey)}
 	_, err := userB.AddContact(context.Background(), request)
 	s.Require().NoError(err)
 

--- a/protocol/messenger_sync_raw_messages.go
+++ b/protocol/messenger_sync_raw_messages.go
@@ -6,8 +6,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"go.uber.org/zap"
 
+	"github.com/status-im/status-go/crypto"
 	messagingtypes "github.com/status-im/status-go/messaging/types"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
@@ -23,7 +23,7 @@ func (m *Messenger) HandleSyncRawMessages(rawMessages []*protobuf.RawMessage) er
 			if err != nil {
 				return err
 			}
-			publicKey, err := common.HexToPubkey(message.PublicKey)
+			publicKey, err := crypto.HexToPubkey(message.PublicKey)
 			if err != nil {
 				return err
 			}

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -220,11 +220,11 @@ func (s *MessengerSuite) TestMarkMessagesSeen() {
 	inputMessage1 := buildTestMessage(*chat)
 	inputMessage1.ID = "1"
 	inputMessage1.Seen = false
-	inputMessage1.Text = "hey @" + common.PubkeyToHex(&s.m.identity.PublicKey)
+	inputMessage1.Text = "hey @" + crypto.PubkeyToHex(&s.m.identity.PublicKey)
 	inputMessage1.Mentioned = true
 	inputMessage2 := buildTestMessage(*chat)
 	inputMessage2.ID = "2"
-	inputMessage2.Text = "hey @" + common.PubkeyToHex(&s.m.identity.PublicKey)
+	inputMessage2.Text = "hey @" + crypto.PubkeyToHex(&s.m.identity.PublicKey)
 	inputMessage2.Mentioned = true
 	inputMessage2.Seen = false
 
@@ -1220,7 +1220,7 @@ func (s *MessengerSuite) TestBlockContact() {
 	s.Require().NoError(err)
 
 	contact2 := Contact{
-		ID:                       common.PubkeyToHex(&key2.PublicKey),
+		ID:                       crypto.PubkeyToHex(&key2.PublicKey),
 		EnsName:                  "contact-name",
 		LastUpdated:              20,
 		ContactRequestLocalState: ContactRequestStateSent,
@@ -1418,7 +1418,7 @@ func (s *MessengerSuite) TestSharedSecretHandler() {
 func (s *MessengerSuite) TestCreateGroupChatWithMembers() {
 	members := []string{testPK}
 
-	pubKey, err := common.HexToPubkey(testPK)
+	pubKey, err := crypto.HexToPubkey(testPK)
 	s.Require().NoError(err)
 	s.Require().NoError(makeMutualContact(s.m, pubKey))
 
@@ -1826,8 +1826,8 @@ func (s *MessengerSuite) TestSendMessageMention() {
 	s.Require().NoError(alice.settings.SaveSettingField(settings.NotificationsEnabled, true))
 
 	// Create one-to-one chats
-	chat, chat2 := CreateOneToOneChat(common.PubkeyToHex(&alice.identity.PublicKey), &alice.identity.PublicKey, bob.getTimesource()),
-		CreateOneToOneChat(common.PubkeyToHex(&bob.identity.PublicKey), &bob.identity.PublicKey, alice.getTimesource())
+	chat, chat2 := CreateOneToOneChat(crypto.PubkeyToHex(&alice.identity.PublicKey), &alice.identity.PublicKey, bob.getTimesource()),
+		CreateOneToOneChat(crypto.PubkeyToHex(&bob.identity.PublicKey), &bob.identity.PublicKey, alice.getTimesource())
 	s.Require().NoError(bob.SaveChat(chat))
 	s.Require().NoError(alice.SaveChat(chat2))
 

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -908,7 +908,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	community := response.Communities()[0]
 
 	// Send a community message
-	chat := CreateOneToOneChat(common.PubkeyToHex(&alice.identity.PublicKey), &alice.identity.PublicKey, alice.getTimesource())
+	chat := CreateOneToOneChat(crypto.PubkeyToHex(&alice.identity.PublicKey), &alice.identity.PublicKey, alice.getTimesource())
 
 	inputMessage := common.NewMessage()
 	inputMessage.ChatId = chat.ID
@@ -946,7 +946,7 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	s.Require().True(requestToJoin1.Our)
 	s.Require().NotEmpty(requestToJoin1.ID)
 	s.Require().NotEmpty(requestToJoin1.Clock)
-	s.Require().Equal(requestToJoin1.PublicKey, common.PubkeyToHex(&alice.identity.PublicKey))
+	s.Require().Equal(requestToJoin1.PublicKey, crypto.PubkeyToHex(&alice.identity.PublicKey))
 	s.Require().Equal(communities.RequestToJoinStatePending, requestToJoin1.State)
 
 	err = tt.RetryWithBackOff(func() error {

--- a/protocol/pushnotificationclient/client.go
+++ b/protocol/pushnotificationclient/client.go
@@ -528,7 +528,7 @@ func (c *Client) HandleContactCodeAdvertisement(clientPublicKey *ecdsa.PublicKey
 		return nil
 	}
 	// nothing to do for our own pubkey
-	if common.IsPubKeyEqual(clientPublicKey, &c.config.Identity.PublicKey) {
+	if crypto.IsPubKeyEqual(clientPublicKey, &c.config.Identity.PublicKey) {
 		return nil
 	}
 
@@ -593,7 +593,7 @@ func (c *Client) AddPushNotificationsServer(publicKey *ecdsa.PublicKey, serverTy
 	}
 
 	for _, server := range currentServers {
-		if common.IsPubKeyEqual(server.PublicKey, publicKey) {
+		if crypto.IsPubKeyEqual(server.PublicKey, publicKey) {
 			return errors.New("push notification server already added")
 		}
 	}
@@ -844,7 +844,7 @@ func (c *Client) handleMessageSent(e *messagingevents.MessageEvent) error {
 	}
 
 	// check if it's for one of our devices, do nothing in that case
-	if e.Recipient != nil && common.IsPubKeyEqual(e.Recipient, &c.config.Identity.PublicKey) {
+	if e.Recipient != nil && crypto.IsPubKeyEqual(e.Recipient, &c.config.Identity.PublicKey) {
 		return nil
 	}
 
@@ -1095,7 +1095,7 @@ func (c *Client) handleMessageScheduled(e *messagingevents.MessageEvent) error {
 	}
 
 	// check if it's for one of our devices, do nothing in that case
-	if e.Recipient != nil && common.IsPubKeyEqual(e.Recipient, &c.config.Identity.PublicKey) {
+	if e.Recipient != nil && crypto.IsPubKeyEqual(e.Recipient, &c.config.Identity.PublicKey) {
 		return nil
 	}
 
@@ -1109,7 +1109,7 @@ func (c *Client) handleMessageScheduled(e *messagingevents.MessageEvent) error {
 // shouldNotifyOn check whether we should notify a particular public-key/installation-id/message-id combination
 func (c *Client) shouldNotifyOn(publicKey *ecdsa.PublicKey, installationID string, messageID []byte) (bool, error) {
 
-	if publicKey != nil && common.IsPubKeyEqual(publicKey, &c.config.Identity.PublicKey) {
+	if publicKey != nil && crypto.IsPubKeyEqual(publicKey, &c.config.Identity.PublicKey) {
 		return false, nil
 	}
 
@@ -1360,7 +1360,7 @@ func (c *Client) registerWithServer(registration *protobuf.PushNotificationRegis
 // the notification is sent using an ephemeral key to shield the real identity of the sender
 func (c *Client) SendNotification(publicKey *ecdsa.PublicKey, installationIDs []string, messageID []byte, chatID string, notificationType protobuf.PushNotification_PushNotificationType) ([]*PushNotificationInfo, error) {
 
-	if common.IsPubKeyEqual(publicKey, &c.config.Identity.PublicKey) {
+	if crypto.IsPubKeyEqual(publicKey, &c.config.Identity.PublicKey) {
 		return nil, nil
 	}
 
@@ -1642,7 +1642,7 @@ func (c *Client) handleGrant(clientPublicKey *ecdsa.PublicKey, serverPublicKey *
 		return err
 	}
 
-	if !common.IsPubKeyEqual(clientPublicKey, extractedPublicKey) {
+	if !crypto.IsPubKeyEqual(clientPublicKey, extractedPublicKey) {
 		return errors.New("invalid grant")
 	}
 	return nil

--- a/protocol/pushnotificationclient/persistence_test.go
+++ b/protocol/pushnotificationclient/persistence_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/crypto"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/sqlite"
 	"github.com/status-im/status-go/t/helpers"
@@ -60,7 +59,7 @@ func (s *SQLitePersistenceSuite) TestSaveAndRetrieveServer() {
 	s.Require().Len(retrievedServers, 1)
 	s.Require().True(retrievedServers[0].Registered)
 	s.Require().Equal(int64(1), retrievedServers[0].RegisteredAt)
-	s.Require().True(common.IsPubKeyEqual(retrievedServers[0].PublicKey, &key.PublicKey))
+	s.Require().True(crypto.IsPubKeyEqual(retrievedServers[0].PublicKey, &key.PublicKey))
 	s.Require().Equal(testAccessToken, retrievedServers[0].AccessToken)
 
 	server.Registered = false
@@ -74,7 +73,7 @@ func (s *SQLitePersistenceSuite) TestSaveAndRetrieveServer() {
 	s.Require().Len(retrievedServers, 1)
 	s.Require().False(retrievedServers[0].Registered)
 	s.Require().Equal(int64(2), retrievedServers[0].RegisteredAt)
-	s.Require().True(common.IsPubKeyEqual(retrievedServers[0].PublicKey, &key.PublicKey))
+	s.Require().True(crypto.IsPubKeyEqual(retrievedServers[0].PublicKey, &key.PublicKey))
 }
 
 func (s *SQLitePersistenceSuite) TestSaveAndRetrieveInfo() {

--- a/protocol/pushnotificationserver/server.go
+++ b/protocol/pushnotificationserver/server.go
@@ -212,7 +212,7 @@ func (s *Server) verifyGrantSignature(clientPublicKey *ecdsa.PublicKey, accessTo
 		return err
 	}
 
-	if !common.IsPubKeyEqual(recoveredPublicKey, clientPublicKey) {
+	if !crypto.IsPubKeyEqual(recoveredPublicKey, clientPublicKey) {
 		return errors.New("pubkey mismatch")
 	}
 	return nil

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -613,7 +613,7 @@ func (s *HandlersSuite) TestHandleAccountInitialsImpl() {
 	// pass a public key to generate ring
 	k, err := crypto.GenerateKey()
 	s.Require().NoError(err)
-	p.PublicKey = common.PubkeyToHex(&k.PublicKey)
+	p.PublicKey = crypto.PubkeyToHex(&k.PublicKey)
 	w = httptest.NewRecorder()
 	handleAccountInitialsImpl(db, s.logger, w, p)
 	s.Require().Equal(http.StatusOK, w.Code)
@@ -669,7 +669,7 @@ func (s *HandlersSuite) TestHandleAccountImagesImpl() {
 	// pass a public key to generate ring
 	k, err := crypto.GenerateKey()
 	s.Require().NoError(err)
-	p.PublicKey = common.PubkeyToHex(&k.PublicKey)
+	p.PublicKey = crypto.PubkeyToHex(&k.PublicKey)
 	w = httptest.NewRecorder()
 	s.server.handleAccountImagesImpl(w, p)
 	s.Require().Equal(http.StatusOK, w.Code)

--- a/services/chat/api_group_chats.go
+++ b/services/chat/api_group_chats.go
@@ -155,7 +155,7 @@ func (api *API) StartGroupChat(ctx context.Context, communityID types.HexBytes, 
 	var response *protocol.MessengerResponse
 	var err error
 	if len(members) == 1 {
-		memberPk, err := common.HexToPubkey(members[0])
+		memberPk, err := crypto.HexToPubkey(members[0])
 		if err != nil {
 			return nil, err
 		}

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -32,7 +32,6 @@ import (
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/protocol"
-	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	communitiestoken "github.com/status-im/status-go/protocol/communities/token"
 	"github.com/status-im/status-go/protocol/ens"
@@ -405,7 +404,7 @@ func tokenURIToCommunityID(tokenURI string) string {
 		return ""
 	}
 
-	pubKey, err := common.HexToPubkey(hexCommunityID)
+	pubKey, err := crypto.HexToPubkey(hexCommunityID)
 	if err != nil {
 		return ""
 	}

--- a/services/utils/utils.go
+++ b/services/utils/utils.go
@@ -11,7 +11,6 @@ import (
 	"github.com/status-im/status-go/api/multiformat"
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
-	prot_common "github.com/status-im/status-go/protocol/common"
 )
 
 func GetSigner(chainID uint64, from types.Address, privateKey *ecdsa.PrivateKey) bind.SignerFn {
@@ -30,7 +29,7 @@ func DeserializePublicKey(compressedKey string) (types.HexBytes, error) {
 	secp256k1Code := "fe701"
 	pubKeyBytes := "0x" + strings.TrimPrefix(rawKey, secp256k1Code)
 
-	pubKey, err := prot_common.HexToPubkey(pubKeyBytes)
+	pubKey, err := crypto.HexToPubkey(pubKeyBytes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
These utils are generic enough to be moved to crypto package.