### PR TITLE
test: move scan_waku_fleet.py to a separate container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,6 @@ RUN mkdir -p /static/configs
 
 COPY --from=builder /go/src/github.com/status-im/status-go/build/bin/status-backend /usr/local/bin/
 COPY --from=builder /go/src/github.com/status-im/status-go/build/bin/push-notification-server /usr/local/bin/
-COPY --from=builder /go/src/github.com/status-im/status-go/tests-functional/scripts/scan_waku_fleet.py /usr/local/bin
 COPY --from=builder /go/src/github.com/status-im/status-go/static/keys/* /static/keys/
 COPY --from=builder /go/src/github.com/status-im/status-go/tests-functional/waku_configs/* /static/configs/
 COPY --from=builder /go/src/github.com/status-im/nim-sds/build/libsds.so /usr/local/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,10 +55,6 @@ COPY --from=builder /go/src/github.com/status-im/nim-sds/build/libsds.so /usr/lo
 
 ENV LD_LIBRARY_PATH=/usr/local/lib/
 
-COPY _assets/scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
-
-# 30304 is used for Discovery v5
 EXPOSE 8080 8545 30303 30303/udp 30304/udp
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["--help"]
+
+CMD ["status-backend", "--help"]

--- a/_assets/scripts/entrypoint.sh
+++ b/_assets/scripts/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# Simple entrypoint: execute the CMD from the Dockerfile.
-exec "$@"

--- a/_assets/scripts/entrypoint.sh
+++ b/_assets/scripts/entrypoint.sh
@@ -1,8 +1,4 @@
 #!/bin/sh
 
-# Define $SCAN_WAKU_FLEET to run a command before running the actual app (CMD).
-# This is expected to be used in functional tests to run `scan_waku_fleet.py` script before starting the app.
-$SCAN_WAKU_FLEET
-
-# This will exec the CMD from your Dockerfile, i.e. "npm start"
+# Simple entrypoint: execute the CMD from the Dockerfile.
 exec "$@"

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -55,6 +55,28 @@ fi
 echo -e "${GRN}Running status-go external dependencies${RST}"
 docker compose -p ${project_name} ${all_compose_files} up -d --build --remove-orphans
 
+# Wait for wakufleet-scanner to finish before running tests. If it fails,
+# there's no point in starting tests because wakufleetconfig.json will not
+# be available for status-backend.
+echo -e "${GRN}Waiting for wakufleet-scanner to complete${RST}"
+scanner_container_id=$(docker compose -p ${project_name} ${all_compose_files} ps -q wakufleet-scanner || true)
+
+if [[ -z "${scanner_container_id}" ]]; then
+  echo -e "${RED}wakufleet-scanner service container not found. Make sure docker-compose.waku.yml defines it correctly.${RST}"
+  exit 1
+fi
+
+scanner_exit_code=$(docker wait "${scanner_container_id}")
+
+if [[ "${scanner_exit_code}" -ne 0 ]]; then
+  echo -e "${RED}wakufleet-scanner failed with exit code ${scanner_exit_code}. See logs below:${RST}"
+  docker logs "${scanner_container_id}" || true
+  echo -e "${RED}Aborting functional tests because wakufleetconfig.json was not generated successfully.${RST}"
+  exit 1
+fi
+
+echo -e "${GRN}wakufleet-scanner completed successfully${RST}"
+
 # Set up virtual environment
 venv_path="${root_path}/.venv"
 

--- a/tests-functional/Dockerfile.waku-fleet-scanner
+++ b/tests-functional/Dockerfile.waku-fleet-scanner
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY scripts/scan_waku_fleet.py /app/scan_waku_fleet.py
+
+ENTRYPOINT ["python", "/app/scan_waku_fleet.py"]

--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -68,7 +68,7 @@ class StatusGoContainer:
                 },
                 # Named volume created by docker-compose.waku.yml for wakufleetconfig.json
                 f"{docker_project_name}_wakufleetconfig": {
-                    "bind": "/usr/status-user",
+                    "bind": "/usr/status-user/config",
                     "mode": "rw",
                 },
             },

--- a/tests-functional/clients/statusgo_container.py
+++ b/tests-functional/clients/statusgo_container.py
@@ -60,13 +60,17 @@ class StatusGoContainer:
             "labels": {"com.docker.compose.project": docker_project_name},
             "environment": {
                 "GOCOVERDIR": "/coverage/binary",
-                "SCAN_WAKU_FLEET": self.get_waku_fleet_scan_command(),
             },
             "volumes": {
                 coverage_path: {
                     "bind": "/coverage/binary",
                     "mode": "rw",
-                }
+                },
+                # Named volume created by docker-compose.waku.yml for wakufleetconfig.json
+                f"{docker_project_name}_wakufleetconfig": {
+                    "bind": "/usr/status-user",
+                    "mode": "rw",
+                },
             },
             "extra_hosts": {
                 "host.docker.internal": "host-gateway",
@@ -91,24 +95,6 @@ class StatusGoContainer:
         StatusGoContainer.all_containers.append(self)
 
         logging.debug(f"Container {self.container.name} created. ID = {self.container.id}")
-
-    def get_waku_fleet_scan_command(self):
-        """Returns the command string for scanning Waku fleet and generating config"""
-
-        # Known node names from docker compose
-        bootstrap_nodes = "boot-1"
-        static_nodes = "boot-1"  # Add bootnode, otherwise metadata exchange doesn't happen, and Waku light mode doesn't work
-        store_nodes = "store"
-
-        return (
-            "python3 /usr/local/bin/scan_waku_fleet.py "
-            f"--fleet-name {Config.waku_fleet} "
-            f"--cluster-id 16 "  # Cluster ID matches docker-compose.waku.yml
-            f"--bootstrap-nodes {bootstrap_nodes} "
-            f"--store-nodes {store_nodes} "
-            f"--static-nodes {static_nodes} "
-            f"--output {Config.waku_fleets_config}"
-        )
 
     def __del__(self):
         self.stop()

--- a/tests-functional/conftest.py
+++ b/tests-functional/conftest.py
@@ -61,7 +61,7 @@ def pytest_addoption(parser):
         "--waku-fleets-config",
         action="store",
         help="Path to a local JSON file with Waku fleets configuration. Default value is a path to config in Docker to run 2 local waku nodes",
-        default="/usr/status-user/wakufleetconfig.json",
+        default="/usr/status-user/config/wakufleetconfig.json",
     )
     parser.addoption(
         "--waku-fleet",

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -60,3 +60,24 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
 
+  wakufleet-scanner:
+    build:
+      context: .
+      dockerfile: Dockerfile.waku-fleet-scanner
+    depends_on:
+      - boot-1
+      - store
+    volumes:
+      - wakufleetconfig:/fleet-config
+    command: [
+      "--fleet-name", "status-go.test",
+      "--cluster-id", "16",
+      "--bootstrap-nodes", "boot-1",
+      "--store-nodes", "store",
+      "--static-nodes", "boot-1",
+      "--output", "/fleet-config/wakufleetconfig.json"
+    ]
+
+volumes:
+  wakufleetconfig:
+

--- a/tests-functional/scripts/scan_waku_fleet.py
+++ b/tests-functional/scripts/scan_waku_fleet.py
@@ -5,6 +5,7 @@ import json
 import sys
 import os
 import logging
+import time
 
 from urllib import request
 from typing import Dict, List, Optional, Tuple
@@ -46,10 +47,25 @@ def parse_args():
 def _fetch_debug_info(host: str) -> Optional[Dict]:
     url = f"http://{host}:8645/debug/v1/info"
     logging.info(f"Fetching debug info from Waku node {url}")
-    with request.urlopen(url, timeout=5.0) as resp:
-        assert resp.status == 200
-        data = resp.read()
-        return json.loads(data.decode("utf-8"))
+
+    attempts = 15
+    delay_seconds = 1.0
+
+    for attempt in range(1, attempts + 1):
+        try:
+            logging.info(f"Attempt {attempt}/{attempts} to fetch debug info from {url}")
+            with request.urlopen(url, timeout=5.0) as resp:
+                if resp.status != 200:
+                    logging.error(f"Unexpected status {resp.status} from {url}")
+                    continue
+                data = resp.read()
+                return json.loads(data.decode("utf-8"))
+        except Exception as e:  # noqa: BLE001
+            logging.error(f"Error fetching debug info from {url}: {e}")
+            if attempt < attempts:
+                time.sleep(delay_seconds)
+
+    return None
 
 
 def _first_dns_addr(listen_addrs: List[str]) -> Optional[str]:


### PR DESCRIPTION
Run Waku fleet scanning in a dedicated docker service, share its output via a volume, and fail functional tests early if fleet config generation fails.

Important changes:
- [x] Removed SCAN_WAKU_FLEET usage from the main Docker entrypoint and image, and introduced a dedicated wakufleet-scanner service
- [x] Added retry in scan_waku_fleet.py and a hard gate in run_functional_tests.sh that waits for wakufleet-scanner to succeed (or fails fast with logs)

Closes [#7089](https://github.com/status-im/status-go/issues/7089)