### PR TITLE
fix(build): go-generate-fast, run-status-backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,9 +301,9 @@ status-backend: ##@build Build status-backend to run status-go as HTTP server
 status-backend: build/bin/status-backend
 
 run-status-backend: PORT ?= 0
-run-status-backend: generate
+run-status-backend: generate $(LIBSDS)
 run-status-backend: ##@run Start status-backend server listening to localhost:PORT
-	go run -mod=mod ./cmd/status-backend --address localhost:${PORT}
+	CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" go run -mod=mod ./cmd/status-backend --address localhost:${PORT}
 
 push-notification-server: ##@build Build push-notification-server
 push-notification-server: build/bin/push-notification-server

--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,6 @@ replace github.com/mutecomm/go-sqlcipher/v4 v4.4.2 => github.com/status-im/go-sq
 
 replace github.com/libp2p/go-libp2p-pubsub v0.13.1 => github.com/waku-org/go-libp2p-pubsub v0.13.1-gowaku
 
-replace github.com/oNaiPs/go-generate-fast v0.3.0 => github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e
-
 require (
 	github.com/anacrolix/torrent v1.41.0
 	github.com/beevik/ntp v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1764,6 +1764,8 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
+github.com/oNaiPs/go-generate-fast v0.3.0 h1:MrLkHD60kyOeoTjwy0tgvM4nUPPlHLv8N8eIkemthDA=
+github.com/oNaiPs/go-generate-fast v0.3.0/go.mod h1:GtejfvpRlmX4GtOF3/aqHhyFFoFEIxal4O9lLRrRJ00=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -2277,8 +2279,6 @@ github.com/status-im/doubleratchet v3.0.0+incompatible h1:aJ1ejcSERpSzmWZBgtfYti
 github.com/status-im/doubleratchet v3.0.0+incompatible/go.mod h1:1sqR0+yhiM/bd+wrdX79AOt2csZuJOni0nUDzKNuqOU=
 github.com/status-im/extkeys v1.4.0 h1:HiB/vQXZrGveZbGy3W6hI4T0CfCt0uP4xvGwjXL4cAQ=
 github.com/status-im/extkeys v1.4.0/go.mod h1:AZGS9vJKbME5tovNqYH/LrfHu8t9ad9nxl76fbLG5PY=
-github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e h1:GV7a03166mVZLUlfMBDbJOjfEB4A+iJ8rYvKlDUvOLA=
-github.com/status-im/go-generate-fast v0.0.0-20250916164518-c78009bcfa9e/go.mod h1:iktiTcPdK+nuL47hn+7UL12uIkgJYyOAh99jdA6ruGw=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3 h1:/73h1w1hUfb3wVyTlNrUIwahZxatgesCHa6lwO57C2M=
 github.com/status-im/go-sqlcipher/v4 v4.5.4-status.3/go.mod h1:mF2UmIpBnzFeBdu/ypTDb/LdbS0nk0dfSN1WUsWTjMA=
 github.com/status-im/go-wallet-sdk v0.0.0-20251128124044-df18aa5cfd60 h1:h3YzafoiTdgg+n8X9OHQBnPmaP1k3UCakCRIyWcehGE=


### PR DESCRIPTION
* Remove `replace go-generate-fast` from go.mod
The upstream repo `github.com/oNaiPs/go-generate-fast` has been updated. Non-existent commit caused `go mod tidy` to fail

* Fix `make run-status-backend` failing with `libsds.h` not found error
Added `$(LIBSDS)` to nim-sds library cmdline when missing. Pass `CGO_CFLAGS` and `CGO_LDFLAGS`