### PR TITLE
feat: add CommunitiesSupported flag for network configurations

### DIFF
--- a/internal/contracts/community-tokens/deployer/address.go
+++ b/internal/contracts/community-tokens/deployer/address.go
@@ -34,3 +34,11 @@ func ContractAddress(chainID uint64) (common.Address, error) {
 	}
 	return addr, nil
 }
+
+func CommunitiesSupportedOnChain(chainID uint64) bool {
+	addr, err := ContractAddress(chainID)
+	if err != nil {
+		return false
+	}
+	return addr != (common.Address{})
+}

--- a/internal/rpc/network/network.go
+++ b/internal/rpc/network/network.go
@@ -204,6 +204,9 @@ func (nm *Manager) setEmbeddedFields(networks []*params.Network) {
 				network.RpcProviders, embeddedNetwork.RpcProviders)
 		}
 	}
+
+	// CommunitiesSupported is derived (not persisted) and should always reflect the contract availability.
+	networkhelper.ApplyCommunitiesSupported(networks)
 }
 
 // networkWithoutEmbeddedProviders returns a copy of the given network without embedded RPC providers.

--- a/params/network_config.go
+++ b/params/network_config.go
@@ -92,6 +92,8 @@ type Network struct {
 	EIP1559Enabled         bool          `json:"eip1559Enabled"`
 	NoBaseFee              bool          `json:"noBaseFee"`
 	NoPriorityFee          bool          `json:"noPriorityFee"`
+
+	CommunitiesSupported bool `json:"communitiesSupported"`
 }
 
 func (n *Network) DeepCopy() Network {

--- a/params/networkhelper/communities_supported.go
+++ b/params/networkhelper/communities_supported.go
@@ -1,0 +1,26 @@
+package networkhelper
+
+import (
+	communitytokendeployer "github.com/status-im/status-go/internal/contracts/community-tokens/deployer"
+	"github.com/status-im/status-go/params"
+)
+
+// WithCommunitiesSupported returns a copy of the given networks slice with CommunitiesSupported
+// set based on CommunitiesSupportedOnChain(chainID).
+func WithCommunitiesSupported(networks []params.Network) []params.Network {
+	updated := DeepCopyNetworks(networks)
+	for i := range updated {
+		updated[i].CommunitiesSupported = communitytokendeployer.CommunitiesSupportedOnChain(updated[i].ChainID)
+	}
+	return updated
+}
+
+// ApplyCommunitiesSupported sets CommunitiesSupported in-place for each network.
+func ApplyCommunitiesSupported(networks []*params.Network) {
+	for _, n := range networks {
+		if n == nil {
+			continue
+		}
+		n.CommunitiesSupported = communitytokendeployer.CommunitiesSupportedOnChain(n.ChainID)
+	}
+}

--- a/pkg/backend/default_networks.go
+++ b/pkg/backend/default_networks.go
@@ -599,5 +599,6 @@ func setRPCs(networks []params.Network, walletConfig *requests.WalletSecretsConf
 
 func BuildDefaultNetworks(walletSecretsConfig *requests.WalletSecretsConfig, thirdpartyServicesEnabled bool) []params.Network {
 	proxyHost := getProxyHost(walletSecretsConfig.EthRpcProxyUrl.Reveal(), walletSecretsConfig.StatusProxyStageName)
-	return setRPCs(defaultNetworks(proxyHost, walletSecretsConfig.StatusProxyStageName, thirdpartyServicesEnabled), walletSecretsConfig)
+	networks := setRPCs(defaultNetworks(proxyHost, walletSecretsConfig.StatusProxyStageName, thirdpartyServicesEnabled), walletSecretsConfig)
+	return networkhelper.WithCommunitiesSupported(networks)
 }


### PR DESCRIPTION
- Introduced CommunitiesSupportedOnChain function to determine if communities are supported on a given chain.
- Updated Network struct to include CommunitiesSupported field.
- Implemented networkhelper functions to apply community support status to networks.
- Modified BuildDefaultNetworks to utilize the new community support feature.