### PR TITLE
fix(community): disable creating anyone can be admin or member perms

### DIFF
--- a/protocol/communities_messenger_test.go
+++ b/protocol/communities_messenger_test.go
@@ -3170,6 +3170,27 @@ func (s *MessengerCommunitiesSuite) TestSyncCommunity_LeftCommunity() {
 	s.Require().False(community.Spectated())
 }
 
+func (s *MessengerCommunitiesSuite) TestInvalidAnyoneCanPermissions() {
+	// Cannot create a "anyone can" permission for admins (that would be chaotic)
+	community, _ := s.createCommunity()
+	_, err := s.owner.CreateCommunityTokenPermission(&requests.CreateCommunityTokenPermission{
+		CommunityID:   community.ID(),
+		Type:          protobuf.CommunityTokenPermission_BECOME_ADMIN,
+		TokenCriteria: []*protobuf.TokenCriteria{}, // Empty Criteria
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, requests.ErrBecomeMemberOrAdminPermissionRequiresCriteria)
+
+	// Cannot create a "anyone can" permission for members (that's the default)
+	community, _ = s.createCommunity()
+	_, err = s.owner.CreateCommunityTokenPermission(&requests.CreateCommunityTokenPermission{
+		CommunityID:   community.ID(),
+		Type:          protobuf.CommunityTokenPermission_BECOME_MEMBER,
+		TokenCriteria: []*protobuf.TokenCriteria{}, // Empty Criteria
+	})
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, requests.ErrBecomeMemberOrAdminPermissionRequiresCriteria)
+}
 func (s *MessengerCommunitiesSuite) TestSetMutePropertyOnChatsByCategory() {
 	// Create a community
 	createCommunityReq := &requests.CreateCommunity{

--- a/protocol/requests/create_community_token_permission_request.go
+++ b/protocol/requests/create_community_token_permission_request.go
@@ -16,6 +16,7 @@ var (
 	ErrCreateCommunityTokenPermissionTooManyTokenCriteria  = errors.New("too many token criteria")
 	ErrCreateCommunityTokenPermissionInvalidPermissionType = errors.New("invalid community token permission type")
 	ErrCreateCommunityTokenPermissionInvalidTokenCriteria  = errors.New("invalid community permission token criteria data")
+	ErrBecomeMemberOrAdminPermissionRequiresCriteria       = errors.New("token criteria required for become member/admin permission type")
 	ErrConvertingAmountToBigInt                            = errors.New("converting amount to big.Int")
 )
 
@@ -53,6 +54,10 @@ func (p *CreateCommunityTokenPermission) Validate() error {
 		if len(c.ContractAddresses) > 0 && amountBig.Cmp(big.NewInt(0)) == 0 {
 			return ErrCreateCommunityTokenPermissionInvalidTokenCriteria
 		}
+	}
+
+	if len(p.TokenCriteria) == 0 && (p.Type == protobuf.CommunityTokenPermission_BECOME_MEMBER || p.Type == protobuf.CommunityTokenPermission_BECOME_ADMIN) {
+		return ErrBecomeMemberOrAdminPermissionRequiresCriteria
 	}
 
 	return nil


### PR DESCRIPTION
Needed for https://github.com/status-im/status-app/issues/19620

It was possible to create permissions where "anyone can be admin", which would be a disaster. We also enabled creating "anyone can join the community", which makes no sense, because that's just the default when there are no permissions.
