### PR TITLE
fix: "from" block fixed on first activity fetching

### DIFF
--- a/services/wallet/activityfetcher/manager.go
+++ b/services/wallet/activityfetcher/manager.go
@@ -63,7 +63,7 @@ func (m *Manager) FetchActivity(ctx context.Context, chainID uint64, account get
 	parameters.ToBlock = &toBlock
 
 	if lastFetchedBlock == nil {
-		fromBlock := gethrpc.EarliestBlockNumber
+		fromBlock := gethrpc.BlockNumber(0)
 		parameters.FromBlock = &fromBlock
 	} else if uint64(lastFetchedBlock.Int64()) >= currentBlock {
 		// Nothing to fetch


### PR DESCRIPTION

## Description

When activity fetched first time there was a problem with `gethrpc.EarliestBlockNumber`value. It shouldn't have been used "as is" in alchemy request.

In this fix it replaced with "0" block.

Closes #7036
