### PR TITLE
fix: fixed broken route calculation and sending collectibles (erc721 and erc1155)

### DIFF
--- a/services/wallet/activity/sent_entries.go
+++ b/services/wallet/activity/sent_entries.go
@@ -9,10 +9,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 
 	eth "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
-
-	"go.uber.org/zap"
 
 	"github.com/status-im/status-go/internal/db/sqlite"
 	"github.com/status-im/status-go/internal/logutils"
@@ -314,12 +311,7 @@ func getToken(token *tokenTypes.Token, processorName string) *ac.Token {
 		ret.Address = token.Address
 		switch processorName {
 		case pathProcessorCommon.ProcessorERC721Name, pathProcessorCommon.ProcessorERC1155Name:
-			id, err := wCommon.GetTokenIdFromSymbol(token.Symbol)
-			if err != nil {
-				logutils.ZapLogger().Warn("malformed token symbol", zap.Error(err))
-				return nil
-			}
-			ret.TokenID = (*hexutil.Big)(id)
+			ret.TokenID = token.CollectibleTokenID
 			if processorName == pathProcessorCommon.ProcessorERC721Name {
 				ret.TokenType = ac.Erc721
 			} else {

--- a/services/wallet/collectibles/manager.go
+++ b/services/wallet/collectibles/manager.go
@@ -929,6 +929,18 @@ func (o *Manager) processCollectionData(_ context.Context, collections []thirdpa
 	return o.collectionsDataDB.SetData(collections, true)
 }
 
+func (o *Manager) GetCacheCollectibleData(uniqueID thirdparty.CollectibleUniqueID) (*thirdparty.CollectibleData, error) {
+	collectibleData, err := o.collectiblesDataDB.GetData([]thirdparty.CollectibleUniqueID{uniqueID})
+	if err != nil {
+		return nil, err
+	}
+	data, ok := collectibleData[uniqueID.HashKey()]
+	if !ok {
+		return nil, errors.New("collectible data not found")
+	}
+	return &data, nil
+}
+
 func (o *Manager) getCacheFullCollectibleData(uniqueIDs []thirdparty.CollectibleUniqueID) ([]thirdparty.FullCollectibleData, error) {
 	ret := make([]thirdparty.FullCollectibleData, 0, len(uniqueIDs))
 

--- a/services/wallet/common/helpers.go
+++ b/services/wallet/common/helpers.go
@@ -36,14 +36,6 @@ func PackApprovalInputData(amountIn *big.Int, approvalContractAddress *common.Ad
 	return erc20ABI.Pack("approve", approvalContractAddress, amountIn)
 }
 
-func GetTokenIdFromSymbol(symbol string) (*big.Int, error) {
-	id, success := big.NewInt(0).SetString(symbol, 0)
-	if !success {
-		return nil, fmt.Errorf("failed to convert %s to big.Int", symbol)
-	}
-	return id, nil
-}
-
 func FullDomainName(username string) string {
 	return username + "." + StatusDomain
 }

--- a/services/wallet/common/helpers_test.go
+++ b/services/wallet/common/helpers_test.go
@@ -19,12 +19,3 @@ func TestPackApprovalInputData(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedData, hex.EncodeToString(data))
 }
-
-func TestGetTokenIdFromSymbol(t *testing.T) {
-
-	expectedData := big.NewInt(100)
-
-	data, err := GetTokenIdFromSymbol(expectedData.String())
-	require.NoError(t, err)
-	require.Equal(t, expectedData, data)
-}

--- a/services/wallet/router/pathprocessor/nft_handler_cryptokitties.go
+++ b/services/wallet/router/pathprocessor/nft_handler_cryptokitties.go
@@ -48,17 +48,16 @@ func (h *CryptoKittiesHandler) CanHandle(contractID thirdparty.ContractID) bool 
 }
 
 func (h *CryptoKittiesHandler) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
+	if params.FromToken == nil || params.FromToken.CollectibleTokenID == nil {
+		return nil, ErrNoTokenSet
+	}
+
 	parsedABI, err := abi.JSON(strings.NewReader(cryptokitties.CryptoKittiesMetaData.ABI))
 	if err != nil {
 		return nil, err
 	}
 
-	tokenID, err := walletCommon.GetTokenIdFromSymbol(params.FromToken.Symbol)
-	if err != nil {
-		return nil, err
-	}
-
-	return parsedABI.Pack(cryptoKittiesFunctionNameTransfer, params.ToAddr, tokenID)
+	return parsedABI.Pack(cryptoKittiesFunctionNameTransfer, params.ToAddr, params.FromToken.CollectibleTokenID.ToInt())
 }
 
 func (h *CryptoKittiesHandler) BuildTransactionV2(

--- a/services/wallet/router/pathprocessor/nft_handler_cryptokitties_test.go
+++ b/services/wallet/router/pathprocessor/nft_handler_cryptokitties_test.go
@@ -56,9 +56,16 @@ func TestCryptoKittiesHandler_Comprehensive(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		parsed, ok := new(big.Int).SetString(tc.tokenID, 0)
+		require.True(t, ok)
+		hb := hexutil.Big(*parsed)
+
 		params := ProcessorInputParams{
-			FromToken: &tokentypes.Token{Token: &types.Token{Symbol: tc.tokenID}},
-			ToAddr:    toAddr,
+			FromToken: &tokentypes.Token{
+				Token:              &types.Token{Symbol: "CK"},
+				CollectibleTokenID: &hb,
+			},
+			ToAddr: toAddr,
 		}
 		data, err := handler.PackTxInputData(params)
 		require.NoError(t, err)
@@ -71,15 +78,17 @@ func TestCryptoKittiesHandler_Comprehensive(t *testing.T) {
 	}
 
 	// Test PackTxInputData - error cases
-	errorCases := []string{"invalid_token", "", "abc123"}
-	for _, tokenID := range errorCases {
-		params := ProcessorInputParams{
-			FromToken: &tokentypes.Token{Token: &types.Token{Symbol: tokenID}},
-			ToAddr:    toAddr,
-		}
-		_, err := handler.PackTxInputData(params)
-		assert.Error(t, err)
-	}
+	_, err = handler.PackTxInputData(ProcessorInputParams{
+		FromToken: nil,
+		ToAddr:    toAddr,
+	})
+	assert.ErrorIs(t, err, ErrNoTokenSet)
+
+	_, err = handler.PackTxInputData(ProcessorInputParams{
+		FromToken: &tokentypes.Token{Token: &types.Token{Symbol: "CK"}},
+		ToAddr:    toAddr,
+	})
+	assert.ErrorIs(t, err, ErrNoTokenSet)
 }
 
 func TestCryptoKittiesHandler_WithMocks(t *testing.T) {

--- a/services/wallet/router/pathprocessor/nft_handler_cryptopunks.go
+++ b/services/wallet/router/pathprocessor/nft_handler_cryptopunks.go
@@ -48,17 +48,16 @@ func (h *CryptoPunksHandler) CanHandle(contractID thirdparty.ContractID) bool {
 }
 
 func (h *CryptoPunksHandler) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
+	if params.FromToken == nil || params.FromToken.CollectibleTokenID == nil {
+		return nil, ErrNoTokenSet
+	}
+
 	parsedABI, err := abi.JSON(strings.NewReader(cryptopunks.CryptoPunksMetaData.ABI))
 	if err != nil {
 		return nil, err
 	}
 
-	tokenID, err := walletCommon.GetTokenIdFromSymbol(params.FromToken.Symbol)
-	if err != nil {
-		return nil, err
-	}
-
-	return parsedABI.Pack(cryptoPunksHandlerFunctionNameTransferPunk, params.ToAddr, tokenID)
+	return parsedABI.Pack(cryptoPunksHandlerFunctionNameTransferPunk, params.ToAddr, params.FromToken.CollectibleTokenID.ToInt())
 }
 
 func (h *CryptoPunksHandler) BuildTransactionV2(

--- a/services/wallet/router/pathprocessor/nft_handler_cryptopunks_test.go
+++ b/services/wallet/router/pathprocessor/nft_handler_cryptopunks_test.go
@@ -43,9 +43,15 @@ func TestCryptoPunksHandler_Comprehensive(t *testing.T) {
 	assert.Equal(t, CryptoPunksContractID.Address, address)
 
 	// Test PackTxInputData - valid case
+	parsed, ok := new(big.Int).SetString("123", 0)
+	require.True(t, ok)
+	hb := hexutil.Big(*parsed)
 	validParams := ProcessorInputParams{
-		FromToken: &tokentypes.Token{Token: &types.Token{Symbol: "123"}},
-		ToAddr:    common.HexToAddress("0x5678901234567890123456789012345678901234"),
+		FromToken: &tokentypes.Token{
+			Token:              &types.Token{Symbol: "PUNK"},
+			CollectibleTokenID: &hb,
+		},
+		ToAddr: common.HexToAddress("0x5678901234567890123456789012345678901234"),
 	}
 	data, err := handler.PackTxInputData(validParams)
 	require.NoError(t, err)
@@ -58,16 +64,16 @@ func TestCryptoPunksHandler_Comprehensive(t *testing.T) {
 
 	// Test PackTxInputData - error cases
 	_, err = handler.PackTxInputData(ProcessorInputParams{
-		FromToken: &tokentypes.Token{Token: &types.Token{Symbol: "invalid"}},
+		FromToken: nil,
 		ToAddr:    validParams.ToAddr,
 	})
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoTokenSet)
 
 	_, err = handler.PackTxInputData(ProcessorInputParams{
-		FromToken: &tokentypes.Token{Token: &types.Token{Symbol: ""}},
+		FromToken: &tokentypes.Token{Token: &types.Token{Symbol: "PUNK"}},
 		ToAddr:    validParams.ToAddr,
 	})
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoTokenSet)
 }
 
 func TestCryptoPunksHandler_WithMocks(t *testing.T) {

--- a/services/wallet/router/pathprocessor/nft_handler_erc721.go
+++ b/services/wallet/router/pathprocessor/nft_handler_erc721.go
@@ -13,7 +13,6 @@ import (
 	"github.com/status-im/status-go/internal/contracts/erc721"
 	"github.com/status-im/status-go/internal/rpc"
 	"github.com/status-im/status-go/internal/transactions"
-	walletCommon "github.com/status-im/status-go/services/wallet/common"
 	pathProcessorCommon "github.com/status-im/status-go/services/wallet/router/pathprocessor/common"
 	"github.com/status-im/status-go/services/wallet/thirdparty"
 	"github.com/status-im/status-go/services/wallet/wallettypes"
@@ -54,12 +53,11 @@ func (h *ERC721Handler) PackTxInputData(params ProcessorInputParams) ([]byte, er
 }
 
 func (h *ERC721Handler) packTxInputDataInternally(params ProcessorInputParams, functionName string) ([]byte, error) {
-	abi, err := abi.JSON(strings.NewReader(erc721.Erc721MetaData.ABI))
-	if err != nil {
-		return []byte{}, err
+	if params.FromToken == nil || params.FromToken.CollectibleTokenID == nil {
+		return nil, ErrNoTokenSet
 	}
 
-	id, err := walletCommon.GetTokenIdFromSymbol(params.FromToken.Symbol)
+	abi, err := abi.JSON(strings.NewReader(erc721.Erc721MetaData.ABI))
 	if err != nil {
 		return []byte{}, err
 	}
@@ -67,7 +65,7 @@ func (h *ERC721Handler) packTxInputDataInternally(params ProcessorInputParams, f
 	return abi.Pack(functionName,
 		params.FromAddr,
 		params.ToAddr,
-		id,
+		params.FromToken.CollectibleTokenID.ToInt(),
 	)
 }
 

--- a/services/wallet/router/pathprocessor/nft_handler_erc721_test.go
+++ b/services/wallet/router/pathprocessor/nft_handler_erc721_test.go
@@ -97,13 +97,22 @@ func TestERC721Handler_PackTxInputDataInternally(t *testing.T) {
 
 	fromAddr := common.HexToAddress("0x1234567890123456789012345678901234567890")
 	toAddr := common.HexToAddress("0x5678901234567890123456789012345678901234")
+	contractAddr := common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd")
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			parsed, ok := new(big.Int).SetString(tc.tokenID, 0)
+			require.True(t, ok)
+			assert.Equal(t, tc.expected, parsed)
+			collectibleTokenID := hexutil.Big(*parsed)
+
 			params := ProcessorInputParams{
-				FromToken: &tokentypes.Token{Token: &types.Token{Symbol: tc.tokenID}},
-				FromAddr:  fromAddr,
-				ToAddr:    toAddr,
+				FromToken: &tokentypes.Token{
+					Token:              &types.Token{Address: contractAddr},
+					CollectibleTokenID: &collectibleTokenID,
+				},
+				FromAddr: fromAddr,
+				ToAddr:   toAddr,
 			}
 
 			// Test safeTransferFrom
@@ -131,24 +140,33 @@ func TestERC721Handler_PackTxInputDataInternally(t *testing.T) {
 	}
 
 	// Test error cases
-	errorCases := []string{"invalid_token", "", "abc123"}
-	for _, tokenID := range errorCases {
-		params := ProcessorInputParams{
-			FromToken: &tokentypes.Token{Token: &types.Token{Symbol: tokenID}},
-			FromAddr:  fromAddr,
-			ToAddr:    toAddr,
-		}
-		_, err := handler.packTxInputDataInternally(params, erc721FunctionNameSafeTransferFrom)
-		assert.Error(t, err)
-	}
-
-	// Test with invalid function name
-	validParams := ProcessorInputParams{
-		FromToken: &tokentypes.Token{Token: &types.Token{Symbol: "123"}},
+	_, err := handler.packTxInputDataInternally(ProcessorInputParams{
+		FromToken: nil,
 		FromAddr:  fromAddr,
 		ToAddr:    toAddr,
+	}, erc721FunctionNameSafeTransferFrom)
+	assert.ErrorIs(t, err, ErrNoTokenSet)
+
+	_, err = handler.packTxInputDataInternally(ProcessorInputParams{
+		FromToken: &tokentypes.Token{Token: &types.Token{Address: contractAddr}},
+		FromAddr:  fromAddr,
+		ToAddr:    toAddr,
+	}, erc721FunctionNameSafeTransferFrom)
+	assert.ErrorIs(t, err, ErrNoTokenSet)
+
+	// Test with invalid function name
+	parsed, ok := new(big.Int).SetString("123", 0)
+	require.True(t, ok)
+	collectibleTokenID := hexutil.Big(*parsed)
+	validParams := ProcessorInputParams{
+		FromToken: &tokentypes.Token{
+			Token:              &types.Token{Address: contractAddr},
+			CollectibleTokenID: &collectibleTokenID,
+		},
+		FromAddr: fromAddr,
+		ToAddr:   toAddr,
 	}
-	_, err := handler.packTxInputDataInternally(validParams, "invalidFunction")
+	_, err = handler.packTxInputDataInternally(validParams, "invalidFunction")
 	assert.Error(t, err) // Should error because function doesn't exist in ABI
 }
 
@@ -157,15 +175,19 @@ func TestERC721Handler_Integration(t *testing.T) {
 
 	// Test complete flow for generic ERC721 transfer
 	contractAddr := common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd")
+	parsed, ok := new(big.Int).SetString("789", 0)
+	require.True(t, ok)
+	collectibleTokenID := hexutil.Big(*parsed)
 	params := ProcessorInputParams{
 		FromChain: &params.Network{ChainID: walletCommon.EthereumMainnet},
 		FromToken: &tokentypes.Token{Token: &types.Token{
 			Address: contractAddr,
-			Symbol:  "789",
 		}},
-		FromAddr: common.HexToAddress("0x1234567890123456789012345678901234567890"),
-		ToAddr:   common.HexToAddress("0x5678901234567890123456789012345678901234"),
+		ToToken: nil,
 	}
+	params.FromToken.CollectibleTokenID = &collectibleTokenID
+	params.FromAddr = common.HexToAddress("0x1234567890123456789012345678901234567890")
+	params.ToAddr = common.HexToAddress("0x5678901234567890123456789012345678901234")
 
 	// 1. Verify handler can handle any contract (ERC721 is generic)
 	contractID := thirdparty.ContractID{

--- a/services/wallet/router/pathprocessor/processor_erc1155.go
+++ b/services/wallet/router/pathprocessor/processor_erc1155.go
@@ -44,7 +44,7 @@ func (s *ERC1155Processor) Name() string {
 }
 
 func (s *ERC1155Processor) AvailableFor(params ProcessorInputParams) (bool, error) {
-	return params.FromChain.ChainID == params.ToChain.ChainID && params.ToToken == nil, nil
+	return params.FromChain.ChainID == params.ToChain.ChainID, nil
 }
 
 func (s *ERC1155Processor) CalculateFees(params ProcessorInputParams) (*big.Int, *big.Int, error) {
@@ -52,12 +52,11 @@ func (s *ERC1155Processor) CalculateFees(params ProcessorInputParams) (*big.Int,
 }
 
 func (s *ERC1155Processor) PackTxInputData(params ProcessorInputParams) ([]byte, error) {
-	abi, err := abi.JSON(strings.NewReader(ierc1155.Ierc1155ABI))
-	if err != nil {
-		return []byte{}, createERC1155ErrorResponse(err)
+	if params.FromToken == nil || params.FromToken.CollectibleTokenID == nil {
+		return nil, ErrNoTokenSet
 	}
 
-	id, err := walletCommon.GetTokenIdFromSymbol(params.FromToken.Symbol)
+	abi, err := abi.JSON(strings.NewReader(ierc1155.Ierc1155ABI))
 	if err != nil {
 		return []byte{}, createERC1155ErrorResponse(err)
 	}
@@ -65,7 +64,7 @@ func (s *ERC1155Processor) PackTxInputData(params ProcessorInputParams) ([]byte,
 	return abi.Pack("safeTransferFrom",
 		params.FromAddr,
 		params.ToAddr,
-		id,
+		params.FromToken.CollectibleTokenID.ToInt(),
 		params.AmountIn,
 		[]byte{},
 	)

--- a/services/wallet/router/pathprocessor/processor_nft.go
+++ b/services/wallet/router/pathprocessor/processor_nft.go
@@ -61,7 +61,7 @@ func (s *NFTProcessor) AvailableFor(params ProcessorInputParams) (bool, error) {
 	}
 
 	// Only handle same-chain transfers with no destination token (NFT transfers)
-	if params.FromChain.ChainID != params.ToChain.ChainID || params.ToToken != nil {
+	if params.FromChain.ChainID != params.ToChain.ChainID {
 		return false, nil
 	}
 

--- a/services/wallet/router/pathprocessor/processor_nft_test.go
+++ b/services/wallet/router/pathprocessor/processor_nft_test.go
@@ -94,7 +94,7 @@ func TestNFTProcessor_AvailableFor(t *testing.T) {
 
 	available, err = processor.AvailableFor(withToTokenParams)
 	require.NoError(t, err)
-	assert.False(t, available, "Should not be available when ToToken is specified")
+	assert.True(t, available, "Should be available when ToToken is specified")
 }
 
 func TestNFTProcessor_GetHandlerForContract(t *testing.T) {

--- a/services/wallet/router/router.go
+++ b/services/wallet/router/router.go
@@ -506,7 +506,7 @@ func (r *Router) prepareBalanceMapForTokenOnChain(ctx context.Context, input *re
 	}
 
 	// check token existence
-	token := findToken(input.SendType, r.tokenManager, r.collectiblesService, input.AddrFrom, input.FromChainID, input.TokenKey)
+	token := findToken(input.SendType, r.tokenManager, r.collectiblesManager, input.TokenKey)
 	if token == nil {
 		err = errors.CreateErrorResponseFromError(ErrTokenNotFound)
 		return
@@ -637,13 +637,13 @@ func (r *Router) findFromAndToTokens(testsMode bool, input *requests.RouteInputP
 	if testsMode {
 		fromToken = input.TestParams.TokenFrom
 	} else {
-		fromToken = findToken(input.SendType, r.tokenManager, r.collectiblesService, input.AddrFrom, chainID, input.TokenKey)
+		fromToken = findToken(input.SendType, r.tokenManager, r.collectiblesManager, input.TokenKey)
 	}
 	if fromToken == nil {
 		return
 	}
 
-	toToken = findToken(input.SendType, r.tokenManager, r.collectiblesService, common.Address{}, chainID, input.ToTokenKey)
+	toToken = findToken(input.SendType, r.tokenManager, r.collectiblesManager, input.ToTokenKey)
 	return
 }
 
@@ -679,7 +679,7 @@ func (r *Router) resolveRoute(ctx context.Context, input *requests.RouteInputPar
 		err = errors.CreateErrorResponseFromError(fmt.Errorf("from token not found for send type %d on chain %d", input.SendType, input.FromChainID))
 		return
 	}
-	if toToken == nil {
+	if !input.SendType.IsCollectiblesTransfer() && toToken == nil {
 		err = errors.CreateErrorResponseFromError(fmt.Errorf("to token not found for send type %d on chain %d", input.SendType, input.ToChainID))
 		return
 	}

--- a/services/wallet/router/router_helper.go
+++ b/services/wallet/router/router_helper.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"math/big"
 	"slices"
-	"strings"
 
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/status-im/status-go/services/wallet/router/pathprocessor"
 	"github.com/status-im/status-go/services/wallet/router/routes"
 	"github.com/status-im/status-go/services/wallet/router/sendtype"
+	"github.com/status-im/status-go/services/wallet/thirdparty"
 	tokentypes "github.com/status-im/status-go/services/wallet/token/types"
 )
 
@@ -111,9 +111,8 @@ func CalculateL1Fee(chainID uint64, data []byte, ethClient ethclient.EthClientIn
 }
 
 func (r *Router) getERC1155Balance(ctx context.Context, chainID uint64, token *tokentypes.Token, account common.Address) (*big.Int, error) {
-	tokenID, success := new(big.Int).SetString(token.Symbol, 10)
-	if !success {
-		return nil, errors.New("failed to convert token symbol to big.Int")
+	if token == nil || token.CollectibleTokenID == nil {
+		return nil, errors.New("token or token ID is nil")
 	}
 
 	balances, err := r.collectiblesManager.FetchERC1155Balances(
@@ -121,7 +120,7 @@ func (r *Router) getERC1155Balance(ctx context.Context, chainID uint64, token *t
 		account,
 		walletCommon.ChainID(chainID),
 		token.Address,
-		[]*bigint.BigInt{&bigint.BigInt{Int: tokenID}},
+		[]*bigint.BigInt{&bigint.BigInt{Int: token.CollectibleTokenID.ToInt()}},
 	)
 	if err != nil {
 		return nil, err
@@ -458,20 +457,8 @@ func (r *Router) evaluateAndUpdatePathDetails(ctx context.Context, path *routes.
 	return
 }
 
-func ParseCollectibleID(tokenKey string) (contractAddress common.Address, tokenID *big.Int, success bool) {
-	success = false
-
-	parts := strings.Split(tokenKey, ":")
-	if len(parts) != 2 {
-		return
-	}
-	contractAddress = common.HexToAddress(parts[0])
-	tokenID, success = new(big.Int).SetString(parts[1], 10)
-	return
-}
-
-func findToken(sendType sendtype.SendType, tokenManager TokenManager, collectibles *collectibles.Service,
-	account common.Address, chainID uint64, tokenKey string) *tokentypes.Token {
+func findToken(sendType sendtype.SendType, tokenManager TokenManager, collectiblesManager *collectibles.Manager,
+	tokenKey string) *tokentypes.Token {
 	if !sendType.IsCollectiblesTransfer() {
 		token, err := tokenManager.GetTokenByKey(tokenKey)
 		if err != nil {
@@ -485,22 +472,30 @@ func findToken(sendType sendtype.SendType, tokenManager TokenManager, collectibl
 		return nil
 	}
 
-	contractAddress, collectibleTokenID, success := ParseCollectibleID(tokenKey)
+	chainID, contractAddress, collectibleTokenID, success := tokentypes.ParseCollectibleKey(tokenKey)
 	if !success {
 		return nil
 	}
-	uniqueID, err := collectibles.GetOwnedCollectible(walletCommon.ChainID(chainID), account, contractAddress, collectibleTokenID)
-	if err != nil || uniqueID == nil {
+
+	collectibleData, err := collectiblesManager.GetCacheCollectibleData(thirdparty.CollectibleUniqueID{
+		ContractID: thirdparty.ContractID{
+			ChainID: walletCommon.ChainID(chainID),
+			Address: contractAddress,
+		},
+		TokenID: &bigint.BigInt{Int: collectibleTokenID},
+	})
+	if err != nil {
 		return nil
 	}
 
 	return &tokentypes.Token{
 		Token: &types.Token{
 			Address:  contractAddress,
-			Symbol:   collectibleTokenID.String(),
 			Decimals: 0,
 			ChainID:  chainID,
+			Name:     collectibleData.Name,
 		},
+		CollectibleTokenID: (*hexutil.Big)(collectibleTokenID),
 	}
 }
 

--- a/services/wallet/router/router_helper_test.go
+++ b/services/wallet/router/router_helper_test.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/common"
 
 	mock_client "github.com/status-im/status-go/internal/rpc/chain/mock/client"
 	walletCommon "github.com/status-im/status-go/services/wallet/common"
@@ -81,18 +80,4 @@ func (s *CalculateFeesTestSuite) TestCalculateApprovalL1Fee_ZeroFeeOnContractCal
 
 func TestCalculateFeesTestSuite(t *testing.T) {
 	suite.Run(t, new(CalculateFeesTestSuite))
-}
-
-func TestParseCollectibleID(t *testing.T) {
-	collectibleID := "RANDOM"
-	_, _, success := router.ParseCollectibleID(collectibleID)
-	require.False(t, success)
-
-	collectibleID = "0xfC43ac5f309499385e91e059862bDb0Bfa2Cd16c:123"
-	expectedContractAddress := common.HexToAddress("0xfC43ac5f309499385e91e059862bDb0Bfa2Cd16c")
-	expectedCollectibleID := big.NewInt(123)
-	parsedContractAddress, parsedCollectibleID, success := router.ParseCollectibleID(collectibleID)
-	require.True(t, success)
-	require.Equal(t, expectedContractAddress, parsedContractAddress)
-	require.Equal(t, expectedCollectibleID, parsedCollectibleID)
 }

--- a/services/wallet/token/types/token.go
+++ b/services/wallet/token/types/token.go
@@ -2,16 +2,24 @@ package tokentypes
 
 import (
 	"math/big"
+	"strconv"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/status-im/go-wallet-sdk/pkg/tokens/types"
+)
+
+const (
+	tokenKeySeparator = "-" // export this from wallet-sdk
 )
 
 type Token struct {
 	*types.Token
 
-	CommunityData *CommunityData `json:"communityData,omitempty"`
+	CollectibleTokenID *hexutil.Big   `json:"collectibleTokenID,omitempty"`
+	CommunityData      *CommunityData `json:"communityData,omitempty"`
 }
 
 // TODO: think about removing CommunityData field and fetch it when needed, that way `tokenlists.Token` can be used directly.
@@ -38,4 +46,20 @@ type TokenList struct {
 	*types.TokenList
 
 	Tokens []*Token `json:"tokens"` // tokens from the `types.TokenList` are shadowed by this field
+}
+
+func ParseCollectibleKey(tokenKey string) (chainID uint64, contractAddress common.Address, collectibleTokenID *big.Int, success bool) {
+	success = false
+
+	parts := strings.Split(tokenKey, tokenKeySeparator)
+	if len(parts) != 3 {
+		return
+	}
+	chainID, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return
+	}
+	contractAddress = common.HexToAddress(parts[1])
+	collectibleTokenID, success = new(big.Int).SetString(parts[2], 10)
+	return
 }

--- a/services/wallet/token/types/token_test.go
+++ b/services/wallet/token/types/token_test.go
@@ -1,0 +1,26 @@
+package tokentypes
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCollectibleKey(t *testing.T) {
+	collectibleKey := "RANDOM"
+	_, _, _, success := ParseCollectibleKey(collectibleKey)
+	require.False(t, success)
+
+	chainID := uint64(1)
+	contractAddress := common.HexToAddress("0xfC43ac5f309499385e91e059862bDb0Bfa2Cd16c")
+	collectibleTokenID := big.NewInt(123)
+	collectibleKey = fmt.Sprintf("%d%s%s%s%s", chainID, tokenKeySeparator, contractAddress.Hex(), tokenKeySeparator, collectibleTokenID.String())
+	parsedChainID, parsedContractAddress, parsedCollectibleTokenID, success := ParseCollectibleKey(collectibleKey)
+	require.True(t, success)
+	require.Equal(t, chainID, parsedChainID)
+	require.Equal(t, contractAddress, parsedContractAddress)
+	require.Equal(t, collectibleTokenID.String(), parsedCollectibleTokenID.String())
+}


### PR DESCRIPTION
- Replaced the GetTokenIdFromSymbol function with direct usage of CollectibleTokenID.
- Introduced GetCacheCollectibleData method in the collectibles manager for improved data retrieval.
- Updated token parsing logic to utilize a new format for collectible keys.