### PR TITLE
fix(backup): if backup path is `content://`, use default data dir

### DIFF
--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -260,7 +261,7 @@ func (n *StatusNode) StartLocalBackup() error {
 		}
 
 		var backupDir string
-		if backupPath != "" {
+		if backupPath != "" && !strings.HasPrefix(backupPath, "content://") {
 			backupDir = backupPath
 		} else {
 			backupDir = filepath.Join(n.config.RootDataDir, "backups")


### PR DESCRIPTION
Needed for #https://github.com/status-im/status-desktop/issues/19082

The issue is that on Android, we cannot write directly to `content://`, we need to use the Android Filesystem. So to remedy this, we save to the data dir, which is inside the sandbox, so always available. We then return that path.

It's the job of the client afterwards to copy that file to the wanted folder using the SAF
