### PR TITLE
feat(connector): add missing commands

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -55,13 +55,22 @@ func NewAPI(s *Service) *API {
 		Db:             s.db,
 		NetworkManager: s.nm,
 	})
+	r.Register("net_version", &commands.NetVersionCommand{
+		Db:             s.db,
+		NetworkManager: s.nm,
+	})
 	r.Register("wallet_switchEthereumChain", &commands.SwitchEthereumChainCommand{
 		Db:             s.db,
 		NetworkManager: s.nm,
 	})
 
 	// Permissions
-	r.Register("wallet_requestPermissions", &commands.RequestPermissionsCommand{})
+	r.Register("wallet_requestPermissions", &commands.RequestPermissionsCommand{
+		Db: s.db,
+	})
+	r.Register("wallet_getPermissions", &commands.GetPermissionsCommand{
+		Db: s.db,
+	})
 	r.Register("wallet_revokePermissions", &commands.RevokePermissionsCommand{
 		Db: s.db,
 	})

--- a/services/connector/commands/get_permissions.go
+++ b/services/connector/commands/get_permissions.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"context"
+	"database/sql"
+
+	persistence "github.com/status-im/status-go/services/connector/database"
+)
+
+type GetPermissionsCommand struct {
+	Db *sql.DB
+}
+
+func (c *GetPermissionsCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
+	err := request.Validate()
+	if err != nil {
+		return "", err
+	}
+
+	permissions, err := persistence.SelectPermissions(c.Db, request.URL, request.ClientID)
+	if err != nil {
+		return "", err
+	}
+
+	// EIP-2255 specifies that wallet_getPermissions should return an array of permissions
+	if permissions == nil {
+		return []persistence.Permission{}, nil
+	}
+
+	return permissions, nil
+}

--- a/services/connector/commands/get_permissions_test.go
+++ b/services/connector/commands/get_permissions_test.go
@@ -1,0 +1,82 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	persistence "github.com/status-im/status-go/services/connector/database"
+)
+
+func TestGetPermissionsWithNoPermissions(t *testing.T) {
+	state, close := setupCommand(t, Method_RequestPermissions)
+	t.Cleanup(close)
+
+	getPermissionsCmd := &GetPermissionsCommand{
+		Db: state.walletDb,
+	}
+
+	request, err := ConstructRPCRequest("wallet_getPermissions", []interface{}{}, &testDAppData)
+	require.NoError(t, err)
+
+	result, err := getPermissionsCmd.Execute(state.ctx, request)
+	require.NoError(t, err)
+
+	permissions, ok := result.([]persistence.Permission)
+	assert.True(t, ok)
+	assert.Empty(t, permissions)
+}
+
+func TestGetPermissionsWithExistingPermissions(t *testing.T) {
+	state, close := setupCommand(t, Method_RequestPermissions)
+	t.Cleanup(close)
+
+	dApp := &persistence.DApp{
+		URL:           testDAppData.URL,
+		Name:          testDAppData.Name,
+		IconURL:       testDAppData.IconURL,
+		ClientID:      testDAppData.ClientID,
+		SharedAccount: [20]byte{0x01},
+		ChainID:       1,
+	}
+	err := persistence.UpsertDApp(state.walletDb, dApp)
+	require.NoError(t, err)
+
+	// Insert a permission
+	caveats := []persistence.Caveat{{Type: "test", Value: "value"}}
+	err = persistence.InsertPermission(state.walletDb, testDAppData.URL, testDAppData.ClientID, "eth_accounts", caveats, 123)
+	require.NoError(t, err)
+
+	getPermissionsCmd := &GetPermissionsCommand{
+		Db: state.walletDb,
+	}
+
+	request, err := ConstructRPCRequest("wallet_getPermissions", []interface{}{}, &testDAppData)
+	require.NoError(t, err)
+
+	result, err := getPermissionsCmd.Execute(state.ctx, request)
+	require.NoError(t, err)
+
+	permissions, ok := result.([]persistence.Permission)
+	assert.True(t, ok)
+	assert.Len(t, permissions, 1)
+	assert.Equal(t, "eth_accounts", permissions[0].ParentCapability)
+}
+
+func TestGetPermissionsValidationError(t *testing.T) {
+	state, close := setupCommand(t, Method_RequestPermissions)
+	t.Cleanup(close)
+
+	getPermissionsCmd := &GetPermissionsCommand{
+		Db: state.walletDb,
+	}
+
+	// Missing DApp data
+	request, err := ConstructRPCRequest("wallet_getPermissions", []interface{}{}, nil)
+	require.NoError(t, err)
+
+	result, err := getPermissionsCmd.Execute(state.ctx, request)
+	assert.Equal(t, ErrRequestMissingDAppData, err)
+	assert.Empty(t, result)
+}

--- a/services/connector/commands/net_version.go
+++ b/services/connector/commands/net_version.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+
+	"github.com/status-im/status-go/rpc/network"
+	"github.com/status-im/status-go/services/connector/chainutils"
+	persistence "github.com/status-im/status-go/services/connector/database"
+)
+
+type NetVersionCommand struct {
+	NetworkManager *network.Manager
+	Db             *sql.DB
+}
+
+func (c *NetVersionCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
+	err := request.Validate()
+	if err != nil {
+		return "", err
+	}
+
+	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	if err != nil {
+		return "", err
+	}
+
+	var chainId uint64
+	if dApp == nil {
+		chainId, err = chainutils.GetDefaultChainID(c.NetworkManager)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		chainId = dApp.ChainID
+	}
+
+	// net_version returns the network ID as a decimal string
+	// (unlike eth_chainId which returns a hex string)
+	networkIdStr := strconv.FormatUint(chainId, 10)
+
+	return networkIdStr, nil
+}

--- a/services/connector/commands/net_version_test.go
+++ b/services/connector/commands/net_version_test.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	persistence "github.com/status-im/status-go/services/connector/database"
+	walletCommon "github.com/status-im/status-go/services/wallet/common"
+)
+
+func TestNetVersionWithoutDApp(t *testing.T) {
+	state, close := setupCommand(t, "net_version")
+	t.Cleanup(close)
+
+	request, err := ConstructRPCRequest("net_version", []interface{}{}, &testDAppData)
+	require.NoError(t, err)
+
+	result, err := state.cmd.Execute(state.ctx, request)
+	require.NoError(t, err)
+
+	// Should return a decimal string
+	assert.Equal(t, "1", result)
+}
+
+func TestNetVersionWithExistingDApp(t *testing.T) {
+	state, close := setupCommand(t, "net_version")
+	t.Cleanup(close)
+
+	dApp := &persistence.DApp{
+		URL:           testDAppData.URL,
+		Name:          testDAppData.Name,
+		IconURL:       testDAppData.IconURL,
+		ClientID:      testDAppData.ClientID,
+		SharedAccount: [20]byte{0x01},
+		ChainID:       walletCommon.OptimismMainnet,
+	}
+	err := persistence.UpsertDApp(state.walletDb, dApp)
+	require.NoError(t, err)
+
+	request, err := ConstructRPCRequest("net_version", []interface{}{}, &testDAppData)
+	require.NoError(t, err)
+
+	result, err := state.cmd.Execute(state.ctx, request)
+	require.NoError(t, err)
+
+	assert.Equal(t, "10", result)
+}
+
+func TestNetVersionValidationError(t *testing.T) {
+	state, close := setupCommand(t, "net_version")
+	t.Cleanup(close)
+
+	// Missing DApp data
+	request, err := ConstructRPCRequest("net_version", []interface{}{}, nil)
+	require.NoError(t, err)
+
+	result, err := state.cmd.Execute(state.ctx, request)
+	assert.Equal(t, ErrRequestMissingDAppData, err)
+	assert.Empty(t, result)
+}

--- a/services/connector/commands/request_accounts.go
+++ b/services/connector/commands/request_accounts.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/status-im/status-go/accounts-management/types"
 	persistence "github.com/status-im/status-go/services/connector/database"
@@ -57,6 +58,15 @@ func (c *RequestAccountsCommand) Execute(ctx context.Context, request RPCRequest
 		if err != nil {
 			return "", err
 		}
+
+		// Store eth_accounts permission (EIP-2255)
+		createdAt := time.Now().Unix()
+		emptyCaveats := []persistence.Caveat{}
+		err = persistence.InsertPermission(c.Db, dApp.URL, dApp.ClientID, "eth_accounts", emptyCaveats, createdAt)
+		if err != nil {
+			return "", err
+		}
+
 		signal.SendConnectorDAppPermissionGranted(connectorDApp, account, []uint64{chainID})
 	}
 

--- a/services/connector/commands/request_accounts_test.go
+++ b/services/connector/commands/request_accounts_test.go
@@ -126,3 +126,30 @@ func TestRequestAccountsRejected(t *testing.T) {
 	_, err = state.cmd.Execute(state.ctx, request)
 	assert.Equal(t, ErrRequestAccountsRejectedByUser, err)
 }
+
+func TestRequestAccountsWithExistingDApp(t *testing.T) {
+	state, close := setupCommand(t, Method_EthRequestAccounts)
+	t.Cleanup(close)
+
+	// Pre-create a dApp
+	accountAddress := types.Address{0x05}
+	dApp := &persistence.DApp{
+		URL:           testDAppData.URL,
+		Name:          testDAppData.Name,
+		IconURL:       testDAppData.IconURL,
+		ClientID:      testDAppData.ClientID,
+		SharedAccount: accountAddress,
+		ChainID:       walletCommon.EthereumMainnet,
+	}
+	err := persistence.UpsertDApp(state.walletDb, dApp)
+	assert.NoError(t, err)
+
+	request, err := ConstructRPCRequest("eth_requestAccounts", []interface{}{}, &testDAppData)
+	assert.NoError(t, err)
+
+	// Should not trigger signal since dApp already exists
+	expectedResponse := FormatAccountAddressToResponse(accountAddress)
+	response, err := state.cmd.Execute(state.ctx, request)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, response)
+}

--- a/services/connector/commands/request_permissions.go
+++ b/services/connector/commands/request_permissions.go
@@ -2,54 +2,70 @@ package commands
 
 import (
 	"context"
+	"database/sql"
 	"errors"
-	"fmt"
 	"time"
+
+	persistence "github.com/status-im/status-go/services/connector/database"
 )
 
-type RequestPermissionsCommand struct{}
-
-type Permission struct {
-	ParentCapability string `json:"parentCapability"`
-	Date             string `json:"date"`
+type RequestPermissionsCommand struct {
+	Db *sql.DB
 }
 
 var (
 	ErrNoRequestPermissionsParamsFound = errors.New("no request permission params found")
 	ErrMultipleKeysFound               = errors.New("multiple methodNames found in request permissions params")
 	ErrInvalidParamType                = errors.New("invalid parameter type")
+	ErrDAppNotFound                    = errors.New("dApp not found; permission not persisted")
 )
 
-func (r *RPCRequest) getRequestPermissionsParam() (string, error) {
+func (r *RPCRequest) getRequestPermissionsParam() (string, map[string]interface{}, error) {
 	if r.Params == nil || len(r.Params) == 0 {
-		return "", ErrEmptyRPCParams
+		return "", nil, ErrEmptyRPCParams
 	}
 
 	paramMap, ok := r.Params[0].(map[string]interface{})
 	if !ok {
-		return "", ErrInvalidParamType
+		return "", nil, ErrInvalidParamType
 	}
 
 	if len(paramMap) > 1 {
-		return "", ErrMultipleKeysFound
+		return "", nil, ErrMultipleKeysFound
 	}
 
-	for methodName := range paramMap {
-		return methodName, nil
+	for methodName, caveatsValue := range paramMap {
+		caveatsMap, ok := caveatsValue.(map[string]interface{})
+		if !ok {
+			return methodName, make(map[string]interface{}), nil
+		}
+		return methodName, caveatsMap, nil
 	}
 
-	return "", ErrNoRequestPermissionsParamsFound
+	return "", nil, ErrNoRequestPermissionsParamsFound
 }
 
-func (c *RequestPermissionsCommand) getPermissionResponse(methodName string) Permission {
-	date := time.Now().UnixNano() / int64(time.Millisecond)
+func (c *RequestPermissionsCommand) parseCaveats(caveatsMap map[string]interface{}) []persistence.Caveat {
+	// TODO: Validate caveat types and values according to EIP-2255 specification
+	// TODO: Implement caveat enforcement logic (e.g., requiredMethods, expiry, etc.)
+	var caveats []persistence.Caveat
 
-	response := Permission{
-		ParentCapability: methodName,
-		Date:             fmt.Sprintf("%d", date),
+	for caveatType, caveatValue := range caveatsMap {
+		caveats = append(caveats, persistence.Caveat{
+			Type:  caveatType,
+			Value: caveatValue,
+		})
 	}
 
-	return response
+	return caveats
+}
+
+func (c *RequestPermissionsCommand) getPermissionResponse(url string, methodName string, caveats []persistence.Caveat) persistence.Permission {
+	return persistence.Permission{
+		Invoker:          url,
+		ParentCapability: methodName,
+		Caveats:          caveats,
+	}
 }
 
 func (c *RequestPermissionsCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
@@ -58,10 +74,28 @@ func (c *RequestPermissionsCommand) Execute(ctx context.Context, request RPCRequ
 		return "", err
 	}
 
-	methodName, err := request.getRequestPermissionsParam()
+	methodName, caveatsMap, err := request.getRequestPermissionsParam()
 	if err != nil {
 		return "", err
 	}
 
-	return c.getPermissionResponse(methodName), nil
+	caveats := c.parseCaveats(caveatsMap)
+
+	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	if err != nil {
+		return "", err
+	}
+
+	if dApp == nil {
+		return "", ErrDAppNotFound
+	}
+
+	createdAt := time.Now().Unix()
+	err = persistence.InsertPermission(c.Db, request.URL, request.ClientID, methodName, caveats, createdAt)
+	if err != nil {
+		return "", err
+	}
+
+	// EIP-2255 - wallet_requestPermissions returns an array
+	return []persistence.Permission{c.getPermissionResponse(request.URL, methodName, caveats)}, nil
 }

--- a/services/connector/commands/request_permissions_test.go
+++ b/services/connector/commands/request_permissions_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	persistence "github.com/status-im/status-go/services/connector/database"
 )
 
 func TestFailToRequestPermissionsWithMissingDAppFields(t *testing.T) {
@@ -22,6 +24,17 @@ func TestFailToRequestPermissionsWithMissingDAppFields(t *testing.T) {
 func TestRequestPermissionsResponse(t *testing.T) {
 	state, close := setupCommand(t, Method_RequestPermissions)
 	t.Cleanup(close)
+
+	dApp := &persistence.DApp{
+		URL:           testDAppData.URL,
+		Name:          testDAppData.Name,
+		IconURL:       testDAppData.IconURL,
+		ClientID:      testDAppData.ClientID,
+		SharedAccount: [20]byte{0x01},
+		ChainID:       1,
+	}
+	err := persistence.UpsertDApp(state.walletDb, dApp)
+	assert.NoError(t, err)
 
 	testCases := []struct {
 		name               string
@@ -96,12 +109,106 @@ func TestRequestPermissionsResponse(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 
-				if permission, ok := response.(Permission); ok {
-					assert.Equal(t, permission.ParentCapability, tc.expectedCapability)
+				if permissions, ok := response.([]persistence.Permission); ok {
+					assert.Len(t, permissions, 1)
+					assert.Equal(t, permissions[0].ParentCapability, tc.expectedCapability)
+					assert.Equal(t, permissions[0].Invoker, testDAppData.URL)
 				} else {
-					assert.Fail(t, "Can't parse permission from the response")
+					assert.Fail(t, "Can't parse permissions array from the response")
 				}
 			}
 		})
 	}
+}
+
+func TestRequestPermissionsWithCaveats(t *testing.T) {
+	state, close := setupCommand(t, Method_RequestPermissions)
+	t.Cleanup(close)
+
+	dApp := &persistence.DApp{
+		URL:           testDAppData.URL,
+		Name:          testDAppData.Name,
+		IconURL:       testDAppData.IconURL,
+		ClientID:      testDAppData.ClientID,
+		SharedAccount: [20]byte{0x01},
+		ChainID:       1,
+	}
+	err := persistence.UpsertDApp(state.walletDb, dApp)
+	assert.NoError(t, err)
+
+	// Test with caveats as map
+	params := []interface{}{
+		map[string]interface{}{
+			"eth_accounts": map[string]interface{}{
+				"requiredMethods": []string{"signTypedData_v4"},
+				"expiry":          float64(1234567890),
+			},
+		},
+	}
+
+	request, err := ConstructRPCRequest("wallet_requestPermissions", params, &testDAppData)
+	assert.NoError(t, err)
+
+	response, err := state.cmd.Execute(state.ctx, request)
+	assert.NoError(t, err)
+
+	permissions, ok := response.([]persistence.Permission)
+	assert.True(t, ok)
+	assert.Len(t, permissions, 1)
+	assert.Equal(t, "eth_accounts", permissions[0].ParentCapability)
+	assert.Len(t, permissions[0].Caveats, 2)
+}
+
+func TestRequestPermissionsWithNonMapCaveats(t *testing.T) {
+	state, close := setupCommand(t, Method_RequestPermissions)
+	t.Cleanup(close)
+
+	dApp := &persistence.DApp{
+		URL:           testDAppData.URL,
+		Name:          testDAppData.Name,
+		IconURL:       testDAppData.IconURL,
+		ClientID:      testDAppData.ClientID,
+		SharedAccount: [20]byte{0x01},
+		ChainID:       1,
+	}
+	err := persistence.UpsertDApp(state.walletDb, dApp)
+	assert.NoError(t, err)
+
+	// Test with non-map caveats value
+	params := []interface{}{
+		map[string]interface{}{
+			"eth_accounts": "not-a-map",
+		},
+	}
+
+	request, err := ConstructRPCRequest("wallet_requestPermissions", params, &testDAppData)
+	assert.NoError(t, err)
+
+	response, err := state.cmd.Execute(state.ctx, request)
+	assert.NoError(t, err)
+
+	permissions, ok := response.([]persistence.Permission)
+	assert.True(t, ok)
+	assert.Len(t, permissions, 1)
+	assert.Equal(t, "eth_accounts", permissions[0].ParentCapability)
+	assert.Empty(t, permissions[0].Caveats)
+}
+
+func TestRequestPermissionsNoDAppFound(t *testing.T) {
+	state, close := setupCommand(t, Method_RequestPermissions)
+	t.Cleanup(close)
+
+	// Don't create a dApp, so it will fail with ErrDAppNotFound
+	params := []interface{}{
+		map[string]interface{}{
+			"eth_accounts": struct{}{},
+		},
+	}
+
+	request, err := ConstructRPCRequest("wallet_requestPermissions", params, &testDAppData)
+	assert.NoError(t, err)
+
+	response, err := state.cmd.Execute(state.ctx, request)
+	assert.Equal(t, ErrDAppNotFound, err)
+	assert.Empty(t, response)
 }

--- a/services/connector/commands/revoke_permissions.go
+++ b/services/connector/commands/revoke_permissions.go
@@ -27,6 +27,7 @@ func (c *RevokePermissionsCommand) Execute(ctx context.Context, request RPCReque
 		return "", ErrDAppIsNotPermittedByUser
 	}
 
+	// Delete the dApp entry (CASCADE will automatically delete permissions)
 	err = persistence.DeleteDApp(c.Db, dApp.URL, dApp.ClientID)
 	if err != nil {
 		return "", err

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -105,6 +105,11 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 			Db:             state.walletDb,
 			NetworkManager: networkManager,
 		}
+	case "net_version":
+		state.cmd = &NetVersionCommand{
+			Db:             state.walletDb,
+			NetworkManager: networkManager,
+		}
 	case Method_PersonalSign:
 		state.cmd = &SignCommand{
 			Db:            state.walletDb,
@@ -123,7 +128,9 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 			FeeManager:      state.feeManager,
 		}
 	case Method_RequestPermissions:
-		state.cmd = &RequestPermissionsCommand{}
+		state.cmd = &RequestPermissionsCommand{
+			Db: state.walletDb,
+		}
 	case Method_RevokePermissions:
 		state.cmd = &RevokePermissionsCommand{
 			Db: state.walletDb,

--- a/services/connector/database/persistence.go
+++ b/services/connector/database/persistence.go
@@ -2,14 +2,26 @@ package persistence
 
 import (
 	"database/sql"
+	"encoding/json"
+	"strings"
 
 	"github.com/status-im/status-go/crypto/types"
 )
+
+func normalizeURL(url string) string {
+	return strings.TrimRight(url, "/")
+}
 
 const upsertDAppQuery = "INSERT INTO connector_dapps (url, name, icon_url, client_id, shared_account, chain_id) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(url, client_id) DO UPDATE SET name = excluded.name, icon_url = excluded.icon_url, shared_account = excluded.shared_account, chain_id = excluded.chain_id"
 const selectDAppQuery = "SELECT name, icon_url, shared_account, chain_id FROM connector_dapps WHERE url = ? AND client_id = ?"
 const selectDAppsQuery = "SELECT url, name, icon_url, client_id, shared_account, chain_id FROM connector_dapps"
 const deleteDAppQuery = "DELETE FROM connector_dapps WHERE url = ? AND client_id = ?"
+
+// Permissions queries
+const insertPermissionQuery = "INSERT INTO connector_permissions (url, client_id, parent_capability, caveats, created_at) VALUES (?, ?, ?, ?, ?)"
+const selectPermissionsQuery = "SELECT parent_capability, caveats FROM connector_permissions WHERE url = ? AND client_id = ?"
+const selectPermissionExistsQuery = "SELECT COUNT(*) FROM connector_permissions WHERE url = ? AND client_id = ? AND parent_capability = ?"
+const deletePermissionsQuery = "DELETE FROM connector_permissions WHERE url = ? AND client_id = ?"
 
 type DApp struct {
 	URL           string        `json:"url"`
@@ -20,18 +32,34 @@ type DApp struct {
 	ChainID       uint64        `json:"chainId"`
 }
 
+// EIP-2255
+// TODO: Add caveat validation and enforcement mechanism
+// TODO: Implement standard caveat types (requiredMethods, expiry, etc.)
+type Caveat struct {
+	Type  string      `json:"type"`
+	Value interface{} `json:"value"`
+}
+
+type Permission struct {
+	Invoker          string   `json:"invoker"`
+	ParentCapability string   `json:"parentCapability"`
+	Caveats          []Caveat `json:"caveats"`
+}
+
 func UpsertDApp(db *sql.DB, dApp *DApp) error {
-	_, err := db.Exec(upsertDAppQuery, dApp.URL, dApp.Name, dApp.IconURL, dApp.ClientID, dApp.SharedAccount, dApp.ChainID)
+	normalizedURL := normalizeURL(dApp.URL)
+	_, err := db.Exec(upsertDAppQuery, normalizedURL, dApp.Name, dApp.IconURL, dApp.ClientID, dApp.SharedAccount, dApp.ChainID)
 	return err
 }
 
 func SelectDApp(db *sql.DB, url string, clientID string) (*DApp, error) {
 	// clientID can be empty for backward compatibility with browser extension
+	normalizedURL := normalizeURL(url)
 	dApp := &DApp{
-		URL:      url,
+		URL:      normalizedURL,
 		ClientID: clientID,
 	}
-	err := db.QueryRow(selectDAppQuery, url, clientID).Scan(&dApp.Name, &dApp.IconURL, &dApp.SharedAccount, &dApp.ChainID)
+	err := db.QueryRow(selectDAppQuery, normalizedURL, clientID).Scan(&dApp.Name, &dApp.IconURL, &dApp.SharedAccount, &dApp.ChainID)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -58,6 +86,70 @@ func SelectAllDApps(db *sql.DB) ([]DApp, error) {
 }
 
 func DeleteDApp(db *sql.DB, url string, clientID string) error {
-	_, err := db.Exec(deleteDAppQuery, url, clientID)
+	normalizedURL := normalizeURL(url)
+	_, err := db.Exec(deleteDAppQuery, normalizedURL, clientID)
+	return err
+}
+
+func InsertPermission(db *sql.DB, url string, clientID string, parentCapability string, caveats []Caveat, createdAt int64) error {
+	normalizedURL := normalizeURL(url)
+
+	var count int
+	err := db.QueryRow(selectPermissionExistsQuery, normalizedURL, clientID, parentCapability).Scan(&count)
+	if err != nil {
+		return err
+	}
+
+	if count > 0 {
+		return nil
+	}
+
+	caveatsJSON, err := json.Marshal(caveats)
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Exec(insertPermissionQuery, normalizedURL, clientID, parentCapability, string(caveatsJSON), createdAt)
+	return err
+}
+
+func SelectPermissions(db *sql.DB, url string, clientID string) ([]Permission, error) {
+	normalizedURL := normalizeURL(url)
+
+	rows, err := db.Query(selectPermissionsQuery, normalizedURL, clientID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var permissions []Permission
+	for rows.Next() {
+		var parentCapability string
+		var caveatsJSON string
+
+		err = rows.Scan(&parentCapability, &caveatsJSON)
+		if err != nil {
+			return nil, err
+		}
+
+		var caveats []Caveat
+		if err := json.Unmarshal([]byte(caveatsJSON), &caveats); err != nil {
+			return nil, err
+		}
+
+		permission := Permission{
+			Invoker:          normalizedURL,
+			ParentCapability: parentCapability,
+			Caveats:          caveats,
+		}
+		permissions = append(permissions, permission)
+	}
+
+	return permissions, nil
+}
+
+func DeletePermissions(db *sql.DB, url string, clientID string) error {
+	normalizedURL := normalizeURL(url)
+	_, err := db.Exec(deletePermissionsQuery, normalizedURL, clientID)
 	return err
 }

--- a/services/connector/database/persistence_test.go
+++ b/services/connector/database/persistence_test.go
@@ -1,9 +1,8 @@
 package persistence
 
 import (
-	"testing"
-
 	"database/sql"
+	"testing"
 
 	"github.com/status-im/status-go/crypto/types"
 	"github.com/status-im/status-go/t/helpers"
@@ -27,6 +26,19 @@ func setupTestDB(t *testing.T) (db *sql.DB, close func()) {
 	return db, func() {
 		require.NoError(t, db.Close())
 	}
+}
+
+func setupTestDAppWithPermission(t *testing.T, db *sql.DB, dApp *DApp, parentCapability string, caveats []Caveat, createdAt int64, expectedCount int) []Permission {
+	err := UpsertDApp(db, dApp)
+	require.NoError(t, err)
+
+	err = InsertPermission(db, dApp.URL, dApp.ClientID, parentCapability, caveats, createdAt)
+	require.NoError(t, err)
+
+	permissions, err := SelectPermissions(db, dApp.URL, dApp.ClientID)
+	require.NoError(t, err)
+	require.Len(t, permissions, expectedCount)
+	return permissions
 }
 
 func TestInsertAndSelectDApp(t *testing.T) {
@@ -241,4 +253,218 @@ func TestBackwardCompatibilityEmptyClientID(t *testing.T) {
 	stillExistsNewDApp, err := SelectDApp(db, newDApp.URL, newDApp.ClientID)
 	require.NoError(t, err)
 	require.Equal(t, &newDApp, stillExistsNewDApp)
+}
+
+// EIP-2255 Permissions Tests
+func TestInsertAndSelectPermission(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	caveats := []Caveat{
+		{Type: "requiredMethods", Value: []interface{}{"signTypedData_v3"}},
+	}
+	createdAt := int64(1234567890)
+
+	permissions := setupTestDAppWithPermission(t, db, &testDApp, "eth_accounts", caveats, createdAt, 1)
+
+	perm := permissions[0]
+	require.Equal(t, testDApp.URL, perm.Invoker)
+	require.Equal(t, "eth_accounts", perm.ParentCapability)
+	require.Len(t, perm.Caveats, 1)
+	require.Equal(t, "requiredMethods", perm.Caveats[0].Type)
+}
+
+func TestSelectPermissionsEmpty(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	permissions, err := SelectPermissions(db, "https://nonexistent.com", "")
+	require.NoError(t, err)
+	require.Empty(t, permissions)
+}
+
+func TestMultiplePermissionsForSameDApp(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	err := UpsertDApp(db, &testDApp)
+	require.NoError(t, err)
+
+	caveats1 := []Caveat{{Type: "caveat1", Value: "value1"}}
+	caveats2 := []Caveat{{Type: "caveat2", Value: "value2"}}
+
+	err = InsertPermission(db, testDApp.URL, testDApp.ClientID, "eth_accounts", caveats1, 111)
+	require.NoError(t, err)
+
+	err = InsertPermission(db, testDApp.URL, testDApp.ClientID, "personal_sign", caveats2, 222)
+	require.NoError(t, err)
+
+	permissions, err := SelectPermissions(db, testDApp.URL, testDApp.ClientID)
+	require.NoError(t, err)
+	require.Len(t, permissions, 2)
+
+	// Verify both permissions
+	foundEthAccounts := false
+	foundPersonalSign := false
+	for _, perm := range permissions {
+		if perm.ParentCapability == "eth_accounts" {
+			foundEthAccounts = true
+			require.Equal(t, "caveat1", perm.Caveats[0].Type)
+		}
+		if perm.ParentCapability == "personal_sign" {
+			foundPersonalSign = true
+			require.Equal(t, "caveat2", perm.Caveats[0].Type)
+		}
+	}
+	require.True(t, foundEthAccounts)
+	require.True(t, foundPersonalSign)
+}
+
+func TestDeletePermissions(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	caveats := []Caveat{{Type: "test", Value: "value"}}
+	setupTestDAppWithPermission(t, db, &testDApp, "eth_accounts", caveats, 123, 1)
+
+	err := DeletePermissions(db, testDApp.URL, testDApp.ClientID)
+	require.NoError(t, err)
+
+	// Verify permissions deleted
+	permissions, err := SelectPermissions(db, testDApp.URL, testDApp.ClientID)
+	require.NoError(t, err)
+	require.Empty(t, permissions)
+}
+
+func TestCascadeDeletePermissionsWhenDAppDeleted(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	caveats := []Caveat{{Type: "test", Value: "value"}}
+	setupTestDAppWithPermission(t, db, &testDApp, "eth_accounts", caveats, 123, 1)
+
+	// Delete dApp (should cascade to permissions)
+	err := DeleteDApp(db, testDApp.URL, testDApp.ClientID)
+	require.NoError(t, err)
+
+	// Verify permissions automatically deleted by CASCADE
+	permissions, err := SelectPermissions(db, testDApp.URL, testDApp.ClientID)
+	require.NoError(t, err)
+	require.Empty(t, permissions)
+}
+
+func TestPermissionWithEmptyCaveats(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	emptyCaveats := []Caveat{}
+	permissions := setupTestDAppWithPermission(t, db, &testDApp, "eth_accounts", emptyCaveats, 123, 1)
+	require.Empty(t, permissions[0].Caveats)
+}
+
+func TestInsertDuplicatePermission(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	err := UpsertDApp(db, &testDApp)
+	require.NoError(t, err)
+
+	caveats := []Caveat{{Type: "test", Value: "value"}}
+
+	err = InsertPermission(db, testDApp.URL, testDApp.ClientID, "eth_accounts", caveats, 111)
+	require.NoError(t, err)
+
+	err = InsertPermission(db, testDApp.URL, testDApp.ClientID, "eth_accounts", caveats, 222)
+	require.NoError(t, err)
+
+	err = InsertPermission(db, testDApp.URL, testDApp.ClientID, "eth_accounts", caveats, 333)
+	require.NoError(t, err)
+
+	// Should only have ONE permission, not duplicates
+	permissions, err := SelectPermissions(db, testDApp.URL, testDApp.ClientID)
+	require.NoError(t, err)
+	require.Len(t, permissions, 1, "Should not create duplicate permissions")
+	require.Equal(t, "eth_accounts", permissions[0].ParentCapability)
+}
+
+func TestURLNormalizationTrailingSlash(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	// dApp with trailing slash
+	dAppWithSlash := DApp{
+		Name:          "Test DApp",
+		URL:           "https://test-dapp.com/",
+		IconURL:       "https://icon.com",
+		ClientID:      "client1",
+		SharedAccount: types.HexToAddress("0x1234567890"),
+		ChainID:       0x1,
+	}
+
+	err := UpsertDApp(db, &dAppWithSlash)
+	require.NoError(t, err)
+
+	dAppBack, err := SelectDApp(db, "https://test-dapp.com", "client1")
+	require.NoError(t, err)
+	require.NotNil(t, dAppBack)
+	require.Equal(t, "Test DApp", dAppBack.Name)
+}
+
+func TestPermissionsWithMultipleClients(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	// 2 dApps with different clients
+	dApp1 := DApp{
+		Name:          "DApp Client 1",
+		URL:           "https://test.com",
+		IconURL:       "https://icon.com",
+		ClientID:      "client1",
+		SharedAccount: types.HexToAddress("0x1111111111"),
+		ChainID:       0x1,
+	}
+
+	dApp2 := DApp{
+		Name:          "DApp Client 2",
+		URL:           "https://test.com",
+		IconURL:       "https://icon.com",
+		ClientID:      "client2",
+		SharedAccount: types.HexToAddress("0x2222222222"),
+		ChainID:       0x1,
+	}
+
+	err := UpsertDApp(db, &dApp1)
+	require.NoError(t, err)
+	err = UpsertDApp(db, &dApp2)
+	require.NoError(t, err)
+
+	// Add permissions for both clients
+	caveats1 := []Caveat{{Type: "test1", Value: "value1"}}
+	caveats2 := []Caveat{{Type: "test2", Value: "value2"}}
+
+	err = InsertPermission(db, dApp1.URL, dApp1.ClientID, "eth_accounts", caveats1, 111)
+	require.NoError(t, err)
+	err = InsertPermission(db, dApp2.URL, dApp2.ClientID, "personal_sign", caveats2, 222)
+	require.NoError(t, err)
+
+	// Verify each client has only their permissions
+	perms1, err := SelectPermissions(db, dApp1.URL, dApp1.ClientID)
+	require.NoError(t, err)
+	require.Len(t, perms1, 1)
+	require.Equal(t, "eth_accounts", perms1[0].ParentCapability)
+
+	perms2, err := SelectPermissions(db, dApp2.URL, dApp2.ClientID)
+	require.NoError(t, err)
+	require.Len(t, perms2, 1)
+	require.Equal(t, "personal_sign", perms2[0].ParentCapability)
+}
+
+func TestSelectPermissionsReturnsNilForNonExistent(t *testing.T) {
+	db, close := setupTestDB(t)
+	defer close()
+
+	permissions, err := SelectPermissions(db, "https://nonexistent.com", "client123")
+	require.NoError(t, err)
+	require.Nil(t, permissions)
+	require.Len(t, permissions, 0)
 }

--- a/services/connector/remote.go
+++ b/services/connector/remote.go
@@ -44,7 +44,7 @@ var dappAllowedRemoteMethods = [...]string{
 	"eth_getWork",
 	"eth_submitWork",
 	"eth_submitHashrate",
-	"net_version",
+	// 	"net_version", 		  // should be available before connection
 	"net_peerCount",
 	"net_listening",
 }

--- a/walletdatabase/migrations/sql/1761742404_add_connector_permissions.up.sql
+++ b/walletdatabase/migrations/sql/1761742404_add_connector_permissions.up.sql
@@ -1,0 +1,17 @@
+-- connector_permissions table stores individual permissions for each dApp connection
+-- This table implements EIP-2255 Wallet Permissions System
+-- Each permission has caveats (restrictions) stored as JSON
+
+CREATE TABLE IF NOT EXISTS connector_permissions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    url TEXT NOT NULL,
+    client_id TEXT NOT NULL DEFAULT '',
+    parent_capability TEXT NOT NULL,
+    caveats TEXT NOT NULL DEFAULT '[]',
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (url, client_id) REFERENCES connector_dapps(url, client_id) ON DELETE CASCADE,
+    UNIQUE(url, client_id, parent_capability)
+);
+
+CREATE INDEX idx_connector_permissions_url_client ON connector_permissions(url, client_id);
+


### PR DESCRIPTION
- Added `wallet_getPermissions` and improved `wallet_requestPermissions` commands to comply with EIP-2255 specification
- Permission storage with caveats (restrictions) as JSON structures

Other:
- Introduced `net_version` command that works before wallet connection establishment
- Enhanced URL normalization to prevent duplicate entries

TODO in next PRs (when needed):
* Add caveat validation and enforcement mechanism
* Implement standard caveat types (requiredMethods, expiry, etc.)


fixes #7041 