### PR TITLE
test: remove usage of setup_backends fixture

### DIFF
--- a/tests-functional/README.MD
+++ b/tests-functional/README.MD
@@ -135,16 +135,26 @@ The main backend factory fixture:
   import pytest
 
   class TestMessenger:
-      @pytest.fixture(autouse=True)
-      def setup_backends(self, backend_factory):
-          self.sender = backend_factory("sender")
-          self.receiver = backend_factory("receiver")
+      @pytest.fixture()
+      def sender(self, backend_factory):
+          return backend_factory("sender")
 
-      def test_send_message(self):
-          # Use self.sender and self.receiver in your test
-          self.sender.send_message(self.receiver, "Hello!")
-          assert self.receiver.has_received_message("Hello!")
+      @pytest.fixture()
+      def receiver(self, backend_factory):
+          return backend_factory("receiver")
+
+      def test_send_message(self, sender, receiver):
+          sender.send_message(receiver, "Hello!")
+          assert receiver.has_received_message("Hello!")
   ```
+
+  # Or with parameters (using `indirect` parametrization of `backend_factory`):
+  ```python
+  @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
+  def test_with_params(self, sender, receiver):
+      ...  # use sender/receiver created by parametrized backend_factory
+  ```
+
   All containers created by this fixture are automatically stopped and removed after the test.
 
 #### 2. Specialized Backend Fixtures

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -261,13 +261,20 @@ class MessengerSteps(NetworkConditionsSteps):
             expected_message=expected_message,
         )
 
-    def create_private_group(self, private_groups_count):
+    def create_private_group(self, private_groups_count, admin=None, member=None):
+        """Create one or more private groups between admin and member and validate signals.
+
+        Args:
+            private_groups_count: number of private groups to create
+            admin: node creating the group (required)
+            member: node invited to the group (required)
+        """
         private_groups = []
         for i in range(private_groups_count):
             private_group_name = f"private_group_{i+1}_{uuid4()}"
-            response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], private_group_name)
+            response = admin.wakuext_service.create_group_chat_with_members([member.public_key], private_group_name)
 
-            expected_group_creation_msg = f"@{self.sender.public_key} created the group {private_group_name}"
+            expected_group_creation_msg = f"@{admin.public_key} created the group {private_group_name}"
             expected_message = self.get_message_by_content_type(
                 response,
                 content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
@@ -278,7 +285,7 @@ class MessengerSteps(NetworkConditionsSteps):
             time.sleep(0.01)
 
         for i, expected_message in enumerate(private_groups):
-            messages_new_event = self.receiver.find_signal_containing_pattern(
+            messages_new_event = member.find_signal_containing_pattern(
                 SignalType.MESSAGES_NEW.value,
                 event_pattern=expected_message.get("id"),
                 timeout=60,

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -259,7 +259,7 @@ class MessengerSteps(NetworkConditionsSteps):
             expected_message=expected_message,
         )
 
-    def create_private_group(self, private_groups_count, admin=None, member=None):
+    def create_private_group(self, private_groups_count, admin, member):
         """Create one or more private groups between admin and member and validate signals.
 
         Args:

--- a/tests-functional/steps/messenger.py
+++ b/tests-functional/steps/messenger.py
@@ -15,7 +15,7 @@ from utils.retry_utils import retry_call
 
 class MessengerSteps(NetworkConditionsSteps):
 
-    def send_contact_request_and_wait_for_signal_to_be_received(self, sender=None, receiver=None) -> str:
+    def send_contact_request_and_wait_for_signal_to_be_received(self, sender, receiver) -> str:
         """
         Send a contact request from sender to receiver and wait for confirmation.
 
@@ -24,8 +24,8 @@ class MessengerSteps(NetworkConditionsSteps):
         This ensures the request has been delivered before proceeding with other operations.
 
         Args:
-            sender: StatusBackend instance of the sender (defaults to self.sender)
-            receiver: StatusBackend instance of the receiver (defaults to self.receiver)
+            sender: StatusBackend instance of the sender
+            receiver: StatusBackend instance of the receiver
 
         Returns:
             str: The message ID of the sent contact request
@@ -39,14 +39,12 @@ class MessengerSteps(NetworkConditionsSteps):
         receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id)
         return message_id
 
-    def accept_contact_request_and_wait_for_signal_to_be_received(self, message_id, sender=None, receiver=None):
-        sender = sender or self.sender
-        receiver = receiver or self.receiver
+    def accept_contact_request_and_wait_for_signal_to_be_received(self, message_id, sender, receiver):
         receiver.wakuext_service.accept_contact_request(message_id)
         accepted_signal = f"@{receiver.public_key} accepted your contact request"
         sender.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=accepted_signal)
 
-    def make_contacts(self, sender=None, receiver=None) -> str:
+    def make_contacts(self, sender, receiver) -> str:
         """
         Create a contact between sender and receiver.
 
@@ -54,8 +52,8 @@ class MessengerSteps(NetworkConditionsSteps):
         It also checks if the contact request has been accepted by the receiver.
 
         Args:
-            sender: StatusBackend instance of the sender (defaults to self.sender)
-            receiver: StatusBackend instance of the receiver (defaults to self.receiver)
+            sender: StatusBackend instance of the sender
+            receiver: StatusBackend instance of the receiver
 
         Returns:
             str: The message ID of the sent contact request

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -18,17 +18,30 @@ def backend_factory(request):
     Individual backend factory that creates backends one by one.
     Each backend is created separately and all are cleaned up at the end.
 
-    Usage:
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_factory):
-        self.sender = backend_factory("sender")
-        self.receiver = backend_factory("receiver")
+    Recommended usage pattern with explicit fixtures:
+
+    ```python
+    import pytest
+
+    class TestMessenger:
+        @pytest.fixture()
+        def sender(self, backend_factory):
+            return backend_factory("sender")
+
+        @pytest.fixture()
+        def receiver(self, backend_factory):
+            return backend_factory("receiver")
+
+        def test_send_message(self, sender, receiver):
+            sender.send_message(receiver, "Hello!")
+    ```
 
     # Or with parameters:
+    ```python
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_with_params(self, backend_factory):
-        self.sender = backend_factory("sender")
-        self.receiver = backend_factory("receiver")
+    def test_with_params(self, sender, receiver):
+        ...  # use sender/receiver created by parametrized backend_factory
+    ```
     """
 
     # Get parameters from request.param if available

--- a/tests-functional/tests/reliability/test_community_messages.py
+++ b/tests-functional/tests/reliability/test_community_messages.py
@@ -10,53 +10,65 @@ from resources.constants import USE_IPV6
 class TestCommunityMessages(MessengerSteps):
 
     @pytest.fixture()
-    def admin(self, backend_new_profile):
-        return backend_new_profile("admin", bridge_network=True)
+    def community_admin(self, backend_new_profile):
+        return backend_new_profile("community_admin", bridge_network=True)
 
     @pytest.fixture()
-    def member(self, backend_new_profile):
-        return backend_new_profile("member", bridge_network=True)
+    def community_member(self, backend_new_profile):
+        return backend_new_profile("community_member", bridge_network=True)
 
-    def _run_community_messages_baseline(self, admin, member, message_count=1, network_condition=None):
-        self.create_community(admin)
-        message_chat_id = self.join_community(member=member, admin=admin)
+    def _run_community_messages_baseline(
+        self,
+        community_admin,
+        community_member,
+        message_count=1,
+        network_condition=None,
+    ):
+        self.create_community(community_admin)
+        message_chat_id = self.join_community(member=community_member, admin=community_admin)
         if network_condition:
-            network_condition(member)
-        self.community_messages(message_chat_id, message_count, sender=admin, receiver=member)
+            network_condition(community_member)
+        self.community_messages(message_chat_id, message_count, sender=community_admin, receiver=community_member)
 
-    def test_community_messages_baseline(self, admin, member, message_count=1, network_condition=None):
-        self._run_community_messages_baseline(admin, member, message_count, network_condition)
+    def test_community_messages_baseline(
+        self,
+        community_admin,
+        community_member,
+        message_count=1,
+        network_condition=None,
+    ):
+        self._run_community_messages_baseline(community_admin, community_member, message_count, network_condition)
 
-    def test_multiple_community_messages(self, admin, member):
-        self._run_community_messages_baseline(admin, member, message_count=50)
-
-    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_community_messages_with_latency(self, admin, member):
-        self._run_community_messages_baseline(admin, member, network_condition=self.add_latency)
-
-    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_community_messages_with_packet_loss(self, admin, member):
-        self._run_community_messages_baseline(admin, member, network_condition=self.add_packet_loss)
+    def test_multiple_community_messages(self, community_admin, community_member):
+        self._run_community_messages_baseline(community_admin, community_member, message_count=50)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_community_messages_with_low_bandwidth(self, admin, member):
-        self._run_community_messages_baseline(admin, member, network_condition=self.add_low_bandwith)
+    def test_community_messages_with_latency(self, community_admin, community_member):
+        self._run_community_messages_baseline(community_admin, community_member, network_condition=self.add_latency)
 
-    def test_community_messages_with_node_pause_30_seconds(self, admin, member):
-        self.create_community(admin)
-        message_chat_id = self.join_community(member=member, admin=admin)
+    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
+    def test_community_messages_with_packet_loss(self, community_admin, community_member):
+        self._run_community_messages_baseline(community_admin, community_member, network_condition=self.add_packet_loss)
 
-        with self.node_pause(member):
+    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
+    def test_community_messages_with_low_bandwidth(self, community_admin, community_member):
+        self._run_community_messages_baseline(community_admin, community_member, network_condition=self.add_low_bandwith)
+
+    def test_community_messages_with_node_pause_30_seconds(self, community_admin, community_member):
+        self.create_community(community_admin)
+        message_chat_id = self.join_community(member=community_member, admin=community_admin)
+
+        with self.node_pause(community_member):
             message_text = f"test_message_{uuid4()}"
-            admin.wakuext_service.send_chat_message(message_chat_id, message_text)
+            community_admin.wakuext_service.send_chat_message(message_chat_id, message_text)
             sleep(30)
-        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_text)
+        community_member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_text)
 
     @pytest.mark.skipif(USE_IPV6 == "Yes", reason="Test works only with IPV4")
-    def test_community_messages_with_ip_change(self, admin, member):
-        self.create_community(admin)
-        message_chat_id = self.join_community(member=member, admin=admin)
+    def test_community_messages_with_ip_change(self, community_admin, community_member):
+        self.create_community(community_admin)
+        message_chat_id = self.join_community(member=community_member, admin=community_admin)
 
-        self.community_messages(message_chat_id, 1, sender=admin, receiver=member)
-        member.change_container_ip()
-        self.community_messages(message_chat_id, 1, sender=admin, receiver=member)
+        self.community_messages(message_chat_id, 1, sender=community_admin, receiver=community_member)
+        community_member.change_container_ip()
+        self.community_messages(message_chat_id, 1, sender=community_admin, receiver=community_member)

--- a/tests-functional/tests/reliability/test_community_messages.py
+++ b/tests-functional/tests/reliability/test_community_messages.py
@@ -9,49 +9,54 @@ from resources.constants import USE_IPV6
 @pytest.mark.reliability
 class TestCommunityMessages(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two unprivileged backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", bridge_network=True)
-        self.receiver = backend_new_profile("receiver", bridge_network=True)
+    @pytest.fixture()
+    def admin(self, backend_new_profile):
+        return backend_new_profile("admin", bridge_network=True)
 
-    def test_community_messages_baseline(self, message_count=1, network_condition=None):
-        self.create_community(self.sender)
-        message_chat_id = self.join_community(member=self.receiver, admin=self.sender)
+    @pytest.fixture()
+    def member(self, backend_new_profile):
+        return backend_new_profile("member", bridge_network=True)
+
+    def _run_community_messages_baseline(self, admin, member, message_count=1, network_condition=None):
+        self.create_community(admin)
+        message_chat_id = self.join_community(member=member, admin=admin)
         if network_condition:
-            network_condition(self.receiver)
-        self.community_messages(message_chat_id, message_count, sender=self.sender, receiver=self.receiver)
+            network_condition(member)
+        self.community_messages(message_chat_id, message_count, sender=admin, receiver=member)
 
-    def test_multiple_community_messages(self):
-        self.test_community_messages_baseline(message_count=50)
+    def test_community_messages_baseline(self, admin, member, message_count=1, network_condition=None):
+        self._run_community_messages_baseline(admin, member, message_count, network_condition)
 
-    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_community_messages_with_latency(self):
-        self.test_community_messages_baseline(network_condition=self.add_latency)
-
-    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_community_messages_with_packet_loss(self):
-        self.test_community_messages_baseline(network_condition=self.add_packet_loss)
+    def test_multiple_community_messages(self, admin, member):
+        self._run_community_messages_baseline(admin, member, message_count=50)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_community_messages_with_low_bandwidth(self):
-        self.test_community_messages_baseline(network_condition=self.add_low_bandwith)
+    def test_community_messages_with_latency(self, admin, member):
+        self._run_community_messages_baseline(admin, member, network_condition=self.add_latency)
 
-    def test_community_messages_with_node_pause_30_seconds(self):
-        self.create_community(self.sender)
-        message_chat_id = self.join_community(member=self.receiver, admin=self.sender)
+    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
+    def test_community_messages_with_packet_loss(self, admin, member):
+        self._run_community_messages_baseline(admin, member, network_condition=self.add_packet_loss)
 
-        with self.node_pause(self.receiver):
+    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
+    def test_community_messages_with_low_bandwidth(self, admin, member):
+        self._run_community_messages_baseline(admin, member, network_condition=self.add_low_bandwith)
+
+    def test_community_messages_with_node_pause_30_seconds(self, admin, member):
+        self.create_community(admin)
+        message_chat_id = self.join_community(member=member, admin=admin)
+
+        with self.node_pause(member):
             message_text = f"test_message_{uuid4()}"
-            self.sender.wakuext_service.send_chat_message(message_chat_id, message_text)
+            admin.wakuext_service.send_chat_message(message_chat_id, message_text)
             sleep(30)
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_text)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_text)
 
     @pytest.mark.skipif(USE_IPV6 == "Yes", reason="Test works only with IPV4")
-    def test_community_messages_with_ip_change(self):
-        self.create_community(self.sender)
-        message_chat_id = self.join_community(member=self.receiver, admin=self.sender)
+    def test_community_messages_with_ip_change(self, admin, member):
+        self.create_community(admin)
+        message_chat_id = self.join_community(member=member, admin=admin)
 
-        self.community_messages(message_chat_id, 1, sender=self.sender, receiver=self.receiver)
-        self.receiver.change_container_ip()
-        self.community_messages(message_chat_id, 1, sender=self.sender, receiver=self.receiver)
+        self.community_messages(message_chat_id, 1, sender=admin, receiver=member)
+        member.change_container_ip()
+        self.community_messages(message_chat_id, 1, sender=admin, receiver=member)

--- a/tests-functional/tests/reliability/test_contact_request.py
+++ b/tests-functional/tests/reliability/test_contact_request.py
@@ -1,6 +1,7 @@
-from time import sleep
-from uuid import uuid4
 import pytest
+from uuid import uuid4
+from time import sleep
+
 from steps.messenger import MessengerSteps
 from clients.signals import SignalType
 from resources.enums import MessageContentType
@@ -9,47 +10,55 @@ from resources.constants import USE_IPV6
 
 @pytest.mark.reliability
 class TestContactRequests(MessengerSteps):
+    @pytest.fixture()
+    def sender(self, backend_new_profile):
+        return backend_new_profile("sender", bridge_network=True)
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two unprivileged backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", bridge_network=True)
-        self.receiver = backend_new_profile("receiver", bridge_network=True)
+    @pytest.fixture()
+    def receiver(self, backend_new_profile):
+        return backend_new_profile("receiver", bridge_network=True)
 
-    def test_contact_request_baseline(self, execution_number=1, network_condition=None):
-        self.add_contact(sender=self.sender, receiver=self.receiver, execution_number=execution_number, network_condition=network_condition)
+    def _run_contact_request_baseline(self, sender, receiver, execution_number=None, network_condition=None):
+        self.add_contact(
+            sender=sender,
+            receiver=receiver,
+            execution_number=execution_number,
+            network_condition=network_condition,
+        )
+
+    def test_contact_request_baseline(self, sender, receiver, execution_number: int = 1, network_condition=None):
+        self._run_contact_request_baseline(sender, receiver, execution_number, network_condition)
 
     @pytest.mark.parametrize("execution_number", range(10))
-    def test_multiple_contact_requests(self, execution_number):
-        self.test_contact_request_baseline(execution_number=execution_number)
+    def test_multiple_contact_requests(self, sender, receiver, execution_number: int):
+        self._run_contact_request_baseline(sender, receiver, execution_number)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
     @pytest.mark.parametrize("execution_number", range(10))
-    def test_contact_request_with_latency(self, execution_number):
-        self.test_contact_request_baseline(execution_number=execution_number, network_condition=self.add_latency)
+    def test_contact_request_with_latency(self, sender, receiver, execution_number: int, backend_factory):
+        self._run_contact_request_baseline(sender, receiver, execution_number, network_condition=self.add_latency)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_contact_request_with_packet_loss(self):
-        self.test_contact_request_baseline(execution_number=10, network_condition=self.add_packet_loss)
+    def test_contact_request_with_packet_loss(self, sender, receiver):
+        self._run_contact_request_baseline(sender, receiver, execution_number=10, network_condition=self.add_packet_loss)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_contact_request_with_low_bandwidth(self):
-        self.test_contact_request_baseline(execution_number=10, network_condition=self.add_low_bandwith)
+    def test_contact_request_with_low_bandwidth(self, sender, receiver, backend_factory):
+        self._run_contact_request_baseline(sender, receiver, execution_number=10, network_condition=self.add_low_bandwith)
 
-    def test_contact_request_with_node_pause_30_seconds(self):
-        with self.node_pause(self.receiver):
+    def test_contact_request_with_node_pause_30_seconds(self, sender, receiver):
+        with self.node_pause(receiver):
             message_text = f"test_contact_request_{uuid4()}"
-            response = self.sender.wakuext_service.send_contact_request(self.receiver.public_key, message_text)
+            response = sender.wakuext_service.send_contact_request(receiver.public_key, message_text)
             expected_message = self.get_message_by_content_type(response, content_type=MessageContentType.CONTACT_REQUEST.value)[0]
             sleep(30)
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=expected_message.get("id"))
-        self.sender.wait_for_signal(SignalType.MESSAGE_DELIVERED.value)
+        receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=expected_message.get("id"))
+        sender.wait_for_signal(SignalType.MESSAGE_DELIVERED.value)
 
     @pytest.mark.skipif(USE_IPV6 == "Yes", reason="Test works only with IPV4")
-    def test_contact_request_with_ip_change(self):
-        self.receiver.change_container_ip()
-
+    def test_contact_request_with_ip_change(self, sender, receiver):
+        receiver.change_container_ip()
         message_text = f"test_contact_request_{uuid4()}"
-        response = self.sender.wakuext_service.send_contact_request(self.receiver.public_key, message_text)
+        response = sender.wakuext_service.send_contact_request(receiver.public_key, message_text)
         expected_message = self.get_message_by_content_type(response, content_type=MessageContentType.CONTACT_REQUEST.value)[0]
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=expected_message.get("id"))
+        receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=expected_message.get("id"))

--- a/tests-functional/tests/reliability/test_create_private_groups.py
+++ b/tests-functional/tests/reliability/test_create_private_groups.py
@@ -9,33 +9,38 @@ from resources.constants import USE_IPV6
 @pytest.mark.reliability
 class TestCreatePrivateGroups(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two unprivileged backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", bridge_network=True)
-        self.receiver = backend_new_profile("receiver", bridge_network=True)
+    @pytest.fixture()
+    def admin(self, backend_new_profile):
+        return backend_new_profile("admin", bridge_network=True)
 
-    def test_create_private_group_baseline(self, private_groups_count=1):
-        self.make_contacts(self.sender, self.receiver)
-        self.create_private_group(private_groups_count)
+    @pytest.fixture()
+    def member(self, backend_new_profile):
+        return backend_new_profile("member", bridge_network=True)
 
-    def test_multiple_create_private_groups(self):
-        self.test_create_private_group_baseline(private_groups_count=50)
+    def _run_create_private_group_baseline(self, admin, member, private_groups_count=1):
+        self.make_contacts(admin, member)
+        self.create_private_group(private_groups_count, admin=admin, member=member)
 
-    def test_create_private_groups_with_node_pause_30_seconds(self):
-        self.make_contacts(self.sender, self.receiver)
+    def test_create_private_group_baseline(self, admin, member, private_groups_count=1):
+        self._run_create_private_group_baseline(admin, member, private_groups_count)
 
-        with self.node_pause(self.receiver):
+    def test_multiple_create_private_groups(self, admin, member):
+        self._run_create_private_group_baseline(admin, member, private_groups_count=50)
+
+    def test_create_private_groups_with_node_pause_30_seconds(self, admin, member):
+        self.make_contacts(admin, member)
+
+        with self.node_pause(member):
             private_group_name = f"private_group_{uuid4()}"
-            self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], private_group_name)
+            admin.wakuext_service.create_group_chat_with_members([member.public_key], private_group_name)
             sleep(30)
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=private_group_name)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=private_group_name)
 
     @pytest.mark.skipif(USE_IPV6 == "Yes", reason="Test works only with IPV4")
-    def test_create_private_groups_with_ip_change(self):
-        self.make_contacts(self.sender, self.receiver)
-        self.receiver.change_container_ip()
+    def test_create_private_groups_with_ip_change(self, admin, member):
+        self.make_contacts(admin, member)
+        member.change_container_ip()
 
         private_group_name = f"private_group_{uuid4()}"
-        self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], private_group_name)
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=private_group_name)
+        admin.wakuext_service.create_group_chat_with_members([member.public_key], private_group_name)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=private_group_name)

--- a/tests-functional/tests/reliability/test_create_private_groups.py
+++ b/tests-functional/tests/reliability/test_create_private_groups.py
@@ -10,37 +10,40 @@ from resources.constants import USE_IPV6
 class TestCreatePrivateGroups(MessengerSteps):
 
     @pytest.fixture()
-    def admin(self, backend_new_profile):
-        return backend_new_profile("admin", bridge_network=True)
+    def community_admin(self, backend_new_profile):
+        return backend_new_profile("community_admin", bridge_network=True)
 
     @pytest.fixture()
-    def member(self, backend_new_profile):
+    def community_member(self, backend_new_profile):
         return backend_new_profile("member", bridge_network=True)
 
-    def _run_create_private_group_baseline(self, admin, member, private_groups_count=1):
-        self.make_contacts(admin, member)
-        self.create_private_group(private_groups_count, admin=admin, member=member)
+    def _run_create_private_group_baseline(self, community_admin, community_member, private_groups_count=1):
+        self.make_contacts(community_admin, community_member)
+        self.create_private_group(private_groups_count, admin=community_admin, member=community_member)
 
-    def test_create_private_group_baseline(self, admin, member, private_groups_count=1):
-        self._run_create_private_group_baseline(admin, member, private_groups_count)
+    def test_create_private_group_baseline(self, community_admin, community_member, private_groups_count=1):
+        self._run_create_private_group_baseline(community_admin, community_member, private_groups_count)
 
-    def test_multiple_create_private_groups(self, admin, member):
-        self._run_create_private_group_baseline(admin, member, private_groups_count=50)
+    def test_multiple_create_private_groups(self, community_admin, community_member):
+        self._run_create_private_group_baseline(community_admin, community_member, private_groups_count=50)
 
-    def test_create_private_groups_with_node_pause_30_seconds(self, admin, member):
-        self.make_contacts(admin, member)
+    def test_create_private_groups_with_node_pause_30_seconds(self, community_admin, community_member):
+        self.make_contacts(community_admin, community_member)
 
-        with self.node_pause(member):
+        with self.node_pause(community_member):
             private_group_name = f"private_group_{uuid4()}"
-            admin.wakuext_service.create_group_chat_with_members([member.public_key], private_group_name)
+            community_admin.wakuext_service.create_group_chat_with_members(
+                [community_member.public_key],
+                private_group_name,
+            )
             sleep(30)
-        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=private_group_name)
+        community_member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=private_group_name)
 
     @pytest.mark.skipif(USE_IPV6 == "Yes", reason="Test works only with IPV4")
-    def test_create_private_groups_with_ip_change(self, admin, member):
-        self.make_contacts(admin, member)
-        member.change_container_ip()
+    def test_create_private_groups_with_ip_change(self, community_admin, community_member):
+        self.make_contacts(community_admin, community_member)
+        community_member.change_container_ip()
 
         private_group_name = f"private_group_{uuid4()}"
-        admin.wakuext_service.create_group_chat_with_members([member.public_key], private_group_name)
-        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=private_group_name)
+        community_admin.wakuext_service.create_group_chat_with_members([community_member.public_key], private_group_name)
+        community_member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=private_group_name)

--- a/tests-functional/tests/reliability/test_join_leave_community.py
+++ b/tests-functional/tests/reliability/test_join_leave_community.py
@@ -6,59 +6,61 @@ from steps.messenger import MessengerSteps
 @pytest.mark.reliability
 class TestJoinLeaveCommunities(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two unprivileged backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", bridge_network=True)
-        self.receiver = backend_new_profile("receiver", bridge_network=True)
+    @pytest.fixture()
+    def admin(self, backend_new_profile):
+        return backend_new_profile("admin", bridge_network=True)
 
-    def test_join_leave_community_baseline(self, num_joins=1, network_condition=None):
-        nodes_list = [self.sender, self.receiver]
-        self.create_community(self.sender)
-        self.leave_the_community(self.sender)
+    @pytest.fixture()
+    def member(self, backend_new_profile):
+        return backend_new_profile("member", bridge_network=True)
+
+    def _run_join_leave_community_baseline(self, admin, member, num_joins=1, network_condition=None):
+        nodes_list = [admin, member]
+        self.create_community(admin)
+        self.leave_the_community(admin)
 
         if network_condition:
             for node in nodes_list:
                 network_condition(node)
 
         for _ in range(num_joins):
-            self.join_community(member=self.receiver, admin=self.sender)
-            self.check_node_joined_community(self.receiver, joined=True)
-            self.leave_the_community(self.receiver)
-            self.check_node_joined_community(self.receiver, joined=False)
+            self.join_community(member=member, admin=admin)
+            self.check_node_joined_community(member, joined=True)
+            self.leave_the_community(member)
+            self.check_node_joined_community(member, joined=False)
 
     @pytest.mark.skip(reason="Skipping due to failing on local build")
     # TODO: check in nightly build locally and recheck test logic
-    def test_multiple_join_leave_community_requests(self):
-        self.test_join_leave_community_baseline(num_joins=10)
+    def test_multiple_join_leave_community_requests(self, admin, member):
+        self._run_join_leave_community_baseline(admin, member, num_joins=10)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_join_leave_community_with_latency(self):
-        self.test_join_leave_community_baseline(network_condition=self.add_latency)
+    def test_join_leave_community_with_latency(self, admin, member):
+        self._run_join_leave_community_baseline(admin, member, network_condition=self.add_latency)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_join_leave_community_with_packet_loss(self):
-        self.test_join_leave_community_baseline(network_condition=self.add_packet_loss)
+    def test_join_leave_community_with_packet_loss(self, admin, member):
+        self._run_join_leave_community_baseline(admin, member, network_condition=self.add_packet_loss)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_join_leave_community_with_low_bandwidth(self):
-        self.test_join_leave_community_baseline(network_condition=self.add_low_bandwith)
+    def test_join_leave_community_with_low_bandwidth(self, admin, member):
+        self._run_join_leave_community_baseline(admin, member, network_condition=self.add_low_bandwith)
 
-    def test_join_leave_community_with_node_pause(self):
-        self.create_community(self.sender)
-        self.join_community(member=self.receiver, admin=self.sender)
-        self.check_node_joined_community(self.receiver, joined=True)
+    def test_join_leave_community_with_node_pause(self, admin, member):
+        self.create_community(admin)
+        self.join_community(member=member, admin=admin)
+        self.check_node_joined_community(member, joined=True)
 
-        with self.node_pause(self.receiver):
+        with self.node_pause(member):
             sleep(2)
-        self.leave_the_community(self.receiver)
-        self.check_node_joined_community(self.receiver, joined=False)
+        self.leave_the_community(member)
+        self.check_node_joined_community(member, joined=False)
 
-    def test_join_leave_community_with_ip_change(self):
-        self.create_community(self.sender)
-        self.join_community(member=self.receiver, admin=self.sender)
-        self.check_node_joined_community(self.receiver, joined=True)
+    def test_join_leave_community_with_ip_change(self, admin, member):
+        self.create_community(admin)
+        self.join_community(member=member, admin=admin)
+        self.check_node_joined_community(member, joined=True)
 
-        self.receiver.change_container_ip()
-        self.leave_the_community(self.receiver)
-        self.check_node_joined_community(self.receiver, joined=False)
+        member.change_container_ip()
+        self.leave_the_community(member)
+        self.check_node_joined_community(member, joined=False)

--- a/tests-functional/tests/reliability/test_join_leave_community.py
+++ b/tests-functional/tests/reliability/test_join_leave_community.py
@@ -7,60 +7,60 @@ from steps.messenger import MessengerSteps
 class TestJoinLeaveCommunities(MessengerSteps):
 
     @pytest.fixture()
-    def admin(self, backend_new_profile):
-        return backend_new_profile("admin", bridge_network=True)
+    def community_admin(self, backend_new_profile):
+        return backend_new_profile("community_admin", bridge_network=True)
 
     @pytest.fixture()
-    def member(self, backend_new_profile):
-        return backend_new_profile("member", bridge_network=True)
+    def community_member(self, backend_new_profile):
+        return backend_new_profile("community_member", bridge_network=True)
 
-    def _run_join_leave_community_baseline(self, admin, member, num_joins=1, network_condition=None):
-        nodes_list = [admin, member]
-        self.create_community(admin)
-        self.leave_the_community(admin)
+    def _run_join_leave_community_baseline(self, community_admin, community_member, num_joins=1, network_condition=None):
+        nodes_list = [community_admin, community_member]
+        self.create_community(community_admin)
+        self.leave_the_community(community_admin)
 
         if network_condition:
             for node in nodes_list:
                 network_condition(node)
 
         for _ in range(num_joins):
-            self.join_community(member=member, admin=admin)
-            self.check_node_joined_community(member, joined=True)
-            self.leave_the_community(member)
-            self.check_node_joined_community(member, joined=False)
+            self.join_community(member=community_member, admin=community_admin)
+            self.check_node_joined_community(community_member, joined=True)
+            self.leave_the_community(community_member)
+            self.check_node_joined_community(community_member, joined=False)
 
     @pytest.mark.skip(reason="Skipping due to failing on local build")
     # TODO: check in nightly build locally and recheck test logic
-    def test_multiple_join_leave_community_requests(self, admin, member):
-        self._run_join_leave_community_baseline(admin, member, num_joins=10)
+    def test_multiple_join_leave_community_requests(self, community_admin, community_member):
+        self._run_join_leave_community_baseline(community_admin, community_member, num_joins=10)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_join_leave_community_with_latency(self, admin, member):
-        self._run_join_leave_community_baseline(admin, member, network_condition=self.add_latency)
+    def test_join_leave_community_with_latency(self, community_admin, community_member):
+        self._run_join_leave_community_baseline(community_admin, community_member, network_condition=self.add_latency)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_join_leave_community_with_packet_loss(self, admin, member):
-        self._run_join_leave_community_baseline(admin, member, network_condition=self.add_packet_loss)
+    def test_join_leave_community_with_packet_loss(self, community_admin, community_member):
+        self._run_join_leave_community_baseline(community_admin, community_member, network_condition=self.add_packet_loss)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_join_leave_community_with_low_bandwidth(self, admin, member):
-        self._run_join_leave_community_baseline(admin, member, network_condition=self.add_low_bandwith)
+    def test_join_leave_community_with_low_bandwidth(self, community_admin, community_member):
+        self._run_join_leave_community_baseline(community_admin, community_member, network_condition=self.add_low_bandwith)
 
-    def test_join_leave_community_with_node_pause(self, admin, member):
-        self.create_community(admin)
-        self.join_community(member=member, admin=admin)
-        self.check_node_joined_community(member, joined=True)
+    def test_join_leave_community_with_node_pause(self, community_admin, community_member):
+        self.create_community(community_admin)
+        self.join_community(member=community_member, admin=community_admin)
+        self.check_node_joined_community(community_member, joined=True)
 
-        with self.node_pause(member):
+        with self.node_pause(community_member):
             sleep(2)
-        self.leave_the_community(member)
-        self.check_node_joined_community(member, joined=False)
+        self.leave_the_community(community_member)
+        self.check_node_joined_community(community_member, joined=False)
 
-    def test_join_leave_community_with_ip_change(self, admin, member):
-        self.create_community(admin)
-        self.join_community(member=member, admin=admin)
-        self.check_node_joined_community(member, joined=True)
+    def test_join_leave_community_with_ip_change(self, community_admin, community_member):
+        self.create_community(community_admin)
+        self.join_community(member=community_member, admin=community_admin)
+        self.check_node_joined_community(community_member, joined=True)
 
-        member.change_container_ip()
-        self.leave_the_community(member)
-        self.check_node_joined_community(member, joined=False)
+        community_member.change_container_ip()
+        self.leave_the_community(community_member)
+        self.check_node_joined_community(community_member, joined=False)

--- a/tests-functional/tests/reliability/test_light_client_rate_limiting.py
+++ b/tests-functional/tests/reliability/test_light_client_rate_limiting.py
@@ -10,18 +10,20 @@ from resources.enums import MessageContentType
 @pytest.mark.reliability
 class TestLightClientRateLimiting(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two light client backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", waku_light_client=True)
-        self.receiver = backend_new_profile("receiver", waku_light_client=True)
+    @pytest.fixture()
+    def light_sender(self, backend_new_profile):
+        return backend_new_profile("sender", waku_light_client=True)
 
-    def test_light_client_rate_limiting(self):
+    @pytest.fixture()
+    def light_receiver(self, backend_new_profile):
+        return backend_new_profile("receiver", waku_light_client=True)
+
+    def test_light_client_rate_limiting(self, light_sender, light_receiver):
         sent_messages = []
 
         for i in range(200):
             message_text = f"test_message_{i+1}_{uuid4()}"
-            response = self.sender.wakuext_service.send_one_to_one_message(self.receiver.public_key, message_text)
+            response = light_sender.wakuext_service.send_one_to_one_message(light_receiver.public_key, message_text)
             expected_message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
             sent_messages.append(expected_message)
             sleep(0.1)
@@ -30,7 +32,7 @@ class TestLightClientRateLimiting(MessengerSteps):
         count = 0
         for i, expected_message in enumerate(sent_messages):
             try:
-                messages_new_event = self.receiver.find_signal_containing_pattern(
+                messages_new_event = light_receiver.find_signal_containing_pattern(
                     SignalType.MESSAGES_NEW.value,
                     event_pattern=expected_message.get("id"),
                     timeout=120,

--- a/tests-functional/tests/reliability/test_one_to_one_messages.py
+++ b/tests-functional/tests/reliability/test_one_to_one_messages.py
@@ -9,43 +9,48 @@ from resources.constants import USE_IPV6
 @pytest.mark.reliability
 class TestOneToOneMessages(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two unprivileged backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", bridge_network=True)
-        self.receiver = backend_new_profile("receiver", bridge_network=True)
+    @pytest.fixture()
+    def sender(self, backend_new_profile):
+        return backend_new_profile("sender", bridge_network=True)
 
-    def test_one_to_one_message_baseline(self, message_count=1):
-        self.one_to_one_message(message_count, sender=self.sender, receiver=self.receiver)
+    @pytest.fixture()
+    def receiver(self, backend_new_profile):
+        return backend_new_profile("receiver", bridge_network=True)
 
-    def test_multiple_one_to_one_messages(self):
-        self.test_one_to_one_message_baseline(message_count=50)
+    def _run_one_to_one_message_baseline(self, sender, receiver, message_count=1):
+        self.one_to_one_message(message_count, sender=sender, receiver=receiver)
 
-    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_one_to_one_message_with_latency(self):
-        with self.add_latency(self.receiver):
-            self.test_one_to_one_message_baseline(message_count=50)
+    def test_one_to_one_message_baseline(self, sender, receiver, message_count=1):
+        self._run_one_to_one_message_baseline(sender, receiver, message_count)
 
-    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_one_to_one_message_with_packet_loss(self):
-        with self.add_packet_loss(self.receiver):
-            self.test_one_to_one_message_baseline(message_count=50)
+    def test_multiple_one_to_one_messages(self, sender, receiver):
+        self._run_one_to_one_message_baseline(sender, receiver, message_count=50)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_one_to_one_message_with_low_bandwidth(self):
-        with self.add_low_bandwith(self.receiver):
-            self.test_one_to_one_message_baseline(message_count=50)
+    def test_one_to_one_message_with_latency(self, sender, receiver):
+        with self.add_latency(receiver):
+            self._run_one_to_one_message_baseline(sender, receiver, message_count=50)
 
-    def test_one_to_one_message_with_node_pause_30_seconds(self):
-        with self.node_pause(self.receiver):
+    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
+    def test_one_to_one_message_with_packet_loss(self, sender, receiver):
+        with self.add_packet_loss(receiver):
+            self._run_one_to_one_message_baseline(sender, receiver, message_count=50)
+
+    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
+    def test_one_to_one_message_with_low_bandwidth(self, sender, receiver):
+        with self.add_low_bandwith(receiver):
+            self._run_one_to_one_message_baseline(sender, receiver, message_count=50)
+
+    def test_one_to_one_message_with_node_pause_30_seconds(self, sender, receiver):
+        with self.node_pause(receiver):
             message_text = f"test_message_{uuid4()}"
-            self.sender.wakuext_service.send_one_to_one_message(self.receiver.public_key, message_text)
+            sender.wakuext_service.send_one_to_one_message(receiver.public_key, message_text)
             sleep(30)
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_text)
-        self.sender.wait_for_signal(SignalType.MESSAGE_DELIVERED.value)
+        receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_text)
+        sender.wait_for_signal(SignalType.MESSAGE_DELIVERED.value)
 
     @pytest.mark.skipif(USE_IPV6 == "Yes", reason="Test works only with IPV4")
-    def test_one_to_one_messages_with_ip_change(self):
-        self.test_one_to_one_message_baseline()
-        self.receiver.change_container_ip()
-        self.test_one_to_one_message_baseline()
+    def test_one_to_one_messages_with_ip_change(self, sender, receiver):
+        self._run_one_to_one_message_baseline(sender, receiver)
+        receiver.change_container_ip()
+        self._run_one_to_one_message_baseline(sender, receiver)

--- a/tests-functional/tests/reliability/test_private_groups_messages.py
+++ b/tests-functional/tests/reliability/test_private_groups_messages.py
@@ -10,54 +10,54 @@ from resources.constants import USE_IPV6
 class TestPrivateGroupMessages(MessengerSteps):
 
     @pytest.fixture()
-    def admin(self, backend_new_profile):
-        return backend_new_profile("admin", bridge_network=True)
+    def community_admin(self, backend_new_profile):
+        return backend_new_profile("community_admin", bridge_network=True)
 
     @pytest.fixture()
-    def member(self, backend_new_profile):
-        return backend_new_profile("member", bridge_network=True)
+    def community_member(self, backend_new_profile):
+        return backend_new_profile("community_member", bridge_network=True)
 
-    def _run_private_group_messages_baseline(self, admin, member, message_count=1):
-        self.make_contacts(admin, member)
-        private_group_id = self.join_private_group(admin=admin, member=member)
-        self.private_group_message(message_count, private_group_id, sender=admin, receiver=member)
+    def _run_private_group_messages_baseline(self, community_admin, community_member, message_count=1):
+        self.make_contacts(community_admin, community_member)
+        private_group_id = self.join_private_group(admin=community_admin, member=community_member)
+        self.private_group_message(message_count, private_group_id, sender=community_admin, receiver=community_member)
 
-    def test_private_group_messages_baseline(self, admin, member, message_count=1):
-        self._run_private_group_messages_baseline(admin, member, message_count)
+    def test_private_group_messages_baseline(self, community_admin, community_member, message_count=1):
+        self._run_private_group_messages_baseline(community_admin, community_member, message_count)
 
-    def test_multiple_group_chat_messages(self, admin, member):
-        self._run_private_group_messages_baseline(admin, member, message_count=50)
-
-    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_private_group_chat_messages_with_latency(self, admin, member):
-        with self.add_latency(member):
-            self._run_private_group_messages_baseline(admin, member, message_count=50)
+    def test_multiple_group_chat_messages(self, community_admin, community_member):
+        self._run_private_group_messages_baseline(community_admin, community_member, message_count=50)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_private_group_chat_messages_with_packet_loss(self, admin, member):
-        with self.add_packet_loss(member):
-            self._run_private_group_messages_baseline(admin, member, message_count=50)
+    def test_private_group_chat_messages_with_latency(self, community_admin, community_member):
+        with self.add_latency(community_member):
+            self._run_private_group_messages_baseline(community_admin, community_member, message_count=50)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_private_group_chat_messages_with_low_bandwidth(self, admin, member):
-        with self.add_low_bandwith(member):
-            self._run_private_group_messages_baseline(admin, member, message_count=50)
+    def test_private_group_chat_messages_with_packet_loss(self, community_admin, community_member):
+        with self.add_packet_loss(community_member):
+            self._run_private_group_messages_baseline(community_admin, community_member, message_count=50)
 
-    def test_private_group_messages_with_node_pause_30_seconds(self, admin, member):
-        self.make_contacts(admin, member)
-        private_group_id = self.join_private_group(admin=admin, member=member)
+    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
+    def test_private_group_chat_messages_with_low_bandwidth(self, community_admin, community_member):
+        with self.add_low_bandwith(community_member):
+            self._run_private_group_messages_baseline(community_admin, community_member, message_count=50)
 
-        with self.node_pause(member):
+    def test_private_group_messages_with_node_pause_30_seconds(self, community_admin, community_member):
+        self.make_contacts(community_admin, community_member)
+        private_group_id = self.join_private_group(admin=community_admin, member=community_member)
+
+        with self.node_pause(community_member):
             message_text = f"test_message_{uuid4()}"
-            admin.wakuext_service.send_group_chat_message(private_group_id, message_text)
+            community_admin.wakuext_service.send_group_chat_message(private_group_id, message_text)
             sleep(30)
-        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_text)
-        admin.wait_for_signal(SignalType.MESSAGE_DELIVERED.value)
+        community_member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_text)
+        community_admin.wait_for_signal(SignalType.MESSAGE_DELIVERED.value)
 
     @pytest.mark.skipif(USE_IPV6 == "Yes", reason="Test works only with IPV4")
-    def test_private_group_messages_with_ip_change(self, admin, member):
-        self.make_contacts(admin, member)
-        private_group_id = self.join_private_group(admin=admin, member=member)
-        self.private_group_message(1, private_group_id, sender=admin, receiver=member)
-        member.change_container_ip()
-        self.private_group_message(1, private_group_id, sender=admin, receiver=member)
+    def test_private_group_messages_with_ip_change(self, community_admin, community_member):
+        self.make_contacts(community_admin, community_member)
+        private_group_id = self.join_private_group(admin=community_admin, member=community_member)
+        self.private_group_message(1, private_group_id, sender=community_admin, receiver=community_member)
+        community_member.change_container_ip()
+        self.private_group_message(1, private_group_id, sender=community_admin, receiver=community_member)

--- a/tests-functional/tests/reliability/test_private_groups_messages.py
+++ b/tests-functional/tests/reliability/test_private_groups_messages.py
@@ -9,50 +9,55 @@ from resources.constants import USE_IPV6
 @pytest.mark.reliability
 class TestPrivateGroupMessages(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two unprivileged backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", bridge_network=True)
-        self.receiver = backend_new_profile("receiver", bridge_network=True)
+    @pytest.fixture()
+    def admin(self, backend_new_profile):
+        return backend_new_profile("admin", bridge_network=True)
 
-    def test_private_group_messages_baseline(self, message_count=1):
-        self.make_contacts(self.sender, self.receiver)
-        self.private_group_id = self.join_private_group(admin=self.sender, member=self.receiver)
-        self.private_group_message(message_count, self.private_group_id, sender=self.sender, receiver=self.receiver)
+    @pytest.fixture()
+    def member(self, backend_new_profile):
+        return backend_new_profile("member", bridge_network=True)
 
-    def test_multiple_group_chat_messages(self):
-        self.test_private_group_messages_baseline(message_count=50)
+    def _run_private_group_messages_baseline(self, admin, member, message_count=1):
+        self.make_contacts(admin, member)
+        private_group_id = self.join_private_group(admin=admin, member=member)
+        self.private_group_message(message_count, private_group_id, sender=admin, receiver=member)
 
-    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_private_group_chat_messages_with_latency(self):
-        with self.add_latency(self.receiver):
-            self.test_private_group_messages_baseline(message_count=50)
+    def test_private_group_messages_baseline(self, admin, member, message_count=1):
+        self._run_private_group_messages_baseline(admin, member, message_count)
 
-    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_private_group_chat_messages_with_packet_loss(self):
-        with self.add_packet_loss(self.receiver):
-            self.test_private_group_messages_baseline(message_count=50)
+    def test_multiple_group_chat_messages(self, admin, member):
+        self._run_private_group_messages_baseline(admin, member, message_count=50)
 
     @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
-    def test_private_group_chat_messages_with_low_bandwidth(self):
-        with self.add_low_bandwith(self.receiver):
-            self.test_private_group_messages_baseline(message_count=50)
+    def test_private_group_chat_messages_with_latency(self, admin, member):
+        with self.add_latency(member):
+            self._run_private_group_messages_baseline(admin, member, message_count=50)
 
-    def test_private_group_messages_with_node_pause_30_seconds(self):
-        self.make_contacts(self.sender, self.receiver)
-        self.private_group_id = self.join_private_group(admin=self.sender, member=self.receiver)
+    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
+    def test_private_group_chat_messages_with_packet_loss(self, admin, member):
+        with self.add_packet_loss(member):
+            self._run_private_group_messages_baseline(admin, member, message_count=50)
 
-        with self.node_pause(self.receiver):
+    @pytest.mark.parametrize("backend_factory", [{"privileged": True}], indirect=True)
+    def test_private_group_chat_messages_with_low_bandwidth(self, admin, member):
+        with self.add_low_bandwith(member):
+            self._run_private_group_messages_baseline(admin, member, message_count=50)
+
+    def test_private_group_messages_with_node_pause_30_seconds(self, admin, member):
+        self.make_contacts(admin, member)
+        private_group_id = self.join_private_group(admin=admin, member=member)
+
+        with self.node_pause(member):
             message_text = f"test_message_{uuid4()}"
-            self.sender.wakuext_service.send_group_chat_message(self.private_group_id, message_text)
+            admin.wakuext_service.send_group_chat_message(private_group_id, message_text)
             sleep(30)
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_text)
-        self.sender.wait_for_signal(SignalType.MESSAGE_DELIVERED.value)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_text)
+        admin.wait_for_signal(SignalType.MESSAGE_DELIVERED.value)
 
     @pytest.mark.skipif(USE_IPV6 == "Yes", reason="Test works only with IPV4")
-    def test_private_group_messages_with_ip_change(self):
-        self.make_contacts(self.sender, self.receiver)
-        self.private_group_id = self.join_private_group(admin=self.sender, member=self.receiver)
-        self.private_group_message(1, self.private_group_id, sender=self.sender, receiver=self.receiver)
-        self.receiver.change_container_ip()
-        self.private_group_message(1, self.private_group_id, sender=self.sender, receiver=self.receiver)
+    def test_private_group_messages_with_ip_change(self, admin, member):
+        self.make_contacts(admin, member)
+        private_group_id = self.join_private_group(admin=admin, member=member)
+        self.private_group_message(1, private_group_id, sender=admin, receiver=member)
+        member.change_container_ip()
+        self.private_group_message(1, private_group_id, sender=admin, receiver=member)

--- a/tests-functional/tests/settings/test_backup.py
+++ b/tests-functional/tests/settings/test_backup.py
@@ -4,20 +4,20 @@ import pytest
 @pytest.mark.rpc
 class TestBackupSettings:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.config = backend_new_profile("sender")
+    @pytest.fixture()
+    def config(self, backend_new_profile):
+        return backend_new_profile("settings-backend")
 
     @pytest.mark.skip(reason="backend currently does not validate backup-path; it is stored verbatim")
-    def test_set_invalid_backup_path(self):
+    def test_set_invalid_backup_path(self, config):
         invalid_path = "/invalid/path/that/does@$<>not|exist"
-        result = self.config.settings_service.save_setting("backup-path", invalid_path)
-        backup_path = self.config.settings_service.backup_path()
+        result = config.settings_service.save_setting("backup-path", invalid_path)
+        backup_path = config.settings_service.backup_path()
         assert backup_path != invalid_path, f"Backend incorrectly saved invalid path: {backup_path}"
         assert result is None or result == "", f"Expected save_setting to fail or return None, got: {result}"
 
-    def test_set_valid_backup_path(self):
-        current_path = self.config.settings_service.backup_path()
+    def test_set_valid_backup_path(self, config):
+        current_path = config.settings_service.backup_path()
 
         # Verify it is a valid path (not empty and is a string)
         assert current_path is not None, "Backup path should not be None"
@@ -25,24 +25,24 @@ class TestBackupSettings:
         assert current_path != "", "Backup path should not be empty"
 
         # Test setting the same path explicitly (round-trip test)
-        result = self.config.settings_service.save_setting("backup-path", current_path)
+        result = config.settings_service.save_setting("backup-path", current_path)
         assert result is None
-        assert self.config.settings_service.backup_path() == current_path
+        assert config.settings_service.backup_path() == current_path
 
-    def test_get_backup_path_type_and_value(self):
-        backup_path = self.config.settings_service.backup_path()
+    def test_get_backup_path_type_and_value(self, config):
+        backup_path = config.settings_service.backup_path()
         assert backup_path is not None, "Expected a non-null backup path"
         assert isinstance(backup_path, str), f"Expected string, got {type(backup_path)}"
         assert backup_path != "", "Expected backup path to be non-empty"
 
-    def test_messages_backup_enabled_type(self):
-        result = self.config.settings_service.messages_backup_enabled()
+    def test_messages_backup_enabled_type(self, config):
+        result = config.settings_service.messages_backup_enabled()
         assert result is not None, "Expected a non-null result"
         assert isinstance(result, bool), f"Expected bool, got {type(result)}"
 
-    def test_toggle_messages_backup_enabled(self):
+    def test_toggle_messages_backup_enabled(self, config):
         value = True
-        self.config.settings_service.save_setting("messages-backup-enabled?", value)
-        result = self.config.settings_service.messages_backup_enabled()
+        config.settings_service.save_setting("messages-backup-enabled?", value)
+        result = config.settings_service.messages_backup_enabled()
         assert isinstance(result, bool)
         assert result is value

--- a/tests-functional/tests/settings/test_general.py
+++ b/tests-functional/tests/settings/test_general.py
@@ -7,67 +7,67 @@ import pytest
 @pytest.mark.rpc
 class TestGeneralSettings:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.config = backend_new_profile("sender")
+    @pytest.fixture()
+    def config(self, backend_new_profile):
+        return backend_new_profile("settings-backend")
 
-    def test_thirdparty_services_enabled(self):
-        result = self.config.settings_service.thirdparty_services_enabled()
+    def test_thirdparty_services_enabled(self, config):
+        result = config.settings_service.thirdparty_services_enabled()
         assert result is not None, "Expected a non-null result"
         assert isinstance(result, bool), f"Expected bool, got {type(result)}"
         assert result is True, "Expected True"
 
-    def test_last_tokens_update_type_check(self):
-        result = self.config.settings_service.last_tokens_update()
+    def test_last_tokens_update_type_check(self, config):
+        result = config.settings_service.last_tokens_update()
         assert result is not None, "Expected non-null timestamp"
         assert isinstance(result, str), f"Expected string, got {type(result)}"
         assert result != "", "Expected non-empty string"
 
-    def test_last_tokens_update_returns_valid_iso_datetime(self):
-        result = self.config.settings_service.last_tokens_update()
+    def test_last_tokens_update_returns_valid_iso_datetime(self, config):
+        result = config.settings_service.last_tokens_update()
         try:
             _ = datetime.datetime.fromisoformat(result.replace("Z", "+00:00"))
         except Exception as e:
             pytest.fail(f"Returned value is not a valid ISO datetime string: {result}. Error: {e}")
 
-    def test_last_tokens_update_advances_after_updating_token_preferences(self):
+    def test_last_tokens_update_advances_after_updating_token_preferences(self, config):
         dummy_prefs = [{"key": "0x1234567890abcdef1234567890abcdef12345678", "position": 1, "visible": True}]
-        self.config.accounts_service.update_token_preferences(dummy_prefs)
-        t1_raw = self.config.settings_service.last_tokens_update()
+        config.accounts_service.update_token_preferences(dummy_prefs)
+        t1_raw = config.settings_service.last_tokens_update()
         t1 = datetime.datetime.fromisoformat(t1_raw.replace("Z", "+00:00"))
         time.sleep(1.2)
-        current_prefs = self.config.accounts_service.get_token_preferences()
-        self.config.accounts_service.update_token_preferences(current_prefs)
-        t2_raw = self.config.settings_service.last_tokens_update()
+        current_prefs = config.accounts_service.get_token_preferences()
+        config.accounts_service.update_token_preferences(current_prefs)
+        t2_raw = config.settings_service.last_tokens_update()
         t2 = datetime.datetime.fromisoformat(t2_raw.replace("Z", "+00:00"))
         assert t2 >= t1, f"Expected last-tokens-update to advance or stay same; got T1={t1} T2={t2}"
 
-    def test_mnemonic_was_shown(self):
-        result = self.config.settings_service.mnemonic_was_shown()
+    def test_mnemonic_was_shown(self, config):
+        result = config.settings_service.mnemonic_was_shown()
         assert result is None or result == "", f"Expected no return value, got: {result}"
 
-    def test_set_bio_valid_string(self):
+    def test_set_bio_valid_string(self, config):
         valid_bio = "This is a new test bio"
-        result = self.config.settings_service.set_bio(valid_bio)
+        result = config.settings_service.set_bio(valid_bio)
         assert result is None or result == "", f"Expected None or empty string, got {result}"
 
-    def test_set_bio_invalid_type(self):
+    def test_set_bio_invalid_type(self, config):
         invalid_bio = 123
         try:
-            result = self.config.settings_service.set_bio(invalid_bio)
+            result = config.settings_service.set_bio(invalid_bio)
             pytest.fail(f"Expected an exception for invalid bio {invalid_bio}, got {result}")
         except Exception:
             assert True
 
-    def test_delete_exemptions_valid_id(self):
-        result = self.config.settings_service.delete_exemptions("12345")
+    def test_delete_exemptions_valid_id(self, config):
+        result = config.settings_service.delete_exemptions("12345")
         assert result is None or result == "", f"Expected None or empty string, got {result}"
 
     @pytest.mark.skip(reason="Pending on issue resolution https://github.com/status-im/status-go/issues/7102")
-    def test_delete_exemptions_invalid_id(self):
+    def test_delete_exemptions_invalid_id(self, config):
         invalid_id = None
         try:
-            result = self.config.settings_service.delete_exemptions(invalid_id)
+            result = config.settings_service.delete_exemptions(invalid_id)
             pytest.fail(f"Expected exception for invalid id: {invalid_id}, but got {result}")
         except Exception:
             assert True

--- a/tests-functional/tests/settings/test_node_config.py
+++ b/tests-functional/tests/settings/test_node_config.py
@@ -8,18 +8,18 @@ logger = logging.getLogger(__name__)
 @pytest.mark.rpc
 class TestNodeConfig:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.config = backend_new_profile("sender")
+    @pytest.fixture()
+    def config(self, backend_new_profile):
+        return backend_new_profile("settings-backend")
 
-    def test_verify_node_config_stability(self):
-        cfg1 = self.config.settings_service.get_node_config()
-        cfg2 = self.config.settings_service.get_node_config()
+    def test_verify_node_config_stability(self, config):
+        cfg1 = config.settings_service.get_node_config()
+        cfg2 = config.settings_service.get_node_config()
         assert cfg1 == cfg2, "NodeConfig should be stable across calls"
 
-    def test_check_node_config_params(self):
-        cfg = self.config.settings_service.get_node_config()
-        boot_api = self.config.get_boot_api_config()
+    def test_check_node_config_params(self, config):
+        cfg = config.settings_service.get_node_config()
+        boot_api = config.get_boot_api_config()
         assert cfg["WSEnabled"] == boot_api["wsEnabled"]
         assert cfg["WSHost"] == boot_api["wsHost"]
         assert cfg["WSPort"] == boot_api["wsPort"]

--- a/tests-functional/tests/settings/test_notifications.py
+++ b/tests-functional/tests/settings/test_notifications.py
@@ -10,41 +10,41 @@ logger = logging.getLogger(__name__)
 @pytest.mark.rpc
 class TestNotificationSettings:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.config = backend_new_profile("sender")
+    @pytest.fixture()
+    def config(self, backend_new_profile):
+        return backend_new_profile("settings-backend")
 
-    def test_notifications_get_allow_notifications(self):
-        result = self.config.settings_service.notifications_get_allow_notifications()
+    def test_notifications_get_allow_notifications(self, config):
+        result = config.settings_service.notifications_get_allow_notifications()
         assert result is not None, "Expected a non-null result"
         assert isinstance(result, bool), f"Expected bool, got {type(result)}"
 
-    def test_notifications_setter_allow_notifications_invalid_values(self):
+    def test_notifications_setter_allow_notifications_invalid_values(self, config):
         with pytest.raises(ApiResponseError, match=re.escape("json: cannot unmarshal")):
-            self.config.settings_service.notifications_set_allow_notifications(1)
+            config.settings_service.notifications_set_allow_notifications(1)
 
-    def test_notifications_setter_allow_notifications_none(self):
-        res = self.config.settings_service.notifications_set_allow_notifications(None)
+    def test_notifications_setter_allow_notifications_none(self, config):
+        res = config.settings_service.notifications_set_allow_notifications(None)
         assert res is None
-        got = self.config.settings_service.notifications_get_allow_notifications()
+        got = config.settings_service.notifications_get_allow_notifications()
         assert isinstance(got, bool), f"Expected bool, got {type(got)}"
 
-    def test_notifications_allow_alter_value(self):
+    def test_notifications_allow_alter_value(self, config):
         for value in [True, False, True]:
-            result = self.config.settings_service.notifications_set_allow_notifications(value)
+            result = config.settings_service.notifications_set_allow_notifications(value)
             assert result is None
-            got = self.config.settings_service.notifications_get_allow_notifications()
+            got = config.settings_service.notifications_get_allow_notifications()
             assert isinstance(got, bool)
             assert got is value
 
-    def test_notifications_get_one_to_one_chats_return_type(self):
-        result = self.config.settings_service.notifications_get_one_to_one_chats()
+    def test_notifications_get_one_to_one_chats_return_type(self, config):
+        result = config.settings_service.notifications_get_one_to_one_chats()
         assert result is not None, "Expected a non-null return value"
         assert isinstance(result, str), f"Expected str, got {type(result)}"
 
-    def test_notifications_set_one_to_one_chats_invalid_type(self):
+    def test_notifications_set_one_to_one_chats_invalid_type(self, config):
         with pytest.raises(ApiResponseError, match=re.escape("json: cannot unmarshal")):
-            self.config.settings_service.notifications_set_one_to_one_chats(123)
+            config.settings_service.notifications_set_one_to_one_chats(123)
 
     @pytest.mark.parametrize(
         "value",
@@ -53,155 +53,155 @@ class TestNotificationSettings:
             "",
         ],
     )
-    def test_notifications_set_get_one_to_one_chats(self, value):
+    def test_notifications_set_get_one_to_one_chats(self, config, value):
         logger.info(f"Setting OneToOneChats to: '{value}'")
-        result = self.config.settings_service.notifications_set_one_to_one_chats(value)
+        result = config.settings_service.notifications_set_one_to_one_chats(value)
         assert result is None, f"Expected None, got {result}"
 
-        got = self.config.settings_service.notifications_get_one_to_one_chats()
+        got = config.settings_service.notifications_get_one_to_one_chats()
         assert isinstance(got, str)
         assert got == value
 
-    def test_notifications_get_group_chats_return_type(self):
-        result = self.config.settings_service.notifications_get_group_chats()
+    def test_notifications_get_group_chats_return_type(self, config):
+        result = config.settings_service.notifications_get_group_chats()
         assert result is not None, "Expected a non-null return value"
         assert isinstance(result, str), f"Expected str, got {type(result)}"
         assert result != "", "Expected non-empty string"
 
-    def test_notifications_set_and_get_group_chats(self):
+    def test_notifications_set_and_get_group_chats(self, config):
         value = "SendAlerts"
-        result = self.config.settings_service.notifications_set_group_chats(value)
+        result = config.settings_service.notifications_set_group_chats(value)
         assert result is None, f"Expected None, got {result}"
-        got = self.config.settings_service.notifications_get_group_chats()
+        got = config.settings_service.notifications_get_group_chats()
         assert got is not None, "Expected non-null value from getter"
         assert isinstance(got, str), f"Expected str, got {type(got)}"
         assert got == value, f"Expected '{value}', got '{got}'"
 
-    def test_notifications_set_group_chats_invalid_values(self):
+    def test_notifications_set_group_chats_invalid_values(self, config):
         with pytest.raises(ApiResponseError, match=re.escape("json: cannot unmarshal")):
-            self.config.settings_service.notifications_set_group_chats(123)
+            config.settings_service.notifications_set_group_chats(123)
 
-    def test_notifications_set_and_get_all_messages(self):
+    def test_notifications_set_and_get_all_messages(self, config):
         value = "AllMessages"
-        result = self.config.settings_service.notifications_set_all_messages(value)
+        result = config.settings_service.notifications_set_all_messages(value)
         assert result is None, f"Expected None, got {result}"
-        got = self.config.settings_service.notifications_get_all_messages()
+        got = config.settings_service.notifications_get_all_messages()
         assert got is not None, "Expected non-null value from getter"
         assert isinstance(got, str), f"Expected str, got {type(got)}"
         assert got == value, f"Expected '{value}', got '{got}'"
 
-    def test_notifications_get_contact_requests(self):
-        result = self.config.settings_service.notifications_get_contact_requests()
+    def test_notifications_get_contact_requests(self, config):
+        result = config.settings_service.notifications_get_contact_requests()
         assert result is not None, "Expected non-null result from NotificationsGetContactRequests()"
         assert isinstance(result, str), f"Expected type str, got {type(result)}"
         assert result != "", "Expected non-empty string"
 
-    def test_notifications_set_contact_requests_rejects_wrong_types_and_preserves_value(self):
-        original_value = self.config.settings_service.notifications_get_contact_requests()
+    def test_notifications_set_contact_requests_rejects_wrong_types_and_preserves_value(self, config):
+        original_value = config.settings_service.notifications_get_contact_requests()
         with pytest.raises(ApiResponseError, match=re.escape("json: cannot unmarshal")):
-            self.config.settings_service.notifications_set_contact_requests(123)
-        current_value = self.config.settings_service.notifications_get_contact_requests()
+            config.settings_service.notifications_set_contact_requests(123)
+        current_value = config.settings_service.notifications_get_contact_requests()
         assert current_value == original_value, f"Value changed after invalid set attempt. Expected {original_value!r}, got {current_value!r}"
 
-    def test_notifications_set_and_get_contact_requests(self):
+    def test_notifications_set_and_get_contact_requests(self, config):
         valid_value = "SendAlerts"
-        self.config.settings_service.notifications_set_contact_requests(valid_value)
-        get_result = self.config.settings_service.notifications_get_contact_requests()
+        config.settings_service.notifications_set_contact_requests(valid_value)
+        get_result = config.settings_service.notifications_get_contact_requests()
         assert get_result is not None, "Expected non-null value from getter"
         assert isinstance(get_result, str), f"Expected string from getter, got {type(get_result)}"
         assert get_result == valid_value, f"Expected getter to return '{valid_value}', but got '{get_result}'"
 
-    def test_notifications_get_identity_verification_requests(self):
-        result = self.config.settings_service.notifications_get_identity_verification_requests()
+    def test_notifications_get_identity_verification_requests(self, config):
+        result = config.settings_service.notifications_get_identity_verification_requests()
         assert isinstance(result, str), f"Expected string, got {type(result)}"
         valid_values = ["SendAlerts", "TurnOff"]
         assert result in valid_values, f"Unexpected value: {result}"
 
     @pytest.mark.xfail(reason="API accepts wrong values")
-    def test_notifications_set_identity_verification_requests_rejects_invalid_values(self):
+    def test_notifications_set_identity_verification_requests_rejects_invalid_values(self, config):
         invalid_value = 123
-        original_value = self.config.settings_service.notifications_get_identity_verification_requests()
+        original_value = config.settings_service.notifications_get_identity_verification_requests()
         with pytest.raises(ApiResponseError, match=re.escape("json: cannot unmarshal")):
-            self.config.settings_service.notifications_set_identity_verification_requests(invalid_value)
-        current_value = self.config.settings_service.notifications_get_identity_verification_requests()
+            config.settings_service.notifications_set_identity_verification_requests(invalid_value)
+        current_value = config.settings_service.notifications_get_identity_verification_requests()
         assert current_value == original_value, f"Value changed after invalid input {invalid_value!r}: expected {original_value}, got {current_value}"
         assert current_value in ["SendAlerts", "TurnOff"], f"Unexpected stored value: {current_value}"
 
-    def test_notifications_get_sound_enabled(self):
-        result = self.config.settings_service.notifications_get_sound_enabled()
+    def test_notifications_get_sound_enabled(self, config):
+        result = config.settings_service.notifications_get_sound_enabled()
         assert result is not None, "Expected non-null result"
         assert isinstance(result, bool), f"Expected bool, got {type(result)}"
         assert result is True, "Expected True"
 
-    def test_toggle_notifications_sound_enabled(self):
-        initial_value = self.config.settings_service.notifications_get_sound_enabled()
+    def test_toggle_notifications_sound_enabled(self, config):
+        initial_value = config.settings_service.notifications_get_sound_enabled()
         assert isinstance(initial_value, bool), f"Expected bool, got {type(initial_value)}"
         new_value = not initial_value
-        self.config.settings_service.notifications_set_sound_enabled(new_value)
-        updated_value = self.config.settings_service.notifications_get_sound_enabled()
+        config.settings_service.notifications_set_sound_enabled(new_value)
+        updated_value = config.settings_service.notifications_get_sound_enabled()
         assert updated_value == new_value, f"Expected sound enabled to be {new_value}, but got {updated_value}"
-        self.config.settings_service.notifications_set_sound_enabled(initial_value)
-        reverted_value = self.config.settings_service.notifications_get_sound_enabled()
+        config.settings_service.notifications_set_sound_enabled(initial_value)
+        reverted_value = config.settings_service.notifications_get_sound_enabled()
         assert reverted_value == initial_value, "Failed to revert sound enabled to its original state"
 
-    def test_notifications_set_sound_enabled_invalid_type(self):
+    def test_notifications_set_sound_enabled_invalid_type(self, config):
         invalid_value = "true"
-        initial_value = self.config.settings_service.notifications_get_sound_enabled()
+        initial_value = config.settings_service.notifications_get_sound_enabled()
         try:
-            self.config.settings_service.notifications_set_sound_enabled(invalid_value)
+            config.settings_service.notifications_set_sound_enabled(invalid_value)
         except Exception:
             pass
-        final_value = self.config.settings_service.notifications_get_sound_enabled()
+        final_value = config.settings_service.notifications_get_sound_enabled()
         assert final_value == initial_value, f"Sound enabled changed after invalid input {invalid_value}"
 
-    def test_notifications_set_exemptions_valid(self):
+    def test_notifications_set_exemptions_valid(self, config):
         test_id = "chat:12345"
         mute_all = True
         personal = "all"
         global_ = "mentions-only"
         other = "none"
-        result = self.config.settings_service.notifications_set_exemptions(test_id, mute_all, personal, global_, other)
+        result = config.settings_service.notifications_set_exemptions(test_id, mute_all, personal, global_, other)
         assert result is None or result == "", f"Expected None or empty string, got {result}"
 
-    def test_set_exemptions_and_verify_each_field(self):
+    def test_set_exemptions_and_verify_each_field(self, config):
         eid = "chat:test001"
         mute = True
         personal = "all"
         global_ = "mentions-only"
         other = "none"
 
-        res = self.config.settings_service.notifications_set_exemptions(eid, mute, personal, global_, other)
+        res = config.settings_service.notifications_set_exemptions(eid, mute, personal, global_, other)
         assert res is None or res == "", f"Expected no payload, got {res}"
 
-        got_mute = self.config.settings_service.notifications_get_ex_mute_all_messages(eid)
+        got_mute = config.settings_service.notifications_get_ex_mute_all_messages(eid)
         assert isinstance(got_mute, bool)
         assert got_mute is mute
 
-        got_personal = self.config.settings_service.notifications_get_ex_personal_mentions(eid)
+        got_personal = config.settings_service.notifications_get_ex_personal_mentions(eid)
         assert isinstance(got_personal, str)
         assert got_personal == personal
 
-        got_global = self.config.settings_service.notifications_get_ex_global_mentions(eid)
+        got_global = config.settings_service.notifications_get_ex_global_mentions(eid)
         assert isinstance(got_global, str)
         assert got_global == global_
 
-        got_other = self.config.settings_service.notifications_get_ex_other_messages(eid)
+        got_other = config.settings_service.notifications_get_ex_other_messages(eid)
         assert isinstance(got_other, str)
         assert got_other == other
 
-    def test_update_existing_exemptions(self):
+    def test_update_existing_exemptions(self, config):
         eid = "chat:test002"
-        self.config.settings_service.notifications_set_exemptions(eid, False, "none", "none", "none")
+        config.settings_service.notifications_set_exemptions(eid, False, "none", "none", "none")
         mute2 = True
         personal2 = "all"
         global2 = "mentions-only"
         other2 = "important-only"
-        res = self.config.settings_service.notifications_set_exemptions(eid, mute2, personal2, global2, other2)
+        res = config.settings_service.notifications_set_exemptions(eid, mute2, personal2, global2, other2)
         assert res is None or res == ""
-        assert self.config.settings_service.notifications_get_ex_mute_all_messages(eid) is mute2
-        assert self.config.settings_service.notifications_get_ex_personal_mentions(eid) == personal2
-        assert self.config.settings_service.notifications_get_ex_global_mentions(eid) == global2
-        assert self.config.settings_service.notifications_get_ex_other_messages(eid) == other2
+        assert config.settings_service.notifications_get_ex_mute_all_messages(eid) is mute2
+        assert config.settings_service.notifications_get_ex_personal_mentions(eid) == personal2
+        assert config.settings_service.notifications_get_ex_global_mentions(eid) == global2
+        assert config.settings_service.notifications_get_ex_other_messages(eid) == other2
 
     @pytest.mark.parametrize(
         "params",
@@ -213,7 +213,7 @@ class TestNotificationSettings:
             ("chat:x", True, "all", "all", 0),
         ],
     )
-    def test_set_exemptions_invalid_inputs(self, params):
+    def test_set_exemptions_invalid_inputs(self, config, params):
         eid, mute, personal, global_, other = params
         logger.info(
             f"\n[TEST] Invalid call: id={eid!r}({type(eid).__name__}), "
@@ -223,134 +223,134 @@ class TestNotificationSettings:
             f"other={other!r}({type(other).__name__})"
         )
         try:
-            self.config.settings_service.notifications_set_exemptions(eid, mute, personal, global_, other)
+            config.settings_service.notifications_set_exemptions(eid, mute, personal, global_, other)
             pytest.fail("Expected exception or backend error for invalid types, but call succeeded.")
         except Exception:
             assert True
 
-    def test_notifications_get_message_preview_type(self):
-        value = self.config.settings_service.notifications_get_message_preview()
+    def test_notifications_get_message_preview_type(self, config):
+        value = config.settings_service.notifications_get_message_preview()
         assert value is not None
         assert isinstance(value, int)
         assert value in [0, 1, 2], f"Unexpected value: {value}"
 
-    def test_notifications_message_preview_roundtrip_set_and_get(self):
-        original = self.config.settings_service.notifications_get_message_preview()
+    def test_notifications_message_preview_roundtrip_set_and_get(self, config):
+        original = config.settings_service.notifications_get_message_preview()
         assert isinstance(original, int)
         candidate = 1 if original == 0 else 0
-        res = self.config.settings_service.notifications_set_message_preview(candidate)
+        res = config.settings_service.notifications_set_message_preview(candidate)
         assert res is None or res == ""
-        got = self.config.settings_service.notifications_get_message_preview()
+        got = config.settings_service.notifications_get_message_preview()
         assert got == candidate
         try:
-            self.config.settings_service.notifications_set_message_preview(original)
+            config.settings_service.notifications_set_message_preview(original)
         except Exception:
             pass
 
     @pytest.mark.xfail(reason=" API accepts -1")
-    def test_notifications_message_preview_rejects_invalid_values(self):
+    def test_notifications_message_preview_rejects_invalid_values(self, config):
         bad_value = -1
-        before = self.config.settings_service.notifications_get_message_preview()
+        before = config.settings_service.notifications_get_message_preview()
         try:
-            _ = self.config.settings_service.notifications_set_message_preview(bad_value)
+            _ = config.settings_service.notifications_set_message_preview(bad_value)
         except ApiResponseError:
             pass
         except Exception:
             pass
-        after = self.config.settings_service.notifications_get_message_preview()
+        after = config.settings_service.notifications_get_message_preview()
         assert after == before
 
-    def test_notifications_get_volume_returns_valid_type(self):
-        result = self.config.settings_service.notifications_get_volume()
+    def test_notifications_get_volume_returns_valid_type(self, config):
+        result = config.settings_service.notifications_get_volume()
         assert isinstance(result, int), f"Expected int, got {type(result)}"
 
-    def test_notifications_set_and_get_volume(self):
+    def test_notifications_set_and_get_volume(self, config):
         """Setter should accept integer; getter should return the same integer type."""
         test_values = [0, 5, 10, 42]
 
         for value in test_values:
-            result = self.config.settings_service.notifications_set_volume(value)
+            result = config.settings_service.notifications_set_volume(value)
             assert result is None or result == "", f"Unexpected setter response: {result}"
-            get_result = self.config.settings_service.notifications_get_volume()
+            get_result = config.settings_service.notifications_get_volume()
 
             assert isinstance(get_result, int), f"Expected int, got {type(get_result)}"
             assert get_result == value, f"Getter returned {get_result}, expected {value}"
 
-    def test_notifications_set_volume_rejects_invalid_types(self):
+    def test_notifications_set_volume_rejects_invalid_types(self, config):
         invalid_value = "loud"
 
-        original_value = self.config.settings_service.notifications_get_volume()
+        original_value = config.settings_service.notifications_get_volume()
         assert isinstance(original_value, int), "Precondition failed: getter did not return int"
 
         with pytest.raises(ApiResponseError, match=re.escape("json: cannot unmarshal")):
-            self.config.settings_service.notifications_set_volume(invalid_value)
-        current_value = self.config.settings_service.notifications_get_volume()
+            config.settings_service.notifications_set_volume(invalid_value)
+        current_value = config.settings_service.notifications_get_volume()
         assert isinstance(current_value, int), f"Getter returned {type(current_value)} after invalid input"
         assert current_value == original_value, f"Volume changed after invalid input: was {original_value}, now {current_value}"
 
-    def test_notifications_get_personal_mentions_type_check(self):
-        value = self.config.settings_service.notifications_get_personal_mentions()
+    def test_notifications_get_personal_mentions_type_check(self, config):
+        value = config.settings_service.notifications_get_personal_mentions()
         assert value is not None
         assert isinstance(value, str)
         assert value != "", "Expected non-empty string"
 
-    def test_notifications_personal_mentions_setter_getter(self):
+    def test_notifications_personal_mentions_setter_getter(self, config):
         new_value = "all"
-        self.config.settings_service.notifications_get_personal_mentions()
-        res = self.config.settings_service.notifications_set_personal_mentions(new_value)
+        config.settings_service.notifications_get_personal_mentions()
+        res = config.settings_service.notifications_set_personal_mentions(new_value)
         assert res is None or res == ""
-        got = self.config.settings_service.notifications_get_personal_mentions()
+        got = config.settings_service.notifications_get_personal_mentions()
         assert isinstance(got, str)
         assert got == new_value
 
-    def test_notifications_set_personal_mentions_rejects_wrong_types(self):
+    def test_notifications_set_personal_mentions_rejects_wrong_types(self, config):
         bad_value = 123
-        before = self.config.settings_service.notifications_get_personal_mentions()
+        before = config.settings_service.notifications_get_personal_mentions()
         with pytest.raises(ApiResponseError, match=re.escape("json: cannot unmarshal")):
-            self.config.settings_service.notifications_set_personal_mentions(bad_value)
-        after = self.config.settings_service.notifications_get_personal_mentions()
+            config.settings_service.notifications_set_personal_mentions(bad_value)
+        after = config.settings_service.notifications_get_personal_mentions()
         assert after == before
 
-    def test_notifications_get_global_mentions_returns_string(self):
-        value = self.config.settings_service.notifications_get_global_mentions()
+    def test_notifications_get_global_mentions_returns_string(self, config):
+        value = config.settings_service.notifications_get_global_mentions()
         assert isinstance(value, str)
         assert value != "", "Expected non-empty string"
 
-    def test_notifications_global_mentions_setter_getter(self):
+    def test_notifications_global_mentions_setter_getter(self, config):
         new_value = "all"
-        self.config.settings_service.notifications_get_global_mentions()
-        res = self.config.settings_service.notifications_set_global_mentions(new_value)
+        config.settings_service.notifications_get_global_mentions()
+        res = config.settings_service.notifications_set_global_mentions(new_value)
         assert res is None or res == ""
-        got = self.config.settings_service.notifications_get_global_mentions()
+        got = config.settings_service.notifications_get_global_mentions()
         assert got == new_value
 
     @pytest.mark.skip(reason="Pending on issue resolution https://github.com/status-im/status-go/issues/7101")
     @pytest.mark.parametrize("bad_value", [123, True, ["list"], {"k": "v"}, None])
-    def test_notifications_set_global_mentions_rejects_wrong_types_and_preserves_value(self, bad_value):
-        before = self.config.settings_service.notifications_get_global_mentions()
+    def test_notifications_set_global_mentions_rejects_wrong_types_and_preserves_value(self, config, bad_value):
+        before = config.settings_service.notifications_get_global_mentions()
         logger.info(f"[SETUP] before={before!r}, bad_value={bad_value!r} ({type(bad_value).__name__})")
         with pytest.raises(ApiResponseError):
-            self.config.settings_service.notifications_set_global_mentions(bad_value)
-        after = self.config.settings_service.notifications_get_global_mentions()
+            config.settings_service.notifications_set_global_mentions(bad_value)
+        after = config.settings_service.notifications_get_global_mentions()
         assert after == before
 
-    def test_get_settings_reflects(self):
-        all_before = self.config.settings_service.get_settings()
-        original_value = self.config.settings_service.notifications_get_global_mentions()
+    def test_get_settings_reflects(self, config):
+        all_before = config.settings_service.get_settings()
+        original_value = config.settings_service.notifications_get_global_mentions()
         new_value = "mentions-only" if original_value != "mentions-only" else "all"
-        self.config.settings_service.notifications_set_global_mentions(new_value)
-        all_after = self.config.settings_service.get_settings()
+        config.settings_service.notifications_set_global_mentions(new_value)
+        all_after = config.settings_service.get_settings()
         assert len(all_before) == len(all_after)
 
-    def test_notifications_get_identity_verification_requests_returns_string(self):
-        value = self.config.settings_service.notifications_get_identity_verification_requests()
+    def test_notifications_get_identity_verification_requests_returns_string(self, config):
+        value = config.settings_service.notifications_get_identity_verification_requests()
         assert isinstance(value, str)
         assert value != "", "Expected non-empty string"
 
-    def test_notifications_identity_verification_requests_roundtrip(self):
-        original = self.config.settings_service.notifications_get_identity_verification_requests()
+    def test_notifications_identity_verification_requests_roundtrip(self, config):
+        original = config.settings_service.notifications_get_identity_verification_requests()
         new_value = "enabled" if original != "enabled" else "disabled"
-        self.config.settings_service.notifications_set_identity_verification_requests(new_value)
-        got = self.config.settings_service.notifications_get_identity_verification_requests()
+        config.settings_service.notifications_set_identity_verification_requests(new_value)
+        got = config.settings_service.notifications_get_identity_verification_requests()
         assert isinstance(got, str)
         assert got == new_value

--- a/tests-functional/tests/test_activity_center_notifications.py
+++ b/tests-functional/tests/test_activity_center_notifications.py
@@ -9,9 +9,11 @@ from clients.services.wakuext import ActivityCenterNotificationType
 
 def _get_activity_center_notifications(
     backend_instance: StatusBackend,
-    activity_types: list = [activity for activity in ActivityCenterNotificationType],
+    activity_types: Union[list, None] = None,
     read_type: Union[int, None] = None,
 ):
+    if activity_types is None:
+        activity_types = [activity for activity in ActivityCenterNotificationType]
     params = {"cursor": "", "limit": 20, "activity_types": activity_types}
     if read_type:
         params["read_type"] = read_type
@@ -21,74 +23,78 @@ def _get_activity_center_notifications(
 @pytest.mark.rpc
 class TestActivityCenterNotifications(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two unprivileged backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender")
-        self.receiver = backend_new_profile("receiver")
+    @pytest.fixture()
+    def sender(self, backend_new_profile):
+        return backend_new_profile("sender")
 
-    def test_activity_center_notifications(self):
-        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
+    @pytest.fixture()
+    def receiver(self, backend_new_profile):
+        return backend_new_profile("receiver")
+
+    def test_activity_center_notifications(self, sender, receiver):
+        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
         response = _get_activity_center_notifications(
-            backend_instance=self.receiver, activity_types=[ActivityCenterNotificationType.NOTIFICATION_TYPE_CONTACT_REQUEST], read_type=2
+            backend_instance=receiver,
+            activity_types=[ActivityCenterNotificationType.NOTIFICATION_TYPE_CONTACT_REQUEST],
+            read_type=2,
         )
         notification = response["notifications"][0]
         assert all(
             (
                 notification["accepted"] is False,
-                notification["author"] == self.sender.public_key,
-                notification["chatId"] == self.sender.public_key,
+                notification["author"] == sender.public_key,
+                notification["chatId"] == sender.public_key,
                 notification["id"] == message_id,
                 notification["read"] is False,
                 notification["lastMessage"]["contactRequestState"] == 1,
             )
         )
 
-        self.accept_contact_request_and_wait_for_signal_to_be_received(message_id)
-        response = _get_activity_center_notifications(backend_instance=self.sender)
+        self.accept_contact_request_and_wait_for_signal_to_be_received(message_id, sender=sender, receiver=receiver)
+        response = _get_activity_center_notifications(backend_instance=sender)
         notification = response["notifications"][0]
         assert all(
             (
                 notification["accepted"] is True,
-                notification["author"] == self.sender.public_key,
-                notification["chatId"] == self.receiver.public_key,
+                notification["author"] == sender.public_key,
+                notification["chatId"] == receiver.public_key,
                 notification["id"] == message_id,
                 notification["read"] is True,
                 notification["message"]["contactRequestState"] == 2,
-                notification["lastMessage"]["text"] == f"@{self.receiver.public_key} accepted your contact request",
+                notification["lastMessage"]["text"] == f"@{receiver.public_key} accepted your contact request",
             )
         )
 
-    def test_activity_center_notifications_count(self):
-        self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.activity_center_notifications_count([1, 2, 3, 4, 5, 7, 8, 9, 10, 23, 24], 2)
+    def test_activity_center_notifications_count(self, sender, receiver):
+        self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        response = receiver.wakuext_service.activity_center_notifications_count([1, 2, 3, 4, 5, 7, 8, 9, 10, 23, 24], 2)
         assert response["5"] == 1
 
-    def test_seen_unseen_activity_center_notifications(self):
-        self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.has_unseen_activity_center_notifications()
+    def test_seen_unseen_activity_center_notifications(self, sender, receiver):
+        self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        response = receiver.wakuext_service.has_unseen_activity_center_notifications()
         assert response is True
 
-        response = self.receiver.wakuext_service.mark_as_seen_activity_center_notifications()
+        response = receiver.wakuext_service.mark_as_seen_activity_center_notifications()
         assert response.get("activityCenterState").get("hasSeen") is True
         assert response.get("discordOldestMessageTimestamp") == 0
 
-        response = self.receiver.wakuext_service.has_unseen_activity_center_notifications()
+        response = receiver.wakuext_service.has_unseen_activity_center_notifications()
         assert response is False
 
-    def test_get_activity_center_state(self):
-        self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.get_activity_center_state()
+    def test_get_activity_center_state(self, sender, receiver):
+        self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        response = receiver.wakuext_service.get_activity_center_state()
         assert response["hasSeen"] is False
 
-        self.receiver.wakuext_service.mark_as_seen_activity_center_notifications()
+        receiver.wakuext_service.mark_as_seen_activity_center_notifications()
 
-        response = self.receiver.wakuext_service.get_activity_center_state()
+        response = receiver.wakuext_service.get_activity_center_state()
         assert response["hasSeen"] is True
 
-    def test_mark_all_activity_center_notifications_read(self):
-        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.mark_all_activity_center_notifications_read()
+    def test_mark_all_activity_center_notifications_read(self, sender, receiver):
+        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        response = receiver.wakuext_service.mark_all_activity_center_notifications_read()
         assert all(
             (
                 response["activityCenterState"]["hasSeen"] is True,
@@ -97,12 +103,12 @@ class TestActivityCenterNotifications(MessengerSteps):
             )
         )
 
-        response = self.receiver.wakuext_service.has_unseen_activity_center_notifications()
+        response = receiver.wakuext_service.has_unseen_activity_center_notifications()
         assert response is False
 
-    def test_mark_activity_center_notifications_read_unread(self):
-        message_id = self.make_contacts(self.sender, self.receiver)
-        response = self.sender.wakuext_service.mark_activity_center_notifications_read([message_id])
+    def test_mark_activity_center_notifications_read_unread(self, sender, receiver):
+        message_id = self.make_contacts(sender, receiver)
+        response = sender.wakuext_service.mark_activity_center_notifications_read([message_id])
         assert all(
             (
                 response["activityCenterNotifications"][0]["id"] == message_id,
@@ -111,11 +117,12 @@ class TestActivityCenterNotifications(MessengerSteps):
         )
 
         result = _get_activity_center_notifications(
-            backend_instance=self.sender, activity_types=[ActivityCenterNotificationType.NOTIFICATION_TYPE_CONTACT_REQUEST]
+            backend_instance=sender,
+            activity_types=[ActivityCenterNotificationType.NOTIFICATION_TYPE_CONTACT_REQUEST],
         )
         assert result["notifications"][0]["read"] is True
 
-        response = self.sender.wakuext_service.mark_activity_center_notifications_unread([message_id])
+        response = sender.wakuext_service.mark_activity_center_notifications_unread([message_id])
         assert all(
             (
                 response["activityCenterState"]["hasSeen"] is False,
@@ -125,32 +132,33 @@ class TestActivityCenterNotifications(MessengerSteps):
         )
 
         result = _get_activity_center_notifications(
-            backend_instance=self.sender, activity_types=[ActivityCenterNotificationType.NOTIFICATION_TYPE_CONTACT_REQUEST]
+            backend_instance=sender,
+            activity_types=[ActivityCenterNotificationType.NOTIFICATION_TYPE_CONTACT_REQUEST],
         )
         assert result["notifications"][0]["read"] is False
 
-    def test_accept_activity_center_notifications(self):
-        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        result = self.receiver.wakuext_service.accept_activity_center_notifications([message_id])
+    def test_accept_activity_center_notifications(self, sender, receiver):
+        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        result = receiver.wakuext_service.accept_activity_center_notifications([message_id])
         assert result.get("activityCenterState").get("hasSeen") is True
 
-        result = _get_activity_center_notifications(backend_instance=self.receiver)
+        result = _get_activity_center_notifications(backend_instance=receiver)
         assert all((result["notifications"][0]["accepted"] is True, result["notifications"][0]["id"] == message_id))
 
-    def test_dismiss_activity_center_notifications(self):
-        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        result = self.receiver.wakuext_service.dismiss_activity_center_notifications([message_id])
+    def test_dismiss_activity_center_notifications(self, sender, receiver):
+        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        result = receiver.wakuext_service.dismiss_activity_center_notifications([message_id])
         assert result is None
 
-        result = _get_activity_center_notifications(backend_instance=self.receiver)
+        result = _get_activity_center_notifications(backend_instance=receiver)
         assert all((result["notifications"][0]["dismissed"] is True, result["notifications"][0]["id"] == message_id))
 
-    def test_delete_activity_center_notifications(self):
-        message_id = self.make_contacts(self.sender, self.receiver)
-        result = _get_activity_center_notifications(backend_instance=self.sender)
+    def test_delete_activity_center_notifications(self, sender, receiver):
+        message_id = self.make_contacts(sender, receiver)
+        result = _get_activity_center_notifications(backend_instance=sender)
         assert len(result["notifications"]) == 1
-        result = self.sender.wakuext_service.delete_activity_center_notifications([message_id])
+        result = sender.wakuext_service.delete_activity_center_notifications([message_id])
         assert result is None
 
-        result = _get_activity_center_notifications(backend_instance=self.sender)
+        result = _get_activity_center_notifications(backend_instance=sender)
         assert not result["notifications"]

--- a/tests-functional/tests/test_add_account.py
+++ b/tests-functional/tests/test_add_account.py
@@ -8,103 +8,108 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestAddAccount:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.account_data = copy.deepcopy(new_account_data_1)
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_add_second_wallet_account_to_profile_keypair(self):
+    @pytest.fixture()
+    def account_data(self):
+        return copy.deepcopy(new_account_data_1)
+
+    def test_add_second_wallet_account_to_profile_keypair(self, account, account_data):
         # add account on path m/44'/60'/0'/0/1 to profile keypair
         path = "m/44'/60'/0'/0/1"
-        derived_addresses_response = self.account.wallet_service.get_derived_addresses_for_mnemonic(self.account.mnemonic, [path])
+        derived_addresses_response = account.wallet_service.get_derived_addresses_for_mnemonic(account.mnemonic, [path])
 
         # update account being added with necessary details
-        self.account_data["key-uid"] = self.account.key_uid  # keyuid of profile keypair
-        self.account_data["path"] = path
-        self.account_data["address"] = derived_addresses_response[0].get("address")
-        self.account_data["public-key"] = derived_addresses_response[0].get("public-key")
+        account_data["key-uid"] = account.key_uid  # keyuid of profile keypair
+        account_data["path"] = path
+        account_data["address"] = derived_addresses_response[0].get("address")
+        account_data["public-key"] = derived_addresses_response[0].get("public-key")
 
-        self.account.accounts_service.add_account(self.account.password, self.account_data)
+        account.accounts_service.add_account(account.password, account_data)
         # TODO: Add more assertions on response
 
         # After adding the account check that the get accounts will retrieve the new account
-        accounts_response = self.account.accounts_service.get_accounts()
-        self.check_new_account_was_created(accounts_response, self.account_data)
+        accounts_response = account.accounts_service.get_accounts()
+        self.check_new_account_was_created(accounts_response, account_data)
 
-    def test_add_duplicate_account(self):
+    def test_add_duplicate_account(self, account):
         # since default wallet account is already added by creating the backend profile, we can try just adding the same account again
-        accounts_response = self.account.accounts_service.get_accounts()
+        accounts_response = account.accounts_service.get_accounts()
         assert len(accounts_response) == 2
-        defaultAccount = accounts_response[0]
-        if not defaultAccount["wallet"]:
-            defaultAccount = accounts_response[1]
-        assert defaultAccount["wallet"] is True
+        default_account = accounts_response[0]
+        if not default_account["wallet"]:
+            default_account = accounts_response[1]
+        assert default_account["wallet"] is True
 
         # Add the same account second time
         with pytest.raises(ApiResponseError, match=re.escape("account already exists")):
-            self.account.accounts_service.add_account(self.account.password, defaultAccount)
+            account.accounts_service.add_account(account.password, default_account)
 
-    def test_add_account_for_unknown_key_uid(self):
-        self.account_data["key-uid"] = "0x3231d92c94548d14f097173765a50bebe28fbad8f2267c9e08cc4433a6f219a4"
+    def test_add_account_for_unknown_key_uid(self, account, account_data):
+        account_data["key-uid"] = "0x3231d92c94548d14f097173765a50bebe28fbad8f2267c9e08cc4433a6f219a4"
         with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
-            self.account.accounts_service.add_account(self.account.password, self.account_data)
+            account.accounts_service.add_account(account.password, account_data)
 
-    def test_add_account_for_empty_address(self):
-        self.account_data["address"] = ""
+    def test_add_account_for_empty_address(self, account, account_data):
+        account_data["address"] = ""
         with pytest.raises(ApiResponseError, match=re.escape("invalid argument 1: hex string has length 0, want 40 for types.Address")):
-            self.account.accounts_service.add_account(self.account.password, self.account_data)
+            account.accounts_service.add_account(account.password, account_data)
 
-    def test_add_account_for_empty_path(self):
-        self.account_data["path"] = ""
+    def test_add_account_for_empty_path(self, account, account_data):
+        account_data["path"] = ""
         with pytest.raises(ApiResponseError, match=re.escape("[account] account mismatch")):
-            self.account.accounts_service.add_account(self.account.password, self.account_data)
+            account.accounts_service.add_account(account.password, account_data)
 
     @pytest.mark.parametrize(
         "key, error", [("wallet", "[database] cannot add default wallet account"), ("chat", "[database] cannot add default chat account")]
     )
-    def test_add_account_with_key_set_on_true__(self, key, error):
-        self.account_data["key-uid"] = self.account.key_uid
-        self.account_data[key] = True
+    def test_add_account_with_key_set_on_true__(self, account, account_data, key, error):
+        account_data["key-uid"] = account.key_uid
+        account_data[key] = True
         with pytest.raises(ApiResponseError, match=re.escape(error)):
-            self.account.accounts_service.add_account(self.account.password, self.account_data)
+            account.accounts_service.add_account(account.password, account_data)
 
-    def test_add_watch_account(self):
-        self.account_data["type"] = "watch"
-        self.account.accounts_service.add_account(self.account.password, self.account_data)
+    def test_add_watch_account(self, account, account_data):
+        account_data["type"] = "watch"
+        account.accounts_service.add_account(account.password, account_data)
         # TODO: Add more assertions on response
 
         # After adding the account check that the get accounts will retrieve the new account
-        accounts_response = self.account.accounts_service.get_accounts()
+        accounts_response = account.accounts_service.get_accounts()
         accounts = accounts_response
-        self.check_new_account_was_created(accounts, self.account_data)
+        self.check_new_account_was_created(accounts, account_data)
 
-    def test_add_account_to_seed_imported_keypair(self):
+    def test_add_account_to_seed_imported_keypair(self, account, account_data):
         used_mnemonic = user_1.passphrase
-        profile_password = self.account.password
-        add_keypair_response = self.account.accounts_service.add_keypair_via_seed_phrase(
+        profile_password = account.password
+        add_keypair_response = account.accounts_service.add_keypair_via_seed_phrase(
             used_mnemonic, profile_password, keypair_name, wallet_account_details_derivation
         )
 
         path = "m/44'/60'/0'/0/1"
-        derived_addresses_response = self.account.wallet_service.get_derived_addresses_for_mnemonic(used_mnemonic, [path])
+        derived_addresses_response = account.wallet_service.get_derived_addresses_for_mnemonic(used_mnemonic, [path])
         derived_addresses = derived_addresses_response
 
         # update account being added with necessary details
-        self.account_data["key-uid"] = add_keypair_response["key-uid"]
-        self.account_data["path"] = path
-        self.account_data["address"] = derived_addresses[0].get("address")
-        self.account_data["public-key"] = derived_addresses[0].get("public-key")
+        account_data["key-uid"] = add_keypair_response["key-uid"]
+        account_data["path"] = path
+        account_data["address"] = derived_addresses[0].get("address")
+        account_data["public-key"] = derived_addresses[0].get("public-key")
 
-        self.account.accounts_service.add_account(profile_password, self.account_data)
+        account.accounts_service.add_account(profile_password, account_data)
         # TODO: Add more assertions on response
 
-    def get_account_keypairs(self):
-        keypairs_response = self.account.accounts_service.get_account_keypairs()
+    @staticmethod
+    def get_account_keypairs(account):
+        keypairs_response = account.accounts_service.get_account_keypairs()
         keypairs = keypairs_response
         assert len(keypairs) > 0
         return keypairs
 
-    def check_new_account_was_created(self, accounts, account_data):
+    @staticmethod
+    def check_new_account_was_created(accounts, account_data):
         mismatch_details = ""
         for acc in accounts:
             mismatches = []

--- a/tests-functional/tests/test_add_account.py
+++ b/tests-functional/tests/test_add_account.py
@@ -9,34 +9,34 @@ from clients.api import ApiResponseError
 class TestAddAccount:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
     def account_data(self):
         return copy.deepcopy(new_account_data_1)
 
-    def test_add_second_wallet_account_to_profile_keypair(self, account, account_data):
+    def test_add_second_wallet_account_to_profile_keypair(self, backend, account_data):
         # add account on path m/44'/60'/0'/0/1 to profile keypair
         path = "m/44'/60'/0'/0/1"
-        derived_addresses_response = account.wallet_service.get_derived_addresses_for_mnemonic(account.mnemonic, [path])
+        derived_addresses_response = backend.wallet_service.get_derived_addresses_for_mnemonic(backend.mnemonic, [path])
 
         # update account being added with necessary details
-        account_data["key-uid"] = account.key_uid  # keyuid of profile keypair
+        account_data["key-uid"] = backend.key_uid  # keyuid of profile keypair
         account_data["path"] = path
         account_data["address"] = derived_addresses_response[0].get("address")
         account_data["public-key"] = derived_addresses_response[0].get("public-key")
 
-        account.accounts_service.add_account(account.password, account_data)
+        backend.accounts_service.add_account(backend.password, account_data)
         # TODO: Add more assertions on response
 
         # After adding the account check that the get accounts will retrieve the new account
-        accounts_response = account.accounts_service.get_accounts()
+        accounts_response = backend.accounts_service.get_accounts()
         self.check_new_account_was_created(accounts_response, account_data)
 
-    def test_add_duplicate_account(self, account):
+    def test_add_duplicate_account(self, backend):
         # since default wallet account is already added by creating the backend profile, we can try just adding the same account again
-        accounts_response = account.accounts_service.get_accounts()
+        accounts_response = backend.accounts_service.get_accounts()
         assert len(accounts_response) == 2
         default_account = accounts_response[0]
         if not default_account["wallet"]:
@@ -45,51 +45,51 @@ class TestAddAccount:
 
         # Add the same account second time
         with pytest.raises(ApiResponseError, match=re.escape("account already exists")):
-            account.accounts_service.add_account(account.password, default_account)
+            backend.accounts_service.add_account(backend.password, default_account)
 
-    def test_add_account_for_unknown_key_uid(self, account, account_data):
+    def test_add_account_for_unknown_key_uid(self, backend, account_data):
         account_data["key-uid"] = "0x3231d92c94548d14f097173765a50bebe28fbad8f2267c9e08cc4433a6f219a4"
         with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
-            account.accounts_service.add_account(account.password, account_data)
+            backend.accounts_service.add_account(backend.password, account_data)
 
-    def test_add_account_for_empty_address(self, account, account_data):
+    def test_add_account_for_empty_address(self, backend, account_data):
         account_data["address"] = ""
         with pytest.raises(ApiResponseError, match=re.escape("invalid argument 1: hex string has length 0, want 40 for types.Address")):
-            account.accounts_service.add_account(account.password, account_data)
+            backend.accounts_service.add_account(backend.password, account_data)
 
-    def test_add_account_for_empty_path(self, account, account_data):
+    def test_add_account_for_empty_path(self, backend, account_data):
         account_data["path"] = ""
         with pytest.raises(ApiResponseError, match=re.escape("[account] account mismatch")):
-            account.accounts_service.add_account(account.password, account_data)
+            backend.accounts_service.add_account(backend.password, account_data)
 
     @pytest.mark.parametrize(
         "key, error", [("wallet", "[database] cannot add default wallet account"), ("chat", "[database] cannot add default chat account")]
     )
-    def test_add_account_with_key_set_on_true__(self, account, account_data, key, error):
-        account_data["key-uid"] = account.key_uid
+    def test_add_account_with_key_set_on_true__(self, backend, account_data, key, error):
+        account_data["key-uid"] = backend.key_uid
         account_data[key] = True
         with pytest.raises(ApiResponseError, match=re.escape(error)):
-            account.accounts_service.add_account(account.password, account_data)
+            backend.accounts_service.add_account(backend.password, account_data)
 
-    def test_add_watch_account(self, account, account_data):
+    def test_add_watch_account(self, backend, account_data):
         account_data["type"] = "watch"
-        account.accounts_service.add_account(account.password, account_data)
+        backend.accounts_service.add_account(backend.password, account_data)
         # TODO: Add more assertions on response
 
         # After adding the account check that the get accounts will retrieve the new account
-        accounts_response = account.accounts_service.get_accounts()
+        accounts_response = backend.accounts_service.get_accounts()
         accounts = accounts_response
         self.check_new_account_was_created(accounts, account_data)
 
-    def test_add_account_to_seed_imported_keypair(self, account, account_data):
+    def test_add_account_to_seed_imported_keypair(self, backend, account_data):
         used_mnemonic = user_1.passphrase
-        profile_password = account.password
-        add_keypair_response = account.accounts_service.add_keypair_via_seed_phrase(
+        profile_password = backend.password
+        add_keypair_response = backend.accounts_service.add_keypair_via_seed_phrase(
             used_mnemonic, profile_password, keypair_name, wallet_account_details_derivation
         )
 
         path = "m/44'/60'/0'/0/1"
-        derived_addresses_response = account.wallet_service.get_derived_addresses_for_mnemonic(used_mnemonic, [path])
+        derived_addresses_response = backend.wallet_service.get_derived_addresses_for_mnemonic(used_mnemonic, [path])
         derived_addresses = derived_addresses_response
 
         # update account being added with necessary details
@@ -98,12 +98,12 @@ class TestAddAccount:
         account_data["address"] = derived_addresses[0].get("address")
         account_data["public-key"] = derived_addresses[0].get("public-key")
 
-        account.accounts_service.add_account(profile_password, account_data)
+        backend.accounts_service.add_account(profile_password, account_data)
         # TODO: Add more assertions on response
 
     @staticmethod
-    def get_account_keypairs(account):
-        keypairs_response = account.accounts_service.get_account_keypairs()
+    def get_account_keypairs(backend):
+        keypairs_response = backend.accounts_service.get_account_keypairs()
         keypairs = keypairs_response
         assert len(keypairs) > 0
         return keypairs

--- a/tests-functional/tests/test_add_keypair_stored_to_keycard.py
+++ b/tests-functional/tests/test_add_keypair_stored_to_keycard.py
@@ -8,42 +8,42 @@ from resources.constants import user_1, wallet_account_details_derivation, keypa
 class TestAddKeypairStoredToKeycard:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_add_keypair_stored_to_keycard_flow(self, account):
-        add_keypair_resp = account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation
+    def test_add_keypair_stored_to_keycard_flow(self, backend):
+        add_keypair_resp = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase, backend.password, keypair_name, wallet_account_details_derivation
         )
         addresses = [add_keypair_resp.get("accounts")[0].get("address"), add_keypair_resp.get("derived-from")]
 
         key_uid = add_keypair_resp.get("key-uid")
-        account.accounts_service.get_keypair_by_key_uid(key_uid)
+        backend.accounts_service.get_keypair_by_key_uid(key_uid)
 
         for address in addresses:
-            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
             assert resp is True
 
         # delete the keypair so we can add it back
-        account.accounts_service.delete_keypair(key_uid, account.password)
+        backend.accounts_service.delete_keypair(key_uid, backend.password)
         with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
-            account.accounts_service.get_keypair_by_key_uid(key_uid)
+            backend.accounts_service.get_keypair_by_key_uid(key_uid)
 
         for address in addresses:
-            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
             assert resp is False
 
         new_name = "keypair-stored"
-        added_stored_keypair = account.accounts_service.add_keypair_stored_to_keycard(
+        added_stored_keypair = backend.accounts_service.add_keypair_stored_to_keycard(
             key_uid, user_1.address, new_name, [wallet_account_details_derivation]
         )
         assert added_stored_keypair.get("key-uid") == key_uid
         assert added_stored_keypair.get("name") == new_name
 
-        kp_after = account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_after = backend.accounts_service.get_keypair_by_key_uid(key_uid)
         assert kp_after.get("key-uid") == key_uid
         assert kp_after.get("name") == new_name
 
         for address in addresses:
-            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
             assert resp is False

--- a/tests-functional/tests/test_add_keypair_stored_to_keycard.py
+++ b/tests-functional/tests/test_add_keypair_stored_to_keycard.py
@@ -7,43 +7,43 @@ from resources.constants import user_1, wallet_account_details_derivation, keypa
 @pytest.mark.rpc
 class TestAddKeypairStoredToKeycard:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_add_keypair_stored_to_keycard_flow(self):
-        add_keypair_resp = self.account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, self.account.password, keypair_name, wallet_account_details_derivation
+    def test_add_keypair_stored_to_keycard_flow(self, account):
+        add_keypair_resp = account.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation
         )
         addresses = [add_keypair_resp.get("accounts")[0].get("address"), add_keypair_resp.get("derived-from")]
 
         key_uid = add_keypair_resp.get("key-uid")
-        self.account.accounts_service.get_keypair_by_key_uid(key_uid)
+        account.accounts_service.get_keypair_by_key_uid(key_uid)
 
         for address in addresses:
-            resp = self.account.accounts_service.verify_keystore_file_for_account(address, self.account.password)
+            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
             assert resp is True
 
         # delete the keypair so we can add it back
-        self.account.accounts_service.delete_keypair(key_uid, self.account.password)
+        account.accounts_service.delete_keypair(key_uid, account.password)
         with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
-            self.account.accounts_service.get_keypair_by_key_uid(key_uid)
+            account.accounts_service.get_keypair_by_key_uid(key_uid)
 
         for address in addresses:
-            resp = self.account.accounts_service.verify_keystore_file_for_account(address, self.account.password)
+            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
             assert resp is False
 
         new_name = "keypair-stored"
-        added_stored_keypair = self.account.accounts_service.add_keypair_stored_to_keycard(
+        added_stored_keypair = account.accounts_service.add_keypair_stored_to_keycard(
             key_uid, user_1.address, new_name, [wallet_account_details_derivation]
         )
         assert added_stored_keypair.get("key-uid") == key_uid
         assert added_stored_keypair.get("name") == new_name
 
-        kp_after = self.account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_after = account.accounts_service.get_keypair_by_key_uid(key_uid)
         assert kp_after.get("key-uid") == key_uid
         assert kp_after.get("name") == new_name
 
         for address in addresses:
-            resp = self.account.accounts_service.verify_keystore_file_for_account(address, self.account.password)
+            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
             assert resp is False

--- a/tests-functional/tests/test_add_keypair_via_private_key.py
+++ b/tests-functional/tests/test_add_keypair_via_private_key.py
@@ -8,12 +8,12 @@ from clients.api import ApiResponseError
 class TestAddKeypairViaPrivateKey:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_add_valid_keypair_via_private_key(self, account):
-        add_keypair_response = account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, account.password, keypair_name, wallet_account_details_root
+    def test_add_valid_keypair_via_private_key(self, backend):
+        add_keypair_response = backend.accounts_service.add_keypair_via_private_key(
+            user_1.private_key, backend.password, keypair_name, wallet_account_details_root
         )
         add_keypair_result = add_keypair_response
         accounts = add_keypair_result.get("accounts")
@@ -36,38 +36,38 @@ class TestAddKeypairViaPrivateKey:
         assert new_keypair.get("wallet") is False
 
         # Fetch keypairs and ensure the imported one is present
-        get_keypairs_response = account.accounts_service.get_account_keypairs()
+        get_keypairs_response = backend.accounts_service.get_account_keypairs()
         imported_keypairs = [keypair for keypair in get_keypairs_response if keypair.get("name") == keypair_name]
         assert len(imported_keypairs) == 1
         assert add_keypair_result.get("key-uid") == imported_keypairs[0].get("key-uid")
         assert add_keypair_result.get("type") == imported_keypairs[0].get("type")
         assert add_keypair_result.get("derived-from") == imported_keypairs[0].get("derived-from")
 
-    def test_add_a_second_keypair_via_pk_with_same_details(self, account):
-        account.accounts_service.add_keypair_via_private_key(user_1.private_key, account.password, keypair_name, wallet_account_details_root)
+    def test_add_a_second_keypair_via_pk_with_same_details(self, backend):
+        backend.accounts_service.add_keypair_via_private_key(user_1.private_key, backend.password, keypair_name, wallet_account_details_root)
 
         # different private key but same details
-        account.accounts_service.add_keypair_via_private_key(user_2.private_key, account.password, keypair_name, wallet_account_details_root)
+        backend.accounts_service.add_keypair_via_private_key(user_2.private_key, backend.password, keypair_name, wallet_account_details_root)
 
-        keypairs_response = account.accounts_service.get_account_keypairs()
+        keypairs_response = backend.accounts_service.get_account_keypairs()
         imported_keypairs = [keypair for keypair in keypairs_response if keypair.get("name") == keypair_name]
         assert len(imported_keypairs) == 2, "2 keypairs with the same name should be saved"
 
-    def test_add_duplicate_keypair_via_pk(self, account):
-        resp1 = account.accounts_service.add_keypair_via_private_key(user_1.private_key, account.password, keypair_name, wallet_account_details_root)
+    def test_add_duplicate_keypair_via_pk(self, backend):
+        resp1 = backend.accounts_service.add_keypair_via_private_key(user_1.private_key, backend.password, keypair_name, wallet_account_details_root)
 
         # same private key
         with pytest.raises(ApiResponseError, match=re.escape(f'[validation] keypair already added -  keyuid: {resp1.get("key-uid")}')):
-            account.accounts_service.add_keypair_via_private_key(user_1.private_key, account.password, keypair_name, wallet_account_details_root)
+            backend.accounts_service.add_keypair_via_private_key(user_1.private_key, backend.password, keypair_name, wallet_account_details_root)
 
-    def test_add_keypair_via_pk_with_wrong_path(self, account):
+    def test_add_keypair_via_pk_with_wrong_path(self, backend):
         with pytest.raises(
             ApiResponseError,
             match=re.escape("[validation] unsupported profile or seed imported key pair wallet account"),
         ):
-            account.accounts_service.add_keypair_via_private_key(
-                user_1.private_key, account.password, keypair_name, wallet_account_details_derivation
+            backend.accounts_service.add_keypair_via_private_key(
+                user_1.private_key, backend.password, keypair_name, wallet_account_details_derivation
             )
 
-    def test_add_keypair_via_pk_with_empty_password(self, account):
-        account.accounts_service.add_keypair_via_private_key(user_1.private_key, "", keypair_name, wallet_account_details_root)
+    def test_add_keypair_via_pk_with_empty_password(self, backend):
+        backend.accounts_service.add_keypair_via_private_key(user_1.private_key, "", keypair_name, wallet_account_details_root)

--- a/tests-functional/tests/test_add_keypair_via_private_key.py
+++ b/tests-functional/tests/test_add_keypair_via_private_key.py
@@ -7,13 +7,13 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestAddKeypairViaPrivateKey:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_add_valid_keypair_via_private_key(self):
-        add_keypair_response = self.account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, self.account.password, keypair_name, wallet_account_details_root
+    def test_add_valid_keypair_via_private_key(self, account):
+        add_keypair_response = account.accounts_service.add_keypair_via_private_key(
+            user_1.private_key, account.password, keypair_name, wallet_account_details_root
         )
         add_keypair_result = add_keypair_response
         accounts = add_keypair_result.get("accounts")
@@ -36,46 +36,38 @@ class TestAddKeypairViaPrivateKey:
         assert new_keypair.get("wallet") is False
 
         # Fetch keypairs and ensure the imported one is present
-        get_keypairs_response = self.account.accounts_service.get_account_keypairs()
+        get_keypairs_response = account.accounts_service.get_account_keypairs()
         imported_keypairs = [keypair for keypair in get_keypairs_response if keypair.get("name") == keypair_name]
         assert len(imported_keypairs) == 1
         assert add_keypair_result.get("key-uid") == imported_keypairs[0].get("key-uid")
         assert add_keypair_result.get("type") == imported_keypairs[0].get("type")
         assert add_keypair_result.get("derived-from") == imported_keypairs[0].get("derived-from")
 
-    def test_add_a_second_keypair_via_pk_with_same_details(self):
-        self.account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, self.account.password, keypair_name, wallet_account_details_root
-        )
+    def test_add_a_second_keypair_via_pk_with_same_details(self, account):
+        account.accounts_service.add_keypair_via_private_key(user_1.private_key, account.password, keypair_name, wallet_account_details_root)
 
         # different private key but same details
-        self.account.accounts_service.add_keypair_via_private_key(
-            user_2.private_key, self.account.password, keypair_name, wallet_account_details_root
-        )
+        account.accounts_service.add_keypair_via_private_key(user_2.private_key, account.password, keypair_name, wallet_account_details_root)
 
-        keypairs_response = self.account.accounts_service.get_account_keypairs()
+        keypairs_response = account.accounts_service.get_account_keypairs()
         imported_keypairs = [keypair for keypair in keypairs_response if keypair.get("name") == keypair_name]
         assert len(imported_keypairs) == 2, "2 keypairs with the same name should be saved"
 
-    def test_add_duplicate_keypair_via_pk(self):
-        resp1 = self.account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, self.account.password, keypair_name, wallet_account_details_root
-        )
+    def test_add_duplicate_keypair_via_pk(self, account):
+        resp1 = account.accounts_service.add_keypair_via_private_key(user_1.private_key, account.password, keypair_name, wallet_account_details_root)
 
         # same private key
         with pytest.raises(ApiResponseError, match=re.escape(f'[validation] keypair already added -  keyuid: {resp1.get("key-uid")}')):
-            self.account.accounts_service.add_keypair_via_private_key(
-                user_1.private_key, self.account.password, keypair_name, wallet_account_details_root
-            )
+            account.accounts_service.add_keypair_via_private_key(user_1.private_key, account.password, keypair_name, wallet_account_details_root)
 
-    def test_add_keypair_via_pk_with_wrong_path(self):
+    def test_add_keypair_via_pk_with_wrong_path(self, account):
         with pytest.raises(
             ApiResponseError,
             match=re.escape("[validation] unsupported profile or seed imported key pair wallet account"),
         ):
-            self.account.accounts_service.add_keypair_via_private_key(
-                user_1.private_key, self.account.password, keypair_name, wallet_account_details_derivation
+            account.accounts_service.add_keypair_via_private_key(
+                user_1.private_key, account.password, keypair_name, wallet_account_details_derivation
             )
 
-    def test_add_keypair_via_pk_with_empty_password(self):
-        self.account.accounts_service.add_keypair_via_private_key(user_1.private_key, "", keypair_name, wallet_account_details_root)
+    def test_add_keypair_via_pk_with_empty_password(self, account):
+        account.accounts_service.add_keypair_via_private_key(user_1.private_key, "", keypair_name, wallet_account_details_root)

--- a/tests-functional/tests/test_add_keypair_via_seed_phrase.py
+++ b/tests-functional/tests/test_add_keypair_via_seed_phrase.py
@@ -7,13 +7,13 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestAddKeypairViaSeedPhrase:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_add_valid_keypair_via_seed_phrase(self):
-        add_keypair_response = self.account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, self.account.password, keypair_name, wallet_account_details_derivation
+    def test_add_valid_keypair_via_seed_phrase(self, account):
+        add_keypair_response = account.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation
         )
         add_keypair_result = add_keypair_response
         accounts = add_keypair_result.get("accounts")
@@ -36,46 +36,38 @@ class TestAddKeypairViaSeedPhrase:
         assert new_keypair.get("wallet") is False
 
         # Fetch keypairs and ensure the imported one is present
-        get_keypairs_response = self.account.accounts_service.get_account_keypairs()
+        get_keypairs_response = account.accounts_service.get_account_keypairs()
         imported_keypairs = [keypair for keypair in get_keypairs_response if keypair.get("name") == keypair_name]
         assert len(imported_keypairs) == 1
         assert add_keypair_result.get("key-uid") == imported_keypairs[0].get("key-uid")
         assert add_keypair_result.get("type") == imported_keypairs[0].get("type")
         assert add_keypair_result.get("derived-from") == imported_keypairs[0].get("derived-from")
 
-    def test_add_a_second_keypair_via_sp_with_same_details(self):
-        self.account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, self.account.password, keypair_name, wallet_account_details_derivation
-        )
+    def test_add_a_second_keypair_via_sp_with_same_details(self, account):
+        account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation)
 
         # different private key but same details
-        self.account.accounts_service.add_keypair_via_seed_phrase(
-            user_2.private_key, self.account.password, keypair_name, wallet_account_details_derivation
-        )
+        account.accounts_service.add_keypair_via_seed_phrase(user_2.private_key, account.password, keypair_name, wallet_account_details_derivation)
 
-        keypairs_response = self.account.accounts_service.get_account_keypairs()
+        keypairs_response = account.accounts_service.get_account_keypairs()
         imported_keypairs = [keypair for keypair in keypairs_response if keypair.get("name") == keypair_name]
         assert len(imported_keypairs) == 2, "2 keypairs with the same name should be saved"
 
-    def test_add_duplicate_keypair_via_sp(self):
-        resp1 = self.account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, self.account.password, keypair_name, wallet_account_details_derivation
+    def test_add_duplicate_keypair_via_sp(self, account):
+        resp1 = account.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation
         )
 
         # same private key
         with pytest.raises(ApiResponseError, match=re.escape(f'[validation] keypair already added -  keyuid: {resp1.get("key-uid")}')):
-            self.account.accounts_service.add_keypair_via_seed_phrase(
-                user_1.passphrase, self.account.password, keypair_name, wallet_account_details_derivation
-            )
+            account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation)
 
-    def test_add_keypair_via_sp_with_wrong_path(self):
+    def test_add_keypair_via_sp_with_wrong_path(self, account):
         with pytest.raises(
             ApiResponseError,
             match=re.escape("[validation] unsupported profile or seed imported key pair wallet account"),
         ):
-            self.account.accounts_service.add_keypair_via_seed_phrase(
-                user_1.passphrase, self.account.password, keypair_name, wallet_account_details_root
-            )
+            account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_root)
 
-    def test_add_keypair_via_sp_with_empty_password(self):
-        self.account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, "", keypair_name, wallet_account_details_derivation)
+    def test_add_keypair_via_sp_with_empty_password(self, account):
+        account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, "", keypair_name, wallet_account_details_derivation)

--- a/tests-functional/tests/test_add_keypair_via_seed_phrase.py
+++ b/tests-functional/tests/test_add_keypair_via_seed_phrase.py
@@ -8,12 +8,12 @@ from clients.api import ApiResponseError
 class TestAddKeypairViaSeedPhrase:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_add_valid_keypair_via_seed_phrase(self, account):
-        add_keypair_response = account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation
+    def test_add_valid_keypair_via_seed_phrase(self, backend):
+        add_keypair_response = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase, backend.password, keypair_name, wallet_account_details_derivation
         )
         add_keypair_result = add_keypair_response
         accounts = add_keypair_result.get("accounts")
@@ -36,38 +36,38 @@ class TestAddKeypairViaSeedPhrase:
         assert new_keypair.get("wallet") is False
 
         # Fetch keypairs and ensure the imported one is present
-        get_keypairs_response = account.accounts_service.get_account_keypairs()
+        get_keypairs_response = backend.accounts_service.get_account_keypairs()
         imported_keypairs = [keypair for keypair in get_keypairs_response if keypair.get("name") == keypair_name]
         assert len(imported_keypairs) == 1
         assert add_keypair_result.get("key-uid") == imported_keypairs[0].get("key-uid")
         assert add_keypair_result.get("type") == imported_keypairs[0].get("type")
         assert add_keypair_result.get("derived-from") == imported_keypairs[0].get("derived-from")
 
-    def test_add_a_second_keypair_via_sp_with_same_details(self, account):
-        account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation)
+    def test_add_a_second_keypair_via_sp_with_same_details(self, backend):
+        backend.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, backend.password, keypair_name, wallet_account_details_derivation)
 
         # different private key but same details
-        account.accounts_service.add_keypair_via_seed_phrase(user_2.private_key, account.password, keypair_name, wallet_account_details_derivation)
+        backend.accounts_service.add_keypair_via_seed_phrase(user_2.private_key, backend.password, keypair_name, wallet_account_details_derivation)
 
-        keypairs_response = account.accounts_service.get_account_keypairs()
+        keypairs_response = backend.accounts_service.get_account_keypairs()
         imported_keypairs = [keypair for keypair in keypairs_response if keypair.get("name") == keypair_name]
         assert len(imported_keypairs) == 2, "2 keypairs with the same name should be saved"
 
-    def test_add_duplicate_keypair_via_sp(self, account):
-        resp1 = account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation
+    def test_add_duplicate_keypair_via_sp(self, backend):
+        resp1 = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase, backend.password, keypair_name, wallet_account_details_derivation
         )
 
         # same private key
         with pytest.raises(ApiResponseError, match=re.escape(f'[validation] keypair already added -  keyuid: {resp1.get("key-uid")}')):
-            account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation)
+            backend.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, backend.password, keypair_name, wallet_account_details_derivation)
 
-    def test_add_keypair_via_sp_with_wrong_path(self, account):
+    def test_add_keypair_via_sp_with_wrong_path(self, backend):
         with pytest.raises(
             ApiResponseError,
             match=re.escape("[validation] unsupported profile or seed imported key pair wallet account"),
         ):
-            account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_root)
+            backend.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, backend.password, keypair_name, wallet_account_details_root)
 
-    def test_add_keypair_via_sp_with_empty_password(self, account):
-        account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, "", keypair_name, wallet_account_details_derivation)
+    def test_add_keypair_via_sp_with_empty_password(self, backend):
+        backend.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, "", keypair_name, wallet_account_details_derivation)

--- a/tests-functional/tests/test_collectible_preferences.py
+++ b/tests-functional/tests/test_collectible_preferences.py
@@ -4,25 +4,25 @@ import pytest
 @pytest.mark.rpc
 class TestCollectiblePreferences:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_update_with_valid_collectible_preferences(self):
-        collectible_preferences_before = self.account.accounts_service.get_collectible_preferences()
+    def test_update_with_valid_collectible_preferences(self, account):
+        collectible_preferences_before = account.accounts_service.get_collectible_preferences()
         assert collectible_preferences_before is None
 
         new_collectible_preferences = [{"key": "collection:1234:1", "position": 3, "type": 0, "visible": True}]
-        update_response = self.account.accounts_service.update_collectible_preferences(new_collectible_preferences)
+        update_response = account.accounts_service.update_collectible_preferences(new_collectible_preferences)
         assert update_response is None
 
-        collectible_preferences_after = self.account.accounts_service.get_collectible_preferences()
+        collectible_preferences_after = account.accounts_service.get_collectible_preferences()
         assert collectible_preferences_after == new_collectible_preferences
 
-    def test_update_with_invalid_collectible_preferences(self):
+    def test_update_with_invalid_collectible_preferences(self, account):
         new_collectible_preferences = [{"key": "collection:1234:1", "foo": "bar"}]
-        self.account.accounts_service.update_collectible_preferences(new_collectible_preferences)
-        collectible_preferences_after = self.account.accounts_service.get_collectible_preferences()
+        account.accounts_service.update_collectible_preferences(new_collectible_preferences)
+        collectible_preferences_after = account.accounts_service.get_collectible_preferences()
         assert len(collectible_preferences_after)
 
         # missing fields are assigned default values
@@ -34,19 +34,19 @@ class TestCollectiblePreferences:
         assert cp.get("type") == 0
         assert cp.get("visible") is False
 
-    def test_overwrite_existing_collectible_preferences(self):
+    def test_overwrite_existing_collectible_preferences(self, account):
         new_collectible_preferences1 = [{"key": "collection:1234:1", "position": 3, "type": 0, "visible": True}]
-        self.account.accounts_service.update_collectible_preferences(new_collectible_preferences1)
+        account.accounts_service.update_collectible_preferences(new_collectible_preferences1)
         new_collectible_preferences2 = [{"key": "collection:5678:2", "position": 1, "type": 1, "visible": False}]
-        self.account.accounts_service.update_collectible_preferences(new_collectible_preferences2)
-        collectible_preferences_after = self.account.accounts_service.get_collectible_preferences()
+        account.accounts_service.update_collectible_preferences(new_collectible_preferences2)
+        collectible_preferences_after = account.accounts_service.get_collectible_preferences()
         assert collectible_preferences_after == new_collectible_preferences2
 
-    def test_add_multiple_collectible_preferences(self):
+    def test_add_multiple_collectible_preferences(self, account):
         new_collectible_preferences = [
             {"key": "collection:1234:1", "position": 3, "type": 0, "visible": True},
             {"key": "collection:5678:2", "position": 1, "type": 1, "visible": False},
         ]
-        self.account.accounts_service.update_collectible_preferences(new_collectible_preferences)
-        collectible_preferences_after = self.account.accounts_service.get_collectible_preferences()
+        account.accounts_service.update_collectible_preferences(new_collectible_preferences)
+        collectible_preferences_after = account.accounts_service.get_collectible_preferences()
         assert collectible_preferences_after == new_collectible_preferences

--- a/tests-functional/tests/test_collectible_preferences.py
+++ b/tests-functional/tests/test_collectible_preferences.py
@@ -5,24 +5,24 @@ import pytest
 class TestCollectiblePreferences:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_update_with_valid_collectible_preferences(self, account):
-        collectible_preferences_before = account.accounts_service.get_collectible_preferences()
+    def test_update_with_valid_collectible_preferences(self, backend):
+        collectible_preferences_before = backend.accounts_service.get_collectible_preferences()
         assert collectible_preferences_before is None
 
         new_collectible_preferences = [{"key": "collection:1234:1", "position": 3, "type": 0, "visible": True}]
-        update_response = account.accounts_service.update_collectible_preferences(new_collectible_preferences)
+        update_response = backend.accounts_service.update_collectible_preferences(new_collectible_preferences)
         assert update_response is None
 
-        collectible_preferences_after = account.accounts_service.get_collectible_preferences()
+        collectible_preferences_after = backend.accounts_service.get_collectible_preferences()
         assert collectible_preferences_after == new_collectible_preferences
 
-    def test_update_with_invalid_collectible_preferences(self, account):
+    def test_update_with_invalid_collectible_preferences(self, backend):
         new_collectible_preferences = [{"key": "collection:1234:1", "foo": "bar"}]
-        account.accounts_service.update_collectible_preferences(new_collectible_preferences)
-        collectible_preferences_after = account.accounts_service.get_collectible_preferences()
+        backend.accounts_service.update_collectible_preferences(new_collectible_preferences)
+        collectible_preferences_after = backend.accounts_service.get_collectible_preferences()
         assert len(collectible_preferences_after)
 
         # missing fields are assigned default values
@@ -34,19 +34,19 @@ class TestCollectiblePreferences:
         assert cp.get("type") == 0
         assert cp.get("visible") is False
 
-    def test_overwrite_existing_collectible_preferences(self, account):
+    def test_overwrite_existing_collectible_preferences(self, backend):
         new_collectible_preferences1 = [{"key": "collection:1234:1", "position": 3, "type": 0, "visible": True}]
-        account.accounts_service.update_collectible_preferences(new_collectible_preferences1)
+        backend.accounts_service.update_collectible_preferences(new_collectible_preferences1)
         new_collectible_preferences2 = [{"key": "collection:5678:2", "position": 1, "type": 1, "visible": False}]
-        account.accounts_service.update_collectible_preferences(new_collectible_preferences2)
-        collectible_preferences_after = account.accounts_service.get_collectible_preferences()
+        backend.accounts_service.update_collectible_preferences(new_collectible_preferences2)
+        collectible_preferences_after = backend.accounts_service.get_collectible_preferences()
         assert collectible_preferences_after == new_collectible_preferences2
 
-    def test_add_multiple_collectible_preferences(self, account):
+    def test_add_multiple_collectible_preferences(self, backend):
         new_collectible_preferences = [
             {"key": "collection:1234:1", "position": 3, "type": 0, "visible": True},
             {"key": "collection:5678:2", "position": 1, "type": 1, "visible": False},
         ]
-        account.accounts_service.update_collectible_preferences(new_collectible_preferences)
-        collectible_preferences_after = account.accounts_service.get_collectible_preferences()
+        backend.accounts_service.update_collectible_preferences(new_collectible_preferences)
+        collectible_preferences_after = backend.accounts_service.get_collectible_preferences()
         assert collectible_preferences_after == new_collectible_preferences

--- a/tests-functional/tests/test_delete_account.py
+++ b/tests-functional/tests/test_delete_account.py
@@ -9,8 +9,7 @@ from clients.api import ApiResponseError
 class TestDeleteAccount:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
-        """Backend for account deletion tests (profile owner)."""
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
@@ -18,39 +17,39 @@ class TestDeleteAccount:
         """Fresh copy of base account data for each test."""
         return copy.deepcopy(new_account_data_1)
 
-    def test_delete_watch_account(self, account, account_data):
+    def test_delete_watch_account(self, backend, account_data):
         account_data["type"] = "watch"
-        account.accounts_service.add_account("", account_data)
+        backend.accounts_service.add_account("", account_data)
 
-        accounts_response = account.accounts_service.get_accounts()
+        accounts_response = backend.accounts_service.get_accounts()
         assert len(accounts_response) == 3
 
-        resp = account.accounts_service.delete_account(account_data["address"], "")
+        resp = backend.accounts_service.delete_account(account_data["address"], "")
         assert resp is None
 
-        accounts_response = account.accounts_service.get_accounts()
+        accounts_response = backend.accounts_service.get_accounts()
         assert len(accounts_response) == 2
 
-    def test_delete_default_chat_account(self, account):
-        accounts_response = account.accounts_service.get_accounts()
+    def test_delete_default_chat_account(self, backend):
+        accounts_response = backend.accounts_service.get_accounts()
         assert len(accounts_response) == 2
 
         with pytest.raises(ApiResponseError, match=re.escape("[database] cannot remove default chat account")):
-            account.accounts_service.delete_account(accounts_response[0].get("address"), account.password)
+            backend.accounts_service.delete_account(accounts_response[0].get("address"), backend.password)
 
-        accounts_response = account.accounts_service.get_accounts()
+        accounts_response = backend.accounts_service.get_accounts()
         assert len(accounts_response) == 2
 
-    def test_delete_default_wallet_account(self, account):
-        accounts_response = account.accounts_service.get_accounts()
+    def test_delete_default_wallet_account(self, backend):
+        accounts_response = backend.accounts_service.get_accounts()
         assert len(accounts_response) == 2
 
         with pytest.raises(ApiResponseError, match=re.escape("[database] cannot remove default wallet account")):
-            account.accounts_service.delete_account(accounts_response[1].get("address"), account.password)
+            backend.accounts_service.delete_account(accounts_response[1].get("address"), backend.password)
 
-        accounts_response = account.accounts_service.get_accounts()
+        accounts_response = backend.accounts_service.get_accounts()
         assert len(accounts_response) == 2
 
-    def test_delete_nonexistent_account(self, account):
+    def test_delete_nonexistent_account(self, backend):
         with pytest.raises(ApiResponseError, match=re.escape("accounts: account is not found")):
-            account.accounts_service.delete_account("0x0000000000000000000000000000000000000001", account.password)
+            backend.accounts_service.delete_account("0x0000000000000000000000000000000000000001", backend.password)

--- a/tests-functional/tests/test_delete_account.py
+++ b/tests-functional/tests/test_delete_account.py
@@ -8,44 +8,49 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestDeleteAccount:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.account_data = copy.deepcopy(new_account_data_1)
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        """Backend for account deletion tests (profile owner)."""
+        return backend_new_profile("account-backend")
 
-    def test_delete_watch_account(self):
-        self.account_data["type"] = "watch"
-        self.account.accounts_service.add_account("", self.account_data)
+    @pytest.fixture()
+    def account_data(self):
+        """Fresh copy of base account data for each test."""
+        return copy.deepcopy(new_account_data_1)
 
-        accounts_response = self.account.accounts_service.get_accounts()
+    def test_delete_watch_account(self, account, account_data):
+        account_data["type"] = "watch"
+        account.accounts_service.add_account("", account_data)
+
+        accounts_response = account.accounts_service.get_accounts()
         assert len(accounts_response) == 3
 
-        resp = self.account.accounts_service.delete_account(self.account_data["address"], "")
+        resp = account.accounts_service.delete_account(account_data["address"], "")
         assert resp is None
 
-        accounts_response = self.account.accounts_service.get_accounts()
+        accounts_response = account.accounts_service.get_accounts()
         assert len(accounts_response) == 2
 
-    def test_delete_default_chat_account(self):
-        accounts_response = self.account.accounts_service.get_accounts()
+    def test_delete_default_chat_account(self, account):
+        accounts_response = account.accounts_service.get_accounts()
         assert len(accounts_response) == 2
 
         with pytest.raises(ApiResponseError, match=re.escape("[database] cannot remove default chat account")):
-            self.account.accounts_service.delete_account(accounts_response[0].get("address"), self.account.password)
+            account.accounts_service.delete_account(accounts_response[0].get("address"), account.password)
 
-        accounts_response = self.account.accounts_service.get_accounts()
+        accounts_response = account.accounts_service.get_accounts()
         assert len(accounts_response) == 2
 
-    def test_delete_default_wallet_account(self):
-        accounts_response = self.account.accounts_service.get_accounts()
+    def test_delete_default_wallet_account(self, account):
+        accounts_response = account.accounts_service.get_accounts()
         assert len(accounts_response) == 2
 
         with pytest.raises(ApiResponseError, match=re.escape("[database] cannot remove default wallet account")):
-            self.account.accounts_service.delete_account(accounts_response[1].get("address"), self.account.password)
+            account.accounts_service.delete_account(accounts_response[1].get("address"), account.password)
 
-        accounts_response = self.account.accounts_service.get_accounts()
+        accounts_response = account.accounts_service.get_accounts()
         assert len(accounts_response) == 2
 
-    def test_delete_nonexistent_account(self):
+    def test_delete_nonexistent_account(self, account):
         with pytest.raises(ApiResponseError, match=re.escape("accounts: account is not found")):
-            self.account.accounts_service.delete_account("0x0000000000000000000000000000000000000001", self.account.password)
+            account.accounts_service.delete_account("0x0000000000000000000000000000000000000001", account.password)

--- a/tests-functional/tests/test_delete_keycard.py
+++ b/tests-functional/tests/test_delete_keycard.py
@@ -8,44 +8,48 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestDeleteKeycard:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.keycard = copy.deepcopy(keycard_1)
-        self.keycard["key-uid"] = self.account.key_uid
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_delete_existing_keycard(self):
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
-        del_resp = self.account.accounts_service.delete_keycard(self.keycard["keycard-uid"])
+    @pytest.fixture()
+    def keycard(self, account):
+        kc = copy.deepcopy(keycard_1)
+        kc["key-uid"] = account.key_uid
+        return kc
+
+    def test_delete_existing_keycard(self, account, keycard):
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
+        del_resp = account.accounts_service.delete_keycard(keycard["keycard-uid"])
         assert del_resp is None
-        keycards_after = self.account.accounts_service.get_all_known_keycards()
+        keycards_after = account.accounts_service.get_all_known_keycards()
         assert keycards_after == []
 
-    def test_delete_nonexistent_keycard(self):
+    def test_delete_nonexistent_keycard(self, account):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            self.account.accounts_service.delete_keycard("non-existent-keycard-uid-1234")
+            account.accounts_service.delete_keycard("non-existent-keycard-uid-1234")
 
-    def test_delete_keycard_accounts(self):
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
-        keycards_before = self.account.accounts_service.get_all_known_keycards()
-        assert keycards_before[0].get("accounts-addresses") == self.keycard["accounts-addresses"]
-        del_resp = self.account.accounts_service.delete_keycard_accounts(self.keycard["keycard-uid"], self.keycard["accounts-addresses"])
+    def test_delete_keycard_accounts(self, account, keycard):
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
+        keycards_before = account.accounts_service.get_all_known_keycards()
+        assert keycards_before[0].get("accounts-addresses") == keycard["accounts-addresses"]
+        del_resp = account.accounts_service.delete_keycard_accounts(keycard["keycard-uid"], keycard["accounts-addresses"])
         assert del_resp is None
-        keycards_after = self.account.accounts_service.get_all_known_keycards()
+        keycards_after = account.accounts_service.get_all_known_keycards()
         assert keycards_after[0].get("accounts-addresses") == ["0x0000000000000000000000000000000000000000"]
 
-    def test_delete_all_keycards_with_key_uid(self):
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
-        second_keycard = copy.deepcopy(self.keycard)
+    def test_delete_all_keycards_with_key_uid(self, account, keycard):
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
+        second_keycard = copy.deepcopy(keycard)
         second_keycard["keycard-uid"] = "second_kc_uid_delete_all"
         second_keycard["keycard-name"] = "second_kc_name_delete_all"
-        self.account.accounts_service.save_or_update_keycard(second_keycard, self.account.password)
+        account.accounts_service.save_or_update_keycard(second_keycard, account.password)
 
-        keycards_before = self.account.accounts_service.get_all_known_keycards()
+        keycards_before = account.accounts_service.get_all_known_keycards()
         assert len(keycards_before) == 2
 
-        resp = self.account.accounts_service.delete_all_keycards_with_key_uid(self.account.key_uid)
+        resp = account.accounts_service.delete_all_keycards_with_key_uid(account.key_uid)
         assert resp is None
 
-        keycards_after = self.account.accounts_service.get_all_known_keycards()
+        keycards_after = account.accounts_service.get_all_known_keycards()
         assert keycards_after == []

--- a/tests-functional/tests/test_delete_keycard.py
+++ b/tests-functional/tests/test_delete_keycard.py
@@ -9,47 +9,47 @@ from clients.api import ApiResponseError
 class TestDeleteKeycard:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
-    def keycard(self, account):
+    def keycard(self, backend):
         kc = copy.deepcopy(keycard_1)
-        kc["key-uid"] = account.key_uid
+        kc["key-uid"] = backend.key_uid
         return kc
 
-    def test_delete_existing_keycard(self, account, keycard):
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
-        del_resp = account.accounts_service.delete_keycard(keycard["keycard-uid"])
+    def test_delete_existing_keycard(self, backend, keycard):
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
+        del_resp = backend.accounts_service.delete_keycard(keycard["keycard-uid"])
         assert del_resp is None
-        keycards_after = account.accounts_service.get_all_known_keycards()
+        keycards_after = backend.accounts_service.get_all_known_keycards()
         assert keycards_after == []
 
-    def test_delete_nonexistent_keycard(self, account):
+    def test_delete_nonexistent_keycard(self, backend):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            account.accounts_service.delete_keycard("non-existent-keycard-uid-1234")
+            backend.accounts_service.delete_keycard("non-existent-keycard-uid-1234")
 
-    def test_delete_keycard_accounts(self, account, keycard):
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
-        keycards_before = account.accounts_service.get_all_known_keycards()
+    def test_delete_keycard_accounts(self, backend, keycard):
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
+        keycards_before = backend.accounts_service.get_all_known_keycards()
         assert keycards_before[0].get("accounts-addresses") == keycard["accounts-addresses"]
-        del_resp = account.accounts_service.delete_keycard_accounts(keycard["keycard-uid"], keycard["accounts-addresses"])
+        del_resp = backend.accounts_service.delete_keycard_accounts(keycard["keycard-uid"], keycard["accounts-addresses"])
         assert del_resp is None
-        keycards_after = account.accounts_service.get_all_known_keycards()
+        keycards_after = backend.accounts_service.get_all_known_keycards()
         assert keycards_after[0].get("accounts-addresses") == ["0x0000000000000000000000000000000000000000"]
 
-    def test_delete_all_keycards_with_key_uid(self, account, keycard):
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
+    def test_delete_all_keycards_with_key_uid(self, backend, keycard):
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
         second_keycard = copy.deepcopy(keycard)
         second_keycard["keycard-uid"] = "second_kc_uid_delete_all"
         second_keycard["keycard-name"] = "second_kc_name_delete_all"
-        account.accounts_service.save_or_update_keycard(second_keycard, account.password)
+        backend.accounts_service.save_or_update_keycard(second_keycard, backend.password)
 
-        keycards_before = account.accounts_service.get_all_known_keycards()
+        keycards_before = backend.accounts_service.get_all_known_keycards()
         assert len(keycards_before) == 2
 
-        resp = account.accounts_service.delete_all_keycards_with_key_uid(account.key_uid)
+        resp = backend.accounts_service.delete_all_keycards_with_key_uid(backend.key_uid)
         assert resp is None
 
-        keycards_after = account.accounts_service.get_all_known_keycards()
+        keycards_after = backend.accounts_service.get_all_known_keycards()
         assert keycards_after == []

--- a/tests-functional/tests/test_delete_keypair.py
+++ b/tests-functional/tests/test_delete_keypair.py
@@ -8,28 +8,28 @@ from resources.constants import user_1, wallet_account_details_root, keypair_nam
 class TestDeleteKeypair:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_delete_keypair(self, account):
-        add_resp = account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, account.password, keypair_name, wallet_account_details_root
+    def test_delete_keypair(self, backend):
+        add_resp = backend.accounts_service.add_keypair_via_private_key(
+            user_1.private_key, backend.password, keypair_name, wallet_account_details_root
         )
         key_uid = add_resp.get("key-uid")
         address = add_resp.get("accounts")[0].get("address")
 
-        resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
+        resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
         assert resp is True
 
-        del_resp = account.accounts_service.delete_keypair(key_uid, account.password)
+        del_resp = backend.accounts_service.delete_keypair(key_uid, backend.password)
         assert del_resp is None
 
         with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
-            account.accounts_service.get_keypair_by_key_uid(key_uid)
+            backend.accounts_service.get_keypair_by_key_uid(key_uid)
 
-        resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
+        resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
         assert resp is False
 
-    def test_delete_non_existent_keypair(self, account):
+    def test_delete_non_existent_keypair(self, backend):
         with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
-            account.accounts_service.delete_keypair("key_uid", account.password)
+            backend.accounts_service.delete_keypair("key_uid", backend.password)

--- a/tests-functional/tests/test_delete_keypair.py
+++ b/tests-functional/tests/test_delete_keypair.py
@@ -7,29 +7,29 @@ from resources.constants import user_1, wallet_account_details_root, keypair_nam
 @pytest.mark.rpc
 class TestDeleteKeypair:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_delete_keypair(self):
-        add_resp = self.account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, self.account.password, keypair_name, wallet_account_details_root
+    def test_delete_keypair(self, account):
+        add_resp = account.accounts_service.add_keypair_via_private_key(
+            user_1.private_key, account.password, keypair_name, wallet_account_details_root
         )
         key_uid = add_resp.get("key-uid")
         address = add_resp.get("accounts")[0].get("address")
 
-        resp = self.account.accounts_service.verify_keystore_file_for_account(address, self.account.password)
+        resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
         assert resp is True
 
-        del_resp = self.account.accounts_service.delete_keypair(key_uid, self.account.password)
+        del_resp = account.accounts_service.delete_keypair(key_uid, account.password)
         assert del_resp is None
 
         with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
-            self.account.accounts_service.get_keypair_by_key_uid(key_uid)
+            account.accounts_service.get_keypair_by_key_uid(key_uid)
 
-        resp = self.account.accounts_service.verify_keystore_file_for_account(address, self.account.password)
+        resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
         assert resp is False
 
-    def test_delete_non_existent_keypair(self):
+    def test_delete_non_existent_keypair(self, account):
         with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
-            self.account.accounts_service.delete_keypair("key_uid", self.account.password)
+            account.accounts_service.delete_keypair("key_uid", account.password)

--- a/tests-functional/tests/test_get_account_by_address.py
+++ b/tests-functional/tests/test_get_account_by_address.py
@@ -8,26 +8,29 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestGetAccountByAddress:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.account_data = copy.deepcopy(new_account_data_1)
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_get_account_for_existing_addresses(self):
+    @pytest.fixture()
+    def account_data(self):
+        return copy.deepcopy(new_account_data_1)
+
+    def test_get_account_for_existing_addresses(self, account, account_data):
         path = "m/44'/60'/0'/0/1"
-        derived_addresses_response = self.account.wallet_service.get_derived_addresses_for_mnemonic(self.account.mnemonic, [path])
+        derived_addresses_response = account.wallet_service.get_derived_addresses_for_mnemonic(account.mnemonic, [path])
         derived_addresses = derived_addresses_response
-        self.account_data["key-uid"] = self.account.key_uid  # keyuid of profile keypair
-        self.account_data["path"] = path
-        self.account_data["address"] = derived_addresses[0].get("address")
-        self.account_data["public-key"] = derived_addresses[0].get("public-key")
-        self.account.accounts_service.add_account(self.account.password, self.account_data)
+        account_data["key-uid"] = account.key_uid  # keyuid of profile keypair
+        account_data["path"] = path
+        account_data["address"] = derived_addresses[0].get("address")
+        account_data["public-key"] = derived_addresses[0].get("public-key")
+        account.accounts_service.add_account(account.password, account_data)
 
-        accounts_response = self.account.accounts_service.get_accounts()
-        for account in accounts_response:
-            resp = self.account.accounts_service.get_account_by_address(account.get("address"))
+        accounts_response = account.accounts_service.get_accounts()
+        for acc in accounts_response:
+            resp = account.accounts_service.get_account_by_address(acc.get("address"))
             get_account_by_address_resp = resp
-            assert get_account_by_address_resp == account
+            assert get_account_by_address_resp == acc
 
     @pytest.mark.parametrize(
         ("address", "error"),
@@ -37,6 +40,6 @@ class TestGetAccountByAddress:
             ("foo", "invalid argument 0: json: cannot unmarshal hex string without 0x prefix into Go value of type types.Address"),
         ],
     )
-    def test_get_account_by_invalid_address(self, address, error):
+    def test_get_account_by_invalid_address(self, account, address, error):
         with pytest.raises(ApiResponseError, match=re.escape(error)):
-            self.account.accounts_service.get_account_by_address(address)
+            account.accounts_service.get_account_by_address(address)

--- a/tests-functional/tests/test_get_account_by_address.py
+++ b/tests-functional/tests/test_get_account_by_address.py
@@ -9,26 +9,26 @@ from clients.api import ApiResponseError
 class TestGetAccountByAddress:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
     def account_data(self):
         return copy.deepcopy(new_account_data_1)
 
-    def test_get_account_for_existing_addresses(self, account, account_data):
+    def test_get_account_for_existing_addresses(self, backend, account_data):
         path = "m/44'/60'/0'/0/1"
-        derived_addresses_response = account.wallet_service.get_derived_addresses_for_mnemonic(account.mnemonic, [path])
+        derived_addresses_response = backend.wallet_service.get_derived_addresses_for_mnemonic(backend.mnemonic, [path])
         derived_addresses = derived_addresses_response
-        account_data["key-uid"] = account.key_uid  # keyuid of profile keypair
+        account_data["key-uid"] = backend.key_uid  # keyuid of profile keypair
         account_data["path"] = path
         account_data["address"] = derived_addresses[0].get("address")
         account_data["public-key"] = derived_addresses[0].get("public-key")
-        account.accounts_service.add_account(account.password, account_data)
+        backend.accounts_service.add_account(backend.password, account_data)
 
-        accounts_response = account.accounts_service.get_accounts()
+        accounts_response = backend.accounts_service.get_accounts()
         for acc in accounts_response:
-            resp = account.accounts_service.get_account_by_address(acc.get("address"))
+            resp = backend.accounts_service.get_account_by_address(acc.get("address"))
             get_account_by_address_resp = resp
             assert get_account_by_address_resp == acc
 
@@ -40,6 +40,6 @@ class TestGetAccountByAddress:
             ("foo", "invalid argument 0: json: cannot unmarshal hex string without 0x prefix into Go value of type types.Address"),
         ],
     )
-    def test_get_account_by_invalid_address(self, account, address, error):
+    def test_get_account_by_invalid_address(self, backend, address, error):
         with pytest.raises(ApiResponseError, match=re.escape(error)):
-            account.accounts_service.get_account_by_address(address)
+            backend.accounts_service.get_account_by_address(address)

--- a/tests-functional/tests/test_get_keycards.py
+++ b/tests-functional/tests/test_get_keycards.py
@@ -11,38 +11,38 @@ class TestGetKeycards:
     # getAllKnownKeycards is covered inside TestSaveOrUpdateKeycard suite
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
-    def keycards(self, account):
+    def keycards(self, backend):
         """Prepare two keycards bound to the current account's key-uid and persist them."""
         first = copy.deepcopy(keycard_1)
-        first["key-uid"] = account.key_uid
-        account.accounts_service.save_or_update_keycard(first, account.password)
+        first["key-uid"] = backend.key_uid
+        backend.accounts_service.save_or_update_keycard(first, backend.password)
 
         second = copy.deepcopy(first)
         second["keycard-uid"] = "second_kc_uid"
         second["keycard-name"] = "second_kc_name"
         second["keycard-addresses"] = "0x2f49e5eff87892deb1fffeed666fa75ccb2dbbc2"
-        account.accounts_service.save_or_update_keycard(second, account.password)
+        backend.accounts_service.save_or_update_keycard(second, backend.password)
 
         return first, second
 
-    def test_get_keycard_by_keycard_uid(self, account, keycards):
+    def test_get_keycard_by_keycard_uid(self, backend, keycards):
         first_keycard_data, second_keycard_data = keycards
-        first_keycard = account.accounts_service.get_keycard_by_keycard_uid(first_keycard_data.get("keycard-uid"))
+        first_keycard = backend.accounts_service.get_keycard_by_keycard_uid(first_keycard_data.get("keycard-uid"))
         assert first_keycard.get("keycard-name") == first_keycard_data.get("keycard-name")
-        second_keycard = account.accounts_service.get_keycard_by_keycard_uid(second_keycard_data.get("keycard-uid"))
+        second_keycard = backend.accounts_service.get_keycard_by_keycard_uid(second_keycard_data.get("keycard-uid"))
         assert second_keycard.get("keycard-name") == second_keycard_data.get("keycard-name")
 
-    def test_get_keycard_by_nonexistent_keycard_uid(self, account):
+    def test_get_keycard_by_nonexistent_keycard_uid(self, backend):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            account.accounts_service.get_keycard_by_keycard_uid("0x0000000000000000000000000000000000000000000000000000000000000000")
+            backend.accounts_service.get_keycard_by_keycard_uid("0x0000000000000000000000000000000000000000000000000000000000000000")
 
-    def test_get_keycards_with_same_keyuid(self, account, keycards):
+    def test_get_keycards_with_same_keyuid(self, backend, keycards):
         first_keycard_data, second_keycard_data = keycards
-        resp = account.accounts_service.get_keycards_with_same_key_uid(account.key_uid)
+        resp = backend.accounts_service.get_keycards_with_same_key_uid(backend.key_uid)
         keycards_list = resp
         assert len(keycards_list) == 2
         assert keycards_list[0].get("keycard-uid") == first_keycard_data.get("keycard-uid")
@@ -58,6 +58,6 @@ class TestGetKeycards:
         assert keycards_list[1].get("key-uid") == second_keycard_data.get("key-uid")
         assert keycards_list[1].get("Position") == 1
 
-    def test_get_keycards_with_same_nonexistent_keyuid(self, account):
-        resp = account.accounts_service.get_keycards_with_same_key_uid("0x0000000000000000000000000000000000000000000000000000000000000000")
+    def test_get_keycards_with_same_nonexistent_keyuid(self, backend):
+        resp = backend.accounts_service.get_keycards_with_same_key_uid("0x0000000000000000000000000000000000000000000000000000000000000000")
         assert resp == []

--- a/tests-functional/tests/test_get_keycards.py
+++ b/tests-functional/tests/test_get_keycards.py
@@ -10,45 +10,54 @@ class TestGetKeycards:
 
     # getAllKnownKeycards is covered inside TestSaveOrUpdateKeycard suite
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.keycard = copy.deepcopy(keycard_1)
-        self.keycard["key-uid"] = self.account.key_uid
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
-        self.second_keycard = copy.deepcopy(self.keycard)
-        self.second_keycard["keycard-uid"] = "second_kc_uid"
-        self.second_keycard["keycard-name"] = "second_kc_name"
-        self.second_keycard["keycard-addresses"] = "0x2f49e5eff87892deb1fffeed666fa75ccb2dbbc2"
-        self.account.accounts_service.save_or_update_keycard(self.second_keycard, self.account.password)
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_get_keycard_by_keycard_uid(self):
-        first_keycard = self.account.accounts_service.get_keycard_by_keycard_uid(self.keycard.get("keycard-uid"))
-        assert first_keycard.get("keycard-name") == self.keycard.get("keycard-name")
-        second_keycard = self.account.accounts_service.get_keycard_by_keycard_uid(self.second_keycard.get("keycard-uid"))
-        assert second_keycard.get("keycard-name") == self.second_keycard.get("keycard-name")
+    @pytest.fixture()
+    def keycards(self, account):
+        """Prepare two keycards bound to the current account's key-uid and persist them."""
+        first = copy.deepcopy(keycard_1)
+        first["key-uid"] = account.key_uid
+        account.accounts_service.save_or_update_keycard(first, account.password)
 
-    def test_get_keycard_by_nonexistent_keycard_uid(self):
+        second = copy.deepcopy(first)
+        second["keycard-uid"] = "second_kc_uid"
+        second["keycard-name"] = "second_kc_name"
+        second["keycard-addresses"] = "0x2f49e5eff87892deb1fffeed666fa75ccb2dbbc2"
+        account.accounts_service.save_or_update_keycard(second, account.password)
+
+        return first, second
+
+    def test_get_keycard_by_keycard_uid(self, account, keycards):
+        first_keycard_data, second_keycard_data = keycards
+        first_keycard = account.accounts_service.get_keycard_by_keycard_uid(first_keycard_data.get("keycard-uid"))
+        assert first_keycard.get("keycard-name") == first_keycard_data.get("keycard-name")
+        second_keycard = account.accounts_service.get_keycard_by_keycard_uid(second_keycard_data.get("keycard-uid"))
+        assert second_keycard.get("keycard-name") == second_keycard_data.get("keycard-name")
+
+    def test_get_keycard_by_nonexistent_keycard_uid(self, account):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            self.account.accounts_service.get_keycard_by_keycard_uid("0x0000000000000000000000000000000000000000000000000000000000000000")
+            account.accounts_service.get_keycard_by_keycard_uid("0x0000000000000000000000000000000000000000000000000000000000000000")
 
-    def test_get_keycards_with_same_keyuid(self):
-        resp = self.account.accounts_service.get_keycards_with_same_key_uid(self.account.key_uid)
-        keycards = resp
-        assert len(keycards) == 2
-        assert keycards[0].get("keycard-uid") == self.keycard.get("keycard-uid")
-        assert keycards[0].get("keycard-name") == self.keycard.get("keycard-name")
-        assert keycards[0].get("keycard-locked") is False
-        assert keycards[0].get("accounts-addresses") == self.keycard.get("accounts-addresses")
-        assert keycards[0].get("key-uid") == self.keycard.get("key-uid")
-        assert keycards[0].get("Position") == 0
-        assert keycards[1].get("keycard-uid") == self.second_keycard.get("keycard-uid")
-        assert keycards[1].get("keycard-name") == self.second_keycard.get("keycard-name")
-        assert keycards[1].get("keycard-locked") is False
-        assert keycards[1].get("accounts-addresses") == self.second_keycard.get("accounts-addresses")
-        assert keycards[1].get("key-uid") == self.second_keycard.get("key-uid")
-        assert keycards[1].get("Position") == 1
+    def test_get_keycards_with_same_keyuid(self, account, keycards):
+        first_keycard_data, second_keycard_data = keycards
+        resp = account.accounts_service.get_keycards_with_same_key_uid(account.key_uid)
+        keycards_list = resp
+        assert len(keycards_list) == 2
+        assert keycards_list[0].get("keycard-uid") == first_keycard_data.get("keycard-uid")
+        assert keycards_list[0].get("keycard-name") == first_keycard_data.get("keycard-name")
+        assert keycards_list[0].get("keycard-locked") is False
+        assert keycards_list[0].get("accounts-addresses") == first_keycard_data.get("accounts-addresses")
+        assert keycards_list[0].get("key-uid") == first_keycard_data.get("key-uid")
+        assert keycards_list[0].get("Position") == 0
+        assert keycards_list[1].get("keycard-uid") == second_keycard_data.get("keycard-uid")
+        assert keycards_list[1].get("keycard-name") == second_keycard_data.get("keycard-name")
+        assert keycards_list[1].get("keycard-locked") is False
+        assert keycards_list[1].get("accounts-addresses") == second_keycard_data.get("accounts-addresses")
+        assert keycards_list[1].get("key-uid") == second_keycard_data.get("key-uid")
+        assert keycards_list[1].get("Position") == 1
 
-    def test_get_keycards_with_same_nonexistent_keyuid(self):
-        resp = self.account.accounts_service.get_keycards_with_same_key_uid("0x0000000000000000000000000000000000000000000000000000000000000000")
+    def test_get_keycards_with_same_nonexistent_keyuid(self, account):
+        resp = account.accounts_service.get_keycards_with_same_key_uid("0x0000000000000000000000000000000000000000000000000000000000000000")
         assert resp == []

--- a/tests-functional/tests/test_get_keypair_by_keyuid.py
+++ b/tests-functional/tests/test_get_keypair_by_keyuid.py
@@ -8,15 +8,15 @@ from clients.api import ApiResponseError
 class TestGetKeypairByKeyUID:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_get_keypair_by_existing_keyuid(self, account):
-        get_account_keypairs_resp = account.accounts_service.get_account_keypairs()
-        get_keypair_by_key_uid_resp = account.accounts_service.get_keypair_by_key_uid(account.key_uid)
+    def test_get_keypair_by_existing_keyuid(self, backend):
+        get_account_keypairs_resp = backend.accounts_service.get_account_keypairs()
+        get_keypair_by_key_uid_resp = backend.accounts_service.get_keypair_by_key_uid(backend.key_uid)
         keypair = get_keypair_by_key_uid_resp
         assert keypair == get_account_keypairs_resp[0]
-        assert keypair.get("name") == account.display_name
+        assert keypair.get("name") == backend.display_name
         accounts = keypair.get("accounts")
         assert accounts[0].get("path") == "m/43'/60'/1581'/0'/0"
         assert accounts[0].get("name") == ""
@@ -31,14 +31,14 @@ class TestGetKeypairByKeyUID:
         assert accounts[0].get("address") != accounts[1].get("address")
         assert accounts[0].get("key-uid") == accounts[1].get("key-uid")
 
-    def test_get_keypair_by_nonexistent_keyuid(self, account):
+    def test_get_keypair_by_nonexistent_keyuid(self, backend):
         with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
-            account.accounts_service.get_keypair_by_key_uid("0x6d462df35b97fabb8f792eac01240556e26fd2600753e5bbffa4713a9c95abc7")
+            backend.accounts_service.get_keypair_by_key_uid("0x6d462df35b97fabb8f792eac01240556e26fd2600753e5bbffa4713a9c95abc7")
 
-    def test_get_newly_imported_keypair(self, account):
-        account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation)
-        keypairs_response = account.accounts_service.get_account_keypairs()
+    def test_get_newly_imported_keypair(self, backend):
+        backend.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, backend.password, keypair_name, wallet_account_details_derivation)
+        keypairs_response = backend.accounts_service.get_account_keypairs()
         imported_keypair = [keypair for keypair in keypairs_response if keypair.get("name") == keypair_name][0]
         imported_keypair_key_uid = imported_keypair.get("key-uid")
-        resp = account.accounts_service.get_keypair_by_key_uid(imported_keypair_key_uid)
+        resp = backend.accounts_service.get_keypair_by_key_uid(imported_keypair_key_uid)
         assert imported_keypair == resp

--- a/tests-functional/tests/test_get_keypair_by_keyuid.py
+++ b/tests-functional/tests/test_get_keypair_by_keyuid.py
@@ -7,16 +7,16 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestGetKeypairByKeyUID:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_get_keypair_by_existing_keyuid(self):
-        get_account_keypairs_resp = self.account.accounts_service.get_account_keypairs()
-        get_keypair_by_key_uid_resp = self.account.accounts_service.get_keypair_by_key_uid(self.account.key_uid)
+    def test_get_keypair_by_existing_keyuid(self, account):
+        get_account_keypairs_resp = account.accounts_service.get_account_keypairs()
+        get_keypair_by_key_uid_resp = account.accounts_service.get_keypair_by_key_uid(account.key_uid)
         keypair = get_keypair_by_key_uid_resp
         assert keypair == get_account_keypairs_resp[0]
-        assert keypair.get("name") == self.account.display_name
+        assert keypair.get("name") == account.display_name
         accounts = keypair.get("accounts")
         assert accounts[0].get("path") == "m/43'/60'/1581'/0'/0"
         assert accounts[0].get("name") == ""
@@ -31,16 +31,14 @@ class TestGetKeypairByKeyUID:
         assert accounts[0].get("address") != accounts[1].get("address")
         assert accounts[0].get("key-uid") == accounts[1].get("key-uid")
 
-    def test_get_keypair_by_nonexistent_keyuid(self):
+    def test_get_keypair_by_nonexistent_keyuid(self, account):
         with pytest.raises(ApiResponseError, match=re.escape("keypair is not found")):
-            self.account.accounts_service.get_keypair_by_key_uid("0x6d462df35b97fabb8f792eac01240556e26fd2600753e5bbffa4713a9c95abc7")
+            account.accounts_service.get_keypair_by_key_uid("0x6d462df35b97fabb8f792eac01240556e26fd2600753e5bbffa4713a9c95abc7")
 
-    def test_get_newly_imported_keypair(self):
-        self.account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, self.account.password, keypair_name, wallet_account_details_derivation
-        )
-        keypairs_response = self.account.accounts_service.get_account_keypairs()
+    def test_get_newly_imported_keypair(self, account):
+        account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation)
+        keypairs_response = account.accounts_service.get_account_keypairs()
         imported_keypair = [keypair for keypair in keypairs_response if keypair.get("name") == keypair_name][0]
         imported_keypair_key_uid = imported_keypair.get("key-uid")
-        resp = self.account.accounts_service.get_keypair_by_key_uid(imported_keypair_key_uid)
+        resp = account.accounts_service.get_keypair_by_key_uid(imported_keypair_key_uid)
         assert imported_keypair == resp

--- a/tests-functional/tests/test_get_num_of_addresses_to_generate_for_keypair.py
+++ b/tests-functional/tests/test_get_num_of_addresses_to_generate_for_keypair.py
@@ -6,12 +6,12 @@ from resources.constants import user_1, wallet_account_details_derivation, keypa
 class TestGetNumOfAddressesToGenerateForKeypair:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_get_num_of_addresses_to_generate_for_keypair(self, account):
-        add_resp = account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation
+    def test_get_num_of_addresses_to_generate_for_keypair(self, backend):
+        add_resp = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase, backend.password, keypair_name, wallet_account_details_derivation
         )
-        result = account.accounts_service.get_num_of_addresses_to_generate_for_keypair(add_resp.get("key-uid"))
+        result = backend.accounts_service.get_num_of_addresses_to_generate_for_keypair(add_resp.get("key-uid"))
         assert result == 100

--- a/tests-functional/tests/test_get_num_of_addresses_to_generate_for_keypair.py
+++ b/tests-functional/tests/test_get_num_of_addresses_to_generate_for_keypair.py
@@ -5,13 +5,13 @@ from resources.constants import user_1, wallet_account_details_derivation, keypa
 @pytest.mark.rpc
 class TestGetNumOfAddressesToGenerateForKeypair:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_get_num_of_addresses_to_generate_for_keypair(self):
-        add_resp = self.account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, self.account.password, keypair_name, wallet_account_details_derivation
+    def test_get_num_of_addresses_to_generate_for_keypair(self, account):
+        add_resp = account.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation
         )
-        result = self.account.accounts_service.get_num_of_addresses_to_generate_for_keypair(add_resp.get("key-uid"))
+        result = account.accounts_service.get_num_of_addresses_to_generate_for_keypair(add_resp.get("key-uid"))
         assert result == 100

--- a/tests-functional/tests/test_get_random_mnemonic.py
+++ b/tests-functional/tests/test_get_random_mnemonic.py
@@ -5,9 +5,9 @@ import pytest
 class TestGetRandomMnemonic:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("rpc-client-backend")
 
-    def test_get_random_mnemonic(self, account):
-        result = account.accounts_service.get_random_mnemonic()
+    def test_get_random_mnemonic(self, backend):
+        result = backend.accounts_service.get_random_mnemonic()
         assert len(result.split()) == 12  # basic check for mnemonic length

--- a/tests-functional/tests/test_get_random_mnemonic.py
+++ b/tests-functional/tests/test_get_random_mnemonic.py
@@ -4,10 +4,10 @@ import pytest
 @pytest.mark.rpc
 class TestGetRandomMnemonic:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("rpc_client")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("rpc-client-backend")
 
-    def test_get_random_mnemonic(self):
-        result = self.account.accounts_service.get_random_mnemonic()
+    def test_get_random_mnemonic(self, account):
+        result = account.accounts_service.get_random_mnemonic()
         assert len(result.split()) == 12  # basic check for mnemonic length

--- a/tests-functional/tests/test_get_watch_only_accounts.py
+++ b/tests-functional/tests/test_get_watch_only_accounts.py
@@ -7,21 +7,21 @@ from resources.constants import new_account_data_1
 class TestGetWatchOnlyAccounts:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
     def account_data(self):
         return copy.deepcopy(new_account_data_1)
 
-    def test_get_watch_only_accounts_returns_all_watch_accounts(self, account, account_data):
+    def test_get_watch_only_accounts_returns_all_watch_accounts(self, backend, account_data):
         account_data["type"] = "watch"
-        account.accounts_service.add_account(account.password, account_data)
+        backend.accounts_service.add_account(backend.password, account_data)
 
-        watch_accounts = account.accounts_service.get_watch_only_accounts()
+        watch_accounts = backend.accounts_service.get_watch_only_accounts()
         assert len(watch_accounts) == 1
         assert watch_accounts[0].get("address") == account_data.get("address")
 
-    def test_get_watch_only_with_no_watch_accounts(self, account):
-        watch_accounts = account.accounts_service.get_watch_only_accounts()
+    def test_get_watch_only_with_no_watch_accounts(self, backend):
+        watch_accounts = backend.accounts_service.get_watch_only_accounts()
         assert watch_accounts is None

--- a/tests-functional/tests/test_get_watch_only_accounts.py
+++ b/tests-functional/tests/test_get_watch_only_accounts.py
@@ -6,19 +6,22 @@ from resources.constants import new_account_data_1
 @pytest.mark.rpc
 class TestGetWatchOnlyAccounts:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.account_data = copy.deepcopy(new_account_data_1)
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_get_watch_only_accounts_returns_all_watch_accounts(self):
-        self.account_data["type"] = "watch"
-        self.account.accounts_service.add_account(self.account.password, self.account_data)
+    @pytest.fixture()
+    def account_data(self):
+        return copy.deepcopy(new_account_data_1)
 
-        watch_accounts = self.account.accounts_service.get_watch_only_accounts()
+    def test_get_watch_only_accounts_returns_all_watch_accounts(self, account, account_data):
+        account_data["type"] = "watch"
+        account.accounts_service.add_account(account.password, account_data)
+
+        watch_accounts = account.accounts_service.get_watch_only_accounts()
         assert len(watch_accounts) == 1
-        assert watch_accounts[0].get("address") == self.account_data.get("address")
+        assert watch_accounts[0].get("address") == account_data.get("address")
 
-    def test_get_watch_only_with_no_watch_accounts(self):
-        watch_accounts = self.account.accounts_service.get_watch_only_accounts()
+    def test_get_watch_only_with_no_watch_accounts(self, account):
+        watch_accounts = account.accounts_service.get_watch_only_accounts()
         assert watch_accounts is None

--- a/tests-functional/tests/test_keycard_lock_unlock.py
+++ b/tests-functional/tests/test_keycard_lock_unlock.py
@@ -9,39 +9,39 @@ from clients.api import ApiResponseError
 class TestKeycardLockUnlock:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
-    def keycard(self, account):
+    def keycard(self, backend):
         """Fresh keycard data bound to the current account's key-uid."""
         kc = copy.deepcopy(keycard_1)
-        kc["key-uid"] = account.key_uid
+        kc["key-uid"] = backend.key_uid
         return kc
 
-    def test_keycard_lock_unlock_flow(self, account, keycard):
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
+    def test_keycard_lock_unlock_flow(self, backend, keycard):
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
 
         # Lock the keycard
-        resp_lock = account.accounts_service.keycard_locked(keycard["keycard-uid"])
+        resp_lock = backend.accounts_service.keycard_locked(keycard["keycard-uid"])
         assert resp_lock is None
 
         # Verify the keycard is locked
-        keycards_after_lock = account.accounts_service.get_all_known_keycards()
+        keycards_after_lock = backend.accounts_service.get_all_known_keycards()
         assert keycards_after_lock[0].get("keycard-locked") is True
 
         # Unlock the keycard
-        resp_unlock = account.accounts_service.keycard_unlocked(keycard["keycard-uid"])
+        resp_unlock = backend.accounts_service.keycard_unlocked(keycard["keycard-uid"])
         assert resp_unlock is None
 
         # Verify the keycard is unlocked
-        keycards_after_unlock = account.accounts_service.get_all_known_keycards()
+        keycards_after_unlock = backend.accounts_service.get_all_known_keycards()
         assert keycards_after_unlock[0].get("keycard-locked") is False
 
-    def test_lock_nonexistent_keycard(self, account):
+    def test_lock_nonexistent_keycard(self, backend):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            account.accounts_service.keycard_locked("non-existent-keycard-uid-1234")
+            backend.accounts_service.keycard_locked("non-existent-keycard-uid-1234")
 
-    def test_unlock_nonexistent_keycard(self, account):
+    def test_unlock_nonexistent_keycard(self, backend):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            account.accounts_service.keycard_unlocked("non-existent-keycard-uid-1234")
+            backend.accounts_service.keycard_unlocked("non-existent-keycard-uid-1234")

--- a/tests-functional/tests/test_keycard_lock_unlock.py
+++ b/tests-functional/tests/test_keycard_lock_unlock.py
@@ -8,35 +8,40 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestKeycardLockUnlock:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.keycard = copy.deepcopy(keycard_1)
-        self.keycard["key-uid"] = self.account.key_uid
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_keycard_lock_unlock_flow(self):
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
+    @pytest.fixture()
+    def keycard(self, account):
+        """Fresh keycard data bound to the current account's key-uid."""
+        kc = copy.deepcopy(keycard_1)
+        kc["key-uid"] = account.key_uid
+        return kc
+
+    def test_keycard_lock_unlock_flow(self, account, keycard):
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
 
         # Lock the keycard
-        resp_lock = self.account.accounts_service.keycard_locked(self.keycard["keycard-uid"])
+        resp_lock = account.accounts_service.keycard_locked(keycard["keycard-uid"])
         assert resp_lock is None
 
         # Verify the keycard is locked
-        keycards_after_lock = self.account.accounts_service.get_all_known_keycards()
+        keycards_after_lock = account.accounts_service.get_all_known_keycards()
         assert keycards_after_lock[0].get("keycard-locked") is True
 
         # Unlock the keycard
-        resp_unlock = self.account.accounts_service.keycard_unlocked(self.keycard["keycard-uid"])
+        resp_unlock = account.accounts_service.keycard_unlocked(keycard["keycard-uid"])
         assert resp_unlock is None
 
         # Verify the keycard is unlocked
-        keycards_after_unlock = self.account.accounts_service.get_all_known_keycards()
+        keycards_after_unlock = account.accounts_service.get_all_known_keycards()
         assert keycards_after_unlock[0].get("keycard-locked") is False
 
-    def test_lock_nonexistent_keycard(self):
+    def test_lock_nonexistent_keycard(self, account):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            self.account.accounts_service.keycard_locked("non-existent-keycard-uid-1234")
+            account.accounts_service.keycard_locked("non-existent-keycard-uid-1234")
 
-    def test_unlock_nonexistent_keycard(self):
+    def test_unlock_nonexistent_keycard(self, account):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            self.account.accounts_service.keycard_unlocked("non-existent-keycard-uid-1234")
+            account.accounts_service.keycard_unlocked("non-existent-keycard-uid-1234")

--- a/tests-functional/tests/test_migrate_non_profile_keycard_keypair_to_app.py
+++ b/tests-functional/tests/test_migrate_non_profile_keycard_keypair_to_app.py
@@ -6,14 +6,14 @@ from resources.constants import keycard_1, user_1, wallet_account_details_deriva
 @pytest.mark.rpc
 class TestMigrateNonProfileKeycardKeypairToApp:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_full_migrate_flow(self):
+    def test_full_migrate_flow(self, account):
         # 1) Add a seed-derived keypair (simulates a keypair that will later be converted to a keycard)
-        add_resp = self.account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, self.account.password, keypair_name, wallet_account_details_derivation
+        add_resp = account.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation
         )
         assert "error" not in add_resp
         add_result = add_resp
@@ -33,34 +33,34 @@ class TestMigrateNonProfileKeycardKeypairToApp:
         addresses = [kc["accounts-addresses"][0], add_result.get("derived-from")]
 
         for address in addresses:
-            resp = self.account.accounts_service.verify_keystore_file_for_account(address, self.account.password)
+            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
             assert resp is True
 
-        self.account.accounts_service.save_or_update_keycard(kc, self.account.password)
+        account.accounts_service.save_or_update_keycard(kc, account.password)
 
         for address in addresses:
-            resp = self.account.accounts_service.verify_keystore_file_for_account(address, self.account.password)
+            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
             assert resp is False
 
         # verify keycard present
-        keycards_before = self.account.accounts_service.get_all_known_keycards()
+        keycards_before = account.accounts_service.get_all_known_keycards()
         kcs = keycards_before
         matching = [x for x in kcs if x.get("keycard-uid") == kc["keycard-uid"]]
         assert len(matching) == 1
 
-        kp_resp = self.account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_resp = account.accounts_service.get_keypair_by_key_uid(key_uid)
 
         # 3) Migrate the non-profile keycard keypair to app (full flow)
-        migrate_resp = self.account.accounts_service.migrate_non_profile_keycard_keypair_to_app(user_1.passphrase, self.account.password)
+        migrate_resp = account.accounts_service.migrate_non_profile_keycard_keypair_to_app(user_1.passphrase, account.password)
         # many RPC "void" actions return result None
         assert migrate_resp is None
 
         for address in addresses:
-            resp = self.account.accounts_service.verify_keystore_file_for_account(address, self.account.password)
+            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
             assert resp is True
 
         # 4) Verify the keypair still exists and that its keycards list is empty (i.e. migrated off keycard)
-        kp_resp = self.account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_resp = account.accounts_service.get_keypair_by_key_uid(key_uid)
         assert kp_resp is not None
         # after migration the keypair should no longer have keycards linked
         assert isinstance(kp_resp.get("keycards"), list)

--- a/tests-functional/tests/test_migrate_non_profile_keycard_keypair_to_app.py
+++ b/tests-functional/tests/test_migrate_non_profile_keycard_keypair_to_app.py
@@ -7,13 +7,13 @@ from resources.constants import keycard_1, user_1, wallet_account_details_deriva
 class TestMigrateNonProfileKeycardKeypairToApp:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_full_migrate_flow(self, account):
+    def test_full_migrate_flow(self, backend):
         # 1) Add a seed-derived keypair (simulates a keypair that will later be converted to a keycard)
-        add_resp = account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation
+        add_resp = backend.accounts_service.add_keypair_via_seed_phrase(
+            user_1.passphrase, backend.password, keypair_name, wallet_account_details_derivation
         )
         assert "error" not in add_resp
         add_result = add_resp
@@ -33,34 +33,34 @@ class TestMigrateNonProfileKeycardKeypairToApp:
         addresses = [kc["accounts-addresses"][0], add_result.get("derived-from")]
 
         for address in addresses:
-            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
             assert resp is True
 
-        account.accounts_service.save_or_update_keycard(kc, account.password)
+        backend.accounts_service.save_or_update_keycard(kc, backend.password)
 
         for address in addresses:
-            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
             assert resp is False
 
         # verify keycard present
-        keycards_before = account.accounts_service.get_all_known_keycards()
+        keycards_before = backend.accounts_service.get_all_known_keycards()
         kcs = keycards_before
         matching = [x for x in kcs if x.get("keycard-uid") == kc["keycard-uid"]]
         assert len(matching) == 1
 
-        kp_resp = account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_resp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
 
         # 3) Migrate the non-profile keycard keypair to app (full flow)
-        migrate_resp = account.accounts_service.migrate_non_profile_keycard_keypair_to_app(user_1.passphrase, account.password)
+        migrate_resp = backend.accounts_service.migrate_non_profile_keycard_keypair_to_app(user_1.passphrase, backend.password)
         # many RPC "void" actions return result None
         assert migrate_resp is None
 
         for address in addresses:
-            resp = account.accounts_service.verify_keystore_file_for_account(address, account.password)
+            resp = backend.accounts_service.verify_keystore_file_for_account(address, backend.password)
             assert resp is True
 
         # 4) Verify the keypair still exists and that its keycards list is empty (i.e. migrated off keycard)
-        kp_resp = account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_resp = backend.accounts_service.get_keypair_by_key_uid(key_uid)
         assert kp_resp is not None
         # after migration the keypair should no longer have keycards linked
         assert isinstance(kp_resp.get("keycards"), list)

--- a/tests-functional/tests/test_move_wallet_account.py
+++ b/tests-functional/tests/test_move_wallet_account.py
@@ -8,35 +8,37 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestMoveWalletAccount:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.account_data = copy.deepcopy(new_account_data_1)
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_move_non_profile_wallet_accounts(self):
+    @pytest.fixture()
+    def account_data(self):
+        """Fresh copy of base account data for each test."""
+        return copy.deepcopy(new_account_data_1)
+
+    def test_move_non_profile_wallet_accounts(self, account, account_data):
         # Add new account
         path = "m/44'/60'/0'/0/1"
-        derived_addresses_response = self.account.wallet_service.get_derived_addresses_for_mnemonic(self.account.mnemonic, [path])
+        derived_addresses_response = account.wallet_service.get_derived_addresses_for_mnemonic(account.mnemonic, [path])
         derived_addresses = derived_addresses_response
-        self.account_data["key-uid"] = self.account.key_uid  # keyuid of profile keypair
-        self.account_data["path"] = path
-        self.account_data["address"] = derived_addresses[0].get("address")
-        self.account_data["public-key"] = derived_addresses[0].get("public-key")
-        self.account.accounts_service.add_account(self.account.password, self.account_data)
+        account_data["key-uid"] = account.key_uid  # keyuid of profile keypair
+        account_data["path"] = path
+        account_data["address"] = derived_addresses[0].get("address")
+        account_data["public-key"] = derived_addresses[0].get("public-key")
+        account.accounts_service.add_account(account.password, account_data)
 
         # Get all accounts to determine positions
-        accounts_response = self.account.accounts_service.get_accounts()
+        accounts_response = account.accounts_service.get_accounts()
         accounts_before = [acc for acc in accounts_response]
         assert len(accounts_before) >= 3, "Need at least two accounts to test move"
 
         # Move wallet account from position 1 to position 2
-        move_accounts_response = self.account.accounts_service.move_wallet_account(
-            accounts_before[1].get("position"), accounts_before[2].get("position")
-        )
+        move_accounts_response = account.accounts_service.move_wallet_account(accounts_before[1].get("position"), accounts_before[2].get("position"))
         assert move_accounts_response is None
 
         # Fetch the accounts again
-        accounts_response_after = self.account.accounts_service.get_accounts()
+        accounts_response_after = account.accounts_service.get_accounts()
         accounts_after = [acc for acc in accounts_response_after]
 
         # Checking the positions are still incremental after move
@@ -54,12 +56,12 @@ class TestMoveWalletAccount:
         assert accounts_before[1] == accounts_after[2]
         assert accounts_before[2] == accounts_after[1]
 
-    def test_move_profile_account_isnt_allowed(self):
+    def test_move_profile_account_isnt_allowed(self, account):
         # Get all accounts to determine positions
-        accounts_response = self.account.accounts_service.get_accounts()
+        accounts_response = account.accounts_service.get_accounts()
         accounts_before = [acc for acc in accounts_response]
         assert len(accounts_before) >= 2, "Need at least two accounts to test move"
 
         # Move wallet account from position 0 to position 1
         with pytest.raises(ApiResponseError, match=re.escape("accounts: trying to move account to a wrong position")):
-            self.account.accounts_service.move_wallet_account(accounts_before[0].get("position"), accounts_before[1].get("position"))
+            account.accounts_service.move_wallet_account(accounts_before[0].get("position"), accounts_before[1].get("position"))

--- a/tests-functional/tests/test_move_wallet_account.py
+++ b/tests-functional/tests/test_move_wallet_account.py
@@ -9,7 +9,7 @@ from clients.api import ApiResponseError
 class TestMoveWalletAccount:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
@@ -17,28 +17,28 @@ class TestMoveWalletAccount:
         """Fresh copy of base account data for each test."""
         return copy.deepcopy(new_account_data_1)
 
-    def test_move_non_profile_wallet_accounts(self, account, account_data):
+    def test_move_non_profile_wallet_accounts(self, backend, account_data):
         # Add new account
         path = "m/44'/60'/0'/0/1"
-        derived_addresses_response = account.wallet_service.get_derived_addresses_for_mnemonic(account.mnemonic, [path])
+        derived_addresses_response = backend.wallet_service.get_derived_addresses_for_mnemonic(backend.mnemonic, [path])
         derived_addresses = derived_addresses_response
-        account_data["key-uid"] = account.key_uid  # keyuid of profile keypair
+        account_data["key-uid"] = backend.key_uid  # keyuid of profile keypair
         account_data["path"] = path
         account_data["address"] = derived_addresses[0].get("address")
         account_data["public-key"] = derived_addresses[0].get("public-key")
-        account.accounts_service.add_account(account.password, account_data)
+        backend.accounts_service.add_account(backend.password, account_data)
 
         # Get all accounts to determine positions
-        accounts_response = account.accounts_service.get_accounts()
+        accounts_response = backend.accounts_service.get_accounts()
         accounts_before = [acc for acc in accounts_response]
         assert len(accounts_before) >= 3, "Need at least two accounts to test move"
 
         # Move wallet account from position 1 to position 2
-        move_accounts_response = account.accounts_service.move_wallet_account(accounts_before[1].get("position"), accounts_before[2].get("position"))
+        move_accounts_response = backend.accounts_service.move_wallet_account(accounts_before[1].get("position"), accounts_before[2].get("position"))
         assert move_accounts_response is None
 
         # Fetch the accounts again
-        accounts_response_after = account.accounts_service.get_accounts()
+        accounts_response_after = backend.accounts_service.get_accounts()
         accounts_after = [acc for acc in accounts_response_after]
 
         # Checking the positions are still incremental after move
@@ -56,12 +56,12 @@ class TestMoveWalletAccount:
         assert accounts_before[1] == accounts_after[2]
         assert accounts_before[2] == accounts_after[1]
 
-    def test_move_profile_account_isnt_allowed(self, account):
+    def test_move_profile_account_isnt_allowed(self, backend):
         # Get all accounts to determine positions
-        accounts_response = account.accounts_service.get_accounts()
+        accounts_response = backend.accounts_service.get_accounts()
         accounts_before = [acc for acc in accounts_response]
         assert len(accounts_before) >= 2, "Need at least two accounts to test move"
 
         # Move wallet account from position 0 to position 1
         with pytest.raises(ApiResponseError, match=re.escape("accounts: trying to move account to a wrong position")):
-            account.accounts_service.move_wallet_account(accounts_before[0].get("position"), accounts_before[1].get("position"))
+            backend.accounts_service.move_wallet_account(accounts_before[0].get("position"), accounts_before[1].get("position"))

--- a/tests-functional/tests/test_push_notification_server.py
+++ b/tests-functional/tests/test_push_notification_server.py
@@ -53,35 +53,37 @@ def expect_push_notification(gorush, sender, receiver):
 @pytest.mark.rpc
 class TestPushNotificationServer(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two backends (alice and bob) for each test function"""
-        self.sender = backend_new_profile("alice")
-        self.receiver = backend_new_profile("bob")
+    @pytest.fixture()
+    def sender(self, backend_new_profile):
+        """Backend for Alice (push notification sender/receiver)."""
+        return backend_new_profile("alice")
 
-    def test_push_notification_delivery(self, push_notification_server):
+    @pytest.fixture()
+    def receiver(self, backend_new_profile):
+        """Backend for Bob (push notification sender/receiver)."""
+        return backend_new_profile("bob")
+
+    def test_push_notification_delivery(self, push_notification_server, sender, receiver):
         server, gorush = push_notification_server
-        alice = self.sender
-        bob = self.receiver
 
         # Register devices
-        alice.device_platform = PushNotificationRegistrationTokenType.APN_TOKEN
-        alice.wakuext_service.register_for_push_notifications(alice.device_id, APN_TOPIC, alice.device_platform)
+        sender.device_platform = PushNotificationRegistrationTokenType.APN_TOKEN
+        sender.wakuext_service.register_for_push_notifications(sender.device_id, APN_TOPIC, sender.device_platform)
 
-        bob.device_platform = PushNotificationRegistrationTokenType.FIREBASE_TOKEN
-        bob.wakuext_service.register_for_push_notifications(bob.device_id, APN_TOPIC, bob.device_platform)
+        receiver.device_platform = PushNotificationRegistrationTokenType.FIREBASE_TOKEN
+        receiver.wakuext_service.register_for_push_notifications(receiver.device_id, APN_TOPIC, receiver.device_platform)
 
         # There is currently no way to reliably check if the devices have been registered, so we just wait a few seconds
         time.sleep(10)
 
         # Make contacts, this should force delivery of a push notification
-        self.make_contacts(alice, bob)
-        expect_push_notification(gorush, alice, bob)
+        self.make_contacts(sender, receiver)
+        expect_push_notification(gorush, sender, receiver)
 
         # Send a message from Alice to Bob
-        alice.wakuext_service.send_one_to_one_message(bob.public_key, f"Message {uuid.uuid4()}")
-        expect_push_notification(gorush, alice, bob)
+        sender.wakuext_service.send_one_to_one_message(receiver.public_key, f"Message {uuid.uuid4()}")
+        expect_push_notification(gorush, sender, receiver)
 
         # Send a message from Bob to Alice
-        bob.wakuext_service.send_one_to_one_message(alice.public_key, f"Message {uuid.uuid4()}")
-        expect_push_notification(gorush, bob, alice)
+        receiver.wakuext_service.send_one_to_one_message(sender.public_key, f"Message {uuid.uuid4()}")
+        expect_push_notification(gorush, receiver, sender)

--- a/tests-functional/tests/test_remaining_account_capacity.py
+++ b/tests-functional/tests/test_remaining_account_capacity.py
@@ -9,47 +9,50 @@ import secrets
 @pytest.mark.rpc
 class TestRemainingAccountCapacity:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.account_data = copy.deepcopy(new_account_data_1)
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_remaining_account_capacity_decreases_on_add(self):
+    @pytest.fixture()
+    def account_data(self):
+        return copy.deepcopy(new_account_data_1)
+
+    def test_remaining_account_capacity_decreases_on_add(self, account, account_data):
         # 1) Query remaining capacity
-        initial_capacity = self.account.accounts_service.remaining_account_capacity()
+        initial_capacity = account.accounts_service.remaining_account_capacity()
         assert initial_capacity == 19
 
         # 2) Add a second account
         path = "m/44'/60'/0'/0/1"
-        derived_addresses_response = self.account.wallet_service.get_derived_addresses_for_mnemonic(self.account.mnemonic, [path])
-        self.account_data["key-uid"] = self.account.key_uid  # keyuid of profile keypair
-        self.account_data["path"] = path
-        self.account_data["address"] = derived_addresses_response[0].get("address")
-        self.account_data["public-key"] = derived_addresses_response[0].get("public-key")
-        self.account.accounts_service.add_account(self.account.password, self.account_data)
+        derived_addresses_response = account.wallet_service.get_derived_addresses_for_mnemonic(account.mnemonic, [path])
+        account_data["key-uid"] = account.key_uid  # keyuid of profile keypair
+        account_data["path"] = path
+        account_data["address"] = derived_addresses_response[0].get("address")
+        account_data["public-key"] = derived_addresses_response[0].get("public-key")
+        account.accounts_service.add_account(account.password, account_data)
 
         # 3) Query remaining capacity again and assert it decreased by exactly 1
-        after_capacity = self.account.accounts_service.remaining_account_capacity()
+        after_capacity = account.accounts_service.remaining_account_capacity()
         assert after_capacity == initial_capacity - 1
 
         # 4) Add a watch-only account (simpler to add without deriving a wallet address)
-        self.account_data2 = copy.deepcopy(new_account_data_2)
-        self.account_data2["type"] = "watch"
-        self.account.accounts_service.add_account(self.account.password, self.account_data2)
+        account_data2 = copy.deepcopy(new_account_data_2)
+        account_data2["type"] = "watch"
+        account.accounts_service.add_account(account.password, account_data2)
 
         # 5) Query remaining capacity again and assert it decreased by exactly 1
-        after_capacity2 = self.account.accounts_service.remaining_account_capacity()
+        after_capacity2 = account.accounts_service.remaining_account_capacity()
         assert after_capacity2 == after_capacity - 1
 
-    def test_no_more_accounts_can_be_added(self):
-        initial_capacity = self.account.accounts_service.remaining_account_capacity()
+    def test_no_more_accounts_can_be_added(self, account, account_data):
+        initial_capacity = account.accounts_service.remaining_account_capacity()
         for _ in range(initial_capacity):
-            self.account_data["type"] = "watch"
-            self.account_data["address"] = "0x" + secrets.token_hex(20)
-            self.account.accounts_service.add_account(self.account.password, self.account_data)
+            account_data["type"] = "watch"
+            account_data["address"] = "0x" + secrets.token_hex(20)
+            account.accounts_service.add_account(account.password, account_data)
 
-        accounts = self.account.accounts_service.get_accounts()
+        accounts = account.accounts_service.get_accounts()
         assert len(accounts) == 21
 
         with pytest.raises(ApiResponseError, match=re.escape("no more accounts can be added")):
-            self.account.accounts_service.remaining_account_capacity()
+            account.accounts_service.remaining_account_capacity()

--- a/tests-functional/tests/test_remaining_account_capacity.py
+++ b/tests-functional/tests/test_remaining_account_capacity.py
@@ -10,49 +10,49 @@ import secrets
 class TestRemainingAccountCapacity:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
     def account_data(self):
         return copy.deepcopy(new_account_data_1)
 
-    def test_remaining_account_capacity_decreases_on_add(self, account, account_data):
+    def test_remaining_account_capacity_decreases_on_add(self, backend, account_data):
         # 1) Query remaining capacity
-        initial_capacity = account.accounts_service.remaining_account_capacity()
+        initial_capacity = backend.accounts_service.remaining_account_capacity()
         assert initial_capacity == 19
 
         # 2) Add a second account
         path = "m/44'/60'/0'/0/1"
-        derived_addresses_response = account.wallet_service.get_derived_addresses_for_mnemonic(account.mnemonic, [path])
-        account_data["key-uid"] = account.key_uid  # keyuid of profile keypair
+        derived_addresses_response = backend.wallet_service.get_derived_addresses_for_mnemonic(backend.mnemonic, [path])
+        account_data["key-uid"] = backend.key_uid  # keyuid of profile keypair
         account_data["path"] = path
         account_data["address"] = derived_addresses_response[0].get("address")
         account_data["public-key"] = derived_addresses_response[0].get("public-key")
-        account.accounts_service.add_account(account.password, account_data)
+        backend.accounts_service.add_account(backend.password, account_data)
 
         # 3) Query remaining capacity again and assert it decreased by exactly 1
-        after_capacity = account.accounts_service.remaining_account_capacity()
+        after_capacity = backend.accounts_service.remaining_account_capacity()
         assert after_capacity == initial_capacity - 1
 
         # 4) Add a watch-only account (simpler to add without deriving a wallet address)
         account_data2 = copy.deepcopy(new_account_data_2)
         account_data2["type"] = "watch"
-        account.accounts_service.add_account(account.password, account_data2)
+        backend.accounts_service.add_account(backend.password, account_data2)
 
         # 5) Query remaining capacity again and assert it decreased by exactly 1
-        after_capacity2 = account.accounts_service.remaining_account_capacity()
+        after_capacity2 = backend.accounts_service.remaining_account_capacity()
         assert after_capacity2 == after_capacity - 1
 
-    def test_no_more_accounts_can_be_added(self, account, account_data):
-        initial_capacity = account.accounts_service.remaining_account_capacity()
+    def test_no_more_accounts_can_be_added(self, backend, account_data):
+        initial_capacity = backend.accounts_service.remaining_account_capacity()
         for _ in range(initial_capacity):
             account_data["type"] = "watch"
             account_data["address"] = "0x" + secrets.token_hex(20)
-            account.accounts_service.add_account(account.password, account_data)
+            backend.accounts_service.add_account(backend.password, account_data)
 
-        accounts = account.accounts_service.get_accounts()
+        accounts = backend.accounts_service.get_accounts()
         assert len(accounts) == 21
 
         with pytest.raises(ApiResponseError, match=re.escape("no more accounts can be added")):
-            account.accounts_service.remaining_account_capacity()
+            backend.accounts_service.remaining_account_capacity()

--- a/tests-functional/tests/test_remaining_keypair_capacity.py
+++ b/tests-functional/tests/test_remaining_keypair_capacity.py
@@ -9,49 +9,48 @@ import secrets
 @pytest.mark.rpc
 class TestRemainingKeypairCapacity:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.account_data = copy.deepcopy(new_account_data_1)
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_remaining_keypair_capacity_decreases_on_add(self):
+    @pytest.fixture()
+    def account_data(self):
+        return copy.deepcopy(new_account_data_1)
+
+    def test_remaining_keypair_capacity_decreases_on_add(self, account):
         # 1) Query remaining capacity
-        initial_capacity = self.account.accounts_service.remaining_keypair_capacity()
+        initial_capacity = account.accounts_service.remaining_keypair_capacity()
         assert initial_capacity == 4
 
         # 2) Add a keypair via private key
-        self.account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, self.account.password, keypair_name, wallet_account_details_root
-        )
+        account.accounts_service.add_keypair_via_private_key(user_1.private_key, account.password, keypair_name, wallet_account_details_root)
 
         # 3) Query remaining capacity again and assert it decreased by exactly 1
-        after_capacity = self.account.accounts_service.remaining_keypair_capacity()
+        after_capacity = account.accounts_service.remaining_keypair_capacity()
         assert after_capacity == initial_capacity - 1
 
         # 4) Add a keypair via seed phrase
-        self.account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, self.account.password, keypair_name, wallet_account_details_derivation
-        )
+        account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation)
 
         # 5) Query remaining capacity again and assert it decreased by exactly 1
-        after_capacity2 = self.account.accounts_service.remaining_keypair_capacity()
+        after_capacity2 = account.accounts_service.remaining_keypair_capacity()
         assert after_capacity2 == after_capacity - 1
 
-    def test_no_more_keypairs_can_be_added(self):
-        initial_capacity = self.account.accounts_service.remaining_keypair_capacity()
+    def test_no_more_keypairs_can_be_added(self, account):
+        initial_capacity = account.accounts_service.remaining_keypair_capacity()
         words = ["alpha", "bravo", "zulu", "test", "key"]
         for i in range(initial_capacity):
             keypair_name = f"stress-kp-{i}-{secrets.token_hex(4)}"
             passphrase = " ".join(secrets.choice(words) for _ in range(12))
-            self.account.accounts_service.add_keypair_via_seed_phrase(
+            account.accounts_service.add_keypair_via_seed_phrase(
                 passphrase,
-                self.account.password,
+                account.password,
                 keypair_name,
                 {"name": keypair_name, "path": f"m/44'/60'/0'/0/{i}", "emoji": "🔑", "colorId": "primary"},
             )
 
-        get_keypairs_response = self.account.accounts_service.get_account_keypairs()
+        get_keypairs_response = account.accounts_service.get_account_keypairs()
         assert len(get_keypairs_response) == 5
 
         with pytest.raises(ApiResponseError, match=re.escape("no more keypairs can be added")):
-            self.account.accounts_service.remaining_keypair_capacity()
+            account.accounts_service.remaining_keypair_capacity()

--- a/tests-functional/tests/test_remaining_keypair_capacity.py
+++ b/tests-functional/tests/test_remaining_keypair_capacity.py
@@ -10,47 +10,47 @@ import secrets
 class TestRemainingKeypairCapacity:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
     def account_data(self):
         return copy.deepcopy(new_account_data_1)
 
-    def test_remaining_keypair_capacity_decreases_on_add(self, account):
+    def test_remaining_keypair_capacity_decreases_on_add(self, backend):
         # 1) Query remaining capacity
-        initial_capacity = account.accounts_service.remaining_keypair_capacity()
+        initial_capacity = backend.accounts_service.remaining_keypair_capacity()
         assert initial_capacity == 4
 
         # 2) Add a keypair via private key
-        account.accounts_service.add_keypair_via_private_key(user_1.private_key, account.password, keypair_name, wallet_account_details_root)
+        backend.accounts_service.add_keypair_via_private_key(user_1.private_key, backend.password, keypair_name, wallet_account_details_root)
 
         # 3) Query remaining capacity again and assert it decreased by exactly 1
-        after_capacity = account.accounts_service.remaining_keypair_capacity()
+        after_capacity = backend.accounts_service.remaining_keypair_capacity()
         assert after_capacity == initial_capacity - 1
 
         # 4) Add a keypair via seed phrase
-        account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation)
+        backend.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, backend.password, keypair_name, wallet_account_details_derivation)
 
         # 5) Query remaining capacity again and assert it decreased by exactly 1
-        after_capacity2 = account.accounts_service.remaining_keypair_capacity()
+        after_capacity2 = backend.accounts_service.remaining_keypair_capacity()
         assert after_capacity2 == after_capacity - 1
 
-    def test_no_more_keypairs_can_be_added(self, account):
-        initial_capacity = account.accounts_service.remaining_keypair_capacity()
+    def test_no_more_keypairs_can_be_added(self, backend):
+        initial_capacity = backend.accounts_service.remaining_keypair_capacity()
         words = ["alpha", "bravo", "zulu", "test", "key"]
         for i in range(initial_capacity):
             keypair_name = f"stress-kp-{i}-{secrets.token_hex(4)}"
             passphrase = " ".join(secrets.choice(words) for _ in range(12))
-            account.accounts_service.add_keypair_via_seed_phrase(
+            backend.accounts_service.add_keypair_via_seed_phrase(
                 passphrase,
-                account.password,
+                backend.password,
                 keypair_name,
                 {"name": keypair_name, "path": f"m/44'/60'/0'/0/{i}", "emoji": "🔑", "colorId": "primary"},
             )
 
-        get_keypairs_response = account.accounts_service.get_account_keypairs()
+        get_keypairs_response = backend.accounts_service.get_account_keypairs()
         assert len(get_keypairs_response) == 5
 
         with pytest.raises(ApiResponseError, match=re.escape("no more keypairs can be added")):
-            account.accounts_service.remaining_keypair_capacity()
+            backend.accounts_service.remaining_keypair_capacity()

--- a/tests-functional/tests/test_remaining_watch_only_account_capacity.py
+++ b/tests-functional/tests/test_remaining_watch_only_account_capacity.py
@@ -10,7 +10,7 @@ import secrets
 class TestRemainingWatchOnlyAccountCapacity:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
@@ -19,24 +19,24 @@ class TestRemainingWatchOnlyAccountCapacity:
         data["type"] = "watch"
         return data
 
-    def test_remaining_watch_only_account_capacity_decreases_on_add(self, account, account_data):
-        initial_capacity = account.accounts_service.remaining_watch_only_account_capacity()
+    def test_remaining_watch_only_account_capacity_decreases_on_add(self, backend, account_data):
+        initial_capacity = backend.accounts_service.remaining_watch_only_account_capacity()
         assert initial_capacity == 3
 
-        account.accounts_service.add_account(account.password, account_data)
+        backend.accounts_service.add_account(backend.password, account_data)
 
-        after_capacity = account.accounts_service.remaining_watch_only_account_capacity()
+        after_capacity = backend.accounts_service.remaining_watch_only_account_capacity()
         assert after_capacity == initial_capacity - 1
 
-    def test_no_more_watch_only_accounts_can_be_added(self, account, account_data):
-        initial_capacity = account.accounts_service.remaining_watch_only_account_capacity()
+    def test_no_more_watch_only_accounts_can_be_added(self, backend, account_data):
+        initial_capacity = backend.accounts_service.remaining_watch_only_account_capacity()
         for _ in range(initial_capacity):
             account_data["address"] = "0x" + secrets.token_hex(20)
-            account.accounts_service.add_account(account.password, account_data)
+            backend.accounts_service.add_account(backend.password, account_data)
 
-        accounts = account.accounts_service.get_accounts()
+        accounts = backend.accounts_service.get_accounts()
         watch_accounts = [account for account in accounts if account["type"] == "watch"]
         assert len(watch_accounts) == 3
 
         with pytest.raises(ApiResponseError, match=re.escape("no more watch-only accounts can be added")):
-            account.accounts_service.remaining_watch_only_account_capacity()
+            backend.accounts_service.remaining_watch_only_account_capacity()

--- a/tests-functional/tests/test_remaining_watch_only_account_capacity.py
+++ b/tests-functional/tests/test_remaining_watch_only_account_capacity.py
@@ -9,30 +9,34 @@ import secrets
 @pytest.mark.rpc
 class TestRemainingWatchOnlyAccountCapacity:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.account_data = copy.deepcopy(new_account_data_1)
-        self.account_data["type"] = "watch"
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_remaining_watch_only_account_capacity_decreases_on_add(self):
-        initial_capacity = self.account.accounts_service.remaining_watch_only_account_capacity()
+    @pytest.fixture()
+    def account_data(self):
+        data = copy.deepcopy(new_account_data_1)
+        data["type"] = "watch"
+        return data
+
+    def test_remaining_watch_only_account_capacity_decreases_on_add(self, account, account_data):
+        initial_capacity = account.accounts_service.remaining_watch_only_account_capacity()
         assert initial_capacity == 3
 
-        self.account.accounts_service.add_account(self.account.password, self.account_data)
+        account.accounts_service.add_account(account.password, account_data)
 
-        after_capacity = self.account.accounts_service.remaining_watch_only_account_capacity()
+        after_capacity = account.accounts_service.remaining_watch_only_account_capacity()
         assert after_capacity == initial_capacity - 1
 
-    def test_no_more_watch_only_accounts_can_be_added(self):
-        initial_capacity = self.account.accounts_service.remaining_watch_only_account_capacity()
+    def test_no_more_watch_only_accounts_can_be_added(self, account, account_data):
+        initial_capacity = account.accounts_service.remaining_watch_only_account_capacity()
         for _ in range(initial_capacity):
-            self.account_data["address"] = "0x" + secrets.token_hex(20)
-            self.account.accounts_service.add_account(self.account.password, self.account_data)
+            account_data["address"] = "0x" + secrets.token_hex(20)
+            account.accounts_service.add_account(account.password, account_data)
 
-        accounts = self.account.accounts_service.get_accounts()
+        accounts = account.accounts_service.get_accounts()
         watch_accounts = [account for account in accounts if account["type"] == "watch"]
         assert len(watch_accounts) == 3
 
         with pytest.raises(ApiResponseError, match=re.escape("no more watch-only accounts can be added")):
-            self.account.accounts_service.remaining_watch_only_account_capacity()
+            account.accounts_service.remaining_watch_only_account_capacity()

--- a/tests-functional/tests/test_resolve_suggested_path.py
+++ b/tests-functional/tests/test_resolve_suggested_path.py
@@ -5,7 +5,7 @@ import pytest
 class TestResolveSuggestedPath:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.mark.parametrize(
@@ -16,10 +16,10 @@ class TestResolveSuggestedPath:
             "test",
         ],
     )
-    def test_resolve_suggested_path_for_random_key(self, account, key_uid):
-        response = account.accounts_service.resolve_suggested_path_for_keypair(key_uid)
+    def test_resolve_suggested_path_for_random_key(self, backend, key_uid):
+        response = backend.accounts_service.resolve_suggested_path_for_keypair(key_uid)
         assert response == "m/44'/60'/0'/0/0"
 
-    def test_resolve_suggested_path_for_used_key(self, account):
-        response = account.accounts_service.resolve_suggested_path_for_keypair(account.key_uid)
+    def test_resolve_suggested_path_for_used_key(self, backend):
+        response = backend.accounts_service.resolve_suggested_path_for_keypair(backend.key_uid)
         assert response == "m/44'/60'/0'/0/1"

--- a/tests-functional/tests/test_resolve_suggested_path.py
+++ b/tests-functional/tests/test_resolve_suggested_path.py
@@ -4,17 +4,22 @@ import pytest
 @pytest.mark.rpc
 class TestResolveSuggestedPath:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
     @pytest.mark.parametrize(
-        "key_uid", ["0x9d26312bace61a229c1db5a43d8f9b93d80d25398476405d66479df1504f0438", "0xC43f4Ab94eC965a3EE9815C5Df07383057d261A8", "test"]
+        "key_uid",
+        [
+            "0x9d26312bace61a229c1db5a43d8f9b93d80d25398476405d66479df1504f0438",
+            "0xC43f4Ab94eC965a3EE9815C5Df07383057d261A8",
+            "test",
+        ],
     )
-    def test_resolve_suggested_path_for_random_key(self, key_uid):
-        response = self.account.accounts_service.resolve_suggested_path_for_keypair(key_uid)
+    def test_resolve_suggested_path_for_random_key(self, account, key_uid):
+        response = account.accounts_service.resolve_suggested_path_for_keypair(key_uid)
         assert response == "m/44'/60'/0'/0/0"
 
-    def test_resolve_suggested_path_for_used_key(self):
-        response = self.account.accounts_service.resolve_suggested_path_for_keypair(self.account.key_uid)
+    def test_resolve_suggested_path_for_used_key(self, account):
+        response = account.accounts_service.resolve_suggested_path_for_keypair(account.key_uid)
         assert response == "m/44'/60'/0'/0/1"

--- a/tests-functional/tests/test_save_or_update_keycard.py
+++ b/tests-functional/tests/test_save_or_update_keycard.py
@@ -9,24 +9,24 @@ from clients.api import ApiResponseError
 class TestSaveOrUpdateKeycard:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
-    def keycard(self, account):
+    def keycard(self, backend):
         """Fresh keycard data bound to the current account's key-uid."""
         kc = copy.deepcopy(keycard_1)
-        kc["key-uid"] = account.key_uid
+        kc["key-uid"] = backend.key_uid
         return kc
 
-    def test_save_new_keycard(self, account, keycard):
-        keycards_before = account.accounts_service.get_all_known_keycards()
+    def test_save_new_keycard(self, backend, keycard):
+        keycards_before = backend.accounts_service.get_all_known_keycards()
         assert keycards_before == []
 
-        resp = account.accounts_service.save_or_update_keycard(keycard, account.password)
+        resp = backend.accounts_service.save_or_update_keycard(keycard, backend.password)
         assert resp is None
 
-        keycards_after = account.accounts_service.get_all_known_keycards()
+        keycards_after = backend.accounts_service.get_all_known_keycards()
         keycards = keycards_after
         assert len(keycards) == 1
         assert keycards[0].get("keycard-uid") == keycard.get("keycard-uid")
@@ -36,22 +36,22 @@ class TestSaveOrUpdateKeycard:
         assert keycards[0].get("key-uid") == keycard.get("key-uid")
         assert keycards[0].get("Position") == 0
 
-    def test_save_duplicate_keycard(self, account, keycard):
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
-        keycards_after = account.accounts_service.get_all_known_keycards()
+    def test_save_duplicate_keycard(self, backend, keycard):
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
+        keycards_after = backend.accounts_service.get_all_known_keycards()
         keycards = keycards_after
         assert len(keycards) == 1  # only one keycard is saved
 
-    def test_save_multiple_keycards(self, account, keycard):
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
+    def test_save_multiple_keycards(self, backend, keycard):
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
         second_keycard = copy.deepcopy(keycard)
         second_keycard["keycard-uid"] = "second_kc_uid"
         second_keycard["keycard-name"] = "second_kc_name"
         second_keycard["keycard-addresses"] = "0x2f49e5eff87892deb1fffeed666fa75ccb2dbbc2"
-        account.accounts_service.save_or_update_keycard(second_keycard, account.password)
+        backend.accounts_service.save_or_update_keycard(second_keycard, backend.password)
 
-        keycards_after = account.accounts_service.get_all_known_keycards()
+        keycards_after = backend.accounts_service.get_all_known_keycards()
         keycards = keycards_after
         assert len(keycards) == 2
         assert keycards[0].get("keycard-uid") == keycard.get("keycard-uid")
@@ -67,32 +67,32 @@ class TestSaveOrUpdateKeycard:
         assert keycards[1].get("key-uid") == second_keycard.get("key-uid")
         assert keycards[1].get("Position") == 1
 
-    def test_save_keycard_with_wrong_key_uid(self, account, keycard):
+    def test_save_keycard_with_wrong_key_uid(self, backend, keycard):
         keycard["key-uid"] = "0x91b0a565ccc994d62b4869984fd720c6f99827966f94cb6a9aff02bcbb86a069"
         with pytest.raises(ApiResponseError, match=re.escape("[validation] keycard does not relate to any keypair: keypair is not found")):
-            account.accounts_service.save_or_update_keycard(keycard, account.password)
+            backend.accounts_service.save_or_update_keycard(keycard, backend.password)
 
-    def test_save_keycard_with_no_account_address(self, account, keycard):
+    def test_save_keycard_with_no_account_address(self, backend, keycard):
         del keycard["accounts-addresses"]
         with pytest.raises(ApiResponseError, match=re.escape("[validation] keycard does not have any accounts")):
-            account.accounts_service.save_or_update_keycard(keycard, account.password)
+            backend.accounts_service.save_or_update_keycard(keycard, backend.password)
 
-    def test_update_keycards(self, account, keycard):
+    def test_update_keycards(self, backend, keycard):
         # First create two keycards
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
         second_keycard = copy.deepcopy(keycard)
         second_keycard["keycard-uid"] = "second_kc_uid"
         second_keycard["keycard-name"] = "second_kc_name"
         second_keycard["keycard-addresses"] = "0x2f49e5eff87892deb1fffeed666fa75ccb2dbbc2"
-        account.accounts_service.save_or_update_keycard(second_keycard, account.password)
+        backend.accounts_service.save_or_update_keycard(second_keycard, backend.password)
 
         # Now update their names
         keycard["keycard-name"] = "UpdatedFirstKeycardName"
         second_keycard["keycard-name"] = "UpdatedSecondKeycardName"
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
-        account.accounts_service.save_or_update_keycard(second_keycard, account.password)
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
+        backend.accounts_service.save_or_update_keycard(second_keycard, backend.password)
 
-        keycards_update = account.accounts_service.get_all_known_keycards()
+        keycards_update = backend.accounts_service.get_all_known_keycards()
         keycards = keycards_update
         assert len(keycards) == 2
         assert keycards[0].get("keycard-name") == keycard.get("keycard-name")

--- a/tests-functional/tests/test_save_or_update_keycard.py
+++ b/tests-functional/tests/test_save_or_update_keycard.py
@@ -8,78 +8,92 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestSaveOrUpdateKeycard:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.keycard = copy.deepcopy(keycard_1)
-        self.keycard["key-uid"] = self.account.key_uid
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_save_new_keycard(self):
-        keycards_before = self.account.accounts_service.get_all_known_keycards()
+    @pytest.fixture()
+    def keycard(self, account):
+        """Fresh keycard data bound to the current account's key-uid."""
+        kc = copy.deepcopy(keycard_1)
+        kc["key-uid"] = account.key_uid
+        return kc
+
+    def test_save_new_keycard(self, account, keycard):
+        keycards_before = account.accounts_service.get_all_known_keycards()
         assert keycards_before == []
 
-        resp = self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
+        resp = account.accounts_service.save_or_update_keycard(keycard, account.password)
         assert resp is None
 
-        keycards_after = self.account.accounts_service.get_all_known_keycards()
+        keycards_after = account.accounts_service.get_all_known_keycards()
         keycards = keycards_after
         assert len(keycards) == 1
-        assert keycards[0].get("keycard-uid") == self.keycard.get("keycard-uid")
-        assert keycards[0].get("keycard-name") == self.keycard.get("keycard-name")
+        assert keycards[0].get("keycard-uid") == keycard.get("keycard-uid")
+        assert keycards[0].get("keycard-name") == keycard.get("keycard-name")
         assert keycards[0].get("keycard-locked") is False
-        assert keycards[0].get("accounts-addresses") == self.keycard.get("accounts-addresses")
-        assert keycards[0].get("key-uid") == self.keycard.get("key-uid")
+        assert keycards[0].get("accounts-addresses") == keycard.get("accounts-addresses")
+        assert keycards[0].get("key-uid") == keycard.get("key-uid")
         assert keycards[0].get("Position") == 0
 
-    def test_save_duplicate_keycard(self):
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
-        keycards_after = self.account.accounts_service.get_all_known_keycards()
+    def test_save_duplicate_keycard(self, account, keycard):
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
+        keycards_after = account.accounts_service.get_all_known_keycards()
         keycards = keycards_after
         assert len(keycards) == 1  # only one keycard is saved
 
-    def test_save_multiple_keycards(self):
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
-        self.second_keycard = copy.deepcopy(self.keycard)
-        self.second_keycard["keycard-uid"] = "second_kc_uid"
-        self.second_keycard["keycard-name"] = "second_kc_name"
-        self.second_keycard["keycard-addresses"] = "0x2f49e5eff87892deb1fffeed666fa75ccb2dbbc2"
-        self.account.accounts_service.save_or_update_keycard(self.second_keycard, self.account.password)
+    def test_save_multiple_keycards(self, account, keycard):
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
+        second_keycard = copy.deepcopy(keycard)
+        second_keycard["keycard-uid"] = "second_kc_uid"
+        second_keycard["keycard-name"] = "second_kc_name"
+        second_keycard["keycard-addresses"] = "0x2f49e5eff87892deb1fffeed666fa75ccb2dbbc2"
+        account.accounts_service.save_or_update_keycard(second_keycard, account.password)
 
-        keycards_after = self.account.accounts_service.get_all_known_keycards()
+        keycards_after = account.accounts_service.get_all_known_keycards()
         keycards = keycards_after
         assert len(keycards) == 2
-        assert keycards[0].get("keycard-uid") == self.keycard.get("keycard-uid")
-        assert keycards[0].get("keycard-name") == self.keycard.get("keycard-name")
+        assert keycards[0].get("keycard-uid") == keycard.get("keycard-uid")
+        assert keycards[0].get("keycard-name") == keycard.get("keycard-name")
         assert keycards[0].get("keycard-locked") is False
-        assert keycards[0].get("accounts-addresses") == self.keycard.get("accounts-addresses")
-        assert keycards[0].get("key-uid") == self.keycard.get("key-uid")
+        assert keycards[0].get("accounts-addresses") == keycard.get("accounts-addresses")
+        assert keycards[0].get("key-uid") == keycard.get("key-uid")
         assert keycards[0].get("Position") == 0
-        assert keycards[1].get("keycard-uid") == self.second_keycard.get("keycard-uid")
-        assert keycards[1].get("keycard-name") == self.second_keycard.get("keycard-name")
+        assert keycards[1].get("keycard-uid") == second_keycard.get("keycard-uid")
+        assert keycards[1].get("keycard-name") == second_keycard.get("keycard-name")
         assert keycards[1].get("keycard-locked") is False
-        assert keycards[1].get("accounts-addresses") == self.second_keycard.get("accounts-addresses")
-        assert keycards[1].get("key-uid") == self.second_keycard.get("key-uid")
+        assert keycards[1].get("accounts-addresses") == second_keycard.get("accounts-addresses")
+        assert keycards[1].get("key-uid") == second_keycard.get("key-uid")
         assert keycards[1].get("Position") == 1
 
-    def test_save_keycard_with_wrong_key_uid(self):
-        self.keycard["key-uid"] = "0x91b0a565ccc994d62b4869984fd720c6f99827966f94cb6a9aff02bcbb86a069"
+    def test_save_keycard_with_wrong_key_uid(self, account, keycard):
+        keycard["key-uid"] = "0x91b0a565ccc994d62b4869984fd720c6f99827966f94cb6a9aff02bcbb86a069"
         with pytest.raises(ApiResponseError, match=re.escape("[validation] keycard does not relate to any keypair: keypair is not found")):
-            self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
+            account.accounts_service.save_or_update_keycard(keycard, account.password)
 
-    def test_save_keycard_with_no_account_address(self):
-        del self.keycard["accounts-addresses"]
+    def test_save_keycard_with_no_account_address(self, account, keycard):
+        del keycard["accounts-addresses"]
         with pytest.raises(ApiResponseError, match=re.escape("[validation] keycard does not have any accounts")):
-            self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
+            account.accounts_service.save_or_update_keycard(keycard, account.password)
 
-    def test_update_keycards(self):
-        self.test_save_multiple_keycards()
-        self.keycard["keycard-name"] = "UpdatedFirstKeycardName"
-        self.second_keycard["keycard-name"] = "UpdatedSecondKeycardName"
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
-        self.account.accounts_service.save_or_update_keycard(self.second_keycard, self.account.password)
-        keycards_update = self.account.accounts_service.get_all_known_keycards()
+    def test_update_keycards(self, account, keycard):
+        # First create two keycards
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
+        second_keycard = copy.deepcopy(keycard)
+        second_keycard["keycard-uid"] = "second_kc_uid"
+        second_keycard["keycard-name"] = "second_kc_name"
+        second_keycard["keycard-addresses"] = "0x2f49e5eff87892deb1fffeed666fa75ccb2dbbc2"
+        account.accounts_service.save_or_update_keycard(second_keycard, account.password)
+
+        # Now update their names
+        keycard["keycard-name"] = "UpdatedFirstKeycardName"
+        second_keycard["keycard-name"] = "UpdatedSecondKeycardName"
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
+        account.accounts_service.save_or_update_keycard(second_keycard, account.password)
+
+        keycards_update = account.accounts_service.get_all_known_keycards()
         keycards = keycards_update
         assert len(keycards) == 2
-        assert keycards[0].get("keycard-name") == self.keycard.get("keycard-name")
-        assert keycards[1].get("keycard-name") == self.second_keycard.get("keycard-name")
+        assert keycards[0].get("keycard-name") == keycard.get("keycard-name")
+        assert keycards[1].get("keycard-name") == second_keycard.get("keycard-name")

--- a/tests-functional/tests/test_set_keycard_name.py
+++ b/tests-functional/tests/test_set_keycard_name.py
@@ -8,23 +8,28 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestSetKeycardName:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.keycard = copy.deepcopy(keycard_1)
-        self.keycard["key-uid"] = self.account.key_uid
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_set_keycard_name_success(self):
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
+    @pytest.fixture()
+    def keycard(self, account):
+        """Fresh keycard data bound to the current account's key-uid."""
+        kc = copy.deepcopy(keycard_1)
+        kc["key-uid"] = account.key_uid
+        return kc
+
+    def test_set_keycard_name_success(self, account, keycard):
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
         new_name = "UpdatedKeycardName"
-        resp = self.account.accounts_service.set_keycard_name(self.keycard["keycard-uid"], new_name)
+        resp = account.accounts_service.set_keycard_name(keycard["keycard-uid"], new_name)
         assert resp is None
 
-        keycards_after = self.account.accounts_service.get_all_known_keycards()
+        keycards_after = account.accounts_service.get_all_known_keycards()
         keycards = keycards_after
         assert len(keycards) == 1
         assert keycards[0].get("keycard-name") == new_name
 
-    def test_set_name_to_nonexistent_keycard(self):
+    def test_set_name_to_nonexistent_keycard(self, account):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            self.account.accounts_service.set_keycard_name("non-existent-keycard-uid-1234", "Name")
+            account.accounts_service.set_keycard_name("non-existent-keycard-uid-1234", "Name")

--- a/tests-functional/tests/test_set_keycard_name.py
+++ b/tests-functional/tests/test_set_keycard_name.py
@@ -9,27 +9,27 @@ from clients.api import ApiResponseError
 class TestSetKeycardName:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
-    def keycard(self, account):
+    def keycard(self, backend):
         """Fresh keycard data bound to the current account's key-uid."""
         kc = copy.deepcopy(keycard_1)
-        kc["key-uid"] = account.key_uid
+        kc["key-uid"] = backend.key_uid
         return kc
 
-    def test_set_keycard_name_success(self, account, keycard):
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
+    def test_set_keycard_name_success(self, backend, keycard):
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
         new_name = "UpdatedKeycardName"
-        resp = account.accounts_service.set_keycard_name(keycard["keycard-uid"], new_name)
+        resp = backend.accounts_service.set_keycard_name(keycard["keycard-uid"], new_name)
         assert resp is None
 
-        keycards_after = account.accounts_service.get_all_known_keycards()
+        keycards_after = backend.accounts_service.get_all_known_keycards()
         keycards = keycards_after
         assert len(keycards) == 1
         assert keycards[0].get("keycard-name") == new_name
 
-    def test_set_name_to_nonexistent_keycard(self, account):
+    def test_set_name_to_nonexistent_keycard(self, backend):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            account.accounts_service.set_keycard_name("non-existent-keycard-uid-1234", "Name")
+            backend.accounts_service.set_keycard_name("non-existent-keycard-uid-1234", "Name")

--- a/tests-functional/tests/test_token_preferences.py
+++ b/tests-functional/tests/test_token_preferences.py
@@ -4,27 +4,27 @@ import pytest
 @pytest.mark.rpc
 class TestTokenPreferences:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_update_with_valid_token_preferences(self):
-        token_preferences_before = self.account.accounts_service.get_token_preferences()
+    def test_update_with_valid_token_preferences(self, account):
+        token_preferences_before = account.accounts_service.get_token_preferences()
         assert token_preferences_before is None
 
         new_token_preferences = [
             {"communityId": "123", "groupPosition": 2, "key": "0x1234567890abcdef1234567890abcdef12345678", "position": 3, "visible": True}
         ]
-        update_response = self.account.accounts_service.update_token_preferences(new_token_preferences)
+        update_response = account.accounts_service.update_token_preferences(new_token_preferences)
         assert update_response is None
 
-        token_preferences_after = self.account.accounts_service.get_token_preferences()
+        token_preferences_after = account.accounts_service.get_token_preferences()
         assert token_preferences_after == new_token_preferences
 
-    def test_update_with_invalid_token_preferences(self):
+    def test_update_with_invalid_token_preferences(self, account):
         new_token_preferences = [{"key": "0x1234567890abcdef1234567890abcdef12345678", "foo": "bar"}]
-        self.account.accounts_service.update_token_preferences(new_token_preferences)
-        token_preferences_after = self.account.accounts_service.get_token_preferences()
+        account.accounts_service.update_token_preferences(new_token_preferences)
+        token_preferences_after = account.accounts_service.get_token_preferences()
         assert len(token_preferences_after)
 
         # missing fields are assigned default values
@@ -37,23 +37,23 @@ class TestTokenPreferences:
         assert token_preference.get("position") == 0
         assert token_preference.get("visible") is False
 
-    def test_overwrite_existing_token_preferences(self):
+    def test_overwrite_existing_token_preferences(self, account):
         new_token_preferences1 = [
             {"communityId": "123", "groupPosition": 2, "key": "0x1234567890abcdef1234567890abcdef12345678", "position": 3, "visible": True}
         ]
-        self.account.accounts_service.update_token_preferences(new_token_preferences1)
+        account.accounts_service.update_token_preferences(new_token_preferences1)
         new_token_preferences2 = [
             {"communityId": "567", "groupPosition": 1, "key": "0x1234567890abcdef1234567890abcdef12345676", "position": 1, "visible": False}
         ]
-        self.account.accounts_service.update_token_preferences(new_token_preferences2)
-        token_preferences_after = self.account.accounts_service.get_token_preferences()
+        account.accounts_service.update_token_preferences(new_token_preferences2)
+        token_preferences_after = account.accounts_service.get_token_preferences()
         assert token_preferences_after == new_token_preferences2
 
-    def test_add_multiple_token_preferences(self):
+    def test_add_multiple_token_preferences(self, account):
         new_token_preferences = [
             {"communityId": "123", "groupPosition": 2, "key": "0x1234567890abcdef1234567890abcdef12345678", "position": 3, "visible": True},
             {"communityId": "567", "groupPosition": 1, "key": "0x1234567890abcdef1234567890abcdef12345676", "position": 1, "visible": False},
         ]
-        self.account.accounts_service.update_token_preferences(new_token_preferences)
-        token_preferences_after = self.account.accounts_service.get_token_preferences()
+        account.accounts_service.update_token_preferences(new_token_preferences)
+        token_preferences_after = account.accounts_service.get_token_preferences()
         assert token_preferences_after == new_token_preferences

--- a/tests-functional/tests/test_token_preferences.py
+++ b/tests-functional/tests/test_token_preferences.py
@@ -5,26 +5,26 @@ import pytest
 class TestTokenPreferences:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_update_with_valid_token_preferences(self, account):
-        token_preferences_before = account.accounts_service.get_token_preferences()
+    def test_update_with_valid_token_preferences(self, backend):
+        token_preferences_before = backend.accounts_service.get_token_preferences()
         assert token_preferences_before is None
 
         new_token_preferences = [
             {"communityId": "123", "groupPosition": 2, "key": "0x1234567890abcdef1234567890abcdef12345678", "position": 3, "visible": True}
         ]
-        update_response = account.accounts_service.update_token_preferences(new_token_preferences)
+        update_response = backend.accounts_service.update_token_preferences(new_token_preferences)
         assert update_response is None
 
-        token_preferences_after = account.accounts_service.get_token_preferences()
+        token_preferences_after = backend.accounts_service.get_token_preferences()
         assert token_preferences_after == new_token_preferences
 
-    def test_update_with_invalid_token_preferences(self, account):
+    def test_update_with_invalid_token_preferences(self, backend):
         new_token_preferences = [{"key": "0x1234567890abcdef1234567890abcdef12345678", "foo": "bar"}]
-        account.accounts_service.update_token_preferences(new_token_preferences)
-        token_preferences_after = account.accounts_service.get_token_preferences()
+        backend.accounts_service.update_token_preferences(new_token_preferences)
+        token_preferences_after = backend.accounts_service.get_token_preferences()
         assert len(token_preferences_after)
 
         # missing fields are assigned default values
@@ -37,23 +37,23 @@ class TestTokenPreferences:
         assert token_preference.get("position") == 0
         assert token_preference.get("visible") is False
 
-    def test_overwrite_existing_token_preferences(self, account):
+    def test_overwrite_existing_token_preferences(self, backend):
         new_token_preferences1 = [
             {"communityId": "123", "groupPosition": 2, "key": "0x1234567890abcdef1234567890abcdef12345678", "position": 3, "visible": True}
         ]
-        account.accounts_service.update_token_preferences(new_token_preferences1)
+        backend.accounts_service.update_token_preferences(new_token_preferences1)
         new_token_preferences2 = [
             {"communityId": "567", "groupPosition": 1, "key": "0x1234567890abcdef1234567890abcdef12345676", "position": 1, "visible": False}
         ]
-        account.accounts_service.update_token_preferences(new_token_preferences2)
-        token_preferences_after = account.accounts_service.get_token_preferences()
+        backend.accounts_service.update_token_preferences(new_token_preferences2)
+        token_preferences_after = backend.accounts_service.get_token_preferences()
         assert token_preferences_after == new_token_preferences2
 
-    def test_add_multiple_token_preferences(self, account):
+    def test_add_multiple_token_preferences(self, backend):
         new_token_preferences = [
             {"communityId": "123", "groupPosition": 2, "key": "0x1234567890abcdef1234567890abcdef12345678", "position": 3, "visible": True},
             {"communityId": "567", "groupPosition": 1, "key": "0x1234567890abcdef1234567890abcdef12345676", "position": 1, "visible": False},
         ]
-        account.accounts_service.update_token_preferences(new_token_preferences)
-        token_preferences_after = account.accounts_service.get_token_preferences()
+        backend.accounts_service.update_token_preferences(new_token_preferences)
+        token_preferences_after = backend.accounts_service.get_token_preferences()
         assert token_preferences_after == new_token_preferences

--- a/tests-functional/tests/test_update_account.py
+++ b/tests-functional/tests/test_update_account.py
@@ -8,18 +8,22 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestUpdateAccount:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.account_data = copy.deepcopy(new_account_data_1)
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_update_editable_fields_to_all_accounts(self):
+    @pytest.fixture()
+    def account_data(self):
+        """Fresh copy of base account data for each test."""
+        return copy.deepcopy(new_account_data_1)
+
+    def test_update_editable_fields_to_all_accounts(self, account, account_data):
         # create also a watch account
-        self.account_data["type"] = "watch"
-        self.account.accounts_service.add_account(self.account.password, self.account_data)
+        account_data["type"] = "watch"
+        account.accounts_service.add_account(account.password, account_data)
 
         # fetch all accounts(chat, wallet and watch) for update
-        accounts_response_before = self.account.accounts_service.get_accounts()
+        accounts_response_before = account.accounts_service.get_accounts()
         accounts_before = accounts_response_before
 
         for before in accounts_before:
@@ -29,11 +33,11 @@ class TestUpdateAccount:
             before["name"] = "UpdatedName"
             before["emoji"] = "✨"
             before["prodPreferredChainIds"] = "2:10:42161:8458"
-            update_resp = self.account.accounts_service.update_account(before)
+            update_resp = account.accounts_service.update_account(before)
             assert update_resp is None
 
         # verify update persisted
-        accounts_response_after = self.account.accounts_service.get_accounts()
+        accounts_response_after = account.accounts_service.get_accounts()
         accounts_after = accounts_response_after
         assert len(accounts_before) == len(accounts_after)
         for before, after in zip(accounts_before, accounts_after):
@@ -41,9 +45,9 @@ class TestUpdateAccount:
             before["clock"] = after["clock"] = 0
             assert after == before
 
-    def test_try_to_update_non_editable_fields(self):
+    def test_try_to_update_non_editable_fields(self, account):
         # fetch all accounts
-        accounts_response_before = self.account.accounts_service.get_accounts()
+        accounts_response_before = account.accounts_service.get_accounts()
         accounts_before = accounts_response_before
 
         for before in accounts_before:
@@ -58,10 +62,10 @@ class TestUpdateAccount:
             )
             before_copy["type"] = "key"
             before_copy["wallet"] = not (before_copy["wallet"])
-            self.account.accounts_service.update_account(before_copy)
+            account.accounts_service.update_account(before_copy)
 
         # verify that no update was made to non editable fields
-        accounts_response_after = self.account.accounts_service.get_accounts()
+        accounts_response_after = account.accounts_service.get_accounts()
         accounts_after = accounts_response_after
         assert len(accounts_before) == len(accounts_after)
         for before, after in zip(accounts_before, accounts_after):
@@ -69,7 +73,7 @@ class TestUpdateAccount:
             before["clock"] = after["clock"] = 0
             assert after == before
 
-    def test_update_nonexistent_account(self):
+    def test_update_nonexistent_account(self, account):
         nonexisting = {"address": "0x0000000000000000000000000000000000000001", "name": "Nope"}
         with pytest.raises(ApiResponseError, match=re.escape("cannot update non-existing account: accounts: account is not found")):
-            self.account.accounts_service.update_account(nonexisting)
+            account.accounts_service.update_account(nonexisting)

--- a/tests-functional/tests/test_update_account.py
+++ b/tests-functional/tests/test_update_account.py
@@ -9,7 +9,7 @@ from clients.api import ApiResponseError
 class TestUpdateAccount:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
@@ -17,13 +17,13 @@ class TestUpdateAccount:
         """Fresh copy of base account data for each test."""
         return copy.deepcopy(new_account_data_1)
 
-    def test_update_editable_fields_to_all_accounts(self, account, account_data):
+    def test_update_editable_fields_to_all_accounts(self, backend, account_data):
         # create also a watch account
         account_data["type"] = "watch"
-        account.accounts_service.add_account(account.password, account_data)
+        backend.accounts_service.add_account(backend.password, account_data)
 
         # fetch all accounts(chat, wallet and watch) for update
-        accounts_response_before = account.accounts_service.get_accounts()
+        accounts_response_before = backend.accounts_service.get_accounts()
         accounts_before = accounts_response_before
 
         for before in accounts_before:
@@ -33,11 +33,11 @@ class TestUpdateAccount:
             before["name"] = "UpdatedName"
             before["emoji"] = "✨"
             before["prodPreferredChainIds"] = "2:10:42161:8458"
-            update_resp = account.accounts_service.update_account(before)
+            update_resp = backend.accounts_service.update_account(before)
             assert update_resp is None
 
         # verify update persisted
-        accounts_response_after = account.accounts_service.get_accounts()
+        accounts_response_after = backend.accounts_service.get_accounts()
         accounts_after = accounts_response_after
         assert len(accounts_before) == len(accounts_after)
         for before, after in zip(accounts_before, accounts_after):
@@ -45,9 +45,9 @@ class TestUpdateAccount:
             before["clock"] = after["clock"] = 0
             assert after == before
 
-    def test_try_to_update_non_editable_fields(self, account):
+    def test_try_to_update_non_editable_fields(self, backend):
         # fetch all accounts
-        accounts_response_before = account.accounts_service.get_accounts()
+        accounts_response_before = backend.accounts_service.get_accounts()
         accounts_before = accounts_response_before
 
         for before in accounts_before:
@@ -62,10 +62,10 @@ class TestUpdateAccount:
             )
             before_copy["type"] = "key"
             before_copy["wallet"] = not (before_copy["wallet"])
-            account.accounts_service.update_account(before_copy)
+            backend.accounts_service.update_account(before_copy)
 
         # verify that no update was made to non editable fields
-        accounts_response_after = account.accounts_service.get_accounts()
+        accounts_response_after = backend.accounts_service.get_accounts()
         accounts_after = accounts_response_after
         assert len(accounts_before) == len(accounts_after)
         for before, after in zip(accounts_before, accounts_after):
@@ -73,7 +73,7 @@ class TestUpdateAccount:
             before["clock"] = after["clock"] = 0
             assert after == before
 
-    def test_update_nonexistent_account(self, account):
+    def test_update_nonexistent_account(self, backend):
         nonexisting = {"address": "0x0000000000000000000000000000000000000001", "name": "Nope"}
         with pytest.raises(ApiResponseError, match=re.escape("cannot update non-existing account: accounts: account is not found")):
-            account.accounts_service.update_account(nonexisting)
+            backend.accounts_service.update_account(nonexisting)

--- a/tests-functional/tests/test_update_keycard_uid.py
+++ b/tests-functional/tests/test_update_keycard_uid.py
@@ -9,34 +9,39 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestUpdateKeycardUID:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
-        self.keycard = copy.deepcopy(keycard_1)
-        self.keycard["key-uid"] = self.account.key_uid
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_update_keycard_uid_success(self):
+    @pytest.fixture()
+    def keycard(self, account):
+        """Fresh keycard data bound to the current account's key-uid."""
+        kc = copy.deepcopy(keycard_1)
+        kc["key-uid"] = account.key_uid
+        return kc
+
+    def test_update_keycard_uid_success(self, account, keycard):
         # Save keycard first
-        self.account.accounts_service.save_or_update_keycard(self.keycard, self.account.password)
+        account.accounts_service.save_or_update_keycard(keycard, account.password)
 
-        old_uid = self.keycard["keycard-uid"]
+        old_uid = keycard["keycard-uid"]
         new_uid = "updated-kc-uid-1234"
 
         sleep(1)
 
         # Update keycard uid
-        resp = self.account.accounts_service.update_keycard_uid(old_uid, new_uid)
+        resp = account.accounts_service.update_keycard_uid(old_uid, new_uid)
         assert resp is None
 
         # Verify new uid resolves to the keycard
-        keycard_new = self.account.accounts_service.get_keycard_by_keycard_uid(new_uid)
+        keycard_new = account.accounts_service.get_keycard_by_keycard_uid(new_uid)
         assert keycard_new is not None
         assert keycard_new.get("keycard-uid") == new_uid
 
         # Verify old uid no longer exists
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            self.account.accounts_service.get_keycard_by_keycard_uid(old_uid)
+            account.accounts_service.get_keycard_by_keycard_uid(old_uid)
 
-    def test_update_keycard_uid_for_nonexistent_keycard(self):
+    def test_update_keycard_uid_for_nonexistent_keycard(self, account):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            self.account.accounts_service.update_keycard_uid("non-existent-old-uid", "some-new-uid")
+            account.accounts_service.update_keycard_uid("non-existent-old-uid", "some-new-uid")

--- a/tests-functional/tests/test_update_keycard_uid.py
+++ b/tests-functional/tests/test_update_keycard_uid.py
@@ -10,19 +10,19 @@ from clients.api import ApiResponseError
 class TestUpdateKeycardUID:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
     @pytest.fixture()
-    def keycard(self, account):
+    def keycard(self, backend):
         """Fresh keycard data bound to the current account's key-uid."""
         kc = copy.deepcopy(keycard_1)
-        kc["key-uid"] = account.key_uid
+        kc["key-uid"] = backend.key_uid
         return kc
 
-    def test_update_keycard_uid_success(self, account, keycard):
+    def test_update_keycard_uid_success(self, backend, keycard):
         # Save keycard first
-        account.accounts_service.save_or_update_keycard(keycard, account.password)
+        backend.accounts_service.save_or_update_keycard(keycard, backend.password)
 
         old_uid = keycard["keycard-uid"]
         new_uid = "updated-kc-uid-1234"
@@ -30,18 +30,18 @@ class TestUpdateKeycardUID:
         sleep(1)
 
         # Update keycard uid
-        resp = account.accounts_service.update_keycard_uid(old_uid, new_uid)
+        resp = backend.accounts_service.update_keycard_uid(old_uid, new_uid)
         assert resp is None
 
         # Verify new uid resolves to the keycard
-        keycard_new = account.accounts_service.get_keycard_by_keycard_uid(new_uid)
+        keycard_new = backend.accounts_service.get_keycard_by_keycard_uid(new_uid)
         assert keycard_new is not None
         assert keycard_new.get("keycard-uid") == new_uid
 
         # Verify old uid no longer exists
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            account.accounts_service.get_keycard_by_keycard_uid(old_uid)
+            backend.accounts_service.get_keycard_by_keycard_uid(old_uid)
 
-    def test_update_keycard_uid_for_nonexistent_keycard(self, account):
+    def test_update_keycard_uid_for_nonexistent_keycard(self, backend):
         with pytest.raises(ApiResponseError, match=re.escape("keycard: no keycard for the passed keycard uid")):
-            account.accounts_service.update_keycard_uid("non-existent-old-uid", "some-new-uid")
+            backend.accounts_service.update_keycard_uid("non-existent-old-uid", "some-new-uid")

--- a/tests-functional/tests/test_update_keypair.py
+++ b/tests-functional/tests/test_update_keypair.py
@@ -8,36 +8,36 @@ from resources.constants import user_1, wallet_account_details_root, keypair_nam
 class TestUpdateKeypair:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_update_keypair(self, account):
-        add_resp = account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, account.password, keypair_name, wallet_account_details_root
+    def test_update_keypair(self, backend):
+        add_resp = backend.accounts_service.add_keypair_via_private_key(
+            user_1.private_key, backend.password, keypair_name, wallet_account_details_root
         )
         key_uid = add_resp.get("key-uid")
 
-        kp_modified = account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_modified = backend.accounts_service.get_keypair_by_key_uid(key_uid)
         updated_name = "KeypairUpdatedName"
         updated_emoji = "🕵️"
         kp_modified["name"] = updated_name
         kp_modified["accounts"][0]["emoji"] = "🕵️"
 
-        update_resp = account.accounts_service.update_keypair(kp_modified)
+        update_resp = backend.accounts_service.update_keypair(kp_modified)
         assert update_resp is None
 
-        kp_after = account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_after = backend.accounts_service.get_keypair_by_key_uid(key_uid)
         assert kp_after.get("name") == updated_name
         assert kp_after.get("accounts")[0].get("emoji") == updated_emoji
 
-    def test_update_non_existent_keypair(self, account):
-        add_resp = account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, account.password, keypair_name, wallet_account_details_root
+    def test_update_non_existent_keypair(self, backend):
+        add_resp = backend.accounts_service.add_keypair_via_private_key(
+            user_1.private_key, backend.password, keypair_name, wallet_account_details_root
         )
         key_uid = add_resp.get("key-uid")
 
-        kp_modified = account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_modified = backend.accounts_service.get_keypair_by_key_uid(key_uid)
         kp_modified["key-uid"] = "213214"
 
         with pytest.raises(ApiResponseError, match=re.escape("cannot update non-existing keypair: keypair is not found")):
-            account.accounts_service.update_keypair(kp_modified)
+            backend.accounts_service.update_keypair(kp_modified)

--- a/tests-functional/tests/test_update_keypair.py
+++ b/tests-functional/tests/test_update_keypair.py
@@ -7,37 +7,37 @@ from resources.constants import user_1, wallet_account_details_root, keypair_nam
 @pytest.mark.rpc
 class TestUpdateKeypair:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_update_keypair(self):
-        add_resp = self.account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, self.account.password, keypair_name, wallet_account_details_root
+    def test_update_keypair(self, account):
+        add_resp = account.accounts_service.add_keypair_via_private_key(
+            user_1.private_key, account.password, keypair_name, wallet_account_details_root
         )
         key_uid = add_resp.get("key-uid")
 
-        kp_modified = self.account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_modified = account.accounts_service.get_keypair_by_key_uid(key_uid)
         updated_name = "KeypairUpdatedName"
         updated_emoji = "🕵️"
         kp_modified["name"] = updated_name
         kp_modified["accounts"][0]["emoji"] = "🕵️"
 
-        update_resp = self.account.accounts_service.update_keypair(kp_modified)
+        update_resp = account.accounts_service.update_keypair(kp_modified)
         assert update_resp is None
 
-        kp_after = self.account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_after = account.accounts_service.get_keypair_by_key_uid(key_uid)
         assert kp_after.get("name") == updated_name
         assert kp_after.get("accounts")[0].get("emoji") == updated_emoji
 
-    def test_update_non_existent_keypair(self):
-        add_resp = self.account.accounts_service.add_keypair_via_private_key(
-            user_1.private_key, self.account.password, keypair_name, wallet_account_details_root
+    def test_update_non_existent_keypair(self, account):
+        add_resp = account.accounts_service.add_keypair_via_private_key(
+            user_1.private_key, account.password, keypair_name, wallet_account_details_root
         )
         key_uid = add_resp.get("key-uid")
 
-        kp_modified = self.account.accounts_service.get_keypair_by_key_uid(key_uid)
+        kp_modified = account.accounts_service.get_keypair_by_key_uid(key_uid)
         kp_modified["key-uid"] = "213214"
 
         with pytest.raises(ApiResponseError, match=re.escape("cannot update non-existing keypair: keypair is not found")):
-            self.account.accounts_service.update_keypair(kp_modified)
+            account.accounts_service.update_keypair(kp_modified)

--- a/tests-functional/tests/test_update_keypair_name.py
+++ b/tests-functional/tests/test_update_keypair_name.py
@@ -8,28 +8,28 @@ from clients.api import ApiResponseError
 class TestUpdateKeypairName:
 
     @pytest.fixture()
-    def account(self, backend_new_profile):
+    def backend(self, backend_new_profile):
         return backend_new_profile("account-backend")
 
-    def test_update_name_for_profile_keypair_isnt_allowed(self, account):
+    def test_update_name_for_profile_keypair_isnt_allowed(self, backend):
         new_name = "Updated Keypair Name"
         with pytest.raises(ApiResponseError, match=re.escape("cannot change profile keypair name")):
-            account.accounts_service.update_keypair_name(account.key_uid, new_name)
+            backend.accounts_service.update_keypair_name(backend.key_uid, new_name)
 
-    def test_update_keypair_name_for_seed_account(self, account):
-        account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation)
+    def test_update_keypair_name_for_seed_account(self, backend):
+        backend.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, backend.password, keypair_name, wallet_account_details_derivation)
 
-        keypairs_response = account.accounts_service.get_account_keypairs()
+        keypairs_response = backend.accounts_service.get_account_keypairs()
         keypairs = keypairs_response
         assert len(keypairs) > 0
         seed_key_uid = keypairs[1].get("key-uid")
         new_name = "Updated Keypair Name"
 
-        response = account.accounts_service.update_keypair_name(seed_key_uid, new_name)
+        response = backend.accounts_service.update_keypair_name(seed_key_uid, new_name)
         assert response is None
 
         # Verify the keypair name was updated by fetching keypairs again
-        keypairs_response_after = account.accounts_service.get_account_keypairs()
+        keypairs_response_after = backend.accounts_service.get_account_keypairs()
         keypairs_after = keypairs_response_after
         updated_keypair = next((kp for kp in keypairs_after if kp.get("key-uid") == seed_key_uid), None)
         assert updated_keypair is not None

--- a/tests-functional/tests/test_update_keypair_name.py
+++ b/tests-functional/tests/test_update_keypair_name.py
@@ -7,31 +7,29 @@ from clients.api import ApiResponseError
 @pytest.mark.rpc
 class TestUpdateKeypairName:
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        self.account = backend_new_profile("sender")
+    @pytest.fixture()
+    def account(self, backend_new_profile):
+        return backend_new_profile("account-backend")
 
-    def test_update_name_for_profile_keypair_isnt_allowed(self):
+    def test_update_name_for_profile_keypair_isnt_allowed(self, account):
         new_name = "Updated Keypair Name"
         with pytest.raises(ApiResponseError, match=re.escape("cannot change profile keypair name")):
-            self.account.accounts_service.update_keypair_name(self.account.key_uid, new_name)
+            account.accounts_service.update_keypair_name(account.key_uid, new_name)
 
-    def test_update_keypair_name_for_seed_account(self):
-        self.account.accounts_service.add_keypair_via_seed_phrase(
-            user_1.passphrase, self.account.password, keypair_name, wallet_account_details_derivation
-        )
+    def test_update_keypair_name_for_seed_account(self, account):
+        account.accounts_service.add_keypair_via_seed_phrase(user_1.passphrase, account.password, keypair_name, wallet_account_details_derivation)
 
-        keypairs_response = self.account.accounts_service.get_account_keypairs()
+        keypairs_response = account.accounts_service.get_account_keypairs()
         keypairs = keypairs_response
         assert len(keypairs) > 0
         seed_key_uid = keypairs[1].get("key-uid")
         new_name = "Updated Keypair Name"
 
-        response = self.account.accounts_service.update_keypair_name(seed_key_uid, new_name)
+        response = account.accounts_service.update_keypair_name(seed_key_uid, new_name)
         assert response is None
 
         # Verify the keypair name was updated by fetching keypairs again
-        keypairs_response_after = self.account.accounts_service.get_account_keypairs()
+        keypairs_response_after = account.accounts_service.get_account_keypairs()
         keypairs_after = keypairs_response_after
         updated_keypair = next((kp for kp in keypairs_after if kp.get("key-uid") == seed_key_uid), None)
         assert updated_keypair is not None

--- a/tests-functional/tests/test_wakuext_chats.py
+++ b/tests-functional/tests/test_wakuext_chats.py
@@ -11,84 +11,86 @@ from steps.messenger import MessengerSteps
 @pytest.mark.parametrize("backend_factory", [{"privileged": False}], indirect=True, ids=["privileged_False"])
 class TestChatActions(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile, waku_light_client):
-        """Initialize two backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", waku_light_client)
-        self.receiver = backend_new_profile("receiver", waku_light_client)
+    @pytest.fixture()
+    def sender(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("sender", waku_light_client)
 
-    def test_all_chats(self):
-        self.make_contacts(self.sender, self.receiver)
-        private_group_id = self.join_private_group(admin=self.sender, member=self.receiver)
-        self.sender.wakuext_service.send_chat_message(private_group_id, "test_message")
-        self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+    @pytest.fixture()
+    def receiver(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("receiver", waku_light_client)
 
-        chats = self.sender.wakuext_service.chats()
+    def test_all_chats(self, sender, receiver):
+        self.make_contacts(sender, receiver)
+        private_group_id = self.join_private_group(admin=sender, member=receiver)
+        sender.wakuext_service.send_chat_message(private_group_id, "test_message")
+        self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+
+        chats = sender.wakuext_service.chats()
         assert len(chats) == 2
 
         private_group_chat = next((chat for chat in chats if chat.get("id") == private_group_id), None)
         assert private_group_chat is not None
         assert private_group_chat.get("chatType", "") == ChatType.PRIVATE_GROUP_CHAT.value
 
-        one_to_one_chat = next((chat for chat in chats if chat.get("id") == self.receiver.public_key), None)
+        one_to_one_chat = next((chat for chat in chats if chat.get("id") == receiver.public_key), None)
         assert one_to_one_chat is not None
         assert one_to_one_chat.get("chatType", "") == ChatType.ONE_TO_ONE.value
 
-    def test_chat_by_chat_id(self):
-        sent_texts, _ = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        chat_id = self.receiver.public_key
+    def test_chat_by_chat_id(self, sender, receiver):
+        sent_texts, _ = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        chat_id = receiver.public_key
 
-        chat = self.sender.wakuext_service.chat(chat_id)
+        chat = sender.wakuext_service.chat(chat_id)
         assert chat.get("chatType", 0) == ChatType.ONE_TO_ONE.value
         assert chat.get("lastMessage", {}).get("text", "") == sent_texts[0]
 
-    def test_chats_preview(self):
+    def test_chats_preview(self, sender, receiver):
         # One to one
-        self.make_contacts(self.sender, self.receiver)
-        self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        one_to_one_chat_id = self.receiver.public_key
+        self.make_contacts(sender, receiver)
+        self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        one_to_one_chat_id = receiver.public_key
 
         # Group
-        private_group_chat_id = self.join_private_group(admin=self.sender, member=self.receiver)
-        self.sender.wakuext_service.send_group_chat_message(private_group_chat_id, "test_message_group")
+        private_group_chat_id = self.join_private_group(admin=sender, member=receiver)
+        sender.wakuext_service.send_group_chat_message(private_group_chat_id, "test_message_group")
 
         # Community
-        self.create_community(self.sender)
-        community_chat_id = self.join_community(member=self.receiver, admin=self.sender)
-        self.sender.wakuext_service.send_chat_message(community_chat_id, "test_message_community")
+        self.create_community(sender)
+        community_chat_id = self.join_community(member=receiver, admin=sender)
+        sender.wakuext_service.send_chat_message(community_chat_id, "test_message_community")
 
-        chats_previews = self.sender.wakuext_service.chats_preview(ChatPreviewFilterType.Community.value)
+        chats_previews = sender.wakuext_service.chats_preview(ChatPreviewFilterType.Community.value)
         assert len(chats_previews) == 1
         assert chats_previews[0].get("id", "") == community_chat_id
 
-        chats_previews = self.sender.wakuext_service.chats_preview(ChatPreviewFilterType.NonCommunity.value)
+        chats_previews = sender.wakuext_service.chats_preview(ChatPreviewFilterType.NonCommunity.value)
         assert len(chats_previews) == 2
         assert {chat.get("id", "") for chat in chats_previews} == {one_to_one_chat_id, private_group_chat_id}
 
-    def test_active_chats(self):
-        self.make_contacts(self.sender, self.receiver)
-        self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        one_to_one_chat_id = self.receiver.public_key
-        private_group_chat_id = self.join_private_group(admin=self.sender, member=self.receiver)
+    def test_active_chats(self, sender, receiver):
+        self.make_contacts(sender, receiver)
+        self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        one_to_one_chat_id = receiver.public_key
+        private_group_chat_id = self.join_private_group(admin=sender, member=receiver)
 
-        chats = self.sender.wakuext_service.active_chats()
+        chats = sender.wakuext_service.active_chats()
         # TODO: Add more assertions on response
         assert len(chats) == 2
 
-        self.sender.wakuext_service.deactivate_chat(private_group_chat_id, False)
+        sender.wakuext_service.deactivate_chat(private_group_chat_id, False)
 
-        chats = self.sender.wakuext_service.active_chats()
+        chats = sender.wakuext_service.active_chats()
         assert len(chats) == 1
         assert chats[0].get("id", 0) == one_to_one_chat_id
 
-    def test_mute_chat(self):
-        self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        chat_id = self.receiver.public_key
+    def test_mute_chat(self, sender, receiver):
+        self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        chat_id = receiver.public_key
 
-        result = self.sender.wakuext_service.mute_chat(chat_id)
+        result = sender.wakuext_service.mute_chat(chat_id)
         assert result == "0001-01-01T00:00:00Z"
 
-        chat = self.sender.wakuext_service.chat(chat_id)
+        chat = sender.wakuext_service.chat(chat_id)
         assert chat.get("muted", False) is True
         assert chat.get("muteTill", "") == result
 
@@ -106,18 +108,18 @@ class TestChatActions(MessengerSteps):
             (MuteType.MUTE_FOR24_HR.value, timedelta(hours=24)),
         ],
     )
-    def test_mute_chat_v2(self, mute_type, time_delta):
-        self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        chat_id = self.receiver.public_key
+    def test_mute_chat_v2(self, sender, receiver, mute_type, time_delta):
+        self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        chat_id = receiver.public_key
 
-        result = self.sender.wakuext_service.mute_chat_v2(chat_id, mute_type)
+        result = sender.wakuext_service.mute_chat_v2(chat_id, mute_type)
         actual = datetime.fromisoformat(result.replace("Z", "+00:00"))
 
         expected = datetime.now(timezone.utc) + time_delta
         diff = expected - actual
         assert abs(diff.total_seconds()) < 2  # 2 sec margin
 
-        chat = self.sender.wakuext_service.chat(chat_id)
+        chat = sender.wakuext_service.chat(chat_id)
         assert chat.get("muted", False) is True
         assert chat.get("muteTill", "") == result
 
@@ -129,28 +131,28 @@ class TestChatActions(MessengerSteps):
             # MuteType.UNMUTED.value,
         ],
     )
-    def test_unmute_mute_chat_v2_till_unmuted(self, mute_type):
-        self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        chat_id = self.receiver.public_key
+    def test_unmute_mute_chat_v2_till_unmuted(self, sender, receiver, mute_type):
+        self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        chat_id = receiver.public_key
 
-        result = self.sender.wakuext_service.mute_chat_v2(chat_id, mute_type)
+        result = sender.wakuext_service.mute_chat_v2(chat_id, mute_type)
         assert result == "0001-01-01T00:00:00Z"
 
-        response = self.sender.wakuext_service.unmute_chat(chat_id)
+        response = sender.wakuext_service.unmute_chat(chat_id)
         assert response is None
 
-        chat = self.sender.wakuext_service.chat(chat_id)
+        chat = sender.wakuext_service.chat(chat_id)
         assert chat.get("muted", True) is False
 
-    def test_clear_history(self):
-        self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        chat_id = self.receiver.public_key
+    def test_clear_history(self, sender, receiver):
+        self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        chat_id = receiver.public_key
 
-        response = self.sender.wakuext_service.chat(chat_id)
+        response = sender.wakuext_service.chat(chat_id)
         last_message = response.get("lastMessage", -1)
         assert isinstance(last_message, dict)
 
-        response = self.sender.wakuext_service.clear_history(chat_id)
+        response = sender.wakuext_service.clear_history(chat_id)
         # TODO: Add more assertions on response
         last_message = response.get("chats", [])[0].get("lastMessage", -1)
         assert last_message is None
@@ -162,29 +164,29 @@ class TestChatActions(MessengerSteps):
             (True, dict),
         ],
     )
-    def test_deactivate_chat(self, preserve_history, expected):
-        self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        chat_id = self.receiver.public_key
+    def test_deactivate_chat(self, sender, receiver, preserve_history, expected):
+        self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        chat_id = receiver.public_key
 
-        response = self.sender.wakuext_service.deactivate_chat(chat_id, preserve_history)
+        response = sender.wakuext_service.deactivate_chat(chat_id, preserve_history)
         # TODO: Add more assertions on response
 
         chat = response.get("chats", [])[0]
         assert chat.get("active", -1) is False
         assert isinstance(chat.get("lastMessage", -1), expected)
 
-    def test_save_chat(self):
+    def test_save_chat(self, sender):
         chat_id = "123"
-        response = self.sender.wakuext_service.save_chat(chat_id, active=True)
+        response = sender.wakuext_service.save_chat(chat_id, active=True)
         assert response is None
 
-        chat = self.sender.wakuext_service.chat(chat_id)
+        chat = sender.wakuext_service.chat(chat_id)
         assert chat.get("id", "") == chat_id
         assert chat.get("active", -1) is True
 
-    def test_create_one_to_one_chat(self):
-        chat_id = self.receiver.public_key
-        response = self.sender.wakuext_service.create_one_to_one_chat(chat_id, ens_name="")
+    def test_create_one_to_one_chat(self, sender, receiver):
+        chat_id = receiver.public_key
+        response = sender.wakuext_service.create_one_to_one_chat(chat_id, ens_name="")
         chats = response.get("chats", [])
         assert len(chats) == 1
         chat = chats[0]

--- a/tests-functional/tests/test_wakuext_community_chats.py
+++ b/tests-functional/tests/test_wakuext_community_chats.py
@@ -11,51 +11,63 @@ from steps.messenger import MessengerSteps
 
 @pytest.mark.rpc
 class TestCommunityChats(MessengerSteps):
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two backends (creator and requester) for each test function"""
-        self.creator = backend_new_profile("creator")
-        self.member = backend_new_profile("member")
-        self.fake_address = "0x" + str(uuid4())[:8]
-        self.community_id = self.create_community(self.creator)
-        self.join_community(member=self.member, admin=self.creator)
-        self.display_name = "chat_" + str(uuid4())
-        self.chat_payload = {
+    @pytest.fixture()
+    def creator(self, backend_new_profile):
+        return backend_new_profile("creator")
+
+    @pytest.fixture()
+    def member(self, backend_new_profile):
+        return backend_new_profile("member")
+
+    @pytest.fixture()
+    def fake_address(self):
+        return "0x" + str(uuid4())[:8]
+
+    @pytest.fixture()
+    def community_id(self, creator, member):
+        cid = self.create_community(creator)
+        self.join_community(member=member, admin=creator)
+        return cid
+
+    @pytest.fixture()
+    def chat_payload(self):
+        display_name = "chat_" + str(uuid4())
+        return {
             "identity": {
-                "displayName": self.display_name,
+                "displayName": display_name,
                 "emoji": "😀",
                 "color": "#1f2c75",
-                "description": self.display_name,
+                "description": display_name,
             },
             "viewersCanPostReactions": False,
             "hideIfPermissionsNotMet": False,
             "permissions": {"access": 1},
         }
 
-    def test_create_edit_delete_community_chat(self):
-        create_resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+    def test_create_edit_delete_community_chat(self, creator, member, community_id, chat_payload):
+        create_resp = creator.wakuext_service.create_community_chat(community_id, chat_payload)
         chats = create_resp.get("chats")
         communities = create_resp.get("communities")
         assert len(chats) == 1
         assert len(communities) == 1
         community_chats = communities[0].get("chats")
 
-        # assert chats[0].get("displayName") == self.chat_payload["identity"]["displayName"] #  https://github.com/status-im/status-go/issues/6985
-        assert chats[0].get("color") == self.chat_payload["identity"]["color"]
-        assert chats[0].get("emoji") == self.chat_payload["identity"]["emoji"]
-        assert chats[0].get("description") == self.chat_payload["identity"]["description"]
-        assert chats[0].get("viewersCanPostReactions") == self.chat_payload["viewersCanPostReactions"]
+        # assert chats[0].get("displayName") == chat_payload["identity"]["displayName"] #  https://github.com/status-im/status-go/issues/6985
+        assert chats[0].get("color") == chat_payload["identity"]["color"]
+        assert chats[0].get("emoji") == chat_payload["identity"]["emoji"]
+        assert chats[0].get("description") == chat_payload["identity"]["description"]
+        assert chats[0].get("viewersCanPostReactions") == chat_payload["viewersCanPostReactions"]
 
         # build a dict keyed by position
         chats_by_position = {chat["position"]: chat for chat in community_chats.values()}
         # position 1 should be the default chat
         assert chats_by_position[0].get("name") == "general"
-        # assert chats_by_position[1].get("name") == self.chat_payload["identity"]["displayName"] # https://github.com/status-im/status-go/issues/6985
-        assert chats_by_position[1].get("hideIfPermissionsNotMet") == self.chat_payload["hideIfPermissionsNotMet"]
-        assert chats_by_position[1].get("permissions") == self.chat_payload["permissions"]
+        # assert chats_by_position[1].get("name") == chat_payload["identity"]["displayName"] # https://github.com/status-im/status-go/issues/6985
+        assert chats_by_position[1].get("hideIfPermissionsNotMet") == chat_payload["hideIfPermissionsNotMet"]
+        assert chats_by_position[1].get("permissions") == chat_payload["permissions"]
         added_chat_id = chats_by_position[1].get("id")
 
-        comm_before_delete = self.fetch_community(self.creator, self.community_id)
+        comm_before_delete = self.fetch_community(creator, community_id)
         assert added_chat_id in comm_before_delete.get("chats")
 
         edit_payload = {
@@ -66,20 +78,20 @@ class TestCommunityChats(MessengerSteps):
                 "description": "edited_" + str(uuid4()),
             }
         }
-        edit_resp = self.creator.wakuext_service.edit_community_chat(self.community_id, added_chat_id, edit_payload)
+        edit_resp = creator.wakuext_service.edit_community_chat(community_id, added_chat_id, edit_payload)
         assert edit_resp.get("chats")[0].get("color") == edit_payload["identity"]["color"]
         assert edit_resp.get("chats")[0].get("emoji") == edit_payload["identity"]["emoji"]
         assert edit_resp.get("chats")[0].get("description") == edit_payload["identity"]["description"]
 
-        del_resp = self.creator.wakuext_service.delete_community_chat(self.community_id, added_chat_id)
+        del_resp = creator.wakuext_service.delete_community_chat(community_id, added_chat_id)
         assert del_resp.get("removedChats")[0] == added_chat_id
         assert added_chat_id not in del_resp.get("communities")[0].get("chats")
 
-        comm_after_delete = self.fetch_community(self.creator, self.community_id)
+        comm_after_delete = self.fetch_community(creator, community_id)
         assert added_chat_id not in comm_after_delete.get("chats")
 
-    def test_reorder_community_chat(self):
-        resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+    def test_reorder_community_chat(self, creator, community_id, chat_payload):
+        resp = creator.wakuext_service.create_community_chat(community_id, chat_payload)
 
         # sort chats by position
         chats_before = sorted(resp.get("communities")[0].get("chats").values(), key=lambda c: c["position"])
@@ -88,7 +100,7 @@ class TestCommunityChats(MessengerSteps):
         second_chat = next(c for c in chats_before if c["position"] == 1)
 
         # reorder: move the new chat to position 0
-        reorder_resp = self.creator.wakuext_service.reorder_community_chat(self.community_id, second_chat["id"], 0)
+        reorder_resp = creator.wakuext_service.reorder_community_chat(community_id, second_chat["id"], 0)
 
         # fetch reordered chats and sort them again by position
         chats_after = sorted(reorder_resp["communities"][0]["chats"].values(), key=lambda c: c["position"])
@@ -99,34 +111,34 @@ class TestCommunityChats(MessengerSteps):
         assert chats_after[1]["id"] == first_chat["id"]
         assert chats_after[1]["position"] == 1
 
-    def test_mute_and_unmute_community_chats(self):
-        self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+    def test_mute_and_unmute_community_chats(self, creator, community_id, chat_payload):
+        creator.wakuext_service.create_community_chat(community_id, chat_payload)
 
-        community_before = self.creator.wakuext_service.fetch_community(self.community_id)
+        community_before = creator.wakuext_service.fetch_community(community_id)
         assert community_before.get("muted") is False
 
-        mute_resp = self.creator.wakuext_service.mute_community_chats(self.community_id, MuteType.MUTE_FOR15_MIN.value)
+        mute_resp = creator.wakuext_service.mute_community_chats(community_id, MuteType.MUTE_FOR15_MIN.value)
         assert mute_resp is not None
 
-        community_after_mute = self.creator.wakuext_service.fetch_community(self.community_id)
+        community_after_mute = creator.wakuext_service.fetch_community(community_id)
         assert community_after_mute.get("muted") is True
         assert community_after_mute.get("muteTill") == mute_resp
 
-        unmute_resp = self.creator.wakuext_service.un_mute_community_chats(self.community_id)
+        unmute_resp = creator.wakuext_service.un_mute_community_chats(community_id)
         assert unmute_resp is not None
 
-        community_after_unmute = self.creator.wakuext_service.fetch_community(self.community_id)
+        community_after_unmute = creator.wakuext_service.fetch_community(community_id)
         assert community_after_unmute.get("muted") is False
         assert community_after_unmute.get("muteTill") == "0001-01-01T00:00:00Z"
 
     @pytest.mark.parametrize("muted_type", [mt.value for mt in MuteType])
-    def test_mute_types_are_applied(self, muted_type):
-        create_resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+    def test_mute_types_are_applied(self, creator, member, community_id, chat_payload, muted_type):
+        create_resp = creator.wakuext_service.create_community_chat(community_id, chat_payload)
         chat_id = create_resp.get("chats")[0].get("id")
-        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=chat_id, timeout=10)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=chat_id, timeout=10)
 
-        mute_resp = self.member.wakuext_service.mute_community_chats(self.community_id, muted_type)
-        community_after_mute = self.member.wakuext_service.fetch_community(self.community_id)
+        mute_resp = member.wakuext_service.mute_community_chats(community_id, muted_type)
+        community_after_mute = member.wakuext_service.fetch_community(community_id)
         muted_flag = community_after_mute.get("muted")
         comm_mute_till = community_after_mute.get("muteTill")
 
@@ -164,73 +176,73 @@ class TestCommunityChats(MessengerSteps):
         else:
             assert comm_mute_till == "0001-01-01T00:00:00Z"
 
-    def test_send_community_chat_message_with_mention(self):
-        create_resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+    def test_send_community_chat_message_with_mention(self, creator, member, community_id, chat_payload):
+        create_resp = creator.wakuext_service.create_community_chat(community_id, chat_payload)
         chat_id = create_resp.get("chats")[0].get("id")
-        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=chat_id, timeout=10)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=chat_id, timeout=10)
 
-        text = f"Hi @{self.member.public_key}"
+        text = f"Hi @{member.public_key}"
         # creator sends a chat message with a mention to trigger a notification
-        send_resp = self.creator.wakuext_service.send_chat_message(chat_id, text)
+        send_resp = creator.wakuext_service.send_chat_message(chat_id, text)
         assert send_resp.get("chats")[0].get("lastMessage").get("text") == text
         message_id = send_resp.get("messages", [])[0].get("id", "")
 
         # member receives that message even if chat is muted
-        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=10)
-        member_msgs_resp = self.member.wakuext_service.chat_messages(chat_id)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=10)
+        member_msgs_resp = member.wakuext_service.chat_messages(chat_id)
         assert member_msgs_resp.get("messages")[0].get("text") == text
         assert member_msgs_resp.get("messages")[0].get("mentioned") is True
 
         # member will receive the mention notification
-        resp = self.member.wakuext_service.get_activity_center_notifications([activity for activity in ActivityCenterNotificationType])
+        resp = member.wakuext_service.get_activity_center_notifications([activity for activity in ActivityCenterNotificationType])
         notifications = resp.get("notifications")
         assert len(notifications) == 2
-        assert notifications[0].get("communityId") == self.community_id
+        assert notifications[0].get("communityId") == community_id
         assert notifications[0].get("chatId") == chat_id
         assert notifications[0].get("message").get("text") == text
 
-    def test_send_community_chat_message_while_chat_is_muted_and_then_unmuted(self):
-        create_resp = self.creator.wakuext_service.create_community_chat(self.community_id, self.chat_payload)
+    def test_send_community_chat_message_while_chat_is_muted_and_then_unmuted(self, creator, member, community_id, chat_payload):
+        create_resp = creator.wakuext_service.create_community_chat(community_id, chat_payload)
         chat_id = create_resp.get("chats")[0].get("id")
-        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=chat_id, timeout=10)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=chat_id, timeout=10)
 
         # muting the community chats
-        self.member.wakuext_service.mute_community_chats(self.community_id, MuteType.MUTE_FOR15_MIN.value)
+        member.wakuext_service.mute_community_chats(community_id, MuteType.MUTE_FOR15_MIN.value)
 
-        text = f"Hi @{self.member.public_key}"
+        text = f"Hi @{member.public_key}"
         # creator sends a chat message with a mention to trigger a notification
-        send_resp = self.creator.wakuext_service.send_chat_message(chat_id, text)
+        send_resp = creator.wakuext_service.send_chat_message(chat_id, text)
         assert send_resp.get("chats")[0].get("lastMessage").get("text") == text
         message_id = send_resp.get("messages", [])[0].get("id", "")
 
         # member receives that message even if chat is muted
-        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=10)
-        member_msgs_resp = self.member.wakuext_service.chat_messages(chat_id)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=10)
+        member_msgs_resp = member.wakuext_service.chat_messages(chat_id)
         assert member_msgs_resp.get("messages")[0].get("text") == text
         assert member_msgs_resp.get("messages")[0].get("mentioned") is True
 
         # member doesn't received the mention notification because the chat was muted
-        resp = self.member.wakuext_service.get_activity_center_notifications([activity for activity in ActivityCenterNotificationType])
+        resp = member.wakuext_service.get_activity_center_notifications([activity for activity in ActivityCenterNotificationType])
         notifications = resp.get("notifications")
         assert len(notifications) == 1
         assert notifications[0].get("chatId") == ""
 
-        self.member.wakuext_service.un_mute_community_chats(self.community_id)
+        member.wakuext_service.un_mute_community_chats(community_id)
 
-        send_resp = self.creator.wakuext_service.send_chat_message(chat_id, text)
+        send_resp = creator.wakuext_service.send_chat_message(chat_id, text)
         assert send_resp.get("chats")[0].get("lastMessage").get("text") == text
         message_id = send_resp.get("messages", [])[0].get("id", "")
 
         # member receives that message even if chat is muted
-        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=10)
-        member_msgs_resp = self.member.wakuext_service.chat_messages(chat_id)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=10)
+        member_msgs_resp = member.wakuext_service.chat_messages(chat_id)
         assert member_msgs_resp.get("messages")[0].get("text") == text
         assert member_msgs_resp.get("messages")[0].get("mentioned") is True
 
         # member receives again the mention notification because the chat was unmuted
-        resp = self.member.wakuext_service.get_activity_center_notifications([activity for activity in ActivityCenterNotificationType])
+        resp = member.wakuext_service.get_activity_center_notifications([activity for activity in ActivityCenterNotificationType])
         notifications = resp.get("notifications")
         assert len(notifications) == 2
-        assert notifications[0].get("communityId") == self.community_id
+        assert notifications[0].get("communityId") == community_id
         assert notifications[0].get("chatId") == chat_id
         assert notifications[0].get("message").get("text") == text

--- a/tests-functional/tests/test_wakuext_community_membership_requests.py
+++ b/tests-functional/tests/test_wakuext_community_membership_requests.py
@@ -8,193 +8,200 @@ from utils.retry_utils import retry_call
 
 @pytest.mark.rpc
 class TestCommunityMembershipRequests(MessengerSteps):
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two backends (creator and requester) for each test function"""
-        self.creator = backend_new_profile("creator")
-        self.requester = backend_new_profile("requester")
-        self.fake_address = "0x" + str(uuid4())[:8]
-        self.community_id = self.create_community(self.creator)
-        self.fetch_community(self.requester)
+    @pytest.fixture()
+    def creator(self, backend_new_profile):
+        return backend_new_profile("creator")
 
-    def test_pending_request_to_join_community_and_cancel(self):
-        req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
+    @pytest.fixture()
+    def requester(self, backend_new_profile, creator):
+        req = backend_new_profile("requester")
+        self.community_id = self.create_community(creator)
+        self.fetch_community(req)
+        return req
+
+    @pytest.fixture()
+    def fake_address(self):
+        return "0x" + str(uuid4())[:8]
+
+    def test_pending_request_to_join_community_and_cancel(self, creator, requester, fake_address):
+        req_resp = requester.wakuext_service.request_to_join_community(self.community_id, fake_address)
         assert len(req_resp.get("requestsToJoinCommunity")) == 1
         assert req_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStatePending.value
         req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
 
         # Requester checks his pending requests
-        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        my_pending = requester.wakuext_service.my_pending_requests_to_join()
         assert len(my_pending) == 1
         assert my_pending[0].get("id") == req_id
         assert my_pending[0].get("communityId") == self.community_id
 
         # Creator fetches pending requests for community and expects at least one entry
-        pending = retry_call(self.creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
+        pending = retry_call(creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
         assert len(pending) == 1
         assert pending[0].get("id") == req_id
         assert pending[0].get("communityId") == self.community_id
 
-        latest = self.requester.wakuext_service.latest_request_to_join_for_community(self.community_id)
+        latest = requester.wakuext_service.latest_request_to_join_for_community(self.community_id)
         assert latest.get("communityId") == self.community_id
         assert latest.get("id") == req_id
 
         # Requester decides to cancel the request to join the community
-        cancel_resp = self.requester.wakuext_service.cancel_request_to_join_community(latest.get("id"))
+        cancel_resp = requester.wakuext_service.cancel_request_to_join_community(latest.get("id"))
         assert len(cancel_resp.get("requestsToJoinCommunity")) == 1
         assert cancel_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStateCanceled.value
 
-        self.creator.wait_for_signal_predicate(
+        creator.wait_for_signal_predicate(
             SignalType.MESSAGES_NEW.value,
             lambda signal: signal.get("event", {}).get("requestsToJoinCommunity")[0].get("state")
             == RequestToJoinState.RequestToJoinStateCanceled.value,
         )
 
-        canceled = self.creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
+        canceled = creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
         assert len(canceled) == 1
         assert canceled[0].get("communityId") == self.community_id
         assert canceled[0].get("id") == req_id
 
-        my_canceled = self.requester.wakuext_service.my_canceled_requests_to_join()
+        my_canceled = requester.wakuext_service.my_canceled_requests_to_join()
         assert len(my_canceled) == 1
         assert my_canceled[0].get("communityId") == self.community_id
         assert my_canceled[0].get("id") == req_id
 
-        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        my_pending = requester.wakuext_service.my_pending_requests_to_join()
         assert my_pending is None
 
-        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        pending = creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
         assert pending is None
 
-    def test_pending_request_to_join_community_and_accept(self):
-        req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
+    def test_pending_request_to_join_community_and_accept(self, creator, requester, fake_address):
+        req_resp = requester.wakuext_service.request_to_join_community(self.community_id, fake_address)
         assert len(req_resp.get("requestsToJoinCommunity")) == 1
         assert req_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStatePending.value
         req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
 
         # Requester checks his pending requests
-        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        my_pending = requester.wakuext_service.my_pending_requests_to_join()
         assert len(my_pending) == 1
         assert my_pending[0].get("id") == req_id
         assert my_pending[0].get("communityId") == self.community_id
 
         # Creator fetches pending requests for community and expects at least one entry
-        pending = retry_call(self.creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
+        pending = retry_call(creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
         assert len(pending) == 1
         assert pending[0].get("id") == req_id
         assert pending[0].get("communityId") == self.community_id
 
-        latest = self.requester.wakuext_service.latest_request_to_join_for_community(self.community_id)
+        latest = requester.wakuext_service.latest_request_to_join_for_community(self.community_id)
         assert latest.get("communityId") == self.community_id
         assert latest.get("id") == req_id
 
-        all_non_approved = self.creator.wakuext_service.all_non_approved_communities_requests_to_join()
+        all_non_approved = creator.wakuext_service.all_non_approved_communities_requests_to_join()
         assert len(all_non_approved) == 1
         assert all_non_approved[0].get("communityId") == self.community_id
         assert all_non_approved[0].get("id") == req_id
 
         # Creator accepts the request from the requester to join the community
-        accept_resp = self.creator.wakuext_service.accept_request_to_join_community(latest.get("id"))
+        accept_resp = creator.wakuext_service.accept_request_to_join_community(latest.get("id"))
         assert len(accept_resp.get("requestsToJoinCommunity")) == 1
         assert accept_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStateAccepted.value
 
-        self.requester.wait_for_signal_predicate(
+        requester.wait_for_signal_predicate(
             SignalType.MESSAGES_NEW.value,
             lambda signal: signal.get("event", {}).get("requestsToJoinCommunity")[0].get("state")
             == RequestToJoinState.RequestToJoinStateAccepted.value,
         )
 
-        canceled = self.creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
+        canceled = creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
         assert canceled is None
 
-        my_canceled = self.requester.wakuext_service.my_canceled_requests_to_join()
+        my_canceled = requester.wakuext_service.my_canceled_requests_to_join()
         assert my_canceled is None
 
-        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        my_pending = requester.wakuext_service.my_pending_requests_to_join()
         assert my_pending is None
 
-        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        pending = creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
         assert pending is None
 
-        all_non_approved = self.creator.wakuext_service.all_non_approved_communities_requests_to_join()
+        all_non_approved = creator.wakuext_service.all_non_approved_communities_requests_to_join()
         assert all_non_approved == []
 
-    def test_pending_request_to_join_community_and_decline(self):
-        req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
+    def test_pending_request_to_join_community_and_decline(self, creator, requester, fake_address):
+        req_resp = requester.wakuext_service.request_to_join_community(self.community_id, fake_address)
         assert len(req_resp.get("requestsToJoinCommunity")) == 1
         assert req_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStatePending.value
         req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
 
         # Requester checks his pending requests
-        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        my_pending = requester.wakuext_service.my_pending_requests_to_join()
         assert len(my_pending) == 1
         assert my_pending[0].get("id") == req_id
         assert my_pending[0].get("communityId") == self.community_id
 
         # Creator fetches pending requests for community and expects at least one entry
-        pending = retry_call(self.creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
+        pending = retry_call(creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
         assert len(pending) == 1
         assert pending[0].get("id") == req_id
         assert pending[0].get("communityId") == self.community_id
 
-        latest = self.requester.wakuext_service.latest_request_to_join_for_community(self.community_id)
+        latest = requester.wakuext_service.latest_request_to_join_for_community(self.community_id)
         assert latest.get("communityId") == self.community_id
         assert latest.get("id") == req_id
 
         # Creator declines the request from the requester to join the community
-        decline_resp = self.creator.wakuext_service.decline_request_to_join_community(latest.get("id"))
+        decline_resp = creator.wakuext_service.decline_request_to_join_community(latest.get("id"))
         assert decline_resp.get("requestsToJoinCommunity")[0].get("state") == RequestToJoinState.RequestToJoinStateDeclined.value
 
-        canceled = self.creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
+        canceled = creator.wakuext_service.canceled_requests_to_join_for_community(self.community_id)
         assert canceled is None
 
-        declined = self.creator.wakuext_service.declined_requests_to_join_for_community(self.community_id)
+        declined = creator.wakuext_service.declined_requests_to_join_for_community(self.community_id)
         assert len(declined) == 1
         assert declined[0].get("communityId") == self.community_id
         assert declined[0].get("id") == req_id
 
-        my_canceled = self.requester.wakuext_service.my_canceled_requests_to_join()
+        my_canceled = requester.wakuext_service.my_canceled_requests_to_join()
         assert my_canceled is None
 
-        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        my_pending = requester.wakuext_service.my_pending_requests_to_join()
         # assert my_pending is None # bug reported here https://github.com/status-im/status-go/issues/6975
 
-        pending = self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+        pending = creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
         assert pending is None
 
-    def test_check_and_delete_pending_request_to_join_community(self):
-        req_resp = self.requester.wakuext_service.request_to_join_community(self.community_id, self.fake_address)
+    def test_check_and_delete_pending_request_to_join_community(self, creator, requester, fake_address):
+        req_resp = requester.wakuext_service.request_to_join_community(self.community_id, fake_address)
         assert len(req_resp.get("requestsToJoinCommunity")) == 1
         req_id = req_resp.get("requestsToJoinCommunity")[0].get("id")
 
         # Requester checks his pending requests
-        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        my_pending = requester.wakuext_service.my_pending_requests_to_join()
         assert len(my_pending) == 1
         assert my_pending[0].get("id") == req_id
         assert my_pending[0].get("communityId") == self.community_id
 
-        retry_call(self.creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
+        retry_call(creator.wakuext_service.pending_requests_to_join_for_community, self.community_id)
 
-        self.requester.wakuext_service.check_and_delete_pending_request_to_join_community()
-        self.creator.wakuext_service.check_and_delete_pending_request_to_join_community()
+        requester.wakuext_service.check_and_delete_pending_request_to_join_community()
+        creator.wakuext_service.check_and_delete_pending_request_to_join_community()
 
-        my_pending = self.requester.wakuext_service.my_pending_requests_to_join()
+        my_pending = requester.wakuext_service.my_pending_requests_to_join()
         # assert my_pending is None # bug reported here https://github.com/status-im/status-go/issues/6976
-        self.creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
+
+        creator.wakuext_service.pending_requests_to_join_for_community(self.community_id)
         # assert pending is None # bug reported here https://github.com/status-im/status-go/issues/6976
 
-    def test_check_permissions_and_generate_community_requests(self):
-        perm_resp = self.requester.wakuext_service.check_permissions_to_join_community(self.community_id)
+    def test_check_permissions_and_generate_community_requests(self, creator, requester):
+        perm_resp = requester.wakuext_service.check_permissions_to_join_community(self.community_id)
         assert perm_resp.get("satisfied") is True
         assert len(perm_resp.get("roles")) == 1
         assert perm_resp.get("roles")[0].get("type") == 2
 
-        member_pub_key = self.requester.public_key
+        member_pub_key = requester.public_key
 
-        gen_join_resp = self.requester.wakuext_service.generate_joining_community_requests_for_signing(member_pub_key, self.community_id, [])
+        gen_join_resp = requester.wakuext_service.generate_joining_community_requests_for_signing(member_pub_key, self.community_id, [])
         assert len(gen_join_resp) == 1
         assert gen_join_resp[0].get("account").lower() == perm_resp.get("validCombinations")[0].get("address").lower()
 
-        gen_edit_resp = self.requester.wakuext_service.generate_edit_community_requests_for_signing(member_pub_key, self.community_id, [])
+        gen_edit_resp = requester.wakuext_service.generate_edit_community_requests_for_signing(member_pub_key, self.community_id, [])
         assert len(gen_edit_resp) == 1
         assert gen_edit_resp[0].get("account").lower() == perm_resp.get("validCombinations")[0].get("address").lower()

--- a/tests-functional/tests/test_wakuext_contact_requests.py
+++ b/tests-functional/tests/test_wakuext_contact_requests.py
@@ -8,15 +8,17 @@ from steps.messenger import MessengerSteps
 @pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
 class TestContactRequests(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile, waku_light_client):
-        """Initialize two backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", waku_light_client=waku_light_client)
-        self.receiver = backend_new_profile("receiver", waku_light_client=waku_light_client)
+    @pytest.fixture()
+    def sender(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("sender", waku_light_client=waku_light_client)
 
-    def test_send_contact_request(self):
+    @pytest.fixture()
+    def receiver(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("receiver", waku_light_client=waku_light_client)
+
+    def test_send_contact_request(self, sender, receiver):
         message_text = "test_send_contact_request"
-        response = self.sender.wakuext_service.send_contact_request(self.receiver.public_key, message_text)
+        response = sender.wakuext_service.send_contact_request(receiver.public_key, message_text)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])
@@ -28,15 +30,15 @@ class TestContactRequests(MessengerSteps):
 
         sent_request_messages = self.get_message_by_content_type(response, content_type=MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_SENT.value)
         assert len(sent_request_messages) == 1, f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_SENT.value}"
-        assert sent_request_messages[0].get("text") == f"You sent a contact request to @{self.receiver.public_key}"
+        assert sent_request_messages[0].get("text") == f"You sent a contact request to @{receiver.public_key}"
 
-    def test_add_contact(self):
-        response = self.sender.wakuext_service.add_contact(self.receiver.public_key, self.receiver.display_name)
+    def test_add_contact(self, sender, receiver):
+        response = sender.wakuext_service.add_contact(receiver.public_key, receiver.display_name)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])
         assert len(contacts) >= 1, "Expected response to have at least one contact"
-        assert contacts[0].get("displayName") == self.receiver.display_name
+        assert contacts[0].get("displayName") == receiver.display_name
 
         contact_request_message = self.get_message_by_content_type(response, content_type=MessageContentType.CONTACT_REQUEST.value)
         assert len(contact_request_message) == 1, f"Expected one message with contentType {MessageContentType.CONTACT_REQUEST.value}"
@@ -44,16 +46,16 @@ class TestContactRequests(MessengerSteps):
 
         sent_request_messages = self.get_message_by_content_type(response, content_type=MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_SENT.value)
         assert len(sent_request_messages) == 1, f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_SENT.value}"
-        assert sent_request_messages[0].get("text") == f"You sent a contact request to @{self.receiver.public_key}"
+        assert sent_request_messages[0].get("text") == f"You sent a contact request to @{receiver.public_key}"
 
-    def test_accept_contact_request(self):
-        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.accept_contact_request(message_id)
+    def test_accept_contact_request(self, sender, receiver):
+        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        response = receiver.wakuext_service.accept_contact_request(message_id)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])
         assert len(contacts) >= 1, "Expected response to have at least one contact"
-        assert contacts[0].get("displayName") == self.sender.display_name
+        assert contacts[0].get("displayName") == sender.display_name
 
         contact_request_messages = self.get_message_by_content_type(response, content_type=MessageContentType.CONTACT_REQUEST.value)
         assert len(contact_request_messages) == 1, f"Expected one message with contentType {MessageContentType.CONTACT_REQUEST.value}"
@@ -65,29 +67,29 @@ class TestContactRequests(MessengerSteps):
         assert (
             len(accept_request_messages) == 1
         ), f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_ACCEPTED.value}"
-        assert accept_request_messages[0].get("text") == f"You accepted @{self.sender.public_key}'s contact request"
+        assert accept_request_messages[0].get("text") == f"You accepted @{sender.public_key}'s contact request"
 
-    def test_decline_contact_request(self):
-        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.decline_contact_request(message_id)
+    def test_decline_contact_request(self, sender, receiver):
+        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        response = receiver.wakuext_service.decline_contact_request(message_id)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])
         assert len(contacts) >= 1, "Expected response to have at least one contact"
-        assert contacts[0].get("displayName") == self.sender.display_name
+        assert contacts[0].get("displayName") == sender.display_name
 
         contact_request_messages = self.get_message_by_content_type(response, content_type=MessageContentType.CONTACT_REQUEST.value)
         assert len(contact_request_messages) == 1, f"Expected one message with contentType {MessageContentType.CONTACT_REQUEST.value}"
         assert contact_request_messages[0].get("text") == "contact_request"
 
-    def test_accept_latest_contact_request_for_contact(self):
-        self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.accept_latest_contact_request_for_contact(self.sender.public_key)
+    def test_accept_latest_contact_request_for_contact(self, sender, receiver):
+        self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        response = receiver.wakuext_service.accept_latest_contact_request_for_contact(sender.public_key)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])
         assert len(contacts) >= 1, "Expected response to have at least one contact"
-        assert contacts[0].get("displayName") == self.sender.display_name
+        assert contacts[0].get("displayName") == sender.display_name
 
         contact_request_messages = self.get_message_by_content_type(response, content_type=MessageContentType.CONTACT_REQUEST.value)
         assert len(contact_request_messages) == 1, f"Expected one message with contentType {MessageContentType.CONTACT_REQUEST.value}"
@@ -99,33 +101,33 @@ class TestContactRequests(MessengerSteps):
         assert (
             len(accept_request_messages) == 1
         ), f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_ACCEPTED.value}"
-        assert accept_request_messages[0].get("text") == f"You accepted @{self.sender.public_key}'s contact request"
+        assert accept_request_messages[0].get("text") == f"You accepted @{sender.public_key}'s contact request"
 
-    def test_dismiss_latest_contact_request_for_contact(self):
-        self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.dismiss_latest_contact_request_for_contact(self.sender.public_key)
+    def test_dismiss_latest_contact_request_for_contact(self, sender, receiver):
+        self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        response = receiver.wakuext_service.dismiss_latest_contact_request_for_contact(sender.public_key)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])
         assert len(contacts) >= 1, "Expected response to have at least one contact"
-        assert contacts[0].get("displayName") == self.sender.display_name
+        assert contacts[0].get("displayName") == sender.display_name
 
         contact_request_messages = self.get_message_by_content_type(response, content_type=MessageContentType.CONTACT_REQUEST.value)
         assert len(contact_request_messages) == 1, f"Expected one message with contentType {MessageContentType.CONTACT_REQUEST.value}"
         assert contact_request_messages[0].get("text") == "contact_request"
 
-    def test_get_latest_contact_request_for_contact(self):
-        self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.receiver.wakuext_service.get_latest_contact_request_for_contact(self.sender.public_key)
+    def test_get_latest_contact_request_for_contact(self, sender, receiver):
+        self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        response = receiver.wakuext_service.get_latest_contact_request_for_contact(sender.public_key)
         # TODO: Add more assertions on response
 
         contact_request_message = self.get_message_by_content_type(response, content_type=MessageContentType.CONTACT_REQUEST.value)
         assert len(contact_request_message) == 1, f"Expected one message with contentType {MessageContentType.CONTACT_REQUEST.value}"
         assert contact_request_message[0].get("text") == "contact_request"
 
-    def test_retract_contact_request(self):
-        self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        response = self.sender.wakuext_service.retract_contact_request(self.receiver.public_key)
+    def test_retract_contact_request(self, sender, receiver):
+        self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        response = sender.wakuext_service.retract_contact_request(receiver.public_key)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])
@@ -137,12 +139,12 @@ class TestContactRequests(MessengerSteps):
         assert (
             len(retract_request_messages) == 1
         ), f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_REMOVED.value}"
-        assert retract_request_messages[0].get("text") == f"You removed @{self.receiver.public_key} as a contact"
+        assert retract_request_messages[0].get("text") == f"You removed @{receiver.public_key} as a contact"
 
-    def test_remove_contact(self):
-        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        self.accept_contact_request_and_wait_for_signal_to_be_received(message_id)
-        response = self.sender.wakuext_service.remove_contact(self.receiver.public_key)
+    def test_remove_contact(self, sender, receiver):
+        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        self.accept_contact_request_and_wait_for_signal_to_be_received(message_id, sender=sender, receiver=receiver)
+        response = sender.wakuext_service.remove_contact(receiver.public_key)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])
@@ -154,17 +156,17 @@ class TestContactRequests(MessengerSteps):
         assert (
             len(retract_request_messages) == 1
         ), f"Expected one message with contentType {MessageContentType.SYSTEM_MESSAGE_MUTUAL_EVENT_REMOVED.value}"
-        assert retract_request_messages[0].get("text") == f"You removed @{self.receiver.public_key} as a contact"
+        assert retract_request_messages[0].get("text") == f"You removed @{receiver.public_key} as a contact"
 
-    def test_set_contact_local_nickname(self):
-        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(self.sender, self.receiver)
-        self.accept_contact_request_and_wait_for_signal_to_be_received(message_id)
+    def test_set_contact_local_nickname(self, sender, receiver):
+        message_id = self.send_contact_request_and_wait_for_signal_to_be_received(sender, receiver)
+        self.accept_contact_request_and_wait_for_signal_to_be_received(message_id, sender=sender, receiver=receiver)
         nickname = str(uuid4())
-        response = self.sender.wakuext_service.set_contact_local_nickname(self.receiver.public_key, nickname)
+        response = sender.wakuext_service.set_contact_local_nickname(receiver.public_key, nickname)
         # TODO: Add more assertions on response
 
         contacts = response.get("contacts", [])
         assert len(contacts) >= 1, "Expected response to have at least one contact"
-        assert contacts[0].get("displayName") == self.receiver.display_name
+        assert contacts[0].get("displayName") == receiver.display_name
         assert contacts[0].get("localNickname") == nickname
         assert contacts[0].get("primaryName") == nickname

--- a/tests-functional/tests/test_wakuext_contact_verification.py
+++ b/tests-functional/tests/test_wakuext_contact_verification.py
@@ -16,106 +16,113 @@ class ContactVerificationState(Enum):
 
 @pytest.mark.rpc
 class TestContactVerification(MessengerSteps):
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two backends (creator and member) for each test function"""
-        self.creator = backend_new_profile("creator")
-        self.member = backend_new_profile("member")
-        self.fake_address = "0x" + str(uuid4())[:8]
-        self.make_contacts(sender=self.creator, receiver=self.member)
 
-    def test_send_and_accept_contact_verification_request(self):
+    @pytest.fixture()
+    def creator(self, backend_new_profile):
+        return backend_new_profile("creator")
+
+    @pytest.fixture()
+    def member(self, backend_new_profile, creator):
+        m = backend_new_profile("member")
+        self.make_contacts(sender=creator, receiver=m)
+        return m
+
+    @pytest.fixture()
+    def fake_address(self):
+        return "0x" + str(uuid4())[:8]
+
+    def test_send_and_accept_contact_verification_request(self, creator, member, fake_address):
         challenge = f"verify-accept_{uuid4()}"
-        send_resp = self.creator.wakuext_service.send_contact_verification_request(self.member.public_key, challenge)
+        send_resp = creator.wakuext_service.send_contact_verification_request(member.public_key, challenge)
         assert send_resp.get("messages")[0].get("contentType") == MessageContentType.IDENTITY_VERIFICATION.value
         assert send_resp.get("verificationRequests")[0].get("challenge") == challenge
         assert send_resp.get("verificationRequests")[0].get("verification_status") == ContactVerificationState.ContactVerificationStatePending.value
 
-        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=challenge, timeout=10)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=challenge, timeout=10)
 
-        get_received_resp_before = self.member.wakuext_service.get_received_verification_requests()
+        get_received_resp_before = member.wakuext_service.get_received_verification_requests()
         req_id = get_received_resp_before[0].get("id")
         assert get_received_resp_before[0].get("challenge") == challenge
         assert get_received_resp_before[0].get("verification_status") == ContactVerificationState.ContactVerificationStatePending.value
 
-        get_verification_resp_before = self.creator.wakuext_service.get_verification_request_sent_to(self.member.public_key)
+        get_verification_resp_before = creator.wakuext_service.get_verification_request_sent_to(member.public_key)
         assert get_verification_resp_before == get_received_resp_before[0]
 
-        get_latest_request_resp_before = self.member.wakuext_service.get_latest_verification_request_from(self.creator.public_key)
+        get_latest_request_resp_before = member.wakuext_service.get_latest_verification_request_from(creator.public_key)
         assert get_latest_request_resp_before == get_received_resp_before[0]
 
         # accept the verification request as the member
         challenge_response = f"accepted-{uuid4()}"
-        accept_resp = self.member.wakuext_service.accept_contact_verification_request(req_id, challenge_response)
+        accept_resp = member.wakuext_service.accept_contact_verification_request(req_id, challenge_response)
         assert accept_resp.get("verificationRequests")[0].get("challenge") == challenge
         assert accept_resp.get("verificationRequests")[0].get("response") == challenge_response
         assert (
             accept_resp.get("verificationRequests")[0].get("verification_status") == ContactVerificationState.ContactVerificationStateAccepted.value
         )
 
-        self.creator.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=challenge_response, timeout=10)
+        creator.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=challenge_response, timeout=10)
 
-        get_received_resp_after = self.member.wakuext_service.get_received_verification_requests()
+        get_received_resp_after = member.wakuext_service.get_received_verification_requests()
         assert get_received_resp_after[0].get("challenge") == challenge
         assert get_received_resp_after[0].get("response") == challenge_response
         assert get_received_resp_after[0].get("verification_status") == ContactVerificationState.ContactVerificationStateAccepted.value
 
-        self.creator.wakuext_service.get_verification_request_sent_to(self.member.public_key)
+        creator.wakuext_service.get_verification_request_sent_to(member.public_key)
         # assert get_verification_resp_after == get_received_resp_after[0] # https://github.com/status-im/status-go/issues/6995
 
-        get_latest_request_resp_after = self.member.wakuext_service.get_latest_verification_request_from(self.creator.public_key)
+        get_latest_request_resp_after = member.wakuext_service.get_latest_verification_request_from(creator.public_key)
         assert get_latest_request_resp_after == get_received_resp_after[0]
 
-    def test_send_and_decline_contact_verification_request(self):
+    def test_send_and_decline_contact_verification_request(self, creator, member, fake_address):
         challenge = f"verify-decline-{uuid4()}"
-        self.creator.wakuext_service.send_contact_verification_request(self.member.public_key, challenge)
+        creator.wakuext_service.send_contact_verification_request(member.public_key, challenge)
 
-        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=challenge, timeout=10)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=challenge, timeout=10)
 
-        get_received_resp_before = self.member.wakuext_service.get_received_verification_requests()
+        get_received_resp_before = member.wakuext_service.get_received_verification_requests()
         req_id = get_received_resp_before[0].get("id")
         assert get_received_resp_before[0].get("challenge") == challenge
         assert get_received_resp_before[0].get("verification_status") == ContactVerificationState.ContactVerificationStatePending.value
 
         # decline the verification request as the member
-        decline_resp = self.member.wakuext_service.decline_contact_verification_request(req_id)
+        decline_resp = member.wakuext_service.decline_contact_verification_request(req_id)
         assert decline_resp.get("verificationRequests")[0].get("challenge") == challenge
         assert decline_resp.get("verificationRequests")[0].get("response") == ""
         assert (
             decline_resp.get("verificationRequests")[0].get("verification_status") == ContactVerificationState.ContactVerificationStateDeclined.value
         )
 
-        get_received_resp_after = self.member.wakuext_service.get_received_verification_requests()
+        get_received_resp_after = member.wakuext_service.get_received_verification_requests()
         assert get_received_resp_after[0].get("challenge") == challenge
         assert get_received_resp_after[0].get("response") == ""
         assert get_received_resp_after[0].get("verification_status") == ContactVerificationState.ContactVerificationStateDeclined.value
 
-    def test_send_and_cancel_contact_verification_request(self):
+    def test_send_and_cancel_contact_verification_request(self, creator, member, fake_address):
         challenge = f"verify-cancel-{uuid4()}"
-        self.creator.wakuext_service.send_contact_verification_request(self.member.public_key, challenge)
+        creator.wakuext_service.send_contact_verification_request(member.public_key, challenge)
 
-        self.member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=challenge, timeout=10)
+        member.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=challenge, timeout=10)
 
-        get_received_resp_before = self.member.wakuext_service.get_received_verification_requests()
+        get_received_resp_before = member.wakuext_service.get_received_verification_requests()
         req_id = get_received_resp_before[0].get("id")
         assert get_received_resp_before[0].get("challenge") == challenge
         assert get_received_resp_before[0].get("verification_status") == ContactVerificationState.ContactVerificationStatePending.value
 
         # cancel the verification request as the creator
-        decline_resp = self.creator.wakuext_service.cancel_verification_request(req_id)
+        decline_resp = creator.wakuext_service.cancel_verification_request(req_id)
         assert decline_resp.get("verificationRequests")[0].get("challenge") == challenge
         assert decline_resp.get("verificationRequests")[0].get("response") == ""
         assert (
             decline_resp.get("verificationRequests")[0].get("verification_status") == ContactVerificationState.ContactVerificationStateCanceled.value
         )
 
-        self.member.wait_for_signal_predicate(
+        member.wait_for_signal_predicate(
             SignalType.MESSAGES_NEW.value,
             lambda signal: signal.get("event").get("verificationRequests")[0].get("verification_status")
             == ContactVerificationState.ContactVerificationStateCanceled.value,
         )
 
-        get_received_resp_after = self.member.wakuext_service.get_received_verification_requests()
+        get_received_resp_after = member.wakuext_service.get_received_verification_requests()
         assert get_received_resp_after[0].get("challenge") == challenge
         assert get_received_resp_after[0].get("response") == ""
         assert get_received_resp_after[0].get("verification_status") == ContactVerificationState.ContactVerificationStateCanceled.value

--- a/tests-functional/tests/test_wakuext_group_chats.py
+++ b/tests-functional/tests/test_wakuext_group_chats.py
@@ -7,192 +7,200 @@ from resources.enums import MessageContentType
 @pytest.mark.rpc
 class TestCreatePrivateGroups(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two unprivileged backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender")
-        self.receiver = backend_new_profile("receiver")
-        self.make_contacts(self.sender, self.receiver)
+    @pytest.fixture()
+    def admin(self, backend_new_profile):
+        return backend_new_profile("admin")
 
-    def test_create_group_chat_with_members(self):
+    @pytest.fixture()
+    def member(self, backend_new_profile):
+        return backend_new_profile("member")
+
+    def test_create_group_chat_with_members(self, admin, member):
+        self.make_contacts(admin, member)
         private_group_name = f"private_group_{uuid4()}"
-        create_group_response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], private_group_name)
+        create_group_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], private_group_name)
         # TODO: Add more assertions on response
 
-        self.get_message_by_content_type(
+        _ = self.get_message_by_content_type(
             create_group_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{self.sender.public_key} created the group {private_group_name}",
+            message_pattern=f"@{admin.public_key} created the group {private_group_name}",
         )[0]
-        self.get_message_by_content_type(
+        _ = self.get_message_by_content_type(
             create_group_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{self.sender.public_key} has added @{self.receiver.public_key}",
+            message_pattern=f"@{admin.public_key} has added @{member.public_key}",
         )[0]
 
-    def test_leave_group_chat(self):
-        create_group_response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], f"private_group_{uuid4()}")
+    def test_leave_group_chat(self, admin, member):
+        self.make_contacts(admin, member)
+        create_group_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"private_group_{uuid4()}")
 
         group_id = create_group_response.get("chats", [])[0].get("id")
         members_before_leave = create_group_response.get("chats", [])[0].get("members", [])
         assert len(members_before_leave) == 2
-        assert self.sender.public_key in str(members_before_leave)
+        assert admin.public_key in str(members_before_leave)
 
-        leave_group_response = self.sender.wakuext_service.leave_group_chat(group_id, True)
+        leave_group_response = admin.wakuext_service.leave_group_chat(group_id, True)
         # TODO: Add more assertions on response
 
-        self.get_message_by_content_type(
+        _ = self.get_message_by_content_type(
             leave_group_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{self.sender.public_key} left the group",
+            message_pattern=f"@{admin.public_key} left the group",
         )[0]
 
         members_after_leave = leave_group_response.get("chats", [])[0].get("members", [])
         assert len(members_after_leave) == 1
-        assert self.sender.public_key not in str(members_after_leave)
+        assert admin.public_key not in str(members_after_leave)
 
-    def test_send_group_chat_invitation_request(self, backend_new_profile):
+    def test_send_group_chat_invitation_request(self, admin, member, backend_new_profile):
         third_node = backend_new_profile("third_node")
-        self.make_contacts(self.sender, third_node)
+        self.make_contacts(admin, third_node)
 
-        create_group_response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], f"private_group_{uuid4()}")
+        create_group_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"private_group_{uuid4()}")
         group_id = create_group_response.get("chats", [])[0].get("id")
 
         invitation_message = f"Please join {uuid4()}"
-        invite_response = self.sender.wakuext_service.send_group_chat_invitation_request(group_id, third_node.public_key, invitation_message)
+        invite_response = admin.wakuext_service.send_group_chat_invitation_request(group_id, third_node.public_key, invitation_message)
         # TODO: Add more assertions on response
 
         invitations = invite_response.get("invitations", [])
         assert len(invitations) == 1
         assert invitations[0].get("chatId", "") == group_id
-        assert invitations[0].get("from", "") == self.sender.public_key
+        assert invitations[0].get("from", "") == admin.public_key
         assert invitations[0].get("introductionMessage", "") == invitation_message
         assert invitations[0].get("state", 0) == 1
 
-    def test_create_group_chat_from_invitation(self):
+    def test_create_group_chat_from_invitation(self, admin, member):
         invitation_group = f"Group name {uuid4()}"
         group_id = str(uuid4())
-        create_from_inv = self.receiver.wakuext_service.create_group_chat_from_invitation(invitation_group, group_id, self.sender.public_key)
+        create_from_inv = member.wakuext_service.create_group_chat_from_invitation(invitation_group, group_id, admin.public_key)
         # TODO: Add more assertions on response
 
         chats = create_from_inv.get("chats", [])
         assert len(chats) == 1
         assert chats[0].get("id", "") == group_id
-        assert chats[0].get("invitationAdmin", "") == self.sender.public_key
+        assert chats[0].get("invitationAdmin", "") == admin.public_key
         assert chats[0].get("name", "") == invitation_group
 
-    def test_add_members_to_group_chat(self, backend_new_profile):
+    def test_add_members_to_group_chat(self, admin, member, backend_new_profile):
         third_node = backend_new_profile("third_node")
-        self.make_contacts(self.sender, third_node)
+        self.make_contacts(admin, third_node)
 
-        create_response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], f"add_members_group_{uuid4()}")
+        self.make_contacts(admin, member)
+        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"add_members_group_{uuid4()}")
         group_id = create_response.get("chats", [])[0].get("id")
 
-        add_members_response = self.sender.wakuext_service.add_members_to_group_chat(group_id, [third_node.public_key])
+        add_members_response = admin.wakuext_service.add_members_to_group_chat(group_id, [third_node.public_key])
         # TODO: Add more assertions on response
 
-        self.get_message_by_content_type(
+        _ = self.get_message_by_content_type(
             add_members_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{self.sender.public_key} has added @{third_node.public_key}",
+            message_pattern=f"@{admin.public_key} has added @{third_node.public_key}",
         )[0]
 
-    def test_remove_member_from_group_chat(self):
-        create_response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], f"group_{uuid4()}")
+    def test_remove_member_from_group_chat(self, admin, member):
+        self.make_contacts(admin, member)
+        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"group_{uuid4()}")
         group_id = create_response.get("chats", [])[0].get("id")
 
-        remove_member_response = self.sender.wakuext_service.remove_member_from_group_chat(group_id, self.receiver.public_key)
+        remove_member_response = admin.wakuext_service.remove_member_from_group_chat(group_id, member.public_key)
         # TODO: Add more assertions on response
 
-        self.get_message_by_content_type(
+        _ = self.get_message_by_content_type(
             remove_member_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{self.receiver.public_key} left the group",
+            message_pattern=f"@{member.public_key} left the group",
         )[0]
 
-    def test_remove_members_from_group_chat(self, backend_new_profile):
+    def test_remove_members_from_group_chat(self, admin, member, backend_new_profile):
         third_node = backend_new_profile("third_node")
-        self.make_contacts(self.sender, third_node)
+        self.make_contacts(admin, third_node)
 
-        create_response = self.sender.wakuext_service.create_group_chat_with_members(
-            [self.receiver.public_key, third_node.public_key], f"add_members_group_{uuid4()}"
+        self.make_contacts(admin, member)
+        create_response = admin.wakuext_service.create_group_chat_with_members(
+            [member.public_key, third_node.public_key], f"add_members_group_{uuid4()}"
         )
         group_id = create_response.get("chats", [])[0].get("id")
 
-        remove_members_response = self.sender.wakuext_service.remove_members_from_group_chat(
-            group_id, [self.receiver.public_key, third_node.public_key]
-        )
+        remove_members_response = admin.wakuext_service.remove_members_from_group_chat(group_id, [member.public_key, third_node.public_key])
         # TODO: Add more assertions on response
 
-        self.get_message_by_content_type(
+        _ = self.get_message_by_content_type(
             remove_members_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{self.receiver.public_key} left the group",
+            message_pattern=f"@{member.public_key} left the group",
         )[0]
-        self.get_message_by_content_type(
+        _ = self.get_message_by_content_type(
             remove_members_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
             message_pattern=f"@{third_node.public_key} left the group",
         )[0]
 
-    def test_confirm_joining_group(self):
-        create_response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], f"confirm_join_group_{uuid4()}")
+    def test_confirm_joining_group(self, admin, member):
+        self.make_contacts(admin, member)
+        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"confirm_join_group_{uuid4()}")
         group_id = create_response.get("chats", [])[0].get("id")
 
-        confirm_response = self.sender.wakuext_service.confirm_joining_group(group_id)
+        confirm_response = admin.wakuext_service.confirm_joining_group(group_id)
         # TODO: Add more assertions on response
 
         chats = confirm_response.get("chats", [])
         assert len(chats) == 1
         assert len(chats[0].get("members", [])) == 2
 
-    def test_change_group_chat_name(self):
+    def test_change_group_chat_name(self, admin, member):
+        self.make_contacts(admin, member)
         initial_group_name = "initial_group_name"
-        create_response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], initial_group_name)
+        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], initial_group_name)
         group_id = create_response.get("chats", [])[0].get("id")
 
         new_group_name = f"new_group_name_{uuid4()}"
-        change_name_response = self.sender.wakuext_service.change_group_chat_name(group_id, new_group_name)
+        change_name_response = admin.wakuext_service.change_group_chat_name(group_id, new_group_name)
         # TODO: Add more assertions on response
 
-        self.get_message_by_content_type(
+        _ = self.get_message_by_content_type(
             change_name_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{self.sender.public_key} changed the group's name to {new_group_name}",
+            message_pattern=f"@{admin.public_key} changed the group's name to {new_group_name}",
         )[0]
 
         chats = change_name_response.get("chats", [])
         assert chats[0].get("name", "") == new_group_name
 
     @pytest.mark.skip(reason="waiting for https://github.com/status-im/status-go/issues/6752 resolution")
-    def test_get_group_chat_invitations(self, backend_new_profile):
+    def test_get_group_chat_invitations(self, admin, member, backend_new_profile):
         third_node = backend_new_profile("third_node")
-        self.make_contacts(self.sender, third_node)
+        self.make_contacts(admin, third_node)
 
-        create_response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], f"group_{uuid4()}")
+        self.make_contacts(admin, member)
+        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"group_{uuid4()}")
         group_id = create_response.get("chats", [])[0].get("id")
 
-        self.sender.wakuext_service.send_group_chat_invitation_request(group_id, third_node.public_key, f"Please join {uuid4()}")
+        admin.wakuext_service.send_group_chat_invitation_request(group_id, third_node.public_key, f"Please join {uuid4()}")
         third_node.wakuext_service.get_group_chat_invitations()
         # TODO: Add more assertions on response
 
-    def test_send_group_chat_invitation_rejection(self, backend_new_profile):
+    def test_send_group_chat_invitation_rejection(self, admin, member, backend_new_profile):
         third_node = backend_new_profile("third_node")
-        self.make_contacts(self.sender, third_node)
+        self.make_contacts(admin, third_node)
 
-        create_response = self.sender.wakuext_service.create_group_chat_with_members([self.receiver.public_key], f"group_{uuid4()}")
+        self.make_contacts(admin, member)
+        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"group_{uuid4()}")
         group_id = create_response.get("chats", [])[0].get("id")
 
         invitation_message = f"Please join {uuid4()}"
-        send_invitation_response = self.sender.wakuext_service.send_group_chat_invitation_request(group_id, third_node.public_key, invitation_message)
+        send_invitation_response = admin.wakuext_service.send_group_chat_invitation_request(group_id, third_node.public_key, invitation_message)
 
         invitation_id = send_invitation_response.get("invitations", [])[0].get("id")
-        reject_response = self.sender.wakuext_service.send_group_chat_invitation_rejection(invitation_id)
+        reject_response = admin.wakuext_service.send_group_chat_invitation_rejection(invitation_id)
         # TODO: Add more assertions on response
 
         invitations = reject_response.get("invitations", [])
         assert len(invitations) == 1
         assert invitations[0].get("chatId", "") == group_id
-        assert invitations[0].get("from", "") == self.sender.public_key
+        assert invitations[0].get("from", "") == admin.public_key
         assert invitations[0].get("introductionMessage", "") == invitation_message
         assert invitations[0].get("state", 0) == 2

--- a/tests-functional/tests/test_wakuext_group_chats.py
+++ b/tests-functional/tests/test_wakuext_group_chats.py
@@ -64,6 +64,8 @@ class TestCreatePrivateGroups(MessengerSteps):
         third_node = backend_new_profile("third_node")
         self.make_contacts(community_admin, third_node)
 
+        self.make_contacts(community_admin, community_member)
+
         create_group_response = community_admin.wakuext_service.create_group_chat_with_members(
             [community_member.public_key],
             f"private_group_{uuid4()}",

--- a/tests-functional/tests/test_wakuext_group_chats.py
+++ b/tests-functional/tests/test_wakuext_group_chats.py
@@ -8,130 +8,162 @@ from resources.enums import MessageContentType
 class TestCreatePrivateGroups(MessengerSteps):
 
     @pytest.fixture()
-    def admin(self, backend_new_profile):
-        return backend_new_profile("admin")
+    def community_admin(self, backend_new_profile):
+        return backend_new_profile("community_admin")
 
     @pytest.fixture()
-    def member(self, backend_new_profile):
-        return backend_new_profile("member")
+    def community_member(self, backend_new_profile):
+        return backend_new_profile("community_member")
 
-    def test_create_group_chat_with_members(self, admin, member):
-        self.make_contacts(admin, member)
+    def test_create_group_chat_with_members(self, community_admin, community_member):
+        self.make_contacts(community_admin, community_member)
         private_group_name = f"private_group_{uuid4()}"
-        create_group_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], private_group_name)
+        create_group_response = community_admin.wakuext_service.create_group_chat_with_members(
+            [community_member.public_key],
+            private_group_name,
+        )
         # TODO: Add more assertions on response
 
         _ = self.get_message_by_content_type(
             create_group_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{admin.public_key} created the group {private_group_name}",
+            message_pattern=f"@{community_admin.public_key} created the group {private_group_name}",
         )[0]
         _ = self.get_message_by_content_type(
             create_group_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{admin.public_key} has added @{member.public_key}",
+            message_pattern=f"@{community_admin.public_key} has added @{community_member.public_key}",
         )[0]
 
-    def test_leave_group_chat(self, admin, member):
-        self.make_contacts(admin, member)
-        create_group_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"private_group_{uuid4()}")
+    def test_leave_group_chat(self, community_admin, community_member):
+        self.make_contacts(community_admin, community_member)
+        create_group_response = community_admin.wakuext_service.create_group_chat_with_members(
+            [community_member.public_key],
+            f"private_group_{uuid4()}",
+        )
 
         group_id = create_group_response.get("chats", [])[0].get("id")
         members_before_leave = create_group_response.get("chats", [])[0].get("members", [])
         assert len(members_before_leave) == 2
-        assert admin.public_key in str(members_before_leave)
+        assert community_admin.public_key in str(members_before_leave)
 
-        leave_group_response = admin.wakuext_service.leave_group_chat(group_id, True)
+        leave_group_response = community_admin.wakuext_service.leave_group_chat(group_id, True)
         # TODO: Add more assertions on response
 
         _ = self.get_message_by_content_type(
             leave_group_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{admin.public_key} left the group",
+            message_pattern=f"@{community_admin.public_key} left the group",
         )[0]
 
         members_after_leave = leave_group_response.get("chats", [])[0].get("members", [])
         assert len(members_after_leave) == 1
-        assert admin.public_key not in str(members_after_leave)
+        assert community_admin.public_key not in str(members_after_leave)
 
-    def test_send_group_chat_invitation_request(self, admin, member, backend_new_profile):
+    def test_send_group_chat_invitation_request(self, community_admin, community_member, backend_new_profile):
         third_node = backend_new_profile("third_node")
-        self.make_contacts(admin, third_node)
+        self.make_contacts(community_admin, third_node)
 
-        create_group_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"private_group_{uuid4()}")
+        create_group_response = community_admin.wakuext_service.create_group_chat_with_members(
+            [community_member.public_key],
+            f"private_group_{uuid4()}",
+        )
         group_id = create_group_response.get("chats", [])[0].get("id")
 
         invitation_message = f"Please join {uuid4()}"
-        invite_response = admin.wakuext_service.send_group_chat_invitation_request(group_id, third_node.public_key, invitation_message)
+        invite_response = community_admin.wakuext_service.send_group_chat_invitation_request(
+            group_id,
+            third_node.public_key,
+            invitation_message,
+        )
         # TODO: Add more assertions on response
 
         invitations = invite_response.get("invitations", [])
         assert len(invitations) == 1
         assert invitations[0].get("chatId", "") == group_id
-        assert invitations[0].get("from", "") == admin.public_key
+        assert invitations[0].get("from", "") == community_admin.public_key
         assert invitations[0].get("introductionMessage", "") == invitation_message
         assert invitations[0].get("state", 0) == 1
 
-    def test_create_group_chat_from_invitation(self, admin, member):
+    def test_create_group_chat_from_invitation(self, community_admin, community_member):
         invitation_group = f"Group name {uuid4()}"
         group_id = str(uuid4())
-        create_from_inv = member.wakuext_service.create_group_chat_from_invitation(invitation_group, group_id, admin.public_key)
+        create_from_inv = community_member.wakuext_service.create_group_chat_from_invitation(
+            invitation_group,
+            group_id,
+            community_admin.public_key,
+        )
         # TODO: Add more assertions on response
 
         chats = create_from_inv.get("chats", [])
         assert len(chats) == 1
         assert chats[0].get("id", "") == group_id
-        assert chats[0].get("invitationAdmin", "") == admin.public_key
+        assert chats[0].get("invitationAdmin", "") == community_admin.public_key
         assert chats[0].get("name", "") == invitation_group
 
-    def test_add_members_to_group_chat(self, admin, member, backend_new_profile):
+    def test_add_members_to_group_chat(self, community_admin, community_member, backend_new_profile):
         third_node = backend_new_profile("third_node")
-        self.make_contacts(admin, third_node)
+        self.make_contacts(community_admin, third_node)
 
-        self.make_contacts(admin, member)
-        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"add_members_group_{uuid4()}")
+        self.make_contacts(community_admin, community_member)
+        create_response = community_admin.wakuext_service.create_group_chat_with_members(
+            [community_member.public_key],
+            f"add_members_group_{uuid4()}",
+        )
         group_id = create_response.get("chats", [])[0].get("id")
 
-        add_members_response = admin.wakuext_service.add_members_to_group_chat(group_id, [third_node.public_key])
+        add_members_response = community_admin.wakuext_service.add_members_to_group_chat(
+            group_id,
+            [third_node.public_key],
+        )
         # TODO: Add more assertions on response
 
         _ = self.get_message_by_content_type(
             add_members_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{admin.public_key} has added @{third_node.public_key}",
+            message_pattern=f"@{community_admin.public_key} has added @{third_node.public_key}",
         )[0]
 
-    def test_remove_member_from_group_chat(self, admin, member):
-        self.make_contacts(admin, member)
-        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"group_{uuid4()}")
+    def test_remove_member_from_group_chat(self, community_admin, community_member):
+        self.make_contacts(community_admin, community_member)
+        create_response = community_admin.wakuext_service.create_group_chat_with_members(
+            [community_member.public_key],
+            f"group_{uuid4()}",
+        )
         group_id = create_response.get("chats", [])[0].get("id")
 
-        remove_member_response = admin.wakuext_service.remove_member_from_group_chat(group_id, member.public_key)
+        remove_member_response = community_admin.wakuext_service.remove_member_from_group_chat(
+            group_id,
+            community_member.public_key,
+        )
         # TODO: Add more assertions on response
 
         _ = self.get_message_by_content_type(
             remove_member_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{member.public_key} left the group",
+            message_pattern=f"@{community_member.public_key} left the group",
         )[0]
 
-    def test_remove_members_from_group_chat(self, admin, member, backend_new_profile):
+    def test_remove_members_from_group_chat(self, community_admin, community_member, backend_new_profile):
         third_node = backend_new_profile("third_node")
-        self.make_contacts(admin, third_node)
+        self.make_contacts(community_admin, third_node)
 
-        self.make_contacts(admin, member)
-        create_response = admin.wakuext_service.create_group_chat_with_members(
-            [member.public_key, third_node.public_key], f"add_members_group_{uuid4()}"
+        self.make_contacts(community_admin, community_member)
+        create_response = community_admin.wakuext_service.create_group_chat_with_members(
+            [community_member.public_key, third_node.public_key], f"add_members_group_{uuid4()}"
         )
         group_id = create_response.get("chats", [])[0].get("id")
 
-        remove_members_response = admin.wakuext_service.remove_members_from_group_chat(group_id, [member.public_key, third_node.public_key])
+        remove_members_response = community_admin.wakuext_service.remove_members_from_group_chat(
+            group_id,
+            [community_member.public_key, third_node.public_key],
+        )
         # TODO: Add more assertions on response
 
         _ = self.get_message_by_content_type(
             remove_members_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{member.public_key} left the group",
+            message_pattern=f"@{community_member.public_key} left the group",
         )[0]
         _ = self.get_message_by_content_type(
             remove_members_response,
@@ -139,68 +171,88 @@ class TestCreatePrivateGroups(MessengerSteps):
             message_pattern=f"@{third_node.public_key} left the group",
         )[0]
 
-    def test_confirm_joining_group(self, admin, member):
-        self.make_contacts(admin, member)
-        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"confirm_join_group_{uuid4()}")
+    def test_confirm_joining_group(self, community_admin, community_member):
+        self.make_contacts(community_admin, community_member)
+        create_response = community_admin.wakuext_service.create_group_chat_with_members(
+            [community_member.public_key],
+            f"confirm_join_group_{uuid4()}",
+        )
         group_id = create_response.get("chats", [])[0].get("id")
 
-        confirm_response = admin.wakuext_service.confirm_joining_group(group_id)
+        confirm_response = community_admin.wakuext_service.confirm_joining_group(group_id)
         # TODO: Add more assertions on response
 
         chats = confirm_response.get("chats", [])
         assert len(chats) == 1
         assert len(chats[0].get("members", [])) == 2
 
-    def test_change_group_chat_name(self, admin, member):
-        self.make_contacts(admin, member)
+    def test_change_group_chat_name(self, community_admin, community_member):
+        self.make_contacts(community_admin, community_member)
         initial_group_name = "initial_group_name"
-        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], initial_group_name)
+        create_response = community_admin.wakuext_service.create_group_chat_with_members(
+            [community_member.public_key],
+            initial_group_name,
+        )
         group_id = create_response.get("chats", [])[0].get("id")
 
         new_group_name = f"new_group_name_{uuid4()}"
-        change_name_response = admin.wakuext_service.change_group_chat_name(group_id, new_group_name)
+        change_name_response = community_admin.wakuext_service.change_group_chat_name(group_id, new_group_name)
         # TODO: Add more assertions on response
 
         _ = self.get_message_by_content_type(
             change_name_response,
             content_type=MessageContentType.SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP.value,
-            message_pattern=f"@{admin.public_key} changed the group's name to {new_group_name}",
+            message_pattern=f"@{community_admin.public_key} changed the group's name to {new_group_name}",
         )[0]
 
         chats = change_name_response.get("chats", [])
         assert chats[0].get("name", "") == new_group_name
 
     @pytest.mark.skip(reason="waiting for https://github.com/status-im/status-go/issues/6752 resolution")
-    def test_get_group_chat_invitations(self, admin, member, backend_new_profile):
+    def test_get_group_chat_invitations(self, community_admin, community_member, backend_new_profile):
         third_node = backend_new_profile("third_node")
-        self.make_contacts(admin, third_node)
+        self.make_contacts(community_admin, third_node)
 
-        self.make_contacts(admin, member)
-        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"group_{uuid4()}")
+        self.make_contacts(community_admin, community_member)
+        create_response = community_admin.wakuext_service.create_group_chat_with_members(
+            [community_member.public_key],
+            f"group_{uuid4()}",
+        )
         group_id = create_response.get("chats", [])[0].get("id")
 
-        admin.wakuext_service.send_group_chat_invitation_request(group_id, third_node.public_key, f"Please join {uuid4()}")
+        community_admin.wakuext_service.send_group_chat_invitation_request(
+            group_id,
+            third_node.public_key,
+            f"Please join {uuid4()}",
+        )
         third_node.wakuext_service.get_group_chat_invitations()
         # TODO: Add more assertions on response
 
-    def test_send_group_chat_invitation_rejection(self, admin, member, backend_new_profile):
+    def test_send_group_chat_invitation_rejection(self, community_admin, community_member, backend_new_profile):
         third_node = backend_new_profile("third_node")
-        self.make_contacts(admin, third_node)
+        self.make_contacts(community_admin, third_node)
 
-        self.make_contacts(admin, member)
-        create_response = admin.wakuext_service.create_group_chat_with_members([member.public_key], f"group_{uuid4()}")
+        self.make_contacts(community_admin, community_member)
+        create_response = community_admin.wakuext_service.create_group_chat_with_members(
+            [community_member.public_key],
+            f"group_{uuid4()}",
+        )
         group_id = create_response.get("chats", [])[0].get("id")
 
         invitation_message = f"Please join {uuid4()}"
-        send_invitation_response = admin.wakuext_service.send_group_chat_invitation_request(group_id, third_node.public_key, invitation_message)
+        send_invitation_response = community_admin.wakuext_service.send_group_chat_invitation_request(
+            group_id,
+            third_node.public_key,
+            invitation_message,
+        )
 
         invitation_id = send_invitation_response.get("invitations", [])[0].get("id")
-        reject_response = admin.wakuext_service.send_group_chat_invitation_rejection(invitation_id)
+        reject_response = community_admin.wakuext_service.send_group_chat_invitation_rejection(invitation_id)
         # TODO: Add more assertions on response
 
         invitations = reject_response.get("invitations", [])
         assert len(invitations) == 1
         assert invitations[0].get("chatId", "") == group_id
-        assert invitations[0].get("from", "") == admin.public_key
+        assert invitations[0].get("from", "") == community_admin.public_key
         assert invitations[0].get("introductionMessage", "") == invitation_message
         assert invitations[0].get("state", 0) == 2

--- a/tests-functional/tests/test_wakuext_message_reactions.py
+++ b/tests-functional/tests/test_wakuext_message_reactions.py
@@ -11,28 +11,32 @@ from steps.messenger import MessengerSteps
 @pytest.mark.rpc
 class TestMessageReactions(MessengerSteps):
 
-    @pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
-    def test_one_to_one_message_reactions(self, backend_new_profile, waku_light_client):
-        """Test message reactions with different wakuV2LightClient configurations"""
-        # Initialize two backends (sender and receiver) for this test
-        self.sender = backend_new_profile("sender", waku_light_client=waku_light_client)
-        self.receiver = backend_new_profile("receiver", waku_light_client=waku_light_client)
+    @pytest.fixture()
+    def sender(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("sender", waku_light_client=waku_light_client)
 
-        self.make_contacts(self.sender, self.receiver)
-        response = self.sender.wakuext_service.send_one_to_one_message(self.receiver.public_key, "test_message")
+    @pytest.fixture()
+    def receiver(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("receiver", waku_light_client=waku_light_client)
+
+    @pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
+    def test_one_to_one_message_reactions(self, sender, receiver, waku_light_client):
+        """Test message reactions with different wakuV2LightClient configurations"""
+        self.make_contacts(sender, receiver)
+        response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, "test_message")
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         message_id, sender_chat_id = message["id"], message["chatId"]
-        receiver_chat_id = self.receiver.wakuext_service.chats()[0]["id"]
+        receiver_chat_id = receiver.wakuext_service.chats()[0]["id"]
         # Send emoji reaction
-        response = self.receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_id, "2764")
+        response = receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_id, "2764")
         # TODO: Add more assertions on response
-        self.sender.find_signal_containing_pattern(
+        sender.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,
             event_pattern="emojiReactions",
             timeout=60,
         )
 
-        result = self.sender.wakuext_service.emoji_reactions_by_chat_id_message_id(sender_chat_id, message_id)
+        result = sender.wakuext_service.emoji_reactions_by_chat_id_message_id(sender_chat_id, message_id)
         # TODO: Add more assertions on response
         assert all(
             (
@@ -44,40 +48,40 @@ class TestMessageReactions(MessengerSteps):
         )
         emoji_id = result[0]["id"]
 
-        response = self.receiver.wakuext_service.send_emoji_reaction_retraction(emoji_id)
+        response = receiver.wakuext_service.send_emoji_reaction_retraction(emoji_id)
         # TODO: Add more assertions on response
         assert response["chats"][0]["id"] == receiver_chat_id
 
-        self.sender.find_signal_containing_pattern(
+        sender.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,
             event_pattern="retracted",
             timeout=60,
         )
-        response = self.sender.wakuext_service.emoji_reactions_by_chat_id_message_id(sender_chat_id, message_id)
+        response = sender.wakuext_service.emoji_reactions_by_chat_id_message_id(sender_chat_id, message_id)
         assert not response
 
-        response = self.sender.wakuext_service.send_one_to_one_message(self.receiver.public_key, "test_message 1")
+        response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, "test_message 1")
         message_1 = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         # Send emoji reaction
-        response = self.receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_1["id"], "1f642")
+        response = receiver.wakuext_service.send_emoji_reaction(receiver_chat_id, message_1["id"], "1f642")
         emoji_1_id = response["emojiReactions"][0]["id"]
-        self.sender.find_signal_containing_pattern(
+        sender.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,
             event_pattern=emoji_1_id,
             timeout=60,
         )
 
-        response = self.receiver.wakuext_service.send_one_to_one_message(self.sender.public_key, "test_message 2")
+        response = receiver.wakuext_service.send_one_to_one_message(sender.public_key, "test_message 2")
         message_2 = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
-        response = self.sender.wakuext_service.send_emoji_reaction(sender_chat_id, message_2["id"], "1f641")
+        response = sender.wakuext_service.send_emoji_reaction(sender_chat_id, message_2["id"], "1f641")
         emoji_2_id = response["emojiReactions"][0]["id"]
-        self.receiver.find_signal_containing_pattern(
+        receiver.find_signal_containing_pattern(
             SignalType.MESSAGES_NEW.value,
             event_pattern=emoji_2_id,
             timeout=60,
         )
         time.sleep(10)
-        result = self.sender.wakuext_service.emoji_reactions_by_chat_id(sender_chat_id, 20)
+        result = sender.wakuext_service.emoji_reactions_by_chat_id(sender_chat_id, 20)
         # TODO: Add more assertions on response
         assert len(result) == 2
         for item in result:
@@ -96,12 +100,8 @@ class TestMessageReactions(MessengerSteps):
             )
 
     @pytest.mark.parametrize("waku_light_client", [False], indirect=True, ids=["wakuV2LightClient_False"])
-    def test_limit_of_20_reactions(self, backend_new_profile, waku_light_client):
+    def test_limit_of_20_reactions(self, sender, receiver, waku_light_client):
         """Test that you cannot send more than 20 message reactions on a single message"""
-        # Initialize two backends (sender and receiver) for this test
-        sender = backend_new_profile("sender", waku_light_client=waku_light_client)
-        receiver = backend_new_profile("receiver", waku_light_client=waku_light_client)
-
         self.make_contacts(sender, receiver)
         response = sender.wakuext_service.send_one_to_one_message(receiver.public_key, "test_message")
         message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]

--- a/tests-functional/tests/test_wakuext_messages_fetching.py
+++ b/tests-functional/tests/test_wakuext_messages_fetching.py
@@ -7,17 +7,19 @@ from steps.messenger import MessengerSteps
 @pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
 class TestFetchingChatMessages(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile, waku_light_client):
-        """Initialize two backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", waku_light_client=waku_light_client)
-        self.receiver = backend_new_profile("receiver", waku_light_client=waku_light_client)
+    @pytest.fixture()
+    def sender(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("sender", waku_light_client=waku_light_client)
 
-    def test_chat_messages(self):
-        sent_texts, _ = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+    @pytest.fixture()
+    def receiver(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("receiver", waku_light_client=waku_light_client)
 
-        sender_chat_id = self.receiver.public_key
-        response = self.sender.wakuext_service.chat_messages(sender_chat_id)
+    def test_chat_messages(self, sender, receiver):
+        sent_texts, _ = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+
+        sender_chat_id = receiver.public_key
+        response = sender.wakuext_service.chat_messages(sender_chat_id)
         # TODO: Add more assertions on response
 
         messages = response.get("messages", [])
@@ -25,12 +27,12 @@ class TestFetchingChatMessages(MessengerSteps):
         actual_text = messages[0].get("text", "")
         assert actual_text == sent_texts[0]
 
-    def test_chat_messages_with_pagination(self):
-        sent_texts, _ = self.send_multiple_one_to_one_messages(5, sender=self.sender, receiver=self.receiver)
-        sender_chat_id = self.receiver.public_key
+    def test_chat_messages_with_pagination(self, sender, receiver):
+        sent_texts, _ = self.send_multiple_one_to_one_messages(5, sender=sender, receiver=receiver)
+        sender_chat_id = receiver.public_key
 
         # Page 1
-        chat_messages_res1 = self.sender.wakuext_service.chat_messages(sender_chat_id, cursor="", limit=3)
+        chat_messages_res1 = sender.wakuext_service.chat_messages(sender_chat_id, cursor="", limit=3)
 
         cursor1 = chat_messages_res1.get("cursor", "")
         messages_page1 = chat_messages_res1.get("messages", [])
@@ -41,7 +43,7 @@ class TestFetchingChatMessages(MessengerSteps):
         assert cursor1 != ""
 
         # Page 2
-        chat_messages_res2 = self.sender.wakuext_service.chat_messages(sender_chat_id, cursor=cursor1, limit=3)
+        chat_messages_res2 = sender.wakuext_service.chat_messages(sender_chat_id, cursor=cursor1, limit=3)
 
         cursor2 = chat_messages_res2.get("cursor", "")
         messages_page2 = chat_messages_res2.get("messages", [])
@@ -50,52 +52,52 @@ class TestFetchingChatMessages(MessengerSteps):
         assert messages_page2[1].get("text", "") == sent_texts[0]
         assert cursor2 == ""
 
-    def test_message_by_message_id(self):
-        sent_texts, responses = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+    def test_message_by_message_id(self, sender, receiver):
+        sent_texts, responses = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
 
         message_id = responses[0].get("messages", [])[0].get("id", "")
-        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        response = sender.wakuext_service.message_by_message_id(message_id)
         # TODO: Add more assertions on response
 
         actual_text = response.get("text", "")
         assert actual_text == sent_texts[0]
 
     @pytest.mark.parametrize(
-        "searchTerm,caseSensitive,expectedCount",
+        "search_term,case_sensitive,expected_count",
         [
             ("test_message_1", False, 1),
             ("TEST_MESSAGE_", False, 3),
-            # ("TEST_MESSAGE_", True, 0),  # Skipped due to https://github.com/status-im/status-go/issues/6359
+            # ("TEST_MESSAGE_", True, 0), # Skipped due to https://github.com/status-im/status-go/issues/6359
         ],
     )
-    def test_all_messages_from_chat_which_match_term(self, searchTerm, caseSensitive, expectedCount):
-        self.send_multiple_one_to_one_messages(3, sender=self.sender, receiver=self.receiver)
-        sender_chat_id = self.receiver.public_key
+    def test_all_messages_from_chat_which_match_term(self, sender, receiver, search_term, case_sensitive, expected_count):
+        self.send_multiple_one_to_one_messages(3, sender=sender, receiver=receiver)
+        sender_chat_id = receiver.public_key
 
-        response = self.sender.wakuext_service.all_messages_from_chat_which_match_term(sender_chat_id, searchTerm, caseSensitive)
+        response = sender.wakuext_service.all_messages_from_chat_which_match_term(sender_chat_id, search_term, case_sensitive)
         # TODO: Add more assertions on response
 
         messages = response.get("messages", [])
-        assert len(messages) == expectedCount
+        assert len(messages) == expected_count
 
-    def test_all_messages_from_chats_and_communities_which_match_term(self):
+    def test_all_messages_from_chats_and_communities_which_match_term(self, sender, receiver):
         # One to one
-        self.make_contacts(self.sender, self.receiver)
-        sent_texts_one_to_one, _ = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        one_to_one_chat_id = self.receiver.public_key
+        self.make_contacts(sender, receiver)
+        sent_texts_one_to_one, _ = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        one_to_one_chat_id = receiver.public_key
 
         # Group
-        private_group_chat_id = self.join_private_group(admin=self.sender, member=self.receiver)
+        private_group_chat_id = self.join_private_group(admin=sender, member=receiver)
         text_group = "test_message_group"
-        response = self.sender.wakuext_service.send_group_chat_message(private_group_chat_id, text_group)
+        response = sender.wakuext_service.send_group_chat_message(private_group_chat_id, text_group)
 
         # Community
-        self.create_community(self.sender)
-        community_chat_id = self.join_community(member=self.receiver, admin=self.sender)
+        self.create_community(sender)
+        community_chat_id = self.join_community(member=receiver, admin=sender)
         text_community = "test_message_community"
-        response = self.sender.wakuext_service.send_chat_message(community_chat_id, text_community)
+        response = sender.wakuext_service.send_chat_message(community_chat_id, text_community)
 
-        response = self.sender.wakuext_service.all_messages_from_chats_and_communities_which_match_term(
+        response = sender.wakuext_service.all_messages_from_chats_and_communities_which_match_term(
             [self.community_id], [one_to_one_chat_id, private_group_chat_id], "TEST_MESSAGE", False
         )
         # TODO: Add more assertions on response
@@ -107,37 +109,37 @@ class TestFetchingChatMessages(MessengerSteps):
         assert text_community in actual_texts
 
     @pytest.mark.skip(reason="Skipped due to https://github.com/status-im/status-go/issues/6359")
-    def test_all_messages_from_chats_and_communities_which_match_term_case_sensitive(self):
+    def test_all_messages_from_chats_and_communities_which_match_term_case_sensitive(self, sender, receiver):
         # One to one
-        self.make_contacts(self.sender, self.receiver)
-        _, _ = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        one_to_one_chat_id = self.receiver.public_key
+        self.make_contacts(sender, receiver)
+        _, _ = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        one_to_one_chat_id = receiver.public_key
 
         # Group
-        private_group_chat_id = self.join_private_group(admin=self.sender, member=self.receiver)
-        self.sender.wakuext_service.send_group_chat_message(private_group_chat_id, "test_message_group")
+        private_group_chat_id = self.join_private_group(admin=sender, member=receiver)
+        sender.wakuext_service.send_group_chat_message(private_group_chat_id, "test_message_group")
 
         # Community
-        self.create_community(self.sender)
-        community_chat_id = self.join_community(member=self.receiver, admin=self.sender)
-        self.sender.wakuext_service.send_chat_message(community_chat_id, "test_message_community")
+        self.create_community(sender)
+        community_chat_id = self.join_community(member=receiver, admin=sender)
+        sender.wakuext_service.send_chat_message(community_chat_id, "test_message_community")
 
-        response = self.sender.wakuext_service.all_messages_from_chats_and_communities_which_match_term(
+        response = sender.wakuext_service.all_messages_from_chats_and_communities_which_match_term(
             [self.community_id], [one_to_one_chat_id, private_group_chat_id], "TEST_MESSAGE", True
         )
 
         messages = response.get("messages", [])
         assert len(messages) == 0
 
-    def test_first_unseen_message(self):
-        _, responses = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
-        sender_chat_id = self.receiver.public_key
+    def test_first_unseen_message(self, sender, receiver):
+        _, responses = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
+        sender_chat_id = receiver.public_key
         message_id = responses[0].get("messages", [])[0].get("id", "")
 
-        self.sender.wakuext_service.mark_message_as_unread(sender_chat_id, message_id)
+        sender.wakuext_service.mark_message_as_unread(sender_chat_id, message_id)
         # TODO: Add more assertions on response
 
-        result = self.sender.wakuext_service.first_unseen_message_id(sender_chat_id)
+        result = sender.wakuext_service.first_unseen_message_id(sender_chat_id)
         # TODO: Add more assertions on response
 
         assert result == message_id

--- a/tests-functional/tests/test_wakuext_messages_interacting.py
+++ b/tests-functional/tests/test_wakuext_messages_interacting.py
@@ -9,14 +9,16 @@ from clients.api import ApiResponseError
 @pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
 class TestInteractingWithChatMessages(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile, waku_light_client):
-        """Initialize two backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", waku_light_client=waku_light_client)
-        self.receiver = backend_new_profile("receiver", waku_light_client=waku_light_client)
+    @pytest.fixture()
+    def sender(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("sender", waku_light_client=waku_light_client)
 
-    def test_pinned_messages(self):
-        sent_texts, responses = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+    @pytest.fixture()
+    def receiver(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("receiver", waku_light_client=waku_light_client)
+
+    def test_pinned_messages(self, sender, receiver):
+        sent_texts, responses = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
 
         # pin
         message = responses[0].get("messages", [])[0]
@@ -26,11 +28,11 @@ class TestInteractingWithChatMessages(MessengerSteps):
             "pinned": True,
         }
 
-        response = self.sender.wakuext_service.send_pin_message(pin_message_payload)
+        response = sender.wakuext_service.send_pin_message(pin_message_payload)
         # TODO: Add more assertions on response
 
-        sender_chat_id = self.receiver.public_key
-        response = self.sender.wakuext_service.chat_pinned_messages(sender_chat_id)
+        sender_chat_id = receiver.public_key
+        response = sender.wakuext_service.chat_pinned_messages(sender_chat_id)
         # TODO: Add more assertions on response
 
         pinned_messages = response.get("pinnedMessages", [])
@@ -40,15 +42,15 @@ class TestInteractingWithChatMessages(MessengerSteps):
 
         # unpin
         pin_message_payload["pinned"] = False
-        self.sender.wakuext_service.send_pin_message(pin_message_payload)
-        response = self.sender.wakuext_service.chat_pinned_messages(sender_chat_id)
+        sender.wakuext_service.send_pin_message(pin_message_payload)
+        response = sender.wakuext_service.chat_pinned_messages(sender_chat_id)
 
         pinned_messages = response.get("pinnedMessages", [])
         assert pinned_messages is None
 
-    def test_pinned_messages_with_pagination(self):
-        sent_texts, responses = self.send_multiple_one_to_one_messages(5, sender=self.sender, receiver=self.receiver)
-        sender_chat_id = self.receiver.public_key
+    def test_pinned_messages_with_pagination(self, sender, receiver):
+        sent_texts, responses = self.send_multiple_one_to_one_messages(5, sender=sender, receiver=receiver)
+        sender_chat_id = receiver.public_key
 
         for response in responses:
             message = response.get("messages", [])[0]
@@ -57,10 +59,10 @@ class TestInteractingWithChatMessages(MessengerSteps):
                 "message_id": message.get("id", ""),
                 "pinned": True,
             }
-            self.sender.wakuext_service.send_pin_message(pin_message_payload)
+            sender.wakuext_service.send_pin_message(pin_message_payload)
 
         # Page 1
-        pinned_messages_res1 = self.sender.wakuext_service.chat_pinned_messages(sender_chat_id, cursor="", limit=3)
+        pinned_messages_res1 = sender.wakuext_service.chat_pinned_messages(sender_chat_id, cursor="", limit=3)
 
         cursor1 = pinned_messages_res1.get("cursor", "")
         pinned_messages_page1 = pinned_messages_res1.get("pinnedMessages", [])
@@ -71,7 +73,7 @@ class TestInteractingWithChatMessages(MessengerSteps):
         assert cursor1 != ""
 
         # Page 2
-        pinned_messages_res2 = self.sender.wakuext_service.chat_pinned_messages(sender_chat_id, cursor=cursor1, limit=3)
+        pinned_messages_res2 = sender.wakuext_service.chat_pinned_messages(sender_chat_id, cursor=cursor1, limit=3)
 
         cursor2 = pinned_messages_res2.get("cursor", "")
         pinned_messages_page2 = pinned_messages_res2.get("pinnedMessages", [])
@@ -80,92 +82,92 @@ class TestInteractingWithChatMessages(MessengerSteps):
         assert pinned_messages_page2[1].get("message", {}).get("text", "") == sent_texts[0]
         assert cursor2 == ""
 
-    def test_edit_message(self):
-        sent_texts, responses = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+    def test_edit_message(self, sender, receiver):
+        sent_texts, responses = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
         message_id = responses[0].get("messages", [])[0].get("id", "")
 
-        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        response = sender.wakuext_service.message_by_message_id(message_id)
         actual_text = response.get("text", "")
         assert actual_text == sent_texts[0]
 
         new_text = "test_message_edited"
-        response = self.sender.wakuext_service.edit_message(message_id, new_text)
+        response = sender.wakuext_service.edit_message(message_id, new_text)
         # TODO: Add more assertions on response
 
-        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        response = sender.wakuext_service.message_by_message_id(message_id)
         actual_text = response.get("text", "")
         assert actual_text == new_text
 
-    def test_delete_message(self):
-        _, responses = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+    def test_delete_message(self, sender, receiver):
+        _, responses = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
 
         message_id = responses[0].get("messages", [])[0].get("id", "")
-        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        response = sender.wakuext_service.message_by_message_id(message_id)
         assert response != {}
 
-        response = self.sender.wakuext_service.delete_message(message_id)
+        response = sender.wakuext_service.delete_message(message_id)
         # TODO: Add more assertions on response
 
         with pytest.raises(ApiResponseError, match=re.escape("record not found")):
-            self.sender.wakuext_service.message_by_message_id(message_id)
+            sender.wakuext_service.message_by_message_id(message_id)
 
-    def test_delete_message_and_send(self):
-        _, responses = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+    def test_delete_message_and_send(self, sender, receiver):
+        _, responses = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
 
         message_id = responses[0].get("messages", [])[0].get("id", "")
-        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        response = sender.wakuext_service.message_by_message_id(message_id)
         assert response != {}
 
-        response = self.sender.wakuext_service.delete_message_and_send(message_id)
+        response = sender.wakuext_service.delete_message_and_send(message_id)
         # TODO: Add more assertions on response
         removed_messages = response.get("removedMessages", [])
         assert len(removed_messages) == 1
         assert removed_messages[0].get("messageId") == message_id
 
-        message = self.sender.wakuext_service.message_by_message_id(message_id)
+        message = sender.wakuext_service.message_by_message_id(message_id)
         assert message.get("id", "") == message_id
         assert message.get("deleted", None) is True
 
-    def test_delete_messages_by_chat_id(self):
-        _, _ = self.send_multiple_one_to_one_messages(3, sender=self.sender, receiver=self.receiver)
-        sender_chat_id = self.receiver.public_key
+    def test_delete_messages_by_chat_id(self, sender, receiver):
+        _, _ = self.send_multiple_one_to_one_messages(3, sender=sender, receiver=receiver)
+        sender_chat_id = receiver.public_key
 
-        response = self.sender.wakuext_service.chat_messages(sender_chat_id)
+        response = sender.wakuext_service.chat_messages(sender_chat_id)
         messages = response.get("messages", [])
         assert len(messages) == 3
 
-        response = self.sender.wakuext_service.delete_messages_by_chat_id(sender_chat_id)
+        response = sender.wakuext_service.delete_messages_by_chat_id(sender_chat_id)
         # TODO: Add more assertions on response
 
-        response = self.sender.wakuext_service.chat_messages(sender_chat_id)
+        response = sender.wakuext_service.chat_messages(sender_chat_id)
         messages = response.get("messages", [])
         assert messages is None
 
-    def test_delete_message_for_me_and_sync(self):
-        _, responses = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+    def test_delete_message_for_me_and_sync(self, sender, receiver):
+        _, responses = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
 
         message_id = responses[0].get("messages", [])[0].get("id", "")
         local_chat_id = responses[0].get("messages", [])[0].get("localChatId", "")
-        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        response = sender.wakuext_service.message_by_message_id(message_id)
         assert response != {}
 
-        response = self.sender.wakuext_service.delete_message_for_me_and_sync(local_chat_id, message_id)
+        response = sender.wakuext_service.delete_message_for_me_and_sync(local_chat_id, message_id)
         # TODO: Add more assertions on response
 
-        message = self.sender.wakuext_service.message_by_message_id(message_id)
+        message = sender.wakuext_service.message_by_message_id(message_id)
         assert message.get("id", "") == message_id
         assert message.get("deletedForMe", None) is True
 
         # TODO: assert sync action
 
-    def test_update_message_outgoing_status(self):
-        _, responses = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+    def test_update_message_outgoing_status(self, sender, receiver):
+        _, responses = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
         message_id = responses[0].get("messages", [])[0].get("id", "")
         new_status = "delivered"
 
-        response = self.sender.wakuext_service.update_message_outgoing_status(message_id, new_status)
+        response = sender.wakuext_service.update_message_outgoing_status(message_id, new_status)
         # TODO: Add more assertions on response
 
-        response = self.sender.wakuext_service.message_by_message_id(message_id)
+        response = sender.wakuext_service.message_by_message_id(message_id)
         outgoing_status = response.get("outgoingStatus", "")
         assert outgoing_status == new_status

--- a/tests-functional/tests/test_wakuext_messages_sending.py
+++ b/tests-functional/tests/test_wakuext_messages_sending.py
@@ -11,64 +11,66 @@ from steps.messenger import MessengerSteps
 @pytest.mark.parametrize("waku_light_client", [False, True], indirect=True, ids=["wakuV2LightClient_False", "wakuV2LightClient_True"])
 class TestSendingChatMessages(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile, waku_light_client):
-        """Initialize two backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender", waku_light_client=waku_light_client)
-        self.receiver = backend_new_profile("receiver", waku_light_client=waku_light_client)
+    @pytest.fixture()
+    def sender(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("sender", waku_light_client=waku_light_client)
 
-    def test_send_one_to_one_message(self):
-        sent_texts, responses = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+    @pytest.fixture()
+    def receiver(self, backend_new_profile, waku_light_client):
+        return backend_new_profile("receiver", waku_light_client=waku_light_client)
+
+    def test_send_one_to_one_message(self, sender, receiver):
+        sent_texts, responses = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
         # TODO: Add more assertions on response
 
         chat = responses[0]["chats"][0]
-        assert chat["id"] == self.receiver.public_key
-        assert chat["lastMessage"]["displayName"] == self.sender.display_name
+        assert chat["id"] == receiver.public_key
+        assert chat["lastMessage"]["displayName"] == sender.display_name
 
-        response = self.sender.wakuext_service.chat_messages(self.receiver.public_key)
+        response = sender.wakuext_service.chat_messages(receiver.public_key)
         messages = response.get("messages", [])
         assert len(messages) == 1
         actual_text = messages[0].get("text", "")
         assert actual_text == sent_texts[0]
 
-    def test_send_chat_message_community(self):
-        self.create_community(self.sender)
-        community_chat_id = self.join_community(member=self.receiver, admin=self.sender)
+    def test_send_chat_message_community(self, sender, receiver):
+        self.create_community(sender)
+        community_chat_id = self.join_community(member=receiver, admin=sender)
 
         text = "test_message"
-        response = self.sender.wakuext_service.send_chat_message(community_chat_id, text)
+        response = sender.wakuext_service.send_chat_message(community_chat_id, text)
         # TODO: Add more assertions on response
 
-        response = self.sender.wakuext_service.chat_messages(community_chat_id)
+        response = sender.wakuext_service.chat_messages(community_chat_id)
         messages = response.get("messages", [])
         assert len(messages) == 1
         actual_text = messages[0].get("text", "")
         assert actual_text == text
 
-    def test_send_chat_message_private_group(self):
-        self.make_contacts(self.sender, self.receiver)
-        private_group_id = self.join_private_group(admin=self.sender, member=self.receiver)
+    def test_send_chat_message_private_group(self, sender, receiver):
+        self.make_contacts(sender, receiver)
+        private_group_id = self.join_private_group(admin=sender, member=receiver)
 
         text = "test_message"
-        response = self.sender.wakuext_service.send_chat_message(private_group_id, text)
+        response = sender.wakuext_service.send_chat_message(private_group_id, text)
 
-        response = self.sender.wakuext_service.chat_messages(private_group_id)
+        response = sender.wakuext_service.chat_messages(private_group_id)
         expected_message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         actual_text = expected_message.get("text", "")
         assert actual_text == text
 
-    def test_send_chat_messages_same_chat(self):
-        self.create_community(self.sender)
-        community_chat_id = self.join_community(member=self.receiver, admin=self.sender)
+    def test_send_chat_messages_same_chat(self, sender, receiver):
+        self.create_community(sender)
+        community_chat_id = self.join_community(member=receiver, admin=sender)
 
         payload = [
             SendChatMessagePayload(chat_id=community_chat_id, text=f"test_message_{i}", content_type=MessageContentType.TEXT_PLAIN.value)
             for i in range(5)
         ]
-        response = self.sender.wakuext_service.send_chat_messages(payload)
+        response = sender.wakuext_service.send_chat_messages(payload)
         # TODO: Add more assertions on response
 
-        response = self.sender.wakuext_service.chat_messages(community_chat_id)
+        response = sender.wakuext_service.chat_messages(community_chat_id)
         messages = response.get("messages", [])
         assert len(payload) == 5
 
@@ -77,35 +79,35 @@ class TestSendingChatMessages(MessengerSteps):
         expected_texts.reverse()
         assert actual_texts == expected_texts
 
-    def test_send_chat_messages_different_chats(self):
+    def test_send_chat_messages_different_chats(self, sender, receiver):
         # Group
-        self.make_contacts(self.sender, self.receiver)
-        private_group_chat_id = self.join_private_group(admin=self.sender, member=self.receiver)
+        self.make_contacts(sender, receiver)
+        private_group_chat_id = self.join_private_group(admin=sender, member=receiver)
 
         # Community
-        self.create_community(self.sender)
-        community_chat_id = self.join_community(member=self.receiver, admin=self.sender)
+        self.create_community(sender)
+        community_chat_id = self.join_community(member=receiver, admin=sender)
 
         payload = [
             SendChatMessagePayload(chat_id=private_group_chat_id, text="test_message_group", content_type=MessageContentType.TEXT_PLAIN.value),
             SendChatMessagePayload(chat_id=community_chat_id, text="test_message_community", content_type=MessageContentType.TEXT_PLAIN.value),
         ]
-        response = self.sender.wakuext_service.send_chat_messages(payload)
+        response = sender.wakuext_service.send_chat_messages(payload)
 
         chats = response.get("chats", [])
         assert len(chats) == 2
         messages = response.get("messages", [])
         assert len(messages) == 2
 
-    def test_send_group_message(self):
-        self.make_contacts(self.sender, self.receiver)
-        private_group_id = self.join_private_group(admin=self.sender, member=self.receiver)
+    def test_send_group_message(self, sender, receiver):
+        self.make_contacts(sender, receiver)
+        private_group_id = self.join_private_group(admin=sender, member=receiver)
 
         text = "test_message_group"
-        response = self.sender.wakuext_service.send_group_chat_message(private_group_id, text)
+        response = sender.wakuext_service.send_group_chat_message(private_group_id, text)
         # TODO: Add more assertions on response
 
-        response = self.sender.wakuext_service.chat_messages(private_group_id)
+        response = sender.wakuext_service.chat_messages(private_group_id)
         expected_message = self.get_message_by_content_type(response, content_type=MessageContentType.TEXT_PLAIN.value)[0]
         actual_text = expected_message.get("text", "")
         assert actual_text == text
@@ -113,27 +115,27 @@ class TestSendingChatMessages(MessengerSteps):
     # Using delete_message is a workaround that might be considered an incorrect behaviour
     # TODO: create more realistic scenario where the message is intercepted in the network and not delivered,
     # use community messages to avoid 1-1 and group chats reliability mechanisms on protocol level
-    def test_resend_one_to_one_message(self):
-        self.make_contacts(self.sender, self.receiver)
+    def test_resend_one_to_one_message(self, sender, receiver):
+        self.make_contacts(sender, receiver)
 
-        _, responses = self.send_multiple_one_to_one_messages(1, sender=self.sender, receiver=self.receiver)
+        _, responses = self.send_multiple_one_to_one_messages(1, sender=sender, receiver=receiver)
         message_id = responses[0].get("messages", [])[0].get("id", "")
-        receiver_chat_id = self.sender.public_key
+        receiver_chat_id = sender.public_key
 
-        self.receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=5)
+        receiver.find_signal_containing_pattern(SignalType.MESSAGES_NEW.value, event_pattern=message_id, timeout=5)
 
-        response = self.receiver.wakuext_service.chat_messages(receiver_chat_id)
+        response = receiver.wakuext_service.chat_messages(receiver_chat_id)
         messages = response.get("messages", [])
         assert len(messages) == 4
 
-        self.receiver.wakuext_service.delete_message(message_id)
-        response = self.receiver.wakuext_service.chat_messages(receiver_chat_id)
+        receiver.wakuext_service.delete_message(message_id)
+        response = receiver.wakuext_service.chat_messages(receiver_chat_id)
         messages = response.get("messages", [])
         assert len(messages) == 3
 
-        self.sender.wakuext_service.resend_chat_message(message_id)
+        sender.wakuext_service.resend_chat_message(message_id)
         sleep(5)
 
-        response = self.receiver.wakuext_service.chat_messages(receiver_chat_id)
+        response = receiver.wakuext_service.chat_messages(receiver_chat_id)
         messages = response.get("messages", [])
         assert len(messages) == 4

--- a/tests-functional/tests/test_wakuext_profile.py
+++ b/tests-functional/tests/test_wakuext_profile.py
@@ -6,37 +6,34 @@ from steps.messenger import MessengerSteps
 
 class TestProfile:
 
-    @pytest.fixture(autouse=True)
-    def setup_backend(self, backend_new_profile):
-        """Initialize one backend for each test function"""
-        self.rpc_client = backend_new_profile("rpc_client")
+    @pytest.fixture()
+    def rpc_client(self, backend_new_profile):
+        return backend_new_profile("rpc-client-backend")
 
-    def test_set_display_name(self):
-        self.rpc_client.wakuext_service.set_display_name("new valid username")
-        result = self.rpc_client.settings_service.get_settings()
+    def test_set_display_name(self, rpc_client):
+        rpc_client.wakuext_service.set_display_name("new valid username")
+        result = rpc_client.settings_service.get_settings()
         assert result.get("display-name") == "new valid username"
 
-    def test_set_bio(self):
-        self.rpc_client.wakuext_service.set_bio("some valid bio")
-        result = self.rpc_client.settings_service.get_settings()
+    def test_set_bio(self, rpc_client):
+        rpc_client.wakuext_service.set_bio("some valid bio")
+        result = rpc_client.settings_service.get_settings()
         assert result.get("bio") == "some valid bio"
 
-    def test_set_customization_color(self):
-        result = self.rpc_client.wakuext_service.set_customization_color(
-            "magenta", "0xea42dd9a4e668b0b76c7a5210ca81576d51cd19cdd0f6a0c22196219dc423f29"
-        )
+    def test_set_customization_color(self, rpc_client):
+        result = rpc_client.wakuext_service.set_customization_color("magenta", "0xea42dd9a4e668b0b76c7a5210ca81576d51cd19cdd0f6a0c22196219dc423f29")
         assert result is None
 
-    def test_set_user_status(self):
+    def test_set_user_status(self, rpc_client):
         status_type = 3
         status_text = "test"
-        self.rpc_client.wakuext_service.set_user_status(status_type, status_text)
-        result = self.rpc_client.settings_service.get_settings()
+        rpc_client.wakuext_service.set_user_status(status_type, status_text)
+        result = rpc_client.settings_service.get_settings()
         assert result.get("current-user-status").get("statusType") == status_type
         assert result.get("current-user-status").get("text") == status_text
 
-    def test_set_syncing_on_mobile_network(self):
-        self.rpc_client.wakuext_service.set_syncing_on_mobile_network(False)
+    def test_set_syncing_on_mobile_network(self, rpc_client):
+        rpc_client.wakuext_service.set_syncing_on_mobile_network(False)
 
     @pytest.mark.parametrize(
         "setting_name, default_value, changed_value",
@@ -58,15 +55,15 @@ class TestProfile:
             ),  # obsolete from v1
         ],
     )
-    def test_settings_(self, setting_name, default_value, changed_value):
+    def test_settings_(self, rpc_client, setting_name, default_value, changed_value):
         logging.info("Step: check that %s is %s by default " % (setting_name, default_value))
-        response = self.rpc_client.settings_service.get_settings()
+        response = rpc_client.settings_service.get_settings()
         assert response[setting_name] == default_value
 
         logging.info("Step: change %s to %s and check it is updated" % (setting_name, changed_value))
         # settings_saveSetting -> settings_service.saveSetting
-        self.rpc_client.settings_service.save_setting(setting_name, changed_value)
-        response = self.rpc_client.settings_service.get_settings()
+        rpc_client.settings_service.save_setting(setting_name, changed_value)
+        response = rpc_client.settings_service.get_settings()
         assert response[setting_name] == changed_value
 
     # tests for `omitempty` params that are set to False or nil by default
@@ -91,15 +88,15 @@ class TestProfile:
             ("collectible-group-by-community?", True),
         ],
     )
-    def test_omitempty_false_(self, setting_name, set_value):
-        logging.info("Step: assert that %s is not retrieved in settings before setting" % (setting_name))
-        response = self.rpc_client.settings_service.get_settings()
+    def test_omitempty_false_(self, rpc_client, setting_name, set_value):
+        logging.info("Step: assert that %s is not retrieved in settings before setting" % setting_name)
+        response = rpc_client.settings_service.get_settings()
         assert setting_name not in response
 
         logging.info("Step: change %s to %s and check it is updated" % (setting_name, set_value))
         # settings_saveSetting -> settings_service.saveSetting
-        self.rpc_client.settings_service.save_setting(setting_name, set_value)
-        response = self.rpc_client.settings_service.get_settings()
+        rpc_client.settings_service.save_setting(setting_name, set_value)
+        response = rpc_client.settings_service.get_settings()
         assert response[setting_name] == set_value
 
     # tests for `omitempty` params that are not nil by default
@@ -115,45 +112,47 @@ class TestProfile:
             ("url-unfurling-mode", 0),
         ],
     )
-    def test_omitempty_true_(self, setting_name, set_value):
-        logging.info("Step: assert that %s is  retrieved in settings before unsetting" % (setting_name))
-        response = self.rpc_client.settings_service.get_settings()
+    def test_omitempty_true_(self, rpc_client, setting_name, set_value):
+        logging.info("Step: assert that %s is  retrieved in settings before unsetting" % setting_name)
+        response = rpc_client.settings_service.get_settings()
         assert setting_name in response
 
         logging.info("Step: change %s to %s and check it is updated and does not retrieve anymore" % (setting_name, set_value))
         # settings_saveSetting -> settings_service.saveSetting
-        self.rpc_client.settings_service.save_setting(setting_name, set_value)
-        response = self.rpc_client.settings_service.get_settings()
+        rpc_client.settings_service.save_setting(setting_name, set_value)
+        response = rpc_client.settings_service.get_settings()
         assert setting_name not in response
 
 
 @pytest.mark.rpc
 class TestUserStatus(MessengerSteps):
 
-    @pytest.fixture(autouse=True)
-    def setup_backends(self, backend_new_profile):
-        """Initialize two unprivileged backends (sender and receiver) for each test function"""
-        self.sender = backend_new_profile("sender")
-        self.receiver = backend_new_profile("receiver")
+    @pytest.fixture()
+    def sender(self, backend_new_profile):
+        return backend_new_profile("sender")
 
-    def test_status_updates(self):
-        self.make_contacts(sender=self.sender, receiver=self.receiver)
+    @pytest.fixture()
+    def receiver(self, backend_new_profile):
+        return backend_new_profile("receiver")
+
+    def test_status_updates(self, sender, receiver):
+        self.make_contacts(sender=sender, receiver=receiver)
 
         statuses = [[1, "text_1"], [2, "text_2"], [3, "text_3"], [4, "text_4"]]
 
         for new_status, custom_text in statuses:
-            response = self.sender.wakuext_service.set_user_status(new_status, custom_text)
+            response = sender.wakuext_service.set_user_status(new_status, custom_text)
             # TODO: Add more assertions on response
 
-            self.receiver.find_signal_containing_pattern(
+            receiver.find_signal_containing_pattern(
                 SignalType.MESSAGES_NEW.value,
                 event_pattern=custom_text,
                 timeout=10,
             )
 
-            response = self.receiver.wakuext_service.status_updates()
+            response = receiver.wakuext_service.status_updates()
             # TODO: Add more assertions on response
 
-            statusUpdate = response.get("statusUpdates", [])[0]
-            assert statusUpdate.get("statusType", -1) == new_status
-            assert statusUpdate.get("text", "") == custom_text
+            status_update = response.get("statusUpdates", [])[0]
+            assert status_update.get("statusType", -1) == new_status
+            assert status_update.get("text", "") == custom_text


### PR DESCRIPTION
Remove usage of setup_backends fixture

Replace it with a more transparent approach.

Important changes:
- [x] Refactor all setup_backends usages
- [x] Update documentation

Closes [#7088](https://github.com/status-im/status-go/issues/7088)
