### PR TITLE
chore: check if client PR exists or not

### DIFF
--- a/.github/workflows/status-app-companion-pr.yml
+++ b/.github/workflows/status-app-companion-pr.yml
@@ -1,0 +1,96 @@
+name: Companion PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-companion-pr:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for companion PR
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          output=$(./scripts/check-companion-pr.sh "${{ github.event.pull_request.number }}" "${{ github.event.pull_request.head.sha }}")
+          exit_code=$?
+          set -e
+          echo "$output"
+          while IFS='=' read -r key value; do
+            echo "${key,,}=${value}" >> "$GITHUB_OUTPUT"
+          done < <(echo "$output" | grep -E '^[A-Z_]+=')
+          exit $exit_code
+
+      - name: Post comment
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          OUTPUTS_JSON: ${{ toJSON(steps.check.outputs) }}
+        with:
+          script: |
+            const outputs = JSON.parse(process.env.OUTPUTS_JSON);
+            const prNumber = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
+
+            let body;
+            if (outputs.reason === 'no_link_in_description') {
+              body = [
+                '<!-- companion-pr-check -->',
+                '## ⚠️ Companion PR Required',
+                '',
+                'Add a link to your status-app PR in this PR\'s description.',
+                '',
+                'Example: `https://github.com/status-im/status-app/pull/123`'
+              ].join('\n');
+            } else if (outputs.reason === 'sha_mismatch') {
+              body = [
+                '<!-- companion-pr-check -->',
+                '## ⚠️ Companion PR Needs Update',
+                '',
+                '[#' + outputs.companion_pr_number + '](' + outputs.companion_pr_url + ') is not using the latest status-go commit (`' + headSha + '`).',
+                '',
+                'Update `vendor/status-go` in the companion PR.'
+              ].join('\n');
+            } else if (outputs.verified === 'true') {
+              body = [
+                '<!-- companion-pr-check -->',
+                '## ✅ Companion PR Verified',
+                '',
+                '[#' + outputs.companion_pr_number + ' - ' + outputs.companion_pr_title + '](' + outputs.companion_pr_url + ')'
+              ].join('\n');
+            } else {
+              return;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const existing = comments.find(c => c.user.type === 'Bot' && c.body.includes('<!-- companion-pr-check -->'));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body
+              });
+            }

--- a/scripts/check-companion-pr.sh
+++ b/scripts/check-companion-pr.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -eu
+
+pr_body=$(gh api "repos/status-im/status-go/pulls/$1" --jq '.body // ""')
+
+if [[ "$pr_body" =~ https://github\.com/status-im/status-app/pull/([0-9]+) ]]; then
+    companion_pr=${BASH_REMATCH[1]}
+elif [[ "$pr_body" =~ status-im/status-app#([0-9]+) ]]; then
+    companion_pr=${BASH_REMATCH[1]}
+else
+    echo "REASON=no_link_in_description"
+    exit 1
+fi
+
+companion_json=$(gh api "repos/status-im/status-app/pulls/${companion_pr}")
+companion_title=$(echo "$companion_json" | jq -r '.title' | tr '\n' ' ')
+companion_sha=$(echo "$companion_json" | jq -r '.head.sha')
+
+submodule_sha=$(gh api "repos/status-im/status-app/contents/vendor/status-go?ref=${companion_sha}" --jq '.sha')
+
+if [[ "$submodule_sha" != "$2" ]]; then
+    echo "COMPANION_PR_NUMBER=${companion_pr}"
+    echo "COMPANION_PR_TITLE=${companion_title}"
+    echo "COMPANION_PR_URL=https://github.com/status-im/status-app/pull/${companion_pr}"
+    echo "REASON=sha_mismatch"
+    exit 1
+fi
+
+echo "COMPANION_PR_NUMBER=${companion_pr}"
+echo "COMPANION_PR_TITLE=${companion_title}"
+echo "COMPANION_PR_URL=https://github.com/status-im/status-app/pull/${companion_pr}"
+echo "VERIFIED=true"


### PR DESCRIPTION
Each status-go PR should ideally be verified against a status-app PR.
