### PR TITLE
fix: reliable messenger cleanup in tests

### DIFF
--- a/cmd/push-notification-server/main.go
+++ b/cmd/push-notification-server/main.go
@@ -193,6 +193,10 @@ func main() {
 		os.Exit(exitCodeStartServerFailed)
 	}
 
+	defer func() {
+		server.Stop()
+	}()
+
 	_, err = messenger.Start()
 	if err != nil {
 		fmt.Println("failed to start messenger", err)

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/status-im/doubleratchet v3.0.0+incompatible
 	github.com/status-im/markdown v0.0.0-20250825083641-55c1df9bc05d
 	github.com/status-im/migrate/v4 v4.6.2-status.3
-	github.com/status-im/mvds v0.0.27-0.20251218214347-120f6178db6e
+	github.com/status-im/mvds v0.0.27-0.20251219201002-7226facd5aaf
 	github.com/status-im/zxcvbn-go v0.0.0-20220311183720-5e8676676857
 	github.com/stretchr/testify v1.11.1
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a // indirect

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/status-im/doubleratchet v3.0.0+incompatible
 	github.com/status-im/markdown v0.0.0-20250825083641-55c1df9bc05d
 	github.com/status-im/migrate/v4 v4.6.2-status.3
-	github.com/status-im/mvds v0.0.27-0.20251022120125-7bdc695d49c4
+	github.com/status-im/mvds v0.0.27-0.20251218214347-120f6178db6e
 	github.com/status-im/zxcvbn-go v0.0.0-20220311183720-5e8676676857
 	github.com/stretchr/testify v1.11.1
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a // indirect

--- a/go.sum
+++ b/go.sum
@@ -2291,8 +2291,8 @@ github.com/status-im/markdown v0.0.0-20250825083641-55c1df9bc05d h1:0jQiaymp0t7X
 github.com/status-im/markdown v0.0.0-20250825083641-55c1df9bc05d/go.mod h1:i31M0FhtYMUeAzWqJafla0Q4+LCGJyorLRCH3EorAWQ=
 github.com/status-im/migrate/v4 v4.6.2-status.3 h1:Khwjb59NzniloUr5i9s9AtkEyqBbQFt1lkoAu66sAu0=
 github.com/status-im/migrate/v4 v4.6.2-status.3/go.mod h1:c/kc90n47GZu/58nnz1OMLTf7uE4Da4gZP5qmU+A/v8=
-github.com/status-im/mvds v0.0.27-0.20251022120125-7bdc695d49c4 h1:NrTkZgbgEu7hOJ2Ku4P1yj9boRzdpMs7OlZREBy6MyE=
-github.com/status-im/mvds v0.0.27-0.20251022120125-7bdc695d49c4/go.mod h1:2fiAx0q9XYIPKYRq2B1oiO9zZESy/n4D32gWw6lMDsE=
+github.com/status-im/mvds v0.0.27-0.20251218214347-120f6178db6e h1:KzGXeyj/npZMbF+9iDqZWWnvdodYjW/t4qFdPp0fN3E=
+github.com/status-im/mvds v0.0.27-0.20251218214347-120f6178db6e/go.mod h1:2fiAx0q9XYIPKYRq2B1oiO9zZESy/n4D32gWw6lMDsE=
 github.com/status-im/zxcvbn-go v0.0.0-20220311183720-5e8676676857 h1:sPkzT7Z7uLmejOsBRlZ0kwDWpqjpHJsp834o5nbhqho=
 github.com/status-im/zxcvbn-go v0.0.0-20220311183720-5e8676676857/go.mod h1:lq9I5ROto5tcua65GmCE6SIW7VE0ucdEBs1fn4z7uWU=
 github.com/stbenjam/no-sprintf-host-port v0.1.1 h1:tYugd/yrm1O0dV+ThCbaKZh195Dfm07ysF0U6JQXczc=

--- a/go.sum
+++ b/go.sum
@@ -2293,6 +2293,8 @@ github.com/status-im/migrate/v4 v4.6.2-status.3 h1:Khwjb59NzniloUr5i9s9AtkEyqBbQ
 github.com/status-im/migrate/v4 v4.6.2-status.3/go.mod h1:c/kc90n47GZu/58nnz1OMLTf7uE4Da4gZP5qmU+A/v8=
 github.com/status-im/mvds v0.0.27-0.20251218214347-120f6178db6e h1:KzGXeyj/npZMbF+9iDqZWWnvdodYjW/t4qFdPp0fN3E=
 github.com/status-im/mvds v0.0.27-0.20251218214347-120f6178db6e/go.mod h1:2fiAx0q9XYIPKYRq2B1oiO9zZESy/n4D32gWw6lMDsE=
+github.com/status-im/mvds v0.0.27-0.20251219201002-7226facd5aaf h1:CKUQmbtf0fodAQRwAcORa8Fk2Ej6x6PMn/yKipK14Es=
+github.com/status-im/mvds v0.0.27-0.20251219201002-7226facd5aaf/go.mod h1:2fiAx0q9XYIPKYRq2B1oiO9zZESy/n4D32gWw6lMDsE=
 github.com/status-im/zxcvbn-go v0.0.0-20220311183720-5e8676676857 h1:sPkzT7Z7uLmejOsBRlZ0kwDWpqjpHJsp834o5nbhqho=
 github.com/status-im/zxcvbn-go v0.0.0-20220311183720-5e8676676857/go.mod h1:lq9I5ROto5tcua65GmCE6SIW7VE0ucdEBs1fn4z7uWU=
 github.com/stbenjam/no-sprintf-host-port v0.1.1 h1:tYugd/yrm1O0dV+ThCbaKZh195Dfm07ysF0U6JQXczc=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-ly3fjFZgtxaTbVn6Kw8f7q7c8jU3kRliR6dRNmjDldw=";
+  vendorHash = "sha256-AyGE2nIaVQX4md/Rh0GeykThu8SRL/O/Rb2ZuJkPQFo=";
 
   inherit meta version;
 

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-AyGE2nIaVQX4md/Rh0GeykThu8SRL/O/Rb2ZuJkPQFo=";
+  vendorHash = "sha256-fvEBn/FYsineTe65PEwr4U71ZZqL5BMOsSe9wKuBb0Y=";
 
   inherit meta version;
 

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -2074,14 +2074,6 @@ func (b *StatusBackend) Logout() error {
 	defer b.mu.Unlock()
 
 	b.logger.Debug("logging out")
-	err := b.cleanupServices()
-	if err != nil {
-		return err
-	}
-	err = b.closeDBs()
-	if err != nil {
-		return err
-	}
 
 	b.AccountsManager().Logout()
 	b.account = nil
@@ -2091,6 +2083,11 @@ func (b *StatusBackend) Logout() error {
 			return err
 		}
 		b.statusNode = nil
+	}
+
+	err := b.closeDBs()
+	if err != nil {
+		return err
 	}
 
 	if !b.LocalPairingStateManager.IsPairing() {
@@ -2122,14 +2119,6 @@ func (b *StatusBackend) Logout() error {
 func (b *StatusBackend) switchToPreLoginLog() error {
 	_ = logutils2.ZapLogger().Sync()
 	return logutils2.OverrideRootLoggerWithConfig(b.preLoginLogConfig.ConvertToLogSettings())
-}
-
-// cleanupServices stops parts of services that aren't managed by a node and removes injected data from services.
-func (b *StatusBackend) cleanupServices() error {
-	if b.statusNode == nil {
-		return nil
-	}
-	return b.statusNode.Cleanup()
 }
 
 func (b *StatusBackend) closeDBs() error {

--- a/pkg/backend/node/status_node_services.go
+++ b/pkg/backend/node/status_node_services.go
@@ -472,32 +472,3 @@ func (b *StatusNode) NewsFeedService() *newsfeed.Service {
 	}
 	return b.newsfeedSrvc
 }
-
-func (b *StatusNode) Cleanup() error {
-	if b.Config() != nil && b.Config().WalletConfig.Enabled {
-		if b.walletSrvc != nil {
-			if b.walletSrvc.IsStarted() {
-				err := b.walletSrvc.Stop()
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	if b.ensSrvc != nil {
-		err := b.ensSrvc.Stop()
-		if err != nil {
-			return err
-		}
-	}
-
-	if b.pendingTracker != nil {
-		err := b.pendingTracker.Stop()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}

--- a/pkg/messaging/core_test_utils.go
+++ b/pkg/messaging/core_test_utils.go
@@ -46,10 +46,6 @@ func (f *TestMessagingEnvironment) Setup(t *testing.T) error {
 	return nil
 }
 
-func (f *TestMessagingEnvironment) TearDown() error {
-	return f.waku.Waku.Stop()
-}
-
 func (f *TestMessagingEnvironment) NewTestCore(params CoreParams, options ...Options) (*Core, error) {
 	return newCore(f.waku, params, newConfig(options...))
 }

--- a/pkg/messaging/core_test_utils.go
+++ b/pkg/messaging/core_test_utils.go
@@ -3,6 +3,7 @@ package messaging
 import (
 	"context"
 	"crypto/ecdsa"
+	"testing"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -16,8 +17,6 @@ type TestMessagingEnvironment struct {
 	// To enable communication between multiple messaging core instances in tests,
 	// share a single Waku instance across them.
 	waku *testWakuWrapper
-
-	cores []*Core
 }
 
 func NewTestMessagingEnvironment() (*TestMessagingEnvironment, error) {
@@ -27,33 +26,32 @@ func NewTestMessagingEnvironment() (*TestMessagingEnvironment, error) {
 	}
 
 	return &TestMessagingEnvironment{
-		waku:  waku,
-		cores: make([]*Core, 0),
+		waku: waku,
 	}, nil
 }
 
-func (f *TestMessagingEnvironment) Setup() error {
-	return f.waku.Waku.Start()
+func (f *TestMessagingEnvironment) Setup(t *testing.T) error {
+	err := f.waku.Waku.Start()
+	if err != nil {
+		return err
+	}
+
+	t.Cleanup(func() {
+		err = f.waku.Waku.Stop()
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	return nil
 }
 
 func (f *TestMessagingEnvironment) TearDown() error {
-	for _, core := range f.cores {
-		if err := core.stop(); err != nil {
-			return err
-		}
-	}
-	f.cores = make([]*Core, 0)
-
 	return f.waku.Waku.Stop()
 }
 
 func (f *TestMessagingEnvironment) NewTestCore(params CoreParams, options ...Options) (*Core, error) {
-	core, err := newCore(f.waku, params, newConfig(options...))
-	if err != nil {
-		return nil, err
-	}
-	f.cores = append(f.cores, core)
-	return core, nil
+	return newCore(f.waku, params, newConfig(options...))
 }
 
 func (f *TestMessagingEnvironment) SubscribePostEvents() chan *PostMessageSubscription {

--- a/pkg/messaging/layers/encryption/publisher/publisher.go
+++ b/pkg/messaging/layers/encryption/publisher/publisher.go
@@ -3,6 +3,7 @@ package publisher
 import (
 	"crypto/ecdsa"
 	"errors"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -30,6 +31,7 @@ type Publisher struct {
 	logger      *zap.Logger
 	notifyCh    chan struct{}
 	quit        chan struct{}
+	quitWg      sync.WaitGroup
 }
 
 func New(logger *zap.Logger) *Publisher {
@@ -51,7 +53,12 @@ func (p *Publisher) Start() <-chan struct{} {
 	p.notifyCh = make(chan struct{}, 100)
 	p.quit = make(chan struct{})
 
-	go p.tickerLoop()
+	p.quitWg.Add(1)
+	go func() {
+		defer gocommon.LogOnPanic()
+		p.quitWg.Done()
+		p.tickerLoop()
+	}()
 
 	return p.notifyCh
 }
@@ -70,34 +77,30 @@ func (p *Publisher) Stop() {
 	default:
 		close(p.quit)
 	}
+	p.quitWg.Wait()
 }
 
 func (p *Publisher) tickerLoop() {
-	defer gocommon.LogOnPanic()
 	ticker := time.NewTicker(tickerInterval * time.Second)
+	logger := p.logger.With(zap.String("site", "tickerLoop"))
 
-	go func() {
-		defer gocommon.LogOnPanic()
-		logger := p.logger.With(zap.String("site", "tickerLoop"))
-
-		for {
-			select {
-			case <-ticker.C:
-				err := p.notify()
-				switch err {
-				case errNotEnoughTimePassed:
-					logger.Debug("not enough time passed")
-				case nil:
-					// skip
-				default:
-					logger.Error("error while sending a contact code", zap.Error(err))
-				}
-			case <-p.quit:
-				ticker.Stop()
-				return
+	for {
+		select {
+		case <-ticker.C:
+			err := p.notify()
+			switch err {
+			case errNotEnoughTimePassed:
+				logger.Debug("not enough time passed")
+			case nil:
+				// skip
+			default:
+				logger.Error("error while sending a contact code", zap.Error(err))
 			}
+		case <-p.quit:
+			ticker.Stop()
+			return
 		}
-	}()
+	}
 }
 
 func (p *Publisher) notify() error {

--- a/pkg/messaging/layers/reliability/datasync/transport.go
+++ b/pkg/messaging/layers/reliability/datasync/transport.go
@@ -1,6 +1,7 @@
 package datasync
 
 import (
+	"context"
 	"errors"
 	"math"
 	"math/rand"
@@ -44,8 +45,13 @@ func (t *NodeTransport) AddPacket(p transport.Packet) {
 	t.packets <- p
 }
 
-func (t *NodeTransport) Watch() transport.Packet {
-	return <-t.packets
+func (t *NodeTransport) Watch(ctx context.Context) (*transport.Packet, bool) {
+	select {
+	case <-ctx.Done():
+		return nil, false
+	case p := <-t.packets:
+		return &p, true
+	}
 }
 
 func (t *NodeTransport) Send(_ state.PeerID, peer state.PeerID, payload *protobuf.Payload) error {

--- a/protocol/common/message_sender.go
+++ b/protocol/common/message_sender.go
@@ -81,10 +81,10 @@ func setMessageID(messageID types2.HexBytes, rawMessage *RawMessage) error {
 
 func (s *MessageSender) Start() {
 	s.wg.Add(1)
-	defer s.wg.Done()
 
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer s.wg.Done()
 
 		sentMessagesSub, unsubSentMessages := pubsub.Subscribe[messagingevents.SentMessage](s.messaging.Publisher(), 100)
 		defer unsubSentMessages()

--- a/protocol/communities/manager.go
+++ b/protocol/communities/manager.go
@@ -112,11 +112,11 @@ type Manager struct {
 	messaging                *messaging.API
 	timesource               common.TimeSource
 	quit                     chan struct{}
+	quitWg                   sync.WaitGroup
 	communityTokensService   CommunityTokensServiceInterface
 	membersReevaluationTasks sync.Map // stores `membersReevaluationTask`
 	forceMembersReevaluation map[string]chan struct{}
 	stopped                  bool
-	RekeyInterval            time.Duration
 	PermissionChecker        PermissionChecker
 	keyDistributor           KeyDistributor
 	communityLock            *CommunityLock
@@ -532,8 +532,10 @@ func (m *Manager) Start() error {
 		m.runOwnerVerificationLoop()
 	}
 
+	m.quitWg.Add(1)
 	go func() {
 		defer utils.LogOnPanic()
+		defer m.quitWg.Done()
 		_ = m.fillMissingCommunityTokens()
 	}()
 
@@ -541,8 +543,10 @@ func (m *Manager) Start() error {
 }
 
 func (m *Manager) runENSVerificationLoop() {
+	m.quitWg.Add(1)
 	go func() {
 		defer utils.LogOnPanic()
+		defer m.quitWg.Done()
 		for {
 			select {
 			case <-m.quit:
@@ -622,8 +626,10 @@ func (m *Manager) CommunitiesToValidate() (map[string][]communityToValidate, err
 
 func (m *Manager) runOwnerVerificationLoop() {
 	m.logger.Info("starting owner verification loop")
+	m.quitWg.Add(1)
 	go func() {
 		defer utils.LogOnPanic()
+		defer m.quitWg.Done()
 		for {
 			select {
 			case <-m.quit:
@@ -724,6 +730,7 @@ func (m *Manager) Stop() error {
 	for _, c := range m.subscriptions {
 		close(c)
 	}
+	m.quitWg.Wait()
 	return nil
 }
 
@@ -1347,11 +1354,15 @@ func (m *Manager) checkChannelsPermissions(channelsPermissionsPreParsedData map[
 }
 
 func (m *Manager) StartMembersReevaluationLoop(communityID types3.HexBytes, reevaluateOnStart bool) {
-	go m.reevaluateMembersLoop(communityID, reevaluateOnStart)
+	m.quitWg.Add(1)
+	go func() {
+		defer utils.LogOnPanic()
+		defer m.quitWg.Done()
+		m.reevaluateMembersLoop(communityID, reevaluateOnStart)
+	}()
 }
 
 func (m *Manager) reevaluateMembersLoop(communityID types3.HexBytes, reevaluateOnStart bool) {
-	defer utils.LogOnPanic()
 	if _, exists := m.membersReevaluationTasks.Load(communityID.String()); exists {
 		return
 	}

--- a/protocol/communities_events_eventual_consistency_test.go
+++ b/protocol/communities_events_eventual_consistency_test.go
@@ -35,12 +35,6 @@ func (s *CommunityEventsEventualConsistencySuite) SetupTest() {
 	s.owner = s.newMessenger("", []string{})
 	s.eventSender = s.newMessenger(accountPassword, []string{eventsSenderAccountAddress})
 	s.alice = s.newMessenger(accountPassword, []string{aliceAccountAddress})
-	_, err := s.owner.Start()
-	s.Require().NoError(err)
-	_, err = s.eventSender.Start()
-	s.Require().NoError(err)
-	_, err = s.alice.Start()
-	s.Require().NoError(err)
 
 }
 

--- a/protocol/communities_events_eventual_consistency_test.go
+++ b/protocol/communities_events_eventual_consistency_test.go
@@ -56,7 +56,6 @@ func (s *CommunityEventsEventualConsistencySuite) newMessenger(password string, 
 }
 
 func (s *CommunityEventsEventualConsistencySuite) TearDownTest() {
-	s.EventSenderCommunityEventsSuiteBase.TearDownTest()
 	s.messagesOrderController.Stop()
 }
 
@@ -73,7 +72,6 @@ func (s *CommunityEventsEventualConsistencySuite) testRequestsToJoin(actions []r
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	advertiseCommunityToUserOldWay(&s.Suite, community, s.owner, user)
 

--- a/protocol/communities_events_owner_without_community_key_test.go
+++ b/protocol/communities_events_owner_without_community_key_test.go
@@ -50,7 +50,6 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerAcceptMemberRequ
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalOwner)
 }
@@ -60,7 +59,6 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerAcceptMemberRequ
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testAcceptMemberRequestToJoin(s, community, user)
 }
@@ -71,7 +69,6 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerRejectMemberRequ
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalOwner)
 }
@@ -81,7 +78,6 @@ func (s *OwnerWithoutCommunityKeyCommunityEventsSuite) TestOwnerRejectMemberRequ
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testRejectMemberRequestToJoin(s, community, user)
 }

--- a/protocol/communities_events_token_master_test.go
+++ b/protocol/communities_events_token_master_test.go
@@ -71,7 +71,6 @@ func (s *TokenMasterCommunityEventsSuite) TestTokenMasterAcceptMemberRequestToJo
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{})
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testAcceptMemberRequestToJoin(s, community, user)
 }
@@ -82,7 +81,6 @@ func (s *TokenMasterCommunityEventsSuite) TestTokenMasterAcceptMemberRequestToJo
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalTokenMaster)
 }
@@ -92,7 +90,6 @@ func (s *TokenMasterCommunityEventsSuite) TestTokenMasterRejectMemberRequestToJo
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{additionalTokenMaster})
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testRejectMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalTokenMaster)
 }
@@ -101,7 +98,6 @@ func (s *TokenMasterCommunityEventsSuite) TestTokenMasterRejectMemberRequestToJo
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_TOKEN_MASTER, []*Messenger{})
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testRejectMemberRequestToJoin(s, community, user)
 }
@@ -207,14 +203,12 @@ func (s *TokenMasterCommunityEventsSuite) TestJoinedTokenMasterReceiveRequestsTo
 	// set up additional user that will join to the community as TokenMaster
 	newPrivilegedUser := s.newMessenger(accountPassword, []string{eventsSenderAccountAddress})
 
-	s.SetupAdditionalMessengers([]*Messenger{bob, newPrivilegedUser})
 	testJoinedPrivilegedMemberReceiveRequestsToJoin(s, community, bob, newPrivilegedUser, protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER)
 }
 
 func (s *TokenMasterCommunityEventsSuite) TestReceiveRequestsToJoinWithRevealedAccountsAfterGettingTokenMasterRole() {
 	// set up additional user (bob) that will send request to join
 	bob := s.newMessenger(accountPassword, []string{bobAccountAddress})
-	s.SetupAdditionalMessengers([]*Messenger{bob})
 	testMemberReceiveRequestsToJoinAfterGettingNewRole(s, bob, protobuf.CommunityTokenPermission_BECOME_TOKEN_MASTER)
 }
 
@@ -223,7 +217,6 @@ func (s *TokenMasterCommunityEventsSuite) TestTokenMasterAcceptsRequestToJoinAft
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 	testPrivilegedMemberAcceptsRequestToJoinAfterMemberLeave(s, community, user)
 }
 

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1407,10 +1407,7 @@ func testRejectMemberRequestToJoin(base CommunityEventsTestsInterface, community
 }
 
 func testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(base CommunityEventsTestsInterface, community *communities.Community, user *Messenger, additionalEventSender *Messenger) {
-	_, err := user.Start()
-
 	s := base.GetSuite()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), user)
 
 	advertiseCommunityToUserOldWay(s, community, base.GetControlNode(), user)
@@ -1419,7 +1416,7 @@ func testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(base Commun
 	requestID := testSendRequestToJoin(base, user, community.ID())
 
 	// event sender receives request to join
-	_, err = WaitOnMessengerResponse(
+	_, err := WaitOnMessengerResponse(
 		base.GetEventSender(),
 		func(r *MessengerResponse) bool {
 			return checkRequestToJoinInResponse(r, user, communities.RequestToJoinStatePending, 0)

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -28,7 +28,6 @@ type CommunityEventsTestsInterface interface {
 	GetMember() *Messenger
 	GetSuite() *suite.Suite
 	GetCollectiblesServiceMock() *CollectiblesServiceMock
-	SetupAdditionalMessengers([]*Messenger)
 	GetAccountsTestData() map[string][]string
 	GetAccountsPasswords() map[string]string
 }
@@ -406,8 +405,6 @@ func assertCheckTokenPermissionCreated(s *suite.Suite, community *communities.Co
 }
 
 func setUpOnRequestCommunityAndRoles(base CommunityEventsTestsInterface, role protobuf.CommunityMember_Roles, additionalEventSenders []*Messenger) *communities.Community {
-	base.SetupAdditionalMessengers(additionalEventSenders)
-
 	tcs2, err := base.GetControlNode().communitiesManager.All()
 	s := base.GetSuite()
 	s.Require().NoError(err, "eventSender.communitiesManager.All")
@@ -1408,7 +1405,6 @@ func testRejectMemberRequestToJoin(base CommunityEventsTestsInterface, community
 
 func testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(base CommunityEventsTestsInterface, community *communities.Community, user *Messenger, additionalEventSender *Messenger) {
 	s := base.GetSuite()
-	defer TearDownMessenger(s.T(), user)
 
 	advertiseCommunityToUserOldWay(s, community, base.GetControlNode(), user)
 

--- a/protocol/communities_events_utils_test.go
+++ b/protocol/communities_events_utils_test.go
@@ -1411,7 +1411,7 @@ func testControlNodeHandlesMultipleEventSenderRequestToJoinDecisions(base Commun
 
 	s := base.GetSuite()
 	s.Require().NoError(err)
-	defer TearDownMessenger(s, user)
+	defer TearDownMessenger(s.T(), user)
 
 	advertiseCommunityToUserOldWay(s, community, base.GetControlNode(), user)
 

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -65,12 +65,6 @@ func (s *EventSenderCommunityEventsSuiteBase) SetupTest() {
 	s.owner = s.newMessenger("", []string{})
 	s.eventSender = s.newMessenger(accountPassword, []string{eventsSenderAccountAddress})
 	s.alice = s.newMessenger(accountPassword, []string{aliceAccountAddress})
-	_, err := s.owner.Start()
-	s.Require().NoError(err)
-	_, err = s.eventSender.Start()
-	s.Require().NoError(err)
-	_, err = s.alice.Start()
-	s.Require().NoError(err)
 }
 
 func (s *EventSenderCommunityEventsSuiteBase) newMessenger(password string, walletAddresses []string) *Messenger {
@@ -103,8 +97,6 @@ func (s *EventSenderCommunityEventsSuiteBase) TearDownTest() {
 func (s *EventSenderCommunityEventsSuiteBase) SetupAdditionalMessengers(messengers []*Messenger) {
 	for _, m := range messengers {
 		s.additionalEventSenders = append(s.additionalEventSenders, m)
-		_, err := m.Start()
-		s.Require().NoError(err)
 	}
 }
 

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -88,12 +88,12 @@ func (s *EventSenderCommunityEventsSuiteBase) newMessenger(password string, wall
 }
 
 func (s *EventSenderCommunityEventsSuiteBase) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.owner)
-	TearDownMessenger(&s.Suite, s.eventSender)
-	TearDownMessenger(&s.Suite, s.alice)
+	TearDownMessenger(s.T(), s.owner)
+	TearDownMessenger(s.T(), s.eventSender)
+	TearDownMessenger(s.T(), s.alice)
 
 	for _, m := range s.additionalEventSenders {
-		TearDownMessenger(&s.Suite, m)
+		TearDownMessenger(s.T(), m)
 	}
 	s.additionalEventSenders = nil
 

--- a/protocol/communities_messenger_admin_test.go
+++ b/protocol/communities_messenger_admin_test.go
@@ -22,8 +22,6 @@ type EventSenderCommunityEventsSuiteBase struct {
 	owner       *Messenger
 	eventSender *Messenger
 	alice       *Messenger
-
-	additionalEventSenders []*Messenger
 }
 
 type AdminCommunityEventsSuite struct {
@@ -79,25 +77,6 @@ func (s *EventSenderCommunityEventsSuiteBase) newMessenger(password string, wall
 		privateKey:   privateKey,
 		extraOptions: []Option{WithCommunityManagerOptions(communityManagerOptions)},
 	}, password, walletAddresses)
-}
-
-func (s *EventSenderCommunityEventsSuiteBase) TearDownTest() {
-	TearDownMessenger(s.T(), s.owner)
-	TearDownMessenger(s.T(), s.eventSender)
-	TearDownMessenger(s.T(), s.alice)
-
-	for _, m := range s.additionalEventSenders {
-		TearDownMessenger(s.T(), m)
-	}
-	s.additionalEventSenders = nil
-
-	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
-}
-
-func (s *EventSenderCommunityEventsSuiteBase) SetupAdditionalMessengers(messengers []*Messenger) {
-	for _, m := range messengers {
-		s.additionalEventSenders = append(s.additionalEventSenders, m)
-	}
 }
 
 func (s *AdminCommunityEventsSuite) TestAdminEditCommunityDescription() {
@@ -156,7 +135,6 @@ func (s *AdminCommunityEventsSuite) TestAdminAcceptMemberRequestToJoinResponseSh
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testAcceptMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalAdmin)
 }
@@ -166,7 +144,6 @@ func (s *AdminCommunityEventsSuite) TestAdminAcceptMemberRequestToJoin() {
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testAcceptMemberRequestToJoin(s, community, user)
 }
@@ -176,7 +153,6 @@ func (s *AdminCommunityEventsSuite) TestAdminRejectMemberRequestToJoinResponseSh
 	community := setUpOnRequestCommunityAndRoles(s, protobuf.CommunityMember_ROLE_ADMIN, []*Messenger{additionalAdmin})
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testRejectMemberRequestToJoinResponseSharedWithOtherEventSenders(s, community, user, additionalAdmin)
 }
@@ -186,7 +162,6 @@ func (s *AdminCommunityEventsSuite) TestAdminRejectMemberRequestToJoin() {
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 
 	testRejectMemberRequestToJoin(s, community, user)
 }
@@ -313,15 +288,12 @@ func (s *AdminCommunityEventsSuite) TestJoinedAdminReceiveRequestsToJoinWithoutR
 	// set up additional user that will join to the community as TokenMaster
 	newPrivilegedUser := s.newMessenger(accountPassword, []string{eventsSenderAccountAddress})
 
-	s.SetupAdditionalMessengers([]*Messenger{bob, newPrivilegedUser})
-
 	testJoinedPrivilegedMemberReceiveRequestsToJoin(s, community, bob, newPrivilegedUser, protobuf.CommunityTokenPermission_BECOME_ADMIN)
 }
 
 func (s *AdminCommunityEventsSuite) TestReceiveRequestsToJoinWithRevealedAccountsAfterGettingAdminRole() {
 	// set up additional user (bob) that will send request to join
 	bob := s.newMessenger(accountPassword, []string{bobAccountAddress})
-	s.SetupAdditionalMessengers([]*Messenger{bob})
 	testMemberReceiveRequestsToJoinAfterGettingNewRole(s, bob, protobuf.CommunityTokenPermission_BECOME_ADMIN)
 }
 
@@ -330,7 +302,6 @@ func (s *AdminCommunityEventsSuite) TestAdminAcceptsRequestToJoinAfterMemberLeav
 
 	// set up additional user that will send request to join
 	user := s.newMessenger("somePassword", []string{"0x0123400000000000000000000000000000000000"})
-	s.SetupAdditionalMessengers([]*Messenger{user})
 	testPrivilegedMemberAcceptsRequestToJoinAfterMemberLeave(s, community, user)
 }
 

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"strconv"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
@@ -236,7 +237,7 @@ type testCommunitiesMessengerConfig struct {
 	collectiblesManager communities.CollectiblesManager
 }
 
-func (tcmc *testCommunitiesMessengerConfig) complete() error {
+func (tcmc *testCommunitiesMessengerConfig) complete(t *testing.T) error {
 	if tcmc.nodeConfig == nil {
 		tcmc.nodeConfig = defaultTestCommunitiesMessengerNodeConfig()
 	}
@@ -244,7 +245,7 @@ func (tcmc *testCommunitiesMessengerConfig) complete() error {
 		tcmc.appSettings = defaultTestCommunitiesMessengerSettings()
 	}
 
-	err := tcmc.testMessengerConfig.complete()
+	err := tcmc.testMessengerConfig.complete(t)
 	if err != nil {
 		return err
 	}
@@ -282,7 +283,7 @@ func defaultTestCommunitiesMessengerSettings() *settings.Settings {
 }
 
 func newTestCommunitiesMessenger(s *suite.Suite, messagingEnv *messaging.TestMessagingEnvironment, config testCommunitiesMessengerConfig) *Messenger {
-	err := config.complete()
+	err := config.complete(s.T())
 	s.Require().NoError(err)
 
 	ctrl := gomock.NewController(s.T())

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -357,6 +357,8 @@ func newTestCommunitiesMessenger(s *suite.Suite, messagingEnv *messaging.TestMes
 
 	err = messenger.messaging.Start()
 	s.Require().NoError(err)
+	_, err = messenger.Start()
+	s.Require().NoError(err)
 
 	return messenger
 }

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -357,8 +357,17 @@ func newTestCommunitiesMessenger(s *suite.Suite, messagingEnv *messaging.TestMes
 
 	err = messenger.messaging.Start()
 	s.Require().NoError(err)
+	s.T().Cleanup(func() {
+		err := messenger.messaging.Stop()
+		s.Assert().NoError(err)
+	})
+
 	_, err = messenger.Start()
 	s.Require().NoError(err)
+	s.T().Cleanup(func() {
+		err := messenger.Shutdown()
+		s.Assert().NoError(err)
+	})
 
 	return messenger
 }

--- a/protocol/communities_messenger_helpers_test.go
+++ b/protocol/communities_messenger_helpers_test.go
@@ -328,7 +328,7 @@ func newTestCommunitiesMessenger(s *suite.Suite, messagingEnv *messaging.TestMes
 
 	config.extraOptions = append(config.extraOptions, options...)
 
-	messenger, err := newTestMessenger(messagingEnv, config.testMessengerConfig)
+	messenger, err := newTestMessenger(s.T(), messagingEnv, config.testMessengerConfig)
 	s.Require().NoError(err)
 
 	currentDistributorObj, ok := messenger.communitiesKeyDistributor.(*CommunitiesKeyDistributorImpl)

--- a/protocol/communities_messenger_shared_member_address_test.go
+++ b/protocol/communities_messenger_shared_member_address_test.go
@@ -62,9 +62,9 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) SetupTest() {
 }
 
 func (s *MessengerCommunitiesSharedMemberAddressSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.owner)
-	TearDownMessenger(&s.Suite, s.bob)
-	TearDownMessenger(&s.Suite, s.alice)
+	TearDownMessenger(s.T(), s.owner)
+	TearDownMessenger(s.T(), s.bob)
+	TearDownMessenger(s.T(), s.alice)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/communities_messenger_shared_member_address_test.go
+++ b/protocol/communities_messenger_shared_member_address_test.go
@@ -48,17 +48,8 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) SetupTest() {
 	s.resetMockedBalances()
 
 	s.owner = s.newMessenger(ownerPassword, []string{ownerAddress}, "owner", []Option{})
-
 	s.bob = s.newMessenger(bobPassword, []string{bobAddress}, "bob", []Option{})
-
 	s.alice = s.newMessenger(alicePassword, []string{aliceAddress1, aliceAddress2}, "alice", []Option{})
-
-	_, err := s.owner.Start()
-	s.Require().NoError(err)
-	_, err = s.bob.Start()
-	s.Require().NoError(err)
-	_, err = s.alice.Start()
-	s.Require().NoError(err)
 }
 
 func (s *MessengerCommunitiesSharedMemberAddressSuite) TearDownTest() {

--- a/protocol/communities_messenger_shared_member_address_test.go
+++ b/protocol/communities_messenger_shared_member_address_test.go
@@ -52,13 +52,6 @@ func (s *MessengerCommunitiesSharedMemberAddressSuite) SetupTest() {
 	s.alice = s.newMessenger(alicePassword, []string{aliceAddress1, aliceAddress2}, "alice", []Option{})
 }
 
-func (s *MessengerCommunitiesSharedMemberAddressSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.owner)
-	TearDownMessenger(s.T(), s.bob)
-	TearDownMessenger(s.T(), s.alice)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerCommunitiesSharedMemberAddressSuite) newMessenger(password string, walletAddresses []string, name string, extraOptions []Option) *Messenger {
 	communityManagerOptions := []communities.ManagerOption{
 		communities.WithAllowForcingCommunityMembersReevaluation(true),

--- a/protocol/communities_messenger_signers_test.go
+++ b/protocol/communities_messenger_signers_test.go
@@ -47,9 +47,9 @@ func (s *MessengerCommunitiesSignersSuite) SetupTest() {
 }
 
 func (s *MessengerCommunitiesSignersSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.john)
-	TearDownMessenger(&s.Suite, s.bob)
-	TearDownMessenger(&s.Suite, s.alice)
+	TearDownMessenger(s.T(), s.john)
+	TearDownMessenger(s.T(), s.bob)
+	TearDownMessenger(s.T(), s.alice)
 	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
 }
 
@@ -596,13 +596,13 @@ func (s *MessengerCommunitiesSignersSuite) testSyncCommunity(mintOwnerToken bool
 	}
 
 	// Create alice second instance
-	alice2, err := newRunningTestMessenger(s.messagingEnv, testMessengerConfig{
+	alice2, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{
 		privateKey:   s.alice.identity,
 		extraOptions: []Option{WithCommunityTokensService(s.collectiblesServiceMock)},
 	})
 
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, alice2)
+	defer TearDownMessenger(s.T(), alice2)
 
 	// Create communities backup
 

--- a/protocol/communities_messenger_signers_test.go
+++ b/protocol/communities_messenger_signers_test.go
@@ -38,12 +38,6 @@ func (s *MessengerCommunitiesSignersSuite) SetupTest() {
 	s.john = s.newMessenger(accountPassword, []string{commonAccountAddress})
 	s.bob = s.newMessenger(accountPassword, []string{bobAddress})
 	s.alice = s.newMessenger(accountPassword, []string{aliceAddress1})
-	_, err := s.john.Start()
-	s.Require().NoError(err)
-	_, err = s.bob.Start()
-	s.Require().NoError(err)
-	_, err = s.alice.Start()
-	s.Require().NoError(err)
 }
 
 func (s *MessengerCommunitiesSignersSuite) TearDownTest() {

--- a/protocol/communities_messenger_signers_test.go
+++ b/protocol/communities_messenger_signers_test.go
@@ -40,13 +40,6 @@ func (s *MessengerCommunitiesSignersSuite) SetupTest() {
 	s.alice = s.newMessenger(accountPassword, []string{aliceAddress1})
 }
 
-func (s *MessengerCommunitiesSignersSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.john)
-	TearDownMessenger(s.T(), s.bob)
-	TearDownMessenger(s.T(), s.alice)
-	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
-}
-
 func (s *MessengerCommunitiesSignersSuite) newMessenger(password string, walletAddresses []string) *Messenger {
 	communityManagerOptions := []communities.ManagerOption{
 		communities.WithAllowForcingCommunityMembersReevaluation(true),
@@ -596,7 +589,6 @@ func (s *MessengerCommunitiesSignersSuite) testSyncCommunity(mintOwnerToken bool
 	})
 
 	s.Require().NoError(err)
-	defer TearDownMessenger(s.T(), alice2)
 
 	// Create communities backup
 

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -68,13 +68,6 @@ func (s *MessengerCommunitiesSuite) SetupTest() {
 	s.setMessengerDisplayName(s.alice, "Alice")
 }
 
-func (s *MessengerCommunitiesSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.owner)
-	TearDownMessenger(s.T(), s.bob)
-	TearDownMessenger(s.T(), s.alice)
-	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
-}
-
 func (s *MessengerCommunitiesSuite) setMessengerDisplayName(m *Messenger, name string) {
 	profileKp, _, _, err := accounts.GetProfileKeypairForTest(true, false, false)
 	s.Require().NoError(err)
@@ -2410,7 +2403,6 @@ func (s *MessengerCommunitiesSuite) createOtherDevice(m1 *Messenger) *Messenger 
 func (s *MessengerCommunitiesSuite) TestSyncCommunitySettings() {
 	// Create new device
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
 
@@ -2464,7 +2456,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunitySettings() {
 func (s *MessengerCommunitiesSuite) TestSyncCommunitySettings_EditCommunity() {
 	// Create new device
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
 
@@ -2555,7 +2546,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity() {
 
 	// Create new device
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
 
@@ -2636,7 +2626,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity() {
 func (s *MessengerCommunitiesSuite) TestSyncCommunity_EncryptionKeys() {
 	// Create new device
 	ownersOtherDevice := s.createOtherDevice(s.owner)
-	defer TearDownMessenger(s.T(), ownersOtherDevice)
 
 	PairDevices(&s.Suite, ownersOtherDevice, s.owner)
 
@@ -2719,7 +2708,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_RequestToJoin() {
 
 	// Create Alice's other device
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	// Pair alice's two devices
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
@@ -2920,7 +2908,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_Join() {
 	s.advertiseCommunityTo(community, s.owner, s.alice)
 
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
 
@@ -2947,7 +2934,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_Leave() {
 
 	// Create Alice's other device
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	// Pair alice's two devices
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
@@ -3059,7 +3045,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_ImportCommunity() {
 
 	// New device is created & paired
 	ownersOtherDevice := s.createOtherDevice(s.owner)
-	defer TearDownMessenger(s.T(), ownersOtherDevice)
 
 	PairDevices(&s.Suite, ownersOtherDevice, s.owner)
 	PairDevices(&s.Suite, s.owner, ownersOtherDevice)
@@ -3117,7 +3102,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_OutdatedDescription() {
 
 	// Create another device
 	aliceOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(s.T(), aliceOtherDevice)
 
 	// Make other device receive community
 	advertiseCommunityToUserOldWay(&s.Suite, community, s.owner, aliceOtherDevice)
@@ -3157,7 +3141,6 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_LeftCommunity() {
 
 	// Create another device
 	aliceOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(s.T(), aliceOtherDevice)
 
 	// Create sync message
 	syncCommunityMsg, err := s.alice.buildSyncInstallationCommunity(response.Communities()[0], 1)
@@ -3564,7 +3547,6 @@ func (s *MessengerCommunitiesSuite) TestCommunityBanUserRequestToJoin() {
 
 func (s *MessengerCommunitiesSuite) TestCommunityMaxNumberOfMembers() {
 	john := s.newMessenger("johnPassword", []string{"0x0765400000000000000000000000000000000000"})
-	defer TearDownMessenger(s.T(), john)
 
 	// Bring back the original values
 	defer communities.SetMaxNbMembers(5000)

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -63,13 +63,6 @@ func (s *MessengerCommunitiesSuite) SetupTest() {
 
 	s.owner.communitiesManager.RekeyInterval = 50 * time.Millisecond
 
-	_, err := s.owner.Start()
-	s.Require().NoError(err)
-	_, err = s.bob.Start()
-	s.Require().NoError(err)
-	_, err = s.alice.Start()
-	s.Require().NoError(err)
-
 	s.setMessengerDisplayName(s.owner, "Charlie")
 	s.setMessengerDisplayName(s.bob, "Bobby")
 	s.setMessengerDisplayName(s.alice, "Alice")
@@ -2411,9 +2404,6 @@ func (s *MessengerCommunitiesSuite) createOtherDevice(m1 *Messenger) *Messenger 
 	err = m2.SetInstallationMetadata(m2.installationID, metadata)
 	s.Require().NoError(err)
 
-	_, err = m2.Start()
-	s.Require().NoError(err)
-
 	return m2
 }
 
@@ -3574,9 +3564,6 @@ func (s *MessengerCommunitiesSuite) TestCommunityBanUserRequestToJoin() {
 
 func (s *MessengerCommunitiesSuite) TestCommunityMaxNumberOfMembers() {
 	john := s.newMessenger("johnPassword", []string{"0x0765400000000000000000000000000000000000"})
-	_, err := john.Start()
-	s.Require().NoError(err)
-
 	defer TearDownMessenger(s.T(), john)
 
 	// Bring back the original values

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -54,14 +54,24 @@ type MessengerCommunitiesSuite struct {
 func (s *MessengerCommunitiesSuite) SetupTest() {
 	s.CommunitiesMessengerTestSuiteBase.SetupTest()
 
-	s.owner = s.newMessenger("", []string{})
-	s.owner.account.CustomizationColor = multiaccountscommon.CustomizationColorOrange
-	s.bob = s.newMessenger(bobPassword, []string{bobAccountAddress})
-	s.bob.account.CustomizationColor = multiaccountscommon.CustomizationColorBlue
-	s.alice = s.newMessenger(alicePassword, []string{aliceAccountAddress})
-	s.alice.account.CustomizationColor = multiaccountscommon.CustomizationColorArmy
+	newMessenger := func(password string, walletAddresses []string) *Messenger {
+		privateKey, err := crypto.GenerateKey()
+		s.Require().NoError(err)
 
-	s.owner.communitiesManager.RekeyInterval = 50 * time.Millisecond
+		return s.newMessengerWithConfig(testMessengerConfig{
+			privateKey: privateKey,
+			extraOptions: []Option{
+				WithCommunitiesRekeyInterval(50 * time.Millisecond),
+			},
+		}, password, walletAddresses)
+	}
+
+	s.owner = newMessenger("", []string{})
+	s.owner.account.CustomizationColor = multiaccountscommon.CustomizationColorOrange
+	s.bob = newMessenger(bobPassword, []string{bobAccountAddress})
+	s.bob.account.CustomizationColor = multiaccountscommon.CustomizationColorBlue
+	s.alice = newMessenger(alicePassword, []string{aliceAccountAddress})
+	s.alice.account.CustomizationColor = multiaccountscommon.CustomizationColorArmy
 
 	s.setMessengerDisplayName(s.owner, "Charlie")
 	s.setMessengerDisplayName(s.bob, "Bobby")
@@ -2630,7 +2640,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_EncryptionKeys() {
 	PairDevices(&s.Suite, ownersOtherDevice, s.owner)
 
 	community, chat := s.createCommunity()
-	s.owner.communitiesManager.RekeyInterval = 1 * time.Hour
+	s.owner.config.communitiesRekeyInterval = 1 * time.Hour
 
 	{ // ensure both community and channel are encrypted
 		permissionRequest := requests.CreateCommunityTokenPermission{
@@ -3720,7 +3730,7 @@ func (s *MessengerCommunitiesSuite) TestStartCommunityRekeyLoop() {
 	// Check that rekeying is occurring by counting the number of keyIDs in the encryptor's DB
 	// This test could be flaky, as the rekey function may not be finished before RekeyInterval * 2 has passed
 	for i := 0; i < 5; i++ {
-		time.Sleep(s.owner.communitiesManager.RekeyInterval * 2)
+		time.Sleep(s.owner.config.communitiesRekeyInterval * 10)
 		communityKeys, err = s.owner.messaging.GetKeysForGroup(community.ID())
 		s.Require().NoError(err)
 		s.Require().Greater(len(communityKeys), communityKeyCount)
@@ -3734,7 +3744,7 @@ func (s *MessengerCommunitiesSuite) TestStartCommunityRekeyLoop() {
 }
 
 func (s *MessengerCommunitiesSuite) TestCommunityRekeyAfterBan() {
-	s.owner.communitiesManager.RekeyInterval = 500 * time.Minute
+	s.owner.config.communitiesRekeyInterval = 500 * time.Minute
 
 	// Create a new community
 	response, err := s.owner.CreateCommunity(

--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -76,9 +76,9 @@ func (s *MessengerCommunitiesSuite) SetupTest() {
 }
 
 func (s *MessengerCommunitiesSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.owner)
-	TearDownMessenger(&s.Suite, s.bob)
-	TearDownMessenger(&s.Suite, s.alice)
+	TearDownMessenger(s.T(), s.owner)
+	TearDownMessenger(s.T(), s.bob)
+	TearDownMessenger(s.T(), s.alice)
 	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
 }
 
@@ -2420,7 +2420,7 @@ func (s *MessengerCommunitiesSuite) createOtherDevice(m1 *Messenger) *Messenger 
 func (s *MessengerCommunitiesSuite) TestSyncCommunitySettings() {
 	// Create new device
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(&s.Suite, alicesOtherDevice)
+	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
 
@@ -2474,7 +2474,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunitySettings() {
 func (s *MessengerCommunitiesSuite) TestSyncCommunitySettings_EditCommunity() {
 	// Create new device
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(&s.Suite, alicesOtherDevice)
+	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
 
@@ -2565,7 +2565,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity() {
 
 	// Create new device
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(&s.Suite, alicesOtherDevice)
+	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
 
@@ -2646,7 +2646,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity() {
 func (s *MessengerCommunitiesSuite) TestSyncCommunity_EncryptionKeys() {
 	// Create new device
 	ownersOtherDevice := s.createOtherDevice(s.owner)
-	defer TearDownMessenger(&s.Suite, ownersOtherDevice)
+	defer TearDownMessenger(s.T(), ownersOtherDevice)
 
 	PairDevices(&s.Suite, ownersOtherDevice, s.owner)
 
@@ -2729,7 +2729,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_RequestToJoin() {
 
 	// Create Alice's other device
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(&s.Suite, alicesOtherDevice)
+	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	// Pair alice's two devices
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
@@ -2930,7 +2930,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_Join() {
 	s.advertiseCommunityTo(community, s.owner, s.alice)
 
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(&s.Suite, alicesOtherDevice)
+	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
 
@@ -2957,7 +2957,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_Leave() {
 
 	// Create Alice's other device
 	alicesOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(&s.Suite, alicesOtherDevice)
+	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	// Pair alice's two devices
 	PairDevices(&s.Suite, alicesOtherDevice, s.alice)
@@ -3069,7 +3069,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_ImportCommunity() {
 
 	// New device is created & paired
 	ownersOtherDevice := s.createOtherDevice(s.owner)
-	defer TearDownMessenger(&s.Suite, ownersOtherDevice)
+	defer TearDownMessenger(s.T(), ownersOtherDevice)
 
 	PairDevices(&s.Suite, ownersOtherDevice, s.owner)
 	PairDevices(&s.Suite, s.owner, ownersOtherDevice)
@@ -3127,7 +3127,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_OutdatedDescription() {
 
 	// Create another device
 	aliceOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(&s.Suite, aliceOtherDevice)
+	defer TearDownMessenger(s.T(), aliceOtherDevice)
 
 	// Make other device receive community
 	advertiseCommunityToUserOldWay(&s.Suite, community, s.owner, aliceOtherDevice)
@@ -3167,7 +3167,7 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_LeftCommunity() {
 
 	// Create another device
 	aliceOtherDevice := s.createOtherDevice(s.alice)
-	defer TearDownMessenger(&s.Suite, aliceOtherDevice)
+	defer TearDownMessenger(s.T(), aliceOtherDevice)
 
 	// Create sync message
 	syncCommunityMsg, err := s.alice.buildSyncInstallationCommunity(response.Communities()[0], 1)
@@ -3577,7 +3577,7 @@ func (s *MessengerCommunitiesSuite) TestCommunityMaxNumberOfMembers() {
 	_, err := john.Start()
 	s.Require().NoError(err)
 
-	defer TearDownMessenger(&s.Suite, john)
+	defer TearDownMessenger(s.T(), john)
 
 	// Bring back the original values
 	defer communities.SetMaxNbMembers(5000)

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -175,9 +175,9 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) SetupTest() {
 }
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.owner)
-	TearDownMessenger(&s.Suite, s.bob)
-	TearDownMessenger(&s.Suite, s.alice)
+	TearDownMessenger(s.T(), s.owner)
+	TearDownMessenger(s.T(), s.bob)
+	TearDownMessenger(s.T(), s.alice)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -165,13 +165,6 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) SetupTest() {
 	s.bob = s.newMessenger(bobPassword, []string{bobAddress}, "bob", []Option{})
 
 	s.alice = s.newMessenger(alicePassword, []string{aliceAddress1, aliceAddress2}, "alice", []Option{})
-
-	_, err := s.owner.Start()
-	s.Require().NoError(err)
-	_, err = s.bob.Start()
-	s.Require().NoError(err)
-	_, err = s.alice.Start()
-	s.Require().NoError(err)
 }
 
 func (s *MessengerCommunitiesTokenPermissionsSuite) TearDownTest() {

--- a/protocol/communities_messenger_token_permissions_test.go
+++ b/protocol/communities_messenger_token_permissions_test.go
@@ -167,13 +167,6 @@ func (s *MessengerCommunitiesTokenPermissionsSuite) SetupTest() {
 	s.alice = s.newMessenger(alicePassword, []string{aliceAddress1, aliceAddress2}, "alice", []Option{})
 }
 
-func (s *MessengerCommunitiesTokenPermissionsSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.owner)
-	TearDownMessenger(s.T(), s.bob)
-	TearDownMessenger(s.T(), s.alice)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerCommunitiesTokenPermissionsSuite) newMessenger(password string, walletAddresses []string, name string, extraOptions []Option) *Messenger {
 	communityManagerOptions := []communities.ManagerOption{
 		communities.WithAllowForcingCommunityMembersReevaluation(true),

--- a/protocol/ens/verifier.go
+++ b/protocol/ens/verifier.go
@@ -195,8 +195,8 @@ func (v *Verifier) verify(ctx context.Context, rpcEndpoint, contractAddress stri
 	for _, ensInfo := range ensDetails {
 		v.quitWg.Add(1)
 		go func(info Details) {
-			defer v.quitWg.Done()
 			defer gocommon.LogOnPanic()
+			defer v.quitWg.Done()
 			select {
 			case ch <- v.verifyENSName(info, ethClient):
 				return

--- a/protocol/ens/verifier.go
+++ b/protocol/ens/verifier.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
@@ -33,6 +34,7 @@ type Verifier struct {
 	rpcEndpoint     string
 	contractAddress string
 	quit            chan struct{}
+	quitWg          sync.WaitGroup
 }
 
 func New(logger *zap.Logger, timesource timesource.Provider, db *sql.DB, rpcEndpoint, contractAddress string) *Verifier {
@@ -48,13 +50,14 @@ func New(logger *zap.Logger, timesource timesource.Provider, db *sql.DB, rpcEndp
 }
 
 func (v *Verifier) Start() error {
+	v.quitWg.Add(1)
 	go v.verifyLoop()
 	return nil
 }
 
 func (v *Verifier) Stop() error {
 	close(v.quit)
-
+	v.quitWg.Wait()
 	return nil
 }
 
@@ -101,12 +104,12 @@ func (v *Verifier) SetOnline(online bool) {
 
 func (v *Verifier) verifyLoop() {
 	defer gocommon.LogOnPanic()
+	defer v.quitWg.Done()
 	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
-
 		case <-v.quit:
-			ticker.Stop()
 			return
 		case <-ticker.C:
 			if !v.online || v.rpcEndpoint == "" || v.contractAddress == "" {
@@ -190,9 +193,18 @@ func (v *Verifier) verify(ctx context.Context, rpcEndpoint, contractAddress stri
 	ethClient := ethclient.NewClient(rpcClient)
 
 	for _, ensInfo := range ensDetails {
+		v.quitWg.Add(1)
 		go func(info Details) {
+			defer v.quitWg.Done()
 			defer gocommon.LogOnPanic()
-			ch <- v.verifyENSName(info, ethClient)
+			select {
+			case ch <- v.verifyENSName(info, ethClient):
+				return
+			case <-ctx.Done():
+				return
+			case <-v.quit:
+				return
+			}
 		}(ensInfo)
 	}
 

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -613,7 +613,10 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 
 	m.messaging.SetStorenodeConfigProvider(m)
 
+	m.shutdownWaitGroup.Add(1)
 	go m.checkForMissingMessagesLoop()
+
+	m.shutdownWaitGroup.Add(1)
 	go m.checkForStorenodeCycleSignals()
 
 	controlledCommunities, err := m.communitiesManager.Controlled()
@@ -622,10 +625,14 @@ func (m *Messenger) Start() (*MessengerResponse, error) {
 	}
 
 	if m.archiveManager.IsReady() {
+		m.shutdownWaitGroup.Add(1)
 		go func() {
 			defer gocommon.LogOnPanic()
+			defer m.shutdownWaitGroup.Done()
 
 			select {
+			case <-m.quit:
+				return
 			case <-m.ctx.Done():
 				return
 			case <-m.messaging.OnStorenodeAvailable():
@@ -1186,10 +1193,16 @@ func (m *Messenger) handleInstallations(installations []*types2.Installation) {
 
 // handleEncryptionLayerSubscriptions handles events from the encryption layer
 func (m *Messenger) handleEncryptionLayerSubscriptions(subscriptions *types2.EncryptionSubscriptions) {
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
+			case <-m.quit:
+				return
+			case <-m.ctx.Done():
+				return
 			case <-subscriptions.SendContactCode:
 				if err := m.publishContactCode(); err != nil {
 					m.logger.Error("failed to publish contact code", zap.Error(err))
@@ -1241,8 +1254,10 @@ func (m *Messenger) handleENSVerified(records []*ens.VerificationRecord) {
 }
 
 func (m *Messenger) handleENSVerificationSubscription(c chan []*ens.VerificationRecord) {
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case records, more := <-c:
@@ -1283,6 +1298,7 @@ func (m *Messenger) watchConnectionChange() {
 
 	subscribedConnectionStatus := func(subscription types2.ConnectionStatusSubscription) {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		defer subscription.Unsubscribe()
 		ticker := time.NewTicker(keepAlivePeriod)
 		defer ticker.Stop()
@@ -1306,14 +1322,18 @@ func (m *Messenger) watchConnectionChange() {
 		m.logger.Error("failed to subscribe to connection status changes", zap.Error(err))
 		return
 	}
+
+	m.shutdownWaitGroup.Add(1)
 	go subscribedConnectionStatus(subscription)
 }
 
 // watchChatsToUnmute checks every minute to identify and unmute chats that should no longer be muted.
 func (m *Messenger) watchChatsToUnmute() {
 	m.logger.Debug("Checking for chats to unmute every minute")
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			// Execute the check immediately upon starting
 			response := &MessengerResponse{}
@@ -1367,8 +1387,10 @@ func (m *Messenger) watchCommunitiesToUnmute() {
 		}
 	}
 
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		check()
 
 		ticker := time.NewTicker(time.Minute)
@@ -1394,8 +1416,10 @@ func (m *Messenger) watchIdentityImageChanges() {
 
 	channel := m.multiAccounts.SubscribeToIdentityImageChanges()
 
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case change := <-channel:
@@ -1432,8 +1456,10 @@ func (m *Messenger) watchIdentityImageChanges() {
 func (m *Messenger) watchPendingCommunityRequestToJoin() {
 	m.logger.Debug("watching community request to join")
 
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case <-time.After(time.Minute * 10):
@@ -1467,17 +1493,22 @@ func (m *Messenger) PublishIdentityImage() error {
 
 // handlePushNotificationClientRegistration handles registration events
 func (m *Messenger) handlePushNotificationClientRegistrations(c chan struct{}) {
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
-			_, more := <-c
-			if !more {
+			select {
+			case <-m.quit:
 				return
+			case _, more := <-c:
+				if !more {
+					return
+				}
+				if err := m.publishContactCode(); err != nil {
+					m.logger.Error("failed to publish contact code", zap.Error(err))
+				}
 			}
-			if err := m.publishContactCode(); err != nil {
-				m.logger.Error("failed to publish contact code", zap.Error(err))
-			}
-
 		}
 	}()
 }
@@ -2659,6 +2690,8 @@ func (m *Messenger) StartRetrieveMessagesLoop(tick time.Duration, cancel <-chan 
 			case <-ticker.C:
 				m.ProcessAllMessages()
 			case <-cancel:
+				return
+			case <-m.quit:
 				return
 			}
 		}
@@ -4651,9 +4684,10 @@ func (m *Messenger) GetDeleteForMeMessages() ([]*protobuf.SyncDeleteForMeMessage
 
 func (m *Messenger) startCleanupLoop(name string, cleanupFunc func() error) {
 	logger := m.logger.Named(name)
-
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		// Delay by a few minutes to minimize messenger's startup time
 		var interval time.Duration = 5 * time.Minute
 		for {

--- a/protocol/messenger.go
+++ b/protocol/messenger.go
@@ -439,7 +439,6 @@ func NewMessenger(
 			pushNotificationClient.Stop,
 			communitiesManager.Stop,
 			archiveManager.Stop,
-			database.Close,
 		},
 		logger:                           logger,
 		tracer:                           c.tracer,

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -46,13 +46,13 @@ func (s *MessengerActivityCenterMessageSuite) SetupTest() {
 }
 
 func (s *MessengerActivityCenterMessageSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.m)
+	TearDownMessenger(s.T(), s.m)
 	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
 }
 
 func (s *MessengerActivityCenterMessageSuite) TestDeleteOneToOneChat() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -106,7 +106,7 @@ func (s *MessengerActivityCenterMessageSuite) TestDeleteOneToOneChat() {
 func (s *MessengerActivityCenterMessageSuite) TestEveryoneMentionTag() {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)
@@ -146,7 +146,7 @@ func (s *MessengerActivityCenterMessageSuite) TestEveryoneMentionTag() {
 func (s *MessengerActivityCenterMessageSuite) TestReplyWithImage() {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	// create an http server
 	mediaServer, err := server.NewMediaServer(nil, nil, nil, nil)
@@ -228,7 +228,7 @@ func (s *MessengerActivityCenterMessageSuite) TestReplyWithImage() {
 func (s *MessengerActivityCenterMessageSuite) TestMuteCommunityActivityCenterNotifications() {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)
@@ -278,7 +278,7 @@ func (s *MessengerActivityCenterMessageSuite) TestMuteCommunityActivityCenterNot
 func (s *MessengerActivityCenterMessageSuite) TestReadCommunityOverviewNotifications() {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)
@@ -301,7 +301,7 @@ func (s *MessengerActivityCenterMessageSuite) TestReadCommunityOverviewNotificat
 func (s *MessengerActivityCenterMessageSuite) prepareCommunityChannelWithMentionAndReply() (*Messenger, *Messenger, *common.Message, *common.Message, *communities.Community) {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)
@@ -475,7 +475,7 @@ func (s *MessengerActivityCenterMessageSuite) TestMarkAllActivityCenterNotificat
 func (s *MessengerActivityCenterMessageSuite) TestAliceDoesNotReceiveCommunityNotificationsBeforeJoined() {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -40,9 +40,6 @@ func (s *MessengerActivityCenterMessageSuite) SetupTest() {
 
 	s.m = s.newMessenger(alicePassword, []string{aliceAccountAddress})
 	s.m.account.CustomizationColor = multiaccountscommon.CustomizationColorOrange
-
-	_, err := s.m.Start()
-	s.Require().NoError(err)
 }
 
 func (s *MessengerActivityCenterMessageSuite) TearDownTest() {

--- a/protocol/messenger_activity_center_test.go
+++ b/protocol/messenger_activity_center_test.go
@@ -42,14 +42,8 @@ func (s *MessengerActivityCenterMessageSuite) SetupTest() {
 	s.m.account.CustomizationColor = multiaccountscommon.CustomizationColorOrange
 }
 
-func (s *MessengerActivityCenterMessageSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.m)
-	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
-}
-
 func (s *MessengerActivityCenterMessageSuite) TestDeleteOneToOneChat() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -103,7 +97,6 @@ func (s *MessengerActivityCenterMessageSuite) TestDeleteOneToOneChat() {
 func (s *MessengerActivityCenterMessageSuite) TestEveryoneMentionTag() {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(s.T(), bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)
@@ -143,7 +136,6 @@ func (s *MessengerActivityCenterMessageSuite) TestEveryoneMentionTag() {
 func (s *MessengerActivityCenterMessageSuite) TestReplyWithImage() {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(s.T(), bob)
 
 	// create an http server
 	mediaServer, err := server.NewMediaServer(nil, nil, nil, nil)
@@ -225,7 +217,6 @@ func (s *MessengerActivityCenterMessageSuite) TestReplyWithImage() {
 func (s *MessengerActivityCenterMessageSuite) TestMuteCommunityActivityCenterNotifications() {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(s.T(), bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)
@@ -275,7 +266,6 @@ func (s *MessengerActivityCenterMessageSuite) TestMuteCommunityActivityCenterNot
 func (s *MessengerActivityCenterMessageSuite) TestReadCommunityOverviewNotifications() {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(s.T(), bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)
@@ -298,7 +288,6 @@ func (s *MessengerActivityCenterMessageSuite) TestReadCommunityOverviewNotificat
 func (s *MessengerActivityCenterMessageSuite) prepareCommunityChannelWithMentionAndReply() (*Messenger, *Messenger, *common.Message, *common.Message, *communities.Community) {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(s.T(), bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)
@@ -472,7 +461,6 @@ func (s *MessengerActivityCenterMessageSuite) TestMarkAllActivityCenterNotificat
 func (s *MessengerActivityCenterMessageSuite) TestAliceDoesNotReceiveCommunityNotificationsBeforeJoined() {
 	alice := s.m
 	bob := s.newMessenger(bobPassword, []string{bobAddress})
-	defer TearDownMessenger(s.T(), bob)
 
 	// Create a community
 	community, chat := s.createCommunity(bob)

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -14,7 +14,9 @@ func (s *MessengerBaseTestSuite) setupMessaging() {
 	var err error
 	s.messagingEnv, err = messaging.NewTestMessagingEnvironment()
 	s.Require().NoError(err)
-	s.Require().NoError(s.messagingEnv.Setup())
+
+	err = s.messagingEnv.Setup(s.T())
+	s.Require().NoError(err)
 }
 
 func (s *MessengerBaseTestSuite) SetupTest() {

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -26,13 +26,6 @@ func (s *MessengerBaseTestSuite) SetupTest() {
 	s.privateKey = s.m.identity
 }
 
-func (s *MessengerBaseTestSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.m)
-	if s.messagingEnv != nil {
-		s.Require().NoError(s.messagingEnv.TearDown())
-	}
-}
-
 func (s *MessengerBaseTestSuite) newMessenger() *Messenger {
 	messenger, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{})
 	s.Require().NoError(err)

--- a/protocol/messenger_base_test.go
+++ b/protocol/messenger_base_test.go
@@ -25,20 +25,20 @@ func (s *MessengerBaseTestSuite) SetupTest() {
 }
 
 func (s *MessengerBaseTestSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.m)
+	TearDownMessenger(s.T(), s.m)
 	if s.messagingEnv != nil {
 		s.Require().NoError(s.messagingEnv.TearDown())
 	}
 }
 
 func (s *MessengerBaseTestSuite) newMessenger() *Messenger {
-	messenger, err := newRunningTestMessenger(s.messagingEnv, testMessengerConfig{})
+	messenger, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{})
 	s.Require().NoError(err)
 	return messenger
 }
 
 func (s *MessengerBaseTestSuite) anotherMessenger() *Messenger {
-	messenger, err := newRunningTestMessenger(s.messagingEnv, testMessengerConfig{privateKey: s.privateKey})
+	messenger, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{privateKey: s.privateKey})
 	s.Require().NoError(err)
 
 	return messenger

--- a/protocol/messenger_bridge_message_test.go
+++ b/protocol/messenger_bridge_message_test.go
@@ -23,7 +23,7 @@ func (s *BridgeMessageSuite) TestSendBridgeMessage() {
 	alice.account = &multiaccounts.Account{KeyUID: "0xdeadbeef"}
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	chatID := statusChatID
 

--- a/protocol/messenger_bridge_message_test.go
+++ b/protocol/messenger_bridge_message_test.go
@@ -23,7 +23,6 @@ func (s *BridgeMessageSuite) TestSendBridgeMessage() {
 	alice.account = &multiaccounts.Account{KeyUID: "0xdeadbeef"}
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	chatID := statusChatID
 

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -47,7 +47,7 @@ type testMessengerConfig struct {
 	extraOptions []Option
 }
 
-func (tmc *testMessengerConfig) complete() error {
+func (tmc *testMessengerConfig) complete(t *testing.T) error {
 	if len(tmc.name) == 0 {
 		tmc.name = uuid.NewString()[0:6]
 	}
@@ -63,6 +63,7 @@ func (tmc *testMessengerConfig) complete() error {
 	if tmc.logger == nil {
 		logger := testutils.MustCreateTestLogger()
 		tmc.logger = logger.Named(tmc.name)
+		t.Logf("created test logger - logger name: %s, test name: %s, ", tmc.name, t.Name())
 		logger.Debug("created test logger", zap.String("name", tmc.name))
 	}
 
@@ -78,7 +79,7 @@ func (tmc *testMessengerConfig) complete() error {
 }
 
 func newTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagingEnvironment, config testMessengerConfig) (*Messenger, error) {
-	err := config.complete()
+	err := config.complete(t)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -60,6 +60,7 @@ func (tmc *testMessengerConfig) complete() error {
 	if tmc.logger == nil {
 		logger := testutils.MustCreateTestLogger()
 		tmc.logger = logger.Named(tmc.name)
+		logger.Debug("created test logger", zap.String("name", tmc.name))
 	}
 
 	if tmc.appSettings == nil {

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -73,7 +73,7 @@ func (tmc *testMessengerConfig) complete() error {
 	return nil
 }
 
-func newTestMessenger(messagingEnv *messaging2.TestMessagingEnvironment, config testMessengerConfig) (*Messenger, error) {
+func newTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagingEnvironment, config testMessengerConfig) (*Messenger, error) {
 	err := config.complete()
 	if err != nil {
 		return nil, err
@@ -201,21 +201,15 @@ func newTestMessenger(messagingEnv *messaging2.TestMessagingEnvironment, config 
 	return m, nil
 }
 
-func newRunningTestMessenger(messagingEnv *messaging2.TestMessagingEnvironment, config testMessengerConfig) (*Messenger, error) {
-	m, err := newTestMessenger(messagingEnv, config)
-	if err != nil {
-		return nil, err
-	}
+func newRunningTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagingEnvironment, config testMessengerConfig) (*Messenger, error) {
+	m, err := newTestMessenger(t, messagingEnv, config)
+	require.NoError(t, err)
 
 	err = m.messaging.Start()
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	_, err = m.Start()
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	return m, nil
 }

--- a/protocol/messenger_builder_test.go
+++ b/protocol/messenger_builder_test.go
@@ -3,10 +3,13 @@ package protocol
 import (
 	"crypto/ecdsa"
 	"encoding/json"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
@@ -91,14 +94,28 @@ func newTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagingEnviro
 	if err != nil {
 		return nil, err
 	}
+	t.Cleanup(func() {
+		err = madb.Close()
+		assert.NoError(t, err)
+	})
+
 	walletDb, err := testutils.SetupTestMemorySQLDB(walletdatabase.DbInitializer{})
 	if err != nil {
 		return nil, err
 	}
+	t.Cleanup(func() {
+		err = walletDb.Close()
+		assert.NoError(t, err)
+	})
+
 	appDb, err := testutils.SetupTestMemorySQLDB(appdatabase.DbInitializer{})
 	if err != nil {
 		return nil, err
 	}
+	t.Cleanup(func() {
+		err = appDb.Close()
+		assert.NoError(t, err)
+	})
 
 	err = sqlite.Migrate(appDb)
 	if err != nil {
@@ -208,9 +225,17 @@ func newRunningTestMessenger(t *testing.T, messagingEnv *messaging2.TestMessagin
 
 	err = m.messaging.Start()
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err = m.messaging.Stop()
+		assert.NoError(t, err)
+	})
 
 	_, err = m.Start()
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := m.Shutdown()
+		assert.NoError(t, err)
+	})
 
 	return m, nil
 }

--- a/protocol/messenger_chat_context_test.go
+++ b/protocol/messenger_chat_context_test.go
@@ -51,7 +51,7 @@ func (s *MessengerSuite) retrieveIdentityImages(alice, bob *Messenger, chat *Cha
 func (s *MessengerSuite) TestTwoImagesAreAddedToChatIdentityForPrivateChat() {
 	alice := s.m
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	bobPkString := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -67,7 +67,7 @@ func (s *MessengerSuite) TestTwoImagesAreAddedToChatIdentityForPrivateChat() {
 func (s *MessengerSuite) TestOneImageIsAddedToChatIdentityForPublicChat() {
 	alice := s.m
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	chat := CreatePublicChat("alic-and-bob-chat", &testTimeSource{})
 	s.Require().Equal(publicChat, GetChatContextFromChatType(chat.ChatType))

--- a/protocol/messenger_chat_context_test.go
+++ b/protocol/messenger_chat_context_test.go
@@ -51,7 +51,6 @@ func (s *MessengerSuite) retrieveIdentityImages(alice, bob *Messenger, chat *Cha
 func (s *MessengerSuite) TestTwoImagesAreAddedToChatIdentityForPrivateChat() {
 	alice := s.m
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	bobPkString := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -67,7 +66,6 @@ func (s *MessengerSuite) TestTwoImagesAreAddedToChatIdentityForPrivateChat() {
 func (s *MessengerSuite) TestOneImageIsAddedToChatIdentityForPublicChat() {
 	alice := s.m
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	chat := CreatePublicChat("alic-and-bob-chat", &testTimeSource{})
 	s.Require().Equal(publicChat, GetChatContextFromChatType(chat.ChatType))

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -1501,21 +1501,27 @@ func (m *Messenger) RequestToJoinCommunity(request *requests.RequestToJoinCommun
 	response.AddCommunity(community)
 
 	// We send a push notification in the background
+
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
-		if m.pushNotificationClient != nil {
-			pks, err := community.CanManageUsersPublicKeys()
+		defer m.shutdownWaitGroup.Done()
+
+		if m.pushNotificationClient == nil {
+			return
+		}
+
+		pks, err := community.CanManageUsersPublicKeys()
+		if err != nil {
+			m.logger.Error("failed to get pks", zap.Error(err))
+			return
+		}
+		for _, publicKey := range pks {
+			pkString := crypto.PubkeyToHex(publicKey)
+			_, err = m.pushNotificationClient.SendNotification(publicKey, nil, requestToJoin.ID, pkString, protobuf.PushNotification_REQUEST_TO_JOIN_COMMUNITY)
 			if err != nil {
-				m.logger.Error("failed to get pks", zap.Error(err))
+				m.logger.Error("error sending notification", zap.Error(err))
 				return
-			}
-			for _, publicKey := range pks {
-				pkString := crypto.PubkeyToHex(publicKey)
-				_, err = m.pushNotificationClient.SendNotification(publicKey, nil, requestToJoin.ID, pkString, protobuf.PushNotification_REQUEST_TO_JOIN_COMMUNITY)
-				if err != nil {
-					m.logger.Error("error sending notification", zap.Error(err))
-					return
-				}
 			}
 		}
 	}()

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -4331,18 +4331,15 @@ func chunkAttachmentsByByteSize(slice []*protobuf.DiscordMessageAttachment, maxF
 func (m *Messenger) startCommunityRekeyLoop() {
 	logger := m.logger.Named("CommunityRekeyLoop")
 	var d time.Duration
-	if m.communitiesManager.RekeyInterval != 0 {
-		if m.communitiesManager.RekeyInterval < 10 {
-			d = time.Nanosecond
-		} else {
-			d = m.communitiesManager.RekeyInterval / 10
-		}
+	if m.config.communitiesRekeyInterval != 0 {
+		d = m.config.communitiesRekeyInterval
 	} else {
 		d = 5 * time.Minute
 	}
 
+	m.logger.Info("starting community rekey loop", zap.Duration("interval", d))
+
 	ticker := time.NewTicker(d)
-	defer ticker.Stop()
 
 	m.shutdownWaitGroup.Add(1)
 	go func() {
@@ -4365,10 +4362,10 @@ func (m *Messenger) startCommunityRekeyLoop() {
 func (m *Messenger) rekeyCommunities(logger *zap.Logger) {
 	// TODO in future have a community level rki rather than a global rki
 	var rekeyInterval time.Duration
-	if m.communitiesManager.RekeyInterval == 0 {
+	if m.config.communitiesRekeyInterval == 0 {
 		rekeyInterval = 48 * time.Hour
 	} else {
-		rekeyInterval = m.communitiesManager.RekeyInterval
+		rekeyInterval = m.config.communitiesRekeyInterval
 	}
 
 	shouldRekey := func(hashRatchetGroupID []byte) bool {

--- a/protocol/messenger_communities.go
+++ b/protocol/messenger_communities.go
@@ -224,8 +224,10 @@ func (m *Messenger) publishCommunityPrivilegedMemberSyncMessage(msg *communities
 
 func (m *Messenger) handleCommunitiesHistoryArchivesSubscription(c chan *communities.Subscription) {
 
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case sub, more := <-c:
@@ -380,8 +382,10 @@ func (m *Messenger) handleCommunitiesSubscription(c chan *communities.Subscripti
 		recentlyPublishedOrgs[community.IDString()] = community.CreateDeepCopy()
 	}
 
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case sub, more := <-c:
@@ -503,8 +507,10 @@ func (m *Messenger) updateCommunitiesActiveMembersPeriodically() {
 	// We check every 5 minutes if we need to update
 	ticker := time.NewTicker(5 * time.Minute)
 
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case <-ticker.C:
@@ -822,8 +828,10 @@ func (m *Messenger) schedulePublishGrantsForControlledCommunities() {
 
 	ticker := time.NewTicker(grantUpdateInterval)
 
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case <-ticker.C:
@@ -4334,8 +4342,12 @@ func (m *Messenger) startCommunityRekeyLoop() {
 	}
 
 	ticker := time.NewTicker(d)
+	defer ticker.Stop()
+
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case <-ticker.C:
@@ -4785,8 +4797,10 @@ func (m *Messenger) requestCommunityEncryptionKeys(community *communities.Commun
 func (m *Messenger) startRequestMissingCommunityChannelsHRKeysLoop() {
 	logger := m.logger.Named("requestMissingCommunityChannelsHRKeysLoop")
 
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case <-time.After(5 * time.Minute):

--- a/protocol/messenger_config.go
+++ b/protocol/messenger_config.go
@@ -107,6 +107,8 @@ type config struct {
 	accountsPublisher *pubsub.Publisher
 
 	onlineChecker func() bool
+
+	communitiesRekeyInterval time.Duration
 }
 
 func messengerDefaultConfig() config {
@@ -348,6 +350,13 @@ func WithAccountsPublisher(publisher *pubsub.Publisher) Option {
 func WithENSVerifier(ensVerifier *ens.Verifier) func(c *config) error {
 	return func(c *config) error {
 		c.ensVerifier = ensVerifier
+		return nil
+	}
+}
+
+func WithCommunitiesRekeyInterval(interval time.Duration) func(c *config) error {
+	return func(c *config) error {
+		c.communitiesRekeyInterval = interval
 		return nil
 	}
 }

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -459,7 +459,6 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequest() { //
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -475,7 +474,6 @@ func (s *MessengerContactRequestSuite) TestReceiveAndDismissContactRequest() {
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -491,7 +489,6 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.Require().NoError(theirMessenger.settings.SaveSettingField(settings.MutualContactEnabled, true))
 
@@ -513,7 +510,6 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 //     2.3) Alice removes bob from contacts
 func (s *MessengerContactRequestSuite) TestAcceptCRRemoveAndRepeat() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
@@ -539,8 +535,6 @@ func (s *MessengerContactRequestSuite) TestAliceTriesToSpamBobWithContactRequest
 	alice := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
-
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
 	// Alice sends a contact request to Bob
@@ -596,7 +590,6 @@ func (s *MessengerContactRequestSuite) TestAliceTriesToSpamBobWithContactRequest
 	alice := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 	bobID := bob.IdentityPublicKeyString()
 
 	// Alice sends a contact request to Bob
@@ -662,7 +655,6 @@ func (s *MessengerContactRequestSuite) TestAliceSeesOnlyOneAcceptFromBob() {
 	alice := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -716,7 +708,6 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequestTwice()
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -758,7 +749,6 @@ func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContact(
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -851,7 +841,6 @@ func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContact
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -883,15 +872,12 @@ func (s *MessengerContactRequestSuite) TestPairedDevicesRemoveContact() {
 
 	alice1 := s.m
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alice2)
-
 	prepAliceMessengersForPairing(&s.Suite, alice1, alice2)
 
 	PairDevices(&s.Suite, alice1, alice2)
 	PairDevices(&s.Suite, alice2, alice1)
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	// Alice sends a contact request to bob
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
@@ -953,7 +939,6 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateSendContactRequest()
 	alice1 := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -972,7 +957,6 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateSendContactRequest()
 
 	// Alice resets her device
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alice2)
 
 	// adds bob again to her device
 	s.sendContactRequest(request, alice2)
@@ -1019,7 +1003,6 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateReceiveContactReques
 	alice1 := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1038,7 +1021,6 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateReceiveContactReques
 
 	// Alice resets her device
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alice2)
 
 	// We want to facilitate the discovery of the x3dh bundle here, since bob does not know about alice device
 	err := messaging.TestUtils{API: bob.messaging}.ProcessPublicBundle(bob.identity, alice2.messaging, alice2.identity)
@@ -1089,7 +1071,6 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsCorrectOrd
 	alice1 := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1137,7 +1118,6 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsWrongOrder
 	alice1 := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1187,7 +1167,6 @@ func (s *MessengerContactRequestSuite) TestAliceResendsContactRequestAfterRemovi
 	messageTextFirst := "hello 1!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
@@ -1241,7 +1220,6 @@ func (s *MessengerContactRequestSuite) TestBobSendsContactRequestAfterDecliningO
 	alice := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1404,7 +1382,6 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 	alice.account.CustomizationColor = multiaccountscommon.CustomizationColorBeige
 
 	bob1 := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob1)
 
 	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob1.identity.PublicKey))
@@ -1423,7 +1400,6 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 	// Bob resets his device
 	bob2, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{privateKey: bob1.identity})
 	s.Require().NoError(err)
-	defer TearDownMessenger(s.T(), bob2)
 
 	// Get bob perspective of alice for backup
 	aliceFromBob := bob1.Contacts()[0]
@@ -1479,9 +1455,7 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 	messageText := "hello, Bobby!"
 
 	alice1 := s.m
-
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice1.identity.PublicKey))
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
@@ -1499,7 +1473,6 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 
 	// Bob resets his device
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alice2)
 
 	// Get bob perspective of alice for backup
 	bobFromAlice := alice1.Contacts()[0]
@@ -1666,7 +1639,6 @@ func (s *MessengerContactRequestSuite) unblockContactAndSync(alice1 *Messenger, 
 func (s *MessengerContactRequestSuite) TestBlockedContactSyncing() {
 	// Setup Bob
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 	_ = bob.SetDisplayName("bob-1")
 	s.T().Log("Bob account set up", zap.String("publicKey", bob.IdentityPublicKeyString()))
 
@@ -1676,7 +1648,6 @@ func (s *MessengerContactRequestSuite) TestBlockedContactSyncing() {
 
 	// Setup Alice-2
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alice2)
 
 	// Pair alice-1 <-> alice-2
 	// NOTE: This doesn't include initial data sync. Local pairing could be used.

--- a/protocol/messenger_contact_requests_test.go
+++ b/protocol/messenger_contact_requests_test.go
@@ -459,7 +459,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequest() { //
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -475,7 +475,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndDismissContactRequest() {
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -491,7 +491,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.Require().NoError(theirMessenger.settings.SaveSettingField(settings.MutualContactEnabled, true))
 
@@ -513,7 +513,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAcceptAndRetractContactRequest
 //     2.3) Alice removes bob from contacts
 func (s *MessengerContactRequestSuite) TestAcceptCRRemoveAndRepeat() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
@@ -539,7 +539,7 @@ func (s *MessengerContactRequestSuite) TestAliceTriesToSpamBobWithContactRequest
 	alice := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -596,7 +596,7 @@ func (s *MessengerContactRequestSuite) TestAliceTriesToSpamBobWithContactRequest
 	alice := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 	bobID := bob.IdentityPublicKeyString()
 
 	// Alice sends a contact request to Bob
@@ -662,7 +662,7 @@ func (s *MessengerContactRequestSuite) TestAliceSeesOnlyOneAcceptFromBob() {
 	alice := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -716,7 +716,7 @@ func (s *MessengerContactRequestSuite) TestReceiveAndAcceptContactRequestTwice()
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -758,7 +758,7 @@ func (s *MessengerContactRequestSuite) TestAcceptLatestContactRequestForContact(
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -851,7 +851,7 @@ func (s *MessengerContactRequestSuite) TestDismissLatestContactRequestForContact
 	messageText := "hello!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 	request := &requests.SendContactRequest{
@@ -883,7 +883,7 @@ func (s *MessengerContactRequestSuite) TestPairedDevicesRemoveContact() {
 
 	alice1 := s.m
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alice2)
+	defer TearDownMessenger(s.T(), alice2)
 
 	prepAliceMessengersForPairing(&s.Suite, alice1, alice2)
 
@@ -891,7 +891,7 @@ func (s *MessengerContactRequestSuite) TestPairedDevicesRemoveContact() {
 	PairDevices(&s.Suite, alice2, alice1)
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	// Alice sends a contact request to bob
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
@@ -953,7 +953,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateSendContactRequest()
 	alice1 := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -972,7 +972,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateSendContactRequest()
 
 	// Alice resets her device
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alice2)
+	defer TearDownMessenger(s.T(), alice2)
 
 	// adds bob again to her device
 	s.sendContactRequest(request, alice2)
@@ -1019,7 +1019,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateReceiveContactReques
 	alice1 := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1038,7 +1038,7 @@ func (s *MessengerContactRequestSuite) TestAliceRecoverStateReceiveContactReques
 
 	// Alice resets her device
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alice2)
+	defer TearDownMessenger(s.T(), alice2)
 
 	// We want to facilitate the discovery of the x3dh bundle here, since bob does not know about alice device
 	err := messaging.TestUtils{API: bob.messaging}.ProcessPublicBundle(bob.identity, alice2.messaging, alice2.identity)
@@ -1089,7 +1089,7 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsCorrectOrd
 	alice1 := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1137,7 +1137,7 @@ func (s *MessengerContactRequestSuite) TestAliceOfflineRetractsAndAddsWrongOrder
 	alice1 := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1187,7 +1187,7 @@ func (s *MessengerContactRequestSuite) TestAliceResendsContactRequestAfterRemovi
 	messageTextFirst := "hello 1!"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&theirMessenger.identity.PublicKey))
 
@@ -1241,7 +1241,7 @@ func (s *MessengerContactRequestSuite) TestBobSendsContactRequestAfterDecliningO
 	alice := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
 
@@ -1404,7 +1404,7 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 	alice.account.CustomizationColor = multiaccountscommon.CustomizationColorBeige
 
 	bob1 := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob1)
+	defer TearDownMessenger(s.T(), bob1)
 
 	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice.identity.PublicKey))
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob1.identity.PublicKey))
@@ -1421,9 +1421,9 @@ func (s *MessengerContactRequestSuite) TestBobRestoresIncomingContactRequestFrom
 	s.Require().NotNil(contactRequest)
 
 	// Bob resets his device
-	bob2, err := newRunningTestMessenger(s.messagingEnv, testMessengerConfig{privateKey: bob1.identity})
+	bob2, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{privateKey: bob1.identity})
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, bob2)
+	defer TearDownMessenger(s.T(), bob2)
 
 	// Get bob perspective of alice for backup
 	aliceFromBob := bob1.Contacts()[0]
@@ -1481,7 +1481,7 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 	alice1 := s.m
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	aliceID := types.EncodeHex(crypto.FromECDSAPub(&alice1.identity.PublicKey))
 	bobID := types.EncodeHex(crypto.FromECDSAPub(&bob.identity.PublicKey))
@@ -1499,7 +1499,7 @@ func (s *MessengerContactRequestSuite) TestAliceRestoresOutgoingContactRequestFr
 
 	// Bob resets his device
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alice2)
+	defer TearDownMessenger(s.T(), alice2)
 
 	// Get bob perspective of alice for backup
 	bobFromAlice := alice1.Contacts()[0]
@@ -1666,7 +1666,7 @@ func (s *MessengerContactRequestSuite) unblockContactAndSync(alice1 *Messenger, 
 func (s *MessengerContactRequestSuite) TestBlockedContactSyncing() {
 	// Setup Bob
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 	_ = bob.SetDisplayName("bob-1")
 	s.T().Log("Bob account set up", zap.String("publicKey", bob.IdentityPublicKeyString()))
 
@@ -1676,7 +1676,7 @@ func (s *MessengerContactRequestSuite) TestBlockedContactSyncing() {
 
 	// Setup Alice-2
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alice2)
+	defer TearDownMessenger(s.T(), alice2)
 
 	// Pair alice-1 <-> alice-2
 	// NOTE: This doesn't include initial data sync. Local pairing could be used.

--- a/protocol/messenger_contact_update_test.go
+++ b/protocol/messenger_contact_update_test.go
@@ -27,7 +27,7 @@ func (s *MessengerContactUpdateSuite) TestReceiveContactUpdate() {
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	// Set ENS name
 	err := theirMessenger.settings.SaveSettingField(settings.PreferredName, theirName)
@@ -93,7 +93,7 @@ func (s *MessengerContactUpdateSuite) TestAddContact() {
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirMessenger.account.CustomizationColor = multiaccountscommon.CustomizationColorSky
 	response, err := theirMessenger.AddContact(context.Background(), &requests.AddContact{ID: contactID, CustomizationColor: string(multiaccountscommon.CustomizationColorRed)})
@@ -128,7 +128,7 @@ func (s *MessengerContactUpdateSuite) TestAddContactWithENS() {
 	ensName := "blah.stateofus.eth"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.Require().NoError(theirMessenger.ENSVerified(contactID, ensName))
 

--- a/protocol/messenger_contact_update_test.go
+++ b/protocol/messenger_contact_update_test.go
@@ -27,7 +27,6 @@ func (s *MessengerContactUpdateSuite) TestReceiveContactUpdate() {
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	// Set ENS name
 	err := theirMessenger.settings.SaveSettingField(settings.PreferredName, theirName)
@@ -93,7 +92,6 @@ func (s *MessengerContactUpdateSuite) TestAddContact() {
 	contactID := types.EncodeHex(crypto.FromECDSAPub(&s.m.identity.PublicKey))
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirMessenger.account.CustomizationColor = multiaccountscommon.CustomizationColorSky
 	response, err := theirMessenger.AddContact(context.Background(), &requests.AddContact{ID: contactID, CustomizationColor: string(multiaccountscommon.CustomizationColorRed)})
@@ -128,7 +126,6 @@ func (s *MessengerContactUpdateSuite) TestAddContactWithENS() {
 	ensName := "blah.stateofus.eth"
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.Require().NoError(theirMessenger.ENSVerified(contactID, ensName))
 

--- a/protocol/messenger_contact_verification_test.go
+++ b/protocol/messenger_contact_verification_test.go
@@ -131,7 +131,7 @@ func (s *MessengerVerificationRequests) mutualContact(theirMessenger *Messenger)
 
 func (s *MessengerVerificationRequests) TestAcceptVerificationRequests() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -259,7 +259,7 @@ func (s *MessengerVerificationRequests) TestAcceptVerificationRequests() {
 
 func (s *MessengerVerificationRequests) TestTrustedVerificationRequests() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -370,7 +370,7 @@ func (s *MessengerVerificationRequests) TestTrustedVerificationRequests() {
 
 func (s *MessengerVerificationRequests) TestUnthrustworthyVerificationRequests() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -497,7 +497,7 @@ func (s *MessengerVerificationRequests) TestUnthrustworthyVerificationRequests()
 func (s *MessengerVerificationRequests) TestRemoveTrustVerificationStatus() {
 	// GIVEN
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -555,7 +555,7 @@ func (s *MessengerVerificationRequests) TestRemoveTrustVerificationStatus() {
 
 func (s *MessengerVerificationRequests) TestDeclineVerificationRequests() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -669,7 +669,7 @@ func (s *MessengerVerificationRequests) TestDeclineVerificationRequests() {
 
 func (s *MessengerVerificationRequests) TestCancelVerificationRequest() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -764,7 +764,7 @@ func (s *MessengerVerificationRequests) TestCancelVerificationRequest() {
 
 func (s *MessengerVerificationRequests) TestTrustStatus() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 

--- a/protocol/messenger_contact_verification_test.go
+++ b/protocol/messenger_contact_verification_test.go
@@ -131,7 +131,6 @@ func (s *MessengerVerificationRequests) mutualContact(theirMessenger *Messenger)
 
 func (s *MessengerVerificationRequests) TestAcceptVerificationRequests() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -259,7 +258,6 @@ func (s *MessengerVerificationRequests) TestAcceptVerificationRequests() {
 
 func (s *MessengerVerificationRequests) TestTrustedVerificationRequests() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -370,7 +368,6 @@ func (s *MessengerVerificationRequests) TestTrustedVerificationRequests() {
 
 func (s *MessengerVerificationRequests) TestUnthrustworthyVerificationRequests() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -497,7 +494,6 @@ func (s *MessengerVerificationRequests) TestUnthrustworthyVerificationRequests()
 func (s *MessengerVerificationRequests) TestRemoveTrustVerificationStatus() {
 	// GIVEN
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -555,7 +551,6 @@ func (s *MessengerVerificationRequests) TestRemoveTrustVerificationStatus() {
 
 func (s *MessengerVerificationRequests) TestDeclineVerificationRequests() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -669,7 +664,6 @@ func (s *MessengerVerificationRequests) TestDeclineVerificationRequests() {
 
 func (s *MessengerVerificationRequests) TestCancelVerificationRequest() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -764,7 +758,6 @@ func (s *MessengerVerificationRequests) TestCancelVerificationRequest() {
 
 func (s *MessengerVerificationRequests) TestTrustStatus() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 

--- a/protocol/messenger_delete_message_for_everyone_test.go
+++ b/protocol/messenger_delete_message_for_everyone_test.go
@@ -32,13 +32,6 @@ func (s *MessengerDeleteMessageForEveryoneSuite) SetupTest() {
 	s.moderator = s.newMessenger(aliceAccountAddress, []string{aliceAddress1})
 }
 
-func (s *MessengerDeleteMessageForEveryoneSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.admin)
-	TearDownMessenger(s.T(), s.bob)
-	TearDownMessenger(s.T(), s.moderator)
-	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
-}
-
 func (s *MessengerDeleteMessageForEveryoneSuite) testSendAndDeleteMessage(messageToSend *common.Message, shouldError bool) {
 	ctx := context.Background()
 	sendResponse, err := s.bob.SendChatMessage(ctx, messageToSend)

--- a/protocol/messenger_delete_message_for_everyone_test.go
+++ b/protocol/messenger_delete_message_for_everyone_test.go
@@ -40,9 +40,9 @@ func (s *MessengerDeleteMessageForEveryoneSuite) SetupTest() {
 }
 
 func (s *MessengerDeleteMessageForEveryoneSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.admin)
-	TearDownMessenger(&s.Suite, s.bob)
-	TearDownMessenger(&s.Suite, s.moderator)
+	TearDownMessenger(s.T(), s.admin)
+	TearDownMessenger(s.T(), s.bob)
+	TearDownMessenger(s.T(), s.moderator)
 	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
 }
 

--- a/protocol/messenger_delete_message_for_everyone_test.go
+++ b/protocol/messenger_delete_message_for_everyone_test.go
@@ -30,13 +30,6 @@ func (s *MessengerDeleteMessageForEveryoneSuite) SetupTest() {
 	s.admin = s.newMessenger("", []string{})
 	s.bob = s.newMessenger(bobPassword, []string{bobPassword})
 	s.moderator = s.newMessenger(aliceAccountAddress, []string{aliceAddress1})
-
-	_, err := s.admin.Start()
-	s.Require().NoError(err)
-	_, err = s.bob.Start()
-	s.Require().NoError(err)
-	_, err = s.moderator.Start()
-	s.Require().NoError(err)
 }
 
 func (s *MessengerDeleteMessageForEveryoneSuite) TearDownTest() {

--- a/protocol/messenger_delete_message_for_me_test.go
+++ b/protocol/messenger_delete_message_for_me_test.go
@@ -27,11 +27,6 @@ func (s *MessengerDeleteMessageForMeSuite) SetupTest() {
 	s.m2 = s.anotherMessenger()
 }
 
-func (s *MessengerDeleteMessageForMeSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.m2)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerDeleteMessageForMeSuite) Pair() {
 	err := s.m2.SetInstallationMetadata(s.m2.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "alice2",
@@ -72,7 +67,6 @@ func (s *MessengerDeleteMessageForMeSuite) TestDeleteMessageForMe() {
 	s.Require().NoError(err)
 
 	otherMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), otherMessenger)
 
 	_, err = otherMessenger.createPublicChat(chatID, &MessengerResponse{})
 	s.Require().NoError(err)
@@ -168,12 +162,8 @@ func (s *MessengerDeleteMessageForMeSuite) TestDeleteMessageForMe() {
 }
 
 func (s *MessengerDeleteMessageForMeSuite) TestDeleteImageMessageFromReceiverSide() {
-
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
-
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, alice.getTimesource())
 	err := alice.SaveChat(theirChat)

--- a/protocol/messenger_delete_message_for_me_test.go
+++ b/protocol/messenger_delete_message_for_me_test.go
@@ -28,7 +28,7 @@ func (s *MessengerDeleteMessageForMeSuite) SetupTest() {
 }
 
 func (s *MessengerDeleteMessageForMeSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.m2)
+	TearDownMessenger(s.T(), s.m2)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 
@@ -72,7 +72,7 @@ func (s *MessengerDeleteMessageForMeSuite) TestDeleteMessageForMe() {
 	s.Require().NoError(err)
 
 	otherMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, otherMessenger)
+	defer TearDownMessenger(s.T(), otherMessenger)
 
 	_, err = otherMessenger.createPublicChat(chatID, &MessengerResponse{})
 	s.Require().NoError(err)
@@ -170,10 +170,10 @@ func (s *MessengerDeleteMessageForMeSuite) TestDeleteMessageForMe() {
 func (s *MessengerDeleteMessageForMeSuite) TestDeleteImageMessageFromReceiverSide() {
 
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, alice.getTimesource())
 	err := alice.SaveChat(theirChat)

--- a/protocol/messenger_delete_messages_test.go
+++ b/protocol/messenger_delete_messages_test.go
@@ -31,13 +31,6 @@ func (s *MessengerDeleteMessagesSuite) SetupTest() {
 	s.admin = s.newMessenger(alicePassword, []string{aliceAddress1})
 }
 
-func (s *MessengerDeleteMessagesSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.owner)
-	TearDownMessenger(s.T(), s.bob)
-	TearDownMessenger(s.T(), s.admin)
-	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
-}
-
 func (s *MessengerDeleteMessagesSuite) sendMessageAndCheckDelivery(sender *Messenger, text string, chatID string) *common.Message {
 	ctx := context.Background()
 	messageToSend := common.NewMessage()

--- a/protocol/messenger_delete_messages_test.go
+++ b/protocol/messenger_delete_messages_test.go
@@ -39,9 +39,9 @@ func (s *MessengerDeleteMessagesSuite) SetupTest() {
 }
 
 func (s *MessengerDeleteMessagesSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.owner)
-	TearDownMessenger(&s.Suite, s.bob)
-	TearDownMessenger(&s.Suite, s.admin)
+	TearDownMessenger(s.T(), s.owner)
+	TearDownMessenger(s.T(), s.bob)
+	TearDownMessenger(s.T(), s.admin)
 	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
 }
 

--- a/protocol/messenger_delete_messages_test.go
+++ b/protocol/messenger_delete_messages_test.go
@@ -29,13 +29,6 @@ func (s *MessengerDeleteMessagesSuite) SetupTest() {
 	s.owner = s.newMessenger("", []string{})
 	s.bob = s.newMessenger(bobPassword, []string{bobAddress})
 	s.admin = s.newMessenger(alicePassword, []string{aliceAddress1})
-
-	_, err := s.owner.Start()
-	s.Require().NoError(err)
-	_, err = s.bob.Start()
-	s.Require().NoError(err)
-	_, err = s.admin.Start()
-	s.Require().NoError(err)
 }
 
 func (s *MessengerDeleteMessagesSuite) TearDownTest() {

--- a/protocol/messenger_edit_message_test.go
+++ b/protocol/messenger_edit_message_test.go
@@ -24,7 +24,7 @@ type MessengerEditMessageSuite struct {
 
 func (s *MessengerEditMessageSuite) TestEditMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -93,7 +93,7 @@ func (s *MessengerEditMessageSuite) TestEditMessage() {
 
 func (s *MessengerEditMessageSuite) TestEditImageMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -175,7 +175,7 @@ func (s *MessengerEditMessageSuite) TestEditImageMessage() {
 
 func (s *MessengerEditMessageSuite) TestEditBridgeMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -248,7 +248,7 @@ func (s *MessengerEditMessageSuite) TestEditBridgeMessage() {
 
 func (s *MessengerEditMessageSuite) TestEditMessageEdgeCases() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -349,7 +349,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageEdgeCases() {
 
 func (s *MessengerEditMessageSuite) TestEditMessageFirstEditsThenMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -406,7 +406,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageFirstEditsThenMessage() {
 // Test editing a message on an existing private group chat
 func (s *MessengerEditMessageSuite) TestEditGroupChatMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	response, err := s.m.CreateGroupChatWithMembers(context.Background(), "id", []string{})
 	s.NoError(err)
@@ -489,7 +489,7 @@ func (s *MessengerEditMessageSuite) TestEditGroupChatMessage() {
 
 func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -594,7 +594,7 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 
 func (s *MessengerEditMessageSuite) TestEditMessageWithLinkPreviews() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_edit_message_test.go
+++ b/protocol/messenger_edit_message_test.go
@@ -24,7 +24,6 @@ type MessengerEditMessageSuite struct {
 
 func (s *MessengerEditMessageSuite) TestEditMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -93,7 +92,6 @@ func (s *MessengerEditMessageSuite) TestEditMessage() {
 
 func (s *MessengerEditMessageSuite) TestEditImageMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -175,7 +173,6 @@ func (s *MessengerEditMessageSuite) TestEditImageMessage() {
 
 func (s *MessengerEditMessageSuite) TestEditBridgeMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -248,7 +245,6 @@ func (s *MessengerEditMessageSuite) TestEditBridgeMessage() {
 
 func (s *MessengerEditMessageSuite) TestEditMessageEdgeCases() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -349,7 +345,6 @@ func (s *MessengerEditMessageSuite) TestEditMessageEdgeCases() {
 
 func (s *MessengerEditMessageSuite) TestEditMessageFirstEditsThenMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -406,7 +401,6 @@ func (s *MessengerEditMessageSuite) TestEditMessageFirstEditsThenMessage() {
 // Test editing a message on an existing private group chat
 func (s *MessengerEditMessageSuite) TestEditGroupChatMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	response, err := s.m.CreateGroupChatWithMembers(context.Background(), "id", []string{})
 	s.NoError(err)
@@ -489,7 +483,6 @@ func (s *MessengerEditMessageSuite) TestEditGroupChatMessage() {
 
 func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -594,7 +587,6 @@ func (s *MessengerEditMessageSuite) TestEditMessageWithMention() {
 
 func (s *MessengerEditMessageSuite) TestEditMessageWithLinkPreviews() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_emoji_test.go
+++ b/protocol/messenger_emoji_test.go
@@ -29,8 +29,6 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 	alice.account = &multiaccounts.Account{KeyUID: "0xdeadbeef"}
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
-
 	chatID := statusChatID
 
 	chat := CreatePublicChat(chatID, alice.getTimesource())
@@ -110,7 +108,7 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 func (s *MessengerEmojiSuite) TestEmojiPrivateGroup() {
 	bob := s.m
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
+
 	response, err := bob.CreateGroupChatWithMembers(context.Background(), "test", []string{})
 	s.NoError(err)
 
@@ -185,7 +183,6 @@ func (s *MessengerEmojiSuite) TestMaxEmojiReactionsPerMessage() {
 	alice.account = &multiaccounts.Account{KeyUID: "0xdeadbeef"}
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	chatID := statusChatID
 

--- a/protocol/messenger_emoji_test.go
+++ b/protocol/messenger_emoji_test.go
@@ -29,7 +29,7 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 	alice.account = &multiaccounts.Account{KeyUID: "0xdeadbeef"}
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	chatID := statusChatID
 
@@ -110,7 +110,7 @@ func (s *MessengerEmojiSuite) TestSendEmoji() {
 func (s *MessengerEmojiSuite) TestEmojiPrivateGroup() {
 	bob := s.m
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 	response, err := bob.CreateGroupChatWithMembers(context.Background(), "test", []string{})
 	s.NoError(err)
 
@@ -185,7 +185,7 @@ func (s *MessengerEmojiSuite) TestMaxEmojiReactionsPerMessage() {
 	alice.account = &multiaccounts.Account{KeyUID: "0xdeadbeef"}
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	chatID := statusChatID
 

--- a/protocol/messenger_group_chat_test.go
+++ b/protocol/messenger_group_chat_test.go
@@ -118,8 +118,8 @@ func (s *MessengerGroupChatSuite) TestGroupChatCreation() {
 
 	for i, testCase := range testCases {
 		creator, member := s.newMessenger(), s.newMessenger()
-		defer TearDownMessenger(&s.Suite, creator)
-		defer TearDownMessenger(&s.Suite, member)
+		defer TearDownMessenger(s.T(), creator)
+		defer TearDownMessenger(s.T(), member)
 
 		members := []string{crypto.PubkeyToHex(&member.identity.PublicKey)}
 
@@ -180,9 +180,9 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersAddition() {
 
 	for i, testCase := range testCases {
 		admin, inviter, member := s.newMessenger(), s.newMessenger(), s.newMessenger()
-		defer TearDownMessenger(&s.Suite, admin)
-		defer TearDownMessenger(&s.Suite, inviter)
-		defer TearDownMessenger(&s.Suite, member)
+		defer TearDownMessenger(s.T(), admin)
+		defer TearDownMessenger(s.T(), inviter)
+		defer TearDownMessenger(s.T(), member)
 
 		members := []string{crypto.PubkeyToHex(&member.identity.PublicKey)}
 
@@ -217,10 +217,10 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersAddition() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatMembersRemoval() {
 	admin, memberA, memberB, memberC := s.newMessenger(), s.newMessenger(), s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(&s.Suite, admin)
-	defer TearDownMessenger(&s.Suite, memberA)
-	defer TearDownMessenger(&s.Suite, memberB)
-	defer TearDownMessenger(&s.Suite, memberC)
+	defer TearDownMessenger(s.T(), admin)
+	defer TearDownMessenger(s.T(), memberA)
+	defer TearDownMessenger(s.T(), memberB)
+	defer TearDownMessenger(s.T(), memberC)
 
 	members := []string{crypto.PubkeyToHex(&memberA.identity.PublicKey), crypto.PubkeyToHex(&memberB.identity.PublicKey),
 		crypto.PubkeyToHex(&memberC.identity.PublicKey)}
@@ -257,8 +257,8 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersRemoval() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatEdit() {
 	admin, member := s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(&s.Suite, admin)
-	defer TearDownMessenger(&s.Suite, member)
+	defer TearDownMessenger(s.T(), admin)
+	defer TearDownMessenger(s.T(), member)
 
 	s.makeMutualContacts(admin, member)
 
@@ -327,8 +327,8 @@ func (s *MessengerGroupChatSuite) TestGroupChatEdit() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatDeleteMemberMessage() {
 	admin, member := s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(&s.Suite, admin)
-	defer TearDownMessenger(&s.Suite, member)
+	defer TearDownMessenger(s.T(), admin)
+	defer TearDownMessenger(s.T(), member)
 
 	s.makeMutualContacts(admin, member)
 
@@ -365,8 +365,8 @@ func (s *MessengerGroupChatSuite) TestGroupChatDeleteMemberMessage() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatHandleDeleteMemberMessage() {
 	admin, member := s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(&s.Suite, admin)
-	defer TearDownMessenger(&s.Suite, member)
+	defer TearDownMessenger(s.T(), admin)
+	defer TearDownMessenger(s.T(), member)
 
 	s.makeMutualContacts(admin, member)
 
@@ -411,8 +411,8 @@ func (s *MessengerGroupChatSuite) TestGroupChatHandleDeleteMemberMessage() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatMembersRemovalOutOfOrder() {
 	admin, memberA := s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(&s.Suite, admin)
-	defer TearDownMessenger(&s.Suite, memberA)
+	defer TearDownMessenger(s.T(), admin)
+	defer TearDownMessenger(s.T(), memberA)
 
 	members := []string{crypto.PubkeyToHex(&memberA.identity.PublicKey)}
 
@@ -455,9 +455,9 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersRemovalOutOfOrder() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatMembersInfoSync() {
 	admin, memberA, memberB := s.newMessenger(), s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(&s.Suite, admin)
-	defer TearDownMessenger(&s.Suite, memberA)
-	defer TearDownMessenger(&s.Suite, memberB)
+	defer TearDownMessenger(s.T(), admin)
+	defer TearDownMessenger(s.T(), memberA)
+	defer TearDownMessenger(s.T(), memberB)
 
 	memberB.account.CustomizationColor = multiaccountscommon.CustomizationColorBlue
 	s.Require().NoError(admin.settings.SaveSettingField(settings.DisplayName, "admin"))

--- a/protocol/messenger_group_chat_test.go
+++ b/protocol/messenger_group_chat_test.go
@@ -118,9 +118,6 @@ func (s *MessengerGroupChatSuite) TestGroupChatCreation() {
 
 	for i, testCase := range testCases {
 		creator, member := s.newMessenger(), s.newMessenger()
-		defer TearDownMessenger(s.T(), creator)
-		defer TearDownMessenger(s.T(), member)
-
 		members := []string{crypto.PubkeyToHex(&member.identity.PublicKey)}
 
 		if testCase.creatorAddedMemberAsContact {
@@ -179,48 +176,42 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersAddition() {
 	}
 
 	for i, testCase := range testCases {
-		admin, inviter, member := s.newMessenger(), s.newMessenger(), s.newMessenger()
-		defer TearDownMessenger(s.T(), admin)
-		defer TearDownMessenger(s.T(), inviter)
-		defer TearDownMessenger(s.T(), member)
+		s.Run(testCase.name, func() {
+			admin, inviter, member := s.newMessenger(), s.newMessenger(), s.newMessenger()
+			members := []string{crypto.PubkeyToHex(&member.identity.PublicKey)}
 
-		members := []string{crypto.PubkeyToHex(&member.identity.PublicKey)}
-
-		if testCase.inviterAddedMemberAsContact {
-			s.makeContact(inviter, member)
-		}
-		if testCase.memberAddedInviterAsContact {
-			s.makeContact(member, inviter)
-		}
-
-		for j, inviterIsAlsoGroupCreator := range []bool{true, false} {
-			var groupChat *Chat
-			if inviterIsAlsoGroupCreator {
-				groupChat = s.createEmptyGroupChat(inviter, fmt.Sprintf("test_group_chat_%d_%d", i, j))
-			} else {
-				s.makeContact(admin, inviter)
-				groupChat = s.createGroupChat(admin, fmt.Sprintf("test_group_chat_%d_%d", i, j), []string{crypto.PubkeyToHex(&inviter.identity.PublicKey)})
-				err := inviter.SaveChat(groupChat)
-				s.Require().NoError(err)
-			}
-
-			_, err := inviter.AddMembersToGroupChat(context.Background(), groupChat.ID, members)
 			if testCase.inviterAddedMemberAsContact {
-				s.Require().NoError(err)
-				s.verifyGroupChatCreated(member, testCase.expectedAddedMemberChatActive)
-			} else {
-				s.Require().EqualError(err, "group-chat: can't add members who are not mutual contacts")
+				s.makeContact(inviter, member)
 			}
-		}
+			if testCase.memberAddedInviterAsContact {
+				s.makeContact(member, inviter)
+			}
+
+			for j, inviterIsAlsoGroupCreator := range []bool{true, false} {
+				var groupChat *Chat
+				if inviterIsAlsoGroupCreator {
+					groupChat = s.createEmptyGroupChat(inviter, fmt.Sprintf("test_group_chat_%d_%d", i, j))
+				} else {
+					s.makeContact(admin, inviter)
+					groupChat = s.createGroupChat(admin, fmt.Sprintf("test_group_chat_%d_%d", i, j), []string{crypto.PubkeyToHex(&inviter.identity.PublicKey)})
+					err := inviter.SaveChat(groupChat)
+					s.Require().NoError(err)
+				}
+
+				_, err := inviter.AddMembersToGroupChat(context.Background(), groupChat.ID, members)
+				if testCase.inviterAddedMemberAsContact {
+					s.Require().NoError(err)
+					s.verifyGroupChatCreated(member, testCase.expectedAddedMemberChatActive)
+				} else {
+					s.Require().EqualError(err, "group-chat: can't add members who are not mutual contacts")
+				}
+			}
+		})
 	}
 }
 
 func (s *MessengerGroupChatSuite) TestGroupChatMembersRemoval() {
 	admin, memberA, memberB, memberC := s.newMessenger(), s.newMessenger(), s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(s.T(), admin)
-	defer TearDownMessenger(s.T(), memberA)
-	defer TearDownMessenger(s.T(), memberB)
-	defer TearDownMessenger(s.T(), memberC)
 
 	members := []string{crypto.PubkeyToHex(&memberA.identity.PublicKey), crypto.PubkeyToHex(&memberB.identity.PublicKey),
 		crypto.PubkeyToHex(&memberC.identity.PublicKey)}
@@ -257,8 +248,6 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersRemoval() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatEdit() {
 	admin, member := s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(s.T(), admin)
-	defer TearDownMessenger(s.T(), member)
 
 	s.makeMutualContacts(admin, member)
 
@@ -327,8 +316,6 @@ func (s *MessengerGroupChatSuite) TestGroupChatEdit() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatDeleteMemberMessage() {
 	admin, member := s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(s.T(), admin)
-	defer TearDownMessenger(s.T(), member)
 
 	s.makeMutualContacts(admin, member)
 
@@ -365,8 +352,6 @@ func (s *MessengerGroupChatSuite) TestGroupChatDeleteMemberMessage() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatHandleDeleteMemberMessage() {
 	admin, member := s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(s.T(), admin)
-	defer TearDownMessenger(s.T(), member)
 
 	s.makeMutualContacts(admin, member)
 
@@ -411,8 +396,6 @@ func (s *MessengerGroupChatSuite) TestGroupChatHandleDeleteMemberMessage() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatMembersRemovalOutOfOrder() {
 	admin, memberA := s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(s.T(), admin)
-	defer TearDownMessenger(s.T(), memberA)
 
 	members := []string{crypto.PubkeyToHex(&memberA.identity.PublicKey)}
 
@@ -455,9 +438,6 @@ func (s *MessengerGroupChatSuite) TestGroupChatMembersRemovalOutOfOrder() {
 
 func (s *MessengerGroupChatSuite) TestGroupChatMembersInfoSync() {
 	admin, memberA, memberB := s.newMessenger(), s.newMessenger(), s.newMessenger()
-	defer TearDownMessenger(s.T(), admin)
-	defer TearDownMessenger(s.T(), memberA)
-	defer TearDownMessenger(s.T(), memberB)
 
 	memberB.account.CustomizationColor = multiaccountscommon.CustomizationColorBlue
 	s.Require().NoError(admin.settings.SaveSettingField(settings.DisplayName, "admin"))

--- a/protocol/messenger_identity_display_name_test.go
+++ b/protocol/messenger_identity_display_name_test.go
@@ -95,7 +95,6 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestDisplayNameSync() {
 
 	// Create new device and add main account to
 	alicesOtherDevice := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	// Store only chat and default wallet account on other device
 	profileKpOtherDevice, _, _, err := accounts.GetProfileKeypairForTest(true, true, false)

--- a/protocol/messenger_identity_display_name_test.go
+++ b/protocol/messenger_identity_display_name_test.go
@@ -95,7 +95,7 @@ func (s *MessengerProfileDisplayNameHandlerSuite) TestDisplayNameSync() {
 
 	// Create new device and add main account to
 	alicesOtherDevice := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alicesOtherDevice)
+	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	// Store only chat and default wallet account on other device
 	profileKpOtherDevice, _, _, err := accounts.GetProfileKeypairForTest(true, true, false)

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -46,11 +46,6 @@ func (s *MessengerProfilePictureHandlerSuite) SetupTest() {
 	s.setupMultiAccount(s.alice)
 }
 
-func (s *MessengerProfilePictureHandlerSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.bob)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerProfilePictureHandlerSuite) setupMultiAccount(m *Messenger) {
 	name, err := m.settings.DisplayName()
 	s.Require().NoError(err)
@@ -264,13 +259,6 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 	// Generate Alice Messenger
 	alice := s.newMessenger()
 	bob := s.newMessenger()
-
-	defer func() {
-		TearDownMessenger(s.T(), alice)
-		alice = nil
-		TearDownMessenger(s.T(), bob)
-		bob = nil
-	}()
 
 	// Setup MultiAccount for Alice Messenger
 	s.setupMultiAccount(alice)

--- a/protocol/messenger_identity_image_test.go
+++ b/protocol/messenger_identity_image_test.go
@@ -47,7 +47,7 @@ func (s *MessengerProfilePictureHandlerSuite) SetupTest() {
 }
 
 func (s *MessengerProfilePictureHandlerSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.bob)
+	TearDownMessenger(s.T(), s.bob)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 
@@ -266,9 +266,9 @@ func (s *MessengerProfilePictureHandlerSuite) testE2eSendingReceivingProfilePict
 	bob := s.newMessenger()
 
 	defer func() {
-		TearDownMessenger(&s.Suite, alice)
+		TearDownMessenger(s.T(), alice)
 		alice = nil
-		TearDownMessenger(&s.Suite, bob)
+		TearDownMessenger(s.T(), bob)
 		bob = nil
 	}()
 

--- a/protocol/messenger_installations_test.go
+++ b/protocol/messenger_installations_test.go
@@ -36,7 +36,7 @@ type MessengerInstallationSuite struct {
 
 func (s *MessengerInstallationSuite) TestReceiveInstallation() {
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	err := theirMessenger.SetInstallationMetadata(theirMessenger.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",
@@ -215,7 +215,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 
 	// Create Alice for the 1-1 chat
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 
 	// Create 1-1 chat
 	ourOneOneChat := CreateOneToOneChat("Our 1TO1", &alice.identity.PublicKey, alice.getTimesource())
@@ -232,7 +232,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 
 	// pair
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	err = theirMessenger.SaveChat(chat2)
 	s.Require().NoError(err)
 
@@ -353,9 +353,9 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 func (s *MessengerInstallationSuite) TestSyncInstallationNewMessages() {
 	bob1 := s.m
 	bob2 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, bob2)
+	defer TearDownMessenger(s.T(), bob2)
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 
 	err := bob2.SetInstallationMetadata(bob2.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",
@@ -402,7 +402,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallationNewMessages() {
 
 func (s *MessengerInstallationSuite) TestInitInstallations() {
 	m := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, m)
+	defer TearDownMessenger(s.T(), m)
 
 	// m.InitInstallations is already called when we set-up the messenger for
 	// testing, thus this test has no act phase.

--- a/protocol/messenger_installations_test.go
+++ b/protocol/messenger_installations_test.go
@@ -36,7 +36,6 @@ type MessengerInstallationSuite struct {
 
 func (s *MessengerInstallationSuite) TestReceiveInstallation() {
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	err := theirMessenger.SetInstallationMetadata(theirMessenger.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",
@@ -215,7 +214,6 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 
 	// Create Alice for the 1-1 chat
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
 
 	// Create 1-1 chat
 	ourOneOneChat := CreateOneToOneChat("Our 1TO1", &alice.identity.PublicKey, alice.getTimesource())
@@ -232,7 +230,6 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 
 	// pair
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	err = theirMessenger.SaveChat(chat2)
 	s.Require().NoError(err)
 
@@ -353,9 +350,7 @@ func (s *MessengerInstallationSuite) TestSyncInstallation() {
 func (s *MessengerInstallationSuite) TestSyncInstallationNewMessages() {
 	bob1 := s.m
 	bob2 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), bob2)
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
 
 	err := bob2.SetInstallationMetadata(bob2.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",
@@ -402,7 +397,6 @@ func (s *MessengerInstallationSuite) TestSyncInstallationNewMessages() {
 
 func (s *MessengerInstallationSuite) TestInitInstallations() {
 	m := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), m)
 
 	// m.InitInstallations is already called when we set-up the messenger for
 	// testing, thus this test has no act phase.

--- a/protocol/messenger_local_backup_test.go
+++ b/protocol/messenger_local_backup_test.go
@@ -35,11 +35,9 @@ func makeMutualContacts(lhs *Messenger, rhs *Messenger) error {
 func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	// Create bob1
 	bob1 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), bob1)
 
 	// Create bob2
 	bob2 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), bob2)
 
 	// Enable message backup on both accounts
 	err := bob1.settings.SaveSetting(settings.MessagesBackupEnabled.GetReactName(), true)
@@ -217,7 +215,6 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 
 	// Create a one-to-one chat
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
 
 	err = makeMutualContacts(bob1, alice)
 	s.Require().NoError(err)

--- a/protocol/messenger_local_backup_test.go
+++ b/protocol/messenger_local_backup_test.go
@@ -35,11 +35,11 @@ func makeMutualContacts(lhs *Messenger, rhs *Messenger) error {
 func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 	// Create bob1
 	bob1 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, bob1)
+	defer TearDownMessenger(s.T(), bob1)
 
 	// Create bob2
 	bob2 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, bob2)
+	defer TearDownMessenger(s.T(), bob2)
 
 	// Enable message backup on both accounts
 	err := bob1.settings.SaveSetting(settings.MessagesBackupEnabled.GetReactName(), true)
@@ -217,7 +217,7 @@ func (s *MessengerLocalBackupSuite) TestLocalBackup() {
 
 	// Create a one-to-one chat
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 
 	err = makeMutualContacts(bob1, alice)
 	s.Require().NoError(err)

--- a/protocol/messenger_mailserver.go
+++ b/protocol/messenger_mailserver.go
@@ -320,6 +320,7 @@ const missingMessageCheckPeriod = 30 * time.Second
 
 func (m *Messenger) checkForMissingMessagesLoop() {
 	defer gocommon.LogOnPanic()
+	defer m.shutdownWaitGroup.Done()
 
 	t := time.NewTicker(missingMessageCheckPeriod)
 	defer t.Stop()

--- a/protocol/messenger_mailserver_cycle.go
+++ b/protocol/messenger_mailserver_cycle.go
@@ -113,6 +113,7 @@ func (m *Messenger) Storenodes() ([]peer.AddrInfo, error) {
 
 func (m *Messenger) checkForStorenodeCycleSignals() {
 	defer gocommon.LogOnPanic()
+	defer m.shutdownWaitGroup.Done()
 
 	changed := m.messaging.OnStorenodeChanged()
 	notWorking := m.messaging.OnStorenodeNotWorking()
@@ -136,6 +137,8 @@ func (m *Messenger) checkForStorenodeCycleSignals() {
 
 	for {
 		select {
+		case <-m.quit:
+			return
 		case <-m.ctx.Done():
 			return
 		case <-notWorking:

--- a/protocol/messenger_messages_tracking_test.go
+++ b/protocol/messenger_messages_tracking_test.go
@@ -87,11 +87,6 @@ func (s *MessengerMessagesTrackingSuite) SetupTest() {
 	s.alice, s.aliceInterceptor = s.newMessenger()
 }
 
-func (s *MessengerMessagesTrackingSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.bob)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerMessagesTrackingSuite) newMessenger() (*Messenger, *EnvelopeEventsInterceptorMock) {
 	envelopeEventsConfig := &messagingtypes.EnvelopeEventsConfig{
 		EnvelopeEventsHandler:      EnvelopeSignalHandlerMock{},

--- a/protocol/messenger_messages_tracking_test.go
+++ b/protocol/messenger_messages_tracking_test.go
@@ -88,7 +88,7 @@ func (s *MessengerMessagesTrackingSuite) SetupTest() {
 }
 
 func (s *MessengerMessagesTrackingSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.bob)
+	TearDownMessenger(s.T(), s.bob)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 
@@ -99,7 +99,7 @@ func (s *MessengerMessagesTrackingSuite) newMessenger() (*Messenger, *EnvelopeEv
 		MailServerConfirmations:    false,
 	}
 
-	messenger, err := newRunningTestMessenger(s.messagingEnv, testMessengerConfig{extraOptions: []Option{WithEnvelopeEventsConfig(envelopeEventsConfig)}})
+	messenger, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{extraOptions: []Option{WithEnvelopeEventsConfig(envelopeEventsConfig)}})
 	s.Require().NoError(err)
 
 	interceptor := &EnvelopeEventsInterceptorMock{

--- a/protocol/messenger_mute_test.go
+++ b/protocol/messenger_mute_test.go
@@ -21,7 +21,6 @@ type MessengerMuteSuite struct {
 
 func (s *MessengerMuteSuite) TestSetMute() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	chatID := publicChatName
 
@@ -70,7 +69,6 @@ func (s *MessengerMuteSuite) TestSetMuteForDuration() {
 	mockTimeOneMinuteAgo := time.Now().Add(-time.Minute)
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	chatID := publicChatName
 

--- a/protocol/messenger_mute_test.go
+++ b/protocol/messenger_mute_test.go
@@ -21,7 +21,7 @@ type MessengerMuteSuite struct {
 
 func (s *MessengerMuteSuite) TestSetMute() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	chatID := publicChatName
 
@@ -70,7 +70,7 @@ func (s *MessengerMuteSuite) TestSetMuteForDuration() {
 	mockTimeOneMinuteAgo := time.Now().Add(-time.Minute)
 
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	chatID := publicChatName
 

--- a/protocol/messenger_offline_test.go
+++ b/protocol/messenger_offline_test.go
@@ -52,13 +52,6 @@ func (s *MessengerOfflineSuite) SetupTest() {
 	s.owner.communitiesManager.RekeyInterval = 50 * time.Millisecond
 }
 
-func (s *MessengerOfflineSuite) TearDownTest() {
-	s.Require().NoError(s.owner.Shutdown())
-	s.Require().NoError(s.bob.Shutdown())
-	s.Require().NoError(s.alice.Shutdown())
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerOfflineSuite) newMessenger(password string, accounts []string) *Messenger {
 	return newTestCommunitiesMessenger(&s.Suite, s.messagingEnv, testCommunitiesMessengerConfig{
 		testMessengerConfig: testMessengerConfig{

--- a/protocol/messenger_offline_test.go
+++ b/protocol/messenger_offline_test.go
@@ -49,7 +49,7 @@ func (s *MessengerOfflineSuite) SetupTest() {
 	s.bob = s.newMessenger(bobPassword, []string{bobAccountAddress})
 	s.alice = s.newMessenger(alicePassword, []string{aliceAddress1})
 
-	s.owner.communitiesManager.RekeyInterval = 50 * time.Millisecond
+	s.owner.config.communitiesRekeyInterval = 50 * time.Millisecond
 }
 
 func (s *MessengerOfflineSuite) newMessenger(password string, accounts []string) *Messenger {

--- a/protocol/messenger_offline_test.go
+++ b/protocol/messenger_offline_test.go
@@ -49,13 +49,6 @@ func (s *MessengerOfflineSuite) SetupTest() {
 	s.bob = s.newMessenger(bobPassword, []string{bobAccountAddress})
 	s.alice = s.newMessenger(alicePassword, []string{aliceAddress1})
 
-	_, err := s.owner.Start()
-	s.Require().NoError(err)
-	_, err = s.bob.Start()
-	s.Require().NoError(err)
-	_, err = s.alice.Start()
-	s.Require().NoError(err)
-
 	s.owner.communitiesManager.RekeyInterval = 50 * time.Millisecond
 }
 

--- a/protocol/messenger_pairing_and_syncing_test.go
+++ b/protocol/messenger_pairing_and_syncing_test.go
@@ -82,7 +82,7 @@ func (m *stubEnableInstallationAndPair) Validate() error {
 func (s *MessengerPairingSuite) TestNewInstallationReceivedIsNotCreated() {
 	alice1 := s.m
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alice2)
+	defer TearDownMessenger(s.T(), alice2)
 
 	mockRequest := &stubEnableInstallationAndPair{installationID: alice1.installationID}
 	_, err := alice2.EnableInstallationAndPair(mockRequest)
@@ -113,8 +113,8 @@ func (s *MessengerPairingSuite) TestNewInstallationCreatedIsNotDeleted() {
 	alice1 := s.m
 	alice2 := s.anotherMessenger()
 	alice3 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alice2)
-	defer TearDownMessenger(&s.Suite, alice3)
+	defer TearDownMessenger(s.T(), alice2)
+	defer TearDownMessenger(s.T(), alice3)
 
 	// prepare AC NewInstallationCreated for alice2
 	_, err := alice2.EnableInstallationAndPair(&requests.EnableInstallationAndPair{InstallationID: alice1.installationID})
@@ -179,7 +179,7 @@ func (s *MessengerPairingSuite) expectInstallationReceived(m *Messenger, install
 func (s *MessengerPairingSuite) TestMessengerSyncFallback() {
 	alice1 := s.m
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alice2)
+	defer TearDownMessenger(s.T(), alice2)
 
 	alice1ProfileKp, _, _, err := accounts.GetProfileKeypairForTest(true, false, false)
 	s.Require().NoError(err)

--- a/protocol/messenger_pairing_and_syncing_test.go
+++ b/protocol/messenger_pairing_and_syncing_test.go
@@ -82,7 +82,6 @@ func (m *stubEnableInstallationAndPair) Validate() error {
 func (s *MessengerPairingSuite) TestNewInstallationReceivedIsNotCreated() {
 	alice1 := s.m
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alice2)
 
 	mockRequest := &stubEnableInstallationAndPair{installationID: alice1.installationID}
 	_, err := alice2.EnableInstallationAndPair(mockRequest)
@@ -113,8 +112,6 @@ func (s *MessengerPairingSuite) TestNewInstallationCreatedIsNotDeleted() {
 	alice1 := s.m
 	alice2 := s.anotherMessenger()
 	alice3 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alice2)
-	defer TearDownMessenger(s.T(), alice3)
 
 	// prepare AC NewInstallationCreated for alice2
 	_, err := alice2.EnableInstallationAndPair(&requests.EnableInstallationAndPair{InstallationID: alice1.installationID})
@@ -179,7 +176,6 @@ func (s *MessengerPairingSuite) expectInstallationReceived(m *Messenger, install
 func (s *MessengerPairingSuite) TestMessengerSyncFallback() {
 	alice1 := s.m
 	alice2 := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alice2)
 
 	alice1ProfileKp, _, _, err := accounts.GetProfileKeypairForTest(true, false, false)
 	s.Require().NoError(err)

--- a/protocol/messenger_pin_message_test.go
+++ b/protocol/messenger_pin_message_test.go
@@ -21,7 +21,6 @@ type MessengerPinMessageSuite struct {
 
 func (s *MessengerPinMessageSuite) TestPinMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -90,7 +89,6 @@ func (s *MessengerPinMessageSuite) TestPinMessage() {
 
 func (s *MessengerPinMessageSuite) TestPinMessageOutOfOrder() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_pin_message_test.go
+++ b/protocol/messenger_pin_message_test.go
@@ -21,7 +21,7 @@ type MessengerPinMessageSuite struct {
 
 func (s *MessengerPinMessageSuite) TestPinMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -90,7 +90,7 @@ func (s *MessengerPinMessageSuite) TestPinMessage() {
 
 func (s *MessengerPinMessageSuite) TestPinMessageOutOfOrder() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_profile_showcase_test.go
+++ b/protocol/messenger_profile_showcase_test.go
@@ -42,7 +42,7 @@ func (s *TestMessengerProfileShowcase) SetupTest() {
 }
 
 func (s *TestMessengerProfileShowcase) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.m)
+	TearDownMessenger(s.T(), s.m)
 	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
 }
 
@@ -232,7 +232,7 @@ func (s *TestMessengerProfileShowcase) TestEncryptAndDecryptProfileShowcaseEntri
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
 
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -426,7 +426,7 @@ func (s *TestMessengerProfileShowcase) TestShareShowcasePreferences() {
 	mutualContact := s.newMessenger(alicePassword, []string{aliceAccountAddress})
 	_, err = mutualContact.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, mutualContact)
+	defer TearDownMessenger(s.T(), mutualContact)
 
 	s.mutualContact(mutualContact)
 
@@ -434,7 +434,7 @@ func (s *TestMessengerProfileShowcase) TestShareShowcasePreferences() {
 	verifiedContact := s.newMessenger(bobPassword, []string{bobAccountAddress})
 	_, err = verifiedContact.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, verifiedContact)
+	defer TearDownMessenger(s.T(), verifiedContact)
 
 	s.mutualContact(verifiedContact)
 	s.verifiedContact(verifiedContact)
@@ -561,7 +561,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipUnenc
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
 	_, err = bob.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
 
@@ -629,7 +629,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipEncry
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
 	_, err = bob.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
 
@@ -715,7 +715,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesGrantExpires(
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
 	_, err = bob.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
 	advertiseCommunityTo(&s.Suite, community, alice, bob)
@@ -783,7 +783,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesDispatchOnGra
 	owner := s.newMessenger("", []string{})
 	_, err = owner.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, owner)
+	defer TearDownMessenger(s.T(), owner)
 
 	owner.communitiesManager.PermissionChecker = &testPermissionChecker{}
 
@@ -794,7 +794,7 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesDispatchOnGra
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
 	_, err = bob.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
 

--- a/protocol/messenger_profile_showcase_test.go
+++ b/protocol/messenger_profile_showcase_test.go
@@ -37,8 +37,6 @@ type TestMessengerProfileShowcase struct {
 func (s *TestMessengerProfileShowcase) SetupTest() {
 	s.CommunitiesMessengerTestSuiteBase.SetupTest()
 	s.m = s.newMessenger("", []string{})
-	_, err := s.m.Start()
-	s.Require().NoError(err)
 }
 
 func (s *TestMessengerProfileShowcase) TearDownTest() {
@@ -229,9 +227,6 @@ func (s *TestMessengerProfileShowcase) TestFailToSaveProfileShowcasePreferencesW
 func (s *TestMessengerProfileShowcase) TestEncryptAndDecryptProfileShowcaseEntries() {
 	// Add mutual contact
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	_, err := theirMessenger.Start()
-	s.Require().NoError(err)
-
 	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
@@ -424,16 +419,12 @@ func (s *TestMessengerProfileShowcase) TestShareShowcasePreferences() {
 
 	// Add mutual contact
 	mutualContact := s.newMessenger(alicePassword, []string{aliceAccountAddress})
-	_, err = mutualContact.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), mutualContact)
 
 	s.mutualContact(mutualContact)
 
 	// Add identity verified contact
 	verifiedContact := s.newMessenger(bobPassword, []string{bobAccountAddress})
-	_, err = verifiedContact.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), verifiedContact)
 
 	s.mutualContact(verifiedContact)
@@ -559,8 +550,6 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipUnenc
 
 	// Add bob as a mutual contact
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
-	_, err = bob.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
@@ -627,8 +616,6 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipEncry
 
 	// Add bob as a mutual contact
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
-	_, err = bob.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
@@ -713,8 +700,6 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesGrantExpires(
 
 	// 2) Bob add Alice become a mutual contacts
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
-	_, err = bob.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
@@ -781,8 +766,6 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesDispatchOnGra
 
 	// 1) Owner creates an encrypted community
 	owner := s.newMessenger("", []string{})
-	_, err = owner.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), owner)
 
 	owner.communitiesManager.PermissionChecker = &testPermissionChecker{}
@@ -792,8 +775,6 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesDispatchOnGra
 
 	// 2) Bob add Alice become a mutual contacts
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
-	_, err = bob.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)

--- a/protocol/messenger_profile_showcase_test.go
+++ b/protocol/messenger_profile_showcase_test.go
@@ -38,12 +38,6 @@ func (s *TestMessengerProfileShowcase) SetupTest() {
 	s.CommunitiesMessengerTestSuiteBase.SetupTest()
 	s.m = s.newMessenger("", []string{})
 }
-
-func (s *TestMessengerProfileShowcase) TearDownTest() {
-	TearDownMessenger(s.T(), s.m)
-	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
-}
-
 func (s *TestMessengerProfileShowcase) mutualContact(theirMessenger *Messenger) {
 	messageText := "hello!"
 
@@ -227,7 +221,6 @@ func (s *TestMessengerProfileShowcase) TestFailToSaveProfileShowcasePreferencesW
 func (s *TestMessengerProfileShowcase) TestEncryptAndDecryptProfileShowcaseEntries() {
 	// Add mutual contact
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	s.mutualContact(theirMessenger)
 
@@ -419,13 +412,11 @@ func (s *TestMessengerProfileShowcase) TestShareShowcasePreferences() {
 
 	// Add mutual contact
 	mutualContact := s.newMessenger(alicePassword, []string{aliceAccountAddress})
-	defer TearDownMessenger(s.T(), mutualContact)
 
 	s.mutualContact(mutualContact)
 
 	// Add identity verified contact
 	verifiedContact := s.newMessenger(bobPassword, []string{bobAccountAddress})
-	defer TearDownMessenger(s.T(), verifiedContact)
 
 	s.mutualContact(verifiedContact)
 	s.verifiedContact(verifiedContact)
@@ -550,7 +541,6 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipUnenc
 
 	// Add bob as a mutual contact
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
-	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
 
@@ -616,7 +606,6 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseProofOfMembershipEncry
 
 	// Add bob as a mutual contact
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
-	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
 
@@ -700,7 +689,6 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesGrantExpires(
 
 	// 2) Bob add Alice become a mutual contacts
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
-	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
 	advertiseCommunityTo(&s.Suite, community, alice, bob)
@@ -766,7 +754,6 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesDispatchOnGra
 
 	// 1) Owner creates an encrypted community
 	owner := s.newMessenger("", []string{})
-	defer TearDownMessenger(s.T(), owner)
 
 	owner.communitiesManager.PermissionChecker = &testPermissionChecker{}
 
@@ -775,7 +762,6 @@ func (s *TestMessengerProfileShowcase) TestProfileShowcaseCommuniesDispatchOnGra
 
 	// 2) Bob add Alice become a mutual contacts
 	bob := s.newMessenger(bobPassword, []string{bobAccountAddress})
-	defer TearDownMessenger(s.T(), bob)
 
 	s.mutualContact(bob)
 

--- a/protocol/messenger_raw_message_resend.go
+++ b/protocol/messenger_raw_message_resend.go
@@ -20,8 +20,10 @@ import (
 // watchExpiredMessages regularly checks for expired emojis and invoke their resending
 func (m *Messenger) watchExpiredMessages() {
 	m.logger.Debug("watching expired messages")
+	m.shutdownWaitGroup.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer m.shutdownWaitGroup.Done()
 		for {
 			select {
 			case <-time.After(time.Second):

--- a/protocol/messenger_raw_message_resend_test.go
+++ b/protocol/messenger_raw_message_resend_test.go
@@ -61,8 +61,8 @@ func (s *MessengerRawMessageResendTest) SetupTest() {
 }
 
 func (s *MessengerRawMessageResendTest) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.aliceMessenger)
-	TearDownMessenger(&s.Suite, s.bobMessenger)
+	TearDownMessenger(s.T(), s.aliceMessenger)
+	TearDownMessenger(s.T(), s.bobMessenger)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/messenger_raw_message_resend_test.go
+++ b/protocol/messenger_raw_message_resend_test.go
@@ -54,12 +54,6 @@ func (s *MessengerRawMessageResendTest) SetupTest() {
 	joinOnRequestCommunity(&s.Suite, community.ID(), s.aliceMessenger, s.bobMessenger, bobPassword, []string{bobAddress})
 }
 
-func (s *MessengerRawMessageResendTest) TearDownTest() {
-	TearDownMessenger(s.T(), s.aliceMessenger)
-	TearDownMessenger(s.T(), s.bobMessenger)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerRawMessageResendTest) waitForMessageSent(messageID string) {
 	err := testutils.RetryWithBackOff(func() error {
 		rawMessage, err := s.bobMessenger.RawMessageByID(messageID)

--- a/protocol/messenger_raw_message_resend_test.go
+++ b/protocol/messenger_raw_message_resend_test.go
@@ -40,9 +40,6 @@ func (s *MessengerRawMessageResendTest) SetupTest() {
 		mockedBalances:  &s.mockedBalances,
 	})
 
-	_, err := s.aliceMessenger.Start()
-	s.Require().NoError(err)
-
 	s.bobMessenger = newTestCommunitiesMessenger(&s.Suite, s.messagingEnv, testCommunitiesMessengerConfig{
 		testMessengerConfig: testMessengerConfig{
 			name: "bob",
@@ -51,9 +48,6 @@ func (s *MessengerRawMessageResendTest) SetupTest() {
 		password:        bobPassword,
 		mockedBalances:  &s.mockedBalances,
 	})
-
-	_, err = s.bobMessenger.Start()
-	s.Require().NoError(err)
 
 	community, _ := createOnRequestCommunity(&s.Suite, s.aliceMessenger)
 	advertiseCommunityToUserOldWay(&s.Suite, community, s.aliceMessenger, s.bobMessenger)

--- a/protocol/messenger_remove_message_test.go
+++ b/protocol/messenger_remove_message_test.go
@@ -23,7 +23,6 @@ type MessengerRemoveMessageSuite struct {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -72,7 +71,6 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessagePreviousLastMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -121,7 +119,6 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessagePreviousLastMessage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteWrongMessageType() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -148,7 +145,6 @@ func (s *MessengerRemoveMessageSuite) TestDeleteWrongMessageType() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessageFirstThenMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -201,7 +197,6 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageFirstThenMessage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteImageMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -275,7 +270,6 @@ func (s *MessengerRemoveMessageSuite) TestDeleteImageMessage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteImageMessageFirstThenMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -353,7 +347,6 @@ func (s *MessengerRemoveMessageSuite) TestDeleteImageMessageFirstThenMessage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessageWithAMention() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -413,7 +406,6 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageWithAMention() {
 // as read but the message still unseen (Seen == false)
 func (s *MessengerRemoveMessageSuite) TestDeleteMessageAndChatIsAlreadyRead() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -472,7 +464,6 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageAndChatIsAlreadyRead() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessageReplyToImage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -525,7 +516,6 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageReplyToImage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessageForMeReplyToImage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_remove_message_test.go
+++ b/protocol/messenger_remove_message_test.go
@@ -23,7 +23,7 @@ type MessengerRemoveMessageSuite struct {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -72,7 +72,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessagePreviousLastMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -121,7 +121,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessagePreviousLastMessage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteWrongMessageType() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -148,7 +148,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteWrongMessageType() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessageFirstThenMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -201,7 +201,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageFirstThenMessage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteImageMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -275,7 +275,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteImageMessage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteImageMessageFirstThenMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -353,7 +353,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteImageMessageFirstThenMessage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessageWithAMention() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -413,7 +413,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageWithAMention() {
 // as read but the message still unseen (Seen == false)
 func (s *MessengerRemoveMessageSuite) TestDeleteMessageAndChatIsAlreadyRead() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -472,7 +472,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageAndChatIsAlreadyRead() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessageReplyToImage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -525,7 +525,7 @@ func (s *MessengerRemoveMessageSuite) TestDeleteMessageReplyToImage() {
 
 func (s *MessengerRemoveMessageSuite) TestDeleteMessageForMeReplyToImage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_reply_test.go
+++ b/protocol/messenger_reply_test.go
@@ -22,7 +22,7 @@ func (s *MessengerReplySuite) TestReceiveReply() {
 	alice.account = &multiaccounts.Account{KeyUID: "0xdeadbeef"}
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	chatID := statusChatID
 

--- a/protocol/messenger_reply_test.go
+++ b/protocol/messenger_reply_test.go
@@ -22,7 +22,6 @@ func (s *MessengerReplySuite) TestReceiveReply() {
 	alice.account = &multiaccounts.Account{KeyUID: "0xdeadbeef"}
 
 	bob := s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	chatID := statusChatID
 

--- a/protocol/messenger_send_images_album_test.go
+++ b/protocol/messenger_send_images_album_test.go
@@ -31,7 +31,7 @@ func (s *MessengerSendImagesAlbumSuite) SetupTest() {
 }
 
 func (s *MessengerSendImagesAlbumSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.m)
+	TearDownMessenger(s.T(), s.m)
 	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
 }
 
@@ -47,7 +47,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesSend() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err = theirMessenger.SaveChat(theirChat)
@@ -108,7 +108,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesWithMentionSend() 
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err = theirMessenger.SaveChat(theirChat)
@@ -161,7 +161,7 @@ func (s *MessengerSendImagesAlbumSuite) TestSingleImageMessageWithMentionInCommu
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	community, chat := createCommunity(&s.Suite, s.m)
 
@@ -212,7 +212,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageEditText() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err = theirMessenger.SaveChat(theirChat)
@@ -296,7 +296,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImagesMessageWithMentionInCommu
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
 	_, err := theirMessenger.Start()
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	community, chat := createCommunity(&s.Suite, s.m)
 

--- a/protocol/messenger_send_images_album_test.go
+++ b/protocol/messenger_send_images_album_test.go
@@ -26,8 +26,6 @@ type MessengerSendImagesAlbumSuite struct {
 func (s *MessengerSendImagesAlbumSuite) SetupTest() {
 	s.CommunitiesMessengerTestSuiteBase.SetupTest()
 	s.m = s.newMessenger("", []string{})
-	_, err := s.m.Start()
-	s.Require().NoError(err)
 }
 
 func (s *MessengerSendImagesAlbumSuite) TearDownTest() {
@@ -45,8 +43,6 @@ func (s *MessengerSendImagesAlbumSuite) joinCommunity(community *communities.Com
 
 func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesSend() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	_, err := theirMessenger.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
@@ -106,8 +102,6 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesSend() {
 
 func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesWithMentionSend() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	_, err := theirMessenger.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
@@ -159,8 +153,6 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesWithMentionSend() 
 // This test makes sure that if you get a mention with an image ina  community, it sends it correctly and has a notif
 func (s *MessengerSendImagesAlbumSuite) TestSingleImageMessageWithMentionInCommunitySend() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	_, err := theirMessenger.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), theirMessenger)
 
 	community, chat := createCommunity(&s.Suite, s.m)
@@ -210,8 +202,6 @@ func (s *MessengerSendImagesAlbumSuite) TestSingleImageMessageWithMentionInCommu
 
 func (s *MessengerSendImagesAlbumSuite) TestAlbumImageEditText() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	_, err := theirMessenger.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
@@ -294,8 +284,6 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageEditText() {
 // This test makes sure that if you get a mention with an album of images in a community, it sends it correctly and has correct AC notif with album
 func (s *MessengerSendImagesAlbumSuite) TestAlbumImagesMessageWithMentionInCommunitySend() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	_, err := theirMessenger.Start()
-	s.Require().NoError(err)
 	defer TearDownMessenger(s.T(), theirMessenger)
 
 	community, chat := createCommunity(&s.Suite, s.m)

--- a/protocol/messenger_send_images_album_test.go
+++ b/protocol/messenger_send_images_album_test.go
@@ -46,7 +46,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesSend() {
 	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
-	err = theirMessenger.SaveChat(theirChat)
+	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
 	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
@@ -105,7 +105,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesWithMentionSend() 
 	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
-	err = theirMessenger.SaveChat(theirChat)
+	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
 	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
@@ -172,7 +172,7 @@ func (s *MessengerSendImagesAlbumSuite) TestSingleImageMessageWithMentionInCommu
 		album = append(album, outgoingMessage)
 	}
 
-	err = s.m.SaveChat(chat)
+	err := s.m.SaveChat(chat)
 	s.NoError(err)
 	response, err := s.m.SendChatMessages(context.Background(), album)
 	s.NoError(err)
@@ -205,7 +205,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageEditText() {
 	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
-	err = theirMessenger.SaveChat(theirChat)
+	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
 
 	ourChat := CreateOneToOneChat("Our 1TO1", &theirMessenger.identity.PublicKey, s.m.getTimesource())
@@ -303,7 +303,7 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImagesMessageWithMentionInCommu
 		album = append(album, outgoingMessage)
 	}
 
-	err = s.m.SaveChat(chat)
+	err := s.m.SaveChat(chat)
 	s.NoError(err)
 	response, err := s.m.SendChatMessages(context.Background(), album)
 	s.NoError(err)

--- a/protocol/messenger_send_images_album_test.go
+++ b/protocol/messenger_send_images_album_test.go
@@ -28,11 +28,6 @@ func (s *MessengerSendImagesAlbumSuite) SetupTest() {
 	s.m = s.newMessenger("", []string{})
 }
 
-func (s *MessengerSendImagesAlbumSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.m)
-	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
-}
-
 func (s *MessengerSendImagesAlbumSuite) advertiseCommunityTo(community *communities.Community, user *Messenger) {
 	advertiseCommunityTo(&s.Suite, community, s.m, user)
 }
@@ -43,7 +38,6 @@ func (s *MessengerSendImagesAlbumSuite) joinCommunity(community *communities.Com
 
 func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesSend() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -102,7 +96,6 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesSend() {
 
 func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesWithMentionSend() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -153,7 +146,6 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageMessagesWithMentionSend() 
 // This test makes sure that if you get a mention with an image ina  community, it sends it correctly and has a notif
 func (s *MessengerSendImagesAlbumSuite) TestSingleImageMessageWithMentionInCommunitySend() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	community, chat := createCommunity(&s.Suite, s.m)
 
@@ -202,7 +194,6 @@ func (s *MessengerSendImagesAlbumSuite) TestSingleImageMessageWithMentionInCommu
 
 func (s *MessengerSendImagesAlbumSuite) TestAlbumImageEditText() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", s.m.IdentityPublicKey(), s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -284,7 +275,6 @@ func (s *MessengerSendImagesAlbumSuite) TestAlbumImageEditText() {
 // This test makes sure that if you get a mention with an album of images in a community, it sends it correctly and has correct AC notif with album
 func (s *MessengerSendImagesAlbumSuite) TestAlbumImagesMessageWithMentionInCommunitySend() {
 	theirMessenger := s.newMessenger(accountPassword, []string{commonAccountAddress})
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	community, chat := createCommunity(&s.Suite, s.m)
 

--- a/protocol/messenger_settings_test.go
+++ b/protocol/messenger_settings_test.go
@@ -26,12 +26,6 @@ func (s *MessengerSettingsSuite) SetupTest() {
 
 	prepareMessengersForPairing(&s.Suite, s.m, s.m2)
 }
-
-func (s *MessengerSettingsSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.m2)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func prepareMessengersForPairing(s *suite.Suite, m1, m2 *Messenger) {
 	// Set m's installation metadata
 	aim := &messagingtypes.InstallationMetadata{

--- a/protocol/messenger_settings_test.go
+++ b/protocol/messenger_settings_test.go
@@ -28,7 +28,7 @@ func (s *MessengerSettingsSuite) SetupTest() {
 }
 
 func (s *MessengerSettingsSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.m2)
+	TearDownMessenger(s.T(), s.m2)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/messenger_share_image_test.go
+++ b/protocol/messenger_share_image_test.go
@@ -56,7 +56,7 @@ func buildImageMessage(s *MessengerShareMessageSuite, chat Chat) *common.Message
 
 func (s *MessengerShareMessageSuite) TestImageMessageSharing() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_share_image_test.go
+++ b/protocol/messenger_share_image_test.go
@@ -56,7 +56,6 @@ func buildImageMessage(s *MessengerShareMessageSuite, chat Chat) *common.Message
 
 func (s *MessengerShareMessageSuite) TestImageMessageSharing() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreateOneToOneChat("Their 1TO1", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)

--- a/protocol/messenger_sync_activity_center_test.go
+++ b/protocol/messenger_sync_activity_center_test.go
@@ -39,12 +39,6 @@ func (s *MessengerSyncActivityCenterSuite) SetupTest() {
 	PairDevices(&s.Suite, s.m, s.m2)
 }
 
-func (s *MessengerSyncActivityCenterSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.m2)
-	TearDownMessenger(s.T(), s.m)
-	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
-}
-
 func (s *MessengerSyncActivityCenterSuite) createAndSaveNotification(m *Messenger, t ActivityCenterType, read bool) types.HexBytes {
 	now := uint64(time.Now().Unix())
 	id := types.HexBytes{0x01}

--- a/protocol/messenger_sync_activity_center_test.go
+++ b/protocol/messenger_sync_activity_center_test.go
@@ -33,15 +33,7 @@ func (s *MessengerSyncActivityCenterSuite) SetupTest() {
 	s.CommunitiesMessengerTestSuiteBase.SetupTest()
 
 	s.m = s.newMessenger(alicePassword, []string{aliceAccountAddress})
-
-	_, err := s.m.Start()
-	s.Require().NoError(err)
-
 	s.m2 = s.newMessengerWithKey(s.m.identity, alicePassword, []string{aliceAccountAddress})
-	s.Require().NoError(err)
-
-	_, err = s.m2.Start()
-	s.Require().NoError(err)
 
 	PairDevices(&s.Suite, s.m2, s.m)
 	PairDevices(&s.Suite, s.m, s.m2)
@@ -128,15 +120,12 @@ func (s *MessengerSyncActivityCenterSuite) testSyncCommunityRequestDecision(acti
 		s.Require().NoError(userB.Shutdown())
 	}()
 
-	_, err := userB.Start()
-	s.Require().NoError(err)
-
 	communityID := s.createClosedCommunity()
 
 	s.addContactAndShareCommunity(userB, communityID)
 
 	request := createRequestToJoinCommunity(&s.Suite, communityID, userB, accountPassword, []string{commonAccountAddress})
-	_, err = userB.RequestToJoinCommunity(request)
+	_, err := userB.RequestToJoinCommunity(request)
 	s.Require().NoError(err)
 
 	requestToJoinID := s.waitForRequestToJoin(s.m)

--- a/protocol/messenger_sync_activity_center_test.go
+++ b/protocol/messenger_sync_activity_center_test.go
@@ -48,8 +48,8 @@ func (s *MessengerSyncActivityCenterSuite) SetupTest() {
 }
 
 func (s *MessengerSyncActivityCenterSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.m2)
-	TearDownMessenger(&s.Suite, s.m)
+	TearDownMessenger(s.T(), s.m2)
+	TearDownMessenger(s.T(), s.m)
 	s.CommunitiesMessengerTestSuiteBase.TearDownTest()
 }
 

--- a/protocol/messenger_sync_bookmark_test.go
+++ b/protocol/messenger_sync_bookmark_test.go
@@ -33,7 +33,7 @@ func (s *MessengerSyncBookmarkSuite) TestSyncBookmark() {
 
 	// pair
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	err = theirMessenger.SetInstallationMetadata(theirMessenger.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",

--- a/protocol/messenger_sync_bookmark_test.go
+++ b/protocol/messenger_sync_bookmark_test.go
@@ -33,7 +33,6 @@ func (s *MessengerSyncBookmarkSuite) TestSyncBookmark() {
 
 	// pair
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	err = theirMessenger.SetInstallationMetadata(theirMessenger.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",

--- a/protocol/messenger_sync_chat_test.go
+++ b/protocol/messenger_sync_chat_test.go
@@ -31,11 +31,6 @@ func (s *MessengerSyncChatSuite) SetupTest() {
 	s.alice2 = s.anotherMessenger()
 }
 
-func (s *MessengerSyncChatSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.alice2)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerSyncChatSuite) Pair() {
 	err := s.alice2.SetInstallationMetadata(s.alice2.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "alice2",
@@ -119,7 +114,6 @@ func (s *MessengerSyncChatSuite) TestMarkChatMessagesRead() {
 	s.Require().NoError(err)
 
 	otherMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), otherMessenger)
 
 	_, err = otherMessenger.createPublicChat(chatID, &MessengerResponse{})
 	s.Require().NoError(err)

--- a/protocol/messenger_sync_chat_test.go
+++ b/protocol/messenger_sync_chat_test.go
@@ -32,7 +32,7 @@ func (s *MessengerSyncChatSuite) SetupTest() {
 }
 
 func (s *MessengerSyncChatSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.alice2)
+	TearDownMessenger(s.T(), s.alice2)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 
@@ -119,7 +119,7 @@ func (s *MessengerSyncChatSuite) TestMarkChatMessagesRead() {
 	s.Require().NoError(err)
 
 	otherMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, otherMessenger)
+	defer TearDownMessenger(s.T(), otherMessenger)
 
 	_, err = otherMessenger.createPublicChat(chatID, &MessengerResponse{})
 	s.Require().NoError(err)

--- a/protocol/messenger_sync_clear_history_test.go
+++ b/protocol/messenger_sync_clear_history_test.go
@@ -55,7 +55,6 @@ func (s *MessengerSyncClearHistory) pair() *Messenger {
 
 func (s *MessengerSyncClearHistory) TestSyncClearHistory() {
 	theirMessenger := s.pair()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	response, err := s.m.CreatePublicChat(&requests.CreatePublicChat{
 		ID: publicChatName,

--- a/protocol/messenger_sync_clear_history_test.go
+++ b/protocol/messenger_sync_clear_history_test.go
@@ -55,7 +55,7 @@ func (s *MessengerSyncClearHistory) pair() *Messenger {
 
 func (s *MessengerSyncClearHistory) TestSyncClearHistory() {
 	theirMessenger := s.pair()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	response, err := s.m.CreatePublicChat(&requests.CreatePublicChat{
 		ID: publicChatName,

--- a/protocol/messenger_sync_contact_request_decision_test.go
+++ b/protocol/messenger_sync_contact_request_decision_test.go
@@ -38,7 +38,7 @@ func (s *MessengerSyncContactRequestDecisionSuite) TearDownTest() {
 
 func (s *MessengerSyncContactRequestDecisionSuite) TestSyncAcceptContactRequest() {
 	userB := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, userB)
+	defer TearDownMessenger(s.T(), userB)
 
 	numM1DispatchedAcceptContactRequest := 0
 	numM2DispatchedAcceptContactRequest := 0

--- a/protocol/messenger_sync_contact_request_decision_test.go
+++ b/protocol/messenger_sync_contact_request_decision_test.go
@@ -31,14 +31,8 @@ func (s *MessengerSyncContactRequestDecisionSuite) SetupTest() {
 	PairDevices(&s.Suite, s.m, s.m2)
 }
 
-func (s *MessengerSyncContactRequestDecisionSuite) TearDownTest() {
-	s.Require().NoError(s.m2.Shutdown())
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerSyncContactRequestDecisionSuite) TestSyncAcceptContactRequest() {
 	userB := s.newMessenger()
-	defer TearDownMessenger(s.T(), userB)
 
 	numM1DispatchedAcceptContactRequest := 0
 	numM2DispatchedAcceptContactRequest := 0

--- a/protocol/messenger_sync_customization_color_test.go
+++ b/protocol/messenger_sync_customization_color_test.go
@@ -30,7 +30,7 @@ func (s *MessengerSyncAccountCustomizationColorSuite) SetupTest() {
 }
 
 func (s *MessengerSyncAccountCustomizationColorSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.alice2)
+	TearDownMessenger(s.T(), s.alice2)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/messenger_sync_customization_color_test.go
+++ b/protocol/messenger_sync_customization_color_test.go
@@ -29,11 +29,6 @@ func (s *MessengerSyncAccountCustomizationColorSuite) SetupTest() {
 	prepareAliceMessengersForPairing(&s.Suite, s.alice, s.alice2)
 }
 
-func (s *MessengerSyncAccountCustomizationColorSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.alice2)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func prepareAliceMessengersForPairing(s *suite.Suite, alice1, alice2 *Messenger) {
 	// Set Alice's installation metadata
 	aim := &messagingtypes.InstallationMetadata{

--- a/protocol/messenger_sync_keycard_change_test.go
+++ b/protocol/messenger_sync_keycard_change_test.go
@@ -96,11 +96,6 @@ func (s *MessengerSyncKeycardChangeSuite) SetupTest() {
 	s.Require().Equal(2, len(dbKeypairs))
 }
 
-func (s *MessengerSyncKeycardChangeSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.other)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerSyncKeycardChangeSuite) TestAddingNewKeycards() {
 	dbOnReceiver := s.other.settings
 

--- a/protocol/messenger_sync_keycard_change_test.go
+++ b/protocol/messenger_sync_keycard_change_test.go
@@ -97,7 +97,7 @@ func (s *MessengerSyncKeycardChangeSuite) SetupTest() {
 }
 
 func (s *MessengerSyncKeycardChangeSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.other)
+	TearDownMessenger(s.T(), s.other)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/messenger_sync_keycards_state_test.go
+++ b/protocol/messenger_sync_keycards_state_test.go
@@ -96,7 +96,7 @@ func (s *MessengerSyncKeycardsStateSuite) SetupTest() {
 }
 
 func (s *MessengerSyncKeycardsStateSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.other)
+	TearDownMessenger(s.T(), s.other)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/messenger_sync_keycards_state_test.go
+++ b/protocol/messenger_sync_keycards_state_test.go
@@ -95,11 +95,6 @@ func (s *MessengerSyncKeycardsStateSuite) SetupTest() {
 	s.Require().Equal(3, len(dbKeypairs))
 }
 
-func (s *MessengerSyncKeycardsStateSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.other)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func (s *MessengerSyncKeycardsStateSuite) TestSyncKeycardsIfReceiverHasNoKeycards() {
 	senderDb := s.main.settings
 	dbOnReceiver := s.other.settings

--- a/protocol/messenger_sync_profile_picture_test.go
+++ b/protocol/messenger_sync_profile_picture_test.go
@@ -28,7 +28,6 @@ func (s *MessengerSyncProfilePictureSuite) TestSyncProfilePicture() {
 
 	// pair
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	err := theirMessenger.SetInstallationMetadata(theirMessenger.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",

--- a/protocol/messenger_sync_profile_picture_test.go
+++ b/protocol/messenger_sync_profile_picture_test.go
@@ -28,7 +28,7 @@ func (s *MessengerSyncProfilePictureSuite) TestSyncProfilePicture() {
 
 	// pair
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	err := theirMessenger.SetInstallationMetadata(theirMessenger.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",

--- a/protocol/messenger_sync_saved_addresses_test.go
+++ b/protocol/messenger_sync_saved_addresses_test.go
@@ -55,7 +55,7 @@ func (s *MessengerSyncSavedAddressesSuite) SetupTest() {
 }
 
 func (s *MessengerSyncSavedAddressesSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.other)
+	TearDownMessenger(s.T(), s.other)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/messenger_sync_saved_addresses_test.go
+++ b/protocol/messenger_sync_saved_addresses_test.go
@@ -54,11 +54,6 @@ func (s *MessengerSyncSavedAddressesSuite) SetupTest() {
 	s.Require().NoError(err)
 }
 
-func (s *MessengerSyncSavedAddressesSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.other)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 // Helpers duplicate of wallet test. Could not import it from saved_addresses_test.go
 
 func contains[T comparable](container []T, element T, isEqual func(T, T) bool) bool {

--- a/protocol/messenger_sync_settings_test.go
+++ b/protocol/messenger_sync_settings_test.go
@@ -103,11 +103,6 @@ func (s *MessengerSyncSettingsSuite) SetupTest() {
 	prepAliceMessengersForPairing(&s.Suite, s.alice, s.alice2)
 }
 
-func (s *MessengerSyncSettingsSuite) TearDownTest() {
-	TearDownMessenger(s.T(), s.alice2)
-	s.MessengerBaseTestSuite.TearDownTest()
-}
-
 func prepAliceMessengersForPairing(s *suite.Suite, alice1, alice2 *Messenger) {
 	// Set Alice's installation metadata
 	aim := &messagingtypes.InstallationMetadata{

--- a/protocol/messenger_sync_settings_test.go
+++ b/protocol/messenger_sync_settings_test.go
@@ -93,7 +93,7 @@ func (s *MessengerSyncSettingsSuite) SetupTest() {
 	}
 
 	var err error
-	s.m, err = newRunningTestMessenger(s.messagingEnv, testMessengerConfig{appSettings: &settings})
+	s.m, err = newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{appSettings: &settings})
 	s.Require().NoError(err)
 	s.privateKey = s.m.identity
 	s.alice = s.m
@@ -104,7 +104,7 @@ func (s *MessengerSyncSettingsSuite) SetupTest() {
 }
 
 func (s *MessengerSyncSettingsSuite) TearDownTest() {
-	TearDownMessenger(&s.Suite, s.alice2)
+	TearDownMessenger(s.T(), s.alice2)
 	s.MessengerBaseTestSuite.TearDownTest()
 }
 

--- a/protocol/messenger_sync_verification_test.go
+++ b/protocol/messenger_sync_verification_test.go
@@ -36,7 +36,7 @@ func (s *MessengerSyncVerificationRequests) TestSyncVerificationRequests() {
 
 	// pair
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	err = theirMessenger.SetInstallationMetadata(theirMessenger.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",
@@ -98,7 +98,7 @@ func (s *MessengerSyncVerificationRequests) TestSyncTrust() {
 
 	// pair
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	err = theirMessenger.SetInstallationMetadata(theirMessenger.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",

--- a/protocol/messenger_sync_verification_test.go
+++ b/protocol/messenger_sync_verification_test.go
@@ -36,7 +36,6 @@ func (s *MessengerSyncVerificationRequests) TestSyncVerificationRequests() {
 
 	// pair
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	err = theirMessenger.SetInstallationMetadata(theirMessenger.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",
@@ -98,8 +97,6 @@ func (s *MessengerSyncVerificationRequests) TestSyncTrust() {
 
 	// pair
 	theirMessenger := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
-
 	err = theirMessenger.SetInstallationMetadata(theirMessenger.installationID, &messagingtypes.InstallationMetadata{
 		Name:       "their-name",
 		DeviceType: "their-device-type",

--- a/protocol/messenger_sync_wallets_test.go
+++ b/protocol/messenger_sync_wallets_test.go
@@ -98,7 +98,6 @@ func (s *MessengerSyncWalletSuite) TestSyncWallets() {
 
 	// Create new device and add main account to
 	alicesOtherDevice := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	// Store only chat and default wallet account on other device
 	profileKpOtherDevice, _, _, err := accounts.GetProfileKeypairForTest(true, true, false)
@@ -324,7 +323,6 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountsReorder() {
 
 	// Create a main account on alice's other device
 	alicesOtherDevice := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	err = alicesOtherDevice.settings.SaveOrUpdateKeypair(profileKp)
 	s.Require().NoError(err, "profile keypair alice.settings.SaveOrUpdateKeypair")
@@ -522,7 +520,6 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 
 	// Create new device and add main account to
 	alicesOtherDevice := s.anotherMessenger()
-	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()

--- a/protocol/messenger_sync_wallets_test.go
+++ b/protocol/messenger_sync_wallets_test.go
@@ -98,7 +98,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWallets() {
 
 	// Create new device and add main account to
 	alicesOtherDevice := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alicesOtherDevice)
+	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	// Store only chat and default wallet account on other device
 	profileKpOtherDevice, _, _, err := accounts.GetProfileKeypairForTest(true, true, false)
@@ -324,7 +324,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountsReorder() {
 
 	// Create a main account on alice's other device
 	alicesOtherDevice := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alicesOtherDevice)
+	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	err = alicesOtherDevice.settings.SaveOrUpdateKeypair(profileKp)
 	s.Require().NoError(err, "profile keypair alice.settings.SaveOrUpdateKeypair")
@@ -522,7 +522,7 @@ func (s *MessengerSyncWalletSuite) TestSyncWalletAccountOrderAfterDeletion() {
 
 	// Create new device and add main account to
 	alicesOtherDevice := s.anotherMessenger()
-	defer TearDownMessenger(&s.Suite, alicesOtherDevice)
+	defer TearDownMessenger(s.T(), alicesOtherDevice)
 
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -448,7 +448,6 @@ func (s *MessengerSuite) TestRetrieveOwnPublic() {
 // Retrieve their public message
 func (s *MessengerSuite) TestRetrieveTheirPublic() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -490,7 +489,6 @@ func (s *MessengerSuite) TestRetrieveTheirPublic() {
 // Drop audio message in public group
 func (s *MessengerSuite) TestDropAudioMessageInPublicGroup() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -515,7 +513,6 @@ func (s *MessengerSuite) TestDropAudioMessageInPublicGroup() {
 
 func (s *MessengerSuite) TestDeletedAtClockValue() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -545,7 +542,6 @@ func (s *MessengerSuite) TestDeletedAtClockValue() {
 
 func (s *MessengerSuite) TestRetrieveBlockedContact() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreatePublicChat("status", s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -623,7 +619,6 @@ func (s *MessengerSuite) TestRetrieveBlockedContact() {
 // Resend their public message, receive only once
 func (s *MessengerSuite) TestResendPublicMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -677,7 +672,6 @@ func (s *MessengerSuite) TestResendPublicMessage() {
 // Test receiving a message on an existing private chat
 func (s *MessengerSuite) TestRetrieveTheirPrivateChatExisting() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	theirChat := CreateOneToOneChat("XXX", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -718,7 +712,6 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateChatExisting() {
 // Test receiving a message on an non-existing private chat
 func (s *MessengerSuite) TestRetrieveTheirPrivateChatNonExisting() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	chat := CreateOneToOneChat("XXX", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(chat)
 	s.NoError(err)
@@ -755,7 +748,6 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateChatNonExisting() {
 // Test receiving a message on an non-existing public chat
 func (s *MessengerSuite) TestRetrieveTheirPublicChatNonExisting() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	chat := CreatePublicChat("test-chat", s.m.getTimesource())
 	err := theirMessenger.SaveChat(chat)
 	s.NoError(err)
@@ -779,7 +771,6 @@ func (s *MessengerSuite) TestRetrieveTheirPublicChatNonExisting() {
 func (s *MessengerSuite) TestRetrieveTheirPrivateGroupChat() {
 	var response *MessengerResponse
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	response, err := s.m.CreateGroupChatWithMembers(context.Background(), "id", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -846,7 +837,6 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateGroupChat() {
 func (s *MessengerSuite) TestChangeNameGroupChat() {
 	var response *MessengerResponse
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	response, err := s.m.CreateGroupChatWithMembers(context.Background(), "old-name", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -901,7 +891,6 @@ func (s *MessengerSuite) TestChangeNameGroupChat() {
 func (s *MessengerSuite) TestReInvitedToGroupChat() {
 	var response *MessengerResponse
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(s.T(), theirMessenger)
 	response, err := s.m.CreateGroupChatWithMembers(context.Background(), "old-name", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -1781,7 +1770,6 @@ func (t *testTimeSource) GetCurrentTime() uint64 {
 func (s *MessengerSuite) TestSendMessageMention() {
 	// Initialize Alice and Bob's messengers
 	alice, bob := s.m, s.newMessenger()
-	defer TearDownMessenger(s.T(), bob)
 
 	// Set display names for Bob and Alice
 	s.Require().NoError(bob.settings.SaveSettingField(settings.DisplayName, "bobby"))

--- a/protocol/messenger_test.go
+++ b/protocol/messenger_test.go
@@ -448,7 +448,7 @@ func (s *MessengerSuite) TestRetrieveOwnPublic() {
 // Retrieve their public message
 func (s *MessengerSuite) TestRetrieveTheirPublic() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -490,7 +490,7 @@ func (s *MessengerSuite) TestRetrieveTheirPublic() {
 // Drop audio message in public group
 func (s *MessengerSuite) TestDropAudioMessageInPublicGroup() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -515,7 +515,7 @@ func (s *MessengerSuite) TestDropAudioMessageInPublicGroup() {
 
 func (s *MessengerSuite) TestDeletedAtClockValue() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -545,7 +545,7 @@ func (s *MessengerSuite) TestDeletedAtClockValue() {
 
 func (s *MessengerSuite) TestRetrieveBlockedContact() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 
 	theirChat := CreatePublicChat("status", s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
@@ -623,7 +623,7 @@ func (s *MessengerSuite) TestRetrieveBlockedContact() {
 // Resend their public message, receive only once
 func (s *MessengerSuite) TestResendPublicMessage() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	theirChat := CreatePublicChat("status", s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -677,7 +677,7 @@ func (s *MessengerSuite) TestResendPublicMessage() {
 // Test receiving a message on an existing private chat
 func (s *MessengerSuite) TestRetrieveTheirPrivateChatExisting() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	theirChat := CreateOneToOneChat("XXX", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(theirChat)
 	s.Require().NoError(err)
@@ -718,7 +718,7 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateChatExisting() {
 // Test receiving a message on an non-existing private chat
 func (s *MessengerSuite) TestRetrieveTheirPrivateChatNonExisting() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	chat := CreateOneToOneChat("XXX", &s.privateKey.PublicKey, s.m.getTimesource())
 	err := theirMessenger.SaveChat(chat)
 	s.NoError(err)
@@ -755,7 +755,7 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateChatNonExisting() {
 // Test receiving a message on an non-existing public chat
 func (s *MessengerSuite) TestRetrieveTheirPublicChatNonExisting() {
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	chat := CreatePublicChat("test-chat", s.m.getTimesource())
 	err := theirMessenger.SaveChat(chat)
 	s.NoError(err)
@@ -779,7 +779,7 @@ func (s *MessengerSuite) TestRetrieveTheirPublicChatNonExisting() {
 func (s *MessengerSuite) TestRetrieveTheirPrivateGroupChat() {
 	var response *MessengerResponse
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	response, err := s.m.CreateGroupChatWithMembers(context.Background(), "id", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -846,7 +846,7 @@ func (s *MessengerSuite) TestRetrieveTheirPrivateGroupChat() {
 func (s *MessengerSuite) TestChangeNameGroupChat() {
 	var response *MessengerResponse
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	response, err := s.m.CreateGroupChatWithMembers(context.Background(), "old-name", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -901,7 +901,7 @@ func (s *MessengerSuite) TestChangeNameGroupChat() {
 func (s *MessengerSuite) TestReInvitedToGroupChat() {
 	var response *MessengerResponse
 	theirMessenger := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, theirMessenger)
+	defer TearDownMessenger(s.T(), theirMessenger)
 	response, err := s.m.CreateGroupChatWithMembers(context.Background(), "old-name", []string{})
 	s.NoError(err)
 	s.Require().Len(response.Chats(), 1)
@@ -1781,7 +1781,7 @@ func (t *testTimeSource) GetCurrentTime() uint64 {
 func (s *MessengerSuite) TestSendMessageMention() {
 	// Initialize Alice and Bob's messengers
 	alice, bob := s.m, s.newMessenger()
-	defer TearDownMessenger(&s.Suite, bob)
+	defer TearDownMessenger(s.T(), bob)
 
 	// Set display names for Bob and Alice
 	s.Require().NoError(bob.settings.SaveSettingField(settings.DisplayName, "bobby"))

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -220,13 +220,6 @@ func SetIdentityImagesAndWaitForChange(s *suite.Suite, messenger *Messenger, tim
 	s.Require().True(ok)
 }
 
-func WaitForAvailableStoreNode(s *suite.Suite, m *Messenger, ctx context.Context) {
-	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
-	defer cancel()
-	available := m.messaging.WaitForAvailableStoreNode(ctx)
-	s.Require().True(available)
-}
-
 func TearDownMessenger(t *testing.T, m *Messenger) {
 	if m == nil {
 		return
@@ -259,27 +252,6 @@ func randomString(length int, runes []rune) string {
 
 func RandomLettersString(length int) string {
 	return randomString(length, letterRunes)
-}
-
-func RandomColor() string {
-	return "#" + randomString(6, hexRunes)
-}
-
-func RandomCommunityTags(count int) []string {
-	availableTagsCount := requests.AvailableTagsCount()
-
-	if count > availableTagsCount {
-		count = availableTagsCount
-	}
-
-	//source := mathRand.New(mathRand.NewSource(time.Now().UnixNano()))
-	indices := mathRand.Perm(availableTagsCount)
-	shuffled := make([]string, count)
-	for i := 0; i < count; i++ {
-		shuffled[i] = requests.TagByIndex(uint32(indices[i]))
-	}
-
-	return shuffled
 }
 
 func RandomBytes(length int) []byte {

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -227,7 +227,7 @@ func WaitForAvailableStoreNode(s *suite.Suite, m *Messenger, ctx context.Context
 	s.Require().True(available)
 }
 
-func TearDownMessenger(s *suite.Suite, m *Messenger) {
+func TearDownMessenger(t *testing.T, m *Messenger) {
 	if m == nil {
 		return
 	}

--- a/protocol/messenger_testing_utils.go
+++ b/protocol/messenger_testing_utils.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"math/big"
-	mathRand "math/rand"
 	"sync"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/status-im/status-go/protocol/communities"
 	"github.com/status-im/status-go/protocol/identity"
 	"github.com/status-im/status-go/protocol/protobuf"
-	"github.com/status-im/status-go/protocol/requests"
 )
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -218,19 +216,6 @@ func SetIdentityImagesAndWaitForChange(s *suite.Suite, messenger *Messenger, tim
 	wg.Wait()
 
 	s.Require().True(ok)
-}
-
-func TearDownMessenger(t *testing.T, m *Messenger) {
-	if m == nil {
-		return
-	}
-	s.Require().NoError(m.Shutdown())
-	if m.database != nil {
-		s.Require().NoError(m.database.Close())
-	}
-	if m.multiAccounts != nil {
-		s.Require().NoError(m.multiAccounts.Close())
-	}
 }
 
 func randomInt(length int) int {

--- a/protocol/messenger_unread_test.go
+++ b/protocol/messenger_unread_test.go
@@ -287,7 +287,7 @@ func (s *MessengerSuite) TestMarkMessageAsUnreadInOneChatDoesNotImpactOtherChats
 
 func (s *MessengerSuite) TestMarkMessageWithNotificationAsUnreadInCommunityChatSetsNotificationAsUnread() {
 	other := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, other)
+	defer TearDownMessenger(s.T(), other)
 
 	description := &requests.CreateCommunity{
 		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,

--- a/protocol/messenger_unread_test.go
+++ b/protocol/messenger_unread_test.go
@@ -287,7 +287,6 @@ func (s *MessengerSuite) TestMarkMessageAsUnreadInOneChatDoesNotImpactOtherChats
 
 func (s *MessengerSuite) TestMarkMessageWithNotificationAsUnreadInCommunityChatSetsNotificationAsUnread() {
 	other := s.newMessenger()
-	defer TearDownMessenger(s.T(), other)
 
 	description := &requests.CreateCommunity{
 		Membership:  protobuf.CommunityPermissions_AUTO_ACCEPT,

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -107,6 +107,10 @@ func (s *MessengerPushNotificationSuite) newPushNotificationServer() (*Messenger
 	err = server.Start(serverPersistence, messenger.Messaging())
 	s.Require().NoError(err)
 
+	s.T().Cleanup(func() {
+		server.Stop()
+	})
+
 	return messenger, server
 }
 

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -114,13 +114,10 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotification() {
 	bob1 := s.m
 	bob2, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{privateKey: s.m.identity, extraOptions: []Option{WithPushNotifications()}})
 	s.Require().NoError(err)
-	defer TearDownMessenger(s.T(), bob2)
 
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(s.T(), messenger)
 
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob1.installationID, bob2.installationID}
 
@@ -291,14 +288,10 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotification() {
 }
 
 func (s *MessengerPushNotificationSuite) TestReceivePushNotificationFromContactOnly() {
-
 	bob := s.m
-
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(s.T(), messenger)
-
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
+
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
 
@@ -428,17 +421,11 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationFromContactO
 }
 
 func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
-
 	bob := s.m
-
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(s.T(), messenger)
-
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
 	// another contact to invalidate the token
 	frank := s.newMessenger()
-	defer TearDownMessenger(s.T(), frank)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
@@ -650,14 +637,9 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
 }
 
 func (s *MessengerPushNotificationSuite) TestContactCode() {
-
 	bob1 := s.m
-
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(s.T(), messenger)
-
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 
@@ -707,14 +689,9 @@ func (s *MessengerPushNotificationSuite) TestContactCode() {
 }
 
 func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
-
 	bob := s.m
-
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(s.T(), messenger)
-
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
@@ -844,14 +821,9 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
 }
 
 func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityRequest() {
-
 	bob := s.m
-
 	messenger, server := s.newPushNotificationServer()
-	defer TearDownMessenger(s.T(), messenger)
-
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 
@@ -977,13 +949,9 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevice
 	bob1 := s.m
 	bob2, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{privateKey: s.m.identity, extraOptions: []Option{WithPushNotifications()}})
 	s.Require().NoError(err)
-	defer TearDownMessenger(s.T(), bob2)
 
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(s.T(), messenger)
-
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob1.installationID, bob2.installationID}
@@ -1155,14 +1123,9 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevice
 }
 
 func (s *MessengerPushNotificationSuite) TestReceivePushNotificationReply() {
-
 	bob := s.m
-
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(s.T(), messenger)
-
 	alice := s.newMessenger()
-	defer TearDownMessenger(s.T(), alice)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}

--- a/protocol/push_notification_test.go
+++ b/protocol/push_notification_test.go
@@ -82,7 +82,7 @@ func (s *MessengerPushNotificationSuite) SetupTest() {
 }
 
 func (s *MessengerPushNotificationSuite) newMessenger() *Messenger {
-	messenger, err := newRunningTestMessenger(s.messagingEnv, testMessengerConfig{extraOptions: []Option{WithPushNotifications()}})
+	messenger, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{extraOptions: []Option{WithPushNotifications()}})
 	s.Require().NoError(err)
 	return messenger
 }
@@ -100,7 +100,7 @@ func (s *MessengerPushNotificationSuite) newPushNotificationServer() (*Messenger
 
 	server := pushnotificationserver.New(serverConfig)
 
-	messenger, err := newRunningTestMessenger(s.messagingEnv, testMessengerConfig{privateKey: privateKey, extraOptions: []Option{WithPushNotificationServer(server)}})
+	messenger, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{privateKey: privateKey, extraOptions: []Option{WithPushNotificationServer(server)}})
 	s.Require().NoError(err)
 
 	serverPersistence := pushnotificationserver.NewSQLitePersistence(messenger.database)
@@ -112,15 +112,15 @@ func (s *MessengerPushNotificationSuite) newPushNotificationServer() (*Messenger
 
 func (s *MessengerPushNotificationSuite) TestReceivePushNotification() {
 	bob1 := s.m
-	bob2, err := newRunningTestMessenger(s.messagingEnv, testMessengerConfig{privateKey: s.m.identity, extraOptions: []Option{WithPushNotifications()}})
+	bob2, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{privateKey: s.m.identity, extraOptions: []Option{WithPushNotifications()}})
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, bob2)
+	defer TearDownMessenger(s.T(), bob2)
 
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(&s.Suite, messenger)
+	defer TearDownMessenger(s.T(), messenger)
 
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob1.installationID, bob2.installationID}
 
@@ -295,10 +295,10 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationFromContactO
 	bob := s.m
 
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(&s.Suite, messenger)
+	defer TearDownMessenger(s.T(), messenger)
 
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
 
@@ -432,13 +432,13 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationRetries() {
 	bob := s.m
 
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(&s.Suite, messenger)
+	defer TearDownMessenger(s.T(), messenger)
 
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 	// another contact to invalidate the token
 	frank := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, frank)
+	defer TearDownMessenger(s.T(), frank)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
@@ -654,10 +654,10 @@ func (s *MessengerPushNotificationSuite) TestContactCode() {
 	bob1 := s.m
 
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(&s.Suite, messenger)
+	defer TearDownMessenger(s.T(), messenger)
 
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 
@@ -711,10 +711,10 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationMention() {
 	bob := s.m
 
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(&s.Suite, messenger)
+	defer TearDownMessenger(s.T(), messenger)
 
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}
@@ -848,10 +848,10 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 	bob := s.m
 
 	messenger, server := s.newPushNotificationServer()
-	defer TearDownMessenger(&s.Suite, messenger)
+	defer TearDownMessenger(s.T(), messenger)
 
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 
@@ -975,15 +975,15 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationCommunityReq
 func (s *MessengerPushNotificationSuite) TestReceivePushNotificationPairedDevices() {
 
 	bob1 := s.m
-	bob2, err := newRunningTestMessenger(s.messagingEnv, testMessengerConfig{privateKey: s.m.identity, extraOptions: []Option{WithPushNotifications()}})
+	bob2, err := newRunningTestMessenger(s.T(), s.messagingEnv, testMessengerConfig{privateKey: s.m.identity, extraOptions: []Option{WithPushNotifications()}})
 	s.Require().NoError(err)
-	defer TearDownMessenger(&s.Suite, bob2)
+	defer TearDownMessenger(s.T(), bob2)
 
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(&s.Suite, messenger)
+	defer TearDownMessenger(s.T(), messenger)
 
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob1.installationID, bob2.installationID}
@@ -1159,10 +1159,10 @@ func (s *MessengerPushNotificationSuite) TestReceivePushNotificationReply() {
 	bob := s.m
 
 	messenger, _ := s.newPushNotificationServer()
-	defer TearDownMessenger(&s.Suite, messenger)
+	defer TearDownMessenger(s.T(), messenger)
 
 	alice := s.newMessenger()
-	defer TearDownMessenger(&s.Suite, alice)
+	defer TearDownMessenger(s.T(), alice)
 
 	s.Require().NoError(alice.EnableSendingPushNotifications())
 	bobInstallationIDs := []string{bob.installationID}

--- a/protocol/pushnotificationclient/client.go
+++ b/protocol/pushnotificationclient/client.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"math"
 	mrand "math/rand"
+	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -192,7 +193,8 @@ type Client struct {
 	// resendingLoopQuitChan is a channel to indicate to the send loop that should be terminating
 	resendingLoopQuitChan chan struct{}
 
-	quit chan struct{}
+	quit   chan struct{}
+	quitWg sync.WaitGroup
 
 	// registrationSubscriptions is a list of chan of client subscribed to the registration event
 	registrationSubscriptions []chan struct{}
@@ -265,6 +267,7 @@ func (c *Client) Stop() error {
 	c.stopRegistrationLoop()
 	c.stopResendingLoop()
 	c.quitRegistrationSubscriptions()
+	c.quitWg.Wait()
 	return nil
 }
 
@@ -707,8 +710,10 @@ func (c *Client) generateSharedKey(publicKey *ecdsa.PublicKey) ([]byte, error) {
 
 // subscribeForMessageEvents subscribes for newly sent/scheduled messages so we can check if we need to send a push notification
 func (c *Client) subscribeForMessageEvents() {
+	c.quitWg.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer c.quitWg.Done()
 		c.config.Logger.Debug("subscribing for message events")
 
 		messagesSub, unsubMessages := pubsub.Subscribe[common.MessageEvent](c.sender.Publisher(), 100)
@@ -774,8 +779,10 @@ func (c *Client) stopResendingLoop() {
 func (c *Client) startRegistrationLoop() {
 	c.stopRegistrationLoop()
 	c.registrationLoopQuitChan = make(chan struct{})
+	c.quitWg.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer c.quitWg.Done()
 		err := c.registrationLoop()
 		if err != nil {
 			c.config.Logger.Error("registration loop exited with an error", zap.Error(err))
@@ -786,8 +793,10 @@ func (c *Client) startRegistrationLoop() {
 func (c *Client) startResendingLoop() {
 	c.stopResendingLoop()
 	c.resendingLoopQuitChan = make(chan struct{})
+	c.quitWg.Add(1)
 	go func() {
 		defer gocommon.LogOnPanic()
+		defer c.quitWg.Done()
 		err := c.resendingLoop()
 		if err != nil {
 			c.config.Logger.Error("resending loop exited with an error", zap.Error(err))
@@ -1541,6 +1550,8 @@ func (c *Client) resendingLoop() error {
 		case <-time.After(waitFor * time.Second):
 		case <-c.resendingLoopQuitChan:
 			return nil
+		case <-c.quit:
+			return nil
 		}
 	}
 }
@@ -1596,9 +1607,10 @@ func (c *Client) registrationLoop() error {
 		waitFor := time.Duration(nextRetry)
 		c.config.Logger.Debug("Waiting for", zap.Any("wait for", waitFor))
 		select {
-
 		case <-time.After(waitFor * time.Second):
 		case <-c.registrationLoopQuitChan:
+			return nil
+		case <-c.quit:
 			return nil
 		}
 	}

--- a/protocol/pushnotificationserver/server.go
+++ b/protocol/pushnotificationserver/server.go
@@ -101,6 +101,11 @@ func (s *Server) Start(persistence Persistence, messaging *messaging.API) error 
 	return nil
 }
 
+func (s *Server) Stop() {
+	s.config.Logger.Info("stopping push notification server")
+	s.sender.Stop()
+}
+
 // HandlePushNotificationRegistration builds a response for the registration and sends it back to the user
 func (s *Server) HandlePushNotificationRegistration(publicKey *ecdsa.PublicKey, payload []byte) error {
 	response := s.buildPushNotificationRegistrationResponse(publicKey, payload)


### PR DESCRIPTION
Requires:
- https://github.com/status-im/mvds/pull/11

Iterates:
- https://github.com/status-im/status-go/issues/7216

# Description

> [!TIP]
> Review by commits. 

We're not properly shutting down a lot of Messenger instances. They're kept dangling and running in the background, because tests are executed as a single process. Goroutines will be running until the whole process is shut down.

## ‼️ Use `t.Cleanup` for Messenger, messaging and databases

The idea is to schedule cleanup with `t.Cleanup(...)` immediately after starting/opening some resource.
This way we can ensure the resource and its all goroutines will be stopped/closed when the test finishes. No manual teardown is needed.

- 1307792 test: automatically start messenger for tests
- bdea242 feat: use t.Cleanup foe messenger, messaging and databases
- bd654f3 fix: don't close database from messenger

## ⚠️  Graceful shutdown

1. Some of the running services were not shutting down its goroutines at all.
2. Some of them were not waiting for the goroutines to finish.

This was also the reason why we would see `sql: database is closed` error in test logs. This was coming from goroutines that kept running from test A during tests B, C, etc.

- 1ef11fc fix: push notification client graceful shutdown 
- 743a0a5 fix: messenger watchExpiredMessages graceful shutdown
- 897cd76 fix: MessageSender graceful shutdown
- 87da310 fix: PushNotificationServer graceful shutdown
- e7607a1 fix: graceful shutdown
- 5f0affc fix: update mvds to get https://github.com/status-im/mvds/pull/11

## 🧹  And the required changes (that make this PR look big)

1. I removed manual Messenger starting from tests. To reliably track where it's started and schedule a cleanup.
2. I removed the manual teardown of messenger and some other parts.
3. I added `t` as argument to some test utils
4. Because of (1), I had to change how we set some of Messenger parameters, e.g. `RekeyInterval`. This has to be passed to `newMessenger` before starting it.

- 1e50952 test: pass t to testing utils
- ad9578c chore: remove unused code
- d8a6b72 test: log test logger name
- 737a2d0 fix: bugs
- 84c6a6f test: remove manual messenger teardown
- 9351b05 test: fixes