### PR TITLE
feat(functional-tests): some endpoints added and refactored

### DIFF
--- a/tests-functional/Makefile
+++ b/tests-functional/Makefile
@@ -3,3 +3,9 @@
 lint:
 	@echo "Running python linting on all files..."
 	pre-commit run --all-files --verbose --config .pre-commit-config.yaml
+
+compose:
+	docker compose \
+		-f docker-compose.anvil.yml \
+		-f docker-compose.waku.yml \
+		up --build --remove-orphans -d

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -654,7 +654,7 @@ class WakuextService(Service):
         response = self.rpc_request("getSavedAddressesPerMode", params)
         return response
 
-    def upsert_saved_address(self, address: str, name: str, color_id: str, ens: str = "", chain_short_names: str = "", is_test: bool = False):
+    def upsert_saved_address(self, address: str, name: str, color_id: str = "", ens: str = "", chain_short_names: str = "", is_test: bool = False):
         params = [
             {
                 "address": address,

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -654,8 +654,17 @@ class WakuextService(Service):
         response = self.rpc_request("getSavedAddressesPerMode", params)
         return response
 
-    def upsert_saved_address(self, address_payload: dict):
-        params = [address_payload]
+    def upsert_saved_address(self, address: str, name: str, color_id: str, ens: str = "", chain_short_names: str = "", is_test: bool = False):
+        params = [
+            {
+                "address": address,
+                "name": name,
+                "ens": ens,
+                "colorId": color_id,
+                "isTest": is_test,
+                "chainShortNames": chain_short_names,
+            },
+        ]
         response = self.rpc_request("upsertSavedAddress", params)
         return response
 

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -346,8 +346,15 @@ class WakuextService(Service):
         response = self.rpc_request("generateEditCommunityRequestsForSigning", params)
         return response
 
-    def send_chat_message(self, chat_id, message, content_type=MessageContentType.TEXT_PLAIN.value):
-        params = [{"chatId": chat_id, "text": message, "contentType": content_type}]
+    def send_chat_message(self, chat_id, message, content_type=MessageContentType.TEXT_PLAIN.value, responseTo: str = ""):
+        params = [
+            {
+                "chatId": chat_id,
+                "text": message,
+                "contentType": content_type,
+                "responseTo": responseTo,
+            }
+        ]
         response = self.rpc_request("sendChatMessage", params)
         return response
 

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -149,6 +149,11 @@ class WakuextService(Service):
         response = self.rpc_request("contacts")
         return response
 
+    def get_contact_by_id(self, id: str):
+        params = [id]
+        response = self.rpc_request("getContactByID", params)
+        return response
+
     def add_contact(self, contact_id: str, displayName: str):
         params = [{"id": contact_id, "nickname": "fake_nickname", "displayName": displayName, "ensName": ""}]
         response = self.rpc_request("addContact", params)

--- a/tests-functional/clients/services/wallet.py
+++ b/tests-functional/clients/services/wallet.py
@@ -88,3 +88,7 @@ class WalletService(Service):
 
     def stop_suggested_routes_async_calculation(self):
         return self.rpc_request("stopSuggestedRoutesAsyncCalculation")
+
+    def fetch_or_get_cached_wallet_balances(self, addresses: list, force_refresh: bool = False):
+        params = [addresses, force_refresh]
+        return self.rpc_request("fetchOrGetCachedWalletBalances", params)

--- a/tests-functional/clients/signals.py
+++ b/tests-functional/clients/signals.py
@@ -134,13 +134,13 @@ class SignalClient:
         self.received_signals[signal_type]["expected_count"] = len(self.received_signals[signal_type]["received"]) + delta_count
         self.received_signals[signal_type]["accept_fn"] = accept_fn
 
-    def wait_for_signal(self, signal_type: SignalType | str, timeout: int = 20):
+    def wait_for_signal(self, signal_type: SignalType | str, timeout: int | None = 20):
         signal_type = self._convert_signal_type(signal_type)
 
         start_time = time.time()
         received_signals = self.received_signals.get(signal_type)
         while (not received_signals) or len(received_signals["received"]) < received_signals["expected_count"]:
-            if time.time() - start_time >= timeout:
+            if timeout is not None and time.time() - start_time >= timeout:
                 raise TimeoutError(f"Signal {signal_type} is not received in {timeout} seconds")
             time.sleep(0.2)
         logging.debug(f"Signal {signal_type} is received in {round(time.time() - start_time)} seconds")

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -332,6 +332,9 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         self.key_uid = self.node_login_event.get("event", {}).get("account", {}).get("key-uid")
         return signal
 
+    def wait_for_messages(self, timeout: int | None = 20):
+        return self.wait_for_signal(SignalType.MESSAGES_NEW, timeout)
+
     def container_pause(self):
         if not self.container:
             raise RuntimeError("Container is not initialized.")

--- a/tests-functional/tests/test_wakuext_savedAddress.py
+++ b/tests-functional/tests/test_wakuext_savedAddress.py
@@ -132,9 +132,9 @@ class TestSavedAddresses:
         # Step: Checking remaining capacity
         remaining_capacity = self.rpc_client.wakuext_service.remaining_capacity_for_saved_addresses(is_test)
 
-        # Step: adding  addresses to fill capacity
+        # Step: adding addresses to fill capacity
         for i in range(remaining_capacity):
-            self.rpc_client.wakuext_service.upsert_saved_address(address=addresses[i], name=f"test{i}", isTest=is_test)
+            self.rpc_client.wakuext_service.upsert_saved_address(address=addresses[i], name=f"test{i}", is_test=is_test)
 
         # Step: Verifying that capacity is now 0
         with pytest.raises(ApiResponseError, match=re.escape("no more save addresses can be added")):

--- a/tests-functional/tests/test_wakuext_savedAddress.py
+++ b/tests-functional/tests/test_wakuext_savedAddress.py
@@ -1,5 +1,7 @@
 import re
+
 import pytest
+
 from clients.api import ApiResponseError
 
 
@@ -45,7 +47,14 @@ class TestSavedAddresses:
         """Test adding saved addresses and verifying their presence in the lists."""
 
         # Step: Adding item in mainnet mode
-        self.rpc_client.wakuext_service.upsert_saved_address(params)
+        self.rpc_client.wakuext_service.upsert_saved_address(
+            address=params.get("address", ""),
+            name=params.get("name", ""),
+            color_id=params.get("colorId", ""),
+            ens=params.get("ens", ""),
+            is_test=params.get("isTest", False),
+            chain_short_names=params.get("chainShortNames"),
+        )
         response = self.rpc_client.wakuext_service.get_saved_addresses()
         # TODO: Add more assertions on response
 
@@ -63,21 +72,31 @@ class TestSavedAddresses:
 
     def test_delete_saved_address(self):
         """Test deleting a saved address and verifying its removal."""
-        address, is_test = "0xc6a54e79fb8915efbe00a8adac5bd94b68022fb6", True
-        params = {
-            "address": address,
-            "name": "testnet_yellow_ENS",
-            "colorId": "red",
-            "ens": "some_red_ENS.stateofus.eth",
-            "isTest": is_test,
-        }
+        address = "0xc6a54e79fb8915efbe00a8adac5bd94b68022fb6"
+        is_test = True
+        name = "testnet_yellow_ENS"
+        color = "red"
+        ens = "some_red_ENS.stateofus.eth"
 
         # Step: Adding item in testnet mode
-        self.rpc_client.wakuext_service.upsert_saved_address(params)
+        self.rpc_client.wakuext_service.upsert_saved_address(
+            address=address,
+            name=name,
+            color_id=color,
+            ens=ens,
+            is_test=is_test,
+        )
 
         # Step: Verifying the item exists in testnet saved addresses
         response = self.rpc_client.wakuext_service.get_saved_addresses_per_mode(is_test)
-        assert any(params.items() <= item.items() for item in response), f"{params['name']} not found in getSavedAddressesPerMode"
+        assert len(response) == 1
+
+        saved_address = response[0]
+        assert saved_address["address"].lower() == address.lower()
+        assert saved_address["name"] == name
+        assert saved_address["colorId"] == color
+        assert saved_address["ens"] == ens
+        assert saved_address["isTest"] == is_test
 
         # Step: Deleting the item and verifying removal
         self.rpc_client.wakuext_service.delete_saved_address(address, is_test)
@@ -115,7 +134,7 @@ class TestSavedAddresses:
 
         # Step: adding  addresses to fill capacity
         for i in range(remaining_capacity):
-            self.rpc_client.wakuext_service.upsert_saved_address({"address": addresses[i], "name": f"test{i}", "isTest": is_test})
+            self.rpc_client.wakuext_service.upsert_saved_address(address=addresses[i], name=f"test{i}", isTest=is_test)
 
         # Step: Verifying that capacity is now 0
         with pytest.raises(ApiResponseError, match=re.escape("no more save addresses can be added")):


### PR DESCRIPTION
Requires:
- https://github.com/status-im/status-go/pull/7060

# Description

1. Added methods for these endpoints:
    - `getContactByID`
    - `fetchOrGetCachedWalletBalances`
    - `wait_for_messages` — not and endpoint, but a handy wrapper.

2. Modified:
    - `send_chat_message` — added `responseTo` argument
    - `wait_for_signal` — timeout can now be `None` (== no timeout)
    - `upsert_saved_address` — refactored to take explicit arguments (tests updated accordingly)
    
