### PR TITLE
chore: add support for custom tokens in wallet configuration

### DIFF
--- a/api/defaults.go
+++ b/api/defaults.go
@@ -203,6 +203,9 @@ func buildWalletConfig(walletRequest *requests.WalletConfig, request *requests.W
 	if len(walletRequest.MulticallOverrides) > 0 {
 		walletConfig.MulticallOverrides = walletRequest.MulticallOverrides
 	}
+	if len(walletRequest.CustomTokens) > 0 {
+		walletConfig.CustomTokens = walletRequest.CustomTokens
+	}
 
 	if !request.StatusProxyUser.Empty() {
 		walletConfig.StatusProxyUser = request.StatusProxyUser

--- a/node/get_status_node.go
+++ b/node/get_status_node.go
@@ -404,6 +404,16 @@ func (n *StatusNode) createAndStartTokenManager() error {
 		return err
 	}
 
+	// check for possible custom tokens in the config
+	if len(n.config.WalletConfig.CustomTokens) > 0 {
+		for _, token := range n.config.WalletConfig.CustomTokens {
+			err := n.tokenManager.UpsertCustom(*token)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return n.tokenManager.Start(context.Background())
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/status-im/status-go/crypto"
 	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/pkg/security"
+	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 // ----------
@@ -239,6 +240,8 @@ type WalletConfig struct {
 	TokensListsAutoRefreshCheckInterval int `json:"TokensListsAutoRefreshCheckInterval"` // in seconds
 
 	MulticallOverrides map[uint64]common.Address `json:"MulticallOverrides"` // map[chainID]multicall3 contract address
+
+	CustomTokens []*tokentypes.Token `json:"CustomTokens"` // custom tokens, mainly used for registering custom tokens for functional tests
 }
 
 type MarketDataProxyConfig struct {
@@ -259,12 +262,14 @@ func (wc WalletConfig) MarshalJSON() ([]byte, error) {
 		TokensListsAutoRefreshInterval      int                       `json:"TokensListsAutoRefreshInterval"`
 		TokensListsAutoRefreshCheckInterval int                       `json:"TokensListsAutoRefreshCheckInterval"`
 		MulticallOverrides                  map[uint64]common.Address `json:"MulticallOverrides"`
+		CustomTokens                        []*tokentypes.Token       `json:"CustomTokens"`
 	}{
 		Enabled:                             wc.Enabled,
 		EnableMercuryoProvider:              wc.EnableMercuryoProvider,
 		TokensListsAutoRefreshInterval:      wc.TokensListsAutoRefreshInterval,
 		TokensListsAutoRefreshCheckInterval: wc.TokensListsAutoRefreshCheckInterval,
 		MulticallOverrides:                  wc.MulticallOverrides,
+		CustomTokens:                        wc.CustomTokens,
 	})
 }
 

--- a/protocol/requests/create_account.go
+++ b/protocol/requests/create_account.go
@@ -8,6 +8,7 @@ import (
 	utils "github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/pkg/security"
+	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
 var ErrCreateAccountInvalidDisplayName = errors.New("create-account: invalid display name")
@@ -99,6 +100,7 @@ type WalletConfig struct {
 
 	MulticallOverrides map[uint64]common.Address `json:"multicallOverrides"` // map[chainID]multicall3 contract address
 
+	CustomTokens []*tokentypes.Token `json:"customTokens"` // custom tokens, mainly used for registering custom tokens for functional tests
 }
 type WalletSecretsConfig struct {
 	PoktToken            security.SensitiveString `json:"poktToken"`

--- a/tests-functional/clients/status_backend.py
+++ b/tests-functional/clients/status_backend.py
@@ -259,6 +259,26 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         data["multicallOverrides"] = {self.network_id: multicall_contract_address}
         return data
 
+    def _set_custom_tokens(self, data, kwargs):
+        token_overrides = kwargs.get("token_overrides", [])
+        if not token_overrides:
+            return data
+
+        tokens = []
+        for token in token_overrides:
+            tokens.append(
+                {
+                    "chainId": self.network_id,
+                    "address": token["address"],
+                    "symbol": token.get("symbol"),
+                    "name": token.get("name", token.get("symbol")),
+                    "decimals": token.get("decimals", 18),
+                }
+            )
+
+        data["customTokens"] = tokens
+        return data
+
     def extract_data(self, path: str):
         if self.container:
             return self.container.extract_data(path)
@@ -323,6 +343,7 @@ class StatusBackend(RpcClient, SignalClient, ApiClient):
         data = self._set_proxy_credentials(data)
         data = self._set_wallet_secrets(data)
         data = self._set_multicall_overrides(data, kwargs)
+        data = self._set_custom_tokens(data, kwargs)
         return data
 
     def create_account_and_login(self, password: str, **kwargs):

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -200,7 +200,14 @@ def snt_addresses(foundry_client):
 
 @pytest.fixture(scope="function")
 def snt_token_overrides(snt_addresses):
-    return [{"symbol": "SNT", "address": snt_addresses["snt"]}]
+    return [
+        {
+            "symbol": "SNT",
+            "name": "Status Network Token",
+            "address": snt_addresses["snt"],
+            "decimals": 18,
+        }
+    ]
 
 
 @pytest.fixture(scope="function", autouse=False)


### PR DESCRIPTION
Introduced CustomTokens field in WalletConfig to allow registration of custom tokens, mainly necessary for the functional tests.

Fixes #7184