### PR TITLE
refactor(emoji): change API to accept hexcodes instead + clean up

### DIFF
--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -940,7 +940,7 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) testViewChannelPermissions(v
 		if viewersCanAddReactions {
 			s.Require().NoError(err)
 			s.Require().Len(response.EmojiReactions(), 1)
-			s.Require().Equal(response.EmojiReactions()[0].Type, protobuf.EmojiReaction_THUMBS_UP)
+			s.Require().Equal(response.EmojiReactions()[0].Emoji, "1f44d")
 		} else {
 			s.Require().Error(err)
 			s.Require().Len(response.EmojiReactions(), 0)

--- a/protocol/emoji_reaction.go
+++ b/protocol/emoji_reaction.go
@@ -14,9 +14,9 @@ import (
 	"github.com/status-im/status-go/protocol/protobuf"
 )
 
-// There is no foolproof way to validate emojis, but this regex should cover all standard emojis
-// it will also allow some non-emoji unicode characters, but that's not a big issue
-var emojiRegex = regexp.MustCompile("(?:\u00A9|\u00AE|[\u2000-\u3300]|[\U0001F000-\U0001FBFF])")
+// Validates that the emoji string is a valid hex string (used for emojis hexcodes
+// eg: 1f385-1f3fe
+var emojiRegex = regexp.MustCompile("[a-f0-9\\-]+")
 
 // EmojiReaction represents an emoji reaction from a user in the application layer, used for persistence, querying and
 // signaling

--- a/protocol/messenger_emoji_reactions.go
+++ b/protocol/messenger_emoji_reactions.go
@@ -57,8 +57,7 @@ func (m *Messenger) CheckMaxNumberOfEmojiReactionsPerMessage(chatID string, mess
 	return nil
 }
 
-// TODO remove emojiID once the client supports sending custom emojis
-func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID string, emojiID protobuf.EmojiReaction_Type, emoji string) (*MessengerResponse, error) {
+func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID string, emoji string) (*MessengerResponse, error) {
 	var response MessengerResponse
 
 	chat, ok := m.allChats.Load(chatID)
@@ -68,10 +67,7 @@ func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID str
 	clock, _ := chat.NextClockAndTimestamp(m.getTimesource())
 
 	if emoji == "" {
-		emoji = ConvertEmojiIDToString(emojiID)
-		if emoji == "" {
-			return nil, errors.New("invalid emojiID")
-		}
+		return nil, errors.New("no emoji provided")
 	}
 
 	// Validate that the emoji is valid
@@ -89,7 +85,7 @@ func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID str
 			Clock:     clock,
 			MessageId: messageID,
 			ChatId:    chatID,
-			Type:      emojiID,
+			Type:      protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE,
 			Emoji:     emoji,
 		},
 		LocalChatID: chatID,

--- a/protocol/messenger_emoji_reactions.go
+++ b/protocol/messenger_emoji_reactions.go
@@ -19,17 +19,17 @@ const maxEmojiReactionsPerMessage = 20
 func ConvertEmojiIDToString(emojiID protobuf.EmojiReaction_Type) string {
 	switch emojiID {
 	case protobuf.EmojiReaction_LOVE:
-		return "❤️"
+		return "2764"
 	case protobuf.EmojiReaction_THUMBS_UP:
-		return "👍"
+		return "1f44d"
 	case protobuf.EmojiReaction_THUMBS_DOWN:
-		return "👎"
+		return "1f44e"
 	case protobuf.EmojiReaction_LAUGH:
-		return "😂"
+		return "1f602"
 	case protobuf.EmojiReaction_SAD:
-		return "😢"
+		return "1f622"
 	case protobuf.EmojiReaction_ANGRY:
-		return "😠"
+		return "1f620"
 	}
 
 	return ""
@@ -57,7 +57,8 @@ func (m *Messenger) CheckMaxNumberOfEmojiReactionsPerMessage(chatID string, mess
 	return nil
 }
 
-func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID string, emoji string) (*MessengerResponse, error) {
+// TODO remove emojiID once the client supports sending custom emojis
+func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID string, messageID string, emojiID protobuf.EmojiReaction_Type, emoji string) (*MessengerResponse, error) {
 	var response MessengerResponse
 
 	chat, ok := m.allChats.Load(chatID)
@@ -67,7 +68,10 @@ func (m *Messenger) SendEmojiReaction(ctx context.Context, chatID, messageID str
 	clock, _ := chat.NextClockAndTimestamp(m.getTimesource())
 
 	if emoji == "" {
-		return nil, errors.New("no emoji provided")
+		emoji = ConvertEmojiIDToString(emojiID)
+		if emoji == "" {
+			return nil, errors.New("invalid emojiID")
+		}
 	}
 
 	// Validate that the emoji is valid

--- a/protocol/messenger_emoji_test.go
+++ b/protocol/messenger_emoji_test.go
@@ -73,7 +73,7 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 	emojiID := response.EmojiReactions()[0].ID()
 
 	// Try sending a non-emoji reaction
-	_, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "haha")
+	_, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "xD")
 	s.Require().Error(err)
 
 	// Wait for the emoji to arrive to alice
@@ -86,8 +86,7 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 
 	s.Require().Len(response.EmojiReactions(), 1)
 	s.Require().Equal(response.EmojiReactions()[0].ID(), emojiID)
-	s.Require().Equal(response.EmojiReactions()[0].Type, protobuf.EmojiReaction_SAD)
-	s.Require().Equal(response.EmojiReactions()[0].Emoji, "😢")
+	s.Require().Equal(response.EmojiReactions()[0].Emoji, "1f622")
 
 	// Retract the emoji
 	response, err = bob.SendEmojiReactionRetraction(context.Background(), emojiID)
@@ -105,7 +104,6 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 
 	s.Require().Len(response.EmojiReactions(), 1)
 	s.Require().Equal(response.EmojiReactions()[0].ID(), emojiID)
-	s.Require().Equal(response.EmojiReactions()[0].Type, protobuf.EmojiReaction_SAD)
 	s.Require().True(response.EmojiReactions()[0].Retracted)
 }
 
@@ -224,7 +222,28 @@ func (s *MessengerEmojiSuite) TestMaxEmojiReactionsPerMessage() {
 	messageID := response.Messages()[0].ID
 
 	// Respond with the max amount of emojis
-	emojis := []string{"😀", "🤓", "😄", "😁", "😆", "😅", "🤣", "😂", "🥹", "🙂", "🙃", "😉", "😊", "😇", "🥰", "😍", "🤩", "😘", "😗", "☺️"}
+	emojis := []string{
+		"1f600",
+		"1f913",
+		"1f604",
+		"1f601",
+		"1f606",
+		"1f605",
+		"1f923",
+		"1f602",
+		"1f979",
+		"1f642",
+		"1f643",
+		"1f609",
+		"1f60a",
+		"1f607",
+		"1f970",
+		"1f60d",
+		"1f929",
+		"1f618",
+		"1f617",
+		"263a-fe0f",
+	}
 	for _, emoji := range emojis {
 		response, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, emoji)
 		s.Require().NoError(err)
@@ -232,7 +251,7 @@ func (s *MessengerEmojiSuite) TestMaxEmojiReactionsPerMessage() {
 	}
 
 	// Try sending one more (should fail)
-	_, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "😋")
+	_, err = bob.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "1f60b")
 	s.Require().Error(err)
 	s.Require().Equal(ErrTooManyEmojiReactionsForMessage, err)
 
@@ -249,7 +268,7 @@ func (s *MessengerEmojiSuite) TestMaxEmojiReactionsPerMessage() {
 		&protobuf.EmojiReaction{
 			MessageId:   messageID,
 			ChatId:      chat.ID,
-			Emoji:       "😋",
+			Emoji:       "1f60b",
 			Type:        protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE,
 			Clock:       123,
 			MessageType: protobuf.MessageType_PUBLIC_GROUP,
@@ -260,7 +279,7 @@ func (s *MessengerEmojiSuite) TestMaxEmojiReactionsPerMessage() {
 	s.Require().Equal(ErrTooManyEmojiReactionsForMessage, err)
 
 	// Sending an existing emoji should work
-	response, err = alice.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "😀")
+	response, err = alice.SendEmojiReaction(context.Background(), chat.ID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "1f600")
 	s.Require().NoError(err)
 	s.Require().Len(response.EmojiReactions(), 1)
 

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -978,14 +978,8 @@ func (api *PublicAPI) RegisteredForPushNotifications() (bool, error) {
 }
 
 // Emoji
-
-func (api *PublicAPI) SendEmojiReaction(ctx context.Context, chatID, messageID string, emojiID protobuf.EmojiReaction_Type) (*protocol.MessengerResponse, error) {
-	return api.service.messenger.SendEmojiReaction(ctx, chatID, messageID, emojiID, "")
-}
-
-// TODO remove SendEmojiReaction and remove the V2 when the client supports sending custom emojis
-func (api *PublicAPI) SendEmojiReactionV2(ctx context.Context, chatID, messageID string, emoji string) (*protocol.MessengerResponse, error) {
-	return api.service.messenger.SendEmojiReaction(ctx, chatID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, emoji)
+func (api *PublicAPI) SendEmojiReaction(ctx context.Context, chatID, messageID string, emoji string) (*protocol.MessengerResponse, error) {
+	return api.service.messenger.SendEmojiReaction(ctx, chatID, messageID, emoji)
 }
 
 func (api *PublicAPI) SendEmojiReactionRetraction(ctx context.Context, emojiReactionID string) (*protocol.MessengerResponse, error) {

--- a/services/ext/api.go
+++ b/services/ext/api.go
@@ -979,7 +979,7 @@ func (api *PublicAPI) RegisteredForPushNotifications() (bool, error) {
 
 // Emoji
 func (api *PublicAPI) SendEmojiReaction(ctx context.Context, chatID, messageID string, emoji string) (*protocol.MessengerResponse, error) {
-	return api.service.messenger.SendEmojiReaction(ctx, chatID, messageID, emoji)
+	return api.service.messenger.SendEmojiReaction(ctx, chatID, messageID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, emoji)
 }
 
 func (api *PublicAPI) SendEmojiReactionRetraction(ctx context.Context, emojiReactionID string) (*protocol.MessengerResponse, error) {

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -620,14 +620,9 @@ class WakuextService(Service):
         response = self.rpc_request("peerID", params)
         return response
 
-    def send_emoji_reaction(self, receiver_chat_id: str, message_id: str, emoji_id: int):
-        params = [receiver_chat_id, message_id, emoji_id]
-        response = self.rpc_request(method="sendEmojiReaction", params=params)
-        return response
-
-    def send_emoji_reaction_v2(self, chat_id: str, message_id: str, emoji: str):
+    def send_emoji_reaction(self, chat_id: str, message_id: str, emoji: str):
         params = [chat_id, message_id, emoji]
-        response = self.rpc_request(method="sendEmojiReactionV2", params=params)
+        response = self.rpc_request(method="sendEmojiReaction", params=params)
         return response
 
     def send_emoji_reaction_retraction(self, last_emoji_id: str):

--- a/tests-functional/tests/test_wakuext_message_reactions.py
+++ b/tests-functional/tests/test_wakuext_message_reactions.py
@@ -23,8 +23,8 @@ class TestMessageReactions(MessengerSteps):
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         message_id, sender_chat_id = message["id"], message["chatId"]
         receiver_chat_id = self.receiver.wakuext_service.chats()[0]["id"]
-        # Send emoji reaction (V1)
-        response = self.receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_id, 1)
+        # Send emoji reaction
+        response = self.receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_id, "2764")
         # TODO: Add more assertions on response
         self.sender.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,
@@ -39,7 +39,7 @@ class TestMessageReactions(MessengerSteps):
                 len(result) == 1,
                 result[0]["chatId"] == receiver_chat_id,
                 result[0]["messageId"] == message_id,
-                result[0]["emoji"] == "❤️",
+                result[0]["emoji"] == "2764",
             )
         )
         emoji_id = result[0]["id"]
@@ -58,8 +58,8 @@ class TestMessageReactions(MessengerSteps):
 
         response = self.sender.wakuext_service.send_one_to_one_message(self.receiver.public_key, "test_message 1")
         message_1 = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
-        # Send emoji reaction (V2)
-        response = self.receiver.wakuext_service.send_emoji_reaction_v2(receiver_chat_id, message_1["id"], "🙂")
+        # Send emoji reaction
+        response = self.receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_1["id"], "1f642")
         emoji_1_id = response["emojiReactions"][0]["id"]
         self.sender.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,
@@ -69,7 +69,7 @@ class TestMessageReactions(MessengerSteps):
 
         response = self.receiver.wakuext_service.send_one_to_one_message(self.sender.public_key, "test_message 2")
         message_2 = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
-        response = self.sender.wakuext_service.send_emoji_reaction_v2(sender_chat_id, message_2["id"], "🙁")
+        response = self.sender.wakuext_service.send_emoji_reaction(sender_chat_id, message_2["id"], "1f641")
         emoji_2_id = response["emojiReactions"][0]["id"]
         self.receiver.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,
@@ -85,13 +85,13 @@ class TestMessageReactions(MessengerSteps):
                 (
                     item["chatId"] == sender_chat_id,
                     item["messageId"] == message_2["id"],
-                    item["emoji"] == "🙁",
+                    item["emoji"] == "1f641",
                 )
             ) or all(
                 (
                     item["chatId"] == receiver_chat_id,
                     item["messageId"] == message_1["id"],
-                    item["emoji"] == "🙂",
+                    item["emoji"] == "1f642",
                 )
             )
 
@@ -109,22 +109,42 @@ class TestMessageReactions(MessengerSteps):
         receiver_chat_id = receiver.wakuext_service.chats()[0]["id"]
 
         # Send 20 emojis
-        emojis = ["😀", "🤓", "😄", "😁", "😆", "😅", "🤣", "😂", "🥹", "🙂", "🙃", "😉", "😊", "😇", "🥰", "😍", "🤩", "😘", "😗", "☺️"]
+        emojis = [
+            "1f600",
+            "1f913",
+            "1f604",
+            "1f601",
+            "1f606",
+            "1f605",
+            "1f923",
+            "1f602",
+            "1f97a",
+            "1f642",
+            "1f643",
+            "1f609",
+            "1f60a",
+            "1f607",
+            "1f970",
+            "1f60d",
+            "1f929",
+            "1f618",
+            "1f617",
+            "263a",
+        ]
         last_emoji_id = None
         for emoji in emojis:
-            response = sender.wakuext_service.send_emoji_reaction_v2(sender_chat_id, message_id, emoji)
+            response = sender.wakuext_service.send_emoji_reaction(sender_chat_id, message_id, emoji)
             assert response["emojiReactions"][0]["emoji"] == emoji
             last_emoji_id = response["emojiReactions"][0]["id"]
 
         # The 21st emoji sent should fail
         with pytest.raises(ApiResponseError, match=re.escape("too many emoji reactions for message")):
-            _ = sender.wakuext_service.send_emoji_reaction_v2(sender_chat_id, message_id, "😋")
-
+            _ = sender.wakuext_service.send_emoji_reaction(sender_chat_id, message_id, "1f60b")
         # Test retract the 20th emoji and adding a new one
         response = sender.wakuext_service.send_emoji_reaction_retraction(last_emoji_id)
 
-        response = sender.wakuext_service.send_emoji_reaction_v2(sender_chat_id, message_id, "⚓️")
-        assert response["emojiReactions"][0]["emoji"] == "⚓️"
+        response = sender.wakuext_service.send_emoji_reaction(sender_chat_id, message_id, "2693")
+        assert response["emojiReactions"][0]["emoji"] == "2693"
         new_emoji_id = response["emojiReactions"][0]["id"]
 
         # Wait for receiver to get the reaction
@@ -135,9 +155,9 @@ class TestMessageReactions(MessengerSteps):
         )
 
         # Test receiver sending the SAME type of a previous reaction (should be allowed)
-        response = receiver.wakuext_service.send_emoji_reaction_v2(receiver_chat_id, message_id, "⚓️")
+        response = receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_id, "2693")
         emoji_2_id = response["emojiReactions"][0]["id"]
-        assert response["emojiReactions"][0]["emoji"] == "⚓️"
+        assert response["emojiReactions"][0]["emoji"] == "2693"
 
         sender.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,


### PR DESCRIPTION
This is necessary, because passing the direct UTF emoji made it so that we had to let the OS show the emoji so it could look bad on some OSes. Plus using the hex makes sure we have control over the size.

This commit also removes the old V1 API because no clients use it anymore.
