### PR TITLE
feat(tests-functional): support `--logs-dir` in non-docker mode

### DIFF
--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -115,25 +115,35 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         if self.container:
             self.container.shutdown(log_sufix)
 
-        if not self.container and Config.logs_dir:
-            timestamp = time.time()
-            log_identifier = self.base_url.replace("http://", "").replace(":", "-")
-            log_name = f"status-backend_{timestamp}_{log_sufix}_{log_identifier}"
-
-            # Create logs subdirectory
-            log_dir_path = os.path.join(Config.logs_dir, log_name)
-            os.makedirs(log_dir_path, exist_ok=True)
-
-            # Copy all .log files from data_dir to log_dir_path
-            for filename in os.listdir(self.data_dir):
-                if not filename.endswith(".log"):
-                    continue
-                src_path = os.path.join(self.data_dir, filename)
-                dst_path = os.path.join(log_dir_path, filename)
-                shutil.copy2(src_path, dst_path)
+        if Config.logs_dir:
+            try:
+                self._export_logs(Config.logs_dir, log_sufix)
+            except Exception as e:
+                logging.warning(f"Failed to export logs: {e}")
 
         if self.temp_dir is not None:
             self.temp_dir.cleanup()
+
+    def _export_logs(self, logs_dir: str, log_sufix: str):
+        if self.container:
+            # Container logs are exported by StatusGoContainer
+            return
+
+        timestamp = time.time()
+        log_identifier = self.base_url.replace("http://", "").replace(":", "-")
+        log_name = f"status-backend_{timestamp}_{log_sufix}_{log_identifier}"
+
+        # Create logs subdirectory
+        log_dir_path = os.path.join(logs_dir, log_name)
+        os.makedirs(log_dir_path, exist_ok=True)
+
+        # Copy all .log files from data_dir to log_dir_path
+        for filename in os.listdir(self.data_dir):
+            if not filename.endswith(".log"):
+                continue
+            src_path = os.path.join(self.data_dir, filename)
+            dst_path = os.path.join(log_dir_path, filename)
+            shutil.copy2(src_path, dst_path)
 
     @retry(
         stop=stop_after_delay(10),

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -3,6 +3,7 @@ import itertools
 import json
 import logging
 import os
+import shutil
 import tempfile
 import time
 import uuid
@@ -113,6 +114,23 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
 
         if self.container:
             self.container.shutdown(log_sufix)
+
+        if not self.container and Config.logs_dir:
+            timestamp = time.time()
+            log_identifier = self.base_url.replace("http://", "").replace(":", "-")
+            log_name = f"status-backend_{timestamp}_{log_sufix}_{log_identifier}"
+
+            # Create logs subdirectory
+            log_dir_path = os.path.join(Config.logs_dir, log_name)
+            os.makedirs(log_dir_path, exist_ok=True)
+
+            # Copy all .log files from data_dir to log_dir_path
+            for filename in os.listdir(self.data_dir):
+                if not filename.endswith(".log"):
+                    continue
+                src_path = os.path.join(self.data_dir, filename)
+                dst_path = os.path.join(log_dir_path, filename)
+                shutil.copy2(src_path, dst_path)
 
         if self.temp_dir is not None:
             self.temp_dir.cleanup()


### PR DESCRIPTION
# Description

Even when running locally, it's sometimes handy to copy the logs to `--logs-dir`, because by default backend runs in a temporary directory, and going into it is not easy. Backend logs can be seen in the app console, but `api.log` is only written to file.