### PR TITLE
fix: properly return token balances fetcher from wallet service

### DIFF
--- a/api/protocol_adaptors.go
+++ b/api/protocol_adaptors.go
@@ -53,11 +53,11 @@ func (m *CommunitiesTokenManager) FindOrCreateTokenByAddress(ctx context.Context
 }
 
 type CommunitiesTokenBalanceManager struct {
-	tokenBalancesFetcher *tokenbalances.Fetcher
+	tokenBalancesFetcher tokenbalances.FetcherIface
 	tokenBalancesStorage tokenbalances.Storage
 }
 
-func NewCommunitiesTokenBalanceManager(f *tokenbalances.Fetcher, s tokenbalances.Storage) *CommunitiesTokenBalanceManager {
+func NewCommunitiesTokenBalanceManager(f tokenbalances.FetcherIface, s tokenbalances.Storage) *CommunitiesTokenBalanceManager {
 	return &CommunitiesTokenBalanceManager{tokenBalancesFetcher: f, tokenBalancesStorage: s}
 }
 

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -517,9 +517,9 @@ func (n *StatusNode) TokenManager() *token.Manager {
 	return n.tokenManager
 }
 
-func (n *StatusNode) TokenBalancesFetcher() *tokenbalances.Fetcher {
+func (n *StatusNode) TokenBalancesFetcher() tokenbalances.FetcherIface {
 	if n.walletSrvc != nil {
-		n.walletSrvc.GetTokenBalancesFetcher()
+		return n.walletSrvc.GetTokenBalancesFetcher()
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/19281
status-dekstop PR: https://github.com/status-im/status-desktop/pull/19426

I stupidly missed a return statement, causing the communities module not the be injected with the token balance fetcher dependency.

This PR fixes that.