### PR TITLE
fix(newsfeed): fix race conditon where news could be fetched before the ac was available

### DIFF
--- a/node/status_node_services.go
+++ b/node/status_node_services.go
@@ -434,7 +434,7 @@ func (b *StatusNode) NewsFeedService() *newsfeed.Service {
 			nil,
 		)
 
-		if wakuext := b.WakuV2ExtService(); wakuext != nil {
+		if wakuext := b.WakuV2ExtService(); wakuext != nil && wakuext.Messenger() != nil {
 			ac := NewNewsFeedActivityCenterAdapter(wakuext.Messenger())
 			b.newsfeedSrvc.SetActivityCenter(ac)
 		}

--- a/services/newsfeed/service.go
+++ b/services/newsfeed/service.go
@@ -33,18 +33,24 @@ type Service struct {
 	storage         Persistence
 	ac              ActivityCenter
 	newsFeedManager *newsfeed.NewsFeedManager
+	started         bool
 }
 
 func NewService(logger *zap.Logger, storage Persistence, ac ActivityCenter) *Service {
 	service := &Service{
 		logger:  logger,
 		storage: storage,
+		started: false,
 	}
 	service.SetActivityCenter(ac)
 	return service
 }
 
 func (s *Service) Start() error {
+	if isNil(s.ac) || s.started {
+		// Cannot start the service without an Activity Center reference
+		return nil
+	}
 	lastFetched, err := s.storage.GetLastFetchedTimestamp()
 	if err != nil {
 		return err
@@ -99,6 +105,10 @@ func (s *Service) SetActivityCenter(ac ActivityCenter) {
 		s.ac = nil
 	} else {
 		s.ac = ac
+		err := s.Start() // We can now start the service
+		if err != nil {
+			s.logger.Error("SetActivityCenter: failed to start service", zap.Error(err))
+		}
 	}
 }
 


### PR DESCRIPTION
Needed to fix #19176

The fix Igor did helped, but there was still a race condition where the AC could be nil when a news was fetched.

This is fixed by making sure a non-null AC is passed and waiting to start the service only when the AC is available
