### PR TITLE
fix(makefile): bump nim-sds to fix windows and iOS crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ endif
 # `nim-sds` variables
 
 # Pin nim-sds revision here. Can be a tag (default) or commit hash.
-NIM_SDS_VERSION ?= fb8039c5a56086ec7fb3e5e1a5a593bb3756ccb6
+NIM_SDS_VERSION ?= v0.2.4
 
 # Option 1: Provide NIM_SDS_SOURCE_DIR. Make clones it if missing.
 NIM_SDS_SOURCE_DIR ?= $(GIT_ROOT)/../nim-sds


### PR DESCRIPTION
Bumps nim-sds to adopt this change: https://github.com/logos-messaging/nim-sds/pull/42

Important changes:
- [x] initialize Lock in libsds.nim so to avoid crashes in Windows and iOS

## Related Issue
- https://github.com/status-im/status-app/issues/19631
