### PR TITLE
chore: improve error reporting when joining community

### DIFF
--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -3942,7 +3942,7 @@ func (m *Manager) SaveRequestToJoinAndCommunity(requestToJoin *RequestToJoin, co
 	return community, requestToJoin, nil
 }
 
-func (m *Manager) CreateRequestToJoin(request *requests.RequestToJoinCommunity, customizationColor multiaccountscommon.CustomizationColor) *RequestToJoin {
+func (m *Manager) CreateRequestToJoin(request *requests.RequestToJoinCommunity, customizationColor multiaccountscommon.CustomizationColor) (*RequestToJoin, error) {
 	clock := uint64(time.Now().Unix())
 	requestToJoin := &RequestToJoin{
 		PublicKey:            crypto.PubkeyToHex(&m.identity.PublicKey),
@@ -3958,21 +3958,20 @@ func (m *Manager) CreateRequestToJoin(request *requests.RequestToJoinCommunity, 
 
 	requestToJoin.CalculateID()
 
-	addSignature := len(request.Signatures) == len(request.AddressesToReveal)
+	if len(request.Signatures) != len(request.AddressesToReveal) {
+		return nil, errors.New("number of signatures does not match number of addresses to reveal")
+	}
+
 	for i := range request.AddressesToReveal {
 		revealedAcc := &protobuf.RevealedAccount{
 			Address:          request.AddressesToReveal[i],
+			Signature:        request.Signatures[i],
 			IsAirdropAddress: types.HexToAddress(request.AddressesToReveal[i]) == types.HexToAddress(request.AirdropAddress),
 		}
-
-		if addSignature {
-			revealedAcc.Signature = request.Signatures[i]
-		}
-
 		requestToJoin.RevealedAccounts = append(requestToJoin.RevealedAccounts, revealedAcc)
 	}
 
-	return requestToJoin
+	return requestToJoin, nil
 }
 
 func (m *Manager) SaveRequestToJoin(request *RequestToJoin) error {

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	hexutil "github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
@@ -426,8 +426,8 @@ func setUpOnRequestCommunityAndRoles(base CommunityEventsTestsInterface, role pr
 
 	joinOnRequestCommunity(s, community.ID(), base.GetControlNode(), base.GetEventSender(), password, accounts)
 
-	accounts = accountsTestData[base.GetEventSender().IdentityPublicKeyString()]
-	password = accountsPasswords[base.GetEventSender().IdentityPublicKeyString()]
+	accounts = accountsTestData[base.GetMember().IdentityPublicKeyString()]
+	password = accountsPasswords[base.GetMember().IdentityPublicKeyString()]
 
 	joinOnRequestCommunity(s, community.ID(), base.GetControlNode(), base.GetMember(), password, accounts)
 

--- a/protocol/communities_messenger_shared_member_address_test.go
+++ b/protocol/communities_messenger_shared_member_address_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
-	hexutil "github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
@@ -204,8 +204,8 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) TestJoinedCommunityMember
 	advertiseCommunityTo(&s.Suite, community, s.owner, s.alice)
 	advertiseCommunityTo(&s.Suite, community, s.owner, s.bob)
 
-	s.joinCommunity(community, s.alice, alicePassword, []string{})
-	s.joinCommunity(community, s.bob, bobPassword, []string{})
+	s.joinCommunity(community, s.alice, alicePassword, []string{aliceAddress1, aliceAddress2})
+	s.joinCommunity(community, s.bob, bobPassword, []string{bobAddress})
 
 	community, err := s.owner.GetCommunityByID(community.ID())
 	s.Require().NoError(err)
@@ -435,7 +435,7 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) TestSharedAddressesReturn
 
 	advertiseCommunityTo(&s.Suite, community, s.owner, s.alice)
 
-	s.joinCommunity(community, s.alice, alicePassword, []string{})
+	s.joinCommunity(community, s.alice, alicePassword, []string{aliceAddress1, aliceAddress2})
 
 	revealedAccounts, err := s.alice.GetRevealedAccounts(community.ID(), crypto.PubkeyToHex(&s.alice.identity.PublicKey))
 	s.Require().NoError(err)

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -3555,7 +3555,8 @@ func (s *MessengerCommunitiesSuite) TestCommunityBanUserRequestToJoin() {
 
 	request := s.createRequestToJoinCommunity(community.ID(), s.alice)
 	// We try to join the org
-	rtj := s.alice.communitiesManager.CreateRequestToJoin(request, s.alice.account.GetCustomizationColor())
+	rtj, err := s.alice.communitiesManager.CreateRequestToJoin(request, s.alice.account.GetCustomizationColor())
+	s.Require().NoError(err)
 
 	s.Require().NoError(err)
 

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -26,10 +26,6 @@ func (s *MessengerActivityCenterMessageSuite) advertiseCommunityTo(community *co
 	advertiseCommunityTo(&s.Suite, community, owner, user)
 }
 
-func (s *MessengerActivityCenterMessageSuite) joinCommunity(community *communities.Community, owner *Messenger, user *Messenger) {
-	joinCommunity(&s.Suite, community.ID(), owner, user, accountPassword, []string{commonAccountAddress})
-}
-
 type MessengerActivityCenterMessageSuite struct {
 	CommunitiesMessengerTestSuiteBase
 	m *Messenger // main instance of Messenger
@@ -115,7 +111,7 @@ func (s *MessengerActivityCenterMessageSuite) TestEveryoneMentionTag() {
 
 	// Alice joins the community
 	s.advertiseCommunityTo(community, bob, alice)
-	s.joinCommunity(community, bob, alice)
+	joinCommunity(&s.Suite, community.ID(), bob, alice, accountPassword, []string{aliceAccountAddress})
 
 	// alice sends a community message
 	inputMessage := common.NewMessage()
@@ -162,7 +158,7 @@ func (s *MessengerActivityCenterMessageSuite) TestReplyWithImage() {
 
 	// Alice joins the community
 	s.advertiseCommunityTo(community, bob, alice)
-	s.joinCommunity(community, bob, alice)
+	joinCommunity(&s.Suite, community.ID(), bob, alice, accountPassword, []string{aliceAccountAddress})
 
 	// Alice sends a community message
 	inputMessage := common.NewMessage()
@@ -237,7 +233,7 @@ func (s *MessengerActivityCenterMessageSuite) TestMuteCommunityActivityCenterNot
 
 	// Alice joins the community
 	s.advertiseCommunityTo(community, bob, alice)
-	s.joinCommunity(community, bob, alice)
+	joinCommunity(&s.Suite, community.ID(), bob, alice, accountPassword, []string{aliceAccountAddress})
 
 	// Bob mutes the community
 	time, err := bob.MuteAllCommunityChats(&requests.MuteCommunity{
@@ -287,7 +283,7 @@ func (s *MessengerActivityCenterMessageSuite) TestReadCommunityOverviewNotificat
 
 	// Alice joins the community
 	s.advertiseCommunityTo(community, bob, alice)
-	s.joinCommunity(community, bob, alice)
+	joinCommunity(&s.Suite, community.ID(), bob, alice, accountPassword, []string{aliceAccountAddress})
 
 	// Mark community overview notification read
 	err := alice.DismissActivityCenterNotificationsByCommunity(context.Background(), &requests.DismissCommunityNotifications{CommunityID: community.ID()})
@@ -310,7 +306,7 @@ func (s *MessengerActivityCenterMessageSuite) prepareCommunityChannelWithMention
 
 	// Alice joins the community
 	s.advertiseCommunityTo(community, bob, alice)
-	s.joinCommunity(community, bob, alice)
+	joinCommunity(&s.Suite, community.ID(), bob, alice, accountPassword, []string{aliceAccountAddress})
 
 	// Bob sends a mention message
 	mentionMessage := common.NewMessage()
@@ -495,7 +491,7 @@ func (s *MessengerActivityCenterMessageSuite) TestAliceDoesNotReceiveCommunityNo
 
 	// Alice joins the community
 	s.advertiseCommunityTo(community, bob, alice)
-	s.joinCommunity(community, bob, alice)
+	joinCommunity(&s.Suite, community.ID(), bob, alice, accountPassword, []string{aliceAccountAddress})
 
 	// Bob sends an another mention message
 	mentionMessage = common.NewMessage()

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1263,29 +1263,36 @@ func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, com
 		return nil, err
 	}
 
-	containsAddress := func(addresses []string, targetAddress string) bool {
-		for _, address := range addresses {
-			if types.HexToAddress(address) == types.HexToAddress(targetAddress) {
-				return true
-			}
-		}
-		return false
+	if len(addressesToReveal) == 0 {
+		return nil, nil
+	}
+
+	walletAccountsMap := make(map[string]*accsmanagementtypes.Account, len(walletAccounts))
+	for _, walletAccount := range walletAccounts {
+		addressHex := strings.ToLower(walletAccount.Address.Hex())
+		walletAccountsMap[addressHex] = walletAccount
 	}
 
 	msgsToSign := make([]personal.SignParams, 0)
-	for _, walletAccount := range walletAccounts {
-		if walletAccount.Chat || walletAccount.Type == accsmanagementtypes.AccountTypeWatch {
-			continue
+	for _, address := range addressesToReveal {
+		walletAccount, ok := walletAccountsMap[strings.ToLower(address)]
+		if !ok {
+			return nil, fmt.Errorf("address %s not found in wallet", address)
 		}
 
-		if len(addressesToReveal) > 0 && !containsAddress(addressesToReveal, walletAccount.Address.Hex()) {
-			continue
+		if walletAccount.Chat {
+			return nil, fmt.Errorf("address %s is a chat account", address)
+		}
+
+		if walletAccount.Type == accsmanagementtypes.AccountTypeWatch {
+			return nil, fmt.Errorf("address %s is a watch account", address)
 		}
 
 		requestID := []byte{}
 		if !isEdit {
 			requestID = communities.CalculateRequestID(memberPubKey, communityID)
 		}
+
 		msgsToSign = append(msgsToSign, personal.SignParams{
 			Data:    types.EncodeHex(crypto.Keccak256(m.IdentityPublicKeyCompressed(), communityID, requestID)),
 			Address: walletAccount.Address.Hex(),

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1371,7 +1371,10 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 		return nil, communities.ErrAlreadyJoined
 	}
 
-	requestToJoin := m.communitiesManager.CreateRequestToJoin(request, m.account.GetCustomizationColor())
+	requestToJoin, err := m.communitiesManager.CreateRequestToJoin(request, m.account.GetCustomizationColor())
+	if err != nil {
+		return nil, err
+	}
 
 	if len(request.AddressesToReveal) > 0 {
 		revealedAddresses := make([]gethcommon.Address, 0)

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1264,7 +1264,7 @@ func (m *Messenger) generateCommunityRequestsForSigning(memberPubKey string, com
 	}
 
 	if len(addressesToReveal) == 0 {
-		return nil, nil
+		return nil, errors.New("no addresses to reveal")
 	}
 
 	walletAccountsMap := make(map[string]*accsmanagementtypes.Account, len(walletAccounts))
@@ -1361,7 +1361,7 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 	// TODO: Because of changes that need to be done in tests, calling this function and providing `request` without `AddressesToReveal`
 	//       is not an error, but it should be.
 	logger := m.logger.Named("RequestToJoinCommunity")
-	logger.Debug("Addresses to reveal", zap.Any("Addresses:", request.AddressesToReveal))
+	logger.Debug("addresses to reveal", zap.Strings("addresses", request.AddressesToReveal))
 
 	if err := request.Validate(); err != nil {
 		logger.Debug("request failed to validate", zap.Error(err), zap.Any("request", request))

--- a/protocol/messenger_delete_message_for_everyone_test.go
+++ b/protocol/messenger_delete_message_for_everyone_test.go
@@ -28,7 +28,7 @@ type MessengerDeleteMessageForEveryoneSuite struct {
 func (s *MessengerDeleteMessageForEveryoneSuite) SetupTest() {
 	s.CommunitiesMessengerTestSuiteBase.SetupTest()
 	s.admin = s.newMessenger("", []string{})
-	s.bob = s.newMessenger(bobPassword, []string{bobPassword})
+	s.bob = s.newMessenger(bobPassword, []string{bobAddress})
 	s.moderator = s.newMessenger(aliceAccountAddress, []string{aliceAddress1})
 
 	_, err := s.admin.Start()

--- a/protocol/messenger_profile_showcase_test.go
+++ b/protocol/messenger_profile_showcase_test.go
@@ -36,7 +36,7 @@ type TestMessengerProfileShowcase struct {
 
 func (s *TestMessengerProfileShowcase) SetupTest() {
 	s.CommunitiesMessengerTestSuiteBase.SetupTest()
-	s.m = s.newMessenger("", []string{})
+	s.m = s.newMessenger(alicePassword, []string{aliceAddress1})
 	_, err := s.m.Start()
 	s.Require().NoError(err)
 }
@@ -765,7 +765,12 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesGrantExpires(
 func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesDispatchOnGrantUpdate() {
 	grantInvokesProfileDispatchIntervalBackup := grantInvokesProfileDispatchInterval
 	grantInvokesProfileDispatchInterval = 1 * time.Millisecond
+
+	//s.m = s.newMessenger(alicePassword, []string{aliceAddress1})
 	alice := s.m
+	//_, err := alice.Start()
+	//s.Require().NoError(err)
+	//defer TearDownMessenger(&s.Suite, alice)
 
 	// Set Display name to pass shouldPublishChatIdentity check
 	profileKp, _, _, err := accounts.GetProfileKeypairForTest(true, false, false)
@@ -803,7 +808,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesDispatchOnGra
 	advertiseCommunityTo(&s.Suite, community, owner, bob)
 
 	alice.communitiesManager.PermissionChecker = &testPermissionChecker{}
-	joinCommunity(&s.Suite, community.ID(), owner, alice, aliceAccountAddress, []string{aliceAddress1})
+	joinCommunity(&s.Suite, community.ID(), owner, alice, alicePassword, []string{aliceAddress1})
 
 	joinedCommunities, err := alice.communitiesManager.Joined()
 	s.Require().NoError(err)

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -11,13 +11,17 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
 
+	"github.com/status-im/status-go/accounts-management/generator"
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/crypto/types"
+	"github.com/status-im/status-go/multiaccounts/accounts"
 	"github.com/status-im/status-go/pkg/testutils"
 	"github.com/status-im/status-go/protocol/common"
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/contacts"
+	mock_protocol_accounts_manager "github.com/status-im/status-go/protocol/mock"
 	"github.com/status-im/status-go/protocol/protobuf"
 	"github.com/status-im/status-go/protocol/pushnotificationclient"
 	"github.com/status-im/status-go/protocol/pushnotificationserver"
@@ -932,6 +936,20 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 		}
 		return nil
 	})
+
+	ctrl := gomock.NewController(s.T())
+	accountsManagerMock := mock_protocol_accounts_manager.NewMockAccountsManager(ctrl)
+	accountsManagerMock.EXPECT().GetVerifiedWalletAccount(gomock.Any(), gomock.Any()).
+		Return(generator.NewAccount(nil, nil), nil).AnyTimes()
+
+	alice.accountsManager = accountsManagerMock
+
+	// add wallet account with keypair
+	kp, _, _, err := accounts.GetProfileKeypairForTest(false, true, false)
+	s.Require().NoError(err)
+	kp.Accounts[0].Address = types.HexToAddress(aliceAddress1)
+	err = alice.settings.SaveOrUpdateKeypair(kp)
+	s.Require().NoError(err)
 
 	request := createRequestToJoinCommunity(&s.Suite, community.ID(), alice, alicePassword, []string{aliceAddress1})
 	alice.communitiesManager.PermissionChecker = &testPermissionChecker{}


### PR DESCRIPTION
Some findings during implementing https://github.com/status-im/status-go/pull/7113

# Description

1. `CreateRequestToJoin` - return error if not enough `Signatures` was provided

2. `generateCommunityRequestsForSigning` - return error if any of given addresses to reveal was not found in wallet accounts, or was found, but didn't match requirements (non-chat & non-watch).