### PR TITLE
refactor: tests no await signals

### DIFF
--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -1,16 +1,18 @@
 import json
 import logging
+import os
 import threading
 import time
-
-import websocket
-import os
-from pathlib import Path
-from resources.constants import SIGNALS_DIR, LOG_SIGNALS_TO_FILE
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
+
+import websocket
+
+from resources.constants import SIGNALS_DIR, LOG_SIGNALS_TO_FILE
 
 
+# Only signals defined in SignalType are processed by SignalClient
 class SignalType(Enum):
     MESSAGES_NEW = "messages.new"
     MESSAGE_DELIVERED = "message.delivered"
@@ -69,10 +71,9 @@ class LocalPairingEventAction(Enum):
 
 
 class SignalClient:
-    def __init__(self, ws_url, await_signals):
+    def __init__(self, ws_url):
         self.url = f"{ws_url}/signals"
 
-        self.await_signals = await_signals
         self.received_signals = {
             # For each signal type, store:
             # - list of received signals
@@ -85,7 +86,7 @@ class SignalClient:
                 "expected_count": 1,
                 "accept_fn": None,
             }
-            for signal in self.await_signals
+            for signal in SignalType
         }
         if LOG_SIGNALS_TO_FILE:
             self.signal_file_path = os.path.join(
@@ -100,19 +101,32 @@ class SignalClient:
             self.write_signal_to_file(signal_data)
 
         signal_type = signal_data.get("type")
-        if signal_type in self.await_signals:
-            accept_fn = self.received_signals[signal_type]["accept_fn"]
-            if not accept_fn or accept_fn(signal_data):
-                self.received_signals[signal_type]["received"].append(signal_data)
+        try:
+            signal_type = self._convert_signal_type(signal_type)
+        except ValueError:
+            # Ignore unregistered signal types
+            return
 
-    def check_signal_type(self, signal_type):
-        if signal_type not in self.await_signals:
-            raise ValueError(f"Signal type {signal_type} is not in the list of awaited signals")
+        if signal_type not in self.received_signals:
+            # This should never happen, as we register all signal types from SignalType enum
+            raise ValueError(f"Signal type {signal_type} is not registered")
+
+        accept_fn = self.received_signals[signal_type]["accept_fn"]
+        if not accept_fn or accept_fn(signal_data):
+            self.received_signals[signal_type]["received"].append(signal_data)
+
+    # TODO: This is a temporary workaround until all tests are migrated to use SignalType enum
+    @staticmethod
+    def _convert_signal_type(signal_type: SignalType | str) -> SignalType:
+        if isinstance(signal_type, SignalType):
+            return signal_type
+        if isinstance(signal_type, str):
+            return SignalType(signal_type)
 
     # Used to set up how many instances of a signal to wait for, before triggering the actions
     # that cause them to be emitted.
-    def prepare_wait_for_signal(self, signal_type, delta_count, accept_fn=None):
-        self.check_signal_type(signal_type)
+    def prepare_wait_for_signal(self, signal_type: SignalType, delta_count: int, accept_fn=None):
+        signal_type = self._convert_signal_type(signal_type)
 
         if delta_count < 1:
             raise ValueError("delta_count must be greater than 0")
@@ -120,8 +134,8 @@ class SignalClient:
         self.received_signals[signal_type]["expected_count"] = len(self.received_signals[signal_type]["received"]) + delta_count
         self.received_signals[signal_type]["accept_fn"] = accept_fn
 
-    def wait_for_signal(self, signal_type, timeout=20):
-        self.check_signal_type(signal_type)
+    def wait_for_signal(self, signal_type: SignalType | str, timeout: int = 20):
+        signal_type = self._convert_signal_type(signal_type)
 
         start_time = time.time()
         received_signals = self.received_signals.get(signal_type)
@@ -136,7 +150,8 @@ class SignalClient:
             return self.received_signals[signal_type]["received"][-1]
         return self.received_signals[signal_type]["received"][-delta_count:]
 
-    def wait_for_signal_predicate(self, signal_type, predicate=lambda signal: True, timeout=20):
+    def wait_for_signal_predicate(self, signal_type: SignalType | str, predicate=lambda signal: True, timeout=20):
+        signal_type = self._convert_signal_type(signal_type)
         start_time = time.time()
         while True:
             elapsed_time = time.time() - start_time
@@ -153,10 +168,12 @@ class SignalClient:
         raise TimeoutError(f"Signal {signal_type} satisfying the predicate is not received in {timeout} seconds")
 
     def wait_for_logout(self):
-        signal = self.wait_for_signal(SignalType.NODE_STOPPED.value)
+        signal = self.wait_for_signal(SignalType.NODE_STOPPED)
         return signal
 
-    def find_signal_containing_pattern(self, signal_type, event_pattern, timeout=20):
+    def find_signal_containing_pattern(self, signal_type: SignalType | str, event_pattern, timeout=20):
+        signal_type = self._convert_signal_type(signal_type)
+
         start_time = time.time()
         while True:
             if time.time() - start_time >= timeout:
@@ -170,7 +187,8 @@ class SignalClient:
                     return event
             time.sleep(0.2)
 
-    def get_all_events(self, signal_type):
+    def get_all_events(self, signal_type: SignalType | str):
+        signal_type = self._convert_signal_type(signal_type)
         signals = self.received_signals.get(signal_type, {}).get("received", [])
         return [signal.get("event") for signal in signals]
 

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -39,7 +39,7 @@ NANOSECONDS_PER_SECOND = 1_000_000_000
 class StatusBackend(RpcClient, SignalClient, ApiClient):
     container = None
 
-    def __init__(self, await_signals=[], privileged=False, ipv6=USE_IPV6, **kwargs):
+    def __init__(self, privileged=False, ipv6=USE_IPV6, **kwargs):
         self.temp_dir = None
         self.ipv6 = True if ipv6 == "Yes" else False
         logging.debug(f"Flag USE_IPV6 is: {self.ipv6}")
@@ -83,7 +83,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
 
         RpcClient.__init__(self)
         ApiClient.__init__(self, self.api_url)
-        SignalClient.__init__(self, self.ws_url, await_signals)
+        SignalClient.__init__(self, self.ws_url)
 
         self.wait_for_healthy()
 

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -15,13 +15,6 @@ from utils.retry_utils import retry_call
 
 class MessengerSteps(NetworkConditionsSteps):
 
-    await_signals = [
-        SignalType.MESSAGES_NEW.value,
-        SignalType.MESSAGE_DELIVERED.value,
-        SignalType.NODE_LOGIN.value,
-        SignalType.NODE_STOPPED.value,
-    ]
-
     def send_contact_request_and_wait_for_signal_to_be_received(self, sender=None, receiver=None) -> str:
         """
         Send a contact request from sender to receiver and wait for confirmation.

--- a/tests-functional/tests/benchmark/test_basic_benchmark.py
+++ b/tests-functional/tests/benchmark/test_basic_benchmark.py
@@ -2,7 +2,6 @@ import time
 
 import pytest
 
-from clients.signals import SignalType
 from clients.status_backend import StatusBackend
 from steps.messenger import MessengerSteps
 from utils import fake
@@ -16,13 +15,6 @@ class TestBasicBenchmark(MessengerSteps):
 
     This test suite contains a few test cases that track CPU, RAM and network usage via Docker API.
     """
-
-    await_signals = [
-        SignalType.MESSAGES_NEW.value,
-        SignalType.MESSAGE_DELIVERED.value,
-        SignalType.NODE_LOGIN.value,
-        SignalType.NODE_STOPPED.value,
-    ]
 
     @pytest.fixture(scope="function", autouse=False)
     def aut(self, request, backend_factory, waku_light_client):

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -32,9 +32,6 @@ def backend_factory(request):
         self.receiver = backend_factory("receiver")
     """
 
-    # Get class-level configuration
-    await_signals = getattr(request.cls, "await_signals", ["messages.new", "message.delivered", "node.login", "node.logout"])
-
     # Get parameters from request.param if available
     params = getattr(request, "param", {})
 
@@ -63,7 +60,7 @@ def backend_factory(request):
         logging.debug(f"📋 [SETUP] Parameters: privileged={privileged}, ipv6={ipv6}")
 
         # Create backend
-        backend = StatusBackend(await_signals=await_signals, privileged=privileged, ipv6=ipv6, **kwargs)
+        backend = StatusBackend(privileged=privileged, ipv6=ipv6, **kwargs)
         created_backends.append(backend)
         logging.debug(f"✅ [SETUP] {name.capitalize()} backend created")
 

--- a/tests-functional/tests/test_backup_mnemonic_and_restore.py
+++ b/tests-functional/tests/test_backup_mnemonic_and_restore.py
@@ -16,14 +16,6 @@ from utils import fake
 @pytest.mark.rpc
 class TestBackupMnemonicAndRestore:
 
-    await_signals = [
-        SignalType.MEDIASERVER_STARTED.value,
-        SignalType.NODE_STARTED.value,
-        SignalType.NODE_READY.value,
-        SignalType.NODE_LOGIN.value,
-        SignalType.NODE_STOPPED.value,
-    ]
-
     @pytest.fixture(autouse=True)
     def setup_cleanup(self, close_status_backend_containers):
         """Automatically cleanup containers after each test"""
@@ -31,7 +23,7 @@ class TestBackupMnemonicAndRestore:
 
     def test_profile_creation_and_mnemonics_backup(self):
         # Create a new account container and initialize
-        account = StatusBackend(self.await_signals)
+        account = StatusBackend()
         account.init_status_backend()
         account.create_account_and_login(password=fake.profile_password())
         account.wait_for_login()
@@ -45,7 +37,7 @@ class TestBackupMnemonicAndRestore:
 
     def test_backup_account_and_restore_it_via_mnemonics(self):
         # Create original account and backup mnemonic
-        original_account = StatusBackend(self.await_signals)
+        original_account = StatusBackend()
         original_account.init_status_backend()
         original_account.create_account_and_login(password=fake.profile_password())
         original_account.wait_for_login()
@@ -58,7 +50,7 @@ class TestBackupMnemonicAndRestore:
         user.passphrase = mnemonic
 
         # Restore account in a new container
-        restored_account = StatusBackend(self.await_signals)
+        restored_account = StatusBackend()
         restored_account.init_status_backend()
         restored_account.restore_account_and_login(user=user)
         restored_account.wait_for_login()
@@ -92,7 +84,7 @@ class TestBackupMnemonicAndRestore:
     )
     def test_restore_app_different_valid_size_mnemonics(self, user_mnemonic):
         # Initialize backend client and restore account using user_mnemonic.
-        restored_account = StatusBackend(self.await_signals)
+        restored_account = StatusBackend()
         restored_account.init_status_backend()
         restored_account.restore_account_and_login(user=user_mnemonic)
         restored_account.wait_for_login()
@@ -118,7 +110,7 @@ class TestBackupMnemonicAndRestore:
         user = copy.deepcopy(user_mnemonic_12)
         user.passphrase = " ".join("".join(random.choice(string.ascii_lowercase) for _ in range(random.randint(2, 10))) for _ in range(mnemonic_size))
 
-        restored_account = StatusBackend(self.await_signals)
+        restored_account = StatusBackend()
         restored_account.init_status_backend()
         restored_account.restore_account_and_login(user=user)
         restored_account.wait_for_login()
@@ -133,7 +125,7 @@ class TestBackupMnemonicAndRestore:
         user = copy.deepcopy(user_mnemonic_12)
         user.passphrase = "<>?`~!@#$%^&*()_+1 $fgdg ^&*()"
 
-        restored_account = StatusBackend(self.await_signals)
+        restored_account = StatusBackend()
         restored_account.init_status_backend()
         restored_account.restore_account_and_login(user=user)
         restored_account.wait_for_login()
@@ -146,7 +138,7 @@ class TestBackupMnemonicAndRestore:
         # Restore with empty mnemonic isn't allowed
         user = copy.deepcopy(user_mnemonic_12)
 
-        restored_account = StatusBackend(self.await_signals)
+        restored_account = StatusBackend()
         restored_account.init_status_backend()
         restored_account._set_display_name()
         data = restored_account._create_account_request(password=user.password)
@@ -157,7 +149,7 @@ class TestBackupMnemonicAndRestore:
     def test_restore_with_both_mnemonic_and_keycard(self):
         # Restore with both keycard and mnemonic isn't allowed
         user = copy.deepcopy(user_mnemonic_12)
-        restored_account = StatusBackend(self.await_signals)
+        restored_account = StatusBackend()
         restored_account.init_status_backend()
         restored_account._set_display_name()
         data = restored_account._create_account_request(password=user.password)
@@ -168,7 +160,7 @@ class TestBackupMnemonicAndRestore:
 
     def test_restored_on_existing_restored_account_fails(self):
         user = copy.deepcopy(user_mnemonic_12)
-        restored_account = StatusBackend(self.await_signals)
+        restored_account = StatusBackend()
         restored_account.init_status_backend()
         restored_account.restore_account_and_login(user=user)
         restored_account.wait_for_login()

--- a/tests-functional/tests/test_edit_community.py
+++ b/tests-functional/tests/test_edit_community.py
@@ -48,12 +48,6 @@ def validate_community_images(community, name, cert_file_path):
 @pytest.mark.rpc
 @pytest.mark.create_account
 class TestEditCommunity:
-    await_signals = [
-        SignalType.MEDIASERVER_STARTED.value,
-        SignalType.NODE_STARTED.value,
-        SignalType.NODE_READY.value,
-        SignalType.NODE_LOGIN.value,
-    ]
 
     @pytest.fixture()
     def backend(self, backend_new_profile) -> StatusBackend:

--- a/tests-functional/tests/test_eth_api.py
+++ b/tests-functional/tests/test_eth_api.py
@@ -1,6 +1,5 @@
 import pytest
 
-from clients.signals import SignalType
 from resources.constants import user_1, user_2
 
 
@@ -8,14 +7,6 @@ from resources.constants import user_1, user_2
 @pytest.mark.ethclient
 @pytest.mark.xdist_group(name="Eth")
 class TestEth:
-    await_signals = [
-        SignalType.NODE_LOGIN.value,
-        SignalType.WALLET.value,
-        SignalType.WALLET_SUGGESTED_ROUTES.value,
-        SignalType.WALLET_ROUTER_SIGN_TRANSACTIONS.value,
-        SignalType.WALLET_ROUTER_SENDING_TRANSACTIONS_STARTED.value,
-        SignalType.WALLET_ROUTER_TRANSACTIONS_SENT.value,
-    ]
 
     def test_estimate_gas(self, backend_recovered_profile):
         backend = backend_recovered_profile("sender", user=user_1)

--- a/tests-functional/tests/test_init_status_app.py
+++ b/tests-functional/tests/test_init_status_app.py
@@ -1,9 +1,9 @@
 import logging
+import os
+
+import pytest
 
 from clients.status_backend import StatusBackend
-import pytest
-from clients.signals import SignalType
-import os
 
 
 @pytest.mark.create_account
@@ -18,14 +18,7 @@ class TestInitialiseApp:
     @pytest.mark.init
     def test_init_app(self):
 
-        await_signals = [
-            SignalType.MEDIASERVER_STARTED.value,
-            SignalType.NODE_STARTED.value,
-            SignalType.NODE_READY.value,
-            SignalType.NODE_LOGIN.value,
-        ]
-
-        backend_client = StatusBackend(await_signals)
+        backend_client = StatusBackend()
         backend_client.init_status_backend()
         backend_client.restore_account_and_login()
 

--- a/tests-functional/tests/test_local_backup.py
+++ b/tests-functional/tests/test_local_backup.py
@@ -17,14 +17,7 @@ class TestLocalBackup:
 
     @pytest.mark.init
     def test_local_backup(self, tmp_path):
-        await_signals = [
-            "mediaserver.started",
-            "node.started",
-            "node.ready",
-            "node.login",
-        ]
-
-        backend_client = StatusBackend(await_signals)
+        backend_client = StatusBackend()
         assert backend_client is not None
 
         # Init and login
@@ -213,7 +206,7 @@ class TestLocalBackup:
         assert backup_file is not None
 
         # Create a new installation
-        backend_client2 = StatusBackend(await_signals)
+        backend_client2 = StatusBackend()
         assert backend_client2 is not None
 
         # Init and login
@@ -296,13 +289,7 @@ class TestLocalBackup:
         assert one_on_one_chat_recovered, "One-to-one chat was not restored correctly"
 
     def test_local_backup_backwards_compatibility(self, tmp_path):
-        await_signals = [
-            "mediaserver.started",
-            "node.started",
-            "node.ready",
-            "node.login",
-        ]
-        backend_client = StatusBackend(await_signals)
+        backend_client = StatusBackend()
         assert backend_client is not None
         # Restore the account with a hardcoded mnemonic to get the same private key
         backend_client.init_status_backend()

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -148,20 +148,12 @@ def login_paired_device(backend: StatusBackend, key_uid, password):
 @pytest.mark.rpc
 class TestLocalPairing(MessengerSteps):
 
-    await_signals = [
-        SignalType.MESSAGES_NEW.value,
-        SignalType.MESSAGE_DELIVERED.value,
-        SignalType.NODE_LOGIN.value,
-        SignalType.NODE_STOPPED.value,
-        SignalType.LOCAL_PAIRING.value,
-    ]
-
     def test_pairing_server_as_sender(self, backend_new_profile):
         # Create users
         alice = backend_new_profile()
         bob = backend_new_profile()
 
-        bob_second_device = StatusBackend(self.await_signals)
+        bob_second_device = StatusBackend()
         bob_second_device.init_status_backend()
 
         # Make contacts before local pairing
@@ -241,7 +233,7 @@ class TestLocalPairing(MessengerSteps):
         # Create users
         alice = backend_new_profile()
         bob = backend_new_profile()
-        bob_second_device = StatusBackend(self.await_signals)
+        bob_second_device = StatusBackend()
         bob_second_device.init_status_backend()
 
         # Make contacts before local pairing
@@ -284,9 +276,9 @@ class TestLocalPairing(MessengerSteps):
     def test_pairing_three_devices(self, backend_new_profile):
         # Create users
         bob1 = backend_new_profile()
-        bob2 = StatusBackend(self.await_signals)
+        bob2 = StatusBackend()
         bob2.init_status_backend()
-        bob3 = StatusBackend(self.await_signals)
+        bob3 = StatusBackend()
         bob3.init_status_backend()
         user_accepted = backend_new_profile()
         user_pending = backend_new_profile()

--- a/tests-functional/tests/test_logging.py
+++ b/tests-functional/tests/test_logging.py
@@ -17,14 +17,7 @@ class TestLogging:
 
     @pytest.mark.init
     def test_logging(self, tmp_path):
-        await_signals = [
-            "mediaserver.started",
-            "node.started",
-            "node.ready",
-            "node.login",
-        ]
-
-        backend_client = StatusBackend(await_signals)
+        backend_client = StatusBackend()
         assert backend_client is not None
 
         # Init and login

--- a/tests-functional/tests/test_media_server.py
+++ b/tests-functional/tests/test_media_server.py
@@ -8,13 +8,6 @@ from clients.status_backend import StatusBackend
 
 @pytest.mark.rpc
 class TestMediaServer:
-    await_signals = [
-        SignalType.MEDIASERVER_STARTED.value,
-        SignalType.NODE_STARTED.value,
-        SignalType.NODE_READY.value,
-        SignalType.NODE_LOGIN.value,
-    ]
-
     @pytest.fixture()
     def backend(self, backend_new_profile) -> StatusBackend:
         return backend_new_profile("sender")

--- a/tests-functional/tests/test_newsfeed.py
+++ b/tests-functional/tests/test_newsfeed.py
@@ -1,16 +1,8 @@
 import pytest
 
-from clients.signals import SignalType
-
 
 @pytest.mark.rpc
 class TestNewsFeed:
-
-    await_signals = [
-        SignalType.NODE_LOGIN.value,
-        SignalType.NODE_STARTED.value,
-        SignalType.NODE_READY.value,
-    ]
 
     def test_newsfeed_settings(self, backend_new_profile):
         backend = backend_new_profile("backend")

--- a/tests-functional/tests/test_password.py
+++ b/tests-functional/tests/test_password.py
@@ -11,15 +11,6 @@ from utils import fake
 @pytest.mark.rpc
 class TestPassword:
 
-    await_signals = [
-        SignalType.NODE_LOGIN.value,
-        SignalType.DB_REENCRYPTION_STARTED.value,
-        SignalType.DB_REENCRYPTION_FINISHED.value,
-        SignalType.NODE_STARTED.value,
-        SignalType.NODE_READY.value,
-        SignalType.NODE_STOPPED.value,
-    ]
-
     def test_verify_correct_password(self, backend_new_profile):
         backend = backend_new_profile("sender")
         response = backend.accounts_service.verify_password(backend.password)

--- a/tests-functional/tests/test_router.py
+++ b/tests-functional/tests/test_router.py
@@ -1,29 +1,19 @@
 import re
 import uuid as uuid_lib
-import pytest
 
-import resources.constants as constants
+import pytest
 from web3.types import Wei  # type: ignore
 
-from clients.signals import SignalType
-from utils import wallet_utils
-from resources.constants import user_1
+import resources.constants as constants
 from clients.api import ApiResponseError
+from resources.constants import user_1
+from utils import wallet_utils
 
 
 @pytest.mark.rpc
 @pytest.mark.transaction
 @pytest.mark.wallet
 class TestRouter:
-
-    await_signals = [
-        SignalType.NODE_LOGIN.value,
-        SignalType.WALLET.value,
-        SignalType.WALLET_SUGGESTED_ROUTES.value,
-        SignalType.WALLET_ROUTER_SIGN_TRANSACTIONS.value,
-        SignalType.WALLET_ROUTER_SENDING_TRANSACTIONS_STARTED.value,
-        SignalType.WALLET_ROUTER_TRANSACTIONS_SENT.value,
-    ]
 
     @pytest.fixture(autouse=True)
     def setup_backend(self, backend_recovered_profile, anvil_client, multicall3_deployer):

--- a/tests-functional/tests/test_status_connector.py
+++ b/tests-functional/tests/test_status_connector.py
@@ -28,16 +28,6 @@ def accept_connector(backend, connector, wallet_acc):
 @pytest.mark.connector
 class TestStatusConnector:
 
-    await_signals = [
-        SignalType.NODE_LOGIN.value,
-        SignalType.CONNECTOR_SEND_REQUEST_ACCOUNTS.value,
-        SignalType.CONNECTOR_SEND_TRANSACTION.value,
-        SignalType.CONNECTOR_SIGN.value,
-        SignalType.CONNECTOR_DAPP_PERMISSION_GRANTED.value,
-        SignalType.CONNECTOR_DAPP_PERMISSION_REVOKED.value,
-        SignalType.CONNECTOR_DAPP_CHAIN_ID_SWITCHED.value,
-    ]
-
     @pytest.fixture
     def backend(self, backend_new_profile):
         yield backend_new_profile("sender", connector_enabled=True)

--- a/tests-functional/tests/test_wallet_activity_session.py
+++ b/tests-functional/tests/test_wallet_activity_session.py
@@ -10,7 +10,6 @@ from clients.contract_deployers.snt import (
     SNTV2_ABI,
     SNT_TOKEN_CONTROLLER_ABI,
 )
-from clients.signals import SignalType
 from resources.constants import DEPLOYER_ACCOUNT
 from resources.constants import user_1, user_2
 from utils import wallet_utils
@@ -30,14 +29,6 @@ def validate_entry(entry, tx_data):
 @pytest.mark.activity
 @pytest.mark.xdist_group(name="WalletSteps")
 class TestWalletActivitySession:
-    await_signals = [
-        SignalType.NODE_LOGIN.value,
-        SignalType.WALLET.value,
-        SignalType.WALLET_SUGGESTED_ROUTES.value,
-        SignalType.WALLET_ROUTER_SIGN_TRANSACTIONS.value,
-        SignalType.WALLET_ROUTER_SENDING_TRANSACTIONS_STARTED.value,
-        SignalType.WALLET_ROUTER_TRANSACTIONS_SENT.value,
-    ]
 
     @staticmethod
     def _token_list_to_token_overrides(token_list):

--- a/tests-functional/tests/test_wallet_assets.py
+++ b/tests-functional/tests/test_wallet_assets.py
@@ -12,14 +12,6 @@ from clients.services.wallet import WalletService
 @pytest.mark.assets
 @pytest.mark.wallet
 class TestWalletAssets:
-    await_signals = [
-        SignalType.NODE_LOGIN.value,
-        SignalType.WALLET.value,
-        SignalType.WALLET_SUGGESTED_ROUTES.value,
-        SignalType.WALLET_ROUTER_SIGN_TRANSACTIONS.value,
-        SignalType.WALLET_ROUTER_SENDING_TRANSACTIONS_STARTED.value,
-        SignalType.WALLET_ROUTER_TRANSACTIONS_SENT.value,
-    ]
 
     @pytest.fixture(autouse=True)
     def setup_backend(self, backend_recovered_profile, multicall3_deployer):

--- a/tests-functional/tests/test_wallet_signals.py
+++ b/tests-functional/tests/test_wallet_signals.py
@@ -9,7 +9,6 @@ from resources.constants import user_1
 @pytest.mark.wallet
 @pytest.mark.rpc
 class TestWalletSignals:
-    await_signals = [SignalType.NODE_LOGIN.value, SignalType.WALLET.value]
 
     @pytest.fixture(autouse=True)
     def setup_backend(self, backend_recovered_profile):


### PR DESCRIPTION
# Description

`SignalClient` now will wait for all signals of `SignalType` enum.

It now doesn't require to define `await_signals` externally.

