### PR TITLE
fix: Crashing with slice bounds out of range

### DIFF
--- a/services/wallet/bigint/var_hex_big_int.go
+++ b/services/wallet/bigint/var_hex_big_int.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"strings"
 )
 
 // Unmarshals hex string as a variable-length hex string with 0x prefix and possible leading zeros
@@ -17,8 +18,26 @@ func (b *VarHexBigInt) UnmarshalJSON(input []byte) error {
 		return err
 	}
 
+	// Check if string is long enough and has 0x prefix
+	if len(hexStr) < 2 {
+		return fmt.Errorf("hex string too short: %s", hexStr)
+	}
+
+	// Check for 0x or 0X prefix and remove it
+	if !strings.HasPrefix(hexStr, "0x") && !strings.HasPrefix(hexStr, "0X") {
+		return fmt.Errorf("hex string must start with 0x prefix: %s", hexStr)
+	}
+
+	hexValue := hexStr[2:]
+
+	// Handle empty hex value (just "0x")
+	if len(hexValue) == 0 {
+		b.Int = big.NewInt(0)
+		return nil
+	}
+
 	var ok bool
-	b.Int, ok = new(big.Int).SetString(hexStr[2:], 16)
+	b.Int, ok = new(big.Int).SetString(hexValue, 16)
 	if !ok {
 		return fmt.Errorf("not a valid big integer: %s", hexStr)
 	}

--- a/services/wallet/bigint/var_hex_big_int_test.go
+++ b/services/wallet/bigint/var_hex_big_int_test.go
@@ -1,0 +1,193 @@
+package bigint
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVarHexBigInt_UnmarshalJSON_ValidCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected *big.Int
+	}{
+		{
+			name:     "simple hex value",
+			input:    "0x123",
+			expected: big.NewInt(291),
+		},
+		{
+			name:     "hex with leading zeros",
+			input:    "0x0001",
+			expected: big.NewInt(1),
+		},
+		{
+			name:     "zero value",
+			input:    "0x0",
+			expected: big.NewInt(0),
+		},
+		{
+			name:     "empty hex after prefix",
+			input:    "0x",
+			expected: big.NewInt(0),
+		},
+		{
+			name:  "large hex value",
+			input: "0x09abc5177d51c36ef4c6a36197d023b60d8fec0100000000000001000000000a",
+			expected: func() *big.Int {
+				i := new(big.Int)
+				i.SetString("09abc5177d51c36ef4c6a36197d023b60d8fec0100000000000001000000000a", 16)
+				return i
+			}(),
+		},
+		{
+			name:     "uppercase X in prefix",
+			input:    "0X123",
+			expected: big.NewInt(291),
+		},
+		{
+			name:     "max uint64",
+			input:    "0xffffffffffffffff",
+			expected: func() *big.Int { i := new(big.Int); i.SetUint64(^uint64(0)); return i }(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputBytes, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+
+			result := new(VarHexBigInt)
+			err = result.UnmarshalJSON(inputBytes)
+
+			require.NoError(t, err)
+			require.NotNil(t, result.Int)
+			require.Equal(t, tt.expected, result.Int, "expected %s, got %s", tt.expected.String(), result.Int.String())
+		})
+	}
+}
+
+func TestVarHexBigInt_UnmarshalJSON_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError string
+	}{
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: "hex string too short",
+		},
+		{
+			name:        "single character",
+			input:       "0",
+			expectError: "hex string too short",
+		},
+		{
+			name:        "missing 0x prefix",
+			input:       "123",
+			expectError: "hex string must start with 0x prefix",
+		},
+		{
+			name:        "invalid hex characters",
+			input:       "0xGHI",
+			expectError: "not a valid big integer",
+		},
+		{
+			name:        "wrong prefix",
+			input:       "1x123",
+			expectError: "hex string must start with 0x prefix",
+		},
+		{
+			name:        "prefix with wrong second character",
+			input:       "0y123",
+			expectError: "hex string must start with 0x prefix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputBytes, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+
+			result := new(VarHexBigInt)
+			err = result.UnmarshalJSON(inputBytes)
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+func TestVarHexBigInt_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *big.Int
+		expected string
+	}{
+		{
+			name:     "zero",
+			input:    big.NewInt(0),
+			expected: "0x0",
+		},
+		{
+			name:     "simple value",
+			input:    big.NewInt(291),
+			expected: "0x123",
+		},
+		{
+			name: "large value",
+			input: func() *big.Int {
+				i := new(big.Int)
+				i.SetString("09abc5177d51c36ef4c6a36197d023b60d8fec0100000000000001000000000a", 16)
+				return i
+			}(),
+			expected: "0x9abc5177d51c36ef4c6a36197d023b60d8fec0100000000000001000000000a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vhbi := &VarHexBigInt{Int: tt.input}
+			result, err := vhbi.MarshalJSON()
+
+			require.NoError(t, err)
+			require.Equal(t, "\""+tt.expected+"\"", string(result))
+		})
+	}
+}
+
+func TestVarHexBigInt_RoundTrip(t *testing.T) {
+	tests := []string{
+		"0x0",
+		"0x123",
+		"0xffffffffffffffff",
+		"0x09abc5177d51c36ef4c6a36197d023b60d8fec0100000000000001000000000a",
+	}
+
+	for _, hexStr := range tests {
+		t.Run(hexStr, func(t *testing.T) {
+			// Unmarshal
+			inputBytes, err := json.Marshal(hexStr)
+			require.NoError(t, err)
+
+			vhbi := new(VarHexBigInt)
+			err = vhbi.UnmarshalJSON(inputBytes)
+			require.NoError(t, err)
+
+			// Marshal back
+			result, err := vhbi.MarshalJSON()
+			require.NoError(t, err)
+
+			// Unmarshal again to compare values
+			vhbi2 := new(VarHexBigInt)
+			err = vhbi2.UnmarshalJSON(result)
+			require.NoError(t, err)
+
+			require.Equal(t, vhbi.Int, vhbi2.Int)
+		})
+	}
+}


### PR DESCRIPTION
### Description

The `func (b *VarHexBigInt) UnmarshalJSON(input []byte) error {` doesn't check for empty hex value


Fixing a crash on activity:

```
panic: runtime error: slice bounds out of range [2:1] [recovered]
	panic: runtime error: slice bounds out of range [2:1]

goroutine 244 [running]:
github.com/status-im/status-go/common.LogOnPanic()
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/common/utils.go:119 +0x194
panic({0x10e9aa8e0?, 0x2400005bd28?})
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/runtime/panic.go:787 +0x124
github.com/status-im/status-go/services/wallet/bigint.(*VarHexBigInt).UnmarshalJSON(0x240013820a0, {0x24002361e90, 0x3, 0xf0})
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/services/wallet/bigint/var_hex_big_int.go:21 +0x138
encoding/json.(*decodeState).literalStore(0x2400145a480, {0x24002361e90, 0x3, 0xf0}, {0x10eb240e0?, 0x2400090ac88?, 0x24001dacc98?}, 0x0)
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/encoding/json/decode.go:861 +0x1b50
encoding/json.(*decodeState).value(0x2400145a480, {0x10eb240e0?, 0x2400090ac88?, 0x7?})
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/encoding/json/decode.go:389 +0x114
encoding/json.(*decodeState).object(0x2400145a480, {0x10ea97240?, 0x2400090ac30?, 0x10bdc48a0?})
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/encoding/json/decode.go:762 +0xae4
encoding/json.(*decodeState).value(0x2400145a480, {0x10ea97240?, 0x2400090ac30?, 0x2?})
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/encoding/json/decode.go:375 +0x40
encoding/json.(*decodeState).array(0x2400145a480, {0x10e5912a0?, 0x24003b10de0?, 0x10e5c2140?})
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/encoding/json/decode.go:556 +0x484
encoding/json.(*decodeState).value(0x2400145a480, {0x10e5912a0?, 0x24003b10de0?, 0x10ebb6c00?})
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/encoding/json/decode.go:365 +0x70
encoding/json.(*decodeState).object(0x2400145a480, {0x10e54f4a0?, 0x24003b10de0?, 0x10bdcf90c?})
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/encoding/json/decode.go:762 +0xae4
encoding/json.(*decodeState).value(0x2400145a480, {0x10e54f4a0?, 0x24003b10de0?, 0x10bdceee0?})
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/encoding/json/decode.go:375 +0x40
encoding/json.(*decodeState).unmarshal(0x2400145a480, {0x10e54f4a0?, 0x24003b10de0?})
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/encoding/json/decode.go:178 +0x100
encoding/json.Unmarshal({0x24002361b00, 0x456, 0x480}, {0x10e54f4a0, 0x24003b10de0})
	/Users/alexjbanca/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.darwin-arm64/src/encoding/json/decode.go:108 +0xe4
github.com/ethereum/go-ethereum/rpc.(*Client).CallContext(0x24002152bd0, {0x10eb8a400, 0x24000cd26e0}, {0x10e54f4a0, 0x24003b10de0}, {0x10da3b4ce?, 0x19?}, {0x240014d6b90?, 0x1?, 0x1?})
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/vendor/github.com/ethereum/go-ethereum/rpc/client.go:375 +0x20c
github.com/status-im/status-go/rpc/chain/ethclient.(*EthClient).CallContext(...)
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/rpc/chain/ethclient/eth_client.go:93
github.com/status-im/status-go/services/wallet/thirdparty/activity/alchemy.(*Client).fetchActivity(0x2400121c498, {0x10eb8a400, 0x24000cd26e0}, 0x40?, {0x24001dd4730, 0x24001dd4648, 0x0, 0x240008b99b0, {0x0, 0x0, ...}, ...})
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/services/wallet/thirdparty/activity/alchemy/client.go:156 +0xe4
github.com/status-im/status-go/services/wallet/thirdparty/activity/alchemy.(*Client).FetchTransfers(0x2400121c498, {0x10eb8a400, 0x24000cd26e0}, 0x2105, {0x24001dd4730, 0x24001dd4648, {0xb5, 0x10, 0x2d, 0x8a, ...}, ...}, ...)
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/services/wallet/thirdparty/activity/alchemy/client.go:120 +0x59c
github.com/status-im/status-go/services/wallet/activityfetcher/alchemy.(*Manager).FetchActivity(0x240012badc0, {0x10eb8a400?, 0x24000cd26e0?}, 0x2105, {0x24001dd4730, 0x24001dd4648, {0xb5, 0x10, 0x2d, 0x8a, ...}, ...}, ...)
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/services/wallet/activityfetcher/alchemy/manager.go:48 +0x7c
github.com/status-im/status-go/services/wallet/activityfetcher.(*Manager).FetchActivity(0x2400121c4b0, {0x10eb8a400, 0x24000cd26e0}, 0x2105, {0xb5, 0x10, 0x2d, 0x8a, 0xbe, 0x9, ...}, ...)
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/services/wallet/activityfetcher/manager.go:92 +0x5fc
github.com/status-im/status-go/services/wallet/activityfetcher.(*Service).fetchActivity(0x24000418160, {0x10eb8a400, 0x24000cd26e0}, 0x2105, {0xb5, 0x10, 0x2d, 0x8a, 0xbe, 0x9, ...})
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/services/wallet/activityfetcher/service.go:457 +0x25c
github.com/status-im/status-go/services/wallet/activityfetcher.(*Service).startFetchActivity.func1()
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/services/wallet/activityfetcher/service.go:439 +0xac
created by github.com/status-im/status-go/services/wallet/activityfetcher.(*Service).startFetchActivity in goroutine 305
	/Users/alexjbanca/Repos/status-desktop/vendor/status-go/services/wallet/activityfetcher/service.go:436 +0xc4
SIGABRT: Abnormal termination.
make: *** [run-macos] Abort trap: 6
```