### PR TITLE
refactor: move ChatEntity back to protocol

### DIFF
--- a/messaging/common/message_sender.go
+++ b/messaging/common/message_sender.go
@@ -522,57 +522,6 @@ func (s *MessageSender) SendPairInstallation(
 	return messageID, nil
 }
 
-func (s *MessageSender) encodeMembershipUpdate(
-	message v1protocol.MembershipUpdateMessage,
-	chatEntity messagingtypes.ChatEntity,
-) ([]byte, error) {
-
-	if chatEntity != nil {
-		chatEntityProtobuf := chatEntity.GetProtobuf()
-		switch chatEntityProtobuf := chatEntityProtobuf.(type) {
-		case *protobuf.ChatMessage:
-			message.Message = chatEntityProtobuf
-		case *protobuf.EmojiReaction:
-			message.EmojiReaction = chatEntityProtobuf
-
-		}
-	}
-
-	encodedMessage, err := v1protocol.EncodeMembershipUpdateMessage(message)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to encode membership update message")
-	}
-
-	return encodedMessage, nil
-}
-
-// EncodeMembershipUpdate takes a group and an optional chat message and returns the protobuf representation to be sent on the wire.
-// All the events in a group are encoded and added to the payload
-func (s *MessageSender) EncodeMembershipUpdate(
-	group *v1protocol.Group,
-	chatEntity messagingtypes.ChatEntity,
-) ([]byte, error) {
-	message := v1protocol.MembershipUpdateMessage{
-		ChatID: group.ChatID(),
-		Events: group.Events(),
-	}
-
-	return s.encodeMembershipUpdate(message, chatEntity)
-}
-
-// EncodeAbridgedMembershipUpdate takes a group and an optional chat message and returns the protobuf representation to be sent on the wire.
-// Only the events relevant to the current group are encoded
-func (s *MessageSender) EncodeAbridgedMembershipUpdate(
-	group *v1protocol.Group,
-	chatEntity messagingtypes.ChatEntity,
-) ([]byte, error) {
-	message := v1protocol.MembershipUpdateMessage{
-		ChatID: group.ChatID(),
-		Events: group.AbridgedEvents(),
-	}
-	return s.encodeMembershipUpdate(message, chatEntity)
-}
-
 func (s *MessageSender) dispatchCommunityChatMessage(ctx context.Context, rawMessage *messagingtypes.RawMessage, wrappedMessage []byte, rekey bool) ([][]byte, []*wakutypes.NewMessage, error) {
 	payload := wrappedMessage
 	var err error

--- a/protocol/chat_entity.go
+++ b/protocol/chat_entity.go
@@ -1,4 +1,4 @@
-package types
+package protocol
 
 import (
 	"crypto/ecdsa"

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -4362,7 +4362,7 @@ func generateAliasAndIdenticon(pk string) (string, string, error) {
 
 }
 
-func (m *Messenger) encodeChatEntity(chat *Chat, message messagingtypes.ChatEntity) ([]byte, error) {
+func (m *Messenger) encodeChatEntity(chat *Chat, message ChatEntity) ([]byte, error) {
 	var encodedMessage []byte
 	var err error
 	l := m.logger.With(zap.String("site", "Send"), zap.String("chatID", chat.ID))

--- a/protocol/messenger_group_chat.go
+++ b/protocol/messenger_group_chat.go
@@ -22,7 +22,7 @@ import (
 
 func encodeMembershipUpdate(
 	group *v1protocol.Group,
-	chatEntity messagingtypes.ChatEntity,
+	chatEntity ChatEntity,
 ) ([]byte, error) {
 	message := v1protocol.MembershipUpdateMessage{
 		ChatID: group.ChatID(),

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -2434,7 +2434,7 @@ func (m *Messenger) HandleSyncAccountCustomizationColor(state *ReceivedMessageSt
 	return nil
 }
 
-func (m *Messenger) matchChatEntity(chatEntity messagingtypes.ChatEntity, messageType protobuf.ApplicationMetadataMessage_Type) (*Chat, error) {
+func (m *Messenger) matchChatEntity(chatEntity ChatEntity, messageType protobuf.ApplicationMetadataMessage_Type) (*Chat, error) {
 	if chatEntity.GetSigPubKey() == nil {
 		m.logger.Error("public key can't be empty")
 		return nil, errors.New("received a chatEntity with empty public key")


### PR DESCRIPTION
It doesn't belong to messaging module.