### PR TITLE
fix: improve peer exchange loop logic

### DIFF
--- a/messaging/waku/gowaku.go
+++ b/messaging/waku/gowaku.go
@@ -589,7 +589,7 @@ func (w *Waku) GetStats() types.StatsSummary {
 	}
 }
 
-func (w *Waku) runPeerExchangeLoop() {
+func (w *Waku) peerExchangeLoop() {
 	defer gocommon.LogOnPanic()
 	defer w.wg.Done()
 
@@ -598,24 +598,49 @@ func (w *Waku) runPeerExchangeLoop() {
 		return
 	}
 
-	ticker := time.NewTicker(time.Second * 5)
-	defer ticker.Stop()
+	logger := w.logger.Named("peer-exchange")
 
 	for {
 		select {
 		case <-w.ctx.Done():
-			w.logger.Debug("Peer exchange loop stopped")
+			logger.Debug("peer exchange loop stopped")
 			return
-		case <-ticker.C:
-			w.logger.Debug("Running peer exchange loop")
-			err := w.node.PeerExchange().Request(
+
+		case status, ok := <-w.topicHealthStatusChan:
+			if !ok {
+				logger.Debug("topic health status channel closed")
+				return
+			}
+
+			logger.Debug("topic health status changed",
+				zap.String("topic", status.Topic),
+				zap.Stringer("status", status.Health),
+			)
+
+			if status.Health == peermanager.SufficientlyHealthy {
+				continue
+			}
+
+			pubsubTopic, err := protocol.ToWakuPubsubTopic(status.Topic)
+			if err != nil {
+				logger.Error("could not convert topic to waku pubsub topic", zap.Error(err))
+				continue
+			}
+
+			shardPubsubTopic, err := protocol.ToShardPubsubTopic(pubsubTopic)
+			if err != nil {
+				logger.Error("failed to convert topic to shard pubsub topic", zap.Error(err))
+				continue
+			}
+
+			err = w.node.PeerExchange().Request(
 				w.ctx,
 				w.cfg.DiscoveryLimit,
 				peer_exchange.WithAutomaticPeerSelection(),
-				peer_exchange.FilterByShard(int(w.defaultShardInfo.ClusterID), int(w.defaultShardInfo.ShardIDs[0])),
+				peer_exchange.FilterByShard(int(shardPubsubTopic.Cluster()), int(shardPubsubTopic.Shard())),
 			)
 			if err != nil {
-				w.logger.Error("could not request peers via peer exchange", zap.Error(err))
+				logger.Error("could not request peers via peer exchange", zap.Error(err))
 			}
 		}
 	}
@@ -1125,7 +1150,7 @@ func (w *Waku) Start() error {
 	}
 
 	w.wg.Add(1)
-	go w.runPeerExchangeLoop()
+	go w.peerExchangeLoop()
 
 	if w.cfg.EnableMissingMessageVerification {
 		w.missingMsgVerifier = missing.NewMissingMessageVerifier(

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -142,7 +142,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
             "apiLoggingEnabled": True,
             "wakuFleetsConfigFilePath": Config.waku_fleets_config,
             "pushFleetsConfigFilePath": Config.push_fleets_config,
-            "mediaServerAddress": f"""{"0.0.0.0" if self.container else "localhost"}:{constants.STATUS_MEDIA_SERVER_PORT}""",
+            "mediaServerAddress": f"""{"0.0.0.0" if self.container else "127.0.0.1"}:{constants.STATUS_MEDIA_SERVER_PORT}""",
             "mediaServerAdvertizeHost": "localhost" if self.container else "",
             "mediaServerAdvertizePort": self.container.media_server_port if self.container else 0,
         }


### PR DESCRIPTION
Closes https://github.com/status-im/status-go/issues/6949
Closes https://github.com/status-im/status-go/issues/4628

Requires:
- https://github.com/waku-org/go-waku/pull/1295

# Description

Instead of running peer exchange each 5 seconds, run it on demand for specific shard