### PR TITLE
fix(leaderboard): use coingecko ID for price lookup 

### DIFF
--- a/services/wallet/leaderboard/fetcher.go
+++ b/services/wallet/leaderboard/fetcher.go
@@ -3,6 +3,7 @@ package leaderboard
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"time"
 
@@ -176,22 +177,25 @@ func (f *ProxyFetcher) FetchPrices(ctx context.Context) error {
 	}
 
 	type ProxyPriceData struct {
-		ID                       string  `json:"id"`
 		CurrentPrice             float64 `json:"price"`
+		MarketCap                float64 `json:"market_cap"`
+		Volume24h                float64 `json:"volume_24h"`
 		PriceChangePercentage24h float64 `json:"percent_change_24h"`
 	}
 
 	var tempPriceMap map[string]ProxyPriceData
-
 	if err := json.Unmarshal(body, &tempPriceMap); err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal price data: %w", err)
 	}
 
 	priceData := PriceMap{}
 	for key, tempPrice := range tempPriceMap {
+		// The key is the cryptocurrency ID (e.g., "bitcoin", "ethereum")
 		priceData[key] = PriceData{
-			ID:               tempPrice.ID,
+			ID:               key,
 			Price:            tempPrice.CurrentPrice,
+			MarketCap:        tempPrice.MarketCap,
+			Volume24h:        tempPrice.Volume24h,
 			PercentChange24h: tempPrice.PriceChangePercentage24h,
 		}
 	}

--- a/services/wallet/leaderboard/fetcher_test.go
+++ b/services/wallet/leaderboard/fetcher_test.go
@@ -1,0 +1,247 @@
+package leaderboard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/status-im/status-go/pkg/security"
+)
+
+func TestProxyFetcherFetchPrices(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+	storage := NewDataStorage(db)
+
+	t.Run("Valid price data with new fields", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			priceResponse := map[string]interface{}{
+				"bitcoin": map[string]interface{}{
+					"price":              80000.0,
+					"market_cap":         1600000000000.0,
+					"volume_24h":         80000000000.0,
+					"percent_change_24h": 7.5,
+				},
+				"ethereum": map[string]interface{}{
+					"price":              1600.0,
+					"market_cap":         195000000000.0,
+					"volume_24h":         40000000000.0,
+					"percent_change_24h": 10.0,
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Etag", "test-etag-123")
+			_ = json.NewEncoder(w).Encode(priceResponse)
+		}))
+		defer server.Close()
+
+		config := ServiceConfig{
+			User:                security.NewSensitiveString("test"),
+			Password:            security.NewSensitiveString("password"),
+			UrlOverride:         security.NewSensitiveString(server.URL),
+			AllowGzip:           false,
+			AllowETag:           true,
+			PriceUpdateInterval: 1 * time.Minute,
+			FullDataInterval:    10 * time.Minute,
+		}
+
+		fetcher := NewProxyFetcher(config, storage, NewSubscriptionManager()).(*ProxyFetcher)
+		err := fetcher.FetchPrices(context.Background())
+		require.NoError(t, err)
+
+		priceData := storage.GetPriceData()
+		require.Equal(t, 2, len(priceData))
+
+		bitcoin, ok := priceData["bitcoin"]
+		require.True(t, ok)
+		require.Equal(t, "bitcoin", bitcoin.ID)
+		require.Equal(t, 80000.0, bitcoin.Price)
+		require.Equal(t, 1600000000000.0, bitcoin.MarketCap)
+		require.Equal(t, 80000000000.0, bitcoin.Volume24h)
+		require.Equal(t, 7.5, bitcoin.PercentChange24h)
+
+		ethereum, ok := priceData["ethereum"]
+		require.True(t, ok)
+		require.Equal(t, "ethereum", ethereum.ID)
+		require.Equal(t, 1600.0, ethereum.Price)
+		require.Equal(t, 195000000000.0, ethereum.MarketCap)
+		require.Equal(t, 40000000000.0, ethereum.Volume24h)
+		require.Equal(t, 10.0, ethereum.PercentChange24h)
+
+		require.Equal(t, "test-etag-123", storage.GetPriceEtag())
+	})
+
+	t.Run("Invalid JSON response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("invalid json{"))
+		}))
+		defer server.Close()
+
+		config := ServiceConfig{
+			User:        security.NewSensitiveString("test"),
+			Password:    security.NewSensitiveString("password"),
+			UrlOverride: security.NewSensitiveString(server.URL),
+			AllowETag:   false,
+		}
+
+		fetcher := NewProxyFetcher(config, storage, NewSubscriptionManager()).(*ProxyFetcher)
+		err := fetcher.FetchPrices(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to unmarshal price data")
+	})
+
+	t.Run("ETag not modified", func(t *testing.T) {
+		storage.UpdatePriceDataWithEtag(mockPriceData, "existing-etag")
+		oldPriceData := storage.GetPriceData()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("If-None-Match") == "existing-etag" {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		config := ServiceConfig{
+			User:        security.NewSensitiveString("test"),
+			Password:    security.NewSensitiveString("password"),
+			UrlOverride: security.NewSensitiveString(server.URL),
+			AllowETag:   true,
+		}
+
+		fetcher := NewProxyFetcher(config, storage, NewSubscriptionManager()).(*ProxyFetcher)
+		err := fetcher.FetchPrices(context.Background())
+		require.NoError(t, err)
+
+		newPriceData := storage.GetPriceData()
+		require.Equal(t, len(oldPriceData), len(newPriceData))
+	})
+
+	t.Run("Server error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("Internal Server Error"))
+		}))
+		defer server.Close()
+
+		config := ServiceConfig{
+			User:        security.NewSensitiveString("test"),
+			Password:    security.NewSensitiveString("password"),
+			UrlOverride: security.NewSensitiveString(server.URL),
+		}
+
+		fetcher := NewProxyFetcher(config, storage, NewSubscriptionManager()).(*ProxyFetcher)
+		err := fetcher.FetchPrices(context.Background())
+		require.NoError(t, err)
+	})
+}
+
+func TestProxyFetcherFetchMarkets(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+	storage := NewDataStorage(db)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		marketResponse := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":                          "bitcoin",
+					"symbol":                      "btc",
+					"name":                        "Bitcoin",
+					"image":                       "https://example.com/bitcoin.png",
+					"current_price":               80000.0,
+					"market_cap":                  1600000000000.0,
+					"total_volume":                80000000000.0,
+					"price_change_percentage_24h": 7.5,
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Etag", "market-etag-456")
+		_ = json.NewEncoder(w).Encode(marketResponse)
+	}))
+	defer server.Close()
+
+	config := ServiceConfig{
+		User:        security.NewSensitiveString("test"),
+		Password:    security.NewSensitiveString("password"),
+		UrlOverride: security.NewSensitiveString(server.URL),
+		AllowETag:   true,
+	}
+
+	fetcher := NewProxyFetcher(config, storage, NewSubscriptionManager()).(*ProxyFetcher)
+	err := fetcher.FetchMarkets(context.Background())
+	require.NoError(t, err)
+
+	cryptoData := storage.GetCryptoData()
+	require.Equal(t, 1, len(cryptoData))
+	require.Equal(t, "bitcoin", cryptoData[0].ID)
+	require.Equal(t, 80000.0, cryptoData[0].CurrentPrice)
+	require.Equal(t, "market-etag-456", storage.GetCryptoEtag())
+}
+
+func TestProxyFetcherStartStop(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+	storage := NewDataStorage(db)
+
+	config := ServiceConfig{
+		User:                security.NewSensitiveString("test"),
+		Password:            security.NewSensitiveString("password"),
+		UrlOverride:         security.NewSensitiveString("http://localhost:9999"),
+		PriceUpdateInterval: 100 * time.Millisecond,
+		FullDataInterval:    200 * time.Millisecond,
+	}
+
+	fetcher := NewProxyFetcher(config, storage, NewSubscriptionManager()).(*ProxyFetcher)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	fetcher.Start(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+
+	require.Nil(t, fetcher.cancelFunc)
+}
+
+func TestProxyFetcherRefreshLoops(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+	storage := NewDataStorage(db)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == PRICES_ENDPOINT {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{})
+		} else {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"data": []interface{}{}})
+		}
+	}))
+	defer server.Close()
+
+	config := ServiceConfig{
+		User:                security.NewSensitiveString("test"),
+		Password:            security.NewSensitiveString("password"),
+		UrlOverride:         security.NewSensitiveString(server.URL),
+		PriceUpdateInterval: 100 * time.Millisecond,
+		FullDataInterval:    100 * time.Millisecond,
+	}
+
+	fetcher := NewProxyFetcher(config, storage, NewSubscriptionManager()).(*ProxyFetcher)
+
+	fetcher.StartRefreshLoops()
+	time.Sleep(350 * time.Millisecond)
+	fetcher.Stop()
+
+	require.Greater(t, requestCount, 0)
+}

--- a/services/wallet/leaderboard/models.go
+++ b/services/wallet/leaderboard/models.go
@@ -21,6 +21,8 @@ type Cryptocurrency struct {
 type PriceData struct {
 	ID               string  `json:"id,omitempty"`
 	Price            float64 `json:"current_price"`
+	MarketCap        float64 `json:"market_cap"`
+	Volume24h        float64 `json:"volume_24h"`
 	PercentChange24h float64 `json:"price_change_percentage_24h"`
 }
 

--- a/services/wallet/leaderboard/storage.go
+++ b/services/wallet/leaderboard/storage.go
@@ -157,13 +157,24 @@ func (s *DataStorage) GetCombinedData() []Cryptocurrency {
 	// Update with the latest price data where available
 	for i := range result {
 		crypto := &result[i]
-		symbol := crypto.Symbol
+		// Use the cryptocurrency ID (in lowercase) to lookup price data
+		cryptoID := strings.ToLower(crypto.ID)
 
-		// If we have updated price data for this symbol, update the cryptocurrency
-		if priceUpdate, ok := s.priceData[symbol]; ok {
+		// If we have updated price data for this crypto ID, update the cryptocurrency
+		if priceUpdate, ok := s.priceData[cryptoID]; ok {
 			// Update the price
 			if crypto.CurrentPrice != priceUpdate.Price {
 				crypto.CurrentPrice = priceUpdate.Price
+			}
+
+			// Update market cap if available
+			if priceUpdate.MarketCap != 0 {
+				crypto.MarketCap = priceUpdate.MarketCap
+			}
+
+			// Update volume if available
+			if priceUpdate.Volume24h != 0 {
+				crypto.TotalVolume = priceUpdate.Volume24h
 			}
 
 			// Update percentage change if available
@@ -227,10 +238,11 @@ func (s *DataStorage) GetLeaderboardPagePrices(page LeaderboardPage) *Leaderboar
 	}
 
 	for i := range data {
-		symbol := strings.ToUpper(data[i].Symbol)
+		// coingecko id lowercase (e.g., "bitcoin", "ethereum")
+		cryptoID := strings.ToLower(data[i].ID)
 
-		// If we have updated price data for this symbol, update the cryptocurrency
-		if priceUpdate, ok := s.priceData[symbol]; ok {
+		// If we have updated price data for this crypto ID, add it to results
+		if priceUpdate, ok := s.priceData[cryptoID]; ok {
 			priceUpdate.ID = data[i].ID
 			result.Data = append(result.Data, priceUpdate)
 		}

--- a/services/wallet/leaderboard/storage_test.go
+++ b/services/wallet/leaderboard/storage_test.go
@@ -324,3 +324,111 @@ func TestGetLeaderboardPageDatabase(t *testing.T) {
 		}
 	}
 }
+
+func TestGetCombinedDataWithPriceUpdates(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+	s := NewDataStorage(db)
+
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+	combined := s.GetCombinedData()
+	require.Equal(t, len(mockCrypto), len(combined))
+	require.Equal(t, mockCrypto[0].CurrentPrice, combined[0].CurrentPrice)
+
+	priceDataWithUpdates := map[string]PriceData{
+		"bitcoin": {
+			Price:            80000.0,
+			MarketCap:        1600000000000,
+			Volume24h:        80000000000,
+			PercentChange24h: 7.5,
+		},
+		"ethereum": {
+			Price:            1600.0,
+			MarketCap:        195000000000,
+			Volume24h:        40000000000,
+			PercentChange24h: 10.0,
+		},
+	}
+	s.UpdatePriceDataWithEtag(priceDataWithUpdates, "price-etag")
+
+	combined = s.GetCombinedData()
+	require.Equal(t, len(mockCrypto), len(combined))
+
+	require.Equal(t, priceDataWithUpdates["bitcoin"].Price, combined[0].CurrentPrice)
+	require.Equal(t, priceDataWithUpdates["bitcoin"].MarketCap, combined[0].MarketCap)
+	require.Equal(t, priceDataWithUpdates["bitcoin"].Volume24h, combined[0].TotalVolume)
+	require.Equal(t, priceDataWithUpdates["bitcoin"].PercentChange24h, combined[0].PriceChangePercentage24h)
+
+	require.Equal(t, priceDataWithUpdates["ethereum"].Price, combined[1].CurrentPrice)
+	require.Equal(t, priceDataWithUpdates["ethereum"].MarketCap, combined[1].MarketCap)
+	require.Equal(t, priceDataWithUpdates["ethereum"].Volume24h, combined[1].TotalVolume)
+	require.Equal(t, priceDataWithUpdates["ethereum"].PercentChange24h, combined[1].PriceChangePercentage24h)
+
+	require.Equal(t, mockCrypto[2].CurrentPrice, combined[2].CurrentPrice)
+	require.Equal(t, mockCrypto[2].MarketCap, combined[2].MarketCap)
+
+	priceDataWithZeros := map[string]PriceData{
+		"ripple": {Price: 2.0},
+	}
+	s.UpdatePriceDataWithEtag(priceDataWithZeros, "price-etag-2")
+
+	combined = s.GetCombinedData()
+	require.Equal(t, priceDataWithZeros["ripple"].Price, combined[3].CurrentPrice)
+	require.Equal(t, mockCrypto[3].MarketCap, combined[3].MarketCap)
+	require.Equal(t, mockCrypto[3].TotalVolume, combined[3].TotalVolume)
+	require.Equal(t, mockCrypto[3].PriceChangePercentage24h, combined[3].PriceChangePercentage24h)
+}
+
+func TestGetLeaderboardPagePricesWithIDLookup(t *testing.T) {
+	db, cleanup := setupTestWalletDB(t)
+	defer cleanup()
+	s := NewDataStorage(db)
+	s.UpdateCryptoDataWithEtag(mockCrypto, "test-etag")
+
+	priceDataWithIDs := map[string]PriceData{
+		"bitcoin": {
+			Price:            81000.0,
+			MarketCap:        1620000000000,
+			Volume24h:        82000000000,
+			PercentChange24h: 8.0,
+		},
+		"ripple": {
+			Price:            1.95,
+			MarketCap:        110000000000,
+			Volume24h:        9500000000,
+			PercentChange24h: 13.0,
+		},
+	}
+	s.UpdatePriceDataWithEtag(priceDataWithIDs, "price-etag")
+
+	rst := s.GetLeaderboardPagePrices(LeaderboardPage{
+		Page:      1,
+		PageSize:  3,
+		SortOrder: -1,
+		Currency:  "usd",
+	})
+
+	require.NotNil(t, rst)
+	require.Equal(t, 1, rst.Page)
+	require.Equal(t, 3, rst.PageSize)
+	require.Equal(t, "usd", rst.Currency)
+	require.Equal(t, -1, rst.SortOrder)
+	require.Equal(t, 1, len(rst.Data))
+
+	require.Equal(t, "bitcoin", rst.Data[0].ID)
+	require.Equal(t, priceDataWithIDs["bitcoin"].Price, rst.Data[0].Price)
+	require.Equal(t, priceDataWithIDs["bitcoin"].MarketCap, rst.Data[0].MarketCap)
+	require.Equal(t, priceDataWithIDs["bitcoin"].Volume24h, rst.Data[0].Volume24h)
+
+	rst2 := s.GetLeaderboardPagePrices(LeaderboardPage{
+		Page:      2,
+		PageSize:  3,
+		SortOrder: -1,
+		Currency:  "usd",
+	})
+
+	require.NotNil(t, rst2)
+	require.Equal(t, 1, len(rst2.Data))
+	require.Equal(t, "ripple", rst2.Data[0].ID)
+	require.Equal(t, priceDataWithIDs["ripple"].Price, rst2.Data[0].Price)
+}

--- a/services/wallet/leaderboard/storage_test.go
+++ b/services/wallet/leaderboard/storage_test.go
@@ -62,16 +62,22 @@ var mockCrypto = []Cryptocurrency{
 }
 
 var mockPriceData = map[string]PriceData{
-	"BTC": {
+	"bitcoin": {
 		Price:            79451,
+		MarketCap:        1577274527423,
+		Volume24h:        78498730801,
 		PercentChange24h: 6.49692,
 	},
-	"ETH": {
+	"ethereum": {
 		Price:            1576.35,
+		MarketCap:        190254450318,
+		Volume24h:        38689205530,
 		PercentChange24h: 9.82681,
 	},
-	"ADA": {
+	"cardano": {
 		Price:            0.3742,
+		MarketCap:        13200401234.55,
+		Volume24h:        238203495.91,
 		PercentChange24h: 0.0041,
 	},
 }
@@ -88,6 +94,8 @@ func insertCryptoDataToDatabase(t *testing.T, db *sql.DB, cryptoData []Cryptocur
 func verifyCryptoPriceData(t *testing.T, expected PriceData, actual Cryptocurrency) {
 	t.Helper()
 	require.Equal(t, expected.Price, actual.CurrentPrice)
+	require.Equal(t, expected.MarketCap, actual.MarketCap)
+	require.Equal(t, expected.Volume24h, actual.TotalVolume)
 	require.Equal(t, expected.PercentChange24h, actual.PriceChangePercentage24h)
 }
 
@@ -186,8 +194,8 @@ func TestGetLeaderboardPageWithUpdatedPrices(t *testing.T) {
 		require.Equal(t, "usd", rst.Currency)
 		require.Equal(t, 3, len(rst.Data))
 		require.Equal(t, mockCrypto[2], rst.Data[2])
-		verifyCryptoPriceData(t, mockPriceData["BTC"], rst.Data[0])
-		verifyCryptoPriceData(t, mockPriceData["ETH"], rst.Data[1])
+		verifyCryptoPriceData(t, mockPriceData["bitcoin"], rst.Data[0])
+		verifyCryptoPriceData(t, mockPriceData["ethereum"], rst.Data[1])
 	}
 }
 

--- a/services/wallet/thirdparty/http_client.go
+++ b/services/wallet/thirdparty/http_client.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -181,6 +182,15 @@ func (c *HTTPClient) doGetRequest(ctx context.Context, url string, params netUrl
 	defer resp.Body.Close()
 
 	if mods.etag != "" && resp.StatusCode == http.StatusNotModified {
+		return
+	}
+
+	// A non-2xx status code doesn't cause an error
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		err = fmt.Errorf("HTTP request failed with status code: %d", resp.StatusCode)
+		logutils.ZapLogger().Debug("GET request returned non-2xx status",
+			zap.String("url", url),
+			zap.Int("status", resp.StatusCode))
 		return
 	}
 


### PR DESCRIPTION
Fixes price data retrieval from leaderboard API:
- Changed lookup key from uppercase symbols (BTC/ETH) to lowercase coingecko IDs (bitcoin/ethereum) 
- Added market_cap and volume_24h fields to PriceData
- Updated GetCombinedData to use ID-based lookup
- Fixed tests to match new data structure

fixes status-im/status-desktop#19197

Issue arose after switching on market-proxy side from Binance Websocket data to Coingecko. 
