### PR TITLE
chore: use system nim always

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,24 @@ ENV CC=clang
 ENV CXX=clang++
 
 RUN apt-get update \
-    && apt-get install -y git bash make llvm clang protobuf-compiler build-essential pkg-config \
+    && apt-get install -y git bash make llvm clang protobuf-compiler build-essential pkg-config curl xz-utils \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Nim using choosenim
+ARG NIM_VERSION=2.2.4
+ENV CHOOSENIM_NO_ANALYTICS=1
+RUN curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y \
+    && /root/.nimble/bin/choosenim ${NIM_VERSION}
+
+ENV PATH="/root/.nimble/bin:${PATH}"
+
+# Create system-wide symlinks for Nim binaries
+RUN ln -sf /root/.choosenim/toolchains/nim-${NIM_VERSION}/bin/nim /usr/local/bin/nim \
+    && ln -sf /root/.choosenim/toolchains/nim-${NIM_VERSION}/bin/nimble /usr/local/bin/nimble \
+    && ln -sf /root/.choosenim/toolchains/nim-${NIM_VERSION}/bin/choosenim /usr/local/bin/choosenim \
+    && chmod 755 /root/.choosenim/toolchains/nim-${NIM_VERSION}/bin/* \
+    && nim --version
 
 ARG build_tags='gowaku_no_rln'
 ARG build_flags=''

--- a/Makefile
+++ b/Makefile
@@ -217,8 +217,7 @@ $(GO_CMD_BUILDS): ##@build Build any Go project from cmd folder
 # Flag needed by nim-based dependencies (e.g., nwaku and nim-sds) that also use nimbus-build-system.
 # When USE_SYSTEM_NIM=1 skips compiling Nim compiler locally and instead,
 # enforces to use system-installed Nim.
-# This is not needed if nim dependencies use nimble.
-USE_SYSTEM_NIM ?= 0
+USE_SYSTEM_NIM ?= 1
 
 # Libwaku targets
 


### PR DESCRIPTION
To avoid running into issues like this on windows
```
[2025-12-08T15:14:54.159Z] fatal: '$GIT_DIR' too big

[2025-12-08T15:14:54.159Z] fatal: clone of
'https://github.com/nim-lang/checksums.git' into submodule path
'J:/Users/jenkins/workspace/_windows_x86_64_package_PR-18965/vendor/status-go/Usersjenkinsworkspace_windows_x86_64_package_PR-18965@tmp/nim-sds/vendor/nimbus-build-system/vendor/Nim/dist/nimble/vendor/checksums'
failed
```

