### PR TITLE
chore: fix windows paths for nim sds src dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,10 @@ endif
 
 # Option 1: Provide NIM_SDS_SOURCE_DIR. Make clones it if missing.
 NIM_SDS_SOURCE_DIR ?= $(GIT_ROOT)/../nim-sds
+# Normalize path separators for Windows (backslashes cause issues when passed through shells)
+ifeq ($(mkspecs),win32)
+	NIM_SDS_SOURCE_DIR := $(subst \,/,$(NIM_SDS_SOURCE_DIR))
+endif
 
 # Option 2: Provide NIM_SDS_LIB_DIR and NIM_SDS_INC_DIR
 

--- a/go.sum
+++ b/go.sum
@@ -2291,8 +2291,6 @@ github.com/status-im/markdown v0.0.0-20250825083641-55c1df9bc05d h1:0jQiaymp0t7X
 github.com/status-im/markdown v0.0.0-20250825083641-55c1df9bc05d/go.mod h1:i31M0FhtYMUeAzWqJafla0Q4+LCGJyorLRCH3EorAWQ=
 github.com/status-im/migrate/v4 v4.6.2-status.3 h1:Khwjb59NzniloUr5i9s9AtkEyqBbQFt1lkoAu66sAu0=
 github.com/status-im/migrate/v4 v4.6.2-status.3/go.mod h1:c/kc90n47GZu/58nnz1OMLTf7uE4Da4gZP5qmU+A/v8=
-github.com/status-im/mvds v0.0.27-0.20251218214347-120f6178db6e h1:KzGXeyj/npZMbF+9iDqZWWnvdodYjW/t4qFdPp0fN3E=
-github.com/status-im/mvds v0.0.27-0.20251218214347-120f6178db6e/go.mod h1:2fiAx0q9XYIPKYRq2B1oiO9zZESy/n4D32gWw6lMDsE=
 github.com/status-im/mvds v0.0.27-0.20251219201002-7226facd5aaf h1:CKUQmbtf0fodAQRwAcORa8Fk2Ej6x6PMn/yKipK14Es=
 github.com/status-im/mvds v0.0.27-0.20251219201002-7226facd5aaf/go.mod h1:2fiAx0q9XYIPKYRq2B1oiO9zZESy/n4D32gWw6lMDsE=
 github.com/status-im/zxcvbn-go v0.0.0-20220311183720-5e8676676857 h1:sPkzT7Z7uLmejOsBRlZ0kwDWpqjpHJsp834o5nbhqho=


### PR DESCRIPTION
## Summary

This fixes weird path issues when nim sds source directory is passed from status-app to status-go.

Client PR: https://github.com/status-im/status-app/pull/19619