### PR TITLE
chore: remove Nodefleet and Grove proxy providers from network configurations

### DIFF
--- a/pkg/backend/default_networks.go
+++ b/pkg/backend/default_networks.go
@@ -51,9 +51,7 @@ func mainnet(proxyHost, stageName string, enableRpcProviders bool) params.Networ
 			// Smart proxy provider
 			*params.NewEthRpcProxyProvider(chainID, common.StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 			// Proxy providers
-			*params.NewProxyProvider(chainID, common.ProxyNodefleet, proxyUrl(stageName, common.Nodefleet, chainName, networkName), false),
 			*params.NewProxyProvider(chainID, common.ProxyInfura, proxyUrl(stageName, common.Infura, chainName, networkName), false),
-			*params.NewProxyProvider(chainID, common.ProxyGrove, proxyUrl(stageName, common.Grove, chainName, networkName), false),
 			// Direct providers
 			*params.NewDirectProvider(chainID, common.DirectInfura, security.NewSensitiveString("https://mainnet.infura.io/v3/"), true),
 			*params.NewDirectProvider(chainID, common.DirectGrove, security.NewSensitiveString("https://eth.rpc.grove.city/v1/"), false),
@@ -93,9 +91,7 @@ func sepolia(proxyHost, stageName string, enableRpcProviders bool) params.Networ
 			// Smart proxy provider
 			*params.NewEthRpcProxyProvider(chainID, common.StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 			// Proxy providers
-			*params.NewProxyProvider(chainID, common.ProxyNodefleet, proxyUrl(stageName, common.Nodefleet, chainName, networkName), false),
 			*params.NewProxyProvider(chainID, common.ProxyInfura, proxyUrl(stageName, common.Infura, chainName, networkName), false),
-			*params.NewProxyProvider(chainID, common.ProxyGrove, proxyUrl(stageName, common.Grove, chainName, networkName), true),
 			// Direct providers
 			*params.NewDirectProvider(chainID, common.DirectInfura, security.NewSensitiveString("https://sepolia.infura.io/v3/"), true),
 			*params.NewDirectProvider(chainID, common.DirectGrove, security.NewSensitiveString("https://eth-sepolia-testnet.rpc.grove.city/v1/"), false),
@@ -135,9 +131,7 @@ func optimism(proxyHost, stageName string, enableRpcProviders bool) params.Netwo
 			// Smart proxy provider
 			*params.NewEthRpcProxyProvider(chainID, common.StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 			// Proxy providers
-			*params.NewProxyProvider(chainID, common.ProxyNodefleet, proxyUrl(stageName, common.Nodefleet, chainName, networkName), false),
 			*params.NewProxyProvider(chainID, common.ProxyInfura, proxyUrl(stageName, common.Infura, chainName, networkName), false),
-			*params.NewProxyProvider(chainID, common.ProxyGrove, proxyUrl(stageName, common.Grove, chainName, networkName), true),
 			// Direct providers
 			*params.NewDirectProvider(chainID, common.DirectInfura, security.NewSensitiveString("https://optimism-mainnet.infura.io/v3/"), true),
 			*params.NewDirectProvider(chainID, common.DirectGrove, security.NewSensitiveString("https://optimism.rpc.grove.city/v1/"), false),
@@ -177,9 +171,7 @@ func optimismSepolia(proxyHost, stageName string, enableRpcProviders bool) param
 			// Smart proxy provider
 			*params.NewEthRpcProxyProvider(chainID, common.StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 			// Proxy providers
-			*params.NewProxyProvider(chainID, common.ProxyNodefleet, proxyUrl(stageName, common.Nodefleet, chainName, networkName), false),
 			*params.NewProxyProvider(chainID, common.ProxyInfura, proxyUrl(stageName, common.Infura, chainName, networkName), false),
-			*params.NewProxyProvider(chainID, common.ProxyGrove, proxyUrl(stageName, common.Grove, chainName, networkName), true),
 			// Direct providers
 			*params.NewDirectProvider(chainID, common.DirectInfura, security.NewSensitiveString("https://optimism-sepolia.infura.io/v3/"), true),
 			*params.NewDirectProvider(chainID, common.DirectGrove, security.NewSensitiveString("https://optimism-sepolia-testnet.rpc.grove.city/v1/"), false),
@@ -219,9 +211,7 @@ func arbitrum(proxyHost, stageName string, enableRpcProviders bool) params.Netwo
 			// Smart proxy provider
 			*params.NewEthRpcProxyProvider(chainID, common.StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 			// Proxy providers
-			*params.NewProxyProvider(chainID, common.ProxyNodefleet, proxyUrl(stageName, common.Nodefleet, chainName, networkName), false),
 			*params.NewProxyProvider(chainID, common.ProxyInfura, proxyUrl(stageName, common.Infura, chainName, networkName), false),
-			*params.NewProxyProvider(chainID, common.ProxyGrove, proxyUrl(stageName, common.Grove, chainName, networkName), true),
 			// Direct providers
 			*params.NewDirectProvider(chainID, common.DirectInfura, security.NewSensitiveString("https://arbitrum-mainnet.infura.io/v3/"), true),
 			*params.NewDirectProvider(chainID, common.DirectGrove, security.NewSensitiveString("https://arbitrum-one.rpc.grove.city/v1/"), false),
@@ -261,9 +251,7 @@ func arbitrumSepolia(proxyHost, stageName string, enableRpcProviders bool) param
 			// Smart proxy provider
 			*params.NewEthRpcProxyProvider(chainID, common.StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 			// Proxy providers
-			*params.NewProxyProvider(chainID, common.ProxyNodefleet, proxyUrl(stageName, common.Nodefleet, chainName, networkName), false),
 			*params.NewProxyProvider(chainID, common.ProxyInfura, proxyUrl(stageName, common.Infura, chainName, networkName), false),
-			*params.NewProxyProvider(chainID, common.ProxyGrove, proxyUrl(stageName, common.Grove, chainName, networkName), true),
 			// Direct providers
 			*params.NewDirectProvider(chainID, common.DirectInfura, security.NewSensitiveString("https://arbitrum-sepolia.infura.io/v3/"), true),
 			*params.NewDirectProvider(chainID, common.DirectGrove, security.NewSensitiveString("https://arbitrum-sepolia-testnet.rpc.grove.city/v1/"), false),
@@ -303,9 +291,7 @@ func base(proxyHost, stageName string, enableRpcProviders bool) params.Network {
 			// Smart proxy provider
 			*params.NewEthRpcProxyProvider(chainID, common.StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 			// Proxy providers
-			*params.NewProxyProvider(chainID, common.ProxyNodefleet, proxyUrl(stageName, common.Nodefleet, chainName, networkName), false),
 			*params.NewProxyProvider(chainID, common.ProxyInfura, proxyUrl(stageName, common.Infura, chainName, networkName), false),
-			*params.NewProxyProvider(chainID, common.ProxyGrove, proxyUrl(stageName, common.Grove, chainName, networkName), true),
 			// Direct providers
 			*params.NewDirectProvider(chainID, common.DirectInfura, security.NewSensitiveString("https://base-mainnet.infura.io/v3/"), true),
 			*params.NewDirectProvider(chainID, common.DirectGrove, security.NewSensitiveString("https://base.rpc.grove.city/v1/"), false),
@@ -345,9 +331,7 @@ func baseSepolia(proxyHost, stageName string, enableRpcProviders bool) params.Ne
 			// Smart proxy provider
 			*params.NewEthRpcProxyProvider(chainID, common.StatusSmartProxy, smartProxyUrl(proxyHost, chainName, networkName), false),
 			// Proxy providers
-			*params.NewProxyProvider(chainID, common.ProxyNodefleet, proxyUrl(stageName, common.Nodefleet, chainName, networkName), false),
 			*params.NewProxyProvider(chainID, common.ProxyInfura, proxyUrl(stageName, common.Infura, chainName, networkName), false),
-			*params.NewProxyProvider(chainID, common.ProxyGrove, proxyUrl(stageName, common.Grove, chainName, networkName), true),
 			// Direct providers
 			*params.NewDirectProvider(chainID, common.DirectInfura, security.NewSensitiveString("https://base-sepolia.infura.io/v3/"), true),
 			*params.NewDirectProvider(chainID, common.DirectGrove, security.NewSensitiveString("https://base-testnet.rpc.grove.city/v1/"), false),

--- a/services/wallet/common/const.go
+++ b/services/wallet/common/const.go
@@ -35,9 +35,7 @@ type ProviderID = string
 // Provider IDs
 const (
 	StatusSmartProxy  = "status-smart-proxy"
-	ProxyNodefleet    = "proxy-nodefleet"
 	ProxyInfura       = "proxy-infura"
-	ProxyGrove        = "proxy-grove"
 	SmartProxyAlchemy = "smart-proxy-alchemy"
 	Nodefleet         = "nodefleet"
 	Infura            = "infura"

--- a/services/wallet/router/router_test_data.go
+++ b/services/wallet/router/router_test_data.go
@@ -51,11 +51,9 @@ const (
 	stageName = "test"
 
 	// Provider types
-	proxyNodefleet = "proxy-nodefleet"
-	proxyInfura    = "proxy-infura"
-	proxyGrove     = "proxy-grove"
-	directInfura   = "direct-infura"
-	directGrove    = "direct-grove"
+	proxyInfura  = "proxy-infura"
+	directInfura = "direct-infura"
+	directGrove  = "direct-grove"
 )
 
 var (
@@ -105,10 +103,8 @@ var mainnet = params.Network{
 	ChainID:   walletCommon.EthereumMainnet,
 	ChainName: "Ethereum",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyNodefleet, security.NewSensitiveStringPrintf("https://%s.api.status.im/nodefleet/ethereum/mainnet/", stageName), false),
 		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/ethereum/mainnet/", stageName), false),
 		*params.NewDirectProvider(walletCommon.EthereumMainnet, directInfura, security.NewSensitiveString("https://mainnet.infura.io/v3/"), true),
-		*params.NewProxyProvider(walletCommon.EthereumMainnet, proxyGrove, security.NewSensitiveStringPrintf("https://%s.api.status.im/grove/ethereum/mainnet/", stageName), false),
 		*params.NewDirectProvider(walletCommon.EthereumMainnet, directGrove, security.NewSensitiveStringPrintf("https://eth-archival.rpc.grove.city/v1/"), false),
 	},
 	BlockExplorerURL:       "https://etherscan.io/",
@@ -131,10 +127,8 @@ var optimism = params.Network{
 	ChainID:   walletCommon.OptimismMainnet,
 	ChainName: "Optimism",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.OptimismMainnet, proxyNodefleet, security.NewSensitiveStringPrintf("https://%s.api.status.im/nodefleet/optimism/mainnet/", stageName), false),
 		*params.NewProxyProvider(walletCommon.OptimismMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/optimism/mainnet/", stageName), false),
 		*params.NewDirectProvider(walletCommon.OptimismMainnet, directInfura, security.NewSensitiveString("https://optimism-mainnet.infura.io/v3/"), true),
-		*params.NewProxyProvider(walletCommon.OptimismMainnet, proxyGrove, security.NewSensitiveStringPrintf("https://%s.api.status.im/grove/optimism/mainnet/", stageName), true),
 		*params.NewDirectProvider(walletCommon.OptimismMainnet, directGrove, security.NewSensitiveString("https://optimism.rpc.grove.city/v1/"), false),
 	},
 	BlockExplorerURL:       "https://optimistic.etherscan.io",
@@ -157,10 +151,8 @@ var arbitrum = params.Network{
 	ChainID:   walletCommon.ArbitrumMainnet,
 	ChainName: "Arbitrum",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.ArbitrumMainnet, proxyNodefleet, security.NewSensitiveStringPrintf("https://%s.api.status.im/nodefleet/arbitrum/mainnet/", stageName), false),
 		*params.NewProxyProvider(walletCommon.ArbitrumMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/arbitrum/mainnet/", stageName), false),
 		*params.NewDirectProvider(walletCommon.ArbitrumMainnet, directInfura, security.NewSensitiveString("https://arbitrum-mainnet.infura.io/v3/"), true),
-		*params.NewProxyProvider(walletCommon.ArbitrumMainnet, proxyGrove, security.NewSensitiveStringPrintf("https://%s.api.status.im/grove/arbitrum/mainnet/", stageName), true),
 		*params.NewDirectProvider(walletCommon.ArbitrumMainnet, directGrove, security.NewSensitiveString("https://arbitrum-one.rpc.grove.city/v1/"), false),
 	},
 	BlockExplorerURL:       "https://arbiscan.io/",
@@ -183,10 +175,8 @@ var base = params.Network{
 	ChainID:   walletCommon.BaseMainnet,
 	ChainName: "Base",
 	RpcProviders: []params.RpcProvider{
-		*params.NewProxyProvider(walletCommon.BaseMainnet, proxyNodefleet, security.NewSensitiveStringPrintf("https://%s.api.status.im/nodefleet/base/mainnet/", stageName), false),
 		*params.NewProxyProvider(walletCommon.BaseMainnet, proxyInfura, security.NewSensitiveStringPrintf("https://%s.api.status.im/infura/base/mainnet/", stageName), false),
 		*params.NewDirectProvider(walletCommon.BaseMainnet, directInfura, security.NewSensitiveString("https://base-mainnet.infura.io/v3/"), true),
-		*params.NewProxyProvider(walletCommon.BaseMainnet, proxyGrove, security.NewSensitiveStringPrintf("https://%s.api.status.im/grove/base/mainnet/", stageName), true),
 		*params.NewDirectProvider(walletCommon.BaseMainnet, directGrove, security.NewSensitiveString("https://base.rpc.grove.city/v1/"), false),
 	},
 	BlockExplorerURL:       "https://basescan.org",


### PR DESCRIPTION
Removed providers are not in use anymore.