### PR TITLE
fix: set non-nil activity center for newsfeed service

### DIFF
--- a/api/geth_backend.go
+++ b/api/geth_backend.go
@@ -2359,6 +2359,7 @@ func (b *GethStatusBackend) initProtocol() error {
 	b.statusNode.EnsService().Init(messenger.SyncEnsNamesWithDispatchMessage)
 	b.statusNode.CommunityTokensService().Init(messenger)
 	b.statusNode.SharedUrlsService().SetDataProvider(node.NewSharedUrlsMessengerAdapter(messenger))
+	b.statusNode.NewsFeedService().SetActivityCenter(node.NewNewsFeedActivityCenterAdapter(messenger))
 
 	return nil
 }

--- a/cmd/generate-db/main.go
+++ b/cmd/generate-db/main.go
@@ -16,15 +16,18 @@ import (
 	"github.com/status-im/status-go/walletdatabase"
 )
 
-const (
-	password            = ""
-	kdfIterationsNumber = 0
+var (
+	outDir              = flag.String("out-dir", "build", "Output directory for generated DB files")
+	migrateOnly         = flag.Bool("migrate-only", false, "Only migrate the DBs, don't generate or recreate them")
+	password            = flag.String("password", "", "Password to encrypt the DBs")
+	kdfIterationsNumber = flag.Int("kdf-iterations", 0, "Number of KDF iterations")
 )
 
-func main() {
-	outDir := flag.String("out-dir", "build", "Output directory for generated DB files")
+func init() {
 	flag.Parse()
+}
 
+func main() {
 	if err := os.MkdirAll(*outDir, 0o755); err != nil {
 		log.Fatalf("failed to create output directory %s: %v", *outDir, err)
 	}
@@ -48,6 +51,9 @@ func main() {
 }
 
 func recreate(path string) error {
+	if *migrateOnly {
+		return nil
+	}
 	_ = os.Remove(path)
 	_ = os.Remove(path + "-wal")
 	_ = os.Remove(path + "-shm")
@@ -62,7 +68,7 @@ func generateAppDB(outDir string) error {
 
 	// Use the same initializer the app uses
 	var init appdatabase.DbInitializer
-	db, err := init.Initialize(path, password, kdfIterationsNumber)
+	db, err := init.Initialize(path, *password, *kdfIterationsNumber)
 	if err != nil {
 		return err
 	}
@@ -88,7 +94,7 @@ func generateWalletDB(outDir string) error {
 
 	// Use the same initializer the app uses
 	var init walletdatabase.DbInitializer
-	_, err := init.Initialize(path, password, kdfIterationsNumber)
+	_, err := init.Initialize(path, *password, *kdfIterationsNumber)
 	if err != nil {
 		return err
 	}

--- a/node/adapters.go
+++ b/node/adapters.go
@@ -39,3 +39,20 @@ func (p *SharedUrlsMessengerAdapter) GetContactByID(pubKey string) (*contacts.Co
 	}
 	return p.messenger.GetContactByID(pubKey), nil
 }
+
+type NewsFeedActivityCenterAdapter struct {
+	messenger *protocol.Messenger
+}
+
+func NewNewsFeedActivityCenterAdapter(messenger *protocol.Messenger) *NewsFeedActivityCenterAdapter {
+	return &NewsFeedActivityCenterAdapter{
+		messenger: messenger,
+	}
+}
+
+func (p *NewsFeedActivityCenterAdapter) AddNotification(response *protocol.MessengerResponse, notification *protocol.ActivityCenterNotification) error {
+	if p.messenger == nil {
+		return ErrMessengerNotReady
+	}
+	return p.messenger.AddActivityCenterNotification(response, notification, nil)
+}

--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -10,7 +10,6 @@ import (
 	"github.com/status-im/status-go/internal/timesource"
 	"github.com/status-im/status-go/pkg/featureflags"
 	"github.com/status-im/status-go/pkg/pubsub"
-	"github.com/status-im/status-go/protocol"
 	"github.com/status-im/status-go/server"
 	"github.com/status-im/status-go/services/eth"
 	"github.com/status-im/status-go/services/newsfeed"
@@ -421,14 +420,6 @@ func (b *StatusNode) timeSourceNow() func() time.Time {
 	return b.TimeSource().Now
 }
 
-type NewsFeedActivityCenter struct {
-	m *protocol.Messenger
-}
-
-func (ac *NewsFeedActivityCenter) AddNotification(response *protocol.MessengerResponse, notification *protocol.ActivityCenterNotification) error {
-	return ac.m.AddActivityCenterNotification(response, notification, nil)
-}
-
 func (b *StatusNode) NewsFeedService() *newsfeed.Service {
 	if !featureflags.EnableNewsFeed {
 		return nil
@@ -436,16 +427,17 @@ func (b *StatusNode) NewsFeedService() *newsfeed.Service {
 
 	if b.newsfeedSrvc == nil {
 		persistence := newsfeed.NewSQLitePersistence(b.appDB)
-		ac := &NewsFeedActivityCenter{}
-		if wakuext := b.WakuV2ExtService(); wakuext != nil {
-			ac.m = wakuext.Messenger()
-		}
 
 		b.newsfeedSrvc = newsfeed.NewService(
 			b.logger.Named("newsfeed"),
 			persistence,
-			ac,
+			nil,
 		)
+
+		if wakuext := b.WakuV2ExtService(); wakuext != nil {
+			ac := NewNewsFeedActivityCenterAdapter(wakuext.Messenger())
+			b.newsfeedSrvc.SetActivityCenter(ac)
+		}
 	}
 	return b.newsfeedSrvc
 }

--- a/services/newsfeed/service.go
+++ b/services/newsfeed/service.go
@@ -3,6 +3,7 @@ package newsfeed
 import (
 	"context"
 	"errors"
+	"reflect"
 	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
@@ -22,6 +23,11 @@ var (
 	errNoActivityCenter  = errors.New("no activity center set up")
 )
 
+func isNil(data interface{}) bool {
+	v := reflect.ValueOf(data).Kind()
+	return data == nil || v == reflect.Ptr && reflect.ValueOf(data).IsNil()
+}
+
 type Service struct {
 	logger          *zap.Logger
 	storage         Persistence
@@ -30,11 +36,12 @@ type Service struct {
 }
 
 func NewService(logger *zap.Logger, storage Persistence, ac ActivityCenter) *Service {
-	return &Service{
+	service := &Service{
 		logger:  logger,
 		storage: storage,
-		ac:      ac,
 	}
+	service.SetActivityCenter(ac)
+	return service
 }
 
 func (s *Service) Start() error {
@@ -84,6 +91,14 @@ func (s *Service) APIs() []rpc.API {
 				service: s,
 			},
 		},
+	}
+}
+
+func (s *Service) SetActivityCenter(ac ActivityCenter) {
+	if isNil(ac) {
+		s.ac = nil
+	} else {
+		s.ac = ac
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/19176

1. Same as in https://github.com/status-im/status-go/pull/7031, we should set `messenger` pointer only when it's ready
Also, we should have use adapter, otherwise `nil` check doesn't work properly.

2. Also added flags for `cmd/generate-db` to migrate an existing DB. Was nice to have in this investigation.