### PR TITLE
chore: community related tokens should always have 18 decimals

### DIFF
--- a/appdatabase/migrations/sql/1763470000_community_tokens_decimals_update.up.sql
+++ b/appdatabase/migrations/sql/1763470000_community_tokens_decimals_update.up.sql
@@ -1,0 +1,2 @@
+-- All community tokens have 18 decimals by default and no way to have any other value (detected by the community creation contract)
+UPDATE community_tokens SET decimals = 18 WHERE type = 1;


### PR DESCRIPTION
18 decimals for community-related tokens is determined by the community creation contract.