### PR TITLE
сhore: pairing logs

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -1555,7 +1555,7 @@ func inputConnectionStringForBootstrapping(cs, configJSON string) string {
 		return response.toJSON(err)
 	}
 
-	return nil
+	return response.toJSON(nil)
 }
 
 func InputConnectionStringForBootstrappingV2(requestJSON string) string {

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -428,6 +428,11 @@ func createAccountAndLogin(requestJSON string) string {
 		return makeJSONResponse(err)
 	}
 
+	logutils.ZapLogger().Debug("<<< createAccountAndLogin",
+		zap.String("request", requestJSON),
+		zap.String("rootDataDir", request.RootDataDir),
+	)
+
 	err = request.Validate(&requests.CreateAccountValidation{
 		AllowEmptyDisplayName: true,
 	})
@@ -1537,6 +1542,12 @@ func inputConnectionStringForBootstrapping(cs, configJSON string) string {
 
 	var conf pairing.ReceiverClientConfig
 	err = json.Unmarshal([]byte(configJSON), &conf)
+
+	logutils.ZapLogger().Debug("<<< inputConnectionStringForBootstrapping",
+		zap.String("cs", cs),
+		zap.String("configJSON", configJSON),
+	)
+
 	if err != nil {
 		logutils.ZapLogger().Error("error parsing config", zap.Error(err), zap.String("config", configJSON))
 		err = errors2.Wrap(err, "could not unmarshal config")

--- a/mobile/status.go
+++ b/mobile/status.go
@@ -10,6 +10,7 @@ import (
 	"time"
 	"unsafe"
 
+	errors2 "github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
@@ -1519,7 +1520,8 @@ func inputConnectionStringForBootstrapping(cs, configJSON string) string {
 	err = params.FromString(cs)
 	if err != nil {
 		response := &inputConnectionStringForBootstrappingResponse{}
-		return response.toJSON(fmt.Errorf("could not parse connection string"))
+		err = errors2.Wrap(err, "error parsing connection string")
+		return response.toJSON(err)
 	}
 	response := &inputConnectionStringForBootstrappingResponse{
 		InstallationID: params.InstallationID(),
@@ -1529,21 +1531,31 @@ func inputConnectionStringForBootstrapping(cs, configJSON string) string {
 	err = statusBackend.LocalPairingStateManager.StartPairing(cs)
 	defer func() { statusBackend.LocalPairingStateManager.StopPairing(cs, err) }()
 	if err != nil {
+		err = errors2.Wrap(err, "could not start pairing")
 		return response.toJSON(err)
 	}
 
 	var conf pairing.ReceiverClientConfig
 	err = json.Unmarshal([]byte(configJSON), &conf)
 	if err != nil {
+		logutils.ZapLogger().Error("error parsing config", zap.Error(err), zap.String("config", configJSON))
+		err = errors2.Wrap(err, "could not unmarshal config")
 		return response.toJSON(err)
 	}
 
 	err = pairing.StartUpReceivingClient(statusBackend, cs, &conf)
 	if err != nil {
+		err = errors2.Wrap(err, "could not start receiving client")
 		return response.toJSON(err)
 	}
 
-	return response.toJSON(statusBackend.Logout())
+	err = statusBackend.Logout()
+	if err != nil {
+		err = errors2.Wrap(err, "could not logout")
+		return response.toJSON(err)
+	}
+
+	return nil
 }
 
 func InputConnectionStringForBootstrappingV2(requestJSON string) string {

--- a/mobile/status_test.go
+++ b/mobile/status_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/brianvoe/gofakeit/v6"
 
@@ -46,4 +47,13 @@ func TestIntendedPanic(t *testing.T) {
 	require.PanicsWithError(t, message, func() {
 		IntendedPanic(message)
 	})
+}
+
+func TestEscapeString(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	const string_2 = `C:\Users\anast\status-desktop\`
+	const string_3 = `C:\\Users\\anast\\status-desktop\\`
+	logger.Info("test log", zap.String("string_2", string_2), zap.String("string_3", string_3))
 }


### PR DESCRIPTION
Improve logging in `inputConnectionStringForBootstrapping`

> [!CAUTION]
> I am logging `configJSON` here. It's probably not a good idea, as it contain local paths.