### PR TITLE
fix: incorrect detection of RPC connection types in the connector service

### DIFF
--- a/services/connector/api.go
+++ b/services/connector/api.go
@@ -11,10 +11,10 @@ import (
 )
 
 var (
-	ErrInvalidResponseFromForwardedRpc         = errors.New("invalid response from forwarded RPC")
-	ErrCannotOverrideClientIDForHttpConnection = errors.New("cannot override clientId for HTTP connection")
-	ErrNotAllowedForUntrustedConnection        = errors.New("cannot call from untrusted connection")
-	ErrEmptyClientIDFromTrustedConnection      = errors.New("trusted connection must provide a clientId")
+	ErrInvalidResponseFromForwardedRpc              = errors.New("invalid response from forwarded RPC")
+	ErrCannotOverrideClientIDForUntrustedConnection = errors.New("cannot override clientId for untrusted connection")
+	ErrNotAllowedForUntrustedConnection             = errors.New("cannot call from untrusted connection")
+	ErrEmptyClientIDFromTrustedConnection           = errors.New("trusted connection must provide a clientId")
 )
 
 type API struct {
@@ -91,7 +91,7 @@ func (api *API) CallRPC(ctx context.Context, inputJSON string) (interface{}, err
 	// This prevents external clients from spoofing ClientID to impersonate trusted clients
 	if IsUntrustedConnection(ctx) {
 		if request.ClientID != "" {
-			return "", ErrCannotOverrideClientIDForHttpConnection
+			return "", ErrCannotOverrideClientIDForUntrustedConnection
 		}
 	} else {
 		// Trusted connections MUST provide a ClientID

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -45,7 +45,7 @@ func TestCallRPC_UntrustedConnection(t *testing.T) {
 				"iconUrl": "https://example.com/icon.png",
 				"clientId": "wallet-connect"
 			}`,
-			expectError: ErrCannotOverrideClientIDForHttpConnection,
+			expectError: ErrCannotOverrideClientIDForUntrustedConnection,
 		},
 	}
 

--- a/services/connector/api_test.go
+++ b/services/connector/api_test.go
@@ -49,7 +49,7 @@ func TestCallRPC_UntrustedConnection(t *testing.T) {
 		},
 	}
 
-	ctx := WithConnectionType(context.Background(), ConnectionTypeHTTP)
+	ctx := WithConnectionType(context.Background(), ConnectionTypeUntrusted)
 	for _, tt := range tests {
 		t.Run(tt.request, func(t *testing.T) {
 			_, err := state.api.CallRPC(ctx, tt.request)
@@ -63,7 +63,7 @@ func TestCallRPC_TrustedConnectionRequiresClientID(t *testing.T) {
 	state := setupTests(t)
 
 	// Trusted connection (Internal) without ClientID should fail
-	ctx := WithConnectionType(context.Background(), ConnectionTypeInternal)
+	ctx := WithConnectionType(context.Background(), ConnectionTypeTrusted)
 
 	request := `{
 		"method": "eth_chainId",
@@ -81,7 +81,7 @@ func TestCallRPC_TrustedConnectionRequiresClientID(t *testing.T) {
 func TestCallRPC_TrustedConnectionWithClientID(t *testing.T) {
 	state := setupTests(t)
 
-	ctx := WithConnectionType(context.Background(), ConnectionTypeInternal)
+	ctx := WithConnectionType(context.Background(), ConnectionTypeTrusted)
 
 	request := `{
 		"method": "eth_chainId",
@@ -101,7 +101,7 @@ func TestChangeAccount_UntrustedConnection(t *testing.T) {
 	state := setupTests(t)
 
 	// Test untrusted connection (HTTP)
-	ctx := WithConnectionType(context.Background(), ConnectionTypeHTTP)
+	ctx := WithConnectionType(context.Background(), ConnectionTypeUntrusted)
 
 	args := commands.ChangeAccountArgs{
 		URL:      "https://example.com",
@@ -116,7 +116,7 @@ func TestChangeAccount_UntrustedConnection(t *testing.T) {
 func TestCallRPC_MethodNotAllowed(t *testing.T) {
 	state := setupTests(t)
 
-	ctx := WithConnectionType(context.Background(), ConnectionTypeHTTP)
+	ctx := WithConnectionType(context.Background(), ConnectionTypeUntrusted)
 
 	// Test a method that's not in the allowed list
 	request := `{
@@ -136,7 +136,7 @@ func TestCallRPC_MethodNotAllowed(t *testing.T) {
 func TestCallRPC_InvalidJSON(t *testing.T) {
 	state := setupTests(t)
 
-	ctx := WithConnectionType(context.Background(), ConnectionTypeHTTP)
+	ctx := WithConnectionType(context.Background(), ConnectionTypeUntrusted)
 
 	request := `invalid json`
 

--- a/services/connector/context.go
+++ b/services/connector/context.go
@@ -2,14 +2,17 @@ package connector
 
 import (
 	"context"
+
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
 )
 
 // ConnectionType represents the source of the RPC connection
 type ConnectionType string
 
 const (
-	ConnectionTypeHTTP     ConnectionType = "http"     // Untrusted - from WebSocket
-	ConnectionTypeInternal ConnectionType = "internal" // Trusted - from CallRPC (status-desktop)
+	ConnectionTypeHTTP     ConnectionType = "http"     // Untrusted - from HTTP
+	ConnectionTypeWS       ConnectionType = "ws"       // Untrusted - from WebSocket
+	ConnectionTypeInternal ConnectionType = "internal" // Trusted - from internal RPC (status-desktop)
 )
 
 // ContextKey is a type used for keys in connector Context.
@@ -28,6 +31,17 @@ func WithConnectionType(ctx context.Context, connType ConnectionType) context.Co
 
 // GetConnectionType retrieves connection type from context
 func GetConnectionType(ctx context.Context) ConnectionType {
+	// Check go-ethereum's PeerInfo first - this is set automatically by the RPC server
+	// for HTTP and WebSocket connections
+	peerInfo := gethrpc.PeerInfoFromContext(ctx)
+	if peerInfo.Transport == "ws" {
+		return ConnectionTypeWS
+	}
+	if peerInfo.Transport == "http" {
+		return ConnectionTypeHTTP
+	}
+
+	// Fall back to context property
 	if connType, ok := ctx.Value(connectionTypeKey).(ConnectionType); ok {
 		return connType
 	}
@@ -36,5 +50,6 @@ func GetConnectionType(ctx context.Context) ConnectionType {
 
 // IsUntrustedConnection checks if the connection is from HTTP/WebSocket
 func IsUntrustedConnection(ctx context.Context) bool {
-	return GetConnectionType(ctx) == ConnectionTypeHTTP
+	connType := GetConnectionType(ctx)
+	return connType == ConnectionTypeHTTP || connType == ConnectionTypeWS
 }

--- a/services/connector/context.go
+++ b/services/connector/context.go
@@ -6,13 +6,12 @@ import (
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
 )
 
-// ConnectionType represents the source of the RPC connection
+// ConnectionType represents trust level of the RPC connection
 type ConnectionType string
 
 const (
-	ConnectionTypeHTTP     ConnectionType = "http"     // Untrusted - from HTTP
-	ConnectionTypeWS       ConnectionType = "ws"       // Untrusted - from WebSocket
-	ConnectionTypeInternal ConnectionType = "internal" // Trusted - from internal RPC (status-desktop)
+	ConnectionTypeTrusted   ConnectionType = "trusted"   // IPC or explicitly set as trusted
+	ConnectionTypeUntrusted ConnectionType = "untrusted" // HTTP, WebSocket, or unknown
 )
 
 // ContextKey is a type used for keys in connector Context.
@@ -32,24 +31,21 @@ func WithConnectionType(ctx context.Context, connType ConnectionType) context.Co
 // GetConnectionType retrieves connection type from context
 func GetConnectionType(ctx context.Context) ConnectionType {
 	// Check go-ethereum's PeerInfo first - this is set automatically by the RPC server
-	// for HTTP and WebSocket connections
 	peerInfo := gethrpc.PeerInfoFromContext(ctx)
-	if peerInfo.Transport == "ws" {
-		return ConnectionTypeWS
-	}
-	if peerInfo.Transport == "http" {
-		return ConnectionTypeHTTP
+	if peerInfo.Transport == "ipc" {
+		return ConnectionTypeTrusted
 	}
 
-	// Fall back to context property
+	// Check custom context value (explicitly set connection type)
 	if connType, ok := ctx.Value(connectionTypeKey).(ConnectionType); ok {
 		return connType
 	}
-	return ConnectionTypeInternal // default to untrusted
+
+	// Default to untrusted for safety
+	return ConnectionTypeUntrusted
 }
 
-// IsUntrustedConnection checks if the connection is from HTTP/WebSocket
+// IsUntrustedConnection checks if the connection should not be trusted
 func IsUntrustedConnection(ctx context.Context) bool {
-	connType := GetConnectionType(ctx)
-	return connType == ConnectionTypeHTTP || connType == ConnectionTypeWS
+	return GetConnectionType(ctx) == ConnectionTypeUntrusted
 }

--- a/services/connector/context_test.go
+++ b/services/connector/context_test.go
@@ -12,17 +12,21 @@ func TestConnectionType(t *testing.T) {
 	require.True(t, IsUntrustedConnection(ctx))
 	require.Equal(t, ConnectionTypeHTTP, GetConnectionType(ctx))
 
+	ctx = WithConnectionType(context.Background(), ConnectionTypeWS)
+	require.True(t, IsUntrustedConnection(ctx))
+	require.Equal(t, ConnectionTypeWS, GetConnectionType(ctx))
+
 	ctx = WithConnectionType(context.Background(), ConnectionTypeInternal)
 	require.False(t, IsUntrustedConnection(ctx))
 	require.Equal(t, ConnectionTypeInternal, GetConnectionType(ctx))
 }
 
 func TestConnectionTypeDefault(t *testing.T) {
-	// Context without connection type should default to untrusted
+	// This is the case for in-process RPC calls from status-desktop
 	ctx := context.Background()
 
 	if IsUntrustedConnection(ctx) {
-		t.Error("Default connection type should be untrusted (HTTP)")
+		t.Error("Default connection type should be trusted (internal) for in-process calls")
 	}
 
 	if got := GetConnectionType(ctx); got != ConnectionTypeInternal {

--- a/services/connector/context_test.go
+++ b/services/connector/context_test.go
@@ -8,28 +8,19 @@ import (
 )
 
 func TestConnectionType(t *testing.T) {
-	ctx := WithConnectionType(context.Background(), ConnectionTypeHTTP)
+	ctx := WithConnectionType(context.Background(), ConnectionTypeUntrusted)
 	require.True(t, IsUntrustedConnection(ctx))
-	require.Equal(t, ConnectionTypeHTTP, GetConnectionType(ctx))
+	require.Equal(t, ConnectionTypeUntrusted, GetConnectionType(ctx))
 
-	ctx = WithConnectionType(context.Background(), ConnectionTypeWS)
-	require.True(t, IsUntrustedConnection(ctx))
-	require.Equal(t, ConnectionTypeWS, GetConnectionType(ctx))
-
-	ctx = WithConnectionType(context.Background(), ConnectionTypeInternal)
+	ctx = WithConnectionType(context.Background(), ConnectionTypeTrusted)
 	require.False(t, IsUntrustedConnection(ctx))
-	require.Equal(t, ConnectionTypeInternal, GetConnectionType(ctx))
+	require.Equal(t, ConnectionTypeTrusted, GetConnectionType(ctx))
 }
 
 func TestConnectionTypeDefault(t *testing.T) {
-	// This is the case for in-process RPC calls from status-desktop
+	// Default should be untrusted for safety
 	ctx := context.Background()
 
-	if IsUntrustedConnection(ctx) {
-		t.Error("Default connection type should be trusted (internal) for in-process calls")
-	}
-
-	if got := GetConnectionType(ctx); got != ConnectionTypeInternal {
-		t.Errorf("Default GetConnectionType() = %v, want %v", got, ConnectionTypeInternal)
-	}
+	require.True(t, IsUntrustedConnection(ctx))
+	require.Equal(t, ConnectionTypeUntrusted, GetConnectionType(ctx))
 }

--- a/services/connector/service.go
+++ b/services/connector/service.go
@@ -79,7 +79,7 @@ func (s *Service) Start() error {
 		}
 
 		// Inject connection type into request context
-		ctx := WithConnectionType(r.Context(), ConnectionTypeHTTP)
+		ctx := WithConnectionType(r.Context(), ConnectionTypeUntrusted)
 		r = r.WithContext(ctx)
 
 		// FIXME: this is a temporary solution to allow all origins

--- a/services/connector/test_helpers_test.go
+++ b/services/connector/test_helpers_test.go
@@ -52,7 +52,7 @@ func createWalletDB(t *testing.T) (db *sql.DB) {
 }
 
 func setupTests(t *testing.T) (state testState) {
-	state.ctx = WithConnectionType(context.Background(), ConnectionTypeHTTP)
+	state.ctx = WithConnectionType(context.Background(), ConnectionTypeUntrusted)
 
 	state.db = createDB(t)
 	state.walletDb = createWalletDB(t)

--- a/tests-functional/clients/connector.py
+++ b/tests-functional/clients/connector.py
@@ -92,7 +92,6 @@ class ConnectorClient:
             "name": self.name,
             "url": "http://localhost/",
             "method": method,
-            "clientId": "tests-functional",
         }
         if params is not None:
             request["params"] = params


### PR DESCRIPTION

* Updated IsUntrustedConnection to correctly identify both HTTP and WebSocket as untrusted (Now uses go-ethereum's PeerInfoFromContext)


Fixes status-im/status-desktop#19459

<img width="1162" height="256" alt="Screenshot 2025-12-02 at 4 51 30 PM" src="https://github.com/user-attachments/assets/265a8649-fbb2-4188-aab9-aeb7c04f1ace" />


https://github.com/user-attachments/assets/2ce012cd-1c6c-47c4-ae68-805b937e5228

