### PR TITLE
feat(connector): changeAccount endpoint

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/status-im/status-go/services/connector/chainutils"
 	"github.com/status-im/status-go/services/connector/commands"
 	persistence "github.com/status-im/status-go/services/connector/database"
 )
@@ -39,8 +40,9 @@ func NewAPI(s *Service) *API {
 	r.Register("eth_requestAccounts", accountsCommand)
 
 	// Active chain per dapp management
-	r.Register("eth_chainId", commands.NewChainIDCommand(s.db, s.nm))
-	r.Register("net_version", commands.NewNetVersionCommand(s.db, s.nm))
+	defaultChainIDGetter := chainutils.NewNetworkManagerAdapter(s.nm)
+	r.Register("eth_chainId", commands.NewChainIDCommand(s.db, defaultChainIDGetter))
+	r.Register("net_version", commands.NewNetVersionCommand(s.db, defaultChainIDGetter))
 	r.Register("wallet_switchEthereumChain", commands.NewSwitchEthereumChainCommand(s.db, s.nm))
 
 	// Permissions

--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -28,58 +28,27 @@ func NewAPI(s *Service) *API {
 	c := commands.NewClientSideHandler(s.db)
 
 	// Transactions and signing
-	r.Register("eth_sendTransaction", &commands.SendTransactionCommand{
-		EthClientGetter: s.ethClientGetter,
-		FeeManager:      s.feeManager,
-		Db:              s.db,
-		ClientHandler:   c,
-	})
-	r.Register("personal_sign", &commands.SignCommand{
-		Db:            s.db,
-		ClientHandler: c,
-	})
-	r.Register("eth_signTypedData_v4", &commands.SignCommand{
-		Db:            s.db,
-		ClientHandler: c,
-	})
+	r.Register("eth_sendTransaction", commands.NewSendTransactionCommand(s.db, s.ethClientGetter, s.feeManager, c))
+	r.Register("personal_sign", commands.NewSignCommand(s.db, c))
+	r.Register("eth_signTypedData_v4", commands.NewSignCommand(s.db, c))
 
 	// Accounts query and dapp permissions
 	// NOTE: Some dApps expect same behavior for both eth_accounts and eth_requestAccounts
-	accountsCommand := &commands.RequestAccountsCommand{
-		ClientHandler: c,
-		Db:            s.db,
-	}
+	accountsCommand := commands.NewRequestAccountsCommand(s.db, c)
 	r.Register("eth_accounts", accountsCommand)
 	r.Register("eth_requestAccounts", accountsCommand)
 
 	// Active chain per dapp management
-	r.Register("eth_chainId", &commands.ChainIDCommand{
-		Db:             s.db,
-		NetworkManager: s.nm,
-	})
-	r.Register("net_version", &commands.NetVersionCommand{
-		Db:             s.db,
-		NetworkManager: s.nm,
-	})
-	r.Register("wallet_switchEthereumChain", &commands.SwitchEthereumChainCommand{
-		Db:             s.db,
-		NetworkManager: s.nm,
-	})
+	r.Register("eth_chainId", commands.NewChainIDCommand(s.db, s.nm))
+	r.Register("net_version", commands.NewNetVersionCommand(s.db, s.nm))
+	r.Register("wallet_switchEthereumChain", commands.NewSwitchEthereumChainCommand(s.db, s.nm))
 
 	// Permissions
-	r.Register("wallet_requestPermissions", &commands.RequestPermissionsCommand{
-		Db: s.db,
-	})
-	r.Register("wallet_getPermissions", &commands.GetPermissionsCommand{
-		Db: s.db,
-	})
-	r.Register("wallet_revokePermissions", &commands.RevokePermissionsCommand{
-		Db: s.db,
-	})
+	r.Register("wallet_requestPermissions", commands.NewRequestPermissionsCommand(s.db))
+	r.Register("wallet_getPermissions", commands.NewGetPermissionsCommand(s.db))
+	r.Register("wallet_revokePermissions", commands.NewRevokePermissionsCommand(s.db))
 
-	changeAccountCommand := &commands.ChangeAccountCommand{
-		Db: s.db,
-	}
+	changeAccountCommand := commands.NewChangeAccountCommand(s.db)
 
 	return &API{
 		s:                    s,

--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -12,13 +12,15 @@ import (
 var (
 	ErrInvalidResponseFromForwardedRpc         = errors.New("invalid response from forwarded RPC")
 	ErrCannotOverrideClientIDForHttpConnection = errors.New("cannot override clientId for HTTP connection")
+	ErrNotAllowedForUntrustedConnection        = errors.New("cannot call from untrusted connection")
 	ErrEmptyClientIDFromTrustedConnection      = errors.New("trusted connection must provide a clientId")
 )
 
 type API struct {
-	s *Service
-	r *CommandRegistry
-	c *commands.ClientSideHandler
+	s                    *Service
+	r                    *CommandRegistry
+	c                    *commands.ClientSideHandler
+	changeAccountCommand *commands.ChangeAccountCommand
 }
 
 func NewAPI(s *Service) *API {
@@ -75,10 +77,15 @@ func NewAPI(s *Service) *API {
 		Db: s.db,
 	})
 
+	changeAccountCommand := &commands.ChangeAccountCommand{
+		Db: s.db,
+	}
+
 	return &API{
-		s: s,
-		r: r,
-		c: c,
+		s:                    s,
+		r:                    r,
+		c:                    c,
+		changeAccountCommand: changeAccountCommand,
 	}
 }
 
@@ -167,4 +174,11 @@ func (api *API) SignAccepted(args commands.SignAcceptedArgs) error {
 
 func (api *API) SignRejected(args commands.RejectedArgs) error {
 	return api.c.SignRejected(args)
+}
+
+func (api *API) ChangeAccount(ctx context.Context, args commands.ChangeAccountArgs) error {
+	if IsUntrustedConnection(ctx) {
+		return ErrNotAllowedForUntrustedConnection
+	}
+	return api.changeAccountCommand.Execute(args)
 }

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -96,3 +96,67 @@ func TestCallRPC_TrustedConnectionWithClientID(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 }
+
+func TestChangeAccount_UntrustedConnection(t *testing.T) {
+	state := setupTests(t)
+
+	// Test untrusted connection (HTTP)
+	ctx := WithConnectionType(context.Background(), ConnectionTypeHTTP)
+
+	args := commands.ChangeAccountArgs{
+		URL:      "https://example.com",
+		ClientID: "test-client",
+	}
+
+	err := state.api.ChangeAccount(ctx, args)
+	require.Error(t, err)
+	require.Equal(t, ErrNotAllowedForUntrustedConnection, err)
+}
+
+func TestCallRPC_MethodNotAllowed(t *testing.T) {
+	state := setupTests(t)
+
+	ctx := WithConnectionType(context.Background(), ConnectionTypeHTTP)
+
+	// Test a method that's not in the allowed list
+	request := `{
+		"method": "eth_subscribe",
+		"params": [],
+		"url": "https://example.com",
+		"name": "Example DApp",
+		"iconUrl": "https://example.com/icon.png"
+	}`
+
+	result, err := state.api.CallRPC(ctx, request)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "not allowed")
+}
+
+func TestCallRPC_InvalidJSON(t *testing.T) {
+	state := setupTests(t)
+
+	ctx := WithConnectionType(context.Background(), ConnectionTypeHTTP)
+
+	request := `invalid json`
+
+	result, err := state.api.CallRPC(ctx, request)
+	require.Error(t, err)
+	require.Equal(t, "", result)
+}
+
+func TestRecallDAppPermission_Deprecated(t *testing.T) {
+	state := setupTests(t)
+
+	err := state.api.RecallDAppPermission("https://example.com")
+	// Error is expected when dApp doesn't exist
+	require.Error(t, err)
+}
+
+func TestGetPermittedDAppsList(t *testing.T) {
+	state := setupTests(t)
+
+	dapps, err := state.api.GetPermittedDAppsList()
+	require.NoError(t, err)
+	require.Empty(t, dapps)
+}

--- a/services/connector/chainutils/interfaces.go
+++ b/services/connector/chainutils/interfaces.go
@@ -18,3 +18,7 @@ type FeeManager interface {
 type EthClientGetter interface {
 	EthClient(chainID uint64) (ethclient.EthClientInterface, error)
 }
+
+type DefaultChainIDGetter interface {
+	GetDefaultChainID() (uint64, error)
+}

--- a/services/connector/chainutils/utils.go
+++ b/services/connector/chainutils/utils.go
@@ -13,6 +13,21 @@ var (
 	ErrUnsupportedNetwork = errors.New("unsupported network")
 )
 
+// Implement DefaultChainIDGetter interface
+type NetworkManagerAdapter struct {
+	networkManager *network.Manager
+}
+
+func NewNetworkManagerAdapter(networkManager *network.Manager) *NetworkManagerAdapter {
+	return &NetworkManagerAdapter{
+		networkManager: networkManager,
+	}
+}
+
+func (a *NetworkManagerAdapter) GetDefaultChainID() (uint64, error) {
+	return GetDefaultChainID(a.networkManager)
+}
+
 // GetSupportedChainIDs retrieves the chain IDs from the provided NetworkManager.
 func GetSupportedChainIDs(networkManager *network.Manager) ([]uint64, error) {
 	activeNetworks, err := networkManager.GetActiveNetworks()

--- a/services/connector/commands/accounts.go
+++ b/services/connector/commands/accounts.go
@@ -10,7 +10,13 @@ import (
 )
 
 type AccountsCommand struct {
-	Db *sql.DB
+	db *sql.DB
+}
+
+func NewAccountsCommand(db *sql.DB) *AccountsCommand {
+	return &AccountsCommand{
+		db: db,
+	}
 }
 
 func FormatAccountAddressToResponse(address types.Address) []string {
@@ -23,7 +29,7 @@ func (c *AccountsCommand) Execute(ctx context.Context, request RPCRequest) (inte
 		return "", err
 	}
 
-	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	dApp, err := persistence.SelectDApp(c.db, request.URL, request.ClientID)
 	if err != nil {
 		return "", err
 	}

--- a/services/connector/commands/chain_id.go
+++ b/services/connector/commands/chain_id.go
@@ -4,21 +4,20 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/status-im/status-go/rpc/network"
 	"github.com/status-im/status-go/services/connector/chainutils"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
 )
 
 type ChainIDCommand struct {
-	networkManager *network.Manager
-	db             *sql.DB
+	defaultChainIDGetter chainutils.DefaultChainIDGetter
+	db                   *sql.DB
 }
 
-func NewChainIDCommand(db *sql.DB, networkManager *network.Manager) *ChainIDCommand {
+func NewChainIDCommand(db *sql.DB, defaultChainIDGetter chainutils.DefaultChainIDGetter) *ChainIDCommand {
 	return &ChainIDCommand{
-		db:             db,
-		networkManager: networkManager,
+		db:                   db,
+		defaultChainIDGetter: defaultChainIDGetter,
 	}
 }
 
@@ -35,7 +34,7 @@ func (c *ChainIDCommand) Execute(ctx context.Context, request RPCRequest) (inter
 
 	var chainId uint64
 	if dApp == nil {
-		chainId, err = chainutils.GetDefaultChainID(c.networkManager)
+		chainId, err = c.defaultChainIDGetter.GetDefaultChainID()
 		if err != nil {
 			return "", err
 		}

--- a/services/connector/commands/chain_id.go
+++ b/services/connector/commands/chain_id.go
@@ -11,8 +11,15 @@ import (
 )
 
 type ChainIDCommand struct {
-	NetworkManager *network.Manager
-	Db             *sql.DB
+	networkManager *network.Manager
+	db             *sql.DB
+}
+
+func NewChainIDCommand(db *sql.DB, networkManager *network.Manager) *ChainIDCommand {
+	return &ChainIDCommand{
+		db:             db,
+		networkManager: networkManager,
+	}
 }
 
 func (c *ChainIDCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
@@ -21,14 +28,14 @@ func (c *ChainIDCommand) Execute(ctx context.Context, request RPCRequest) (inter
 		return "", err
 	}
 
-	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	dApp, err := persistence.SelectDApp(c.db, request.URL, request.ClientID)
 	if err != nil {
 		return "", err
 	}
 
 	var chainId uint64
 	if dApp == nil {
-		chainId, err = chainutils.GetDefaultChainID(c.NetworkManager)
+		chainId, err = chainutils.GetDefaultChainID(c.networkManager)
 		if err != nil {
 			return "", err
 		}

--- a/services/connector/commands/change_account.go
+++ b/services/connector/commands/change_account.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"database/sql"
+
+	persistence "github.com/status-im/status-go/services/connector/database"
+	"github.com/status-im/status-go/signal"
+)
+
+type ChangeAccountCommand struct {
+	Db *sql.DB
+}
+
+func (c *ChangeAccountCommand) Execute(args ChangeAccountArgs) error {
+	err := args.Validate()
+	if err != nil {
+		return err
+	}
+
+	dApp, err := persistence.SelectDApp(c.Db, args.URL, args.ClientID)
+	if err != nil {
+		return err
+	}
+
+	if dApp == nil {
+		return nil
+	}
+
+	dApp.SharedAccount = args.Account
+
+	err = persistence.UpsertDApp(c.Db, dApp)
+	if err != nil {
+		return err
+	}
+
+	signal.SendConnectorAccountChanged(args.URL, args.ClientID, args.Account)
+	return nil
+}

--- a/services/connector/commands/change_account.go
+++ b/services/connector/commands/change_account.go
@@ -8,7 +8,13 @@ import (
 )
 
 type ChangeAccountCommand struct {
-	Db *sql.DB
+	db *sql.DB
+}
+
+func NewChangeAccountCommand(db *sql.DB) *ChangeAccountCommand {
+	return &ChangeAccountCommand{
+		db: db,
+	}
 }
 
 func (c *ChangeAccountCommand) Execute(args ChangeAccountArgs) error {
@@ -17,7 +23,7 @@ func (c *ChangeAccountCommand) Execute(args ChangeAccountArgs) error {
 		return err
 	}
 
-	dApp, err := persistence.SelectDApp(c.Db, args.URL, args.ClientID)
+	dApp, err := persistence.SelectDApp(c.db, args.URL, args.ClientID)
 	if err != nil {
 		return err
 	}
@@ -28,7 +34,7 @@ func (c *ChangeAccountCommand) Execute(args ChangeAccountArgs) error {
 
 	dApp.SharedAccount = args.Account
 
-	err = persistence.UpsertDApp(c.Db, dApp)
+	err = persistence.UpsertDApp(c.db, dApp)
 	if err != nil {
 		return err
 	}

--- a/services/connector/commands/change_account_test.go
+++ b/services/connector/commands/change_account_test.go
@@ -1,0 +1,94 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/status-im/status-go/crypto/types"
+	persistence "github.com/status-im/status-go/services/connector/database"
+)
+
+func TestFailToChangeAccountWithMissingFields(t *testing.T) {
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	cmd := &ChangeAccountCommand{
+		Db: db,
+	}
+
+	args := ChangeAccountArgs{
+		URL:      "",
+		ClientID: "testClientID",
+		Account:  types.HexToAddress("0x1234567890123456789012345678901234567890"),
+	}
+
+	err := cmd.Execute(args)
+	assert.Equal(t, ErrEmptyRPCParams, err)
+
+	args = ChangeAccountArgs{
+		URL:      "http://example.com",
+		ClientID: "",
+		Account:  types.HexToAddress("0x1234567890123456789012345678901234567890"),
+	}
+	err = cmd.Execute(args)
+	assert.Equal(t, ErrEmptyRPCParams, err)
+
+	// Test zero address
+	args = ChangeAccountArgs{
+		URL:      "http://example.com",
+		ClientID: "testClientID",
+		Account:  types.ZeroAddress(),
+	}
+	err = cmd.Execute(args)
+	assert.Equal(t, ErrEmptyRPCParams, err)
+}
+
+func TestChangeAccountForUnpermittedDApp(t *testing.T) {
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	cmd := &ChangeAccountCommand{
+		Db: db,
+	}
+
+	args := ChangeAccountArgs{
+		URL:      "http://nonexistentDAppURL",
+		ClientID: "testClientID",
+		Account:  types.HexToAddress("0x1234567890123456789012345678901234567890"),
+	}
+
+	err := cmd.Execute(args)
+	assert.NoError(t, err)
+}
+
+func TestChangeAccountForPermittedDApp(t *testing.T) {
+	db, cleanup := createWalletDB(t)
+	t.Cleanup(cleanup)
+
+	cmd := &ChangeAccountCommand{
+		Db: db,
+	}
+
+	sharedAccount := types.HexToAddress("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg")
+	clientID := "testClientID"
+
+	dApp := testDAppData
+	dApp.ClientID = clientID
+	err := PersistDAppData(db, dApp, sharedAccount, 0x123)
+	assert.NoError(t, err)
+
+	newAccount := types.HexToAddress("0x2222222222222222222222222222222222222222")
+	args := ChangeAccountArgs{
+		URL:      dApp.URL,
+		ClientID: clientID,
+		Account:  newAccount,
+	}
+
+	err = cmd.Execute(args)
+	assert.NoError(t, err)
+
+	updatedDApp, err := persistence.SelectDApp(db, dApp.URL, clientID)
+	assert.NoError(t, err)
+	assert.Equal(t, newAccount, updatedDApp.SharedAccount)
+}

--- a/services/connector/commands/change_account_test.go
+++ b/services/connector/commands/change_account_test.go
@@ -13,9 +13,7 @@ func TestFailToChangeAccountWithMissingFields(t *testing.T) {
 	db, cleanup := createWalletDB(t)
 	t.Cleanup(cleanup)
 
-	cmd := &ChangeAccountCommand{
-		Db: db,
-	}
+	cmd := NewChangeAccountCommand(db)
 
 	args := ChangeAccountArgs{
 		URL:      "",
@@ -48,9 +46,7 @@ func TestChangeAccountForUnpermittedDApp(t *testing.T) {
 	db, cleanup := createWalletDB(t)
 	t.Cleanup(cleanup)
 
-	cmd := &ChangeAccountCommand{
-		Db: db,
-	}
+	cmd := NewChangeAccountCommand(db)
 
 	args := ChangeAccountArgs{
 		URL:      "http://nonexistentDAppURL",
@@ -66,9 +62,7 @@ func TestChangeAccountForPermittedDApp(t *testing.T) {
 	db, cleanup := createWalletDB(t)
 	t.Cleanup(cleanup)
 
-	cmd := &ChangeAccountCommand{
-		Db: db,
-	}
+	cmd := NewChangeAccountCommand(db)
 
 	sharedAccount := types.HexToAddress("0x6d0aa2a774b74bb1d36f97700315adf962c69fcg")
 	clientID := "testClientID"

--- a/services/connector/commands/get_permissions.go
+++ b/services/connector/commands/get_permissions.go
@@ -8,7 +8,13 @@ import (
 )
 
 type GetPermissionsCommand struct {
-	Db *sql.DB
+	db *sql.DB
+}
+
+func NewGetPermissionsCommand(db *sql.DB) *GetPermissionsCommand {
+	return &GetPermissionsCommand{
+		db: db,
+	}
 }
 
 func (c *GetPermissionsCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
@@ -17,7 +23,7 @@ func (c *GetPermissionsCommand) Execute(ctx context.Context, request RPCRequest)
 		return "", err
 	}
 
-	permissions, err := persistence.SelectPermissions(c.Db, request.URL, request.ClientID)
+	permissions, err := persistence.SelectPermissions(c.db, request.URL, request.ClientID)
 	if err != nil {
 		return "", err
 	}

--- a/services/connector/commands/get_permissions_test.go
+++ b/services/connector/commands/get_permissions_test.go
@@ -13,9 +13,7 @@ func TestGetPermissionsWithNoPermissions(t *testing.T) {
 	state, close := setupCommand(t, Method_RequestPermissions)
 	t.Cleanup(close)
 
-	getPermissionsCmd := &GetPermissionsCommand{
-		Db: state.walletDb,
-	}
+	getPermissionsCmd := NewGetPermissionsCommand(state.walletDb)
 
 	request, err := ConstructRPCRequest("wallet_getPermissions", []interface{}{}, &testDAppData)
 	require.NoError(t, err)
@@ -48,9 +46,7 @@ func TestGetPermissionsWithExistingPermissions(t *testing.T) {
 	err = persistence.InsertPermission(state.walletDb, testDAppData.URL, testDAppData.ClientID, "eth_accounts", caveats, 123)
 	require.NoError(t, err)
 
-	getPermissionsCmd := &GetPermissionsCommand{
-		Db: state.walletDb,
-	}
+	getPermissionsCmd := NewGetPermissionsCommand(state.walletDb)
 
 	request, err := ConstructRPCRequest("wallet_getPermissions", []interface{}{}, &testDAppData)
 	require.NoError(t, err)
@@ -68,9 +64,7 @@ func TestGetPermissionsValidationError(t *testing.T) {
 	state, close := setupCommand(t, Method_RequestPermissions)
 	t.Cleanup(close)
 
-	getPermissionsCmd := &GetPermissionsCommand{
-		Db: state.walletDb,
-	}
+	getPermissionsCmd := NewGetPermissionsCommand(state.walletDb)
 
 	// Missing DApp data
 	request, err := ConstructRPCRequest("wallet_getPermissions", []interface{}{}, nil)

--- a/services/connector/commands/net_version.go
+++ b/services/connector/commands/net_version.go
@@ -11,8 +11,15 @@ import (
 )
 
 type NetVersionCommand struct {
-	NetworkManager *network.Manager
-	Db             *sql.DB
+	networkManager *network.Manager
+	db             *sql.DB
+}
+
+func NewNetVersionCommand(db *sql.DB, networkManager *network.Manager) *NetVersionCommand {
+	return &NetVersionCommand{
+		db:             db,
+		networkManager: networkManager,
+	}
 }
 
 func (c *NetVersionCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
@@ -21,14 +28,14 @@ func (c *NetVersionCommand) Execute(ctx context.Context, request RPCRequest) (in
 		return "", err
 	}
 
-	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	dApp, err := persistence.SelectDApp(c.db, request.URL, request.ClientID)
 	if err != nil {
 		return "", err
 	}
 
 	var chainId uint64
 	if dApp == nil {
-		chainId, err = chainutils.GetDefaultChainID(c.NetworkManager)
+		chainId, err = chainutils.GetDefaultChainID(c.networkManager)
 		if err != nil {
 			return "", err
 		}

--- a/services/connector/commands/net_version.go
+++ b/services/connector/commands/net_version.go
@@ -5,20 +5,19 @@ import (
 	"database/sql"
 	"strconv"
 
-	"github.com/status-im/status-go/rpc/network"
 	"github.com/status-im/status-go/services/connector/chainutils"
 	persistence "github.com/status-im/status-go/services/connector/database"
 )
 
 type NetVersionCommand struct {
-	networkManager *network.Manager
-	db             *sql.DB
+	defaultChainIDGetter chainutils.DefaultChainIDGetter
+	db                   *sql.DB
 }
 
-func NewNetVersionCommand(db *sql.DB, networkManager *network.Manager) *NetVersionCommand {
+func NewNetVersionCommand(db *sql.DB, defaultChainIDGetter chainutils.DefaultChainIDGetter) *NetVersionCommand {
 	return &NetVersionCommand{
-		db:             db,
-		networkManager: networkManager,
+		db:                   db,
+		defaultChainIDGetter: defaultChainIDGetter,
 	}
 }
 
@@ -35,7 +34,7 @@ func (c *NetVersionCommand) Execute(ctx context.Context, request RPCRequest) (in
 
 	var chainId uint64
 	if dApp == nil {
-		chainId, err = chainutils.GetDefaultChainID(c.networkManager)
+		chainId, err = c.defaultChainIDGetter.GetDefaultChainID()
 		if err != nil {
 			return "", err
 		}

--- a/services/connector/commands/request_accounts.go
+++ b/services/connector/commands/request_accounts.go
@@ -11,8 +11,15 @@ import (
 )
 
 type RequestAccountsCommand struct {
-	ClientHandler ClientSideHandlerInterface
-	Db            *sql.DB
+	clientHandler ClientSideHandlerInterface
+	db            *sql.DB
+}
+
+func NewRequestAccountsCommand(db *sql.DB, clientHandler ClientSideHandlerInterface) *RequestAccountsCommand {
+	return &RequestAccountsCommand{
+		db:            db,
+		clientHandler: clientHandler,
+	}
 }
 
 type RawAccountsResponse struct {
@@ -27,7 +34,7 @@ func (c *RequestAccountsCommand) Execute(ctx context.Context, request RPCRequest
 		return "", err
 	}
 
-	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	dApp, err := persistence.SelectDApp(c.db, request.URL, request.ClientID)
 	if err != nil {
 		return "", err
 	}
@@ -40,7 +47,7 @@ func (c *RequestAccountsCommand) Execute(ctx context.Context, request RPCRequest
 			IconURL:  request.IconURL,
 			ClientID: request.ClientID,
 		}
-		account, chainID, err := c.ClientHandler.RequestShareAccountForDApp(connectorDApp)
+		account, chainID, err := c.clientHandler.RequestShareAccountForDApp(connectorDApp)
 		if err != nil {
 			return "", err
 		}
@@ -54,7 +61,7 @@ func (c *RequestAccountsCommand) Execute(ctx context.Context, request RPCRequest
 			ChainID:       chainID,
 		}
 
-		err = persistence.UpsertDApp(c.Db, dApp)
+		err = persistence.UpsertDApp(c.db, dApp)
 		if err != nil {
 			return "", err
 		}
@@ -62,7 +69,7 @@ func (c *RequestAccountsCommand) Execute(ctx context.Context, request RPCRequest
 		// Store eth_accounts permission (EIP-2255)
 		createdAt := time.Now().Unix()
 		emptyCaveats := []persistence.Caveat{}
-		err = persistence.InsertPermission(c.Db, dApp.URL, dApp.ClientID, "eth_accounts", emptyCaveats, createdAt)
+		err = persistence.InsertPermission(c.db, dApp.URL, dApp.ClientID, "eth_accounts", emptyCaveats, createdAt)
 		if err != nil {
 			return "", err
 		}

--- a/services/connector/commands/request_permissions.go
+++ b/services/connector/commands/request_permissions.go
@@ -10,7 +10,13 @@ import (
 )
 
 type RequestPermissionsCommand struct {
-	Db *sql.DB
+	db *sql.DB
+}
+
+func NewRequestPermissionsCommand(db *sql.DB) *RequestPermissionsCommand {
+	return &RequestPermissionsCommand{
+		db: db,
+	}
 }
 
 var (
@@ -81,7 +87,7 @@ func (c *RequestPermissionsCommand) Execute(ctx context.Context, request RPCRequ
 
 	caveats := c.parseCaveats(caveatsMap)
 
-	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	dApp, err := persistence.SelectDApp(c.db, request.URL, request.ClientID)
 	if err != nil {
 		return "", err
 	}
@@ -91,7 +97,7 @@ func (c *RequestPermissionsCommand) Execute(ctx context.Context, request RPCRequ
 	}
 
 	createdAt := time.Now().Unix()
-	err = persistence.InsertPermission(c.Db, request.URL, request.ClientID, methodName, caveats, createdAt)
+	err = persistence.InsertPermission(c.db, request.URL, request.ClientID, methodName, caveats, createdAt)
 	if err != nil {
 		return "", err
 	}

--- a/services/connector/commands/request_permissions.go
+++ b/services/connector/commands/request_permissions.go
@@ -62,7 +62,7 @@ func (c *RequestPermissionsCommand) parseCaveats(caveatsMap map[string]interface
 
 func (c *RequestPermissionsCommand) getPermissionResponse(url string, methodName string, caveats []persistence.Caveat) persistence.Permission {
 	return persistence.Permission{
-		Invoker:          url,
+		Invoker:          persistence.NormalizeURL(url),
 		ParentCapability: methodName,
 		Caveats:          caveats,
 	}

--- a/services/connector/commands/revoke_permissions.go
+++ b/services/connector/commands/revoke_permissions.go
@@ -9,7 +9,13 @@ import (
 )
 
 type RevokePermissionsCommand struct {
-	Db *sql.DB
+	db *sql.DB
+}
+
+func NewRevokePermissionsCommand(db *sql.DB) *RevokePermissionsCommand {
+	return &RevokePermissionsCommand{
+		db: db,
+	}
 }
 
 func (c *RevokePermissionsCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
@@ -18,7 +24,7 @@ func (c *RevokePermissionsCommand) Execute(ctx context.Context, request RPCReque
 		return "", err
 	}
 
-	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	dApp, err := persistence.SelectDApp(c.db, request.URL, request.ClientID)
 	if err != nil {
 		return "", err
 	}
@@ -28,7 +34,7 @@ func (c *RevokePermissionsCommand) Execute(ctx context.Context, request RPCReque
 	}
 
 	// Delete the dApp entry (CASCADE will automatically delete permissions)
-	err = persistence.DeleteDApp(c.Db, dApp.URL, dApp.ClientID)
+	err = persistence.DeleteDApp(c.db, dApp.URL, dApp.ClientID)
 	if err != nil {
 		return "", err
 	}

--- a/services/connector/commands/rpc_traits.go
+++ b/services/connector/commands/rpc_traits.go
@@ -72,6 +72,12 @@ type RecallDAppPermissionsArgs struct {
 	ClientID string `json:"clientId"`
 }
 
+type ChangeAccountArgs struct {
+	URL      string        `json:"url"`
+	Account  types.Address `json:"account"`
+	ClientID string        `json:"clientId"`
+}
+
 type ClientSideHandlerInterface interface {
 	RequestShareAccountForDApp(dApp signal.ConnectorDApp) (types.Address, uint64, error)
 	RequestAccountsAccepted(args RequestAccountsAcceptedArgs) error
@@ -110,5 +116,14 @@ func (r *RPCRequest) Validate() error {
 		return ErrRequestMissingDAppData
 	}
 
+	return nil
+}
+func (c *ChangeAccountArgs) Validate() error {
+	if c.ClientID == "" || c.URL == "" {
+		return ErrEmptyRPCParams
+	}
+	if c.Account == types.ZeroAddress() {
+		return ErrEmptyRPCParams
+	}
 	return nil
 }

--- a/services/connector/commands/send_transaction.go
+++ b/services/connector/commands/send_transaction.go
@@ -27,10 +27,19 @@ var (
 )
 
 type SendTransactionCommand struct {
-	EthClientGetter chainutils.EthClientGetter
-	FeeManager      chainutils.FeeManager
-	Db              *sql.DB
-	ClientHandler   ClientSideHandlerInterface
+	ethClientGetter chainutils.EthClientGetter
+	feeManager      chainutils.FeeManager
+	db              *sql.DB
+	clientHandler   ClientSideHandlerInterface
+}
+
+func NewSendTransactionCommand(db *sql.DB, ethClientGetter chainutils.EthClientGetter, feeManager chainutils.FeeManager, clientHandler ClientSideHandlerInterface) *SendTransactionCommand {
+	return &SendTransactionCommand{
+		db:              db,
+		ethClientGetter: ethClientGetter,
+		feeManager:      feeManager,
+		clientHandler:   clientHandler,
+	}
 }
 
 func (r *RPCRequest) getSendTransactionParams() (*wallettypes.SendTxArgs, error) {
@@ -63,7 +72,7 @@ func (c *SendTransactionCommand) Execute(ctx context.Context, request RPCRequest
 		return "", err
 	}
 
-	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	dApp, err := persistence.SelectDApp(c.db, request.URL, request.ClientID)
 	if err != nil {
 		return "", err
 	}
@@ -90,7 +99,7 @@ func (c *SendTransactionCommand) Execute(ctx context.Context, request RPCRequest
 	}
 
 	if params.GasPrice == nil || (params.MaxFeePerGas == nil && params.MaxPriorityFeePerGas == nil) {
-		fetchedFees, _, _, err := c.FeeManager.SuggestedFees(ctx, dApp.ChainID, common.Address(dApp.SharedAccount))
+		fetchedFees, _, _, err := c.feeManager.SuggestedFees(ctx, dApp.ChainID, common.Address(dApp.SharedAccount))
 		if err != nil {
 			return "", err
 		}
@@ -108,7 +117,7 @@ func (c *SendTransactionCommand) Execute(ctx context.Context, request RPCRequest
 	}
 
 	if params.Nonce == nil {
-		ethClient, err := c.EthClientGetter.EthClient(dApp.ChainID)
+		ethClient, err := c.ethClientGetter.EthClient(dApp.ChainID)
 		if err != nil {
 			return "", err
 		}
@@ -121,7 +130,7 @@ func (c *SendTransactionCommand) Execute(ctx context.Context, request RPCRequest
 		params.Nonce = (*hexutil.Uint64)(&nonce)
 	}
 
-	hash, err := c.ClientHandler.RequestSendTransaction(signal.ConnectorDApp{
+	hash, err := c.clientHandler.RequestSendTransaction(signal.ConnectorDApp{
 		URL:      request.URL,
 		Name:     request.Name,
 		IconURL:  request.IconURL,

--- a/services/connector/commands/sign.go
+++ b/services/connector/commands/sign.go
@@ -16,8 +16,15 @@ var (
 )
 
 type SignCommand struct {
-	Db            *sql.DB
-	ClientHandler ClientSideHandlerInterface
+	db            *sql.DB
+	clientHandler ClientSideHandlerInterface
+}
+
+func NewSignCommand(db *sql.DB, clientHandler ClientSideHandlerInterface) *SignCommand {
+	return &SignCommand{
+		db:            db,
+		clientHandler: clientHandler,
+	}
 }
 
 type SignParams struct {
@@ -77,7 +84,7 @@ func (c *SignCommand) Execute(ctx context.Context, request RPCRequest) (interfac
 		return "", err
 	}
 
-	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	dApp, err := persistence.SelectDApp(c.db, request.URL, request.ClientID)
 	if err != nil {
 		return "", err
 	}
@@ -86,7 +93,7 @@ func (c *SignCommand) Execute(ctx context.Context, request RPCRequest) (interfac
 		return "", ErrDAppIsNotPermittedByUser
 	}
 
-	return c.ClientHandler.RequestSign(signal.ConnectorDApp{
+	return c.clientHandler.RequestSign(signal.ConnectorDApp{
 		URL:      request.URL,
 		Name:     request.Name,
 		IconURL:  request.IconURL,

--- a/services/connector/commands/switch_ethereum_chain.go
+++ b/services/connector/commands/switch_ethereum_chain.go
@@ -97,8 +97,9 @@ func (c *SwitchEthereumChainCommand) Execute(ctx context.Context, request RPCReq
 	}
 
 	signal.SendConnectorDAppChainIdSwitched(signal.ConnectorDAppChainIdSwitchedSignal{
-		URL:     request.URL,
-		ChainId: chainId,
+		URL:      request.URL,
+		ChainId:  chainId,
+		ClientID: request.ClientID,
 	})
 
 	return chainId, nil

--- a/services/connector/commands/switch_ethereum_chain.go
+++ b/services/connector/commands/switch_ethereum_chain.go
@@ -22,8 +22,15 @@ var (
 )
 
 type SwitchEthereumChainCommand struct {
-	NetworkManager *network.Manager
-	Db             *sql.DB
+	networkManager *network.Manager
+	db             *sql.DB
+}
+
+func NewSwitchEthereumChainCommand(db *sql.DB, networkManager *network.Manager) *SwitchEthereumChainCommand {
+	return &SwitchEthereumChainCommand{
+		db:             db,
+		networkManager: networkManager,
+	}
 }
 
 func hexStringToUint64(s string) (uint64, error) {
@@ -52,7 +59,7 @@ func (r *RPCRequest) getChainID() (uint64, error) {
 }
 
 func (c *SwitchEthereumChainCommand) getSupportedChainIDs() ([]uint64, error) {
-	return chainutils.GetSupportedChainIDs(c.NetworkManager)
+	return chainutils.GetSupportedChainIDs(c.networkManager)
 }
 
 func (c *SwitchEthereumChainCommand) Execute(ctx context.Context, request RPCRequest) (interface{}, error) {
@@ -75,7 +82,7 @@ func (c *SwitchEthereumChainCommand) Execute(ctx context.Context, request RPCReq
 		return "", ErrUnsupportedNetwork
 	}
 
-	dApp, err := persistence.SelectDApp(c.Db, request.URL, request.ClientID)
+	dApp, err := persistence.SelectDApp(c.db, request.URL, request.ClientID)
 	if err != nil {
 		return "", err
 	}
@@ -86,7 +93,7 @@ func (c *SwitchEthereumChainCommand) Execute(ctx context.Context, request RPCReq
 
 	dApp.ChainID = requestedChainID
 
-	err = persistence.UpsertDApp(c.Db, dApp)
+	err = persistence.UpsertDApp(c.db, dApp)
 	if err != nil {
 		return "", err
 	}

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/status-im/status-go/pkg/security"
 	"github.com/status-im/status-go/rpc/network"
 	network_testutil "github.com/status-im/status-go/rpc/network/testutil"
+	"github.com/status-im/status-go/services/connector/chainutils"
 	mock_chainutils "github.com/status-im/status-go/services/connector/chainutils/mock"
 	persistence "github.com/status-im/status-go/services/connector/database"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -96,9 +97,11 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 	case Method_EthRequestAccounts:
 		state.cmd = NewRequestAccountsCommand(state.walletDb, state.handler)
 	case Method_EthChainId:
-		state.cmd = NewChainIDCommand(state.walletDb, networkManager)
+		defaultChainIDGetter := chainutils.NewNetworkManagerAdapter(networkManager)
+		state.cmd = NewChainIDCommand(state.walletDb, defaultChainIDGetter)
 	case "net_version":
-		state.cmd = NewNetVersionCommand(state.walletDb, networkManager)
+		defaultChainIDGetter := chainutils.NewNetworkManagerAdapter(networkManager)
+		state.cmd = NewNetVersionCommand(state.walletDb, defaultChainIDGetter)
 	case Method_PersonalSign:
 		state.cmd = NewSignCommand(state.walletDb, state.handler)
 	case Method_SignTypedDataV4:

--- a/services/connector/commands/test_helpers.go
+++ b/services/connector/commands/test_helpers.go
@@ -92,54 +92,25 @@ func setupCommand(t *testing.T, method string) (state testState, close func()) {
 
 	switch method {
 	case Method_EthAccounts:
-		state.cmd = &AccountsCommand{
-			Db: state.walletDb,
-		}
+		state.cmd = NewAccountsCommand(state.walletDb)
 	case Method_EthRequestAccounts:
-		state.cmd = &RequestAccountsCommand{
-			ClientHandler: state.handler,
-			Db:            state.walletDb,
-		}
+		state.cmd = NewRequestAccountsCommand(state.walletDb, state.handler)
 	case Method_EthChainId:
-		state.cmd = &ChainIDCommand{
-			Db:             state.walletDb,
-			NetworkManager: networkManager,
-		}
+		state.cmd = NewChainIDCommand(state.walletDb, networkManager)
 	case "net_version":
-		state.cmd = &NetVersionCommand{
-			Db:             state.walletDb,
-			NetworkManager: networkManager,
-		}
+		state.cmd = NewNetVersionCommand(state.walletDb, networkManager)
 	case Method_PersonalSign:
-		state.cmd = &SignCommand{
-			Db:            state.walletDb,
-			ClientHandler: state.handler,
-		}
+		state.cmd = NewSignCommand(state.walletDb, state.handler)
 	case Method_SignTypedDataV4:
-		state.cmd = &SignCommand{
-			Db:            state.walletDb,
-			ClientHandler: state.handler,
-		}
+		state.cmd = NewSignCommand(state.walletDb, state.handler)
 	case Method_EthSendTransaction:
-		state.cmd = &SendTransactionCommand{
-			Db:              state.walletDb,
-			ClientHandler:   state.handler,
-			EthClientGetter: state.ethClientGetter,
-			FeeManager:      state.feeManager,
-		}
+		state.cmd = NewSendTransactionCommand(state.walletDb, state.ethClientGetter, state.feeManager, state.handler)
 	case Method_RequestPermissions:
-		state.cmd = &RequestPermissionsCommand{
-			Db: state.walletDb,
-		}
+		state.cmd = NewRequestPermissionsCommand(state.walletDb)
 	case Method_RevokePermissions:
-		state.cmd = &RevokePermissionsCommand{
-			Db: state.walletDb,
-		}
+		state.cmd = NewRevokePermissionsCommand(state.walletDb)
 	case Method_SwitchEthereumChain:
-		state.cmd = &SwitchEthereumChainCommand{
-			Db:             state.walletDb,
-			NetworkManager: networkManager,
-		}
+		state.cmd = NewSwitchEthereumChainCommand(state.walletDb, networkManager)
 	}
 
 	return state, func() {

--- a/services/connector/database/persistence.go
+++ b/services/connector/database/persistence.go
@@ -8,7 +8,7 @@ import (
 	"github.com/status-im/status-go/crypto/types"
 )
 
-func normalizeURL(url string) string {
+func NormalizeURL(url string) string {
 	return strings.TrimRight(url, "/")
 }
 
@@ -47,14 +47,14 @@ type Permission struct {
 }
 
 func UpsertDApp(db *sql.DB, dApp *DApp) error {
-	normalizedURL := normalizeURL(dApp.URL)
+	normalizedURL := NormalizeURL(dApp.URL)
 	_, err := db.Exec(upsertDAppQuery, normalizedURL, dApp.Name, dApp.IconURL, dApp.ClientID, dApp.SharedAccount, dApp.ChainID)
 	return err
 }
 
 func SelectDApp(db *sql.DB, url string, clientID string) (*DApp, error) {
 	// clientID can be empty for backward compatibility with browser extension
-	normalizedURL := normalizeURL(url)
+	normalizedURL := NormalizeURL(url)
 	dApp := &DApp{
 		URL:      normalizedURL,
 		ClientID: clientID,
@@ -86,13 +86,13 @@ func SelectAllDApps(db *sql.DB) ([]DApp, error) {
 }
 
 func DeleteDApp(db *sql.DB, url string, clientID string) error {
-	normalizedURL := normalizeURL(url)
+	normalizedURL := NormalizeURL(url)
 	_, err := db.Exec(deleteDAppQuery, normalizedURL, clientID)
 	return err
 }
 
 func InsertPermission(db *sql.DB, url string, clientID string, parentCapability string, caveats []Caveat, createdAt int64) error {
-	normalizedURL := normalizeURL(url)
+	normalizedURL := NormalizeURL(url)
 
 	var count int
 	err := db.QueryRow(selectPermissionExistsQuery, normalizedURL, clientID, parentCapability).Scan(&count)
@@ -114,7 +114,7 @@ func InsertPermission(db *sql.DB, url string, clientID string, parentCapability 
 }
 
 func SelectPermissions(db *sql.DB, url string, clientID string) ([]Permission, error) {
-	normalizedURL := normalizeURL(url)
+	normalizedURL := NormalizeURL(url)
 
 	rows, err := db.Query(selectPermissionsQuery, normalizedURL, clientID)
 	if err != nil {
@@ -149,7 +149,7 @@ func SelectPermissions(db *sql.DB, url string, clientID string) ([]Permission, e
 }
 
 func DeletePermissions(db *sql.DB, url string, clientID string) error {
-	normalizedURL := normalizeURL(url)
+	normalizedURL := NormalizeURL(url)
 	_, err := db.Exec(deletePermissionsQuery, normalizedURL, clientID)
 	return err
 }

--- a/signal/events_connector.go
+++ b/signal/events_connector.go
@@ -50,8 +50,9 @@ type ConnectorSignSignal struct {
 }
 
 type ConnectorDAppChainIdSwitchedSignal struct {
-	URL     string `json:"url"`
-	ChainId string `json:"chainId"`
+	URL      string `json:"url"`
+	ChainId  string `json:"chainId"`
+	ClientID string `json:"clientId"`
 }
 
 type ConnectorAccountChangedSignal struct {

--- a/signal/events_connector.go
+++ b/signal/events_connector.go
@@ -11,6 +11,7 @@ const (
 	EventConnectorDAppPermissionGranted = "connector.dAppPermissionGranted"
 	EventConnectorDAppPermissionRevoked = "connector.dAppPermissionRevoked"
 	EventConnectorDAppChainIdSwitched   = "connector.dAppChainIdSwitched"
+	EventConnectorAccountChanged        = "connector.dAppAccountChanged"
 )
 
 type ConnectorDApp struct {
@@ -53,6 +54,12 @@ type ConnectorDAppChainIdSwitchedSignal struct {
 	ChainId string `json:"chainId"`
 }
 
+type ConnectorAccountChangedSignal struct {
+	URL           string        `json:"url"`
+	ClientID      string        `json:"clientId"`
+	SharedAccount types.Address `json:"sharedAccount"`
+}
+
 func SendConnectorSendRequestAccounts(dApp ConnectorDApp, requestID string) {
 	send(EventConnectorSendRequestAccounts, ConnectorSendRequestAccountsSignal{
 		ConnectorDApp: dApp,
@@ -93,4 +100,12 @@ func SendConnectorDAppPermissionRevoked(dApp ConnectorDApp) {
 
 func SendConnectorDAppChainIdSwitched(payload ConnectorDAppChainIdSwitchedSignal) {
 	send(EventConnectorDAppChainIdSwitched, payload)
+}
+
+func SendConnectorAccountChanged(url string, clientID string, account types.Address) {
+	send(EventConnectorAccountChanged, ConnectorAccountChangedSignal{
+		URL:           url,
+		ClientID:      clientID,
+		SharedAccount: account,
+	})
 }


### PR DESCRIPTION
Adds a command to change the shared account for a permitted dApp connection

**Changes:**
- New `ChangeAccountCommand` to update a dApp's shared account
- `ChangeAccount` API endpoint restricted to trusted connections
- Signal event `EventConnectorAccountChanged` to notify clients

(this method is required for the Account Selector Popup in the dapp browser)

Fixes #7048
