### PR TITLE
fix: prevent downgrading migration versions in migration tables

### DIFF
--- a/sqlite/migrate.go
+++ b/sqlite/migrate.go
@@ -220,7 +220,19 @@ func UpdateMigrationTableVersion(db *sql.DB, migrationTableName string, assetNam
 		return err
 	}
 
-	if !exists {
+	storedVersion := uint(0)
+
+	if exists {
+		dirty := false
+		row = tx.QueryRow(fmt.Sprintf("SELECT version, dirty FROM %s", migrationTableName))
+		err = row.Scan(&storedVersion, &dirty)
+		if err != nil && err != sql.ErrNoRows {
+			return err
+		}
+		if dirty {
+			return fmt.Errorf("cannot update migration table version; current table %s is dirty at version %d", migrationTableName, storedVersion)
+		}
+	} else {
 		createTable := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (version uint64, dirty bool);`, migrationTableName)
 		_, err = tx.Exec(createTable)
 		if err != nil {
@@ -233,8 +245,9 @@ func UpdateMigrationTableVersion(db *sql.DB, migrationTableName string, assetNam
 		}
 	}
 
-	version := getMaxMigrationVersion(assetNames, maxVersion)
-	if version > 0 {
+	targetVersion := getMaxMigrationVersion(assetNames, maxVersion)
+	// Never downgrade the version in the migration table!
+	if targetVersion > 0 && targetVersion > storedVersion {
 		// #nosec G201 -- migrationTableName is a trusted constant, not user input
 		deleteQuery := fmt.Sprintf("DELETE FROM %s", migrationTableName)
 		_, err = tx.Exec(deleteQuery)
@@ -243,7 +256,7 @@ func UpdateMigrationTableVersion(db *sql.DB, migrationTableName string, assetNam
 		}
 
 		insertVersion := fmt.Sprintf(`INSERT INTO %s (version, dirty)`, migrationTableName) + `VALUES (?, ?)`
-		_, err = tx.Exec(insertVersion, version, false)
+		_, err = tx.Exec(insertVersion, targetVersion, false)
 		if err != nil {
 			return err
 		}

--- a/sqlite/migrate_test.go
+++ b/sqlite/migrate_test.go
@@ -1,0 +1,81 @@
+package sqlite
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Scenario:
+// - The parent module currently reports migrations up to version 4.
+// - A subset of those migrations (e.g., 1, 2, and 5) is moved into a new submodule.
+// - The submodule applies the remaining migrations that weren't ran in the parent.
+// - Additional migrations are then added and executed within the submodule.
+func TestUpdateMigrationTableVersion(t *testing.T) {
+	db, err := OpenDB(":memory:", "password", 3200)
+	require.NoError(t, err)
+
+	migrationTableName := "schema_migrations_submodule"
+
+	checkVersion := func(expectedVersion uint) {
+		row := db.QueryRow(fmt.Sprintf(`SELECT version, dirty FROM %s`, migrationTableName))
+		var version uint64
+		var dirty bool
+		require.NoError(t, row.Scan(&version, &dirty))
+		require.EqualValues(t, expectedVersion, version)
+		require.False(t, dirty)
+	}
+
+	simulateMigration := func(newVersion uint) {
+		r, err := db.Exec(fmt.Sprintf(`UPDATE %s SET version = ?`, migrationTableName), newVersion)
+		require.NoError(t, err)
+		affected, err := r.RowsAffected()
+		require.NoError(t, err)
+		require.EqualValues(t, 1, affected)
+	}
+
+	assetNames := []string{
+		"1_A.up.sql",
+		"2_B.up.sql",
+		"5_E.up.sql",
+	}
+
+	currentParentVersion := uint(4)
+	currentVersion := uint(2)
+
+	// Initial migration table setup
+	err = UpdateMigrationTableVersion(db, migrationTableName, assetNames, currentParentVersion)
+	require.NoError(t, err)
+	checkVersion(currentVersion)
+
+	// Simulate the migration to version 5
+	currentVersion = 5
+	simulateMigration(currentVersion)
+	checkVersion(currentVersion)
+
+	// Invoke `UpdateMigrationTableVersion` again
+	err = UpdateMigrationTableVersion(db, migrationTableName, assetNames, currentParentVersion)
+	require.NoError(t, err)
+	// Verify version remains at 5
+	checkVersion(currentVersion)
+
+	// Add new migration and update to it
+	assetNames = append(assetNames, "6_F.up.sql")
+	currentVersion = 6
+	simulateMigration(currentVersion)
+	checkVersion(currentVersion)
+
+	// Invoke `UpdateMigrationTableVersion` once again
+	err = UpdateMigrationTableVersion(db, migrationTableName, assetNames, currentParentVersion)
+	require.NoError(t, err)
+	// Verify version remains at 6
+	checkVersion(currentVersion)
+
+	// Simulate parent module updating to version 10
+	currentParentVersion = 10
+	err = UpdateMigrationTableVersion(db, migrationTableName, assetNames, currentParentVersion)
+	require.NoError(t, err)
+	// Verify version remains at 6
+	checkVersion(currentVersion)
+}


### PR DESCRIPTION
`UpdateMigrationTableVersion` is invoked for each module that provides its own migration table, which effectively capped the module's migration version at the protocol's maximum version. As a result, migration versions could not advance beyond the current protocol version, causing new module migrations to be re-applied repeatedly on each login.

The fix ensures that migration versions are never downgraded.
