### PR TITLE
feat(Makefile): cleanup generated files before generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,13 +312,10 @@ statusgo-c-bindings:
 	mkdir -p $(STATUS_GO_BINDINGS_PATH)
 	go run -mod=mod cmd/library/*.go > $(STATUS_GO_BINDINGS_PATH)/main.go
 
+statusgo-library: STATUS_GO_BINDINGS_PATH ?= build/bin/statusgo-lib
+statusgo-library: STATUS_GO_LIBRARY_OUT ?= build/bin
 statusgo-library: generate
-statusgo-library: statusgo-library-build ##@cross-compile Build status-go as static library for current platform
-
-# This target is kept separate and has no dependencies to be used in Nix builds
-statusgo-library-build: STATUS_GO_BINDINGS_PATH ?= build/bin/statusgo-lib
-statusgo-library-build: STATUS_GO_LIBRARY_OUT ?= build/bin
-statusgo-library-build: statusgo-c-bindings $(LIBWAKU) $(LIBSDS)
+statusgo-library: statusgo-c-bindings $(LIBWAKU) $(LIBSDS)  ##@cross-compile Build status-go as static library for current platform
 	@echo "Building static library..."
 	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
 	go build \
@@ -393,17 +390,22 @@ setup-dev: ##@setup Install all necessary tools for development
 setup-dev:
 	echo "Replaced by Nix shell. Use 'make shell' or just any target as-is."
 
-generate-clean: DRY_RUN=false
-generate-clean: ##@generate Remove orphaned generated files
-	@./_assets/scripts/cleanup_generated_files.sh
+clean-generated: CLEANUP_GENERATED_FILES?=true
+clean-generated: CLEANUP_GENERATED_FILES_DRY_RUN?=false
+clean-generated: ##@generate Remove orphaned generated files
+	if [ "$(CLEANUP_GENERATED_FILES)" = "true" ]; then \
+		./_assets/scripts/cleanup_generated_files.sh; \
+	else \
+	  	echo "Skipping cleanup of generated files"; \
+	fi
 
 generate: PACKAGES ?= $$(go list -e ./... | grep -v "/contracts/")
 generate: PACKAGES ?= $$(go list -e ./... | grep -v "/contracts/")
 generate: GO_GENERATE_CMD ?= go tool go-generate-fast
 generate: export GO_GENERATE_FAST_DEBUG ?= false
 generate: export GO_GENERATE_FAST_RECACHE ?= false
-generate: generate-clean
-generate:  ##@ Run generate for all given packages using go-generate-fast, fallback to `go generate` (e.g. for docker)
+generate: clean-generated
+generate: ##@ Run generate for all given packages using go-generate-fast, fallback to `go generate` (e.g. for docker)
 	@GOROOT=$$(go env GOROOT) $(GO_GENERATE_CMD) $(PACKAGES)
 
 generate-contracts:

--- a/Makefile
+++ b/Makefile
@@ -390,10 +390,16 @@ setup-dev: ##@setup Install all necessary tools for development
 setup-dev:
 	echo "Replaced by Nix shell. Use 'make shell' or just any target as-is."
 
+generate-clean: DRY_RUN=false
+generate-clean: ##@generate Remove orphaned generated files
+	@./_assets/scripts/cleanup_generated_files.sh
+
+generate: PACKAGES ?= $$(go list -e ./... | grep -v "/contracts/")
 generate: PACKAGES ?= $$(go list -e ./... | grep -v "/contracts/")
 generate: GO_GENERATE_CMD ?= go tool go-generate-fast
 generate: export GO_GENERATE_FAST_DEBUG ?= false
 generate: export GO_GENERATE_FAST_RECACHE ?= false
+generate: generate-clean
 generate:  ##@ Run generate for all given packages using go-generate-fast, fallback to `go generate` (e.g. for docker)
 	@GOROOT=$$(go env GOROOT) $(GO_GENERATE_CMD) $(PACKAGES)
 

--- a/Makefile
+++ b/Makefile
@@ -312,10 +312,13 @@ statusgo-c-bindings:
 	mkdir -p $(STATUS_GO_BINDINGS_PATH)
 	go run -mod=mod cmd/library/*.go > $(STATUS_GO_BINDINGS_PATH)/main.go
 
-statusgo-library: STATUS_GO_BINDINGS_PATH ?= build/bin/statusgo-lib
-statusgo-library: STATUS_GO_LIBRARY_OUT ?= build/bin
 statusgo-library: generate
-statusgo-library: statusgo-c-bindings $(LIBWAKU) $(LIBSDS) ##@cross-compile Build status-go as static library for current platform
+statusgo-library: statusgo-library-build ##@cross-compile Build status-go as static library for current platform
+
+# This target is kept separate and has no dependencies to be used in Nix builds
+statusgo-library-build: STATUS_GO_BINDINGS_PATH ?= build/bin/statusgo-lib
+statusgo-library-build: STATUS_GO_LIBRARY_OUT ?= build/bin
+statusgo-library-build: statusgo-c-bindings $(LIBWAKU) $(LIBSDS)
 	@echo "Building static library..."
 	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \
 	go build \
@@ -551,3 +554,6 @@ pytest-lint:
 generate-db: build/bin/generate-db
 generate-db: ##@build Generate fake sqlite DBs in ./build directory for IDE SQL inspections
 	./build/bin/generate-db -out-dir build/db
+
+env:
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" \

--- a/_assets/scripts/cleanup_generated_files.sh
+++ b/_assets/scripts/cleanup_generated_files.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Removes all generated files. List of non-tracked generated files can be found in .gitignore.
 
-DRY_RUN="${DRY_RUN:-false}"
+DRY_RUN="${CLEANUP_GENERATED_FILES_DRY_RUN:-false}"
 CMD="rm -rf"
 if [[ "$DRY_RUN" == "true" ]]; then
     CMD="echo [DRY-RUN]"

--- a/_assets/scripts/cleanup_generated_files.sh
+++ b/_assets/scripts/cleanup_generated_files.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Removes all generated files. List of non-tracked generated files can be found in .gitignore.
+
+DRY_RUN="${DRY_RUN:-false}"
+CMD="rm -rf"
+if [[ "$DRY_RUN" == "true" ]]; then
+    CMD="echo [DRY-RUN]"
+fi
+
+echo "Cleaning up generated files... (dry run: $DRY_RUN) "
+
+# Ignoring vendor directory is required for nix builds.
+
+find . -path './vendor' -prune -o -type d -name 'mock' -exec $CMD {} +
+find . -path './vendor' -prune -o -type f -name 'mock.go' -exec $CMD {} +
+find . -path './vendor' -prune -o -type f -name '*_mock_test.go' -exec $CMD {} +
+find . -path './vendor' -prune -o -type f -name '*.pb.go' -exec $CMD {} +
+find . -path './vendor' -prune -o -type f -name 'bindata.go' -exec $CMD {} +
+find . -path './vendor' -prune -o -type f -name 'migrations.go' -exec $CMD {} +
+
+$CMD ./cmd/status-backend/server/endpoints.go
+$CMD ./protocol/messenger_handlers.go
+$CMD ./pkg/version/VERSION
+$CMD ./pkg/version/GIT_COMMIT
+$CMD ./pkg/sentry/SENTRY_CONTEXT_NAME
+$CMD ./pkg/sentry/SENTRY_CONTEXT_VERSION
+$CMD ./pkg/sentry/SENTRY_PRODUCTION

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -26,7 +26,7 @@ in pkgs.buildGoModule {
       fakeGit
   ];
 
-  phases = ["unpackPhase" "configurePhase" "postPatch" "buildPhase"];
+  phases = ["unpackPhase" "configurePhase" "modPostBuild" "buildPhase"];
 
   # https://pkg.go.dev/net#hdr-Name_Resolution
   # https://github.com/status-im/status-mobile/issues/19736
@@ -40,7 +40,7 @@ in pkgs.buildGoModule {
 
   # Code generation should be run before buildPhase because buildGoModule
   # performs dependency inspection before buildPhase, and will fail if generated files are missing.
-  postPatch = ''
+  modPostBuild = ''
     # this line removes a bug where value of $HOME is set to a non-writable /homeless-shelter dir
     export HOME=$TMPDIR
 

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -26,7 +26,7 @@ in pkgs.buildGoModule {
       fakeGit
   ];
 
-  phases = ["unpackPhase" "configurePhase" "modPostBuild" "buildPhase"];
+  phases = ["unpackPhase" "configurePhase" "buildPhase"];
 
   # https://pkg.go.dev/net#hdr-Name_Resolution
   # https://github.com/status-im/status-mobile/issues/19736
@@ -40,7 +40,7 @@ in pkgs.buildGoModule {
 
   # Code generation should be run before buildPhase because buildGoModule
   # performs dependency inspection before buildPhase, and will fail if generated files are missing.
-  modPostBuild = ''
+  preBuild = ''
     # this line removes a bug where value of $HOME is set to a non-writable /homeless-shelter dir
     export HOME=$TMPDIR
 
@@ -55,15 +55,18 @@ in pkgs.buildGoModule {
   # ld flags and netgo tag are necessary for integration tests to work on MacOS
   # https://github.com/status-im/status-mobile/issues/20135
   #
-  # Using `make statusgo-library-build` target ensures that code generation is not involved in this phase.
-  # Generation is manually invoked in postPatch phase, because in needs scripts,
-  # which are are not available at buildPhase (only .go files are present at this point).
+  # Also set CLEANUP_GENERATED_FILES_DRY_RUN=true to avoid running cleanup_generated_files.sh script,
+  # which is not available at this phase, because buildGoModule only copies Go files.
   buildPhase = ''
-    make statusgo-library-build \
+    # this line removes a bug where value of $HOME is set to a non-writable /homeless-shelter dir
+    export HOME=$TMPDIR
+    make statusgo-library \
         NIM_SDS_INC_DIR="${pkgs.lib-sds-pkg}/include" \
         NIM_SDS_LIB_DIR="${pkgs.lib-sds-pkg}/lib" \
         STATUS_GO_BINDINGS_PATH="$NIX_BUILD_TOP" \
-        STATUS_GO_LIBRARY_OUT="$out"
+        STATUS_GO_LIBRARY_OUT="$out" \
+        CLEANUP_GENERATED_FILES=false \
+        GO_GENERATE_CMD='go generate'
     runHook postBuild
   '';
 }

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -26,7 +26,7 @@ in pkgs.buildGoModule {
       fakeGit
   ];
 
-  phases = ["unpackPhase" "configurePhase" "buildPhase"];
+  phases = ["unpackPhase" "configurePhase" "postPatch" "buildPhase"];
 
   # https://pkg.go.dev/net#hdr-Name_Resolution
   # https://github.com/status-im/status-mobile/issues/19736
@@ -38,19 +38,30 @@ in pkgs.buildGoModule {
   # FIXME: Remove this when go 1.23 or later versions fix this madness.
   allowGoReference = true;
 
-  preBuild = ''
-    export NIM_SDS_INC_DIR="${pkgs.lib-sds-pkg}/include"
-    export NIM_SDS_LIB_DIR="${pkgs.lib-sds-pkg}/lib"
-    export GO_GENERATE_CMD='go generate'
-    make generate
+  # Code generation should be run before buildPhase because buildGoModule
+  # performs dependency inspection before buildPhase, and will fail if generated files are missing.
+  postPatch = ''
+    # this line removes a bug where value of $HOME is set to a non-writable /homeless-shelter dir
+    export HOME=$TMPDIR
+
+    make generate \
+        NIM_SDS_INC_DIR="${pkgs.lib-sds-pkg}/include" \
+        NIM_SDS_LIB_DIR="${pkgs.lib-sds-pkg}/lib" \
+        GO_GENERATE_CMD='go generate'
   '';
 
   # Build the Go library
+  #
   # ld flags and netgo tag are necessary for integration tests to work on MacOS
   # https://github.com/status-im/status-mobile/issues/20135
+  #
+  # Using `make statusgo-library-build` target ensures that code generation is not involved in this phase.
+  # Generation is manually invoked in postPatch phase, because in needs scripts,
+  # which are are not available at buildPhase (only .go files are present at this point).
   buildPhase = ''
-    runHook preBuild
-    make statusgo-library \
+    make statusgo-library-build \
+        NIM_SDS_INC_DIR="${pkgs.lib-sds-pkg}/include" \
+        NIM_SDS_LIB_DIR="${pkgs.lib-sds-pkg}/lib" \
         STATUS_GO_BINDINGS_PATH="$NIX_BUILD_TOP" \
         STATUS_GO_LIBRARY_OUT="$out"
     runHook postBuild

--- a/services/wallet/market/feed_subscription_test.go
+++ b/services/wallet/market/feed_subscription_test.go
@@ -1,4 +1,4 @@
-package mock_common
+package market
 
 import (
 	"time"

--- a/services/wallet/market/market_feed_test.go
+++ b/services/wallet/market/market_feed_test.go
@@ -13,21 +13,19 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
 
-	mock_common "github.com/status-im/status-go/services/wallet/common/mock"
-	mock_market "github.com/status-im/status-go/services/wallet/market/mock"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 )
 
 type MarketTestSuite struct {
 	suite.Suite
-	feedSub    *mock_common.FeedSubscription
+	feedSub    *FeedSubscription
 	tokensKeys []string
 	currencies []string
 }
 
 func (s *MarketTestSuite) SetupTest() {
 	feed := new(event.Feed)
-	s.feedSub = mock_common.NewFeedSubscription(feed)
+	s.feedSub = NewFeedSubscription(feed)
 
 	// Create test tokens
 	s.tokensKeys = []string{
@@ -46,7 +44,7 @@ func (s *MarketTestSuite) TestEventOnRpsError() {
 	defer ctrl.Finish()
 	// GIVEN
 	customErr := errors.New("request rate exceeded")
-	priceProviderWithError := mock_market.NewMockPriceProviderWithError(ctrl, customErr)
+	priceProviderWithError := NewMockPriceProviderWithError(ctrl, customErr)
 	manager := setupMarketManager(s.T(), []thirdparty.MarketDataProvider{priceProviderWithError}, s.feedSub.GetFeed())
 
 	// WHEN
@@ -65,7 +63,7 @@ func (s *MarketTestSuite) TestEventOnNetworkError() {
 
 	// GIVEN
 	customErr := errors.New("dial tcp: lookup optimism-goerli.infura.io: no such host")
-	priceProviderWithError := mock_market.NewMockPriceProviderWithError(ctrl, customErr)
+	priceProviderWithError := NewMockPriceProviderWithError(ctrl, customErr)
 	manager := setupMarketManager(s.T(), []thirdparty.MarketDataProvider{priceProviderWithError}, s.feedSub.GetFeed())
 
 	_, err := manager.FetchPrices(s.tokensKeys, s.currencies)

--- a/services/wallet/market/market_test.go
+++ b/services/wallet/market/market_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
-	mock_market "github.com/status-im/status-go/services/wallet/market/mock"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
 )
@@ -104,7 +103,7 @@ var testTokensKeys = []string{
 func TestPrice(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	priceProvider := mock_market.NewMockPriceProvider(ctrl)
+	priceProvider := NewMockPriceProvider(ctrl)
 	priceProvider.SetMockPrices(mockPrices)
 
 	manager := setupMarketManager(t, []thirdparty.MarketDataProvider{priceProvider, priceProvider}, &event.Feed{})
@@ -147,11 +146,11 @@ func TestPrice(t *testing.T) {
 func TestFetchPriceErrorFirstProvider(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	priceProvider := mock_market.NewMockPriceProvider(ctrl)
+	priceProvider := NewMockPriceProvider(ctrl)
 	priceProvider.SetMockPrices(mockPrices)
 
 	customErr := errors.New("error")
-	priceProviderWithError := mock_market.NewMockPriceProviderWithError(ctrl, customErr)
+	priceProviderWithError := NewMockPriceProviderWithError(ctrl, customErr)
 
 	currencies := []string{"USD", "EUR"}
 

--- a/services/wallet/market/mock_price_provider_test.go
+++ b/services/wallet/market/mock_price_provider_test.go
@@ -1,4 +1,4 @@
-package mock_market
+package market
 
 import (
 	"go.uber.org/mock/gomock"


### PR DESCRIPTION
Required for https://github.com/status-im/status-go/issues/7067

# Description

1. Always remove all generated files before generating them again.
When moving files around repo, generated files will remain in old locations on developers machines. We need to clean that up to prevent compilation issues.
We use `go-generate-fast`, so re-generation it's not time consuming.

2. Moved some hard-coded (non-generated) mocks to `*_test.go` files, otherwise they're removed by (1).