### PR TITLE
fix: rpc tests docker image build

### DIFF
--- a/_assets/ci/tests.Dockerfile
+++ b/_assets/ci/tests.Dockerfile
@@ -14,20 +14,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends --fix-missing 
     openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/debian/gpg  | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-    gpg --no-default-keyring --keyring /etc/apt/keyrings/docker.gpg --fingerprint | \
-    grep -q "8D81 803C 0EBF CD88" && \
-    echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
-    https://download.docker.com/linux/debian  \
-    bullseye stable" \
-    | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    apt-get update && apt-get install -y \
-    docker-ce-cli \
-    docker-compose-plugin \
-    && rm -rf /var/lib/apt/lists/*
-
 USER jenkins
 
 ENTRYPOINT [""]

--- a/_assets/ci/tests.Dockerfile
+++ b/_assets/ci/tests.Dockerfile
@@ -14,8 +14,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends --fix-missing 
     openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
 RUN mkdir -p /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/debian/gpg  | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
     gpg --no-default-keyring --keyring /etc/apt/keyrings/docker.gpg --fingerprint | \


### PR DESCRIPTION
The base image `harbor.status.im/infra/ci-build-containers:linux-base-1.0.0` already has
  -  `/usr/bin/python` properly configured as a symlink to `python3`
  -  docker tools
so we don't have to perform these steps in `_assets/ci/tests.Dockerfile`

