### PR TITLE
chore: add libsds dependency before running test-unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -420,6 +420,7 @@ docker-test: ##@tests Run tests in a docker container with golang.
 
 test: test-unit ##@tests Run basic, short tests during development
 
+test-unit-prep: $(LIBSDS)
 test-unit-prep: generate
 test-unit-prep: export BUILD_TAGS ?=
 test-unit-prep: export UNIT_TEST_DRY_RUN ?= false


### PR DESCRIPTION
Simple PR to make sure the following job works fine:

- https://ci.status.im/job/status-go/job/tests-develop/

[This](https://ci.status.im/job/status-go/job/tests-develop/688/) is the result of latest run with this branch

## Related PR
- https://github.com/status-im/status-go/pull/7157
