### PR TITLE
ci: stricter codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,12 +18,12 @@ coverage:
     project:
       unit-tests:
         target: auto
-        threshold: 10%
+        threshold: 5%
         if_not_found: failure
         flags:
           - unit
       functional-tests:
-        threshold: 10%
+        threshold: 5%
         target: auto
         if_not_found: failure
         flags:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,11 +19,13 @@ coverage:
       unit-tests:
         target: auto
         threshold: 10%
+        if_not_found: failure
         flags:
           - unit
       functional-tests:
         threshold: 10%
         target: auto
+        if_not_found: failure
         flags:
           - functional
     patch:


### PR DESCRIPTION
10% was quite generous. 
While losing 5% coverage is already a sign of something going wrong.

Such config would prevent https://github.com/status-im/status-go/issues/7216