### PR TITLE
refactor: complete nwaku integration (timesource)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/status-im/go-wallet-sdk v0.0.0-20251027141302-43edbd6abc92
 	github.com/waku-org/go-waku v0.10.1-0.20251003225121-06c9af60f35b
 	github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965
-	github.com/waku-org/waku-go-bindings v0.0.0-20251125210804-dbe238895a21
+	github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/status-im/go-wallet-sdk v0.0.0-20251027141302-43edbd6abc92
 	github.com/waku-org/go-waku v0.10.1-0.20251003225121-06c9af60f35b
 	github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965
-	github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3
+	github.com/waku-org/waku-go-bindings v0.0.0-20251125164942-89efd76f99d7
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/status-im/go-wallet-sdk v0.0.0-20251027141302-43edbd6abc92
 	github.com/waku-org/go-waku v0.10.1-0.20251003225121-06c9af60f35b
 	github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965
-	github.com/waku-org/waku-go-bindings v0.0.0-20251125164942-89efd76f99d7
+	github.com/waku-org/waku-go-bindings v0.0.0-20251125210804-dbe238895a21
 	github.com/wk8/go-ordered-map/v2 v2.1.7
 	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -2416,10 +2416,6 @@ github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
 github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965 h1:1xx0AQeLfxSLxuGvu7em1LrNM5lVXTU6PiuaPfTkbpA=
 github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965/go.mod h1:rC5yaoM7ee8h/zEyCGfdnYTOEhyW3jpdck7maoiRQQE=
-github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3 h1:VimYvS377VZh/b/kipnv2rp0a2r8Dd7D+4ihVd3hipI=
-github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
-github.com/waku-org/waku-go-bindings v0.0.0-20251125164942-89efd76f99d7 h1:zhw8ZvD5PFkYEfEK1/UwBARFYKxgYQ4BKhvVVCbHdtw=
-github.com/waku-org/waku-go-bindings v0.0.0-20251125164942-89efd76f99d7/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/waku-org/waku-go-bindings v0.0.0-20251125210804-dbe238895a21 h1:J/Pl4v6ryCgLhZBKI20XDjSPiKNaID9uoOmPW5/GkPc=
 github.com/waku-org/waku-go-bindings v0.0.0-20251125210804-dbe238895a21/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.6.0 h1:EAByZlHRQ3vxqzzwNi0GvEq1AjVozfWO4DMldHcoVg8=

--- a/go.sum
+++ b/go.sum
@@ -2416,8 +2416,6 @@ github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1 h1:
 github.com/waku-org/go-zerokit-rln-x86_64 v0.0.0-20230916171518-2a77c3734dd1/go.mod h1:+LeEYoW5/uBUTVjtBGLEVCUe9mOYAlu5ZPkIxLOSr5Y=
 github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965 h1:1xx0AQeLfxSLxuGvu7em1LrNM5lVXTU6PiuaPfTkbpA=
 github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965/go.mod h1:rC5yaoM7ee8h/zEyCGfdnYTOEhyW3jpdck7maoiRQQE=
-github.com/waku-org/waku-go-bindings v0.0.0-20251125210804-dbe238895a21 h1:J/Pl4v6ryCgLhZBKI20XDjSPiKNaID9uoOmPW5/GkPc=
-github.com/waku-org/waku-go-bindings v0.0.0-20251125210804-dbe238895a21/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9 h1:x4SKQ8zceFNhSBG02yULii7m/bFtGDuqX5XuahpSTCo=
 github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.6.0 h1:EAByZlHRQ3vxqzzwNi0GvEq1AjVozfWO4DMldHcoVg8=

--- a/go.sum
+++ b/go.sum
@@ -2418,6 +2418,8 @@ github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965 h1:1xx0AQ
 github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965/go.mod h1:rC5yaoM7ee8h/zEyCGfdnYTOEhyW3jpdck7maoiRQQE=
 github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3 h1:VimYvS377VZh/b/kipnv2rp0a2r8Dd7D+4ihVd3hipI=
 github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20251125164942-89efd76f99d7 h1:zhw8ZvD5PFkYEfEK1/UwBARFYKxgYQ4BKhvVVCbHdtw=
+github.com/waku-org/waku-go-bindings v0.0.0-20251125164942-89efd76f99d7/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.6.0 h1:EAByZlHRQ3vxqzzwNi0GvEq1AjVozfWO4DMldHcoVg8=
 github.com/wealdtech/go-ens/v3 v3.6.0/go.mod h1:hcmMr9qPoEgVSEXU2Bwzrn/9NczTWZ1rE53jIlqUpzw=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/go.sum
+++ b/go.sum
@@ -2418,6 +2418,8 @@ github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965 h1:1xx0AQ
 github.com/waku-org/sds-go-bindings v0.0.0-20251119184907-e78f76307965/go.mod h1:rC5yaoM7ee8h/zEyCGfdnYTOEhyW3jpdck7maoiRQQE=
 github.com/waku-org/waku-go-bindings v0.0.0-20251125210804-dbe238895a21 h1:J/Pl4v6ryCgLhZBKI20XDjSPiKNaID9uoOmPW5/GkPc=
 github.com/waku-org/waku-go-bindings v0.0.0-20251125210804-dbe238895a21/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9 h1:x4SKQ8zceFNhSBG02yULii7m/bFtGDuqX5XuahpSTCo=
+github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.6.0 h1:EAByZlHRQ3vxqzzwNi0GvEq1AjVozfWO4DMldHcoVg8=
 github.com/wealdtech/go-ens/v3 v3.6.0/go.mod h1:hcmMr9qPoEgVSEXU2Bwzrn/9NczTWZ1rE53jIlqUpzw=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/go.sum
+++ b/go.sum
@@ -2420,6 +2420,8 @@ github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3 h1:VimYv
 github.com/waku-org/waku-go-bindings v0.0.0-20251030105913-aa64c47d2bf3/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/waku-org/waku-go-bindings v0.0.0-20251125164942-89efd76f99d7 h1:zhw8ZvD5PFkYEfEK1/UwBARFYKxgYQ4BKhvVVCbHdtw=
 github.com/waku-org/waku-go-bindings v0.0.0-20251125164942-89efd76f99d7/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
+github.com/waku-org/waku-go-bindings v0.0.0-20251125210804-dbe238895a21 h1:J/Pl4v6ryCgLhZBKI20XDjSPiKNaID9uoOmPW5/GkPc=
+github.com/waku-org/waku-go-bindings v0.0.0-20251125210804-dbe238895a21/go.mod h1:v6ogkMCyQRUTazRyQR5LIouukY4/2bkjjHpnBKBxcAY=
 github.com/wealdtech/go-ens/v3 v3.6.0 h1:EAByZlHRQ3vxqzzwNi0GvEq1AjVozfWO4DMldHcoVg8=
 github.com/wealdtech/go-ens/v3 v3.6.0/go.mod h1:hcmMr9qPoEgVSEXU2Bwzrn/9NczTWZ1rE53jIlqUpzw=
 github.com/wealdtech/go-multicodec v1.4.0 h1:iq5PgxwssxnXGGPTIK1srvt6U5bJwIp7k6kBrudIWxg=

--- a/messaging/waku/nwaku.go
+++ b/messaging/waku/nwaku.go
@@ -45,17 +45,18 @@ import (
 	"github.com/waku-org/go-waku/waku/v2/api/missing"
 	"github.com/waku-org/go-waku/waku/v2/api/publish"
 	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
+	"github.com/waku-org/go-waku/waku/v2/node"
 	"github.com/waku-org/go-waku/waku/v2/onlinechecker"
 	"github.com/waku-org/go-waku/waku/v2/peermanager"
 	wps "github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
-	gowakutimesource "github.com/waku-org/go-waku/waku/v2/timesource"
 
 	"github.com/waku-org/go-waku/waku/v2/protocol/relay"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
 
 	"github.com/waku-org/waku-go-bindings/waku"
 	bindingscommon "github.com/waku-org/waku-go-bindings/waku/common"
+	wakutimesource "github.com/waku-org/waku-go-bindings/waku/timesource"
 
 	gocommon "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/connection"
@@ -65,7 +66,6 @@ import (
 	"github.com/status-im/status-go/messaging/waku/common"
 	"github.com/status-im/status-go/messaging/waku/types"
 
-	"github.com/waku-org/go-waku/waku/v2/node"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
 )
 
@@ -155,7 +155,7 @@ type Waku struct {
 
 	logger *zap.Logger
 
-	timesource gowakutimesource.Timesource
+	timesource wakutimesource.Timesource
 
 	// seededBootnodesForDiscV5 indicates whether we manage to retrieve discovery
 	// bootnodes successfully
@@ -209,7 +209,7 @@ func New(nodeKey *ecdsa.PrivateKey, cfg *Config, logger *zap.Logger, ts timesour
 		}
 	}
 
-	var wakuTimeSource gowakutimesource.Timesource
+	var wakuTimeSource wakutimesource.Timesource
 	if ts != nil {
 		wakuTimeSource = timesourceAdapter{ts}
 	} else {

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-xkIq5tJj5jYm6+DD7IHVh23jPNfrGjEWM9/3NzwLMZ8=";
+  vendorHash = "sha256-4FJc5hV+DBgEkTm14xzpaQVOuQu+ahAkIL+lde3dWHk=";
 
   inherit meta version;
 

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-t6dtjRx3xBg15WhNe7oenkPPHTZrsajvc60pWnj1OxY=";
+  vendorHash = "sha256-xkIq5tJj5jYm6+DD7IHVh23jPNfrGjEWM9/3NzwLMZ8=";
 
   inherit meta version;
 


### PR DESCRIPTION
Complete some leftovers in nwaku integration.
There will be more PRs similar to that one where we move code from go-waku to waku-go-bindings.
These PR series are inspired by a dependency highlighted by @osmaczko 

### Changes
- Use timesource from waku-go-bindings

### Issue

- https://github.com/waku-org/nwaku/issues/3076
