### PR TITLE
fix(backup): skip CR for removed contacts and send partial result in case of error

### DIFF
--- a/protocol/messenger_backup_handler.go
+++ b/protocol/messenger_backup_handler.go
@@ -193,6 +193,7 @@ func (m *Messenger) handleLocalBackupCommunities(state *ReceivedMessageState, co
 		err := m.handleSyncInstallationCommunity(context.Background(), state, syncCommunity)
 		if err != nil {
 			errors = append(errors, err)
+			continue
 		}
 
 		err = m.requestCommunityKeysAndSharedAddresses(syncCommunity)

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -542,34 +542,6 @@ func (m *Messenger) HandleSyncInstallationContactV2(ctx context.Context, state *
 			if err != nil {
 				return err
 			}
-		} else if message.Added || message.HasAddedUs {
-			// NOTE(cammellos): this is for handling backward compatibility, old clients
-			// won't propagate ContactRequestRemoteClock or ContactRequestLocalClock
-
-			if message.Added && contact.LastUpdatedLocally < message.LastUpdatedLocally {
-				contact.ContactRequestSent(message.LastUpdatedLocally)
-
-				err := m.syncContactRequestForInstallationContact(contact, state, chat, true)
-				if err != nil {
-					return err
-				}
-			}
-
-			if message.HasAddedUs && contact.LastUpdated < message.LastUpdated {
-				contact.ContactRequestReceived(message.LastUpdated)
-
-				err := m.syncContactRequestForInstallationContact(contact, state, chat, false)
-				if err != nil {
-					return err
-				}
-			}
-
-			if message.Removed && contact.LastUpdatedLocally < message.LastUpdatedLocally {
-				err := m.removeContact(context.Background(), state.Response, contact.ID, false)
-				if err != nil {
-					return err
-				}
-			}
 		}
 	}
 

--- a/protocol/messenger_handler.go
+++ b/protocol/messenger_handler.go
@@ -525,47 +525,50 @@ func (m *Messenger) HandleSyncInstallationContactV2(ctx context.Context, state *
 		}
 	}
 
-	if message.ContactRequestRemoteClock != 0 || message.ContactRequestLocalClock != 0 {
-		// Some local action about contact requests were performed,
-		// process them
-		contact.ProcessSyncContactRequestState(
-			contacts.ContactRequestState(message.ContactRequestRemoteState),
-			uint64(message.ContactRequestRemoteClock),
-			contacts.ContactRequestState(message.ContactRequestLocalState),
-			uint64(message.ContactRequestLocalClock))
-		state.ModifiedContacts.Store(contact.ID, true)
-		state.AllContacts.Store(contact.ID, contact)
+	// Check if we need to create a contact request
+	if chat != nil {
+		if message.ContactRequestRemoteClock != 0 || message.ContactRequestLocalClock != 0 {
+			// Some local action about contact requests were performed,
+			// process them
+			contact.ProcessSyncContactRequestState(
+				contacts.ContactRequestState(message.ContactRequestRemoteState),
+				uint64(message.ContactRequestRemoteClock),
+				contacts.ContactRequestState(message.ContactRequestLocalState),
+				uint64(message.ContactRequestLocalClock))
+			state.ModifiedContacts.Store(contact.ID, true)
+			state.AllContacts.Store(contact.ID, contact)
 
-		err := m.syncContactRequestForInstallationContact(contact, state, chat, contact.ContactRequestLocalState == contacts.ContactRequestStateSent)
-		if err != nil {
-			return err
-		}
-	} else if message.Added || message.HasAddedUs {
-		// NOTE(cammellos): this is for handling backward compatibility, old clients
-		// won't propagate ContactRequestRemoteClock or ContactRequestLocalClock
-
-		if message.Added && contact.LastUpdatedLocally < message.LastUpdatedLocally {
-			contact.ContactRequestSent(message.LastUpdatedLocally)
-
-			err := m.syncContactRequestForInstallationContact(contact, state, chat, true)
+			err := m.syncContactRequestForInstallationContact(contact, state, chat, contact.ContactRequestLocalState == contacts.ContactRequestStateSent)
 			if err != nil {
 				return err
 			}
-		}
+		} else if message.Added || message.HasAddedUs {
+			// NOTE(cammellos): this is for handling backward compatibility, old clients
+			// won't propagate ContactRequestRemoteClock or ContactRequestLocalClock
 
-		if message.HasAddedUs && contact.LastUpdated < message.LastUpdated {
-			contact.ContactRequestReceived(message.LastUpdated)
+			if message.Added && contact.LastUpdatedLocally < message.LastUpdatedLocally {
+				contact.ContactRequestSent(message.LastUpdatedLocally)
 
-			err := m.syncContactRequestForInstallationContact(contact, state, chat, false)
-			if err != nil {
-				return err
+				err := m.syncContactRequestForInstallationContact(contact, state, chat, true)
+				if err != nil {
+					return err
+				}
 			}
-		}
 
-		if message.Removed && contact.LastUpdatedLocally < message.LastUpdatedLocally {
-			err := m.removeContact(context.Background(), state.Response, contact.ID, false)
-			if err != nil {
-				return err
+			if message.HasAddedUs && contact.LastUpdated < message.LastUpdated {
+				contact.ContactRequestReceived(message.LastUpdated)
+
+				err := m.syncContactRequestForInstallationContact(contact, state, chat, false)
+				if err != nil {
+					return err
+				}
+			}
+
+			if message.Removed && contact.LastUpdatedLocally < message.LastUpdatedLocally {
+				err := m.removeContact(context.Background(), state.Response, contact.ID, false)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/protocol/messenger_local_backup.go
+++ b/protocol/messenger_local_backup.go
@@ -313,13 +313,18 @@ func (m *Messenger) ImportBackup(data []byte) error {
 		&state,
 		&backup,
 	)
+	// Proceed to save data even if there were errors during handling because some data might have been handled successfully
+	response, err := m.saveDataAndPrepareResponse(&state)
+	if response != nil {
+		// Send response even if there were errors as some data might have been saved successfully
+		signal.SendNewMessages(response)
+	}
+	if err != nil {
+		errs = append(errs, err)
+	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
 
-	response, err := m.saveDataAndPrepareResponse(&state)
-
-	signal.SendNewMessages(response)
-
-	return err
+	return nil
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-go/pull/7203

Fixes https://github.com/status-im/status-app/issues/19557

There were two issues:
1. We tried to generate a Contact request for removed contacts, so that obviously failed for no reason, stopping the saving of contacts
2. More importantly, if there were errors, we didn't call the save and signals, even if 99% of the data was working. So we send the error at the very end instead
