### PR TITLE
refactor: stop messaging alongside messenger

### DIFF
--- a/pkg/messaging/core_test_utils.go
+++ b/pkg/messaging/core_test_utils.go
@@ -16,8 +16,6 @@ type TestMessagingEnvironment struct {
 	// To enable communication between multiple messaging core instances in tests,
 	// share a single Waku instance across them.
 	waku *testWakuWrapper
-
-	cores []*Core
 }
 
 func NewTestMessagingEnvironment() (*TestMessagingEnvironment, error) {
@@ -27,8 +25,7 @@ func NewTestMessagingEnvironment() (*TestMessagingEnvironment, error) {
 	}
 
 	return &TestMessagingEnvironment{
-		waku:  waku,
-		cores: make([]*Core, 0),
+		waku: waku,
 	}, nil
 }
 
@@ -37,13 +34,6 @@ func (f *TestMessagingEnvironment) Setup() error {
 }
 
 func (f *TestMessagingEnvironment) TearDown() error {
-	for _, core := range f.cores {
-		if err := core.stop(); err != nil {
-			return err
-		}
-	}
-	f.cores = make([]*Core, 0)
-
 	return f.waku.Waku.Stop()
 }
 
@@ -52,7 +42,6 @@ func (f *TestMessagingEnvironment) NewTestCore(params CoreParams, options ...Opt
 	if err != nil {
 		return nil, err
 	}
-	f.cores = append(f.cores, core)
 	return core, nil
 }
 

--- a/protocol/messenger_offline_test.go
+++ b/protocol/messenger_offline_test.go
@@ -60,9 +60,9 @@ func (s *MessengerOfflineSuite) SetupTest() {
 }
 
 func (s *MessengerOfflineSuite) TearDownTest() {
-	s.Require().NoError(s.owner.Shutdown())
-	s.Require().NoError(s.bob.Shutdown())
-	s.Require().NoError(s.alice.Shutdown())
+	TearDownMessenger(&s.Suite, s.owner)
+	TearDownMessenger(&s.Suite, s.bob)
+	TearDownMessenger(&s.Suite, s.alice)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/messenger_sync_activity_center_test.go
+++ b/protocol/messenger_sync_activity_center_test.go
@@ -125,7 +125,7 @@ func (s *MessengerSyncActivityCenterSuite) testSyncCommunityRequestDecision(acti
 
 	userB := s.newMessenger(accountPassword, []string{commonAccountAddress})
 	defer func() {
-		s.Require().NoError(userB.Shutdown())
+		TearDownMessenger(&s.Suite, userB)
 	}()
 
 	_, err := userB.Start()

--- a/protocol/messenger_sync_contact_request_decision_test.go
+++ b/protocol/messenger_sync_contact_request_decision_test.go
@@ -32,7 +32,7 @@ func (s *MessengerSyncContactRequestDecisionSuite) SetupTest() {
 }
 
 func (s *MessengerSyncContactRequestDecisionSuite) TearDownTest() {
-	s.Require().NoError(s.m2.Shutdown())
+	TearDownMessenger(&s.Suite, s.m2)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -232,6 +232,7 @@ func TearDownMessenger(s *suite.Suite, m *Messenger) {
 		return
 	}
 	s.Require().NoError(m.Shutdown())
+	s.Require().NoError(m.Messaging().Stop())
 	if m.database != nil {
 		s.Require().NoError(m.database.Close())
 	}


### PR DESCRIPTION
This is a bit cleaner, as messaging is stopped together with messenger it was created for. There is no need to store core references in `TestMessagingEnvironment`.
