### PR TITLE
fix(connector): eth_accounts to comply with EIP-1102 standard

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -34,10 +34,12 @@ func NewAPI(s *Service) *API {
 	r.Register("eth_signTypedData_v4", commands.NewSignCommand(s.db, c))
 
 	// Accounts query and dapp permissions
-	// NOTE: Some dApps expect same behavior for both eth_accounts and eth_requestAccounts
-	accountsCommand := commands.NewRequestAccountsCommand(s.db, c)
+	// NOTE: eth_accounts returns accounts only if already permitted, without user prompt
+	// eth_requestAccounts always prompts the user for permission (EIP-1102)
+	accountsCommand := commands.NewAccountsCommand(s.db)
+	requestAccountsCommand := commands.NewRequestAccountsCommand(s.db, c)
 	r.Register("eth_accounts", accountsCommand)
-	r.Register("eth_requestAccounts", accountsCommand)
+	r.Register("eth_requestAccounts", requestAccountsCommand)
 
 	// Active chain per dapp management
 	defaultChainIDGetter := chainutils.NewNetworkManagerAdapter(s.nm)

--- a/services/connector/commands/accounts.go
+++ b/services/connector/commands/accounts.go
@@ -35,7 +35,8 @@ func (c *AccountsCommand) Execute(ctx context.Context, request RPCRequest) (inte
 	}
 
 	if dApp == nil {
-		return "", ErrDAppIsNotPermittedByUser
+		// Per EIP-1102, eth_accounts should return empty array if not permitted
+		return []string{}, nil
 	}
 
 	return FormatAccountAddressToResponse(dApp.SharedAccount), nil

--- a/services/connector/commands/accounts_test.go
+++ b/services/connector/commands/accounts_test.go
@@ -29,8 +29,8 @@ func TestFailToGetAccountForUnpermittedDApp(t *testing.T) {
 	assert.NoError(t, err)
 
 	result, err := state.cmd.Execute(state.ctx, request)
-	assert.Equal(t, ErrDAppIsNotPermittedByUser, err)
-	assert.Empty(t, result)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{}, result)
 }
 
 func TestGetAccountForPermittedDApp(t *testing.T) {

--- a/tests-functional/tests/test_status_connector.py
+++ b/tests-functional/tests/test_status_connector.py
@@ -54,14 +54,26 @@ class TestStatusConnector:
         assert message.get("result") == hex(backend.network_id)
 
     def test_connect_and_accounts(self, backend, connector, wallet_account):
-        # Request accounts through connector
+        # eth_accounts returns empty array when not connected (per EIP-1102)
         connector.eth_accounts()
+        message = connector.receive()
+        assert message.get("result") == []
+
+        # Use eth_requestAccounts to trigger connection request
+        connector.eth_request_accounts()
         # And accept connection request
         accept_connector(backend, connector, wallet_account)
 
         # Receive accounts on connector
         message = connector.receive()
         assert message.get("result") is not None
+        accounts = message.get("result")
+        assert len(accounts) == 1
+        assert accounts[0] == wallet_account
+
+        # Now eth_accounts should return the connected account
+        connector.eth_accounts()
+        message = connector.receive()
         accounts = message.get("result")
         assert len(accounts) == 1
         assert accounts[0] == wallet_account
@@ -86,7 +98,7 @@ class TestStatusConnector:
             connector.receive()
 
         # Establish connection
-        connector.eth_accounts()
+        connector.eth_request_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
@@ -105,7 +117,7 @@ class TestStatusConnector:
             connector.receive()
 
         # Establish connection
-        connector.eth_accounts()
+        connector.eth_request_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
@@ -124,7 +136,7 @@ class TestStatusConnector:
             connector.receive()
 
         # Establish connection
-        connector.eth_accounts()
+        connector.eth_request_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
@@ -144,7 +156,7 @@ class TestStatusConnector:
             connector.receive()
 
         # Establish connection
-        connector.eth_accounts()
+        connector.eth_request_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
@@ -164,7 +176,7 @@ class TestStatusConnector:
             connector.receive()
 
         # Establish connection
-        connector.eth_accounts()
+        connector.eth_request_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
@@ -184,7 +196,7 @@ class TestStatusConnector:
             connector.receive()
 
         # Establish connection
-        connector.eth_accounts()
+        connector.eth_request_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
@@ -206,7 +218,7 @@ class TestStatusConnector:
             connector.receive()
 
         # Establish connection
-        connector.eth_accounts()
+        connector.eth_request_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
@@ -232,7 +244,7 @@ class TestStatusConnector:
             connector.receive()
 
         # Establish connection
-        connector.eth_accounts()
+        connector.eth_request_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
@@ -249,7 +261,7 @@ class TestStatusConnector:
     def test_revoke_permissions_on_disconnect(self, backend, connector, wallet_account):
         # Request accounts through connector
         # And accept connection request
-        connector.eth_accounts()
+        connector.eth_request_accounts()
         accept_connector(backend, connector, wallet_account)
         message = connector.receive()
         assert message.get("result") is not None
@@ -266,7 +278,7 @@ class TestStatusConnector:
 
     def test_unavailable_statusgo_method(self, backend, connector, wallet_account):
         # First, register the dApp by calling some proper command
-        connector.eth_accounts()
+        connector.eth_request_accounts()
         accept_connector(backend, connector, wallet_account)
         connector.receive()  # Read out the message
 


### PR DESCRIPTION
**Problem**:
Both `eth_accounts` and `eth_requestAccounts` were using the same command, causing `eth_accounts` to prompt users for permission. This violates the EIP-1102 standard.

**Solution**:
- Separated command handlers: `eth_accounts` uses `AccountsCommand`, `eth_requestAccounts` uses `RequestAccountsCommand`
- Modified `AccountsCommand` to return empty array `[]` instead of error when dApp is not permitted

closes [status-im/status-desktop#19736](https://github.com/status-im/status-desktop/issues/19376)


https://github.com/user-attachments/assets/7f574783-d9a5-49b9-bbba-e2577deaaed5


