### PR TITLE
feat: local timesource

### DIFF
--- a/cmd/push-notification-server/main.go
+++ b/cmd/push-notification-server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/status-im/status-go/appdatabase"
 	"github.com/status-im/status-go/common/dbsetup"
 	"github.com/status-im/status-go/crypto"
+	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/messaging"
 	"github.com/status-im/status-go/params"
@@ -27,7 +28,6 @@ import (
 	"github.com/status-im/status-go/protocol/sqlite"
 	mailserversDB "github.com/status-im/status-go/services/mailservers"
 	"github.com/status-im/status-go/services/personal"
-	"github.com/status-im/status-go/timesource"
 	"github.com/status-im/status-go/walletdatabase"
 )
 
@@ -141,7 +141,7 @@ func main() {
 				ClusterID:            16,
 			},
 			InstallationID: installationID,
-			TimeSource:     timesource.Default(),
+			TimeSource:     timesource.DefaultService(),
 		},
 		messaging.WithLogger(logger.Named("messaging")),
 	)

--- a/internal/timesource/local.go
+++ b/internal/timesource/local.go
@@ -1,0 +1,21 @@
+package timesource
+
+import (
+	"context"
+	"time"
+)
+
+type localTimeSource struct {
+}
+
+func (l *localTimeSource) Now() time.Time {
+	return time.Now()
+}
+
+func (l *localTimeSource) Start(ctx context.Context) error {
+	return nil
+}
+
+func (l *localTimeSource) Stop() {
+	return
+}

--- a/internal/timesource/ntp.go
+++ b/internal/timesource/ntp.go
@@ -125,7 +125,7 @@ func computeOffset(timeQuery ntpQuery, servers []string, allowedFailures int) (t
 	return offsets[mid], nil
 }
 
-var defaultTimeSource = &NTPTimeSource{
+var defaultNTPTimeSource = &ntpTimeSource{
 	servers:           defaultServers,
 	allowedFailures:   DefaultMaxAllowedFailures,
 	fastNTPSyncPeriod: FastNTPSyncPeriod,
@@ -134,14 +134,9 @@ var defaultTimeSource = &NTPTimeSource{
 	now:               time.Now,
 }
 
-// Default initializes time source with default config values.
-func Default() *NTPTimeSource {
-	return defaultTimeSource
-}
-
-// NTPTimeSource provides source of time that tries to be resistant to time skews.
+// ntpTimeSource provides source of time that tries to be resistant to time skews.
 // It does so by periodically querying time offset from ntp servers.
-type NTPTimeSource struct {
+type ntpTimeSource struct {
 	servers           []string
 	allowedFailures   int
 	fastNTPSyncPeriod time.Duration
@@ -160,7 +155,7 @@ type NTPTimeSource struct {
 
 // Now returns time adjusted by latest known offset
 // and detects system time changes
-func (s *NTPTimeSource) Now() time.Time {
+func (s *ntpTimeSource) Now() time.Time {
 	s.timeDataMu.RLock()
 
 	currentTime := s.now()
@@ -197,7 +192,7 @@ func (s *NTPTimeSource) Now() time.Time {
 	return adjustedTime
 }
 
-func (s *NTPTimeSource) updateOffset() error {
+func (s *ntpTimeSource) updateOffset() error {
 	offset, err := computeOffset(s.timeQuery, s.servers, s.allowedFailures)
 	if err != nil {
 		logutils.ZapLogger().Error("failed to compute offset", zap.Error(err))
@@ -208,14 +203,14 @@ func (s *NTPTimeSource) updateOffset() error {
 	defer s.timeDataMu.Unlock()
 	s.latestOffset = offset
 	//TBD: if we found offset is too large, we should notify user that system time might not be accurate via emit signal,
-	// and because go-waku doesn't use NTPTimeSource ATM (it just use time.Now()), this might be a problem for MissingMessageVerifier work normally.
+	// and because go-waku doesn't use ntpTimeSource ATM (it just use time.Now()), this might be a problem for MissingMessageVerifier work normally.
 	// e.g. might get errInvalidTimeRange when validate StoreQueryRequest
 	return nil
 }
 
-// runPeriodically runs periodically the given function based on NTPTimeSource
+// runPeriodically runs periodically the given function based on ntpTimeSource
 // synchronization limits (fastNTPSyncPeriod / slowNTPSyncPeriod)
-func (s *NTPTimeSource) runPeriodically(ctx context.Context, fn func() error, starWithSlowSyncPeriod bool) {
+func (s *ntpTimeSource) runPeriodically(ctx context.Context, fn func() error, starWithSlowSyncPeriod bool) {
 	if s.started {
 		return
 	}
@@ -243,7 +238,7 @@ func (s *NTPTimeSource) runPeriodically(ctx context.Context, fn func() error, st
 }
 
 // Start initializes the local offset and starts a goroutine that periodically updates the local offset.
-func (s *NTPTimeSource) Start(ctx context.Context) error {
+func (s *ntpTimeSource) Start(ctx context.Context) error {
 	s.stateMu.Lock()
 	defer s.stateMu.Unlock()
 	if s.started {
@@ -272,7 +267,7 @@ func (s *NTPTimeSource) Start(ctx context.Context) error {
 }
 
 // Stop goroutine that updates time source.
-func (s *NTPTimeSource) Stop() {
+func (s *ntpTimeSource) Stop() {
 	if s.cancel == nil {
 		return
 	}
@@ -280,7 +275,7 @@ func (s *NTPTimeSource) Stop() {
 	s.started = false
 }
 
-func (s *NTPTimeSource) GetCurrentTime() time.Time {
+func (s *ntpTimeSource) GetCurrentTime() time.Time {
 	err := s.Start(context.Background())
 	if err != nil {
 		panic("could not obtain timesource: " + err.Error())
@@ -288,12 +283,12 @@ func (s *NTPTimeSource) GetCurrentTime() time.Time {
 	return s.Now()
 }
 
-func (s *NTPTimeSource) GetCurrentTimeInMillis() uint64 {
+func (s *ntpTimeSource) GetCurrentTimeInMillis() uint64 {
 	return convertToMillis(s.GetCurrentTime())
 }
 
 func GetCurrentTime() time.Time {
-	ts := Default()
+	ts := DefaultService()
 	err := ts.Start(context.Background())
 	if err != nil {
 		panic("could not obtain timesource: " + err.Error())

--- a/internal/timesource/ntp_test.go
+++ b/internal/timesource/ntp_test.go
@@ -174,7 +174,7 @@ func TestComputeOffset(t *testing.T) {
 func TestNTPTimeSource(t *testing.T) {
 	for _, tc := range newTestCases() {
 		t.Run(tc.description, func(t *testing.T) {
-			source := &NTPTimeSource{
+			source := &ntpTimeSource{
 				servers:         tc.servers,
 				allowedFailures: tc.allowedFailures,
 				timeQuery:       tc.query,
@@ -202,7 +202,7 @@ func TestRunningPeriodically(t *testing.T) {
 	slowHits := 1
 
 	t.Run(tc.description, func(t *testing.T) {
-		source := &NTPTimeSource{
+		source := &ntpTimeSource{
 			servers:           tc.servers,
 			allowedFailures:   tc.allowedFailures,
 			timeQuery:         tc.query,
@@ -212,7 +212,7 @@ func TestRunningPeriodically(t *testing.T) {
 		}
 		lastCall := time.Now()
 		// we're simulating a calls to updateOffset, testing ntp calls happens
-		// on NTPTimeSource specified periods (fastNTPSyncPeriod & slowNTPSyncPeriod)
+		// on ntpTimeSource specified periods (fastNTPSyncPeriod & slowNTPSyncPeriod)
 		wg := sync.WaitGroup{}
 		wg.Add(1)
 		source.runPeriodically(context.TODO(), func() error {
@@ -263,7 +263,7 @@ func TestGetCurrentTimeInMillis(t *testing.T) {
 	}
 
 	currentTime := time.Now()
-	ts := NTPTimeSource{
+	ts := ntpTimeSource{
 		servers:           tc.servers,
 		allowedFailures:   tc.allowedFailures,
 		timeQuery:         tc.query,
@@ -289,7 +289,7 @@ func TestGetCurrentTimeInMillis(t *testing.T) {
 
 func TestGetCurrentTimeOffline(t *testing.T) {
 	// covers https://github.com/status-im/status-desktop/issues/12691
-	ts := &NTPTimeSource{
+	ts := &ntpTimeSource{
 		servers:           defaultServers,
 		allowedFailures:   DefaultMaxAllowedFailures,
 		fastNTPSyncPeriod: 1 * time.Millisecond,
@@ -322,7 +322,7 @@ func TestSystemTimeChangeDetection(t *testing.T) {
 	}
 
 	// Create a time source with our mocks
-	ts := &NTPTimeSource{
+	ts := &ntpTimeSource{
 		servers:           []string{"test-server"},
 		allowedFailures:   0,
 		fastNTPSyncPeriod: 1 * time.Hour,
@@ -438,7 +438,7 @@ func TestTimeTrackingInitialization(t *testing.T) {
 	}
 
 	// Create the time source with our controlled functions
-	ts := &NTPTimeSource{
+	ts := &ntpTimeSource{
 		servers:           mockedServers,
 		allowedFailures:   DefaultMaxAllowedFailures,
 		fastNTPSyncPeriod: 1 * time.Hour, // Use long periods to avoid actual periodic updates during test
@@ -486,7 +486,7 @@ func TestTimeChangeDetectionSkippedWhenNotInitialized(t *testing.T) {
 	}
 
 	// Create the time source with our controlled functions
-	ts := &NTPTimeSource{
+	ts := &ntpTimeSource{
 		servers:           mockedServers,
 		allowedFailures:   DefaultMaxAllowedFailures,
 		fastNTPSyncPeriod: 1 * time.Hour,
@@ -529,7 +529,7 @@ func TestTimeChangeDetectionWithUpdateFailure(t *testing.T) {
 	}
 
 	// Create the time source with our controlled functions
-	ts := &NTPTimeSource{
+	ts := &ntpTimeSource{
 		servers:           mockedServers,
 		allowedFailures:   DefaultMaxAllowedFailures,
 		fastNTPSyncPeriod: 1 * time.Hour,

--- a/internal/timesource/timesource.go
+++ b/internal/timesource/timesource.go
@@ -1,7 +1,25 @@
 package timesource
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
-type TimeSource interface {
+type Provider interface {
 	Now() time.Time
+}
+
+type Service interface {
+	Provider
+	Start(ctx context.Context) error
+	Stop()
+}
+
+// DefaultService initializes time source with default config values.
+func DefaultService() Service {
+	return defaultNTPTimeSource
+}
+
+func LocalService() Service {
+	return &localTimeSource{}
 }

--- a/messaging/core.go
+++ b/messaging/core.go
@@ -73,7 +73,7 @@ type CoreParams struct {
 	WakuConfig    params.WakuV2Config
 	ClusterConfig params.ClusterConfig
 
-	TimeSource timesource.TimeSource
+	TimeSource timesource.Provider
 }
 
 func newCore(waku wakutypes.Waku, params CoreParams, config *config) (*Core, error) {
@@ -381,7 +381,7 @@ type wakuParams struct {
 	onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error)
 	onPeerStats                     func(wakutypes.ConnStatus)
 
-	timeSource timesource.TimeSource
+	timeSource timesource.Provider
 
 	logger *zap.Logger
 }

--- a/messaging/waku/gowaku.go
+++ b/messaging/waku/gowaku.go
@@ -82,6 +82,9 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
 	"github.com/waku-org/go-waku/waku/v2/utils"
 
+	"github.com/waku-org/go-waku/waku/v2/node"
+	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
+
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/connection"
 	cryptotypes "github.com/status-im/status-go/crypto/types"
@@ -90,10 +93,6 @@ import (
 	"github.com/status-im/status-go/messaging/waku/common"
 	"github.com/status-im/status-go/messaging/waku/persistence"
 	"github.com/status-im/status-go/messaging/waku/types"
-	ntptimesource "github.com/status-im/status-go/timesource"
-
-	"github.com/waku-org/go-waku/waku/v2/node"
-	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 )
 
 const messageQueueLimit = 1024
@@ -188,7 +187,7 @@ type Waku struct {
 
 	logger *zap.Logger
 
-	timesource timesource.TimeSource
+	timesource timesource.Provider
 
 	// seededBootnodesForDiscV5 indicates whether we manage to retrieve discovery
 	// bootnodes successfully
@@ -221,7 +220,7 @@ func newTTLCache() *ttlcache.Cache[gethcommon.Hash, bool] {
 }
 
 // New creates a WakuV2 client ready to communicate through the LibP2P network.
-func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, protectedTopicsPersistence persistence.ProtectedTopics, ts timesource.TimeSource, onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
+func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, protectedTopicsPersistence persistence.ProtectedTopics, ts timesource.Provider, onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
 	var err error
 	if logger == nil {
 		logger, err = zap.NewDevelopment()
@@ -231,7 +230,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, protectedTo
 	}
 
 	if ts == nil {
-		ts = ntptimesource.Default()
+		ts = timesource.DefaultService()
 	}
 
 	cfg = setDefaults(cfg)

--- a/messaging/waku/nwaku.go
+++ b/messaging/waku/nwaku.go
@@ -212,11 +212,11 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, protectedTo
 		}
 	}
 
-	var timesource gowakutimesource.Timesource
+	var wakuTimeSource gowakutimesource.Timesource
 	if ts != nil {
-		timesource = timesourceAdapter{ts}
+		wakuTimeSource = timesourceAdapter{ts}
 	} else {
-		timesource = timesource.Default()
+		wakuTimeSource = timesource.DefaultService()
 	}
 
 	cfg = setDefaults(cfg)
@@ -268,7 +268,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, protectedTo
 		dnsAddressCacheLock:             &sync.RWMutex{},
 		dnsDiscAsyncRetrievedSignal:     make(chan struct{}),
 		storeMsgIDs:                     make(map[gethcommon.Hash]bool),
-		timesource:                      timesource,
+		timesource:                      wakuTimeSource,
 		storeMsgIDsMu:                   sync.RWMutex{},
 		logger:                          logger,
 		discV5BootstrapNodes:            cfg.DiscV5BootstrapNodes,

--- a/messaging/waku/nwaku.go
+++ b/messaging/waku/nwaku.go
@@ -54,6 +54,9 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
 
+	"github.com/waku-org/waku-go-bindings/waku"
+	bindingscommon "github.com/waku-org/waku-go-bindings/waku/common"
+
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/connection"
 	cryptotypes "github.com/status-im/status-go/crypto/types"
@@ -62,12 +65,8 @@ import (
 	"github.com/status-im/status-go/messaging/waku/common"
 	"github.com/status-im/status-go/messaging/waku/persistence"
 	"github.com/status-im/status-go/messaging/waku/types"
-	ntptimesource "github.com/status-im/status-go/timesource"
 
-	"github.com/waku-org/waku-go-bindings/waku"
-	bindingscommon "github.com/waku-org/waku-go-bindings/waku/common"
-
-	node "github.com/waku-org/go-waku/waku/v2/node"
+	"github.com/waku-org/go-waku/waku/v2/node"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 )
 
@@ -182,7 +181,7 @@ type Waku struct {
 // timesource provided in constructor is managed by status-go; go-waku must not invoke Start or Stop.
 // The adapter only fulfills the required interface; Start and Stop are no-ops.
 type timesourceAdapter struct {
-	timesource.TimeSource
+	timesource.Provider
 }
 
 func (t timesourceAdapter) Start(ctx context.Context) error { return nil }
@@ -204,7 +203,7 @@ func newTTLCache() *ttlcache.Cache[gethcommon.Hash, bool] {
 }
 
 // New creates a WakuV2 client ready to communicate through the LibP2P network.
-func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, protectedTopicsPersistence persistence.ProtectedTopics, ts timesource.TimeSource, onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
+func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, protectedTopicsPersistence persistence.ProtectedTopics, ts timesource.Provider, onHistoricMessagesRequestFailed func([]byte, peer.AddrInfo, error), onPeerStats func(types.ConnStatus)) (*Waku, error) {
 	var err error
 	if logger == nil {
 		logger, err = zap.NewDevelopment()
@@ -217,7 +216,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, protectedTo
 	if ts != nil {
 		timesource = timesourceAdapter{ts}
 	} else {
-		timesource = ntptimesource.Default()
+		timesource = timesource.Default()
 	}
 
 	cfg = setDefaults(cfg)

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -54,6 +54,7 @@ import (
 	"github.com/status-im/status-go/services/wallet"
 	"github.com/status-im/status-go/services/wallet/community"
 	"github.com/status-im/status-go/services/wallet/token"
+	"github.com/status-im/status-go/services/wallet/tokenbalances"
 	"github.com/status-im/status-go/transactions"
 )
 

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -23,6 +23,7 @@ import (
 	common2 "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/connection"
 	"github.com/status-im/status-go/crypto"
+	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/ipfs"
 	"github.com/status-im/status-go/multiaccounts"
 	"github.com/status-im/status-go/multiaccounts/accounts"
@@ -53,8 +54,6 @@ import (
 	"github.com/status-im/status-go/services/wallet"
 	"github.com/status-im/status-go/services/wallet/community"
 	"github.com/status-im/status-go/services/wallet/token"
-	"github.com/status-im/status-go/services/wallet/tokenbalances"
-	"github.com/status-im/status-go/timesource"
 	"github.com/status-im/status-go/transactions"
 )
 
@@ -63,6 +62,9 @@ var (
 	ErrNodeRunning   = errors.New("node is already running")
 	ErrNoRunningNode = errors.New("there is no running node")
 )
+
+// FIXME: This is temporal and will be replaced with the actual setting
+const privateMode = false
 
 // StatusNode abstracts contained geth node and provides helper methods to
 // interact with it.
@@ -107,7 +109,7 @@ type StatusNode struct {
 	walletSrvc             *wallet.Service
 	localNotificationsSrvc *localnotifications.Service
 	personalSrvc           *personal.Service
-	timeSourceSrvc         *timesource.NTPTimeSource
+	timeSourceSrvc         timesource.Service
 	wakuV2ExtSrvc          *wakuv2ext.Service
 	ensSrvc                *ens.Service
 	communityTokensSrvc    *communitytokens.Service

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -7,6 +7,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/pkg/pubsub"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/eth"
@@ -36,7 +37,6 @@ import (
 	"github.com/status-im/status-go/services/wallet"
 	"github.com/status-im/status-go/services/wallet/router/fees"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
-	"github.com/status-im/status-go/timesource"
 )
 
 var (
@@ -374,9 +374,13 @@ func (b *StatusNode) personalService() *personal.Service {
 	return b.personalSrvc
 }
 
-func (b *StatusNode) TimeSource() *timesource.NTPTimeSource {
+func (b *StatusNode) TimeSource() timesource.Provider {
 	if b.timeSourceSrvc == nil {
-		b.timeSourceSrvc = timesource.Default()
+		if privateMode {
+			b.timeSourceSrvc = timesource.LocalService()
+		} else {
+			b.timeSourceSrvc = timesource.DefaultService()
+		}
 	}
 	return b.timeSourceSrvc
 }

--- a/protocol/ens/verifier.go
+++ b/protocol/ens/verifier.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
+
 	gocommon "github.com/status-im/status-go/common"
 	enstypes "github.com/status-im/status-go/eth-node/types/ens"
 	"github.com/status-im/status-go/internal/timesource"
@@ -18,14 +19,14 @@ type Verifier struct {
 	online          bool
 	persistence     *Persistence
 	logger          *zap.Logger
-	timesource      timesource.TimeSource
+	timesource      timesource.Provider
 	subscriptions   []chan []*VerificationRecord
 	rpcEndpoint     string
 	contractAddress string
 	quit            chan struct{}
 }
 
-func New(logger *zap.Logger, timesource timesource.TimeSource, db *sql.DB, rpcEndpoint, contractAddress string) *Verifier {
+func New(logger *zap.Logger, timesource timesource.Provider, db *sql.DB, rpcEndpoint, contractAddress string) *Verifier {
 	persistence := NewPersistence(db)
 	return &Verifier{
 		logger:          logger,

--- a/protocol/messenger_settings.go
+++ b/protocol/messenger_settings.go
@@ -3,9 +3,9 @@ package protocol
 import (
 	"context"
 
+	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/nodecfg"
 	"github.com/status-im/status-go/protocol/requests"
-	"github.com/status-im/status-go/timesource"
 )
 
 func (m *Messenger) SetLightClient(request *requests.SetLightClient) error {

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/status-im/status-go/crypto/types"
 	"github.com/status-im/status-go/deprecation"
 	"github.com/status-im/status-go/images"
+	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/multiaccounts/settings"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
@@ -24,7 +25,6 @@ import (
 	"github.com/status-im/status-go/protocol/requests"
 	v1protocol "github.com/status-im/status-go/protocol/v1"
 	"github.com/status-im/status-go/server"
-	"github.com/status-im/status-go/timesource"
 )
 
 const (

--- a/server/pairing/client.go
+++ b/server/pairing/client.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/status-im/status-go/api"
 	gocommon "github.com/status-im/status-go/common"
+	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/signal"
-	"github.com/status-im/status-go/timesource"
 )
 
 /*

--- a/server/pairing/server.go
+++ b/server/pairing/server.go
@@ -13,9 +13,8 @@ import (
 	errorspkg "github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/status-im/status-go/timesource"
-
 	"github.com/status-im/status-go/api"
+	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/server"
 )

--- a/services/accounts/multiaccounts.go
+++ b/services/accounts/multiaccounts.go
@@ -3,8 +3,7 @@ package accounts
 import (
 	"errors"
 
-	"github.com/status-im/status-go/timesource"
-
+	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/server"
 
 	"github.com/status-im/status-go/images"

--- a/services/ext/service.go
+++ b/services/ext/service.go
@@ -103,7 +103,7 @@ type InitProtocolParams struct {
 	WalletService          *wallet.Service
 	CommunityTokensService *communitytokens.Service
 	AccountsPublisher      *pubsub.Publisher
-	TimeSource             timesource.TimeSource
+	TimeSource             timesource.Provider
 	MetricsEnabled         bool
 	TokenManager           communities.TokenManager
 	TokenBalanceManager    communities.TokenBalanceManager


### PR DESCRIPTION
# Description

1. Use `timesource.Provider` and `timesource.Service` interfaces
2. Implemented a local timesource service (will be used in privacy mode)
3. Moved `timesource` package to `internal/timesource`, refactored things a bit