### PR TITLE
fix(messenger_handler): ignore messages from dismissed contacts

### DIFF
--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -571,12 +571,79 @@ func (s *MessengerContactRequestSuite) TestAliceTriesToSpamBobWithContactRequest
 	s.Require().Equal(common.ContactRequestStatePending, contactRequest.ContactRequestState)
 	s.Require().Equal(request.Message, contactRequest.Text)
 
-	// We should not receive a CR from a rejected contact
+	// We should not receive a CR or an AC notification from a rejected contact
 	_, err = WaitOnMessengerResponse(
 		bob,
 		func(r *MessengerResponse) bool {
-			return len(r.Messages()) > 0 &&
-				s.findFirstByContentType(resp.Messages(), protobuf.ChatMessage_CONTACT_REQUEST) != nil
+			return (len(r.Messages()) > 0 &&
+				s.findFirstByContentType(r.Messages(), protobuf.ChatMessage_CONTACT_REQUEST) != nil) ||
+				len(r.ActivityCenterNotifications()) > 0
+		},
+		"no messages",
+	)
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "no messages")
+}
+
+// The scenario tested is as follow:
+// 1) Alice sends a contact request to Bob
+// 2) Bob declines the contact request
+// 3) Alice blocks Bob
+// 4) Alice unblocks Bob (this retracts the contact request and allows sending a new one)
+// 5) Alice sends a new contact request to Bob but Bob still doesn't get bothered
+func (s *MessengerContactRequestSuite) TestAliceTriesToSpamBobWithContactRequestsByBlocking() {
+	messageTextAlice := "You wanna play with fire, Bobby?!"
+	alice := s.m
+
+	bob := s.newMessenger()
+	defer TearDownMessenger(&s.Suite, bob)
+	bobID := bob.IdentityPublicKeyString()
+
+	// Alice sends a contact request to Bob
+	request := &requests.SendContactRequest{
+		ID:      bobID,
+		Message: messageTextAlice,
+	}
+	s.sendContactRequest(request, alice)
+
+	contactRequest := s.receiveContactRequest(messageTextAlice, bob)
+	s.Require().NotNil(contactRequest)
+
+	// Bob declines the contact request
+	s.declineContactRequest(contactRequest, bob)
+
+	// Alice blocks Bob
+	_, err := alice.BlockContact(context.Background(), bobID, false)
+	s.Require().NoError(err)
+	s.Require().Len(alice.BlockedContacts(), 1)
+	s.Require().Equal(bobID, alice.BlockedContacts()[0].ID)
+
+	// Alice unblocks Bob
+	_, err = alice.UnblockContact(bobID)
+	s.Require().NoError(err)
+	s.Require().Len(alice.BlockedContacts(), 0)
+
+	// Alice sends a new contact request
+	resp, err := alice.SendContactRequest(context.Background(), request)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	// Check CR and mutual state update messages
+	s.Require().Len(resp.Messages(), 2)
+
+	contactRequest = s.findFirstByContentType(resp.Messages(), protobuf.ChatMessage_CONTACT_REQUEST)
+	s.Require().NotNil(contactRequest)
+
+	s.Require().Equal(common.ContactRequestStatePending, contactRequest.ContactRequestState)
+	s.Require().Equal(request.Message, contactRequest.Text)
+
+	// We should not receive a CR or an AC notification from a rejected contact
+	_, err = WaitOnMessengerResponse(
+		bob,
+		func(r *MessengerResponse) bool {
+			return (len(r.Messages()) > 0 &&
+				s.findFirstByContentType(r.Messages(), protobuf.ChatMessage_CONTACT_REQUEST) != nil) ||
+				len(r.ActivityCenterNotifications()) > 0
 		},
 		"no messages",
 	)
@@ -678,7 +745,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequestTwice()
 		theirMessenger,
 		func(r *MessengerResponse) bool {
 			return len(r.Messages()) > 0 &&
-				s.findFirstByContentType(resp.Messages(), protobuf.ChatMessage_CONTACT_REQUEST) != nil
+				s.findFirstByContentType(r.Messages(), protobuf.ChatMessage_CONTACT_REQUEST) != nil
 		},
 		"no messages",
 	)

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -577,7 +577,8 @@ func (s *MessengerContactRequestSuite) TestAliceTriesToSpamBobWithContactRequest
 		func(r *MessengerResponse) bool {
 			return (len(r.Messages()) > 0 &&
 				s.findFirstByContentType(r.Messages(), protobuf.ChatMessage_CONTACT_REQUEST) != nil) ||
-				len(r.ActivityCenterNotifications()) > 0
+				len(r.ActivityCenterNotifications()) > 0 ||
+				len(r.Chats()) > 0
 		},
 		"no messages",
 	)
@@ -643,7 +644,8 @@ func (s *MessengerContactRequestSuite) TestAliceTriesToSpamBobWithContactRequest
 		func(r *MessengerResponse) bool {
 			return (len(r.Messages()) > 0 &&
 				s.findFirstByContentType(r.Messages(), protobuf.ChatMessage_CONTACT_REQUEST) != nil) ||
-				len(r.ActivityCenterNotifications()) > 0
+				len(r.ActivityCenterNotifications()) > 0 ||
+				len(r.Chats()) > 0
 		},
 		"no messages",
 	)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1040,7 +1040,7 @@ func (m *Messenger) handleRetractContactRequest(state *ReceivedMessageState, con
 	m.logger.Debug("handling retracted contact request", zap.Uint64("clock", message.Clock))
 	r := contact.ContactRequestRetracted(message.Clock, false)
 	if !r.Processed() {
-		m.logger.Debug("not handling retract since clock lower")
+		m.logger.Debug("not handling retract since clock lower or already retracted")
 		return nil
 	}
 

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -1044,6 +1044,13 @@ func (m *Messenger) handleRetractContactRequest(state *ReceivedMessageState, con
 		return nil
 	}
 
+	m.allContacts.Store(contact.ID, contact)
+
+	if contact.Dismissed() {
+		// We dismissed this contact request locally already, no need to proceed
+		return nil
+	}
+
 	// System message for mutual state update
 	chat, clock, err := m.getOneToOneAndNextClock(contact)
 	if err != nil {
@@ -1095,8 +1102,6 @@ func (m *Messenger) handleRetractContactRequest(state *ReceivedMessageState, con
 		m.logger.Warn("failed to create activity center notification", zap.Error(err))
 		return err
 	}
-
-	m.allContacts.Store(contact.ID, contact)
 
 	return nil
 }
@@ -2185,6 +2190,11 @@ func (m *Messenger) handleChatMessage(state *ReceivedMessageState, forceSeen boo
 	}
 
 	contact := state.CurrentMessageState.Contact
+
+	if chat.ChatType == ChatTypeOneToOne && contact.Dismissed() {
+		m.logger.Info("ignoring one on one messages dismissed contacts")
+		return nil
+	}
 
 	if receivedMessage.ContentType == protobuf.ChatMessage_DISCORD_MESSAGE {
 		discordMessage := receivedMessage.GetDiscordMessage()


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/18674

We still had edge cases where we accepted messages/requests from dismissed contacts.

The principle was ok, because it makes sense to receive messages from non-contacts, because we need to receive contact requests, but when the contact is dismissed, we shouldn't accept anymore messages from them, since we do not want those requests (there was a way to send more than one request).

I'm not sure if it fixes the issue mentioned above, because I don't exactly know the reproduction steps. It's possible that the problem were the waku backups, but those don't exist anymore.
I'll try this PR over next days to see if it happens again