### PR TITLE
fix: shutdown containers in tests

### DIFF
--- a/_assets/ci/Jenkinsfile.tests-rpc
+++ b/_assets/ci/Jenkinsfile.tests-rpc
@@ -59,6 +59,7 @@ pipeline {
     BRANCH =                          "${params.BRANCH}"
     FUNCTIONAL_TESTS_REPORT_CODECOV = "${params.FUNCTIONAL_TESTS_REPORT_CODECOV}"
     FUNCTIONAL_TESTS_LOG_LEVEL =      "${params.FUNCTIONAL_TESTS_LOG_LEVEL}"
+    FUNCTIONAL_TESTS_CONTAINER_PREFIX = "${env.BUILD_TAG}"
     USE_NWAKU = "${params.USE_NWAKU}"
     /* nwaku source directory */
     NWAKU_SOURCE_DIR = "${WORKSPACE_TMP}/nwaku"
@@ -103,7 +104,7 @@ pipeline {
     failure { script { github.notifyPR(false) } }
     cleanup {
       sh '''
-        docker ps -a --filter "name=status-go-func-tests-${BUILD_TAG}" -q | xargs -r docker rm -f
+        docker ps -a --filter "name=${FUNCTIONAL_TESTS_CONTAINER_PREFIX}" -q | xargs -r docker rm -f
       '''
       cleanWs()
       dir(env.WORKSPACE_TMP) { deleteDir() }

--- a/_assets/ci/Jenkinsfile.tests-rpc
+++ b/_assets/ci/Jenkinsfile.tests-rpc
@@ -103,7 +103,7 @@ pipeline {
     failure { script { github.notifyPR(false) } }
     cleanup {
       sh '''
-        docker ps -a --filter "name=status-go-func-tests-${BUILD_ID}" -q | xargs -r docker rm -f
+        docker ps -a --filter "name=status-go-func-tests-${BUILD_TAG}" -q | xargs -r docker rm -f
       '''
       cleanWs()
       dir(env.WORKSPACE_TMP) { deleteDir() }

--- a/_assets/scripts/run_functional_tests.sh
+++ b/_assets/scripts/run_functional_tests.sh
@@ -30,7 +30,7 @@ mkdir -p "${test_results_path}"
 mkdir -p "${logs_path}"
 
 all_compose_files="-f ${root_path}/docker-compose.anvil.yml -f ${root_path}/docker-compose.waku.yml"
-identifier=${BUILD_TAG:-"status-go-func-tests-$(git rev-parse --short HEAD)"}
+identifier=${FUNCTIONAL_TESTS_CONTAINER_PREFIX:-"status-go-func-tests-$(git rev-parse --short HEAD)"}
 project_name="${identifier,,}"
 image_name="statusgo-${identifier,,}"
 

--- a/tests-functional/Makefile
+++ b/tests-functional/Makefile
@@ -9,3 +9,9 @@ compose:
 		-f docker-compose.anvil.yml \
 		-f docker-compose.waku.yml \
 		up --build --remove-orphans -d
+
+compose-down:
+	docker compose \
+		-f docker-compose.anvil.yml \
+		-f docker-compose.waku.yml \
+		down

--- a/tests-functional/clients/push_notification_server.py
+++ b/tests-functional/clients/push_notification_server.py
@@ -15,3 +15,7 @@ class PushNotificationServer:
         self.container.start_health_monitoring()
 
         assert self.data_dir != ""
+
+    def shutdown(self):
+        if self.container:
+            self.container.shutdown()

--- a/tests-functional/tests/conftest.py
+++ b/tests-functional/tests/conftest.py
@@ -1,11 +1,11 @@
+import json
 import logging
+import os
 from uuid import uuid4
 
 import pytest
 from filelock import FileLock
 from requests import ReadTimeout
-import os
-import json
 
 from clients.anvil import Anvil
 from clients.contract_deployers.multicall3 import Multicall3Deployer
@@ -64,7 +64,7 @@ def backend_factory(request):
     node = getattr(request, "node", None)
     test_name = getattr(node, "name", f"test-{uuid4()}")
 
-    def factory(name, **kwargs) -> StatusBackend:
+    def factory(name="", **kwargs) -> StatusBackend:
         """
         Create a single backend with the given name.
 

--- a/tests-functional/tests/test_local_backup.py
+++ b/tests-functional/tests/test_local_backup.py
@@ -3,11 +3,10 @@ import re
 
 import pytest
 
-from clients.status_backend import StatusBackend
+from clients.api import ApiResponseError
 from resources.constants import Account, user_1
 from resources.test_data import profile_showcase_utils
 from utils import fake
-from clients.api import ApiResponseError
 
 test_one_to_one_chat_id = (
     "0x043329fc08727f15c4ec9a17bf7d6a3dc44e9d0d8f782a55804f3660b28827194a365dc1765cf96b6fa5cd666b9ee5298e8ac82f51f7952c4110cbf321d4f63864"
@@ -18,11 +17,8 @@ test_one_to_one_chat_id = (
 class TestLocalBackup:
 
     @pytest.mark.init
-    def test_local_backup(self, tmp_path):
-        backend_client = StatusBackend()
-        assert backend_client is not None
-
-        # Init and login
+    def test_local_backup(self, tmp_path, backend_factory):
+        backend_client = backend_factory()
         backend_client.init_status_backend()
         backend_client.create_account_and_login(password=fake.profile_password())
         backend_client.wait_for_login()
@@ -213,10 +209,7 @@ class TestLocalBackup:
         assert backup_file is not None
 
         # Create a new installation
-        backend_client2 = StatusBackend()
-        assert backend_client2 is not None
-
-        # Init and login
+        backend_client2 = backend_factory()
         backend_client2.init_status_backend()
         backend_client2.restore_account_and_login(
             user=Account(
@@ -295,9 +288,9 @@ class TestLocalBackup:
         assert group_chat_recovered, "Group chat was not restored correctly"
         assert one_on_one_chat_recovered, "One-to-one chat was not restored correctly"
 
-    def test_local_backup_backwards_compatibility(self, tmp_path):
-        backend_client = StatusBackend()
-        assert backend_client is not None
+    def test_local_backup_backwards_compatibility(self, backend_factory):
+        backend_client = backend_factory()
+        # assert backend_client is not None
         # Restore the account with a hardcoded mnemonic to get the same private key
         backend_client.init_status_backend()
         backend_client.restore_account_and_login(

--- a/tests-functional/tests/test_local_pairing.py
+++ b/tests-functional/tests/test_local_pairing.py
@@ -148,12 +148,12 @@ def login_paired_device(backend: StatusBackend, key_uid, password):
 @pytest.mark.rpc
 class TestLocalPairing(MessengerSteps):
 
-    def test_pairing_server_as_sender(self, backend_new_profile):
+    def test_pairing_server_as_sender(self, backend_new_profile, backend_factory):
         # Create users
         alice = backend_new_profile()
         bob = backend_new_profile()
 
-        bob_second_device = StatusBackend()
+        bob_second_device = backend_factory()
         bob_second_device.init_status_backend()
 
         # Make contacts before local pairing
@@ -229,11 +229,11 @@ class TestLocalPairing(MessengerSteps):
         assert messages_map[message_id2]["text"] == "hello bob"
         assert messages_map[message_id2]["clock"] == clock_2, "Message 2 clock is not right on paired device"
 
-    def test_pairing_server_as_receiver(self, backend_new_profile):
+    def test_pairing_server_as_receiver(self, backend_new_profile, backend_factory):
         # Create users
         alice = backend_new_profile()
         bob = backend_new_profile()
-        bob_second_device = StatusBackend()
+        bob_second_device = backend_factory()
         bob_second_device.init_status_backend()
 
         # Make contacts before local pairing
@@ -273,12 +273,12 @@ class TestLocalPairing(MessengerSteps):
         messages = bob_second_device.wakuext_service.chat_messages(sender_chat_id, limit=10)["messages"]
         assert messages is None, "Messages found on paired device wrongly"
 
-    def test_pairing_three_devices(self, backend_new_profile):
+    def test_pairing_three_devices(self, backend_new_profile, backend_factory):
         # Create users
         bob1 = backend_new_profile()
-        bob2 = StatusBackend()
+        bob2 = backend_factory()
         bob2.init_status_backend()
-        bob3 = StatusBackend()
+        bob3 = backend_factory()
         bob3.init_status_backend()
         user_accepted = backend_new_profile()
         user_pending = backend_new_profile()

--- a/tests-functional/tests/test_push_notification_server.py
+++ b/tests-functional/tests/test_push_notification_server.py
@@ -34,8 +34,7 @@ def push_notification_server(gorush_stub):
     """
     server = PushNotificationServer(gorush_port=gorush_stub.server.server_port)
     yield server, gorush_stub
-    if server.container:
-        server.container.stop()
+    server.shutdown()
 
 
 def expect_push_notification(gorush, sender, receiver):


### PR DESCRIPTION
# Description

1. Remove all dangling containers in Jenkinsfile.
This was my oopsie from https://github.com/status-im/status-go/pull/7076

2. Replace direct usage of `StatusBackend` with `backend_factory` to ensure containers get shutdown.