### PR TITLE
feat(backup): implement emoji reaction backup

### DIFF
--- a/protocol/message_persistence.go
+++ b/protocol/message_persistence.go
@@ -146,7 +146,12 @@ func (db sqlitePersistence) tableUserMessagesProtobufFields() string {
 
 			m1.payment_requests,
 
-			pm.pinned_by`
+			pm.pinned_by,
+			
+			e.clock_value,
+			e.source,
+			e.emoji
+		`
 }
 
 // keep the same order as in tableUserMessagesScanAllFields
@@ -529,92 +534,6 @@ func (db sqlitePersistence) tableUserMessagesScanAllFields(row scanner, message 
 	return nil
 }
 
-// keep the same order as in tableUserMessagesProtobufFields
-func (db sqlitePersistence) tableUserMessagesScanProtobufFields(row scanner, message *protobuf.BackedUpMessage, others ...interface{}) error {
-
-	sticker := &protobuf.StickerMessage{}
-	image := &protobuf.ImageMessage{}
-	var serializedLinks []byte
-	var serializedUnfurledLinks []byte
-	var serializedPaymentRequests []byte
-	var serializedUnfurledStatusLinks []byte
-	var pinnedBy sql.NullString
-
-	args := []interface{}{
-		&message.Id,
-		&message.Timestamp,
-		&message.Clock,
-		&message.Text,
-		&message.From, // source in table
-		&message.ResponseTo,
-		&message.ChatId,
-		&message.MessageType,
-		&message.ContentType,
-
-		&sticker.Pack,
-		&sticker.Hash,
-
-		&image.Payload,
-		&image.Format,
-
-		&image.AlbumId,
-		&image.AlbumImagesCount,
-		&image.Width,
-		&image.Height,
-
-		&serializedLinks,
-		&serializedUnfurledLinks,
-		&serializedUnfurledStatusLinks,
-
-		&serializedPaymentRequests,
-
-		&pinnedBy,
-	}
-	err := row.Scan(append(args, others...)...)
-	if err != nil {
-		return err
-	}
-
-	if serializedUnfurledLinks != nil {
-		err = json.Unmarshal(serializedUnfurledLinks, &message.UnfurledLinks)
-		if err != nil {
-			return err
-		}
-	}
-
-	if serializedUnfurledStatusLinks != nil {
-		// use proto.Marshal, because json.Marshal doesn't support `oneof` fields
-		var links protobuf.UnfurledStatusLinks
-		err = proto.Unmarshal(serializedUnfurledStatusLinks, &links)
-		if err != nil {
-			return err
-		}
-		message.UnfurledStatusLinks = &links
-	}
-
-	if serializedPaymentRequests != nil {
-		err := json.Unmarshal(serializedPaymentRequests, &message.PaymentRequests)
-		if err != nil {
-			return err
-		}
-	}
-
-	if pinnedBy.Valid {
-		message.PinnedBy = pinnedBy.String
-	}
-
-	switch message.ContentType {
-	case int64(protobuf.ChatMessage_STICKER):
-		message.Payload = &protobuf.BackedUpMessage_Sticker{Sticker: sticker}
-
-	case int64(protobuf.ChatMessage_IMAGE):
-		message.Payload = &protobuf.BackedUpMessage_Image{Image: image}
-
-	}
-
-	return nil
-}
-
 func (db sqlitePersistence) tableUserMessagesAllValues(message *common.Message) ([]interface{}, error) {
 	var gapFrom, gapTo uint32
 
@@ -917,7 +836,7 @@ func (db sqlitePersistence) FirstUnseenMessageID(chatID string) (string, error) 
 			LIMIT 1`,
 		chatID).Scan(&id)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}
 	if err != nil {
@@ -1033,7 +952,7 @@ func (db sqlitePersistence) LatestPendingContactRequestIDForContact(contactID st
 			LIMIT 1
 		`, cursor),
 		contactID, protobuf.ChatMessage_CONTACT_REQUEST).Scan(&id)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}
 
@@ -1229,7 +1148,7 @@ func (db sqlitePersistence) CountActiveChattersInCommunity(communityID string, a
 			WHERE chats.community_id = ?
 			AND user_messages.timestamp >= ?
 		`, communityID, activeAfterTimestamp).Scan(&activeChattersCount)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
 	}
 	if err != nil {
@@ -1394,31 +1313,162 @@ func (db sqlitePersistence) MessageByChatIDs(chatIDs []string, currCursor string
 	return result, newCursor, nil
 }
 
+// AllMessagesForBackup fetches all messages and pins
+// with their non-retracted emoji reactions in a single query, and assembles them into
+// protobuf-backed structures suitable for backups.
 func (db sqlitePersistence) AllMessagesForBackup() ([]*protobuf.BackedUpMessage, error) {
-	where := "WHERE NOT(m1.hide) AND (discord_message_id IS NULL OR discord_message_id == '')"
 	fields := db.tableUserMessagesProtobufFields()
-	selectQuery := `SELECT    %s
-				FROM      user_messages m1
-				LEFT JOIN pin_messages pm
-				ON 	      m1.id = pm.message_id AND pm.pinned = 1`
-	query := fmt.Sprintf(selectQuery, fields) + " " + where
+	//nolint: gosec
+	query := fmt.Sprintf(`SELECT %s
+			FROM user_messages m1
+            LEFT JOIN pin_messages pm
+                ON pm.message_id = m1.id AND pm.pinned = 1
+			LEFT JOIN emoji_reactions e
+			  ON e.message_id = m1.id AND NOT(e.retracted)
+			WHERE NOT(m1.hide) AND (discord_message_id IS NULL OR discord_message_id == '')
+			ORDER BY m1.local_chat_id, m1.id, e.clock_value`, fields)
+
 	rows, err := db.db.Query(query)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return []*protobuf.BackedUpMessage{}, nil
+		}
 		return nil, err
 	}
 	defer rows.Close()
 
-	var messages []*protobuf.BackedUpMessage
+	messages := make(map[string]*protobuf.BackedUpMessage)
+	order := make([]string, 0, 128)
+
 	for rows.Next() {
-		message := &protobuf.BackedUpMessage{}
-		if err := db.tableUserMessagesScanProtobufFields(rows, message); err != nil {
+		var (
+			// message fields
+			msgID, msgSource, msgText, msgLocalChatID string
+			msgTimestamp, msgClockValue               uint64
+			msgContentType                            int64
+			msgType                                   int64
+			msgResponseTo                             string
+			pinnedBy                                  sql.NullString
+			// reaction fields (nullable)
+			rClock                        sql.NullInt64
+			rSource                       sql.NullString
+			rEmoji                        sql.NullString
+			serializedLinks               []byte
+			serializedUnfurledLinks       []byte
+			serializedPaymentRequests     []byte
+			serializedUnfurledStatusLinks []byte
+		)
+
+		sticker := &protobuf.StickerMessage{}
+		image := &protobuf.ImageMessage{}
+
+		// keep the same order as in tableUserMessagesProtobufFields
+		if err := rows.Scan(
+			&msgID,
+			&msgTimestamp,
+			&msgClockValue,
+			&msgText,
+			&msgSource,
+			&msgResponseTo,
+			&msgLocalChatID,
+			&msgType,
+			&msgContentType,
+
+			&sticker.Pack,
+			&sticker.Hash,
+
+			&image.Payload,
+			&image.Format,
+			&image.AlbumId,
+			&image.AlbumImagesCount,
+			&image.Width,
+			&image.Height,
+
+			&serializedLinks,
+			&serializedUnfurledLinks,
+			&serializedUnfurledStatusLinks,
+
+			&serializedPaymentRequests,
+
+			&pinnedBy,
+
+			&rClock,
+			&rSource,
+			&rEmoji,
+		); err != nil {
 			return nil, err
 		}
 
-		messages = append(messages, message)
+		bm, ok := messages[msgID]
+		if !ok {
+			bm = &protobuf.BackedUpMessage{
+				Id:          msgID,
+				Timestamp:   msgTimestamp,
+				Clock:       msgClockValue,
+				Text:        msgText,
+				From:        msgSource,
+				ResponseTo:  msgResponseTo,
+				ChatId:      msgLocalChatID,
+				MessageType: protobuf.MessageType(msgType),
+				ContentType: msgContentType,
+			}
+			if serializedUnfurledLinks != nil {
+				err = json.Unmarshal(serializedUnfurledLinks, &bm.UnfurledLinks)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if serializedUnfurledStatusLinks != nil {
+				// use proto.Marshal, because json.Marshal doesn't support `oneof` fields
+				var links protobuf.UnfurledStatusLinks
+				err = proto.Unmarshal(serializedUnfurledStatusLinks, &links)
+				if err != nil {
+					return nil, err
+				}
+				bm.UnfurledStatusLinks = &links
+			}
+			if serializedPaymentRequests != nil {
+				err := json.Unmarshal(serializedPaymentRequests, &bm.PaymentRequests)
+				if err != nil {
+					return nil, err
+				}
+			}
+			if pinnedBy.Valid {
+				bm.PinnedBy = pinnedBy.String
+			}
+
+			switch bm.ContentType {
+			case int64(protobuf.ChatMessage_STICKER):
+				bm.Payload = &protobuf.BackedUpMessage_Sticker{Sticker: sticker}
+
+			case int64(protobuf.ChatMessage_IMAGE):
+				bm.Payload = &protobuf.BackedUpMessage_Image{Image: image}
+
+			}
+			messages[msgID] = bm
+			order = append(order, msgID)
+		}
+
+		// Append reaction if present (LEFT JOIN may yield NULLs when none)
+		if rEmoji.Valid {
+			bm.EmojiReactions = append(bm.EmojiReactions, &protobuf.BackedUpEmojiReaction{
+				Clock: uint64(rClock.Int64),
+				From:  rSource.String,
+				Emoji: rEmoji.String,
+			})
+		}
 	}
 
-	return messages, nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Preserve row order grouping
+	result := make([]*protobuf.BackedUpMessage, 0, len(order))
+	for _, k := range order {
+		result = append(result, messages[k])
+	}
+	return result, nil
 }
 
 func (db sqlitePersistence) saveBackedUpMessages(messages []*protobuf.BackedUpMessage) error {
@@ -1508,7 +1558,85 @@ func (db sqlitePersistence) SaveBackedUpMessages(messages []*protobuf.BackedUpMe
 		return err
 	}
 
+	// Save emoji reactions attached to backed up messages
+	err = db.saveBackedUpEmojiReactions(messages)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// saveBackedUpEmojiReactions persists emoji reactions found on backed up messages.
+// Only non-retracted reactions are included in backups, so we store them directly.
+func (db sqlitePersistence) saveBackedUpEmojiReactions(messages []*protobuf.BackedUpMessage) error {
+	reactions := make([]*EmojiReaction, 0)
+	for _, msg := range messages {
+		if len(msg.EmojiReactions) == 0 {
+			continue
+		}
+		for _, er := range msg.EmojiReactions {
+			reactions = append(reactions, &EmojiReaction{
+				EmojiReaction: &protobuf.EmojiReaction{
+					Clock:       er.Clock,
+					ChatId:      msg.ChatId,
+					MessageId:   msg.Id,
+					MessageType: msg.MessageType,
+					Retracted:   false,
+					Emoji:       er.Emoji,
+				},
+				From:        er.From,
+				LocalChatID: msg.ChatId,
+			})
+		}
+	}
+	if len(reactions) == 0 {
+		return nil
+	}
+	return db.SaveEmojiReactions(reactions)
+}
+
+// SaveEmojiReactions persists multiple emoji reactions efficiently in a single transaction.
+func (db sqlitePersistence) SaveEmojiReactions(reactions []*EmojiReaction) (err error) {
+	tx, err := db.db.Begin()
+	if err != nil {
+		return
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		} else {
+			err = tx.Commit()
+		}
+	}()
+
+	query := "INSERT INTO emoji_reactions(id,clock_value,source,emoji_id,message_id,chat_id,local_chat_id,retracted,emoji) VALUES (?,?,?,?,?,?,?,?,?)"
+	stmt, err := tx.Prepare(query)
+	if err != nil {
+		return
+	}
+	defer stmt.Close()
+
+	for _, emojiReaction := range reactions {
+		if emojiReaction == nil {
+			continue
+		}
+		_, err = stmt.Exec(
+			emojiReaction.ID(),
+			emojiReaction.Clock,
+			emojiReaction.From,
+			emojiReaction.Type,
+			emojiReaction.MessageId,
+			emojiReaction.ChatId,
+			emojiReaction.LocalChatID,
+			emojiReaction.Retracted,
+			emojiReaction.Emoji,
+		)
+		if err != nil {
+			return
+		}
+	}
+	return
 }
 
 func (db sqlitePersistence) backedUpMessageToUserMessageValues(message *protobuf.BackedUpMessage) ([]interface{}, error) {
@@ -3446,7 +3574,7 @@ func (db sqlitePersistence) GetCommunityMemberAllMessages(member string, communi
 	rows, err := db.db.Query(query, communityID, member)
 
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return []*common.Message{}, nil
 		}
 

--- a/protocol/messenger_local_backup_test.go
+++ b/protocol/messenger_local_backup_test.go
@@ -91,6 +91,18 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	_, err = bob1.SendChatMessage(ctx, inputMessage)
 	s.Require().NoError(err)
 
+	// React to the first text message with an emoji and then retract it
+	respEmoji, err := bob1.SendEmojiReaction(context.Background(), chatID, inputMessage.ID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "1f601")
+	s.Require().NoError(err)
+	s.Require().Len(respEmoji.EmojiReactions(), 1)
+	firstEmojiID := respEmoji.EmojiReactions()[0].ID()
+
+	// Retract the emoji reaction
+	respRetract, err := bob1.SendEmojiReactionRetraction(context.Background(), firstEmojiID)
+	s.Require().NoError(err)
+	s.Require().Len(respRetract.EmojiReactions(), 1)
+	s.Require().True(respRetract.EmojiReactions()[0].Retracted)
+
 	// Pin message
 	pinMessage := common.NewPinMessage()
 	pinMessage.ChatId = chatID
@@ -133,6 +145,11 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 
 	_, err = bob1.SendChatMessage(ctx, imageMessage)
 	s.Require().NoError(err)
+
+	// React to the image message with an emoji (no retraction)
+	respImageEmoji, err := bob1.SendEmojiReaction(context.Background(), chatID, imageMessage.ID, protobuf.EmojiReaction_UNKNOWN_EMOJI_REACTION_TYPE, "1fae0")
+	s.Require().NoError(err)
+	s.Require().Len(respImageEmoji.EmojiReactions(), 1)
 
 	// Send sticker on community
 	stickerMessage := common.NewMessage()
@@ -341,6 +358,13 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	s.Require().True(ok)
 	s.Require().Equal(int64(protobuf.ChatMessage_IMAGE), imageMsg.ContentType)
 
+	// Emoji reactions: the first text message had a reaction retracted, so none should be present
+	s.Require().Len(textMsg.EmojiReactions, 0)
+
+	// The image message has one non-retracted emoji reaction
+	s.Require().Len(imageMsg.EmojiReactions, 1)
+	s.Require().Equal("1fae0", imageMsg.EmojiReactions[0].Emoji)
+
 	stickerMsg, ok := messageMap["some sticker"]
 	s.Require().True(ok)
 	s.Require().Equal(int64(protobuf.ChatMessage_STICKER), stickerMsg.ContentType)
@@ -366,5 +390,4 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	s.Require().NoError(err)
 	s.Require().Len(pinnedMessages, 1)
 	s.Require().Equal(bob2.selfContact.ID, pinnedMessages[0].PinnedBy)
-
 }

--- a/protocol/protobuf/pairing.proto
+++ b/protocol/protobuf/pairing.proto
@@ -500,8 +500,19 @@ message BackedUpMessage {
   repeated PaymentRequest payment_requests = 14;
 
   string pinned_by = 15;
+
+  repeated BackedUpEmojiReaction emoji_reactions = 16;
 }
 
 message BackedUpMessageBatch {
   repeated BackedUpMessage messages = 1;
+}
+
+message BackedUpEmojiReaction {
+  // clock Lamport timestamp of the chat message
+  uint64 clock = 1;
+
+  string from = 2;
+
+  string emoji = 3;
 }

--- a/tests-functional/tests/test_local_backup.py
+++ b/tests-functional/tests/test_local_backup.py
@@ -136,6 +136,24 @@ class TestLocalBackup:
         assert chats is not None, "One-to-one chat was not created (None)"
         assert len(chats) == 1, "One-to-one chat was not created (empty)"
 
+        # Send messages and add emoji reactions to validate backup/restore of reactions
+        group_msg_text = "backup emoji group"
+        one_msg_text = "backup emoji one"
+        send_response = backend_client.wakuext_service.send_group_chat_message(group_chat_id, group_msg_text)
+        assert send_response is not None, "Failed to send group message"
+        group_msg_id = send_response.get("messages", [])[0].get("id", "")
+        assert group_msg_id != "", "Failed to get group message ID"
+        send_response = backend_client.wakuext_service.send_one_to_one_message(test_one_to_one_chat_id, one_msg_text)
+        assert send_response is not None, "Failed to send one-to-one message"
+        one_msg_id = send_response.get("messages", [])[0].get("id", "")
+        assert one_msg_id != "", "Failed to get one-to-one message ID"
+
+        # Add emoji reactions (hex emoji codes)
+        response = backend_client.wakuext_service.send_emoji_reaction(group_chat_id, group_msg_id, "1f642")  # 🙂
+        assert response["emojiReactions"][0]["emoji"] == "1f642", "Failed to add emoji reaction to group message"
+        response = backend_client.wakuext_service.send_emoji_reaction(test_one_to_one_chat_id, one_msg_id, "2764")  # ❤
+        assert response["emojiReactions"][0]["emoji"] == "2764", "Failed to add emoji reaction to one-to-one message"
+
         # Validate settings on the first backend client
         result = backend_client.settings_service.get_settings()
         assert result is not None, "Settings were not set"
@@ -197,8 +215,33 @@ class TestLocalBackup:
         with pytest.raises(ApiResponseError, match=re.escape("backup path is not set")):
             backend_client.api_request_json("PerformLocalBackup", "")
 
+        # Validate emoji reactions before backup
+        result = backend_client.wakuext_service.emoji_reactions_by_chat_id_message_id(group_chat_id, group_msg_id)
+        assert result is not None, "Group chat emoji reactions not found"
+        assert all(
+            (
+                len(result) == 1,
+                result[0]["chatId"] == group_chat_id,
+                result[0]["messageId"] == group_msg_id,
+                result[0]["emoji"] == "1f642",
+            )
+        )
+        result = backend_client.wakuext_service.emoji_reactions_by_chat_id_message_id(test_one_to_one_chat_id, one_msg_id)
+        assert result is not None, "One-to-one chat emoji reactions not found"
+        assert all(
+            (
+                len(result) == 1,
+                result[0]["chatId"] == test_one_to_one_chat_id,
+                result[0]["messageId"] == one_msg_id,
+                result[0]["emoji"] == "2764",
+            )
+        )
+
         # Change the backup path (Docker restricts access to a lot of folders)
         backend_client.settings_service.save_setting("backup-path", "/usr/status-user/backups")
+
+        # Enable message sync on local backups
+        backend_client.settings_service.save_setting("messages-backup-enabled?", True)
 
         # Perform the backup
         response = backend_client.api_request_json("PerformLocalBackup", "")
@@ -287,6 +330,15 @@ class TestLocalBackup:
                 one_on_one_chat_recovered = True
         assert group_chat_recovered, "Group chat was not restored correctly"
         assert one_on_one_chat_recovered, "One-to-one chat was not restored correctly"
+
+        # Validate emoji reactions restored on the new client
+        result = backend_client2.wakuext_service.emoji_reactions_by_chat_id_message_id(group_chat_id, group_msg_id)
+        assert result is not None, "Emoji reactions for group chat not restored"
+        assert len(result) == 1 and result[0].get("emoji") == "1f642", "Group message emoji reaction was not restored correctly"
+
+        result = backend_client2.wakuext_service.emoji_reactions_by_chat_id_message_id(test_one_to_one_chat_id, one_msg_id)
+        assert result is not None, "Emoji reactions for one-to-one chat not restored"
+        assert len(result) == 1 and result[0].get("emoji") == "2764", "One-to-one message emoji reaction was not restored correctly"
 
     def test_local_backup_backwards_compatibility(self, backend_factory):
         backend_client = backend_factory()

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -173,6 +173,9 @@ class TestLocalPairing(MessengerSteps):
         self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         message_id2, clock_2 = message["id"], message["clock"]
 
+        response = bob.wakuext_service.send_emoji_reaction(alice.public_key, message_id2, "1f642")  # 🙂
+        assert response["emojiReactions"][0]["emoji"] == "1f642", "Failed to add emoji reaction to message"
+
         # Wait for the message to be delivered
         bob.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,
@@ -228,6 +231,11 @@ class TestLocalPairing(MessengerSteps):
         assert message_id2 in messages_map, "Message 2 sent before pairing not found on paired device"
         assert messages_map[message_id2]["text"] == "hello bob"
         assert messages_map[message_id2]["clock"] == clock_2, "Message 2 clock is not right on paired device"
+
+        # Validate emoji reactions restored on the new client
+        result = bob_second_device.wakuext_service.emoji_reactions_by_chat_id_message_id(alice.public_key, message_id2)
+        assert result is not None, "Emoji reactions for group chat not restored"
+        assert len(result) == 1 and result[0].get("emoji") == "1f642", "Message emoji reaction was not restored correctly"
 
     def test_pairing_server_as_receiver(self, backend_new_profile, backend_factory):
         # Create users


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/19343

Enables users to backup and sync emoji reactions along with messages during a pairing.

[emoji-backup.webm](https://github.com/user-attachments/assets/560d8c1d-653e-4479-8d4c-3b432e33651d)
