### PR TITLE
fix(ens_usernames): remove duplicated status ens domain

### DIFF
--- a/appdatabase/migrations/sql/1762805165_remove-double-ens-domain.up.sql
+++ b/appdatabase/migrations/sql/1762805165_remove-double-ens-domain.up.sql
@@ -1,0 +1,6 @@
+-- This migration updates the ens_usernames table to fix entries when the Status domain was set twice
+-- eg: test.stateofus.eth.stateofus.eth is changed to test.stateofus.eth
+
+UPDATE ens_usernames
+SET username = REPLACE(username, '.stateofus.eth.stateofus.eth', '.stateofus.eth')
+WHERE username LIKE '%.stateofus.eth.stateofus.eth';

--- a/services/ens/api.go
+++ b/services/ens/api.go
@@ -7,6 +7,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/url"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -37,6 +39,23 @@ func NewAPI(rpcClient *rpc.Client, accountsManager *accsmanagement.AccountsManag
 		timeSource:         timeSource,
 		syncUserDetailFunc: syncUserDetailFunc,
 	}
+}
+
+func ValidateUsername(username string) error {
+	// Validate ENS name format: allows subdomains (e.g., subdomain.domain.eth)
+	ensPattern := `^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.eth$`
+	matched, err := regexp.MatchString(ensPattern, username)
+	if err != nil {
+		return fmt.Errorf("failed to validate username: %w", err)
+	}
+	if !matched {
+		return fmt.Errorf("user name must be a valid ENS name ending with .eth")
+	}
+	// Make sure the username does not end with .stateofus.eth.stateofus.eth, which happens due to a bug in some older clients
+	if strings.HasSuffix(username, ".stateofus.eth.stateofus.eth") {
+		return fmt.Errorf("user name must not have a duplicated domain")
+	}
+	return nil
 }
 
 type URI struct {
@@ -78,6 +97,9 @@ func (api *API) GetEnsUsernames(ctx context.Context) ([]*UsernameDetail, error) 
 }
 
 func (api *API) Add(ctx context.Context, chainID uint64, username string) error {
+	if err := ValidateUsername(username); err != nil {
+		return err
+	}
 	ud := &UsernameDetail{Username: username, ChainID: chainID, Clock: api.unixTime()}
 	err := api.db.AddEnsUsername(ud)
 	if err != nil {

--- a/services/ens/api_test.go
+++ b/services/ens/api_test.go
@@ -151,3 +151,77 @@ func TestResourceURL(t *testing.T) {
 	require.Equal(t, "noahzinsmeister.com", uri.Host)
 	require.Equal(t, "", uri.Path)
 }
+
+func TestValidateUsername(t *testing.T) {
+	testCases := []struct {
+		name        string
+		username    string
+		expectedErr bool
+		errContains string
+	}{
+		{
+			name:        "valid username with .eth",
+			username:    "validusername.eth",
+			expectedErr: false,
+		},
+		{
+			name:        "valid username with subdomain",
+			username:    "sub.validusername.eth",
+			expectedErr: false,
+		},
+		{
+			name:        "valid stateofus username",
+			username:    "username.stateofus.eth",
+			expectedErr: false,
+		},
+		{
+			name:        "invalid - no .eth suffix",
+			username:    "invalidusername",
+			expectedErr: true,
+			errContains: "user name must be a valid ENS name ending with .eth",
+		},
+		{
+			name:        "invalid - .com suffix",
+			username:    "username.com",
+			expectedErr: true,
+			errContains: "user name must be a valid ENS name ending with .eth",
+		},
+		{
+			name:        "invalid - duplicated stateofus domain",
+			username:    "username.stateofus.eth.stateofus.eth",
+			expectedErr: true,
+			errContains: "must not have a duplicated domain",
+		},
+		{
+			name:        "invalid - duplicated stateofus domain with subdomain",
+			username:    "sub.username.stateofus.eth.stateofus.eth",
+			expectedErr: true,
+			errContains: "must not have a duplicated domain",
+		},
+		{
+			name:        "invalid - empty string should fail",
+			username:    "",
+			expectedErr: true,
+			errContains: "user name must be a valid ENS name ending with .eth",
+		},
+		{
+			name:        "invalid - only .eth",
+			username:    ".eth",
+			expectedErr: true, // This is technically valid per the current implementation
+			errContains: "user name must be a valid ENS name ending with .eth",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateUsername(tc.username)
+
+			if tc.expectedErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/18619

We had an issue in Desktop where we would append the status ENS domain twice and then add it to the DB. This fixes past issues using a migration.
