### PR TITLE
fix(backup): mark messages as seen when importing backup

### DIFF
--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -1568,7 +1568,7 @@ func (db sqlitePersistence) backedUpMessageToUserMessageValues(message *protobuf
 		message.GetChatId(),           // local_chat_id (same as chat_id) // TODO this should be adapated if 1-1
 		messageType,                   // message_type
 		message.GetClock(),            // clock_value
-		false,                         // seen
+		true,                          // seen
 		"",                            // outgoing_status
 		jsonParsedText,                // parsed_text
 		sticker.GetPack(),             // sticker_pack


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/19369

Marking the messages as seen makes it so that when switching to the channel, either we show the actual newly fetched messages or we just show the last messages from the chat that were imported and then it's fase.