### PR TITLE
chore: bring in nim-sds from branch fix-ios-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ endif
 # `nim-sds` variables
 
 # Pin nim-sds revision here. Can be a tag (default) or commit hash.
-NIM_SDS_VERSION ?= 8d33a7f7dafe37f482d09a8fb113869f78baf0b8
+NIM_SDS_VERSION ?= fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6
 
 # Option 1: Provide NIM_SDS_SOURCE_DIR. Make clones it if missing.
 NIM_SDS_SOURCE_DIR ?= $(GIT_ROOT)/../nim-sds


### PR DESCRIPTION
This is needed to fix iOS build with linking errors

nim-sds PR : https://github.com/logos-messaging/nim-sds/pull/41

