### PR TITLE
ci: pass github_token to setup-protoc to avoid rate limiting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: read # Keep permissions read-only. Required to provide `repo-token` for arduino/setup-protoc@v3 stage.
 
 jobs:
   golangci:
@@ -37,6 +37,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "29.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache go-generate-fast
         uses: actions/cache@v4


### PR DESCRIPTION
# Description

We have faced rate limiting a few times already: https://github.com/status-im/status-go/actions/runs/20095562898/attempts/1

https://github.com/arduino/setup-protoc suggests to pass a `repo-token` to avoid rate limiting.

