### PR TITLE
ci: update nwaku to 0.37.1 in testing env

### DIFF
--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -141,7 +141,7 @@ pipeline {
           "--env=POSTGRES_HOST_AUTH_METHOD=trust",
           "--publish=${DB_PORT}:${DB_PORT}",
         ].join(' '), "-p ${DB_PORT}") { c ->
-          nwaku = docker.image('wakuorg/nwaku:v0.36.0').withRun([
+          nwaku = docker.image('wakuorg/nwaku:v0.37.1-beta').withRun([
             "--name=${NWAKU_CONT}",
             "--publish=${NWAKU_TCP_PORT}:${NWAKU_TCP_PORT}/tcp",
             "--publish=${NWAKU_UDP_PORT}:${NWAKU_UDP_PORT}/udp",
@@ -150,7 +150,7 @@ pipeline {
             "--tcp-port=${NWAKU_TCP_PORT}",
             "--discv5-discovery=true",
             "--cluster-id=16",
-         // "--num-shards-in-network=0", // uncomment when switching to nwaku:v0.37.0
+            "--num-shards-in-network=65",
             "--shard=32",
             "--shard=64",
             "--nat=extip:${ipAddress}",

--- a/_assets/ci/Jenkinsfile.tests
+++ b/_assets/ci/Jenkinsfile.tests
@@ -141,7 +141,7 @@ pipeline {
           "--env=POSTGRES_HOST_AUTH_METHOD=trust",
           "--publish=${DB_PORT}:${DB_PORT}",
         ].join(' '), "-p ${DB_PORT}") { c ->
-          nwaku = docker.image('wakuorg/nwaku:v0.37.1-beta').withRun([
+          nwaku = docker.image('harbor.status.im/wakuorg/nwaku:v0.37.1-beta').withRun([
             "--name=${NWAKU_CONT}",
             "--publish=${NWAKU_TCP_PORT}:${NWAKU_TCP_PORT}/tcp",
             "--publish=${NWAKU_UDP_PORT}:${NWAKU_UDP_PORT}/udp",

--- a/messaging/waku/nwaku_test.go
+++ b/messaging/waku/nwaku_test.go
@@ -161,8 +161,8 @@ func newTestStorenodeConfigProvider(storenode peer.AddrInfo) history.StorenodeCo
 //
 //	IP_ADDRESS=$(hostname -I | awk '{print $1}');
 // 	docker run \
-// 	-p 61000:61000/tcp -p 8000:8000/udp -p 8646:8646/tcp harbor.status.im/wakuorg/nwaku:v0.36.0 \
-// 	--discv5-discovery=true --cluster-id=16 --log-level=DEBUG --shard=64 --tcp-port=61000 \
+// 	-p 61000:61000/tcp -p 8000:8000/udp -p 8646:8646/tcp harbor.status.im/wakuorg/nwaku:v0.37.1-beta \
+// 	--discv5-discovery=true --cluster-id=16 --num-shards-in-network=65 --log-level=DEBUG --shard=64 --tcp-port=61000 \
 // 	--nat=extip:${IP_ADDRESS} --discv5-udp-port=8000 --rest-address=0.0.0.0 --store --rest-port=8646 \
 
 func TestBasicWakuV2(t *testing.T) {

--- a/messaging/waku/waku_test.go
+++ b/messaging/waku/waku_test.go
@@ -163,8 +163,8 @@ func parseNodes(rec []string) []*enode.Node {
 //
 //	IP_ADDRESS=$(hostname -I | awk '{print $1}');
 //	docker run \
-//	 -p 60000:60000/tcp -p 9000:9000/udp -p 8645:8645/tcp harbor.status.im/wakuorg/nwaku:v0.36.0 \
-//	 --tcp-port=60000 --discv5-discovery=true --cluster-id=16 --pubsub-topic=/waku/2/rs/16/32 --pubsub-topic=/waku/2/rs/16/64 \
+//	 -p 60000:60000/tcp -p 9000:9000/udp -p 8645:8645/tcp harbor.status.im/wakuorg/nwaku:v0.37.1-beta \
+//	 --tcp-port=60000 --discv5-discovery=true --cluster-id=16 --num-shards-in-network=65 --pubsub-topic=/waku/2/rs/16/32 --pubsub-topic=/waku/2/rs/16/64 \
 //	 --nat=extip:${IP_ADDRESS} --discv5-discovery --discv5-udp-port=9000 --rest-address=0.0.0.0 --store
 
 func TestBasicWakuV2(t *testing.T) {

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -1,12 +1,13 @@
 services:
   boot-1:
-    image: wakuorg/nwaku:v0.36.0
+    image: wakuorg/nwaku:v0.37.1-beta
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
       "--discv5-enr-auto-update=True",
       "--discv5-udp-port=9000",
       "--cluster-id=16",
+      "--num-shards-in-network=65",
       # Docker DNS server
       "--dns-addrs-name-server=127.0.0.11",
       "--dns4-domain-name=boot-1",
@@ -33,13 +34,14 @@ services:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
 
   store:
-    image: wakuorg/nwaku:v0.36.0
+    image: wakuorg/nwaku:v0.37.1-beta
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
       "--discv5-enr-auto-update=True",
       "--discv5-udp-port=9000",
       "--cluster-id=16",
+      "--num-shards-in-network=65",
       # Docker DNS server
       "--dns-addrs-name-server=127.0.0.11",
       "--dns4-domain-name=store",

--- a/tests-functional/docker-compose.waku.yml
+++ b/tests-functional/docker-compose.waku.yml
@@ -1,6 +1,6 @@
 services:
   boot-1:
-    image: wakuorg/nwaku:v0.37.1-beta
+    image: harbor.status.im/wakuorg/nwaku:v0.37.1-beta
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",
@@ -34,7 +34,7 @@ services:
       test: ["CMD-SHELL", "curl -X GET -H 'Content-Type: application/json' http://0.0.0.0:8645 || exit 0"]
 
   store:
-    image: wakuorg/nwaku:v0.37.1-beta
+    image: harbor.status.im/wakuorg/nwaku:v0.37.1-beta
     entrypoint: [
       "/usr/bin/wakunode",
       "--discv5-discovery=true",


### PR DESCRIPTION
# Description

At least to get this fix: https://github.com/logos-messaging/logos-messaging-nim/pull/3652
But also to get ready for nwaku 0.37 fleet deployment.