### PR TITLE
chore: update go-wallet-sdk dependency and add skipped token keys to token manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/schollz/peerdiscovery v1.7.0
 	github.com/status-im/extkeys v1.4.0
-	github.com/status-im/go-wallet-sdk v0.0.0-20251128124044-df18aa5cfd60
+	github.com/status-im/go-wallet-sdk v0.0.0-20260108075629-2691c53cc1dc
 	github.com/waku-org/go-waku v0.10.1
 	github.com/waku-org/sds-go-bindings v0.0.0-20251222164514-d5b47a911904
 	github.com/waku-org/waku-go-bindings v0.0.0-20251202095947-63b01b7d0ca9

--- a/go.sum
+++ b/go.sum
@@ -518,8 +518,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
-github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
-github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
+github.com/cespare/cp v1.1.1 h1:nCb6ZLdB7NRaqsm91JtQTAme2SKJzXVsdPIPkyJr1MU=
+github.com/cespare/cp v1.1.1/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -2281,8 +2281,8 @@ github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e h1:GV7a
 github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e/go.mod h1:iktiTcPdK+nuL47hn+7UL12uIkgJYyOAh99jdA6ruGw=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3 h1:/73h1w1hUfb3wVyTlNrUIwahZxatgesCHa6lwO57C2M=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
-github.com/status-im/go-wallet-sdk v0.0.0-20251128124044-df18aa5cfd60 h1:h3YzafoiTdgg+n8X9OHQBnPmaP1k3UCakCRIyWcehGE=
-github.com/status-im/go-wallet-sdk v0.0.0-20251128124044-df18aa5cfd60/go.mod h1:6zJF+lF5y88viQAtALL4FrPcZYR8dAeR/kNOPXwlY/o=
+github.com/status-im/go-wallet-sdk v0.0.0-20260108075629-2691c53cc1dc h1:zQ1OeaKemSnxyK+bVvVDAMGR+Xq3xB2K//tfT4dqwiA=
+github.com/status-im/go-wallet-sdk v0.0.0-20260108075629-2691c53cc1dc/go.mod h1:E4E1D0mflc2pcjsutZpvMYSjI+a231uBHQf8UjdT1Ug=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4 h1:CtobZoiNdHpx+xurFxnuJ1xsGm3oKMfcZkB3vmomJmA=
 github.com/status-im/gomoji v1.1.3-0.20220213022530-e5ac4a8732d4/go.mod h1:hmpnZzkzSZJbFYWAUkrPV8I36x7mdYiPhPqnALP4fKA=
 github.com/status-im/goroutine-defer-guard v0.3.1 h1:cZhcJ3gO6OgMYBOfEaAAUZaZgKZeSzMlGNEjMyejuRo=

--- a/nix/pkgs/status-go/library/default.nix
+++ b/nix/pkgs/status-go/library/default.nix
@@ -11,7 +11,7 @@ let
 in pkgs.buildGoModule {
   pname = "status-go";
   src = builtins.path { path = ./../../../..; name = "status-go-library"; };
-  vendorHash = "sha256-owwYkQ/3AqTC3EZqxuD+k0aNxmTeUUZ6CWZ3v9dx2MQ=";
+  vendorHash = "sha256-O2hS/NtjbU4QVPjsu3xh/BScRY+qqydMUdl+uo++OZs=";
 
   inherit meta version;
 

--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -271,3 +271,10 @@ func MandatoryTokens() []string {
 	}
 	return mandatoryTokens
 }
+
+func SkippedTokenKeys() []string {
+	return []string{
+		types.TokenKey(OptimismMainnet, common.HexToAddress("0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000")),
+		types.TokenKey(OptimismSepolia, common.HexToAddress("0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000")),
+	}
+}

--- a/services/wallet/token/token.go
+++ b/services/wallet/token/token.go
@@ -191,6 +191,8 @@ func setUpTokenListsManager(mng *Manager, walletDB *sql.DB, lastUpdate time.Time
 		},
 
 		Chains: walletcommon.AllChainIDsAsUint64(),
+
+		SkippedTokenKeys: walletcommon.SkippedTokenKeys(),
 	}
 
 	return manager.New(config, wsdkFetcher, contentStore, customTokenStore)


### PR DESCRIPTION
Corresponding `go-wallet-sdk`
- https://github.com/status-im/go-wallet-sdk/pull/36

Changes:
- Updated go-wallet-sdk version in go.mod and go.sum
- Integrated SkippedTokenKeys into token manager

Closes https://github.com/status-im/status-app/issues/19647