### PR TITLE
ci: use BUILD_TAG in functional tests image identifier

### DIFF
--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -46,6 +46,11 @@ docker build . \
   --build-arg "enable_go_cache=false" \
   --tag "${image_name}"
 
+if [[ $? -ne 0 ]]; then
+    echo -e "${RED}Docker build failed. Exiting.${RST}"
+    exit 1
+fi
+
 # Run docker
 echo -e "${GRN}Running status-go external dependencies${RST}"
 docker compose -p ${project_name} ${all_compose_files} up -d --build --remove-orphans

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -30,7 +30,7 @@ mkdir -p "${test_results_path}"
 mkdir -p "${logs_path}"
 
 all_compose_files="-f ${root_path}/docker-compose.anvil.yml -f ${root_path}/docker-compose.waku.yml"
-identifier=${BUILD_ID:-$(git rev-parse --short HEAD)}
+identifier=${BUILD_TAG:-$(git rev-parse --short HEAD)}
 project_name="status-go-func-tests-${identifier}"
 image_name="statusgo-${identifier}"
 

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -30,13 +30,13 @@ mkdir -p "${test_results_path}"
 mkdir -p "${logs_path}"
 
 all_compose_files="-f ${root_path}/docker-compose.anvil.yml -f ${root_path}/docker-compose.waku.yml"
-identifier=${BUILD_TAG:-$(git rev-parse --short HEAD)}
-project_name="status-go-func-tests-${identifier}"
-image_name="statusgo-${identifier}"
+identifier=${BUILD_TAG:-"status-go-func-tests-$(git rev-parse --short HEAD)"}
+project_name="${identifier,,}"
+image_name="statusgo-${identifier,,}"
 
 # Remove orphans
 echo -e "${GRN}Cleanup old containers${RST}"
-docker ps -a --filter "name=status-go-func-tests-${identifier}" --filter "status=exited" -q | xargs -r docker rm -f
+docker ps -a --filter "name=${project_name}" --filter "status=exited" -q | xargs -r docker rm -f
 
 # Build statusgo image
 echo -e "${GRN}Building status-go${RST}"


### PR DESCRIPTION
Iterates https://github.com/status-im/status-go/issues/7103

# Description

Use `BUILD_TAG` instead of `BUILD_ID`, because the latter is is just the build number, like `3`. 
This was leading to conflicts between different PRs.