### PR TITLE
fix(migration): fix the news feed migration not having the timestamp

### DIFF
--- a/appdatabase/migrations/sql/1761341220_newsfeed_settings.up.sql
+++ b/appdatabase/migrations/sql/1761341220_newsfeed_settings.up.sql
@@ -22,7 +22,9 @@ SELECT 1,
        news_feed_enabled,
        news_rss_enabled,
        news_notifications_enabled,
-       news_feed_last_fetched_timestamp
+       -- We cannot guarantee that last_fetched_timestamp will be initialized correctly
+       -- if this migration is run on an older version of the database. So we default to CURRENT_TIMESTAMP.
+       CURRENT_TIMESTAMP
 FROM settings;
 
 -- Drop columns from settings table


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/19176

The issue is that if we run the migrations on an old DB, the news_feed_last_fetched_timestamp row will not be populated or created yet, so it makes the migration crash.

The perfect fix would have been to use `ADD COLUMN IF NOT EXISTS`, but it is not availble in our version of SQLite.

The other solution is to just default to `CURRENT_TIMESTAMP` instead.

The only downside is if someone did use 2.34, got some news, then stopped using the app for a while, uses 2.36, they will not receive the past News. They will get the new ones though. So it is acceptable.

This was tested on a very old DB, a recent dev DB and a new account, everything works as expected.
