### PR TITLE
feat: `--anvil-url`

### DIFF
--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -168,7 +168,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
                 {
                     "chainId": self.network_id,
                     "name": "Anvil Direct",
-                    "url": "http://anvil:8545",
+                    "url": Config.anvil_url,
                     "enableRpsLimiter": False,
                     "type": "embedded-direct",
                     "enabled": True,

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -1,6 +1,7 @@
-import os
 import logging
+import os
 from typing import Iterator
+
 from utils.config import Config
 
 
@@ -10,6 +11,9 @@ def pytest_addoption(parser):
         action="append",
         help="",
         default=None,
+    )
+    parser.addoption(
+        "--anvil-url", action="store", help="URL of the Anvil node to use. Default: http://anvil:8545 (docker container)", default="http://anvil:8545"
     )
     parser.addoption(
         "--password",
@@ -104,6 +108,7 @@ def _calculate_port_range():
 def pytest_configure(config):
     status_backend_urls = config.getoption("--status_backend_url")
     Config.status_backend_urls = _status_backend_url_generator(status_backend_urls) if status_backend_urls else None
+    Config.anvil_url = config.getoption("--anvil-url")
     Config.password = config.getoption("--password")
     Config.docker_project_name = config.getoption("--docker_project_name")
     Config.docker_image = config.getoption("--docker-image")

--- a/tests-functional/utils/config.py
+++ b/tests-functional/utils/config.py
@@ -1,5 +1,5 @@
-from typing import List, Iterator
 from dataclasses import field
+from typing import List, Iterator
 
 
 class Config:
@@ -7,6 +7,7 @@ class Config:
     base_dir: str = ""
 
     status_backend_urls: Iterator[str] | None = None
+    anvil_url: str = ""
     password: str = ""  # FIXME: remove
     docker_project_name: str = ""
     docker_image: str = ""


### PR DESCRIPTION
# Description

When running with `--status_backend_url`, Anvil can't be accessed with Docker DNS `http://anvil:8545`.
In that case `--anvil-url http://127.0.0.1:8545` should be used (assuming that Anvil 8545 port is exposed to host)