### PR TITLE
fix(cr): use default CR when not found when accepting and dismissing

### DIFF
--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -210,17 +210,16 @@ func (s *MessengerContactRequestSuite) logResponse(response *MessengerResponse, 
 	}
 }
 
-func (s *MessengerContactRequestSuite) acceptContactRequest(
-	contactRequest *common.Message, sender *Messenger, receiver *Messenger) {
+func (s *MessengerContactRequestSuite) acceptContactRequest(contactRequest *common.Message, sender *Messenger, receiver *Messenger) {
 	s.T().Log("acceptContactRequest",
 		zap.String("sender", sender.IdentityPublicKeyString()),
 		zap.String("receiver", receiver.IdentityPublicKeyString()))
 
 	// Accept contact request, receiver side
-	resp, err := receiver.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequest.ID)})
+	resp, err := receiver.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
 	s.Require().NoError(err)
 
-	// Chack updated contact request message and mutual state update
+	// Check updated contact request message and mutual state update
 	s.Require().NotNil(resp)
 	s.Require().Len(resp.Messages(), 2)
 
@@ -348,7 +347,7 @@ func (s *MessengerContactRequestSuite) createContactRequest(contactPublicKey str
 
 func (s *MessengerContactRequestSuite) declineContactRequest(contactRequest *common.Message, theirMessenger *Messenger) {
 	// Dismiss contact request, receiver side
-	resp, err := theirMessenger.DeclineContactRequest(context.Background(), &requests.DeclineContactRequest{ID: types.Hex2Bytes(contactRequest.ID)})
+	resp, err := theirMessenger.DeclineContactRequest(context.Background(), &requests.DeclineContactRequest{ID: types.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
 	s.Require().NoError(err)
 
 	// Check the contact state is correctly set
@@ -612,7 +611,7 @@ func (s *MessengerContactRequestSuite) TestAliceSeesOnlyOneAcceptFromBob() {
 	s.acceptContactRequest(contactRequest, alice, bob)
 
 	// Accept contact request again
-	_, err := bob.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequest.ID)})
+	_, err := bob.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
 	s.Require().NoError(err)
 
 	// Check we don't have extra messages on Alice's side
@@ -1615,4 +1614,36 @@ func (s *MessengerContactRequestSuite) TestBlockedContactSyncing() {
 		s.blockContactAndSync(alice1, alice2, bob)
 		s.unblockContactAndSync(alice1, alice2, bob)
 	}
+}
+
+func (s *MessengerContactRequestSuite) TestAcceptContactWithoutRequest() { //nolint: unused
+	theirMessenger := s.newMessenger()
+	defer TearDownMessenger(&s.Suite, theirMessenger)
+
+	// Send contact request but don't wait to receive it
+	request := &requests.SendContactRequest{
+		ID:      theirMessenger.myHexIdentity(),
+		Message: "hello!",
+	}
+	s.sendContactRequest(request, s.m)
+
+	contactRequest, err := s.m.createDefaultContactRequest(s.m.selfContact, s.m.getTimesource().GetCurrentTime())
+	s.Require().NoError(err)
+	resp, err := theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequest.ID), ContactID: contactRequest.From})
+	s.Require().NoError(err)
+	// Check updated contact request message and mutual state update
+	s.Require().NotNil(resp)
+	s.Require().Len(resp.Messages(), 2)
+
+	contactRequestMsg := s.findFirstByContentType(resp.Messages(), protobuf.ChatMessage_CONTACT_REQUEST)
+	s.Require().NotNil(contactRequestMsg)
+
+	mutualStateUpdate := s.findFirstByContentType(resp.Messages(), protobuf.ChatMessage_SYSTEM_MESSAGE_MUTUAL_EVENT_ACCEPTED)
+	s.Require().NotNil(mutualStateUpdate)
+
+	s.Require().Equal(contactRequestMsg.ID, contactRequest.ID)
+	s.Require().Equal(common.ContactRequestStateAccepted, contactRequestMsg.ContactRequestState)
+
+	s.Require().Equal(mutualStateUpdate.ChatId, contactRequestMsg.From)
+	s.Require().Equal(mutualStateUpdate.Text, fmt.Sprintf(outgoingMutualStateEventAcceptedDefaultText, contactRequestMsg.From))
 }

--- a/protocol/messenger_contact_verification_test.go
+++ b/protocol/messenger_contact_verification_test.go
@@ -77,7 +77,7 @@ func (s *MessengerVerificationRequests) mutualContact(theirMessenger *Messenger)
 	s.Require().Equal(contactRequests[0].ContactRequestState, common.ContactRequestStatePending)
 
 	// Accept contact request, receiver side
-	resp, err = theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequests[0].ID)})
+	resp, err = theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequests[0].ID), ContactID: contactRequests[0].From})
 	s.Require().NoError(err)
 
 	// Make sure the message is updated

--- a/protocol/messenger_contacts.go
+++ b/protocol/messenger_contacts.go
@@ -99,23 +99,52 @@ func (m *Messenger) prepareMutualStateUpdateMessage(contactID string, updateType
 	return message, nil
 }
 
-func (m *Messenger) acceptContactRequest(ctx context.Context, requestID string, fromSyncing bool) (*MessengerResponse, error) {
+func (m *Messenger) retrieveContactRequest(requestID string, contact *contacts.Contact) (*common.Message, error) {
 	contactRequest, err := m.persistence.MessageByID(requestID)
+	if err == common.ErrRecordNotFound {
+		// original requestID(Message ID) is useless since we don't sync UserMessage in this case
+		requestID = defaultContactRequestID(contact.ID)
+		contactRequest, err = m.persistence.MessageByID(requestID)
+	}
+	if err == common.ErrRecordNotFound {
+		// We still can't find the contact request, create one with default values
+		m.logger.Warn("could not find contact request message, creating a default one", zap.String("requestID", requestID), zap.String("contactID", contact.ID))
+		contactRequest, err = m.createDefaultContactRequest(contact, m.getTimesource().GetCurrentTime())
+	}
 	if err != nil {
-		m.logger.Error("could not find contact request message", zap.Error(err))
+		m.logger.Error("could not retrieve contact request message", zap.Error(err))
+		return nil, err
+	}
+	return contactRequest, nil
+}
+
+func (m *Messenger) acceptContactRequest(ctx context.Context, requestID, contactID string, fromSyncing bool) (*MessengerResponse, error) {
+	var ensName, nickname, displayName string
+	var customizationColor multiaccountscommon.CustomizationColor
+
+	contact, ok := m.allContacts.Load(contactID)
+	var err error
+	if ok {
+		ensName = contact.EnsName
+		nickname = contact.LocalNickname
+		displayName = contact.DisplayName
+		customizationColor = contact.CustomizationColor
+	} else {
+		contact, err = m.BuildContact(&requests.BuildContact{PublicKey: contactID})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	contactRequest, err := m.retrieveContactRequest(requestID, contact)
+	if err != nil {
 		return nil, err
 	}
 
 	m.logger.Info("acceptContactRequest")
 
-	var ensName, nickname, displayName string
-	customizationColor := multiaccountscommon.IDToColorFallbackToBlue(contactRequest.CustomizationColor)
-
-	if contact, ok := m.allContacts.Load(contactRequest.From); ok {
-		ensName = contact.EnsName
-		nickname = contact.LocalNickname
-		displayName = contact.DisplayName
-		customizationColor = contact.CustomizationColor
+	if customizationColor == "" {
+		customizationColor = multiaccountscommon.IDToColorFallbackToBlue(contactRequest.CustomizationColor)
 	}
 
 	response, err := m.addContact(ctx, contactRequest.From, ensName, nickname, displayName, customizationColor, contactRequest.ID, "", fromSyncing, false, false)
@@ -149,7 +178,7 @@ func (m *Messenger) AcceptContactRequest(ctx context.Context, request *requests.
 		return nil, err
 	}
 
-	response, err := m.acceptContactRequest(ctx, request.ID.String(), false)
+	response, err := m.acceptContactRequest(ctx, request.ID.String(), request.ContactID, false)
 	if err != nil {
 		return nil, err
 	}
@@ -165,23 +194,18 @@ func (m *Messenger) AcceptContactRequest(ctx context.Context, request *requests.
 func (m *Messenger) declineContactRequest(requestID, contactID string, fromSyncing bool) (*MessengerResponse, error) {
 	m.logger.Info("declineContactRequest")
 
-	contactRequest, err := m.persistence.MessageByID(requestID)
-	if err == common.ErrRecordNotFound && fromSyncing {
-		// original requestID(Message ID) is useless since we don't sync UserMessage in this case
-		requestID = defaultContactRequestID(contactID)
-		contactRequest, err = m.persistence.MessageByID(requestID)
+	contact, err := m.BuildContact(&requests.BuildContact{PublicKey: contactID})
+	if err != nil {
+		return nil, err
 	}
+
+	contactRequest, err := m.retrieveContactRequest(requestID, contact)
 	if err != nil {
 		return nil, err
 	}
 
 	response := &MessengerResponse{}
-	var contact *contacts.Contact
 	if contactRequest != nil {
-		contact, err = m.BuildContact(&requests.BuildContact{PublicKey: contactRequest.From})
-		if err != nil {
-			return nil, err
-		}
 		contactRequest.ContactRequestState = common.ContactRequestStateDismissed
 		err = m.persistence.SetContactRequestState(contactRequest.ID, contactRequest.ContactRequestState)
 		if err != nil {
@@ -206,7 +230,7 @@ func (m *Messenger) declineContactRequest(requestID, contactID string, fromSynci
 	}
 
 	// update notification with the correct status
-	notification, err := m.persistence.GetActivityCenterNotificationByID(types.FromHex(requestID))
+	notification, err := m.persistence.GetActivityCenterNotificationByID(types.FromHex(contactRequest.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +256,7 @@ func (m *Messenger) DeclineContactRequest(ctx context.Context, request *requests
 		return nil, err
 	}
 
-	response, err := m.declineContactRequest(request.ID.String(), "", false)
+	response, err := m.declineContactRequest(request.ID.String(), request.ContactID, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1219,17 +1243,30 @@ func (m *Messenger) GetLatestContactRequestForContact(contactID string) (*Messen
 	return response, nil
 }
 
+func (m *Messenger) retrieveLatestContactRequestIDForContact(contactID string) (string, error) {
+	if len(contactID) == 0 {
+		return "", ErrGetLatestContactRequestForContactInvalidID
+	}
+
+	contactRequestID, err := m.persistence.LatestPendingContactRequestIDForContact(contactID)
+	if err == common.ErrRecordNotFound {
+		// No pending request found, use a default one
+		contactRequestID = defaultContactRequestID(contactID)
+	}
+	return contactRequestID, err
+}
+
 func (m *Messenger) AcceptLatestContactRequestForContact(ctx context.Context, request *requests.AcceptLatestContactRequestForContact) (*MessengerResponse, error) {
 	if err := request.Validate(); err != nil {
 		return nil, err
 	}
 
-	contactRequestID, err := m.persistence.LatestPendingContactRequestIDForContact(request.ID.String())
+	contactRequestID, err := m.retrieveLatestContactRequestIDForContact(request.ID.String())
 	if err != nil {
 		return nil, err
 	}
 
-	return m.AcceptContactRequest(ctx, &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequestID)})
+	return m.AcceptContactRequest(ctx, &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequestID), ContactID: request.ID.String()})
 }
 
 func (m *Messenger) DismissLatestContactRequestForContact(ctx context.Context, request *requests.DismissLatestContactRequestForContact) (*MessengerResponse, error) {
@@ -1237,12 +1274,12 @@ func (m *Messenger) DismissLatestContactRequestForContact(ctx context.Context, r
 		return nil, err
 	}
 
-	contactRequestID, err := m.persistence.LatestPendingContactRequestIDForContact(request.ID.String())
+	contactRequestID, err := m.retrieveLatestContactRequestIDForContact(request.ID.String())
 	if err != nil {
 		return nil, err
 	}
 
-	return m.DeclineContactRequest(ctx, &requests.DeclineContactRequest{ID: types.Hex2Bytes(contactRequestID)})
+	return m.DeclineContactRequest(ctx, &requests.DeclineContactRequest{ID: types.Hex2Bytes(contactRequestID), ContactID: request.ID.String()})
 }
 
 func (m *Messenger) PendingContactRequests(cursor string, limit int) ([]*common.Message, string, error) {

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -311,11 +311,10 @@ func (m *Messenger) PendingNotificationContactRequest(contactID string) (*Activi
 	return m.persistence.ActiveContactRequestNotification(contactID)
 }
 
-func (m *Messenger) createContactRequestForContactUpdate(contact *contacts.Contact, messageState *ReceivedMessageState) (*common.Message, error) {
-
+func (m *Messenger) createDefaultContactRequest(contact *contacts.Contact, timestamp uint64) (*common.Message, error) {
 	contactRequest, err := m.generateContactRequest(
 		contact.ContactRequestRemoteClock,
-		messageState.CurrentMessageState.WhisperTimestamp,
+		timestamp,
 		contact,
 		defaultContactRequestText(),
 		false,
@@ -327,12 +326,21 @@ func (m *Messenger) createContactRequestForContactUpdate(contact *contacts.Conta
 	contactRequest.ID = defaultContactRequestID(contact.ID)
 
 	// save this message
-	messageState.Response.AddMessage(contactRequest)
 	err = m.persistence.SaveMessages([]*common.Message{contactRequest})
-
 	if err != nil {
 		return nil, err
 	}
+
+	return contactRequest, nil
+}
+func (m *Messenger) createContactRequestForContactUpdate(contact *contacts.Contact, messageState *ReceivedMessageState) (*common.Message, error) {
+	contactRequest, err := m.createDefaultContactRequest(contact, messageState.CurrentMessageState.WhisperTimestamp)
+	if err != nil {
+		return nil, err
+	}
+
+	// save this message
+	messageState.Response.AddMessage(contactRequest)
 
 	return contactRequest, nil
 }

--- a/protocol/messenger_profile_showcase_test.go
+++ b/protocol/messenger_profile_showcase_test.go
@@ -76,7 +76,7 @@ func (s *TestMessengerProfileShowcase) mutualContact(theirMessenger *Messenger) 
 	s.Require().Equal(contactRequests[0].ContactRequestState, common.ContactRequestStatePending)
 
 	// Accept contact request, receiver side
-	_, err = theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequests[0].ID)})
+	_, err = theirMessenger.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: types.Hex2Bytes(contactRequests[0].ID), ContactID: contactRequests[0].From})
 	s.Require().NoError(err)
 
 	// Wait for the message to reach its destination

--- a/protocol/messenger_sync_activity_center_test.go
+++ b/protocol/messenger_sync_activity_center_test.go
@@ -206,7 +206,7 @@ func (s *MessengerSyncActivityCenterSuite) addContactAndShareCommunity(userB *Me
 		return false
 	}, "contact request not received on device 2")
 	s.Require().NoError(err)
-	_, err = s.m.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: contactRequestMessageID})
+	_, err = s.m.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: contactRequestMessageID, ContactID: crypto.PubkeyToHex(&s.m2.identity.PublicKey)})
 	s.Require().NoError(err)
 	_, err = WaitOnMessengerResponse(s.m2, func(r *MessengerResponse) bool {
 		if len(r.ActivityCenterNotifications()) > 0 {

--- a/protocol/messenger_sync_contact_request_decision_test.go
+++ b/protocol/messenger_sync_contact_request_decision_test.go
@@ -74,7 +74,7 @@ func (s *MessengerSyncContactRequestDecisionSuite) TestSyncAcceptContactRequest(
 	s.Require().NoError(err)
 
 	// m accept contact request from userB
-	_, err = s.m.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: contactRequestMessageID})
+	_, err = s.m.AcceptContactRequest(context.Background(), &requests.AcceptContactRequest{ID: contactRequestMessageID, ContactID: crypto.PubkeyToHex(&s.m2.identity.PublicKey)})
 	s.Require().NoError(err)
 
 	// check sync contact request decision processed for m2

--- a/protocol/requests/accept_contact_request.go
+++ b/protocol/requests/accept_contact_request.go
@@ -7,14 +7,19 @@ import (
 )
 
 var ErrAcceptContactRequestInvalidID = errors.New("accept-contact-request: invalid id")
+var ErrAcceptContactRequestInvalidContactID = errors.New("accept-contact-request: invalid contact id")
 
 type AcceptContactRequest struct {
-	ID types.HexBytes `json:"id"`
+	ID        types.HexBytes `json:"id"`
+	ContactID string         `json:"contactId"`
 }
 
 func (a *AcceptContactRequest) Validate() error {
 	if len(a.ID) == 0 {
 		return ErrAcceptContactRequestInvalidID
+	}
+	if len(a.ContactID) == 0 {
+		return ErrAcceptContactRequestInvalidContactID
 	}
 
 	return nil

--- a/protocol/requests/decline_contact_request.go
+++ b/protocol/requests/decline_contact_request.go
@@ -7,14 +7,19 @@ import (
 )
 
 var ErrDeclineContactRequestInvalidID = errors.New("decline-contact-request: invalid id")
+var ErrDeclineContactRequestInvalidContactID = errors.New("decline-contact-request: invalid contact id")
 
 type DeclineContactRequest struct {
-	ID types.HexBytes `json:"id"`
+	ID        types.HexBytes `json:"id"`
+	ContactID string         `json:"contactId"`
 }
 
 func (a *DeclineContactRequest) Validate() error {
 	if len(a.ID) == 0 {
 		return ErrDeclineContactRequestInvalidID
+	}
+	if len(a.ContactID) == 0 {
+		return ErrDeclineContactRequestInvalidContactID
 	}
 
 	return nil

--- a/tests-functional/clients/services/wakuext.py
+++ b/tests-functional/clients/services/wakuext.py
@@ -105,8 +105,8 @@ class WakuextService(Service):
         response = self.rpc_request("sendContactRequest", params)
         return response
 
-    def accept_contact_request(self, request_id: str):
-        params = [{"id": request_id}]
+    def accept_contact_request(self, request_id: str, contact_id: str):
+        params = [{"id": request_id, "contactID": contact_id}]
         response = self.rpc_request("acceptContactRequest", params)
         return response
 
@@ -115,8 +115,8 @@ class WakuextService(Service):
         response = self.rpc_request("acceptLatestContactRequestForContact", params)
         return response
 
-    def decline_contact_request(self, request_id: str):
-        params = [{"id": request_id}]
+    def decline_contact_request(self, request_id: str, contact_id: str):
+        params = [{"id": request_id, "contactID": contact_id}]
         response = self.rpc_request("declineContactRequest", params)
         return response
 

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -42,7 +42,7 @@ class MessengerSteps(NetworkConditionsSteps):
     def accept_contact_request_and_wait_for_signal_to_be_received(self, message_id, sender=None, receiver=None):
         sender = sender or self.sender
         receiver = receiver or self.receiver
-        receiver.wakuext_service.accept_contact_request(message_id)
+        receiver.wakuext_service.accept_contact_request(message_id, sender.public_key)
         accepted_signal = f"@{receiver.public_key} accepted your contact request"
         sender.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=accepted_signal)
 

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -288,7 +288,7 @@ class TestLocalPairing(MessengerSteps):
         self.make_contacts(user_accepted, bob1)
         self.send_contact_request_and_wait_for_signal_to_be_received(user_pending, bob1)
         message_id = self.send_contact_request_and_wait_for_signal_to_be_received(user_declined, bob1)
-        bob1.wakuext_service.decline_contact_request(message_id)
+        bob1.wakuext_service.decline_contact_request(message_id, user_declined.public_key)
 
         # Pair second device
         pair_server_as_sender(bob1, bob2)

--- a/tests-functional/tests/test_wakuext_contact_requests.py
+++ b/tests-functional/tests/test_wakuext_contact_requests.py
@@ -48,7 +48,7 @@ class TestContactRequests(MessengerSteps):
 
     def test_accept_contact_request(self):
         message_id = self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.accept_contact_request(message_id)
+        response = self.receiver.wakuext_service.accept_contact_request(message_id, self.sender.public_key)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])
@@ -69,7 +69,7 @@ class TestContactRequests(MessengerSteps):
 
     def test_decline_contact_request(self):
         message_id = self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.decline_contact_request(message_id)
+        response = self.receiver.wakuext_service.decline_contact_request(message_id, self.sender.public_key)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/15930

Sometimes, the contact request message doesn't have the same ID as the contact request itself. The source is still unclear, but I think it is related to having multiple devices.

Anyway, the goal of this fix is to let users still approve or deny contact request even if they happen to run into this edge case problem. The rationale is that the user doesn't care if the message is there correctly in the DB, they want to mark the contact as approved/dismissed and possibly interact with them, which is sometimes impossible without this fix.

The fix itself is simple, if the contact request is not found in the DB at the request ID, we generate a default one instead that is then marked appropriately and the contact is also marked accordingly. A warning is thrown, but no error, so the interaction goes through for the user without them knowing that something was wrong.
