### PR TITLE
test: simplify login/createAccount method signatures

### DIFF
--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -28,7 +28,7 @@ from clients.services.wakuext import (
 from clients.services.wallet import WalletService
 from clients.signals import SignalClient, SignalType
 from clients.statusgo_container import StatusBackendContainer
-from resources.constants import USE_IPV6, user_1, ANVIL_NETWORK_ID, Account
+from resources.constants import USE_IPV6, user_1, ANVIL_NETWORK_ID
 from utils import fake
 from utils import keys
 from utils.config import Config
@@ -254,8 +254,8 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
     def _set_display_name(self, **kwargs):
         self.display_name = kwargs.get("display_name", fake.profile_name())
 
-    def _create_account_request(self, user, **kwargs):
-        self.password = kwargs.get("password", user.password)
+    def _create_account_request(self, password: str, **kwargs):
+        self.password = password
         data = {
             "rootDataDir": self.data_dir,
             "kdfIterations": 256000,
@@ -291,26 +291,26 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         data = self._set_multicall_overrides(data, kwargs)
         return data
 
-    def create_account_and_login(self, user=user_1, **kwargs):
+    def create_account_and_login(self, password: str, **kwargs):
         self._set_display_name(**kwargs)
         method = "CreateAccountAndLogin"
-        data = self._create_account_request(user, **kwargs)
+        data = self._create_account_request(password=password, **kwargs)
         return self.api_request_json(method, data)
 
     def restore_account_and_login(self, user=user_1, **kwargs):
         self._set_display_name(**kwargs)
         method = "RestoreAccountAndLogin"
-        data = self._create_account_request(user, **kwargs)
+        data = self._create_account_request(password=user.password, **kwargs)
         data["mnemonic"] = user.passphrase
         return self.api_request_json(method, data)
 
-    def login(self, keyUid, user=user_1):
-        self.password = user.password
+    def login(self, key_uid, password: str, kdf_iterations=256000):
+        self.password = password
         method = "LoginAccount"
         data = {
-            "password": user.password,
-            "keyUid": keyUid,
-            "kdfIterations": 256000,
+            "password": self.password,
+            "keyUid": key_uid,
+            "kdfIterations": kdf_iterations,
         }
         data = self._set_proxy_credentials(data)
         data = self._set_wallet_secrets(data)
@@ -390,16 +390,10 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
     def input_connection_string_for_bootstrapping(self, connection_string):
         method = "InputConnectionStringForBootstrappingV2"
         # Empty user
-        user = Account(
-            address="",
-            private_key="",
-            password="",
-            passphrase="",
-        )
         data = {
             "connectionString": connection_string,
             "receiverClientConfig": {
-                "receiverConfig": {"createAccount": self._create_account_request(user)},
+                "receiverConfig": {"createAccount": self._create_account_request(password="")},
                 "clientConfig": {},
             },
         }
@@ -407,15 +401,9 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
 
     def get_connection_string_for_being_bootstrapped(self):
         method = "GetConnectionStringForBeingBootstrapped"
-        user = Account(
-            address="",
-            private_key="",
-            password="",
-            passphrase="",
-        )
         data = {
             "receiverConfig": {
-                "createAccount": self._create_account_request(user),
+                "createAccount": self._create_account_request(password=""),
                 "deviceType": "macos",
             },
             "serverConfig": {

--- a/tests-functional/tests/benchmark/test_basic_benchmark.py
+++ b/tests-functional/tests/benchmark/test_basic_benchmark.py
@@ -1,10 +1,12 @@
-import pytest
 import time
+
+import pytest
 
 from clients.signals import SignalType
 from clients.status_backend import StatusBackend
-from utils.config import Config
 from steps.messenger import MessengerSteps
+from utils import fake
+from utils.config import Config
 
 
 @pytest.mark.benchmark
@@ -33,7 +35,7 @@ class TestBasicBenchmark(MessengerSteps):
 
         status_backend.init_status_backend()
         status_backend.events.append("CreateAccountAndLogin")
-        status_backend.create_account_and_login(waku_light_client=waku_light_client)
+        status_backend.create_account_and_login(password=fake.profile_password(), waku_light_client=waku_light_client)
         status_backend.wait_for_login()
         status_backend.events.append("Logged in")
         status_backend.wakuext_service.start_messenger()

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -89,12 +89,14 @@ def backend_new_profile(request, backend_factory):
     backends: list[StatusBackend] = []
 
     def factory(name: str = "", waku_light_client: bool = False, **kwargs) -> StatusBackend:
+        password = kwargs.pop("password", fake.profile_password())
+
         logging.debug(f"📋 [SETUP] backend_new_profile parameters: wakuV2LightClient={waku_light_client}")
         backend = backend_factory(name, **kwargs)
         backends.append(backend)
 
         backend.init_status_backend()
-        backend.create_account_and_login(password=fake.profile_password(), waku_light_client=waku_light_client, **kwargs)
+        backend.create_account_and_login(password=password, waku_light_client=waku_light_client, **kwargs)
         backend.wait_for_login()
         backend.wakuext_service.start_messenger()
         return backend

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -1,14 +1,16 @@
 import logging
 from uuid import uuid4
+
 import pytest
 from requests import ReadTimeout
 
+from clients.anvil import Anvil
+from clients.contract_deployers.multicall3 import Multicall3Deployer
+from clients.foundry import Foundry
 from clients.status_backend import StatusBackend
 from clients.statusgo_container import StatusGoContainer
-from clients.anvil import Anvil
-from clients.foundry import Foundry
-from clients.contract_deployers.multicall3 import Multicall3Deployer
 from resources.constants import USE_IPV6
+from utils import fake
 
 
 @pytest.fixture(scope="function", autouse=False)
@@ -92,7 +94,7 @@ def backend_new_profile(request, backend_factory):
         backends.append(backend)
 
         backend.init_status_backend()
-        backend.create_account_and_login(waku_light_client=waku_light_client, **kwargs)
+        backend.create_account_and_login(password=fake.profile_password(), waku_light_client=waku_light_client, **kwargs)
         backend.wait_for_login()
         backend.wakuext_service.start_messenger()
         return backend

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -88,7 +88,7 @@ def waku_light_client(request) -> bool:
 def backend_new_profile(request, backend_factory):
     backends: list[StatusBackend] = []
 
-    def _backend_new_profile(name: str, waku_light_client: bool = False, **kwargs) -> StatusBackend:
+    def factory(name: str = "", waku_light_client: bool = False, **kwargs) -> StatusBackend:
         logging.debug(f"📋 [SETUP] backend_new_profile parameters: wakuV2LightClient={waku_light_client}")
         backend = backend_factory(name, **kwargs)
         backends.append(backend)
@@ -99,7 +99,7 @@ def backend_new_profile(request, backend_factory):
         backend.wakuext_service.start_messenger()
         return backend
 
-    yield _backend_new_profile
+    yield factory
 
     for backend in backends:
         try:

--- a/tests-functional/tests/test_backup_mnemonic_and_restore.py
+++ b/tests-functional/tests/test_backup_mnemonic_and_restore.py
@@ -1,13 +1,15 @@
+import copy
 import random
 import string
-import copy
-from clients.status_backend import StatusBackend
-from clients.signals import SignalType
-import pytest
-from clients.api import ApiResponseError
 
+import pytest
+
+from clients.api import ApiResponseError
+from clients.signals import SignalType
+from clients.status_backend import StatusBackend
 from resources.constants import user_mnemonic_12, user_mnemonic_15, user_mnemonic_24, user_keycard_1
 from resources.utils import assert_response_attributes
+from utils import fake
 
 
 @pytest.mark.create_account
@@ -31,7 +33,7 @@ class TestBackupMnemonicAndRestore:
         # Create a new account container and initialize
         account = StatusBackend(self.await_signals)
         account.init_status_backend()
-        account.create_account_and_login()
+        account.create_account_and_login(password=fake.profile_password())
         account.wait_for_login()
 
         # Retrieve and verify the mnemonic
@@ -45,7 +47,7 @@ class TestBackupMnemonicAndRestore:
         # Create original account and backup mnemonic
         original_account = StatusBackend(self.await_signals)
         original_account.init_status_backend()
-        original_account.create_account_and_login()
+        original_account.create_account_and_login(password=fake.profile_password())
         original_account.wait_for_login()
         original_get_settings_response = original_account.settings_service.get_settings()
         original_settings = original_get_settings_response
@@ -147,7 +149,7 @@ class TestBackupMnemonicAndRestore:
         restored_account = StatusBackend(self.await_signals)
         restored_account.init_status_backend()
         restored_account._set_display_name()
-        data = restored_account._create_account_request(user)
+        data = restored_account._create_account_request(password=user.password)
         data["mnemonic"] = ""
         with pytest.raises(ApiResponseError, match=r"restore-account: mnemonic is not set"):
             restored_account.api_request_json("RestoreAccountAndLogin", data)
@@ -158,7 +160,7 @@ class TestBackupMnemonicAndRestore:
         restored_account = StatusBackend(self.await_signals)
         restored_account.init_status_backend()
         restored_account._set_display_name()
-        data = restored_account._create_account_request(user)
+        data = restored_account._create_account_request(password=user.password)
         data["mnemonic"] = user.passphrase
         data["keycard"] = user_keycard_1
         with pytest.raises(ApiResponseError, match=r"restore-account: mnemonic is set for keycard account"):

--- a/tests-functional/tests/test_local_backup.py
+++ b/tests-functional/tests/test_local_backup.py
@@ -1,9 +1,11 @@
 import os
-from clients.status_backend import StatusBackend
+
 import pytest
+
+from clients.status_backend import StatusBackend
 from resources.constants import Account, user_1
 from resources.test_data import profile_showcase_utils
-
+from utils import fake
 
 test_one_to_one_chat_id = (
     "0x043329fc08727f15c4ec9a17bf7d6a3dc44e9d0d8f782a55804f3660b28827194a365dc1765cf96b6fa5cd666b9ee5298e8ac82f51f7952c4110cbf321d4f63864"
@@ -27,7 +29,7 @@ class TestLocalBackup:
 
         # Init and login
         backend_client.init_status_backend()
-        backend_client.create_account_and_login()
+        backend_client.create_account_and_login(password=fake.profile_password())
         backend_client.wait_for_login()
         backend_client.wakuext_service.start_messenger()
 

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -1,12 +1,13 @@
 import re
+
 import pytest
+
 from clients.api import ApiResponseError
 from clients.services.wakuext import ActivityCenterNotificationType, ContactRequestState
 from clients.signals import SignalType, LocalPairingEventType, LocalPairingEventAction
 from clients.status_backend import StatusBackend
-from resources.constants import Account
-from steps.messenger import MessengerSteps
 from resources.enums import MessageContentType
+from steps.messenger import MessengerSteps
 
 
 def check_server_sender_events(events):
@@ -138,14 +139,8 @@ def pair_server_as_receiver(sender, receiver):
 
 
 def login_paired_device(backend: StatusBackend, key_uid, password):
-    user = Account(
-        password=password,
-        address="",
-        private_key="",
-        passphrase="",
-    )
     backend.init_status_backend()
-    backend.login(key_uid, user)
+    backend.login(key_uid, password)
     backend.wait_for_login()
     backend.wakuext_service.start_messenger()
 
@@ -161,23 +156,10 @@ class TestLocalPairing(MessengerSteps):
         SignalType.LOCAL_PAIRING.value,
     ]
 
-    @pytest.fixture(autouse=True)
-    def setup_cleanup(self, close_status_backend_containers):
-        """Automatically cleanup containers after each test"""
-        yield
-
-    def initialize_backend(self, await_signals, privileged=True, **kwargs):
-        backend = StatusBackend(await_signals, privileged=privileged)
-        backend.init_status_backend()
-        backend.create_account_and_login(**kwargs)
-        backend.wait_for_login()
-        backend.wakuext_service.start_messenger()
-        return backend
-
-    def test_pairing_server_as_sender(self):
+    def test_pairing_server_as_sender(self, backend_new_profile):
         # Create users
-        alice = self.initialize_backend(self.await_signals, False)
-        bob = self.initialize_backend(self.await_signals, False)
+        alice = backend_new_profile()
+        bob = backend_new_profile()
 
         bob_second_device = StatusBackend(self.await_signals)
         bob_second_device.init_status_backend()
@@ -255,10 +237,10 @@ class TestLocalPairing(MessengerSteps):
         assert messages_map[message_id2]["text"] == "hello bob"
         assert messages_map[message_id2]["clock"] == clock_2, "Message 2 clock is not right on paired device"
 
-    def test_pairing_server_as_receiver(self):
+    def test_pairing_server_as_receiver(self, backend_new_profile):
         # Create users
-        alice = self.initialize_backend(self.await_signals, False)
-        bob = self.initialize_backend(self.await_signals, False)
+        alice = backend_new_profile()
+        bob = backend_new_profile()
         bob_second_device = StatusBackend(self.await_signals)
         bob_second_device.init_status_backend()
 
@@ -299,16 +281,16 @@ class TestLocalPairing(MessengerSteps):
         messages = bob_second_device.wakuext_service.chat_messages(sender_chat_id, limit=10)["messages"]
         assert messages is None, "Messages found on paired device wrongly"
 
-    def test_pairing_three_devices(self):
+    def test_pairing_three_devices(self, backend_new_profile):
         # Create users
-        bob1 = self.initialize_backend(self.await_signals, False)
+        bob1 = backend_new_profile()
         bob2 = StatusBackend(self.await_signals)
         bob2.init_status_backend()
         bob3 = StatusBackend(self.await_signals)
         bob3.init_status_backend()
-        user_accepted = self.initialize_backend(self.await_signals, False)
-        user_pending = self.initialize_backend(self.await_signals, False)
-        user_declined = self.initialize_backend(self.await_signals, False)
+        user_accepted = backend_new_profile()
+        user_pending = backend_new_profile()
+        user_declined = backend_new_profile()
 
         # Setup contacts before local pairing
         self.make_contacts(user_accepted, bob1)
@@ -355,9 +337,9 @@ class TestLocalPairing(MessengerSteps):
             assert user_declined_notification["accepted"] is False
             assert user_declined_notification["dismissed"] is True
 
-    def test_pairing_receiver_must_be_logged_out(self):
-        sender = self.initialize_backend(self.await_signals, False)
-        receiver = self.initialize_backend(self.await_signals, False)
+    def test_pairing_receiver_must_be_logged_out(self, backend_new_profile):
+        sender = backend_new_profile()
+        receiver = backend_new_profile()
 
         # Client receiver must be logged out
         connection_string = sender.get_connection_string_for_bootstrapping_another_device()

--- a/tests-functional/tests/test_logging.py
+++ b/tests-functional/tests/test_logging.py
@@ -1,7 +1,10 @@
-import re
-from clients.status_backend import StatusBackend
-import pytest
 import os
+import re
+
+import pytest
+
+from clients.status_backend import StatusBackend
+from utils import fake
 
 
 @pytest.mark.rpc
@@ -26,7 +29,7 @@ class TestLogging:
 
         # Init and login
         backend_client.init_status_backend()
-        backend_client.create_account_and_login()
+        backend_client.create_account_and_login(password=fake.profile_password())
         backend_client.wait_for_login()
 
         # Configure logging
@@ -67,7 +70,7 @@ class TestLogging:
 
         # Ensure changes are persisted after re-login
         backend_client.logout()
-        backend_client.login(key_uid)
+        backend_client.login(key_uid, password=backend_client.password)
         backend_client.wait_for_login()
         backend_client.wakuext_service.log_test()
         profile_log = backend_client.extract_data(log_path)

--- a/tests-functional/tests/test_password.py
+++ b/tests-functional/tests/test_password.py
@@ -5,7 +5,6 @@ import pytest
 
 from clients.api import ApiResponseError
 from clients.signals import SignalType
-from resources.constants import Account
 from utils import fake
 
 
@@ -52,26 +51,13 @@ class TestPassword:
         backend.wait_for_signal(SignalType.NODE_STOPPED.value)
 
         # Try login with the old password
-        account = Account(
-            password=backend.password,
-            address="",
-            private_key="",
-            passphrase="",
-        )
         logging.info(f"Logging in with old password: {backend.password}, key uid: {backend.key_uid}")
-        backend.login(backend.key_uid, account)
+        backend.login(backend.key_uid, backend.password)
         signal = backend.wait_for_signal(SignalType.NODE_LOGIN.value)
         event = signal.get("event")
         assert "error" in event
         assert "failed to open database" in event.get("error")
 
         # Login with the new password
-        backend.password = new_password
-        account = Account(
-            password=new_password,
-            address="",
-            private_key="",
-            passphrase="",
-        )
-        backend.login(backend.key_uid, account)
+        backend.login(backend.key_uid, new_password)
         backend.wait_for_login()


### PR DESCRIPTION
# Description

1. `Login` and `CreateAccountAndLogin` now take password as an explicit argument. 
    - this makes more sense than passing `User` struct
    - this is handy when using pure `StatusBackend`

2. `backend_new_profile` name arg is now optional (defaults to empty string)

3. `TestLocalPairing` now uses `backend_new_profile` fixture. This simplifies the code.
    I tried to have it in a separate PR, but things god too complicated to untangle. https://github.com/status-im/status-go/pull/7059