### PR TITLE
chore: cleanup pip packages

### DIFF
--- a/tests-functional/requirements.txt
+++ b/tests-functional/requirements.txt
@@ -1,5 +1,5 @@
 pytest~=7.4.0
-requests~=2.31.0
+requests~=2.32.4
 websocket-client~=1.4.2
 tenacity~=9.0.0
 docker~=7.1.0

--- a/tests-functional/requirements.txt
+++ b/tests-functional/requirements.txt
@@ -1,9 +1,7 @@
-deepdiff~=5.5.0
 pytest~=7.4.0
 requests~=2.31.0
 websocket-client~=1.4.2
 tenacity~=9.0.0
-pytest-dependency~=0.6.0
 docker~=7.1.0
 pyright~=1.1.388
 black~=24.10.0


### PR DESCRIPTION
Fixes:
- CVE-2025-58367 (though it wasn't a big deal for us as we don't run python code in prod)
- CVE-2024-35195
- CVE-2024-47081