### PR TITLE
fix: migration check using merge base

### DIFF
--- a/_assets/scripts/migration_check.sh
+++ b/_assets/scripts/migration_check.sh
@@ -59,9 +59,16 @@ git checkout -
 for MIGRATION_DIR in "${MIGRATION_DIRS[@]}"; do
   echo -e "${GRN}Checking migrations:${RST} ${MIGRATION_DIR}"
 
-  # Collect files from base and from current diff
+  # Compute the common ancestor (merge-base) between BASE_COMMIT and HEAD
+  merge_base=$(git merge-base "${BASE_COMMIT}" HEAD) || { echo "no merge-base"; exit 1; }
+
+  # Files present in BASE_COMMIT
   base_files=$(git ls-tree -r --name-only ${BASE_COMMIT} ${MIGRATION_DIR}/*.sql | sort)
-  new_files=$(git diff --name-only ${BASE_COMMIT} ${MIGRATION_DIR}/*.sql | sort)
+
+  # Files changed on this branch since the merge-base
+  new_files=$(git diff --name-only ${merge_base}...HEAD ${MIGRATION_DIR}/*.sql | sort)
+
+  # Combine lists
   all_files=$(echo -e "$base_files\n$new_files")
 
   # Regex validation: ONLY verify newly added/changed files match ^[0-9]{10}_ prefix

--- a/_assets/scripts/migration_check.sh
+++ b/_assets/scripts/migration_check.sh
@@ -45,8 +45,14 @@ BASE_COMMIT=${1:-origin/${BASE_BRANCH}}
 
 MIGRATION_DIRS=( \
   "protocol/migrations/sqlite" \
+  "protocol/pushnotificationclient/migrations/migrations/sqlite" \
+  "protocol/pushnotificationserver/migrations/migrations/sqlite" \
   "appdatabase/migrations/sql" \
-  "protocol/encryption/migrations/sqlite" \
+  "messaging/common/migrations/sqlite" \
+  "messaging/waku/migrations/migrations/sqlite" \
+  "messaging/layers/encryption/migrations/migrations/sqlite" \
+  "messaging/layers/transport/migrations/migrations/sqlite" \
+  "services/newsfeed/migrations/migrations/sqlite" \
   "walletdatabase/migrations/sql" \
 )
 


### PR DESCRIPTION
Iterates https://github.com/status-im/status-go/issues/7103

# Description

1. Script wasn't behaving correctly when migrations were modified on `BASE_BRANCH` (e.g. moved/deleted).
Fixed this by only calculating `new_files` as the diff between current commit and merge-base.

2. Added all migrations paths to the check