### PR TITLE
feat: externally provided nwaku

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,9 @@ ifeq ($(MAKECMDGOALS),statusgo-android-library)
         MOBILE_GOARCH := $(ARCH)
         ANDROID_CLANG_TARGET := aarch64-linux-android$(ANDROID_API)
     endif
-    ANDROID_BUILD_FLAGS := CC="$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(HOST_OS)-x86_64/bin/clang --target=$(ANDROID_CLANG_TARGET) --sysroot=$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(HOST_OS)-x86_64/sysroot" CGO_CFLAGS="-Os -flto -fembed-bitcode" CGO_LDFLAGS="-Os -flto" CGO_ENABLED=1 GOOS=android GOARCH=$(MOBILE_GOARCH)
+    ANDROID_BUILD_FLAGS := CC="$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(HOST_OS)-x86_64/bin/clang --target=$(ANDROID_CLANG_TARGET) --sysroot=$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/$(HOST_OS)-x86_64/sysroot" CGO_ENABLED=1 GOOS=android GOARCH=$(MOBILE_GOARCH)
+    CGO_CFLAGS+=-Os -flto -fembed-bitcode
+    CGO_LDFLAGS+=-Os -flto
 endif
 
 ifeq ($(MAKECMDGOALS),statusgo-ios-library)
@@ -64,7 +66,9 @@ ifeq ($(MAKECMDGOALS),statusgo-ios-library)
     else
         MOBILE_GOARCH := $(ARCH)
     endif
-    IOS_BUILD_FLAGS := CGO_LDFLAGS="-Os -flto" CGO_ENABLED=1 GOOS=ios GOARCH=$(MOBILE_GOARCH)
+    IOS_BUILD_FLAGS := CGO_ENABLED=1 GOOS=ios GOARCH=$(MOBILE_GOARCH)
+    CGO_CFLAGS+=-Os -flto -arch $(ARCH) -isysroot $$(xcrun --sdk $(IPHONE_SDK) --show-sdk-path) -miphoneos-version-min=$(IOS_TARGET) -fembed-bitcode
+    CGO_LDFLAGS+=-Os -flto
 endif
 
 ifeq ($(detected_OS),Darwin)
@@ -74,14 +78,13 @@ ifeq ($(detected_OS),Darwin)
 else ifeq ($(detected_OS),Windows)
  GOBIN_SHARED_LIB_EXT := dll
  LIBWAKU_EXT := dll
- GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS=""
 else
  GOBIN_SHARED_LIB_EXT := so
  LIBWAKU_EXT := so
- GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS="-Wl,-soname,libstatus.so.0"
+ CGO_LDFLAGS += "-Wl,-soname,libstatus.so.0"
 endif
 
-CGO_CFLAGS = -I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
+CGO_CFLAGS+=-I/$(JAVA_HOME)/include -I/$(JAVA_HOME)/include/darwin
 export GOPATH ?= $(HOME)/go
 
 GIT_ROOT ?= $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
@@ -237,7 +240,8 @@ statusgo-shared-library: generate
 statusgo-shared-library: statusgo-c-bindings $(LIBWAKU) ##@cross-compile Build status-go as shared library for current platform
 	@echo "Building shared library..."
 	@echo "Tags: $(BUILD_TAGS)"
-	$(GOBIN_SHARED_LIB_CFLAGS) $(GOBIN_SHARED_LIB_CGO_LDFLAGS) go build \
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
+ 	go build \
 		-tags '$(BUILD_TAGS)' \
 		$(BUILD_FLAGS) \
 		-buildmode=c-shared \
@@ -254,7 +258,8 @@ endif
 
 statusgo-android-library: generate statusgo-c-bindings $(LIBWAKU) ##@cross-compile Build status-go as Android mobile library
 	@echo "Building Android mobile library..."
-	$(ANDROID_BUILD_FLAGS) go build -buildmode=c-shared -tags 'gowaku_no_rln nowatchdog disable_torrent' \
+	$(ANDROID_BUILD_FLAGS) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
+	go build -buildmode=c-shared -tags 'gowaku_no_rln nowatchdog disable_torrent' \
 		-ldflags="-checklinkname=0 -X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=true" \
 		-o "build/bin/libstatus.so" ./build/bin/statusgo-lib
 	@echo "Android library built"
@@ -264,8 +269,8 @@ statusgo-ios-library: generate statusgo-c-bindings $(LIBWAKU) ##@cross-compile B
 	@echo "Building iOS mobile library..."
 	DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer" \
 	CC="$$(xcrun --sdk $(IPHONE_SDK) --find clang)" \
-	CGO_CFLAGS="-Os -flto -arch $(ARCH) -isysroot $$(xcrun --sdk $(IPHONE_SDK) --show-sdk-path) -miphoneos-version-min=$(IOS_TARGET) -fembed-bitcode" \
-	$(IOS_BUILD_FLAGS) go build -buildmode=c-archive -tags 'gowaku_no_rln nowatchdog disable_torrent' \
+	$(IOS_BUILD_FLAGS) CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
+	go build -buildmode=c-archive -tags 'gowaku_no_rln nowatchdog disable_torrent' \
 		-ldflags="-checklinkname=0 -X github.com/status-im/status-go/vendor/github.com/ethereum/go-ethereum/metrics.EnabledStr=true" \
 		-o "build/bin/libstatus.a" ./build/bin/statusgo-lib
 	@echo "iOS library built"

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,13 @@ GIT_AUTHOR ?= $(shell git config user.email || echo $$USER)
 BUILD_TAGS ?= gowaku_no_rln
 
 ifeq ($(USE_NWAKU), true)
-BUILD_TAGS += use_nwaku
+    BUILD_TAGS += use_nwaku
+    ifndef NWAKU_SOURCE_DIR
+        $(error NWAKU_SOURCE_DIR must be set when USE_NWAKU is true)
+    endif
+    LIBWAKU := $(NWAKU_SOURCE_DIR)/build/libwaku.$(LIBWAKU_EXT)
+    CGO_CFLAGS+=-I$(NWAKU_SOURCE_DIR)/library
+	CGO_LDFLAGS+=-L$(NWAKU_SOURCE_DIR)/build -lwaku -Wl,-rpath,$(NWAKU_SOURCE_DIR)/build
 endif
 
 BUILD_FLAGS ?= -ldflags=""
@@ -168,20 +174,21 @@ nix-purge: ##@nix Completely remove Nix setup, including /nix directory
 all: $(GO_CMD_NAMES)
 
 .PHONY: $(GO_CMD_NAMES) $(GO_CMD_PATHS) $(GO_CMD_BUILDS)
-$(GO_CMD_BUILDS): generate
+$(GO_CMD_BUILDS): generate $(LIBWAKU)
 $(GO_CMD_BUILDS): ##@build Build any Go project from cmd folder
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
 	go build -mod=vendor -v \
 		-tags '$(BUILD_TAGS)' $(BUILD_FLAGS) \
 		-o ./$@ ./cmd/$(notdir $@)
 	@echo "Compilation done."
 	@echo "Run \"build/bin/$(notdir $@) -h\" to view available commands."
 
-LIBWAKU := $(CURDIR)/vendor/github.com/waku-org/waku-go-bindings/third_party/nwaku/build/libwaku.$(LIBWAKU_EXT)
 $(LIBWAKU):
 ifeq ($(USE_NWAKU),true)
-	@echo "Building libwaku"
-	$(MAKE) -C $(CURDIR)/vendor/github.com/waku-org/waku-go-bindings/waku SHELL=/bin/bash
+	@echo "Building libwaku" $(LIBWAKU)
+	$(MAKE) -C $(NWAKU_SOURCE_DIR) SHELL=/bin/bash
 endif
+
 build-libwaku: $(LIBWAKU)
 
 test-libwaku: | $(LIBWAKU)
@@ -193,6 +200,11 @@ clean-libwaku:
 
 rebuild-libwaku: | clean-libwaku $(LIBWAKU)
 
+clone-nwaku: NWAKU_SOURCE_DIR ?= $(GIT_ROOT)/../nwaku
+clone-nwaku: NWAKU_VERSION ?= v0.37.0-rc.3
+clone-nwaku: ##@build Clone or checkout nwaku v0.37.0-rc.3 into ../nwaku
+	@echo "Cloning nwaku $(NWAKU_VERSION)..."
+	git clone --branch $(NWAKU_VERSION) https://github.com/waku-org/nwaku.git $(NWAKU_SOURCE_DIR)
 
 statusgo: ##@build Build status-go as status-backend server
 statusgo: build/bin/status-backend
@@ -227,6 +239,7 @@ statusgo-c-bindings:
 statusgo-library: generate
 statusgo-library: statusgo-c-bindings $(LIBWAKU) ##@cross-compile Build status-go as static library for current platform
 	@echo "Building static library..."
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
 	go build \
 		-tags '$(BUILD_TAGS)' \
 		$(BUILD_FLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,8 @@ BUILD_TAGS ?= gowaku_no_rln
 
 ifeq ($(USE_NWAKU), true)
     BUILD_TAGS += use_nwaku
-    ifndef NWAKU_SOURCE_DIR
-        $(error NWAKU_SOURCE_DIR must be set when USE_NWAKU is true)
-    endif
+    NWAKU_VERSION ?= v0.37.0-rc.3
+    NWAKU_SOURCE_DIR ?= $(GIT_ROOT)/../nwaku
     LIBWAKU := $(NWAKU_SOURCE_DIR)/build/libwaku.$(LIBWAKU_EXT)
     CGO_CFLAGS+=-I$(NWAKU_SOURCE_DIR)/library
 	CGO_LDFLAGS+=-L$(NWAKU_SOURCE_DIR)/build -lwaku -Wl,-rpath,$(NWAKU_SOURCE_DIR)/build
@@ -183,7 +182,16 @@ $(GO_CMD_BUILDS): ##@build Build any Go project from cmd folder
 	@echo "Compilation done."
 	@echo "Run \"build/bin/$(notdir $@) -h\" to view available commands."
 
-$(LIBWAKU):
+
+$(NWAKU_SOURCE_DIR): ##@build Clone nwaku
+ifeq ($(USE_NWAKU),true)
+	@echo "Cloning nwaku $(NWAKU_VERSION)..."
+	git clone --branch $(NWAKU_VERSION) https://github.com/waku-org/nwaku.git $(NWAKU_SOURCE_DIR)
+endif
+
+clone-nwaku: $(NWAKU_SOURCE_DIR)
+
+$(LIBWAKU): clone-nwaku
 ifeq ($(USE_NWAKU),true)
 	@echo "Building libwaku" $(LIBWAKU)
 	$(MAKE) -C $(NWAKU_SOURCE_DIR) SHELL=/bin/bash
@@ -199,12 +207,6 @@ clean-libwaku:
 	rm $(LIBWAKU)
 
 rebuild-libwaku: | clean-libwaku $(LIBWAKU)
-
-clone-nwaku: NWAKU_SOURCE_DIR ?= $(GIT_ROOT)/../nwaku
-clone-nwaku: NWAKU_VERSION ?= v0.37.0-rc.3
-clone-nwaku: ##@build Clone or checkout nwaku v0.37.0-rc.3 into ../nwaku
-	@echo "Cloning nwaku $(NWAKU_VERSION)..."
-	git clone --branch $(NWAKU_VERSION) https://github.com/waku-org/nwaku.git $(NWAKU_SOURCE_DIR)
 
 statusgo: ##@build Build status-go as status-backend server
 statusgo: build/bin/status-backend

--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ clone-nwaku: $(NWAKU_SOURCE_DIR)
 $(LIBWAKU): clone-nwaku
 ifeq ($(USE_NWAKU),true)
 	@echo "Building libwaku" $(LIBWAKU)
-	$(MAKE) -C $(NWAKU_SOURCE_DIR) SHELL=/bin/bash
+	$(MAKE) -C $(NWAKU_SOURCE_DIR) libwaku SHELL=/bin/bash
 endif
 
 build-libwaku: $(LIBWAKU)

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,17 @@ ifeq ($(USE_NWAKU),true)
 	@echo "Building libwaku"
 	$(MAKE) -C $(CURDIR)/vendor/github.com/waku-org/waku-go-bindings/waku SHELL=/bin/bash
 endif
+build-libwaku: $(LIBWAKU)
+
+test-libwaku: | $(LIBWAKU)
+	go test -tags '$(BUILD_TAGS) use_nwaku' -run TestDial ./wakuv2/... -count 1 -v -json | jq -r '.Output'
+
+clean-libwaku:
+	@echo "Removing libwaku"
+	rm $(LIBWAKU)
+
+rebuild-libwaku: | clean-libwaku $(LIBWAKU)
+
 
 statusgo: ##@build Build status-go as status-backend server
 statusgo: build/bin/status-backend
@@ -221,8 +232,6 @@ statusgo-library: statusgo-c-bindings $(LIBWAKU) ##@cross-compile Build status-g
 		./build/bin/statusgo-lib
 	@echo "Static library built:"
 	@ls -la build/bin/libstatus.*
-
-build-libwaku: $(LIBWAKU)
 
 statusgo-shared-library: generate
 statusgo-shared-library: statusgo-c-bindings $(LIBWAKU) ##@cross-compile Build status-go as shared library for current platform
@@ -313,15 +322,6 @@ lint-fix:
 
 docker-test: ##@tests Run tests in a docker container with golang.
 	docker run --privileged --rm -it -v "$(PWD):$(DOCKER_TEST_WORKDIR)" -w "$(DOCKER_TEST_WORKDIR)" $(DOCKER_TEST_IMAGE) go test ${ARGS}
-
-test-libwaku: | $(LIBWAKU)
-	go test -tags '$(BUILD_TAGS) use_nwaku' -run TestDial ./wakuv2/... -count 1 -v -json | jq -r '.Output'
-
-clean-libwaku:
-	@echo "Removing libwaku"
-	rm $(LIBWAKU)
-
-rebuild-libwaku: | clean-libwaku $(LIBWAKU)
 
 test: test-unit ##@tests Run basic, short tests during development
 

--- a/_assets/ci/Jenkinsfile.nwaku
+++ b/_assets/ci/Jenkinsfile.nwaku
@@ -64,6 +64,9 @@ pipeline {
     /* Ensure env var is set on first run. */
     USE_NWAKU = "${params.USE_NWAKU}"
 
+    /* nwaku source directory */
+    NWAKU_SOURCE_DIR = "${WORKSPACE}/../nwaku"
+
     /* fixes nim cache collision */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
   }
@@ -90,6 +93,16 @@ pipeline {
     stage('Generate') {
       steps { script {
         nix.develop('make generate', pure: false)
+      }
+    }
+  }
+
+    stage('Clone nwaku') {
+      when {
+        expression { params.USE_NWAKU == true }
+      }
+      steps { script {
+        nix.develop('make clone-nwaku', pure: false)
       }
     }
   }

--- a/_assets/ci/Jenkinsfile.nwaku
+++ b/_assets/ci/Jenkinsfile.nwaku
@@ -79,6 +79,8 @@ pipeline {
                 sh "mkdir -p \$(dirname ${REPO_SRC})"
                 sh "ln -s ${WORKSPACE} ${REPO_SRC}"
               }
+            // Clean up any existing nwaku directory
+            sh "rm -rf ${NWAKU_SOURCE_DIR} || true"
           }
       }
   }
@@ -141,6 +143,7 @@ pipeline {
      success { script { github.notifyPR(true) } }
      failure { script { github.notifyPR(false) } }
      cleanup {
+       sh "rm -rf ${env.NWAKU_SOURCE_DIR} || true"
        cleanWs()
        dir("${env.WORKSPACE}@tmp") { deleteDir() }
      }

--- a/_assets/ci/Jenkinsfile.nwaku
+++ b/_assets/ci/Jenkinsfile.nwaku
@@ -65,7 +65,7 @@ pipeline {
     USE_NWAKU = "${params.USE_NWAKU}"
 
     /* nwaku source directory */
-    NWAKU_SOURCE_DIR = "${WORKSPACE}/../nwaku"
+    NWAKU_SOURCE_DIR = "${WORKSPACE_TMP}/nwaku"
 
     /* fixes nim cache collision */
     XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
@@ -79,8 +79,6 @@ pipeline {
                 sh "mkdir -p \$(dirname ${REPO_SRC})"
                 sh "ln -s ${WORKSPACE} ${REPO_SRC}"
               }
-            // Clean up any existing nwaku directory
-            sh "rm -rf ${NWAKU_SOURCE_DIR} || true"
           }
       }
   }
@@ -95,16 +93,6 @@ pipeline {
     stage('Generate') {
       steps { script {
         nix.develop('make generate', pure: false)
-      }
-    }
-  }
-
-    stage('Clone nwaku') {
-      when {
-        expression { params.USE_NWAKU == true }
-      }
-      steps { script {
-        nix.develop('make clone-nwaku', pure: false)
       }
     }
   }
@@ -143,7 +131,6 @@ pipeline {
      success { script { github.notifyPR(true) } }
      failure { script { github.notifyPR(false) } }
      cleanup {
-       sh "rm -rf ${env.NWAKU_SOURCE_DIR} || true"
        cleanWs()
        dir("${env.WORKSPACE}@tmp") { deleteDir() }
      }

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/status-im/extkeys v1.4.0
 	github.com/status-im/go-wallet-sdk v0.0.0-20251027141302-43edbd6abc92
 	github.com/waku-org/go-waku v0.10.1-0.20251003225121-06c9af60f35b
-	github.com/waku-org/waku-go-bindings v0.0.0-20250926172336-8360dbaa6b0e
+	github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.lsp.dev/jsonrpc2 v0.10.0
 	go.lsp.dev/protocol v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/status-im/extkeys v1.4.0
 	github.com/status-im/go-wallet-sdk v0.0.0-20251027141302-43edbd6abc92
 	github.com/waku-org/go-waku v0.10.1-0.20251003225121-06c9af60f35b
-	github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d
+	github.com/waku-org/waku-go-bindings v0.0.0-20250926172336-8360dbaa6b0e
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.lsp.dev/jsonrpc2 v0.10.0
 	go.lsp.dev/protocol v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -2212,8 +2212,8 @@ github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065 h1:Sd7
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065/go.mod h1:7cSGUoGVIla1IpnChrLbkVjkYgdOcr7rcifEfh4ReR4=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:4HSdWMFMufpRo3ECTX6BrvA+VzKhXZf7mS0rTa5cCWU=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
-github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d h1:k22pZ7dnQ5vTplQ7ZwTfkaZgEUl9IwO9NlbwzRsg73M=
-github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20250926172336-8360dbaa6b0e h1:N8vkMBAajnjpJAO09j6BUvYQQW98I0UICNAmHmRgoEw=
+github.com/waku-org/waku-go-bindings v0.0.0-20250926172336-8360dbaa6b0e/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.5.0 h1:Huc9GxBgiGweCOGTYomvsg07K2QggAqZpZ5SuiZdC8o=
 github.com/wealdtech/go-ens/v3 v3.5.0/go.mod h1:bVuYoWYEEeEu7Zy95rIMjPR34QFJarxt8p84ywSo0YM=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/go.sum
+++ b/go.sum
@@ -2212,8 +2212,8 @@ github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065 h1:Sd7
 github.com/waku-org/go-zerokit-rln-arm v0.0.0-20230916171929-1dd9494ff065/go.mod h1:7cSGUoGVIla1IpnChrLbkVjkYgdOcr7rcifEfh4ReR4=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:4HSdWMFMufpRo3ECTX6BrvA+VzKhXZf7mS0rTa5cCWU=
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
-github.com/waku-org/waku-go-bindings v0.0.0-20250926172336-8360dbaa6b0e h1:N8vkMBAajnjpJAO09j6BUvYQQW98I0UICNAmHmRgoEw=
-github.com/waku-org/waku-go-bindings v0.0.0-20250926172336-8360dbaa6b0e/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3 h1:VimYvS377VZh/b/kipnv2rp0a2r8Dd7D+4ihVd3hipI=
+github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.5.0 h1:Huc9GxBgiGweCOGTYomvsg07K2QggAqZpZ5SuiZdC8o=
 github.com/wealdtech/go-ens/v3 v3.5.0/go.mod h1:bVuYoWYEEeEu7Zy95rIMjPR34QFJarxt8p84ywSo0YM=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/Makefile
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/Makefile
@@ -1,37 +1,25 @@
 # Makefile for Waku Go Bindings
 
 # Directories
-THIRD_PARTY_DIR := ../third_party
+THIRD_PARTY_DIR := $(shell pwd)/../third_party
 NWAKU_REPO := https://github.com/waku-org/nwaku
 NWAKU_DIR := $(THIRD_PARTY_DIR)/nwaku
 
-.PHONY: all clean prepare build-libwaku build
+.PHONY: all clean build-libwaku build
 
 # Default target
 all: build
 
-# Prepare third_party directory and clone nwaku
-prepare:
-	@echo "Creating third_party directory..."
-	@mkdir -p $(THIRD_PARTY_DIR)
-
-	@echo "Cloning nwaku repository..."
-	@if [ ! -d "$(NWAKU_DIR)" ]; then \
-		cd $(THIRD_PARTY_DIR) && \
-		git clone $(NWAKU_REPO) && \
-		cd $(NWAKU_DIR) && \
-		make update; \
-	else \
-		echo "nwaku repository already exists."; \
-	fi
-
 # Build libwaku
-build-libwaku: prepare
+build-libwaku:
 	@echo "Building libwaku..."
 	@cd $(NWAKU_DIR) && make libwaku
 
 # Build Waku Go Bindings
-build: build-libwaku
+
+build: export CGO_CFLAGS = "-I${NWAKU_DIR}/library/"
+build: export CGO_LDFLAGS = "-L${NWAKU_DIR}/build/ -lwaku -L${NWAKU_DIR} -Wl,-rpath,${NWAKU_DIR}/build/"
+build:
 	@echo "Building Waku Go Bindings..."
 	go build ./...
 

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
@@ -1,7 +1,7 @@
 package waku
 
 /*
-	#include "libwaku.h"
+	#include <libwaku.h>
 	#include <stdio.h>
 	#include <stdlib.h>
 

--- a/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
+++ b/vendor/github.com/waku-org/waku-go-bindings/waku/nwaku.go
@@ -1,10 +1,7 @@
 package waku
 
 /*
-	#cgo LDFLAGS: -L../third_party/nwaku/build/ -lwaku
-	#cgo LDFLAGS: -L../third_party/nwaku -Wl,-rpath,../third_party/nwaku/build/
-
-	#include "../third_party/nwaku/library/libwaku.h"
+	#include "libwaku.h"
 	#include <stdio.h>
 	#include <stdlib.h>
 
@@ -348,6 +345,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 	"github.com/waku-org/go-waku/waku/v2/utils"
+
 	"github.com/waku-org/waku-go-bindings/waku/common"
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1365,7 +1365,7 @@ github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-pc-windows-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-musl
 github.com/waku-org/go-zerokit-rln-x86_64/rln
-# github.com/waku-org/waku-go-bindings v0.0.0-20250714110306-6feba5b0df4d
+# github.com/waku-org/waku-go-bindings v0.0.0-20250926172336-8360dbaa6b0e
 ## explicit; go 1.21
 github.com/waku-org/waku-go-bindings/utils
 github.com/waku-org/waku-go-bindings/waku

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1365,7 +1365,7 @@ github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-pc-windows-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-gnu
 github.com/waku-org/go-zerokit-rln-x86_64/libs/x86_64-unknown-linux-musl
 github.com/waku-org/go-zerokit-rln-x86_64/rln
-# github.com/waku-org/waku-go-bindings v0.0.0-20250926172336-8360dbaa6b0e
+# github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3
 ## explicit; go 1.21
 github.com/waku-org/waku-go-bindings/utils
 github.com/waku-org/waku-go-bindings/waku


### PR DESCRIPTION
Iterates https://github.com/status-im/status-go/issues/6970#issuecomment-3436132966
Requires https://github.com/waku-org/waku-go-bindings/pull/95

# Description

Expect nwaku to be provided externally.
In the future, dependencies will be defined with Nimble package manager.

# Current development requirements

1. Define `NWAKU_SOURCE_DIR` pointing to locally fetched `nwaku` repository.
    This variable defaults to `$(GIT_ROOT)/../nwaku`

Note:
1.  `status-go` makefile will automatically run `nwaku` build if `$NWAKU_SOURCE_DIR/build/libwaku.<ext>` is missing.

3. If a `nwaku` source code was updated, manually run `make clean-libwaku`

4. If `NWAKU_SOURCE_DIR` is missing when `USE_NWAKU=true`, error will be raised:
    ```
    > make statusgo USE_NWAKU=true
    Makefile:99: *** NWAKU_SOURCE_DIR must be set when USE_NWAKU is true.  Stop.
    ```
  
