### PR TITLE
docs_: Fix broken link to Status Desktop in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # status-go
 
-`status-go` is the backbone library of [Status Desktop](github.com/status-im/status-desktop) and [Status Mobile](https://github.com/status-im/status-mobile). It acts as a "backend" for both applications and implements most of the Status apps business logic. 
+`status-go` is the backbone library of [Status Desktop](https://github.com/status-im/status-desktop) and [Status Mobile](https://github.com/status-im/status-mobile). It acts as a "backend" for both applications and implements most of the Status apps business logic. 
 
 A comprehensive list of `status-go` functionality can be found in [Brief overview](https://www.notion.so/WIP-Brief-overview-1578f96fb65c8042a166ecd79a6b1cb6?pvs=4).
 


### PR DESCRIPTION
Fix broken link to [Status Desktop](https://github.com/status-im/status-desktop) in README.md