### PR TITLE
test: start wallet by default

### DIFF
--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -4,10 +4,10 @@ from uuid import uuid4
 import pytest
 from requests import ReadTimeout
 
-from clients.status_backend import StatusBackend
 from clients.anvil import Anvil
-from clients.foundry import Foundry
 from clients.contract_deployers.multicall3 import Multicall3Deployer
+from clients.foundry import Foundry
+from clients.status_backend import StatusBackend
 from resources.constants import USE_IPV6
 from utils import fake
 
@@ -98,6 +98,7 @@ def backend_new_profile(request, backend_factory):
         backend.create_account_and_login(password=password, waku_light_client=waku_light_client, **kwargs)
         backend.wait_for_login()
         backend.wakuext_service.start_messenger()
+        backend.wallet_service.start_wallet()
         return backend
 
     yield factory
@@ -122,6 +123,7 @@ def backend_recovered_profile(request, backend_factory):
         backend.restore_account_and_login(user=user, waku_light_client=waku_light_client, **kwargs)
         backend.wait_for_login()
         backend.wakuext_service.start_messenger()
+        backend.wallet_service.start_wallet()
         return backend
 
     yield _backend_recovered_profile


### PR DESCRIPTION
# Description

Added `wallet_service.start_wallet()` call in both main fixtures for spawning backend.

Yes, wallet is not needed in many tests, but always starting it:
- prevents potential misunderstanding of something not working as expected
- demonstrates a more realisrtic scenarios of how status app uses backend.

The other way would be to not start any services here (incl. messenger), but explicitly start only needed ones inside specific test suite. I'm fine with both if anyone has a strong opinion.