### PR TITLE
feat(multiaccount): add back functions to delete a multiaccount

### DIFF
--- a/mobile/status.go
+++ b/mobile/status.go
@@ -556,6 +556,26 @@ func logout() string {
 	return makeJSONResponse(statusBackend.Logout())
 }
 
+func DeleteMultiaccount(requestJSON string) string {
+	return callWithResponse(deleteMultiaccount, requestJSON)
+}
+
+func deleteMultiaccount(requestJSON string) string {
+	var request requests.DeleteMultiaccount
+	err := json.Unmarshal([]byte(requestJSON), &request)
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = request.Validate()
+	if err != nil {
+		return makeJSONResponse(err)
+	}
+
+	err = statusBackend.DeleteMultiaccount(request.KeyUID, request.KeyStoreDir)
+	return makeJSONResponse(err)
+}
+
 func SignMessage(rpcParams string) string {
 	return callWithResponse(signMessage, rpcParams)
 }

--- a/mobile/status_test.go
+++ b/mobile/status_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/status-im/status-go/internal/db/multiaccounts"
 	"github.com/status-im/status-go/internal/db/multiaccounts/settings"
+	"github.com/status-im/status-go/protocol/requests"
 	"github.com/status-im/status-go/signal"
 )
 
@@ -46,4 +47,87 @@ func TestIntendedPanic(t *testing.T) {
 	require.PanicsWithError(t, message, func() {
 		IntendedPanic(message)
 	})
+}
+
+func TestDeleteMultiaccountResponseFormat(t *testing.T) {
+	// Test that the function returns a proper JSON response even with invalid input
+	tests := []struct {
+		name        string
+		requestJSON string
+	}{
+		{
+			name:        "invalid JSON",
+			requestJSON: `{"keyUID": invalid}`,
+		},
+		{
+			name: "missing required field",
+			requestJSON: `{
+				"keyUID": ""
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call the actual function - it will fail internally but should return valid JSON
+			result := deleteMultiaccount(tt.requestJSON)
+
+			// Verify it returns valid JSON
+			var response APIResponse
+			err := json.Unmarshal([]byte(result), &response)
+			require.NoError(t, err, "Response should be valid JSON")
+			require.NotEmpty(t, response.Error, "Response should contain an error message")
+		})
+	}
+}
+
+func TestDeleteMultiaccountRequestValidation(t *testing.T) {
+	// Test the request validation logic in isolation
+	tests := []struct {
+		name    string
+		keyUID  string
+		keyDir  string
+		wantErr bool
+	}{
+		{
+			name:    "valid request",
+			keyUID:  "0xabcd1234",
+			keyDir:  "/path/to/keystore",
+			wantErr: false,
+		},
+		{
+			name:    "empty keyUID",
+			keyUID:  "",
+			keyDir:  "/path/to/keystore",
+			wantErr: true,
+		},
+		{
+			name:    "empty keyStoreDir",
+			keyUID:  "0xabcd1234",
+			keyDir:  "",
+			wantErr: true,
+		},
+		{
+			name:    "both empty",
+			keyUID:  "",
+			keyDir:  "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := requests.DeleteMultiaccount{
+				KeyUID:      tt.keyUID,
+				KeyStoreDir: tt.keyDir,
+			}
+
+			err := request.Validate()
+			if tt.wantErr {
+				require.Error(t, err, "Validate() should return an error")
+			} else {
+				require.NoError(t, err, "Validate() should not return an error")
+			}
+		})
+	}
 }

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -1462,7 +1463,6 @@ func TestRestoreKeycardAccountAndLogin(t *testing.T) {
 	require.NoError(t, err)
 
 	backend := NewStatusBackend(testutils.MustCreateTestLogger())
-	require.NoError(t, err)
 
 	backend.UpdateRootDataDir(conf.RootDataDir)
 
@@ -1502,4 +1502,25 @@ func TestRestoreKeycardAccountAndLogin(t *testing.T) {
 	acc, err := backend.RestoreKeycardAccountAndLogin(request)
 	require.NoError(t, err)
 	require.NotNil(t, acc)
+}
+
+func TestDeleteMultiaccount(t *testing.T) {
+	testContext := setupTestContext(t, testPassword, true, true, true)
+
+	rootDataDir := testContext.backend.rootDataDir
+	keyStoreDir := filepath.Join(rootDataDir, "keystore")
+
+	err := testContext.backend.OpenAccounts(false)
+	require.NoError(t, err)
+
+	files, err := os.ReadDir(rootDataDir)
+	require.NoError(t, err)
+	require.NotEqual(t, 3, len(files))
+
+	err = testContext.backend.DeleteMultiaccount(testContext.profileKeypair.KeyUID, keyStoreDir)
+	require.NoError(t, err)
+
+	files, err = os.ReadDir(rootDataDir)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(files))
 }

--- a/pkg/backend/geth_backend.go
+++ b/pkg/backend/geth_backend.go
@@ -328,6 +328,59 @@ func (b *StatusBackend) SaveAccount(account multiaccounts.Account) error {
 	return b.multiaccountsDB.SaveAccount(account)
 }
 
+func (b *StatusBackend) DeleteMultiaccount(keyUID string, keyStoreDir string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.multiaccountsDB == nil {
+		return errors.New("accounts db wasn't initialized")
+	}
+
+	err := b.multiaccountsDB.DeleteAccount(keyUID)
+	if err != nil {
+		return err
+	}
+
+	appDbPath, err := b.getAppDBPath(keyUID)
+	if err != nil {
+		return err
+	}
+
+	walletDbPath, err := b.getWalletDBPath(keyUID)
+	if err != nil {
+		return err
+	}
+
+	dbFiles := []string{
+		filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql", keyUID)),
+		filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql-shm", keyUID)),
+		filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql-wal", keyUID)),
+		filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db", keyUID)),
+		filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db-shm", keyUID)),
+		filepath.Join(b.rootDataDir, fmt.Sprintf("%s.db-wal", keyUID)),
+		appDbPath,
+		appDbPath + "-shm",
+		appDbPath + "-wal",
+		walletDbPath,
+		walletDbPath + "-shm",
+		walletDbPath + "-wal",
+	}
+	for _, path := range dbFiles {
+		if _, err := os.Stat(path); err == nil {
+			err = os.Remove(path)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if b.account != nil && b.account.KeyUID == keyUID {
+		// reset active account
+		b.account = nil
+	}
+
+	return os.RemoveAll(keyStoreDir)
+}
+
 func (b *StatusBackend) runDBFileMigrations(account multiaccounts.Account, password string) (string, error) {
 	// Migrate file path to fix issue https://github.com/status-im/status-go/issues/2027
 	unsupportedPath := filepath.Join(b.rootDataDir, fmt.Sprintf("app-%x.sql", account.KeyUID))

--- a/protocol/requests/delete_multiaccount.go
+++ b/protocol/requests/delete_multiaccount.go
@@ -8,6 +8,9 @@ import (
 type DeleteMultiaccount struct {
 	// KeyUID is the unique identifier for the key.
 	KeyUID string `json:"keyUID" validate:"required"`
+
+	// KeyStoreDir is the directory where the keystore files are located.
+	KeyStoreDir string `json:"keyStoreDir" validate:"required"`
 }
 
 // Validate checks the validity of the DeleteMultiaccount request.


### PR DESCRIPTION
Needed for https://github.com/status-im/status-app/issues/15350

It was deleted as "not used" because desktop didn't have it yet, but we planned to use it. This was the commit: https://github.com/status-im/status-go/commit/d96dfaaf0ff6d4e487daa71ae437bbb7a0dd246e#diff-37b0477fdcc303b15489e4502027610f4a45ee12b564c48b7ccb45439e0c4b74

I only brought back `DeleteMultiaccountV2`, but removed the V2 part. I updated the test to work with the new way of managing accounts, which is pleasantly way simpler.