### PR TITLE
feat: add api to refetch tx history

### DIFF
--- a/services/wallet/activityfetcher/alchemy/manager.go
+++ b/services/wallet/activityfetcher/alchemy/manager.go
@@ -64,3 +64,7 @@ func (m *Manager) FetchActivity(ctx context.Context, chainID uint64, parameters 
 		NextCursor:     nextCursor,
 	}, nil
 }
+
+func (m *Manager) ClearAll(ctx context.Context) error {
+	return m.persistence.ClearAll(ctx)
+}

--- a/services/wallet/activityfetcher/manager.go
+++ b/services/wallet/activityfetcher/manager.go
@@ -23,6 +23,7 @@ type ManagerIface interface {
 	IsChainSupported(chainID uint64) bool
 	FetchActivity(ctx context.Context, chainID uint64, account gethcommon.Address, currentBlock uint64) (thirdparty.ActivityEntryContainer, error)
 	GetLastFetchedBlockAndTimestamp(ctx context.Context, chainID uint64, address gethcommon.Address) (*gethrpc.BlockNumber, *time.Time, error)
+	ClearAll(ctx context.Context) error
 }
 
 type Manager struct {
@@ -103,4 +104,8 @@ func (m *Manager) FetchActivity(ctx context.Context, chainID uint64, account get
 		zap.Duration("duration", duration))
 
 	return activity, nil
+}
+
+func (m *Manager) ClearAll(ctx context.Context) error {
+	return m.fetcher.ClearAll(ctx)
 }

--- a/services/wallet/activityfetcher/service.go
+++ b/services/wallet/activityfetcher/service.go
@@ -460,3 +460,17 @@ func (s *Service) fetchActivity(ctx context.Context, chainID uint64, account get
 		return
 	}
 }
+
+func (s *Service) RefetchTxHistory() error {
+	s.logger.Info("Refetching tx history")
+
+	err := s.activityFetcherManager.ClearAll(context.Background())
+	if err != nil {
+		return err
+	}
+
+	// Trigger a refetch
+	s.triggerRefetch(true)
+
+	return nil
+}

--- a/services/wallet/api.go
+++ b/services/wallet/api.go
@@ -826,3 +826,8 @@ func (api *API) UnsubscribeFromLeaderboard() error {
 	logutils.ZapLogger().Debug("call to UnsubscribeFromLeaderboard")
 	return api.s.leaderboardService.UnsubscribeFromLeaderboard()
 }
+
+func (api *API) RefetchTxHistory() error {
+	logutils.ZapLogger().Debug("call to RefetchTxHistory")
+	return api.s.activityFetcherService.RefetchTxHistory()
+}

--- a/services/wallet/thirdparty/activity/alchemy/persistence.go
+++ b/services/wallet/thirdparty/activity/alchemy/persistence.go
@@ -154,3 +154,8 @@ func (p *Persistence) GetLastFetchedBlockAndTimestamp(ctx context.Context, chain
 
 	return &lastFetchedBlock, &lastFetchedTimestamp, nil
 }
+
+func (p *Persistence) ClearAll(ctx context.Context) error {
+	_, err := p.db.ExecContext(ctx, "DELETE FROM fetched_alchemy_transfers")
+	return err
+}

--- a/services/wallet/thirdparty/activity_types.go
+++ b/services/wallet/thirdparty/activity_types.go
@@ -72,6 +72,7 @@ type ActivityFetcher interface {
 	ActivityProvider
 	FetchActivity(ctx context.Context, chainID uint64, parameters ActivityFetchParameters, cursor string, limit int) (ActivityEntryContainer, error)
 	GetLastFetchedBlockAndTimestamp(ctx context.Context, chainID uint64, address common.Address) (*rpc.BlockNumber, *time.Time, error)
+	ClearAll(ctx context.Context) error
 }
 
 func (e ActivityEntry) String() string {


### PR DESCRIPTION
Add API to let users clear the TX History storage and trigger a refetch.

Part of https://github.com/status-im/status-app/issues/19542

