### PR TITLE
fix(backup): return error if there is no backup path set

### DIFF
--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -259,14 +259,11 @@ func (n *StatusNode) StartLocalBackup() error {
 			return "", err
 		}
 
-		var backupDir string
-		if backupPath != "" {
-			backupDir = backupPath
-		} else {
-			backupDir = filepath.Join(n.config.RootDataDir, "backups")
+		if backupPath == "" {
+			return "", errors.New("backup path is not set")
 		}
 
-		fullPath := filepath.Join(backupDir, fmt.Sprintf("%s_user_data.bkp", compressedPubKey[len(compressedPubKey)-6:]))
+		fullPath := filepath.Join(backupPath, fmt.Sprintf("%s_user_data.bkp", compressedPubKey[len(compressedPubKey)-6:]))
 
 		return fullPath, nil
 	}

--- a/tests-functional/tests/test_local_backup.py
+++ b/tests-functional/tests/test_local_backup.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import pytest
 
@@ -6,6 +7,7 @@ from clients.status_backend import StatusBackend
 from resources.constants import Account, user_1
 from resources.test_data import profile_showcase_utils
 from utils import fake
+from clients.api import ApiResponseError
 
 test_one_to_one_chat_id = (
     "0x043329fc08727f15c4ec9a17bf7d6a3dc44e9d0d8f782a55804f3660b28827194a365dc1765cf96b6fa5cd666b9ee5298e8ac82f51f7952c4110cbf321d4f63864"
@@ -193,6 +195,11 @@ class TestLocalBackup:
 
         assert group_chat_recovered, "Group chat was not restored correctly"
         assert one_on_one_chat_recovered, "One-to-one chat was not restored correctly"
+
+        # Test that it fails if no backupPath is set
+        backend_client.settings_service.save_setting("backup-path", "")
+        with pytest.raises(ApiResponseError, match=re.escape("backup path is not set")):
+            backend_client.api_request_json("PerformLocalBackup", "")
 
         # Change the backup path (Docker restricts access to a lot of folders)
         backend_client.settings_service.save_setting("backup-path", "/usr/status-user/backups")


### PR DESCRIPTION
Needed for https://github.com/status-im/status-desktop/issues/19377

For Android, we are setting the default path to empty string so that the user can know that they need to modify it. Otherwise, the default path was the datadir and users cannot access it.

What this meant is that once the auto-backup was happening, the status-go code worked, but then it failed because of the missing user permission.

Also, less code :+1: 