### PR TITLE
feat: update goroutine-defer-guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,7 @@ benchmark:
 
 lint-panics: generate
 	GOFLAGS=-tags='$(BUILD_TAGS),lint' \
-	go tool goroutine-defer-guard -skip=./cmd -test=false ./...
+	go tool goroutine-defer-guard -test=false -target github.com/status-im/status-go/common.LogOnPanic ./...
 
 lint: generate lint-panics
 lint:

--- a/cmd/push-notification-server/main.go
+++ b/cmd/push-notification-server/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	"github.com/status-im/status-go/common"
 	"github.com/status-im/status-go/common/dbsetup"
 	"github.com/status-im/status-go/internal/crypto"
 	"github.com/status-im/status-go/internal/db/appdatabase"
@@ -210,6 +211,7 @@ func main() {
 	messenger.StartRetrieveMessagesLoop(300*time.Millisecond, cancelMessenger)
 
 	go func() {
+		defer common.LogOnPanic()
 		select {
 		case <-cancelMessenger:
 			return

--- a/cmd/status-backend/main.go
+++ b/cmd/status-backend/main.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/cmd/status-backend/server"
+	"github.com/status-im/status-go/common"
 	logutils2 "github.com/status-im/status-go/internal/logutils"
 	statusgo "github.com/status-im/status-go/mobile"
 	"github.com/status-im/status-go/pkg/sentry"
@@ -41,7 +42,10 @@ func main() {
 	defer sentry.Recover()
 
 	flag.Parse()
-	go handleInterrupts()
+	go func() {
+		defer common.LogOnPanic()
+		handleInterrupts()
+	}()
 
 	srv := server.NewServer(
 		logger.Named("server"),

--- a/go.mod
+++ b/go.mod
@@ -433,7 +433,7 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/spf13/viper v1.17.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
-	github.com/status-im/goroutine-defer-guard v0.1.1 // indirect
+	github.com/status-im/goroutine-defer-guard v0.3.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2285,8 +2285,6 @@ github.com/status-im/go-wallet-sdk v0.0.0-20251128124044-df18aa5cfd60 h1:h3Yzafo
 github.com/status-im/go-wallet-sdk v0.0.0-20251128124044-df18aa5cfd60/go.mod h1:6zJF+lF5y88viQAtALL4FrPcZYR8dAeR/kNOPXwlY/o=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4 h1:CtobZoiNdHpx+xurFxnuJ1xsGm3oKMfcZkB3vmomJmA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4/go.mod h1:hmpnZzkzSZJbFYWAUkrPV8I36x7mdYiPhPqnALP4fKA=
-github.com/status-im/goroutine-defer-guard v0.3.0 h1:NcTYRVOV8UNyNKFdew9VxVv8v641j/v3LZM3sRU8CTI=
-github.com/status-im/goroutine-defer-guard v0.3.0/go.mod h1:HwUfqi1wF8tg8OEEEYKlJuJwsgNNlu5Kq5SzE1DNe3k=
 github.com/status-im/goroutine-defer-guard v0.3.1 h1:cZhcJ3gO6OgMYBOfEaAAUZaZgKZeSzMlGNEjMyejuRo=
 github.com/status-im/goroutine-defer-guard v0.3.1/go.mod h1:HwUfqi1wF8tg8OEEEYKlJuJwsgNNlu5Kq5SzE1DNe3k=
 github.com/status-im/markdown v0.0.0-20250825083641-55c1df9bc05d h1:0jQiaymp0t7XwC45c08/cYpjFDxFSMTE6VznZ03Jktg=

--- a/go.sum
+++ b/go.sum
@@ -2285,8 +2285,10 @@ github.com/status-im/go-wallet-sdk v0.0.0-20251128124044-df18aa5cfd60 h1:h3Yzafo
 github.com/status-im/go-wallet-sdk v0.0.0-20251128124044-df18aa5cfd60/go.mod h1:6zJF+lF5y88viQAtALL4FrPcZYR8dAeR/kNOPXwlY/o=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4 h1:CtobZoiNdHpx+xurFxnuJ1xsGm3oKMfcZkB3vmomJmA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4/go.mod h1:hmpnZzkzSZJbFYWAUkrPV8I36x7mdYiPhPqnALP4fKA=
-github.com/status-im/goroutine-defer-guard v0.1.1 h1:zb7iY28CDcKwMXxYHsb7gvuwGabkjY8RGqOYxD0gofc=
-github.com/status-im/goroutine-defer-guard v0.1.1/go.mod h1:CcC+zyc/1DPSHWZ81bgEmayeQgOvKPxntp/uIa8BbVs=
+github.com/status-im/goroutine-defer-guard v0.3.0 h1:NcTYRVOV8UNyNKFdew9VxVv8v641j/v3LZM3sRU8CTI=
+github.com/status-im/goroutine-defer-guard v0.3.0/go.mod h1:HwUfqi1wF8tg8OEEEYKlJuJwsgNNlu5Kq5SzE1DNe3k=
+github.com/status-im/goroutine-defer-guard v0.3.1 h1:cZhcJ3gO6OgMYBOfEaAAUZaZgKZeSzMlGNEjMyejuRo=
+github.com/status-im/goroutine-defer-guard v0.3.1/go.mod h1:HwUfqi1wF8tg8OEEEYKlJuJwsgNNlu5Kq5SzE1DNe3k=
 github.com/status-im/markdown v0.0.0-20250825083641-55c1df9bc05d h1:0jQiaymp0t7XwC45c08/cYpjFDxFSMTE6VznZ03Jktg=
 github.com/status-im/markdown v0.0.0-20250825083641-55c1df9bc05d/go.mod h1:i31M0FhtYMUeAzWqJafla0Q4+LCGJyorLRCH3EorAWQ=
 github.com/status-im/migrate/v4 v4.6.2-status.3 h1:Khwjb59NzniloUr5i9s9AtkEyqBbQFt1lkoAu66sAu0=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-bImoWkSlJw2oRgtXh4e76gxAmgzaFqGvhTzsH8dYwWY=";
+  vendorHash = "sha256-ly3fjFZgtxaTbVn6Kw8f7q7c8jU3kRliR6dRNmjDldw=";
 
   inherit meta version;
 


### PR DESCRIPTION
# Description

Upgrade https://github.com/status-im/goroutine-defer-guard to v0.3.1.
Latest release allows to explicitly define target function to be called.

Also start linting `cmd` directory.

Required to be able to move `common.LogOnPanic` elsewhere as part of https://github.com/status-im/status-go/issues/7103.